### PR TITLE
feat(approval): make Canvas V2 the primary authoring surface

### DIFF
--- a/apps/web/src/approvals/components/ApprovalFlowCanvas.vue
+++ b/apps/web/src/approvals/components/ApprovalFlowCanvas.vue
@@ -184,7 +184,7 @@
           />
         </svg>
       </div>
-      <p class="template-authoring__hint">画布用于编排结构（增删节点 / 分支、拖动布局）。点击节点在右侧检查器编辑配置；也可切换「结构列表」。</p>
+      <p class="template-authoring__hint">画布用于编排结构（增删节点 / 分支、拖动布局）。点击节点在右侧检查器编辑配置；也可切换「辅助编辑模式」。</p>
     </div>
     <aside
       v-if="selectedCanvasInspectorNode"

--- a/apps/web/src/approvals/templateAuthoring.ts
+++ b/apps/web/src/approvals/templateAuthoring.ts
@@ -803,7 +803,7 @@ export function unsupportedTemplateAuthoringReason(template: ApprovalTemplateDet
 export function graphReadOnlyReason(template: ApprovalTemplateDetailDTO): string | null {
   if (unsupportedTemplateAuthoringReason(template)) return null
   if (!isComplexApprovalGraph(template.approvalGraph)) return null
-  return '该模板已启用分支流程编辑：可在画布调整流程结构，并在结构列表编辑各节点配置。'
+  return '该模板已启用分支流程编辑：可在画布调整流程结构，并在辅助编辑模式编辑各节点配置。'
 }
 
 export function draftFromTemplate(template: ApprovalTemplateDetailDTO): TemplateAuthoringDraft {

--- a/apps/web/src/views/approval/TemplateAuthoringView.vue
+++ b/apps/web/src/views/approval/TemplateAuthoringView.vue
@@ -65,7 +65,7 @@
     <el-alert
       v-if="!unsupportedReason && graphReadOnlyMessage"
       :title="graphReadOnlyMessage"
-      description="画布编排结构；选中节点后可在右侧检查器编辑审批人、条件、并行汇聚、抄送和字段权限（与结构列表共用同一草稿）。"
+      description="画布编排结构；选中节点后可在右侧检查器编辑审批人、条件、并行汇聚、抄送和字段权限（与辅助编辑模式共用同一草稿）。"
       type="info"
       show-icon
       :closable="false"
@@ -133,6 +133,33 @@
           class="template-authoring__content"
           data-testid="approval-template-workspace-content"
         >
+      <div
+        v-if="canvasV2Enabled"
+        v-show="activeAuthoringSection === 'fields' || activeAuthoringSection === 'flow'"
+        class="template-authoring__mode-switch"
+        role="group"
+        aria-label="审批设计模式"
+        data-testid="approval-authoring-mode-switch"
+      >
+        <el-button
+          size="small"
+          :type="activeAuthoringSection === 'fields' ? 'primary' : 'default'"
+          :aria-pressed="activeAuthoringSection === 'fields'"
+          data-testid="approval-authoring-mode-form"
+          @click="selectAuthoringSection('fields')"
+        >
+          表单设计
+        </el-button>
+        <el-button
+          size="small"
+          :type="activeAuthoringSection === 'flow' ? 'primary' : 'default'"
+          :aria-pressed="activeAuthoringSection === 'flow'"
+          data-testid="approval-authoring-mode-flow"
+          @click="selectAuthoringSection('flow')"
+        >
+          流程设计
+        </el-button>
+      </div>
       <el-card
         v-if="showPresetLibrary"
         v-show="activeAuthoringSection === 'basic'"
@@ -534,17 +561,15 @@
           </div>
         </template>
 
-        <!-- Complex graphs use a canvas for topology and a structured list for node configuration. -->
-        <!-- D-6 view toggle: structured list ⇄ visual canvas. C1: available for a LINEAR draft too
-             (its structured list is the step-card stack below), so both shapes reach the same canvas
-             through the same `buildApprovalGraph` adapter. `list` stays the default either way. -->
+        <!-- C2: Canvas V2 is canvas-first while the flag is ON. The structured surface remains an
+             explicit accessible fallback until the lock's keyboard/assistive equivalence gate passes. -->
         <div v-if="canvasAvailable" class="template-authoring__view-toggle" data-testid="approval-graph-view-toggle">
-          <el-button size="small" :type="canvasViewMode === 'list' ? 'primary' : 'default'" data-testid="approval-view-list" @click="canvasViewMode = 'list'">结构列表</el-button>
-          <el-button size="small" :type="canvasViewMode === 'canvas' ? 'primary' : 'default'" data-testid="approval-view-canvas" @click="canvasViewMode = 'canvas'">画布视图</el-button>
+          <el-button size="small" :type="canvasViewMode === 'canvas' ? 'primary' : 'default'" data-testid="approval-view-canvas" @click="canvasViewMode = 'canvas'">流程画布</el-button>
+          <el-button size="small" :type="canvasViewMode === 'list' ? 'primary' : 'default'" data-testid="approval-view-list" @click="canvasViewMode = 'list'">辅助编辑模式</el-button>
         </div>
 
         <!-- D-1/D-5 visual canvas + Canvas V2 Slice A right-side inspector.
-             Topology stays on the canvas; node config reuses the SAME draft handlers as 结构列表.
+             Topology stays on the canvas; node config reuses the SAME draft handlers as 辅助编辑模式.
              ApprovalFlowCanvas is a presentational shell (E2 extraction) — this view stays the
              owner of selection/zoom/move state and every topology/command handler below. -->
         <ApprovalFlowCanvas
@@ -689,9 +714,9 @@
           </template>
         </div>
 
-        <!-- C1: the step cards ARE the structured list for a linear draft — the D-6 toggle swaps
+        <!-- C1: the step cards ARE the structured fallback for a linear draft — the D-6 toggle swaps
              them for the canvas exactly as it swaps `approval-graph-readonly-list` for a complex
-             graph, and they come back untouched on 结构列表 (nothing about the toggle edits them). -->
+             graph, and they come back untouched in 辅助编辑模式 (nothing about the toggle edits them). -->
         <div
           v-for="(step, index) in draft.steps"
           v-show="!graphReadOnly && !linearCanvasActive"
@@ -2012,7 +2037,9 @@ function canRemoveNode(node: ApprovalNode): boolean {
 // ── D-1/D-5/D-6 visual canvas. Layout and semantic move targets are pure data; drag/drop and
 // Alt+Arrow both invoke the same topology edit, so visual position never diverges from the saved graph.
 // Reuses the same topology handlers as the list and the same draft-backed right-side inspector. ──
-const canvasViewMode = ref<'list' | 'canvas'>('list')
+// C2 canvas-first: this ref only matters while the Canvas flag is available. With the flag OFF,
+// `canvasAvailable` stays false and the existing structured surface renders byte-for-byte as before.
+const canvasViewMode = ref<'list' | 'canvas'>('canvas')
 // C1: one canvas for both shapes. A preserved complex graph keeps exactly the availability it had
 // before (flag only). A LINEAR draft additionally requires an AUTHORABLE template: when
 // `unsupportedReason` is set (attachment field / unknown node / extra config keys) the whole editor
@@ -2121,8 +2148,8 @@ watch(canvasEffectiveGraph, (graph) => {
   const movingKey = movingCanvasNode.value
   if (movingKey && linearNodeMoveTargets(graph, movingKey).length === 0) cancelCanvasNodeMove()
 })
-watch([canvasViewMode, canvasLayout], async ([mode]) => {
-  if (mode !== 'canvas') return
+watch([canvasViewMode, canvasLayout, activeAuthoringSection], async ([mode, _layout, section]) => {
+  if (mode !== 'canvas' || section !== 'flow') return
   await nextTick()
   syncCanvasViewportState()
 })
@@ -3360,6 +3387,16 @@ pre {
   display: flex;
   gap: 8px;
   margin-bottom: 12px;
+}
+
+.template-authoring__mode-switch {
+  display: inline-flex;
+  gap: 4px;
+  margin-bottom: 12px;
+  padding: 3px;
+  border: 1px solid var(--el-border-color-light);
+  border-radius: 6px;
+  background: var(--el-fill-color-light);
 }
 
 /* RP-3 (route-preview lock, B3-06) 试运行面板 — chip styling mirrors ApprovalNewView's RP-2 live

--- a/apps/web/tests/approval-template-authoring-canvas-inspector.spec.ts
+++ b/apps/web/tests/approval-template-authoring-canvas-inspector.spec.ts
@@ -828,7 +828,9 @@ describe('Canvas V2 Slice A — canvas inspector', () => {
     await mountView()
     await flushUi()
 
-    // List surface (default): condition branch must receive child-owned dashed border + wrap head.
+    // Canvas V2 is canvas-first; switch to the retained structured fallback to verify its styles.
+    ;(container!.querySelector('[data-testid="approval-view-list"]') as HTMLButtonElement).click()
+    await flushUi()
     const listBranch = container!.querySelector(
       '[data-testid="approval-graph-readonly-list"] .template-authoring__condition-branch',
     ) as HTMLElement | null

--- a/apps/web/tests/approval-template-authoring-linear-canvas.spec.ts
+++ b/apps/web/tests/approval-template-authoring-linear-canvas.spec.ts
@@ -422,20 +422,13 @@ describe('C1 unified canvas — linear step drafts on the production Canvas V2 s
     unmountView()
   })
 
-  it('exposes the list/canvas toggle for a linear draft and swaps the step cards for the canvas', async () => {
+  it('defaults a linear draft to the canvas and retains the auxiliary structured editor', async () => {
     routeParams = { id: 'tpl_linear_toggle' }
     await mountView()
     await flushUi()
 
-    // Default: the structured step cards, no canvas — the toggle only OFFERS the canvas.
+    // C2: Canvas V2 is the default flow surface while the flag is ON.
     expect(q('[data-testid="approval-graph-view-toggle"]')).not.toBeNull()
-    expect(q('[data-testid="approval-canvas-workspace"]')).toBeNull()
-    expect(visibleStepRows()).toHaveLength(2)
-    expect(q('[data-testid="approval-template-step-spine"]')).not.toBeNull()
-
-    click('approval-view-canvas')
-    await flushUi()
-
     expect(q('[data-testid="approval-canvas-workspace"]')).not.toBeNull()
     // start → approval_1 → approval_2 → end, exactly the graph `buildApprovalGraph` derives.
     // Compared as a set: paint order is the layout's business, node identity is the adapter's.
@@ -450,11 +443,58 @@ describe('C1 unified canvas — linear step drafts on the production Canvas V2 s
     expect(q('[data-testid="approval-template-step-spine"]')).toBeNull()
     expect(q('[data-testid="approval-graph-readonly-list"]')).toBeNull()
 
-    // …and 结构列表 brings the same cards back (the accessibility fallback stays reachable).
+    // …and 辅助编辑模式 brings the same cards back (the accessibility fallback stays reachable).
     click('approval-view-list')
     await flushUi()
     expect(q('[data-testid="approval-canvas-workspace"]')).toBeNull()
     expect(visibleStepRows()).toHaveLength(2)
+    expect(q('[data-testid="approval-template-step-spine"]')).not.toBeNull()
+  })
+
+  it('switches directly between the form and flow workspaces while Canvas V2 is enabled', async () => {
+    routeParams = { id: 'tpl_canvas_mode_switch' }
+    await mountView()
+    await flushUi()
+
+    click('approval-template-section-fields')
+    await flushUi()
+    const modeSwitch = q('[data-testid="approval-authoring-mode-switch"]')
+    expect(modeSwitch).not.toBeNull()
+    expect(modeSwitch?.getAttribute('role')).toBe('group')
+    expect(q('[data-testid="approval-authoring-mode-form"]')?.getAttribute('aria-pressed')).toBe('true')
+
+    click('approval-authoring-mode-flow')
+    await flushUi()
+    expect(q('[data-testid="approval-authoring-mode-flow"]')?.getAttribute('aria-pressed')).toBe('true')
+    expect(q('[data-testid="approval-canvas-workspace"]')).not.toBeNull()
+
+    click('approval-authoring-mode-form')
+    await flushUi()
+    expect(q('[data-testid="approval-authoring-mode-form"]')?.getAttribute('aria-pressed')).toBe('true')
+    const fieldsPanel = q('[data-testid="approval-template-add-field"]')?.closest('.template-authoring__panel') as HTMLElement | null
+    const flowPanel = q('[data-testid="approval-canvas-workspace"]')?.closest('.template-authoring__panel') as HTMLElement | null
+    expect(fieldsPanel?.style.display).not.toBe('none')
+    expect(flowPanel?.style.display).toBe('none')
+  })
+
+  it('remeasures the canvas viewport when the hidden flow section becomes visible', async () => {
+    routeParams = { id: 'tpl_canvas_viewport_reveal' }
+    await mountView()
+    await flushUi()
+
+    const viewport = q<HTMLElement>('.template-authoring__canvas-viewport')
+    expect(viewport).not.toBeNull()
+    Object.defineProperties(viewport!, {
+      clientWidth: { configurable: true, value: 640 },
+      clientHeight: { configurable: true, value: 480 },
+    })
+
+    click('approval-template-section-flow')
+    await flushUi()
+
+    const minimapWindow = q<SVGRectElement>('[data-testid="approval-canvas-minimap-window"]')
+    expect(Number(minimapWindow?.getAttribute('width'))).toBeGreaterThan(0)
+    expect(Number(minimapWindow?.getAttribute('height'))).toBeGreaterThan(0)
   })
 
   it('keeps every canvas surface absent for a linear draft while the flag is off', async () => {
@@ -464,6 +504,7 @@ describe('C1 unified canvas — linear step drafts on the production Canvas V2 s
     await flushUi()
 
     expect(q('[data-testid="approval-graph-view-toggle"]')).toBeNull()
+    expect(q('[data-testid="approval-authoring-mode-switch"]')).toBeNull()
     expect(q('[data-testid="approval-canvas-workspace"]')).toBeNull()
     expect(q('[data-testid="approval-graph-canvas"]')).toBeNull()
     expect(visibleStepRows()).toHaveLength(2)
@@ -673,7 +714,14 @@ describe('C1 unified canvas — linear step drafts on the production Canvas V2 s
     await mountView()
     await flushUi()
 
-    // Complex still defaults to the structured read-only list, never the step cards.
+    // Canvas V2 is canvas-first for both linear and preserved complex graphs.
+    expect(q('[data-testid="approval-canvas-workspace"]')).not.toBeNull()
+    expect(q('[data-testid="approval-graph-readonly-list"]')).toBeNull()
+    expect(visibleStepRows()).toHaveLength(0)
+
+    // The accessible structured fallback remains available until equivalence is proven.
+    click('approval-view-list')
+    await flushUi()
     expect(q('[data-testid="approval-graph-readonly-list"]')).not.toBeNull()
     expect(visibleStepRows()).toHaveLength(0)
 


### PR DESCRIPTION
## What changed

- make Canvas V2 the default flow surface while the existing feature flag is ON
- retain the structured step/list editor as an explicit auxiliary mode
- add a Form Design / Flow Design segmented switch over the existing authoring sections
- remeasure the canvas viewport when the hidden flow section becomes visible
- keep the flag-OFF and unsupported-template fallbacks unchanged
- align user-facing copy with the new auxiliary-mode label

Stacked on #4649 (C1 unified canvas carrier). This PR does not enable the feature flag.

## Verification

- approval authoring/canvas/graph suite: 260 passed
- focused C2/C1 mounted specs: 22 passed
- `pnpm --filter @metasheet/web type-check`
- ESLint on all touched TypeScript/Vue/spec files
- mutation checks: canvas-first default, Form/Flow switch, viewport remeasure, and segmented-control semantics each turn RED when neutralized
- real Chromium at 1440 / 1024 / 390: no horizontal overflow; Form -> Flow -> Form and auxiliary-mode transitions verified; console errors 0
- independent Kimi adversarial re-review: no remaining P1/P2

## Boundaries

C3 still owns edge-centered insertion and removal of the current per-node button cluster. F1-F3 still own the draggable form-component palette and right-side field inspector.