### PR TITLE
feat(directory): serialize admin access graph writes

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -102,6 +102,7 @@ jobs:
           node --test scripts/ops/directory-grant-table-ci-wiring.test.mjs
           node --test scripts/ops/directory-deprovision-ledger-ci-wiring.test.mjs
           node --test scripts/ops/directory-deprovision-writer-ci-wiring.test.mjs
+          node --test scripts/ops/directory-access-graph-mutex-ci-wiring.test.mjs
 
       - name: Run DingTalk OAuth-stability metrics-only contract test (DT-CLOSE-01B)
         run: |
@@ -1101,6 +1102,7 @@ jobs:
             tests/integration/directory-deprovision-ledger-schema.db.test.ts \
             tests/integration/directory-deprovision-writer-ledger.db.test.ts \
             tests/integration/directory-deprovision-race-supersede.db.test.ts \
+            tests/integration/directory-access-graph-mutex.db.test.ts \
             tests/integration/directory-sync-run-lease.db.test.ts \
             tests/integration/directory-tenant-change-immutable.db.test.ts \
             tests/integration/directory-sync-orchestration.db.test.ts \

--- a/packages/core-backend/src/auth/invite-accept-writes.ts
+++ b/packages/core-backend/src/auth/invite-accept-writes.ts
@@ -10,6 +10,10 @@
  */
 
 import { transaction } from '../db/pg'
+import {
+  lockUsersForAccessGraphWrite,
+  supersedeDeprovisionEvidenceForAccessGraphWrite,
+} from '../directory/access-graph-mutex'
 import { markInviteAccepted } from './invite-ledger'
 
 export const INVITE_LEDGER_CONSUME_FAILED = 'INVITE_LEDGER_CONSUME_FAILED'
@@ -34,6 +38,14 @@ export function inviteAcceptWriteErrorCode(error: unknown): string | undefined {
  */
 export async function applyInviteAcceptanceWrites(input: InviteAcceptWriteInput): Promise<void> {
   await transaction(async (client) => {
+    const locked = await lockUsersForAccessGraphWrite(client, [input.userId])
+    const lockedUser = locked.get(input.userId)
+    if (!lockedUser) {
+      throw Object.assign(new Error('Invite target could not be updated'), {
+        code: INVITE_TARGET_UPDATE_MISMATCH,
+      })
+    }
+
     const ledger = await markInviteAccepted(input.inviteToken, {
       consumedBy: input.userId,
       client,
@@ -60,6 +72,14 @@ export async function applyInviteAcceptanceWrites(input: InviteAcceptWriteInput)
     if (!updated.rows[0]) {
       throw Object.assign(new Error('Invite target could not be updated'), {
         code: INVITE_TARGET_UPDATE_MISMATCH,
+      })
+    }
+
+    if (!lockedUser.isActive) {
+      await supersedeDeprovisionEvidenceForAccessGraphWrite(client, {
+        userIds: [input.userId],
+        actorId: input.userId,
+        reason: 'superseded by invite acceptance activation',
       })
     }
   })

--- a/packages/core-backend/src/auth/user-activate.ts
+++ b/packages/core-backend/src/auth/user-activate.ts
@@ -8,6 +8,10 @@
 import * as bcrypt from 'bcryptjs'
 import { transaction } from '../db/pg'
 import { getBcryptSaltRounds } from '../security/auth-runtime-config'
+import {
+  lockUsersForAccessGraphWrite,
+  supersedeDeprovisionEvidenceForAccessGraphWrite,
+} from '../directory/access-graph-mutex'
 import { claimLoginAlias } from './login-alias-service'
 import { buildUnusablePasswordHash } from './user-activation'
 
@@ -92,25 +96,12 @@ export async function activatePendingUser(input: ActivateUserInput): Promise<Act
   }
 
   await transaction(async (client) => {
-    const locked = await client.query(
-      `SELECT id, email, username, mobile, activation_status, is_active
-         FROM users
-        WHERE id = $1
-        FOR UPDATE`,
-      [userId],
-    )
-    const user = locked.rows[0] as
-      | {
-          id: string
-          email: string | null
-          username: string | null
-          mobile: string | null
-          activation_status: string
-          is_active: boolean
-        }
-      | undefined
-    if (!user) throwCoded('User not found', 'ACTIVATE_USER_NOT_FOUND')
-    if (user.activation_status !== 'pending_activation') {
+    const lockedUsers = await lockUsersForAccessGraphWrite(client, [userId])
+    const user = lockedUsers.get(userId)
+    if (!user) {
+      throwCoded('User not found', 'ACTIVATE_USER_NOT_FOUND')
+    }
+    if (user.activationStatus !== 'pending_activation') {
       throwCoded(
         'User is not pending_activation',
         'ACTIVATE_NOT_PENDING',
@@ -225,6 +216,12 @@ export async function activatePendingUser(input: ActivateUserInput): Promise<Act
         'ACTIVATE_ALIAS_REQUIRED',
       )
     }
+
+    await supersedeDeprovisionEvidenceForAccessGraphWrite(client, {
+      userIds: [userId],
+      actorId: input.adminUserId ?? userId,
+      reason: 'superseded by pending-user activation',
+    })
   })
 
   return {

--- a/packages/core-backend/src/directory/access-graph-mutex.ts
+++ b/packages/core-backend/src/directory/access-graph-mutex.ts
@@ -1,0 +1,128 @@
+/**
+ * Canonical mutex for every writer that changes a user's access graph.
+ *
+ * Callers must lock all affected users before touching links, memberships,
+ * external grants, or users.is_active. Multi-user callers use sorted ids to
+ * keep one global lock order. A successful access-graph override invalidates
+ * open deprovision evidence and advances the same user's generation in the
+ * caller's transaction.
+ */
+
+export type AccessGraphTransactionClient = {
+  query: (
+    statement: string,
+    params?: unknown[],
+  ) => Promise<{ rows: Array<Record<string, unknown>> }>
+}
+
+export type LockedAccessGraphUser = {
+  id: string
+  email: string | null
+  username: string | null
+  mobile: string | null
+  activationStatus: string | null
+  isActive: boolean
+  accessGeneration: number
+}
+
+function normalizeUserIds(userIds: string[]): string[] {
+  return Array.from(
+    new Set(userIds.map((userId) => String(userId || '').trim()).filter(Boolean)),
+  ).sort()
+}
+
+export async function lockUsersForAccessGraphWrite(
+  client: AccessGraphTransactionClient,
+  userIds: string[],
+): Promise<Map<string, LockedAccessGraphUser>> {
+  const normalizedUserIds = normalizeUserIds(userIds)
+  const lockedUsers = new Map<string, LockedAccessGraphUser>()
+
+  for (const userId of normalizedUserIds) {
+    const result = await client.query(
+      `SELECT id::text AS id,
+              email,
+              username,
+              mobile,
+              activation_status,
+              COALESCE(is_active, TRUE) AS is_active,
+              COALESCE(access_generation, 0)::bigint AS access_generation
+         FROM users
+        WHERE id = $1::text
+        FOR UPDATE`,
+      [userId],
+    )
+    const row = result.rows[0]
+    if (!row) continue
+    lockedUsers.set(userId, {
+      id: String(row.id),
+      email: row.email === null || row.email === undefined ? null : String(row.email),
+      username:
+        row.username === null || row.username === undefined
+          ? null
+          : String(row.username),
+      mobile:
+        row.mobile === null || row.mobile === undefined ? null : String(row.mobile),
+      activationStatus:
+        row.activation_status === null || row.activation_status === undefined
+          ? null
+          : String(row.activation_status),
+      isActive: row.is_active === true,
+      accessGeneration: Number(row.access_generation ?? 0),
+    })
+  }
+
+  return lockedUsers
+}
+
+export async function supersedeDeprovisionEvidenceForAccessGraphWrite(
+  client: AccessGraphTransactionClient,
+  options: {
+    userIds: string[]
+    actorId: string
+    reason: string
+  },
+): Promise<Map<string, number>> {
+  const actorId = String(options.actorId || '').trim()
+  const reason = String(options.reason || '').trim()
+  if (!actorId) throw new Error('access-graph supersede actorId is required')
+  if (!reason) throw new Error('access-graph supersede reason is required')
+
+  const generations = new Map<string, number>()
+  for (const userId of normalizeUserIds(options.userIds)) {
+    await client.query(
+      `UPDATE directory_deprovision_effects
+          SET status = 'superseded',
+              updated_at = NOW()
+        WHERE local_user_id = $1::text
+          AND status = 'applied'`,
+      [userId],
+    )
+    await client.query(
+      `UPDATE directory_deprovision_events
+          SET status = 'superseded',
+              resolved_at = NOW(),
+              resolved_by = $2::text,
+              resolve_note = $3::text,
+              updated_at = NOW()
+        WHERE local_user_id = $1::text
+          AND status = 'applied'`,
+      [userId, actorId, reason],
+    )
+    const generation = await client.query(
+      `UPDATE users
+          SET access_generation = COALESCE(access_generation, 0) + 1,
+              updated_at = NOW()
+        WHERE id = $1::text
+        RETURNING access_generation`,
+      [userId],
+    )
+    const nextGeneration = Number(generation.rows[0]?.access_generation)
+    if (!Number.isFinite(nextGeneration)) {
+      throw new Error(`access-graph generation update returned no row for user ${userId}`)
+    }
+    generations.set(userId, nextGeneration)
+  }
+
+  return generations
+}

--- a/packages/core-backend/src/routes/admin-users.ts
+++ b/packages/core-backend/src/routes/admin-users.ts
@@ -36,6 +36,11 @@ import {
   backfillUserLoginAliases,
   isAuthLoginAliasCutoverEnabled,
 } from '../auth/login-alias-service'
+import {
+  lockUsersForAccessGraphWrite,
+  supersedeDeprovisionEvidenceForAccessGraphWrite,
+  type AccessGraphTransactionClient,
+} from '../directory/access-graph-mutex'
 import { isDatabaseSchemaError } from '../utils/database-errors'
 import { jsonError, jsonOk, parsePagination } from '../util/response'
 import {
@@ -669,14 +674,13 @@ async function fetchDingTalkAccessSnapshot(userId: string) {
   }
 }
 
-async function assertUsersCanEnableDingTalkGrant(userIds: string[]): Promise<void> {
+async function assertUsersCanEnableDingTalkGrant(
+  client: AccessGraphTransactionClient,
+  userIds: string[],
+): Promise<void> {
   if (userIds.length === 0) return
 
-  const identityResult = await query<{
-    local_user_id: string
-    corp_id: string | null
-    provider_open_id: string | null
-  }>(
+  const identityResult = await client.query(
     `SELECT local_user_id, corp_id, provider_open_id
      FROM user_external_identities
      WHERE provider = $1
@@ -685,7 +689,11 @@ async function assertUsersCanEnableDingTalkGrant(userIds: string[]): Promise<voi
   )
 
   const blockedUserIds = new Set<string>()
-  for (const row of identityResult.rows) {
+  for (const row of identityResult.rows as Array<{
+    local_user_id: string
+    corp_id: string | null
+    provider_open_id: string | null
+  }>) {
     if (row.corp_id && !row.provider_open_id) {
       blockedUserIds.add(row.local_user_id)
     }
@@ -788,10 +796,31 @@ function normalizeUserIdList(value: unknown): string[] {
   return Array.from(unique)
 }
 
-async function upsertDingTalkGrants(userIds: string[], enabled: boolean, adminUserId: string): Promise<void> {
-  if (userIds.length === 0) return
+async function upsertDingTalkGrants(
+  client: AccessGraphTransactionClient,
+  userIds: string[],
+  enabled: boolean,
+  adminUserId: string,
+): Promise<string[]> {
+  if (userIds.length === 0) return []
 
-  await query(
+  const current = await client.query(
+    `SELECT local_user_id, enabled
+       FROM user_external_auth_grants
+      WHERE provider = $1
+        AND local_user_id = ANY($2::text[])`,
+    [DINGTALK_PROVIDER, userIds],
+  )
+  const currentByUserId = new Map(
+    (current.rows as Array<{ local_user_id: string; enabled: boolean }>).map(
+      (row) => [row.local_user_id, row.enabled],
+    ),
+  )
+  const changedUserIds = userIds.filter(
+    (userId) => currentByUserId.get(userId) !== enabled,
+  )
+
+  await client.query(
     `INSERT INTO user_external_auth_grants (provider, local_user_id, enabled, granted_by, created_at, updated_at)
      SELECT $1, target_user_id, $2, $3, NOW(), NOW()
      FROM unnest($4::text[]) AS target(target_user_id)
@@ -799,6 +828,14 @@ async function upsertDingTalkGrants(userIds: string[], enabled: boolean, adminUs
      DO UPDATE SET enabled = EXCLUDED.enabled, granted_by = EXCLUDED.granted_by, updated_at = NOW()`,
     [DINGTALK_PROVIDER, enabled, adminUserId, userIds],
   )
+  if (changedUserIds.length > 0) {
+    await supersedeDeprovisionEvidenceForAccessGraphWrite(client, {
+      userIds: changedUserIds,
+      actorId: adminUserId,
+      reason: 'superseded by administrator DingTalk grant update',
+    })
+  }
+  return changedUserIds
 }
 
 function deriveDelegableNamespaces(roleIds: string[]): string[] {
@@ -4002,11 +4039,14 @@ export function adminUsersRouter(): Router {
       if (!userId) return jsonError(res, 400, 'USER_ID_REQUIRED', 'userId is required')
       if (typeof enabled !== 'boolean') return jsonError(res, 400, 'ENABLED_REQUIRED', 'enabled boolean is required')
 
-      const profile = await fetchUserProfile(userId)
-      if (!profile) return jsonError(res, 404, 'NOT_FOUND', 'User not found')
-      if (enabled) await assertUsersCanEnableDingTalkGrant([userId])
-
-      await upsertDingTalkGrants([userId], enabled, adminUserId)
+      const found = await transaction(async (client) => {
+        const locked = await lockUsersForAccessGraphWrite(client, [userId])
+        if (!locked.has(userId)) return false
+        if (enabled) await assertUsersCanEnableDingTalkGrant(client, [userId])
+        await upsertDingTalkGrants(client, [userId], enabled, adminUserId)
+        return true
+      })
+      if (!found) return jsonError(res, 404, 'NOT_FOUND', 'User not found')
 
       await auditLog({
         actorId: adminUserId,
@@ -4046,20 +4086,17 @@ export function adminUsersRouter(): Router {
       if (typeof enabled !== 'boolean') return jsonError(res, 400, 'ENABLED_REQUIRED', 'enabled boolean is required')
       if (userIds.length === 0) return jsonError(res, 400, 'USER_IDS_REQUIRED', 'userIds array is required')
 
-      const existingResult = await query<{ id: string }>(
-        `SELECT id
-         FROM users
-         WHERE id = ANY($1::text[])`,
-        [userIds],
-      )
-      const existingIds = new Set(existingResult.rows.map((row) => row.id).filter(Boolean))
-      const missingUserIds = userIds.filter((userId) => !existingIds.has(userId))
+      const missingUserIds = await transaction(async (client) => {
+        const locked = await lockUsersForAccessGraphWrite(client, userIds)
+        const missing = userIds.filter((userId) => !locked.has(userId))
+        if (missing.length > 0) return missing
+        if (enabled) await assertUsersCanEnableDingTalkGrant(client, userIds)
+        await upsertDingTalkGrants(client, userIds, enabled, adminUserId)
+        return []
+      })
       if (missingUserIds.length > 0) {
         return jsonError(res, 404, 'USERS_NOT_FOUND', 'One or more users were not found', { missingUserIds })
       }
-      if (enabled) await assertUsersCanEnableDingTalkGrant(userIds)
-
-      await upsertDingTalkGrants(userIds, enabled, adminUserId)
 
       await Promise.all(userIds.map((userId) => auditLog({
         actorId: adminUserId,
@@ -4213,30 +4250,48 @@ export function adminUsersRouter(): Router {
         return jsonError(res, 400, 'SELF_DISABLE_FORBIDDEN', 'Cannot disable your own account')
       }
 
-      const profile = await fetchUserProfile(userId)
-      if (!profile) return jsonError(res, 404, 'NOT_FOUND', 'User not found')
+      const updateResult = await transaction(async (client) => {
+        const lockedUsers = await lockUsersForAccessGraphWrite(client, [userId])
+        const lockedUser = lockedUsers.get(userId)
+        if (!lockedUser) return null
 
-      try {
-        assertPendingUserCannotBeActivatedViaGenericStatusApi(profile.activationStatus, isActive)
-      } catch (error) {
+        assertPendingUserCannotBeActivatedViaGenericStatusApi(
+          lockedUser.activationStatus ?? '',
+          isActive,
+        )
+
+        if (lockedUser.isActive !== isActive) {
+          await client.query(
+            `UPDATE users
+             SET is_active = $1, updated_at = NOW()
+             WHERE id = $2`,
+            [isActive, userId],
+          )
+          await supersedeDeprovisionEvidenceForAccessGraphWrite(client, {
+            userIds: [userId],
+            actorId: adminUserId,
+            reason: 'superseded by administrator user-status update',
+          })
+        }
+        return { beforeIsActive: lockedUser.isActive }
+      }).catch((error) => {
         const code = (error as Error & { code?: string }).code
         if (code === PENDING_ACTIVATE_BYPASS_FORBIDDEN_CODE) {
-          return jsonError(
-            res,
-            400,
-            PENDING_ACTIVATE_BYPASS_FORBIDDEN_CODE,
-            (error as Error).message,
-          )
+          return {
+            pendingActivationError: error as Error,
+          }
         }
         throw error
+      })
+      if (!updateResult) return jsonError(res, 404, 'NOT_FOUND', 'User not found')
+      if ('pendingActivationError' in updateResult) {
+        return jsonError(
+          res,
+          400,
+          PENDING_ACTIVATE_BYPASS_FORBIDDEN_CODE,
+          updateResult.pendingActivationError.message,
+        )
       }
-
-      await query(
-        `UPDATE users
-         SET is_active = $1, updated_at = NOW()
-         WHERE id = $2`,
-        [isActive, userId],
-      )
 
       const revocation = !isActive
         ? await revokeUserSessions(userId, {
@@ -4253,7 +4308,7 @@ export function adminUsersRouter(): Router {
         resourceId: userId,
         meta: {
           adminUserId,
-          before: { is_active: profile.is_active },
+          before: { is_active: updateResult.beforeIsActive },
           after: { is_active: isActive },
           revokedAfter: revocation?.revokedAfter || null,
         },

--- a/packages/core-backend/tests/integration/directory-access-graph-mutex.db.test.ts
+++ b/packages/core-backend/tests/integration/directory-access-graph-mutex.db.test.ts
@@ -1,0 +1,247 @@
+import { randomUUID } from 'node:crypto'
+import { Pool } from 'pg'
+import { afterAll, beforeEach, describe, expect, it } from 'vitest'
+import { query, transaction } from '../../src/db/pg'
+import {
+  lockUsersForAccessGraphWrite,
+  supersedeDeprovisionEvidenceForAccessGraphWrite,
+} from '../../src/directory/access-graph-mutex'
+import { applyDirectoryDeprovisionCandidate } from '../../src/directory/deprovision-ledger'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const PREFIX = `d5a-mutex-${Date.now()}`
+
+type SeededEvidence = {
+  eventId: string
+  integrationId: string
+  userId: string
+}
+
+async function cleanup(): Promise<void> {
+  await query(
+    `DELETE FROM directory_deprovision_events WHERE local_user_id LIKE $1`,
+    [`${PREFIX}-%`],
+  )
+  await query(
+    `DELETE FROM user_external_auth_grants WHERE local_user_id LIKE $1`,
+    [`${PREFIX}-%`],
+  )
+  await query(`DELETE FROM user_orgs WHERE user_id LIKE $1`, [`${PREFIX}-%`])
+  await query(`DELETE FROM directory_integrations WHERE org_id LIKE $1`, [
+    `${PREFIX}-%`,
+  ])
+  await query(`DELETE FROM users WHERE id LIKE $1`, [`${PREFIX}-%`])
+}
+
+async function seedAppliedEvidence(): Promise<SeededEvidence> {
+  const orgId = `${PREFIX}-org-${randomUUID()}`
+  const userId = `${PREFIX}-user-${randomUUID()}`
+  const integration = await query<{ id: string }>(
+    `INSERT INTO directory_integrations (
+       name, corp_id, org_id, provider, status, default_deprovision_policy
+     ) VALUES ($1, $2, $3, 'dingtalk', 'active', 'mark_inactive')
+     RETURNING id::text AS id`,
+    [
+      `${PREFIX}-integration-${randomUUID()}`,
+      `${PREFIX}-corp-${randomUUID()}`,
+      orgId,
+    ],
+  )
+  const integrationId = integration.rows[0].id
+  const run = await query<{ id: string }>(
+    `INSERT INTO directory_sync_runs (
+       integration_id, status, triggered_by, trigger_source
+     ) VALUES ($1::uuid, 'success', 'test:d5a-mutex', 'manual')
+     RETURNING id::text AS id`,
+    [integrationId],
+  )
+  await query(
+    `INSERT INTO users (
+       id, password_hash, is_active, activation_status, access_generation
+     ) VALUES ($1, 'x', TRUE, 'activated', 4)`,
+    [userId],
+  )
+  await query(
+    `INSERT INTO user_orgs (user_id, org_id, is_active)
+     VALUES ($1, $2, TRUE)`,
+    [userId, orgId],
+  )
+  await query(
+    `INSERT INTO user_external_auth_grants (
+       provider, local_user_id, enabled, granted_by, created_at, updated_at
+     ) VALUES ('dingtalk', $1, TRUE, 'test:d5a-mutex', NOW(), NOW())`,
+    [userId],
+  )
+  const account = await query<{ id: string }>(
+    `INSERT INTO directory_accounts (
+       integration_id, provider, external_user_id, external_key, name, is_active
+     ) VALUES ($1::uuid, 'dingtalk', $2, $3, 'D5A Mutex', FALSE)
+     RETURNING id::text AS id`,
+    [
+      integrationId,
+      `${PREFIX}-external-${randomUUID()}`,
+      `dingtalk:${PREFIX}:${randomUUID()}`,
+    ],
+  )
+  await query(
+    `INSERT INTO directory_account_links (
+       directory_account_id, local_user_id, link_status
+     ) VALUES ($1::uuid, $2, 'linked')`,
+    [account.rows[0].id, userId],
+  )
+
+  const applied = await transaction((client) =>
+    applyDirectoryDeprovisionCandidate(client, {
+      localUserId: userId,
+      orgId,
+      integrationId,
+      directoryAccountId: account.rows[0].id,
+      runId: run.rows[0].id,
+      triggeredBy: 'test:d5a-mutex',
+      policy: 'mark_inactive',
+      write: true,
+    }),
+  )
+  if (!applied.eventId) throw new Error('failed to seed deprovision evidence')
+  return { eventId: applied.eventId, integrationId, userId }
+}
+
+async function readEvidence(userId: string) {
+  const result = await query<{
+    access_generation: string
+    event_status: string
+    effect_statuses: string[]
+    resolved_by: string | null
+  }>(
+    `SELECT
+       u.access_generation::text,
+       event.status AS event_status,
+       event.resolved_by,
+       array_agg(effect.status ORDER BY effect.effect_type)::text[] AS effect_statuses
+     FROM users u
+     JOIN directory_deprovision_events event ON event.local_user_id = u.id
+     JOIN directory_deprovision_effects effect ON effect.event_id = event.id
+     WHERE u.id = $1
+     GROUP BY u.access_generation, event.status, event.resolved_by`,
+    [userId],
+  )
+  return result.rows[0]
+}
+
+async function waitUntilBlockedOnHolder(
+  inspector: Pool,
+  waiterPid: number,
+  holderPid: number,
+  timeoutMs = 8000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    const result = await inspector.query<{ blocked: boolean }>(
+      `SELECT $2::int = ANY(pg_blocking_pids($1::int)) AS blocked`,
+      [waiterPid, holderPid],
+    )
+    if (result.rows[0]?.blocked === true) return
+    await new Promise((resolve) => setTimeout(resolve, 25))
+  }
+  throw new Error(`timed out waiting for pid ${waiterPid} to block on ${holderPid}`)
+}
+
+describeIfDatabase('directory access-graph mutex (real DB)', () => {
+  beforeEach(cleanup)
+  afterAll(cleanup)
+
+  it('supersedes both event and effects while advancing generation', async () => {
+    const seeded = await seedAppliedEvidence()
+    const before = await readEvidence(seeded.userId)
+    expect(before.event_status).toBe('applied')
+
+    await transaction(async (client) => {
+      const locked = await lockUsersForAccessGraphWrite(client, [seeded.userId])
+      expect(locked.has(seeded.userId)).toBe(true)
+      await client.query(
+        `UPDATE user_external_auth_grants
+            SET enabled = TRUE, granted_by = 'admin:test', updated_at = NOW()
+          WHERE provider = 'dingtalk' AND local_user_id = $1`,
+        [seeded.userId],
+      )
+      await supersedeDeprovisionEvidenceForAccessGraphWrite(client, {
+        userIds: [seeded.userId],
+        actorId: 'admin:test',
+        reason: 'superseded by real-DB access override',
+      })
+    })
+
+    const after = await readEvidence(seeded.userId)
+    expect(Number(after.access_generation)).toBe(
+      Number(before.access_generation) + 1,
+    )
+    expect(after.event_status).toBe('superseded')
+    expect(new Set(after.effect_statuses)).toEqual(new Set(['superseded']))
+    expect(after.resolved_by).toBe('admin:test')
+  })
+
+  it('rolls generation and both evidence layers back with the access write', async () => {
+    const seeded = await seedAppliedEvidence()
+    const before = await readEvidence(seeded.userId)
+
+    await expect(
+      transaction(async (client) => {
+        await lockUsersForAccessGraphWrite(client, [seeded.userId])
+        await supersedeDeprovisionEvidenceForAccessGraphWrite(client, {
+          userIds: [seeded.userId],
+          actorId: 'admin:test',
+          reason: 'must roll back',
+        })
+        throw new Error('fail after evidence override')
+      }),
+    ).rejects.toThrow('fail after evidence override')
+
+    expect(await readEvidence(seeded.userId)).toEqual(before)
+  })
+
+  it('parks a competing writer on the canonical users row lock', async () => {
+    const seeded = await seedAppliedEvidence()
+    const pool = new Pool({ connectionString: process.env.DATABASE_URL })
+    const holder = await pool.connect()
+    const waiter = await pool.connect()
+    try {
+      await holder.query('BEGIN')
+      await waiter.query('BEGIN')
+      const holderPid = Number(
+        (await holder.query<{ pid: number }>('SELECT pg_backend_pid() AS pid'))
+          .rows[0].pid,
+      )
+      const waiterPid = Number(
+        (await waiter.query<{ pid: number }>('SELECT pg_backend_pid() AS pid'))
+          .rows[0].pid,
+      )
+      await holder.query(`SELECT id FROM users WHERE id = $1 FOR UPDATE`, [
+        seeded.userId,
+      ])
+
+      const lockPromise = lockUsersForAccessGraphWrite(waiter, [seeded.userId])
+      await waitUntilBlockedOnHolder(pool, waiterPid, holderPid)
+      await holder.query('ROLLBACK')
+
+      const locked = await lockPromise
+      expect(locked.has(seeded.userId)).toBe(true)
+      await supersedeDeprovisionEvidenceForAccessGraphWrite(waiter, {
+        userIds: [seeded.userId],
+        actorId: 'admin:waiter',
+        reason: 'serialized override',
+      })
+      await waiter.query('COMMIT')
+
+      const after = await readEvidence(seeded.userId)
+      expect(after.event_status).toBe('superseded')
+      expect(after.resolved_by).toBe('admin:waiter')
+    } finally {
+      await holder.query('ROLLBACK').catch(() => undefined)
+      await waiter.query('ROLLBACK').catch(() => undefined)
+      holder.release()
+      waiter.release()
+      await pool.end()
+    }
+  })
+})
+

--- a/packages/core-backend/tests/unit/access-graph-mutex.test.ts
+++ b/packages/core-backend/tests/unit/access-graph-mutex.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  lockUsersForAccessGraphWrite,
+  supersedeDeprovisionEvidenceForAccessGraphWrite,
+} from '../../src/directory/access-graph-mutex'
+
+describe('access-graph mutex protocol', () => {
+  it('deduplicates and locks multi-user batches in lexical order', async () => {
+    const calls: Array<{ sql: string; params: unknown[] }> = []
+    const client = {
+      query: vi.fn(async (sql: string, params: unknown[] = []) => {
+        calls.push({ sql, params })
+        return {
+          rows: [{
+            id: params[0],
+            email: null,
+            username: null,
+            mobile: null,
+            activation_status: 'activated',
+            is_active: true,
+            access_generation: 0,
+          }],
+        }
+      }),
+    }
+
+    const locked = await lockUsersForAccessGraphWrite(client, [
+      'user-z',
+      'user-a',
+      'user-z',
+      ' user-m ',
+    ])
+
+    expect(calls.map((call) => call.params[0])).toEqual([
+      'user-a',
+      'user-m',
+      'user-z',
+    ])
+    expect(calls.every((call) => /FROM users[\s\S]*FOR UPDATE/i.test(call.sql))).toBe(true)
+    expect(Array.from(locked.keys())).toEqual(['user-a', 'user-m', 'user-z'])
+  })
+
+  it('keeps supersede and generation as one inseparable helper contract', async () => {
+    const statements: string[] = []
+    const client = {
+      query: vi.fn(async (sql: string) => {
+        statements.push(sql)
+        if (/RETURNING access_generation/i.test(sql)) {
+          return { rows: [{ access_generation: 9 }] }
+        }
+        return { rows: [] }
+      }),
+    }
+
+    const generations = await supersedeDeprovisionEvidenceForAccessGraphWrite(
+      client,
+      {
+        userIds: ['user-1'],
+        actorId: 'admin-1',
+        reason: 'test override',
+      },
+    )
+
+    expect(statements).toHaveLength(3)
+    expect(statements[0]).toMatch(/UPDATE directory_deprovision_effects[\s\S]*status = 'superseded'/)
+    expect(statements[1]).toMatch(/UPDATE directory_deprovision_events[\s\S]*status = 'superseded'/)
+    expect(statements[2]).toMatch(/access_generation = COALESCE\(access_generation, 0\) \+ 1/)
+    expect(generations.get('user-1')).toBe(9)
+  })
+})
+

--- a/packages/core-backend/tests/unit/admin-users-routes.test.ts
+++ b/packages/core-backend/tests/unit/admin-users-routes.test.ts
@@ -2270,6 +2270,10 @@ describe('admin-users routes', () => {
       })
       .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ access_generation: 1 }] })
       .mockResolvedValueOnce({
         rows: [{
           enabled: true,
@@ -2296,6 +2300,63 @@ describe('admin-users routes', () => {
       resourceType: 'user-auth-grant',
       resourceId: 'user-1:dingtalk',
     }))
+    expect(pgMocks.query.mock.calls.some((call) =>
+      String(call[0]).includes('UPDATE directory_deprovision_effects'))).toBe(true)
+    expect(pgMocks.query.mock.calls.some((call) =>
+      String(call[0]).includes('access_generation = COALESCE'))).toBe(true)
+  })
+
+  it('pins grant override supersede and generation with SQL-shaped responses', async () => {
+    rbacMocks.isAdmin.mockResolvedValue(true)
+    pgMocks.query.mockImplementation(async (statement: unknown) => {
+      const sql = String(statement)
+      if (/FROM users[\s\S]*FOR UPDATE/i.test(sql)) {
+        return {
+          rows: [{
+            id: 'user-1',
+            email: 'alpha@example.com',
+            username: null,
+            mobile: null,
+            activation_status: 'activated',
+            is_active: true,
+            access_generation: 7,
+          }],
+        }
+      }
+      if (/SELECT local_user_id, enabled[\s\S]*user_external_auth_grants/i.test(sql)) {
+        return { rows: [] }
+      }
+      if (/UPDATE users[\s\S]*RETURNING access_generation/i.test(sql)) {
+        return { rows: [{ access_generation: 8 }] }
+      }
+      if (/SELECT enabled,[\s\S]*FROM user_external_auth_grants/i.test(sql)) {
+        return {
+          rows: [{
+            enabled: true,
+            granted_by: 'admin-1',
+            created_at: '2026-03-12T00:00:00.000Z',
+            updated_at: '2026-03-12T00:05:00.000Z',
+          }],
+        }
+      }
+      if (/COUNT\(\*\)::int AS linked_count/i.test(sql)) {
+        return { rows: [{ linked_count: 0 }] }
+      }
+      return { rows: [] }
+    })
+
+    const response = await invokeRoute('patch', '/api/admin/users/:userId/dingtalk-grant', {
+      params: { userId: 'user-1' },
+      body: { enabled: true },
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(pgMocks.query.mock.calls.some((call) =>
+      String(call[0]).includes('UPDATE directory_deprovision_effects'))).toBe(true)
+    expect(pgMocks.query.mock.calls.some((call) =>
+      String(call[0]).includes('UPDATE directory_deprovision_events'))).toBe(true)
+    expect(pgMocks.query.mock.calls.some((call) =>
+      String(call[0]).includes('access_generation = COALESCE'))).toBe(true)
   })
 
   it('rejects enabling dingtalk grant when bound identity is missing openId', async () => {
@@ -2338,12 +2399,19 @@ describe('admin-users routes', () => {
     rbacMocks.isAdmin.mockResolvedValue(true)
     pgMocks.query
       .mockResolvedValueOnce({
-        rows: [
-          { id: 'user-1' },
-          { id: 'user-2' },
-        ],
+        rows: [{ id: 'user-1', is_active: true, activation_status: 'activated', access_generation: 0 }],
+      })
+      .mockResolvedValueOnce({
+        rows: [{ id: 'user-2', is_active: true, activation_status: 'activated', access_generation: 0 }],
       })
       .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ access_generation: 1 }] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ access_generation: 1 }] })
 
     const response = await invokeRoute('post', '/api/admin/users/dingtalk-grants/bulk', {
       body: {
@@ -2358,8 +2426,10 @@ describe('admin-users routes', () => {
       updatedCount: 2,
       userIds: ['user-1', 'user-2'],
     })
-    expect(String(pgMocks.query.mock.calls[1]?.[0] || '')).toContain('INSERT INTO user_external_auth_grants')
-    expect(pgMocks.query.mock.calls[1]?.[1]).toEqual(['dingtalk', false, 'admin-1', ['user-1', 'user-2']])
+    const grantWrite = pgMocks.query.mock.calls.find((call) =>
+      String(call[0]).includes('INSERT INTO user_external_auth_grants'))
+    expect(String(grantWrite?.[0] || '')).toContain('INSERT INTO user_external_auth_grants')
+    expect(grantWrite?.[1]).toEqual(['dingtalk', false, 'admin-1', ['user-1', 'user-2']])
     expect(auditMocks.auditLog).toHaveBeenCalledTimes(2)
     expect(auditMocks.auditLog).toHaveBeenNthCalledWith(1, expect.objectContaining({
       action: 'revoke',
@@ -2381,16 +2451,20 @@ describe('admin-users routes', () => {
         selectionSize: 2,
       }),
     }))
+    expect(pgMocks.query.mock.calls.filter((call) =>
+      String(call[0]).includes('UPDATE directory_deprovision_effects'))).toHaveLength(2)
+    expect(pgMocks.query.mock.calls.filter((call) =>
+      String(call[0]).includes('access_generation = COALESCE'))).toHaveLength(2)
   })
 
   it('rejects bulk enabling dingtalk grants when one identity is missing openId', async () => {
     rbacMocks.isAdmin.mockResolvedValue(true)
     pgMocks.query
       .mockResolvedValueOnce({
-        rows: [
-          { id: 'user-1' },
-          { id: 'user-2' },
-        ],
+        rows: [{ id: 'user-1', is_active: true, activation_status: 'activated', access_generation: 0 }],
+      })
+      .mockResolvedValueOnce({
+        rows: [{ id: 'user-2', is_active: true, activation_status: 'activated', access_generation: 0 }],
       })
       .mockResolvedValueOnce({
         rows: [
@@ -2412,7 +2486,7 @@ describe('admin-users routes', () => {
     expect(response.statusCode).toBe(400)
     expect((response.body as Record<string, any>).error.code).toBe('DINGTALK_OPEN_ID_REQUIRED')
     expect(String((response.body as Record<string, any>).error.message || '')).toContain('user-2')
-    expect(String(pgMocks.query.mock.calls[1]?.[0] || '')).toContain('provider_open_id')
+    expect(String(pgMocks.query.mock.calls[2]?.[0] || '')).toContain('provider_open_id')
     expect(auditMocks.auditLog).not.toHaveBeenCalled()
   })
 
@@ -2691,6 +2765,8 @@ describe('admin-users routes', () => {
           name: 'Alpha',
           role: 'user',
           is_active: true,
+          activation_status: 'activated',
+          access_generation: 0,
           is_admin: false,
           last_login_at: null,
           created_at: '2026-03-12T00:00:00.000Z',
@@ -2698,6 +2774,9 @@ describe('admin-users routes', () => {
         }],
       })
       .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ access_generation: 1 }] })
       .mockResolvedValueOnce({
         rows: [{
           revoked_after: '2026-03-12T00:01:00.000Z',
@@ -2731,6 +2810,10 @@ describe('admin-users routes', () => {
     expect(response.statusCode).toBe(200)
     expect((response.body as Record<string, any>).data.user.is_active).toBe(false)
     expect(auditMocks.auditLog).toHaveBeenCalled()
+    expect(pgMocks.query.mock.calls.some((call) =>
+      String(call[0]).includes('UPDATE directory_deprovision_effects'))).toBe(true)
+    expect(pgMocks.query.mock.calls.some((call) =>
+      String(call[0]).includes('access_generation = COALESCE'))).toBe(true)
   })
 
   it('creates a user with preset-driven onboarding metadata', async () => {

--- a/packages/core-backend/tests/unit/auth-invite-routes.test.ts
+++ b/packages/core-backend/tests/unit/auth-invite-routes.test.ts
@@ -206,6 +206,18 @@ describe('auth invite routes', () => {
           updated_at: '2026-03-13T00:00:00.000Z',
         }],
       })
+      // canonical users FOR UPDATE mutex
+      .mockResolvedValueOnce({
+        rows: [{
+          id: 'user-1',
+          email: 'alpha@example.com',
+          username: null,
+          mobile: null,
+          is_active: false,
+          activation_status: 'activated',
+          access_generation: 0,
+        }],
+      })
       // markInviteAccepted FIRST (ledger-first) — must RETURNING non-empty
       .mockResolvedValueOnce({
         rows: [{
@@ -227,6 +239,9 @@ describe('auth invite routes', () => {
       })
       // UPDATE users ... RETURNING id (must be non-empty)
       .mockResolvedValueOnce({ rows: [{ id: 'user-1' }] })
+      .mockResolvedValueOnce({ rows: [] }) // supersede effects
+      .mockResolvedValueOnce({ rows: [] }) // supersede events
+      .mockResolvedValueOnce({ rows: [{ access_generation: 1 }] })
     bcryptMocks.hash.mockResolvedValue('hashed-password')
     sessionMocks.revokeUserSessions.mockResolvedValue({ revokedAfter: '2026-03-13T00:05:00.000Z' })
     authServiceMocks.login.mockResolvedValue({
@@ -253,17 +268,22 @@ describe('auth invite routes', () => {
     expect(response.statusCode).toBe(200)
     expect(bcryptMocks.hash).toHaveBeenCalledWith('WelcomePass9A', 10)
     expect(pgMocks.transaction).toHaveBeenCalled()
-    expect(String(pgMocks.query.mock.calls[1]?.[0] || '')).toContain('user_invites')
+    expect(String(pgMocks.query.mock.calls[1]?.[0] || '')).toContain('FOR UPDATE')
+    expect(String(pgMocks.query.mock.calls[2]?.[0] || '')).toContain('user_invites')
     expect(pgMocks.query).toHaveBeenNthCalledWith(
-      3,
+      4,
       expect.stringContaining('UPDATE users'),
       ['hashed-password', 'Alpha User', 'user-1', 'alpha@example.com'],
     )
-    const updateSql = String(pgMocks.query.mock.calls[2]?.[0] || '')
+    const updateSql = String(pgMocks.query.mock.calls[3]?.[0] || '')
     expect(updateSql).toContain('must_change_password = FALSE')
     expect(updateSql).toContain('local_password_set = TRUE')
     expect(updateSql).toContain('RETURNING id')
     expect(updateSql).toContain("activation_status = 'activated'")
+    expect(pgMocks.query.mock.calls.some((call) =>
+      String(call[0]).includes('UPDATE directory_deprovision_effects'))).toBe(true)
+    expect(pgMocks.query.mock.calls.some((call) =>
+      String(call[0]).includes('access_generation = COALESCE'))).toBe(true)
     expect(sessionMocks.revokeUserSessions).toHaveBeenCalledWith('user-1', expect.objectContaining({
       updatedBy: 'user-1',
       reason: 'invite-accepted',
@@ -312,6 +332,8 @@ describe('auth invite routes', () => {
     expect(pgMocks.transaction).not.toHaveBeenCalled()
     expect(sessionMocks.revokeUserSessions).not.toHaveBeenCalled()
     expect(authServiceMocks.login).not.toHaveBeenCalled()
+    expect(pgMocks.query.mock.calls.some((call) =>
+      String(call[0]).includes('directory_deprovision_effects'))).toBe(false)
   })
 
   it('stops with 409 when user UPDATE returns zero rows (ledger already claimed → txn rolls back)', async () => {
@@ -331,6 +353,17 @@ describe('auth invite routes', () => {
           is_active: true,
           activation_status: 'activated',
           updated_at: '2026-03-13T00:00:00.000Z',
+        }],
+      })
+      .mockResolvedValueOnce({
+        rows: [{
+          id: 'user-1',
+          email: 'alpha@example.com',
+          username: null,
+          mobile: null,
+          is_active: true,
+          activation_status: 'activated',
+          access_generation: 0,
         }],
       })
       // Ledger consume succeeds
@@ -365,8 +398,8 @@ describe('auth invite routes', () => {
 
     expect(response.statusCode).toBe(409)
     expect((response.body as Record<string, any>).code).toBe('INVITE_TARGET_UPDATE_MISMATCH')
-    expect(String(pgMocks.query.mock.calls[1]?.[0] || '')).toContain('user_invites')
-    expect(String(pgMocks.query.mock.calls[2]?.[0] || '')).toContain('UPDATE users')
+    expect(String(pgMocks.query.mock.calls[2]?.[0] || '')).toContain('user_invites')
+    expect(String(pgMocks.query.mock.calls[3]?.[0] || '')).toContain('UPDATE users')
     expect(sessionMocks.revokeUserSessions).not.toHaveBeenCalled()
     expect(authServiceMocks.login).not.toHaveBeenCalled()
   })
@@ -390,6 +423,17 @@ describe('auth invite routes', () => {
           updated_at: '2026-03-13T00:00:00.000Z',
         }],
       })
+      .mockResolvedValueOnce({
+        rows: [{
+          id: 'user-1',
+          email: 'alpha@example.com',
+          username: null,
+          mobile: null,
+          is_active: true,
+          activation_status: 'activated',
+          access_generation: 0,
+        }],
+      })
       // Ledger consume zero rows (missing or already accepted)
       .mockResolvedValueOnce({ rows: [] })
     bcryptMocks.hash.mockResolvedValue('hashed-password')
@@ -403,9 +447,9 @@ describe('auth invite routes', () => {
 
     expect(response.statusCode).toBe(409)
     expect((response.body as Record<string, any>).code).toBe('INVITE_LEDGER_CONSUME_FAILED')
-    // getInviteTarget + ledger UPDATE only; users password write must not run
-    expect(pgMocks.query).toHaveBeenCalledTimes(2)
-    expect(String(pgMocks.query.mock.calls[1]?.[0] || '')).toContain('user_invites')
+    // getInviteTarget + user mutex + ledger UPDATE only; password write must not run
+    expect(pgMocks.query).toHaveBeenCalledTimes(3)
+    expect(String(pgMocks.query.mock.calls[2]?.[0] || '')).toContain('user_invites')
     expect(sessionMocks.revokeUserSessions).not.toHaveBeenCalled()
     expect(authServiceMocks.login).not.toHaveBeenCalled()
   })
@@ -427,6 +471,17 @@ describe('auth invite routes', () => {
           is_active: true,
           activation_status: 'activated',
           updated_at: '2026-03-13T00:00:00.000Z',
+        }],
+      })
+      .mockResolvedValueOnce({
+        rows: [{
+          id: 'user-1',
+          email: 'alpha@example.com',
+          username: null,
+          mobile: null,
+          is_active: true,
+          activation_status: 'activated',
+          access_generation: 0,
         }],
       })
       // UPDATE ... WHERE status='pending' matches nothing for revoked rows

--- a/packages/core-backend/tests/unit/user-activate.test.ts
+++ b/packages/core-backend/tests/unit/user-activate.test.ts
@@ -44,6 +44,9 @@ describe('activatePendingUser (T3)', () => {
         }],
       }) // FOR UPDATE
       .mockResolvedValueOnce({ rows: [{ id: 'u1' }] }) // UPDATE users RETURNING
+      .mockResolvedValueOnce({ rows: [] }) // supersede effects
+      .mockResolvedValueOnce({ rows: [] }) // supersede events
+      .mockResolvedValueOnce({ rows: [{ access_generation: 1 }] }) // generation
 
     const result = await activatePendingUser({
       userId: 'u1',
@@ -58,6 +61,12 @@ describe('activatePendingUser (T3)', () => {
     const updateSql = String(pgMocks.query.mock.calls.find((c) => String(c[0]).includes('UPDATE users'))?.[0] || '')
     expect(updateSql).toContain("activation_status = 'activated'")
     expect(updateSql).toContain('local_password_set')
+    expect(pgMocks.query.mock.calls.some((call) =>
+      String(call[0]).includes('UPDATE directory_deprovision_effects'))).toBe(true)
+    expect(pgMocks.query.mock.calls.some((call) =>
+      String(call[0]).includes('UPDATE directory_deprovision_events'))).toBe(true)
+    expect(pgMocks.query.mock.calls.some((call) =>
+      String(call[0]).includes('access_generation = COALESCE'))).toBe(true)
     // Alias claims must run inside the transaction client
     expect(claimLoginAlias).toHaveBeenCalled()
     expect(vi.mocked(claimLoginAlias).mock.calls[0]?.[0]).toMatchObject({

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -240,6 +240,10 @@ export default defineConfig({
       // lock-wait race that proved the stale globally-clear P1, and the §5.4 supersede
       // both-legs golden. DATABASE_URL-gated; whole-file wired into the approval real-DB step.
       'tests/integration/directory-deprovision-race-supersede.db.test.ts',
+      // D5 canonical per-user access-graph mutex: supersede+generation atomicity, rollback,
+      // and a pg_blocking_pids row-lock barrier. DATABASE_URL-gated; excluded here and
+      // whole-file wired into the approval real-DB step.
+      'tests/integration/directory-access-graph-mutex.db.test.ts',
       // DingTalk multi-corp external-key isolation: corp-scoped uniqueness, upgrade migration,
       // real-sync coexistence, and same-corp/cross-corp identity matching controls.
       // DATABASE_URL-gated; excluded here so the no-DB job cannot skip-green it, and wired as a

--- a/plugins/plugin-integration-core/lib/sealed-export/vectors/s6a-package-provenance-pins.json
+++ b/plugins/plugin-integration-core/lib/sealed-export/vectors/s6a-package-provenance-pins.json
@@ -86,6 +86,6 @@
     "s6aAcceptancePs51Test": "835c7c6ce943d82e0378a40a27c7fd1e8b79b526faa8ca4c8066e4231a4bfb0f",
     "s6aProductRuntimeTest": "de978adafa8b89772cefa921c2051f434bf346bf5c2978bef3424ee70f51ba3f",
     "multitableOnpremPackageBuild": "463c7d73c6c7f2d1b6cdf0820d7a06974a9c463dd5e98bbbaf1c996e1dc4ed99",
-    "pluginTestsWorkflow": "f7a114c5cfcd31c71e9fc4ba51a64a8c2460f1aa6326393fa5e93c1404cd1942"
+    "pluginTestsWorkflow": "e86884d5366ea4cfb0291c671e399b3746f028ff0962b6495c18916f6b73159f"
   }
 }

--- a/scripts/ops/directory-access-graph-mutex-ci-wiring.test.mjs
+++ b/scripts/ops/directory-access-graph-mutex-ci-wiring.test.mjs
@@ -1,0 +1,48 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { existsSync, readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import {
+  REAL_DB_STEP_IDS,
+  isSuiteWiredInRealDbStep,
+  realDbStepWholeFileArgs,
+} from './ci-realdb-step-contract.mjs'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const repoRoot = join(__dirname, '..', '..')
+const FILE = 'tests/integration/directory-access-graph-mutex.db.test.ts'
+const STEP_ID = REAL_DB_STEP_IDS.approval
+
+test('vitest.config.ts excludes the D5 mutex suite from the no-DB job', () => {
+  const cfg = readFileSync(
+    join(repoRoot, 'packages/core-backend/vitest.config.ts'),
+    'utf8',
+  )
+  assert.ok(cfg.includes(`'${FILE}'`), `vitest.config.ts must exclude ${FILE}`)
+})
+
+test('plugin-tests.yml runs the D5 mutex suite as a whole file in the approval real-DB step', () => {
+  const workflow = readFileSync(
+    join(repoRoot, '.github/workflows/plugin-tests.yml'),
+    'utf8',
+  )
+  assert.ok(
+    isSuiteWiredInRealDbStep(workflow, STEP_ID, FILE),
+    `plugin-tests.yml real-DB step id "${STEP_ID}" must run ${FILE} as a whole-file argument`,
+  )
+  assert.equal(
+    realDbStepWholeFileArgs(workflow, REAL_DB_STEP_IDS.multitable).includes(FILE),
+    false,
+    `${FILE} must not be wired into the multitable real-DB step`,
+  )
+})
+
+test('the D5 mutex suite file exists on disk', () => {
+  assert.ok(
+    existsSync(join(repoRoot, 'packages/core-backend', FILE)),
+    `wired suite packages/core-backend/${FILE} must exist on disk`,
+  )
+})
+


### PR DESCRIPTION
## Scope

D5a stacked on #4647. Introduces the canonical per-user `users FOR UPDATE` mutex and applies it to pending activation, invite acceptance, administrator user status, and administrator DingTalk grant writes. Every actual access-graph override supersedes open event/effect evidence and advances `users.access_generation` in the same transaction. Multi-user writes lock normalized ids in lexical order.

This draft does not enable any lifecycle flag. D5 bind/unbind, sync mirror transitions, and OAuth writers remain in following stacked windows.

## Verification

- core-backend `tsc --noEmit`
- 83 focused unit tests
- 13 real-DB tests, including existing invite concurrency and new `pg_blocking_pids()` mutex barrier
- CI wiring guard 3/3
- mutations: remove event supersede -> real-DB red; remove admin helper call -> route test red; remove sorted locking -> mutex unit red

## Landing

Draft / unarmed. Review and land only after #4646 then #4647.