### PR TITLE
test(integration): prove SQL Server snapshot page sequences

### DIFF
--- a/.github/workflows/b1c-sqlserver-snapshot-spike.yml
+++ b/.github/workflows/b1c-sqlserver-snapshot-spike.yml
@@ -1,0 +1,157 @@
+name: B1c SQL Server snapshot page-sequence spike (evidence only)
+
+# EVIDENCE ONLY. This workflow runs against ephemeral first-party SQL Server containers.
+# It does not certify a profile, register a runtime executor, activate a binding, connect to
+# a customer system, or authorize deployment/rollout.
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - 'packages/core-backend/scripts/spike-b1c-*.ts'
+      - 'packages/core-backend/scripts/spike-b1b-shared.ts'
+      - 'packages/core-backend/package.json'
+      - 'pnpm-lock.yaml'
+      - '.github/workflows/b1c-sqlserver-snapshot-spike.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  sqlserver-snapshot-spike:
+    name: B1c SQL Server ${{ matrix.mssql }} explicit SNAPSHOT page sequence
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        mssql: ['2019', '2022']
+    services:
+      mssql:
+        image: mcr.microsoft.com/mssql/server:${{ matrix.mssql }}-latest
+        env:
+          ACCEPT_EULA: 'Y'
+          MSSQL_SA_PASSWORD: 'Spike!Probe2026'
+          SA_PASSWORD: 'Spike!Probe2026'
+        ports:
+          - 1433:1433
+    env:
+      MSSQL_HOST: 127.0.0.1
+      MSSQL_PORT: '1433'
+      MSSQL_USERNAME: sa
+      MSSQL_PASSWORD: 'Spike!Probe2026'
+      MSSQL_ENCRYPT: 'true'
+      MSSQL_TRUST_SERVER_CERTIFICATE: 'true'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js 20.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.16.1
+          run_install: false
+
+      - name: Use empty npmrc for pnpm
+        run: |
+          echo "" > /tmp/empty-npmrc
+          echo "NPM_CONFIG_USERCONFIG=/tmp/empty-npmrc" >> "$GITHUB_ENV"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run pure B1c schema, gate, transaction-binding, and loss-posture tests
+        run: >-
+          pnpm --filter @metasheet/core-backend exec vitest run
+          scripts/spike-b1c-shared.test.ts
+          scripts/spike-b1c-gate-check.test.ts
+          scripts/spike-b1c-sqlserver.test.ts
+
+      - name: Wait for SQL Server
+        run: |
+          for i in $(seq 1 40); do
+            if pnpm --filter @metasheet/core-backend exec node -e "
+              const sql = require('mssql');
+              new sql.ConnectionPool({server:'127.0.0.1',port:1433,user:'sa',password:'Spike!Probe2026',database:'master',options:{encrypt:true,trustServerCertificate:true},connectionTimeout:3000})
+                .connect().then(p => p.close()).then(() => process.exit(0)).catch(() => process.exit(1));
+            "; then
+              echo "SQL Server ready on attempt $i"
+              exit 0
+            fi
+            echo "attempt $i: SQL Server not ready yet; sleeping 5s"
+            sleep 5
+          done
+          echo "SQL Server never became ready within timeout"
+          exit 1
+
+      - name: Run B1c SQL Server explicit SNAPSHOT page-sequence spike
+        env:
+          B1C_MSSQL_DECLARED_MAJOR_VERSION: ${{ matrix.mssql }}
+          B1B_SEED_ALLOW_WRITE: 'true'
+          B1C_EVIDENCE_DIR: ${{ github.workspace }}/b1c-evidence-${{ matrix.mssql }}
+        run: pnpm --filter @metasheet/core-backend exec tsx scripts/spike-b1c-sqlserver.ts
+
+      - name: Upload values-free B1c evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: b1c-sqlserver-snapshot-evidence-${{ matrix.mssql }}
+          path: b1c-evidence-${{ matrix.mssql }}/
+          if-no-files-found: warn
+          retention-days: 14
+
+  gate-check:
+    name: B1c gate-check (evidence only, no certification)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: [sqlserver-snapshot-spike]
+    if: always()
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js 20.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.16.1
+          run_install: false
+
+      - name: Use empty npmrc for pnpm
+        run: |
+          echo "" > /tmp/empty-npmrc
+          echo "NPM_CONFIG_USERCONFIG=/tmp/empty-npmrc" >> "$GITHUB_ENV"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Download B1c evidence artifacts
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          pattern: b1c-sqlserver-snapshot-evidence-*
+          path: b1c-evidence-combined
+          merge-multiple: true
+
+      - name: Ensure evidence directory exists
+        run: mkdir -p b1c-evidence-combined
+
+      - name: Compute values-free B1c evidence verdicts
+        env:
+          B1C_EVIDENCE_DIR: ${{ github.workspace }}/b1c-evidence-combined
+          B1C_DECLARED_CELLS: >-
+            [
+              {"dialect":"sqlserver","engineMajorVersion":"2019","capabilityPosture":"explicit_snapshot_transaction"},
+              {"dialect":"sqlserver","engineMajorVersion":"2022","capabilityPosture":"explicit_snapshot_transaction"}
+            ]
+        run: pnpm --filter @metasheet/core-backend exec tsx scripts/spike-b1c-gate-check.ts

--- a/packages/core-backend/scripts/spike-b1c-gate-check.test.ts
+++ b/packages/core-backend/scripts/spike-b1c-gate-check.test.ts
@@ -1,0 +1,211 @@
+import { spawnSync } from 'node:child_process'
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import { describe, expect, it } from 'vitest'
+import {
+  B1C_CAPABILITY_POSTURE,
+  B1C_CONSISTENCY_PROOF,
+  B1C_CONTINUATION_LIFETIME,
+  type B1cSqlServerEvidenceRecord,
+} from './spike-b1c-shared'
+import {
+  assertEveryDeclaredCellHasEvidence,
+  assertEveryDeclaredCellProven,
+  computeB1cGateVerdicts,
+  type B1cGateCell,
+} from './spike-b1c-gate-check'
+
+const CELL_2019: B1cGateCell = {
+  dialect: 'sqlserver',
+  engineMajorVersion: '2019',
+  capabilityPosture: B1C_CAPABILITY_POSTURE,
+}
+const CELL_2022: B1cGateCell = {
+  ...CELL_2019,
+  engineMajorVersion: '2022',
+}
+
+function record(
+  overrides: Partial<B1cSqlServerEvidenceRecord> = {},
+): B1cSqlServerEvidenceRecord {
+  return {
+    evidenceSchemaVersion: 1,
+    dialect: 'sqlserver',
+    engineMajorVersion: '2019',
+    capabilityPosture: B1C_CAPABILITY_POSTURE,
+    outcome: 'SQLSERVER_SNAPSHOT_PAGE_SEQUENCE_PROVEN',
+    consistencyProof: B1C_CONSISTENCY_PROOF,
+    continuationLifetime: B1C_CONTINUATION_LIFETIME,
+    snapshotEnabledReadback: true,
+    snapshotIsolationObserved: true,
+    activeSnapshotObserved: true,
+    sameSessionAcrossPages: true,
+    terminalShortPageObserved: true,
+    snapshotMatchesOriginal: true,
+    freshStateMatchesMutated: true,
+    snapshotDisabledRejected: true,
+    killedSessionAbsent: true,
+    connectionLossRejected: true,
+    commitAfterLossRejected: true,
+    cleanupComplete: true,
+    lossControlTransactionFactoryCalls: 1,
+    writerMutationsCommitted: 3,
+    pageSize: 3,
+    originalRowCount: 8,
+    snapshotRowCount: 8,
+    snapshotDuplicateCount: 0,
+    snapshotMissingCount: 0,
+    snapshotUnexpectedCount: 0,
+    freshRowCount: 8,
+    freshDuplicateCount: 0,
+    freshMissingCount: 0,
+    freshUnexpectedCount: 0,
+    pageCount: 3,
+    pageSessionObservationCount: 3,
+    controlsTotal: 5,
+    controlsPassed: 5,
+    observationsTaken: 12,
+    recordedAt: '2026-07-28T00:00:00Z',
+    ...overrides,
+  }
+}
+
+describe('B1c gate verdicts', () => {
+  it('proves only a complete opening record and keeps sibling versions separate', () => {
+    const verdicts = computeB1cGateVerdicts([record()], [CELL_2019, CELL_2022])
+    expect(verdicts).toEqual([
+      {
+        ...CELL_2019,
+        evidencePresent: true,
+        proven: true,
+        reason: 'SQLSERVER_SNAPSHOT_PAGE_SEQUENCE_PROVEN',
+      },
+      {
+        ...CELL_2022,
+        evidencePresent: false,
+        proven: false,
+        reason: 'ABSENT',
+      },
+    ])
+    expect(() => assertEveryDeclaredCellHasEvidence(verdicts)).toThrow(
+      /1 declared cell/,
+    )
+    expect(() => assertEveryDeclaredCellProven(verdicts)).toThrow(
+      /1 declared cell/,
+    )
+  })
+
+  it.each([
+    'SQLSERVER_SNAPSHOT_PAGE_SEQUENCE_UNOBTAINABLE',
+    'INCONCLUSIVE',
+  ] as const)('does not prove the non-opening outcome %s', (outcome) => {
+    const [verdict] = computeB1cGateVerdicts(
+      [record({ outcome, snapshotMatchesOriginal: false })],
+      [CELL_2019],
+    )
+    expect(verdict.evidencePresent).toBe(true)
+    expect(verdict.proven).toBe(false)
+    expect(verdict.reason).toBe(outcome)
+    expect(() => assertEveryDeclaredCellHasEvidence([verdict])).not.toThrow()
+    expect(() => assertEveryDeclaredCellProven([verdict])).toThrow(
+      /did not prove/,
+    )
+  })
+
+  it('opens only when every declared cell has opening evidence', () => {
+    const verdicts = computeB1cGateVerdicts(
+      [record(), record({ engineMajorVersion: '2022' })],
+      [CELL_2019, CELL_2022],
+    )
+    expect(() => assertEveryDeclaredCellProven(verdicts)).not.toThrow()
+  })
+
+  it('wires the CLI to the opening gate, with a positive control', () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'b1c-gate-'))
+    const evidencePath = path.join(
+      directory,
+      'b1c-sqlserver-2019-snapshot-page-sequence.json',
+    )
+    const run = () =>
+      spawnSync(
+        path.join(process.cwd(), 'node_modules/.bin/tsx'),
+        [
+          path.join(process.cwd(), 'scripts/spike-b1c-gate-check.ts'),
+          '--evidence-dir',
+          directory,
+          '--declared-cells',
+          JSON.stringify([CELL_2019]),
+        ],
+        {
+          encoding: 'utf8',
+          env: { ...process.env, GITHUB_STEP_SUMMARY: '' },
+        },
+      )
+    try {
+      fs.writeFileSync(evidencePath, JSON.stringify(record()))
+      const opening = run()
+      expect(opening.status, opening.stderr).toBe(0)
+
+      fs.writeFileSync(
+        evidencePath,
+        JSON.stringify(
+          record({
+            outcome: 'SQLSERVER_SNAPSHOT_PAGE_SEQUENCE_UNOBTAINABLE',
+            snapshotMatchesOriginal: false,
+          }),
+        ),
+      )
+      const nonOpening = run()
+      expect(nonOpening.status).toBe(1)
+      expect(nonOpening.stderr).toContain('did not prove')
+    } finally {
+      fs.rmSync(directory, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects undeclared evidence, duplicate evidence, and duplicate declared cells', () => {
+    expect(() =>
+      computeB1cGateVerdicts(
+        [record({ engineMajorVersion: '2022' })],
+        [CELL_2019],
+      ),
+    ).toThrow(/undeclared cell/)
+    expect(() =>
+      computeB1cGateVerdicts([record(), record()], [CELL_2019]),
+    ).toThrow(/multiple evidence/)
+    expect(() =>
+      computeB1cGateVerdicts([], [CELL_2019, { ...CELL_2019 }]),
+    ).toThrow(/appears more than once/)
+  })
+
+  it('rejects forged opening evidence instead of trusting the outcome token', () => {
+    expect(() =>
+      computeB1cGateVerdicts(
+        [record({ sameSessionAcrossPages: false })],
+        [CELL_2019],
+      ),
+    ).toThrow(/complete page-sequence proof/)
+    expect(() =>
+      computeB1cGateVerdicts([record({ controlsPassed: 4 })], [CELL_2019]),
+    ).toThrow(/every declared control/)
+  })
+
+  it('rejects empty or widened declared-cell schemas', () => {
+    expect(() => computeB1cGateVerdicts([], [])).toThrow(/at least one/)
+    expect(() =>
+      computeB1cGateVerdicts(
+        [],
+        [
+          {
+            ...CELL_2019,
+            customerScope: 'forbidden',
+          } as unknown as B1cGateCell,
+        ],
+      ),
+    ).toThrow(/closed schema/)
+    expect(() =>
+      computeB1cGateVerdicts([], [new Proxy(CELL_2019, {})]),
+    ).toThrow(/must not be a Proxy/)
+  })
+})

--- a/packages/core-backend/scripts/spike-b1c-gate-check.ts
+++ b/packages/core-backend/scripts/spike-b1c-gate-check.ts
@@ -1,0 +1,270 @@
+// B1c SQL Server snapshot page-sequence evidence gate.
+//
+// This computes a values-free evidence verdict. It does not certify a profile, register an
+// executor, activate a binding, or authorize runtime/deployment work.
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import { pathToFileURL } from 'node:url'
+import { isProxy } from 'node:util/types'
+import {
+  B1C_CAPABILITY_POSTURE,
+  assertValidB1cSqlServerEvidenceRecord,
+  type B1cSqlServerEvidenceRecord,
+  type B1cSqlServerOutcome,
+} from './spike-b1c-shared'
+
+export interface B1cGateCell {
+  readonly dialect: 'sqlserver'
+  readonly engineMajorVersion: '2019' | '2022'
+  readonly capabilityPosture: typeof B1C_CAPABILITY_POSTURE
+}
+
+export interface B1cGateVerdict extends B1cGateCell {
+  readonly evidencePresent: boolean
+  readonly proven: boolean
+  readonly reason: B1cSqlServerOutcome | 'ABSENT'
+}
+
+const CELL_KEYS = Object.freeze([
+  'dialect',
+  'engineMajorVersion',
+  'capabilityPosture',
+] as const)
+
+function assertGateCell(value: unknown): asserts value is B1cGateCell {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new Error(
+      'spike-b1c-gate-check: each declared cell must be a plain object',
+    )
+  }
+  if (isProxy(value)) {
+    throw new Error('spike-b1c-gate-check: declared cell must not be a Proxy')
+  }
+  let prototype: object | null
+  let keys: readonly PropertyKey[]
+  let descriptors: PropertyDescriptorMap
+  try {
+    prototype = Object.getPrototypeOf(value)
+    keys = Reflect.ownKeys(value)
+    descriptors = Object.getOwnPropertyDescriptors(value)
+  } catch {
+    throw new Error(
+      'spike-b1c-gate-check: declared cell shape is not inspectable',
+    )
+  }
+  if (prototype !== Object.prototype) {
+    throw new Error(
+      'spike-b1c-gate-check: declared cell must use the ordinary object prototype',
+    )
+  }
+  if (
+    keys.length !== CELL_KEYS.length ||
+    keys.some(
+      (key) =>
+        typeof key !== 'string' ||
+        !CELL_KEYS.includes(key as (typeof CELL_KEYS)[number]),
+    )
+  ) {
+    throw new Error(
+      'spike-b1c-gate-check: declared cell fields must exactly match the closed schema',
+    )
+  }
+  for (const key of CELL_KEYS) {
+    const descriptor = descriptors[key]
+    if (!descriptor || !descriptor.enumerable || !('value' in descriptor)) {
+      throw new Error(
+        'spike-b1c-gate-check: declared cell fields must be enumerable data properties',
+      )
+    }
+  }
+  const cell = value as unknown as B1cGateCell
+  if (cell.dialect !== 'sqlserver') {
+    throw new Error(
+      'spike-b1c-gate-check: only sqlserver is declared for this spike',
+    )
+  }
+  if (
+    cell.engineMajorVersion !== '2019' &&
+    cell.engineMajorVersion !== '2022'
+  ) {
+    throw new Error(
+      'spike-b1c-gate-check: undeclared SQL Server engine version',
+    )
+  }
+  if (cell.capabilityPosture !== B1C_CAPABILITY_POSTURE) {
+    throw new Error('spike-b1c-gate-check: undeclared capability posture')
+  }
+}
+
+function cellKey(cell: B1cGateCell): string {
+  return `${cell.dialect}/${cell.engineMajorVersion}/${cell.capabilityPosture}`
+}
+
+export function computeB1cGateVerdicts(
+  records: readonly B1cSqlServerEvidenceRecord[],
+  declaredCells: readonly B1cGateCell[],
+): B1cGateVerdict[] {
+  if (declaredCells.length === 0) {
+    throw new Error(
+      'spike-b1c-gate-check: at least one declared cell is required',
+    )
+  }
+  const declared = new Map<string, B1cGateCell>()
+  for (const cell of declaredCells) {
+    assertGateCell(cell)
+    const key = cellKey(cell)
+    if (declared.has(key)) {
+      throw new Error(
+        `spike-b1c-gate-check: declared cell appears more than once: ${key}`,
+      )
+    }
+    declared.set(key, cell)
+  }
+
+  const byCell = new Map<string, B1cSqlServerEvidenceRecord>()
+  for (const record of records) {
+    assertValidB1cSqlServerEvidenceRecord(record)
+    const key = cellKey(record)
+    if (!declared.has(key)) {
+      throw new Error(
+        `spike-b1c-gate-check: evidence belongs to an undeclared cell: ${key}`,
+      )
+    }
+    if (byCell.has(key)) {
+      throw new Error(
+        `spike-b1c-gate-check: multiple evidence records for one cell: ${key}`,
+      )
+    }
+    byCell.set(key, record)
+  }
+
+  return [...declared.values()].map((cell) => {
+    const record = byCell.get(cellKey(cell))
+    if (!record) {
+      return {
+        ...cell,
+        evidencePresent: false,
+        proven: false,
+        reason: 'ABSENT',
+      }
+    }
+    return {
+      ...cell,
+      evidencePresent: true,
+      proven: record.outcome === 'SQLSERVER_SNAPSHOT_PAGE_SEQUENCE_PROVEN',
+      reason: record.outcome,
+    }
+  })
+}
+
+export function assertEveryDeclaredCellHasEvidence(
+  verdicts: readonly B1cGateVerdict[],
+): void {
+  const absentCount = verdicts.filter(
+    (verdict) => !verdict.evidencePresent,
+  ).length
+  if (absentCount > 0) {
+    throw new Error(
+      `spike-b1c-gate-check: ${absentCount} declared cell(s) have no evidence`,
+    )
+  }
+}
+
+export function assertEveryDeclaredCellProven(
+  verdicts: readonly B1cGateVerdict[],
+): void {
+  assertEveryDeclaredCellHasEvidence(verdicts)
+  const nonOpeningCount = verdicts.filter((verdict) => !verdict.proven).length
+  if (nonOpeningCount > 0) {
+    throw new Error(
+      `spike-b1c-gate-check: ${nonOpeningCount} declared cell(s) did not prove the page-sequence capability`,
+    )
+  }
+}
+
+export function readB1cEvidenceRecords(
+  evidenceDir: string,
+): B1cSqlServerEvidenceRecord[] {
+  if (!fs.existsSync(evidenceDir)) return []
+  const records: B1cSqlServerEvidenceRecord[] = []
+  for (const name of fs
+    .readdirSync(evidenceDir)
+    .filter((name) => name.endsWith('.json'))
+    .sort()) {
+    const filePath = path.join(evidenceDir, name)
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(fs.readFileSync(filePath, 'utf8'))
+    } catch {
+      throw new Error(`spike-b1c-gate-check: ${name} is not valid JSON`)
+    }
+    assertValidB1cSqlServerEvidenceRecord(parsed)
+    records.push(parsed)
+  }
+  return records
+}
+
+function main(): void {
+  const args = process.argv.slice(2)
+  const flag = (name: string): string | undefined => {
+    const index = args.indexOf(name)
+    return index >= 0 ? args[index + 1] : undefined
+  }
+  const evidenceDir = flag('--evidence-dir') ?? process.env.B1C_EVIDENCE_DIR
+  const declaredCellsRaw =
+    flag('--declared-cells') ?? process.env.B1C_DECLARED_CELLS
+  if (!evidenceDir) {
+    throw new Error(
+      'spike-b1c-gate-check: --evidence-dir (or B1C_EVIDENCE_DIR) is required',
+    )
+  }
+  if (!declaredCellsRaw) {
+    throw new Error(
+      'spike-b1c-gate-check: --declared-cells (or B1C_DECLARED_CELLS) is required',
+    )
+  }
+  const declaredCells = JSON.parse(declaredCellsRaw) as B1cGateCell[]
+  const verdicts = computeB1cGateVerdicts(
+    readB1cEvidenceRecords(evidenceDir),
+    declaredCells,
+  )
+
+  console.log('[b1c-gate-check] values-free verdicts (EVIDENCE ONLY):')
+  for (const verdict of verdicts) {
+    console.log(
+      `  ${cellKey(verdict)} evidencePresent=${verdict.evidencePresent} proven=${verdict.proven} reason=${verdict.reason}`,
+    )
+  }
+
+  const summaryPath = process.env.GITHUB_STEP_SUMMARY
+  if (summaryPath) {
+    const rows = verdicts
+      .map(
+        (verdict) =>
+          `| ${verdict.engineMajorVersion} | ${verdict.evidencePresent} | ${verdict.proven} | ${verdict.reason} |`,
+      )
+      .join('\n')
+    fs.appendFileSync(
+      summaryPath,
+      `\n### B1c SQL Server snapshot page-sequence evidence\n\n` +
+        `This verdict does not certify or activate a profile.\n\n` +
+        `| engine | evidence | proven | reason |\n|---|---|---|---|\n${rows}\n`,
+    )
+  }
+  // Non-opening records remain valid evidence and are rendered above, but this workflow is
+  // the opening proof gate: every declared matrix cell must actually prove the capability.
+  assertEveryDeclaredCellProven(verdicts)
+}
+
+const entryUrl = process.argv[1]
+  ? pathToFileURL(path.resolve(process.argv[1])).href
+  : ''
+if (import.meta.url === entryUrl) {
+  try {
+    main()
+  } catch (error) {
+    console.error('[b1c-gate-check] FAILED (malformed or ambiguous evidence)')
+    console.error(error)
+    process.exitCode = 1
+  }
+}

--- a/packages/core-backend/scripts/spike-b1c-shared.test.ts
+++ b/packages/core-backend/scripts/spike-b1c-shared.test.ts
@@ -1,0 +1,217 @@
+import { describe, expect, it } from 'vitest'
+import {
+  B1C_CAPABILITY_POSTURE,
+  B1C_CONSISTENCY_PROOF,
+  B1C_CONTINUATION_LIFETIME,
+  assertValidB1cSqlServerEvidenceRecord,
+  b1cEvidenceFileName,
+  classifyPageSequenceMeasurement,
+  compareSequence,
+  pageSequenceProven,
+  type B1cSqlServerEvidenceRecord,
+  type PageSequenceMeasurement,
+} from './spike-b1c-shared'
+
+const PROVEN_MEASUREMENT: PageSequenceMeasurement = {
+  snapshotEnabledReadback: true,
+  snapshotIsolationObserved: true,
+  activeSnapshotObserved: true,
+  sameSessionAcrossPages: true,
+  terminalShortPageObserved: true,
+  snapshotMatchesOriginal: true,
+  freshStateMatchesMutated: true,
+  snapshotDisabledRejected: true,
+  killedSessionAbsent: true,
+  connectionLossRejected: true,
+  commitAfterLossRejected: true,
+  cleanupComplete: true,
+  lossControlTransactionFactoryCalls: 1,
+  writerMutationsCommitted: 3,
+  pageSize: 3,
+  originalRowCount: 8,
+  snapshotRowCount: 8,
+  snapshotDuplicateCount: 0,
+  snapshotMissingCount: 0,
+  snapshotUnexpectedCount: 0,
+  freshRowCount: 8,
+  freshDuplicateCount: 0,
+  freshMissingCount: 0,
+  freshUnexpectedCount: 0,
+  pageCount: 3,
+  pageSessionObservationCount: 3,
+}
+
+function record(
+  overrides: Partial<B1cSqlServerEvidenceRecord> = {},
+): B1cSqlServerEvidenceRecord {
+  return {
+    evidenceSchemaVersion: 1,
+    dialect: 'sqlserver',
+    engineMajorVersion: '2019',
+    capabilityPosture: B1C_CAPABILITY_POSTURE,
+    outcome: 'SQLSERVER_SNAPSHOT_PAGE_SEQUENCE_PROVEN',
+    consistencyProof: B1C_CONSISTENCY_PROOF,
+    continuationLifetime: B1C_CONTINUATION_LIFETIME,
+    ...PROVEN_MEASUREMENT,
+    controlsTotal: 5,
+    controlsPassed: 5,
+    observationsTaken: 9,
+    recordedAt: '2026-07-28T00:00:00Z',
+    ...overrides,
+  }
+}
+
+describe('B1c page-sequence classifier', () => {
+  it('opens only for the complete SOURCE_SNAPSHOT_TXN + CONNECTION_BOUND measurement', () => {
+    expect(pageSequenceProven(PROVEN_MEASUREMENT)).toBe(true)
+    expect(classifyPageSequenceMeasurement(PROVEN_MEASUREMENT, true)).toBe(
+      'SQLSERVER_SNAPSHOT_PAGE_SEQUENCE_PROVEN',
+    )
+  })
+
+  it.each([
+    ['snapshotEnabledReadback', false],
+    ['snapshotIsolationObserved', false],
+    ['activeSnapshotObserved', false],
+    ['sameSessionAcrossPages', false],
+    ['terminalShortPageObserved', false],
+    ['snapshotMatchesOriginal', false],
+    ['freshStateMatchesMutated', false],
+    ['snapshotDisabledRejected', false],
+    ['killedSessionAbsent', false],
+    ['connectionLossRejected', false],
+    ['commitAfterLossRejected', false],
+    ['cleanupComplete', false],
+    ['lossControlTransactionFactoryCalls', 2],
+    ['writerMutationsCommitted', 2],
+    ['pageSize', 4],
+    ['snapshotRowCount', 7],
+    ['snapshotDuplicateCount', 1],
+    ['snapshotMissingCount', 1],
+    ['snapshotUnexpectedCount', 1],
+    ['freshRowCount', 7],
+    ['freshDuplicateCount', 1],
+    ['freshMissingCount', 1],
+    ['freshUnexpectedCount', 1],
+    ['pageCount', 1],
+    ['pageSessionObservationCount', 2],
+  ] as const)('refuses when %s is weakened', (key, value) => {
+    const weakened = { ...PROVEN_MEASUREMENT, [key]: value }
+    expect(pageSequenceProven(weakened)).toBe(false)
+    expect(classifyPageSequenceMeasurement(weakened, true)).toBe(
+      'SQLSERVER_SNAPSHOT_PAGE_SEQUENCE_UNOBTAINABLE',
+    )
+  })
+
+  it('uses INCONCLUSIVE for an incomplete harness instead of claiming engine unavailability', () => {
+    expect(classifyPageSequenceMeasurement(PROVEN_MEASUREMENT, false)).toBe(
+      'INCONCLUSIVE',
+    )
+  })
+})
+
+describe('B1c closed values-free evidence', () => {
+  it('accepts a complete opening record and both declared engine versions', () => {
+    expect(() => assertValidB1cSqlServerEvidenceRecord(record())).not.toThrow()
+    expect(() =>
+      assertValidB1cSqlServerEvidenceRecord(
+        record({ engineMajorVersion: '2022' }),
+      ),
+    ).not.toThrow()
+  })
+
+  it('rejects unknown fields, accessors, non-plain objects, and undeclared versions', () => {
+    expect(() =>
+      assertValidB1cSqlServerEvidenceRecord({
+        ...record(),
+        sourceRowKey: 'customer-value',
+      }),
+    ).toThrow(/unknown field|closed schema/)
+    const accessor = record() as unknown as Record<string, unknown>
+    Object.defineProperty(accessor, 'pageCount', {
+      enumerable: true,
+      get: () => 3,
+    })
+    expect(() => assertValidB1cSqlServerEvidenceRecord(accessor)).toThrow(
+      /data properties/,
+    )
+    expect(() =>
+      assertValidB1cSqlServerEvidenceRecord(
+        Object.assign(Object.create(null), record()),
+      ),
+    ).toThrow(/ordinary object prototype/)
+    expect(() =>
+      assertValidB1cSqlServerEvidenceRecord(new Proxy(record(), {})),
+    ).toThrow(/must not be a Proxy/)
+    expect(() =>
+      assertValidB1cSqlServerEvidenceRecord({
+        ...record(),
+        engineMajorVersion: 'latest',
+      }),
+    ).toThrow(/declared SQL Server matrix version/)
+  })
+
+  it('rejects a forged opening outcome when any independent proof leg or control count is missing', () => {
+    expect(() =>
+      assertValidB1cSqlServerEvidenceRecord(
+        record({ activeSnapshotObserved: false }),
+      ),
+    ).toThrow(/complete page-sequence proof/)
+    expect(() =>
+      assertValidB1cSqlServerEvidenceRecord(record({ controlsPassed: 3 })),
+    ).toThrow(/every declared control/)
+    expect(() =>
+      assertValidB1cSqlServerEvidenceRecord(
+        record({ controlsTotal: 1, controlsPassed: 1 }),
+      ),
+    ).toThrow(/every declared control/)
+    expect(() =>
+      assertValidB1cSqlServerEvidenceRecord(record({ observationsTaken: 0 })),
+    ).toThrow(/complete page-sequence proof/)
+  })
+
+  it('allows a closed non-opening result without pretending that it proved the capability', () => {
+    expect(() =>
+      assertValidB1cSqlServerEvidenceRecord(
+        record({
+          outcome: 'SQLSERVER_SNAPSHOT_PAGE_SEQUENCE_UNOBTAINABLE',
+          snapshotEnabledReadback: false,
+        }),
+      ),
+    ).not.toThrow()
+  })
+})
+
+describe('B1c sequence comparison', () => {
+  it('requires exact order and exact multiset equality', () => {
+    expect(compareSequence([10, 20, 30], [10, 20, 30])).toEqual({
+      matchesExpected: true,
+      rowCount: 3,
+      duplicateCount: 0,
+      missingCount: 0,
+      unexpectedCount: 0,
+    })
+    expect(compareSequence([10, 30, 20], [10, 20, 30]).matchesExpected).toBe(
+      false,
+    )
+    expect(compareSequence([10, 20, 20], [10, 20, 30])).toMatchObject({
+      matchesExpected: false,
+      duplicateCount: 1,
+      missingCount: 1,
+    })
+    expect(compareSequence([10, 20, 40], [10, 20, 30])).toMatchObject({
+      matchesExpected: false,
+      missingCount: 1,
+      unexpectedCount: 1,
+    })
+  })
+
+  it('uses a distinct B1c artifact name', () => {
+    expect(b1cEvidenceFileName('2019')).toBe(
+      'b1c-sqlserver-2019-snapshot-page-sequence.json',
+    )
+    expect(b1cEvidenceFileName('2022')).toBe(
+      'b1c-sqlserver-2022-snapshot-page-sequence.json',
+    )
+  })
+})

--- a/packages/core-backend/scripts/spike-b1c-shared.ts
+++ b/packages/core-backend/scripts/spike-b1c-shared.ts
@@ -1,0 +1,370 @@
+// B1c SQL Server page-sequence capability spike: closed, values-free evidence schema.
+//
+// EVIDENCE ONLY. Nothing in this module certifies a profile, registers a runtime
+// executor, activates a binding, or makes a customer request reachable. The real-engine
+// spike uses synthetic rows in a throwaway database and records only counts, booleans, and
+// closed tokens.
+import { isProxy } from 'node:util/types'
+
+export const B1C_SQLSERVER_OUTCOMES = Object.freeze([
+  'SQLSERVER_SNAPSHOT_PAGE_SEQUENCE_PROVEN',
+  'SQLSERVER_SNAPSHOT_PAGE_SEQUENCE_UNOBTAINABLE',
+  'INCONCLUSIVE',
+] as const)
+export type B1cSqlServerOutcome = (typeof B1C_SQLSERVER_OUTCOMES)[number]
+const OUTCOME_SET: ReadonlySet<string> = new Set(B1C_SQLSERVER_OUTCOMES)
+
+export const B1C_CONSISTENCY_PROOF = 'SOURCE_SNAPSHOT_TXN' as const
+export const B1C_CONTINUATION_LIFETIME = 'CONNECTION_BOUND' as const
+export const B1C_CAPABILITY_POSTURE = 'explicit_snapshot_transaction' as const
+
+export const B1C_CONTROL_IDS = Object.freeze([
+  'B1C-WRITE-OPT-IN',
+  'B1C-DEDICATED-DATABASE',
+  'B1C-SNAPSHOT-OFF-NEGATIVE',
+  'B1C-FOREIGN-SESSION-CONTROL',
+  'B1C-SEQUENCE-DISCRIMINATOR',
+] as const)
+
+export interface PageSequenceMeasurement {
+  readonly snapshotEnabledReadback: boolean
+  readonly snapshotIsolationObserved: boolean
+  readonly activeSnapshotObserved: boolean
+  readonly sameSessionAcrossPages: boolean
+  readonly terminalShortPageObserved: boolean
+  readonly snapshotMatchesOriginal: boolean
+  readonly freshStateMatchesMutated: boolean
+  readonly snapshotDisabledRejected: boolean
+  readonly killedSessionAbsent: boolean
+  readonly connectionLossRejected: boolean
+  readonly commitAfterLossRejected: boolean
+  readonly cleanupComplete: boolean
+  readonly lossControlTransactionFactoryCalls: number
+  readonly writerMutationsCommitted: number
+  readonly pageSize: number
+  readonly originalRowCount: number
+  readonly snapshotRowCount: number
+  readonly snapshotDuplicateCount: number
+  readonly snapshotMissingCount: number
+  readonly snapshotUnexpectedCount: number
+  readonly freshRowCount: number
+  readonly freshDuplicateCount: number
+  readonly freshMissingCount: number
+  readonly freshUnexpectedCount: number
+  readonly pageCount: number
+  readonly pageSessionObservationCount: number
+}
+
+export interface B1cSqlServerEvidenceRecord extends PageSequenceMeasurement {
+  readonly evidenceSchemaVersion: 1
+  readonly dialect: 'sqlserver'
+  readonly engineMajorVersion: '2019' | '2022'
+  readonly capabilityPosture: typeof B1C_CAPABILITY_POSTURE
+  readonly outcome: B1cSqlServerOutcome
+  readonly consistencyProof: typeof B1C_CONSISTENCY_PROOF
+  readonly continuationLifetime: typeof B1C_CONTINUATION_LIFETIME
+  readonly controlsTotal: number
+  readonly controlsPassed: number
+  readonly observationsTaken: number
+  readonly recordedAt: string
+}
+
+const RECORD_KEYS = Object.freeze([
+  'evidenceSchemaVersion',
+  'dialect',
+  'engineMajorVersion',
+  'capabilityPosture',
+  'outcome',
+  'consistencyProof',
+  'continuationLifetime',
+  'snapshotEnabledReadback',
+  'snapshotIsolationObserved',
+  'activeSnapshotObserved',
+  'sameSessionAcrossPages',
+  'terminalShortPageObserved',
+  'snapshotMatchesOriginal',
+  'freshStateMatchesMutated',
+  'snapshotDisabledRejected',
+  'killedSessionAbsent',
+  'connectionLossRejected',
+  'commitAfterLossRejected',
+  'cleanupComplete',
+  'lossControlTransactionFactoryCalls',
+  'writerMutationsCommitted',
+  'pageSize',
+  'originalRowCount',
+  'snapshotRowCount',
+  'snapshotDuplicateCount',
+  'snapshotMissingCount',
+  'snapshotUnexpectedCount',
+  'freshRowCount',
+  'freshDuplicateCount',
+  'freshMissingCount',
+  'freshUnexpectedCount',
+  'pageCount',
+  'pageSessionObservationCount',
+  'controlsTotal',
+  'controlsPassed',
+  'observationsTaken',
+  'recordedAt',
+] as const)
+const RECORD_KEY_SET: ReadonlySet<string> = new Set(RECORD_KEYS)
+
+const MEASUREMENT_BOOLEAN_KEYS = Object.freeze([
+  'snapshotEnabledReadback',
+  'snapshotIsolationObserved',
+  'activeSnapshotObserved',
+  'sameSessionAcrossPages',
+  'terminalShortPageObserved',
+  'snapshotMatchesOriginal',
+  'freshStateMatchesMutated',
+  'snapshotDisabledRejected',
+  'killedSessionAbsent',
+  'connectionLossRejected',
+  'commitAfterLossRejected',
+  'cleanupComplete',
+] as const)
+
+const MEASUREMENT_COUNT_KEYS = Object.freeze([
+  'lossControlTransactionFactoryCalls',
+  'writerMutationsCommitted',
+  'pageSize',
+  'originalRowCount',
+  'snapshotRowCount',
+  'snapshotDuplicateCount',
+  'snapshotMissingCount',
+  'snapshotUnexpectedCount',
+  'freshRowCount',
+  'freshDuplicateCount',
+  'freshMissingCount',
+  'freshUnexpectedCount',
+  'pageCount',
+  'pageSessionObservationCount',
+] as const)
+
+function assertPlainClosedRecord(
+  value: unknown,
+): asserts value is Record<string, unknown> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new Error('spike-b1c: evidence record must be a plain object')
+  }
+  if (isProxy(value)) {
+    throw new Error('spike-b1c: evidence record must not be a Proxy')
+  }
+
+  let prototype: object | null
+  let keys: readonly PropertyKey[]
+  let descriptors: PropertyDescriptorMap
+  try {
+    prototype = Object.getPrototypeOf(value)
+    keys = Reflect.ownKeys(value)
+    descriptors = Object.getOwnPropertyDescriptors(value)
+  } catch {
+    throw new Error('spike-b1c: evidence record shape is not inspectable')
+  }
+  if (prototype !== Object.prototype) {
+    throw new Error(
+      'spike-b1c: evidence record must use the ordinary object prototype',
+    )
+  }
+  if (keys.length !== RECORD_KEYS.length) {
+    throw new Error(
+      'spike-b1c: evidence record does not match the closed schema',
+    )
+  }
+  for (const key of keys) {
+    if (typeof key !== 'string' || !RECORD_KEY_SET.has(key)) {
+      throw new Error('spike-b1c: evidence record contains an unknown field')
+    }
+    const descriptor = descriptors[key]
+    if (!descriptor || !descriptor.enumerable || !('value' in descriptor)) {
+      throw new Error(
+        'spike-b1c: evidence fields must be enumerable data properties',
+      )
+    }
+  }
+  for (const key of RECORD_KEYS) {
+    if (!Object.prototype.hasOwnProperty.call(value, key)) {
+      throw new Error(
+        `spike-b1c: evidence record is missing required field ${key}`,
+      )
+    }
+  }
+}
+
+function assertCanonicalTimestamp(value: unknown): asserts value is string {
+  if (typeof value !== 'string' || value.length > 32) {
+    throw new Error('spike-b1c: recordedAt must be a canonical UTC timestamp')
+  }
+  const parsed = Date.parse(value)
+  if (!Number.isFinite(parsed)) {
+    throw new Error('spike-b1c: recordedAt must be a canonical UTC timestamp')
+  }
+  const canonical = new Date(parsed).toISOString()
+  if (value !== canonical && value !== canonical.replace('.000Z', 'Z')) {
+    throw new Error('spike-b1c: recordedAt must be a canonical UTC timestamp')
+  }
+}
+
+function assertNonNegativeInteger(
+  value: unknown,
+  field: string,
+): asserts value is number {
+  if (!Number.isInteger(value) || (value as number) < 0) {
+    throw new Error(`spike-b1c: ${field} must be a non-negative integer`)
+  }
+}
+
+export function pageSequenceProven(
+  measurement: PageSequenceMeasurement,
+): boolean {
+  return (
+    measurement.snapshotEnabledReadback &&
+    measurement.snapshotIsolationObserved &&
+    measurement.activeSnapshotObserved &&
+    measurement.sameSessionAcrossPages &&
+    measurement.terminalShortPageObserved &&
+    measurement.snapshotMatchesOriginal &&
+    measurement.freshStateMatchesMutated &&
+    measurement.snapshotDisabledRejected &&
+    measurement.killedSessionAbsent &&
+    measurement.connectionLossRejected &&
+    measurement.commitAfterLossRejected &&
+    measurement.cleanupComplete &&
+    measurement.lossControlTransactionFactoryCalls === 1 &&
+    measurement.writerMutationsCommitted === 3 &&
+    measurement.pageSize > 0 &&
+    measurement.originalRowCount > 0 &&
+    measurement.snapshotRowCount === measurement.originalRowCount &&
+    measurement.snapshotDuplicateCount === 0 &&
+    measurement.snapshotMissingCount === 0 &&
+    measurement.snapshotUnexpectedCount === 0 &&
+    measurement.freshRowCount === measurement.originalRowCount &&
+    measurement.freshDuplicateCount === 0 &&
+    measurement.freshMissingCount === 0 &&
+    measurement.freshUnexpectedCount === 0 &&
+    measurement.pageCount > 1 &&
+    measurement.pageSessionObservationCount === measurement.pageCount &&
+    measurement.pageCount ===
+      Math.ceil(measurement.originalRowCount / measurement.pageSize) &&
+    measurement.originalRowCount % measurement.pageSize !== 0
+  )
+}
+
+export function classifyPageSequenceMeasurement(
+  measurement: PageSequenceMeasurement,
+  harnessComplete: boolean,
+): B1cSqlServerOutcome {
+  if (!harnessComplete) return 'INCONCLUSIVE'
+  return pageSequenceProven(measurement)
+    ? 'SQLSERVER_SNAPSHOT_PAGE_SEQUENCE_PROVEN'
+    : 'SQLSERVER_SNAPSHOT_PAGE_SEQUENCE_UNOBTAINABLE'
+}
+
+export function assertValidB1cSqlServerEvidenceRecord(
+  value: unknown,
+): asserts value is B1cSqlServerEvidenceRecord {
+  assertPlainClosedRecord(value)
+  const record = value as unknown as B1cSqlServerEvidenceRecord
+  if (record.evidenceSchemaVersion !== 1) {
+    throw new Error('spike-b1c: unsupported evidenceSchemaVersion')
+  }
+  if (record.dialect !== 'sqlserver') {
+    throw new Error('spike-b1c: evidence dialect must be sqlserver')
+  }
+  if (
+    record.engineMajorVersion !== '2019' &&
+    record.engineMajorVersion !== '2022'
+  ) {
+    throw new Error(
+      'spike-b1c: engineMajorVersion must be a declared SQL Server matrix version',
+    )
+  }
+  if (record.capabilityPosture !== B1C_CAPABILITY_POSTURE) {
+    throw new Error(
+      'spike-b1c: capabilityPosture is outside the closed vocabulary',
+    )
+  }
+  if (!OUTCOME_SET.has(record.outcome)) {
+    throw new Error('spike-b1c: outcome is outside the closed vocabulary')
+  }
+  if (record.consistencyProof !== B1C_CONSISTENCY_PROOF) {
+    throw new Error('spike-b1c: evidence must identify SOURCE_SNAPSHOT_TXN')
+  }
+  if (record.continuationLifetime !== B1C_CONTINUATION_LIFETIME) {
+    throw new Error('spike-b1c: evidence must identify CONNECTION_BOUND')
+  }
+  for (const key of MEASUREMENT_BOOLEAN_KEYS) {
+    if (typeof record[key] !== 'boolean') {
+      throw new Error(`spike-b1c: ${key} must be boolean`)
+    }
+  }
+  for (const key of MEASUREMENT_COUNT_KEYS) {
+    assertNonNegativeInteger(record[key], key)
+  }
+  assertNonNegativeInteger(record.controlsTotal, 'controlsTotal')
+  assertNonNegativeInteger(record.controlsPassed, 'controlsPassed')
+  assertNonNegativeInteger(record.observationsTaken, 'observationsTaken')
+  if (record.controlsPassed > record.controlsTotal) {
+    throw new Error('spike-b1c: controlsPassed cannot exceed controlsTotal')
+  }
+  assertCanonicalTimestamp(record.recordedAt)
+
+  if (record.outcome === 'SQLSERVER_SNAPSHOT_PAGE_SEQUENCE_PROVEN') {
+    if (
+      record.controlsTotal !== B1C_CONTROL_IDS.length ||
+      record.controlsPassed !== record.controlsTotal
+    ) {
+      throw new Error(
+        'spike-b1c: opening evidence requires every declared control to pass',
+      )
+    }
+    if (record.observationsTaken < 1 || !pageSequenceProven(record)) {
+      throw new Error(
+        'spike-b1c: opening evidence lacks the complete page-sequence proof',
+      )
+    }
+  }
+}
+
+export interface SequenceCounts {
+  readonly matchesExpected: boolean
+  readonly rowCount: number
+  readonly duplicateCount: number
+  readonly missingCount: number
+  readonly unexpectedCount: number
+}
+
+export function compareSequence(
+  observed: readonly number[],
+  expected: readonly number[],
+): SequenceCounts {
+  const observedSet = new Set(observed)
+  const expectedSet = new Set(expected)
+  const duplicateCount = observed.length - observedSet.size
+  const missingCount = expected.filter(
+    (value) => !observedSet.has(value),
+  ).length
+  const unexpectedCount = [...observedSet].filter(
+    (value) => !expectedSet.has(value),
+  ).length
+  const matchesExpected =
+    duplicateCount === 0 &&
+    missingCount === 0 &&
+    unexpectedCount === 0 &&
+    observed.length === expected.length &&
+    observed.every((value, index) => value === expected[index])
+  return {
+    matchesExpected,
+    rowCount: observed.length,
+    duplicateCount,
+    missingCount,
+    unexpectedCount,
+  }
+}
+
+export function b1cEvidenceFileName(
+  engineMajorVersion: '2019' | '2022',
+): string {
+  return `b1c-sqlserver-${engineMajorVersion}-snapshot-page-sequence.json`
+}

--- a/packages/core-backend/scripts/spike-b1c-sqlserver.test.ts
+++ b/packages/core-backend/scripts/spike-b1c-sqlserver.test.ts
@@ -1,0 +1,257 @@
+import { spawnSync } from 'node:child_process'
+import * as path from 'node:path'
+import { describe, expect, it, vi } from 'vitest'
+import {
+  assertExactB1cControlRoster,
+  assertB1cDatabaseTarget,
+  isSnapshotNotAllowedError,
+  readSnapshotPage,
+  readSnapshotPageSequence,
+  runConnectionLossControl,
+  sqlServerErrorNumbers,
+  type MssqlRequestLike,
+  type MssqlTransactionLike,
+} from './spike-b1c-sqlserver'
+
+function requestReturning(
+  rows: Array<Array<{ keyValue: number; sessionId: number }> | Error>,
+): MssqlRequestLike {
+  return {
+    input() {
+      return this
+    },
+    async query<T>() {
+      const next = rows.shift()
+      if (next instanceof Error) throw next
+      return { recordset: (next ?? []) as T[] }
+    },
+    async batch<T>() {
+      return { recordset: [] as T[] }
+    },
+  }
+}
+
+function transactionReturning(
+  pages: Array<Array<{ keyValue: number; sessionId: number }> | Error>,
+): MssqlTransactionLike & { requestCalls: number } {
+  const request = requestReturning(pages)
+  return {
+    requestCalls: 0,
+    async begin() {
+      return this
+    },
+    async commit() {},
+    async rollback() {},
+    request() {
+      this.requestCalls += 1
+      return request
+    },
+  }
+}
+
+describe('B1c transaction-bound page reader', () => {
+  it('reads every page through the supplied transaction and runs the mutation callback after page 1', async () => {
+    const transaction = transactionReturning([
+      [
+        { keyValue: 10, sessionId: 41 },
+        { keyValue: 20, sessionId: 41 },
+        { keyValue: 30, sessionId: 41 },
+      ],
+      [
+        { keyValue: 40, sessionId: 41 },
+        { keyValue: 50, sessionId: 41 },
+      ],
+    ])
+    const afterFirstPage = vi.fn(async () => undefined)
+    const result = await readSnapshotPageSequence(
+      transaction,
+      3,
+      afterFirstPage,
+    )
+    expect(result).toEqual({
+      keys: [10, 20, 30, 40, 50],
+      sessionIds: [41, 41],
+      pageSizes: [3, 2],
+    })
+    expect(transaction.requestCalls).toBe(2)
+    expect(afterFirstPage).toHaveBeenCalledTimes(1)
+  })
+
+  it('fails closed on invalid bounds, empty pages, or a page spanning sessions', async () => {
+    await expect(
+      readSnapshotPage(transactionReturning([]), -1, 3),
+    ).rejects.toThrow(/invalid page bounds/)
+    await expect(
+      readSnapshotPage(transactionReturning([[]]), 0, 3),
+    ).rejects.toThrow(/unexpected empty page/)
+    await expect(
+      readSnapshotPage(
+        transactionReturning([
+          [
+            { keyValue: 10, sessionId: 41 },
+            { keyValue: 20, sessionId: 42 },
+          ],
+        ]),
+        0,
+        3,
+      ),
+    ).rejects.toThrow(/crossed SQL Server sessions/)
+  })
+})
+
+describe('B1c connection-loss posture', () => {
+  it('constructs exactly one transaction and rejects both the next page and commit without resnapshot', async () => {
+    let factoryCalls = 0
+    const transaction = transactionReturning([
+      [
+        { keyValue: 10, sessionId: 51 },
+        { keyValue: 20, sessionId: 51 },
+        { keyValue: 30, sessionId: 51 },
+      ],
+      new Error('connection killed'),
+    ])
+    transaction.commit = vi.fn(async () => {
+      throw new Error('transaction aborted')
+    })
+    const killSession = vi.fn(async () => true)
+    const result = await runConnectionLossControl(
+      () => {
+        factoryCalls += 1
+        return transaction
+      },
+      5,
+      killSession,
+    )
+    expect(result).toEqual({
+      killedSessionAbsent: true,
+      pageAfterLossRejected: true,
+      commitAfterLossRejected: true,
+      transactionFactoryCalls: 1,
+    })
+    expect(factoryCalls).toBe(1)
+    expect(killSession).toHaveBeenCalledWith(51)
+  })
+
+  it('does not report a loss proof if the same transaction can keep reading or commit', async () => {
+    const transaction = transactionReturning([
+      [
+        { keyValue: 10, sessionId: 51 },
+        { keyValue: 20, sessionId: 51 },
+        { keyValue: 30, sessionId: 51 },
+      ],
+      [
+        { keyValue: 40, sessionId: 51 },
+        { keyValue: 50, sessionId: 51 },
+      ],
+    ])
+    const result = await runConnectionLossControl(
+      () => transaction,
+      5,
+      async () => false,
+    )
+    expect(result.killedSessionAbsent).toBe(false)
+    expect(result.pageAfterLossRejected).toBe(false)
+    expect(result.commitAfterLossRejected).toBe(false)
+  })
+
+  it('does not let arbitrary page and commit failures stand in for a confirmed killed session', async () => {
+    const transaction = transactionReturning([
+      [
+        { keyValue: 10, sessionId: 51 },
+        { keyValue: 20, sessionId: 51 },
+        { keyValue: 30, sessionId: 51 },
+      ],
+      new Error('unrelated timeout'),
+    ])
+    transaction.commit = vi.fn(async () => {
+      throw new Error('unrelated transaction error')
+    })
+    const result = await runConnectionLossControl(
+      () => transaction,
+      5,
+      async () => false,
+    )
+    expect(result).toEqual({
+      killedSessionAbsent: false,
+      pageAfterLossRejected: true,
+      commitAfterLossRejected: true,
+      transactionFactoryCalls: 1,
+    })
+  })
+})
+
+describe('B1c dedicated database guard', () => {
+  it('accepts only the fixed B1c database', () => {
+    expect(() => assertB1cDatabaseTarget('b1c_spike_sqlserver')).not.toThrow()
+    expect(() => assertB1cDatabaseTarget('b1b_spike_sqlserver')).toThrow(
+      /refusing to target/,
+    )
+    expect(() => assertB1cDatabaseTarget('master')).toThrow(
+      /refusing to target/,
+    )
+  })
+})
+
+describe('B1c executable entry point', () => {
+  it('fails instead of skip-green when no SQL Server host is configured', () => {
+    const childEnv = { ...process.env }
+    delete childEnv.MSSQL_HOST
+    delete childEnv.MSSQL_SERVER
+    const result = spawnSync(
+      path.join(process.cwd(), 'node_modules/.bin/tsx'),
+      [path.join(process.cwd(), 'scripts/spike-b1c-sqlserver.ts')],
+      {
+        encoding: 'utf8',
+        env: childEnv,
+      },
+    )
+    expect(result.status).toBe(1)
+    expect(result.stdout).not.toContain('[skip]')
+    expect(result.stderr).toContain(
+      '[failed] B1c SQL Server snapshot page-sequence spike',
+    )
+  })
+})
+
+describe('B1c SQL Server error and control vocabularies', () => {
+  it('finds the exact SQL Server number through the node-mssql originalError chain', () => {
+    const original = Object.assign(new Error('driver text'), { number: 3952 })
+    const wrapped = Object.assign(new Error('wrapper text'), {
+      originalError: original,
+    })
+    expect(sqlServerErrorNumbers(wrapped)).toEqual([3952])
+    expect(isSnapshotNotAllowedError(wrapped)).toBe(true)
+    expect(
+      sqlServerErrorNumbers(Object.assign(new Error(), { number: 3951 })),
+    ).toEqual([3951])
+    expect(
+      isSnapshotNotAllowedError(Object.assign(new Error(), { number: 3951 })),
+    ).toBe(false)
+  })
+
+  it('does not invoke hostile accessors while reading an error chain', () => {
+    const hostile = Object.defineProperty({}, 'originalError', {
+      get() {
+        throw new Error('must not escape')
+      },
+    })
+    expect(sqlServerErrorNumbers(hostile)).toEqual([])
+  })
+
+  it('requires the exact frozen control roster in order', () => {
+    const ids = [
+      'B1C-WRITE-OPT-IN',
+      'B1C-DEDICATED-DATABASE',
+      'B1C-SNAPSHOT-OFF-NEGATIVE',
+      'B1C-FOREIGN-SESSION-CONTROL',
+      'B1C-SEQUENCE-DISCRIMINATOR',
+    ]
+    expect(() => assertExactB1cControlRoster(ids)).not.toThrow()
+    expect(() => assertExactB1cControlRoster(ids.slice(1))).toThrow(
+      /frozen B1c roster/,
+    )
+    expect(() =>
+      assertExactB1cControlRoster([...ids, 'B1C-UNDECLARED']),
+    ).toThrow(/frozen B1c roster/)
+  })
+})

--- a/packages/core-backend/scripts/spike-b1c-sqlserver.ts
+++ b/packages/core-backend/scripts/spike-b1c-sqlserver.ts
@@ -1,0 +1,854 @@
+// B1c SQL Server explicit-SNAPSHOT page-sequence capability spike.
+//
+// EVIDENCE ONLY. This runs only against a first-party, ephemeral SQL Server instance and a
+// fixed throwaway database. It does not mint a profile, register a runtime executor, touch a
+// customer system, activate a binding, or authorize deployment.
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import { pathToFileURL } from 'node:url'
+import {
+  MutationLog,
+  assertSelectOnly,
+  assertWriteOptIn,
+} from './spike-b1b-shared'
+import {
+  B1C_CAPABILITY_POSTURE,
+  B1C_CONSISTENCY_PROOF,
+  B1C_CONTROL_IDS,
+  B1C_CONTINUATION_LIFETIME,
+  assertValidB1cSqlServerEvidenceRecord,
+  b1cEvidenceFileName,
+  classifyPageSequenceMeasurement,
+  compareSequence,
+  type B1cSqlServerEvidenceRecord,
+  type PageSequenceMeasurement,
+} from './spike-b1c-shared'
+
+const env = process.env
+const SPIKE_DATABASE = 'b1c_spike_sqlserver'
+const SPIKE_TABLE = 'b1c_page_sequence'
+const PAGE_SIZE = 3
+const MAX_PAGES = 10
+const SNAPSHOT_NOT_ALLOWED_ERROR = 3952
+const SYSTEM_DATABASE_NAMES: ReadonlySet<string> = new Set([
+  'master',
+  'model',
+  'msdb',
+  'tempdb',
+])
+const EXPECTED_ORIGINAL_KEYS = Object.freeze([10, 20, 30, 40, 50, 60, 70, 80])
+const EXPECTED_MUTATED_KEYS = Object.freeze([10, 80, 20, 25, 30, 40, 50, 70])
+const PRODUCT_VERSION_PREFIX: Readonly<Record<'2019' | '2022', string>> =
+  Object.freeze({
+    '2019': '15.',
+    '2022': '16.',
+  })
+
+interface MssqlRecordset<T> extends Array<T> {}
+interface MssqlResult<T> {
+  readonly recordset: MssqlRecordset<T>
+}
+export interface MssqlRequestLike {
+  input(name: string, value: unknown): MssqlRequestLike
+  query<T = Record<string, unknown>>(sql: string): Promise<MssqlResult<T>>
+  batch<T = Record<string, unknown>>(sql: string): Promise<MssqlResult<T>>
+}
+interface MssqlConnectionPoolLike {
+  connect(): Promise<MssqlConnectionPoolLike>
+  close(): Promise<void>
+  request(): MssqlRequestLike
+  on(event: 'error', listener: () => void): MssqlConnectionPoolLike
+}
+export interface MssqlTransactionLike {
+  begin(isolationLevel: number): Promise<MssqlTransactionLike>
+  commit(): Promise<void>
+  rollback(): Promise<void>
+  request(): MssqlRequestLike
+}
+interface MssqlModuleLike {
+  ConnectionPool: new (
+    config: Record<string, unknown>,
+  ) => MssqlConnectionPoolLike
+  Transaction: new (pool: MssqlConnectionPoolLike) => MssqlTransactionLike
+  ISOLATION_LEVEL: {
+    readonly READ_COMMITTED: number
+    readonly SNAPSHOT: number
+  }
+}
+
+let mssql: MssqlModuleLike | null = null
+try {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+  mssql = require('mssql') as MssqlModuleLike
+} catch {
+  // Reported only when the opt-in real-engine path is invoked.
+}
+
+function requiredEnv(name: string): string {
+  const value = env[name]
+  if (!value) throw new Error(`Missing required environment variable: ${name}`)
+  return value
+}
+
+function declaredEngineVersion(): '2019' | '2022' {
+  const value = requiredEnv('B1C_MSSQL_DECLARED_MAJOR_VERSION')
+  if (value !== '2019' && value !== '2022') {
+    throw new Error(
+      'spike-b1c-sqlserver: declared engine version is outside the 2019/2022 matrix',
+    )
+  }
+  return value
+}
+
+export function assertB1cDatabaseTarget(name: string): void {
+  if (
+    SYSTEM_DATABASE_NAMES.has(name.toLowerCase()) ||
+    name !== SPIKE_DATABASE
+  ) {
+    throw new Error(
+      'spike-b1c-sqlserver: refusing to target a database other than the dedicated B1c database',
+    )
+  }
+}
+
+function connectionConfig(database: string): Record<string, unknown> {
+  return {
+    server: env.MSSQL_HOST || env.MSSQL_SERVER,
+    port: env.MSSQL_PORT ? Number(env.MSSQL_PORT) : 1433,
+    database,
+    user: requiredEnv('MSSQL_USERNAME'),
+    password: requiredEnv('MSSQL_PASSWORD'),
+    options: {
+      encrypt: env.MSSQL_ENCRYPT !== 'false',
+      trustServerCertificate: env.MSSQL_TRUST_SERVER_CERTIFICATE !== 'false',
+    },
+    connectionTimeout: 10_000,
+    requestTimeout: 15_000,
+    // One physical connection per pool makes any accidental pool.request() while a
+    // transaction owns that connection block/fail instead of silently reading another
+    // snapshot. Page helpers accept only a transaction, so the intended path cannot do that.
+    pool: { max: 1, min: 1 },
+  }
+}
+
+async function openPool(database: string): Promise<MssqlConnectionPoolLike> {
+  if (!mssql) throw new Error('mssql package is not installed')
+  const pool = new mssql.ConnectionPool(connectionConfig(database))
+  // A killed loss-control connection may emit at pool level in addition to rejecting the
+  // transaction request. The request rejection is the measured signal; prevent an unhandled
+  // EventEmitter error from terminating the process before it can be recorded.
+  pool.on('error', () => undefined)
+  await pool.connect()
+  return pool
+}
+
+function probeSql(sql: string): string {
+  return assertSelectOnly(sql, 'spike-b1c-sqlserver')
+}
+
+async function poolScalar<T>(
+  pool: MssqlConnectionPoolLike,
+  sql: string,
+): Promise<T> {
+  const result = await pool
+    .request()
+    .query<Record<string, unknown>>(probeSql(sql))
+  const row = result.recordset[0]
+  const key = row ? Object.keys(row)[0] : undefined
+  return (key ? row![key] : undefined) as T
+}
+
+interface PageRow {
+  readonly keyValue: number
+  readonly sessionId: number
+}
+
+export interface SnapshotPage {
+  readonly keys: readonly number[]
+  readonly sessionId: number
+}
+
+function positiveInteger(value: unknown, field: string): number {
+  const number = Number(value)
+  if (!Number.isInteger(number) || number < 1) {
+    throw new Error(`spike-b1c-sqlserver: ${field} was not a positive integer`)
+  }
+  return number
+}
+
+export async function readSnapshotPage(
+  transaction: MssqlTransactionLike,
+  offset: number,
+  pageSize: number,
+): Promise<SnapshotPage> {
+  if (
+    !Number.isInteger(offset) ||
+    offset < 0 ||
+    !Number.isInteger(pageSize) ||
+    pageSize < 1
+  ) {
+    throw new Error('spike-b1c-sqlserver: invalid page bounds')
+  }
+  const result = await transaction
+    .request()
+    .input('offset', offset)
+    .input('pageSize', pageSize)
+    .query<PageRow>(
+      probeSql(
+        `SELECT row_id AS keyValue, @@SPID AS sessionId
+         FROM dbo.${SPIKE_TABLE}
+         ORDER BY sort_key ASC, row_id ASC
+         OFFSET @offset ROWS FETCH NEXT @pageSize ROWS ONLY`,
+      ),
+    )
+  if (result.recordset.length === 0) {
+    throw new Error(
+      'spike-b1c-sqlserver: page sequence reached an unexpected empty page',
+    )
+  }
+  const sessionIds = new Set(
+    result.recordset.map((row) =>
+      positiveInteger(row.sessionId, 'page session id'),
+    ),
+  )
+  if (sessionIds.size !== 1) {
+    throw new Error('spike-b1c-sqlserver: one page crossed SQL Server sessions')
+  }
+  return {
+    keys: result.recordset.map((row) =>
+      positiveInteger(row.keyValue, 'synthetic row key'),
+    ),
+    sessionId: [...sessionIds][0]!,
+  }
+}
+
+export interface SnapshotPageSequence {
+  readonly keys: readonly number[]
+  readonly sessionIds: readonly number[]
+  readonly pageSizes: readonly number[]
+}
+
+export async function readSnapshotPageSequence(
+  transaction: MssqlTransactionLike,
+  pageSize: number,
+  afterFirstPage: () => Promise<void>,
+): Promise<SnapshotPageSequence> {
+  const keys: number[] = []
+  const sessionIds: number[] = []
+  const pageSizes: number[] = []
+  for (let pageIndex = 0; pageIndex < MAX_PAGES; pageIndex += 1) {
+    const page = await readSnapshotPage(
+      transaction,
+      pageIndex * pageSize,
+      pageSize,
+    )
+    keys.push(...page.keys)
+    sessionIds.push(page.sessionId)
+    pageSizes.push(page.keys.length)
+    if (pageIndex === 0) await afterFirstPage()
+    if (page.keys.length < pageSize) {
+      return { keys, sessionIds, pageSizes }
+    }
+  }
+  throw new Error(
+    'spike-b1c-sqlserver: page sequence exceeded the bounded page budget',
+  )
+}
+
+interface ConnectionLossObservation {
+  readonly killedSessionAbsent: boolean
+  readonly pageAfterLossRejected: boolean
+  readonly commitAfterLossRejected: boolean
+  readonly transactionFactoryCalls: number
+}
+
+export async function runConnectionLossControl(
+  createTransaction: () => MssqlTransactionLike,
+  snapshotIsolationLevel: number,
+  killAndConfirmSessionAbsent: (sessionId: number) => Promise<boolean>,
+): Promise<ConnectionLossObservation> {
+  let transactionFactoryCalls = 0
+  const transaction = createTransaction()
+  transactionFactoryCalls += 1
+  let committed = false
+  try {
+    await transaction.begin(snapshotIsolationLevel)
+    const firstPage = await readSnapshotPage(transaction, 0, PAGE_SIZE)
+    const killedSessionAbsent = await killAndConfirmSessionAbsent(
+      firstPage.sessionId,
+    )
+
+    let pageAfterLossRejected = false
+    try {
+      await readSnapshotPage(transaction, PAGE_SIZE, PAGE_SIZE)
+    } catch {
+      pageAfterLossRejected = true
+    }
+
+    let commitAfterLossRejected = false
+    try {
+      await transaction.commit()
+      committed = true
+    } catch {
+      commitAfterLossRejected = true
+    }
+    return {
+      killedSessionAbsent,
+      pageAfterLossRejected,
+      commitAfterLossRejected,
+      transactionFactoryCalls,
+    }
+  } finally {
+    if (!committed) await transaction.rollback().catch(() => undefined)
+  }
+}
+
+interface SnapshotState {
+  readonly sessionId: number
+  readonly isolationLevel: number
+  readonly activeSnapshotCount: number
+}
+
+async function readSnapshotState(
+  transaction: MssqlTransactionLike,
+): Promise<SnapshotState> {
+  const result = await transaction.request().query<{
+    sessionId: number
+    isolationLevel: number
+    activeSnapshotCount: number | string
+  }>(
+    probeSql(
+      `SELECT
+         @@SPID AS sessionId,
+         (SELECT transaction_isolation_level
+            FROM sys.dm_exec_sessions
+           WHERE session_id = @@SPID) AS isolationLevel,
+         (SELECT COUNT_BIG(*)
+            FROM sys.dm_tran_active_snapshot_database_transactions
+           WHERE session_id = @@SPID AND is_snapshot = 1) AS activeSnapshotCount`,
+    ),
+  )
+  const row = result.recordset[0]
+  if (!row)
+    throw new Error('spike-b1c-sqlserver: snapshot-state query returned no row')
+  return {
+    sessionId: positiveInteger(row.sessionId, 'snapshot session id'),
+    isolationLevel: positiveInteger(
+      row.isolationLevel,
+      'snapshot isolation level',
+    ),
+    activeSnapshotCount: Number(row.activeSnapshotCount),
+  }
+}
+
+async function readCurrentKeys(
+  pool: MssqlConnectionPoolLike,
+): Promise<number[]> {
+  const result = await pool.request().query<{ keyValue: number }>(
+    probeSql(
+      `SELECT row_id AS keyValue
+         FROM dbo.${SPIKE_TABLE}
+        ORDER BY sort_key ASC, row_id ASC`,
+    ),
+  )
+  return result.recordset.map((row) =>
+    positiveInteger(row.keyValue, 'synthetic row key'),
+  )
+}
+
+async function applyWriterMutations(
+  pool: MssqlConnectionPoolLike,
+): Promise<number> {
+  const result = await pool.request().batch<{
+    insertedCount: number
+    deletedCount: number
+    updatedCount: number
+  }>(
+    `SET NOCOUNT ON;
+     SET XACT_ABORT ON;
+     DECLARE @insertedCount INT;
+     DECLARE @deletedCount INT;
+     DECLARE @updatedCount INT;
+     BEGIN TRANSACTION;
+       INSERT INTO dbo.${SPIKE_TABLE} (row_id, sort_key) VALUES (25, 25);
+       SET @insertedCount = @@ROWCOUNT;
+       DELETE FROM dbo.${SPIKE_TABLE} WHERE row_id = 60;
+       SET @deletedCount = @@ROWCOUNT;
+       UPDATE dbo.${SPIKE_TABLE} SET sort_key = 15 WHERE row_id = 80;
+       SET @updatedCount = @@ROWCOUNT;
+       IF @insertedCount <> 1 OR @deletedCount <> 1 OR @updatedCount <> 1
+         THROW 51000, 'B1c mutation cardinality mismatch', 1;
+     COMMIT TRANSACTION;
+     SELECT
+       @insertedCount AS insertedCount,
+       @deletedCount AS deletedCount,
+       @updatedCount AS updatedCount;`,
+  )
+  const row = result.recordset[0]
+  if (!row) {
+    throw new Error(
+      'spike-b1c-sqlserver: writer mutation counts were not returned',
+    )
+  }
+  return (
+    positiveInteger(row.insertedCount, 'inserted mutation count') +
+    positiveInteger(row.deletedCount, 'deleted mutation count') +
+    positiveInteger(row.updatedCount, 'updated mutation count')
+  )
+}
+
+export function sqlServerErrorNumbers(error: unknown): readonly number[] {
+  const numbers = new Set<number>()
+  const seen = new Set<object>()
+  const pending: Array<{ value: unknown; depth: number }> = [
+    { value: error, depth: 0 },
+  ]
+  while (pending.length > 0) {
+    const next = pending.pop()!
+    if (
+      next.depth > 4 ||
+      typeof next.value !== 'object' ||
+      next.value === null ||
+      seen.has(next.value)
+    ) {
+      continue
+    }
+    seen.add(next.value)
+    let descriptors: PropertyDescriptorMap
+    try {
+      descriptors = Object.getOwnPropertyDescriptors(next.value)
+    } catch {
+      continue
+    }
+    const numberDescriptor = descriptors.number
+    if (numberDescriptor && 'value' in numberDescriptor) {
+      const number = Number(numberDescriptor.value)
+      if (Number.isInteger(number)) numbers.add(number)
+    }
+    for (const key of ['originalError', 'cause'] as const) {
+      const descriptor = descriptors[key]
+      if (descriptor && 'value' in descriptor) {
+        pending.push({ value: descriptor.value, depth: next.depth + 1 })
+      }
+    }
+  }
+  return [...numbers]
+}
+
+export function isSnapshotNotAllowedError(error: unknown): boolean {
+  const numbers = sqlServerErrorNumbers(error)
+  return numbers.length === 1 && numbers[0] === SNAPSHOT_NOT_ALLOWED_ERROR
+}
+
+async function waitForSessionAbsent(
+  masterPool: MssqlConnectionPoolLike,
+  sessionId: number,
+): Promise<boolean> {
+  for (let attempt = 0; attempt < 50; attempt += 1) {
+    const result = await masterPool
+      .request()
+      .input('sessionId', sessionId)
+      .query<{ presentCount: number | string }>(
+        probeSql(
+          `SELECT COUNT_BIG(*) AS presentCount
+             FROM sys.dm_exec_sessions
+            WHERE session_id = @sessionId`,
+        ),
+      )
+    const count = Number(result.recordset[0]?.presentCount)
+    if (!Number.isInteger(count) || count < 0 || count > 1) {
+      throw new Error(
+        'spike-b1c-sqlserver: killed-session presence probe returned an invalid count',
+      )
+    }
+    if (count === 0) return true
+    await new Promise((resolve) => setTimeout(resolve, 100))
+  }
+  return false
+}
+
+export function assertExactB1cControlRoster(ids: readonly string[]): void {
+  if (
+    ids.length !== B1C_CONTROL_IDS.length ||
+    ids.some((id, index) => id !== B1C_CONTROL_IDS[index])
+  ) {
+    throw new Error(
+      'spike-b1c-sqlserver: executed control roster does not match the frozen B1c roster',
+    )
+  }
+}
+
+async function setSnapshotIsolation(
+  masterPool: MssqlConnectionPoolLike,
+  state: 'ON' | 'OFF',
+): Promise<void> {
+  assertB1cDatabaseTarget(SPIKE_DATABASE)
+  await masterPool
+    .request()
+    .batch(
+      `ALTER DATABASE [${SPIKE_DATABASE}] SET ALLOW_SNAPSHOT_ISOLATION ${state}`,
+    )
+}
+
+async function dropSpikeDatabase(
+  masterPool: MssqlConnectionPoolLike,
+): Promise<void> {
+  assertB1cDatabaseTarget(SPIKE_DATABASE)
+  await masterPool.request().batch(
+    `IF DB_ID('${SPIKE_DATABASE}') IS NOT NULL
+     BEGIN
+       ALTER DATABASE [${SPIKE_DATABASE}] SET SINGLE_USER WITH ROLLBACK IMMEDIATE;
+       DROP DATABASE [${SPIKE_DATABASE}];
+     END`,
+  )
+}
+
+function persistEvidence(record: B1cSqlServerEvidenceRecord): void {
+  const evidenceDir = env.B1C_EVIDENCE_DIR
+  if (!evidenceDir) return
+  fs.mkdirSync(evidenceDir, { recursive: true })
+  fs.writeFileSync(
+    path.join(evidenceDir, b1cEvidenceFileName(record.engineMajorVersion)),
+    JSON.stringify(record, null, 2),
+  )
+}
+
+async function main(): Promise<void> {
+  if (!env.MSSQL_HOST && !env.MSSQL_SERVER) {
+    throw new Error(
+      'spike-b1c-sqlserver: MSSQL_HOST or MSSQL_SERVER is required',
+    )
+  }
+  if (!mssql) throw new Error('mssql package is not installed')
+  const sql = mssql
+  assertWriteOptIn(env, 'spike-b1c-sqlserver')
+  const engineMajorVersion = declaredEngineVersion()
+  const log = new MutationLog()
+  let observationsTaken = 0
+  const observed = <T>(value: T): T => {
+    observationsTaken += 1
+    return value
+  }
+
+  let missingOptInRejected = false
+  try {
+    assertWriteOptIn({}, 'spike-b1c-sqlserver-control')
+  } catch {
+    missingOptInRejected = true
+  }
+  log.check(
+    'B1C-WRITE-OPT-IN',
+    'unset write opt-in is refused before any throwaway-database mutation',
+    'RED',
+    !missingOptInRejected,
+  )
+  let wrongDatabaseRejected = false
+  try {
+    assertB1cDatabaseTarget('b1b_spike_sqlserver')
+  } catch {
+    wrongDatabaseRejected = true
+  }
+  log.check(
+    'B1C-DEDICATED-DATABASE',
+    'a sibling spike database is refused by the exact target guard',
+    'RED',
+    !wrongDatabaseRejected,
+  )
+
+  let masterPool: MssqlConnectionPoolLike | null = null
+  let controlPool: MssqlConnectionPoolLike | null = null
+  let readerPool: MssqlConnectionPoolLike | null = null
+  let writerPool: MssqlConnectionPoolLike | null = null
+  let lossPool: MssqlConnectionPoolLike | null = null
+  let controlTransaction: MssqlTransactionLike | null = null
+  let snapshotTransaction: MssqlTransactionLike | null = null
+  let measured: Omit<PageSequenceMeasurement, 'cleanupComplete'> | null = null
+  let primaryError: unknown
+  let cleanupError: unknown
+  let cleanupComplete = false
+
+  try {
+    masterPool = await openPool('master')
+    await dropSpikeDatabase(masterPool)
+    await masterPool.request().batch(`CREATE DATABASE [${SPIKE_DATABASE}]`)
+
+    const observedProductVersion = String(
+      observed(
+        await poolScalar<string>(
+          masterPool,
+          `SELECT CONVERT(VARCHAR(128), SERVERPROPERTY('ProductVersion')) AS v`,
+        ),
+      ),
+    )
+    if (
+      !observedProductVersion.startsWith(
+        PRODUCT_VERSION_PREFIX[engineMajorVersion],
+      )
+    ) {
+      throw new Error(
+        'spike-b1c-sqlserver: observed engine version does not match the declared matrix cell',
+      )
+    }
+
+    controlPool = await openPool(SPIKE_DATABASE)
+    await controlPool.request().batch(
+      `CREATE TABLE dbo.${SPIKE_TABLE} (
+         row_id INT NOT NULL PRIMARY KEY,
+         sort_key INT NOT NULL UNIQUE
+       );
+       INSERT INTO dbo.${SPIKE_TABLE} (row_id, sort_key)
+       VALUES (10,10),(20,20),(30,30),(40,40),(50,50),(60,60),(70,70),(80,80);`,
+    )
+    await controlPool.close()
+    controlPool = null
+
+    await setSnapshotIsolation(masterPool, 'OFF')
+    controlPool = await openPool(SPIKE_DATABASE)
+    const snapshotOffReadback = Number(
+      observed(
+        await poolScalar<number>(
+          controlPool,
+          'SELECT snapshot_isolation_state AS v FROM sys.databases WHERE database_id = DB_ID()',
+        ),
+      ),
+    )
+    if (snapshotOffReadback !== 0) {
+      throw new Error(
+        'spike-b1c-sqlserver: snapshot-isolation OFF precondition was not established',
+      )
+    }
+
+    // Positive connection control: the same pool can execute a normal transaction while
+    // SNAPSHOT is disabled, so the negative control below is not an authentication failure.
+    const readCommittedControl = new sql.Transaction(controlPool)
+    await readCommittedControl.begin(sql.ISOLATION_LEVEL.READ_COMMITTED)
+    await readCommittedControl
+      .request()
+      .query(probeSql(`SELECT COUNT_BIG(*) AS v FROM dbo.${SPIKE_TABLE}`))
+    await readCommittedControl.rollback()
+
+    controlTransaction = new sql.Transaction(controlPool)
+    let snapshotAccessSucceededWhileDisabled = false
+    let snapshotDisabledRejected = false
+    try {
+      await controlTransaction.begin(sql.ISOLATION_LEVEL.SNAPSHOT)
+      // SQL Server defines the transaction start at first data access. Include that access
+      // in the negative control instead of assuming begin() alone is the failure point.
+      await controlTransaction
+        .request()
+        .query(probeSql(`SELECT COUNT_BIG(*) AS v FROM dbo.${SPIKE_TABLE}`))
+      snapshotAccessSucceededWhileDisabled = true
+    } catch (error) {
+      snapshotDisabledRejected = isSnapshotNotAllowedError(error)
+    } finally {
+      await controlTransaction.rollback().catch(() => undefined)
+      controlTransaction = null
+    }
+    snapshotDisabledRejected =
+      !snapshotAccessSucceededWhileDisabled && snapshotDisabledRejected
+    log.check(
+      'B1C-SNAPSHOT-OFF-NEGATIVE',
+      'explicit SNAPSHOT first data access while ALLOW_SNAPSHOT_ISOLATION is OFF rejects with SQL Server 3952',
+      'RED',
+      !snapshotDisabledRejected,
+    )
+    await controlPool.close()
+    controlPool = null
+
+    await setSnapshotIsolation(masterPool, 'ON')
+    readerPool = await openPool(SPIKE_DATABASE)
+    writerPool = await openPool(SPIKE_DATABASE)
+    const snapshotEnabledReadback =
+      Number(
+        observed(
+          await poolScalar<number>(
+            readerPool,
+            'SELECT snapshot_isolation_state AS v FROM sys.databases WHERE database_id = DB_ID()',
+          ),
+        ),
+      ) === 1
+
+    snapshotTransaction = new sql.Transaction(readerPool)
+    await snapshotTransaction.begin(sql.ISOLATION_LEVEL.SNAPSHOT)
+    const firstPageContext: {
+      snapshotState?: SnapshotState
+      writerSessionId?: number
+    } = {}
+    let writerMutationsCommitted = 0
+    const pageSequence = await readSnapshotPageSequence(
+      snapshotTransaction,
+      PAGE_SIZE,
+      async () => {
+        // This is deliberately the first transaction-scoped observation after page 1. A
+        // SNAPSHOT transaction starts its data snapshot at first data access, not at BEGIN.
+        firstPageContext.snapshotState = observed(
+          await readSnapshotState(snapshotTransaction!),
+        )
+        firstPageContext.writerSessionId = positiveInteger(
+          observed(await poolScalar<number>(writerPool!, 'SELECT @@SPID AS v')),
+          'writer session id',
+        )
+        writerMutationsCommitted = await applyWriterMutations(writerPool!)
+      },
+    )
+    await snapshotTransaction.commit()
+    snapshotTransaction = null
+
+    const snapshotState = firstPageContext.snapshotState
+    const writerSessionId = firstPageContext.writerSessionId
+    if (!snapshotState || writerSessionId === undefined) {
+      throw new Error(
+        'spike-b1c-sqlserver: first-page snapshot observation was not recorded',
+      )
+    }
+    observationsTaken += pageSequence.pageSizes.length
+    const snapshotComparison = compareSequence(
+      pageSequence.keys,
+      EXPECTED_ORIGINAL_KEYS,
+    )
+    const freshKeys = observed(await readCurrentKeys(writerPool))
+    const freshComparison = compareSequence(freshKeys, EXPECTED_MUTATED_KEYS)
+    const sameSessionAcrossPages =
+      pageSequence.sessionIds.length === pageSequence.pageSizes.length &&
+      pageSequence.sessionIds.every(
+        (sessionId) => sessionId === snapshotState!.sessionId,
+      )
+    log.check(
+      'B1C-FOREIGN-SESSION-CONTROL',
+      'the independently opened writer session must not equal the transaction-bound reader session',
+      'RED',
+      snapshotState.sessionId === writerSessionId,
+    )
+    log.check(
+      'B1C-SEQUENCE-DISCRIMINATOR',
+      'the pre-mutation snapshot sequence must not equal the independently verified post-mutation order',
+      'RED',
+      compareSequence(pageSequence.keys, EXPECTED_MUTATED_KEYS).matchesExpected,
+    )
+
+    lossPool = await openPool(SPIKE_DATABASE)
+    const loss = observed(
+      await runConnectionLossControl(
+        () => new sql.Transaction(lossPool!),
+        sql.ISOLATION_LEVEL.SNAPSHOT,
+        async (sessionId) => {
+          positiveInteger(sessionId, 'loss-control session id')
+          await masterPool!.request().batch(`KILL ${sessionId}`)
+          return waitForSessionAbsent(masterPool!, sessionId)
+        },
+      ),
+    )
+
+    measured = {
+      snapshotEnabledReadback,
+      snapshotIsolationObserved:
+        snapshotState.isolationLevel === sql.ISOLATION_LEVEL.SNAPSHOT,
+      activeSnapshotObserved: snapshotState.activeSnapshotCount >= 1,
+      sameSessionAcrossPages,
+      terminalShortPageObserved:
+        pageSequence.pageSizes.length > 0 &&
+        pageSequence.pageSizes[pageSequence.pageSizes.length - 1]! < PAGE_SIZE,
+      snapshotMatchesOriginal: snapshotComparison.matchesExpected,
+      freshStateMatchesMutated: freshComparison.matchesExpected,
+      snapshotDisabledRejected,
+      killedSessionAbsent: loss.killedSessionAbsent,
+      connectionLossRejected: loss.pageAfterLossRejected,
+      commitAfterLossRejected: loss.commitAfterLossRejected,
+      lossControlTransactionFactoryCalls: loss.transactionFactoryCalls,
+      writerMutationsCommitted,
+      pageSize: PAGE_SIZE,
+      originalRowCount: EXPECTED_ORIGINAL_KEYS.length,
+      snapshotRowCount: snapshotComparison.rowCount,
+      snapshotDuplicateCount: snapshotComparison.duplicateCount,
+      snapshotMissingCount: snapshotComparison.missingCount,
+      snapshotUnexpectedCount: snapshotComparison.unexpectedCount,
+      freshRowCount: freshComparison.rowCount,
+      freshDuplicateCount: freshComparison.duplicateCount,
+      freshMissingCount: freshComparison.missingCount,
+      freshUnexpectedCount: freshComparison.unexpectedCount,
+      pageCount: pageSequence.pageSizes.length,
+      pageSessionObservationCount: pageSequence.sessionIds.length,
+    }
+  } catch (error) {
+    primaryError = error
+  } finally {
+    await controlTransaction?.rollback().catch(() => undefined)
+    await snapshotTransaction?.rollback().catch(() => undefined)
+    for (const pool of [controlPool, readerPool, writerPool, lossPool]) {
+      await pool?.close().catch((error) => {
+        cleanupError ??= error
+      })
+    }
+    if (masterPool) {
+      await dropSpikeDatabase(masterPool).catch((error) => {
+        cleanupError ??= error
+      })
+      if (cleanupError === undefined) {
+        await poolScalar<number | null>(
+          masterPool,
+          `SELECT DB_ID('${SPIKE_DATABASE}') AS v`,
+        )
+          .then((databaseId) => {
+            cleanupComplete = databaseId === null
+            if (!cleanupComplete) {
+              cleanupError = new Error(
+                'spike-b1c-sqlserver: throwaway database still exists after cleanup',
+              )
+            }
+          })
+          .catch((error) => {
+            cleanupError ??= error
+          })
+      }
+      await masterPool.close().catch((error) => {
+        cleanupError ??= error
+      })
+    }
+  }
+
+  if (primaryError !== undefined) throw primaryError
+  if (cleanupError !== undefined) throw cleanupError
+  if (!measured)
+    throw new Error('spike-b1c-sqlserver: measurement was not produced')
+
+  const measurement: PageSequenceMeasurement = {
+    ...measured,
+    cleanupComplete,
+  }
+  const summary = log.summary()
+  assertExactB1cControlRoster(log.all().map((entry) => entry.id))
+  const harnessComplete = summary.failed === 0
+  const outcome = classifyPageSequenceMeasurement(measurement, harnessComplete)
+  const record: B1cSqlServerEvidenceRecord = {
+    evidenceSchemaVersion: 1,
+    dialect: 'sqlserver',
+    engineMajorVersion,
+    capabilityPosture: B1C_CAPABILITY_POSTURE,
+    outcome,
+    consistencyProof: B1C_CONSISTENCY_PROOF,
+    continuationLifetime: B1C_CONTINUATION_LIFETIME,
+    ...measurement,
+    controlsTotal: summary.total,
+    controlsPassed: summary.passed,
+    observationsTaken,
+    recordedAt: new Date().toISOString(),
+  }
+  assertValidB1cSqlServerEvidenceRecord(record)
+  persistEvidence(record)
+  console.log(
+    '[b1c-sqlserver] RECORD (values-free):',
+    JSON.stringify(record, null, 2),
+  )
+  log.assertAllPassed('b1c-sqlserver')
+}
+
+const entryUrl = process.argv[1]
+  ? pathToFileURL(path.resolve(process.argv[1])).href
+  : ''
+if (import.meta.url === entryUrl) {
+  main().catch((error) => {
+    console.error('[failed] B1c SQL Server snapshot page-sequence spike')
+    console.error(error instanceof Error ? error.name : 'UnknownError')
+    process.exitCode = 1
+  })
+}


### PR DESCRIPTION
## Scope

- add an evidence-only SQL Server 2019/2022 matrix for explicit `SNAPSHOT` multi-page reads
- prove one transaction/session spans all pages while an independent writer inserts, deletes, and moves a sort key
- prove connection-bound continuation fails after the exact reader SPID is killed
- persist closed, values-free evidence and require both declared cells to be `SQLSERVER_SNAPSHOT_PAGE_SEQUENCE_PROVEN`

## Boundaries

This PR does not certify a profile, register a runtime executor, activate a binding, connect to a customer system, deploy, arm a flag, or authorize rollout. It uses only synthetic rows in a fixed throwaway CI database.

## Verification

- focused B1c suites: 51/51 pass
- full core-backend suite: 557 files pass, 185 skipped; 7803 tests pass, 1651 skipped
- `pnpm --filter @metasheet/core-backend type-check`: pass
- mutation battery: 9/9 target mutations RED, baseline restored GREEN
- exact-head independent review: Kimi 0 P1 / 0 P2; Grok reviewed the pre-hardening semantic body at 0 P1 / 0 P2, with the final 44-line hardening delta independently re-reviewed by Kimi

## Real-engine gate

Local Docker was unavailable, so this is not yet real-engine proof. The dedicated workflow must run both SQL Server 2019 and 2022 service containers, upload one values-free artifact per cell, and pass the combined opening gate. Any absent, malformed, `UNOBTAINABLE`, or `INCONCLUSIVE` cell fails closed.