### PR TITLE
fix(integration-core): close B1a-2 canonical readiness brand rethrow

### DIFF
--- a/docs/development/gip-b1a2-canonical-registry-brand-rethrow-fix-dev-verification-20260726.md
+++ b/docs/development/gip-b1a2-canonical-registry-brand-rethrow-fix-dev-verification-20260726.md
@@ -1,0 +1,109 @@
+# GIP B1a-2 Canonical Registry Brand-Rethrow Fix — Development and Verification
+
+**Status:** BUILT and independently verified, **HELD** as a child fix for Draft PR
+`zensgit/metasheet2#4610`. This document does not authorize merging, runtime
+wiring, deployment, or activation.
+
+## 1. Scope and evidence boundary
+
+The review started from exact parent head
+`1e761bc2450ad66e850624bf479be259319bb592` and was revalidated after the
+parent advanced to
+`c79576296e` (`#4610` round 10).
+
+The new parent commit changes only the connector-kind registry's rejection
+wording and its boundary tests. It does not touch the canonical-object
+registry fixed here. The child was rebased onto that exact parent, and its net
+diff remains the same canonical implementation/test pair plus this DEV/V file.
+
+The parent slice remains LATENT:
+
+- the connector-kind and canonical-object registries ship empty;
+- the trusted system-identity service and inventory attestation have no call
+  sites;
+- no route, scheduler, flag, or runtime consumer imports the three B1a-2
+  modules.
+
+The defect below is therefore not a production-path exploit in the shipped
+tree. It is still a real, parent-PR-blocking breach of the closed error
+contract on an exported `__internals` mechanism.
+
+## 2. Confirmed defect
+
+`gip-canonical-object-contract-registry.cjs` exported both:
+
+- the `GipCanonicalObjectContractError` constructor; and
+- `__internals.computeActivationReadiness(registry, references)`.
+
+The latter caught `registry.lookup(...)` errors but rethrew every
+`GipCanonicalObjectContractError` unchanged. A hostile registry could therefore
+throw a forged instance carrying an arbitrary reason, message, details, cause,
+and stack. Those caller-controlled values crossed the boundary unchanged even
+though a raw `TypeError` from the same callback was converted to the fixed
+`CANONICAL_OBJECT_CONTRACT_DECLARATION_INVALID` error.
+
+The pre-fix probe reproduced three sentinel hits in the escaped
+message/details/stack. The production activation gate was also probed and
+correctly rejected the hostile registry at its private-identity trust check;
+that negative control is why this document does not claim live production
+reachability.
+
+## 3. Repair
+
+`computeActivationReadiness` now:
+
+1. reads and validates each `contractId` and `version` with the module's own
+   `requiredIdentityToken` before entering the foreign callback;
+2. passes only those validated tokens to `registry.lookup`; and
+3. discards every exception from `registry.lookup` unconditionally, replacing
+   it with the fixed, values-free registry error.
+
+Pre-validation preserves the existing malformed-reference contract:
+`contractId: ""` still fails with
+`CANONICAL_OBJECT_CONTRACT_DECLARATION_INVALID` and
+`details.field === "contractId"`. The callback catch no longer needs a branded
+exception exemption because no module-authored validation is left inside it.
+
+The regression test supplies a hostile registry that throws a forged branded
+error with distinct reason, message/details, and cause sentinels. It asserts
+that none survive and keeps the malformed-token case as a positive control.
+
+## 4. Independent review
+
+- **Codex:** reproduced the pre-fix leak, inspected all eight parent-PR files,
+  verified zero runtime consumers, and reviewed the final diff.
+- **Grok 4.5:** independently reproduced the same branded-rethrow hole,
+  implemented the two-file repair, and ran the focused suite.
+- **Kimi K3:** read-only review independently confirmed the defect and the
+  pre-validate-then-unconditionally-discard repair; it found no additional
+  confirmed defect in the eight-file parent scope.
+
+The reviewers agree on the boundary: real contract defect, LATENT-only
+reachability at this head, no claim of production exploitation.
+
+## 5. Verification
+
+All commands ran in the isolated child worktree based on the exact parent head.
+
+| Check | Result |
+| --- | --- |
+| Eight plain-Node `gip-*.test.cjs` contract files | PASS |
+| `npm --prefix plugins/plugin-integration-core run test:gip-canonical-object-contract-registry` | PASS |
+| `git diff --check` | PASS |
+| Tree-wide import/symbol search excluding the three modules and paired tests | zero runtime consumers |
+| Mutation: restore `instanceof GipCanonicalObjectContractError` rethrow | expected RED, exit 1 |
+| Mutation discriminator | forged `UNREGISTERED` reason escaped instead of fixed `DECLARATION_INVALID` |
+| Restore fixed implementation and rerun focused test | PASS |
+
+The mutation changed only the catch branch, was not committed, and was restored
+before the final test run.
+
+## 6. Remaining gates
+
+- Parent PR `#4610` remains Draft/HOLD.
+- This child fix must be reviewed against its exact head and merged only into
+  the parent branch before any parent ratification decision.
+- No connector kind, canonical contract, trusted service, or inventory
+  attestation is populated by this change.
+- Runtime wiring, migration, deployment, and feature activation remain outside
+  this authorization.

--- a/plugins/plugin-integration-core/__tests__/gip-canonical-object-contract-registry.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/gip-canonical-object-contract-registry.test.cjs
@@ -713,15 +713,65 @@ function computeActivationReadinessNeverEscapesRawForeignErrors() {
   const serializedLookup = String(caughtLookup.message) + JSON.stringify(caughtLookup.details) + String(caughtLookup.stack)
   assert.ok(!serializedLookup.includes(lookupMarker), 'the raw marker text must never leak into the branded error')
 
-  // Non-regression: a registry.lookup() call that throws its OWN legitimate
-  // branded error (e.g. a malformed contractId) must propagate UNCHANGED,
-  // never re-labeled as a `registry` failure.
+  // (c2) P1 FIX (adversarial residual after #4610 head): the round-7 catch
+  // re-threw any GipCanonicalObjectContractError unchanged, so a hostile
+  // registry.lookup that threw a FORGED branded error (the class is a public
+  // constructor) smuggled attacker message/details/cause past the "never
+  // escape raw foreign error" guard that already covered TypeError. This is
+  // the same brand-exemption class system-identity round 3 deleted. Positive
+  // control just below: a genuine malformed token still fails with field
+  // contractId (pre-validation), proving the pin is not a blanket "every
+  // lookup failure becomes field:registry".
+  const forgedBrandMarker = 'ACTIVATION-READINESS-FORGED-BRAND-MARKER'
+  const forgedCauseMarker = 'ACTIVATION-READINESS-FORGED-CAUSE-MARKER'
+  const forgedBrandRegistry = {
+    lookup() {
+      const err = new GipCanonicalObjectContractError(
+        'CANONICAL_OBJECT_CONTRACT_UNREGISTERED',
+        `forged branded leak ${forgedBrandMarker}`,
+        { leaked: forgedBrandMarker, nested: { s: forgedBrandMarker } },
+      )
+      err.cause = new Error(forgedCauseMarker)
+      throw err
+    },
+  }
+  const caughtForgedBrand = rejects(
+    () => __internals.computeActivationReadiness(forgedBrandRegistry, [{ contractId: 'bom_line', version: 'v1' }]),
+    'CANONICAL_OBJECT_CONTRACT_DECLARATION_INVALID',
+    'a forged GipCanonicalObjectContractError from hostile registry.lookup must be discarded and converted, never rethrown',
+  )
+  assert.equal(caughtForgedBrand.details.field, 'registry')
+  assert.equal(
+    caughtForgedBrand.message,
+    'registry.lookup could not be evaluated',
+    'POSITIVE CONTROL of the fixed reason text — a message-only or reason-only check could be satisfied by rethrowing the forged error if it happened to use the same reason token',
+  )
+  assert.equal(caughtForgedBrand.reason, 'CANONICAL_OBJECT_CONTRACT_DECLARATION_INVALID')
+  assert.notEqual(
+    caughtForgedBrand.reason,
+    'CANONICAL_OBJECT_CONTRACT_UNREGISTERED',
+    'MUTATION DISCRIMINATOR — the forged reason token must not survive; reintroducing `if (error instanceof GipCanonicalObjectContractError) throw error` would let UNREGISTERED through and this assertion reds',
+  )
+  const serializedForged = String(caughtForgedBrand.message)
+    + JSON.stringify(caughtForgedBrand.details)
+    + String(caughtForgedBrand.stack)
+    + String(caughtForgedBrand.cause && caughtForgedBrand.cause.message)
+    + JSON.stringify(caughtForgedBrand.cause)
+  assert.ok(!serializedForged.includes(forgedBrandMarker), 'forged branded message/details/stack must never leak')
+  assert.ok(!serializedForged.includes(forgedCauseMarker), 'forged .cause chain must never leak')
+  assert.equal(caughtForgedBrand.cause, undefined, 'replacement error must not retain the foreign .cause pointer')
+
+  // Positive control: a malformed reference contractId is refused by THIS
+  // module's own requiredIdentityToken pre-validation (field: contractId),
+  // never re-labeled as a `registry` failure and never dependent on
+  // rethrowing whatever registry.lookup threw. Discriminates against a
+  // broken fix that only ever emits field:registry for every bad reference.
   const malformedRefCaught = rejects(
     () => __internals.computeActivationReadiness(registry, [{ contractId: '', version: 'v1' }]),
     'CANONICAL_OBJECT_CONTRACT_DECLARATION_INVALID',
-    'a malformed reference contractId must propagate lookup()\'s own branded error unchanged',
+    'a malformed reference contractId must fail via requiredIdentityToken pre-validation with field contractId',
   )
-  assert.equal(malformedRefCaught.details.field, 'contractId', 'the branded error from inside registry.lookup() must keep its ORIGINAL field, not be re-labeled to "registry"')
+  assert.equal(malformedRefCaught.details.field, 'contractId', 'the pre-validation error must keep field contractId, not be re-labeled to "registry"')
 }
 
 // ---------------------------------------------------------------------------

--- a/plugins/plugin-integration-core/lib/gip-canonical-object-contract-registry.cjs
+++ b/plugins/plugin-integration-core/lib/gip-canonical-object-contract-registry.cjs
@@ -584,25 +584,43 @@ function assertTrustedInventoryAttestation(inventoryReport) {
 // FUNCTION if the caller passes a duck-typed registry object (this function
 // takes no trust check on `registry` — that is the CALLER's job, per this
 // comment's own "ALREADY-TRUSTED" precondition — but "the caller is supposed
-// to have checked" does not stop a raw throw from a caller who didn't). The
-// `registry.lookup` catch re-throws unchanged when the caught error is
-// ALREADY a GipCanonicalObjectContractError — lookup()'s own internal
-// requiredIdentityToken validation legitimately throws that type for a
-// malformed contractId/version, and that branded throw must propagate as-is,
-// not be re-labeled as a `registry` failure.
+// to have checked" does not stop a raw throw from a caller who didn't).
+//
+// P1 FIX (adversarial residual after #4610 head): the round-7 catch used to
+// re-throw unchanged when the caught error was ALREADY a
+// GipCanonicalObjectContractError, reasoning that lookup()'s own
+// requiredIdentityToken validation legitimately throws that type. That
+// reasoning is the SAME brand-exemption class gip-system-identity-read.cjs
+// round 3 deleted entirely: GipCanonicalObjectContractError is a PUBLIC
+// constructor (exported on module.exports), so a hostile registry.lookup can
+// `throw new GipCanonicalObjectContractError(reason, attackerMessage,
+// attackerDetails)` — optionally with `.cause` chained — and the exemption
+// forwards attacker text VERBATIM (message/details/cause/stack). A TypeError
+// from the same lookup was already converted; the branded form was the hole
+// the TypeError-only probe missed. Fix: validate contractId/version HERE via
+// requiredIdentityToken (module-authored, values-free) BEFORE calling
+// lookup, then discard EVERY throw from lookup unconditionally and replace
+// it with this module's fixed reason. After pre-validation, a genuine
+// createCanonicalObjectContractRegistry lookup cannot throw for token shape
+// (its own requiredIdentityToken would accept the same values) — it only
+// returns found/null — so the "legitimate branded rethrow" case no longer
+// needs to cross this catch at all.
 function computeActivationReadiness(registry, references) {
   const referencesLength = readArrayLength(references, 'references')
   let backedCount = 0
   let unbackedCount = 0
   for (let index = 0; index < referencesLength; index += 1) {
     const reference = readArrayElement(references, index, 'references')
-    const contractId = readEntryField(reference, 'contractId')
-    const version = readEntryField(reference, 'version')
+    // Pre-validate BEFORE lookup so a malformed token fails with THIS
+    // module's own requiredIdentityToken error (field: contractId|version),
+    // never by rethrowing whatever registry.lookup chose to throw.
+    const contractId = requiredIdentityToken(readEntryField(reference, 'contractId'), 'contractId')
+    const version = requiredIdentityToken(readEntryField(reference, 'version'), 'version')
     let found
     try {
       found = registry.lookup(contractId, version)
-    } catch (error) {
-      if (error instanceof GipCanonicalObjectContractError) throw error
+    } catch {
+      // Unconditional discard — no brand exemption. See the P1 fix note above.
       fail('CANONICAL_OBJECT_CONTRACT_DECLARATION_INVALID', 'registry.lookup could not be evaluated', { field: 'registry' })
     }
     if (found) backedCount += 1


### PR DESCRIPTION
## Scope

Child security fix for Draft PR #4610, rebased onto exact parent head `c79576296eed29b28a8da5f7009882fa8303d8f1`.

The parent advanced from the originally reviewed `1e761bc2450ad66e850624bf479be259319bb592` by one round-10 commit limited to connector-kind rejection wording and its boundary tests. The child net diff remains the canonical-object implementation/test pair plus its DEV/V document.

This remains LATENT: no route, scheduler, flag, runtime consumer, populated registry, trusted service, or inventory attestation is added. This PR does not target `main` and does not authorize merge, runtime wiring, deployment, or activation.

## Confirmed defect

`__internals.computeActivationReadiness()` converted raw `registry.lookup()` failures but rethrew every `GipCanonicalObjectContractError` unchanged. Because the error class is public, a hostile lookup could forge arbitrary `reason`, `message`, `details`, `cause`, and `stack`; those values escaped the module's stated closed error contract.

The production activation gate was checked separately and rejects a hostile registry before this path. The defect is real but limited to the exported `__internals` mechanism at this LATENT head.

## Repair

- Validate `contractId` and `version` with module-owned `requiredIdentityToken` before the foreign callback.
- Unconditionally discard every `registry.lookup()` exception and emit the fixed values-free registry error.
- Preserve the malformed-token contract with a positive control (`details.field === contractId`).
- Add a forged-branded-error regression test covering reason, message/details, cause, and stack.

## Verification

- Eight plain-Node `gip-*.test.cjs` contract files, including the parent's round-10 connector-kind test: PASS.
- `npm --prefix plugins/plugin-integration-core run test:gip-canonical-object-contract-registry`: PASS.
- `git diff --check`: PASS.
- Tree-wide import/symbol search excluding the three modules and paired tests: zero runtime consumers.
- Exact-base mutation: restoring the old `instanceof GipCanonicalObjectContractError` rethrow makes the new test fail with escaped `CANONICAL_OBJECT_CONTRACT_UNREGISTERED`; fixed code restored and focused test passes.
- Independent lenses: Codex reproduction/review, Grok 4.5 implementation + tests, Kimi K3 read-only security review. All three converged on the same repair; no additional confirmed defect was found in the eight-file parent scope.

Full evidence: `docs/development/gip-b1a2-canonical-registry-brand-rethrow-fix-dev-verification-20260726.md`.

## Gate

Draft / build-then-HOLD. Merge only into the #4610 parent branch after exact-head review. Do not merge to `main`, migrate, deploy, wire, populate registries, or activate.
