### PR TITLE
feat(approval): add semantic canvas drag controls

### DIFF
--- a/.github/workflows/approval-web-guard.yml
+++ b/.github/workflows/approval-web-guard.yml
@@ -101,6 +101,7 @@ on:
       - 'apps/web/tests/approval-template-authoring-complex-node-config-allowlist.test.ts'
       - 'apps/web/tests/approval-graph-topology-edit.test.ts'
       - 'apps/web/tests/approval-canvas-commands.test.ts'
+      - 'apps/web/tests/approval-canvas-c4-command-wiring.test.ts'
       - 'apps/web/tests/approval-form-commands.test.ts'
       - 'apps/web/tests/approval-graph-layout.test.ts'
       - 'apps/web/src/approvals/canvasViewport.ts'
@@ -281,6 +282,7 @@ on:
       - 'apps/web/tests/approval-template-authoring-complex-node-config-allowlist.test.ts'
       - 'apps/web/tests/approval-graph-topology-edit.test.ts'
       - 'apps/web/tests/approval-canvas-commands.test.ts'
+      - 'apps/web/tests/approval-canvas-c4-command-wiring.test.ts'
       - 'apps/web/tests/approval-form-commands.test.ts'
       - 'apps/web/tests/approval-graph-layout.test.ts'
       - 'apps/web/src/approvals/canvasViewport.ts'
@@ -431,7 +433,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Run Canvas V2 command canaries
-        run: pnpm --filter @metasheet/web exec vitest run approval-canvas-commands approval-form-commands --reporter=dot
+        run: pnpm --filter @metasheet/web exec vitest run approval-canvas-commands approval-canvas-c4-command-wiring approval-form-commands --reporter=dot
 
       - name: Run FWB mapping authoring contract
         run: pnpm --filter @metasheet/web exec vitest run approval-fwb-mapping-config approval-fwb-mapping-editor --reporter=dot

--- a/apps/web/scripts/run-required-web-tests.sh
+++ b/apps/web/scripts/run-required-web-tests.sh
@@ -133,7 +133,7 @@
 # any existing token).
 set -euo pipefail
 cd "$(dirname "$0")/.."
-npx vitest run approval-canvas-commands approval-form-commands --reporter=dot
+npx vitest run approval-canvas-commands approval-canvas-c4-command-wiring approval-form-commands --reporter=dot
 npx vitest run featureFlagsApprovalAttachments --reporter=dot
 npx vitest run approval-fwb-mapping-config approval-fwb-mapping-editor --reporter=dot
 npx vitest run fwb-rule-authoring-helpers fwb-rule-authoring --reporter=dot

--- a/apps/web/src/approvals/components/ApprovalFlowCanvas.vue
+++ b/apps/web/src/approvals/components/ApprovalFlowCanvas.vue
@@ -101,14 +101,16 @@
               </div>
               <button
                 v-for="line in canvasMoveTargetLines"
+                v-show="!readOnly"
                 :key="`move-target-${line.key}`"
                 type="button"
-                class="template-authoring__canvas-move-target"
+                class="template-authoring__canvas-move-target is-drag-active"
                 :style="{ left: `${line.dropX}px`, top: `${line.dropY}px` }"
                 :aria-label="canvasMoveTargetLabel(line.key)"
+                data-drag-active="true"
                 :data-testid="`approval-canvas-move-target-${line.key}`"
                 @click.stop="emit('move-target-click', line.key)"
-                @dragover.prevent
+                @dragover.stop.prevent
                 @drop="onMoveTargetDrop($event, line.key)"
               >
                 <el-icon><Rank /></el-icon>
@@ -244,9 +246,69 @@
         >关闭</el-button>
       </div>
       <div class="template-authoring__canvas-inspector-body">
+        <section
+          v-if="!readOnly && selectedCanvasBranchGroup"
+          class="template-authoring__canvas-branch-reorder"
+          :aria-label="selectedCanvasBranchGroup.title"
+          data-testid="approval-canvas-branch-reorder"
+        >
+          <strong>{{ selectedCanvasBranchGroup.title }}</strong>
+          <div
+            v-for="(branch, branchIndex) in selectedCanvasBranchGroup.branches"
+            :key="branch.edgeKey"
+            class="template-authoring__canvas-branch-row"
+            :class="{ 'is-dragging': draggingCanvasBranchEdgeKey === branch.edgeKey }"
+            :data-testid="`approval-canvas-branch-row-${branch.edgeKey}`"
+            @dragover.stop.prevent
+            @drop="onBranchTargetDrop($event, branch.edgeKey)"
+          >
+            <button
+              type="button"
+              class="template-authoring__canvas-branch-handle"
+              :draggable="selectedCanvasBranchGroup.branches.length > 1"
+              :title="`拖动${branch.label}`"
+              :aria-label="`拖动${branch.label}`"
+              :data-testid="`approval-canvas-branch-handle-${branch.edgeKey}`"
+              @dragstart.stop="emit('branch-drag-start', $event, selectedCanvasBranchGroup.kind, selectedCanvasBranchGroup.nodeKey, branch.edgeKey)"
+              @dragend.stop="emit('branch-drag-end')"
+              @keydown.alt.up.stop.prevent="emit('move-branch-step', selectedCanvasBranchGroup.kind, selectedCanvasBranchGroup.nodeKey, branch.edgeKey, 'up')"
+              @keydown.alt.down.stop.prevent="emit('move-branch-step', selectedCanvasBranchGroup.kind, selectedCanvasBranchGroup.nodeKey, branch.edgeKey, 'down')"
+            >
+              <el-icon><Rank /></el-icon>
+            </button>
+            <span class="template-authoring__canvas-branch-label">{{ branch.label }}</span>
+            <div class="template-authoring__canvas-branch-actions">
+              <el-button
+                :icon="Top"
+                size="small"
+                title="提高优先级"
+                :aria-label="`提高${branch.label}优先级`"
+                :disabled="branchIndex === 0"
+                :data-testid="`approval-canvas-branch-up-${branch.edgeKey}`"
+                @click="emit('move-branch-step', selectedCanvasBranchGroup.kind, selectedCanvasBranchGroup.nodeKey, branch.edgeKey, 'up')"
+              />
+              <el-button
+                :icon="Bottom"
+                size="small"
+                title="降低优先级"
+                :aria-label="`降低${branch.label}优先级`"
+                :disabled="branchIndex === selectedCanvasBranchGroup.branches.length - 1"
+                :data-testid="`approval-canvas-branch-down-${branch.edgeKey}`"
+                @click="emit('move-branch-step', selectedCanvasBranchGroup.kind, selectedCanvasBranchGroup.nodeKey, branch.edgeKey, 'down')"
+              />
+            </div>
+          </div>
+        </section>
         <ApprovalGraphNodeConfigEditor :node="selectedCanvasInspectorNode" />
       </div>
     </aside>
+    <p
+      class="template-authoring__sr-only"
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
+      data-testid="approval-canvas-live-message"
+    >{{ canvasLiveMessage }}</p>
   </div>
 </template>
 
@@ -283,6 +345,15 @@ interface CanvasInsertionTarget {
   nodeTypes: EdgeInsertableNodeType[]
 }
 
+type CanvasBranchKind = 'condition' | 'parallel'
+
+interface CanvasBranchReorderGroup {
+  kind: CanvasBranchKind
+  nodeKey: string
+  title: string
+  branches: Array<{ edgeKey: string; label: string }>
+}
+
 const props = defineProps<{
   readOnly: boolean
   canvasValidity: string[]
@@ -293,6 +364,9 @@ const props = defineProps<{
   canvasEdgeLines: CanvasEdgeLine[]
   canvasInsertionTargets: CanvasInsertionTarget[]
   canvasMoveTargetLines: CanvasEdgeLine[]
+  selectedCanvasBranchGroup: CanvasBranchReorderGroup | null
+  draggingCanvasBranchEdgeKey: string | null
+  canvasLiveMessage: string
   canvasMinimap: MinimapFrame
   selectedCanvasNode: string | null
   movingCanvasNode: string | null
@@ -322,8 +396,13 @@ const emit = defineEmits<{
   (e: 'node-drag-start', event: DragEvent, nodeKey: string): void
   (e: 'node-drag-end'): void
   (e: 'move-target-click', edgeKey: string): void
+  (e: 'move-target-drop', event: DragEvent, edgeKey: string): void
   (e: 'move-step', nodeKey: string, direction: 'up' | 'down'): void
   (e: 'begin-move', nodeKey: string): void
+  (e: 'branch-drag-start', event: DragEvent, kind: CanvasBranchKind, nodeKey: string, edgeKey: string): void
+  (e: 'branch-drag-end'): void
+  (e: 'branch-target-drop', event: DragEvent, kind: CanvasBranchKind, nodeKey: string, edgeKey: string): void
+  (e: 'move-branch-step', kind: CanvasBranchKind, nodeKey: string, edgeKey: string, direction: 'up' | 'down'): void
   (e: 'add-condition-branch', nodeKey: string): void
   (e: 'add-parallel-branch', nodeKey: string): void
   (e: 'insert-node-into-edge', edgeKey: string, nodeType: EdgeInsertableNodeType): void
@@ -366,7 +445,15 @@ function chooseInsertion(edgeKey: string, nodeType: EdgeInsertableNodeType): voi
 function onMoveTargetDrop(event: DragEvent, edgeKey: string): void {
   event.preventDefault()
   event.stopPropagation()
-  emit('move-target-click', edgeKey)
+  emit('move-target-drop', event, edgeKey)
+}
+
+function onBranchTargetDrop(event: DragEvent, edgeKey: string): void {
+  event.preventDefault()
+  event.stopPropagation()
+  const group = props.selectedCanvasBranchGroup
+  if (!group) return
+  emit('branch-target-drop', event, group.kind, group.nodeKey, edgeKey)
 }
 
 // Exposed for the parent to read/measure (fit-to-viewport, scroll sync, mobile inspector scroll)
@@ -550,7 +637,8 @@ defineExpose({ canvasViewportRef, canvasInspectorRef })
   font-size: 12px;
 }
 .template-authoring__canvas-move-target:hover,
-.template-authoring__canvas-move-target:focus-visible {
+.template-authoring__canvas-move-target:focus-visible,
+.template-authoring__canvas-move-target.is-drag-active {
   border-style: solid;
   background: var(--el-color-primary-light-9);
   outline: none;
@@ -622,6 +710,64 @@ defineExpose({ canvasViewportRef, canvasInspectorRef })
   min-height: 0;
   overflow: auto;
   padding: 10px 12px 14px;
+}
+.template-authoring__canvas-branch-reorder {
+  display: grid;
+  gap: 8px;
+  margin-bottom: 12px;
+  padding-bottom: 12px;
+  border-bottom: 1px solid var(--el-border-color-light);
+}
+.template-authoring__canvas-branch-row {
+  display: grid;
+  grid-template-columns: 32px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 8px;
+  min-height: 40px;
+  padding: 4px;
+  border: 1px solid var(--el-border-color-light);
+  border-radius: 6px;
+  background: var(--el-bg-color);
+}
+.template-authoring__canvas-branch-row.is-dragging {
+  border-color: var(--el-color-primary);
+  border-style: dashed;
+}
+.template-authoring__canvas-branch-handle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  border: 0;
+  border-radius: 4px;
+  color: var(--el-text-color-secondary);
+  background: transparent;
+  cursor: grab;
+}
+.template-authoring__canvas-branch-handle:focus-visible {
+  outline: 2px solid var(--el-color-primary-light-5);
+  outline-offset: 1px;
+}
+.template-authoring__canvas-branch-label {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+.template-authoring__canvas-branch-actions {
+  display: flex;
+  gap: 4px;
+}
+.template-authoring__sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 @media (max-width: 960px) {
   .template-authoring__canvas-workspace {

--- a/apps/web/src/views/approval/TemplateAuthoringView.vue
+++ b/apps/web/src/views/approval/TemplateAuthoringView.vue
@@ -584,6 +584,9 @@
           :canvas-edge-lines="canvasEdgeLines"
           :canvas-insertion-targets="canvasInsertionTargets"
           :canvas-move-target-lines="canvasMoveTargetLines"
+          :selected-canvas-branch-group="selectedCanvasBranchGroup"
+          :dragging-canvas-branch-edge-key="canvasBranchDragSession?.edgeKey ?? null"
+          :canvas-live-message="canvasLiveMessage"
           :canvas-minimap="canvasMinimap"
           :selected-canvas-node="selectedCanvasNode"
           :moving-canvas-node="movingCanvasNode"
@@ -608,10 +611,15 @@
           @close-inspector="clearCanvasSelection"
           @node-keydown="onCanvasNodeKeydown"
           @node-drag-start="onCanvasNodeDragStart"
-          @node-drag-end="cancelCanvasNodeMove"
+          @node-drag-end="finishCanvasNodeDrag"
           @move-target-click="applyCanvasNodeMove"
+          @move-target-drop="onCanvasNodeDrop"
           @move-step="moveCanvasNodeStep"
           @begin-move="beginCanvasNodeMove"
+          @branch-drag-start="onCanvasBranchDragStart"
+          @branch-drag-end="finishCanvasBranchDrag"
+          @branch-target-drop="onCanvasBranchDrop"
+          @move-branch-step="moveCanvasBranchStep"
           @add-condition-branch="onAddConditionBranch"
           @add-parallel-branch="onAddParallelBranch"
           @insert-node-into-edge="onInsertNodeIntoEdge"
@@ -1281,10 +1289,14 @@ import {
   insertNodeIntoEdge,
   insertParallelGateway,
   linearNodeMoveTargets,
-  moveLinearNode,
   removeLinearNode,
   type EdgeInsertableNodeType,
 } from '../../approvals/graphTopologyEdit'
+import {
+  executeApprovalCanvasCommand,
+  type ApprovalCanvasCommand,
+  type ApprovalCanvasSelection,
+} from '../../approvals/approvalCanvasCommands'
 import {
   computeLayout,
   graphValidityIssues,
@@ -1974,6 +1986,39 @@ function runTopologyOp(op: (graph: ApprovalGraph) => ApprovalGraph): boolean {
     return false
   }
 }
+
+const CANVAS_COMMAND_REJECTED = Symbol('canvas-command-rejected')
+
+/**
+ * C4 page seam for every semantic node move and branch reorder. C5 can replace the body with the
+ * shared history apply without changing renderer intents or leaving a second graph-write path.
+ */
+function applyCanvasCommand(
+  command: ApprovalCanvasCommand,
+  selectionBefore: ApprovalCanvasSelection,
+  guard: (graph: ApprovalGraph) => boolean = () => true,
+): boolean {
+  if (readOnly.value) return false
+  try {
+    let applied = false
+    const nextDraft = applyTopologyToDraft(draft.value, (graph) => {
+      if (!guard(graph)) throw CANVAS_COMMAND_REJECTED
+      const result = executeApprovalCanvasCommand(graph, command, selectionBefore)
+      if (!result.ok) throw CANVAS_COMMAND_REJECTED
+      applied = true
+      return result.graph
+    })
+    if (!applied) return false
+    draft.value = nextDraft
+    return true
+  } catch (error) {
+    if (error !== CANVAS_COMMAND_REJECTED) {
+      loadError.value = '该拓扑操作不适用于当前流程结构'
+    }
+    return false
+  }
+}
+
 function onAddConditionBranch(nodeKey: string): void {
   runTopologyOp((graph) => addConditionBranch(graph, nodeKey))
 }
@@ -2077,9 +2122,35 @@ const canvasAvailable = computed(() => (
 const linearCanvasActive = computed(() => (
   canvasAvailable.value && !graphReadOnly.value && canvasViewMode.value === 'canvas'
 ))
+type CanvasBranchKind = 'condition' | 'parallel'
+interface CanvasBranchReorderGroup {
+  kind: CanvasBranchKind
+  nodeKey: string
+  title: string
+  branches: Array<{ edgeKey: string; label: string }>
+}
+interface CanvasNodeDragSession {
+  token: number
+  nodeKey: string
+}
+interface CanvasBranchDragSession {
+  token: number
+  kind: CanvasBranchKind
+  nodeKey: string
+  edgeKey: string
+}
+
+const CANVAS_NODE_DRAG_TYPE = 'application/x-metasheet-approval-canvas-node'
+const CANVAS_BRANCH_DRAG_TYPE = 'application/x-metasheet-approval-canvas-branch'
+const INVALID_NODE_DROP_MESSAGE = '该位置不能放置此节点'
+const INVALID_BRANCH_DROP_MESSAGE = '该分支位置已失效，请重试'
 const selectedCanvasNode = ref<string | null>(null)
 const flowCanvasRef = ref<InstanceType<typeof ApprovalFlowCanvas> | null>(null)
 const movingCanvasNode = ref<string | null>(null)
+const canvasNodeDragSession = ref<CanvasNodeDragSession | null>(null)
+const canvasBranchDragSession = ref<CanvasBranchDragSession | null>(null)
+const canvasDragSequence = ref(0)
+const canvasLiveMessage = ref('')
 const canvasZoom = ref(1)
 const canvasViewportState = ref({ width: 0, height: 0, scrollLeft: 0, scrollTop: 0 })
 const CANVAS_NODE_W = GRAPH_LAYOUT_NODE_WIDTH
@@ -2164,11 +2235,54 @@ const selectedCanvasInspectorNode = computed<ApprovalNode | null>(() => {
   if (!key) return null
   return canvasNodeByKey(key) ?? null
 })
+
+function canvasBranchOrder(
+  graph: ApprovalGraph,
+  kind: CanvasBranchKind,
+  nodeKey: string,
+): string[] | undefined {
+  const node = graph.nodes.find((candidate) => candidate.key === nodeKey)
+  if (!node || node.type !== kind) return undefined
+  if (kind === 'condition') {
+    const branches = (node.config as ConditionNodeConfig).branches
+    return Array.isArray(branches) && branches.every((branch) => typeof branch.edgeKey === 'string')
+      ? branches.map((branch) => branch.edgeKey)
+      : undefined
+  }
+  const branches = (node.config as ParallelNodeConfig).branches
+  return Array.isArray(branches) && branches.every((edgeKey) => typeof edgeKey === 'string')
+    ? [...branches]
+    : undefined
+}
+
+const selectedCanvasBranchGroup = computed<CanvasBranchReorderGroup | null>(() => {
+  if (readOnly.value) return null
+  const node = selectedCanvasInspectorNode.value
+  if (!node || (node.type !== 'condition' && node.type !== 'parallel')) return null
+  const order = canvasBranchOrder(canvasEffectiveGraph.value, node.type, node.key)
+  if (!order?.length) return null
+  return {
+    kind: node.type,
+    nodeKey: node.key,
+    title: node.type === 'condition' ? '条件分支优先级' : '并行分支顺序',
+    branches: order.map((edgeKey, index) => ({
+      edgeKey,
+      label: node.type === 'condition'
+        ? `优先级 ${index + 1} · ${conditionEdgeLabel(node.key, edgeKey)}`
+        : `分支 ${index + 1} · ${graphEdgeTargetLabel(node.key, edgeKey)}`,
+    })),
+  }
+})
+
 watch(canvasEffectiveGraph, (graph) => {
   const key = selectedCanvasNode.value
   if (key && !graph.nodes.some((node) => node.key === key)) clearCanvasSelection()
   const movingKey = movingCanvasNode.value
-  if (movingKey && linearNodeMoveTargets(graph, movingKey).length === 0) cancelCanvasNodeMove()
+  if (
+    movingKey
+    && !canvasNodeDragSession.value
+    && linearNodeMoveTargets(graph, movingKey).length === 0
+  ) cancelCanvasNodeMove()
 })
 watch([canvasViewMode, canvasLayout, activeAuthoringSection], async ([mode, _layout, section]) => {
   if (mode !== 'canvas' || section !== 'flow') return
@@ -2252,7 +2366,7 @@ const canvasInsertionTargets = computed(() => {
       : []
   })
 })
-const canvasMoveTargets = computed(() => movingCanvasNode.value
+const canvasMoveTargets = computed(() => !readOnly.value && movingCanvasNode.value
   ? new Set(linearNodeMoveTargets(canvasEffectiveGraph.value, movingCanvasNode.value).map((target) => target.edgeKey))
   : new Set<string>())
 const canvasMoveTargetLines = computed(() => canvasEdgeLines.value.filter((line) => canvasMoveTargets.value.has(line.key)))
@@ -2267,19 +2381,69 @@ function canvasMoveTargetLabel(edgeKey: string): string {
   const movingLabel = movingCanvasNode.value ? graphNodeLabel(movingCanvasNode.value) : '节点'
   return edge ? `将${movingLabel}移动到${graphNodeLabel(edge.source)}之后` : `移动${movingLabel}`
 }
+function currentCanvasSelection(): ApprovalCanvasSelection {
+  return selectedCanvasNode.value
+    ? { kind: 'node', nodeKey: selectedCanvasNode.value }
+    : { kind: 'none' }
+}
+function announceCanvas(message: string): void {
+  canvasLiveMessage.value = ''
+  void nextTick(() => {
+    canvasLiveMessage.value = message
+  })
+}
+function serializeCanvasDragSession(session: CanvasNodeDragSession | CanvasBranchDragSession): string {
+  return JSON.stringify(session)
+}
 function beginCanvasNodeMove(nodeKey: string): void {
   if (readOnly.value || !canMoveCanvasNode(nodeKey)) return
-  movingCanvasNode.value = movingCanvasNode.value === nodeKey ? null : nodeKey
+  if (movingCanvasNode.value === nodeKey) {
+    cancelCanvasNodeMove()
+    return
+  }
+  canvasNodeDragSession.value = null
+  movingCanvasNode.value = nodeKey
 }
 function cancelCanvasNodeMove(): void {
+  canvasNodeDragSession.value = null
   movingCanvasNode.value = null
+}
+function rejectCanvasNodeDrop(): void {
+  cancelCanvasNodeMove()
+  announceCanvas(INVALID_NODE_DROP_MESSAGE)
+}
+function finishCanvasNodeDrag(): void {
+  if (!canvasNodeDragSession.value) return
+  rejectCanvasNodeDrop()
 }
 function applyCanvasNodeMove(targetEdgeKey: string): void {
   const nodeKey = movingCanvasNode.value
-  if (!nodeKey || !canvasMoveTargets.value.has(targetEdgeKey)) return
-  runTopologyOp((graph) => moveLinearNode(graph, nodeKey, targetEdgeKey))
+  if (!nodeKey) return
+  if (!canvasMoveTargets.value.has(targetEdgeKey)) {
+    rejectCanvasNodeDrop()
+    return
+  }
+  const applied = applyCanvasCommand(
+    { type: 'move-node-into-edge', nodeKey, intoEdgeKey: targetEdgeKey },
+    currentCanvasSelection(),
+    (graph) => linearNodeMoveTargets(graph, nodeKey)
+      .some((target) => target.edgeKey === targetEdgeKey),
+  )
+  if (!applied) {
+    rejectCanvasNodeDrop()
+    return
+  }
   selectedCanvasNode.value = nodeKey
   cancelCanvasNodeMove()
+}
+function onCanvasNodeDrop(event: DragEvent, targetEdgeKey: string): void {
+  const session = canvasNodeDragSession.value
+  const payload = event.dataTransfer?.getData(CANVAS_NODE_DRAG_TYPE) ?? ''
+  if (!session || payload !== serializeCanvasDragSession(session)) {
+    rejectCanvasNodeDrop()
+    return
+  }
+  applyCanvasNodeMove(targetEdgeKey)
 }
 function moveCanvasNodeStep(nodeKey: string, direction: 'up' | 'down'): void {
   const target = canvasStepMoveTarget(nodeKey, direction)
@@ -2294,13 +2458,123 @@ function onCanvasNodeKeydown(event: KeyboardEvent, nodeKey: string): void {
   moveCanvasNodeStep(nodeKey, event.key === 'ArrowUp' ? 'up' : 'down')
 }
 function onCanvasNodeDragStart(event: DragEvent, nodeKey: string): void {
-  if (readOnly.value || !canMoveCanvasNode(nodeKey)) {
+  if (readOnly.value || !canMoveCanvasNode(nodeKey) || !event.dataTransfer) {
     event.preventDefault()
     return
   }
+  const session: CanvasNodeDragSession = {
+    token: ++canvasDragSequence.value,
+    nodeKey,
+  }
+  canvasNodeDragSession.value = session
   movingCanvasNode.value = nodeKey
-  event.dataTransfer?.setData('text/plain', nodeKey)
-  if (event.dataTransfer) event.dataTransfer.effectAllowed = 'move'
+  event.dataTransfer.setData(CANVAS_NODE_DRAG_TYPE, serializeCanvasDragSession(session))
+  event.dataTransfer.setData('text/plain', 'approval-canvas-node')
+  event.dataTransfer.effectAllowed = 'move'
+}
+
+function cancelCanvasBranchDrag(): void {
+  canvasBranchDragSession.value = null
+}
+function rejectCanvasBranchDrop(): void {
+  cancelCanvasBranchDrag()
+  announceCanvas(INVALID_BRANCH_DROP_MESSAGE)
+}
+function onCanvasBranchDragStart(
+  event: DragEvent,
+  kind: CanvasBranchKind,
+  nodeKey: string,
+  edgeKey: string,
+): void {
+  const group = selectedCanvasBranchGroup.value
+  if (
+    readOnly.value
+    || !event.dataTransfer
+    || group?.kind !== kind
+    || group.nodeKey !== nodeKey
+    || !group.branches.some((branch) => branch.edgeKey === edgeKey)
+  ) {
+    event.preventDefault()
+    return
+  }
+  const session: CanvasBranchDragSession = {
+    token: ++canvasDragSequence.value,
+    kind,
+    nodeKey,
+    edgeKey,
+  }
+  canvasBranchDragSession.value = session
+  event.dataTransfer.setData(CANVAS_BRANCH_DRAG_TYPE, serializeCanvasDragSession(session))
+  event.dataTransfer.setData('text/plain', 'approval-canvas-branch')
+  event.dataTransfer.effectAllowed = 'move'
+}
+function applyCanvasBranchReorder(
+  kind: CanvasBranchKind,
+  nodeKey: string,
+  edgeKey: string,
+  targetEdgeKey: string,
+): boolean {
+  const order = canvasBranchOrder(canvasEffectiveGraph.value, kind, nodeKey)
+  if (!order) return false
+  const fromIndex = order.indexOf(edgeKey)
+  const targetIndex = order.indexOf(targetEdgeKey)
+  if (fromIndex < 0 || targetIndex < 0) return false
+  if (fromIndex === targetIndex) return true
+  const orderedEdgeKeys = [...order]
+  const [movedEdgeKey] = orderedEdgeKeys.splice(fromIndex, 1)
+  orderedEdgeKeys.splice(targetIndex, 0, movedEdgeKey)
+  const command: ApprovalCanvasCommand = kind === 'condition'
+    ? { type: 'reorder-condition-branches', conditionNodeKey: nodeKey, orderedEdgeKeys }
+    : { type: 'reorder-parallel-branches', parallelNodeKey: nodeKey, orderedEdgeKeys }
+  const selectionBefore: ApprovalCanvasSelection = kind === 'condition'
+    ? { kind: 'condition-branch', conditionNodeKey: nodeKey, edgeKey }
+    : { kind: 'parallel-branch', parallelNodeKey: nodeKey, edgeKey }
+  return applyCanvasCommand(command, selectionBefore, (graph) => {
+    const latestOrder = canvasBranchOrder(graph, kind, nodeKey)
+    return Boolean(
+      latestOrder
+      && latestOrder.length === order.length
+      && latestOrder.every((candidate, index) => candidate === order[index]),
+    )
+  })
+}
+function onCanvasBranchDrop(
+  event: DragEvent,
+  kind: CanvasBranchKind,
+  nodeKey: string,
+  targetEdgeKey: string,
+): void {
+  const session = canvasBranchDragSession.value
+  const payload = event.dataTransfer?.getData(CANVAS_BRANCH_DRAG_TYPE) ?? ''
+  if (
+    !session
+    || session.kind !== kind
+    || session.nodeKey !== nodeKey
+    || payload !== serializeCanvasDragSession(session)
+    || !applyCanvasBranchReorder(kind, nodeKey, session.edgeKey, targetEdgeKey)
+  ) {
+    rejectCanvasBranchDrop()
+    return
+  }
+  cancelCanvasBranchDrag()
+}
+function finishCanvasBranchDrag(): void {
+  if (!canvasBranchDragSession.value) return
+  rejectCanvasBranchDrop()
+}
+function moveCanvasBranchStep(
+  kind: CanvasBranchKind,
+  nodeKey: string,
+  edgeKey: string,
+  direction: 'up' | 'down',
+): void {
+  const order = canvasBranchOrder(canvasEffectiveGraph.value, kind, nodeKey)
+  const index = order?.indexOf(edgeKey) ?? -1
+  const targetIndex = direction === 'up' ? index - 1 : index + 1
+  if (!order || index < 0 || targetIndex < 0 || targetIndex >= order.length) return
+  if (!applyCanvasBranchReorder(kind, nodeKey, edgeKey, order[targetIndex])) {
+    announceCanvas(INVALID_BRANCH_DROP_MESSAGE)
+  }
 }
 function setApprovalSourceIds(nodeKey: string, ids: string[]): void {
   const step = linearStepForNode(nodeKey)

--- a/apps/web/tests/approval-canvas-c4-command-wiring.test.ts
+++ b/apps/web/tests/approval-canvas-c4-command-wiring.test.ts
@@ -1,0 +1,135 @@
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { executeApprovalCanvasCommand } from '../src/approvals/approvalCanvasCommands'
+import type { ApprovalGraph, ConditionNodeConfig, ParallelNodeConfig } from '../src/types/approval'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const AUTHORING_SOURCE = readFileSync(
+  join(HERE, '../src/views/approval/TemplateAuthoringView.vue'),
+  'utf8',
+)
+const RENDERER_SOURCE = readFileSync(
+  join(HERE, '../src/approvals/components/ApprovalFlowCanvas.vue'),
+  'utf8',
+)
+
+function linearGraph(): ApprovalGraph {
+  return {
+    nodes: [
+      { key: 'start', type: 'start', name: 'Start', config: {} },
+      { key: 'a', type: 'approval', name: 'A', config: { assigneeSources: [{ kind: 'requester' }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+      { key: 'b', type: 'cc', name: 'B', config: { targetType: 'role', targetIds: ['finance'] } },
+      { key: 'c', type: 'approval', name: 'C', config: { assigneeSources: [{ kind: 'direct_manager' }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+      { key: 'end', type: 'end', name: 'End', config: {} },
+    ],
+    edges: [
+      { key: 'e-start-a', source: 'start', target: 'a' },
+      { key: 'e-a-b', source: 'a', target: 'b' },
+      { key: 'e-b-c', source: 'b', target: 'c' },
+      { key: 'e-c-end', source: 'c', target: 'end' },
+    ],
+  }
+}
+
+function branchGraph(): ApprovalGraph {
+  return {
+    nodes: [
+      { key: 'start', type: 'start', name: 'Start', config: {} },
+      {
+        key: 'condition',
+        type: 'condition',
+        name: 'Condition',
+        config: {
+          branches: [
+            { edgeKey: 'e-high', rules: [{ fieldId: 'amount', operator: 'gte', value: 1000 }], conjunction: 'and' },
+            { edgeKey: 'e-low', rules: [{ fieldId: 'amount', operator: 'gte', value: 100 }], conjunction: 'and' },
+          ],
+          defaultEdgeKey: 'e-default',
+        },
+      },
+      { key: 'high', type: 'approval', name: 'High', config: { assigneeSources: [{ kind: 'requester' }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+      { key: 'low', type: 'approval', name: 'Low', config: { assigneeSources: [{ kind: 'direct_manager' }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+      { key: 'fallback', type: 'cc', name: 'Fallback', config: { targetType: 'role', targetIds: ['audit'] } },
+      { key: 'merge', type: 'cc', name: 'Merge', config: { targetType: 'role', targetIds: ['finance'] } },
+      { key: 'parallel', type: 'parallel', name: 'Parallel', config: { branches: ['e-left', 'e-right'], joinMode: 'all', joinNodeKey: 'join' } },
+      { key: 'left', type: 'approval', name: 'Left', config: { assigneeSources: [{ kind: 'requester' }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+      { key: 'right', type: 'approval', name: 'Right', config: { assigneeSources: [{ kind: 'direct_manager' }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+      { key: 'join', type: 'approval', name: 'Join', config: { assigneeSources: [{ kind: 'dept_head' }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+      { key: 'end', type: 'end', name: 'End', config: {} },
+    ],
+    edges: [
+      { key: 'e-start-condition', source: 'start', target: 'condition' },
+      { key: 'e-high', source: 'condition', target: 'high' },
+      { key: 'e-low', source: 'condition', target: 'low' },
+      { key: 'e-default', source: 'condition', target: 'fallback' },
+      { key: 'e-high-merge', source: 'high', target: 'merge' },
+      { key: 'e-low-merge', source: 'low', target: 'merge' },
+      { key: 'e-default-merge', source: 'fallback', target: 'merge' },
+      { key: 'e-merge-parallel', source: 'merge', target: 'parallel' },
+      { key: 'e-left', source: 'parallel', target: 'left' },
+      { key: 'e-right', source: 'parallel', target: 'right' },
+      { key: 'e-left-join', source: 'left', target: 'join' },
+      { key: 'e-right-join', source: 'right', target: 'join' },
+      { key: 'e-join-end', source: 'join', target: 'end' },
+    ],
+  }
+}
+
+describe('Canvas V2 C4 typed command wiring', () => {
+  it('keeps one page-level command apply seam for node and both branch command kinds', () => {
+    expect(AUTHORING_SOURCE.match(/executeApprovalCanvasCommand\(/g)).toHaveLength(1)
+    expect(AUTHORING_SOURCE).toContain("type: 'move-node-into-edge'")
+    expect(AUTHORING_SOURCE).toContain("type: 'reorder-condition-branches'")
+    expect(AUTHORING_SOURCE).toContain("type: 'reorder-parallel-branches'")
+    expect(AUTHORING_SOURCE).not.toMatch(/\bmoveLinearNode\s*\(/)
+  })
+
+  it('keeps the renderer intent-only and free of topology config rules', () => {
+    expect(RENDERER_SOURCE).not.toMatch(
+      /executeApprovalCanvasCommand|applyTopologyToDraft|linearNodeMoveTargets|ConditionNodeConfig|ParallelNodeConfig/,
+    )
+    expect(RENDERER_SOURCE).toContain("emit('move-target-drop'")
+    expect(RENDERER_SOURCE).toContain("emit('branch-target-drop'")
+    expect(RENDERER_SOURCE).toContain('aria-live="polite"')
+  })
+
+  it('executes node, condition, and parallel edits through the existing command algebra', () => {
+    const move = executeApprovalCanvasCommand(linearGraph(), {
+      type: 'move-node-into-edge',
+      nodeKey: 'b',
+      intoEdgeKey: 'e-start-a',
+    })
+    expect(move.ok).toBe(true)
+    if (!move.ok) return
+    expect(move.graph.edges).toEqual([
+      { key: 'e-start-a', source: 'start', target: 'b' },
+      { key: 'e-b-c', source: 'b', target: 'a' },
+      { key: 'e-a-b', source: 'a', target: 'c' },
+      { key: 'e-c-end', source: 'c', target: 'end' },
+    ])
+
+    const condition = executeApprovalCanvasCommand(branchGraph(), {
+      type: 'reorder-condition-branches',
+      conditionNodeKey: 'condition',
+      orderedEdgeKeys: ['e-low', 'e-high'],
+    })
+    expect(condition.ok).toBe(true)
+    if (!condition.ok) return
+    const conditionNode = condition.graph.nodes.find((node) => node.key === 'condition')!
+    expect((conditionNode.config as ConditionNodeConfig).branches.map((branch) => branch.edgeKey))
+      .toEqual(['e-low', 'e-high'])
+    expect((conditionNode.config as ConditionNodeConfig).defaultEdgeKey).toBe('e-default')
+
+    const parallel = executeApprovalCanvasCommand(condition.graph, {
+      type: 'reorder-parallel-branches',
+      parallelNodeKey: 'parallel',
+      orderedEdgeKeys: ['e-right', 'e-left'],
+    })
+    expect(parallel.ok).toBe(true)
+    if (!parallel.ok) return
+    expect((parallel.graph.nodes.find((node) => node.key === 'parallel')!.config as ParallelNodeConfig).branches)
+      .toEqual(['e-right', 'e-left'])
+  })
+})

--- a/apps/web/tests/approval-template-authoring-canvas-inspector.spec.ts
+++ b/apps/web/tests/approval-template-authoring-canvas-inspector.spec.ts
@@ -378,6 +378,52 @@ function buildLinearReorderGraph() {
   }
 }
 
+function buildBranchReorderGraph() {
+  return {
+    nodes: [
+      { key: 'start', type: 'start', name: '发起', config: {} },
+      {
+        key: 'cond_1',
+        type: 'condition',
+        name: '金额判断',
+        config: {
+          branches: [
+            { edgeKey: 'e-high', rules: [{ fieldId: 'amount', operator: 'gte', value: 1000 }], conjunction: 'and' },
+            { edgeKey: 'e-medium', rules: [{ fieldId: 'amount', operator: 'gte', value: 500 }], conjunction: 'and' },
+          ],
+          defaultEdgeKey: 'e-default',
+        },
+      },
+      { key: 'high_a', type: 'approval', name: '高额初审', config: { assigneeSources: [{ kind: 'dept_head' }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+      { key: 'high_b', type: 'approval', name: '高额复审', config: { assigneeSources: [{ kind: 'direct_manager' }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+      { key: 'medium', type: 'approval', name: '中额审批', config: { assigneeSources: [{ kind: 'requester' }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+      { key: 'fallback', type: 'cc', name: '默认抄送', config: { targetType: 'role', targetIds: ['finance'] } },
+      { key: 'merge', type: 'cc', name: '条件汇合', config: { targetType: 'role', targetIds: ['audit'] } },
+      { key: 'fork_1', type: 'parallel', name: '并行审批', config: { branches: ['e-fork-a', 'e-fork-b'], joinMode: 'all', joinNodeKey: 'join_1' } },
+      { key: 'app_a', type: 'approval', name: '分支 A', config: { assigneeSources: [{ kind: 'requester' }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+      { key: 'app_b', type: 'approval', name: '分支 B', config: { assigneeSources: [{ kind: 'static_role', roleIds: ['legal'] }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+      { key: 'join_1', type: 'approval', name: '汇聚', config: { assigneeSources: [{ kind: 'direct_manager' }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+      { key: 'end', type: 'end', name: '结束', config: {} },
+    ],
+    edges: [
+      { key: 'e-start-c', source: 'start', target: 'cond_1' },
+      { key: 'e-high', source: 'cond_1', target: 'high_a' },
+      { key: 'e-high-a-b', source: 'high_a', target: 'high_b' },
+      { key: 'e-high-merge', source: 'high_b', target: 'merge' },
+      { key: 'e-medium', source: 'cond_1', target: 'medium' },
+      { key: 'e-medium-merge', source: 'medium', target: 'merge' },
+      { key: 'e-default', source: 'cond_1', target: 'fallback' },
+      { key: 'e-default-merge', source: 'fallback', target: 'merge' },
+      { key: 'e-merge-fork', source: 'merge', target: 'fork_1' },
+      { key: 'e-fork-a', source: 'fork_1', target: 'app_a' },
+      { key: 'e-fork-b', source: 'fork_1', target: 'app_b' },
+      { key: 'e-a-join', source: 'app_a', target: 'join_1' },
+      { key: 'e-b-join', source: 'app_b', target: 'join_1' },
+      { key: 'e-join-end', source: 'join_1', target: 'end' },
+    ],
+  }
+}
+
 let container: HTMLDivElement | null = null
 let app: VueApp<Element> | null = null
 
@@ -403,6 +449,30 @@ function clickCanvasNode(nodeKey: string) {
   const node = container!.querySelector(`[data-testid="approval-canvas-node"][data-canvas-node="${nodeKey}"]`) as HTMLElement | null
   expect(node, `canvas node ${nodeKey}`).not.toBeNull()
   node!.click()
+}
+
+function createDragDataTransfer(): DataTransfer {
+  const data = new Map<string, string>()
+  return {
+    dropEffect: 'none',
+    effectAllowed: 'uninitialized',
+    files: [] as unknown as FileList,
+    items: [] as unknown as DataTransferItemList,
+    types: [],
+    clearData: (format?: string) => {
+      if (format) data.delete(format)
+      else data.clear()
+    },
+    getData: (format: string) => data.get(format) ?? '',
+    setData: (format: string, value: string) => { data.set(format, value) },
+    setDragImage: vi.fn(),
+  }
+}
+
+function createDragEvent(type: 'dragstart' | 'dragend' | 'drop', dataTransfer: DataTransfer): DragEvent {
+  const event = new Event(type, { bubbles: true, cancelable: true }) as DragEvent
+  Object.defineProperty(event, 'dataTransfer', { value: dataTransfer })
+  return event
 }
 
 describe('Canvas V2 Slice A — canvas inspector', () => {
@@ -520,15 +590,12 @@ describe('Canvas V2 Slice A — canvas inspector', () => {
     expect(surface.style.transform).toBe('scale(1.25)')
 
     const node = container!.querySelector('[data-canvas-node="cc_b"]') as HTMLElement
-    const dragStart = new Event('dragstart', { bubbles: true, cancelable: true })
-    Object.defineProperty(dragStart, 'dataTransfer', {
-      value: { setData: vi.fn(), effectAllowed: '' },
-    })
-    node.dispatchEvent(dragStart)
+    const dataTransfer = createDragDataTransfer()
+    node.dispatchEvent(createDragEvent('dragstart', dataTransfer))
     await flushUi()
     const dropTarget = container!.querySelector('[data-testid="approval-canvas-move-target-e-start-a"]') as HTMLButtonElement
     expect(dropTarget).not.toBeNull()
-    dropTarget.dispatchEvent(new Event('drop', { bubbles: true, cancelable: true }))
+    dropTarget.dispatchEvent(createDragEvent('drop', dataTransfer))
     await flushUi()
 
     const movedNode = container!.querySelector('[data-canvas-node="cc_b"]') as HTMLElement
@@ -548,6 +615,145 @@ describe('Canvas V2 Slice A — canvas inspector', () => {
     await flushUi()
     const payload = updateTemplateSpy.mock.calls.at(-1)?.[1] as any
     expect(payload.approvalGraph.edges).toEqual(buildLinearReorderGraph().edges)
+  })
+
+  it('keeps every legal edge slot highlighted and rejects outside or expired node drops without a write', async () => {
+    routeParams = { id: 'tpl_canvas_drag_reject' }
+    const graph = buildLinearReorderGraph()
+    getTemplateSpy.mockResolvedValue(buildTemplate({ approvalGraph: graph as any }))
+    await mountView()
+    await flushUi()
+
+    const node = container!.querySelector('[data-canvas-node="cc_b"]') as HTMLElement
+    const outsideTransfer = createDragDataTransfer()
+    node.dispatchEvent(createDragEvent('dragstart', outsideTransfer))
+    await flushUi()
+
+    const targets = Array.from(container!.querySelectorAll('[data-testid^="approval-canvas-move-target-"]'))
+    expect(targets.map((target) => target.getAttribute('data-testid')).sort()).toEqual([
+      'approval-canvas-move-target-e-c-end',
+      'approval-canvas-move-target-e-start-a',
+    ])
+    expect(targets.every((target) => target.getAttribute('data-drag-active') === 'true')).toBe(true)
+    targets[0].dispatchEvent(new Event('dragover', { bubbles: true, cancelable: true }))
+    await flushUi()
+    expect(container!.querySelectorAll('[data-testid^="approval-canvas-move-target-"]')).toHaveLength(2)
+
+    node.dispatchEvent(createDragEvent('dragend', outsideTransfer))
+    await flushUi()
+    const liveRegion = container!.querySelector('[data-testid="approval-canvas-live-message"]') as HTMLElement
+    expect(liveRegion.textContent).toBe('该位置不能放置此节点')
+    expect(liveRegion.textContent).not.toMatch(/cc_b|e-start-a/)
+
+    const currentNode = container!.querySelector('[data-canvas-node="cc_b"]') as HTMLElement
+    const activeTransfer = createDragDataTransfer()
+    currentNode.dispatchEvent(createDragEvent('dragstart', activeTransfer))
+    await flushUi()
+    const legalTarget = container!.querySelector(
+      '[data-testid="approval-canvas-move-target-e-start-a"]',
+    ) as HTMLElement
+    expect(legalTarget).not.toBeNull()
+    const expiredTransfer = createDragDataTransfer()
+    expiredTransfer.setData('application/x-metasheet-approval-canvas-node', '{"token":0}')
+    legalTarget.dispatchEvent(createDragEvent('drop', expiredTransfer))
+    await flushUi()
+    expect(liveRegion.textContent).toBe('该位置不能放置此节点')
+
+    ;(container!.querySelector('[data-testid="approval-template-save-button"]') as HTMLButtonElement).click()
+    await flushUi()
+    const payload = updateTemplateSpy.mock.calls.at(-1)?.[1] as any
+    expect(payload.approvalGraph.edges).toEqual(graph.edges)
+  })
+
+  it('does not expose a cross-region node drop slot and announces the rejected release', async () => {
+    routeParams = { id: 'tpl_canvas_cross_region' }
+    getTemplateSpy.mockResolvedValue(buildTemplate({ approvalGraph: buildBranchReorderGraph() as any }))
+    await mountView()
+    await flushUi()
+
+    const node = container!.querySelector('[data-canvas-node="high_a"]') as HTMLElement
+    const dataTransfer = createDragDataTransfer()
+    node.dispatchEvent(createDragEvent('dragstart', dataTransfer))
+    await flushUi()
+
+    expect(container!.querySelector('[data-testid="approval-canvas-move-target-e-high-merge"]')).not.toBeNull()
+    expect(container!.querySelector('[data-testid="approval-canvas-move-target-e-medium-merge"]')).toBeNull()
+    expect(container!.querySelector('[data-testid="approval-canvas-move-target-e-default-merge"]')).toBeNull()
+
+    node.dispatchEvent(createDragEvent('dragend', dataTransfer))
+    await flushUi()
+    const message = container!.querySelector('[data-testid="approval-canvas-live-message"]')?.textContent ?? ''
+    expect(message).toBe('该位置不能放置此节点')
+    expect(message).not.toMatch(/high_a|e-medium/)
+  })
+
+  it('reorders condition priority and parallel branches by handle drag with keyboard-equivalent commands', async () => {
+    routeParams = { id: 'tpl_canvas_branch_reorder' }
+    getTemplateSpy.mockResolvedValue(buildTemplate({ approvalGraph: buildBranchReorderGraph() as any }))
+    await mountView()
+    await flushUi()
+
+    clickCanvasNode('cond_1')
+    await flushUi()
+    let panel = container!.querySelector('[data-testid="approval-canvas-branch-reorder"]') as HTMLElement
+    expect(panel.textContent).toContain('条件分支优先级')
+    expect(panel.textContent).toContain('优先级 1')
+    expect(panel.textContent).toContain('优先级 2')
+    expect(panel.textContent).not.toMatch(/e-high|e-medium|e-default/)
+    expect(panel.querySelectorAll('[draggable="true"]')).toHaveLength(2)
+    expect(Array.from(panel.querySelectorAll('[draggable="true"]')).every((element) =>
+      element.matches('[data-testid^="approval-canvas-branch-handle-"]'))).toBe(true)
+
+    let dataTransfer = createDragDataTransfer()
+    ;(panel.querySelector('[data-testid="approval-canvas-branch-handle-e-high"]') as HTMLElement)
+      .dispatchEvent(createDragEvent('dragstart', dataTransfer))
+    ;(panel.querySelector('[data-testid="approval-canvas-branch-row-e-medium"]') as HTMLElement)
+      .dispatchEvent(createDragEvent('drop', dataTransfer))
+    await flushUi()
+    ;(container!.querySelector('[data-testid="approval-template-save-button"]') as HTMLButtonElement).click()
+    await flushUi()
+    let payload = updateTemplateSpy.mock.calls.at(-1)?.[1] as any
+    let condition = payload.approvalGraph.nodes.find((candidate: any) => candidate.key === 'cond_1')
+    expect(condition.config.branches.map((branch: any) => branch.edgeKey)).toEqual(['e-medium', 'e-high'])
+    expect(condition.config.defaultEdgeKey).toBe('e-default')
+
+    panel = container!.querySelector('[data-testid="approval-canvas-branch-reorder"]') as HTMLElement
+    ;(panel.querySelector('[data-testid="approval-canvas-branch-handle-e-high"]') as HTMLElement)
+      .dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp', altKey: true, bubbles: true }))
+    await flushUi()
+    ;(container!.querySelector('[data-testid="approval-template-save-button"]') as HTMLButtonElement).click()
+    await flushUi()
+    payload = updateTemplateSpy.mock.calls.at(-1)?.[1] as any
+    condition = payload.approvalGraph.nodes.find((candidate: any) => candidate.key === 'cond_1')
+    expect(condition.config.branches.map((branch: any) => branch.edgeKey)).toEqual(['e-high', 'e-medium'])
+
+    clickCanvasNode('fork_1')
+    await flushUi()
+    panel = container!.querySelector('[data-testid="approval-canvas-branch-reorder"]') as HTMLElement
+    expect(panel.textContent).toContain('并行分支顺序')
+    dataTransfer = createDragDataTransfer()
+    ;(panel.querySelector('[data-testid="approval-canvas-branch-handle-e-fork-b"]') as HTMLElement)
+      .dispatchEvent(createDragEvent('dragstart', dataTransfer))
+    ;(panel.querySelector('[data-testid="approval-canvas-branch-row-e-fork-a"]') as HTMLElement)
+      .dispatchEvent(createDragEvent('drop', dataTransfer))
+    await flushUi()
+    ;(container!.querySelector('[data-testid="approval-template-save-button"]') as HTMLButtonElement).click()
+    await flushUi()
+    payload = updateTemplateSpy.mock.calls.at(-1)?.[1] as any
+    let parallel = payload.approvalGraph.nodes.find((candidate: any) => candidate.key === 'fork_1')
+    expect(parallel.config.branches).toEqual(['e-fork-b', 'e-fork-a'])
+    expect(parallel.config.joinMode).toBe('all')
+    expect(parallel.config.joinNodeKey).toBe('join_1')
+
+    panel = container!.querySelector('[data-testid="approval-canvas-branch-reorder"]') as HTMLElement
+    ;(panel.querySelector('[data-testid="approval-canvas-branch-handle-e-fork-b"]') as HTMLElement)
+      .dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', altKey: true, bubbles: true }))
+    await flushUi()
+    ;(container!.querySelector('[data-testid="approval-template-save-button"]') as HTMLButtonElement).click()
+    await flushUi()
+    payload = updateTemplateSpy.mock.calls.at(-1)?.[1] as any
+    parallel = payload.approvalGraph.nodes.find((candidate: any) => candidate.key === 'fork_1')
+    expect(parallel.config.branches).toEqual(['e-fork-a', 'e-fork-b'])
   })
 
   it('shows business labels instead of internal topology keys in the inspector', async () => {
@@ -731,6 +937,8 @@ describe('Canvas V2 Slice A — canvas inspector', () => {
     expect(inspector.querySelector('[data-testid="approval-parallel-editor"]')).not.toBeNull()
     const joinMode = inspector.querySelector('[data-testid="approval-parallel-join-mode"]') as HTMLSelectElement
     expect(joinMode.disabled).toBe(true)
+    expect(inspector.querySelector('[data-testid="approval-canvas-branch-reorder"]')).toBeNull()
+    expect(container!.querySelector('[data-testid^="approval-canvas-branch-handle-"]')).toBeNull()
 
     clickCanvasNode('approval_high')
     await flushUi()


### PR DESCRIPTION
## What
- route node drag/drop through the existing typed canvas command algebra
- expose legal edge targets only and reject stale, invalid, or cross-region drops with values-free status
- add condition/parallel branch handle drag plus Alt+Arrow keyboard parity
- wire discriminating command-layer and mounted-view tests into required Web gates

## Verification
- `bash apps/web/scripts/run-required-web-tests.sh` (360 files, 4338 tests)
- focused C4/command/topology/mounted suites (79 tests)
- `pnpm --filter @metasheet/web exec vue-tsc --noEmit`
- `pnpm --filter @metasheet/web build`

## Hold
Draft and stacked on #4697. Real-browser drag screenshots remain a required gate: the Codex in-app Browser could not attach a new local tab during this run, while the Vite server itself returned HTTP 200. No merge, deployment, or flag enablement is authorized.