### PR TITLE
feat(directory): serialize sync and OAuth access writes

### DIFF
--- a/packages/core-backend/src/auth/dingtalk-oauth.ts
+++ b/packages/core-backend/src/auth/dingtalk-oauth.ts
@@ -20,6 +20,10 @@ import {
 import { getBcryptSaltRounds } from '../security/auth-runtime-config'
 import { evaluateUserAuthenticationGate } from './user-activation'
 import { recordDingTalkOAuthStateFallback, recordDingTalkOAuthStateOperation } from '../metrics/metrics'
+import {
+  lockUsersForAccessGraphWrite,
+  supersedeDeprovisionEvidenceForAccessGraphWrite,
+} from '../directory/access-graph-mutex'
 
 const logger = new Logger('DingTalkOAuth')
 
@@ -422,16 +426,34 @@ async function readGrantEnabled(localUserId: string): Promise<boolean | null> {
 }
 
 async function ensureGrant(localUserId: string): Promise<void> {
-  try {
-    await query(
+  await transaction(async (client) => {
+    const lockedUsers = await lockUsersForAccessGraphWrite(client, [localUserId])
+    if (!lockedUsers.has(localUserId)) {
+      throw createPolicyError('Local user no longer exists', {
+        statusCode: 403,
+        code: 'local_user_disabled',
+      })
+    }
+    const grant = await client.query(
       `INSERT INTO user_external_auth_grants (provider, local_user_id, enabled, granted_by, created_at, updated_at)
        VALUES ($1, $2, TRUE, $3, NOW(), NOW())
-       ON CONFLICT (provider, local_user_id) DO NOTHING`,
+       ON CONFLICT (provider, local_user_id)
+       DO UPDATE SET
+         enabled = TRUE,
+         granted_by = EXCLUDED.granted_by,
+         updated_at = NOW()
+       WHERE user_external_auth_grants.enabled IS DISTINCT FROM TRUE
+       RETURNING local_user_id`,
       [PROVIDER, localUserId, localUserId],
     )
-  } catch (error) {
-    logger.warn('Failed to persist DingTalk auth grant', error instanceof Error ? error : undefined)
-  }
+    if (grant.rows.length > 0) {
+      await supersedeDeprovisionEvidenceForAccessGraphWrite(client, {
+        userIds: [localUserId],
+        actorId: localUserId,
+        reason: 'DingTalk OAuth enabled the user grant',
+      })
+    }
+  })
 }
 
 async function upsertExternalIdentity(localUserId: string, dtUser: DingTalkUserInfo): Promise<void> {
@@ -440,14 +462,27 @@ async function upsertExternalIdentity(localUserId: string, dtUser: DingTalkUserI
   const profile = JSON.stringify(dtUser)
 
   await transaction(async (client) => {
+    const lockedUsers = await lockUsersForAccessGraphWrite(client, [localUserId])
+    if (!lockedUsers.has(localUserId)) {
+      throw createPolicyError('Local user no longer exists', {
+        statusCode: 403,
+        code: 'local_user_disabled',
+      })
+    }
     const existingByUser = await client.query(
-      `SELECT id
+      `SELECT id,
+              external_key,
+              provider_union_id,
+              provider_open_id,
+              corp_id
        FROM user_external_identities
        WHERE provider = $1 AND local_user_id = $2
+       FOR UPDATE
        LIMIT 1`,
       [PROVIDER, localUserId],
     )
 
+    let accessGraphChanged = false
     if (existingByUser.rows.length > 0) {
       // E1 (container-login design-lock §2): the container surface carries no
       // sns openId, so a container login must never clobber the openId-derived
@@ -455,6 +490,23 @@ async function upsertExternalIdentity(localUserId: string, dtUser: DingTalkUserI
       // move when the incoming profile actually has an openId (one-way
       // enrichment; alternating logins stay stable).
       const hasOpenId = Boolean(dtUser.openId)
+      const existing = existingByUser.rows[0]
+      const nextExternalKey = hasOpenId
+        ? externalKey
+        : String(existing.external_key ?? '').trim() || externalKey
+      const nextUnionId =
+        dtUser.unionId || existing.provider_union_id || null
+      const nextOpenId = hasOpenId
+        ? dtUser.openId || null
+        : existing.provider_open_id || null
+      const nextCorpId = hasOpenId
+        ? config.corpId || null
+        : existing.corp_id ?? config.corpId ?? null
+      accessGraphChanged =
+        (existing.external_key || '') !== nextExternalKey
+        || (existing.provider_union_id ?? null) !== nextUnionId
+        || (existing.provider_open_id ?? null) !== nextOpenId
+        || (existing.corp_id ?? null) !== nextCorpId
       await client.query(
         `UPDATE user_external_identities
          SET external_key = CASE WHEN $8::boolean THEN $3 ELSE COALESCE(NULLIF(external_key, ''), $3) END,
@@ -468,36 +520,42 @@ async function upsertExternalIdentity(localUserId: string, dtUser: DingTalkUserI
          WHERE provider = $1 AND local_user_id = $2`,
         [PROVIDER, localUserId, externalKey, dtUser.unionId || null, dtUser.openId ?? null, config.corpId, profile, hasOpenId],
       )
-      return
+    } else {
+      const inserted = await client.query(
+        `INSERT INTO user_external_identities (
+           provider,
+           external_key,
+           provider_union_id,
+           provider_open_id,
+           corp_id,
+           local_user_id,
+           profile,
+           bound_by,
+           last_login_at,
+           created_at,
+           updated_at
+         )
+         VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb, $6, NOW(), NOW(), NOW())
+         ON CONFLICT (provider, external_key) DO NOTHING
+         RETURNING id`,
+        [PROVIDER, externalKey, dtUser.unionId || null, dtUser.openId ?? null, config.corpId, localUserId, profile],
+      )
+      if (inserted.rows.length === 0) {
+        throw createPolicyError('DingTalk identity is already bound to another local user', {
+          statusCode: 409,
+          code: 'identity_already_bound',
+        })
+      }
+      accessGraphChanged = true
     }
 
-    await client.query(
-      `INSERT INTO user_external_identities (
-         provider,
-         external_key,
-         provider_union_id,
-         provider_open_id,
-         corp_id,
-         local_user_id,
-         profile,
-         bound_by,
-         last_login_at,
-         created_at,
-         updated_at
-       )
-       VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb, $6, NOW(), NOW(), NOW())
-       ON CONFLICT (provider, external_key)
-       DO UPDATE SET
-         provider_union_id = EXCLUDED.provider_union_id,
-         provider_open_id = EXCLUDED.provider_open_id,
-         corp_id = EXCLUDED.corp_id,
-         local_user_id = EXCLUDED.local_user_id,
-         profile = EXCLUDED.profile,
-         bound_by = COALESCE(user_external_identities.bound_by, EXCLUDED.bound_by),
-         last_login_at = NOW(),
-         updated_at = NOW()`,
-      [PROVIDER, externalKey, dtUser.unionId || null, dtUser.openId ?? null, config.corpId, localUserId, profile],
-    )
+    if (accessGraphChanged) {
+      await supersedeDeprovisionEvidenceForAccessGraphWrite(client, {
+        userIds: [localUserId],
+        actorId: localUserId,
+        reason: 'DingTalk OAuth identity binding changed',
+      })
+    }
   })
 }
 
@@ -513,6 +571,8 @@ async function enrichMissingOpenIdForRejectedLogin(localUserId: string, dtUser: 
   const profile = JSON.stringify(dtUser)
 
   await transaction(async (client) => {
+    const lockedUsers = await lockUsersForAccessGraphWrite(client, [localUserId])
+    if (!lockedUsers.has(localUserId)) return
     const conflictResult = await client.query(
       `SELECT local_user_id
        FROM user_external_identities
@@ -1076,6 +1136,13 @@ export async function bindDingTalkIdentityToUser(input: {
   const unionId = dtUser.unionId || ''
 
   await transaction(async (client) => {
+    const lockedUsers = await lockUsersForAccessGraphWrite(client, [localUserId])
+    if (!lockedUsers.has(localUserId)) {
+      throw createPolicyError('Local user no longer exists', {
+        statusCode: 403,
+        code: 'local_user_disabled',
+      })
+    }
     const conflictResult = await client.query(
       `SELECT local_user_id
        FROM user_external_identities
@@ -1097,14 +1164,26 @@ export async function bindDingTalkIdentityToUser(input: {
     }
 
     const existingByUser = await client.query(
-      `SELECT id
+      `SELECT id,
+              external_key,
+              provider_union_id,
+              provider_open_id,
+              corp_id
        FROM user_external_identities
        WHERE provider = $1 AND local_user_id = $2
+       FOR UPDATE
        LIMIT 1`,
       [PROVIDER, localUserId],
     )
 
+    let accessGraphChanged = false
     if (existingByUser.rows.length > 0) {
+      const existing = existingByUser.rows[0]
+      accessGraphChanged =
+        existing.external_key !== externalKey
+        || (existing.provider_union_id ?? null) !== (dtUser.unionId || null)
+        || (existing.provider_open_id ?? null) !== (dtUser.openId || null)
+        || (existing.corp_id ?? null) !== (config.corpId || null)
       await client.query(
         `UPDATE user_external_identities
          SET external_key = $3,
@@ -1118,7 +1197,7 @@ export async function bindDingTalkIdentityToUser(input: {
         [PROVIDER, localUserId, externalKey, dtUser.unionId || null, dtUser.openId, config.corpId, profile, boundBy],
       )
     } else {
-      await client.query(
+      const inserted = await client.query(
         `INSERT INTO user_external_identities (
            provider,
            external_key,
@@ -1131,20 +1210,96 @@ export async function bindDingTalkIdentityToUser(input: {
            created_at,
            updated_at
          )
-         VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb, $8, NOW(), NOW())`,
+         VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb, $8, NOW(), NOW())
+         ON CONFLICT (provider, external_key) DO NOTHING
+         RETURNING id`,
         [PROVIDER, externalKey, dtUser.unionId || null, dtUser.openId, config.corpId, localUserId, profile, boundBy],
       )
+      if (inserted.rows.length === 0) {
+        throw createPolicyError('DingTalk identity is already bound to another local user', {
+          statusCode: 409,
+          code: 'identity_already_bound',
+        })
+      }
+      accessGraphChanged = true
     }
 
     if (enableGrant) {
-      await client.query(
+      const grant = await client.query(
         `INSERT INTO user_external_auth_grants (provider, local_user_id, enabled, granted_by, created_at, updated_at)
          VALUES ($1, $2, TRUE, $3, NOW(), NOW())
          ON CONFLICT (provider, local_user_id)
-         DO UPDATE SET enabled = TRUE, granted_by = EXCLUDED.granted_by, updated_at = NOW()`,
+         DO UPDATE SET
+           enabled = TRUE,
+           granted_by = EXCLUDED.granted_by,
+           updated_at = NOW()
+         WHERE user_external_auth_grants.enabled IS DISTINCT FROM TRUE
+         RETURNING local_user_id`,
         [PROVIDER, localUserId, boundBy],
       )
+      accessGraphChanged ||= grant.rows.length > 0
     }
+    if (accessGraphChanged) {
+      await supersedeDeprovisionEvidenceForAccessGraphWrite(client, {
+        userIds: [localUserId],
+        actorId: boundBy,
+        reason: 'DingTalk identity bound by OAuth callback',
+      })
+    }
+  })
+}
+
+export async function unbindSelfManagedDingTalkIdentity(input: {
+  localUserId: string
+  actorId?: string
+}): Promise<boolean> {
+  const localUserId = String(input.localUserId || '').trim()
+  const actorId = String(input.actorId || '').trim() || localUserId
+  if (!localUserId) throw new Error('localUserId is required')
+
+  return transaction(async (client) => {
+    const lockedUsers = await lockUsersForAccessGraphWrite(client, [localUserId])
+    if (!lockedUsers.has(localUserId)) {
+      throw createPolicyError('Local user no longer exists', {
+        statusCode: 403,
+        code: 'local_user_disabled',
+      })
+    }
+    const managedLink = await client.query(
+      `SELECT 1
+         FROM directory_account_links link
+         JOIN directory_accounts account
+           ON account.id = link.directory_account_id
+        WHERE link.local_user_id = $1::text
+          AND link.link_status = 'linked'
+          AND account.provider = $2::text
+        LIMIT 1`,
+      [localUserId, PROVIDER],
+    )
+    if (managedLink.rows.length > 0) {
+      throw createPolicyError(
+        'Current DingTalk identity is directory-managed. Please contact an administrator.',
+        {
+          statusCode: 409,
+          code: 'directory_managed_identity',
+        },
+      )
+    }
+
+    const removed = await client.query(
+      `DELETE FROM user_external_identities
+        WHERE provider = $1 AND local_user_id = $2
+        RETURNING id`,
+      [PROVIDER, localUserId],
+    )
+    if (removed.rows.length === 0) return false
+
+    await supersedeDeprovisionEvidenceForAccessGraphWrite(client, {
+      userIds: [localUserId],
+      actorId,
+      reason: 'DingTalk identity unbound by the local user',
+    })
+    return true
   })
 }
 

--- a/packages/core-backend/src/auth/dingtalk-oauth.ts
+++ b/packages/core-backend/src/auth/dingtalk-oauth.ts
@@ -425,6 +425,15 @@ async function readGrantEnabled(localUserId: string): Promise<boolean | null> {
   }
 }
 
+/**
+ * Creation-only ON PURPOSE (`DO NOTHING`, never `DO UPDATE enabled=TRUE`): an existing DISABLED
+ * row is deprovision's authoritative "this person was offboarded" mark — the OPS-01 writer
+ * leaves it precisely so a later OAuth attempt CANNOT silently re-grant (D5 review P2: the
+ * DO UPDATE variant flipped a deprovision-written enabled=false back to true on next login).
+ * Re-enabling after deprovision is exclusively the audited rehire/force-restore path. A
+ * genuinely NEW grant (row created, RETURNING non-empty) IS an access-graph write, so it takes
+ * the mutex and supersedes open deprovision evidence (§5.4 both legs) below.
+ */
 async function ensureGrant(localUserId: string): Promise<void> {
   await transaction(async (client) => {
     const lockedUsers = await lockUsersForAccessGraphWrite(client, [localUserId])
@@ -438,11 +447,7 @@ async function ensureGrant(localUserId: string): Promise<void> {
       `INSERT INTO user_external_auth_grants (provider, local_user_id, enabled, granted_by, created_at, updated_at)
        VALUES ($1, $2, TRUE, $3, NOW(), NOW())
        ON CONFLICT (provider, local_user_id)
-       DO UPDATE SET
-         enabled = TRUE,
-         granted_by = EXCLUDED.granted_by,
-         updated_at = NOW()
-       WHERE user_external_auth_grants.enabled IS DISTINCT FROM TRUE
+       DO NOTHING
        RETURNING local_user_id`,
       [PROVIDER, localUserId, localUserId],
     )
@@ -1311,4 +1316,5 @@ export async function unbindSelfManagedDingTalkIdentity(input: {
  */
 export const __dingtalkOAuthInternalsForTests = {
   createProvisionedUser,
+  ensureGrant,
 }

--- a/packages/core-backend/src/directory/directory-sync.ts
+++ b/packages/core-backend/src/directory/directory-sync.ts
@@ -3294,6 +3294,36 @@ async function lockDirectorySyncAccessGraphUsers(
            FROM users candidate_user
           WHERE lower(candidate_user.email) = ANY($6::text[])
              OR regexp_replace(candidate_user.mobile, '\\s+', '', 'g') = ANY($7::text[])
+         UNION ALL
+         -- D5 review P1: the payload-built arms above under-covered the loop, which iterates
+         -- EVERY account of the integration (retained-but-departed included) and resolves
+         -- against match maps built from all of them. One retained account whose email/mobile
+         -- or identity keys newly matched a local user made the loop resolve a user the
+         -- inventory never locked -> 'resolved after the mutex inventory' -> the whole run
+         -- failed, and every subsequent run failed identically. These two DB-side arms make the
+         -- inventory a superset of anything the loop can resolve; over-locking a user is safe,
+         -- under-locking kills the run.
+         SELECT db_identity.local_user_id
+           FROM user_external_identities db_identity
+           JOIN directory_accounts db_account
+             ON db_account.integration_id = $1::uuid
+            AND (
+              db_identity.external_key = db_account.external_key
+              OR (db_account.union_id IS NOT NULL AND db_identity.provider_union_id = db_account.union_id)
+              OR (db_account.open_id IS NOT NULL AND db_identity.provider_open_id = db_account.open_id)
+            )
+          WHERE db_identity.provider = $2::text
+         UNION ALL
+         SELECT db_user.id
+           FROM users db_user
+           JOIN directory_accounts db_match
+             ON db_match.integration_id = $1::uuid
+          WHERE (db_match.email IS NOT NULL AND lower(db_user.email) = lower(db_match.email))
+             OR (
+               db_match.mobile IS NOT NULL
+               AND db_user.mobile IS NOT NULL
+               AND regexp_replace(db_user.mobile, '\\s+', '', 'g') = regexp_replace(db_match.mobile, '\\s+', '', 'g')
+             )
        ) candidate
       WHERE candidate.local_user_id IS NOT NULL`,
     [

--- a/packages/core-backend/src/directory/directory-sync.ts
+++ b/packages/core-backend/src/directory/directory-sync.ts
@@ -48,6 +48,7 @@ import { applyDirectoryDeprovisionCandidate } from './deprovision-ledger'
 import {
   lockUsersForAccessGraphWrite,
   supersedeDeprovisionEvidenceForAccessGraphWrite,
+  type AccessGraphTransactionClient,
 } from './access-graph-mutex'
 
 const logger = new Logger('DirectorySync')
@@ -279,6 +280,14 @@ type DirectoryAccountLinkedUserRow = {
   local_user_email: string | null
   local_user_username: string | null
   local_user_name: string | null
+}
+
+type DirectorySyncPriorAccessRow = {
+  account_id: string
+  external_user_id: string
+  is_active: boolean
+  link_status: string | null
+  local_user_id: string | null
 }
 
 export type DirectoryIntegrationSummary = {
@@ -3229,6 +3238,127 @@ export function buildUniqueLocalUserMatchMap(
   return { uniqueMap, ambiguousKeys }
 }
 
+async function lockDirectorySyncAccessGraphUsers(
+  client: AccessGraphTransactionClient,
+  options: {
+    integrationId: string
+    users: DingTalkDirectoryUser[]
+  },
+): Promise<{
+  lockedUserIds: Set<string>
+  openRehireAccountIds: Set<string>
+  priorAccessByExternalUserId: Map<string, DirectorySyncPriorAccessRow>
+}> {
+  const externalKeys = Array.from(new Set(
+    options.users
+      .map((user) => normalizeText(user.unionId || user.openId || user.userId))
+      .filter(Boolean),
+  ))
+  const unionIds = Array.from(new Set(
+    options.users.map((user) => normalizeText(user.unionId)).filter(Boolean),
+  ))
+  const openIds = Array.from(new Set(
+    options.users.map((user) => normalizeText(user.openId)).filter(Boolean),
+  ))
+  const emails = Array.from(new Set(
+    options.users
+      .map((user) => normalizeText(user.email).toLowerCase())
+      .filter(Boolean),
+  ))
+  const mobiles = Array.from(new Set(
+    options.users
+      .map((user) => normalizeMobileIdentifier(user.mobile))
+      .filter(Boolean),
+  ))
+
+  const candidates = await client.query(
+    `SELECT DISTINCT candidate.local_user_id
+       FROM (
+         SELECT link.local_user_id
+           FROM directory_account_links link
+           JOIN directory_accounts account
+             ON account.id = link.directory_account_id
+          WHERE account.integration_id = $1::uuid
+            AND link.local_user_id IS NOT NULL
+         UNION ALL
+         SELECT identity.local_user_id
+           FROM user_external_identities identity
+          WHERE identity.provider = $2::text
+            AND (
+              identity.external_key = ANY($3::text[])
+              OR identity.provider_union_id = ANY($4::text[])
+              OR identity.provider_open_id = ANY($5::text[])
+            )
+         UNION ALL
+         SELECT candidate_user.id
+           FROM users candidate_user
+          WHERE lower(candidate_user.email) = ANY($6::text[])
+             OR regexp_replace(candidate_user.mobile, '\\s+', '', 'g') = ANY($7::text[])
+       ) candidate
+      WHERE candidate.local_user_id IS NOT NULL`,
+    [
+      options.integrationId,
+      DEFAULT_PROVIDER,
+      externalKeys,
+      unionIds,
+      openIds,
+      emails,
+      mobiles,
+    ],
+  )
+  const candidateUserIds = candidates.rows
+    .map((row) => normalizeText(row.local_user_id))
+    .filter(Boolean)
+  const lockedUsers = await lockUsersForAccessGraphWrite(client, candidateUserIds)
+
+  const recheckedPrior = await client.query(
+    `SELECT account.id::text AS account_id,
+            account.external_user_id,
+            account.is_active,
+            link.local_user_id,
+            link.link_status
+       FROM directory_accounts account
+       LEFT JOIN directory_account_links link
+         ON link.directory_account_id = account.id
+      WHERE account.integration_id = $1::uuid`,
+    [options.integrationId],
+  )
+  const priorAccessByExternalUserId = new Map<string, DirectorySyncPriorAccessRow>()
+  for (const row of recheckedPrior.rows as DirectorySyncPriorAccessRow[]) {
+    if (row.local_user_id && !lockedUsers.has(row.local_user_id)) {
+      throw new Error('Directory sync account binding changed before the user mutex was acquired; retry the run')
+    }
+    priorAccessByExternalUserId.set(row.external_user_id, row)
+  }
+  const openRehireEvidence = await client.query(
+    `SELECT DISTINCT event.directory_account_id::text AS account_id
+       FROM directory_deprovision_events event
+       JOIN directory_account_links link
+         ON link.directory_account_id = event.directory_account_id
+        AND link.local_user_id = event.local_user_id
+        AND link.link_status = 'linked'
+      WHERE event.integration_id = $1::uuid
+        AND event.status = 'applied'
+        AND EXISTS (
+          SELECT 1
+            FROM directory_deprovision_effects effect
+           WHERE effect.event_id = event.id
+             AND effect.status = 'applied'
+        )`,
+    [options.integrationId],
+  )
+
+  return {
+    lockedUserIds: new Set(lockedUsers.keys()),
+    openRehireAccountIds: new Set(
+      openRehireEvidence.rows
+        .map((row) => normalizeText(row.account_id))
+        .filter(Boolean),
+    ),
+    priorAccessByExternalUserId,
+  }
+}
+
 async function loadMatchMaps(
   accounts: DirectoryAccountRow[],
   identityClient?: {
@@ -3712,6 +3842,17 @@ export async function syncDirectoryIntegration(
       // → the two-connection create/refreeze-vs-sync barrier suite reds.
       await acquireSourceSyncFreezeLock(client, integrationId)
       await assertDirectorySyncNotFrozenByTransfer(integrationId, client as FreezeCheckClient)
+      const syncAccess = await lockDirectorySyncAccessGraphUsers(client, {
+        integrationId,
+        users: Array.from(users.values()),
+      })
+      const priorAccessByAccountId = new Map(
+        Array.from(syncAccess.priorAccessByExternalUserId.values())
+          .map((row) => [row.account_id, row] as const),
+      )
+      const changedAccessGraphUserIds = new Set<string>()
+      const alreadySupersededUserIds = new Set<string>()
+      const newlyAdmittedUserIds = new Set<string>()
 
       // R5: created-vs-updated split for the run summary. `departmentsSynced`/`accountsSynced`
       // conflate "0 new" and "500 new"; the discriminator is `(xmax = 0)` on the upserted row —
@@ -3851,6 +3992,12 @@ export async function syncDirectoryIntegration(
         [integrationId, syncTimestamp],
       )
       const deactivatedAccountIds = (deactivatedAccountsResult.rows as Array<{ id: string }>).map((row) => row.id)
+      for (const accountId of deactivatedAccountIds) {
+        const priorAccess = priorAccessByAccountId.get(accountId)
+        if (priorAccess?.link_status === 'linked' && priorAccess.local_user_id) {
+          changedAccessGraphUserIds.add(priorAccess.local_user_id)
+        }
+      }
 
       const [departmentRows, accountRows] = await Promise.all([
         client.query(
@@ -4093,6 +4240,13 @@ export async function syncDirectoryIntegration(
                   }
                 }
                 localUserId = created.userId
+                newlyAdmittedUserIds.add(created.userId)
+                if (
+                  existing?.local_user_id
+                  && existing.local_user_id !== created.userId
+                ) {
+                  alreadySupersededUserIds.add(existing.local_user_id)
+                }
                 linkStatus = 'linked'
                 matchStrategy = 'auto_admit'
                 autoAdmittedCount += 1
@@ -4146,6 +4300,28 @@ export async function syncDirectoryIntegration(
           linkedUserIdByExternalUserId.set(account.external_user_id, localUserId)
         }
 
+        if (
+          localUserId
+          && !newlyAdmittedUserIds.has(localUserId)
+          && !syncAccess.lockedUserIds.has(localUserId)
+        ) {
+          throw new Error(
+            'Directory sync resolved a local user after the mutex inventory; retry the run',
+          )
+        }
+        const priorLinkedUserId =
+          existing?.link_status === 'linked' ? existing.local_user_id : null
+        const nextLinkedUserId = linkStatus === 'linked' ? localUserId : null
+        if (
+          priorLinkedUserId !== nextLinkedUserId
+          || existing?.link_status !== linkStatus
+        ) {
+          if (priorLinkedUserId) changedAccessGraphUserIds.add(priorLinkedUserId)
+          if (nextLinkedUserId && !newlyAdmittedUserIds.has(nextLinkedUserId)) {
+            changedAccessGraphUserIds.add(nextLinkedUserId)
+          }
+        }
+
         // W4-PRE-1b item A: an `external_identity` re-match confirms a PRE-EXISTING user against
         // this account without going through `applyDirectoryAccountBindInTransaction` (that
         // helper only runs for the manual-bind / admit call sites) — this is the "auto-match"
@@ -4168,8 +4344,24 @@ export async function syncDirectoryIntegration(
         // reopening the exact stale-access half of the owner's original P1 finding via this line's
         // OWN new write point (review finding, #4526). A currently-inactive account never confirms
         // membership through this writer; only a live account does.
-        if (linkStatus === 'linked' && localUserId && account.is_active) {
-          await upsertActiveUserOrgMembership(client, { userId: localUserId, orgId: integration.org_id })
+        const preservesOpenRehireEvidence =
+          syncAccess.openRehireAccountIds.has(account.id)
+          && existing?.link_status === 'linked'
+          && existing.local_user_id === localUserId
+          && linkStatus === 'linked'
+        if (
+          linkStatus === 'linked'
+          && localUserId
+          && account.is_active
+          && !preservesOpenRehireEvidence
+        ) {
+          const membershipChanged = await upsertActiveUserOrgMembership(client, {
+            userId: localUserId,
+            orgId: integration.org_id,
+          })
+          if (membershipChanged && !newlyAdmittedUserIds.has(localUserId)) {
+            changedAccessGraphUserIds.add(localUserId)
+          }
         }
 
         await client.query(
@@ -4185,6 +4377,20 @@ export async function syncDirectoryIntegration(
              updated_at = NOW()`,
           [account.id, localUserId, linkStatus, matchStrategy],
         )
+      }
+
+      for (const userId of alreadySupersededUserIds) {
+        changedAccessGraphUserIds.delete(userId)
+      }
+      for (const userId of newlyAdmittedUserIds) {
+        changedAccessGraphUserIds.delete(userId)
+      }
+      if (changedAccessGraphUserIds.size > 0) {
+        await supersedeDeprovisionEvidenceForAccessGraphWrite(client, {
+          userIds: Array.from(changedAccessGraphUserIds),
+          actorId: triggeredBy,
+          reason: 'directory synchronization changed account or binding state',
+        })
       }
 
       const memberGroupPlans = buildDirectoryProjectedMemberGroupPlans({
@@ -5354,13 +5560,17 @@ async function resolveDirectoryAccountOrgId(client: MembershipWriteClient, integ
 export async function upsertActiveUserOrgMembership(
   client: MembershipWriteClient,
   options: { userId: string; orgId: string },
-): Promise<void> {
-  await client.query(
+): Promise<boolean> {
+  const result = await client.query(
     `INSERT INTO user_orgs (user_id, org_id, is_active)
      VALUES ($1::text, $2::text, TRUE)
-     ON CONFLICT (user_id, org_id) DO UPDATE SET is_active = EXCLUDED.is_active`,
+     ON CONFLICT (user_id, org_id)
+     DO UPDATE SET is_active = EXCLUDED.is_active
+     WHERE user_orgs.is_active IS DISTINCT FROM TRUE
+     RETURNING user_id`,
     [options.userId, options.orgId],
   )
+  return result.rows.length > 0
 }
 
 /**
@@ -5909,6 +6119,7 @@ async function createDirectoryAdmittedUserInTransaction(
 export const __directorySyncInternalsForTests = {
   createDirectoryAdmittedUserInTransaction,
   doesExternalIdentityMatchAccount,
+  lockDirectorySyncAccessGraphUsers,
 }
 
 async function applyDirectoryProjectedMemberGroupGovernanceInTransaction(

--- a/packages/core-backend/src/routes/auth.ts
+++ b/packages/core-backend/src/routes/auth.ts
@@ -20,6 +20,7 @@ import {
   getDingTalkRuntimeStatus,
   generateState,
   isDingTalkConfigured,
+  unbindSelfManagedDingTalkIdentity,
   validateState,
 } from '../auth/dingtalk-oauth'
 import {
@@ -1162,11 +1163,10 @@ authRouter.post('/dingtalk/unbind', async (req: Request, res: Response) => {
       })
     }
 
-    await query(
-      `DELETE FROM user_external_identities
-       WHERE provider = $1 AND local_user_id = $2`,
-      ['dingtalk', authResult.user.id],
-    )
+    await unbindSelfManagedDingTalkIdentity({
+      localUserId: authResult.user.id,
+      actorId: authResult.user.id,
+    })
 
     const nextSnapshot = await fetchCurrentUserDingTalkAccessSnapshot(authResult.user.id)
     return res.json({
@@ -1174,6 +1174,13 @@ authRouter.post('/dingtalk/unbind', async (req: Request, res: Response) => {
       data: nextSnapshot,
     })
   } catch (error) {
+    if (error instanceof DingTalkLoginPolicyError) {
+      return res.status(error.statusCode).json({
+        success: false,
+        error: error.message,
+        code: error.code,
+      })
+    }
     logger.error('DingTalk self-unbind error', error instanceof Error ? error : undefined)
     return res.status(500).json({
       success: false,

--- a/packages/core-backend/tests/integration/directory-access-graph-mutex.db.test.ts
+++ b/packages/core-backend/tests/integration/directory-access-graph-mutex.db.test.ts
@@ -20,6 +20,7 @@ import {
   archiveLocalAccount,
   createLocalAccount,
 } from '../../src/directory/local-directory-org'
+import { __dingtalkOAuthInternalsForTests } from '../../src/auth/dingtalk-oauth'
 
 const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
 const PREFIX = `d5a-mutex-${Date.now()}`
@@ -543,6 +544,8 @@ describeIfDatabase('directory access-graph mutex (real DB)', () => {
     )
     expect(link.rows).toHaveLength(1)
     expect(link.rows[0]).toMatchObject({ local_user_id: targetUserId, link_status: 'linked' })
+  })
+
   it('automatic sync inventory parks on the linked user mutex before re-reading account state', async () => {
     const seeded = await seedAppliedEvidence()
     await resetSeededForAccessOverride(seeded)
@@ -672,5 +675,45 @@ describeIfDatabase('directory access-graph mutex (real DB)', () => {
     )
     expect(after.event_status).toBe('superseded')
     expect(after.resolved_by).toBe(seeded.userId)
+  })
+
+  it("OAuth ensureGrant is creation-only: a deprovision-written DISABLED grant is never flipped back (D5 review P2)", async () => {
+    const orgId = `${PREFIX}-org-${randomUUID()}`
+    const offboarded = `${PREFIX}-offboarded-${randomUUID()}`
+    const newcomer = `${PREFIX}-newcomer-${randomUUID()}`
+    for (const uid of [offboarded, newcomer]) {
+      await query(
+        `INSERT INTO users (id, password_hash, is_active, activation_status, access_generation)
+         VALUES ($1, 'x', TRUE, 'activated', 3)`,
+        [uid],
+      )
+    }
+    // Deprovision's authoritative mark: an explicit disabled row.
+    await query(
+      `INSERT INTO user_external_auth_grants (provider, local_user_id, enabled, granted_by)
+       VALUES ('dingtalk', $1, FALSE, 'system:directory-deprovision')`,
+      [offboarded],
+    )
+
+    // The offboarded person attempts OAuth login: the DO UPDATE variant flipped this row back to
+    // TRUE (silently undoing deprovision); creation-only must leave it exactly as written.
+    await __dingtalkOAuthInternalsForTests.ensureGrant(offboarded)
+    const after = await query<{ enabled: boolean }>(
+      `SELECT enabled FROM user_external_auth_grants WHERE local_user_id = $1`, [offboarded])
+    expect(after.rows[0]?.enabled).toBe(false)
+    const gen = await query<{ g: number }>(
+      `SELECT access_generation::int AS g FROM users WHERE id = $1`, [offboarded])
+    expect(gen.rows[0]?.g).toBe(3) // no supersede leg fired — nothing changed
+
+    // A genuinely NEW grant (no row) IS an access-graph write: row created enabled, and the
+    // §5.4 legs fire — generation moves.
+    void orgId
+    await __dingtalkOAuthInternalsForTests.ensureGrant(newcomer)
+    const created = await query<{ enabled: boolean }>(
+      `SELECT enabled FROM user_external_auth_grants WHERE local_user_id = $1`, [newcomer])
+    expect(created.rows[0]?.enabled).toBe(true)
+    const newcomerGen = await query<{ g: number }>(
+      `SELECT access_generation::int AS g FROM users WHERE id = $1`, [newcomer])
+    expect(newcomerGen.rows[0]?.g).toBeGreaterThan(3)
   })
 })

--- a/packages/core-backend/tests/integration/directory-access-graph-mutex.db.test.ts
+++ b/packages/core-backend/tests/integration/directory-access-graph-mutex.db.test.ts
@@ -1,6 +1,10 @@
 import { randomUUID } from 'node:crypto'
 import { Pool } from 'pg'
-import { afterAll, beforeEach, describe, expect, it } from 'vitest'
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  bindDingTalkIdentityToUser,
+  unbindSelfManagedDingTalkIdentity,
+} from '../../src/auth/dingtalk-oauth'
 import { query, transaction } from '../../src/db/pg'
 import {
   lockUsersForAccessGraphWrite,
@@ -8,6 +12,7 @@ import {
 } from '../../src/directory/access-graph-mutex'
 import { applyDirectoryDeprovisionCandidate } from '../../src/directory/deprovision-ledger'
 import {
+  __directorySyncInternalsForTests,
   bindDirectoryAccount,
   unbindDirectoryAccount,
 } from '../../src/directory/directory-sync'
@@ -21,13 +26,18 @@ const PREFIX = `d5a-mutex-${Date.now()}`
 
 type SeededEvidence = {
   accountId: string
+  corpId: string
   eventId: string
+  externalUserId: string
   integrationId: string
+  openId: string
   orgId: string
+  unionId: string
   userId: string
 }
 
 async function cleanup(): Promise<void> {
+  vi.unstubAllEnvs()
   await query(
     `DELETE FROM directory_deprovision_events WHERE local_user_id LIKE $1`,
     [`${PREFIX}-%`],
@@ -43,9 +53,23 @@ async function cleanup(): Promise<void> {
   await query(`DELETE FROM users WHERE id LIKE $1`, [`${PREFIX}-%`])
 }
 
+function configureDingTalkOAuth(corpId: string): void {
+  vi.stubEnv('DINGTALK_CLIENT_ID', 'd5c-client')
+  vi.stubEnv('DINGTALK_CLIENT_SECRET', 'd5c-secret')
+  vi.stubEnv(
+    'DINGTALK_REDIRECT_URI',
+    'https://metasheet.example.test/api/auth/dingtalk/callback',
+  )
+  vi.stubEnv('DINGTALK_CORP_ID', corpId)
+}
+
 async function seedAppliedEvidence(): Promise<SeededEvidence> {
   const orgId = `${PREFIX}-org-${randomUUID()}`
   const userId = `${PREFIX}-user-${randomUUID()}`
+  const corpId = `${PREFIX}-corp-${randomUUID()}`
+  const externalUserId = `${PREFIX}-external-${randomUUID()}`
+  const unionId = `${PREFIX}-union-${randomUUID()}`
+  const openId = `${PREFIX}-open-${randomUUID()}`
   const integration = await query<{ id: string }>(
     `INSERT INTO directory_integrations (
        name, corp_id, org_id, provider, status, default_deprovision_policy
@@ -53,7 +77,7 @@ async function seedAppliedEvidence(): Promise<SeededEvidence> {
      RETURNING id::text AS id`,
     [
       `${PREFIX}-integration-${randomUUID()}`,
-      `${PREFIX}-corp-${randomUUID()}`,
+      corpId,
       orgId,
     ],
   )
@@ -101,9 +125,9 @@ async function seedAppliedEvidence(): Promise<SeededEvidence> {
      RETURNING id::text AS id`,
     [
       integrationId,
-      `${PREFIX}-external-${randomUUID()}`,
-      `${PREFIX}-union-${randomUUID()}`,
-      `${PREFIX}-open-${randomUUID()}`,
+      externalUserId,
+      unionId,
+      openId,
     ],
   )
   await query(
@@ -128,9 +152,13 @@ async function seedAppliedEvidence(): Promise<SeededEvidence> {
   if (!applied.eventId) throw new Error('failed to seed deprovision evidence')
   return {
     accountId: account.rows[0].id,
+    corpId,
     eventId: applied.eventId,
+    externalUserId,
     integrationId,
+    openId,
     orgId,
+    unionId,
     userId,
   }
 }
@@ -515,5 +543,134 @@ describeIfDatabase('directory access-graph mutex (real DB)', () => {
     )
     expect(link.rows).toHaveLength(1)
     expect(link.rows[0]).toMatchObject({ local_user_id: targetUserId, link_status: 'linked' })
+  it('automatic sync inventory parks on the linked user mutex before re-reading account state', async () => {
+    const seeded = await seedAppliedEvidence()
+    await resetSeededForAccessOverride(seeded)
+    const pool = new Pool({ connectionString: process.env.DATABASE_URL })
+    const holder = await pool.connect()
+    try {
+      await holder.query('BEGIN')
+      const holderPid = Number(
+        (await holder.query<{ pid: number }>('SELECT pg_backend_pid() AS pid'))
+          .rows[0].pid,
+      )
+      await holder.query(`SELECT id FROM users WHERE id = $1 FOR UPDATE`, [
+        seeded.userId,
+      ])
+
+      const inventoryPromise = transaction((client) =>
+        __directorySyncInternalsForTests.lockDirectorySyncAccessGraphUsers(
+          client,
+          {
+            integrationId: seeded.integrationId,
+            users: [{
+              userId: seeded.externalUserId,
+              name: 'D5C Sync',
+              unionId: seeded.unionId,
+              openId: seeded.openId,
+              departmentIds: [],
+              source: {},
+            }],
+          },
+        ),
+      )
+      await waitForAnyUserLockWaiter(pool, holderPid)
+      await holder.query('ROLLBACK')
+
+      const inventory = await inventoryPromise
+      expect(inventory.lockedUserIds).toEqual(new Set([seeded.userId]))
+      expect(
+        inventory.priorAccessByExternalUserId.get(seeded.externalUserId),
+      ).toMatchObject({
+        account_id: seeded.accountId,
+        local_user_id: seeded.userId,
+        link_status: 'linked',
+      })
+    } finally {
+      await holder.query('ROLLBACK').catch(() => undefined)
+      holder.release()
+      await pool.end()
+    }
+  })
+
+  it('OAuth bind supersedes only a real canonical identity or grant change', async () => {
+    const seeded = await seedAppliedEvidence()
+    await resetSeededForAccessOverride(seeded)
+    configureDingTalkOAuth(seeded.corpId)
+    const profile = {
+      openId: seeded.openId,
+      unionId: seeded.unionId,
+      nick: 'D5C OAuth',
+    }
+    const beforeFirstBind = await readEvidence(seeded.userId)
+
+    await bindDingTalkIdentityToUser({
+      localUserId: seeded.userId,
+      dtUser: profile,
+      boundBy: 'admin:d5c-oauth',
+      enableGrant: true,
+    })
+
+    const afterFirstBind = await readEvidence(seeded.userId)
+    expect(Number(afterFirstBind.access_generation)).toBe(
+      Number(beforeFirstBind.access_generation) + 1,
+    )
+    expect(afterFirstBind.event_status).toBe('superseded')
+    expect(afterFirstBind.resolved_by).toBe('admin:d5c-oauth')
+
+    await reopenEvidence(seeded.eventId)
+    const beforeNoopBind = await readEvidence(seeded.userId)
+    await bindDingTalkIdentityToUser({
+      localUserId: seeded.userId,
+      dtUser: profile,
+      boundBy: 'admin:d5c-oauth',
+      enableGrant: true,
+    })
+    expect(await readEvidence(seeded.userId)).toEqual(beforeNoopBind)
+  })
+
+  it('self-managed OAuth unbind supersedes evidence in the same transaction', async () => {
+    const seeded = await seedAppliedEvidence()
+    await resetSeededForAccessOverride(seeded)
+    configureDingTalkOAuth(seeded.corpId)
+    await bindDingTalkIdentityToUser({
+      localUserId: seeded.userId,
+      dtUser: {
+        openId: seeded.openId,
+        unionId: seeded.unionId,
+        nick: 'D5C OAuth',
+      },
+      boundBy: 'admin:d5c-oauth',
+      enableGrant: false,
+    })
+    await query(
+      `UPDATE directory_account_links
+          SET link_status = 'unlinked'
+        WHERE directory_account_id = $1::uuid`,
+      [seeded.accountId],
+    )
+    await reopenEvidence(seeded.eventId)
+    const before = await readEvidence(seeded.userId)
+
+    await expect(
+      unbindSelfManagedDingTalkIdentity({
+        localUserId: seeded.userId,
+        actorId: seeded.userId,
+      }),
+    ).resolves.toBe(true)
+
+    const identity = await query(
+      `SELECT id
+         FROM user_external_identities
+        WHERE provider = 'dingtalk' AND local_user_id = $1`,
+      [seeded.userId],
+    )
+    expect(identity.rows).toHaveLength(0)
+    const after = await readEvidence(seeded.userId)
+    expect(Number(after.access_generation)).toBe(
+      Number(before.access_generation) + 1,
+    )
+    expect(after.event_status).toBe('superseded')
+    expect(after.resolved_by).toBe(seeded.userId)
   })
 })

--- a/packages/core-backend/tests/integration/directory-sync-orchestration.db.test.ts
+++ b/packages/core-backend/tests/integration/directory-sync-orchestration.db.test.ts
@@ -37,7 +37,8 @@ vi.mock('../../src/integrations/dingtalk/client', () => ({
   getDingTalkUserDetail: clientMocks.getDingTalkUserDetail,
 }))
 
-import { query } from '../../src/db/pg'
+import { query, transaction } from '../../src/db/pg'
+import { applyDirectoryDeprovisionCandidate } from '../../src/directory/deprovision-ledger'
 import {
   createDirectoryIntegration,
   DirectorySyncInProgressError,
@@ -504,7 +505,15 @@ describeIfDatabase('syncDirectoryIntegration orchestration harness (real DB)', (
   // arms run the REAL sync over a departure.
   // -------------------------------------------------------------------------
   describe('deprovision executor wiring inside the sync run (OPS-01 call site)', () => {
-    async function seedDepartureFixture(tag: string): Promise<{ integrationId: string; localUserId: string; accountId: string; deptId: string; survivorExt: string }> {
+    async function seedDepartureFixture(tag: string): Promise<{
+      accountId: string
+      departedExternalUserId: string
+      departedUnionId: string
+      deptId: string
+      integrationId: string
+      localUserId: string
+      survivorExt: string
+    }> {
       const integration = await createDirectoryIntegration({
         name: `dso-dep-${tag}-${TS}`,
         corpId: `dso-dep-corp-${tag}-${TS}`,
@@ -523,23 +532,43 @@ describeIfDatabase('syncDirectoryIntegration orchestration harness (real DB)', (
       // Pre-linked directory account that will be ABSENT from the pull below —
       // last_seen_at predates the sync timestamp, so the sweep transitions it
       // to inactive and hands its id to the executor within the same run.
+      const departedExternalUserId = `dso-dep-ext-${tag}-${TS}`
+      const departedUnionId = `dso-dep-un-${tag}-${TS}`
       const account = await query<{ id: string }>(
         `INSERT INTO directory_accounts (
            integration_id, corp_id, external_user_id, union_id, external_key, name, is_active, last_seen_at, created_at, updated_at
          ) VALUES ($1, $2, $3, $4, $4, 'Departed', true, NOW(), NOW(), NOW())
          RETURNING id`,
-        [integration.id, `dso-dep-corp-${tag}-${TS}`, `dso-dep-ext-${tag}-${TS}`, `dso-dep-un-${tag}-${TS}`],
+        [
+          integration.id,
+          `dso-dep-corp-${tag}-${TS}`,
+          departedExternalUserId,
+          departedUnionId,
+        ],
       )
       await query(
         `INSERT INTO directory_account_links (directory_account_id, local_user_id, link_status, match_strategy, created_at, updated_at)
          VALUES ($1, $2, 'linked', 'manual', NOW(), NOW())`,
         [account.rows[0].id, localUserId],
       )
+      await query(
+        `INSERT INTO user_orgs (user_id, org_id, is_active) VALUES ($1, 'default', TRUE)
+         ON CONFLICT (user_id, org_id) DO UPDATE SET is_active = TRUE`,
+        [localUserId],
+      )
+      await query(
+        `INSERT INTO user_external_auth_grants (
+           provider, local_user_id, enabled, granted_by, created_at, updated_at
+         ) VALUES ('dingtalk', $1, TRUE, 'system:test-fixture', NOW(), NOW())`,
+        [localUserId],
+      )
 
       return {
         integrationId: integration.id,
         localUserId,
         accountId: account.rows[0].id,
+        departedExternalUserId,
+        departedUnionId,
         deptId: `dso-dep-dept-${tag}-${TS}`,
         survivorExt: `dso-dep-surv-${tag}-${TS}`,
       }
@@ -555,6 +584,76 @@ describeIfDatabase('syncDirectoryIntegration orchestration harness (real DB)', (
             { userId: fixture.survivorExt, name: 'Survivor', departmentIds: [fixture.deptId], unionId: `${fixture.survivorExt}-un` },
           ],
         },
+      }
+    }
+
+    function rehireDirectory(fixture: {
+      departedExternalUserId: string
+      departedUnionId: string
+      deptId: string
+    }): MockDirectory {
+      return {
+        departments: [{
+          id: fixture.deptId,
+          parentId: '1',
+          name: 'Rehire Ops',
+          order: 0,
+        }],
+        usersByDept: {
+          [fixture.deptId]: [{
+            userId: fixture.departedExternalUserId,
+            name: 'Returned',
+            departmentIds: [fixture.deptId],
+            unionId: fixture.departedUnionId,
+          }],
+        },
+      }
+    }
+
+    async function seedOpenEvidenceBeforeDeparture(
+      fixture: {
+        accountId: string
+        integrationId: string
+        localUserId: string
+      },
+    ): Promise<{ eventId: string; generation: number }> {
+      await query(
+        `UPDATE directory_accounts SET is_active = FALSE WHERE id = $1::uuid`,
+        [fixture.accountId],
+      )
+      const run = await query<{ id: string }>(
+        `INSERT INTO directory_sync_runs (
+           integration_id, status, triggered_by, trigger_source
+         ) VALUES ($1::uuid, 'success', 'test:d5c-prior-event', 'manual')
+         RETURNING id::text AS id`,
+        [fixture.integrationId],
+      )
+      const applied = await transaction((client) =>
+        applyDirectoryDeprovisionCandidate(client, {
+          localUserId: fixture.localUserId,
+          orgId: 'default',
+          integrationId: fixture.integrationId,
+          directoryAccountId: fixture.accountId,
+          runId: run.rows[0].id,
+          triggeredBy: 'test:d5c-prior-event',
+          policy: 'mark_inactive',
+          write: true,
+        }),
+      )
+      if (!applied.eventId) {
+        throw new Error('failed to seed prior deprovision evidence')
+      }
+
+      // Re-open only the source account. The prior event remains applied and its
+      // three after-values remain current, so the next source-state transition
+      // must supersede that evidence without inventing a replacement event.
+      await query(
+        `UPDATE directory_accounts SET is_active = TRUE WHERE id = $1::uuid`,
+        [fixture.accountId],
+      )
+      return {
+        eventId: applied.eventId,
+        generation: applied.accessGeneration,
       }
     }
 
@@ -645,7 +744,7 @@ describeIfDatabase('syncDirectoryIntegration orchestration harness (real DB)', (
       const result = await syncDirectoryIntegration(fixture.integrationId, 'system:dso-dep-off')
       const stats = result.run.stats as Record<string, unknown>
 
-      // Default-off pin: the person keeps access; no grant row appears.
+      // Default-off pin: the person keeps every pre-existing access-graph edge.
       const user = await query<{ is_active: boolean }>(`SELECT is_active FROM users WHERE id = $1`, [fixture.localUserId])
       expect(user.rows[0].is_active).toBe(true)
 
@@ -653,13 +752,143 @@ describeIfDatabase('syncDirectoryIntegration orchestration harness (real DB)', (
         `SELECT enabled FROM user_external_auth_grants WHERE provider = 'dingtalk' AND local_user_id = $1`,
         [fixture.localUserId],
       )
-      expect(grant.rows).toHaveLength(0)
+      expect(grant.rows).toHaveLength(1)
+      expect(grant.rows[0].enabled).toBe(true)
+
+      const membership = await query<{ is_active: boolean }>(
+        `SELECT is_active FROM user_orgs WHERE user_id = $1 AND org_id = 'default'`,
+        [fixture.localUserId],
+      )
+      expect(membership.rows).toHaveLength(1)
+      expect(membership.rows[0].is_active).toBe(true)
 
       // But the run REPORTS what it would have done (the operator preview).
       expect(stats.deprovisionApplied).toBe(false)
       expect(stats.deprovisionCandidateCount).toBe(1)
       expect(stats.deprovisionGlobalCandidateCount).toBe(1)
+      expect(stats.deprovisionGrantsDisabledCount).toBe(1)
       expect(stats.deprovisionUsersDeactivatedCount).toBe(1)
+    })
+
+    it('supersedes prior evidence when the sync itself changes a linked account from active to inactive', async () => {
+      const fixture = await seedDepartureFixture('d5c-supersede')
+      cleanupTargets.push(fixture)
+      const prior = await seedOpenEvidenceBeforeDeparture(fixture)
+      activeDirectory = departureDirectory(fixture)
+      expect(process.env.DIRECTORY_DEPROVISION_ENABLED).toBeUndefined()
+
+      await syncDirectoryIntegration(
+        fixture.integrationId,
+        'system:d5c-sync-account-transition',
+      )
+
+      const state = await query<{
+        access_generation: string
+        account_active: boolean
+        event_status: string
+        effect_statuses: string[]
+        resolved_by: string | null
+      }>(
+        `SELECT
+           candidate_user.access_generation::text,
+           account.is_active AS account_active,
+           event.status AS event_status,
+           event.resolved_by,
+           array_agg(effect.status ORDER BY effect.effect_type)::text[] AS effect_statuses
+         FROM users candidate_user
+         JOIN directory_accounts account ON account.id = $2::uuid
+         JOIN directory_deprovision_events event
+           ON event.id = $3::uuid
+          AND event.local_user_id = candidate_user.id
+         JOIN directory_deprovision_effects effect ON effect.event_id = event.id
+        WHERE candidate_user.id = $1
+        GROUP BY
+          candidate_user.access_generation,
+          account.is_active,
+          event.status,
+          event.resolved_by`,
+        [fixture.localUserId, fixture.accountId, prior.eventId],
+      )
+      expect(state.rows).toHaveLength(1)
+      expect(state.rows[0]).toMatchObject({
+        account_active: false,
+        event_status: 'superseded',
+        effect_statuses: ['superseded', 'superseded', 'superseded'],
+        resolved_by: 'system:d5c-sync-account-transition',
+      })
+      expect(Number(state.rows[0].access_generation)).toBe(
+        prior.generation + 1,
+      )
+
+      const events = await query<{ status: string }>(
+        `SELECT status
+           FROM directory_deprovision_events
+          WHERE local_user_id = $1`,
+        [fixture.localUserId],
+      )
+      expect(events.rows).toEqual([{ status: 'superseded' }])
+    })
+
+    it('preserves applied evidence and the inactive access graph when its source account reappears for rehire review', async () => {
+      const fixture = await seedDepartureFixture('d5c-rehire')
+      cleanupTargets.push(fixture)
+      const prior = await seedOpenEvidenceBeforeDeparture(fixture)
+      activeDirectory = rehireDirectory(fixture)
+      expect(process.env.DIRECTORY_DEPROVISION_ENABLED).toBeUndefined()
+
+      await syncDirectoryIntegration(
+        fixture.integrationId,
+        'system:d5c-sync-rehire-signal',
+      )
+
+      const state = await query<{
+        access_generation: string
+        account_active: boolean
+        event_status: string
+        effect_statuses: string[]
+        grant_enabled: boolean
+        membership_active: boolean
+        user_active: boolean
+      }>(
+        `SELECT
+           candidate_user.access_generation::text,
+           candidate_user.is_active AS user_active,
+           account.is_active AS account_active,
+           event.status AS event_status,
+           grant_row.enabled AS grant_enabled,
+           membership.is_active AS membership_active,
+           array_agg(effect.status ORDER BY effect.effect_type)::text[] AS effect_statuses
+         FROM users candidate_user
+         JOIN directory_accounts account ON account.id = $2::uuid
+         JOIN directory_deprovision_events event
+           ON event.id = $3::uuid
+          AND event.local_user_id = candidate_user.id
+         JOIN directory_deprovision_effects effect ON effect.event_id = event.id
+         JOIN user_external_auth_grants grant_row
+           ON grant_row.provider = 'dingtalk'
+          AND grant_row.local_user_id = candidate_user.id
+         JOIN user_orgs membership
+           ON membership.user_id = candidate_user.id
+          AND membership.org_id = 'default'
+        WHERE candidate_user.id = $1
+        GROUP BY
+          candidate_user.access_generation,
+          candidate_user.is_active,
+          account.is_active,
+          event.status,
+          grant_row.enabled,
+          membership.is_active`,
+        [fixture.localUserId, fixture.accountId, prior.eventId],
+      )
+      expect(state.rows).toEqual([{
+        access_generation: String(prior.generation),
+        account_active: true,
+        event_status: 'applied',
+        effect_statuses: ['applied', 'applied', 'applied'],
+        grant_enabled: false,
+        membership_active: false,
+        user_active: false,
+      }])
     })
 
     // -----------------------------------------------------------------------

--- a/packages/core-backend/tests/integration/directory-sync-orchestration.db.test.ts
+++ b/packages/core-backend/tests/integration/directory-sync-orchestration.db.test.ts
@@ -735,6 +735,58 @@ describeIfDatabase('syncDirectoryIntegration orchestration harness (real DB)', (
       })
     })
 
+    it('a retained account whose email newly matches a local user does not kill the run (D5 review P1: inventory is a superset of the loop)', async () => {
+      // Before the fix, the mutex inventory was built ONLY from the pull payload, while the link
+      // loop iterates EVERY account of the integration and resolves against match maps built
+      // from all of them. This fixture is the deterministic killer: an account already in the DB
+      // (absent from the pull) whose email matches a user created since the last sync — the loop
+      // resolved a user the inventory never locked, threw "resolved a local user after the mutex
+      // inventory; retry the run", and every retry failed identically.
+      const integration = await createDirectoryIntegration({
+        name: `dso-inv-${TS}`,
+        corpId: `dso-inv-corp-${TS}`,
+        appKey: `dso-inv-appkey-${TS}`,
+        appSecret: 'dso-secret',
+        admissionMode: 'manual_only',
+        defaultDeprovisionPolicy: 'manual_review',
+      })
+      const matchedUserId = `dso-inv-user-${TS}`
+      await query(`INSERT INTO users (id, email, password_hash, is_active) VALUES ($1, $2, 'x', TRUE)`, [
+        matchedUserId,
+        `${matchedUserId}@example.test`,
+      ])
+      // Retained DB account with the matching email — NOT in the pull below.
+      await query(
+        `INSERT INTO directory_accounts (
+           integration_id, corp_id, external_user_id, external_key, name, email, is_active, last_seen_at, created_at, updated_at
+         ) VALUES ($1, $2, $3, $3, 'Retained', $4, true, NOW(), NOW(), NOW())`,
+        [integration.id, `dso-inv-corp-${TS}`, `dso-inv-ext-${TS}`, `${matchedUserId}@example.test`],
+      )
+      const survivorExt = `dso-inv-survivor-${TS}`
+      const deptId = `55${TS % 100000}`
+      activeDirectory = {
+        departments: [{ id: deptId, parentId: '1', name: 'Dep Inv', order: 0 }],
+        usersByDept: {
+          [deptId]: [
+            { userId: survivorExt, name: 'Survivor', departmentIds: [deptId], unionId: `${survivorExt}-un` },
+          ],
+        },
+      }
+      cleanupTargets.push({ integrationId: integration.id, localUserId: matchedUserId })
+
+      const result = await syncDirectoryIntegration(integration.id, 'system:dso-inv')
+      expect(result.run.status).toBe('completed')
+      // The retained account resolved its email hint without killing the run.
+      const hint = await query<{ local_user_id: string | null; link_status: string }>(
+        `SELECT l.local_user_id, l.link_status
+           FROM directory_account_links l
+           JOIN directory_accounts a ON a.id = l.directory_account_id
+          WHERE a.integration_id = $1 AND a.external_user_id = $2`,
+        [integration.id, `dso-inv-ext-${TS}`],
+      )
+      expect(hint.rows[0]?.local_user_id).toBe(matchedUserId)
+    })
+
     it('with the flag unset (shipped default), the same departure writes NOTHING — counts are preview-only', async () => {
       const fixture = await seedDepartureFixture('off')
       cleanupTargets.push(fixture)

--- a/packages/core-backend/tests/unit/auth-login-routes.test.ts
+++ b/packages/core-backend/tests/unit/auth-login-routes.test.ts
@@ -46,6 +46,7 @@ const dingtalkOauthMocks = vi.hoisted(() => ({
   exchangeEnterpriseAuthCodeForUser: vi.fn(),
   exchangeCodeForDingTalkProfile: vi.fn(),
   bindDingTalkIdentityToUser: vi.fn(),
+  unbindSelfManagedDingTalkIdentity: vi.fn(),
   DingTalkLoginPolicyError: class DingTalkLoginPolicyError extends Error {
     statusCode: number
     code: string
@@ -121,6 +122,7 @@ vi.mock('../../src/auth/dingtalk-oauth', () => ({
   exchangeEnterpriseAuthCodeForUser: dingtalkOauthMocks.exchangeEnterpriseAuthCodeForUser,
   exchangeCodeForDingTalkProfile: dingtalkOauthMocks.exchangeCodeForDingTalkProfile,
   bindDingTalkIdentityToUser: dingtalkOauthMocks.bindDingTalkIdentityToUser,
+  unbindSelfManagedDingTalkIdentity: dingtalkOauthMocks.unbindSelfManagedDingTalkIdentity,
   DingTalkLoginPolicyError: dingtalkOauthMocks.DingTalkLoginPolicyError,
 }))
 
@@ -238,6 +240,8 @@ describe('auth login routes', () => {
     dingtalkOauthMocks.exchangeCodeForUser.mockReset()
     dingtalkOauthMocks.exchangeCodeForDingTalkProfile.mockReset()
     dingtalkOauthMocks.bindDingTalkIdentityToUser.mockReset()
+    dingtalkOauthMocks.unbindSelfManagedDingTalkIdentity.mockReset()
+    dingtalkOauthMocks.unbindSelfManagedDingTalkIdentity.mockResolvedValue(true)
     rbacMocks.listUserPermissions.mockReset()
     dingtalkOauthMocks.getDingTalkRuntimeStatus.mockReturnValue({
       configured: true,
@@ -862,11 +866,10 @@ describe('auth login routes', () => {
     })
 
     expect(response.statusCode).toBe(200)
-    expect(pgMocks.query).toHaveBeenNthCalledWith(
-      4,
-      expect.stringContaining('DELETE FROM user_external_identities'),
-      ['dingtalk', 'user-1'],
-    )
+    expect(dingtalkOauthMocks.unbindSelfManagedDingTalkIdentity).toHaveBeenCalledWith({
+      localUserId: 'user-1',
+      actorId: 'user-1',
+    })
     expect((response.body as Record<string, any>).data.identity.exists).toBe(false)
     expect((response.body as Record<string, any>).data.directory.linked).toBe(false)
   })
@@ -900,6 +903,48 @@ describe('auth login routes', () => {
     expect(response.statusCode).toBe(409)
     expect((response.body as Record<string, any>).error).toContain('directory-managed')
     expect(pgMocks.query).toHaveBeenCalledTimes(3)
+  })
+
+  it('maps the transactional directory-managed recheck to 409', async () => {
+    authServiceMocks.verifyToken.mockResolvedValue({
+      id: 'user-1',
+      email: 'manager@example.com',
+      name: 'Manager',
+      role: 'user',
+      permissions: ['attendance:read'],
+    })
+    pgMocks.query
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({
+        rows: [{
+          corp_id: 'dingcorp',
+          last_login_at: '2026-04-11T12:00:00.000Z',
+          created_at: '2026-04-11T12:00:00.000Z',
+          updated_at: '2026-04-11T12:00:00.000Z',
+        }],
+      })
+      .mockResolvedValueOnce({ rows: [{ linked_count: 0 }] })
+    dingtalkOauthMocks.unbindSelfManagedDingTalkIdentity.mockRejectedValue(
+      new dingtalkOauthMocks.DingTalkLoginPolicyError(
+        'Current DingTalk identity is directory-managed. Please contact an administrator.',
+        {
+          statusCode: 409,
+          code: 'directory_managed_identity',
+        },
+      ),
+    )
+
+    const response = await invokeRoute('post', '/dingtalk/unbind', {
+      headers: {
+        authorization: 'Bearer live-token',
+      },
+    })
+
+    expect(response.statusCode).toBe(409)
+    expect(response.body).toMatchObject({
+      success: false,
+      code: 'directory_managed_identity',
+    })
   })
 
   it('requires authentication before issuing a DingTalk bind auth URL', async () => {

--- a/packages/core-backend/tests/unit/dingtalk-oauth-login-gates.test.ts
+++ b/packages/core-backend/tests/unit/dingtalk-oauth-login-gates.test.ts
@@ -44,10 +44,41 @@ vi.mock('../../src/integrations/dingtalk/client', () => ({
 
 import {
   __resetDingTalkOAuthStateStoreForTests,
+  bindDingTalkIdentityToUser,
   exchangeCodeForUser,
   exchangeEnterpriseAuthCodeForUser,
   getDingTalkRuntimeStatus,
 } from '../../src/auth/dingtalk-oauth'
+
+function createDefaultTransactionQuery() {
+  return vi.fn(async (sql: string, params: unknown[] = []) => {
+    const statement = String(sql)
+    if (/FROM users[\s\S]*FOR UPDATE/i.test(statement)) {
+      return {
+        rows: [{
+          id: String(params[0]),
+          name: 'Alpha',
+          email: 'alpha@example.com',
+          username: null,
+          mobile: '13800000000',
+          activation_status: 'activated',
+          is_active: true,
+          access_generation: 0,
+        }],
+      }
+    }
+    if (/INSERT INTO user_external_identities/i.test(statement)) {
+      return { rows: [{ id: 'identity-new' }] }
+    }
+    if (/INSERT INTO user_external_auth_grants/i.test(statement)) {
+      return { rows: [{ local_user_id: String(params[1]) }] }
+    }
+    if (/UPDATE users[\s\S]*access_generation/i.test(statement)) {
+      return { rows: [{ access_generation: 1 }] }
+    }
+    return { rows: [] }
+  })
+}
 
 describe('dingtalk oauth login gates', () => {
   beforeEach(async () => {
@@ -93,12 +124,12 @@ describe('dingtalk oauth login gates', () => {
       corpId: 'ding-corp',
       baseUrl: 'https://oapi.dingtalk.com',
     })
-    pgMocks.transaction.mockImplementation(async (callback: (client: { query: typeof pgMocks.query }) => Promise<unknown>) => {
-      const txQuery = vi.fn()
-        .mockResolvedValueOnce({ rows: [] })
-        .mockResolvedValueOnce({ rows: [] })
-      return callback({ query: txQuery })
-    })
+    pgMocks.transaction.mockImplementation(
+      async (callback: (client: { query: typeof pgMocks.query }) => Promise<unknown>) =>
+        callback({
+          query: createDefaultTransactionQuery() as unknown as typeof pgMocks.query,
+        }),
+    )
     await __resetDingTalkOAuthStateStoreForTests()
   })
 
@@ -131,10 +162,11 @@ describe('dingtalk oauth login gates', () => {
     vi.stubEnv('DINGTALK_AUTH_REQUIRE_GRANT', '1')
     const txCalls: Array<{ sql: string; params: unknown[] }> = []
     pgMocks.transaction.mockImplementation(async (callback: (client: { query: typeof pgMocks.query }) => Promise<unknown>) => {
+      const fallback = createDefaultTransactionQuery()
       const txQuery = vi.fn(async (sql: string, params: unknown[]) => {
         txCalls.push({ sql: String(sql), params })
         if (String(sql).includes('SELECT local_user_id')) return { rows: [] }
-        return { rows: [] }
+        return fallback(sql, params)
       })
       return callback({ query: txQuery as unknown as typeof pgMocks.query })
     })
@@ -178,12 +210,13 @@ describe('dingtalk oauth login gates', () => {
     vi.stubEnv('DINGTALK_AUTH_REQUIRE_GRANT', '1')
     const txCalls: Array<{ sql: string; params: unknown[] }> = []
     pgMocks.transaction.mockImplementation(async (callback: (client: { query: typeof pgMocks.query }) => Promise<unknown>) => {
+      const fallback = createDefaultTransactionQuery()
       const txQuery = vi.fn(async (sql: string, params: unknown[]) => {
         txCalls.push({ sql: String(sql), params })
         if (String(sql).includes('SELECT local_user_id')) {
           return { rows: [{ local_user_id: 'other-user' }] }
         }
-        return { rows: [] }
+        return fallback(sql, params)
       })
       return callback({ query: txQuery as unknown as typeof pgMocks.query })
     })
@@ -304,6 +337,101 @@ describe('dingtalk oauth login gates', () => {
     expect(pgMocks.query.mock.calls.some((call) => String(call[0]).includes('INSERT INTO users'))).toBe(true)
   })
 
+  it('does not supersede evidence for an idempotent explicit bind', async () => {
+    const txCalls: Array<{ sql: string; params: unknown[] }> = []
+    pgMocks.transaction.mockImplementation(async (callback: (client: { query: typeof pgMocks.query }) => Promise<unknown>) => {
+      const fallback = createDefaultTransactionQuery()
+      const txQuery = vi.fn(async (sql: string, params: unknown[]) => {
+        const statement = String(sql)
+        txCalls.push({ sql: statement, params })
+        if (statement.includes('SELECT local_user_id')) return { rows: [] }
+        if (
+          statement.includes('SELECT id,')
+          && statement.includes('FROM user_external_identities')
+        ) {
+          return {
+            rows: [{
+              id: 'identity-1',
+              external_key: 'ding-corp:open-1',
+              provider_union_id: 'union-1',
+              provider_open_id: 'open-1',
+              corp_id: 'ding-corp',
+            }],
+          }
+        }
+        if (statement.includes('INSERT INTO user_external_auth_grants')) {
+          return { rows: [] }
+        }
+        return fallback(sql, params)
+      })
+      return callback({ query: txQuery as unknown as typeof pgMocks.query })
+    })
+
+    await bindDingTalkIdentityToUser({
+      localUserId: 'user-1',
+      boundBy: 'user-1',
+      enableGrant: true,
+      dtUser: {
+        openId: 'open-1',
+        unionId: 'union-1',
+        nick: 'Alpha',
+      },
+    })
+
+    expect(txCalls.some((call) => call.sql.includes('UPDATE user_external_identities'))).toBe(true)
+    expect(txCalls.some((call) => call.sql.includes('UPDATE directory_deprovision_events'))).toBe(false)
+    expect(txCalls.some((call) => /UPDATE users[\s\S]*access_generation/.test(call.sql))).toBe(false)
+  })
+
+  it('supersedes evidence when an explicit bind changes the canonical identity', async () => {
+    const txCalls: Array<{ sql: string; params: unknown[] }> = []
+    pgMocks.transaction.mockImplementation(async (callback: (client: { query: typeof pgMocks.query }) => Promise<unknown>) => {
+      const fallback = createDefaultTransactionQuery()
+      const txQuery = vi.fn(async (sql: string, params: unknown[]) => {
+        const statement = String(sql)
+        txCalls.push({ sql: statement, params })
+        if (statement.includes('SELECT local_user_id')) return { rows: [] }
+        if (
+          statement.includes('SELECT id,')
+          && statement.includes('FROM user_external_identities')
+        ) {
+          return {
+            rows: [{
+              id: 'identity-1',
+              external_key: 'ding-corp:old-open',
+              provider_union_id: 'old-union',
+              provider_open_id: 'old-open',
+              corp_id: 'ding-corp',
+            }],
+          }
+        }
+        if (statement.includes('INSERT INTO user_external_auth_grants')) {
+          return { rows: [] }
+        }
+        return fallback(sql, params)
+      })
+      return callback({ query: txQuery as unknown as typeof pgMocks.query })
+    })
+
+    await bindDingTalkIdentityToUser({
+      localUserId: 'user-1',
+      boundBy: 'admin-1',
+      enableGrant: true,
+      dtUser: {
+        openId: 'open-1',
+        unionId: 'union-1',
+        nick: 'Alpha',
+      },
+    })
+
+    const lockIndex = txCalls.findIndex((call) => /FROM users[\s\S]*FOR UPDATE/.test(call.sql))
+    const identityWriteIndex = txCalls.findIndex((call) => call.sql.includes('UPDATE user_external_identities'))
+    expect(lockIndex).toBeGreaterThanOrEqual(0)
+    expect(identityWriteIndex).toBeGreaterThan(lockIndex)
+    expect(txCalls.some((call) => call.sql.includes('UPDATE directory_deprovision_events'))).toBe(true)
+    expect(txCalls.some((call) => call.sql.includes('access_generation = COALESCE'))).toBe(true)
+  })
+
   it('reports runtime status with grant mode and allowlist details', () => {
     vi.stubEnv('DINGTALK_CLIENT_ID', 'dt-client')
     vi.stubEnv('DINGTALK_CLIENT_SECRET', 'dt-secret')
@@ -380,10 +508,24 @@ describe('dingtalk oauth login gates', () => {
       vi.stubEnv('DINGTALK_AUTH_AUTO_LINK_EMAIL', '1')
       const txCalls: Array<{ sql: string; params: unknown[] }> = []
       pgMocks.transaction.mockImplementation(async (callback: (client: { query: typeof pgMocks.query }) => Promise<unknown>) => {
+        const fallback = createDefaultTransactionQuery()
         const txQuery = vi.fn(async (sql: string, params: unknown[]) => {
           txCalls.push({ sql: String(sql), params })
-          if (String(sql).includes('SELECT id')) return { rows: [{ id: 'identity-1' }] }
-          return { rows: [] }
+          if (
+            String(sql).includes('SELECT id,')
+            && String(sql).includes('FROM user_external_identities')
+          ) {
+            return {
+              rows: [{
+                id: 'identity-1',
+                external_key: 'ding-corp:union-1',
+                provider_union_id: 'union-1',
+                provider_open_id: null,
+                corp_id: 'ding-corp',
+              }],
+            }
+          }
+          return fallback(sql, params)
         })
         return callback({ query: txQuery as unknown as typeof pgMocks.query })
       })
@@ -408,6 +550,59 @@ describe('dingtalk oauth login gates', () => {
       expect(update!.sql).toContain('CASE WHEN $8::boolean')
       expect(update!.params[4]).toBeNull()
       expect(update!.params[7]).toBe(false)
+    })
+
+    it('supersedes evidence when a container login fills a previously missing corp scope', async () => {
+      vi.stubEnv('DINGTALK_AUTH_REQUIRE_GRANT', '1')
+      vi.stubEnv('DINGTALK_AUTH_AUTO_LINK_EMAIL', '1')
+      const txCalls: Array<{ sql: string; params: unknown[] }> = []
+      pgMocks.transaction.mockImplementation(async (callback: (client: { query: typeof pgMocks.query }) => Promise<unknown>) => {
+        const fallback = createDefaultTransactionQuery()
+        const txQuery = vi.fn(async (sql: string, params: unknown[]) => {
+          const statement = String(sql)
+          txCalls.push({ sql: statement, params })
+          if (
+            statement.includes('SELECT id,')
+            && statement.includes('FROM user_external_identities')
+          ) {
+            return {
+              rows: [{
+                id: 'identity-1',
+                external_key: 'ding-corp:union-1',
+                provider_union_id: 'union-1',
+                provider_open_id: null,
+                corp_id: null,
+              }],
+            }
+          }
+          return fallback(sql, params)
+        })
+        return callback({ query: txQuery as unknown as typeof pgMocks.query })
+      })
+      pgMocks.query
+        .mockResolvedValueOnce({ rows: [] })
+        .mockResolvedValueOnce({
+          rows: [{
+            id: 'user-1',
+            email: 'alpha@example.com',
+            name: 'Alpha',
+            role: 'user',
+            is_active: true,
+            activation_status: 'activated',
+          }],
+        })
+        .mockResolvedValueOnce({ rows: [{ enabled: true }] })
+
+      await exchangeEnterpriseAuthCodeForUser('auth-code-corp-fill')
+
+      expect(
+        txCalls.some((call) =>
+          call.sql.includes('UPDATE directory_deprovision_events')),
+      ).toBe(true)
+      expect(
+        txCalls.some((call) =>
+          /UPDATE users[\s\S]*access_generation/.test(call.sql)),
+      ).toBe(true)
     })
 
     it('proceeds on user/get failure when getuserinfo already carried unionid', async () => {

--- a/packages/core-backend/tests/unit/dingtalk-oauth-state-store.test.ts
+++ b/packages/core-backend/tests/unit/dingtalk-oauth-state-store.test.ts
@@ -433,14 +433,39 @@ describe('DingTalk OAuth state store', () => {
           name: 'Ding User',
           role: 'user',
           is_active: true,
+          activation_status: 'activated',
         }],
       } as any)
       .mockResolvedValueOnce({ rows: [] } as any)
 
     vi.mocked(transaction).mockImplementation(async (callback: (client: { query: typeof query }) => Promise<unknown>) => {
-      const clientQuery = vi.fn()
-        .mockResolvedValueOnce({ rows: [] })
-        .mockResolvedValueOnce({ rows: [] })
+      const clientQuery = vi.fn(async (sql: string, params: unknown[] = []) => {
+        const statement = String(sql)
+        if (/FROM users[\s\S]*FOR UPDATE/i.test(statement)) {
+          return {
+            rows: [{
+              id: String(params[0]),
+              name: 'Ding User',
+              email: 'dingtalk_open-id-1@placeholder.local',
+              username: null,
+              mobile: null,
+              activation_status: 'activated',
+              is_active: true,
+              access_generation: 0,
+            }],
+          }
+        }
+        if (/INSERT INTO user_external_auth_grants/i.test(statement)) {
+          return { rows: [{ local_user_id: String(params[1]) }] }
+        }
+        if (/INSERT INTO user_external_identities/i.test(statement)) {
+          return { rows: [{ id: 'identity-new' }] }
+        }
+        if (/UPDATE users[\s\S]*access_generation/i.test(statement)) {
+          return { rows: [{ access_generation: 1 }] }
+        }
+        return { rows: [] }
+      })
       return callback({ query: clientQuery as unknown as typeof query })
     })
 

--- a/packages/core-backend/tests/unit/directory-sync-admission-orphan-guard.test.ts
+++ b/packages/core-backend/tests/unit/directory-sync-admission-orphan-guard.test.ts
@@ -58,6 +58,7 @@ const CORP_ACCOUNT_WITHOUT_OPENID = {
   name: '张三',
   email: null,
   mobile: null,
+  is_active: true,
 }
 
 const baseOptions = {

--- a/packages/core-backend/tests/unit/directory-sync-pending-activation-default-off.test.ts
+++ b/packages/core-backend/tests/unit/directory-sync-pending-activation-default-off.test.ts
@@ -54,6 +54,7 @@ const ACCOUNT = {
   name: '李四',
   email: 'li@example.com',
   mobile: null as string | null,
+  is_active: true,
 }
 
 const baseOptions = {


### PR DESCRIPTION
## Scope

D5c only, stacked on #4651. Keeps all lifecycle flags OFF.

- locks every existing local user that automatic sync may touch before account/link/membership writes
- supersedes prior evidence only for actual account deactivation, link, membership, identity, grant, or self-unbind changes
- preserves an applied event when its source account reappears so rehire remains reachable and membership is not partially restored
- moves OAuth grant/identity/self-unbind writes under the canonical user mutex and makes failures honest

## Verification

- `pnpm --filter @metasheet/core-backend exec tsc --noEmit`
- related unit: 80/80
- `directory-access-graph-mutex.db.test.ts`: 10/10 real DB
- `directory-sync-orchestration.db.test.ts`: 15/15 real DB
- mutations: disabling sync supersede reds the departure test; removing rehire protection reds event/membership/generation assertions; removing corp-scope change detection reds the container-login test

## Posture

Draft, unarmed, no flag enablement, no merge authorization. D6 restore transaction hardening follows as a separate window.