### PR TITLE
fix(directory): harden D7 evidence API and UI

### DIFF
--- a/apps/web/src/components/directory/DirectoryDeprovisionEvidencePanel.vue
+++ b/apps/web/src/components/directory/DirectoryDeprovisionEvidencePanel.vue
@@ -2,7 +2,7 @@
   <article class="deprov-evidence" data-testid="deprovision-evidence-panel">
     <div class="deprov-evidence__head">
       <div>
-        <h2>离岗证据链（D7）</h2>
+        <h2>离岗证据链</h2>
         <p class="deprov-evidence__hint">
           预览计划、查看 effect 事件、执行 rehire / admin force 恢复。策略配置 ≠ 已执行。
         </p>
@@ -135,7 +135,7 @@
         <button
           class="deprov-evidence__btn"
           type="button"
-          :disabled="restoring"
+          :disabled="restoring || !canRestore"
           data-testid="deprovision-restore-rehire"
           @click="void restore('rehire')"
         >
@@ -144,7 +144,7 @@
         <button
           class="deprov-evidence__btn deprov-evidence__btn--danger"
           type="button"
-          :disabled="restoring || !forceConfirm"
+          :disabled="restoring || !canRestore || !forceConfirm || forceNote.trim().length < 8"
           data-testid="deprovision-restore-force"
           @click="void restore('admin_force')"
         >
@@ -162,6 +162,9 @@
         placeholder="force 备注（≥8 字）"
         data-testid="deprovision-force-note"
       />
+      <p v-if="!canRestore" class="deprov-evidence__hint">
+        该事件没有可恢复的 applied effects。
+      </p>
       <p v-if="restoreConflict" class="deprov-evidence__status deprov-evidence__status--error" data-testid="deprovision-drift-conflict">
         {{ restoreConflict }}
       </p>
@@ -171,7 +174,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, watch } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { apiFetch } from '../../utils/api'
 
 type DeprovisionFlags = {
@@ -205,7 +208,7 @@ type DeprovisionEvent = {
   id: string
   local_user_id: string
   access_generation_at_apply: number
-  status: string
+  status: 'applied' | 'fully_resolved' | 'superseded'
   open_effect_count?: number
   integration_id?: string
 }
@@ -213,7 +216,7 @@ type DeprovisionEvent = {
 type DeprovisionEffect = {
   id: string
   effect_type: string
-  status: string
+  status: 'applied' | 'reversed' | 'superseded'
   after_active: boolean
   access_generation_at_apply: number
 }
@@ -243,6 +246,11 @@ const restoring = ref(false)
 const forceConfirm = ref(false)
 const forceNote = ref('')
 const restoreConflict = ref('')
+const canRestore = computed(
+  () =>
+    selectedEvent.value?.status === 'applied'
+    && effects.value.some((effect) => effect.status === 'applied'),
+)
 
 function shortId(id: string): string {
   if (!id) return ''
@@ -304,17 +312,30 @@ async function runPreview() {
 async function loadEvents() {
   loadingEvents.value = true
   try {
+    if (!props.integrationId) {
+      events.value = []
+      selectedEvent.value = null
+      effects.value = []
+      return
+    }
+    const selectedEventId = selectedEvent.value?.id
     const params = new URLSearchParams()
-    if (props.integrationId) params.set('integrationId', props.integrationId)
     if (eventsUserFilter.value.trim()) params.set('userId', eventsUserFilter.value.trim())
     params.set('limit', '50')
-    const response = await apiFetch(`/api/admin/directory/deprovision/events?${params.toString()}`)
+    const response = await apiFetch(
+      `/api/admin/directory/integrations/${encodeURIComponent(props.integrationId)}/deprovision-events?${params.toString()}`,
+    )
     const body = await response.json().catch(() => ({}))
     if (!response.ok) {
       setError(body?.error?.message || '加载事件失败')
       return
     }
     events.value = (body?.data?.items || []) as DeprovisionEvent[]
+    if (selectedEventId) {
+      selectedEvent.value =
+        events.value.find((event) => event.id === selectedEventId) ?? null
+      if (!selectedEvent.value) effects.value = []
+    }
     if (body?.data?.flags) flags.value = body.data.flags as DeprovisionFlags
   } catch (error) {
     setError(error instanceof Error ? error.message : '加载事件失败')
@@ -329,7 +350,9 @@ async function selectEvent(ev: DeprovisionEvent) {
   forceConfirm.value = false
   forceNote.value = ''
   try {
-    const response = await apiFetch(`/api/admin/directory/deprovision/events/${encodeURIComponent(ev.id)}/effects`)
+    const response = await apiFetch(
+      `/api/admin/directory/deprovision-events/${encodeURIComponent(ev.id)}/effects`,
+    )
     const body = await response.json().catch(() => ({}))
     if (!response.ok) {
       setError(body?.error?.message || '加载 effects 失败')
@@ -343,17 +366,18 @@ async function selectEvent(ev: DeprovisionEvent) {
 }
 
 async function restore(mode: 'rehire' | 'admin_force') {
-  if (!selectedEvent.value) return
+  if (!selectedEvent.value || !canRestore.value) return
   restoring.value = true
   restoreConflict.value = ''
   try {
     const response = await apiFetch(
-      `/api/admin/directory/deprovision/events/${encodeURIComponent(selectedEvent.value.id)}/restore`,
+      `/api/admin/directory/deprovision-events/${encodeURIComponent(selectedEvent.value.id)}/${
+        mode === 'rehire' ? 'reactivate' : 'force-reactivate'
+      }`,
       {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          mode,
           confirm: mode === 'admin_force' ? forceConfirm.value : undefined,
           note: mode === 'admin_force' ? forceNote.value : undefined,
         }),
@@ -363,14 +387,23 @@ async function restore(mode: 'rehire' | 'admin_force') {
     if (!response.ok) {
       const code = body?.error?.code || ''
       const message = body?.error?.message || '恢复失败'
-      if (code === 'DRIFT_CONFLICT' || code === 'SOURCE_INACTIVE' || code === 'NO_EFFECTS') {
+      if (
+        code === 'DRIFT_CONFLICT'
+        || code === 'SOURCE_INACTIVE'
+        || code === 'NO_EFFECTS'
+        || code === 'EVENT_NOT_APPLIED'
+      ) {
         restoreConflict.value = `${code}: ${message}`
       } else {
         setError(`${code || 'ERROR'}: ${message}`)
       }
       return
     }
-    setOk(`恢复成功（${mode}）· effects=${body?.data?.restoredEffectCount ?? 0}`)
+    setOk(
+      `恢复成功（${body?.data?.restoreMode || mode}）· effects=${
+        body?.data?.restoredEffectCount ?? 0
+      }`,
+    )
     await loadEvents()
     if (selectedEvent.value) await selectEvent(selectedEvent.value)
   } catch (error) {

--- a/apps/web/tests/DirectoryDeprovisionEvidencePanel.spec.ts
+++ b/apps/web/tests/DirectoryDeprovisionEvidencePanel.spec.ts
@@ -55,7 +55,7 @@ describe('DirectoryDeprovisionEvidencePanel (D7)', () => {
           policyNote: '策略≠已执行',
         })
       }
-      if (String(url).includes('/deprovision/events')) {
+      if (String(url).includes('/deprovision-events?')) {
         return jsonResponse({ items: [], flags: { enabled: false, maxBatch: 25, policyNote: 'x' } })
       }
       return jsonResponse({})
@@ -79,7 +79,7 @@ describe('DirectoryDeprovisionEvidencePanel (D7)', () => {
       if (String(url).includes('/deprovision/flags')) {
         return jsonResponse({ enabled: false, maxBatch: 25, policyNote: 'n' })
       }
-      if (String(url).includes('/deprovision/events?')) {
+      if (String(url).includes('/deprovision-events?')) {
         return jsonResponse({ items: [] })
       }
       if (String(url).includes('/deprovision/preview/')) {
@@ -122,9 +122,9 @@ describe('DirectoryDeprovisionEvidencePanel (D7)', () => {
         return jsonResponse({ enabled: false, maxBatch: 25, policyNote: 'n' })
       }
       if (
-        String(url).includes('/deprovision/events')
+        String(url).includes('/deprovision-events?')
         && !String(url).includes('/effects')
-        && !String(url).includes('/restore')
+        && !String(url).includes('/reactivate')
       ) {
         return jsonResponse({
           items: [
@@ -132,7 +132,7 @@ describe('DirectoryDeprovisionEvidencePanel (D7)', () => {
               id: 'ev-1',
               local_user_id: 'u1',
               access_generation_at_apply: 3,
-              status: 'open',
+              status: 'applied',
               open_effect_count: 1,
             },
           ],
@@ -143,7 +143,7 @@ describe('DirectoryDeprovisionEvidencePanel (D7)', () => {
           items: [
             {
               id: 'fx-1',
-              effect_type: 'set_user_inactive',
+              effect_type: 'membership_changed',
               status: 'applied',
               after_active: false,
               access_generation_at_apply: 3,
@@ -151,7 +151,7 @@ describe('DirectoryDeprovisionEvidencePanel (D7)', () => {
           ],
         })
       }
-      if (String(url).includes('/restore') && init?.method === 'POST') {
+      if (String(url).includes('/reactivate') && init?.method === 'POST') {
         return jsonResponse({ code: 'DRIFT_CONFLICT', message: 'access_generation mismatch' }, false, 409)
       }
       return jsonResponse({})
@@ -172,5 +172,80 @@ describe('DirectoryDeprovisionEvidencePanel (D7)', () => {
     await flushUi()
 
     expect(root.querySelector('[data-testid="deprovision-drift-conflict"]')?.textContent).toMatch(/DRIFT_CONFLICT/)
+  })
+
+  it('requires applied evidence, explicit confirmation, and an eight-character note before force restore', async () => {
+    apiFetchMock.mockImplementation(async (url: string, init?: { method?: string; body?: string }) => {
+      if (String(url).includes('/deprovision/flags')) {
+        return jsonResponse({ enabled: false, maxBatch: 25, policyNote: 'n' })
+      }
+      if (String(url).includes('/deprovision-events?')) {
+        return jsonResponse({
+          items: [
+            {
+              id: 'ev-1',
+              local_user_id: 'u1',
+              access_generation_at_apply: 3,
+              status: 'applied',
+              open_effect_count: 1,
+            },
+          ],
+        })
+      }
+      if (String(url).includes('/effects')) {
+        return jsonResponse({
+          items: [
+            {
+              id: 'fx-1',
+              effect_type: 'membership_changed',
+              status: 'applied',
+              after_active: false,
+              access_generation_at_apply: 3,
+            },
+          ],
+        })
+      }
+      if (String(url).includes('/force-reactivate') && init?.method === 'POST') {
+        return jsonResponse({
+          restoreMode: 'admin_force',
+          restoredEffectCount: 1,
+        })
+      }
+      return jsonResponse({})
+    })
+
+    const root = mountPanel({ integrationId: 'int-1' })
+    ;(root.querySelector('[data-testid="deprovision-evidence-toggle"]') as HTMLButtonElement).click()
+    await flushUi()
+    const detailBtn = Array.from(root.querySelectorAll('button')).find((button) =>
+      button.textContent?.includes('详情'))
+    detailBtn!.click()
+    await flushUi()
+
+    const force = root.querySelector('[data-testid="deprovision-restore-force"]') as HTMLButtonElement
+    const confirm = root.querySelector('[data-testid="deprovision-force-confirm"]') as HTMLInputElement
+    const note = root.querySelector('[data-testid="deprovision-force-note"]') as HTMLTextAreaElement
+    expect(force.disabled).toBe(true)
+
+    confirm.click()
+    note.value = 'short'
+    note.dispatchEvent(new Event('input'))
+    await flushUi(2)
+    expect(force.disabled).toBe(true)
+
+    note.value = 'confirmed by owner'
+    note.dispatchEvent(new Event('input'))
+    await flushUi(2)
+    expect(force.disabled).toBe(false)
+    force.click()
+    await flushUi()
+
+    const call = apiFetchMock.mock.calls.find((args) =>
+      String(args[0]).includes('/force-reactivate'))
+    expect(call?.[0]).toContain('/api/admin/directory/deprovision-events/ev-1/force-reactivate')
+    expect(JSON.parse(String(call?.[1]?.body))).toEqual({
+      confirm: true,
+      note: 'confirmed by owner',
+    })
   })
 })

--- a/packages/core-backend/src/directory/deprovision-evidence-api.ts
+++ b/packages/core-backend/src/directory/deprovision-evidence-api.ts
@@ -128,6 +128,7 @@ export async function listDeprovisionEvents(options: {
   integrationId?: string
   localUserId?: string
   limit?: number
+  status?: 'applied' | 'fully_resolved' | 'superseded'
 }) {
   const limit = Math.min(Math.max(options.limit ?? 50, 1), 200)
   const clauses: string[] = []
@@ -139,6 +140,10 @@ export async function listDeprovisionEvents(options: {
   if (options.localUserId) {
     params.push(options.localUserId)
     clauses.push(`e.local_user_id = $${params.length}`)
+  }
+  if (options.status) {
+    params.push(options.status)
+    clauses.push(`e.status = $${params.length}`)
   }
   const where = clauses.length ? `WHERE ${clauses.join(' AND ')}` : ''
   params.push(limit)

--- a/packages/core-backend/src/routes/admin-directory.ts
+++ b/packages/core-backend/src/routes/admin-directory.ts
@@ -1252,6 +1252,128 @@ export function adminDirectoryRouter(): Router {
 
   // ── D7 evidence chain: flags / plan preview / events / restore ────────────
 
+  type DeprovisionEventStatus =
+    | 'applied'
+    | 'fully_resolved'
+    | 'superseded'
+
+  function readDeprovisionEventStatus(
+    value: unknown,
+  ): DeprovisionEventStatus | undefined | null {
+    if (value === undefined || value === null || value === '') return undefined
+    if (
+      value === 'applied'
+      || value === 'fully_resolved'
+      || value === 'superseded'
+    ) {
+      return value
+    }
+    return null
+  }
+
+  async function listDeprovisionEventsForRequest(
+    req: Request,
+    res: Response,
+    integrationId?: string,
+  ): Promise<void> {
+    const adminUserId = await ensurePlatformAdmin(req, res)
+    if (!adminUserId) return
+    const status = readDeprovisionEventStatus(req.query.status)
+    if (status === null) {
+      jsonError(
+        res,
+        400,
+        'DEPROVISION_EVENT_STATUS_INVALID',
+        'status must be applied, fully_resolved, or superseded',
+      )
+      return
+    }
+    try {
+      const items = await listDeprovisionEvents({
+        integrationId:
+          integrationId
+          ?? (typeof req.query.integrationId === 'string'
+            ? req.query.integrationId
+            : undefined),
+        localUserId:
+          typeof req.query.userId === 'string'
+            ? req.query.userId
+            : undefined,
+        limit:
+          typeof req.query.limit === 'string'
+            ? Number(req.query.limit)
+            : 50,
+        status,
+      })
+      jsonOk(res, { items, flags: readDeprovisionRuntimeFlags() })
+    } catch (error) {
+      jsonError(
+        res,
+        500,
+        'DEPROVISION_EVENTS_FAILED',
+        readErrorMessage(error, 'List events failed'),
+      )
+    }
+  }
+
+  async function restoreDeprovisionEventForRequest(
+    req: Request,
+    res: Response,
+    mode: 'rehire' | 'admin_force',
+  ): Promise<void> {
+    const adminUserId = await ensurePlatformAdmin(req, res)
+    if (!adminUserId) return
+    try {
+      const result = await restoreDeprovisionEvent({
+        eventId: req.params.eventId,
+        mode,
+        adminUserId,
+        confirm: req.body?.confirm === true,
+        note:
+          typeof req.body?.note === 'string'
+            ? req.body.note
+            : undefined,
+      })
+      await auditLog({
+        actorId: adminUserId,
+        actorType: 'user',
+        action: 'update',
+        resourceType: 'directory-deprovision-event',
+        resourceId: req.params.eventId,
+        meta: {
+          restoreMode: mode,
+          restoredEffectCount: result.restoredEffectCount,
+          localUserId: result.localUserId,
+          noteLength: result.note ? result.note.length : 0,
+        },
+      })
+      jsonOk(res, result)
+    } catch (error) {
+      const code =
+        (error as { code?: string })?.code
+        || 'DEPROVISION_RESTORE_FAILED'
+      const status =
+        code === 'EVENT_NOT_FOUND' || code === 'USER_NOT_FOUND'
+          ? 404
+          : code === 'DRIFT_CONFLICT'
+              || code === 'SOURCE_INACTIVE'
+              || code === 'NO_EFFECTS'
+              || code === 'NOT_APPLIED'
+              || code === 'EVENT_NOT_APPLIED'
+            ? 409
+            : code === 'FORCE_CONFIRM_REQUIRED'
+                || code === 'FORCE_NOTE_REQUIRED'
+              ? 400
+              : 500
+      jsonError(
+        res,
+        status,
+        code,
+        (error as Error)?.message || 'Restore failed',
+      )
+    }
+  }
+
   router.get('/deprovision/flags', async (req: Request, res: Response) => {
     const adminUserId = await ensurePlatformAdmin(req, res)
     if (!adminUserId) return
@@ -1282,19 +1404,38 @@ export function adminDirectoryRouter(): Router {
   })
 
   router.get('/deprovision/events', async (req: Request, res: Response) => {
-    const adminUserId = await ensurePlatformAdmin(req, res)
-    if (!adminUserId) return
-    try {
-      const items = await listDeprovisionEvents({
-        integrationId: typeof req.query.integrationId === 'string' ? req.query.integrationId : undefined,
-        localUserId: typeof req.query.userId === 'string' ? req.query.userId : undefined,
-        limit: typeof req.query.limit === 'string' ? Number(req.query.limit) : 50,
-      })
-      jsonOk(res, { items, flags: readDeprovisionRuntimeFlags() })
-    } catch (error) {
-      jsonError(res, 500, 'DEPROVISION_EVENTS_FAILED', readErrorMessage(error, 'List events failed'))
-    }
+    await listDeprovisionEventsForRequest(req, res)
   })
+
+  router.get(
+    '/integrations/:integrationId/deprovision-events',
+    async (req: Request, res: Response) => {
+      await listDeprovisionEventsForRequest(
+        req,
+        res,
+        req.params.integrationId,
+      )
+    },
+  )
+
+  router.get(
+    '/deprovision-events/:eventId/effects',
+    async (req: Request, res: Response) => {
+      const adminUserId = await ensurePlatformAdmin(req, res)
+      if (!adminUserId) return
+      try {
+        const items = await listDeprovisionEffects(req.params.eventId)
+        jsonOk(res, { items })
+      } catch (error) {
+        jsonError(
+          res,
+          500,
+          'DEPROVISION_EFFECTS_FAILED',
+          readErrorMessage(error, 'List effects failed'),
+        )
+      }
+    },
+  )
 
   router.get('/deprovision/events/:eventId/effects', async (req: Request, res: Response) => {
     const adminUserId = await ensurePlatformAdmin(req, res)
@@ -1308,47 +1449,34 @@ export function adminDirectoryRouter(): Router {
   })
 
   router.post('/deprovision/events/:eventId/restore', async (req: Request, res: Response) => {
-    const adminUserId = await ensurePlatformAdmin(req, res)
-    if (!adminUserId) return
-    try {
-      const modeRaw = String(req.body?.mode || 'rehire').trim()
-      const mode = modeRaw === 'admin_force' ? 'admin_force' : 'rehire'
-      const result = await restoreDeprovisionEvent({
-        eventId: req.params.eventId,
-        mode,
-        adminUserId,
-        confirm: req.body?.confirm === true,
-        note: typeof req.body?.note === 'string' ? req.body.note : undefined,
-      })
-      await auditLog({
-        actorId: adminUserId,
-        actorType: 'user',
-        action: 'update',
-        resourceType: 'directory-deprovision-event',
-        resourceId: req.params.eventId,
-        meta: {
-          restoreMode: mode,
-          restoredEffectCount: result.restoredEffectCount,
-          localUserId: result.localUserId,
-          noteLength: result.note ? result.note.length : 0,
-        },
-      })
-      jsonOk(res, result)
-    } catch (error) {
-      const code = (error as { code?: string })?.code || 'DEPROVISION_RESTORE_FAILED'
-      const status =
-        code === 'EVENT_NOT_FOUND' || code === 'USER_NOT_FOUND' ? 404
-          : code === 'DRIFT_CONFLICT'
-              || code === 'SOURCE_INACTIVE'
-              || code === 'NO_EFFECTS'
-              || code === 'NOT_APPLIED'
-              || code === 'EVENT_NOT_APPLIED'
-            ? 409
-            : code === 'FORCE_CONFIRM_REQUIRED' || code === 'FORCE_NOTE_REQUIRED' ? 400
-              : 500
-      jsonError(res, status, code, (error as Error)?.message || 'Restore failed')
+    const mode = String(req.body?.mode ?? 'rehire').trim()
+    if (mode !== 'rehire' && mode !== 'admin_force') {
+      const adminUserId = await ensurePlatformAdmin(req, res)
+      if (!adminUserId) return
+      jsonError(
+        res,
+        400,
+        'RESTORE_MODE_INVALID',
+        'mode must be rehire or admin_force',
+      )
+      return
     }
+    await restoreDeprovisionEventForRequest(req, res, mode)
   })
+
+  router.post(
+    '/deprovision-events/:eventId/reactivate',
+    async (req: Request, res: Response) => {
+      await restoreDeprovisionEventForRequest(req, res, 'rehire')
+    },
+  )
+
+  router.post(
+    '/deprovision-events/:eventId/force-reactivate',
+    async (req: Request, res: Response) => {
+      await restoreDeprovisionEventForRequest(req, res, 'admin_force')
+    },
+  )
 
   return router
 }

--- a/packages/core-backend/tests/unit/admin-directory-routes.test.ts
+++ b/packages/core-backend/tests/unit/admin-directory-routes.test.ts
@@ -284,6 +284,122 @@ describe('adminDirectoryRouter', () => {
     expect(auditMocks.auditLog).not.toHaveBeenCalled()
   })
 
+  it('rejects an invalid compatibility restore mode instead of silently treating it as rehire', async () => {
+    const response = await invokeRoute(
+      'post',
+      '/deprovision/events/:eventId/restore',
+      {
+        params: { eventId: 'event-1' },
+        body: { mode: 'force' },
+        user: { id: 'admin-1', role: 'admin' },
+      },
+    )
+
+    expect(response.statusCode).toBe(400)
+    expect(response.body).toMatchObject({
+      ok: false,
+      error: { code: 'RESTORE_MODE_INVALID' },
+    })
+    expect(deprovisionMocks.restoreDeprovisionEvent).not.toHaveBeenCalled()
+  })
+
+  it('exposes the locked rehire and force-reactivate routes with fixed modes', async () => {
+    deprovisionMocks.restoreDeprovisionEvent.mockResolvedValue({
+      eventId: 'event-1',
+      restoreMode: 'rehire',
+      restoredEffectCount: 1,
+      localUserId: 'user-1',
+      note: null,
+    })
+
+    const rehire = await invokeRoute(
+      'post',
+      '/deprovision-events/:eventId/reactivate',
+      {
+        params: { eventId: 'event-1' },
+        user: { id: 'admin-1', role: 'admin' },
+      },
+    )
+    expect(rehire.statusCode).toBe(200)
+    expect(deprovisionMocks.restoreDeprovisionEvent).toHaveBeenLastCalledWith({
+      eventId: 'event-1',
+      mode: 'rehire',
+      adminUserId: 'admin-1',
+      confirm: false,
+      note: undefined,
+    })
+
+    deprovisionMocks.restoreDeprovisionEvent.mockResolvedValue({
+      eventId: 'event-2',
+      restoreMode: 'admin_force',
+      restoredEffectCount: 1,
+      localUserId: 'user-2',
+      note: 'confirmed by owner',
+    })
+    const forced = await invokeRoute(
+      'post',
+      '/deprovision-events/:eventId/force-reactivate',
+      {
+        params: { eventId: 'event-2' },
+        body: { confirm: true, note: 'confirmed by owner' },
+        user: { id: 'admin-1', role: 'admin' },
+      },
+    )
+    expect(forced.statusCode).toBe(200)
+    expect(deprovisionMocks.restoreDeprovisionEvent).toHaveBeenLastCalledWith({
+      eventId: 'event-2',
+      mode: 'admin_force',
+      adminUserId: 'admin-1',
+      confirm: true,
+      note: 'confirmed by owner',
+    })
+    expect(auditMocks.auditLog).toHaveBeenCalledTimes(2)
+  })
+
+  it('lists integration-scoped events and rejects an unknown status before querying', async () => {
+    deprovisionMocks.listDeprovisionEvents.mockResolvedValue([
+      { id: 'event-1', status: 'applied' },
+    ])
+    deprovisionMocks.readDeprovisionRuntimeFlags.mockReturnValue({
+      enabled: false,
+      maxBatch: 25,
+    })
+
+    const listed = await invokeRoute(
+      'get',
+      '/integrations/:integrationId/deprovision-events',
+      {
+        params: { integrationId: 'integration-1' },
+        query: { status: 'applied', userId: 'user-1', limit: '10' },
+        user: { id: 'admin-1', role: 'admin' },
+      },
+    )
+    expect(listed.statusCode).toBe(200)
+    expect(deprovisionMocks.listDeprovisionEvents).toHaveBeenCalledWith({
+      integrationId: 'integration-1',
+      localUserId: 'user-1',
+      limit: 10,
+      status: 'applied',
+    })
+
+    deprovisionMocks.listDeprovisionEvents.mockClear()
+    const invalid = await invokeRoute(
+      'get',
+      '/integrations/:integrationId/deprovision-events',
+      {
+        params: { integrationId: 'integration-1' },
+        query: { status: 'open' },
+        user: { id: 'admin-1', role: 'admin' },
+      },
+    )
+    expect(invalid.statusCode).toBe(400)
+    expect(invalid.body).toMatchObject({
+      ok: false,
+      error: { code: 'DEPROVISION_EVENT_STATUS_INVALID' },
+    })
+    expect(deprovisionMocks.listDeprovisionEvents).not.toHaveBeenCalled()
+  })
+
   describe('approval-card config (CFG-2)', () => {
     const CARD_STATUS = {
       integration: { id: 'dir-1', name: 'DingTalk CN', status: 'active' },


### PR DESCRIPTION
## Summary

- add the design-locked integration-scoped event API and fixed-mode rehire/force-reactivate endpoints while retaining compatibility routes
- fail closed on invalid compatibility restore modes and unsupported event status filters
- gate D7 restore actions on applied event/effect evidence and require explicit force confirmation plus an 8-character note
- keep all lifecycle flags default-off; this PR does not authorize canary enablement

## Verification

- `pnpm --filter @metasheet/core-backend exec tsc --noEmit`
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/admin-directory-routes.test.ts --watch=false` (105/105)
- D6 real-DB evidence suite (11/11, re-run before this commit)
- `pnpm --filter @metasheet/web exec vue-tsc --noEmit`
- `pnpm --filter @metasheet/web exec vitest run tests/DirectoryDeprovisionEvidencePanel.spec.ts --watch=false` (4/4)

## Load-bearing mutations

- remove the force-note length gate: the dedicated UI test fails
- restore the old unknown-mode fallback: the compatibility route test fails

## Posture

Draft, stacked on D6, unarmed. No lifecycle flag is enabled.