### PR TITLE
fix(stock-prep): M0-A — retract freeze-act blocker, record A1 build+verify (run 30148584851)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -244,6 +244,19 @@ jobs:
       - name: Approval data-closure CI wiring contract
         run: node --test scripts/ops/approval-data-closure-ci-wiring.test.mjs
 
+      # #4604 owner HOLD: multitable-onprem-package-build.yml is workflow_dispatch only and
+      # only ever exercises the verify script against a NORMAL package — it never proves the
+      # loopback-config negative case. Without an automated caller, deleting the loopback
+      # regex or its main-flow call site in scripts/ops/multitable-onprem-package-verify.sh
+      # still left every PR required check green. This step is that automated caller: pure
+      # bash, no DB, no pnpm install needed, so it runs early in the no-DB block. Gated to the
+      # 20.x leg only so it lands inside the required `test (20.x)` context (18.x is not
+      # required) rather than doubling the run for no reason — a failure here reds a required
+      # check on any PR touching the verify script.
+      - name: Multitable on-prem loopback-verify CI wiring contract (#4604)
+        if: matrix.node-version == '20.x'
+        run: bash scripts/ops/multitable-onprem-package-verify-loopback.test.sh
+
 
       # The production monitor invokes the same state helper covered here.
       # Keep this in the required 18/20 matrix so HTTP classification, silence

--- a/docs/development/stock-preparation-rc-a-m0a-package-build-status-and-4437-pointer-draft-20260725.md
+++ b/docs/development/stock-preparation-rc-a-m0a-package-build-status-and-4437-pointer-draft-20260725.md
@@ -384,6 +384,28 @@ missing its frontend bundle).
    `bash scripts/ops/multitable-onprem-package-verify.provenance.test.sh`; the doc does not imply CI coverage
    for either that it does not have.
 
+**Erratum / owner override (review #4604, round 2 — this update):** item 2's "Disclosed here rather than
+wired into a caller" decision above was **overruled by the owner**, on the specific finding that deleting the
+loopback regex or the main-flow call site still left every PR required check green — the "equally uncalled
+`.test.mjs` siblings" argument does not change that. Item 2's text above is left as the historical record of
+that (now-superseded) decision, not the current state. **What exists now:** a step in
+`.github/workflows/plugin-tests.yml`'s `test` job, gated `if: matrix.node-version == '20.x'` so it lands
+inside the branch-protection-required `test (20.x)` context rather than a new, unrequired one:
+```yaml
+- name: Multitable on-prem loopback-verify CI wiring contract (#4604)
+  if: matrix.node-version == '20.x'
+  run: bash scripts/ops/multitable-onprem-package-verify-loopback.test.sh
+```
+`plugin-tests.yml`'s `pull_request:` trigger carries no path filter, so this step runs on every PR regardless
+of which files changed. The step is a plain `run:` — no `continue-on-error`, no `|| true` — so a non-zero
+exit fails the job, which reds the required `test (20.x)` check. Proved locally against the exact command the
+step runs, before touching the workflow file (both mutations restored afterward, `git diff` empty): deleting
+the main-flow call site → 4 passed/1 failed; neutering the regex itself (`if search_extended_regex
+'VITE_API_(URL|BASE):"http://(127\.0\.0\.1|localhost)' "$web_dist"; then` → `if false; then`) → 3 passed/2
+failed. Confirmed in a real CI run that the step executes inside the actual `test (20.x)` job and reports
+`RESULT: 5 passed, 0 failed`. The two `.test.mjs` siblings named in item 2 remain uncalled — that is unchanged
+and out of this update's scope; only the focused loopback test named in review #4604 was wired.
+
 **Scope limitation, stated plainly:** the ported pattern is reused **verbatim** per the owner's ruling
 ("reuse attendance's rule") and is not changed here. The fixtures prove the rule is falsifiable *as specified*
 — a bundle containing that exact literal string shape fails, a clean one passes — not that multitable's own
@@ -549,10 +571,15 @@ abbreviated to `<local>`:
    as its own historical record — not deleted or silently overwritten — because the P2 hardening changed how
    the `"loopback"` row is *derived* (a real code change, unlike the comment-only edit the erratum above
    describes), not what result a successful run against this artifact reports. The call-site pin added in
-   Hardening item 1 only fires when `multitable-onprem-package-verify-loopback.test.sh` is itself run (it is
-   not wired into any automated caller, per Hardening item 2 above) — it does not run as part of this or any
-   other real verify invocation, which is why this step re-runs the full verify script directly rather than
-   relying on the pin for behavioral proof.
+   Hardening item 1 only fires when `multitable-onprem-package-verify-loopback.test.sh` is itself run — at
+   the time this paragraph was originally written, that file had no automated caller (per Hardening item 2
+   above), so it did not run as part of this or any other real verify invocation, which is why this step
+   re-runs the full verify script directly rather than relying on the pin for behavioral proof.
+   **This is no longer the current state — see the Erratum / owner override immediately after Hardening item
+   2 above (review #4604, round 2): the pin's underlying focused test now runs automatically, inside CI's
+   required `test (20.x)` job, on every PR.** The point stands about *this specific historical run*
+   (`posthoc-verify-3`, a manual/standalone invocation): it did not depend on, and is not evidence about,
+   whatever CI wiring exists today.
 
 **Explicit non-conflation, stated plainly (this is the exact thing ⟲R7 exists to prevent):** run
 `30148584851`'s own `verify.json`, the one packaged inside the CI-produced Actions artifact, is **immutable

--- a/docs/development/stock-preparation-rc-a-m0a-package-build-status-and-4437-pointer-draft-20260725.md
+++ b/docs/development/stock-preparation-rc-a-m0a-package-build-status-and-4437-pointer-draft-20260725.md
@@ -2,18 +2,33 @@
 
 Lane: **LANE C — M0-A** (per `docs/development/database-system-integration-line-design-and-verification-20260724.md`,
 §2 M0-A / §4 "Parallel and unblocked" M0-A track, ⟲C1/⟲R1/⟲R7). Authorized: build + verify the COMPLETE
-on-prem deployment package at the owner-chosen main SHA, regenerate manifest/SHA256/provenance/loopback
-verification, prepare (not post) the #4437 pointer revision. Not authorized: deployment, flag-ON, connecting
-to any host, editing #4437 itself, merging, pushing to main.
+on-prem deployment package at the owner-chosen main SHA, regenerate manifest/SHA256/provenance/(disputed —
+see §6) loopback verification, prepare (not post) the #4437 pointer revision. Not authorized: deployment,
+flag-ON, connecting to any host, editing #4437 itself, merging, pushing to main, and — per this fix pass —
+still not the release/freeze act (see §3 A2).
 
 **Scope note:** the ledger's §2 M0-A paragraph also names "prepare the bounded approved config" as part of
-M0-A. This document's Lane-C task list (the four numbered "Your job" items given to this run) does not include
-that item, and it is **not** addressed here — do not read this document as a complete M0-A closeout.
+M0-A. This document's Lane-C task list does not include that item, and it is **not** addressed here — do not
+read this document as a complete M0-A closeout.
 
-## Status: BLOCKED on the build itself. Investigation, blob-identity proof, and the pointer draft are DONE.
+## FIX PASS (2026-07-25, same day): the prior "BLOCKED" verdict below was WRONG on its primary reason. Retracted in §3.
 
-No package was built. No release was published. No fabricated checksum was produced. §3 below gives the
-exact blocker and what a human needs to run.
+**What changed:** an adversarial reviewer proved that `.github/workflows/multitable-onprem-package-build.yml`
+runs the build (`Build on-prem package`) and verify steps, and uploads the CI artifact, **unconditionally** —
+only the `Publish GitHub Release` step (and one echo line in the step summary) are gated behind
+`inputs.publish_release == 'true'`. The build+verify half this lane is authorized for was executable all
+along; the original document's "(b) PRIMARY = freeze act blocks everything" reasoning conflated the *ref
+prerequisite* (minting a ref at the desired commit, needed only because `workflow_dispatch` takes a
+branch/tag, not a bare SHA) with the *publish/freeze act* (owner-only). This session independently confirmed
+the reviewer's read against the current workflow file and then **ran the authorized build+verify half for
+real** — see §3 A1 for the run and §2.4/§6 below for what the "no fabrication" claim now covers.
+
+## Status: build + verify (A1) is DONE and PASSED. Residual blocker is narrow: only the owner's publish/freeze act (A2).
+
+A real CI run built and verified the complete on-prem package at the exact recommended SHA, using the
+project's own unmodified tooling, and self-verified with four structural checks (all PASS). No release was
+published. No checksum was hand-typed or fabricated — the checksums recorded below are read verbatim from the
+run's own `SHA256SUMS` output. §3 gives the retraction, the A1 record, and the narrow residual (A2, owner-only).
 
 ---
 
@@ -32,8 +47,9 @@ builder:
   `metasheet-multitable-onprem-v2.5.0-rc-a-20260717-d87e086fd.*` (`.tgz`, `.zip`, `.json`, bootstrap `.ps1`/`.bat`,
   `SHA256SUMS`, `*.verify.json`/`.md`) — the exact output shape the multitable workflow produces.
 - `gh run list --repo zensgit/metasheet2 --workflow=multitable-onprem-package-build.yml` shows a `success` run
-  at `headSha=d87e086fd1218b4cfb150177d43f2c52904b1d6d`, created `2026-07-17T06:16:54Z`, matching the release's
-  `generatedAt`/`gitSha` exactly.
+  at `headSha=d87e086fd1218b4cfb150177d43f2c52904b1d6d`, created `2026-07-17T06:16:54Z`. Its `gitSha` matches
+  the release's exactly; `generatedAt` does **not** match exactly (corrected in §2.4 — it falls inside the
+  run's time window, which is the actual mechanic, not an exact-timestamp match).
 - The package's own metadata (`metasheet-multitable-onprem-v2.5.0-rc-a-20260717-d87e086fd.json`, downloaded
   read-only for this investigation): `"includedPlugins": ["plugin-attendance", "plugin-integration-core"]`,
   `"productMode": "platform"` — the platform+plugin bundle, confirming ⟲R7's claim directly: the sidecar ZIP
@@ -58,13 +74,21 @@ current `origin/main` (`402f04982`).
 ```
 git log --oneline 7bf2bd7a1..origin/main
 ```
-gives the 11 commits between the recommended SHA and current main tip: `#4590` (this ledger doc, doc-only),
-three attendance W4/W5 commits (`#4595/#4592/#4588/#4585/#4586/#4584/#4576`), two directory-deprovision
-commits (`#4577/#4575`), and **`#4583`** — `fix(data-source): enforce the A5 row bound in MySQLAdapter + pin
-the SQL-adapter roster` — a **runtime data-source change**. Building at current main tip (instead of `7bf2bd7a1`)
-would silently pull `#4583` into the RC-A package for no RC-A benefit, which is exactly the "enlarging the
-runtime change surface" the ledger's recommendation warns against. I found no reason to deviate from `7bf2bd7a1`
-and did not choose a different SHA.
+gave the 11 commits between the recommended SHA and main tip at original draft time (main tip then =
+`402f04982`): `#4590` (this ledger doc, doc-only), **seven** attendance W4/W5 commits
+(`#4595/#4592/#4588/#4585/#4586/#4584/#4576` — the original draft undercounted this as "three" while
+listing all seven PR numbers; corrected here), two directory-deprovision commits (`#4577/#4575`), and
+**`#4583`** — `fix(data-source): enforce the A5 row bound in MySQLAdapter + pin the SQL-adapter roster` — a
+**runtime data-source change**. Building at current main tip (instead of `7bf2bd7a1`) would silently pull
+`#4583` into the RC-A package for no RC-A benefit, which is exactly the "enlarging the runtime change surface"
+the ledger's recommendation warns against. I found no reason to deviate from `7bf2bd7a1` and did not choose a
+different SHA.
+
+**Drift note (fix pass, re-run same day):** `origin/main` has since advanced one more commit — tip is now
+`b5ff168e9` (`#4600`, doc-only, committed `2026-07-25T06:51:44Z`), so `git rev-list --count 7bf2bd7a1..origin/main`
+now reads **12**, not 11. The count was accurate when first drafted; it is a moving target because main keeps
+advancing. The choose-`7bf2bd7a1`-over-main-tip argument is unaffected by this drift (if anything strengthened
+— one more non-RC-A commit would be pulled in by building at tip instead).
 
 Also verified: the build tooling itself is byte-identical between the recommended SHA and current main —
 ```
@@ -122,96 +146,162 @@ and `7bf2bd7a1`, so the helper content hash may carry over") and gives the exact
     `checksum` PASS, `required-content` PASS (`requiredCount: 128`), `deployability-contract` PASS, `no-github-links`
     PASS — this is what `multitable-onprem-package-verify.sh` actually runs: a local/offline structural
     verification of the produced archive (checksum + required-file inventory + deployability-contract shape +
-    no leaked GitHub URLs). **Mapping this to the ledger's phrase "loopback verification" is my inference, not
-    a confirmed match** — I searched `multitable-onprem-package-verify.sh` for a `loopback`-named check (the
-    kind attendance's `attendance-onprem-package-verify.sh` has, which fails if the built frontend bundle
-    embeds a loopback `VITE_API_URL`) and found none; multitable's verify script has no such check. If the
-    ledger's "loopback verification" instead means a live loopback HTTP probe against a running instance (the
-    pattern `stock-preparation-rca-c-window-runner-development-verification-20260722.md` uses), that is a
-    runtime/host action and belongs to M0-B's "flag-OFF health verification," not to this build-only step —
-    it was not run here either way.
+    no leaked GitHub URLs). **There is no `loopback`-named check in this script — confirmed by grep, zero
+    hits.** This is now escalated as a specification gap against the RATIFIED ledger rather than silently
+    inferred; see §6. It is not resolved here and this document does not rule on it.
   - `SHA256SUMS` — four checksummed files: `.tgz`, `.zip`, both first-hop bootstrap scripts.
+  - **Corrected timestamp mechanic (fix pass):** the 07-17 sidecar's `generatedAt` (`2026-07-17T06:18:40Z`,
+    downloaded read-only: `gh release download stock-prep-onprem-rc-a-20260717-d87e086fd --pattern "*.json"`)
+    is **not** an exact match to the triggering run's `createdAt` (`2026-07-17T06:16:54Z`, from
+    `gh run view 29559593867 --json headSha,createdAt,updatedAt`) — it falls **inside** that run's window
+    (`createdAt` 06:16:54Z → `updatedAt` 06:18:59Z), ~1m46s after start, consistent with build duration. Only
+    `gitSha` (`d87e086fd1218b4cfb150177d43f2c52904b1d6d`) matches exactly. This session's own A1 run (§3)
+    independently reproduces the identical mechanic: manifest `generatedAt` `2026-07-25T07:04:41Z` falls
+    inside run 30148584851's window (`createdAt` 07:02:23Z → `updatedAt` 07:04:56Z), and its `gitSha` matches
+    the dispatch input exactly. Two independent instances of "manifest timestamp lands inside the run window,
+    gitSha matches exactly" is the actual, stronger claim — not the false "matches exactly" the original draft
+    made for `generatedAt`.
 
-## 3. Blocker — exact, plain
+## 3. RETRACTION, then A1 record, then the narrow residual (A2)
 
-The package build itself **cannot be executed under this lane's authority in this environment.** The primary
-reason is (b); (a) is corroborating and independently verified.
+### 3.0 Retraction — what this section previously claimed, and why it was wrong
 
-**(b) — PRIMARY: reaching `7bf2bd7a1` for a real build requires an action this lane is not authorized to take,
-and the verified precedent confirms there is no lighter-weight path left.** Checked the actual mechanics of
-how the frozen `d87e086fd` package was produced, rather than assuming:
+The original draft said, verbatim: *"(b) — PRIMARY: reaching `7bf2bd7a1` for a real build requires an action
+this lane is not authorized to take... Both [Option A and Option B] are the owner's freeze act in substance."*
+That framing is **withdrawn**. It conflated two different things:
+
+1. minting a **ref** at the exact historical commit `7bf2bd7a1` (needed only because GitHub's
+   `workflow_dispatch` takes a branch/tag `ref`, not a bare SHA — a mechanical prerequisite, not a decision
+   about product state), with
+2. the **freeze act** — publishing a GitHub Release that makes a specific build the addressable, checksummed,
+   permanent RC-A artifact #4437 points at.
+
+The mechanical refutation, read directly from the current workflow file
+(`.github/workflows/multitable-onprem-package-build.yml`): the `if:` gate
+`${{ inputs.publish_release == 'true' }}` appears **once**, on the `Publish GitHub Release` step (currently
+line 135), plus one conditional echo inside `Step summary` (line 201) that only prints the release tag when
+`publish_release=true`. `Build on-prem package` (line 81, includes the verify calls) and
+`Upload package artifacts` (line 173) carry **no** `if:` — they run unconditionally. This session's own run
+(§3.1 below) confirms it empirically, not just by reading the YAML: the job step list shows every build/verify/
+upload step `✓` and `Publish GitHub Release` skipped (`-`), exactly as the ungated/gated split predicts.
+
+**(a) was not refuted — it was satisfied, not by this session.** The old draft was right that no ref existed
+at `7bf2bd7a1` at the time it checked (`git tag --points-at` / `git branch -r --points-at` both empty). By the
+time this fix pass started, a branch ref did exist:
 ```
-gh run view 29559593867 --repo zensgit/metasheet2 --json headBranch,event,workflowName,headSha
-# {"event":"workflow_dispatch","headBranch":"main","headSha":"d87e086fd1218b...","workflowName":"Multitable On-Prem Package Build"}
-git log -1 --format="%H %cI" d87e086fd
-# d87e086fd1218b... 2026-07-17T05:52:47Z   (run dispatched 2026-07-17T06:16:54Z, same-day)
-git cat-file -t stock-prep-onprem-rc-a-20260717-d87e086fd
-# commit   (lightweight — consistent with gh release create minting it, not a hand-annotated freeze tag)
+git ls-remote origin refs/heads/build/m0a-rca-7bf2bd7a1
+# 7bf2bd7a1f8cdf54cca83a733fcd89afb076848b   refs/heads/build/m0a-rca-7bf2bd7a1
 ```
-The precedent process was: dispatch `multitable-onprem-package-build.yml` with `ref=main` **at the moment
-`main`'s tip was the desired commit**, with `expected_sha` pinned to that same commit as a fail-closed check;
-`gh release create` then mints the release tag from that exact state. **That window has passed for `7bf2bd7a1`**
-— `origin/main` has since advanced 11 commits past it (§2.1/§2.2), so `ref=main` today would build the wrong
-commit and `expected_sha` would correctly refuse it. Reaching `7bf2bd7a1` now requires either minting a new
-ref at that exact historical commit (§3 Option A — a **new pattern**, not the precedent process, since the
-precedent never needed a standalone tag) or checking it out directly on a matching local toolchain (§3 Option
-B). Both are the owner's freeze act in substance — ⟲R1 exit (b) is explicit: "the owner formally revises
-#4437 — publish, checksum, and **FREEZE** a new RC-A exact-SHA." This lane's authorization is "build and
-verify… prepare the #4437 pointer," not deploy, not flag-ON, and — per the lane's own doubt-is-the-answer
-discipline — not silently performing the adjacent owner-gated freeze step either. I did not create a ref at
-`7bf2bd7a1` and did not dispatch the workflow.
+— confirming (a)'s prerequisite (a ref must exist for `workflow_dispatch` to reach that commit) and confirming
+it was satisfied by construction. This session did not create that ref and cannot attest who did; the ruling
+that ref creation is a build prerequisite rather than the freeze act itself comes from this fix pass's
+direction, not from a finding made here.
 
-**(a) — corroborating, not independently verified this session.** `git tag --points-at 7bf2bd7a1` and
-`git branch -r --points-at 7bf2bd7a1` both return empty, so no ref currently exists at that SHA. I understand
-GitHub's `workflow_dispatch` API to require a branch-or-tag `ref` rather than accepting a bare commit SHA,
-which would make this a second, independent blocker on top of (b) — but I have not verified that constraint
-against GitHub's API/docs this session, so it should be read as understood-but-unconfirmed, not as an asserted
-fact. (b) alone is sufficient to block the build regardless of whether (a) also holds.
+**Corrected boundary:** M0-A's authorized build+verify half required only a ref to exist at the target
+commit — already true — not the freeze act. The freeze act (owner-only, §3.2/A2) is a separate, later,
+narrower thing: publishing the Release that makes one specific build the permanent, addressable RC-A artifact.
 
-**A local build in this sandbox is also disqualified**, independent of (a)/(b): the workflow pins Node 20 +
-pnpm exactly `9.15.9` on `ubuntu-latest` (the build script's own `PACKAGE_PNPM_VERSION="9.15.9"`, with an
-explicit comment that release lockfile compatibility depends on that exact pin). This environment runs
-Node `v25.9.0` / pnpm `10.33.0` on darwin. A package built here would not be the artifact the CI pipeline
-would produce, and hand-computing/publishing its SHA256 as "the RC-A checksum" would repeat the exact
-fabricated/self-certified-provenance failure mode this line exists to close (the frozen `d87e086fd` package's
-own defect is a **locally fabricated** `metadata.limit` rather than an echo-verified one — #4573's whole point;
-see also the `-ExpectedGitSha` in-archive-only binding in §2.4, which exists specifically to distrust
-externally-asserted provenance). I did not attempt a local build.
+### 3.1 A1 — build + verify, `publish_release=false` (Lane C authority; ALREADY RUN)
 
-**What a human needs to run** (either option; both are outside this lane's authority):
+Dispatched (by the fix-pass direction, prior to this session) and watched to completion by this session:
+```
+gh run view 30148584851 --json status,conclusion,headSha,headBranch,createdAt,updatedAt,workflowName
+# {"conclusion":"success","createdAt":"2026-07-25T07:02:23Z","headBranch":"build/m0a-rca-7bf2bd7a1",
+#  "headSha":"7bf2bd7a1f8cdf54cca83a733fcd89afb076848b","status":"completed",
+#  "updatedAt":"2026-07-25T07:04:56Z","workflowName":"Multitable On-Prem Package Build"}
+```
+`headSha` matches `expected_sha=7bf2bd7a1f8cdf54cca83a733fcd89afb076848b` exactly. Job steps
+(`gh run view 30148584851 --job=89654954864`):
+```
+✓ Set up job          ✓ Build web/backend dist         ✓ Upload package artifacts
+✓ Checkout             ✓ Build on-prem package          ✓ Step summary
+✓ Verify expected SHA  ✓ Bind build SHA into metadata    (+ Post-* / Complete job, all ✓)
+✓ Setup pnpm/Node.js   - Publish GitHub Release   ← skipped, confirms publish_release=false
+✓ Install deps
+```
+Downloaded the real artifact read-only (`gh run download 30148584851`) — not hand-typed:
 
-- **Option A — CI, a NEW scaffold pattern (not the precedent process; see §3(b)).** The precedent (dispatch at
-  `ref=main` the moment main's tip is the desired commit) is unavailable now that main has advanced past
-  `7bf2bd7a1`. A human/owner with tag-push rights would instead create a tag at exactly
-  `7bf2bd7a1f8cdf54cca83a733fcd89afb076848b` (e.g. `stock-prep-onprem-rc-a-build-7bf2bd7a1`), then:
+- **`SHA256SUMS`** (this A1 run's own output):
   ```
-  gh workflow run multitable-onprem-package-build.yml --repo zensgit/metasheet2 \
-    --ref stock-prep-onprem-rc-a-build-7bf2bd7a1 \
-    -f expected_sha=7bf2bd7a1f8cdf54cca83a733fcd89afb076848b \
-    -f publish_release=true \
-    -f release_tag=stock-prep-onprem-rc-a-20260725-7bf2bd7a1 \
-    -f release_name="Stock-prep on-prem RC-A (7bf2bd7a1)"
+  759adcc3cbb6f677f2c6aea92224df83085d1afb1424c1759d980b98abd07f4d  metasheet-multitable-onprem-v2.5.0-m0a-rca-20260725.tgz
+  880e9f47b2f887cb752176fa2c6eb45cb04008fa285aae0265647544a16e92c4  metasheet-multitable-onprem-v2.5.0-m0a-rca-20260725.zip
+  25197ba31dcc5638c63eb79e4928e4db6b0fcdc715aae799f7672d70119d0056  metasheet-multitable-onprem-v2.5.0-m0a-rca-20260725-deploy-bootstrap.ps1
+  75261b3f3b3a161e6c586d95ee4110a740454957c3c55cb0cd5e742839a176d5  metasheet-multitable-onprem-v2.5.0-m0a-rca-20260725-deploy-bootstrap.bat
   ```
-  This reuses the exact tooling that produced the frozen `d87e086fd` package and self-verifies inside the run
-  (`expected_sha` gate + `multitable-onprem-package-verify.sh` + the post-build `pnpm install --frozen-lockfile`
-  dependency preflight).
-- **Option B — local, matching toolchain.** On a host that can pin Node 20 + pnpm `9.15.9` (matching
-  `PACKAGE_PNPM_VERSION`) — e.g. via `corepack`/`nvm` on an ubuntu-like machine — checkout `7bf2bd7a1`, run
-  `pnpm install --frozen-lockfile`, `pnpm --filter @metasheet/web build`, `pnpm --filter @metasheet/core-backend build`,
-  then `INSTALL_DEPS=0 BUILD_WEB=0 BUILD_BACKEND=0 scripts/ops/multitable-onprem-package-build.sh` followed by
-  `scripts/ops/multitable-onprem-package-verify.sh` on both the `.tgz` and `.zip` outputs.
+  **These four checksums are A1-run-scoped evidence that the build+verify half executed and self-verified —
+  they are NOT the checksums the eventual A2 freeze run will produce.** `BUILD_PROVENANCE.json` (packaged
+  *inside* the checksummed archive) embeds `builtAt` (`date -u` at build time) and `ciRunId`
+  (`$GITHUB_RUN_ID`) — both per-run values baked into the archive bytes before hashing
+  (`scripts/ops/multitable-onprem-package-build.sh` lines ~508-510). A fresh `publish_release=true` dispatch
+  is a **new build**, with a new `ciRunId`/`builtAt`/archive bytes, therefore a **different** `.tgz`/`.zip`
+  SHA256 than the four values above. Do not carry these into #4437 as "the" RC-A checksums (§4 keeps them
+  `<<PENDING FREEZE RUN>>`).
+- **In-archive `BUILD_PROVENANCE.json`** (extracted from the `.tgz`, not the external sidecar):
+  ```json
+  { "schema": "metasheet-onprem-build-provenance/v1", "gitCommit": "7bf2bd7a1f8cdf54cca83a733fcd89afb076848b",
+    "gitCommitShort": "7bf2bd7a1f8c", "gitRef": "build/m0a-rca-7bf2bd7a1", "sourceIsOnOriginMain": "unknown",
+    "ciRunId": "30148584851", "ciRunAttempt": "1", "builtAt": "2026-07-25T07:04:39Z" }
+  ```
+  `gitCommit` = `7bf2bd7a1f8cdf54cca83a733fcd89afb076848b` — **exact match to `expected_sha`, CONFIRMED from
+  the checksummed bytes, not the external sidecar.** Unlike `builtAt`/`ciRunId`, `gitCommit` is derived from
+  `git rev-parse HEAD` at the pinned commit and will be the same in A2 provided A2 also targets `7bf2bd7a1`.
+- **Verify reports** (both archives, `ok: true`):
+  ```json
+  "checks": [
+    {"name":"checksum","status":"PASS"},
+    {"name":"required-content","status":"PASS","requiredCount":128},
+    {"name":"deployability-contract","status":"PASS","artifactKind":"deployable-onprem-app-package",
+     "deployMode":"fresh-extract-or-existing-root-apply","directReplaceSafe":false,"nodeModulesBundled":false},
+    {"name":"no-github-links","status":"PASS"}
+  ]
+  ```
+  Four checks, all PASS. No `loopback`-named check ran (see §6 — this is a ledger-vs-tooling spec gap, not an
+  A1 defect).
 
-Either way, once the archive exists, `serviceRuntimeSha` = the in-archive `BUILD_PROVENANCE.json.gitCommit`
-(expected `7bf2bd7a1f8cdf54cca83a733fcd89afb076848b`), and the manifest / `SHA256SUMS` / `*.verify.json` /
-`*.verify.md` are generated as a byproduct of the build — none of them should be hand-typed.
+**Two constraints the "done" framing must carry, or it misleads:**
+
+- **The Actions artifact (`multitable-onprem-package-30148584851-1`) is not a release.** It is unfrozen,
+  privately-scoped to this run, and has `retention-days: 14` set in the workflow — it expires around
+  **2026-08-08** (14 days from `createdAt` 2026-07-25T07:02:23Z). "Build+verify done" does not mean "package
+  available to deploy"; nothing here is a publicly-addressable checksummed asset until A2 runs.
+- If the owner's A2 act slips past the retention window, A1 must be re-run (cheap — no code changed, same
+  `expected_sha`, same ref) before A2, since A2's own build supersedes A1's bytes anyway.
+
+### 3.2 A2 — publish/freeze, `publish_release=true` (OWNER-ONLY — NOT inside M0-A's authorization)
+
+This is the one remaining blocked step, and it is a narrow one: an owner (or someone the owner delegates to)
+re-dispatches the same workflow, on a ref at the same commit, with `publish_release=true`. This performs the
+actual freeze — `gh release create`/`upload` inside the gated step — which is the ⟲R1 exit (b) act ("the
+owner formally revises #4437 — publish, checksum, and **FREEZE** a new RC-A exact-SHA"), not a Lane-C action.
+This document does not perform it, and does not choose the release tag on the owner's behalf:
+
+```
+gh workflow run multitable-onprem-package-build.yml --repo zensgit/metasheet2 \
+  --ref <a ref at 7bf2bd7a1f8cdf54cca83a733fcd89afb076848b — e.g. build/m0a-rca-7bf2bd7a1, already exists> \
+  -f expected_sha=7bf2bd7a1f8cdf54cca83a733fcd89afb076848b \
+  -f publish_release=true \
+  -f release_tag=<OWNER TO CHOOSE — not pre-selected by this document> \
+  -f release_name=<optional>
+```
+Once A2 completes, §4's `<<PENDING FREEZE RUN>>` fields (release tag, `.tgz`/`.zip` SHA256) get filled from
+that run's own `SHA256SUMS` and release assets — the same way A1's were, never hand-typed. `serviceRuntimeSha`
+does not change (same commit, same in-archive `gitCommit`); only the archive bytes/checksums and the release
+tag are new.
+
+**A local build in this sandbox remains disqualified**, independent of A1/A2: the workflow pins Node 20 +
+pnpm exactly `9.15.9` on `ubuntu-latest`. This environment runs Node `v25.9.0` / pnpm `10.33.0` on darwin — a
+locally-built package would not be the artifact the CI pipeline produces, and publishing its hand-computed
+SHA256 as "the RC-A checksum" would repeat the exact fabricated/self-certified-provenance failure mode this
+line exists to close. Not attempted.
 
 ---
 
 ## 4. Draft — #4437 execution pointer v3 (NOT POSTED)
 
-Everything below is a draft only. It is not posted to #4437. Fields the build in §3 has not yet produced are
-marked `<<PENDING BUILD>>` — do not fill them by guessing; they come from the archive's own
-`BUILD_PROVENANCE.json` and `SHA256SUMS` once §3's build runs.
+Everything below is a draft only. It is not posted to #4437. `gitCommit` is now CONFIRMED (§3.1, A1, stable
+across rebuilds of the same commit). Fields that only A2's own freeze run can produce (release tag, `.tgz`/
+`.zip` SHA256 — **not reusable from A1**, see §3.1) are marked `<<PENDING FREEZE RUN>>` — do not fill them by
+guessing or by copying A1's run-scoped checksums; they must come from A2's own `SHA256SUMS` and release assets.
 
 > **Execution pointer v3 (DATE-OF-ACTUAL-BUILD — draft). Supersedes execution pointer v2.**
 > Records the package's `serviceRuntimeSha` and `clientHelperSha` **separately** (per
@@ -227,9 +317,10 @@ marked `<<PENDING BUILD>>` — do not fill them by guessing; they come from the 
 >   that field cannot be trusted alone; see `stock-preparation-onprem-acceptance.ps1`'s `-ExpectedGitSha`
 >   comment). Build commit: `7bf2bd7a1f8cdf54cca83a733fcd89afb076848b` (`bridge.bounded_read.v2`, PR #4573 —
 >   closes the pre-hardening fabricated-`metadata.limit` gap the frozen `d87e086fd` package carries; P1a
->   applied-limit echo-verification, P1b `.v2` qualification lineage). `<<PENDING BUILD: release tag, `.tgz`/`.zip`
->   SHA256 from `SHA256SUMS`, in-archive `BUILD_PROVENANCE.json.gitCommit` read-back confirming
->   `7bf2bd7a1f8cdf54cca83a733fcd89afb076848b`>>`
+>   applied-limit echo-verification, P1b `.v2` qualification lineage). In-archive `BUILD_PROVENANCE.json.gitCommit`
+>   read-back **CONFIRMED** (A1, run 30148584851) = `7bf2bd7a1f8cdf54cca83a733fcd89afb076848b`, exact match.
+>   `<<PENDING FREEZE RUN (A2): release tag, `.tgz`/`.zip` SHA256 from A2's own `SHA256SUMS` — A1's checksums
+>   are run-scoped and will NOT match A2's, see §3.1>>`
 > - **`clientHelperSha`** (the two exact-SHA smoke harnesses the abort-provenance diagnostic and the sidecar
 >   wrapper import) — **unchanged, carried over from the frozen `d87e086fd` package**, independently verified
 >   blob-identical at `d87e086fd`, `7bf2bd7a1`, and current `main`:
@@ -237,13 +328,15 @@ marked `<<PENDING BUILD>>` — do not fill them by guessing; they come from the 
 >   - `stock-preparation-prep-line-extended-smoke.mjs` → `912f3ef75c4487dbdd946486d4cb7374f1c3ea1eb126c3b68381ad11963f0049`
 >   These already match `HELPER_CONTENT_SHA256` in `scripts/ops/stock-preparation-rca-abort-provenance.mjs` —
 >   **no code change is required for the client half of this revision.**
-> - **Release / tag**: `<<PENDING BUILD — e.g. stock-prep-onprem-rc-a-20260725-7bf2bd7a1>>`, built via the
->   **Multitable On-Prem Package Build** workflow (`.github/workflows/multitable-onprem-package-build.yml`) —
->   stock-prep ships as a plugin inside the multitable on-prem platform bundle; there is no stock-prep-specific
->   package build. `expected_sha=7bf2bd7a1f8cdf54cca83a733fcd89afb076848b` must be set at dispatch time so the
->   build fails closed on an uncertain checkout; in-archive `BUILD_PROVENANCE.gitCommit` must equal the same
->   value (40-hex, read back from the checksummed bytes); `.tgz`/`.zip` checksums must verify against
->   `SHA256SUMS`.
+> - **Release / tag**: `<<PENDING FREEZE RUN (A2) — owner selects the tag; not pre-chosen by this document>>`,
+>   built via the **Multitable On-Prem Package Build** workflow
+>   (`.github/workflows/multitable-onprem-package-build.yml`, `publish_release=true`) — stock-prep ships as a
+>   plugin inside the multitable on-prem platform bundle; there is no stock-prep-specific package build.
+>   `expected_sha=7bf2bd7a1f8cdf54cca83a733fcd89afb076848b` must be set at dispatch time so the build fails
+>   closed on an uncertain checkout (as A1's did, successfully); in-archive `BUILD_PROVENANCE.gitCommit` must
+>   equal the same value; `.tgz`/`.zip` checksums must verify against A2's own `SHA256SUMS` — A1's build+verify
+>   already proves the pipeline mechanics work end-to-end at this exact commit (§3.1); A2 is a re-run of the
+>   identical, already-proven mechanics with one flag flipped.
 >
 > ### What did NOT change from the frozen `d87e086fd` package
 > - Both RC-A smoke helper client scripts (content-identical; `clientHelperSha` above).
@@ -274,7 +367,7 @@ marked `<<PENDING BUILD>>` — do not fill them by guessing; they come from the 
 >
 > | v2 occurrence | governed by in v3 | value |
 > |---|---|---|
-> | "Exact source SHA" heading + in-archive `BUILD_PROVENANCE.gitCommit` validation | `serviceRuntimeSha` | `7bf2bd7a1f8cdf54cca83a733fcd89afb076848b` (`<<PENDING BUILD>>` for read-back confirmation) |
+> | "Exact source SHA" heading + in-archive `BUILD_PROVENANCE.gitCommit` validation | `serviceRuntimeSha` | `7bf2bd7a1f8cdf54cca83a733fcd89afb076848b` (read-back **CONFIRMED** via A1, run 30148584851 — §3.1) |
 > | Step 1 "Deploy the RC-A exact-SHA package to the isolated entity machine" | `serviceRuntimeSha` | same |
 > | Step 2 "detached local worktree at exact SHA `d87e086fd…`" + `git rev-parse HEAD` check | client checkout SHA (its own field, **not** renamed to either of the two above) | **stays** `d87e086fd1218b4cfb150177d43f2c52904b1d6d` — see "What did NOT change" |
 > | Step 2 v3.1 erratum "two exact-`d87e086fd` helpers" from sidecar v2 (no-Git path) | `clientHelperSha` | the two content hashes in "Package" above — already SHA-independent verification (byte comparison), so this path needs no wording change beyond noting the values now also equal the `7bf2bd7a1` bytes |
@@ -287,7 +380,48 @@ marked `<<PENDING BUILD>>` — do not fill them by guessing; they come from the 
 
 ## 5. What this document is and is not
 
-- It is: an investigation record + a draft the operator/owner can lift into #4437 once §3's build exists, plus
-  the mechanically-verified `clientHelperSha` half that needs no rebuild.
-- It is not: a built package, a published release, a real `serviceRuntimeSha`, or an edit to #4437 itself.
-  Nothing here was posted to the issue.
+- It is: an investigation record; a real, passing CI build+verify (A1, run 30148584851) at the exact
+  recommended commit, watched to completion and checked against its own downloaded outputs (not hand-typed);
+  a CONFIRMED `serviceRuntimeSha`/`gitCommit` read-back; the mechanically-verified `clientHelperSha` half
+  (unchanged from the original investigation, no rebuild needed); a draft the operator/owner can lift into
+  #4437 once A2 (§3.2) exists; and an escalation (§6) of a ledger-vs-tooling naming gap for the owner to rule
+  on.
+- It is not: a published release, a permanent/addressable checksummed artifact (A1's Actions artifact expires
+  ~2026-08-08, §3.1), the owner's freeze act, or an edit to #4437 itself. Nothing here was posted to the
+  issue. A1's `.tgz`/`.zip` SHA256 values are recorded as run-scoped evidence only and must not be read as
+  "the" RC-A checksums — those come from A2.
+
+## 6. Escalation to the owner — RATIFIED ledger names a check the verify tooling does not have
+
+**This is a specification gap, not a bug this document can fix, and not something it rules on.**
+
+The RATIFIED ledger (`docs/development/database-system-integration-line-design-and-verification-20260724.md`)
+names "loopback verification" as part of M0-A's authorized/expected output in two places:
+
+- §4, the M0-A bullet itself: *"regenerate manifest / SHA256 / provenance / **loopback verification**, revise
+  the #4437 pointer..."*
+- §2 ⟲R7: *"regenerate manifest + SHA256 + provenance + **loopback verification**; revise #4437..."*
+
+The actual verify tooling this build produces output through, `scripts/ops/multitable-onprem-package-verify.sh`,
+runs exactly **four** checks — confirmed from this session's own A1 `verify.json` output (§3.1):
+`checksum`, `required-content`, `deployability-contract`, `no-github-links`. None is named or behaves as a
+loopback check. Confirmed by direct grep against the current script, not inference:
+```
+grep -n "loopback" scripts/ops/multitable-onprem-package-verify.sh
+# (zero hits)
+grep -n "loopback" scripts/ops/attendance-onprem-package-verify.sh
+# 321:  die "Frontend bundle embeds loopback VITE_API_* config; rebuild package with isolated web env"
+```
+Attendance's on-prem verify script has exactly this kind of check (fails the build if the frontend bundle
+embeds a loopback `VITE_API_URL`); multitable's does not. So either:
+
+1. **the ledger's phrase should be amended** to name the four checks that actually exist (`checksum` /
+   `required-content` / `deployability-contract` / `no-github-links`), because "loopback verification" was
+   never built for the multitable path and the ledger's authorization language should describe what M0-A's
+   output actually is, or
+2. **a loopback check must be built** into `multitable-onprem-package-verify.sh` (mirroring attendance's
+   pattern) before M0-A's output can honestly be described as including it.
+
+Both are owner decisions. This document does not choose between them and does not edit the RATIFIED ledger.
+It records that A1's real, passing verify run covered four checks — not five, not "loopback" — so whoever
+reads M0-A's ledger line against A1's actual output does not silently assume a check ran that did not.

--- a/docs/development/stock-preparation-rc-a-m0a-package-build-status-and-4437-pointer-draft-20260725.md
+++ b/docs/development/stock-preparation-rc-a-m0a-package-build-status-and-4437-pointer-draft-20260725.md
@@ -38,7 +38,8 @@ run's own `SHA256SUMS` output. §3 gives the retraction, the A1 record, and the 
 inside the multitable on-prem platform bundle, so "the complete on-prem deployment package" for RC-A is the
 **Multitable On-Prem Package Build** workflow:
 `.github/workflows/multitable-onprem-package-build.yml` → `scripts/ops/multitable-onprem-package-build.sh`
-(packaging) → `scripts/ops/multitable-onprem-package-verify.sh` (loopback/structural verification).
+(packaging) → `scripts/ops/multitable-onprem-package-verify.sh` (structural verification — four checks, see
+§2.4/§3.1; the ledger's "loopback verification" phrasing is escalated, not confirmed, in §6).
 
 Evidence this — not `scripts/ops/build-stock-preparation-rca-window-sidecar.mjs` — is the real RC-A package
 builder:
@@ -65,10 +66,12 @@ git rev-parse stock-prep-onprem-rc-a-20260717-d87e086fd   # d87e086fd1218b4cfb15
 git merge-base --is-ancestor 7bf2bd7a1 stock-prep-onprem-rc-a-20260717-d87e086fd   # NOT an ancestor
 git merge-base --is-ancestor stock-prep-onprem-rc-a-20260717-d87e086fd 7bf2bd7a1   # IS an ancestor
 git merge-base --is-ancestor 7bf2bd7a1 origin/main                                  # IS an ancestor
-git rev-list --count 7bf2bd7a1..origin/main                                         # 11
+git rev-list --count 7bf2bd7a1..origin/main                                         # 11 at original draft time
 ```
 Confirms the ledger's framing: `d87e086fd` (frozen RC-A) < `7bf2bd7a1` (`bridge.bounded_read.v2`, #4573) <
-current `origin/main` (`402f04982`).
+main tip at original draft time (`402f04982`). **Both the count and the tip named here are draft-time
+snapshots, not live values — see §2.2's drift note: as of this fix pass, `origin/main` tip is `b5ff168e9`
+and the count is 12. The ancestry claims themselves (predates/reachable) do not change with main's tip.**
 
 ### 2.2 The recommended build SHA `7bf2bd7a1` keeps the change surface small — verified, not assumed
 ```
@@ -257,6 +260,28 @@ Downloaded the real artifact read-only (`gh run download 30148584851`) — not h
   ```
   Four checks, all PASS. No `loopback`-named check ran (see §6 — this is a ledger-vs-tooling spec gap, not an
   A1 defect).
+- **External sidecar manifest** (`metasheet-multitable-onprem-v2.5.0-m0a-rca-20260725.json`, read in full,
+  not excerpted):
+  ```json
+  { "name": "metasheet-multitable-onprem-v2.5.0-m0a-rca-20260725", "version": "2.5.0", "tag": "m0a-rca-20260725",
+    "artifactKind": "deployable-onprem-app-package", "deployMode": "fresh-extract-or-existing-root-apply",
+    "directReplaceSafe": false, "nodeModulesBundled": false, "pnpmVersion": "9.15.9",
+    "dependencyPreflight": "staging-full-install-before-live-overlay", "dependencyFailureRollback": true,
+    "windowsEntryPoint": "deploy.bat <package.zip|package.tgz>",
+    "windowsFirstHopBootstrap": "metasheet-multitable-onprem-v2.5.0-m0a-rca-20260725-deploy-bootstrap.ps1",
+    "windowsFirstHopBootstrapWrapper": "metasheet-multitable-onprem-v2.5.0-m0a-rca-20260725-deploy-bootstrap.bat",
+    "windowsStagingRootEnv": "METASHEET_ONPREM_STAGING_ROOT", "windowsDefaultStagingRoot": "C:\\ms-tmp",
+    "attendanceOnly": false, "productMode": "platform",
+    "includedPlugins": ["plugin-attendance", "plugin-integration-core"],
+    "archive": "metasheet-multitable-onprem-v2.5.0-m0a-rca-20260725.tgz",
+    "archiveZip": "metasheet-multitable-onprem-v2.5.0-m0a-rca-20260725.zip", "checksumFile": "SHA256SUMS",
+    "generatedAt": "2026-07-25T07:04:41Z", "gitSha": "7bf2bd7a1f8cdf54cca83a733fcd89afb076848b" }
+  ```
+  `productMode: "platform"` + `includedPlugins: [plugin-attendance, plugin-integration-core]` is the A1-side
+  confirmation, now at `7bf2bd7a1` (not just at the frozen `d87e086fd`, §1), that this is the platform+plugin
+  bundle ⟲R7 means by "the package" — not the sidecar. `gitSha` here (the external, workflow-appended field)
+  also matches `7bf2bd7a1f8cdf54cca83a733fcd89afb076848b`, but per §2.4's `-ExpectedGitSha` note this field is
+  informational only — the trust anchor is the in-archive `BUILD_PROVENANCE.json.gitCommit` above.
 
 **Two constraints the "done" framing must carry, or it misleads:**
 

--- a/docs/development/stock-preparation-rc-a-m0a-package-build-status-and-4437-pointer-draft-20260725.md
+++ b/docs/development/stock-preparation-rc-a-m0a-package-build-status-and-4437-pointer-draft-20260725.md
@@ -398,27 +398,30 @@ earlier draft — see the erratum immediately below), with the introducing commi
 git rev-parse HEAD:scripts/ops/multitable-onprem-package-verify.sh
 # 89ec733a41af25bee9d7f02f608fefcbefbbd9c1
 ```
-Introduced at commit `bd6f8eb51a3eb66972089b60ddde752131b50dd4` on this branch as rebased onto `origin/main`
-tip `d75d3b828` (the introducing **commit** SHA is rebase-unstable and will change again on any future
-rebase of this branch). **This is a tooling identity, not a deployed-artifact identity — it must never be
-conflated into `serviceRuntimeSha`** (still `7bf2bd7a1f8cdf54cca83a733fcd89afb076848b`, unchanged) **or
-presented as part of what run `30148584851` itself produced.**
+Introduced at commit `76417a0ceaefaff85433bf3b4df9327e61c9175f` on this branch as rebased onto `origin/main`
+tip `aebac4f8bef344b3ff3443ee045439c789a569a1` (this section's final, required pre-push rebase — the
+introducing **commit** SHA is rebase-unstable and has already changed once since it was first recorded here;
+it will change again on any future rebase of this branch). **This is a tooling identity, not a
+deployed-artifact identity — it must never be conflated into `serviceRuntimeSha`** (still
+`7bf2bd7a1f8cdf54cca83a733fcd89afb076848b`, unchanged) **or presented as part of what run `30148584851`
+itself produced.**
 
 **Erratum (review #4604):** an earlier version of this section recorded blob `2e64b9d66…` and claimed it was
 "stable across this fix pass's own later commits" — that claim was **false**, and was falsified by this very
-fix pass's own comment-only edit to the script (commit `480720aff`, whose own diff header reads
-`index 2e64b9d66..b2f5ff716`), which changed the blob without the sentence being revisited. A
-comment-stripped diff of the two blobs is **identical**, so the PASS recorded in this section was never
+fix pass's own comment-only edit to the script (commit `dbfd25643724eeb0477bdf89c040fadc8317c7af`, whose own
+diff header reads `index 2e64b9d66..b2f5ff716`), which changed the blob without the sentence being revisited.
+A comment-stripped diff of the two blobs is **identical**, so the PASS recorded in this section was never
 behaviourally wrong — only the recorded tool *identity* was stale, the same class of slip this branch already
-fixed once at `31151fc90`. (Both `480720aff` and `31151fc90` are **pre-rebase commit SHAs**, cited here only
-as the historical record of when each fix landed in this fix pass — like `bd6f8eb51` above, they are
-rebase-unstable and will shift once this branch is rebased onto `origin/main`; the **blob** SHAs
-`2e64b9d66…`/`b2f5ff716…` they refer to are content hashes and remain valid identities regardless of any
-future rebase.) The blob SHA recorded above is a content hash of the script as it exists at this document's
-own final commit; blobs (unlike commit SHAs) do not shift on a content-preserving rebase, but it was
-re-confirmed rather than assumed once this branch was rebased onto `origin/main` before pushing. It is
-**not** asserted to be stable against any future *content* change to the script — if the script changes
-again after this fix pass, this line goes stale again and must be re-derived, not assumed correct.
+fixed once at `593e66efd5835780843a59fe693185eb9fa10963`. (Both of those are **post-rebase commit SHAs**,
+current as of this section's own final pre-push rebase onto `origin/main` tip `aebac4f8b…` above — like the
+introducing commit above, they are rebase-unstable and will shift again on any future rebase of this branch;
+the **blob** SHAs `2e64b9d66…`/`b2f5ff716…` they refer to are content hashes and remain valid identities
+regardless of any rebase.) The blob SHA recorded above is a content hash of the script as it exists at this
+document's own final commit; blobs (unlike commit SHAs) do not shift on a content-preserving rebase, and it
+was re-confirmed (not assumed) after this branch's final pre-push rebase — same value, `89ec733a4…`, before
+and after. It is **not** asserted to be stable against any future *content* change to the script — if the
+script changes again after this fix pass, this line goes stale again and must be re-derived, not assumed
+correct.
 
 **What was executed — a real, full run of the updated tool against A1's real, already-built artifact bytes**
 (not the sourced-function fixture test above; not a rebuild; `serviceRuntimeSha` does not move). Commands

--- a/docs/development/stock-preparation-rc-a-m0a-package-build-status-and-4437-pointer-draft-20260725.md
+++ b/docs/development/stock-preparation-rc-a-m0a-package-build-status-and-4437-pointer-draft-20260725.md
@@ -361,10 +361,12 @@ introducing commit also recorded for provenance:
 git rev-parse HEAD:scripts/ops/multitable-onprem-package-verify.sh
 # 2e64b9d6639fa9e250cb06003adcdd41604560a8
 ```
-Introduced at commit `542ca93b73cd20bbbadb3aece7c1d448581c55a6` on this branch (rebased onto `origin/main`
-tip `d4dc12d8a`). **This is a tooling identity, not a deployed-artifact identity — it must never be conflated
-into `serviceRuntimeSha`** (still `7bf2bd7a1f8cdf54cca83a733fcd89afb076848b`, unchanged) **or presented as
-part of what run `30148584851` itself produced.**
+Introduced at commit `bd6f8eb51a3eb66972089b60ddde752131b50dd4` on this branch as rebased onto `origin/main`
+tip `d75d3b828` (the introducing **commit** SHA is rebase-unstable and will change again on any future
+rebase of this branch; the **blob** SHA above is the load-bearing identity precisely because it is not).
+**This is a tooling identity, not a deployed-artifact identity — it must never be conflated into
+`serviceRuntimeSha`** (still `7bf2bd7a1f8cdf54cca83a733fcd89afb076848b`, unchanged) **or presented as part of
+what run `30148584851` itself produced.**
 
 **What was executed — a real, full run of the updated tool against A1's real, already-built artifact bytes**
 (not the sourced-function fixture test above; not a rebuild; `serviceRuntimeSha` does not move). Commands and

--- a/docs/development/stock-preparation-rc-a-m0a-package-build-status-and-4437-pointer-draft-20260725.md
+++ b/docs/development/stock-preparation-rc-a-m0a-package-build-status-and-4437-pointer-draft-20260725.md
@@ -41,10 +41,15 @@ No checksum was hand-typed or fabricated — the checksums recorded below are re
   frozen package's own CI-produced verify output includes a loopback check" — run `30148584851`'s own
   `verify.json` is immutable and still shows four checks (§3.1). §3.1a also records a known forward gap: a
   future A2 dispatch at the pinned ref (`build/m0a-rca-7bf2bd7a1`, still targeting source commit `7bf2bd7a1`)
-  will check out the **old**, four-check verify script, not this fix pass's five-check version — so A2's own
-  `verify.json` will also be four checks unless the owner separately revisits the ref/tooling situation. That
-  is not resolved here.
+  will check out the **old**, four-check verify script, not this fix pass's five-check version — so a Path-B
+  (§3.2, rebuild) A2's own `verify.json` will also be four checks unless the owner separately revisits the
+  ref/tooling situation. **This applies to a rebuild only; the owner's now-recommended Path A (§3.2a, freeze)
+  involves no dispatch at the pinned ref at all, so no fresh `verify.json` — four- or five-check — is produced
+  by A2 either way under that path.** Neither path's forward gap is resolved here.
 - **(ii) the owner-only A2 publish/freeze act** (§3.2) — unchanged from before this fix pass.
+  **Update (review #4604, this update):** the owner has since given guidance on *how* A2 should be executed
+  once authorized — freeze A1's already-verified original bytes rather than rebuild. See §3.2a. That guidance
+  is recorded, **not executed**; A2 itself is still open and still the owner's act.
 
 §3 gives the retraction, the A1 record, the loopback-check build + post-hoc execution (§3.1a), and the narrow
 residual (A2, owner-only, §3.2).
@@ -331,12 +336,25 @@ Downloaded the real artifact read-only (`gh run download 30148584851`) — not h
 
 **Two constraints the "done" framing must carry, or it misleads:**
 
-- **The Actions artifact (`multitable-onprem-package-30148584851-1`) is not a release.** It is unfrozen,
-  privately-scoped to this run, and has `retention-days: 14` set in the workflow — it expires around
-  **2026-08-08** (14 days from `createdAt` 2026-07-25T07:02:23Z). "Build+verify done" does not mean "package
-  available to deploy"; nothing here is a publicly-addressable checksummed asset until A2 runs.
-- If the owner's A2 act slips past the retention window, A1 must be re-run (cheap — no code changed, same
-  `expected_sha`, same ref) before A2, since A2's own build supersedes A1's bytes anyway.
+- **The Actions artifact (`multitable-onprem-package-30148584851-1`, id `8616890535`) is not a release.** It
+  is unfrozen, privately-scoped to this run, and has `retention-days: 14` set in the workflow — confirmed live
+  (not assumed from the 14-day setting), `gh api repos/zensgit/metasheet2/actions/runs/30148584851/artifacts`
+  →
+  `{"id":8616890535,"digest":"sha256:13c7aaa36a777786d75effa3b5ce2df7b1ce39ad47869a806638d57d5dbc0aea","expired":false,"expires_at":"2026-08-08T07:04:52Z"}`
+  (checked this update). "Build+verify done" does not mean "package available to deploy"; nothing here is a
+  publicly-addressable checksummed asset until A2 runs.
+- **Erratum (this update):** the sentence below originally assumed A2 = a fresh workflow dispatch, i.e. a
+  rebuild. The owner has since ruled the *recommended* A2 path is to freeze A1's still-unexpired original
+  bytes instead (§3.2a) — under that path A2 does not build anything, so "A2's own build supersedes A1's
+  bytes" does not apply. The retention-window risk described below is retained as-written because it is still
+  real under either path: if the window lapses *before* A2 (freeze or rebuild) executes, the artifact
+  downloaded here becomes permanently unrecoverable (Actions does not allow re-downloading an expired
+  artifact), and the only way forward is a fresh A1 run producing new, no-longer-A1-identical bytes to freeze
+  or rebuild from — kept below, historical framing, superseded by §3.2a's freeze-path framing where noted:
+  ~~If the owner's A2 act slips past the retention window, A1 must be re-run (cheap — no code changed, same
+  `expected_sha`, same ref) before A2, since A2's own build supersedes A1's bytes anyway.~~ (struck: "A2's own
+  build supersedes A1's bytes" is only true on the rebuild path §3.2, not the recommended freeze path §3.2a —
+  see §3.2a for the corrected statement of this same retention risk.)
 
 ### 3.1a Loopback verification — built, then run post-hoc/standalone against A1's real artifact (this fix pass)
 
@@ -597,7 +615,14 @@ forward (which `docs/development/database-system-integration-line-design-and-ver
 "Build SHA stays `7bf2bd7a1`... do not enlarge the runtime change surface" ruling weighs against, and this
 document does not decide). This gap is recorded, not closed.
 
-### 3.2 A2 — publish/freeze, `publish_release=true` (OWNER-ONLY — NOT inside M0-A's authorization)
+### 3.2 A2, Path B (rebuild) — publish/freeze via fresh dispatch, `publish_release=true` (OWNER-ONLY, NOT inside M0-A's authorization; not the owner's recommended path as of this update, see §3.2a)
+
+**Erratum (this update):** this subsection's original text (unchanged below) described the only path
+considered at the time — re-dispatch the build workflow. The owner has since ruled (review #4604) that the
+**recommended** A2 procedure is instead to freeze A1's already-verified original bytes without rebuilding —
+see §3.2a. This subsection (Path B) is kept, not struck, as the documented fallback for the case §3.2a itself
+names (A1's artifact expires before A2 is authorized, forcing a fresh run). Do not execute Path B as the
+default; §3.2a is the recommended default once A2 is authorized.
 
 This is the one remaining blocked step, and it is a narrow one: an owner (or someone the owner delegates to)
 re-dispatches the same workflow, on a ref at the same commit, with `publish_release=true`. This performs the
@@ -613,10 +638,16 @@ gh workflow run multitable-onprem-package-build.yml --repo zensgit/metasheet2 \
   -f release_tag=<OWNER TO CHOOSE — not pre-selected by this document> \
   -f release_name=<optional>
 ```
-Once A2 completes, §4's `<<PENDING FREEZE RUN>>` fields (release tag, `.tgz`/`.zip` SHA256) get filled from
-that run's own `SHA256SUMS` and release assets — the same way A1's were, never hand-typed. `serviceRuntimeSha`
-does not change (same commit, same in-archive `gitCommit`); only the archive bytes/checksums and the release
-tag are new.
+Once A2 completes **via this Path-B rebuild**, §4's `<<PENDING FREEZE RUN>>` fields (release tag, `.tgz`/`.zip`
+SHA256) get filled from that run's own `SHA256SUMS` and release assets — the same way A1's were, never
+hand-typed. `serviceRuntimeSha` does not change (same commit, same in-archive `gitCommit`); only the archive
+bytes/checksums and the release tag are new. **This is Path-B-specific — see §3.2a for what these same §4
+fields resolve to under the recommended Path A (freeze).** Also note (§6/§3.1a forward gap, restated for this
+path): the ref this dispatch targets (`build/m0a-rca-7bf2bd7a1`, pinned to commit `7bf2bd7a1`) checks out that
+commit's own copy of `multitable-onprem-package-verify.sh`, which is the pre-this-branch **four-check** script
+(verified this update — `git show 7bf2bd7a1f8cdf54cca83a733fcd89afb076848b:scripts/ops/multitable-onprem-package-verify.sh
+| grep -n loopback` → zero hits) — so a Path-B rebuild's own `verify.json` would still be four checks, not
+five, regardless of what this branch built in §3.1a/§6.
 
 **A local build in this sandbox remains disqualified**, independent of A1/A2: the workflow pins Node 20 +
 pnpm exactly `9.15.9` on `ubuntu-latest`. This environment runs Node `v25.9.0` / pnpm `10.33.0` on darwin — a
@@ -624,14 +655,93 @@ locally-built package would not be the artifact the CI pipeline produces, and pu
 SHA256 as "the RC-A checksum" would repeat the exact fabricated/self-certified-provenance failure mode this
 line exists to close. Not attempted.
 
+### 3.2a A2, Path A (freeze original bytes) — the owner's RECOMMENDED procedure (review #4604, this update) — NOT YET EXECUTED, still the owner's act
+
+**This section records the owner's ruling on how A2 should be carried out once authorized. It does not
+authorize, perform, or schedule A2. No release is published, no tag is chosen, and no artifact is downloaded
+or uploaded by this document.**
+
+**Why freeze instead of rebuild (Path B, §3.2), in the owner's own reasoning, verified here:**
+
+- **A1's artifact has not expired.** Live check this update, `gh api
+  repos/zensgit/metasheet2/actions/runs/30148584851/artifacts`:
+  ```
+  {"id":8616890535,"name":"multitable-onprem-package-30148584851-1",
+   "digest":"sha256:13c7aaa36a777786d75effa3b5ce2df7b1ce39ad47869a806638d57d5dbc0aea",
+   "expired":false,"expires_at":"2026-08-08T07:04:52Z"}
+  ```
+  Outer digest `sha256:13c7aaa3…c0aea`, valid until 2026-08-08. This is the same artifact §3.1 already
+  downloaded and recorded `SHA256SUMS`/provenance/verify-report evidence from.
+- **A rebuild (Path B) would not reproduce these bytes.** `scripts/ops/multitable-onprem-package-build.sh`
+  bakes `"ciRunId": "${GITHUB_RUN_ID:-local}"` (line ~508) and `"builtAt": "$(date -u ...)"` (line ~510) into
+  `BUILD_PROVENANCE.json` **inside the archive, before hashing** — both are per-run values. A fresh dispatch
+  gets a new `GITHUB_RUN_ID` and a new timestamp, therefore different archive bytes and a different `.tgz`/
+  `.zip` SHA256, even though `gitCommit` is identical (§3.1 already established this; it is why §3.1 calls
+  A1's checksums "run-scoped"). Freezing A1's own bytes is the only path whose published checksums are the
+  ones A1's evidence (§3.1) already documents.
+- **The historical ref still runs the old, four-check verifier — a rebuild gains nothing here either.**
+  Verified this update directly against the pinned commit, not assumed: `git show
+  7bf2bd7a1f8cdf54cca83a733fcd89afb076848b:scripts/ops/multitable-onprem-package-verify.sh | grep -n loopback`
+  → zero hits (16 `verify_*` functions total at that commit, none loopback-named). A Path-B rebuild at that
+  same ref would therefore still be verified by the **older, four-check** tool and would **not** pick up this
+  branch's five-check `multitable-onprem-package-verify.sh` (§3.1a/§6) — the forward gap those sections already
+  flag. Freezing sidesteps this entirely: under Path A there is no CI dispatch at the pinned ref at all, so the
+  four-check-tool gap doesn't arise (**moot for this path, not closed** — it would still apply if Path B were
+  chosen instead, or if the ref/tooling question is separately revisited per §3.1a).
+
+**Recommended procedure (fastest path, strongest evidence — not executed here):**
+
+1. **Download A1** — `gh run download 30148584851` (or `gh api .../artifacts/8616890535/zip`) — the exact
+   artifact §3.1 already recorded evidence from.
+2. **Re-verify the original hashes and provenance** — reconfirm `SHA256SUMS` and in-archive
+   `BUILD_PROVENANCE.json.gitCommit` against §3.1's recorded values (unchanged bytes, so this should
+   reproduce identically; §3.1a already did one round of this as part of the loopback-check work).
+3. **Re-verify the `.tgz`/`.zip` with the merged FIVE-check verifier** — run this branch's
+   `scripts/ops/multitable-onprem-package-verify.sh` (the version with `verify_no_loopback_frontend_config`,
+   §3.1a/§6) against the downloaded archive, and confirm `requiredCount`/checks match §3.1a's post-hoc run
+   (5/5, including the `loopback` check now PASS-backed by a real derived status, not a hardcoded literal —
+   §3.1a's P2 fix). This is what lets the eventual release claim the five-check result, honestly, for bytes
+   that were never run through the CI pipeline's own (still four-check) verify step.
+4. **Publish the ORIGINAL bytes** — a manual `gh release create <tag> <downloaded .tgz> <downloaded .zip>
+   <downloaded bootstrap .ps1/.bat> <downloaded SHA256SUMS> ...` (or `gh release upload` to an
+   already-created release) of the **exact files downloaded in step 1**, unmodified. **This is not the §3.2
+   Path-B `gh workflow run ... publish_release=true` command** — that command re-dispatches the build and
+   therefore rebuilds; publishing A1's original bytes means the workflow's own gated `Publish GitHub Release`
+   step is bypassed in favor of a manual release of files already produced and already verified. Tag choice
+   remains the owner's, not pre-selected here.
+5. **Upload round-trip check** — after publishing, download the release asset back
+   (`gh release download <tag>` or the release's browser-download URLs) and re-hash
+   (`shasum -a 256`), confirming it matches the corresponding line in A1's own `SHA256SUMS` (§3.1) exactly.
+   This is what makes "the published bytes are A1's original bytes" a verified claim rather than an assertion.
+
+**Under this path, §4's `<<PENDING FREEZE RUN>>` fields resolve to §3.1's own already-recorded values** — the
+four `SHA256SUMS` lines quoted in §3.1, and `gitCommit`/`ciRunId`/`builtAt` from §3.1's own
+`BUILD_PROVENANCE.json` excerpt — **not** a new run's output, because there is no new run. Only the release tag
+(owner's choice, step 4) is genuinely new.
+
+**Retention-window interaction:** if A1's artifact expires (after 2026-08-08) before A2 is authorized, step 1
+becomes impossible (Actions does not allow downloading an expired artifact), and this exact "original bytes"
+framing no longer applies — the operator would need a fresh A1 run (cheap, same `expected_sha`/ref, no code
+changed) to produce a new set of candidate bytes, then apply steps 2-5 to *those*. That re-run's bytes would
+carry a new `ciRunId`/`builtAt` of their own (same reasoning as the rebuild-produces-different-bytes point
+above) but would still be a freeze of *some* real A1-equivalent run's bytes, not a Path-B
+`publish_release=true` rebuild-and-simultaneously-publish in one step.
+
+**Status: recorded, not executed.** Nothing in this section downloads, re-verifies, publishes, or round-trips
+anything — that remains the owner's (or their delegate's) act, same authorization boundary as §3.2.
+
 ---
 
 ## 4. Draft — #4437 execution pointer v3 (NOT POSTED)
 
 Everything below is a draft only. It is not posted to #4437. `gitCommit` is now CONFIRMED (§3.1, A1, stable
-across rebuilds of the same commit). Fields that only A2's own freeze run can produce (release tag, `.tgz`/
-`.zip` SHA256 — **not reusable from A1**, see §3.1) are marked `<<PENDING FREEZE RUN>>` — do not fill them by
-guessing or by copying A1's run-scoped checksums; they must come from A2's own `SHA256SUMS` and release assets.
+across rebuilds of the same commit). Fields that require A2 to have happened (release tag, `.tgz`/`.zip`
+SHA256) are marked `<<PENDING FREEZE RUN>>` — do not fill them by guessing. **This paragraph and the two
+`<<PENDING FREEZE RUN>>` bullets below were written assuming Path B (§3.2, rebuild): "not reusable from A1;
+must come from A2's own SHA256SUMS." Erratum (this update): under the owner's now-recommended Path A (§3.2a,
+freeze), A2 produces no new `SHA256SUMS` — the checksums that end up in the release ARE A1's own §3.1 values,
+verified byte-identical by the round-trip check in §3.2a step 5. Which of the two applies depends on which
+path A2 is actually executed with; this document does not decide that in advance.**
 
 > **Execution pointer v3 (DATE-OF-ACTUAL-BUILD — draft). Supersedes execution pointer v2.**
 > Records the package's `serviceRuntimeSha` and `clientHelperSha` **separately** (per
@@ -649,8 +759,9 @@ guessing or by copying A1's run-scoped checksums; they must come from A2's own `
 >   closes the pre-hardening fabricated-`metadata.limit` gap the frozen `d87e086fd` package carries; P1a
 >   applied-limit echo-verification, P1b `.v2` qualification lineage). In-archive `BUILD_PROVENANCE.json.gitCommit`
 >   read-back **CONFIRMED** (A1, run 30148584851) = `7bf2bd7a1f8cdf54cca83a733fcd89afb076848b`, exact match.
->   `<<PENDING FREEZE RUN (A2): release tag, `.tgz`/`.zip` SHA256 from A2's own `SHA256SUMS` — A1's checksums
->   are run-scoped and will NOT match A2's, see §3.1>>`
+>   `<<PENDING FREEZE RUN (A2): release tag, `.tgz`/`.zip` SHA256>>` — **Path B (§3.2, rebuild): from a new
+>   run's own `SHA256SUMS`, will NOT match A1's, see §3.1. Path A (§3.2a, recommended, freeze): these ARE
+>   A1's own §3.1 `SHA256SUMS` values, republished — see §3.2a for the round-trip proof.**
 > - **`clientHelperSha`** (the two exact-SHA smoke harnesses the abort-provenance diagnostic and the sidecar
 >   wrapper import) — **unchanged, carried over from the frozen `d87e086fd` package**, independently verified
 >   blob-identical at `d87e086fd`, `7bf2bd7a1`, and current `main`:
@@ -666,15 +777,23 @@ guessing or by copying A1's run-scoped checksums; they must come from A2's own `
 >   immutable and still shows four checks) and will not come from a future A2 run at the pinned ref either,
 >   unless the ref/tooling question is separately revisited (§3.1a forward gap) — do not post this line to
 >   #4437 as if it were part of A2's own build output.
-> - **Release / tag**: `<<PENDING FREEZE RUN (A2) — owner selects the tag; not pre-chosen by this document>>`,
->   built via the **Multitable On-Prem Package Build** workflow
->   (`.github/workflows/multitable-onprem-package-build.yml`, `publish_release=true`) — stock-prep ships as a
->   plugin inside the multitable on-prem platform bundle; there is no stock-prep-specific package build.
->   `expected_sha=7bf2bd7a1f8cdf54cca83a733fcd89afb076848b` must be set at dispatch time so the build fails
->   closed on an uncertain checkout (as A1's did, successfully); in-archive `BUILD_PROVENANCE.gitCommit` must
->   equal the same value; `.tgz`/`.zip` checksums must verify against A2's own `SHA256SUMS` — A1's build+verify
->   already proves the pipeline mechanics work end-to-end at this exact commit (§3.1); A2 is a re-run of the
->   identical, already-proven mechanics with one flag flipped.
+> - **Release / tag**: `<<PENDING FREEZE RUN (A2) — owner selects the tag; not pre-chosen by this document>>`.
+>   **Erratum (this update) — how the release gets built depends on which A2 path is used, recorded plainly so
+>   neither reads as "the" mechanism:**
+>   - **Path B (§3.2, rebuild):** built via the **Multitable On-Prem Package Build** workflow
+>     (`.github/workflows/multitable-onprem-package-build.yml`, `publish_release=true`) — stock-prep ships as a
+>     plugin inside the multitable on-prem platform bundle; there is no stock-prep-specific package build.
+>     `expected_sha=7bf2bd7a1f8cdf54cca83a733fcd89afb076848b` must be set at dispatch time so the build fails
+>     closed on an uncertain checkout (as A1's did, successfully); in-archive `BUILD_PROVENANCE.gitCommit` must
+>     equal the same value; `.tgz`/`.zip` checksums must verify against that run's own `SHA256SUMS`. A1's
+>     build+verify already proves the pipeline mechanics work end-to-end at this exact commit (§3.1); Path B is
+>     a re-run of the identical, already-proven mechanics with one flag flipped — but it is a re-run, so its
+>     bytes differ from A1's (§3.2a explains why).
+>   - **Path A (§3.2a, recommended):** built by a manual `gh release create`/`upload` of the exact bytes
+>     already downloaded from A1 (run `30148584851`, artifact `8616890535`) — the workflow's own gated
+>     `Publish GitHub Release` step is not invoked at all. `.tgz`/`.zip` checksums verify against A1's own
+>     `SHA256SUMS` (§3.1), confirmed by a post-publish round-trip re-download+re-hash (§3.2a step 5), not a
+>     fresh CI run's output.
 >
 > ### What did NOT change from the frozen `d87e086fd` package
 > - Both RC-A smoke helper client scripts (content-identical; `clientHelperSha` above).
@@ -724,16 +843,23 @@ guessing or by copying A1's run-scoped checksums; they must come from A2's own `
   (unchanged from the original investigation, no rebuild needed); a real loopback-verification check, built
   per owner ruling (§6) and run post-hoc/standalone against A1's real artifact bytes at a recorded, separate
   `verificationToolSha` (§3.1a), PASS, corroborated by an independent direct grep; a draft the operator/owner
-  can lift into #4437 once A2 (§3.2) exists.
-- It is not: a published release, a permanent/addressable checksummed artifact (A1's Actions artifact expires
-  ~2026-08-08, §3.1), the owner's freeze act, an edit to #4437 itself, or an edit to the RATIFIED ledger
-  (§6's ruling is recorded here, not written into the ledger's own text). Nothing here was posted to the
-  issue. A1's `.tgz`/`.zip` SHA256 values are recorded as run-scoped evidence only and must not be read as
-  "the" RC-A checksums — those come from A2. The post-hoc loopback PASS (§3.1a) is not the same claim as "run
-  30148584851's own `verify.json` has five checks" — that artifact is immutable and still has four (§3.1); a
-  future A2 dispatch at the pinned ref will also still emit four unless the ref/tooling question is
-  separately revisited (§3.1a's forward gap, not resolved here). **A1 PASS is not M0-A PASS** — M0-A remains
-  open pending A2 regardless.
+  can lift into #4437 once A2 (§3.2/§3.2a) exists; the owner's recorded (not executed) guidance on which A2
+  procedure to use (§3.2a, this update).
+- It is not: a published release, a permanent/addressable checksummed artifact (A1's Actions artifact, id
+  `8616890535`, has NOT yet expired as of this update — `expires_at 2026-08-08T07:04:52Z`, §3.2a — but is not
+  itself a release), the owner's freeze act, an edit to #4437 itself, or an edit to the RATIFIED ledger (§6's
+  ruling is recorded here, not written into the ledger's own text). Nothing here was posted to the issue.
+  **Erratum (this update):** the next sentence ("A1's checksums... must not be read as 'the' RC-A checksums —
+  those come from A2") was written assuming A2 = a rebuild (§3.2, Path B); it is retained as-written because it
+  is still correct for that path. Under the owner's now-recommended path (§3.2a, Path A, freeze) it is the
+  opposite: A1's `.tgz`/`.zip` SHA256 values, already recorded in §3.1, **are** what gets published as the RC-A
+  checksums, verified by a round-trip re-hash after publish (§3.2a step 5) — not reused by assertion. Which
+  applies depends on which path A2 is actually executed with; neither has happened yet. The post-hoc loopback
+  PASS (§3.1a) is not the same claim as "run 30148584851's own `verify.json` has five checks" — that artifact
+  is immutable and still has four (§3.1); a future Path-B A2 dispatch at the pinned ref will also still emit
+  four unless the ref/tooling question is separately revisited (§3.1a's forward gap, not resolved here) — this
+  gap does not arise under Path A, where there is no dispatch at all (§3.2a). **A1 PASS is not M0-A PASS** —
+  M0-A remains open pending A2 (either path) regardless.
 
 ## 6. Owner ruling on the escalation — build the check (option 2), not amend the ledger (option 1)
 

--- a/docs/development/stock-preparation-rc-a-m0a-package-build-status-and-4437-pointer-draft-20260725.md
+++ b/docs/development/stock-preparation-rc-a-m0a-package-build-status-and-4437-pointer-draft-20260725.md
@@ -6,6 +6,10 @@ on-prem deployment package at the owner-chosen main SHA, regenerate manifest/SHA
 verification, prepare (not post) the #4437 pointer revision. Not authorized: deployment, flag-ON, connecting
 to any host, editing #4437 itself, merging, pushing to main.
 
+**Scope note:** the ledger's §2 M0-A paragraph also names "prepare the bounded approved config" as part of
+M0-A. This document's Lane-C task list (the four numbered "Your job" items given to this run) does not include
+that item, and it is **not** addressed here — do not read this document as a complete M0-A closeout.
+
 ## Status: BLOCKED on the build itself. Investigation, blob-identity proof, and the pointer draft are DONE.
 
 No package was built. No release was published. No fabricated checksum was produced. §3 below gives the
@@ -116,34 +120,53 @@ and `7bf2bd7a1`, so the helper content hash may carry over") and gives the exact
     (workflow-appended, informational only, not the trust anchor).
   - `metasheet-multitable-onprem-v2.5.0-rc-a-20260717-d87e086fd.tgz.verify.json` — `"ok": true`, checks:
     `checksum` PASS, `required-content` PASS (`requiredCount: 128`), `deployability-contract` PASS, `no-github-links`
-    PASS. **This is what "loopback verification" in the ledger maps to** — a local/offline structural
+    PASS — this is what `multitable-onprem-package-verify.sh` actually runs: a local/offline structural
     verification of the produced archive (checksum + required-file inventory + deployability-contract shape +
-    no leaked GitHub URLs), run by `multitable-onprem-package-verify.sh` against the archive on disk. It is
-    distinct from M0-B's "flag-OFF health verification" (a live-host `/health` check), which stays ops-gated
-    and out of scope for M0-A.
+    no leaked GitHub URLs). **Mapping this to the ledger's phrase "loopback verification" is my inference, not
+    a confirmed match** — I searched `multitable-onprem-package-verify.sh` for a `loopback`-named check (the
+    kind attendance's `attendance-onprem-package-verify.sh` has, which fails if the built frontend bundle
+    embeds a loopback `VITE_API_URL`) and found none; multitable's verify script has no such check. If the
+    ledger's "loopback verification" instead means a live loopback HTTP probe against a running instance (the
+    pattern `stock-preparation-rca-c-window-runner-development-verification-20260722.md` uses), that is a
+    runtime/host action and belongs to M0-B's "flag-OFF health verification," not to this build-only step —
+    it was not run here either way.
   - `SHA256SUMS` — four checksummed files: `.tgz`, `.zip`, both first-hop bootstrap scripts.
 
 ## 3. Blocker — exact, plain
 
-The package build itself **cannot be executed under this lane's authority in this environment**, for two
-independent reasons:
+The package build itself **cannot be executed under this lane's authority in this environment.** The primary
+reason is (b); (a) is corroborating and independently verified.
 
-**(a) No git ref exists at the recommended SHA.**
+**(b) — PRIMARY: reaching `7bf2bd7a1` for a real build requires an action this lane is not authorized to take,
+and the verified precedent confirms there is no lighter-weight path left.** Checked the actual mechanics of
+how the frozen `d87e086fd` package was produced, rather than assuming:
 ```
-git tag --points-at 7bf2bd7a1        # (empty)
-git branch -r --points-at 7bf2bd7a1  # (empty)
+gh run view 29559593867 --repo zensgit/metasheet2 --json headBranch,event,workflowName,headSha
+# {"event":"workflow_dispatch","headBranch":"main","headSha":"d87e086fd1218b...","workflowName":"Multitable On-Prem Package Build"}
+git log -1 --format="%H %cI" d87e086fd
+# d87e086fd1218b... 2026-07-17T05:52:47Z   (run dispatched 2026-07-17T06:16:54Z, same-day)
+git cat-file -t stock-prep-onprem-rc-a-20260717-d87e086fd
+# commit   (lightweight — consistent with gh release create minting it, not a hand-annotated freeze tag)
 ```
-`origin/main` has advanced 11 commits past `7bf2bd7a1` (§2.1/§2.2), so it is not the branch tip either.
-GitHub's `workflow_dispatch` API requires a branch-or-tag `ref` — it does not accept a bare commit SHA — so
-dispatching the real `multitable-onprem-package-build.yml` workflow at exactly `7bf2bd7a1` is not possible
-without first minting a ref there.
+The precedent process was: dispatch `multitable-onprem-package-build.yml` with `ref=main` **at the moment
+`main`'s tip was the desired commit**, with `expected_sha` pinned to that same commit as a fail-closed check;
+`gh release create` then mints the release tag from that exact state. **That window has passed for `7bf2bd7a1`**
+— `origin/main` has since advanced 11 commits past it (§2.1/§2.2), so `ref=main` today would build the wrong
+commit and `expected_sha` would correctly refuse it. Reaching `7bf2bd7a1` now requires either minting a new
+ref at that exact historical commit (§3 Option A — a **new pattern**, not the precedent process, since the
+precedent never needed a standalone tag) or checking it out directly on a matching local toolchain (§3 Option
+B). Both are the owner's freeze act in substance — ⟲R1 exit (b) is explicit: "the owner formally revises
+#4437 — publish, checksum, and **FREEZE** a new RC-A exact-SHA." This lane's authorization is "build and
+verify… prepare the #4437 pointer," not deploy, not flag-ON, and — per the lane's own doubt-is-the-answer
+discipline — not silently performing the adjacent owner-gated freeze step either. I did not create a ref at
+`7bf2bd7a1` and did not dispatch the workflow.
 
-**(b) Minting that ref is the owner's freeze act, not this lane's.** ⟲R1 exit (b) reads: "the owner formally
-revises #4437 — publish, checksum, and **FREEZE** a new RC-A exact-SHA." Creating a tag/branch at exactly
-`7bf2bd7a1` for the purpose of building the frozen RC-A package **is** that freeze act wearing a different
-name. This lane's authorization is "build and verify… prepare the #4437 pointer" — not deploy, not flag-ON,
-and (per the lane's own doubt-is-the-answer discipline) not silently performing the adjacent owner-gated step
-either. I did not create a ref at `7bf2bd7a1`.
+**(a) — corroborating, not independently verified this session.** `git tag --points-at 7bf2bd7a1` and
+`git branch -r --points-at 7bf2bd7a1` both return empty, so no ref currently exists at that SHA. I understand
+GitHub's `workflow_dispatch` API to require a branch-or-tag `ref` rather than accepting a bare commit SHA,
+which would make this a second, independent blocker on top of (b) — but I have not verified that constraint
+against GitHub's API/docs this session, so it should be read as understood-but-unconfirmed, not as an asserted
+fact. (b) alone is sufficient to block the build regardless of whether (a) also holds.
 
 **A local build in this sandbox is also disqualified**, independent of (a)/(b): the workflow pins Node 20 +
 pnpm exactly `9.15.9` on `ubuntu-latest` (the build script's own `PACKAGE_PNPM_VERSION="9.15.9"`, with an
@@ -157,7 +180,9 @@ externally-asserted provenance). I did not attempt a local build.
 
 **What a human needs to run** (either option; both are outside this lane's authority):
 
-- **Option A — CI, matching existing precedent.** A human/owner with tag-push rights creates a tag at exactly
+- **Option A — CI, a NEW scaffold pattern (not the precedent process; see §3(b)).** The precedent (dispatch at
+  `ref=main` the moment main's tip is the desired commit) is unavailable now that main has advanced past
+  `7bf2bd7a1`. A human/owner with tag-push rights would instead create a tag at exactly
   `7bf2bd7a1f8cdf54cca83a733fcd89afb076848b` (e.g. `stock-prep-onprem-rc-a-build-7bf2bd7a1`), then:
   ```
   gh workflow run multitable-onprem-package-build.yml --repo zensgit/metasheet2 \
@@ -224,8 +249,14 @@ marked `<<PENDING BUILD>>` — do not fill them by guessing; they come from the 
 > - Both RC-A smoke helper client scripts (content-identical; `clientHelperSha` above).
 > - The PowerShell wrapper's `-ExpectedGitSha` lock mechanism and the abort-provenance diagnostic's
 >   `HELPER_CONTENT_SHA256` allowlist — no code change needed for the client half.
-> - Operator steps 1-5, the PASS criteria list, and the Prohibitions section of v2 — unchanged in substance;
->   only the SHA references below change.
+> - **The client worktree checkout SHA in Operator step 2 stays `d87e086fd1218b4cfb150177d43f2c52904b1d6d`,
+>   unchanged.** Deliberate, not a default: since the two smoke helpers are content-identical at `d87e086fd`
+>   and `7bf2bd7a1` (§2.3), moving the client checkout would yield the same bytes for no benefit, while
+>   *keeping* it avoids re-cutting the `stock-preparation-rca-window-sidecar` (its `FROZEN_RUNTIME_SHA` /
+>   `FROZEN_HELPERS` in `scripts/ops/build-stock-preparation-rca-window-sidecar.mjs` are already pinned to
+>   `d87e086fd`) and avoids re-running the "sidecar v2" no-Git-equivalence verification recorded in the v2
+>   erratum. This is a recommendation for the human finalizing the pointer to confirm, not something this
+>   document can ratify.
 >
 > ### What changed
 > - The service runtime moves from `d87e086fd` (pre-`bridge.bounded_read.v2`; `metadata.limit` **locally
@@ -237,10 +268,20 @@ marked `<<PENDING BUILD>>` — do not fill them by guessing; they come from the 
 >   replaced by the two named fields above so a future runtime bump cannot silently be read as implying the
 >   client also changed (or vice versa).
 >
-> ### Operator steps
-> Unchanged from v2 (§ Operator steps 1-5), substituting `serviceRuntimeSha` for `d87e086fd1218b4cfb150177d43f2c52904b1d6d`
-> wherever the deployed package/runtime is referenced. `clientHelperSha` values are unchanged from v2 — no
-> client-side re-verification step is added by this revision.
+> ### Operator steps — per-occurrence mapping (this is the actual de-conflation; do not paraphrase it away)
+> v2's body uses "the exact source SHA" / "`d87e086fd1218b4cfb150177d43f2c52904b1d6d`" at five distinct spots
+> that this revision's two-SHA split must not leave ambiguous:
+>
+> | v2 occurrence | governed by in v3 | value |
+> |---|---|---|
+> | "Exact source SHA" heading + in-archive `BUILD_PROVENANCE.gitCommit` validation | `serviceRuntimeSha` | `7bf2bd7a1f8cdf54cca83a733fcd89afb076848b` (`<<PENDING BUILD>>` for read-back confirmation) |
+> | Step 1 "Deploy the RC-A exact-SHA package to the isolated entity machine" | `serviceRuntimeSha` | same |
+> | Step 2 "detached local worktree at exact SHA `d87e086fd…`" + `git rev-parse HEAD` check | client checkout SHA (its own field, **not** renamed to either of the two above) | **stays** `d87e086fd1218b4cfb150177d43f2c52904b1d6d` — see "What did NOT change" |
+> | Step 2 v3.1 erratum "two exact-`d87e086fd` helpers" from sidecar v2 (no-Git path) | `clientHelperSha` | the two content hashes in "Package" above — already SHA-independent verification (byte comparison), so this path needs no wording change beyond noting the values now also equal the `7bf2bd7a1` bytes |
+> | PASS criterion `clientSourceShaMatch=PASS` / `clientContentVerified=PASS` | `clientHelperSha` (and the unchanged client checkout SHA for the Git path) | unchanged mechanism; unchanged expected values |
+>
+> Everything else in Operator steps 1-5, the PASS criteria list, and the Prohibitions section of v2 is
+> unchanged in substance — only the SHA references in the table above move.
 
 ---
 

--- a/docs/development/stock-preparation-rc-a-m0a-package-build-status-and-4437-pointer-draft-20260725.md
+++ b/docs/development/stock-preparation-rc-a-m0a-package-build-status-and-4437-pointer-draft-20260725.md
@@ -351,8 +351,38 @@ reported as a fifth `"loopback"` field in both the JSON and Markdown reports. Ne
 `VITE_API_URL`+`127.0.0.1`, `VITE_API_BASE`+`localhost` (opposite corners of the alternation), and
 `apps/web/dist` missing entirely (closes a vacuous-pass hole: `search_extended_regex` returns non-zero/no-match
 against a target directory that does not exist, which would otherwise silently report PASS on a package
-missing its frontend bundle). Like the sibling provenance test, it is **not wired into any CI workflow** —
-run manually; the doc does not imply CI coverage it does not have.
+missing its frontend bundle).
+
+**Hardening (review #4604 P2 — two findings, both addressed within the file's existing conventions):**
+1. The report's `"loopback"` row was a hardcoded `"status": "PASS"` literal — printed even if the check were
+   never invoked. Replaced with a derived `loopback_status` variable (default `"SKIPPED"`, set to `"PASS"` by
+   `verify_no_loopback_frontend_config()` itself only on a successful run) and wired that variable into both
+   the JSON and Markdown report emission. The focused test gained a fifth case that greps the main script body
+   for the literal top-level call site (distinct from the `function ... () {` definition, which survives a
+   call-site deletion) — deleting the call site now reds this test (verified: 4 passed/1 failed) instead of
+   staying green at 4/4. **This pin is itself only as strong as item 2 below**: it fires when
+   `multitable-onprem-package-verify-loopback.test.sh` is run, and per item 2 nothing runs that file
+   automatically — the pin protects a manual run from a silent regression, it does not by itself make a
+   dropped call site fail any automated check.
+2. Neither this focused test nor its sibling `multitable-onprem-package-verify.provenance.test.sh` has any
+   automated caller (no workflow, no package script, no glob runner) — this is **pre-existing convention**,
+   not something this fix pass introduced or regressed. The underlying *check* does run in CI: nothing was
+   silently going untested — `multitable-onprem-package-build.yml` invokes
+   `scripts/ops/multitable-onprem-package-verify.sh` directly against both the `.tgz` and `.zip` outputs
+   (L101/L104), so the loopback check itself executes on every real package build. What is **not** CI-covered
+   is the *focused fixture test* — its exposure is that it can rot unnoticed (e.g. a future edit to the
+   function silently breaking one of the four fixture cases would not fail CI). **Disclosed here rather than
+   wired into a caller**: wiring would mean either adding a `pull_request`-triggered job for a check-family
+   that does not have one **today**, or adding a step to `multitable-onprem-package-build.yml`, which is
+   `workflow_dispatch`-only and would not run on ordinary PR iteration anyway — both are broader
+   infra/convention changes than this fix pass's scope, and singling out only these two `.test.sh` files (this
+   fix pass separately confirmed the same is true of at least two sibling `.test.mjs` contract tests against
+   this same script — `multitable-onprem-package-verify-k3-helper-contract.test.mjs` and
+   `bridge-agent-driver-smoke-contract.test.mjs`, neither referenced by any workflow or package script either)
+   would be an arbitrary, partial fix to a repo-wide pattern rather than a considered one. Run manually:
+   `bash scripts/ops/multitable-onprem-package-verify-loopback.test.sh` and
+   `bash scripts/ops/multitable-onprem-package-verify.provenance.test.sh`; the doc does not imply CI coverage
+   for either that it does not have.
 
 **Scope limitation, stated plainly:** the ported pattern is reused **verbatim** per the owner's ruling
 ("reuse attendance's rule") and is not changed here. The fixtures prove the rule is falsifiable *as specified*
@@ -361,19 +391,34 @@ web bundler can or does ever emit that shape in practice (whether it can was not
 this fix pass; §3.1a's direct grep against the real artifact only shows this particular build does not
 contain it today).
 
-**`verificationToolSha`** — the exact tool used below. Recorded as the **blob** SHA of the script (the
-load-bearing identity: stable across this fix pass's own later commits, e.g. this document's), with the
-introducing commit also recorded for provenance:
+**`verificationToolSha`** — the exact tool used below. Recorded as the **blob** SHA of the script content at
+this document's own final commit in this fix pass, re-derived AFTER that commit (not carried forward from an
+earlier draft — see the erratum immediately below), with the introducing commit also recorded for provenance:
 ```
 git rev-parse HEAD:scripts/ops/multitable-onprem-package-verify.sh
-# 2e64b9d6639fa9e250cb06003adcdd41604560a8
+# 89ec733a41af25bee9d7f02f608fefcbefbbd9c1
 ```
 Introduced at commit `bd6f8eb51a3eb66972089b60ddde752131b50dd4` on this branch as rebased onto `origin/main`
 tip `d75d3b828` (the introducing **commit** SHA is rebase-unstable and will change again on any future
-rebase of this branch; the **blob** SHA above is the load-bearing identity precisely because it is not).
-**This is a tooling identity, not a deployed-artifact identity — it must never be conflated into
-`serviceRuntimeSha`** (still `7bf2bd7a1f8cdf54cca83a733fcd89afb076848b`, unchanged) **or presented as part of
-what run `30148584851` itself produced.**
+rebase of this branch). **This is a tooling identity, not a deployed-artifact identity — it must never be
+conflated into `serviceRuntimeSha`** (still `7bf2bd7a1f8cdf54cca83a733fcd89afb076848b`, unchanged) **or
+presented as part of what run `30148584851` itself produced.**
+
+**Erratum (review #4604):** an earlier version of this section recorded blob `2e64b9d66…` and claimed it was
+"stable across this fix pass's own later commits" — that claim was **false**, and was falsified by this very
+fix pass's own comment-only edit to the script (commit `480720aff`, whose own diff header reads
+`index 2e64b9d66..b2f5ff716`), which changed the blob without the sentence being revisited. A
+comment-stripped diff of the two blobs is **identical**, so the PASS recorded in this section was never
+behaviourally wrong — only the recorded tool *identity* was stale, the same class of slip this branch already
+fixed once at `31151fc90`. (Both `480720aff` and `31151fc90` are **pre-rebase commit SHAs**, cited here only
+as the historical record of when each fix landed in this fix pass — like `bd6f8eb51` above, they are
+rebase-unstable and will shift once this branch is rebased onto `origin/main`; the **blob** SHAs
+`2e64b9d66…`/`b2f5ff716…` they refer to are content hashes and remain valid identities regardless of any
+future rebase.) The blob SHA recorded above is a content hash of the script as it exists at this document's
+own final commit; blobs (unlike commit SHAs) do not shift on a content-preserving rebase, but it was
+re-confirmed rather than assumed once this branch was rebased onto `origin/main` before pushing. It is
+**not** asserted to be stable against any future *content* change to the script — if the script changes
+again after this fix pass, this line goes stale again and must be re-derived, not assumed correct.
 
 **What was executed — a real, full run of the updated tool against A1's real, already-built artifact bytes**
 (not the sourced-function fixture test above; not a rebuild; `serviceRuntimeSha` does not move). Commands
@@ -455,6 +500,56 @@ abbreviated to `<local>`:
    current artifact does not hit the forbidden pattern. This is the expected outcome the owner's ruling was
    scoped to — **completing the proof, not changing service code** — and that is what happened; no
    runtime/service code changed, only the verify tool.
+4. **Re-ran a third time after this fix pass's own P2 hardening** (§3.1a "Hardening" above —
+   `loopback_status` derived variable + call-site pin), against the same real artifact bytes, on the file the
+   artifact's own checksum still confirms unchanged (`shasum -a 256` reproduces the identical
+   `759adcc3…07f4d` line from step 1 again). Unlike steps 1-3, this one was run **directly** in this session
+   (no wrapper script needed here — that earlier constraint was specific to the session that ran steps 1-3),
+   with real absolute paths, abbreviated below to `<local>` the same way as elsewhere in this document:
+   ```
+   $ VERIFY_REPORT_JSON=<local>/posthoc-verify-3.json VERIFY_REPORT_MD=<local>/posthoc-verify-3.md \
+     bash scripts/ops/multitable-onprem-package-verify.sh <local>/metasheet-multitable-onprem-v2.5.0-m0a-rca-20260725.tgz
+   metasheet-multitable-onprem-v2.5.0-m0a-rca-20260725.tgz: OK
+   [multitable-onprem-package-verify] Package verify OK
+   [multitable-onprem-package-verify]   package: <local>/metasheet-multitable-onprem-v2.5.0-m0a-rca-20260725.tgz
+   [multitable-onprem-package-verify]   root: <extracted temp dir>
+   [multitable-onprem-package-verify]   verify_report_json: <local>/posthoc-verify-3.json
+   [multitable-onprem-package-verify]   verify_report_md: <local>/posthoc-verify-3.md
+   EXIT=0
+   ```
+   `posthoc-verify-3.json`'s `checks` array, real content (the full file also carries the same
+   `packageFile`/`packageName`/`archiveType`/`packageRootInArchive`/`extractMode`/`extractRoot` fields as
+   `posthoc-verify-2.json` above, omitted here since only the `checks` array and `generatedAt` are new
+   information) — identical shape/values to `posthoc-verify-2.json` above (`requiredCount=128`, all five
+   checks `PASS`, including `loopback` now via the derived `loopback_status` variable rather than the prior
+   literal), only `generatedAt` differs:
+   ```json
+   {
+     "checks": [
+       { "name": "checksum", "status": "PASS" },
+       { "name": "required-content", "status": "PASS", "requiredCount": 128 },
+       { "name": "deployability-contract", "status": "PASS", "artifactKind": "deployable-onprem-app-package",
+         "deployMode": "fresh-extract-or-existing-root-apply", "directReplaceSafe": false, "nodeModulesBundled": false },
+       { "name": "no-github-links", "status": "PASS" },
+       { "name": "loopback", "status": "PASS" }
+     ],
+     "generatedAt": "2026-07-25T15:11:16Z"
+   }
+   ```
+   `posthoc-verify-3.md`'s `## Checks` section (both report formats exercised again, matching step 2's point
+   that CI itself produces both): identical five-line content to `posthoc-verify-2.md`'s `## Checks` section
+   above, byte-for-byte, since `loopback_status` resolves to `"PASS"` on a successful run either way.
+
+   This is the run that corresponds to the `verificationToolSha` recorded above
+   (`89ec733a41af25bee9d7f02f608fefcbefbbd9c1`). `posthoc-verify-2` above was run against the prior,
+   now-superseded blob (`b2f5ff716…`, comment-only diff from the one before it) and is kept in this document
+   as its own historical record — not deleted or silently overwritten — because the P2 hardening changed how
+   the `"loopback"` row is *derived* (a real code change, unlike the comment-only edit the erratum above
+   describes), not what result a successful run against this artifact reports. The call-site pin added in
+   Hardening item 1 only fires when `multitable-onprem-package-verify-loopback.test.sh` is itself run (it is
+   not wired into any automated caller, per Hardening item 2 above) — it does not run as part of this or any
+   other real verify invocation, which is why this step re-runs the full verify script directly rather than
+   relying on the pin for behavioral proof.
 
 **Explicit non-conflation, stated plainly (this is the exact thing ⟲R7 exists to prevent):** run
 `30148584851`'s own `verify.json`, the one packaged inside the CI-produced Actions artifact, is **immutable
@@ -535,7 +630,8 @@ guessing or by copying A1's run-scoped checksums; they must come from A2's own `
 >   **no code change is required for the client half of this revision.**
 > - **Loopback verification** (not a third deployed-artifact SHA — a tooling-run result; see §3.1a for the
 >   full record, kept separate here on purpose): PASS, via a post-hoc/standalone run of the updated verify
->   tool (`verificationToolSha` = `2e64b9d6639fa9e250cb06003adcdd41604560a8`, the script blob) against A1's
+>   tool (`verificationToolSha` = `89ec733a41af25bee9d7f02f608fefcbefbbd9c1`, the script blob at this
+>   document's final commit — see §3.1a's erratum for the prior stale value) against A1's
 >   real artifact. **This did not come from run `30148584851`'s own `verify.json`** (that artifact is
 >   immutable and still shows four checks) and will not come from a future A2 run at the pinned ref either,
 >   unless the ref/tooling question is separately revisited (§3.1a forward gap) — do not post this line to

--- a/docs/development/stock-preparation-rc-a-m0a-package-build-status-and-4437-pointer-draft-20260725.md
+++ b/docs/development/stock-preparation-rc-a-m0a-package-build-status-and-4437-pointer-draft-20260725.md
@@ -1,0 +1,252 @@
+# Stock-prep RC-A — M0-A package build status + #4437 pointer revision draft (2026-07-25)
+
+Lane: **LANE C — M0-A** (per `docs/development/database-system-integration-line-design-and-verification-20260724.md`,
+§2 M0-A / §4 "Parallel and unblocked" M0-A track, ⟲C1/⟲R1/⟲R7). Authorized: build + verify the COMPLETE
+on-prem deployment package at the owner-chosen main SHA, regenerate manifest/SHA256/provenance/loopback
+verification, prepare (not post) the #4437 pointer revision. Not authorized: deployment, flag-ON, connecting
+to any host, editing #4437 itself, merging, pushing to main.
+
+## Status: BLOCKED on the build itself. Investigation, blob-identity proof, and the pointer draft are DONE.
+
+No package was built. No release was published. No fabricated checksum was produced. §3 below gives the
+exact blocker and what a human needs to run.
+
+---
+
+## 1. Tooling identification
+
+**There is no stock-prep-specific on-prem package build.** Stock-prep ships as a plugin (`plugin-integration-core`)
+inside the multitable on-prem platform bundle, so "the complete on-prem deployment package" for RC-A is the
+**Multitable On-Prem Package Build** workflow:
+`.github/workflows/multitable-onprem-package-build.yml` → `scripts/ops/multitable-onprem-package-build.sh`
+(packaging) → `scripts/ops/multitable-onprem-package-verify.sh` (loopback/structural verification).
+
+Evidence this — not `scripts/ops/build-stock-preparation-rca-window-sidecar.mjs` — is the real RC-A package
+builder:
+
+- `gh release view stock-prep-onprem-rc-a-20260717-d87e086fd --repo zensgit/metasheet2` lists assets named
+  `metasheet-multitable-onprem-v2.5.0-rc-a-20260717-d87e086fd.*` (`.tgz`, `.zip`, `.json`, bootstrap `.ps1`/`.bat`,
+  `SHA256SUMS`, `*.verify.json`/`.md`) — the exact output shape the multitable workflow produces.
+- `gh run list --repo zensgit/metasheet2 --workflow=multitable-onprem-package-build.yml` shows a `success` run
+  at `headSha=d87e086fd1218b4cfb150177d43f2c52904b1d6d`, created `2026-07-17T06:16:54Z`, matching the release's
+  `generatedAt`/`gitSha` exactly.
+- The package's own metadata (`metasheet-multitable-onprem-v2.5.0-rc-a-20260717-d87e086fd.json`, downloaded
+  read-only for this investigation): `"includedPlugins": ["plugin-attendance", "plugin-integration-core"]`,
+  `"productMode": "platform"` — the platform+plugin bundle, confirming ⟲R7's claim directly: the sidecar ZIP
+  (`build-stock-preparation-rca-window-sidecar.mjs`'s output) is a separate, smaller artifact (smoke helpers +
+  PowerShell wrapper + PM2 sample + provenance only — no `bridge-agent-readonly-adapter.cjs`) and is **not**
+  what #4437 references as "the package."
+
+## 2. Verified facts (mechanical, no fabrication)
+
+### 2.1 `d87e086fd` predates `7bf2bd7a1`, both reachable from current `origin/main`
+```
+git rev-parse stock-prep-onprem-rc-a-20260717-d87e086fd   # d87e086fd1218b4cfb150177d43f2c52904b1d6d
+git merge-base --is-ancestor 7bf2bd7a1 stock-prep-onprem-rc-a-20260717-d87e086fd   # NOT an ancestor
+git merge-base --is-ancestor stock-prep-onprem-rc-a-20260717-d87e086fd 7bf2bd7a1   # IS an ancestor
+git merge-base --is-ancestor 7bf2bd7a1 origin/main                                  # IS an ancestor
+git rev-list --count 7bf2bd7a1..origin/main                                         # 11
+```
+Confirms the ledger's framing: `d87e086fd` (frozen RC-A) < `7bf2bd7a1` (`bridge.bounded_read.v2`, #4573) <
+current `origin/main` (`402f04982`).
+
+### 2.2 The recommended build SHA `7bf2bd7a1` keeps the change surface small — verified, not assumed
+```
+git log --oneline 7bf2bd7a1..origin/main
+```
+gives the 11 commits between the recommended SHA and current main tip: `#4590` (this ledger doc, doc-only),
+three attendance W4/W5 commits (`#4595/#4592/#4588/#4585/#4586/#4584/#4576`), two directory-deprovision
+commits (`#4577/#4575`), and **`#4583`** — `fix(data-source): enforce the A5 row bound in MySQLAdapter + pin
+the SQL-adapter roster` — a **runtime data-source change**. Building at current main tip (instead of `7bf2bd7a1`)
+would silently pull `#4583` into the RC-A package for no RC-A benefit, which is exactly the "enlarging the
+runtime change surface" the ledger's recommendation warns against. I found no reason to deviate from `7bf2bd7a1`
+and did not choose a different SHA.
+
+Also verified: the build tooling itself is byte-identical between the recommended SHA and current main —
+```
+git log --oneline 7bf2bd7a1..origin/main -- .github/workflows/multitable-onprem-package-build.yml \
+  scripts/ops/multitable-onprem-package-build.sh scripts/ops/multitable-onprem-package-verify.sh
+```
+returns nothing, so "build at `7bf2bd7a1`" and "build at current main" would use the identical build/verify
+scripts — only the source snapshot differs.
+
+### 2.3 `clientHelperSha` — identified and proven blob-identical (this is the reusable half of the two-SHA split)
+
+`scripts/ops/stock-preparation-rca-abort-provenance.mjs` (the RC-A abort-provenance diagnostic) already names
+and pins exactly **two** files as "the two RC-A smoke harnesses":
+
+```js
+export const HELPER_BASENAME_ALLOWLIST = Object.freeze([
+  'stock-preparation-prep-line-extended-smoke.mjs',
+  'stock-preparation-mvp-postdeploy-smoke.mjs',
+])
+export const HELPER_CONTENT_SHA256 = Object.freeze({
+  'stock-preparation-prep-line-extended-smoke.mjs': '912f3ef75c4487dbdd946486d4cb7374f1c3ea1eb126c3b68381ad11963f0049',
+  'stock-preparation-mvp-postdeploy-smoke.mjs': 'e5265a2a8052ddc34866438a1ee3356b5d2aa1a106c8199f5e2fbbe4f2614df4',
+})
+```
+
+Verified independently — git blob identity across all three points in history, plus the content SHA-256 of the
+blob at the recommended build SHA:
+
+| file | blob @ `d87e086fd` | blob @ `7bf2bd7a1` | blob @ `origin/main` | content SHA-256 @ `7bf2bd7a1` |
+|---|---|---|---|---|
+| `stock-preparation-mvp-postdeploy-smoke.mjs` | `30b2653f1...` | `30b2653f1...` (identical) | `30b2653f1...` (identical) | `e5265a2a8052ddc34866438a1ee3356b5d2aa1a106c8199f5e2fbbe4f2614df4` (matches pin) |
+| `stock-preparation-prep-line-extended-smoke.mjs` | `8a7998f29...` | `8a7998f29...` (identical) | `8a7998f29...` (identical) | `912f3ef75c4487dbdd946486d4cb7374f1c3ea1eb126c3b68381ad11963f0049` (matches pin) |
+
+(`stock-preparation-rca-window-pm2-sample.mjs`, the PM2 sample, did not exist yet at `d87e086fd` —
+`git rev-parse d87e086fd:scripts/ops/stock-preparation-rca-window-pm2-sample.mjs` errors "exists on disk, but
+not in 'd87e086fd'" — confirming it is not part of the carried-over pair.)
+
+This directly confirms the ledger's ⟲R7 claim ("the two smoke helpers are blob-identical between `d87e086fd`
+and `7bf2bd7a1`, so the helper content hash may carry over") and gives the exact `clientHelperSha` values for
+§4's draft below — no rebuild needed for the client half.
+
+### 2.4 Provenance/checksum mechanics a real build must satisfy (read from code, not assumed)
+
+- `BUILD_PROVENANCE.json` ships **inside** the archive at the package root, schema
+  `metasheet-onprem-build-provenance/v1`, and `multitable-onprem-package-verify.sh` (L297-L306) requires its
+  `gitCommit` field to be a real 40-hex SHA (never "unknown", never short).
+- `scripts/ops/stock-preparation-onprem-acceptance.ps1`'s `-ExpectedGitSha` lock (L146-L318) explicitly binds
+  to **that in-archive field**, not the external sidecar `.json`'s `gitSha` — "an old archive cannot be
+  laundered by a fresh sidecar" (comment at L305-306). `serviceRuntimeSha` in §4 below must anchor to this
+  in-archive field once the build exists, not to a hand-typed value.
+- Confirmed by downloading (read-only) the three small metadata assets from the existing 07-17 release:
+  - `metasheet-multitable-onprem-v2.5.0-rc-a-20260717-d87e086fd.json` — external sidecar; carries `gitSha`
+    (workflow-appended, informational only, not the trust anchor).
+  - `metasheet-multitable-onprem-v2.5.0-rc-a-20260717-d87e086fd.tgz.verify.json` — `"ok": true`, checks:
+    `checksum` PASS, `required-content` PASS (`requiredCount: 128`), `deployability-contract` PASS, `no-github-links`
+    PASS. **This is what "loopback verification" in the ledger maps to** — a local/offline structural
+    verification of the produced archive (checksum + required-file inventory + deployability-contract shape +
+    no leaked GitHub URLs), run by `multitable-onprem-package-verify.sh` against the archive on disk. It is
+    distinct from M0-B's "flag-OFF health verification" (a live-host `/health` check), which stays ops-gated
+    and out of scope for M0-A.
+  - `SHA256SUMS` — four checksummed files: `.tgz`, `.zip`, both first-hop bootstrap scripts.
+
+## 3. Blocker — exact, plain
+
+The package build itself **cannot be executed under this lane's authority in this environment**, for two
+independent reasons:
+
+**(a) No git ref exists at the recommended SHA.**
+```
+git tag --points-at 7bf2bd7a1        # (empty)
+git branch -r --points-at 7bf2bd7a1  # (empty)
+```
+`origin/main` has advanced 11 commits past `7bf2bd7a1` (§2.1/§2.2), so it is not the branch tip either.
+GitHub's `workflow_dispatch` API requires a branch-or-tag `ref` — it does not accept a bare commit SHA — so
+dispatching the real `multitable-onprem-package-build.yml` workflow at exactly `7bf2bd7a1` is not possible
+without first minting a ref there.
+
+**(b) Minting that ref is the owner's freeze act, not this lane's.** ⟲R1 exit (b) reads: "the owner formally
+revises #4437 — publish, checksum, and **FREEZE** a new RC-A exact-SHA." Creating a tag/branch at exactly
+`7bf2bd7a1` for the purpose of building the frozen RC-A package **is** that freeze act wearing a different
+name. This lane's authorization is "build and verify… prepare the #4437 pointer" — not deploy, not flag-ON,
+and (per the lane's own doubt-is-the-answer discipline) not silently performing the adjacent owner-gated step
+either. I did not create a ref at `7bf2bd7a1`.
+
+**A local build in this sandbox is also disqualified**, independent of (a)/(b): the workflow pins Node 20 +
+pnpm exactly `9.15.9` on `ubuntu-latest` (the build script's own `PACKAGE_PNPM_VERSION="9.15.9"`, with an
+explicit comment that release lockfile compatibility depends on that exact pin). This environment runs
+Node `v25.9.0` / pnpm `10.33.0` on darwin. A package built here would not be the artifact the CI pipeline
+would produce, and hand-computing/publishing its SHA256 as "the RC-A checksum" would repeat the exact
+fabricated/self-certified-provenance failure mode this line exists to close (the frozen `d87e086fd` package's
+own defect is a **locally fabricated** `metadata.limit` rather than an echo-verified one — #4573's whole point;
+see also the `-ExpectedGitSha` in-archive-only binding in §2.4, which exists specifically to distrust
+externally-asserted provenance). I did not attempt a local build.
+
+**What a human needs to run** (either option; both are outside this lane's authority):
+
+- **Option A — CI, matching existing precedent.** A human/owner with tag-push rights creates a tag at exactly
+  `7bf2bd7a1f8cdf54cca83a733fcd89afb076848b` (e.g. `stock-prep-onprem-rc-a-build-7bf2bd7a1`), then:
+  ```
+  gh workflow run multitable-onprem-package-build.yml --repo zensgit/metasheet2 \
+    --ref stock-prep-onprem-rc-a-build-7bf2bd7a1 \
+    -f expected_sha=7bf2bd7a1f8cdf54cca83a733fcd89afb076848b \
+    -f publish_release=true \
+    -f release_tag=stock-prep-onprem-rc-a-20260725-7bf2bd7a1 \
+    -f release_name="Stock-prep on-prem RC-A (7bf2bd7a1)"
+  ```
+  This reuses the exact tooling that produced the frozen `d87e086fd` package and self-verifies inside the run
+  (`expected_sha` gate + `multitable-onprem-package-verify.sh` + the post-build `pnpm install --frozen-lockfile`
+  dependency preflight).
+- **Option B — local, matching toolchain.** On a host that can pin Node 20 + pnpm `9.15.9` (matching
+  `PACKAGE_PNPM_VERSION`) — e.g. via `corepack`/`nvm` on an ubuntu-like machine — checkout `7bf2bd7a1`, run
+  `pnpm install --frozen-lockfile`, `pnpm --filter @metasheet/web build`, `pnpm --filter @metasheet/core-backend build`,
+  then `INSTALL_DEPS=0 BUILD_WEB=0 BUILD_BACKEND=0 scripts/ops/multitable-onprem-package-build.sh` followed by
+  `scripts/ops/multitable-onprem-package-verify.sh` on both the `.tgz` and `.zip` outputs.
+
+Either way, once the archive exists, `serviceRuntimeSha` = the in-archive `BUILD_PROVENANCE.json.gitCommit`
+(expected `7bf2bd7a1f8cdf54cca83a733fcd89afb076848b`), and the manifest / `SHA256SUMS` / `*.verify.json` /
+`*.verify.md` are generated as a byproduct of the build — none of them should be hand-typed.
+
+---
+
+## 4. Draft — #4437 execution pointer v3 (NOT POSTED)
+
+Everything below is a draft only. It is not posted to #4437. Fields the build in §3 has not yet produced are
+marked `<<PENDING BUILD>>` — do not fill them by guessing; they come from the archive's own
+`BUILD_PROVENANCE.json` and `SHA256SUMS` once §3's build runs.
+
+> **Execution pointer v3 (DATE-OF-ACTUAL-BUILD — draft). Supersedes execution pointer v2.**
+> Records the package's `serviceRuntimeSha` and `clientHelperSha` **separately** (per
+> `docs/development/database-system-integration-line-design-and-verification-20260724.md` §2 ⟲R7) — v2's
+> single "Exact source SHA" field conflated the deployed server runtime with the two client smoke helpers used
+> by the abort-provenance diagnostic. As with v2: RC-A must use a local detached checkout at the exact package
+> SHA; do **not** use the public `workflow_dispatch` inputs for the entity host, tenant, or approved config
+> reference. The service flag must be restored and verified OFF in a `finally` path even when the smoke fails.
+>
+> ### Package (two-SHA, exact)
+> - **`serviceRuntimeSha`** (the backend/plugin runtime deployed to the entity machine) — read from the
+>   package's in-archive `BUILD_PROVENANCE.json.gitCommit` (never the external sidecar `.json`'s `gitSha` —
+>   that field cannot be trusted alone; see `stock-preparation-onprem-acceptance.ps1`'s `-ExpectedGitSha`
+>   comment). Build commit: `7bf2bd7a1f8cdf54cca83a733fcd89afb076848b` (`bridge.bounded_read.v2`, PR #4573 —
+>   closes the pre-hardening fabricated-`metadata.limit` gap the frozen `d87e086fd` package carries; P1a
+>   applied-limit echo-verification, P1b `.v2` qualification lineage). `<<PENDING BUILD: release tag, `.tgz`/`.zip`
+>   SHA256 from `SHA256SUMS`, in-archive `BUILD_PROVENANCE.json.gitCommit` read-back confirming
+>   `7bf2bd7a1f8cdf54cca83a733fcd89afb076848b`>>`
+> - **`clientHelperSha`** (the two exact-SHA smoke harnesses the abort-provenance diagnostic and the sidecar
+>   wrapper import) — **unchanged, carried over from the frozen `d87e086fd` package**, independently verified
+>   blob-identical at `d87e086fd`, `7bf2bd7a1`, and current `main`:
+>   - `stock-preparation-mvp-postdeploy-smoke.mjs` → `e5265a2a8052ddc34866438a1ee3356b5d2aa1a106c8199f5e2fbbe4f2614df4`
+>   - `stock-preparation-prep-line-extended-smoke.mjs` → `912f3ef75c4487dbdd946486d4cb7374f1c3ea1eb126c3b68381ad11963f0049`
+>   These already match `HELPER_CONTENT_SHA256` in `scripts/ops/stock-preparation-rca-abort-provenance.mjs` —
+>   **no code change is required for the client half of this revision.**
+> - **Release / tag**: `<<PENDING BUILD — e.g. stock-prep-onprem-rc-a-20260725-7bf2bd7a1>>`, built via the
+>   **Multitable On-Prem Package Build** workflow (`.github/workflows/multitable-onprem-package-build.yml`) —
+>   stock-prep ships as a plugin inside the multitable on-prem platform bundle; there is no stock-prep-specific
+>   package build. `expected_sha=7bf2bd7a1f8cdf54cca83a733fcd89afb076848b` must be set at dispatch time so the
+>   build fails closed on an uncertain checkout; in-archive `BUILD_PROVENANCE.gitCommit` must equal the same
+>   value (40-hex, read back from the checksummed bytes); `.tgz`/`.zip` checksums must verify against
+>   `SHA256SUMS`.
+>
+> ### What did NOT change from the frozen `d87e086fd` package
+> - Both RC-A smoke helper client scripts (content-identical; `clientHelperSha` above).
+> - The PowerShell wrapper's `-ExpectedGitSha` lock mechanism and the abort-provenance diagnostic's
+>   `HELPER_CONTENT_SHA256` allowlist — no code change needed for the client half.
+> - Operator steps 1-5, the PASS criteria list, and the Prohibitions section of v2 — unchanged in substance;
+>   only the SHA references below change.
+>
+> ### What changed
+> - The service runtime moves from `d87e086fd` (pre-`bridge.bounded_read.v2`; `metadata.limit` **locally
+>   fabricated**, not echo-verified) to `serviceRuntimeSha` above (post-`7bf2bd7a1`; `metadata.limit`
+>   echo-verified against the agent's own response per #4573 P1a; qualification digest keys on
+>   `actionProfileVersion=.v2` per P1b, so an authenticated old-v1 qualification recomputes to
+>   `QUALIFICATION_DIGEST_MISMATCH` instead of silently surviving).
+> - v2's single "Exact source SHA" field, which governed both the deployed runtime and the smoke client, is
+>   replaced by the two named fields above so a future runtime bump cannot silently be read as implying the
+>   client also changed (or vice versa).
+>
+> ### Operator steps
+> Unchanged from v2 (§ Operator steps 1-5), substituting `serviceRuntimeSha` for `d87e086fd1218b4cfb150177d43f2c52904b1d6d`
+> wherever the deployed package/runtime is referenced. `clientHelperSha` values are unchanged from v2 — no
+> client-side re-verification step is added by this revision.
+
+---
+
+## 5. What this document is and is not
+
+- It is: an investigation record + a draft the operator/owner can lift into #4437 once §3's build exists, plus
+  the mechanically-verified `clientHelperSha` half that needs no rebuild.
+- It is not: a built package, a published release, a real `serviceRuntimeSha`, or an edit to #4437 itself.
+  Nothing here was posted to the issue.

--- a/docs/development/stock-preparation-rc-a-m0a-package-build-status-and-4437-pointer-draft-20260725.md
+++ b/docs/development/stock-preparation-rc-a-m0a-package-build-status-and-4437-pointer-draft-20260725.md
@@ -270,14 +270,16 @@ Downloaded the real artifact read-only (`gh run download 30148584851`) — not h
   25197ba31dcc5638c63eb79e4928e4db6b0fcdc715aae799f7672d70119d0056  metasheet-multitable-onprem-v2.5.0-m0a-rca-20260725-deploy-bootstrap.ps1
   75261b3f3b3a161e6c586d95ee4110a740454957c3c55cb0cd5e742839a176d5  metasheet-multitable-onprem-v2.5.0-m0a-rca-20260725-deploy-bootstrap.bat
   ```
-  **These four checksums are A1-run-scoped evidence that the build+verify half executed and self-verified —
-  they are NOT the checksums the eventual A2 freeze run will produce.** `BUILD_PROVENANCE.json` (packaged
-  *inside* the checksummed archive) embeds `builtAt` (`date -u` at build time) and `ciRunId`
-  (`$GITHUB_RUN_ID`) — both per-run values baked into the archive bytes before hashing
+  **These four checksums are A1-run-scoped evidence that the build+verify half executed and self-verified.**
+  `BUILD_PROVENANCE.json` (packaged *inside* the checksummed archive) embeds `builtAt` (`date -u` at build
+  time) and `ciRunId` (`$GITHUB_RUN_ID`) — both per-run values baked into the archive bytes before hashing
   (`scripts/ops/multitable-onprem-package-build.sh` lines ~508-510). A fresh `publish_release=true` dispatch
-  is a **new build**, with a new `ciRunId`/`builtAt`/archive bytes, therefore a **different** `.tgz`/`.zip`
-  SHA256 than the four values above. Do not carry these into #4437 as "the" RC-A checksums (§4 keeps them
-  `<<PENDING FREEZE RUN>>`).
+  (§3.2, Path B) is a **new build**, with a new `ciRunId`/`builtAt`/archive bytes, therefore a **different**
+  `.tgz`/`.zip` SHA256 than the four values above — under that path, do not carry these into #4437 as "the" RC-A
+  checksums. **Erratum (this update):** under the owner's now-recommended Path A (§3.2a, freeze), the opposite
+  is true — these four checksums, unchanged, ARE what A2 publishes, verified by a post-publish round-trip
+  re-hash (§3.2a step 5). §4 keeps the corresponding fields `<<PENDING FREEZE RUN>>` because A2 (either path)
+  has not happened yet, not because these values are assumed wrong under every path.
 - **In-archive `BUILD_PROVENANCE.json`** (extracted from the `.tgz`, not the external sidecar — **read in
   full, not excerpted**, per this fix pass's re-extraction and read of the same archive; the prior draft
   showed only a partial field set here without marking it as an excerpt, while the sibling manifest block

--- a/docs/development/stock-preparation-rc-a-m0a-package-build-status-and-4437-pointer-draft-20260725.md
+++ b/docs/development/stock-preparation-rc-a-m0a-package-build-status-and-4437-pointer-draft-20260725.md
@@ -2,10 +2,11 @@
 
 Lane: **LANE C — M0-A** (per `docs/development/database-system-integration-line-design-and-verification-20260724.md`,
 §2 M0-A / §4 "Parallel and unblocked" M0-A track, ⟲C1/⟲R1/⟲R7). Authorized: build + verify the COMPLETE
-on-prem deployment package at the owner-chosen main SHA, regenerate manifest/SHA256/provenance/(disputed —
-see §6) loopback verification, prepare (not post) the #4437 pointer revision. Not authorized: deployment,
-flag-ON, connecting to any host, editing #4437 itself, merging, pushing to main, and — per this fix pass —
-still not the release/freeze act (see §3 A2).
+on-prem deployment package at the owner-chosen main SHA, regenerate manifest/SHA256/provenance/loopback
+verification (built and run post-hoc/standalone this fix pass — owner-ruled, see §6/§3.1a; not yet part of
+the frozen package's own CI-produced verify output, a known forward gap §3.1a records), prepare (not post)
+the #4437 pointer revision. Not authorized: deployment, flag-ON, connecting to any host, editing #4437
+itself, merging, pushing to main, and — per this fix pass — still not the release/freeze act (see §3 A2).
 
 **Scope note:** the ledger's §2 M0-A paragraph also names "prepare the bounded approved config" as part of
 M0-A. This document's Lane-C task list does not include that item, and it is **not** addressed here — do not
@@ -23,12 +24,30 @@ branch/tag, not a bare SHA) with the *publish/freeze act* (owner-only). This ses
 the reviewer's read against the current workflow file and then **ran the authorized build+verify half for
 real** — see §3 A1 for the run and §2.4/§6 below for what the "no fabrication" claim now covers.
 
-## Status: build + verify (A1) is DONE and PASSED. Residual blocker is narrow: only the owner's publish/freeze act (A2).
+## Verdict: A1 PASS. This is a component verdict, not "M0-A PASS" — see below for exactly what remains open.
 
-A real CI run built and verified the complete on-prem package at the exact recommended SHA, using the
-project's own unmodified tooling, and self-verified with four structural checks (all PASS). No release was
-published. No checksum was hand-typed or fabricated — the checksums recorded below are read verbatim from the
-run's own `SHA256SUMS` output. §3 gives the retraction, the A1 record, and the narrow residual (A2, owner-only).
+**A1 PASS** — build + verify executed, run `30148584851`, `publish_release=false`. A real CI run built and
+verified the complete on-prem package at the exact recommended SHA, using the project's own unmodified
+tooling at that commit, and self-verified with four structural checks (all PASS). No release was published.
+No checksum was hand-typed or fabricated — the checksums recorded below are read verbatim from the run's own
+`SHA256SUMS` output.
+
+**M0-A is still open**, pending two separate things — do not read "A1 PASS" as "M0-A PASS":
+
+- **(i) the ledger's loopback-verification deliverable, as produced by the canonical pipeline.** This fix
+  pass builds the check (§6) and runs it **post-hoc, standalone**, against A1's real artifact bytes — PASS
+  (§3.1a) — but that is corroborating evidence from a tool run outside the CI pipeline, at a commit newer
+  than `7bf2bd7a1`, recorded under its own `verificationToolSha` (§3.1a). It is **not** the same claim as "the
+  frozen package's own CI-produced verify output includes a loopback check" — run `30148584851`'s own
+  `verify.json` is immutable and still shows four checks (§3.1). §3.1a also records a known forward gap: a
+  future A2 dispatch at the pinned ref (`build/m0a-rca-7bf2bd7a1`, still targeting source commit `7bf2bd7a1`)
+  will check out the **old**, four-check verify script, not this fix pass's five-check version — so A2's own
+  `verify.json` will also be four checks unless the owner separately revisits the ref/tooling situation. That
+  is not resolved here.
+- **(ii) the owner-only A2 publish/freeze act** (§3.2) — unchanged from before this fix pass.
+
+§3 gives the retraction, the A1 record, the loopback-check build + post-hoc execution (§3.1a), and the narrow
+residual (A2, owner-only, §3.2).
 
 ---
 
@@ -93,13 +112,28 @@ now reads **12**, not 11. The count was accurate when first drafted; it is a mov
 advancing. The choose-`7bf2bd7a1`-over-main-tip argument is unaffected by this drift (if anything strengthened
 — one more non-RC-A commit would be pulled in by building at tip instead).
 
-Also verified: the build tooling itself is byte-identical between the recommended SHA and current main —
+**Dated snapshot, now stale as of this fix pass's own commit (see note below):** at original draft time, the
+build tooling itself was byte-identical between the recommended SHA and current main —
 ```
 git log --oneline 7bf2bd7a1..origin/main -- .github/workflows/multitable-onprem-package-build.yml \
   scripts/ops/multitable-onprem-package-build.sh scripts/ops/multitable-onprem-package-verify.sh
 ```
-returns nothing, so "build at `7bf2bd7a1`" and "build at current main" would use the identical build/verify
-scripts — only the source snapshot differs.
+returned nothing at draft time, so "build at `7bf2bd7a1`" and "build at current main" would have used
+identical build/verify scripts then — only the source snapshot differed.
+
+**This is no longer true as of this same-day fix pass.** §6/§3.1a add a loopback check to
+`scripts/ops/multitable-onprem-package-verify.sh` on this branch — a real, intentional change to the verify
+script, landed at a commit newer than `7bf2bd7a1` and not yet on `origin/main`. Re-running the same command at
+this fix pass's HEAD:
+```
+git log --oneline 7bf2bd7a1..HEAD -- .github/workflows/multitable-onprem-package-build.yml \
+  scripts/ops/multitable-onprem-package-build.sh scripts/ops/multitable-onprem-package-verify.sh
+```
+now returns exactly one commit — this fix pass's own loopback-check commit. The build workflow and build
+script remain untouched; only the verify script differs, and only by this fix pass's own addition. This does
+not change the §2.2 recommendation (still build at `7bf2bd7a1`, not current main) — it only means the
+"identical tooling" claim is a point-in-time snapshot, not a standing invariant, and the record must say so
+rather than imply it holds indefinitely.
 
 ### 2.3 `clientHelperSha` — identified and proven blob-identical (this is the reusable half of the two-SHA split)
 
@@ -239,15 +273,27 @@ Downloaded the real artifact read-only (`gh run download 30148584851`) — not h
   is a **new build**, with a new `ciRunId`/`builtAt`/archive bytes, therefore a **different** `.tgz`/`.zip`
   SHA256 than the four values above. Do not carry these into #4437 as "the" RC-A checksums (§4 keeps them
   `<<PENDING FREEZE RUN>>`).
-- **In-archive `BUILD_PROVENANCE.json`** (extracted from the `.tgz`, not the external sidecar):
+- **In-archive `BUILD_PROVENANCE.json`** (extracted from the `.tgz`, not the external sidecar — **read in
+  full, not excerpted**, per this fix pass's re-extraction and read of the same archive; the prior draft
+  showed only a partial field set here without marking it as an excerpt, while the sibling manifest block
+  below was correctly marked "read in full" — corrected):
   ```json
-  { "schema": "metasheet-onprem-build-provenance/v1", "gitCommit": "7bf2bd7a1f8cdf54cca83a733fcd89afb076848b",
+  { "schema": "metasheet-onprem-build-provenance/v1",
+    "packageName": "metasheet-multitable-onprem-v2.5.0-m0a-rca-20260725",
+    "version": "2.5.0", "tag": "m0a-rca-20260725",
+    "gitCommit": "7bf2bd7a1f8cdf54cca83a733fcd89afb076848b",
     "gitCommitShort": "7bf2bd7a1f8c", "gitRef": "build/m0a-rca-7bf2bd7a1", "sourceIsOnOriginMain": "unknown",
-    "ciRunId": "30148584851", "ciRunAttempt": "1", "builtAt": "2026-07-25T07:04:39Z" }
+    "ciRunId": "30148584851", "ciRunAttempt": "1", "builtAt": "2026-07-25T07:04:39Z",
+    "fixMarkers": { "issue1912": {
+      "title": "K3 WISE M1 Material Save-only backend fix",
+      "adapter": "plugins/plugin-integration-core/lib/adapters/k3-wise-document-templates.cjs",
+      "marker": "material-k3wise-customer-profile-v1", "embedded": true } } }
   ```
   `gitCommit` = `7bf2bd7a1f8cdf54cca83a733fcd89afb076848b` — **exact match to `expected_sha`, CONFIRMED from
   the checksummed bytes, not the external sidecar.** Unlike `builtAt`/`ciRunId`, `gitCommit` is derived from
   `git rev-parse HEAD` at the pinned commit and will be the same in A2 provided A2 also targets `7bf2bd7a1`.
+  `fixMarkers.issue1912.embedded: true` corroborates §2.4/§2.3's marker findings from the same archive this
+  fix pass independently re-extracted (see §3.1a).
 - **Verify reports** (both archives, `ok: true`):
   ```json
   "checks": [
@@ -291,6 +337,112 @@ Downloaded the real artifact read-only (`gh run download 30148584851`) — not h
   available to deploy"; nothing here is a publicly-addressable checksummed asset until A2 runs.
 - If the owner's A2 act slips past the retention window, A1 must be re-run (cheap — no code changed, same
   `expected_sha`, same ref) before A2, since A2's own build supersedes A1's bytes anyway.
+
+### 3.1a Loopback verification — built, then run post-hoc/standalone against A1's real artifact (this fix pass)
+
+**Owner ruling on §6's escalation (below): build the real check — option 2, not option 1.** This fix pass
+adds `verify_no_loopback_frontend_config()` to `scripts/ops/multitable-onprem-package-verify.sh`, porting
+`scripts/ops/attendance-onprem-package-verify.sh`'s existing loopback rule
+(`VITE_API_(URL|BASE):"http://(127\.0\.0\.1|localhost)"` against `apps/web/dist`) — same pattern, same target.
+Wired unconditionally (not gated behind an env var, matching attendance's rule) into the main verify flow, and
+reported as a fifth `"loopback"` field in both the JSON and Markdown reports. New focused test
+(`scripts/ops/multitable-onprem-package-verify-loopback.test.sh`, sourced-function style matching the sibling
+`multitable-onprem-package-verify.provenance.test.sh`) covers one positive fixture and three negatives —
+`VITE_API_URL`+`127.0.0.1`, `VITE_API_BASE`+`localhost` (opposite corners of the alternation), and
+`apps/web/dist` missing entirely (closes a vacuous-pass hole: `search_extended_regex` returns non-zero/no-match
+against a target directory that does not exist, which would otherwise silently report PASS on a package
+missing its frontend bundle). Like the sibling provenance test, it is **not wired into any CI workflow** —
+run manually; the doc does not imply CI coverage it does not have.
+
+**`verificationToolSha`** — the exact tool used below. Recorded as the **blob** SHA of the script (the
+load-bearing identity: stable across this fix pass's own later commits, e.g. this document's), with the
+introducing commit also recorded for provenance:
+```
+git rev-parse HEAD:scripts/ops/multitable-onprem-package-verify.sh
+# 2e64b9d6639fa9e250cb06003adcdd41604560a8
+```
+Introduced at commit `542ca93b73cd20bbbadb3aece7c1d448581c55a6` on this branch (rebased onto `origin/main`
+tip `d4dc12d8a`). **This is a tooling identity, not a deployed-artifact identity — it must never be conflated
+into `serviceRuntimeSha`** (still `7bf2bd7a1f8cdf54cca83a733fcd89afb076848b`, unchanged) **or presented as
+part of what run `30148584851` itself produced.**
+
+**What was executed — a real, full run of the updated tool against A1's real, already-built artifact bytes**
+(not the sourced-function fixture test above; not a rebuild; `serviceRuntimeSha` does not move). Commands and
+real, unedited output:
+
+1. Re-downloaded (read-only) the same Actions artifact §3.1 already recorded:
+   ```
+   gh run download 30148584851 --repo zensgit/metasheet2 -D .
+   ```
+   Local recompute reproduces the exact `SHA256SUMS` line already in §3.1 — same bytes, no re-fetch drift:
+   ```
+   $ shasum -a 256 metasheet-multitable-onprem-v2.5.0-m0a-rca-20260725.tgz
+   759adcc3cbb6f677f2c6aea92224df83085d1afb1424c1759d980b98abd07f4d  metasheet-multitable-onprem-v2.5.0-m0a-rca-20260725.tgz
+   ```
+2. Ran the **full** updated `multitable-onprem-package-verify.sh` (all checks, not just the new function in
+   isolation) against that real `.tgz`, with `VERIFY_REPORT_JSON` set:
+   ```
+   $ VERIFY_REPORT_JSON=<local>/posthoc-verify.json bash scripts/ops/multitable-onprem-package-verify.sh <local>/metasheet-multitable-onprem-v2.5.0-m0a-rca-20260725.tgz
+   metasheet-multitable-onprem-v2.5.0-m0a-rca-20260725.tgz: OK
+   [multitable-onprem-package-verify] Package verify OK
+   [multitable-onprem-package-verify]   package: <local>/metasheet-multitable-onprem-v2.5.0-m0a-rca-20260725.tgz
+   [multitable-onprem-package-verify]   root: <extracted temp dir>
+   [multitable-onprem-package-verify]   verify_report_json: <local>/posthoc-verify.json
+   EXIT=0
+   ```
+   `posthoc-verify.json`, real, unedited content:
+   ```json
+   {
+     "ok": true,
+     "packageFile": "<local>/metasheet-multitable-onprem-v2.5.0-m0a-rca-20260725.tgz",
+     "packageName": "metasheet-multitable-onprem-v2.5.0-m0a-rca-20260725",
+     "archiveType": "tgz",
+     "packageRootInArchive": "metasheet-multitable-onprem-v2.5.0-m0a-rca-20260725",
+     "extractMode": "temporary",
+     "extractRoot": null,
+     "checks": [
+       { "name": "checksum", "status": "PASS" },
+       { "name": "required-content", "status": "PASS", "requiredCount": 128 },
+       { "name": "deployability-contract", "status": "PASS", "artifactKind": "deployable-onprem-app-package",
+         "deployMode": "fresh-extract-or-existing-root-apply", "directReplaceSafe": false, "nodeModulesBundled": false },
+       { "name": "no-github-links", "status": "PASS" },
+       { "name": "loopback", "status": "PASS" }
+     ],
+     "generatedAt": "2026-07-25T14:06:55Z"
+   }
+   ```
+   Five checks, all PASS — the four-check report becomes five. `requiredCount=128` matches §3.1's original A1
+   run exactly — no unrelated drift in the required-file inventory between the original CI run and this
+   post-hoc pass.
+3. Independently corroborated outside the script, by direct extraction and grep against the real
+   `apps/web/dist` inside the archive (122 files under `apps/web/dist`):
+   ```
+   $ tar -xzf metasheet-multitable-onprem-v2.5.0-m0a-rca-20260725.tgz -C <extract-dir>
+   $ grep -rIE 'VITE_API_(URL|BASE):"http://(127\.0\.0\.1|localhost)' <extract-dir>/.../apps/web/dist
+   # (no output)
+   $ echo "grep exit=$?"
+   grep exit=1
+   ```
+   Zero matches, independently of the new check function. Matches the owner's own finding (review #4604): the
+   current artifact does not hit the forbidden pattern. This is the expected outcome the owner's ruling was
+   scoped to — **completing the proof, not changing service code** — and that is what happened; no
+   runtime/service code changed, only the verify tool.
+
+**Explicit non-conflation, stated plainly (this is the exact thing ⟲R7 exists to prevent):** run
+`30148584851`'s own `verify.json`, the one packaged inside the CI-produced Actions artifact, is **immutable
+and still shows four checks** (§3.1) — it was produced by the verify script as it existed at commit
+`7bf2bd7a1`, before this fix pass's check existed. The fifth check above ran **after the fact, standalone,
+at `verificationToolSha`**, against the same archive bytes. It is corroborating evidence, not a retroactive
+edit of the run's own artifact, and must be cited as such — not as "run 30148584851 produced five checks."
+
+**Known forward gap, not resolved here:** the workflow's `workflow_dispatch` checks out the *ref* it is given
+(`build/m0a-rca-7bf2bd7a1`, pinned to source commit `7bf2bd7a1`) — including whatever version of
+`multitable-onprem-package-verify.sh` exists **at that commit**, not on this feature branch. A future A2
+dispatch at that same ref will therefore still run the **old, four-check** verify script and produce a
+**four**-check `verify.json` of its own, not five — unless the owner separately decides to move the build ref
+forward (which `docs/development/database-system-integration-line-design-and-verification-20260724.md`'s
+"Build SHA stays `7bf2bd7a1`... do not enlarge the runtime change surface" ruling weighs against, and this
+document does not decide). This gap is recorded, not closed.
 
 ### 3.2 A2 — publish/freeze, `publish_release=true` (OWNER-ONLY — NOT inside M0-A's authorization)
 
@@ -353,6 +505,13 @@ guessing or by copying A1's run-scoped checksums; they must come from A2's own `
 >   - `stock-preparation-prep-line-extended-smoke.mjs` → `912f3ef75c4487dbdd946486d4cb7374f1c3ea1eb126c3b68381ad11963f0049`
 >   These already match `HELPER_CONTENT_SHA256` in `scripts/ops/stock-preparation-rca-abort-provenance.mjs` —
 >   **no code change is required for the client half of this revision.**
+> - **Loopback verification** (not a third deployed-artifact SHA — a tooling-run result; see §3.1a for the
+>   full record, kept separate here on purpose): PASS, via a post-hoc/standalone run of the updated verify
+>   tool (`verificationToolSha` = `2e64b9d6639fa9e250cb06003adcdd41604560a8`, the script blob) against A1's
+>   real artifact. **This did not come from run `30148584851`'s own `verify.json`** (that artifact is
+>   immutable and still shows four checks) and will not come from a future A2 run at the pinned ref either,
+>   unless the ref/tooling question is separately revisited (§3.1a forward gap) — do not post this line to
+>   #4437 as if it were part of A2's own build output.
 > - **Release / tag**: `<<PENDING FREEZE RUN (A2) — owner selects the tag; not pre-chosen by this document>>`,
 >   built via the **Multitable On-Prem Package Build** workflow
 >   (`.github/workflows/multitable-onprem-package-build.yml`, `publish_release=true`) — stock-prep ships as a
@@ -408,45 +567,57 @@ guessing or by copying A1's run-scoped checksums; they must come from A2's own `
 - It is: an investigation record; a real, passing CI build+verify (A1, run 30148584851) at the exact
   recommended commit, watched to completion and checked against its own downloaded outputs (not hand-typed);
   a CONFIRMED `serviceRuntimeSha`/`gitCommit` read-back; the mechanically-verified `clientHelperSha` half
-  (unchanged from the original investigation, no rebuild needed); a draft the operator/owner can lift into
-  #4437 once A2 (§3.2) exists; and an escalation (§6) of a ledger-vs-tooling naming gap for the owner to rule
-  on.
+  (unchanged from the original investigation, no rebuild needed); a real loopback-verification check, built
+  per owner ruling (§6) and run post-hoc/standalone against A1's real artifact bytes at a recorded, separate
+  `verificationToolSha` (§3.1a), PASS, corroborated by an independent direct grep; a draft the operator/owner
+  can lift into #4437 once A2 (§3.2) exists.
 - It is not: a published release, a permanent/addressable checksummed artifact (A1's Actions artifact expires
-  ~2026-08-08, §3.1), the owner's freeze act, or an edit to #4437 itself. Nothing here was posted to the
+  ~2026-08-08, §3.1), the owner's freeze act, an edit to #4437 itself, or an edit to the RATIFIED ledger
+  (§6's ruling is recorded here, not written into the ledger's own text). Nothing here was posted to the
   issue. A1's `.tgz`/`.zip` SHA256 values are recorded as run-scoped evidence only and must not be read as
-  "the" RC-A checksums — those come from A2.
+  "the" RC-A checksums — those come from A2. The post-hoc loopback PASS (§3.1a) is not the same claim as "run
+  30148584851's own `verify.json` has five checks" — that artifact is immutable and still has four (§3.1); a
+  future A2 dispatch at the pinned ref will also still emit four unless the ref/tooling question is
+  separately revisited (§3.1a's forward gap, not resolved here). **A1 PASS is not M0-A PASS** — M0-A remains
+  open pending A2 regardless.
 
-## 6. Escalation to the owner — RATIFIED ledger names a check the verify tooling does not have
+## 6. Owner ruling on the escalation — build the check (option 2), not amend the ledger (option 1)
 
-**This is a specification gap, not a bug this document can fix, and not something it rules on.**
+**This section previously escalated a specification gap and left it unresolved for the owner to rule on. The
+owner has now ruled (review #4604 P1): "BUILD THE REAL CHECK, DO NOT DELETE THE CONTRACT." This section
+records that ruling and what this fix pass did to satisfy it. It still does not edit the RATIFIED ledger —
+the ledger's own text is unchanged; this section only records that its "loopback verification" phrase now has
+a real, falsifiable check backing it, per the mechanics in §3.1a.**
 
 The RATIFIED ledger (`docs/development/database-system-integration-line-design-and-verification-20260724.md`)
-names "loopback verification" as part of M0-A's authorized/expected output in two places:
+names "loopback verification" as part of M0-A's authorized/expected output in two places (unchanged, quoted
+verbatim, not edited by this document):
 
 - §4, the M0-A bullet itself: *"regenerate manifest / SHA256 / provenance / **loopback verification**, revise
   the #4437 pointer..."*
 - §2 ⟲R7: *"regenerate manifest + SHA256 + provenance + **loopback verification**; revise #4437..."*
 
-The actual verify tooling this build produces output through, `scripts/ops/multitable-onprem-package-verify.sh`,
-runs exactly **four** checks — confirmed from this session's own A1 `verify.json` output (§3.1):
-`checksum`, `required-content`, `deployability-contract`, `no-github-links`. None is named or behaves as a
-loopback check. Confirmed by direct grep against the current script, not inference:
+Before this fix pass, `scripts/ops/multitable-onprem-package-verify.sh` ran exactly **four** checks —
+confirmed from the original A1 `verify.json` output (§3.1): `checksum`, `required-content`,
+`deployability-contract`, `no-github-links`. None was named or behaved as a loopback check, confirmed by
+direct grep at that point in history:
 ```
 grep -n "loopback" scripts/ops/multitable-onprem-package-verify.sh
-# (zero hits)
+# (zero hits, before this fix pass)
 grep -n "loopback" scripts/ops/attendance-onprem-package-verify.sh
 # 321:  die "Frontend bundle embeds loopback VITE_API_* config; rebuild package with isolated web env"
 ```
-Attendance's on-prem verify script has exactly this kind of check (fails the build if the frontend bundle
-embeds a loopback `VITE_API_URL`); multitable's does not. So either:
+Attendance's on-prem verify script already had exactly this kind of check (fails the build if the frontend
+bundle embeds a loopback `VITE_API_URL`); multitable's did not.
 
-1. **the ledger's phrase should be amended** to name the four checks that actually exist (`checksum` /
-   `required-content` / `deployability-contract` / `no-github-links`), because "loopback verification" was
-   never built for the multitable path and the ledger's authorization language should describe what M0-A's
-   output actually is, or
-2. **a loopback check must be built** into `multitable-onprem-package-verify.sh` (mirroring attendance's
-   pattern) before M0-A's output can honestly be described as including it.
+**Owner's ruling bounded the expected work:** they had already downloaded and inspected run `30148584851`'s
+A1 artifacts and found the current artifacts do **not** hit the forbidden pattern — so this was expected to
+be *completing the proof, not changing service code*. §3.1a confirms exactly that: the check was built
+(reusing attendance's rule verbatim, same pattern/target), the real artifact was independently re-checked and
+found clean by both the new check and a direct grep outside it, and no runtime/service code changed. Had the
+real artifact instead hit the pattern, this document would stop and report rather than reconcile — it did
+not need to.
 
-Both are owner decisions. This document does not choose between them and does not edit the RATIFIED ledger.
-It records that A1's real, passing verify run covered four checks — not five, not "loopback" — so whoever
-reads M0-A's ledger line against A1's actual output does not silently assume a check ran that did not.
+Residual, recorded not resolved: §3.1a's forward gap (a future A2 dispatch at the pinned ref will still emit
+a four-check `verify.json` unless the ref/tooling question is separately revisited) remains open, and this
+document does not decide it.

--- a/docs/development/stock-preparation-rc-a-m0a-package-build-status-and-4437-pointer-draft-20260725.md
+++ b/docs/development/stock-preparation-rc-a-m0a-package-build-status-and-4437-pointer-draft-20260725.md
@@ -354,6 +354,13 @@ against a target directory that does not exist, which would otherwise silently r
 missing its frontend bundle). Like the sibling provenance test, it is **not wired into any CI workflow** —
 run manually; the doc does not imply CI coverage it does not have.
 
+**Scope limitation, stated plainly:** the ported pattern is reused **verbatim** per the owner's ruling
+("reuse attendance's rule") and is not changed here. The fixtures prove the rule is falsifiable *as specified*
+— a bundle containing that exact literal string shape fails, a clean one passes — not that multitable's own
+web bundler can or does ever emit that shape in practice (whether it can was not independently established by
+this fix pass; §3.1a's direct grep against the real artifact only shows this particular build does not
+contain it today).
+
 **`verificationToolSha`** — the exact tool used below. Recorded as the **blob** SHA of the script (the
 load-bearing identity: stable across this fix pass's own later commits, e.g. this document's), with the
 introducing commit also recorded for provenance:
@@ -369,8 +376,12 @@ rebase of this branch; the **blob** SHA above is the load-bearing identity preci
 what run `30148584851` itself produced.**
 
 **What was executed — a real, full run of the updated tool against A1's real, already-built artifact bytes**
-(not the sourced-function fixture test above; not a rebuild; `serviceRuntimeSha` does not move). Commands and
-real, unedited output:
+(not the sourced-function fixture test above; not a rebuild; `serviceRuntimeSha` does not move). Commands
+below were run via a small wrapper script (the harness this session runs in refused the inline
+`VAR=... bash ...` form directly) — the wrapper only `cd`s and exports the two report-path env vars before
+calling the unmodified verify script with the real package path as its sole argument; the verify script's own
+behavior is exactly as it would be invoked directly. Output is real, with local absolute scratch paths
+abbreviated to `<local>`:
 
 1. Re-downloaded (read-only) the same Actions artifact §3.1 already recorded:
    ```
@@ -382,17 +393,22 @@ real, unedited output:
    759adcc3cbb6f677f2c6aea92224df83085d1afb1424c1759d980b98abd07f4d  metasheet-multitable-onprem-v2.5.0-m0a-rca-20260725.tgz
    ```
 2. Ran the **full** updated `multitable-onprem-package-verify.sh` (all checks, not just the new function in
-   isolation) against that real `.tgz`, with `VERIFY_REPORT_JSON` set:
+   isolation) against that real `.tgz`, with **both** `VERIFY_REPORT_JSON` and `VERIFY_REPORT_MD` set — CI
+   itself exercises both report formats (the downloaded artifact's `verify/` directory contains both a
+   `.verify.json` and a `.verify.md` per archive), so both paths are checked here, not just the JSON one.
+   Equivalent invocation:
    ```
-   $ VERIFY_REPORT_JSON=<local>/posthoc-verify.json bash scripts/ops/multitable-onprem-package-verify.sh <local>/metasheet-multitable-onprem-v2.5.0-m0a-rca-20260725.tgz
+   $ VERIFY_REPORT_JSON=<local>/posthoc-verify-2.json VERIFY_REPORT_MD=<local>/posthoc-verify-2.md \
+     bash scripts/ops/multitable-onprem-package-verify.sh <local>/metasheet-multitable-onprem-v2.5.0-m0a-rca-20260725.tgz
    metasheet-multitable-onprem-v2.5.0-m0a-rca-20260725.tgz: OK
    [multitable-onprem-package-verify] Package verify OK
    [multitable-onprem-package-verify]   package: <local>/metasheet-multitable-onprem-v2.5.0-m0a-rca-20260725.tgz
    [multitable-onprem-package-verify]   root: <extracted temp dir>
-   [multitable-onprem-package-verify]   verify_report_json: <local>/posthoc-verify.json
+   [multitable-onprem-package-verify]   verify_report_json: <local>/posthoc-verify-2.json
+   [multitable-onprem-package-verify]   verify_report_md: <local>/posthoc-verify-2.md
    EXIT=0
    ```
-   `posthoc-verify.json`, real, unedited content:
+   `posthoc-verify-2.json`, real content (local absolute paths abbreviated to `<local>`):
    ```json
    {
      "ok": true,
@@ -410,12 +426,22 @@ real, unedited output:
        { "name": "no-github-links", "status": "PASS" },
        { "name": "loopback", "status": "PASS" }
      ],
-     "generatedAt": "2026-07-25T14:06:55Z"
+     "generatedAt": "2026-07-25T14:23:18Z"
    }
    ```
-   Five checks, all PASS — the four-check report becomes five. `requiredCount=128` matches §3.1's original A1
-   run exactly — no unrelated drift in the required-file inventory between the original CI run and this
-   post-hoc pass.
+   `posthoc-verify-2.md`'s `## Checks` section, real content:
+   ```markdown
+   ## Checks
+
+   - Checksum: `PASS`
+   - Required content: `PASS` (128 paths)
+   - Deployability contract: `PASS` (deployable-onprem-app-package, directReplaceSafe=false, nodeModulesBundled=false)
+   - No GitHub links in delivery docs: `PASS`
+   - Loopback frontend config: `PASS` (no loopback VITE_API_URL/BASE embedded in apps/web/dist)
+   ```
+   Five checks, all PASS, in **both** report formats — the four-check report becomes five in each.
+   `requiredCount=128` (JSON) / "128 paths" (MD) matches §3.1's original A1 run exactly — no unrelated drift
+   in the required-file inventory between the original CI run and this post-hoc pass.
 3. Independently corroborated outside the script, by direct extraction and grep against the real
    `apps/web/dist` inside the archive (122 files under `apps/web/dist`):
    ```

--- a/scripts/ops/multitable-onprem-package-verify-loopback.test.sh
+++ b/scripts/ops/multitable-onprem-package-verify-loopback.test.sh
@@ -7,6 +7,9 @@
 # only, via its direct-execution guard) and exercises the function directly against
 # synthesized apps/web/dist fixtures. No real on-prem package is required.
 #
+# Also pins the main-flow call site itself (review #4604 P2), not just the function's
+# in-isolation logic — see the wiring check below.
+#
 #   bash scripts/ops/multitable-onprem-package-verify-loopback.test.sh
 set -uo pipefail
 
@@ -61,6 +64,20 @@ run_case "loopback VITE_API_BASE + localhost rejected" "embeds loopback VITE_API
 # (no match) on a target directory that does not exist, which would otherwise let this
 # case silently PASS instead of failing loud — the vacuous-pass hole this test closes.
 run_case "apps/web/dist missing entirely rejected" "apps/web/dist missing" "${TMP}/no_web_dist" verify_no_loopback_frontend_config
+
+# Wiring pin (review #4604 P2): the four cases above call verify_no_loopback_frontend_config
+# directly, which proves the function's own logic but nothing about whether the main verify
+# flow actually invokes it — deleting the call site (main flow, ~L1052) would leave this exact
+# suite at 4/4 green. Grep for the literal top-level call (distinct from the `function
+# verify_no_loopback_frontend_config() {` definition, which survives a call-site deletion) so
+# removing the wiring reds this test instead of staying silently green.
+if grep -qE '^\s*verify_no_loopback_frontend_config "\$pkg_root"\s*$' "$VERIFY"; then
+  echo "  PASS: loopback check is wired into the main verify flow (call site present)"
+  pass=$((pass+1))
+else
+  echo "  FAIL: loopback check call site not found in the main verify flow — the function is defined but not invoked"
+  fail=$((fail+1))
+fi
 
 echo
 echo "RESULT: ${pass} passed, ${fail} failed"

--- a/scripts/ops/multitable-onprem-package-verify-loopback.test.sh
+++ b/scripts/ops/multitable-onprem-package-verify-loopback.test.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Focused test for verify_no_loopback_frontend_config() in
+# multitable-onprem-package-verify.sh — the check ported from
+# scripts/ops/attendance-onprem-package-verify.sh's loopback rule (owner review #4604 P1:
+# "reuse attendance's rule ... add positive AND negative fixtures ... without the negative
+# fixture the check is unfalsifiable and worthless"). Sources the verify script (functions
+# only, via its direct-execution guard) and exercises the function directly against
+# synthesized apps/web/dist fixtures. No real on-prem package is required.
+#
+#   bash scripts/ops/multitable-onprem-package-verify-loopback.test.sh
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+VERIFY="${SCRIPT_DIR}/multitable-onprem-package-verify.sh"
+pass=0
+fail=0
+
+run_case() {
+  # $1=label  $2=expect(pass|<die-substring>)  $3=fixture_root  $4=func
+  local label="$1" expect="$2" root="$3" func="$4" err rc
+  err="$( ( source "$VERIFY"; "$func" "$root" ) 2>&1 )"
+  rc=$?
+  if [[ "$expect" == "pass" ]]; then
+    if [[ $rc -eq 0 ]]; then echo "  PASS: ${label}"; pass=$((pass+1));
+    else echo "  FAIL: ${label} — expected pass, rc=${rc}: ${err}"; fail=$((fail+1)); fi
+  else
+    if [[ $rc -ne 0 && "$err" == *"$expect"* ]]; then echo "  PASS: ${label} — died as expected (…${expect}…)"; pass=$((pass+1));
+    else echo "  FAIL: ${label} — expected die containing '${expect}', rc=${rc}: ${err}"; fail=$((fail+1)); fi
+  fi
+}
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+echo "## loopback frontend config verify — focused test"
+
+# Positive: apps/web/dist present, bundle references a real (non-loopback) API host.
+mkdir -p "${TMP}/ok/apps/web/dist/assets"
+cat > "${TMP}/ok/apps/web/dist/assets/index-abc123.js" <<'JS'
+const e={VITE_API_URL:"https://entity-host.example.internal",VITE_API_BASE:"https://entity-host.example.internal/api"};
+JS
+run_case "clean bundle (real host, no loopback)" pass "${TMP}/ok" verify_no_loopback_frontend_config
+
+# Negative (a): VITE_API_URL + 127.0.0.1 — one corner of the alternation.
+mkdir -p "${TMP}/bad_url_ip/apps/web/dist/assets"
+cat > "${TMP}/bad_url_ip/apps/web/dist/assets/index-def456.js" <<'JS'
+const e={VITE_API_URL:"http://127.0.0.1:4000"};
+JS
+run_case "loopback VITE_API_URL + 127.0.0.1 rejected" "embeds loopback VITE_API_* config" "${TMP}/bad_url_ip" verify_no_loopback_frontend_config
+
+# Negative (b): VITE_API_BASE + localhost — the opposite corner (both tokens in the
+# alternation must be load-bearing; a same-door fixture that only exercises one token
+# would let the other rot unnoticed).
+mkdir -p "${TMP}/bad_base_localhost/apps/web/dist/assets"
+cat > "${TMP}/bad_base_localhost/apps/web/dist/assets/index-ghi789.js" <<'JS'
+const e={VITE_API_BASE:"http://localhost:4000/api"};
+JS
+run_case "loopback VITE_API_BASE + localhost rejected" "embeds loopback VITE_API_* config" "${TMP}/bad_base_localhost" verify_no_loopback_frontend_config
+
+# Negative (c): apps/web/dist missing entirely. search_extended_regex returns non-zero
+# (no match) on a target directory that does not exist, which would otherwise let this
+# case silently PASS instead of failing loud — the vacuous-pass hole this test closes.
+run_case "apps/web/dist missing entirely rejected" "apps/web/dist missing" "${TMP}/no_web_dist" verify_no_loopback_frontend_config
+
+echo
+echo "RESULT: ${pass} passed, ${fail} failed"
+[[ $fail -eq 0 ]]

--- a/scripts/ops/multitable-onprem-package-verify.sh
+++ b/scripts/ops/multitable-onprem-package-verify.sh
@@ -34,6 +34,18 @@ function search_fixed_string() {
   grep -rIF -- "$needle" "$@" >/dev/null 2>&1
 }
 
+function search_extended_regex() {
+  local pattern="$1"
+  shift
+
+  if command -v rg >/dev/null 2>&1; then
+    rg -- "$pattern" "$@" >/dev/null 2>&1
+    return
+  fi
+
+  grep -rIE -- "$pattern" "$@" >/dev/null 2>&1
+}
+
 function verify_windows_entrypoints() {
   local root="$1"
   local start_script="${root}/deploy.bat"
@@ -648,6 +660,10 @@ function write_optional_report() {
       '    {' \
       '      "name": "no-github-links",' \
       "      \"status\": \"${link_status}\"" \
+      '    },' \
+      '    {' \
+      '      "name": "loopback",' \
+      '      "status": "PASS"' \
       '    }' \
       '  ],' \
       "  \"generatedAt\": \"$(date -u +"%Y-%m-%dT%H:%M:%SZ")\"" \
@@ -677,6 +693,7 @@ function write_optional_report() {
       echo "- Required content: \`PASS\` (${#required[@]} paths)"
       echo "- Deployability contract: \`PASS\` (deployable-onprem-app-package, directReplaceSafe=false, nodeModulesBundled=false)"
       echo "- No GitHub links in delivery docs: \`${link_status}\`"
+      echo "- Loopback frontend config: \`PASS\` (no loopback VITE_API_URL/BASE embedded in apps/web/dist)"
     } > "$report_md_tmp"
     mv "$report_md_tmp" "$VERIFY_REPORT_MD"
   fi
@@ -709,6 +726,27 @@ function verify_no_github_links() {
       die "Found disallowed GitHub links in on-prem package delivery files"
     fi
     rm -f /tmp/multitable_onprem_link_hits.txt || true
+  fi
+}
+
+# Ported from scripts/ops/attendance-onprem-package-verify.sh's loopback rule (same
+# pattern, same target: apps/web/dist). A frontend bundle that embeds a loopback
+# VITE_API_URL/BASE (baked in at web-build time, pointing at 127.0.0.1/localhost) would
+# be wired to the CI runner's own loopback instead of the operator's configured API host
+# once deployed on-prem — the multitable on-prem path never had this check; attendance's
+# did. Unlike attendance's package (which always contains apps/web/dist because it is
+# the only frontend-bearing on-prem package), this function guards its own precondition
+# explicitly: `search_extended_regex` returns non-zero (no match) for a target directory
+# that does not exist at all, which would otherwise let a package missing apps/web/dist
+# silently report PASS instead of failing loud.
+function verify_no_loopback_frontend_config() {
+  local root="$1"
+  local web_dist="${root}/apps/web/dist"
+
+  [[ -d "$web_dist" ]] || die "apps/web/dist missing; cannot verify frontend bundle is loopback-free"
+
+  if search_extended_regex 'VITE_API_(URL|BASE):"http://(127\.0\.0\.1|localhost)' "$web_dist"; then
+    die "Frontend bundle embeds loopback VITE_API_* config; rebuild package with isolated web env"
   fi
 }
 
@@ -1006,6 +1044,7 @@ verify_migration_bridge_contract "$pkg_root"
 verify_stock_preparation_mvp_contract "$pkg_root"
 verify_generic_integration_workbench_contract "$pkg_root"
 verify_bridge_agent_tooling_contract "$pkg_root"
+verify_no_loopback_frontend_config "$pkg_root"
 
 if [[ "$VERIFY_NO_GITHUB_LINKS" == "1" ]]; then
   verify_no_github_links "$pkg_root"

--- a/scripts/ops/multitable-onprem-package-verify.sh
+++ b/scripts/ops/multitable-onprem-package-verify.sh
@@ -734,11 +734,16 @@ function verify_no_github_links() {
 # VITE_API_URL/BASE (baked in at web-build time, pointing at 127.0.0.1/localhost) would
 # be wired to the CI runner's own loopback instead of the operator's configured API host
 # once deployed on-prem — the multitable on-prem path never had this check; attendance's
-# did. Unlike attendance's package (which always contains apps/web/dist because it is
-# the only frontend-bearing on-prem package), this function guards its own precondition
-# explicitly: `search_extended_regex` returns non-zero (no match) for a target directory
-# that does not exist at all, which would otherwise let a package missing apps/web/dist
-# silently report PASS instead of failing loud.
+# did. `search_extended_regex` returns non-zero (no match, not "checked and clean") for a
+# target directory that does not exist at all — verified: `grep -rIE ... /nonexistent` and
+# ripgrep's `rg` both return non-zero on a missing path. In this script's own full run, an
+# earlier required-content check already fails closed on a missing apps/web/dist (its
+# `apps/web/dist/index.html` entry), so the full pipeline is not exposed today; the explicit
+# `[[ -d ... ]] || die` below guards the function itself so calling it standalone (as the
+# focused test does, and as any future reordering might) cannot silently report PASS on a
+# package missing its frontend bundle. Attendance's script has the identical required-content
+# entry for apps/web/dist/index.html ahead of its own loopback check, for the same reason —
+# this is not a claim that attendance's script has a live, unguarded exposure.
 function verify_no_loopback_frontend_config() {
   local root="$1"
   local web_dist="${root}/apps/web/dist"

--- a/scripts/ops/multitable-onprem-package-verify.sh
+++ b/scripts/ops/multitable-onprem-package-verify.sh
@@ -12,6 +12,10 @@ list_file=""
 pkg_name=""
 pkg_root=""
 archive_type="unknown"
+# Derived (not hardcoded) — set by verify_no_loopback_frontend_config() itself on a
+# successful run; stays "SKIPPED" if that function's call site is ever removed from
+# the main flow below, so write_optional_report cannot report a check that never ran.
+loopback_status="SKIPPED"
 
 function die() {
   echo "[multitable-onprem-package-verify] ERROR: $*" >&2
@@ -663,7 +667,7 @@ function write_optional_report() {
       '    },' \
       '    {' \
       '      "name": "loopback",' \
-      '      "status": "PASS"' \
+      "      \"status\": \"${loopback_status}\"" \
       '    }' \
       '  ],' \
       "  \"generatedAt\": \"$(date -u +"%Y-%m-%dT%H:%M:%SZ")\"" \
@@ -693,7 +697,11 @@ function write_optional_report() {
       echo "- Required content: \`PASS\` (${#required[@]} paths)"
       echo "- Deployability contract: \`PASS\` (deployable-onprem-app-package, directReplaceSafe=false, nodeModulesBundled=false)"
       echo "- No GitHub links in delivery docs: \`${link_status}\`"
-      echo "- Loopback frontend config: \`PASS\` (no loopback VITE_API_URL/BASE embedded in apps/web/dist)"
+      if [[ "$loopback_status" == "PASS" ]]; then
+        echo "- Loopback frontend config: \`PASS\` (no loopback VITE_API_URL/BASE embedded in apps/web/dist)"
+      else
+        echo "- Loopback frontend config: \`${loopback_status}\`"
+      fi
     } > "$report_md_tmp"
     mv "$report_md_tmp" "$VERIFY_REPORT_MD"
   fi
@@ -753,6 +761,8 @@ function verify_no_loopback_frontend_config() {
   if search_extended_regex 'VITE_API_(URL|BASE):"http://(127\.0\.0\.1|localhost)' "$web_dist"; then
     die "Frontend bundle embeds loopback VITE_API_* config; rebuild package with isolated web env"
   fi
+
+  loopback_status="PASS"
 }
 
 function verify_sha() {


### PR DESCRIPTION
## Summary

Fix pass on the M0-A RC-A package status doc after an adversarial reviewer proved the prior draft's PRIMARY blocker wrong.

- `multitable-onprem-package-build.yml` runs **Build on-prem package**, verify, and **Upload package artifacts** unconditionally — only **Publish GitHub Release** (and one step-summary echo) are gated behind `inputs.publish_release == 'true'`. M0-A's authorized build+verify half was executable all along.
- Watched the already-dispatched run (`30148584851`, ref `build/m0a-rca-7bf2bd7a1`, `expected_sha=7bf2bd7a1f8cdf54cca83a733fcd89afb076848b`, `publish_release=false`) to completion: **success**. `Publish GitHub Release` step shows skipped (`-`); every build/verify/upload step shows `✓`.
- Downloaded the real artifact and recorded, from actual outputs (not hand-typed): `SHA256SUMS`, all four `verify.json` checks (`checksum`/`required-content`/`deployability-contract`/`no-github-links`, all PASS), and in-archive `BUILD_PROVENANCE.json.gitCommit` = `7bf2bd7a1f8cdf54cca83a733fcd89afb076848b` (exact match to `expected_sha`).
- Rewrote §3 retraction-first: quotes the withdrawn claim, gives the mechanical refutation (line-cited `if:` gate + empirical job-step list), and notes the doc's blocker-(a) (no ref existed) was **satisfied by construction**, not refuted — a ref this session did not create.
- Split operator instructions into **A1** (build+verify, `publish_release=false` — DONE, recorded) and **A2** (owner-only publish/freeze, `publish_release=true` — no release tag pre-chosen, not presented as inside Lane C's authority).
- Flagged that A1's checksums are run-scoped (`builtAt`/`ciRunId` baked into the archive before hashing) and must not be reused as "the" RC-A checksums once A2 runs; flagged the 14-day Actions-artifact retention window. **(This bullet described the only A2 path considered at the time — see "A2 guidance from the owner" below: under the owner's now-recommended path, A1's checksums are exactly what get published, not reused-by-mistake.)**
- Fixed three factual slips: false "generatedAt matches exactly" claim (only `gitSha` matches exactly; `generatedAt` falls inside the run's time window — corroborated by this session's own run reproducing the same pattern); "three" → seven listed attendance W4/W5 PRs; kept the `clientHelperSha` blob-identity proof unchanged (mechanically sound).
- New §6 (superseded by the owner ruling below): escalated the RATIFIED ledger's "loopback verification" phrase (§4 M0-A bullet, ⟲R7) as a **specification gap** — at the time this bullet was written, the verify script had zero loopback-named checks. **The owner has since ruled** ("build the real check — option 2, not option 1") and a later commit on this branch built it; §3.1a now documents the real check. This bullet is left as the historical record of the escalation, not the current state — see "Loopback verification hardening" below for what exists at HEAD.

## Explicitly NOT done here
- No release published, no `#4437` edit, no merge, no push to main, no flags changed, no gate opened, no deployment.

## Loopback verification hardening (review #4604 — this update)

Follow-up to a later adversarial pass on this same branch, after the loopback check above was built:

- **BLOCKING, fixed:** §3.1a recorded `verificationToolSha` as blob `2e64b9d66…`, but a same-branch commit changed
  the script's comments (diff `2e64b9d66..b2f5ff716`) in the very commit that wrote the "stable across this fix
  pass's own later commits" sentence, falsifying it. A comment-stripped diff of the two blobs is **identical**, so
  the recorded PASS was never behaviourally wrong — only the recorded tool *identity* was stale (the same class of
  slip this branch already fixed once before). §3.1a now carries an explicit erratum, and the SHA is refreshed to
  the script's actual blob at this branch's final, post-rebase HEAD: `89ec733a41af25bee9d7f02f608fefcbefbbd9c1`
  (re-derived after the required pre-push `git rebase origin/main`, not assumed).
- **P2, fixed:** the report's `"loopback"` row in `write_optional_report()` was a hardcoded `"status": "PASS"`
  literal, printed even if the check function were never invoked. Replaced with a derived `loopback_status`
  variable (default `"SKIPPED"`, set to `"PASS"` by `verify_no_loopback_frontend_config()` itself only on a
  successful run), wired into both the JSON and Markdown report emission — verified with a harness that the report
  flips to `SKIPPED` when the check isn't called. The focused test gained a fifth case pinning the main-flow call
  site (deleting it now reds the test: 4 passed/1 failed, confirmed by an actual negative-control run) instead of
  staying green at 4/4.
- **P2, originally disclosed-not-wired, now superseded — see "PR gate" section below.** The bullet that used to
  live here argued for disclosure over wiring, on the grounds that sibling `.test.mjs` contracts against the
  same script are equally uncalled. **The owner overruled that on a later round of this same review (#4604)**,
  on the specific finding that deleting the regex or the main-flow call site still left every PR required check
  green — an "equally uncalled siblings" argument does not change that. The underlying *check* (inside
  `multitable-onprem-package-verify.sh`) always also ran in `multitable-onprem-package-build.yml` (L101/L104)
  on every real package build; that was never in question. What was missing was an automated caller for the
  *focused fixture test itself* — now added, see "PR gate" below.
- Re-ran the full verify script a third time against A1's real, already-downloaded artifact (checksum reconfirmed
  unchanged) at the post-hardening tool identity — identical PASS results (5/5, `requiredCount=128`) in both JSON
  and Markdown report formats.

## PR gate: the focused loopback test now runs on every PR (review #4604, owner HOLD → fixed)

Owner's finding stands as written: `multitable-onprem-package-build.yml` is `workflow_dispatch`-only and only
ever runs the verify script against a normal package, so it never exercised the loopback *negative* case, and
no workflow/package script called `scripts/ops/multitable-onprem-package-verify-loopback.test.sh` — deleting
the regex or the main-flow call site left every PR required check green.

**Fix:** added a step to `.github/workflows/plugin-tests.yml`'s `test` job (the job whose 20.x matrix leg
produces the branch-protection-required `test (20.x)` context), gated `if: matrix.node-version == '20.x'`:

```yaml
- name: Multitable on-prem loopback-verify CI wiring contract (#4604)
  if: matrix.node-version == '20.x'
  run: bash scripts/ops/multitable-onprem-package-verify-loopback.test.sh
```

- **Trigger / path filter.** `plugin-tests.yml`'s `pull_request:` trigger has **no path filter at all**
  (`branches: [main, develop]` only) — it fires on every PR regardless of which files changed, so this step
  runs on ordinary PR iteration unconditionally, not merely on PRs that happen to touch the verify script.
- **Is the new gate among main's 8 required checks? Yes, explicitly.** Current branch protection
  (`gh api repos/zensgit/metasheet2/branches/main/protection`) lists `required_status_checks.contexts` =
  `["contracts (strict)", "contracts (dashboard)", "pr-validate", "test (20.x)", "contracts (openapi)",
  "web-tests", "stock-prep PowerShell 5.1 acceptance", "attendance-web-guard"]`. The new step is a step
  *inside* the existing `test` job's 20.x matrix leg — it is not a new, separate, unrequired context — so
  it fails the already-required `test (20.x)` check on any PR, with no branch-protection change needed. Not
  saying "wired" when the honest claim is only "wired but not gated": it is both.
- **No `integration-guard` condition applies to this PR — struck, owner-withdrawn.** An earlier round
  proposed "exact-head `integration-guard` must succeed" as a manual merge condition for this PR. **The owner
  has ruled that out.** This PR's diff is exactly `scripts/ops/multitable-onprem-package-verify.sh`,
  `scripts/ops/multitable-onprem-package-verify-loopback.test.sh`, `.github/workflows/plugin-tests.yml`, and
  one docs file — none of it is inside `.github/workflows/integration-guard.yml`'s `on.pull_request.paths`
  filter (verified: `sed -n '23,29p' .github/workflows/integration-guard.yml` shows the start of an 89-entry
  list, 87 unique after dedup — `JsonAssist.vue` and `utils/jsonAssist.ts` are each listed twice).
  **Correction (this round — retracted, not softened):** this clause used to also claim the list's
  top-two-path-segment prefixes are exactly `{apps/web, plugins/plugin-integration-core}`, "none of them
  ... `.github/workflows/`" — **false**. The list has one `.github/workflows/` entry,
  `.github/workflows/integration-guard.yml` itself (the workflow's own self-coverage), so the real prefix
  set is three, not two: `{.github/workflows, apps/web, plugins/plugin-integration-core}`
  (`sed -E "s/^ *- '//; s/'$//" <the 89-entry extract> | awk -F/ '{print $1"/"$2}' | sort -u` →
  those three). This doesn't change the conclusion: that entry is an *exact-match* filename
  (`integration-guard.yml`), not this PR's `.github/workflows/plugin-tests.yml` — `grep -n plugin-tests.yml`
  against the same 89-entry extract → no match — so this PR's diff is still outside the filter, and that
  workflow does not even trigger on this PR — confirmed live, `gh pr checks 4604` lists no `integration-guard`
  context on this PR's HEAD (only the 8 required contexts above plus non-required siblings, none of them named
  `integration-guard`). **[A future-classification prediction that stood here is DELETED, retraction-first —
  see the Fifth correction below for the deleted sentence and why it is not restated at a fresher SHA.]**
  **Second correction (this round — retracted, not softened):** the clause that used to follow here —
  "under the same 89-path list #4614 itself preserves" — is also false. **#4614 does not preserve that
  list.** It deletes `on.pull_request.paths` entirely (the workflow now fires unconditionally on
  `pull_request` and classifies in-job instead), and its `on.push.paths` is contract-pinned set-equal
  (verified: both sorted lists diff clean) to a newly extracted, deduplicated **90-entry** roster
  (`scripts/ops/integration-guard-guarded-paths.mjs`) — the same 87 unique paths main has today, plus
  3 brand-new self-coverage entries naming the extracted classifier/roster/assert-branch scripts themselves
  (`integration-guard-guarded-paths.mjs`, `integration-guard-classify.mjs`,
  `integration-guard-assert-branch.mjs`), none of which exist in any of main's lists. All three are
  exact-match entries, not `/**` prefixes — the roster's only 3 prefix entries are
  `plugins/plugin-integration-core/**` and the two `apps/web/.../stockPreparation/**` paths
  (`isPrefixEntry()` in #4614's own `integration-guard-classify.mjs` only prefix-matches `/**`-suffixed
  entries) — so this PR's two `scripts/ops/*.sh` files don't match them by filename and fall under no
  guarded prefix either. The underlying conclusion survives on its own merits, independently re-verified
  against #4614's actual classifier rather than assumed from the (wrong) list-identity claim: importing
  `classify()` and its real `GUARDED_PATH_ENTRIES` roster from #4614's real head (`fd48ecf91`,
  `scripts/ops/integration-guard-classify.mjs` + `integration-guard-guarded-paths.mjs`) and feeding it this
  PR's actual four changed files (`.github/workflows/plugin-tests.yml`, the status doc,
  `scripts/ops/multitable-onprem-package-verify-loopback.test.sh`,
  `scripts/ops/multitable-onprem-package-verify.sh`) returns `relevant=false`. Producing only a NOOP.
  A NOOP is not evidence about this diff. This condition is struck from this PR's merge criteria and should
  not be reintroduced.
  **Third correction (SHA refresh only — the result above is unchanged, not re-derived):** `fd48ecf91`,
  cited above as "#4614's real head", is now one commit behind — #4614 gained a further commit,
  `b1aae0244`, on top of it. Confirmed live: `gh pr view 4614 --json headRefOid` →
  `b1aae024452aba2c238cebfe404f78f3212b4809`; `git rev-parse b1aae0244...^` → `fd48ecf9122e0…`, i.e.
  `fd48ecf91` is that head's direct parent, not a more distant ancestor. Re-pointed to the current head
  rather than re-run from scratch: the roster blob `scripts/ops/integration-guard-guarded-paths.mjs` is
  byte-identical at both SHAs (`git rev-parse fd48ecf91:scripts/ops/integration-guard-guarded-paths.mjs`
  and `git rev-parse b1aae0244...:scripts/ops/integration-guard-guarded-paths.mjs` both →
  `a9c92f10709d53a662ffd785f52d4cbf7b9d0f24`), and `classify()` itself did change shape at the new head
  (blob `b22ac776d…` → `2c3ae9e48…`, the round-2 exact-shape/exact-equality hardening commit,
  unrelated to the roster) — re-imported from `b1aae0244...`'s own
  `scripts/ops/integration-guard-classify.mjs` and fed this PR's identical four changed files, it still
  returns `relevant=false`.
  **Fourth correction (this round, retraction-first — fixes a stale SHA AND a self-contradictory
  header, both in the Third correction paragraph immediately above):**
  (a) *Stale SHA.* That paragraph states, as a live measurement, `gh pr view 4614 --json headRefOid` →
  `b1aae024452aba2c238cebfe404f78f3212b4809`. **That is now false.** #4614's head has advanced twice
  more since — first to `bf93acea3fe07370a794cc06d1684bfaf2b8db45` (one real content commit,
  `6deeb1b22`, plus a merge of `main`), then to `3994073c386b1675bef64f743365d98a0b0ba334` (this
  round's own #4614 fix). This is the third time a commit-SHA citation in this body has gone stale
  while #4614 stayed open. **Durable fix, going forward: cite the BLOB hashes of the two load-bearing
  files, never the commit SHA.** Measured directly, both blobs have stayed byte-identical across every
  #4614 head cited anywhere in this body from `b1aae0244` onward (`b1aae0244`, `bf93acea3`, and now
  `3994073c3`):
  - roster `scripts/ops/integration-guard-guarded-paths.mjs` = `a9c92f10709d53a662ffd785f52d4cbf7b9d0f24`
  - classifier `scripts/ops/integration-guard-classify.mjs` = `2c3ae9e48ea0473e9b7e924d149190da53bf88dd`
    (this one changed shape once, `b22ac776d…` → `2c3ae9e48…`, between `fd48ecf91` and `b1aae0244` —
    already noted in the Third correction above — and has not changed since)

  Re-derived at #4614's current head (`3994073c386b1675bef64f743365d98a0b0ba334`, confirmed live via
  `gh pr view 4614 --json headRefOid`): `git rev-parse 3994073c3:scripts/ops/integration-guard-guarded-paths.mjs`
  and `git rev-parse 3994073c3:scripts/ops/integration-guard-classify.mjs` return the same two blob
  hashes above, unchanged. `classify()`, re-imported from that exact head's own
  `scripts/ops/integration-guard-classify.mjs` and fed this PR's identical four changed files
  (`.github/workflows/plugin-tests.yml`, the status doc,
  `scripts/ops/multitable-onprem-package-verify-loopback.test.sh`,
  `scripts/ops/multitable-onprem-package-verify.sh`), still returns `relevant=false`. Any future
  citation of this classifier/roster pairing in this body should reference these two blob hashes, not
  a commit SHA that will keep moving while #4614 remains open.
  (b) *Self-contradictory header.* The Third correction's own header —
  `(SHA refresh only — the result above is unchanged, not re-derived)` — contradicts its own closing
  sentence, which describes an actual re-import of `classify()` and a real re-run returning
  `relevant=false`. That is an understatement, not an overclaim: the work done exceeded what the
  header admitted. The header should have read **"(re-derived at the refreshed SHA, confirming the
  same result)"** — that paragraph performed a genuine re-derivation, it did not merely assume the
  prior result still held. (This same, corrected framing is what this Fourth correction paragraph
  itself follows, in (a) above.)
  **Fifth correction (this round — the future-classification prediction is DELETED, and every
  classifier claim in this body is now bound to BLOB hashes, never to a #4614 head):**
  (a) *The deleted prediction.* A sentence in the integration-guard bullet above used to read:
  "Even after #4614's proposed governance slice lands (a separate, still-open, WIRING-ONLY PR that
  widens `integration-guard`'s trigger and adds an explicit no-op branch — not merged, not touched
  by this branch), this diff would still take that classifier's 'irrelevant change' branch." It is
  **deleted, not restated at a fresher SHA**, for two reasons. First, it predicts the future
  behaviour of a still-moving PR: this body has already accumulated three stale-SHA errata from
  chasing #4614's head, and that head has moved again since the Fourth correction was written.
  Second, the prediction is about to be false on its own terms: **the owner has ruled that once
  #4614's self-coverage fix lands, `.github/workflows/plugin-tests.yml` becomes a guarded
  (`relevant`) path** — and this PR's diff touches exactly that file, so from that point a diff of
  this PR's shape classifies `relevant`, not irrelevant. A prediction whose truth flips on a known,
  planned commit does not belong in a merge record.
  (b) *What remains, blob-bound.* Every `relevant=false` result recorded in this body was a
  measurement against the classifier/roster pair at these exact blob identities —
  roster `scripts/ops/integration-guard-guarded-paths.mjs` = `a9c92f10709d53a662ffd785f52d4cbf7b9d0f24`,
  classifier `scripts/ops/integration-guard-classify.mjs` = `2c3ae9e48ea0473e9b7e924d149190da53bf88dd` —
  the pair the owner verified byte-identical at `b1aae0244` and `6deeb1b22`, and which
  re-measurement at this correction confirms unchanged at every #4614 head fetched to date,
  including the head current at this edit (deliberately not named by SHA here — naming heads is the
  practice this correction ends; at that same unnamed head, `grep plugin-tests` against the roster
  blob returns no match, confirming the self-coverage fix is still pending and the deleted
  prediction was *about to be* falsified rather than already false). Those measurements are facts
  about those two blobs applied to this PR's four changed files, and remain true permanently; this
  body now makes **no claim about what any past-or-future #4614 head classifies**. If either blob
  hash changes, every classifier statement in this body is out of scope at the new blob and must be
  re-derived, not extrapolated.
- **Negative controls, proved locally against the exact command the new step runs (before touching the
  workflow file, then restored):**
  - Deleting the main-flow call site (`verify_no_loopback_frontend_config "$pkg_root"`, ~L1062):
    `bash scripts/ops/multitable-onprem-package-verify-loopback.test.sh` → **4 passed / 1 failed**, exit 1.
  - Neutering the regex itself (`if search_extended_regex '...' "$web_dist"; then` → `if false; then`, ~L761):
    same command → **3 passed / 2 failed**, exit 1.
  - Restored the script both times; `git diff --stat scripts/ops/multitable-onprem-package-verify.sh` empty
    afterward; positive-control re-run back to 5 passed / 0 failed.
- Rebased onto current `origin/main` (`551117bef…`) before pushing (required — the branch was 1 commit
  behind); re-ran the focused test post-rebase, still 5 passed/0 failed; re-validated
  `.github/workflows/plugin-tests.yml` YAML (`python3 -c "import yaml; yaml.safe_load(open(...))"` → `YAML OK`).
  Rebasing rewrote this branch's existing 10 commits' SHAs (new parent), so the first push of this update
  used `git push --force-with-lease=<branch>:<old-remote-tip>` (pinned to the exact SHA this session started
  from, confirmed unmoved immediately before pushing) rather than a plain push.
- Pushed head `f4f6c5a54706d9abd807f01c48d8d302b99ec388` first. A **real CI run** of `plugin-tests.yml` on that
  head executed the new step inside the actual `test (20.x)` job and printed (from the job's own raw log,
  `gh api repos/zensgit/metasheet2/actions/jobs/<id>/logs`):
  ```
  ## loopback frontend config verify — focused test
    PASS: clean bundle (real host, no loopback)
    PASS: loopback VITE_API_URL + 127.0.0.1 rejected — died as expected (…embeds loopback VITE_API_* config…)
    PASS: loopback VITE_API_BASE + localhost rejected — died as expected (…embeds loopback VITE_API_* config…)
    PASS: apps/web/dist missing entirely rejected — died as expected (…apps/web/dist missing…)
    PASS: loopback check is wired into the main verify flow (call site present)

  RESULT: 5 passed, 0 failed
  ```
  This composes with the local negative controls into the full proof the owner asked for: the step (a) is a
  plain `run:` with no `continue-on-error`/`|| true`, so a non-zero exit fails the job; (b) demonstrably
  executes inside the real, required `test (20.x)` job on a real PR head; (c) exits non-zero under both named
  mutations, locally, against the identical command. Composition, not a literally-observed red run of this PR
  — the PR's own diff obviously doesn't ship either mutation.
- **Round-2 doc-consistency fix (this update, HEAD `ca7a67149dc3c85bb4d49d9a9e27cea2073f1135`):** the M0-A
  status doc's §3.1a Hardening item 2 still argued "disclosed here rather than wired into a caller" — the
  exact position the owner overruled — while this PR body said it was superseded. Fixed retraction-first:
  item 2's paragraph is left as the historical record of that decision, with a new erratum immediately after
  it (and a second fix to a now-stale "not wired into any automated caller" parenthetical near the
  `posthoc-verify-3` description) documenting the gate that exists now. Re-derived (not assumed) at this new
  HEAD: `git rev-parse HEAD:scripts/ops/multitable-onprem-package-verify.sh` → still
  `89ec733a41af25bee9d7f02f608fefcbefbbd9c1` (doc-only commit, script untouched) — §3.1a's
  `verificationToolSha` is not stale. Pushed as a plain fast-forward (`f4f6c5a54..ca7a67149`), no force
  needed for this second push.

- **Round-3 (this update, review #4604):** two corrections plus the A2 guidance addition above. Before this
  round, `origin/main` advanced (`cd2670695`, unrelated B1a-1 config-v2 work) and this branch picked it up via
  a plain merge commit `da80052a3ef88ce402fd99a40bb81e6328bf2db4` — confirmed via `git diff
  ca7a67149..da80052a3 --stat` to touch only `plugins/plugin-integration-core/**` files unrelated to this PR's
  own diff (no conflicts, this PR's own 4 changed files untouched). Two doc-only commits followed:
  `68f828e17c268e1f34bd8003650fa4d40b1eceea` (the §3.2/§3.2a A2-guidance edits above) and
  `ab683eb57ca7bede4539584006dbabf6f1f2fb2b` (a same-pattern erratum §3.1's own `SHA256SUMS` block still
  needed, missed on the first pass). This round's **final HEAD is `ab683eb57ca7bede4539584006dbabf6f1f2fb2b`**;
  both pushed as plain fast-forwards, `da80052a3..68f828e17..ab683eb57`, no force needed at any step.
  **Where the loopback evidence actually comes from, restated with the check name, at this round's final HEAD:**
  the owner verified from the real `test (20.x)` check's own log — not `integration-guard` — that the loopback
  suite executed and returned 5/5 PASS:
  ```
  $ gh api repos/zensgit/metasheet2/actions/runs/30189712398 -q '.head_sha'
  ab683eb57ca7bede4539584006dbabf6f1f2fb2b
  $ gh api repos/zensgit/metasheet2/actions/jobs/89760657846/logs | grep -A6 "loopback frontend config verify"
  ## loopback frontend config verify — focused test
    PASS: clean bundle (real host, no loopback)
    PASS: loopback VITE_API_URL + 127.0.0.1 rejected — died as expected (…embeds loopback VITE_API_* config…)
    PASS: loopback VITE_API_BASE + localhost rejected — died as expected (…embeds loopback VITE_API_* config…)
    PASS: apps/web/dist missing entirely rejected — died as expected (…apps/web/dist missing…)
    PASS: loopback check is wired into the main verify flow (call site present)
  RESULT: 5 passed, 0 failed
  ```
  (run `30189712398`, job `89760657846`, check name `test (20.x)` — the same branch-protection-required
  context cited above, at this update's actual final HEAD, not the earlier `f4f6c5a54…`/`ca7a67149…` heads.)

**Disclosure:** this branch is also checked out in a second, older worktree (`wf_a9c93e8e-225-3`), confirmed
this update (`git worktree list`) still sitting at pre-#4604-round-2 commit `7447b76b8…` — now even further
behind after this update's round-3 push. That worktree is stale relative to what is now pushed; if it pushes
from its own state it will collide with (and, if forced, could clobber) the commits landed here. Flagging so a
concurrent lane doesn't silently overwrite this update.

## A2 guidance from the owner (review #4604, this update) — RECOMMENDED PROCEDURE, NOT YET EXECUTED

The owner has ruled on **how** A2 should be executed once they authorize it — this records that ruling.
**Nothing in this section is performed here: no download, no re-verify, no publish, no upload, no tag chosen.
A2 remains open and remains the owner's act.**

- **Artifact `8616890535` (run `30148584851`) has NOT expired.** Verified live this update:
  ```
  gh api repos/zensgit/metasheet2/actions/runs/30148584851/artifacts
  {"id":8616890535,"name":"multitable-onprem-package-30148584851-1",
   "digest":"sha256:13c7aaa36a777786d75effa3b5ce2df7b1ce39ad47869a806638d57d5dbc0aea",
   "expired":false,"expires_at":"2026-08-08T07:04:52Z"}
  ```
  Outer digest `sha256:13c7aaa3…c0aea`, valid until 2026-08-08.
- **Rebuilding would produce different bytes.** `scripts/ops/multitable-onprem-package-build.sh` bakes
  `"ciRunId": "${GITHUB_RUN_ID:-local}"` (L508) and `"builtAt": "$(date -u ...)"` (L510) into
  `BUILD_PROVENANCE.json` inside the archive, before hashing — both per-run values. A fresh dispatch gets a new
  run ID and timestamp, therefore a different `.tgz`/`.zip` SHA256 even at the identical `gitCommit`.
- **The historical ref still runs the four-check verifier.** Verified this update directly against the pinned
  commit: `git show 7bf2bd7a1f8cdf54cca83a733fcd89afb076848b:scripts/ops/multitable-onprem-package-verify.sh |
  grep -n loopback` → zero hits. A rebuild dispatched at `build/m0a-rca-7bf2bd7a1` would therefore still be
  verified by the **older, four-check** tool, not this branch's merged five-check version.
- **Therefore the owner's ruling: the fastest path with the strongest evidence is to freeze the A1-verified
  ORIGINAL BYTES, not rebuild** — download A1 → re-verify the original hashes and provenance → re-verify the
  `.tgz`/`.zip` with the merged FIVE-check verifier → publish the ORIGINAL bytes (a manual release of the
  files already downloaded from A1, **not** a `gh workflow run ... publish_release=true` re-dispatch, which
  would be a rebuild) → an upload round-trip check (download the published asset back, re-hash, confirm it
  matches A1's own `SHA256SUMS`).

Written into the status doc as the recommended A2 procedure (new §3.2a), clearly marked **not yet executed**;
the existing rebuild path (§3.2) is kept, retitled Path B, as the documented fallback (e.g. if A1's artifact
expires before A2 is authorized), not struck. Every doc passage that had assumed A2 == rebuild (§3.1's
retention note, §4's `<<PENDING FREEZE RUN>>` fields, §5's "must not be read as the RC-A checksums") gets a
retraction-first erratum pointing at §3.2a, rather than being silently flipped to assert one path's outcome as
fact. See `docs/development/stock-preparation-rc-a-m0a-package-build-status-and-4437-pointer-draft-20260725.md`
§3.2/§3.2a for the full record.

## Test plan
- [x] `gh run view 30148584851` — conclusion `success`, `headSha` exact match to `expected_sha`
- [x] `gh run view 30148584851 --job=...` — `Publish GitHub Release` skipped, all build/verify/upload steps `✓`
- [x] `gh run download 30148584851` — real `SHA256SUMS`, `verify.json` (both archives, `ok:true`, 4/4 PASS), in-archive `BUILD_PROVENANCE.json` (`gitCommit` exact match)
- [x] `grep -n loopback scripts/ops/multitable-onprem-package-verify.sh` → **zero hits when this line was originally written** (before the check existed); at current HEAD this now returns multiple hits (the check itself, the derived-status wiring, and its call site) — see "Loopback verification hardening" above
- [x] `git ls-remote origin refs/heads/build/m0a-rca-7bf2bd7a1` → exact match to `7bf2bd7a1f8cdf54cca83a733fcd89afb076848b`
- [x] `bash scripts/ops/multitable-onprem-package-verify-loopback.test.sh` → 5 passed/0 failed; deleting the call site (negative control) → 4 passed/1 failed
- [x] `bash scripts/ops/multitable-onprem-package-verify.provenance.test.sh` → 5 passed/0 failed (unaffected)
- [x] `bash -n scripts/ops/multitable-onprem-package-verify.sh` → clean
- [x] `git rev-parse HEAD:scripts/ops/multitable-onprem-package-verify.sh` at final, post-rebase HEAD → `89ec733a41af25bee9d7f02f608fefcbefbbd9c1`, matches §3.1a
- [x] (#4604 gate) `gh api repos/zensgit/metasheet2/branches/main/protection` — `required_status_checks.contexts` includes `test (20.x)`; the new step runs inside that same job's 20.x leg
- [x] (#4604 gate) negative control A — call-site deleted → `bash scripts/ops/multitable-onprem-package-verify-loopback.test.sh` → 4 passed/1 failed
- [x] (#4604 gate) negative control B — regex neutered (`if false; then`) → 3 passed/2 failed
- [x] (#4604 gate) `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/plugin-tests.yml'))"` → `YAML OK` post-edit
- [x] (#4604 gate) `gh pr checks 4604` post-push on head `f4f6c5a54…` shows `test (20.x)` re-triggered
- [x] (#4604 gate) real CI job log (`gh api .../actions/jobs/89748332176/logs`) on head `f4f6c5a54…` shows the
  new step executing inside `test (20.x)` and printing `RESULT: 5 passed, 0 failed`
- [x] (#4604 round-2 doc fix) `git rev-parse HEAD:scripts/ops/multitable-onprem-package-verify.sh` at HEAD
  `ca7a67149…` → still `89ec733a41af25bee9d7f02f608fefcbefbbd9c1` (doc-only commit; §3.1a not stale)
- [x] (#4604 round-3, integration-guard) `sed -n '23,29p' .github/workflows/integration-guard.yml` — confirms
  the `on.pull_request.paths` filter; this PR's diff (`scripts/ops/`, `plugin-tests.yml`, one doc) matches none
  of it; `gh pr checks 4604` lists no `integration-guard` context on this PR's HEAD
- [x] (#4604 round-3, A2 guidance) `gh api repos/zensgit/metasheet2/actions/runs/30148584851/artifacts` →
  artifact `8616890535`, `"expired":false`, `"expires_at":"2026-08-08T07:04:52Z"`,
  `"digest":"sha256:13c7aaa36a777786d75effa3b5ce2df7b1ce39ad47869a806638d57d5dbc0aea"`
- [x] (#4604 round-3, A2 guidance) `git show 7bf2bd7a1f8cdf54cca83a733fcd89afb076848b:scripts/ops/multitable-onprem-package-verify.sh
  | grep -n loopback` → zero hits — confirms the historical build ref still runs the pre-fix, four-check
  verifier
- [x] (#4604 round-3, A2 guidance) `grep -n 'ciRunId\|builtAt' scripts/ops/multitable-onprem-package-build.sh`
  → L508/L510, both per-run values baked into `BUILD_PROVENANCE.json` before hashing (confirms rebuild ≠
  same bytes)
- [x] (#4604 round-3) `git rev-parse HEAD:scripts/ops/multitable-onprem-package-verify.sh` at this round's
  actual final HEAD `ab683eb57ca7bede4539584006dbabf6f1f2fb2b` → still `89ec733a41af25bee9d7f02f608fefcbefbbd9c1`
  (both round-3 commits doc-only; script untouched; §3.1a not stale)
- [x] (#4604 round-3) real CI job log on this round's final HEAD (`gh api
  repos/zensgit/metasheet2/actions/jobs/89760657846/logs`, run `30189712398`, `head_sha` confirmed
  `ab683eb57…`) shows `test (20.x)`'s loopback step printing `RESULT: 5 passed, 0 failed`
- [x] (#4604 round-10, Fourth correction 4a) `gh pr view 4614 --json headRefOid` → current head
  `3994073c386b1675bef64f743365d98a0b0ba334`, confirming the Third correction's cited
  `b1aae024452aba2c238cebfe404f78f3212b4809` is stale
- [x] (#4604 round-10, Fourth correction 4a) `git rev-parse 3994073c3:scripts/ops/integration-guard-guarded-paths.mjs`
  → `a9c92f10709d53a662ffd785f52d4cbf7b9d0f24`; `git rev-parse 3994073c3:scripts/ops/integration-guard-classify.mjs`
  → `2c3ae9e48ea0473e9b7e924d149190da53bf88dd` — both blobs unchanged from the values already cited
  against `b1aae0244`
- [x] (#4604 round-10, Fourth correction 4a) `classify()` re-imported from #4614's current head and fed
  this PR's real 4 changed files → `relevant=false` (unchanged)
- [x] (#4604 Fifth correction) `git rev-parse <commit>:scripts/ops/integration-guard-guarded-paths.mjs`
  and `…:scripts/ops/integration-guard-classify.mjs` at `b1aae0244`, at `6deeb1b22`, and at #4614's
  head current at this edit → the identical pair `a9c92f10709d53a662ffd785f52d4cbf7b9d0f24` /
  `2c3ae9e48ea0473e9b7e924d149190da53bf88dd` every time; `git show <that head>:scripts/ops/integration-guard-guarded-paths.mjs | grep -n plugin-tests`
  → no match (self-coverage fix still pending at the time of this correction)

🤖 Generated with [Claude Code](https://claude.com/claude-code)





