### PR TITLE
fix(sealed-export+activate): bind manifest digest and receipts, freeze activate policy, resolve AST bindings (owner post-merge review)

### DIFF
--- a/packages/core-backend/src/routes/admin-users.ts
+++ b/packages/core-backend/src/routes/admin-users.ts
@@ -1751,11 +1751,11 @@ async function syncLegacyAdminProfile(userId: string, enabled: boolean): Promise
  * asserts set equality between the reasons thrown at `throwCoded` call sites and the policy
  * table's keys, and folding the fallback into the table would make that equality vacuous.
  */
-export const ACTIVATE_ERROR_FALLBACK = {
+export const ACTIVATE_ERROR_FALLBACK = Object.freeze({
   status: 500,
   code: 'ACTIVATE_FAILED',
   message: 'Activation failed',
-} as const
+} as const)
 
 /**
  * Closed policy table: every authored activation reason → the status and the message we publish.
@@ -1770,7 +1770,7 @@ export const ACTIVATE_ERROR_FALLBACK = {
  * Messages are authored HERE, not inherited from the thrown Error. The thrown message stays
  * useful for server-side logs; it is simply never part of the response.
  */
-export const ACTIVATE_ERROR_POLICY: Record<ActivateErrorCode, { status: number; message: string }> = {
+const ACTIVATE_ERROR_POLICY_SOURCE: Record<ActivateErrorCode, { status: number; message: string }> = {
   ACTIVATE_USER_REQUIRED: { status: 400, message: 'A target user id is required to activate' },
   ACTIVATE_USER_NOT_FOUND: { status: 404, message: 'User not found' },
   ACTIVATE_NOT_PENDING: { status: 409, message: 'User is not pending activation' },
@@ -1789,14 +1789,41 @@ export const ACTIVATE_ERROR_POLICY: Record<ActivateErrorCode, { status: number; 
   ACTIVATE_LINK_MISMATCH: { status: 409, message: 'Directory link points to a different user' },
 }
 
+type ActivatePolicyRow = Readonly<{ status: number; message: string }>
+
+/** A row the holder owns: a fresh frozen copy, never the source object. */
+function frozenPolicyRow(row: { status: number; message: string }): ActivatePolicyRow {
+  return Object.freeze({ status: row.status, message: row.message })
+}
+
 /**
  * Lookup view of the table above. A `Map` rather than an object index: a Map has no prototype
  * chain to borrow from, so a thrown `.code` of `'constructor'` / `'toString'` / `'__proto__'`
  * cannot resolve to a row, and the response path needs no computed property access at all
  * (which keeps the AST scan's "no computed read on the response path" rule strict).
+ *
+ * OWNER POST-MERGE FINDING (P2, 2026-07-27): this was `new Map(Object.entries(ACTIVATE_ERROR_POLICY))`
+ * over an EXPORTED, non-frozen table — so the Map held the very row objects any importer could
+ * reach. Owner's executed repro: setting `ACTIVATE_RACE` to 200 plus database text through the
+ * public export made `mapActivateError()` return it verbatim, defeating the closure this table
+ * exists to build. The source table is now module-private, the Map holds its own frozen copies,
+ * and the export is a frozen projection.
  */
-const ACTIVATE_ERROR_POLICY_LOOKUP: ReadonlyMap<string, { status: number; message: string }> =
-  new Map(Object.entries(ACTIVATE_ERROR_POLICY))
+const ACTIVATE_ERROR_POLICY_LOOKUP: ReadonlyMap<string, ActivatePolicyRow> = new Map(
+  Object.entries(ACTIVATE_ERROR_POLICY_SOURCE).map(([code, row]) => [code, frozenPolicyRow(row)]),
+)
+
+/**
+ * The published, DEEP-FROZEN projection. Exported only because the closure and mapping tests
+ * need to read the table's keys and rows; it is not the object the response path reads, and
+ * mutating it changes nothing.
+ */
+export const ACTIVATE_ERROR_POLICY: Readonly<Record<ActivateErrorCode, ActivatePolicyRow>> =
+  Object.freeze(
+    Object.fromEntries(
+      Object.entries(ACTIVATE_ERROR_POLICY_SOURCE).map(([code, row]) => [code, frozenPolicyRow(row)]),
+    ),
+  ) as Readonly<Record<ActivateErrorCode, ActivatePolicyRow>>
 
 /**
  * Error surface for `POST /api/admin/users/:id/activate`.

--- a/packages/core-backend/tests/unit/admin-users-activate-error-mapping.test.ts
+++ b/packages/core-backend/tests/unit/admin-users-activate-error-mapping.test.ts
@@ -174,6 +174,68 @@ describe('mapActivateError (activate endpoint error surface)', () => {
     expect(ACTIVATE_ERROR_FALLBACK.code).toBe('ACTIVATE_FAILED')
   })
 
+  /**
+   * OWNER POST-MERGE FINDING (P2, 2026-07-27), reproduced before it was fixed.
+   *
+   * `ACTIVATE_ERROR_FALLBACK` and `ACTIVATE_ERROR_POLICY` were exported and NOT recursively
+   * frozen, and `ACTIVATE_ERROR_POLICY_LOOKUP = new Map(Object.entries(ACTIVATE_ERROR_POLICY))`
+   * held THE SAME row objects. Owner's executed repro: an external importer set `ACTIVATE_RACE`
+   * to 200 plus database text and `mapActivateError()` returned it verbatim — the closure this
+   * change exists to build was runtime-mutable from any importer.
+   *
+   * The mutation is attempted through the PUBLIC export, exactly as an importer would. On a
+   * deep-frozen object a strict-mode assignment throws; that is a pass, so the attempt is
+   * caught and the BEHAVIOUR is what the assertions read.
+   */
+  it('survives the owner mutation: the policy is deep-frozen and the response never moves', () => {
+    const importerView = ACTIVATE_ERROR_POLICY as unknown as
+      Record<string, { status: number; message: string }>
+    const driverText = 'relation "user_orgs" column "secret_col" does not exist'
+
+    try {
+      importerView.ACTIVATE_RACE.status = 200
+      importerView.ACTIVATE_RACE.message = driverText
+    } catch {
+      // Frozen: the assignment threw. That is the desired outcome, not a test failure.
+    }
+    try {
+      importerView.ACTIVATE_RACE = { status: 200, message: driverText }
+    } catch {
+      // Frozen table: replacing a whole row threw.
+    }
+
+    const mapped = mapActivateError(Object.assign(new Error('x'), { code: 'ACTIVATE_RACE' }))
+    expect(mapped.status).toBe(409)
+    expect(mapped.code).toBe('ACTIVATE_RACE')
+    expect(mapped.message).toBe('User is no longer pending activation')
+    expect(mapped.message).not.toMatch(/secret_col|user_orgs|relation/i)
+
+    // The exported projection itself must also be unchanged, so a later reader of the
+    // export is not shown a value the response would never publish.
+    expect(ACTIVATE_ERROR_POLICY.ACTIVATE_RACE.status).toBe(409)
+    expect(ACTIVATE_ERROR_POLICY.ACTIVATE_RACE.message).toBe('User is no longer pending activation')
+  })
+
+  it('is deep-frozen: the table, every row, and the fallback', () => {
+    expect(Object.isFrozen(ACTIVATE_ERROR_POLICY)).toBe(true)
+    for (const [code, row] of Object.entries(ACTIVATE_ERROR_POLICY)) {
+      expect(Object.isFrozen(row), `policy row ${code} must be frozen`).toBe(true)
+    }
+    expect(Object.isFrozen(ACTIVATE_ERROR_FALLBACK)).toBe(true)
+  })
+
+  it('the fallback cannot be rewritten through its export either', () => {
+    const importerView = ACTIVATE_ERROR_FALLBACK as unknown as { status: number; message: string }
+    try {
+      importerView.status = 200
+      importerView.message = 'column "secret_col" does not exist'
+    } catch {
+      // Frozen: the assignment threw.
+    }
+    expect(mapActivateError(new Error('boom')))
+      .toEqual({ status: 500, code: 'ACTIVATE_FAILED', message: 'Activation failed' })
+  })
+
   it('returns a fresh object each call — a caller cannot mutate the shared fallback', () => {
     const first = mapActivateError(new Error('boom')) as { message: string }
     first.message = 'mutated'

--- a/plugins/plugin-integration-core/__tests__/sealed-export-contracts.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/sealed-export-contracts.test.cjs
@@ -168,10 +168,32 @@ function evidence(overrides) {
   }, overrides || {})
 }
 
+// §6.4 keys an upload session by "the immutable manifest digest", so the session key is
+// DERIVED from the manifest here, exactly the way production derives it.
+//
+// RETRACTION (2026-07-27). This fixture used to hard-code `D('manifest-session')` — an
+// arbitrary well-formed hex string that the test supplied as both the question and the
+// answer. `classifyChunkSubmission` only ever checked the FORMAT of its `manifestDigest`
+// parameter and that the submission and receipts echoed the same value, so any hex string
+// keyed any manifest and two different manifests could share one fabricated session
+// digest. A test that supplies its own answer cannot detect that class, and this one did
+// not for a whole slice. The constant is deleted; nothing below may reintroduce it.
+function sessionDigestOf(manifestObject) {
+  return contracts.computeManifestDigest(manifestObject)
+}
+
+let defaultSessionDigestCache = null
+function defaultSessionDigest() {
+  if (defaultSessionDigestCache === null) {
+    defaultSessionDigestCache = sessionDigestOf(manifest(envelope()))
+  }
+  return defaultSessionDigestCache
+}
+
 function receipt(index, overrides) {
   const descriptors = chunkDescriptors()
   return Object.assign({
-    manifestDigest: D('manifest-session'),
+    manifestDigest: defaultSessionDigest(),
     chunkIndex: index,
     chunkDigest: descriptors[index] ? descriptors[index].chunkDigest : D('unknown-chunk'),
     byteCount: descriptors[index] ? descriptors[index].byteCount : 1,
@@ -682,7 +704,7 @@ function snapshotProofIsNotRelabelled() {
 function chunkSubmissionClassification() {
   const goodEnvelope = envelope()
   const goodManifest = contracts.validateSignedManifest(manifest(goodEnvelope))
-  const sessionDigest = D('manifest-session')
+  const sessionDigest = sessionDigestOf(goodManifest)
 
   // POSITIVE CONTROL — the first chunk of an empty session is ACCEPTed.
   assert.deepEqual(
@@ -778,6 +800,147 @@ function chunkSetCompletenessRefusesDuplicatesAndUndeclared() {
 }
 
 // ---------------------------------------------------------------------------
+// §6.4 "An upload session is keyed by the immutable manifest digest" — BOUND to the
+// manifest, not merely well-formed.
+//
+// OWNER POST-MERGE FINDING (P1, 2026-07-27), reproduced here before it was fixed:
+// `classifyChunkSubmission(manifest, manifestDigest, …)` took the manifest and never
+// derived `computeManifestDigest(manifest)` from it. It checked the FORMAT of the
+// supplied digest and that the submission plus every receipt echoed the same value, so
+// any well-formed hex string was a valid session key for any manifest, and two different
+// manifests could share one fabricated session digest and both be ACCEPTed.
+// ---------------------------------------------------------------------------
+function manifestDigestIsBoundToTheManifest() {
+  const goodEnvelope = envelope()
+  const manifestA = contracts.validateSignedManifest(manifest(goodEnvelope))
+  const manifestB = contracts.validateSignedManifest(
+    manifest(goodEnvelope, { sourceCaptureIdentity: 'sx-capture-identity-b' }),
+  )
+  const digestA = sessionDigestOf(manifestA)
+  const digestB = sessionDigestOf(manifestB)
+
+  // The derivation must DISCRIMINATE: two different manifests are two different sessions.
+  // Without this the checks below could pass against a digest that is constant.
+  assert.notEqual(digestA, digestB, 'different manifests must derive different session digests')
+  assert.equal(digests.isLowerHexDigest(digestA), true)
+
+  // POSITIVE CONTROL — the derived digest keys its own manifest's session.
+  assert.deepEqual(
+    contracts.classifyChunkSubmission(manifestA, digestA, [], submission(0, { manifestDigest: digestA })),
+    { decision: 'ACCEPT', acceptedChunkCount: 1 },
+  )
+
+  // THE GAP — an arbitrary well-formed hex string that everyone agrees on is still not
+  // this manifest's digest. Before the fix this returned ACCEPT.
+  const fabricated = D('fabricated-session-key')
+  assert.equal(digests.isLowerHexDigest(fabricated), true, 'the fabricated key is well-formed hex')
+  assert.notEqual(fabricated, digestA)
+  refuses(
+    () => contracts.classifyChunkSubmission(manifestA, fabricated, [],
+      submission(0, { manifestDigest: fabricated })),
+    'SEALED_EXPORT_UPLOAD_SESSION_INVALID', 'fabricated session key, echoed by the submission',
+  )
+  // …including when accepted receipts echo it too, which is the whole "everyone agrees"
+  // shape the old check mistook for a binding.
+  refuses(
+    () => contracts.classifyChunkSubmission(manifestA, fabricated,
+      [receipt(0, { manifestDigest: fabricated })], submission(1, { manifestDigest: fabricated })),
+    'SEALED_EXPORT_UPLOAD_SESSION_INVALID', 'fabricated session key, echoed by submission and receipt',
+  )
+
+  // TWO MANIFESTS, ONE FABRICATED KEY — the owner's reproduction verbatim. Both calls
+  // returned ACCEPT before the fix.
+  refuses(
+    () => contracts.classifyChunkSubmission(manifestB, fabricated, [],
+      submission(0, { manifestDigest: fabricated })),
+    'SEALED_EXPORT_UPLOAD_SESSION_INVALID', 'the same fabricated key against a second manifest',
+  )
+
+  // A REAL digest, but of the WRONG manifest. This is the case a format check can never
+  // catch: `digestB` is a genuine manifest digest, just not this manifest's.
+  refuses(
+    () => contracts.classifyChunkSubmission(manifestA, digestB, [],
+      submission(0, { manifestDigest: digestB })),
+    'SEALED_EXPORT_UPLOAD_SESSION_INVALID', 'another manifest\'s genuine digest',
+  )
+  refuses(
+    () => contracts.classifyChunkSubmission(manifestB, digestA, [],
+      submission(0, { manifestDigest: digestA })),
+    'SEALED_EXPORT_UPLOAD_SESSION_INVALID', 'the mirror case, so neither direction is special',
+  )
+}
+
+// ---------------------------------------------------------------------------
+// §6.2 "ordered chunk identities and digests" — an accepted receipt is evidence about a
+// MANIFEST CHUNK, so it is checked against the manifest's descriptor at that index.
+//
+// OWNER POST-MERGE FINDING (P1, 2026-07-27), reproduced here before it was fixed: the
+// replay path in `classifyChunkSubmission` compared the submission against the RECEIPT
+// only, and `assertChunkSetComplete` compared INDEX SETS only. Receipts carrying the
+// wrong `chunkDigest` and the wrong `byteCount` produced `IDEMPOTENT_REPLAY` and
+// `{ chunkCount: 2 }` respectively.
+// ---------------------------------------------------------------------------
+function receiptsAreBoundToManifestDescriptors() {
+  const goodEnvelope = envelope()
+  const goodManifest = contracts.validateSignedManifest(manifest(goodEnvelope))
+  const sessionDigest = sessionDigestOf(goodManifest)
+  const forged = { chunkDigest: D('bytes-the-manifest-never-declared'), byteCount: 999 }
+
+  // POSITIVE CONTROLS — honest receipts are still accepted by both functions, so the
+  // refusals below are not "everything is refused".
+  assert.deepEqual(
+    contracts.classifyChunkSubmission(goodManifest, sessionDigest, [receipt(0)], submission(0)),
+    { decision: 'IDEMPOTENT_REPLAY', acceptedChunkCount: 1 },
+  )
+  assert.deepEqual(
+    contracts.assertChunkSetComplete(goodManifest, [receipt(0), receipt(1)]),
+    { chunkCount: 2 },
+  )
+
+  // classifyChunkSubmission — a receipt whose bytes the manifest never declared cannot
+  // make a matching re-send an idempotent replay. Before the fix: IDEMPOTENT_REPLAY.
+  refuses(
+    () => contracts.classifyChunkSubmission(goodManifest, sessionDigest,
+      [receipt(0, forged)], submission(0, forged)),
+    'SEALED_EXPORT_CHUNK_DIGEST_MISMATCH', 'replay against a receipt that disagrees with the descriptor',
+  )
+  // The two descriptor terms are checked SEPARATELY, so neither can cover for the other.
+  refuses(
+    () => contracts.classifyChunkSubmission(goodManifest, sessionDigest,
+      [receipt(0, { chunkDigest: D('bytes-the-manifest-never-declared') })],
+      submission(0, { chunkDigest: D('bytes-the-manifest-never-declared') })),
+    'SEALED_EXPORT_CHUNK_DIGEST_MISMATCH', 'receipt digest alone disagreeing with the descriptor',
+  )
+  refuses(
+    () => contracts.classifyChunkSubmission(goodManifest, sessionDigest,
+      [receipt(0, { byteCount: 999 })], submission(0, { byteCount: 999 })),
+    'SEALED_EXPORT_CHUNK_DIGEST_MISMATCH', 'receipt byte count alone disagreeing with the descriptor',
+  )
+  // …and a forged receipt is refused on the ACCEPT path too, not only on replay.
+  refuses(
+    () => contracts.classifyChunkSubmission(goodManifest, sessionDigest,
+      [receipt(0, forged)], submission(1)),
+    'SEALED_EXPORT_CHUNK_DIGEST_MISMATCH', 'forged receipt in the accepted set of a new submission',
+  )
+
+  // assertChunkSetComplete — a complete INDEX SET of forged receipts is not a complete
+  // chunk set. Before the fix: { chunkCount: 2 }.
+  refuses(
+    () => contracts.assertChunkSetComplete(goodManifest, [receipt(0, forged), receipt(1)]),
+    'SEALED_EXPORT_CHUNK_DIGEST_MISMATCH', 'complete index set, forged chunk digest and byte count',
+  )
+  refuses(
+    () => contracts.assertChunkSetComplete(goodManifest,
+      [receipt(0, { chunkDigest: D('bytes-the-manifest-never-declared') }), receipt(1)]),
+    'SEALED_EXPORT_CHUNK_DIGEST_MISMATCH', 'complete index set, forged chunk digest only',
+  )
+  refuses(
+    () => contracts.assertChunkSetComplete(goodManifest, [receipt(0), receipt(1, { byteCount: 999 })]),
+    'SEALED_EXPORT_CHUNK_DIGEST_MISMATCH', 'complete index set, forged byte count only',
+  )
+}
+
+// ---------------------------------------------------------------------------
 // §9.2: no caller value may reach the refusal surface.
 // ---------------------------------------------------------------------------
 function refusalSurfaceIsValuesFree() {
@@ -859,6 +1022,8 @@ function main() {
   snapshotProofIsNotRelabelled()
   chunkSubmissionClassification()
   chunkSetCompletenessRefusesDuplicatesAndUndeclared()
+  manifestDigestIsBoundToTheManifest()
+  receiptsAreBoundToManifestDescriptors()
   refusalSurfaceIsValuesFree()
   canonicalBytesFailClosed()
   console.log('sealed-export-contracts.test.cjs OK')

--- a/plugins/plugin-integration-core/__tests__/sealed-export-failure-vocabulary.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/sealed-export-failure-vocabulary.test.cjs
@@ -436,6 +436,43 @@ function astScanMatchesBindingsNotNames() {
   assert.equal(escapes.findings.length, 1, 'a bound name used as a value must be reported')
   assert.equal(escapes.findings[0].checkId, 'THROW_SITE_BINDING_ESCAPES')
 
+  // A member read is itself a function value. Direct invocation and the two alias forms
+  // above are the only uses this resolver follows; invocation helpers and containers escape
+  // that model and must fail loud rather than looking like a clean source file.
+  const assertMemberEscape = (label, body) => {
+    const result = scan([{
+      name: 'synthetic.cjs',
+      text: 'const v = ' + REQUIRE + '\n' + body + '\n',
+    }])
+    assert.equal(result.findings.length, 1, label + ': exactly one escape finding')
+    assert.equal(result.findings[0].checkId, 'THROW_SITE_BINDING_ESCAPES', label)
+  }
+  assertMemberEscape('.call', "v.failSealedExport.call(null, 'NOT_DECLARED')")
+  assertMemberEscape('.apply', "v.failSealedExport.apply(null, ['NOT_DECLARED'])")
+  assertMemberEscape('.bind', "const fail = v.failSealedExport.bind(null)\nfail('NOT_DECLARED')")
+  assertMemberEscape('Reflect.apply', "Reflect.apply(v.failSealedExport, null, ['NOT_DECLARED'])")
+  assertMemberEscape('array storage', 'const values = [v.failSealedExport]\nmodule.exports = values')
+  assertMemberEscape('object storage', 'const values = { fail: v.failSealedExport }\nmodule.exports = values')
+
+  // Wrapper syntax must not turn the two supported forms into false escapes.
+  const wrappedDirect = scan([{
+    name: 'synthetic.cjs',
+    text: 'const v = ' + REQUIRE + ";\n(v.failSealedExport)('SEALED_EXPORT_MANIFEST_INVALID')\n",
+  }])
+  assert.deepEqual(wrappedDirect.findings, [], 'a parenthesized direct call remains resolved')
+  const wrappedAlias = scan([{
+    name: 'synthetic.cjs',
+    text: 'const v = ' + REQUIRE
+      + "\nconst fail = (v.failSealedExport)\nfail('SEALED_EXPORT_MANIFEST_INVALID')\n",
+  }])
+  assert.deepEqual(wrappedAlias.findings, [], 'a parenthesized alias remains resolved')
+  const wrappedIdentifier = scan([{
+    name: 'synthetic.cjs',
+    text: 'const { failSealedExport: fail } = ' + REQUIRE
+      + ";\n(fail)('SEALED_EXPORT_MANIFEST_INVALID')\n",
+  }])
+  assert.deepEqual(wrappedIdentifier.findings, [], 'a parenthesized bound identifier remains resolved')
+
   // …and a computed member read OF THE VOCABULARY MODULE is an unreadable binding form.
   const computedAlias = scan([{
     name: 'synthetic.cjs',

--- a/plugins/plugin-integration-core/__tests__/sealed-export-failure-vocabulary.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/sealed-export-failure-vocabulary.test.cjs
@@ -13,10 +13,12 @@
 // statements and the declared vocabulary are consistent in the source text. What the code
 // does at runtime is proven separately, by the pins that call the real functions.
 //
-// GOVERNANCE NOTE, deliberately load-bearing on nothing: §10 says of this set "This
-// exact set is **proposed**, not ratified", while §12 lists "failure vocabulary"
-// among what S0 freezes. This file takes NO position; it pins the §10 list so any
-// drift REDs. Nothing here asserts the set has been ratified.
+// GOVERNANCE NOTE — RETRACTION (2026-07-27). This note previously read: §10 says of
+// this set "This exact set is **proposed**, not ratified", while §12 lists "failure
+// vocabulary" among what S0 freezes; this file takes NO position. That is NO LONGER
+// TRUE. The owner RATIFIED this exact set on 2026-07-27 and froze it at exactly 30
+// tokens; no reason may be added, removed or renamed. The pin below is unchanged —
+// it still transcribes §10 from the DOCUMENT so any drift REDs.
 
 const assert = require('node:assert/strict')
 const path = require('node:path')
@@ -218,10 +220,15 @@ function throwSiteInvariant() {
 // RETRACTION. The previous scanner blanked comments and strings with a character scan that
 // could not distinguish a regex literal `/.../` from division. compliance-harness.cjs then
 // contained `/failSealedExport\(\s*(['"])([^'"]*)\1/g`; the scanner read the `'` inside that
-// literal as the start of a string and blanked everything to the next `'`, desynchronising
-// for the rest of the file. A real `throw` placed after that line was counted ZERO, while
-// the module's own header asserted "no throw ... asserted mechanically". The claim was true;
-// the mechanism was blind. Controls 1-3 are the regression pins.
+// literal as the start of a string and blanked from there to the next `'`. A real `throw`
+// placed inside that window was counted ZERO, while the module's own header asserted "no
+// throw ... asserted mechanically". The claim was true; the mechanism was blind.
+//
+// SECOND RETRACTION (2026-07-27), narrowing the first: this text used to add "desynchronising
+// for the rest of the file". That overstates it. The window was BOUNDED — the scanner
+// re-synchronised at a later quote — so the blindness ran from the offending literal to that
+// point, not to the end of the file. Bounded was already enough to hide a real throw.
+// Controls 1-3 are the regression pins.
 // ---------------------------------------------------------------------------
 function astThrowSiteScanHasNoBlindWindow() {
   // CONTROL 1 — a `throw` INSIDE A REGEX LITERAL is not a throw statement.
@@ -305,6 +312,146 @@ function astThrowSiteScanHasNoBlindWindow() {
   const healthy = scan([{ name: 'synthetic.cjs', text: 'const a = 1\nmodule.exports = { a }\n' }])
   assert.deepEqual(healthy.findings, [])
   assert.equal(healthy.parsedSources, 1)
+}
+
+// ---------------------------------------------------------------------------
+// PIN 3, third half — the scan matches the BINDING, not the call NAME.
+//
+// OWNER POST-MERGE FINDING (P2, 2026-07-27). `calleeName` handled only `ts.isIdentifier`
+// and `ts.isPropertyAccessExpression`, so the scan matched a call by the name written at
+// the call site. A direct undeclared reason REDed, but a renamed destructure and an
+// element access both produced ZERO findings:
+//     const { failSealedExport: fail } = ...; fail('NOT_DECLARED')
+//     v['failSealedExport']('NOT_DECLARED')
+// Enumerating call forms is the same non-converging mistake as the hand-written stripper,
+// so the scan now RESOLVES the binding — every local name bound to failSealedExport,
+// renames included — and fails LOUD on any call shape it cannot statically resolve.
+// Silence on an unresolvable shape is the defect.
+// ---------------------------------------------------------------------------
+function astScanMatchesBindingsNotNames() {
+  const REQUIRE = "require('./failure-vocabulary.cjs')"
+
+  // SHAPE 1 — the direct call. This one always worked; it is here so the three shapes
+  // are compared side by side rather than asserted apart.
+  const direct = scan([{
+    name: 'synthetic.cjs',
+    text: 'const { failSealedExport } = ' + REQUIRE + "\nfailSealedExport('NOT_DECLARED')\n",
+  }])
+  assert.equal(direct.findings.length, 1, 'direct call: exactly one finding')
+  assert.equal(direct.findings[0].checkId, 'THROW_SITE_REASON_UNDECLARED')
+
+  // SHAPE 2 — the RENAMED DESTRUCTURE. Zero findings before the fix.
+  const renamed = scan([{
+    name: 'synthetic.cjs',
+    text: 'const { failSealedExport: fail } = ' + REQUIRE + "\nfail('NOT_DECLARED')\n",
+  }])
+  assert.equal(renamed.findings.length, 1, 'renamed destructure must be resolved to the binding')
+  assert.equal(renamed.findings[0].checkId, 'THROW_SITE_REASON_UNDECLARED')
+
+  // SHAPE 2b — an alias of the alias. Resolution is transitive or it is name matching
+  // with extra steps.
+  const aliasChain = scan([{
+    name: 'synthetic.cjs',
+    text: 'const { failSealedExport: fail } = ' + REQUIRE
+      + "\nconst deeper = fail\ndeeper('NOT_DECLARED')\n",
+  }])
+  assert.equal(aliasChain.findings.length, 1, 'an alias of an alias must resolve')
+  assert.equal(aliasChain.findings[0].checkId, 'THROW_SITE_REASON_UNDECLARED')
+
+  // SHAPE 2c — a member alias: `const fail = vocabulary.failSealedExport`.
+  const memberAlias = scan([{
+    name: 'synthetic.cjs',
+    text: 'const v = ' + REQUIRE + "\nconst fail = v.failSealedExport\nfail('NOT_DECLARED')\n",
+  }])
+  assert.equal(memberAlias.findings.length, 1, 'a member alias must resolve')
+  assert.equal(memberAlias.findings[0].checkId, 'THROW_SITE_REASON_UNDECLARED')
+
+  // SHAPE 3 — ELEMENT ACCESS with a static string. Zero findings before the fix.
+  const elementAccess = scan([{
+    name: 'synthetic.cjs',
+    text: 'const v = ' + REQUIRE + "\nv['failSealedExport']('NOT_DECLARED')\n",
+  }])
+  assert.equal(elementAccess.findings.length, 1, 'static element access must be resolved')
+  assert.equal(elementAccess.findings[0].checkId, 'THROW_SITE_REASON_UNDECLARED')
+
+  // SHAPE 4 — UNRESOLVABLE. A computed callee cannot be read by any static scan. The
+  // scan must say so LOUDLY; reporting nothing would be indistinguishable from clean.
+  const computed = scan([{
+    name: 'synthetic.cjs',
+    text: 'const v = ' + REQUIRE + "\nconst name = 'failSealedExport'\nv[name]('NOT_DECLARED')\n",
+  }])
+  assert.equal(computed.findings.length, 1, 'an unresolvable callee must produce a finding, not silence')
+  assert.equal(computed.findings[0].checkId, 'THROW_SITE_CALLEE_UNRESOLVABLE')
+
+  // …and the same for a callee that is itself the result of a call.
+  const callOfCall = scan([{
+    name: 'synthetic.cjs',
+    text: 'const v = ' + REQUIRE + "\npick(v)('NOT_DECLARED')\n",
+  }])
+  assert.equal(callOfCall.findings.length, 1, 'a call-of-call callee is unresolvable')
+  assert.equal(callOfCall.findings[0].checkId, 'THROW_SITE_CALLEE_UNRESOLVABLE')
+
+  // NEGATIVE CONTROL — a rename of something that is NOT failSealedExport must stay
+  // clean. Without this, "flag every one-string-argument call" would pass everything above.
+  const otherBinding = scan([{
+    name: 'synthetic.cjs',
+    text: 'const { isDeclaredFailureReason: fail } = ' + REQUIRE + "\nfail('NOT_DECLARED')\n",
+  }])
+  assert.deepEqual(otherBinding.findings, [], 'a rename of a different export must not be matched')
+
+  // NEGATIVE CONTROL — a DECLARED reason through a rename is clean, and its reason is
+  // still collected, so binding resolution did not shrink reachedReasons.
+  const declaredThroughAlias = scan([{
+    name: 'synthetic.cjs',
+    text: 'const { failSealedExport: fail } = ' + REQUIRE
+      + "\nfail('SEALED_EXPORT_MANIFEST_INVALID')\n",
+  }])
+  assert.deepEqual(declaredThroughAlias.findings, [], 'a declared reason through an alias is clean')
+  assert.deepEqual(declaredThroughAlias.reachedReasons, ['SEALED_EXPORT_MANIFEST_INVALID'],
+    'a reason reached through an alias must still be collected')
+
+  // A dynamic reason through an alias is still an enumerated dynamic site, not silence.
+  const dynamicThroughAlias = scan([{
+    name: 'synthetic.cjs',
+    text: 'const { failSealedExport: fail } = ' + REQUIRE + '\nfail(pickReason(), {})\n',
+  }])
+  assert.deepEqual(dynamicThroughAlias.dynamicReasonSites, ['synthetic.cjs'],
+    'a computed reason through an alias must be enumerated')
+
+  // An IIFE callee is a literal function, statically known not to be failSealedExport.
+  // It must NOT be reported as unresolvable, or CONTROL 2 above would be a false alarm.
+  const iife = scan([{
+    name: 'synthetic.cjs',
+    text: 'const s = (function () { return 1 })()\nmodule.exports = { s }\n',
+  }])
+  assert.deepEqual(iife.findings, [], 'an immediately-invoked function literal is resolvable')
+
+  // ESCAPE — a binding handed out as a VALUE leaves this resolver's reach. Beyond the
+  // owner's named finding, and reported for the same reason: an escape that is silently
+  // ignored is a hole shaped exactly like the one being closed.
+  const escapes = scan([{
+    name: 'synthetic.cjs',
+    text: 'const { failSealedExport } = ' + REQUIRE + '\nmodule.exports = { failSealedExport }\n',
+  }])
+  assert.equal(escapes.findings.length, 1, 'a bound name used as a value must be reported')
+  assert.equal(escapes.findings[0].checkId, 'THROW_SITE_BINDING_ESCAPES')
+
+  // …and a computed member read OF THE VOCABULARY MODULE is an unreadable binding form.
+  const computedAlias = scan([{
+    name: 'synthetic.cjs',
+    text: 'const v = ' + REQUIRE + "\nconst k = 'failSealedExport'\nconst fail = v[k]\nfail('X')\n",
+  }])
+  assert.equal(computedAlias.findings.length, 1, 'a computed alias off the vocabulary module is reported')
+  assert.equal(computedAlias.findings[0].checkId, 'THROW_SITE_BINDING_UNRESOLVABLE')
+
+  // NEGATIVE CONTROL for that rule — an ordinary computed read (an array index) is NOT a
+  // binding attempt. Flagging every `bytes[index]` would drown the scan in noise and is
+  // why the receiver must resolve to the vocabulary module.
+  const arrayIndex = scan([{
+    name: 'synthetic.cjs',
+    text: 'const bytes = [1, 2]\nconst index = 1\nconst one = bytes[index]\nmodule.exports = { one }\n',
+  }])
+  assert.deepEqual(arrayIndex.findings, [], 'an array index must not be read as an alias attempt')
 }
 
 // ---------------------------------------------------------------------------
@@ -637,6 +784,7 @@ function main() {
   latentSurfacePin()
   throwSiteInvariant()
   astThrowSiteScanHasNoBlindWindow()
+  astScanMatchesBindingsNotNames()
   zeroConsumerSweep()
   undeclaredReasonIsNeverEchoed()
   detailsCarryNoCallerValues()

--- a/plugins/plugin-integration-core/__tests__/support/sealed-export-source-scan.cjs
+++ b/plugins/plugin-integration-core/__tests__/support/sealed-export-source-scan.cjs
@@ -61,7 +61,7 @@ try {
   )
 }
 
-const SEALED_EXPORT_SOURCE_SCAN_VERSION = 'sealed-export/source-scan/ast-binding-v2'
+const SEALED_EXPORT_SOURCE_SCAN_VERSION = 'sealed-export/source-scan/ast-binding-v3'
 
 const FAIL_SEALED_EXPORT = 'failSealedExport'
 
@@ -75,9 +75,11 @@ function defaultParse(name, text) {
 
 // Parent pointers are NOT requested from the parser (a parseOverride may return anything),
 // so the parent is threaded explicitly by the walker.
-function walkWithParent(node, parent, visit) {
-  visit(node, parent)
-  node.forEachChild((child) => walkWithParent(child, node, visit))
+function walkWithParent(node, parent, visit, ancestors = []) {
+  visit(node, parent, ancestors)
+  ancestors.push(node)
+  node.forEachChild((child) => walkWithParent(child, node, visit, ancestors))
+  ancestors.pop()
 }
 
 // Strip parentheses / `as T` / `<T>x` / `x!` so `(fail)('X')` still resolves to `fail`.
@@ -244,18 +246,68 @@ function collectVocabularyNamespaces(sourceFile) {
 
 // A bound name used anywhere other than as a callee, a declaration/binding name, a member
 // NAME, or the right-hand side of an alias, has escaped this resolver's reach.
-function isTrackedUse(node, parent, bound) {
+function isTrackedUse(node, parent, ancestors, bound) {
   if (parent === null) return true
-  if (ts.isCallExpression(parent) && unwrap(parent.expression) === node) return true
-  if (ts.isVariableDeclaration(parent)) return true
+  const { outer, use } = outerUse(node, parent, ancestors)
+  if (use && ts.isCallExpression(use) && unwrap(use.expression) === unwrap(outer)) return true
+  if (ts.isVariableDeclaration(parent) && parent.name === node) return true
+  if (use && ts.isVariableDeclaration(use) && use.initializer
+    && unwrap(use.initializer) === unwrap(outer)) return true
   if (ts.isBindingElement(parent)) return true
   if (ts.isImportSpecifier(parent) || ts.isImportClause(parent)) return true
   if (ts.isFunctionDeclaration(parent) || ts.isFunctionExpression(parent)) return true
   if (ts.isPropertyAccessExpression(parent) && parent.name === node) return true
-  if (ts.isBinaryExpression(parent)
-    && parent.operatorToken.kind === ts.SyntaxKind.EqualsToken) {
+  if (use && ts.isBinaryExpression(use)
+    && use.operatorToken.kind === ts.SyntaxKind.EqualsToken) {
     // Either side of an alias assignment is tracked; the left side is added to `bound`.
-    return ts.isIdentifier(unwrap(parent.left)) ? bound.has(unwrap(parent.left).text) : false
+    return ts.isIdentifier(unwrap(use.left)) ? bound.has(unwrap(use.left).text) : false
+  }
+  return false
+}
+
+function isTransparentExpressionWrapper(node, child) {
+  return node.expression === child && (
+    ts.isParenthesizedExpression(node)
+    || (ts.isAsExpression && ts.isAsExpression(node))
+    || ts.isNonNullExpression(node)
+    || (ts.isTypeAssertionExpression && ts.isTypeAssertionExpression(node))
+  )
+}
+
+// Returns the first use outside transparent expression wrappers. The parser is intentionally
+// created without parent pointers, so the explicit ancestor stack from walkWithParent() is the
+// only trustworthy way to distinguish `(v.failSealedExport)('X')` from an escaping value.
+function outerUse(node, parent, ancestors) {
+  let outer = node
+  let use = parent
+  let ancestorIndex = ancestors.length - 2
+  while (use && isTransparentExpressionWrapper(use, outer)) {
+    outer = use
+    use = ancestorIndex >= 0 ? ancestors[ancestorIndex] : null
+    ancestorIndex -= 1
+  }
+  return { outer, use }
+}
+
+// A static member read of failSealedExport is safe for this syntactic resolver only when the
+// member is called directly or is captured by one of the alias forms collectFailBindings() owns.
+// `.call/.apply/.bind`, Reflect.apply, arguments, returns and container storage all move the
+// function value outside that model and therefore must be reported as an escape.
+function isTrackedMemberUse(node, parent, ancestors, bound) {
+  const { outer, use } = outerUse(node, parent, ancestors)
+  if (use === null) return false
+  if (ts.isCallExpression(use) && unwrap(use.expression) === unwrap(outer)) return true
+  if (ts.isVariableDeclaration(use)
+    && use.initializer
+    && unwrap(use.initializer) === unwrap(outer)
+    && ts.isIdentifier(use.name)) {
+    return bound.has(use.name.text)
+  }
+  if (ts.isBinaryExpression(use)
+    && use.operatorToken.kind === ts.SyntaxKind.EqualsToken
+    && unwrap(use.right) === unwrap(outer)
+    && ts.isIdentifier(unwrap(use.left))) {
+    return bound.has(unwrap(use.left).text)
   }
   return false
 }
@@ -332,12 +384,18 @@ function scanSealedExportThrowSites(sources, declaredReasons, allowedThrowModule
     let throwCount = 0
     const seenUnresolvableCallee = new Set()
     const seenEscape = new Set()
-    walkWithParent(sourceFile, null, (node, parent) => {
+    walkWithParent(sourceFile, null, (node, parent, ancestors) => {
       if (ts.isThrowStatement(node)) throwCount += 1
 
       if (ts.isIdentifier(node) && bound.has(node.text) && !isDeclaringModule
-        && !isTrackedUse(node, parent, bound)) {
+        && !isTrackedUse(node, parent, ancestors, bound)) {
         seenEscape.add(node.text)
+      }
+
+      const member = staticMemberRead(node)
+      if (member.kind === 'static' && member.name === FAIL_SEALED_EXPORT && !isDeclaringModule
+        && !isTrackedMemberUse(node, parent, ancestors, bound)) {
+        seenEscape.add(FAIL_SEALED_EXPORT)
       }
 
       if (!ts.isCallExpression(node)) return

--- a/plugins/plugin-integration-core/__tests__/support/sealed-export-source-scan.cjs
+++ b/plugins/plugin-integration-core/__tests__/support/sealed-export-source-scan.cjs
@@ -10,11 +10,24 @@
 //
 // WHY A PARSER AND NOT A HAND-WRITTEN STRIPPER. The previous implementation blanked
 // comments and quoted strings with a character scanner and then searched for `\bthrow\b`.
-// That scanner could not tell a regular-expression literal from division, so the very
-// first `/.../` literal containing a quote character desynchronised it and everything
-// after that line was blanked — including real code. A regex-literal case can be patched;
-// the class cannot. A parser has no such window: a `throw` is a ThrowStatement node or it
-// is not a throw at all.
+// That scanner could not tell a regular-expression literal from division, so a `/.../`
+// literal containing a quote character desynchronised it and opened a BLIND WINDOW —
+// bounded, not unbounded: the scanner re-synchronised at a later quote, so the damage ran
+// from the offending literal to that point, and real code inside the window was blanked.
+// RETRACTION: an earlier version of this comment said "everything after that line was
+// blanked", which overstates a bounded window as a permanent desynchronisation. A
+// regex-literal case can be patched; the class cannot. A parser has no such window: a
+// `throw` is a ThrowStatement node or it is not a throw at all.
+//
+// WHY BINDINGS AND NOT CALL NAMES. Owner post-merge finding (2026-07-27): matching a call
+// by the name written at the call site is the same non-converging mistake one level up.
+// `const { failSealedExport: fail } = ...; fail('NOT_DECLARED')` and
+// `v['failSealedExport']('NOT_DECLARED')` both produced ZERO findings. The scan now
+// RESOLVES the binding — every local name bound to failSealedExport by a declaration, an
+// assignment, an import or a transitive alias — and matches those names. Any call shape
+// whose callee cannot be resolved statically (a computed member, a callee that is itself
+// a call) is a LOUD finding, because silence on an unreadable shape is indistinguishable
+// from a clean result.
 //
 // WHAT THIS PROVES, AND WHAT IT DOES NOT. This is a STATIC SOURCE assertion. It shows the
 // source text is internally consistent — throw statements only in the allowed module, and
@@ -22,6 +35,12 @@
 // NOT a behaviour proof: that the runtime actually raises those reasons, and only those,
 // is a separate class of test (see latentSurfacePin / undeclaredReasonIsNeverEchoed in
 // sealed-export-failure-vocabulary.test.cjs, which drive the real functions).
+//
+// RESOLUTION LIMIT, stated rather than hidden: this is a syntactic binding resolver, not a
+// type-checked dataflow analysis. A binding that ESCAPES — handed to a function, returned,
+// or stored in an object — cannot be followed to its call site by any such resolver, so
+// escapes are reported as THROW_SITE_BINDING_ESCAPES in every module except the one that
+// declares the function (which necessarily exports it).
 //
 // FAIL-CLOSED IS THE POINT. A scanner that returns "zero findings" when it could not read
 // its input is worse than no scanner. Two doors enforce that here, and both are exercised
@@ -42,7 +61,7 @@ try {
   )
 }
 
-const SEALED_EXPORT_SOURCE_SCAN_VERSION = 'sealed-export/source-scan/ast-v1'
+const SEALED_EXPORT_SOURCE_SCAN_VERSION = 'sealed-export/source-scan/ast-binding-v2'
 
 const FAIL_SEALED_EXPORT = 'failSealedExport'
 
@@ -54,21 +73,201 @@ function defaultParse(name, text) {
   return ts.createSourceFile(name, text, ts.ScriptTarget.Latest, /* setParentNodes */ false, ts.ScriptKind.JS)
 }
 
-// The callee is `failSealedExport(...)` or `something.failSealedExport(...)`.
-function calleeName(node) {
-  const callee = node.expression
-  if (ts.isIdentifier(callee)) return callee.text
-  if (ts.isPropertyAccessExpression(callee) && ts.isIdentifier(callee.name)) return callee.name.text
+// Parent pointers are NOT requested from the parser (a parseOverride may return anything),
+// so the parent is threaded explicitly by the walker.
+function walkWithParent(node, parent, visit) {
+  visit(node, parent)
+  node.forEachChild((child) => walkWithParent(child, node, visit))
+}
+
+// Strip parentheses / `as T` / `<T>x` / `x!` so `(fail)('X')` still resolves to `fail`.
+function unwrap(node) {
+  let current = node
+  for (;;) {
+    if (ts.isParenthesizedExpression(current)) current = current.expression
+    else if (ts.isAsExpression && ts.isAsExpression(current)) current = current.expression
+    else if (ts.isNonNullExpression(current)) current = current.expression
+    else if (ts.isTypeAssertionExpression && ts.isTypeAssertionExpression(current)) current = current.expression
+    else return current
+  }
+}
+
+function staticStringOf(node) {
+  if (node === undefined || node === null) return null
+  if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) return node.text
   return null
+}
+
+// The member name a `<expr>.name` / `<expr>['name']` reads, when it is static.
+// Returns { kind: 'static', name } | { kind: 'dynamic' } | { kind: 'none' }.
+function staticMemberRead(node) {
+  const expression = unwrap(node)
+  if (ts.isPropertyAccessExpression(expression) && ts.isIdentifier(expression.name)) {
+    return { kind: 'static', name: expression.name.text }
+  }
+  if (ts.isElementAccessExpression(expression)) {
+    const literal = staticStringOf(expression.argumentExpression)
+    if (literal !== null) return { kind: 'static', name: literal }
+    return { kind: 'dynamic' }
+  }
+  return { kind: 'none' }
+}
+
+// A callee is RESOLVABLE when its identity can be read from the syntax alone.
+// Returns { resolvable: true, name } | { resolvable: true, name: null } | { resolvable: false }.
+//   - name is the callee's identifier or static member name;
+//   - name === null means "a callee that is statically known NOT to be a named binding",
+//     i.e. a function/arrow literal invoked in place, or `super(...)` / `import(...)`.
+function resolveCallee(node) {
+  const callee = unwrap(node.expression)
+  if (ts.isIdentifier(callee)) return { resolvable: true, name: callee.text }
+  if (callee.kind === ts.SyntaxKind.SuperKeyword || callee.kind === ts.SyntaxKind.ImportKeyword) {
+    return { resolvable: true, name: null }
+  }
+  if (ts.isFunctionExpression(callee) || ts.isArrowFunction(callee)) {
+    return { resolvable: true, name: null }
+  }
+  const member = staticMemberRead(callee)
+  if (member.kind === 'static') return { resolvable: true, name: member.name }
+  return { resolvable: false }
 }
 
 // A reason argument is READABLE only when it is a plain string literal. A template with
 // no substitutions is equally static and is accepted; anything else is dynamic.
 function literalReasonOf(node) {
   if (node.arguments.length === 0) return null
-  const first = node.arguments[0]
-  if (ts.isStringLiteral(first) || ts.isNoSubstitutionTemplateLiteral(first)) return first.text
-  return null
+  return staticStringOf(node.arguments[0])
+}
+
+// Every local name bound to failSealedExport in this source, renames and transitive
+// aliases included. Iterated to a fixed point so declaration order does not matter.
+// `unresolvedBindings` collects binding forms that cannot be read statically.
+function collectFailBindings(sourceFile, unresolvedBindings) {
+  const bound = new Set([FAIL_SEALED_EXPORT])
+  const namespaces = collectVocabularyNamespaces(sourceFile)
+  let changed = true
+  let rounds = 0
+  while (changed && rounds < 16) {
+    changed = false
+    rounds += 1
+    walkWithParent(sourceFile, null, (node) => {
+      // (a) import { failSealedExport as fail } from '...'
+      if (ts.isImportSpecifier(node)) {
+        const source = node.propertyName ? node.propertyName.text : node.name.text
+        if (source === FAIL_SEALED_EXPORT && !bound.has(node.name.text)) {
+          bound.add(node.name.text)
+          changed = true
+        }
+        return
+      }
+      // (b) const { failSealedExport: fail } = <expr>
+      if (ts.isBindingElement(node) && ts.isIdentifier(node.name)) {
+        if (node.propertyName && ts.isComputedPropertyName(node.propertyName)) {
+          unresolvedBindings.add('computed destructuring key')
+          return
+        }
+        const source = node.propertyName && !ts.isComputedPropertyName(node.propertyName)
+          ? node.propertyName.text
+          : node.name.text
+        if (source === FAIL_SEALED_EXPORT && !bound.has(node.name.text)) {
+          bound.add(node.name.text)
+          changed = true
+        }
+        return
+      }
+      // (c) const fail = <expr>.failSealedExport   /   const fail = <bound name>
+      if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.initializer) {
+        if (bindsFailSealedExport(node.initializer, bound, unresolvedBindings, namespaces)
+          && !bound.has(node.name.text)) {
+          bound.add(node.name.text)
+          changed = true
+        }
+        return
+      }
+      // (d) fail = <expr>.failSealedExport  (assignment, not declaration)
+      if (ts.isBinaryExpression(node)
+        && node.operatorToken.kind === ts.SyntaxKind.EqualsToken
+        && ts.isIdentifier(unwrap(node.left))) {
+        const target = unwrap(node.left)
+        if (bindsFailSealedExport(node.right, bound, unresolvedBindings, namespaces) && !bound.has(target.text)) {
+          bound.add(target.text)
+          changed = true
+        }
+      }
+    })
+  }
+  return bound
+}
+
+function bindsFailSealedExport(initializer, bound, unresolvedBindings, namespaces) {
+  const init = unwrap(initializer)
+  if (ts.isIdentifier(init)) return bound.has(init.text)
+  const member = staticMemberRead(init)
+  if (member.kind === 'static') return member.name === FAIL_SEALED_EXPORT
+  if (member.kind === 'dynamic') {
+    // `const fail = v[k]` where `v` is the vocabulary module cannot be read, and could be
+    // failSealedExport. Recorded so it cannot pass as "not a binding".
+    //
+    // Deliberately NOT reported for an arbitrary receiver: `bytes[index]` is an array
+    // read, and flagging every computed read would drown the scan in noise and make its
+    // findings worthless. The receiver must resolve to the vocabulary module itself.
+    const receiver = unwrap(init.expression)
+    if (ts.isIdentifier(receiver) && namespaces.has(receiver.text)) {
+      unresolvedBindings.add('computed member alias on the vocabulary module')
+    }
+  }
+  return false
+}
+
+// Identifiers bound to the vocabulary module as a whole: `const v = require('…')`,
+// `import * as v from '…'`. The specifier is matched by module basename, not by path.
+function collectVocabularyNamespaces(sourceFile) {
+  const namespaces = new Set()
+  const isVocabularySpecifier = (node) => {
+    const literal = staticStringOf(node)
+    return literal !== null && literal.indexOf('failure-vocabulary') >= 0
+  }
+  walkWithParent(sourceFile, null, (node) => {
+    if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.initializer) {
+      const init = unwrap(node.initializer)
+      if (ts.isCallExpression(init)
+        && ts.isIdentifier(unwrap(init.expression))
+        && unwrap(init.expression).text === 'require'
+        && isVocabularySpecifier(init.arguments[0])) {
+        namespaces.add(node.name.text)
+      }
+    }
+    if (ts.isNamespaceImport(node)) namespaces.add(node.name.text)
+  })
+  return namespaces
+}
+
+// A bound name used anywhere other than as a callee, a declaration/binding name, a member
+// NAME, or the right-hand side of an alias, has escaped this resolver's reach.
+function isTrackedUse(node, parent, bound) {
+  if (parent === null) return true
+  if (ts.isCallExpression(parent) && unwrap(parent.expression) === node) return true
+  if (ts.isVariableDeclaration(parent)) return true
+  if (ts.isBindingElement(parent)) return true
+  if (ts.isImportSpecifier(parent) || ts.isImportClause(parent)) return true
+  if (ts.isFunctionDeclaration(parent) || ts.isFunctionExpression(parent)) return true
+  if (ts.isPropertyAccessExpression(parent) && parent.name === node) return true
+  if (ts.isBinaryExpression(parent)
+    && parent.operatorToken.kind === ts.SyntaxKind.EqualsToken) {
+    // Either side of an alias assignment is tracked; the left side is added to `bound`.
+    return ts.isIdentifier(unwrap(parent.left)) ? bound.has(unwrap(parent.left).text) : false
+  }
+  return false
+}
+
+function declaresFailSealedExport(sourceFile) {
+  let declares = false
+  walkWithParent(sourceFile, null, (node) => {
+    if (ts.isFunctionDeclaration(node) && node.name && node.name.text === FAIL_SEALED_EXPORT) {
+      declares = true
+    }
+  })
+  return declares
 }
 
 /**
@@ -115,28 +314,62 @@ function scanSealedExportThrowSites(sources, declaredReasons, allowedThrowModule
       findings.push(frozenFinding('SOURCE_PARSE_FAILED', name, 'source did not parse cleanly'))
       continue
     }
+    if (typeof sourceFile.forEachChild !== 'function') {
+      findings.push(frozenFinding('SOURCE_PARSE_UNVERIFIABLE', name, 'source file is not walkable'))
+      continue
+    }
     parsedSources += 1
 
+    const unresolvedBindings = new Set()
+    const bound = collectFailBindings(sourceFile, unresolvedBindings)
+    for (const detail of unresolvedBindings) {
+      findings.push(frozenFinding('THROW_SITE_BINDING_UNRESOLVABLE', name, detail))
+    }
+    // The declaring module necessarily exports the function by value; every other module
+    // that lets a bound name escape puts it beyond this resolver's reach.
+    const isDeclaringModule = declaresFailSealedExport(sourceFile)
+
     let throwCount = 0
-    const walk = (node) => {
+    const seenUnresolvableCallee = new Set()
+    const seenEscape = new Set()
+    walkWithParent(sourceFile, null, (node, parent) => {
       if (ts.isThrowStatement(node)) throwCount += 1
-      if (ts.isCallExpression(node) && calleeName(node) === FAIL_SEALED_EXPORT) {
-        const reason = literalReasonOf(node)
-        if (reason === null) {
-          // Not readable by ANY source scan. Enumerated, not tolerated and not banned:
-          // the caller is obliged to pin the enumeration and prove behaviourally that each
-          // listed producer yields vocabulary members only.
-          dynamicReasonSites.add(name)
-        } else {
-          reachedReasons.add(reason)
-          if (!reasonSet.has(reason)) {
-            findings.push(frozenFinding('THROW_SITE_REASON_UNDECLARED', name, 'reason not in vocabulary'))
-          }
+
+      if (ts.isIdentifier(node) && bound.has(node.text) && !isDeclaringModule
+        && !isTrackedUse(node, parent, bound)) {
+        seenEscape.add(node.text)
+      }
+
+      if (!ts.isCallExpression(node)) return
+      const callee = resolveCallee(node)
+      if (!callee.resolvable) {
+        // Not readable by ANY static scan. Reported, never skipped: a callee this scan
+        // cannot read could be failSealedExport, and silence would look identical to clean.
+        seenUnresolvableCallee.add(node.getStart(sourceFile))
+        return
+      }
+      if (callee.name === null || !bound.has(callee.name)) return
+
+      const reason = literalReasonOf(node)
+      if (reason === null) {
+        // Not readable by ANY source scan. Enumerated, not tolerated and not banned:
+        // the caller is obliged to pin the enumeration and prove behaviourally that each
+        // listed producer yields vocabulary members only.
+        dynamicReasonSites.add(name)
+      } else {
+        reachedReasons.add(reason)
+        if (!reasonSet.has(reason)) {
+          findings.push(frozenFinding('THROW_SITE_REASON_UNDECLARED', name, 'reason not in vocabulary'))
         }
       }
-      node.forEachChild(walk)
+    })
+
+    for (let count = 0; count < seenUnresolvableCallee.size; count += 1) {
+      findings.push(frozenFinding('THROW_SITE_CALLEE_UNRESOLVABLE', name, 'callee not statically readable'))
     }
-    sourceFile.forEachChild(walk)
+    for (const escaped of seenEscape) {
+      findings.push(frozenFinding('THROW_SITE_BINDING_ESCAPES', name, 'bound name used as a value'))
+    }
 
     if (throwCount > 0) {
       throwSiteCount += throwCount

--- a/plugins/plugin-integration-core/lib/sealed-export/compliance-harness.cjs
+++ b/plugins/plugin-integration-core/lib/sealed-export/compliance-harness.cjs
@@ -23,8 +23,18 @@
 // scanner blanked comments and strings with a hand-written character scan which could not
 // distinguish a regular-expression literal from division; the first `/.../` literal in
 // this file containing a quote character desynchronised it, and a real `throw` injected
-// after that line was counted ZERO. The claim happened to be true; the evidence for it was
-// not. The scanner has been replaced by a TypeScript-parser walk over ThrowStatement nodes
+// after that line was counted ZERO.
+//
+// SECOND RETRACTION (2026-07-27), narrowing the first: this text used to say the scanner
+// blanked "everything after" the offending line. That overstates it. The blind window was
+// BOUNDED — the scanner re-synchronised at a later quote character — so the damage ran
+// from the offending literal to that point, not to the end of the file. The confirmed
+// defect is a bounded blind window, and it was enough to hide a real throw; it was not a
+// permanent desynchronisation, and describing it as one made the old evidence sound worse
+// than it was rather than describing it accurately.
+//
+// The claim happened to be true; the evidence for it was not. The scanner has been
+// replaced by a TypeScript-parser walk over ThrowStatement nodes
 // (__tests__/support/sealed-export-source-scan.cjs), which has no such blind window and
 // fails closed when a source does not parse. That scan is a STATIC SOURCE assertion, not a
 // behaviour proof. This module still contains no `throw`: every failure is a finding in

--- a/plugins/plugin-integration-core/lib/sealed-export/contracts.cjs
+++ b/plugins/plugin-integration-core/lib/sealed-export/contracts.cjs
@@ -679,8 +679,39 @@ function verifyRowsetAgainstManifest(manifest, rows) {
 // no tombstone is consulted — those are S3/S4 and are out of scope, which is why
 // SEALED_EXPORT_MANIFEST_REPLAYED stays in the S1-unreached partition.
 // ---------------------------------------------------------------------------
+// §6.2 binds "ordered chunk identities and digests", so a receipt is checked against the
+// manifest descriptor AT ITS INDEX — never against another receipt, another submission or
+// an index set. The two descriptor terms are compared in SEPARATE guards on purpose: a
+// single combined condition lets one term cover for the other under mutation.
+//
+// An index the manifest never declared is UNDECLARED first. There is no descriptor to
+// compare against at all, and reporting a digest mismatch would misname the defect.
+function assertReceiptMatchesDescriptor(manifest, receipt) {
+  if (receipt.chunkIndex >= manifest.chunks.length) {
+    failSealedExport('SEALED_EXPORT_CHUNK_UNDECLARED', { chunkIndex: receipt.chunkIndex })
+  }
+  const descriptor = manifest.chunks[receipt.chunkIndex]
+  if (!constantTimeEqualDigest(receipt.chunkDigest, descriptor.chunkDigest)) {
+    failSealedExport('SEALED_EXPORT_CHUNK_DIGEST_MISMATCH', { chunkIndex: receipt.chunkIndex })
+  }
+  if (receipt.byteCount !== descriptor.byteCount) {
+    failSealedExport('SEALED_EXPORT_CHUNK_DIGEST_MISMATCH', { chunkIndex: receipt.chunkIndex })
+  }
+}
+
 function classifyChunkSubmission(manifest, manifestDigest, acceptedReceipts, submission) {
   if (!isLowerHexDigest(manifestDigest)) {
+    failSealedExport('SEALED_EXPORT_UPLOAD_SESSION_INVALID', { field: 'manifestDigest' })
+  }
+  // Owner post-merge finding (P1, 2026-07-27): this function took `manifest` and never
+  // derived its digest. It checked only that the supplied key was well-formed hex and
+  // that the submission and every receipt echoed the SAME value — so any hex string
+  // keyed any manifest, and two different manifests could share one fabricated session
+  // digest and both be ACCEPTed. "Everyone agrees on X" is not "X is this manifest".
+  // The session key is now DERIVED from the manifest and compared in constant time; a
+  // caller-supplied digest that is not this manifest's fails closed.
+  const derivedManifestDigest = computeManifestDigest(manifest)
+  if (!constantTimeEqualDigest(derivedManifestDigest, manifestDigest)) {
     failSealedExport('SEALED_EXPORT_UPLOAD_SESSION_INVALID', { field: 'manifestDigest' })
   }
   const validSubmission = validateChunkSubmission(submission)
@@ -700,6 +731,12 @@ function classifyChunkSubmission(manifest, manifestDigest, acceptedReceipts, sub
     if (acceptedByIndex.has(receipt.chunkIndex)) {
       failSealedExport('SEALED_EXPORT_UPLOAD_SESSION_INVALID', { chunkIndex: receipt.chunkIndex })
     }
+    // Owner post-merge finding (P1, 2026-07-27): an accepted receipt is evidence about a
+    // MANIFEST CHUNK, and nothing compared it to one. A receipt carrying a chunkDigest
+    // and byteCount the manifest never declared was accepted into the session, which is
+    // what let a matching re-send return IDEMPOTENT_REPLAY. §6.2 binds "ordered chunk
+    // identities and digests", so the descriptor at that index is the authority.
+    assertReceiptMatchesDescriptor(manifest, receipt)
     acceptedByIndex.set(receipt.chunkIndex, receipt)
   }
   // §6.4 resume "asks only for accepted receipt indexes"; an accepted set with a hole
@@ -729,6 +766,13 @@ function classifyChunkSubmission(manifest, manifestDigest, acceptedReceipts, sub
       })
     }
     // §6.4: an identical re-send "is an idempotent replay and does not increment counts".
+    //
+    // The comparison above is submission-against-RECEIPT, and that is sufficient here
+    // ONLY because every receipt was bound to the manifest descriptor in the accept loop
+    // above: identical-to-a-descriptor-bound-receipt therefore means descriptor-bound.
+    // Do NOT add a second submission-against-descriptor comparison here as a belt — two
+    // doors for one property cover for each other and make the neuter probes for either
+    // one non-discriminating.
     return Object.freeze({
       decision: 'IDEMPOTENT_REPLAY',
       acceptedChunkCount: acceptedByIndex.size,
@@ -762,7 +806,8 @@ function assertChunkSetComplete(manifest, acceptedReceipts) {
     failSealedExport('SEALED_EXPORT_CHUNK_SET_INCOMPLETE', { declaredCount: manifest.chunks.length })
   }
   for (let index = 0; index < acceptedReceipts.length; index += 1) {
-    const receiptIndex = validateChunkReceipt(acceptedReceipts[index]).chunkIndex
+    const receipt = validateChunkReceipt(acceptedReceipts[index])
+    const receiptIndex = receipt.chunkIndex
     // S1 harness finding: a bare Set silently COLLAPSED a duplicated receipt index,
     // so [0,0,1] against a two-chunk manifest returned complete. §10 names
     // CHUNK_DUPLICATE_CONFLICT for exactly this; closed means refused, not deduped.
@@ -771,9 +816,13 @@ function assertChunkSetComplete(manifest, acceptedReceipts) {
     }
     // S1 harness finding: a receipt for an index the manifest never declared was
     // silently tolerated because the completeness loop only walked manifest indexes.
-    if (receiptIndex >= manifest.chunks.length) {
-      failSealedExport('SEALED_EXPORT_CHUNK_UNDECLARED', { chunkIndex: receiptIndex })
-    }
+    //
+    // Owner post-merge finding (P1, 2026-07-27): this loop then compared INDEX SETS and
+    // nothing else, so a complete set of receipts carrying the wrong chunkDigest and the
+    // wrong byteCount returned { chunkCount: 2 }. A complete index set is not a complete
+    // chunk set. The undeclared-index refusal now lives in the shared descriptor guard,
+    // which reports it with the same reason and the same detail.
+    assertReceiptMatchesDescriptor(manifest, receipt)
     seen.add(receiptIndex)
   }
   for (let index = 0; index < manifest.chunks.length; index += 1) {

--- a/plugins/plugin-integration-core/lib/sealed-export/failure-vocabulary.cjs
+++ b/plugins/plugin-integration-core/lib/sealed-export/failure-vocabulary.cjs
@@ -13,15 +13,16 @@
 //
 // PROVENANCE / GOVERNANCE STATUS OF THIS SET
 // -----------------------------------------
-// The token list below is copied byte-for-byte from §10 of
-// docs/development/stock-prep-sealed-export-manifest-capability-spike-20260727.md.
-// That section states of this exact set: "This exact set is **proposed**, not
-// ratified." §12 of the same document lists "failure vocabulary" among the things
-// S0 freezes, and issue #4636 lists "closed failure vocabulary" as an S1
-// deliverable. Those texts disagree. This module takes NO position on that
-// disagreement: it pins the §10 set byte-for-byte so any drift REDs, and the
-// question of which text governs is raised for the owner in the PR body. Nothing
-// here asserts the set has been ratified.
+// RETRACTION (2026-07-27). This header previously said of the token list below:
+// "This exact set is **proposed**, not ratified", and described §10 and §12 as
+// disagreeing texts on which this module took no position. That is NO LONGER TRUE
+// and must not be relied on: the owner RATIFIED this exact set on 2026-07-27 and
+// froze it at exactly 30 tokens. No reason may be added, removed or renamed.
+//
+// What still holds: the list is copied byte-for-byte from §10 of
+// docs/development/stock-prep-sealed-export-manifest-capability-spike-20260727.md,
+// and the module pins it so any drift REDs. What changed is only the governance
+// status — from proposed-and-disputed to RATIFIED and frozen.
 //
 // §10 rules implemented here:
 //   - every thrown domain reason is a member of SEALED_EXPORT_FAILURE_REASONS;


### PR DESCRIPTION
> **CURRENT EXACT-HEAD TRANSPORT UPDATE (2026-07-28)**
>
> Reviewed and approved for **latent merge only** at `2e7049032cb911fdd4b739de3e5d5bb4845b6c0e`. The branch update from the owner-authored fix commit changed none of the two scanner files byte-for-byte; it only absorbed current main. All checks completed successfully, including `test (20.x)` and `integration-guard`. Since #4614, `integration-guard` is the ninth required context on main, so the older "NOT required" statement below is historical and withdrawn. The older opening "Draft. Do not merge" is likewise superseded by this exact-head approval. This does **not** authorize S2, runtime wiring, flags, deployment, arming, or rollout.

Owner post-merge review of #4638 / #4587 (2026-07-27). All five findings reproduced before
fixing; each fix has a test that RED-ed on the unfixed code and a mutation that REDs the fixed
code. **Draft. Do not merge.**

**No rollback was needed: there is no runtime consumer.** Nothing under `lib/sealed-export/` is
wired to a route, scheduler, flag or package entry point, so nothing was live.

**S2, runtime wiring and arming remain HOLD until both P1s are closed.** This PR closes them in
code; the HOLD is the owner's to lift. No flag was touched, nothing was armed, #4579 stays HELD.

**The 30-token failure vocabulary is RATIFIED and frozen — no reason was added, removed or
renamed.** The new refusals reuse `SEALED_EXPORT_UPLOAD_SESSION_INVALID`,
`SEALED_EXPORT_CHUNK_DIGEST_MISMATCH` and `SEALED_EXPORT_CHUNK_UNDECLARED`. The scan's own finding
ids (`THROW_SITE_*`) are scanner output, not domain reasons, and are not part of that vocabulary.

---

## P1 — `manifestDigest` is now bound to the real manifest

`classifyChunkSubmission` derives `computeManifestDigest(manifest)` and compares it in constant
time. A caller-supplied digest that is not this manifest's fails closed with
`SEALED_EXPORT_UPLOAD_SESSION_INVALID`.

Reproduction, run against the pre-fix and post-fix `contracts.cjs` (same probe, same fixtures):

```
BEFORE                                            AFTER
classify(manifestA, FAKE, [], sub0) => ACCEPT     => REFUSED SEALED_EXPORT_UPLOAD_SESSION_INVALID
classify(manifestB, FAKE, [], sub0) => ACCEPT     => REFUSED SEALED_EXPORT_UPLOAD_SESSION_INVALID
```

`FAKE` is a well-formed lower-hex string that is not either manifest's digest; both manifests
accepted it, which is the "two different manifests share one fake session digest" case.

The arbitrary `D('manifest-session')` fixture is **deleted**. The test derives the session digest
from the manifest the way production does, and adds negatives for a fabricated key echoed by the
submission and by receipts, and for a *genuine* digest belonging to a *different* manifest — the
case no format check can catch.

## P1 — receipts are now bound to the manifest's chunk descriptors

Every accepted receipt is checked against the manifest descriptor at its index — chunk digest and
byte count, in **separate** guards — in both `classifyChunkSubmission` and `assertChunkSetComplete`.

```
BEFORE                                                          AFTER
classify(A, REAL, [receipt0-forged], sub0-forged)               => REFUSED
  => IDEMPOTENT_REPLAY                                             SEALED_EXPORT_CHUNK_DIGEST_MISMATCH
assertChunkSetComplete(A, [receipt0-forged, receipt1])          => REFUSED
  => { chunkCount: 2 }                                             SEALED_EXPORT_CHUNK_DIGEST_MISMATCH
```

The replay branch still compares submission-against-receipt, deliberately: the receipt was bound to
the descriptor in the accept loop, so the replay decision is transitively descriptor-bound. A
second submission-against-descriptor check there would be a second door for one property and would
make the neuter probe for either one non-discriminating; the code says so at the branch.

## P2 — the activate closed error policy is no longer runtime-mutable

`ACTIVATE_ERROR_POLICY_SOURCE` is module-private. The `Map` is built from its own frozen row
copies. `ACTIVATE_ERROR_POLICY` and `ACTIVATE_ERROR_FALLBACK` are deep-frozen projections.

The owner's exact mutation is now a test: set `ACTIVATE_RACE` to `200` plus driver text through the
public export, then call `mapActivateError()`.

```
BEFORE  AssertionError: expected 200 to be 409        (and the driver text was published)
AFTER   409 / 'User is no longer pending activation'
```

## P2 — the AST vocabulary scan resolves the binding, not the name

The scan now records every local name bound to `failSealedExport` — destructures, renames,
transitive aliases, member aliases, ESM import specifiers — and matches those. A callee it cannot
resolve statically is a **loud** finding rather than a silent miss.

| shape | before | after |
|---|---|---|
| direct call | 1 `THROW_SITE_REASON_UNDECLARED` | 1 `THROW_SITE_REASON_UNDECLARED` |
| `const { failSealedExport: fail } = …; fail('NOT_DECLARED')` | **0** | 1 `THROW_SITE_REASON_UNDECLARED` |
| alias of alias | **0** | 1 `THROW_SITE_REASON_UNDECLARED` |
| `const fail = v.failSealedExport` | **0** | 1 `THROW_SITE_REASON_UNDECLARED` |
| `v['failSealedExport']('NOT_DECLARED')` | **0** | 1 `THROW_SITE_REASON_UNDECLARED` |
| `v[name]('NOT_DECLARED')` (computed) | **0** | 1 `THROW_SITE_CALLEE_UNRESOLVABLE` |
| `pick(v)('NOT_DECLARED')` (call-of-call) | **0** | 1 `THROW_SITE_CALLEE_UNRESOLVABLE` |
| rename of a **different** export | 0 | 0 (negative control) |

Beyond the named finding, two further unreadable shapes are reported rather than skipped: a bound
name used as a **value** (`THROW_SITE_BINDING_ESCAPES`, outside the declaring module) and a computed
member read **of the vocabulary module** (`THROW_SITE_BINDING_UNRESOLVABLE`). An ordinary
`bytes[index]` is not treated as an alias attempt — that negative control is asserted, because
flagging every computed read would make the findings worthless.

## P3 — stale text corrected, retraction-first, at five sites

The owner named four; a multi-line sweep found a fifth (the same "desynchronising for the rest of
the file" overclaim in `sealed-export-failure-vocabulary.test.cjs`).

- `lib/sealed-export/failure-vocabulary.cjs` — "proposed, not ratified" → RATIFIED 2026-07-27, 30 tokens frozen
- `__tests__/sealed-export-failure-vocabulary.test.cjs` — same
- `lib/sealed-export/compliance-harness.cjs` — "blanked everything after" → **bounded** blind window
- `__tests__/support/sealed-export-source-scan.cjs` — same
- `__tests__/sealed-export-failure-vocabulary.test.cjs` — "desynchronising for the rest of the file" → bounded

Sweep result after the edits: **live claims 0**, five hits remaining and all of them quoted inside
an explicit withdrawal. (One unrelated live hit exists in
`docs/development/attendance-advanced-scheduling-rule-set-diagnostic-verification-20260526.md`,
about a scheduling rule set, not this vocabulary. Out of scope, untouched.)

---

## Mutations (each neutered separately; file hash confirmed changed and restored byte-identically)

| # | mutation | result |
|---|---|---|
| M1 | derived manifest-digest comparison always passes | RED — "fabricated session key, echoed by the submission" |
| M2 | receipt `chunkDigest` vs descriptor always passes | RED — "receipt digest alone disagreeing with the descriptor" |
| M3 | receipt `byteCount` vs descriptor always passes | RED — "receipt byte count alone disagreeing with the descriptor" |
| M4 | undeclared receipt index refusal removed | RED — "receipt beyond the manifest" |
| M5 | session digest derived from a constant, not the manifest | RED — "fabricated session key…" |
| S1 | renamed destructure no longer binds | RED — "renamed destructure must be resolved to the binding" |
| S2 | static element access no longer resolves | RED |
| S3 | unresolvable callee reported as nothing | RED — "must produce a finding, not silence" |
| S4 | escaping bound name reported as nothing | RED — "a bound name used as a value must be reported" |
| S5 | alias-of-alias no longer resolves | RED |
| F1 | policy rows no longer frozen | RED — "expected 200 to be 409" |
| F2 | exported policy table no longer frozen | RED |
| F3 | fallback no longer frozen | RED |
| F4 | Map shares the module-private source rows | **GREEN** — see non-claims |

M2/M3 fail on their own named assertion, so the two descriptor terms do not cover for each other.

## Where these run

- The six sealed-export suites are in `plugins/plugin-integration-core`'s explicit `scripts.test`
  `&&` chain, run by **`integration-guard`** → "Run plugin-integration-core CJS test chain".
  `integration-guard` is **NOT** one of the eight required contexts on `main`.
- The activate tests run under `pnpm --filter @metasheet/core-backend test`, the "Run core-backend
  tests" step of the `test` job in `plugin-tests.yml` — i.e. **`test (20.x)`, which IS required**.

Stated plainly rather than softened: the sealed-export half of this PR lands in a non-required
channel; the activate half lands in a required one.

## Non-claims

- **The `Map` holding distinct row objects is not asserted by any test.** With every published row
  frozen, row sharing has no behavioural discriminator — mutation F4 restores the sharing and the
  suite stays GREEN. The clone is defense-in-depth and satisfies the owner's literal instruction;
  the load-bearing property is the deep freeze, and that is what the tests prove.
- The AST scan is a **static source assertion**, not a behaviour proof, and it is a syntactic
  binding resolver, not a type-checked dataflow analysis. A binding that escapes through a function
  parameter or a return value cannot be followed; escapes are reported rather than resolved.
- No claim that S2 is unblocked, that any runtime path exists, or that the sealed-export surface has
  a consumer. It remains latent by authorization.
- No claim about the S3 dependency-resolution failures seen locally
  (`@aws-sdk/client-s3` unavailable in the local tree, three suites); CI's run is the authority.
