### PR TITLE
feat(directory): harden and batch pending-user activation

### DIFF
--- a/packages/core-backend/src/auth/user-activate.ts
+++ b/packages/core-backend/src/auth/user-activate.ts
@@ -3,6 +3,19 @@
  *
  * Single durable transaction: status + is_active + optional password + optional
  * memberships. Rejects inactive directory sources for SSO-shaped activates.
+ *
+ * Load-bearing mutation notes (source-link hardening):
+ * - Explicit `directoryAccountId` must JOIN a real link row with
+ *   `link_status = 'linked'` AND `local_user_id` exactly the pending user.
+ *   LEFT JOIN + "only reject truthy mismatched local_user_id" is forbidden:
+ *   missing link / unlinked / null local_user_id must fail closed.
+ * - Implicit source branch requires `link_status = 'linked'` exactly
+ *   (never `COALESCE(NULL, 'linked')`).
+ * - SOURCE_MISSING vs LINK_MISMATCH stay precise: missing/unlinked → MISSING;
+ *   linked-to-another-user → MISMATCH.
+ * - mode=sso additionally requires authoritative DingTalk provider on both
+ *   account and integration plus corp_id consistency between those rows.
+ *   Request body corp/provider hints are never consulted.
  */
 
 import * as bcrypt from 'bcryptjs'
@@ -16,6 +29,16 @@ import { claimLoginAlias } from './login-alias-service'
 import { buildUnusablePasswordHash } from './user-activation'
 
 export type ActivateMode = 'temp_password' | 'sso' | 'admin_no_password'
+
+export const ACTIVATE_MODES: readonly ActivateMode[] = [
+  'temp_password',
+  'sso',
+  'admin_no_password',
+] as const
+
+export function isActivateMode(value: unknown): value is ActivateMode {
+  return value === 'temp_password' || value === 'sso' || value === 'admin_no_password'
+}
 
 export type ActivateUserInput = {
   userId: string
@@ -61,6 +84,8 @@ export type ActivateErrorCode =
   | 'ACTIVATE_SOURCE_INACTIVE'
   | 'ACTIVATE_INTEGRATION_INACTIVE'
   | 'ACTIVATE_LINK_MISMATCH'
+  /** SSO-only: account/integration provider is not DingTalk, or corp_id is inconsistent. */
+  | 'ACTIVATE_SOURCE_INELIGIBLE'
 
 function throwCoded(message: string, code: ActivateErrorCode): never {
   const err = new Error(message)
@@ -112,6 +137,7 @@ export async function activatePendingUser(input: ActivateUserInput): Promise<Act
       await assertDirectorySourceActiveForActivate(client, {
         userId,
         directoryAccountId: input.directoryAccountId ?? null,
+        requireDingTalkSso: input.mode === 'sso',
       })
     }
 
@@ -233,53 +259,111 @@ export async function activatePendingUser(input: ActivateUserInput): Promise<Act
   }
 }
 
+type DirectorySourceRow = {
+  account_active: boolean
+  integration_status: string
+  local_user_id: string | null
+  link_status: string | null
+  account_provider: string | null
+  integration_provider: string | null
+  account_corp_id: string | null
+  integration_corp_id: string | null
+}
+
 async function assertDirectorySourceActiveForActivate(
   client: { query: (sql: string, params?: unknown[]) => Promise<{ rows: unknown[] }> },
-  options: { userId: string; directoryAccountId: string | null },
+  options: {
+    userId: string
+    directoryAccountId: string | null
+    requireDingTalkSso: boolean
+  },
 ): Promise<void> {
   // Closed set: linked directory account must be active; integration active.
+  // Explicit id: account row + link fail-closed (INNER semantics enforced in TS after LEFT JOIN
+  // so we can distinguish SOURCE_MISSING account-not-found from LINK_MISMATCH).
+  // Implicit: start from links with exact link_status='linked' (no COALESCE default).
   const sql = options.directoryAccountId
     ? `SELECT da.id, da.is_active AS account_active, di.status AS integration_status,
-              l.local_user_id, l.link_status
+              l.local_user_id, l.link_status,
+              da.provider AS account_provider, di.provider AS integration_provider,
+              da.corp_id AS account_corp_id, di.corp_id AS integration_corp_id
          FROM directory_accounts da
          JOIN directory_integrations di ON di.id = da.integration_id
          LEFT JOIN directory_account_links l ON l.directory_account_id = da.id
-        WHERE da.id = $1
-        LIMIT 1`
+        WHERE da.id = $1`
     : `SELECT da.id, da.is_active AS account_active, di.status AS integration_status,
-              l.local_user_id, l.link_status
+              l.local_user_id, l.link_status,
+              da.provider AS account_provider, di.provider AS integration_provider,
+              da.corp_id AS account_corp_id, di.corp_id AS integration_corp_id
          FROM directory_account_links l
          JOIN directory_accounts da ON da.id = l.directory_account_id
          JOIN directory_integrations di ON di.id = da.integration_id
         WHERE l.local_user_id = $1
-          AND COALESCE(l.link_status, 'linked') = 'linked'
-        LIMIT 1`
+          AND l.link_status = 'linked'
+        ORDER BY da.id`
 
   const params = options.directoryAccountId
     ? [options.directoryAccountId]
     : [options.userId]
   const result = await client.query(sql, params)
-  const row = result.rows[0] as
-    | {
-        account_active: boolean
-        integration_status: string
-        local_user_id: string | null
-        link_status: string | null
-      }
-    | undefined
+  const rows = result.rows as DirectorySourceRow[]
+  const row = rows[0]
 
   if (!row) {
     throwCoded('No linked active directory account for activation', 'ACTIVATE_SOURCE_MISSING')
   }
-  if (row.account_active === false) {
-    throwCoded('Directory account is inactive; cannot activate', 'ACTIVATE_SOURCE_INACTIVE')
+
+  // Fail closed on the link itself (explicit path especially — LEFT JOIN can return account
+  // rows with no link / unlinked / null local_user_id).
+  const linkStatus = row.link_status == null ? null : String(row.link_status)
+  const linkedUserId = row.local_user_id == null ? null : String(row.local_user_id)
+  if (linkStatus !== 'linked') {
+    // Not a linked source for anyone (missing row, pending, unlinked, …).
+    throwCoded('No linked active directory account for activation', 'ACTIVATE_SOURCE_MISSING')
   }
-  if (String(row.integration_status || '').toLowerCase() !== 'active') {
+  if (linkedUserId !== options.userId) {
+    // Linked status but not this pending user: precise mismatch vs missing.
+    if (linkedUserId) {
+      throwCoded('Directory link points to a different user', 'ACTIVATE_LINK_MISMATCH')
+    }
+    throwCoded('No linked active directory account for activation', 'ACTIVATE_SOURCE_MISSING')
+  }
+
+  const isDingTalkEligible = (candidate: DirectorySourceRow): boolean => {
+    const accountProvider = String(candidate.account_provider || '').toLowerCase()
+    const integrationProvider = String(candidate.integration_provider || '').toLowerCase()
+    const accountCorp = String(candidate.account_corp_id || '').trim()
+    const integrationCorp = String(candidate.integration_corp_id || '').trim()
+    return (
+      accountProvider === 'dingtalk'
+      && integrationProvider === 'dingtalk'
+      && accountCorp.length > 0
+      && accountCorp === integrationCorp
+    )
+  }
+
+  const eligibleRows = options.requireDingTalkSso
+    ? rows.filter(isDingTalkEligible)
+    : rows
+  if (eligibleRows.length === 0) {
+    throwCoded(
+      'Directory source is not a DingTalk account eligible for SSO activation',
+      'ACTIVATE_SOURCE_INELIGIBLE',
+    )
+  }
+  if (eligibleRows.some(
+    (candidate) =>
+      candidate.account_active === true
+      && String(candidate.integration_status || '').toLowerCase() === 'active',
+  )) {
+    return
+  }
+  if (eligibleRows.some(
+    (candidate) => String(candidate.integration_status || '').toLowerCase() !== 'active',
+  )) {
     throwCoded('Directory integration is not active; cannot activate', 'ACTIVATE_INTEGRATION_INACTIVE')
   }
-  if (row.local_user_id && row.local_user_id !== options.userId) {
-    throwCoded('Directory link points to a different user', 'ACTIVATE_LINK_MISMATCH')
-  }
+  throwCoded('Directory account is inactive; cannot activate', 'ACTIVATE_SOURCE_INACTIVE')
 }
 
 function generateTempPassword(): string {

--- a/packages/core-backend/src/routes/admin-users.ts
+++ b/packages/core-backend/src/routes/admin-users.ts
@@ -29,8 +29,13 @@ import {
   assertPendingUserCannotBeActivatedViaGenericStatusApi,
   PENDING_ACTIVATE_BYPASS_FORBIDDEN_CODE,
 } from '../auth/user-activation'
-import { activatePendingUser } from '../auth/user-activate'
-import type { ActivateErrorCode } from '../auth/user-activate'
+import { activatePendingUser, isActivateMode } from '../auth/user-activate'
+import type {
+  ActivateErrorCode,
+  ActivateMode,
+  ActivateUserInput,
+  ActivateUserResult,
+} from '../auth/user-activate'
 import {
   applyMobileLoginAliasChangeOrThrow,
   assertAliasCutoverAllowed,
@@ -1832,6 +1837,10 @@ const ACTIVATE_ERROR_POLICY_SOURCE: Record<ActivateErrorCode, { status: number; 
   // RULED 409: an inactive integration is likewise configuration, not an outage.
   ACTIVATE_INTEGRATION_INACTIVE: { status: 409, message: 'Directory integration is not active; cannot activate' },
   ACTIVATE_LINK_MISMATCH: { status: 409, message: 'Directory link points to a different user' },
+  ACTIVATE_SOURCE_INELIGIBLE: {
+    status: 409,
+    message: 'Directory source is not eligible for DingTalk SSO activation',
+  },
 }
 
 type ActivatePolicyRow = Readonly<{ status: number; message: string }>
@@ -1916,6 +1925,132 @@ export function mapActivateError(error: unknown): { status: number; code: string
     if (policy) return { code: rawCode, ...policy }
   }
   return { ...ACTIVATE_ERROR_FALLBACK }
+}
+
+const MAX_BULK_ACTIVATE_ITEMS = 100
+
+type ParsedActivateRequest = Omit<ActivateUserInput, 'adminUserId'>
+
+type BulkActivateResult =
+  | {
+      userId: string
+      ok: true
+      result: ActivateUserResult
+    }
+  | {
+      userId: string
+      ok: false
+      error: { code: string; message: string; status: number }
+    }
+
+function parseOptionalNonEmptyString(
+  value: unknown,
+  fieldName: string,
+): string | null | undefined {
+  if (value === undefined) return undefined
+  if (value === null) return null
+  if (typeof value !== 'string' || !value.trim()) {
+    throw Object.assign(new Error(`${fieldName} must be a non-empty string or null`), {
+      code: 'ACTIVATE_REQUEST_INVALID',
+    })
+  }
+  return value.trim()
+}
+
+function parseActivateRequest(
+  raw: unknown,
+  routeUserId?: string,
+): ParsedActivateRequest {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    throw Object.assign(new Error('Activation request must be an object'), {
+      code: 'ACTIVATE_REQUEST_INVALID',
+    })
+  }
+  const body = raw as Record<string, unknown>
+  const rawUserId = routeUserId ?? body.userId
+  if (typeof rawUserId !== 'string' || !rawUserId.trim()) {
+    throw Object.assign(new Error('userId must be a non-empty string'), {
+      code: 'ACTIVATE_REQUEST_INVALID',
+    })
+  }
+
+  const rawMode = body.mode === undefined ? 'temp_password' : body.mode
+  if (!isActivateMode(rawMode)) {
+    throw Object.assign(new Error('mode must be temp_password, sso, or admin_no_password'), {
+      code: 'ACTIVATE_REQUEST_INVALID',
+    })
+  }
+  const mode: ActivateMode = rawMode
+
+  if (body.temporaryPassword !== undefined && typeof body.temporaryPassword !== 'string') {
+    throw Object.assign(new Error('temporaryPassword must be a string'), {
+      code: 'ACTIVATE_REQUEST_INVALID',
+    })
+  }
+  if (mode !== 'temp_password' && body.temporaryPassword !== undefined) {
+    throw Object.assign(new Error('temporaryPassword is only valid for temp_password mode'), {
+      code: 'ACTIVATE_REQUEST_INVALID',
+    })
+  }
+  if (
+    body.enableDingTalkGrant !== undefined
+    && typeof body.enableDingTalkGrant !== 'boolean'
+  ) {
+    throw Object.assign(new Error('enableDingTalkGrant must be a boolean'), {
+      code: 'ACTIVATE_REQUEST_INVALID',
+    })
+  }
+
+  return {
+    userId: rawUserId.trim(),
+    mode,
+    temporaryPassword: typeof body.temporaryPassword === 'string'
+      ? body.temporaryPassword
+      : undefined,
+    orgId: parseOptionalNonEmptyString(body.orgId, 'orgId'),
+    directoryAccountId: parseOptionalNonEmptyString(
+      body.directoryAccountId,
+      'directoryAccountId',
+    ),
+    enableDingTalkGrant: body.enableDingTalkGrant === true,
+  }
+}
+
+function mapActivateRequestError(error: unknown): {
+  status: number
+  code: string
+  message: string
+} {
+  if ((error as { code?: unknown } | null)?.code === 'ACTIVATE_REQUEST_INVALID') {
+    return {
+      status: 400,
+      code: 'ACTIVATE_REQUEST_INVALID',
+      message: (error as Error).message,
+    }
+  }
+  return mapActivateError(error)
+}
+
+async function auditActivateSuccess(
+  adminUserId: string,
+  result: ActivateUserResult,
+  mode: ActivateMode,
+  source: 'admin_activate' | 'admin_activate_bulk',
+): Promise<void> {
+  await auditLog({
+    actorId: adminUserId,
+    actorType: 'user',
+    action: 'update',
+    resourceType: 'user',
+    resourceId: result.userId,
+    meta: {
+      source,
+      mode,
+      localPasswordSet: result.localPasswordSet,
+      // Boolean only: plaintext passwords and provider identity values are forbidden in audit.
+      temporaryPasswordIssued: Boolean(result.temporaryPassword),
+    },
+  })
 }
 
 export function adminUsersRouter(): Router {
@@ -4949,42 +5084,107 @@ export function adminUsersRouter(): Router {
   })
 
   // T3 — promote pending_activation → activated (temp password / SSO-shaped source check).
+  r.post('/api/admin/users/activate/bulk', authenticate, async (req: Request, res: Response) => {
+    const adminUserId = await ensurePlatformAdmin(req, res)
+    if (!adminUserId) return
+
+    const rawItems = req.body?.items
+    if (
+      !Array.isArray(rawItems)
+      || rawItems.length === 0
+      || rawItems.length > MAX_BULK_ACTIVATE_ITEMS
+    ) {
+      return jsonError(
+        res,
+        400,
+        'ACTIVATE_BULK_INVALID',
+        `items must contain between 1 and ${MAX_BULK_ACTIVATE_ITEMS} activation requests`,
+      )
+    }
+
+    let items: ParsedActivateRequest[]
+    try {
+      items = rawItems.map((item) => parseActivateRequest(item))
+      const seenUserIds = new Set<string>()
+      for (const item of items) {
+        if (seenUserIds.has(item.userId)) {
+          return jsonError(
+            res,
+            400,
+            'ACTIVATE_BULK_DUPLICATE_USER',
+            'Each userId may appear only once in a bulk activation request',
+          )
+        }
+        seenUserIds.add(item.userId)
+      }
+    } catch (error) {
+      const mapped = mapActivateRequestError(error)
+      return jsonError(res, mapped.status, mapped.code, mapped.message)
+    }
+
+    const results: BulkActivateResult[] = []
+    for (const item of items) {
+      try {
+        const result = await activatePendingUser({
+          ...item,
+          adminUserId,
+        })
+        await auditActivateSuccess(adminUserId, result, item.mode, 'admin_activate_bulk')
+        results.push({ userId: item.userId, ok: true, result })
+      } catch (error) {
+        const mapped = mapActivateError(error)
+        results.push({
+          userId: item.userId,
+          ok: false,
+          error: {
+            status: mapped.status,
+            code: mapped.code,
+            message: mapped.message,
+          },
+        })
+      }
+    }
+
+    const successCount = results.filter((item) => item.ok).length
+    const failureCount = results.length - successCount
+    await auditLog({
+      actorId: adminUserId,
+      actorType: 'user',
+      action: 'update',
+      resourceType: 'user',
+      resourceId: 'bulk-activate',
+      meta: {
+        source: 'admin_activate_bulk',
+        requestedCount: results.length,
+        successCount,
+        failureCount,
+      },
+    })
+    return jsonOk(res, {
+      items: results,
+      successCount,
+      failureCount,
+    })
+  })
+
   r.post('/api/admin/users/:id/activate', authenticate, async (req: Request, res: Response) => {
     const adminUserId = await ensurePlatformAdmin(req, res)
     if (!adminUserId) return
+    let input: ParsedActivateRequest
     try {
-      const modeRaw = String(req.body?.mode || 'temp_password').trim()
-      const mode =
-        modeRaw === 'sso' || modeRaw === 'admin_no_password' ? modeRaw : 'temp_password'
+      input = parseActivateRequest(req.body ?? {}, String(req.params.id || ''))
+    } catch (error) {
+      const mapped = mapActivateRequestError(error)
+      return jsonError(res, mapped.status, mapped.code, mapped.message)
+    }
+    try {
       // claimAliases is NOT client-controllable: production activate always claims
       // email/username/mobile aliases inside the activation transaction.
       const result = await activatePendingUser({
-        userId: String(req.params.id || ''),
-        mode,
+        ...input,
         adminUserId,
-        temporaryPassword: typeof req.body?.temporaryPassword === 'string'
-          ? req.body.temporaryPassword
-          : undefined,
-        orgId: typeof req.body?.orgId === 'string' ? req.body.orgId : null,
-        directoryAccountId: typeof req.body?.directoryAccountId === 'string'
-          ? req.body.directoryAccountId
-          : null,
-        enableDingTalkGrant: req.body?.enableDingTalkGrant === true,
       })
-      await auditLog({
-        actorId: adminUserId,
-        actorType: 'user',
-        action: 'update',
-        resourceType: 'user',
-        resourceId: result.userId,
-        meta: {
-          source: 'admin_activate',
-          mode,
-          localPasswordSet: result.localPasswordSet,
-          // never audit plaintext password
-          temporaryPasswordIssued: Boolean(result.temporaryPassword),
-        },
-      })
+      await auditActivateSuccess(adminUserId, result, input.mode, 'admin_activate')
       return jsonOk(res, result)
     } catch (error) {
       const mapped = mapActivateError(error)

--- a/packages/core-backend/tests/integration/directory-deprovision-grant-table.db.test.ts
+++ b/packages/core-backend/tests/integration/directory-deprovision-grant-table.db.test.ts
@@ -74,6 +74,56 @@ async function seedDirectory(opts: { sourceActive: boolean }) {
   return { integrationId, accountId, runId: run.rows[0].id }
 }
 
+async function seedActivationSource(options: {
+  linkedUserId?: string
+  linkStatus?: string
+  accountActive?: boolean
+  accountProvider?: string
+  integrationProvider?: string
+  accountCorpId?: string
+  integrationCorpId?: string
+  integrationStatus?: string
+}) {
+  const integrationCorpId = options.integrationCorpId ?? `corp-${ORG}`
+  const integration = await query<{ id: string }>(
+    `INSERT INTO directory_integrations
+       (name, corp_id, org_id, provider, status, default_deprovision_policy)
+     VALUES ('activation-source-test', $1, $2, $3, $4, 'manual_review')
+     RETURNING id::text AS id`,
+    [
+      integrationCorpId,
+      ORG,
+      options.integrationProvider ?? 'dingtalk',
+      options.integrationStatus ?? 'active',
+    ],
+  )
+  const account = await query<{ id: string }>(
+    `INSERT INTO directory_accounts
+       (integration_id, provider, corp_id, external_user_id, external_key, name, is_active)
+     VALUES ($1::uuid, $2, $3, 'ext-activation-source',
+             'dingtalk:activation-source:ext', 'Activation Source', $4)
+     RETURNING id::text AS id`,
+    [
+      integration.rows[0].id,
+      options.accountProvider ?? 'dingtalk',
+      options.accountCorpId ?? integrationCorpId,
+      options.accountActive ?? true,
+    ],
+  )
+  if (options.linkedUserId !== undefined) {
+    await query(
+      `INSERT INTO directory_account_links
+         (directory_account_id, local_user_id, link_status)
+       VALUES ($1::uuid, $2, $3)`,
+      [account.rows[0].id, options.linkedUserId, options.linkStatus ?? 'linked'],
+    )
+  }
+  return {
+    integrationId: integration.rows[0].id,
+    accountId: account.rows[0].id,
+  }
+}
+
 async function seedEvent(
   seeded: { integrationId: string; accountId: string; runId: string },
   effects: Array<{ type: string; orgId: string | null }>,
@@ -233,6 +283,187 @@ describeIfDatabase('DingTalk grant/membership writes target the real tables (rea
       [USER],
     )
     expect(aliases.rows.map((r) => r.normalized_value)).toContain('grant-fix@example.com')
+  })
+
+  it('T3 SSO activate commits only with an active exact DingTalk source link', async () => {
+    await query(
+      `INSERT INTO users
+         (id, username, name, password_hash, is_active, activation_status, local_password_set)
+       VALUES ($1, 'sso-source-user', 'SSO Source', 'x', FALSE, 'pending_activation', FALSE)`,
+      [USER],
+    )
+    const source = await seedActivationSource({ linkedUserId: USER })
+
+    await activatePendingUser({
+      userId: USER,
+      mode: 'sso',
+      adminUserId: 'admin-test',
+      orgId: ORG,
+      enableDingTalkGrant: true,
+      directoryAccountId: source.accountId,
+    })
+
+    const committed = await query<{
+      activation_status: string
+      is_active: boolean
+      membership_active: boolean | null
+      grant_enabled: boolean | null
+    }>(
+      `SELECT u.activation_status,
+              u.is_active,
+              membership.is_active AS membership_active,
+              auth_grant.enabled AS grant_enabled
+         FROM users u
+         LEFT JOIN user_orgs membership
+           ON membership.user_id = u.id AND membership.org_id = $2
+         LEFT JOIN user_external_auth_grants auth_grant
+           ON auth_grant.local_user_id = u.id AND auth_grant.provider = 'dingtalk'
+        WHERE u.id = $1`,
+      [USER, ORG],
+    )
+    expect(committed.rows[0]).toMatchObject({
+      activation_status: 'activated',
+      is_active: true,
+      membership_active: true,
+      grant_enabled: true,
+    })
+  })
+
+  it('T3 SSO rejects an account with no linked witness and leaves zero activation residue', async () => {
+    await query(
+      `INSERT INTO users
+         (id, username, name, password_hash, is_active, activation_status, local_password_set)
+       VALUES ($1, 'missing-source-user', 'Missing Source', 'x', FALSE, 'pending_activation', FALSE)`,
+      [USER],
+    )
+    const source = await seedActivationSource({})
+
+    await expect(
+      activatePendingUser({
+        userId: USER,
+        mode: 'sso',
+        adminUserId: 'admin-test',
+        orgId: ORG,
+        enableDingTalkGrant: true,
+        directoryAccountId: source.accountId,
+      }),
+    ).rejects.toMatchObject({ code: 'ACTIVATE_SOURCE_MISSING' })
+
+    const residue = await query<{
+      activation_status: string
+      is_active: boolean
+      memberships: number
+      grants: number
+      aliases: number
+    }>(
+      `SELECT u.activation_status,
+              u.is_active,
+              (SELECT count(*)::int FROM user_orgs WHERE user_id = u.id) AS memberships,
+              (SELECT count(*)::int FROM user_external_auth_grants WHERE local_user_id = u.id) AS grants,
+              (SELECT count(*)::int FROM user_login_aliases WHERE user_id = u.id) AS aliases
+         FROM users u
+        WHERE u.id = $1`,
+      [USER],
+    )
+    expect(residue.rows[0]).toMatchObject({
+      activation_status: 'pending_activation',
+      is_active: false,
+      memberships: 0,
+      grants: 0,
+      aliases: 0,
+    })
+  })
+
+  it('T3 SSO requires link_status=linked even when local_user_id matches', async () => {
+    await query(
+      `INSERT INTO users
+         (id, username, name, password_hash, is_active, activation_status, local_password_set)
+       VALUES ($1, 'unlinked-source-user', 'Unlinked Source', 'x', FALSE, 'pending_activation', FALSE)`,
+      [USER],
+    )
+    const source = await seedActivationSource({
+      linkedUserId: USER,
+      linkStatus: 'unlinked',
+    })
+
+    await expect(
+      activatePendingUser({
+        userId: USER,
+        mode: 'sso',
+        adminUserId: 'admin-test',
+        directoryAccountId: source.accountId,
+      }),
+    ).rejects.toMatchObject({ code: 'ACTIVATE_SOURCE_MISSING' })
+
+    const target = await query<{ activation_status: string; is_active: boolean }>(
+      `SELECT activation_status, is_active FROM users WHERE id = $1`,
+      [USER],
+    )
+    expect(target.rows[0]).toEqual({
+      activation_status: 'pending_activation',
+      is_active: false,
+    })
+  })
+
+  it('T3 SSO rejects a linked account that belongs to another user', async () => {
+    await query(
+      `INSERT INTO users
+         (id, username, name, password_hash, is_active, activation_status, local_password_set)
+       VALUES
+         ($1, 'source-owner', 'Source Owner', 'x', TRUE, 'activated', TRUE),
+         ($2, 'source-target', 'Source Target', 'x', FALSE, 'pending_activation', FALSE)`,
+      [USER_A, USER_B],
+    )
+    const source = await seedActivationSource({ linkedUserId: USER_A })
+
+    await expect(
+      activatePendingUser({
+        userId: USER_B,
+        mode: 'sso',
+        adminUserId: 'admin-test',
+        directoryAccountId: source.accountId,
+      }),
+    ).rejects.toMatchObject({ code: 'ACTIVATE_LINK_MISMATCH' })
+
+    const target = await query<{ activation_status: string; is_active: boolean }>(
+      `SELECT activation_status, is_active FROM users WHERE id = $1`,
+      [USER_B],
+    )
+    expect(target.rows[0]).toEqual({
+      activation_status: 'pending_activation',
+      is_active: false,
+    })
+  })
+
+  it('T3 SSO rejects provider/corp-ineligible source rows without activating', async () => {
+    await query(
+      `INSERT INTO users
+         (id, username, name, password_hash, is_active, activation_status, local_password_set)
+       VALUES ($1, 'ineligible-source', 'Ineligible Source', 'x', FALSE, 'pending_activation', FALSE)`,
+      [USER],
+    )
+    const source = await seedActivationSource({
+      linkedUserId: USER,
+      accountCorpId: `other-corp-${ORG}`,
+    })
+
+    await expect(
+      activatePendingUser({
+        userId: USER,
+        mode: 'sso',
+        adminUserId: 'admin-test',
+        directoryAccountId: source.accountId,
+      }),
+    ).rejects.toMatchObject({ code: 'ACTIVATE_SOURCE_INELIGIBLE' })
+
+    const target = await query<{ activation_status: string; is_active: boolean }>(
+      `SELECT activation_status, is_active FROM users WHERE id = $1`,
+      [USER],
+    )
+    expect(target.rows[0]).toEqual({
+      activation_status: 'pending_activation',
+      is_active: false,
+    })
   })
 
   it('restoring a membership effect actually re-activates the membership', async () => {

--- a/packages/core-backend/tests/unit/admin-users-activate-error-closure.test.ts
+++ b/packages/core-backend/tests/unit/admin-users-activate-error-closure.test.ts
@@ -260,7 +260,7 @@ describe('activate error closure — LAYER 3: static consistency, NOT a behaviou
       + `site, so their row is unreachable and untested: ${JSON.stringify(tableNotThrown)}`,
     ).toEqual([])
 
-    expect(reasons.size).toBe(11)
+    expect(reasons.size).toBe(12)
   })
 
   it('mapActivateError reads ONLY `.code` off its error parameter — never `.message`', () => {

--- a/packages/core-backend/tests/unit/admin-users-activate-error-leak.test.ts
+++ b/packages/core-backend/tests/unit/admin-users-activate-error-leak.test.ts
@@ -52,6 +52,8 @@ vi.mock('../../src/audit/audit', () => ({ auditLog: vi.fn() }))
 
 vi.mock('../../src/auth/user-activate', () => ({
   activatePendingUser: activateMocks.activatePendingUser,
+  isActivateMode: (value: unknown) =>
+    value === 'temp_password' || value === 'sso' || value === 'admin_no_password',
 }))
 
 import { adminUsersRouter } from '../../src/routes/admin-users'

--- a/packages/core-backend/tests/unit/admin-users-activate-error-mapping.test.ts
+++ b/packages/core-backend/tests/unit/admin-users-activate-error-mapping.test.ts
@@ -70,6 +70,10 @@ describe('mapActivateError (activate endpoint error surface)', () => {
       status: 409,
       message: 'Directory link points to a different user',
     },
+    ACTIVATE_SOURCE_INELIGIBLE: {
+      status: 409,
+      message: 'Directory source is not eligible for DingTalk SSO activation',
+    },
   }
 
   it('maps every authored reason to the RULED status and OUR message, never the thrown text', () => {
@@ -94,7 +98,7 @@ describe('mapActivateError (activate endpoint error surface)', () => {
 
   it('asserts the RULED transcription covers exactly the policy table (no silent drift)', () => {
     expect(Object.keys(RULED).sort()).toEqual(Object.keys(ACTIVATE_ERROR_POLICY).sort())
-    expect(Object.keys(RULED)).toHaveLength(11)
+    expect(Object.keys(RULED)).toHaveLength(12)
   })
 
   it('collapses an unauthored but ACTIVATE_-shaped code — the fail-open the owner reproduced', () => {

--- a/packages/core-backend/tests/unit/admin-users-routes.test.ts
+++ b/packages/core-backend/tests/unit/admin-users-routes.test.ts
@@ -67,6 +67,8 @@ vi.mock('../../src/middleware/auth', () => ({
 // catch reverting ACTIVATE_ALIAS_FAILED → 409 or echoing raw driver text.
 vi.mock('../../src/auth/user-activate', () => ({
   activatePendingUser: activateMocks.activatePendingUser,
+  isActivateMode: (value: unknown) =>
+    value === 'temp_password' || value === 'sso' || value === 'admin_no_password',
 }))
 
 vi.mock('../../src/db/pg', () => ({
@@ -3990,5 +3992,137 @@ describe('admin-users routes', () => {
     expect(body.ok).toBe(false)
     expect(body.error?.code).toBe('ACTIVATE_ALIAS_CONFLICT')
     expect(body.error?.message).toMatch(/already claimed/i)
+  })
+
+  it('POST activate rejects an unknown mode before calling the activation service', async () => {
+    rbacMocks.isAdmin.mockResolvedValue(true)
+
+    const response = await invokeRoute('post', '/api/admin/users/:id/activate', {
+      params: { id: 'pending-user-3' },
+      body: { mode: 'passwordish' },
+    })
+
+    expect(response.statusCode).toBe(400)
+    expect(response.body).toMatchObject({
+      ok: false,
+      error: { code: 'ACTIVATE_REQUEST_INVALID' },
+    })
+    expect(activateMocks.activatePendingUser).not.toHaveBeenCalled()
+  })
+
+  it('POST bulk activate validates every item before the first activation write', async () => {
+    rbacMocks.isAdmin.mockResolvedValue(true)
+
+    const response = await invokeRoute('post', '/api/admin/users/activate/bulk', {
+      body: {
+        items: [
+          { userId: 'pending-user-1', mode: 'temp_password' },
+          { userId: 'pending-user-2', mode: 'not-a-mode' },
+        ],
+      },
+    })
+
+    expect(response.statusCode).toBe(400)
+    expect(response.body).toMatchObject({
+      ok: false,
+      error: { code: 'ACTIVATE_REQUEST_INVALID' },
+    })
+    expect(activateMocks.activatePendingUser).not.toHaveBeenCalled()
+    expect(auditMocks.auditLog).not.toHaveBeenCalled()
+  })
+
+  it('POST bulk activate rejects duplicate users before the first activation write', async () => {
+    rbacMocks.isAdmin.mockResolvedValue(true)
+
+    const response = await invokeRoute('post', '/api/admin/users/activate/bulk', {
+      body: {
+        items: [
+          { userId: 'pending-user-1', mode: 'temp_password' },
+          { userId: 'pending-user-1', mode: 'sso' },
+        ],
+      },
+    })
+
+    expect(response.statusCode).toBe(400)
+    expect(response.body).toMatchObject({
+      ok: false,
+      error: { code: 'ACTIVATE_BULK_DUPLICATE_USER' },
+    })
+    expect(activateMocks.activatePendingUser).not.toHaveBeenCalled()
+  })
+
+  it('POST bulk activate keeps item transactions independent and returns only safe failures', async () => {
+    rbacMocks.isAdmin.mockResolvedValue(true)
+    activateMocks.activatePendingUser
+      .mockResolvedValueOnce({
+        userId: 'pending-user-1',
+        activationStatus: 'activated',
+        isActive: true,
+        temporaryPassword: 'TempPass9A!',
+        localPasswordSet: true,
+      })
+      .mockRejectedValueOnce(Object.assign(
+        new Error('DETAIL: union id secret connection refused 5432'),
+        { code: 'ACTIVATE_SOURCE_INELIGIBLE' },
+      ))
+
+    const response = await invokeRoute('post', '/api/admin/users/activate/bulk', {
+      body: {
+        items: [
+          {
+            userId: 'pending-user-1',
+            mode: 'temp_password',
+            temporaryPassword: 'TempPass9A!',
+          },
+          {
+            userId: 'pending-user-2',
+            mode: 'sso',
+            directoryAccountId: 'account-2',
+          },
+        ],
+      },
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(response.body).toMatchObject({
+      ok: true,
+      data: {
+        successCount: 1,
+        failureCount: 1,
+        items: [
+          {
+            userId: 'pending-user-1',
+            ok: true,
+            result: {
+              activationStatus: 'activated',
+              temporaryPassword: 'TempPass9A!',
+            },
+          },
+          {
+            userId: 'pending-user-2',
+            ok: false,
+            error: {
+              status: 409,
+              code: 'ACTIVATE_SOURCE_INELIGIBLE',
+              message: 'Directory source is not eligible for DingTalk SSO activation',
+            },
+          },
+        ],
+      },
+    })
+    expect(activateMocks.activatePendingUser).toHaveBeenCalledTimes(2)
+    expect(JSON.stringify(response.body)).not.toMatch(/DETAIL|union id secret|connection refused|5432/i)
+    expect(auditMocks.auditLog).toHaveBeenCalledTimes(2)
+    expect(auditMocks.auditLog).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        resourceId: 'bulk-activate',
+        meta: {
+          source: 'admin_activate_bulk',
+          requestedCount: 2,
+          successCount: 1,
+          failureCount: 1,
+        },
+      }),
+    )
   })
 })

--- a/packages/core-backend/tests/unit/user-activate.test.ts
+++ b/packages/core-backend/tests/unit/user-activate.test.ts
@@ -16,7 +16,7 @@ vi.mock('../../src/auth/login-alias-service', () => ({
   claimLoginAlias: vi.fn(async () => ({ ok: true, normalized: 'x' })),
 }))
 
-import { activatePendingUser } from '../../src/auth/user-activate'
+import { activatePendingUser, isActivateMode } from '../../src/auth/user-activate'
 
 describe('activatePendingUser (T3)', () => {
   beforeEach(async () => {
@@ -28,6 +28,17 @@ describe('activatePendingUser (T3)', () => {
     const { claimLoginAlias } = await import('../../src/auth/login-alias-service')
     vi.mocked(claimLoginAlias).mockReset()
     vi.mocked(claimLoginAlias).mockResolvedValue({ ok: true, normalized: 'x' })
+  })
+
+  it('keeps the runtime activation mode set closed', () => {
+    expect(['temp_password', 'sso', 'admin_no_password'].map(isActivateMode)).toEqual([
+      true,
+      true,
+      true,
+    ])
+    for (const value of ['', 'passwordish', 'SSO', null, 1, {}, []]) {
+      expect(isActivateMode(value)).toBe(false)
+    }
   })
 
   it('promotes pending → activated with temp password in one transaction', async () => {
@@ -167,6 +178,10 @@ describe('activatePendingUser (T3)', () => {
           integration_status: 'active',
           local_user_id: 'u1',
           link_status: 'linked',
+          account_provider: 'dingtalk',
+          integration_provider: 'dingtalk',
+          account_corp_id: 'corp-1',
+          integration_corp_id: 'corp-1',
         }],
       })
 
@@ -177,6 +192,173 @@ describe('activatePendingUser (T3)', () => {
         directoryAccountId: 'da-1',
       }),
     ).rejects.toMatchObject({ code: 'ACTIVATE_SOURCE_INACTIVE' })
+  })
+
+  it('rejects an explicit account whose link row is missing or unlinked', async () => {
+    pgMocks.query
+      .mockResolvedValueOnce({
+        rows: [{
+          id: 'u1',
+          email: null,
+          username: 'x',
+          mobile: null,
+          activation_status: 'pending_activation',
+          is_active: false,
+        }],
+      })
+      .mockResolvedValueOnce({
+        rows: [{
+          account_active: true,
+          integration_status: 'active',
+          local_user_id: null,
+          link_status: null,
+          account_provider: 'dingtalk',
+          integration_provider: 'dingtalk',
+          account_corp_id: 'corp-1',
+          integration_corp_id: 'corp-1',
+        }],
+      })
+
+    await expect(
+      activatePendingUser({
+        userId: 'u1',
+        mode: 'sso',
+        directoryAccountId: 'da-1',
+      }),
+    ).rejects.toMatchObject({ code: 'ACTIVATE_SOURCE_MISSING' })
+  })
+
+  it('rejects an explicit account linked to another local user', async () => {
+    pgMocks.query
+      .mockResolvedValueOnce({
+        rows: [{
+          id: 'u1',
+          email: null,
+          username: 'x',
+          mobile: null,
+          activation_status: 'pending_activation',
+          is_active: false,
+        }],
+      })
+      .mockResolvedValueOnce({
+        rows: [{
+          account_active: true,
+          integration_status: 'active',
+          local_user_id: 'u-other',
+          link_status: 'linked',
+          account_provider: 'dingtalk',
+          integration_provider: 'dingtalk',
+          account_corp_id: 'corp-1',
+          integration_corp_id: 'corp-1',
+        }],
+      })
+
+    await expect(
+      activatePendingUser({
+        userId: 'u1',
+        mode: 'sso',
+        directoryAccountId: 'da-1',
+      }),
+    ).rejects.toMatchObject({ code: 'ACTIVATE_LINK_MISMATCH' })
+  })
+
+  it.each([
+    {
+      label: 'account provider is not DingTalk',
+      account_provider: 'local',
+      integration_provider: 'dingtalk',
+      account_corp_id: 'corp-1',
+      integration_corp_id: 'corp-1',
+    },
+    {
+      label: 'account and integration corp ids differ',
+      account_provider: 'dingtalk',
+      integration_provider: 'dingtalk',
+      account_corp_id: 'corp-a',
+      integration_corp_id: 'corp-b',
+    },
+  ])('rejects SSO when $label', async (source) => {
+    pgMocks.query
+      .mockResolvedValueOnce({
+        rows: [{
+          id: 'u1',
+          email: null,
+          username: 'x',
+          mobile: null,
+          activation_status: 'pending_activation',
+          is_active: false,
+        }],
+      })
+      .mockResolvedValueOnce({
+        rows: [{
+          account_active: true,
+          integration_status: 'active',
+          local_user_id: 'u1',
+          link_status: 'linked',
+          ...source,
+        }],
+      })
+
+    await expect(
+      activatePendingUser({
+        userId: 'u1',
+        mode: 'sso',
+        directoryAccountId: 'da-1',
+      }),
+    ).rejects.toMatchObject({ code: 'ACTIVATE_SOURCE_INELIGIBLE' })
+  })
+
+  it('accepts an implicit SSO source when at least one linked DingTalk source is active', async () => {
+    pgMocks.query
+      .mockResolvedValueOnce({
+        rows: [{
+          id: 'u1',
+          email: null,
+          username: 'x',
+          mobile: null,
+          activation_status: 'pending_activation',
+          is_active: false,
+        }],
+      })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            account_active: false,
+            integration_status: 'active',
+            local_user_id: 'u1',
+            link_status: 'linked',
+            account_provider: 'dingtalk',
+            integration_provider: 'dingtalk',
+            account_corp_id: 'corp-1',
+            integration_corp_id: 'corp-1',
+          },
+          {
+            account_active: true,
+            integration_status: 'active',
+            local_user_id: 'u1',
+            link_status: 'linked',
+            account_provider: 'dingtalk',
+            integration_provider: 'dingtalk',
+            account_corp_id: 'corp-2',
+            integration_corp_id: 'corp-2',
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ rows: [{ id: 'u1' }] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ access_generation: 1 }] })
+
+    await expect(
+      activatePendingUser({
+        userId: 'u1',
+        mode: 'sso',
+      }),
+    ).resolves.toMatchObject({
+      userId: 'u1',
+      activationStatus: 'activated',
+      localPasswordSet: false,
+    })
   })
 
   it('rejects activate when user has no claimable identifier', async () => {


### PR DESCRIPTION
## Scope

Stacked on #4658. T3 only: harden pending-user activation source links and add the platform-admin bulk activation endpoint. No lifecycle flags are enabled.

## Behavior

- Reject unknown activation modes before any write.
- SSO requires an exact linked account for the pending user, active account/integration, DingTalk providers, and matching non-empty corp IDs.
- Add `POST /api/admin/users/activate/bulk` with full-batch prevalidation, unique user IDs, max 100 items, and independent per-item transactions/results.
- Keep response errors in the closed safe mapping; audit only booleans/counts, never passwords or provider identity values.

## Verification

- Backend TypeScript: clean.
- Focused unit/error-surface battery: 114 passed.
- Real PostgreSQL lifecycle battery: 16 passed.
- Load-bearing mutations: removing exact link status, linked-user equality, DingTalk provider/corp eligibility, or unknown-mode rejection each reddens its dedicated test.
- Independent Kimi K3 adversarial read: zero P1/P2; Codex rechecked all observations and added a direct runtime mode-closure test.

## Landing boundary

Draft and unarmed. Retarget/rebase and full required CI happen only after the parent lifecycle windows land. All lifecycle flags remain OFF.