### PR TITLE
docs(attendance): propose W4C-3a byte-parity field amendment

### DIFF
--- a/docs/development/attendance-issue-4556-w4c3a-byte-parity-field-amendment-20260730.md
+++ b/docs/development/attendance-issue-4556-w4c3a-byte-parity-field-amendment-20260730.md
@@ -1,0 +1,138 @@
+# Attendance issue #4556 W4C-3a byte-parity field amendment
+
+Status: **PROPOSED — owner RATIFY required**
+
+Date: 2026-07-30
+
+Authority proposed against:
+
+- merged amendment SHA
+  `e6c536fe7a201ca0466b2dc776b15fbdb23aa890`;
+- owner decision `OD-W4C-56=(a)`, durably transcribed in PR #4677 comment
+  `#5125676385`.
+
+This document is a narrow correction to the exact W4C-3a durable legacy plan
+union. It does not authorize W4C-3a merge, W4C-3b, W4C-5 soak, a flag change,
+deployment, production/customer data, or issue closure.
+
+## 1. Why the correction is required
+
+The accepted plan must replay the existing legacy effect byte-compatibly from
+durable values. Three values written by the retained implementation have no
+honest field in the exact union at the authority SHA:
+
+1. A normal batch writes `payload.source ?? null` to
+   `attendance_import_batches.source`
+   (`plugins/plugin-attendance/index.cjs:26096-26128`). The request schema
+   admits exactly five non-null values
+   (`plugins/plugin-attendance/index.cjs:24751-24753`), while the governing
+   batch-plan contract names source without freezing its nullable closed domain
+   (`docs/development/attendance-issue-4556-w4c3a-durable-legacy-plan-amendment-20260729.md:846-865`).
+2. Both retained attendance-record upsert strategies write
+   `row.timezone` to `attendance_records.timezone`
+   (`plugins/plugin-attendance/index.cjs:20187-20236` and
+   `:20249-20344`), while the governing record-write freeze list contains no
+   timezone
+   (`docs/development/attendance-issue-4556-w4c3a-durable-legacy-plan-amendment-20260729.md:940-952`).
+3. The retained group path keeps a normalized lookup key separately from the
+   original trimmed display name, then writes the display name to
+   `attendance_groups.name`
+   (`plugins/plugin-attendance/index.cjs:9085-9145` and `:9219-9236`), while
+   the governing exact `ensure_group` union contains only `normalizedName`
+   (`docs/development/attendance-issue-4556-w4c3a-durable-legacy-plan-amendment-20260729.md:1048-1056`).
+
+Using `compatibilityMetadata`, a snapshot, or another opaque leaf for any of
+these values is forbidden. It would make an opaque leaf select a literal
+business write and would hide a required effect input from the exact union.
+Recomputing any value from mutable state at worker time is also forbidden.
+
+## 2. Proposed decision
+
+### OD-W4C-57 — exact byte-parity fields
+
+- **(a) Recommended:** correct the exact union with only the three fields in
+  section 3, then continue W4C-3a under both RATIFIED amendments.
+- **(b):** retain the current union and narrow W4C-3a to legacy inputs for
+  which batch source is non-null, record timezone is not written, and group
+  display name equals its normalized key.
+
+Option (b) is not recommended. The retained writers always write record
+timezone, and the restriction would remove already shipped input shapes rather
+than preserve byte compatibility.
+
+## 3. Exact union correction for option (a)
+
+If `OD-W4C-57=(a)` is RATIFIED:
+
+1. `LegacyImportBatchPlanV1` normal variant changes only:
+
+   ```text
+   source: 'dingtalk' | 'manual' | 'dingtalk_csv' |
+           'dingtalk_api' | 'csv' | null
+   ```
+
+   Null and non-null are distinct digest inputs. Empty string is not a null
+   surrogate, and no other string is accepted.
+
+2. `LegacyImportRecordWritePlanV1` adds exactly:
+
+   ```text
+   timezone: string
+   ```
+
+   The value is the exact resolved timezone frozen while preparing the
+   retained legacy row. The apply adapter writes this frozen value and never
+   reloads a current default.
+
+3. `LegacyImportGroupEffectPlanV1` `ensure_group` adds exactly:
+
+   ```text
+   displayName: string
+   ```
+
+   `normalizedName` remains the canonical lookup, sort, uniqueness, reference,
+   and lock key. `displayName` is the exact non-empty trimmed value written to
+   `attendance_groups.name`. The parser requires
+   `displayName.trim() === displayName`,
+   `displayName.toLowerCase() === normalizedName`, and rejects `/^\d+$/`
+   exactly as the retained collector does. It does not replace
+   `displayName` with `normalizedName`.
+
+All three fields remain covered by the existing chunk digest and logical plan
+digest. No root manifest field, physical table column, route, response, lock
+class, authorization rule, or operational branch is added.
+
+## 4. Required proof
+
+The W4C-3a implementation gate must include:
+
+1. normal batch `source=null` and all five non-null source positive controls,
+   plus independent mutations that coerce null to empty string and substitute
+   one legal non-null source for another;
+2. record timezone positive controls for both `values` and `unnest` strategies,
+   plus a mutation that reloads a changed current/default timezone after
+   enqueue and independent mutations that replace the frozen valid timezone at
+   each writer;
+3. a mixed-case group display name whose normalized key differs, proving
+   prepare freezes both values and apply writes the display name; replacing
+   `displayName` with `normalizedName` must fail, and a numeric-only name must
+   create no group;
+4. restart parity for each value from persisted manifest/chunk data only;
+5. exact-key negatives for omission, extra keys, null under the wrong field,
+   and opaque-leaf substitution.
+
+Each mutation has its own positive control. Where a neighboring guard could
+reject first, that guard is neutralized in a separate mutation run so the
+field-specific leg must fail independently.
+
+## 5. Ratification and execution boundary
+
+An owner RATIFY must name the merged SHA of this PROPOSED amendment and
+`OD-W4C-57=(a|b)`. Only then may implementation depend on the selected
+correction. Existing W4C-3a foundation work that does not consume these three
+values may continue under `OD-W4C-56=(a)`, but prepare/apply cutover must not be
+declared complete before this decision is durable.
+
+Even after RATIFY, W4C-3a still stops at its separately reviewed Draft PR and
+owner merge decision. No later slice or runtime activation follows
+automatically.

--- a/docs/development/attendance-issue-4556-w4c3a-durable-legacy-plan-amendment-20260729.md
+++ b/docs/development/attendance-issue-4556-w4c3a-durable-legacy-plan-amendment-20260729.md
@@ -1,20 +1,23 @@
 # Attendance Issue #4556 W4C-3a Durable Legacy Execution Plan Amendment
 
-> Status: **PROPOSED**
+> Status: **RATIFIED**
 >
 > Date: 2026-07-29
 >
-> Decision required: `OD-W4C-56`
+> Ratified: 2026-07-30, merged SHA
+> `e6c536fe7a201ca0466b2dc776b15fbdb23aa890`, `OD-W4C-56=(a)`;
+> owner-decision transcription: PR #4677 comment `#5125676385`.
 >
 > Governing base: W4 design lock and the RATIFIED W4C-3a legacy-preimage
 > amendment at exact merged SHA
 > `1055e543a3680be9f37462de23483bf61ad4610c`. The owner decision is durably
 > transcribed in PR #4672 comment `#5113759839`.
 >
-> This document does not authorize W4C-3a implementation, merge, W4C-3b or
-> later slices, flag changes, deployment, staging soak, production use, or
-> closure of issue #4556. A future implementation remains separately gated and
-> requires an exact-head independent review with zero P1/P2 findings.
+> The owner decision authorizes W4C-3a implementation under this document. It
+> does not authorize W4C-3a merge, W4C-3b or later slices, flag changes,
+> deployment, staging soak, production use, or closure of issue #4556. The
+> implementation remains separately gated and requires an exact-head
+> independent review with zero P1/P2 findings.
 
 ## 0. Why another amendment is required
 
@@ -46,8 +49,10 @@ This is a contract-shape conflict, not an unimplemented helper:
   the existing import execution;
 - keeping a process-local closure would fail P08 restart recovery.
 
-W4C-3a runtime therefore remains paused. The implementation worktree is frozen
-inventory and is not evidence that this amendment has been accepted.
+At drafting time W4C-3a runtime therefore remained paused, and the frozen
+implementation worktree was not evidence that this amendment had been
+accepted. The 2026-07-30 owner RATIFY lifts that implementation pause only; it
+does not lift the merge or later-slice gates in the header.
 
 Terminology in this amendment keeps the governing slice ownership: `P07 worker`
 means `processAsyncImportCommitJob`, and `P08` means startup recovery that
@@ -1868,8 +1873,7 @@ satisfy this amendment.
 
 ## 8. Relationship to the frozen implementation inventory
 
-The unmerged W4C-3a worktree may be reused only after this amendment is
-RATIFIED. Reuse is selective:
+Following RATIFY, the unmerged W4C-3a worktree may be reused only selectively:
 
 - core authorization, identity, lock-order, rollback, and 5000-boundary work
   must be re-reviewed against the new exact head;
@@ -1881,16 +1885,19 @@ RATIFIED. Reuse is selective:
 
 ## 9. Ratification and implementation sequence
 
-1. merge this document as `PROPOSED`;
-2. independently verify the merged document against the exact main tree;
-3. owner RATIFY the exact merged SHA and choose `OD-W4C-56=(a|b)`;
-4. only if `(a)` is RATIFIED, restore a fresh W4C-3a implementation branch from
-   then-current main and selectively port valid frozen inventory;
-5. implement schema/parser/enqueue first, then worker replay, then caller
-   cutover and parity tests;
-6. open a Draft implementation PR;
-7. run exact-head independent review and repair until zero P1/P2;
-8. stop at the owner merge decision.
+1. **Completed:** merge this document as `PROPOSED` at
+   `e6c536fe7a201ca0466b2dc776b15fbdb23aa890`;
+2. **Completed:** independently verify the merged document against that exact
+   main tree;
+3. **Completed:** owner RATIFY that merged SHA with `OD-W4C-56=(a)` on
+   2026-07-30;
+4. **In progress:** use a fresh implementation branch from that main tree and
+   selectively port valid frozen inventory;
+5. **In progress:** implement schema/parser/enqueue first, then worker replay,
+   then caller cutover and parity tests;
+6. **Pending:** open a Draft implementation PR;
+7. **Pending:** run exact-head independent review and repair until zero P1/P2;
+8. **Pending:** stop at the owner merge decision.
 
 None of these steps authorizes W4C-3b, W4C-5 soak, flag changes, deployment,
 production/customer data, or issue closure.


### PR DESCRIPTION
## Why

The RATIFIED W4C-3a durable-plan contract cannot byte-faithfully replay three retained legacy values: nullable closed-domain batch source, per-record timezone, and the original group display name distinct from its normalized key.

This PR also transcribes the already-issued owner decision `OD-W4C-56=(a)` against merged SHA `e6c536fe7a201ca0466b2dc776b15fbdb23aa890` into the governing document header; it does not expand that authorization.

## Proposed decision

- `OD-W4C-57=(a)` (recommended): add only the three exact fields and their discriminating proof matrix.
- `OD-W4C-57=(b)`: narrow accepted legacy inputs, which would remove already-shipped shapes.

## Evidence

- Independently reviewed twice; first review findings were absorbed.
- Final docs review before the ratification-header transcription: 0 P1 / 0 P2 / 0 P3.
- Docs-only; no runtime, migration, route, flag, deployment, production/customer data, or issue-close action.

## Boundary

This PR remains PROPOSED and unarmed. Merge and owner RATIFY of the merged SHA for `OD-W4C-57` are separate steps. It does not authorize W4C-3a merge, W4C-3b, W4C-5 soak, flag changes, or deployment.