### PR TITLE
fix(directory): make deprovision preview mirror apply

### DIFF
--- a/apps/web/src/components/directory/DirectoryDeprovisionEvidencePanel.vue
+++ b/apps/web/src/components/directory/DirectoryDeprovisionEvidencePanel.vue
@@ -70,6 +70,9 @@
       </div>
       <div v-if="preview" class="deprov-evidence__card" data-testid="deprovision-preview-result">
         <div>用户 {{ preview.user.id }} · activation={{ preview.user.activationStatus }} · is_active={{ preview.user.isActive }} · gen={{ preview.user.accessGeneration }}</div>
+        <div class="deprov-evidence__hint" data-testid="deprovision-preview-scope">
+          预演范围：当前集成下 {{ preview.prospectiveDeactivatedAccountIds.length }} 个 active linked account
+        </div>
         <div v-if="preview.plan.skipReason" class="deprov-evidence__hint">
           skipReason: {{ preview.plan.skipReason }}（零 effect）
         </div>
@@ -192,6 +195,7 @@ type PlannedEffect = {
 
 type PreviewPayload = {
   flags: DeprovisionFlags
+  prospectiveDeactivatedAccountIds: string[]
   user: {
     id: string
     activationStatus: string

--- a/apps/web/tests/DirectoryDeprovisionEvidencePanel.spec.ts
+++ b/apps/web/tests/DirectoryDeprovisionEvidencePanel.spec.ts
@@ -85,6 +85,7 @@ describe('DirectoryDeprovisionEvidencePanel (D7)', () => {
       if (String(url).includes('/deprovision/preview/')) {
         return jsonResponse({
           flags: { enabled: false, maxBatch: 25, policyNote: 'n' },
+          prospectiveDeactivatedAccountIds: ['account-1', 'account-2'],
           user: { id: 'u1', activationStatus: 'activated', isActive: true, accessGeneration: 2 },
           plan: {
             skipReason: null,
@@ -114,6 +115,7 @@ describe('DirectoryDeprovisionEvidencePanel (D7)', () => {
       && String(c[0]).includes('integrationId=int-1')
     ))).toBe(true)
     expect(root.querySelector('[data-testid="deprovision-preview-result"]')?.textContent).toMatch(/user_changed/)
+    expect(root.querySelector('[data-testid="deprovision-preview-scope"]')?.textContent).toMatch(/2 个/)
   })
 
   it('surfaces DRIFT_CONFLICT on restore failure', async () => {

--- a/packages/core-backend/src/directory/deprovision-evidence-api.ts
+++ b/packages/core-backend/src/directory/deprovision-evidence-api.ts
@@ -5,9 +5,9 @@
 import { query, transaction } from '../db/pg'
 import { invalidateUserPerms } from '../rbac/service'
 import {
-  planDirectoryDeprovision,
-  type DirectoryDeprovisionPolicy,
+  resolveLeastDestructiveDirectoryDeprovisionPolicy,
 } from './deprovision-planner'
+import { planDirectoryDeprovisionCandidate } from './deprovision-ledger'
 import {
   evaluateDeprovisionRestoreEligibility,
   type RestoreEffectView,
@@ -27,101 +27,130 @@ export function readDeprovisionRuntimeFlags() {
 }
 
 export async function previewDeprovisionForUser(localUserId: string, integrationId: string) {
-  const user = await query<{
-    id: string
-    activation_status: string | null
-    is_active: boolean
-    access_generation: number | null
-  }>(
-    `SELECT id,
-            COALESCE(activation_status, 'activated') AS activation_status,
-            COALESCE(is_active, TRUE) AS is_active,
-            COALESCE(access_generation, 0) AS access_generation
-       FROM users WHERE id = $1`,
-    [localUserId],
-  )
-  if (!user.rows[0]) {
-    const err = new Error('User not found')
-    ;(err as Error & { code?: string }).code = 'USER_NOT_FOUND'
-    throw err
-  }
-  const u = user.rows[0]
+  return transaction(async (client) => {
+    // Preview spans user, integration, account, sibling, membership and grant reads.
+    // A read-only repeatable snapshot prevents a mixed-time plan while sync is changing
+    // those rows. This must be the first statement in the transaction.
+    await client.query('SET TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY')
+    const read = async <T extends Record<string, unknown>>(
+      statement: string,
+      params?: unknown[],
+    ): Promise<{ rows: T[] }> => {
+      const result = await client.query(statement, params)
+      return { rows: result.rows as T[] }
+    }
 
-  const integration = await query<{ org_id: string; default_deprovision_policy: string }>(
-    `SELECT org_id, default_deprovision_policy
-       FROM directory_integrations
-      WHERE id = $1::uuid`,
-    [integrationId],
-  )
-  if (!integration.rows[0]) {
-    const err = new Error('Directory integration not found')
-    ;(err as Error & { code?: string }).code = 'INTEGRATION_NOT_FOUND'
-    throw err
-  }
-  const orgId = integration.rows[0].org_id
+    const user = await read<{
+      id: string
+      activation_status: string | null
+      is_active: boolean
+      access_generation: number | null
+    }>(
+      `SELECT id,
+              activation_status,
+              COALESCE(is_active, TRUE) AS is_active,
+              COALESCE(access_generation, 0) AS access_generation
+         FROM users
+        WHERE id = $1`,
+      [localUserId],
+    )
+    if (!user.rows[0]) {
+      const err = new Error('User not found')
+      ;(err as Error & { code?: string }).code = 'USER_NOT_FOUND'
+      throw err
+    }
+    const currentUser = user.rows[0]
 
-  const membership = await query<{ active: boolean }>(
-    `SELECT EXISTS (
-       SELECT 1 FROM user_orgs
-        WHERE user_id = $1 AND org_id = $2 AND COALESCE(is_active, TRUE) = TRUE
-     ) AS active`,
-    [localUserId, orgId],
-  )
+    const integration = await read<{
+      org_id: string
+      default_deprovision_policy: string
+    }>(
+      `SELECT org_id, default_deprovision_policy
+         FROM directory_integrations
+        WHERE id = $1::uuid`,
+      [integrationId],
+    )
+    if (!integration.rows[0]) {
+      const err = new Error('Directory integration not found')
+      ;(err as Error & { code?: string }).code = 'INTEGRATION_NOT_FOUND'
+      throw err
+    }
+    const orgId = integration.rows[0].org_id
 
-  // `user_external_auth_grants` is the table the OAuth login path reads. This used to read
-  // `user_external_identities.grant_enabled` — a column no migration creates — behind a `.catch`
-  // that turned the resulting error into "no grant", so the preview could never show a grant
-  // effect no matter what the truth was. No `.catch` either: a preview that cannot read the
-  // access graph must say so rather than quietly under-report what deprovision would take away.
-  const grant = await query<{ enabled: boolean }>(
-    `SELECT enabled
-       FROM user_external_auth_grants
-      WHERE local_user_id = $1 AND provider = 'dingtalk'
-      LIMIT 1`,
-    [localUserId],
-  )
-  const globalBinding = await query<{ active: boolean }>(
-    `SELECT EXISTS (
-       SELECT 1
-         FROM directory_account_links l
-         JOIN directory_accounts a ON a.id = l.directory_account_id
-        WHERE l.local_user_id = $1
-          AND l.link_status = 'linked'
-          AND a.is_active = TRUE
-          AND a.integration_id <> $2::uuid
-     ) AS active`,
-    [localUserId, integrationId],
-  )
+    const prospectiveAccounts = await read<{
+      id: string
+      deprovision_policy_override: string | null
+    }>(
+      `SELECT account.id::text AS id,
+              account.deprovision_policy_override
+         FROM directory_account_links link
+         JOIN directory_accounts account
+           ON account.id = link.directory_account_id
+        WHERE link.local_user_id = $1::text
+          AND link.link_status = 'linked'
+          AND account.integration_id = $2::uuid
+          AND account.is_active = TRUE
+        ORDER BY account.id`,
+      [localUserId, integrationId],
+    )
+    const prospectiveDeactivatedAccountIds = prospectiveAccounts.rows.map(
+      (account) => account.id,
+    )
+    const policy = resolveLeastDestructiveDirectoryDeprovisionPolicy(
+      integration.rows[0].default_deprovision_policy,
+      prospectiveAccounts.rows.map(
+        (account) => account.deprovision_policy_override,
+      ),
+    )
+    if (prospectiveDeactivatedAccountIds.length === 0) {
+      return {
+        flags: readDeprovisionRuntimeFlags(),
+        user: {
+          id: currentUser.id,
+          activationStatus: currentUser.activation_status,
+          isActive: currentUser.is_active,
+          accessGeneration: Number(currentUser.access_generation ?? 0),
+        },
+        prospectiveDeactivatedAccountIds,
+        plan: {
+          localUserId,
+          skipReason: 'no_active_linked_accounts',
+          effects: [],
+        },
+      }
+    }
 
-  const storedPolicy = integration.rows[0].default_deprovision_policy
-  const policy: DirectoryDeprovisionPolicy = [
-    'manual_review',
-    'disable_grant_only',
-    'mark_inactive',
-  ].includes(storedPolicy)
-    ? (storedPolicy as DirectoryDeprovisionPolicy)
-    : 'manual_review'
-  const plan = planDirectoryDeprovision({
-    localUserId,
-    policy,
-    activationStatus: u.activation_status,
-    isActive: u.is_active,
-    orgId,
-    orgMembershipActive: membership.rows[0]?.active === true,
-    dingtalkGrantEnabled: grant.rows[0]?.enabled === true,
-    globallyClear: globalBinding.rows[0]?.active !== true,
+    const { plan, snapshot } = await planDirectoryDeprovisionCandidate(
+      {
+        query: async (statement, params) => {
+          const result = await read<Record<string, unknown>>(statement, params)
+          return { rows: result.rows }
+        },
+      },
+      {
+        localUserId,
+        orgId,
+        integrationId,
+        directoryAccountId: prospectiveDeactivatedAccountIds[0],
+        policy,
+        write: false,
+        prospectiveDeactivatedAccountIds,
+        requireSourceInactive: false,
+      },
+    )
+
+    return {
+      flags: readDeprovisionRuntimeFlags(),
+      user: {
+        id: localUserId,
+        activationStatus: snapshot.activationStatus,
+        isActive: snapshot.isActive,
+        accessGeneration: snapshot.accessGeneration,
+      },
+      prospectiveDeactivatedAccountIds,
+      plan,
+    }
   })
-
-  return {
-    flags: readDeprovisionRuntimeFlags(),
-    user: {
-      id: u.id,
-      activationStatus: u.activation_status,
-      isActive: u.is_active,
-      accessGeneration: Number(u.access_generation ?? 0),
-    },
-    plan,
-  }
 }
 
 export async function listDeprovisionEvents(options: {

--- a/packages/core-backend/src/directory/deprovision-ledger.ts
+++ b/packages/core-backend/src/directory/deprovision-ledger.ts
@@ -32,6 +32,34 @@ export type ApplyDeprovisionCandidateInput = {
   write: boolean
 }
 
+export type PlanDeprovisionCandidateInput = Pick<
+  ApplyDeprovisionCandidateInput,
+  | 'localUserId'
+  | 'orgId'
+  | 'integrationId'
+  | 'directoryAccountId'
+  | 'policy'
+  | 'write'
+> & {
+  /**
+   * Active account ids the preview treats as deactivated together. Apply
+   * normally passes none because the sync transaction already flipped them.
+   */
+  prospectiveDeactivatedAccountIds?: string[]
+  requireSourceInactive?: boolean
+}
+
+export type DirectoryDeprovisionCandidateSnapshot = {
+  activationStatus: string | null
+  isActive: boolean
+  accessGeneration: number
+  linkedAtApply: boolean
+  orgMembershipActive: boolean
+  orgCandidacyClear: boolean
+  globallyClear: boolean
+  dingtalkGrantEnabled: boolean
+}
+
 export type ApplyDeprovisionCandidateResult = {
   applied: boolean
   eventId: string | null
@@ -88,8 +116,21 @@ async function lockCandidateUser(
 
 async function loadCandidateState(
   client: DirectoryTransactionClient,
-  input: ApplyDeprovisionCandidateInput,
+  input: PlanDeprovisionCandidateInput,
 ): Promise<CandidateStateRow | null> {
+  // #4659 preview-mirror inputs: the preview may model account deactivations the sync has not
+  // performed yet (prospective ids), and may relax the source-inactive requirement — apply
+  // always runs with the strict defaults. NEVER a lock here in either mode: the apply path
+  // takes the users FOR UPDATE mutex FIRST as its own statement (adversarial-review P1 — the
+  // lock and this read must not share a statement/snapshot), and preview locks nothing.
+  const prospectiveDeactivatedAccountIds = Array.from(
+    new Set(
+      (input.prospectiveDeactivatedAccountIds ?? [])
+        .map((accountId) => String(accountId || '').trim())
+        .filter(Boolean),
+    ),
+  )
+  const requireSourceInactive = input.requireSourceInactive !== false
   const result = await client.query(
     `SELECT
        candidate_user.activation_status,
@@ -106,7 +147,16 @@ async function loadCandidateState(
             AND source_link.local_user_id = candidate_user.id
             AND source_link.link_status = 'linked'
             AND source_account.integration_id = $3::uuid
-            AND source_account.is_active = FALSE
+            AND (
+              ($6::boolean = TRUE AND source_account.is_active = FALSE)
+              OR (
+                $6::boolean = FALSE
+                AND (
+                  source_account.is_active = FALSE
+                  OR source_account.id = ANY($5::uuid[])
+                )
+              )
+            )
             AND source_integration.org_id = $4::text
        ) AS linked_at_apply,
        EXISTS (
@@ -126,6 +176,7 @@ async function loadCandidateState(
           WHERE sibling_link.local_user_id = candidate_user.id
             AND sibling_link.link_status = 'linked'
             AND sibling.is_active = TRUE
+            AND sibling.id <> ALL($5::uuid[])
             AND sibling_integration.org_id = $4::text
        ) AS org_candidacy_clear,
        NOT EXISTS (
@@ -136,6 +187,7 @@ async function loadCandidateState(
           WHERE sibling_link.local_user_id = candidate_user.id
             AND sibling_link.link_status = 'linked'
             AND sibling.is_active = TRUE
+            AND sibling.id <> ALL($5::uuid[])
        ) AS globally_clear,
        COALESCE((
          SELECT grant_row.enabled
@@ -151,15 +203,59 @@ async function loadCandidateState(
       input.directoryAccountId,
       input.integrationId,
       input.orgId,
+      prospectiveDeactivatedAccountIds,
+      requireSourceInactive,
     ],
   )
-  // Adversarial review of #4647 (P2): a vanished user or a concurrently-unbound source account
-  // is a PER-CANDIDATE race, not a sync-level fault — throwing here aborted the entire directory
-  // sync run (and did so even with the deprovision flag OFF, a regression main's writer did not
-  // have). Both shapes now surface as null → the caller skips this candidate with a warning.
+  // Adversarial review of #4647 (P2): a vanished user is a PER-CANDIDATE race, not a sync-level
+  // fault — null here, and the APPLY caller skips with a warning (never aborts the run). The
+  // linked_at_apply decision is the caller's: apply treats an unlinked source as the same skip,
+  // while the PLAN path (#4659 preview) throws its coded error so the API can 4xx honestly.
   const row = result.rows[0] as CandidateStateRow | undefined
-  if (!row || !row.linked_at_apply) return null
+  if (!row) return null
   return row
+}
+
+export async function planDirectoryDeprovisionCandidate(
+  client: DirectoryTransactionClient,
+  input: PlanDeprovisionCandidateInput,
+): Promise<{
+  plan: DirectoryDeprovisionPlan
+  snapshot: DirectoryDeprovisionCandidateSnapshot
+}> {
+  const state = await loadCandidateState(client, input)
+  if (!state) {
+    throw new Error(`directory deprovision user not found: ${input.localUserId}`)
+  }
+  if (!state.linked_at_apply) {
+    throw new Error(
+      'directory deprovision source account is no longer linked to the candidate user',
+    )
+  }
+  const snapshot: DirectoryDeprovisionCandidateSnapshot = {
+    activationStatus: state.activation_status,
+    isActive: state.is_active,
+    accessGeneration: Number(state.access_generation),
+    linkedAtApply: state.linked_at_apply,
+    orgMembershipActive: state.org_membership_active,
+    orgCandidacyClear: state.org_candidacy_clear,
+    globallyClear: state.globally_clear,
+    dingtalkGrantEnabled: state.dingtalk_grant_enabled,
+  }
+  return {
+    snapshot,
+    plan: planDirectoryDeprovision({
+      localUserId: input.localUserId,
+      policy: input.policy,
+      activationStatus: snapshot.activationStatus,
+      isActive: snapshot.isActive,
+      orgId: input.orgId,
+      orgMembershipActive:
+        snapshot.orgMembershipActive && snapshot.orgCandidacyClear,
+      dingtalkGrantEnabled: snapshot.dingtalkGrantEnabled,
+      globallyClear: snapshot.globallyClear,
+    }),
+  }
 }
 
 async function writeEffects(
@@ -209,7 +305,7 @@ export async function applyDirectoryDeprovisionCandidate(
     }
   }
   const state = await loadCandidateState(client, input)
-  if (!state) {
+  if (!state || !state.linked_at_apply) {
     return {
       applied: false,
       eventId: null,

--- a/packages/core-backend/src/directory/deprovision-planner.ts
+++ b/packages/core-backend/src/directory/deprovision-planner.ts
@@ -11,6 +11,74 @@ export type DirectoryDeprovisionPolicy =
   | 'disable_grant_only'
   | 'mark_inactive'
 
+export const DIRECTORY_DEPROVISION_POLICIES: readonly DirectoryDeprovisionPolicy[] = [
+  'manual_review',
+  'disable_grant_only',
+  'mark_inactive',
+]
+
+const DIRECTORY_DEPROVISION_POLICY_SEVERITY: Record<
+  DirectoryDeprovisionPolicy,
+  number
+> = {
+  manual_review: 0,
+  disable_grant_only: 1,
+  mark_inactive: 2,
+}
+
+/**
+ * Unknown stored values fail closed to review-only. When several source
+ * accounts are deactivated together, the least-destructive policy wins.
+ */
+export function resolveDirectoryDeprovisionPolicy(
+  integrationDefault: string | null | undefined,
+  accountOverride: string | null | undefined,
+): DirectoryDeprovisionPolicy {
+  const override = String(accountOverride ?? '').trim()
+  const fallback = String(integrationDefault ?? '').trim()
+  const candidate = override || fallback
+  return (DIRECTORY_DEPROVISION_POLICIES as readonly string[]).includes(candidate)
+    ? (candidate as DirectoryDeprovisionPolicy)
+    : 'manual_review'
+}
+
+export function resolveLeastDestructiveDirectoryDeprovisionPolicy(
+  integrationDefault: string | null | undefined,
+  accountOverrides: Array<string | null | undefined>,
+): DirectoryDeprovisionPolicy {
+  const resolved = accountOverrides.length > 0
+    ? accountOverrides.map((override) =>
+        resolveDirectoryDeprovisionPolicy(integrationDefault, override),
+      )
+    : [
+        resolveDirectoryDeprovisionPolicy(
+          integrationDefault,
+          undefined,
+        ),
+      ]
+  return selectLeastDestructiveDirectoryDeprovisionPolicy(resolved)
+}
+
+/**
+ * Select between policies that have already resolved their account overrides.
+ * Keep this distinct from the resolver above: the integration default is a
+ * fallback for an account without an override, not an extra veto candidate.
+ */
+export function selectLeastDestructiveDirectoryDeprovisionPolicy(
+  policies: readonly DirectoryDeprovisionPolicy[],
+): DirectoryDeprovisionPolicy {
+  let selected = policies[0] ?? 'manual_review'
+  for (const candidate of policies.slice(1)) {
+    if (
+      DIRECTORY_DEPROVISION_POLICY_SEVERITY[candidate]
+      < DIRECTORY_DEPROVISION_POLICY_SEVERITY[selected]
+    ) {
+      selected = candidate
+    }
+  }
+  return selected
+}
+
 export type PlannedEffect = {
   type: DeprovisionEffectType
   orgId?: string | null
@@ -61,7 +129,13 @@ export function planDirectoryDeprovision(input: DirectoryDeprovisionPlanInput): 
       effects: [],
     }
   }
-
+  if (input.activationStatus !== 'activated') {
+    return {
+      localUserId: input.localUserId,
+      skipReason: 'unknown_activation_status',
+      effects: [],
+    }
+  }
   const effects: PlannedEffect[] = []
 
   if (input.orgMembershipActive) {

--- a/packages/core-backend/src/directory/directory-sync.ts
+++ b/packages/core-backend/src/directory/directory-sync.ts
@@ -47,6 +47,12 @@ import { resolveDirectoryScheduleTimezone } from './directory-sync-timezone'
 import { acquireSourceSyncFreezeLock } from './source-sync-freeze-lock'
 import { applyDirectoryDeprovisionCandidate } from './deprovision-ledger'
 import {
+  DIRECTORY_DEPROVISION_POLICIES,
+  resolveDirectoryDeprovisionPolicy,
+  selectLeastDestructiveDirectoryDeprovisionPolicy,
+  type DirectoryDeprovisionPolicy,
+} from './deprovision-planner'
+import {
   lockUsersForAccessGraphWrite,
   supersedeDeprovisionEvidenceForAccessGraphWrite,
   type AccessGraphTransactionClient,
@@ -1320,13 +1326,11 @@ export function resolveDirectoryIdentityMatch(
  * off — the shipped default — nothing is written and the run reports exactly what it
  * WOULD have done, giving an operator the preview the roadmap asks for before enabling.
  */
-export type DirectoryDeprovisionPolicy = 'manual_review' | 'disable_grant_only' | 'mark_inactive'
-
-export const DIRECTORY_DEPROVISION_POLICIES: readonly DirectoryDeprovisionPolicy[] = [
-  'manual_review',
-  'disable_grant_only',
-  'mark_inactive',
-]
+export {
+  DIRECTORY_DEPROVISION_POLICIES,
+  resolveDirectoryDeprovisionPolicy,
+}
+export type { DirectoryDeprovisionPolicy }
 
 export function isDirectoryDeprovisionEnabled(): boolean {
   return ['true', '1', 'yes'].includes(
@@ -1338,16 +1342,6 @@ export function isDirectoryDeprovisionEnabled(): boolean {
  * An unrecognised stored value must never be interpreted as "do something destructive".
  * Anything we do not understand degrades to review-only.
  */
-export function resolveDirectoryDeprovisionPolicy(
-  integrationDefault: string | null | undefined,
-  accountOverride: string | null | undefined,
-): DirectoryDeprovisionPolicy {
-  const candidate = normalizeText(accountOverride) || normalizeText(integrationDefault)
-  return (DIRECTORY_DEPROVISION_POLICIES as readonly string[]).includes(candidate)
-    ? (candidate as DirectoryDeprovisionPolicy)
-    : 'manual_review'
-}
-
 export type DirectoryDeprovisionOutcome = {
   applied: boolean
   /**
@@ -1436,16 +1430,6 @@ type DeprovisionCandidateRow = {
   directory_account_id: string
   local_user_id: string
   deprovision_policy_override: string | null
-}
-
-/**
- * Least-destructive wins. A user reached through several departed accounts is deprovisioned
- * by the *safest* policy any of them names: if one binding says review-only, a human looks.
- */
-const DEPROVISION_POLICY_SEVERITY: Record<DirectoryDeprovisionPolicy, number> = {
-  manual_review: 0,
-  disable_grant_only: 1,
-  mark_inactive: 2,
 }
 
 /**
@@ -1577,8 +1561,17 @@ export async function applyDirectoryDeprovisionPolicies(
   for (const row of candidates.rows as DeprovisionCandidateRow[]) {
     const policy = resolveDirectoryDeprovisionPolicy(options.integrationDefaultPolicy, row.deprovision_policy_override)
     const existing = byUser.get(row.local_user_id)
-    if (!existing || DEPROVISION_POLICY_SEVERITY[policy] < DEPROVISION_POLICY_SEVERITY[existing.policy]) {
-      byUser.set(row.local_user_id, { directoryAccountId: row.directory_account_id, policy })
+    const selectedPolicy = existing
+      ? selectLeastDestructiveDirectoryDeprovisionPolicy([
+          existing.policy,
+          policy,
+        ])
+      : policy
+    if (!existing || selectedPolicy !== existing.policy) {
+      byUser.set(row.local_user_id, {
+        directoryAccountId: row.directory_account_id,
+        policy: selectedPolicy,
+      })
     }
   }
 

--- a/packages/core-backend/tests/integration/directory-deprovision-writer-ledger.db.test.ts
+++ b/packages/core-backend/tests/integration/directory-deprovision-writer-ledger.db.test.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'node:crypto'
 import { afterAll, beforeEach, describe, expect, it } from 'vitest'
 import { query, transaction } from '../../src/db/pg'
+import { previewDeprovisionForUser } from '../../src/directory/deprovision-evidence-api'
 import { applyDirectoryDeprovisionCandidate } from '../../src/directory/deprovision-ledger'
 import { applyDirectoryDeprovisionPolicies } from '../../src/directory/directory-sync'
 
@@ -158,10 +159,69 @@ async function seedActiveSibling(
   return { integrationId, orgId }
 }
 
+async function seedSameOrgActiveSibling(
+  seeded: SeededDirectory,
+): Promise<{ accountId: string; integrationId: string }> {
+  const integration = await query<{ id: string }>(
+    `INSERT INTO directory_integrations (
+       name, corp_id, org_id, provider, status
+     ) VALUES ($1, $2, $3, 'dingtalk', 'active')
+     RETURNING id::text AS id`,
+    [
+      `${PREFIX}-same-org-integration-${randomUUID()}`,
+      `${PREFIX}-same-org-corp-${randomUUID()}`,
+      seeded.orgId,
+    ],
+  )
+  const integrationId = integration.rows[0].id
+  const account = await query<{ id: string }>(
+    `INSERT INTO directory_accounts (
+       integration_id, provider, external_user_id, external_key, name, is_active
+     ) VALUES ($1::uuid, 'dingtalk', $2, $3, 'D4 Same Org Sibling', TRUE)
+     RETURNING id::text AS id`,
+    [
+      integrationId,
+      `${PREFIX}-same-org-external-${randomUUID()}`,
+      `dingtalk:${PREFIX}:same-org:${randomUUID()}`,
+    ],
+  )
+  await query(
+    `INSERT INTO directory_account_links (
+       directory_account_id, local_user_id, link_status
+     ) VALUES ($1::uuid, $2, 'linked')`,
+    [account.rows[0].id, seeded.userId],
+  )
+  return { accountId: account.rows[0].id, integrationId }
+}
+
+async function readOnlyApplyPlan(seeded: SeededDirectory) {
+  return transaction(async (client) =>
+    applyDirectoryDeprovisionCandidate(
+      {
+        query: async (statement, params) => {
+          const result = await client.query(statement, params)
+          return { rows: result.rows as Array<Record<string, unknown>> }
+        },
+      },
+      {
+        localUserId: seeded.userId,
+        orgId: seeded.orgId,
+        integrationId: seeded.integrationId,
+        directoryAccountId: seeded.accountId,
+        runId: seeded.runId,
+        triggeredBy: 'test:d7-preview-parity',
+        policy: 'mark_inactive',
+        write: false,
+      },
+    ),
+  )
+}
+
 async function apply(
   seeded: SeededDirectory,
   options: {
     enabled?: boolean
+    integrationDefaultPolicy?: 'manual_review' | 'disable_grant_only' | 'mark_inactive'
     runId?: string
   } = {},
 ) {
@@ -179,7 +239,7 @@ async function apply(
         triggeredBy: 'test:d4-writer',
         deactivatedAccountIds: [seeded.accountId],
         syncedAccountCount: 1,
-        integrationDefaultPolicy: 'mark_inactive',
+        integrationDefaultPolicy: options.integrationDefaultPolicy ?? 'mark_inactive',
         enabled: options.enabled ?? true,
       },
     ),
@@ -553,6 +613,159 @@ describeIfDatabase(
         [seeded.userId],
       )
       expect(evidence.rows[0].count).toBe('0')
+    })
+
+    it('keeps preview and apply identical when a same-org sibling remains active', async () => {
+      const seeded = await seedDirectory({ grantEnabled: true })
+      await seedSameOrgActiveSibling(seeded)
+      await query(
+        `UPDATE directory_accounts SET is_active = TRUE WHERE id = $1::uuid`,
+        [seeded.accountId],
+      )
+
+      const preview = await previewDeprovisionForUser(
+        seeded.userId,
+        seeded.integrationId,
+      )
+      const afterPreview = await query<{
+        access_generation: string
+        grant_enabled: boolean
+        membership_active: boolean
+        user_active: boolean
+        event_count: string
+      }>(
+        `SELECT u.access_generation::text,
+                u.is_active AS user_active,
+                m.is_active AS membership_active,
+                g.enabled AS grant_enabled,
+                (
+                  SELECT COUNT(*)::text
+                    FROM directory_deprovision_events event
+                   WHERE event.local_user_id = u.id
+                ) AS event_count
+           FROM users u
+           JOIN user_orgs m ON m.user_id = u.id AND m.org_id = $2
+           JOIN user_external_auth_grants g
+             ON g.local_user_id = u.id AND g.provider = 'dingtalk'
+          WHERE u.id = $1`,
+        [seeded.userId, seeded.orgId],
+      )
+      expect(afterPreview.rows[0]).toEqual({
+        access_generation: '7',
+        grant_enabled: true,
+        membership_active: true,
+        user_active: true,
+        event_count: '0',
+      })
+      await query(
+        `UPDATE directory_accounts SET is_active = FALSE WHERE id = $1::uuid`,
+        [seeded.accountId],
+      )
+      const applyPlan = await readOnlyApplyPlan(seeded)
+
+      expect(preview.plan).toEqual(applyPlan.plan)
+      expect(preview.plan.effects).toEqual([])
+      expect(preview.prospectiveDeactivatedAccountIds).toEqual([
+        seeded.accountId,
+      ])
+    })
+
+    it('keeps preview and apply identical for a globally-clear prospective departure', async () => {
+      const seeded = await seedDirectory({ grantEnabled: true })
+      await query(
+        `UPDATE directory_accounts SET is_active = TRUE WHERE id = $1::uuid`,
+        [seeded.accountId],
+      )
+
+      const preview = await previewDeprovisionForUser(
+        seeded.userId,
+        seeded.integrationId,
+      )
+      await query(
+        `UPDATE directory_accounts SET is_active = FALSE WHERE id = $1::uuid`,
+        [seeded.accountId],
+      )
+      const applyPlan = await readOnlyApplyPlan(seeded)
+
+      expect(preview.plan).toEqual(applyPlan.plan)
+      expect(preview.plan.effects.map((effect) => effect.type).sort()).toEqual([
+        'grant_changed',
+        'membership_changed',
+        'user_changed',
+      ])
+    })
+
+    it('lets an account override replace a more conservative integration default in both preview and apply', async () => {
+      const seeded = await seedDirectory({
+        grantEnabled: true,
+        policy: 'manual_review',
+      })
+      await query(
+        `UPDATE directory_accounts
+            SET is_active = TRUE,
+                deprovision_policy_override = 'mark_inactive'
+          WHERE id = $1::uuid`,
+        [seeded.accountId],
+      )
+
+      const preview = await previewDeprovisionForUser(
+        seeded.userId,
+        seeded.integrationId,
+      )
+      expect(preview.plan.skipReason).toBeNull()
+      expect(preview.plan.effects.map((effect) => effect.type).sort()).toEqual([
+        'grant_changed',
+        'membership_changed',
+        'user_changed',
+      ])
+
+      await query(
+        `UPDATE directory_accounts SET is_active = FALSE WHERE id = $1::uuid`,
+        [seeded.accountId],
+      )
+      const outcome = await apply(seeded, {
+        integrationDefaultPolicy: 'manual_review',
+      })
+      expect(outcome.usersDeactivatedCount).toBe(1)
+      expect(outcome.grantsDisabledCount).toBe(1)
+      expect(outcome.membershipDeactivationAttemptedCount).toBe(1)
+
+      const event = await query<{ policy: string }>(
+        `SELECT policy
+           FROM directory_deprovision_events
+          WHERE local_user_id = $1`,
+        [seeded.userId],
+      )
+      expect(event.rows).toEqual([{ policy: 'mark_inactive' }])
+    })
+
+    it('keeps preview and apply identical when only a different-org sibling remains active', async () => {
+      const seeded = await seedDirectory({ grantEnabled: true })
+      await seedActiveSibling(seeded)
+      await query(
+        `UPDATE directory_accounts SET is_active = TRUE WHERE id = $1::uuid`,
+        [seeded.accountId],
+      )
+
+      const preview = await previewDeprovisionForUser(
+        seeded.userId,
+        seeded.integrationId,
+      )
+      await query(
+        `UPDATE directory_accounts SET is_active = FALSE WHERE id = $1::uuid`,
+        [seeded.accountId],
+      )
+      const applyPlan = await readOnlyApplyPlan(seeded)
+
+      expect(preview.plan).toEqual(applyPlan.plan)
+      expect(preview.plan.effects).toEqual([
+        {
+          type: 'membership_changed',
+          orgId: seeded.orgId,
+          beforeActive: true,
+          afterActive: false,
+        },
+      ])
     })
   },
 )

--- a/packages/core-backend/tests/unit/deprovision-evidence-api.test.ts
+++ b/packages/core-backend/tests/unit/deprovision-evidence-api.test.ts
@@ -1,5 +1,20 @@
-import { describe, expect, it } from 'vitest'
-import { readDeprovisionRuntimeFlags } from '../../src/directory/deprovision-evidence-api'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const dbMocks = vi.hoisted(() => ({
+  query: vi.fn(),
+  transaction: vi.fn(),
+  clientQuery: vi.fn(),
+}))
+
+vi.mock('../../src/db/pg', () => ({
+  query: dbMocks.query,
+  transaction: dbMocks.transaction,
+}))
+
+import {
+  previewDeprovisionForUser,
+  readDeprovisionRuntimeFlags,
+} from '../../src/directory/deprovision-evidence-api'
 
 describe('readDeprovisionRuntimeFlags', () => {
   it('defaults deprovision writer OFF', () => {
@@ -11,5 +26,55 @@ describe('readDeprovisionRuntimeFlags', () => {
     expect(flags.policyNote).toMatch(/策略≠已执行/)
     if (prev === undefined) delete process.env.DIRECTORY_DEPROVISION_ENABLED
     else process.env.DIRECTORY_DEPROVISION_ENABLED = prev
+  })
+})
+
+describe('previewDeprovisionForUser snapshot contract', () => {
+  beforeEach(() => {
+    dbMocks.query.mockReset()
+    dbMocks.clientQuery.mockReset()
+    dbMocks.transaction.mockReset()
+    dbMocks.transaction.mockImplementation(
+      async (handler: (client: { query: typeof dbMocks.clientQuery }) => Promise<unknown>) =>
+        handler({ query: dbMocks.clientQuery }),
+    )
+  })
+
+  it('sets read-only repeatable-read before every preview read', async () => {
+    dbMocks.clientQuery
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({
+        rows: [{
+          id: 'user-1',
+          activation_status: 'activated',
+          is_active: true,
+          access_generation: 3,
+        }],
+      })
+      .mockResolvedValueOnce({
+        rows: [{
+          org_id: 'org-1',
+          default_deprovision_policy: 'mark_inactive',
+        }],
+      })
+      .mockResolvedValueOnce({ rows: [] })
+
+    const preview = await previewDeprovisionForUser(
+      'user-1',
+      '00000000-0000-4000-8000-000000000001',
+    )
+
+    expect(dbMocks.clientQuery).toHaveBeenNthCalledWith(
+      1,
+      'SET TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY',
+    )
+    expect(dbMocks.query).not.toHaveBeenCalled()
+    expect(preview).toMatchObject({
+      prospectiveDeactivatedAccountIds: [],
+      plan: {
+        skipReason: 'no_active_linked_accounts',
+        effects: [],
+      },
+    })
   })
 })

--- a/packages/core-backend/tests/unit/deprovision-planner.test.ts
+++ b/packages/core-backend/tests/unit/deprovision-planner.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest'
-import { planDirectoryDeprovision } from '../../src/directory/deprovision-planner'
+import {
+  planDirectoryDeprovision,
+  resolveDirectoryDeprovisionPolicy,
+  resolveLeastDestructiveDirectoryDeprovisionPolicy,
+  selectLeastDestructiveDirectoryDeprovisionPolicy,
+} from '../../src/directory/deprovision-planner'
 
 describe('planDirectoryDeprovision (D2 prospective)', () => {
   it('returns zero effects for pending_activation (no fake offboarding)', () => {
@@ -16,6 +21,27 @@ describe('planDirectoryDeprovision (D2 prospective)', () => {
     expect(plan.effects).toEqual([])
     expect(plan.skipReason).toBe('pending_activation_no_offboarding_effects')
   })
+
+  it.each([null, '', 'suspended'])(
+    'fails unknown activation status %j closed with zero effects',
+    (activationStatus) => {
+      const plan = planDirectoryDeprovision({
+        localUserId: 'u-unknown',
+        policy: 'mark_inactive',
+        activationStatus,
+        isActive: true,
+        orgId: 'org-1',
+        orgMembershipActive: true,
+        dingtalkGrantEnabled: true,
+        globallyClear: true,
+      })
+      expect(plan).toEqual({
+        localUserId: 'u-unknown',
+        skipReason: 'unknown_activation_status',
+        effects: [],
+      })
+    },
+  )
 
   it('plans one source-org membership + grant + user effect for globally-clear', () => {
     const plan = planDirectoryDeprovision({
@@ -104,5 +130,34 @@ describe('planDirectoryDeprovision (D2 prospective)', () => {
       skipReason: 'manual_review',
       effects: [],
     })
+  })
+
+  it('fails unknown stored policies closed and selects the least-destructive override', () => {
+    expect(resolveDirectoryDeprovisionPolicy('unknown', null)).toBe(
+      'manual_review',
+    )
+    expect(
+      resolveLeastDestructiveDirectoryDeprovisionPolicy('mark_inactive', [
+        'disable_grant_only',
+        'manual_review',
+      ]),
+    ).toBe('manual_review')
+  })
+
+  it('treats the integration default as an account fallback, not a preview veto', () => {
+    expect(
+      resolveLeastDestructiveDirectoryDeprovisionPolicy('manual_review', [
+        'mark_inactive',
+      ]),
+    ).toBe('mark_inactive')
+    expect(
+      resolveLeastDestructiveDirectoryDeprovisionPolicy('disable_grant_only', []),
+    ).toBe('disable_grant_only')
+    expect(
+      selectLeastDestructiveDirectoryDeprovisionPolicy([
+        'mark_inactive',
+        'manual_review',
+      ]),
+    ).toBe('manual_review')
   })
 })


### PR DESCRIPTION
## Summary
- route preview and apply through one deprovision planner and snapshot loader
- model preview as all active linked accounts in the selected integration departing prospectively
- exclude that prospective set from org/global sibling checks and expose the exact scope to the UI
- run preview in one repeatable-read read-only transaction
- preserve account override semantics: the integration default is only a fallback, not a preview veto

## Independent review finding closed
Kimi K3 found a real preview/apply mismatch: default `manual_review` plus account override `mark_inactive` previewed zero effects while apply would deactivate. The policy resolver is now split between resolving each account override and selecting among already-resolved account policies. A real-Postgres parity test pins the corrected behavior.

## Verification
- backend unit: 13 passed
- real Postgres writer/ledger/preview: 11 passed
- web panel: 4 passed
- backend `tsc --noEmit`
- web `vue-tsc --noEmit`
- mutations: remove org prospective exclusion -> parity red; remove global exclusion -> parity red; remove unknown-status fail-close -> planner red; remove read-only transaction statement -> API test red; restore old default-as-veto resolver -> unit and real-DB override parity tests red

## Posture
Draft and unarmed. All lifecycle flags remain OFF. Stacked on the D7 API/UI hardening branch; do not merge before its base.