### PR TITLE
fix(auth): cover activated user alias writers

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -1099,6 +1099,7 @@ jobs:
             tests/integration/directory-sync-alert-coverage.db.test.ts \
             tests/integration/directory-deprovision-selection.db.test.ts \
             tests/integration/directory-deprovision-grant-table.db.test.ts \
+            tests/integration/login-alias-writers.db.test.ts \
             tests/integration/directory-deprovision-ledger-schema.db.test.ts \
             tests/integration/directory-deprovision-writer-ledger.db.test.ts \
             tests/integration/directory-deprovision-race-supersede.db.test.ts \

--- a/packages/core-backend/src/auth/AuthService.ts
+++ b/packages/core-backend/src/auth/AuthService.ts
@@ -16,6 +16,7 @@ import { isUserSessionRevoked } from './session-revocation'
 import { createUserSession, isUserSessionActive } from './session-registry'
 import {
   assertAliasCutoverAllowed,
+  claimNonEmptyLoginAliasesOrThrow,
   findUserIdByLoginAlias,
   isAuthLoginAliasCutoverEnabled,
 } from './login-alias-service'
@@ -625,6 +626,11 @@ export class AuthService {
 
   /**
    * 创建新用户
+   *
+   * Load-bearing alias writer hook: activated self-registration must claim the email
+   * login alias in the same transaction as the users row. Removing
+   * claimNonEmptyLoginAliasesOrThrow here must fail tests/unit/login-alias-writers.test.ts
+   * and tests/integration/login-alias-writers.db.test.ts (auth_register class).
    */
   private async createUser(userData: {
     id: string
@@ -638,29 +644,41 @@ export class AuthService {
       try {
         const pool = poolManager.get()
         const permissionsJson = JSON.stringify(userData.permissions)
-        const result = await pool.query(
-          `INSERT INTO users (
-             id, email, name, password_hash, role, permissions,
-             activation_status, local_password_set, is_active,
-             created_at, updated_at
-           )
-           VALUES ($1, $2, $3, $4, $5, $6::jsonb, 'activated', TRUE, TRUE, NOW(), NOW())
-           RETURNING id, email, name, role, permissions, must_change_password,
-                     activation_status, local_password_set, is_active, created_at, updated_at`,
-          [userData.id, userData.email, userData.name, userData.password_hash, userData.role, permissionsJson]
-        )
+        // Transaction required: alias conflict must roll back the users insert (fail-closed).
+        const created = await pool.transaction(async (client) => {
+          const result = await client.query(
+            `INSERT INTO users (
+               id, email, name, password_hash, role, permissions,
+               activation_status, local_password_set, is_active,
+               created_at, updated_at
+             )
+             VALUES ($1, $2, $3, $4, $5, $6::jsonb, 'activated', TRUE, TRUE, NOW(), NOW())
+             RETURNING id, email, name, role, permissions, must_change_password,
+                       activation_status, local_password_set, is_active, created_at, updated_at`,
+            [userData.id, userData.email, userData.name, userData.password_hash, userData.role, permissionsJson],
+          )
 
-        if (result.rows.length > 0) {
-          const row = result.rows[0] as User
+          if (result.rows.length === 0) return null
+
+          // Alias full-writer: claim non-empty identifiers (email for self-registration).
+          await claimNonEmptyLoginAliasesOrThrow({
+            userId: userData.id,
+            email: userData.email,
+            source: 'auth_register',
+            client,
+          })
+
           if (userData.permissions.length > 0) {
             const values = userData.permissions.map((_, index) => `($1, $${index + 2})`).join(', ')
-            await pool.query(
+            await client.query(
               `INSERT INTO user_permissions (user_id, permission_code)
                VALUES ${values}
                ON CONFLICT DO NOTHING`,
-              [userData.id, ...userData.permissions]
+              [userData.id, ...userData.permissions],
             )
           }
+
+          const row = result.rows[0] as User
           return {
             id: row.id,
             email: row.email,
@@ -669,9 +687,10 @@ export class AuthService {
             permissions: Array.isArray(row.permissions) ? row.permissions : [],
             must_change_password: row.must_change_password,
             created_at: row.created_at,
-            updated_at: row.updated_at
+            updated_at: row.updated_at,
           }
-        }
+        })
+        return created
       } catch (dbError) {
         this.logger.warn('Database insert failed', dbError instanceof Error ? dbError : undefined)
       }

--- a/packages/core-backend/src/auth/dingtalk-oauth.ts
+++ b/packages/core-backend/src/auth/dingtalk-oauth.ts
@@ -19,11 +19,21 @@ import {
 } from '../integrations/dingtalk/runtime-policy'
 import { getBcryptSaltRounds } from '../security/auth-runtime-config'
 import { evaluateUserAuthenticationGate } from './user-activation'
+import {
+  claimNonEmptyLoginAliasesOrThrow,
+  LoginAliasClaimError,
+} from './login-alias-service'
 import { recordDingTalkOAuthStateFallback, recordDingTalkOAuthStateOperation } from '../metrics/metrics'
 import {
   lockUsersForAccessGraphWrite,
   supersedeDeprovisionEvidenceForAccessGraphWrite,
 } from '../directory/access-graph-mutex'
+
+/** JIT placeholder email is not a login identifier — never claim it as an alias. */
+function isDingTalkPlaceholderEmail(email: string | null | undefined): boolean {
+  if (!email) return true
+  return /@placeholder\.local$/i.test(email.trim())
+}
 
 const logger = new Logger('DingTalkOAuth')
 
@@ -729,29 +739,64 @@ async function createProvisionedUser(dtUser: DingTalkUserInfo): Promise<LocalUse
     }
   }
 
-  try {
-    const result = await query<LocalUserRow>(
-      `INSERT INTO users (
-         id, email, name, password_hash, role,
-         activation_status, local_password_set, is_active,
-         created_at, updated_at
-       )
-       VALUES ($1, $2, $3, $4, 'user', 'activated', FALSE, TRUE, NOW(), NOW())
-       RETURNING id,
-                 email,
-                 COALESCE(name, '') AS name,
-                 COALESCE(role, 'user') AS role,
-                 COALESCE(is_active, TRUE) AS is_active,
-                 activation_status`,
-      [userId, email, name, passwordHash],
-    )
+  // Real identifiers only for the login-alias namespace. The synthetic
+  // `dingtalk_*@placeholder.local` email is stored on users.email for uniqueness
+  // but must NEVER be claimed as a login alias (alias full-writer coverage).
+  const realEmail = dtUser.email && !isDingTalkPlaceholderEmail(dtUser.email) ? dtUser.email : null
+  const realMobile = dtUser.mobile && String(dtUser.mobile).trim() ? dtUser.mobile : null
 
-    const row = result.rows[0]
-    if (!row) {
-      throw new Error('Failed to create local user for DingTalk login')
-    }
+  try {
+    // Load-bearing alias writer hook: claim real email/mobile inside the same transaction
+    // as the JIT users insert. Removing claimNonEmptyLoginAliasesOrThrow must fail the
+    // dingtalk_jit writer tests. Placeholder email is intentionally omitted from claims.
+    const row = await transaction(async (client) => {
+      // Persist real mobile on users.mobile in the same transaction as the alias claim.
+      // Claiming a mobile login alias without storing users.mobile left profile/login
+      // mirrors inconsistent under T2a OR-column reads.
+      const result = await client.query(
+        `INSERT INTO users (
+           id, email, name, mobile, password_hash, role,
+           activation_status, local_password_set, is_active,
+           created_at, updated_at
+         )
+         VALUES ($1, $2, $3, $4, $5, 'user', 'activated', FALSE, TRUE, NOW(), NOW())
+         RETURNING id,
+                   email,
+                   COALESCE(name, '') AS name,
+                   COALESCE(role, 'user') AS role,
+                   COALESCE(is_active, TRUE) AS is_active,
+                   activation_status`,
+        [userId, email, name, realMobile, passwordHash],
+      )
+
+      const created = result.rows[0] as LocalUserRow | undefined
+      if (!created) {
+        throw new Error('Failed to create local user for DingTalk login')
+      }
+
+      if (realEmail || realMobile) {
+        await claimNonEmptyLoginAliasesOrThrow({
+          userId,
+          email: realEmail,
+          mobile: realMobile,
+          source: 'dingtalk_jit',
+          client,
+        })
+      }
+
+      return created
+    })
     return row
   } catch (error) {
+    if (error instanceof LoginAliasClaimError && error.code === 'ALIAS_CONFLICT') {
+      throw createPolicyError(
+        'Refusing to auto-provision DingTalk user because a login identifier is already claimed',
+        {
+          statusCode: 409,
+          code: 'auto_provision_alias_conflict',
+        },
+      )
+    }
     if (
       dtUser.email &&
       typeof error === 'object' &&

--- a/packages/core-backend/src/auth/login-alias-service.ts
+++ b/packages/core-backend/src/auth/login-alias-service.ts
@@ -51,11 +51,203 @@ export async function findUserIdByLoginAlias(rawIdentifier: string): Promise<str
   return result.rows[0].user_id
 }
 
-type AliasQueryClient = {
-  query: <T extends Record<string, unknown> = Record<string, unknown>>(
+/**
+ * Transaction client surface used by alias writers.
+ * Kept structurally loose so directory-sync / admin / OAuth transaction clients assign cleanly.
+ */
+export type AliasQueryClient = {
+  query: (
     sql: string,
     params?: unknown[],
-  ) => Promise<{ rows: T[] }>
+  ) => Promise<{ rows: Array<Record<string, unknown>> | unknown[] }>
+}
+
+/** Safe client-facing codes for activated-user identifier writers (never raw PG text). */
+export type LoginAliasWriterErrorCode = 'ALIAS_CONFLICT' | 'ALIAS_WRITE_FAILED'
+
+export type ClaimedLoginAlias = {
+  kind: LoginAliasKind
+  normalized: string
+}
+
+export type ClaimNonEmptyLoginAliasesResult =
+  | { ok: true; claimed: ClaimedLoginAlias[] }
+  | {
+      ok: false
+      code: LoginAliasWriterErrorCode
+      kind?: LoginAliasKind
+      /** Fixed safe message — never re-export claimLoginAlias/driver text. */
+      message: string
+    }
+
+const ALIAS_CONFLICT_MESSAGE = 'A login identifier is already claimed by another account'
+const ALIAS_WRITE_FAILED_MESSAGE = 'Failed to claim login alias'
+
+/** Thrown by writer paths so outer transactions roll back without leaking PG text. */
+export class LoginAliasClaimError extends Error {
+  readonly code: LoginAliasWriterErrorCode
+  readonly kind?: LoginAliasKind
+
+  constructor(code: LoginAliasWriterErrorCode, kind?: LoginAliasKind) {
+    super(code === 'ALIAS_CONFLICT' ? ALIAS_CONFLICT_MESSAGE : ALIAS_WRITE_FAILED_MESSAGE)
+    this.name = 'LoginAliasClaimError'
+    this.code = code
+    this.kind = kind
+  }
+}
+
+function mapClaimFailure(
+  claimed: { ok: false; code: string; message: string },
+  kind: LoginAliasKind,
+): Extract<ClaimNonEmptyLoginAliasesResult, { ok: false }> {
+  // Never echo claimed.message — claimLoginAlias may attach raw PostgreSQL/driver text on WRITE_FAILED.
+  if (claimed.code === 'ALIAS_CONFLICT' || claimed.code === 'ALIAS_EMPTY') {
+    // ALIAS_EMPTY after we already normalized non-empty is treated as conflict/unusable claim.
+    return {
+      ok: false,
+      code: 'ALIAS_CONFLICT',
+      kind,
+      message: ALIAS_CONFLICT_MESSAGE,
+    }
+  }
+  return {
+    ok: false,
+    code: 'ALIAS_WRITE_FAILED',
+    kind,
+    message: ALIAS_WRITE_FAILED_MESSAGE,
+  }
+}
+
+/**
+ * Fail-closed transactional helper for activated-user / identifier writers.
+ *
+ * Claims every non-empty email / username / mobile through `normalizeLoginIdentifier` +
+ * `claimLoginAlias` on the caller's transaction client. Empty / un-normalizable fields are
+ * skipped. Conflicts and write failures return fixed safe messages only (no raw PG text).
+ *
+ * Callers MUST pass `client` from an open transaction so a conflict rolls back the user write.
+ */
+export async function claimNonEmptyLoginAliases(options: {
+  userId: string
+  email?: string | null
+  username?: string | null
+  mobile?: string | null
+  source?: string
+  client: AliasQueryClient
+}): Promise<ClaimNonEmptyLoginAliasesResult> {
+  const fields: Array<{ raw: string | null | undefined; kind: LoginAliasKind }> = [
+    { raw: options.email, kind: 'email' },
+    { raw: options.username, kind: 'username' },
+    { raw: options.mobile, kind: 'mobile' },
+  ]
+  const claimed: ClaimedLoginAlias[] = []
+  for (const field of fields) {
+    if (field.raw == null || !String(field.raw).trim()) continue
+    const normalized = normalizeLoginIdentifier(field.raw)
+    if (!normalized) continue
+    const result = await claimLoginAlias({
+      userId: options.userId,
+      rawValue: field.raw,
+      kind: field.kind,
+      source: options.source ?? 'writer_claim',
+      client: options.client,
+    })
+    if (result.ok === false) {
+      return mapClaimFailure(result, field.kind)
+    }
+    claimed.push({ kind: field.kind, normalized: result.normalized })
+  }
+  return { ok: true, claimed }
+}
+
+/**
+ * Same as claimNonEmptyLoginAliases but throws LoginAliasClaimError (safe message / code).
+ * Intended for in-transaction writer hooks where failure must abort the unit of work.
+ */
+export async function claimNonEmptyLoginAliasesOrThrow(options: {
+  userId: string
+  email?: string | null
+  username?: string | null
+  mobile?: string | null
+  source?: string
+  client: AliasQueryClient
+}): Promise<ClaimedLoginAlias[]> {
+  const result = await claimNonEmptyLoginAliases(options)
+  if (result.ok === false) {
+    throw new LoginAliasClaimError(result.code, result.kind)
+  }
+  return result.claimed
+}
+
+/**
+ * Profile mobile identifier change (same transaction as users.mobile UPDATE):
+ * 1) claim the new mobile when normalized value is non-empty and differs from prior
+ * 2) run `afterNewClaim` (caller performs the profile row replace / CAS)
+ * 3) retire the prior mobile alias only if owned by this user and normalized values differ
+ *
+ * A conflict or afterNewClaim failure leaves the transaction to roll back — no partial retire.
+ */
+export async function applyMobileLoginAliasChange(options: {
+  userId: string
+  previousMobile?: string | null
+  nextMobile?: string | null
+  source?: string
+  client: AliasQueryClient
+  afterNewClaim: () => Promise<void>
+}): Promise<ClaimNonEmptyLoginAliasesResult & { retiredNormalized: string | null }> {
+  const previousNormalized = options.previousMobile
+    ? normalizeLoginIdentifier(options.previousMobile)
+    : null
+  const nextNormalized = options.nextMobile
+    ? normalizeLoginIdentifier(options.nextMobile)
+    : null
+
+  const claimed: ClaimedLoginAlias[] = []
+  if (nextNormalized && nextNormalized !== previousNormalized && options.nextMobile) {
+    const result = await claimLoginAlias({
+      userId: options.userId,
+      rawValue: options.nextMobile,
+      kind: 'mobile',
+      source: options.source ?? 'profile_mobile',
+      client: options.client,
+    })
+    if (result.ok === false) {
+      return { ...mapClaimFailure(result, 'mobile'), retiredNormalized: null }
+    }
+    claimed.push({ kind: 'mobile', normalized: result.normalized })
+  }
+
+  await options.afterNewClaim()
+
+  let retiredNormalized: string | null = null
+  if (previousNormalized && previousNormalized !== nextNormalized) {
+    // Only delete an alias owned by this user; never touch another principal's row.
+    await options.client.query(
+      `DELETE FROM user_login_aliases
+        WHERE user_id = $1
+          AND kind = 'mobile'
+          AND normalized_value = $2`,
+      [options.userId, previousNormalized],
+    )
+    retiredNormalized = previousNormalized
+  }
+
+  return { ok: true, claimed, retiredNormalized }
+}
+
+export async function applyMobileLoginAliasChangeOrThrow(options: {
+  userId: string
+  previousMobile?: string | null
+  nextMobile?: string | null
+  source?: string
+  client: AliasQueryClient
+  afterNewClaim: () => Promise<void>
+}): Promise<{ claimed: ClaimedLoginAlias[]; retiredNormalized: string | null }> {
+  const result = await applyMobileLoginAliasChange(options)
+  if (result.ok === false) {
+    throw new LoginAliasClaimError(result.code, result.kind)
+  }
+  return { claimed: result.claimed, retiredNormalized: result.retiredNormalized }
 }
 
 export async function claimLoginAlias(options: {
@@ -71,14 +263,16 @@ export async function claimLoginAlias(options: {
     return { ok: false, code: 'ALIAS_EMPTY', message: 'Identifier is empty after normalization' }
   }
   const kind = options.kind ?? inferLoginAliasKind(options.rawValue)
-  const runQuery = async <T extends Record<string, unknown> = Record<string, unknown>>(
+  const runQuery = async (
     sql: string,
     params?: unknown[],
-  ): Promise<{ rows: T[] }> => {
+  ): Promise<{ rows: Array<Record<string, unknown>> }> => {
     if (options.client) {
-      return options.client.query<T>(sql, params)
+      const result = await options.client.query(sql, params)
+      return { rows: result.rows as Array<Record<string, unknown>> }
     }
-    return query<T>(sql, params)
+    const result = await query<Record<string, unknown>>(sql, params)
+    return { rows: result.rows }
   }
   try {
     await runQuery(
@@ -87,14 +281,15 @@ export async function claimLoginAlias(options: {
        ON CONFLICT (normalized_value) DO NOTHING`,
       [options.userId, kind, normalized, options.source ?? 'claim'],
     )
-    const check = await runQuery<{ user_id: string }>(
+    const check = await runQuery(
       `SELECT user_id FROM user_login_aliases WHERE normalized_value = $1`,
       [normalized],
     )
-    if (!check.rows[0]) {
+    const ownerId = check.rows[0]?.user_id
+    if (ownerId == null) {
       return { ok: false, code: 'ALIAS_CONFLICT', message: 'Normalized identifier already claimed' }
     }
-    if (check.rows[0].user_id !== options.userId) {
+    if (String(ownerId) !== options.userId) {
       return { ok: false, code: 'ALIAS_CONFLICT', message: 'Normalized identifier already claimed' }
     }
     return { ok: true, normalized }
@@ -102,6 +297,8 @@ export async function claimLoginAlias(options: {
     return {
       ok: false,
       code: 'ALIAS_WRITE_FAILED',
+      // Intentionally may include driver text for server logs; writers must map via
+      // claimNonEmptyLoginAliases / LoginAliasClaimError and never echo this to clients.
       message: error instanceof Error ? error.message : 'alias write failed',
     }
   }

--- a/packages/core-backend/src/directory/directory-sync.ts
+++ b/packages/core-backend/src/directory/directory-sync.ts
@@ -40,6 +40,7 @@ import {
   buildUnusablePasswordHash,
   isDirectoryPendingActivationEnabled,
 } from '../auth/user-activation'
+import { claimNonEmptyLoginAliasesOrThrow } from '../auth/login-alias-service'
 import { SimpleCronExpression } from '../services/SchedulerService'
 import { deliverDirectorySyncFailureAlert, getDirectoryManagerBindingCoverage } from './directory-sync-alert-delivery'
 import { resolveDirectoryScheduleTimezone } from './directory-sync-timezone'
@@ -6133,6 +6134,20 @@ async function createDirectoryAdmittedUserInTransaction(
       supersedeTargetUser: false,
       skipUserOrgMembership: pendingMode,
     })
+
+    // Alias full-writer: claim only when admission creates an activated user.
+    // pending_activation must claim nothing until T3 activate (design lock).
+    // Load-bearing: removing this branch must fail directory_admit activated writer tests.
+    if (activationStatus === 'activated') {
+      await claimNonEmptyLoginAliasesOrThrow({
+        userId,
+        email: options.email,
+        username: options.username,
+        mobile: options.mobile,
+        source: 'directory_admit',
+        client,
+      })
+    }
   } catch (error) {
     // Undo the users INSERT (and recover the transaction if the throw came from a failed
     // statement), then release, so the outer sync transaction stays usable for the next account.

--- a/packages/core-backend/src/routes/admin-users.ts
+++ b/packages/core-backend/src/routes/admin-users.ts
@@ -32,9 +32,12 @@ import {
 import { activatePendingUser } from '../auth/user-activate'
 import type { ActivateErrorCode } from '../auth/user-activate'
 import {
+  applyMobileLoginAliasChangeOrThrow,
   assertAliasCutoverAllowed,
   backfillUserLoginAliases,
+  claimNonEmptyLoginAliasesOrThrow,
   isAuthLoginAliasCutoverEnabled,
+  LoginAliasClaimError,
 } from '../auth/login-alias-service'
 import {
   lockUsersForAccessGraphWrite,
@@ -3580,6 +3583,17 @@ export function adminUsersRouter(): Router {
           ],
         )
 
+        // Load-bearing alias writer hook: admin create always inserts activation_status=activated.
+        // Removing claimNonEmptyLoginAliasesOrThrow must fail the admin_create writer tests.
+        await claimNonEmptyLoginAliasesOrThrow({
+          userId,
+          email: cleanEmail || null,
+          username: cleanUsername,
+          mobile: cleanMobile,
+          source: 'admin_create',
+          client,
+        })
+
         if (roleId) {
           await client.query(
             `INSERT INTO user_roles (user_id, role_id)
@@ -3728,6 +3742,13 @@ export function adminUsersRouter(): Router {
       if (error instanceof AttendanceDefaultShiftNotFoundError) {
         return jsonError(res, error.status, error.code, error.message)
       }
+      if (error instanceof LoginAliasClaimError) {
+        // Fixed safe messages only — never echo error.stack / PG detail from nested drivers.
+        if (error.code === 'ALIAS_CONFLICT') {
+          return jsonError(res, 409, 'LOGIN_ALIAS_CONFLICT', error.message)
+        }
+        return jsonError(res, 500, 'LOGIN_ALIAS_FAILED', error.message)
+      }
       if (isDatabaseSchemaError(error)) {
         return jsonError(res, 503, 'USER_CREATE_SCHEMA_UNAVAILABLE', 'Required user or attendance tables are not available until migrations are applied')
       }
@@ -3785,37 +3806,172 @@ export function adminUsersRouter(): Router {
       // (strip all whitespace, map empty to NULL) before comparison so legacy
       // rows like "138 0013 8000" don't spuriously fail CAS when the client
       // sends the already-sanitised "13800138000" witness.
-      const updateResult = await query<{ id: string }>(
-        `UPDATE users
-         SET name = $1,
-             mobile = $2,
-             employee_no = $3,
-             department = $4,
-             position = $5,
-             hire_date = $6::date,
-             updated_at = NOW()
-         WHERE id = $7
-           AND (
-             $8::boolean = FALSE
-             OR NULLIF(regexp_replace(COALESCE(mobile, ''), '\\s+', '', 'g'), '')
-                IS NOT DISTINCT FROM
-                NULLIF(regexp_replace(COALESCE($9::text, ''), '\\s+', '', 'g'), '')
-           )
-         RETURNING id`,
-        [
-          nextName,
-          nextMobile,
-          nextEmployeeNo,
-          nextDepartment,
-          nextPosition,
-          nextHireDate,
-          userId,
-          hasExpectedMobile,
-          expectedMobile ?? null,
-        ],
-      )
-      if (updateResult.rows.length === 0) {
-        return jsonError(res, 409, 'PROFILE_MOBILE_CONFLICT', 'User mobile changed before update was applied')
+      //
+      // Mobile path TOCTOU fix: do NOT retire aliases from the pre-transaction
+      // profile.mobile snapshot. Lock the users row FOR UPDATE, derive the
+      // authoritative previous mobile from that locked row, then claim → update
+      // → retire in the same transaction. A concurrent mobile writer cannot make
+      // this route delete a stale prior alias.
+      // Load-bearing alias writer hook: removing applyMobileLoginAliasChangeOrThrow
+      // or the FOR UPDATE load must fail the admin_profile_mobile route/unit tests.
+      type ProfileTxnClient = {
+        query: <T extends Record<string, unknown> = Record<string, unknown>>(
+          sql: string,
+          params?: unknown[],
+        ) => Promise<{ rows: T[] }>
+      }
+
+      const runProfileUpdate = async (
+        client: ProfileTxnClient,
+        fields: {
+          name: string
+          mobile: string | null
+          employeeNo: string | null
+          department: string | null
+          position: string | null
+          hireDate: string | null
+        },
+      ) => {
+        const updateResult = await client.query<{ id: string }>(
+          `UPDATE users
+           SET name = $1,
+               mobile = $2,
+               employee_no = $3,
+               department = $4,
+               position = $5,
+               hire_date = $6::date,
+               updated_at = NOW()
+           WHERE id = $7
+             AND (
+               $8::boolean = FALSE
+               OR NULLIF(regexp_replace(COALESCE(mobile, ''), '\\s+', '', 'g'), '')
+                  IS NOT DISTINCT FROM
+                  NULLIF(regexp_replace(COALESCE($9::text, ''), '\\s+', '', 'g'), '')
+             )
+           RETURNING id`,
+          [
+            fields.name,
+            fields.mobile,
+            fields.employeeNo,
+            fields.department,
+            fields.position,
+            fields.hireDate,
+            userId,
+            hasExpectedMobile,
+            expectedMobile ?? null,
+          ],
+        )
+        if (updateResult.rows.length === 0) {
+          const err = new Error('User mobile changed before update was applied') as Error & {
+            code?: string
+          }
+          err.code = 'PROFILE_MOBILE_CONFLICT'
+          throw err
+        }
+      }
+
+      // Authoritative before/after values for audit — mobile path refreshes from the locked row.
+      let auditBefore = {
+        name: profile.name,
+        mobile: profile.mobile,
+        employeeNo: profile.employeeNo,
+        department: profile.department,
+        position: profile.position,
+        hireDate: profile.hireDate,
+      }
+      let auditAfter = {
+        name: nextName,
+        mobile: nextMobile,
+        employeeNo: nextEmployeeNo,
+        department: nextDepartment,
+        position: nextPosition,
+        hireDate: nextHireDate,
+      }
+
+      if (hasMobile) {
+        await transaction(async (client) => {
+          type LockedProfileRow = {
+            id: string
+            name: string
+            mobile: string | null
+            employeeNo: string | null
+            department: string | null
+            position: string | null
+            hireDate: string | null
+          }
+          const locked = await client.query(
+            `SELECT ${ADMIN_USER_PROFILE_SELECT}
+             FROM users
+             WHERE id = $1
+             FOR UPDATE`,
+            [userId],
+          )
+          const lockedRow = locked.rows[0] as LockedProfileRow | undefined
+          if (!lockedRow) {
+            const err = new Error('User not found') as Error & { code?: string }
+            err.code = 'NOT_FOUND'
+            throw err
+          }
+
+          // Authoritative previous mobile comes from the locked row only — never the
+          // pre-transaction snapshot (stale profile.mobile would retire the wrong alias).
+          const previousMobileFromLock = lockedRow.mobile
+          const effectiveNextName = hasName ? nextName : lockedRow.name
+          const effectiveNextMobile = nextMobile
+          const effectiveNextEmployeeNo = hasEmployeeNo ? nextEmployeeNo : lockedRow.employeeNo
+          const effectiveNextDepartment = hasDepartment ? nextDepartment : lockedRow.department
+          const effectiveNextPosition = hasPosition ? nextPosition : lockedRow.position
+          const effectiveNextHireDate = hasHireDate ? nextHireDate : lockedRow.hireDate
+
+          auditBefore = {
+            name: lockedRow.name,
+            mobile: lockedRow.mobile,
+            employeeNo: lockedRow.employeeNo,
+            department: lockedRow.department,
+            position: lockedRow.position,
+            hireDate: lockedRow.hireDate,
+          }
+          auditAfter = {
+            name: effectiveNextName,
+            mobile: effectiveNextMobile,
+            employeeNo: effectiveNextEmployeeNo,
+            department: effectiveNextDepartment,
+            position: effectiveNextPosition,
+            hireDate: effectiveNextHireDate,
+          }
+
+          await applyMobileLoginAliasChangeOrThrow({
+            userId,
+            previousMobile: previousMobileFromLock,
+            nextMobile: effectiveNextMobile,
+            source: 'admin_profile_mobile',
+            client,
+            afterNewClaim: async () => {
+              await runProfileUpdate(client, {
+                name: effectiveNextName,
+                mobile: effectiveNextMobile,
+                employeeNo: effectiveNextEmployeeNo,
+                department: effectiveNextDepartment,
+                position: effectiveNextPosition,
+                hireDate: effectiveNextHireDate,
+              })
+            },
+          })
+        })
+      } else {
+        await runProfileUpdate(
+          {
+            query: async (sql, params) => query(sql, params),
+          },
+          {
+            name: nextName,
+            mobile: nextMobile,
+            employeeNo: nextEmployeeNo,
+            department: nextDepartment,
+            position: nextPosition,
+            hireDate: nextHireDate,
+          },
+        )
       }
 
       await auditLog({
@@ -3826,22 +3982,8 @@ export function adminUsersRouter(): Router {
         resourceId: userId,
         meta: {
           adminUserId,
-          before: {
-            name: profile.name,
-            mobile: profile.mobile,
-            employeeNo: profile.employeeNo,
-            department: profile.department,
-            position: profile.position,
-            hireDate: profile.hireDate,
-          },
-          after: {
-            name: nextName,
-            mobile: nextMobile,
-            employeeNo: nextEmployeeNo,
-            department: nextDepartment,
-            position: nextPosition,
-            hireDate: nextHireDate,
-          },
+          before: auditBefore,
+          after: auditAfter,
         },
       })
 
@@ -3851,6 +3993,19 @@ export function adminUsersRouter(): Router {
         actorId: adminUserId,
       })
     } catch (error) {
+      const code = (error as { code?: string } | null)?.code
+      if (code === 'NOT_FOUND') {
+        return jsonError(res, 404, 'NOT_FOUND', 'User not found')
+      }
+      if (code === 'PROFILE_MOBILE_CONFLICT') {
+        return jsonError(res, 409, 'PROFILE_MOBILE_CONFLICT', 'User mobile changed before update was applied')
+      }
+      if (error instanceof LoginAliasClaimError) {
+        if (error.code === 'ALIAS_CONFLICT') {
+          return jsonError(res, 409, 'LOGIN_ALIAS_CONFLICT', error.message)
+        }
+        return jsonError(res, 500, 'LOGIN_ALIAS_FAILED', error.message)
+      }
       return jsonError(res, 500, 'USER_PROFILE_UPDATE_FAILED', (error as Error)?.message || 'Failed to update user profile')
     }
   })

--- a/packages/core-backend/tests/integration/dingtalk-container-login.db.test.ts
+++ b/packages/core-backend/tests/integration/dingtalk-container-login.db.test.ts
@@ -36,6 +36,17 @@ const describeIfDb = process.env.DATABASE_URL ? describe : describe.skip
 const q = (sql: string, params?: unknown[]) => pool.query(sql, params)
 
 const RUN = `e1c_${Date.now()}`
+
+// #4658 makes login identifiers a GLOBAL unique namespace (user_login_aliases), so the suite's
+// old shared literal mobile ('13800000000' on every profile) now correctly refuses the second
+// provisioning — two different people cannot hold the same mobile alias. Same person must keep
+// the same mobile across container/web hops, different people must differ: derive it from the
+// unionId deterministically.
+function mobileFor(unionId: string): string {
+  let h = 0
+  for (const ch of unionId) h = (h * 31 + ch.charCodeAt(0)) >>> 0
+  return `13${String(h % 900000000 + 100000000)}`
+}
 const CORP = `corp_${RUN}`
 const USER_LINKED = `user_${RUN}_linked`
 const USER_DISABLED = `user_${RUN}_disabled`
@@ -54,7 +65,7 @@ function primeContainerChain(unionId: string, userId = `emp_${unionId}`, options
     name: `Name ${unionId}`,
     unionId,
     email: options.omitEmail ? undefined : (options.email ?? `${unionId}@example.com`),
-    mobile: '13800000000',
+    mobile: mobileFor(unionId),
     avatarUrl: '',
     departmentIds: [],
     source: {},
@@ -187,7 +198,7 @@ describeIfDb('E1 — dingtalk container login (real DB)', () => {
       unionId: UNION_GOLDEN,
       nick: 'Golden',
       email: `${UNION_GOLDEN}@example.com`,
-      mobile: '13800000000',
+      mobile: mobileFor(UNION_GOLDEN),
       avatarUrl: '',
     })
     const second = await exchangeCodeForUser('web-code-golden')

--- a/packages/core-backend/tests/integration/login-alias-writers.db.test.ts
+++ b/packages/core-backend/tests/integration/login-alias-writers.db.test.ts
@@ -1,0 +1,644 @@
+/**
+ * Alias full-writer coverage — real Postgres.
+ *
+ * Proves positive alias rows + rollback-on-conflict for production writer classes that
+ * are reachable without HTTP (flags remain OFF; no T3 batch/SSO / deprovision / env / docs).
+ *
+ * Load-bearing notes:
+ * 1. auth_register — AuthService.register (production createUser + claim)
+ * 2. helper admin_create shape — claimNonEmptyLoginAliasesOrThrow rollback only
+ *    (HTTP POST /api/admin/users hook is load-bearing in admin-users-routes unit tests)
+ * 3. directory_admit_activated / pending — createDirectoryAdmittedUserInTransaction
+ * 4. dingtalk_jit — createProvisionedUser real email/mobile + users.mobile persist
+ * 5. helper profile mobile + concurrent FOR UPDATE barrier — proves stale prior cannot
+ *    be retired across concurrent writers; HTTP PATCH profile hook is in unit harness
+ *
+ * Production route hooks for admin create/profile are NOT claimed green by this file alone.
+ */
+import { afterAll, beforeEach, describe, expect, it } from 'vitest'
+import { Pool } from 'pg'
+import { AuthService } from '../../src/auth/AuthService'
+import { __dingtalkOAuthInternalsForTests } from '../../src/auth/dingtalk-oauth'
+import {
+  applyMobileLoginAliasChangeOrThrow,
+  claimNonEmptyLoginAliasesOrThrow,
+  LoginAliasClaimError,
+} from '../../src/auth/login-alias-service'
+import { normalizeLoginIdentifier } from '../../src/auth/login-identifier'
+import { query, transaction } from '../../src/db/pg'
+import { __directorySyncInternalsForTests } from '../../src/directory/directory-sync'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
+const NS = `alias-writers-${Date.now()}`
+const createdUserIds: string[] = []
+const createdIntegrationIds: string[] = []
+
+async function cleanup() {
+  for (const uid of createdUserIds.splice(0, createdUserIds.length)) {
+    await query(`DELETE FROM user_login_aliases WHERE user_id = $1`, [uid])
+    await query(`DELETE FROM user_permissions WHERE user_id = $1`, [uid])
+    await query(`DELETE FROM user_roles WHERE user_id = $1`, [uid])
+    await query(`DELETE FROM user_orgs WHERE user_id = $1`, [uid])
+    await query(`DELETE FROM directory_account_links WHERE local_user_id = $1`, [uid])
+    await query(`DELETE FROM user_external_auth_grants WHERE local_user_id = $1`, [uid])
+    await query(`DELETE FROM user_external_identities WHERE local_user_id = $1`, [uid])
+    await query(`DELETE FROM users WHERE id = $1`, [uid])
+  }
+  for (const integ of createdIntegrationIds.splice(0, createdIntegrationIds.length)) {
+    await query(`DELETE FROM directory_account_links WHERE directory_account_id IN
+      (SELECT id FROM directory_accounts WHERE integration_id = $1::uuid)`, [integ])
+    await query(`DELETE FROM directory_accounts WHERE integration_id = $1::uuid`, [integ])
+    await query(`DELETE FROM directory_integrations WHERE id = $1::uuid`, [integ])
+  }
+}
+
+async function aliasRows(userId: string) {
+  const result = await query<{ kind: string; normalized_value: string; source: string }>(
+    `SELECT kind, normalized_value, source
+       FROM user_login_aliases
+      WHERE user_id = $1
+      ORDER BY kind, normalized_value`,
+    [userId],
+  )
+  return result.rows
+}
+
+async function userExists(userId: string): Promise<boolean> {
+  const result = await query(`SELECT 1 FROM users WHERE id = $1`, [userId])
+  return result.rows.length > 0
+}
+
+async function seedOccupyingAlias(normalized: string, kind: 'email' | 'username' | 'mobile' = 'email') {
+  const ownerId = `${NS}-owner-${kind}-${normalized.slice(0, 12).replace(/[^a-z0-9]/gi, '')}`
+  createdUserIds.push(ownerId)
+  await query(
+    `INSERT INTO users (id, email, name, password_hash, is_active, activation_status, local_password_set)
+     VALUES ($1, $2, 'Alias Owner', 'x', TRUE, 'activated', TRUE)
+     ON CONFLICT (id) DO NOTHING`,
+    [ownerId, `${ownerId}@owner.example`],
+  )
+  await query(
+    `INSERT INTO user_login_aliases (user_id, kind, normalized_value, source)
+     VALUES ($1, $2, $3, 'test_seed')
+     ON CONFLICT (normalized_value) DO NOTHING`,
+    [ownerId, kind, normalized],
+  )
+  return ownerId
+}
+
+/**
+ * Production-shaped mobile profile writer (lock → derive previous from lock → claim/update/retire).
+ * Mirrors PATCH /api/admin/users/:userId/profile mobile path so the concurrent barrier exercises
+ * the same ordering without HTTP.
+ */
+async function productionShapedProfileMobileChange(
+  client: { query: (sql: string, params?: unknown[]) => Promise<{ rows: Array<Record<string, unknown>> }> },
+  options: { userId: string; nextMobile: string | null },
+): Promise<void> {
+  const locked = await client.query(
+    `SELECT id, mobile FROM users WHERE id = $1 FOR UPDATE`,
+    [options.userId],
+  )
+  const row = locked.rows[0] as { id: string; mobile: string | null } | undefined
+  if (!row) {
+    throw Object.assign(new Error('User not found'), { code: 'NOT_FOUND' })
+  }
+  await applyMobileLoginAliasChangeOrThrow({
+    userId: options.userId,
+    previousMobile: row.mobile,
+    nextMobile: options.nextMobile,
+    source: 'admin_profile_mobile',
+    client,
+    afterNewClaim: async () => {
+      await client.query(
+        `UPDATE users SET mobile = $1, updated_at = NOW() WHERE id = $2`,
+        [options.nextMobile, options.userId],
+      )
+    },
+  })
+}
+
+describeIfDatabase('alias full-writer coverage (real Postgres)', () => {
+  beforeEach(async () => {
+    await cleanup()
+  })
+  afterAll(async () => {
+    await cleanup()
+  })
+
+  describe('1) auth_register (AuthService.register / createUser)', () => {
+    it('positive: register claims email alias row', async () => {
+      const email = `${NS}-reg@example.com`
+      const auth = new AuthService()
+      const user = await auth.register(email, 'AliasWriter1Pass!', 'Register Writer')
+      expect(user).toBeTruthy()
+      createdUserIds.push(user!.id)
+
+      const aliases = await aliasRows(user!.id)
+      expect(aliases.map((a) => a.normalized_value)).toContain(normalizeLoginIdentifier(email))
+      expect(aliases.some((a) => a.kind === 'email' && a.source === 'auth_register')).toBe(true)
+    })
+
+    it('conflict: rolls back users row when email alias is taken', async () => {
+      const email = `${NS}-reg-conflict@example.com`
+      const normalized = normalizeLoginIdentifier(email)!
+      await seedOccupyingAlias(normalized, 'email')
+
+      const auth = new AuthService()
+      const user = await auth.register(email, 'AliasWriter1Pass!', 'Conflict Register')
+      expect(user).toBeNull()
+
+      const orphans = await query(
+        `SELECT id FROM users WHERE lower(email) = lower($1)`,
+        [email],
+      )
+      expect(orphans.rows).toEqual([])
+    })
+  })
+
+  describe('2) helper claimNonEmptyLoginAliasesOrThrow transactional rollback (not the HTTP route)', () => {
+    it('positive: helper claims email/username/mobile inside a transaction', async () => {
+      const userId = `${NS}-admin-create`
+      createdUserIds.push(userId)
+      const email = `${NS}-admin@example.com`
+      const username = `${NS}_admin_user`
+      const mobile = '13700137001'
+
+      await transaction(async (client) => {
+        await client.query(
+          `INSERT INTO users (
+             id, email, username, name, mobile, password_hash, role, permissions,
+             is_active, activation_status, local_password_set, created_at, updated_at
+           ) VALUES (
+             $1, $2, $3, 'Admin Create', $4, 'x', 'user', '[]'::jsonb,
+             TRUE, 'activated', TRUE, NOW(), NOW()
+           )`,
+          [userId, email, username, mobile],
+        )
+        await claimNonEmptyLoginAliasesOrThrow({
+          userId,
+          email,
+          username,
+          mobile,
+          source: 'admin_create',
+          client,
+        })
+      })
+
+      const aliases = await aliasRows(userId)
+      expect(aliases.map((a) => a.normalized_value).sort()).toEqual(
+        [
+          normalizeLoginIdentifier(email),
+          normalizeLoginIdentifier(username),
+          normalizeLoginIdentifier(mobile),
+        ].sort(),
+      )
+    })
+
+    it('conflict: helper failure rolls back users insert when username alias is taken', async () => {
+      const userId = `${NS}-admin-conflict`
+      const username = `${NS}_taken_user`
+      await seedOccupyingAlias(normalizeLoginIdentifier(username)!, 'username')
+
+      await expect(
+        transaction(async (client) => {
+          await client.query(
+            `INSERT INTO users (
+               id, email, username, name, password_hash, role, permissions,
+               is_active, activation_status, local_password_set, created_at, updated_at
+             ) VALUES (
+               $1, $2, $3, 'Conflict', 'x', 'user', '[]'::jsonb,
+               TRUE, 'activated', TRUE, NOW(), NOW()
+             )`,
+            [userId, `${userId}@example.com`, username],
+          )
+          await claimNonEmptyLoginAliasesOrThrow({
+            userId,
+            email: `${userId}@example.com`,
+            username,
+            source: 'admin_create',
+            client,
+          })
+        }),
+      ).rejects.toBeInstanceOf(LoginAliasClaimError)
+
+      expect(await userExists(userId)).toBe(false)
+    })
+  })
+
+  describe('3) directory_admit activated vs pending', () => {
+    async function seedAccount(tag: string) {
+      const integ = await query<{ id: string }>(
+        `INSERT INTO directory_integrations (name, corp_id, org_id, status, default_deprovision_policy)
+         VALUES ($1, $2, $3, 'active', 'mark_inactive')
+         RETURNING id::text AS id`,
+        [`${NS}-${tag}`, `corp-${NS}-${tag}`, `org-${NS}-${tag}`],
+      )
+      const integrationId = integ.rows[0].id
+      createdIntegrationIds.push(integrationId)
+      const acct = await query<{ id: string }>(
+        `INSERT INTO directory_accounts (
+           integration_id, provider, corp_id, external_user_id, external_key,
+           name, email, mobile, union_id, open_id, is_active
+         )
+         SELECT id, 'dingtalk', corp_id, $2, $3, 'Admit Fixture', $4, $5, $6, $7, TRUE
+           FROM directory_integrations WHERE id = $1::uuid
+         RETURNING id::text AS id`,
+        [
+          integrationId,
+          `ext-${tag}`,
+          `dingtalk:${NS}:${tag}`,
+          `${NS}-${tag}@dir.example.com`,
+          '13600136001',
+          `union-${tag}`,
+          `open-${tag}`,
+        ],
+      )
+      return {
+        id: acct.rows[0].id,
+        integration_id: integrationId,
+        provider: 'dingtalk',
+        corp_id: `corp-${NS}-${tag}`,
+        external_user_id: `ext-${tag}`,
+        union_id: `union-${tag}`,
+        open_id: `open-${tag}`,
+        external_key: `dingtalk:${NS}:${tag}`,
+        name: 'Admit Fixture',
+        email: `${NS}-${tag}@dir.example.com`,
+        mobile: '13600136001',
+        is_active: true,
+      }
+    }
+
+    it('positive activated (pending flag OFF): claims aliases', async () => {
+      const prev = process.env.DIRECTORY_PENDING_ACTIVATION_ENABLED
+      delete process.env.DIRECTORY_PENDING_ACTIVATION_ENABLED
+      try {
+        const account = await seedAccount('act')
+        const { createDirectoryAdmittedUserInTransaction } = __directorySyncInternalsForTests
+        const created = await transaction(async (client) =>
+          createDirectoryAdmittedUserInTransaction(client, {
+            account: account as never,
+            adminUserId: 'admin-alias-test',
+            name: 'Admit Activated',
+            email: account.email,
+            username: `${NS}_dir_user`,
+            mobile: account.mobile,
+            passwordHash: 'x',
+            mustChangePassword: true,
+            enableDingTalkGrant: false,
+          }),
+        )
+        createdUserIds.push(created.userId)
+        const aliases = await aliasRows(created.userId)
+        expect(aliases.map((a) => a.normalized_value)).toEqual(
+          expect.arrayContaining([
+            normalizeLoginIdentifier(account.email),
+            normalizeLoginIdentifier(`${NS}_dir_user`),
+            normalizeLoginIdentifier(account.mobile),
+          ]),
+        )
+        expect(aliases.every((a) => a.source === 'directory_admit')).toBe(true)
+      } finally {
+        if (prev === undefined) delete process.env.DIRECTORY_PENDING_ACTIVATION_ENABLED
+        else process.env.DIRECTORY_PENDING_ACTIVATION_ENABLED = prev
+      }
+    })
+
+    it('pending_activation (flag ON): claims nothing', async () => {
+      const prev = process.env.DIRECTORY_PENDING_ACTIVATION_ENABLED
+      process.env.DIRECTORY_PENDING_ACTIVATION_ENABLED = '1'
+      try {
+        const account = await seedAccount('pend')
+        const { createDirectoryAdmittedUserInTransaction } = __directorySyncInternalsForTests
+        const created = await transaction(async (client) =>
+          createDirectoryAdmittedUserInTransaction(client, {
+            account: account as never,
+            adminUserId: 'admin-alias-test',
+            name: 'Admit Pending',
+            email: account.email,
+            username: `${NS}_dir_pending`,
+            mobile: account.mobile,
+            passwordHash: 'x',
+            mustChangePassword: true,
+            enableDingTalkGrant: false,
+          }),
+        )
+        createdUserIds.push(created.userId)
+        const status = await query<{ activation_status: string }>(
+          `SELECT activation_status FROM users WHERE id = $1`,
+          [created.userId],
+        )
+        expect(status.rows[0]?.activation_status).toBe('pending_activation')
+        expect(await aliasRows(created.userId)).toEqual([])
+      } finally {
+        if (prev === undefined) delete process.env.DIRECTORY_PENDING_ACTIVATION_ENABLED
+        else process.env.DIRECTORY_PENDING_ACTIVATION_ENABLED = prev
+      }
+    })
+
+    it('activated conflict: rolls back users + bind (no orphan)', async () => {
+      const prev = process.env.DIRECTORY_PENDING_ACTIVATION_ENABLED
+      delete process.env.DIRECTORY_PENDING_ACTIVATION_ENABLED
+      try {
+        const account = await seedAccount('conf')
+        const taken = normalizeLoginIdentifier(account.email)!
+        await seedOccupyingAlias(taken, 'email')
+
+        const { createDirectoryAdmittedUserInTransaction } = __directorySyncInternalsForTests
+        await expect(
+          transaction(async (client) =>
+            createDirectoryAdmittedUserInTransaction(client, {
+              account: account as never,
+              adminUserId: 'admin-alias-test',
+              name: 'Admit Conflict',
+              email: account.email,
+              username: `${NS}_dir_conflict`,
+              mobile: null,
+              passwordHash: 'x',
+              mustChangePassword: true,
+              enableDingTalkGrant: false,
+            }),
+          ),
+        ).rejects.toBeInstanceOf(LoginAliasClaimError)
+
+        const orphans = await query(
+          `SELECT id FROM users WHERE lower(email) = lower($1)`,
+          [account.email],
+        )
+        expect(orphans.rows).toEqual([])
+      } finally {
+        if (prev === undefined) delete process.env.DIRECTORY_PENDING_ACTIVATION_ENABLED
+        else process.env.DIRECTORY_PENDING_ACTIVATION_ENABLED = prev
+      }
+    })
+  })
+
+  describe('4) dingtalk_jit createProvisionedUser', () => {
+    it('positive: persists users.mobile and claims real email + mobile; never placeholder', async () => {
+      const { createProvisionedUser } = __dingtalkOAuthInternalsForTests
+      const email = `${NS}-dt@example.com`
+      const mobile = '13500135001'
+      const localUser = await createProvisionedUser({
+        unionId: `${NS}-union-real`,
+        nick: 'DT Real',
+        email,
+        mobile,
+      })
+      createdUserIds.push(localUser.id)
+
+      const userRow = await query<{ mobile: string | null; email: string }>(
+        `SELECT mobile, email FROM users WHERE id = $1`,
+        [localUser.id],
+      )
+      expect(userRow.rows[0]?.mobile).toBe(mobile)
+      expect(userRow.rows[0]?.email).toBe(email)
+
+      const aliases = await aliasRows(localUser.id)
+      expect(aliases.map((a) => a.normalized_value).sort()).toEqual(
+        [normalizeLoginIdentifier(email), normalizeLoginIdentifier(mobile)].sort(),
+      )
+      expect(aliases.every((a) => a.source === 'dingtalk_jit')).toBe(true)
+      expect(aliases.some((a) => a.normalized_value.includes('placeholder'))).toBe(false)
+    })
+
+    it('placeholder-only provision (no mobile): users.mobile null, zero alias rows', async () => {
+      const { createProvisionedUser } = __dingtalkOAuthInternalsForTests
+      const localUser = await createProvisionedUser({
+        unionId: `${NS}-union-ph`,
+        nick: 'DT Placeholder',
+        // no email / mobile → synthetic placeholder email on users.email
+      })
+      createdUserIds.push(localUser.id)
+      expect(localUser.email).toMatch(/@placeholder\.local$/i)
+
+      const userRow = await query<{ mobile: string | null; email: string }>(
+        `SELECT mobile, email FROM users WHERE id = $1`,
+        [localUser.id],
+      )
+      expect(userRow.rows[0]?.email).toMatch(/@placeholder\.local$/i)
+      expect(userRow.rows[0]?.mobile).toBeNull()
+      expect(await aliasRows(localUser.id)).toEqual([])
+    })
+
+    it('real email without mobile: users.mobile null, email alias only (no placeholder claim)', async () => {
+      const { createProvisionedUser } = __dingtalkOAuthInternalsForTests
+      const email = `${NS}-dt-email-only@example.com`
+      const localUser = await createProvisionedUser({
+        unionId: `${NS}-union-email-only`,
+        nick: 'DT Email Only',
+        email,
+      })
+      createdUserIds.push(localUser.id)
+
+      const userRow = await query<{ mobile: string | null }>(
+        `SELECT mobile FROM users WHERE id = $1`,
+        [localUser.id],
+      )
+      expect(userRow.rows[0]?.mobile).toBeNull()
+      const aliases = await aliasRows(localUser.id)
+      expect(aliases.map((a) => a.normalized_value)).toEqual([normalizeLoginIdentifier(email)])
+      expect(aliases.some((a) => a.kind === 'mobile')).toBe(false)
+    })
+
+    it('conflict: rolls back users row when real email alias taken', async () => {
+      const email = `${NS}-dt-conflict@example.com`
+      await seedOccupyingAlias(normalizeLoginIdentifier(email)!, 'email')
+      const { createProvisionedUser } = __dingtalkOAuthInternalsForTests
+
+      await expect(
+        createProvisionedUser({
+          unionId: `${NS}-union-conf`,
+          nick: 'DT Conflict',
+          email,
+        }),
+      ).rejects.toMatchObject({ code: 'auto_provision_alias_conflict' })
+
+      const orphans = await query(
+        `SELECT id FROM users WHERE lower(email) = lower($1)`,
+        [email],
+      )
+      expect(orphans.rows).toEqual([])
+    })
+  })
+
+  describe('5) profile mobile helper + concurrent FOR UPDATE barrier', () => {
+    it('positive: claims new mobile, updates row, retires prior owned alias only', async () => {
+      const userId = `${NS}-profile`
+      createdUserIds.push(userId)
+      const prior = '13400134001'
+      const next = '13400134002'
+      await query(
+        `INSERT INTO users (id, email, name, mobile, password_hash, is_active, activation_status, local_password_set)
+         VALUES ($1, $2, 'Profile User', $3, 'x', TRUE, 'activated', TRUE)`,
+        [userId, `${userId}@example.com`, prior],
+      )
+      await query(
+        `INSERT INTO user_login_aliases (user_id, kind, normalized_value, source)
+         VALUES ($1, 'mobile', $2, 'seed')`,
+        [userId, normalizeLoginIdentifier(prior)],
+      )
+      const otherId = `${NS}-profile-other`
+      createdUserIds.push(otherId)
+      await query(
+        `INSERT INTO users (id, email, name, mobile, password_hash, is_active, activation_status, local_password_set)
+         VALUES ($1, $2, 'Other', $3, 'x', TRUE, 'activated', TRUE)`,
+        [otherId, `${otherId}@example.com`, '13400134999'],
+      )
+      await query(
+        `INSERT INTO user_login_aliases (user_id, kind, normalized_value, source)
+         VALUES ($1, 'mobile', $2, 'seed')`,
+        [otherId, normalizeLoginIdentifier('13400134999')],
+      )
+
+      await transaction(async (client) => {
+        await productionShapedProfileMobileChange(client, { userId, nextMobile: next })
+      })
+
+      const mobile = await query<{ mobile: string }>(`SELECT mobile FROM users WHERE id = $1`, [userId])
+      expect(mobile.rows[0]?.mobile).toBe(next)
+      const aliases = await aliasRows(userId)
+      expect(aliases.map((a) => a.normalized_value)).toEqual([normalizeLoginIdentifier(next)])
+      const otherAliases = await aliasRows(otherId)
+      expect(otherAliases.map((a) => a.normalized_value)).toEqual([
+        normalizeLoginIdentifier('13400134999'),
+      ])
+    })
+
+    it('conflict: does not replace users.mobile when new mobile alias is taken', async () => {
+      const userId = `${NS}-profile-conf`
+      createdUserIds.push(userId)
+      const prior = '13300133001'
+      const next = '13300133002'
+      await query(
+        `INSERT INTO users (id, email, name, mobile, password_hash, is_active, activation_status, local_password_set)
+         VALUES ($1, $2, 'Profile Conflict', $3, 'x', TRUE, 'activated', TRUE)`,
+        [userId, `${userId}@example.com`, prior],
+      )
+      await query(
+        `INSERT INTO user_login_aliases (user_id, kind, normalized_value, source)
+         VALUES ($1, 'mobile', $2, 'seed')`,
+        [userId, normalizeLoginIdentifier(prior)],
+      )
+      await seedOccupyingAlias(normalizeLoginIdentifier(next)!, 'mobile')
+
+      await expect(
+        transaction(async (client) => {
+          await productionShapedProfileMobileChange(client, { userId, nextMobile: next })
+        }),
+      ).rejects.toBeInstanceOf(LoginAliasClaimError)
+
+      const mobile = await query<{ mobile: string }>(`SELECT mobile FROM users WHERE id = $1`, [userId])
+      expect(mobile.rows[0]?.mobile).toBe(prior)
+      const aliases = await aliasRows(userId)
+      expect(aliases.map((a) => a.normalized_value)).toEqual([normalizeLoginIdentifier(prior)])
+    })
+
+    it('concurrent barrier: FOR UPDATE derives previous from lock so stale retire cannot orphan intermediate alias', async () => {
+      const userId = `${NS}-profile-race`
+      createdUserIds.push(userId)
+      const m1 = '13200132001'
+      const m2 = '13200132002'
+      const m3 = '13200132003'
+      await query(
+        `INSERT INTO users (id, email, name, mobile, password_hash, is_active, activation_status, local_password_set)
+         VALUES ($1, $2, 'Race User', $3, 'x', TRUE, 'activated', TRUE)`,
+        [userId, `${userId}@example.com`, m1],
+      )
+      await query(
+        `INSERT INTO user_login_aliases (user_id, kind, normalized_value, source)
+         VALUES ($1, 'mobile', $2, 'seed')`,
+        [userId, normalizeLoginIdentifier(m1)],
+      )
+
+      const pool = new Pool({ connectionString: process.env.DATABASE_URL })
+      const holder = await pool.connect()
+      const waiter = await pool.connect()
+
+      // Pin the barrier to this two-connection chain only — never any other
+      // Lock-waiting FOR UPDATE in the database (unrelated concurrent tests).
+      const holderPid = holder.processID
+      const waiterPid = waiter.processID
+      expect(typeof holderPid).toBe('number')
+      expect(typeof waiterPid).toBe('number')
+      expect(holderPid).toBeGreaterThan(0)
+      expect(waiterPid).toBeGreaterThan(0)
+      expect(holderPid).not.toBe(waiterPid)
+
+      async function waitForWaiterBlockedByHolder(): Promise<void> {
+        for (let attempt = 0; attempt < 100; attempt += 1) {
+          const result = await pool.query<{ blocked: boolean }>(
+            `SELECT EXISTS (
+               SELECT 1
+                 FROM pg_stat_activity a
+                WHERE a.pid = $1::int
+                  AND a.wait_event_type = 'Lock'
+                  AND $2::int = ANY (pg_blocking_pids(a.pid))
+             ) AS blocked`,
+            [waiterPid, holderPid],
+          )
+          if (result.rows[0]?.blocked === true) return
+          await new Promise((resolve) => setTimeout(resolve, 20))
+        }
+        throw new Error(
+          `timed out waiting for waiter pid=${waiterPid} Lock-blocked by holder pid=${holderPid}`,
+        )
+      }
+
+      try {
+        // Client A (holder): lock the row with the original mobile still visible.
+        await holder.query('BEGIN')
+        await holder.query(`SELECT id, mobile FROM users WHERE id = $1 FOR UPDATE`, [userId])
+
+        // Client B (waiter): production-shaped mobile change to m3 — blocks on FOR UPDATE.
+        // If it used a STALE previous=m1 (pre-txn snapshot), after A commits m1→m2 it would
+        // claim m3, update to m3, and retire m1 (already gone) — leaving m2 orphaned.
+        const waiterPromise = (async () => {
+          await waiter.query('BEGIN')
+          await productionShapedProfileMobileChange(waiter, { userId, nextMobile: m3 })
+          await waiter.query('COMMIT')
+        })()
+
+        await waitForWaiterBlockedByHolder()
+
+        // While B is blocked, A performs an intermediate mobile write m1→m2 (with aliases).
+        await applyMobileLoginAliasChangeOrThrow({
+          userId,
+          previousMobile: m1,
+          nextMobile: m2,
+          source: 'concurrent_intermediate',
+          client: holder,
+          afterNewClaim: async () => {
+            await holder.query(
+              `UPDATE users SET mobile = $1, updated_at = NOW() WHERE id = $2`,
+              [m2, userId],
+            )
+          },
+        })
+        await holder.query('COMMIT')
+
+        await waiterPromise
+
+        const mobile = await query<{ mobile: string }>(
+          `SELECT mobile FROM users WHERE id = $1`,
+          [userId],
+        )
+        expect(mobile.rows[0]?.mobile).toBe(m3)
+
+        const aliases = await aliasRows(userId)
+        // Only m3 must remain. If B retired stale m1 instead of authoritative m2,
+        // m2 would still be present (the discriminating orphan).
+        expect(aliases.map((a) => a.normalized_value)).toEqual([normalizeLoginIdentifier(m3)])
+        expect(aliases.map((a) => a.normalized_value)).not.toContain(normalizeLoginIdentifier(m1))
+        expect(aliases.map((a) => a.normalized_value)).not.toContain(normalizeLoginIdentifier(m2))
+      } finally {
+        await holder.query('ROLLBACK').catch(() => undefined)
+        await waiter.query('ROLLBACK').catch(() => undefined)
+        holder.release()
+        waiter.release()
+        await pool.end()
+      }
+    })
+  })
+})

--- a/packages/core-backend/tests/unit/AuthService.test.ts
+++ b/packages/core-backend/tests/unit/AuthService.test.ts
@@ -8,10 +8,15 @@ const jwtMocks = vi.hoisted(() => ({
 
 const poolMocks = vi.hoisted(() => {
   const query = vi.fn()
+  // AuthService.createUser uses pool.transaction so alias claim + users insert roll back together.
+  const transaction = vi.fn(async (handler: (client: { query: typeof query }) => Promise<unknown>) =>
+    handler({ query }),
+  )
   return {
     query,
+    transaction,
     poolManager: {
-      get: () => ({ query, getInternalPool: () => null })
+      get: () => ({ query, transaction, getInternalPool: () => null })
     }
   }
 })
@@ -405,6 +410,11 @@ describe('AuthService.register', () => {
     jwtMocks.sign.mockReset()
     poolMocks.query.mockReset()
     poolMocks.query.mockResolvedValue({ rows: [] })
+    poolMocks.transaction.mockReset()
+    poolMocks.transaction.mockImplementation(
+      async (handler: (client: { query: typeof poolMocks.query }) => Promise<unknown>) =>
+        handler({ query: poolMocks.query }),
+    )
     rbacMocks.isAdmin.mockReset()
     rbacMocks.listUserPermissions.mockReset()
     secretManagerMocks.get.mockReset()
@@ -414,77 +424,92 @@ describe('AuthService.register', () => {
     sessionMocks.isUserSessionActive.mockReset()
   })
 
+  function mockRegisterQueries(opts: {
+    id: string
+    email: string
+    name: string
+    permissions: string[]
+  }) {
+    let createdId = opts.id
+    poolMocks.query.mockImplementation(async (sql: string, params?: unknown[]) => {
+      const text = String(sql)
+      if (text.includes('FROM users') && text.includes('lower(email)')) {
+        return { rows: [] }
+      }
+      if (text.includes('INSERT INTO users')) {
+        createdId = String(params?.[0] ?? opts.id)
+        return {
+          rows: [{
+            id: createdId,
+            email: opts.email,
+            name: opts.name,
+            role: 'user',
+            permissions: opts.permissions,
+            created_at: new Date('2026-04-03T00:00:00.000Z'),
+            updated_at: new Date('2026-04-03T00:00:00.000Z'),
+          }],
+        }
+      }
+      // claimLoginAlias: INSERT alias then SELECT owner
+      if (text.includes('INSERT INTO user_login_aliases')) return { rows: [] }
+      if (text.includes('SELECT user_id FROM user_login_aliases')) {
+        return { rows: [{ user_id: createdId }] }
+      }
+      if (text.includes('INSERT INTO user_permissions')) return { rows: [] }
+      if (text.includes('INSERT INTO user_roles')) return { rows: [] }
+      return { rows: [] }
+    })
+  }
+
   it('assigns attendance self-service permissions and role on attendance-mode registration', async () => {
     process.env.PRODUCT_MODE = 'attendance'
-    poolMocks.query
-      .mockResolvedValueOnce({ rows: [] })
-      .mockResolvedValueOnce({
-        rows: [{
-          id: 'user-1',
-          email: 'employee@example.com',
-          name: 'Employee',
-          role: 'user',
-          permissions: [
-            'spreadsheet:read',
-            'spreadsheet:write',
-            'spreadsheets:read',
-            'spreadsheets:write',
-            'attendance:read',
-            'attendance:write',
-          ],
-          created_at: new Date('2026-04-03T00:00:00.000Z'),
-          updated_at: new Date('2026-04-03T00:00:00.000Z'),
-        }],
-      })
-      .mockResolvedValueOnce({ rows: [] })
-      .mockResolvedValueOnce({ rows: [] })
+    mockRegisterQueries({
+      id: 'user-1',
+      email: 'employee@example.com',
+      name: 'Employee',
+      permissions: [
+        'spreadsheet:read',
+        'spreadsheet:write',
+        'spreadsheets:read',
+        'spreadsheets:write',
+        'attendance:read',
+        'attendance:write',
+      ],
+    })
     const auth = new AuthService()
     const user = await auth.register('employee@example.com', 'WelcomePass9A', 'Employee')
 
     expect(user).toBeTruthy()
     expect(user?.permissions).toEqual(expect.arrayContaining(['attendance:read', 'attendance:write']))
-    expect(poolMocks.query).toHaveBeenNthCalledWith(
-      4,
-      expect.stringContaining('INSERT INTO user_roles'),
-      [expect.any(String), 'attendance_employee'],
-    )
+    expect(poolMocks.transaction).toHaveBeenCalled()
+    expect(poolMocks.query.mock.calls.some(([sql]) => String(sql).includes('INSERT INTO user_login_aliases'))).toBe(true)
+    expect(poolMocks.query.mock.calls.some(([sql]) => String(sql).includes('INSERT INTO user_roles'))).toBe(true)
   })
 
   it('assigns attendance self-service permissions and role on platform registration', async () => {
     process.env.PRODUCT_MODE = 'platform'
-    poolMocks.query
-      .mockResolvedValueOnce({ rows: [] })
-      .mockResolvedValueOnce({
-        rows: [{
-          id: 'user-2',
-          email: 'platform@example.com',
-          name: 'Platform User',
-          role: 'user',
-          permissions: [
-            'spreadsheet:read',
-            'spreadsheet:write',
-            'spreadsheets:read',
-            'spreadsheets:write',
-            'attendance:read',
-            'attendance:write',
-          ],
-          created_at: new Date('2026-04-03T00:00:00.000Z'),
-          updated_at: new Date('2026-04-03T00:00:00.000Z'),
-        }],
-      })
-      .mockResolvedValueOnce({ rows: [] })
-      .mockResolvedValueOnce({ rows: [] })
+    mockRegisterQueries({
+      id: 'user-2',
+      email: 'platform@example.com',
+      name: 'Platform User',
+      permissions: [
+        'spreadsheet:read',
+        'spreadsheet:write',
+        'spreadsheets:read',
+        'spreadsheets:write',
+        'attendance:read',
+        'attendance:write',
+      ],
+    })
 
     const auth = new AuthService()
     const user = await auth.register('platform@example.com', 'WelcomePass9A', 'Platform User')
 
     expect(user).toBeTruthy()
     expect(user?.permissions).toEqual(expect.arrayContaining(['attendance:read', 'attendance:write']))
-    expect(poolMocks.query).toHaveBeenNthCalledWith(
-      4,
-      expect.stringContaining('INSERT INTO user_roles'),
-      [expect.any(String), 'attendance_employee'],
-    )
+    expect(poolMocks.transaction).toHaveBeenCalled()
+    expect(poolMocks.query.mock.calls.some(([sql]) => String(sql).includes('INSERT INTO user_login_aliases'))).toBe(true)
+    expect(poolMocks.query.mock.calls.some(([sql]) => String(sql).includes('INSERT INTO user_roles'))).toBe(true)
   })
 })
 

--- a/packages/core-backend/tests/unit/admin-users-routes.test.ts
+++ b/packages/core-backend/tests/unit/admin-users-routes.test.ts
@@ -79,6 +79,25 @@ vi.mock('../../src/db/pg', () => ({
     handler({ query: pgMocks.query })),
 }))
 
+// Alias full-writer hooks: default stubs keep existing create/profile once-chains green.
+// Dedicated load-bearing coverage lives in login-alias-writers*.test.ts (do not weaken those).
+const loginAliasWriterMocks = vi.hoisted(() => ({
+  claimNonEmptyLoginAliasesOrThrow: vi.fn(async () => []),
+  applyMobileLoginAliasChangeOrThrow: vi.fn(async (options: { afterNewClaim: () => Promise<void> }) => {
+    await options.afterNewClaim()
+    return { claimed: [], retiredNormalized: null }
+  }),
+}))
+
+vi.mock('../../src/auth/login-alias-service', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/auth/login-alias-service')>()
+  return {
+    ...actual,
+    claimNonEmptyLoginAliasesOrThrow: loginAliasWriterMocks.claimNonEmptyLoginAliasesOrThrow,
+    applyMobileLoginAliasChangeOrThrow: loginAliasWriterMocks.applyMobileLoginAliasChangeOrThrow,
+  }
+})
+
 vi.mock('../../src/rbac/service', () => ({
   isAdmin: rbacMocks.isAdmin,
   listUserPermissions: rbacMocks.listUserPermissions,
@@ -113,6 +132,7 @@ vi.mock('../../src/auth/dingtalk-oauth', () => ({
 
 vi.mock('../../src/attendance/w4c0-identity', () => attendanceW4Mocks)
 
+import { LoginAliasClaimError } from '../../src/auth/login-alias-service'
 import { adminUsersRouter } from '../../src/routes/admin-users'
 
 function createMockResponse() {
@@ -208,6 +228,15 @@ describe('admin-users routes', () => {
     }
     pgMocks.query.mockReset()
     pgMocks.query.mockResolvedValue({ rows: [] })
+    loginAliasWriterMocks.claimNonEmptyLoginAliasesOrThrow.mockReset()
+    loginAliasWriterMocks.claimNonEmptyLoginAliasesOrThrow.mockResolvedValue([])
+    loginAliasWriterMocks.applyMobileLoginAliasChangeOrThrow.mockReset()
+    loginAliasWriterMocks.applyMobileLoginAliasChangeOrThrow.mockImplementation(
+      async (options: { afterNewClaim: () => Promise<void> }) => {
+        await options.afterNewClaim()
+        return { claimed: [], retiredNormalized: null }
+      },
+    )
     rbacMocks.isAdmin.mockReset()
     rbacMocks.isAdmin.mockResolvedValue(false)
     rbacMocks.listUserPermissions.mockReset()
@@ -508,41 +537,31 @@ describe('admin-users routes', () => {
       .mockResolvedValueOnce(true)
       .mockResolvedValueOnce(false)
     rbacMocks.listUserPermissions.mockResolvedValue(['crm:admin'])
+    const profileRow = {
+      id: 'user-1',
+      email: 'alpha@example.com',
+      name: 'Alpha',
+      mobile: null as string | null,
+      employeeNo: null,
+      department: null,
+      position: null,
+      hireDate: null,
+      role: 'user',
+      is_active: true,
+      is_admin: false,
+      last_login_at: null,
+      created_at: '2026-03-12T00:00:00.000Z',
+      updated_at: '2026-03-12T00:00:00.000Z',
+    }
     pgMocks.query
+      .mockResolvedValueOnce({ rows: [{ ...profileRow }] }) // pre-read
+      .mockResolvedValueOnce({ rows: [{ ...profileRow }] }) // FOR UPDATE lock
+      .mockResolvedValueOnce({ rows: [{ id: 'user-1' }] }) // UPDATE
       .mockResolvedValueOnce({
         rows: [{
-          id: 'user-1',
-          email: 'alpha@example.com',
-          name: 'Alpha',
-          mobile: null,
-          employeeNo: null,
-          department: null,
-          position: null,
-          hireDate: null,
-          role: 'user',
-          is_active: true,
-          is_admin: false,
-          last_login_at: null,
-          created_at: '2026-03-12T00:00:00.000Z',
-          updated_at: '2026-03-12T00:00:00.000Z',
-        }],
-      })
-      .mockResolvedValueOnce({ rows: [{ id: 'user-1' }] })
-      .mockResolvedValueOnce({
-        rows: [{
-          id: 'user-1',
-          email: 'alpha@example.com',
+          ...profileRow,
           name: 'Alpha Prime',
           mobile: '13800138000',
-          employeeNo: null,
-          department: null,
-          position: null,
-          hireDate: null,
-          role: 'user',
-          is_active: true,
-          is_admin: false,
-          last_login_at: null,
-          created_at: '2026-03-12T00:00:00.000Z',
           updated_at: '2026-03-13T00:00:00.000Z',
         }],
       })
@@ -556,7 +575,8 @@ describe('admin-users routes', () => {
     })
 
     expect(response.statusCode).toBe(200)
-    expect(pgMocks.query).toHaveBeenNthCalledWith(2,
+    expect(String(pgMocks.query.mock.calls[1]?.[0] || '')).toMatch(/FOR UPDATE/)
+    expect(pgMocks.query).toHaveBeenNthCalledWith(3,
       expect.stringContaining('UPDATE users'),
       ['Alpha Prime', '13800138000', null, null, null, null, 'user-1', true, null],
     )
@@ -714,43 +734,28 @@ describe('admin-users routes', () => {
       .mockResolvedValueOnce(true)
       .mockResolvedValueOnce(false)
     rbacMocks.listUserPermissions.mockResolvedValue([])
+    const profileRow = {
+      id: 'user-1',
+      email: 'alpha@example.com',
+      name: 'Alpha',
+      mobile: '13800138000' as string | null,
+      employeeNo: null,
+      department: null,
+      position: null,
+      hireDate: null,
+      role: 'user',
+      is_active: true,
+      is_admin: false,
+      last_login_at: null,
+      created_at: '2026-03-12T00:00:00.000Z',
+      updated_at: '2026-03-12T00:00:00.000Z',
+    }
     pgMocks.query
-      .mockResolvedValueOnce({
-        rows: [{
-          id: 'user-1',
-          email: 'alpha@example.com',
-          name: 'Alpha',
-          mobile: '13800138000',
-          employeeNo: null,
-          department: null,
-          position: null,
-          hireDate: null,
-          role: 'user',
-          is_active: true,
-          is_admin: false,
-          last_login_at: null,
-          created_at: '2026-03-12T00:00:00.000Z',
-          updated_at: '2026-03-12T00:00:00.000Z',
-        }],
-      })
+      .mockResolvedValueOnce({ rows: [{ ...profileRow }] })
+      .mockResolvedValueOnce({ rows: [{ ...profileRow }] }) // FOR UPDATE
       .mockResolvedValueOnce({ rows: [{ id: 'user-1' }] })
       .mockResolvedValueOnce({
-        rows: [{
-          id: 'user-1',
-          email: 'alpha@example.com',
-          name: 'Alpha',
-          mobile: null,
-          employeeNo: null,
-          department: null,
-          position: null,
-          hireDate: null,
-          role: 'user',
-          is_active: true,
-          is_admin: false,
-          last_login_at: null,
-          created_at: '2026-03-12T00:00:00.000Z',
-          updated_at: '2026-03-13T00:00:00.000Z',
-        }],
+        rows: [{ ...profileRow, mobile: null, updated_at: '2026-03-13T00:00:00.000Z' }],
       })
       .mockResolvedValueOnce({
         rows: [],
@@ -762,7 +767,8 @@ describe('admin-users routes', () => {
     })
 
     expect(response.statusCode).toBe(200)
-    expect(pgMocks.query).toHaveBeenNthCalledWith(2,
+    expect(String(pgMocks.query.mock.calls[1]?.[0] || '')).toMatch(/FOR UPDATE/)
+    expect(pgMocks.query).toHaveBeenNthCalledWith(3,
       expect.stringContaining('UPDATE users'),
       ['Alpha', null, null, null, null, null, 'user-1', true, '13800138000'],
     )
@@ -777,43 +783,32 @@ describe('admin-users routes', () => {
       .mockResolvedValueOnce(true)
       .mockResolvedValueOnce(false)
     rbacMocks.listUserPermissions.mockResolvedValue([])
+    const profileRow = {
+      id: 'user-1',
+      email: 'alpha@example.com',
+      name: 'Alpha',
+      mobile: '138 0013 8000',
+      employeeNo: null,
+      department: null,
+      position: null,
+      hireDate: null,
+      role: 'user',
+      is_active: true,
+      is_admin: false,
+      last_login_at: null,
+      created_at: '2026-03-12T00:00:00.000Z',
+      updated_at: '2026-03-12T00:00:00.000Z',
+    }
     pgMocks.query
       // fetchUserProfile returns legacy dirty data with embedded whitespace.
-      .mockResolvedValueOnce({
-        rows: [{
-          id: 'user-1',
-          email: 'alpha@example.com',
-          name: 'Alpha',
-          mobile: '138 0013 8000',
-          employeeNo: null,
-          department: null,
-          position: null,
-          hireDate: null,
-          role: 'user',
-          is_active: true,
-          is_admin: false,
-          last_login_at: null,
-          created_at: '2026-03-12T00:00:00.000Z',
-          updated_at: '2026-03-12T00:00:00.000Z',
-        }],
-      })
+      .mockResolvedValueOnce({ rows: [{ ...profileRow }] })
+      .mockResolvedValueOnce({ rows: [{ ...profileRow }] }) // FOR UPDATE
       // UPDATE still matches because both sides are normalised in SQL.
       .mockResolvedValueOnce({ rows: [{ id: 'user-1' }] })
       .mockResolvedValueOnce({
         rows: [{
-          id: 'user-1',
-          email: 'alpha@example.com',
-          name: 'Alpha',
+          ...profileRow,
           mobile: '13800138000',
-          employeeNo: null,
-          department: null,
-          position: null,
-          hireDate: null,
-          role: 'user',
-          is_active: true,
-          is_admin: false,
-          last_login_at: null,
-          created_at: '2026-03-12T00:00:00.000Z',
           updated_at: '2026-03-13T00:00:00.000Z',
         }],
       })
@@ -825,7 +820,8 @@ describe('admin-users routes', () => {
     })
 
     expect(response.statusCode).toBe(200)
-    const updateCall = pgMocks.query.mock.calls[1]
+    expect(String(pgMocks.query.mock.calls[1]?.[0] || '')).toMatch(/FOR UPDATE/)
+    const updateCall = pgMocks.query.mock.calls[2]
     expect(String(updateCall[0])).toContain('regexp_replace')
     expect(String(updateCall[0])).toContain('IS NOT DISTINCT FROM')
     expect(updateCall[1]).toEqual(['Alpha', '13800138000', null, null, null, null, 'user-1', true, '13800138000'])
@@ -833,26 +829,26 @@ describe('admin-users routes', () => {
 
   it('returns 409 when expected mobile no longer matches current value', async () => {
     rbacMocks.isAdmin.mockResolvedValue(true)
+    const profileRow = {
+      id: 'user-1',
+      email: 'alpha@example.com',
+      name: 'Alpha',
+      mobile: '13600000000',
+      employeeNo: null,
+      department: null,
+      position: null,
+      hireDate: null,
+      role: 'user',
+      is_active: true,
+      is_admin: false,
+      last_login_at: null,
+      created_at: '2026-03-12T00:00:00.000Z',
+      updated_at: '2026-03-12T00:00:00.000Z',
+    }
     pgMocks.query
-      .mockResolvedValueOnce({
-        rows: [{
-          id: 'user-1',
-          email: 'alpha@example.com',
-          name: 'Alpha',
-          mobile: '13600000000',
-          employeeNo: null,
-          department: null,
-          position: null,
-          hireDate: null,
-          role: 'user',
-          is_active: true,
-          is_admin: false,
-          last_login_at: null,
-          created_at: '2026-03-12T00:00:00.000Z',
-          updated_at: '2026-03-12T00:00:00.000Z',
-        }],
-      })
-      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ ...profileRow }] })
+      .mockResolvedValueOnce({ rows: [{ ...profileRow }] }) // FOR UPDATE
+      .mockResolvedValueOnce({ rows: [] }) // CAS UPDATE fails
 
     const response = await invokeRoute('patch', '/api/admin/users/:userId/profile', {
       params: { userId: 'user-1' },
@@ -3173,6 +3169,285 @@ describe('admin-users routes', () => {
     expect(String((response.body as Record<string, any>).data.onboarding.acceptInviteUrl || '')).toBe('')
     expect(String((response.body as Record<string, any>).data.onboarding.inviteMessage)).toContain('账号：liqing')
     expect(inviteMocks.issueInviteToken).not.toHaveBeenCalled()
+  })
+
+  /**
+   * Load-bearing alias full-writer route hooks (admin_create / admin_profile_mobile).
+   * Removing claimNonEmptyLoginAliasesOrThrow / applyMobileLoginAliasChangeOrThrow from the
+   * production handlers, or swapping previousMobile back to the pre-txn snapshot, must red these.
+   */
+  it('POST /api/admin/users invokes claimNonEmptyLoginAliasesOrThrow with exact identifiers + txn client', async () => {
+    rbacMocks.isAdmin
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(false)
+    rbacMocks.listUserPermissions.mockResolvedValue([])
+    bcryptMocks.hash.mockResolvedValue('hashed-initial-password')
+    pgMocks.query.mockImplementation(async (sql: string) => {
+      const statement = String(sql)
+      if (statement.includes('SELECT id FROM users WHERE email')) return { rows: [] }
+      if (statement.includes('SELECT id FROM users WHERE lower(username)')) return { rows: [] }
+      if (statement.includes('SELECT id FROM users WHERE mobile')) return { rows: [] }
+      if (statement.includes('INSERT INTO users (')) return { rows: [] }
+      if (statement.includes('FROM users') && statement.includes('WHERE id = $1')) {
+        return {
+          rows: [{
+            id: 'user-new',
+            email: 'hook@example.com',
+            username: 'hookuser',
+            name: 'Hook User',
+            mobile: '13900139000',
+            role: 'user',
+            is_active: true,
+            is_admin: false,
+            last_login_at: null,
+            created_at: '2026-03-12T00:00:00.000Z',
+            updated_at: '2026-03-12T00:00:00.000Z',
+          }],
+        }
+      }
+      if (statement.includes('FROM user_roles')) return { rows: [] }
+      return { rows: [] }
+    })
+
+    const response = await invokeRoute('post', '/api/admin/users', {
+      body: {
+        email: 'hook@example.com',
+        username: 'hookuser',
+        mobile: '13900139000',
+        name: 'Hook User',
+        password: 'WelcomePass9A',
+        isActive: true,
+      },
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(loginAliasWriterMocks.claimNonEmptyLoginAliasesOrThrow).toHaveBeenCalledTimes(1)
+    expect(loginAliasWriterMocks.claimNonEmptyLoginAliasesOrThrow).toHaveBeenCalledWith(
+      expect.objectContaining({
+        email: 'hook@example.com',
+        username: 'hookuser',
+        mobile: '13900139000',
+        source: 'admin_create',
+        client: expect.objectContaining({ query: expect.any(Function) }),
+        userId: expect.any(String),
+      }),
+    )
+  })
+
+  it('POST /api/admin/users maps LoginAliasClaimError ALIAS_CONFLICT to safe 409', async () => {
+    rbacMocks.isAdmin.mockResolvedValue(true)
+    bcryptMocks.hash.mockResolvedValue('hashed-initial-password')
+    pgMocks.query.mockImplementation(async (sql: string) => {
+      const statement = String(sql)
+      if (statement.includes('SELECT id FROM users')) return { rows: [] }
+      if (statement.includes('INSERT INTO users (')) return { rows: [] }
+      return { rows: [] }
+    })
+    loginAliasWriterMocks.claimNonEmptyLoginAliasesOrThrow.mockRejectedValueOnce(
+      new LoginAliasClaimError('ALIAS_CONFLICT', 'email'),
+    )
+
+    const response = await invokeRoute('post', '/api/admin/users', {
+      body: {
+        email: 'taken@example.com',
+        name: 'Taken',
+        password: 'WelcomePass9A',
+        isActive: true,
+      },
+    })
+
+    expect(response.statusCode).toBe(409)
+    const body = response.body as Record<string, any>
+    expect(body.error?.code).toBe('LOGIN_ALIAS_CONFLICT')
+    expect(String(body.error?.message || '')).toBe('A login identifier is already claimed by another account')
+    expect(JSON.stringify(body)).not.toMatch(/DETAIL|duplicate key|5432|relation/i)
+  })
+
+  it('POST /api/admin/users maps LoginAliasClaimError ALIAS_WRITE_FAILED to safe 500', async () => {
+    rbacMocks.isAdmin.mockResolvedValue(true)
+    bcryptMocks.hash.mockResolvedValue('hashed-initial-password')
+    pgMocks.query.mockImplementation(async (sql: string) => {
+      const statement = String(sql)
+      if (statement.includes('SELECT id FROM users')) return { rows: [] }
+      if (statement.includes('INSERT INTO users (')) return { rows: [] }
+      return { rows: [] }
+    })
+    loginAliasWriterMocks.claimNonEmptyLoginAliasesOrThrow.mockRejectedValueOnce(
+      new LoginAliasClaimError('ALIAS_WRITE_FAILED', 'email'),
+    )
+
+    const response = await invokeRoute('post', '/api/admin/users', {
+      body: {
+        email: 'fail@example.com',
+        name: 'Fail',
+        password: 'WelcomePass9A',
+        isActive: true,
+      },
+    })
+
+    expect(response.statusCode).toBe(500)
+    const body = response.body as Record<string, any>
+    expect(body.error?.code).toBe('LOGIN_ALIAS_FAILED')
+    expect(String(body.error?.message || '')).toBe('Failed to claim login alias')
+    expect(JSON.stringify(body)).not.toMatch(/DETAIL|connection refused|5432/i)
+  })
+
+  it('PATCH profile mobile locks row FOR UPDATE and passes locked previousMobile to alias helper', async () => {
+    rbacMocks.isAdmin
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(false)
+    rbacMocks.listUserPermissions.mockResolvedValue([])
+    // Pre-read is intentionally STALE (null) vs locked row (13800138000).
+    // Using profile.mobile for retire would pass null; production must use the lock.
+    const stalePreRead = {
+      id: 'user-1',
+      email: 'alpha@example.com',
+      name: 'Alpha',
+      mobile: null as string | null,
+      employeeNo: null,
+      department: null,
+      position: null,
+      hireDate: null,
+      role: 'user',
+      is_active: true,
+      is_admin: false,
+      last_login_at: null,
+      created_at: '2026-03-12T00:00:00.000Z',
+      updated_at: '2026-03-12T00:00:00.000Z',
+    }
+    const lockedRow = { ...stalePreRead, mobile: '13800138000' }
+    pgMocks.query
+      .mockResolvedValueOnce({ rows: [{ ...stalePreRead }] })
+      .mockResolvedValueOnce({ rows: [{ ...lockedRow }] }) // FOR UPDATE
+      .mockResolvedValueOnce({ rows: [{ id: 'user-1' }] }) // UPDATE
+      .mockResolvedValueOnce({
+        rows: [{ ...lockedRow, mobile: '13900139000', updated_at: '2026-03-13T00:00:00.000Z' }],
+      })
+      .mockResolvedValueOnce({ rows: [] })
+
+    const response = await invokeRoute('patch', '/api/admin/users/:userId/profile', {
+      params: { userId: 'user-1' },
+      body: { mobile: '13900139000' },
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(String(pgMocks.query.mock.calls[1]?.[0] || '')).toMatch(/FOR UPDATE/)
+    expect(loginAliasWriterMocks.applyMobileLoginAliasChangeOrThrow).toHaveBeenCalledTimes(1)
+    expect(loginAliasWriterMocks.applyMobileLoginAliasChangeOrThrow).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: 'user-1',
+        previousMobile: '13800138000', // from lock, NOT stale null pre-read
+        nextMobile: '13900139000',
+        source: 'admin_profile_mobile',
+        client: expect.objectContaining({ query: expect.any(Function) }),
+        afterNewClaim: expect.any(Function),
+      }),
+    )
+  })
+
+  it('PATCH profile mobile maps LoginAliasClaimError ALIAS_CONFLICT to safe 409', async () => {
+    rbacMocks.isAdmin.mockResolvedValue(true)
+    const profileRow = {
+      id: 'user-1',
+      email: 'alpha@example.com',
+      name: 'Alpha',
+      mobile: '13800138000',
+      employeeNo: null,
+      department: null,
+      position: null,
+      hireDate: null,
+      role: 'user',
+      is_active: true,
+      is_admin: false,
+      last_login_at: null,
+      created_at: '2026-03-12T00:00:00.000Z',
+      updated_at: '2026-03-12T00:00:00.000Z',
+    }
+    pgMocks.query
+      .mockResolvedValueOnce({ rows: [{ ...profileRow }] })
+      .mockResolvedValueOnce({ rows: [{ ...profileRow }] })
+    loginAliasWriterMocks.applyMobileLoginAliasChangeOrThrow.mockRejectedValueOnce(
+      new LoginAliasClaimError('ALIAS_CONFLICT', 'mobile'),
+    )
+
+    const response = await invokeRoute('patch', '/api/admin/users/:userId/profile', {
+      params: { userId: 'user-1' },
+      body: { mobile: '13900139000' },
+    })
+
+    expect(response.statusCode).toBe(409)
+    const body = response.body as Record<string, any>
+    expect(body.error?.code).toBe('LOGIN_ALIAS_CONFLICT')
+    expect(JSON.stringify(body)).not.toMatch(/DETAIL|duplicate key|5432/i)
+  })
+
+  it('PATCH profile mobile maps LoginAliasClaimError ALIAS_WRITE_FAILED to safe 500', async () => {
+    rbacMocks.isAdmin.mockResolvedValue(true)
+    const profileRow = {
+      id: 'user-1',
+      email: 'alpha@example.com',
+      name: 'Alpha',
+      mobile: '13800138000',
+      employeeNo: null,
+      department: null,
+      position: null,
+      hireDate: null,
+      role: 'user',
+      is_active: true,
+      is_admin: false,
+      last_login_at: null,
+      created_at: '2026-03-12T00:00:00.000Z',
+      updated_at: '2026-03-12T00:00:00.000Z',
+    }
+    pgMocks.query
+      .mockResolvedValueOnce({ rows: [{ ...profileRow }] })
+      .mockResolvedValueOnce({ rows: [{ ...profileRow }] })
+    loginAliasWriterMocks.applyMobileLoginAliasChangeOrThrow.mockRejectedValueOnce(
+      new LoginAliasClaimError('ALIAS_WRITE_FAILED', 'mobile'),
+    )
+
+    const response = await invokeRoute('patch', '/api/admin/users/:userId/profile', {
+      params: { userId: 'user-1' },
+      body: { mobile: '13900139000' },
+    })
+
+    expect(response.statusCode).toBe(500)
+    const body = response.body as Record<string, any>
+    expect(body.error?.code).toBe('LOGIN_ALIAS_FAILED')
+    expect(JSON.stringify(body)).not.toMatch(/DETAIL|connection refused|5432/i)
+  })
+
+  it('PATCH profile mobile returns 404 when locked row is missing', async () => {
+    rbacMocks.isAdmin.mockResolvedValue(true)
+    pgMocks.query
+      .mockResolvedValueOnce({
+        rows: [{
+          id: 'user-1',
+          email: 'alpha@example.com',
+          name: 'Alpha',
+          mobile: '13800138000',
+          employeeNo: null,
+          department: null,
+          position: null,
+          hireDate: null,
+          role: 'user',
+          is_active: true,
+          is_admin: false,
+          last_login_at: null,
+          created_at: '2026-03-12T00:00:00.000Z',
+          updated_at: '2026-03-12T00:00:00.000Z',
+        }],
+      })
+      .mockResolvedValueOnce({ rows: [] }) // FOR UPDATE: gone
+
+    const response = await invokeRoute('patch', '/api/admin/users/:userId/profile', {
+      params: { userId: 'user-1' },
+      body: { mobile: '13900139000' },
+    })
+
+    expect(response.statusCode).toBe(404)
+    expect((response.body as Record<string, any>).error?.code).toBe('NOT_FOUND')
+    expect(loginAliasWriterMocks.applyMobileLoginAliasChangeOrThrow).not.toHaveBeenCalled()
   })
 
   it('resets password and returns temporary password', async () => {

--- a/packages/core-backend/tests/unit/dingtalk-oauth-login-gates.test.ts
+++ b/packages/core-backend/tests/unit/dingtalk-oauth-login-gates.test.ts
@@ -50,9 +50,33 @@ import {
   getDingTalkRuntimeStatus,
 } from '../../src/auth/dingtalk-oauth'
 
+const defaultTransactionStatements: string[] = []
+
 function createDefaultTransactionQuery() {
+  const aliasOwners = new Map<string, string>()
   return vi.fn(async (sql: string, params: unknown[] = []) => {
     const statement = String(sql)
+    defaultTransactionStatements.push(statement)
+    if (/INSERT INTO users/i.test(statement)) {
+      return {
+        rows: [{
+          id: String(params[0]),
+          email: String(params[1]),
+          name: String(params[2]),
+          role: 'user',
+          is_active: true,
+          activation_status: 'activated',
+        }],
+      }
+    }
+    if (/INSERT INTO user_login_aliases/i.test(statement)) {
+      aliasOwners.set(String(params[2]), String(params[0]))
+      return { rows: [] }
+    }
+    if (/SELECT user_id FROM user_login_aliases/i.test(statement)) {
+      const ownerId = aliasOwners.get(String(params[0]))
+      return { rows: ownerId ? [{ user_id: ownerId }] : [] }
+    }
     if (/FROM users[\s\S]*FOR UPDATE/i.test(statement)) {
       return {
         rows: [{
@@ -83,6 +107,7 @@ function createDefaultTransactionQuery() {
 describe('dingtalk oauth login gates', () => {
   beforeEach(async () => {
     vi.unstubAllEnvs()
+    defaultTransactionStatements.length = 0
     pgMocks.query.mockReset()
     pgMocks.transaction.mockReset()
     clientMocks.exchangeCodeForUserAccessToken.mockReset()
@@ -330,11 +355,13 @@ describe('dingtalk oauth login gates', () => {
     const result = await exchangeCodeForUser('code-5')
 
     expect(result).toMatchObject({
-      localUserId: 'user-new',
+      localUserId: expect.stringMatching(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+      ),
       localUserEmail: 'alpha@example.com',
       isNewUser: true,
     })
-    expect(pgMocks.query.mock.calls.some((call) => String(call[0]).includes('INSERT INTO users'))).toBe(true)
+    expect(defaultTransactionStatements.some((statement) => statement.includes('INSERT INTO users'))).toBe(true)
   })
 
   it('does not supersede evidence for an idempotent explicit bind', async () => {

--- a/packages/core-backend/tests/unit/dingtalk-oauth-state-store.test.ts
+++ b/packages/core-backend/tests/unit/dingtalk-oauth-state-store.test.ts
@@ -438,9 +438,20 @@ describe('DingTalk OAuth state store', () => {
       } as any)
       .mockResolvedValueOnce({ rows: [] } as any)
 
+    const txCalls: Array<[string, unknown[]]> = []
     vi.mocked(transaction).mockImplementation(async (callback: (client: { query: typeof query }) => Promise<unknown>) => {
+      const aliasOwners = new Map<string, string>()
       const clientQuery = vi.fn(async (sql: string, params: unknown[] = []) => {
+        txCalls.push([String(sql), params])
         const statement = String(sql)
+        if (/INSERT INTO user_login_aliases/i.test(statement)) {
+          aliasOwners.set(String(params[2] ?? ''), String(params[0] ?? ''))
+          return { rows: [] }
+        }
+        if (/SELECT user_id FROM user_login_aliases/i.test(statement)) {
+          const ownerId = aliasOwners.get(String(params[0] ?? ''))
+          return { rows: ownerId ? [{ user_id: ownerId }] : [] }
+        }
         if (/FROM users[\s\S]*FOR UPDATE/i.test(statement)) {
           return {
             rows: [{
@@ -452,6 +463,18 @@ describe('DingTalk OAuth state store', () => {
               activation_status: 'activated',
               is_active: true,
               access_generation: 0,
+            }],
+          }
+        }
+        if (/INSERT INTO users/i.test(statement)) {
+          return {
+            rows: [{
+              id: 'user-new',
+              email: 'dingtalk_open-id-1@placeholder.local',
+              name: 'Ding User',
+              role: 'user',
+              is_active: true,
+              activation_status: 'activated',
             }],
           }
         }
@@ -472,7 +495,11 @@ describe('DingTalk OAuth state store', () => {
     const result = await exchangeCodeForUser('auth-code')
 
     expect(result.localUserId).toBe('user-new')
-    expect(vi.mocked(query).mock.calls[1]?.[0]).toContain('password_hash')
-    expect(vi.mocked(query).mock.calls[1]?.[1]?.[3]).toMatch(/^\$2[aby]\$/)
+    // #4658 moved provisioning INSERTs into the alias-claiming transaction: the password-hash
+    // witness now lives on the transaction client, not the top-level query sequence.
+    const usersInsert = txCalls.find(([sql]) => /INSERT INTO users/i.test(sql) && sql.includes('password_hash'))
+    expect(usersInsert).toBeDefined()
+    const hashParam = (usersInsert?.[1] ?? []).find((p) => typeof p === 'string' && /^\$2[aby]\$/.test(p))
+    expect(hashParam).toBeDefined()
   })
 })

--- a/packages/core-backend/tests/unit/directory-sync-admission-orphan-guard.test.ts
+++ b/packages/core-backend/tests/unit/directory-sync-admission-orphan-guard.test.ts
@@ -18,10 +18,19 @@ const { createDirectoryAdmittedUserInTransaction } = __directorySyncInternalsFor
  */
 function fakeClient(account = CORP_ACCOUNT_WITHOUT_OPENID) {
   const queries: string[] = []
+  const aliasOwners = new Map<string, string>()
   return {
     queries,
-    query: async (sql: string) => {
+    query: async (sql: string, params?: unknown[]) => {
       queries.push(sql)
+      if (/INSERT INTO user_login_aliases/i.test(sql)) {
+        aliasOwners.set(String(params?.[2] ?? ''), String(params?.[0] ?? ''))
+        return { rows: [] as Array<Record<string, unknown>> }
+      }
+      if (/SELECT user_id FROM user_login_aliases/i.test(sql)) {
+        const ownerId = aliasOwners.get(String(params?.[0] ?? ''))
+        return { rows: (ownerId ? [{ user_id: ownerId }] : []) as Array<Record<string, unknown>> }
+      }
       if (/FROM directory_accounts account/.test(sql)) {
         return {
           rows: [{

--- a/packages/core-backend/tests/unit/directory-sync-bind-account.test.ts
+++ b/packages/core-backend/tests/unit/directory-sync-bind-account.test.ts
@@ -49,8 +49,17 @@ describe('bindDirectoryAccount', () => {
     accountOverrides: Record<string, unknown> = {},
     missingAccountIds: ReadonlySet<string> = new Set(),
   ): void {
+    const aliasOwners = new Map<string, string>()
     pgMocks.transaction.mockImplementation(async (handler) => handler({
       query: async (sql: string, params?: unknown[]) => {
+        if (/INSERT INTO user_login_aliases/i.test(String(sql))) {
+          aliasOwners.set(String(params?.[2] ?? ''), String(params?.[0] ?? ''))
+          return { rows: [] as Array<Record<string, unknown>> }
+        }
+        if (/SELECT user_id FROM user_login_aliases/i.test(String(sql))) {
+          const ownerId = aliasOwners.get(String(params?.[0] ?? ''))
+          return { rows: (ownerId ? [{ user_id: ownerId }] : []) as Array<Record<string, unknown>> }
+        }
         if (/FROM directory_accounts account\s+JOIN directory_integrations integration/.test(String(sql))) {
           const accountId = String(params?.[0] ?? 'account-1')
           if (missingAccountIds.has(accountId)) return { rows: [] }

--- a/packages/core-backend/tests/unit/directory-sync-pending-activation-default-off.test.ts
+++ b/packages/core-backend/tests/unit/directory-sync-pending-activation-default-off.test.ts
@@ -9,10 +9,19 @@ const { createDirectoryAdmittedUserInTransaction } = __directorySyncInternalsFor
  */
 function fakeClient() {
   const queries: Array<{ sql: string; params?: unknown[] }> = []
+  const aliasOwners = new Map<string, string>()
   return {
     queries,
     query: async (sql: string, params?: unknown[]) => {
       queries.push({ sql, params })
+      if (/INSERT INTO user_login_aliases/i.test(sql)) {
+        aliasOwners.set(String(params?.[2] ?? ''), String(params?.[0] ?? ''))
+        return { rows: [] as Array<Record<string, unknown>> }
+      }
+      if (/SELECT user_id FROM user_login_aliases/i.test(sql)) {
+        const ownerId = aliasOwners.get(String(params?.[0] ?? ''))
+        return { rows: (ownerId ? [{ user_id: ownerId }] : []) as Array<Record<string, unknown>> }
+      }
       if (/FROM directory_accounts account/.test(sql)) {
         return {
           rows: [{

--- a/packages/core-backend/tests/unit/login-alias-writers.test.ts
+++ b/packages/core-backend/tests/unit/login-alias-writers.test.ts
@@ -1,0 +1,339 @@
+/**
+ * Alias full-writer coverage — unit tests (design lock Rev 4.2 §4 + closeout P1 writers gap).
+ *
+ * Load-bearing mutation notes:
+ * - Remove claimNonEmptyLoginAliases / applyMobileLoginAliasChange from login-alias-service → these fail.
+ * - Remove each production writer hook (AuthService.createUser, POST /api/admin/users,
+ *   createDirectoryAdmittedUserInTransaction activated branch, createProvisionedUser real-id claims,
+ *   PATCH profile mobile applyMobileLoginAliasChangeOrThrow) → the matching dedicated test below
+ *   (or the real-DB suite) must fail.
+ *
+ * All lifecycle flags remain OFF; no T3 batch/SSO, deprovision, docs, env, or flag changes.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const pgMocks = vi.hoisted(() => ({
+  query: vi.fn(),
+}))
+
+vi.mock('../../src/db/pg', () => ({
+  query: pgMocks.query,
+  transaction: vi.fn(async (handler: (c: { query: typeof pgMocks.query }) => Promise<unknown>) =>
+    handler({ query: pgMocks.query }),
+  ),
+}))
+
+import {
+  applyMobileLoginAliasChange,
+  applyMobileLoginAliasChangeOrThrow,
+  claimNonEmptyLoginAliases,
+  claimNonEmptyLoginAliasesOrThrow,
+  LoginAliasClaimError,
+} from '../../src/auth/login-alias-service'
+import { normalizeLoginIdentifier } from '../../src/auth/login-identifier'
+
+describe('claimNonEmptyLoginAliases (reusable fail-closed helper)', () => {
+  beforeEach(() => {
+    pgMocks.query.mockReset()
+  })
+
+  it('claims non-empty email/username/mobile through normalizeLoginIdentifier + claimLoginAlias', async () => {
+    const client = { query: pgMocks.query }
+    const owner = 'u-writer-1'
+    pgMocks.query.mockImplementation(async (sql: string, params?: unknown[]) => {
+      const text = String(sql)
+      if (text.includes('INSERT INTO user_login_aliases')) return { rows: [] }
+      if (text.includes('SELECT user_id FROM user_login_aliases')) {
+        return { rows: [{ user_id: owner }] }
+      }
+      return { rows: [] }
+    })
+
+    const result = await claimNonEmptyLoginAliases({
+      userId: owner,
+      email: '  Bob@Example.COM ',
+      username: 'AliceUser',
+      mobile: '13800138000',
+      source: 'unit_helper',
+      client,
+    })
+
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.claimed.map((c) => c.normalized).sort()).toEqual(
+        [
+          normalizeLoginIdentifier('Bob@Example.COM'),
+          normalizeLoginIdentifier('AliceUser'),
+          normalizeLoginIdentifier('13800138000'),
+        ].sort(),
+      )
+    }
+    const insertParams = pgMocks.query.mock.calls
+      .filter(([sql]) => String(sql).includes('INSERT INTO user_login_aliases'))
+      .map(([, params]) => params)
+    expect(insertParams).toEqual(
+      expect.arrayContaining([
+        expect.arrayContaining([owner, 'email', 'bob@example.com', 'unit_helper']),
+        expect.arrayContaining([owner, 'username', 'aliceuser', 'unit_helper']),
+        expect.arrayContaining([owner, 'mobile', '+8613800138000', 'unit_helper']),
+      ]),
+    )
+  })
+
+  it('skips empty fields and does not require at least one claim', async () => {
+    const client = { query: pgMocks.query }
+    const result = await claimNonEmptyLoginAliases({
+      userId: 'u1',
+      email: '  ',
+      username: null,
+      mobile: undefined,
+      client,
+    })
+    expect(result).toEqual({ ok: true, claimed: [] })
+    expect(pgMocks.query).not.toHaveBeenCalled()
+  })
+
+  it('maps conflict without leaking raw PG text', async () => {
+    const client = { query: pgMocks.query }
+    pgMocks.query
+      .mockResolvedValueOnce({ rows: [] }) // INSERT
+      .mockResolvedValueOnce({ rows: [{ user_id: 'other-user' }] }) // SELECT owner
+
+    const result = await claimNonEmptyLoginAliases({
+      userId: 'u1',
+      email: 'taken@x.com',
+      client,
+    })
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.code).toBe('ALIAS_CONFLICT')
+      expect(result.message).toBe('A login identifier is already claimed by another account')
+      expect(result.message).not.toMatch(/DETAIL|duplicate key|5432|relation/i)
+    }
+  })
+
+  it('maps WRITE_FAILED without echoing claim.message driver text', async () => {
+    const client = { query: pgMocks.query }
+    pgMocks.query.mockRejectedValueOnce(
+      new Error('duplicate key value violates unique constraint "user_login_aliases" DETAIL: secret-pg'),
+    )
+
+    const result = await claimNonEmptyLoginAliases({
+      userId: 'u1',
+      email: 'a@x.com',
+      client,
+    })
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.code).toBe('ALIAS_WRITE_FAILED')
+      expect(result.message).toBe('Failed to claim login alias')
+      expect(result.message).not.toMatch(/DETAIL|secret-pg|duplicate key/i)
+    }
+  })
+
+  it('claimNonEmptyLoginAliasesOrThrow throws LoginAliasClaimError with safe message', async () => {
+    const client = { query: pgMocks.query }
+    pgMocks.query
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ user_id: 'other' }] })
+
+    let thrown: unknown
+    try {
+      await claimNonEmptyLoginAliasesOrThrow({ userId: 'u1', email: 'x@y.com', client })
+    } catch (error) {
+      thrown = error
+    }
+    expect(thrown).toBeInstanceOf(LoginAliasClaimError)
+    expect(thrown).toMatchObject({ code: 'ALIAS_CONFLICT' })
+    expect(String((thrown as Error).message)).not.toMatch(/DETAIL|secret|relation/i)
+  })
+})
+
+describe('applyMobileLoginAliasChange (profile mobile claim-then-replace)', () => {
+  beforeEach(() => {
+    pgMocks.query.mockReset()
+  })
+
+  it('claims new mobile before afterNewClaim and retires prior only when normalized values differ', async () => {
+    const client = { query: pgMocks.query }
+    const order: string[] = []
+    pgMocks.query.mockImplementation(async (sql: string) => {
+      const text = String(sql)
+      if (text.includes('INSERT INTO user_login_aliases')) {
+        order.push('claim_insert')
+        return { rows: [] }
+      }
+      if (text.includes('SELECT user_id FROM user_login_aliases')) {
+        order.push('claim_select')
+        return { rows: [{ user_id: 'u1' }] }
+      }
+      if (text.includes('DELETE FROM user_login_aliases')) {
+        order.push('delete_prior')
+        return { rows: [] }
+      }
+      return { rows: [] }
+    })
+
+    const result = await applyMobileLoginAliasChange({
+      userId: 'u1',
+      previousMobile: '13800138000',
+      nextMobile: '13900139000',
+      client,
+      afterNewClaim: async () => {
+        order.push('profile_update')
+      },
+    })
+
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.claimed).toEqual([
+        { kind: 'mobile', normalized: normalizeLoginIdentifier('13900139000') },
+      ])
+      expect(result.retiredNormalized).toBe(normalizeLoginIdentifier('13800138000'))
+    }
+    expect(order).toEqual(['claim_insert', 'claim_select', 'profile_update', 'delete_prior'])
+
+    const deleteCall = pgMocks.query.mock.calls.find(([sql]) =>
+      String(sql).includes('DELETE FROM user_login_aliases'),
+    )
+    expect(deleteCall?.[1]).toEqual([
+      'u1',
+      normalizeLoginIdentifier('13800138000'),
+    ])
+    // Ownership guard: DELETE always scopes user_id = this user.
+    expect(String(deleteCall?.[0])).toMatch(/user_id\s*=\s*\$1/)
+    expect(String(deleteCall?.[0])).toMatch(/kind\s*=\s*'mobile'/)
+  })
+
+  it('does not delete prior alias when normalized mobile is unchanged', async () => {
+    const client = { query: pgMocks.query }
+    const result = await applyMobileLoginAliasChange({
+      userId: 'u1',
+      previousMobile: '138 0013 8000',
+      nextMobile: '13800138000',
+      client,
+      afterNewClaim: async () => undefined,
+    })
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.claimed).toEqual([])
+      expect(result.retiredNormalized).toBeNull()
+    }
+    expect(pgMocks.query.mock.calls.some(([sql]) => String(sql).includes('DELETE'))).toBe(false)
+    expect(pgMocks.query.mock.calls.some(([sql]) => String(sql).includes('INSERT'))).toBe(false)
+  })
+
+  it('rolls back path: conflict before afterNewClaim (afterNewClaim not invoked)', async () => {
+    const client = { query: pgMocks.query }
+    let afterCalled = false
+    pgMocks.query
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ user_id: 'other' }] })
+
+    const result = await applyMobileLoginAliasChange({
+      userId: 'u1',
+      previousMobile: '13800138000',
+      nextMobile: '13900139000',
+      client,
+      afterNewClaim: async () => {
+        afterCalled = true
+      },
+    })
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.code).toBe('ALIAS_CONFLICT')
+      expect(result.message).not.toMatch(/DETAIL|duplicate/i)
+    }
+    expect(afterCalled).toBe(false)
+    expect(pgMocks.query.mock.calls.some(([sql]) => String(sql).includes('DELETE'))).toBe(false)
+  })
+
+  it('applyMobileLoginAliasChangeOrThrow surfaces LoginAliasClaimError', async () => {
+    const client = { query: pgMocks.query }
+    pgMocks.query
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ user_id: 'other' }] })
+
+    await expect(
+      applyMobileLoginAliasChangeOrThrow({
+        userId: 'u1',
+        previousMobile: null,
+        nextMobile: '13900139000',
+        client,
+        afterNewClaim: async () => undefined,
+      }),
+    ).rejects.toMatchObject({ code: 'ALIAS_CONFLICT', name: 'LoginAliasClaimError' })
+  })
+})
+
+describe('writer hook call contracts (load-bearing mutation notes)', () => {
+  /**
+   * Source-level pins: removing each production writer hook must red its dedicated case.
+   * Real-DB suite (`login-alias-writers.db.test.ts`) proves rows + rollback end-to-end.
+   */
+  it('AuthService.createUser wires claimNonEmptyLoginAliasesOrThrow (auth_register)', async () => {
+    const fs = await import('node:fs/promises')
+    const src = await fs.readFile(new URL('../../src/auth/AuthService.ts', import.meta.url), 'utf8')
+    expect(src).toMatch(/claimNonEmptyLoginAliasesOrThrow/)
+    expect(src).toMatch(/source:\s*'auth_register'/)
+    expect(src).toMatch(/pool\.transaction/)
+  })
+
+  it('POST /api/admin/users wires claimNonEmptyLoginAliasesOrThrow (admin_create)', async () => {
+    const fs = await import('node:fs/promises')
+    const src = await fs.readFile(new URL('../../src/routes/admin-users.ts', import.meta.url), 'utf8')
+    expect(src).toMatch(/claimNonEmptyLoginAliasesOrThrow/)
+    expect(src).toMatch(/source:\s*'admin_create'/)
+    expect(src).toMatch(/applyMobileLoginAliasChangeOrThrow/)
+    expect(src).toMatch(/source:\s*'admin_profile_mobile'/)
+  })
+
+  it('directory admit claims only when activationStatus=activated (directory_admit)', async () => {
+    const fs = await import('node:fs/promises')
+    const src = await fs.readFile(
+      new URL('../../src/directory/directory-sync.ts', import.meta.url),
+      'utf8',
+    )
+    expect(src).toMatch(/claimNonEmptyLoginAliasesOrThrow/)
+    expect(src).toMatch(/activationStatus === 'activated'/)
+    expect(src).toMatch(/source:\s*'directory_admit'/)
+  })
+
+  it('dingtalk JIT claims real identifiers only; never placeholder (dingtalk_jit)', async () => {
+    const fs = await import('node:fs/promises')
+    const src = await fs.readFile(new URL('../../src/auth/dingtalk-oauth.ts', import.meta.url), 'utf8')
+    expect(src).toMatch(/claimNonEmptyLoginAliasesOrThrow/)
+    expect(src).toMatch(/source:\s*'dingtalk_jit'/)
+    expect(src).toMatch(/isDingTalkPlaceholderEmail/)
+    expect(src).toMatch(/@placeholder\.local/)
+    // Placeholder email must not be passed as the email claim field.
+    expect(src).toMatch(/realEmail/)
+    expect(src).toMatch(/realMobile/)
+    // Real mobile must be persisted on users.mobile in the same INSERT as the claim.
+    expect(src).toMatch(/mobile, password_hash/)
+    expect(src).toMatch(/\[userId, email, name, realMobile, passwordHash\]/)
+  })
+
+  it('admin profile mobile path locks FOR UPDATE and derives previous from lock', async () => {
+    const fs = await import('node:fs/promises')
+    const src = await fs.readFile(new URL('../../src/routes/admin-users.ts', import.meta.url), 'utf8')
+    expect(src).toMatch(/applyMobileLoginAliasChangeOrThrow/)
+    expect(src).toMatch(/FOR UPDATE/)
+    expect(src).toMatch(/previousMobileFromLock/)
+    expect(src).toMatch(/previousMobile:\s*previousMobileFromLock/)
+    // Must not pass the pre-transaction profile.mobile into the retire path.
+    expect(src).not.toMatch(/previousMobile:\s*profile\.mobile/)
+  })
+
+  it('directory admit internals still export createDirectoryAdmittedUserInTransaction', async () => {
+    const { __directorySyncInternalsForTests } = await import('../../src/directory/directory-sync')
+    expect(typeof __directorySyncInternalsForTests.createDirectoryAdmittedUserInTransaction).toBe(
+      'function',
+    )
+  })
+
+  it('dingtalk OAuth internals still export createProvisionedUser', async () => {
+    const { __dingtalkOAuthInternalsForTests } = await import('../../src/auth/dingtalk-oauth')
+    expect(typeof __dingtalkOAuthInternalsForTests.createProvisionedUser).toBe('function')
+  })
+})

--- a/plugins/plugin-integration-core/lib/sealed-export/vectors/s6a-package-provenance-pins.json
+++ b/plugins/plugin-integration-core/lib/sealed-export/vectors/s6a-package-provenance-pins.json
@@ -86,6 +86,6 @@
     "s6aAcceptancePs51Test": "835c7c6ce943d82e0378a40a27c7fd1e8b79b526faa8ca4c8066e4231a4bfb0f",
     "s6aProductRuntimeTest": "de978adafa8b89772cefa921c2051f434bf346bf5c2978bef3424ee70f51ba3f",
     "multitableOnpremPackageBuild": "463c7d73c6c7f2d1b6cdf0820d7a06974a9c463dd5e98bbbaf1c996e1dc4ed99",
-    "pluginTestsWorkflow": "e86884d5366ea4cfb0291c671e399b3746f028ff0962b6495c18916f6b73159f"
+    "pluginTestsWorkflow": "9920e53278ff36aac7f2954219269a9c425df4ce84ee61238d49871507ff0837"
   }
 }


### PR DESCRIPTION
## Summary
- claim login aliases in every activated-user writer: self-register, admin create, directory admit, and DingTalk JIT
- make admin mobile changes claim/update/retire atomically from a locked users row
- keep pending activation alias-free and skip synthetic DingTalk placeholder emails
- add real-Postgres rollback and two-connection concurrency evidence plus CI wiring
- update the inherited DingTalk JIT unit transaction fixture to execute the new in-transaction users + alias writes instead of returning a false zero-row insert

## Verification
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/login-alias-writers.test.ts tests/unit/AuthService.test.ts tests/unit/admin-users-routes.test.ts tests/unit/dingtalk-oauth-login-gates.test.ts` (122 passed)
- `DATABASE_URL=... pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/login-alias-writers.db.test.ts` (14 passed)
- `pnpm --filter @metasheet/core-backend exec tsc --noEmit`
- mutation: remove auth-register alias hook -> 2 targeted real-DB failures
- mutation: remove DingTalk JIT alias hook -> 3 targeted real-DB failures
- mutation: remove admin profile `FOR UPDATE` -> route contract failure

## Posture
Draft and unarmed. All lifecycle flags remain OFF. Stacked on the D7 API/UI hardening branch; do not merge before its base.