### PR TITLE
fix(directory): make deprovision restore drift-atomic

### DIFF
--- a/packages/core-backend/src/directory/deprovision-evidence-api.ts
+++ b/packages/core-backend/src/directory/deprovision-evidence-api.ts
@@ -3,6 +3,7 @@
  */
 
 import { query, transaction } from '../db/pg'
+import { invalidateUserPerms } from '../rbac/service'
 import {
   planDirectoryDeprovision,
   type DirectoryDeprovisionPolicy,
@@ -169,40 +170,29 @@ export async function listDeprovisionEffects(eventId: string) {
   return result.rows
 }
 
-async function loadEventBundle(eventId: string) {
-  const ev = await query<{
-    id: string
-    local_user_id: string
-    access_generation_at_apply: number
-    status: string
-    directory_account_id: string
-  }>(
-    `SELECT id, local_user_id, access_generation_at_apply, status, directory_account_id
-       FROM directory_deprovision_events WHERE id = $1`,
-    [eventId],
-  )
-  if (!ev.rows[0]) {
-    const err = new Error('Deprovision event not found')
-    ;(err as Error & { code?: string }).code = 'EVENT_NOT_FOUND'
-    throw err
-  }
-  const effects = await listDeprovisionEffects(eventId)
-  return { event: ev.rows[0], effects }
+type RestoreEventRow = {
+  access_generation_at_apply: string | number
+  directory_account_id: string
+  id: string
+  integration_id: string
+  local_user_id: string
+  status: string
 }
 
-async function isDirectorySourceActive(directoryAccountId: string): Promise<boolean> {
-  const r = await query<{ account_active: boolean; integration_status: string }>(
-    `SELECT COALESCE(da.is_active, FALSE) AS account_active,
-            COALESCE(di.status, '') AS integration_status
-       FROM directory_accounts da
-       JOIN directory_integrations di ON di.id = da.integration_id
-      WHERE da.id::text = $1 OR da.id = $1::uuid
-      LIMIT 1`,
-    [directoryAccountId],
-  ).catch(() => ({ rows: [] as Array<{ account_active: boolean; integration_status: string }> }))
-  const row = r.rows[0]
-  if (!row) return false
-  return row.account_active === true && String(row.integration_status).toLowerCase() === 'active'
+type RestoreEffectRow = {
+  access_generation_at_apply: string | number
+  after_active: boolean
+  before_active: boolean
+  effect_type: string
+  id: string
+  org_id: string | null
+  status: string
+}
+
+function restoreError(code: string, message: string): Error {
+  const error = new Error(message)
+  ;(error as Error & { code?: string }).code = code
+  return error
 }
 
 /**
@@ -228,166 +218,360 @@ export async function restoreDeprovisionEvent(options: {
     }
   }
 
-  const { event, effects } = await loadEventBundle(options.eventId)
-  const applied = effects.filter((e: any) => e.status === 'applied') as Array<{
-    id: string
-    status: string
-    after_active: boolean
-    access_generation_at_apply: number
-    effect_type: string
-    org_id: string | null
-  }>
-
-  const user = await query<{ is_active: boolean; access_generation: number }>(
-    `SELECT COALESCE(is_active, TRUE) AS is_active,
-            COALESCE(access_generation, 0) AS access_generation
-       FROM users WHERE id = $1`,
-    [event.local_user_id],
-  )
-  if (!user.rows[0]) {
-    const err = new Error('User not found')
-    ;(err as Error & { code?: string }).code = 'USER_NOT_FOUND'
-    throw err
-  }
-
-  const sourceActive = await isDirectorySourceActive(event.directory_account_id)
-
-  const effectViews: RestoreEffectView[] = applied.map((e) => ({
-    id: e.id,
-    status: e.status,
-    afterActive: e.after_active,
-    accessGenerationAtApply: Number(e.access_generation_at_apply),
-    effectType: e.effect_type,
-  }))
-
-  const currentMatchesAfter: Record<string, boolean> = {}
-  for (const e of applied) {
-    if (e.effect_type === 'user_changed') {
-      // after_active false means user should still be inactive for restore eligibility
-      currentMatchesAfter[e.id] = user.rows[0].is_active === false
-    } else if (e.effect_type === 'membership_changed') {
-      // DRIFT GATE — must fail closed. Swallowing this read turned a failed query into
-      // "0 active memberships", which reads as "current state matches after_active=false":
-      // the gate was satisfied BY ITS OWN FAILURE and could never fire on this leg. Same
-      // defect class as the phantom grant column fixed in #4587; a gate read that cannot
-      // complete must abort the restore, not wave it through.
-      const org = await query<{ n: number }>(
-        `SELECT count(*)::int AS n FROM user_orgs
-          WHERE user_id = $1 AND org_id = $2 AND COALESCE(is_active, TRUE) = TRUE`,
-        [event.local_user_id, e.org_id],
-      )
-      // after false → no active membership
-      currentMatchesAfter[e.id] = (org.rows[0]?.n ?? 0) === 0
-    } else if (e.effect_type === 'grant_changed') {
-      // This is a DRIFT GATE, so it must fail closed. Reading the phantom column and catching the
-      // error yielded "no grant", which reads as "current state matches after_active=false" — the
-      // gate was satisfied *by the read failing*, so it could never fire, and a grant that was
-      // genuinely still enabled sailed straight through as if there were no drift.
-      const g = await query<{ enabled: boolean }>(
-        `SELECT enabled
-           FROM user_external_auth_grants
-          WHERE local_user_id = $1 AND provider = 'dingtalk' LIMIT 1`,
-        [event.local_user_id],
-      )
-      currentMatchesAfter[e.id] = g.rows[0]?.enabled !== true
-    } else {
-      const err = new Error(`Unsupported deprovision effect type: ${e.effect_type}`)
-      ;(err as Error & { code?: string }).code = 'EFFECT_TYPE_UNSUPPORTED'
-      throw err
+  const restored = await transaction(async (client) => {
+    // Event identity is DB-immutable. Read only the owner first so the canonical
+    // users-row mutex remains the first blocking lock shared with every other
+    // access-graph writer.
+    const ownerResult = await client.query(
+      `SELECT local_user_id
+         FROM directory_deprovision_events
+        WHERE id = $1::uuid`,
+      [options.eventId],
+    )
+    const eventOwner = String(ownerResult.rows[0]?.local_user_id ?? '')
+    if (!eventOwner) {
+      throw restoreError('EVENT_NOT_FOUND', 'Deprovision event not found')
     }
-  }
 
-  const eligibility = evaluateDeprovisionRestoreEligibility({
-    mode: options.mode,
-    directorySourceActive: sourceActive,
-    currentUserAccessGeneration: Number(user.rows[0].access_generation),
-    eventAccessGeneration: Number(event.access_generation_at_apply),
-    effects: effectViews,
-    currentMatchesAfter,
-  })
+    const userResult = await client.query(
+      `SELECT id,
+              email,
+              username,
+              mobile,
+              activation_status,
+              COALESCE(is_active, TRUE) AS is_active,
+              COALESCE(access_generation, 0) AS access_generation
+         FROM users
+        WHERE id = $1::text
+        FOR UPDATE`,
+      [eventOwner],
+    )
+    const user = userResult.rows[0] as
+      | {
+          access_generation: string | number
+          activation_status: string | null
+          email: string | null
+          id: string
+          is_active: boolean
+          mobile: string | null
+          username: string | null
+        }
+      | undefined
+    if (!user) throw restoreError('USER_NOT_FOUND', 'User not found')
 
-  if (eligibility.ok === false) {
-    const err = new Error(eligibility.message)
-    ;(err as Error & { code?: string }).code =
-      eligibility.code === 'DRIFT' ? 'DRIFT_CONFLICT' : eligibility.code
-    throw err
-  }
+    const eventResult = await client.query(
+      `SELECT id::text AS id,
+              integration_id::text AS integration_id,
+              directory_account_id::text AS directory_account_id,
+              local_user_id,
+              access_generation_at_apply,
+              status
+         FROM directory_deprovision_events
+        WHERE id = $1::uuid
+        FOR UPDATE`,
+      [options.eventId],
+    )
+    const event = eventResult.rows[0] as RestoreEventRow | undefined
+    if (!event) {
+      throw restoreError('EVENT_NOT_FOUND', 'Deprovision event not found')
+    }
+    if (event.local_user_id !== eventOwner) {
+      throw restoreError(
+        'DRIFT_CONFLICT',
+        'Deprovision event owner changed while acquiring the user mutex',
+      )
+    }
+    if (event.status !== 'applied') {
+      throw restoreError(
+        'EVENT_NOT_APPLIED',
+        'Deprovision event is no longer applied',
+      )
+    }
 
-  await transaction(async (client) => {
-    await client.query(`SELECT id FROM users WHERE id = $1 FOR UPDATE`, [event.local_user_id])
+    const effectsResult = await client.query(
+      `SELECT id::text AS id,
+              effect_type,
+              org_id,
+              before_active,
+              after_active,
+              access_generation_at_apply,
+              status
+         FROM directory_deprovision_effects
+        WHERE event_id = $1::uuid
+        ORDER BY id
+        FOR UPDATE`,
+      [options.eventId],
+    )
+    const effects = effectsResult.rows as RestoreEffectRow[]
+    const applied = effects.filter((effect) => effect.status === 'applied')
+    if (effects.some((effect) => effect.status !== 'applied')) {
+      throw restoreError(
+        'EVENT_NOT_APPLIED',
+        'Deprovision event has effects that are no longer applied',
+      )
+    }
 
-    for (const e of applied) {
-      if (e.effect_type === 'user_changed') {
-        await client.query(
-          `UPDATE users SET is_active = TRUE, updated_at = NOW() WHERE id = $1`,
+    let sourceActive = false
+    if (options.mode === 'rehire') {
+      const sourceResult = await client.query(
+        `SELECT account.is_active AS account_active,
+                integration.status AS integration_status,
+                link.link_status = 'linked' AS link_matches
+           FROM directory_accounts account
+           JOIN directory_integrations integration
+             ON integration.id = account.integration_id
+           JOIN directory_account_links link
+             ON link.directory_account_id = account.id
+            AND link.local_user_id = $3::text
+          WHERE account.id = $1::uuid
+            AND integration.id = $2::uuid
+          FOR SHARE OF account, integration, link`,
+        [
+          event.directory_account_id,
+          event.integration_id,
+          event.local_user_id,
+        ],
+      )
+      const source = sourceResult.rows[0] as
+        | {
+            account_active: boolean
+            integration_status: string
+            link_matches: boolean
+          }
+        | undefined
+      sourceActive =
+        source?.account_active === true
+        && String(source.integration_status).toLowerCase() === 'active'
+        && source.link_matches === true
+    }
+
+    const currentMatchesAfter: Record<string, boolean> = {}
+    for (const effect of applied) {
+      if (effect.effect_type === 'user_changed') {
+        currentMatchesAfter[effect.id] =
+          user.is_active === effect.after_active
+      } else if (effect.effect_type === 'membership_changed') {
+        if (!effect.org_id) {
+          throw restoreError(
+            'EFFECT_TYPE_UNSUPPORTED',
+            'membership_changed effect is missing org_id',
+          )
+        }
+        const membership = await client.query(
+          `SELECT COALESCE(is_active, TRUE) AS is_active
+             FROM user_orgs
+            WHERE user_id = $1::text AND org_id = $2::text`,
+          [event.local_user_id, effect.org_id],
+        )
+        currentMatchesAfter[effect.id] =
+          (membership.rows[0]?.is_active === true) === effect.after_active
+      } else if (effect.effect_type === 'grant_changed') {
+        const grant = await client.query(
+          `SELECT enabled
+             FROM user_external_auth_grants
+            WHERE local_user_id = $1::text
+              AND provider = 'dingtalk'
+            LIMIT 1`,
           [event.local_user_id],
         )
-      } else if (e.effect_type === 'membership_changed' && e.org_id) {
-        // `user_orgs` is (user_id, org_id, is_active, created_at) — there is no `updated_at`.
-        // Setting one raised `42703`, which the `.catch` hid; the aborted transaction then failed
-        // the very next statement with `25P02`, so restoring ANY event carrying a membership
-        // effect — which is every real deprovision event — rolled back entirely. The sibling
-        // writer in `directory-sync.ts` gets this right; only this path invented the column.
-        // Same reasoning as the grant leg: a restore that cannot give membership back must fail
-        // loudly, not report a success the admin will act on.
-        const mem = await client.query(
-          `UPDATE user_orgs SET is_active = TRUE
-            WHERE user_id = $1 AND org_id = $2
-            RETURNING user_id`,
-          [event.local_user_id, e.org_id],
-        )
-        if (!mem.rows[0]) {
-          const err = new Error(
-            `membership row missing for org ${e.org_id}; cannot reverse membership_changed`,
-          )
-          ;(err as Error & { code?: string }).code = 'DRIFT_CONFLICT'
-          throw err
-        }
-      } else if (e.effect_type === 'grant_changed') {
-        // Upsert, not UPDATE: deprovision may have created the disabled row itself, and a restore
-        // that silently matched zero rows would report success while the person stayed locked
-        // out. The `.catch` is gone for the same reason it was wrong on the read — it could not
-        // make the failure harmless, only turn it into `25P02` on the next statement, which is
-        // what made every event carrying a grant effect unrestorable.
-        await client.query(
-          `INSERT INTO user_external_auth_grants (provider, local_user_id, enabled, granted_by, created_at, updated_at)
-           VALUES ('dingtalk', $1, TRUE, $2, NOW(), NOW())
-           ON CONFLICT (provider, local_user_id)
-           DO UPDATE SET enabled = TRUE,
-                         granted_by = EXCLUDED.granted_by,
-                         updated_at = NOW()`,
-          [event.local_user_id, `restore:${options.adminUserId}`],
+        currentMatchesAfter[effect.id] =
+          (grant.rows[0]?.enabled === true) === effect.after_active
+      } else {
+        throw restoreError(
+          'EFFECT_TYPE_UNSUPPORTED',
+          `Unsupported deprovision effect type: ${effect.effect_type}`,
         )
       }
-      await client.query(
-        `UPDATE directory_deprovision_effects
-            SET status = 'reversed', reversed_at = NOW(), updated_at = NOW()
-          WHERE id = $1`,
-        [e.id],
+    }
+
+    const effectViews: RestoreEffectView[] = effects.map((effect) => ({
+      id: effect.id,
+      status: effect.status,
+      afterActive: effect.after_active,
+      accessGenerationAtApply: Number(effect.access_generation_at_apply),
+      effectType: effect.effect_type,
+    }))
+    const eventGeneration = Number(event.access_generation_at_apply)
+    const eligibility = evaluateDeprovisionRestoreEligibility({
+      mode: options.mode,
+      directorySourceActive: sourceActive,
+      currentUserAccessGeneration: Number(user.access_generation),
+      eventAccessGeneration: eventGeneration,
+      effects: effectViews,
+      currentMatchesAfter,
+    })
+    if (eligibility.ok === false) {
+      throw restoreError(
+        eligibility.code === 'DRIFT'
+          ? 'DRIFT_CONFLICT'
+          : eligibility.code,
+        eligibility.message,
       )
     }
 
-    await client.query(
+    for (const effect of applied) {
+      if (effect.effect_type === 'user_changed') {
+        const changed = await client.query(
+          `UPDATE users
+              SET is_active = $2::boolean, updated_at = NOW()
+            WHERE id = $1::text
+              AND COALESCE(is_active, TRUE) IS NOT DISTINCT FROM $3::boolean
+            RETURNING id`,
+          [event.local_user_id, effect.before_active, effect.after_active],
+        )
+        if (!changed.rows[0]) {
+          throw restoreError(
+            'DRIFT_CONFLICT',
+            'User active state changed before restore',
+          )
+        }
+      } else if (effect.effect_type === 'membership_changed') {
+        const changed = await client.query(
+          `UPDATE user_orgs
+              SET is_active = $3::boolean
+            WHERE user_id = $1::text
+              AND org_id = $2::text
+              AND COALESCE(is_active, TRUE) IS NOT DISTINCT FROM $4::boolean
+            RETURNING user_id`,
+          [
+            event.local_user_id,
+            effect.org_id,
+            effect.before_active,
+            effect.after_active,
+          ],
+        )
+        if (!changed.rows[0]) {
+          throw restoreError(
+            'DRIFT_CONFLICT',
+            `membership row missing or changed for org ${effect.org_id}`,
+          )
+        }
+      } else if (effect.effect_type === 'grant_changed') {
+        const changed = await client.query(
+          `INSERT INTO user_external_auth_grants (
+             provider, local_user_id, enabled, granted_by, created_at, updated_at
+           ) VALUES ('dingtalk', $1::text, $2::boolean, $3::text, NOW(), NOW())
+           ON CONFLICT (provider, local_user_id)
+           DO UPDATE SET enabled = EXCLUDED.enabled,
+                         granted_by = EXCLUDED.granted_by,
+                         updated_at = NOW()
+                 WHERE user_external_auth_grants.enabled
+                       IS NOT DISTINCT FROM $4::boolean
+           RETURNING local_user_id`,
+          [
+            event.local_user_id,
+            effect.before_active,
+            `restore:${options.adminUserId}`,
+            effect.after_active,
+          ],
+        )
+        if (!changed.rows[0]) {
+          throw restoreError(
+            'DRIFT_CONFLICT',
+            'DingTalk grant state changed before restore',
+          )
+        }
+      }
+
+      const reversed = await client.query(
+        `UPDATE directory_deprovision_effects
+            SET status = 'reversed',
+                reversed_at = NOW(),
+                reversed_by = $3::text,
+                updated_at = NOW()
+          WHERE id = $1::uuid
+            AND event_id = $2::uuid
+            AND status = 'applied'
+            AND access_generation_at_apply = $4::bigint
+          RETURNING id`,
+        [
+          effect.id,
+          options.eventId,
+          options.adminUserId,
+          eventGeneration,
+        ],
+      )
+      if (!reversed.rows[0]) {
+        throw restoreError(
+          'DRIFT_CONFLICT',
+          `effect ${effect.id} changed before restore`,
+        )
+      }
+    }
+
+    const generation = await client.query(
       `UPDATE users
           SET access_generation = COALESCE(access_generation, 0) + 1,
               updated_at = NOW()
-        WHERE id = $1`,
-      [event.local_user_id],
+        WHERE id = $1::text
+          AND COALESCE(access_generation, 0) = $2::bigint
+        RETURNING access_generation`,
+      [event.local_user_id, eventGeneration],
     )
+    if (!generation.rows[0]) {
+      throw restoreError(
+        'DRIFT_CONFLICT',
+        'access_generation changed before restore completion',
+      )
+    }
 
-    await client.query(
+    const resolved = await client.query(
       `UPDATE directory_deprovision_events
-          SET status = 'fully_resolved', updated_at = NOW()
-        WHERE id = $1`,
-      [options.eventId],
+          SET status = 'fully_resolved',
+              resolved_at = NOW(),
+              resolved_by = $2::text,
+              resolve_note = $3::text,
+              restore_mode = $4::text,
+              updated_at = NOW()
+        WHERE id = $1::uuid
+          AND status = 'applied'
+          AND access_generation_at_apply = $5::bigint
+        RETURNING id`,
+      [
+        options.eventId,
+        options.adminUserId,
+        options.mode === 'admin_force'
+          ? options.note!.trim()
+          : 'rehire restore after the directory source became active',
+        options.mode,
+        eventGeneration,
+      ],
     )
+    if (!resolved.rows[0]) {
+      throw restoreError(
+        'DRIFT_CONFLICT',
+        'Deprovision event changed before restore completion',
+      )
+    }
+
+    return {
+      event,
+      effectsReversed: applied.map((effect) => effect.effect_type),
+      localUser: {
+        id: user.id,
+        email: user.email,
+        username: user.username,
+        mobile: user.mobile,
+        isActive:
+          applied.find((effect) => effect.effect_type === 'user_changed')
+            ?.before_active ?? user.is_active,
+        activationStatus: user.activation_status,
+      },
+      restoredEffectCount: applied.length,
+    }
   })
+  invalidateUserPerms(restored.event.local_user_id)
 
   return {
     eventId: options.eventId,
-    mode: options.mode,
-    restoredEffectCount: applied.length,
-    localUserId: event.local_user_id,
+    restoreMode: options.mode,
+    restoredEffectCount: restored.restoredEffectCount,
+    localUserId: restored.event.local_user_id,
+    localUser: restored.localUser,
+    effectsReversed: restored.effectsReversed,
+    passwordUnchanged: true,
+    passwordResetHint:
+      'Use the existing administrator password-reset flow when local credentials need to change.',
     note: options.note ?? null,
     adminUserId: options.adminUserId,
   }

--- a/packages/core-backend/src/routes/admin-directory.ts
+++ b/packages/core-backend/src/routes/admin-directory.ts
@@ -1338,7 +1338,11 @@ export function adminDirectoryRouter(): Router {
       const code = (error as { code?: string })?.code || 'DEPROVISION_RESTORE_FAILED'
       const status =
         code === 'EVENT_NOT_FOUND' || code === 'USER_NOT_FOUND' ? 404
-          : code === 'DRIFT_CONFLICT' || code === 'SOURCE_INACTIVE' || code === 'NO_EFFECTS' || code === 'NOT_APPLIED'
+          : code === 'DRIFT_CONFLICT'
+              || code === 'SOURCE_INACTIVE'
+              || code === 'NO_EFFECTS'
+              || code === 'NOT_APPLIED'
+              || code === 'EVENT_NOT_APPLIED'
             ? 409
             : code === 'FORCE_CONFIRM_REQUIRED' || code === 'FORCE_NOTE_REQUIRED' ? 400
               : 500

--- a/packages/core-backend/tests/integration/directory-deprovision-grant-table.db.test.ts
+++ b/packages/core-backend/tests/integration/directory-deprovision-grant-table.db.test.ts
@@ -1,6 +1,8 @@
 import { afterAll, beforeEach, describe, expect, it } from 'vitest'
+import { Client } from 'pg'
 import { query } from '../../src/db/pg'
 import { activatePendingUser } from '../../src/auth/user-activate'
+import { supersedeDeprovisionEvidenceForAccessGraphWrite } from '../../src/directory/access-graph-mutex'
 import { restoreDeprovisionEvent } from '../../src/directory/deprovision-evidence-api'
 
 /**
@@ -109,6 +111,96 @@ const grantRow = async (): Promise<{ enabled: boolean; granted_by: string | null
 
 const grantEnabled = async (): Promise<boolean | undefined> => (await grantRow())?.enabled
 
+async function waitForRestoreWaiters(
+  holderPid: number,
+  expected: number,
+  timeoutMs = 8_000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    const waiting = await query<{ blocked: number; rooted: number }>(
+      `SELECT
+         count(*) FILTER (
+           WHERE wait_event_type = 'Lock'
+             AND query ILIKE '%activation_status%'
+             AND query ILIKE '%FROM users%'
+             AND query ILIKE '%FOR UPDATE%'
+         )::int AS blocked,
+         count(*) FILTER (
+           WHERE $1 = ANY(pg_blocking_pids(pid))
+             AND query ILIKE '%activation_status%'
+             AND query ILIKE '%FROM users%'
+             AND query ILIKE '%FOR UPDATE%'
+         )::int AS rooted
+       FROM pg_stat_activity
+       WHERE datname = current_database()
+         AND state = 'active'
+         AND pid <> pg_backend_pid()`,
+      [holderPid],
+    )
+    if (
+      (waiting.rows[0]?.blocked ?? 0) >= expected
+      && (waiting.rows[0]?.rooted ?? 0) >= 1
+    ) {
+      return
+    }
+    await new Promise((resolve) => setTimeout(resolve, 20))
+  }
+  throw new Error(
+    `timed out waiting for ${expected} restore transaction(s) queued behind holder ${holderPid}`,
+  )
+}
+
+async function waitForQueryBlockedOnHolder(
+  holderPid: number,
+  queryPattern: string,
+  timeoutMs = 8_000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    const waiting = await query<{ n: number }>(
+      `SELECT count(*)::int AS n
+         FROM pg_stat_activity
+        WHERE datname = current_database()
+          AND state = 'active'
+          AND wait_event_type = 'Lock'
+          AND $1 = ANY(pg_blocking_pids(pid))
+          AND query ILIKE $2`,
+      [holderPid, queryPattern],
+    )
+    if ((waiting.rows[0]?.n ?? 0) >= 1) return
+    await new Promise((resolve) => setTimeout(resolve, 20))
+  }
+  throw new Error(
+    `timed out waiting for query ${queryPattern} blocked by holder ${holderPid}`,
+  )
+}
+
+async function withLockedUser<T>(
+  callback: (holder: Client, holderPid: number) => Promise<T>,
+): Promise<T> {
+  const holder = new Client({ connectionString: process.env.DATABASE_URL })
+  await holder.connect()
+  try {
+    await holder.query('BEGIN')
+    const pid = await holder.query<{ pid: number }>(
+      'SELECT pg_backend_pid() AS pid',
+    )
+    await holder.query(
+      `SELECT id FROM users WHERE id = $1 FOR UPDATE`,
+      [USER],
+    )
+    return await callback(holder, pid.rows[0].pid)
+  } finally {
+    try {
+      await holder.query('ROLLBACK')
+    } catch {
+      // The callback may already have committed the holder.
+    }
+    await holder.end()
+  }
+}
+
 describeIfDatabase('DingTalk grant/membership writes target the real tables (real DB)', () => {
   beforeEach(cleanup)
   afterAll(cleanup)
@@ -157,6 +249,16 @@ describeIfDatabase('DingTalk grant/membership writes target the real tables (rea
       eventId, mode: 'rehire', adminUserId: 'admin-test',
     })
     expect(result.restoredEffectCount).toBe(1)
+    expect(result).toMatchObject({
+      restoreMode: 'rehire',
+      effectsReversed: ['membership_changed'],
+      passwordUnchanged: true,
+      localUser: {
+        id: USER,
+        isActive: true,
+        activationStatus: 'activated',
+      },
+    })
 
     // Before the fix this whole call aborted with 25P02 (`user_orgs.updated_at` does not exist),
     // so the membership stayed FALSE — for EVERY real deprovision event, since every candidate
@@ -234,6 +336,327 @@ describeIfDatabase('DingTalk grant/membership writes target the real tables (rea
     const effects = await query<{ status: string }>(
       `SELECT status FROM directory_deprovision_effects WHERE local_user_id = $1`, [USER])
     expect(effects.rows.map((r) => r.status)).toEqual(['applied'])
+  })
+
+  it('a grant writer racing after eligibility is preserved by the write-point drift guard', async () => {
+    await query(
+      `INSERT INTO users (id, email, name, password_hash, is_active, activation_status, access_generation)
+       VALUES ($1, 'grant-fix@example.com', 'Grant Fix', 'x', TRUE, 'activated', 3)`,
+      [USER],
+    )
+    await query(
+      `INSERT INTO user_external_auth_grants (provider, local_user_id, enabled, granted_by)
+       VALUES ('dingtalk', $1, FALSE, 'system:directory-deprovision')`,
+      [USER],
+    )
+    const seeded = await seedDirectory({ sourceActive: true })
+    const eventId = await seedEvent(
+      seeded,
+      [{ type: 'grant_changed', orgId: null }],
+      3,
+    )
+    const holder = new Client({ connectionString: process.env.DATABASE_URL })
+    await holder.connect()
+    try {
+      await holder.query('BEGIN')
+      const pid = await holder.query<{ pid: number }>(
+        'SELECT pg_backend_pid() AS pid',
+      )
+      await holder.query(
+        `UPDATE user_external_auth_grants
+            SET enabled = TRUE, granted_by = 'concurrent-writer'
+          WHERE provider = 'dingtalk' AND local_user_id = $1`,
+        [USER],
+      )
+
+      const restore = restoreDeprovisionEvent({
+        eventId,
+        mode: 'rehire',
+        adminUserId: 'admin-test',
+      })
+      await waitForQueryBlockedOnHolder(
+        pid.rows[0].pid,
+        '%INSERT INTO user_external_auth_grants%',
+      )
+      await holder.query('COMMIT')
+
+      await expect(restore).rejects.toMatchObject({ code: 'DRIFT_CONFLICT' })
+    } finally {
+      try {
+        await holder.query('ROLLBACK')
+      } catch {
+        // The holder may already be committed.
+      }
+      await holder.end()
+    }
+
+    expect(await grantRow()).toMatchObject({
+      enabled: true,
+      granted_by: 'concurrent-writer',
+    })
+    const state = await query<{
+      access_generation: string
+      effect_status: string
+      event_status: string
+    }>(
+      `SELECT users.access_generation::text,
+              event.status AS event_status,
+              effect.status AS effect_status
+         FROM users
+         JOIN directory_deprovision_events event
+           ON event.local_user_id = users.id
+         JOIN directory_deprovision_effects effect
+           ON effect.event_id = event.id
+        WHERE users.id = $1`,
+      [USER],
+    )
+    expect(state.rows[0]).toMatchObject({
+      access_generation: '3',
+      event_status: 'applied',
+      effect_status: 'applied',
+    })
+  })
+
+  it('rehire requires the exact source account to remain actively linked to the same user', async () => {
+    await query(
+      `INSERT INTO users (id, email, name, password_hash, is_active, activation_status, access_generation)
+       VALUES ($1, 'grant-fix@example.com', 'Grant Fix', 'x', TRUE, 'activated', 3)`,
+      [USER],
+    )
+    await query(
+      `INSERT INTO user_orgs (user_id, org_id, is_active)
+       VALUES ($1, $2, FALSE)`,
+      [USER, ORG],
+    )
+    const seeded = await seedDirectory({ sourceActive: true })
+    const eventId = await seedEvent(
+      seeded,
+      [{ type: 'membership_changed', orgId: ORG }],
+      3,
+    )
+    await query(
+      `UPDATE directory_account_links
+          SET link_status = 'unlinked'
+        WHERE directory_account_id = $1::uuid
+          AND local_user_id = $2`,
+      [seeded.accountId, USER],
+    )
+
+    await expect(
+      restoreDeprovisionEvent({
+        eventId,
+        mode: 'rehire',
+        adminUserId: 'admin-test',
+      }),
+    ).rejects.toMatchObject({ code: 'SOURCE_INACTIVE' })
+
+    const membership = await query<{ is_active: boolean }>(
+      `SELECT is_active FROM user_orgs WHERE user_id = $1 AND org_id = $2`,
+      [USER, ORG],
+    )
+    expect(membership.rows[0]?.is_active).toBe(false)
+    const event = await query<{ status: string }>(
+      `SELECT status FROM directory_deprovision_events WHERE id = $1::uuid`,
+      [eventId],
+    )
+    expect(event.rows[0]?.status).toBe('applied')
+  })
+
+  it('admin force may restore an inactive source only with explicit confirmation and provenance', async () => {
+    await query(
+      `INSERT INTO users (id, email, name, password_hash, is_active, activation_status, access_generation)
+       VALUES ($1, 'grant-fix@example.com', 'Grant Fix', 'x', TRUE, 'activated', 3)`,
+      [USER],
+    )
+    await query(
+      `INSERT INTO user_orgs (user_id, org_id, is_active)
+       VALUES ($1, $2, FALSE)`,
+      [USER, ORG],
+    )
+    const seeded = await seedDirectory({ sourceActive: false })
+    const eventId = await seedEvent(
+      seeded,
+      [{ type: 'membership_changed', orgId: ORG }],
+      3,
+    )
+
+    await expect(
+      restoreDeprovisionEvent({
+        eventId,
+        mode: 'admin_force',
+        adminUserId: 'admin-test',
+        confirm: false,
+        note: 'confirmed source remains inactive',
+      }),
+    ).rejects.toMatchObject({ code: 'FORCE_CONFIRM_REQUIRED' })
+
+    const result = await restoreDeprovisionEvent({
+      eventId,
+      mode: 'admin_force',
+      adminUserId: 'admin-test',
+      confirm: true,
+      note: 'confirmed source remains inactive',
+    })
+    expect(result.restoreMode).toBe('admin_force')
+
+    const event = await query<{
+      resolve_note: string
+      resolved_by: string
+      restore_mode: string
+      status: string
+    }>(
+      `SELECT status, resolved_by, resolve_note, restore_mode
+         FROM directory_deprovision_events
+        WHERE id = $1::uuid`,
+      [eventId],
+    )
+    expect(event.rows[0]).toMatchObject({
+      status: 'fully_resolved',
+      resolved_by: 'admin-test',
+      resolve_note: 'confirmed source remains inactive',
+      restore_mode: 'admin_force',
+    })
+  })
+
+  it('a concurrent access-graph writer supersedes evidence before a blocked restore can act', async () => {
+    await query(
+      `INSERT INTO users (id, email, name, password_hash, is_active, activation_status, access_generation)
+       VALUES ($1, 'grant-fix@example.com', 'Grant Fix', 'x', TRUE, 'activated', 3)`,
+      [USER],
+    )
+    await query(
+      `INSERT INTO user_orgs (user_id, org_id, is_active)
+       VALUES ($1, $2, FALSE)`,
+      [USER, ORG],
+    )
+    const seeded = await seedDirectory({ sourceActive: true })
+    const eventId = await seedEvent(
+      seeded,
+      [{ type: 'membership_changed', orgId: ORG }],
+      3,
+    )
+
+    await withLockedUser(async (holder, holderPid) => {
+      const restore = restoreDeprovisionEvent({
+        eventId,
+        mode: 'rehire',
+        adminUserId: 'admin-test',
+      })
+      await waitForRestoreWaiters(holderPid, 1)
+
+      await supersedeDeprovisionEvidenceForAccessGraphWrite(holder, {
+        userIds: [USER],
+        actorId: 'concurrent-admin',
+        reason: 'concurrent admin access update',
+      })
+      await holder.query('COMMIT')
+
+      await expect(restore).rejects.toMatchObject({
+        code: 'EVENT_NOT_APPLIED',
+      })
+    })
+
+    const state = await query<{
+      access_generation: string
+      event_status: string
+      effect_status: string
+      membership_active: boolean
+    }>(
+      `SELECT u.access_generation::text,
+              event.status AS event_status,
+              effect.status AS effect_status,
+              membership.is_active AS membership_active
+         FROM users u
+         JOIN directory_deprovision_events event
+           ON event.local_user_id = u.id
+         JOIN directory_deprovision_effects effect
+           ON effect.event_id = event.id
+         JOIN user_orgs membership
+           ON membership.user_id = u.id
+          AND membership.org_id = $2
+        WHERE u.id = $1`,
+      [USER, ORG],
+    )
+    expect(state.rows[0]).toMatchObject({
+      access_generation: '4',
+      event_status: 'superseded',
+      effect_status: 'superseded',
+      membership_active: false,
+    })
+  })
+
+  it('two blocked restores linearize to exactly one reversal with complete resolution provenance', async () => {
+    await query(
+      `INSERT INTO users (id, email, name, password_hash, is_active, activation_status, access_generation)
+       VALUES ($1, 'grant-fix@example.com', 'Grant Fix', 'x', TRUE, 'activated', 3)`,
+      [USER],
+    )
+    await query(
+      `INSERT INTO user_orgs (user_id, org_id, is_active)
+       VALUES ($1, $2, FALSE)`,
+      [USER, ORG],
+    )
+    const seeded = await seedDirectory({ sourceActive: true })
+    const eventId = await seedEvent(
+      seeded,
+      [{ type: 'membership_changed', orgId: ORG }],
+      3,
+    )
+
+    const outcomes = await withLockedUser(async (holder, holderPid) => {
+      const calls = Array.from({ length: 2 }, () =>
+        restoreDeprovisionEvent({
+          eventId,
+          mode: 'rehire',
+          adminUserId: 'admin-test',
+        }),
+      )
+      await waitForRestoreWaiters(holderPid, 2)
+      await holder.query('COMMIT')
+      return Promise.allSettled(calls)
+    })
+
+    const successes = outcomes.filter(
+      (outcome) => outcome.status === 'fulfilled',
+    )
+    const failures = outcomes.filter(
+      (outcome): outcome is PromiseRejectedResult =>
+        outcome.status === 'rejected',
+    )
+    expect(successes).toHaveLength(1)
+    expect(failures).toHaveLength(1)
+    expect(failures[0].reason).toMatchObject({ code: 'EVENT_NOT_APPLIED' })
+
+    const state = await query<{
+      access_generation: string
+      effect_status: string
+      event_status: string
+      resolved_by: string
+      restore_mode: string
+      reversed_by: string
+    }>(
+      `SELECT users.access_generation::text,
+              event.status AS event_status,
+              event.resolved_by,
+              event.restore_mode,
+              effect.status AS effect_status,
+              effect.reversed_by
+         FROM users
+         JOIN directory_deprovision_events event
+           ON event.local_user_id = users.id
+         JOIN directory_deprovision_effects effect
+           ON effect.event_id = event.id
+        WHERE users.id = $1`,
+      [USER],
+    )
+    expect(state.rows[0]).toMatchObject({
+      access_generation: '4',
+      event_status: 'fully_resolved',
+      resolved_by: 'admin-test',
+      restore_mode: 'rehire',
+      effect_status: 'reversed',
+      reversed_by: 'admin-test',
+    })
   })
 
   it('alias conflict rolls back users/membership/grant (real Postgres transaction)', async () => {

--- a/packages/core-backend/tests/unit/admin-directory-routes.test.ts
+++ b/packages/core-backend/tests/unit/admin-directory-routes.test.ts
@@ -51,6 +51,14 @@ const workNotificationMocks = vi.hoisted(() => ({
   testDingTalkWorkNotificationAgentId: vi.fn(),
 }))
 
+const deprovisionMocks = vi.hoisted(() => ({
+  listDeprovisionEffects: vi.fn(),
+  listDeprovisionEvents: vi.fn(),
+  previewDeprovisionForUser: vi.fn(),
+  readDeprovisionRuntimeFlags: vi.fn(),
+  restoreDeprovisionEvent: vi.fn(),
+}))
+
 vi.mock('../../src/rbac/service', () => ({
   isAdmin: rbacMocks.isRbacAdmin,
 }))
@@ -128,6 +136,14 @@ vi.mock('../../src/integrations/dingtalk/approval-card-config', () => ({
   generateApprovalCardLinkSecret: approvalCardConfigMocks.generateApprovalCardLinkSecret,
   getApprovalCardConfigStatus: approvalCardConfigMocks.getApprovalCardConfigStatus,
   saveApprovalCardPublicAppUrl: approvalCardConfigMocks.saveApprovalCardPublicAppUrl,
+}))
+
+vi.mock('../../src/directory/deprovision-evidence-api', () => ({
+  listDeprovisionEffects: deprovisionMocks.listDeprovisionEffects,
+  listDeprovisionEvents: deprovisionMocks.listDeprovisionEvents,
+  previewDeprovisionForUser: deprovisionMocks.previewDeprovisionForUser,
+  readDeprovisionRuntimeFlags: deprovisionMocks.readDeprovisionRuntimeFlags,
+  restoreDeprovisionEvent: deprovisionMocks.restoreDeprovisionEvent,
 }))
 
 import { adminDirectoryRouter } from '../../src/routes/admin-directory'
@@ -233,6 +249,39 @@ describe('adminDirectoryRouter', () => {
     approvalCardConfigMocks.generateApprovalCardLinkSecret.mockReset()
     approvalCardConfigMocks.getApprovalCardConfigStatus.mockReset()
     approvalCardConfigMocks.saveApprovalCardPublicAppUrl.mockReset()
+    deprovisionMocks.listDeprovisionEffects.mockReset()
+    deprovisionMocks.listDeprovisionEvents.mockReset()
+    deprovisionMocks.previewDeprovisionForUser.mockReset()
+    deprovisionMocks.readDeprovisionRuntimeFlags.mockReset()
+    deprovisionMocks.restoreDeprovisionEvent.mockReset()
+  })
+
+  it('maps a superseded or already-restored deprovision event to 409 without auditing success', async () => {
+    deprovisionMocks.restoreDeprovisionEvent.mockRejectedValue(
+      Object.assign(new Error('Deprovision event is no longer applied'), {
+        code: 'EVENT_NOT_APPLIED',
+      }),
+    )
+
+    const response = await invokeRoute(
+      'post',
+      '/deprovision/events/:eventId/restore',
+      {
+        params: { eventId: 'event-1' },
+        body: { mode: 'rehire' },
+        user: { id: 'admin-1', role: 'admin' },
+      },
+    )
+
+    expect(response.statusCode).toBe(409)
+    expect(response.body).toMatchObject({
+      ok: false,
+      error: {
+        code: 'EVENT_NOT_APPLIED',
+        message: 'Deprovision event is no longer applied',
+      },
+    })
+    expect(auditMocks.auditLog).not.toHaveBeenCalled()
   })
 
   describe('approval-card config (CFG-2)', () => {


### PR DESCRIPTION
## Summary
- move restore eligibility, source witness validation, graph writes, effect reversal, event resolution, and generation advance into one users-row-mutex transaction
- re-read and lock event/effects after acquiring the canonical user lock; fail closed on supersede, drift, missing membership, or a concurrent grant write
- persist restore provenance, return the locked response contract, invalidate RBAC cache, and map EVENT_NOT_APPLIED to HTTP 409
- keep all lifecycle flags unchanged and OFF

## Verification
- `pnpm --filter @metasheet/core-backend exec tsc --noEmit`
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/admin-directory-routes.test.ts` (102/102)
- `DATABASE_URL=... pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/directory-deprovision-grant-table.db.test.ts` (11/11 real DB)
- deterministic `pg_blocking_pids()` barriers cover concurrent supersede, two-way restore, and grant drift after eligibility
- mutations: remove exact link witness, grant write-point predicate, or users FOR UPDATE; each dedicated test turns red

## Posture
Draft and unarmed. Stacked on D5c PR #4653; do not merge or enable lifecycle flags before owner review and the lower stack lands.