### PR TITLE
feat(approval): author attachment fields behind flags

### DIFF
--- a/apps/web/src/approvals/approvalFormCommands.ts
+++ b/apps/web/src/approvals/approvalFormCommands.ts
@@ -1,7 +1,7 @@
 import type { DetailColumnDraft } from './detailField'
 import type {
-  AuthorableFieldType,
   FieldAuthoringDraft,
+  FormAuthoringFieldType,
   TemplateAuthoringDraft,
 } from './templateAuthoring'
 
@@ -83,6 +83,14 @@ export interface CompleteFormIdentityHistory {
   readonly localIds: readonly string[]
 }
 
+/**
+ * Capability is a command input rather than an inferred UI condition. This keeps
+ * attachment creation unavailable to every flag-OFF caller, including drag payloads.
+ */
+export interface FormAuthoringCapabilities {
+  readonly attachmentAuthoringEnabled?: boolean
+}
+
 export type FormCommandResult =
   | {
       ok: true
@@ -95,7 +103,7 @@ export type FormCommandResult =
       dependencies: readonly FormFieldDependency[]
     }
 
-const FIELD_LABELS: Record<AuthorableFieldType, string> = {
+const FIELD_LABELS: Record<FormAuthoringFieldType, string> = {
   text: '单行文本',
   textarea: '多行文本',
   number: '数字',
@@ -106,10 +114,11 @@ const FIELD_LABELS: Record<AuthorableFieldType, string> = {
   user: '人员',
   detail: '明细',
   'record-link': '关联记录',
+  attachment: '附件',
 }
 
-const AUTHORABLE_FIELD_TYPES = new Set<AuthorableFieldType>(
-  Object.keys(FIELD_LABELS) as AuthorableFieldType[],
+const FORM_AUTHORING_FIELD_TYPES = new Set<FormAuthoringFieldType>(
+  Object.keys(FIELD_LABELS) as FormAuthoringFieldType[],
 )
 
 function successful(
@@ -144,7 +153,7 @@ function nonBlank(value: unknown): value is string {
 }
 
 function isUsableIdentity(
-  fieldType: AuthorableFieldType,
+  fieldType: FormAuthoringFieldType,
   identity: FormFieldIdentity | undefined,
 ): identity is FormFieldIdentity {
   if (
@@ -213,12 +222,15 @@ function identityConflicts(
  */
 export function addFormField(
   draft: TemplateAuthoringDraft,
-  fieldType: AuthorableFieldType,
+  fieldType: FormAuthoringFieldType,
   identity: FormFieldIdentity,
   history: CompleteFormIdentityHistory,
   afterLocalId?: string,
+  capabilities: FormAuthoringCapabilities = {},
 ): FormCommandResult {
-  if (!AUTHORABLE_FIELD_TYPES.has(fieldType))
+  if (!FORM_AUTHORING_FIELD_TYPES.has(fieldType))
+    return rejected('unsupported_field_type')
+  if (fieldType === 'attachment' && capabilities.attachmentAuthoringEnabled !== true)
     return rejected('unsupported_field_type')
   if (!isUsableIdentity(fieldType, identity))
     return rejected('invalid_field_identity')

--- a/apps/web/src/approvals/components/ApprovalFieldInspector.vue
+++ b/apps/web/src/approvals/components/ApprovalFieldInspector.vue
@@ -42,6 +42,11 @@
           <el-option label="用户" value="user" />
           <el-option label="明细（子表单）" value="detail" />
           <el-option label="关联记录" value="record-link" />
+          <el-option
+            v-if="attachmentAuthoringEnabled"
+            label="附件"
+            value="attachment"
+          />
         </el-select>
       </el-form-item>
       <el-form-item label="占位文本">
@@ -307,6 +312,7 @@ const props = withDefaults(defineProps<{
   recordLinkCatalogLoading: boolean
   recordLinkCatalogLoaded: boolean
   recordLinkCatalogError: string
+  attachmentAuthoringEnabled: boolean
 }>(), {
   showHeading: true,
 })

--- a/apps/web/src/approvals/components/ApprovalFormBuilder.vue
+++ b/apps/web/src/approvals/components/ApprovalFormBuilder.vue
@@ -27,6 +27,7 @@
     <div v-if="workspaceEnabled" class="approval-form-builder__workspace">
       <ApprovalFormPalette
         :read-only="readOnly || !structuralMutationEnabled"
+        :attachment-authoring-enabled="attachmentAuthoringEnabled"
         @add="appendFieldOfType"
       />
 
@@ -186,6 +187,7 @@
           :record-link-catalog-loading="recordLinkCatalogLoading"
           :record-link-catalog-loaded="recordLinkCatalogLoaded"
           :record-link-catalog-error="recordLinkCatalogError"
+          :attachment-authoring-enabled="attachmentAuthoringEnabled"
           @retry-record-link-catalog="emit('retry-record-link-catalog')"
           @field-type-change="emit('field-type-change', $event)"
         />
@@ -230,6 +232,7 @@
           :record-link-catalog-loading="recordLinkCatalogLoading"
           :record-link-catalog-loaded="recordLinkCatalogLoaded"
           :record-link-catalog-error="recordLinkCatalogError"
+          :attachment-authoring-enabled="attachmentAuthoringEnabled"
           @retry-record-link-catalog="emit('retry-record-link-catalog')"
           @field-type-change="emit('field-type-change', $event)"
         />
@@ -243,7 +246,7 @@ import { computed, ref, watch } from 'vue'
 import { ArrowDown, ArrowUp, Delete, Plus, Rank } from '@element-plus/icons-vue'
 import ApprovalFieldInspector from './ApprovalFieldInspector.vue'
 import ApprovalFormPalette from './ApprovalFormPalette.vue'
-import type { AuthorableFieldType, FieldAuthoringDraft } from '../templateAuthoring'
+import type { FieldAuthoringDraft, FormAuthoringFieldType } from '../templateAuthoring'
 import {
   APPROVAL_FORM_FIELD_MOVE_MIME,
   APPROVAL_FORM_FIELD_TYPE_LABELS,
@@ -262,6 +265,7 @@ const props = defineProps<{
   recordLinkCatalogError: string
   structuralMutationEnabled: boolean
   structuralMutationReason: string
+  attachmentAuthoringEnabled: boolean
 }>()
 
 const fields = defineModel<FieldAuthoringDraft[]>('fields', { required: true })
@@ -269,7 +273,7 @@ const fields = defineModel<FieldAuthoringDraft[]>('fields', { required: true })
 const emit = defineEmits<{
   'retry-record-link-catalog': []
   'field-type-change': [field: FieldAuthoringDraft]
-  'add-field': [request: { type: AuthorableFieldType; insertionIndex: number }]
+  'add-field': [request: { type: FormAuthoringFieldType; insertionIndex: number }]
   'remove-field': [request: { localId: string }]
   'move-field': [request: { localId: string; targetIndex: number }]
 }>()
@@ -305,14 +309,15 @@ function selectField(localId: string): void {
   selectedFieldLocalId.value = localId
 }
 
-function requestAddField(type: AuthorableFieldType, index: number): void {
+function requestAddField(type: FormAuthoringFieldType, index: number): void {
   if (props.readOnly || !props.structuralMutationEnabled) return
+  if (type === 'attachment' && !props.attachmentAuthoringEnabled) return
   const insertionIndex = Math.max(0, Math.min(index, fields.value.length))
   emit('add-field', { type, insertionIndex })
   selectedFieldInsertionIndex.value = null
 }
 
-function appendFieldOfType(type: AuthorableFieldType): void {
+function appendFieldOfType(type: FormAuthoringFieldType): void {
   requestAddField(type, selectedFieldInsertionIndex.value ?? fields.value.length)
 }
 
@@ -373,7 +378,7 @@ function onFieldInsertionDrop(event: DragEvent, insertionIndex: number): void {
     resetFieldDragState()
     return
   }
-  const paletteType = readPaletteFieldType(event.dataTransfer)
+  const paletteType = readPaletteFieldType(event.dataTransfer, props.attachmentAuthoringEnabled)
   if (paletteType) {
     requestAddField(paletteType, insertionIndex)
     resetFieldDragState()

--- a/apps/web/src/approvals/components/ApprovalFormPalette.vue
+++ b/apps/web/src/approvals/components/ApprovalFormPalette.vue
@@ -33,6 +33,7 @@
 </template>
 
 <script setup lang="ts">
+import { computed } from "vue";
 import {
   Calendar,
   Checked,
@@ -42,26 +43,28 @@ import {
   EditPen,
   Grid,
   List,
+  Paperclip,
   Tickets,
   User,
 } from "@element-plus/icons-vue";
 import type { Component } from "vue";
-import type { AuthorableFieldType } from "../templateAuthoring";
+import type { FormAuthoringFieldType } from "../templateAuthoring";
 import {
   APPROVAL_FORM_FIELD_TYPE_LABELS,
   APPROVAL_FORM_PALETTE_MIME,
-  APPROVAL_FORM_PALETTE_TYPES,
+  approvalFormPaletteTypes,
 } from "../formPalette";
 
-defineProps<{
+const props = defineProps<{
   readOnly: boolean;
+  attachmentAuthoringEnabled: boolean;
 }>();
 
 const emit = defineEmits<{
-  add: [type: AuthorableFieldType];
+  add: [type: FormAuthoringFieldType];
 }>();
 
-const icons: Record<AuthorableFieldType, Component> = {
+const icons: Record<FormAuthoringFieldType, Component> = {
   text: EditPen,
   textarea: Document,
   number: Tickets,
@@ -72,15 +75,16 @@ const icons: Record<AuthorableFieldType, Component> = {
   user: User,
   detail: Grid,
   "record-link": Connection,
+  attachment: Paperclip,
 };
 
-const paletteItems = APPROVAL_FORM_PALETTE_TYPES.map((type) => ({
+const paletteItems = computed(() => approvalFormPaletteTypes(props.attachmentAuthoringEnabled).map((type) => ({
   type,
   label: APPROVAL_FORM_FIELD_TYPE_LABELS[type],
   icon: icons[type],
-}));
+})));
 
-function onDragStart(event: DragEvent, type: AuthorableFieldType) {
+function onDragStart(event: DragEvent, type: FormAuthoringFieldType) {
   if (!event.dataTransfer) return;
   event.dataTransfer.effectAllowed = "copy";
   event.dataTransfer.setData(APPROVAL_FORM_PALETTE_MIME, type);

--- a/apps/web/src/approvals/formPalette.ts
+++ b/apps/web/src/approvals/formPalette.ts
@@ -1,6 +1,7 @@
 import {
   AUTHORABLE_FIELD_TYPES,
   type AuthorableFieldType,
+  type FormAuthoringFieldType,
 } from "./templateAuthoring";
 
 export const APPROVAL_FORM_PALETTE_MIME =
@@ -9,7 +10,7 @@ export const APPROVAL_FORM_FIELD_MOVE_MIME =
   "application/x-metasheet-approval-field-index";
 
 export const APPROVAL_FORM_FIELD_TYPE_LABELS: Record<
-  AuthorableFieldType,
+  FormAuthoringFieldType,
   string
 > = {
   text: "单行文本",
@@ -22,6 +23,7 @@ export const APPROVAL_FORM_FIELD_TYPE_LABELS: Record<
   user: "用户",
   detail: "明细",
   "record-link": "关联记录",
+  attachment: "附件",
 };
 
 export const APPROVAL_FORM_PALETTE_TYPES: readonly AuthorableFieldType[] =
@@ -29,10 +31,23 @@ export const APPROVAL_FORM_PALETTE_TYPES: readonly AuthorableFieldType[] =
 
 const AUTHORABLE_FIELD_TYPE_SET = new Set<string>(AUTHORABLE_FIELD_TYPES);
 
+/** Attachment is opt-in even when the canvas itself is enabled. */
+export function approvalFormPaletteTypes(
+  attachmentAuthoringEnabled: boolean,
+): readonly FormAuthoringFieldType[] {
+  return attachmentAuthoringEnabled
+    ? [...APPROVAL_FORM_PALETTE_TYPES, "attachment"]
+    : APPROVAL_FORM_PALETTE_TYPES;
+}
+
 export function readPaletteFieldType(
   dataTransfer: DataTransfer | null,
-): AuthorableFieldType | null {
+  attachmentAuthoringEnabled = false,
+): FormAuthoringFieldType | null {
   const value = dataTransfer?.getData(APPROVAL_FORM_PALETTE_MIME) ?? "";
+  if (value === "attachment") {
+    return attachmentAuthoringEnabled ? "attachment" : null;
+  }
   return AUTHORABLE_FIELD_TYPE_SET.has(value)
     ? (value as AuthorableFieldType)
     : null;

--- a/apps/web/src/approvals/templateAuthoring.ts
+++ b/apps/web/src/approvals/templateAuthoring.ts
@@ -70,7 +70,13 @@ export { CC_TARGET_TYPES } from './ccEdit'
 export type { ApprovalNodeEdits, ApprovalNodeSourceEdit } from './approvalNodeEdit'
 export { placeholderRoleNodeKeys } from './approvalNodeEdit'
 
+/**
+ * The established authoring surface. Attachments deliberately stay out of this
+ * default set: they require an explicit attachment capability at the caller.
+ */
 export type AuthorableFieldType = Exclude<FormFieldType, 'attachment'>
+/** A top-level field type that the form-builder command algebra can carry. */
+export type FormAuthoringFieldType = AuthorableFieldType | 'attachment'
 export type ApprovalStepSourceKind = ApprovalAssigneeSource['kind']
 
 // Top-level authorable field types: the 8 leaf scalar types plus `detail` (repeatable
@@ -106,7 +112,7 @@ export interface FieldVisibilityDraft {
 export interface FieldAuthoringDraft {
   localId: string
   id: string
-  type: AuthorableFieldType
+  type: FormAuthoringFieldType
   label: string
   required: boolean
   placeholder: string
@@ -382,6 +388,10 @@ function isAuthorableFieldType(value: FormFieldType): value is AuthorableFieldTy
   return AUTHORABLE_FIELD_TYPES.includes(value as AuthorableFieldType)
 }
 
+function isFormAuthoringFieldType(value: FormFieldType): value is FormAuthoringFieldType {
+  return value === 'attachment' || isAuthorableFieldType(value)
+}
+
 function isNodeFieldAccess(value: unknown): value is NodeFieldAccess {
   return value === 'editable' || value === 'readonly' || value === 'hidden'
 }
@@ -415,8 +425,14 @@ export function setStepFieldPermission(
   return [...permissions, { fieldId, access }]
 }
 
-function fieldDraftFromField(field: FormField): FieldAuthoringDraft | null {
-  if (!isAuthorableFieldType(field.type)) return null
+function fieldDraftFromField(
+  field: FormField,
+  options: { attachmentAuthoringEnabled?: boolean },
+): FieldAuthoringDraft | null {
+  if (
+    !isAuthorableFieldType(field.type)
+    && !(field.type === 'attachment' && options.attachmentAuthoringEnabled === true)
+  ) return null
   const props = field.props && typeof field.props === 'object' ? field.props as Record<string, unknown> : {}
   return {
     localId: nextLocalId('field'),
@@ -725,8 +741,14 @@ function complexNodeConfigHasBackendDrop(node: ApprovalNode): boolean {
   }
 }
 
-export function unsupportedTemplateAuthoringReason(template: ApprovalTemplateDetailDTO): string | null {
-  const unsupportedField = template.formSchema.fields.find((field) => !isAuthorableFieldType(field.type))
+export function unsupportedTemplateAuthoringReason(
+  template: ApprovalTemplateDetailDTO,
+  options: { attachmentAuthoringEnabled?: boolean } = {},
+): string | null {
+  const unsupportedField = template.formSchema.fields.find((field) => (
+    !isFormAuthoringFieldType(field.type)
+    || (field.type === 'attachment' && options.attachmentAuthoringEnabled !== true)
+  ))
   if (unsupportedField) {
     return `包含暂不支持编辑的字段类型：${unsupportedField.label || '未命名字段'}`
   }
@@ -809,20 +831,26 @@ export function unsupportedTemplateAuthoringReason(template: ApprovalTemplateDet
  * linear steps editor. Complex graphs remain editable and save-preserved; only genuinely unknown
  * node config is blocked by `unsupportedTemplateAuthoringReason`.
  */
-export function graphReadOnlyReason(template: ApprovalTemplateDetailDTO): string | null {
-  if (unsupportedTemplateAuthoringReason(template)) return null
+export function graphReadOnlyReason(
+  template: ApprovalTemplateDetailDTO,
+  options: { attachmentAuthoringEnabled?: boolean } = {},
+): string | null {
+  if (unsupportedTemplateAuthoringReason(template, options)) return null
   if (!isComplexApprovalGraph(template.approvalGraph)) return null
   return '该模板已启用分支流程编辑：可在画布调整流程结构，并在辅助编辑模式编辑各节点配置。'
 }
 
-export function draftFromTemplate(template: ApprovalTemplateDetailDTO): TemplateAuthoringDraft {
+export function draftFromTemplate(
+  template: ApprovalTemplateDetailDTO,
+  options: { attachmentAuthoringEnabled?: boolean } = {},
+): TemplateAuthoringDraft {
   // G-1 anti-flatten keystone: a complex graph is captured VERBATIM and never projected to the
   // linear `steps` model. `buildApprovalGraph` re-emits it byte-identical, so load→save can not
   // drop or reorder its cc/condition/parallel nodes/edges/config.
   const complex = isComplexApprovalGraph(template.approvalGraph)
   const ordered = orderedLinearNodes(template.approvalGraph) ?? template.approvalGraph.nodes
   const fields = template.formSchema.fields
-    .map(fieldDraftFromField)
+    .map((field) => fieldDraftFromField(field, options))
     .filter((field): field is FieldAuthoringDraft => field !== null)
   // Skip the approval-only step projection for complex graphs — they round-trip via
   // `preservedGraph`, and projecting would discard the non-approval nodes (the flatten risk).
@@ -881,6 +909,11 @@ export function buildFormSchema(draft: TemplateAuthoringDraft): FormSchema {
       }
       if (!field.placeholder.trim()) {
         delete next.placeholder
+      }
+      // Existing attachment schemas commonly omit `required` when false. Preserve that
+      // byte shape on an untouched attachment instead of manufacturing `required:false`.
+      if (field.type === 'attachment' && field.required === false && field.original?.required === undefined) {
+        delete next.required
       }
       if (field.type === 'select' || field.type === 'multi-select') {
         next.options = parseOptionsText(field.optionsText)

--- a/apps/web/src/views/approval/TemplateAuthoringView.vue
+++ b/apps/web/src/views/approval/TemplateAuthoringView.vue
@@ -250,6 +250,7 @@
         v-show="activeAuthoringSection === 'fields'"
         v-model:fields="draft.fields"
         :workspace-enabled="canvasV2Enabled"
+        :attachment-authoring-enabled="attachmentAuthoringEnabled"
         :read-only="readOnly"
         :record-link-bases="recordLinkBases"
         :record-link-sheets="recordLinkSheets"
@@ -944,7 +945,10 @@ import {
   updateTemplate,
   type ApprovalRoutePreview,
 } from '../../approvals/api'
-import type { ApprovalTemplateFormAuthoringContextDTO } from '../../types/approval'
+import type {
+  ApprovalTemplateDetailDTO,
+  ApprovalTemplateFormAuthoringContextDTO,
+} from '../../types/approval'
 import { describeTemplateAuthoringError } from '../../approvals/templateAuthoringErrors'
 import { createRoutePreviewController } from '../../approvals/routePreviewController'
 import { routePreviewAssigneeSummary } from '../../approvals/routePreviewSummary'
@@ -990,7 +994,7 @@ import {
   approvalFormulaInsertOptions,
   parallelDynamicAssigneeConflicts,
   type ApprovalStepDraft,
-  type AuthorableFieldType,
+  type FormAuthoringFieldType,
   type ConditionBranchEdit,
   type ConditionNodeEdit,
   type ConditionRuleEdit,
@@ -1056,6 +1060,10 @@ const router = useRouter()
 const { canManageTemplates } = useApprovalPermissions()
 const { features: productFeatures } = useFeatureFlags()
 const canvasV2Enabled = computed(() => productFeatures.value.approvalCanvasV2 === true)
+// Attachment authoring is a separate rollout from the canvas. Neither flag implies the other.
+const attachmentAuthoringEnabled = computed(
+  () => canvasV2Enabled.value && productFeatures.value.approvalAttachments === true,
+)
 
 const loading = ref(false)
 const saving = ref(false)
@@ -1064,6 +1072,7 @@ const creatingPresetId = ref<CommonApprovalTemplatePresetId | null>(null)
 const loadError = ref<string | null>(null)
 const validationErrors = ref<string[]>([])
 const unsupportedReason = ref<string | null>(null)
+const loadedTemplateForAuthoring = ref<ApprovalTemplateDetailDTO | null>(null)
 // G-1: a COMPLEX (condition/parallel/cc/non-linear) graph renders read-only but is NOT
 // unsupported — the form/metadata stay editable and save preserves the graph verbatim.
 const graphReadOnlyMessage = ref<string | null>(null)
@@ -1077,6 +1086,14 @@ const formAuthoringContextLoading = ref(false)
 const formAuthoringContextError = ref('')
 const retiredFormPersistentIds = ref<string[]>([])
 const retiredFormLocalIds = ref<string[]>([])
+
+watch(attachmentAuthoringEnabled, (enabled, previous) => {
+  if (enabled === previous || !loadedTemplateForAuthoring.value) return
+  // A live capability flip cannot safely rehydrate an in-memory draft without risking a
+  // structural overwrite. Require a fresh load instead of changing the save surface in place.
+  unsupportedReason.value = '附件编辑能力已变更，请刷新后继续'
+  graphReadOnlyMessage.value = null
+})
 
 // FWB-0 Layer 2: typed base/sheet catalog for record-link authoring (IDs persist on the draft,
 // never shown as ordinary free-text labels). Loaded via MultitableApiClient listBases/listSheets.
@@ -2241,7 +2258,7 @@ function currentFormReferenceInventory(): CompleteFormReferenceInventory | undef
   return formAuthoringContext.value?.referenceInventory
 }
 
-function newFormFieldIdentity(type: AuthorableFieldType): FormFieldIdentity {
+function newFormFieldIdentity(type: FormAuthoringFieldType): FormFieldIdentity {
   const fieldToken = globalThis.crypto.randomUUID().replace(/-/g, '')
   const identity: FormFieldIdentity = {
     persistentId: `field_${fieldToken}`,
@@ -2280,7 +2297,7 @@ function acceptFormCommand(result: FormCommandResult, announcement: string): boo
   return true
 }
 
-function onAddFormField(request: { type: AuthorableFieldType; insertionIndex: number }): void {
+function onAddFormField(request: { type: FormAuthoringFieldType; insertionIndex: number }): void {
   const history = currentFormIdentityHistory()
   if (!history) {
     acceptFormCommand(
@@ -2291,7 +2308,14 @@ function onAddFormField(request: { type: AuthorableFieldType; insertionIndex: nu
   }
   const identity = newFormFieldIdentity(request.type)
   const before = draft.value.fields.slice()
-  let result = addFormField(draft.value, request.type, identity, history)
+  let result = addFormField(
+    draft.value,
+    request.type,
+    identity,
+    history,
+    undefined,
+    { attachmentAuthoringEnabled: attachmentAuthoringEnabled.value },
+  )
   if (result.ok && request.insertionIndex < before.length) {
     result = moveFormField(
       result.draft,
@@ -2446,6 +2470,7 @@ async function loadTemplateForEdit() {
     formAuthoringContext.value = null
     formAuthoringContextError.value = ''
     unsupportedReason.value = null
+    loadedTemplateForAuthoring.value = null
     graphReadOnlyMessage.value = null
     snapshotDraft()
     return
@@ -2454,9 +2479,16 @@ async function loadTemplateForEdit() {
   loadError.value = null
   try {
     const template = await getTemplate(templateId.value)
-    unsupportedReason.value = unsupportedTemplateAuthoringReason(template)
-    graphReadOnlyMessage.value = graphReadOnlyReason(template)
-    draft.value = draftFromTemplate(template)
+    loadedTemplateForAuthoring.value = template
+    unsupportedReason.value = unsupportedTemplateAuthoringReason(template, {
+      attachmentAuthoringEnabled: attachmentAuthoringEnabled.value,
+    })
+    graphReadOnlyMessage.value = graphReadOnlyReason(template, {
+      attachmentAuthoringEnabled: attachmentAuthoringEnabled.value,
+    })
+    draft.value = draftFromTemplate(template, {
+      attachmentAuthoringEnabled: attachmentAuthoringEnabled.value,
+    })
     await loadFormAuthoringContext(template.id)
     syncAllStepOptions()
     syncAllApprovalNodeOptions()
@@ -2508,18 +2540,32 @@ async function persistDraft() {
   try {
     if (draft.value.templateId) {
       const updated = await updateTemplate(draft.value.templateId, buildUpdateTemplatePayload(draft.value))
-      draft.value = draftFromTemplate(updated)
+      draft.value = draftFromTemplate(updated, {
+        attachmentAuthoringEnabled: attachmentAuthoringEnabled.value,
+      })
       await loadFormAuthoringContext(updated.id)
-      unsupportedReason.value = unsupportedTemplateAuthoringReason(updated)
-      graphReadOnlyMessage.value = graphReadOnlyReason(updated)
+      loadedTemplateForAuthoring.value = updated
+      unsupportedReason.value = unsupportedTemplateAuthoringReason(updated, {
+        attachmentAuthoringEnabled: attachmentAuthoringEnabled.value,
+      })
+      graphReadOnlyMessage.value = graphReadOnlyReason(updated, {
+        attachmentAuthoringEnabled: attachmentAuthoringEnabled.value,
+      })
       snapshotDraft()
       return updated
     }
     const created = await createTemplate(buildCreateTemplatePayload(draft.value))
-    draft.value = draftFromTemplate(created)
+    draft.value = draftFromTemplate(created, {
+      attachmentAuthoringEnabled: attachmentAuthoringEnabled.value,
+    })
     await loadFormAuthoringContext(created.id)
-    unsupportedReason.value = unsupportedTemplateAuthoringReason(created)
-    graphReadOnlyMessage.value = graphReadOnlyReason(created)
+    loadedTemplateForAuthoring.value = created
+    unsupportedReason.value = unsupportedTemplateAuthoringReason(created, {
+      attachmentAuthoringEnabled: attachmentAuthoringEnabled.value,
+    })
+    graphReadOnlyMessage.value = graphReadOnlyReason(created, {
+      attachmentAuthoringEnabled: attachmentAuthoringEnabled.value,
+    })
     snapshotDraft() // before the route replace so the leave guard stays quiet
     await router.replace({ path: `/approval-templates/${created.id}/edit` })
     return created
@@ -2537,10 +2583,17 @@ async function createFromPreset(presetId: CommonApprovalTemplatePresetId) {
   loadError.value = null
   try {
     const created = await createTemplate(buildCommonApprovalTemplatePresetPayload(presetId))
-    draft.value = draftFromTemplate(created)
+    draft.value = draftFromTemplate(created, {
+      attachmentAuthoringEnabled: attachmentAuthoringEnabled.value,
+    })
     await loadFormAuthoringContext(created.id)
-    unsupportedReason.value = unsupportedTemplateAuthoringReason(created)
-    graphReadOnlyMessage.value = graphReadOnlyReason(created)
+    loadedTemplateForAuthoring.value = created
+    unsupportedReason.value = unsupportedTemplateAuthoringReason(created, {
+      attachmentAuthoringEnabled: attachmentAuthoringEnabled.value,
+    })
+    graphReadOnlyMessage.value = graphReadOnlyReason(created, {
+      attachmentAuthoringEnabled: attachmentAuthoringEnabled.value,
+    })
     syncAllStepOptions()
     syncAllApprovalNodeOptions()
     syncAllCcOptions()

--- a/apps/web/tests/approval-form-commands.test.ts
+++ b/apps/web/tests/approval-form-commands.test.ts
@@ -180,6 +180,33 @@ describe('approvalFormCommands - add', () => {
     ).toMatchObject({ ok: false, reason: 'target_not_found' })
   })
 
+  it('requires an explicit attachment authoring capability before it creates an attachment field', () => {
+    const source = draftWith([field(1)])
+    expect(
+      addFormField(source, 'attachment', identity(2), EMPTY_IDENTITY_HISTORY),
+    ).toMatchObject({ ok: false, reason: 'unsupported_field_type' })
+
+    const enabled = addFormField(
+      source,
+      'attachment',
+      identity(2),
+      EMPTY_IDENTITY_HISTORY,
+      undefined,
+      { attachmentAuthoringEnabled: true },
+    )
+    assertOk(enabled)
+    expect(enabled.draft.fields.at(-1)).toMatchObject({
+      id: 'new_field_2',
+      type: 'attachment',
+      label: '附件',
+      required: false,
+      placeholder: '',
+      detailColumns: [],
+      recordLinkBaseId: '',
+      recordLinkSheetId: '',
+    })
+  })
+
   it('rejects blank and field/detail-column identity collisions before it changes the draft', () => {
     const source = draftWith([
       field(1, {

--- a/apps/web/tests/approval-form-palette.spec.ts
+++ b/apps/web/tests/approval-form-palette.spec.ts
@@ -4,6 +4,7 @@ import {
   APPROVAL_FORM_FIELD_TYPE_LABELS,
   APPROVAL_FORM_PALETTE_MIME,
   APPROVAL_FORM_PALETTE_TYPES,
+  approvalFormPaletteTypes,
   readMovedFieldIndex,
   readPaletteFieldType,
 } from "../src/approvals/formPalette";
@@ -19,8 +20,13 @@ describe("approval form palette drag payload", () => {
   it("derives the rendered palette from the schema authoring allowlist", () => {
     expect(APPROVAL_FORM_PALETTE_TYPES).toEqual(AUTHORABLE_FIELD_TYPES);
     expect(Object.keys(APPROVAL_FORM_FIELD_TYPE_LABELS).sort()).toEqual(
-      [...AUTHORABLE_FIELD_TYPES].sort(),
+      [...AUTHORABLE_FIELD_TYPES, "attachment"].sort(),
     );
+    expect(approvalFormPaletteTypes(false)).toEqual(AUTHORABLE_FIELD_TYPES);
+    expect(approvalFormPaletteTypes(true)).toEqual([
+      ...AUTHORABLE_FIELD_TYPES,
+      "attachment",
+    ]);
   });
 
   it("accepts only field types supported by the existing authoring schema", () => {
@@ -38,6 +44,14 @@ describe("approval form palette drag payload", () => {
         }),
       ),
     ).toBeNull();
+    expect(
+      readPaletteFieldType(
+        transfer({
+          [APPROVAL_FORM_PALETTE_MIME]: "attachment",
+        }),
+        true,
+      ),
+    ).toBe("attachment");
     expect(
       readPaletteFieldType(
         transfer({

--- a/apps/web/tests/approval-template-authoring-canvas-inspector.spec.ts
+++ b/apps/web/tests/approval-template-authoring-canvas-inspector.spec.ts
@@ -63,7 +63,7 @@ vi.mock('../src/approvals/permissions', () => ({
   }),
 }))
 
-const featureFlags = ref({ approvalCanvasV2: true })
+const featureFlags = ref({ approvalCanvasV2: true, approvalAttachments: false })
 vi.mock('../src/stores/featureFlags', () => ({
   useFeatureFlags: () => ({
     features: featureFlags,
@@ -429,7 +429,7 @@ describe('Canvas V2 Slice A — canvas inspector', () => {
   beforeEach(() => {
     routeParams = {}
     canManageTemplates.value = true
-    featureFlags.value.approvalCanvasV2 = true
+    featureFlags.value = { approvalCanvasV2: true, approvalAttachments: false }
     createTemplateSpy.mockReset()
     updateTemplateSpy.mockReset()
     publishTemplateSpy.mockReset()
@@ -540,6 +540,94 @@ describe('Canvas V2 Slice A — canvas inspector', () => {
     ])
     expect(container!.querySelector('[data-testid="approval-form-builder-status"]')?.textContent)
       .toContain('第 2 位')
+  })
+
+  it('offers and saves an attachment field only when both Canvas V2 and attachments are enabled', async () => {
+    featureFlags.value = { approvalCanvasV2: true, approvalAttachments: true }
+    routeParams = { id: 'tpl_attachment_authoring_enabled' }
+    getTemplateSpy.mockResolvedValue(buildTemplate({ id: routeParams.id }))
+    await mountView()
+    await flushUi()
+
+    ;(container!.querySelector('[data-testid="approval-template-section-fields"]') as HTMLButtonElement).click()
+    await flushUi()
+    const attachmentPaletteItem = container!.querySelector(
+      '[data-testid="approval-form-palette-attachment"]',
+    ) as HTMLButtonElement
+    expect(attachmentPaletteItem).not.toBeNull()
+    attachmentPaletteItem.click()
+    await flushUi()
+
+    ;(container!.querySelector('[data-testid="approval-template-save-button"]') as HTMLButtonElement).click()
+    await flushUi()
+    const payload = updateTemplateSpy.mock.calls.at(-1)?.[1] as {
+      formSchema: { fields: Array<Record<string, unknown>> }
+    }
+    expect(payload.formSchema.fields.at(-1)).toEqual(expect.objectContaining({
+      type: 'attachment',
+      label: '附件',
+    }))
+    expect(payload.formSchema.fields.at(-1)).not.toHaveProperty('required')
+    expect(payload.formSchema.fields.at(-1)).not.toHaveProperty('props')
+    expect(payload.formSchema.fields.at(-1)).not.toHaveProperty('options')
+    expect(payload.formSchema.fields.at(-1)).not.toHaveProperty('columns')
+  })
+
+  it.each([
+    [false, false],
+    [false, true],
+    [true, false],
+  ])('keeps attachment templates fail-closed when Canvas=%s and attachments=%s', async (canvas, attachments) => {
+    featureFlags.value = { approvalCanvasV2: canvas, approvalAttachments: attachments }
+    routeParams = { id: `tpl_attachment_authoring_${canvas}_${attachments}` }
+    getTemplateSpy.mockResolvedValue(buildTemplate({
+      id: routeParams.id,
+      formSchema: { fields: [{ id: 'file', type: 'attachment', label: '附件' }] },
+    }))
+    await mountView()
+    await flushUi()
+
+    ;(container!.querySelector('[data-testid="approval-template-section-fields"]') as HTMLButtonElement).click()
+    await flushUi()
+    expect(container!.querySelector('[data-testid="approval-template-unsupported-alert"]')).not.toBeNull()
+    expect(
+      container!.querySelector('[data-testid="approval-template-save-button"]') as HTMLButtonElement,
+    ).toHaveProperty('disabled', true)
+    expect(container!.querySelector('[data-testid="approval-form-palette-attachment"]')).toBeNull()
+    ;(container!.querySelector('[data-testid="approval-template-save-button"]') as HTMLButtonElement).click()
+    await flushUi()
+    expect(updateTemplateSpy).not.toHaveBeenCalled()
+  })
+
+  it('preserves an existing attachment field when both authoring flags are enabled', async () => {
+    featureFlags.value = { approvalCanvasV2: true, approvalAttachments: true }
+    routeParams = { id: 'tpl_attachment_authoring_preserve' }
+    const template = buildTemplate({
+      id: routeParams.id,
+      formSchema: {
+        fields: [
+          { id: 'file', type: 'attachment', label: '凭证', required: true, placeholder: '选择文件' },
+          { id: 'amount', type: 'number', label: '金额' },
+        ],
+      },
+    })
+    getTemplateSpy.mockResolvedValue(template)
+    await mountView()
+    await flushUi()
+
+    ;(container!.querySelector('[data-testid="approval-template-section-fields"]') as HTMLButtonElement).click()
+    await flushUi()
+    expect(container!.querySelector('[data-testid="approval-template-unsupported-alert"]')).toBeNull()
+    expect(
+      container!.querySelector('[data-testid="approval-form-field-list"]')?.textContent,
+    ).toContain('附件')
+
+    ;(container!.querySelector('[data-testid="approval-template-save-button"]') as HTMLButtonElement).click()
+    await flushUi()
+    const payload = updateTemplateSpy.mock.calls.at(-1)?.[1] as {
+      formSchema: { fields: Array<Record<string, unknown>> }
+    }
+    expect(payload.formSchema.fields[0]).toEqual(template.formSchema.fields[0])
   })
 
   it('keeps forward, backward, and adjacent insertion-slot reorders exact', async () => {

--- a/apps/web/tests/approvalTemplateAuthoring.spec.ts
+++ b/apps/web/tests/approvalTemplateAuthoring.spec.ts
@@ -397,16 +397,21 @@ describe('approval template authoring helpers', () => {
     expect((node.config as ApprovalNodeConfig).fieldPermissions).toEqual([{ fieldId: 'amount', access: 'hidden' }])
   })
 
-  it('blocks existing attachment fields because the MVP has no upload runtime', () => {
-    const reason = unsupportedTemplateAuthoringReason(buildTemplate({
+  it('keeps existing attachment fields fail-closed until attachment authoring is explicitly enabled', () => {
+    const template = buildTemplate({
       formSchema: {
         fields: [
           { id: 'file', type: 'attachment', label: '附件' },
         ],
       },
-    }))
+    })
+    const reason = unsupportedTemplateAuthoringReason(template)
 
     expect(reason).toContain('暂不支持编辑的字段类型')
+    expect(unsupportedTemplateAuthoringReason(template, { attachmentAuthoringEnabled: true })).toBeNull()
+    expect(draftFromTemplate(template).fields).toMatchObject([{ type: 'text' }])
+    expect(buildFormSchema(draftFromTemplate(template, { attachmentAuthoringEnabled: true })).fields)
+      .toEqual(template.formSchema.fields)
   })
 
   it('keeps raw field and node identifiers out of author-facing refusal and validation messages', () => {


### PR DESCRIPTION
## Summary
- expose the existing attachment field contract in the form palette and inspector only when both Canvas V2 and approval attachments are enabled
- route attachment creation through the F2 form command layer, preserving flag-off fail-closed behavior and existing attachment schema shape
- cover the four flag quadrants, forged drag/command inputs, new attachment save, and existing attachment round-trip

## Verification
- `pnpm exec vitest run approval-form-commands approval-form-palette approval-template-authoring-canvas-inspector approvalTemplateAuthoring --reporter=dot` (123/123)
- `pnpm exec vue-tsc --noEmit`
- `pnpm build`
- required Web runner (359 files / 4335 tests)
- three discriminating mutations: command capability, page double gate, and flag-off draft projection all RED

## Boundaries
- Draft, stacked on #4699
- no attachment runtime/backend changes
- no flag enablement, deployment, or UAT
