### PR TITLE
fix(attendance): resume stranded W4C-2 scheduled runs

### DIFF
--- a/packages/core-backend/src/attendance/w4c2-live-scheduled-boundary.ts
+++ b/packages/core-backend/src/attendance/w4c2-live-scheduled-boundary.ts
@@ -132,6 +132,7 @@ import {
   finalizeAttendanceScheduledRunV1,
   recordAttendanceScheduledRunTargetOutcomeV1,
   requireAttendanceScheduledRunRunningBeforeSourceDmlV1,
+  resumeAttendanceScheduledRunByExactIdV1,
   type AttendanceScheduledRunMemberInputV1,
   type AttendanceScheduledRunMembershipResolverV1,
 } from './w4c2-scheduled-run'
@@ -444,6 +445,12 @@ export interface AttendanceScheduledRunBoundaryInputV1 {
   readonly targetUserIds: readonly string[]
   readonly initiator: AttendanceScheduledRunInitiatorV1
   /**
+   * Process-local duplicate signal from the plugin caller. It is honored only
+   * after this boundary resolves `legacy_projection_only`; W4 postures ignore
+   * it and continue through the durable class-01 run protocol.
+   */
+  readonly legacyDedupHit?: boolean
+  /**
    * W4C-2 remediation P1-4 (#4612 gate finding): the real host-authenticated
    * administrator identity for `initiator: 'admin_run'` — plain route-supplied
    * data (the ROUTE already performed its `attendance:admin` permission check
@@ -478,8 +485,16 @@ export interface AttendanceScheduledRunBoundaryInputV1 {
   readonly reviewTargets: readonly { readonly userId: string; readonly reasonCode: string }[]
 }
 
+export type AttendanceScheduledRunRecoveryBoundaryInputV1 = Omit<
+  AttendanceScheduledRunBoundaryInputV1,
+  'adminActorId'
+> & {
+  readonly runId: string
+}
+
 export type AttendanceScheduledRunBoundaryResultV1 =
   | { readonly kind: 'legacy'; readonly rows: Array<{ user_id: string }> }
+  | { readonly kind: 'legacy_dedup' }
   | { readonly kind: 'suspended' }
   | {
       readonly kind: 'w4'
@@ -495,6 +510,9 @@ export type AttendanceScheduledRunBoundaryResultV1 =
 export interface AttendanceW4LiveScheduledBoundaryV1 {
   executeLivePunch(input: AttendanceLivePunchBoundaryInputV1): Promise<AttendanceLivePunchBoundaryResultV1>
   executeScheduledRun(input: AttendanceScheduledRunBoundaryInputV1): Promise<AttendanceScheduledRunBoundaryResultV1>
+  recoverScheduledRun(
+    input: AttendanceScheduledRunRecoveryBoundaryInputV1,
+  ): Promise<AttendanceScheduledRunBoundaryResultV1>
 }
 
 export interface AttendanceW4BoundaryConnectionV1 {
@@ -516,6 +534,7 @@ const SCHEDULED_SOURCE_REF: Record<AttendanceScheduledRunInitiatorV1, string> = 
   cron: 'plugin-attendance:auto-absence:cron',
   admin_run: 'plugin-attendance:auto-absence:admin-run',
 })
+const SCHEDULED_RECOVERY_SOURCE_REF = 'plugin-attendance:auto-absence:recovery-sweep'
 const SCHEDULED_ABSENCE_SOURCE: Record<AttendanceScheduledRunInitiatorV1, string> = Object.freeze({
   cron: 'cron_auto_absence',
   admin_run: 'admin_auto_absence_run',
@@ -1589,7 +1608,10 @@ export function createAttendanceLiveScheduledBoundaryV1(
    * intentionally waives per-subject predicates; the scheduler's target-user
    * list itself is not caller-authorization-bearing).
    */
-  function cronScheduledAuthorization(orgId: string): AuthorizedAttendanceWriteContextV1 {
+  function internalScheduledAuthorization(
+    orgId: string,
+    sourceRef: string,
+  ): AuthorizedAttendanceWriteContextV1 {
     return createAuthorizedAttendanceWriteContextV1({
       actorId: ATTENDANCE_INTERNAL_SCHEDULER_ACTOR_ID_V1,
       actorPosture: 'scheduler',
@@ -1597,7 +1619,7 @@ export function createAttendanceLiveScheduledBoundaryV1(
       orgId,
       subjectScope: { kind: 'org_scheduler' },
       capability: 'scheduled',
-      sourceRef: SCHEDULED_SOURCE_REF.cron,
+      sourceRef,
     })
   }
 
@@ -1649,8 +1671,9 @@ export function createAttendanceLiveScheduledBoundaryV1(
     })
   }
 
-  async function executeScheduledRun(
+  async function executeScheduledRunInternal(
     input: AttendanceScheduledRunBoundaryInputV1,
+    recoveryRunId: string | null,
   ): Promise<AttendanceScheduledRunBoundaryResultV1> {
     if (!(SCHEDULED_INITIATORS as readonly string[]).includes(input.initiator)) {
       boundaryFail('W4C2_SCHEDULED_INITIATOR_INVALID')
@@ -1662,11 +1685,16 @@ export function createAttendanceLiveScheduledBoundaryV1(
     // input reaches it), not a new business-input rejection surface on the
     // byte-identical legacy response, so it does not conflict with this
     // module's "legacy admits no new rejection surface" doctrine.
-    if (input.initiator === 'cron' && input.adminActorId !== null) {
-      boundaryFail('W4C2_SCHEDULED_WITNESS_INITIATOR_MISMATCH')
-    }
-    if (input.initiator === 'admin_run' && (typeof input.adminActorId !== 'string' || input.adminActorId.length === 0)) {
-      boundaryFail('W4C2_SCHEDULED_ADMIN_WITNESS_REQUIRED')
+    if (recoveryRunId === null) {
+      if (input.initiator === 'cron' && input.adminActorId !== null) {
+        boundaryFail('W4C2_SCHEDULED_WITNESS_INITIATOR_MISMATCH')
+      }
+      if (
+        input.initiator === 'admin_run'
+        && (typeof input.adminActorId !== 'string' || input.adminActorId.length === 0)
+      ) {
+        boundaryFail('W4C2_SCHEDULED_ADMIN_WITNESS_REQUIRED')
+      }
     }
     const workDate = parseCanonicalAttendanceWorkDateV1(input.workDate) as string
     const targetUserIds = [...input.targetUserIds].map(String)
@@ -1687,6 +1715,12 @@ export function createAttendanceLiveScheduledBoundaryV1(
     const probe = await withConnection((client) =>
       runAttendanceResultOperationTransactionV1(client, async (trx) => {
         if (rolloutKey === null) {
+          if (recoveryRunId !== null) {
+            boundaryFail('W4C2_SCHEDULED_RUN_RECOVERY_ORG_INVALID')
+          }
+          if (input.legacyDedupHit === true) {
+            return { mode: 'legacy_dedup' as const, rows: [] as Array<{ user_id: string }> }
+          }
           if (targetUserIds.length === 0) {
             return { mode: 'legacy' as const, rows: [] as Array<{ user_id: string }> }
           }
@@ -1704,6 +1738,12 @@ export function createAttendanceLiveScheduledBoundaryV1(
           return { mode: 'suspended' as const, rows: [] as Array<{ user_id: string }> }
         }
         if (posture.writePosture === 'legacy_projection_only') {
+          if (recoveryRunId !== null) {
+            return { mode: 'w4' as const, rows: [] as Array<{ user_id: string }> }
+          }
+          if (input.legacyDedupHit === true) {
+            return { mode: 'legacy_dedup' as const, rows: [] as Array<{ user_id: string }> }
+          }
           if (targetUserIds.length === 0) {
             return { mode: 'legacy' as const, rows: [] as Array<{ user_id: string }> }
           }
@@ -1723,15 +1763,21 @@ export function createAttendanceLiveScheduledBoundaryV1(
     )
 
     if (probe.mode === 'suspended') return { kind: 'suspended' }
+    if (probe.mode === 'legacy_dedup') return { kind: 'legacy_dedup' }
     if (probe.mode === 'legacy') return { kind: 'legacy', rows: probe.rows }
 
-    // W4 path only below: `cron` mints ONE org-scoped witness reused across
-    // every target user (no per-subject identity); `admin_run` mints a FRESH
-    // witness per user from the real host-authenticated admin identity
-    // (validated non-null/non-scheduler above) — see cronScheduledAuthorization
-    // / adminRunScheduledAuthorization. Both are SQL-rechecked inside every
-    // per-user registry transaction before any source/result DML.
-    const cronAuthorization = input.initiator === 'cron' ? cronScheduledAuthorization(orgKey) : null
+    // W4 path only below: an ordinary `cron` run and a recovery sweep use the
+    // registered internal scheduler identity; an ordinary `admin_run` mints a
+    // FRESH witness per user from the real host-authenticated admin identity.
+    // Recovery preserves the durable run initiator but records its own recovery
+    // source ref, never fabricating a human actor. Every witness is SQL-rechecked
+    // inside each per-user registry transaction before any source/result DML.
+    const recoveryAuthorization =
+      recoveryRunId === null ? null : internalScheduledAuthorization(orgKey, SCHEDULED_RECOVERY_SOURCE_REF)
+    const cronAuthorization =
+      recoveryRunId === null && input.initiator === 'cron'
+        ? internalScheduledAuthorization(orgKey, SCHEDULED_SOURCE_REF.cron)
+        : null
     const adminActorId = input.adminActorId
 
     // W4C-2 caller cutover (owner ruling 2026-07-28, "(b-narrow)"): the durable
@@ -1753,13 +1799,20 @@ export function createAttendanceLiveScheduledBoundaryV1(
     const resolveMembership: AttendanceScheduledRunMembershipResolverV1 = async () => membersForRun
 
     const startOutcome = await withConnection((client) =>
-      runAttendanceResultOperationTransactionV1(client, (trx) =>
-        createOrResumeAttendanceScheduledRunV1(
+      runAttendanceResultOperationTransactionV1(client, (trx) => {
+        if (recoveryRunId !== null) {
+          return resumeAttendanceScheduledRunByExactIdV1(
+            trx,
+            { orgId: orgKey, initiator: input.initiator, workDate, runId: recoveryRunId },
+            resolveMembership,
+          )
+        }
+        return createOrResumeAttendanceScheduledRunV1(
           trx,
           { orgId: orgKey, initiator: input.initiator, workDate },
           resolveMembership,
-        ),
-      ),
+        )
+      }),
     )
 
     if (startOutcome.kind === 'org_suspended_deferred') {
@@ -1770,6 +1823,7 @@ export function createAttendanceLiveScheduledBoundaryV1(
       // the run-creation transaction (section 1.7 step 1): the SAME null-ID
       // legacy contract the probe's own legacy branch above takes — a single
       // batch INSERT..SELECT, zero W4 rows, no per-user split.
+      if (input.legacyDedupHit === true) return { kind: 'legacy_dedup' }
       if (targetUserIds.length === 0) return { kind: 'legacy', rows: [] }
       const rows = await withConnection((client) =>
         runAttendanceResultOperationTransactionV1(client, (trx) =>
@@ -1787,6 +1841,9 @@ export function createAttendanceLiveScheduledBoundaryV1(
       // Section 1.9: zero `generate` targets — the run-creation transaction
       // WAS the finalization transaction; there is no per-user work and
       // nothing left to do here.
+      return { kind: 'w4', runId: startOutcome.runId, rows: [], perUser: [] }
+    }
+    if (startOutcome.kind === 'not_running') {
       return { kind: 'w4', runId: startOutcome.runId, rows: [], perUser: [] }
     }
 
@@ -1827,7 +1884,9 @@ export function createAttendanceLiveScheduledBoundaryV1(
         batch: null,
       })
       const authorization =
-        cronAuthorization ?? adminRunScheduledAuthorization(orgKey, adminActorId as string, userId)
+        recoveryAuthorization
+        ?? cronAuthorization
+        ?? adminRunScheduledAuthorization(orgKey, adminActorId as string, userId)
       const outcome = await withConnectionRetryingTargetContention((client) =>
         runAttendanceResultOperationTransactionV1(client, async (trx) => {
           const preflight = await attendanceResultOperationPreflightV1(trx, authorization, envelope.registryInput)
@@ -1995,5 +2054,31 @@ export function createAttendanceLiveScheduledBoundaryV1(
     return { kind: 'w4', runId, rows: insertedRows, perUser }
   }
 
-  return { executeLivePunch, executeScheduledRun }
+  async function executeScheduledRun(
+    input: AttendanceScheduledRunBoundaryInputV1,
+  ): Promise<AttendanceScheduledRunBoundaryResultV1> {
+    return executeScheduledRunInternal(input, null)
+  }
+
+  async function recoverScheduledRun(
+    input: AttendanceScheduledRunRecoveryBoundaryInputV1,
+  ): Promise<AttendanceScheduledRunBoundaryResultV1> {
+    return executeScheduledRunInternal(
+      {
+        orgId: input.orgId,
+        workDate: input.workDate,
+        timezone: input.timezone,
+        targetUserIds: input.targetUserIds,
+        initiator: input.initiator,
+        adminActorId: null,
+        isWorkday: input.isWorkday,
+        holidayKind: input.holidayKind,
+        reviewTargets: input.reviewTargets,
+        legacyDedupHit: false,
+      },
+      input.runId,
+    )
+  }
+
+  return { executeLivePunch, executeScheduledRun, recoverScheduledRun }
 }

--- a/packages/core-backend/src/attendance/w4c2-scheduled-run-ops-worker.ts
+++ b/packages/core-backend/src/attendance/w4c2-scheduled-run-ops-worker.ts
@@ -14,19 +14,12 @@
  * (the `abandoned` transition's authorization/lock-order/audit/concurrency/idempotency
  * contract).
  *
- * Sweep tick scope, disclosed (not silently assumed): section 1.7 describes TWO branches per
- * candidate — "not yet terminal" resumes the run "exactly as the resume protocol...describes",
- * "all terminal" finalizes. `sweepAttendanceScheduledRunCandidateV1` (w4c2-scheduled-run.ts)
- * implements ONLY the second branch today: it calls `finalizeAttendanceScheduledRunV1` and
- * returns its own `not_ready` outcome as the first branch's SIGNAL, per that module's own
- * comment — it does NOT itself drive per-user replay for a not-yet-terminal candidate (doing so
- * would require reconstructing the same rule/holiday/calendar context
- * `runAutoAbsenceForOrgDate` builds today, which is plugin-owned, not this module's). This
- * worker wires that function AS-IS: it closes the "last per-user commit succeeded, finalization
- * never ran" absorbing state (section 1.7's own stated motivation for the sweep, and section 2
- * gate 18's positive/negative controls, both of which are about exactly this branch), across
- * every calendar day (not just the cron's own lookback window), on a fixed cadence, without
- * waiting for a matching org/workDate cron invocation to recur.
+ * Sweep tick scope: section 1.7 describes TWO branches per candidate — "not yet terminal"
+ * resumes the exact run and "all terminal" finalizes it. The transaction-local step determines
+ * which branch applies. For the first branch, this worker requires a plugin-owned callback that
+ * rebuilds the current rule/holiday/calendar context and resumes the exact scanned `run_id`.
+ * Keeping that context outside core avoids a second policy implementation while keeping
+ * generation allocation outside the recovery path.
  *
  * It does NOT unwedge a target-set-drift candidate
  * (`W4C2_SCHEDULED_RUN_RESUME_TARGET_SET_DRIFT`) — section 1.7's own closing sentence names
@@ -44,6 +37,7 @@ import {
   sweepAttendanceScheduledRunCandidateV1,
   type AttendanceScheduledRunAbandonOutcomeV1,
   type AttendanceScheduledRunAbandonReasonCodeV1,
+  type AttendanceScheduledRunSweepCandidateV1,
 } from './w4c2-scheduled-run'
 
 // ---------------------------------------------------------------------------
@@ -60,6 +54,11 @@ export interface AttendanceScheduledRunSweepTickResultV1 {
 
 const SWEEP_DEFAULT_LIMIT = 25
 
+export interface AttendanceScheduledRunSweepOptionsV1 {
+  readonly limit?: number
+  readonly recoverCandidate: (candidate: AttendanceScheduledRunSweepCandidateV1) => Promise<void>
+}
+
 /**
  * One sweep tick: the scan runs in its OWN transaction, then EACH candidate gets its OWN fresh
  * connection and its OWN transaction — never batched (section 1.7's own comment on
@@ -72,7 +71,7 @@ const SWEEP_DEFAULT_LIMIT = 25
  */
 export async function sweepAttendanceScheduledRunsOnceV1(
   pool: Pick<Pool, 'connect'>,
-  options: { readonly limit?: number } = {},
+  options: AttendanceScheduledRunSweepOptionsV1,
 ): Promise<AttendanceScheduledRunSweepTickResultV1> {
   const limit =
     Number.isInteger(options.limit) && (options.limit as number) > 0 ? (options.limit as number) : SWEEP_DEFAULT_LIMIT
@@ -94,19 +93,32 @@ export async function sweepAttendanceScheduledRunsOnceV1(
   let errored = 0
   for (const candidate of candidates) {
     const client = (await pool.connect()) as unknown as PoolClient
+    let outcome: Awaited<ReturnType<typeof sweepAttendanceScheduledRunCandidateV1>> | null = null
     try {
-      const outcome = await runAttendanceResultOperationTransactionV1(
+      outcome = await runAttendanceResultOperationTransactionV1(
         client as unknown as AttendanceW4TransactionClientV1,
-        (trx) => sweepAttendanceScheduledRunCandidateV1(trx, candidate as never),
+        (trx) => sweepAttendanceScheduledRunCandidateV1(trx, candidate as AttendanceScheduledRunSweepCandidateV1),
       )
-      if (outcome.kind === 'finalized') finalized += 1
-      else if (outcome.kind === 'not_ready') notReady += 1
-      else skipped += 1
     } catch {
       errored += 1
     } finally {
       client.release()
     }
+    if (!outcome) continue
+    if (outcome.kind === 'finalized') {
+      finalized += 1
+      continue
+    }
+    if (outcome.kind === 'not_ready') {
+      try {
+        await options.recoverCandidate(candidate as AttendanceScheduledRunSweepCandidateV1)
+        notReady += 1
+      } catch {
+        errored += 1
+      }
+      continue
+    }
+    skipped += 1
   }
 
   return { scanned: candidates.length, finalized, notReady, skipped, errored }

--- a/packages/core-backend/src/attendance/w4c2-scheduled-run.ts
+++ b/packages/core-backend/src/attendance/w4c2-scheduled-run.ts
@@ -33,10 +33,10 @@
  * `deriveAttendanceScheduledRunIdV1` (formerly `w4c2-live-scheduled-boundary.ts`), is retired
  * by this cutover (section 1.1's "must not survive implementation" rule) — `runId` is now
  * always the server-minted `attendance_scheduled_runs.run_id` this module's own
- * `INSERT ... RETURNING`/resume read produces. The recovery sweep (`scanAttendance-
- * ScheduledRunSweepCandidatesV1`/`sweepAttendanceScheduledRunCandidateV1`) is still NOT wired
- * to any live tick — that remains a separate, disclosed residual (the dispatcher's own
- * "zero-caller posture" doctrine: scheduling is the caller's concern, not this module's).
+ * `INSERT ... RETURNING`/resume read produces. The recovery sweep is wired through the
+ * plugin-owned scheduler context builder: it resumes the exact scanned `run_id`, never the
+ * ordinary create-or-resume entry point, so a scan/finalize race cannot create generation
+ * `n+1`.
  *
  * Values-free discipline: every throw is a closed code string only, never the offending
  * input bytes.
@@ -536,6 +536,14 @@ export type AttendanceScheduledRunStartOutcomeV1 =
       readonly readyToFinalize: boolean
     }
 
+export interface AttendanceScheduledRunExactResumeKeyV1 extends AttendanceScheduledRunKeyInputV1 {
+  readonly runId: string
+}
+
+export type AttendanceScheduledRunExactResumeOutcomeV1 =
+  | AttendanceScheduledRunStartOutcomeV1
+  | { readonly kind: 'not_running'; readonly runId: string; readonly state: 'completed' | 'abandoned' }
+
 async function readRunningScheduledRunForUpdateV1(
   trx: AttendanceW4TransactionClientV1,
   orgId: string,
@@ -550,6 +558,26 @@ async function readRunningScheduledRunForUpdateV1(
       WHERE org_id = $1 AND initiator = $2 AND work_date = $3::date AND state = 'running'
       FOR UPDATE`,
     [orgId, initiator, workDate],
+  )
+  if (result.rows.length === 0) return null
+  if (result.rows.length > 1) fail('W4C2_SCHEDULED_RUN_STATE_AMBIGUOUS')
+  return result.rows[0] as unknown as AttendanceScheduledRunRowShapeV1
+}
+
+async function readScheduledRunByExactIdV1(
+  trx: AttendanceW4TransactionClientV1,
+  orgId: string,
+  runId: string,
+  forUpdate: boolean,
+): Promise<AttendanceScheduledRunRowShapeV1 | null> {
+  const result = await trx.query(
+    `SELECT run_id::text AS run_id, org_id, entrypoint, initiator, work_date::text AS work_date,
+            generation, accepted_write_posture, target_set_fingerprint, expected_user_count,
+            review_count, state
+       FROM attendance_scheduled_runs
+      WHERE org_id = $1 AND run_id = $2::uuid
+      ${forUpdate ? 'FOR UPDATE' : ''}`,
+    [orgId, runId],
   )
   if (result.rows.length === 0) return null
   if (result.rows.length > 1) fail('W4C2_SCHEDULED_RUN_STATE_AMBIGUOUS')
@@ -700,6 +728,54 @@ export async function createOrResumeAttendanceScheduledRunV1(
   }
 
   return { kind: 'created_running', runId, generation, expectedUserCount, reviewCount }
+}
+
+/**
+ * Recovery-only exact-run resume. Unlike `createOrResumeAttendanceScheduledRunV1`, this
+ * function can never allocate a generation. The pre-lock read only discovers and verifies
+ * the durable class-01 key; authority is established by the class-00/class-01 locks and the
+ * second `FOR UPDATE` read.
+ */
+export async function resumeAttendanceScheduledRunByExactIdV1(
+  trx: AttendanceW4TransactionClientV1,
+  key: AttendanceScheduledRunExactResumeKeyV1,
+  resolveMembership: AttendanceScheduledRunMembershipResolverV1,
+): Promise<AttendanceScheduledRunExactResumeOutcomeV1> {
+  const canonicalKey = parseCanonicalAttendanceScheduledRunKeyV1({
+    orgId: key.orgId,
+    initiator: key.initiator,
+    workDate: key.workDate,
+  })
+  const runId = parseUuidSyntax(key.runId, 'W4C2_SCHEDULED_RUN_ID_INVALID')
+  requireRfc4122VariantVersion(runId, 'W4C2_SCHEDULED_RUN_ID_INVALID')
+
+  await acquireAttendanceCalculationRolloutLock(trx, canonicalKey.orgId, 'shared')
+  const posture = await resolveSegmentCalculationPosture(trx, canonicalKey.orgId)
+  if (posture.writePosture === 'blocked') {
+    return { kind: 'org_suspended_deferred' }
+  }
+
+  const preRead = await readScheduledRunByExactIdV1(trx, canonicalKey.orgId, runId, false)
+  if (!preRead) fail('W4C2_SCHEDULED_RUN_NOT_FOUND')
+  if (preRead.initiator !== canonicalKey.initiator || preRead.work_date !== canonicalKey.workDate) {
+    fail('W4C2_SCHEDULED_RUN_RECOVERY_KEY_MISMATCH')
+  }
+
+  await acquireAttendanceScheduledRunLock(trx, canonicalKey)
+  const existing = await readScheduledRunByExactIdV1(trx, canonicalKey.orgId, runId, true)
+  if (!existing) fail('W4C2_SCHEDULED_RUN_NOT_FOUND')
+  if (existing.initiator !== canonicalKey.initiator || existing.work_date !== canonicalKey.workDate) {
+    fail('W4C2_SCHEDULED_RUN_RECOVERY_KEY_MISMATCH')
+  }
+  if (existing.state !== 'running') {
+    if (existing.state !== 'completed' && existing.state !== 'abandoned') {
+      fail('W4C2_SCHEDULED_RUN_STATE_INVALID')
+    }
+    return { kind: 'not_running', runId, state: existing.state }
+  }
+
+  const org = createVerifiedAttendanceOrgIdentityV1({ orgKey: canonicalKey.orgId, posture })
+  return resumeAttendanceScheduledRunV1(trx, org, existing, resolveMembership)
 }
 
 /**
@@ -1097,8 +1173,6 @@ export async function finalizeAttendanceScheduledRunV1(
 
 // ---------------------------------------------------------------------------
 // Section 1.7, "no stuck absorbing state" — the recovery-sweep scan + one-candidate step.
-// NOT wired to any live tick in this slice (module docstring) — the scan/step functions and
-// their real-DB gates are the sweep's full specification, ready for that later wiring.
 // ---------------------------------------------------------------------------
 
 export interface AttendanceScheduledRunSweepCandidateV1 {
@@ -1147,9 +1221,8 @@ export type AttendanceScheduledRunSweepStepOutcomeV1 =
  * -> resume; "all terminal" -> finalize) that are "already fully specified elsewhere in this
  * section" — this function reuses `finalizeAttendanceScheduledRunV1` verbatim rather than
  * inventing a third transaction shape: `not_ready` IS the "resume" branch's terminal-evidence
- * signal (the actual per-user replay/execution the resume protocol's remaining steps describe
- * is the existing, unchanged per-user execution path — out of this function's scope, per the
- * module docstring's caller-cutover note). Intended to run as ONE candidate per its OWN
+ * signal. The worker then invokes the plugin-owned context builder and its recovery-only
+ * exact-run boundary for the actual per-user replay. Intended to run as ONE candidate per its OWN
  * `runAttendanceResultOperationTransactionV1` call, never batched, so one stuck candidate
  * cannot block the others in the same scan.
  */

--- a/packages/core-backend/src/index.ts
+++ b/packages/core-backend/src/index.ts
@@ -2102,15 +2102,22 @@ export class MetaSheetServer {
                   }
                 },
                 // W4C-2 P1-1 fix (#4612 verdict second gate round; amendment section 1.7 "No
-                // stuck absorbing state — recovery sweep, fully specified"). ONE sweep tick —
-                // scan plus a per-candidate finalize attempt, never batched into one
-                // transaction. See `sweepAttendanceScheduledRunsOnceV1`'s own module comment
-                // for this function's disclosed scope (it closes the "terminal but never
-                // finalized" absorbing state; it does not itself resume a target-set-drift
-                // candidate — that is `abandonScheduledRun` below).
-                sweepScheduledRuns: async (options?: { limit?: number }) =>
+                // stuck absorbing state — recovery sweep, fully specified"). ONE sweep tick:
+                // all-terminal candidates finalize in core; nonterminal candidates call back
+                // into the plugin to rebuild current scheduling context and resume the exact
+                // scanned run id.
+                sweepScheduledRuns: async (options: {
+                  limit?: number
+                  recoverCandidate(candidate: {
+                    orgId: string
+                    initiator: 'cron' | 'admin_run'
+                    workDate: string
+                    runId: string
+                  }): Promise<void>
+                }) =>
                   sweepAttendanceScheduledRunsOnceV1(poolManager.get().getInternalPool(), {
-                    limit: options?.limit,
+                    limit: options.limit,
+                    recoverCandidate: options.recoverCandidate,
                   }),
                 // W4C-2 P1-1 fix (#4612 verdict second gate round; amendment section 1.1.2, the
                 // `abandoned` transition). `adminActorId` is the route's OWN authenticated actor

--- a/packages/core-backend/src/types/plugin.ts
+++ b/packages/core-backend/src/types/plugin.ts
@@ -1171,11 +1171,18 @@ export interface PluginServices {
     /**
      * W4C-2 P1-1 fix (#4612 verdict second gate round; amendment section 1.7's recovery sweep).
      * ONE sweep tick over `state='running'` scheduled-run rows, cross-`workDate`, bounded by
-     * `limit`. See `sweepAttendanceScheduledRunsOnceV1`'s own module comment for this call's
-     * disclosed scope: it closes the "terminal but never finalized" absorbing state; it does
-     * NOT resume a target-set-drift candidate (that exit is `abandonScheduledRun` below).
+     * `limit`. `recoverCandidate` must rebuild plugin-owned scheduling context and resume the
+     * exact scanned run; the host never silently treats `not_ready` as completed work.
      */
-    sweepScheduledRuns(options?: { limit?: number }): Promise<{
+    sweepScheduledRuns(options: {
+      limit?: number
+      recoverCandidate(candidate: {
+        orgId: string
+        initiator: 'cron' | 'admin_run'
+        workDate: string
+        runId: string
+      }): Promise<void>
+    }): Promise<{
       scanned: number
       finalized: number
       notReady: number

--- a/packages/core-backend/tests/integration/attendance-w4c2-gate-matrix-e5.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-w4c2-gate-matrix-e5.db.test.ts
@@ -222,6 +222,8 @@ describeDb('W4C-2 Stage E gate matrix (real DB: isolation, forged authz, freeze 
   const cutoverStragglerRaceOrg = randomUUID()
   const cutoverInitiatorOrg = randomUUID()
   const cutoverDispatchOrg = randomUUID()
+  const cutoverRecoveryOrg = randomUUID()
+  const cutoverAdminRecoveryOrg = randomUUID()
   // Gate 8 (owner ruling 2026-07-28, "(b-narrow)" required-gate list item 8):
   // an ALLOWLISTED org whose rollout row is `legacy` — resolves to
   // `legacy_projection_only` via `resolveSegmentCalculationPosture` (the
@@ -334,7 +336,7 @@ describeDb('W4C-2 Stage E gate matrix (real DB: isolation, forged authz, freeze 
     )).rows
   const operationRows = async (orgId: string, entrypoint?: string) =>
     (await pool.query(
-      `SELECT operation_id::text AS operation_id, entrypoint, state, accepted_write_posture, actor_id, capability,
+      `SELECT operation_id::text AS operation_id, entrypoint, state, accepted_write_posture, actor_id, capability, source_ref,
               identity_source_kind, source_root_id::text AS source_root_id, proof_user_id, proof_work_date::text AS proof_work_date,
               resolved_record_id::text AS resolved_record_id,
               resolved_calculation_id::text AS resolved_calculation_id, response_snapshot
@@ -528,7 +530,8 @@ describeDb('W4C-2 Stage E gate matrix (real DB: isolation, forged authz, freeze 
       ambOrg, isoOrg, isoOrg2, replayOrg, authzOrg, authoritativeOrg, rebaseOrg, orderOrg, schedOrg,
       adminWitnessOrg,
       cutoverRestartOrg, cutoverConcurrentOrg, cutoverStragglerOrg, cutoverStragglerControlOrg,
-      cutoverStragglerRaceOrg, cutoverInitiatorOrg, cutoverDispatchOrg, cutoverLegacyOrg,
+      cutoverStragglerRaceOrg, cutoverInitiatorOrg, cutoverDispatchOrg, cutoverRecoveryOrg,
+      cutoverAdminRecoveryOrg, cutoverLegacyOrg,
     ].join(',')
 
     const repoRoot = path.join(__dirname, '../../../../')
@@ -1405,6 +1408,9 @@ describeDb('W4C-2 Stage E gate matrix (real DB: isolation, forged authz, freeze 
         reviewTargets: [],
         initiator: 'cron',
         adminActorId: null,
+        // A process-local duplicate signal must never hide a W4 running run.
+        // Both the crash and retry therefore continue through class-01.
+        legacyDedupHit: true,
       })
 
     // First attempt: userA commits (real INSERT), userB's per-user
@@ -1458,6 +1464,132 @@ describeDb('W4C-2 Stage E gate matrix (real DB: isolation, forged authz, freeze 
     expect(userARowAfterRetry).toEqual(userARowBeforeRetry)
     const userBRow = opsAfterRetry.find((row) => row.proof_user_id === userB)
     expect(userBRow).toMatchObject({ state: 'completed', proof_work_date: workDate })
+  })
+
+  it('leg 9g-recovery — a fresh boundary resumes the exact stranded run and never allocates generation n+1', async () => {
+    const orgId = cutoverRecoveryOrg
+    const userA = randomUUID()
+    const userB = randomUUID()
+    await insertRolloutRow(orgId, 'shadow')
+    await insertActiveUser(userA, orgId)
+    await insertActiveUser(userB, orgId)
+    const workDate = '2026-03-07'
+
+    const firstAdapters = onceFailingAdapters(userB)
+    const firstBoundary = buildDirectScheduledBoundary(firstAdapters.adapters)
+    await expect(
+      firstBoundary.executeScheduledRun({
+        orgId,
+        workDate,
+        timezone: 'UTC',
+        targetUserIds: [userA, userB],
+        reviewTargets: [],
+        initiator: 'cron',
+        adminActorId: null,
+      }),
+    ).rejects.toThrow('W4C2_CUTOVER_SIMULATED_CRASH')
+
+    const stranded = await scheduledRunRows(orgId, workDate)
+    expect(stranded).toHaveLength(1)
+    expect(stranded[0]).toMatchObject({ generation: 1, state: 'running' })
+    const runId = stranded[0].run_id as string
+
+    // A fresh boundary instance stands in for a restarted process. The worker callback carries
+    // the scanned run id into the recovery-only entry, so it cannot fall back to ordinary
+    // create-or-resume generation allocation.
+    const recoveryAdapters = realScheduledAdapters()
+    const recoveryBoundary = buildDirectScheduledBoundary(recoveryAdapters.adapters)
+    await recoveryBoundary.recoverScheduledRun({
+      orgId,
+      workDate,
+      timezone: 'UTC',
+      targetUserIds: [userA, userB],
+      reviewTargets: [],
+      initiator: 'cron',
+      runId,
+    })
+
+    const after = await scheduledRunRows(orgId, workDate)
+    expect(after).toHaveLength(1)
+    expect(after[0]).toMatchObject({
+      run_id: runId,
+      generation: 1,
+      state: 'completed',
+      expected_user_count: 2,
+      completed_user_count: 2,
+      generated_count: 2,
+    })
+    expect((await operationRows(orgId, 'scheduled'))).toHaveLength(2)
+    expect(await recordCount(userA)).toBe(1)
+    expect(await recordCount(userB)).toBe(1)
+    // Only the outstanding user is executed by the recovery boundary.
+    expect(recoveryAdapters.absenceCallUserIds()).toEqual([userB])
+
+    // Scan/finalize race: the same stale candidate reaches recovery after another worker has
+    // already completed it. The exact-run entry is a zero-DML no-op; routing this through the
+    // ordinary create-or-resume entry would allocate generation 2 and this assertion would fail.
+    await recoveryBoundary.recoverScheduledRun({
+      orgId,
+      workDate,
+      timezone: 'UTC',
+      targetUserIds: [userA, userB],
+      reviewTargets: [],
+      initiator: 'cron',
+      runId,
+    })
+    expect(await scheduledRunRows(orgId, workDate)).toHaveLength(1)
+    expect(recoveryAdapters.absenceCallUserIds()).toEqual([userB])
+  })
+
+  it('leg 9g-admin-recovery — the registered service identity resumes an admin_run without fabricating a human actor', async () => {
+    const orgId = cutoverAdminRecoveryOrg
+    const userA = randomUUID()
+    const userB = randomUUID()
+    await insertRolloutRow(orgId, 'shadow')
+    await insertActiveUser(userA, orgId)
+    await insertActiveUser(userB, orgId)
+    const workDate = '2026-03-08'
+
+    const firstAdapters = onceFailingAdapters(userB)
+    const firstBoundary = buildDirectScheduledBoundary(firstAdapters.adapters)
+    await expect(
+      firstBoundary.executeScheduledRun({
+        orgId,
+        workDate,
+        timezone: 'UTC',
+        targetUserIds: [userA, userB],
+        reviewTargets: [],
+        initiator: 'admin_run',
+        adminActorId: schedAdminUser,
+      }),
+    ).rejects.toThrow('W4C2_CUTOVER_SIMULATED_CRASH')
+    const run = (await scheduledRunRows(orgId, workDate))[0]
+    expect(run).toMatchObject({ initiator: 'admin_run', generation: 1, state: 'running' })
+
+    const recoveryAdapters = realScheduledAdapters()
+    const recoveryBoundary = buildDirectScheduledBoundary(recoveryAdapters.adapters)
+    await recoveryBoundary.recoverScheduledRun({
+      orgId,
+      workDate,
+      timezone: 'UTC',
+      targetUserIds: [userA, userB],
+      reviewTargets: [],
+      initiator: 'admin_run',
+      runId: run.run_id,
+    })
+
+    expect(await scheduledRunRows(orgId, workDate)).toMatchObject([
+      { run_id: run.run_id, initiator: 'admin_run', generation: 1, state: 'completed' },
+    ])
+    const operations = await operationRows(orgId, 'scheduled')
+    expect(operations.find((row) => row.proof_user_id === userA)?.actor_id).toBe(schedAdminUser)
+    expect(operations.find((row) => row.proof_user_id === userB)?.actor_id).toBe(
+      ATTENDANCE_INTERNAL_SCHEDULER_ACTOR_ID_V1,
+    )
+    expect(operations.find((row) => row.proof_user_id === userB)?.source_ref).toBe(
+      'plugin-attendance:auto-absence:recovery-sweep',
+    )
+    expect(recoveryAdapters.absenceCallUserIds()).toEqual([userB])
   })
 
   it('leg 9h — concurrent same run: two simultaneous calls for the SAME (org, initiator, workDate) never duplicate the run row, the target row, or the absence insert; exactly one run, one operation, one record survive', async () => {
@@ -1883,6 +2015,28 @@ describeDb('W4C-2 Stage E gate matrix (real DB: isolation, forged authz, freeze 
       const n = (await pool.query(`SELECT count(*)::int AS n FROM ${table} WHERE org_id = $1`, [orgId])).rows[0].n
       expect(n, `${table} must stay empty under legacy posture`).toBe(0)
     }
+  })
+
+  it('leg 9m-dedup — the process-local key remains a zero-DML legacy-only short circuit', async () => {
+    const orgId = randomUUID()
+    await insertRolloutRow(orgId, 'legacy')
+    const { adapters, absenceCallCount } = throwingScheduledAdapters()
+    const boundary = buildDirectScheduledBoundary(adapters)
+
+    const outcome = await boundary.executeScheduledRun({
+      orgId,
+      workDate: '2026-07-22',
+      timezone: 'UTC',
+      targetUserIds: [randomUUID()],
+      reviewTargets: [],
+      initiator: 'cron',
+      adminActorId: null,
+      legacyDedupHit: true,
+    })
+
+    expect(outcome).toEqual({ kind: 'legacy_dedup' })
+    expect(absenceCallCount()).toBe(0)
+    expect(await scheduledRunRows(orgId)).toEqual([])
   })
 
   it('leg 9m2 — P2-1 fix (#4612 verdict second gate round): a `legacy_projection_only` org with TWO W2-ambiguous members exercises the ONLY shape leg 9m\'s empty `reviewRequired: []` cannot see — the deleted `ORDER BY uo.user_id ASC` (verdict P2-1) previously changed exactly this array\'s element order versus pre-amendment `main`; asserted as an exact SET (order is, and always was, unspecified absent an explicit sort — the frozen membership-query row order was never a real contract), never a literal sequence a real row-order flake could later break', async () => {

--- a/packages/core-backend/tests/integration/attendance-w4c2-p12-run-transactions.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-w4c2-p12-run-transactions.db.test.ts
@@ -27,11 +27,13 @@ import {
   abandonAttendanceScheduledRunV1,
   scanAttendanceScheduledRunSweepCandidatesV1,
   sweepAttendanceScheduledRunCandidateV1,
+  resumeAttendanceScheduledRunByExactIdV1,
   resolveAttendanceScheduledRunTargetSetV1,
   computeAttendanceScheduledRunTargetSetFingerprintV1,
   type AttendanceScheduledRunMemberInputV1,
   type AttendanceScheduledRunMembershipResolverV1,
 } from '../../src/attendance/w4c2-scheduled-run'
+import { sweepAttendanceScheduledRunsOnceV1 } from '../../src/attendance/w4c2-scheduled-run-ops-worker'
 import { createVerifiedAttendanceOperationIdentityV1, createVerifiedAttendanceOrgIdentityV1, resolveSegmentCalculationPosture } from '../../src/attendance/w4c0-identity'
 import { createAuthorizedAttendanceWriteContextV1 } from '../../src/attendance/w4c0-authorization'
 import { runAttendanceResultOperationTransactionV1 } from '../../src/attendance/w4c0-operation-registry'
@@ -1072,6 +1074,241 @@ describeIfDatabase('W4C-2 P1-2 — run-creation/resume/finalization/abandoned tr
         withTxn((trx) => sweepAttendanceScheduledRunCandidateV1(trx, { orgId, initiator: 'cron', workDate, runId: created.runId })),
       )
       expect(stepOutcome).toEqual({ kind: 'not_ready', runId: created.runId })
+    })
+
+    it.each(['cron', 'admin_run'] as const)(
+      'resumes the exact scanned %s run without allocating a new generation',
+      async (initiator) => {
+        const orgId = orgIdFor(`sweep-exact-${initiator}`)
+        await setRolloutState(orgId, 'shadow')
+        const workDate = initiator === 'cron' ? '2026-02-20' : '2026-02-21'
+        const userA = uuid()
+        const members = [{ userId: userA, targetKind: 'generate' as const, reviewReasonCode: null }]
+        const created = await withAllowlist(orgId, () =>
+          withTxn((trx) =>
+            createOrResumeAttendanceScheduledRunV1(
+              trx,
+              { orgId, initiator, workDate },
+              memberResolverFor(members),
+            ),
+          ),
+        )
+        if (created.kind !== 'created_running') throw new Error('expected created_running')
+
+        const resumed = await withAllowlist(orgId, () =>
+          withTxn((trx) =>
+            resumeAttendanceScheduledRunByExactIdV1(
+              trx,
+              { orgId, initiator, workDate, runId: created.runId },
+              memberResolverFor(members),
+            ),
+          ),
+        )
+        expect(resumed).toMatchObject({
+          kind: 'resumed',
+          runId: created.runId,
+          generation: 1,
+          readyToFinalize: false,
+        })
+        const runs = await pool.query(
+          `SELECT run_id::text AS run_id, generation, state
+             FROM attendance_scheduled_runs
+            WHERE org_id = $1 AND initiator = $2 AND work_date = $3::date`,
+          [orgId, initiator, workDate],
+        )
+        expect(runs.rows).toEqual([{ run_id: created.runId, generation: 1, state: 'running' }])
+      },
+    )
+
+    it('returns not_running when the scanned run finalized before recovery and never creates generation n+1', async () => {
+      const orgId = orgIdFor('sweep-finalize-race')
+      await setRolloutState(orgId, 'shadow')
+      const workDate = '2026-02-22'
+      const userA = uuid()
+      const members = [{ userId: userA, targetKind: 'generate' as const, reviewReasonCode: null }]
+      const created = await withAllowlist(orgId, () =>
+        withTxn((trx) =>
+          createOrResumeAttendanceScheduledRunV1(
+            trx,
+            { orgId, initiator: 'cron', workDate },
+            memberResolverFor(members),
+          ),
+        ),
+      )
+      if (created.kind !== 'created_running') throw new Error('expected created_running')
+      await sealGenerateTarget(orgId, created.runId, userA, workDate, 'completed', true)
+      await withAllowlist(orgId, () =>
+        withTxn((trx) =>
+          finalizeAttendanceScheduledRunV1(trx, {
+            orgId,
+            initiator: 'cron',
+            workDate,
+            runId: created.runId,
+          }),
+        ),
+      )
+
+      const raced = await withAllowlist(orgId, () =>
+        withTxn((trx) =>
+          resumeAttendanceScheduledRunByExactIdV1(
+            trx,
+            { orgId, initiator: 'cron', workDate, runId: created.runId },
+            memberResolverFor(members),
+          ),
+        ),
+      )
+      expect(raced).toEqual({ kind: 'not_running', runId: created.runId, state: 'completed' })
+      const count = await pool.query(
+        `SELECT count(*)::int AS n, max(generation)::int AS max_generation
+           FROM attendance_scheduled_runs
+          WHERE org_id = $1 AND initiator = 'cron' AND work_date = $2::date`,
+        [orgId, workDate],
+      )
+      expect(count.rows[0]).toEqual({ n: 1, max_generation: 1 })
+    })
+
+    it('fails closed on membership drift and leaves the exact run running', async () => {
+      const orgId = orgIdFor('sweep-drift')
+      await setRolloutState(orgId, 'shadow')
+      const workDate = '2026-02-23'
+      const userA = uuid()
+      const userB = uuid()
+      const created = await withAllowlist(orgId, () =>
+        withTxn((trx) =>
+          createOrResumeAttendanceScheduledRunV1(
+            trx,
+            { orgId, initiator: 'cron', workDate },
+            memberResolverFor([{ userId: userA, targetKind: 'generate', reviewReasonCode: null }]),
+          ),
+        ),
+      )
+      if (created.kind !== 'created_running') throw new Error('expected created_running')
+
+      const error = await withAllowlist(orgId, () =>
+        catchAsync(() =>
+          withTxn((trx) =>
+            resumeAttendanceScheduledRunByExactIdV1(
+              trx,
+              { orgId, initiator: 'cron', workDate, runId: created.runId },
+              memberResolverFor([
+                { userId: userA, targetKind: 'generate', reviewReasonCode: null },
+                { userId: userB, targetKind: 'generate', reviewReasonCode: null },
+              ]),
+            ),
+          ),
+        ),
+      )
+      expect(String((error as { code?: string })?.code)).toBe('W4C2_SCHEDULED_RUN_RESUME_TARGET_SET_DRIFT')
+      expect(
+        (await pool.query('SELECT state FROM attendance_scheduled_runs WHERE run_id = $1::uuid', [created.runId]))
+          .rows[0].state,
+      ).toBe('running')
+    })
+
+    it('defers exact recovery while suspended, then resumes the same run after unblocking', async () => {
+      const orgId = orgIdFor('sweep-suspended')
+      await setRolloutState(orgId, 'authoritative')
+      const workDate = '2026-02-25'
+      const userA = uuid()
+      const members = [{ userId: userA, targetKind: 'generate' as const, reviewReasonCode: null }]
+      const created = await withAllowlist(orgId, () =>
+        withTxn((trx) =>
+          createOrResumeAttendanceScheduledRunV1(
+            trx,
+            { orgId, initiator: 'cron', workDate },
+            memberResolverFor(members),
+          ),
+        ),
+      )
+      if (created.kind !== 'created_running') throw new Error('expected created_running')
+
+      await setRolloutState(orgId, 'suspended')
+      const deferred = await withAllowlist(orgId, () =>
+        withTxn((trx) =>
+          resumeAttendanceScheduledRunByExactIdV1(
+            trx,
+            { orgId, initiator: 'cron', workDate, runId: created.runId },
+            memberResolverFor(members),
+          ),
+        ),
+      )
+      expect(deferred).toEqual({ kind: 'org_suspended_deferred' })
+      expect(
+        (await pool.query('SELECT state FROM attendance_scheduled_runs WHERE run_id = $1::uuid', [created.runId]))
+          .rows[0].state,
+      ).toBe('running')
+
+      await setRolloutState(orgId, 'authoritative')
+      const resumed = await withAllowlist(orgId, () =>
+        withTxn((trx) =>
+          resumeAttendanceScheduledRunByExactIdV1(
+            trx,
+            { orgId, initiator: 'cron', workDate, runId: created.runId },
+            memberResolverFor(members),
+          ),
+        ),
+      )
+      expect(resumed).toMatchObject({ kind: 'resumed', runId: created.runId, generation: 1 })
+      const runs = await pool.query(
+        `SELECT run_id::text AS run_id, generation, state
+           FROM attendance_scheduled_runs
+          WHERE org_id = $1 AND initiator = 'cron' AND work_date = $2::date`,
+        [orgId, workDate],
+      )
+      expect(runs.rows).toEqual([{ run_id: created.runId, generation: 1, state: 'running' }])
+    })
+
+    it('contains one recovery callback failure and still finalizes a later all-terminal candidate', async () => {
+      const orgError = orgIdFor('sweep-worker-error')
+      const orgFinal = orgIdFor('sweep-worker-final')
+      await setRolloutState(orgError, 'shadow')
+      await setRolloutState(orgFinal, 'shadow')
+      const workDate = '2026-02-24'
+      const userError = uuid()
+      const userFinal = uuid()
+      const [errorRun, finalRun] = await withAllowlist([orgError, orgFinal], () =>
+        Promise.all([
+          withTxn((trx) =>
+            createOrResumeAttendanceScheduledRunV1(
+              trx,
+              { orgId: orgError, initiator: 'cron', workDate },
+              memberResolverFor([{ userId: userError, targetKind: 'generate', reviewReasonCode: null }]),
+            ),
+          ),
+          withTxn((trx) =>
+            createOrResumeAttendanceScheduledRunV1(
+              trx,
+              { orgId: orgFinal, initiator: 'cron', workDate },
+              memberResolverFor([{ userId: userFinal, targetKind: 'generate', reviewReasonCode: null }]),
+            ),
+          ),
+        ]),
+      )
+      if (errorRun.kind !== 'created_running' || finalRun.kind !== 'created_running') {
+        throw new Error('expected created_running')
+      }
+      await sealGenerateTarget(orgFinal, finalRun.runId, userFinal, workDate, 'completed', true)
+
+      const callbackRuns: string[] = []
+      const result = await withAllowlist([orgError, orgFinal], () =>
+        sweepAttendanceScheduledRunsOnceV1(pool, {
+          limit: 500,
+          async recoverCandidate(candidate) {
+            callbackRuns.push(candidate.runId)
+            if (candidate.runId === errorRun.runId) throw new Error('W4C2_TEST_RECOVERY_FAILURE')
+          },
+        }),
+      )
+      expect(callbackRuns).toContain(errorRun.runId)
+      expect(result.errored).toBeGreaterThanOrEqual(1)
+      expect(
+        (await pool.query('SELECT state FROM attendance_scheduled_runs WHERE run_id = $1::uuid', [finalRun.runId]))
+          .rows[0].state,
+      ).toBe('completed')
+      expect(
+        (await pool.query('SELECT state FROM attendance_scheduled_runs WHERE run_id = $1::uuid', [errorRun.runId]))
+          .rows[0].state,
+      ).toBe('running')
     })
   })
 

--- a/packages/core-backend/tests/unit/attendance-w4c2-recovery-wiring.test.ts
+++ b/packages/core-backend/tests/unit/attendance-w4c2-recovery-wiring.test.ts
@@ -1,0 +1,38 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+const pluginSource = readFileSync(
+  new URL('../../../../plugins/plugin-attendance/index.cjs', import.meta.url),
+  'utf8',
+).replace(/\r\n/g, '\n')
+
+describe('W4C-2 scheduled-run recovery wiring', () => {
+  it('registers the env-gated sweep with a plugin context rebuild for the exact scanned run', () => {
+    const registration = pluginSource.match(
+      /w4ScheduledRunSweepRunOnce = \(\) => attendanceW4SegmentCalculationPort\.sweepScheduledRuns\(\{[\s\S]*?\n\s*\}\)/,
+    )?.[0]
+
+    expect(registration).toBeDefined()
+    expect(registration).toContain('recoverCandidate: (candidate) => runAutoAbsenceForOrgDate')
+    expect(registration).toContain('skipDedup: true')
+    expect(registration).toContain('w4Boundary: w4LiveScheduledBoundary')
+    expect(registration).toContain('initiator: candidate.initiator')
+    expect(registration).toContain('recoveryRunId: candidate.runId')
+    expect(pluginSource).toContain(
+      'if (recoveryRunId === null && calendarOverrides.length === 0 && holiday && holiday.isWorkingDay === false)',
+    )
+  })
+
+  it('routes recovery through the dedicated exact-run boundary instead of ordinary create-or-resume', () => {
+    expect(pluginSource).toContain('w4Boundary.recoverScheduledRun({ ...boundaryInput, runId: recoveryRunId })')
+    expect(pluginSource).toContain('w4Boundary.executeScheduledRun({ ...boundaryInput, adminActorId })')
+  })
+
+  it('defers process-local dedup to the posture-aware boundary', () => {
+    expect(pluginSource).toContain('const legacyDedupHit = !skipDedup && key === lastAutoAbsenceKey')
+    expect(pluginSource).toContain('if (!w4Boundary && legacyDedupHit)')
+    expect(pluginSource).toContain('legacyDedupHit,')
+    expect(pluginSource).toContain("outcome.kind === 'legacy_dedup'")
+    expect(pluginSource).not.toContain('if (!skipDedup && key === lastAutoAbsenceKey)')
+  })
+})

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -21589,6 +21589,7 @@ function clearHolidaySyncSchedule() {
 // query on holiday-rest days for orgs that haven't configured any policy).
 async function runAutoAbsenceForOrgDate(db, options) {
   const { orgId, workDate, logger, emit, skipDedup = false } = options
+  const recoveryRunId = typeof options.recoveryRunId === 'string' ? options.recoveryRunId : null
   const rule = options.rule ?? await loadDefaultRule(db, orgId)
   let calendarOverrides = Array.isArray(options.calendarOverrides) ? options.calendarOverrides : null
   if (calendarOverrides === null) {
@@ -21603,11 +21604,17 @@ async function runAutoAbsenceForOrgDate(db, options) {
   }
   const holiday = await loadHoliday(db, orgId, workDate)
   // Optimization preserved ONLY when no policy can flip the holiday verdict.
-  if (calendarOverrides.length === 0 && holiday && holiday.isWorkingDay === false) {
+  if (recoveryRunId === null && calendarOverrides.length === 0 && holiday && holiday.isWorkingDay === false) {
     return { skipped: true, reason: 'holiday-rest-no-policy', total: 0 }
   }
   const key = `${orgId}:${workDate}`
-  if (!skipDedup && key === lastAutoAbsenceKey) {
+  const legacyDedupHit = !skipDedup && key === lastAutoAbsenceKey
+  const w4Boundary = options.w4Boundary ?? null
+  // Bare-module consumers have no posture-aware boundary, so retain the
+  // historical process-local dedup exactly. Production callers pass the
+  // boundary: it alone may honor this signal after proving the org is legacy;
+  // W4 postures always continue into the durable class-01 run protocol.
+  if (!w4Boundary && legacyDedupHit) {
     return { skipped: true, reason: 'dedup', total: 0 }
   }
   // W4C-2 P2-1 fix (#4612 verdict second gate round): this query intentionally carries NO
@@ -21700,7 +21707,6 @@ async function runAutoAbsenceForOrgDate(db, options) {
   // construct their own `db` (no host services port exists there, so no boundary can) — the
   // production initiators fail closed instead of taking this branch when the boundary is
   // missing (see the cron run loop and POST /api/attendance/auto-absence/run).
-  const w4Boundary = options.w4Boundary ?? null
   let rows
   let suspendedByRollout = false
   // W4C-2 caller cutover (owner ruling 2026-07-28, "(b-narrow)"): for the w4
@@ -21720,7 +21726,10 @@ async function runAutoAbsenceForOrgDate(db, options) {
     // scheduler constant); cron MUST carry exactly null. The boundary rejects
     // any other combination before minting any witness.
     const adminActorId = initiator === 'admin_run' ? (options.adminActorId || null) : null
-    const outcome = await w4Boundary.executeScheduledRun({
+    if (recoveryRunId !== null && typeof w4Boundary.recoverScheduledRun !== 'function') {
+      throw new Error('W4C2_SCHEDULED_RUN_RECOVERY_BOUNDARY_UNAVAILABLE')
+    }
+    const boundaryInput = {
       orgId,
       workDate,
       timezone: rule.timezone,
@@ -21731,16 +21740,24 @@ async function runAutoAbsenceForOrgDate(db, options) {
       // `review` targets too, never a re-derivation.
       reviewTargets: reviewRequired.map((entry) => ({ userId: entry.userId, reasonCode: entry.reasonCode })),
       initiator,
-      adminActorId,
-    })
+      legacyDedupHit,
+    }
+    const outcome = recoveryRunId === null
+      ? await w4Boundary.executeScheduledRun({ ...boundaryInput, adminActorId })
+      : await w4Boundary.recoverScheduledRun({ ...boundaryInput, runId: recoveryRunId })
     if (outcome.kind === 'suspended') {
       suspendedByRollout = true
       rows = []
+    } else if (outcome.kind === 'legacy_dedup') {
+      return { skipped: true, reason: 'dedup', total: 0 }
     } else {
       rows = outcome.rows
       w4EventsHandledByDispatcher = outcome.kind === 'w4'
     }
   } else {
+    if (recoveryRunId !== null) {
+      throw new Error('W4C2_SCHEDULED_RUN_RECOVERY_BOUNDARY_UNAVAILABLE')
+    }
     rows = await generateAbsenceRecords(db, orgId, workDate, rule.timezone, targetUsers)
   }
   if (suspendedByRollout) {
@@ -45384,12 +45401,10 @@ module.exports = {
 	      // W4C-2 P1-1 fix (#4612 verdict second gate round; amendment section 1.7's recovery
 	      // sweep, "No stuck absorbing state"). Same env-gated-at-registration posture as the
 	      // outbox drain worker directly above (SAME variable, SAME reasoning: no env => no job
-	      // object exists at all => byte-identical runtime). One sweep tick per cadence — scan
-	      // plus a per-candidate finalize attempt, values-free, never throwing out of the tick
-	      // (`sweepScheduledRuns`'s own per-candidate containment; see
-	      // `w4c2-scheduled-run-ops-worker.ts` for this call's disclosed scope — it closes the
-	      // "terminal but never finalized" absorbing state, not a target-set-drift wedge, whose
-	      // exit is the admin abandon route below).
+	      // object exists at all => byte-identical runtime). All-terminal candidates finalize;
+	      // nonterminal candidates rebuild the SAME plugin-owned rule/calendar/membership
+	      // context as an ordinary run, then resume the exact scanned run id. One candidate's
+	      // failure is contained by the host worker and cannot skip later candidates.
 	      if (w4ScheduledRunSweepSchedulerUnregister) {
 	        w4ScheduledRunSweepSchedulerUnregister()
 	        w4ScheduledRunSweepSchedulerUnregister = null
@@ -45400,7 +45415,18 @@ module.exports = {
 	        && attendanceW4SegmentCalculationPort
 	        && typeof attendanceW4SegmentCalculationPort.sweepScheduledRuns === 'function'
 	      ) {
-	        w4ScheduledRunSweepRunOnce = () => attendanceW4SegmentCalculationPort.sweepScheduledRuns()
+	        w4ScheduledRunSweepRunOnce = () => attendanceW4SegmentCalculationPort.sweepScheduledRuns({
+	          recoverCandidate: (candidate) => runAutoAbsenceForOrgDate(db, {
+	            orgId: candidate.orgId,
+	            workDate: candidate.workDate,
+	            logger,
+	            emit: emitEvent,
+	            skipDedup: true,
+	            w4Boundary: w4LiveScheduledBoundary,
+	            initiator: candidate.initiator,
+	            recoveryRunId: candidate.runId,
+	          }),
+	        })
 	        w4ScheduledRunSweepSchedulerUnregister = context.services?.attendanceScheduler?.registerJob?.({
 	          name: 'attendance-w4-scheduled-run-sweep',
 	          run: w4ScheduledRunSweepRunOnce,


### PR DESCRIPTION
## What

- resume non-terminal scheduled-run targets by the exact durable `run_id`
- finalize all-terminal stranded runs from the registered scheduled-entrypoint sweep
- keep process-local dedup as a legacy-only zero-DML optimization; W4 postures always enter the durable run protocol
- preserve suspended runs as retryable zero-DML work and retain the original initiator on recovery

## Why

The held #4612 head could scan running runs but did not route non-terminal candidates back through the exact-run resume protocol, leaving interrupted runs stranded.

## Verification

- backend full suite: 558 files passed, 7724 tests passed
- W4C-2 E5 real DB: 29/29
- W4C-2 transaction real DB: 30/30
- recovery wiring unit: 3/3
- backend type-check and plugin syntax check
- mutation: W4 dedup short-circuit makes the restart leg fail
- mutation: removing the legacy dedup branch makes the legacy zero-DML leg fail
- independent Grok 4.5 exact-commit review: APPROVE, 0 P1/P2

## Scope boundary

This is a Draft child remediation against the Draft/HOLD #4612 branch. It does not authorize #4612 merge, W4C-3+, staging soak, flag enablement, deployment, production or customer data use, or issue #4556 closure. It also does not resolve the pre-existing deterministic per-target failed-outcome production-path gap; that remains a separate required remediation before #4612 can be considered merge-ready.