### PR TITLE
fix(approval): harden responsive designer layout

### DIFF
--- a/apps/web/src/approvals/components/ApprovalFieldInspector.vue
+++ b/apps/web/src/approvals/components/ApprovalFieldInspector.vue
@@ -270,6 +270,7 @@
             :model-value="field.visibility.dependsOnFieldId"
             :disabled="readOnly"
             class="ms-w-200"
+            placeholder="无（始终显示）"
             data-testid="approval-field-visibility-depends"
             @update:model-value="updateVisibilityString('dependsOnFieldId', $event)"
           >

--- a/apps/web/src/approvals/components/ApprovalFlowCanvas.vue
+++ b/apps/web/src/approvals/components/ApprovalFlowCanvas.vue
@@ -11,7 +11,12 @@
       >
         <ul class="template-authoring__error-list"><li v-for="issue in canvasValidity" :key="issue">{{ issue }}</li></ul>
       </el-alert>
-      <div class="template-authoring__canvas-toolbar" data-testid="approval-canvas-toolbar">
+      <div
+        class="template-authoring__canvas-toolbar"
+        role="toolbar"
+        aria-label="画布视图"
+        data-testid="approval-canvas-toolbar"
+      >
         <el-button-group>
           <el-button :icon="ZoomOut" title="缩小画布" aria-label="缩小画布" data-testid="approval-canvas-zoom-out" @click="emit('zoom-out')" />
           <el-button
@@ -745,6 +750,35 @@ defineExpose({ canvasViewportRef, canvasInspectorRef })
 @media (max-width: 560px) {
   .template-authoring__canvas-minimap {
     display: none;
+  }
+  .template-authoring__canvas-toolbar {
+    flex-wrap: wrap;
+    justify-content: flex-start;
+  }
+  .template-authoring__canvas-toolbar :deep(.el-button-group) {
+    display: flex;
+    flex: 1 1 220px;
+  }
+  .template-authoring__canvas-toolbar :deep(.el-button-group .el-button) {
+    flex: 1 1 0;
+  }
+  .template-authoring__canvas-toolbar :deep(.el-button) {
+    min-width: 44px;
+    min-height: 44px;
+    margin-left: 0;
+  }
+  .template-authoring__canvas-inspector-header :deep(.el-button) {
+    min-height: 44px;
+  }
+  .template-authoring__canvas-node-actions :deep(.el-button),
+  .template-authoring__canvas-branch-actions :deep(.el-button) {
+    min-width: 40px;
+    min-height: 40px;
+    margin-left: 0;
+  }
+  .template-authoring__canvas-branch-handle {
+    width: 40px;
+    height: 40px;
   }
 }
 .template-authoring__canvas-inspector {

--- a/apps/web/src/approvals/components/ApprovalFlowCanvas.vue
+++ b/apps/web/src/approvals/components/ApprovalFlowCanvas.vue
@@ -747,40 +747,6 @@ defineExpose({ canvasViewportRef, canvasInspectorRef })
   stroke: var(--el-color-primary);
   stroke-width: 1.5;
 }
-@media (max-width: 560px) {
-  .template-authoring__canvas-minimap {
-    display: none;
-  }
-  .template-authoring__canvas-toolbar {
-    flex-wrap: wrap;
-    justify-content: flex-start;
-  }
-  .template-authoring__canvas-toolbar :deep(.el-button-group) {
-    display: flex;
-    flex: 1 1 220px;
-  }
-  .template-authoring__canvas-toolbar :deep(.el-button-group .el-button) {
-    flex: 1 1 0;
-  }
-  .template-authoring__canvas-toolbar :deep(.el-button) {
-    min-width: 44px;
-    min-height: 44px;
-    margin-left: 0;
-  }
-  .template-authoring__canvas-inspector-header :deep(.el-button) {
-    min-height: 44px;
-  }
-  .template-authoring__canvas-node-actions :deep(.el-button),
-  .template-authoring__canvas-branch-actions :deep(.el-button) {
-    min-width: 40px;
-    min-height: 40px;
-    margin-left: 0;
-  }
-  .template-authoring__canvas-branch-handle {
-    width: 40px;
-    height: 40px;
-  }
-}
 .template-authoring__canvas-inspector {
   /* ~400px so ms-w-360 controls fit with body padding; stacks to 100% under 960px. */
   flex: 0 0 400px;
@@ -908,5 +874,47 @@ defineExpose({ canvasViewportRef, canvasInspectorRef })
 .template-authoring__error-list {
   margin: 6px 0 0;
   padding-left: 20px;
+}
+
+@media (max-width: 560px) {
+  .template-authoring__canvas-minimap {
+    display: none;
+  }
+  .template-authoring__canvas-toolbar {
+    flex-wrap: wrap;
+    justify-content: flex-start;
+  }
+  .template-authoring__canvas-toolbar :deep(.el-button-group) {
+    display: flex;
+    flex: 1 1 220px;
+  }
+  .template-authoring__canvas-toolbar :deep(.el-button-group .el-button) {
+    flex: 1 1 0;
+  }
+  .template-authoring__canvas-toolbar :deep(.el-button) {
+    min-width: 44px;
+    min-height: 44px;
+    margin-left: 0;
+  }
+  .template-authoring__canvas-inspector-header :deep(.el-button),
+  .template-authoring__canvas-inspector-body :deep(.el-button),
+  .template-authoring__canvas-branch-actions :deep(.el-button) {
+    min-width: 44px;
+    min-height: 44px;
+    margin-left: 0;
+  }
+  .template-authoring__canvas-node-actions :deep(.el-button),
+  .template-authoring__canvas-move-target {
+    min-width: 40px;
+    min-height: 40px;
+    margin-left: 0;
+  }
+  .template-authoring__canvas-branch-row {
+    grid-template-columns: 44px minmax(0, 1fr) auto;
+  }
+  .template-authoring__canvas-branch-handle {
+    width: 44px;
+    height: 44px;
+  }
 }
 </style>

--- a/apps/web/src/approvals/components/ApprovalFormBuilder.vue
+++ b/apps/web/src/approvals/components/ApprovalFormBuilder.vue
@@ -659,7 +659,7 @@ function onFieldKeyboardReorder(event: KeyboardEvent, index: number): void {
 
 @media (max-width: 1280px) {
   .approval-form-builder__workspace {
-    grid-template-columns: minmax(180px, 210px) minmax(300px, 1fr);
+    grid-template-columns: minmax(220px, 240px) minmax(300px, 1fr);
   }
 
   .approval-form-builder__inspector-shell {

--- a/apps/web/src/approvals/components/ApprovalFormBuilder.vue
+++ b/apps/web/src/approvals/components/ApprovalFormBuilder.vue
@@ -453,7 +453,7 @@ function onFieldKeyboardReorder(event: KeyboardEvent, index: number): void {
 
 .approval-form-builder__workspace {
   display: grid;
-  grid-template-columns: minmax(190px, 220px) minmax(300px, 1fr) minmax(300px, 380px);
+  grid-template-columns: minmax(220px, 240px) minmax(300px, 1fr) minmax(300px, 380px);
   align-items: start;
   gap: 16px;
 }

--- a/apps/web/src/approvals/components/ApprovalFormPalette.vue
+++ b/apps/web/src/approvals/components/ApprovalFormPalette.vue
@@ -155,7 +155,9 @@ function onDragStart(event: DragEvent, type: FormAuthoringFieldType) {
     position: static;
     grid-row: auto;
   }
+}
 
+@media (max-width: 860px) {
   .approval-form-palette__items {
     grid-template-columns: repeat(5, minmax(0, 1fr));
   }

--- a/apps/web/src/approvals/components/ApprovalFormPalette.vue
+++ b/apps/web/src/approvals/components/ApprovalFormPalette.vue
@@ -146,8 +146,8 @@ function onDragStart(event: DragEvent, type: FormAuthoringFieldType) {
 
 .approval-form-palette__item span {
   min-width: 0;
-  overflow-wrap: anywhere;
   font-size: 13px;
+  white-space: nowrap;
 }
 
 @media (max-width: 1024px) {

--- a/apps/web/src/approvals/components/ApprovalGraphNodeConfigEditor.vue
+++ b/apps/web/src/approvals/components/ApprovalGraphNodeConfigEditor.vue
@@ -801,4 +801,21 @@ const { node } = toRefs(props)
     grid-template-columns: 1fr;
   }
 }
+
+@media (max-width: 560px) {
+  .approval-node-config-editor :deep(.el-button),
+  .approval-node-config-editor :deep(.el-checkbox),
+  .approval-node-config-editor :deep(.el-input__wrapper),
+  .approval-node-config-editor :deep(.el-select__wrapper),
+  .approval-node-config-editor :deep(.el-input-number),
+  .approval-node-config-editor :deep(.el-textarea__inner) {
+    min-height: 44px;
+  }
+
+  .approval-node-config-editor :deep(.el-input-number__decrease),
+  .approval-node-config-editor :deep(.el-input-number__increase) {
+    width: 44px;
+    height: 44px;
+  }
+}
 </style>

--- a/apps/web/src/approvals/components/ApprovalRoutePreviewPanel.vue
+++ b/apps/web/src/approvals/components/ApprovalRoutePreviewPanel.vue
@@ -261,4 +261,21 @@ function setField(fieldId: string, value: unknown): void {
   border-left: 2px solid var(--el-color-primary-light-5);
   font-size: 12px;
 }
+
+@media (max-width: 560px) {
+  .approval-route-preview-panel :deep(.el-button),
+  .approval-route-preview-panel :deep(.el-input__wrapper),
+  .approval-route-preview-panel :deep(.el-select__wrapper),
+  .approval-route-preview-panel :deep(.el-input-number),
+  .approval-route-preview-panel :deep(.el-textarea__inner),
+  .approval-route-preview-panel :deep(.el-collapse-item__header) {
+    min-height: 44px;
+  }
+
+  .approval-route-preview-panel :deep(.el-input-number__decrease),
+  .approval-route-preview-panel :deep(.el-input-number__increase) {
+    width: 44px;
+    height: 44px;
+  }
+}
 </style>

--- a/apps/web/src/approvals/components/ApprovalVersionWorkspace.vue
+++ b/apps/web/src/approvals/components/ApprovalVersionWorkspace.vue
@@ -40,7 +40,7 @@
               {{ versionStatusLabel(summary.status) }}
             </el-tag>
           </span>
-          <span>{{ formatDate(summary.updatedAt) }}</span>
+          <span data-testid="approval-version-timeline-date">{{ formatDate(summary.updatedAt) }}</span>
           <small>{{ summary.publishNote?.trim() || '未填写发布说明' }}</small>
           <small v-if="summary.restoredFromVersionId">
             由 {{ restoredSourceLabel(summary.restoredFromVersionId) }} 恢复

--- a/apps/web/src/approvals/components/ApprovalVersionWorkspace.vue
+++ b/apps/web/src/approvals/components/ApprovalVersionWorkspace.vue
@@ -743,6 +743,10 @@ function fieldTypeLabel(type: FormField['type']): string {
     padding: 10px 12px;
     border-top: 1px solid var(--el-border-color-lighter);
   }
+  :global(.approval-version-workspace-dialog .el-dialog__headerbtn) {
+    width: 44px;
+    height: 44px;
+  }
   .approval-version-workspace {
     grid-template-columns: 1fr;
     min-height: 0;
@@ -757,7 +761,12 @@ function fieldTypeLabel(type: FormField['type']): string {
   }
   .approval-version-workspace__current,
   .approval-version-workspace__version {
-    flex: 0 0 210px;
+    flex: 0 0 min(240px, calc(100vw - 48px));
+  }
+  .approval-version-workspace__version > span,
+  .approval-version-workspace__version > small {
+    overflow-wrap: anywhere;
+    white-space: normal;
   }
   .approval-version-workspace__graphs,
   .approval-version-workspace__details {
@@ -771,6 +780,18 @@ function fieldTypeLabel(type: FormField['type']): string {
     display: block;
     margin: 0 0 8px;
     text-align: left;
+  }
+}
+
+@media (max-width: 560px) {
+  .approval-version-workspace__timeline {
+    flex-direction: column;
+    overflow-x: visible;
+  }
+  .approval-version-workspace__current,
+  .approval-version-workspace__version {
+    flex: 0 0 auto;
+    width: 100%;
   }
 }
 </style>

--- a/apps/web/src/views/approval/TemplateAuthoringView.vue
+++ b/apps/web/src/views/approval/TemplateAuthoringView.vue
@@ -3682,7 +3682,7 @@ onUnmounted(() => {
 
 .template-authoring__validation-summary,
 .template-authoring__content {
-  scroll-margin-top: 124px;
+  scroll-margin-top: 140px;
 }
 
 .template-authoring__validation-summary:focus {
@@ -4031,6 +4031,9 @@ pre {
     grid-template-columns: 28px minmax(0, 1fr);
   }
 
+  .template-authoring__section-actions {
+    position: static;
+  }
 }
 
 @media (max-width: 760px) {
@@ -4059,12 +4062,30 @@ pre {
     width: 100%;
   }
 
+  .template-authoring__actions {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    align-items: stretch;
+  }
+
+  .template-authoring__actions > * {
+    min-width: 0;
+  }
+
+  .template-authoring__actions > span {
+    display: flex;
+  }
+
   .template-authoring__actions :deep(.el-button) {
-    flex: 1;
+    min-width: 0;
+    min-height: 40px;
+    margin-left: 0;
   }
 
   .template-authoring__steps {
-    top: 0;
+    position: static;
+    top: auto;
+    z-index: auto;
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
@@ -4081,9 +4102,6 @@ pre {
     min-height: 44px;
   }
 
-  .template-authoring__section-actions {
-    position: static;
-  }
 }
 
 .template-authoring__view-toggle {
@@ -4100,6 +4118,12 @@ pre {
   border: 1px solid var(--el-border-color-light);
   border-radius: 6px;
   background: var(--el-fill-color-light);
+}
+
+.template-authoring__mode-switch :deep(.el-button--primary) {
+  border-color: var(--el-color-primary);
+  background: var(--el-color-primary);
+  color: var(--el-color-white);
 }
 
 .template-authoring__tryrun-conditions {

--- a/apps/web/src/views/approval/TemplateAuthoringView.vue
+++ b/apps/web/src/views/approval/TemplateAuthoringView.vue
@@ -4016,9 +4016,9 @@ pre {
   }
 
   .template-authoring__steps {
-    position: sticky;
-    top: 108px;
-    z-index: 2;
+    position: static;
+    top: auto;
+    z-index: auto;
     grid-template-columns: repeat(4, minmax(0, 1fr));
   }
 
@@ -4103,6 +4103,11 @@ pre {
 
   .template-authoring__section-actions :deep(.el-button) {
     flex: 1;
+    min-height: 44px;
+  }
+
+  .template-authoring__canvas-inspector-header :deep(.el-button) {
+    min-width: 44px;
     min-height: 44px;
   }
 

--- a/apps/web/src/views/approval/TemplateAuthoringView.vue
+++ b/apps/web/src/views/approval/TemplateAuthoringView.vue
@@ -4007,6 +4007,10 @@ pre {
 }
 
 @media (max-width: 1024px) {
+  .template-authoring__header {
+    position: static;
+  }
+
   .template-authoring__workspace {
     grid-template-columns: 1fr;
   }

--- a/apps/web/verification/approval-designer.spec.ts
+++ b/apps/web/verification/approval-designer.spec.ts
@@ -26,6 +26,29 @@ async function openFormDesigner(page: Page) {
   await expect(page.getByTestId('approval-form-palette')).toBeVisible()
 }
 
+async function contrastRatio(page: Page, selector: string): Promise<number> {
+  return page.locator(selector).evaluate((element) => {
+    const parseRgb = (value: string) => {
+      const channels = value.match(/[\d.]+/g)?.slice(0, 3).map(Number)
+      if (!channels || channels.length !== 3) throw new Error(`unsupported color ${value}`)
+      return channels.map((channel) => {
+        const normalized = channel / 255
+        return normalized <= 0.04045
+          ? normalized / 12.92
+          : ((normalized + 0.055) / 1.055) ** 2.4
+      })
+    }
+    const luminance = (value: string) => {
+      const [red, green, blue] = parseRgb(value)
+      return 0.2126 * red + 0.7152 * green + 0.0722 * blue
+    }
+    const styles = window.getComputedStyle(element)
+    const foreground = luminance(styles.color)
+    const background = luminance(styles.backgroundColor)
+    return (Math.max(foreground, background) + 0.05) / (Math.min(foreground, background) + 0.05)
+  })
+}
+
 const versionGraph = {
   nodes: [
     { key: 'secret_start_key', type: 'start', name: '发起', config: {} },
@@ -114,6 +137,12 @@ test('approval form palette supports real drag, keyboard reorder, inspector edit
   await page.setViewportSize({ width: 1440, height: 900 })
   await openFormDesigner(page)
 
+  await expect(page.getByTestId('approval-field-visibility-depends')).toContainText('无（始终显示）')
+  const paletteLabelsFit = await page.locator('.approval-form-palette__item span').evaluateAll((elements) =>
+    elements.every((element) => element.scrollWidth <= element.clientWidth),
+  )
+  expect(paletteLabelsFit).toBe(true)
+
   await page.getByTestId('approval-form-palette-textarea').dragTo(
     page.getByTestId('approval-form-drop-slot-1'),
   )
@@ -140,6 +169,19 @@ test('approval form palette supports real drag, keyboard reorder, inspector edit
     /报销说明多行文本/,
     /字段 1单行文本/,
   ])
+
+  await page.mouse.move(0, 0)
+  await expect(page.locator('.el-popper[role="tooltip"]:visible')).toHaveCount(0)
+  const headerSeparation = await page.evaluate(() => {
+    const header = document.querySelector<HTMLElement>('.template-authoring__header')
+    const hint = document.querySelector<HTMLElement>('.approval-form-builder__header small')
+    if (!header || !hint) throw new Error('missing sticky header or form-builder hint')
+    return {
+      headerBottom: header.getBoundingClientRect().bottom,
+      hintTop: hint.getBoundingClientRect().top,
+    }
+  })
+  expect(headerSeparation.hintTop).toBeGreaterThanOrEqual(headerSeparation.headerBottom)
 
   await page.screenshot({
     path: 'verification-output/approval-designer-desktop.png',
@@ -238,8 +280,45 @@ test('approval route preview remains operable without horizontal overflow at a p
   })
 
   await page.goto(`${HARNESS}?mode=route-preview`)
+  const headerActionIds = [
+    'approval-template-undo',
+    'approval-template-redo',
+    'approval-template-route-preview-toggle',
+    'approval-template-version-workspace-button',
+    'approval-template-save-button',
+    'approval-template-publish-button',
+  ]
+  for (const testId of headerActionIds) {
+    const box = await page.getByTestId(testId).boundingBox()
+    expect(box, `${testId} must render`).not.toBeNull()
+    expect(box!.x, `${testId} left edge`).toBeGreaterThanOrEqual(0)
+    expect(box!.x + box!.width, `${testId} right edge`).toBeLessThanOrEqual(390)
+  }
   const toggle = page.getByTestId('approval-template-route-preview-toggle')
   await toggle.click()
+  const canvasToolbar = page.getByRole('toolbar', { name: '画布视图' })
+  await expect(canvasToolbar).toBeVisible()
+  for (const button of await canvasToolbar.getByRole('button').all()) {
+    const box = await button.boundingBox()
+    expect(box?.width).toBeGreaterThanOrEqual(44)
+    expect(box?.height).toBeGreaterThanOrEqual(44)
+  }
+  const nodeActionButtons = page.locator('.template-authoring__canvas-node-actions .el-button')
+  expect(await nodeActionButtons.count()).toBeGreaterThan(0)
+  for (const button of await nodeActionButtons.all()) {
+    const box = await button.boundingBox()
+    expect(box?.width).toBeGreaterThanOrEqual(40)
+    expect(box?.height).toBeGreaterThanOrEqual(40)
+  }
+  const canvasNodeBoxes = await page.getByTestId('approval-canvas-node').evaluateAll((nodes) => nodes
+    .map((node) => {
+      const rect = node.getBoundingClientRect()
+      return { top: rect.top, bottom: rect.bottom }
+    })
+    .sort((left, right) => left.top - right.top))
+  for (let index = 1; index < canvasNodeBoxes.length; index += 1) {
+    expect(canvasNodeBoxes[index].top).toBeGreaterThanOrEqual(canvasNodeBoxes[index - 1].bottom)
+  }
   const panel = page.getByTestId('approval-canvas-route-preview-panel')
   await expect(panel).toBeVisible()
   await panel.getByRole('spinbutton').fill('1200')
@@ -261,6 +340,19 @@ test('approval route preview remains operable without horizontal overflow at a p
   expect(layout.panel.right).toBeLessThanOrEqual(layout.viewportWidth)
   expect(layout.panel.top).toBeGreaterThanOrEqual(layout.canvas.bottom)
 
+  await panel.scrollIntoViewIfNeeded()
+  const navigationOverlap = await page.evaluate(() => {
+    const steps = document.querySelector<HTMLElement>('.template-authoring__steps')
+    const canvas = document.querySelector<HTMLElement>('[data-testid="approval-canvas-viewport"]')
+    if (!steps || !canvas) throw new Error('missing authoring navigation or canvas')
+    const a = steps.getBoundingClientRect()
+    const b = canvas.getBoundingClientRect()
+    const intersects = a.left < b.right && a.right > b.left && a.top < b.bottom && a.bottom > b.top
+    return { position: getComputedStyle(steps).position, intersects }
+  })
+  expect(navigationOverlap.position).toBe('static')
+  expect(navigationOverlap.intersects).toBe(false)
+
   await page.screenshot({
     path: 'verification-output/approval-route-preview-mobile.png',
     fullPage: true,
@@ -269,6 +361,46 @@ test('approval route preview remains operable without horizontal overflow at a p
   await page.getByTestId('approval-canvas-route-preview-close').click()
   await expect(panel).toHaveCount(0)
   await expect(toggle).toBeFocused()
+})
+
+test('approval designer remains contained at tablet and compact desktop viewports', async ({ page }) => {
+  for (const viewport of [
+    { width: 1280, height: 800 },
+    { width: 1024, height: 768 },
+  ]) {
+    await page.setViewportSize(viewport)
+    await openFormDesigner(page)
+    await page.getByRole('button', { name: '流程设计' }).click()
+    await expect(page.getByTestId('approval-authoring-mode-flow')).toHaveAttribute('aria-pressed', 'true')
+    await expect.poll(() => contrastRatio(page, '[data-testid="approval-authoring-mode-flow"]')).toBeGreaterThanOrEqual(4.5)
+
+    const geometry = await page.evaluate(() => {
+      const workspace = document.querySelector<HTMLElement>('[data-testid="approval-template-workspace-content"]')
+      const canvas = document.querySelector<HTMLElement>('[data-testid="approval-canvas-workspace"]')
+      const toolbar = document.querySelector<HTMLElement>('[data-testid="approval-canvas-toolbar"]')
+      const actions = document.querySelector<HTMLElement>('.template-authoring__section-actions')
+      if (!workspace || !canvas || !toolbar || !actions) throw new Error('missing designer surface')
+      return {
+        bodyWidth: document.body.scrollWidth,
+        viewportWidth: document.documentElement.clientWidth,
+        workspaceRight: workspace.getBoundingClientRect().right,
+        canvasRight: canvas.getBoundingClientRect().right,
+        canvasBottom: canvas.getBoundingClientRect().bottom,
+        toolbarRight: toolbar.getBoundingClientRect().right,
+        actionsTop: actions.getBoundingClientRect().top,
+      }
+    })
+    expect(geometry.bodyWidth).toBeLessThanOrEqual(geometry.viewportWidth)
+    expect(geometry.workspaceRight).toBeLessThanOrEqual(geometry.viewportWidth)
+    expect(geometry.canvasRight).toBeLessThanOrEqual(geometry.viewportWidth)
+    expect(geometry.toolbarRight).toBeLessThanOrEqual(geometry.viewportWidth)
+    if (viewport.width === 1024) expect(geometry.actionsTop).toBeGreaterThanOrEqual(geometry.canvasBottom)
+  }
+
+  await page.screenshot({
+    path: 'verification-output/approval-designer-tablet.png',
+    fullPage: true,
+  })
 })
 
 test('approval form designer stacks without horizontal overflow at a phone viewport', async ({ page }) => {
@@ -430,6 +562,20 @@ test('approval version workspace stacks without horizontal overflow at a phone v
   await page.goto(`${HARNESS}?mode=version`)
   await page.getByTestId('approval-template-version-workspace-button').click()
   await expect(page.getByTestId('approval-version-workspace')).toBeVisible()
+  const closeButton = page.locator('.approval-version-workspace-dialog .el-dialog__headerbtn')
+  const closeBox = await closeButton.boundingBox()
+  expect(closeBox?.width).toBeGreaterThanOrEqual(44)
+  expect(closeBox?.height).toBeGreaterThanOrEqual(44)
+  const versionDate = page.getByTestId('approval-version-timeline-3').locator('small')
+  await expect(versionDate).toBeVisible()
+  expect(await versionDate.evaluate((element) => element.scrollWidth <= element.clientWidth)).toBe(true)
+  const timelineCardsFit = await page.locator(
+    '[data-testid="approval-version-current-draft"], [data-testid^="approval-version-timeline-"]',
+  ).evaluateAll((elements) => elements.every((element) => {
+    const rect = element.getBoundingClientRect()
+    return rect.left >= 0 && rect.right <= document.documentElement.clientWidth
+  }))
+  expect(timelineCardsFit).toBe(true)
 
   const layout = await page.evaluate(() => {
     const rect = (selector: string) => {

--- a/apps/web/verification/approval-designer.spec.ts
+++ b/apps/web/verification/approval-designer.spec.ts
@@ -647,8 +647,9 @@ test('approval version workspace stacks without horizontal overflow at a phone v
   await expect(page.getByTestId('approval-version-workspace')).toBeVisible()
   const closeButton = page.locator('.approval-version-workspace-dialog .el-dialog__headerbtn')
   const closeBox = await closeButton.boundingBox()
-  expect(closeBox?.width).toBeGreaterThanOrEqual(44)
-  expect(closeBox?.height).toBeGreaterThanOrEqual(44)
+  // Chromium can report a CSS 44px target as 43.999999px after device-scale conversion.
+  expect(closeBox?.width).toBeGreaterThanOrEqual(44 - 0.001)
+  expect(closeBox?.height).toBeGreaterThanOrEqual(44 - 0.001)
   const versionDate = page.getByTestId('approval-version-timeline-date')
   await expect(versionDate).toBeVisible()
   expect(await versionDate.evaluate((element) => element.scrollWidth <= element.clientWidth)).toBe(true)

--- a/apps/web/verification/approval-designer.spec.ts
+++ b/apps/web/verification/approval-designer.spec.ts
@@ -98,7 +98,12 @@ const versionGraph = {
   ],
 }
 
-async function mockVersionWorkspaceApi(page: Page) {
+async function mockVersionWorkspaceApi(
+  page: Page,
+  formFields: Array<Record<string, unknown>> = [
+    { id: 'secret_amount_id', type: 'number', label: '报销金额', required: true },
+  ],
+) {
   const currentGraph = {
     ...versionGraph,
     nodes: versionGraph.nodes.map((node) => node.key === 'secret_approval_two'
@@ -118,7 +123,7 @@ async function mockVersionWorkspaceApi(page: Page) {
     latestVersionId: 'ver-current',
     createdAt: '2026-07-20T00:00:00.000Z',
     updatedAt: '2026-07-31T00:00:00.000Z',
-    formSchema: { fields: [{ id: 'secret_amount_id', type: 'number', label: '报销金额', required: true }] },
+    formSchema: { fields: formFields },
     approvalGraph: currentGraph,
   }
   const summary = {
@@ -296,7 +301,22 @@ test('approval route preview runs through the production wrapper and highlights 
 
 test('approval route preview remains operable without horizontal overflow at a phone viewport', async ({ page }) => {
   await page.setViewportSize({ width: 390, height: 844 })
-  await mockVersionWorkspaceApi(page)
+  await mockVersionWorkspaceApi(page, [
+    { id: 'secret_amount_id', type: 'number', label: '报销金额', required: true },
+    { id: 'secret_reason_id', type: 'textarea', label: '报销说明' },
+    {
+      id: 'secret_kind_id',
+      type: 'select',
+      label: '报销类型',
+      options: [{ label: '普通', value: 'normal' }],
+    },
+    {
+      id: 'secret_hidden_id',
+      type: 'text',
+      label: '条件备注',
+      visibilityRule: { fieldId: 'secret_kind_id', operator: 'eq', value: 'show' },
+    },
+  ])
   await page.route('**/api/approval-templates/tpl-browser/route-preview', async (route) => {
     await route.fulfill({
       json: {
@@ -352,16 +372,15 @@ test('approval route preview remains operable without horizontal overflow at a p
   }
   const panel = page.getByTestId('approval-canvas-route-preview-panel')
   await expect(panel).toBeVisible()
-  await expectTouchTargetsAtLeast(page.locator([
-    '[data-testid="approval-canvas-route-preview-close"]:visible',
-    '.approval-route-preview-panel .el-button:visible',
-    '.approval-route-preview-panel .el-input__wrapper:visible',
-    '.approval-route-preview-panel .el-select__wrapper:visible',
-    '.approval-route-preview-panel .el-input-number:visible',
-    '.approval-route-preview-panel .el-input-number__decrease:visible',
-    '.approval-route-preview-panel .el-input-number__increase:visible',
-    '.approval-route-preview-panel .el-textarea__inner:visible',
-  ].join(', ')), 44)
+  await expectTouchTargetsAtLeast(page.locator('[data-testid="approval-canvas-route-preview-close"]:visible'), 44)
+  await expectTouchTargetsAtLeast(panel.locator('.el-button:visible'), 44)
+  await expectTouchTargetsAtLeast(panel.locator('.el-input__wrapper:visible'), 44)
+  await expectTouchTargetsAtLeast(panel.locator('.el-select__wrapper:visible'), 44)
+  await expectTouchTargetsAtLeast(panel.locator('.el-input-number:visible'), 44)
+  await expectTouchTargetsAtLeast(panel.locator('.el-input-number__decrease:visible'), 44)
+  await expectTouchTargetsAtLeast(panel.locator('.el-input-number__increase:visible'), 44)
+  await expectTouchTargetsAtLeast(panel.locator('.el-textarea__inner:visible'), 44)
+  await expectTouchTargetsAtLeast(panel.locator('.el-collapse-item__header:visible'), 44)
   await panel.getByRole('spinbutton').fill('1200')
   await page.getByTestId('approval-template-tryrun-button').click()
   await expect(page.getByTestId('approval-template-tryrun-result')).toContainText('张三')
@@ -515,15 +534,22 @@ test('mobile canvas move and branch inspector controls meet the touch contract',
     '.template-authoring__canvas-branch-handle, .template-authoring__canvas-branch-actions .el-button, .template-authoring__canvas-inspector-body .el-button',
   )
   await expectTouchTargetsAtLeast(bottomSheetControls, 44)
-  await expectTouchTargetsAtLeast(page.locator([
-    '[data-testid="approval-canvas-inspector"] .el-checkbox:visible',
-    '[data-testid="approval-canvas-inspector"] .el-input__wrapper:visible',
-    '[data-testid="approval-canvas-inspector"] .el-select__wrapper:visible',
-    '[data-testid="approval-canvas-inspector"] .el-input-number:visible',
-    '[data-testid="approval-canvas-inspector"] .el-input-number__decrease:visible',
-    '[data-testid="approval-canvas-inspector"] .el-input-number__increase:visible',
-    '[data-testid="approval-canvas-inspector"] .el-textarea__inner:visible',
-  ].join(', ')), 44)
+  const inspector = page.getByTestId('approval-canvas-inspector')
+  await expectTouchTargetsAtLeast(inspector.locator('.el-input__wrapper:visible'), 44)
+  await expectTouchTargetsAtLeast(inspector.locator('.el-select__wrapper:visible'), 44)
+
+  await page.getByTestId('approval-condition-predicate-mode').first().click()
+  await page.getByRole('option', { name: '公式', exact: true }).click()
+  await expectTouchTargetsAtLeast(inspector.locator('.el-textarea__inner:visible'), 44)
+
+  await page.getByTestId('approval-canvas-node').filter({ hasText: '审批人 1' }).first().click()
+  await expect(page.getByTestId('approval-node-editor')).toBeVisible()
+  await page.getByTestId('approval-node-source-kind').click()
+  await page.getByRole('option', { name: '指定层级上级', exact: true }).click()
+  await expectTouchTargetsAtLeast(inspector.locator('.el-checkbox:visible'), 44)
+  await expectTouchTargetsAtLeast(inspector.locator('.el-input-number:visible'), 44)
+  await expectTouchTargetsAtLeast(inspector.locator('.el-input-number__decrease:visible'), 44)
+  await expectTouchTargetsAtLeast(inspector.locator('.el-input-number__increase:visible'), 44)
 })
 
 test('approval form designer stacks without horizontal overflow at a phone viewport', async ({ page }) => {

--- a/apps/web/verification/approval-designer.spec.ts
+++ b/apps/web/verification/approval-designer.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, type Page } from '@playwright/test'
+import { expect, test, type Locator, type Page } from '@playwright/test'
 
 const HARNESS = '/verification/approval-designer-harness.html'
 const browserErrors = new WeakMap<Page, string[]>()
@@ -24,6 +24,16 @@ async function openFormDesigner(page: Page) {
   await page.goto(HARNESS)
   await page.getByTestId('approval-template-section-fields').click()
   await expect(page.getByTestId('approval-form-palette')).toBeVisible()
+}
+
+async function expectTouchTargetsAtLeast(locator: Locator, size: number): Promise<void> {
+  expect(await locator.count()).toBeGreaterThan(0)
+  for (const target of await locator.all()) {
+    const box = await target.boundingBox()
+    expect(box).not.toBeNull()
+    expect(box!.width).toBeGreaterThanOrEqual(size - 0.001)
+    expect(box!.height).toBeGreaterThanOrEqual(size - 0.001)
+  }
 }
 
 async function contrastRatio(page: Page, selector: string): Promise<number> {
@@ -342,6 +352,16 @@ test('approval route preview remains operable without horizontal overflow at a p
   }
   const panel = page.getByTestId('approval-canvas-route-preview-panel')
   await expect(panel).toBeVisible()
+  await expectTouchTargetsAtLeast(page.locator([
+    '[data-testid="approval-canvas-route-preview-close"]:visible',
+    '.approval-route-preview-panel .el-button:visible',
+    '.approval-route-preview-panel .el-input__wrapper:visible',
+    '.approval-route-preview-panel .el-select__wrapper:visible',
+    '.approval-route-preview-panel .el-input-number:visible',
+    '.approval-route-preview-panel .el-input-number__decrease:visible',
+    '.approval-route-preview-panel .el-input-number__increase:visible',
+    '.approval-route-preview-panel .el-textarea__inner:visible',
+  ].join(', ')), 44)
   await panel.getByRole('spinbutton').fill('1200')
   await page.getByTestId('approval-template-tryrun-button').click()
   await expect(page.getByTestId('approval-template-tryrun-result')).toContainText('张三')
@@ -435,6 +455,7 @@ test('approval designer remains contained at tablet and compact desktop viewport
 test('authoring navigation never scrolls content beneath a dynamic header', async ({ page }) => {
   for (const viewport of [
     { width: 1280, height: 800 },
+    { width: 1024, height: 800 },
     { width: 900, height: 800 },
     { width: 800, height: 800 },
     { width: 761, height: 800 },
@@ -447,6 +468,21 @@ test('authoring navigation never scrolls content beneath a dynamic header', asyn
       if (!header || !hint) throw new Error('missing header or form-builder hint')
       return hint.getBoundingClientRect().top >= header.getBoundingClientRect().bottom
     })).toBe(true)
+    if (viewport.width <= 1024) {
+      const navigation = await page.evaluate(() => {
+        const steps = document.querySelector<HTMLElement>('.template-authoring__steps')
+        const modeSwitch = document.querySelector<HTMLElement>('.template-authoring__mode-switch')
+        if (!steps || !modeSwitch) throw new Error('missing steps or authoring mode switch')
+        const a = steps.getBoundingClientRect()
+        const b = modeSwitch.getBoundingClientRect()
+        return {
+          position: getComputedStyle(steps).position,
+          intersects: a.left < b.right && a.right > b.left && a.top < b.bottom && a.bottom > b.top,
+        }
+      })
+      expect(navigation.position).toBe('static')
+      expect(navigation.intersects).toBe(false)
+    }
   }
 })
 
@@ -478,12 +514,16 @@ test('mobile canvas move and branch inspector controls meet the touch contract',
   const bottomSheetControls = page.locator(
     '.template-authoring__canvas-branch-handle, .template-authoring__canvas-branch-actions .el-button, .template-authoring__canvas-inspector-body .el-button',
   )
-  expect(await bottomSheetControls.count()).toBeGreaterThan(0)
-  for (const control of await bottomSheetControls.all()) {
-    const box = await control.boundingBox()
-    expect(box?.width).toBeGreaterThanOrEqual(44)
-    expect(box?.height).toBeGreaterThanOrEqual(44)
-  }
+  await expectTouchTargetsAtLeast(bottomSheetControls, 44)
+  await expectTouchTargetsAtLeast(page.locator([
+    '[data-testid="approval-canvas-inspector"] .el-checkbox:visible',
+    '[data-testid="approval-canvas-inspector"] .el-input__wrapper:visible',
+    '[data-testid="approval-canvas-inspector"] .el-select__wrapper:visible',
+    '[data-testid="approval-canvas-inspector"] .el-input-number:visible',
+    '[data-testid="approval-canvas-inspector"] .el-input-number__decrease:visible',
+    '[data-testid="approval-canvas-inspector"] .el-input-number__increase:visible',
+    '[data-testid="approval-canvas-inspector"] .el-textarea__inner:visible',
+  ].join(', ')), 44)
 })
 
 test('approval form designer stacks without horizontal overflow at a phone viewport', async ({ page }) => {

--- a/apps/web/verification/approval-designer.spec.ts
+++ b/apps/web/verification/approval-designer.spec.ts
@@ -28,24 +28,45 @@ async function openFormDesigner(page: Page) {
 
 async function contrastRatio(page: Page, selector: string): Promise<number> {
   return page.locator(selector).evaluate((element) => {
-    const parseRgb = (value: string) => {
-      const channels = value.match(/[\d.]+/g)?.slice(0, 3).map(Number)
-      if (!channels || channels.length !== 3) throw new Error(`unsupported color ${value}`)
-      return channels.map((channel) => {
+    type Rgba = [number, number, number, number]
+    const parseColor = (value: string): Rgba => {
+      if (value === 'transparent') return [0, 0, 0, 0]
+      const channels = value.match(/[\d.]+/g)?.map(Number)
+      if (!channels || channels.length < 3) throw new Error(`unsupported color ${value}`)
+      return [channels[0], channels[1], channels[2], channels[3] ?? 1]
+    }
+    const composite = (front: Rgba, back: Rgba): Rgba => {
+      const alpha = front[3] + back[3] * (1 - front[3])
+      if (alpha === 0) return [0, 0, 0, 0]
+      return [
+        (front[0] * front[3] + back[0] * back[3] * (1 - front[3])) / alpha,
+        (front[1] * front[3] + back[1] * back[3] * (1 - front[3])) / alpha,
+        (front[2] * front[3] + back[2] * back[3] * (1 - front[3])) / alpha,
+        alpha,
+      ]
+    }
+    const luminance = (color: Rgba) => {
+      const channels = color.slice(0, 3).map((channel) => {
         const normalized = channel / 255
         return normalized <= 0.04045
           ? normalized / 12.92
           : ((normalized + 0.055) / 1.055) ** 2.4
       })
+      return 0.2126 * channels[0] + 0.7152 * channels[1] + 0.0722 * channels[2]
     }
-    const luminance = (value: string) => {
-      const [red, green, blue] = parseRgb(value)
-      return 0.2126 * red + 0.7152 * green + 0.0722 * blue
-    }
+
     const styles = window.getComputedStyle(element)
-    const foreground = luminance(styles.color)
-    const background = luminance(styles.backgroundColor)
-    return (Math.max(foreground, background) + 0.05) / (Math.min(foreground, background) + 0.05)
+    let background = parseColor(styles.backgroundColor)
+    let ancestor = element.parentElement
+    while (background[3] < 1 && ancestor) {
+      background = composite(background, parseColor(window.getComputedStyle(ancestor).backgroundColor))
+      ancestor = ancestor.parentElement
+    }
+    if (background[3] < 1) background = composite(background, [255, 255, 255, 1])
+    const foreground = luminance(composite(parseColor(styles.color), background))
+    const backgroundLuminance = luminance(background)
+    return (Math.max(foreground, backgroundLuminance) + 0.05)
+      / (Math.min(foreground, backgroundLuminance) + 0.05)
   })
 }
 
@@ -370,6 +391,14 @@ test('approval designer remains contained at tablet and compact desktop viewport
   ]) {
     await page.setViewportSize(viewport)
     await openFormDesigner(page)
+    const paletteGeometry = await page.locator('.approval-form-palette__item').evaluateAll((items) => items.map((item) => {
+      const label = item.querySelector('span')
+      return {
+        itemWidth: item.getBoundingClientRect().width,
+        labelFits: Boolean(label && label.scrollWidth <= label.clientWidth),
+      }
+    }))
+    expect(paletteGeometry.every(({ itemWidth, labelFits }) => itemWidth >= 80 && labelFits)).toBe(true)
     await page.getByRole('button', { name: '流程设计' }).click()
     await expect(page.getByTestId('approval-authoring-mode-flow')).toHaveAttribute('aria-pressed', 'true')
     await expect.poll(() => contrastRatio(page, '[data-testid="approval-authoring-mode-flow"]')).toBeGreaterThanOrEqual(4.5)
@@ -401,6 +430,60 @@ test('approval designer remains contained at tablet and compact desktop viewport
     path: 'verification-output/approval-designer-tablet.png',
     fullPage: true,
   })
+})
+
+test('authoring navigation never scrolls content beneath a dynamic header', async ({ page }) => {
+  for (const viewport of [
+    { width: 1280, height: 800 },
+    { width: 900, height: 800 },
+    { width: 800, height: 800 },
+    { width: 761, height: 800 },
+  ]) {
+    await page.setViewportSize(viewport)
+    await openFormDesigner(page)
+    await expect.poll(() => page.evaluate(() => {
+      const header = document.querySelector<HTMLElement>('.template-authoring__header')
+      const hint = document.querySelector<HTMLElement>('.approval-form-builder__header small')
+      if (!header || !hint) throw new Error('missing header or form-builder hint')
+      return hint.getBoundingClientRect().top >= header.getBoundingClientRect().bottom
+    })).toBe(true)
+  }
+})
+
+test('mobile canvas move and branch inspector controls meet the touch contract', async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 })
+  await openFormDesigner(page)
+  await page.getByRole('button', { name: '流程设计' }).click()
+
+  await page.getByRole('button', { name: '在「审批人 1」之后插入节点' }).click()
+  await page.getByRole('menuitem', { name: '审批' }).click()
+  const moveButton = page.locator(
+    '[data-testid^="approval-canvas-move-"]:not([data-testid^="approval-canvas-move-up-"]):not([data-testid^="approval-canvas-move-down-"])',
+  ).first()
+  await moveButton.click()
+  const moveTargets = page.locator('[data-testid^="approval-canvas-move-target-"]')
+  expect(await moveTargets.count()).toBeGreaterThan(0)
+  for (const target of await moveTargets.all()) {
+    const box = await target.boundingBox()
+    expect(box?.width).toBeGreaterThanOrEqual(40)
+    expect(box?.height).toBeGreaterThanOrEqual(40)
+  }
+  await moveButton.click()
+
+  await page.getByRole('button', { name: '在「审批人 1」之后插入节点' }).click()
+  await page.getByRole('menuitem', { name: '条件分支' }).click()
+  await page.getByTestId(/approval-canvas-add-condition-/).click()
+  await expect(page.getByTestId('approval-canvas-branch-reorder')).toBeVisible()
+
+  const bottomSheetControls = page.locator(
+    '.template-authoring__canvas-branch-handle, .template-authoring__canvas-branch-actions .el-button, .template-authoring__canvas-inspector-body .el-button',
+  )
+  expect(await bottomSheetControls.count()).toBeGreaterThan(0)
+  for (const control of await bottomSheetControls.all()) {
+    const box = await control.boundingBox()
+    expect(box?.width).toBeGreaterThanOrEqual(44)
+    expect(box?.height).toBeGreaterThanOrEqual(44)
+  }
 })
 
 test('approval form designer stacks without horizontal overflow at a phone viewport', async ({ page }) => {
@@ -566,7 +649,7 @@ test('approval version workspace stacks without horizontal overflow at a phone v
   const closeBox = await closeButton.boundingBox()
   expect(closeBox?.width).toBeGreaterThanOrEqual(44)
   expect(closeBox?.height).toBeGreaterThanOrEqual(44)
-  const versionDate = page.getByTestId('approval-version-timeline-3').locator('small')
+  const versionDate = page.getByTestId('approval-version-timeline-date')
   await expect(versionDate).toBeVisible()
   expect(await versionDate.evaluate((element) => element.scrollWidth <= element.clientWidth)).toBe(true)
   const timelineCardsFit = await page.locator(


### PR DESCRIPTION
## Summary
- keep the approval designer contained at 1280px, 1024px, and 390px viewports
- enforce readable active-mode contrast, complete palette labels, mobile touch targets, and unclipped version history
- remove sticky action/navigation overlap without changing approval graph or command semantics
- close the exact-head review gaps: compact palette width, dynamic header separation, alpha-aware contrast checks, non-button inspector/route-preview touch targets, and an unambiguous version-date test anchor

## Verification
- `pnpm --filter @metasheet/web exec playwright test --config playwright.verification.config.ts` (15/15, the CI-equivalent browser workflow)
- `pnpm --filter @metasheet/web exec vue-tsc --noEmit`
- `pnpm --filter @metasheet/web build`
- Playwright geometry checks: no horizontal overflow; Canvas move/node controls >=40px; toolbar, button, checkbox, input, select, number-stepper, textarea, branch-inspector, route-preview, and version controls >=44px on mobile; no node overlap; alpha-composited active-tab contrast >=4.5; dynamic header never covers authoring content; palette labels fit at compact desktop widths

## Boundaries
- stacked on #4704; no merge/deploy/UAT/flag change
- no approval graph, persistence, or backend behavior change