### PR TITLE
test(attendance): W4C-0 E1 — absorb teardown-scoped 57P01 from scratch FORCE drop (CI flake root fix)

### DIFF
--- a/packages/core-backend/tests/integration/attendance-w4c0-db-gates-e1.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-w4c0-db-gates-e1.db.test.ts
@@ -300,6 +300,7 @@ describeIfDatabase('W4C-0 Stage E1 — section 12.1 database gates (real DB)', (
     const scratchName = `ms2_w4c0_e1_${RUN}`
     let adminPool: Pool
     let scratchPool: Pool
+    let scratchKyselyPool: Pool
     let scratchDb: Kysely<unknown>
     // Captured legacy bytes for the upgrade-preservation assertion.
     let legacyJobsBefore: string[] = []
@@ -314,8 +315,9 @@ describeIfDatabase('W4C-0 Stage E1 — section 12.1 database gates (real DB)', (
       const scratchUrl = new URL(dbUrl as string)
       scratchUrl.pathname = `/${scratchName}`
       scratchPool = new Pool({ connectionString: scratchUrl.toString() })
+      scratchKyselyPool = new Pool({ connectionString: scratchUrl.toString() })
       scratchDb = new Kysely<unknown>({
-        dialect: new PostgresDialect({ pool: new Pool({ connectionString: scratchUrl.toString() }) }),
+        dialect: new PostgresDialect({ pool: scratchKyselyPool }),
       })
       // Minimal legacy replicas: exactly the columns the migration DDL (ALTER/FK/unique)
       // and its triggers reference. The behavior matrix runs against the REAL schema on
@@ -375,6 +377,13 @@ describeIfDatabase('W4C-0 Stage E1 — section 12.1 database gates (real DB)', (
     }, 60000)
 
     afterAll(async () => {
+      // Teardown-scoped FATAL absorber (CI flake root-caused on PR #4607): pool.end()
+      // resolves when the client-side sockets close, but a backend whose server-side
+      // teardown races that close is then killed by WITH (FORCE) and emits an async
+      // 57P01 FATAL on the already-"ended" pool — vitest counts that unhandled 'error'
+      // event and exits 1 with all tests green. Handlers are attached ONLY here, at
+      // teardown start, so a FATAL during the tests themselves still fails loudly.
+      for (const p of [scratchPool, scratchKyselyPool, adminPool]) p?.on('error', () => undefined)
       await scratchDb?.destroy()
       await scratchPool?.end()
       await adminPool?.query(`DROP DATABASE IF EXISTS ${scratchName} WITH (FORCE)`).catch(() => undefined)


### PR DESCRIPTION
**症状**（PR #4607 `test (20.x)` 实录）：**753/753 全绿但 vitest exit 1**——`Errors 1 error`，序列化错误 `code: '57P01'`（FATAL: terminating connection due to administrator command），归因文件 `attendance-w4c0-db-gates-e1.db.test.ts`，最后测试 = `migration lifecycle (scratch database)`。

**根因**：scratch 的 `afterAll` 先 `pool.end()` 再 `DROP DATABASE … WITH (FORCE)`。`end()` 在**客户端** socket 关闭时 resolve，而 server 侧 backend 拆除与之竞态——残余 backend 被 FORCE 杀掉后向已「ended」的 pool 异步发出 57P01，成为 vitest 的 unhandled `error` 事件。

**修法（外科，teardown-scoped by construction）**：三个 scratch 生命周期 pool 的 no-op `error` handler **只在 afterAll 开头挂**——测试期间不挂，真 FATAL 仍响亮失败，不引入任何掩蔽面。匿名的 Kysely pool 提名为 `scratchKyselyPool` 以便挂接。零断言改动。

**验证**：CI 同构迁移库上连续 5 次 `20/20, 零 unhandled error`；`tsc --noEmit` 0。

独立 test-infra 小修，不属任何 W4C 切片；与 #4607（已获门审 APPROVE @ exact head）无文件交集。

refs #4556

🤖 Generated with [Claude Code](https://claude.com/claude-code)