### PR TITLE
feat(approval): protect form structure commands

### DIFF
--- a/apps/web/src/approvals/api.ts
+++ b/apps/web/src/approvals/api.ts
@@ -9,6 +9,7 @@ import { apiFetch, apiGet, apiPost } from '../utils/api'
 import type {
   ApprovalTemplateListItemDTO,
   ApprovalTemplateDetailDTO,
+  ApprovalTemplateFormAuthoringContextDTO,
   ApprovalTemplateVersionDetailDTO,
   ApprovalTemplateVersionSummaryDTO,
   UnifiedApprovalDTO,
@@ -847,6 +848,30 @@ export async function unarchiveTemplate(templateId: string): Promise<ApprovalTem
 export async function getTemplate(id: string): Promise<ApprovalTemplateDetailDTO> {
   if (USE_MOCK) return mockTemplateDetail(id)
   return apiGet(`/api/approval-templates/${id}`)
+}
+
+export async function getTemplateFormAuthoringContext(
+  templateId: string,
+): Promise<ApprovalTemplateFormAuthoringContextDTO> {
+  if (USE_MOCK) {
+    const template = mockTemplateDetail(templateId)
+    const persistentIds = template.formSchema.fields.flatMap((field) => {
+      const columns = field.type === 'detail' && Array.isArray(field.columns)
+        ? field.columns
+            .map((column) => column.id)
+            .filter((id): id is string => typeof id === 'string' && id.length > 0)
+        : []
+      return [field.id, ...columns]
+    })
+    return {
+      templateId,
+      identityHistory: { complete: true, persistentIds },
+      referenceInventory: { complete: true, references: [] },
+    }
+  }
+  return apiGet(
+    `/api/approval-templates/${encodeURIComponent(templateId)}/form-authoring-context`,
+  )
 }
 
 export async function getTemplateVersion(

--- a/apps/web/src/approvals/components/ApprovalFormBuilder.vue
+++ b/apps/web/src/approvals/components/ApprovalFormBuilder.vue
@@ -14,9 +14,9 @@
         <el-button
           v-if="!workspaceEnabled"
           size="small"
-          :disabled="readOnly"
+          :disabled="readOnly || !structuralMutationEnabled"
           data-testid="approval-template-add-field"
-          @click="appendLegacyField"
+          @click="requestAddField('text', fields.length)"
         >
           <el-icon><Plus /></el-icon>
           添加字段
@@ -25,7 +25,10 @@
     </template>
 
     <div v-if="workspaceEnabled" class="approval-form-builder__workspace">
-      <ApprovalFormPalette :read-only="readOnly" @add="appendFieldOfType" />
+      <ApprovalFormPalette
+        :read-only="readOnly || !structuralMutationEnabled"
+        @add="appendFieldOfType"
+      />
 
       <main
         class="approval-form-builder__canvas"
@@ -123,7 +126,7 @@
                 text
                 size="small"
                 type="danger"
-                :disabled="readOnly || fields.length === 1"
+                :disabled="readOnly || !structuralMutationEnabled || fields.length === 1"
                 aria-label="删除字段"
                 data-testid="approval-template-remove-field"
                 @click.stop="removeField(index)"
@@ -161,6 +164,14 @@
           data-testid="approval-form-builder-status"
         >
           {{ formBuilderAnnouncement }}
+        </p>
+        <p
+          v-if="!structuralMutationEnabled && structuralMutationReason"
+          class="approval-form-builder__status"
+          role="status"
+          data-testid="approval-form-structure-disabled"
+        >
+          {{ structuralMutationReason }}
         </p>
       </main>
 
@@ -201,7 +212,7 @@
             <el-button
               size="small"
               type="danger"
-              :disabled="readOnly || fields.length === 1"
+              :disabled="readOnly || !structuralMutationEnabled || fields.length === 1"
               data-testid="approval-template-remove-field"
               @click="removeField(index)"
             >
@@ -232,13 +243,7 @@ import { computed, ref, watch } from 'vue'
 import { ArrowDown, ArrowUp, Delete, Plus, Rank } from '@element-plus/icons-vue'
 import ApprovalFieldInspector from './ApprovalFieldInspector.vue'
 import ApprovalFormPalette from './ApprovalFormPalette.vue'
-import {
-  createEmptyFieldDraft,
-  moveItemToIndex,
-  nextAvailableFieldDraftIndex,
-  type AuthorableFieldType,
-  type FieldAuthoringDraft,
-} from '../templateAuthoring'
+import type { AuthorableFieldType, FieldAuthoringDraft } from '../templateAuthoring'
 import {
   APPROVAL_FORM_FIELD_MOVE_MIME,
   APPROVAL_FORM_FIELD_TYPE_LABELS,
@@ -255,6 +260,8 @@ const props = defineProps<{
   recordLinkCatalogLoading: boolean
   recordLinkCatalogLoaded: boolean
   recordLinkCatalogError: string
+  structuralMutationEnabled: boolean
+  structuralMutationReason: string
 }>()
 
 const fields = defineModel<FieldAuthoringDraft[]>('fields', { required: true })
@@ -262,6 +269,9 @@ const fields = defineModel<FieldAuthoringDraft[]>('fields', { required: true })
 const emit = defineEmits<{
   'retry-record-link-catalog': []
   'field-type-change': [field: FieldAuthoringDraft]
+  'add-field': [request: { type: AuthorableFieldType; insertionIndex: number }]
+  'remove-field': [request: { localId: string }]
+  'move-field': [request: { localId: string; targetIndex: number }]
 }>()
 
 const selectedFieldLocalId = ref(fields.value[0]?.localId ?? '')
@@ -295,55 +305,28 @@ function selectField(localId: string): void {
   selectedFieldLocalId.value = localId
 }
 
-function replaceFields(next: FieldAuthoringDraft[]): void {
-  // Nested prop mutation is intentional here: palette/drop/delete events can occur in the same
-  // tick, before a v-model emit has flowed back from the parent. Updating the shared reactive
-  // array first keeps the next command on the authoritative state; the assignment then preserves
-  // the normal v-model notification contract.
-  fields.value.splice(0, fields.value.length, ...next)
-  fields.value = [...fields.value]
-}
-
-function appendLegacyField(): void {
-  const next = createEmptyFieldDraft(nextAvailableFieldDraftIndex(fields.value))
-  replaceFields([...fields.value, next])
-  selectedFieldLocalId.value = next.localId
-}
-
-function insertFieldOfType(type: AuthorableFieldType, index: number): void {
-  if (props.readOnly) return
-  const nextField = createEmptyFieldDraft(nextAvailableFieldDraftIndex(fields.value))
-  nextField.type = type
+function requestAddField(type: AuthorableFieldType, index: number): void {
+  if (props.readOnly || !props.structuralMutationEnabled) return
   const insertionIndex = Math.max(0, Math.min(index, fields.value.length))
-  replaceFields([
-    ...fields.value.slice(0, insertionIndex),
-    nextField,
-    ...fields.value.slice(insertionIndex),
-  ])
-  selectedFieldLocalId.value = nextField.localId
+  emit('add-field', { type, insertionIndex })
   selectedFieldInsertionIndex.value = null
-  formBuilderAnnouncement.value = `${APPROVAL_FORM_FIELD_TYPE_LABELS[type]}已插入为字段 ${insertionIndex + 1}`
 }
 
 function appendFieldOfType(type: AuthorableFieldType): void {
-  insertFieldOfType(type, selectedFieldInsertionIndex.value ?? fields.value.length)
+  requestAddField(type, selectedFieldInsertionIndex.value ?? fields.value.length)
 }
 
 function removeField(index: number): void {
-  if (props.readOnly || fields.value.length === 1) return
-  const removingSelected = fields.value[index]?.localId === selectedFieldLocalId.value
-  const next = fields.value.filter((_, current) => current !== index)
-  replaceFields(next)
-  if (removingSelected) {
-    selectedFieldLocalId.value = next[Math.min(index, next.length - 1)]?.localId ?? ''
-  }
+  if (props.readOnly || !props.structuralMutationEnabled || fields.value.length === 1) return
+  const localId = fields.value[index]?.localId
+  if (localId) emit('remove-field', { localId })
 }
 
 function moveField(index: number, delta: -1 | 1): void {
   const target = index + delta
   if (props.readOnly || target < 0 || target >= fields.value.length) return
-  replaceFields(moveItemToIndex(fields.value, index, target))
-  formBuilderAnnouncement.value = `字段已移动到第 ${target + 1} 位`
+  const localId = fields.value[index]?.localId
+  if (localId) emit('move-field', { localId, targetIndex: target })
 }
 
 function onFieldDragStart(event: DragEvent, index: number): void {
@@ -356,7 +339,8 @@ function onFieldDragStart(event: DragEvent, index: number): void {
 
 function onLegacyFieldDrop(index: number): void {
   if (props.readOnly || draggedFieldIndex.value === null) return
-  replaceFields(moveItemToIndex(fields.value, draggedFieldIndex.value, index))
+  const localId = fields.value[draggedFieldIndex.value]?.localId
+  if (localId) emit('move-field', { localId, targetIndex: index })
   resetFieldDragState()
 }
 
@@ -365,7 +349,7 @@ function activateFieldDropSlot(index: number): void {
 }
 
 function selectFieldInsertionSlot(index: number): void {
-  if (props.readOnly) return
+  if (props.readOnly || !props.structuralMutationEnabled) return
   if (selectedFieldInsertionIndex.value === index) {
     selectedFieldInsertionIndex.value = null
     formBuilderAnnouncement.value = '已取消插入位置'
@@ -391,7 +375,7 @@ function onFieldInsertionDrop(event: DragEvent, insertionIndex: number): void {
   }
   const paletteType = readPaletteFieldType(event.dataTransfer)
   if (paletteType) {
-    insertFieldOfType(paletteType, insertionIndex)
+    requestAddField(paletteType, insertionIndex)
     resetFieldDragState()
     return
   }
@@ -408,11 +392,21 @@ function onFieldInsertionDrop(event: DragEvent, insertionIndex: number): void {
   }
   const targetIndex = insertionIndex > sourceIndex ? insertionIndex - 1 : insertionIndex
   if (targetIndex !== sourceIndex) {
-    replaceFields(moveItemToIndex(fields.value, sourceIndex, targetIndex))
-    formBuilderAnnouncement.value = `字段已移动到第 ${targetIndex + 1} 位`
+    const localId = fields.value[sourceIndex]?.localId
+    if (localId) emit('move-field', { localId, targetIndex })
   }
   resetFieldDragState()
 }
+
+function focusField(localId: string): void {
+  selectedFieldLocalId.value = localId
+}
+
+function announce(message: string): void {
+  formBuilderAnnouncement.value = message
+}
+
+defineExpose({ focusField, announce })
 
 function onFieldKeyboardReorder(event: KeyboardEvent, index: number): void {
   if (props.readOnly || !event.altKey) return

--- a/apps/web/src/types/approval.ts
+++ b/apps/web/src/types/approval.ts
@@ -323,6 +323,24 @@ export interface ApprovalTemplateDetailDTO extends ApprovalTemplateListItemDTO {
   approvalGraph: ApprovalGraph
 }
 
+export interface ApprovalTemplateFormAuthoringContextDTO {
+  templateId: string
+  identityHistory: {
+    complete: true
+    persistentIds: string[]
+  }
+  referenceInventory: {
+    complete: true
+    references: Array<{
+      fieldId: string
+      kind: 'fwb_mapping' | 'fwb_record_link'
+      location:
+        | 'automation.write_approval_form_values.mappings.formFieldId'
+        | 'automation.write_approval_form_values.recordLinkFieldId'
+    }>
+  }
+}
+
 export interface ApprovalTemplateVisibilityScope {
   type: ApprovalTemplateVisibilityType
   ids: string[]

--- a/apps/web/src/views/approval/TemplateAuthoringView.vue
+++ b/apps/web/src/views/approval/TemplateAuthoringView.vue
@@ -246,6 +246,7 @@
       </el-card>
 
       <ApprovalFormBuilder
+        ref="formBuilderRef"
         v-show="activeAuthoringSection === 'fields'"
         v-model:fields="draft.fields"
         :workspace-enabled="canvasV2Enabled"
@@ -255,8 +256,13 @@
         :record-link-catalog-loading="recordLinkCatalogLoading"
         :record-link-catalog-loaded="recordLinkCatalogLoaded"
         :record-link-catalog-error="recordLinkCatalogError"
+        :structural-mutation-enabled="formStructuralMutationEnabled"
+        :structural-mutation-reason="formStructuralMutationReason"
         @retry-record-link-catalog="retryRecordLinkCatalog"
         @field-type-change="invalidateStaleRecordLinkDependencies"
+        @add-field="onAddFormField"
+        @remove-field="onRemoveFormField"
+        @move-field="onMoveFormField"
       />
 
       <el-card v-show="activeAuthoringSection === 'flow'" class="template-authoring__panel" shadow="never">
@@ -932,11 +938,13 @@ import {
   createTemplate,
   dryRunApprovalConditionFormula,
   getTemplate,
+  getTemplateFormAuthoringContext,
   previewTemplateRoute,
   publishTemplate,
   updateTemplate,
   type ApprovalRoutePreview,
 } from '../../approvals/api'
+import type { ApprovalTemplateFormAuthoringContextDTO } from '../../types/approval'
 import { describeTemplateAuthoringError } from '../../approvals/templateAuthoringErrors'
 import { createRoutePreviewController } from '../../approvals/routePreviewController'
 import { routePreviewAssigneeSummary } from '../../approvals/routePreviewSummary'
@@ -948,6 +956,15 @@ import ApprovalUserPicker from '../../approvals/components/ApprovalUserPicker.vu
 import ApprovalGraphNodeConfigEditor from '../../approvals/components/ApprovalGraphNodeConfigEditor.vue'
 import ApprovalFlowCanvas from '../../approvals/components/ApprovalFlowCanvas.vue'
 import ApprovalFormBuilder from '../../approvals/components/ApprovalFormBuilder.vue'
+import {
+  addFormField,
+  moveFormField,
+  removeFormField,
+  type CompleteFormIdentityHistory,
+  type CompleteFormReferenceInventory,
+  type FormCommandResult,
+  type FormFieldIdentity,
+} from '../../approvals/approvalFormCommands'
 import {
   APPROVAL_NODE_CONFIG_EDITOR_KEY,
   type ApprovalNodeConfigEditorApi,
@@ -973,6 +990,7 @@ import {
   approvalFormulaInsertOptions,
   parallelDynamicAssigneeConflicts,
   type ApprovalStepDraft,
+  type AuthorableFieldType,
   type ConditionBranchEdit,
   type ConditionNodeEdit,
   type ConditionRuleEdit,
@@ -1050,6 +1068,15 @@ const unsupportedReason = ref<string | null>(null)
 // unsupported — the form/metadata stay editable and save preserves the graph verbatim.
 const graphReadOnlyMessage = ref<string | null>(null)
 const draft = ref<TemplateAuthoringDraft>(createEmptyTemplateDraft())
+const formBuilderRef = ref<{
+  focusField(localId: string): void
+  announce(message: string): void
+} | null>(null)
+const formAuthoringContext = ref<ApprovalTemplateFormAuthoringContextDTO | null>(null)
+const formAuthoringContextLoading = ref(false)
+const formAuthoringContextError = ref('')
+const retiredFormPersistentIds = ref<string[]>([])
+const retiredFormLocalIds = ref<string[]>([])
 
 // FWB-0 Layer 2: typed base/sheet catalog for record-link authoring (IDs persist on the draft,
 // never shown as ordinary free-text labels). Loaded via MultitableApiClient listBases/listSheets.
@@ -1138,6 +1165,15 @@ const conditionFormulaDryRunBusy = ref<Record<string, boolean>>({})
 
 const templateId = computed(() => typeof route.params.id === 'string' ? route.params.id : '')
 const isEditMode = computed(() => templateId.value.length > 0)
+const formStructuralMutationEnabled = computed(
+  () => !draft.value.templateId || formAuthoringContext.value !== null,
+)
+const formStructuralMutationReason = computed(() => {
+  if (formStructuralMutationEnabled.value) return ''
+  return formAuthoringContextLoading.value
+    ? '正在核对字段历史与外部引用'
+    : formAuthoringContextError.value || '字段依赖未完成核对，新增和删除已暂停'
+})
 const commonTemplatePresets = COMMON_APPROVAL_TEMPLATE_PRESETS
 const showPresetLibrary = computed(() => !isEditMode.value && canManageTemplates.value)
 // Truly-unsupported (attachment field / unknown node / extra config keys) locks the WHOLE form.
@@ -2182,6 +2218,167 @@ function swap<T>(items: T[], index: number, delta: -1 | 1) {
   return copy
 }
 
+function currentFormIdentityHistory(): CompleteFormIdentityHistory | undefined {
+  if (draft.value.templateId && !formAuthoringContext.value) return undefined
+  return {
+    complete: true,
+    persistentIds: [
+      ...(formAuthoringContext.value?.identityHistory.persistentIds ?? []),
+      ...retiredFormPersistentIds.value,
+    ],
+    localIds: [
+      ...draft.value.fields.flatMap((field) => [
+        field.localId,
+        ...field.detailColumns.map((column) => column.localId),
+      ]),
+      ...retiredFormLocalIds.value,
+    ],
+  }
+}
+
+function currentFormReferenceInventory(): CompleteFormReferenceInventory | undefined {
+  if (!draft.value.templateId) return { complete: true, references: [] }
+  return formAuthoringContext.value?.referenceInventory
+}
+
+function newFormFieldIdentity(type: AuthorableFieldType): FormFieldIdentity {
+  const fieldToken = globalThis.crypto.randomUUID().replace(/-/g, '')
+  const identity: FormFieldIdentity = {
+    persistentId: `field_${fieldToken}`,
+    localId: `field_local_${fieldToken}`,
+  }
+  if (type !== 'detail') return identity
+  const columnToken = globalThis.crypto.randomUUID().replace(/-/g, '')
+  return {
+    ...identity,
+    detailColumn: {
+      persistentId: `column_${columnToken}`,
+      localId: `column_local_${columnToken}`,
+    },
+  }
+}
+
+function describeFormCommandFailure(result: Extract<FormCommandResult, { ok: false }>): string {
+  if (result.reason === 'field_is_referenced') return '该字段仍被流程或自动化引用，不能删除'
+  if (result.reason === 'identity_history_missing') return '字段历史未完成核对，暂不能新增字段'
+  if (result.reason === 'reference_inventory_missing') return '字段引用未完成核对，暂不能删除字段'
+  return '表单结构操作未完成，请刷新后重试'
+}
+
+function acceptFormCommand(result: FormCommandResult, announcement: string): boolean {
+  if (!result.ok) {
+    const message = describeFormCommandFailure(result)
+    formBuilderRef.value?.announce(message)
+    ElMessage.warning(message)
+    return false
+  }
+  draft.value = result.draft
+  if (result.focusLocalId) {
+    void nextTick(() => formBuilderRef.value?.focusField(result.focusLocalId!))
+  }
+  formBuilderRef.value?.announce(announcement)
+  return true
+}
+
+function onAddFormField(request: { type: AuthorableFieldType; insertionIndex: number }): void {
+  const history = currentFormIdentityHistory()
+  if (!history) {
+    acceptFormCommand(
+      { ok: false, reason: 'identity_history_missing', dependencies: [] },
+      '',
+    )
+    return
+  }
+  const identity = newFormFieldIdentity(request.type)
+  const before = draft.value.fields.slice()
+  let result = addFormField(draft.value, request.type, identity, history)
+  if (result.ok && request.insertionIndex < before.length) {
+    result = moveFormField(
+      result.draft,
+      identity.localId,
+      before[Math.max(0, request.insertionIndex)]!.localId,
+      'before',
+    )
+  }
+  acceptFormCommand(
+    result,
+    `${request.type === 'detail' ? '明细' : '表单组件'}已插入为字段 ${request.insertionIndex + 1}`,
+  )
+}
+
+function onRemoveFormField(request: { localId: string }): void {
+  const removing = draft.value.fields.find((field) => field.localId === request.localId)
+  if (!removing) return
+  const result = removeFormField(
+    draft.value,
+    request.localId,
+    currentFormReferenceInventory(),
+  )
+  if (!acceptFormCommand(result, '字段已删除')) return
+  retiredFormPersistentIds.value = [
+    ...retiredFormPersistentIds.value,
+    removing.id,
+    ...removing.detailColumns.map((column) => column.id),
+  ]
+  retiredFormLocalIds.value = [
+    ...retiredFormLocalIds.value,
+    removing.localId,
+    ...removing.detailColumns.map((column) => column.localId),
+  ]
+}
+
+function onMoveFormField(request: { localId: string; targetIndex: number }): void {
+  const currentIndex = draft.value.fields.findIndex((field) => field.localId === request.localId)
+  if (currentIndex < 0 || currentIndex === request.targetIndex) return
+  const remaining = draft.value.fields.filter((field) => field.localId !== request.localId)
+  if (remaining.length === 0) return
+  const targetIndex = Math.max(0, Math.min(request.targetIndex, remaining.length))
+  const anchor = targetIndex === remaining.length ? remaining[remaining.length - 1] : remaining[targetIndex]
+  const result = moveFormField(
+    draft.value,
+    request.localId,
+    anchor.localId,
+    targetIndex === remaining.length ? 'after' : 'before',
+  )
+  acceptFormCommand(result, `字段已移动到第 ${targetIndex + 1} 位`)
+}
+
+async function loadFormAuthoringContext(id: string): Promise<void> {
+  formAuthoringContext.value = null
+  formAuthoringContextError.value = ''
+  if (!id) return
+  formAuthoringContextLoading.value = true
+  try {
+    const context = await getTemplateFormAuthoringContext(id)
+    if (
+      context.templateId !== id
+      || context.identityHistory.complete !== true
+      || !Array.isArray(context.identityHistory.persistentIds)
+      || !context.identityHistory.persistentIds.every(
+        (persistentId) => typeof persistentId === 'string' && persistentId.trim().length > 0,
+      )
+      || context.referenceInventory.complete !== true
+      || !Array.isArray(context.referenceInventory.references)
+      || !context.referenceInventory.references.every((reference) =>
+        typeof reference?.fieldId === 'string'
+        && reference.fieldId.trim().length > 0
+        && (reference.kind === 'fwb_mapping' || reference.kind === 'fwb_record_link')
+        && (
+          reference.location === 'automation.write_approval_form_values.mappings.formFieldId'
+          || reference.location === 'automation.write_approval_form_values.recordLinkFieldId'
+        ),
+      )
+    ) {
+      throw new Error('invalid_form_authoring_context')
+    }
+    formAuthoringContext.value = context
+  } catch {
+    formAuthoringContextError.value = '字段历史与外部引用核对失败，新增和删除已暂停'
+  } finally {
+    formAuthoringContextLoading.value = false
+  }
+}
+
 /**
  * When a field is retyped to/from record-link (or detail), drop stale visibility deps and
  * condition rules that referenced it — otherwise the UI would keep a now-illegal dependency
@@ -2242,8 +2439,12 @@ async function loadTemplateForEdit() {
   selectedCanvasNode.value = null
   movingCanvasNode.value = null
   canvasZoom.value = 1
+  retiredFormPersistentIds.value = []
+  retiredFormLocalIds.value = []
   if (!isEditMode.value) {
     draft.value = createEmptyTemplateDraft()
+    formAuthoringContext.value = null
+    formAuthoringContextError.value = ''
     unsupportedReason.value = null
     graphReadOnlyMessage.value = null
     snapshotDraft()
@@ -2256,6 +2457,7 @@ async function loadTemplateForEdit() {
     unsupportedReason.value = unsupportedTemplateAuthoringReason(template)
     graphReadOnlyMessage.value = graphReadOnlyReason(template)
     draft.value = draftFromTemplate(template)
+    await loadFormAuthoringContext(template.id)
     syncAllStepOptions()
     syncAllApprovalNodeOptions()
     syncAllCcOptions()
@@ -2307,6 +2509,7 @@ async function persistDraft() {
     if (draft.value.templateId) {
       const updated = await updateTemplate(draft.value.templateId, buildUpdateTemplatePayload(draft.value))
       draft.value = draftFromTemplate(updated)
+      await loadFormAuthoringContext(updated.id)
       unsupportedReason.value = unsupportedTemplateAuthoringReason(updated)
       graphReadOnlyMessage.value = graphReadOnlyReason(updated)
       snapshotDraft()
@@ -2314,6 +2517,7 @@ async function persistDraft() {
     }
     const created = await createTemplate(buildCreateTemplatePayload(draft.value))
     draft.value = draftFromTemplate(created)
+    await loadFormAuthoringContext(created.id)
     unsupportedReason.value = unsupportedTemplateAuthoringReason(created)
     graphReadOnlyMessage.value = graphReadOnlyReason(created)
     snapshotDraft() // before the route replace so the leave guard stays quiet
@@ -2334,6 +2538,7 @@ async function createFromPreset(presetId: CommonApprovalTemplatePresetId) {
   try {
     const created = await createTemplate(buildCommonApprovalTemplatePresetPayload(presetId))
     draft.value = draftFromTemplate(created)
+    await loadFormAuthoringContext(created.id)
     unsupportedReason.value = unsupportedTemplateAuthoringReason(created)
     graphReadOnlyMessage.value = graphReadOnlyReason(created)
     syncAllStepOptions()

--- a/apps/web/tests/approval-template-authoring-canvas-inspector.spec.ts
+++ b/apps/web/tests/approval-template-authoring-canvas-inspector.spec.ts
@@ -74,6 +74,7 @@ const createTemplateSpy = vi.fn()
 const updateTemplateSpy = vi.fn()
 const publishTemplateSpy = vi.fn()
 const getTemplateSpy = vi.fn()
+const getTemplateFormAuthoringContextSpy = vi.fn()
 const dryRunApprovalConditionFormulaSpy = vi.fn()
 
 vi.mock('../src/approvals/api', () => ({
@@ -81,6 +82,7 @@ vi.mock('../src/approvals/api', () => ({
   updateTemplate: (id: string, payload: unknown) => updateTemplateSpy(id, payload),
   publishTemplate: (id: string, payload: unknown) => publishTemplateSpy(id, payload),
   getTemplate: (id: string) => getTemplateSpy(id),
+  getTemplateFormAuthoringContext: (id: string) => getTemplateFormAuthoringContextSpy(id),
   dryRunApprovalConditionFormula: (payload: unknown) => dryRunApprovalConditionFormulaSpy(payload),
 }))
 
@@ -432,6 +434,12 @@ describe('Canvas V2 Slice A — canvas inspector', () => {
     updateTemplateSpy.mockReset()
     publishTemplateSpy.mockReset()
     getTemplateSpy.mockReset()
+    getTemplateFormAuthoringContextSpy.mockReset()
+    getTemplateFormAuthoringContextSpy.mockImplementation(async (id: string) => ({
+      templateId: id,
+      identityHistory: { complete: true, persistentIds: [] },
+      referenceInventory: { complete: true, references: [] },
+    }))
     dryRunApprovalConditionFormulaSpy.mockReset()
     pushSpy.mockClear()
     replaceSpy.mockClear()
@@ -450,7 +458,7 @@ describe('Canvas V2 Slice A — canvas inspector', () => {
 
   it('adds palette fields, inserts at an explicit drop slot, and reorders with the keyboard', async () => {
     routeParams = { id: 'tpl_form_palette' }
-    getTemplateSpy.mockResolvedValue(buildTemplate())
+    getTemplateSpy.mockResolvedValue(buildTemplate({ id: routeParams.id }))
     await mountView()
     await flushUi()
 
@@ -536,13 +544,14 @@ describe('Canvas V2 Slice A — canvas inspector', () => {
 
   it('keeps forward, backward, and adjacent insertion-slot reorders exact', async () => {
     routeParams = { id: 'tpl_form_palette_crossing' }
-    getTemplateSpy.mockResolvedValue(buildTemplate())
+    getTemplateSpy.mockResolvedValue(buildTemplate({ id: routeParams.id }))
     await mountView()
     await flushUi()
 
     ;(container!.querySelector('[data-testid="approval-template-section-fields"]') as HTMLButtonElement).click()
     await flushUi()
     ;(container!.querySelector('[data-testid="approval-form-palette-textarea"]') as HTMLButtonElement).click()
+    await flushUi()
     ;(container!.querySelector('[data-testid="approval-form-palette-date"]') as HTMLButtonElement).click()
     await flushUi()
 
@@ -638,11 +647,11 @@ describe('Canvas V2 Slice A — canvas inspector', () => {
     ;(container!.querySelector('[data-testid="approval-template-save-button"]') as HTMLButtonElement).click()
     await flushUi()
     const payload = updateTemplateSpy.mock.calls.at(-1)?.[1] as any
-    expect(payload.formSchema.fields.map((field: any) => field.id)).toEqual([
-      'field_1',
-      'field_3',
-      'field_2',
-    ])
+    const ids = payload.formSchema.fields.map((field: any) => field.id)
+    expect(ids.slice(0, 2)).toEqual(['field_1', 'field_3'])
+    expect(ids[2]).toMatch(/^field_[a-f0-9]{32}$/)
+    expect(new Set(ids).size).toBe(3)
+    expect(ids[2]).not.toBe('field_2')
   })
 
   it('keeps generated field ids unique after delete-then-insert', async () => {
@@ -670,11 +679,146 @@ describe('Canvas V2 Slice A — canvas inspector', () => {
     ;(container!.querySelector('[data-testid="approval-template-save-button"]') as HTMLButtonElement).click()
     await flushUi()
     const payload = updateTemplateSpy.mock.calls.at(-1)?.[1] as any
-    expect(payload.formSchema.fields.map((field: any) => field.id)).toEqual([
-      'field_1',
-      'field_2',
-      'field_3',
-    ])
+    const ids = payload.formSchema.fields.map((field: any) => field.id)
+    expect(ids[0]).toBe('field_1')
+    expect(ids[1]).toMatch(/^field_[a-f0-9]{32}$/)
+    expect(ids[2]).toBe('field_3')
+    expect(new Set(ids).size).toBe(3)
+    expect(ids[1]).not.toBe('field_2')
+  })
+
+  it('fails closed on historical identity collisions before adding a field', async () => {
+    routeParams = { id: 'tpl_form_palette_history_collision' }
+    const reservedToken = 'aaaaaaaaaaaa4aaa8aaaaaaaaaaaaaaa'
+    getTemplateSpy.mockResolvedValue(buildTemplate({ id: routeParams.id }))
+    getTemplateFormAuthoringContextSpy.mockResolvedValue({
+      templateId: routeParams.id,
+      identityHistory: {
+        complete: true,
+        persistentIds: [`field_${reservedToken}`],
+      },
+      referenceInventory: { complete: true, references: [] },
+    })
+    const randomUuidSpy = vi.spyOn(globalThis.crypto, 'randomUUID')
+      .mockReturnValue('aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa')
+    await mountView()
+    await flushUi()
+
+    ;(container!.querySelector('[data-testid="approval-template-section-fields"]') as HTMLButtonElement).click()
+    await flushUi()
+    const before = container!.querySelectorAll('[data-testid="approval-template-field-row"]').length
+    ;(container!.querySelector('[data-testid="approval-form-palette-date"]') as HTMLButtonElement).click()
+    await flushUi()
+
+    expect(container!.querySelectorAll('[data-testid="approval-template-field-row"]')).toHaveLength(before)
+    expect(container!.querySelector('[data-testid="approval-form-builder-status"]')?.textContent)
+      .toBe('表单结构操作未完成，请刷新后重试')
+    expect(container!.textContent).not.toContain(reservedToken)
+    randomUuidSpy.mockRestore()
+  })
+
+  it('blocks an externally referenced field delete without exposing its storage location', async () => {
+    routeParams = { id: 'tpl_form_palette_external_reference' }
+    getTemplateSpy.mockResolvedValue(buildTemplate({ id: routeParams.id }))
+    getTemplateFormAuthoringContextSpy.mockResolvedValue({
+      templateId: routeParams.id,
+      identityHistory: { complete: true, persistentIds: ['amount', 'reviewer'] },
+      referenceInventory: {
+        complete: true,
+        references: [{
+          fieldId: 'amount',
+          kind: 'fwb_mapping',
+          location: 'automation.write_approval_form_values.mappings.formFieldId',
+        }],
+      },
+    })
+    await mountView()
+    await flushUi()
+
+    ;(container!.querySelector('[data-testid="approval-template-section-fields"]') as HTMLButtonElement).click()
+    await flushUi()
+    const firstRow = container!.querySelectorAll('[data-testid="approval-template-field-row"]')[0] as HTMLElement
+    ;(firstRow.querySelector('[data-testid="approval-template-remove-field"]') as HTMLButtonElement).click()
+    await flushUi()
+
+    expect(container!.querySelectorAll('[data-testid="approval-template-field-row"]')).toHaveLength(2)
+    expect(container!.querySelector('[data-testid="approval-form-builder-status"]')?.textContent)
+      .toBe('该字段仍被流程或自动化引用，不能删除')
+    expect(container!.textContent).not.toContain(
+      'automation.write_approval_form_values.mappings.formFieldId',
+    )
+    ;(container!.querySelector('[data-testid="approval-template-save-button"]') as HTMLButtonElement).click()
+    await flushUi()
+    const payload = updateTemplateSpy.mock.calls.at(-1)?.[1] as any
+    expect(payload.formSchema.fields.map((field: any) => field.id)).toEqual(['amount', 'reviewer'])
+  })
+
+  it('pauses add and delete on a mismatched authoring context but keeps field reordering available', async () => {
+    routeParams = { id: 'tpl_form_palette_context_unavailable' }
+    getTemplateSpy.mockResolvedValue(buildTemplate({ id: routeParams.id }))
+    getTemplateFormAuthoringContextSpy.mockResolvedValue({
+      templateId: 'wrong_template_private_id',
+      identityHistory: { complete: true, persistentIds: [] },
+      referenceInventory: { complete: true, references: [] },
+    })
+    await mountView()
+    await flushUi()
+
+    ;(container!.querySelector('[data-testid="approval-template-section-fields"]') as HTMLButtonElement).click()
+    await flushUi()
+    const paletteButton = container!.querySelector(
+      '[data-testid="approval-form-palette-date"]',
+    ) as HTMLButtonElement
+    const firstRow = container!.querySelectorAll('[data-testid="approval-template-field-row"]')[0] as HTMLElement
+    expect(paletteButton.disabled).toBe(true)
+    expect((firstRow.querySelector('[data-testid="approval-template-remove-field"]') as HTMLButtonElement).disabled)
+      .toBe(true)
+    const disabledStatus = container!.querySelector('[data-testid="approval-form-structure-disabled"]')
+    expect(disabledStatus?.textContent).toContain('新增和删除已暂停')
+    expect(disabledStatus?.textContent).not.toContain('wrong_template_private_id')
+
+    const firstHandle = firstRow.querySelector(
+      '[data-testid="approval-form-field-drag-handle"]',
+    ) as HTMLButtonElement
+    expect(firstHandle.disabled).toBe(false)
+    firstHandle.dispatchEvent(new KeyboardEvent('keydown', {
+      key: 'ArrowDown',
+      altKey: true,
+      bubbles: true,
+      cancelable: true,
+    }))
+    await flushUi()
+    ;(container!.querySelector('[data-testid="approval-template-save-button"]') as HTMLButtonElement).click()
+    await flushUi()
+    const payload = updateTemplateSpy.mock.calls.at(-1)?.[1] as any
+    expect(payload.formSchema.fields.map((field: any) => field.id)).toEqual(['reviewer', 'amount'])
+  })
+
+  it('fails closed when the authoring context carries an incomplete external reference', async () => {
+    routeParams = { id: 'tpl_form_palette_context_malformed' }
+    getTemplateSpy.mockResolvedValue(buildTemplate({ id: routeParams.id }))
+    getTemplateFormAuthoringContextSpy.mockResolvedValue({
+      templateId: routeParams.id,
+      identityHistory: { complete: true, persistentIds: ['amount', 'reviewer'] },
+      referenceInventory: {
+        complete: true,
+        references: [{
+          fieldId: '',
+          kind: 'fwb_mapping',
+          location: 'automation.write_approval_form_values.mappings.formFieldId',
+        }],
+      },
+    })
+    await mountView()
+    await flushUi()
+
+    ;(container!.querySelector('[data-testid="approval-template-section-fields"]') as HTMLButtonElement).click()
+    await flushUi()
+    expect((container!.querySelector(
+      '[data-testid="approval-form-palette-date"]',
+    ) as HTMLButtonElement).disabled).toBe(true)
+    expect(container!.querySelector('[data-testid="approval-form-structure-disabled"]')?.textContent)
+      .toContain('新增和删除已暂停')
   })
 
   it('rejects a moved-field drop when its typed payload does not match the local drag', async () => {

--- a/apps/web/tests/approval-template-authoring-linear-canvas.spec.ts
+++ b/apps/web/tests/approval-template-authoring-linear-canvas.spec.ts
@@ -78,6 +78,11 @@ const createTemplateSpy = vi.fn()
 const updateTemplateSpy = vi.fn()
 const publishTemplateSpy = vi.fn()
 const getTemplateSpy = vi.fn()
+const getTemplateFormAuthoringContextSpy = vi.fn().mockImplementation(async (id: string) => ({
+  templateId: id,
+  identityHistory: { complete: true, persistentIds: [] },
+  referenceInventory: { complete: true, references: [] },
+}))
 const dryRunApprovalConditionFormulaSpy = vi.fn()
 
 vi.mock('../src/approvals/api', () => ({
@@ -85,6 +90,7 @@ vi.mock('../src/approvals/api', () => ({
   updateTemplate: (id: string, payload: unknown) => updateTemplateSpy(id, payload),
   publishTemplate: (id: string, payload: unknown) => publishTemplateSpy(id, payload),
   getTemplate: (id: string) => getTemplateSpy(id),
+  getTemplateFormAuthoringContext: (id: string) => getTemplateFormAuthoringContextSpy(id),
   dryRunApprovalConditionFormula: (payload: unknown) => dryRunApprovalConditionFormulaSpy(payload),
 }))
 

--- a/apps/web/tests/approvalStaticPicker.spec.ts
+++ b/apps/web/tests/approvalStaticPicker.spec.ts
@@ -41,11 +41,17 @@ const createTemplateSpy = vi.fn()
 const updateTemplateSpy = vi.fn()
 const publishTemplateSpy = vi.fn()
 const getTemplateSpy = vi.fn()
+const getTemplateFormAuthoringContextSpy = vi.fn().mockImplementation(async (id: string) => ({
+  templateId: id,
+  identityHistory: { complete: true, persistentIds: [] },
+  referenceInventory: { complete: true, references: [] },
+}))
 vi.mock('../src/approvals/api', () => ({
   createTemplate: (payload: unknown) => createTemplateSpy(payload),
   updateTemplate: (id: string, payload: unknown) => updateTemplateSpy(id, payload),
   publishTemplate: (id: string, payload: unknown) => publishTemplateSpy(id, payload),
   getTemplate: (id: string) => getTemplateSpy(id),
+  getTemplateFormAuthoringContext: (id: string) => getTemplateFormAuthoringContextSpy(id),
 }))
 
 // Mock the directory composable so the picker renders without any network.

--- a/apps/web/tests/approvalTemplateAuthoring.spec.ts
+++ b/apps/web/tests/approvalTemplateAuthoring.spec.ts
@@ -58,6 +58,7 @@ const createTemplateSpy = vi.fn()
 const updateTemplateSpy = vi.fn()
 const publishTemplateSpy = vi.fn()
 const getTemplateSpy = vi.fn()
+const getTemplateFormAuthoringContextSpy = vi.fn()
 const dryRunApprovalConditionFormulaSpy = vi.fn()
 
 vi.mock('../src/approvals/api', () => ({
@@ -65,6 +66,7 @@ vi.mock('../src/approvals/api', () => ({
   updateTemplate: (id: string, payload: unknown) => updateTemplateSpy(id, payload),
   publishTemplate: (id: string, payload: unknown) => publishTemplateSpy(id, payload),
   getTemplate: (id: string) => getTemplateSpy(id),
+  getTemplateFormAuthoringContext: (id: string) => getTemplateFormAuthoringContextSpy(id),
   dryRunApprovalConditionFormula: (payload: unknown) => dryRunApprovalConditionFormulaSpy(payload),
 }))
 
@@ -681,6 +683,12 @@ describe('TemplateAuthoringView', () => {
     updateTemplateSpy.mockReset()
     publishTemplateSpy.mockReset()
     getTemplateSpy.mockReset()
+    getTemplateFormAuthoringContextSpy.mockReset()
+    getTemplateFormAuthoringContextSpy.mockImplementation(async (id: string) => ({
+      templateId: id,
+      identityHistory: { complete: true, persistentIds: [] },
+      referenceInventory: { complete: true, references: [] },
+    }))
     dryRunApprovalConditionFormulaSpy.mockReset()
     pushSpy.mockClear()
     replaceSpy.mockClear()
@@ -1506,6 +1514,7 @@ describe('TemplateAuthoringView', () => {
     routeParams = { id: 'tpl_1' }
     getTemplateSpy.mockResolvedValue(buildTemplate())
     await mountView()
+    await flushUi()
 
     setInput('approval-template-name', '费用审批 v2')
     ;(container!.querySelector('[data-testid="approval-template-save-button"]') as HTMLButtonElement).click()
@@ -1593,11 +1602,12 @@ describe('TemplateAuthoringView', () => {
     expect(confirmButton.disabled).toBe(false)
 
     confirmButton.click()
-    await flushUi()
+    await vi.waitFor(() => {
+      expect(pushSpy).toHaveBeenCalledWith({ path: '/approval-templates/tpl_created' })
+    })
 
     expect(createTemplateSpy).toHaveBeenCalledTimes(1)
     expect(publishTemplateSpy).toHaveBeenCalledWith('tpl_created', { policy: { allowRevoke: true } })
-    expect(pushSpy).toHaveBeenCalledWith({ path: '/approval-templates/tpl_created' })
   })
 
   // B3-09 (模板治理 — 发布说明): the checklist dialog carries an OPTIONAL note; typed → trimmed and

--- a/packages/core-backend/src/routes/approvals.ts
+++ b/packages/core-backend/src/routes/approvals.ts
@@ -628,6 +628,20 @@ export function approvalsRouter(options?: ApprovalRouterOptions): Router {
     }
   })
 
+  r.get('/api/approval-templates/:id/form-authoring-context', authenticate, approvalTemplateAdminGuard, async (req: Request, res: Response) => {
+    try {
+      const context = await productService.getTemplateFormAuthoringContext(req.params.id)
+      res.json(context)
+    } catch (error) {
+      handleApprovalsError(
+        res,
+        error,
+        'APPROVAL_FORM_AUTHORING_CONTEXT_FETCH_FAILED',
+        'Failed to fetch approval form authoring context',
+      )
+    }
+  })
+
   // Wave 2 WP4 slice 1 — clone an existing template as a new draft. Always
   // creates the clone as draft; no `published_definition` is copied over, so
   // the caller must publish the clone separately before it can initiate

--- a/packages/core-backend/src/services/ApprovalProductService.ts
+++ b/packages/core-backend/src/services/ApprovalProductService.ts
@@ -9,6 +9,7 @@ import type {
   AutoApprovalPolicy,
   AutoApprovalPolicySource,
   ApprovalTemplateDetailDTO,
+  ApprovalFormAuthoringContextDTO,
   ApprovalTemplateListItemDTO,
   ApprovalTemplateVisibilityScope,
   ApprovalTemplateVersionDetailDTO,
@@ -116,6 +117,11 @@ import {
 } from './approval-record-link-txn-auth'
 import { Logger } from '../core/logger'
 import { eventBus } from '../integration/events/event-bus'
+import {
+  collectApprovalFormPersistentIds,
+  findMissingApprovalFormReferenceIds,
+  loadApprovalFormExternalReferences,
+} from './approval-form-authoring-context'
 
 const metricsLogger = new Logger('ApprovalMetricsHook')
 const nodeTimeoutLogger = new Logger('ApprovalNodeTimeout')
@@ -3534,6 +3540,63 @@ export class ApprovalProductService {
     }))
   }
 
+  async getTemplateFormAuthoringContext(
+    templateId: string,
+  ): Promise<ApprovalFormAuthoringContextDTO> {
+    if (!pool) throw new Error('Database not available')
+
+    let client: ApprovalDbClient | null = null
+    try {
+      client = await pool.connect()
+      await client.query('BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY')
+
+      const templateResult = await client.query<{ id: string }>(
+        'SELECT id FROM approval_templates WHERE id = $1',
+        [templateId],
+      )
+      if (!templateResult.rows[0]) {
+        throw new ServiceError('Approval template not found', 404, 'APPROVAL_TEMPLATE_NOT_FOUND')
+      }
+
+      const versionsResult = await client.query<{ form_schema: unknown }>(
+        `SELECT form_schema
+         FROM approval_template_versions
+         WHERE template_id = $1
+         ORDER BY version ASC`,
+        [templateId],
+      )
+      let persistentIds: string[]
+      try {
+        persistentIds = collectApprovalFormPersistentIds(
+          versionsResult.rows.map((row) => row.form_schema),
+        )
+      } catch {
+        throw new ServiceError(
+          'Approval form authoring context is unavailable',
+          500,
+          'APPROVAL_FORM_AUTHORING_CONTEXT_INCOMPLETE',
+        )
+      }
+
+      const references = await loadApprovalFormExternalReferences(
+        async (sql, params) => client!.query(sql, params),
+        templateId,
+      )
+      await client.query('COMMIT')
+
+      return {
+        templateId,
+        identityHistory: { complete: true, persistentIds },
+        referenceInventory: { complete: true, references },
+      }
+    } catch (error) {
+      await rollbackQuietly(client)
+      throw error
+    } finally {
+      client?.release()
+    }
+  }
+
   async restoreTemplateVersion(
     templateId: string,
     versionId: string,
@@ -3924,6 +3987,20 @@ export class ApprovalProductService {
       )
 
       const formSchema = asFormSchema(version.form_schema)
+      const fwbReferences = await loadApprovalFormExternalReferences(
+        async (sql, params) => client!.query(sql, params),
+        id,
+      )
+      if (findMissingApprovalFormReferenceIds(formSchema, fwbReferences).length > 0) {
+        throw new ServiceError(
+          'Approval form fields required by automation writeback are missing',
+          409,
+          'APPROVAL_TEMPLATE_FORM_FIELD_REFERENCED',
+        )
+      }
+      // This in-transaction rescan is the publish choke point, not a claim that the authoring GET
+      // is TOCTOU-free. A concurrently-created rule after this scan is still fail-closed by FWB's
+      // sourceTemplateVersionId mismatch at execution time.
       const storedApprovalGraph = asApprovalGraph(version.approval_graph)
       // Publishing is a write choke point: historical drafts stay readable, but
       // must satisfy the current all-runtime-path contract before activation.

--- a/packages/core-backend/src/services/approval-form-authoring-context.ts
+++ b/packages/core-backend/src/services/approval-form-authoring-context.ts
@@ -1,0 +1,157 @@
+import { collectFwbActionConfigs } from '../multitable/approval-fwb-activation'
+import type {
+  ApprovalFormExternalReferenceDTO,
+  FormSchema,
+} from '../types/approval-product'
+
+export const FWB_MAPPING_REFERENCE_LOCATION =
+  'automation.write_approval_form_values.mappings.formFieldId' as const
+export const FWB_RECORD_LINK_REFERENCE_LOCATION =
+  'automation.write_approval_form_values.recordLinkFieldId' as const
+
+interface FwbRuleRow {
+  action_type: string | null
+  action_config: unknown
+  actions: unknown
+}
+
+type QueryFn = (
+  sql: string,
+  params?: unknown[],
+) => Promise<{ rows: unknown[] }>
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function nonBlankString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim().length > 0
+    ? value.trim()
+    : null
+}
+
+function collectSchemaIds(schema: unknown, output: Set<string>): void {
+  if (!isRecord(schema) || !Array.isArray(schema.fields)) {
+    throw new Error('approval_form_schema_history_incomplete')
+  }
+
+  for (const field of schema.fields) {
+    if (!isRecord(field)) {
+      throw new Error('approval_form_schema_history_incomplete')
+    }
+    const fieldId = nonBlankString(field.id)
+    if (!fieldId) {
+      throw new Error('approval_form_schema_history_incomplete')
+    }
+    output.add(fieldId)
+
+    if (field.columns === undefined) continue
+    if (!Array.isArray(field.columns)) {
+      throw new Error('approval_form_schema_history_incomplete')
+    }
+    for (const column of field.columns) {
+      if (!isRecord(column)) {
+        throw new Error('approval_form_schema_history_incomplete')
+      }
+      const columnId = nonBlankString(column.id)
+      if (!columnId) {
+        throw new Error('approval_form_schema_history_incomplete')
+      }
+      output.add(columnId)
+    }
+  }
+}
+
+/**
+ * Reserve every persisted top-level field and detail-column id ever used by a template.
+ * Historical schemas are read as stored instead of being normalized under today's authoring
+ * rules: an old-but-readable version must still reserve identities that the latest draft deleted.
+ */
+export function collectApprovalFormPersistentIds(
+  formSchemas: readonly unknown[],
+): string[] {
+  const ids = new Set<string>()
+  for (const schema of formSchemas) collectSchemaIds(schema, ids)
+  return [...ids].sort()
+}
+
+function asPersistedActions(
+  value: unknown,
+): ReadonlyArray<{ type?: unknown; config?: unknown }> | null {
+  return Array.isArray(value)
+    ? value as ReadonlyArray<{ type?: unknown; config?: unknown }>
+    : null
+}
+
+/**
+ * Enumerate FWB references without exposing rule ids, target values, or action config. The shared
+ * collectFwbActionConfigs walker is the authority for top-level versus nested action semantics.
+ */
+export function collectApprovalFormExternalReferences(
+  rows: readonly FwbRuleRow[],
+): ApprovalFormExternalReferenceDTO[] {
+  const references = new Map<string, ApprovalFormExternalReferenceDTO>()
+  const addReference = (reference: ApprovalFormExternalReferenceDTO) => {
+    references.set(`${reference.fieldId}\u0000${reference.kind}`, reference)
+  }
+
+  for (const row of rows) {
+    const configs = collectFwbActionConfigs(
+      row.action_type,
+      row.action_config,
+      asPersistedActions(row.actions),
+    )
+    for (const config of configs) {
+      if (Array.isArray(config.mappings)) {
+        for (const mapping of config.mappings) {
+          if (!isRecord(mapping)) continue
+          const fieldId = nonBlankString(mapping.formFieldId)
+          if (!fieldId) continue
+          addReference({
+            fieldId,
+            kind: 'fwb_mapping',
+            location: FWB_MAPPING_REFERENCE_LOCATION,
+          })
+        }
+      }
+
+      const recordLinkFieldId = nonBlankString(config.recordLinkFieldId)
+      if (recordLinkFieldId) {
+        addReference({
+          fieldId: recordLinkFieldId,
+          kind: 'fwb_record_link',
+          location: FWB_RECORD_LINK_REFERENCE_LOCATION,
+        })
+      }
+    }
+  }
+
+  return [...references.values()].sort((left, right) =>
+    left.fieldId.localeCompare(right.fieldId)
+      || left.kind.localeCompare(right.kind))
+}
+
+export async function loadApprovalFormExternalReferences(
+  query: QueryFn,
+  templateId: string,
+): Promise<ApprovalFormExternalReferenceDTO[]> {
+  const result = await query(
+    `SELECT action_type, action_config, actions
+     FROM automation_rules
+     WHERE trigger_config->>'templateId' = $1`,
+    [templateId],
+  )
+  return collectApprovalFormExternalReferences(result.rows as FwbRuleRow[])
+}
+
+export function findMissingApprovalFormReferenceIds(
+  formSchema: FormSchema,
+  references: readonly ApprovalFormExternalReferenceDTO[],
+): string[] {
+  const available = new Set(collectApprovalFormPersistentIds([formSchema]))
+  return [...new Set(
+    references
+      .map((reference) => reference.fieldId)
+      .filter((fieldId) => !available.has(fieldId)),
+  )].sort()
+}

--- a/packages/core-backend/src/types/approval-product.ts
+++ b/packages/core-backend/src/types/approval-product.ts
@@ -494,6 +494,35 @@ export interface ApprovalTemplateDetailDTO extends ApprovalTemplateListItemDTO {
   approvalGraph: ApprovalGraph
 }
 
+export type ApprovalFormExternalReferenceKind =
+  | 'fwb_mapping'
+  | 'fwb_record_link'
+
+export interface ApprovalFormExternalReferenceDTO {
+  fieldId: string
+  kind: ApprovalFormExternalReferenceKind
+  /** Values-free dependency class; never contains a rule id or action payload. */
+  location:
+    | 'automation.write_approval_form_values.mappings.formFieldId'
+    | 'automation.write_approval_form_values.recordLinkFieldId'
+}
+
+/**
+ * Backend authority for the form command layer. Persistent ids come from every stored template
+ * version; browser-local ids remain session-owned and are deliberately not invented here.
+ */
+export interface ApprovalFormAuthoringContextDTO {
+  templateId: string
+  identityHistory: {
+    complete: true
+    persistentIds: string[]
+  }
+  referenceInventory: {
+    complete: true
+    references: ApprovalFormExternalReferenceDTO[]
+  }
+}
+
 export interface ApprovalTemplateVisibilityScope {
   type: ApprovalTemplateVisibilityType
   ids: string[]

--- a/packages/core-backend/tests/integration/approval-template-authoring-uat.api.test.ts
+++ b/packages/core-backend/tests/integration/approval-template-authoring-uat.api.test.ts
@@ -31,9 +31,14 @@ async function canListenOnEphemeralPort(): Promise<boolean> {
   })
 }
 
-async function authToken(baseUrl: string, userId: string): Promise<string> {
+async function authToken(
+  baseUrl: string,
+  userId: string,
+  roles = 'admin',
+  perms = '*:*',
+): Promise<string> {
   const response = await realFetch(
-    `${baseUrl}/api/auth/dev-token?userId=${encodeURIComponent(userId)}&roles=admin&perms=${encodeURIComponent('*:*')}`,
+    `${baseUrl}/api/auth/dev-token?userId=${encodeURIComponent(userId)}&roles=${encodeURIComponent(roles)}&perms=${encodeURIComponent(perms)}`,
   )
   expect(response.status).toBe(200)
   const payload = await response.json() as { token: string }
@@ -97,6 +102,7 @@ describeIfDatabase('Approval template authoring MVP — operator UAT (real DB, n
   let requesterToken = ''
   const createdTemplateIds = new Set<string>()
   const createdApprovalIds = new Set<string>()
+  const createdAutomationRuleIds = new Set<string>()
 
   beforeAll(async () => {
     const canListen = await canListenOnEphemeralPort()
@@ -135,6 +141,10 @@ describeIfDatabase('Approval template authoring MVP — operator UAT (real DB, n
       )
       const approvalIds = [...createdApprovalIds]
       const templateIds = [...createdTemplateIds]
+      const automationRuleIds = [...createdAutomationRuleIds]
+      if (automationRuleIds.length > 0) {
+        await pool.query('DELETE FROM automation_rules WHERE id = ANY($1::text[])', [automationRuleIds])
+      }
       if (approvalIds.length > 0) {
         await pool.query('DELETE FROM approval_records WHERE instance_id = ANY($1::text[])', [approvalIds])
         await pool.query('DELETE FROM approval_assignments WHERE instance_id = ANY($1::text[])', [approvalIds])
@@ -707,5 +717,177 @@ describeIfDatabase('Approval template authoring MVP — operator UAT (real DB, n
       [created.id],
     )
     expect(versions.rows.map((row) => row.version)).toEqual([1, 2, 3])
+  })
+
+  it('serves complete form identity/reference authority and blocks publishing a deleted FWB field', async () => {
+    const graph = {
+      nodes: [
+        { key: 'start', type: 'start', config: {} },
+        {
+          key: 'approval_1',
+          type: 'approval',
+          config: {
+            assigneeSources: [{ kind: 'requester' }],
+            approvalMode: 'single',
+            emptyAssigneePolicy: 'error',
+          },
+        },
+        { key: 'end', type: 'end', config: {} },
+      ],
+      edges: [
+        { key: 'e1', source: 'start', target: 'approval_1' },
+        { key: 'e2', source: 'approval_1', target: 'end' },
+      ],
+    }
+    const createResp = await jsonRequest(baseUrl, '/api/approval-templates', adminToken, {
+      method: 'POST',
+      body: {
+        key: `uat-authoring-context-${Date.now()}`,
+        name: 'UAT Authoring Context',
+        visibilityScope: { type: 'all', ids: [] },
+        formSchema: {
+          fields: [
+            { id: 'live_text', type: 'text', label: 'Live' },
+            { id: 'retired_top', type: 'text', label: 'Retired' },
+            {
+              id: 'retired_detail',
+              type: 'detail',
+              label: 'Retired detail',
+              columns: [{ id: 'retired_detail_column', type: 'text', label: 'Retired column' }],
+            },
+          ],
+        },
+        approvalGraph: graph,
+      },
+    })
+    expect(createResp.status).toBe(201)
+    const created = await createResp.json() as { id: string; latestVersionId: string }
+    createdTemplateIds.add(created.id)
+
+    const updateResp = await jsonRequest(baseUrl, `/api/approval-templates/${created.id}`, adminToken, {
+      method: 'PATCH',
+      body: {
+        formSchema: { fields: [{ id: 'live_text', type: 'text', label: 'Live' }] },
+      },
+    })
+    expect(updateResp.status).toBe(200)
+
+    const pool = poolManager.get()
+    const disabledRuleId = `uat_ctx_disabled_${Date.now()}`
+    const nestedRuleId = `uat_ctx_nested_${Date.now()}`
+    createdAutomationRuleIds.add(disabledRuleId)
+    createdAutomationRuleIds.add(nestedRuleId)
+    await pool.query(
+      `INSERT INTO automation_rules
+         (id, sheet_id, name, trigger_type, trigger_config, action_type, action_config, enabled, actions, created_by)
+       VALUES
+         ($1, $2, 'disabled FWB', 'approval.completed', $3::jsonb,
+          'write_approval_form_values', $4::jsonb, FALSE, NULL, 'uat-admin'),
+         ($5, $2, 'nested FWB', 'approval.completed', $3::jsonb,
+          'condition_branch', '{}'::jsonb, TRUE, $6::jsonb, 'uat-admin')`,
+      [
+        disabledRuleId,
+        `uat_ctx_sheet_${Date.now()}`,
+        JSON.stringify({ templateId: created.id }),
+        JSON.stringify({
+          sourceTemplateVersionId: created.latestVersionId,
+          mappings: [{ formFieldId: 'retired_top', targetFieldId: 'private_target_value' }],
+        }),
+        nestedRuleId,
+        JSON.stringify([{
+          type: 'condition_branch',
+          config: {
+            branches: [{
+              key: 'yes',
+              actions: [{
+                type: 'write_approval_form_values',
+                config: {
+                  sourceTemplateVersionId: created.latestVersionId,
+                  mappings: [{ formFieldId: 'live_text', targetFieldId: 'another_private_target' }],
+                  recordLinkFieldId: 'retired_detail_column',
+                },
+              }],
+            }],
+          },
+        }]),
+      ],
+    )
+
+    const readerToken = await authToken(baseUrl, 'uat-authoring-context-reader', 'user', 'approvals:read')
+    const forbidden = await jsonRequest(
+      baseUrl,
+      `/api/approval-templates/${created.id}/form-authoring-context`,
+      readerToken,
+    )
+    expect(forbidden.status).toBe(403)
+
+    const contextResp = await jsonRequest(
+      baseUrl,
+      `/api/approval-templates/${created.id}/form-authoring-context`,
+      adminToken,
+    )
+    expect(contextResp.status).toBe(200)
+    const context = await contextResp.json() as {
+      templateId: string
+      identityHistory: { complete: boolean; persistentIds: string[] }
+      referenceInventory: {
+        complete: boolean
+        references: Array<{ fieldId: string; kind: string; location: string }>
+      }
+    }
+    expect(context.templateId).toBe(created.id)
+    expect(context.identityHistory).toEqual({
+      complete: true,
+      persistentIds: ['live_text', 'retired_detail', 'retired_detail_column', 'retired_top'],
+    })
+    expect(context.referenceInventory).toEqual({
+      complete: true,
+      references: [
+        {
+          fieldId: 'live_text',
+          kind: 'fwb_mapping',
+          location: 'automation.write_approval_form_values.mappings.formFieldId',
+        },
+        {
+          fieldId: 'retired_detail_column',
+          kind: 'fwb_record_link',
+          location: 'automation.write_approval_form_values.recordLinkFieldId',
+        },
+        {
+          fieldId: 'retired_top',
+          kind: 'fwb_mapping',
+          location: 'automation.write_approval_form_values.mappings.formFieldId',
+        },
+      ],
+    })
+    const serializedContext = JSON.stringify(context)
+    expect(serializedContext).not.toContain(disabledRuleId)
+    expect(serializedContext).not.toContain(nestedRuleId)
+    expect(serializedContext).not.toContain('private_target_value')
+    expect(serializedContext).not.toContain('another_private_target')
+
+    const rejectedPublish = await jsonRequest(
+      baseUrl,
+      `/api/approval-templates/${created.id}/publish`,
+      adminToken,
+      { method: 'POST', body: { policy: { allowRevoke: true } } },
+    )
+    expect(rejectedPublish.status).toBe(409)
+    const rejectedPayload = await rejectedPublish.json() as { error: { code: string; message: string } }
+    expect(rejectedPayload.error.code).toBe('APPROVAL_TEMPLATE_FORM_FIELD_REFERENCED')
+    expect(JSON.stringify(rejectedPayload)).not.toContain('retired_top')
+    expect(JSON.stringify(rejectedPayload)).not.toContain('retired_detail_column')
+    expect(JSON.stringify(rejectedPayload)).not.toContain(disabledRuleId)
+
+    await pool.query('DELETE FROM automation_rules WHERE id = ANY($1::text[])', [[disabledRuleId, nestedRuleId]])
+    createdAutomationRuleIds.delete(disabledRuleId)
+    createdAutomationRuleIds.delete(nestedRuleId)
+    const acceptedPublish = await jsonRequest(
+      baseUrl,
+      `/api/approval-templates/${created.id}/publish`,
+      adminToken,
+      { method: 'POST', body: { policy: { allowRevoke: true } } },
+    )
+    expect(acceptedPublish.status).toBe(200)
   })
 })

--- a/packages/core-backend/tests/unit/approval-form-authoring-context.test.ts
+++ b/packages/core-backend/tests/unit/approval-form-authoring-context.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest'
+import {
+  collectApprovalFormExternalReferences,
+  collectApprovalFormPersistentIds,
+  findMissingApprovalFormReferenceIds,
+} from '../../src/services/approval-form-authoring-context'
+
+describe('approval form authoring context', () => {
+  it('reserves top-level and detail-column ids across deleted historical fields', () => {
+    expect(collectApprovalFormPersistentIds([
+      {
+        fields: [
+          { id: 'retired_top', type: 'text' },
+          {
+            id: 'retired_detail',
+            type: 'detail',
+            columns: [{ id: 'retired_column', type: 'text' }],
+          },
+        ],
+      },
+      { fields: [{ id: 'current', type: 'text' }] },
+    ])).toEqual(['current', 'retired_column', 'retired_detail', 'retired_top'])
+  })
+
+  it('uses the shared action walker for disabled top-level and nested FWB references', () => {
+    const references = collectApprovalFormExternalReferences([
+      {
+        action_type: 'write_approval_form_values',
+        action_config: {
+          mappings: [{ formFieldId: 'retired_top', targetFieldId: 'private_target' }],
+        },
+        actions: null,
+      },
+      {
+        action_type: 'condition_branch',
+        action_config: {},
+        actions: [
+          {
+            type: 'condition_branch',
+            config: {
+              branches: [{
+                key: 'yes',
+                actions: [{
+                  type: 'write_approval_form_values',
+                  config: {
+                    mappings: [{ formFieldId: 'current', targetFieldId: 'another_private_target' }],
+                    recordLinkFieldId: 'record_link',
+                  },
+                }],
+              }],
+            },
+          },
+        ],
+      },
+    ])
+
+    expect(references).toEqual([
+      {
+        fieldId: 'current',
+        kind: 'fwb_mapping',
+        location: 'automation.write_approval_form_values.mappings.formFieldId',
+      },
+      {
+        fieldId: 'record_link',
+        kind: 'fwb_record_link',
+        location: 'automation.write_approval_form_values.recordLinkFieldId',
+      },
+      {
+        fieldId: 'retired_top',
+        kind: 'fwb_mapping',
+        location: 'automation.write_approval_form_values.mappings.formFieldId',
+      },
+    ])
+    expect(JSON.stringify(references)).not.toContain('private_target')
+  })
+
+  it('finds missing references against top-level and detail-column ids', () => {
+    const schema = {
+      fields: [
+        { id: 'current', type: 'text', label: 'Current' },
+        {
+          id: 'details',
+          type: 'detail',
+          label: 'Details',
+          columns: [{ id: 'detail_note', type: 'text', label: 'Note' }],
+        },
+      ],
+    } as const
+    expect(findMissingApprovalFormReferenceIds(schema, [
+      {
+        fieldId: 'detail_note',
+        kind: 'fwb_mapping',
+        location: 'automation.write_approval_form_values.mappings.formFieldId',
+      },
+      {
+        fieldId: 'gone',
+        kind: 'fwb_mapping',
+        location: 'automation.write_approval_form_values.mappings.formFieldId',
+      },
+    ])).toEqual(['gone'])
+  })
+})

--- a/packages/core-backend/tests/unit/approval-product-service.test.ts
+++ b/packages/core-backend/tests/unit/approval-product-service.test.ts
@@ -287,6 +287,11 @@ function commonApprovalClientMockResult(statement: string): { rows: unknown[]; r
   if (statement.startsWith('SELECT id FROM approval_templates WHERE')) {
     return { rows: [{ id: 'tpl-1' }], rowCount: 1 }
   }
+  // F2-a publish-time FWB reference rescan. Dedicated unit and real-DB route goldens own
+  // referenced-field refusal; unrelated publish tests retain the ordinary no-reference baseline.
+  if (statement.startsWith('SELECT action_type, action_config, actions FROM automation_rules')) {
+    return { rows: [], rowCount: 0 }
+  }
   return null
 }
 
@@ -2884,7 +2889,7 @@ describe('ApprovalProductService', () => {
         }
         if (statement.startsWith("UPDATE approval_template_versions SET status = 'published'")) return { rows: [{ ...version, status: 'published' }], rowCount: 1 }
         if (statement.startsWith("UPDATE approval_templates SET status = 'published'")) return { rows: [], rowCount: 1 }
-        { const epochResult = epochMockResult(statement); if (epochResult) return epochResult } throw new Error(`Unhandled query: ${statement}`)
+        { const commonResult = commonApprovalClientMockResult(statement); if (commonResult) return commonResult } throw new Error(`Unhandled query: ${statement}`)
       })
     }
 


### PR DESCRIPTION
## What
- route add, remove, and reorder through the pure form command algebra
- allocate non-reusable UUID-backed persistent identities and reserve every historical field/detail-column id
- add an admin-only, repeatable-read authoring context for identity history and values-free FWB reference inventory
- fail closed on unavailable, mismatched, or malformed authoring context while preserving reorder
- block publish in the same transaction when FWB still references a deleted field

## Verification
- required Web: 359 files, 4330 tests
- focused mounted/linear/main authoring: 105 tests
- backend context/product unit: 147 tests
- fresh PostgreSQL 15 full migration + real MetaSheetServer integration: 8 tests
- frontend `vue-tsc --noEmit`, backend `tsc --noEmit`, production web build
- mutation: neutered context-member validation makes the malformed-context test RED
- mutation: neutered publish reference gate changes expected 409 to 200 and makes the real-DB test RED

## Hold
Draft and stacked on #4696. No merge, deployment, UAT, or flag enablement is authorized.