### PR TITLE
fix(deploy): require explicit production dispatch

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -8,6 +8,11 @@ on:
       - 'output/**'
   workflow_dispatch:
     inputs:
+      confirm_production_deploy:
+        description: 'Type DEPLOY_PRODUCTION to run the production deploy job; leave blank for build-only'
+        required: false
+        type: string
+        default: ''
       drill_fail_stage:
         description: 'Optional: intentionally fail deploy at a stage for summary drill (none|deploy|migrate|smoke)'
         required: false
@@ -75,8 +80,15 @@ jobs:
 
   deploy:
     needs: build
-    if: ${{ github.ref == 'refs/heads/main' }}
+    if: >-
+      ${{
+        github.event_name == 'workflow_dispatch' &&
+        github.ref == 'refs/heads/main' &&
+        github.event.inputs.confirm_production_deploy == 'DEPLOY_PRODUCTION'
+      }}
     runs-on: ubuntu-latest
+    environment:
+      name: production
     steps:
       - uses: actions/checkout@v4
 

--- a/docs/deployment/docker-ghcr.md
+++ b/docs/deployment/docker-ghcr.md
@@ -4,12 +4,23 @@ This guide uses GitHub Actions to build/push Docker images to GHCR, then runs th
 
 ## 1) Build images on GitHub
 
-1. Push to `main` or trigger `Build and Push Docker Images` manually in Actions.
+1. Push to `main` or trigger `Build and Push Docker Images` manually in Actions. Both paths build and push immutable images; a push does not deploy production.
 2. Ensure the workflow has `packages: write` permissions (already set in `.github/workflows/docker-build.yml`).
 
 Images produced:
 - `ghcr.io/<owner>/metasheet2-backend:latest`
 - `ghcr.io/<owner>/metasheet2-web:latest`
+
+To deploy the current `main` commit after its images pass verification, run:
+
+```bash
+gh workflow run docker-build.yml \
+  --ref main \
+  -f confirm_production_deploy=DEPLOY_PRODUCTION \
+  -f drill_fail_stage=none
+```
+
+Any other event/input combination leaves the production `deploy` job skipped.
 
 ## 2) Prepare the cloud host
 

--- a/docs/operations/deploy-immutable-traceability-runbook.md
+++ b/docs/operations/deploy-immutable-traceability-runbook.md
@@ -16,6 +16,26 @@ The production Docker workflow builds both runtime images with the current `GITH
 
 The workflow and `scripts/ops/deploy-attendance-prod.sh` reject deploys whose `DEPLOY_IMAGE_TAG` is not a full 40-character commit SHA. The backend image exposes the same SHA through `/health`; the web image writes it to `/build-info.json`.
 
+## GitHub Actions Production Gate
+
+A push to `main` builds and publishes immutable backend/web images but does not deploy them. Production deployment is a separate explicit action:
+
+```bash
+gh workflow run docker-build.yml \
+  --ref main \
+  -f confirm_production_deploy=DEPLOY_PRODUCTION \
+  -f drill_fail_stage=none
+```
+
+The `deploy` job runs only when all of these are true:
+
+- the event is `workflow_dispatch`;
+- the selected ref is `main`;
+- `confirm_production_deploy` exactly equals `DEPLOY_PRODUCTION`;
+- the job enters the GitHub `production` environment.
+
+Leaving the confirmation blank is a build-only run. Configure required reviewers on the `production` environment in repository settings when the plan supports protected environments; the workflow-level three-part gate remains mandatory either way.
+
 ## Operator-Visible Evidence
 
 Download the deploy artifact for a run:

--- a/scripts/ops/deploy-immutable-traceability-contract.test.mjs
+++ b/scripts/ops/deploy-immutable-traceability-contract.test.mjs
@@ -42,7 +42,26 @@ test('docker images carry commit trace metadata for backend and web', () => {
 
 test('docker-build workflow deploys exact commit images and verifies served backend/web commits', () => {
   const raw = readRepoFile('.github', 'workflows', 'docker-build.yml')
+  const deployJobMatches = raw.match(/^  deploy:\s*$/gm) ?? []
+  assert.equal(deployJobMatches.length, 1, 'docker-build workflow must expose exactly one deploy job')
+  const deployJobStart = raw.indexOf('\n  deploy:\n')
+  const deployStepsStart = raw.indexOf('\n    steps:\n', deployJobStart)
+  assert.ok(deployJobStart >= 0 && deployStepsStart > deployJobStart, 'deploy job header must be structurally bounded')
+  const deployJobHeader = raw.slice(deployJobStart, deployStepsStart)
 
+  assertContains(raw, 'confirm_production_deploy:', 'manual production deploy input')
+  assertContains(deployJobHeader, "github.event_name == 'workflow_dispatch'", 'manual production deploy gate')
+  assertContains(deployJobHeader, "github.ref == 'refs/heads/main'", 'production deploy main-ref gate')
+  assertContains(
+    deployJobHeader,
+    "github.event.inputs.confirm_production_deploy == 'DEPLOY_PRODUCTION'",
+    'production deploy confirmation gate',
+  )
+  assertContains(deployJobHeader, 'environment:\n      name: production', 'production deploy environment')
+  assert.ok(
+    !raw.includes("if: ${{ github.ref == 'refs/heads/main' }}"),
+    'a push to main must build images without automatically deploying production',
+  )
   assertContains(raw, '--build-arg VCS_REF="${GITHUB_SHA}"', 'docker-build workflow')
   assertContains(raw, '--build-arg BUILD_IMAGE_TAG="${GITHUB_SHA}"', 'docker-build workflow')
   assertContains(raw, '--build-arg BUILD_IMAGE_SOURCE="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}"', 'docker-build workflow')


### PR DESCRIPTION
## What changed

- keep immutable backend/web image builds on pushes to `main`
- run the production deploy job only for a manual dispatch on `main` with the exact `DEPLOY_PRODUCTION` confirmation
- bind the deploy job to the `production` GitHub environment
- add a load-bearing contract guard against restoring push-to-main auto-deploy
- update the authoritative deployment guides with the manual command and build-only default

## Why

The prior job condition checked only `refs/heads/main`, so every non-doc merge built, migrated, and deployed the production track without a separate deployment decision. Build and deployment are now separate gates.

## Verification

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/docker-build.yml")'`
- `node --test scripts/ops/deploy-immutable-traceability-contract.test.mjs scripts/ops/integration-k3wise-postdeploy-workflow-contract.test.mjs scripts/ops/remote-summary-pipefail-contract.test.mjs` (9/9)
- `git diff --check`

## Operational boundary

This PR does not deploy, migrate, alter feature flags, or change application runtime code. After merge, the main-push run builds images and skips `deploy`; production deployment requires an explicit manual dispatch.
