### PR TITLE
feat(approval): unify linear and graph canvas carriers

### DIFF
--- a/apps/web/src/approvals/components/ApprovalGraphNodeConfigEditor.vue
+++ b/apps/web/src/approvals/components/ApprovalGraphNodeConfigEditor.vue
@@ -326,9 +326,11 @@
 
     <!-- G-5: editable approval node — approver SOURCE only (assigneeSources[0]). The node's
          approvalMode / emptyAssigneePolicy / autoApprovalPolicy + edges are preserved. Legacy
-         nodes (no assigneeSources) aren't seeded → fall to the read-only summary below. -->
+         nodes (no assigneeSources) aren't seeded → fall to the read-only summary below.
+         C1: the same form serves a LINEAR draft's step nodes, whose carrier is the step draft —
+         hence the carrier-agnostic `hasApprovalNodeEditor` gate. -->
     <div
-      v-else-if="node.type === 'approval' && approvalNodeEditFor(node.key)"
+      v-else-if="node.type === 'approval' && hasApprovalNodeEditor(node.key)"
       class="template-authoring__approval-node"
       data-testid="approval-node-editor"
       :data-approval-node="node.key"
@@ -561,7 +563,7 @@ const formulaRoles = computed(() => unwrap(api.formulaRoles))
 const conditionEditFor = api.conditionEditFor
 const parallelEditFor = api.parallelEditFor
 const ccEditFor = api.ccEditFor
-const approvalNodeEditFor = api.approvalNodeEditFor
+const hasApprovalNodeEditor = api.hasApprovalNodeEditor
 const conditionOperatorLabel = api.conditionOperatorLabel
 const liveBranchSummary = api.liveBranchSummary
 const conditionRuleValueText = api.conditionRuleValueText

--- a/apps/web/src/approvals/linearCanvasCarrier.ts
+++ b/apps/web/src/approvals/linearCanvasCarrier.ts
@@ -1,0 +1,37 @@
+import type { ApprovalStepDraft } from './templateAuthoring'
+
+/**
+ * C1 unified canvas — the ONE place that knows which `ApprovalStepDraft` a linear draft's canvas
+ * node stands for.
+ *
+ * The canvas renders `buildApprovalGraph(draft)` for BOTH shapes: a preserved complex graph is
+ * emitted verbatim, and a linear draft is projected into `start → approval_N* → end`. For the
+ * complex shape every node already has a persisted carrier (`draft.approvalNodeEdits[nodeKey]`);
+ * for the linear shape the carrier is the step itself, and the ONLY link between a canvas node and
+ * that step is the key `buildApprovalGraph` assigned to it. So that key convention lives here and
+ * `buildApprovalGraph` imports it — one definition, no second regex to drift from it.
+ *
+ * Deliberately pure and renderer-free: no coordinates, no selection/zoom, no Vue. Layout is
+ * `graphLayout.computeLayout`'s job and stays out of the graph the adapter produces.
+ */
+
+/** The node key `buildApprovalGraph` gives the linear step at 0-based `index`. */
+export function linearStepNodeKey(index: number): string {
+  return `approval_${index + 1}`
+}
+
+/**
+ * The step a linear draft's canvas node edits, or `undefined` when `nodeKey` is not a step node
+ * (`start`/`end`, or a key from some other graph). Resolved by re-deriving `linearStepNodeKey` per
+ * position rather than parsing the key, so the lookup can never disagree with the builder.
+ *
+ * Callers must only reach here for a LINEAR draft (no `preservedGraph`): once a draft is promoted,
+ * `steps` is emptied and `approvalNodeEdits` is the carrier.
+ */
+export function linearStepForNodeKey(
+  steps: ApprovalStepDraft[],
+  nodeKey: string,
+): ApprovalStepDraft | undefined {
+  const index = steps.findIndex((_step, position) => linearStepNodeKey(position) === nodeKey)
+  return index === -1 ? undefined : steps[index]
+}

--- a/apps/web/src/approvals/nodeConfigEditorContext.ts
+++ b/apps/web/src/approvals/nodeConfigEditorContext.ts
@@ -15,7 +15,6 @@ import type {
   ConditionRuleOperator,
   CcNodeEdit,
   ParallelNodeEdit,
-  ApprovalNodeSourceEdit,
 } from './templateAuthoring'
 import type { FormulaInsertOption } from './conditionEdit'
 
@@ -23,13 +22,25 @@ import type { FormulaInsertOption } from './conditionEdit'
  * Shared context for G-2..G-5 node config editors. Canvas inspector and structured-list mode both
  * inject this so they mutate the SAME draft.conditionEdits / parallelEdits / ccEdits /
  * approvalNodeEdits handlers — one source of truth (Canvas V2 Slice A).
+ *
+ * C1: the approval-node accessors below are carrier-agnostic. A node from a preserved complex graph
+ * resolves to `draft.approvalNodeEdits[nodeKey]`; a node projected from a LINEAR draft resolves to
+ * the matching `draft.steps[i]` (see `linearCanvasCarrier`). Both write straight through to the
+ * draft the payload builders read — the inspector never holds a shadow copy of either.
  */
 export interface ApprovalNodeConfigEditorApi {
   readOnly: ComputedRef<boolean> | Ref<boolean> | boolean
   conditionEditFor: (nodeKey: string) => ConditionNodeEdit | undefined
   parallelEditFor: (nodeKey: string) => ParallelNodeEdit | undefined
   ccEditFor: (nodeKey: string) => CcNodeEdit | undefined
-  approvalNodeEditFor: (nodeKey: string) => ApprovalNodeSourceEdit | undefined
+  /**
+   * True when an `approval` node has an edit carrier and so renders the editable form rather than
+   * the read-only summary (a legacy complex node with no `assigneeSources` has none). This is the
+   * render gate ON PURPOSE — gating on a carrier OBJECT would silently exclude linear steps, whose
+   * carrier is not an `ApprovalNodeSourceEdit`. Says nothing about `readOnly`, which disables the
+   * controls but still renders them.
+   */
+  hasApprovalNodeEditor: (nodeKey: string) => boolean
   conditionFieldOptions: ComputedRef<Array<{ id: string; label: string }>> | Array<{ id: string; label: string }>
   userFields: ComputedRef<Array<{ id: string; label: string }>> | Array<{ id: string; label: string }>
   conditionFormulaInsertOptions: ComputedRef<FormulaInsertOption[]> | FormulaInsertOption[]

--- a/apps/web/src/approvals/templateAuthoring.ts
+++ b/apps/web/src/approvals/templateAuthoring.ts
@@ -50,6 +50,7 @@ import {
   validateApprovalNodeEdits,
   type ApprovalNodeEdits,
 } from './approvalNodeEdit'
+import { linearStepNodeKey } from './linearCanvasCarrier'
 
 export type { DetailColumnDraft } from './detailField'
 export { createEmptyDetailColumnDraft, DETAIL_LEAF_FIELD_TYPES } from './detailField'
@@ -1012,7 +1013,9 @@ export function buildApprovalGraph(draft: TemplateAuthoringDraft): ApprovalGraph
   // whose field was deleted so a dangling fieldId can never reach the backend cross-reference.
   const fieldIds = new Set(draft.fields.map((field) => field.id.trim()).filter(Boolean))
   const approvalNodes = draft.steps.map((step, index) => ({
-    key: `approval_${index + 1}`,
+    // C1: the key convention is owned by `linearCanvasCarrier` so the canvas inspector can resolve
+    // a linear node back to THIS step (its edit carrier) without a second copy of the rule.
+    key: linearStepNodeKey(index),
     type: 'approval' as const,
     name: step.name.trim() || `审批人 ${index + 1}`,
     config: buildStepConfig(step, fieldIds),

--- a/apps/web/src/views/approval/TemplateAuthoringView.vue
+++ b/apps/web/src/views/approval/TemplateAuthoringView.vue
@@ -535,8 +535,10 @@
         </template>
 
         <!-- Complex graphs use a canvas for topology and a structured list for node configuration. -->
-        <!-- D-6 view toggle: structured list ⇄ visual canvas (complex graphs only) -->
-        <div v-if="graphReadOnly && canvasV2Enabled" class="template-authoring__view-toggle" data-testid="approval-graph-view-toggle">
+        <!-- D-6 view toggle: structured list ⇄ visual canvas. C1: available for a LINEAR draft too
+             (its structured list is the step-card stack below), so both shapes reach the same canvas
+             through the same `buildApprovalGraph` adapter. `list` stays the default either way. -->
+        <div v-if="canvasAvailable" class="template-authoring__view-toggle" data-testid="approval-graph-view-toggle">
           <el-button size="small" :type="canvasViewMode === 'list' ? 'primary' : 'default'" data-testid="approval-view-list" @click="canvasViewMode = 'list'">结构列表</el-button>
           <el-button size="small" :type="canvasViewMode === 'canvas' ? 'primary' : 'default'" data-testid="approval-view-canvas" @click="canvasViewMode = 'canvas'">画布视图</el-button>
         </div>
@@ -546,7 +548,7 @@
              ApprovalFlowCanvas is a presentational shell (E2 extraction) — this view stays the
              owner of selection/zoom/move state and every topology/command handler below. -->
         <ApprovalFlowCanvas
-          v-if="graphReadOnly && canvasV2Enabled && canvasViewMode === 'canvas'"
+          v-if="canvasAvailable && canvasViewMode === 'canvas'"
           ref="flowCanvasRef"
           :read-only="readOnly"
           :canvas-validity="canvasValidity"
@@ -594,7 +596,7 @@
           @remove-node="onRemoveNode"
         />
 
-        <div v-if="graphReadOnly && (!canvasV2Enabled || canvasViewMode === 'list')" data-testid="approval-graph-readonly-list">
+        <div v-if="graphReadOnly && (!canvasAvailable || canvasViewMode === 'list')" data-testid="approval-graph-readonly-list">
           <div
             v-for="node in graphPreviewNodes"
             :key="node.key"
@@ -659,7 +661,7 @@
              straight from draft.steps (see linearStepSpine.ts). Not editable here; clicking a step
              chip scrolls to and briefly highlights the matching card below. -->
         <div
-          v-if="!graphReadOnly"
+          v-if="!graphReadOnly && !linearCanvasActive"
           class="template-authoring__spine"
           data-testid="approval-template-step-spine"
         >
@@ -687,9 +689,12 @@
           </template>
         </div>
 
+        <!-- C1: the step cards ARE the structured list for a linear draft — the D-6 toggle swaps
+             them for the canvas exactly as it swaps `approval-graph-readonly-list` for a complex
+             graph, and they come back untouched on 结构列表 (nothing about the toggle edits them). -->
         <div
           v-for="(step, index) in draft.steps"
-          v-show="!graphReadOnly"
+          v-show="!graphReadOnly && !linearCanvasActive"
           :id="`approval-step-card-${step.localId}`"
           :key="step.localId"
           class="template-authoring__item"
@@ -1198,6 +1203,7 @@ import { routePreviewAssigneeSummary } from '../../approvals/routePreviewSummary
 import { describeRoutePreviewError } from '../../approvals/routePreviewErrors'
 import { computeRequesterPreviewFields } from '../../approvals/requesterPreviewFields'
 import { buildLinearStepSpine, type LinearStepSpineChip } from '../../approvals/linearStepSpine'
+import { linearStepForNodeKey } from '../../approvals/linearCanvasCarrier'
 import ApprovalUserPicker from '../../approvals/components/ApprovalUserPicker.vue'
 import ApprovalGraphNodeConfigEditor from '../../approvals/components/ApprovalGraphNodeConfigEditor.vue'
 import ApprovalFlowCanvas from '../../approvals/components/ApprovalFlowCanvas.vue'
@@ -1803,30 +1809,60 @@ function ccTargetTypeLabel(targetType: ApprovalAssigneeType): string {
 // (`draft.approvalNodeEdits[nodeKey].assigneeSources`) is seeded 1:1 + carried through
 // `applyApprovalNodeEditsToGraph` (every other node + all edges byte-identical). Any extra sources
 // (index 1+) are preserved verbatim. Shared with the canvas inspector via provide/inject.
+//
+// C1: every accessor below is CARRIER-AGNOSTIC. For a LINEAR draft the canvas node's carrier is the
+// step draft itself (`linearStepForNode`), so the inspector writes the very fields the step card
+// writes — `buildApprovalGraph`/`buildStepConfig` then emit them, and merely LOOKING at the canvas
+// seeds nothing (no `approvalNodeEdits` entry is created for a linear draft, so opening the canvas
+// can not dirty the draft or move the payload).
 function approvalNodeEditFor(nodeKey: string): ApprovalNodeSourceEdit | undefined {
   return draft.value.approvalNodeEdits?.[nodeKey]
+}
+/** The step a linear draft's canvas node edits — `undefined` for a promoted/complex draft. */
+function linearStepForNode(nodeKey: string): ApprovalStepDraft | undefined {
+  if (draft.value.preservedGraph) return undefined
+  return linearStepForNodeKey(draft.value.steps, nodeKey)
+}
+/** Render gate for the editable approval form (see `hasApprovalNodeEditor` in the shared API). */
+function hasApprovalNodeEditor(nodeKey: string): boolean {
+  return Boolean(linearStepForNode(nodeKey) ?? approvalNodeEditFor(nodeKey))
 }
 function approvalNodeFirstSource(nodeKey: string): ApprovalAssigneeSource | undefined {
   return approvalNodeEditFor(nodeKey)?.assigneeSources[0]
 }
 function approvalNodeMode(nodeKey: string): ApprovalMode {
+  const step = linearStepForNode(nodeKey)
+  if (step) return step.approvalMode
   return approvalNodeEditFor(nodeKey)?.approvalMode ?? 'single'
 }
 function setApprovalNodeMode(nodeKey: string, mode: ApprovalMode): void {
+  const step = linearStepForNode(nodeKey)
+  if (step) { step.approvalMode = mode; return }
   const edit = approvalNodeEditFor(nodeKey)
   if (edit) edit.approvalMode = mode
 }
 function approvalNodeEmptyPolicy(nodeKey: string): EmptyAssigneePolicy {
+  const step = linearStepForNode(nodeKey)
+  if (step) return step.emptyAssigneePolicy
   return approvalNodeEditFor(nodeKey)?.emptyAssigneePolicy ?? 'error'
 }
 function setApprovalNodeEmptyPolicy(nodeKey: string, policy: EmptyAssigneePolicy): void {
+  const step = linearStepForNode(nodeKey)
+  if (step) { step.emptyAssigneePolicy = policy; return }
   const edit = approvalNodeEditFor(nodeKey)
   if (edit) edit.emptyAssigneePolicy = policy
 }
 function approvalNodeMergeWithRequester(nodeKey: string): boolean {
+  // Linear carrier: `mergeWithRequester` is its own boolean field; the three non-merge
+  // `autoApprovalPolicy` sub-fields live in `originalAutoApprovalPolicy` and `buildStepConfig`
+  // recomposes them — so the toggle stays the only authored sub-field on both carriers.
+  const step = linearStepForNode(nodeKey)
+  if (step) return step.mergeWithRequester
   return Boolean(approvalNodeEditFor(nodeKey)?.autoApprovalPolicy?.mergeWithRequester)
 }
 function setApprovalNodeMergeWithRequester(nodeKey: string, enabled: boolean): void {
+  const step = linearStepForNode(nodeKey)
+  if (step) { step.mergeWithRequester = enabled; return }
   const edit = approvalNodeEditFor(nodeKey)
   if (!edit) return
   const policy = edit.autoApprovalPolicy && edit.autoApprovalPolicy !== null
@@ -1837,9 +1873,14 @@ function setApprovalNodeMergeWithRequester(nodeKey: string, enabled: boolean): v
   edit.autoApprovalPolicy = Object.keys(policy).length > 0 ? policy : null
 }
 function approvalNodeFieldAccess(nodeKey: string, fieldId: string): NodeFieldAccess {
+  const step = linearStepForNode(nodeKey)
+  if (step) return stepFieldAccess(step, fieldId)
   return approvalNodeEditFor(nodeKey)?.fieldPermissions?.find((permission) => permission.fieldId === fieldId)?.access ?? 'editable'
 }
 function setApprovalNodeFieldAccess(nodeKey: string, fieldId: string, access: NodeFieldAccess): void {
+  const step = linearStepForNode(nodeKey)
+  // Same `setStepFieldPermission` write the step card's select performs (absent === editable).
+  if (step) { onStepFieldAccessChange(step, fieldId, access); return }
   const edit = approvalNodeEditFor(nodeKey)
   if (!edit) return
   const next = (edit.fieldPermissions ?? []).filter((permission) => permission.fieldId !== fieldId)
@@ -1853,9 +1894,17 @@ function setApprovalNodeSource(nodeKey: string, source: ApprovalAssigneeSource):
   edit.assigneeSources = [source, ...edit.assigneeSources.slice(1)]
 }
 function approvalSourceKind(nodeKey: string): ApprovalAssigneeSourceKind {
+  const step = linearStepForNode(nodeKey)
+  if (step) return step.sourceKind
   return approvalNodeFirstSource(nodeKey)?.kind ?? 'requester'
 }
 function setApprovalSourceKind(nodeKey: string, kind: ApprovalAssigneeSourceKind): void {
+  // Linear carrier: set ONLY `sourceKind`, exactly as the step card's `v-model="step.sourceKind"`
+  // does — the per-kind carriers (`idsText` / `fieldId` / `levels` / `level`) survive a kind switch
+  // there, and `sourceFromStep` reads only the one the new kind needs. The complex branch below
+  // builds a FRESH source object because its carrier holds no per-kind siblings to preserve.
+  const step = linearStepForNode(nodeKey)
+  if (step) { step.sourceKind = kind; return }
   const next: ApprovalAssigneeSource =
     kind === 'static_user' ? { kind, userIds: [] }
       : kind === 'static_role' ? { kind, roleIds: [] }
@@ -1866,6 +1915,10 @@ function setApprovalSourceKind(nodeKey: string, kind: ApprovalAssigneeSourceKind
   setApprovalNodeSource(nodeKey, next)
 }
 function approvalSourceIds(nodeKey: string): string[] {
+  const step = linearStepForNode(nodeKey)
+  // The step's `idsText` is the SOLE carrier (parsed only at save time), so the picker reads the
+  // same `stepIds` projection the step card's picker reads.
+  if (step) return step.sourceKind === 'static_user' || step.sourceKind === 'static_role' ? stepIds(step) : []
   const source = approvalNodeFirstSource(nodeKey)
   if (source?.kind === 'static_user') return source.userIds
   if (source?.kind === 'static_role') return source.roleIds
@@ -1915,8 +1968,13 @@ function onRemoveNode(nodeKey: string): void {
   // Canvas V2 Slice A: deleting the selected node clears selection and closes the inspector.
   if (selectedCanvasNode.value === nodeKey) clearCanvasSelection()
 }
+// C1: count edges on the EFFECTIVE graph, not `preservedGraph` alone. A linear draft has no
+// `preservedGraph` yet renders real nodes on the canvas — a preservedGraph-only count would report 0
+// edges for every one of them and silently hide every insert/remove affordance (and, for a guard
+// read as "no outgoing edge", could offer an op the engine then rejects). `canvasEffectiveGraph` is
+// the same graph the canvas draws and the same one the topology op runs on.
 function topologyEdgeCount(nodeKey: string, dir: 'source' | 'target'): number {
-  return (draft.value.preservedGraph?.edges ?? []).filter((edge) => edge[dir] === nodeKey).length
+  return canvasEffectiveGraph.value.edges.filter((edge) => edge[dir] === nodeKey).length
 }
 function canInsertAfter(node: ApprovalNode): boolean {
   return node.type !== 'end' && topologyEdgeCount(node.key, 'source') === 1
@@ -1925,7 +1983,7 @@ function canInsertAfter(node: ApprovalNode): boolean {
 // parallel node"), and the canvas lock requires guiding toward valid shapes rather than building a
 // 422. Condition-in-parallel stays legal, so only the +并行 affordance is gated by region membership.
 const parallelRegionKeys = computed<Set<string>>(() =>
-  collectParallelRegionNodeKeys(draft.value.preservedGraph ?? { nodes: [], edges: [] }),
+  collectParallelRegionNodeKeys(canvasEffectiveGraph.value),
 )
 function canInsertParallelAfter(node: ApprovalNode): boolean {
   return canInsertAfter(node) && !parallelRegionKeys.value.has(node.key)
@@ -1935,6 +1993,11 @@ function canRemoveNode(node: ApprovalNode): boolean {
     && topologyEdgeCount(node.key, 'target') === 1
     && topologyEdgeCount(node.key, 'source') === 1
   if (!isLinearRemovable) return false
+  // C1: keep the linear editor's own floor. The step card disables 删除 at `steps.length === 1`, and
+  // `validateTemplateApprovalFlow` only enforces 至少需要一个审批步骤 while the draft is linear — so
+  // removing the last step ON THE CANVAS would promote to an approver-less start→end graph that no
+  // longer trips that check. `removeLinearNode` itself permits it, so the guard belongs here.
+  if (!draft.value.preservedGraph && draft.value.steps.length <= 1) return false
   try {
     removeLinearNode(buildApprovalGraph(draft.value), node.key)
     return true
@@ -1947,6 +2010,21 @@ function canRemoveNode(node: ApprovalNode): boolean {
 // Alt+Arrow both invoke the same topology edit, so visual position never diverges from the saved graph.
 // Reuses the same topology handlers as the list and the same draft-backed right-side inspector. ──
 const canvasViewMode = ref<'list' | 'canvas'>('list')
+// C1: one canvas for both shapes. A preserved complex graph keeps exactly the availability it had
+// before (flag only). A LINEAR draft additionally requires an AUTHORABLE template: when
+// `unsupportedReason` is set (attachment field / unknown node / extra config keys) the whole editor
+// is locked and `steps` is a lossy projection of a graph we must not offer a structural surface for
+// — unknown config stays fail-closed. `graphReadOnly` (preservedGraph presence) is the
+// linear-vs-graph-authoring discriminator, NOT a canvas gate.
+const canvasAvailable = computed(() => (
+  canvasV2Enabled.value && (graphReadOnly.value || !unsupportedReason.value)
+))
+// True while a LINEAR draft is showing the canvas instead of its structured step cards. The step
+// cards + flow spine are the structured list for a linear draft, so the toggle swaps them exactly
+// as it swaps `approval-graph-readonly-list` for a complex one. Always false with the flag off.
+const linearCanvasActive = computed(() => (
+  canvasAvailable.value && !graphReadOnly.value && canvasViewMode.value === 'canvas'
+))
 const selectedCanvasNode = ref<string | null>(null)
 const flowCanvasRef = ref<InstanceType<typeof ApprovalFlowCanvas> | null>(null)
 const movingCanvasNode = ref<string | null>(null)
@@ -1958,7 +2036,13 @@ const CANVAS_MINIMAP_W = 220
 const CANVAS_MINIMAP_H = 120
 const canvasEffectiveGraph = computed<ApprovalGraph>(() => buildApprovalGraph(draft.value))
 const canvasLayout = computed<GraphLayout>(() => computeLayout(canvasEffectiveGraph.value))
-const canvasValidity = computed<string[]>(() => (draft.value.preservedGraph ? graphValidityIssues(canvasEffectiveGraph.value) : []))
+// C1: validity now reads the effective graph for BOTH shapes. This does not move publish gating for
+// a linear draft (`publishApprovalFlowIssues` consumes it): every check in `graphValidityIssues`
+// is vacuous on a `buildApprovalGraph` linear chain — no parallel node, positionally-unique node and
+// edge keys, no dangling endpoint, forward- and backward-reachable, acyclic — so it stays `[]` for
+// any linear draft. Dropping the branch keeps the alert describing exactly the graph the canvas
+// draws, for whichever shape is on screen.
+const canvasValidity = computed<string[]>(() => graphValidityIssues(canvasEffectiveGraph.value))
 const canvasZoomLabel = computed(() => `${Math.round(canvasZoom.value * 100)}%`)
 const canvasStageStyle = computed(() => ({
   width: `${Math.round(canvasLayout.value.width * canvasZoom.value)}px`,
@@ -2151,6 +2235,8 @@ function onCanvasNodeDragStart(event: DragEvent, nodeKey: string): void {
   if (event.dataTransfer) event.dataTransfer.effectAllowed = 'move'
 }
 function setApprovalSourceIds(nodeKey: string, ids: string[]): void {
+  const step = linearStepForNode(nodeKey)
+  if (step) { setStepIds(step, ids); return }
   const kind = approvalSourceKind(nodeKey)
   if (kind === 'static_user') setApprovalNodeSource(nodeKey, { kind, userIds: ids })
   else if (kind === 'static_role') setApprovalNodeSource(nodeKey, { kind, roleIds: ids })
@@ -2168,19 +2254,37 @@ function setApprovalSourceIdsFromPicker(nodeKey: string, ids: string[]): void {
   setApprovalSourceIds(nodeKey, ids)
 }
 function approvalSourceFieldId(nodeKey: string): string {
+  const step = linearStepForNode(nodeKey)
+  if (step) return step.sourceKind === 'form_field_user' ? step.fieldId : ''
   const source = approvalNodeFirstSource(nodeKey)
   return source?.kind === 'form_field_user' ? source.fieldId : ''
 }
 function setApprovalSourceFieldId(nodeKey: string, fieldId: string): void {
+  const step = linearStepForNode(nodeKey)
+  if (step) { step.fieldId = fieldId; return }
   setApprovalNodeSource(nodeKey, { kind: 'form_field_user', fieldId })
 }
 function approvalSourceLevel(nodeKey: string): number {
+  // The step carries BOTH level carriers at all times (`level` for manager_at_level, `levels` for
+  // continuous_managers) — read the one the current kind means, mirroring `sourceFromStep`.
+  const step = linearStepForNode(nodeKey)
+  if (step) {
+    if (step.sourceKind === 'manager_at_level') return step.level
+    if (step.sourceKind === 'continuous_managers') return step.levels
+    return 1
+  }
   const source = approvalNodeFirstSource(nodeKey)
   if (source?.kind === 'manager_at_level') return source.level
   if (source?.kind === 'continuous_managers') return source.levels
   return 1
 }
 function setApprovalSourceLevel(nodeKey: string, value: number): void {
+  const step = linearStepForNode(nodeKey)
+  if (step) {
+    if (step.sourceKind === 'manager_at_level') step.level = value
+    else if (step.sourceKind === 'continuous_managers') step.levels = value
+    return
+  }
   const kind = approvalSourceKind(nodeKey)
   if (kind === 'manager_at_level') setApprovalNodeSource(nodeKey, { kind, level: value })
   else if (kind === 'continuous_managers') setApprovalNodeSource(nodeKey, { kind, levels: value })
@@ -2253,6 +2357,9 @@ function syncAllStepOptions(): void {
 // G-B2-18: same hydrate-time visibility sync as syncStepOptions, applied to complex-graph
 // approval-node assignee sources (approvalNodeEdits is keyed by nodeKey).
 function syncApprovalNodeOptions(nodeKey: string): void {
+  // C1: a linear node's ids live on the step, so reuse the step-card sync (identical semantics).
+  const step = linearStepForNode(nodeKey)
+  if (step) { syncStepOptions(step); return }
   const kind = approvalSourceKind(nodeKey)
   if (kind === 'static_user') {
     for (const id of approvalSourceIds(nodeKey)) directory.ensureUserOptionVisible(id)
@@ -2292,7 +2399,7 @@ const nodeConfigEditorApi: ApprovalNodeConfigEditorApi = {
   conditionEditFor,
   parallelEditFor,
   ccEditFor,
-  approvalNodeEditFor,
+  hasApprovalNodeEditor,
   conditionFieldOptions,
   userFields,
   conditionFormulaInsertOptions,

--- a/apps/web/src/views/approval/TemplateAuthoringView.vue
+++ b/apps/web/src/views/approval/TemplateAuthoringView.vue
@@ -1993,11 +1993,14 @@ function canRemoveNode(node: ApprovalNode): boolean {
     && topologyEdgeCount(node.key, 'target') === 1
     && topologyEdgeCount(node.key, 'source') === 1
   if (!isLinearRemovable) return false
-  // C1: keep the linear editor's own floor. The step card disables 删除 at `steps.length === 1`, and
-  // `validateTemplateApprovalFlow` only enforces 至少需要一个审批步骤 while the draft is linear — so
-  // removing the last step ON THE CANVAS would promote to an approver-less start→end graph that no
-  // longer trips that check. `removeLinearNode` itself permits it, so the guard belongs here.
-  if (!draft.value.preservedGraph && draft.value.steps.length <= 1) return false
+  // C1: keep at least one approval node on the effective graph. The first topology edit promotes a
+  // linear draft to `preservedGraph`; a guard based only on `steps.length` would disappear at that
+  // boundary and allow a second delete to produce start→end. `removeLinearNode` itself permits that
+  // shape, so the authoring affordance must retain the same floor before and after promotion.
+  if (
+    node.type === 'approval'
+    && canvasEffectiveGraph.value.nodes.filter((candidate) => candidate.type === 'approval').length <= 1
+  ) return false
   try {
     removeLinearNode(buildApprovalGraph(draft.value), node.key)
     return true

--- a/apps/web/tests/approval-template-authoring-canvas-inspector.spec.ts
+++ b/apps/web/tests/approval-template-authoring-canvas-inspector.spec.ts
@@ -653,12 +653,23 @@ describe('Canvas V2 Slice A — canvas inspector', () => {
 
   it('deleting the selected node clears selection and closes the inspector', async () => {
     routeParams = { id: 'tpl_inspector_delete' }
-    // Must be a COMPLEX graph (cc) so the canvas toggle mounts; approval_mid is a linear
-    // mid-chain approval (1 in / 1 out) so removeLinearNode + the canvas remove button apply.
+    // Must be a COMPLEX graph (cc) so the canvas toggle mounts. Keep a second approval so
+    // approval_mid is both a linear mid-chain node (1 in / 1 out) and legally removable under
+    // the authoring floor that preserves at least one approval after deletion.
     getTemplateSpy.mockResolvedValue(buildTemplate({
       approvalGraph: {
         nodes: [
           { key: 'start', type: 'start', name: '发起', config: {} },
+          {
+            key: 'approval_first',
+            type: 'approval',
+            name: '首轮审批',
+            config: {
+              assigneeSources: [{ kind: 'requester' }],
+              approvalMode: 'single',
+              emptyAssigneePolicy: 'error',
+            },
+          },
           {
             key: 'approval_mid',
             type: 'approval',
@@ -678,7 +689,8 @@ describe('Canvas V2 Slice A — canvas inspector', () => {
           { key: 'end', type: 'end', name: '结束', config: {} },
         ],
         edges: [
-          { key: 'e-s-m', source: 'start', target: 'approval_mid' },
+          { key: 'e-s-f', source: 'start', target: 'approval_first' },
+          { key: 'e-f-m', source: 'approval_first', target: 'approval_mid' },
           { key: 'e-m-c', source: 'approval_mid', target: 'cc_1' },
           { key: 'e-c-e', source: 'cc_1', target: 'end' },
         ],

--- a/apps/web/tests/approval-template-authoring-linear-canvas.spec.ts
+++ b/apps/web/tests/approval-template-authoring-linear-canvas.spec.ts
@@ -1,0 +1,685 @@
+/* eslint-disable vue/one-component-per-file, vue/require-default-prop */
+/**
+ * C1 unified canvas — the production Canvas V2 surface serves a LINEAR step draft through the same
+ * `buildApprovalGraph` adapter it already uses for a preserved complex graph.
+ *
+ * Each test is written to FAIL for a specific regression rather than to exercise the happy path:
+ *  - the toggle/canvas appear for a linear draft, and the step cards are the structured fallback;
+ *  - flag OFF (and an unsupported template) keep every canvas surface absent;
+ *  - merely opening/selecting leaves the draft clean and the payload byte-identical;
+ *  - inspector edits land on the SAME `ApprovalStepDraft` the step cards read (not a shadow copy);
+ *  - the first structural canvas edit promotes to `preservedGraph`, keeping graph + config;
+ *  - the canvas cannot delete a linear draft's only approval step;
+ *  - a complex graph round-trips exactly as before.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { computed, createApp, defineComponent, h, nextTick, ref, type App as VueApp } from 'vue'
+import TemplateAuthoringView from '../src/views/approval/TemplateAuthoringView.vue'
+import type { ApprovalTemplateDetailDTO } from '../src/types/approval'
+
+const pushSpy = vi.fn().mockResolvedValue(undefined)
+const replaceSpy = vi.fn().mockResolvedValue(undefined)
+let routeParams: Record<string, string> = {}
+
+vi.mock('vue-router', async () => {
+  const actual = await vi.importActual<typeof import('vue-router')>('vue-router')
+  return {
+    ...actual,
+    useRouter: () => ({ push: pushSpy, replace: replaceSpy, back: vi.fn() }),
+    useRoute: () => ({
+      params: routeParams,
+      query: {},
+      path: routeParams.id ? `/approval-templates/${routeParams.id}/edit` : '/approval-templates/new',
+      meta: {},
+    }),
+  }
+})
+
+const canManageTemplates = ref(true)
+vi.mock('../src/approvals/permissions', () => ({
+  useApprovalPermissions: () => ({
+    canManageTemplates,
+    canRead: ref(true),
+    canWrite: ref(true),
+    canAct: ref(true),
+  }),
+}))
+
+const approvalCanvasV2 = ref(true)
+vi.mock('../src/stores/featureFlags', () => ({
+  useFeatureFlags: () => ({
+    features: computed(() => ({ approvalCanvasV2: approvalCanvasV2.value })),
+  }),
+}))
+
+// Real role/user options so the multi-select pickers have selectable <option>s (the ids write path
+// goes through the picker, not a raw-text field).
+const directoryRoles = ref([{ id: 'role_legal', name: '法务' }, { id: 'role_finance', name: '财务' }])
+vi.mock('../src/approvals/useApprovalDirectory', () => ({
+  useApprovalDirectory: () => ({
+    users: ref([{ id: 'u_alice', name: 'Alice', email: 'alice@example.com' }]),
+    roles: directoryRoles,
+    formulaRoles: ref([]),
+    usersLoading: ref(false),
+    rolesLoading: ref(false),
+    formulaRolesLoading: ref(false),
+    statusMessage: ref(''),
+    searchUsers: vi.fn().mockResolvedValue(undefined),
+    loadRoles: vi.fn().mockResolvedValue(undefined),
+    loadFormulaRoles: vi.fn().mockResolvedValue(undefined),
+    ensureUserOptionVisible: vi.fn(),
+    ensureRoleOptionVisible: vi.fn(),
+    formatUserLabel: (user: { id: string }) => user.id,
+    formatRoleLabel: (role: { id: string }) => role.id,
+  }),
+}))
+
+const createTemplateSpy = vi.fn()
+const updateTemplateSpy = vi.fn()
+const publishTemplateSpy = vi.fn()
+const getTemplateSpy = vi.fn()
+const dryRunApprovalConditionFormulaSpy = vi.fn()
+
+vi.mock('../src/approvals/api', () => ({
+  createTemplate: (payload: unknown) => createTemplateSpy(payload),
+  updateTemplate: (id: string, payload: unknown) => updateTemplateSpy(id, payload),
+  publishTemplate: (id: string, payload: unknown) => publishTemplateSpy(id, payload),
+  getTemplate: (id: string) => getTemplateSpy(id),
+  dryRunApprovalConditionFormula: (payload: unknown) => dryRunApprovalConditionFormulaSpy(payload),
+}))
+
+vi.mock('element-plus', () => ({
+  ElMessage: { success: vi.fn(), warning: vi.fn(), error: vi.fn() },
+  ElMessageBox: { confirm: vi.fn().mockResolvedValue(undefined) },
+}))
+
+const ElButton = defineComponent({
+  name: 'ElButton',
+  props: { disabled: Boolean, loading: Boolean, type: String, text: Boolean, size: String },
+  emits: ['click'],
+  render() {
+    return h('button', {
+      type: 'button',
+      disabled: this.disabled || this.loading,
+      'data-testid': (this.$attrs as any)?.['data-testid'],
+      onClick: (event: Event) => this.$emit('click', event),
+    }, this.$slots.default?.())
+  },
+})
+
+const ElInput = defineComponent({
+  name: 'ElInput',
+  props: { modelValue: [String, Number], disabled: Boolean, type: String, rows: Number, placeholder: String, size: String },
+  emits: ['update:modelValue'],
+  render() {
+    return h('input', {
+      value: this.modelValue ?? '',
+      disabled: this.disabled,
+      'data-testid': (this.$attrs as any)?.['data-testid'],
+      onInput: (event: Event) => this.$emit('update:modelValue', (event.target as HTMLInputElement).value),
+    })
+  },
+})
+
+const ElInputNumber = defineComponent({
+  name: 'ElInputNumber',
+  props: { modelValue: Number, disabled: Boolean, min: Number, max: Number, step: Number },
+  emits: ['update:modelValue'],
+  render() {
+    return h('input', {
+      type: 'number',
+      value: this.modelValue ?? '',
+      disabled: this.disabled,
+      'data-testid': (this.$attrs as any)?.['data-testid'],
+      onInput: (event: Event) => this.$emit('update:modelValue', Number((event.target as HTMLInputElement).value)),
+    })
+  },
+})
+
+/**
+ * Mirrors el-select's contract: a `multiple` select emits an ARRAY, a single one emits the value.
+ * A multi-select's bound value is exposed as `data-model` because a bare `<select multiple>` cannot
+ * render an incoming array as `selectedOptions` (the real el-select renders its own chips) — reading
+ * the attribute is what the component was HANDED, so a read-back assertion stays load-bearing.
+ */
+const ElSelect = defineComponent({
+  name: 'ElSelect',
+  props: { modelValue: [String, Array], disabled: Boolean, multiple: Boolean },
+  emits: ['update:modelValue', 'change'],
+  render() {
+    return h('select', {
+      multiple: this.multiple,
+      value: this.multiple ? undefined : (this.modelValue ?? ''),
+      disabled: this.disabled,
+      'data-model': JSON.stringify(this.modelValue ?? null),
+      'data-testid': (this.$attrs as any)?.['data-testid'],
+      onChange: (event: Event) => {
+        const select = event.target as HTMLSelectElement
+        const payload = this.multiple
+          ? Array.from(select.selectedOptions).map((option) => option.value)
+          : select.value
+        this.$emit('update:modelValue', payload)
+        this.$emit('change', payload)
+      },
+    }, this.$slots.default?.())
+  },
+})
+
+const ElOption = defineComponent({
+  name: 'ElOption',
+  props: { label: String, value: String },
+  render() {
+    return h('option', { value: this.value }, this.label)
+  },
+})
+
+const ElCheckbox = defineComponent({
+  name: 'ElCheckbox',
+  inheritAttrs: false,
+  props: { modelValue: Boolean, disabled: Boolean },
+  emits: ['update:modelValue'],
+  render() {
+    return h('label', [
+      h('input', {
+        type: 'checkbox',
+        checked: this.modelValue,
+        disabled: this.disabled,
+        'data-testid': (this.$attrs as any)?.['data-testid'],
+        onChange: (event: Event) => this.$emit('update:modelValue', (event.target as HTMLInputElement).checked),
+      }),
+      this.$slots.default?.(),
+    ])
+  },
+})
+
+const passthrough = (name: string, tag = 'div') => defineComponent({
+  name,
+  render() {
+    return h(tag, { 'data-testid': (this.$attrs as any)?.['data-testid'] }, this.$slots.default?.())
+  },
+})
+
+const ElAlert = defineComponent({
+  name: 'ElAlert',
+  props: { title: String, description: String },
+  render() {
+    return h('div', { 'data-testid': (this.$attrs as any)?.['data-testid'] }, [
+      h('strong', this.title),
+      this.description ? h('p', this.description) : null,
+      this.$slots.default?.(),
+    ])
+  },
+})
+
+const ElDialog = defineComponent({
+  name: 'ElDialog',
+  props: { modelValue: Boolean, title: String, width: String },
+  emits: ['update:modelValue'],
+  render() {
+    if (!this.modelValue) return null
+    return h('div', { 'data-testid': (this.$attrs as any)?.['data-testid'] }, [this.$slots.default?.(), this.$slots.footer?.()])
+  },
+})
+
+function installStubs(app: VueApp<Element>) {
+  app.directive('loading', {})
+  app.component('ElButton', ElButton)
+  app.component('ElButtonGroup', passthrough('ElButtonGroup'))
+  app.component('ElInput', ElInput)
+  app.component('ElInputNumber', ElInputNumber)
+  app.component('ElSelect', ElSelect)
+  app.component('ElOption', ElOption)
+  app.component('ElCheckbox', ElCheckbox)
+  app.component('ElAlert', ElAlert)
+  app.component('ElDialog', ElDialog)
+  app.component('ElCard', passthrough('ElCard', 'section'))
+  app.component('ElForm', passthrough('ElForm', 'form'))
+  app.component('ElFormItem', passthrough('ElFormItem', 'label'))
+  app.component('ElIcon', passthrough('ElIcon', 'span'))
+  app.component('ElCollapse', passthrough('ElCollapse'))
+  app.component('ElCollapseItem', passthrough('ElCollapseItem'))
+  app.component('ElTable', passthrough('ElTable'))
+  app.component('ElTableColumn', passthrough('ElTableColumn'))
+}
+
+const LINEAR_STEP_1_CONFIG = {
+  assigneeSources: [{ kind: 'direct_manager' }],
+  approvalMode: 'single',
+  emptyAssigneePolicy: 'error',
+}
+const LINEAR_STEP_2_CONFIG = {
+  assigneeSources: [{ kind: 'static_role', roleIds: ['role_legal'] }],
+  approvalMode: 'all',
+  emptyAssigneePolicy: 'auto-approve',
+  autoApprovalPolicy: { mergeWithRequester: true },
+  fieldPermissions: [{ fieldId: 'amount', access: 'hidden' }],
+}
+
+/** A plain LINEAR template: `steps` is the carrier, there is no `preservedGraph`. */
+function buildLinearGraph() {
+  return {
+    nodes: [
+      { key: 'start', type: 'start', name: '发起', config: {} },
+      { key: 'approval_1', type: 'approval', name: '直属上级', config: { ...LINEAR_STEP_1_CONFIG } },
+      { key: 'approval_2', type: 'approval', name: '法务复核', config: { ...LINEAR_STEP_2_CONFIG } },
+      { key: 'end', type: 'end', name: '结束', config: {} },
+    ],
+    edges: [
+      { key: 'edge-start-approval_1', source: 'start', target: 'approval_1' },
+      { key: 'edge-approval_1-approval_2', source: 'approval_1', target: 'approval_2' },
+      { key: 'edge-approval_2-end', source: 'approval_2', target: 'end' },
+    ],
+  }
+}
+
+function buildSingleStepLinearGraph() {
+  return {
+    nodes: [
+      { key: 'start', type: 'start', name: '发起', config: {} },
+      { key: 'approval_1', type: 'approval', name: '直属上级', config: { ...LINEAR_STEP_1_CONFIG } },
+      { key: 'end', type: 'end', name: '结束', config: {} },
+    ],
+    edges: [
+      { key: 'edge-start-approval_1', source: 'start', target: 'approval_1' },
+      { key: 'edge-approval_1-end', source: 'approval_1', target: 'end' },
+    ],
+  }
+}
+
+/** A preserved COMPLEX graph (condition + cc) — the shape the canvas already served before C1. */
+function buildComplexGraph() {
+  return {
+    nodes: [
+      { key: 'start', type: 'start', name: '发起', config: {} },
+      {
+        key: 'cond_1',
+        type: 'condition',
+        name: '金额判断',
+        config: {
+          branches: [{ edgeKey: 'e-high', rules: [{ fieldId: 'amount', operator: 'gte', value: 1000 }], conjunction: 'and' }],
+          defaultEdgeKey: 'e-low',
+        },
+      },
+      { key: 'approval_high', type: 'approval', name: '高额审批', config: { ...LINEAR_STEP_1_CONFIG } },
+      { key: 'cc_1', type: 'cc', name: '抄送财务', config: { targetType: 'role', targetIds: ['role_finance'] } },
+      { key: 'end', type: 'end', name: '结束', config: {} },
+    ],
+    edges: [
+      { key: 'e-start-c', source: 'start', target: 'cond_1' },
+      { key: 'e-high', source: 'cond_1', target: 'approval_high' },
+      { key: 'e-low', source: 'cond_1', target: 'cc_1' },
+      { key: 'e-high-cc', source: 'approval_high', target: 'cc_1' },
+      { key: 'e-cc-end', source: 'cc_1', target: 'end' },
+    ],
+  }
+}
+
+function buildTemplate(overrides: Partial<ApprovalTemplateDetailDTO> = {}): ApprovalTemplateDetailDTO {
+  return {
+    id: 'tpl_linear_canvas',
+    key: 'expense',
+    name: '费用审批',
+    description: null,
+    category: null,
+    visibilityScope: { type: 'all', ids: [] },
+    slaHours: null,
+    status: 'draft',
+    activeVersionId: null,
+    latestVersionId: 'ver_1',
+    createdAt: '2026-07-28T00:00:00Z',
+    updatedAt: '2026-07-28T00:00:00Z',
+    formSchema: {
+      fields: [
+        { id: 'amount', type: 'number', label: '金额', required: true },
+        { id: 'reviewer', type: 'user', label: '审批人' },
+      ],
+    },
+    approvalGraph: buildLinearGraph() as any,
+    ...overrides,
+  }
+}
+
+let container: HTMLDivElement | null = null
+let app: VueApp<Element> | null = null
+
+async function mountView() {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  app = createApp(TemplateAuthoringView)
+  installStubs(app)
+  app.mount(container)
+  await nextTick()
+  await Promise.resolve()
+  await nextTick()
+}
+
+function unmountView() {
+  app?.unmount()
+  container?.remove()
+  app = null
+  container = null
+}
+
+async function flushUi() {
+  for (let i = 0; i < 6; i += 1) {
+    await nextTick()
+    await Promise.resolve()
+  }
+}
+
+function q<T extends Element = HTMLElement>(selector: string): T | null {
+  return container!.querySelector(selector) as T | null
+}
+function all(selector: string): HTMLElement[] {
+  return Array.from(container!.querySelectorAll(selector)) as HTMLElement[]
+}
+function click(testId: string) {
+  const button = q<HTMLButtonElement>(`[data-testid="${testId}"]`)
+  expect(button, testId).not.toBeNull()
+  button!.click()
+}
+function selectValue(testId: string, value: string, scope = '') {
+  const select = q<HTMLSelectElement>(`${scope}[data-testid="${testId}"]`)
+  expect(select, testId).not.toBeNull()
+  select!.value = value
+  select!.dispatchEvent(new Event('change'))
+}
+function clickCanvasNode(nodeKey: string) {
+  const node = q(`[data-testid="approval-canvas-node"][data-canvas-node="${nodeKey}"]`)
+  expect(node, `canvas node ${nodeKey}`).not.toBeNull()
+  node!.click()
+}
+/** Step cards use `v-show`, so "hidden" means display:none rather than removal. */
+function visibleStepRows(): HTMLElement[] {
+  return all('[data-testid="approval-template-step-row"]').filter((row) => row.style.display !== 'none')
+}
+async function saveDraft() {
+  click('approval-template-save-button')
+  await flushUi()
+}
+function lastUpdatePayload(): any {
+  return updateTemplateSpy.mock.calls.at(-1)?.[1]
+}
+
+describe('C1 unified canvas — linear step drafts on the production Canvas V2 surface', () => {
+  beforeEach(() => {
+    routeParams = {}
+    canManageTemplates.value = true
+    approvalCanvasV2.value = true
+    createTemplateSpy.mockReset()
+    updateTemplateSpy.mockReset()
+    publishTemplateSpy.mockReset()
+    getTemplateSpy.mockReset()
+    dryRunApprovalConditionFormulaSpy.mockReset()
+    pushSpy.mockClear()
+    replaceSpy.mockClear()
+    // Echo the payload back so a save re-hydrates from what it just sent (as the real API does).
+    updateTemplateSpy.mockImplementation(async (id, payload) => ({ ...buildTemplate({ id }), ...payload }))
+    getTemplateSpy.mockResolvedValue(buildTemplate())
+  })
+
+  afterEach(() => {
+    unmountView()
+  })
+
+  it('exposes the list/canvas toggle for a linear draft and swaps the step cards for the canvas', async () => {
+    routeParams = { id: 'tpl_linear_toggle' }
+    await mountView()
+    await flushUi()
+
+    // Default: the structured step cards, no canvas — the toggle only OFFERS the canvas.
+    expect(q('[data-testid="approval-graph-view-toggle"]')).not.toBeNull()
+    expect(q('[data-testid="approval-canvas-workspace"]')).toBeNull()
+    expect(visibleStepRows()).toHaveLength(2)
+    expect(q('[data-testid="approval-template-step-spine"]')).not.toBeNull()
+
+    click('approval-view-canvas')
+    await flushUi()
+
+    expect(q('[data-testid="approval-canvas-workspace"]')).not.toBeNull()
+    // start → approval_1 → approval_2 → end, exactly the graph `buildApprovalGraph` derives.
+    // Compared as a set: paint order is the layout's business, node identity is the adapter's.
+    expect(all('[data-testid="approval-canvas-node"]').map((node) => node.dataset.canvasNode).sort())
+      .toEqual(['approval_1', 'approval_2', 'end', 'start'])
+    expect(all('[data-testid="approval-canvas-edge"]')).toHaveLength(3)
+    // A valid linear chain raises no structural warning.
+    expect(q('[data-testid="approval-canvas-validity"]')).toBeNull()
+    // The structured list is swapped out, not duplicated — and a linear draft never renders the
+    // complex read-only list.
+    expect(visibleStepRows()).toHaveLength(0)
+    expect(q('[data-testid="approval-template-step-spine"]')).toBeNull()
+    expect(q('[data-testid="approval-graph-readonly-list"]')).toBeNull()
+
+    // …and 结构列表 brings the same cards back (the accessibility fallback stays reachable).
+    click('approval-view-list')
+    await flushUi()
+    expect(q('[data-testid="approval-canvas-workspace"]')).toBeNull()
+    expect(visibleStepRows()).toHaveLength(2)
+  })
+
+  it('keeps every canvas surface absent for a linear draft while the flag is off', async () => {
+    approvalCanvasV2.value = false
+    routeParams = { id: 'tpl_linear_flag_off' }
+    await mountView()
+    await flushUi()
+
+    expect(q('[data-testid="approval-graph-view-toggle"]')).toBeNull()
+    expect(q('[data-testid="approval-canvas-workspace"]')).toBeNull()
+    expect(q('[data-testid="approval-graph-canvas"]')).toBeNull()
+    expect(visibleStepRows()).toHaveLength(2)
+    expect(q('[data-testid="approval-template-step-spine"]')).not.toBeNull()
+  })
+
+  it('keeps the canvas absent for an UNSUPPORTED template even with the flag on (fail-closed)', async () => {
+    routeParams = { id: 'tpl_linear_unsupported' }
+    getTemplateSpy.mockResolvedValue(buildTemplate({
+      // An attachment field makes the whole template un-authorable: its `steps` projection is not a
+      // faithful carrier, so no structural surface may be offered for it.
+      formSchema: { fields: [{ id: 'file', type: 'attachment', label: '附件' }] } as any,
+    }))
+    await mountView()
+    await flushUi()
+
+    expect(q('[data-testid="approval-graph-view-toggle"]')).toBeNull()
+    expect(q('[data-testid="approval-canvas-workspace"]')).toBeNull()
+  })
+
+  it('opening and selecting on the linear canvas leaves the draft clean and the payload identical', async () => {
+    routeParams = { id: 'tpl_linear_viewonly' }
+
+    // Baseline: load → save, no canvas interaction at all.
+    await mountView()
+    await flushUi()
+    await saveDraft()
+    const baseline = lastUpdatePayload()
+    // Requirement: an untouched linear template round-trips its graph verbatim.
+    expect(baseline.approvalGraph).toEqual(buildLinearGraph())
+    unmountView()
+
+    updateTemplateSpy.mockClear()
+    await mountView()
+    await flushUi()
+    click('approval-view-canvas')
+    await flushUi()
+    clickCanvasNode('approval_2')
+    await flushUi()
+    // The inspector is open on a real step node…
+    expect(q('[data-testid="approval-canvas-inspector"]')?.getAttribute('data-inspector-node')).toBe('approval_2')
+    // …and NOTHING was written: the dirty baseline still matches.
+    const saveState = q('.template-authoring__save-state')!
+    expect(saveState.classList.contains('template-authoring__save-state--dirty')).toBe(false)
+    expect(saveState.textContent?.trim()).toBe('已保存')
+
+    click('approval-canvas-inspector-close')
+    await flushUi()
+    click('approval-view-list')
+    await flushUi()
+    await saveDraft()
+    expect(lastUpdatePayload()).toEqual(baseline)
+  })
+
+  it('linear inspector edits write through to the step carrier the step cards read', async () => {
+    routeParams = { id: 'tpl_linear_inspector' }
+    await mountView()
+    await flushUi()
+    click('approval-view-canvas')
+    await flushUi()
+    clickCanvasNode('approval_1')
+    await flushUi()
+
+    const inspector = '[data-testid="approval-canvas-inspector"] '
+    expect(q(`${inspector}[data-testid="approval-node-editor"]`)).not.toBeNull()
+    // Seeded FROM the step (single / error / merge off), not from a blank shadow default.
+    expect(q<HTMLSelectElement>(`${inspector}[data-testid="approval-node-source-kind"]`)!.value).toBe('direct_manager')
+    expect(q<HTMLSelectElement>(`${inspector}[data-testid="approval-node-mode"]`)!.value).toBe('single')
+    expect(q<HTMLSelectElement>(`${inspector}[data-testid="approval-node-empty-policy"]`)!.value).toBe('error')
+
+    selectValue('approval-node-source-kind', 'manager_at_level', inspector)
+    await flushUi()
+    const level = q<HTMLInputElement>(`${inspector}[data-testid="approval-node-source-level"]`)!
+    level.value = '3'
+    level.dispatchEvent(new Event('input'))
+    selectValue('approval-node-mode', 'all', inspector)
+    selectValue('approval-node-empty-policy', 'auto-approve', inspector)
+    const merge = q<HTMLInputElement>(`${inspector}[data-testid="approval-node-merge-with-requester"]`)!
+    merge.checked = true
+    merge.dispatchEvent(new Event('change'))
+    selectValue('approval-node-field-access-amount', 'hidden', inspector)
+    await flushUi()
+
+    // Same carrier, not a copy: the STEP CARD controls now read the inspector's values, and the
+    // draft is still LINEAR (no promotion, no complex read-only list).
+    click('approval-view-list')
+    await flushUi()
+    expect(q('[data-testid="approval-graph-readonly-list"]')).toBeNull()
+    const stepCard = all('[data-testid="approval-template-step-row"]')[0]
+    expect((stepCard.querySelector('[data-testid="approval-step-source-kind"]') as HTMLSelectElement).value).toBe('manager_at_level')
+    expect((stepCard.querySelector('[data-testid="approval-step-level"]') as HTMLInputElement).value).toBe('3')
+    expect((stepCard.querySelector('[data-testid="approval-step-merge-with-requester"]') as HTMLInputElement).checked).toBe(true)
+    expect((stepCard.querySelector('[data-testid="approval-step-field-access-amount"]') as HTMLSelectElement).value).toBe('hidden')
+
+    await saveDraft()
+    const node = lastUpdatePayload().approvalGraph.nodes.find((n: any) => n.key === 'approval_1')
+    expect(node.config).toEqual({
+      assigneeSources: [{ kind: 'manager_at_level', level: 3 }],
+      approvalMode: 'all',
+      emptyAssigneePolicy: 'auto-approve',
+      autoApprovalPolicy: { mergeWithRequester: true },
+      fieldPermissions: [{ fieldId: 'amount', access: 'hidden' }],
+    })
+    // The untouched sibling step is unaffected — the write targeted one carrier.
+    expect(lastUpdatePayload().approvalGraph.nodes.find((n: any) => n.key === 'approval_2').config)
+      .toEqual(LINEAR_STEP_2_CONFIG)
+  })
+
+  it('linear inspector role picker writes the step idsText carrier', async () => {
+    routeParams = { id: 'tpl_linear_ids' }
+    await mountView()
+    await flushUi()
+    click('approval-view-canvas')
+    await flushUi()
+    clickCanvasNode('approval_2')
+    await flushUi()
+
+    const inspector = '[data-testid="approval-canvas-inspector"] '
+    const picker = q<HTMLSelectElement>(`${inspector}[data-testid="approval-node-source-role-picker"]`)!
+    expect(picker).not.toBeNull()
+    // Seeded from the step's own idsText carrier (hydrated as `role_legal`), not from an empty copy.
+    expect(picker.getAttribute('data-model')).toBe(JSON.stringify(['role_legal']))
+    for (const option of Array.from(picker.options)) option.selected = option.value === 'role_finance'
+    picker.dispatchEvent(new Event('change'))
+    await flushUi()
+
+    click('approval-view-list')
+    await flushUi()
+    const stepCard = all('[data-testid="approval-template-step-row"]')[1]
+    const listPicker = stepCard.querySelector('[data-testid="approval-step-role-picker"]') as HTMLSelectElement
+    expect(listPicker.getAttribute('data-model')).toBe(JSON.stringify(['role_finance']))
+
+    await saveDraft()
+    expect(lastUpdatePayload().approvalGraph.nodes.find((n: any) => n.key === 'approval_2').config.assigneeSources)
+      .toEqual([{ kind: 'static_role', roleIds: ['role_finance'] }])
+  })
+
+  it('the first structural canvas edit promotes the linear draft, preserving graph and config', async () => {
+    routeParams = { id: 'tpl_linear_promote' }
+    await mountView()
+    await flushUi()
+    click('approval-view-canvas')
+    await flushUi()
+    expect(q('[data-testid="approval-graph-readonly-list"]')).toBeNull()
+
+    click('approval-canvas-insert-approval_1')
+    await flushUi()
+
+    // Promoted: the canvas grew by one node and the structured view is now the graph node list.
+    expect(all('[data-testid="approval-canvas-node"]')).toHaveLength(5)
+    click('approval-view-list')
+    await flushUi()
+    expect(q('[data-testid="approval-graph-readonly-list"]')).not.toBeNull()
+    expect(visibleStepRows()).toHaveLength(0)
+
+    await saveDraft()
+    const graph = lastUpdatePayload().approvalGraph
+    const inserted = graph.nodes.find((n: any) => !['start', 'approval_1', 'approval_2', 'end'].includes(n.key))
+    expect(inserted?.type).toBe('approval')
+    // Every pre-existing node keeps its key, name and config — promotion preserved the EFFECTIVE
+    // graph the linear steps produced, including step 2's mode / policy / merge / field permissions.
+    for (const original of buildLinearGraph().nodes) {
+      const preserved = graph.nodes.find((n: any) => n.key === original.key)
+      expect(preserved, original.key).toBeTruthy()
+      expect(preserved.name).toBe(original.name)
+      expect(preserved.config).toEqual(original.config)
+    }
+    // …and it is wired in on the chain, not dangling.
+    const targetOf = (source: string) => graph.edges.find((edge: any) => edge.source === source)?.target
+    expect(targetOf('start')).toBe('approval_1')
+    expect(targetOf('approval_1')).toBe(inserted.key)
+    expect(targetOf(inserted.key)).toBe('approval_2')
+    expect(targetOf('approval_2')).toBe('end')
+  })
+
+  it('never offers a canvas delete for a linear draft with a single approval step', async () => {
+    routeParams = { id: 'tpl_linear_last_step' }
+    getTemplateSpy.mockResolvedValue(buildTemplate({ approvalGraph: buildSingleStepLinearGraph() as any }))
+    await mountView()
+    await flushUi()
+    click('approval-view-canvas')
+    await flushUi()
+    // The step card disables 删除 at one step; the canvas must not become the bypass that promotes
+    // an approver-less start→end graph.
+    expect(q('[data-testid="approval-canvas-remove-approval_1"]')).toBeNull()
+    unmountView()
+
+    // Two steps → removable again (proves the guard is step-count scoped, not a blanket disable).
+    getTemplateSpy.mockResolvedValue(buildTemplate())
+    await mountView()
+    await flushUi()
+    click('approval-view-canvas')
+    await flushUi()
+    expect(q('[data-testid="approval-canvas-remove-approval_1"]')).not.toBeNull()
+  })
+
+  it('leaves the preserved complex graph round-trip unchanged', async () => {
+    routeParams = { id: 'tpl_complex_roundtrip' }
+    getTemplateSpy.mockResolvedValue(buildTemplate({ approvalGraph: buildComplexGraph() as any }))
+    await mountView()
+    await flushUi()
+
+    // Complex still defaults to the structured read-only list, never the step cards.
+    expect(q('[data-testid="approval-graph-readonly-list"]')).not.toBeNull()
+    expect(visibleStepRows()).toHaveLength(0)
+
+    click('approval-view-canvas')
+    await flushUi()
+    clickCanvasNode('cond_1')
+    await flushUi()
+    expect(q('[data-testid="approval-canvas-inspector"]')?.getAttribute('data-inspector-type')).toBe('condition')
+    clickCanvasNode('approval_high')
+    await flushUi()
+    expect(q('[data-testid="approval-canvas-inspector"] [data-testid="approval-node-editor"]')).not.toBeNull()
+
+    await saveDraft()
+    expect(lastUpdatePayload().approvalGraph).toEqual(buildComplexGraph())
+  })
+})

--- a/apps/web/tests/approval-template-authoring-linear-canvas.spec.ts
+++ b/apps/web/tests/approval-template-authoring-linear-canvas.spec.ts
@@ -639,7 +639,7 @@ describe('C1 unified canvas — linear step drafts on the production Canvas V2 s
     expect(targetOf('approval_2')).toBe('end')
   })
 
-  it('never offers a canvas delete for a linear draft with a single approval step', async () => {
+  it('never offers a canvas delete for the last approval before or after graph promotion', async () => {
     routeParams = { id: 'tpl_linear_last_step' }
     getTemplateSpy.mockResolvedValue(buildTemplate({ approvalGraph: buildSingleStepLinearGraph() as any }))
     await mountView()
@@ -651,13 +651,20 @@ describe('C1 unified canvas — linear step drafts on the production Canvas V2 s
     expect(q('[data-testid="approval-canvas-remove-approval_1"]')).toBeNull()
     unmountView()
 
-    // Two steps → removable again (proves the guard is step-count scoped, not a blanket disable).
+    // Two steps → removable again (positive control: this is not a blanket disable).
     getTemplateSpy.mockResolvedValue(buildTemplate())
     await mountView()
     await flushUi()
     click('approval-view-canvas')
     await flushUi()
     expect(q('[data-testid="approval-canvas-remove-approval_1"]')).not.toBeNull()
+
+    // The delete promotes the draft to preservedGraph. The remaining approval must retain the same
+    // floor after that carrier transition; otherwise a second click can create start→end.
+    click('approval-canvas-remove-approval_1')
+    await flushUi()
+    expect(all('[data-testid="approval-canvas-node"]')).toHaveLength(3)
+    expect(q('[data-testid="approval-canvas-remove-approval_2"]')).toBeNull()
   })
 
   it('leaves the preserved complex graph round-trip unchanged', async () => {


### PR DESCRIPTION
## Summary

- stack on #4642 and expose the same Canvas V2 surface for linear and preserved complex approval drafts
- route every linear approval inspector edit directly into its existing `ApprovalStepDraft`; no shadow carrier and no view-only dirty state
- promote the first structural edit through the existing graph command path while preserving source, ids, approval policy, field permissions, and node config
- retain flag-OFF and unsupported-template fallback to the structured list
- keep at least one approval node before and after linear-to-graph promotion

## Verification

- focused authoring/topology/viewport suite: 124/124
- C1 mounted production-view spec: 9/9
- style guard after stacked #4642: 83/83
- ESLint and `pnpm --filter @metasheet/web type-check`: pass
- mutation: remove linear carrier lookup -> inspector tests RED
- mutation: restore preservedGraph-only edge count -> promotion/delete positives RED
- mutation: restore pre-fix post-promotion delete floor -> exact second-delete test RED
- independent Kimi exact-head adversarial review: APPROVE, no P1/P2; the one newly reachable deletion residual was fixed before this PR

## Browser evidence

Production `TemplateAuthoringView` was exercised in a real Chromium session at 1440, 1024, and 390 px. No horizontal overflow or console errors; inspector changes persisted when switching back to the structured list, and view-only canvas use stayed clean. Screenshots are retained outside the repository under `/private/tmp/approval-editor-c1-browser-evidence/`.

## Boundaries

- `APPROVAL_CANVAS_V2_ENABLED` remains default OFF
- no deployment or production flag change
- C2/X1 owns edge-plus productization, card action cleanup, undo/redo, and compact/mobile sticky-navigation overlap
- F1-F3 owns the DingTalk/Feishu-style field palette drag-in and form inspector
