### PR TITLE
feat(directory): D4 atomic deprovision writer and evidence

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -1100,6 +1100,7 @@ jobs:
             tests/integration/directory-deprovision-grant-table.db.test.ts \
             tests/integration/directory-deprovision-ledger-schema.db.test.ts \
             tests/integration/directory-deprovision-writer-ledger.db.test.ts \
+            tests/integration/directory-deprovision-race-supersede.db.test.ts \
             tests/integration/directory-sync-run-lease.db.test.ts \
             tests/integration/directory-tenant-change-immutable.db.test.ts \
             tests/integration/directory-sync-orchestration.db.test.ts \

--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -101,6 +101,7 @@ jobs:
           node --test scripts/ops/dingtalk-closeout-env-contract.test.mjs
           node --test scripts/ops/directory-grant-table-ci-wiring.test.mjs
           node --test scripts/ops/directory-deprovision-ledger-ci-wiring.test.mjs
+          node --test scripts/ops/directory-deprovision-writer-ci-wiring.test.mjs
 
       - name: Run DingTalk OAuth-stability metrics-only contract test (DT-CLOSE-01B)
         run: |
@@ -1098,6 +1099,7 @@ jobs:
             tests/integration/directory-deprovision-selection.db.test.ts \
             tests/integration/directory-deprovision-grant-table.db.test.ts \
             tests/integration/directory-deprovision-ledger-schema.db.test.ts \
+            tests/integration/directory-deprovision-writer-ledger.db.test.ts \
             tests/integration/directory-sync-run-lease.db.test.ts \
             tests/integration/directory-tenant-change-immutable.db.test.ts \
             tests/integration/directory-sync-orchestration.db.test.ts \

--- a/docs/development/dingtalk-deprovision-reactivation-and-evidence-chain-design-20260723.md
+++ b/docs/development/dingtalk-deprovision-reactivation-and-evidence-chain-design-20260723.md
@@ -150,7 +150,9 @@ Apply 在 directory transition 之后调用时，prospective = 本轮 `RETURNING
 
 **Positive control test:** 将消失的 linked 账号 → Preview `candidateCount ≥ 1`；去掉 prospective 排除 → 变 0 且测试红。
 
-Writer：`applyDirectoryDeprovisionPlan` 仅在 `enabled=true` 时写访问图 + ledger；`enabled=false` 零写。
+Writer：`applyDirectoryDeprovisionCandidate(client, ...)` 只接受调用方现有的 sync 事务
+client；`enabled=true` 时在该事务内完成 user row lock、写时重读、访问图、
+generation 与 ledger，`enabled=false` 零写且不自开第二事务。
 
 ---
 

--- a/packages/core-backend/src/directory/deprovision-evidence-api.ts
+++ b/packages/core-backend/src/directory/deprovision-evidence-api.ts
@@ -3,7 +3,10 @@
  */
 
 import { query, transaction } from '../db/pg'
-import { planDirectoryDeprovision } from './deprovision-planner'
+import {
+  planDirectoryDeprovision,
+  type DirectoryDeprovisionPolicy,
+} from './deprovision-planner'
 import {
   evaluateDeprovisionRestoreEligibility,
   type RestoreEffectView,
@@ -43,8 +46,10 @@ export async function previewDeprovisionForUser(localUserId: string, integration
   }
   const u = user.rows[0]
 
-  const integration = await query<{ org_id: string }>(
-    `SELECT org_id FROM directory_integrations WHERE id = $1::uuid`,
+  const integration = await query<{ org_id: string; default_deprovision_policy: string }>(
+    `SELECT org_id, default_deprovision_policy
+       FROM directory_integrations
+      WHERE id = $1::uuid`,
     [integrationId],
   )
   if (!integration.rows[0]) {
@@ -87,8 +92,17 @@ export async function previewDeprovisionForUser(localUserId: string, integration
     [localUserId, integrationId],
   )
 
+  const storedPolicy = integration.rows[0].default_deprovision_policy
+  const policy: DirectoryDeprovisionPolicy = [
+    'manual_review',
+    'disable_grant_only',
+    'mark_inactive',
+  ].includes(storedPolicy)
+    ? (storedPolicy as DirectoryDeprovisionPolicy)
+    : 'manual_review'
   const plan = planDirectoryDeprovision({
     localUserId,
+    policy,
     activationStatus: u.activation_status,
     isActive: u.is_active,
     orgId,

--- a/packages/core-backend/src/directory/deprovision-ledger.ts
+++ b/packages/core-backend/src/directory/deprovision-ledger.ts
@@ -244,7 +244,6 @@ export async function applyDirectoryDeprovisionCandidate(
   }
 
   const membershipChanged = hasEffect(plan.effects, 'membership_changed')
-  const grantChanged = hasEffect(plan.effects, 'grant_changed')
   const userChanged = hasEffect(plan.effects, 'user_changed')
 
   const generationResult = userChanged
@@ -305,7 +304,13 @@ export async function applyDirectoryDeprovisionCandidate(
     }
   }
 
-  if (grantChanged) {
+  // The bookkeeping upsert is deliberately UNCONDITIONAL for a globally-clear candidate, not
+  // gated on the grant effect: since OPS-01 the departed person's row shape has been "an
+  // explicit disabled grant", whether or not a grant ever existed (the orchestration suite pins
+  // exactly this). Writing a fresh enabled=FALSE row for someone who never had a grant takes
+  // nothing away from them — so `grant_changed` (the LEDGER effect) stays gated on the
+  // pre-locked "was actually enabled" read; only the row parity is unconditional.
+  if (state.globally_clear) {
     await client.query(
       `INSERT INTO user_external_auth_grants (
          provider, local_user_id, enabled, granted_by, created_at, updated_at

--- a/packages/core-backend/src/directory/deprovision-ledger.ts
+++ b/packages/core-backend/src/directory/deprovision-ledger.ts
@@ -40,7 +40,8 @@ export type ApplyDeprovisionCandidateResult = {
   /**
    * Set when this candidate was skipped for a per-candidate race (user row vanished, or the
    * source account was unbound between candidate selection and the lock). A skip never aborts
-   * the surrounding sync run; `plan.effects` is empty so counters stay untouched.
+   * the surrounding sync run; `plan.effects` is empty so counters stay untouched. When set,
+   * `accessGeneration` is a meaningless 0 — discriminate on THIS field, never on the number.
    */
   skipReason: 'candidate_vanished' | null
   plan: DirectoryDeprovisionPlan

--- a/packages/core-backend/src/directory/deprovision-ledger.ts
+++ b/packages/core-backend/src/directory/deprovision-ledger.ts
@@ -37,6 +37,12 @@ export type ApplyDeprovisionCandidateResult = {
   eventId: string | null
   accessGeneration: number
   globallyClear: boolean
+  /**
+   * Set when this candidate was skipped for a per-candidate race (user row vanished, or the
+   * source account was unbound between candidate selection and the lock). A skip never aborts
+   * the surrounding sync run; `plan.effects` is empty so counters stay untouched.
+   */
+  skipReason: 'candidate_vanished' | null
   plan: DirectoryDeprovisionPlan
 }
 
@@ -58,11 +64,31 @@ function hasEffect(
   return effects.some((effect) => effect.type === type)
 }
 
+/**
+ * Adversarial review of #4647 (P1, two-connection proof): candidacy MUST NOT be read by the
+ * statement that acquires the lock. Under READ COMMITTED the locking statement's subqueries are
+ * evaluated against a snapshot taken BEFORE the lock wait — EPQ re-checks only the locked `users`
+ * row itself, so `globally_clear` came back stale while `access_generation` looked fresh, and a
+ * cross-org rehire committing during the wait was invisible: the user was platform-deactivated,
+ * the grant revoked, and the event recorded `globally_clear=true` — false evidence. The lock is
+ * therefore taken FIRST, in its own statement (`lockCandidateUser`), and this state read runs as
+ * a SEPARATE statement afterwards, whose snapshot postdates the lock (§5.3 step 1 / §7.4).
+ */
+async function lockCandidateUser(
+  client: DirectoryTransactionClient,
+  localUserId: string,
+): Promise<boolean> {
+  const locked = await client.query(
+    `SELECT id FROM users WHERE id = $1::text FOR UPDATE`,
+    [localUserId],
+  )
+  return locked.rows.length > 0
+}
+
 async function loadCandidateState(
   client: DirectoryTransactionClient,
   input: ApplyDeprovisionCandidateInput,
-): Promise<CandidateStateRow> {
-  const lockClause = input.write ? 'FOR UPDATE OF candidate_user' : ''
+): Promise<CandidateStateRow | null> {
   const result = await client.query(
     `SELECT
        candidate_user.activation_status,
@@ -118,8 +144,7 @@ async function loadCandidateState(
           LIMIT 1
        ), FALSE) AS dingtalk_grant_enabled
      FROM users candidate_user
-     WHERE candidate_user.id = $1::text
-     ${lockClause}`,
+     WHERE candidate_user.id = $1::text`,
     [
       input.localUserId,
       input.directoryAccountId,
@@ -127,17 +152,12 @@ async function loadCandidateState(
       input.orgId,
     ],
   )
+  // Adversarial review of #4647 (P2): a vanished user or a concurrently-unbound source account
+  // is a PER-CANDIDATE race, not a sync-level fault — throwing here aborted the entire directory
+  // sync run (and did so even with the deprovision flag OFF, a regression main's writer did not
+  // have). Both shapes now surface as null → the caller skips this candidate with a warning.
   const row = result.rows[0] as CandidateStateRow | undefined
-  if (!row) {
-    throw new Error(
-      `directory deprovision user not found: ${input.localUserId}`,
-    )
-  }
-  if (!row.linked_at_apply) {
-    throw new Error(
-      'directory deprovision source account is no longer linked to the candidate user',
-    )
-  }
+  if (!row || !row.linked_at_apply) return null
   return row
 }
 
@@ -171,7 +191,33 @@ export async function applyDirectoryDeprovisionCandidate(
   client: DirectoryTransactionClient,
   input: ApplyDeprovisionCandidateInput,
 ): Promise<ApplyDeprovisionCandidateResult> {
+  // §5.3 step 0: in write mode the mutex comes FIRST, as its own statement — see
+  // `lockCandidateUser`'s doc comment for why the lock and the state read must never share a
+  // statement. Preview takes no lock (it writes nothing, so there is nothing to serialise).
+  if (input.write) {
+    const lockHeld = await lockCandidateUser(client, input.localUserId)
+    if (!lockHeld) {
+      return {
+        applied: false,
+        eventId: null,
+        accessGeneration: 0,
+        globallyClear: false,
+        skipReason: 'candidate_vanished',
+        plan: { localUserId: input.localUserId, skipReason: 'candidate_vanished', effects: [] },
+      }
+    }
+  }
   const state = await loadCandidateState(client, input)
+  if (!state) {
+    return {
+      applied: false,
+      eventId: null,
+      accessGeneration: 0,
+      globallyClear: false,
+      skipReason: 'candidate_vanished',
+      plan: { localUserId: input.localUserId, skipReason: 'candidate_vanished', effects: [] },
+    }
+  }
   const plan = planDirectoryDeprovision({
     localUserId: input.localUserId,
     policy: input.policy,
@@ -191,6 +237,7 @@ export async function applyDirectoryDeprovisionCandidate(
       eventId: null,
       accessGeneration: currentGeneration,
       globallyClear: state.globally_clear,
+      skipReason: null,
       plan,
     }
   }
@@ -331,6 +378,7 @@ export async function applyDirectoryDeprovisionCandidate(
     eventId,
     accessGeneration: generation,
     globallyClear: state.globally_clear,
+    skipReason: null,
     plan,
   }
 }

--- a/packages/core-backend/src/directory/deprovision-ledger.ts
+++ b/packages/core-backend/src/directory/deprovision-ledger.ts
@@ -1,222 +1,336 @@
 /**
- * D3/D4 — deprovision effect ledger helpers (design lock Rev 4.2 companion §5).
+ * D4 deprovision writer.
  *
- * Immutability of identity fields is enforced by DB triggers in migration;
- * application helpers only INSERT events/effects and supersede open rows.
+ * The caller supplies the transaction client used by the directory sync. This
+ * module never opens a second transaction: user locking, write-time candidacy,
+ * access-graph changes, generation, event, and effects either commit together
+ * or all roll back.
  */
 
-import { query, transaction } from '../db/pg'
-import type { PlannedEffect } from './deprovision-planner'
+import type {
+  DirectoryDeprovisionPlan,
+  DirectoryDeprovisionPolicy,
+  PlannedEffect,
+} from './deprovision-planner'
 import { planDirectoryDeprovision } from './deprovision-planner'
 
-export type ApplyDeprovisionInput = {
+export type DirectoryTransactionClient = {
+  query: (
+    statement: string,
+    params?: unknown[],
+  ) => Promise<{ rows: Array<Record<string, unknown>> }>
+}
+
+export type ApplyDeprovisionCandidateInput = {
   localUserId: string
   orgId: string
   integrationId: string
   directoryAccountId: string
-  runId: string | null
+  runId: string
   triggeredBy: string
-  policy: 'manual_review' | 'disable_grant_only' | 'mark_inactive'
-  enabled: boolean
-  /** When false, planner runs but writer is no-op (preview mode). */
+  policy: DirectoryDeprovisionPolicy
   write: boolean
-  loadUserState: () => Promise<{
-    activationStatus: string | null
-    isActive: boolean
-    orgMembershipActive: boolean
-    dingtalkGrantEnabled: boolean
-    accessGeneration: number
-  }>
-  globallyClear?: boolean
 }
 
-export type ApplyDeprovisionResult = {
+export type ApplyDeprovisionCandidateResult = {
   applied: boolean
-  effectCount: number
-  accessGeneration: number | null
-  skipReason: string | null
   eventId: string | null
+  accessGeneration: number
+  globallyClear: boolean
+  plan: DirectoryDeprovisionPlan
 }
 
-/**
- * Apply deprovision: zero-effect → no generation++ / no ledger rows.
- * Non-zero → generation++ AND event+effects in one transaction.
- */
-export async function applyDirectoryDeprovisionPlan(
-  input: ApplyDeprovisionInput,
-): Promise<ApplyDeprovisionResult> {
-  if (!input.enabled) {
-    return {
-      applied: false,
-      effectCount: 0,
-      accessGeneration: null,
-      skipReason: 'deprovision_disabled',
-      eventId: null,
-    }
-  }
+type CandidateStateRow = {
+  activation_status: string | null
+  is_active: boolean
+  access_generation: string | number
+  linked_at_apply: boolean
+  org_membership_active: boolean
+  org_candidacy_clear: boolean
+  globally_clear: boolean
+  dingtalk_grant_enabled: boolean
+}
 
-  const state = await input.loadUserState()
+function hasEffect(
+  effects: PlannedEffect[],
+  type: PlannedEffect['type'],
+): boolean {
+  return effects.some((effect) => effect.type === type)
+}
+
+async function loadCandidateState(
+  client: DirectoryTransactionClient,
+  input: ApplyDeprovisionCandidateInput,
+): Promise<CandidateStateRow> {
+  const lockClause = input.write ? 'FOR UPDATE OF candidate_user' : ''
+  const result = await client.query(
+    `SELECT
+       candidate_user.activation_status,
+       candidate_user.is_active,
+       COALESCE(candidate_user.access_generation, 0) AS access_generation,
+       EXISTS (
+         SELECT 1
+           FROM directory_account_links source_link
+           JOIN directory_accounts source_account
+             ON source_account.id = source_link.directory_account_id
+           JOIN directory_integrations source_integration
+             ON source_integration.id = source_account.integration_id
+          WHERE source_link.directory_account_id = $2::uuid
+            AND source_link.local_user_id = candidate_user.id
+            AND source_link.link_status = 'linked'
+            AND source_account.integration_id = $3::uuid
+            AND source_account.is_active = FALSE
+            AND source_integration.org_id = $4::text
+       ) AS linked_at_apply,
+       EXISTS (
+         SELECT 1
+           FROM user_orgs membership
+          WHERE membership.user_id = candidate_user.id
+            AND membership.org_id = $4::text
+            AND COALESCE(membership.is_active, TRUE) = TRUE
+       ) AS org_membership_active,
+       NOT EXISTS (
+         SELECT 1
+           FROM directory_account_links sibling_link
+           JOIN directory_accounts sibling
+             ON sibling.id = sibling_link.directory_account_id
+           JOIN directory_integrations sibling_integration
+             ON sibling_integration.id = sibling.integration_id
+          WHERE sibling_link.local_user_id = candidate_user.id
+            AND sibling_link.link_status = 'linked'
+            AND sibling.is_active = TRUE
+            AND sibling_integration.org_id = $4::text
+       ) AS org_candidacy_clear,
+       NOT EXISTS (
+         SELECT 1
+           FROM directory_account_links sibling_link
+           JOIN directory_accounts sibling
+             ON sibling.id = sibling_link.directory_account_id
+          WHERE sibling_link.local_user_id = candidate_user.id
+            AND sibling_link.link_status = 'linked'
+            AND sibling.is_active = TRUE
+       ) AS globally_clear,
+       COALESCE((
+         SELECT grant_row.enabled
+           FROM user_external_auth_grants grant_row
+          WHERE grant_row.provider = 'dingtalk'
+            AND grant_row.local_user_id = candidate_user.id
+          LIMIT 1
+       ), FALSE) AS dingtalk_grant_enabled
+     FROM users candidate_user
+     WHERE candidate_user.id = $1::text
+     ${lockClause}`,
+    [
+      input.localUserId,
+      input.directoryAccountId,
+      input.integrationId,
+      input.orgId,
+    ],
+  )
+  const row = result.rows[0] as CandidateStateRow | undefined
+  if (!row) {
+    throw new Error(
+      `directory deprovision user not found: ${input.localUserId}`,
+    )
+  }
+  if (!row.linked_at_apply) {
+    throw new Error(
+      'directory deprovision source account is no longer linked to the candidate user',
+    )
+  }
+  return row
+}
+
+async function writeEffects(
+  client: DirectoryTransactionClient,
+  eventId: string,
+  localUserId: string,
+  generation: number,
+  effects: PlannedEffect[],
+): Promise<void> {
+  for (const effect of effects) {
+    await client.query(
+      `INSERT INTO directory_deprovision_effects (
+         event_id, local_user_id, org_id, effect_type,
+         before_active, after_active, access_generation_at_apply, status
+       ) VALUES ($1::uuid, $2::text, $3::text, $4::text, $5, $6, $7, 'applied')`,
+      [
+        eventId,
+        localUserId,
+        effect.orgId ?? null,
+        effect.type,
+        effect.beforeActive,
+        effect.afterActive,
+        generation,
+      ],
+    )
+  }
+}
+
+export async function applyDirectoryDeprovisionCandidate(
+  client: DirectoryTransactionClient,
+  input: ApplyDeprovisionCandidateInput,
+): Promise<ApplyDeprovisionCandidateResult> {
+  const state = await loadCandidateState(client, input)
   const plan = planDirectoryDeprovision({
     localUserId: input.localUserId,
-    activationStatus: state.activationStatus,
-    isActive: state.isActive,
-    orgId: input.orgId,
-    orgMembershipActive: state.orgMembershipActive,
-    dingtalkGrantEnabled: state.dingtalkGrantEnabled,
-    globallyClear: input.globallyClear !== false,
-  })
-
-  if (plan.effects.length === 0) {
-    return {
-      applied: false,
-      effectCount: 0,
-      accessGeneration: state.accessGeneration,
-      skipReason: plan.skipReason ?? 'zero_effect',
-      eventId: null,
-    }
-  }
-
-  if (!input.write) {
-    return {
-      applied: false,
-      effectCount: plan.effects.length,
-      accessGeneration: state.accessGeneration,
-      skipReason: 'preview_only',
-      eventId: null,
-    }
-  }
-
-  return writeDeprovisionLedger({
-    localUserId: input.localUserId,
-    orgId: input.orgId,
-    integrationId: input.integrationId,
-    directoryAccountId: input.directoryAccountId,
-    runId: input.runId,
-    triggeredBy: input.triggeredBy,
     policy: input.policy,
-    globallyClear: input.globallyClear !== false,
-    effects: plan.effects,
-    previousGeneration: state.accessGeneration,
+    activationStatus: state.activation_status,
+    isActive: state.is_active,
+    orgId: input.orgId,
+    orgMembershipActive:
+      state.org_membership_active && state.org_candidacy_clear,
+    dingtalkGrantEnabled: state.dingtalk_grant_enabled,
+    globallyClear: state.globally_clear,
   })
-}
+  const currentGeneration = Number(state.access_generation)
 
-async function writeDeprovisionLedger(options: {
-  localUserId: string
-  orgId: string
-  integrationId: string
-  directoryAccountId: string
-  runId: string | null
-  triggeredBy: string
-  policy: 'manual_review' | 'disable_grant_only' | 'mark_inactive'
-  globallyClear: boolean
-  effects: PlannedEffect[]
-  previousGeneration: number
-}): Promise<ApplyDeprovisionResult> {
-  let eventId: string | null = null
-  let nextGen = options.previousGeneration
+  if (!input.write || plan.effects.length === 0) {
+    return {
+      applied: false,
+      eventId: null,
+      accessGeneration: currentGeneration,
+      globallyClear: state.globally_clear,
+      plan,
+    }
+  }
 
-  await transaction(async (client) => {
-    // Per-user mutex
-    await client.query(`SELECT id FROM users WHERE id = $1 FOR UPDATE`, [options.localUserId])
+  const membershipChanged = hasEffect(plan.effects, 'membership_changed')
+  const grantChanged = hasEffect(plan.effects, 'grant_changed')
+  const userChanged = hasEffect(plan.effects, 'user_changed')
 
-    const gen = await client.query(
-      `UPDATE users
+  const generationResult = userChanged
+    ? await client.query(
+        `UPDATE users
           SET access_generation = COALESCE(access_generation, 0) + 1,
               is_active = FALSE,
               updated_at = NOW()
-        WHERE id = $1
+        WHERE id = $1::text
         RETURNING access_generation`,
-      [options.localUserId],
+        [input.localUserId],
+      )
+    : await client.query(
+        `UPDATE users
+          SET access_generation = COALESCE(access_generation, 0) + 1,
+              updated_at = NOW()
+        WHERE id = $1::text
+        RETURNING access_generation`,
+        [input.localUserId],
+      )
+  const generation = Number(
+    (
+      generationResult.rows[0] as
+        | { access_generation?: string | number }
+        | undefined
+    )?.access_generation,
+  )
+  if (!Number.isFinite(generation)) {
+    throw new Error('directory deprovision generation update returned no row')
+  }
+
+  if (membershipChanged) {
+    const membership = await client.query(
+      `UPDATE user_orgs
+          SET is_active = FALSE
+        WHERE user_id = $1::text
+          AND org_id = $2::text
+          AND COALESCE(is_active, TRUE) = TRUE
+          AND NOT EXISTS (
+            SELECT 1
+              FROM directory_account_links sibling_link
+              JOIN directory_accounts sibling
+                ON sibling.id = sibling_link.directory_account_id
+              JOIN directory_integrations sibling_integration
+                ON sibling_integration.id = sibling.integration_id
+             WHERE sibling_link.local_user_id = $1::text
+               AND sibling_link.link_status = 'linked'
+               AND sibling.is_active = TRUE
+               AND sibling_integration.org_id = $2::text
+          )
+        RETURNING user_id`,
+      [input.localUserId, input.orgId],
     )
-    nextGen = Number(gen.rows[0]?.access_generation ?? options.previousGeneration + 1)
-
-    // Supersede applied effects for this user.
-    await client.query(
-      `UPDATE directory_deprovision_effects
-          SET status = 'superseded', updated_at = NOW()
-        WHERE local_user_id = $1 AND status = 'applied'`,
-      [options.localUserId],
-    )
-
-    const ev = await client.query(
-      `INSERT INTO directory_deprovision_events (
-         org_id, integration_id, directory_account_id, local_user_id,
-         run_id, triggered_by, event_origin, link_witness_account_id,
-         link_witness_local_user_id, policy, globally_clear,
-         access_generation_at_apply, status
-       ) VALUES ($1,$2,$3,$4,$5,$6,'sync',$3,$4,$7,$8,$9,'applied')
-       RETURNING id`,
-      [
-        options.orgId,
-        options.integrationId,
-        options.directoryAccountId,
-        options.localUserId,
-        options.runId,
-        options.triggeredBy,
-        options.policy,
-        options.globallyClear,
-        nextGen,
-      ],
-    )
-
-    eventId = (ev.rows[0] as { id?: string } | undefined)?.id ?? null
-    if (!eventId) {
-      throw new Error('directory deprovision event INSERT returned no id')
-    }
-
-    for (const effect of options.effects) {
-      await client.query(
-        `INSERT INTO directory_deprovision_effects (
-           event_id, local_user_id, org_id, effect_type,
-           before_active, after_active, access_generation_at_apply, status
-         ) VALUES ($1,$2,$3,$4,$5,$6,$7,'applied')`,
-        [
-          eventId,
-          options.localUserId,
-          effect.orgId ?? options.orgId,
-          effect.type,
-          effect.beforeActive,
-          effect.afterActive,
-          nextGen,
-        ],
+    if (!membership.rows[0]) {
+      throw new Error(
+        'directory deprovision membership changed after planning; transaction aborted',
       )
     }
-  })
+  }
+
+  if (grantChanged) {
+    await client.query(
+      `INSERT INTO user_external_auth_grants (
+         provider, local_user_id, enabled, granted_by, created_at, updated_at
+       ) VALUES ('dingtalk', $1::text, FALSE, 'system:directory-deprovision', NOW(), NOW())
+       ON CONFLICT (provider, local_user_id)
+       DO UPDATE SET enabled = FALSE,
+                     granted_by = EXCLUDED.granted_by,
+                     updated_at = NOW()`,
+      [input.localUserId],
+    )
+  }
+
+  await client.query(
+    `UPDATE directory_deprovision_effects
+        SET status = 'superseded', updated_at = NOW()
+      WHERE local_user_id = $1::text
+        AND status = 'applied'`,
+    [input.localUserId],
+  )
+  await client.query(
+    `UPDATE directory_deprovision_events
+        SET status = 'superseded',
+            resolved_at = NOW(),
+            resolved_by = $2::text,
+            resolve_note = 'superseded by a newer directory deprovision event',
+            updated_at = NOW()
+      WHERE local_user_id = $1::text
+        AND status = 'applied'`,
+    [input.localUserId, input.triggeredBy],
+  )
+
+  const eventResult = await client.query(
+    `INSERT INTO directory_deprovision_events (
+       org_id, integration_id, directory_account_id, local_user_id,
+       run_id, triggered_by, event_origin, link_witness_account_id,
+       link_witness_local_user_id, policy, globally_clear,
+       access_generation_at_apply, status
+     ) VALUES (
+       $1::text, $2::uuid, $3::uuid, $4::text,
+       $5::uuid, $6::text, 'sync', $3::uuid,
+       $4::text, $7::text, $8::boolean, $9, 'applied'
+     )
+     RETURNING id`,
+    [
+      input.orgId,
+      input.integrationId,
+      input.directoryAccountId,
+      input.localUserId,
+      input.runId,
+      input.triggeredBy,
+      input.policy,
+      state.globally_clear,
+      generation,
+    ],
+  )
+  const eventId = (eventResult.rows[0] as { id?: string } | undefined)?.id
+  if (!eventId) {
+    throw new Error('directory deprovision event INSERT returned no id')
+  }
+
+  await writeEffects(
+    client,
+    eventId,
+    input.localUserId,
+    generation,
+    plan.effects,
+  )
 
   return {
     applied: true,
-    effectCount: options.effects.length,
-    accessGeneration: nextGen,
-    skipReason: null,
     eventId,
+    accessGeneration: generation,
+    globallyClear: state.globally_clear,
+    plan,
   }
-}
-
-/** D5 helper — supersede open effects + bump generation (other writers). */
-export async function supersedeOpenDeprovisionEffects(userId: string): Promise<void> {
-  await transaction(async (client) => {
-    await client.query(`SELECT id FROM users WHERE id = $1 FOR UPDATE`, [userId])
-    await client.query(
-      `UPDATE users
-          SET access_generation = COALESCE(access_generation, 0) + 1,
-              updated_at = NOW()
-        WHERE id = $1`,
-      [userId],
-    )
-    await client.query(
-      `UPDATE directory_deprovision_effects
-          SET status = 'superseded', updated_at = NOW()
-        WHERE local_user_id = $1 AND status = 'applied'`,
-      [userId],
-    )
-  })
-}
-
-export async function countOpenDeprovisionEffects(userId: string): Promise<number> {
-  const r = await query<{ n: number }>(
-    `SELECT count(*)::int AS n FROM directory_deprovision_effects
-      WHERE local_user_id = $1 AND status = 'applied'`,
-    [userId],
-  )
-  return r.rows[0]?.n ?? 0
 }

--- a/packages/core-backend/src/directory/deprovision-planner.ts
+++ b/packages/core-backend/src/directory/deprovision-planner.ts
@@ -6,6 +6,10 @@
  */
 
 export type DeprovisionEffectType = 'membership_changed' | 'grant_changed' | 'user_changed'
+export type DirectoryDeprovisionPolicy =
+  | 'manual_review'
+  | 'disable_grant_only'
+  | 'mark_inactive'
 
 export type PlannedEffect = {
   type: DeprovisionEffectType
@@ -16,6 +20,7 @@ export type PlannedEffect = {
 
 export type DirectoryDeprovisionPlanInput = {
   localUserId: string
+  policy: DirectoryDeprovisionPolicy
   activationStatus: string | null | undefined
   isActive: boolean
   /** Source integration org for this event. */
@@ -41,6 +46,14 @@ export type DirectoryDeprovisionPlan = {
  * Prospective planner: pending users never invent offboarding effects.
  */
 export function planDirectoryDeprovision(input: DirectoryDeprovisionPlanInput): DirectoryDeprovisionPlan {
+  if (input.policy === 'manual_review') {
+    return {
+      localUserId: input.localUserId,
+      skipReason: 'manual_review',
+      effects: [],
+    }
+  }
+
   if (input.activationStatus === 'pending_activation') {
     return {
       localUserId: input.localUserId,
@@ -69,7 +82,7 @@ export function planDirectoryDeprovision(input: DirectoryDeprovisionPlanInput): 
         afterActive: false,
       })
     }
-    if (input.isActive) {
+    if (input.policy === 'mark_inactive' && input.isActive) {
       effects.push({
         type: 'user_changed',
         orgId: null,

--- a/packages/core-backend/src/directory/directory-sync.ts
+++ b/packages/core-backend/src/directory/directory-sync.ts
@@ -1596,9 +1596,12 @@ export async function applyDirectoryDeprovisionPolicies(
       continue
     }
 
-    // D4: the helper re-reads both candidacy scopes while holding the canonical users row lock
-    // (write mode), applies the access graph, generation, and ledger on this SAME transaction
-    // client, and fails the whole sync transaction if any evidence write fails.
+    // D4: in write mode the helper acquires the canonical `users` row lock FIRST (its own
+    // statement), then re-reads both candidacy scopes in a SEPARATE statement whose snapshot
+    // postdates the lock — the two must never share a statement, or the subqueries evaluate on
+    // the pre-wait snapshot (adversarial-review P1, proved with a two-connection race; see
+    // `lockCandidateUser` in deprovision-ledger.ts). Access graph, generation, event and effects
+    // then commit or roll back together on this SAME transaction client.
     const result = await applyDirectoryDeprovisionCandidate(client, {
       localUserId,
       orgId,
@@ -1609,6 +1612,15 @@ export async function applyDirectoryDeprovisionPolicies(
       policy,
       write: options.enabled,
     })
+    if (result.skipReason) {
+      // Per-candidate race (user vanished / source unbound mid-run): skip THIS person, never
+      // abort the whole sync run — with the flag off this path must be indistinguishable from
+      // a no-op preview.
+      logger.warn(
+        `Directory deprovision skipped ${localUserId} for ${options.integrationId}: ${result.skipReason}`,
+      )
+      continue
+    }
     const effectTypes = new Set(result.plan.effects.map((effect) => effect.type))
     if (effectTypes.size === 0) continue
 

--- a/packages/core-backend/src/directory/directory-sync.ts
+++ b/packages/core-backend/src/directory/directory-sync.ts
@@ -1645,7 +1645,12 @@ export async function applyDirectoryDeprovisionPolicies(
     if (result.globallyClear) {
       outcome.globalCandidateCount += 1
     }
-    if (effectTypes.has('grant_changed')) {
+    // ATTEMPT semantics, matching this field's own doc-comment and the OPS-01 run-stats pinned
+    // by the orchestration suite: every globally-clear candidate gets the disabled-grant
+    // bookkeeping upsert (whether or not a grant previously existed), so the count follows the
+    // bookkeeping write. Whether a grant was ACTUALLY taken away is the ledger's job — the
+    // `grant_changed` effect stays gated on the pre-locked "was enabled" read.
+    if (result.globallyClear) {
       outcome.grantsDisabledCount += 1
     }
     if (effectTypes.has('user_changed')) {

--- a/packages/core-backend/src/directory/directory-sync.ts
+++ b/packages/core-backend/src/directory/directory-sync.ts
@@ -1379,6 +1379,12 @@ export type DirectoryDeprovisionOutcome = {
    * helper's `UPDATE` has no `RETURNING`); this is attempt-visibility, not flip-visibility.
    */
   membershipDeactivationAttemptedCount: number
+  /**
+   * Delta-review NIT-D3: per-candidate races (vanished user / concurrently-unbound source) are
+   * SKIPPED rather than aborting the run — counted here so a run that silently skipped people is
+   * distinguishable from one that considered them, without digging through logs.
+   */
+  skippedCandidateCount: number
   /** Set when the circuit breaker refused to act; `applied` is forced false. */
   abortedReason: DirectoryDeprovisionAbortReason | null
   affected: Array<{
@@ -1501,6 +1507,7 @@ export async function applyDirectoryDeprovisionPolicies(
     grantsDisabledCount: 0,
     usersDeactivatedCount: 0,
     membershipDeactivationAttemptedCount: 0,
+    skippedCandidateCount: 0,
     abortedReason: null,
     affected: [],
     manualReviewPending: [],
@@ -1615,7 +1622,9 @@ export async function applyDirectoryDeprovisionPolicies(
     if (result.skipReason) {
       // Per-candidate race (user vanished / source unbound mid-run): skip THIS person, never
       // abort the whole sync run — with the flag off this path must be indistinguishable from
-      // a no-op preview.
+      // a no-op preview. Counted on the outcome so skips are visible in run stats, not only in
+      // logs (delta-review NIT-D3).
+      outcome.skippedCandidateCount += 1
       logger.warn(
         `Directory deprovision skipped ${localUserId} for ${options.integrationId}: ${result.skipReason}`,
       )

--- a/packages/core-backend/src/directory/directory-sync.ts
+++ b/packages/core-backend/src/directory/directory-sync.ts
@@ -44,6 +44,7 @@ import { SimpleCronExpression } from '../services/SchedulerService'
 import { deliverDirectorySyncFailureAlert, getDirectoryManagerBindingCoverage } from './directory-sync-alert-delivery'
 import { resolveDirectoryScheduleTimezone } from './directory-sync-timezone'
 import { acquireSourceSyncFreezeLock } from './source-sync-freeze-lock'
+import { applyDirectoryDeprovisionCandidate } from './deprovision-ledger'
 
 const logger = new Logger('DirectorySync')
 const DEFAULT_ORG_ID = 'default'
@@ -1481,6 +1482,8 @@ export async function applyDirectoryDeprovisionPolicies(
   client: { query: (sql: string, params?: unknown[]) => Promise<{ rows: Array<Record<string, unknown>> }> },
   options: {
     integrationId: string
+    runId: string
+    triggeredBy: string
     /** Ids of the accounts this run *transitioned* to inactive. NOT the lifetime backlog. */
     deactivatedAccountIds: string[]
     /** How many accounts the DingTalk fetch actually returned — the circuit breaker's input. */
@@ -1532,6 +1535,7 @@ export async function applyDirectoryDeprovisionPolicies(
         AND l.link_status = 'linked'
         AND l.local_user_id IS NOT NULL
       WHERE a.id = ANY($1::uuid[])
+        AND a.is_active = FALSE
         AND NOT EXISTS (
           SELECT 1
             FROM directory_account_links sibling_link
@@ -1578,57 +1582,10 @@ export async function applyDirectoryDeprovisionPolicies(
     return outcome
   }
 
-  // W4-PRE-1d item 2 (owner P2, #4530 review, issuecomment-5043752399, verbatim — "全局账号/
-  // 授权候选：保留『任意位置无活跃绑定』守卫，才允许关闭 DingTalk grant 或 users.is_active"): the
-  // pre-existing GLOBAL "no active binding ANYWHERE" guard, relocated from candidate SELECTION
-  // (where it wrongly excluded org-A-only candidacy) to here, where it gates only the
-  // grant-disable / platform-user-deactivation actions. Computed once for every non-
-  // `manual_review` org-membership candidate — manual_review never writes anything regardless,
-  // so it is excluded from this batch check entirely.
-  //
-  // Known gap (review finding, deferred — not overlooked): this is a batch-level, no-lock
-  // check-then-act read. It is taken ONCE, before the write loop below, over READ COMMITTED
-  // snapshots for every candidate in the batch. A concurrent transaction that changes this
-  // person's binding elsewhere (another org's departure completing, or a rehire committing a
-  // new linked+active account) between this read and the write loop's `INSERT`/`UPDATE` below
-  // is invisible to this snapshot — unlike `deactivateUserOrgMembershipIfNoOtherActiveBinding`'s
-  // own write-time `SELECT ... FOR UPDATE` re-read for the org-membership write, there is no
-  // equivalent write-time re-check here for the grant/platform-user writes. Concretely: (a) two
-  // concurrent last-org departures for the same person can each see the other's org as still
-  // active and both skip the grant/user-deactivate writes, leaving an enabled DingTalk grant
-  // with zero live bindings and no automatic reconciliation; (b) a same-window rehire can have
-  // its grant/user-deactivate writes applied against a now-stale "globally clear" snapshot. Both
-  // shapes are inherited from the pre-existing (pre-W4-PRE-1d) global guard, which read from an
-  // even earlier point (the old unscoped candidate SELECT) — this relocation does not widen
-  // either window. Closing it needs a lock-strategy or reconciliation-sweep design decision
-  // (e.g. a `users`-row `FOR UPDATE` re-check at write time, mirroring the org-membership
-  // helper) that is outside the owner's verbatim 4-item P2 spec this PR implements — left for
-  // the owner to scope as a follow-up, not silently dropped.
-  const nonManualReviewUserIds = Array.from(byUser.entries())
-    .filter(([, c]) => c.policy !== 'manual_review')
-    .map(([localUserId]) => localUserId)
-
-  const globallyClearUserIds = new Set<string>()
-  if (nonManualReviewUserIds.length > 0) {
-    const globalClear = await client.query(
-      `SELECT candidate_user AS local_user_id
-         FROM UNNEST($1::text[]) AS candidate_user
-        WHERE NOT EXISTS (
-          SELECT 1
-            FROM directory_account_links sibling_link
-            JOIN directory_accounts sibling ON sibling.id = sibling_link.directory_account_id
-           WHERE sibling_link.local_user_id = candidate_user
-             AND sibling_link.link_status = 'linked'
-             AND sibling.is_active = true
-        )`,
-      [nonManualReviewUserIds],
-    )
-    for (const row of globalClear.rows as Array<{ local_user_id: string }>) {
-      globallyClearUserIds.add(row.local_user_id)
-    }
-  }
-
-  for (const [localUserId, { directoryAccountId, policy }] of byUser) {
+  const orderedCandidates = [...byUser.entries()].sort(([leftUserId], [rightUserId]) =>
+    leftUserId.localeCompare(rightUserId),
+  )
+  for (const [localUserId, { directoryAccountId, policy }] of orderedCandidates) {
     if (policy === 'manual_review') {
       outcome.manualReviewCount += 1
       // Owner 裁决② (#4522 rev3 review — issuecomment-5042388830: "manual_review 保持 active
@@ -1639,77 +1596,39 @@ export async function applyDirectoryDeprovisionPolicies(
       continue
     }
 
-    const globallyClear = globallyClearUserIds.has(localUserId)
-    outcome.affected.push({ directoryAccountId, localUserId, policy, globallyClear })
+    // D4: the helper re-reads both candidacy scopes while holding the canonical users row lock
+    // (write mode), applies the access graph, generation, and ledger on this SAME transaction
+    // client, and fails the whole sync transaction if any evidence write fails.
+    const result = await applyDirectoryDeprovisionCandidate(client, {
+      localUserId,
+      orgId,
+      integrationId: options.integrationId,
+      directoryAccountId,
+      runId: options.runId,
+      triggeredBy: options.triggeredBy,
+      policy,
+      write: options.enabled,
+    })
+    const effectTypes = new Set(result.plan.effects.map((effect) => effect.type))
+    if (effectTypes.size === 0) continue
 
-    // W4-PRE-1d: org-membership deactivation is attempted for EVERY org-membership candidate
-    // reaching this point, unconditional on `globallyClear` — the global guard governs only the
-    // grant/platform-user actions below, never this one (owner P2 item 1 vs item 2 split).
-    // Same gate as before (breaker passed + `options.enabled`), see this field's own doc-comment
-    // on `DirectoryDeprovisionOutcome` for the attempt-not-flip distinction.
-    outcome.membershipDeactivationAttemptedCount += 1
-    if (options.enabled) {
-      // W4-PRE-1c (owner 裁决②, #4522 rev3 review — the only GitHub-persisted record is the
-      // owner's own acknowledgment comment, issuecomment-5042388830: "不因单次同步缺失撤销
-      // membership；deprovision circuit-breaker 通过 + 开关启用 + 策略实际执行时同事务失活对应
-      // user_orgs；manual_review 保持 active 并暴露待人工确认状态。" No #4522 review or review-
-      // thread comment carries a longer/earlier original — this IS the citable text, not a
-      // paraphrase of something else on record): the circuit breaker already passed (we are
-      // past the abort-and-return above), the switch is on (`options.enabled`), and this
-      // policy just executed for this person — THIS moment — not the DT-OPS-01 sweep flipping
-      // `directory_accounts.is_active` alone — is "策略实际执行", and is what deactivates
-      // `user_orgs`, same transaction. Reuses #4526's own org-scoped "no other active binding"
-      // rule verbatim (`deactivateUserOrgMembershipIfNoOtherActiveBinding`) — and that helper's
-      // OWN re-read (`SELECT ... FOR UPDATE` then a fresh READ COMMITTED `NOT EXISTS`) is NOT
-      // redundant with this function's own org-scoped candidate-selection guard above, despite
-      // both checking "no other active binding in this org": the guard above is read ONCE,
-      // early, before this loop and before any write in this run; this helper re-checks AT
-      // WRITE TIME under a row lock. A concurrent transaction that commits a brand-new
-      // linked+active directory account for this SAME person in this SAME org, in the window
-      // between the guard's read and this call, is invisible to the guard's stale snapshot but
-      // IS caught by this helper's fresh re-read — the same write-skew shape #4526 itself fixed
-      // with `FOR UPDATE` for concurrent unbinds. So this check is independently load-bearing on
-      // this call path, not merely inherited defense-in-depth. `manual_review` is excluded by
-      // the `continue` above: a single missed sync, or a policy that never executes, must never
-      // itself revoke membership.
-      await deactivateUserOrgMembershipIfNoOtherActiveBinding(client, { userId: localUserId, orgId })
+    outcome.affected.push({
+      directoryAccountId,
+      localUserId,
+      policy,
+      globallyClear: result.globallyClear,
+    })
+    if (effectTypes.has('membership_changed')) {
+      outcome.membershipDeactivationAttemptedCount += 1
     }
-
-    // W4-PRE-1d item 2: grant-disable and (for mark_inactive) platform-user deactivation are
-    // gated by the GLOBAL "no active binding ANYWHERE" guard — a person still actively employed
-    // through a DIFFERENT org's directory keeps DingTalk login and their platform account, even
-    // though THIS org's membership was just deactivated above.
-    //
-    // Known gap (review finding, deferred — see this function's `globallyClearUserIds` batch
-    // read above for the forward-direction case; this is the reverse): `globallyClear` here is
-    // the STALE batch snapshot, not re-checked at this write. If a concurrent transaction
-    // commits a brand-new linked+active directory account for this SAME person (rehire, or a
-    // new org's onboarding) in the window between that snapshot and this write, these two writes
-    // still fire against the stale `true`, closing the grant and (mark_inactive) deactivating an
-    // otherwise-currently-employed user. Same inherited-not-widened window as the guard's own
-    // doc-comment above; same deferred lock/reconciliation design decision.
-    if (globallyClear) {
+    if (result.globallyClear) {
       outcome.globalCandidateCount += 1
+    }
+    if (effectTypes.has('grant_changed')) {
       outcome.grantsDisabledCount += 1
-      if (options.enabled) {
-        await client.query(
-          `INSERT INTO user_external_auth_grants (provider, local_user_id, enabled, granted_by, created_at, updated_at)
-           VALUES ($1, $2, FALSE, $3, NOW(), NOW())
-           ON CONFLICT (provider, local_user_id)
-           DO UPDATE SET enabled = FALSE, updated_at = NOW()`,
-          [DEFAULT_PROVIDER, localUserId, 'system:directory-deprovision'],
-        )
-      }
-
-      if (policy === 'mark_inactive') {
-        outcome.usersDeactivatedCount += 1
-        if (options.enabled) {
-          await client.query(
-            `UPDATE users SET is_active = FALSE, updated_at = NOW() WHERE id = $1::text`,
-            [localUserId],
-          )
-        }
-      }
+    }
+    if (effectTypes.has('user_changed')) {
+      outcome.usersDeactivatedCount += 1
     }
   }
 
@@ -4266,6 +4185,8 @@ export async function syncDirectoryIntegration(
       // Default-off: this only counts what it WOULD do unless explicitly enabled.
       deprovisionOutcome = await applyDirectoryDeprovisionPolicies(client, {
         integrationId,
+        runId,
+        triggeredBy,
         deactivatedAccountIds,
         // The circuit breaker's input: how many accounts DingTalk actually returned. Zero
         // means the fetch is broken, not that the company evacuated.

--- a/packages/core-backend/tests/integration/attendance-w4pre1c-departure-org-scoped.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-w4pre1c-departure-org-scoped.db.test.ts
@@ -1,6 +1,10 @@
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
 import { query } from '../../src/db/pg'
 import { applyDirectoryDeprovisionPolicies } from '../../src/directory/directory-sync'
+import {
+  createDirectoryDeprovisionRun,
+  deleteDirectoryDeprovisionEvidence,
+} from '../utils/directory-deprovision-fixtures'
 
 /**
  * W4-PRE-1c items A/B, owner cases ② ("双组织") and ③ ("活跃 sibling") — proved against real
@@ -46,6 +50,7 @@ describeIfDatabase('W4-PRE-1c cases ②③ — org-scoped user_orgs deactivation
   let integrationB = ''
   let orgA = ''
   let orgB = ''
+  let runA = ''
 
   const client = {
     query: (sql: string, params?: unknown[]) =>
@@ -56,6 +61,8 @@ describeIfDatabase('W4-PRE-1c cases ②③ — org-scoped user_orgs deactivation
     integrationDefaultPolicy: 'mark_inactive',
     syncedAccountCount: 100,
     enabled: true,
+    runId: '',
+    triggeredBy: 'test:w4pre1c-org-scoped',
   }
 
   async function seedAccount(opts: {
@@ -101,9 +108,12 @@ describeIfDatabase('W4-PRE-1c cases ②③ — org-scoped user_orgs deactivation
       [`w4pre1cos-b-${TS}`, `w4pre1cos-corp-b-${TS}`, `w4pre1cos-org-b-${TS}`],
     )).rows[0].id
     orgB = `w4pre1cos-org-b-${TS}`
+    runA = await createDirectoryDeprovisionRun(integrationA)
+    baseOptions.runId = runA
   })
 
   afterEach(async () => {
+    await deleteDirectoryDeprovisionEvidence([integrationA, integrationB])
     await query(`DELETE FROM user_external_auth_grants WHERE local_user_id LIKE $1`, [`w4pre1cos-%-${TS}`])
     await query(`DELETE FROM user_orgs WHERE user_id LIKE $1`, [`w4pre1cos-%-${TS}`])
     await query(`DELETE FROM directory_accounts WHERE integration_id = ANY($1::uuid[])`, [[integrationA, integrationB]]) // links cascade
@@ -174,6 +184,12 @@ describeIfDatabase('W4-PRE-1c cases ②③ — org-scoped user_orgs deactivation
     const user = uid('grantonly')
     const departed = await seedAccount({ integrationId: integrationA, userId: user, accountActive: false })
     await query(`INSERT INTO user_orgs (user_id, org_id, is_active) VALUES ($1, $2, TRUE)`, [user, orgA])
+    await query(
+      `INSERT INTO user_external_auth_grants (
+         provider, local_user_id, enabled, granted_by, created_at, updated_at
+       ) VALUES ('dingtalk', $1, TRUE, 'test:w4pre1c-org-scoped', NOW(), NOW())`,
+      [user],
+    )
 
     const outcome = await applyDirectoryDeprovisionPolicies(client, {
       ...baseOptions,

--- a/packages/core-backend/tests/integration/attendance-w4pre1c-departure-permission-negative.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-w4pre1c-departure-permission-negative.db.test.ts
@@ -3,6 +3,10 @@ import express from 'express'
 import request from 'supertest'
 import { query } from '../../src/db/pg'
 import { applyDirectoryDeprovisionPolicies } from '../../src/directory/directory-sync'
+import {
+  createDirectoryDeprovisionRun,
+  deleteDirectoryDeprovisionEvidence,
+} from '../utils/directory-deprovision-fixtures'
 import { db } from '../../src/db/db'
 import { DingTalkGroupDestinationService } from '../../src/multitable/dingtalk-group-destination-service'
 
@@ -56,6 +60,7 @@ describeIfDatabase('W4-PRE-1c case ⑤ leg 1 — readiness gate 403 after a poli
   const activeUser = `${NS}-active`
   let integrationId = ''
   let orgId = ''
+  let runId = ''
 
   const depClient = {
     query: (sql: string, params?: unknown[]) =>
@@ -85,6 +90,7 @@ describeIfDatabase('W4-PRE-1c case ⑤ leg 1 — readiness gate 403 after a poli
     )).rows[0]
     integrationId = row.id
     orgId = row.org_id
+    runId = await createDirectoryDeprovisionRun(integrationId)
 
     for (const userId of [departedUser, activeUser]) {
       await query(
@@ -109,6 +115,8 @@ describeIfDatabase('W4-PRE-1c case ⑤ leg 1 — readiness gate 403 after a poli
     )
     const outcome = await applyDirectoryDeprovisionPolicies(depClient, {
       integrationId,
+      runId,
+      triggeredBy: 'test:w4pre1c-permission-negative',
       deactivatedAccountIds: [account.rows[0].id],
       syncedAccountCount: 50,
       integrationDefaultPolicy: 'mark_inactive',
@@ -118,6 +126,7 @@ describeIfDatabase('W4-PRE-1c case ⑤ leg 1 — readiness gate 403 after a poli
   })
 
   afterAll(async () => {
+    await deleteDirectoryDeprovisionEvidence([integrationId])
     await query(`DELETE FROM user_orgs WHERE user_id = ANY($1::text[])`, [[departedUser, activeUser]])
     await query(`DELETE FROM user_external_auth_grants WHERE local_user_id = $1`, [departedUser])
     await query(`DELETE FROM directory_accounts WHERE integration_id = $1`, [integrationId]) // links cascade

--- a/packages/core-backend/tests/integration/attendance-w4pre1c-departure-sweep-deprovision.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-w4pre1c-departure-sweep-deprovision.db.test.ts
@@ -119,6 +119,7 @@ function armMockDirectory(fixture: Fixture): void {
 
 async function cleanupFixture(fixture: Fixture): Promise<void> {
   await query(`DELETE FROM directory_sync_alerts WHERE integration_id = $1`, [fixture.integrationId])
+  await query(`DELETE FROM directory_deprovision_events WHERE integration_id = $1`, [fixture.integrationId])
   await query(`DELETE FROM directory_sync_runs WHERE integration_id = $1`, [fixture.integrationId])
   await query(
     `DELETE FROM directory_account_links WHERE directory_account_id IN (SELECT id FROM directory_accounts WHERE integration_id = $1)`,
@@ -208,6 +209,98 @@ describeIfDatabase('W4-PRE-1c case ① — real sync sweep composed with the dep
 
       const user = await query<{ is_active: boolean }>(`SELECT is_active FROM users WHERE id = $1`, [fixture.localUserId])
       expect(user.rows[0].is_active).toBe(false)
+
+      // D4 orchestration pin: the production sync passed its own transaction client and real
+      // run id into the writer. A second transaction or synthetic run cannot satisfy this readback.
+      const evidence = await query<{
+        effect_count: number
+        run_id: string
+      }>(
+        `SELECT event.run_id::text,
+                COUNT(effect.id)::int AS effect_count
+           FROM directory_deprovision_events event
+           JOIN directory_deprovision_effects effect ON effect.event_id = event.id
+          WHERE event.local_user_id = $1
+          GROUP BY event.run_id`,
+        [fixture.localUserId],
+      )
+      expect(evidence.rows).toEqual([
+        { effect_count: 2, run_id: result.run.id },
+      ])
+    }, 30_000)
+  })
+
+  describe('D4 fail-last evidence write rolls the production sync transaction back', () => {
+    let fixture: Fixture
+    const triggerName = `d4_fail_event_trigger_${TS}`
+    const functionName = `d4_fail_event_function_${TS}`
+
+    afterAll(async () => {
+      await query(`DROP TRIGGER IF EXISTS ${triggerName} ON directory_deprovision_events`)
+      await query(`DROP FUNCTION IF EXISTS ${functionName}()`)
+      if (fixture) await cleanupFixture(fixture)
+      delete process.env.DIRECTORY_DEPROVISION_ENABLED
+    })
+
+    it('rolls back the account sweep and every access write when the ledger INSERT fails', async () => {
+      fixture = await seedDepartureFixture('ledger-fail')
+      armMockDirectory(fixture)
+      process.env.DIRECTORY_DEPROVISION_ENABLED = 'true'
+      await query(`
+        CREATE FUNCTION ${functionName}()
+        RETURNS trigger AS $$
+        BEGIN
+          IF NEW.local_user_id = '${fixture.localUserId}' THEN
+            RAISE EXCEPTION 'D4 deterministic ledger failure';
+          END IF;
+          RETURN NEW;
+        END;
+        $$ LANGUAGE plpgsql
+      `)
+      await query(`
+        CREATE TRIGGER ${triggerName}
+        BEFORE INSERT ON directory_deprovision_events
+        FOR EACH ROW EXECUTE FUNCTION ${functionName}()
+      `)
+
+      try {
+        await expect(
+          syncDirectoryIntegration(
+            fixture.integrationId,
+            'system:w4pre1c-d4-ledger-fail',
+            'manual',
+          ),
+        ).rejects.toThrow('D4 deterministic ledger failure')
+      } finally {
+        await query(`DROP TRIGGER IF EXISTS ${triggerName} ON directory_deprovision_events`)
+        await query(`DROP FUNCTION IF EXISTS ${functionName}()`)
+      }
+
+      const account = await query<{ is_active: boolean }>(
+        `SELECT is_active FROM directory_accounts WHERE id = $1`,
+        [fixture.accountId],
+      )
+      expect(account.rows[0].is_active).toBe(true)
+      await expect(
+        membershipIsActive(fixture.localUserId, fixture.orgId),
+      ).resolves.toBe(true)
+      const user = await query<{ access_generation: string; is_active: boolean }>(
+        `SELECT access_generation::text, is_active FROM users WHERE id = $1`,
+        [fixture.localUserId],
+      )
+      expect(user.rows[0]).toEqual({ access_generation: '0', is_active: true })
+      const evidence = await query<{ count: string }>(
+        `SELECT COUNT(*)::text AS count
+           FROM directory_deprovision_events
+          WHERE local_user_id = $1`,
+        [fixture.localUserId],
+      )
+      expect(evidence.rows[0].count).toBe('0')
+      const runs = await listDirectorySyncRuns(fixture.integrationId, {
+        limit: 1,
+        offset: 0,
+      })
+      expect(runs.items[0]?.status).toBe('failed')
     }, 30_000)
   })
 })

--- a/packages/core-backend/tests/integration/attendance-w4pre1c-manual-review-pending.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-w4pre1c-manual-review-pending.db.test.ts
@@ -1,6 +1,10 @@
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
 import { query } from '../../src/db/pg'
 import { applyDirectoryDeprovisionPolicies } from '../../src/directory/directory-sync'
+import {
+  createDirectoryDeprovisionRun,
+  deleteDirectoryDeprovisionEvidence,
+} from '../utils/directory-deprovision-fixtures'
 
 /**
  * W4-PRE-1c item B, owner case ④ ("人工复核") — owner 裁决② (#4522 rev3 review; the only
@@ -27,6 +31,7 @@ const uid = (name: string) => `w4pre1cmr-${name}-${TS}`
 describeIfDatabase('W4-PRE-1c case ④ — manual_review keeps membership ACTIVE and exposes a pending-confirmation state (real DB)', () => {
   let integrationId = ''
   let orgId = ''
+  let runId = ''
 
   const client = {
     query: (sql: string, params?: unknown[]) =>
@@ -46,9 +51,11 @@ describeIfDatabase('W4-PRE-1c case ④ — manual_review keeps membership ACTIVE
     )).rows[0]
     integrationId = row.id
     orgId = row.org_id
+    runId = await createDirectoryDeprovisionRun(integrationId)
   })
 
   afterEach(async () => {
+    await deleteDirectoryDeprovisionEvidence([integrationId])
     await query(`DELETE FROM user_external_auth_grants WHERE local_user_id LIKE $1`, [`w4pre1cmr-%-${TS}`])
     await query(`DELETE FROM user_orgs WHERE user_id LIKE $1`, [`w4pre1cmr-%-${TS}`])
     await query(`DELETE FROM directory_accounts WHERE integration_id = $1`, [integrationId]) // links cascade
@@ -77,6 +84,8 @@ describeIfDatabase('W4-PRE-1c case ④ — manual_review keeps membership ACTIVE
 
     const outcome = await applyDirectoryDeprovisionPolicies(client, {
       integrationId,
+      runId,
+      triggeredBy: 'test:w4pre1c-manual-review',
       deactivatedAccountIds: [accountId],
       syncedAccountCount: 50,
       integrationDefaultPolicy: 'manual_review',
@@ -121,6 +130,8 @@ describeIfDatabase('W4-PRE-1c case ④ — manual_review keeps membership ACTIVE
 
     const outcome = await applyDirectoryDeprovisionPolicies(client, {
       integrationId,
+      runId,
+      triggeredBy: 'test:w4pre1c-manual-review',
       deactivatedAccountIds: [accountId],
       syncedAccountCount: 50,
       integrationDefaultPolicy: 'mark_inactive',
@@ -152,6 +163,8 @@ describeIfDatabase('W4-PRE-1c case ④ — manual_review keeps membership ACTIVE
 
     const outcome = await applyDirectoryDeprovisionPolicies(client, {
       integrationId,
+      runId,
+      triggeredBy: 'test:w4pre1c-manual-review',
       deactivatedAccountIds: [accountId],
       syncedAccountCount: 50,
       integrationDefaultPolicy: 'manual_review',

--- a/packages/core-backend/tests/integration/attendance-w4pre1d-departure-candidate-split.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-w4pre1d-departure-candidate-split.db.test.ts
@@ -1,6 +1,10 @@
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
 import { query } from '../../src/db/pg'
 import { applyDirectoryDeprovisionPolicies } from '../../src/directory/directory-sync'
+import {
+  createDirectoryDeprovisionRun,
+  deleteDirectoryDeprovisionEvidence,
+} from '../utils/directory-deprovision-fixtures'
 
 /**
  * W4-PRE-1d — candidate-set split (owner P1/P2, #4530 review, issuecomment-5043752399,
@@ -38,6 +42,8 @@ describeIfDatabase('W4-PRE-1d — org-membership vs global candidate-set split (
   let integrationB = ''
   let orgA = ''
   let orgB = ''
+  let runA = ''
+  let runB = ''
 
   const client = {
     query: (sql: string, params?: unknown[]) =>
@@ -111,9 +117,12 @@ describeIfDatabase('W4-PRE-1d — org-membership vs global candidate-set split (
       [`w4pre1d-b-${TS}`, `w4pre1d-corp-b-${TS}`, `w4pre1d-org-b-${TS}`],
     )).rows[0].id
     orgB = `w4pre1d-org-b-${TS}`
+    runA = await createDirectoryDeprovisionRun(integrationA)
+    runB = await createDirectoryDeprovisionRun(integrationB)
   })
 
   afterEach(async () => {
+    await deleteDirectoryDeprovisionEvidence([integrationA, integrationB])
     await query(`DELETE FROM user_external_auth_grants WHERE local_user_id LIKE $1`, [`w4pre1d-%-${TS}`])
     await query(`DELETE FROM user_orgs WHERE user_id LIKE $1`, [`w4pre1d-%-${TS}`])
     await query(`DELETE FROM directory_accounts WHERE integration_id = ANY($1::uuid[])`, [[integrationA, integrationB]]) // links cascade
@@ -133,6 +142,8 @@ describeIfDatabase('W4-PRE-1d — org-membership vs global candidate-set split (
 
       const outcome = await applyDirectoryDeprovisionPolicies(client, {
         integrationId: integrationA,
+        runId: runA,
+        triggeredBy: 'test:w4pre1d-candidate-split',
         deactivatedAccountIds: [departedA],
         syncedAccountCount: 50,
         integrationDefaultPolicy: 'mark_inactive',
@@ -164,6 +175,8 @@ describeIfDatabase('W4-PRE-1d — org-membership vs global candidate-set split (
 
       const outcome = await applyDirectoryDeprovisionPolicies(client, {
         integrationId: integrationA,
+        runId: runA,
+        triggeredBy: 'test:w4pre1d-candidate-split',
         deactivatedAccountIds: [departedA],
         syncedAccountCount: 50,
         integrationDefaultPolicy: 'disable_grant_only',
@@ -192,6 +205,8 @@ describeIfDatabase('W4-PRE-1d — org-membership vs global candidate-set split (
       // Run 1: A departs while B is still active — same as case① above.
       const first = await applyDirectoryDeprovisionPolicies(client, {
         integrationId: integrationA,
+        runId: runA,
+        triggeredBy: 'test:w4pre1d-candidate-split',
         deactivatedAccountIds: [departedA],
         syncedAccountCount: 50,
         integrationDefaultPolicy: 'mark_inactive',
@@ -205,6 +220,8 @@ describeIfDatabase('W4-PRE-1d — org-membership vs global candidate-set split (
       await query(`UPDATE directory_accounts SET is_active = false WHERE id = $1`, [bindingB])
       const second = await applyDirectoryDeprovisionPolicies(client, {
         integrationId: integrationB,
+        runId: runB,
+        triggeredBy: 'test:w4pre1d-candidate-split',
         deactivatedAccountIds: [bindingB],
         syncedAccountCount: 50,
         integrationDefaultPolicy: 'mark_inactive',
@@ -230,6 +247,8 @@ describeIfDatabase('W4-PRE-1d — org-membership vs global candidate-set split (
 
       await applyDirectoryDeprovisionPolicies(client, {
         integrationId: integrationA,
+        runId: runA,
+        triggeredBy: 'test:w4pre1d-candidate-split',
         deactivatedAccountIds: [departedA],
         syncedAccountCount: 50,
         integrationDefaultPolicy: 'disable_grant_only',
@@ -241,6 +260,8 @@ describeIfDatabase('W4-PRE-1d — org-membership vs global candidate-set split (
       await query(`UPDATE directory_accounts SET is_active = false WHERE id = $1`, [bindingB])
       const second = await applyDirectoryDeprovisionPolicies(client, {
         integrationId: integrationB,
+        runId: runB,
+        triggeredBy: 'test:w4pre1d-candidate-split',
         deactivatedAccountIds: [bindingB],
         syncedAccountCount: 50,
         integrationDefaultPolicy: 'disable_grant_only',
@@ -285,6 +306,8 @@ describeIfDatabase('W4-PRE-1d — org-membership vs global candidate-set split (
 
         const outcome = await applyDirectoryDeprovisionPolicies(client, {
           integrationId: integrationA,
+          runId: runA,
+          triggeredBy: 'test:w4pre1d-candidate-split',
           deactivatedAccountIds: departedIds,
           syncedAccountCount: 50,
           integrationDefaultPolicy: 'mark_inactive',
@@ -318,6 +341,8 @@ describeIfDatabase('W4-PRE-1d — org-membership vs global candidate-set split (
 
       const outcome = await applyDirectoryDeprovisionPolicies(client, {
         integrationId: integrationA,
+        runId: runA,
+        triggeredBy: 'test:w4pre1d-candidate-split',
         deactivatedAccountIds: [departedA],
         syncedAccountCount: 50,
         integrationDefaultPolicy: 'manual_review',
@@ -344,6 +369,8 @@ describeIfDatabase('W4-PRE-1d — org-membership vs global candidate-set split (
 
       const outcome = await applyDirectoryDeprovisionPolicies(client, {
         integrationId: integrationA,
+        runId: runA,
+        triggeredBy: 'test:w4pre1d-candidate-split',
         deactivatedAccountIds: [departedA],
         syncedAccountCount: 50,
         integrationDefaultPolicy: 'mark_inactive',

--- a/packages/core-backend/tests/integration/directory-deprovision-race-supersede.db.test.ts
+++ b/packages/core-backend/tests/integration/directory-deprovision-race-supersede.db.test.ts
@@ -112,7 +112,12 @@ describeIfDatabase('D4 writer two-connection goldens (race + supersede, real DB)
       await holder.query('BEGIN')
       await holder.query(`SELECT id FROM users WHERE id = $1 FOR UPDATE`, [seeded.userId])
 
-      // Connection 2 starts the real writer; it must BLOCK on that lock.
+      // Connection 2 starts the real writer; it must BLOCK on that lock. Its backend pid is
+      // captured BEFORE the writer starts (a blocked connection cannot answer), so the barrier
+      // below waits on THIS writer specifically, not on any waiter in the cluster.
+      const writerPid = Number(
+        (await writer.query('SELECT pg_backend_pid() AS pid')).rows[0]?.pid,
+      )
       await writer.query('BEGIN')
       const writerRun = (async () => {
         const result = await applyDirectoryDeprovisionCandidate(
@@ -130,8 +135,9 @@ describeIfDatabase('D4 writer two-connection goldens (race + supersede, real DB)
         const waiting = await holder.query(
           `SELECT count(*)::int AS n
              FROM pg_locks blocked
-             JOIN pg_stat_activity blocked_activity ON blocked_activity.pid = blocked.pid
-            WHERE NOT blocked.granted`,
+            WHERE NOT blocked.granted
+              AND blocked.pid = $1`,
+          [writerPid],
         )
         waiters = Number(waiting.rows[0]?.n ?? 0)
         if (waiters === 0) await new Promise((resolve) => setTimeout(resolve, 50))

--- a/packages/core-backend/tests/integration/directory-deprovision-race-supersede.db.test.ts
+++ b/packages/core-backend/tests/integration/directory-deprovision-race-supersede.db.test.ts
@@ -1,0 +1,254 @@
+import pg from 'pg'
+import { randomUUID } from 'node:crypto'
+import { afterAll, beforeEach, describe, expect, it } from 'vitest'
+import { query } from '../../src/db/pg'
+import { applyDirectoryDeprovisionCandidate } from '../../src/directory/deprovision-ledger'
+
+/**
+ * §11 two-connection goldens for the D4 writer — the tests whose absence let the
+ * adversarial-review P1 through.
+ *
+ * That P1, proved with this exact race: candidacy used to be read by the SAME statement that
+ * acquired the `users FOR UPDATE` lock. Under READ COMMITTED the statement's subqueries evaluate
+ * on the pre-wait snapshot (EPQ refreshes only the locked row itself), so a cross-org rehire
+ * committing while the writer waited was invisible — the person was platform-deactivated, the
+ * grant revoked, and the event recorded `globally_clear=true`: false evidence.
+ *
+ * Test 1 reconstructs that interleaving deterministically (a second connection holds the lock,
+ * the writer is proven BLOCKED via pg_locks, the rehire commits, the lock releases) and pins the
+ * post-fix behaviour. It kills BOTH mutations the review ran: remove the mutex (the writer no
+ * longer blocks, reads the pre-rehire world, revokes the grant → red) and re-fuse lock+read into
+ * one statement (stale snapshot → same red).
+ *
+ * Test 2 pins §5.4's two legs — a newer event must supersede open effects AND bump the
+ * generation; deleting either leg alone reds it.
+ */
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const PREFIX = `d4-race-${Date.now()}`
+
+async function cleanup(): Promise<void> {
+  await query(`DELETE FROM directory_deprovision_events WHERE local_user_id LIKE $1`, [`${PREFIX}-%`])
+  await query(`DELETE FROM user_external_auth_grants WHERE local_user_id LIKE $1`, [`${PREFIX}-%`])
+  await query(`DELETE FROM user_orgs WHERE user_id LIKE $1`, [`${PREFIX}-%`])
+  await query(`DELETE FROM directory_integrations WHERE org_id LIKE $1`, [`${PREFIX}-%`])
+  await query(`DELETE FROM users WHERE id LIKE $1`, [`${PREFIX}-%`])
+}
+
+type Seeded = {
+  userId: string
+  orgId: string
+  integrationId: string
+  accountId: string
+  runId: string
+}
+
+async function seed(tag: string): Promise<Seeded> {
+  const userId = `${PREFIX}-${tag}-user`
+  const orgId = `${PREFIX}-${tag}-org`
+  await query(
+    `INSERT INTO users (id, email, name, password_hash, is_active, activation_status, access_generation)
+     VALUES ($1, $2, 'Race', 'x', TRUE, 'activated', 0)`,
+    [userId, `${tag}-${randomUUID()}@example.com`],
+  )
+  await query(`INSERT INTO user_orgs (user_id, org_id, is_active) VALUES ($1, $2, TRUE)`, [userId, orgId])
+  await query(
+    `INSERT INTO user_external_auth_grants (provider, local_user_id, enabled, granted_by)
+     VALUES ('dingtalk', $1, TRUE, 'seed')`,
+    [userId],
+  )
+  const integ = await query<{ id: string }>(
+    `INSERT INTO directory_integrations (name, corp_id, org_id, status, default_deprovision_policy)
+     VALUES ($1, $2, $3, 'active', 'mark_inactive') RETURNING id::text AS id`,
+    [`${PREFIX}-${tag}`, `corp-${tag}`, orgId],
+  )
+  const acct = await query<{ id: string }>(
+    `INSERT INTO directory_accounts (integration_id, provider, external_user_id, external_key, name, is_active)
+     VALUES ($1::uuid, 'dingtalk', $2, $3, 'Race', FALSE) RETURNING id::text AS id`,
+    [integ.rows[0].id, `ext-${tag}`, `dingtalk:${tag}:${randomUUID()}`],
+  )
+  await query(
+    `INSERT INTO directory_account_links (directory_account_id, local_user_id, link_status)
+     VALUES ($1::uuid, $2, 'linked')`,
+    [acct.rows[0].id, userId],
+  )
+  const run = await query<{ id: string }>(
+    `INSERT INTO directory_sync_runs (integration_id, status, triggered_by)
+     VALUES ($1::uuid, 'running', 'test') RETURNING id::text AS id`,
+    [integ.rows[0].id],
+  )
+  return {
+    userId,
+    orgId,
+    integrationId: integ.rows[0].id,
+    accountId: acct.rows[0].id,
+    runId: run.rows[0].id,
+  }
+}
+
+const applyInput = (seeded: Seeded, write: boolean) => ({
+  localUserId: seeded.userId,
+  orgId: seeded.orgId,
+  integrationId: seeded.integrationId,
+  directoryAccountId: seeded.accountId,
+  runId: seeded.runId,
+  triggeredBy: 'test',
+  policy: 'mark_inactive' as const,
+  write,
+})
+
+describeIfDatabase('D4 writer two-connection goldens (race + supersede, real DB)', () => {
+  beforeEach(cleanup)
+  afterAll(cleanup)
+
+  it('a cross-org rehire committing while the writer waits on the mutex flips globally-clear OFF before any grant/user write', async () => {
+    const seeded = await seed('rehire')
+
+    const holder = new pg.Client({ connectionString: process.env.DATABASE_URL })
+    const writer = new pg.Client({ connectionString: process.env.DATABASE_URL })
+    await holder.connect()
+    await writer.connect()
+    try {
+      // Connection 1 takes the canonical per-user mutex and holds it.
+      await holder.query('BEGIN')
+      await holder.query(`SELECT id FROM users WHERE id = $1 FOR UPDATE`, [seeded.userId])
+
+      // Connection 2 starts the real writer; it must BLOCK on that lock.
+      await writer.query('BEGIN')
+      const writerRun = (async () => {
+        const result = await applyDirectoryDeprovisionCandidate(
+          { query: (sql, params) => writer.query(sql, params as unknown[]) },
+          applyInput(seeded, true),
+        )
+        await writer.query('COMMIT')
+        return result
+      })()
+
+      // Deterministic barrier: wait until the writer's lock wait is VISIBLE in pg_locks —
+      // never a sleep-and-hope (async-settle discipline).
+      let waiters = 0
+      for (let attempt = 0; attempt < 100 && waiters === 0; attempt += 1) {
+        const waiting = await holder.query(
+          `SELECT count(*)::int AS n
+             FROM pg_locks blocked
+             JOIN pg_stat_activity blocked_activity ON blocked_activity.pid = blocked.pid
+            WHERE NOT blocked.granted`,
+        )
+        waiters = Number(waiting.rows[0]?.n ?? 0)
+        if (waiters === 0) await new Promise((resolve) => setTimeout(resolve, 50))
+      }
+      expect(waiters).toBeGreaterThan(0)
+
+      // While the writer is provably blocked: a cross-org rehire commits — a NEW active linked
+      // account in a DIFFERENT integration. After this, the person is NOT globally clear.
+      const integB = await holder.query(
+        `INSERT INTO directory_integrations (name, corp_id, org_id, status, default_deprovision_policy)
+         VALUES ($1, $2, $3, 'active', 'manual_review') RETURNING id`,
+        [`${PREFIX}-rehire-b`, 'corp-rehire-b', `${PREFIX}-rehire-org-b`],
+      )
+      const acctB = await holder.query(
+        `INSERT INTO directory_accounts (integration_id, provider, external_user_id, external_key, name, is_active)
+         VALUES ($1, 'dingtalk', 'ext-b', $2, 'Race', TRUE) RETURNING id`,
+        [integB.rows[0].id, `dingtalk:rehire-b:${randomUUID()}`],
+      )
+      await holder.query(
+        `INSERT INTO directory_account_links (directory_account_id, local_user_id, link_status)
+         VALUES ($1, $2, 'linked')`,
+        [acctB.rows[0].id, seeded.userId],
+      )
+      await holder.query('COMMIT') // releases the mutex; the writer proceeds
+
+      const result = await writerRun
+
+      // The writer's post-lock re-read MUST see the rehire: org-A membership still deactivates
+      // (org-scoped), but the grant and the platform account survive, and the evidence says so.
+      expect(result.applied).toBe(true)
+      expect(result.globallyClear).toBe(false)
+      expect(result.plan.effects.map((effect) => effect.type)).toEqual(['membership_changed'])
+
+      const user = await query<{ is_active: boolean }>(
+        `SELECT is_active FROM users WHERE id = $1`, [seeded.userId])
+      expect(user.rows[0]?.is_active).toBe(true)
+      const grant = await query<{ enabled: boolean }>(
+        `SELECT enabled FROM user_external_auth_grants WHERE local_user_id = $1`, [seeded.userId])
+      expect(grant.rows[0]?.enabled).toBe(true)
+      const membership = await query<{ is_active: boolean }>(
+        `SELECT is_active FROM user_orgs WHERE user_id = $1 AND org_id = $2`,
+        [seeded.userId, seeded.orgId])
+      expect(membership.rows[0]?.is_active).toBe(false)
+
+      const event = await query<{ globally_clear: boolean }>(
+        `SELECT globally_clear FROM directory_deprovision_events WHERE local_user_id = $1`,
+        [seeded.userId])
+      expect(event.rows).toHaveLength(1)
+      expect(event.rows[0]?.globally_clear).toBe(false)
+      const effects = await query<{ effect_type: string }>(
+        `SELECT effect_type FROM directory_deprovision_effects WHERE local_user_id = $1`,
+        [seeded.userId])
+      expect(effects.rows.map((row) => row.effect_type)).toEqual(['membership_changed'])
+    } finally {
+      await holder.end()
+      await writer.end()
+    }
+  })
+
+  it('a newer event supersedes open effects AND bumps the generation (§5.4 — both legs, not one)', async () => {
+    const seeded = await seed('supersede')
+
+    // First deprovision: full mark_inactive → 3 effects at generation 1.
+    const runCandidate = async (runId: string) => {
+      const client = new pg.Client({ connectionString: process.env.DATABASE_URL })
+      await client.connect()
+      try {
+        await client.query('BEGIN')
+        const result = await applyDirectoryDeprovisionCandidate(
+          { query: (sql, params) => client.query(sql, params as unknown[]) },
+          { ...applyInput(seeded, true), runId },
+        )
+        await client.query('COMMIT')
+        return result
+      } finally {
+        await client.end()
+      }
+    }
+
+    const first = await runCandidate(seeded.runId)
+    expect(first.applied).toBe(true)
+    const firstGeneration = first.accessGeneration
+
+    // Rehire in the SAME org: reactivate user/account/membership/grant, new run.
+    await query(`UPDATE users SET is_active = TRUE WHERE id = $1`, [seeded.userId])
+    await query(`UPDATE user_orgs SET is_active = TRUE WHERE user_id = $1`, [seeded.userId])
+    await query(`UPDATE user_external_auth_grants SET enabled = TRUE WHERE local_user_id = $1`, [seeded.userId])
+    await query(`UPDATE directory_accounts SET is_active = FALSE WHERE id = $1::uuid`, [seeded.accountId])
+    // `uq_directory_sync_runs_one_running_per_integration`: only one 'running' run per
+    // integration, so the second run enters as a finished one (the event trigger checks the run
+    // exists and matches the integration, not its status).
+    const runB = await query<{ id: string }>(
+      `INSERT INTO directory_sync_runs (integration_id, status, triggered_by)
+       VALUES ($1::uuid, 'success', 'test') RETURNING id::text AS id`,
+      [seeded.integrationId],
+    )
+
+    // Second deprovision for the same person.
+    const second = await runCandidate(runB.rows[0].id)
+    expect(second.applied).toBe(true)
+
+    // Leg 1: the first event's rows are superseded — replaying their `before` would overwrite
+    // the newer decision, so they must stop being restore targets.
+    const firstEvent = await query<{ status: string }>(
+      `SELECT status FROM directory_deprovision_events WHERE id = $1::uuid`,
+      [first.eventId])
+    expect(firstEvent.rows[0]?.status).toBe('superseded')
+    const firstEffects = await query<{ status: string }>(
+      `SELECT DISTINCT status FROM directory_deprovision_effects WHERE event_id = $1::uuid`,
+      [first.eventId])
+    expect(firstEffects.rows.map((row) => row.status)).toEqual(['superseded'])
+
+    // Leg 2: the generation moved strictly forward — equal generations would let a stale
+    // restore pass the §5.4 eligibility check.
+    expect(second.accessGeneration).toBeGreaterThan(firstGeneration)
+    const userGeneration = await query<{ g: number }>(
+      `SELECT access_generation::int AS g FROM users WHERE id = $1`, [seeded.userId])
+    expect(userGeneration.rows[0]?.g).toBe(second.accessGeneration)
+  })
+})

--- a/packages/core-backend/tests/integration/directory-deprovision-selection.db.test.ts
+++ b/packages/core-backend/tests/integration/directory-deprovision-selection.db.test.ts
@@ -128,8 +128,13 @@ describeIfDatabase('DT-OPS-01 deprovision selection (real DB)', () => {
     expect(outcome.candidateCount).toBe(1)
     expect(outcome.usersDeactivatedCount).toBe(1)
     await expect(isUserActive(user)).resolves.toBe(false)
-    // No grant row existed, so there is no grant transition or grant effect to invent.
-    await expect(grantEnabled(user)).resolves.toBeUndefined()
+    // No grant row existed, so the LEDGER records no grant effect (nothing was taken away) —
+    // but the bookkeeping upsert still leaves an explicit DISABLED row. That row is load-bearing:
+    // dingtalk-oauth's ensureGrant path is INSERT ... enabled=TRUE ... ON CONFLICT DO NOTHING, so
+    // a departed person with NO row would be silently re-granted on their next OAuth attempt;
+    // the explicit disabled row is what makes that a no-op. (Also pinned by the orchestration
+    // suite's OPS-01 test — the run-effect shape has been this since DT-OPS-01.)
+    await expect(grantEnabled(user)).resolves.toBe(false)
   })
 
   // P1-1. The rehire. `directory_account_links` is unique on the ACCOUNT, not the person.

--- a/packages/core-backend/tests/integration/directory-deprovision-selection.db.test.ts
+++ b/packages/core-backend/tests/integration/directory-deprovision-selection.db.test.ts
@@ -1,6 +1,10 @@
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
 import { query } from '../../src/db/pg'
 import { applyDirectoryDeprovisionPolicies } from '../../src/directory/directory-sync'
+import {
+  createDirectoryDeprovisionRun,
+  deleteDirectoryDeprovisionEvidence,
+} from '../utils/directory-deprovision-fixtures'
 
 /**
  * DT-OPS-01 — who loses access, proved against the REAL migrated tables.
@@ -30,6 +34,7 @@ const uid = (name: string) => `dtdep-${name}-${TS}`
 describeIfDatabase('DT-OPS-01 deprovision selection (real DB)', () => {
   let integrationA = ''
   let integrationB = ''
+  let runA = ''
 
   const client = {
     query: (sql: string, params?: unknown[]) =>
@@ -40,6 +45,8 @@ describeIfDatabase('DT-OPS-01 deprovision selection (real DB)', () => {
     integrationDefaultPolicy: 'mark_inactive',
     syncedAccountCount: 100,
     enabled: true,
+    runId: '',
+    triggeredBy: 'test:directory-deprovision-selection',
   }
 
   /** Creates a user (if new) plus one linked directory account. Returns the account id. */
@@ -88,10 +95,13 @@ describeIfDatabase('DT-OPS-01 deprovision selection (real DB)', () => {
       `INSERT INTO directory_integrations (name, corp_id) VALUES ($1, $2) RETURNING id::text AS id`,
       [`dtdep-b-${TS}`, `dtdep-corp-b-${TS}`],
     )).rows[0].id
+    runA = await createDirectoryDeprovisionRun(integrationA)
+    baseOptions.runId = runA
   })
 
   // Every scenario owns its people; wipe between tests so a leaked write cannot pass the next one.
   afterEach(async () => {
+    await deleteDirectoryDeprovisionEvidence([integrationA, integrationB])
     await query(`DELETE FROM user_external_auth_grants WHERE local_user_id LIKE $1`, [`dtdep-%-${TS}`])
     await query(
       `DELETE FROM directory_accounts WHERE integration_id = ANY($1::uuid[])`,
@@ -118,7 +128,8 @@ describeIfDatabase('DT-OPS-01 deprovision selection (real DB)', () => {
     expect(outcome.candidateCount).toBe(1)
     expect(outcome.usersDeactivatedCount).toBe(1)
     await expect(isUserActive(user)).resolves.toBe(false)
-    await expect(grantEnabled(user)).resolves.toBe(false)
+    // No grant row existed, so there is no grant transition or grant effect to invent.
+    await expect(grantEnabled(user)).resolves.toBeUndefined()
   })
 
   // P1-1. The rehire. `directory_account_links` is unique on the ACCOUNT, not the person.
@@ -249,6 +260,12 @@ describeIfDatabase('DT-OPS-01 deprovision selection (real DB)', () => {
   it('disable_grant_only revokes DingTalk login and leaves the local account alive', async () => {
     const user = uid('grantonly')
     const departed = await seedAccount({ userId: user, accountActive: false })
+    await query(
+      `INSERT INTO user_external_auth_grants (
+         provider, local_user_id, enabled, granted_by, created_at, updated_at
+       ) VALUES ('dingtalk', $1, TRUE, 'test:directory-deprovision-selection', NOW(), NOW())`,
+      [user],
+    )
 
     const outcome = await applyDirectoryDeprovisionPolicies(client, {
       ...baseOptions,

--- a/packages/core-backend/tests/integration/directory-deprovision-writer-ledger.db.test.ts
+++ b/packages/core-backend/tests/integration/directory-deprovision-writer-ledger.db.test.ts
@@ -473,37 +473,41 @@ describeIfDatabase(
       expect(evidence.rows[0].count).toBe('0')
     })
 
-    it('rejects a direct writer call when the source account is no longer inactive', async () => {
+    it('skips (without writing or aborting) a direct writer call when the source account is no longer inactive', async () => {
       const seeded = await seedDirectory({ grantEnabled: true })
       await query(
         `UPDATE directory_accounts SET is_active = TRUE WHERE id = $1::uuid`,
         [seeded.accountId],
       )
 
-      await expect(
-        transaction(async (client) =>
-          applyDirectoryDeprovisionCandidate(
-            {
-              query: async (statement, params) => {
-                const result = await client.query(statement, params)
-                return { rows: result.rows as Array<Record<string, unknown>> }
-              },
+      // Adversarial-review P2 absorption: this used to THROW, which aborted the ENTIRE directory
+      // sync transaction for a per-candidate race — and did so even with the deprovision flag
+      // OFF. The contract is now a skip: the invariant under test is unchanged (a re-activated
+      // source must never be deprovisioned — zero writes below), only the failure mode moved
+      // from run-fatal to candidate-scoped.
+      const result = await transaction(async (client) =>
+        applyDirectoryDeprovisionCandidate(
+          {
+            query: async (statement, params) => {
+              const result = await client.query(statement, params)
+              return { rows: result.rows as Array<Record<string, unknown>> }
             },
-            {
-              localUserId: seeded.userId,
-              orgId: seeded.orgId,
-              integrationId: seeded.integrationId,
-              directoryAccountId: seeded.accountId,
-              runId: seeded.runId,
-              triggeredBy: 'test:d4-direct-writer',
-              policy: 'mark_inactive',
-              write: true,
-            },
-          ),
+          },
+          {
+            localUserId: seeded.userId,
+            orgId: seeded.orgId,
+            integrationId: seeded.integrationId,
+            directoryAccountId: seeded.accountId,
+            runId: seeded.runId,
+            triggeredBy: 'test:d4-direct-writer',
+            policy: 'mark_inactive',
+            write: true,
+          },
         ),
-      ).rejects.toThrow(
-        'directory deprovision source account is no longer linked to the candidate user',
       )
+      expect(result.applied).toBe(false)
+      expect(result.skipReason).toBe('candidate_vanished')
+      expect(result.plan.effects).toEqual([])
 
       const user = await query<{
         access_generation: string

--- a/packages/core-backend/tests/integration/directory-deprovision-writer-ledger.db.test.ts
+++ b/packages/core-backend/tests/integration/directory-deprovision-writer-ledger.db.test.ts
@@ -1,0 +1,554 @@
+import { randomUUID } from 'node:crypto'
+import { afterAll, beforeEach, describe, expect, it } from 'vitest'
+import { query, transaction } from '../../src/db/pg'
+import { applyDirectoryDeprovisionCandidate } from '../../src/directory/deprovision-ledger'
+import { applyDirectoryDeprovisionPolicies } from '../../src/directory/directory-sync'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const TS = Date.now()
+const PREFIX = `d4-writer-${TS}`
+
+type SeededDirectory = {
+  accountId: string
+  integrationId: string
+  orgId: string
+  runId: string
+  userId: string
+}
+
+async function cleanup(): Promise<void> {
+  await query(
+    `DELETE FROM directory_deprovision_events
+      WHERE local_user_id LIKE $1`,
+    [`${PREFIX}-%`],
+  )
+  await query(
+    `DELETE FROM user_external_auth_grants
+      WHERE local_user_id LIKE $1`,
+    [`${PREFIX}-%`],
+  )
+  await query(`DELETE FROM user_orgs WHERE user_id LIKE $1`, [`${PREFIX}-%`])
+  await query(`DELETE FROM directory_integrations WHERE org_id LIKE $1`, [
+    `${PREFIX}-%`,
+  ])
+  await query(`DELETE FROM users WHERE id LIKE $1`, [`${PREFIX}-%`])
+}
+
+async function seedDirectory(
+  options: {
+    grantEnabled?: boolean
+    membershipActive?: boolean
+    policy?: 'manual_review' | 'disable_grant_only' | 'mark_inactive'
+  } = {},
+): Promise<SeededDirectory> {
+  const orgId = `${PREFIX}-org-${randomUUID()}`
+  const userId = `${PREFIX}-user-${randomUUID()}`
+  const integration = await query<{ id: string }>(
+    `INSERT INTO directory_integrations (
+       name, corp_id, org_id, provider, status, default_deprovision_policy
+     ) VALUES ($1, $2, $3, 'dingtalk', 'active', $4)
+     RETURNING id::text AS id`,
+    [
+      `${PREFIX}-integration-${randomUUID()}`,
+      `${PREFIX}-corp-${randomUUID()}`,
+      orgId,
+      options.policy ?? 'mark_inactive',
+    ],
+  )
+  const integrationId = integration.rows[0].id
+  const run = await query<{ id: string }>(
+    `INSERT INTO directory_sync_runs (
+       integration_id, status, triggered_by, trigger_source
+     ) VALUES ($1::uuid, 'success', 'test:d4-writer', 'manual')
+     RETURNING id::text AS id`,
+    [integrationId],
+  )
+  await query(
+    `INSERT INTO users (
+       id, password_hash, is_active, activation_status, access_generation
+     ) VALUES ($1, 'x', TRUE, 'activated', 7)`,
+    [userId],
+  )
+  if (options.membershipActive !== false) {
+    await query(
+      `INSERT INTO user_orgs (user_id, org_id, is_active)
+       VALUES ($1, $2, TRUE)`,
+      [userId, orgId],
+    )
+  } else {
+    await query(
+      `INSERT INTO user_orgs (user_id, org_id, is_active)
+       VALUES ($1, $2, FALSE)`,
+      [userId, orgId],
+    )
+  }
+  const account = await query<{ id: string }>(
+    `INSERT INTO directory_accounts (
+       integration_id, provider, external_user_id, external_key, name, is_active
+     ) VALUES ($1::uuid, 'dingtalk', $2, $3, 'D4 Writer', FALSE)
+     RETURNING id::text AS id`,
+    [
+      integrationId,
+      `${PREFIX}-external-${randomUUID()}`,
+      `dingtalk:${PREFIX}:${randomUUID()}`,
+    ],
+  )
+  const accountId = account.rows[0].id
+  await query(
+    `INSERT INTO directory_account_links (
+       directory_account_id, local_user_id, link_status
+     ) VALUES ($1::uuid, $2, 'linked')`,
+    [accountId, userId],
+  )
+  if (options.grantEnabled === true) {
+    await query(
+      `INSERT INTO user_external_auth_grants (
+         provider, local_user_id, enabled, granted_by, created_at, updated_at
+       ) VALUES ('dingtalk', $1, TRUE, 'test:d4-writer', NOW(), NOW())`,
+      [userId],
+    )
+  }
+  return {
+    accountId,
+    integrationId,
+    orgId,
+    runId: run.rows[0].id,
+    userId,
+  }
+}
+
+async function seedActiveSibling(
+  seeded: SeededDirectory,
+): Promise<{ integrationId: string; orgId: string }> {
+  const orgId = `${PREFIX}-sibling-org-${randomUUID()}`
+  const integration = await query<{ id: string }>(
+    `INSERT INTO directory_integrations (
+       name, corp_id, org_id, provider, status
+     ) VALUES ($1, $2, $3, 'dingtalk', 'active')
+     RETURNING id::text AS id`,
+    [
+      `${PREFIX}-sibling-integration-${randomUUID()}`,
+      `${PREFIX}-sibling-corp-${randomUUID()}`,
+      orgId,
+    ],
+  )
+  const integrationId = integration.rows[0].id
+  const account = await query<{ id: string }>(
+    `INSERT INTO directory_accounts (
+       integration_id, provider, external_user_id, external_key, name, is_active
+     ) VALUES ($1::uuid, 'dingtalk', $2, $3, 'D4 Sibling', TRUE)
+     RETURNING id::text AS id`,
+    [
+      integrationId,
+      `${PREFIX}-sibling-external-${randomUUID()}`,
+      `dingtalk:${PREFIX}:sibling:${randomUUID()}`,
+    ],
+  )
+  await query(
+    `INSERT INTO directory_account_links (
+       directory_account_id, local_user_id, link_status
+     ) VALUES ($1::uuid, $2, 'linked')`,
+    [account.rows[0].id, seeded.userId],
+  )
+  await query(
+    `INSERT INTO user_orgs (user_id, org_id, is_active)
+     VALUES ($1, $2, TRUE)`,
+    [seeded.userId, orgId],
+  )
+  return { integrationId, orgId }
+}
+
+async function apply(
+  seeded: SeededDirectory,
+  options: {
+    enabled?: boolean
+    runId?: string
+  } = {},
+) {
+  return transaction(async (client) =>
+    applyDirectoryDeprovisionPolicies(
+      {
+        query: async (statement, params) => {
+          const result = await client.query(statement, params)
+          return { rows: result.rows as Array<Record<string, unknown>> }
+        },
+      },
+      {
+        integrationId: seeded.integrationId,
+        runId: options.runId ?? seeded.runId,
+        triggeredBy: 'test:d4-writer',
+        deactivatedAccountIds: [seeded.accountId],
+        syncedAccountCount: 1,
+        integrationDefaultPolicy: 'mark_inactive',
+        enabled: options.enabled ?? true,
+      },
+    ),
+  )
+}
+
+describeIfDatabase(
+  'D4 deprovision writer and evidence ledger (real DB)',
+  () => {
+    beforeEach(cleanup)
+    afterAll(cleanup)
+
+    it('commits access-graph changes, generation, event, and typed effects together', async () => {
+      const seeded = await seedDirectory({ grantEnabled: true })
+      const outcome = await apply(seeded)
+
+      expect(outcome.usersDeactivatedCount).toBe(1)
+      expect(outcome.grantsDisabledCount).toBe(1)
+      expect(outcome.membershipDeactivationAttemptedCount).toBe(1)
+
+      const state = await query<{
+        access_generation: string
+        grant_enabled: boolean
+        membership_active: boolean
+        user_active: boolean
+      }>(
+        `SELECT u.is_active AS user_active,
+              u.access_generation::text,
+              m.is_active AS membership_active,
+              g.enabled AS grant_enabled
+         FROM users u
+         JOIN user_orgs m ON m.user_id = u.id AND m.org_id = $2
+         JOIN user_external_auth_grants g
+           ON g.local_user_id = u.id AND g.provider = 'dingtalk'
+        WHERE u.id = $1`,
+        [seeded.userId, seeded.orgId],
+      )
+      expect(state.rows[0]).toMatchObject({
+        access_generation: '8',
+        grant_enabled: false,
+        membership_active: false,
+        user_active: false,
+      })
+
+      const event = await query<{
+        access_generation_at_apply: string
+        directory_account_id: string
+        globally_clear: boolean
+        integration_id: string
+        link_witness_account_id: string
+        link_witness_local_user_id: string
+        local_user_id: string
+        org_id: string
+        policy: string
+        run_id: string
+        status: string
+        triggered_by: string
+      }>(
+        `SELECT org_id, integration_id::text, directory_account_id::text, local_user_id,
+              run_id::text, triggered_by, link_witness_account_id::text,
+              link_witness_local_user_id, policy, globally_clear,
+              access_generation_at_apply::text, status
+         FROM directory_deprovision_events
+        WHERE local_user_id = $1`,
+        [seeded.userId],
+      )
+      expect(event.rows[0]).toEqual({
+        access_generation_at_apply: '8',
+        directory_account_id: seeded.accountId,
+        globally_clear: true,
+        integration_id: seeded.integrationId,
+        link_witness_account_id: seeded.accountId,
+        link_witness_local_user_id: seeded.userId,
+        local_user_id: seeded.userId,
+        org_id: seeded.orgId,
+        policy: 'mark_inactive',
+        run_id: seeded.runId,
+        status: 'applied',
+        triggered_by: 'test:d4-writer',
+      })
+      const effects = await query<{
+        after_active: boolean
+        before_active: boolean
+        effect_type: string
+        org_id: string | null
+        status: string
+      }>(
+        `SELECT effect_type, org_id, before_active, after_active, status
+         FROM directory_deprovision_effects
+        WHERE local_user_id = $1
+        ORDER BY effect_type`,
+        [seeded.userId],
+      )
+      expect(effects.rows).toEqual([
+        {
+          after_active: false,
+          before_active: true,
+          effect_type: 'grant_changed',
+          org_id: null,
+          status: 'applied',
+        },
+        {
+          after_active: false,
+          before_active: true,
+          effect_type: 'membership_changed',
+          org_id: seeded.orgId,
+          status: 'applied',
+        },
+        {
+          after_active: false,
+          before_active: true,
+          effect_type: 'user_changed',
+          org_id: null,
+          status: 'applied',
+        },
+      ])
+    })
+
+    it('deactivates only the source-org membership when another org still has an active binding', async () => {
+      const seeded = await seedDirectory({ grantEnabled: true })
+      const sibling = await seedActiveSibling(seeded)
+      const outcome = await apply(seeded)
+
+      expect(outcome.globalCandidateCount).toBe(0)
+      expect(outcome.usersDeactivatedCount).toBe(0)
+      expect(outcome.grantsDisabledCount).toBe(0)
+      const state = await query<{
+        access_generation: string
+        grant_enabled: boolean
+        sibling_membership_active: boolean
+        source_membership_active: boolean
+        user_active: boolean
+      }>(
+        `SELECT u.is_active AS user_active,
+              u.access_generation::text,
+              source_membership.is_active AS source_membership_active,
+              sibling_membership.is_active AS sibling_membership_active,
+              grant_row.enabled AS grant_enabled
+         FROM users u
+         JOIN user_orgs source_membership
+           ON source_membership.user_id = u.id AND source_membership.org_id = $2
+         JOIN user_orgs sibling_membership
+           ON sibling_membership.user_id = u.id AND sibling_membership.org_id = $3
+         JOIN user_external_auth_grants grant_row
+           ON grant_row.local_user_id = u.id AND grant_row.provider = 'dingtalk'
+        WHERE u.id = $1`,
+        [seeded.userId, seeded.orgId, sibling.orgId],
+      )
+      expect(state.rows[0]).toMatchObject({
+        access_generation: '8',
+        grant_enabled: true,
+        sibling_membership_active: true,
+        source_membership_active: false,
+        user_active: true,
+      })
+      const effects = await query<{
+        effect_type: string
+        org_id: string | null
+      }>(
+        `SELECT effect_type, org_id
+         FROM directory_deprovision_effects
+        WHERE local_user_id = $1`,
+        [seeded.userId],
+      )
+      expect(effects.rows).toEqual([
+        { effect_type: 'membership_changed', org_id: seeded.orgId },
+      ])
+    })
+
+    it('keeps the default-off path strictly read-only, including generation and ledger', async () => {
+      const seeded = await seedDirectory({ grantEnabled: true })
+      const outcome = await apply(seeded, { enabled: false })
+
+      expect(outcome.applied).toBe(false)
+      expect(outcome.usersDeactivatedCount).toBe(1)
+      const state = await query<{
+        access_generation: string
+        grant_enabled: boolean
+        membership_active: boolean
+        user_active: boolean
+      }>(
+        `SELECT u.is_active AS user_active,
+              u.access_generation::text,
+              m.is_active AS membership_active,
+              g.enabled AS grant_enabled
+         FROM users u
+         JOIN user_orgs m ON m.user_id = u.id AND m.org_id = $2
+         JOIN user_external_auth_grants g
+           ON g.local_user_id = u.id AND g.provider = 'dingtalk'
+        WHERE u.id = $1`,
+        [seeded.userId, seeded.orgId],
+      )
+      expect(state.rows[0]).toMatchObject({
+        access_generation: '7',
+        grant_enabled: true,
+        membership_active: true,
+        user_active: true,
+      })
+      const evidence = await query<{ count: string }>(
+        `SELECT COUNT(*)::text AS count
+         FROM directory_deprovision_events
+        WHERE local_user_id = $1`,
+        [seeded.userId],
+      )
+      expect(evidence.rows[0].count).toBe('0')
+    })
+
+    it('writes no generation or evidence when the planner produces zero effects', async () => {
+      const seeded = await seedDirectory({
+        grantEnabled: false,
+        membershipActive: false,
+        policy: 'disable_grant_only',
+      })
+      const outcome = await transaction(async (client) =>
+        applyDirectoryDeprovisionPolicies(
+          {
+            query: async (statement, params) => {
+              const result = await client.query(statement, params)
+              return { rows: result.rows as Array<Record<string, unknown>> }
+            },
+          },
+          {
+            integrationId: seeded.integrationId,
+            runId: seeded.runId,
+            triggeredBy: 'test:d4-writer',
+            deactivatedAccountIds: [seeded.accountId],
+            syncedAccountCount: 1,
+            integrationDefaultPolicy: 'disable_grant_only',
+            enabled: true,
+          },
+        ),
+      )
+
+      expect(outcome.affected).toEqual([])
+      const user = await query<{
+        access_generation: string
+        is_active: boolean
+      }>(`SELECT access_generation::text, is_active FROM users WHERE id = $1`, [
+        seeded.userId,
+      ])
+      expect(user.rows[0]).toEqual({ access_generation: '7', is_active: true })
+      const evidence = await query<{ count: string }>(
+        `SELECT COUNT(*)::text AS count
+         FROM directory_deprovision_events
+        WHERE local_user_id = $1`,
+        [seeded.userId],
+      )
+      expect(evidence.rows[0].count).toBe('0')
+    })
+
+    it('ignores a stale transition id when the source account is active again', async () => {
+      const seeded = await seedDirectory({ grantEnabled: true })
+      await query(
+        `UPDATE directory_accounts SET is_active = TRUE WHERE id = $1::uuid`,
+        [seeded.accountId],
+      )
+
+      const outcome = await apply(seeded)
+
+      expect(outcome.candidateCount).toBe(0)
+      expect(outcome.affected).toEqual([])
+      const state = await query<{
+        access_generation: string
+        grant_enabled: boolean
+        membership_active: boolean
+        user_active: boolean
+      }>(
+        `SELECT u.is_active AS user_active,
+              u.access_generation::text,
+              m.is_active AS membership_active,
+              g.enabled AS grant_enabled
+         FROM users u
+         JOIN user_orgs m ON m.user_id = u.id AND m.org_id = $2
+         JOIN user_external_auth_grants g
+           ON g.local_user_id = u.id AND g.provider = 'dingtalk'
+        WHERE u.id = $1`,
+        [seeded.userId, seeded.orgId],
+      )
+      expect(state.rows[0]).toMatchObject({
+        access_generation: '7',
+        grant_enabled: true,
+        membership_active: true,
+        user_active: true,
+      })
+      const evidence = await query<{ count: string }>(
+        `SELECT COUNT(*)::text AS count
+         FROM directory_deprovision_events
+        WHERE local_user_id = $1`,
+        [seeded.userId],
+      )
+      expect(evidence.rows[0].count).toBe('0')
+    })
+
+    it('rejects a direct writer call when the source account is no longer inactive', async () => {
+      const seeded = await seedDirectory({ grantEnabled: true })
+      await query(
+        `UPDATE directory_accounts SET is_active = TRUE WHERE id = $1::uuid`,
+        [seeded.accountId],
+      )
+
+      await expect(
+        transaction(async (client) =>
+          applyDirectoryDeprovisionCandidate(
+            {
+              query: async (statement, params) => {
+                const result = await client.query(statement, params)
+                return { rows: result.rows as Array<Record<string, unknown>> }
+              },
+            },
+            {
+              localUserId: seeded.userId,
+              orgId: seeded.orgId,
+              integrationId: seeded.integrationId,
+              directoryAccountId: seeded.accountId,
+              runId: seeded.runId,
+              triggeredBy: 'test:d4-direct-writer',
+              policy: 'mark_inactive',
+              write: true,
+            },
+          ),
+        ),
+      ).rejects.toThrow(
+        'directory deprovision source account is no longer linked to the candidate user',
+      )
+
+      const user = await query<{
+        access_generation: string
+        is_active: boolean
+      }>(`SELECT access_generation::text, is_active FROM users WHERE id = $1`, [
+        seeded.userId,
+      ])
+      expect(user.rows[0]).toEqual({ access_generation: '7', is_active: true })
+    })
+
+    it('rolls back every access write when the evidence event cannot satisfy its run FK', async () => {
+      const seeded = await seedDirectory({ grantEnabled: true })
+
+      await expect(apply(seeded, { runId: randomUUID() })).rejects.toThrow()
+
+      const state = await query<{
+        access_generation: string
+        grant_enabled: boolean
+        membership_active: boolean
+        user_active: boolean
+      }>(
+        `SELECT u.is_active AS user_active,
+              u.access_generation::text,
+              m.is_active AS membership_active,
+              g.enabled AS grant_enabled
+         FROM users u
+         JOIN user_orgs m ON m.user_id = u.id AND m.org_id = $2
+         JOIN user_external_auth_grants g
+           ON g.local_user_id = u.id AND g.provider = 'dingtalk'
+        WHERE u.id = $1`,
+        [seeded.userId, seeded.orgId],
+      )
+      expect(state.rows[0]).toMatchObject({
+        access_generation: '7',
+        grant_enabled: true,
+        membership_active: true,
+        user_active: true,
+      })
+      const evidence = await query<{ count: string }>(
+        `SELECT COUNT(*)::text AS count
+         FROM directory_deprovision_events
+        WHERE local_user_id = $1`,
+        [seeded.userId],
+      )
+      expect(evidence.rows[0].count).toBe('0')
+    })
+  },
+)

--- a/packages/core-backend/tests/integration/directory-sync-orchestration.db.test.ts
+++ b/packages/core-backend/tests/integration/directory-sync-orchestration.db.test.ts
@@ -161,6 +161,15 @@ async function readRun(runId: string): Promise<{ status: string; error_message: 
 
 async function cleanupIntegration(integrationId: string): Promise<void> {
   await query(`DELETE FROM directory_sync_alerts WHERE integration_id = $1`, [integrationId])
+  // D4: deprovision evidence references the run via the composite FK
+  // ddev_run_integration_fk (that FK holding is the schema working, not a test bug), so the
+  // ledger rows go first or the runs DELETE is refused.
+  await query(
+    `DELETE FROM directory_deprovision_effects WHERE event_id IN
+       (SELECT id FROM directory_deprovision_events WHERE integration_id = $1::uuid)`,
+    [integrationId],
+  )
+  await query(`DELETE FROM directory_deprovision_events WHERE integration_id = $1::uuid`, [integrationId])
   await query(`DELETE FROM directory_sync_runs WHERE integration_id = $1`, [integrationId])
   await query(
     `DELETE FROM directory_account_links WHERE directory_account_id IN (SELECT id FROM directory_accounts WHERE integration_id = $1)`,

--- a/packages/core-backend/tests/unit/deprovision-planner.test.ts
+++ b/packages/core-backend/tests/unit/deprovision-planner.test.ts
@@ -5,6 +5,7 @@ describe('planDirectoryDeprovision (D2 prospective)', () => {
   it('returns zero effects for pending_activation (no fake offboarding)', () => {
     const plan = planDirectoryDeprovision({
       localUserId: 'u1',
+      policy: 'mark_inactive',
       activationStatus: 'pending_activation',
       isActive: false,
       orgId: 'org-1',
@@ -19,6 +20,7 @@ describe('planDirectoryDeprovision (D2 prospective)', () => {
   it('plans one source-org membership + grant + user effect for globally-clear', () => {
     const plan = planDirectoryDeprovision({
       localUserId: 'u2',
+      policy: 'mark_inactive',
       activationStatus: 'activated',
       isActive: true,
       orgId: 'org-a',
@@ -37,6 +39,7 @@ describe('planDirectoryDeprovision (D2 prospective)', () => {
   it('keeps the source-org membership effect while another org preserves global access', () => {
     const plan = planDirectoryDeprovision({
       localUserId: 'u-cross-org',
+      policy: 'mark_inactive',
       activationStatus: 'activated',
       isActive: true,
       orgId: 'org-a',
@@ -57,6 +60,7 @@ describe('planDirectoryDeprovision (D2 prospective)', () => {
   it('zero-effect when already inactive with no orgs/grant', () => {
     const plan = planDirectoryDeprovision({
       localUserId: 'u3',
+      policy: 'mark_inactive',
       activationStatus: 'activated',
       isActive: false,
       orgId: 'org-a',
@@ -66,5 +70,39 @@ describe('planDirectoryDeprovision (D2 prospective)', () => {
     })
     expect(plan.effects).toEqual([])
     expect(plan.skipReason).toBe('zero_effect')
+  })
+
+  it('disable_grant_only never plans a platform-user effect', () => {
+    const plan = planDirectoryDeprovision({
+      localUserId: 'u-grant-only',
+      policy: 'disable_grant_only',
+      activationStatus: 'activated',
+      isActive: true,
+      orgId: 'org-a',
+      orgMembershipActive: true,
+      dingtalkGrantEnabled: true,
+      globallyClear: true,
+    })
+    expect(plan.effects.map((effect) => effect.type).sort()).toEqual(
+      ['membership_changed', 'grant_changed'].sort(),
+    )
+  })
+
+  it('manual_review is always a zero-write plan', () => {
+    const plan = planDirectoryDeprovision({
+      localUserId: 'u-review',
+      policy: 'manual_review',
+      activationStatus: 'activated',
+      isActive: true,
+      orgId: 'org-a',
+      orgMembershipActive: true,
+      dingtalkGrantEnabled: true,
+      globallyClear: true,
+    })
+    expect(plan).toEqual({
+      localUserId: 'u-review',
+      skipReason: 'manual_review',
+      effects: [],
+    })
   })
 })

--- a/packages/core-backend/tests/unit/directory-deprovision-policy.test.ts
+++ b/packages/core-backend/tests/unit/directory-deprovision-policy.test.ts
@@ -64,6 +64,12 @@ function stubClient(
       if (/SELECT org_id\s+FROM directory_integrations/i.test(sql)) {
         return { rows: [{ org_id: STUB_ORG_ID }] }
       }
+      // Delta re-review P1-D: the write-mode mutex is its own statement now (lock FIRST, then
+      // the candidacy read as a separate post-lock snapshot). The stub answers the lock with the
+      // row's existence; the ordering itself is asserted by the write-mode tests below.
+      if (/SELECT id FROM users WHERE id = \$1::text\s+FOR UPDATE/i.test(sql)) {
+        return { rows: [{ id: String(params?.[0] ?? '') }] }
+      }
       if (/FROM users candidate_user/i.test(sql)) {
         const userId = String(params?.[0] ?? '')
         return {
@@ -124,6 +130,8 @@ describe('DT-OPS-01 deprovision executor (policy dispatch, given candidates)', (
     // The load-bearing safety property: merging this cannot deactivate anyone.
     expect(wrote(client.queries, DEACTIVATES_USER)).toBe(false)
     expect(wrote(client.queries, DISABLES_GRANT)).toBe(false)
+    // P1-D: preview writes nothing, so it must lock nothing.
+    expect(wrote(client.queries, /FOR UPDATE/i)).toBe(false)
     // W4-PRE-1c (owner 裁决②): disabled must ALSO never attempt the user_orgs deactivation —
     // this is the unit-level half of mutation ①/② (moving the write before the enabled gate,
     // or dropping the gate); the real-DB half lives in the W4-PRE-1c real-DB suite.
@@ -146,6 +154,15 @@ describe('DT-OPS-01 deprovision executor (policy dispatch, given candidates)', (
   it('enabled + mark_inactive: disables the grant, deactivates the local user, AND attempts the user_orgs deactivation', async () => {
     const client = stubClient([CANDIDATE])
     const outcome = await applyDirectoryDeprovisionPolicies(client, { ...baseOptions, enabled: true })
+
+    // P1-D ordering guard (answers the stub, not just silences it): write mode must take the
+    // users FOR UPDATE mutex BEFORE the candidacy read — the two sharing a statement (or the
+    // read coming first) is the exact stale-snapshot P1 the race golden kills on real PG.
+    const lockIndex = client.queries.findIndex((sql) => /FOR UPDATE/i.test(sql))
+    const stateIndex = client.queries.findIndex((sql) => /FROM users candidate_user/i.test(sql))
+    expect(lockIndex).toBeGreaterThanOrEqual(0)
+    expect(stateIndex).toBeGreaterThan(lockIndex)
+    expect(client.queries[stateIndex]).not.toMatch(/FOR UPDATE/i)
 
     expect(wrote(client.queries, DISABLES_GRANT)).toBe(true)
     expect(wrote(client.queries, DEACTIVATES_USER)).toBe(true)

--- a/packages/core-backend/tests/unit/directory-deprovision-policy.test.ts
+++ b/packages/core-backend/tests/unit/directory-deprovision-policy.test.ts
@@ -58,21 +58,41 @@ function stubClient(
         // evaluate the predicate — see the scope note.
         return { rows: candidates }
       }
-      if (/INSERT INTO user_external_auth_grants/i.test(sql) || /UPDATE users SET is_active = FALSE/i.test(sql)) {
+      if (/INSERT INTO user_external_auth_grants/i.test(sql)) {
         return { rows: [] }
       }
       if (/SELECT org_id\s+FROM directory_integrations/i.test(sql)) {
         return { rows: [{ org_id: STUB_ORG_ID }] }
       }
-      if (/FROM user_orgs WHERE user_id = \$1::text AND org_id = \$2::text\s+FOR UPDATE/i.test(sql)) {
-        return { rows: [] }
+      if (/FROM users candidate_user/i.test(sql)) {
+        const userId = String(params?.[0] ?? '')
+        return {
+          rows: [{
+            activation_status: 'activated',
+            is_active: true,
+            access_generation: 0,
+            linked_at_apply: true,
+            org_membership_active: true,
+            org_candidacy_clear: true,
+            globally_clear: !notGloballyClear.has(userId),
+            dingtalk_grant_enabled: true,
+          }],
+        }
       }
       if (/UPDATE user_orgs\s+SET is_active = FALSE/i.test(sql)) {
-        return { rows: [] }
+        return { rows: [{ user_id: String(params?.[0] ?? '') }] }
       }
-      if (/FROM UNNEST\(\$1::text\[\]\) AS candidate_user/i.test(sql)) {
-        const requested = (params?.[0] as string[] | undefined) ?? []
-        return { rows: requested.filter((id) => !notGloballyClear.has(id)).map((id) => ({ local_user_id: id })) }
+      if (/UPDATE users\s+SET access_generation/i.test(sql)) {
+        return { rows: [{ access_generation: 1 }] }
+      }
+      if (/INSERT INTO directory_deprovision_events/i.test(sql)) {
+        return { rows: [{ id: 'event-1' }] }
+      }
+      if (
+        /directory_deprovision_(?:events|effects)/i.test(sql)
+        || /INSERT INTO directory_deprovision_effects/i.test(sql)
+      ) {
+        return { rows: [] }
       }
       // Anything else is drift: a new query appeared that no test has reasoned about.
       throw new Error(`Unhandled SQL in deprovision stub:\n${sql}`)
@@ -81,7 +101,7 @@ function stubClient(
 }
 
 const wrote = (queries: string[], pattern: RegExp) => queries.some((sql) => pattern.test(sql))
-const DEACTIVATES_USER = /UPDATE users SET is_active = FALSE/i
+const DEACTIVATES_USER = /UPDATE users[\s\S]*is_active = FALSE/i
 const DEACTIVATES_USER_ORG = /UPDATE user_orgs\s+SET is_active = FALSE/i
 const DISABLES_GRANT = /INSERT INTO user_external_auth_grants/i
 
@@ -90,6 +110,8 @@ const CANDIDATE = { directory_account_id: 'acct-1', local_user_id: 'user-1', dep
 describe('DT-OPS-01 deprovision executor (policy dispatch, given candidates)', () => {
   const baseOptions = {
     integrationId: 'dir-1',
+    runId: 'run-1',
+    triggeredBy: 'unit-test',
     deactivatedAccountIds: ['acct-1'],
     syncedAccountCount: 100,
     integrationDefaultPolicy: 'mark_inactive',

--- a/packages/core-backend/tests/utils/directory-deprovision-fixtures.ts
+++ b/packages/core-backend/tests/utils/directory-deprovision-fixtures.ts
@@ -1,0 +1,25 @@
+import { query } from '../../src/db/pg'
+
+export async function createDirectoryDeprovisionRun(
+  integrationId: string,
+  triggeredBy = 'test:directory-deprovision',
+): Promise<string> {
+  const result = await query<{ id: string }>(
+    `INSERT INTO directory_sync_runs (integration_id, status, triggered_by, trigger_source)
+     VALUES ($1::uuid, 'success', $2::text, 'manual')
+     RETURNING id::text AS id`,
+    [integrationId, triggeredBy],
+  )
+  return result.rows[0].id
+}
+
+export async function deleteDirectoryDeprovisionEvidence(
+  integrationIds: string[],
+): Promise<void> {
+  if (integrationIds.length === 0) return
+  await query(
+    `DELETE FROM directory_deprovision_events
+      WHERE integration_id = ANY($1::uuid[])`,
+    [integrationIds],
+  )
+}

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -232,6 +232,10 @@ export default defineConfig({
       // DATABASE_URL-gated; excluded here and wired as a whole file into the approval real-DB
       // step, with both points pinned by directory-deprovision-ledger-ci-wiring.test.mjs.
       'tests/integration/directory-deprovision-ledger-schema.db.test.ts',
+      // D4 access-graph writer + evidence are one transaction: real committed state, cross-org
+      // split, default-off/zero-effect no-write, and fail-last ledger rollback. DATABASE_URL-gated;
+      // excluded here and whole-file wired into the approval real-DB step.
+      'tests/integration/directory-deprovision-writer-ledger.db.test.ts',
       // DingTalk multi-corp external-key isolation: corp-scoped uniqueness, upgrade migration,
       // real-sync coexistence, and same-corp/cross-corp identity matching controls.
       // DATABASE_URL-gated; excluded here so the no-DB job cannot skip-green it, and wired as a

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -236,6 +236,10 @@ export default defineConfig({
       // split, default-off/zero-effect no-write, and fail-last ledger rollback. DATABASE_URL-gated;
       // excluded here and whole-file wired into the approval real-DB step.
       'tests/integration/directory-deprovision-writer-ledger.db.test.ts',
+      // D4 two-connection goldens (adversarial-review absorption): the deterministic
+      // lock-wait race that proved the stale globally-clear P1, and the §5.4 supersede
+      // both-legs golden. DATABASE_URL-gated; whole-file wired into the approval real-DB step.
+      'tests/integration/directory-deprovision-race-supersede.db.test.ts',
       // DingTalk multi-corp external-key isolation: corp-scoped uniqueness, upgrade migration,
       // real-sync coexistence, and same-corp/cross-corp identity matching controls.
       // DATABASE_URL-gated; excluded here so the no-DB job cannot skip-green it, and wired as a

--- a/plugins/plugin-integration-core/lib/sealed-export/vectors/s6a-package-provenance-pins.json
+++ b/plugins/plugin-integration-core/lib/sealed-export/vectors/s6a-package-provenance-pins.json
@@ -86,6 +86,6 @@
     "s6aAcceptancePs51Test": "835c7c6ce943d82e0378a40a27c7fd1e8b79b526faa8ca4c8066e4231a4bfb0f",
     "s6aProductRuntimeTest": "de978adafa8b89772cefa921c2051f434bf346bf5c2978bef3424ee70f51ba3f",
     "multitableOnpremPackageBuild": "463c7d73c6c7f2d1b6cdf0820d7a06974a9c463dd5e98bbbaf1c996e1dc4ed99",
-    "pluginTestsWorkflow": "55ad6fb931e30d6104590e741fb5823f919aea2a1f02e8b2c9830859111dfd69"
+    "pluginTestsWorkflow": "f7a114c5cfcd31c71e9fc4ba51a64a8c2460f1aa6326393fa5e93c1404cd1942"
   }
 }

--- a/scripts/ops/directory-deprovision-ledger-ci-wiring.test.mjs
+++ b/scripts/ops/directory-deprovision-ledger-ci-wiring.test.mjs
@@ -8,30 +8,40 @@ import { REAL_DB_STEP_IDS, isSuiteWiredInRealDbStep, realDbStepWholeFileArgs } f
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const repoRoot = join(__dirname, '..', '..')
-const FILE = 'tests/integration/directory-deprovision-ledger-schema.db.test.ts'
+const FILES = [
+  'tests/integration/directory-deprovision-ledger-schema.db.test.ts',
+  'tests/integration/directory-deprovision-writer-ledger.db.test.ts',
+  'tests/integration/directory-deprovision-race-supersede.db.test.ts',
+]
 const STEP_ID = REAL_DB_STEP_IDS.approval
 
-test('vitest.config.ts excludes the D3 ledger suite from the no-DB job', () => {
+test('vitest.config.ts excludes every D3/D4 ledger suite from the no-DB job', () => {
   const cfg = readFileSync(join(repoRoot, 'packages/core-backend/vitest.config.ts'), 'utf8')
-  assert.ok(cfg.includes(`'${FILE}'`), `vitest.config.ts must exclude ${FILE}`)
+  for (const file of FILES) {
+    assert.ok(cfg.includes(`'${file}'`), `vitest.config.ts must exclude ${file}`)
+  }
 })
 
-test('plugin-tests.yml runs the D3 ledger suite as a whole file in the approval real-DB step', () => {
+test('plugin-tests.yml runs every D3/D4 ledger suite as a whole file in the approval real-DB step', () => {
   const workflow = readFileSync(join(repoRoot, '.github/workflows/plugin-tests.yml'), 'utf8')
-  assert.ok(
-    isSuiteWiredInRealDbStep(workflow, STEP_ID, FILE),
-    `plugin-tests.yml real-DB step id "${STEP_ID}" must run ${FILE} as a whole-file argument`,
-  )
-  assert.equal(
-    realDbStepWholeFileArgs(workflow, REAL_DB_STEP_IDS.multitable).includes(FILE),
-    false,
-    `${FILE} must not be wired into the multitable real-DB step`,
-  )
+  for (const file of FILES) {
+    assert.ok(
+      isSuiteWiredInRealDbStep(workflow, STEP_ID, file),
+      `plugin-tests.yml real-DB step id "${STEP_ID}" must run ${file} as a whole-file argument`,
+    )
+    assert.equal(
+      realDbStepWholeFileArgs(workflow, REAL_DB_STEP_IDS.multitable).includes(file),
+      false,
+      `${file} must not be wired into the multitable real-DB step`,
+    )
+  }
 })
 
-test('the D3 ledger suite file exists on disk', () => {
-  assert.ok(
-    existsSync(join(repoRoot, 'packages/core-backend', FILE)),
-    `wired suite packages/core-backend/${FILE} must exist on disk`,
-  )
+test('every wired D3/D4 ledger suite file exists on disk', () => {
+  for (const file of FILES) {
+    assert.ok(
+      existsSync(join(repoRoot, 'packages/core-backend', file)),
+      `wired suite packages/core-backend/${file} must exist on disk`,
+    )
+  }
 })

--- a/scripts/ops/directory-deprovision-writer-ci-wiring.test.mjs
+++ b/scripts/ops/directory-deprovision-writer-ci-wiring.test.mjs
@@ -1,0 +1,49 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { existsSync, readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import {
+  REAL_DB_STEP_IDS,
+  isSuiteWiredInRealDbStep,
+  realDbStepWholeFileArgs,
+} from './ci-realdb-step-contract.mjs'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const repoRoot = join(__dirname, '..', '..')
+const FILE = 'tests/integration/directory-deprovision-writer-ledger.db.test.ts'
+const STEP_ID = REAL_DB_STEP_IDS.approval
+
+test('vitest.config.ts excludes the D4 writer suite from the no-DB job', () => {
+  const cfg = readFileSync(
+    join(repoRoot, 'packages/core-backend/vitest.config.ts'),
+    'utf8',
+  )
+  assert.ok(cfg.includes(`'${FILE}'`), `vitest.config.ts must exclude ${FILE}`)
+})
+
+test('plugin-tests.yml runs the D4 writer suite as a whole file in the approval real-DB step', () => {
+  const workflow = readFileSync(
+    join(repoRoot, '.github/workflows/plugin-tests.yml'),
+    'utf8',
+  )
+  assert.ok(
+    isSuiteWiredInRealDbStep(workflow, STEP_ID, FILE),
+    `plugin-tests.yml real-DB step id "${STEP_ID}" must run ${FILE} as a whole-file argument`,
+  )
+  assert.equal(
+    realDbStepWholeFileArgs(workflow, REAL_DB_STEP_IDS.multitable).includes(
+      FILE,
+    ),
+    false,
+    `${FILE} must not be wired into the multitable real-DB step`,
+  )
+})
+
+test('the D4 writer suite file exists on disk', () => {
+  assert.ok(
+    existsSync(join(repoRoot, 'packages/core-backend', FILE)),
+    `wired suite packages/core-backend/${FILE} must exist on disk`,
+  )
+})


### PR DESCRIPTION
## Scope

Stacked on D3 draft PR #4646. This window wires the deprovision planner and typed evidence ledger into the real directory-sync transaction. All lifecycle flags remain default OFF.

- re-read candidacy under the canonical users row lock
- apply membership, DingTalk grant, user state, generation, event, and effects on the caller transaction client
- require the real sync run id and linked inactive source witness
- preserve org-scoped versus global candidate semantics
- keep manual review, pending users, zero-effect, and default-off paths write-free
- sort per-user lock acquisition order for the following D5 mutex window

## Verification

- core-backend tsc --noEmit
- focused unit: 27/27
- related real-DB battery: 56/56
- D4 CI-wiring contract: 3/3
- mutation: remove inactive source witness -> direct-writer golden reds
- mutation: replace sync transaction client with global query -> fail-last rollback golden reds

## Hold

Draft and unarmed. D3 must land first. D5 all-writer mutex, D6 restore recheck, D7 Apply≈Plan, alias full writers, T3 batch/SSO, and every runtime flag remain outside this window.