### PR TITLE
feat(directory): harden deprovision evidence ledger

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -100,6 +100,7 @@ jobs:
         run: |
           node --test scripts/ops/dingtalk-closeout-env-contract.test.mjs
           node --test scripts/ops/directory-grant-table-ci-wiring.test.mjs
+          node --test scripts/ops/directory-deprovision-ledger-ci-wiring.test.mjs
 
       - name: Run DingTalk OAuth-stability metrics-only contract test (DT-CLOSE-01B)
         run: |
@@ -1088,6 +1089,7 @@ jobs:
             tests/integration/directory-sync-alert-coverage.db.test.ts \
             tests/integration/directory-deprovision-selection.db.test.ts \
             tests/integration/directory-deprovision-grant-table.db.test.ts \
+            tests/integration/directory-deprovision-ledger-schema.db.test.ts \
             tests/integration/directory-sync-run-lease.db.test.ts \
             tests/integration/directory-tenant-change-immutable.db.test.ts \
             tests/integration/directory-sync-orchestration.db.test.ts \

--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -233,6 +233,14 @@ jobs:
             scripts/ops/multitable-onprem-package-verify-k3-helper-contract.test.mjs \
             scripts/ops/resolve-k3wise-smoke-token.test.mjs
 
+      # Same promotion, same reason (adversarial review of #4646, P3): the D3 deprovision-ledger
+      # CI-wiring contract is the ONLY mechanical guard proving the ledger real-DB suites stay in
+      # the required run-list and excluded from the no-DB job. Its original home is the
+      # k3wise-offline-poc job, whose check cannot block a merge — invoked here as well so it
+      # actually gates. Duplicate run costs <1s; the original stays for job self-containment.
+      - name: Directory deprovision ledger CI-wiring contract (required lane)
+        run: node --test scripts/ops/directory-deprovision-ledger-ci-wiring.test.mjs
+
       # Integration Guard required-wiring contract (governance slice, standalone from #4603/#4604/
       # #4610 by owner instruction; hardened 2026-07-25 after a P1x2/P2 review — see the workflow's own
       # header for the corrected rationale). Mixed YAML-shape + BEHAVIOURAL contract that makes

--- a/apps/web/src/components/directory/DirectoryDeprovisionEvidencePanel.vue
+++ b/apps/web/src/components/directory/DirectoryDeprovisionEvidencePanel.vue
@@ -282,7 +282,8 @@ async function runPreview() {
   loadingPreview.value = true
   preview.value = null
   try {
-    const params = new URLSearchParams({ integrationId: props.integrationId })
+    const params = new URLSearchParams()
+    if (props.integrationId) params.set('integrationId', props.integrationId)
     const response = await apiFetch(
       `/api/admin/directory/deprovision/preview/${encodeURIComponent(userId)}?${params.toString()}`,
     )

--- a/apps/web/src/components/directory/DirectoryDeprovisionEvidencePanel.vue
+++ b/apps/web/src/components/directory/DirectoryDeprovisionEvidencePanel.vue
@@ -282,7 +282,10 @@ async function runPreview() {
   loadingPreview.value = true
   preview.value = null
   try {
-    const response = await apiFetch(`/api/admin/directory/deprovision/preview/${encodeURIComponent(userId)}`)
+    const params = new URLSearchParams({ integrationId: props.integrationId })
+    const response = await apiFetch(
+      `/api/admin/directory/deprovision/preview/${encodeURIComponent(userId)}?${params.toString()}`,
+    )
     const body = await response.json().catch(() => ({}))
     if (!response.ok) {
       setError(body?.error?.message || body?.error?.code || '预览失败')

--- a/apps/web/tests/DirectoryDeprovisionEvidencePanel.spec.ts
+++ b/apps/web/tests/DirectoryDeprovisionEvidencePanel.spec.ts
@@ -88,7 +88,7 @@ describe('DirectoryDeprovisionEvidencePanel (D7)', () => {
           user: { id: 'u1', activationStatus: 'activated', isActive: true, accessGeneration: 2 },
           plan: {
             skipReason: null,
-            effects: [{ type: 'set_user_inactive', beforeActive: true, afterActive: false }],
+            effects: [{ type: 'user_changed', beforeActive: true, afterActive: false }],
           },
         })
       }
@@ -109,8 +109,11 @@ describe('DirectoryDeprovisionEvidencePanel (D7)', () => {
     btn.click()
     await flushUi()
 
-    expect(apiFetchMock.mock.calls.some((c) => String(c[0]).includes('/deprovision/preview/u1'))).toBe(true)
-    expect(root.querySelector('[data-testid="deprovision-preview-result"]')?.textContent).toMatch(/set_user_inactive/)
+    expect(apiFetchMock.mock.calls.some((c) => (
+      String(c[0]).includes('/deprovision/preview/u1')
+      && String(c[0]).includes('integrationId=int-1')
+    ))).toBe(true)
+    expect(root.querySelector('[data-testid="deprovision-preview-result"]')?.textContent).toMatch(/user_changed/)
   })
 
   it('surfaces DRIFT_CONFLICT on restore failure', async () => {

--- a/docs/development/dingtalk-deprovision-reactivation-and-evidence-chain-design-20260723.md
+++ b/docs/development/dingtalk-deprovision-reactivation-and-evidence-chain-design-20260723.md
@@ -50,6 +50,8 @@ Prospective planner、三 effect 意图、event 恢复、全写者锁意图、ma
 |---|------|--------------|
 | **P1** | `globally_clear` 被误读为「清全部组织 membership」，与主写者的 org/global 双候选语义及 `UNIQUE(event_id,effect_type)` 冲突 | 每 event 只记源 integration 所属 org 的一条 `membership_changed`；`globally_clear` 只门控 `grant_changed` / `user_changed` |
 
+**Ratification 记录（2026-08-07）**：owner 于会话「钉钉同步业务功能开发-260721」下达收尾指令（「请排序并完成所有这条线剩余的开发」），采纳的收尾意见以「显式批准 Rev 4.3 的来源组织单 membership effect 语义」为第 1 步 —— 本勘误据此落账执行。该勘误使锁文与已落 main 的主写者语义（W4-PRE-1d owner P2 裁决，#4530 review issuecomment-5043752399：org 候选与 global 候选分立，global 守卫只门控 grant/`users.is_active`）一致，并非新语义。终版随验证 MD 提请 owner 会签。
+
 产品方向见 companion — **已赞成**。  
 **Implementation design lock 已于 2026-07-23 批准。**  
 序：lock → T1→T2→T3 → D1…D7 → canary。  

--- a/docs/development/dingtalk-deprovision-reactivation-and-evidence-chain-design-20260723.md
+++ b/docs/development/dingtalk-deprovision-reactivation-and-evidence-chain-design-20260723.md
@@ -1,7 +1,7 @@
 # DingTalk Deprovision 恢复 + Preview/UI 证据链 — 实现级设计
 
 - Date: 2026-07-23
-- Status: **implementation design lock / Rev 4.2**
+- Status: **implementation design lock / Rev 4.3**
 - Locked: 2026-07-23（owner 批准两篇一并升 lock）
 - Scope: 打开 `DIRECTORY_DEPROVISION_ENABLED` 之前，把「权威 effect 账本 + prospective planner + 全写者 per-user 锁 + event 恢复（含 drift）」设计正确
 - Baseline: **`origin/main @ 1bcfc86b8`**；相对 `ca625f14a` 本线相关代码 **scoped diff = 0**（membership + globally-clear 事实基线仍成立）
@@ -43,6 +43,12 @@ Prospective planner、三 effect 意图、event 恢复、全写者锁意图、ma
 |---|------|------------|
 | **P1** | `event → directory_account_links` FK 卡死 unbind/rebind；partial unique 不能作 FK 目标 | §5.2：**删除** event→current-link FK；**保留** INSERT trigger 验当前 linked + 字段 immutability 固化历史；**不**采用 append-only link_versions（YAGNI，除非未来另票） |
 | **P2** | §3 写 supersede **或** generation++ | §3 与 §5.4 统一为 **generation++ AND supersede** |
+
+### 0.6 Rev 4.2 → Rev 4.3（D3 implementation erratum）
+
+| # | 问题 | Rev 4.3 锁定 |
+|---|------|--------------|
+| **P1** | `globally_clear` 被误读为「清全部组织 membership」，与主写者的 org/global 双候选语义及 `UNIQUE(event_id,effect_type)` 冲突 | 每 event 只记源 integration 所属 org 的一条 `membership_changed`；`globally_clear` 只门控 `grant_changed` / `user_changed` |
 
 产品方向见 companion — **已赞成**。  
 **Implementation design lock 已于 2026-07-23 批准。**  
@@ -156,7 +162,14 @@ Writer：`applyDirectoryDeprovisionPlan` 仅在 `enabled=true` 时写访问图 +
 - membership `org_id` 可空 → 无法锚定组织成员 effect。  
 - 恢复盲写 before 覆盖后续安全停用（drift/generation 必须严格）。
 
-### 5.2 表结构意图（Rev 4.2 — DB 权威；历史 witness 不绑 live link）
+### 5.2 表结构意图（Rev 4.3 — DB 权威；历史 witness 不绑 live link）
+
+**Rev 4.3 implementation erratum:** `globally_clear` 只表示该用户在任意目录中已无其他
+active linked account，因此允许同时关闭 DingTalk grant 与 `users.is_active`。当前 integration
+所属组织的 `user_orgs` membership 是独立的组织级 effect，不因用户在其他组织仍 active 而保留。
+因此一次 event 最多有一个 `membership_changed`（锚定 event 的 `org_id`），而不是为用户的全部
+组织各写一个 membership effect。此勘误使 schema 的 `UNIQUE (event_id, effect_type)`、effects
+trigger 与已落地主写者的 org/global 双候选语义一致。
 
 **Prerequisite unique keys**（迁移必须先有，否则复合 FK 无法建）：
 
@@ -244,7 +257,7 @@ directory_deprovision_event_effects (
 | 机制 | 要求 |
 |------|------|
 | **BEFORE INSERT ON events** | 在 **已持有对应 `users` 行锁的同一事务** 内校验：**当时** 存在 linked 行（`link_status='linked'` 且 account/user 匹配）；account ∈ integration；integration.org_id 匹配；sync 时 run 存在且同 integration。失败 → **拒绝 INSERT**。 |
-| **BEFORE INSERT ON effects** | `membership_changed` ⇒ `NEW.org_id = parent event.org_id`，否则拒绝。 |
+| **BEFORE INSERT ON effects** | `membership_changed` ⇒ `NEW.org_id = parent event.org_id`；grant/user effect 的 `org_id` 必须为 NULL；effect 的 user/generation 必须与 parent event 一致。 |
 | **Immutability** | events：INSERT 后禁止改身份字段（含 `directory_account_id`, `local_user_id`, `link_witness_*`, policy, globally_clear, generation, event_origin, run_id, org_id, integration_id, triggered_by）。仅允许 resolve 列。effects：INSERT 后禁止改 type/org/before_active/after_active/generation；仅 status/reversed_*。 |
 | **禁止** | event→**current** `directory_account_links` FK；partial unique 作 FK 目标；仅靠 witness=自身 CHECK 充当“当时已 linked”（CHECK 只防自相矛盾，**trigger 才验 live link**）。 |
 

--- a/packages/core-backend/src/db/migrations/zzzz20260728100000_harden_directory_deprovision_ledger.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260728100000_harden_directory_deprovision_ledger.ts
@@ -1,0 +1,565 @@
+import type { Kysely } from 'kysely'
+import { sql } from 'kysely'
+
+/**
+ * D3 completion for the Rev 4.3 deprovision evidence ledger.
+ *
+ * The earlier zzzz20260724170000 migration intentionally landed a weak, empty
+ * scaffold. This migration makes the database authoritative: provenance is
+ * typed, event/account/run relationships are FK-backed, effect vocabulary is
+ * closed, the live account link is checked at INSERT time, and historical
+ * identity fields are immutable.
+ *
+ * Upgrade policy:
+ * - an empty weak scaffold can be upgraded;
+ * - a hardened ledger can be replayed even after evidence exists;
+ * - a non-empty weak or partial scaffold fails before any DDL because witness,
+ *   policy, and globally-clear provenance cannot be reconstructed honestly;
+ * - down() refuses to remove a ledger that contains evidence.
+ */
+
+const EVENTS = 'directory_deprovision_events'
+const EFFECTS = 'directory_deprovision_effects'
+const OWNER = 'owned-by:zzzz20260728100000_harden_directory_deprovision_ledger'
+const REQUIRED_PROVENANCE_COLUMNS = [
+  'link_witness_account_id',
+  'link_witness_local_user_id',
+  'policy',
+  'globally_clear',
+] as const
+
+export const __deprovisionLedgerEffectTypes = ['membership_changed', 'grant_changed', 'user_changed'] as const
+
+async function tableExists(db: Kysely<unknown>, tableName: string): Promise<boolean> {
+  const result = await sql<{ exists: boolean }>`
+    SELECT EXISTS (
+      SELECT 1
+        FROM information_schema.tables
+       WHERE table_schema = current_schema()
+         AND table_name = ${tableName}
+    ) AS exists
+  `.execute(db)
+  return result.rows[0]?.exists === true
+}
+
+async function columnExists(db: Kysely<unknown>, tableName: string, columnName: string): Promise<boolean> {
+  const result = await sql<{ exists: boolean }>`
+    SELECT EXISTS (
+      SELECT 1
+        FROM information_schema.columns
+       WHERE table_schema = current_schema()
+         AND table_name = ${tableName}
+         AND column_name = ${columnName}
+    ) AS exists
+  `.execute(db)
+  return result.rows[0]?.exists === true
+}
+
+async function columnType(db: Kysely<unknown>, tableName: string, columnName: string): Promise<string | null> {
+  const result = await sql<{ data_type: string }>`
+    SELECT data_type
+      FROM information_schema.columns
+     WHERE table_schema = current_schema()
+       AND table_name = ${tableName}
+       AND column_name = ${columnName}
+  `.execute(db)
+  return result.rows[0]?.data_type ?? null
+}
+
+async function rowCount(db: Kysely<unknown>, tableName: string): Promise<number> {
+  const result = await sql<{ count: string }>`
+    SELECT COUNT(*)::text AS count FROM ${sql.table(tableName)}
+  `.execute(db)
+  return Number(result.rows[0]?.count ?? 0)
+}
+
+async function assertUpgradePreflight(db: Kysely<unknown>): Promise<void> {
+  const hasEvents = await tableExists(db, EVENTS)
+  const hasEffects = await tableExists(db, EFFECTS)
+  if (!hasEvents || !hasEffects) {
+    throw new Error('directory deprovision ledger hardening requires both scaffold tables from ' + 'zzzz20260724170000')
+  }
+
+  const provenancePresence = await Promise.all(
+    REQUIRED_PROVENANCE_COLUMNS.map((column) => columnExists(db, EVENTS, column)),
+  )
+  const hardenedProvenancePresent = provenancePresence.every(Boolean)
+  if (hardenedProvenancePresent) return
+
+  const eventRows = await rowCount(db, EVENTS)
+  const effectRows = await rowCount(db, EFFECTS)
+  if (eventRows > 0 || effectRows > 0) {
+    throw new Error(
+      'directory deprovision ledger hardening aborted before DDL: the weak or partial ledger ' +
+        `contains ${eventRows} event row(s) and ${effectRows} effect row(s), so link witness, ` +
+        'policy, and globally-clear provenance cannot be reconstructed safely',
+    )
+  }
+}
+
+async function ensureUuidColumn(db: Kysely<unknown>, tableName: string, columnName: string): Promise<void> {
+  const type = await columnType(db, tableName, columnName)
+  if (type === 'uuid') return
+  if (type !== 'text') {
+    throw new Error(`directory deprovision ledger column drift: ${tableName}.${columnName} is ${type ?? 'missing'}`)
+  }
+  await sql`
+    ALTER TABLE ${sql.table(tableName)}
+    ALTER COLUMN ${sql.id(columnName)} TYPE uuid
+    USING ${sql.id(columnName)}::uuid
+  `.execute(db)
+}
+
+async function uniqueColumnSets(
+  db: Kysely<unknown>,
+  tableName: string,
+): Promise<Array<{ name: string; columns: string[] }>> {
+  const result = await sql<{ name: string; columns: string[] }>`
+    SELECT constraint_row.conname AS name,
+           array_agg(attribute.attname ORDER BY key_column.ordinality)::text[] AS columns
+      FROM pg_constraint constraint_row
+      JOIN pg_class table_rel ON table_rel.oid = constraint_row.conrelid
+      JOIN pg_namespace namespace ON namespace.oid = table_rel.relnamespace
+      JOIN unnest(constraint_row.conkey) WITH ORDINALITY AS key_column(attnum, ordinality)
+        ON TRUE
+      JOIN pg_attribute attribute
+        ON attribute.attrelid = table_rel.oid
+       AND attribute.attnum = key_column.attnum
+     WHERE namespace.nspname = current_schema()
+       AND table_rel.relname = ${tableName}
+       AND constraint_row.contype IN ('p', 'u')
+     GROUP BY constraint_row.oid, constraint_row.conname
+  `.execute(db)
+  return result.rows
+}
+
+async function ensureUniqueColumns(
+  db: Kysely<unknown>,
+  tableName: string,
+  constraintName: string,
+  columns: string[],
+  leaveOnDown = false,
+): Promise<void> {
+  const shapes = await uniqueColumnSets(db, tableName)
+  const named = shapes.find((shape) => shape.name === constraintName)
+  if (named && named.columns.join('\0') !== columns.join('\0')) {
+    throw new Error(`directory deprovision ledger prerequisite drift: ${tableName}.${constraintName}`)
+  }
+  if (shapes.some((shape) => shape.columns.join('\0') === columns.join('\0'))) return
+
+  await sql`
+    ALTER TABLE ${sql.table(tableName)}
+    ADD CONSTRAINT ${sql.id(constraintName)}
+    UNIQUE (${sql.join(columns.map((column) => sql.id(column)))})
+  `.execute(db)
+  if (!leaveOnDown) {
+    await sql`
+      COMMENT ON CONSTRAINT ${sql.id(constraintName)} ON ${sql.table(tableName)}
+      IS ${sql.lit(OWNER)}
+    `.execute(db)
+  }
+}
+
+async function constraintOwned(db: Kysely<unknown>, tableName: string, constraintName: string): Promise<boolean> {
+  const result = await sql<{ owned: boolean }>`
+    SELECT COALESCE(obj_description(constraint_row.oid, 'pg_constraint'), '') = ${OWNER} AS owned
+      FROM pg_constraint constraint_row
+      JOIN pg_class table_rel ON table_rel.oid = constraint_row.conrelid
+      JOIN pg_namespace namespace ON namespace.oid = table_rel.relnamespace
+     WHERE namespace.nspname = current_schema()
+       AND table_rel.relname = ${tableName}
+       AND constraint_row.conname = ${constraintName}
+  `.execute(db)
+  return result.rows[0]?.owned === true
+}
+
+async function replaceConstraint(
+  db: Kysely<unknown>,
+  tableName: string,
+  constraintName: string,
+  definition: string,
+): Promise<void> {
+  await sql`
+    ALTER TABLE ${sql.table(tableName)}
+    DROP CONSTRAINT IF EXISTS ${sql.id(constraintName)}
+  `.execute(db)
+  await sql`
+    ALTER TABLE ${sql.table(tableName)}
+    ADD CONSTRAINT ${sql.id(constraintName)} ${sql.raw(definition)}
+  `.execute(db)
+}
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await assertUpgradePreflight(db)
+
+  await ensureUniqueColumns(db, 'directory_integrations', 'uq_directory_integrations_id_org', ['id', 'org_id'], true)
+  await ensureUniqueColumns(db, 'directory_accounts', 'uq_directory_accounts_id_integration', ['id', 'integration_id'])
+  await ensureUniqueColumns(db, 'directory_sync_runs', 'uq_directory_sync_runs_id_integration', [
+    'id',
+    'integration_id',
+  ])
+
+  await ensureUuidColumn(db, EVENTS, 'integration_id')
+  await ensureUuidColumn(db, EVENTS, 'directory_account_id')
+  await ensureUuidColumn(db, EVENTS, 'run_id')
+
+  await sql`
+    ALTER TABLE directory_deprovision_events
+      ADD COLUMN IF NOT EXISTS link_witness_account_id uuid,
+      ADD COLUMN IF NOT EXISTS link_witness_local_user_id text,
+      ADD COLUMN IF NOT EXISTS policy text,
+      ADD COLUMN IF NOT EXISTS globally_clear boolean,
+      ADD COLUMN IF NOT EXISTS resolved_at timestamptz,
+      ADD COLUMN IF NOT EXISTS resolved_by text,
+      ADD COLUMN IF NOT EXISTS resolve_note text,
+      ADD COLUMN IF NOT EXISTS restore_mode text
+  `.execute(db)
+  await sql`
+    ALTER TABLE directory_deprovision_effects
+      ADD COLUMN IF NOT EXISTS reversed_by text
+  `.execute(db)
+
+  await sql`
+    ALTER TABLE directory_deprovision_events
+      ALTER COLUMN link_witness_account_id SET NOT NULL,
+      ALTER COLUMN link_witness_local_user_id SET NOT NULL,
+      ALTER COLUMN policy SET NOT NULL,
+      ALTER COLUMN policy SET DEFAULT 'manual_review',
+      ALTER COLUMN globally_clear SET NOT NULL,
+      ALTER COLUMN globally_clear SET DEFAULT FALSE,
+      ALTER COLUMN triggered_by SET NOT NULL,
+      ALTER COLUMN status SET DEFAULT 'applied'
+  `.execute(db)
+  await sql`
+    ALTER TABLE directory_deprovision_effects
+      ALTER COLUMN event_id SET NOT NULL,
+      ALTER COLUMN status SET DEFAULT 'applied'
+  `.execute(db)
+
+  await replaceConstraint(db, EVENTS, 'ddev_event_origin_check', "CHECK (event_origin IN ('sync','admin_manual'))")
+  await replaceConstraint(
+    db,
+    EVENTS,
+    'ddev_run_id_by_origin_check',
+    "CHECK ((event_origin = 'sync' AND run_id IS NOT NULL) OR " + "(event_origin = 'admin_manual' AND run_id IS NULL))",
+  )
+  await replaceConstraint(
+    db,
+    EVENTS,
+    'ddev_policy_check',
+    "CHECK (policy IN ('manual_review','disable_grant_only','mark_inactive'))",
+  )
+  await replaceConstraint(
+    db,
+    EVENTS,
+    'ddev_status_check',
+    "CHECK (status IN ('applied','fully_resolved','superseded'))",
+  )
+  await replaceConstraint(
+    db,
+    EVENTS,
+    'ddev_witness_account_check',
+    'CHECK (link_witness_account_id = directory_account_id)',
+  )
+  await replaceConstraint(db, EVENTS, 'ddev_witness_user_check', 'CHECK (link_witness_local_user_id = local_user_id)')
+  await replaceConstraint(
+    db,
+    EVENTS,
+    'ddev_restore_mode_check',
+    "CHECK (restore_mode IS NULL OR restore_mode IN ('rehire','admin_force'))",
+  )
+
+  await replaceConstraint(
+    db,
+    EFFECTS,
+    'ddef_effect_type_check',
+    "CHECK (effect_type IN ('membership_changed','grant_changed','user_changed'))",
+  )
+  await replaceConstraint(db, EFFECTS, 'ddef_status_check', "CHECK (status IN ('applied','reversed','superseded'))")
+  await replaceConstraint(
+    db,
+    EFFECTS,
+    'ddef_org_id_by_type_check',
+    "CHECK ((effect_type = 'membership_changed' AND org_id IS NOT NULL) OR " +
+      "(effect_type IN ('grant_changed','user_changed') AND org_id IS NULL))",
+  )
+  await replaceConstraint(db, EFFECTS, 'ddef_event_effect_type_key', 'UNIQUE (event_id, effect_type)')
+
+  await replaceConstraint(db, EVENTS, 'ddev_user_fk', 'FOREIGN KEY (local_user_id) REFERENCES users(id)')
+  await replaceConstraint(
+    db,
+    EVENTS,
+    'ddev_account_integration_fk',
+    'FOREIGN KEY (directory_account_id, integration_id) ' + 'REFERENCES directory_accounts(id, integration_id)',
+  )
+  await replaceConstraint(
+    db,
+    EVENTS,
+    'ddev_integration_org_fk',
+    'FOREIGN KEY (integration_id, org_id) REFERENCES directory_integrations(id, org_id)',
+  )
+  await replaceConstraint(
+    db,
+    EVENTS,
+    'ddev_run_integration_fk',
+    'FOREIGN KEY (run_id, integration_id) REFERENCES directory_sync_runs(id, integration_id)',
+  )
+  await replaceConstraint(
+    db,
+    EFFECTS,
+    'ddef_event_fk',
+    'FOREIGN KEY (event_id) REFERENCES directory_deprovision_events(id) ON DELETE CASCADE',
+  )
+
+  await sql`
+    CREATE OR REPLACE FUNCTION directory_deprovision_validate_event()
+    RETURNS trigger AS $$
+    BEGIN
+      IF NOT EXISTS (
+        SELECT 1
+          FROM directory_account_links link
+         WHERE link.directory_account_id = NEW.directory_account_id
+           AND link.local_user_id = NEW.local_user_id
+           AND link.link_status = 'linked'
+      ) THEN
+        RAISE EXCEPTION 'deprovision event requires a linked account/user at apply time';
+      END IF;
+
+      IF NOT EXISTS (
+        SELECT 1 FROM directory_accounts account
+         WHERE account.id = NEW.directory_account_id
+           AND account.integration_id = NEW.integration_id
+      ) THEN
+        RAISE EXCEPTION 'deprovision event account/integration mismatch';
+      END IF;
+
+      IF NOT EXISTS (
+        SELECT 1 FROM directory_integrations integration
+         WHERE integration.id = NEW.integration_id
+           AND integration.org_id = NEW.org_id
+      ) THEN
+        RAISE EXCEPTION 'deprovision event integration/org mismatch';
+      END IF;
+
+      IF NEW.event_origin = 'sync' AND NOT EXISTS (
+        SELECT 1 FROM directory_sync_runs run
+         WHERE run.id = NEW.run_id
+           AND run.integration_id = NEW.integration_id
+      ) THEN
+        RAISE EXCEPTION 'deprovision sync event run/integration mismatch';
+      END IF;
+
+      RETURN NEW;
+    END;
+    $$ LANGUAGE plpgsql
+  `.execute(db)
+
+  await sql`
+    CREATE OR REPLACE FUNCTION directory_deprovision_validate_effect()
+    RETURNS trigger AS $$
+    DECLARE
+      parent_org text;
+      parent_user text;
+      parent_generation bigint;
+    BEGIN
+      SELECT org_id, local_user_id, access_generation_at_apply
+        INTO parent_org, parent_user, parent_generation
+        FROM directory_deprovision_events
+       WHERE id = NEW.event_id;
+
+      IF NOT FOUND THEN
+        RAISE EXCEPTION 'deprovision effect has no parent event';
+      END IF;
+      IF NEW.local_user_id IS DISTINCT FROM parent_user THEN
+        RAISE EXCEPTION 'deprovision effect user does not match parent event';
+      END IF;
+      IF NEW.access_generation_at_apply IS DISTINCT FROM parent_generation THEN
+        RAISE EXCEPTION 'deprovision effect generation does not match parent event';
+      END IF;
+      IF NEW.effect_type = 'membership_changed'
+         AND NEW.org_id IS DISTINCT FROM parent_org THEN
+        RAISE EXCEPTION 'membership effect org does not match parent event';
+      END IF;
+
+      RETURN NEW;
+    END;
+    $$ LANGUAGE plpgsql
+  `.execute(db)
+
+  await sql`
+    CREATE OR REPLACE FUNCTION directory_deprovision_reject_identity_update()
+    RETURNS trigger AS $$
+    BEGIN
+      IF TG_TABLE_NAME = 'directory_deprovision_events' THEN
+        IF NEW.org_id IS DISTINCT FROM OLD.org_id
+           OR NEW.integration_id IS DISTINCT FROM OLD.integration_id
+           OR NEW.directory_account_id IS DISTINCT FROM OLD.directory_account_id
+           OR NEW.local_user_id IS DISTINCT FROM OLD.local_user_id
+           OR NEW.link_witness_account_id IS DISTINCT FROM OLD.link_witness_account_id
+           OR NEW.link_witness_local_user_id IS DISTINCT FROM OLD.link_witness_local_user_id
+           OR NEW.policy IS DISTINCT FROM OLD.policy
+           OR NEW.globally_clear IS DISTINCT FROM OLD.globally_clear
+           OR NEW.access_generation_at_apply IS DISTINCT FROM OLD.access_generation_at_apply
+           OR NEW.event_origin IS DISTINCT FROM OLD.event_origin
+           OR NEW.run_id IS DISTINCT FROM OLD.run_id
+           OR NEW.triggered_by IS DISTINCT FROM OLD.triggered_by THEN
+          RAISE EXCEPTION 'directory_deprovision_events identity fields are immutable';
+        END IF;
+      ELSIF TG_TABLE_NAME = 'directory_deprovision_effects' THEN
+        IF NEW.event_id IS DISTINCT FROM OLD.event_id
+           OR NEW.local_user_id IS DISTINCT FROM OLD.local_user_id
+           OR NEW.effect_type IS DISTINCT FROM OLD.effect_type
+           OR NEW.org_id IS DISTINCT FROM OLD.org_id
+           OR NEW.before_active IS DISTINCT FROM OLD.before_active
+           OR NEW.after_active IS DISTINCT FROM OLD.after_active
+           OR NEW.access_generation_at_apply IS DISTINCT FROM OLD.access_generation_at_apply THEN
+          RAISE EXCEPTION 'directory_deprovision_effects identity fields are immutable';
+        END IF;
+      END IF;
+      RETURN NEW;
+    END;
+    $$ LANGUAGE plpgsql
+  `.execute(db)
+
+  await sql`DROP TRIGGER IF EXISTS trg_deprovision_events_validate ON directory_deprovision_events`.execute(db)
+  await sql`
+    CREATE TRIGGER trg_deprovision_events_validate
+    BEFORE INSERT ON directory_deprovision_events
+    FOR EACH ROW EXECUTE FUNCTION directory_deprovision_validate_event()
+  `.execute(db)
+  await sql`DROP TRIGGER IF EXISTS trg_deprovision_effects_validate ON directory_deprovision_effects`.execute(db)
+  await sql`
+    CREATE TRIGGER trg_deprovision_effects_validate
+    BEFORE INSERT ON directory_deprovision_effects
+    FOR EACH ROW EXECUTE FUNCTION directory_deprovision_validate_effect()
+  `.execute(db)
+  await sql`DROP TRIGGER IF EXISTS trg_deprovision_events_immutable ON directory_deprovision_events`.execute(db)
+  await sql`
+    CREATE TRIGGER trg_deprovision_events_immutable
+    BEFORE UPDATE ON directory_deprovision_events
+    FOR EACH ROW EXECUTE FUNCTION directory_deprovision_reject_identity_update()
+  `.execute(db)
+  await sql`DROP TRIGGER IF EXISTS trg_deprovision_effects_immutable ON directory_deprovision_effects`.execute(db)
+  await sql`
+    CREATE TRIGGER trg_deprovision_effects_immutable
+    BEFORE UPDATE ON directory_deprovision_effects
+    FOR EACH ROW EXECUTE FUNCTION directory_deprovision_reject_identity_update()
+  `.execute(db)
+
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_directory_deprovision_events_integration_status
+    ON directory_deprovision_events(integration_id, status, created_at DESC)
+  `.execute(db)
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_directory_deprovision_effects_event_status
+    ON directory_deprovision_effects(event_id, status)
+  `.execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  if (!(await tableExists(db, EVENTS)) || !(await tableExists(db, EFFECTS))) return
+
+  const eventRows = await rowCount(db, EVENTS)
+  const effectRows = await rowCount(db, EFFECTS)
+  if (eventRows > 0 || effectRows > 0) {
+    throw new Error(
+      'directory deprovision ledger hardening down migration refused before DDL: ' +
+        `${eventRows} event row(s) and ${effectRows} effect row(s) are durable evidence`,
+    )
+  }
+
+  await sql`DROP TRIGGER IF EXISTS trg_deprovision_effects_validate ON directory_deprovision_effects`.execute(db)
+  await sql`DROP TRIGGER IF EXISTS trg_deprovision_events_validate ON directory_deprovision_events`.execute(db)
+  await sql`DROP FUNCTION IF EXISTS directory_deprovision_validate_effect()`.execute(db)
+  await sql`DROP FUNCTION IF EXISTS directory_deprovision_validate_event()`.execute(db)
+
+  for (const [tableName, constraintName] of [
+    [EFFECTS, 'ddef_event_fk'],
+    [EFFECTS, 'ddef_event_effect_type_key'],
+    [EFFECTS, 'ddef_org_id_by_type_check'],
+    [EFFECTS, 'ddef_status_check'],
+    [EFFECTS, 'ddef_effect_type_check'],
+    [EVENTS, 'ddev_run_integration_fk'],
+    [EVENTS, 'ddev_integration_org_fk'],
+    [EVENTS, 'ddev_account_integration_fk'],
+    [EVENTS, 'ddev_user_fk'],
+    [EVENTS, 'ddev_restore_mode_check'],
+    [EVENTS, 'ddev_witness_user_check'],
+    [EVENTS, 'ddev_witness_account_check'],
+    [EVENTS, 'ddev_status_check'],
+    [EVENTS, 'ddev_policy_check'],
+    [EVENTS, 'ddev_run_id_by_origin_check'],
+    [EVENTS, 'ddev_event_origin_check'],
+  ] as const) {
+    await sql`
+      ALTER TABLE ${sql.table(tableName)}
+      DROP CONSTRAINT IF EXISTS ${sql.id(constraintName)}
+    `.execute(db)
+  }
+
+  await sql`DROP INDEX IF EXISTS idx_directory_deprovision_effects_event_status`.execute(db)
+  await sql`DROP INDEX IF EXISTS idx_directory_deprovision_events_integration_status`.execute(db)
+
+  await sql`
+    ALTER TABLE directory_deprovision_effects
+      ALTER COLUMN event_id DROP NOT NULL,
+      DROP COLUMN IF EXISTS reversed_by
+  `.execute(db)
+  await sql`
+    ALTER TABLE directory_deprovision_events
+      ALTER COLUMN triggered_by DROP NOT NULL,
+      ALTER COLUMN status SET DEFAULT 'open',
+      DROP COLUMN IF EXISTS restore_mode,
+      DROP COLUMN IF EXISTS resolve_note,
+      DROP COLUMN IF EXISTS resolved_by,
+      DROP COLUMN IF EXISTS resolved_at,
+      DROP COLUMN IF EXISTS globally_clear,
+      DROP COLUMN IF EXISTS policy,
+      DROP COLUMN IF EXISTS link_witness_local_user_id,
+      DROP COLUMN IF EXISTS link_witness_account_id,
+      ALTER COLUMN integration_id TYPE text USING integration_id::text,
+      ALTER COLUMN directory_account_id TYPE text USING directory_account_id::text,
+      ALTER COLUMN run_id TYPE text USING run_id::text
+  `.execute(db)
+
+  await sql`
+    CREATE OR REPLACE FUNCTION directory_deprovision_reject_identity_update()
+    RETURNS trigger AS $$
+    BEGIN
+      IF TG_TABLE_NAME = 'directory_deprovision_events' THEN
+        IF NEW.org_id IS DISTINCT FROM OLD.org_id
+           OR NEW.integration_id IS DISTINCT FROM OLD.integration_id
+           OR NEW.directory_account_id IS DISTINCT FROM OLD.directory_account_id
+           OR NEW.local_user_id IS DISTINCT FROM OLD.local_user_id
+           OR NEW.access_generation_at_apply IS DISTINCT FROM OLD.access_generation_at_apply
+           OR NEW.event_origin IS DISTINCT FROM OLD.event_origin
+           OR NEW.run_id IS DISTINCT FROM OLD.run_id THEN
+          RAISE EXCEPTION 'directory_deprovision_events identity fields are immutable';
+        END IF;
+      ELSIF TG_TABLE_NAME = 'directory_deprovision_effects' THEN
+        IF NEW.effect_type IS DISTINCT FROM OLD.effect_type
+           OR NEW.org_id IS DISTINCT FROM OLD.org_id
+           OR NEW.before_active IS DISTINCT FROM OLD.before_active
+           OR NEW.after_active IS DISTINCT FROM OLD.after_active
+           OR NEW.access_generation_at_apply IS DISTINCT FROM OLD.access_generation_at_apply
+           OR NEW.local_user_id IS DISTINCT FROM OLD.local_user_id THEN
+          RAISE EXCEPTION 'directory_deprovision_effects identity fields are immutable';
+        END IF;
+      END IF;
+      RETURN NEW;
+    END;
+    $$ LANGUAGE plpgsql
+  `.execute(db)
+
+  for (const [tableName, constraintName] of [
+    ['directory_accounts', 'uq_directory_accounts_id_integration'],
+    ['directory_sync_runs', 'uq_directory_sync_runs_id_integration'],
+  ] as const) {
+    if (await constraintOwned(db, tableName, constraintName)) {
+      await sql`
+        ALTER TABLE ${sql.table(tableName)}
+        DROP CONSTRAINT ${sql.id(constraintName)}
+      `.execute(db)
+    }
+  }
+}

--- a/packages/core-backend/src/directory/deprovision-evidence-api.ts
+++ b/packages/core-backend/src/directory/deprovision-evidence-api.ts
@@ -252,11 +252,16 @@ export async function restoreDeprovisionEvent(options: {
       // after_active false means user should still be inactive for restore eligibility
       currentMatchesAfter[e.id] = user.rows[0].is_active === false
     } else if (e.effect_type === 'membership_changed') {
+      // DRIFT GATE — must fail closed. Swallowing this read turned a failed query into
+      // "0 active memberships", which reads as "current state matches after_active=false":
+      // the gate was satisfied BY ITS OWN FAILURE and could never fire on this leg. Same
+      // defect class as the phantom grant column fixed in #4587; a gate read that cannot
+      // complete must abort the restore, not wave it through.
       const org = await query<{ n: number }>(
         `SELECT count(*)::int AS n FROM user_orgs
           WHERE user_id = $1 AND org_id = $2 AND COALESCE(is_active, TRUE) = TRUE`,
         [event.local_user_id, e.org_id],
-      ).catch(() => ({ rows: [{ n: 0 }] }))
+      )
       // after false → no active membership
       currentMatchesAfter[e.id] = (org.rows[0]?.n ?? 0) === 0
     } else if (e.effect_type === 'grant_changed') {

--- a/packages/core-backend/src/directory/deprovision-evidence-api.ts
+++ b/packages/core-backend/src/directory/deprovision-evidence-api.ts
@@ -22,7 +22,7 @@ export function readDeprovisionRuntimeFlags() {
   }
 }
 
-export async function previewDeprovisionForUser(localUserId: string) {
+export async function previewDeprovisionForUser(localUserId: string, integrationId: string) {
   const user = await query<{
     id: string
     activation_status: string | null
@@ -43,10 +43,24 @@ export async function previewDeprovisionForUser(localUserId: string) {
   }
   const u = user.rows[0]
 
-  const orgs = await query<{ org_id: string }>(
-    `SELECT org_id FROM user_orgs WHERE user_id = $1 AND COALESCE(is_active, TRUE) = TRUE`,
-    [localUserId],
-  ).catch(() => ({ rows: [] as Array<{ org_id: string }> }))
+  const integration = await query<{ org_id: string }>(
+    `SELECT org_id FROM directory_integrations WHERE id = $1::uuid`,
+    [integrationId],
+  )
+  if (!integration.rows[0]) {
+    const err = new Error('Directory integration not found')
+    ;(err as Error & { code?: string }).code = 'INTEGRATION_NOT_FOUND'
+    throw err
+  }
+  const orgId = integration.rows[0].org_id
+
+  const membership = await query<{ active: boolean }>(
+    `SELECT EXISTS (
+       SELECT 1 FROM user_orgs
+        WHERE user_id = $1 AND org_id = $2 AND COALESCE(is_active, TRUE) = TRUE
+     ) AS active`,
+    [localUserId, orgId],
+  )
 
   // `user_external_auth_grants` is the table the OAuth login path reads. This used to read
   // `user_external_identities.grant_enabled` — a column no migration creates — behind a `.catch`
@@ -60,14 +74,27 @@ export async function previewDeprovisionForUser(localUserId: string) {
       LIMIT 1`,
     [localUserId],
   )
+  const globalBinding = await query<{ active: boolean }>(
+    `SELECT EXISTS (
+       SELECT 1
+         FROM directory_account_links l
+         JOIN directory_accounts a ON a.id = l.directory_account_id
+        WHERE l.local_user_id = $1
+          AND l.link_status = 'linked'
+          AND a.is_active = TRUE
+          AND a.integration_id <> $2::uuid
+     ) AS active`,
+    [localUserId, integrationId],
+  )
 
   const plan = planDirectoryDeprovision({
     localUserId,
     activationStatus: u.activation_status,
     isActive: u.is_active,
-    activeOrgIds: orgs.rows.map((r) => r.org_id),
+    orgId,
+    orgMembershipActive: membership.rows[0]?.active === true,
     dingtalkGrantEnabled: grant.rows[0]?.enabled === true,
-    globallyClear: true,
+    globallyClear: globalBinding.rows[0]?.active !== true,
   })
 
   return {
@@ -221,10 +248,10 @@ export async function restoreDeprovisionEvent(options: {
 
   const currentMatchesAfter: Record<string, boolean> = {}
   for (const e of applied) {
-    if (e.effect_type === 'set_user_inactive') {
+    if (e.effect_type === 'user_changed') {
       // after_active false means user should still be inactive for restore eligibility
       currentMatchesAfter[e.id] = user.rows[0].is_active === false
-    } else if (e.effect_type === 'clear_user_orgs') {
+    } else if (e.effect_type === 'membership_changed') {
       const org = await query<{ n: number }>(
         `SELECT count(*)::int AS n FROM user_orgs
           WHERE user_id = $1 AND org_id = $2 AND COALESCE(is_active, TRUE) = TRUE`,
@@ -232,7 +259,7 @@ export async function restoreDeprovisionEvent(options: {
       ).catch(() => ({ rows: [{ n: 0 }] }))
       // after false → no active membership
       currentMatchesAfter[e.id] = (org.rows[0]?.n ?? 0) === 0
-    } else if (e.effect_type === 'disable_dingtalk_grant') {
+    } else if (e.effect_type === 'grant_changed') {
       // This is a DRIFT GATE, so it must fail closed. Reading the phantom column and catching the
       // error yielded "no grant", which reads as "current state matches after_active=false" — the
       // gate was satisfied *by the read failing*, so it could never fire, and a grant that was
@@ -245,7 +272,9 @@ export async function restoreDeprovisionEvent(options: {
       )
       currentMatchesAfter[e.id] = g.rows[0]?.enabled !== true
     } else {
-      currentMatchesAfter[e.id] = true
+      const err = new Error(`Unsupported deprovision effect type: ${e.effect_type}`)
+      ;(err as Error & { code?: string }).code = 'EFFECT_TYPE_UNSUPPORTED'
+      throw err
     }
   }
 
@@ -269,12 +298,12 @@ export async function restoreDeprovisionEvent(options: {
     await client.query(`SELECT id FROM users WHERE id = $1 FOR UPDATE`, [event.local_user_id])
 
     for (const e of applied) {
-      if (e.effect_type === 'set_user_inactive') {
+      if (e.effect_type === 'user_changed') {
         await client.query(
           `UPDATE users SET is_active = TRUE, updated_at = NOW() WHERE id = $1`,
           [event.local_user_id],
         )
-      } else if (e.effect_type === 'clear_user_orgs' && e.org_id) {
+      } else if (e.effect_type === 'membership_changed' && e.org_id) {
         // `user_orgs` is (user_id, org_id, is_active, created_at) — there is no `updated_at`.
         // Setting one raised `42703`, which the `.catch` hid; the aborted transaction then failed
         // the very next statement with `25P02`, so restoring ANY event carrying a membership
@@ -290,12 +319,12 @@ export async function restoreDeprovisionEvent(options: {
         )
         if (!mem.rows[0]) {
           const err = new Error(
-            `membership row missing for org ${e.org_id}; cannot reverse clear_user_orgs`,
+            `membership row missing for org ${e.org_id}; cannot reverse membership_changed`,
           )
           ;(err as Error & { code?: string }).code = 'DRIFT_CONFLICT'
           throw err
         }
-      } else if (e.effect_type === 'disable_dingtalk_grant') {
+      } else if (e.effect_type === 'grant_changed') {
         // Upsert, not UPDATE: deprovision may have created the disabled row itself, and a restore
         // that silently matched zero rows would report success while the person stayed locked
         // out. The `.catch` is gone for the same reason it was wrong on the read — it could not

--- a/packages/core-backend/src/directory/deprovision-ledger.ts
+++ b/packages/core-backend/src/directory/deprovision-ledger.ts
@@ -16,13 +16,14 @@ export type ApplyDeprovisionInput = {
   directoryAccountId: string
   runId: string | null
   triggeredBy: string
+  policy: 'manual_review' | 'disable_grant_only' | 'mark_inactive'
   enabled: boolean
   /** When false, planner runs but writer is no-op (preview mode). */
   write: boolean
   loadUserState: () => Promise<{
     activationStatus: string | null
     isActive: boolean
-    activeOrgIds: string[]
+    orgMembershipActive: boolean
     dingtalkGrantEnabled: boolean
     accessGeneration: number
   }>
@@ -59,7 +60,8 @@ export async function applyDirectoryDeprovisionPlan(
     localUserId: input.localUserId,
     activationStatus: state.activationStatus,
     isActive: state.isActive,
-    activeOrgIds: state.activeOrgIds,
+    orgId: input.orgId,
+    orgMembershipActive: state.orgMembershipActive,
     dingtalkGrantEnabled: state.dingtalkGrantEnabled,
     globallyClear: input.globallyClear !== false,
   })
@@ -91,6 +93,8 @@ export async function applyDirectoryDeprovisionPlan(
     directoryAccountId: input.directoryAccountId,
     runId: input.runId,
     triggeredBy: input.triggeredBy,
+    policy: input.policy,
+    globallyClear: input.globallyClear !== false,
     effects: plan.effects,
     previousGeneration: state.accessGeneration,
   })
@@ -103,6 +107,8 @@ async function writeDeprovisionLedger(options: {
   directoryAccountId: string
   runId: string | null
   triggeredBy: string
+  policy: 'manual_review' | 'disable_grant_only' | 'mark_inactive'
+  globallyClear: boolean
   effects: PlannedEffect[]
   previousGeneration: number
 }): Promise<ApplyDeprovisionResult> {
@@ -124,21 +130,21 @@ async function writeDeprovisionLedger(options: {
     )
     nextGen = Number(gen.rows[0]?.access_generation ?? options.previousGeneration + 1)
 
-    // Supersede open effects for this user
+    // Supersede applied effects for this user.
     await client.query(
       `UPDATE directory_deprovision_effects
           SET status = 'superseded', updated_at = NOW()
         WHERE local_user_id = $1 AND status = 'applied'`,
       [options.localUserId],
-    ).catch(() => {
-      /* table may not exist in unit mocks */
-    })
+    )
 
     const ev = await client.query(
       `INSERT INTO directory_deprovision_events (
          org_id, integration_id, directory_account_id, local_user_id,
-         run_id, triggered_by, event_origin, access_generation_at_apply, status
-       ) VALUES ($1,$2,$3,$4,$5,$6,'sync',$7,'open')
+         run_id, triggered_by, event_origin, link_witness_account_id,
+         link_witness_local_user_id, policy, globally_clear,
+         access_generation_at_apply, status
+       ) VALUES ($1,$2,$3,$4,$5,$6,'sync',$3,$4,$7,$8,$9,'applied')
        RETURNING id`,
       [
         options.orgId,
@@ -147,11 +153,16 @@ async function writeDeprovisionLedger(options: {
         options.localUserId,
         options.runId,
         options.triggeredBy,
+        options.policy,
+        options.globallyClear,
         nextGen,
       ],
-    ).catch(() => ({ rows: [] as Array<{ id: string }> }))
+    )
 
     eventId = (ev.rows[0] as { id?: string } | undefined)?.id ?? null
+    if (!eventId) {
+      throw new Error('directory deprovision event INSERT returned no id')
+    }
 
     for (const effect of options.effects) {
       await client.query(
@@ -168,9 +179,7 @@ async function writeDeprovisionLedger(options: {
           effect.afterActive,
           nextGen,
         ],
-      ).catch(() => {
-        /* unit/mock */
-      })
+      )
     }
   })
 
@@ -199,7 +208,7 @@ export async function supersedeOpenDeprovisionEffects(userId: string): Promise<v
           SET status = 'superseded', updated_at = NOW()
         WHERE local_user_id = $1 AND status = 'applied'`,
       [userId],
-    ).catch(() => {})
+    )
   })
 }
 
@@ -208,6 +217,6 @@ export async function countOpenDeprovisionEffects(userId: string): Promise<numbe
     `SELECT count(*)::int AS n FROM directory_deprovision_effects
       WHERE local_user_id = $1 AND status = 'applied'`,
     [userId],
-  ).catch(() => ({ rows: [{ n: 0 }] }))
+  )
   return r.rows[0]?.n ?? 0
 }

--- a/packages/core-backend/src/directory/deprovision-planner.ts
+++ b/packages/core-backend/src/directory/deprovision-planner.ts
@@ -5,10 +5,7 @@
  * Pending_activation users produce zero offboarding effects (no fake deprovision).
  */
 
-export type DeprovisionEffectType =
-  | 'clear_user_orgs'
-  | 'disable_dingtalk_grant'
-  | 'set_user_inactive'
+export type DeprovisionEffectType = 'membership_changed' | 'grant_changed' | 'user_changed'
 
 export type PlannedEffect = {
   type: DeprovisionEffectType
@@ -21,11 +18,16 @@ export type DirectoryDeprovisionPlanInput = {
   localUserId: string
   activationStatus: string | null | undefined
   isActive: boolean
-  /** Current active user_org memberships for this user. */
-  activeOrgIds: string[]
+  /** Source integration org for this event. */
+  orgId: string
+  /** Whether the source org membership is currently active. */
+  orgMembershipActive: boolean
   /** Whether DingTalk grant is currently enabled. */
   dingtalkGrantEnabled: boolean
-  /** Policy: when true, plan will clear all orgs + grant + is_active. */
+  /**
+   * No other active linked directory account exists anywhere. This gates the
+   * grant/user effects only; the source-org membership is independently scoped.
+   */
   globallyClear: boolean
 }
 
@@ -38,9 +40,7 @@ export type DirectoryDeprovisionPlan = {
 /**
  * Prospective planner: pending users never invent offboarding effects.
  */
-export function planDirectoryDeprovision(
-  input: DirectoryDeprovisionPlanInput,
-): DirectoryDeprovisionPlan {
+export function planDirectoryDeprovision(input: DirectoryDeprovisionPlanInput): DirectoryDeprovisionPlan {
   if (input.activationStatus === 'pending_activation') {
     return {
       localUserId: input.localUserId,
@@ -51,25 +51,28 @@ export function planDirectoryDeprovision(
 
   const effects: PlannedEffect[] = []
 
+  if (input.orgMembershipActive) {
+    effects.push({
+      type: 'membership_changed',
+      orgId: input.orgId,
+      beforeActive: true,
+      afterActive: false,
+    })
+  }
+
   if (input.globallyClear) {
-    for (const orgId of input.activeOrgIds) {
-      effects.push({
-        type: 'clear_user_orgs',
-        orgId,
-        beforeActive: true,
-        afterActive: false,
-      })
-    }
     if (input.dingtalkGrantEnabled) {
       effects.push({
-        type: 'disable_dingtalk_grant',
+        type: 'grant_changed',
+        orgId: null,
         beforeActive: true,
         afterActive: false,
       })
     }
     if (input.isActive) {
       effects.push({
-        type: 'set_user_inactive',
+        type: 'user_changed',
+        orgId: null,
         beforeActive: true,
         afterActive: false,
       })

--- a/packages/core-backend/src/routes/admin-directory.ts
+++ b/packages/core-backend/src/routes/admin-directory.ts
@@ -1262,11 +1262,18 @@ export function adminDirectoryRouter(): Router {
     const adminUserId = await ensurePlatformAdmin(req, res)
     if (!adminUserId) return
     try {
-      const data = await previewDeprovisionForUser(req.params.userId)
+      const integrationId = typeof req.query.integrationId === 'string'
+        ? req.query.integrationId.trim()
+        : ''
+      if (!integrationId) {
+        jsonError(res, 400, 'INTEGRATION_ID_REQUIRED', 'integrationId is required')
+        return
+      }
+      const data = await previewDeprovisionForUser(req.params.userId, integrationId)
       jsonOk(res, data)
     } catch (error) {
       const code = (error as { code?: string })?.code
-      if (code === 'USER_NOT_FOUND') {
+      if (code === 'USER_NOT_FOUND' || code === 'INTEGRATION_NOT_FOUND') {
         jsonError(res, 404, code, (error as Error).message)
         return
       }

--- a/packages/core-backend/tests/integration/directory-deprovision-grant-table.db.test.ts
+++ b/packages/core-backend/tests/integration/directory-deprovision-grant-table.db.test.ts
@@ -80,8 +80,10 @@ async function seedEvent(
   const ev = await query<{ id: string }>(
     `INSERT INTO directory_deprovision_events
        (org_id, integration_id, directory_account_id, local_user_id, run_id, triggered_by,
-        event_origin, access_generation_at_apply, status)
-     VALUES ($1, $2, $3, $4, $5, 'test', 'sync', $6, 'open')
+        event_origin, link_witness_account_id, link_witness_local_user_id,
+        policy, globally_clear, access_generation_at_apply, status)
+     VALUES ($1, $2, $3, $4, $5, 'test', 'sync', $3, $4,
+             'mark_inactive', TRUE, $6, 'applied')
      RETURNING id::text AS id`,
     [ORG, seeded.integrationId, seeded.accountId, USER, seeded.runId, generation],
   )
@@ -149,7 +151,7 @@ describeIfDatabase('DingTalk grant/membership writes target the real tables (rea
     )
     await query(`INSERT INTO user_orgs (user_id, org_id, is_active) VALUES ($1, $2, FALSE)`, [USER, ORG])
     const seeded = await seedDirectory({ sourceActive: true })
-    const eventId = await seedEvent(seeded, [{ type: 'clear_user_orgs', orgId: ORG }], 3)
+    const eventId = await seedEvent(seeded, [{ type: 'membership_changed', orgId: ORG }], 3)
 
     const result = await restoreDeprovisionEvent({
       eventId, mode: 'rehire', adminUserId: 'admin-test',
@@ -179,7 +181,7 @@ describeIfDatabase('DingTalk grant/membership writes target the real tables (rea
       `INSERT INTO user_external_auth_grants (provider, local_user_id, enabled, granted_by)
        VALUES ('dingtalk', $1, FALSE, 'system:directory-deprovision')`, [USER])
     const seeded = await seedDirectory({ sourceActive: true })
-    const eventId = await seedEvent(seeded, [{ type: 'disable_dingtalk_grant', orgId: null }], 3)
+    const eventId = await seedEvent(seeded, [{ type: 'grant_changed', orgId: null }], 3)
 
     await restoreDeprovisionEvent({ eventId, mode: 'rehire', adminUserId: 'admin-test' })
 
@@ -196,7 +198,7 @@ describeIfDatabase('DingTalk grant/membership writes target the real tables (rea
     )
     // Deliberately NO user_orgs row — effect says membership was cleared, but the row is gone.
     const seeded = await seedDirectory({ sourceActive: true })
-    const eventId = await seedEvent(seeded, [{ type: 'clear_user_orgs', orgId: ORG }], 3)
+    const eventId = await seedEvent(seeded, [{ type: 'membership_changed', orgId: ORG }], 3)
 
     await expect(
       restoreDeprovisionEvent({ eventId, mode: 'rehire', adminUserId: 'admin-test' }),
@@ -221,7 +223,7 @@ describeIfDatabase('DingTalk grant/membership writes target the real tables (rea
       `INSERT INTO user_external_auth_grants (provider, local_user_id, enabled, granted_by)
        VALUES ('dingtalk', $1, TRUE, 'someone-re-granted-it')`, [USER])
     const seeded = await seedDirectory({ sourceActive: true })
-    const eventId = await seedEvent(seeded, [{ type: 'disable_dingtalk_grant', orgId: null }], 3)
+    const eventId = await seedEvent(seeded, [{ type: 'grant_changed', orgId: null }], 3)
 
     await expect(
       restoreDeprovisionEvent({ eventId, mode: 'rehire', adminUserId: 'admin-test' }),

--- a/packages/core-backend/tests/integration/directory-deprovision-ledger-schema.db.test.ts
+++ b/packages/core-backend/tests/integration/directory-deprovision-ledger-schema.db.test.ts
@@ -1,0 +1,378 @@
+/**
+ * D3 Rev 4.3 ledger schema proof.
+ *
+ * Runs the weak scaffold and hardening migration in an isolated schema. The
+ * suite proves upgrade/replay/down behavior as well as the account, run, link,
+ * parent-effect, and immutability invariants against real Postgres.
+ */
+import { randomUUID } from 'node:crypto'
+
+import { Kysely, PostgresDialect, sql } from 'kysely'
+import { Pool } from 'pg'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { up as weakLedgerUp } from '../../src/db/migrations/zzzz20260724170000_directory_deprovision_ledger_and_generation'
+import {
+  down as hardenedLedgerDown,
+  up as hardenedLedgerUp,
+} from '../../src/db/migrations/zzzz20260728100000_harden_directory_deprovision_ledger'
+
+const dbUrl = process.env.DATABASE_URL
+const describeDb = dbUrl ? describe : describe.skip
+
+describeDb('directory deprovision ledger hardening (real DB, isolated schema)', () => {
+  let adminPool: Pool
+  let schema: string
+  let testPool: Pool
+  let db: Kysely<unknown>
+
+  beforeEach(async () => {
+    adminPool = new Pool({ connectionString: dbUrl })
+    schema = `d3ledger_${randomUUID().replace(/-/g, '')}`
+    await adminPool.query(`CREATE SCHEMA "${schema}"`)
+    testPool = new Pool({
+      connectionString: dbUrl,
+      options: `-c search_path=${schema}`,
+    })
+    db = new Kysely<unknown>({
+      dialect: new PostgresDialect({ pool: testPool }),
+    })
+
+    await sql`CREATE EXTENSION IF NOT EXISTS pgcrypto`.execute(db)
+    await sql`
+      CREATE TABLE users (
+        id text PRIMARY KEY,
+        is_active boolean NOT NULL DEFAULT TRUE,
+        updated_at timestamptz NOT NULL DEFAULT NOW()
+      )
+    `.execute(db)
+    await sql`
+      CREATE TABLE directory_integrations (
+        id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+        org_id text NOT NULL,
+        provider text NOT NULL DEFAULT 'dingtalk',
+        CONSTRAINT uq_directory_integrations_id_org UNIQUE (id, org_id)
+      )
+    `.execute(db)
+    await sql`
+      CREATE TABLE directory_accounts (
+        id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+        integration_id uuid NOT NULL REFERENCES directory_integrations(id),
+        provider text NOT NULL DEFAULT 'dingtalk',
+        is_active boolean NOT NULL DEFAULT TRUE
+      )
+    `.execute(db)
+    await sql`
+      CREATE TABLE directory_account_links (
+        directory_account_id uuid NOT NULL REFERENCES directory_accounts(id),
+        local_user_id text REFERENCES users(id),
+        link_status text NOT NULL
+      )
+    `.execute(db)
+    await sql`
+      CREATE TABLE directory_sync_runs (
+        id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+        integration_id uuid NOT NULL REFERENCES directory_integrations(id),
+        status text NOT NULL DEFAULT 'success'
+      )
+    `.execute(db)
+    await weakLedgerUp(db)
+  })
+
+  afterEach(async () => {
+    await db.destroy()
+    await adminPool.query(`DROP SCHEMA IF EXISTS "${schema}" CASCADE`)
+    await adminPool.end()
+  })
+
+  async function columnDataType(table: string, column: string): Promise<string | null> {
+    const result = await sql<{ data_type: string }>`
+      SELECT data_type
+        FROM information_schema.columns
+       WHERE table_schema = current_schema()
+         AND table_name = ${table}
+         AND column_name = ${column}
+    `.execute(db)
+    return result.rows[0]?.data_type ?? null
+  }
+
+  async function columnExists(table: string, column: string): Promise<boolean> {
+    return (await columnDataType(table, column)) !== null
+  }
+
+  async function constraintDefinition(table: string, name: string): Promise<string | null> {
+    const result = await sql<{ definition: string }>`
+      SELECT pg_get_constraintdef(constraint_row.oid) AS definition
+        FROM pg_constraint constraint_row
+        JOIN pg_class table_rel ON table_rel.oid = constraint_row.conrelid
+        JOIN pg_namespace namespace ON namespace.oid = table_rel.relnamespace
+       WHERE namespace.nspname = current_schema()
+         AND table_rel.relname = ${table}
+         AND constraint_row.conname = ${name}
+    `.execute(db)
+    return result.rows[0]?.definition ?? null
+  }
+
+  async function seedAuthority() {
+    const userId = `user-${randomUUID()}`
+    const orgId = `org-${randomUUID()}`
+    await sql`INSERT INTO users (id) VALUES (${userId})`.execute(db)
+    const integration = await sql<{ id: string }>`
+      INSERT INTO directory_integrations (org_id) VALUES (${orgId}) RETURNING id
+    `.execute(db)
+    const integrationId = integration.rows[0]!.id
+    const account = await sql<{ id: string }>`
+      INSERT INTO directory_accounts (integration_id) VALUES (${integrationId}) RETURNING id
+    `.execute(db)
+    const accountId = account.rows[0]!.id
+    await sql`
+      INSERT INTO directory_account_links (directory_account_id, local_user_id, link_status)
+      VALUES (${accountId}, ${userId}, 'linked')
+    `.execute(db)
+    const run = await sql<{ id: string }>`
+      INSERT INTO directory_sync_runs (integration_id) VALUES (${integrationId}) RETURNING id
+    `.execute(db)
+    return {
+      userId,
+      orgId,
+      integrationId,
+      accountId,
+      runId: run.rows[0]!.id,
+    }
+  }
+
+  async function insertValidEvent(authority: Awaited<ReturnType<typeof seedAuthority>>) {
+    const event = await sql<{ id: string }>`
+      INSERT INTO directory_deprovision_events (
+        org_id, integration_id, directory_account_id, local_user_id, run_id,
+        triggered_by, event_origin, link_witness_account_id,
+        link_witness_local_user_id, policy, globally_clear,
+        access_generation_at_apply, status
+      ) VALUES (
+        ${authority.orgId}, ${authority.integrationId}, ${authority.accountId},
+        ${authority.userId}, ${authority.runId}, 'test', 'sync',
+        ${authority.accountId}, ${authority.userId}, 'mark_inactive', TRUE, 1, 'applied'
+      )
+      RETURNING id
+    `.execute(db)
+    return event.rows[0]!.id
+  }
+
+  it('upgrades the weak scaffold to the exact typed FK/check vocabulary', async () => {
+    await hardenedLedgerUp(db)
+
+    expect(await columnDataType('directory_deprovision_events', 'integration_id')).toBe('uuid')
+    expect(await columnDataType('directory_deprovision_events', 'directory_account_id')).toBe('uuid')
+    expect(await columnDataType('directory_deprovision_events', 'run_id')).toBe('uuid')
+    expect(await columnExists('directory_deprovision_events', 'link_witness_account_id')).toBe(true)
+    expect(await columnExists('directory_deprovision_events', 'globally_clear')).toBe(true)
+
+    expect(await constraintDefinition('directory_deprovision_events', 'ddev_account_integration_fk')).toContain(
+      'FOREIGN KEY (directory_account_id, integration_id)',
+    )
+    expect(await constraintDefinition('directory_deprovision_events', 'ddev_run_integration_fk')).toContain(
+      'FOREIGN KEY (run_id, integration_id)',
+    )
+    expect(await constraintDefinition('directory_deprovision_effects', 'ddef_event_effect_type_key')).toContain(
+      'UNIQUE (event_id, effect_type)',
+    )
+  })
+
+  it('accepts a valid chain, replays with evidence, and refuses down before DDL', async () => {
+    await hardenedLedgerUp(db)
+    const authority = await seedAuthority()
+    const eventId = await insertValidEvent(authority)
+
+    for (const effect of [
+      { type: 'membership_changed', orgId: authority.orgId },
+      { type: 'grant_changed', orgId: null },
+      { type: 'user_changed', orgId: null },
+    ]) {
+      await sql`
+        INSERT INTO directory_deprovision_effects (
+          event_id, local_user_id, org_id, effect_type, before_active,
+          after_active, access_generation_at_apply, status
+        ) VALUES (
+          ${eventId}, ${authority.userId}, ${effect.orgId}, ${effect.type},
+          TRUE, FALSE, 1, 'applied'
+        )
+      `.execute(db)
+    }
+
+    await hardenedLedgerUp(db)
+    const counts = await sql<{ events: number; effects: number }>`
+      SELECT
+        (SELECT count(*)::int FROM directory_deprovision_events) AS events,
+        (SELECT count(*)::int FROM directory_deprovision_effects) AS effects
+    `.execute(db)
+    expect(counts.rows[0]).toEqual({ events: 1, effects: 3 })
+
+    await expect(hardenedLedgerDown(db)).rejects.toThrow(/refused before DDL/)
+    expect(await columnDataType('directory_deprovision_events', 'integration_id')).toBe('uuid')
+    expect(await constraintDefinition('directory_deprovision_events', 'ddev_account_integration_fk')).not.toBeNull()
+  })
+
+  it('rejects malformed account/link/run/effect chains and immutable witness changes', async () => {
+    await hardenedLedgerUp(db)
+    const a = await seedAuthority()
+    const b = await seedAuthority()
+
+    await expect(
+      sql`
+      INSERT INTO directory_deprovision_events (
+        org_id, integration_id, directory_account_id, local_user_id, run_id,
+        triggered_by, event_origin, link_witness_account_id,
+        link_witness_local_user_id, policy, globally_clear,
+        access_generation_at_apply, status
+      ) VALUES (
+        ${a.orgId}, ${a.integrationId}, ${a.accountId}, ${b.userId}, ${a.runId},
+        'test', 'sync', ${a.accountId}, ${b.userId}, 'mark_inactive', TRUE, 1, 'applied'
+      )
+    `.execute(db),
+    ).rejects.toThrow(/requires a linked account\/user/)
+
+    await expect(
+      sql`
+      INSERT INTO directory_deprovision_events (
+        org_id, integration_id, directory_account_id, local_user_id, run_id,
+        triggered_by, event_origin, link_witness_account_id,
+        link_witness_local_user_id, policy, globally_clear,
+        access_generation_at_apply, status
+      ) VALUES (
+        ${a.orgId}, ${a.integrationId}, ${a.accountId}, ${a.userId}, ${b.runId},
+        'test', 'sync', ${a.accountId}, ${a.userId}, 'mark_inactive', TRUE, 1, 'applied'
+      )
+    `.execute(db),
+    ).rejects.toThrow()
+
+    const eventId = await insertValidEvent(a)
+    await expect(
+      sql`
+      INSERT INTO directory_deprovision_effects (
+        event_id, local_user_id, org_id, effect_type, before_active,
+        after_active, access_generation_at_apply, status
+      ) VALUES (
+        ${eventId}, ${a.userId}, ${b.orgId}, 'membership_changed',
+        TRUE, FALSE, 1, 'applied'
+      )
+    `.execute(db),
+    ).rejects.toThrow(/membership effect org/)
+
+    await expect(
+      sql`
+      INSERT INTO directory_deprovision_effects (
+        event_id, local_user_id, org_id, effect_type, before_active,
+        after_active, access_generation_at_apply, status
+      ) VALUES (
+        ${eventId}, ${b.userId}, NULL, 'grant_changed',
+        TRUE, FALSE, 1, 'applied'
+      )
+    `.execute(db),
+    ).rejects.toThrow(/effect user/)
+
+    await sql`
+      INSERT INTO directory_deprovision_effects (
+        event_id, local_user_id, org_id, effect_type, before_active,
+        after_active, access_generation_at_apply, status
+      ) VALUES (
+        ${eventId}, ${a.userId}, ${a.orgId}, 'membership_changed',
+        TRUE, FALSE, 1, 'applied'
+      )
+    `.execute(db)
+    await expect(
+      sql`
+      INSERT INTO directory_deprovision_effects (
+        event_id, local_user_id, org_id, effect_type, before_active,
+        after_active, access_generation_at_apply, status
+      ) VALUES (
+        ${eventId}, ${a.userId}, ${a.orgId}, 'membership_changed',
+        TRUE, FALSE, 1, 'applied'
+      )
+    `.execute(db),
+    ).rejects.toThrow(/ddef_event_effect_type_key/)
+
+    await expect(
+      sql`
+      UPDATE directory_deprovision_events
+         SET link_witness_local_user_id = ${b.userId}
+       WHERE id = ${eventId}
+    `.execute(db),
+    ).rejects.toThrow(/identity fields are immutable/)
+  })
+
+  it('keeps historical witness stable while the live link is unbound and rebound', async () => {
+    await hardenedLedgerUp(db)
+    const authority = await seedAuthority()
+    const eventId = await insertValidEvent(authority)
+
+    await sql`
+      UPDATE directory_account_links
+         SET local_user_id = NULL, link_status = 'unlinked'
+       WHERE directory_account_id = ${authority.accountId}
+    `.execute(db)
+    await sql`
+      UPDATE directory_account_links
+         SET local_user_id = ${authority.userId}, link_status = 'linked'
+       WHERE directory_account_id = ${authority.accountId}
+    `.execute(db)
+
+    const event = await sql<{
+      directory_account_id: string
+      local_user_id: string
+      link_witness_account_id: string
+      link_witness_local_user_id: string
+    }>`
+      SELECT directory_account_id, local_user_id,
+             link_witness_account_id, link_witness_local_user_id
+        FROM directory_deprovision_events
+       WHERE id = ${eventId}
+    `.execute(db)
+    expect(event.rows[0]).toEqual({
+      directory_account_id: authority.accountId,
+      local_user_id: authority.userId,
+      link_witness_account_id: authority.accountId,
+      link_witness_local_user_id: authority.userId,
+    })
+  })
+
+  it('fails before DDL when the weak scaffold already contains unmodelled evidence', async () => {
+    await sql`
+      INSERT INTO directory_deprovision_events (
+        org_id, integration_id, directory_account_id, local_user_id,
+        triggered_by, event_origin, access_generation_at_apply, status
+      ) VALUES ('org-old', 'not-a-uuid', 'not-a-uuid', 'user-old',
+                'legacy', 'sync', 0, 'open')
+    `.execute(db)
+
+    await expect(hardenedLedgerUp(db)).rejects.toThrow(/aborted before DDL/)
+    expect(await columnDataType('directory_deprovision_events', 'integration_id')).toBe('text')
+    expect(await columnExists('directory_deprovision_events', 'policy')).toBe(false)
+    expect(await constraintDefinition('directory_accounts', 'uq_directory_accounts_id_integration')).toBeNull()
+  })
+
+  it('fails closed on a same-named prerequisite UNIQUE with the wrong column shape', async () => {
+    await sql`
+      ALTER TABLE directory_accounts
+      ADD CONSTRAINT uq_directory_accounts_id_integration UNIQUE (id, provider)
+    `.execute(db)
+
+    await expect(hardenedLedgerUp(db)).rejects.toThrow(/prerequisite drift/)
+    expect(await columnDataType('directory_deprovision_events', 'integration_id')).toBe('text')
+    expect(await columnExists('directory_deprovision_events', 'policy')).toBe(false)
+  })
+
+  it('down restores the weak shape and removes only parent UNIQUEs it owns', async () => {
+    await sql`
+      ALTER TABLE directory_accounts
+      ADD CONSTRAINT preexisting_accounts_id_integration UNIQUE (id, integration_id)
+    `.execute(db)
+    await hardenedLedgerUp(db)
+    await hardenedLedgerDown(db)
+
+    expect(await columnDataType('directory_deprovision_events', 'integration_id')).toBe('text')
+    expect(await columnExists('directory_deprovision_events', 'policy')).toBe(false)
+    expect(await constraintDefinition('directory_accounts', 'preexisting_accounts_id_integration')).not.toBeNull()
+    expect(await constraintDefinition('directory_sync_runs', 'uq_directory_sync_runs_id_integration')).toBeNull()
+    expect(await constraintDefinition('directory_integrations', 'uq_directory_integrations_id_org')).not.toBeNull()
+  })
+})

--- a/packages/core-backend/tests/integration/directory-deprovision-ledger-schema.db.test.ts
+++ b/packages/core-backend/tests/integration/directory-deprovision-ledger-schema.db.test.ts
@@ -298,6 +298,39 @@ describeDb('directory deprovision ledger hardening (real DB, isolated schema)', 
        WHERE id = ${eventId}
     `.execute(db),
     ).rejects.toThrow(/identity fields are immutable/)
+
+    // Adversarial review of #4646 (P2): the witness probe above was the ONLY immutability
+    // assertion — the provenance columns and the entire effects branch of the trigger could be
+    // neutered with every test green. One probe per trigger arm, so each arm is load-bearing.
+    await expect(
+      sql`UPDATE directory_deprovision_events SET policy = 'manual_review' WHERE id = ${eventId}`.execute(db),
+    ).rejects.toThrow(/identity fields are immutable/)
+    await expect(
+      sql`UPDATE directory_deprovision_events SET globally_clear = FALSE WHERE id = ${eventId}`.execute(db),
+    ).rejects.toThrow(/identity fields are immutable/)
+    await expect(
+      sql`UPDATE directory_deprovision_events SET triggered_by = 'tampered' WHERE id = ${eventId}`.execute(db),
+    ).rejects.toThrow(/identity fields are immutable/)
+    await expect(
+      sql`UPDATE directory_deprovision_effects SET before_active = FALSE WHERE event_id = ${eventId}`.execute(db),
+    ).rejects.toThrow(/identity fields are immutable/)
+    await expect(
+      sql`UPDATE directory_deprovision_effects SET access_generation_at_apply = 99 WHERE event_id = ${eventId}`.execute(db),
+    ).rejects.toThrow(/identity fields are immutable/)
+
+    // Positive control for the family above: a resolve-column UPDATE on the same rows must
+    // SUCCEED — proving the rejections come from the guarded columns, not from a trigger that
+    // rejects every UPDATE (which would also freeze supersede/restore forever).
+    await sql`
+      UPDATE directory_deprovision_events
+         SET status = 'superseded', resolved_by = 'test', updated_at = NOW()
+       WHERE id = ${eventId}
+    `.execute(db)
+    await sql`
+      UPDATE directory_deprovision_effects
+         SET status = 'superseded', updated_at = NOW()
+       WHERE event_id = ${eventId}
+    `.execute(db)
   })
 
   it('keeps historical witness stable while the live link is unbound and rebound', async () => {

--- a/packages/core-backend/tests/integration/directory-deprovision-ledger-schema.db.test.ts
+++ b/packages/core-backend/tests/integration/directory-deprovision-ledger-schema.db.test.ts
@@ -318,6 +318,32 @@ describeDb('directory deprovision ledger hardening (real DB, isolated schema)', 
       sql`UPDATE directory_deprovision_effects SET access_generation_at_apply = 99 WHERE event_id = ${eventId}`.execute(db),
     ).rejects.toThrow(/identity fields are immutable/)
 
+    // Delta re-review (P3-D1): the six columns below were individually neuterable with the suite
+    // still green — the net had holes even though the trigger was correct. The property under
+    // test is "the DB refuses the tamper", whichever mechanism answers (immutability trigger, or
+    // a CHECK that independently rejects the same write), so the assertions accept either
+    // refusal message. `effects.after_active` (what the drift gate compares against) and
+    // `effects.effect_type` (which selects the reversal branch) are the two that most invited
+    // silent tampering.
+    await expect(
+      sql`UPDATE directory_deprovision_events SET access_generation_at_apply = 41 WHERE id = ${eventId}`.execute(db),
+    ).rejects.toThrow(/immutable|violates/)
+    await expect(
+      sql`UPDATE directory_deprovision_events SET event_origin = 'admin_manual' WHERE id = ${eventId}`.execute(db),
+    ).rejects.toThrow(/immutable|violates/)
+    await expect(
+      sql`UPDATE directory_deprovision_events SET run_id = NULL WHERE id = ${eventId}`.execute(db),
+    ).rejects.toThrow(/immutable|violates/)
+    await expect(
+      sql`UPDATE directory_deprovision_effects SET after_active = TRUE WHERE event_id = ${eventId}`.execute(db),
+    ).rejects.toThrow(/immutable|violates/)
+    await expect(
+      sql`UPDATE directory_deprovision_effects SET effect_type = 'grant_changed' WHERE event_id = ${eventId}`.execute(db),
+    ).rejects.toThrow(/immutable|violates/)
+    await expect(
+      sql`UPDATE directory_deprovision_effects SET org_id = NULL WHERE event_id = ${eventId}`.execute(db),
+    ).rejects.toThrow(/immutable|violates/)
+
     // Positive control for the family above: a resolve-column UPDATE on the same rows must
     // SUCCEED — proving the rejections come from the guarded columns, not from a trigger that
     // rejects every UPDATE (which would also freeze supersede/restore forever).

--- a/packages/core-backend/tests/unit/deprovision-planner.test.ts
+++ b/packages/core-backend/tests/unit/deprovision-planner.test.ts
@@ -7,7 +7,8 @@ describe('planDirectoryDeprovision (D2 prospective)', () => {
       localUserId: 'u1',
       activationStatus: 'pending_activation',
       isActive: false,
-      activeOrgIds: ['org-1'],
+      orgId: 'org-1',
+      orgMembershipActive: false,
       dingtalkGrantEnabled: true,
       globallyClear: true,
     })
@@ -15,23 +16,42 @@ describe('planDirectoryDeprovision (D2 prospective)', () => {
     expect(plan.skipReason).toBe('pending_activation_no_offboarding_effects')
   })
 
-  it('plans org clear + grant + inactive for activated globally-clear', () => {
+  it('plans one source-org membership + grant + user effect for globally-clear', () => {
     const plan = planDirectoryDeprovision({
       localUserId: 'u2',
       activationStatus: 'activated',
       isActive: true,
-      activeOrgIds: ['org-a', 'org-b'],
+      orgId: 'org-a',
+      orgMembershipActive: true,
       dingtalkGrantEnabled: true,
       globallyClear: true,
     })
     expect(plan.skipReason).toBeNull()
-    expect(plan.effects.map((e) => e.type).sort()).toEqual([
-      'clear_user_orgs',
-      'clear_user_orgs',
-      'disable_dingtalk_grant',
-      'set_user_inactive',
-    ].sort())
+    expect(plan.effects.map((e) => e.type).sort()).toEqual(
+      ['membership_changed', 'grant_changed', 'user_changed'].sort(),
+    )
+    expect(plan.effects.find((e) => e.type === 'membership_changed')?.orgId).toBe('org-a')
     expect(plan.effects.every((e) => e.beforeActive === true && e.afterActive === false)).toBe(true)
+  })
+
+  it('keeps the source-org membership effect while another org preserves global access', () => {
+    const plan = planDirectoryDeprovision({
+      localUserId: 'u-cross-org',
+      activationStatus: 'activated',
+      isActive: true,
+      orgId: 'org-a',
+      orgMembershipActive: true,
+      dingtalkGrantEnabled: true,
+      globallyClear: false,
+    })
+    expect(plan.effects).toEqual([
+      {
+        type: 'membership_changed',
+        orgId: 'org-a',
+        beforeActive: true,
+        afterActive: false,
+      },
+    ])
   })
 
   it('zero-effect when already inactive with no orgs/grant', () => {
@@ -39,7 +59,8 @@ describe('planDirectoryDeprovision (D2 prospective)', () => {
       localUserId: 'u3',
       activationStatus: 'activated',
       isActive: false,
-      activeOrgIds: [],
+      orgId: 'org-a',
+      orgMembershipActive: false,
       dingtalkGrantEnabled: false,
       globallyClear: true,
     })

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -227,6 +227,11 @@ export default defineConfig({
       // wired into the approval real-DB step (both points asserted by
       // scripts/ops/directory-grant-table-ci-wiring.test.mjs).
       'tests/integration/directory-deprovision-grant-table.db.test.ts',
+      // D3 Rev 4.3 evidence-ledger migration: isolated-schema upgrade, replay with evidence,
+      // fail-before-DDL weak-data guard, FK/trigger invariants, and ownership-safe down.
+      // DATABASE_URL-gated; excluded here and wired as a whole file into the approval real-DB
+      // step, with both points pinned by directory-deprovision-ledger-ci-wiring.test.mjs.
+      'tests/integration/directory-deprovision-ledger-schema.db.test.ts',
       // DingTalk multi-corp external-key isolation: corp-scoped uniqueness, upgrade migration,
       // real-sync coexistence, and same-corp/cross-corp identity matching controls.
       // DATABASE_URL-gated; excluded here so the no-DB job cannot skip-green it, and wired as a

--- a/plugins/plugin-integration-core/lib/sealed-export/vectors/s6a-package-provenance-pins.json
+++ b/plugins/plugin-integration-core/lib/sealed-export/vectors/s6a-package-provenance-pins.json
@@ -86,6 +86,6 @@
     "s6aAcceptancePs51Test": "835c7c6ce943d82e0378a40a27c7fd1e8b79b526faa8ca4c8066e4231a4bfb0f",
     "s6aProductRuntimeTest": "de978adafa8b89772cefa921c2051f434bf346bf5c2978bef3424ee70f51ba3f",
     "multitableOnpremPackageBuild": "463c7d73c6c7f2d1b6cdf0820d7a06974a9c463dd5e98bbbaf1c996e1dc4ed99",
-    "pluginTestsWorkflow": "f4d03ea72e9006b5f4ae06e163eec65df86c4b49bf2330848bdf2010ecd0f893"
+    "pluginTestsWorkflow": "55ad6fb931e30d6104590e741fb5823f919aea2a1f02e8b2c9830859111dfd69"
   }
 }

--- a/scripts/ops/directory-deprovision-ledger-ci-wiring.test.mjs
+++ b/scripts/ops/directory-deprovision-ledger-ci-wiring.test.mjs
@@ -1,0 +1,37 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { existsSync, readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { REAL_DB_STEP_IDS, isSuiteWiredInRealDbStep, realDbStepWholeFileArgs } from './ci-realdb-step-contract.mjs'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const repoRoot = join(__dirname, '..', '..')
+const FILE = 'tests/integration/directory-deprovision-ledger-schema.db.test.ts'
+const STEP_ID = REAL_DB_STEP_IDS.approval
+
+test('vitest.config.ts excludes the D3 ledger suite from the no-DB job', () => {
+  const cfg = readFileSync(join(repoRoot, 'packages/core-backend/vitest.config.ts'), 'utf8')
+  assert.ok(cfg.includes(`'${FILE}'`), `vitest.config.ts must exclude ${FILE}`)
+})
+
+test('plugin-tests.yml runs the D3 ledger suite as a whole file in the approval real-DB step', () => {
+  const workflow = readFileSync(join(repoRoot, '.github/workflows/plugin-tests.yml'), 'utf8')
+  assert.ok(
+    isSuiteWiredInRealDbStep(workflow, STEP_ID, FILE),
+    `plugin-tests.yml real-DB step id "${STEP_ID}" must run ${FILE} as a whole-file argument`,
+  )
+  assert.equal(
+    realDbStepWholeFileArgs(workflow, REAL_DB_STEP_IDS.multitable).includes(FILE),
+    false,
+    `${FILE} must not be wired into the multitable real-DB step`,
+  )
+})
+
+test('the D3 ledger suite file exists on disk', () => {
+  assert.ok(
+    existsSync(join(repoRoot, 'packages/core-backend', FILE)),
+    `wired suite packages/core-backend/${FILE} must exist on disk`,
+  )
+})


### PR DESCRIPTION
## What
- harden the existing empty deprovision ledger scaffold to the Rev 4.3 typed/FK-backed evidence model
- correct the org-membership versus globally-clear planner scope and align D7 vocabulary
- add replay/down fail-closed behavior, ownership-safe prerequisite UNIQUE handling, and CI-wired real-DB proof

## Safety
- all lifecycle flags remain default OFF
- a non-empty weak/partial ledger aborts before DDL
- a hardened ledger replays with evidence; down refuses when evidence exists
- this PR does not connect the production sync writer (D4 follows separately)

## Verification
- core-backend tsc --noEmit
- web vue-tsc --noEmit
- unit: 10/10
- web D7: 3/3
- real DB: 13/13
- CI wiring contracts: 6/6
- mutation: removing the live-link trigger makes the account/user mismatch gold test fail

## Process
Draft and unarmed. Supersedes only the D3 schema portion of held #4579; no auto-merge requested.