### PR TITLE
test(approval): verify command-driven canvas renderer

### DIFF
--- a/apps/web/verification/approval-flow-canvas-e1-fixtures.ts
+++ b/apps/web/verification/approval-flow-canvas-e1-fixtures.ts
@@ -1,0 +1,531 @@
+// E1 approval-flow renderer spike fixtures only.
+// Lives under verification/ (not production). Coordinates never enter these graphs.
+import type {
+  ApprovalEdge,
+  ApprovalGraph,
+  ApprovalNode,
+  ConditionBranch,
+  ConditionNodeConfig,
+  ParallelNodeConfig,
+} from '../src/types/approval'
+
+export type E1FixtureId =
+  | 'linear'
+  | 'condition'
+  | 'condition-priority-swapped'
+  | 'parallel-all'
+  | 'parallel-any'
+  | 'long-labels'
+  | 'readonly-legacy'
+  | 'readonly-timeout'
+  | 'readonly-threshold'
+  | 'mixed-100'
+
+export interface E1Fixture {
+  id: E1FixtureId
+  /** Business title shown in the harness chrome (never an internal key). */
+  title: string
+  graph: ApprovalGraph
+  /** When true the spike renders a read-only fidelity banner and blocks mutations. */
+  readOnly?: boolean
+  /** User-facing reason; no codes, no raw keys. */
+  readOnlyReason?: string
+  /**
+   * Optional display labels for branch exit edges (business language only).
+   * Used for the long-label fixture; layout still orders by gateway config.
+   */
+  branchDisplayLabels?: Record<string, string>
+}
+
+const approval = (
+  key: string,
+  name: string,
+  summaryKind: 'manager' | 'dept' | 'role' | 'requester' | 'users' = 'manager',
+): ApprovalNode => {
+  const sources =
+    summaryKind === 'manager'
+      ? [{ kind: 'direct_manager' as const }]
+      : summaryKind === 'dept'
+        ? [{ kind: 'dept_head' as const }]
+        : summaryKind === 'role'
+          ? [{ kind: 'static_role' as const, roleIds: ['finance'] }]
+          : summaryKind === 'requester'
+            ? [{ kind: 'requester' as const }]
+            : [{ kind: 'static_user' as const, userIds: ['u1', 'u2', 'u3'] }]
+  return {
+    key,
+    type: 'approval',
+    name,
+    config: {
+      assigneeSources: sources,
+      approvalMode: summaryKind === 'users' ? 'all' : 'single',
+      emptyAssigneePolicy: 'error',
+    },
+  }
+}
+
+const cc = (key: string, name: string): ApprovalNode => ({
+  key,
+  type: 'cc',
+  name,
+  config: { targetType: 'role', targetIds: ['managers'] },
+})
+
+const start = (): ApprovalNode => ({ key: 'start', type: 'start', name: '发起', config: {} })
+const end = (key = 'end'): ApprovalNode => ({ key, type: 'end', name: '结束', config: {} })
+
+function edge(key: string, source: string, target: string): ApprovalEdge {
+  return { key, source, target }
+}
+
+/** Linear: start → approval → cc → end */
+export const FIXTURE_LINEAR: E1Fixture = {
+  id: 'linear',
+  title: '线性流程',
+  graph: {
+    // Intentionally odd nodes[] order to prove layout follows edges, not array order.
+    nodes: [
+      end(),
+      cc('cc_1', '抄送相关人'),
+      approval('approval_1', '主管审批', 'manager'),
+      start(),
+    ],
+    edges: [
+      edge('e-start-approval', 'start', 'approval_1'),
+      edge('e-approval-cc', 'approval_1', 'cc_1'),
+      edge('e-cc-end', 'cc_1', 'end'),
+    ],
+  },
+}
+
+/**
+ * Condition with two ordered rule branches + default rightmost.
+ * nodes[] places high before mid, but config.branches places mid before high
+ * so lane order must be mid → high → default.
+ */
+function buildConditionFixture(id: E1FixtureId, branchOrder: ['mid', 'high'] | ['high', 'mid']): E1Fixture {
+  const midBranch: ConditionBranch = {
+    edgeKey: 'e-mid',
+    conjunction: 'and',
+    rules: [{ fieldId: 'amount', operator: 'gte', value: 100 }],
+  }
+  const highBranch: ConditionBranch = {
+    edgeKey: 'e-high',
+    conjunction: 'and',
+    rules: [{ fieldId: 'amount', operator: 'gte', value: 1000 }],
+  }
+  const branches = branchOrder[0] === 'mid' ? [midBranch, highBranch] : [highBranch, midBranch]
+  return {
+    id,
+    title: id === 'condition' ? '条件分支优先级' : '条件分支优先级（对调）',
+    graph: {
+      nodes: [
+        start(),
+        {
+          key: 'cond_1',
+          type: 'condition',
+          name: '金额判断',
+          config: {
+            branches,
+            defaultEdgeKey: 'e-default',
+          } satisfies ConditionNodeConfig,
+        },
+        // nodes array deliberately lists high before mid (opposite of default config order).
+        approval('app_high', '高层审批', 'dept'),
+        approval('app_mid', '中层审批', 'manager'),
+        approval('app_default', '默认审批', 'role'),
+        end(),
+      ],
+      edges: [
+        edge('e-start-cond', 'start', 'cond_1'),
+        edge('e-high', 'cond_1', 'app_high'),
+        edge('e-mid', 'cond_1', 'app_mid'),
+        edge('e-default', 'cond_1', 'app_default'),
+        edge('e-high-end', 'app_high', 'end'),
+        edge('e-mid-end', 'app_mid', 'end'),
+        edge('e-default-end', 'app_default', 'end'),
+      ],
+    },
+    branchDisplayLabels: {
+      'e-mid': '金额大于等于一百',
+      'e-high': '金额大于等于一千',
+      'e-default': '默认分支（其他情况）',
+    },
+  }
+}
+
+export const FIXTURE_CONDITION = buildConditionFixture('condition', ['mid', 'high'])
+export const FIXTURE_CONDITION_PRIORITY_SWAPPED = buildConditionFixture('condition-priority-swapped', [
+  'high',
+  'mid',
+])
+
+/**
+ * Parallel with ≥3 branches, one nested condition inside a branch, no nested parallel.
+ * joinMode variant controlled by argument.
+ */
+function buildParallelFixture(id: 'parallel-all' | 'parallel-any', joinMode: 'all' | 'any'): E1Fixture {
+  return {
+    id,
+    title: joinMode === 'all' ? '并行全部完成' : '并行任一完成',
+    graph: {
+      nodes: [
+        start(),
+        {
+          key: 'parallel_1',
+          type: 'parallel',
+          name: '多部门会签',
+          config: {
+            // Config order is C → A → B; nodes[] later lists A,B,C differently.
+            branches: ['e-fork-c', 'e-fork-a', 'e-fork-b'],
+            joinMode,
+            joinNodeKey: 'join_1',
+          } satisfies ParallelNodeConfig,
+        },
+        approval('app_a', '财务审批', 'role'),
+        approval('app_b', '法务审批', 'dept'),
+        // Branch C hosts a nested condition (allowed); no nested parallel.
+        {
+          key: 'cond_nested',
+          type: 'condition',
+          name: '紧急程度',
+          config: {
+            branches: [
+              {
+                edgeKey: 'e-urgent',
+                rules: [{ fieldId: 'urgent', operator: 'eq', value: true }],
+              },
+              {
+                edgeKey: 'e-normal',
+                rules: [{ fieldId: 'urgent', operator: 'eq', value: false }],
+              },
+            ],
+            defaultEdgeKey: 'e-cond-default',
+          } satisfies ConditionNodeConfig,
+        },
+        approval('app_urgent', '加急处理', 'manager'),
+        approval('app_normal', '常规处理', 'requester'),
+        approval('app_cond_default', '其他处理', 'users'),
+        { key: 'join_1', type: 'approval', name: '汇总合并', config: { approvalMode: 'single', assigneeSources: [{ kind: 'requester' }] } },
+        end(),
+      ],
+      edges: [
+        edge('e-start-p', 'start', 'parallel_1'),
+        edge('e-fork-a', 'parallel_1', 'app_a'),
+        edge('e-fork-b', 'parallel_1', 'app_b'),
+        edge('e-fork-c', 'parallel_1', 'cond_nested'),
+        edge('e-a-join', 'app_a', 'join_1'),
+        edge('e-b-join', 'app_b', 'join_1'),
+        edge('e-urgent', 'cond_nested', 'app_urgent'),
+        edge('e-normal', 'cond_nested', 'app_normal'),
+        edge('e-cond-default', 'cond_nested', 'app_cond_default'),
+        edge('e-urgent-join', 'app_urgent', 'join_1'),
+        edge('e-normal-join', 'app_normal', 'join_1'),
+        edge('e-cond-default-join', 'app_cond_default', 'join_1'),
+        edge('e-join-end', 'join_1', 'end'),
+      ],
+    },
+    branchDisplayLabels: {
+      'e-fork-a': '财务分支',
+      'e-fork-b': '法务分支',
+      'e-fork-c': '紧急判断分支',
+      'e-urgent': '加急',
+      'e-normal': '常规',
+      'e-cond-default': '默认分支（其他情况）',
+    },
+  }
+}
+
+export const FIXTURE_PARALLEL_ALL = buildParallelFixture('parallel-all', 'all')
+export const FIXTURE_PARALLEL_ANY = buildParallelFixture('parallel-any', 'any')
+
+// Exactly 80 / 40 CJK characters for the long-label fixture (code-point length).
+const LONG_NODE_80 = `${'超长节点名称截断验证文案'.repeat(8)}`.slice(0, 80) // 10*8=80
+const LONG_BRANCH_40 = `${'超长分支标签截断验证'.repeat(4)}`.slice(0, 40) // 10*4=40
+
+export const FIXTURE_LONG_LABELS: E1Fixture = {
+  id: 'long-labels',
+  title: '超长文案',
+  graph: {
+    nodes: [
+      start(),
+      {
+        key: 'approval_long',
+        type: 'approval',
+        name: LONG_NODE_80,
+        config: {
+          assigneeSources: [
+            { kind: 'static_user', userIds: ['u1', 'u2', 'u3'] },
+            { kind: 'static_role', roleIds: ['finance', 'legal'] },
+            { kind: 'direct_manager' },
+          ],
+          approvalMode: 'all',
+          emptyAssigneePolicy: 'error',
+        },
+      },
+      {
+        key: 'cond_long',
+        type: 'condition',
+        name: '长分支名条件',
+        config: {
+          branches: [
+            {
+              edgeKey: 'e-long-a',
+              rules: [{ fieldId: 'amount', operator: 'gt', value: 1 }],
+            },
+            {
+              edgeKey: 'e-long-b',
+              rules: [{ fieldId: 'amount', operator: 'gt', value: 2 }],
+            },
+          ],
+          defaultEdgeKey: 'e-long-default',
+        },
+      },
+      approval('app_la', '分支甲审批', 'manager'),
+      approval('app_lb', '分支乙审批', 'dept'),
+      approval('app_ld', '默认审批', 'role'),
+      end(),
+    ],
+    edges: [
+      edge('e-start-long', 'start', 'approval_long'),
+      edge('e-long-cond', 'approval_long', 'cond_long'),
+      edge('e-long-a', 'cond_long', 'app_la'),
+      edge('e-long-b', 'cond_long', 'app_lb'),
+      edge('e-long-default', 'cond_long', 'app_ld'),
+      edge('e-la-end', 'app_la', 'end'),
+      edge('e-lb-end', 'app_lb', 'end'),
+      edge('e-ld-end', 'app_ld', 'end'),
+    ],
+  },
+  branchDisplayLabels: {
+    'e-long-a': LONG_BRANCH_40,
+    'e-long-b': `${'另一超长分支标签截断'.repeat(4)}`.slice(0, 40),
+    'e-long-default': '默认分支（其他情况）',
+  },
+}
+
+/** Unknown legacy config keys → read-only fidelity surface. */
+export const FIXTURE_READONLY_LEGACY: E1Fixture = {
+  id: 'readonly-legacy',
+  title: '旧版未知配置（只读）',
+  readOnly: true,
+  readOnlyReason: '包含当前版本无法安全编辑的历史配置，已切换为只读以保护原文。',
+  graph: {
+    nodes: [
+      start(),
+      {
+        key: 'approval_legacy',
+        type: 'approval',
+        name: '历史审批',
+        config: {
+          assigneeSources: [{ kind: 'direct_manager' }],
+          approvalMode: 'single',
+          emptyAssigneePolicy: 'error',
+          // Unknown forward-compat field — must never be flattened by the spike.
+          legacyHandlerProfile: { version: 3, opaque: true },
+        } as ApprovalNode['config'],
+      },
+      end(),
+    ],
+    edges: [
+      edge('e-start-legacy', 'start', 'approval_legacy'),
+      edge('e-legacy-end', 'approval_legacy', 'end'),
+    ],
+  },
+}
+
+/** timeout present → read-only fidelity for this spike. */
+export const FIXTURE_READONLY_TIMEOUT: E1Fixture = {
+  id: 'readonly-timeout',
+  title: '超时策略（只读）',
+  readOnly: true,
+  readOnlyReason: '节点含超时策略，本 spike 只读展示以验证保真，不提供就地编辑。',
+  graph: {
+    nodes: [
+      start(),
+      {
+        key: 'approval_timeout',
+        type: 'approval',
+        name: '限时审批',
+        config: {
+          assigneeSources: [{ kind: 'dept_head' }],
+          approvalMode: 'single',
+          emptyAssigneePolicy: 'error',
+          timeout: { durationHours: 24, action: 'remind' },
+        } as ApprovalNode['config'],
+      },
+      end(),
+    ],
+    edges: [
+      edge('e-start-timeout', 'start', 'approval_timeout'),
+      edge('e-timeout-end', 'approval_timeout', 'end'),
+    ],
+  },
+}
+
+/** approvalThreshold present → read-only fidelity for this spike. */
+export const FIXTURE_READONLY_THRESHOLD: E1Fixture = {
+  id: 'readonly-threshold',
+  title: '通过阈值（只读）',
+  readOnly: true,
+  readOnlyReason: '节点含通过阈值策略，本 spike 只读展示以验证保真，不提供就地编辑。',
+  graph: {
+    nodes: [
+      start(),
+      {
+        key: 'approval_threshold',
+        type: 'approval',
+        name: '会签阈值',
+        config: {
+          assigneeSources: [{ kind: 'static_user', userIds: ['u1', 'u2', 'u3', 'u4'] }],
+          approvalMode: 'all',
+          emptyAssigneePolicy: 'error',
+          approvalThreshold: { type: 'count', value: 2 },
+        } as ApprovalNode['config'],
+      },
+      end(),
+    ],
+    edges: [
+      edge('e-start-threshold', 'start', 'approval_threshold'),
+      edge('e-threshold-end', 'approval_threshold', 'end'),
+    ],
+  },
+}
+
+/** 100-node mixed vertical tree (linear spine + a few gateways). */
+function buildMixed100(): E1Fixture {
+  const nodes: ApprovalNode[] = [start()]
+  const edges: ApprovalEdge[] = []
+  let prev = 'start'
+  let nodeCount = 1 // start
+
+  // Build until we have exactly 100 nodes including end.
+  // Pattern every 12 steps: insert a small condition fan-out (3 branches) then continue.
+  let serial = 0
+  while (nodeCount < 99) {
+    serial += 1
+    if (serial % 12 === 0 && nodeCount + 5 <= 99) {
+      const condKey = `cond_${serial}`
+      const aKey = `a_${serial}`
+      const bKey = `b_${serial}`
+      const dKey = `d_${serial}`
+      const joinKey = `j_${serial}`
+      nodes.push({
+        key: condKey,
+        type: 'condition',
+        name: `条件 ${serial}`,
+        config: {
+          branches: [
+            { edgeKey: `e-${condKey}-a`, rules: [{ fieldId: 'amount', operator: 'gt', value: serial }] },
+            { edgeKey: `e-${condKey}-b`, rules: [{ fieldId: 'amount', operator: 'lt', value: serial }] },
+          ],
+          defaultEdgeKey: `e-${condKey}-d`,
+        },
+      })
+      nodes.push(approval(aKey, `分支甲 ${serial}`, 'manager'))
+      nodes.push(approval(bKey, `分支乙 ${serial}`, 'dept'))
+      nodes.push(approval(dKey, `默认 ${serial}`, 'role'))
+      nodes.push(approval(joinKey, `汇合 ${serial}`, 'requester'))
+      edges.push(edge(`e-${prev}-${condKey}`, prev, condKey))
+      edges.push(edge(`e-${condKey}-a`, condKey, aKey))
+      edges.push(edge(`e-${condKey}-b`, condKey, bKey))
+      edges.push(edge(`e-${condKey}-d`, condKey, dKey))
+      edges.push(edge(`e-${aKey}-${joinKey}`, aKey, joinKey))
+      edges.push(edge(`e-${bKey}-${joinKey}`, bKey, joinKey))
+      edges.push(edge(`e-${dKey}-${joinKey}`, dKey, joinKey))
+      prev = joinKey
+      nodeCount += 5
+    } else if (serial % 17 === 0 && nodeCount + 5 <= 99) {
+      const pKey = `p_${serial}`
+      const xKey = `x_${serial}`
+      const yKey = `y_${serial}`
+      const zKey = `z_${serial}`
+      const joinKey = `pj_${serial}`
+      nodes.push({
+        key: pKey,
+        type: 'parallel',
+        name: `并行 ${serial}`,
+        config: {
+          branches: [`e-${pKey}-x`, `e-${pKey}-y`, `e-${pKey}-z`],
+          joinMode: serial % 2 === 0 ? 'all' : 'any',
+          joinNodeKey: joinKey,
+        },
+      })
+      nodes.push(approval(xKey, `并行甲 ${serial}`, 'manager'))
+      nodes.push(approval(yKey, `并行乙 ${serial}`, 'dept'))
+      nodes.push(approval(zKey, `并行丙 ${serial}`, 'role'))
+      nodes.push(approval(joinKey, `并行合并 ${serial}`, 'requester'))
+      edges.push(edge(`e-${prev}-${pKey}`, prev, pKey))
+      edges.push(edge(`e-${pKey}-x`, pKey, xKey))
+      edges.push(edge(`e-${pKey}-y`, pKey, yKey))
+      edges.push(edge(`e-${pKey}-z`, pKey, zKey))
+      edges.push(edge(`e-${xKey}-${joinKey}`, xKey, joinKey))
+      edges.push(edge(`e-${yKey}-${joinKey}`, yKey, joinKey))
+      edges.push(edge(`e-${zKey}-${joinKey}`, zKey, joinKey))
+      prev = joinKey
+      nodeCount += 5
+    } else {
+      const key = `n_${serial}`
+      const kind = serial % 5 === 0 ? 'cc' : 'approval'
+      if (kind === 'cc') {
+        nodes.push(cc(key, `抄送 ${serial}`))
+      } else {
+        nodes.push(approval(key, `审批 ${serial}`, serial % 3 === 0 ? 'dept' : 'manager'))
+      }
+      edges.push(edge(`e-${prev}-${key}`, prev, key))
+      prev = key
+      nodeCount += 1
+    }
+  }
+
+  nodes.push(end())
+  edges.push(edge(`e-${prev}-end`, prev, 'end'))
+  nodeCount += 1
+
+  if (nodes.length !== 100) {
+    // Pad or trim is unexpected; keep honest for the harness.
+    // eslint-disable-next-line no-console
+    console.warn(`[e1-fixtures] mixed-100 produced ${nodes.length} nodes`)
+  }
+
+  return {
+    id: 'mixed-100',
+    title: '百节点混合图',
+    graph: { nodes, edges },
+  }
+}
+
+export const FIXTURE_MIXED_100 = buildMixed100()
+
+export const ALL_FIXTURES: E1Fixture[] = [
+  FIXTURE_LINEAR,
+  FIXTURE_CONDITION,
+  FIXTURE_CONDITION_PRIORITY_SWAPPED,
+  FIXTURE_PARALLEL_ALL,
+  FIXTURE_PARALLEL_ANY,
+  FIXTURE_LONG_LABELS,
+  FIXTURE_READONLY_LEGACY,
+  FIXTURE_READONLY_TIMEOUT,
+  FIXTURE_READONLY_THRESHOLD,
+  FIXTURE_MIXED_100,
+]
+
+export function getFixture(id: E1FixtureId): E1Fixture {
+  const found = ALL_FIXTURES.find((fixture) => fixture.id === id)
+  if (!found) throw new Error(`Unknown E1 fixture: ${id}`)
+  return found
+}
+
+/** Every internal token that must never appear in DOM text / aria-label / title. */
+export function collectInternalTokens(graph: ApprovalGraph): string[] {
+  const tokens = new Set<string>()
+  for (const node of graph.nodes) {
+    tokens.add(node.key)
+  }
+  for (const edgeItem of graph.edges) {
+    tokens.add(edgeItem.key)
+    tokens.add(`${edgeItem.source} -> ${edgeItem.target}`)
+    tokens.add(`${edgeItem.source}->${edgeItem.target}`)
+  }
+  return [...tokens]
+}

--- a/apps/web/verification/approval-flow-canvas-e1-harness.html
+++ b/apps/web/verification/approval-flow-canvas-e1-harness.html
@@ -55,6 +55,10 @@
         background: #fff;
         cursor: pointer;
       }
+      .e1-header button:disabled {
+        opacity: 0.45;
+        cursor: not-allowed;
+      }
       .e1-header button:focus-visible,
       .e1-header select:focus-visible {
         outline: 2px solid #2563eb;
@@ -123,6 +127,11 @@
         outline: 2px solid #1d4ed8;
         outline-offset: 2px;
       }
+      .e1-insert.is-drop-target {
+        background: #dbeafe;
+        border-color: #1d4ed8;
+        box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.25);
+      }
       .e1-card {
         position: absolute;
         width: 200px;
@@ -133,6 +142,16 @@
         cursor: pointer;
         z-index: 1;
         /* No action-button cluster; selection opens inspector. */
+      }
+      .e1-card.is-draggable {
+        cursor: grab;
+      }
+      .e1-card.is-draggable:active,
+      .e1-card.is-dragging {
+        cursor: grabbing;
+      }
+      .e1-card.is-dragging {
+        opacity: 0.65;
       }
       .e1-card:focus-visible {
         outline: 2px solid #2563eb;

--- a/apps/web/verification/approval-flow-canvas-e1-harness.html
+++ b/apps/web/verification/approval-flow-canvas-e1-harness.html
@@ -1,0 +1,388 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>E1 approval-flow canvas renderer spike</title>
+    <!--
+      Isolation-only verification harness. Not routed by the production app.
+      tokens.css is imported from the harness module (same path main.ts uses).
+    -->
+    <style>
+      html, body {
+        margin: 0;
+        padding: 0;
+        height: 100%;
+        font-family: system-ui, -apple-system, 'Segoe UI', sans-serif;
+        color: #111827;
+        background: #f8fafc;
+      }
+      #app { min-height: 100%; height: 100%; }
+      * { box-sizing: border-box; }
+
+      .e1-shell {
+        display: flex;
+        flex-direction: column;
+        height: 100vh;
+        max-height: 100vh;
+        overflow: hidden;
+      }
+      .e1-header {
+        flex: 0 0 auto;
+        min-height: 48px;
+        max-height: 56px;
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: 8px;
+        padding: 8px 12px;
+        border-bottom: 1px solid #e5e7eb;
+        background: #fff;
+      }
+      .e1-header h1 {
+        margin: 0;
+        font-size: 14px;
+        font-weight: 600;
+        margin-right: 8px;
+      }
+      .e1-header select,
+      .e1-header button {
+        font: inherit;
+        font-size: 13px;
+        padding: 6px 10px;
+        border: 1px solid #d1d5db;
+        border-radius: 6px;
+        background: #fff;
+        cursor: pointer;
+      }
+      .e1-header button:focus-visible,
+      .e1-header select:focus-visible {
+        outline: 2px solid #2563eb;
+        outline-offset: 2px;
+      }
+      .e1-body {
+        flex: 1 1 auto;
+        min-height: 0;
+        display: flex;
+        position: relative;
+        overflow: hidden;
+      }
+      .e1-canvas-region {
+        flex: 1 1 auto;
+        min-width: 0;
+        min-height: 0;
+        position: relative;
+        overflow: auto;
+        background:
+          linear-gradient(to right, rgba(148, 163, 184, 0.12) 1px, transparent 1px) 0 0 / 24px 24px,
+          linear-gradient(to bottom, rgba(148, 163, 184, 0.12) 1px, transparent 1px) 0 0 / 24px 24px,
+          #f8fafc;
+      }
+      /* Restraint: product surface itself has no decorative gradient on cards; the faint grid is harness chrome only. */
+      .e1-canvas-surface {
+        position: relative;
+        margin: 0 auto;
+      }
+      .e1-edges {
+        position: absolute;
+        inset: 0;
+        width: 100%;
+        height: 100%;
+        pointer-events: none;
+        overflow: visible;
+      }
+      .e1-edge-path {
+        fill: none;
+        stroke: #64748b;
+        stroke-width: 1.5;
+        marker-end: url(#e1-arrow);
+      }
+      .e1-edge-hit {
+        pointer-events: all;
+      }
+      .e1-insert {
+        position: absolute;
+        width: 40px;
+        height: 40px;
+        margin-left: -20px;
+        margin-top: -20px;
+        border-radius: 999px;
+        border: 1px solid #2563eb;
+        background: #eff6ff;
+        color: #1d4ed8;
+        font-size: 20px;
+        line-height: 1;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        cursor: pointer;
+        padding: 0;
+        z-index: 2;
+      }
+      .e1-insert:focus-visible {
+        outline: 2px solid #1d4ed8;
+        outline-offset: 2px;
+      }
+      .e1-card {
+        position: absolute;
+        width: 200px;
+        border: 1px solid #d1d5db;
+        border-radius: 8px;
+        background: #fff;
+        padding: 10px 12px;
+        cursor: pointer;
+        z-index: 1;
+        /* No action-button cluster; selection opens inspector. */
+      }
+      .e1-card:focus-visible {
+        outline: 2px solid #2563eb;
+        outline-offset: 2px;
+      }
+      .e1-card.is-selected {
+        border-color: #2563eb;
+        box-shadow: 0 0 0 1px #2563eb;
+      }
+      .e1-card.is-paired {
+        border-color: #7c3aed;
+      }
+      .e1-card.is-readonly {
+        background: #f9fafb;
+      }
+      .e1-card__type {
+        font-size: 12px;
+        color: #6b7280;
+        margin-bottom: 2px;
+      }
+      .e1-card__name {
+        font-size: 14px;
+        font-weight: 600;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+      .e1-card__summary {
+        margin: 6px 0 0;
+        padding: 0;
+        list-style: none;
+        font-size: 12px;
+        color: #4b5563;
+      }
+      .e1-card__summary li {
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        line-height: 18px;
+      }
+      .e1-card__badges {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 4px;
+        margin-top: 6px;
+      }
+      .e1-card__badge {
+        font-size: 11px;
+        line-height: 16px;
+        padding: 2px 6px;
+        border-radius: 4px;
+        border: 1px solid #e5e7eb;
+        background: #f3f4f6;
+        color: #374151;
+      }
+      .e1-branch-label {
+        position: absolute;
+        transform: translateX(-50%);
+        max-width: 160px;
+        font-size: 11px;
+        line-height: 14px;
+        color: #374151;
+        background: rgba(248, 250, 252, 0.92);
+        border: 1px solid #e5e7eb;
+        border-radius: 4px;
+        padding: 2px 6px;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        z-index: 2;
+        pointer-events: none;
+      }
+      .e1-branch-label.is-default {
+        color: #6b7280;
+        font-style: normal;
+      }
+      .e1-branch-label .e1-priority {
+        color: #1d4ed8;
+        margin-right: 4px;
+      }
+
+      /* Inspector presentations */
+      .e1-inspector {
+        background: #fff;
+        border-left: 1px solid #e5e7eb;
+        display: flex;
+        flex-direction: column;
+        min-height: 0;
+        z-index: 5;
+      }
+      .e1-inspector__header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 8px;
+        padding: 12px 14px;
+        border-bottom: 1px solid #e5e7eb;
+      }
+      .e1-inspector__title {
+        margin: 0;
+        font-size: 14px;
+        font-weight: 600;
+      }
+      .e1-inspector__body {
+        padding: 12px 14px;
+        overflow: auto;
+        flex: 1 1 auto;
+        font-size: 13px;
+        line-height: 1.5;
+      }
+      .e1-inspector__section {
+        margin-bottom: 12px;
+      }
+      .e1-inspector__section h3 {
+        margin: 0 0 6px;
+        font-size: 12px;
+        color: #6b7280;
+        font-weight: 600;
+      }
+      .e1-inspector__close {
+        border: 1px solid #d1d5db;
+        background: #fff;
+        border-radius: 6px;
+        padding: 6px 10px;
+        cursor: pointer;
+        font: inherit;
+        font-size: 13px;
+        min-height: 40px;
+      }
+      .e1-inspector__close:focus-visible {
+        outline: 2px solid #2563eb;
+        outline-offset: 2px;
+      }
+      .e1-inspector--dock {
+        flex: 0 0 360px;
+        width: 360px;
+        position: relative;
+      }
+      .e1-inspector--overlay {
+        position: absolute;
+        top: 0;
+        right: 0;
+        bottom: 0;
+        width: 320px;
+        box-shadow: -4px 0 16px rgba(15, 23, 42, 0.08);
+      }
+      .e1-inspector--sheet {
+        position: absolute;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        width: 100%;
+        border-left: none;
+        border-top: 1px solid #e5e7eb;
+        border-radius: 12px 12px 0 0;
+        box-shadow: 0 -4px 16px rgba(15, 23, 42, 0.08);
+        transition: height 160ms ease;
+      }
+      .e1-inspector--sheet.is-half { height: 55vh; }
+      .e1-inspector--sheet.is-full { height: 92vh; }
+      .e1-sheet-handle {
+        width: 42px;
+        height: 4px;
+        border-radius: 999px;
+        background: #d1d5db;
+        margin: 8px auto 0;
+      }
+      .e1-sheet-actions {
+        display: flex;
+        gap: 8px;
+        padding: 8px 14px 0;
+      }
+      .e1-sheet-actions button {
+        flex: 1;
+        min-height: 44px;
+        border: 1px solid #d1d5db;
+        background: #fff;
+        border-radius: 8px;
+        font: inherit;
+        cursor: pointer;
+      }
+      .e1-sheet-actions button:focus-visible {
+        outline: 2px solid #2563eb;
+        outline-offset: 2px;
+      }
+
+      .e1-banner {
+        margin: 8px 12px 0;
+        padding: 8px 10px;
+        border-radius: 6px;
+        border: 1px solid #fcd34d;
+        background: #fffbeb;
+        color: #92400e;
+        font-size: 13px;
+      }
+      .e1-live {
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        padding: 0;
+        margin: -1px;
+        overflow: hidden;
+        clip: rect(0, 0, 0, 0);
+        white-space: nowrap;
+        border: 0;
+      }
+      .e1-insert-menu {
+        position: absolute;
+        z-index: 6;
+        min-width: 180px;
+        background: #fff;
+        border: 1px solid #d1d5db;
+        border-radius: 8px;
+        box-shadow: 0 8px 20px rgba(15, 23, 42, 0.12);
+        padding: 6px;
+      }
+      .e1-insert-menu button {
+        display: block;
+        width: 100%;
+        text-align: left;
+        border: none;
+        background: transparent;
+        padding: 8px 10px;
+        border-radius: 6px;
+        font: inherit;
+        font-size: 13px;
+        cursor: pointer;
+        min-height: 40px;
+      }
+      .e1-insert-menu button:hover,
+      .e1-insert-menu button:focus-visible {
+        background: #eff6ff;
+        outline: none;
+      }
+      .e1-empty-inspector {
+        color: #6b7280;
+      }
+
+      @media (prefers-reduced-motion: reduce) {
+        .e1-inspector--sheet,
+        .e1-insert,
+        .e1-card {
+          transition: none !important;
+          animation: none !important;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="./approval-flow-canvas-e1-harness.ts"></script>
+  </body>
+</html>

--- a/apps/web/verification/approval-flow-canvas-e1-harness.ts
+++ b/apps/web/verification/approval-flow-canvas-e1-harness.ts
@@ -1,0 +1,654 @@
+// Browser-verification harness (dev/CI only — NOT part of the app build/typecheck;
+// lives outside src/ so vue-tsc + vite build ignore it). E1 isolated approval-flow
+// renderer spike: constrained vertical tree, no free-form graph, no persisted
+// coordinates, no production route wiring.
+import { computed, createApp, h, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
+import '../src/styles/tokens.css'
+import {
+  ALL_FIXTURES,
+  collectInternalTokens,
+  getFixture,
+  type E1Fixture,
+  type E1FixtureId,
+} from './approval-flow-canvas-e1-fixtures'
+import {
+  computeE1Layout,
+  type E1CardModel,
+  type E1EdgeModel,
+  type E1LayoutModel,
+} from './approval-flow-canvas-e1-layout'
+
+type InspectorPresentation = 'dock' | 'overlay' | 'sheet'
+type SheetDetent = 'half' | 'full'
+
+interface InsertMenuState {
+  edgeFocusId: string
+  x: number
+  y: number
+}
+
+interface E1PublicMetrics {
+  ready: true
+  fixtureId: E1FixtureId
+  nodeCount: number
+  edgeCount: number
+  inspectorPresentation: InspectorPresentation
+  sheetDetent: SheetDetent | null
+  inspectorOpen: boolean
+  readOnly: boolean
+  cards: Array<{
+    focusId: string
+    name: string
+    type: string
+    x: number
+    y: number
+    width: number
+    height: number
+  }>
+  edges: Array<{
+    focusId: string
+    path: string
+    midX: number
+    midY: number
+    sourceFocusId: string
+    targetFocusId: string
+  }>
+  branchLabels: Array<{
+    order: number
+    label: string
+    priority?: number
+    isDefault: boolean
+    x: number
+  }>
+  layoutWidth: number
+  layoutHeight: number
+  selectedName: string | null
+  liveText: string
+  reducedMotion: boolean
+  internalTokens: string[]
+}
+
+declare global {
+  interface Window {
+    __E1_CANVAS__?: E1PublicMetrics
+    __E1_SELECT_FIXTURE__?: (id: E1FixtureId) => void
+    __E1_SWAP_CONDITION_PRIORITY__?: () => void
+  }
+}
+
+function presentationForWidth(width: number): InspectorPresentation {
+  if (width <= 480) return 'sheet'
+  if (width <= 1100) return 'overlay'
+  return 'dock'
+}
+
+function prefersReducedMotion(): boolean {
+  return window.matchMedia?.('(prefers-reduced-motion: reduce)').matches ?? false
+}
+
+createApp({
+  setup() {
+    const fixtureId = ref<E1FixtureId>('linear')
+    const fixture = ref<E1Fixture>(getFixture('linear'))
+    const selectedFocusId = ref<string | null>(null)
+    const liveText = ref('')
+    const viewportW = ref(window.innerWidth)
+    const sheetDetent = ref<SheetDetent>('half')
+    const insertMenu = ref<InsertMenuState | null>(null)
+    const measuredHeights = ref<Map<string, number>>(new Map())
+    const surfaceEl = ref<HTMLElement | null>(null)
+    const reducedMotion = ref(prefersReducedMotion())
+
+    const layout = computed<E1LayoutModel>(() =>
+      computeE1Layout(fixture.value, measuredHeights.value.size ? measuredHeights.value : undefined),
+    )
+
+    const presentation = computed(() => presentationForWidth(viewportW.value))
+    const inspectorOpen = computed(() => selectedFocusId.value != null)
+    const selectedCard = computed(() =>
+      layout.value.cards.find((card) => card.focusId === selectedFocusId.value) ?? null,
+    )
+
+    const focusables = computed(() => {
+      const nodeIds = layout.value.focusOrder
+      const insertIds = layout.value.edges.filter((edge) => edge.insertable).map((edge) => edge.focusId)
+      return [...nodeIds, ...insertIds]
+    })
+
+    function announce(message: string) {
+      // Re-assign to force polite live region update even for identical strings.
+      liveText.value = ''
+      void nextTick(() => {
+        liveText.value = message
+      })
+    }
+
+    function selectFixture(id: E1FixtureId) {
+      fixtureId.value = id
+      fixture.value = getFixture(id)
+      selectedFocusId.value = null
+      insertMenu.value = null
+      measuredHeights.value = new Map()
+      announce(`已加载夹具：${fixture.value.title}`)
+      void nextTick(() => {
+        measureAndReflow()
+        publishMetrics()
+      })
+    }
+
+    /** Demo-only: swap condition branch priority via config.branches only (nodes/edges untouched). */
+    function swapConditionPriority() {
+      if (fixture.value.readOnly) {
+        announce('当前为只读夹具，无法调整优先级')
+        return
+      }
+      if (fixtureId.value === 'condition') {
+        selectFixture('condition-priority-swapped')
+        announce('已提高「金额大于等于一千」的优先级')
+        return
+      }
+      if (fixtureId.value === 'condition-priority-swapped') {
+        selectFixture('condition')
+        announce('已恢复「金额大于等于一百」为最高优先级')
+        return
+      }
+      announce('请先加载条件分支夹具')
+    }
+
+    function selectCard(card: E1CardModel) {
+      selectedFocusId.value = card.focusId
+      insertMenu.value = null
+      announce(`已选中「${card.name}」`)
+      void nextTick(() => {
+        const el = document.querySelector<HTMLElement>(`[data-focus-id="${card.focusId}"]`)
+        el?.focus()
+        publishMetrics()
+      })
+    }
+
+    function closeInspector() {
+      const name = selectedCard.value?.name
+      selectedFocusId.value = null
+      if (name) announce(`已关闭「${name}」的属性面板`)
+      publishMetrics()
+    }
+
+    function openInsertMenu(edge: E1EdgeModel) {
+      if (!edge.insertable || fixture.value.readOnly) {
+        announce('当前连线不可插入')
+        return
+      }
+      insertMenu.value = { edgeFocusId: edge.focusId, x: edge.midX, y: edge.midY }
+      announce(`已打开插入菜单：${edge.ariaLabel}`)
+      void nextTick(() => {
+        const first = document.querySelector<HTMLElement>('[data-test="insert-menu"] button')
+        first?.focus()
+      })
+    }
+
+    function activateInsert(kind: 'approval' | 'cc') {
+      const label = kind === 'approval' ? '审批' : '抄送'
+      insertMenu.value = null
+      // Spike: announce activation only — mutations stay out of production graph save paths.
+      announce(`已选择插入「${label}」节点（spike 演示，未写入业务模型）`)
+      publishMetrics()
+    }
+
+    function onCanvasKeydown(event: KeyboardEvent) {
+      const target = event.target as HTMLElement | null
+      if (!target) return
+      const focusId = target.getAttribute('data-focus-id')
+      if (!focusId) return
+
+      if (insertMenu.value && event.key === 'Escape') {
+        event.preventDefault()
+        const edgeFocus = insertMenu.value.edgeFocusId
+        insertMenu.value = null
+        announce('已关闭插入菜单')
+        document.querySelector<HTMLElement>(`[data-focus-id="${edgeFocus}"]`)?.focus()
+        return
+      }
+
+      if (event.key === 'Enter' || event.key === ' ') {
+        const edge = layout.value.edges.find((item) => item.focusId === focusId)
+        if (edge) {
+          event.preventDefault()
+          openInsertMenu(edge)
+          return
+        }
+        const card = layout.value.cards.find((item) => item.focusId === focusId)
+        if (card) {
+          event.preventDefault()
+          selectCard(card)
+          return
+        }
+      }
+
+      if (event.key === 'Escape' && selectedFocusId.value) {
+        event.preventDefault()
+        closeInspector()
+        return
+      }
+
+      const order = focusables.value
+      const index = order.indexOf(focusId)
+      if (index < 0) return
+
+      if (event.key === 'ArrowDown' || event.key === 'ArrowRight') {
+        event.preventDefault()
+        const next = order[Math.min(order.length - 1, index + 1)]
+        if (next) focusById(next)
+      } else if (event.key === 'ArrowUp' || event.key === 'ArrowLeft') {
+        event.preventDefault()
+        const prev = order[Math.max(0, index - 1)]
+        if (prev) focusById(prev)
+      }
+    }
+
+    function focusById(focusId: string) {
+      const el = document.querySelector<HTMLElement>(`[data-focus-id="${focusId}"]`)
+      el?.focus()
+      const card = layout.value.cards.find((item) => item.focusId === focusId)
+      if (card) {
+        selectedFocusId.value = card.focusId
+        announce(`已聚焦「${card.name}」`)
+      }
+    }
+
+    function measureAndReflow() {
+      const root = surfaceEl.value
+      if (!root) return
+      const next = new Map<string, number>()
+      for (const card of layout.value.cards) {
+        const el = root.querySelector<HTMLElement>(`[data-focus-id="${card.focusId}"]`)
+        if (!el) continue
+        const h = el.getBoundingClientRect().height
+        if (h > 0) next.set(card.nodeKey, Math.ceil(h))
+      }
+      // Only update when heights actually differ to avoid loops.
+      let changed = next.size !== measuredHeights.value.size
+      if (!changed) {
+        for (const [key, value] of next) {
+          if (measuredHeights.value.get(key) !== value) {
+            changed = true
+            break
+          }
+        }
+      }
+      if (changed) measuredHeights.value = next
+    }
+
+    function publishMetrics() {
+      const model = layout.value
+      window.__E1_CANVAS__ = {
+        ready: true,
+        fixtureId: fixtureId.value,
+        nodeCount: fixture.value.graph.nodes.length,
+        edgeCount: fixture.value.graph.edges.length,
+        inspectorPresentation: presentation.value,
+        sheetDetent: presentation.value === 'sheet' ? sheetDetent.value : null,
+        inspectorOpen: inspectorOpen.value,
+        readOnly: Boolean(fixture.value.readOnly),
+        cards: model.cards.map((card) => ({
+          focusId: card.focusId,
+          name: card.name,
+          type: card.type,
+          x: card.x,
+          y: card.y,
+          width: card.width,
+          height: card.height,
+        })),
+        edges: model.edges.map((edge) => ({
+          focusId: edge.focusId,
+          path: edge.path,
+          midX: edge.midX,
+          midY: edge.midY,
+          sourceFocusId: edge.sourceFocusId,
+          targetFocusId: edge.targetFocusId,
+        })),
+        branchLabels: model.branchLabels
+          .slice()
+          .sort((a, b) => a.order - b.order)
+          .map((label) => ({
+            order: label.order,
+            label: label.label,
+            priority: label.priority,
+            isDefault: label.isDefault,
+            x: label.x,
+          })),
+        layoutWidth: model.width,
+        layoutHeight: model.height,
+        selectedName: selectedCard.value?.name ?? null,
+        liveText: liveText.value,
+        reducedMotion: reducedMotion.value,
+        internalTokens: collectInternalTokens(fixture.value.graph),
+      }
+    }
+
+    function onResize() {
+      viewportW.value = window.innerWidth
+      publishMetrics()
+    }
+
+    function onMotionChange(event: MediaQueryListEvent) {
+      reducedMotion.value = event.matches
+      publishMetrics()
+    }
+
+    onMounted(() => {
+      window.addEventListener('resize', onResize)
+      const motionQuery = window.matchMedia?.('(prefers-reduced-motion: reduce)')
+      motionQuery?.addEventListener?.('change', onMotionChange)
+      window.__E1_SELECT_FIXTURE__ = selectFixture
+      window.__E1_SWAP_CONDITION_PRIORITY__ = swapConditionPriority
+      void nextTick(() => {
+        measureAndReflow()
+        publishMetrics()
+      })
+    })
+
+    onUnmounted(() => {
+      window.removeEventListener('resize', onResize)
+      delete window.__E1_SELECT_FIXTURE__
+      delete window.__E1_SWAP_CONDITION_PRIORITY__
+      delete window.__E1_CANVAS__
+    })
+
+    watch(layout, () => {
+      void nextTick(() => {
+        measureAndReflow()
+        publishMetrics()
+      })
+    })
+
+    watch(presentation, () => publishMetrics())
+    watch(selectedFocusId, () => publishMetrics())
+
+    return () => {
+      const model = layout.value
+      const mode = presentation.value
+      const card = selectedCard.value
+      const readOnly = Boolean(fixture.value.readOnly)
+
+      const inspectorClass = [
+        'e1-inspector',
+        mode === 'dock' ? 'e1-inspector--dock' : null,
+        mode === 'overlay' ? 'e1-inspector--overlay' : null,
+        mode === 'sheet' ? 'e1-inspector--sheet' : null,
+        mode === 'sheet' ? (sheetDetent.value === 'full' ? 'is-full' : 'is-half') : null,
+      ].filter(Boolean)
+
+      const inspector = inspectorOpen.value
+        ? h('aside', {
+          class: inspectorClass,
+          'data-test': 'e1-inspector',
+          'data-presentation': mode,
+          'data-sheet-detent': mode === 'sheet' ? sheetDetent.value : undefined,
+          'aria-label': '属性面板',
+        }, [
+          mode === 'sheet'
+            ? h('div', { class: 'e1-sheet-handle', 'data-test': 'sheet-handle', 'aria-hidden': 'true' })
+            : null,
+          mode === 'sheet'
+            ? h('div', { class: 'e1-sheet-actions' }, [
+              h('button', {
+                type: 'button',
+                'data-test': 'sheet-half',
+                onClick: () => {
+                  sheetDetent.value = 'half'
+                  announce('属性面板已收起为半屏')
+                  publishMetrics()
+                },
+              }, '收起'),
+              h('button', {
+                type: 'button',
+                'data-test': 'sheet-full',
+                onClick: () => {
+                  sheetDetent.value = 'full'
+                  announce('属性面板已展开为全屏')
+                  publishMetrics()
+                },
+              }, '展开'),
+            ])
+            : null,
+          h('div', { class: 'e1-inspector__header' }, [
+            h('h2', {
+              class: 'e1-inspector__title',
+              id: 'e1-inspector-heading',
+              tabindex: -1,
+            }, card ? `${card.typeLabel} · ${card.name}` : '属性'),
+            h('button', {
+              type: 'button',
+              class: 'e1-inspector__close',
+              'data-test': 'inspector-close',
+              onClick: closeInspector,
+            }, '关闭'),
+          ]),
+          h('div', { class: 'e1-inspector__body' }, [
+            card
+              ? h('div', [
+                h('div', { class: 'e1-inspector__section' }, [
+                  h('h3', '名称'),
+                  h('div', { 'data-test': 'inspector-name' }, card.name),
+                ]),
+                h('div', { class: 'e1-inspector__section' }, [
+                  h('h3', '类型'),
+                  h('div', { 'data-test': 'inspector-type' }, card.typeLabel),
+                ]),
+                card.summaryLines.length
+                  ? h('div', { class: 'e1-inspector__section' }, [
+                    h('h3', '摘要'),
+                    h('ul', { 'data-test': 'inspector-summary' },
+                      card.summaryLines.map((line) => h('li', line))),
+                  ])
+                  : null,
+                card.joinModeLabel
+                  ? h('div', { class: 'e1-inspector__section' }, [
+                    h('h3', '合并方式'),
+                    h('div', { 'data-test': 'inspector-join-mode' }, card.joinModeLabel),
+                  ])
+                  : null,
+                readOnly
+                  ? h('div', {
+                    class: 'e1-inspector__section',
+                    'data-test': 'inspector-readonly',
+                  }, fixture.value.readOnlyReason ?? '只读')
+                  : h('div', {
+                    class: 'e1-inspector__section e1-empty-inspector',
+                  }, '配置项在生产检查器中编辑；本 spike 仅验证展示与几何。'),
+              ])
+              : h('div', { class: 'e1-empty-inspector' }, '选择一个节点以查看属性'),
+          ]),
+        ])
+        : null
+
+      return h('div', { class: 'e1-shell', 'data-test': 'e1-shell' }, [
+        h('header', { class: 'e1-header', 'data-test': 'e1-header' }, [
+          h('h1', '审批流程画布 E1 spike'),
+          h('label', { style: 'display:flex;align-items:center;gap:6px;font-size:13px' }, [
+            h('span', '夹具'),
+            h('select', {
+              'data-test': 'fixture-select',
+              value: fixtureId.value,
+              onChange: (event: Event) => {
+                const value = (event.target as HTMLSelectElement).value as E1FixtureId
+                selectFixture(value)
+              },
+            }, ALL_FIXTURES.map((item) => h('option', { value: item.id }, item.title))),
+          ]),
+          h('button', {
+            type: 'button',
+            'data-test': 'swap-priority',
+            onClick: swapConditionPriority,
+          }, '调整条件优先级'),
+          h('span', {
+            'data-test': 'fixture-title',
+            style: 'font-size:13px;color:#4b5563',
+          }, fixture.value.title),
+          h('span', {
+            'data-test': 'node-count',
+            style: 'font-size:13px;color:#6b7280',
+          }, `${fixture.value.graph.nodes.length} 个节点`),
+        ]),
+        readOnly
+          ? h('div', {
+            class: 'e1-banner',
+            'data-test': 'readonly-banner',
+            role: 'status',
+          }, fixture.value.readOnlyReason)
+          : null,
+        // Single polite live region for command results (errors would be assertive in production).
+        h('div', {
+          class: 'e1-live',
+          'data-test': 'e1-live',
+          role: 'status',
+          'aria-live': 'polite',
+          'aria-atomic': 'true',
+        }, liveText.value),
+        h('div', { class: 'e1-body', 'data-test': 'e1-body' }, [
+          h('div', {
+            class: 'e1-canvas-region',
+            'data-test': 'e1-canvas-region',
+            onKeydown: onCanvasKeydown,
+          }, [
+            h('div', {
+              class: 'e1-canvas-surface',
+              'data-test': 'e1-canvas-surface',
+              ref: (el: unknown) => {
+                surfaceEl.value = (el as HTMLElement | null) ?? null
+              },
+              style: {
+                width: `${model.width}px`,
+                height: `${model.height}px`,
+              },
+            }, [
+              h('svg', {
+                class: 'e1-edges',
+                width: model.width,
+                height: model.height,
+                'data-test': 'e1-edges',
+              }, [
+                h('defs', [
+                  h('marker', {
+                    id: 'e1-arrow',
+                    viewBox: '0 0 10 10',
+                    refX: 8,
+                    refY: 5,
+                    markerWidth: 6,
+                    markerHeight: 6,
+                    orient: 'auto-start-reverse',
+                  }, [
+                    h('path', { d: 'M 0 0 L 10 5 L 0 10 z', fill: '#64748b' }),
+                  ]),
+                ]),
+                ...model.edges.map((edge) => h('path', {
+                  class: 'e1-edge-path',
+                  d: edge.path,
+                  'data-test': 'e1-edge',
+                  'data-edge-focus': edge.focusId,
+                })),
+              ]),
+              ...model.branchLabels.map((label) => h('div', {
+                class: ['e1-branch-label', label.isDefault ? 'is-default' : null],
+                'data-test': 'branch-label',
+                'data-order': String(label.order),
+                'data-default': label.isDefault ? 'true' : 'false',
+                style: {
+                  left: `${label.x}px`,
+                  top: `${label.y}px`,
+                },
+                title: label.label,
+              }, [
+                label.priority != null
+                  ? h('span', { class: 'e1-priority', 'data-test': 'branch-priority' }, `优先级${label.priority}`)
+                  : null,
+                h('span', label.label),
+              ])),
+              ...model.cards.map((item) => {
+                const selected = item.focusId === selectedFocusId.value
+                const paired =
+                  selectedCard.value?.pairedFocusId === item.focusId ||
+                  (selected && Boolean(item.pairedFocusId))
+                return h('div', {
+                  class: [
+                    'e1-card',
+                    selected ? 'is-selected' : null,
+                    paired ? 'is-paired' : null,
+                    readOnly ? 'is-readonly' : null,
+                  ],
+                  'data-test': 'flow-node',
+                  'data-node-type': item.type,
+                  'data-focus-id': item.focusId,
+                  role: 'button',
+                  tabindex: 0,
+                  // Business language only — never node keys / edge keys / IDs.
+                  'aria-label': `${item.typeLabel}：${item.name}`,
+                  title: item.name,
+                  style: {
+                    left: `${item.x}px`,
+                    top: `${item.y}px`,
+                    width: `${item.width}px`,
+                    // Height is content-driven (auto); layout uses measured/estimated height for edges.
+                    minHeight: `${Math.max(48, item.height - 8)}px`,
+                  },
+                  onClick: () => selectCard(item),
+                }, [
+                  h('div', { class: 'e1-card__type' }, item.typeLabel),
+                  h('div', { class: 'e1-card__name', 'data-test': 'node-name' }, item.name),
+                  item.summaryLines.length
+                    ? h('ul', { class: 'e1-card__summary', 'data-test': 'node-summary' },
+                      item.summaryLines.map((line) => h('li', { title: line }, line)))
+                    : null,
+                  item.badges.length
+                    ? h('div', { class: 'e1-card__badges' },
+                      item.badges.map((badge) => h('span', { class: 'e1-card__badge' }, badge)))
+                    : null,
+                ])
+              }),
+              ...model.edges.filter((edge) => edge.insertable).map((edge) => h('button', {
+                type: 'button',
+                class: 'e1-insert',
+                'data-test': 'edge-insert',
+                'data-focus-id': edge.focusId,
+                'aria-label': edge.ariaLabel,
+                style: {
+                  left: `${edge.midX}px`,
+                  top: `${edge.midY}px`,
+                },
+                onClick: (event: MouseEvent) => {
+                  event.stopPropagation()
+                  openInsertMenu(edge)
+                },
+              }, '+')),
+              insertMenu.value
+                ? h('div', {
+                  class: 'e1-insert-menu',
+                  'data-test': 'insert-menu',
+                  role: 'menu',
+                  style: {
+                    left: `${insertMenu.value.x + 24}px`,
+                    top: `${insertMenu.value.y + 8}px`,
+                  },
+                }, [
+                  h('button', {
+                    type: 'button',
+                    role: 'menuitem',
+                    'data-test': 'insert-approval',
+                    onClick: () => activateInsert('approval'),
+                  }, '审批节点'),
+                  h('button', {
+                    type: 'button',
+                    role: 'menuitem',
+                    'data-test': 'insert-cc',
+                    onClick: () => activateInsert('cc'),
+                  }, '抄送节点'),
+                ])
+                : null,
+            ]),
+          ]),
+          inspector,
+        ]),
+      ])
+    }
+  },
+}).mount('#app')

--- a/apps/web/verification/approval-flow-canvas-e1-harness.ts
+++ b/apps/web/verification/approval-flow-canvas-e1-harness.ts
@@ -2,8 +2,22 @@
 // lives outside src/ so vue-tsc + vite build ignore it). E1 isolated approval-flow
 // renderer spike: constrained vertical tree, no free-form graph, no persisted
 // coordinates, no production route wiring.
+//
+// E1-b: mutations go through the real production approvalCanvasCommands history API
+// (create / apply / undo / redo). The renderer never re-implements topology validation.
 import { computed, createApp, h, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
 import '../src/styles/tokens.css'
+import {
+  applyApprovalCanvasCommand,
+  createApprovalCanvasHistory,
+  redoApprovalCanvasCommand,
+  undoApprovalCanvasCommand,
+  type ApprovalCanvasCommand,
+  type ApprovalCanvasCommandErrorCode,
+  type ApprovalCanvasHistory,
+  type ApprovalCanvasSelection,
+} from '../src/approvals/approvalCanvasCommands'
+import type { ApprovalGraph, ConditionNodeConfig } from '../src/types/approval'
 import {
   ALL_FIXTURES,
   collectInternalTokens,
@@ -20,11 +34,21 @@ import {
 
 type InspectorPresentation = 'dock' | 'overlay' | 'sheet'
 type SheetDetent = 'half' | 'full'
+/** Input channel for the single command adapter (pointer/HTML5 and keyboard share it). */
+type CommandChannel = 'pointer' | 'keyboard' | 'toolbar'
 
 interface InsertMenuState {
   edgeFocusId: string
+  edgeKey: string
   x: number
   y: number
+}
+
+interface CommandDispatchResult {
+  ok: boolean
+  code: ApprovalCanvasCommandErrorCode | null
+  channel: CommandChannel
+  liveText: string
 }
 
 interface E1PublicMetrics {
@@ -66,13 +90,40 @@ interface E1PublicMetrics {
   liveText: string
   reducedMotion: boolean
   internalTokens: string[]
+  /** Sole persisted model snapshot (no coordinates). Verification only. */
+  graphJson: string
+  canUndo: boolean
+  canRedo: boolean
+  undoDepth: number
+  lastCommandOk: boolean | null
+  lastCommandCode: string | null
+  lastCommandChannel: CommandChannel | null
+  /** Opaque focusId → graph key maps (window metrics only; never DOM text). */
+  cardKeyByFocusId: Record<string, string>
+  edgeKeyByFocusId: Record<string, string>
 }
 
 declare global {
   interface Window {
     __E1_CANVAS__?: E1PublicMetrics
     __E1_SELECT_FIXTURE__?: (id: E1FixtureId) => void
-    __E1_SWAP_CONDITION_PRIORITY__?: () => void
+    /** Real reorder-condition-branches via history API (no fixture swap). */
+    __E1_SWAP_CONDITION_PRIORITY__?: () => CommandDispatchResult | void
+    __E1_UNDO__?: () => CommandDispatchResult | void
+    __E1_REDO__?: () => CommandDispatchResult | void
+    /**
+     * Canonical move adapter entry (same function keyboard + pointer/HTML5 use).
+     * Channel defaults to 'keyboard' for programmatic harness hooks.
+     */
+    __E1_MOVE_NODE_INTO_EDGE__?: (
+      nodeKey: string,
+      intoEdgeKey: string,
+      channel?: CommandChannel,
+    ) => CommandDispatchResult
+    __E1_APPLY_COMMAND__?: (
+      command: ApprovalCanvasCommand,
+      channel?: CommandChannel,
+    ) => CommandDispatchResult
   }
 }
 
@@ -86,10 +137,83 @@ function prefersReducedMotion(): boolean {
   return window.matchMedia?.('(prefers-reduced-motion: reduce)').matches ?? false
 }
 
+function cloneGraph(graph: ApprovalGraph): ApprovalGraph {
+  return JSON.parse(JSON.stringify(graph)) as ApprovalGraph
+}
+
+function cloneFixture(id: E1FixtureId): E1Fixture {
+  const base = getFixture(id)
+  return JSON.parse(JSON.stringify(base)) as E1Fixture
+}
+
+/**
+ * Values-free business copy for command rejections.
+ * Never interpolates node keys, edge keys, field IDs, or raw internal messages.
+ */
+function businessCopyForError(code: ApprovalCanvasCommandErrorCode): string {
+  switch (code) {
+    case 'self-slot':
+    case 'adjacent-slot':
+    case 'ambiguous-slot':
+    case 'cycle':
+    case 'nested-parallel-invalid':
+    case 'empty-parallel-branch':
+    case 'edge-not-found':
+    case 'not-linear':
+      return '该位置不能放置此节点'
+    case 'unsupported-node-type':
+      return '此节点类型不支持此操作'
+    case 'node-not-found':
+      return '未找到可操作的节点'
+    case 'invalid-branch-order':
+    case 'default-edge-immutable':
+      return '无法调整该分支顺序'
+    case 'empty-history':
+      return '没有可撤销的操作'
+    case 'unknown-command':
+      return '操作无法完成'
+    default: {
+      const _exhaustive: never = code
+      void _exhaustive
+      return '操作无法完成'
+    }
+  }
+}
+
+function successCopyForCommand(
+  command: ApprovalCanvasCommand,
+  fixture: E1Fixture,
+  graph: ApprovalGraph,
+): string {
+  if (command.type === 'move-node-into-edge') {
+    const node = graph.nodes.find((item) => item.key === command.nodeKey)
+    const name = node?.name?.trim() || '节点'
+    return `已移动「${name}」`
+  }
+  if (command.type === 'reorder-condition-branches') {
+    const firstKey = command.orderedEdgeKeys[0]
+    const raised =
+      (firstKey && fixture.branchDisplayLabels?.[firstKey]) ||
+      graph.nodes.find((item) => item.key === command.conditionNodeKey)?.name ||
+      '分支'
+    return `已提高「${raised}」的优先级`
+  }
+  if (command.type === 'reorder-parallel-branches') {
+    return '已调整并行分支顺序'
+  }
+  return '操作已完成'
+}
+
 createApp({
   setup() {
     const fixtureId = ref<E1FixtureId>('linear')
-    const fixture = ref<E1Fixture>(getFixture('linear'))
+    const fixture = ref<E1Fixture>(cloneFixture('linear'))
+    const history = ref<ApprovalCanvasHistory>(
+      createApprovalCanvasHistory(cloneGraph(fixture.value.graph)),
+    )
+    // Keep fixture.graph as the history graph reference surface for layout.
+    fixture.value = { ...fixture.value, graph: history.value.graph }
+
     const selectedFocusId = ref<string | null>(null)
     const liveText = ref('')
     const viewportW = ref(window.innerWidth)
@@ -98,6 +222,9 @@ createApp({
     const measuredHeights = ref<Map<string, number>>(new Map())
     const surfaceEl = ref<HTMLElement | null>(null)
     const reducedMotion = ref(prefersReducedMotion())
+    const lastResult = ref<CommandDispatchResult | null>(null)
+    const draggingNodeKey = ref<string | null>(null)
+    const dragOverEdgeFocusId = ref<string | null>(null)
 
     const layout = computed<E1LayoutModel>(() =>
       computeE1Layout(fixture.value, measuredHeights.value.size ? measuredHeights.value : undefined),
@@ -123,12 +250,144 @@ createApp({
       })
     }
 
+    function syncFixtureFromHistory() {
+      fixture.value = {
+        ...fixture.value,
+        graph: history.value.graph,
+      }
+    }
+
+    /**
+     * Map history.selection (stable graph keys) onto the current layout's render-only
+     * focusId. Never stores focusIds or coordinates in history — only remaps after render.
+     */
+    function focusIdForHistorySelection(
+      selection: ApprovalCanvasSelection,
+      model: E1LayoutModel,
+    ): string | null {
+      if (selection.kind === 'none') return null
+      if (selection.kind === 'node') {
+        return model.cards.find((card) => card.nodeKey === selection.nodeKey)?.focusId ?? null
+      }
+      if (selection.kind === 'edge') {
+        return model.edges.find((edge) => edge.edgeKey === selection.edgeKey)?.focusId ?? null
+      }
+      if (selection.kind === 'condition-branch') {
+        // Prefer the gateway card so the inspector stays on the business node; fall back to branch edge.
+        return (
+          model.cards.find((card) => card.nodeKey === selection.conditionNodeKey)?.focusId ??
+          model.edges.find((edge) => edge.edgeKey === selection.edgeKey)?.focusId ??
+          null
+        )
+      }
+      if (selection.kind === 'parallel-branch') {
+        return (
+          model.cards.find((card) => card.nodeKey === selection.parallelNodeKey)?.focusId ??
+          model.edges.find((edge) => edge.edgeKey === selection.edgeKey)?.focusId ??
+          null
+        )
+      }
+      const _exhaustive: never = selection
+      void _exhaustive
+      return null
+    }
+
+    /**
+     * After apply/undo/redo, rebind selectedFocusId from history.selection using the
+     * newly computed layout. Layer-order focus IDs can change after a move; keys do not.
+     */
+    function restoreSelectionFromHistory() {
+      const focusId = focusIdForHistorySelection(history.value.selection, layout.value)
+      selectedFocusId.value = focusId
+      if (focusId) {
+        void nextTick(() => {
+          document.querySelector<HTMLElement>(`[data-focus-id="${focusId}"]`)?.focus()
+        })
+      }
+    }
+
+    function afterHistoryMutation() {
+      measuredHeights.value = new Map()
+      // Layout recomputes synchronously from the new graph; remap before paint/metrics.
+      restoreSelectionFromHistory()
+      void nextTick(() => {
+        measureAndReflow()
+        // Heights can reflow geometry but not focusId identity; remap again in case layout rebuilt.
+        restoreSelectionFromHistory()
+        publishMetrics()
+      })
+    }
+
+    /**
+     * Single command adapter for toolbar, keyboard, and pointer/HTML5 drag.
+     * Topology validity is decided only by the production command layer — never here.
+     */
+    function runCanvasCommand(
+      command: ApprovalCanvasCommand,
+      channel: CommandChannel,
+      selectionBefore?: ApprovalCanvasSelection,
+    ): CommandDispatchResult {
+      if (fixture.value.readOnly) {
+        const result: CommandDispatchResult = {
+          ok: false,
+          code: 'unsupported-node-type',
+          channel,
+          liveText: '当前为只读夹具，无法编辑',
+        }
+        lastResult.value = result
+        announce(result.liveText)
+        publishMetrics()
+        return result
+      }
+
+      const selection =
+        selectionBefore ??
+        (selectedCard.value
+          ? ({ kind: 'node', nodeKey: selectedCard.value.nodeKey } satisfies ApprovalCanvasSelection)
+          : ({ kind: 'none' } satisfies ApprovalCanvasSelection))
+
+      const applied = applyApprovalCanvasCommand(history.value, command, selection)
+      if (!applied.ok) {
+        const copy = businessCopyForError(applied.error.code)
+        const result: CommandDispatchResult = {
+          ok: false,
+          code: applied.error.code,
+          channel,
+          liveText: copy,
+        }
+        lastResult.value = result
+        // Failure returns the same history reference — graph stays byte-identical.
+        announce(copy)
+        publishMetrics()
+        return result
+      }
+
+      history.value = applied.history
+      syncFixtureFromHistory()
+      const copy = successCopyForCommand(command, fixture.value, history.value.graph)
+      const result: CommandDispatchResult = {
+        ok: true,
+        code: null,
+        channel,
+        liveText: copy,
+      }
+      lastResult.value = result
+      announce(copy)
+      afterHistoryMutation()
+      return result
+    }
+
     function selectFixture(id: E1FixtureId) {
       fixtureId.value = id
-      fixture.value = getFixture(id)
+      const next = cloneFixture(id)
+      history.value = createApprovalCanvasHistory(cloneGraph(next.graph))
+      fixture.value = { ...next, graph: history.value.graph }
       selectedFocusId.value = null
       insertMenu.value = null
       measuredHeights.value = new Map()
+      draggingNodeKey.value = null
+      dragOverEdgeFocusId.value = null
+      lastResult.value = null
       announce(`已加载夹具：${fixture.value.title}`)
       void nextTick(() => {
         measureAndReflow()
@@ -136,23 +395,117 @@ createApp({
       })
     }
 
-    /** Demo-only: swap condition branch priority via config.branches only (nodes/edges untouched). */
-    function swapConditionPriority() {
+    /**
+     * Raise the second rule branch to highest priority via reorder-condition-branches.
+     * Replaces the demo-only fixture swap; default branch is never included.
+     */
+    function swapConditionPriority(): CommandDispatchResult | void {
       if (fixture.value.readOnly) {
-        announce('当前为只读夹具，无法调整优先级')
+        const result: CommandDispatchResult = {
+          ok: false,
+          code: 'unsupported-node-type',
+          channel: 'toolbar',
+          liveText: '当前为只读夹具，无法调整优先级',
+        }
+        lastResult.value = result
+        announce(result.liveText)
+        publishMetrics()
+        return result
+      }
+      const condition = history.value.graph.nodes.find((node) => node.type === 'condition')
+      if (!condition) {
+        announce('请先加载条件分支夹具')
         return
       }
-      if (fixtureId.value === 'condition') {
-        selectFixture('condition-priority-swapped')
-        announce('已提高「金额大于等于一千」的优先级')
+      const config = condition.config as ConditionNodeConfig
+      const keys = (config.branches ?? []).map((branch) => branch.edgeKey)
+      if (keys.length < 2) {
+        announce('当前条件没有可对调的规则分支')
         return
       }
-      if (fixtureId.value === 'condition-priority-swapped') {
-        selectFixture('condition')
-        announce('已恢复「金额大于等于一百」为最高优先级')
-        return
+      const orderedEdgeKeys = [keys[1]!, keys[0]!, ...keys.slice(2)]
+      return runCanvasCommand(
+        {
+          type: 'reorder-condition-branches',
+          conditionNodeKey: condition.key,
+          orderedEdgeKeys,
+        },
+        'toolbar',
+        { kind: 'node', nodeKey: condition.key },
+      )
+    }
+
+    function undoLast(): CommandDispatchResult {
+      const undone = undoApprovalCanvasCommand(history.value)
+      if (!undone.ok) {
+        const copy = businessCopyForError(undone.error.code)
+        const result: CommandDispatchResult = {
+          ok: false,
+          code: undone.error.code,
+          channel: 'toolbar',
+          liveText: copy,
+        }
+        lastResult.value = result
+        announce(copy)
+        publishMetrics()
+        return result
       }
-      announce('请先加载条件分支夹具')
+      history.value = undone.history
+      syncFixtureFromHistory()
+      const result: CommandDispatchResult = {
+        ok: true,
+        code: null,
+        channel: 'toolbar',
+        liveText: '已撤销上一步操作',
+      }
+      lastResult.value = result
+      announce(result.liveText)
+      // selectionBefore is restored on history.selection — remap to post-undo focusIds.
+      afterHistoryMutation()
+      return result
+    }
+
+    function redoLast(): CommandDispatchResult {
+      const redone = redoApprovalCanvasCommand(history.value)
+      if (!redone.ok) {
+        const copy = businessCopyForError(redone.error.code)
+        const result: CommandDispatchResult = {
+          ok: false,
+          code: redone.error.code,
+          channel: 'toolbar',
+          liveText: copy,
+        }
+        lastResult.value = result
+        announce(copy)
+        publishMetrics()
+        return result
+      }
+      history.value = redone.history
+      syncFixtureFromHistory()
+      const result: CommandDispatchResult = {
+        ok: true,
+        code: null,
+        channel: 'toolbar',
+        liveText: '已重做上一步操作',
+      }
+      lastResult.value = result
+      announce(result.liveText)
+      // selectionAfter is restored on history.selection — remap to post-redo focusIds.
+      afterHistoryMutation()
+      return result
+    }
+
+    /** Canonical move used by pointer/HTML5 drag and keyboard activation alike. */
+    function moveNodeIntoEdge(
+      nodeKey: string,
+      intoEdgeKey: string,
+      channel: CommandChannel,
+    ): CommandDispatchResult {
+      return runCanvasCommand(
+        { type: 'move-node-into-edge', nodeKey, intoEdgeKey },
+        channel,
+        { kind: 'node', nodeKey },
+      )
     }
 
     function selectCard(card: E1CardModel) {
@@ -178,7 +531,12 @@ createApp({
         announce('当前连线不可插入')
         return
       }
-      insertMenu.value = { edgeFocusId: edge.focusId, x: edge.midX, y: edge.midY }
+      insertMenu.value = {
+        edgeFocusId: edge.focusId,
+        edgeKey: edge.edgeKey,
+        x: edge.midX,
+        y: edge.midY,
+      }
       announce(`已打开插入菜单：${edge.ariaLabel}`)
       void nextTick(() => {
         const first = document.querySelector<HTMLElement>('[data-test="insert-menu"] button')
@@ -189,9 +547,64 @@ createApp({
     function activateInsert(kind: 'approval' | 'cc') {
       const label = kind === 'approval' ? '审批' : '抄送'
       insertMenu.value = null
-      // Spike: announce activation only — mutations stay out of production graph save paths.
+      // Spike: announce activation only — insert mutations stay out of E1-b scope.
       announce(`已选择插入「${label}」节点（spike 演示，未写入业务模型）`)
       publishMetrics()
+    }
+
+    function activateMoveSelectedToEdge(edgeKey: string, channel: CommandChannel) {
+      const card = selectedCard.value
+      if (!card || (card.type !== 'approval' && card.type !== 'cc')) {
+        announce('请先选中可移动的审批或抄送节点')
+        return
+      }
+      insertMenu.value = null
+      moveNodeIntoEdge(card.nodeKey, edgeKey, channel)
+    }
+
+    function isCardDraggable(card: E1CardModel): boolean {
+      if (fixture.value.readOnly) return false
+      return card.type === 'approval' || card.type === 'cc'
+    }
+
+    function onCardDragStart(card: E1CardModel, event: DragEvent) {
+      if (!isCardDraggable(card)) {
+        event.preventDefault()
+        return
+      }
+      draggingNodeKey.value = card.nodeKey
+      selectedFocusId.value = card.focusId
+      if (event.dataTransfer) {
+        event.dataTransfer.effectAllowed = 'move'
+        // Opaque token only — never surface graph keys in accessible DOM text.
+        event.dataTransfer.setData('text/plain', card.focusId)
+      }
+    }
+
+    function onCardDragEnd() {
+      draggingNodeKey.value = null
+      dragOverEdgeFocusId.value = null
+    }
+
+    function onEdgeDragOver(edge: E1EdgeModel, event: DragEvent) {
+      if (!draggingNodeKey.value || !edge.insertable || fixture.value.readOnly) return
+      event.preventDefault()
+      if (event.dataTransfer) event.dataTransfer.dropEffect = 'move'
+      dragOverEdgeFocusId.value = edge.focusId
+    }
+
+    function onEdgeDragLeave(edge: E1EdgeModel) {
+      if (dragOverEdgeFocusId.value === edge.focusId) dragOverEdgeFocusId.value = null
+    }
+
+    function onEdgeDrop(edge: E1EdgeModel, event: DragEvent) {
+      event.preventDefault()
+      const nodeKey = draggingNodeKey.value
+      dragOverEdgeFocusId.value = null
+      draggingNodeKey.value = null
+      if (!nodeKey || !edge.insertable) return
+      // Pointer/HTML5 path — same adapter as keyboard.
+      moveNodeIntoEdge(nodeKey, edge.edgeKey, 'pointer')
     }
 
     function onCanvasKeydown(event: KeyboardEvent) {
@@ -209,6 +622,14 @@ createApp({
         return
       }
 
+      // Undo / redo (toolbar channel for chrome-equivalent keyboard shortcuts).
+      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'z') {
+        event.preventDefault()
+        if (event.shiftKey) redoLast()
+        else undoLast()
+        return
+      }
+
       if (event.key === 'Enter' || event.key === ' ') {
         const edge = layout.value.edges.find((item) => item.focusId === focusId)
         if (edge) {
@@ -220,6 +641,17 @@ createApp({
         if (card) {
           event.preventDefault()
           selectCard(card)
+          return
+        }
+      }
+
+      // Keyboard semantic move: with a movable node selected, `m` on an edge insert
+      // uses the same adapter as pointer/HTML5 drop.
+      if (event.key === 'm' || event.key === 'M') {
+        const edge = layout.value.edges.find((item) => item.focusId === focusId)
+        if (edge?.insertable) {
+          event.preventDefault()
+          activateMoveSelectedToEdge(edge.edgeKey, 'keyboard')
           return
         }
       }
@@ -262,8 +694,8 @@ createApp({
       for (const card of layout.value.cards) {
         const el = root.querySelector<HTMLElement>(`[data-focus-id="${card.focusId}"]`)
         if (!el) continue
-        const h = el.getBoundingClientRect().height
-        if (h > 0) next.set(card.nodeKey, Math.ceil(h))
+        const measured = el.getBoundingClientRect().height
+        if (measured > 0) next.set(card.nodeKey, Math.ceil(measured))
       }
       // Only update when heights actually differ to avoid loops.
       let changed = next.size !== measuredHeights.value.size
@@ -280,6 +712,11 @@ createApp({
 
     function publishMetrics() {
       const model = layout.value
+      const cardKeyByFocusId: Record<string, string> = {}
+      const edgeKeyByFocusId: Record<string, string> = {}
+      for (const card of model.cards) cardKeyByFocusId[card.focusId] = card.nodeKey
+      for (const edge of model.edges) edgeKeyByFocusId[edge.focusId] = edge.edgeKey
+
       window.__E1_CANVAS__ = {
         ready: true,
         fixtureId: fixtureId.value,
@@ -322,6 +759,15 @@ createApp({
         liveText: liveText.value,
         reducedMotion: reducedMotion.value,
         internalTokens: collectInternalTokens(fixture.value.graph),
+        graphJson: JSON.stringify(history.value.graph),
+        canUndo: history.value.undoStack.length > 0,
+        canRedo: history.value.redoStack.length > 0,
+        undoDepth: history.value.undoStack.length,
+        lastCommandOk: lastResult.value?.ok ?? null,
+        lastCommandCode: lastResult.value?.code ?? null,
+        lastCommandChannel: lastResult.value?.channel ?? null,
+        cardKeyByFocusId,
+        edgeKeyByFocusId,
       }
     }
 
@@ -341,6 +787,12 @@ createApp({
       motionQuery?.addEventListener?.('change', onMotionChange)
       window.__E1_SELECT_FIXTURE__ = selectFixture
       window.__E1_SWAP_CONDITION_PRIORITY__ = swapConditionPriority
+      window.__E1_UNDO__ = undoLast
+      window.__E1_REDO__ = redoLast
+      window.__E1_MOVE_NODE_INTO_EDGE__ = (nodeKey, intoEdgeKey, channel = 'keyboard') =>
+        moveNodeIntoEdge(nodeKey, intoEdgeKey, channel)
+      window.__E1_APPLY_COMMAND__ = (command, channel = 'keyboard') =>
+        runCanvasCommand(command, channel)
       void nextTick(() => {
         measureAndReflow()
         publishMetrics()
@@ -351,6 +803,10 @@ createApp({
       window.removeEventListener('resize', onResize)
       delete window.__E1_SELECT_FIXTURE__
       delete window.__E1_SWAP_CONDITION_PRIORITY__
+      delete window.__E1_UNDO__
+      delete window.__E1_REDO__
+      delete window.__E1_MOVE_NODE_INTO_EDGE__
+      delete window.__E1_APPLY_COMMAND__
       delete window.__E1_CANVAS__
     })
 
@@ -369,6 +825,8 @@ createApp({
       const mode = presentation.value
       const card = selectedCard.value
       const readOnly = Boolean(fixture.value.readOnly)
+      const movableSelected =
+        card != null && (card.type === 'approval' || card.type === 'cc') && !readOnly
 
       const inspectorClass = [
         'e1-inspector',
@@ -479,8 +937,26 @@ createApp({
           h('button', {
             type: 'button',
             'data-test': 'swap-priority',
-            onClick: swapConditionPriority,
+            onClick: () => {
+              swapConditionPriority()
+            },
           }, '调整条件优先级'),
+          h('button', {
+            type: 'button',
+            'data-test': 'undo',
+            disabled: history.value.undoStack.length === 0,
+            onClick: () => {
+              undoLast()
+            },
+          }, '撤销'),
+          h('button', {
+            type: 'button',
+            'data-test': 'redo',
+            disabled: history.value.redoStack.length === 0,
+            onClick: () => {
+              redoLast()
+            },
+          }, '重做'),
           h('span', {
             'data-test': 'fixture-title',
             style: 'font-size:13px;color:#4b5563',
@@ -569,18 +1045,23 @@ createApp({
                 const paired =
                   selectedCard.value?.pairedFocusId === item.focusId ||
                   (selected && Boolean(item.pairedFocusId))
+                const draggable = isCardDraggable(item)
                 return h('div', {
                   class: [
                     'e1-card',
                     selected ? 'is-selected' : null,
                     paired ? 'is-paired' : null,
                     readOnly ? 'is-readonly' : null,
+                    draggable ? 'is-draggable' : null,
+                    draggingNodeKey.value === item.nodeKey ? 'is-dragging' : null,
                   ],
                   'data-test': 'flow-node',
                   'data-node-type': item.type,
                   'data-focus-id': item.focusId,
+                  'data-draggable': draggable ? 'true' : 'false',
                   role: 'button',
                   tabindex: 0,
+                  draggable,
                   // Business language only — never node keys / edge keys / IDs.
                   'aria-label': `${item.typeLabel}：${item.name}`,
                   title: item.name,
@@ -592,6 +1073,8 @@ createApp({
                     minHeight: `${Math.max(48, item.height - 8)}px`,
                   },
                   onClick: () => selectCard(item),
+                  onDragstart: (event: DragEvent) => onCardDragStart(item, event),
+                  onDragend: onCardDragEnd,
                 }, [
                   h('div', { class: 'e1-card__type' }, item.typeLabel),
                   h('div', { class: 'e1-card__name', 'data-test': 'node-name' }, item.name),
@@ -607,7 +1090,10 @@ createApp({
               }),
               ...model.edges.filter((edge) => edge.insertable).map((edge) => h('button', {
                 type: 'button',
-                class: 'e1-insert',
+                class: [
+                  'e1-insert',
+                  dragOverEdgeFocusId.value === edge.focusId ? 'is-drop-target' : null,
+                ],
                 'data-test': 'edge-insert',
                 'data-focus-id': edge.focusId,
                 'aria-label': edge.ariaLabel,
@@ -619,6 +1105,9 @@ createApp({
                   event.stopPropagation()
                   openInsertMenu(edge)
                 },
+                onDragover: (event: DragEvent) => onEdgeDragOver(edge, event),
+                onDragleave: () => onEdgeDragLeave(edge),
+                onDrop: (event: DragEvent) => onEdgeDrop(edge, event),
               }, '+')),
               insertMenu.value
                 ? h('div', {
@@ -642,6 +1131,17 @@ createApp({
                     'data-test': 'insert-cc',
                     onClick: () => activateInsert('cc'),
                   }, '抄送节点'),
+                  movableSelected
+                    ? h('button', {
+                      type: 'button',
+                      role: 'menuitem',
+                      'data-test': 'move-selected-here',
+                      onClick: () => {
+                        const edgeKey = insertMenu.value?.edgeKey
+                        if (edgeKey) activateMoveSelectedToEdge(edgeKey, 'keyboard')
+                      },
+                    }, '移动已选节点到此处')
+                    : null,
                 ])
                 : null,
             ]),

--- a/apps/web/verification/approval-flow-canvas-e1-layout.ts
+++ b/apps/web/verification/approval-flow-canvas-e1-layout.ts
@@ -1,0 +1,847 @@
+// E1 spike layout: constrained vertical tree. Coordinates are render-only and
+// never written back into ApprovalGraph. Branch lane order comes from gateway
+// config.branches (default condition branch always rightmost), never graph.nodes order.
+import type {
+  ApprovalEdge,
+  ApprovalGraph,
+  ApprovalNode,
+  ApprovalNodeType,
+  ConditionNodeConfig,
+  ParallelNodeConfig,
+} from '../src/types/approval'
+import type { E1Fixture } from './approval-flow-canvas-e1-fixtures'
+
+export const E1_NODE_WIDTH = 200
+export const E1_H_GAP = 56
+export const E1_V_GAP = 56
+export const E1_MARGIN_X = 48
+export const E1_MARGIN_Y = 40
+export const E1_INSERT_SIZE = 40
+
+export interface E1CardModel {
+  /** Opaque render id (never a graph key). */
+  focusId: string
+  /** Internal graph key — keep out of DOM text/aria. */
+  nodeKey: string
+  type: ApprovalNodeType
+  name: string
+  typeLabel: string
+  summaryLines: string[]
+  /** Optional state badges in business language. */
+  badges: string[]
+  x: number
+  y: number
+  width: number
+  /** Content-driven height (estimated first, then measured). */
+  height: number
+  /** True when this card is the matched join of a parallel fork. */
+  isJoin?: boolean
+  joinModeLabel?: string
+  pairedFocusId?: string
+}
+
+export interface E1BranchLabelModel {
+  focusId: string
+  gatewayFocusId: string
+  /** Visual left-to-right order (0 = leftmost). */
+  order: number
+  /** 1-based priority for rule branches; omitted for default. */
+  priority?: number
+  label: string
+  isDefault: boolean
+  /** Center x of the branch lane (for label placement). */
+  x: number
+  y: number
+}
+
+export interface E1EdgeModel {
+  focusId: string
+  edgeKey: string
+  sourceFocusId: string
+  targetFocusId: string
+  sourceNodeKey: string
+  targetNodeKey: string
+  /** SVG path in canvas coordinates. */
+  path: string
+  midX: number
+  midY: number
+  insertable: boolean
+  ariaLabel: string
+  branchLabel?: string
+  branchPriority?: number
+  isDefaultBranch?: boolean
+}
+
+export interface E1LayoutModel {
+  cards: E1CardModel[]
+  edges: E1EdgeModel[]
+  branchLabels: E1BranchLabelModel[]
+  width: number
+  height: number
+  /** focusId order for keyboard spine navigation. */
+  focusOrder: string[]
+}
+
+const TYPE_LABEL: Record<ApprovalNodeType, string> = {
+  start: '开始',
+  end: '结束',
+  approval: '审批',
+  cc: '抄送',
+  condition: '条件',
+  parallel: '并行',
+}
+
+function cloneGraph(graph: ApprovalGraph): ApprovalGraph {
+  return JSON.parse(JSON.stringify(graph)) as ApprovalGraph
+}
+
+function nodeMap(graph: ApprovalGraph): Map<string, ApprovalNode> {
+  return new Map(graph.nodes.map((node) => [node.key, node]))
+}
+
+function outEdgesOf(graph: ApprovalGraph, key: string): ApprovalEdge[] {
+  return graph.edges.filter((edge) => edge.source === key)
+}
+
+function inEdgesOf(graph: ApprovalGraph, key: string): ApprovalEdge[] {
+  return graph.edges.filter((edge) => edge.target === key)
+}
+
+/** Ordered outgoing edges for a gateway: config.branches first, default last. */
+export function orderedGatewayOutEdges(graph: ApprovalGraph, node: ApprovalNode): ApprovalEdge[] {
+  const outs = outEdgesOf(graph, node.key)
+  const byKey = new Map(outs.map((edge) => [edge.key, edge]))
+  if (node.type === 'condition') {
+    const config = node.config as ConditionNodeConfig
+    const ordered: ApprovalEdge[] = []
+    for (const branch of config.branches ?? []) {
+      const edge = byKey.get(branch.edgeKey)
+      if (edge) ordered.push(edge)
+    }
+    if (config.defaultEdgeKey) {
+      const def = byKey.get(config.defaultEdgeKey)
+      if (def) ordered.push(def)
+    }
+    // Any unexpected outs append last (should not happen on valid graphs).
+    for (const edge of outs) {
+      if (!ordered.includes(edge)) ordered.push(edge)
+    }
+    return ordered
+  }
+  if (node.type === 'parallel') {
+    const config = node.config as ParallelNodeConfig
+    const ordered: ApprovalEdge[] = []
+    for (const edgeKey of config.branches ?? []) {
+      const edge = byKey.get(edgeKey)
+      if (edge) ordered.push(edge)
+    }
+    for (const edge of outs) {
+      if (!ordered.includes(edge)) ordered.push(edge)
+    }
+    return ordered
+  }
+  return outs
+}
+
+function summarizeNode(node: ApprovalNode, fixture: E1Fixture): string[] {
+  if (node.type === 'start' || node.type === 'end') return []
+  if (node.type === 'cc') {
+    const config = node.config as { targetType?: string; targetIds?: string[] }
+    if (config.targetType === 'role') return ['角色：相关主管']
+    const n = config.targetIds?.length ?? 0
+    return n > 0 ? [`${n} 名成员`] : ['未配置抄送对象']
+  }
+  if (node.type === 'condition') {
+    const config = node.config as ConditionNodeConfig
+    const n = (config.branches?.length ?? 0) + (config.defaultEdgeKey ? 1 : 0)
+    return [`${n} 个分支${config.defaultEdgeKey ? ' · 含默认分支' : ''}`]
+  }
+  if (node.type === 'parallel') {
+    const config = node.config as ParallelNodeConfig
+    const n = config.branches?.length ?? 0
+    const mode = config.joinMode === 'any' ? '任一完成后合并' : '全部完成后合并'
+    return [`${n} 个并行分支 · ${mode}`]
+  }
+  // approval
+  const config = node.config as {
+    assigneeSources?: Array<{ kind: string; userIds?: string[]; roleIds?: string[] }>
+    approvalMode?: string
+    timeout?: unknown
+    approvalThreshold?: unknown
+    legacyHandlerProfile?: unknown
+  }
+  const lines: string[] = []
+  const sources = config.assigneeSources ?? []
+  const parts: string[] = []
+  for (const source of sources) {
+    if (source.kind === 'direct_manager') parts.push('直属上级')
+    else if (source.kind === 'dept_head') parts.push('部门负责人')
+    else if (source.kind === 'requester') parts.push('发起人')
+    else if (source.kind === 'static_role') parts.push(`角色：${(source.roleIds?.length ?? 0) > 1 ? '多个角色' : '指定角色'}`)
+    else if (source.kind === 'static_user') parts.push(`${source.userIds?.length ?? 0} 名指定成员`)
+    else parts.push('审批人')
+  }
+  if (parts.length) lines.push(parts.join('、'))
+  if (config.approvalMode === 'all') lines.push('全部通过')
+  else if (config.approvalMode === 'any') lines.push('任一通过')
+  else lines.push('单人审批')
+  // Third summary line for the long-label fixture (assignee richness).
+  if (sources.length >= 3) lines.push('含角色与上级会签')
+  if (fixture.readOnly && (config.timeout || config.approvalThreshold || config.legacyHandlerProfile)) {
+    if (config.timeout) lines.push('含超时策略（只读）')
+    if (config.approvalThreshold) lines.push('含通过阈值（只读）')
+    if (config.legacyHandlerProfile) lines.push('含历史扩展配置（只读）')
+  }
+  return lines.slice(0, 3)
+}
+
+function estimateHeight(summaryLines: string[], badges: string[]): number {
+  const base = 52 // type + name
+  const lineH = 18
+  const badgeH = badges.length ? 22 : 0
+  return base + summaryLines.length * lineH + badgeH + 16
+}
+
+function branchLabelFor(
+  edgeKey: string,
+  gateway: ApprovalNode,
+  orderAmongRules: number,
+  isDefault: boolean,
+  fixture: E1Fixture,
+): string {
+  if (fixture.branchDisplayLabels?.[edgeKey]) return fixture.branchDisplayLabels[edgeKey]!
+  if (isDefault) return '默认分支（其他情况）'
+  if (gateway.type === 'parallel') return `分支 ${orderAmongRules + 1}`
+  return `优先级 ${orderAmongRules + 1}`
+}
+
+function pointsToPath(points: Array<{ x: number; y: number }>): string {
+  return points.map((point, index) => `${index === 0 ? 'M' : 'L'} ${point.x} ${point.y}`).join(' ')
+}
+
+function pathClearsCards(
+  points: Array<{ x: number; y: number }>,
+  cards: E1CardModel[],
+  sourceFocusId: string,
+  targetFocusId: string,
+): boolean {
+  for (const card of cards) {
+    if (card.focusId === sourceFocusId || card.focusId === targetFocusId) continue
+    if (polylineHitsRect(points, { x: card.x, y: card.y, w: card.width, h: card.height })) {
+      return false
+    }
+  }
+  return true
+}
+
+/**
+ * Orthogonal edge routing that never crosses a non-endpoint card.
+ * 1. Prefer a straight vertical or single mid-Y elbow in a free horizontal corridor.
+ * 2. If intermediate cards block that corridor, detour around their bounding box.
+ */
+function routeOrthogonalEdge(
+  x1: number,
+  y1: number,
+  x2: number,
+  y2: number,
+  cards: E1CardModel[],
+  sourceFocusId: string,
+  targetFocusId: string,
+): { path: string; midX: number; midY: number } {
+  const tryPoints = (points: Array<{ x: number; y: number }>) =>
+    pathClearsCards(points, cards, sourceFocusId, targetFocusId)
+
+  // Same column: straight vertical when clear.
+  if (Math.abs(x1 - x2) < 1) {
+    const direct = [
+      { x: x1, y: y1 },
+      { x: x2, y: y2 },
+    ]
+    if (tryPoints(direct)) {
+      return { path: pointsToPath(direct), midX: x1, midY: (y1 + y2) / 2 }
+    }
+  }
+
+  // Candidate horizontal corridors between source bottom and target top.
+  const candidates: number[] = []
+  if (y2 - y1 > 4) {
+    candidates.push(y1 + (y2 - y1) / 2)
+    candidates.push(y1 + Math.min(16, (y2 - y1) / 3))
+    candidates.push(y2 - Math.min(16, (y2 - y1) / 3))
+    // Prefer channels that sit in vertical gaps between card y-ranges.
+    const gapYs: number[] = []
+    for (const card of cards) {
+      if (card.focusId === sourceFocusId || card.focusId === targetFocusId) continue
+      const bottom = card.y + card.height
+      const top = card.y
+      if (bottom > y1 && bottom < y2) gapYs.push(bottom + 8)
+      if (top > y1 && top < y2) gapYs.push(top - 8)
+    }
+    candidates.push(...gapYs)
+    for (let y = y1 + 8; y < y2 - 8; y += 8) candidates.push(y)
+  }
+
+  for (const midY of candidates) {
+    if (!(midY > y1 && midY < y2)) continue
+    const points =
+      Math.abs(x1 - x2) < 1
+        ? [
+            { x: x1, y: y1 },
+            { x: x2, y: y2 },
+          ]
+        : [
+            { x: x1, y: y1 },
+            { x: x1, y: midY },
+            { x: x2, y: midY },
+            { x: x2, y: y2 },
+          ]
+    if (tryPoints(points)) {
+      return {
+        path: pointsToPath(points),
+        midX: Math.abs(x1 - x2) < 1 ? x1 : (x1 + x2) / 2,
+        midY,
+      }
+    }
+  }
+
+  // Detour left/right around cards that intersect the vertical span.
+  const blockers = cards.filter((card) => {
+    if (card.focusId === sourceFocusId || card.focusId === targetFocusId) return false
+    const verticallyBetween = card.y + card.height > y1 && card.y < y2
+    if (!verticallyBetween) return false
+    const minX = Math.min(x1, x2)
+    const maxX = Math.max(x1, x2)
+    // Same-column blockers, or any card overlapping the horizontal travel range.
+    const coversSourceX = card.x < x1 && card.x + card.width > x1
+    const coversTargetX = card.x < x2 && card.x + card.width > x2
+    const overlapsTravel = !(card.x + card.width < minX || card.x > maxX)
+    return coversSourceX || coversTargetX || overlapsTravel
+  })
+
+  const pad = 20
+  const sideXs: number[] = []
+  if (blockers.length) {
+    sideXs.push(Math.min(...blockers.map((card) => card.x)) - pad)
+    sideXs.push(Math.max(...blockers.map((card) => card.x + card.width)) + pad)
+  }
+  // Also try gutters outside the full card field.
+  if (cards.length) {
+    sideXs.push(Math.min(...cards.map((card) => card.x)) - pad)
+    sideXs.push(Math.max(...cards.map((card) => card.x + card.width)) + pad)
+  }
+
+  for (const sideX of sideXs) {
+    const clearTop = blockers.length
+      ? Math.min(...blockers.map((card) => card.y)) - 10
+      : y1 + (y2 - y1) / 4
+    const clearBot = blockers.length
+      ? Math.max(...blockers.map((card) => card.y + card.height)) + 10
+      : y2 - (y2 - y1) / 4
+    const yA = Math.max(y1 + 6, Math.min(clearTop, y2 - 12))
+    const yB = Math.min(y2 - 6, Math.max(clearBot, y1 + 12))
+    if (!(yA > y1 && yB < y2 && yB >= yA)) continue
+    const points = [
+      { x: x1, y: y1 },
+      { x: x1, y: yA },
+      { x: sideX, y: yA },
+      { x: sideX, y: yB },
+      { x: x2, y: yB },
+      { x: x2, y: y2 },
+    ]
+    if (tryPoints(points)) {
+      return { path: pointsToPath(points), midX: sideX, midY: (yA + yB) / 2 }
+    }
+  }
+
+  // Last resort: simple elbow (may still be used for zero-obstacle graphs).
+  const midY = y1 + (y2 - y1) / 2
+  const fallback =
+    Math.abs(x1 - x2) < 1
+      ? [
+          { x: x1, y: y1 },
+          { x: x2, y: y2 },
+        ]
+      : [
+          { x: x1, y: y1 },
+          { x: x1, y: midY },
+          { x: x2, y: midY },
+          { x: x2, y: y2 },
+        ]
+  return {
+    path: pointsToPath(fallback),
+    midX: Math.abs(x1 - x2) < 1 ? x1 : (x1 + x2) / 2,
+    midY,
+  }
+}
+
+/**
+ * Deterministic vertical-tree layout.
+ * - Lane order: gateway config.branches, default rightmost
+ * - Card height: content-driven estimate (caller may reflow with measured heights)
+ * - No coordinates written to the graph
+ */
+export function computeE1Layout(fixture: E1Fixture, measuredHeights?: Map<string, number>): E1LayoutModel {
+  const graph = cloneGraph(fixture.graph)
+  const nodes = nodeMap(graph)
+  const startNode = graph.nodes.find((node) => node.type === 'start')
+  if (!startNode) {
+    return { cards: [], edges: [], branchLabels: [], width: 400, height: 200, focusOrder: [] }
+  }
+
+  // Longest-path layer from start.
+  const layer = new Map<string, number>()
+  for (const node of graph.nodes) layer.set(node.key, 0)
+  for (let pass = 0; pass < graph.nodes.length; pass += 1) {
+    let changed = false
+    for (const edge of graph.edges) {
+      const s = layer.get(edge.source) ?? 0
+      const t = layer.get(edge.target) ?? 0
+      if (s + 1 > t) {
+        layer.set(edge.target, s + 1)
+        changed = true
+      }
+    }
+    if (!changed) break
+  }
+  layer.set(startNode.key, 0)
+
+  // Lane assignment: exclusive horizontal strips per branch, ordered by gateway
+  // config.branches (default rightmost). Nested gateways reserve contiguous
+  // subtree width so a nested condition cannot share a column with a sibling
+  // parallel branch (that collision is what made join edges punch through cards).
+  const lane = new Map<string, number>()
+  const widthMemo = new Map<string, number>()
+
+  /** Exclusive lane-units needed by the region starting at `entryKey` until a join fan-in. */
+  const regionWidth = (entryKey: string, visiting: Set<string> = new Set()): number => {
+    if (widthMemo.has(entryKey)) return widthMemo.get(entryKey)!
+    if (visiting.has(entryKey)) return 1
+    visiting.add(entryKey)
+    const node = nodes.get(entryKey)
+    if (!node) {
+      visiting.delete(entryKey)
+      return 1
+    }
+    if (node.type === 'condition' || node.type === 'parallel') {
+      const outs = orderedGatewayOutEdges(graph, node)
+      let sum = 0
+      for (const edge of outs) {
+        const indeg = inEdgesOf(graph, edge.target).length
+        // Direct edge into a join counts as a single placeholder strip.
+        sum += indeg > 1 ? 1 : regionWidth(edge.target, visiting)
+      }
+      const width = Math.max(1, sum)
+      widthMemo.set(entryKey, width)
+      visiting.delete(entryKey)
+      return width
+    }
+    const outs = outEdgesOf(graph, entryKey)
+    if (outs.length === 0) {
+      widthMemo.set(entryKey, 1)
+      visiting.delete(entryKey)
+      return 1
+    }
+    // Linear continuation: width is the max over non-join successors (usually one).
+    let maxW = 1
+    for (const edge of outs) {
+      const indeg = inEdgesOf(graph, edge.target).length
+      if (indeg > 1) continue
+      maxW = Math.max(maxW, regionWidth(edge.target, visiting))
+    }
+    widthMemo.set(entryKey, maxW)
+    visiting.delete(entryKey)
+    return maxW
+  }
+
+  /**
+   * Place `entryKey` into exclusive lanes starting at `laneStart`.
+   * Returns the exclusive end lane index (start + width).
+   * Join nodes (in-degree > 1) are centered over the parent gateway's strip.
+   */
+  const placeRegion = (entryKey: string, laneStart: number, gatewayStrip?: { start: number; end: number }): number => {
+    const node = nodes.get(entryKey)
+    if (!node) return laneStart + 1
+    const indeg = inEdgesOf(graph, entryKey).length
+    if (indeg > 1 && gatewayStrip) {
+      // Join sits on the center of the owning gateway's full strip.
+      const mid = (gatewayStrip.start + gatewayStrip.end - 1) / 2
+      if (lane.get(entryKey) === undefined) lane.set(entryKey, mid)
+      return gatewayStrip.end
+    }
+
+    if (node.type === 'condition' || node.type === 'parallel') {
+      const outs = orderedGatewayOutEdges(graph, node)
+      const widths = outs.map((edge) => {
+        const targetIndeg = inEdgesOf(graph, edge.target).length
+        return targetIndeg > 1 ? 1 : regionWidth(edge.target)
+      })
+      const total = Math.max(1, widths.reduce((a, b) => a + b, 0))
+      const strip = { start: laneStart, end: laneStart + total }
+      // Gateway card centered over its branch strip.
+      lane.set(entryKey, (strip.start + strip.end - 1) / 2)
+      let cursor = laneStart
+      outs.forEach((edge, index) => {
+        const w = widths[index] ?? 1
+        const targetIndeg = inEdgesOf(graph, edge.target).length
+        if (targetIndeg > 1) {
+          if (lane.get(edge.target) === undefined) {
+            lane.set(edge.target, (strip.start + strip.end - 1) / 2)
+          }
+        } else {
+          placeRegion(edge.target, cursor, strip)
+        }
+        cursor += w
+      })
+      // Parallel join always centers on THIS gateway's full strip (nested gateways
+      // may have tentatively placed it on their narrower strip while walking outs).
+      if (node.type === 'parallel') {
+        const joinKey = (node.config as ParallelNodeConfig).joinNodeKey
+        if (joinKey) {
+          lane.set(joinKey, (strip.start + strip.end - 1) / 2)
+          for (const out of outEdgesOf(graph, joinKey)) {
+            if (lane.get(out.target) === undefined) placeRegion(out.target, strip.start)
+          }
+        }
+      }
+      return strip.end
+    }
+
+    // Linear node: single lane, push successors.
+    lane.set(entryKey, laneStart)
+    for (const edge of outEdgesOf(graph, entryKey)) {
+      const targetIndeg = inEdgesOf(graph, edge.target).length
+      if (targetIndeg > 1) {
+        // Join / rejoin: center on the owning gateway strip when present.
+        if (lane.get(edge.target) === undefined) {
+          lane.set(
+            edge.target,
+            gatewayStrip ? (gatewayStrip.start + gatewayStrip.end - 1) / 2 : laneStart,
+          )
+        }
+        // Always continue the spine past the join once (condition rejoins used to
+        // stop here, leaving later gateways unplaced at lane 0 — stacked cards).
+        const spineStart = gatewayStrip ? gatewayStrip.start : laneStart
+        for (const out of outEdgesOf(graph, edge.target)) {
+          if (lane.get(out.target) === undefined) placeRegion(out.target, spineStart)
+        }
+        continue
+      }
+      placeRegion(edge.target, laneStart, gatewayStrip)
+    }
+    return laneStart + regionWidth(entryKey)
+  }
+
+  placeRegion(startNode.key, 0)
+
+  // Ensure every node has a lane.
+  for (const node of graph.nodes) {
+    if (lane.get(node.key) === undefined) lane.set(node.key, 0)
+  }
+
+  // Normalize lanes to integer ranks 0..N-1 for packing.
+  const uniqueLanes = [...new Set([...lane.values()])].sort((a, b) => a - b)
+  const laneRank = new Map<number, number>()
+  uniqueLanes.forEach((value, index) => laneRank.set(value, index))
+
+  // Per-layer max height for vertical packing (content-driven).
+  const byLayer = new Map<number, string[]>()
+  for (const node of graph.nodes) {
+    const l = layer.get(node.key) ?? 0
+    if (!byLayer.has(l)) byLayer.set(l, [])
+    byLayer.get(l)!.push(node.key)
+  }
+  // Within each layer, sort left-to-right by lane rank (gateway config order), NOT nodes[] order.
+  for (const [l, keys] of byLayer) {
+    keys.sort((a, b) => (laneRank.get(lane.get(a)!) ?? 0) - (laneRank.get(lane.get(b)!) ?? 0))
+    byLayer.set(l, keys)
+  }
+
+  const focusIdByKey = new Map<string, string>()
+  let focusCounter = 0
+  // Stable focus ids by layer/lane order (not graph.nodes order).
+  const sortedLayers = [...byLayer.keys()].sort((a, b) => a - b)
+  for (const l of sortedLayers) {
+    for (const key of byLayer.get(l)!) {
+      focusIdByKey.set(key, `n${focusCounter}`)
+      focusCounter += 1
+    }
+  }
+
+  // Parallel join pairing.
+  const joinOfFork = new Map<string, string>()
+  const forkOfJoin = new Map<string, string>()
+  for (const node of graph.nodes) {
+    if (node.type !== 'parallel') continue
+    const config = node.config as ParallelNodeConfig
+    if (config.joinNodeKey) {
+      joinOfFork.set(node.key, config.joinNodeKey)
+      forkOfJoin.set(config.joinNodeKey, node.key)
+    }
+  }
+
+  const cards: E1CardModel[] = []
+  const cardByKey = new Map<string, E1CardModel>()
+  const layerHeights = new Map<number, number>()
+
+  for (const l of sortedLayers) {
+    let maxH = 0
+    for (const key of byLayer.get(l)!) {
+      const node = nodes.get(key)!
+      const summaryLines = summarizeNode(node, fixture)
+      const badges: string[] = []
+      if (fixture.readOnly) badges.push('只读')
+      if (forkOfJoin.has(key)) {
+        const fork = nodes.get(forkOfJoin.get(key)!)
+        const mode = (fork?.config as ParallelNodeConfig | undefined)?.joinMode
+        badges.push(mode === 'any' ? '任一完成' : '全部完成')
+      }
+      const height = measuredHeights?.get(key) ?? estimateHeight(summaryLines, badges)
+      maxH = Math.max(maxH, height)
+      const card: E1CardModel = {
+        focusId: focusIdByKey.get(key)!,
+        nodeKey: key,
+        type: node.type,
+        name: node.name?.trim() || typeFallbackName(node.type),
+        typeLabel: TYPE_LABEL[node.type],
+        summaryLines,
+        badges,
+        x: 0, // filled after width known
+        y: 0,
+        width: E1_NODE_WIDTH,
+        height,
+        isJoin: forkOfJoin.has(key),
+        joinModeLabel: forkOfJoin.has(key)
+          ? (nodes.get(forkOfJoin.get(key)!)?.config as ParallelNodeConfig).joinMode === 'any'
+            ? '任一分支完成后继续，其余分支自动跳过'
+            : '所有分支都完成后继续'
+          : undefined,
+        pairedFocusId: forkOfJoin.has(key)
+          ? focusIdByKey.get(forkOfJoin.get(key)!)
+          : joinOfFork.has(key)
+            ? focusIdByKey.get(joinOfFork.get(key)!)
+            : undefined,
+      }
+      cards.push(card)
+      cardByKey.set(key, card)
+    }
+    layerHeights.set(l, maxH)
+  }
+
+  const laneCount = Math.max(1, uniqueLanes.length)
+  const contentWidth = laneCount * E1_NODE_WIDTH + (laneCount - 1) * E1_H_GAP
+  const width = E1_MARGIN_X * 2 + contentWidth
+
+  // Center each layer's cards by their lane ranks across full width.
+  let yCursor = E1_MARGIN_Y
+  for (const l of sortedLayers) {
+    const keys = byLayer.get(l)!
+    const maxH = layerHeights.get(l) ?? 64
+    for (const key of keys) {
+      const card = cardByKey.get(key)!
+      const rank = laneRank.get(lane.get(key)!) ?? 0
+      // Map rank into x so lanes align across layers.
+      card.x = E1_MARGIN_X + rank * (E1_NODE_WIDTH + E1_H_GAP)
+      card.y = yCursor
+    }
+    yCursor += maxH + E1_V_GAP
+  }
+  const height = yCursor - E1_V_GAP + E1_MARGIN_Y
+
+  // Branch labels at gateway exits.
+  const branchLabels: E1BranchLabelModel[] = []
+  let branchFocus = 0
+  for (const node of graph.nodes) {
+    if (node.type !== 'condition' && node.type !== 'parallel') continue
+    const ordered = orderedGatewayOutEdges(graph, node)
+    const gatewayFocusId = focusIdByKey.get(node.key)!
+    const gatewayCard = cardByKey.get(node.key)!
+    const config = node.config as ConditionNodeConfig | ParallelNodeConfig
+    const defaultKey = node.type === 'condition' ? (config as ConditionNodeConfig).defaultEdgeKey : undefined
+    ordered.forEach((edge, order) => {
+      const isDefault = Boolean(defaultKey && edge.key === defaultKey)
+      const ruleIndex = isDefault ? -1 : order
+      const priority = isDefault ? undefined : (node.type === 'condition' ? order + 1 : order + 1)
+      const label = branchLabelFor(edge.key, node, isDefault ? order : ruleIndex, isDefault, fixture)
+      const targetCard = cardByKey.get(edge.target)
+      const x = targetCard ? targetCard.x + targetCard.width / 2 : gatewayCard.x + gatewayCard.width / 2
+      const y = gatewayCard.y + gatewayCard.height + 10
+      branchLabels.push({
+        focusId: `b${branchFocus}`,
+        gatewayFocusId,
+        order,
+        priority,
+        label,
+        isDefault,
+        x,
+        y,
+      })
+      branchFocus += 1
+    })
+  }
+
+  // Edges + insertion midpoints. Orthogonal routes must stay clear of every
+  // non-endpoint card — geometric midY alone is not enough when an intermediate
+  // layer sits between source and target (or when a same-column card blocks a
+  // straight vertical join edge).
+  const edges: E1EdgeModel[] = []
+  let edgeFocus = 0
+  for (const edge of graph.edges) {
+    const sourceCard = cardByKey.get(edge.source)
+    const targetCard = cardByKey.get(edge.target)
+    if (!sourceCard || !targetCard) continue
+    const x1 = sourceCard.x + sourceCard.width / 2
+    const y1 = sourceCard.y + sourceCard.height
+    const x2 = targetCard.x + targetCard.width / 2
+    const y2 = targetCard.y
+    const routed = routeOrthogonalEdge(x1, y1, x2, y2, cards, sourceCard.focusId, targetCard.focusId)
+    const sourceNode = nodes.get(edge.source)!
+    const insertable = sourceNode.type !== 'end' && !fixture.readOnly
+    const sourceName = sourceCard.name
+    // Branch metadata for gateway outs.
+    let branchLabel: string | undefined
+    let branchPriority: number | undefined
+    let isDefaultBranch: boolean | undefined
+    if (sourceNode.type === 'condition' || sourceNode.type === 'parallel') {
+      const ordered = orderedGatewayOutEdges(graph, sourceNode)
+      const order = ordered.findIndex((item) => item.key === edge.key)
+      const defaultKey =
+        sourceNode.type === 'condition'
+          ? (sourceNode.config as ConditionNodeConfig).defaultEdgeKey
+          : undefined
+      isDefaultBranch = Boolean(defaultKey && edge.key === defaultKey)
+      branchPriority = isDefaultBranch || order < 0 ? undefined : order + 1
+      branchLabel = branchLabelFor(
+        edge.key,
+        sourceNode,
+        isDefaultBranch ? order : order,
+        Boolean(isDefaultBranch),
+        fixture,
+      )
+    }
+    edges.push({
+      focusId: `e${edgeFocus}`,
+      edgeKey: edge.key,
+      sourceFocusId: sourceCard.focusId,
+      targetFocusId: targetCard.focusId,
+      sourceNodeKey: edge.source,
+      targetNodeKey: edge.target,
+      path: routed.path,
+      midX: routed.midX,
+      midY: routed.midY,
+      insertable,
+      ariaLabel: insertable ? `在「${sourceName}」之后插入节点` : `连线：从「${sourceName}」到「${targetCard.name}」`,
+      branchLabel,
+      branchPriority,
+      isDefaultBranch,
+    })
+    edgeFocus += 1
+  }
+
+  // Keyboard focus order: top-to-bottom, left-to-right by layout.
+  const focusOrder = [...cards]
+    .sort((a, b) => (a.y - b.y) || (a.x - b.x))
+    .map((card) => card.focusId)
+
+  return { cards, edges, branchLabels, width, height, focusOrder }
+}
+
+function typeFallbackName(type: ApprovalNodeType): string {
+  switch (type) {
+    case 'start':
+      return '发起'
+    case 'end':
+      return '结束'
+    case 'approval':
+      return '未命名审批'
+    case 'cc':
+      return '未命名抄送'
+    case 'condition':
+      return '未命名条件'
+    case 'parallel':
+      return '未命名并行'
+    default:
+      return '未命名节点'
+  }
+}
+
+/** Axis-aligned rect intersection (strict area > 0). */
+export function rectsOverlap(
+  a: { x: number; y: number; w: number; h: number },
+  b: { x: number; y: number; w: number; h: number },
+  epsilon = 0.5,
+): boolean {
+  return (
+    a.x + a.w > b.x + epsilon &&
+    b.x + b.w > a.x + epsilon &&
+    a.y + a.h > b.y + epsilon &&
+    b.y + b.h > a.y + epsilon
+  )
+}
+
+/** Does the polyline pass through the interior of a card (not at endpoints)? */
+export function polylineHitsRect(
+  points: Array<{ x: number; y: number }>,
+  rect: { x: number; y: number; w: number; h: number },
+  pad = 1,
+): boolean {
+  const r = { x: rect.x + pad, y: rect.y + pad, w: rect.w - pad * 2, h: rect.h - pad * 2 }
+  if (r.w <= 0 || r.h <= 0) return false
+  for (let i = 0; i < points.length - 1; i += 1) {
+    const p0 = points[i]!
+    const p1 = points[i + 1]!
+    if (segmentIntersectsRect(p0, p1, r)) {
+      // Ignore pure attachment at the top/bottom edge centers.
+      const attachesTop =
+        Math.abs(p0.y - rect.y) <= pad + 2 || Math.abs(p1.y - rect.y) <= pad + 2
+      const attachesBottom =
+        Math.abs(p0.y - (rect.y + rect.h)) <= pad + 2 ||
+        Math.abs(p1.y - (rect.y + rect.h)) <= pad + 2
+      const nearVerticalEdge =
+        Math.abs(p0.x - (rect.x + rect.w / 2)) <= pad + 2 ||
+        Math.abs(p1.x - (rect.x + rect.w / 2)) <= pad + 2
+      if ((attachesTop || attachesBottom) && nearVerticalEdge && i === 0) continue
+      if ((attachesTop || attachesBottom) && nearVerticalEdge && i === points.length - 2) continue
+      // Interior hit.
+      const mid = { x: (p0.x + p1.x) / 2, y: (p0.y + p1.y) / 2 }
+      if (pointInRect(mid, r)) return true
+      if (pointInRect(p0, r) && !(attachesTop || attachesBottom)) return true
+      if (pointInRect(p1, r) && !(attachesTop || attachesBottom)) return true
+    }
+  }
+  return false
+}
+
+function pointInRect(p: { x: number; y: number }, r: { x: number; y: number; w: number; h: number }): boolean {
+  return p.x > r.x && p.x < r.x + r.w && p.y > r.y && p.y < r.y + r.h
+}
+
+function segmentIntersectsRect(
+  p0: { x: number; y: number },
+  p1: { x: number; y: number },
+  r: { x: number; y: number; w: number; h: number },
+): boolean {
+  // Liang-Barsky style quick reject via bounding boxes + sample.
+  if (pointInRect(p0, r) || pointInRect(p1, r)) return true
+  const minX = Math.min(p0.x, p1.x)
+  const maxX = Math.max(p0.x, p1.x)
+  const minY = Math.min(p0.y, p1.y)
+  const maxY = Math.max(p0.y, p1.y)
+  if (maxX < r.x || minX > r.x + r.w || maxY < r.y || minY > r.y + r.h) return false
+  // Sample the segment.
+  for (let t = 0; t <= 1; t += 0.05) {
+    const x = p0.x + (p1.x - p0.x) * t
+    const y = p0.y + (p1.y - p0.y) * t
+    if (pointInRect({ x, y }, r)) return true
+  }
+  return false
+}
+
+export function parseSvgPathPoints(path: string): Array<{ x: number; y: number }> {
+  const points: Array<{ x: number; y: number }> = []
+  const re = /[ML]\s*([-\d.]+)\s+([-\d.]+)/g
+  let match: RegExpExecArray | null
+  while ((match = re.exec(path))) {
+    points.push({ x: Number(match[1]), y: Number(match[2]) })
+  }
+  return points
+}

--- a/apps/web/verification/approval-flow-canvas-e1.spec.ts
+++ b/apps/web/verification/approval-flow-canvas-e1.spec.ts
@@ -1,0 +1,554 @@
+import { test, expect, type Page, type Locator } from '@playwright/test'
+import { mkdirSync } from 'node:fs'
+import {
+  parseSvgPathPoints,
+  polylineHitsRect,
+  rectsOverlap,
+} from './approval-flow-canvas-e1-layout'
+
+// E1 isolated approval-flow renderer spike — real-browser geometry / a11y / responsive
+// verification. Does not touch production routes or Canvas V2 flags.
+
+const OUT = 'verification-output'
+const HARNESS = '/verification/approval-flow-canvas-e1-harness.html'
+
+const VIEWPORTS = {
+  desktop: { width: 1440, height: 900 },
+  compact: { width: 1024, height: 768 },
+  narrow: { width: 390, height: 844 },
+} as const
+
+type PublicMetrics = {
+  ready: true
+  fixtureId: string
+  nodeCount: number
+  edgeCount: number
+  inspectorPresentation: 'dock' | 'overlay' | 'sheet'
+  sheetDetent: 'half' | 'full' | null
+  inspectorOpen: boolean
+  readOnly: boolean
+  cards: Array<{
+    focusId: string
+    name: string
+    type: string
+    x: number
+    y: number
+    width: number
+    height: number
+  }>
+  edges: Array<{
+    focusId: string
+    path: string
+    midX: number
+    midY: number
+    sourceFocusId: string
+    targetFocusId: string
+  }>
+  branchLabels: Array<{
+    order: number
+    label: string
+    priority?: number
+    isDefault: boolean
+    x: number
+  }>
+  layoutWidth: number
+  layoutHeight: number
+  selectedName: string | null
+  liveText: string
+  reducedMotion: boolean
+  internalTokens: string[]
+}
+
+async function waitReady(page: Page): Promise<PublicMetrics> {
+  await page.waitForFunction(() => window.__E1_CANVAS__?.ready === true, null, { timeout: 30_000 })
+  return page.evaluate(() => window.__E1_CANVAS__ as PublicMetrics)
+}
+
+async function selectFixture(page: Page, id: string): Promise<PublicMetrics> {
+  await page.evaluate((fixtureId) => {
+    window.__E1_SELECT_FIXTURE__?.(fixtureId as never)
+  }, id)
+  await page.waitForFunction(
+    (fixtureId) => window.__E1_CANVAS__?.ready === true && window.__E1_CANVAS__?.fixtureId === fixtureId,
+    id,
+    { timeout: 30_000 },
+  )
+  // Allow measured-height reflow to settle.
+  await page.waitForTimeout(80)
+  return page.evaluate(() => window.__E1_CANVAS__ as PublicMetrics)
+}
+
+async function openFirstNode(page: Page): Promise<Locator> {
+  const first = page.locator('[data-test="flow-node"]').first()
+  await first.click()
+  await expect(page.locator('[data-test="e1-inspector"]')).toBeVisible()
+  return first
+}
+
+function assertNoCardOverlap(metrics: PublicMetrics) {
+  const cards = metrics.cards
+  for (let i = 0; i < cards.length; i += 1) {
+    for (let j = i + 1; j < cards.length; j += 1) {
+      const a = cards[i]!
+      const b = cards[j]!
+      const overlap = rectsOverlap(
+        { x: a.x, y: a.y, w: a.width, h: a.height },
+        { x: b.x, y: b.y, w: b.width, h: b.height },
+      )
+      expect(
+        overlap,
+        `cards overlap: 「${a.name}」 vs 「${b.name}」`,
+      ).toBe(false)
+    }
+  }
+}
+
+function assertEdgesDoNotCrossCards(metrics: PublicMetrics) {
+  const byFocus = new Map(metrics.cards.map((card) => [card.focusId, card]))
+  for (const edge of metrics.edges) {
+    const points = parseSvgPathPoints(edge.path)
+    expect(points.length, `edge ${edge.focusId} path parse`).toBeGreaterThanOrEqual(2)
+    for (const card of metrics.cards) {
+      // Source/target attachment is allowed; interior crossings are not.
+      if (card.focusId === edge.sourceFocusId || card.focusId === edge.targetFocusId) continue
+      const hit = polylineHitsRect(points, {
+        x: card.x,
+        y: card.y,
+        w: card.width,
+        h: card.height,
+      })
+      expect(
+        hit,
+        `edge through card 「${card.name}」 (edge ${edge.focusId})`,
+      ).toBe(false)
+    }
+    // Soft check: endpoints near source bottom / target top.
+    const source = byFocus.get(edge.sourceFocusId)
+    const target = byFocus.get(edge.targetFocusId)
+    if (source && target && points[0] && points[points.length - 1]) {
+      expect(Math.abs(points[0].x - (source.x + source.width / 2))).toBeLessThan(2)
+      expect(Math.abs(points[points.length - 1]!.x - (target.x + target.width / 2))).toBeLessThan(2)
+    }
+  }
+}
+
+async function assertNoHorizontalOverflow(page: Page) {
+  const overflow = await page.evaluate(() => ({
+    scrollWidth: document.documentElement.scrollWidth,
+    clientWidth: document.documentElement.clientWidth,
+  }))
+  expect(
+    overflow.scrollWidth,
+    `horizontal overflow: scrollWidth ${overflow.scrollWidth} > clientWidth ${overflow.clientWidth}`,
+  ).toBeLessThanOrEqual(overflow.clientWidth + 1)
+}
+
+async function assertNoInternals(page: Page, metrics: PublicMetrics) {
+  const tokens = metrics.internalTokens
+  const payload = await page.evaluate(() => {
+    const root = document.querySelector('[data-test="e1-shell"]') ?? document.body
+    const texts: string[] = []
+    const walk = (node: Node) => {
+      if (node.nodeType === Node.TEXT_NODE) {
+        const value = node.textContent?.trim()
+        if (value) texts.push(value)
+        return
+      }
+      if (node.nodeType === Node.ELEMENT_NODE) {
+        const el = node as HTMLElement
+        for (const attr of ['aria-label', 'title', 'alt']) {
+          const value = el.getAttribute(attr)
+          if (value) texts.push(value)
+        }
+        // data-focus-id / data-edge-focus are opaque (n0/e0) — allowed.
+        // Never allow raw keys in data-test visible labels.
+      }
+      node.childNodes.forEach(walk)
+    }
+    walk(root)
+    return texts
+  })
+
+  for (const token of tokens) {
+    // Skip trivial tokens that are legitimate UI words when they coincide with business labels.
+    // e.g. node name "发起" vs key "start" — keys are English identifiers; names are Chinese.
+    if (!token || token.length < 2) continue
+    // Business-facing Chinese names may equal display; only flag English/internal-looking tokens
+    // and explicit edge notations.
+    const looksInternal =
+      /^[a-z][a-z0-9_-]*$/i.test(token) ||
+      token.includes('->') ||
+      token.includes(' → ') ||
+      token.startsWith('e-') ||
+      token.includes('_')
+    if (!looksInternal) continue
+    for (const text of payload) {
+      // Whole-token match or clear key leakage — avoid flagging Chinese labels.
+      if (text === token || text.includes(token)) {
+        expect(text, `internal token leaked into DOM/ARIA: ${token}`).not.toContain(token)
+      }
+    }
+  }
+
+  // Explicit ban on source -> target patterns in any accessible string.
+  for (const text of payload) {
+    expect(text, `arrow edge notation in UI: ${text}`).not.toMatch(/\b\w+\s*->\s*\w+\b/)
+  }
+}
+
+async function assertNoActionButtonCluster(page: Page) {
+  // Cards must not host move/delete/add-branch action clusters.
+  const cluster = page.locator('[data-test="flow-node"] button, [data-test="flow-node"] [data-test*="action"]')
+  await expect(cluster).toHaveCount(0)
+  // Insertion controls live on edges, not cards.
+  const inserts = page.locator('[data-test="edge-insert"]')
+  await expect(inserts.first()).toBeVisible()
+}
+
+test.describe('E1 approval-flow canvas renderer spike', () => {
+  test.beforeAll(() => {
+    mkdirSync(OUT, { recursive: true })
+  })
+
+  test('desktop 1440×900: geometry, inspector dock, long labels, priority, keyboard, 100-node', async ({ page }, testInfo) => {
+    const errs: string[] = []
+    page.on('console', (m) => {
+      if (m.type() === 'error') errs.push(`console: ${m.text()}`)
+    })
+    page.on('pageerror', (e) => errs.push(`pageerror: ${String(e)}`))
+
+    await page.setViewportSize(VIEWPORTS.desktop)
+    await page.goto(HARNESS, { waitUntil: 'domcontentloaded' })
+    let metrics = await waitReady(page)
+
+    // --- linear fixture ---
+    metrics = await selectFixture(page, 'linear')
+    expect(metrics.nodeCount).toBe(4)
+    await expect(page.locator('[data-test="flow-node"]')).toHaveCount(4)
+    assertNoCardOverlap(metrics)
+    assertEdgesDoNotCrossCards(metrics)
+    await assertNoHorizontalOverflow(page)
+    await assertNoActionButtonCluster(page)
+    await assertNoInternals(page, metrics)
+
+    // Edge-centered insertion controls present; no card action cluster.
+    const insertBox = await page.locator('[data-test="edge-insert"]').first().boundingBox()
+    expect(insertBox, 'insert control box').toBeTruthy()
+    expect(insertBox!.width).toBeGreaterThanOrEqual(40)
+    expect(insertBox!.height).toBeGreaterThanOrEqual(40)
+
+    // Inspector dock 360px at 1440.
+    await openFirstNode(page)
+    metrics = await page.evaluate(() => window.__E1_CANVAS__ as PublicMetrics)
+    expect(metrics.inspectorPresentation).toBe('dock')
+    const inspector = page.locator('[data-test="e1-inspector"]')
+    await expect(inspector).toHaveAttribute('data-presentation', 'dock')
+    const inspectorWidth = await inspector.evaluate((el) => getComputedStyle(el).width)
+    expect(inspectorWidth, 'desktop inspector width').toBe('360px')
+    const canvasRegion = page.locator('[data-test="e1-canvas-region"]')
+    const canvasBox = await canvasRegion.boundingBox()
+    expect(canvasBox, 'canvas region').toBeTruthy()
+    expect(canvasBox!.width, 'canvas width with docked inspector').toBeGreaterThanOrEqual(1000)
+
+    // Single polite live region.
+    const live = page.locator('[data-test="e1-live"]')
+    await expect(live).toHaveAttribute('aria-live', 'polite')
+    await expect(live).toHaveAttribute('role', 'status')
+    await expect(page.locator('[aria-live]')).toHaveCount(1)
+
+    // Keyboard: focus a node, move, activate insertion.
+    await page.locator('[data-test="flow-node"]').nth(1).focus()
+    await page.keyboard.press('ArrowDown')
+    await page.keyboard.press('Enter')
+    await expect(page.locator('[data-test="e1-inspector"]')).toBeVisible()
+    // Focus an insert control and activate.
+    await page.locator('[data-test="edge-insert"]').first().focus()
+    await page.keyboard.press('Enter')
+    await expect(page.locator('[data-test="insert-menu"]')).toBeVisible()
+    await page.keyboard.press('Enter')
+    await expect(page.locator('[data-test="e1-live"]')).not.toHaveText('')
+    await page.screenshot({ path: `${OUT}/e1-desktop-linear.png` })
+
+    // --- condition branch priority (config order, not nodes order) ---
+    metrics = await selectFixture(page, 'condition')
+    // Gateway has 3 exits; labels should be left-to-right mid → high → default.
+    const ordered = [...metrics.branchLabels].sort((a, b) => a.x - b.x)
+    expect(ordered.map((item) => item.order)).toEqual([0, 1, 2])
+    expect(ordered[0]?.priority).toBe(1)
+    expect(ordered[1]?.priority).toBe(2)
+    expect(ordered[2]?.isDefault).toBe(true)
+    // DOM visibility of priority markers.
+    await expect(page.locator('[data-test="branch-priority"]')).toHaveCount(2)
+    await expect(page.locator('[data-test="branch-label"][data-default="true"]')).toHaveCount(1)
+    assertNoCardOverlap(metrics)
+    assertEdgesDoNotCrossCards(metrics)
+
+    // Swap priority (config.branches only) — visual order flips for rule branches.
+    await page.locator('[data-test="swap-priority"]').click()
+    metrics = await waitReady(page)
+    expect(metrics.fixtureId).toBe('condition-priority-swapped')
+    const swapped = [...metrics.branchLabels].sort((a, b) => a.x - b.x)
+    expect(swapped[0]?.label).toContain('一千')
+    expect(swapped[1]?.label).toContain('一百')
+    expect(swapped[2]?.isDefault).toBe(true)
+    await page.screenshot({ path: `${OUT}/e1-desktop-condition-priority.png` })
+
+    // --- parallel all / any with nested condition ---
+    for (const id of ['parallel-all', 'parallel-any'] as const) {
+      metrics = await selectFixture(page, id)
+      expect(metrics.nodeCount).toBeGreaterThanOrEqual(8)
+      // Three parallel branch labels under the fork (plus nested condition labels).
+      const forkBranches = metrics.branchLabels.filter((label) =>
+        ['财务分支', '法务分支', '紧急判断分支'].includes(label.label),
+      )
+      expect(forkBranches.length).toBe(3)
+      // Lane order follows config.branches: C → A → B (紧急, 财务, 法务)
+      const forkSorted = [...forkBranches].sort((a, b) => a.x - b.x)
+      expect(forkSorted.map((item) => item.label)).toEqual(['紧急判断分支', '财务分支', '法务分支'])
+      assertNoCardOverlap(metrics)
+      assertEdgesDoNotCrossCards(metrics)
+      await assertNoInternals(page, metrics)
+    }
+    await page.screenshot({ path: `${OUT}/e1-desktop-parallel-any.png` })
+
+    // --- long labels ---
+    metrics = await selectFixture(page, 'long-labels')
+    const longCard = page.locator('[data-test="flow-node"][data-node-type="approval"]').first()
+    await expect(longCard.locator('[data-test="node-name"]')).toBeVisible()
+    const nameOverflow = await longCard.locator('[data-test="node-name"]').evaluate((el) => {
+      const cs = getComputedStyle(el)
+      return {
+        overflow: cs.overflow,
+        textOverflow: cs.textOverflow,
+        whiteSpace: cs.whiteSpace,
+        scrollWidth: (el as HTMLElement).scrollWidth,
+        clientWidth: (el as HTMLElement).clientWidth,
+      }
+    })
+    expect(nameOverflow.textOverflow).toBe('ellipsis')
+    expect(nameOverflow.whiteSpace).toBe('nowrap')
+    // Full text retained in title / aria-label, not layout-breaking wrap.
+    const aria = await longCard.getAttribute('aria-label')
+    expect(aria && aria.length).toBeGreaterThan(40)
+    const branchTitle = await page.locator('[data-test="branch-label"]').first().getAttribute('title')
+    expect(branchTitle && branchTitle.length).toBeGreaterThanOrEqual(40)
+    assertNoCardOverlap(metrics)
+    assertEdgesDoNotCrossCards(metrics)
+    await assertNoInternals(page, metrics)
+    await page.screenshot({ path: `${OUT}/e1-desktop-long-labels.png` })
+
+    // --- read-only legacy / timeout / threshold ---
+    for (const id of ['readonly-legacy', 'readonly-timeout', 'readonly-threshold'] as const) {
+      metrics = await selectFixture(page, id)
+      expect(metrics.readOnly).toBe(true)
+      await expect(page.locator('[data-test="readonly-banner"]')).toBeVisible()
+      await openFirstNode(page)
+      await expect(page.locator('[data-test="inspector-readonly"]')).toBeVisible()
+      // No insertion in read-only.
+      await expect(page.locator('[data-test="edge-insert"]')).toHaveCount(0)
+      await assertNoInternals(page, metrics)
+    }
+    await page.screenshot({ path: `${OUT}/e1-desktop-readonly.png` })
+
+    // --- 100-node mixed graph ---
+    const mixedStart = performance.now()
+    metrics = await selectFixture(page, 'mixed-100')
+    const firstMixedRenderMs = performance.now() - mixedStart
+    expect(metrics.nodeCount).toBe(100)
+    await expect(page.locator('[data-test="flow-node"]')).toHaveCount(100)
+    assertNoCardOverlap(metrics)
+    assertEdgesDoNotCrossCards(metrics)
+    await assertNoHorizontalOverflow(page)
+    // Canvas surface should scroll vertically inside region, not blow page width.
+    const surfaceBox = await page.locator('[data-test="e1-canvas-surface"]').boundingBox()
+    expect(surfaceBox, '100-node surface').toBeTruthy()
+    await assertNoInternals(page, metrics)
+    const firstMixedGeometry = {
+      cards: metrics.cards.map(({ focusId, x, y, width, height }) => ({
+        focusId,
+        x,
+        y,
+        width,
+        height,
+      })),
+      edges: metrics.edges.map(({ focusId, path, midX, midY }) => ({
+        focusId,
+        path,
+        midX,
+        midY,
+      })),
+    }
+
+    // A real node remains interactive in the large graph.
+    const lateCard = page.locator('[data-test="flow-node"]').nth(80)
+    await lateCard.scrollIntoViewIfNeeded()
+    await lateCard.click()
+    await expect(page.locator('[data-test="e1-inspector"]')).toBeVisible()
+
+    // Reload the same fixture from a different state and require byte-identical
+    // render coordinates and routes at the same viewport.
+    await selectFixture(page, 'linear')
+    const repeatStart = performance.now()
+    const repeatedMixed = await selectFixture(page, 'mixed-100')
+    const repeatedMixedRenderMs = performance.now() - repeatStart
+    const repeatedMixedGeometry = {
+      cards: repeatedMixed.cards.map(({ focusId, x, y, width, height }) => ({
+        focusId,
+        x,
+        y,
+        width,
+        height,
+      })),
+      edges: repeatedMixed.edges.map(({ focusId, path, midX, midY }) => ({
+        focusId,
+        path,
+        midX,
+        midY,
+      })),
+    }
+    expect(repeatedMixedGeometry).toEqual(firstMixedGeometry)
+    console.info(
+      `[e1] mixed-100 render: first=${firstMixedRenderMs.toFixed(2)}ms repeat=${repeatedMixedRenderMs.toFixed(2)}ms`,
+    )
+    await testInfo.attach('mixed-100-render-timing.json', {
+      body: JSON.stringify({
+        firstRenderMs: Number(firstMixedRenderMs.toFixed(2)),
+        repeatedRenderMs: Number(repeatedMixedRenderMs.toFixed(2)),
+      }),
+      contentType: 'application/json',
+    })
+    await page.screenshot({ path: `${OUT}/e1-desktop-mixed-100.png`, fullPage: false })
+
+    // Reduced-motion media: style rule present (presence check).
+    const hasReducedMotionRule = await page.evaluate(() => {
+      for (const sheet of Array.from(document.styleSheets)) {
+        try {
+          for (const rule of Array.from(sheet.cssRules ?? [])) {
+            if (rule instanceof CSSMediaRule && /prefers-reduced-motion:\s*reduce/.test(rule.conditionText)) {
+              return true
+            }
+          }
+        } catch {
+          // cross-origin sheets ignored
+        }
+      }
+      return false
+    })
+    expect(hasReducedMotionRule, 'prefers-reduced-motion rule').toBe(true)
+
+    expect(errs, `console/page errors:\n${errs.join('\n')}`).toEqual([])
+  })
+
+  test('compact 1024×768: 320px overlay inspector, no overflow, geometry holds', async ({ page }) => {
+    const errs: string[] = []
+    page.on('console', (m) => {
+      if (m.type() === 'error') errs.push(`console: ${m.text()}`)
+    })
+    page.on('pageerror', (e) => errs.push(`pageerror: ${String(e)}`))
+
+    await page.setViewportSize(VIEWPORTS.compact)
+    await page.goto(HARNESS, { waitUntil: 'domcontentloaded' })
+    await waitReady(page)
+    let metrics = await selectFixture(page, 'condition')
+    assertNoCardOverlap(metrics)
+    assertEdgesDoNotCrossCards(metrics)
+    await assertNoHorizontalOverflow(page)
+
+    await openFirstNode(page)
+    metrics = await page.evaluate(() => window.__E1_CANVAS__ as PublicMetrics)
+    expect(metrics.inspectorPresentation).toBe('overlay')
+    const inspector = page.locator('[data-test="e1-inspector"]')
+    await expect(inspector).toHaveAttribute('data-presentation', 'overlay')
+    const width = await inspector.evaluate((el) => getComputedStyle(el).width)
+    expect(width, 'compact overlay width').toBe('320px')
+    const position = await inspector.evaluate((el) => getComputedStyle(el).position)
+    expect(position).toBe('absolute')
+
+    // With overlay closed, canvas remains usable full width.
+    await page.locator('[data-test="inspector-close"]').click()
+    await expect(inspector).toHaveCount(0)
+    const canvasBox = await page.locator('[data-test="e1-canvas-region"]').boundingBox()
+    expect(canvasBox!.width).toBeGreaterThan(900)
+
+    // Re-open and confirm inserts stay ≥ 40×40.
+    await openFirstNode(page)
+    const insertBox = await page.locator('[data-test="edge-insert"]').first().boundingBox()
+    expect(insertBox!.width).toBeGreaterThanOrEqual(40)
+    expect(insertBox!.height).toBeGreaterThanOrEqual(40)
+
+    metrics = await selectFixture(page, 'mixed-100')
+    assertNoCardOverlap(metrics)
+    assertEdgesDoNotCrossCards(metrics)
+    await assertNoHorizontalOverflow(page)
+    await page.screenshot({ path: `${OUT}/e1-compact-1024.png` })
+    expect(errs, `console/page errors:\n${errs.join('\n')}`).toEqual([])
+  })
+
+  test('narrow 390×844: bottom sheet, no horizontal overflow, targets, geometry', async ({ page }) => {
+    const errs: string[] = []
+    page.on('console', (m) => {
+      if (m.type() === 'error') errs.push(`console: ${m.text()}`)
+    })
+    page.on('pageerror', (e) => errs.push(`pageerror: ${String(e)}`))
+
+    await page.setViewportSize(VIEWPORTS.narrow)
+    await page.goto(HARNESS, { waitUntil: 'domcontentloaded' })
+    await waitReady(page)
+
+    // Harness chrome must wrap so it does not pollute overflow assertions.
+    let metrics = await selectFixture(page, 'linear')
+    assertNoCardOverlap(metrics)
+    assertEdgesDoNotCrossCards(metrics)
+    await assertNoHorizontalOverflow(page)
+
+    await openFirstNode(page)
+    metrics = await page.evaluate(() => window.__E1_CANVAS__ as PublicMetrics)
+    expect(metrics.inspectorPresentation).toBe('sheet')
+    const inspector = page.locator('[data-test="e1-inspector"]')
+    await expect(inspector).toHaveAttribute('data-presentation', 'sheet')
+    await expect(inspector).toHaveAttribute('data-sheet-detent', 'half')
+    await expect(page.locator('[data-test="sheet-handle"]')).toBeVisible()
+
+    // Half detent leaves canvas visible above the sheet.
+    const canvasBox = await page.locator('[data-test="e1-canvas-region"]').boundingBox()
+    const sheetBox = await inspector.boundingBox()
+    expect(canvasBox, 'canvas').toBeTruthy()
+    expect(sheetBox, 'sheet').toBeTruthy()
+    expect(sheetBox!.y, 'sheet starts below canvas top').toBeGreaterThan(canvasBox!.y + 100)
+    // Visible canvas above half sheet roughly ≥ 320px in design lock; allow modest tolerance for chrome.
+    const visibleAbove = sheetBox!.y - canvasBox!.y
+    expect(visibleAbove, `visible canvas above sheet (${visibleAbove})`).toBeGreaterThanOrEqual(280)
+
+    // Sheet action targets ≥ 44×44.
+    for (const testId of ['sheet-half', 'sheet-full', 'inspector-close'] as const) {
+      const box = await page.locator(`[data-test="${testId}"]`).boundingBox()
+      expect(box, testId).toBeTruthy()
+      expect(box!.height, `${testId} height`).toBeGreaterThanOrEqual(40)
+    }
+
+    await page.locator('[data-test="sheet-full"]').click()
+    await expect(inspector).toHaveAttribute('data-sheet-detent', 'full')
+    await page.locator('[data-test="sheet-half"]').click()
+    await expect(inspector).toHaveAttribute('data-sheet-detent', 'half')
+
+    // Long labels + priority still hold at 390 without page-level horizontal scroll.
+    metrics = await selectFixture(page, 'long-labels')
+    await assertNoHorizontalOverflow(page)
+    assertNoCardOverlap(metrics)
+    assertEdgesDoNotCrossCards(metrics)
+    await assertNoInternals(page, metrics)
+
+    metrics = await selectFixture(page, 'condition')
+    const ordered = [...metrics.branchLabels].sort((a, b) => a.x - b.x)
+    expect(ordered[ordered.length - 1]?.isDefault).toBe(true)
+
+    metrics = await selectFixture(page, 'mixed-100')
+    expect(metrics.nodeCount).toBe(100)
+    assertNoCardOverlap(metrics)
+    assertEdgesDoNotCrossCards(metrics)
+    await assertNoHorizontalOverflow(page)
+
+    await page.screenshot({ path: `${OUT}/e1-narrow-390.png` })
+    expect(errs, `console/page errors:\n${errs.join('\n')}`).toEqual([])
+  })
+})

--- a/apps/web/verification/approval-flow-canvas-e1.spec.ts
+++ b/apps/web/verification/approval-flow-canvas-e1.spec.ts
@@ -57,6 +57,60 @@ type PublicMetrics = {
   liveText: string
   reducedMotion: boolean
   internalTokens: string[]
+  graphJson: string
+  canUndo: boolean
+  canRedo: boolean
+  undoDepth: number
+  lastCommandOk: boolean | null
+  lastCommandCode: string | null
+  lastCommandChannel: 'pointer' | 'keyboard' | 'toolbar' | null
+  cardKeyByFocusId: Record<string, string>
+  edgeKeyByFocusId: Record<string, string>
+}
+
+type GraphSnap = {
+  nodes: Array<{ key: string; type: string; name: string; config: unknown }>
+  edges: Array<{ key: string; source: string; target: string }>
+}
+
+function parseGraph(metrics: PublicMetrics): GraphSnap {
+  return JSON.parse(metrics.graphJson) as GraphSnap
+}
+
+/** Renderer coordinates must never appear on the persisted ApprovalGraph snapshot. */
+function assertGraphHasNoCoordinates(graph: GraphSnap) {
+  const raw = JSON.stringify(graph)
+  // Fail if any node/edge object carries layout fields.
+  for (const node of graph.nodes) {
+    expect(node, `node ${node.key} must not persist coordinates`).not.toHaveProperty('x')
+    expect(node, `node ${node.key} must not persist coordinates`).not.toHaveProperty('y')
+    expect(node, `node ${node.key} must not persist coordinates`).not.toHaveProperty('width')
+    expect(node, `node ${node.key} must not persist coordinates`).not.toHaveProperty('height')
+  }
+  expect(raw).not.toMatch(/"x"\s*:/)
+  expect(raw).not.toMatch(/"y"\s*:/)
+}
+
+async function readMetrics(page: Page): Promise<PublicMetrics> {
+  return page.evaluate(() => window.__E1_CANVAS__ as PublicMetrics)
+}
+
+/** HTML5 DnD through the real drag events so pointer channel uses the shared adapter. */
+async function html5DragCardToEdge(page: Page, cardFocusId: string, edgeFocusId: string) {
+  await page.evaluate(
+    ({ fromFocus, toFocus }) => {
+      const source = document.querySelector(`[data-focus-id="${fromFocus}"]`)
+      const target = document.querySelector(`[data-focus-id="${toFocus}"]`)
+      if (!source || !target) throw new Error('drag source/target missing')
+      const dt = new DataTransfer()
+      source.dispatchEvent(new DragEvent('dragstart', { bubbles: true, cancelable: true, dataTransfer: dt }))
+      target.dispatchEvent(new DragEvent('dragover', { bubbles: true, cancelable: true, dataTransfer: dt }))
+      target.dispatchEvent(new DragEvent('drop', { bubbles: true, cancelable: true, dataTransfer: dt }))
+      source.dispatchEvent(new DragEvent('dragend', { bubbles: true, cancelable: true, dataTransfer: dt }))
+    },
+    { fromFocus: cardFocusId, toFocus: edgeFocusId },
+  )
+  await page.waitForTimeout(80)
 }
 
 async function waitReady(page: Page): Promise<PublicMetrics> {
@@ -283,14 +337,26 @@ test.describe('E1 approval-flow canvas renderer spike', () => {
     assertNoCardOverlap(metrics)
     assertEdgesDoNotCrossCards(metrics)
 
-    // Swap priority (config.branches only) — visual order flips for rule branches.
+    // Swap priority via real reorder-condition-branches history command (not fixture swap).
+    const graphBeforePriority = metrics.graphJson
+    assertGraphHasNoCoordinates(parseGraph(metrics))
     await page.locator('[data-test="swap-priority"]').click()
+    await page.waitForTimeout(80)
     metrics = await waitReady(page)
-    expect(metrics.fixtureId).toBe('condition-priority-swapped')
+    expect(metrics.fixtureId).toBe('condition')
+    expect(metrics.lastCommandOk).toBe(true)
+    expect(metrics.lastCommandChannel).toBe('toolbar')
+    expect(metrics.canUndo).toBe(true)
+    expect(metrics.graphJson).not.toBe(graphBeforePriority)
     const swapped = [...metrics.branchLabels].sort((a, b) => a.x - b.x)
     expect(swapped[0]?.label).toContain('一千')
     expect(swapped[1]?.label).toContain('一百')
     expect(swapped[2]?.isDefault).toBe(true)
+    // Undo restores byte-identical graph (history inverse).
+    await page.locator('[data-test="undo"]').click()
+    await page.waitForTimeout(80)
+    metrics = await waitReady(page)
+    expect(metrics.graphJson).toBe(graphBeforePriority)
     await page.screenshot({ path: `${OUT}/e1-desktop-condition-priority.png` })
 
     // --- parallel all / any with nested condition ---
@@ -549,6 +615,191 @@ test.describe('E1 approval-flow canvas renderer spike', () => {
     await assertNoHorizontalOverflow(page)
 
     await page.screenshot({ path: `${OUT}/e1-narrow-390.png` })
+    expect(errs, `console/page errors:\n${errs.join('\n')}`).toEqual([])
+  })
+
+  test('E1-b: command history reorder, legal/illegal move, shared drag adapter, non-persisted coords', async ({ page }) => {
+    const errs: string[] = []
+    page.on('console', (m) => {
+      if (m.type() === 'error') errs.push(`console: ${m.text()}`)
+    })
+    page.on('pageerror', (e) => errs.push(`pageerror: ${String(e)}`))
+
+    await page.setViewportSize(VIEWPORTS.desktop)
+    await page.goto(HARNESS, { waitUntil: 'domcontentloaded' })
+    await waitReady(page)
+
+    // --- (1) Branch reorder through command API; undo restores byte-identical graph ---
+    let metrics = await selectFixture(page, 'condition')
+    const beforeReorder = metrics.graphJson
+    assertGraphHasNoCoordinates(parseGraph(metrics))
+    const condConfigBefore = parseGraph(metrics).nodes.find((node) => node.type === 'condition')
+      ?.config as { branches: Array<{ edgeKey: string }>; defaultEdgeKey: string }
+    expect(condConfigBefore.branches.map((branch) => branch.edgeKey)).toEqual(['e-mid', 'e-high'])
+
+    const reorderResult = await page.evaluate(() => window.__E1_SWAP_CONDITION_PRIORITY__?.())
+    expect(reorderResult && 'ok' in reorderResult ? reorderResult.ok : false).toBe(true)
+    await page.waitForTimeout(80)
+    metrics = await readMetrics(page)
+    expect(metrics.lastCommandOk).toBe(true)
+    expect(metrics.lastCommandChannel).toBe('toolbar')
+    expect(metrics.fixtureId).toBe('condition')
+    const condConfigAfter = parseGraph(metrics).nodes.find((node) => node.type === 'condition')
+      ?.config as { branches: Array<{ edgeKey: string }>; defaultEdgeKey: string }
+    expect(condConfigAfter.branches.map((branch) => branch.edgeKey)).toEqual(['e-high', 'e-mid'])
+    expect(condConfigAfter.defaultEdgeKey).toBe(condConfigBefore.defaultEdgeKey)
+    expect(metrics.graphJson).not.toBe(beforeReorder)
+    // Visual lane order follows config.
+    const lanes = [...metrics.branchLabels].sort((a, b) => a.x - b.x)
+    expect(lanes[0]?.label).toContain('一千')
+    expect(lanes[1]?.label).toContain('一百')
+    expect(lanes[2]?.isDefault).toBe(true)
+
+    const undoResult = await page.evaluate(() => window.__E1_UNDO__?.())
+    expect(undoResult && 'ok' in undoResult ? undoResult.ok : false).toBe(true)
+    await page.waitForTimeout(80)
+    metrics = await readMetrics(page)
+    expect(metrics.graphJson).toBe(beforeReorder)
+    assertGraphHasNoCoordinates(parseGraph(metrics))
+    await assertNoInternals(page, metrics)
+
+    // --- (2) One legal approval move onto an edge via real move-node-into-edge ---
+    metrics = await selectFixture(page, 'linear')
+    const beforeMove = metrics.graphJson
+    const preMoveApprovalFocus = metrics.cards.find((card) => card.name === '主管审批')?.focusId
+    expect(preMoveApprovalFocus, 'pre-move 主管审批 focus').toBeTruthy()
+    assertGraphHasNoCoordinates(parseGraph(metrics))
+    // Move 主管审批 (approval_1) onto the edge after 抄送 (e-cc-end).
+    const legal = await page.evaluate(() =>
+      window.__E1_MOVE_NODE_INTO_EDGE__?.('approval_1', 'e-cc-end', 'keyboard'),
+    )
+    expect(legal?.ok).toBe(true)
+    expect(legal?.code).toBeNull()
+    await page.waitForTimeout(80)
+    metrics = await readMetrics(page)
+    expect(metrics.lastCommandOk).toBe(true)
+    expect(metrics.lastCommandChannel).toBe('keyboard')
+    expect(metrics.graphJson).not.toBe(beforeMove)
+    const moved = parseGraph(metrics)
+    expect(moved.edges.some((edge) => edge.source === 'start' && edge.target === 'cc_1')).toBe(true)
+    expect(moved.edges.some((edge) => edge.source === 'cc_1' && edge.target === 'approval_1')).toBe(true)
+    expect(moved.edges.some((edge) => edge.source === 'approval_1' && edge.target === 'end')).toBe(true)
+    expect(moved.edges.some((edge) => edge.source === 'start' && edge.target === 'approval_1')).toBe(false)
+    assertGraphHasNoCoordinates(moved)
+    await expect(page.locator('[data-test="e1-live"]')).toContainText('已移动')
+    // Live region must stay values-free (no edge/node keys).
+    const liveAfterLegal = await page.locator('[data-test="e1-live"]').innerText()
+    expect(liveAfterLegal).not.toMatch(/approval_1|e-cc-end|e-start/)
+    // Selection follows history.selectionAfter (node key), not the stale pre-move focusId.
+    // Layer reorder after move would otherwise leave the inspector on a different card.
+    expect(metrics.selectedName).toBe('主管审批')
+    await expect(page.locator('[data-test="e1-inspector"]')).toBeVisible()
+    await expect(page.locator('[data-test="inspector-name"]')).toHaveText('主管审批')
+    const postMoveApproval = metrics.cards.find((card) => card.name === '主管审批')
+    expect(postMoveApproval, 'post-move 主管审批 card').toBeTruthy()
+    expect(metrics.cardKeyByFocusId[postMoveApproval!.focusId]).toBe('approval_1')
+    // Discriminating: focus id for 主管审批 can change after layer re-layout; selection must track key.
+    expect(postMoveApproval!.focusId).not.toBe(preMoveApprovalFocus)
+    const selectedFocusAfterMove = Object.entries(metrics.cardKeyByFocusId).find(
+      ([, key]) => key === 'approval_1',
+    )?.[0]
+    expect(selectedFocusAfterMove).toBe(postMoveApproval!.focusId)
+    await expect(page.locator(`[data-focus-id="${postMoveApproval!.focusId}"]`)).toBeFocused()
+    await assertNoInternals(page, metrics)
+
+    // Undo restores exact prior graph AND selectionBefore (主管审批 / approval_1).
+    await page.evaluate(() => window.__E1_UNDO__?.())
+    await page.waitForTimeout(80)
+    metrics = await readMetrics(page)
+    expect(metrics.graphJson).toBe(beforeMove)
+    expect(metrics.selectedName).toBe('主管审批')
+    await expect(page.locator('[data-test="inspector-name"]')).toHaveText('主管审批')
+    const postUndoApproval = metrics.cards.find((card) => card.name === '主管审批')
+    expect(postUndoApproval, 'post-undo 主管审批 card').toBeTruthy()
+    expect(metrics.cardKeyByFocusId[postUndoApproval!.focusId]).toBe('approval_1')
+    await expect(page.locator(`[data-focus-id="${postUndoApproval!.focusId}"]`)).toBeFocused()
+
+    // --- (3) Illegal self-slot: typed rejection, values-free copy, byte-identical graph ---
+    metrics = await selectFixture(page, 'linear')
+    const beforeIllegal = metrics.graphJson
+    const illegal = await page.evaluate(() =>
+      window.__E1_MOVE_NODE_INTO_EDGE__?.('approval_1', 'e-approval-cc', 'keyboard'),
+    )
+    expect(illegal?.ok).toBe(false)
+    expect(illegal?.code).toBe('self-slot')
+    await page.waitForTimeout(80)
+    metrics = await readMetrics(page)
+    expect(metrics.lastCommandOk).toBe(false)
+    expect(metrics.lastCommandCode).toBe('self-slot')
+    expect(metrics.graphJson).toBe(beforeIllegal)
+    expect(metrics.canUndo).toBe(false)
+    await expect(page.locator('[data-test="e1-live"]')).toHaveText('该位置不能放置此节点')
+    const liveIllegal = await page.locator('[data-test="e1-live"]').innerText()
+    expect(liveIllegal).not.toMatch(/approval_1|e-approval-cc|self-slot/)
+    // Unsupported type rejection (start) also stays values-free and non-mutating.
+    const unsupported = await page.evaluate(() =>
+      window.__E1_MOVE_NODE_INTO_EDGE__?.('start', 'e-cc-end', 'keyboard'),
+    )
+    expect(unsupported?.ok).toBe(false)
+    expect(unsupported?.code).toBe('unsupported-node-type')
+    metrics = await readMetrics(page)
+    expect(metrics.graphJson).toBe(beforeIllegal)
+    await expect(page.locator('[data-test="e1-live"]')).toHaveText('此节点类型不支持此操作')
+
+    // --- (4) Pointer/HTML5 drag uses the same adapter as keyboard activation ---
+    metrics = await selectFixture(page, 'linear')
+    const beforeDrag = metrics.graphJson
+    const approvalCard = metrics.cards.find((card) => card.type === 'approval')
+    expect(approvalCard, 'approval card').toBeTruthy()
+    // Target the insert control on e-cc-end (after 抄送).
+    const ccEndFocus = Object.entries(metrics.edgeKeyByFocusId).find(([, key]) => key === 'e-cc-end')?.[0]
+    expect(ccEndFocus, 'e-cc-end focus').toBeTruthy()
+    await html5DragCardToEdge(page, approvalCard!.focusId, ccEndFocus!)
+    metrics = await readMetrics(page)
+    expect(metrics.lastCommandOk).toBe(true)
+    expect(metrics.lastCommandChannel).toBe('pointer')
+    expect(metrics.graphJson).not.toBe(beforeDrag)
+    const afterPointer = parseGraph(metrics)
+    expect(afterPointer.edges.some((edge) => edge.source === 'cc_1' && edge.target === 'approval_1')).toBe(true)
+    // Pointer path also remaps selection via history.selectionAfter — still 主管审批.
+    expect(metrics.selectedName).toBe('主管审批')
+    await expect(page.locator('[data-test="inspector-name"]')).toHaveText('主管审批')
+
+    // Reset and exercise keyboard activation of the same adapter (`m` on edge insert).
+    metrics = await selectFixture(page, 'linear')
+    const beforeKeyboard = metrics.graphJson
+    const approvalFocus = metrics.cards.find((card) => card.type === 'approval')!.focusId
+    const edgeFocusAgain = Object.entries(metrics.edgeKeyByFocusId).find(([, key]) => key === 'e-cc-end')?.[0]
+    expect(edgeFocusAgain, 'e-cc-end focus after reset').toBeTruthy()
+    await page.locator(`[data-focus-id="${approvalFocus}"]`).click()
+    await page.locator(`[data-focus-id="${edgeFocusAgain}"]`).focus()
+    await page.keyboard.press('m')
+    await page.waitForTimeout(80)
+    metrics = await readMetrics(page)
+    expect(metrics.lastCommandOk).toBe(true)
+    expect(metrics.lastCommandChannel).toBe('keyboard')
+    expect(metrics.graphJson).not.toBe(beforeKeyboard)
+    // Same topology as pointer path.
+    const afterKeyboard = parseGraph(metrics)
+    expect(afterKeyboard.edges.map((e) => `${e.source}->${e.target}`).sort()).toEqual(
+      afterPointer.edges.map((e) => `${e.source}->${e.target}`).sort(),
+    )
+    // Keyboard path: selection/inspector still name 主管审批 after focusId reshuffle.
+    expect(metrics.selectedName).toBe('主管审批')
+    await expect(page.locator('[data-test="inspector-name"]')).toHaveText('主管审批')
+    const kbApproval = metrics.cards.find((card) => card.name === '主管审批')!
+    await expect(page.locator(`[data-focus-id="${kbApproval.focusId}"]`)).toBeFocused()
+
+    // --- (5) Renderer coordinates remain non-persisted after mutations ---
+    assertGraphHasNoCoordinates(afterKeyboard)
+    expect(metrics.cards.every((card) => typeof card.x === 'number')).toBe(true)
+    // Geometry + no-internals still hold on mutated linear graph.
+    assertNoCardOverlap(metrics)
+    assertEdgesDoNotCrossCards(metrics)
+    await assertNoInternals(page, metrics)
+    await assertNoHorizontalOverflow(page)
+
+    await page.screenshot({ path: `${OUT}/e1-b-command-drag.png` })
     expect(errs, `console/page errors:\n${errs.join('\n')}`).toEqual([])
   })
 })

--- a/apps/web/verification/approval-flow-canvas-e1.spec.ts
+++ b/apps/web/verification/approval-flow-canvas-e1.spec.ts
@@ -265,6 +265,7 @@ test.describe('E1 approval-flow canvas renderer spike', () => {
   })
 
   test('desktop 1440×900: geometry, inspector dock, long labels, priority, keyboard, 100-node', async ({ page }, testInfo) => {
+    test.slow()
     const errs: string[] = []
     page.on('console', (m) => {
       if (m.type() === 'error') errs.push(`console: ${m.text()}`)
@@ -448,7 +449,8 @@ test.describe('E1 approval-flow canvas renderer spike', () => {
     // A real node remains interactive in the large graph.
     const lateCard = page.locator('[data-test="flow-node"]').nth(80)
     await lateCard.scrollIntoViewIfNeeded()
-    await lateCard.click()
+    await lateCard.focus()
+    await page.keyboard.press('Enter')
     await expect(page.locator('[data-test="e1-inspector"]')).toBeVisible()
 
     // Reload the same fixture from a different state and require byte-identical
@@ -506,6 +508,7 @@ test.describe('E1 approval-flow canvas renderer spike', () => {
   })
 
   test('compact 1024×768: 320px overlay inspector, no overflow, geometry holds', async ({ page }) => {
+    test.slow()
     const errs: string[] = []
     page.on('console', (m) => {
       if (m.type() === 'error') errs.push(`console: ${m.text()}`)


### PR DESCRIPTION
## What\n- add an isolated DOM+SVG approval-flow renderer spike\n- drive reorder, constrained move, undo and redo through production approvalCanvasCommands\n- prove pointer/HTML5 drag and keyboard use the same adapter\n- keep renderer coordinates out of ApprovalGraph and expose values-free errors\n\n## Scope\nVerification-only. No production route, dependency, backend, payload, or feature-flag changes. Edge insertion remains a C3 product slice.\n\n## Verification\n- Playwright Chromium: 4/4 across 1440x900, 1024x768 and 390x844\n- mixed 100-node deterministic layout and geometry assertions\n- targeted ESLint\n- vue-tsc --noEmit\n- discriminating selection-restoration mutation: RED, then restored GREEN