### PR TITLE
fix(directory): Phase B expand corp-scoped identity constraints

### DIFF
--- a/docs/development/dingtalk-directory-corp-scope-closeout-verification-20260725.md
+++ b/docs/development/dingtalk-directory-corp-scope-closeout-verification-20260725.md
@@ -1,0 +1,117 @@
+# DingTalk directory corp-scope closeout verification
+
+Status: ENGINEERING COMPLETE / EXACT-HEAD REVIEW AND CI PENDING / NOT DEPLOYED / UAT NOT RUN
+
+Date: 2026-07-25
+
+## 1. Delivery claim
+
+The code delivery is split into two reviewable PRs:
+
+- Phase A makes every worker safe before schema expansion.
+- Phase B expands database uniqueness only after the Phase A drain gate.
+
+This document does not claim merge, deployment, staging success, account binding, callback UAT,
+automatic sync, deprovision, or runtime enablement.
+
+## 2. Verification matrix
+
+| Contract | Evidence |
+| --- | --- |
+| cross-corp raw identity cannot auto-link | real sync negative plus same-corp positive |
+| delimiter-containing identifiers do not collide | pure helper negative and mutation |
+| duplicate same-corp provider identity fails closed | direct ambiguity outcome plus real-DB no-link |
+| generic tenant mutation remains closed | unit and real-DB empty/set, set/change; same-corp positive |
+| historical child corp repairs during sync | real-DB blank-to-parent assertion and mutation |
+| callback account/integration corp drift cannot act | real approval callback, zero engine write, card remains sent |
+| legacy whitespace corp cannot bypass bind conflict | real bind negative and mutation |
+| migration canonicalizes data | isolated old-schema assertions |
+| all replacement indexes are structurally valid | catalog inspection plus wrong-definition negative |
+| expression/include keys cannot masquerade as ordinary columns | key/attribute counts plus expression catalog flag; up/down negatives |
+| partial replay cannot pass | no-legacy/incomplete-replacement negative |
+| duplicate scoped union cannot migrate | real unique-index build failure; legacy guard retained |
+| parent provider/corp is authoritative | integration canonicalization plus provider-drift rollback negative |
+| DB/runtime corp grammar agrees | tab/newline/NBSP/EM SPACE/BOM negatives |
+| up failure is atomic | constraints and new indexes absent after failure |
+| compatible down and replay work | real DB |
+| incompatible down retains scoped protection | real DB |
+| compatible down does not invent pre-migration text | canonical corp remains canonical after down |
+| lock wait is bounded | real second-connection ACCESS EXCLUSIVE blocker; abort around 5.2 seconds |
+| timeout scope is contained | prior lock/statement settings restored after up/down |
+| migration runner integration works | fresh database migrated through the new migration |
+| PostgreSQL 14 compatibility | pending: required CI after Phase B retargets to main |
+
+## 3. Local results
+
+Phase A:
+
+- unit 43/43;
+- real PostgreSQL 15 55/55;
+- required attendance directory/user-org real-DB regressions 14/14;
+- CI contracts 82/82;
+- TypeScript clean;
+- nine mutations killed.
+
+Phase B:
+
+- isolated migration and inherited Phase A real-DB suite 30/30 on PostgreSQL 15;
+- full fresh-database migration reaches
+  `zzzz20260725130000_expand_directory_identity_corp_scope`;
+- a second Migrator run has no pending migration;
+- 10-integration / 100,000-account / 200,000-identity scale sample completes in 3,158 ms;
+- a real lock blocker fails closed after about 5.2 seconds;
+- TypeScript clean.
+
+Seven Phase B mutations are load-bearing:
+
+1. trusting an existing replacement index without shape verification makes the wrong-definition
+   upgrade test red;
+2. treating any no-legacy state as a replay makes the partial-replay test red;
+3. removing the authoritative-parent-corp preflight changes the values-free refusal and reds its
+   dedicated test;
+4. trusting an existing legacy index during down makes the wrong-definition rollback test red.
+5. ignoring expression/extra key attributes lets a same-name replacement index pass;
+6. removing parent-provider equality lets a drifted account adopt the parent corp;
+7. restoring the BTRIM-only CHECK lets Unicode whitespace corp tokens persist.
+
+Required CI is recorded only after the final pushed head settles.
+
+## 4. Operational risks
+
+The scoped indexes are built with ordinary `CREATE UNIQUE INDEX` inside the migration transaction.
+This is intentionally PostgreSQL 14-compatible and atomic, but it can hold locks and scan large
+tables. A local 100,000-account / 200,000-identity sample completed in 3,158 ms, while a real lock
+blocker was cut off at about 5.2 seconds. Before deployment, ops must still measure real
+account/identity row counts and choose a controlled migration window. No claim is made that the
+local sample predicts production lock acquisition, I/O, replicas, or WAL behavior.
+
+Kysely 0.28 executes all pending migrations in one transaction. The 5-second lock timeout therefore
+also protects this migration from waiting indefinitely, but a timeout aborts the whole pending
+migration batch. Run Phase B only after Phase A is on every worker and the old-worker count is zero.
+
+A compatible down restores the old global uniqueness shape but does not restore whitespace or NULL
+corp values rewritten by up. That data canonicalization is deliberately irreversible.
+
+The persisted DingTalk external identity key keeps its existing OAuth-compatible encoding. The
+runtime tuple collision that could cause a wrong match is fixed. Versioning the persisted key is
+not part of this delivery.
+
+## 5. Final disposition
+
+Engineering status: implementation and local evidence complete; exact-head adversarial re-review
+and CI remain required.
+
+Operational status: blocked by explicit owner gates, not by unfinished code.
+
+Required order:
+
+```text
+Phase A review/merge/deploy
+  -> prove all old workers drained
+  -> Phase B review/merge/deploy
+  -> post-fix two-corp staging UAT
+  -> authorized existing-user bind
+  -> same-corp approval callback proof
+```
+
+Flags, schedules, and deprovision remain unchanged throughout.

--- a/docs/development/dingtalk-directory-corp-scope-closeout-verification-20260725.md
+++ b/docs/development/dingtalk-directory-corp-scope-closeout-verification-20260725.md
@@ -27,7 +27,8 @@ automatic sync, deprovision, or runtime enablement.
 | legacy whitespace corp cannot bypass bind conflict | real bind negative and mutation |
 | migration canonicalizes data | isolated old-schema assertions |
 | all replacement indexes are structurally valid | catalog inspection plus wrong-definition negative |
-| expression/include keys cannot masquerade as ordinary columns | key/attribute counts plus expression catalog flag; up/down negatives |
+| expression/include keys cannot masquerade as ordinary columns | key-only catalog projection, total-attribute count, expression flag, and independent negatives |
+| weaker same-name CHECK cannot masquerade as canonical | exact catalog-definition negative |
 | partial replay cannot pass | no-legacy/incomplete-replacement negative |
 | duplicate scoped union cannot migrate | real unique-index build failure; legacy guard retained |
 | parent provider/corp is authoritative | integration canonicalization plus provider-drift rollback negative |
@@ -54,7 +55,9 @@ Phase A:
 
 Phase B:
 
-- isolated migration and inherited Phase A real-DB suite 30/30 on PostgreSQL 15;
+- pre-Phase-B public schema plus isolated migration suite 32/32 on PostgreSQL 15;
+- fully migrated Phase-B public schema plus the same suite 32/32, with five legacy-dirty-state
+  runtime fixtures switching to their stronger database-rejection assertions rather than skipping;
 - full fresh-database migration reaches
   `zzzz20260725130000_expand_directory_identity_corp_scope`;
 - a second Migrator run has no pending migration;
@@ -62,7 +65,7 @@ Phase B:
 - a real lock blocker fails closed after about 5.2 seconds;
 - TypeScript clean.
 
-Seven Phase B mutations are load-bearing:
+Ten Phase B mutations are load-bearing:
 
 1. trusting an existing replacement index without shape verification makes the wrong-definition
    upgrade test red;
@@ -73,6 +76,10 @@ Seven Phase B mutations are load-bearing:
 5. ignoring expression/extra key attributes lets a same-name replacement index pass;
 6. removing parent-provider equality lets a drifted account adopt the parent corp;
 7. restoring the BTRIM-only CHECK lets Unicode whitespace corp tokens persist.
+8. removing the total-attribute count lets an `INCLUDE` disguise pass;
+9. removing exact CHECK-definition comparison lets a weaker same-name constraint pass;
+10. forcing the suite to treat a migrated database as pre-Phase-B makes all five phase-aware
+    compatibility tests red.
 
 Required CI is recorded only after the final pushed head settles.
 

--- a/docs/development/dingtalk-directory-corp-scope-closeout-verification-20260725.md
+++ b/docs/development/dingtalk-directory-corp-scope-closeout-verification-20260725.md
@@ -68,6 +68,8 @@ Phase B:
 - a second Migrator run has no pending migration;
 - fully migrated Phase-B migration plus DingTalk callback compatibility suites run 60/60 after
   exact-head CI exposed and the fix removed a now-illegal blank-corp callback fixture;
+- the corp-immutability real-DB suite runs 5/5 on both pre-Phase-B and fully migrated schemas,
+  proving application-layer refusal before the migration and stronger database rejection after it;
 - 10-integration / 100,000-account / 200,000-identity scale sample completes in 3,158 ms;
 - a real lock blocker fails closed after about 5.2 seconds;
 - TypeScript clean.

--- a/docs/development/dingtalk-directory-corp-scope-closeout-verification-20260725.md
+++ b/docs/development/dingtalk-directory-corp-scope-closeout-verification-20260725.md
@@ -66,6 +66,8 @@ Phase B:
 - full fresh-database migration reaches
   `zzzz20260725130000_expand_directory_identity_corp_scope`;
 - a second Migrator run has no pending migration;
+- fully migrated Phase-B migration plus DingTalk callback compatibility suites run 60/60 after
+  exact-head CI exposed and the fix removed a now-illegal blank-corp callback fixture;
 - 10-integration / 100,000-account / 200,000-identity scale sample completes in 3,158 ms;
 - a real lock blocker fails closed after about 5.2 seconds;
 - TypeScript clean.

--- a/docs/development/dingtalk-directory-corp-scope-closeout-verification-20260725.md
+++ b/docs/development/dingtalk-directory-corp-scope-closeout-verification-20260725.md
@@ -1,6 +1,6 @@
 # DingTalk directory corp-scope closeout verification
 
-Status: ENGINEERING COMPLETE / EXACT-HEAD REVIEW AND CI PENDING / NOT DEPLOYED / UAT NOT RUN
+Status: ENGINEERING COMPLETE / INDEPENDENT REVIEW APPROVED / EXACT-HEAD CI PENDING / NOT DEPLOYED / UAT NOT RUN
 
 Date: 2026-07-25
 
@@ -32,6 +32,7 @@ automatic sync, deprovision, or runtime enablement.
 | partial replay cannot pass | no-legacy/incomplete-replacement negative |
 | duplicate scoped union cannot migrate | real unique-index build failure; legacy guard retained |
 | parent provider/corp is authoritative | integration canonicalization plus provider-drift rollback negative |
+| nullable parent-corp schema/data cannot pass | catalog `attnotnull` gate, explicit NULL count, migration refusal |
 | DB/runtime corp grammar agrees | tab/newline/NBSP/EM SPACE/BOM negatives |
 | up failure is atomic | constraints and new indexes absent after failure |
 | compatible down and replay work | real DB |
@@ -40,24 +41,28 @@ automatic sync, deprovision, or runtime enablement.
 | lock wait is bounded | real second-connection ACCESS EXCLUSIVE blocker; abort around 5.2 seconds |
 | timeout scope is contained | prior lock/statement settings restored after up/down |
 | migration runner integration works | fresh database migrated through the new migration |
-| PostgreSQL 14 compatibility | pending: required CI after Phase B retargets to main |
+| Phase B data/schema readiness is executable | values-free read-only preflight, projected duplicate/drift negatives, CLI exit-code rehearsal |
+| PostgreSQL 14 compatibility | local 14.23 suite 40/40; required CI pending after Phase B retarget |
 
 ## 3. Local results
 
 Phase A:
 
 - unit 43/43;
-- real PostgreSQL 15 55/55;
+- real PostgreSQL 15 63/63;
 - required attendance directory/user-org real-DB regressions 14/14;
 - CI contracts 82/82;
 - TypeScript clean;
-- nine mutations killed.
+- ten mutations killed.
 
 Phase B:
 
-- pre-Phase-B public schema plus isolated migration suite 32/32 on PostgreSQL 15;
-- fully migrated Phase-B public schema plus the same suite 32/32, with five legacy-dirty-state
+- pre-Phase-B public schema plus preflight and isolated migration suite 40/40 on PostgreSQL 15;
+- fully migrated Phase-B public schema plus the same suite 40/40, with five legacy-dirty-state
   runtime fixtures switching to their stronger database-rejection assertions rather than skipping;
+- fully migrated PostgreSQL 14.23 runs the same suite 40/40 locally;
+- CLI rehearsal: `PASS`/`0`, projected duplicate `BLOCKED`/`2`, and missing-configuration
+  values-free `ERROR`/`1`;
 - full fresh-database migration reaches
   `zzzz20260725130000_expand_directory_identity_corp_scope`;
 - a second Migrator run has no pending migration;
@@ -65,7 +70,7 @@ Phase B:
 - a real lock blocker fails closed after about 5.2 seconds;
 - TypeScript clean.
 
-Ten Phase B mutations are load-bearing:
+Seventeen Phase B mutations are load-bearing:
 
 1. trusting an existing replacement index without shape verification makes the wrong-definition
    upgrade test red;
@@ -80,6 +85,14 @@ Ten Phase B mutations are load-bearing:
 9. removing exact CHECK-definition comparison lets a weaker same-name constraint pass;
 10. forcing the suite to treat a migrated database as pre-Phase-B makes all five phase-aware
     compatibility tests red.
+11. removing `READ ONLY` makes the preflight's read-only positive control red;
+12. neutralizing one projected scoped-identity duplicate query makes its exact count assertion red;
+13. hiding a Phase B replacement index makes the partial-schema refusal red.
+14. removing the migration's parent-corp `NOT NULL` catalog assertion makes the nullable-schema
+    migration negative red;
+15. removing the preflight's nullable-column blocker makes its exact blocker assertion red;
+16. removing explicit NULL data detection makes the invalid-scope count assertion red;
+17. mapping `BLOCKED` to exit `0` makes the required subprocess test red.
 
 Required CI is recorded only after the final pushed head settles.
 
@@ -89,8 +102,10 @@ The scoped indexes are built with ordinary `CREATE UNIQUE INDEX` inside the migr
 This is intentionally PostgreSQL 14-compatible and atomic, but it can hold locks and scan large
 tables. A local 100,000-account / 200,000-identity sample completed in 3,158 ms, while a real lock
 blocker was cut off at about 5.2 seconds. Before deployment, ops must still measure real
-account/identity row counts and choose a controlled migration window. No claim is made that the
-local sample predicts production lock acquisition, I/O, replicas, or WAL behavior.
+account/identity row counts, obtain a `PASS` from the read-only preflight, and choose a controlled
+migration window. The preflight proves the projected schema/data blockers are absent in one
+repeatable-read snapshot; it does not predict production lock acquisition, I/O, replicas, WAL
+behavior, or prove old-worker drain.
 
 Kysely 0.28 executes all pending migrations in one transaction. The 5-second lock timeout therefore
 also protects this migration from waiting indefinitely, but a timeout aborts the whole pending
@@ -105,8 +120,8 @@ not part of this delivery.
 
 ## 5. Final disposition
 
-Engineering status: implementation and local evidence complete; exact-head adversarial re-review
-and CI remain required.
+Engineering status: implementation, local evidence, and independent adversarial re-review complete;
+exact-head required CI and owner review remain required.
 
 Operational status: blocked by explicit owner gates, not by unfinished code.
 
@@ -115,6 +130,7 @@ Required order:
 ```text
 Phase A review/merge/deploy
   -> prove all old workers drained
+  -> Phase B values-free preflight returns 0 / PASS
   -> Phase B review/merge/deploy
   -> post-fix two-corp staging UAT
   -> authorized existing-user bind

--- a/docs/development/dingtalk-directory-corp-scope-execution-ledger-20260725.md
+++ b/docs/development/dingtalk-directory-corp-scope-execution-ledger-20260725.md
@@ -128,6 +128,7 @@ until the stacked PR is retargeted after Phase A lands.
 | function tests missed a CLI top-level-await load failure | remove top-level await and add a required subprocess startup/error-contract test |
 | SQL three-value logic let NULL parent corp evade `!~` | require the parent column to remain `NOT NULL`, count NULL explicitly, and pin both preflight and migration refusals |
 | required CI only exercised CLI `ERROR/1` | execute `PASS/0` and `BLOCKED/2` through subprocesses in the required real-DB file |
+| exact-head CI found the callback `delivery_corp_unresolved` fixture still inserted a blank DingTalk corp that Phase B correctly rejects | preserve the canonical corp CHECK; construct the same fail-closed callback outcome with a valid-corp non-DingTalk integration, update the stale resolver comment, and run the migration plus callback suites 60/60 |
 
 ## 6. Remaining owner gates
 

--- a/docs/development/dingtalk-directory-corp-scope-execution-ledger-20260725.md
+++ b/docs/development/dingtalk-directory-corp-scope-execution-ledger-20260725.md
@@ -1,0 +1,126 @@
+# DingTalk directory corp-scope execution ledger
+
+Status: IMPLEMENTED / REVIEW PENDING
+
+Date: 2026-07-25
+
+## 1. Authorized scope
+
+Authorized:
+
+- implement corp-scoped directory keys and identity matching in isolated worktrees;
+- run unit, real-database, migration, and mutation tests;
+- create review PRs.
+
+Not authorized:
+
+- merge;
+- staging or production deployment;
+- runtime flag changes;
+- automatic directory sync or deprovision;
+- creation of a new MetaSheet user.
+
+## 2. Expand/contract split
+
+| Phase | PR/branch | Contents | Deployment gate |
+| --- | --- | --- | --- |
+| A | `codex/dingtalk-directory-corp-scope-20260725` / PR #4602 | matcher ambiguity, injective scope key, in-transaction bind/unbind authority, serialized identity snapshot, sync child-corp repair, immutable generic update, callback corp equality | review and merge first |
+| B | `codex/dingtalk-directory-corp-scope-migration-20260725` / Draft PR #4605 | canonicalization, CHECK constraints, account/union/open scoped uniqueness, structural drift checks, bounded migration waits, rollback contract | Phase A deployed and every old worker drained |
+
+The original combined shape was rejected after adversarial review: dropping global uniqueness
+while an old unscoped worker remained could turn a visible collision into a cross-corp mislink.
+
+## 3. Phase A execution
+
+Completed:
+
+1. removed the schema relaxation from Phase A;
+2. changed in-memory corp/provider keys to an injective JSON tuple;
+3. added ambiguity sets for external key, unionId, and openId;
+4. normalized bind/unbind corp comparisons;
+5. made sync refresh account corp from its immutable integration;
+6. blocked empty/set, set/change, and set/clear generic integration edits;
+7. required callback account corp to agree with its pinned integration;
+8. added replacement staging UAT instructions and marked the old runbook historical.
+
+Local verification at the final Phase A implementation worktree:
+
+- focused unit: 43/43;
+- focused PostgreSQL 15: 55/55;
+- required attendance directory/user-org real-DB regressions: 14/14;
+- CI placement/values-free contracts: 82/82;
+- nine discriminating mutations killed;
+- TypeScript and diff checks clean.
+
+The first CI run found five old admission tests whose fake transaction clients did not model the
+new authoritative account lock. The fixtures now return a same-corp account; a separate negative
+control proves a NULL-corp authoritative account rolls back the admission savepoint. Required CI
+on the replacement pushed head remains a separate gate.
+
+## 4. Phase B execution
+
+Completed:
+
+1. canonicalize the parent integration corp, then copy that exact authoritative value to every
+   account;
+2. reject blank/non-printable/whitespace-containing corp tokens and account/provider drift;
+3. normalize legacy identity whitespace corp to canonical text/NULL, then reject any remaining
+   non-canonical value;
+4. enforce canonical corp CHECKs on integrations, accounts, and identities;
+5. add scoped account, unionId, and openId partial unique indexes;
+6. verify index uniqueness, validity, table, ordered key count, total attribute count, absence of
+   expressions, and predicate;
+7. refuse same-name drift, expression/include-key disguises, and partial no-legacy replay states;
+8. remove the global account key only after every replacement verifies;
+9. recreate and verify the global guard before down removes scoped protection;
+10. preserve scoped protection when down is data-incompatible;
+11. bound migration lock waiting to 5 seconds and statements to 5 minutes, restoring the caller's
+    prior settings after successful up/down.
+
+Kysely 0.28 supplies one transaction for all pending PostgreSQL migrations; this migration does
+not open a nested transaction. The scoped settings are transaction-local. Failure rolls back the
+data normalization, constraints, indexes, and settings together. A compatible down removes
+constraints/indexes but intentionally does not reverse already-canonicalized data.
+
+Local PostgreSQL 15 evidence:
+
+- combined Phase A compatibility plus isolated Phase B migration suite: 30/30;
+- fresh full Migrator reaches `zzzz20260725130000_expand_directory_identity_corp_scope`, and replay
+  has no pending migration;
+- lock contention aborts after about 5.2 seconds while retaining the legacy guard;
+- synthetic scale sample (10 integrations, 100,000 accounts, 200,000 identities): 3,158 ms in one
+  transaction, nine resulting indexes, three CHECKs, zero NULL account corp values;
+- seven Phase B mutations killed, including expression-index disguise, parent-provider drift, and
+  Unicode-whitespace acceptance;
+- TypeScript and diff checks clean.
+
+The scale sample is a local engineering bound, not a production latency or availability promise.
+PostgreSQL 14 remains unclaimed until the stacked PR is retargeted and required CI executes after
+Phase A lands.
+
+## 5. Incident and correction ledger
+
+| Finding | Correction |
+| --- | --- |
+| combined deploy left mixed-version wrong-match window | split Phase A and Phase B |
+| duplicate identity test initially stayed green when ambiguity was neutered | added direct outcome golden; mutation now reds |
+| isolated migration test used plain Kysely and missed runner behavior | ran full fresh-DB Migrator; removed unsupported nested transaction |
+| `IF NOT EXISTS` could accept wrong same-name index | explicit catalog shape verification |
+| legacy blank/whitespace corp could compare differently in JS and SQL | normalized runtime comparison plus Phase B canonical CHECK |
+| expression key disappeared from the catalog column list | reject expressions and require exact key/total attribute counts |
+| child provider could drift from its parent integration | fail the migration before any backfill |
+| BTRIM and JavaScript trim accepted different whitespace sets | printable-ASCII token grammar in runtime and database |
+| ordinary index creation could wait without bound | transaction-local 5-second lock timeout plus real contention test |
+| down appeared to imply data restoration | explicitly document and test irreversible canonicalization |
+
+## 6. Remaining owner gates
+
+1. review Phase A;
+2. review Phase B as a stacked contract;
+3. merge/deploy Phase A;
+4. prove old-worker count is zero;
+5. merge/deploy Phase B in a controlled migration window;
+6. execute the staging UAT;
+7. bind only the authorized account to the existing MetaSheet user;
+8. verify the same-corp approval callback;
+9. decide any later automatic-sync/deprovision/flag changes separately.

--- a/docs/development/dingtalk-directory-corp-scope-execution-ledger-20260725.md
+++ b/docs/development/dingtalk-directory-corp-scope-execution-ledger-20260725.md
@@ -84,14 +84,15 @@ constraints/indexes but intentionally does not reverse already-canonicalized dat
 
 Local PostgreSQL 15 evidence:
 
-- combined Phase A compatibility plus isolated Phase B migration suite: 30/30;
+- pre-Phase-B and fully migrated Phase-B public-schema runs of the combined compatibility plus
+  isolated migration suite: 32/32 in each state;
 - fresh full Migrator reaches `zzzz20260725130000_expand_directory_identity_corp_scope`, and replay
   has no pending migration;
 - lock contention aborts after about 5.2 seconds while retaining the legacy guard;
 - synthetic scale sample (10 integrations, 100,000 accounts, 200,000 identities): 3,158 ms in one
   transaction, nine resulting indexes, three CHECKs, zero NULL account corp values;
-- seven Phase B mutations killed, including expression-index disguise, parent-provider drift, and
-  Unicode-whitespace acceptance;
+- ten Phase B mutations killed, including expression/`INCLUDE` index disguises, weaker same-name
+  CHECK acceptance, phase-detection drift, parent-provider drift, and Unicode-whitespace acceptance;
 - TypeScript and diff checks clean.
 
 The scale sample is a local engineering bound, not a production latency or availability promise.
@@ -110,6 +111,8 @@ Phase A lands.
 | expression key disappeared from the catalog column list | reject expressions and require exact key/total attribute counts |
 | child provider could drift from its parent integration | fail the migration before any backfill |
 | BTRIM and JavaScript trim accepted different whitespace sets | printable-ASCII token grammar in runtime and database |
+| Phase A compatibility fixtures became illegal after Phase B | keep one two-stage suite: runtime repair before Phase B, stronger DB rejection after Phase B, zero skips |
+| key-column catalog projection also included `INCLUDE` attributes | restrict the projection to `indnkeyatts` and pin total attributes with an independent mutation |
 | ordinary index creation could wait without bound | transaction-local 5-second lock timeout plus real contention test |
 | down appeared to imply data restoration | explicitly document and test irreversible canonicalization |
 

--- a/docs/development/dingtalk-directory-corp-scope-execution-ledger-20260725.md
+++ b/docs/development/dingtalk-directory-corp-scope-execution-ledger-20260725.md
@@ -129,6 +129,7 @@ until the stacked PR is retargeted after Phase A lands.
 | SQL three-value logic let NULL parent corp evade `!~` | require the parent column to remain `NOT NULL`, count NULL explicitly, and pin both preflight and migration refusals |
 | required CI only exercised CLI `ERROR/1` | execute `PASS/0` and `BLOCKED/2` through subprocesses in the required real-DB file |
 | exact-head CI found the callback `delivery_corp_unresolved` fixture still inserted a blank DingTalk corp that Phase B correctly rejects | preserve the canonical corp CHECK; construct the same fail-closed callback outcome with a valid-corp non-DingTalk integration, update the stale resolver comment, and run the migration plus callback suites 60/60 |
+| the approval real-DB lane still modeled a legacy empty integration corp as insertable after Phase B | make the immutability golden phase-aware: retain the generic-update refusal before Phase B, require the named canonical-corp CHECK and zero residue after Phase B, and run 5/5 in both schema states |
 
 ## 6. Remaining owner gates
 

--- a/docs/development/dingtalk-directory-corp-scope-execution-ledger-20260725.md
+++ b/docs/development/dingtalk-directory-corp-scope-execution-ledger-20260725.md
@@ -1,6 +1,6 @@
 # DingTalk directory corp-scope execution ledger
 
-Status: IMPLEMENTED / REVIEW PENDING
+Status: IMPLEMENTED / INDEPENDENT REVIEW APPROVED / OWNER REVIEW PENDING
 
 Date: 2026-07-25
 
@@ -46,10 +46,10 @@ Completed:
 Local verification at the final Phase A implementation worktree:
 
 - focused unit: 43/43;
-- focused PostgreSQL 15: 55/55;
+- focused PostgreSQL 15: 63/63;
 - required attendance directory/user-org real-DB regressions: 14/14;
 - CI placement/values-free contracts: 82/82;
-- nine discriminating mutations killed;
+- ten discriminating mutations killed;
 - TypeScript and diff checks clean.
 
 The first CI run found five old admission tests whose fake transaction clients did not model the
@@ -75,7 +75,11 @@ Completed:
 9. recreate and verify the global guard before down removes scoped protection;
 10. preserve scoped protection when down is data-incompatible;
 11. bound migration lock waiting to 5 seconds and statements to 5 minutes, restoring the caller's
-    prior settings after successful up/down.
+    prior settings after successful up/down;
+12. add a values-free, read-only Phase B preflight that projects the migration's corp
+    canonicalization and rejects a nullable parent-corp column, schema drift,
+    orphan/provider-drift accounts, invalid corp shapes, and every scoped identity duplicate
+    class before the migration window.
 
 Kysely 0.28 supplies one transaction for all pending PostgreSQL migrations; this migration does
 not open a nested transaction. The scoped settings are transaction-local. Failure rolls back the
@@ -84,20 +88,25 @@ constraints/indexes but intentionally does not reverse already-canonicalized dat
 
 Local PostgreSQL 15 evidence:
 
-- pre-Phase-B and fully migrated Phase-B public-schema runs of the combined compatibility plus
-  isolated migration suite: 32/32 in each state;
+- pre-Phase-B and fully migrated Phase-B public-schema runs of the combined compatibility,
+  preflight, plus isolated migration suite: 40/40 in each state;
+- fully migrated PostgreSQL 14.23 runs the same combined suite 40/40 locally;
+- CLI rehearsal on an isolated PostgreSQL 15 database: `PASS` exits `0`, a projected scoped
+  duplicate exits `2` as `BLOCKED`, and missing `DATABASE_URL` exits `1` with a values-free error;
 - fresh full Migrator reaches `zzzz20260725130000_expand_directory_identity_corp_scope`, and replay
   has no pending migration;
 - lock contention aborts after about 5.2 seconds while retaining the legacy guard;
 - synthetic scale sample (10 integrations, 100,000 accounts, 200,000 identities): 3,158 ms in one
   transaction, nine resulting indexes, three CHECKs, zero NULL account corp values;
-- ten Phase B mutations killed, including expression/`INCLUDE` index disguises, weaker same-name
-  CHECK acceptance, phase-detection drift, parent-provider drift, and Unicode-whitespace acceptance;
+- seventeen Phase B mutations killed, including expression/`INCLUDE` index disguises, weaker
+  same-name CHECK acceptance, phase-detection drift, parent-provider drift, Unicode-whitespace
+  acceptance, read-only transaction enforcement, projected duplicate detection, partial-schema
+  detection, nullable parent-corp schema/data checks, and CLI exit-code mapping;
 - TypeScript and diff checks clean.
 
 The scale sample is a local engineering bound, not a production latency or availability promise.
-PostgreSQL 14 remains unclaimed until the stacked PR is retargeted and required CI executes after
-Phase A lands.
+Local PostgreSQL 14 compatibility is established, but required PostgreSQL 14 CI remains unclaimed
+until the stacked PR is retargeted after Phase A lands.
 
 ## 5. Incident and correction ledger
 
@@ -115,6 +124,10 @@ Phase A lands.
 | key-column catalog projection also included `INCLUDE` attributes | restrict the projection to `indnkeyatts` and pin total attributes with an independent mutation |
 | ordinary index creation could wait without bound | transaction-local 5-second lock timeout plus real contention test |
 | down appeared to imply data restoration | explicitly document and test irreversible canonicalization |
+| row-count guidance did not prove a migration would accept staging data | add the read-only projected preflight and make `0 / PASS` an explicit deployment gate |
+| function tests missed a CLI top-level-await load failure | remove top-level await and add a required subprocess startup/error-contract test |
+| SQL three-value logic let NULL parent corp evade `!~` | require the parent column to remain `NOT NULL`, count NULL explicitly, and pin both preflight and migration refusals |
+| required CI only exercised CLI `ERROR/1` | execute `PASS/0` and `BLOCKED/2` through subprocesses in the required real-DB file |
 
 ## 6. Remaining owner gates
 
@@ -122,8 +135,9 @@ Phase A lands.
 2. review Phase B as a stacked contract;
 3. merge/deploy Phase A;
 4. prove old-worker count is zero;
-5. merge/deploy Phase B in a controlled migration window;
-6. execute the staging UAT;
-7. bind only the authorized account to the existing MetaSheet user;
-8. verify the same-corp approval callback;
-9. decide any later automatic-sync/deprovision/flag changes separately.
+5. run the values-free read-only preflight and require exit `0` / `PASS`;
+6. merge/deploy Phase B in a controlled migration window;
+7. execute the staging UAT;
+8. bind only the authorized account to the existing MetaSheet user;
+9. verify the same-corp approval callback;
+10. decide any later automatic-sync/deprovision/flag changes separately.

--- a/docs/development/dingtalk-directory-corp-scope-staging-uat-20260725.md
+++ b/docs/development/dingtalk-directory-corp-scope-staging-uat-20260725.md
@@ -19,27 +19,62 @@ Run this owner/ops gate before UAT:
 
 4. Verify the staging topology has no alternate backend upstream outside the managed Compose
    `backend` service and the fixed loopback publish `127.0.0.1:18900`.
-5. Hold an exclusive host change window. Merge/deploy/verify Phase B migration before releasing
+5. Run the Phase B values-free preflight immediately before the controlled migration and require
+   exit code `0` with status `PASS`.
+6. Hold an exclusive host change window. Merge/deploy/verify Phase B migration before releasing
    it.
-6. If any privileged Docker/Compose or ingress change occurs after the PASS and before migration
+7. If any privileged Docker/Compose or ingress change occurs after the PASS and before migration
    completion, invalidate the evidence and repeat from step 3.
 
 Do not re-deploy Phase A after Phase B migration. The PASS is point-in-time evidence for the
 cutover, not a durable host lock or a claim about unrelated host processes.
 
-## 2. UAT entry criteria
+## 2. Phase B preflight
+
+Run this after Phase A is deployed to every worker and the old-worker count is zero, but before
+applying the Phase B migration:
+
+```bash
+DATABASE_URL="$STAGING_DATABASE_URL" \
+  pnpm --silent --filter @metasheet/core-backend \
+  preflight:dingtalk-directory-corp-scope \
+  > artifacts/dingtalk-directory-corp-scope-preflight.json
+```
+
+The preflight opens a `REPEATABLE READ READ ONLY` transaction. Its JSON contains only schema
+booleans, counts, and stable blocker codes; it does not return corp IDs, provider identity values,
+account keys, credentials, or the database URL.
+
+Exit codes:
+
+- `0`: `PASS`; retain the JSON evidence and continue to the controlled migration window.
+- `2`: `BLOCKED`; do not migrate. Resolve the reported data/schema class under a separately
+  reviewed repair plan, then rerun the preflight.
+- `1`: `ERROR`; read-only execution was not verified or the query could not complete. Do not
+  migrate and do not infer safety from an empty/missing report.
+
+`PASS` requires the exact legacy global index, a `NOT NULL` parent-integration corp column, no
+Phase B replacement index/CHECK already present, canonicalizable parent integration scope, no
+orphan/provider-drift account, canonicalizable identity corp, and no duplicate group that a
+Phase B scoped identity index would reject.
+
+Never paste the database URL or query raw offending values for this evidence. The report is a
+deployment gate, not a repair tool and not proof that old workers were drained.
+
+## 3. UAT entry criteria
 
 Do not start the UAT procedure until all conditions are true:
 
 1. The saved pre-UAT cutover evidence above is complete.
-2. Phase B schema migration is deployed and verified on staging.
-3. Automatic directory sync and directory deprovision remain disabled.
-4. The owner has authorized one manual sync and binding to one existing MetaSheet user.
-5. Two real DingTalk enterprises and one overlap person are available.
+2. The retained Phase B preflight report records exit code `0`, status `PASS`, and zero blockers.
+3. Phase B schema migration is deployed and verified on staging.
+4. Automatic directory sync and directory deprovision remain disabled.
+5. The owner has authorized one manual sync and binding to one existing MetaSheet user.
+6. Two real DingTalk enterprises and one overlap person are available.
 
 Stop if any criterion is unproven. Do not infer rollout completion from a successful migration.
 
-## 3. Values-free evidence
+## 4. Values-free evidence
 
 Record identifiers only as redacted labels (`integration-A`, `integration-B`, `user-existing`).
 Do not paste credentials, corp IDs, unionId/openId/userId values, raw SQL errors, card payloads,
@@ -52,36 +87,40 @@ Allowed evidence:
 - the values-free `WORKER_DRAIN_GATE_PASS` summary;
 - managed-project and staging-ingress worker counts;
 - whether an alternate staging backend upstream exists;
+- the complete values-free preflight JSON and exit code;
 - sync run status and values-free reason code;
 - row counts grouped by redacted integration label;
 - link status and match strategy;
 - callback outcome/reason and approval record count;
 - whether all runtime flags and schedules stayed unchanged.
 
-## 4. UAT procedure
+## 5. UAT procedure
 
-1. Capture the saved cutover PASS, exact Phase A SHA, Phase B migration ledger, private image
-   provenance reference, topology result, and relevant flag states. Do not run the Phase A deploy
-   again.
-2. Run one manual sync for integration A.
-3. Run one manual sync for integration B.
-4. Confirm both runs complete and each integration retains its own departments/accounts.
-5. Confirm the overlap account exists once under each integration even when provider identity
+1. Capture the saved cutover PASS, exact Phase A SHA, Phase B preflight report/exit code, Phase B
+   migration ledger, private image provenance reference, topology result, and relevant flag
+   states. Do not run the Phase A deploy again.
+2. Confirm no old worker remains.
+3. Run one manual sync for integration A.
+4. Run one manual sync for integration B.
+5. Confirm both runs complete and each integration retains its own departments/accounts.
+6. Confirm the overlap account exists once under each integration even when provider identity
    values are equal.
-6. Confirm neither account is automatically linked to the other enterprise's local user.
-7. Bind only the authorized target account to the existing MetaSheet user.
-8. Confirm bind/unbind conflict checks do not modify the other enterprise's identity row.
-9. Send a fresh approval card for the bound integration and click one decision.
-10. Confirm the callback resolves through the same integration and corp, writes one approval
+7. Confirm neither account is automatically linked to the other enterprise's local user.
+8. Bind only the authorized target account to the existing MetaSheet user.
+9. Confirm bind/unbind conflict checks do not modify the other enterprise's identity row.
+10. Send a fresh approval card for the bound integration and click one decision.
+11. Confirm the callback resolves through the same integration and corp, writes one approval
     action, and leaves the other integration untouched.
-11. Confirm no new MetaSheet user was created and no schedule/deprovision/flag changed.
+12. Confirm no new MetaSheet user was created and no schedule/deprovision/flag changed.
 
-## 5. Fail-closed outcomes
+## 6. Fail-closed outcomes
 
 Stop and do not retry automatically when:
 
 - the managed project has another backend, the fixed staging ingress resolves to another
   container, or an alternate staging backend upstream exists;
+- any old worker remains;
+- the preflight status is not `PASS`, its exit code is not `0`, or its JSON cannot be retained;
 - migration/index verification fails;
 - either manual sync fails or rolls back;
 - identity matching is ambiguous;
@@ -91,12 +130,14 @@ Stop and do not retry automatically when:
 
 Retain values-free evidence and return to code review. Do not repair staging data ad hoc.
 
-## 6. Evidence block
+## 7. Evidence block
 
 ```text
 Phase A deployment SHA:                 TBD
 Phase A image provenance schema:        TBD
 worker-drain gate summary:              TBD (must be WORKER_DRAIN_GATE_PASS)
+Phase B preflight exit/status:          TBD (must be 0 / PASS)
+Phase B preflight blocker count:        TBD (must be 0)
 Phase B migration SHA:                  TBD
 managed-project old worker count:       TBD (must be 0)
 staging-ingress unmanaged worker count: TBD (must be 0)

--- a/packages/core-backend/package.json
+++ b/packages/core-backend/package.json
@@ -17,6 +17,7 @@
     "db:rollback": "tsx src/db/migrate.ts --rollback",
     "seed:demo": "echo 'Seeding demo data...' && exit 0",
     "seed:rbac": "tsx scripts/seed-rbac.ts",
+    "preflight:dingtalk-directory-corp-scope": "tsx scripts/dingtalk-directory-corp-scope-preflight.ts",
     "smoke:plugins": "tsx scripts/smoke-plugins.ts",
     "smoke:sqlserver": "tsx scripts/smoke-sqlserver.ts",
     "smoke:sqlserver:seed": "tsx scripts/smoke-sqlserver-seed.ts",

--- a/packages/core-backend/scripts/dingtalk-directory-corp-scope-preflight.ts
+++ b/packages/core-backend/scripts/dingtalk-directory-corp-scope-preflight.ts
@@ -1,0 +1,430 @@
+#!/usr/bin/env tsx
+
+import path from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+import { Pool, type PoolClient } from 'pg'
+
+const OPERATION = 'dingtalk_directory_corp_scope_phase_b_preflight'
+const DEFAULT_CONNECTION_TIMEOUT_MS = 10_000
+const DEFAULT_STATEMENT_TIMEOUT_MS = 30_000
+const LEGACY_INDEX = 'idx_directory_accounts_provider_external_key'
+const SCOPED_INDEXES = [
+  'idx_directory_accounts_provider_corp_external_key',
+  'idx_directory_accounts_provider_null_corp_external_key',
+  'idx_user_external_identities_provider_corp_union',
+  'idx_user_external_identities_provider_null_corp_union',
+  'idx_user_external_identities_provider_corp_open',
+  'idx_user_external_identities_provider_null_corp_open',
+] as const
+const CORP_CHECKS = [
+  'directory_integrations_corp_id_canonical',
+  'directory_accounts_corp_id_canonical',
+  'user_external_identities_corp_id_canonical',
+] as const
+
+type CountText = string
+
+type PreflightCounts = {
+  integrations: CountText
+  accounts: CountText
+  identities: CountText
+  invalidIntegrationScope: CountText
+  orphanAccounts: CountText
+  accountProviderDrift: CountText
+  invalidIdentityCorp: CountText
+  duplicateAccountScopeGroups: CountText
+  duplicateCorpUnionGroups: CountText
+  duplicateNullCorpUnionGroups: CountText
+  duplicateCorpOpenGroups: CountText
+  duplicateNullCorpOpenGroups: CountText
+}
+
+export type DirectoryCorpScopePreflightReport = {
+  operation: typeof OPERATION
+  version: 1
+  status: 'PASS' | 'BLOCKED'
+  valuesFree: true
+  readOnly: true
+  schema: {
+    requiredTablesPresent: boolean
+    integrationCorpNotNull: boolean
+    legacyIndexExact: boolean
+    scopedIndexCount: CountText
+    corpCheckCount: CountText
+  }
+  counts: PreflightCounts
+  blockers: string[]
+}
+
+type Queryable = Pick<PoolClient, 'query'>
+type Connectable = Pick<Pool, 'connect'>
+
+type SchemaRow = {
+  required_tables_present: boolean
+  integration_corp_not_null: boolean
+  legacy_index_exact: boolean
+  scoped_index_count: CountText
+  corp_check_count: CountText
+}
+
+const ZERO_COUNTS: PreflightCounts = {
+  integrations: '0',
+  accounts: '0',
+  identities: '0',
+  invalidIntegrationScope: '0',
+  orphanAccounts: '0',
+  accountProviderDrift: '0',
+  invalidIdentityCorp: '0',
+  duplicateAccountScopeGroups: '0',
+  duplicateCorpUnionGroups: '0',
+  duplicateNullCorpUnionGroups: '0',
+  duplicateCorpOpenGroups: '0',
+  duplicateNullCorpOpenGroups: '0',
+}
+
+function requireCount(value: unknown): CountText {
+  if (typeof value !== 'string' || !/^(0|[1-9]\d*)$/.test(value)) {
+    throw new Error('PREFLIGHT_COUNT_INVALID')
+  }
+  return value
+}
+
+function nonZero(value: CountText): boolean {
+  return value !== '0'
+}
+
+async function readSchema(db: Queryable): Promise<SchemaRow> {
+  const result = await db.query<SchemaRow>(
+    `
+      WITH required_tables AS (
+        SELECT count(*)::int AS present
+          FROM (VALUES
+            ('directory_integrations'),
+            ('directory_accounts'),
+            ('user_external_identities')
+          ) AS required(table_name)
+         WHERE to_regclass(required.table_name) IS NOT NULL
+      ),
+      legacy_shape AS (
+        SELECT
+          count(*) = 1
+          AND bool_and(index_row.indisunique)
+          AND bool_and(index_row.indisvalid)
+          AND bool_and(index_row.indexprs IS NULL)
+          AND bool_and(index_row.indpred IS NULL)
+          AND bool_and(index_row.indnkeyatts = 2)
+          AND bool_and(index_row.indnatts = 2)
+          AND bool_and(ARRAY(
+            SELECT attribute.attname
+              FROM unnest(index_row.indkey) WITH ORDINALITY AS key(attnum, position)
+              JOIN pg_attribute attribute
+                ON attribute.attrelid = table_row.oid
+               AND attribute.attnum = key.attnum
+             WHERE key.position <= index_row.indnkeyatts
+             ORDER BY key.position
+          )::text[] = ARRAY['provider', 'external_key']::text[]) AS exact
+          FROM pg_class index_class
+          JOIN pg_index index_row ON index_row.indexrelid = index_class.oid
+          JOIN pg_class table_row ON table_row.oid = index_row.indrelid
+          JOIN pg_namespace namespace ON namespace.oid = table_row.relnamespace
+         WHERE namespace.nspname = current_schema()
+           AND index_class.relname = $1
+           AND table_row.relname = 'directory_accounts'
+      )
+      SELECT
+        required_tables.present = 3 AS required_tables_present,
+        COALESCE((
+          SELECT attribute.attnotnull
+            FROM pg_attribute attribute
+            JOIN pg_class table_row ON table_row.oid = attribute.attrelid
+            JOIN pg_namespace namespace ON namespace.oid = table_row.relnamespace
+           WHERE namespace.nspname = current_schema()
+             AND table_row.relname = 'directory_integrations'
+             AND attribute.attname = 'corp_id'
+             AND attribute.attnum > 0
+             AND NOT attribute.attisdropped
+        ), false) AS integration_corp_not_null,
+        COALESCE(legacy_shape.exact, false) AS legacy_index_exact,
+        (
+          SELECT count(*)::text
+            FROM pg_class index_class
+            JOIN pg_namespace namespace ON namespace.oid = index_class.relnamespace
+           WHERE namespace.nspname = current_schema()
+             AND index_class.relkind = 'i'
+             AND index_class.relname = ANY($2::text[])
+        ) AS scoped_index_count,
+        (
+          SELECT count(*)::text
+            FROM pg_constraint constraint_row
+            JOIN pg_class table_row ON table_row.oid = constraint_row.conrelid
+            JOIN pg_namespace namespace ON namespace.oid = table_row.relnamespace
+           WHERE namespace.nspname = current_schema()
+             AND constraint_row.contype = 'c'
+             AND constraint_row.conname = ANY($3::text[])
+        ) AS corp_check_count
+        FROM required_tables
+        CROSS JOIN legacy_shape
+    `,
+    [LEGACY_INDEX, [...SCOPED_INDEXES], [...CORP_CHECKS]],
+  )
+  const row = result.rows[0]
+  if (!row) throw new Error('PREFLIGHT_SCHEMA_QUERY_EMPTY')
+  return {
+    required_tables_present: row.required_tables_present === true,
+    integration_corp_not_null: row.integration_corp_not_null === true,
+    legacy_index_exact: row.legacy_index_exact === true,
+    scoped_index_count: requireCount(row.scoped_index_count),
+    corp_check_count: requireCount(row.corp_check_count),
+  }
+}
+
+async function readCounts(db: Queryable): Promise<PreflightCounts> {
+  const result = await db.query<Record<string, unknown>>(
+    `
+      WITH projected_accounts AS (
+        SELECT
+          account.provider,
+          BTRIM(integration.corp_id) AS corp_id,
+          account.external_key
+          FROM directory_accounts account
+          JOIN directory_integrations integration ON integration.id = account.integration_id
+      ),
+      projected_identities AS (
+        SELECT
+          provider,
+          NULLIF(BTRIM(corp_id), '') AS corp_id,
+          provider_union_id,
+          provider_open_id
+          FROM user_external_identities
+      )
+      SELECT
+        (SELECT count(*)::text FROM directory_integrations) AS integrations,
+        (SELECT count(*)::text FROM directory_accounts) AS accounts,
+        (SELECT count(*)::text FROM user_external_identities) AS identities,
+        (
+          SELECT count(*)::text
+            FROM directory_integrations
+           WHERE provider IS NULL
+              OR provider = ''
+              OR corp_id IS NULL
+              OR BTRIM(corp_id) !~ '^[!-~]+$'
+        ) AS "invalidIntegrationScope",
+        (
+          SELECT count(*)::text
+            FROM directory_accounts account
+            LEFT JOIN directory_integrations integration ON integration.id = account.integration_id
+           WHERE integration.id IS NULL
+        ) AS "orphanAccounts",
+        (
+          SELECT count(*)::text
+            FROM directory_accounts account
+            JOIN directory_integrations integration ON integration.id = account.integration_id
+           WHERE account.provider IS DISTINCT FROM integration.provider
+        ) AS "accountProviderDrift",
+        (
+          SELECT count(*)::text
+            FROM projected_identities
+           WHERE corp_id IS NOT NULL
+             AND corp_id !~ '^[!-~]+$'
+        ) AS "invalidIdentityCorp",
+        (
+          SELECT count(*)::text
+            FROM (
+              SELECT provider, corp_id, external_key
+                FROM projected_accounts
+               WHERE corp_id IS NOT NULL
+               GROUP BY provider, corp_id, external_key
+              HAVING count(*) > 1
+            ) duplicate_groups
+        ) AS "duplicateAccountScopeGroups",
+        (
+          SELECT count(*)::text
+            FROM (
+              SELECT provider, corp_id, provider_union_id
+                FROM projected_identities
+               WHERE corp_id IS NOT NULL AND provider_union_id IS NOT NULL
+               GROUP BY provider, corp_id, provider_union_id
+              HAVING count(*) > 1
+            ) duplicate_groups
+        ) AS "duplicateCorpUnionGroups",
+        (
+          SELECT count(*)::text
+            FROM (
+              SELECT provider, provider_union_id
+                FROM projected_identities
+               WHERE corp_id IS NULL AND provider_union_id IS NOT NULL
+               GROUP BY provider, provider_union_id
+              HAVING count(*) > 1
+            ) duplicate_groups
+        ) AS "duplicateNullCorpUnionGroups",
+        (
+          SELECT count(*)::text
+            FROM (
+              SELECT provider, corp_id, provider_open_id
+                FROM projected_identities
+               WHERE corp_id IS NOT NULL AND provider_open_id IS NOT NULL
+               GROUP BY provider, corp_id, provider_open_id
+              HAVING count(*) > 1
+            ) duplicate_groups
+        ) AS "duplicateCorpOpenGroups",
+        (
+          SELECT count(*)::text
+            FROM (
+              SELECT provider, provider_open_id
+                FROM projected_identities
+               WHERE corp_id IS NULL AND provider_open_id IS NOT NULL
+               GROUP BY provider, provider_open_id
+              HAVING count(*) > 1
+            ) duplicate_groups
+        ) AS "duplicateNullCorpOpenGroups"
+    `,
+  )
+  const row = result.rows[0]
+  if (!row) throw new Error('PREFLIGHT_COUNT_QUERY_EMPTY')
+  return Object.fromEntries(
+    Object.keys(ZERO_COUNTS).map((key) => [key, requireCount(row[key])]),
+  ) as PreflightCounts
+}
+
+async function collectDirectoryCorpScopePreflight(
+  db: Queryable,
+): Promise<DirectoryCorpScopePreflightReport> {
+  const schema = await readSchema(db)
+  const counts = schema.required_tables_present ? await readCounts(db) : { ...ZERO_COUNTS }
+  const blockers: string[] = []
+
+  if (!schema.required_tables_present) blockers.push('required_tables_missing')
+  if (!schema.integration_corp_not_null) blockers.push('integration_corp_not_null_missing')
+  if (!schema.legacy_index_exact) blockers.push('legacy_index_not_exact')
+  if (nonZero(schema.scoped_index_count)) blockers.push('scoped_indexes_already_present')
+  if (nonZero(schema.corp_check_count)) blockers.push('corp_checks_already_present')
+  for (const [key, value] of Object.entries(counts)) {
+    if (
+      key !== 'integrations'
+      && key !== 'accounts'
+      && key !== 'identities'
+      && nonZero(value)
+    ) {
+      blockers.push(key)
+    }
+  }
+
+  return {
+    operation: OPERATION,
+    version: 1,
+    status: blockers.length === 0 ? 'PASS' : 'BLOCKED',
+    valuesFree: true,
+    readOnly: true,
+    schema: {
+      requiredTablesPresent: schema.required_tables_present,
+      integrationCorpNotNull: schema.integration_corp_not_null,
+      legacyIndexExact: schema.legacy_index_exact,
+      scopedIndexCount: schema.scoped_index_count,
+      corpCheckCount: schema.corp_check_count,
+    },
+    counts,
+    blockers,
+  }
+}
+
+export async function runDirectoryCorpScopePreflight(
+  pool: Connectable,
+  statementTimeoutMs = DEFAULT_STATEMENT_TIMEOUT_MS,
+): Promise<DirectoryCorpScopePreflightReport> {
+  if (!Number.isSafeInteger(statementTimeoutMs) || statementTimeoutMs < 1_000 || statementTimeoutMs > 300_000) {
+    throw new Error('PREFLIGHT_STATEMENT_TIMEOUT_INVALID')
+  }
+  const client = await pool.connect()
+  try {
+    await client.query('BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY')
+    await client.query(`SET LOCAL statement_timeout = '${statementTimeoutMs}ms'`)
+    const readOnly = await client.query<{ transaction_read_only: string }>(
+      'SHOW transaction_read_only',
+    )
+    if (readOnly.rows[0]?.transaction_read_only !== 'on') {
+      throw new Error('PREFLIGHT_TRANSACTION_NOT_READ_ONLY')
+    }
+    const report = await collectDirectoryCorpScopePreflight(client)
+    await client.query('ROLLBACK')
+    return report
+  } catch (error) {
+    await client.query('ROLLBACK').catch(() => undefined)
+    throw error
+  } finally {
+    client.release()
+  }
+}
+
+function parseStatementTimeout(argv: string[]): number {
+  if (argv.length === 0) return DEFAULT_STATEMENT_TIMEOUT_MS
+  if (argv.length !== 2 || argv[0] !== '--statement-timeout-ms') {
+    throw new Error('PREFLIGHT_ARGUMENT_INVALID')
+  }
+  const value = Number(argv[1])
+  if (!Number.isSafeInteger(value)) throw new Error('PREFLIGHT_ARGUMENT_INVALID')
+  return value
+}
+
+function valuesFreeFailure(code: string) {
+  return {
+    operation: OPERATION,
+    version: 1,
+    status: 'ERROR',
+    valuesFree: true,
+    readOnlyVerified: false,
+    code,
+  }
+}
+
+async function main(): Promise<void> {
+  const databaseUrl = process.env.DATABASE_URL
+  if (!databaseUrl) {
+    console.log(JSON.stringify(valuesFreeFailure('PREFLIGHT_DATABASE_URL_REQUIRED')))
+    process.exitCode = 1
+    return
+  }
+
+  let timeoutMs: number
+  try {
+    timeoutMs = parseStatementTimeout(process.argv.slice(2))
+  } catch {
+    console.log(JSON.stringify(valuesFreeFailure('PREFLIGHT_ARGUMENT_INVALID')))
+    process.exitCode = 1
+    return
+  }
+
+  const pool = new Pool({
+    connectionString: databaseUrl,
+    application_name: OPERATION,
+    connectionTimeoutMillis: DEFAULT_CONNECTION_TIMEOUT_MS,
+    max: 1,
+  })
+  let output: DirectoryCorpScopePreflightReport | ReturnType<typeof valuesFreeFailure>
+  let exitCode: 0 | 1 | 2
+  try {
+    const report = await runDirectoryCorpScopePreflight(pool, timeoutMs)
+    output = report
+    exitCode = report.status === 'PASS' ? 0 : 2
+  } catch {
+    output = valuesFreeFailure('PREFLIGHT_QUERY_FAILED')
+    exitCode = 1
+  } finally {
+    try {
+      await pool.end()
+    } catch {
+      output = valuesFreeFailure('PREFLIGHT_POOL_CLOSE_FAILED')
+      exitCode = 1
+    }
+  }
+  console.log(JSON.stringify(output, null, 2))
+  process.exitCode = exitCode
+}
+
+const invokedPath = process.argv[1] ? path.resolve(process.argv[1]) : ''
+if (invokedPath && pathToFileURL(invokedPath).href === import.meta.url) {
+  void main().catch(() => {
+    console.log(JSON.stringify(valuesFreeFailure('PREFLIGHT_UNEXPECTED_FAILURE')))
+    process.exitCode = 1
+  })
+}

--- a/packages/core-backend/src/db/migrations/zzzz20260725130000_expand_directory_identity_corp_scope.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260725130000_expand_directory_identity_corp_scope.ts
@@ -103,6 +103,7 @@ async function readIndexShape(db: Kysely<unknown>, shape: IndexShape): Promise<I
           JOIN pg_attribute attr
             ON attr.attrelid = table_rel.oid
            AND attr.attnum = key.attnum
+         WHERE key.position <= idx.indnkeyatts
          ORDER BY key.position
       )::text[] AS columns,
       pg_get_expr(idx.indpred, idx.indrelid) AS predicate

--- a/packages/core-backend/src/db/migrations/zzzz20260725130000_expand_directory_identity_corp_scope.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260725130000_expand_directory_identity_corp_scope.ts
@@ -232,7 +232,8 @@ async function assertAuthoritativeDirectoryScope(db: Kysely<unknown>): Promise<v
   const invalidIntegrations = await sql<{ count: string }>`
     SELECT COUNT(*)::text AS count
       FROM directory_integrations
-     WHERE corp_id !~ '^[!-~]+$'
+     WHERE corp_id IS NULL
+        OR corp_id !~ '^[!-~]+$'
         OR provider IS NULL
         OR provider = ''
   `.execute(db)
@@ -245,6 +246,7 @@ async function assertAuthoritativeDirectoryScope(db: Kysely<unknown>): Promise<v
       FROM directory_accounts account
       JOIN directory_integrations integration ON integration.id = account.integration_id
      WHERE account.provider IS DISTINCT FROM integration.provider
+        OR integration.corp_id IS NULL
         OR integration.corp_id !~ '^[!-~]+$'
   `.execute(db)
   if (result.rows[0]?.count !== '0') {
@@ -252,7 +254,27 @@ async function assertAuthoritativeDirectoryScope(db: Kysely<unknown>): Promise<v
   }
 }
 
+async function assertIntegrationCorpColumnNotNull(db: Kysely<unknown>): Promise<void> {
+  const result = await sql<{ is_not_null: boolean }>`
+    SELECT attribute.attnotnull AS is_not_null
+      FROM pg_attribute attribute
+      JOIN pg_class table_row ON table_row.oid = attribute.attrelid
+      JOIN pg_namespace namespace ON namespace.oid = table_row.relnamespace
+     WHERE namespace.nspname = current_schema()
+       AND table_row.relname = 'directory_integrations'
+       AND attribute.attname = 'corp_id'
+       AND attribute.attnum > 0
+       AND NOT attribute.attisdropped
+  `.execute(db)
+  if (result.rows[0]?.is_not_null !== true) {
+    throw new Error(
+      'directory corp-scope migration blocked: integration corp column must be NOT NULL',
+    )
+  }
+}
+
 async function canonicalizeCorpScope(db: Kysely<unknown>): Promise<void> {
+  await assertIntegrationCorpColumnNotNull(db)
   await sql`
     UPDATE directory_integrations
        SET corp_id = BTRIM(corp_id)

--- a/packages/core-backend/src/db/migrations/zzzz20260725130000_expand_directory_identity_corp_scope.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260725130000_expand_directory_identity_corp_scope.ts
@@ -1,0 +1,390 @@
+import type { Kysely } from 'kysely'
+import { sql } from 'kysely'
+
+const ACCOUNT_LEGACY_INDEX = 'idx_directory_accounts_provider_external_key'
+const ACCOUNT_CORP_INDEX = 'idx_directory_accounts_provider_corp_external_key'
+const ACCOUNT_NULL_CORP_INDEX = 'idx_directory_accounts_provider_null_corp_external_key'
+const IDENTITY_CORP_UNION_INDEX = 'idx_user_external_identities_provider_corp_union'
+const IDENTITY_NULL_CORP_UNION_INDEX = 'idx_user_external_identities_provider_null_corp_union'
+const IDENTITY_CORP_OPEN_INDEX = 'idx_user_external_identities_provider_corp_open'
+const IDENTITY_NULL_CORP_OPEN_INDEX = 'idx_user_external_identities_provider_null_corp_open'
+const INTEGRATION_CORP_SHAPE_CHECK = 'directory_integrations_corp_id_canonical'
+const ACCOUNT_CORP_SHAPE_CHECK = 'directory_accounts_corp_id_canonical'
+const IDENTITY_CORP_SHAPE_CHECK = 'user_external_identities_corp_id_canonical'
+const REQUIRED_CORP_SHAPE_DEFINITION = "CHECK ((corp_id ~ '^[!-~]+$'))"
+const OPTIONAL_CORP_SHAPE_DEFINITION =
+  "CHECK (((corp_id IS NULL) OR (corp_id ~ '^[!-~]+$')))"
+const MIGRATION_LOCK_TIMEOUT = '5s'
+const MIGRATION_STATEMENT_TIMEOUT = '5min'
+
+type IndexShape = {
+  name: string
+  table: string
+  columns: string[]
+  predicate: string | null
+}
+
+const ACCOUNT_LEGACY_SHAPE: IndexShape = {
+  name: ACCOUNT_LEGACY_INDEX,
+  table: 'directory_accounts',
+  columns: ['provider', 'external_key'],
+  predicate: null,
+}
+const INDEX_SHAPES: IndexShape[] = [
+  {
+    name: ACCOUNT_CORP_INDEX,
+    table: 'directory_accounts',
+    columns: ['provider', 'corp_id', 'external_key'],
+    predicate: '(corp_id is not null)',
+  },
+  {
+    name: ACCOUNT_NULL_CORP_INDEX,
+    table: 'directory_accounts',
+    columns: ['provider', 'external_key'],
+    predicate: '(corp_id is null)',
+  },
+  {
+    name: IDENTITY_CORP_UNION_INDEX,
+    table: 'user_external_identities',
+    columns: ['provider', 'corp_id', 'provider_union_id'],
+    predicate: '((corp_id is not null) and (provider_union_id is not null))',
+  },
+  {
+    name: IDENTITY_NULL_CORP_UNION_INDEX,
+    table: 'user_external_identities',
+    columns: ['provider', 'provider_union_id'],
+    predicate: '((corp_id is null) and (provider_union_id is not null))',
+  },
+  {
+    name: IDENTITY_CORP_OPEN_INDEX,
+    table: 'user_external_identities',
+    columns: ['provider', 'corp_id', 'provider_open_id'],
+    predicate: '((corp_id is not null) and (provider_open_id is not null))',
+  },
+  {
+    name: IDENTITY_NULL_CORP_OPEN_INDEX,
+    table: 'user_external_identities',
+    columns: ['provider', 'provider_open_id'],
+    predicate: '((corp_id is null) and (provider_open_id is not null))',
+  },
+]
+
+type IndexCatalogRow = {
+  is_unique: boolean
+  is_valid: boolean
+  key_attribute_count: number
+  total_attribute_count: number
+  has_expressions: boolean
+  columns: string[]
+  predicate: string | null
+}
+
+function normalizeCatalogExpression(value: string | null): string | null {
+  if (value === null) return null
+  return value
+    .toLowerCase()
+    .replaceAll('"', '')
+    .replaceAll('::text', '')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+async function readIndexShape(db: Kysely<unknown>, shape: IndexShape): Promise<IndexCatalogRow | null> {
+  const result = await sql<IndexCatalogRow>`
+    SELECT
+      idx.indisunique AS is_unique,
+      idx.indisvalid AS is_valid,
+      idx.indnkeyatts::int AS key_attribute_count,
+      idx.indnatts::int AS total_attribute_count,
+      (idx.indexprs IS NOT NULL) AS has_expressions,
+      ARRAY(
+        SELECT attr.attname
+          FROM unnest(idx.indkey) WITH ORDINALITY AS key(attnum, position)
+          JOIN pg_attribute attr
+            ON attr.attrelid = table_rel.oid
+           AND attr.attnum = key.attnum
+         ORDER BY key.position
+      )::text[] AS columns,
+      pg_get_expr(idx.indpred, idx.indrelid) AS predicate
+      FROM pg_class index_rel
+      JOIN pg_index idx ON idx.indexrelid = index_rel.oid
+      JOIN pg_class table_rel ON table_rel.oid = idx.indrelid
+      JOIN pg_namespace namespace ON namespace.oid = table_rel.relnamespace
+     WHERE namespace.nspname = current_schema()
+       AND index_rel.relname = ${shape.name}
+       AND table_rel.relname = ${shape.table}
+  `.execute(db)
+  return result.rows[0] ?? null
+}
+
+async function assertIndexShape(db: Kysely<unknown>, shape: IndexShape): Promise<void> {
+  const actual = await readIndexShape(db, shape)
+  if (
+    !actual
+    || !actual.is_unique
+    || !actual.is_valid
+    || actual.has_expressions
+    || actual.key_attribute_count !== shape.columns.length
+    || actual.total_attribute_count !== shape.columns.length
+    || actual.columns.join('\u0000') !== shape.columns.join('\u0000')
+    || normalizeCatalogExpression(actual.predicate) !== normalizeCatalogExpression(shape.predicate)
+  ) {
+    throw new Error(`directory corp-scope migration index drift: ${shape.name}`)
+  }
+}
+
+async function createIndexIfAbsent(db: Kysely<unknown>, shape: IndexShape): Promise<void> {
+  const existing = await readIndexShape(db, shape)
+  if (existing) {
+    await assertIndexShape(db, shape)
+    return
+  }
+
+  if (shape.name === ACCOUNT_CORP_INDEX) {
+    await sql`CREATE UNIQUE INDEX ${sql.id(ACCOUNT_CORP_INDEX)}
+      ON directory_accounts(provider, corp_id, external_key)
+      WHERE corp_id IS NOT NULL`.execute(db)
+  } else if (shape.name === ACCOUNT_NULL_CORP_INDEX) {
+    await sql`CREATE UNIQUE INDEX ${sql.id(ACCOUNT_NULL_CORP_INDEX)}
+      ON directory_accounts(provider, external_key)
+      WHERE corp_id IS NULL`.execute(db)
+  } else if (shape.name === IDENTITY_CORP_UNION_INDEX) {
+    await sql`CREATE UNIQUE INDEX ${sql.id(IDENTITY_CORP_UNION_INDEX)}
+      ON user_external_identities(provider, corp_id, provider_union_id)
+      WHERE corp_id IS NOT NULL AND provider_union_id IS NOT NULL`.execute(db)
+  } else if (shape.name === IDENTITY_NULL_CORP_UNION_INDEX) {
+    await sql`CREATE UNIQUE INDEX ${sql.id(IDENTITY_NULL_CORP_UNION_INDEX)}
+      ON user_external_identities(provider, provider_union_id)
+      WHERE corp_id IS NULL AND provider_union_id IS NOT NULL`.execute(db)
+  } else if (shape.name === IDENTITY_CORP_OPEN_INDEX) {
+    await sql`CREATE UNIQUE INDEX ${sql.id(IDENTITY_CORP_OPEN_INDEX)}
+      ON user_external_identities(provider, corp_id, provider_open_id)
+      WHERE corp_id IS NOT NULL AND provider_open_id IS NOT NULL`.execute(db)
+  } else if (shape.name === IDENTITY_NULL_CORP_OPEN_INDEX) {
+    await sql`CREATE UNIQUE INDEX ${sql.id(IDENTITY_NULL_CORP_OPEN_INDEX)}
+      ON user_external_identities(provider, provider_open_id)
+      WHERE corp_id IS NULL AND provider_open_id IS NOT NULL`.execute(db)
+  } else {
+    throw new Error(`unsupported directory corp-scope index: ${shape.name}`)
+  }
+  await assertIndexShape(db, shape)
+}
+
+async function readCheckConstraint(
+  db: Kysely<unknown>,
+  table: string,
+  name: string,
+): Promise<{ is_valid: boolean; definition: string } | null> {
+  const result = await sql<{ is_valid: boolean; definition: string }>`
+    SELECT
+      constraint_row.convalidated AS is_valid,
+      pg_get_constraintdef(constraint_row.oid) AS definition
+      FROM pg_constraint constraint_row
+      JOIN pg_class table_rel ON table_rel.oid = constraint_row.conrelid
+      JOIN pg_namespace namespace ON namespace.oid = table_rel.relnamespace
+     WHERE namespace.nspname = current_schema()
+       AND table_rel.relname = ${table}
+       AND constraint_row.contype = 'c'
+       AND constraint_row.conname = ${name}
+  `.execute(db)
+  return result.rows[0] ?? null
+}
+
+async function ensureCorpShapeCheck(
+  db: Kysely<unknown>,
+  table: 'directory_integrations' | 'directory_accounts' | 'user_external_identities',
+  name: string,
+  required: boolean,
+): Promise<void> {
+  const existing = await readCheckConstraint(db, table, name)
+  if (!existing) {
+    if (table === 'directory_integrations') {
+      await sql`ALTER TABLE directory_integrations
+        ADD CONSTRAINT ${sql.id(name)}
+        CHECK (corp_id ~ '^[!-~]+$')`.execute(db)
+    } else if (table === 'directory_accounts') {
+      await sql`ALTER TABLE directory_accounts
+        ADD CONSTRAINT ${sql.id(name)}
+        CHECK (corp_id IS NULL OR corp_id ~ '^[!-~]+$')`.execute(db)
+    } else {
+      await sql`ALTER TABLE user_external_identities
+        ADD CONSTRAINT ${sql.id(name)}
+        CHECK (corp_id IS NULL OR corp_id ~ '^[!-~]+$')`.execute(db)
+    }
+  }
+
+  const actual = await readCheckConstraint(db, table, name)
+  const expectedDefinition = required
+    ? REQUIRED_CORP_SHAPE_DEFINITION
+    : OPTIONAL_CORP_SHAPE_DEFINITION
+  if (
+    !actual
+    || !actual.is_valid
+    || normalizeCatalogExpression(actual.definition)
+      !== normalizeCatalogExpression(expectedDefinition)
+  ) {
+    throw new Error(`directory corp-scope migration constraint drift: ${name}`)
+  }
+}
+
+async function assertAuthoritativeDirectoryScope(db: Kysely<unknown>): Promise<void> {
+  const invalidIntegrations = await sql<{ count: string }>`
+    SELECT COUNT(*)::text AS count
+      FROM directory_integrations
+     WHERE corp_id !~ '^[!-~]+$'
+        OR provider IS NULL
+        OR provider = ''
+  `.execute(db)
+  if (invalidIntegrations.rows[0]?.count !== '0') {
+    throw new Error('directory corp-scope migration blocked: integration scope is non-canonical')
+  }
+
+  const result = await sql<{ count: string }>`
+    SELECT COUNT(*)::text AS count
+      FROM directory_accounts account
+      JOIN directory_integrations integration ON integration.id = account.integration_id
+     WHERE account.provider IS DISTINCT FROM integration.provider
+        OR integration.corp_id !~ '^[!-~]+$'
+  `.execute(db)
+  if (result.rows[0]?.count !== '0') {
+    throw new Error('directory corp-scope migration blocked: account parent scope is inconsistent')
+  }
+}
+
+async function canonicalizeCorpScope(db: Kysely<unknown>): Promise<void> {
+  await sql`
+    UPDATE directory_integrations
+       SET corp_id = BTRIM(corp_id)
+     WHERE corp_id IS DISTINCT FROM BTRIM(corp_id)
+  `.execute(db)
+  await assertAuthoritativeDirectoryScope(db)
+  await sql`
+    UPDATE directory_accounts account
+       SET corp_id = integration.corp_id
+      FROM directory_integrations integration
+     WHERE integration.id = account.integration_id
+       AND account.corp_id IS DISTINCT FROM integration.corp_id
+  `.execute(db)
+  await sql`
+    UPDATE user_external_identities
+       SET corp_id = NULLIF(BTRIM(corp_id), '')
+     WHERE corp_id IS DISTINCT FROM NULLIF(BTRIM(corp_id), '')
+  `.execute(db)
+  const invalidIdentities = await sql<{ count: string }>`
+    SELECT COUNT(*)::text AS count
+      FROM user_external_identities
+     WHERE corp_id IS NOT NULL
+       AND corp_id !~ '^[!-~]+$'
+  `.execute(db)
+  if (invalidIdentities.rows[0]?.count !== '0') {
+    throw new Error('directory corp-scope migration blocked: identity corp is non-canonical')
+  }
+}
+
+async function createLegacyIndexIfAbsent(db: Kysely<unknown>): Promise<void> {
+  const existing = await readIndexShape(db, ACCOUNT_LEGACY_SHAPE)
+  if (existing) {
+    await assertIndexShape(db, ACCOUNT_LEGACY_SHAPE)
+    return
+  }
+  await sql`CREATE UNIQUE INDEX ${sql.id(ACCOUNT_LEGACY_INDEX)}
+    ON directory_accounts(provider, external_key)`.execute(db)
+  await assertIndexShape(db, ACCOUNT_LEGACY_SHAPE)
+}
+
+async function readMigrationTimeouts(
+  db: Kysely<unknown>,
+): Promise<{ lock_timeout: string; statement_timeout: string }> {
+  const result = await sql<{ lock_timeout: string; statement_timeout: string }>`
+    SELECT
+      current_setting('lock_timeout') AS lock_timeout,
+      current_setting('statement_timeout') AS statement_timeout
+  `.execute(db)
+  return result.rows[0] ?? { lock_timeout: '0', statement_timeout: '0' }
+}
+
+async function applyMigrationTimeouts(db: Kysely<unknown>): Promise<void> {
+  await sql`
+    SELECT
+      set_config('lock_timeout', ${MIGRATION_LOCK_TIMEOUT}, true),
+      set_config('statement_timeout', ${MIGRATION_STATEMENT_TIMEOUT}, true)
+  `.execute(db)
+}
+
+async function restoreMigrationTimeouts(
+  db: Kysely<unknown>,
+  previous: { lock_timeout: string; statement_timeout: string },
+): Promise<void> {
+  await sql`
+    SELECT
+      set_config('lock_timeout', ${previous.lock_timeout}, true),
+      set_config('statement_timeout', ${previous.statement_timeout}, true)
+  `.execute(db)
+}
+
+async function applyUp(db: Kysely<unknown>): Promise<void> {
+  await canonicalizeCorpScope(db)
+
+  await ensureCorpShapeCheck(
+    db,
+    'directory_integrations',
+    INTEGRATION_CORP_SHAPE_CHECK,
+    true,
+  )
+  await ensureCorpShapeCheck(db, 'directory_accounts', ACCOUNT_CORP_SHAPE_CHECK, false)
+  await ensureCorpShapeCheck(db, 'user_external_identities', IDENTITY_CORP_SHAPE_CHECK, false)
+
+  const legacyIndex = await readIndexShape(db, ACCOUNT_LEGACY_SHAPE)
+  if (!legacyIndex) {
+    // Idempotent replay is legal only when every replacement is already present and valid.
+    // A partially applied shape with no legacy guard remains an unknown rollout state.
+    for (const shape of INDEX_SHAPES) await assertIndexShape(db, shape)
+    return
+  }
+
+  // Phase B is eligible only while the Phase-A-compatible legacy guard is still present.
+  // A same-name-but-drifted guard means rollout state is unknown, so abort.
+  await assertIndexShape(db, ACCOUNT_LEGACY_SHAPE)
+
+  for (const shape of INDEX_SHAPES) await createIndexIfAbsent(db, shape)
+
+  // Remove legacy protection only after every replacement has been structurally verified.
+  await sql`DROP INDEX ${sql.id(ACCOUNT_LEGACY_INDEX)}`.execute(db)
+}
+
+async function applyDown(db: Kysely<unknown>): Promise<void> {
+  // Cross-corp account duplicates make this CREATE fail. The migrator transaction then preserves
+  // every scoped index and check; rollback never silently deletes or rewrites directory data.
+  await createLegacyIndexIfAbsent(db)
+
+  for (const shape of INDEX_SHAPES) {
+    const existing = await readIndexShape(db, shape)
+    if (existing) {
+      await assertIndexShape(db, shape)
+      await sql`DROP INDEX ${sql.id(shape.name)}`.execute(db)
+    }
+  }
+  await sql`ALTER TABLE directory_accounts
+    DROP CONSTRAINT IF EXISTS ${sql.id(ACCOUNT_CORP_SHAPE_CHECK)}`.execute(db)
+  await sql`ALTER TABLE user_external_identities
+    DROP CONSTRAINT IF EXISTS ${sql.id(IDENTITY_CORP_SHAPE_CHECK)}`.execute(db)
+  await sql`ALTER TABLE directory_integrations
+    DROP CONSTRAINT IF EXISTS ${sql.id(INTEGRATION_CORP_SHAPE_CHECK)}`.execute(db)
+}
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  // Kysely 0.28 runs all pending PostgreSQL migrations in one transaction. Scope the lock and
+  // statement bounds to this migration and restore them on success so later migrations do not
+  // inherit the settings. On failure the enclosing transaction rolls back the settings too.
+  const previousTimeouts = await readMigrationTimeouts(db)
+  await applyMigrationTimeouts(db)
+  await applyUp(db)
+  await restoreMigrationTimeouts(db, previousTimeouts)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  const previousTimeouts = await readMigrationTimeouts(db)
+  await applyMigrationTimeouts(db)
+  await applyDown(db)
+  await restoreMigrationTimeouts(db, previousTimeouts)
+}

--- a/packages/core-backend/src/integrations/dingtalk/interactive-card-callback.ts
+++ b/packages/core-backend/src/integrations/dingtalk/interactive-card-callback.ts
@@ -208,10 +208,11 @@ function readCallbackCorpAnchor(payload: unknown): CallbackCorpAnchor {
  * integration UNPINS the delivery — which refuses earlier as `integration_unpinned`. A delivery can never
  * point at a missing integration (the FK forbids it).
  *
- * What IS reachable: the row exists but its corp cannot be read — `corp_id` is NOT NULL yet '' is still
- * accepted, and this lookup also requires `provider='dingtalk'`. Both are misconfigurations on OUR side,
- * and they surface as `delivery_corp_unresolved` — deliberately NOT as `corp_anchor_absent`, because the
- * two demand opposite responses (fix our config vs. close the flag because DingTalk sends no corp field).
+ * What IS reachable: the row exists but is not a DingTalk integration. This lookup deliberately requires
+ * `provider='dingtalk'`, so a delivery pinned to a differently typed directory integration cannot supply
+ * an authoritative DingTalk corp. That misconfiguration surfaces as `delivery_corp_unresolved` —
+ * deliberately NOT as `corp_anchor_absent`, because the two demand opposite responses (fix our config vs.
+ * close the flag because DingTalk sends no corp field).
  */
 async function resolveIntegrationCorpId(query: QueryFn, integrationId: string): Promise<string> {
   const result = await query(

--- a/packages/core-backend/tests/integration/dingtalk-approval-card-callback.db.test.ts
+++ b/packages/core-backend/tests/integration/dingtalk-approval-card-callback.db.test.ts
@@ -509,16 +509,17 @@ describeIfDatabase('B-3 DingTalk card callback adapter (real DB)', () => {
       // resolveIntegrationCorpId ("returns '' when the integration row is missing, e.g. deleted") names a
       // cause the schema makes unreachable.
       //
-      // The genuinely reachable cause is an integration that EXISTS but whose corp cannot be read:
-      // corp_id is NOT NULL yet '' is still accepted (and resolveIntegrationCorpId also filters
-      // provider='dingtalk'). That is a real misconfiguration, and it must read as OUR failure — never as
-      // "the frame carried no corp anchor", which would wrongly tell an operator to close the flag.
+      // The genuinely reachable cause is an integration that EXISTS but is not a DingTalk integration.
+      // Phase B rejects blank corp ids at the schema boundary, while resolveIntegrationCorpId also
+      // requires provider='dingtalk'. A delivery pinned to a differently typed integration is a real
+      // misconfiguration, and it must read as OUR failure — never as "the frame carried no corp anchor",
+      // which would wrongly tell an operator to close the flag.
       const instanceId = await newInstance()
       const brokenIntegrationId = randomUUID()
       await q(
         `INSERT INTO directory_integrations (id, name, provider, status, corp_id, config, updated_at)
-         VALUES ($1, $2, 'dingtalk', 'active', '', '{}'::jsonb, now())`,
-        [brokenIntegrationId, `b3cb-corp-broken-${TS}`],
+         VALUES ($1, $2, 'wecom', 'active', $3, '{}'::jsonb, now())`,
+        [brokenIntegrationId, `b3cb-corp-broken-${TS}`, CORP_B],
       )
       try {
         const row = await insertDingTalkApprovalCardDelivery(q, {

--- a/packages/core-backend/tests/integration/directory-account-external-key-collision-mechanism.db.test.ts
+++ b/packages/core-backend/tests/integration/directory-account-external-key-collision-mechanism.db.test.ts
@@ -1,4 +1,7 @@
+import { spawnSync } from 'node:child_process'
 import { randomUUID } from 'node:crypto'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 
 import { Kysely, PostgresDialect, sql } from 'kysely'
 import { Pool } from 'pg'
@@ -41,6 +44,7 @@ import {
   syncDirectoryIntegration,
   unbindDirectoryAccount,
 } from '../../src/directory/directory-sync'
+import { runDirectoryCorpScopePreflight } from '../../scripts/dingtalk-directory-corp-scope-preflight'
 
 const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
 const TS = Date.now()
@@ -769,9 +773,10 @@ describeIfDatabase('DingTalk directory account corp-scope (real sync, mocked pul
 
 describeIfDatabase('directory corp-scope Phase B migration (isolated real DB)', () => {
   const dbUrl = process.env.DATABASE_URL!
+  const coreBackendRoot = path.resolve(fileURLToPath(new URL('../..', import.meta.url)))
 
   async function withLegacySchema(
-    run: (db: Kysely<unknown>) => Promise<void>,
+    run: (db: Kysely<unknown>, pool: Pool, schema: string) => Promise<void>,
   ): Promise<void> {
     const adminPool = new Pool({ connectionString: dbUrl })
     const schema = `dtcorp_${randomUUID().replace(/-/g, '')}`
@@ -812,7 +817,7 @@ describeIfDatabase('directory corp-scope Phase B migration (isolated real DB)', 
         CREATE UNIQUE INDEX idx_directory_accounts_provider_external_key
         ON directory_accounts(provider, external_key)
       `.execute(db)
-      await run(db)
+      await run(db, testPool, schema)
     } finally {
       await db.destroy()
       await adminPool.query(`DROP SCHEMA IF EXISTS "${schema}" CASCADE`)
@@ -854,6 +859,361 @@ describeIfDatabase('directory corp-scope Phase B migration (isolated real DB)', 
       (trx) => corpScopeDown(trx as unknown as Kysely<unknown>),
     )
   }
+
+  function runPreflightCli(schema: string): {
+    exitCode: number | null
+    report: Record<string, unknown>
+    stdout: string
+  } {
+    const result = spawnSync(
+      'pnpm',
+      ['--silent', 'preflight:dingtalk-directory-corp-scope'],
+      {
+        cwd: coreBackendRoot,
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          DATABASE_URL: dbUrl,
+          PGOPTIONS: `-c search_path=${schema}`,
+        },
+      },
+    )
+    return {
+      exitCode: result.status,
+      report: JSON.parse(result.stdout) as Record<string, unknown>,
+      stdout: result.stdout,
+    }
+  }
+
+  it('preflight CLI starts cleanly and emits one values-free JSON error without DATABASE_URL', () => {
+    const env = { ...process.env }
+    delete env.DATABASE_URL
+    const result = spawnSync(
+      'pnpm',
+      ['--silent', 'preflight:dingtalk-directory-corp-scope'],
+      {
+        cwd: coreBackendRoot,
+        encoding: 'utf8',
+        env,
+      },
+    )
+
+    expect(result.status).toBe(1)
+    expect(() => JSON.parse(result.stdout)).not.toThrow()
+    expect(JSON.parse(result.stdout)).toEqual({
+      operation: 'dingtalk_directory_corp_scope_phase_b_preflight',
+      version: 1,
+      status: 'ERROR',
+      valuesFree: true,
+      readOnlyVerified: false,
+      code: 'PREFLIGHT_DATABASE_URL_REQUIRED',
+    })
+  })
+
+  it('preflight passes from a read-only snapshot and emits counts without source values', async () => {
+    await withLegacySchema(async (db, pool, schema) => {
+      const integrationId = randomUUID()
+      const corpId = `secret-corp-${randomUUID()}`
+      const externalKey = `secret-account-${randomUUID()}`
+      const unionId = `secret-union-${randomUUID()}`
+      await sql`
+        INSERT INTO directory_integrations(id, corp_id)
+        VALUES (${integrationId}, ${` ${corpId} `})
+      `.execute(db)
+      await sql`
+        INSERT INTO directory_accounts(integration_id, provider, corp_id, external_key)
+        VALUES (${integrationId}, 'dingtalk', NULL, ${externalKey})
+      `.execute(db)
+      await sql`
+        INSERT INTO user_external_identities(
+          provider, external_key, provider_union_id, corp_id
+        ) VALUES ('dingtalk', 'opaque-local-key', ${unionId}, ${corpId})
+      `.execute(db)
+
+      const before = await sql<{ integrations: string; accounts: string; identities: string }>`
+        SELECT
+          (SELECT count(*)::text FROM directory_integrations) AS integrations,
+          (SELECT count(*)::text FROM directory_accounts) AS accounts,
+          (SELECT count(*)::text FROM user_external_identities) AS identities
+      `.execute(db)
+      const report = await runDirectoryCorpScopePreflight(pool)
+      const cli = runPreflightCli(schema)
+      const serialized = JSON.stringify(report)
+      const after = await sql<{ integrations: string; accounts: string; identities: string }>`
+        SELECT
+          (SELECT count(*)::text FROM directory_integrations) AS integrations,
+          (SELECT count(*)::text FROM directory_accounts) AS accounts,
+          (SELECT count(*)::text FROM user_external_identities) AS identities
+      `.execute(db)
+
+      expect(report).toMatchObject({
+        status: 'PASS',
+        valuesFree: true,
+        readOnly: true,
+        schema: {
+          requiredTablesPresent: true,
+          integrationCorpNotNull: true,
+          legacyIndexExact: true,
+          scopedIndexCount: '0',
+          corpCheckCount: '0',
+        },
+        counts: {
+          integrations: '1',
+          accounts: '1',
+          identities: '1',
+        },
+        blockers: [],
+      })
+      expect(serialized).not.toContain(corpId)
+      expect(serialized).not.toContain(externalKey)
+      expect(serialized).not.toContain(unionId)
+      expect(after.rows).toEqual(before.rows)
+      expect(cli.exitCode).toBe(0)
+      expect(cli.report).toMatchObject({
+        status: 'PASS',
+        readOnly: true,
+        blockers: [],
+      })
+      expect(cli.stdout).not.toContain(corpId)
+      expect(cli.stdout).not.toContain(externalKey)
+      expect(cli.stdout).not.toContain(unionId)
+    })
+  })
+
+  it('preflight blocks projected identity collisions and scope drift without exposing values', async () => {
+    await withLegacySchema(async (db, pool, schema) => {
+      const integrationId = randomUUID()
+      const corpId = `blocked-corp-${randomUUID()}`
+      const duplicateUnionId = `blocked-union-${randomUUID()}`
+      const duplicateNullUnionId = `blocked-null-union-${randomUUID()}`
+      const duplicateCorpOpenId = `blocked-corp-open-${randomUUID()}`
+      const duplicateOpenId = `blocked-open-${randomUUID()}`
+      await sql`
+        INSERT INTO directory_integrations(id, provider, corp_id)
+        VALUES (${integrationId}, 'dingtalk', ${corpId})
+      `.execute(db)
+      await sql`
+        INSERT INTO directory_integrations(provider, corp_id)
+        VALUES ('dingtalk', '   ')
+      `.execute(db)
+      await sql`
+        INSERT INTO directory_accounts(integration_id, provider, corp_id, external_key)
+        VALUES (${integrationId}, 'drifted-provider', NULL, 'blocked-account')
+      `.execute(db)
+      await sql`
+        INSERT INTO user_external_identities(
+          provider, external_key, provider_union_id, provider_open_id, corp_id
+        ) VALUES
+          ('dingtalk', 'identity-corp-a', ${duplicateUnionId}, NULL, ${corpId}),
+          ('dingtalk', 'identity-corp-b', ${duplicateUnionId}, NULL, ${corpId}),
+          ('dingtalk', 'identity-null-union-a', ${duplicateNullUnionId}, NULL, NULL),
+          ('dingtalk', 'identity-null-union-b', ${duplicateNullUnionId}, NULL, '   '),
+          ('dingtalk', 'identity-corp-open-a', NULL, ${duplicateCorpOpenId}, ${corpId}),
+          ('dingtalk', 'identity-corp-open-b', NULL, ${duplicateCorpOpenId}, ${corpId}),
+          ('dingtalk', 'identity-null-open-a', NULL, ${duplicateOpenId}, NULL),
+          ('dingtalk', 'identity-null-open-b', NULL, ${duplicateOpenId}, '   '),
+          ('dingtalk', 'identity-invalid', NULL, NULL, E'corp\\tinvalid')
+      `.execute(db)
+
+      const report = await runDirectoryCorpScopePreflight(pool)
+      const cli = runPreflightCli(schema)
+      const serialized = JSON.stringify(report)
+
+      expect(report.status).toBe('BLOCKED')
+      expect(report.counts).toMatchObject({
+        invalidIntegrationScope: '1',
+        accountProviderDrift: '1',
+        invalidIdentityCorp: '1',
+        duplicateCorpUnionGroups: '1',
+        duplicateNullCorpUnionGroups: '1',
+        duplicateCorpOpenGroups: '1',
+        duplicateNullCorpOpenGroups: '1',
+      })
+      expect(report.blockers).toEqual([
+        'invalidIntegrationScope',
+        'accountProviderDrift',
+        'invalidIdentityCorp',
+        'duplicateCorpUnionGroups',
+        'duplicateNullCorpUnionGroups',
+        'duplicateCorpOpenGroups',
+        'duplicateNullCorpOpenGroups',
+      ])
+      expect(serialized).not.toContain(corpId)
+      expect(serialized).not.toContain(duplicateUnionId)
+      expect(serialized).not.toContain(duplicateNullUnionId)
+      expect(serialized).not.toContain(duplicateCorpOpenId)
+      expect(serialized).not.toContain(duplicateOpenId)
+      expect(cli.exitCode).toBe(2)
+      expect(cli.report).toMatchObject({
+        status: 'BLOCKED',
+        blockers: report.blockers,
+      })
+      expect(cli.stdout).not.toContain(corpId)
+      expect(cli.stdout).not.toContain(duplicateUnionId)
+      expect(cli.stdout).not.toContain(duplicateNullUnionId)
+      expect(cli.stdout).not.toContain(duplicateCorpOpenId)
+      expect(cli.stdout).not.toContain(duplicateOpenId)
+    })
+  })
+
+  it('preflight blocks a partially applied Phase B schema before reading it as migration-ready', async () => {
+    await withLegacySchema(async (db, pool) => {
+      await sql`
+        CREATE UNIQUE INDEX idx_user_external_identities_provider_corp_union
+        ON user_external_identities(provider, corp_id, provider_union_id)
+        WHERE corp_id IS NOT NULL AND provider_union_id IS NOT NULL
+      `.execute(db)
+
+      const report = await runDirectoryCorpScopePreflight(pool)
+
+      expect(report).toMatchObject({
+        status: 'BLOCKED',
+        schema: {
+          legacyIndexExact: true,
+          scopedIndexCount: '1',
+          corpCheckCount: '0',
+        },
+      })
+      expect(report.blockers).toEqual(['scoped_indexes_already_present'])
+    })
+  })
+
+  it('preflight and migration reject a nullable integration corp column with a NULL row', async () => {
+    await withLegacySchema(async (db, pool, schema) => {
+      await sql`
+        ALTER TABLE directory_integrations
+        ALTER COLUMN corp_id DROP NOT NULL
+      `.execute(db)
+      await sql`
+        INSERT INTO directory_integrations(provider, corp_id)
+        VALUES ('dingtalk', NULL)
+      `.execute(db)
+
+      const report = await runDirectoryCorpScopePreflight(pool)
+      const cli = runPreflightCli(schema)
+
+      expect(report).toMatchObject({
+        status: 'BLOCKED',
+        schema: {
+          requiredTablesPresent: true,
+          integrationCorpNotNull: false,
+          legacyIndexExact: true,
+        },
+        counts: {
+          invalidIntegrationScope: '1',
+        },
+      })
+      expect(report.blockers).toEqual([
+        'integration_corp_not_null_missing',
+        'invalidIntegrationScope',
+      ])
+      expect(cli.exitCode).toBe(2)
+      expect(cli.report).toMatchObject({
+        status: 'BLOCKED',
+        blockers: report.blockers,
+      })
+      await expect(runUp(db)).rejects.toThrow(
+        /integration corp column must be NOT NULL/,
+      )
+      expect(await indexNames(db)).toContain('idx_directory_accounts_provider_external_key')
+      expect(await constraintNames(db)).not.toContain(
+        'directory_integrations_corp_id_canonical',
+      )
+    })
+  })
+
+  it('preflight reports a missing required table without attempting partial data reads', async () => {
+    await withLegacySchema(async (db, pool) => {
+      await sql`DROP TABLE user_external_identities`.execute(db)
+
+      const report = await runDirectoryCorpScopePreflight(pool)
+
+      expect(report.status).toBe('BLOCKED')
+      expect(report.schema).toMatchObject({
+        requiredTablesPresent: false,
+        integrationCorpNotNull: true,
+        legacyIndexExact: true,
+      })
+      expect(report.counts).toEqual({
+        integrations: '0',
+        accounts: '0',
+        identities: '0',
+        invalidIntegrationScope: '0',
+        orphanAccounts: '0',
+        accountProviderDrift: '0',
+        invalidIdentityCorp: '0',
+        duplicateAccountScopeGroups: '0',
+        duplicateCorpUnionGroups: '0',
+        duplicateNullCorpUnionGroups: '0',
+        duplicateCorpOpenGroups: '0',
+        duplicateNullCorpOpenGroups: '0',
+      })
+      expect(report.blockers).toEqual(['required_tables_missing'])
+    })
+  })
+
+  it('preflight reports legacy-index and existing-CHECK drift as separate blockers', async () => {
+    await withLegacySchema(async (db, pool) => {
+      await sql`DROP INDEX idx_directory_accounts_provider_external_key`.execute(db)
+      await sql`
+        ALTER TABLE directory_accounts
+        ADD CONSTRAINT directory_accounts_corp_id_canonical
+        CHECK (corp_id IS NULL OR corp_id ~ '^[!-~]+$')
+      `.execute(db)
+
+      const report = await runDirectoryCorpScopePreflight(pool)
+
+      expect(report).toMatchObject({
+        status: 'BLOCKED',
+        schema: {
+          legacyIndexExact: false,
+          scopedIndexCount: '0',
+          corpCheckCount: '1',
+        },
+      })
+      expect(report.blockers).toEqual([
+        'legacy_index_not_exact',
+        'corp_checks_already_present',
+      ])
+    })
+  })
+
+  it('preflight reports orphan accounts and projected account-scope duplicates under schema drift', async () => {
+    await withLegacySchema(async (db, pool) => {
+      const integrationA = randomUUID()
+      const integrationB = randomUUID()
+      await sql`
+        DROP INDEX idx_directory_accounts_provider_external_key
+      `.execute(db)
+      await sql`
+        ALTER TABLE directory_accounts
+        DROP CONSTRAINT directory_accounts_integration_id_fkey
+      `.execute(db)
+      await sql`
+        INSERT INTO directory_integrations(id, corp_id)
+        VALUES (${integrationA}, 'corp-a'), (${integrationB}, 'corp-a')
+      `.execute(db)
+      await sql`
+        INSERT INTO directory_accounts(integration_id, provider, corp_id, external_key)
+        VALUES
+          (${integrationA}, 'dingtalk', NULL, 'duplicate-account'),
+          (${integrationB}, 'dingtalk', NULL, 'duplicate-account'),
+          (${randomUUID()}, 'dingtalk', NULL, 'orphan-account')
+      `.execute(db)
+
+      const report = await runDirectoryCorpScopePreflight(pool)
+
+      expect(report.counts).toMatchObject({
+        orphanAccounts: '1',
+        duplicateAccountScopeGroups: '1',
+      })
+      expect(report.blockers).toEqual([
+        'legacy_index_not_exact',
+        'orphanAccounts',
+        'duplicateAccountScopeGroups',
+      ])
+    })
+  })
 
   it('up canonicalizes corp data, installs every scoped guard, permits cross-corp keys, and replays', async () => {
     await withLegacySchema(async (db) => {

--- a/packages/core-backend/tests/integration/directory-account-external-key-collision-mechanism.db.test.ts
+++ b/packages/core-backend/tests/integration/directory-account-external-key-collision-mechanism.db.test.ts
@@ -3,7 +3,6 @@ import { randomUUID } from 'node:crypto'
 import { Kysely, PostgresDialect, sql } from 'kysely'
 import { Pool } from 'pg'
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
-import { Pool } from 'pg'
 
 // Phase A DingTalk directory identity isolation.
 //
@@ -49,12 +48,19 @@ const TS = Date.now()
 /** One root department with one user; the user's identity fields are per-test knobs. */
 type MockTenant = { unionId?: string; openId?: string; userId: string; name: string }
 let activeTenant: MockTenant | null = null
+let phaseBSchemaInstalled = false
 
 describeIfDatabase('DingTalk directory account corp-scope (real sync, mocked pull)', () => {
   const cleanupIntegrationIds: string[] = []
   const cleanupUserIds: string[] = []
 
-  beforeAll(() => {
+  beforeAll(async () => {
+    const phaseBSchema = await query<{ installed: boolean }>(
+      `SELECT to_regclass(
+         'idx_directory_accounts_provider_corp_external_key'
+       ) IS NOT NULL AS installed`,
+    )
+    phaseBSchemaInstalled = phaseBSchema.rows[0]?.installed ?? false
     clientMocks.fetchDingTalkAppAccessToken.mockResolvedValue('t2g-token')
     clientMocks.listDingTalkDepartments.mockImplementation(async (_token: string, parentId: string) =>
       parentId === '1' && activeTenant ? [{ id: 'd100', parentId: '1', name: 'Mechanism Dept', order: 1, source: {} }] : []
@@ -166,12 +172,28 @@ describeIfDatabase('DingTalk directory account corp-scope (real sync, mocked pul
     expect((await accountKeys(corpB)).map((r) => r.external_key)).toEqual([`t2g-union-okB-${TS}`])
   })
 
-  it('repairs a legacy blank account corp from its immutable parent integration during sync', async () => {
+  it('repairs a legacy blank account corp before Phase B or rejects it after Phase B', async () => {
     const integrationId = await seedIntegration('corp-repair')
     activeTenant = {
       unionId: `t2g-union-corp-repair-${TS}`,
       userId: `t2g-user-corp-repair-${TS}`,
       name: 'Corp Repair',
+    }
+    if (phaseBSchemaInstalled) {
+      await expect(query(
+        `INSERT INTO directory_accounts (
+           integration_id, provider, corp_id, external_user_id, external_key, name, is_active, raw
+         ) VALUES ($1, 'dingtalk', '', $2, $3, 'Legacy Blank Corp', true, '{}'::jsonb)`,
+        [integrationId, activeTenant.userId, activeTenant.unionId],
+      )).rejects.toThrow(/directory_accounts_corp_id_canonical/)
+      const account = await query<{ count: number }>(
+        `SELECT count(*)::int AS count
+           FROM directory_accounts
+          WHERE integration_id = $1`,
+        [integrationId],
+      )
+      expect(account.rows).toEqual([{ count: 0 }])
+      return
     }
     await query(
       `INSERT INTO directory_accounts (
@@ -204,6 +226,30 @@ describeIfDatabase('DingTalk directory account corp-scope (real sync, mocked pul
     )
     const corpId = corpIdForTag('ambiguous')
     const sharedUnionId = `t2g-ambiguous-union-${TS}`
+    if (phaseBSchemaInstalled) {
+      await query(
+        `INSERT INTO user_external_identities (
+           provider, external_key, provider_union_id, corp_id, local_user_id, profile
+         ) VALUES ('dingtalk', $1, $2, $3, $4, '{}'::jsonb)`,
+        [`t2g-ambiguous-key-a-${TS}`, sharedUnionId, corpId, firstUserId],
+      )
+      await expect(query(
+        `INSERT INTO user_external_identities (
+           provider, external_key, provider_union_id, corp_id, local_user_id, profile
+         ) VALUES ('dingtalk', $1, $2, $3, $4, '{}'::jsonb)`,
+        [`t2g-ambiguous-key-b-${TS}`, sharedUnionId, corpId, secondUserId],
+      )).rejects.toThrow(/idx_user_external_identities_provider_corp_union/)
+      const identities = await query<{ count: number }>(
+        `SELECT count(*)::int AS count
+           FROM user_external_identities
+          WHERE provider = 'dingtalk'
+            AND corp_id = $1
+            AND provider_union_id = $2`,
+        [corpId, sharedUnionId],
+      )
+      expect(identities.rows).toEqual([{ count: 1 }])
+      return
+    }
     await query(
       `INSERT INTO user_external_identities (
          provider, external_key, provider_union_id, corp_id, local_user_id, profile
@@ -242,7 +288,7 @@ describeIfDatabase('DingTalk directory account corp-scope (real sync, mocked pul
     }])
   })
 
-  it('serializes the identity snapshot with writers and reconciles a later duplicate', async () => {
+  it('serializes the identity snapshot before Phase B or serializes uniqueness after Phase B', async () => {
     const firstUserId = `t2g-lock-first-${TS}`
     const secondUserId = `t2g-lock-second-${TS}`
     cleanupUserIds.push(firstUserId, secondUserId)
@@ -258,6 +304,34 @@ describeIfDatabase('DingTalk directory account corp-scope (real sync, mocked pul
     )
     const corpId = corpIdForTag('snapshot-lock')
     const sharedUnionId = `t2g-lock-union-${TS}`
+    if (phaseBSchemaInstalled) {
+      const inserts = await Promise.allSettled([
+        query(
+          `INSERT INTO user_external_identities (
+             provider, external_key, provider_union_id, corp_id, local_user_id, profile
+           ) VALUES ('dingtalk', $1, $2, $3, $4, '{}'::jsonb)`,
+          [`t2g-lock-first-key-${TS}`, sharedUnionId, corpId, firstUserId],
+        ),
+        query(
+          `INSERT INTO user_external_identities (
+             provider, external_key, provider_union_id, corp_id, local_user_id, profile
+           ) VALUES ('dingtalk', $1, $2, $3, $4, '{}'::jsonb)`,
+          [`t2g-lock-second-key-${TS}`, sharedUnionId, corpId, secondUserId],
+        ),
+      ])
+      expect(inserts.filter((result) => result.status === 'fulfilled')).toHaveLength(1)
+      expect(inserts.filter((result) => result.status === 'rejected')).toHaveLength(1)
+      const identities = await query<{ count: number }>(
+        `SELECT count(*)::int AS count
+           FROM user_external_identities
+          WHERE provider = 'dingtalk'
+            AND corp_id = $1
+            AND provider_union_id = $2`,
+        [corpId, sharedUnionId],
+      )
+      expect(identities.rows).toEqual([{ count: 1 }])
+      return
+    }
     await query(
       `INSERT INTO user_external_identities (
          provider, external_key, provider_union_id, corp_id, local_user_id, profile
@@ -512,7 +586,7 @@ describeIfDatabase('DingTalk directory account corp-scope (real sync, mocked pul
     expect(effects.rows).toEqual([{ identities: 0, linked: 0 }])
   })
 
-  it('fails unbind closed when a repaired account still has a legacy blank-corp identity', async () => {
+  it('fails unbind closed on a legacy blank identity or rejects that state after Phase B', async () => {
     const localUserId = `t2g-blank-unbind-user-${TS}`
     cleanupUserIds.push(localUserId)
     await query(
@@ -533,6 +607,26 @@ describeIfDatabase('DingTalk directory account corp-scope (real sync, mocked pul
       adminUserId: `t2g-admin-${TS}`,
       enableDingTalkGrant: false,
     })
+    if (phaseBSchemaInstalled) {
+      await expect(query(
+        `UPDATE user_external_identities SET corp_id = '' WHERE local_user_id = $1`,
+        [localUserId],
+      )).rejects.toThrow(/user_external_identities_corp_id_canonical/)
+      const state = await query<{ corp_id: string; link_status: string; local_user_id: string }>(
+        `SELECT identity.corp_id, link.link_status, link.local_user_id
+           FROM user_external_identities identity
+           JOIN directory_account_links link ON link.local_user_id = identity.local_user_id
+          WHERE identity.local_user_id = $1
+            AND link.directory_account_id = $2`,
+        [localUserId, directoryAccountId],
+      )
+      expect(state.rows).toEqual([{
+        corp_id: corpIdForTag('blank-unbind'),
+        link_status: 'linked',
+        local_user_id: localUserId,
+      }])
+      return
+    }
     await query(
       `UPDATE user_external_identities SET corp_id = '' WHERE local_user_id = $1`,
       [localUserId],
@@ -558,7 +652,7 @@ describeIfDatabase('DingTalk directory account corp-scope (real sync, mocked pul
     }])
   })
 
-  it('normalizes legacy whitespace corp before rejecting a same-corp identity conflict', async () => {
+  it('normalizes legacy whitespace corp before Phase B or rejects it after Phase B', async () => {
     const existingUserId = `t2g-space-existing-${TS}`
     const targetUserId = `t2g-space-target-${TS}`
     cleanupUserIds.push(existingUserId, targetUserId)
@@ -575,6 +669,27 @@ describeIfDatabase('DingTalk directory account corp-scope (real sync, mocked pul
 
     const corpId = corpIdForTag('space-conflict')
     const sharedUnionId = `t2g-space-union-${TS}`
+    if (phaseBSchemaInstalled) {
+      await expect(query(
+        `INSERT INTO user_external_identities (
+           provider, external_key, provider_union_id, corp_id, local_user_id, profile
+         ) VALUES ('dingtalk', $1, $2, $3, $4, '{}'::jsonb)`,
+        [
+          `t2g-space-existing-key-${TS}`,
+          sharedUnionId,
+          `  ${corpId}  `,
+          existingUserId,
+        ],
+      )).rejects.toThrow(/user_external_identities_corp_id_canonical/)
+      const identities = await query<{ count: number }>(
+        `SELECT count(*)::int AS count
+           FROM user_external_identities
+          WHERE local_user_id = $1`,
+        [existingUserId],
+      )
+      expect(identities.rows).toEqual([{ count: 0 }])
+      return
+    }
     await query(
       `INSERT INTO user_external_identities (
          provider, external_key, provider_union_id, corp_id, local_user_id, profile
@@ -912,6 +1027,42 @@ describeIfDatabase('directory corp-scope Phase B migration (isolated real DB)', 
       )
       expect(await indexNames(db)).toContain('idx_directory_accounts_provider_external_key')
       expect(await constraintNames(db)).not.toContain('directory_integrations_corp_id_canonical')
+    })
+  })
+
+  it('up rejects a same-name INCLUDE replacement index with hidden extra attributes', async () => {
+    await withLegacySchema(async (db) => {
+      await sql`
+        CREATE UNIQUE INDEX idx_directory_accounts_provider_corp_external_key
+        ON directory_accounts(provider, corp_id, external_key)
+        INCLUDE (integration_id)
+        WHERE corp_id IS NOT NULL
+      `.execute(db)
+
+      await expect(runUp(db)).rejects.toThrow(
+        /index drift: idx_directory_accounts_provider_corp_external_key/,
+      )
+      expect(await indexNames(db)).toContain('idx_directory_accounts_provider_external_key')
+      expect(await constraintNames(db)).not.toContain('directory_integrations_corp_id_canonical')
+    })
+  })
+
+  it('up rejects a weaker same-name corp CHECK instead of accepting it as canonical', async () => {
+    await withLegacySchema(async (db) => {
+      await sql`
+        ALTER TABLE directory_accounts
+        ADD CONSTRAINT directory_accounts_corp_id_canonical
+        CHECK (corp_id IS NULL OR length(corp_id) > 0)
+      `.execute(db)
+
+      await expect(runUp(db)).rejects.toThrow(
+        /constraint drift: directory_accounts_corp_id_canonical/,
+      )
+      expect(await indexNames(db)).toContain('idx_directory_accounts_provider_external_key')
+      expect(await indexNames(db)).not.toContain(
+        'idx_directory_accounts_provider_corp_external_key',
+      )
+      expect(await constraintNames(db)).toContain('directory_accounts_corp_id_canonical')
     })
   })
 

--- a/packages/core-backend/tests/integration/directory-account-external-key-collision-mechanism.db.test.ts
+++ b/packages/core-backend/tests/integration/directory-account-external-key-collision-mechanism.db.test.ts
@@ -1,3 +1,7 @@
+import { randomUUID } from 'node:crypto'
+
+import { Kysely, PostgresDialect, sql } from 'kysely'
+import { Pool } from 'pg'
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
 import { Pool } from 'pg'
 
@@ -28,6 +32,10 @@ vi.mock('../../src/integrations/dingtalk/client', () => ({
 }))
 
 import { query } from '../../src/db/pg'
+import {
+  down as corpScopeDown,
+  up as corpScopeUp,
+} from '../../src/db/migrations/zzzz20260725130000_expand_directory_identity_corp_scope'
 import {
   bindDirectoryAccount,
   createDirectoryIntegration,
@@ -641,5 +649,438 @@ describeIfDatabase('DingTalk directory account corp-scope (real sync, mocked pul
       link_status: 'linked',
       match_strategy: 'external_identity',
     }])
+  })
+})
+
+describeIfDatabase('directory corp-scope Phase B migration (isolated real DB)', () => {
+  const dbUrl = process.env.DATABASE_URL!
+
+  async function withLegacySchema(
+    run: (db: Kysely<unknown>) => Promise<void>,
+  ): Promise<void> {
+    const adminPool = new Pool({ connectionString: dbUrl })
+    const schema = `dtcorp_${randomUUID().replace(/-/g, '')}`
+    await adminPool.query(`CREATE SCHEMA "${schema}"`)
+    const testPool = new Pool({
+      connectionString: dbUrl,
+      options: `-c search_path=${schema}`,
+    })
+    const db = new Kysely<unknown>({ dialect: new PostgresDialect({ pool: testPool }) })
+    try {
+      await sql`
+        CREATE TABLE directory_integrations (
+          id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+          provider text NOT NULL DEFAULT 'dingtalk',
+          corp_id text NOT NULL
+        )
+      `.execute(db)
+      await sql`
+        CREATE TABLE directory_accounts (
+          id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+          integration_id uuid NOT NULL REFERENCES directory_integrations(id),
+          provider text NOT NULL,
+          corp_id text,
+          external_key text NOT NULL
+        )
+      `.execute(db)
+      await sql`
+        CREATE TABLE user_external_identities (
+          id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+          provider text NOT NULL,
+          external_key text NOT NULL,
+          provider_union_id text,
+          provider_open_id text,
+          corp_id text
+        )
+      `.execute(db)
+      await sql`
+        CREATE UNIQUE INDEX idx_directory_accounts_provider_external_key
+        ON directory_accounts(provider, external_key)
+      `.execute(db)
+      await run(db)
+    } finally {
+      await db.destroy()
+      await adminPool.query(`DROP SCHEMA IF EXISTS "${schema}" CASCADE`)
+      await adminPool.end()
+    }
+  }
+
+  async function indexNames(db: Kysely<unknown>): Promise<string[]> {
+    const result = await sql<{ indexname: string }>`
+      SELECT indexname
+        FROM pg_indexes
+       WHERE schemaname = current_schema()
+       ORDER BY indexname
+    `.execute(db)
+    return result.rows.map((row) => row.indexname)
+  }
+
+  async function constraintNames(db: Kysely<unknown>): Promise<string[]> {
+    const result = await sql<{ conname: string }>`
+      SELECT constraint_row.conname
+        FROM pg_constraint constraint_row
+        JOIN pg_class table_rel ON table_rel.oid = constraint_row.conrelid
+        JOIN pg_namespace namespace ON namespace.oid = table_rel.relnamespace
+       WHERE namespace.nspname = current_schema()
+         AND constraint_row.contype = 'c'
+       ORDER BY constraint_row.conname
+    `.execute(db)
+    return result.rows.map((row) => row.conname)
+  }
+
+  async function runUp(db: Kysely<unknown>): Promise<void> {
+    await db.transaction().execute(
+      (trx) => corpScopeUp(trx as unknown as Kysely<unknown>),
+    )
+  }
+
+  async function runDown(db: Kysely<unknown>): Promise<void> {
+    await db.transaction().execute(
+      (trx) => corpScopeDown(trx as unknown as Kysely<unknown>),
+    )
+  }
+
+  it('up canonicalizes corp data, installs every scoped guard, permits cross-corp keys, and replays', async () => {
+    await withLegacySchema(async (db) => {
+      const integrationA = randomUUID()
+      const integrationB = randomUUID()
+      await sql`
+        INSERT INTO directory_integrations(id, corp_id)
+        VALUES (${integrationA}, ' corp-a '), (${integrationB}, 'corp-b')
+      `.execute(db)
+      await sql`
+        INSERT INTO directory_accounts(integration_id, provider, corp_id, external_key)
+        VALUES (${integrationA}, 'dingtalk', '', 'shared')
+      `.execute(db)
+      await sql`
+        INSERT INTO user_external_identities(
+          provider, external_key, provider_union_id, provider_open_id, corp_id
+        ) VALUES
+          ('dingtalk', 'identity-a', 'union-a', 'open-a', ' corp-a '),
+          ('dingtalk', 'identity-legacy', 'union-legacy', 'open-legacy', '   ')
+      `.execute(db)
+
+      await runUp(db)
+      await runUp(db)
+
+      expect(await indexNames(db)).toEqual(expect.arrayContaining([
+        'idx_directory_accounts_provider_corp_external_key',
+        'idx_directory_accounts_provider_null_corp_external_key',
+        'idx_user_external_identities_provider_corp_union',
+        'idx_user_external_identities_provider_null_corp_union',
+        'idx_user_external_identities_provider_corp_open',
+        'idx_user_external_identities_provider_null_corp_open',
+      ]))
+      expect(await indexNames(db)).not.toContain('idx_directory_accounts_provider_external_key')
+      expect(await constraintNames(db)).toEqual(expect.arrayContaining([
+        'directory_integrations_corp_id_canonical',
+        'directory_accounts_corp_id_canonical',
+        'user_external_identities_corp_id_canonical',
+      ]))
+
+      const integrationCorps = await sql<{ corp_id: string }>`
+        SELECT corp_id FROM directory_integrations ORDER BY corp_id
+      `.execute(db)
+      expect(integrationCorps.rows).toEqual([{ corp_id: 'corp-a' }, { corp_id: 'corp-b' }])
+      const accountCorp = await sql<{ corp_id: string }>`
+        SELECT corp_id FROM directory_accounts WHERE external_key = 'shared'
+      `.execute(db)
+      expect(accountCorp.rows).toEqual([{ corp_id: 'corp-a' }])
+      const identityCorps = await sql<{ corp_id: string | null }>`
+        SELECT corp_id FROM user_external_identities ORDER BY external_key
+      `.execute(db)
+      expect(identityCorps.rows).toEqual([{ corp_id: 'corp-a' }, { corp_id: null }])
+
+      await expect(sql`
+        INSERT INTO directory_accounts(integration_id, provider, corp_id, external_key)
+        VALUES (${integrationB}, 'dingtalk', 'corp-b', 'shared')
+      `.execute(db)).resolves.toBeTruthy()
+      await expect(sql`
+        INSERT INTO directory_accounts(integration_id, provider, corp_id, external_key)
+        VALUES (${integrationA}, 'dingtalk', 'corp-a', 'shared')
+      `.execute(db)).rejects.toThrow(/idx_directory_accounts_provider_corp_external_key/)
+      await expect(sql`
+        INSERT INTO user_external_identities(
+          provider, external_key, provider_union_id, corp_id
+        ) VALUES ('dingtalk', 'identity-duplicate', 'union-a', 'corp-a')
+      `.execute(db)).rejects.toThrow(/idx_user_external_identities_provider_corp_union/)
+      await expect(sql`
+        INSERT INTO directory_accounts(integration_id, provider, corp_id, external_key)
+        VALUES (${integrationB}, 'dingtalk', ' corp-b ', 'bad-corp-shape')
+      `.execute(db)).rejects.toThrow(/directory_accounts_corp_id_canonical/)
+      await expect(sql`
+        INSERT INTO user_external_identities(provider, external_key, corp_id)
+        VALUES ('dingtalk', 'bad-identity-corp-shape', '   ')
+      `.execute(db)).rejects.toThrow(/user_external_identities_corp_id_canonical/)
+      for (const [suffix, invalidCorp] of [
+        ['tab', '\t'],
+        ['newline', '\n'],
+        ['nbsp', '\u00a0'],
+        ['em-space', '\u2003'],
+        ['bom', '\ufeff'],
+      ]) {
+        await expect(sql`
+          INSERT INTO user_external_identities(provider, external_key, corp_id)
+          VALUES ('dingtalk', ${`bad-identity-${suffix}`}, ${invalidCorp})
+        `.execute(db)).rejects.toThrow(/user_external_identities_corp_id_canonical/)
+      }
+      await expect(sql`
+        INSERT INTO user_external_identities(provider, external_key, corp_id)
+        VALUES ('dingtalk', 'null-identity-corp', NULL)
+      `.execute(db)).resolves.toBeTruthy()
+    })
+  })
+
+  it('up fails closed and rolls back every change when a parent integration corp is blank', async () => {
+    await withLegacySchema(async (db) => {
+      const integrationId = randomUUID()
+      await sql`INSERT INTO directory_integrations(id, corp_id) VALUES (${integrationId}, '')`.execute(db)
+      await sql`
+        INSERT INTO directory_accounts(integration_id, provider, corp_id, external_key)
+        VALUES (${integrationId}, 'dingtalk', NULL, 'legacy')
+      `.execute(db)
+
+      await expect(runUp(db)).rejects.toThrow(/integration scope is non-canonical/)
+      expect(await indexNames(db)).toContain('idx_directory_accounts_provider_external_key')
+      expect(await indexNames(db)).not.toContain('idx_directory_accounts_provider_corp_external_key')
+      expect(await constraintNames(db)).not.toContain('directory_accounts_corp_id_canonical')
+    })
+  })
+
+  it('up rejects account/provider drift instead of silently adopting the parent corp', async () => {
+    await withLegacySchema(async (db) => {
+      const integrationId = randomUUID()
+      await sql`
+        INSERT INTO directory_integrations(id, provider, corp_id)
+        VALUES (${integrationId}, 'dingtalk', 'corp-a')
+      `.execute(db)
+      await sql`
+        INSERT INTO directory_accounts(integration_id, provider, corp_id, external_key)
+        VALUES (${integrationId}, 'other-provider', NULL, 'legacy')
+      `.execute(db)
+
+      await expect(runUp(db)).rejects.toThrow(/account parent scope is inconsistent/)
+      expect(await indexNames(db)).toContain('idx_directory_accounts_provider_external_key')
+      expect(await constraintNames(db)).not.toContain('directory_integrations_corp_id_canonical')
+    })
+  })
+
+  it('up rejects duplicate same-scope union identities without dropping the legacy account guard', async () => {
+    await withLegacySchema(async (db) => {
+      await sql`
+        INSERT INTO user_external_identities(
+          provider, external_key, provider_union_id, corp_id
+        ) VALUES
+          ('dingtalk', 'identity-a', 'duplicate-union', 'corp-a'),
+          ('dingtalk', 'identity-b', 'duplicate-union', 'corp-a')
+      `.execute(db)
+
+      await expect(runUp(db)).rejects.toThrow(/idx_user_external_identities_provider_corp_union/)
+      expect(await indexNames(db)).toContain('idx_directory_accounts_provider_external_key')
+      expect(await indexNames(db)).not.toContain('idx_directory_accounts_provider_corp_external_key')
+      expect(await constraintNames(db)).not.toContain('directory_accounts_corp_id_canonical')
+    })
+  })
+
+  it('up rejects a same-name wrong-definition replacement index and keeps the legacy guard', async () => {
+    await withLegacySchema(async (db) => {
+      await sql`
+        CREATE UNIQUE INDEX idx_directory_accounts_provider_corp_external_key
+        ON directory_accounts(provider, external_key)
+        WHERE corp_id IS NOT NULL
+      `.execute(db)
+
+      await expect(runUp(db)).rejects.toThrow(
+        /index drift: idx_directory_accounts_provider_corp_external_key/,
+      )
+      expect(await indexNames(db)).toContain('idx_directory_accounts_provider_external_key')
+      expect(await indexNames(db)).toContain('idx_directory_accounts_provider_corp_external_key')
+      expect(await constraintNames(db)).not.toContain('directory_accounts_corp_id_canonical')
+    })
+  })
+
+  it('up rejects a same-name expression replacement index that only appears to have the right keys', async () => {
+    await withLegacySchema(async (db) => {
+      await sql`
+        CREATE UNIQUE INDEX idx_directory_accounts_provider_corp_external_key
+        ON directory_accounts(provider, corp_id, external_key, ((id::text)))
+        WHERE corp_id IS NOT NULL
+      `.execute(db)
+
+      await expect(runUp(db)).rejects.toThrow(
+        /index drift: idx_directory_accounts_provider_corp_external_key/,
+      )
+      expect(await indexNames(db)).toContain('idx_directory_accounts_provider_external_key')
+      expect(await constraintNames(db)).not.toContain('directory_integrations_corp_id_canonical')
+    })
+  })
+
+  it('up rejects a partially applied no-legacy state instead of treating it as a replay', async () => {
+    await withLegacySchema(async (db) => {
+      await sql`DROP INDEX idx_directory_accounts_provider_external_key`.execute(db)
+      await sql`
+        CREATE UNIQUE INDEX idx_directory_accounts_provider_corp_external_key
+        ON directory_accounts(provider, corp_id, external_key)
+        WHERE corp_id IS NOT NULL
+      `.execute(db)
+
+      await expect(runUp(db)).rejects.toThrow(
+        /index drift: idx_directory_accounts_provider_null_corp_external_key/,
+      )
+      expect(await indexNames(db)).toEqual(expect.arrayContaining([
+        'idx_directory_accounts_provider_corp_external_key',
+      ]))
+      expect(await indexNames(db)).not.toContain(
+        'idx_directory_accounts_provider_null_corp_external_key',
+      )
+      expect(await constraintNames(db)).not.toContain('directory_accounts_corp_id_canonical')
+    })
+  })
+
+  it('compatible down restores the global guard first and replays', async () => {
+    await withLegacySchema(async (db) => {
+      const integrationId = randomUUID()
+      await sql`INSERT INTO directory_integrations(id, corp_id) VALUES (${integrationId}, 'corp-a')`.execute(db)
+      await sql`
+        INSERT INTO directory_accounts(integration_id, provider, corp_id, external_key)
+        VALUES (${integrationId}, 'dingtalk', 'corp-a', 'one')
+      `.execute(db)
+
+      await runUp(db)
+      const canonicalBeforeDown = await sql<{ corp_id: string }>`
+        SELECT corp_id FROM directory_integrations WHERE id = ${integrationId}
+      `.execute(db)
+      await runDown(db)
+      await runDown(db)
+
+      expect(await indexNames(db)).toContain('idx_directory_accounts_provider_external_key')
+      expect(await indexNames(db)).not.toContain('idx_directory_accounts_provider_corp_external_key')
+      expect(await constraintNames(db)).not.toContain('directory_accounts_corp_id_canonical')
+      expect(await constraintNames(db)).not.toContain('directory_integrations_corp_id_canonical')
+      const canonicalAfterDown = await sql<{ corp_id: string }>`
+        SELECT corp_id FROM directory_integrations WHERE id = ${integrationId}
+      `.execute(db)
+      expect(canonicalAfterDown.rows).toEqual(canonicalBeforeDown.rows)
+    })
+  })
+
+  it('incompatible down preserves all scoped protections', async () => {
+    await withLegacySchema(async (db) => {
+      const integrationA = randomUUID()
+      const integrationB = randomUUID()
+      await sql`
+        INSERT INTO directory_integrations(id, corp_id)
+        VALUES (${integrationA}, 'corp-a'), (${integrationB}, 'corp-b')
+      `.execute(db)
+      await runUp(db)
+      await sql`
+        INSERT INTO directory_accounts(integration_id, provider, corp_id, external_key)
+        VALUES
+          (${integrationA}, 'dingtalk', 'corp-a', 'shared'),
+          (${integrationB}, 'dingtalk', 'corp-b', 'shared')
+      `.execute(db)
+
+      await expect(runDown(db)).rejects.toThrow(/idx_directory_accounts_provider_external_key/)
+      expect(await indexNames(db)).toEqual(expect.arrayContaining([
+        'idx_directory_accounts_provider_corp_external_key',
+        'idx_user_external_identities_provider_corp_union',
+      ]))
+      expect(await constraintNames(db)).toContain('directory_accounts_corp_id_canonical')
+    })
+  })
+
+  it('down rejects a same-name wrong legacy index and leaves scoped protections intact', async () => {
+    await withLegacySchema(async (db) => {
+      await runUp(db)
+      await sql`
+        CREATE UNIQUE INDEX idx_directory_accounts_provider_external_key
+        ON directory_accounts(external_key)
+      `.execute(db)
+
+      await expect(runDown(db)).rejects.toThrow(
+        /index drift: idx_directory_accounts_provider_external_key/,
+      )
+      expect(await indexNames(db)).toEqual(expect.arrayContaining([
+        'idx_directory_accounts_provider_external_key',
+        'idx_directory_accounts_provider_corp_external_key',
+        'idx_user_external_identities_provider_corp_union',
+      ]))
+      expect(await constraintNames(db)).toContain('directory_accounts_corp_id_canonical')
+    })
+  })
+
+  it('down rejects a same-name expression legacy index and leaves scoped protections intact', async () => {
+    await withLegacySchema(async (db) => {
+      await runUp(db)
+      await sql`
+        CREATE UNIQUE INDEX idx_directory_accounts_provider_external_key
+        ON directory_accounts(provider, external_key, ((id::text)))
+      `.execute(db)
+
+      await expect(runDown(db)).rejects.toThrow(
+        /index drift: idx_directory_accounts_provider_external_key/,
+      )
+      expect(await indexNames(db)).toEqual(expect.arrayContaining([
+        'idx_directory_accounts_provider_external_key',
+        'idx_directory_accounts_provider_corp_external_key',
+        'idx_user_external_identities_provider_corp_union',
+      ]))
+      expect(await constraintNames(db)).toContain('directory_integrations_corp_id_canonical')
+    })
+  })
+
+  it('restores caller transaction timeouts after successful up and down', async () => {
+    await withLegacySchema(async (db) => {
+      await db.transaction().execute(async (trx) => {
+        await sql`SELECT set_config('lock_timeout', '37s', true)`.execute(trx)
+        await sql`SELECT set_config('statement_timeout', '41s', true)`.execute(trx)
+        await corpScopeUp(trx as unknown as Kysely<unknown>)
+        const afterUp = await sql<{ lock_timeout: string; statement_timeout: string }>`
+          SELECT
+            current_setting('lock_timeout') AS lock_timeout,
+            current_setting('statement_timeout') AS statement_timeout
+        `.execute(trx)
+        expect(afterUp.rows).toEqual([{ lock_timeout: '37s', statement_timeout: '41s' }])
+
+        await corpScopeDown(trx as unknown as Kysely<unknown>)
+        const afterDown = await sql<{ lock_timeout: string; statement_timeout: string }>`
+          SELECT
+            current_setting('lock_timeout') AS lock_timeout,
+            current_setting('statement_timeout') AS statement_timeout
+        `.execute(trx)
+        expect(afterDown.rows).toEqual([{ lock_timeout: '37s', statement_timeout: '41s' }])
+      })
+    })
+  })
+
+  it('bounds lock waiting and rolls back without dropping the legacy guard', async () => {
+    await withLegacySchema(async (db) => {
+      const schemaResult = await sql<{ schema_name: string }>`
+        SELECT current_schema() AS schema_name
+      `.execute(db)
+      const schemaName = schemaResult.rows[0].schema_name
+      const blockerPool = new Pool({
+        connectionString: dbUrl,
+        options: `-c search_path=${schemaName}`,
+      })
+      const blocker = await blockerPool.connect()
+      try {
+        await blocker.query('BEGIN')
+        await blocker.query('LOCK TABLE directory_accounts IN ACCESS EXCLUSIVE MODE')
+        const startedAt = Date.now()
+        await expect(runUp(db)).rejects.toThrow(/lock timeout|canceling statement due to lock timeout/i)
+        const elapsedMs = Date.now() - startedAt
+        expect(elapsedMs).toBeGreaterThanOrEqual(4_000)
+        expect(elapsedMs).toBeLessThan(10_000)
+      } finally {
+        await blocker.query('ROLLBACK')
+        blocker.release()
+        await blockerPool.end()
+      }
+
+      expect(await indexNames(db)).toContain('idx_directory_accounts_provider_external_key')
+      expect(await indexNames(db)).not.toContain('idx_directory_accounts_provider_corp_external_key')
+      expect(await constraintNames(db)).not.toContain('directory_integrations_corp_id_canonical')
+    })
   })
 })

--- a/packages/core-backend/tests/integration/directory-tenant-change-immutable.db.test.ts
+++ b/packages/core-backend/tests/integration/directory-tenant-change-immutable.db.test.ts
@@ -14,8 +14,9 @@ import { DirectoryTenantChangeBlockedError, updateDirectoryIntegration } from '.
  * flight; nothing has been written). A "block only if synced records already exist" rule
  * would let that swap through. These goldens seed that real row shape directly against the
  * migrated schema and re-SELECT after every rejected call to prove zero mutation, not just a
- * thrown error — plus the same-corp resend path that must remain allowed. Legacy empty rows
- * are fail-closed because a generic update cannot atomically retag existing or racing children.
+ * thrown error — plus the same-corp resend path that must remain allowed. Before Phase B, legacy
+ * empty rows are fail-closed because a generic update cannot atomically retag existing or racing
+ * children. After Phase B, the database rejects that legacy-invalid row shape outright.
  */
 const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
 
@@ -45,6 +46,20 @@ async function readIntegration(id: string): Promise<{ corp_id: string; name: str
     [id],
   )
   return result.rows[0]
+}
+
+async function phaseBCorpConstraintInstalled(): Promise<boolean> {
+  const result = await query<{ installed: boolean }>(
+    `SELECT EXISTS (
+       SELECT 1
+         FROM pg_constraint constraint_row
+         JOIN pg_class table_row ON table_row.oid = constraint_row.conrelid
+        WHERE constraint_row.conname = 'directory_integrations_corp_id_canonical'
+          AND constraint_row.contype = 'c'
+          AND table_row.relname = 'directory_integrations'
+     ) AS installed`,
+  )
+  return result.rows[0]?.installed === true
 }
 
 function updateInput(overrides: { name: string; corpId: string }) {
@@ -119,7 +134,24 @@ describeIfDatabase('org-transfer Phase 1 §12.1 corp_id immutable-once-set guard
     expect(row.name).toBe(`renamed-${STAMP}`)
   })
 
-  it('legacy empty corp_id cannot be set through the generic update path', async () => {
+  it('legacy empty corp_id is blocked by the generic update before Phase B or rejected by the database after Phase B', async () => {
+    if (await phaseBCorpConstraintInstalled()) {
+      await expect(
+        insertIntegration(`initial-set-${STAMP}`, ''),
+      ).rejects.toMatchObject({
+        code: '23514',
+        constraint: 'directory_integrations_corp_id_canonical',
+      })
+      const residue = await query<{ count: number }>(
+        `SELECT count(*)::int AS count
+           FROM directory_integrations
+          WHERE name = $1`,
+        [`initial-set-${STAMP}`],
+      )
+      expect(residue.rows).toEqual([{ count: 0 }])
+      return
+    }
+
     const id = await insertIntegration(`initial-set-${STAMP}`, '')
     integrationIds.push(id)
 


### PR DESCRIPTION
## Phase B stacked migration

Stacked on Phase A #4602. **Do not retarget, merge, or deploy this PR before Phase A is reviewed. Do not deploy it until Phase A is running on every worker and all older workers are drained.**

## Contract

- canonicalize the parent integration corp, then copy that authoritative value to every account;
- require the parent integration corp column to remain `NOT NULL`, and reject NULL, blank, non-printable, or whitespace-containing scope;
- reject parent provider drift;
- normalize legacy external-identity whitespace corp to canonical text/NULL, then reject remaining non-canonical values;
- add canonical corp CHECK constraints to integrations, accounts, and identities;
- add account, unionId, and openId scoped partial unique indexes, including NULL-corp legacy identity scopes;
- structurally verify uniqueness, validity, table, ordered key-only columns, key/total-attribute counts, absence of expressions, and predicates;
- refuse same-name drift, expression/INCLUDE-key disguises, weaker same-name CHECKs, and partial no-legacy states;
- recreate and verify the global account guard before down removes scoped protection;
- preserve all scoped protections when down is data-incompatible;
- bound lock wait to 5 seconds and statements to 5 minutes, restoring the caller settings on success;
- provide a values-free `REPEATABLE READ READ ONLY` preflight that projects every Phase B data/schema blocker before the migration window.

Kysely 0.28 supplies one transaction for the pending PostgreSQL migration batch. The migration opens no nested transaction. Compatible down restores the old schema guards but intentionally does not reverse data canonicalization.

Operational preflight:

```bash
DATABASE_URL="$STAGING_DATABASE_URL" \
  pnpm --silent --filter @metasheet/core-backend \
  preflight:dingtalk-directory-corp-scope
```

Only exit `0` / status `PASS` permits the controlled migration. Exit `2` is `BLOCKED`; exit `1` is `ERROR`. Output contains counts, booleans, and stable blocker codes only, never corp/user/account values, credentials, raw database errors, or the database URL.

## Verification on exact head `dbc4bfec5`

- pre-Phase-B public schema + preflight + isolated migration suite: 40/40 on PostgreSQL 15.17
- fully migrated Phase-B public schema + the same suite: 40/40; five legacy-state tests assert the stronger DB refusal instead of skipping
- fully migrated PostgreSQL 14.23: 40/40 locally; required PostgreSQL 14 CI remains a post-retarget gate
- CLI subprocess contract in the required real-DB file: `PASS/0`, `BLOCKED/2`, `ERROR/1`
- full fresh-database Migrator reaches the new migration; replay has no pending work
- real second-connection lock contention aborts around 5.2 seconds with the legacy guard retained
- synthetic 10-integration / 100,000-account / 200,000-identity migration: 3,158 ms, 9 indexes, 3 CHECKs, 0 NULL account corp
- TypeScript, required-file CI wiring 26/26, and diff checks clean
- seventeen discriminating Phase B mutations killed, including nullable parent-corp schema/data gates and CLI exit-code mapping
- independent exact-delta adversarial re-review: APPROVE, no P1/P2/P3

Current stacked checks are not the final required suite. PostgreSQL 14 and the full required matrix must run after Phase A lands and this PR retargets.

## Boundaries

No merge or deployment. No flag changes. No automatic sync or deprovision. No new user. Staging preflight, controlled migration, two-enterprise UAT, and the authorized existing-user bind remain owner-gated after the Phase A rollout/drain proof.
