### PR TITLE
docs(approval): track Approval Designer 2.0 delivery

### DIFF
--- a/docs/development/approval-editor-flow-parity-closeout-verification-20260728.md
+++ b/docs/development/approval-editor-flow-parity-closeout-verification-20260728.md
@@ -1,12 +1,12 @@
-# 审批编辑器与流程编排 E1-b / E2 / C1 收尾验证（2026-07-28）
+# 审批编辑器与流程编排 E1-b / E2 / C1 / C2 收尾验证（2026-07-28）
 
-**范围状态：PR VERIFIED（C1 required CI 仍在运行）**
+**范围状态：PR VERIFIED（C2 required CI 仍在运行）**
 
 **整线状态：NOT FINAL**
 
-本报告只关闭 E1-b renderer/command feasibility、E2 第一刀无行为抽取和
-C1 线性/复杂流程统一载体。它不宣称审批编辑器已对标完成，不授权
-C2-C5、F1-F3、部署、UAT 或 flag 开启。
+本报告只关闭 E1-b renderer/command feasibility、E2 第一刀无行为抽取、
+C1 线性/复杂流程统一载体和 C2 canvas-first 工作区。它不宣称审批编辑器
+已对标完成，不授权 C3-C5、F1-F3、部署、UAT 或 flag 开启。
 
 ## 1. Exact heads
 
@@ -15,6 +15,7 @@ C2-C5、F1-F3、部署、UAT 或 flag 开启。
 | E1-b | `codex/approval-editor-e1b-command-drag-20260728` | `2955a68da` |
 | E2 | `codex/approval-editor-e2-shell-extract-20260728` | `5a9bb4db2` |
 | C1 | `codex/approval-editor-c1-unified-canvas-20260728` | `704276e1a` |
+| C2 | `codex/approval-editor-c2-canvas-first-20260728` | `068d6e628` |
 | 文档 | `codex/approval-editor-flow-parity-plan-20260727` | 本报告提交后的 head |
 
 E2 起点为 `origin/main@9da0335b4`。canonical checkout 未被修改。
@@ -168,22 +169,53 @@ Kimi 对 `8cf218f31` 做 exact-head 只读对抗复审，结论 APPROVE、无 P1
 console error 为 0。Canvas inspector 勾选“自审合并”后切回结构列表，同一
 checkbox 保持选中；只在真实编辑后 header 才变为“有未保存更改”。
 
-## 6. 残余与 owner 门
+## 6. C2 证据
 
-1. #4642/#4643 required CI 已绿，#4649 required CI 待结算；三者均未 merge；
-2. 默认仍是结构列表；canvas-first 属于 C2；
-3. edge `+` 产品接线、节点按钮群移除属于 C3；
-4. 统一 drag feedback、undo/redo 属于 C4/C5；
-5. 表单仅有既有字段排序，尚无 palette 拖入和统一字段 inspector（F1-F3）；
-6. 版本时间线/双画布 diff、路由预览整合、真实键盘/a11y 仍未完成；
-7. 390 虽无横向溢出，但 sticky bottom navigation 会遮住内容，属于 X1；
-8. production Canvas 仍默认 OFF；staging UAT 与生产 flag 为 owner 门；
-9. 结构化辅助编辑入口必须保留，直到键盘/辅助技术等价性有真浏览器证据。
+### 6.1 行为与回退
 
-## 7. 结论
+- Canvas flag ON 时线性与复杂流程默认进入真正 Canvas；
+- 表单/流程在同一工作区用 segmented control 往返；
+- 原结构视图保留为“辅助编辑模式”，切回后原有步骤仍在；
+- Canvas 从隐藏状态显示时重新测量 viewport；
+- flag OFF 不出现新切换器，保持旧路径。
+
+### 6.2 测试、变异与真浏览器
+
+```text
+17 authoring/canvas/graph files: 260/260 PASS
+focused mounted specs: 22/22 PASS
+targeted ESLint: PASS
+vue-tsc --noEmit: PASS
+git diff --check: PASS
+```
+
+四刀判别变异分别中和 Canvas 默认值、Form/Flow action、viewport reveal
+watch 和 ARIA group 语义，指定测试均精确转红。真实 Chromium 在
+1440 / 1024 / 390 验证默认 Canvas、Form -> Flow -> Form、辅助模式恢复、
+无横向溢出和零 console error。
+
+变异恢复阶段曾误命中另一个同形 `@click`，导致表单/流程按钮目标反转；
+单测运行时点未覆盖该恢复错误，真浏览器交互发现并阻止发布。按按钮上下文
+修复后，完整测试、类型、lint 和浏览器矩阵全部重跑。Kimi exact-head
+对抗复审的两个 P2（不完整 tablist 语义、隐藏 Canvas 0x0 viewport）均已
+闭合，最终无 P1/P2。
+
+## 7. 残余与 owner 门
+
+1. #4642/#4643/#4649 required CI 已绿，#4652 required CI 待结算；四者均未 merge；
+2. edge `+` 产品接线、节点按钮群移除属于 C3；
+3. 统一 drag feedback、undo/redo 属于 C4/C5；
+4. 表单仅有既有字段排序，尚无 palette 拖入和统一字段 inspector（F1-F3）；
+5. 版本时间线/双画布 diff、路由预览整合、真实键盘/a11y 仍未完成；
+6. 390 虽无横向溢出，但 sticky bottom navigation 会遮住内容，属于 X1；
+7. production Canvas 仍默认 OFF；staging UAT 与生产 flag 为 owner 门；
+8. 结构化辅助编辑入口必须保留，直到键盘/辅助技术等价性有真浏览器证据。
+
+## 8. 结论
 
 - `A1 renderer feasibility = PASS`；
 - `A2 first extraction = PR VERIFIED / CI PASS`；
-- `C1 unified carrier = IMPLEMENTED + LOCAL/BROWSER/ADVERSARIAL VERIFIED`；
+- `C1 unified carrier = PR VERIFIED / CI PASS`；
+- `C2 canvas-first = IMPLEMENTED + LOCAL/BROWSER/ADVERSARIAL VERIFIED / CI RUNNING`；
 - `approval editor parity line = IN PROGRESS / NOT FINAL`；
-- 下一开发点为 C2/C3 canvas-first 产品化，并行启动 F1 表单 palette 抽取。
+- 下一开发点为 C3 边 `+` 产品化，并行启动 F1 表单 palette 抽取。

--- a/docs/development/approval-editor-flow-parity-closeout-verification-20260728.md
+++ b/docs/development/approval-editor-flow-parity-closeout-verification-20260728.md
@@ -1,0 +1,134 @@
+# 审批编辑器与流程编排 E1-b / E2 收尾验证（2026-07-28）
+
+**范围状态：LOCAL VERIFIED**
+
+**整线状态：NOT FINAL**
+
+本报告只关闭 E1-b renderer/command feasibility 与 E2 第一刀无行为抽取。
+它不宣称审批编辑器已对标完成，不授权 C1/C2、部署、UAT 或 flag 开启。
+
+## 1. Exact heads
+
+| 切片 | 分支 | exact head |
+|---|---|---|
+| E1-b | `codex/approval-editor-e1b-command-drag-20260728` | `1303d7ba7` |
+| E2 | `codex/approval-editor-e2-shell-extract-20260728` | `ffe0c6229` |
+| 文档 | `codex/approval-editor-flow-parity-plan-20260727` | 本报告提交后的 head |
+
+E2 起点为 `origin/main@9da0335b4`。canonical checkout 未被修改。
+
+## 2. E1-b 证据
+
+### 2.1 静态与真浏览器
+
+```text
+targeted ESLint: PASS
+vue-tsc --noEmit: PASS
+Playwright Chromium: 4/4 PASS
+mixed-100: first 111.18ms, repeat 107.48ms
+```
+
+三 viewport 为 1440x900、1024x768、390x844。截图人工复核确认：
+
+- 画布与右侧 inspector 不重叠；
+- 选中节点有明确 focus ring；
+- edge `+` 可见；
+- 卡片、边和文字无横向溢出；
+- 390 使用 bottom sheet；
+- 100 节点仍可滚动和选择。
+
+### 2.2 命令与数据合同
+
+- reorder 使用生产 `reorder-condition-branches`；
+- move 使用生产 `move-node-into-edge`；
+- 非法 self-slot / unsupported-node-type 保持 graph byte-identical；
+- pointer 与 keyboard 产生相同拓扑；
+- undo 恢复 byte-identical graph；
+- selection/focus/inspector 在层级变化后仍指向同一业务 key；
+- graph JSON 不含 renderer 坐标。
+
+### 2.3 判别变异
+
+中和 `restoreSelectionFromHistory` 后：
+
+```text
+Expected: "主管审批"
+Received: null
+E1-b Playwright: RED
+```
+
+恢复 exact file 后同一用例重新 PASS。该测试不是仅靠“边集合变化”假绿。
+
+## 3. E2 证据
+
+### 3.1 定向回归
+
+```text
+13 approval authoring test files: 247/247 PASS
+targeted ESLint: PASS
+vue-tsc --noEmit: PASS
+git diff --check: PASS
+```
+
+覆盖：
+
+- Canvas flag OFF 时实验面不可见；
+- flag ON 的 list/canvas 切换；
+- Canvas drag/drop 与 Alt+Arrow；
+- Inspector 编辑写回既有 save payload；
+- 删除后 selection 清理；
+- read-only mutation controls；
+- 390 宽度 inspector scroll；
+- condition/parallel/cc/approval 编辑；
+- 复杂图 load -> save byte-identical round-trip；
+- unknown/unsupported config 的 fail-closed 保真。
+
+测试运行中已有的 Vue Router 和未 stub Element Plus 警告仍存在；没有新增
+测试失败。它们不是本刀引入的产品错误。
+
+### 3.2 DOM 与 CSS
+
+- 抽取前后 Canvas `data-testid`：25 / 25，missing 0，added 0；
+- markup 与 Canvas scoped CSS 同时移入 `ApprovalFlowCanvas.vue`；
+- 父组件不再拥有 `.template-authoring__canvas-workspace`；
+- 子组件继续拥有 400px desktop inspector 和 164px mobile scroll margin；
+- 真实 mounted test 验证 list 与 Canvas inspector 的 child-owned 样式。
+
+### 3.3 判别变异
+
+中和子组件 `onMoveTargetDrop` 的 typed intent 后，mounted test 精确转红：
+
+```text
+expected moved node top < app node top
+received 340 < 190: false
+```
+
+恢复 exact file 后同一测试重新 PASS。该证据钉住子组件到父 command
+handler 的事件透传。
+
+## 4. 审阅发现与处置
+
+| 严重度 | 发现 | 处置 |
+|---|---|---|
+| P2 | E1-b 第一版在 move 后保留 render focus id，可能选错 inspector 节点 | 改用 history stable key 重映射 focus id；Playwright + mutation |
+| P3 | E2 抽取后父组件残留 3 个常量 import 和 1 个 helper | 删除机械残差；lint 转绿 |
+| P3 | Claude Sonnet 卡在 Playwright MCP 启动，不是产品测试 | 终止悬挂 MCP；Codex 独立运行全部验证，不采信未完成模型声明 |
+
+最终审阅未发现新的 P1/P2。
+
+## 5. 残余与 owner 门
+
+1. E1-b/E2 尚未 push、开 PR、跑 required CI 或 merge；
+2. edge `+` 插入仍是 spike 演示，生产接线属于 C3；
+3. C1 的统一线性/复杂图 adapter 尚未开发；
+4. E0 的表单 command 绕过、required CI 收集和业务文案缺口仍未关闭；
+5. production Canvas 仍默认 OFF；
+6. staging UAT 与生产 flag 为 owner 门；
+7. 结构化辅助编辑入口必须保留，直到键盘/辅助技术等价性有真浏览器证据。
+
+## 6. 结论
+
+- `A1 renderer feasibility = PASS`；
+- `A2 first extraction = IMPLEMENTED + LOCAL VERIFIED`；
+- `approval editor parity line = IN PROGRESS / NOT FINAL`；
+- 下一开发授权点为：先审合 E1-b/E2，再单独授权 C1。

--- a/docs/development/approval-editor-flow-parity-closeout-verification-20260728.md
+++ b/docs/development/approval-editor-flow-parity-closeout-verification-20260728.md
@@ -14,7 +14,7 @@ C2-C5、F1-F3、部署、UAT 或 flag 开启。
 |---|---|---|
 | E1-b | `codex/approval-editor-e1b-command-drag-20260728` | `2955a68da` |
 | E2 | `codex/approval-editor-e2-shell-extract-20260728` | `5a9bb4db2` |
-| C1 | `codex/approval-editor-c1-unified-canvas-20260728` | `bbd436177` |
+| C1 | `codex/approval-editor-c1-unified-canvas-20260728` | `704276e1a` |
 | 文档 | `codex/approval-editor-flow-parity-plan-20260727` | 本报告提交后的 head |
 
 E2 起点为 `origin/main@9da0335b4`。canonical checkout 未被修改。
@@ -150,8 +150,10 @@ vue-tsc: PASS
 3. 恢复 promote 前专属删除下限 -> 第二次删除测试 RED。
 
 Kimi 对 `8cf218f31` 做 exact-head 只读对抗复审，结论 APPROVE、无 P1/P2；
-其 P3 删除边界在最终 head `bbd436177` 修复。Codex 重新运行目标测试并
-核对 clean diff。
+其 P3 删除边界在 `bbd436177` 修复。required approval-web-guard 首跑随后
+暴露既有 inspector 删除测试使用“唯一审批节点”作为正控；`704276e1a`
+把 fixture 改为两个审批节点，保留 selection/inspector 清理断言且不弱化
+产品守卫。相关两 spec 20/20、ESLint 和 diff check 通过。
 
 ### 5.3 真浏览器
 

--- a/docs/development/approval-editor-flow-parity-closeout-verification-20260728.md
+++ b/docs/development/approval-editor-flow-parity-closeout-verification-20260728.md
@@ -1,13 +1,13 @@
-# 审批编辑器与流程编排 E1-b / E2 / C1 / C2 / F1-a 收尾验证（2026-07-28）
+# 审批编辑器与流程编排 E1-b / E2 / C1 / C2 / C3 / F1-a / F1-b 收尾验证（2026-07-31）
 
 **范围状态：PR VERIFIED / REQUIRED CI PASS**
 
 **整线状态：NOT FINAL**
 
 本报告只关闭 E1-b renderer/command feasibility、E2 第一刀无行为抽取、
-C1 线性/复杂流程统一载体、C2 canvas-first 工作区和 F1-a 表单 palette/
-插入移动交互。它不宣称审批编辑器已对标完成，不授权 C3-C5、
-F1-b/F2/F3、部署、UAT 或 flag 开启。
+C1 线性/复杂流程统一载体、C2 canvas-first 工作区、C3 边 `+` 插入，及
+F1-a/F1-b 表单 palette、三栏 builder/inspector 与插入移动交互。它不宣称
+审批编辑器已对标完成，不授权 C4/C5、F2/F3、部署、UAT 或 flag 开启。
 
 ## 1. Exact heads
 
@@ -18,6 +18,8 @@ F1-b/F2/F3、部署、UAT 或 flag 开启。
 | C1 | `codex/approval-editor-c1-unified-canvas-20260728` | `704276e1a` |
 | C2 | `codex/approval-editor-c2-canvas-first-20260728` | `068d6e628` |
 | F1-a | `codex/approval-editor-f1-form-palette-20260728` | `6b926dce5` |
+| C3 | `codex/approval-editor-c3-edge-insert-agent-20260728` | `525915d3d` |
+| F1-b | `codex/approval-editor-f1b-form-builder-20260728` | `93a9527f2` |
 | 文档 | `codex/approval-editor-flow-parity-plan-20260727` | 本报告提交后的 head |
 
 E2 起点为 `origin/main@9da0335b4`。canonical checkout 未被修改。
@@ -243,28 +245,63 @@ required PR checks: 3/3 PASS
 | 1024 x 900 | 上下堆叠 | 插入槽可选择 | 无 | 0 |
 | 390 x 844 | 上下堆叠 | 触屏选择后插入多行文本为字段 2 | 无 | 0 |
 
-F1-a 没有抽出独立 builder，也没有提供聚焦字段的右侧属性检查器；不能把
-上述证据扩张为 F1/F2/F3 或整条表单设计器完成。
+F1-a 本身没有抽出独立 builder，也没有提供聚焦字段的右侧属性检查器；
+该缺口由 F1-b 关闭，但完整命令层引用保护和附件 authoring 仍属于 F2/F3。
 
-## 8. 残余与 owner 门
+## 8. C3 与 F1-b 证据
 
-1. #4642/#4643/#4649/#4652/#4657 required CI 已绿；五者均未 merge；
-2. edge `+` 产品接线、节点按钮群移除属于 C3；
-3. 统一 drag feedback、undo/redo 属于 C4/C5；
-4. F1-a 已有 palette 点击/拖入、插入槽和字段移动；独立 builder、聚焦字段
-   右侧 inspector、完整引用保护和附件 authoring 仍属于 F1-b/F2/F3；
+### 8.1 C3 边 `+`
+
+- 每条合法 edge 一个 40x40 可聚焦 `+`；menu 提供当前上下文合法的
+  approval / cc / condition / parallel；
+- renderer 只发 typed intent，拓扑仍由纯 command 层修改；节点卡内旧插入
+  按钮群删除，branch management 保留；
+- nested parallel、malformed graph 和 stale edge 均 fail-closed；
+- 独立复核补上两个守卫：无显式 default 的合法 condition 不被误锁；并行
+  每条 branch path 必须收敛到 configured join；
+- focused 58/58、required Web Tests 360 文件 / 4335 测试、类型、lint、
+  production build、diff check 全 PASS；
+- 真 Chromium：4 -> 5 nodes、3 -> 4 edge slots、四项 menu、validity error 0。
+
+1440 viewport 的 `documentElement` 仍有 28px 横向溢出，截图定位为全站顶部
+导航既有宽度，而不是本刀 Canvas/menu/inspector 重叠。该事实保留到 X1，
+不能把 C3 证据写成“整页零溢出”。
+
+### 8.2 F1-b 三栏表单工作区
+
+- 新增 `ApprovalFormBuilder.vue` 和 `ApprovalFieldInspector.vue`；
+- flag ON 为左 palette、中字段画布、右聚焦 inspector；flag OFF 保留旧路径；
+- palette drag/click、插入槽、handle-only 拖排、上下移动和
+  `Alt+ArrowUp/Down` 共用同一 fields 载体；
+- options/detail/visibility/record-link catalog retry 全迁入同一 inspector，
+  未改变持久化 form schema；
+- required Web Tests 359 文件 / 4326 测试、类型、lint、production build、
+  diff check 全 PASS；
+- 真 Chromium 1440 / 1024 / 390 builder overflow 0、console error 0；桌面
+  拖入日期后字段数 3 -> 4，并在右侧把选中字段改名为“财务复核人”。
+
+## 9. 残余与 owner 门
+
+1. #4642/#4643/#4649/#4652/#4657 required CI 已绿；#4696/#4697 已开 Draft，
+   本地门已绿、PR CI 单独结算；全部未 merge；
+2. edge `+` 产品接线和节点按钮群移除已由 C3 完成；
+3. 统一 drag feedback、分支拖排和 undo/redo 属于 C4/C5；
+4. F1-a/F1-b 已有 palette、插入槽、字段移动和三栏 builder/inspector；完整
+   引用保护和附件 authoring 仍属于 F2/F3；
 5. 版本时间线/双画布 diff、路由预览整合、真实键盘/a11y 仍未完成；
 6. 390 虽无横向溢出，但 sticky bottom navigation 会遮住内容，属于 X1；
 7. production Canvas 仍默认 OFF；staging UAT 与生产 flag 为 owner 门；
 8. 结构化辅助编辑入口必须保留，直到键盘/辅助技术等价性有真浏览器证据。
 
-## 9. 结论
+## 10. 结论
 
 - `A1 renderer feasibility = PASS`；
 - `A2 first extraction = PR VERIFIED / CI PASS`；
 - `C1 unified carrier = PR VERIFIED / CI PASS`；
 - `C2 canvas-first = PR VERIFIED / CI PASS`；
 - `F1-a form palette and insertion = PR VERIFIED / CI PASS`；
+- `C3 edge insertion = DRAFT PR / LOCAL REQUIRED PASS / PR CI PENDING`；
+- `F1-b form builder and inspector = DRAFT PR / LOCAL REQUIRED PASS / PR CI PENDING`；
 - `approval editor parity line = IN PROGRESS / NOT FINAL`；
-- 下一开发点为 C3 边 `+` 产品化，并行推进 F1-b 表单 builder 和右侧字段
-  inspector。
+- 下一开发点为 C4/C5 语义拖拽、分支排序与 undo/redo，并行推进 F2/F3
+  引用保护和附件 authoring。

--- a/docs/development/approval-editor-flow-parity-closeout-verification-20260728.md
+++ b/docs/development/approval-editor-flow-parity-closeout-verification-20260728.md
@@ -1,14 +1,16 @@
-# 审批编辑器与流程编排 E1-b / E2 / C1-C4 / F1-a-F2 收尾验证（2026-07-31）
+# 审批编辑器与流程编排 E1-b / E2 / C1-C5 / F1-a-F3 收尾验证（2026-07-31）
 
 **范围状态：PR VERIFIED / REQUIRED CI PASS**
 
 **整线状态：NOT FINAL**
 
 本报告只关闭 E1-b renderer/command feasibility、E2 第一刀无行为抽取、
-C1 线性/复杂流程统一载体、C2 canvas-first 工作区、C3 边 `+` 插入，及
-F1-a/F1-b/F2 表单 palette、三栏 builder/inspector、命令与引用保护，以及
-C4 语义拖拽/分支排序。它不宣称审批编辑器已对标完成，不授权 C5/F3、
-部署、UAT 或 flag 开启；C4 真浏览器证据仍未闭合。
+C1 线性/复杂流程统一载体、C2 canvas-first 工作区、C3 边 `+` 插入、C4
+语义拖拽/分支排序、C5 Canvas 历史，以及 F1-a/F1-b/F2/F3 表单 palette、
+三栏 builder/inspector、命令/引用保护和附件 authoring 代码门。#4702 又完成
+表单与 Canvas 单一 per-draft history 的组合验证。它不宣称审批编辑器已对标
+完成，不授权部署、UAT 或 flag 开启；C4/F1/F3 真浏览器 T1、V1/V2、P1、
+X1 仍未闭合。
 
 ## 1. Exact heads
 
@@ -21,6 +23,11 @@ C4 语义拖拽/分支排序。它不宣称审批编辑器已对标完成，不�
 | F1-a | `codex/approval-editor-f1-form-palette-20260728` | `6b926dce5` |
 | C3 | `codex/approval-editor-c3-edge-insert-agent-20260728` | `525915d3d` |
 | F1-b | `codex/approval-editor-f1b-form-builder-20260728` | `93a9527f2` |
+| C4 | `codex/approval-editor-c4-semantic-drag-20260731` | `c6f0b7bbc` |
+| F2 | `codex/approval-editor-f2-form-command-protection-20260731` | `4ccc20f71`（组合含 `5fff366e8`） |
+| F3 | `codex/approval-editor-f3-attachment-authoring-20260731` | `2cbbd539a` |
+| C5 | `codex/approval-editor-c5-unified-history-20260731` | `a2dacd562` |
+| I1 | `codex/approval-editor-2-final-integration-20260731` | `7192a56fd` |
 | 文档 | `codex/approval-editor-flow-parity-plan-20260727` | 本报告提交后的 head |
 
 E2 起点为 `origin/main@9da0335b4`。canonical checkout 未被修改。
@@ -304,14 +311,57 @@ F1-a 本身没有抽出独立 builder，也没有提供聚焦字段的右侧属�
   required Web 359 文件 / 4330 测试、两刀 mutation RED；Draft PR #4699，
   exact head `4ccc20f71`。
 
+### 8.5 F3 附件 authoring
+
+- 附件字段只在 Canvas V2 与附件 authoring 两个 flag 同时开启时进入 palette；
+- 任一能力关闭时，已有附件模板由 unsupported/read-only gate fail-closed，
+  不能在可写编辑器中静默删除附件字段；
+- Draft PR #4700，exact head `2cbbd539a`，required checks 3/3 PASS、
+  merge state CLEAN；尚未 merge、部署或开启 flag。
+
+### 8.6 C5 与 I1 单一历史
+
+- C5 为 Canvas topology/configure/delete 提供顶栏 undo/redo 和快捷键，恢复
+  graph、selection 与 focus；Draft PR #4701 exact head `a2dacd562`，
+  required checks 3/3 PASS；
+- I1 把表单 add/remove/move/configure 也接入同一 history；字段 inspector
+  完全受控，builder 只发事件，父 view 是唯一草稿写入口；
+- 每条 history entry 记录实际改变的顶层 draft key，撤销字段操作不会覆盖
+  之后发生的 description 等基本信息编辑；
+- 成功保存回读服务端全版本 identity context 后建立新历史边界并清空临时
+  退役集合；失败保存不清空 undo；
+- form selection/focus 随 undo/redo 恢复；无具体 control id 时聚焦 inspector
+  第一个可交互控件，避免焦点落到 body。
+
+### 8.7 I1 exact-head 验证与审阅
+
+```text
+focused history + mounted inspector: 46/46 PASS
+required Web: 360 files / 4366 tests PASS
+targeted ESLint: PASS
+vue-tsc --noEmit: PASS
+production Web build: PASS
+git diff --check: PASS
+```
+
+五刀判别变异分别中和 history gate、撤销后的身份保留、changed-key restore、
+焦点 fallback 和成功保存后的历史边界，指定测试均精确 RED；恢复后全绿。
+
+Kimi exact-tree 对抗复核确认没有 nested `v-model`/direct mutation 绕过，
+flag OFF 继续 mutate-only 且不展示 history 控件。它提出的跨成功保存旧快照
+风险已通过“成功保存清空、失败保存保留”双正反控制关闭。其剩余 P3 为输入
+逐键产生历史项及明细表格焦点粒度，均不构成数据正确性或 flag-ON 阻塞。
+Grok 本轮因上游连接失败未读取代码，未计入复核证据。
+
 ## 9. 残余与 owner 门
 
-1. #4642/#4643/#4649/#4652/#4657 required CI 已绿；#4696/#4697 已开 Draft，
-   本地门与 exact-head required CI 均已绿，merge state 均为 CLEAN；全部未 merge；
+1. #4642/#4643/#4649/#4652/#4657/#4696-#4702 required CI 已绿；#4702 为
+   Draft、required checks 3/3 PASS；全部未 merge；
 2. edge `+` 产品接线和节点按钮群移除已由 C3 完成；
-3. drag feedback 和分支拖排已由 C4 实现，但真浏览器证据待补；undo/redo 属于 C5；
-4. F1-a/F1-b/F2 已有 palette、三栏 builder、字段命令和引用保护；附件
-   authoring 仍属于 F3；
+3. drag feedback 和分支拖排已由 C4 实现，C5/I1 已实现 Canvas、节点检查器、
+   表单结构与字段属性的单一 history；真浏览器证据仍待补；
+4. F1-a-F3 已有 palette、三栏 builder、字段命令、引用保护及附件双 flag
+   authoring；不得在 T1 前宣称交互交付；
 5. 版本时间线/双画布 diff、路由预览整合、真实键盘/a11y 仍未完成；
 6. 390 虽无横向溢出，但 sticky bottom navigation 会遮住内容，属于 X1；
 7. production Canvas 仍默认 OFF；staging UAT 与生产 flag 为 owner 门；
@@ -327,6 +377,9 @@ F1-a 本身没有抽出独立 builder，也没有提供聚焦字段的右侧属�
 - `C3 edge insertion = DRAFT PR / LOCAL REQUIRED PASS / EXACT-HEAD PR CI PASS / CLEAN`；
 - `F1-b form builder and inspector = DRAFT PR / LOCAL REQUIRED PASS / EXACT-HEAD PR CI PASS / CLEAN`；
 - `C4 semantic drag = DRAFT PR / LOCAL REQUIRED PASS / BROWSER EVIDENCE PENDING`；
-- `F2 form command protection = DRAFT PR / LOCAL REQUIRED PASS / REAL DB PASS / PR CI RUNNING`；
+- `C5 unified canvas history = DRAFT PR / EXACT-HEAD PR CI PASS / CLEAN / BROWSER EVIDENCE PENDING`；
+- `F2 form command protection = DRAFT PR / LOCAL REQUIRED PASS / REAL DB PASS / PR CI PASS`；
+- `F3 attachment authoring = DRAFT PR / EXACT-HEAD PR CI PASS / CLEAN / BROWSER EVIDENCE PENDING`；
+- `I1 form + canvas single history = DRAFT PR / LOCAL REQUIRED PASS / EXACT-HEAD PR CI PASS / BROWSER EVIDENCE PENDING`；
 - `approval editor parity line = IN PROGRESS / NOT FINAL`；
-- 下一开发点为 C5 统一 undo/redo 与 F3 附件 authoring，并补 C4 真浏览器门。
+- 下一开发点为 T1 真浏览器、V1/V2、P1 和 X1；T1/U0 前不得标 FINAL。

--- a/docs/development/approval-editor-flow-parity-closeout-verification-20260728.md
+++ b/docs/development/approval-editor-flow-parity-closeout-verification-20260728.md
@@ -1,18 +1,20 @@
-# 审批编辑器与流程编排 E1-b / E2 收尾验证（2026-07-28）
+# 审批编辑器与流程编排 E1-b / E2 / C1 收尾验证（2026-07-28）
 
-**范围状态：LOCAL VERIFIED**
+**范围状态：PR VERIFIED（C1 required CI 仍在运行）**
 
 **整线状态：NOT FINAL**
 
-本报告只关闭 E1-b renderer/command feasibility 与 E2 第一刀无行为抽取。
-它不宣称审批编辑器已对标完成，不授权 C1/C2、部署、UAT 或 flag 开启。
+本报告只关闭 E1-b renderer/command feasibility、E2 第一刀无行为抽取和
+C1 线性/复杂流程统一载体。它不宣称审批编辑器已对标完成，不授权
+C2-C5、F1-F3、部署、UAT 或 flag 开启。
 
 ## 1. Exact heads
 
 | 切片 | 分支 | exact head |
 |---|---|---|
-| E1-b | `codex/approval-editor-e1b-command-drag-20260728` | `1303d7ba7` |
-| E2 | `codex/approval-editor-e2-shell-extract-20260728` | `ffe0c6229` |
+| E1-b | `codex/approval-editor-e1b-command-drag-20260728` | `2955a68da` |
+| E2 | `codex/approval-editor-e2-shell-extract-20260728` | `5a9bb4db2` |
+| C1 | `codex/approval-editor-c1-unified-canvas-20260728` | `bbd436177` |
 | 文档 | `codex/approval-editor-flow-parity-plan-20260727` | 本报告提交后的 head |
 
 E2 起点为 `origin/main@9da0335b4`。canonical checkout 未被修改。
@@ -111,24 +113,75 @@ handler 的事件透传。
 | 严重度 | 发现 | 处置 |
 |---|---|---|
 | P2 | E1-b 第一版在 move 后保留 render focus id，可能选错 inspector 节点 | 改用 history stable key 重映射 focus id；Playwright + mutation |
+| P3 | C1 线性流程 promote 后，原 `steps.length` 删除下限失效，可继续删到 start→end | 改按 effective graph 的 approval node 数量守卫；中和回旧逻辑后 exact test RED |
 | P3 | E2 抽取后父组件残留 3 个常量 import 和 1 个 helper | 删除机械残差；lint 转绿 |
 | P3 | Claude Sonnet 卡在 Playwright MCP 启动，不是产品测试 | 终止悬挂 MCP；Codex 独立运行全部验证，不采信未完成模型声明 |
 
 最终审阅未发现新的 P1/P2。
 
-## 5. 残余与 owner 门
+## 5. C1 证据
 
-1. E1-b/E2 尚未 push、开 PR、跑 required CI 或 merge；
-2. edge `+` 插入仍是 spike 演示，生产接线属于 C3；
-3. C1 的统一线性/复杂图 adapter 尚未开发；
-4. E0 的表单 command 绕过、required CI 收集和业务文案缺口仍未关闭；
-5. production Canvas 仍默认 OFF；
-6. staging UAT 与生产 flag 为 owner 门；
-7. 结构化辅助编辑入口必须保留，直到键盘/辅助技术等价性有真浏览器证据。
+### 5.1 数据与拓扑
 
-## 6. 结论
+- 线性 Canvas inspector 不创建 shadow edit，全部写回已有
+  `ApprovalStepDraft`；
+- 仅打开/选中/切换 Canvas 不置 dirty，保存 payload byte-identical；
+- 首次插入/移动通过 `applyTopologyToDraft` promote，原审批节点的 key、name、
+  source ids、mode、empty policy、auto approval policy 和 field permissions
+  保持；
+- flag OFF 回到结构列表；unsupported template 不开放 Canvas；
+- `topologyEdgeCount`、parallel-region 和 validity 读取 effective graph；
+- 最后审批节点删除下限在 promote 前后都成立。
+
+### 5.2 测试与变异
+
+```text
+C1 mounted production-view spec: 9/9 PASS
+authoring / inspector / topology / viewport focused battery: 124/124 PASS
+style guard: 83/83 PASS
+targeted ESLint: PASS
+vue-tsc: PASS
+```
+
+三刀判别变异：
+
+1. 中和 linear carrier lookup -> inspector write-through tests RED；
+2. 恢复 preservedGraph-only edge count -> promotion/delete positive controls RED；
+3. 恢复 promote 前专属删除下限 -> 第二次删除测试 RED。
+
+Kimi 对 `8cf218f31` 做 exact-head 只读对抗复审，结论 APPROVE、无 P1/P2；
+其 P3 删除边界在最终 head `bbd436177` 修复。Codex 重新运行目标测试并
+核对 clean diff。
+
+### 5.3 真浏览器
+
+真实 `TemplateAuthoringView` 在 Chromium 中验证：
+
+| viewport | Canvas | graph region | inspector | 横向溢出 |
+|---|---:|---:|---:|---|
+| 1440 | 1078 x 554 | 666 x 478 | 400 x 554 | 无 |
+| 1024 | 918 x 572 | 506 x 478 | 400 x 538 | 无 |
+| 390 | 300 x 1003 | 300 x 478 | 300 x 401 | 无 |
+
+console error 为 0。Canvas inspector 勾选“自审合并”后切回结构列表，同一
+checkbox 保持选中；只在真实编辑后 header 才变为“有未保存更改”。
+
+## 6. 残余与 owner 门
+
+1. #4642/#4643 required CI 已绿，#4649 required CI 待结算；三者均未 merge；
+2. 默认仍是结构列表；canvas-first 属于 C2；
+3. edge `+` 产品接线、节点按钮群移除属于 C3；
+4. 统一 drag feedback、undo/redo 属于 C4/C5；
+5. 表单仅有既有字段排序，尚无 palette 拖入和统一字段 inspector（F1-F3）；
+6. 版本时间线/双画布 diff、路由预览整合、真实键盘/a11y 仍未完成；
+7. 390 虽无横向溢出，但 sticky bottom navigation 会遮住内容，属于 X1；
+8. production Canvas 仍默认 OFF；staging UAT 与生产 flag 为 owner 门；
+9. 结构化辅助编辑入口必须保留，直到键盘/辅助技术等价性有真浏览器证据。
+
+## 7. 结论
 
 - `A1 renderer feasibility = PASS`；
-- `A2 first extraction = IMPLEMENTED + LOCAL VERIFIED`；
+- `A2 first extraction = PR VERIFIED / CI PASS`；
+- `C1 unified carrier = IMPLEMENTED + LOCAL/BROWSER/ADVERSARIAL VERIFIED`；
 - `approval editor parity line = IN PROGRESS / NOT FINAL`；
-- 下一开发授权点为：先审合 E1-b/E2，再单独授权 C1。
+- 下一开发点为 C2/C3 canvas-first 产品化，并行启动 F1 表单 palette 抽取。

--- a/docs/development/approval-editor-flow-parity-closeout-verification-20260728.md
+++ b/docs/development/approval-editor-flow-parity-closeout-verification-20260728.md
@@ -1,12 +1,13 @@
-# 审批编辑器与流程编排 E1-b / E2 / C1 / C2 收尾验证（2026-07-28）
+# 审批编辑器与流程编排 E1-b / E2 / C1 / C2 / F1-a 收尾验证（2026-07-28）
 
 **范围状态：PR VERIFIED / REQUIRED CI PASS**
 
 **整线状态：NOT FINAL**
 
 本报告只关闭 E1-b renderer/command feasibility、E2 第一刀无行为抽取、
-C1 线性/复杂流程统一载体和 C2 canvas-first 工作区。它不宣称审批编辑器
-已对标完成，不授权 C3-C5、F1-F3、部署、UAT 或 flag 开启。
+C1 线性/复杂流程统一载体、C2 canvas-first 工作区和 F1-a 表单 palette/
+插入移动交互。它不宣称审批编辑器已对标完成，不授权 C3-C5、
+F1-b/F2/F3、部署、UAT 或 flag 开启。
 
 ## 1. Exact heads
 
@@ -16,6 +17,7 @@ C1 线性/复杂流程统一载体和 C2 canvas-first 工作区。它不宣称�
 | E2 | `codex/approval-editor-e2-shell-extract-20260728` | `5a9bb4db2` |
 | C1 | `codex/approval-editor-c1-unified-canvas-20260728` | `704276e1a` |
 | C2 | `codex/approval-editor-c2-canvas-first-20260728` | `068d6e628` |
+| F1-a | `codex/approval-editor-f1-form-palette-20260728` | `6b926dce5` |
 | 文档 | `codex/approval-editor-flow-parity-plan-20260727` | 本报告提交后的 head |
 
 E2 起点为 `origin/main@9da0335b4`。canonical checkout 未被修改。
@@ -200,22 +202,69 @@ watch 和 ARIA group 语义，指定测试均精确转红。真实 Chromium 在
 对抗复审的两个 P2（不完整 tablist 语义、隐藏 Canvas 0x0 viewport）均已
 闭合，最终无 P1/P2。
 
-## 7. 残余与 owner 门
+## 7. F1-a 证据
 
-1. #4642/#4643/#4649/#4652 required CI 已绿；四者均未 merge；
+### 7.1 行为与兼容
+
+- palette 精确覆盖当前 `AUTHORABLE_FIELD_TYPES`，点击和 typed native drag
+  均可把字段加入所选插入槽；
+- 每个字段前后都有可聚焦插入槽；鼠标、键盘和触屏都可选择位置，重复点击
+  同一槽位会取消；
+- 只有字段拖拽把手可启动移动；typed payload 必须与本地 active drag
+  session 匹配，外来或 malformed payload 不改草稿；
+- 键盘 `Alt+ArrowUp/Down` 与既有上下移动按钮提供等价重排；
+- 删除后新增字段选择最小可用 `field_N`，不产生重复 ID；
+- read-only 全部 inert；Canvas flag OFF 不显示 palette、插入槽和新把手，
+  继续走旧路径。
+
+### 7.2 测试、变异与真浏览器
+
+```text
+focused palette + mounted authoring specs: 22/22 PASS
+required web tests: 359 files / 4320 tests PASS
+targeted ESLint: PASS
+vue-tsc --noEmit: PASS
+web production build: PASS
+git diff --check: PASS
+required PR checks: 3/3 PASS
+```
+
+三刀判别变异分别恢复错误的前向移动索引、恢复 `fields.length + 1` 字段
+编号、删除 typed payload 与本地 drag session 一致性检查，指定测试均
+精确转红。三轮独立子代理复审发现并推动关闭 malformed drag、前向跨越
+覆盖、palette allowlist、键盘/触屏插入点、删除空隙重复 ID 和 CI 收集等
+问题；最终 exact diff 无 P1/P2。
+
+真实 `TemplateAuthoringView` 在 Chromium 中验证：
+
+| viewport | palette / form | 插入行为 | 横向溢出 | console error |
+|---|---|---|---|---:|
+| 1440 x 1000 | 左右并列 | 日期插入字段 1 | 无 | 0 |
+| 1024 x 900 | 上下堆叠 | 插入槽可选择 | 无 | 0 |
+| 390 x 844 | 上下堆叠 | 触屏选择后插入多行文本为字段 2 | 无 | 0 |
+
+F1-a 没有抽出独立 builder，也没有提供聚焦字段的右侧属性检查器；不能把
+上述证据扩张为 F1/F2/F3 或整条表单设计器完成。
+
+## 8. 残余与 owner 门
+
+1. #4642/#4643/#4649/#4652/#4657 required CI 已绿；五者均未 merge；
 2. edge `+` 产品接线、节点按钮群移除属于 C3；
 3. 统一 drag feedback、undo/redo 属于 C4/C5；
-4. 表单仅有既有字段排序，尚无 palette 拖入和统一字段 inspector（F1-F3）；
+4. F1-a 已有 palette 点击/拖入、插入槽和字段移动；独立 builder、聚焦字段
+   右侧 inspector、完整引用保护和附件 authoring 仍属于 F1-b/F2/F3；
 5. 版本时间线/双画布 diff、路由预览整合、真实键盘/a11y 仍未完成；
 6. 390 虽无横向溢出，但 sticky bottom navigation 会遮住内容，属于 X1；
 7. production Canvas 仍默认 OFF；staging UAT 与生产 flag 为 owner 门；
 8. 结构化辅助编辑入口必须保留，直到键盘/辅助技术等价性有真浏览器证据。
 
-## 8. 结论
+## 9. 结论
 
 - `A1 renderer feasibility = PASS`；
 - `A2 first extraction = PR VERIFIED / CI PASS`；
 - `C1 unified carrier = PR VERIFIED / CI PASS`；
 - `C2 canvas-first = PR VERIFIED / CI PASS`；
+- `F1-a form palette and insertion = PR VERIFIED / CI PASS`；
 - `approval editor parity line = IN PROGRESS / NOT FINAL`；
-- 下一开发点为 C3 边 `+` 产品化，并行启动 F1 表单 palette 抽取。
+- 下一开发点为 C3 边 `+` 产品化，并行推进 F1-b 表单 builder 和右侧字段
+  inspector。

--- a/docs/development/approval-editor-flow-parity-closeout-verification-20260728.md
+++ b/docs/development/approval-editor-flow-parity-closeout-verification-20260728.md
@@ -1,4 +1,4 @@
-# 审批编辑器与流程编排 E1-b / E2 / C1 / C2 / C3 / F1-a / F1-b 收尾验证（2026-07-31）
+# 审批编辑器与流程编排 E1-b / E2 / C1-C4 / F1-a-F2 收尾验证（2026-07-31）
 
 **范围状态：PR VERIFIED / REQUIRED CI PASS**
 
@@ -6,8 +6,9 @@
 
 本报告只关闭 E1-b renderer/command feasibility、E2 第一刀无行为抽取、
 C1 线性/复杂流程统一载体、C2 canvas-first 工作区、C3 边 `+` 插入，及
-F1-a/F1-b 表单 palette、三栏 builder/inspector 与插入移动交互。它不宣称
-审批编辑器已对标完成，不授权 C4/C5、F2/F3、部署、UAT 或 flag 开启。
+F1-a/F1-b/F2 表单 palette、三栏 builder/inspector、命令与引用保护，以及
+C4 语义拖拽/分支排序。它不宣称审批编辑器已对标完成，不授权 C5/F3、
+部署、UAT 或 flag 开启；C4 真浏览器证据仍未闭合。
 
 ## 1. Exact heads
 
@@ -280,14 +281,37 @@ F1-a 本身没有抽出独立 builder，也没有提供聚焦字段的右侧属�
 - 真 Chromium 1440 / 1024 / 390 builder overflow 0、console error 0；桌面
   拖入日期后字段数 3 -> 4，并在右侧把选中字段改名为“财务复核人”。
 
+### 8.3 C4 语义拖拽与分支排序
+
+- 节点拖入合法 edge slot、条件分支排序和并行分支排序统一经页面
+  `applyCanvasCommand` 接现有命令代数，renderer 无拓扑业务逻辑；
+- 拖拽 payload 与本地 session token 绑定；stale、非法和跨区域输入 no-op，
+  visible/live 文案 values-free；分支把手、`Alt+Arrow` 和按钮共享语义；
+- focused 79/79、required Web 360 文件 / 4338 测试、类型和 production build
+  PASS；Draft PR #4698，exact head `c6f0b7bbc`；
+- 本轮 Codex In-app Browser 无法附着 localhost 新标签页。HTTP 服务本身 200，
+  但缺 drag/screenshot 证据，因此 C4 只记 `IMPLEMENTED / LOCAL REQUIRED PASS`。
+
+### 8.4 F2 表单命令与权威引用
+
+- Builder 仅发 typed add/remove/move intent，页面调用 `approvalFormCommands`；
+- 新字段/明细列使用 UUID identity；后端收集该模板全部历史版本的字段与明细
+  列 ID，删除后不可复用；
+- admin-only authoring context 在 REPEATABLE READ 只读事务返回完整身份与
+  values-free FWB reference inventory；错模板、缺项或畸形成员全部 fail-closed；
+- publish 在同一事务重扫引用，删除仍被 FWB 使用的字段返回 values-free 409；
+- focused FE 105/105、BE unit 147/147、fresh PG15 全迁移真实 API 8/8、
+  required Web 359 文件 / 4330 测试、两刀 mutation RED；Draft PR #4699，
+  exact head `4ccc20f71`。
+
 ## 9. 残余与 owner 门
 
 1. #4642/#4643/#4649/#4652/#4657 required CI 已绿；#4696/#4697 已开 Draft，
    本地门与 exact-head required CI 均已绿，merge state 均为 CLEAN；全部未 merge；
 2. edge `+` 产品接线和节点按钮群移除已由 C3 完成；
-3. 统一 drag feedback、分支拖排和 undo/redo 属于 C4/C5；
-4. F1-a/F1-b 已有 palette、插入槽、字段移动和三栏 builder/inspector；完整
-   引用保护和附件 authoring 仍属于 F2/F3；
+3. drag feedback 和分支拖排已由 C4 实现，但真浏览器证据待补；undo/redo 属于 C5；
+4. F1-a/F1-b/F2 已有 palette、三栏 builder、字段命令和引用保护；附件
+   authoring 仍属于 F3；
 5. 版本时间线/双画布 diff、路由预览整合、真实键盘/a11y 仍未完成；
 6. 390 虽无横向溢出，但 sticky bottom navigation 会遮住内容，属于 X1；
 7. production Canvas 仍默认 OFF；staging UAT 与生产 flag 为 owner 门；
@@ -302,6 +326,7 @@ F1-a 本身没有抽出独立 builder，也没有提供聚焦字段的右侧属�
 - `F1-a form palette and insertion = PR VERIFIED / CI PASS`；
 - `C3 edge insertion = DRAFT PR / LOCAL REQUIRED PASS / EXACT-HEAD PR CI PASS / CLEAN`；
 - `F1-b form builder and inspector = DRAFT PR / LOCAL REQUIRED PASS / EXACT-HEAD PR CI PASS / CLEAN`；
+- `C4 semantic drag = DRAFT PR / LOCAL REQUIRED PASS / BROWSER EVIDENCE PENDING`；
+- `F2 form command protection = DRAFT PR / LOCAL REQUIRED PASS / REAL DB PASS / PR CI RUNNING`；
 - `approval editor parity line = IN PROGRESS / NOT FINAL`；
-- 下一开发点为 C4/C5 语义拖拽、分支排序与 undo/redo，并行推进 F2/F3
-  引用保护和附件 authoring。
+- 下一开发点为 C5 统一 undo/redo 与 F3 附件 authoring，并补 C4 真浏览器门。

--- a/docs/development/approval-editor-flow-parity-closeout-verification-20260728.md
+++ b/docs/development/approval-editor-flow-parity-closeout-verification-20260728.md
@@ -1,6 +1,6 @@
 # 审批编辑器与流程编排 E1-b / E2 / C1 / C2 收尾验证（2026-07-28）
 
-**范围状态：PR VERIFIED（C2 required CI 仍在运行）**
+**范围状态：PR VERIFIED / REQUIRED CI PASS**
 
 **整线状态：NOT FINAL**
 
@@ -202,7 +202,7 @@ watch 和 ARIA group 语义，指定测试均精确转红。真实 Chromium 在
 
 ## 7. 残余与 owner 门
 
-1. #4642/#4643/#4649 required CI 已绿，#4652 required CI 待结算；四者均未 merge；
+1. #4642/#4643/#4649/#4652 required CI 已绿；四者均未 merge；
 2. edge `+` 产品接线、节点按钮群移除属于 C3；
 3. 统一 drag feedback、undo/redo 属于 C4/C5；
 4. 表单仅有既有字段排序，尚无 palette 拖入和统一字段 inspector（F1-F3）；
@@ -216,6 +216,6 @@ watch 和 ARIA group 语义，指定测试均精确转红。真实 Chromium 在
 - `A1 renderer feasibility = PASS`；
 - `A2 first extraction = PR VERIFIED / CI PASS`；
 - `C1 unified carrier = PR VERIFIED / CI PASS`；
-- `C2 canvas-first = IMPLEMENTED + LOCAL/BROWSER/ADVERSARIAL VERIFIED / CI RUNNING`；
+- `C2 canvas-first = PR VERIFIED / CI PASS`；
 - `approval editor parity line = IN PROGRESS / NOT FINAL`；
 - 下一开发点为 C3 边 `+` 产品化，并行启动 F1 表单 palette 抽取。

--- a/docs/development/approval-editor-flow-parity-closeout-verification-20260728.md
+++ b/docs/development/approval-editor-flow-parity-closeout-verification-20260728.md
@@ -283,7 +283,7 @@ F1-a 本身没有抽出独立 builder，也没有提供聚焦字段的右侧属�
 ## 9. 残余与 owner 门
 
 1. #4642/#4643/#4649/#4652/#4657 required CI 已绿；#4696/#4697 已开 Draft，
-   本地门已绿、PR CI 单独结算；全部未 merge；
+   本地门与 exact-head required CI 均已绿，merge state 均为 CLEAN；全部未 merge；
 2. edge `+` 产品接线和节点按钮群移除已由 C3 完成；
 3. 统一 drag feedback、分支拖排和 undo/redo 属于 C4/C5；
 4. F1-a/F1-b 已有 palette、插入槽、字段移动和三栏 builder/inspector；完整
@@ -300,8 +300,8 @@ F1-a 本身没有抽出独立 builder，也没有提供聚焦字段的右侧属�
 - `C1 unified carrier = PR VERIFIED / CI PASS`；
 - `C2 canvas-first = PR VERIFIED / CI PASS`；
 - `F1-a form palette and insertion = PR VERIFIED / CI PASS`；
-- `C3 edge insertion = DRAFT PR / LOCAL REQUIRED PASS / PR CI PENDING`；
-- `F1-b form builder and inspector = DRAFT PR / LOCAL REQUIRED PASS / PR CI PENDING`；
+- `C3 edge insertion = DRAFT PR / LOCAL REQUIRED PASS / EXACT-HEAD PR CI PASS / CLEAN`；
+- `F1-b form builder and inspector = DRAFT PR / LOCAL REQUIRED PASS / EXACT-HEAD PR CI PASS / CLEAN`；
 - `approval editor parity line = IN PROGRESS / NOT FINAL`；
 - 下一开发点为 C4/C5 语义拖拽、分支排序与 undo/redo，并行推进 F2/F3
   引用保护和附件 authoring。

--- a/docs/development/approval-editor-flow-parity-development-plan-20260727.md
+++ b/docs/development/approval-editor-flow-parity-development-plan-20260727.md
@@ -1,6 +1,6 @@
 # 审批编辑器与流程编排对标开发计划（2026-07-27）
 
-**状态：IN PROGRESS（E0 / E1 / E1-b / E2 / C1 已完成并形成待审 Draft PR；C2 以后仍在开发队列）**
+**状态：IN PROGRESS（E0 / E1 / E1-b / E2 / C1 / C2 已完成并形成待审 Draft PR；C3 以后及 F1-F3 仍在开发队列）**
 
 **事实审计基线：** `origin/main@d449aa7e6d02f94df2738a77cafffa778b12fde0`
 
@@ -63,9 +63,9 @@
 
 | 用户面 | 当前 `main` | 对标差距 |
 |---|---|---|
-| 信息架构 | 左侧“基础/表单/流程/发布”四步导航 | 表单与流程不是同一工作区内的直接模式切换 |
-| 线性流程 | 旧步骤卡片 + 只读横向脊柱 | 新模板默认看不到真正流程画布 |
-| 复杂流程 | flag ON 后可切换列表/画布；默认 `list` | 未做到 canvas-first |
+| 信息架构 | C2 在 Canvas flag ON 时提供表单/流程直接模式切换 | shell、字段 builder 和版本工作区仍待继续拆分 |
+| 线性流程 | C1 派生统一 Canvas carrier；C2 默认进入流程画布 | 边 `+`、统一历史和拖拽反馈仍未产品化 |
+| 复杂流程 | flag ON 后默认 Canvas；结构视图保留为“辅助编辑模式” | 节点按钮群、分支拖排和 undo/redo 尚未收口 |
 | 节点操作 | 节点内上移/下移/移动/插入/删除按钮群 | 应改为边 `+`、上下文菜单和检查器动作 |
 | 拖拽 | 审批/抄送节点可移入合法边槽 | 缺合法槽持续高亮、统一拖拽状态机和分支拖排 UI |
 | 撤销/重做 | 命令层有逆操作/历史类型 | 顶栏未挂载统一 undo/redo |
@@ -184,7 +184,16 @@ promote 为 graph，并保留审批来源、ids、审批/空值/自审策略及�
 feature flag OFF 和 unsupported template 继续 fail-closed 回结构列表。
 Kimi exact-head 对抗复审为 APPROVE、无 P1/P2；其发现的 promote 后可继续
 删除最后审批节点边界已修复并由判别变异钉死。Draft PR #4649 依赖 #4642，
-尚未 merge、部署或开启 flag。
+required CI 已全绿；尚未 merge、部署或开启 flag。
+
+C2 已在 C1 head 上完成 canvas-first 工作区。Canvas flag ON 时，线性与复杂
+流程都默认进入流程画布，表单/流程可在同一工作区直接切换；原结构视图改名
+为“辅助编辑模式”并保留为可访问回退。隐藏挂载 Canvas 在返回流程模式时会
+重新测量 viewport，避免 0x0 缩略图状态。真实 Chromium 在 1440 / 1024 /
+390 验证默认画布、表单往返、辅助模式和零横向溢出；四刀判别变异分别钉住
+默认模式、模式切换、viewport 重测和 ARIA group 语义。Kimi 对抗复审无
+P1/P2。Draft PR #4652 依赖 #4649；required CI 仍在运行，未 merge、部署或
+开启 flag。
 
 ### 4.1 依赖图
 
@@ -405,8 +414,8 @@ U0 至少包含以下 12 项，全部保存截图、录屏或网络/数据库证
 
 1. **E0：完成。** Codex exact-head 审阅，Claude Opus 只读对抗复核；
 2. **E1 / E1-b：完成。** Kimi 提供视觉 IA，Grok 构建隔离 renderer 和生产命令适配验证，Codex 复核与变异；
-3. **E2 第一刀：完成。** Claude Sonnet 5 做 presentational shell 抽取，Codex 清理、扩测和事件透传变异。
+3. **E2 / C1 / C2：完成待审。** Claude 负责 shell 与统一 carrier，Codex 完成 canvas-first 接线、真浏览器验证和判别变异，Kimi 复审。
 
-本轮没有启动 C1/C2 以后功能，没有开启任何 flag，也没有接触审批运行时
-服务。下一步必须先审合 E1-b/E2，再由 owner 单独授权 C1；不得把本轮
-验证通过解释为整条编辑器已达到飞书/钉钉产品完成度。
+本轮尚未启动 C3-C5、F1-F3 及版本/试运行收口，没有开启任何 flag，也没有
+接触审批运行时服务。下一开发点为 C3 边 `+` 产品化与 F1 表单 palette；
+不得把 C2 验证通过解释为整条编辑器已达到飞书/钉钉产品完成度。

--- a/docs/development/approval-editor-flow-parity-development-plan-20260727.md
+++ b/docs/development/approval-editor-flow-parity-development-plan-20260727.md
@@ -1,0 +1,372 @@
+# 审批编辑器与流程编排对标开发计划（2026-07-27）
+
+**状态：PROPOSED，等待 owner 确认后执行**
+
+**核对基线：** `origin/main@d449aa7e6d02f94df2738a77cafffa778b12fde0`
+
+**范围：** 审批模板编辑器、表单设计器、流程画布、节点检查器、路由试运行、版本查看/比较/恢复、浏览器验收和灰度启用。
+
+**不在本计划内：** 修改审批运行时语义、自由连线白板、生产 flag 直接开启、真实租户 UAT 代执行、FWB/附件/钉钉凭据变更。
+
+本计划刷新而不替代以下文档：
+
+- `approval-canvas-v2-development-plan-20260720.md`
+- `approval-canvas-v2-interaction-design-lock-20260721.md`
+- `approval-automation-canvas-completion-closeout-verification-20260722.md`
+
+旧文档分别记录目标合同、早期执行分解和基础工程收口。本计划只排列当前 `main` 上仍未完成的产品化差距，不把已落地能力重新开发，也不把“已合入、CI 绿、flag OFF、UAT 未做”混写成同一状态。
+
+---
+
+## 1. 产品目标
+
+普通业务管理员无需接触 JSON、字段 ID、边 key 或原始成员 ID，即可在一个编辑工作区完成：
+
+1. 从控件面板添加并排序表单字段；
+2. 在垂直流程画布上配置线性、条件和并行流程；
+3. 点击节点，在同一检查器中配置审批人、审批方式、字段权限、条件优先级和并行汇聚方式；
+4. 用边上的 `+` 插入节点，也可把字段或节点拖到合法语义槽位；
+5. 对代表性表单数据执行真实路由试运行；
+6. 保存草稿、发布版本、查看历史差异并恢复为新草稿；
+7. 在桌面、紧凑桌面和窄屏上完成等价操作；
+8. 保留结构化辅助编辑入口，直到键盘和辅助技术等价性有真实浏览器证据。
+
+对标目标是飞书/钉钉的核心创作闭环和可理解性，不是复制视觉皮肤。飞书管理员手册描述的中部流程设计区和边上 `+` 添加审批人、抄送人、办理人、条件分支，是本计划的最低交互基线；MetaSheet 保留更严格的语义拖拽、版本恢复和审批数据写回差异化能力。
+
+参考：
+
+- [飞书审批管理员手册](https://www.feishu.cn/hc/zh-CN/articles/360033971554-%E9%A3%9E%E4%B9%A6%E5%AE%A1%E6%89%B9%E7%AE%A1%E7%90%86%E5%91%98%E6%89%8B%E5%86%8C)
+- [钉钉 OA 审批业务控件](https://open.dingtalk.com/document/dashboard/oa-approval-business-controls-overview)
+
+---
+
+## 2. 当前实现对账
+
+### 2.1 已完成，禁止重建
+
+| 能力 | 当前证据 | 本计划处置 |
+|---|---|---|
+| 审批图业务模型 | `ApprovalGraph` + 后端 `normalizeApprovalGraph` | 保持唯一权威，不引入第二份画布模型 |
+| 条件/并行拓扑 | `graphTopologyEdit.ts`、`parallelEdit.ts` | 只改善交互，不改运行时语义 |
+| 语义移动/分支排序/逆操作代数 | `approvalCanvasCommands.ts`（577 行） | 接入 UI 和统一历史，不重写算法 |
+| 表单增删排序与依赖保护 | `approvalFormCommands.ts`（521 行） | 接入 palette/键盘/拖拽，不另造命令层 |
+| 确定性布局、缩放、适应画布、缩略图 | `graphLayout.ts`、`canvasViewport.ts`、`TemplateAuthoringView.vue` | 作为 renderer 输入和回归基线 |
+| 复杂图画布和右侧节点配置 | `TemplateAuthoringView.vue` + `ApprovalGraphNodeConfigEditor.vue` | 抽组件并产品化，不复制配置逻辑 |
+| 路由试运行 | 既有 template-author dry-run 和 stale-result guard | 迁入统一检查器，不新建 preview 服务 |
+| 版本读取、差异、恢复 | `TemplateDetailView.vue`、`templateVersionDiff.ts`、`restoreTemplateVersion` | 保留安全合同，只升级呈现 |
+| 安全恢复语义 | 恢复创建新草稿；`expectedLatestVersionId` 并发保护；运行实例继续 pin 历史版本 | 必须持续有真实 API/DB 回归 |
+| FWB 和附件底座 | 已落 `main`，独立 flag 和独立验收 | 只做编辑器兼容回归，不借 Canvas flag 开启 |
+
+### 2.2 已部分完成，不能宣称对标完成
+
+| 用户面 | 当前 `main` | 对标差距 |
+|---|---|---|
+| 信息架构 | 左侧“基础/表单/流程/发布”四步导航 | 表单与流程不是同一工作区内的直接模式切换 |
+| 线性流程 | 旧步骤卡片 + 只读横向脊柱 | 新模板默认看不到真正流程画布 |
+| 复杂流程 | flag ON 后可切换列表/画布；默认 `list` | 未做到 canvas-first |
+| 节点操作 | 节点内上移/下移/移动/插入/删除按钮群 | 应改为边 `+`、上下文菜单和检查器动作 |
+| 拖拽 | 审批/抄送节点可移入合法边槽 | 缺合法槽持续高亮、统一拖拽状态机和分支拖排 UI |
+| 撤销/重做 | 命令层有逆操作/历史类型 | 顶栏未挂载统一 undo/redo |
+| 表单设计 | 已有字段拖排；新增字段靠“添加字段”按钮 | 缺控件 palette 拖入、字段插入槽和字段检查器 |
+| 检查器 | 复杂画布已有右侧检查器 | 线性流程、字段、版本差异未统一；窄屏不是正式 bottom sheet |
+| 版本比较 | 表格历史 + 变化列表 + 单画布 overlay | 缺编辑器内时间线、双画布并排和 before/after 检查器 |
+| 可访问性 | 部分按钮/键盘事件和结构列表 fallback | 缺完整键盘创作、live region、焦点恢复和真实浏览器证明 |
+| 浏览器验收 | 主要为 Vitest/jsdom 和真库 API | 没有审批编辑器 Playwright 视觉/交互矩阵 |
+| 文件边界 | `TemplateAuthoringView.vue` 3732 行/约 150 KB | 热文件继续叠功能会扩大回归和并行冲突 |
+| feature flag | `approvalCanvasV2` 默认 `false` | 未经 staging UAT，不得开启生产 |
+
+### 2.3 状态纪律
+
+1. `approval-canvas-v2-interaction-design-lock-20260721.md` 的仓内状态仍写 `PROPOSED`。本计划不把历史实现合入自动解释为整份锁已 ratify。
+2. 进入 E2 以前，owner 需要确认剩余交互方向：canvas-first、结构化辅助模式保留、边 `+`、统一 undo/redo、表单 palette、版本双画布。
+3. 每一项必须分别记录：设计状态、代码状态、CI 状态、合入状态、部署状态、UAT 状态、flag 状态。
+
+---
+
+## 3. 目标架构
+
+```mermaid
+flowchart LR
+  API["Template API"] --> Draft["Approval draft"]
+  Draft --> Graph["ApprovalGraph"]
+  Graph --> Adapter["Canvas render adapter"]
+  Adapter --> Canvas["ApprovalFlowCanvas"]
+  Canvas --> Intent["Typed user intent"]
+  Intent --> Commands["ApprovalCanvasCommands"]
+  Commands --> Graph
+  Draft --> Form["ApprovalFormBuilder"]
+  Form --> FormCommands["ApprovalFormCommands"]
+  FormCommands --> Draft
+  Canvas --> Inspector["Unified inspector"]
+  Form --> Inspector
+  Draft --> Preview["Existing route preview"]
+  Draft --> Save["Save / publish"]
+  Save --> Normalize["Backend normalizeApprovalGraph"]
+  Normalize --> Version["Immutable version"]
+  Version --> History["Version timeline / diff / restore"]
+```
+
+### 3.1 组件边界
+
+- `TemplateAuthoringView.vue`：路由、加载、保存/发布、权限和全局草稿协调；不再承载具体画布和字段编辑 DOM。
+- `ApprovalAuthoringShell.vue`：顶栏、表单/流程切换、状态、undo/redo、试运行和版本入口。
+- `ApprovalFlowCanvas.vue`：选择、焦点、viewport、插入槽、拖拽会话、live region；不直接改图。
+- `ApprovalFlowNode.vue` / `ApprovalFlowEdge.vue`：业务摘要和交互外壳；不下沉业务校验。
+- `ApprovalFlowInspector.vue`：节点/分支/字段/全局检查；复用现有 `ApprovalGraphNodeConfigEditor`。
+- `ApprovalFormBuilder.vue`：控件 palette、字段序列、插入槽和字段检查器；调用 `approvalFormCommands.ts`。
+- `ApprovalVersionWorkspace.vue`：历史时间线、双画布比较、before/after 检查器和恢复预览。
+- `approvalCanvasCommands.ts` / `approvalFormCommands.ts`：唯一写命令入口；renderer 不复制拓扑规则。
+
+### 3.2 Renderer 决策
+
+E1 spike 只允许以下两种结果：
+
+1. **Vue Flow 负责渲染/交互，继续使用现有 `computeLayout` 提供确定性坐标。** 这是首选验证路径，可避免立即引入约 427 KB gzip 且带 EPL/GPL 许可选择的 ELK。
+2. **保留现有 renderer，但必须证明全部 V 系列验收、100 节点性能、键盘焦点和边槽命中。**
+
+E1 不得默认引入 ELK。只有现有布局在构造的条件/并行/长标签/100 节点 fixture 上失败，且 owner 接受 bundle 与许可证后，才能单独提案 lazy-loaded ELK。
+
+---
+
+## 4. 执行切片和合入顺序
+
+每行默认一个 PR。除 E0/E1/U0 外，前置依赖必须先进入 `main`，不得长期 stacked 在未审热文件上。
+
+| ID | 工作 | 主要输出 | 前置 | 模型主责 | 必过门 |
+|---|---|---|---|---|---|
+| E0 | exact-head 全链审阅和状态对账 | 代码/设计锁/flag/旧 PR 清单；截取当前 UI 基线；不改产品代码 | 无 | Codex；Claude Opus 对抗复核 | A0 |
+| E1 | renderer + 视觉 spike | Vue Flow+现有布局与现 renderer 对照；1440/1024/390 原型；bundle/a11y/100 节点数据 | E0 的 fixture/约束清单 | Kimi K3 视觉；Grok spike；Codex裁决 | A1 |
+| E2 | 热文件无行为抽取 | 拆 `TemplateAuthoringView` 为 shell/form/flow/inspector 边界；DOM、payload、flag OFF 字节等价 | E0 | Sonnet 5；Codex复核 | A2 |
+| C1 | 统一线性/复杂图适配 | 线性草稿派生为画布 render model；未编辑保存 round-trip 等价；不持久化坐标 | E2 | Grok；Claude Opus图不变量复核 | C1 |
+| C2 | canvas-first 工作区 | flag ON 默认画布；表单/流程 segmented control；结构列表保留为“辅助编辑模式” | C1,E1 | Grok + Kimi K3视觉复核 | C2 |
+| C3 | 边 `+` 和插入菜单 | 所有合法边槽可点/键盘插入；菜单只列合法节点类型；节点按钮群移除 | C2 | Grok | C3 |
+| C4 | 语义拖拽和分支排序 | 节点/条件优先级/并行分支拖排；合法槽高亮；非法落点 no-op + live message | C3 | Grok；Claude Opus命令复核 | C4 |
+| C5 | 统一 undo/redo | 顶栏按钮、快捷键、选择/焦点恢复；Canvas 和 inspector 共用一条历史 | C4 | Grok；Codex复核 | C5 |
+| F1 | 表单组件抽取和 palette | 控件面板点击/拖入、字段插入槽、拖排/键盘等价；复用表单命令层 | E2 | Sonnet 5抽取；Grok交互；Kimi K3视觉 | F1 |
+| F2 | 字段检查器与引用保护 | 字段属性、选项、明细、显隐、record-link；移动/删除依赖明确拒绝或保留 | F1 | Grok；Codex数据合同复核 | F2 |
+| F3 | 附件 authoring 兼容 | 仅在附件运行时锁和 flag 条件满足时向 palette 开放；旧模板/flag OFF 不变 | F2 | Grok；Claude Opus安全复核 | F3 |
+| V1 | 版本入口整合 | 编辑器顶栏版本时间线、发布说明和当前草稿；复用现有 API | E2 | Sonnet 5 | V1 |
+| V2 | 双画布 diff + 恢复预览 | 左历史/右当前、同步缩放、文字+轮廓变化、before/after inspector | V1,C2 | Grok + Kimi K3；Codex复核 | V2 |
+| P1 | 试运行整合 | 既有 route-preview 嵌入检查器；结果高亮真实画布；stale guard 不变 | C2 | Sonnet 5；Codex复核 | P1 |
+| X1 | 响应式和可访问性 | 360/320 检查器、390 bottom sheet、键盘全路径、focus return、live region | C3,F1,V2 | Grok + Kimi K3 | X1 |
+| T1 | 浏览器验收和 required CI | Playwright 三 viewport、视觉/DOM测量、键盘构建、100节点、旧图 round-trip、flag OFF | C5,F2,V2,P1,X1 | Grok测试；Codex最终 gate | T1 |
+| U0 | staging UAT 与 canary | 基线截图、任务脚本、缺陷分诊、回滚演练；不直接开生产 | T1 | Codex协调；owner执行真实租户动作 | U0 |
+| D0 | 三份收口文档 | 设计锁 delta、执行台账、收尾验证 MD；逐项列明未完成 owner 门 | U0 | Fable 5起草；Codex定稿 | D0 |
+
+### 4.1 依赖图
+
+```mermaid
+flowchart TD
+  E0 --> E1
+  E0 --> E2
+  E2 --> C1 --> C2 --> C3 --> C4 --> C5
+  E1 --> C2
+  E2 --> F1 --> F2 --> F3
+  E2 --> V1
+  V1 --> V2
+  C2 --> V2
+  C2 --> P1
+  C3 --> X1
+  F1 --> X1
+  V2 --> X1
+  C5 --> T1
+  F2 --> T1
+  V2 --> T1
+  P1 --> T1
+  X1 --> T1
+  T1 --> U0 --> D0
+```
+
+### 4.2 可并行车道
+
+- **Wave 0：** E0 代码审阅与 Kimi K3 视觉研究可并行。E0 先交付 graph fixture/约束清单，Grok 才启动 E1 renderer spike；E0 的其余状态审计可继续并行。E1 只产隔离原型和数据，不做产品提交。
+- **Wave 1：** E2 单独占有 `TemplateAuthoringView.vue`。这一波不允许第二个模型同时修改该文件。
+- **Wave 2：** C1/C2 串行；F1 与 V1 可在 E2 合入后并行，因为分别拥有 form 与 version 组件。
+- **Wave 3：** C3-C5 串行；F2 和 V2 可并行；P1 在 C2 后独立进行。
+- **Wave 4：** X1 在各交互面稳定后统一收口；T1 不得由实现模型自判通过。
+- **Wave 5：** U0 和 D0 串行；UAT 失败返回对应切片，不在收尾文档里豁免。
+
+### 4.3 热文件所有权
+
+| 文件/边界 | 同时 owner 数 | 规则 |
+|---|---:|---|
+| `TemplateAuthoringView.vue` | 1 | E2 抽取期间独占；之后原则上只留协调改动 |
+| `approvalCanvasCommands.ts` | 1 | C3-C5 共用一个实现 owner；审阅模型只读 |
+| `approvalFormCommands.ts` | 1 | F1-F2 共用一个实现 owner |
+| `ApprovalGraphNodeConfigEditor.vue` | 1 | Canvas inspector 与辅助列表复用，不复制 |
+| `TemplateDetailView.vue` / version API | 1 | V1 先抽取，V2 不与其并行改同一文件 |
+| `ApprovalProductService.ts` / `ApprovalGraphExecutor.ts` | 1 | 本计划原则上不修改；一旦需要运行时语义立即停线并另立锁 |
+
+---
+
+## 5. 模型编排
+
+### Codex
+
+- 总体协调、exact-head 事实核对、依赖/热文件控制、最终代码审阅和验收裁决；
+- 所有涉及 `ApprovalGraph`、权限、版本恢复、payload round-trip 的最终签字；
+- 不以其他模型的“测试通过”代替读取运行列表、失败注入和 exact SHA。
+
+### Claude Opus 4.8
+
+- 只读对抗审阅：图不变量、命令逆操作、权限、历史恢复、旧图兼容；
+- 构造反例，不担任同一切片的主要实现者；
+- 使用 Goal 模式时目标固定为“找出可反驳当前交付声明的最小反例”，不得自动合并或开启 flag。
+
+### Grok
+
+- 主要前端实现、拖拽状态机、Vue Flow/renderer spike、Playwright；
+- 每个实现任务必须给出 exact files、禁止运行时变更、必跑测试和停止条件；
+- 产物由 Codex 逐文件复核，不接受只给截图或测试数字。
+
+### Kimi K3
+
+- 视觉 IA、节点/边/检查器/表单 palette/版本 diff 原型和截图批评；
+- 不决定 graph schema、权限或持久化合同；
+- 每轮只提交视觉规格或隔离原型，不直接改安全/运行时文件。
+
+### Sonnet 5
+
+- 低风险组件抽取、类型迁移、现有功能搬迁和 version/form 中等复杂度实现；
+- 不单独负责并发、权限或拓扑算法。
+
+### Fable 5
+
+- 执行台账、测试证据整理、最终 MD 初稿；
+- 不把文档声明当作代码完成证据；不可自 ratify。
+
+---
+
+## 6. 验收门
+
+### A0：事实基线
+
+- 当前 `origin/main`、feature flag 默认值、相关开放/已吸收 PR、设计锁状态全部记录；
+- 1440×900、1024×768、390×844 当前页面截图齐全；
+- 任何“已完成”结论都能落到文件/测试/运行态证据。
+
+### A1：renderer 决策
+
+- 相同 graph 和 viewport 连续两次坐标一致；
+- condition/parallel 顺序不漂移，边不穿卡；
+- 100 节点混合图可交互，记录渲染时间和 bundle 增量；
+- 键盘焦点、edge `+`、drag slot 均可实现；
+- license 清单明确。未过即停，不进入 C2。
+
+### A2：无行为抽取
+
+- flag OFF 的 DOM、API payload 和保存/发布行为与抽取前等价；
+- 旧图加载后不编辑直接保存，规范化 graph 等价；
+- 原有 required web tests 不删不弱化。
+
+### C1-C5：画布
+
+- 线性、条件、并行均从同一画布进入，不因图形复杂度切换产品；
+- 所有写操作走 typed command；renderer 中零拓扑业务逻辑；
+- 边插入、拖拽、键盘、上下文菜单产生同一规范化 graph；
+- cycle/orphan/非法 fork-join/nested parallel 在变更前拒绝，graph 零部分修改；
+- move→undo 和 reorder→undo 恢复 graph、selection 和 focus；
+- 结构列表在 S12 以前仍可到达，但不再是默认入口。
+
+### F1-F3：表单
+
+- 每种可编辑字段可由点击和拖入添加，结果一致；
+- 字段移动不改变 ID，不静默改写 visibility/condition/assignee/permission/FWB 引用；
+- 删除有依赖字段明确列出业务名称并拒绝或确认迁移，不显示 raw ID；
+- attachment 只有独立 flag ON 且后端合同可用时可创建；OFF 时旧行为不变。
+
+### V1-V2：版本
+
+- 发布版本不可变，运行实例继续解析原 pinned version；
+- 恢复永远创建新草稿，历史版本不被 UPDATE；
+- 并发恢复以 `expectedLatestVersionId` fail closed；
+- 无权限用户无法从 list/detail/diff/restore 的错误、数量或时间差推断版本存在；
+- 双画布 added/removed/changed/moved 都有文字，不只用颜色。
+
+### T1：浏览器和 CI
+
+- Chromium 真浏览器完成：添加字段→条件→并行→审批人→试运行→保存→发布→比较→恢复；
+- 1440、1024、390 三 viewport 无重叠、无页面横向滚动、文字不溢出；
+- 键盘独立完成线性+条件+并行创作；
+- 100 节点 fixture 无卡片相交、无边穿卡，操作延迟有阈值；
+- network capture 证明 payload 无坐标、无 renderer 状态；
+- Playwright spec 进入 required CI；path filter 同时覆盖组件、命令层、layout、version 文件；
+- positive control 证明测试真正挂载并操作了画布，而不是 skip-green。
+
+---
+
+## 7. UAT 任务
+
+U0 至少包含以下 12 项，全部保存截图、录屏或网络/数据库证据：
+
+1. 新建线性审批并发布；
+2. 从控件 palette 拖入文本、日期、选项、人员和关联记录；
+3. 添加条件分支，验证优先级和默认分支；
+4. 添加并行分支，分别验证 `all` 和 `any`；
+5. 移动审批/抄送节点到合法边槽；
+6. 向非法槽位拖动，确认 graph 和保存 payload 不变；
+7. undo/redo 恢复结构、配置和焦点；
+8. 用真实成员/角色/部门来源试运行；
+9. 发布 v1，修改后发布 v2，查看业务化差异；
+10. 将 v1 恢复为新草稿，确认 v1/v2 和运行中实例不变；
+11. 390 宽度完成插入、配置和保存；
+12. 辅助编辑模式与画布保存同一 graph。
+
+结果分诊：
+
+- **产品代码缺陷：** 回对应切片修复并重跑该切片及下游；
+- **环境/账号/目录缺陷：** 记录值域无关证据，不修改产品代码掩盖；
+- **第三方依赖缺陷：** 保持 fail closed，单列 owner 决策；
+- **仅视觉偏差：** Kimi K3 复核后进入小型 polish PR，不和安全/拓扑修复混合。
+
+---
+
+## 8. Flag 与回滚
+
+1. `approvalCanvasV2` 继续默认 OFF。
+2. T1 通过后只允许 staging 单租户启用。
+3. staging 顺序：内部管理员模板 → 新模板 → 既有线性模板 → 既有复杂模板。
+4. 每一档观察保存失败、normalize 拒绝、客户端异常、UAT 任务完成率和回退次数。
+5. Canvas flag 只控制作者界面，绝不联动 FWB、附件、durable、Class A/B。
+6. 回滚为关闭 Canvas flag；数据层不得依赖 Canvas 专属坐标或状态，因此旧编辑器仍能读取同一 graph。
+7. 生产开启和结构化辅助入口退役均为独立 owner 决策；后者还需辅助技术等价证据和观察窗口。
+
+---
+
+## 9. 明确不做
+
+- 任意自由连线、自由坐标、保存画布位置；
+- 跨条件/并行区域的任意拖排；
+- 移动端原生流程编排应用；
+- 新 handler/processing 节点、组审批人、发起人自选审批人、表单部门→负责人等新运行时语义；
+- 在本计划内开放 FWB number 映射；
+- 因 UI 对标而改变版本、权限、附件或 durable 的安全合同；
+- 在真实浏览器证据前移除结构化辅助编辑模式。
+
+上述能力如需开发，必须单独设计锁和验收，不得塞入 C/F/V 切片。
+
+---
+
+## 10. 文档交付
+
+执行中持续维护三份文档：
+
+1. **设计锁 delta**：只记录本计划相对 2026-07-21 锁的 owner 决策、renderer 选择和明确非目标；
+2. **执行台账**：每个 ID 的 PR、SHA、实现模型、复核模型、测试命令、CI URL、合入和 flag 状态；
+3. **收尾验证 MD**：merged-main exact SHA、浏览器证据、UAT、残余风险和 owner-only 开关。
+
+禁止在 T1/U0 前把文档状态写成 `FINAL`。正确中间状态为：
+
+`DESIGN RATIFIED` → `IMPLEMENTED` → `CI GREEN` → `MERGED` → `STAGING UAT PASS` → `PRODUCTION ENABLED`。
+
+---
+
+## 11. 首轮执行建议
+
+确认本计划后，只启动以下三项：
+
+1. **E0：** Codex 在独立 worktree 对当前 `origin/main` 做全链审阅和基线截图；
+2. **E1：** Kimi K3 出两套高保真 IA，Grok 做 Vue Flow+现有 layout 与现 renderer 的一次性 spike；
+3. **E2 准备：** Sonnet 5 只读给出 3732 行热文件的抽取边界，等 E0/E1 裁决后才提交代码。
+
+首轮不启动 C2 以后功能，不开启任何 flag，不接触审批运行时服务。这样先固定产品表面和 renderer，再并行实施，能最大限度避免在 3732 行热文件上重复返工。

--- a/docs/development/approval-editor-flow-parity-development-plan-20260727.md
+++ b/docs/development/approval-editor-flow-parity-development-plan-20260727.md
@@ -1,6 +1,6 @@
 # 审批编辑器与流程编排对标开发计划（2026-07-27）
 
-**状态：IN PROGRESS（E0 / E1 / E1-b / E2 / C1 / C2 / F1-a 已完成并形成待审 Draft PR；C3 以后及 F1-b / F2 / F3 仍在开发队列）**
+**状态：IN PROGRESS（E0 / E1 / E1-b / E2 / C1 / C2 / C3 / F1-a / F1-b 已完成并形成待审 Draft PR；C4 / C5 及 F2 / F3 仍在开发队列）**
 
 **事实审计基线：** `origin/main@d449aa7e6d02f94df2738a77cafffa778b12fde0`
 
@@ -64,12 +64,12 @@
 | 用户面 | 当前 `main` | 对标差距 |
 |---|---|---|
 | 信息架构 | C2 在 Canvas flag ON 时提供表单/流程直接模式切换 | shell、字段 builder 和版本工作区仍待继续拆分 |
-| 线性流程 | C1 派生统一 Canvas carrier；C2 默认进入流程画布 | 边 `+`、统一历史和拖拽反馈仍未产品化 |
-| 复杂流程 | flag ON 后默认 Canvas；结构视图保留为“辅助编辑模式” | 节点按钮群、分支拖排和 undo/redo 尚未收口 |
-| 节点操作 | 节点内上移/下移/移动/插入/删除按钮群 | 应改为边 `+`、上下文菜单和检查器动作 |
+| 线性流程 | C1 派生统一 Canvas carrier；C2 默认进入流程画布；C3 提供边 `+` 插入 | 统一历史、拖拽反馈和上下文操作仍未产品化 |
+| 复杂流程 | flag ON 后默认 Canvas；结构视图保留为“辅助编辑模式”；C3 仅向合法边提供插入菜单 | 分支拖排和 undo/redo 尚未收口 |
+| 节点操作 | C3 已移除节点卡内插入按钮群，审批/抄送/条件/并行改由边 `+` 插入 | 上下文菜单、删除/移动动作和统一历史仍待 C4/C5 |
 | 拖拽 | 审批/抄送节点可移入合法边槽 | 缺合法槽持续高亮、统一拖拽状态机和分支拖排 UI |
 | 撤销/重做 | 命令层有逆操作/历史类型 | 顶栏未挂载统一 undo/redo |
-| 表单设计 | F1-a 已提供全字段 palette 点击/拖入、显式插入槽、handle 拖排及键盘/触屏等价入口 | 独立 builder、聚焦字段的右侧属性检查器及附件 authoring 仍未完成 |
+| 表单设计 | F1-a 提供全字段 palette；F1-b 已形成左 palette + 中画布 + 右侧聚焦字段检查器 | 完整命令层引用保护与附件 authoring 仍未完成 |
 | 检查器 | 复杂画布已有右侧检查器 | 线性流程、字段、版本差异未统一；窄屏不是正式 bottom sheet |
 | 版本比较 | 表格历史 + 变化列表 + 单画布 overlay | 缺编辑器内时间线、双画布并排和 before/after 检查器 |
 | 可访问性 | 部分按钮/键盘事件和结构列表 fallback | 缺完整键盘创作、live region、焦点恢复和真实浏览器证明 |
@@ -203,7 +203,23 @@ ON 时，全部当前可编辑字段类型可点击或原生拖入显式插入�
 会话一致，外来、缺失或错配 payload 均 no-op；只读和 flag OFF 保持旧行为。
 删除后新增字段使用最小可用 `field_N`，不会因编号空隙产生重复 ID。Draft
 PR #4657 依赖 #4652，required CI 已全绿；尚未 merge、部署或开启 flag。
-F1-b 的独立 builder 和右侧聚焦字段检查器仍未完成。
+F1-b 已在 F1-a head 上抽出独立 `ApprovalFormBuilder` 与
+`ApprovalFieldInspector`。Canvas flag ON 时形成左 palette、中字段画布、
+右侧聚焦属性检查器；字段拖入、点击插入、handle-only 拖排、
+`Alt+ArrowUp/Down` 和插入槽继续复用 F1-a 的 typed payload 及草稿载体。
+flag OFF 保留原全字段编辑列表。真实 Chromium 在 1440 / 1024 / 390
+验证桌面三栏、平板两栏加下方 inspector、手机单列；拖入日期后字段数
+`3 -> 4`，右侧改名即时写回，builder 横向溢出和 console error 均为 0。
+Draft PR #4696（`93a9527f2`）依赖 #4657；尚未 merge、部署或开启 flag。
+
+C3 已在 C2 head 上把节点卡内插入按钮群迁移为每条合法边上的 40x40
+`+` 控件。菜单只提供当前上下文合法的审批、抄送、条件和并行节点，渲染层
+只发 typed intent，结构写入仍由纯 topology command 完成。Codex 独立复核
+发现并修复两处 fail-closed 漂移：合法的无显式 default 条件图不应被误锁；
+并行图必须证明每条分支路径汇聚到配置 join，才显示插入控件。required Web
+Tests 为 360 文件 / 4335 测试，生产 build 和真 Chromium 插入 `4 -> 5`
+节点均通过。Draft PR #4697（`525915d3d`）依赖 #4652；尚未 merge、部署或
+开启 flag。
 
 ### 4.1 依赖图
 
@@ -426,9 +442,10 @@ U0 至少包含以下 12 项，全部保存截图、录屏或网络/数据库证
 1. **E0：完成。** Codex exact-head 审阅，Claude Opus 只读对抗复核；
 2. **E1 / E1-b：完成。** Kimi 提供视觉 IA，Grok 构建隔离 renderer 和生产命令适配验证，Codex 复核与变异；
 3. **E2 / C1 / C2：完成待审。** Claude 负责 shell 与统一 carrier，Codex 完成 canvas-first 接线、真浏览器验证和判别变异，Kimi 复审；
-4. **F1-a：完成待审。** Codex 完成 palette、插入槽、handle-only 拖排、键盘/触屏等价和唯一字段 ID 修复，多代理对抗复核后 required CI 全绿。
+4. **F1-a / F1-b：完成待审。** Codex 完成 palette、三栏 builder/inspector、插入槽、handle-only 拖排、键盘/触屏等价和唯一字段 ID 修复；
+5. **C3：完成待审。** 子代理实现边 `+`，Codex exact-source 复核后修正 condition default 与 parallel join 两处合法性守卫，并重跑 required Web Tests、生产 build 和真浏览器。
 
-本轮尚未启动 C3-C5、F1-b/F2/F3 及版本/试运行收口，没有开启任何 flag，
-也没有接触审批运行时服务。下一开发点为 C3 边 `+` 产品化，并行推进
-F1-b 表单 builder/右侧字段检查器；不得把 F1-a 的拖入能力解释为整条
-编辑器已达到飞书/钉钉产品完成度。
+本轮尚未启动 C4/C5、F2/F3 及版本/试运行收口，没有开启任何 flag，也没有
+接触审批运行时服务。下一开发点为 C4 语义拖拽/分支排序与 C5 undo/redo，
+并行推进 F2 引用保护、F3 附件 authoring；不得把 C3/F1-b 的交互完成解释为
+整条编辑器已达到飞书/钉钉产品完成度。

--- a/docs/development/approval-editor-flow-parity-development-plan-20260727.md
+++ b/docs/development/approval-editor-flow-parity-development-plan-20260727.md
@@ -1,6 +1,6 @@
 # 审批编辑器与流程编排对标开发计划（2026-07-27）
 
-**状态：IN PROGRESS（E0 / E1 / E1-b / E2 / C1 / C2 已完成并形成待审 Draft PR；C3 以后及 F1-F3 仍在开发队列）**
+**状态：IN PROGRESS（E0 / E1 / E1-b / E2 / C1 / C2 / F1-a 已完成并形成待审 Draft PR；C3 以后及 F1-b / F2 / F3 仍在开发队列）**
 
 **事实审计基线：** `origin/main@d449aa7e6d02f94df2738a77cafffa778b12fde0`
 
@@ -69,7 +69,7 @@
 | 节点操作 | 节点内上移/下移/移动/插入/删除按钮群 | 应改为边 `+`、上下文菜单和检查器动作 |
 | 拖拽 | 审批/抄送节点可移入合法边槽 | 缺合法槽持续高亮、统一拖拽状态机和分支拖排 UI |
 | 撤销/重做 | 命令层有逆操作/历史类型 | 顶栏未挂载统一 undo/redo |
-| 表单设计 | 已有字段拖排；新增字段靠“添加字段”按钮 | 缺控件 palette 拖入、字段插入槽和字段检查器 |
+| 表单设计 | F1-a 已提供全字段 palette 点击/拖入、显式插入槽、handle 拖排及键盘/触屏等价入口 | 独立 builder、聚焦字段的右侧属性检查器及附件 authoring 仍未完成 |
 | 检查器 | 复杂画布已有右侧检查器 | 线性流程、字段、版本差异未统一；窄屏不是正式 bottom sheet |
 | 版本比较 | 表格历史 + 变化列表 + 单画布 overlay | 缺编辑器内时间线、双画布并排和 before/after 检查器 |
 | 可访问性 | 部分按钮/键盘事件和结构列表 fallback | 缺完整键盘创作、live region、焦点恢复和真实浏览器证明 |
@@ -144,8 +144,9 @@ E1 不得默认引入 ELK。只有现有布局在构造的条件/并行/长标�
 | C3 | 边 `+` 和插入菜单 | 所有合法边槽可点/键盘插入；菜单只列合法节点类型；节点按钮群移除 | C2 | Grok | C3 |
 | C4 | 语义拖拽和分支排序 | 节点/条件优先级/并行分支拖排；合法槽高亮；非法落点 no-op + live message | C3 | Grok；Claude Opus命令复核 | C4 |
 | C5 | 统一 undo/redo | 顶栏按钮、快捷键、选择/焦点恢复；Canvas 和 inspector 共用一条历史 | C4 | Grok；Codex复核 | C5 |
-| F1 | 表单组件抽取和 palette | 左侧控件库点击/拖入、中部真实表单画布与字段插入槽、拖排/键盘等价、右侧字段属性检查器；复用表单命令层 | E2 | Sonnet 5抽取；Grok交互；Kimi K3视觉 | F1 |
-| F2 | 字段检查器与引用保护 | 字段属性、选项、明细、显隐、record-link；移动/删除依赖明确拒绝或保留 | F1 | Grok；Codex数据合同复核 | F2 |
+| F1-a | 表单 palette 和插入/移动交互 | 全字段控件库点击/拖入、显式插入槽、handle-only 拖排、键盘/触屏等价；复用现有草稿写路径 | E2,C2 | Codex实现；多代理对抗复核 | F1-a |
+| F1-b | 表单 builder 抽取和三栏工作区 | 抽出 `ApprovalFormBuilder`；左 palette、中表单、右侧聚焦字段属性检查器；旧路径和 flag OFF 等价 | F1-a | Sonnet 5抽取；Kimi K3视觉；Codex复核 | F1-b |
+| F2 | 字段检查器与引用保护 | 字段属性、选项、明细、显隐、record-link；移动/删除依赖明确拒绝或保留 | F1-b | Grok；Codex数据合同复核 | F2 |
 | F3 | 附件 authoring 兼容 | 仅在附件运行时锁和 flag 条件满足时向 palette 开放；旧模板/flag OFF 不变 | F2 | Grok；Claude Opus安全复核 | F3 |
 | V1 | 版本入口整合 | 编辑器顶栏版本时间线、发布说明和当前草稿；复用现有 API | E2 | Sonnet 5 | V1 |
 | V2 | 双画布 diff + 恢复预览 | 左历史/右当前、同步缩放、文字+轮廓变化、before/after inspector | V1,C2 | Grok + Kimi K3；Codex复核 | V2 |
@@ -195,6 +196,15 @@ C2 已在 C1 head 上完成 canvas-first 工作区。Canvas flag ON 时，线性
 P1/P2。Draft PR #4652 依赖 #4649，required CI 已全绿；未 merge、部署或
 开启 flag。
 
+F1-a 已在 C2 head 上完成表单控件 palette 与插入/移动交互。Canvas flag
+ON 时，全部当前可编辑字段类型可点击或原生拖入显式插入槽；字段本体不再
+整体可拖，只有拖拽把手启动移动会话，且键盘 `Alt+ArrowUp/Down` 与触屏/
+键盘可选择的插入槽提供等价路径。typed drag payload 必须与当前本地拖拽
+会话一致，外来、缺失或错配 payload 均 no-op；只读和 flag OFF 保持旧行为。
+删除后新增字段使用最小可用 `field_N`，不会因编号空隙产生重复 ID。Draft
+PR #4657 依赖 #4652，required CI 已全绿；尚未 merge、部署或开启 flag。
+F1-b 的独立 builder 和右侧聚焦字段检查器仍未完成。
+
 ### 4.1 依赖图
 
 ```mermaid
@@ -203,13 +213,14 @@ flowchart TD
   E0 --> E2
   E2 --> C1 --> C2 --> C3 --> C4 --> C5
   E1 --> C2
-  E2 --> F1 --> F2 --> F3
+  E2 --> F1a --> F1b --> F2 --> F3
+  C2 --> F1a
   E2 --> V1
   V1 --> V2
   C2 --> V2
   C2 --> P1
   C3 --> X1
-  F1 --> X1
+  F1b --> X1
   V2 --> X1
   C5 --> T1
   F2 --> T1
@@ -223,7 +234,7 @@ flowchart TD
 
 - **Wave 0：** E0 代码审阅与 Kimi K3 视觉研究可并行。E0 先交付 graph fixture/约束清单，Grok 才启动 E1 renderer spike；E0 的其余状态审计可继续并行。E1 只产隔离原型和数据，不做产品提交。
 - **Wave 1：** E2 单独占有 `TemplateAuthoringView.vue`。这一波不允许第二个模型同时修改该文件。
-- **Wave 2：** C1/C2 串行；F1 与 V1 可在 E2 合入后并行，因为分别拥有 form 与 version 组件。
+- **Wave 2：** C1/C2 串行；F1-a 已在 C2 head 完成；F1-b 与 V1 可在 F1-a/E2 合入后并行，因为分别拥有 form 与 version 组件。
 - **Wave 3：** C3-C5 串行；F2 和 V2 可并行；P1 在 C2 后独立进行。
 - **Wave 4：** X1 在各交互面稳定后统一收口；T1 不得由实现模型自判通过。
 - **Wave 5：** U0 和 D0 串行；UAT 失败返回对应切片，不在收尾文档里豁免。
@@ -234,7 +245,7 @@ flowchart TD
 |---|---:|---|
 | `TemplateAuthoringView.vue` | 1 | E2 抽取期间独占；之后原则上只留协调改动 |
 | `approvalCanvasCommands.ts` | 1 | C3-C5 共用一个实现 owner；审阅模型只读 |
-| `approvalFormCommands.ts` | 1 | F1-F2 共用一个实现 owner |
+| `approvalFormCommands.ts` | 1 | F1-a-F2 共用一个实现 owner |
 | `ApprovalGraphNodeConfigEditor.vue` | 1 | Canvas inspector 与辅助列表复用，不复制 |
 | `TemplateDetailView.vue` / version API | 1 | V1 先抽取，V2 不与其并行改同一文件 |
 | `ApprovalProductService.ts` / `ApprovalGraphExecutor.ts` | 1 | 本计划原则上不修改；一旦需要运行时语义立即停线并另立锁 |
@@ -310,7 +321,7 @@ flowchart TD
 - move→undo 和 reorder→undo 恢复 graph、selection 和 focus；
 - 结构列表在 S12 以前仍可到达，但不再是默认入口。
 
-### F1-F3：表单
+### F1-a-F3：表单
 
 - 每种可编辑字段可由点击和拖入添加，结果一致；
 - 字段移动不改变 ID，不静默改写 visibility/condition/assignee/permission/FWB 引用；
@@ -414,8 +425,10 @@ U0 至少包含以下 12 项，全部保存截图、录屏或网络/数据库证
 
 1. **E0：完成。** Codex exact-head 审阅，Claude Opus 只读对抗复核；
 2. **E1 / E1-b：完成。** Kimi 提供视觉 IA，Grok 构建隔离 renderer 和生产命令适配验证，Codex 复核与变异；
-3. **E2 / C1 / C2：完成待审。** Claude 负责 shell 与统一 carrier，Codex 完成 canvas-first 接线、真浏览器验证和判别变异，Kimi 复审。
+3. **E2 / C1 / C2：完成待审。** Claude 负责 shell 与统一 carrier，Codex 完成 canvas-first 接线、真浏览器验证和判别变异，Kimi 复审；
+4. **F1-a：完成待审。** Codex 完成 palette、插入槽、handle-only 拖排、键盘/触屏等价和唯一字段 ID 修复，多代理对抗复核后 required CI 全绿。
 
-本轮尚未启动 C3-C5、F1-F3 及版本/试运行收口，没有开启任何 flag，也没有
-接触审批运行时服务。下一开发点为 C3 边 `+` 产品化与 F1 表单 palette；
-不得把 C2 验证通过解释为整条编辑器已达到飞书/钉钉产品完成度。
+本轮尚未启动 C3-C5、F1-b/F2/F3 及版本/试运行收口，没有开启任何 flag，
+也没有接触审批运行时服务。下一开发点为 C3 边 `+` 产品化，并行推进
+F1-b 表单 builder/右侧字段检查器；不得把 F1-a 的拖入能力解释为整条
+编辑器已达到飞书/钉钉产品完成度。

--- a/docs/development/approval-editor-flow-parity-development-plan-20260727.md
+++ b/docs/development/approval-editor-flow-parity-development-plan-20260727.md
@@ -158,6 +158,13 @@ E0 已在 exact `origin/main@d449aa7e6d02f94df2738a77cafffa778b12fde0`
 `approval-editor-flow-parity-e0-audit-20260727.md`。该完成状态只关闭
 E0 审计任务，不改变本计划和历史交互锁的 `PROPOSED` / owner-gated 状态。
 
+E1 的隔离 DOM + SVG renderer feasibility spike 已完成，真 Chromium
+三 viewport 通过，100 节点两次布局确定且约 105ms，无新生产依赖。
+但 mutation 尚未接 `approvalCanvasCommands`，drag slot 和未编辑
+round-trip 尚未证明，因此 A1 记录为 `PARTIAL`，不得据此启动 C2 或开启
+Canvas flag。详见
+`approval-editor-flow-parity-e1-renderer-spike-verification-20260727.md`。
+
 ### 4.1 依赖图
 
 ```mermaid

--- a/docs/development/approval-editor-flow-parity-development-plan-20260727.md
+++ b/docs/development/approval-editor-flow-parity-development-plan-20260727.md
@@ -1,6 +1,6 @@
 # 审批编辑器与流程编排对标开发计划（2026-07-27）
 
-**状态：IN PROGRESS（仅 E0 / E1 / E1-b / E2 已获准并在隔离分支完成；C1 以后仍未授权）**
+**状态：IN PROGRESS（E0 / E1 / E1-b / E2 / C1 已完成并形成待审 Draft PR；C2 以后仍在开发队列）**
 
 **事实审计基线：** `origin/main@d449aa7e6d02f94df2738a77cafffa778b12fde0`
 
@@ -144,7 +144,7 @@ E1 不得默认引入 ELK。只有现有布局在构造的条件/并行/长标�
 | C3 | 边 `+` 和插入菜单 | 所有合法边槽可点/键盘插入；菜单只列合法节点类型；节点按钮群移除 | C2 | Grok | C3 |
 | C4 | 语义拖拽和分支排序 | 节点/条件优先级/并行分支拖排；合法槽高亮；非法落点 no-op + live message | C3 | Grok；Claude Opus命令复核 | C4 |
 | C5 | 统一 undo/redo | 顶栏按钮、快捷键、选择/焦点恢复；Canvas 和 inspector 共用一条历史 | C4 | Grok；Codex复核 | C5 |
-| F1 | 表单组件抽取和 palette | 控件面板点击/拖入、字段插入槽、拖排/键盘等价；复用表单命令层 | E2 | Sonnet 5抽取；Grok交互；Kimi K3视觉 | F1 |
+| F1 | 表单组件抽取和 palette | 左侧控件库点击/拖入、中部真实表单画布与字段插入槽、拖排/键盘等价、右侧字段属性检查器；复用表单命令层 | E2 | Sonnet 5抽取；Grok交互；Kimi K3视觉 | F1 |
 | F2 | 字段检查器与引用保护 | 字段属性、选项、明细、显隐、record-link；移动/删除依赖明确拒绝或保留 | F1 | Grok；Codex数据合同复核 | F2 |
 | F3 | 附件 authoring 兼容 | 仅在附件运行时锁和 flag 条件满足时向 palette 开放；旧模板/flag OFF 不变 | F2 | Grok；Claude Opus安全复核 | F3 |
 | V1 | 版本入口整合 | 编辑器顶栏版本时间线、发布说明和当前草稿；复用现有 API | E2 | Sonnet 5 | V1 |
@@ -174,7 +174,17 @@ E2 已在 `origin/main@9da0335b4` 的隔离分支完成第一刀无行为抽取�
 `ApprovalFlowCanvas.vue` 只接收派生 props 并发出 typed intents，业务状态、
 保存/发布和拓扑命令仍由父层拥有。13 个审批 authoring 测试文件
 247/247、ESLint、`vue-tsc` 通过；中和 drop intent 后拖放断言精确转红。
-状态仅为 `IMPLEMENTED + LOCAL VERIFIED`，尚未 push、CI、merge 或部署。
+修复静态 style 守卫误判后，Draft PR #4642 的 required CI 已全绿；尚未
+merge 或部署。
+
+C1 已在 E2 head 上完成线性/复杂流程统一载体。线性 Canvas inspector
+直接写现有 `ApprovalStepDraft`，只查看/切换画布不会生成 shadow carrier、
+不会置 dirty，也不会改变 save payload；首次拓扑编辑通过既有命令层
+promote 为 graph，并保留审批来源、ids、审批/空值/自审策略及字段权限。
+feature flag OFF 和 unsupported template 继续 fail-closed 回结构列表。
+Kimi exact-head 对抗复审为 APPROVE、无 P1/P2；其发现的 promote 后可继续
+删除最后审批节点边界已修复并由判别变异钉死。Draft PR #4649 依赖 #4642，
+尚未 merge、部署或开启 flag。
 
 ### 4.1 依赖图
 

--- a/docs/development/approval-editor-flow-parity-development-plan-20260727.md
+++ b/docs/development/approval-editor-flow-parity-development-plan-20260727.md
@@ -192,7 +192,7 @@ C2 已在 C1 head 上完成 canvas-first 工作区。Canvas flag ON 时，线性
 重新测量 viewport，避免 0x0 缩略图状态。真实 Chromium 在 1440 / 1024 /
 390 验证默认画布、表单往返、辅助模式和零横向溢出；四刀判别变异分别钉住
 默认模式、模式切换、viewport 重测和 ARIA group 语义。Kimi 对抗复审无
-P1/P2。Draft PR #4652 依赖 #4649；required CI 仍在运行，未 merge、部署或
+P1/P2。Draft PR #4652 依赖 #4649，required CI 已全绿；未 merge、部署或
 开启 flag。
 
 ### 4.1 依赖图

--- a/docs/development/approval-editor-flow-parity-development-plan-20260727.md
+++ b/docs/development/approval-editor-flow-parity-development-plan-20260727.md
@@ -1,6 +1,6 @@
 # 审批编辑器与流程编排对标开发计划（2026-07-27）
 
-**状态：IN PROGRESS（E0 / E1 / E1-b / E2 / C1 / C2 / C3 / F1-a / F1-b 已完成并形成待审 Draft PR；C4 / C5 及 F2 / F3 仍在开发队列）**
+**状态：IN PROGRESS（C4 与 F2 已实现并形成待审 Draft PR；C4 仍缺真浏览器证据，C5 / F3 仍在开发队列）**
 
 **事实审计基线：** `origin/main@d449aa7e6d02f94df2738a77cafffa778b12fde0`
 
@@ -64,12 +64,12 @@
 | 用户面 | 当前 `main` | 对标差距 |
 |---|---|---|
 | 信息架构 | C2 在 Canvas flag ON 时提供表单/流程直接模式切换 | shell、字段 builder 和版本工作区仍待继续拆分 |
-| 线性流程 | C1 派生统一 Canvas carrier；C2 默认进入流程画布；C3 提供边 `+` 插入 | 统一历史、拖拽反馈和上下文操作仍未产品化 |
-| 复杂流程 | flag ON 后默认 Canvas；结构视图保留为“辅助编辑模式”；C3 仅向合法边提供插入菜单 | 分支拖排和 undo/redo 尚未收口 |
-| 节点操作 | C3 已移除节点卡内插入按钮群，审批/抄送/条件/并行改由边 `+` 插入 | 上下文菜单、删除/移动动作和统一历史仍待 C4/C5 |
-| 拖拽 | 审批/抄送节点可移入合法边槽 | 缺合法槽持续高亮、统一拖拽状态机和分支拖排 UI |
+| 线性流程 | C1 派生统一 Canvas carrier；C2 默认进入流程画布；C3 提供边 `+` 插入；C4 接入语义拖拽 | 统一历史和上下文操作仍未产品化 |
+| 复杂流程 | flag ON 后默认 Canvas；结构视图保留为“辅助编辑模式”；C3 仅向合法边提供插入菜单；C4 接入条件/并行分支拖排 | undo/redo 尚未收口 |
+| 节点操作 | C3 已移除节点卡内插入按钮群；C4 的节点移动与分支排序共用 typed command seam | 上下文菜单和统一历史仍待 C5 |
+| 拖拽 | C4 已实现合法槽高亮、stale/cross-region no-op、values-free live message 和分支把手/键盘等价 | 真浏览器拖拽证据仍待 Browser 会话恢复后补齐 |
 | 撤销/重做 | 命令层有逆操作/历史类型 | 顶栏未挂载统一 undo/redo |
-| 表单设计 | F1-a 提供全字段 palette；F1-b 已形成左 palette + 中画布 + 右侧聚焦字段检查器 | 完整命令层引用保护与附件 authoring 仍未完成 |
+| 表单设计 | F1-a/F1-b 提供 palette 与三栏工作区；F2 已把增删移动接到命令层，并接后端历史 ID / FWB 引用权威 | 附件 authoring 仍未完成 |
 | 检查器 | 复杂画布已有右侧检查器 | 线性流程、字段、版本差异未统一；窄屏不是正式 bottom sheet |
 | 版本比较 | 表格历史 + 变化列表 + 单画布 overlay | 缺编辑器内时间线、双画布并排和 before/after 检查器 |
 | 可访问性 | 部分按钮/键盘事件和结构列表 fallback | 缺完整键盘创作、live region、焦点恢复和真实浏览器证明 |
@@ -220,6 +220,25 @@ C3 已在 C2 head 上把节点卡内插入按钮群迁移为每条合法边上�
 Tests 为 360 文件 / 4335 测试，生产 build 和真 Chromium 插入 `4 -> 5`
 节点均通过。Draft PR #4697（`525915d3d`）依赖 #4652；尚未 merge、部署或
 开启 flag。
+
+C4 已在 C3 head 上完成语义拖拽与分支排序。渲染层只发 node/branch drag
+intent，页面统一通过 `applyCanvasCommand` 接既有 command algebra；合法边槽
+在拖拽期间高亮，stale、非法与跨区域 payload 均 no-op，并仅返回 values-free
+live message。条件与并行分支的把手拖排、`Alt+Arrow` 和原按钮重排共用同一
+typed command。required Web 为 360 文件 / 4338 测试，类型与 production
+build 通过；Draft PR #4698（`c6f0b7bbc`）依赖 #4697。Codex In-app Browser
+本轮无法附着本地新标签页，因此真浏览器 drag/screenshot 仍是独立未闭合门，
+不得用 jsdom 或构建绿替代。
+
+F2 已在 F1-b head 上完成表单结构命令与后端权威接线。新增/删除/移动只经
+`approvalFormCommands`；新增字段使用不可复用 UUID identity，后端在
+REPEATABLE READ 只读事务内收集全部模板版本的顶层字段与明细列 ID，并以
+values-free 方式枚举停用/嵌套 FWB 引用。上下文缺失、错模板或成员格式异常时
+新增/删除 fail-closed，但无结构风险的重排保留；发布时在同一事务再次扫描
+FWB 引用并拒绝删除仍在使用的字段。前端 focused 105/105、后端 unit
+147/147、fresh PostgreSQL 15 全迁移真实服务器 8/8、required Web 359 文件 /
+4330 测试、两刀中和精确转红。Draft PR #4699（`4ccc20f71`）依赖 #4696；
+尚未 merge、部署或开启 flag。
 
 ### 4.1 依赖图
 
@@ -442,10 +461,10 @@ U0 至少包含以下 12 项，全部保存截图、录屏或网络/数据库证
 1. **E0：完成。** Codex exact-head 审阅，Claude Opus 只读对抗复核；
 2. **E1 / E1-b：完成。** Kimi 提供视觉 IA，Grok 构建隔离 renderer 和生产命令适配验证，Codex 复核与变异；
 3. **E2 / C1 / C2：完成待审。** Claude 负责 shell 与统一 carrier，Codex 完成 canvas-first 接线、真浏览器验证和判别变异，Kimi 复审；
-4. **F1-a / F1-b：完成待审。** Codex 完成 palette、三栏 builder/inspector、插入槽、handle-only 拖排、键盘/触屏等价和唯一字段 ID 修复；
-5. **C3：完成待审。** 子代理实现边 `+`，Codex exact-source 复核后修正 condition default 与 parallel join 两处合法性守卫，并重跑 required Web Tests、生产 build 和真浏览器。
+4. **F1-a / F1-b / F2：完成待审。** Codex 完成 palette、三栏 builder/inspector、命令接线、不可复用字段身份与后端历史/FWB 引用权威；
+5. **C3：完成待审。** 子代理实现边 `+`，Codex exact-source 复核后修正 condition default 与 parallel join 两处合法性守卫，并重跑 required Web Tests、生产 build 和真浏览器；
+6. **C4：代码与 CI 门完成，浏览器门未闭合。** 语义拖拽和分支排序已形成 Draft PR，真实 Browser 附着失败被保留为显式阻塞，未伪报视觉验收。
 
-本轮尚未启动 C4/C5、F2/F3 及版本/试运行收口，没有开启任何 flag，也没有
-接触审批运行时服务。下一开发点为 C4 语义拖拽/分支排序与 C5 undo/redo，
-并行推进 F2 引用保护、F3 附件 authoring；不得把 C3/F1-b 的交互完成解释为
-整条编辑器已达到飞书/钉钉产品完成度。
+本轮尚未启动 C5/F3 及版本/试运行收口，没有开启任何 flag。下一开发点为
+C5 统一 undo/redo 与 F3 附件 authoring；同时补 C4 真浏览器证据。不得把
+C4/F2 的实现完成解释为整条编辑器已达到飞书/钉钉产品完成度。

--- a/docs/development/approval-editor-flow-parity-development-plan-20260727.md
+++ b/docs/development/approval-editor-flow-parity-development-plan-20260727.md
@@ -1,6 +1,6 @@
 # 审批编辑器与流程编排对标开发计划（2026-07-27）
 
-**状态：IN PROGRESS（C4 与 F2 已实现并形成待审 Draft PR；C4 仍缺真浏览器证据，C5 / F3 仍在开发队列）**
+**状态：IN PROGRESS（C3-C5 与 F1-a-F3 已形成待审 Draft 栈；最终整合 PR #4702 本地门与 required CI 通过；T1 真浏览器、V1/V2、P1、X1 仍未闭合）**
 
 **事实审计基线：** `origin/main@d449aa7e6d02f94df2738a77cafffa778b12fde0`
 
@@ -64,13 +64,13 @@
 | 用户面 | 当前 `main` | 对标差距 |
 |---|---|---|
 | 信息架构 | C2 在 Canvas flag ON 时提供表单/流程直接模式切换 | shell、字段 builder 和版本工作区仍待继续拆分 |
-| 线性流程 | C1 派生统一 Canvas carrier；C2 默认进入流程画布；C3 提供边 `+` 插入；C4 接入语义拖拽 | 统一历史和上下文操作仍未产品化 |
-| 复杂流程 | flag ON 后默认 Canvas；结构视图保留为“辅助编辑模式”；C3 仅向合法边提供插入菜单；C4 接入条件/并行分支拖排 | undo/redo 尚未收口 |
-| 节点操作 | C3 已移除节点卡内插入按钮群；C4 的节点移动与分支排序共用 typed command seam | 上下文菜单和统一历史仍待 C5 |
+| 线性流程 | C1 派生统一 Canvas carrier；C2 默认进入流程画布；C3 提供边 `+` 插入；C4 接入语义拖拽；C5 接入统一历史 | 上下文菜单与 T1 真浏览器全路径仍未闭合 |
+| 复杂流程 | flag ON 后默认 Canvas；结构视图保留为“辅助编辑模式”；C3 仅向合法边提供插入菜单；C4 接入条件/并行分支拖排；C5 接入 undo/redo | 辅助入口等价证明、版本工作区和大图验收仍未完成 |
+| 节点操作 | C3 已移除节点卡内插入按钮群；C4 的节点移动与分支排序共用 typed command seam；C5 顶栏 undo/redo 恢复选择与焦点 | 上下文菜单与浏览器键盘全路径仍待 T1 |
 | 拖拽 | C4 已实现合法槽高亮、stale/cross-region no-op、values-free live message 和分支把手/键盘等价 | 真浏览器拖拽证据仍待 Browser 会话恢复后补齐 |
-| 撤销/重做 | 命令层有逆操作/历史类型 | 顶栏未挂载统一 undo/redo |
-| 表单设计 | F1-a/F1-b 提供 palette 与三栏工作区；F2 已把增删移动接到命令层，并接后端历史 ID / FWB 引用权威 | 附件 authoring 仍未完成 |
-| 检查器 | 复杂画布已有右侧检查器 | 线性流程、字段、版本差异未统一；窄屏不是正式 bottom sheet |
+| 撤销/重做 | C5 提供顶栏、快捷键、Canvas/节点检查器统一历史；#4702 将表单增删移动与字段属性也纳入同一 per-draft history | 辅助结构列表仍是回退入口；成功保存建立新历史边界，T1 仍需实测焦点 |
+| 表单设计 | F1-a/F1-b 提供 palette 与三栏工作区；F2 接命令层、历史 ID / FWB 引用权威；F3 按 Canvas+附件双 flag 开放附件控件 | 嵌套明细精确焦点、长表单性能和真浏览器全链仍待 T1/X1 |
+| 检查器 | 线性/复杂节点和字段已有受控检查器，所有字段写入由父层单一命令入口拥有 | 版本 before/after 检查器未整合；窄屏不是正式 bottom sheet |
 | 版本比较 | 表格历史 + 变化列表 + 单画布 overlay | 缺编辑器内时间线、双画布并排和 before/after 检查器 |
 | 可访问性 | 部分按钮/键盘事件和结构列表 fallback | 缺完整键盘创作、live region、焦点恢复和真实浏览器证明 |
 | 浏览器验收 | 主要为 Vitest/jsdom 和真库 API | 没有审批编辑器 Playwright 视觉/交互矩阵 |
@@ -239,6 +239,28 @@ FWB 引用并拒绝删除仍在使用的字段。前端 focused 105/105、后端
 147/147、fresh PostgreSQL 15 全迁移真实服务器 8/8、required Web 359 文件 /
 4330 测试、两刀中和精确转红。Draft PR #4699（`4ccc20f71`）依赖 #4696；
 尚未 merge、部署或开启 flag。
+
+F3 已在 F2 head 上完成附件 authoring 兼容。附件控件只有 Canvas V2 与附件
+authoring 两个 flag 同时开启才出现在 palette；任何已有附件字段在任一能力
+关闭时继续以 unsupported/read-only fail-closed，避免保存时静默丢字段。
+Draft PR #4700（`2cbbd539a`）依赖 #4699；required checks 3/3 PASS、merge
+state CLEAN，尚未 merge、部署或开启 flag。
+
+C5 已在 C4 head 上完成 Canvas 和节点检查器统一历史。顶栏 undo/redo、
+Cmd/Ctrl+Z、Cmd/Ctrl+Shift+Z、选择与焦点恢复均基于稳定业务 key；renderer
+仍只发 intent，不拥有历史或业务校验。Draft PR #4701（`a2dacd562`）依赖
+#4698；required checks 3/3 PASS、merge state CLEAN，尚未 merge、部署或
+开启 flag。
+
+最终组合 PR #4702（`7192a56fd`）把 C3/C4/C5 与 F1/F2/F3 组合验证，并关闭
+原锁 §7.1 的遗漏：表单新增、删除、移动和属性配置与 Canvas/节点检查器共用
+一条 per-draft history。字段组件改为受控输入，父 view 是唯一草稿写入口；
+undo/redo 只恢复命令实际改变的顶层 draft 域，不覆盖后来发生的基本信息编辑；
+成功保存以服务端全版本 identity context 建立新历史边界，失败保存保留本地
+undo。exact-head 本地门：focused 46/46、required Web 360 文件 / 4366 测试、
+ESLint、`vue-tsc`、production build PASS；五刀判别变异均 RED-before。该 PR
+仍为 Draft、required checks 3/3 PASS，且 C4/F1/F3 的完整真浏览器 T1
+仍未闭合。
 
 ### 4.1 依赖图
 
@@ -461,10 +483,11 @@ U0 至少包含以下 12 项，全部保存截图、录屏或网络/数据库证
 1. **E0：完成。** Codex exact-head 审阅，Claude Opus 只读对抗复核；
 2. **E1 / E1-b：完成。** Kimi 提供视觉 IA，Grok 构建隔离 renderer 和生产命令适配验证，Codex 复核与变异；
 3. **E2 / C1 / C2：完成待审。** Claude 负责 shell 与统一 carrier，Codex 完成 canvas-first 接线、真浏览器验证和判别变异，Kimi 复审；
-4. **F1-a / F1-b / F2：完成待审。** Codex 完成 palette、三栏 builder/inspector、命令接线、不可复用字段身份与后端历史/FWB 引用权威；
+4. **F1-a / F1-b / F2 / F3：完成待审。** Codex 完成 palette、三栏 builder/inspector、命令接线、不可复用字段身份、后端历史/FWB 引用权威及附件双 flag authoring；
 5. **C3：完成待审。** 子代理实现边 `+`，Codex exact-source 复核后修正 condition default 与 parallel join 两处合法性守卫，并重跑 required Web Tests、生产 build 和真浏览器；
-6. **C4：代码与 CI 门完成，浏览器门未闭合。** 语义拖拽和分支排序已形成 Draft PR，真实 Browser 附着失败被保留为显式阻塞，未伪报视觉验收。
+6. **C4 / C5：代码与 CI 门完成，浏览器门未闭合。** 语义拖拽、分支排序和统一 Canvas 历史已形成 Draft PR；真实 Browser 附着失败被保留为显式阻塞，未伪报视觉验收；
+7. **最终表单+画布历史整合：完成待审。** #4702 把表单结构与属性编辑纳入同一 history，补成功/失败保存边界、焦点恢复和身份不可复用回归；本地门与 required checks 3/3 PASS。
 
-本轮尚未启动 C5/F3 及版本/试运行收口，没有开启任何 flag。下一开发点为
-C5 统一 undo/redo 与 F3 附件 authoring；同时补 C4 真浏览器证据。不得把
-C4/F2 的实现完成解释为整条编辑器已达到飞书/钉钉产品完成度。
+本轮尚未完成版本/试运行/响应式与无障碍收口，也没有开启任何 flag。下一
+开发点为补 C4/F1/F3 真浏览器 T1，并继续 V1/V2、P1、X1。不得把
+C3-C5/F1-F3 的代码完成解释为整条编辑器已达到飞书/钉钉产品完成度。

--- a/docs/development/approval-editor-flow-parity-development-plan-20260727.md
+++ b/docs/development/approval-editor-flow-parity-development-plan-20260727.md
@@ -153,6 +153,11 @@ E1 不得默认引入 ELK。只有现有布局在构造的条件/并行/长标�
 | U0 | staging UAT 与 canary | 基线截图、任务脚本、缺陷分诊、回滚演练；不直接开生产 | T1 | Codex协调；owner执行真实租户动作 | U0 |
 | D0 | 三份收口文档 | 设计锁 delta、执行台账、收尾验证 MD；逐项列明未完成 owner 门 | U0 | Fable 5起草；Codex定稿 | D0 |
 
+E0 已在 exact `origin/main@d449aa7e6d02f94df2738a77cafffa778b12fde0`
+完成。判定、可复现探针、能力矩阵及 E1 夹具约束见
+`approval-editor-flow-parity-e0-audit-20260727.md`。该完成状态只关闭
+E0 审计任务，不改变本计划和历史交互锁的 `PROPOSED` / owner-gated 状态。
+
 ### 4.1 依赖图
 
 ```mermaid

--- a/docs/development/approval-editor-flow-parity-development-plan-20260727.md
+++ b/docs/development/approval-editor-flow-parity-development-plan-20260727.md
@@ -1,8 +1,10 @@
 # 审批编辑器与流程编排对标开发计划（2026-07-27）
 
-**状态：PROPOSED，等待 owner 确认后执行**
+**状态：IN PROGRESS（仅 E0 / E1 / E1-b / E2 已获准并在隔离分支完成；C1 以后仍未授权）**
 
-**核对基线：** `origin/main@d449aa7e6d02f94df2738a77cafffa778b12fde0`
+**事实审计基线：** `origin/main@d449aa7e6d02f94df2738a77cafffa778b12fde0`
+
+**E2 实现基线：** `origin/main@9da0335b4`（2026-07-28）
 
 **范围：** 审批模板编辑器、表单设计器、流程画布、节点检查器、路由试运行、版本查看/比较/恢复、浏览器验收和灰度启用。
 
@@ -160,10 +162,19 @@ E0 审计任务，不改变本计划和历史交互锁的 `PROPOSED` / owner-gat
 
 E1 的隔离 DOM + SVG renderer feasibility spike 已完成，真 Chromium
 三 viewport 通过，100 节点两次布局确定且约 105ms，无新生产依赖。
-但 mutation 尚未接 `approvalCanvasCommands`，drag slot 和未编辑
-round-trip 尚未证明，因此 A1 记录为 `PARTIAL`，不得据此启动 C2 或开启
-Canvas flag。详见
+E1-b 又把分支重排、合法/非法节点移动、undo/redo、HTML5 drag 和键盘
+移动接到生产 `approvalCanvasCommands`，并证明 renderer 坐标不进入
+`ApprovalGraph`。稳定键选择恢复的判别变异会使 Playwright 精确转红。
+因此 A1 的 renderer feasibility 门记录为 `PASS`；该 PASS 不等于 C1-C5
+产品接线完成，也不授权开启 Canvas flag。详见
 `approval-editor-flow-parity-e1-renderer-spike-verification-20260727.md`。
+
+E2 已在 `origin/main@9da0335b4` 的隔离分支完成第一刀无行为抽取：
+`TemplateAuthoringView.vue` 从 3732 行降为 3340 行，新
+`ApprovalFlowCanvas.vue` 只接收派生 props 并发出 typed intents，业务状态、
+保存/发布和拓扑命令仍由父层拥有。13 个审批 authoring 测试文件
+247/247、ESLint、`vue-tsc` 通过；中和 drop intent 后拖放断言精确转红。
+状态仅为 `IMPLEMENTED + LOCAL VERIFIED`，尚未 push、CI、merge 或部署。
 
 ### 4.1 依赖图
 
@@ -363,9 +374,14 @@ U0 至少包含以下 12 项，全部保存截图、录屏或网络/数据库证
 
 执行中持续维护三份文档：
 
-1. **设计锁 delta**：只记录本计划相对 2026-07-21 锁的 owner 决策、renderer 选择和明确非目标；
-2. **执行台账**：每个 ID 的 PR、SHA、实现模型、复核模型、测试命令、CI URL、合入和 flag 状态；
-3. **收尾验证 MD**：merged-main exact SHA、浏览器证据、UAT、残余风险和 owner-only 开关。
+1. **设计锁 delta**：本文；只记录相对 2026-07-21 锁的 owner 决策、
+   renderer 选择和明确非目标；
+2. **执行台账**：
+   `approval-editor-flow-parity-execution-ledger-20260728.md`；记录每个 ID
+   的 SHA、实现模型、复核模型、测试、CI、合入和 flag 状态；
+3. **收尾验证 MD**：
+   `approval-editor-flow-parity-closeout-verification-20260728.md`；记录
+   exact head、浏览器证据、判别变异、残余风险和 owner-only 开关。
 
 禁止在 T1/U0 前把文档状态写成 `FINAL`。正确中间状态为：
 
@@ -375,10 +391,12 @@ U0 至少包含以下 12 项，全部保存截图、录屏或网络/数据库证
 
 ## 11. 首轮执行建议
 
-确认本计划后，只启动以下三项：
+以下三项已按隔离车道执行：
 
-1. **E0：** Codex 在独立 worktree 对当前 `origin/main` 做全链审阅和基线截图；
-2. **E1：** Kimi K3 出两套高保真 IA，Grok 做 Vue Flow+现有 layout 与现 renderer 的一次性 spike；
-3. **E2 准备：** Sonnet 5 只读给出 3732 行热文件的抽取边界，等 E0/E1 裁决后才提交代码。
+1. **E0：完成。** Codex exact-head 审阅，Claude Opus 只读对抗复核；
+2. **E1 / E1-b：完成。** Kimi 提供视觉 IA，Grok 构建隔离 renderer 和生产命令适配验证，Codex 复核与变异；
+3. **E2 第一刀：完成。** Claude Sonnet 5 做 presentational shell 抽取，Codex 清理、扩测和事件透传变异。
 
-首轮不启动 C2 以后功能，不开启任何 flag，不接触审批运行时服务。这样先固定产品表面和 renderer，再并行实施，能最大限度避免在 3732 行热文件上重复返工。
+本轮没有启动 C1/C2 以后功能，没有开启任何 flag，也没有接触审批运行时
+服务。下一步必须先审合 E1-b/E2，再由 owner 单独授权 C1；不得把本轮
+验证通过解释为整条编辑器已达到飞书/钉钉产品完成度。

--- a/docs/development/approval-editor-flow-parity-e0-audit-20260727.md
+++ b/docs/development/approval-editor-flow-parity-e0-audit-20260727.md
@@ -1,0 +1,250 @@
+# 审批编辑器与流程画布 E0 现状审计
+
+**审计状态：** COMPLETE  
+**审计基线：** `origin/main@d449aa7e6d02f94df2738a77cafffa778b12fde0`  
+**审计日期：** 2026-07-27  
+**范围：** 审批表单编辑、流程画布、条件/并行拓扑、检查器、路线预览、版本差异与恢复、功能开关、CI 收集面  
+**结论：** 无 P1。存在 5 项 P2，均应在生产开启 `APPROVAL_CANVAS_V2_ENABLED` 或宣布飞书/钉钉对标前关闭。
+
+本报告只记录 exact-head 可复现证据。代码存在、单测通过、设计锁写明或模型审阅通过，均不单独等于用户可达能力。
+
+## 1. Findings
+
+### P2-1 表单生产 UI 绕过命令层，可制造不可保存草稿并静默删除字段权限
+
+生产页面没有导入 `approvalFormCommands.ts`：
+
+- `TemplateAuthoringView.vue:2562-2568` 直接追加和过滤 `draft.value.fields`。
+- `TemplateAuthoringView.vue:2571-2583` 直接交换或调用通用数组移动函数。
+- `templateAuthoring.ts:225-228` 仍以当前长度生成持久 ID `field_${index}`。
+- `approvalFormCommands.ts:56-84` 已定义不可复用的持久身份历史。
+- `approvalFormCommands.ts:420-451` 已定义删除前完整引用清点和 fail-closed 拒绝，但生产页面未调用。
+
+两个独立判别探针：
+
+1. 新建字段 1/2/3，删除中间字段 2，再新增字段。序列化结果为：
+
+   ```json
+   [
+     { "id": "field_1", "label": "字段 1" },
+     { "id": "field_3", "label": "字段 3" },
+     { "id": "field_3", "label": "字段 3" }
+   ]
+   ```
+
+   `validateTemplateFormFields` 在 `templateAuthoring.ts:1126-1128` 只会提示“字段 id 不能重复”，但普通用户看不到也不能编辑字段 ID。后端在 `ApprovalProductService.ts:859-866` 再次拒绝。结果是用户可通过正常 UI 进入无法修复、无法保存的草稿状态。
+
+2. 字段 2 被审批步骤设置为 `hidden` 后，通过页面当前删除逻辑删除字段 2：
+
+   - `validateTemplateDraft` 返回 `[]`。
+   - `buildApprovalGraph` 静默移除 `fieldPermissions`，因为 `templateAuthoring.ts:977-990` 会过滤已删除字段。
+   - 同一输入调用 `removeFormField` 返回 `field_is_referenced`，依赖类型为 `step_field_permission`。
+
+这不是仅缺少 undo 的体验差异，而是生产 UI 绕过现成 fail-closed 合约后产生的配置静默丢失。
+
+**关闭条件：**
+
+- 页面新增、删除、排序全部改走 `approvalFormCommands`。
+- 接入完整 identity history 与 external reference inventory；缺失时拒绝，不回退到长度派生 ID。
+- mounted browser 测试覆盖“删除中间字段再新增”和“删除被字段权限/条件/FWB 引用字段”。
+- 旧图未编辑 round-trip 必须 byte-identical。
+
+### P2-2 版本差异页面向管理员展示内部字段/节点/边标识
+
+- `templateVersionDiff.ts:42-52` 在缺少业务名称时回退到 `field.id`、`node.key`，边标签直接拼接 `${source} -> ${target}`。
+- `TemplateDetailView.vue:496-512` 原样渲染 `change.label`。
+- required 测试 `approval-template-version-diff.test.ts:72-73` 反而固定了 `approve -> cc` 与 `cc -> end`。
+
+该页面不受 Canvas V2 flag 保护，模板管理员当前即可访问。它违反现有交互锁“普通用户不见 node/edge/key/ID”的约束，也使后续正确修复必然先改 required 测试。
+
+**关闭条件：**
+
+- 边显示业务节点名称与业务关系文案，不显示 source/target key。
+- 缺少名称时使用“未命名字段/节点”，不回退内部 ID。
+- 增加 DOM 级 no-internals 守卫，覆盖文本、`aria-label` 与 tooltip。
+
+### P2-3 两个负担安全/保真的 authoring spec 未进入任何 required CI
+
+以下文件既不在 `apps/web/scripts/run-required-web-tests.sh`，也未进入 required workflow：
+
+- `apps/web/tests/approval-template-authoring-errors.test.ts`
+- `apps/web/tests/approval-template-authoring-field-permissions.test.ts`
+
+`approval-web-guard.yml` 当前不是 `main` 的 required context。2026-07-27 实查 required contexts 只有：
+
+```text
+contracts (strict)
+contracts (dashboard)
+pr-validate
+test (20.x)
+contracts (openapi)
+web-tests
+stock-prep PowerShell 5.1 acceptance
+attendance-web-guard
+```
+
+因此 values-free 错误映射和字段权限保真可回归而 required checks 仍全绿。
+
+**关闭条件：**
+
+- 两个 spec 接入 `run-required-web-tests.sh`。
+- 同时保留 path-filter guard 作为快速反馈，但不能把非 required guard 当最终门。
+- 用一次中和 values-free 映射、一次中和 field permission 保真证明 required job 精确变红。
+
+### P2-4 条件公式 capture-prone 拒绝缺少用户可行动文案
+
+- 后端在 `ApprovalProductService.ts:1597` 与 `ApprovalGraphExecutor.ts:1206` 返回 `APPROVAL_CONDITION_FORMULA_CAPTURE_PRONE`。
+- `templateAuthoringErrors.ts:3-8` 没有该 code。
+- `describeTemplateAuthoringError` 对未知 code 只返回通用 fallback。
+
+管理员输入 `{amount} - {amount} == 0` 后，保存只会得到“保存模板失败”，无法定位分支或修正公式。后端 fail-closed 是正确的，但编辑器没有完成这一机器码的产品闭环。
+
+**关闭条件：**
+
+- 增加 values-free、可操作的 code-to-copy 映射。
+- mounted UI 测试断言不会显示原始表达式、字段 ID 或后端 message。
+- save/update/publish/restore 的同类错误使用同一映射入口。
+
+### P2-5 Canvas flag 开启后仍不满足无障碍和真浏览器激活门
+
+`TemplateAuthoringView.vue` 当前：
+
+- 没有 `aria-live`、`role="status"` 或 `role="alert"`。
+- 没有 `prefers-reduced-motion`。
+- `onCanvasNodeKeydown` 在 `:2326-2331` 只支持 `Alt+ArrowUp/Down`。
+- 没有设计锁要求的普通方向键导航、`Shift+F10` 上下文菜单、命令结果与拒绝播报。
+- 变更仍直接调用 `graphTopologyEdit`，没有挂载 `approvalCanvasCommands` 的 undo/redo 历史。
+
+测试层只有 Vitest/jsdom 和纯函数规格。`apps/web/verification/` 没有审批 Playwright 用例，无法证明拖拽、焦点、缩放、响应式检查器、长文案和触摸等真实浏览器行为。
+
+**关闭条件：**
+
+- 一套 mounted command adapter，所有鼠标、拖拽和键盘操作调用同一命令代数。
+- 单一 polite live region；错误/冲突才使用 assertive。
+- reduced-motion、焦点恢复、键盘全流程。
+- Playwright 在 1440x900、1024x768、390x844 下跑 E1 夹具并做像素/DOM 几何断言。
+- 完成这些门前 Canvas V2 保持默认 OFF，结构列表继续作为可访问回退。
+
+## 2. P3 与实现漂移
+
+### P3-1 分支优先级命令不会改变当前画布布局
+
+`approvalCanvasCommands.ts:364-425` 只重排 condition/parallel config 中的 branch key，保持 `edges` 不变；`graphLayout.ts:51-67` 却按 `graph.nodes` 数组顺序排列同层节点。于是优先级改变在画布上可能完全无视觉变化。
+
+E1 布局必须以 gateway config 的 branch order 为 lane order，默认条件分支固定在最右侧。
+
+### P3-2 当前布局固定卡片尺寸，且节点卡片内仍堆操作按钮
+
+- `graphLayout.ts:24-27` 固定 190x96。
+- `TemplateAuthoringView.vue:654-692` 在节点卡片内放置移动、添加分支、插入和删除按钮。
+- 右侧 inspector 没有 390px 窄屏 bottom sheet 两档形态。
+
+这不构成 flag-OFF 下的运行时漏洞，但不能作为飞书/钉钉产品面完成证据。
+
+### P3-3 timeout / approvalThreshold 保真守卫的注释与覆盖不完整
+
+`templateAuthoring.ts:582-596` 声称复杂图 allowlist 与后端重放能力一致，但后端现在会规范化并保留 `timeout` 与 `approvalThreshold`。当前前端仍保守锁定，安全但注释已失真。
+
+现有测试覆盖线性 `timeout` 只读拒绝；没有明确的 `approvalThreshold` 只读正反控，也没有复杂图两者的 mounted 保存禁用证据。不得简单把 key 加入 allowlist，必须先证明 hydrate-edit-save 全链 byte-identical。
+
+### P3-4 设计治理状态漂移
+
+`approval-canvas-v2-interaction-design-lock-20260721.md` 头部仍为 `PROPOSED`，同时记录 D2-b/D6-f1 已交付。实现已进入 `main`，但 G0 未在权威文档中追认。该漂移不是运行时 bug，但 D3-D6 不能以“代码已存在”替代 owner ratify。
+
+## 3. As-built 能力矩阵
+
+| 能力 | 当前状态 | 可交付判断 |
+|---|---|---|
+| Canvas flag 严格默认 OFF | 已实现 | 可保留 |
+| 复杂图列表/画布切换 | 部分实现 | 仅复杂图，且默认 list |
+| 线性流程统一画布 | 未实现 | 对标阻塞 |
+| 条件/并行拓扑编辑 | 已实现基础命令 | 生产 UI 仍是按钮群/直接 mutation |
+| 语义拖动 | 部分实现 | 仅 approval/cc 合法线性边槽 |
+| 分支优先级排序 | 纯命令存在 | 当前布局不体现顺序 |
+| undo/redo | 纯命令存在 | 生产 UI 未挂载 |
+| 表单字段拖动排序 | 已实现原生 HTML5 | 新增/删除绕过命令层 |
+| 左侧控件 palette 拖入 | 未实现 | 表单对标阻塞 |
+| 路线预览 | 已实现 | 保留，需放入统一工作台 |
+| 版本时间线 | 已实现 | 可用 |
+| 版本差异 | 部分实现 | 有内部 ID 泄露，非并排对照 |
+| 恢复为新草稿 | 已实现且并发保护 | 可用，不修改历史版本 |
+| 真浏览器审批编辑器验收 | 未实现 | 开 flag 阻塞 |
+
+## 4. E1 最小图形夹具
+
+E1 spike 只做隔离渲染研究，不修改生产路由、不修改保存模型、不启用 flag。
+
+### 4.1 必备流程形状
+
+1. `start -> approval -> cc -> end` 线性主干。
+2. 一个 condition gateway：
+   - 两个规则分支；
+   - 一个 default 分支；
+   - 分支优先级可重排；
+   - default 始终最后。
+3. 一个 parallel gateway：
+   - `joinMode=all` 与 `joinMode=any` 两个 variant；
+   - 至少三条分支；
+   - 一条分支内含 condition；
+   - 不包含 nested parallel。
+4. 一个 80 字符节点名、40 字符分支名、三行审批人摘要。
+5. 一个 100 节点混合图。
+6. 一个带未知 legacy config 的只读图。
+7. 一个带 `timeout` 和一个带 `approvalThreshold` 的只读保真图。
+8. 一个仅重排 `config.branches`、不改变 `nodes`/`edges` 数组的 priority variant。
+
+### 4.2 不可协商约束
+
+1. **一个业务模型：** 坐标、缩放、选中态不得进入 `ApprovalGraph` 或保存 payload。
+2. **一个命令入口：** 渲染层不得重写业务校验；所有 mutation 经 `approvalCanvasCommands` / `graphTopologyEdit`。
+3. **分支顺序真实可见：** lane 顺序从 gateway config 读取，不从 `graph.nodes` 数组猜测。
+4. **动态测量：** 边路由不得依赖固定卡片高度；边不得穿卡，卡片不得重叠。
+5. **旧图保真：** 未编辑 hydrate-save payload byte-identical；未知 config 保持只读。
+6. **业务语言：** DOM、tooltip、`aria-label` 不得出现 node/edge/key/ID 或 `source -> target`。
+7. **键盘等价：** 无鼠标完成新增、分支、移动、配置、撤销和保存。
+8. **无障碍：** 命令结果、拒绝和校验计数可播报；reduced-motion 有效；焦点可恢复。
+9. **响应式：** 1440 右侧 360px dock，1024 右侧 320px overlay，390 使用 bottom sheet。
+10. **两点 CI：** 新 spec 同时进入 required web-tests 与快速 path guard。
+
+## 5. E1 模型分工
+
+| 任务 | 模型 | 边界 |
+|---|---|---|
+| 视觉 IA、节点层级、分支可读性、空/错/长文案状态 | Kimi K3 | 只读评审与原型建议，不改生产代码 |
+| 隔离 renderer spike、Playwright 几何验证 | Grok | 仅 E1 实验目录/分支，不接生产路由 |
+| 命令边界、保真、无障碍与 false-green 对抗审阅 | Claude Opus 5 | 只读；Codex 逐条复核 |
+| 证据归并、P 级裁决、最终合入门 | Codex | 不把模型自评当验收 |
+
+## 6. 验证记录
+
+在 exact-head 隔离 worktree 执行：
+
+```text
+approval canvas/form/version focused Vitest: 7 files, 125 passed
+vue-tsc --noEmit: PASS
+```
+
+这些结果证明纯命令和既有 jsdom 规格当前通过，不证明生产 UI 已挂载命令，也不证明真实浏览器拖拽/布局。
+
+独立 Opus 5 审阅使用：
+
+```text
+model: claude-opus-5
+context window: 1,000,000
+max output: 64,000
+mode: read-only review
+```
+
+Codex 对其结论做了二次裁决：
+
+- 接受：raw key 版本差异、CI 漏收集、capture-prone 缺文案、无障碍/浏览器门、命令层未挂载。
+- 升级：表单命令层未挂载从体验 P3 升为数据保真 P2，并用两个判别探针证明。
+- 驳回“timeout 零覆盖”：现有线性 timeout 测试存在；修正为 P3 注释/组合覆盖漂移。
+
+## 7. Owner 门
+
+1. G0：追认或修订现有 Canvas V2 交互锁。
+2. 明确 E1 为 pre-G0 隔离 spike，不能被解释为 runtime 授权。
+3. E0 五项 P2 关闭前，不开启生产 Canvas flag。
+4. E1 通过后再选择 renderer；不得由模型自行决定依赖与产品架构。
+5. merged-main Playwright + 真租户 UAT 通过后，才讨论 staging canary 与生产分级开启。

--- a/docs/development/approval-editor-flow-parity-e1-renderer-spike-verification-20260727.md
+++ b/docs/development/approval-editor-flow-parity-e1-renderer-spike-verification-20260727.md
@@ -1,8 +1,9 @@
 # 审批编辑器与流程画布 E1 Renderer Spike 验证
 
-**状态：** SPIKE COMPLETE / A1 PARTIAL
+**状态：** SPIKE + E1-b COMPLETE / A1 PASS（仅 renderer feasibility）
 **基线：** `origin/main@d449aa7e6d02f94df2738a77cafffa778b12fde0`
 **实验分支：** `codex/approval-editor-e1-renderer-spike-20260727`
+**E1-b 分支：** `codex/approval-editor-e1b-command-drag-20260728`
 **日期：** 2026-07-27
 **产品代码、路由、依赖、flag：** 零改动
 
@@ -46,6 +47,21 @@ Grok Bridge 本地 server 未成功启动，且主机 DNS 对 Grok CLI endpoint 
 
 实现保持坐标、选中态、sheet 状态只存在于 render model；夹具中的
 `ApprovalGraph` 不写入坐标。
+
+### 2.1 E1-b：生产命令适配与拖拽判别
+
+E1-b 在同一 verification harness 中增加：
+
+- 分支优先级调整调用生产 `reorder-condition-branches`；
+- 合法/非法节点移动调用生产 `move-node-into-edge`；
+- undo/redo 调用生产 history API，不复制逆操作；
+- HTML5 drag 与键盘 `m` 共用同一个 command adapter；
+- typed error 只映射为 values-free 业务文案；
+- history selection 用稳定 node/edge key 恢复当前 render focus id；
+- mutation 后序列化 graph 仍不含 `x/y/width/height`。
+
+E1-b 提交为 `1303d7ba7`。它仍是 verification-only，不是生产路由接线；
+边 `+` 插入菜单仍只演示选择，不写业务模型，留给 C3。
 
 ## 3. Fail-first 记录
 
@@ -91,11 +107,12 @@ pnpm exec playwright test \
 结果：
 
 ```text
-chromium: 3 passed
+chromium: 4 passed
 desktop 1440x900: PASS
 compact 1024x768: PASS
 narrow 390x844: PASS
 mixed-100 render: first=105.53ms repeat=105.15ms
+E1-b command/drag/history: PASS
 ```
 
 浏览器断言包括：
@@ -122,6 +139,12 @@ mixed-100 render: first=105.53ms repeat=105.15ms
 - `apps/web/verification-output/e1-desktop-mixed-100.png`
 - `apps/web/verification-output/e1-compact-1024.png`
 - `apps/web/verification-output/e1-narrow-390.png`
+- `apps/web/verification-output/e1-b-command-drag.png`
+
+E1-b 判别变异把 `restoreSelectionFromHistory` 的稳定键映射中和后，
+Playwright 在 `selectedName` 精确转红（期望“主管审批”，实际 `null`）；
+恢复后同一用例重新转绿。该证据证明测试钉住的是“拓扑变化后 selection /
+focus / inspector 仍指向同一业务节点”，不是只检查最终边集合。
 
 静态门：
 
@@ -149,27 +172,17 @@ vue-tsc --noEmit: PASS
 
 ## 6. 未关闭项
 
-### A1-1 mutation 尚未接生产命令代数
+### A1-1 edge `+` 插入尚未接生产命令
 
-实验中的 edge `+` 只打开菜单并播报选择，不写 graph。它证明可供性与
-键盘路径，不证明 `approvalCanvasCommands`、undo、保真或保存。
+E1-b 已用生产命令证明 reorder、constrained move、typed rejection 与
+undo/redo。实验中的 edge `+` 仍只打开菜单并播报选择，不写 graph。
 
-**关闭条件：** E1-b 在隔离 harness 中挂一个 command adapter，至少用同一
-命令入口完成 insert、branch reorder 和 constrained move；拒绝路径必须
-保持 graph byte-identical。
+**关闭条件：** C3 在生产组件用同一命令入口完成 insert；拒绝路径保持
+graph byte-identical。
 
-### A1-2 drag slot 尚无真浏览器证据
+### A1-2 生产组件 round-trip 与 CI
 
-实验有 edge insertion control，没有 pointer/drag hit-test。生产代码已有
-受约束 drag，但本实验 renderer 尚未证明合法槽高亮、非法落点 no-op 和
-焦点恢复。
-
-**关闭条件：** E1-b 增加一个合法拖动、一个非法拖动和键盘等价测试，
-不得在 renderer 复制拓扑判断。
-
-### A1-3 round-trip 与 CI 未证明
-
-实验不调用 hydrate/save，不在 required CI。未编辑 byte-identical、
+E1-b 不调用 hydrate/save，也不在 required CI。未编辑 byte-identical、
 unknown config 保真、required web-tests 两点接线仍属于后续产品切片。
 
 ### P3 视觉密度
@@ -181,15 +194,15 @@ unknown config 保真、required web-tests 两点接线仍属于后续产品切�
 ## 7. Gate 结论
 
 - **E1 可行性 spike：PASS。**
-- **A1 生产晋级门：PARTIAL。**
-- **允许并行启动 E2 无行为抽取：是，E2 只依赖 E0。**
-- **允许启动 C2 canvas-first：否，先关闭 E1-b 与 C1 round-trip。**
+- **A1 renderer feasibility 门：PASS。**
+- **E2 无行为抽取：已在独立分支完成，本报告不替代其 A2 证据。**
+- **允许启动 C2 canvas-first：否，先审合 E2 并关闭 C1 round-trip。**
 - **允许开启 staging/production Canvas flag：否。**
 
 下一执行顺序：
 
-1. E1-b：command adapter + drag hit-test；
-2. E2：`TemplateAuthoringView.vue` 无行为抽取，可与 E1-b 并行；
-3. E0 P2-2/P2-3/P2-4 可独立小 PR 先关闭；
-4. E0 P2-1 与 E2/F1 合并规划，避免两次修改热文件；
-5. C1 在 E1-b 与 E2 后开始。
+1. 审合 E1-b verification 与 E2 无行为抽取；
+2. E0 P2-2/P2-3/P2-4 可独立小 PR 关闭；
+3. E0 P2-1 与 F1 合并规划，避免再次堆回父组件；
+4. owner 单独授权后启动 C1；
+5. C1 通过前不启动 C2、不调整 Canvas flag。

--- a/docs/development/approval-editor-flow-parity-e1-renderer-spike-verification-20260727.md
+++ b/docs/development/approval-editor-flow-parity-e1-renderer-spike-verification-20260727.md
@@ -1,0 +1,195 @@
+# 审批编辑器与流程画布 E1 Renderer Spike 验证
+
+**状态：** SPIKE COMPLETE / A1 PARTIAL
+**基线：** `origin/main@d449aa7e6d02f94df2738a77cafffa778b12fde0`
+**实验分支：** `codex/approval-editor-e1-renderer-spike-20260727`
+**日期：** 2026-07-27
+**产品代码、路由、依赖、flag：** 零改动
+
+本报告验证一个隔离的 DOM + SVG 受约束垂直树 renderer 是否能承载审批
+画布的布局、分支可读性、响应式检查器和真浏览器验收。它不授权把实验
+代码接入生产，也不把“能渲染”解释为“编辑器已对标飞书/钉钉”。
+
+## 1. 模型分工与实际运行
+
+| 环节 | 实际模型/执行者 | 结果 |
+|---|---|---|
+| exact-head 对抗审阅 | Claude `claude-opus-5` | 只读审阅完成；Codex 逐条复核并形成 E0 |
+| 视觉 IA 批评 | 本机 Kimi Code 当前配置模型 | 完成；CLI 未给出可验证的 K3 型号，因此不宣称 exact K3 |
+| 隔离 renderer 与 Playwright | `grok-4.5-build` | 生成 5 个 verification 文件；未改生产路径 |
+| 最终裁决、补测与门控 | Codex | 发现并修正 ESLint 漏项，补确定性/百节点交互/耗时证据 |
+
+Grok Bridge 本地 server 未成功启动，且主机 DNS 对 Grok CLI endpoint 的
+解析异常。执行改用已认证的原生 Grok CLI，并通过仅监听
+`127.0.0.1` 的临时 CONNECT 转发访问正确 endpoint；未修改系统 DNS，
+未扩大代码发送范围。
+
+## 2. 实验交付物
+
+实验只新增：
+
+- `apps/web/verification/approval-flow-canvas-e1-fixtures.ts`
+- `apps/web/verification/approval-flow-canvas-e1-layout.ts`
+- `apps/web/verification/approval-flow-canvas-e1-harness.html`
+- `apps/web/verification/approval-flow-canvas-e1-harness.ts`
+- `apps/web/verification/approval-flow-canvas-e1.spec.ts`
+
+夹具覆盖：
+
+1. 线性 `start -> approval -> cc -> end`；
+2. 条件分支、默认分支与 priority-only 重排；
+3. `joinMode=all/any` 的三路并行，且一条分支内含 condition；
+4. 长节点名、长分支名、三行摘要；
+5. 100 节点混合图；
+6. legacy、timeout、approvalThreshold 三种只读保真图；
+7. 1440、1024、390 三种 inspector 呈现。
+
+实现保持坐标、选中态、sheet 状态只存在于 render model；夹具中的
+`ApprovalGraph` 不写入坐标。
+
+## 3. Fail-first 记录
+
+首次真浏览器运行不是假绿：
+
+```text
+desktop: FAIL
+edge e4 crosses card "其他处理"
+compact: PASS
+narrow: PASS
+```
+
+失败来自 nested condition 与 parallel sibling 共用 lane，join edge 穿过
+中间卡片。修复没有删除、跳过、放宽或 special-case
+`assertEdgesDoNotCrossCards`，而是：
+
+1. gateway 子树按配置顺序分配互斥连续 lane；
+2. nested gateway 先计算 subtree width；
+3. join 固定在所属 parallel strip 中央；
+4. SVG edge 使用 obstacle-aware orthogonal routing；
+5. 找不到直达 corridor 时绕开 blocker card。
+
+同一断言随后在全部 viewport 与夹具通过。
+
+Codex 复核又发现两个模型未报告的问题：
+
+- layout 中一个未使用的 `rank`；
+- Playwright 中一个未使用的 `labels`。
+
+定向 ESLint 因此先红，再做最小清理后转绿。该过程说明
+`vue-tsc` 绿不能替代 lint 门。
+
+## 4. 真浏览器结果
+
+执行：
+
+```text
+pnpm exec playwright test \
+  verification/approval-flow-canvas-e1.spec.ts \
+  --config playwright.verification.config.ts
+```
+
+结果：
+
+```text
+chromium: 3 passed
+desktop 1440x900: PASS
+compact 1024x768: PASS
+narrow 390x844: PASS
+mixed-100 render: first=105.53ms repeat=105.15ms
+```
+
+浏览器断言包括：
+
+- 卡片不重叠；
+- 非端点 edge 不穿卡；
+- 页面无水平溢出；
+- condition/parallel lane 顺序来自 gateway config，default 最右；
+- 100 节点两次加载的卡片坐标与 edge path 完全一致；
+- 100 节点中的后段节点可滚动、选择并打开 inspector；
+- edge `+` 可键盘激活；
+- 单一 polite live region；
+- card 内无动作按钮群；
+- DOM 文本、title 与 `aria-label` 不出现 raw node/edge key；
+- 1440 使用 360px dock，1024 使用 320px overlay，390 使用 bottom sheet；
+- reduced-motion media rule 存在；
+- read-only fidelity 图不提供 insertion。
+
+视觉输出：
+
+- `apps/web/verification-output/e1-desktop-linear.png`
+- `apps/web/verification-output/e1-desktop-parallel-any.png`
+- `apps/web/verification-output/e1-desktop-long-labels.png`
+- `apps/web/verification-output/e1-desktop-mixed-100.png`
+- `apps/web/verification-output/e1-compact-1024.png`
+- `apps/web/verification-output/e1-narrow-390.png`
+
+静态门：
+
+```text
+targeted ESLint: PASS
+vue-tsc --noEmit: PASS
+```
+
+## 5. Renderer 决策
+
+**当前决定：继续验证无新依赖的 DOM + SVG constrained renderer，不在
+本阶段引入 Vue Flow 或 ELK。**
+
+理由：
+
+1. branch-order、nested condition、parallel join、动态卡高和 100 节点已
+   在真 Chromium 中可行；
+2. 当前实验不增加 production bundle，也没有新增许可证；
+3. ApprovalGraph、命令代数和 fail-closed 校验可以继续保持独立；
+4. 现在引入通用图编辑库不能自动解决业务语义、权限、版本保真和命令
+   入口问题，反而增加第二套状态模型风险。
+
+这不是永久排除 Vue Flow/ELK。只有 E1-b 或 C1 证明现有方案无法满足
+拖拽命中、焦点或大图性能，才重新打开依赖决策。
+
+## 6. 未关闭项
+
+### A1-1 mutation 尚未接生产命令代数
+
+实验中的 edge `+` 只打开菜单并播报选择，不写 graph。它证明可供性与
+键盘路径，不证明 `approvalCanvasCommands`、undo、保真或保存。
+
+**关闭条件：** E1-b 在隔离 harness 中挂一个 command adapter，至少用同一
+命令入口完成 insert、branch reorder 和 constrained move；拒绝路径必须
+保持 graph byte-identical。
+
+### A1-2 drag slot 尚无真浏览器证据
+
+实验有 edge insertion control，没有 pointer/drag hit-test。生产代码已有
+受约束 drag，但本实验 renderer 尚未证明合法槽高亮、非法落点 no-op 和
+焦点恢复。
+
+**关闭条件：** E1-b 增加一个合法拖动、一个非法拖动和键盘等价测试，
+不得在 renderer 复制拓扑判断。
+
+### A1-3 round-trip 与 CI 未证明
+
+实验不调用 hydrate/save，不在 required CI。未编辑 byte-identical、
+unknown config 保真、required web-tests 两点接线仍属于后续产品切片。
+
+### P3 视觉密度
+
+复杂并行图的每段 edge 都显示 `+`，branch label、线和 `+` 在局部较密。
+产品化时应在 hover/focus/selected path 才强化 insertion affordance，
+同时保持键盘可发现性；不能通过缩小触控目标解决。
+
+## 7. Gate 结论
+
+- **E1 可行性 spike：PASS。**
+- **A1 生产晋级门：PARTIAL。**
+- **允许并行启动 E2 无行为抽取：是，E2 只依赖 E0。**
+- **允许启动 C2 canvas-first：否，先关闭 E1-b 与 C1 round-trip。**
+- **允许开启 staging/production Canvas flag：否。**
+
+下一执行顺序：
+
+1. E1-b：command adapter + drag hit-test；
+2. E2：`TemplateAuthoringView.vue` 无行为抽取，可与 E1-b 并行；
+3. E0 P2-2/P2-3/P2-4 可独立小 PR 先关闭；
+4. E0 P2-1 与 E2/F1 合并规划，避免两次修改热文件；
+5. C1 在 E1-b 与 E2 后开始。

--- a/docs/development/approval-editor-flow-parity-execution-ledger-20260728.md
+++ b/docs/development/approval-editor-flow-parity-execution-ledger-20260728.md
@@ -21,6 +21,7 @@ merge、部署、UAT 和 flag 是不同状态，不互相替代。
 | E2 | Flow Canvas presentational shell 抽取 | `origin/main@9da0335b4` / `codex/approval-editor-e2-shell-extract-20260728` | `5a9bb4db2` | Claude Sonnet 5 | 247 测、类型、事件变异；修复静态 style 守卫误判 | Draft PR #4642；required CI 绿 |
 | C1 | 线性/复杂流程统一 Canvas 载体 | E2 head / `codex/approval-editor-c1-unified-canvas-20260728` | `704276e1a` | Claude Opus 5 实现；Kimi exact-head 只读复审 | 真实视图写回、payload/dirty、promote 保真、flag fallback、删除下限及浏览器三 viewport | Draft PR #4649；required CI 绿 |
 | C2 | Canvas-first 工作区与表单/流程切换 | C1 head / `codex/approval-editor-c2-canvas-first-20260728` | `068d6e628` | Codex 实现；Kimi exact-head 对抗复审 | 默认画布、辅助模式、Form/Flow 往返、viewport 重测、ARIA、三 viewport 真浏览器 | Draft PR #4652；required CI 绿 |
+| F1-a | 表单 palette、插入槽和字段移动 | C2 head / `codex/approval-editor-f1-form-palette-20260728` | `6b926dce5` | Codex 实现；三轮独立子代理对抗复审 | 点击/typed drag 插入、handle-only 拖排、键盘/触屏等价、唯一字段 ID、三 viewport 真浏览器 | Draft PR #4657；required CI 绿 |
 
 ## 2. E1-b 执行事实
 
@@ -60,25 +61,25 @@ E2 只修改：
 
 ## 4. 状态矩阵
 
-| 面 | E1-b | E2 | C1 | C2 |
-|---|---|---|---|---|
-| 设计方向 | 已由 delta 计划约束 | 已由 delta 计划约束 | 已由 delta 计划约束 | 已由 delta 计划约束 |
-| 实现 | 完成 | 完成 | 完成 | 完成 |
-| 本地测试 | PASS | PASS | PASS | PASS |
-| 判别变异 | PASS | PASS | PASS（3 刀） | PASS（4 刀） |
-| 独立复审 | Codex | Codex | Kimi APPROVE，无 P1/P2；Codex复核修 P3 | Kimi APPROVE，无 P1/P2；Codex复核 |
-| 提交 | 是 | 是 | 是 | 是 |
-| push / PR | #4643 | #4642 | #4649（stacked on #4642） | #4652（stacked on #4649） |
-| required CI | PASS | PASS | PASS | PASS |
-| merge | 否 | 否 | 否 | 否 |
-| staging / UAT | 否 | 否 | 否 | 否 |
-| production flag | 保持 OFF | 保持 OFF | 保持 OFF | 保持 OFF |
+| 面 | E1-b | E2 | C1 | C2 | F1-a |
+|---|---|---|---|---|---|
+| 设计方向 | 已由 delta 计划约束 | 已由 delta 计划约束 | 已由 delta 计划约束 | 已由 delta 计划约束 | 已由 delta 计划约束 |
+| 实现 | 完成 | 完成 | 完成 | 完成 | 完成 |
+| 本地测试 | PASS | PASS | PASS | PASS | PASS |
+| 判别变异 | PASS | PASS | PASS（3 刀） | PASS（4 刀） | PASS（3 刀） |
+| 独立复审 | Codex | Codex | Kimi APPROVE，无 P1/P2；Codex复核修 P3 | Kimi APPROVE，无 P1/P2；Codex复核 | 三轮子代理复审；最终无 P1/P2 |
+| 提交 | 是 | 是 | 是 | 是 | 是 |
+| push / PR | #4643 | #4642 | #4649（stacked on #4642） | #4652（stacked on #4649） | #4657（stacked on #4652） |
+| required CI | PASS | PASS | PASS | PASS | PASS |
+| merge | 否 | 否 | 否 | 否 | 否 |
+| staging / UAT | 否 | 否 | 否 | 否 | 否 |
+| production flag | 保持 OFF | 保持 OFF | 保持 OFF | 保持 OFF | 保持 OFF |
 
 ## 5. 后续顺序
 
-1. 审阅并按依赖落 #4642 -> #4649 -> #4652；#4643 是 verification-only 独立支线；
+1. 审阅并按依赖落 #4642 -> #4649 -> #4652 -> #4657；#4643 是 verification-only 独立支线；
 2. C3 把节点按钮群改为边 `+`，C4/C5 收拖拽与 undo/redo；
-3. F1 抽表单 builder，并实现左 palette 拖入 + 中画布 + 右字段检查器；
+3. F1-a 已交付 palette/插入槽；F1-b 再抽表单 builder 并形成左 palette + 中画布 + 右字段检查器；
 4. F2/F3 补字段引用保护与附件 authoring；
 5. V1/V2、P1、X1 收版本、试运行、移动端/无障碍；
 6. T1 真浏览器 required CI 全闭合后才进入 staging UAT；
@@ -116,3 +117,26 @@ E2 只修改：
 - 一次变异恢复误命中同形 `@click`，单测未暴露，真实浏览器发现按钮目标
   反转；按按钮上下文修复后重跑完整测试与浏览器矩阵。该事件证明真浏览器
   不是可省略的展示步骤。
+
+## 8. F1-a 执行事实
+
+- Canvas flag ON 时，palette 从 `AUTHORABLE_FIELD_TYPES` 派生全部当前可编辑
+  字段类型；点击与 typed native drag 都写入同一草稿字段序列；
+- 字段前、中、后都有显式插入槽；插入槽是可聚焦按钮，支持鼠标、键盘和
+  触屏选择，再由 palette 点击插入；
+- 字段移动只允许从拖拽把手启动，本地 active drag index 必须与 typed
+  payload 一致；外来、缺失、负数和错配 payload 均 no-op；
+- `Alt+ArrowUp/Down` 与上下移动按钮保留为拖拽等价路径，并声明
+  `aria-keyshortcuts`；
+- 删除后新增字段使用最小未占用 `field_N`，避免 `fields.length + 1`
+  在编号空隙下生成重复 ID；
+- read-only 时 palette、插入槽和拖拽把手均不可写；Canvas flag OFF 保持
+  旧“添加字段”和原字段拖排路径；
+- focused specs 22/22、required web test 总计 359 文件 / 4320 测试、
+  `vue-tsc`、ESLint、web build 和 diff check 全通过；
+- 三刀判别变异分别中和前向移动索引修正、恢复易重复 ID 算法、删除 typed
+  payload 与本地拖拽会话一致性检查，指定测试均精确转红；
+- 真实 Chromium 在 1440 / 1024 / 390 验证桌面左右布局、窄屏纵向布局、
+  插入槽选择、字段插入、无横向溢出和零 console error；
+- 本刀未抽出 `ApprovalFormBuilder`，也未形成聚焦字段的独立右侧属性
+  inspector；这些明确留给 F1-b，不以 #4657 提前关闭。

--- a/docs/development/approval-editor-flow-parity-execution-ledger-20260728.md
+++ b/docs/development/approval-editor-flow-parity-execution-ledger-20260728.md
@@ -19,7 +19,8 @@ merge、部署、UAT 和 flag 是不同状态，不互相替代。
 | E1 | renderer spike | `origin/main@9da0335b4` / `codex/approval-editor-e1b-command-drag-20260728` | `6151d37cb` | Grok 4.5 Build；Kimi 做视觉 IA | Playwright、ESLint、类型、截图与 100 节点复核 | Draft PR #4643；required CI 绿 |
 | E1-b | 生产命令适配、drag、history | 基于 E1 / `codex/approval-editor-e1b-command-drag-20260728` | `2955a68da` | Grok 4.5 Build | stale focus 修复、判别变异、浏览器超时/100 节点交互稳定化 | Draft PR #4643；required CI 绿 |
 | E2 | Flow Canvas presentational shell 抽取 | `origin/main@9da0335b4` / `codex/approval-editor-e2-shell-extract-20260728` | `5a9bb4db2` | Claude Sonnet 5 | 247 测、类型、事件变异；修复静态 style 守卫误判 | Draft PR #4642；required CI 绿 |
-| C1 | 线性/复杂流程统一 Canvas 载体 | E2 head / `codex/approval-editor-c1-unified-canvas-20260728` | `704276e1a` | Claude Opus 5 实现；Kimi exact-head 只读复审 | 真实视图写回、payload/dirty、promote 保真、flag fallback、删除下限及浏览器三 viewport | Draft PR #4649；CI 修复后重跑 |
+| C1 | 线性/复杂流程统一 Canvas 载体 | E2 head / `codex/approval-editor-c1-unified-canvas-20260728` | `704276e1a` | Claude Opus 5 实现；Kimi exact-head 只读复审 | 真实视图写回、payload/dirty、promote 保真、flag fallback、删除下限及浏览器三 viewport | Draft PR #4649；required CI 绿 |
+| C2 | Canvas-first 工作区与表单/流程切换 | C1 head / `codex/approval-editor-c2-canvas-first-20260728` | `068d6e628` | Codex 实现；Kimi exact-head 对抗复审 | 默认画布、辅助模式、Form/Flow 往返、viewport 重测、ARIA、三 viewport 真浏览器 | Draft PR #4652；required CI 运行中 |
 
 ## 2. E1-b 执行事实
 
@@ -59,24 +60,24 @@ E2 只修改：
 
 ## 4. 状态矩阵
 
-| 面 | E1-b | E2 | C1 |
-|---|---|---|---|
-| 设计方向 | 已由 delta 计划约束 | 已由 delta 计划约束 | 已由 delta 计划约束 |
-| 实现 | 完成 | 完成 | 完成 |
-| 本地测试 | PASS | PASS | PASS |
-| 判别变异 | PASS | PASS | PASS（3 刀） |
-| 独立复审 | Codex | Codex | Kimi APPROVE，无 P1/P2；Codex复核修 P3 |
-| 提交 | 是 | 是 | 是 |
-| push / PR | #4643 | #4642 | #4649（stacked on #4642） |
-| required CI | PASS | PASS | 运行中 |
-| merge | 否 | 否 | 否 |
-| staging / UAT | 否 | 否 | 否 |
-| production flag | 保持 OFF | 保持 OFF | 保持 OFF |
+| 面 | E1-b | E2 | C1 | C2 |
+|---|---|---|---|---|
+| 设计方向 | 已由 delta 计划约束 | 已由 delta 计划约束 | 已由 delta 计划约束 | 已由 delta 计划约束 |
+| 实现 | 完成 | 完成 | 完成 | 完成 |
+| 本地测试 | PASS | PASS | PASS | PASS |
+| 判别变异 | PASS | PASS | PASS（3 刀） | PASS（4 刀） |
+| 独立复审 | Codex | Codex | Kimi APPROVE，无 P1/P2；Codex复核修 P3 | Kimi APPROVE，无 P1/P2；Codex复核 |
+| 提交 | 是 | 是 | 是 | 是 |
+| push / PR | #4643 | #4642 | #4649（stacked on #4642） | #4652（stacked on #4649） |
+| required CI | PASS | PASS | PASS | 运行中 |
+| merge | 否 | 否 | 否 | 否 |
+| staging / UAT | 否 | 否 | 否 | 否 |
+| production flag | 保持 OFF | 保持 OFF | 保持 OFF | 保持 OFF |
 
 ## 5. 后续顺序
 
-1. 审阅并按依赖落 #4642 -> #4649；#4643 是 verification-only 独立支线；
-2. C2 接通 canvas-first，C3 把节点按钮群改为边 `+`，C4/C5 收拖拽与 undo/redo；
+1. 审阅并按依赖落 #4642 -> #4649 -> #4652；#4643 是 verification-only 独立支线；
+2. C3 把节点按钮群改为边 `+`，C4/C5 收拖拽与 undo/redo；
 3. F1 抽表单 builder，并实现左 palette 拖入 + 中画布 + 右字段检查器；
 4. F2/F3 补字段引用保护与附件 authoring；
 5. V1/V2、P1、X1 收版本、试运行、移动端/无障碍；
@@ -98,3 +99,20 @@ E2 只修改：
 - 真 Chromium 在 1440 / 1024 / 390 无横向溢出或 console error；
 - 390 下 sticky bottom navigation 遮挡、卡片内按钮群和紧凑触控尺寸仍属于
   C2/C3/X1，未被 C1 结论掩盖。
+
+## 7. C2 执行事实
+
+- Canvas flag ON 时 `canvasViewMode` 默认 `canvas`，线性与复杂图一致；
+- “结构列表”改名“辅助编辑模式”，仍可切换且没有退役可访问回退；
+- 表单/流程 segmented control 使用 `role="group"` 与 `aria-pressed`，真实
+  production view 验证 Form -> Flow -> Form 往返；
+- Canvas 从隐藏状态重新显示时重测 viewport，避免隐藏挂载产生 0x0 minimap；
+- flag OFF 不出现新模式切换，不改变旧页面路径；
+- 17 个 authoring/canvas/graph 文件 260/260、focused mounted 22/22、
+  ESLint、`vue-tsc`、diff check 全通过；
+- 四刀变异分别中和默认 Canvas、模式切换、viewport watch 和 group 语义，
+  指定测试均精确转红；
+- 真 Chromium 1440 / 1024 / 390 均无横向溢出、console error 为 0；
+- 一次变异恢复误命中同形 `@click`，单测未暴露，真实浏览器发现按钮目标
+  反转；按按钮上下文修复后重跑完整测试与浏览器矩阵。该事件证明真浏览器
+  不是可省略的展示步骤。

--- a/docs/development/approval-editor-flow-parity-execution-ledger-20260728.md
+++ b/docs/development/approval-editor-flow-parity-execution-ledger-20260728.md
@@ -22,6 +22,8 @@ merge、部署、UAT 和 flag 是不同状态，不互相替代。
 | C1 | 线性/复杂流程统一 Canvas 载体 | E2 head / `codex/approval-editor-c1-unified-canvas-20260728` | `704276e1a` | Claude Opus 5 实现；Kimi exact-head 只读复审 | 真实视图写回、payload/dirty、promote 保真、flag fallback、删除下限及浏览器三 viewport | Draft PR #4649；required CI 绿 |
 | C2 | Canvas-first 工作区与表单/流程切换 | C1 head / `codex/approval-editor-c2-canvas-first-20260728` | `068d6e628` | Codex 实现；Kimi exact-head 对抗复审 | 默认画布、辅助模式、Form/Flow 往返、viewport 重测、ARIA、三 viewport 真浏览器 | Draft PR #4652；required CI 绿 |
 | F1-a | 表单 palette、插入槽和字段移动 | C2 head / `codex/approval-editor-f1-form-palette-20260728` | `6b926dce5` | Codex 实现；三轮独立子代理对抗复审 | 点击/typed drag 插入、handle-only 拖排、键盘/触屏等价、唯一字段 ID、三 viewport 真浏览器 | Draft PR #4657；required CI 绿 |
+| C3 | 合法边 `+` 与 typed 插入菜单 | C2 head / `codex/approval-editor-c3-edge-insert-agent-20260728` | `525915d3d` | 子代理实现；Codex exact-source 复核和修复 | 40x40 边控件、四类节点、renderer intent、无 default 条件图、parallel join 收敛、真浏览器 | Draft PR #4697；本地 required Web Tests / build PASS，PR CI 待结算 |
+| F1-b | 三栏表单 builder 与聚焦 inspector | F1-a head / `codex/approval-editor-f1b-form-builder-20260728` | `93a9527f2` | Codex 实现与复核 | 左 palette / 中画布 / 右 inspector、typed drag、键盘/触屏等价、flag OFF 回退、三 viewport 真浏览器 | Draft PR #4696；本地 required Web Tests / build PASS，PR CI 待结算 |
 
 ## 2. E1-b 执行事实
 
@@ -61,26 +63,26 @@ E2 只修改：
 
 ## 4. 状态矩阵
 
-| 面 | E1-b | E2 | C1 | C2 | F1-a |
-|---|---|---|---|---|---|
-| 设计方向 | 已由 delta 计划约束 | 已由 delta 计划约束 | 已由 delta 计划约束 | 已由 delta 计划约束 | 已由 delta 计划约束 |
-| 实现 | 完成 | 完成 | 完成 | 完成 | 完成 |
-| 本地测试 | PASS | PASS | PASS | PASS | PASS |
-| 判别变异 | PASS | PASS | PASS（3 刀） | PASS（4 刀） | PASS（3 刀） |
-| 独立复审 | Codex | Codex | Kimi APPROVE，无 P1/P2；Codex复核修 P3 | Kimi APPROVE，无 P1/P2；Codex复核 | 三轮子代理复审；最终无 P1/P2 |
-| 提交 | 是 | 是 | 是 | 是 | 是 |
-| push / PR | #4643 | #4642 | #4649（stacked on #4642） | #4652（stacked on #4649） | #4657（stacked on #4652） |
-| required CI | PASS | PASS | PASS | PASS | PASS |
-| merge | 否 | 否 | 否 | 否 | 否 |
-| staging / UAT | 否 | 否 | 否 | 否 | 否 |
-| production flag | 保持 OFF | 保持 OFF | 保持 OFF | 保持 OFF | 保持 OFF |
+| 面 | E1-b | E2 | C1 | C2 | F1-a | C3 | F1-b |
+|---|---|---|---|---|---|---|---|
+| 设计方向 | 已由 delta 计划约束 | 已由 delta 计划约束 | 已由 delta 计划约束 | 已由 delta 计划约束 | 已由 delta 计划约束 | 已由 delta 计划约束 | 已由 delta 计划约束 |
+| 实现 | 完成 | 完成 | 完成 | 完成 | 完成 | 完成 | 完成 |
+| 本地测试 | PASS | PASS | PASS | PASS | PASS | PASS | PASS |
+| 判别变异 | PASS | PASS | PASS（3 刀） | PASS（4 刀） | PASS（3 刀） | focused guards + exact browser | focused guards + exact browser |
+| 独立复审 | Codex | Codex | Kimi APPROVE，无 P1/P2；Codex复核修 P3 | Kimi APPROVE，无 P1/P2；Codex复核 | 三轮子代理复审；最终无 P1/P2 | Codex 复核，修 2 个 P2 级合法性漂移 | Codex exact-source 复核 |
+| 提交 | 是 | 是 | 是 | 是 | 是 | 是 | 是 |
+| push / PR | #4643 | #4642 | #4649（stacked on #4642） | #4652（stacked on #4649） | #4657（stacked on #4652） | #4697（stacked on #4652） | #4696（stacked on #4657） |
+| required CI | PASS | PASS | PASS | PASS | PASS | PR 待结算 | PR 待结算 |
+| merge | 否 | 否 | 否 | 否 | 否 | 否 | 否 |
+| staging / UAT | 否 | 否 | 否 | 否 | 否 | 否 | 否 |
+| production flag | 保持 OFF | 保持 OFF | 保持 OFF | 保持 OFF | 保持 OFF | 保持 OFF | 保持 OFF |
 
 ## 5. 后续顺序
 
-1. 审阅并按依赖落 #4642 -> #4649 -> #4652 -> #4657；#4643 是 verification-only 独立支线；
-2. C3 把节点按钮群改为边 `+`，C4/C5 收拖拽与 undo/redo；
-3. F1-a 已交付 palette/插入槽；F1-b 再抽表单 builder 并形成左 palette + 中画布 + 右字段检查器；
-4. F2/F3 补字段引用保护与附件 authoring；
+1. 审阅并按依赖落 #4642 -> #4649 -> #4652；其后 #4697 走 C3，#4657 -> #4696 走 F1；#4643 是 verification-only 独立支线；
+2. C3 已把节点按钮群改为边 `+`，C4/C5 继续收拖拽与 undo/redo；
+3. F1-a/F1-b 已交付 palette/插入槽和三栏 builder/inspector；
+4. F2/F3 补完整字段引用保护与附件 authoring；
 5. V1/V2、P1、X1 收版本、试运行、移动端/无障碍；
 6. T1 真浏览器 required CI 全闭合后才进入 staging UAT；
 7. production flag 和结构化辅助入口退役始终由 owner 单独决定。
@@ -140,3 +142,34 @@ E2 只修改：
   插入槽选择、字段插入、无横向溢出和零 console error；
 - 本刀未抽出 `ApprovalFormBuilder`，也未形成聚焦字段的独立右侧属性
   inspector；这些明确留给 F1-b，不以 #4657 提前关闭。
+
+## 9. C3 执行事实
+
+- 每条通过纯合法性判定的 edge 渲染一个 40x40 可聚焦 `+`；Enter/Space
+  打开菜单，Esc 关闭并返回原按钮；
+- menu 只列当前 edge 合法的 approval / cc / condition / parallel，parallel
+  branch 内不提供 nested parallel；
+- renderer 仅 emit typed insertion intent，父层调用既有 topology command；
+  节点卡内旧插入按钮群被移除，condition/parallel 的分支管理入口保留；
+- Codex 独立复核发现：条件图无显式 default 仍可合法执行，不能误锁；并行
+  分支仅“edge 存在”不足以开放写入，必须证明所有路径收敛到 configured join；
+- 修复后 focused specs 58/58，required Web Tests 360 文件 / 4335 测试，
+  `vue-tsc`、ESLint、production build 和 diff check 均通过；
+- 真 Chromium 验证 4 个节点 / 3 个 edge slot 插入后成为 5 / 4，menu 四项、
+  validity error 0；1440 下观察到 28px 全站顶栏既有横向溢出，画布、菜单、
+  inspector 本身无重叠，该 shell 残余记入 X1，未伪称整页零溢出。
+
+## 10. F1-b 执行事实
+
+- 新增 `ApprovalFormBuilder.vue` 与 `ApprovalFieldInspector.vue`；父 view 继续
+  拥有 draft、catalog 和保存/发布，不在子组件复制持久化合同；
+- flag ON 为左 palette、中字段画布、右聚焦 inspector；1024 降为两栏加
+  下方 inspector，390 为单列；flag OFF 保留旧全字段编辑列表；
+- palette 点击/拖入、字段 handle-only 拖排、插入槽、上下移动和
+  `Alt+ArrowUp/Down` 共用同一 fields 载体；typed payload 不放宽；
+- record-link catalog error/retry、detail、visibility、options 和 required
+  继续由同一 inspector 编辑，required source guard 同步到新 ownership；
+- required Web Tests 359 文件 / 4326 测试、`vue-tsc`、ESLint、production
+  build 和 diff check 均通过；
+- 真 Chromium 1440 / 1024 / 390 builder overflow 0、console error 0；桌面
+  拖入日期后字段数 3 -> 4，选中字段在右 inspector 改名成功。

--- a/docs/development/approval-editor-flow-parity-execution-ledger-20260728.md
+++ b/docs/development/approval-editor-flow-parity-execution-ledger-20260728.md
@@ -20,7 +20,7 @@ merge、部署、UAT 和 flag 是不同状态，不互相替代。
 | E1-b | 生产命令适配、drag、history | 基于 E1 / `codex/approval-editor-e1b-command-drag-20260728` | `2955a68da` | Grok 4.5 Build | stale focus 修复、判别变异、浏览器超时/100 节点交互稳定化 | Draft PR #4643；required CI 绿 |
 | E2 | Flow Canvas presentational shell 抽取 | `origin/main@9da0335b4` / `codex/approval-editor-e2-shell-extract-20260728` | `5a9bb4db2` | Claude Sonnet 5 | 247 测、类型、事件变异；修复静态 style 守卫误判 | Draft PR #4642；required CI 绿 |
 | C1 | 线性/复杂流程统一 Canvas 载体 | E2 head / `codex/approval-editor-c1-unified-canvas-20260728` | `704276e1a` | Claude Opus 5 实现；Kimi exact-head 只读复审 | 真实视图写回、payload/dirty、promote 保真、flag fallback、删除下限及浏览器三 viewport | Draft PR #4649；required CI 绿 |
-| C2 | Canvas-first 工作区与表单/流程切换 | C1 head / `codex/approval-editor-c2-canvas-first-20260728` | `068d6e628` | Codex 实现；Kimi exact-head 对抗复审 | 默认画布、辅助模式、Form/Flow 往返、viewport 重测、ARIA、三 viewport 真浏览器 | Draft PR #4652；required CI 运行中 |
+| C2 | Canvas-first 工作区与表单/流程切换 | C1 head / `codex/approval-editor-c2-canvas-first-20260728` | `068d6e628` | Codex 实现；Kimi exact-head 对抗复审 | 默认画布、辅助模式、Form/Flow 往返、viewport 重测、ARIA、三 viewport 真浏览器 | Draft PR #4652；required CI 绿 |
 
 ## 2. E1-b 执行事实
 
@@ -69,7 +69,7 @@ E2 只修改：
 | 独立复审 | Codex | Codex | Kimi APPROVE，无 P1/P2；Codex复核修 P3 | Kimi APPROVE，无 P1/P2；Codex复核 |
 | 提交 | 是 | 是 | 是 | 是 |
 | push / PR | #4643 | #4642 | #4649（stacked on #4642） | #4652（stacked on #4649） |
-| required CI | PASS | PASS | PASS | 运行中 |
+| required CI | PASS | PASS | PASS | PASS |
 | merge | 否 | 否 | 否 | 否 |
 | staging / UAT | 否 | 否 | 否 | 否 |
 | production flag | 保持 OFF | 保持 OFF | 保持 OFF | 保持 OFF |

--- a/docs/development/approval-editor-flow-parity-execution-ledger-20260728.md
+++ b/docs/development/approval-editor-flow-parity-execution-ledger-20260728.md
@@ -24,6 +24,8 @@ merge、部署、UAT 和 flag 是不同状态，不互相替代。
 | F1-a | 表单 palette、插入槽和字段移动 | C2 head / `codex/approval-editor-f1-form-palette-20260728` | `6b926dce5` | Codex 实现；三轮独立子代理对抗复审 | 点击/typed drag 插入、handle-only 拖排、键盘/触屏等价、唯一字段 ID、三 viewport 真浏览器 | Draft PR #4657；required CI 绿 |
 | C3 | 合法边 `+` 与 typed 插入菜单 | C2 head / `codex/approval-editor-c3-edge-insert-agent-20260728` | `525915d3d` | 子代理实现；Codex exact-source 复核和修复 | 40x40 边控件、四类节点、renderer intent、无 default 条件图、parallel join 收敛、真浏览器 | Draft PR #4697；本地 required Web Tests / build PASS；exact-head required CI PASS，merge state CLEAN |
 | F1-b | 三栏表单 builder 与聚焦 inspector | F1-a head / `codex/approval-editor-f1b-form-builder-20260728` | `93a9527f2` | Codex 实现与复核 | 左 palette / 中画布 / 右 inspector、typed drag、键盘/触屏等价、flag OFF 回退、三 viewport 真浏览器 | Draft PR #4696；本地 required Web Tests / build PASS；exact-head required CI PASS，merge state CLEAN |
+| C4 | 语义节点拖拽与条件/并行分支排序 | C3 head / `codex/approval-editor-c4-semantic-drag-20260731` | `c6f0b7bbc` | 子代理实现；Codex exact-source 复核 | renderer intent-only、统一 command seam、合法槽、stale/cross-region no-op、values-free live message、键盘等价 | Draft PR #4698；本地 required Web 360/4338 + build PASS；PR checks 运行中；真浏览器证据待补 |
+| F2 | 表单结构命令、历史身份与 FWB 引用保护 | F1-b head / `codex/approval-editor-f2-form-command-protection-20260731` | `5fff366e8` + `4ccc20f71` | Codex 前端；子代理后端；Codex 组合复核 | UUID identity、全版本字段/明细列历史、values-free 引用、发布同事务 gate、错配/畸形上下文 fail-closed | Draft PR #4699；required Web 359/4330、unit 147、fresh PG15 API 8/8、两刀 mutation RED；PR checks 运行中 |
 
 ## 2. E1-b 执行事实
 
@@ -63,26 +65,24 @@ E2 只修改：
 
 ## 4. 状态矩阵
 
-| 面 | E1-b | E2 | C1 | C2 | F1-a | C3 | F1-b |
-|---|---|---|---|---|---|---|---|
-| 设计方向 | 已由 delta 计划约束 | 已由 delta 计划约束 | 已由 delta 计划约束 | 已由 delta 计划约束 | 已由 delta 计划约束 | 已由 delta 计划约束 | 已由 delta 计划约束 |
-| 实现 | 完成 | 完成 | 完成 | 完成 | 完成 | 完成 | 完成 |
-| 本地测试 | PASS | PASS | PASS | PASS | PASS | PASS | PASS |
-| 判别变异 | PASS | PASS | PASS（3 刀） | PASS（4 刀） | PASS（3 刀） | focused guards + exact browser | focused guards + exact browser |
-| 独立复审 | Codex | Codex | Kimi APPROVE，无 P1/P2；Codex复核修 P3 | Kimi APPROVE，无 P1/P2；Codex复核 | 三轮子代理复审；最终无 P1/P2 | Codex 复核，修 2 个 P2 级合法性漂移 | Codex exact-source 复核 |
-| 提交 | 是 | 是 | 是 | 是 | 是 | 是 | 是 |
-| push / PR | #4643 | #4642 | #4649（stacked on #4642） | #4652（stacked on #4649） | #4657（stacked on #4652） | #4697（stacked on #4652） | #4696（stacked on #4657） |
-| required CI | PASS | PASS | PASS | PASS | PASS | PR 待结算 | PR 待结算 |
-| merge | 否 | 否 | 否 | 否 | 否 | 否 | 否 |
-| staging / UAT | 否 | 否 | 否 | 否 | 否 | 否 | 否 |
-| production flag | 保持 OFF | 保持 OFF | 保持 OFF | 保持 OFF | 保持 OFF | 保持 OFF | 保持 OFF |
+| 面 | E1-b | E2 | C1 | C2 | F1-a | C3 | F1-b | C4 | F2 |
+|---|---|---|---|---|---|---|---|---|---|
+| 设计方向 | 已约束 | 已约束 | 已约束 | 已约束 | 已约束 | 已约束 | 已约束 | 已约束 | 已约束 |
+| 实现 | 完成 | 完成 | 完成 | 完成 | 完成 | 完成 | 完成 | 完成 | 完成 |
+| 本地测试 | PASS | PASS | PASS | PASS | PASS | PASS | PASS | PASS | PASS |
+| 判别变异 | PASS | PASS | 3 刀 | 4 刀 | 3 刀 | focused + browser | focused + browser | command/mounted 判别 | 2 刀 + real DB |
+| 独立复审 | Codex | Codex | Kimi + Codex | Kimi + Codex | 子代理 + Codex | Codex | Codex | Codex，无 P1/P2 | Codex 组合复核，修 DTO/mock/运行时校验 |
+| push / PR | #4643 | #4642 | #4649 | #4652 | #4657 | #4697 | #4696 | #4698 | #4699 |
+| required CI | PASS | PASS | PASS | PASS | PASS | PASS | PASS | 运行中 | 运行中 |
+| 真浏览器 | PASS | N/A | PASS | PASS | PASS | PASS | PASS | 待补 | 待补 |
+| merge / UAT / flag | 全部否 | 全部否 | 全部否 | 全部否 | 全部否 | 全部否 | 全部否 | 全部否 | 全部否 |
 
 ## 5. 后续顺序
 
 1. 审阅并按依赖落 #4642 -> #4649 -> #4652；其后 #4697 走 C3，#4657 -> #4696 走 F1；#4643 是 verification-only 独立支线；
-2. C3 已把节点按钮群改为边 `+`，C4/C5 继续收拖拽与 undo/redo；
-3. F1-a/F1-b 已交付 palette/插入槽和三栏 builder/inspector；
-4. F2/F3 补完整字段引用保护与附件 authoring；
+2. C3/C4 已交付边 `+`、语义拖拽与分支排序；C5 继续收统一 undo/redo；
+3. F1-a/F1-b/F2 已交付 palette、三栏 builder、命令层与外部引用保护；
+4. F3 补附件 authoring；
 5. V1/V2、P1、X1 收版本、试运行、移动端/无障碍；
 6. T1 真浏览器 required CI 全闭合后才进入 staging UAT；
 7. production flag 和结构化辅助入口退役始终由 owner 单独决定。

--- a/docs/development/approval-editor-flow-parity-execution-ledger-20260728.md
+++ b/docs/development/approval-editor-flow-parity-execution-ledger-20260728.md
@@ -22,8 +22,8 @@ merge、部署、UAT 和 flag 是不同状态，不互相替代。
 | C1 | 线性/复杂流程统一 Canvas 载体 | E2 head / `codex/approval-editor-c1-unified-canvas-20260728` | `704276e1a` | Claude Opus 5 实现；Kimi exact-head 只读复审 | 真实视图写回、payload/dirty、promote 保真、flag fallback、删除下限及浏览器三 viewport | Draft PR #4649；required CI 绿 |
 | C2 | Canvas-first 工作区与表单/流程切换 | C1 head / `codex/approval-editor-c2-canvas-first-20260728` | `068d6e628` | Codex 实现；Kimi exact-head 对抗复审 | 默认画布、辅助模式、Form/Flow 往返、viewport 重测、ARIA、三 viewport 真浏览器 | Draft PR #4652；required CI 绿 |
 | F1-a | 表单 palette、插入槽和字段移动 | C2 head / `codex/approval-editor-f1-form-palette-20260728` | `6b926dce5` | Codex 实现；三轮独立子代理对抗复审 | 点击/typed drag 插入、handle-only 拖排、键盘/触屏等价、唯一字段 ID、三 viewport 真浏览器 | Draft PR #4657；required CI 绿 |
-| C3 | 合法边 `+` 与 typed 插入菜单 | C2 head / `codex/approval-editor-c3-edge-insert-agent-20260728` | `525915d3d` | 子代理实现；Codex exact-source 复核和修复 | 40x40 边控件、四类节点、renderer intent、无 default 条件图、parallel join 收敛、真浏览器 | Draft PR #4697；本地 required Web Tests / build PASS，PR CI 待结算 |
-| F1-b | 三栏表单 builder 与聚焦 inspector | F1-a head / `codex/approval-editor-f1b-form-builder-20260728` | `93a9527f2` | Codex 实现与复核 | 左 palette / 中画布 / 右 inspector、typed drag、键盘/触屏等价、flag OFF 回退、三 viewport 真浏览器 | Draft PR #4696；本地 required Web Tests / build PASS，PR CI 待结算 |
+| C3 | 合法边 `+` 与 typed 插入菜单 | C2 head / `codex/approval-editor-c3-edge-insert-agent-20260728` | `525915d3d` | 子代理实现；Codex exact-source 复核和修复 | 40x40 边控件、四类节点、renderer intent、无 default 条件图、parallel join 收敛、真浏览器 | Draft PR #4697；本地 required Web Tests / build PASS；exact-head required CI PASS，merge state CLEAN |
+| F1-b | 三栏表单 builder 与聚焦 inspector | F1-a head / `codex/approval-editor-f1b-form-builder-20260728` | `93a9527f2` | Codex 实现与复核 | 左 palette / 中画布 / 右 inspector、typed drag、键盘/触屏等价、flag OFF 回退、三 viewport 真浏览器 | Draft PR #4696；本地 required Web Tests / build PASS；exact-head required CI PASS，merge state CLEAN |
 
 ## 2. E1-b 执行事实
 

--- a/docs/development/approval-editor-flow-parity-execution-ledger-20260728.md
+++ b/docs/development/approval-editor-flow-parity-execution-ledger-20260728.md
@@ -24,8 +24,11 @@ merge、部署、UAT 和 flag 是不同状态，不互相替代。
 | F1-a | 表单 palette、插入槽和字段移动 | C2 head / `codex/approval-editor-f1-form-palette-20260728` | `6b926dce5` | Codex 实现；三轮独立子代理对抗复审 | 点击/typed drag 插入、handle-only 拖排、键盘/触屏等价、唯一字段 ID、三 viewport 真浏览器 | Draft PR #4657；required CI 绿 |
 | C3 | 合法边 `+` 与 typed 插入菜单 | C2 head / `codex/approval-editor-c3-edge-insert-agent-20260728` | `525915d3d` | 子代理实现；Codex exact-source 复核和修复 | 40x40 边控件、四类节点、renderer intent、无 default 条件图、parallel join 收敛、真浏览器 | Draft PR #4697；本地 required Web Tests / build PASS；exact-head required CI PASS，merge state CLEAN |
 | F1-b | 三栏表单 builder 与聚焦 inspector | F1-a head / `codex/approval-editor-f1b-form-builder-20260728` | `93a9527f2` | Codex 实现与复核 | 左 palette / 中画布 / 右 inspector、typed drag、键盘/触屏等价、flag OFF 回退、三 viewport 真浏览器 | Draft PR #4696；本地 required Web Tests / build PASS；exact-head required CI PASS，merge state CLEAN |
-| C4 | 语义节点拖拽与条件/并行分支排序 | C3 head / `codex/approval-editor-c4-semantic-drag-20260731` | `c6f0b7bbc` | 子代理实现；Codex exact-source 复核 | renderer intent-only、统一 command seam、合法槽、stale/cross-region no-op、values-free live message、键盘等价 | Draft PR #4698；本地 required Web 360/4338 + build PASS；PR checks 运行中；真浏览器证据待补 |
-| F2 | 表单结构命令、历史身份与 FWB 引用保护 | F1-b head / `codex/approval-editor-f2-form-command-protection-20260731` | `5fff366e8` + `4ccc20f71` | Codex 前端；子代理后端；Codex 组合复核 | UUID identity、全版本字段/明细列历史、values-free 引用、发布同事务 gate、错配/畸形上下文 fail-closed | Draft PR #4699；required Web 359/4330、unit 147、fresh PG15 API 8/8、两刀 mutation RED；PR checks 运行中 |
+| C4 | 语义节点拖拽与条件/并行分支排序 | C3 head / `codex/approval-editor-c4-semantic-drag-20260731` | `c6f0b7bbc` | 子代理实现；Codex exact-source 复核 | renderer intent-only、统一 command seam、合法槽、stale/cross-region no-op、values-free live message、键盘等价 | Draft PR #4698；本地 required Web 360/4338 + build PASS；required checks 3/3 PASS、CLEAN；真浏览器证据待补 |
+| F2 | 表单结构命令、历史身份与 FWB 引用保护 | F1-b head / `codex/approval-editor-f2-form-command-protection-20260731` | `5fff366e8` + `4ccc20f71` | Codex 前端；子代理后端；Codex 组合复核 | UUID identity、全版本字段/明细列历史、values-free 引用、发布同事务 gate、错配/畸形上下文 fail-closed | Draft PR #4699；required Web 359/4330、unit 147、fresh PG15 API 8/8、两刀 mutation RED；required checks 3/3 PASS、CLEAN |
+| F3 | 附件字段 authoring 双 flag 兼容 | F2 head / `codex/approval-editor-f3-attachment-authoring-20260731` | `2cbbd539a` | Codex 实现与复核 | palette allowlist、已有附件模板 fail-closed、flag OFF 不丢字段 | Draft PR #4700；required checks 3/3 PASS；CLEAN；真浏览器整链待 T1 |
+| C5 | Canvas/节点检查器统一 undo/redo | C4 head / `codex/approval-editor-c5-unified-history-20260731` | `a2dacd562` | Codex 实现；Kimi 只读复核 | 顶栏/快捷键、稳定 key 选择、焦点恢复、redo 分叉清理 | Draft PR #4701；required checks 3/3 PASS；CLEAN；真浏览器整链待 T1 |
+| I1 | 表单与 Canvas 单一 per-draft history 最终组合 | F3 head + C3/C4/C5 / `codex/approval-editor-2-final-integration-20260731` | `7192a56fd` | Codex 实现/组合复核；Kimi 对抗复核；Grok 上游不可用 | 受控字段组件、唯一父层写入口、表单四类命令、changed-key restore、保存边界、身份不可复用 | Draft PR #4702；本地 focused 46/46、required Web 360/4366、lint/type/build PASS、五刀 mutation RED；required checks 3/3 PASS |
 
 ## 2. E1-b 执行事实
 
@@ -73,16 +76,30 @@ E2 只修改：
 | 判别变异 | PASS | PASS | 3 刀 | 4 刀 | 3 刀 | focused + browser | focused + browser | command/mounted 判别 | 2 刀 + real DB |
 | 独立复审 | Codex | Codex | Kimi + Codex | Kimi + Codex | 子代理 + Codex | Codex | Codex | Codex，无 P1/P2 | Codex 组合复核，修 DTO/mock/运行时校验 |
 | push / PR | #4643 | #4642 | #4649 | #4652 | #4657 | #4697 | #4696 | #4698 | #4699 |
-| required CI | PASS | PASS | PASS | PASS | PASS | PASS | PASS | 运行中 | 运行中 |
+| required CI | PASS | PASS | PASS | PASS | PASS | PASS | PASS | PASS | PASS |
 | 真浏览器 | PASS | N/A | PASS | PASS | PASS | PASS | PASS | 待补 | 待补 |
 | merge / UAT / flag | 全部否 | 全部否 | 全部否 | 全部否 | 全部否 | 全部否 | 全部否 | 全部否 | 全部否 |
+
+新增切片状态：
+
+| 面 | F3 | C5 | I1 (#4702) |
+|---|---|---|---|
+| 设计方向 | 已约束 | 已约束 | 锁 §7.1 组合闭环 |
+| 实现 | 完成 | 完成 | 完成 |
+| 本地测试 | PASS | PASS | PASS |
+| 判别变异 | focused 判别 | history 判别 | 5 刀 RED-before |
+| 独立复审 | Codex | Codex | Kimi + Codex；无未闭合 P1/P2 |
+| push / PR | #4700 | #4701 | #4702 |
+| required CI | PASS | PASS | PASS |
+| 真浏览器 | 整链待 T1 | 整链待 T1 | 待 T1 |
+| merge / UAT / flag | 全部否 | 全部否 | 全部否 |
 
 ## 5. 后续顺序
 
 1. 审阅并按依赖落 #4642 -> #4649 -> #4652；其后 #4697 走 C3，#4657 -> #4696 走 F1；#4643 是 verification-only 独立支线；
-2. C3/C4 已交付边 `+`、语义拖拽与分支排序；C5 继续收统一 undo/redo；
-3. F1-a/F1-b/F2 已交付 palette、三栏 builder、命令层与外部引用保护；
-4. F3 补附件 authoring；
+2. C3/C4/C5 已交付边 `+`、语义拖拽、分支排序及 Canvas/节点检查器统一历史；
+3. F1-a/F1-b/F2/F3 已交付 palette、三栏 builder、命令层、外部引用保护及附件双 flag authoring；
+4. #4702 已完成表单与 Canvas 单一 history 的组合收口，required checks 3/3 PASS，待 owner 审阅；
 5. V1/V2、P1、X1 收版本、试运行、移动端/无障碍；
 6. T1 真浏览器 required CI 全闭合后才进入 staging UAT；
 7. production flag 和结构化辅助入口退役始终由 owner 单独决定。
@@ -173,3 +190,26 @@ E2 只修改：
   build 和 diff check 均通过；
 - 真 Chromium 1440 / 1024 / 390 builder overflow 0、console error 0；桌面
   拖入日期后字段数 3 -> 4，选中字段在右 inspector 改名成功。
+
+## 11. C4 / C5 / F2 / F3 / I1 执行事实
+
+- C4 的 node/branch drag intent 只在页面进入既有 command algebra；合法槽、
+  session token、stale/cross-region no-op 和 values-free live message 已由
+  focused tests 与 required CI 覆盖，真浏览器仍待 T1；
+- C5 把 Canvas 和节点检查器的 topology/configure/delete 统一进顶栏历史，
+  selection/focus 用稳定业务 key 恢复；#4701 required checks 3/3 PASS；
+- F2 的后端 identity/reference authority 与发布同事务 gate 保持不变；F3 只在
+  Canvas+附件双 flag 时开放新附件字段，旧模板在能力关闭时 read-only；
+- I1 将 `ApprovalFieldInspector` 改为 props-in/events-out，
+  `ApprovalFormBuilder` 不再通过嵌套 `v-model` 拥有草稿，父 view 成为唯一写
+  入口；add/remove/move/configure-form-field 与 Canvas 共用一个 history；
+- history entry 记录命令实际改变的顶层 draft key，避免撤销字段操作覆盖后来
+  修改的 description 等基本信息；成功保存回读全版本 identity context 后清空
+  本地历史与临时退役集合，失败保存保留 undo；
+- exact head `7192a56fd`：focused 46/46、required Web 360 文件 / 4366 测试、
+  targeted ESLint、`vue-tsc --noEmit`、production build、diff check 全 PASS；
+- 五刀判别变异依次中和 history gate、身份保留、changed-key restore、焦点
+  fallback 和成功保存历史边界，指定测试均 RED，恢复后全绿；
+- Kimi 对抗复核确认受控组件 ownership、nested field mutation 和 flag OFF
+  路径没有 P1；其跨保存旧快照风险已通过成功/失败保存边界回归关闭。Grok
+  session 因上游连接失败未读取代码，不计入复核证据。

--- a/docs/development/approval-editor-flow-parity-execution-ledger-20260728.md
+++ b/docs/development/approval-editor-flow-parity-execution-ledger-20260728.md
@@ -19,7 +19,7 @@ merge、部署、UAT 和 flag 是不同状态，不互相替代。
 | E1 | renderer spike | `origin/main@9da0335b4` / `codex/approval-editor-e1b-command-drag-20260728` | `6151d37cb` | Grok 4.5 Build；Kimi 做视觉 IA | Playwright、ESLint、类型、截图与 100 节点复核 | Draft PR #4643；required CI 绿 |
 | E1-b | 生产命令适配、drag、history | 基于 E1 / `codex/approval-editor-e1b-command-drag-20260728` | `2955a68da` | Grok 4.5 Build | stale focus 修复、判别变异、浏览器超时/100 节点交互稳定化 | Draft PR #4643；required CI 绿 |
 | E2 | Flow Canvas presentational shell 抽取 | `origin/main@9da0335b4` / `codex/approval-editor-e2-shell-extract-20260728` | `5a9bb4db2` | Claude Sonnet 5 | 247 测、类型、事件变异；修复静态 style 守卫误判 | Draft PR #4642；required CI 绿 |
-| C1 | 线性/复杂流程统一 Canvas 载体 | E2 head / `codex/approval-editor-c1-unified-canvas-20260728` | `bbd436177` | Claude Opus 5 实现；Kimi exact-head 只读复审 | 真实视图写回、payload/dirty、promote 保真、flag fallback、删除下限及浏览器三 viewport | Draft PR #4649；CI 运行中 |
+| C1 | 线性/复杂流程统一 Canvas 载体 | E2 head / `codex/approval-editor-c1-unified-canvas-20260728` | `704276e1a` | Claude Opus 5 实现；Kimi exact-head 只读复审 | 真实视图写回、payload/dirty、promote 保真、flag fallback、删除下限及浏览器三 viewport | Draft PR #4649；CI 修复后重跑 |
 
 ## 2. E1-b 执行事实
 
@@ -92,6 +92,9 @@ E2 只修改：
 - first structural edit 使用 `applyTopologyToDraft`，不另造 promote 路径；
 - edge count、parallel region、validity 全部基于 `canvasEffectiveGraph`；
 - 删除守卫按有效图审批节点数工作，promote 后仍保留最后一个审批节点；
+- required approval-web-guard 首跑暴露旧 inspector 删除正控仍使用唯一审批
+  fixture；改为两个审批节点后，既保留删除/selection 正控，也不弱化最后节点
+  拒绝，目标 20/20；
 - 真 Chromium 在 1440 / 1024 / 390 无横向溢出或 console error；
 - 390 下 sticky bottom navigation 遮挡、卡片内按钮群和紧凑触控尺寸仍属于
   C2/C3/X1，未被 C1 结论掩盖。

--- a/docs/development/approval-editor-flow-parity-execution-ledger-20260728.md
+++ b/docs/development/approval-editor-flow-parity-execution-ledger-20260728.md
@@ -15,10 +15,11 @@ merge、部署、UAT 和 flag 是不同状态，不互相替代。
 
 | ID | 交付 | 基线 / 分支 | 提交 | 实现模型 | Codex 复核 | 当前状态 |
 |---|---|---|---|---|---|---|
-| E0 | exact-head 审计 | `d449aa7e6` / `codex/approval-editor-flow-parity-plan-20260727` | `1941e2f0c` | Claude Opus 5 只读反例 + Codex | 代码、测试、flag、设计锁逐项核对 | 文档已提交；未 push |
-| E1 | renderer spike | `origin/main@9da0335b4` / `codex/approval-editor-e1b-command-drag-20260728` | `6151d37cb` | Grok 4.5 Build；Kimi 做视觉 IA | Playwright、ESLint、类型、截图与 100 节点复核 | verification-only；未 push |
-| E1-b | 生产命令适配、drag、history | 基于 E1 / `codex/approval-editor-e1b-command-drag-20260728` | `1303d7ba7` | Grok 4.5 Build | 发现并修复移动后 stale focus id；补判别变异 | verification-only；未 push |
-| E2 | Flow Canvas presentational shell 抽取 | `origin/main@9da0335b4` / `codex/approval-editor-e2-shell-extract-20260728` | `ffe0c6229` | Claude Sonnet 5 | 清理 4 个 lint 残差；247 测、类型、事件变异 | local verified；未 push |
+| E0 | exact-head 审计 | `d449aa7e6` / `codex/approval-editor-flow-parity-plan-20260727` | `1941e2f0c` | Claude Opus 5 只读反例 + Codex | 代码、测试、flag、设计锁逐项核对 | Draft PR #4644；required CI 绿 |
+| E1 | renderer spike | `origin/main@9da0335b4` / `codex/approval-editor-e1b-command-drag-20260728` | `6151d37cb` | Grok 4.5 Build；Kimi 做视觉 IA | Playwright、ESLint、类型、截图与 100 节点复核 | Draft PR #4643；required CI 绿 |
+| E1-b | 生产命令适配、drag、history | 基于 E1 / `codex/approval-editor-e1b-command-drag-20260728` | `2955a68da` | Grok 4.5 Build | stale focus 修复、判别变异、浏览器超时/100 节点交互稳定化 | Draft PR #4643；required CI 绿 |
+| E2 | Flow Canvas presentational shell 抽取 | `origin/main@9da0335b4` / `codex/approval-editor-e2-shell-extract-20260728` | `5a9bb4db2` | Claude Sonnet 5 | 247 测、类型、事件变异；修复静态 style 守卫误判 | Draft PR #4642；required CI 绿 |
+| C1 | 线性/复杂流程统一 Canvas 载体 | E2 head / `codex/approval-editor-c1-unified-canvas-20260728` | `bbd436177` | Claude Opus 5 实现；Kimi exact-head 只读复审 | 真实视图写回、payload/dirty、promote 保真、flag fallback、删除下限及浏览器三 viewport | Draft PR #4649；CI 运行中 |
 
 ## 2. E1-b 执行事实
 
@@ -58,25 +59,39 @@ E2 只修改：
 
 ## 4. 状态矩阵
 
-| 面 | E1-b | E2 |
-|---|---|---|
-| 设计方向 | 已由 delta 计划约束 | 已由 delta 计划约束 |
-| 实现 | 完成 | 完成 |
-| 本地测试 | PASS | PASS |
-| 判别变异 | PASS | PASS |
-| 提交 | 是 | 是 |
-| push | 否 | 否 |
-| required CI | 未运行 | 未运行 |
-| merge | 否 | 否 |
-| staging / UAT | 否 | 否 |
-| production flag | 保持 OFF | 保持 OFF |
+| 面 | E1-b | E2 | C1 |
+|---|---|---|---|
+| 设计方向 | 已由 delta 计划约束 | 已由 delta 计划约束 | 已由 delta 计划约束 |
+| 实现 | 完成 | 完成 | 完成 |
+| 本地测试 | PASS | PASS | PASS |
+| 判别变异 | PASS | PASS | PASS（3 刀） |
+| 独立复审 | Codex | Codex | Kimi APPROVE，无 P1/P2；Codex复核修 P3 |
+| 提交 | 是 | 是 | 是 |
+| push / PR | #4643 | #4642 | #4649（stacked on #4642） |
+| required CI | PASS | PASS | 运行中 |
+| merge | 否 | 否 | 否 |
+| staging / UAT | 否 | 否 | 否 |
+| production flag | 保持 OFF | 保持 OFF | 保持 OFF |
 
 ## 5. 后续顺序
 
-1. 对 E1-b、E2 做 owner review；决定是否 push / 开 PR；
-2. 合入 E2 后才启动 C1 线性/复杂图统一 adapter；
-3. C1 的未编辑 round-trip 和旧图保真通过后，才启动 C2 canvas-first；
-4. E0 的 required CI、业务错误文案和表单命令绕过问题分别小刀关闭；
-5. F1 在 E2 后抽表单 builder，再做 palette 拖入；
+1. 审阅并按依赖落 #4642 -> #4649；#4643 是 verification-only 独立支线；
+2. C2 接通 canvas-first，C3 把节点按钮群改为边 `+`，C4/C5 收拖拽与 undo/redo；
+3. F1 抽表单 builder，并实现左 palette 拖入 + 中画布 + 右字段检查器；
+4. F2/F3 补字段引用保护与附件 authoring；
+5. V1/V2、P1、X1 收版本、试运行、移动端/无障碍；
 6. T1 真浏览器 required CI 全闭合后才进入 staging UAT；
 7. production flag 和结构化辅助入口退役始终由 owner 单独决定。
+
+## 6. C1 执行事实
+
+- 线性 node key 规则只有 `linearCanvasCarrier.ts` 一处权威；
+- inspector 的 source、ids、field、level、mode、empty policy、self-approval
+  与 field permissions 全部写回 `ApprovalStepDraft`；
+- view toggle 和 selection 不写 draft；保存 payload 只读 draft；
+- first structural edit 使用 `applyTopologyToDraft`，不另造 promote 路径；
+- edge count、parallel region、validity 全部基于 `canvasEffectiveGraph`；
+- 删除守卫按有效图审批节点数工作，promote 后仍保留最后一个审批节点；
+- 真 Chromium 在 1440 / 1024 / 390 无横向溢出或 console error；
+- 390 下 sticky bottom navigation 遮挡、卡片内按钮群和紧凑触控尺寸仍属于
+  C2/C3/X1，未被 C1 结论掩盖。

--- a/docs/development/approval-editor-flow-parity-execution-ledger-20260728.md
+++ b/docs/development/approval-editor-flow-parity-execution-ledger-20260728.md
@@ -1,0 +1,82 @@
+# 审批编辑器与流程编排对标执行台账（2026-07-28）
+
+**状态：IN PROGRESS**
+
+**权威交互合同：**
+`approval-canvas-v2-interaction-design-lock-20260721.md`
+
+**本轮 delta 计划：**
+`approval-editor-flow-parity-development-plan-20260727.md`
+
+本台账只记录实际执行状态。`IMPLEMENTED`、测试通过、提交、push、CI、
+merge、部署、UAT 和 flag 是不同状态，不互相替代。
+
+## 1. 切片台账
+
+| ID | 交付 | 基线 / 分支 | 提交 | 实现模型 | Codex 复核 | 当前状态 |
+|---|---|---|---|---|---|---|
+| E0 | exact-head 审计 | `d449aa7e6` / `codex/approval-editor-flow-parity-plan-20260727` | `1941e2f0c` | Claude Opus 5 只读反例 + Codex | 代码、测试、flag、设计锁逐项核对 | 文档已提交；未 push |
+| E1 | renderer spike | `origin/main@9da0335b4` / `codex/approval-editor-e1b-command-drag-20260728` | `6151d37cb` | Grok 4.5 Build；Kimi 做视觉 IA | Playwright、ESLint、类型、截图与 100 节点复核 | verification-only；未 push |
+| E1-b | 生产命令适配、drag、history | 基于 E1 / `codex/approval-editor-e1b-command-drag-20260728` | `1303d7ba7` | Grok 4.5 Build | 发现并修复移动后 stale focus id；补判别变异 | verification-only；未 push |
+| E2 | Flow Canvas presentational shell 抽取 | `origin/main@9da0335b4` / `codex/approval-editor-e2-shell-extract-20260728` | `ffe0c6229` | Claude Sonnet 5 | 清理 4 个 lint 残差；247 测、类型、事件变异 | local verified；未 push |
+
+## 2. E1-b 执行事实
+
+改动仅位于 `apps/web/verification/`：
+
+- harness 引用生产 `approvalCanvasCommands`；
+- reorder、move、undo、redo 共用生产 history；
+- pointer/HTML5 drag 与键盘调用同一 adapter；
+- typed rejection 映射 values-free 文案；
+- graph snapshot 不持久化 renderer 坐标；
+- selection 用稳定业务 key 映射当前 focus id。
+
+模型第一版存在真实缺陷：拓扑重排后保留旧 `selectedFocusId`，可能使
+inspector 指向另一个节点。Codex 返回同一 Grok session 修复后，再中和
+稳定键恢复逻辑，Playwright 精确转红；恢复后转绿。
+
+## 3. E2 执行事实
+
+E2 只修改：
+
+- `apps/web/src/views/approval/TemplateAuthoringView.vue`
+- `apps/web/src/approvals/components/ApprovalFlowCanvas.vue`（新增）
+- `apps/web/tests/approval-template-authoring-canvas-inspector.spec.ts`
+
+边界：
+
+- 父组件继续拥有 draft、selection、zoom、viewport、save/publish 和全部
+  topology/command handlers；
+- 子组件只接收派生 props、渲染既有 DOM，并发出 typed intents；
+- `ApprovalGraphNodeConfigEditor` 继续复用同一 provide/inject 上下文；
+- scoped CSS 随 markup 移入子组件；列表所需样式保留在父组件；
+- 25 个 Canvas `data-testid` 抽取前后集合一致；
+- 无依赖、后端、API、payload、feature flag 或默认视图改动。
+
+父组件由 3732 行降至 3340 行。新增 shell 为 526 行；本刀不是最终文件
+拆分，后续 form、shell 和 version 仍按计划独立切片。
+
+## 4. 状态矩阵
+
+| 面 | E1-b | E2 |
+|---|---|---|
+| 设计方向 | 已由 delta 计划约束 | 已由 delta 计划约束 |
+| 实现 | 完成 | 完成 |
+| 本地测试 | PASS | PASS |
+| 判别变异 | PASS | PASS |
+| 提交 | 是 | 是 |
+| push | 否 | 否 |
+| required CI | 未运行 | 未运行 |
+| merge | 否 | 否 |
+| staging / UAT | 否 | 否 |
+| production flag | 保持 OFF | 保持 OFF |
+
+## 5. 后续顺序
+
+1. 对 E1-b、E2 做 owner review；决定是否 push / 开 PR；
+2. 合入 E2 后才启动 C1 线性/复杂图统一 adapter；
+3. C1 的未编辑 round-trip 和旧图保真通过后，才启动 C2 canvas-first；
+4. E0 的 required CI、业务错误文案和表单命令绕过问题分别小刀关闭；
+5. F1 在 E2 后抽表单 builder，再做 palette 拖入；
+6. T1 真浏览器 required CI 全闭合后才进入 staging UAT；
+7. production flag 和结构化辅助入口退役始终由 owner 单独决定。


### PR DESCRIPTION
## What\n- add the Approval Designer 2.0 delta development plan\n- record the exact-head E0 audit\n- record E1/E1-b renderer verification\n- add the execution ledger and scoped closeout verification\n\n## State discipline\nThe line remains IN PROGRESS / NOT FINAL. E1-b is verification-only; E2 is locally verified but not merged. C1+, staging UAT, production enablement and auxiliary-list retirement remain separate gates.\n\nNo runtime or feature-flag changes.