### PR TITLE
feat(directory): serialize account binding access writes

### DIFF
--- a/packages/core-backend/src/directory/access-graph-mutex.ts
+++ b/packages/core-backend/src/directory/access-graph-mutex.ts
@@ -17,6 +17,7 @@ export type AccessGraphTransactionClient = {
 
 export type LockedAccessGraphUser = {
   id: string
+  name: string | null
   email: string | null
   username: string | null
   mobile: string | null
@@ -41,6 +42,7 @@ export async function lockUsersForAccessGraphWrite(
   for (const userId of normalizedUserIds) {
     const result = await client.query(
       `SELECT id::text AS id,
+              name,
               email,
               username,
               mobile,
@@ -56,6 +58,7 @@ export async function lockUsersForAccessGraphWrite(
     if (!row) continue
     lockedUsers.set(userId, {
       id: String(row.id),
+      name: row.name === null || row.name === undefined ? null : String(row.name),
       email: row.email === null || row.email === undefined ? null : String(row.email),
       username:
         row.username === null || row.username === undefined

--- a/packages/core-backend/src/directory/directory-sync.ts
+++ b/packages/core-backend/src/directory/directory-sync.ts
@@ -45,6 +45,10 @@ import { deliverDirectorySyncFailureAlert, getDirectoryManagerBindingCoverage } 
 import { resolveDirectoryScheduleTimezone } from './directory-sync-timezone'
 import { acquireSourceSyncFreezeLock } from './source-sync-freeze-lock'
 import { applyDirectoryDeprovisionCandidate } from './deprovision-ledger'
+import {
+  lockUsersForAccessGraphWrite,
+  supersedeDeprovisionEvidenceForAccessGraphWrite,
+} from './access-graph-mutex'
 
 const logger = new Logger('DirectorySync')
 const DEFAULT_ORG_ID = 'default'
@@ -267,6 +271,7 @@ type DirectoryBindingTargetAccountRow = {
   name: string
   email: string | null
   mobile: string | null
+  is_active: boolean
 }
 
 type DirectoryAccountLinkedUserRow = {
@@ -4039,6 +4044,7 @@ export async function syncDirectoryIntegration(
                     name: account.name,
                     email: account.email,
                     mobile: account.mobile,
+                    is_active: account.is_active,
                   },
                   adminUserId: triggeredBy,
                   name: cleanName,
@@ -5455,6 +5461,7 @@ async function lockAuthoritativeDirectoryBindingAccount(
        account.name,
        account.email,
        account.mobile,
+       account.is_active,
        integration.provider AS integration_provider,
        integration.corp_id AS integration_corp_id
      FROM directory_accounts account
@@ -5493,6 +5500,8 @@ async function applyDirectoryAccountBindInTransaction(
     normalizedAdminUserId: string
     enableDingTalkGrant: boolean
     localUser: Pick<DirectoryBindingUserRow, 'id' | 'email' | 'username' | 'name'>
+    expectedPriorLocalUserId: string | null
+    supersedeTargetUser?: boolean
     /**
      * T1 pending create: link + identity only — no active user_orgs until activate (Action C).
      * Default false preserves W4-PRE-1b membership maintenance for normal bind/admit.
@@ -5505,10 +5514,13 @@ async function applyDirectoryAccountBindInTransaction(
     normalizedAdminUserId,
     enableDingTalkGrant,
     localUser,
+    expectedPriorLocalUserId,
+    supersedeTargetUser = true,
     skipUserOrgMembership = false,
   } = options
   const account = await lockAuthoritativeDirectoryBindingAccount(client, normalizedAccountId)
   if (!account) throw new Error('Directory account not found')
+  if (!account.is_active) throw new Error('Directory account is inactive and cannot be bound')
   const identityExternalKey = buildDingTalkIdentityExternalKey(account.corp_id, account.open_id, account.union_id)
   if (!identityExternalKey) {
     throw new Error('Directory account is missing DingTalk openId/unionId and cannot be pre-bound for DingTalk login')
@@ -5535,10 +5547,14 @@ async function applyDirectoryAccountBindInTransaction(
      FROM directory_account_links
      WHERE directory_account_id = $1::uuid
        AND link_status = 'linked'
+     FOR UPDATE
      LIMIT 1`,
     [normalizedAccountId],
   )
   const priorLocalUserId = (priorLinkResult.rows[0] as { local_user_id?: string | null } | undefined)?.local_user_id ?? null
+  if (priorLocalUserId !== expectedPriorLocalUserId) {
+    throw new Error('Directory account binding changed; retry the operation')
+  }
 
   const profile = JSON.stringify({
     source: 'directory_admin_bind',
@@ -5696,6 +5712,18 @@ async function applyDirectoryAccountBindInTransaction(
   if (priorLocalUserId && priorLocalUserId !== localUser.id) {
     await deactivateUserOrgMembershipIfNoOtherActiveBinding(client, { userId: priorLocalUserId, orgId })
   }
+
+  const supersededUserIds = [
+    ...(supersedeTargetUser ? [localUser.id] : []),
+    ...(priorLocalUserId && priorLocalUserId !== localUser.id ? [priorLocalUserId] : []),
+  ]
+  if (supersededUserIds.length > 0) {
+    await supersedeDeprovisionEvidenceForAccessGraphWrite(client, {
+      userIds: supersededUserIds,
+      actorId: normalizedAdminUserId,
+      reason: 'directory account binding changed by an administrator',
+    })
+  }
 }
 
 async function createDirectoryAdmittedUserInTransaction(
@@ -5710,6 +5738,7 @@ async function createDirectoryAdmittedUserInTransaction(
     passwordHash: string
     mustChangePassword: boolean
     enableDingTalkGrant: boolean
+    expectedPriorLocalUserId?: string | null
   },
 ): Promise<{ userId: string }> {
   const userId = crypto.randomUUID()
@@ -5788,6 +5817,27 @@ async function createDirectoryAdmittedUserInTransaction(
     }
   }
 
+  let expectedPriorLocalUserId = options.expectedPriorLocalUserId
+  if (expectedPriorLocalUserId === undefined) {
+    const priorLinkResult = await client.query(
+      `SELECT local_user_id
+         FROM directory_account_links
+        WHERE directory_account_id = $1::uuid
+          AND link_status = 'linked'
+        LIMIT 1`,
+      [options.account.id],
+    )
+    expectedPriorLocalUserId =
+      (priorLinkResult.rows[0] as { local_user_id?: string | null } | undefined)?.local_user_id
+      ?? null
+  }
+  if (expectedPriorLocalUserId) {
+    const lockedPriorUsers = await lockUsersForAccessGraphWrite(client, [expectedPriorLocalUserId])
+    if (!lockedPriorUsers.has(expectedPriorLocalUserId)) {
+      throw new Error('Directory account binding changed; retry the operation')
+    }
+  }
+
   // DT-HARDEN-02: INSERT + bind are one all-or-nothing unit. A bind throw after the INSERT
   // (missing openId/unionId, or an identity already bound to another local user) would
   // otherwise leave a committed orphan once the sync loop swallows the error — the exact
@@ -5839,6 +5889,8 @@ async function createDirectoryAdmittedUserInTransaction(
         username: options.username,
         name: options.name,
       },
+      expectedPriorLocalUserId,
+      supersedeTargetUser: false,
       skipUserOrgMembership: pendingMode,
     })
   } catch (error) {
@@ -6180,7 +6232,7 @@ async function resolveDirectoryBindingUser(localUserRef: string): Promise<Direct
 
 async function loadDirectoryBindingTargetAccount(directoryAccountId: string): Promise<DirectoryBindingTargetAccountRow | null> {
   const result = await query<DirectoryBindingTargetAccountRow>(
-    `SELECT id, integration_id, provider, corp_id, external_user_id, union_id, open_id, external_key, name, email, mobile
+    `SELECT id, integration_id, provider, corp_id, external_user_id, union_id, open_id, external_key, name, email, mobile, is_active
      FROM directory_accounts
      WHERE id = $1
      LIMIT 1`,
@@ -6366,13 +6418,26 @@ export async function bindDirectoryAccount(
 
   const localUser = await resolveDirectoryBindingUser(normalizedLocalUserRef)
   if (!localUser) throw new Error('Local user not found')
+  const expectedPriorLocalUserId = previousLinkedUser?.local_user_id ?? null
 
   await transaction(async (client) => {
+    const lockedUsers = await lockUsersForAccessGraphWrite(client, [
+      localUser.id,
+      ...(expectedPriorLocalUserId ? [expectedPriorLocalUserId] : []),
+    ])
+    const lockedTargetUser = lockedUsers.get(localUser.id)
+    if (!lockedTargetUser || !lockedTargetUser.isActive) {
+      throw new Error('Local user is no longer active; retry the operation')
+    }
+    if (expectedPriorLocalUserId && !lockedUsers.has(expectedPriorLocalUserId)) {
+      throw new Error('Directory account binding changed; retry the operation')
+    }
     await applyDirectoryAccountBindInTransaction(client, {
       normalizedAccountId,
       normalizedAdminUserId,
       enableDingTalkGrant,
-      localUser,
+      localUser: lockedTargetUser,
+      expectedPriorLocalUserId,
     })
   })
 
@@ -6458,6 +6523,7 @@ export async function admitDirectoryAccountUser(
       passwordHash,
       mustChangePassword,
       enableDingTalkGrant,
+      expectedPriorLocalUserId: previousLinkedUser?.local_user_id ?? null,
     })
     userId = created.userId
   })
@@ -6546,20 +6612,33 @@ export async function unbindDirectoryAccount(
   if (!normalizedAccountId) throw new Error('directoryAccountId is required')
   if (!normalizedAdminUserId) throw new Error('adminUserId is required')
 
-  // #4526 review fix: `previousLinkedUser` used to be read via `loadDirectoryLinkedUser` OUTSIDE
-  // this transaction (alongside `account`, in the `Promise.all` this replaced). That pre-read was
-  // load-bearing but stale: if this account's link changed between the pre-read and the
-  // transaction body below (e.g. a rapid unbind+rebind of the SAME account), the link UPSERT
-  // below unconditionally severs whoever is linked NOW while the deactivation call only
-  // considered the STALE holder — the CURRENT holder could be left with an active membership and
-  // zero bindings. Reading it here, inside the transaction, with `FOR UPDATE OF l` locking the
-  // `directory_account_links` row for this account closes that window: any concurrent writer of
-  // THIS SAME row (bind/admit/another unbind) now serializes behind this transaction instead of
-  // racing it. `FOR UPDATE OF l` (not a bare `FOR UPDATE`) is required because of the `LEFT JOIN
-  // users u` — Postgres refuses to lock the nullable side of an outer join.
   let previousLinkedUser: DirectoryAccountLinkedUserRow | null = null
 
   await transaction(async (client) => {
+    // This unlocked read is only an expected-holder snapshot. The first row lock is still the
+    // canonical users row; after it is held, the account/link are locked and re-read. A mismatch
+    // fails closed instead of modifying an unprotected replacement holder.
+    const expectedLinkedUserResult = await client.query(
+      `SELECT l.local_user_id,
+              u.email AS local_user_email,
+              u.username AS local_user_username,
+              u.name AS local_user_name
+         FROM directory_account_links l
+         LEFT JOIN users u ON u.id = l.local_user_id
+        WHERE l.directory_account_id = $1
+        LIMIT 1`,
+      [normalizedAccountId],
+    )
+    const expectedLinkedUser =
+      (expectedLinkedUserResult.rows[0] as DirectoryAccountLinkedUserRow | undefined)
+      ?? null
+    const expectedLocalUserId = expectedLinkedUser?.local_user_id ?? null
+    if (expectedLocalUserId) {
+      const lockedUsers = await lockUsersForAccessGraphWrite(client, [expectedLocalUserId])
+      if (!lockedUsers.has(expectedLocalUserId)) {
+        throw new Error('Directory account binding changed; retry the operation')
+      }
+    }
     const account = await lockAuthoritativeDirectoryBindingAccount(client, normalizedAccountId)
     if (!account) throw new Error('Directory account not found')
     const identityExternalKey = buildDingTalkIdentityExternalKey(
@@ -6581,6 +6660,9 @@ export async function unbindDirectoryAccount(
       [normalizedAccountId],
     )
     previousLinkedUser = (linkedUserLockResult.rows[0] as DirectoryAccountLinkedUserRow | undefined) ?? null
+    if ((previousLinkedUser?.local_user_id ?? null) !== expectedLocalUserId) {
+      throw new Error('Directory account binding changed; retry the operation')
+    }
 
     if (previousLinkedUser?.local_user_id) {
       const candidateIdentityParams: unknown[] = [
@@ -6666,6 +6748,11 @@ export async function unbindDirectoryAccount(
       await deactivateUserOrgMembershipIfNoOtherActiveBinding(client, {
         userId: previousLinkedUser.local_user_id,
         orgId,
+      })
+      await supersedeDeprovisionEvidenceForAccessGraphWrite(client, {
+        userIds: [previousLinkedUser.local_user_id],
+        actorId: normalizedAdminUserId,
+        reason: 'directory account unbound by an administrator',
       })
     }
   })

--- a/packages/core-backend/src/directory/directory-sync.ts
+++ b/packages/core-backend/src/directory/directory-sync.ts
@@ -6241,6 +6241,20 @@ async function loadDirectoryBindingTargetAccount(directoryAccountId: string): Pr
   return result.rows[0] ?? null
 }
 
+/**
+ * The prior-HOLDER witness for bind/admit CAS checks — `link_status = 'linked'` on purpose, and
+ * this predicate must stay IDENTICAL to the CAS re-reads in
+ * `applyDirectoryAccountBindInTransaction` / `createDirectoryAdmittedUserInTransaction`.
+ *
+ * D5 adversarial review P1: this read used to be status-agnostic while the CAS re-read was
+ * linked-scoped. A 'pending' email/mobile match row (the sync loop itself writes
+ * `local_user_id` onto 'pending' rows as a match HINT) made the witness non-null, the
+ * linked-scoped CAS null, and every manual bind/admit of such an account failed forever with
+ * "binding changed; retry" — the retry could never succeed, on precisely the top-ranked bind
+ * targets in the review workbench. A pending hint is not a holder: it never activated
+ * membership, holds nothing to deactivate, and must neither trip the CAS nor be shown as
+ * `previousLocalUser`.
+ */
 async function loadDirectoryLinkedUser(directoryAccountId: string): Promise<DirectoryAccountLinkedUserRow | null> {
   const result = await query<DirectoryAccountLinkedUserRow>(
     `SELECT l.local_user_id,
@@ -6250,6 +6264,7 @@ async function loadDirectoryLinkedUser(directoryAccountId: string): Promise<Dire
      FROM directory_account_links l
      LEFT JOIN users u ON u.id = l.local_user_id
      WHERE l.directory_account_id = $1
+       AND l.link_status = 'linked'
      LIMIT 1`,
     [directoryAccountId],
   )

--- a/packages/core-backend/src/directory/local-directory-org.ts
+++ b/packages/core-backend/src/directory/local-directory-org.ts
@@ -35,6 +35,10 @@ import {
   upsertActiveUserOrgMembership,
   deactivateUserOrgMembershipIfNoOtherActiveBinding,
 } from './directory-sync'
+import {
+  lockUsersForAccessGraphWrite,
+  supersedeDeprovisionEvidenceForAccessGraphWrite,
+} from './access-graph-mutex'
 
 function normalizeText(value: unknown): string {
   return typeof value === 'string' ? value.trim() : String(value ?? '').trim()
@@ -445,6 +449,7 @@ export interface CreateLocalAccountInput {
   email?: string | null
   mobile?: string | null
   title?: string | null
+  actorId?: string
 }
 
 /**
@@ -462,25 +467,26 @@ export async function createLocalAccount(input: CreateLocalAccountInput): Promis
 
   const integration = await getOrCreateLocalIntegration(input.orgId)
 
-  const userRow = await query<{ id: string; name: string | null; email: string | null }>(
-    `SELECT id, name, email FROM users WHERE id = $1`,
-    [localUserId],
-  )
-  const user = userRow.rows[0]
-  if (!user) throw new LocalDirectoryNotFoundError('local user not found')
-
-  const name = normalizeText(input.name) || normalizeText(user.name) || normalizeText(user.email) || localUserId
-  if (name.length > MAX_NAME_LENGTH) throw new LocalDirectoryValidationError(`name must be at most ${MAX_NAME_LENGTH} characters`)
-  const email = input.email !== undefined ? normalizeText(input.email) || null : user.email ?? null
-  const mobile = input.mobile !== undefined ? normalizeText(input.mobile) || null : null
-  const title = input.title !== undefined ? normalizeText(input.title) || null : null
-
   const externalUserId = localUserId
   const externalKey = `${input.orgId}:${localUserId}`
+  const actorId = normalizeText(input.actorId) || 'system:local-directory'
 
   let accountId = ''
   try {
     await transaction(async (client) => {
+      const lockedUsers = await lockUsersForAccessGraphWrite(client, [localUserId])
+      const user = lockedUsers.get(localUserId)
+      if (!user) throw new LocalDirectoryNotFoundError('local user not found')
+      if (!user.isActive) throw new LocalDirectoryConflictError('local user is inactive')
+
+      const name = normalizeText(input.name) || normalizeText(user.name) || normalizeText(user.email) || localUserId
+      if (name.length > MAX_NAME_LENGTH) {
+        throw new LocalDirectoryValidationError(`name must be at most ${MAX_NAME_LENGTH} characters`)
+      }
+      const email = input.email !== undefined ? normalizeText(input.email) || null : user.email
+      const mobile = input.mobile !== undefined ? normalizeText(input.mobile) || null : null
+      const title = input.title !== undefined ? normalizeText(input.title) || null : null
+
       const inserted = await client.query(
         `INSERT INTO directory_accounts (
            integration_id, provider, corp_id, external_user_id, external_key, name, email, mobile,
@@ -521,6 +527,11 @@ export async function createLocalAccount(input: CreateLocalAccountInput): Promis
       // reimplemented (this file's own header: "directory-sync.ts is edited nowhere by this
       // file" — same convention `getOrCreateLocalIntegration` already follows).
       await upsertActiveUserOrgMembership(client, { userId: localUserId, orgId: input.orgId })
+      await supersedeDeprovisionEvidenceForAccessGraphWrite(client, {
+        userIds: [localUserId],
+        actorId,
+        reason: 'local directory account created by an administrator',
+      })
     })
   } catch (error) {
     if (isUniqueViolation(error)) {
@@ -609,15 +620,62 @@ export async function updateLocalAccount(
  * user (`current.local_user_id`) — an account nobody was ever linked to has no membership to
  * reconsider.
  */
-export async function archiveLocalAccount(orgId: string, accountId: string): Promise<LocalAccountSummary | null> {
+export async function archiveLocalAccount(
+  orgId: string,
+  accountId: string,
+  actorIdInput?: string,
+): Promise<LocalAccountSummary | null> {
   const current = await loadLocalAccountForOrg(orgId, accountId)
   if (!current) return null
 
   if (current.is_active) {
     await transaction(async (client) => {
-      await client.query(`UPDATE directory_accounts SET is_active = false, updated_at = NOW() WHERE id = $1`, [accountId])
-      if (current.local_user_id) {
-        await deactivateUserOrgMembershipIfNoOtherActiveBinding(client, { userId: current.local_user_id, orgId })
+      const expectedLocalUserId = current.local_user_id
+      if (expectedLocalUserId) {
+        const lockedUsers = await lockUsersForAccessGraphWrite(client, [expectedLocalUserId])
+        if (!lockedUsers.has(expectedLocalUserId)) {
+          throw new LocalDirectoryConflictError('local account binding changed; retry')
+        }
+      }
+
+      const accountResult = await client.query(
+        `SELECT id, is_active
+           FROM directory_accounts
+          WHERE id = $1 AND integration_id = $2 AND provider = 'local'
+          FOR UPDATE`,
+        [accountId, current.integration_id],
+      )
+      const lockedAccount = accountResult.rows[0] as { id: string; is_active: boolean } | undefined
+      if (!lockedAccount) throw new LocalDirectoryNotFoundError('local account not found')
+      if (!lockedAccount.is_active) return
+
+      const linkResult = await client.query(
+        `SELECT local_user_id
+           FROM directory_account_links
+          WHERE directory_account_id = $1
+          FOR UPDATE`,
+        [accountId],
+      )
+      const actualLocalUserId =
+        (linkResult.rows[0] as { local_user_id?: string | null } | undefined)?.local_user_id
+        ?? null
+      if (actualLocalUserId !== expectedLocalUserId) {
+        throw new LocalDirectoryConflictError('local account binding changed; retry')
+      }
+
+      await client.query(
+        `UPDATE directory_accounts
+            SET is_active = false, updated_at = NOW()
+          WHERE id = $1 AND is_active = TRUE`,
+        [accountId],
+      )
+      if (expectedLocalUserId) {
+        await deactivateUserOrgMembershipIfNoOtherActiveBinding(client, { userId: expectedLocalUserId, orgId })
+        await supersedeDeprovisionEvidenceForAccessGraphWrite(client, {
+          userIds: [expectedLocalUserId],
+          actorId: normalizeText(actorIdInput) || 'system:local-directory',
+          reason: 'local directory account archived by an administrator',
+        })
       }
     })
   }

--- a/packages/core-backend/src/routes/admin-directory-local.ts
+++ b/packages/core-backend/src/routes/admin-directory-local.ts
@@ -275,7 +275,15 @@ export function adminDirectoryLocalRouter(): Router {
 
     try {
       const orgId = resolveLocalDirectoryOrgId(req)
-      const account = await createLocalAccount({ orgId, localUserId, name, email, mobile, title })
+      const account = await createLocalAccount({
+        orgId,
+        localUserId,
+        name,
+        email,
+        mobile,
+        title,
+        actorId: adminUserId,
+      })
       await auditLog({
         actorId: adminUserId,
         actorType: 'user',
@@ -339,7 +347,7 @@ export function adminDirectoryLocalRouter(): Router {
     try {
       const orgId = resolveLocalDirectoryOrgId(req)
       if (rejectNonUuidParam(res, 'accountId', req.params.accountId)) return
-      const account = await archiveLocalAccount(orgId, req.params.accountId)
+      const account = await archiveLocalAccount(orgId, req.params.accountId, adminUserId)
       if (!account) {
         jsonError(res, 404, 'DIRECTORY_LOCAL_NOT_FOUND', 'Local account not found')
         return

--- a/packages/core-backend/tests/integration/directory-access-graph-mutex.db.test.ts
+++ b/packages/core-backend/tests/integration/directory-access-graph-mutex.db.test.ts
@@ -453,4 +453,67 @@ describeIfDatabase('directory access-graph mutex (real DB)', () => {
       await pool.end()
     }
   })
+
+  it("a 'pending' email-match hint never trips the bind CAS: witness and re-read share the linked-only predicate (D5 review P1)", async () => {
+    // The sync loop writes local_user_id onto 'pending' rows as a match HINT (the top-ranked
+    // bind target in the review workbench). Before the fix, the prior-holder witness read that
+    // hint (status-agnostic) while the in-transaction CAS re-read was linked-scoped: witness
+    // non-null, CAS null, and EVERY manual bind of such an account failed forever with
+    // "binding changed; retry" — a retry that could never succeed.
+    const orgId = `${PREFIX}-org-${randomUUID()}`
+    const hintUserId = `${PREFIX}-hint-${randomUUID()}`
+    const targetUserId = `${PREFIX}-target-${randomUUID()}`
+    const integration = await query<{ id: string }>(
+      `INSERT INTO directory_integrations (name, corp_id, org_id, provider, status, default_deprovision_policy)
+       VALUES ($1, $2, $3, 'dingtalk', 'active', 'manual_review') RETURNING id::text AS id`,
+      [`${PREFIX}-integration-${randomUUID()}`, `${PREFIX}-corp-${randomUUID()}`, orgId],
+    )
+    for (const [uid, email] of [
+      [hintUserId, `${PREFIX}-hint@example.com`],
+      [targetUserId, `${PREFIX}-target@example.com`],
+    ]) {
+      await query(
+        `INSERT INTO users (id, email, password_hash, is_active, activation_status, access_generation)
+         VALUES ($1, $2, 'x', TRUE, 'activated', 0)`,
+        [uid, email],
+      )
+    }
+    const account = await query<{ id: string }>(
+      `INSERT INTO directory_accounts (integration_id, provider, corp_id, external_user_id, union_id, open_id, external_key, name, email, is_active)
+       SELECT integration.id, 'dingtalk', integration.corp_id, $2, $3, $4, $2, 'Pending Hint', $5, TRUE
+         FROM directory_integrations integration WHERE integration.id = $1::uuid
+       RETURNING id::text AS id`,
+      [
+        integration.rows[0].id,
+        `${PREFIX}-external-${randomUUID()}`,
+        `${PREFIX}-union-${randomUUID()}`,
+        `${PREFIX}-open-${randomUUID()}`,
+        `${PREFIX}-hint@example.com`,
+      ],
+    )
+    // The sync loop's own shape: a PENDING row carrying the match hint.
+    await query(
+      `INSERT INTO directory_account_links (directory_account_id, local_user_id, link_status, match_strategy)
+       VALUES ($1::uuid, $2, 'pending', 'email')`,
+      [account.rows[0].id, hintUserId],
+    )
+
+    // Binding to a DIFFERENT user must succeed — the pending hint is not a holder.
+    const bound = await bindDirectoryAccount(account.rows[0].id, {
+      localUserRef: targetUserId,
+      adminUserId: 'admin:d5-pending-hint',
+      enableDingTalkGrant: false,
+    })
+    expect(bound.account.linkStatus).toBe('linked')
+    expect(bound.account.localUser?.id).toBe(targetUserId)
+    // And the hint user is NOT presented as a previous holder — they never held anything.
+    expect(bound.previousLocalUser).toBeNull()
+
+    const link = await query<{ local_user_id: string; link_status: string }>(
+      `SELECT local_user_id, link_status FROM directory_account_links WHERE directory_account_id = $1::uuid`,
+      [account.rows[0].id],
+    )
+    expect(link.rows).toHaveLength(1)
+    expect(link.rows[0]).toMatchObject({ local_user_id: targetUserId, link_status: 'linked' })
+  })
 })

--- a/packages/core-backend/tests/integration/directory-access-graph-mutex.db.test.ts
+++ b/packages/core-backend/tests/integration/directory-access-graph-mutex.db.test.ts
@@ -7,13 +7,23 @@ import {
   supersedeDeprovisionEvidenceForAccessGraphWrite,
 } from '../../src/directory/access-graph-mutex'
 import { applyDirectoryDeprovisionCandidate } from '../../src/directory/deprovision-ledger'
+import {
+  bindDirectoryAccount,
+  unbindDirectoryAccount,
+} from '../../src/directory/directory-sync'
+import {
+  archiveLocalAccount,
+  createLocalAccount,
+} from '../../src/directory/local-directory-org'
 
 const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
 const PREFIX = `d5a-mutex-${Date.now()}`
 
 type SeededEvidence = {
+  accountId: string
   eventId: string
   integrationId: string
+  orgId: string
   userId: string
 }
 
@@ -74,13 +84,26 @@ async function seedAppliedEvidence(): Promise<SeededEvidence> {
   )
   const account = await query<{ id: string }>(
     `INSERT INTO directory_accounts (
-       integration_id, provider, external_user_id, external_key, name, is_active
-     ) VALUES ($1::uuid, 'dingtalk', $2, $3, 'D5A Mutex', FALSE)
+       integration_id, provider, corp_id, external_user_id, union_id, open_id,
+       external_key, name, is_active
+     )
+     SELECT integration.id,
+            'dingtalk',
+            integration.corp_id,
+            $2,
+            $3,
+            $4,
+            $2,
+            'D5A Mutex',
+            FALSE
+       FROM directory_integrations integration
+      WHERE integration.id = $1::uuid
      RETURNING id::text AS id`,
     [
       integrationId,
       `${PREFIX}-external-${randomUUID()}`,
-      `dingtalk:${PREFIX}:${randomUUID()}`,
+      `${PREFIX}-union-${randomUUID()}`,
+      `${PREFIX}-open-${randomUUID()}`,
     ],
   )
   await query(
@@ -103,7 +126,59 @@ async function seedAppliedEvidence(): Promise<SeededEvidence> {
     }),
   )
   if (!applied.eventId) throw new Error('failed to seed deprovision evidence')
-  return { eventId: applied.eventId, integrationId, userId }
+  return {
+    accountId: account.rows[0].id,
+    eventId: applied.eventId,
+    integrationId,
+    orgId,
+    userId,
+  }
+}
+
+async function resetSeededForAccessOverride(
+  seeded: SeededEvidence,
+): Promise<void> {
+  await query(
+    `UPDATE users
+        SET is_active = TRUE, activation_status = 'activated'
+      WHERE id = $1`,
+    [seeded.userId],
+  )
+  await query(
+    `UPDATE directory_accounts SET is_active = TRUE WHERE id = $1::uuid`,
+    [seeded.accountId],
+  )
+  await query(
+    `UPDATE directory_account_links
+        SET local_user_id = $2, link_status = 'linked'
+      WHERE directory_account_id = $1::uuid`,
+    [seeded.accountId, seeded.userId],
+  )
+  await query(
+    `INSERT INTO user_orgs (user_id, org_id, is_active)
+     VALUES ($1, $2, TRUE)
+     ON CONFLICT (user_id, org_id)
+     DO UPDATE SET is_active = TRUE`,
+    [seeded.userId, seeded.orgId],
+  )
+}
+
+async function reopenEvidence(eventId: string): Promise<void> {
+  await query(
+    `UPDATE directory_deprovision_effects
+        SET status = 'applied', reversed_at = NULL, reversed_by = NULL
+      WHERE event_id = $1::uuid`,
+    [eventId],
+  )
+  await query(
+    `UPDATE directory_deprovision_events
+        SET status = 'applied',
+            resolved_at = NULL,
+            resolved_by = NULL,
+            resolve_note = NULL
+      WHERE id = $1::uuid`,
+    [eventId],
+  )
 }
 
 async function readEvidence(userId: string) {
@@ -144,6 +219,30 @@ async function waitUntilBlockedOnHolder(
     await new Promise((resolve) => setTimeout(resolve, 25))
   }
   throw new Error(`timed out waiting for pid ${waiterPid} to block on ${holderPid}`)
+}
+
+async function waitForAnyUserLockWaiter(
+  inspector: Pool,
+  holderPid: number,
+  timeoutMs = 8000,
+): Promise<number> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    const result = await inspector.query<{ pid: number }>(
+      `SELECT activity.pid
+         FROM pg_stat_activity activity
+        WHERE activity.pid <> $1::int
+          AND activity.wait_event_type = 'Lock'
+          AND $1::int = ANY(pg_blocking_pids(activity.pid))
+          AND activity.query LIKE '%FROM users%'
+        ORDER BY activity.pid
+        LIMIT 1`,
+      [holderPid],
+    )
+    if (result.rows[0]?.pid) return Number(result.rows[0].pid)
+    await new Promise((resolve) => setTimeout(resolve, 25))
+  }
+  throw new Error(`timed out waiting for a production writer to block on user holder ${holderPid}`)
 }
 
 describeIfDatabase('directory access-graph mutex (real DB)', () => {
@@ -243,5 +342,115 @@ describeIfDatabase('directory access-graph mutex (real DB)', () => {
       await pool.end()
     }
   })
-})
 
+  it('manual bind supersedes open evidence and advances generation in the bind transaction', async () => {
+    const seeded = await seedAppliedEvidence()
+    await resetSeededForAccessOverride(seeded)
+    const before = await readEvidence(seeded.userId)
+
+    await bindDirectoryAccount(seeded.accountId, {
+      localUserRef: seeded.userId,
+      adminUserId: 'admin:d5b-bind',
+      enableDingTalkGrant: false,
+    })
+
+    const after = await readEvidence(seeded.userId)
+    expect(Number(after.access_generation)).toBe(Number(before.access_generation) + 1)
+    expect(after.event_status).toBe('superseded')
+    expect(new Set(after.effect_statuses)).toEqual(new Set(['superseded']))
+    expect(after.resolved_by).toBe('admin:d5b-bind')
+  })
+
+  it('manual unbind supersedes open evidence and advances generation in the unbind transaction', async () => {
+    const seeded = await seedAppliedEvidence()
+    await resetSeededForAccessOverride(seeded)
+    const before = await readEvidence(seeded.userId)
+
+    await unbindDirectoryAccount(seeded.accountId, {
+      adminUserId: 'admin:d5b-unbind',
+      disableDingTalkGrant: true,
+    })
+
+    const after = await readEvidence(seeded.userId)
+    expect(Number(after.access_generation)).toBe(Number(before.access_generation) + 1)
+    expect(after.event_status).toBe('superseded')
+    expect(new Set(after.effect_statuses)).toEqual(new Set(['superseded']))
+    expect(after.resolved_by).toBe('admin:d5b-unbind')
+  })
+
+  it('local account create and archive both invalidate open evidence', async () => {
+    const seeded = await seedAppliedEvidence()
+    await resetSeededForAccessOverride(seeded)
+    const beforeCreate = await readEvidence(seeded.userId)
+
+    const localAccount = await createLocalAccount({
+      orgId: seeded.orgId,
+      localUserId: seeded.userId,
+      actorId: 'admin:d5b-local-create',
+    })
+    const afterCreate = await readEvidence(seeded.userId)
+    expect(Number(afterCreate.access_generation)).toBe(
+      Number(beforeCreate.access_generation) + 1,
+    )
+    expect(afterCreate.event_status).toBe('superseded')
+    expect(afterCreate.resolved_by).toBe('admin:d5b-local-create')
+
+    await reopenEvidence(seeded.eventId)
+    const beforeArchive = await readEvidence(seeded.userId)
+    await archiveLocalAccount(
+      seeded.orgId,
+      localAccount.id,
+      'admin:d5b-local-archive',
+    )
+    const afterArchive = await readEvidence(seeded.userId)
+    expect(Number(afterArchive.access_generation)).toBe(
+      Number(beforeArchive.access_generation) + 1,
+    )
+    expect(afterArchive.event_status).toBe('superseded')
+    expect(afterArchive.resolved_by).toBe('admin:d5b-local-archive')
+  })
+
+  it('the production bind parks on the canonical user mutex before it locks the account', async () => {
+    const seeded = await seedAppliedEvidence()
+    await resetSeededForAccessOverride(seeded)
+    const pool = new Pool({ connectionString: process.env.DATABASE_URL })
+    const holder = await pool.connect()
+    try {
+      await holder.query('BEGIN')
+      const holderPid = Number(
+        (await holder.query<{ pid: number }>('SELECT pg_backend_pid() AS pid'))
+          .rows[0].pid,
+      )
+      await holder.query(`SELECT id FROM users WHERE id = $1 FOR UPDATE`, [
+        seeded.userId,
+      ])
+
+      const bindPromise = bindDirectoryAccount(seeded.accountId, {
+        localUserRef: seeded.userId,
+        adminUserId: 'admin:d5b-barrier',
+        enableDingTalkGrant: false,
+      })
+      const waiterPid = await waitForAnyUserLockWaiter(pool, holderPid)
+      const waiter = await pool.query<{ account_locked: boolean }>(
+        `SELECT EXISTS (
+           SELECT 1
+             FROM pg_locks account_lock
+             JOIN pg_class relation ON relation.oid = account_lock.relation
+            WHERE account_lock.pid = $1::int
+              AND relation.relname = 'directory_accounts'
+              AND account_lock.granted
+         ) AS account_locked`,
+        [waiterPid],
+      )
+      expect(waiter.rows[0]?.account_locked).toBe(false)
+
+      await holder.query('ROLLBACK')
+      await bindPromise
+      expect((await readEvidence(seeded.userId)).event_status).toBe('superseded')
+    } finally {
+      await holder.query('ROLLBACK').catch(() => undefined)
+      holder.release()
+      await pool.end()
+    }
+  })
+})

--- a/packages/core-backend/tests/unit/directory-sync-admission-orphan-guard.test.ts
+++ b/packages/core-backend/tests/unit/directory-sync-admission-orphan-guard.test.ts
@@ -45,6 +45,8 @@ function fakeClient(account = CORP_ACCOUNT_WITHOUT_OPENID) {
 }
 
 const CORP_ACCOUNT_WITHOUT_OPENID = {
+  // #4651: the bind path re-reads the account under lock and refuses an inactive one.
+  is_active: true,
   id: '11111111-1111-1111-1111-111111111111',
   integration_id: '22222222-2222-2222-2222-222222222222',
   provider: 'dingtalk',

--- a/packages/core-backend/tests/unit/directory-sync-bind-account.test.ts
+++ b/packages/core-backend/tests/unit/directory-sync-bind-account.test.ts
@@ -67,11 +67,30 @@ describe('bindDirectoryAccount', () => {
               name: '林岚',
               email: null,
               mobile: '13900001234',
+              is_active: true,
               integration_provider: 'dingtalk',
               integration_corp_id: 'dingcorp',
               ...accountOverrides,
             }],
           }
+        }
+        if (/FROM users[\s\S]*FOR UPDATE/.test(String(sql))) {
+          const userId = String(params?.[0] ?? 'user-1')
+          return {
+            rows: [{
+              id: userId,
+              name: userId === 'user-1' ? 'Alpha' : 'Previous User',
+              email: userId === 'user-1' ? 'alpha@example.com' : `${userId}@example.com`,
+              username: null,
+              mobile: null,
+              activation_status: 'activated',
+              is_active: true,
+              access_generation: 0,
+            }],
+          }
+        }
+        if (/UPDATE users[\s\S]*access_generation/.test(String(sql))) {
+          return { rows: [{ access_generation: 1 }] }
         }
         return clientQuery(sql, params)
       },
@@ -939,6 +958,87 @@ describe('bindDirectoryAccount', () => {
     expect(pgMocks.transaction).not.toHaveBeenCalled()
   })
 
+  it('rechecks account active state at the bind write point', async () => {
+    const clientQuery = vi.fn(async (sql: string) => {
+      if (/SELECT local_user_id\s+FROM directory_account_links/.test(String(sql))) {
+        return { rows: [] }
+      }
+      if (/SELECT org_id\s+FROM directory_integrations/.test(String(sql))) {
+        return { rows: [{ org_id: 'default' }] }
+      }
+      return { rows: [] }
+    })
+    installTransactionMock(clientQuery, { is_active: false })
+    pgMocks.query
+      .mockResolvedValueOnce({
+        rows: [{
+          id: 'account-1',
+          integration_id: 'dir-1',
+          provider: 'dingtalk',
+          corp_id: 'dingcorp',
+          external_user_id: 'external-1',
+          union_id: 'union-1',
+          open_id: 'open-1',
+          external_key: 'union-1',
+          name: 'Account',
+          email: null,
+          mobile: null,
+          is_active: true,
+        }],
+      })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({
+        rows: [{
+          id: 'user-1',
+          email: 'alpha@example.com',
+          username: null,
+          mobile: null,
+          name: 'Alpha',
+          role: 'user',
+          is_active: true,
+        }],
+      })
+
+    await expect(bindDirectoryAccount('account-1', {
+      localUserRef: 'user-1',
+      adminUserId: 'admin-1',
+      enableDingTalkGrant: false,
+    })).rejects.toThrow('inactive and cannot be bound')
+
+    expect(clientQuery).not.toHaveBeenCalledWith(
+      expect.stringContaining('INSERT INTO directory_account_links'),
+      expect.anything(),
+    )
+  })
+
+  it('fails closed when the unbind holder changes between snapshot and locked re-read', async () => {
+    let linkReadCount = 0
+    const clientQuery = vi.fn(async (sql: string) => {
+      if (/SELECT l\.local_user_id,[\s\S]*FROM directory_account_links l/.test(String(sql))) {
+        linkReadCount += 1
+        return {
+          rows: [{
+            local_user_id: linkReadCount === 1 ? 'user-1' : 'user-2',
+            local_user_email: null,
+            local_user_username: null,
+            local_user_name: null,
+          }],
+        }
+      }
+      return { rows: [] }
+    })
+    installTransactionMock(clientQuery)
+
+    await expect(unbindDirectoryAccount('account-1', {
+      adminUserId: 'admin-1',
+    })).rejects.toThrow('binding changed; retry')
+
+    expect(clientQuery).not.toHaveBeenCalledWith(
+      expect.stringContaining('INSERT INTO directory_account_links'),
+      expect.anything(),
+    )
+  })
+
   it('removes the bound identity, optionally disables grant, and resets the link on unbind', async () => {
     // W4-PRE-1b item B: unbindDirectoryAccount now ALSO resolves the account's org and
     // deactivates the previously-linked user's user_orgs row (org-scoped sibling check) in the
@@ -952,7 +1052,7 @@ describe('bindDirectoryAccount', () => {
       if (/SELECT org_id\s+FROM directory_integrations/.test(String(sql))) {
         return { rows: [{ org_id: 'default' }] }
       }
-      if (String(sql).includes('FOR UPDATE OF l')) {
+      if (/SELECT l\.local_user_id,[\s\S]*FROM directory_account_links l/.test(String(sql))) {
         return { rows: [{ local_user_id: 'user-1', local_user_email: 'alpha@example.com', local_user_name: 'Alpha' }] }
       }
       if (String(sql).includes('FROM user_external_identities') && String(sql).includes('FOR UPDATE')) {
@@ -1036,7 +1136,7 @@ describe('bindDirectoryAccount', () => {
       if (/SELECT org_id\s+FROM directory_integrations/.test(String(sql))) {
         return { rows: [{ org_id: 'default' }] }
       }
-      if (String(sql).includes('FOR UPDATE OF l')) {
+      if (/SELECT l\.local_user_id,[\s\S]*FROM directory_account_links l/.test(String(sql))) {
         return { rows: [{ local_user_id: 'user-1', local_user_email: 'alpha@example.com', local_user_name: 'Alpha' }] }
       }
       return { rows: [] }
@@ -1110,7 +1210,7 @@ describe('bindDirectoryAccount', () => {
       }
       // #4526 review fix: the previously-linked-user read moved INSIDE the transaction
       // (`FOR UPDATE OF l`) — served here now, not via the outer `pgMocks.query`.
-      if (String(sql).includes('FOR UPDATE OF l')) {
+      if (/SELECT l\.local_user_id,[\s\S]*FROM directory_account_links l/.test(String(sql))) {
         return { rows: [{ local_user_id: 'user-1', local_user_email: 'alpha@example.com', local_user_name: 'Alpha' }] }
       }
       return { rows: [] }

--- a/packages/core-backend/tests/unit/directory-sync-pending-activation-default-off.test.ts
+++ b/packages/core-backend/tests/unit/directory-sync-pending-activation-default-off.test.ts
@@ -41,6 +41,9 @@ function fakeClient() {
 
 const ACCOUNT = {
   id: '11111111-1111-1111-1111-111111111111',
+  // #4651: the bind path now re-reads the account authoritatively under lock and refuses an
+  // inactive one — an admissible fixture account must therefore say so explicitly.
+  is_active: true,
   integration_id: '22222222-2222-2222-2222-222222222222',
   provider: 'dingtalk',
   corp_id: 'corpA',


### PR DESCRIPTION
## Scope\n\nD5b of the locked DingTalk lifecycle closeout. Extends the canonical users-row mutex to manual bind/admit/unbind and local account create/archive writers. Every effective access-graph override supersedes open deprovision evidence and advances access_generation in the caller transaction.\n\nThis PR is stacked on #4648. It remains draft and unarmed. Lifecycle flags remain OFF. Automatic sync/OAuth writers are intentionally deferred to D5c.\n\n## Safety properties\n\n- locks affected users in lexical order before account/link row locks\n- re-reads the link under lock and fails closed on holder drift\n- rejects bind to an account archived after the outer lookup\n- local create/archive carry the authenticated admin actor into evidence supersession\n- idempotent archive does not advance generation twice\n\n## Verification\n\n- TypeScript: clean\n- focused unit: 22/22\n- related real DB: 110/110\n- D5 real-DB goldens: bind, unbind, local create/archive evidence invalidation plus production bind lock barrier\n- mutations: disabling bind supersede reds generation/evidence; removing canonical FOR UPDATE reds the production barrier\n\n## Holds\n\n- no auto-merge / no flag enablement\n- retarget and exact-head required CI only after prior stack windows are reviewed and landed