### PR TITLE
fix(integration): enforce PAGED_READ capability combinations

### DIFF
--- a/plugins/plugin-integration-core/__tests__/gip-profile-certification-contracts.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/gip-profile-certification-contracts.test.cjs
@@ -18,6 +18,7 @@ const {
   GIP_CROSS_ROLE_TEMPORAL_POLICIES,
   GIP_CONSISTENCY_REQUIREMENT_STATUSES,
   GIP_PROFILE_ERROR_REASONS,
+  PAGED_READ_LEGAL_COMBINATIONS,
   GipProfileContractError,
   isValidProfileId,
   normalizeCertifiedReadActionProfile,
@@ -227,6 +228,109 @@ function crossDimensionLegality() {
   })), 'COMPLETENESS_COMBINATION_INVALID')
 }
 
+// ── 4b. Frozen PAGED_READ legal-combination table ──
+function pagedReadLegalCombinationTable() {
+  assert.deepEqual(PAGED_READ_LEGAL_COMBINATIONS, [
+    { consistencyProof: 'SOURCE_SNAPSHOT_TXN', continuationLifetime: 'CONNECTION_BOUND' },
+    { consistencyProof: 'IMMUTABLE_SNAPSHOT_TOKEN', continuationLifetime: 'DURABLE_TOKEN' },
+  ])
+  assert.ok(Object.isFrozen(PAGED_READ_LEGAL_COMBINATIONS))
+  for (const row of PAGED_READ_LEGAL_COMBINATIONS) {
+    assert.ok(Object.isFrozen(row))
+    const certified = normalizeCertifiedReadActionProfile(fixtureProfile({
+      certificate: {
+        acquisitionMode: 'PAGED_READ',
+        supportedConsistencyProofs: [row.consistencyProof],
+        continuationLifetime: row.continuationLifetime,
+        supportedCompletenessProofs: ['SHORT_PAGE'],
+      },
+    }))
+    assert.equal(certified.certificate.acquisitionMode, 'PAGED_READ')
+    assert.equal(certified.certificate.continuationLifetime, row.continuationLifetime)
+    assert.deepEqual([...certified.certificate.supportedConsistencyProofs], [row.consistencyProof])
+  }
+
+  const refusedByRule = (supportedConsistencyProofs, continuationLifetime, expectedRule) => {
+    let produced = null
+    let caught = null
+    try {
+      produced = normalizeCertifiedReadActionProfile(fixtureProfile({
+        certificate: {
+          acquisitionMode: 'PAGED_READ',
+          supportedConsistencyProofs,
+          continuationLifetime,
+          supportedCompletenessProofs: ['SHORT_PAGE'],
+        },
+      }))
+    } catch (error) {
+      caught = error
+    }
+    assert.equal(produced, null, 'an illegal PAGED_READ profile must not be silently downgraded')
+    assert.ok(caught instanceof GipProfileContractError)
+    assert.equal(caught.reason, 'ILLEGAL_CAPABILITY_COMBINATION')
+    assert.equal(caught.details.rule, expectedRule)
+    return caught
+  }
+
+  const unmapped = refusedByRule(
+    ['MONOTONIC_VERSION_PIN'],
+    'CONNECTION_BOUND',
+    'PAGED_READ_LEGAL_COMBINATION',
+  )
+  refusedByRule(
+    ['IMMUTABLE_SNAPSHOT_TOKEN'],
+    'CONNECTION_BOUND',
+    'PAGED_READ_LEGAL_COMBINATION',
+  )
+  refusedByRule(
+    ['SOURCE_SNAPSHOT_TXN'],
+    'SINGLE_REQUEST',
+    'PAGED_READ_LEGAL_COMBINATION',
+  )
+  refusedByRule(
+    ['SOURCE_SNAPSHOT_TXN', 'MONOTONIC_VERSION_PIN'],
+    'CONNECTION_BOUND',
+    'PAGED_READ_LEGAL_COMBINATION',
+  )
+  refusedByRule([], 'CONNECTION_BOUND', 'PAGED_READ_REQUIRES_CONSISTENCY_PROOF')
+
+  // Rule 5 is PAGED_READ-scoped: the ratified enterprise watermark combination
+  // remains legal, and an honest empty set remains legal for bounded single reads.
+  normalizeCertifiedReadActionProfile(fixtureProfile({
+    certificate: {
+      acquisitionMode: 'CHANGE_FEED',
+      continuationLifetime: 'DURABLE_TOKEN',
+      supportedConsistencyProofs: ['MONOTONIC_VERSION_PIN'],
+      supportedCompletenessProofs: ['DECLARED_TOTAL'],
+    },
+  }))
+  const bounded = normalizeCertifiedReadActionProfile(fixtureProfile({
+    certificate: {
+      acquisitionMode: 'BOUNDED_READ',
+      continuationLifetime: 'SINGLE_REQUEST',
+      supportedConsistencyProofs: [],
+      supportedCompletenessProofs: ['SHORT_PAGE'],
+    },
+  }))
+  assert.deepEqual([...bounded.certificate.supportedConsistencyProofs], [])
+
+  // Recovery derivation delegates to the same full validator.
+  const recoveryError = rejectsWith(() => deriveRecoveryStrategy({
+    acquisitionMode: 'PAGED_READ',
+    continuationLifetime: 'CONNECTION_BOUND',
+    supportedConsistencyProofs: ['MONOTONIC_VERSION_PIN'],
+    supportedCompletenessProofs: ['SHORT_PAGE'],
+  }), 'ILLEGAL_CAPABILITY_COMBINATION')
+  assert.equal(recoveryError.details.rule, 'PAGED_READ_LEGAL_COMBINATION')
+
+  // Public errors remain values-free: only the rule token and count are exposed.
+  const serialized = JSON.stringify({ message: unmapped.message, details: unmapped.details })
+  assert.ok(!serialized.includes('MONOTONIC_VERSION_PIN'))
+  assert.ok(!serialized.includes('SOURCE_SNAPSHOT_TXN'))
+  assert.ok(!serialized.includes('IMMUTABLE_SNAPSHOT_TOKEN'))
+  assert.equal(unmapped.details.declaredProofCount, 1)
+}
+
 // ── 5. Recovery derivation matrix (derived, never declared) ──
 function recoveryDerivation() {
   // deriveRecoveryStrategy validates the FULL certificate (review P2 fail-closed), so
@@ -396,6 +500,7 @@ function main() {
   readProfileHappyPath()
   readProfileFailClosed()
   crossDimensionLegality()
+  pagedReadLegalCombinationTable()
   recoveryDerivation()
   applyProfile()
   evidenceShapes()

--- a/plugins/plugin-integration-core/lib/gip-profile-certification-contracts.cjs
+++ b/plugins/plugin-integration-core/lib/gip-profile-certification-contracts.cjs
@@ -227,6 +227,16 @@ const READ_CERTIFICATE_FIELDS = Object.freeze([
 // (= profileId); the action/queryPreset version is pinned INSIDE this definition and
 // is never an independent digest input (review P2: two implementations must not each
 // compute their own digest).
+//
+// PAGED_READ needs one consistency context spanning the page sequence. The table is
+// scoped to PAGED_READ so the ratified CHANGE_FEED watermark combination remains
+// legal. MONOTONIC_VERSION_PIN deliberately has no PAGED_READ row: it can detect
+// drift, but cannot make separately-read pages belong to one snapshot.
+const PAGED_READ_LEGAL_COMBINATIONS = Object.freeze([
+  Object.freeze({ consistencyProof: 'SOURCE_SNAPSHOT_TXN', continuationLifetime: 'CONNECTION_BOUND' }),
+  Object.freeze({ consistencyProof: 'IMMUTABLE_SNAPSHOT_TOKEN', continuationLifetime: 'DURABLE_TOKEN' }),
+])
+
 // Frozen cross-dimension legality (scale-D0 §2) — shared so deriveRecoveryStrategy
 // re-checks it too (review P2: derivation must never grant a resume strategy to a
 // schema-ILLEGAL certificate). Reads only membership of already-frozen closed sets.
@@ -251,6 +261,27 @@ function assertCertificateCrossDimensionLegal({ acquisitionMode, continuationLif
     const watermarkAnchor = acquisitionMode === 'CHANGE_FEED' && consistency.includes('MONOTONIC_VERSION_PIN')
     if (!immutableAnchor && !watermarkAnchor) {
       fail('ILLEGAL_CAPABILITY_COMBINATION', 'DURABLE_TOKEN continuation requires a durable consistency anchor', { rule: 'DURABLE_TOKEN_REQUIRES_DURABLE_ANCHOR' })
+    }
+  }
+  // 5. Every PAGED_READ proof must anchor the declared continuation lifetime.
+  // Refuse instead of silently downgrading to BOUNDED_READ: callers needing bounded
+  // semantics certify a separate bounded profile.
+  if (acquisitionMode === 'PAGED_READ') {
+    if (consistency.length === 0) {
+      fail('ILLEGAL_CAPABILITY_COMBINATION', 'PAGED_READ requires a consistency proof from the frozen legal-combination table', {
+        rule: 'PAGED_READ_REQUIRES_CONSISTENCY_PROOF',
+      })
+    }
+    for (const proof of consistency) {
+      const anchored = PAGED_READ_LEGAL_COMBINATIONS.some(
+        (row) => row.consistencyProof === proof && row.continuationLifetime === continuationLifetime,
+      )
+      if (!anchored) {
+        fail('ILLEGAL_CAPABILITY_COMBINATION', 'PAGED_READ combination is outside the frozen legal-combination table', {
+          rule: 'PAGED_READ_LEGAL_COMBINATION',
+          declaredProofCount: consistency.length,
+        })
+      }
     }
   }
 }
@@ -567,6 +598,7 @@ module.exports = {
   GIP_CROSS_ROLE_TEMPORAL_POLICIES,
   GIP_CONSISTENCY_REQUIREMENT_STATUSES,
   GIP_PROFILE_ERROR_REASONS,
+  PAGED_READ_LEGAL_COMBINATIONS,
   GipProfileContractError,
   isValidProfileId,
   normalizeCertifiedReadActionProfile,


### PR DESCRIPTION
## Why

The ratified integration line freezes exactly two legal `PAGED_READ` consistency/lifetime combinations, but main did not enforce that table. A paged profile with an empty consistency-proof set could therefore normalize successfully.

## What changed

- add the frozen `PAGED_READ_LEGAL_COMBINATIONS` table
- refuse empty, unmapped, mismatched, or mixed paged proof sets without silent downgrade
- keep the rule scoped to `PAGED_READ`, preserving bounded reads and the existing change-feed watermark combination
- apply the same validation to recovery derivation
- pin table identity, deep freeze, legal rows, rule-exclusive refusals, every-proof semantics, values-free errors, and derivation behavior

## Verification

- `node plugins/plugin-integration-core/__tests__/gip-profile-certification-contracts.test.cjs`
- `pnpm --filter plugin-integration-core test`
- mutation battery: 6/6 RED, each restored GREEN (rule removal, quantifier weakening, table widening, scope widening, derivation bypass, proof leakage)
- Kimi K3 read-only review: 0 P1 / 0 P2
- Grok 4.5 exact-head review at `70020c03d`: 0 P1 / 0 P2

## Boundaries

Latent contract and tests only. This PR does not certify a concrete profile, implement a page-sequence executor, wire runtime or bindings, change routes, deploy, arm flags, or authorize rollout.

Relates to #4593.
