### PR TITLE
feat(auth): add DingTalk activation OAuth intent

### DIFF
--- a/docs/development/dingtalk-lifecycle-development-closeout-20260728.md
+++ b/docs/development/dingtalk-lifecycle-development-closeout-20260728.md
@@ -1,0 +1,91 @@
+# DingTalk lifecycle development closeout (2026-07-28)
+
+Status: **development delivered / landing and runtime acceptance pending**
+
+This record closes the implementation work authorized by the admission/activation
+and deprovision/reactivation design locks. It does not declare the stack merged,
+deployed, enabled, or production-accepted.
+
+## 1. Authority and baseline
+
+- Design locks:
+  - `dingtalk-directory-admission-activation-lifecycle-design-20260723.md`
+  - `dingtalk-deprovision-reactivation-and-evidence-chain-design-20260723.md`
+- Main observed while preparing this record: `ed7a739537d33f7a9a128d58d14468b79164454e`.
+- The delivery remains a draft, unarmed stack. All lifecycle flags remain OFF.
+- Historical PR #4579 remains HELD and is not part of this landing chain.
+
+## 2. Reviewable delivery stack
+
+| Order | Slice | PR | Exact review head | Current base |
+|---:|---|---:|---|---|
+| 1 | D3 evidence-ledger schema | #4646 | `4c75a93d0` | `main` |
+| 2 | D4 atomic writer and evidence | #4647 | `cb0454065` | D3 |
+| 3 | D5a admin access-writer mutex | #4648 | `33fa24ea6` | D4 |
+| 4 | D5b account-binding mutex | #4651 | `75ba0f6b8` | D5a |
+| 5 | D5c sync/OAuth access mutex | #4653 | `a40ccd63b` | D5b |
+| 6 | D6 restore transaction | #4655 | `b20f33e75` | D5c |
+| 7 | D7 evidence API and UI | #4656 | `a0bcdcafe` | D6 |
+| 8 | Preview/apply policy parity | #4659 | `8328e2890` | D7 |
+| 9 | Activated-user alias writers | #4658 | `8b356ec8e` | D7 |
+| 10 | T3 source-link hardening and batch activation | #4660 | `14a0c4580` | alias writers |
+| 11 | OAuth `intent=activate` | #4662 | code commit `c4f5f8dce` | T3 |
+
+PRs #4658 and #4659 are sibling stacks over D7. Before landing, choose a
+single order, retarget the second sibling onto the first merge, and rerun its
+ticket-specific evidence. No merge SHA exists yet for any row above.
+
+## 3. Final OAuth activation contract
+
+- `activate` has a distinct, one-time OAuth state shape. Unknown or incomplete
+  persisted intent values fail closed.
+- Launch binds the pending target and the authenticated platform administrator.
+- Callback rechecks that the administrator is still active, activated, and holds
+  the RBAC admin role.
+- The DingTalk code exchange does not enter login auto-provision/JIT.
+- The source account must be exactly one active DingTalk account under an active
+  DingTalk integration, with matching configured corp and callback openId/unionId.
+- The activation transaction rechecks the active link to the same pending user
+  and derives membership org from the locked integration row.
+- The session is issued only after activation returns and the activated user row
+  is reloaded.
+
+## 4. Verification completed
+
+OAuth final-head local evidence:
+
+- backend TypeScript: clean;
+- OAuth/auth/admin regression battery: 129/129;
+- real PostgreSQL lifecycle battery: 17/17;
+- parent alias-writer regression battery after fixture correction: 122/122;
+- T3 replay after restack: 114/114 unit/error tests and 16/16 real-DB tests.
+
+Load-bearing mutations were run separately and restored:
+
+1. accept an unknown persisted OAuth intent;
+2. ignore callback identity during the transactional source check;
+3. remove callback administrator recheck;
+4. issue a session without awaiting activation;
+5. accept a disabled state-bound administrator;
+6. use caller-supplied org instead of the source integration org.
+
+Each mutation reddened its dedicated assertion. The final worktrees contain no
+mutation residue.
+
+## 5. Remaining owner and operations gates
+
+1. Review each exact head in order. A review applies only to that SHA.
+2. Retarget/rebase one PR at a time, replay that ticket's mutations, run full
+   required CI, and merge only after a fresh owner verdict.
+3. Record the real merge SHA for every row above.
+4. Keep `AUTH_LOGIN_USE_ALIASES`,
+   `DIRECTORY_PENDING_ACTIVATION_ENABLED`, and
+   `DIRECTORY_DEPROVISION_ENABLED` OFF through landing.
+5. Run real enterprise UAT and evidence review after deployment.
+6. Canary requires a separate explicit GO and remains ordered:
+   alias-only, pending admission, then deprovision. Do not enable multiple
+   lifecycle flags in one window.
+
+The honest closeout statement is therefore: the locked development scope is
+implemented and reviewable; repository landing, deployment, UAT, and canary are
+still open gates.

--- a/packages/core-backend/src/auth/dingtalk-oauth.ts
+++ b/packages/core-backend/src/auth/dingtalk-oauth.ts
@@ -74,13 +74,15 @@ interface LocalUserRow {
   activation_status?: string | null
 }
 
-export type DingTalkOAuthIntent = 'login' | 'bind'
+export type DingTalkOAuthIntent = 'login' | 'bind' | 'activate'
 
 interface StateRecord {
   expiresAt: number
   redirectPath?: string
   intent?: DingTalkOAuthIntent
   bindUserId?: string
+  activateUserId?: string
+  activateAdminUserId?: string
 }
 
 export interface StateValidationResult {
@@ -89,6 +91,8 @@ export interface StateValidationResult {
   redirectPath?: string
   intent?: DingTalkOAuthIntent
   bindUserId?: string
+  activateUserId?: string
+  activateAdminUserId?: string
 }
 
 export type DingTalkRuntimeUnavailableReason =
@@ -371,7 +375,7 @@ async function validateStateFromRedis(state: string): Promise<StateValidationRes
       parsed = null
     }
 
-    if (!parsed || typeof parsed.expiresAt !== 'number') {
+    if (!parsed || typeof parsed.expiresAt !== 'number' || !isValidStateRecord(parsed)) {
       return { valid: false, error: 'Invalid or unknown state parameter' }
     }
 
@@ -384,6 +388,8 @@ async function validateStateFromRedis(state: string): Promise<StateValidationRes
       redirectPath: parsed.redirectPath,
       intent: parsed.intent,
       bindUserId: parsed.bindUserId,
+      activateUserId: parsed.activateUserId,
+      activateAdminUserId: parsed.activateAdminUserId,
     }
   } catch (error) {
     logRedisFallback('Redis state validation failed', error)
@@ -406,6 +412,10 @@ function validateStateFromMemory(state: string): StateValidationResult {
   if (!record) return { valid: false, error: 'Invalid or unknown state parameter' }
   pendingStates.delete(state)
 
+  if (!isValidStateRecord(record)) {
+    return { valid: false, error: 'Invalid or unknown state parameter' }
+  }
+
   if (Date.now() > record.expiresAt) {
     return { valid: false, error: 'State parameter has expired' }
   }
@@ -415,7 +425,35 @@ function validateStateFromMemory(state: string): StateValidationResult {
     redirectPath: record.redirectPath,
     intent: record.intent,
     bindUserId: record.bindUserId,
+    activateUserId: record.activateUserId,
+    activateAdminUserId: record.activateAdminUserId,
   }
+}
+
+function isNonEmptyStateId(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0
+}
+
+function isValidStateRecord(record: StateRecord): boolean {
+  const intent = record.intent
+  if (intent === undefined || intent === 'login') {
+    return !record.bindUserId && !record.activateUserId && !record.activateAdminUserId
+  }
+  if (intent === 'bind') {
+    return (
+      isNonEmptyStateId(record.bindUserId)
+      && !record.activateUserId
+      && !record.activateAdminUserId
+    )
+  }
+  if (intent === 'activate') {
+    return (
+      !record.bindUserId
+      && isNonEmptyStateId(record.activateUserId)
+      && isNonEmptyStateId(record.activateAdminUserId)
+    )
+  }
+  return false
 }
 
 async function readGrantEnabled(localUserId: string): Promise<boolean | null> {
@@ -969,12 +1007,31 @@ export async function generateState(options: {
   redirectPath?: string | null
   intent?: DingTalkOAuthIntent | null
   bindUserId?: string | null
+  activateUserId?: string | null
+  activateAdminUserId?: string | null
 } = {}): Promise<string> {
   const state = crypto.randomUUID()
-  const normalizedIntent = options.intent === 'bind' ? 'bind' : null
+  const normalizedIntent = options.intent === 'bind' || options.intent === 'activate'
+    ? options.intent
+    : null
   const normalizedBindUserId = typeof options.bindUserId === 'string' && options.bindUserId.trim().length > 0
     ? options.bindUserId.trim()
     : null
+  const normalizedActivateUserId = typeof options.activateUserId === 'string' && options.activateUserId.trim().length > 0
+    ? options.activateUserId.trim()
+    : null
+  const normalizedActivateAdminUserId = typeof options.activateAdminUserId === 'string' && options.activateAdminUserId.trim().length > 0
+    ? options.activateAdminUserId.trim()
+    : null
+  if (normalizedIntent === 'bind' && !normalizedBindUserId) {
+    throw new Error('DingTalk bind state requires a user')
+  }
+  if (
+    normalizedIntent === 'activate'
+    && (!normalizedActivateUserId || !normalizedActivateAdminUserId)
+  ) {
+    throw new Error('DingTalk activation state requires target and administrator')
+  }
   const record: StateRecord = {
     expiresAt: Date.now() + STATE_TTL_MS,
     ...(typeof options.redirectPath === 'string' && options.redirectPath.trim().length > 0
@@ -982,6 +1039,12 @@ export async function generateState(options: {
       : {}),
     ...(normalizedIntent ? { intent: normalizedIntent } : {}),
     ...(normalizedIntent === 'bind' && normalizedBindUserId ? { bindUserId: normalizedBindUserId } : {}),
+    ...(normalizedIntent === 'activate' && normalizedActivateUserId
+      ? { activateUserId: normalizedActivateUserId }
+      : {}),
+    ...(normalizedIntent === 'activate' && normalizedActivateAdminUserId
+      ? { activateAdminUserId: normalizedActivateAdminUserId }
+      : {}),
   }
 
   const storedInRedis = await writeStateToRedis(state, record)

--- a/packages/core-backend/src/auth/user-activate.ts
+++ b/packages/core-backend/src/auth/user-activate.ts
@@ -50,6 +50,12 @@ export type ActivateUserInput = {
   enableDingTalkGrant?: boolean
   /** SSO: directory account that must be active + linked to this user. */
   directoryAccountId?: string | null
+  /** OAuth SSO: provider identity that the locked directory source must still match. */
+  expectedDingTalkIdentity?: {
+    corpId: string
+    openId?: string | null
+    unionId?: string | null
+  } | null
 }
 
 export type ActivateUserResult = {
@@ -104,6 +110,7 @@ export async function activatePendingUser(input: ActivateUserInput): Promise<Act
   let passwordHash: string | null = null
   let localPasswordSet = false
   let mustChangePassword = false
+  let membershipOrgId = input.orgId ?? null
 
   if (input.mode === 'temp_password') {
     temporaryPassword = input.temporaryPassword?.trim() || generateTempPassword()
@@ -134,11 +141,15 @@ export async function activatePendingUser(input: ActivateUserInput): Promise<Act
     }
 
     if (input.mode === 'sso' || input.directoryAccountId) {
-      await assertDirectorySourceActiveForActivate(client, {
+      const sourceOrgId = await assertDirectorySourceActiveForActivate(client, {
         userId,
         directoryAccountId: input.directoryAccountId ?? null,
         requireDingTalkSso: input.mode === 'sso',
+        expectedDingTalkIdentity: input.expectedDingTalkIdentity ?? null,
       })
+      if (input.mode === 'sso') {
+        membershipOrgId = sourceOrgId
+      }
     }
 
     const updated = await client.query(
@@ -159,7 +170,7 @@ export async function activatePendingUser(input: ActivateUserInput): Promise<Act
     }
 
     // Active membership for current org when provided.
-    if (input.orgId) {
+    if (membershipOrgId) {
       // `user_orgs` is (user_id, org_id, is_active, created_at) with PK (user_id, org_id) — there
       // is no `updated_at`. Writing one raised `42703` and aborted this transaction, which is why
       // the "schema variance" fallback underneath could never help: once a statement fails inside
@@ -173,7 +184,7 @@ export async function activatePendingUser(input: ActivateUserInput): Promise<Act
          VALUES ($1, $2, TRUE, NOW())
          ON CONFLICT (user_id, org_id) DO UPDATE
            SET is_active = TRUE`,
-        [userId, input.orgId],
+        [userId, membershipOrgId],
       )
     }
 
@@ -268,6 +279,9 @@ type DirectorySourceRow = {
   integration_provider: string | null
   account_corp_id: string | null
   integration_corp_id: string | null
+  account_open_id: string | null
+  account_union_id: string | null
+  integration_org_id: string | null
 }
 
 async function assertDirectorySourceActiveForActivate(
@@ -276,8 +290,9 @@ async function assertDirectorySourceActiveForActivate(
     userId: string
     directoryAccountId: string | null
     requireDingTalkSso: boolean
+    expectedDingTalkIdentity: ActivateUserInput['expectedDingTalkIdentity']
   },
-): Promise<void> {
+): Promise<string> {
   // Closed set: linked directory account must be active; integration active.
   // Explicit id: account row + link fail-closed (INNER semantics enforced in TS after LEFT JOIN
   // so we can distinguish SOURCE_MISSING account-not-found from LINK_MISMATCH).
@@ -286,7 +301,9 @@ async function assertDirectorySourceActiveForActivate(
     ? `SELECT da.id, da.is_active AS account_active, di.status AS integration_status,
               l.local_user_id, l.link_status,
               da.provider AS account_provider, di.provider AS integration_provider,
-              da.corp_id AS account_corp_id, di.corp_id AS integration_corp_id
+              da.corp_id AS account_corp_id, di.corp_id AS integration_corp_id,
+              da.open_id AS account_open_id, da.union_id AS account_union_id,
+              di.org_id AS integration_org_id
          FROM directory_accounts da
          JOIN directory_integrations di ON di.id = da.integration_id
          LEFT JOIN directory_account_links l ON l.directory_account_id = da.id
@@ -294,7 +311,9 @@ async function assertDirectorySourceActiveForActivate(
     : `SELECT da.id, da.is_active AS account_active, di.status AS integration_status,
               l.local_user_id, l.link_status,
               da.provider AS account_provider, di.provider AS integration_provider,
-              da.corp_id AS account_corp_id, di.corp_id AS integration_corp_id
+              da.corp_id AS account_corp_id, di.corp_id AS integration_corp_id,
+              da.open_id AS account_open_id, da.union_id AS account_union_id,
+              di.org_id AS integration_org_id
          FROM directory_account_links l
          JOIN directory_accounts da ON da.id = l.directory_account_id
          JOIN directory_integrations di ON di.id = da.integration_id
@@ -334,12 +353,39 @@ async function assertDirectorySourceActiveForActivate(
     const integrationProvider = String(candidate.integration_provider || '').toLowerCase()
     const accountCorp = String(candidate.account_corp_id || '').trim()
     const integrationCorp = String(candidate.integration_corp_id || '').trim()
-    return (
+    const providerAndCorpEligible = (
       accountProvider === 'dingtalk'
       && integrationProvider === 'dingtalk'
       && accountCorp.length > 0
       && accountCorp === integrationCorp
     )
+    if (!providerAndCorpEligible) return false
+
+    const expected = options.expectedDingTalkIdentity
+    if (!expected) return true
+    const expectedCorp = String(expected.corpId || '').trim()
+    const expectedOpenId = String(expected.openId || '').trim()
+    const expectedUnionId = String(expected.unionId || '').trim()
+    if (
+      expectedCorp.length === 0
+      || (expectedOpenId.length === 0 && expectedUnionId.length === 0)
+      || accountCorp !== expectedCorp
+    ) {
+      return false
+    }
+    if (
+      expectedOpenId.length > 0
+      && String(candidate.account_open_id || '').trim() !== expectedOpenId
+    ) {
+      return false
+    }
+    if (
+      expectedUnionId.length > 0
+      && String(candidate.account_union_id || '').trim() !== expectedUnionId
+    ) {
+      return false
+    }
+    return true
   }
 
   const eligibleRows = options.requireDingTalkSso
@@ -351,12 +397,18 @@ async function assertDirectorySourceActiveForActivate(
       'ACTIVATE_SOURCE_INELIGIBLE',
     )
   }
-  if (eligibleRows.some(
+  const activeEligible = eligibleRows.find(
     (candidate) =>
       candidate.account_active === true
       && String(candidate.integration_status || '').toLowerCase() === 'active',
-  )) {
-    return
+  )
+  if (activeEligible) {
+    const sourceOrgId = String(activeEligible.integration_org_id || '').trim()
+    if (sourceOrgId) return sourceOrgId
+    throwCoded(
+      'Directory source is not a DingTalk account eligible for SSO activation',
+      'ACTIVATE_SOURCE_INELIGIBLE',
+    )
   }
   if (eligibleRows.some(
     (candidate) => String(candidate.integration_status || '').toLowerCase() !== 'active',

--- a/packages/core-backend/src/routes/auth.ts
+++ b/packages/core-backend/src/routes/auth.ts
@@ -31,6 +31,7 @@ import {
 } from '../auth/invite-accept-writes'
 import { verifyInviteToken } from '../auth/invite-tokens'
 import { validatePassword } from '../auth/password-policy'
+import { activatePendingUser } from '../auth/user-activate'
 import { createUserSession, getUserSession, listUserSessions, revokeUserSession, touchUserSession } from '../auth/session-registry'
 import { revokeUserSessions } from '../auth/session-revocation'
 import { FEATURE_FLAGS } from '../config/flags'
@@ -41,7 +42,8 @@ import { isFwbWritebackEnabled } from '../multitable/approval-fwb-activation'
 import { extractTenantFromHeaders } from '../db/sharding/tenant-context'
 import { query } from '../db/pg'
 import { parseUserActivationStatus } from '../auth/user-activation'
-import { listUserPermissions } from '../rbac/service'
+import { isAdmin as isRbacAdmin, listUserPermissions } from '../rbac/service'
+import { auditLog } from '../audit/audit'
 import { secretManager } from '../security/SecretManager'
 import { isPlmEnabled, resolveEffectiveProductMode } from '../config/product-mode'
 import { getBcryptSaltRounds, resolveRuntimeJwtSecret } from '../security/auth-runtime-config'
@@ -451,6 +453,162 @@ async function loadAuthPermissions(userId: string): Promise<string[]> {
     logger.warn('Failed to load legacy permissions for auth user', error instanceof Error ? error : undefined)
     return []
   }
+}
+
+async function isActivePlatformAdmin(userId: string): Promise<boolean> {
+  const result = await query<{
+    is_active: boolean
+    activation_status: string | null
+  }>(
+    `SELECT is_active, activation_status
+       FROM users
+      WHERE id = $1
+      LIMIT 1`,
+    [userId],
+  )
+  const row = result.rows[0]
+  const activationStatus = parseUserActivationStatus(row?.activation_status)
+  return Boolean(
+    row?.is_active === true
+    && activationStatus.ok
+    && activationStatus.status === 'activated'
+    && await isRbacAdmin(userId),
+  )
+}
+
+class DingTalkActivationIntentError extends Error {
+  readonly statusCode: number
+  readonly code: string
+
+  constructor(statusCode: number, code: string, message: string) {
+    super(message)
+    this.name = 'DingTalkActivationIntentError'
+    this.statusCode = statusCode
+    this.code = code
+  }
+}
+
+type DingTalkActivationSource = {
+  directoryAccountId: string
+}
+
+async function resolveDingTalkActivationSource(input: {
+  corpId: string
+  openId?: string
+  unionId?: string
+}): Promise<DingTalkActivationSource> {
+  const corpId = input.corpId.trim()
+  const openId = String(input.openId || '').trim()
+  const unionId = String(input.unionId || '').trim()
+  if (!corpId || (!openId && !unionId)) {
+    throw new DingTalkActivationIntentError(
+      409,
+      'activate_source_ineligible',
+      'DingTalk activation source is not eligible',
+    )
+  }
+
+  const result = await query<{
+    directory_account_id: string
+  }>(
+    `SELECT account.id AS directory_account_id
+       FROM directory_accounts account
+       JOIN directory_integrations integration
+         ON integration.id = account.integration_id
+      WHERE account.provider = 'dingtalk'
+        AND integration.provider = 'dingtalk'
+        AND account.is_active = TRUE
+        AND integration.status = 'active'
+        AND account.corp_id = $1
+        AND integration.corp_id = $1
+        AND ($2 = '' OR account.open_id = $2)
+        AND ($3 = '' OR account.union_id = $3)
+      ORDER BY account.id
+      LIMIT 2`,
+    [corpId, openId, unionId],
+  )
+  if (result.rows.length !== 1) {
+    throw new DingTalkActivationIntentError(
+      409,
+      'activate_source_ineligible',
+      'DingTalk activation source is not eligible',
+    )
+  }
+  return {
+    directoryAccountId: result.rows[0].directory_account_id,
+  }
+}
+
+async function loadActivatedAuthUser(userId: string): Promise<User> {
+  const result = await query<{
+    id: string
+    email: string | null
+    name: string | null
+    role: string | null
+    is_active: boolean
+    activation_status: string | null
+  }>(
+    `SELECT id, email, name, role, is_active, activation_status
+       FROM users
+      WHERE id = $1
+      LIMIT 1`,
+    [userId],
+  )
+  const row = result.rows[0]
+  const activationStatus = parseUserActivationStatus(row?.activation_status)
+  if (
+    !row
+    || row.is_active !== true
+    || !activationStatus.ok
+    || activationStatus.status !== 'activated'
+  ) {
+    throw new DingTalkActivationIntentError(
+      409,
+      'activate_commit_incomplete',
+      'DingTalk activation did not complete',
+    )
+  }
+  return {
+    id: row.id,
+    email: row.email ?? '',
+    name: row.name ?? row.email ?? row.id,
+    role: row.role ?? 'user',
+    permissions: await loadAuthPermissions(row.id),
+    created_at: new Date(),
+    updated_at: new Date(),
+  }
+}
+
+function mapDingTalkActivationFailure(error: unknown): DingTalkActivationIntentError {
+  if (error instanceof DingTalkActivationIntentError) return error
+  const code = error instanceof Error
+    ? String((error as Error & { code?: unknown }).code || '')
+    : ''
+  if (code === 'ACTIVATE_USER_NOT_FOUND') {
+    return new DingTalkActivationIntentError(404, 'activate_target_not_found', 'Activation target was not found')
+  }
+  if (
+    code === 'ACTIVATE_NOT_PENDING'
+    || code === 'ACTIVATE_RACE'
+    || code === 'ACTIVATE_SOURCE_MISSING'
+    || code === 'ACTIVATE_SOURCE_INACTIVE'
+    || code === 'ACTIVATE_INTEGRATION_INACTIVE'
+    || code === 'ACTIVATE_LINK_MISMATCH'
+    || code === 'ACTIVATE_SOURCE_INELIGIBLE'
+    || code === 'ACTIVATE_ALIAS_CONFLICT'
+    || code === 'ACTIVATE_ALIAS_REQUIRED'
+  ) {
+    return new DingTalkActivationIntentError(
+      409,
+      'activate_source_ineligible',
+      'DingTalk activation source is not eligible',
+    )
+  }
+  return new DingTalkActivationIntentError(
+    500,
+    'activate_failed',
+    'DingTalk activation failed',
+  )
 }
 
 async function issueAuthSessionToken(user: User, req: Request): Promise<string> {
@@ -1212,19 +1370,76 @@ authRouter.get('/dingtalk/launch', async (req: Request, res: Response) => {
     }
 
     const rawIntent = typeof req.query.intent === 'string' ? req.query.intent.trim().toLowerCase() : ''
-    const mode: 'bind' | 'login' = rawIntent === 'bind' ? 'bind' : 'login'
+    if (rawIntent && rawIntent !== 'login' && rawIntent !== 'bind' && rawIntent !== 'activate') {
+      return res.status(400).json({
+        success: false,
+        error: 'Unsupported DingTalk OAuth intent',
+        code: 'invalid_dingtalk_intent',
+      })
+    }
+    const mode: 'bind' | 'activate' | 'login' = rawIntent === 'bind'
+      ? 'bind'
+      : rawIntent === 'activate'
+        ? 'activate'
+        : 'login'
     const redirectPath = normalizeDingTalkRedirectPath(req.query.redirect)
 
     let bindUserId: string | null = null
+    let activateUserId: string | null = null
+    let activateAdminUserId: string | null = null
     if (mode === 'bind') {
       const authResult = await requireAuthenticatedUser(req, res)
       if (!authResult) return
       bindUserId = authResult.user.id
+    } else if (mode === 'activate') {
+      const authResult = await requireAuthenticatedUser(req, res)
+      if (!authResult) return
+      if (!await isRbacAdmin(authResult.user.id)) {
+        return res.status(403).json({
+          success: false,
+          error: 'Platform administrator permission is required',
+          code: 'activate_admin_required',
+        })
+      }
+      activateUserId = typeof req.query.targetUserId === 'string'
+        ? req.query.targetUserId.trim()
+        : ''
+      if (!activateUserId) {
+        return res.status(400).json({
+          success: false,
+          error: 'Missing required parameter: targetUserId',
+          code: 'activate_target_required',
+        })
+      }
+      const target = await query<{ id: string }>(
+        `SELECT id
+           FROM users
+          WHERE id = $1
+            AND activation_status = 'pending_activation'
+            AND is_active = FALSE
+          LIMIT 1`,
+        [activateUserId],
+      )
+      if (!target.rows[0]) {
+        return res.status(409).json({
+          success: false,
+          error: 'Activation target is not pending',
+          code: 'activate_target_not_pending',
+        })
+      }
+      activateAdminUserId = authResult.user.id
     }
 
     const state = await generateState(
       mode === 'bind'
         ? { redirectPath, intent: 'bind', bindUserId }
+        : mode === 'activate'
+          ? {
+              redirectPath,
+              intent: 'activate',
+              activateUserId,
+              activateAdminUserId,
+            }
         : { redirectPath },
     )
     const url = buildAuthUrl(state)
@@ -1241,7 +1456,7 @@ authRouter.get('/dingtalk/launch', async (req: Request, res: Response) => {
     logger.error('DingTalk launch error', error instanceof Error ? error : undefined)
     return res.status(500).json({
       success: false,
-      error: error instanceof Error ? error.message : 'Failed to build DingTalk auth URL',
+      error: 'Failed to build DingTalk auth URL',
     })
   }
 })
@@ -1320,6 +1535,82 @@ authRouter.post('/dingtalk/callback', async (req: Request, res: Response) => {
       })
     }
 
+    if (stateCheck.intent === 'activate') {
+      const activateUserId = String(stateCheck.activateUserId || '').trim()
+      const activateAdminUserId = String(stateCheck.activateAdminUserId || '').trim()
+      if (!activateUserId || !activateAdminUserId) {
+        throw new DingTalkActivationIntentError(
+          400,
+          'activate_state_invalid',
+          'DingTalk activation state is invalid',
+        )
+      }
+      if (!await isActivePlatformAdmin(activateAdminUserId)) {
+        throw new DingTalkActivationIntentError(
+          403,
+          'activate_admin_required',
+          'Platform administrator permission is required',
+        )
+      }
+
+      const profile = await exchangeCodeForDingTalkProfile(code)
+      const runtimeStatus = getDingTalkRuntimeStatus()
+      const corpId = String(runtimeStatus.corpId || '').trim()
+      const source = await resolveDingTalkActivationSource({
+        corpId,
+        openId: profile.openId,
+        unionId: profile.unionId,
+      })
+
+      try {
+        await activatePendingUser({
+          userId: activateUserId,
+          mode: 'sso',
+          adminUserId: activateAdminUserId,
+          directoryAccountId: source.directoryAccountId,
+          enableDingTalkGrant: true,
+          expectedDingTalkIdentity: {
+            corpId,
+            openId: profile.openId,
+            unionId: profile.unionId,
+          },
+        })
+      } catch (error) {
+        throw mapDingTalkActivationFailure(error)
+      }
+
+      const user = await loadActivatedAuthUser(activateUserId)
+      const token = await issueAuthSessionToken(user, req)
+      await auditLog({
+        actorId: activateAdminUserId,
+        actorType: 'user',
+        action: 'directory.user.activate_sso',
+        resourceType: 'user',
+        resourceId: activateUserId,
+        meta: {
+          mode: 'sso',
+          source: 'dingtalk_oauth',
+        },
+      })
+
+      return res.json({
+        success: true,
+        data: {
+          mode: 'activate',
+          user: {
+            id: user.id,
+            email: user.email,
+            name: user.name,
+            role: user.role,
+            permissions: user.permissions,
+          },
+          token,
+          redirectPath: stateCheck.redirectPath || null,
+          features: buildFeaturePayload(user),
+        },
+      })
+    }
+
     const result = await exchangeCodeForUser(code)
     const permissions = await loadAuthPermissions(result.localUserId)
     const user: User = {
@@ -1353,12 +1644,16 @@ authRouter.post('/dingtalk/callback', async (req: Request, res: Response) => {
     })
   } catch (error) {
     logger.error('DingTalk callback error', error instanceof Error ? error : undefined)
-    const statusCode = error instanceof DingTalkLoginPolicyError
+    const statusCode = error instanceof DingTalkActivationIntentError
+      ? error.statusCode
+      : error instanceof DingTalkLoginPolicyError
       ? error.statusCode
       : error instanceof DingTalkRequestError
         ? 502
         : 500
-    const message = error instanceof DingTalkLoginPolicyError
+    const message = error instanceof DingTalkActivationIntentError
+      ? error.message
+      : error instanceof DingTalkLoginPolicyError
       ? error.message
       : error instanceof DingTalkRequestError
         ? error.message
@@ -1367,6 +1662,7 @@ authRouter.post('/dingtalk/callback', async (req: Request, res: Response) => {
     return res.status(statusCode).json({
       success: false,
       error: message,
+      ...(error instanceof DingTalkActivationIntentError ? { code: error.code } : {}),
     })
   }
 })

--- a/packages/core-backend/tests/integration/directory-deprovision-grant-table.db.test.ts
+++ b/packages/core-backend/tests/integration/directory-deprovision-grant-table.db.test.ts
@@ -83,6 +83,8 @@ async function seedActivationSource(options: {
   accountCorpId?: string
   integrationCorpId?: string
   integrationStatus?: string
+  openId?: string
+  unionId?: string
 }) {
   const integrationCorpId = options.integrationCorpId ?? `corp-${ORG}`
   const integration = await query<{ id: string }>(
@@ -99,14 +101,17 @@ async function seedActivationSource(options: {
   )
   const account = await query<{ id: string }>(
     `INSERT INTO directory_accounts
-       (integration_id, provider, corp_id, external_user_id, external_key, name, is_active)
+       (integration_id, provider, corp_id, external_user_id, external_key, name,
+        open_id, union_id, is_active)
      VALUES ($1::uuid, $2, $3, 'ext-activation-source',
-             'dingtalk:activation-source:ext', 'Activation Source', $4)
+             'dingtalk:activation-source:ext', 'Activation Source', $4, $5, $6)
      RETURNING id::text AS id`,
     [
       integration.rows[0].id,
       options.accountProvider ?? 'dingtalk',
       options.accountCorpId ?? integrationCorpId,
+      options.openId ?? null,
+      options.unionId ?? null,
       options.accountActive ?? true,
     ],
   )
@@ -292,15 +297,23 @@ describeIfDatabase('DingTalk grant/membership writes target the real tables (rea
        VALUES ($1, 'sso-source-user', 'SSO Source', 'x', FALSE, 'pending_activation', FALSE)`,
       [USER],
     )
-    const source = await seedActivationSource({ linkedUserId: USER })
+    const source = await seedActivationSource({
+      linkedUserId: USER,
+      openId: 'oauth-open-1',
+      unionId: 'oauth-union-1',
+    })
 
     await activatePendingUser({
       userId: USER,
       mode: 'sso',
       adminUserId: 'admin-test',
-      orgId: ORG,
       enableDingTalkGrant: true,
       directoryAccountId: source.accountId,
+      expectedDingTalkIdentity: {
+        corpId: `corp-${ORG}`,
+        openId: 'oauth-open-1',
+        unionId: 'oauth-union-1',
+      },
     })
 
     const committed = await query<{
@@ -326,6 +339,57 @@ describeIfDatabase('DingTalk grant/membership writes target the real tables (rea
       is_active: true,
       membership_active: true,
       grant_enabled: true,
+    })
+  })
+
+  it('T3 SSO rejects an OAuth profile that does not match the locked source row', async () => {
+    await query(
+      `INSERT INTO users
+         (id, username, name, password_hash, is_active, activation_status, local_password_set)
+       VALUES ($1, 'oauth-mismatch-user', 'OAuth Mismatch', 'x', FALSE, 'pending_activation', FALSE)`,
+      [USER],
+    )
+    const source = await seedActivationSource({
+      linkedUserId: USER,
+      openId: 'oauth-open-authoritative',
+      unionId: 'oauth-union-authoritative',
+    })
+
+    await expect(
+      activatePendingUser({
+        userId: USER,
+        mode: 'sso',
+        adminUserId: 'admin-test',
+        orgId: ORG,
+        enableDingTalkGrant: true,
+        directoryAccountId: source.accountId,
+        expectedDingTalkIdentity: {
+          corpId: `corp-${ORG}`,
+          openId: 'oauth-open-attacker',
+          unionId: 'oauth-union-authoritative',
+        },
+      }),
+    ).rejects.toMatchObject({ code: 'ACTIVATE_SOURCE_INELIGIBLE' })
+
+    const residue = await query<{
+      activation_status: string
+      is_active: boolean
+      memberships: number
+      grants: number
+    }>(
+      `SELECT u.activation_status,
+              u.is_active,
+              (SELECT count(*)::int FROM user_orgs WHERE user_id = u.id) AS memberships,
+              (SELECT count(*)::int FROM user_external_auth_grants WHERE local_user_id = u.id) AS grants
+         FROM users u
+        WHERE u.id = $1`,
+      [USER],
+    )
+    expect(residue.rows[0]).toMatchObject({
+      activation_status: 'pending_activation',
+      is_active: false,
+      memberships: 0,
+      grants: 0,
     })
   })
 

--- a/packages/core-backend/tests/unit/auth-invite-routes.test.ts
+++ b/packages/core-backend/tests/unit/auth-invite-routes.test.ts
@@ -40,6 +40,8 @@ vi.mock('../../src/auth/invite-tokens', () => ({
 vi.mock('../../src/db/pg', () => ({
   query: pgMocks.query,
   transaction: pgMocks.transaction,
+  // #4662's OAuth activation intent imports pool from db/pg; this suite never touches it.
+  pool: { query: pgMocks.query },
 }))
 
 vi.mock('bcryptjs', () => bcryptMocks)

--- a/packages/core-backend/tests/unit/auth-login-routes.test.ts
+++ b/packages/core-backend/tests/unit/auth-login-routes.test.ts
@@ -28,6 +28,14 @@ const sessionMocks = vi.hoisted(() => ({
   revokeUserSessions: vi.fn(),
 }))
 
+const activationMocks = vi.hoisted(() => ({
+  activatePendingUser: vi.fn(),
+}))
+
+const auditMocks = vi.hoisted(() => ({
+  auditLog: vi.fn(),
+}))
+
 const sessionRegistryMocks = vi.hoisted(() => ({
   createUserSession: vi.fn(),
   listUserSessions: vi.fn(),
@@ -84,6 +92,7 @@ const dingtalkClientMocks = vi.hoisted(() => ({
 
 const rbacMocks = vi.hoisted(() => ({
   listUserPermissions: vi.fn(),
+  isAdmin: vi.fn(),
 }))
 
 vi.mock('../../src/auth/AuthService', () => ({
@@ -102,6 +111,14 @@ vi.mock('bcryptjs', () => bcryptMocks)
 
 vi.mock('../../src/auth/session-revocation', () => ({
   revokeUserSessions: sessionMocks.revokeUserSessions,
+}))
+
+vi.mock('../../src/auth/user-activate', () => ({
+  activatePendingUser: activationMocks.activatePendingUser,
+}))
+
+vi.mock('../../src/audit/audit', () => ({
+  auditLog: auditMocks.auditLog,
 }))
 
 vi.mock('../../src/auth/session-registry', () => ({
@@ -128,6 +145,7 @@ vi.mock('../../src/auth/dingtalk-oauth', () => ({
 
 vi.mock('../../src/rbac/service', () => ({
   listUserPermissions: rbacMocks.listUserPermissions,
+  isAdmin: rbacMocks.isAdmin,
 }))
 
 vi.mock('../../src/integrations/dingtalk/client', () => ({
@@ -227,6 +245,8 @@ describe('auth login routes', () => {
     bcryptMocks.hash.mockReset()
     bcryptMocks.compare.mockReset()
     sessionMocks.revokeUserSessions.mockReset()
+    activationMocks.activatePendingUser.mockReset()
+    auditMocks.auditLog.mockReset()
     sessionRegistryMocks.createUserSession.mockReset()
     sessionRegistryMocks.listUserSessions.mockReset()
     sessionRegistryMocks.getUserSession.mockReset()
@@ -243,6 +263,7 @@ describe('auth login routes', () => {
     dingtalkOauthMocks.unbindSelfManagedDingTalkIdentity.mockReset()
     dingtalkOauthMocks.unbindSelfManagedDingTalkIdentity.mockResolvedValue(true)
     rbacMocks.listUserPermissions.mockReset()
+    rbacMocks.isAdmin.mockReset()
     dingtalkOauthMocks.getDingTalkRuntimeStatus.mockReturnValue({
       configured: true,
       available: true,
@@ -997,6 +1018,299 @@ describe('auth login routes', () => {
       state: 'state-bind-1',
       mode: 'bind',
     })
+  })
+
+  it('rejects unknown DingTalk launch intents instead of falling back to login', async () => {
+    dingtalkOauthMocks.isDingTalkConfigured.mockReturnValue(true)
+
+    const response = await invokeRoute('get', '/dingtalk/launch', {
+      query: { intent: 'future-mode' },
+    })
+
+    expect(response.statusCode).toBe(400)
+    expect((response.body as Record<string, any>).code).toBe('invalid_dingtalk_intent')
+    expect(dingtalkOauthMocks.generateState).not.toHaveBeenCalled()
+  })
+
+  it('requires an authoritative platform admin to launch activate intent', async () => {
+    dingtalkOauthMocks.isDingTalkConfigured.mockReturnValue(true)
+    authServiceMocks.verifyToken.mockResolvedValue({
+      id: 'role-text-admin',
+      email: 'operator@example.com',
+      name: 'Operator',
+      role: 'admin',
+      permissions: [],
+    })
+    rbacMocks.isAdmin.mockResolvedValue(false)
+
+    const response = await invokeRoute('get', '/dingtalk/launch', {
+      query: {
+        intent: 'activate',
+        targetUserId: 'pending-user',
+      },
+      headers: { authorization: 'Bearer live-token' },
+    })
+
+    expect(response.statusCode).toBe(403)
+    expect((response.body as Record<string, any>).code).toBe('activate_admin_required')
+    expect(pgMocks.query).not.toHaveBeenCalled()
+    expect(dingtalkOauthMocks.generateState).not.toHaveBeenCalled()
+  })
+
+  it('rejects activate launch without a target before querying the target', async () => {
+    dingtalkOauthMocks.isDingTalkConfigured.mockReturnValue(true)
+    authServiceMocks.verifyToken.mockResolvedValue({
+      id: 'platform-admin',
+      email: 'admin@example.com',
+      name: 'Admin',
+      role: 'user',
+      permissions: [],
+    })
+    rbacMocks.isAdmin.mockResolvedValue(true)
+
+    const response = await invokeRoute('get', '/dingtalk/launch', {
+      query: { intent: 'activate' },
+      headers: { authorization: 'Bearer live-token' },
+    })
+
+    expect(response.statusCode).toBe(400)
+    expect((response.body as Record<string, any>).code).toBe('activate_target_required')
+    expect(pgMocks.query).not.toHaveBeenCalled()
+    expect(dingtalkOauthMocks.generateState).not.toHaveBeenCalled()
+  })
+
+  it('binds activate state to the pending target and authoritative admin', async () => {
+    dingtalkOauthMocks.isDingTalkConfigured.mockReturnValue(true)
+    dingtalkOauthMocks.generateState.mockResolvedValue('state-activate-1')
+    dingtalkOauthMocks.buildAuthUrl.mockReturnValue('https://login.dingtalk.test/oauth-activate')
+    authServiceMocks.verifyToken.mockResolvedValue({
+      id: 'platform-admin',
+      email: 'admin@example.com',
+      name: 'Admin',
+      role: 'user',
+      permissions: [],
+    })
+    rbacMocks.isAdmin.mockResolvedValue(true)
+    pgMocks.query.mockResolvedValueOnce({ rows: [{ id: 'pending-user' }] })
+
+    const response = await invokeRoute('get', '/dingtalk/launch', {
+      query: {
+        intent: 'activate',
+        targetUserId: 'pending-user',
+        redirect: '/admin/users',
+      },
+      headers: { authorization: 'Bearer live-token' },
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(dingtalkOauthMocks.generateState).toHaveBeenCalledWith({
+      redirectPath: '/admin/users',
+      intent: 'activate',
+      activateUserId: 'pending-user',
+      activateAdminUserId: 'platform-admin',
+    })
+    expect((response.body as Record<string, any>).data.mode).toBe('activate')
+  })
+
+  it('rechecks that the state-bound administrator is still active before an activate callback', async () => {
+    dingtalkOauthMocks.validateState.mockResolvedValue({
+      valid: true,
+      intent: 'activate',
+      activateUserId: 'pending-user',
+      activateAdminUserId: 'former-admin',
+    })
+    dingtalkOauthMocks.isDingTalkConfigured.mockReturnValue(true)
+    rbacMocks.isAdmin.mockResolvedValue(true)
+    pgMocks.query.mockResolvedValueOnce({
+      rows: [{
+        is_active: false,
+        activation_status: 'activated',
+      }],
+    })
+
+    const response = await invokeRoute('post', '/dingtalk/callback', {
+      body: { code: 'auth-code', state: 'state-activate-1' },
+    })
+
+    expect(response.statusCode).toBe(403)
+    expect((response.body as Record<string, any>).code).toBe('activate_admin_required')
+    expect(rbacMocks.isAdmin).not.toHaveBeenCalled()
+    expect(dingtalkOauthMocks.exchangeCodeForDingTalkProfile).not.toHaveBeenCalled()
+    expect(activationMocks.activatePendingUser).not.toHaveBeenCalled()
+  })
+
+  it('activates the exact DingTalk source before issuing a session', async () => {
+    dingtalkOauthMocks.validateState.mockResolvedValue({
+      valid: true,
+      redirectPath: '/admin/users',
+      intent: 'activate',
+      activateUserId: 'pending-user',
+      activateAdminUserId: 'platform-admin',
+    })
+    dingtalkOauthMocks.isDingTalkConfigured.mockReturnValue(true)
+    dingtalkOauthMocks.exchangeCodeForDingTalkProfile.mockResolvedValue({
+      openId: 'open-1',
+      unionId: 'union-1',
+      nick: 'Pending Person',
+    })
+    rbacMocks.isAdmin.mockResolvedValue(true)
+    rbacMocks.listUserPermissions.mockResolvedValue(['attendance:read'])
+    let resolveActivation!: (result: {
+      userId: string
+      activationStatus: 'activated'
+      isActive: true
+      localPasswordSet: boolean
+    }) => void
+    activationMocks.activatePendingUser.mockReturnValue(new Promise((resolve) => {
+      resolveActivation = resolve
+    }))
+    pgMocks.query
+      .mockResolvedValueOnce({
+        rows: [{
+          is_active: true,
+          activation_status: 'activated',
+        }],
+      })
+      .mockResolvedValueOnce({
+        rows: [{ directory_account_id: 'account-1' }],
+      })
+      .mockResolvedValueOnce({
+        rows: [{
+          id: 'pending-user',
+          email: null,
+          name: 'Pending Person',
+          role: 'user',
+          is_active: true,
+          activation_status: 'activated',
+        }],
+      })
+      .mockResolvedValueOnce({ rows: [] })
+    authServiceMocks.createToken.mockReturnValue('activated-session-token')
+    authServiceMocks.readTokenPayload.mockReturnValue(null)
+
+    const responsePromise = invokeRoute('post', '/dingtalk/callback', {
+      body: { code: 'auth-code', state: 'state-activate-1' },
+    })
+    await vi.waitFor(() => {
+      expect(activationMocks.activatePendingUser).toHaveBeenCalledTimes(1)
+    })
+    expect(authServiceMocks.createToken).not.toHaveBeenCalled()
+    resolveActivation({
+      userId: 'pending-user',
+      activationStatus: 'activated',
+      isActive: true,
+      localPasswordSet: false,
+    })
+    const response = await responsePromise
+
+    expect(response.statusCode).toBe(200)
+    expect(dingtalkOauthMocks.exchangeCodeForUser).not.toHaveBeenCalled()
+    expect(activationMocks.activatePendingUser).toHaveBeenCalledWith({
+      userId: 'pending-user',
+      mode: 'sso',
+      adminUserId: 'platform-admin',
+      directoryAccountId: 'account-1',
+      enableDingTalkGrant: true,
+      expectedDingTalkIdentity: {
+        corpId: 'ding-corp',
+        openId: 'open-1',
+        unionId: 'union-1',
+      },
+    })
+    expect((response.body as Record<string, any>).data).toMatchObject({
+      mode: 'activate',
+      token: 'activated-session-token',
+      redirectPath: '/admin/users',
+      user: {
+        id: 'pending-user',
+        email: '',
+      },
+    })
+    expect(auditMocks.auditLog).toHaveBeenCalledWith(expect.objectContaining({
+      actorId: 'platform-admin',
+      resourceId: 'pending-user',
+      meta: {
+        mode: 'sso',
+        source: 'dingtalk_oauth',
+      },
+    }))
+  })
+
+  it('issues no session when the activate callback source is not an exact match', async () => {
+    dingtalkOauthMocks.validateState.mockResolvedValue({
+      valid: true,
+      intent: 'activate',
+      activateUserId: 'pending-user',
+      activateAdminUserId: 'platform-admin',
+    })
+    dingtalkOauthMocks.isDingTalkConfigured.mockReturnValue(true)
+    dingtalkOauthMocks.exchangeCodeForDingTalkProfile.mockResolvedValue({
+      openId: 'wrong-open',
+      unionId: 'wrong-union',
+      nick: 'Wrong Person',
+    })
+    rbacMocks.isAdmin.mockResolvedValue(true)
+    pgMocks.query
+      .mockResolvedValueOnce({
+        rows: [{
+          is_active: true,
+          activation_status: 'activated',
+        }],
+      })
+      .mockResolvedValueOnce({ rows: [] })
+
+    const response = await invokeRoute('post', '/dingtalk/callback', {
+      body: { code: 'auth-code', state: 'state-activate-1' },
+    })
+
+    expect(response.statusCode).toBe(409)
+    expect((response.body as Record<string, any>).code).toBe('activate_source_ineligible')
+    expect(activationMocks.activatePendingUser).not.toHaveBeenCalled()
+    expect(authServiceMocks.createToken).not.toHaveBeenCalled()
+    expect(sessionRegistryMocks.createUserSession).not.toHaveBeenCalled()
+  })
+
+  it('issues no session and hides internal details when activate commit fails', async () => {
+    dingtalkOauthMocks.validateState.mockResolvedValue({
+      valid: true,
+      intent: 'activate',
+      activateUserId: 'pending-user',
+      activateAdminUserId: 'platform-admin',
+    })
+    dingtalkOauthMocks.isDingTalkConfigured.mockReturnValue(true)
+    dingtalkOauthMocks.exchangeCodeForDingTalkProfile.mockResolvedValue({
+      openId: 'open-1',
+      unionId: 'union-1',
+      nick: 'Pending Person',
+    })
+    rbacMocks.isAdmin.mockResolvedValue(true)
+    pgMocks.query
+      .mockResolvedValueOnce({
+        rows: [{
+          is_active: true,
+          activation_status: 'activated',
+        }],
+      })
+      .mockResolvedValueOnce({
+        rows: [{ directory_account_id: 'account-1' }],
+      })
+    activationMocks.activatePendingUser.mockRejectedValue(
+      new Error('duplicate key value violates constraint secret_alias_idx'),
+    )
+
+    const response = await invokeRoute('post', '/dingtalk/callback', {
+      body: { code: 'auth-code', state: 'state-activate-1' },
+    })
+
+    expect(response.statusCode).toBe(500)
+    expect(response.body).toMatchObject({
+      success: false,
+      error: 'DingTalk activation failed',
+      code: 'activate_failed',
+    })
+    expect(JSON.stringify(response.body)).not.toContain('duplicate key')
+    expect(authServiceMocks.createToken).not.toHaveBeenCalled()
+    expect(auditMocks.auditLog).not.toHaveBeenCalled()
   })
 
   it('rejects a bind callback when no session token is provided', async () => {

--- a/packages/core-backend/tests/unit/dingtalk-oauth-state-store.test.ts
+++ b/packages/core-backend/tests/unit/dingtalk-oauth-state-store.test.ts
@@ -241,6 +241,56 @@ describe('DingTalk OAuth state store', () => {
     })
   })
 
+  it('round-trips an activate intent once with both target and administrator bound', async () => {
+    vi.stubEnv('REDIS_URL', 'redis://localhost:6379')
+
+    const state = await generateState({
+      redirectPath: '/admin/users',
+      intent: 'activate',
+      activateUserId: 'pending-user',
+      activateAdminUserId: 'platform-admin',
+    })
+
+    await expect(validateState(state)).resolves.toEqual({
+      valid: true,
+      redirectPath: '/admin/users',
+      intent: 'activate',
+      activateUserId: 'pending-user',
+      activateAdminUserId: 'platform-admin',
+    })
+    await expect(validateState(state)).resolves.toEqual({
+      valid: false,
+      error: 'Invalid or unknown state parameter',
+    })
+  })
+
+  it('rejects incomplete activate state generation', async () => {
+    await expect(generateState({
+      intent: 'activate',
+      activateUserId: 'pending-user',
+    })).rejects.toThrow('requires target and administrator')
+  })
+
+  it('fails closed on a persisted unknown intent', async () => {
+    vi.stubEnv('REDIS_URL', 'redis://localhost:6379')
+    const state = await generateState()
+    const key = `metasheet:auth:dingtalk:state:${state}`
+    const stored = redisMockState.kv.get(key)
+    expect(stored).toBeDefined()
+    redisMockState.kv.set(key, {
+      value: JSON.stringify({
+        expiresAt: Date.now() + 60_000,
+        intent: 'future-unsafe-intent',
+      }),
+      expiresAt: stored?.expiresAt ?? null,
+    })
+
+    await expect(validateState(state)).resolves.toEqual({
+      valid: false,
+      error: 'Invalid or unknown state parameter',
+    })
+  })
+
   it('returns expired when a Redis-backed state exceeds its logical TTL', async () => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date('2026-03-31T00:00:00.000Z'))
@@ -424,25 +474,12 @@ describe('DingTalk OAuth state store', () => {
       unionId: 'union-id-1',
       nick: 'Ding User',
     })
-    vi.mocked(query)
-      .mockResolvedValueOnce({ rows: [] } as any)
-      .mockResolvedValueOnce({
-        rows: [{
-          id: 'user-new',
-          email: 'dingtalk_open-id-1@placeholder.local',
-          name: 'Ding User',
-          role: 'user',
-          is_active: true,
-          activation_status: 'activated',
-        }],
-      } as any)
-      .mockResolvedValueOnce({ rows: [] } as any)
+    vi.mocked(query).mockResolvedValueOnce({ rows: [] } as any)
 
-    const txCalls: Array<[string, unknown[]]> = []
+    let insertedUserParams: unknown[] | null = null
     vi.mocked(transaction).mockImplementation(async (callback: (client: { query: typeof query }) => Promise<unknown>) => {
       const aliasOwners = new Map<string, string>()
       const clientQuery = vi.fn(async (sql: string, params: unknown[] = []) => {
-        txCalls.push([String(sql), params])
         const statement = String(sql)
         if (/INSERT INTO user_login_aliases/i.test(statement)) {
           aliasOwners.set(String(params[2] ?? ''), String(params[0] ?? ''))
@@ -451,6 +488,19 @@ describe('DingTalk OAuth state store', () => {
         if (/SELECT user_id FROM user_login_aliases/i.test(statement)) {
           const ownerId = aliasOwners.get(String(params[0] ?? ''))
           return { rows: ownerId ? [{ user_id: ownerId }] : [] }
+        }
+        if (/INSERT INTO users/i.test(statement)) {
+          insertedUserParams = params
+          return {
+            rows: [{
+              id: 'user-new',
+              email: 'dingtalk_open-id-1@placeholder.local',
+              name: 'Ding User',
+              role: 'user',
+              is_active: true,
+              activation_status: 'activated',
+            }],
+          }
         }
         if (/FROM users[\s\S]*FOR UPDATE/i.test(statement)) {
           return {
@@ -495,11 +545,6 @@ describe('DingTalk OAuth state store', () => {
     const result = await exchangeCodeForUser('auth-code')
 
     expect(result.localUserId).toBe('user-new')
-    // #4658 moved provisioning INSERTs into the alias-claiming transaction: the password-hash
-    // witness now lives on the transaction client, not the top-level query sequence.
-    const usersInsert = txCalls.find(([sql]) => /INSERT INTO users/i.test(sql) && sql.includes('password_hash'))
-    expect(usersInsert).toBeDefined()
-    const hashParam = (usersInsert?.[1] ?? []).find((p) => typeof p === 'string' && /^\$2[aby]\$/.test(p))
-    expect(hashParam).toBeDefined()
+    expect(insertedUserParams?.[4]).toMatch(/^\$2[aby]\$/)
   })
 })

--- a/packages/core-backend/tests/unit/user-activate.test.ts
+++ b/packages/core-backend/tests/unit/user-activate.test.ts
@@ -331,6 +331,7 @@ describe('activatePendingUser (T3)', () => {
             integration_provider: 'dingtalk',
             account_corp_id: 'corp-1',
             integration_corp_id: 'corp-1',
+            integration_org_id: 'org-1',
           },
           {
             account_active: true,
@@ -341,10 +342,12 @@ describe('activatePendingUser (T3)', () => {
             integration_provider: 'dingtalk',
             account_corp_id: 'corp-2',
             integration_corp_id: 'corp-2',
+            integration_org_id: 'org-2',
           },
         ],
       })
       .mockResolvedValueOnce({ rows: [{ id: 'u1' }] })
+      .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({ rows: [{ access_generation: 1 }] })
@@ -359,6 +362,9 @@ describe('activatePendingUser (T3)', () => {
       activationStatus: 'activated',
       localPasswordSet: false,
     })
+    const membershipWrite = pgMocks.query.mock.calls.find((call) =>
+      String(call[0]).includes('INSERT INTO user_orgs'))
+    expect(membershipWrite?.[1]).toEqual(['u1', 'org-2'])
   })
 
   it('rejects activate when user has no claimable identifier', async () => {


### PR DESCRIPTION
## Scope

Stacked on #4660. Implements the locked DingTalk OAuth `intent=activate` flow and adds the persistent development-closeout ledger. No lifecycle flag is enabled.

## Behavior

- Uses a distinct one-time state record bound to the pending target and launching administrator; unknown or malformed persisted intents fail closed.
- Launch requires an authenticated RBAC platform administrator and a pending target; callback rechecks that the administrator is still active and activated.
- Exchanges the DingTalk code without entering login/JIT, resolves exactly one active DingTalk account, and rechecks provider, corp, openId/unionId, link owner, account status, and integration status inside the activation transaction.
- Derives active membership from the locked source integration org; it never trusts an org hint from the callback.
- Issues the user session only after activation commits and the activated row is reloaded; errors use a closed safe mapping.

## Verification

- Production code commit: `c4f5f8dce`; final PR head includes the docs-only closeout commit.
- TypeScript: clean.
- OAuth/auth/admin regression battery: 129 passed.
- Real PostgreSQL lifecycle battery: 17 passed.
- Load-bearing mutations: unknown persisted intent, ignored exact identity, removed callback admin recheck, missing activation await, callback-admin inactive gate, and caller-supplied SSO org each redden their dedicated test.
- #4658 parent fixture debt found by the expanded battery was fixed at `8b356ec8e`; #4660 was restacked and replayed at `14a0c4580`.
- Durable record: `docs/development/dingtalk-lifecycle-development-closeout-20260728.md`.

## Landing boundary

Draft and unarmed. Retarget/rebase and full required CI happen only after the parent lifecycle windows land. All lifecycle flags remain OFF; this PR is not canary authorization.