### PR TITLE
feat(attendance): audit legacy membership overlaps

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -436,13 +436,18 @@ jobs:
         run: |
           node --test scripts/ops/attendance-calculation-group-membership-w1-contract.test.mjs
 
+      - name: Run attendance legacy membership audit contract
+        run: |
+          node --test scripts/ops/attendance-legacy-membership-overlap-audit-contract.test.mjs
+
       # #4561 W1 P2: the service-level read/transition matrix bypasses the DB
       # EXCLUDE constraint on purpose and proves the runtime integrity guard is
       # independently load-bearing. Keep whole-file execution explicit.
-      - name: Run attendance calculation-group W1 timeline-integrity unit
+      - name: Run attendance calculation-group timeline and legacy audit units
         run: |
           pnpm --filter @metasheet/core-backend exec vitest run \
             tests/unit/attendance-calculation-group-membership-timeline-integrity.test.ts \
+            tests/unit/attendance-legacy-membership-overlap-audit.test.ts \
             --reporter=dot
 
       # #4556 W2: shared work-date resolver unit matrix (overlap precedence, attribution tail,
@@ -1078,6 +1083,7 @@ jobs:
             tests/integration/attendance-setup-readiness-w4-0.db.test.ts \
             tests/integration/attendance-decision-trace-w5-0.db.test.ts \
             tests/integration/attendance-calculation-group-membership-w1.db.test.ts \
+            tests/integration/attendance-legacy-membership-overlap-audit.db.test.ts \
             tests/integration/attendance-work-date-resolver-w2.db.test.ts \
             tests/integration/attendance-w4c0-durable-storage-smoke.db.test.ts \
             tests/integration/attendance-w4c0-identity-golden-parity.db.test.ts \

--- a/packages/core-backend/src/services/AttendanceLegacyMembershipOverlapAudit.ts
+++ b/packages/core-backend/src/services/AttendanceLegacyMembershipOverlapAudit.ts
@@ -1,0 +1,228 @@
+import type { QueryResult, QueryResultRow } from 'pg'
+import { query } from '../db/pg'
+
+export const ATTENDANCE_LEGACY_MEMBERSHIP_AUDIT_SCHEMA_NOT_READY =
+  'ATTENDANCE_LEGACY_MEMBERSHIP_AUDIT_SCHEMA_NOT_READY'
+export const ATTENDANCE_LEGACY_MEMBERSHIP_AUDIT_INTEGRITY_ERROR =
+  'ATTENDANCE_LEGACY_MEMBERSHIP_AUDIT_INTEGRITY_ERROR'
+
+const MANIFEST_VERSION = 'attendance-legacy-membership-overlap-v1' as const
+const INTERVAL_POSTURE = 'legacy_effective_interval_unknown' as const
+const REMEDIATION = 'manual_transfer_required' as const
+
+type QueryExecutor = (
+  statement: string,
+  params?: unknown[],
+) => Promise<QueryResult<QueryResultRow>>
+
+type SchemaRow = {
+  members_table: string | null
+  groups_table: string | null
+  member_columns: string[] | null
+  group_columns: string[] | null
+}
+
+type LegacyMembershipRow = {
+  source_row_id: string
+  org_id: string
+  user_id: string
+  group_id: string
+  group_found: boolean
+}
+
+export interface AttendanceLegacyMembershipCandidate {
+  groupId: string
+  sourceRowIds: string[]
+}
+
+export interface AttendanceLegacyMembershipConflict {
+  orgId: string
+  userId: string
+  interval: {
+    posture: typeof INTERVAL_POSTURE
+    effectiveFrom: null
+    effectiveTo: null
+  }
+  remediation: {
+    posture: typeof REMEDIATION
+    transitionService: 'transitionAttendanceCalculationGroupMembership'
+    requiredInput: readonly [
+      'targetGroupId',
+      'effectiveOn',
+      'actorId',
+      'reason',
+      'correlationId',
+    ]
+  }
+  candidates: AttendanceLegacyMembershipCandidate[]
+}
+
+export interface AttendanceLegacyMembershipAuditManifest {
+  manifestVersion: typeof MANIFEST_VERSION
+  orgId: string
+  sourceTable: 'attendance_group_members'
+  intervalPosture: typeof INTERVAL_POSTURE
+  scannedRows: number
+  conflictCount: number
+  zeroConflicts: boolean
+  conflicts: AttendanceLegacyMembershipConflict[]
+}
+
+export class AttendanceLegacyMembershipAuditError extends Error {
+  constructor(
+    public readonly code: string,
+    public readonly status: number,
+    message: string,
+  ) {
+    super(message)
+    this.name = 'AttendanceLegacyMembershipAuditError'
+  }
+}
+
+function compareText(left: string, right: string): number {
+  if (left < right) return -1
+  if (left > right) return 1
+  return 0
+}
+
+function requireOrgId(value: string): string {
+  const normalized = String(value || '').trim()
+  if (!normalized) {
+    throw new AttendanceLegacyMembershipAuditError(
+      'ORG_ID_REQUIRED',
+      400,
+      'orgId is required',
+    )
+  }
+  return normalized
+}
+
+function buildManifest(
+  orgId: string,
+  rows: LegacyMembershipRow[],
+): AttendanceLegacyMembershipAuditManifest {
+  const rowsByUser = new Map<string, LegacyMembershipRow[]>()
+  for (const row of rows) {
+    if (!row.group_found) {
+      throw new AttendanceLegacyMembershipAuditError(
+        ATTENDANCE_LEGACY_MEMBERSHIP_AUDIT_INTEGRITY_ERROR,
+        409,
+        'Legacy membership references a missing or cross-organization group',
+      )
+    }
+    const userRows = rowsByUser.get(row.user_id) ?? []
+    userRows.push(row)
+    rowsByUser.set(row.user_id, userRows)
+  }
+
+  const conflicts = [...rowsByUser.entries()]
+    .sort(([left], [right]) => compareText(left, right))
+    .flatMap(([userId, userRows]) => {
+      const rowsByGroup = new Map<string, string[]>()
+      for (const row of userRows) {
+        const sourceRows = rowsByGroup.get(row.group_id) ?? []
+        sourceRows.push(row.source_row_id)
+        rowsByGroup.set(row.group_id, sourceRows)
+      }
+      if (rowsByGroup.size < 2) return []
+
+      const candidates = [...rowsByGroup.entries()]
+        .sort(([left], [right]) => compareText(left, right))
+        .map(([groupId, sourceRowIds]) => ({
+          groupId,
+          sourceRowIds: [...sourceRowIds].sort(compareText),
+        }))
+
+      return [{
+        orgId,
+        userId,
+        interval: {
+          posture: INTERVAL_POSTURE,
+          effectiveFrom: null,
+          effectiveTo: null,
+        },
+        remediation: {
+          posture: REMEDIATION,
+          transitionService: 'transitionAttendanceCalculationGroupMembership' as const,
+          requiredInput: [
+            'targetGroupId',
+            'effectiveOn',
+            'actorId',
+            'reason',
+            'correlationId',
+          ] as const,
+        },
+        candidates,
+      }]
+    })
+
+  return {
+    manifestVersion: MANIFEST_VERSION,
+    orgId,
+    sourceTable: 'attendance_group_members',
+    intervalPosture: INTERVAL_POSTURE,
+    scannedRows: rows.length,
+    conflictCount: conflicts.length,
+    zeroConflicts: conflicts.length === 0,
+    conflicts,
+  }
+}
+
+export async function auditAttendanceLegacyMembershipOverlaps(
+  orgIdInput: string,
+  runQuery: QueryExecutor = query,
+): Promise<AttendanceLegacyMembershipAuditManifest> {
+  const orgId = requireOrgId(orgIdInput)
+  const schemaResult = await runQuery(
+    `SELECT to_regclass('public.attendance_group_members')::text AS members_table,
+            to_regclass('public.attendance_groups')::text AS groups_table,
+            ARRAY(
+              SELECT column_name::text
+                FROM information_schema.columns
+               WHERE table_schema = 'public'
+                 AND table_name = 'attendance_group_members'
+               ORDER BY column_name
+            ) AS member_columns,
+            ARRAY(
+              SELECT column_name::text
+                FROM information_schema.columns
+               WHERE table_schema = 'public'
+                 AND table_name = 'attendance_groups'
+               ORDER BY column_name
+            ) AS group_columns`,
+  )
+  const schema = schemaResult.rows[0] as SchemaRow | undefined
+  const memberColumns = new Set(schema?.member_columns ?? [])
+  const groupColumns = new Set(schema?.group_columns ?? [])
+  const requiredMemberColumns = ['id', 'org_id', 'group_id', 'user_id']
+  const requiredGroupColumns = ['id', 'org_id']
+  if (
+    !schema?.members_table
+    || !schema.groups_table
+    || requiredMemberColumns.some((column) => !memberColumns.has(column))
+    || requiredGroupColumns.some((column) => !groupColumns.has(column))
+  ) {
+    throw new AttendanceLegacyMembershipAuditError(
+      ATTENDANCE_LEGACY_MEMBERSHIP_AUDIT_SCHEMA_NOT_READY,
+      503,
+      'Legacy attendance membership schema is not ready',
+    )
+  }
+
+  const result = await runQuery(
+    `SELECT m.id::text AS source_row_id,
+            m.org_id,
+            m.user_id,
+            m.group_id::text AS group_id,
+            (g.id IS NOT NULL) AS group_found
+       FROM attendance_group_members m
+       LEFT JOIN attendance_groups g
+         ON g.id = m.group_id
+        AND g.org_id = m.org_id
+      WHERE m.org_id = $1
+      ORDER BY m.user_id ASC, m.group_id ASC, m.id ASC`,
+    [orgId],
+  )
+
+  return buildManifest(orgId, result.rows as LegacyMembershipRow[])
+}

--- a/packages/core-backend/tests/integration/attendance-legacy-membership-overlap-audit.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-legacy-membership-overlap-audit.db.test.ts
@@ -1,0 +1,194 @@
+import { spawnSync } from 'node:child_process'
+import { randomUUID } from 'node:crypto'
+import { resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { Kysely, PostgresDialect } from 'kysely'
+import { Pool } from 'pg'
+import {
+  ATTENDANCE_LEGACY_MEMBERSHIP_AUDIT_INTEGRITY_ERROR,
+  ATTENDANCE_LEGACY_MEMBERSHIP_AUDIT_SCHEMA_NOT_READY,
+  auditAttendanceLegacyMembershipOverlaps,
+} from '../../src/services/AttendanceLegacyMembershipOverlapAudit'
+import { up as membershipMigrationUp } from '../../src/db/migrations/zzzz20260723140000_create_attendance_calculation_group_memberships'
+
+const serverUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
+const describeIfDatabase = serverUrl ? describe : describe.skip
+
+describeIfDatabase('legacy attendance membership overlap audit (isolated real DB)', () => {
+  const repoRoot = fileURLToPath(new URL('../../../../', import.meta.url))
+  const tsxCli = resolve(repoRoot, 'node_modules/tsx/dist/cli.mjs')
+  const auditCli = resolve(repoRoot, 'scripts/ops/attendance-legacy-membership-overlap-audit.ts')
+  const databaseName = `attendance_legacy_audit_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`
+  const adminUrl = new URL(serverUrl || 'postgresql://postgres@localhost/postgres')
+  adminUrl.pathname = '/postgres'
+  const scratchUrl = new URL(adminUrl)
+  scratchUrl.pathname = `/${databaseName}`
+  const adminPool = new Pool({ connectionString: adminUrl.toString() })
+  let pool: Pool
+
+  function runAuditCli(orgId: string) {
+    return spawnSync(process.execPath, [tsxCli, auditCli, '--org', orgId], {
+      cwd: repoRoot,
+      env: {
+        ...process.env,
+        DATABASE_URL: scratchUrl.toString(),
+        ATTENDANCE_TEST_DATABASE_URL: scratchUrl.toString(),
+      },
+      encoding: 'utf8',
+      timeout: 30_000,
+    })
+  }
+
+  const orgA = 'org-a'
+  const orgB = 'org-b'
+  const userId = 'user-a'
+  const raceUserId = 'user-race'
+  const groupA = randomUUID()
+  const groupB = randomUUID()
+  const groupForeign = randomUUID()
+
+  beforeAll(async () => {
+    await adminPool.query(`CREATE DATABASE ${databaseName}`)
+    pool = new Pool({ connectionString: scratchUrl.toString(), max: 6 })
+  })
+
+  afterAll(async () => {
+    await pool?.end()
+    await adminPool.query(
+      `SELECT pg_terminate_backend(pid)
+         FROM pg_stat_activity
+        WHERE datname = $1 AND pid <> pg_backend_pid()`,
+      [databaseName],
+    )
+    await adminPool.query(`DROP DATABASE IF EXISTS ${databaseName}`)
+    await adminPool.end()
+  })
+
+  it('fails closed on a fresh database, then audits an upgraded legacy shape deterministically', async () => {
+    await expect(
+      auditAttendanceLegacyMembershipOverlaps(orgA, (statement, params) => pool.query(statement, params)),
+    ).rejects.toMatchObject({ code: ATTENDANCE_LEGACY_MEMBERSHIP_AUDIT_SCHEMA_NOT_READY })
+    const freshDatabaseCli = runAuditCli(orgA)
+    expect(freshDatabaseCli.status, freshDatabaseCli.stderr).toBe(3)
+    expect(freshDatabaseCli.stderr).toContain(ATTENDANCE_LEGACY_MEMBERSHIP_AUDIT_SCHEMA_NOT_READY)
+
+    await pool.query('CREATE EXTENSION IF NOT EXISTS pgcrypto')
+    await pool.query('CREATE EXTENSION IF NOT EXISTS btree_gist')
+    await pool.query(`
+      CREATE TABLE users (
+        id text PRIMARY KEY,
+        is_active boolean NOT NULL
+      );
+      CREATE TABLE user_orgs (
+        user_id text NOT NULL,
+        org_id text NOT NULL,
+        is_active boolean NOT NULL,
+        PRIMARY KEY (user_id, org_id)
+      );
+      CREATE TABLE attendance_groups (
+        id uuid PRIMARY KEY,
+        org_id text NOT NULL,
+        name text NOT NULL
+      );
+      CREATE TABLE attendance_group_members (
+        id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+        org_id text NOT NULL,
+        group_id uuid NOT NULL REFERENCES attendance_groups(id) ON DELETE CASCADE,
+        user_id text NOT NULL,
+        created_at timestamptz NOT NULL DEFAULT now(),
+        updated_at timestamptz NOT NULL DEFAULT now(),
+        UNIQUE (org_id, group_id, user_id)
+      )
+    `)
+
+    await pool.query(
+      `INSERT INTO users (id, is_active) VALUES ($1, true), ($2, true)`,
+      [userId, raceUserId],
+    )
+    await pool.query(
+      `INSERT INTO user_orgs (user_id, org_id, is_active)
+       VALUES ($1, $2, true), ($1, $3, true), ($4, $2, true)`,
+      [userId, orgA, orgB, raceUserId],
+    )
+    await pool.query(
+      `INSERT INTO attendance_groups (id, org_id, name)
+       VALUES ($1, $4, 'A'), ($2, $4, 'B'), ($3, $5, 'Foreign')`,
+      [groupA, groupB, groupForeign, orgA, orgB],
+    )
+    await pool.query(
+      `INSERT INTO attendance_group_members (org_id, group_id, user_id)
+       VALUES ($1, $2, $3), ($1, $4, $3), ($5, $6, $3)`,
+      [orgA, groupA, userId, groupB, orgB, groupForeign],
+    )
+
+    const migrationPool = new Pool({ connectionString: scratchUrl.toString(), max: 2 })
+    const db = new Kysely<unknown>({ dialect: new PostgresDialect({ pool: migrationPool }) })
+    try {
+      await membershipMigrationUp(db)
+    } finally {
+      await db.destroy()
+    }
+
+    const runQuery = (statement: string, params?: unknown[]) => pool.query(statement, params)
+    const first = await auditAttendanceLegacyMembershipOverlaps(orgA, runQuery)
+    const second = await auditAttendanceLegacyMembershipOverlaps(orgA, runQuery)
+    const foreign = await auditAttendanceLegacyMembershipOverlaps(orgB, runQuery)
+
+    expect(second).toEqual(first)
+    expect(first).toMatchObject({
+      orgId: orgA,
+      scannedRows: 2,
+      conflictCount: 1,
+      zeroConflicts: false,
+      conflicts: [{ userId, remediation: { posture: 'manual_transfer_required' } }],
+    })
+    expect(foreign).toMatchObject({ orgId: orgB, scannedRows: 1, conflictCount: 0, zeroConflicts: true })
+
+    const conflictCli = runAuditCli(orgA)
+    expect(conflictCli.status, conflictCli.stderr).toBe(4)
+    expect(JSON.parse(conflictCli.stdout)).toEqual(first)
+    const cleanCli = runAuditCli(orgB)
+    expect(cleanCli.status, cleanCli.stderr).toBe(0)
+    expect(JSON.parse(cleanCli.stdout)).toEqual(foreign)
+
+    await pool.query(
+      `INSERT INTO attendance_group_members (org_id, group_id, user_id)
+       VALUES ($1, $2, $3)`,
+      [orgA, groupForeign, userId],
+    )
+    await expect(auditAttendanceLegacyMembershipOverlaps(orgA, runQuery)).rejects.toMatchObject({
+      code: ATTENDANCE_LEGACY_MEMBERSHIP_AUDIT_INTEGRITY_ERROR,
+      status: 409,
+    })
+    const crossOrgCli = runAuditCli(orgA)
+    expect(crossOrgCli.status, crossOrgCli.stderr).toBe(3)
+    expect(crossOrgCli.stderr).toContain(ATTENDANCE_LEGACY_MEMBERSHIP_AUDIT_INTEGRITY_ERROR)
+
+    const concurrent = await Promise.allSettled([
+      pool.query(
+        `INSERT INTO attendance_calculation_group_memberships (
+           org_id, user_id, group_id, effective_from, effective_to,
+           assigned_by, assigned_reason, assigned_correlation_id
+         ) VALUES ($1, $2, $3, '2026-08-01', NULL, 'qa', 'race-a', 'race-a')`,
+        [orgA, raceUserId, groupA],
+      ),
+      pool.query(
+        `INSERT INTO attendance_calculation_group_memberships (
+           org_id, user_id, group_id, effective_from, effective_to,
+           assigned_by, assigned_reason, assigned_correlation_id
+         ) VALUES ($1, $2, $3, '2026-08-01', NULL, 'qa', 'race-b', 'race-b')`,
+        [orgA, raceUserId, groupB],
+      ),
+    ])
+    expect(concurrent.filter((entry) => entry.status === 'fulfilled')).toHaveLength(1)
+    const rejected = concurrent.find((entry) => entry.status === 'rejected')
+    expect(rejected).toMatchObject({
+      status: 'rejected',
+      reason: {
+        code: '23P01',
+        constraint: 'attendance_calc_group_memberships_no_overlap',
+      },
+    })
+  })
+})

--- a/packages/core-backend/tests/integration/attendance-plugin.test.ts
+++ b/packages/core-backend/tests/integration/attendance-plugin.test.ts
@@ -19362,8 +19362,64 @@ attendanceIntegrationDescribe(
           const rightReplay = right?.body?.data?.idempotent === true ? 1 : 0
           return leftReplay - rightReplay
         })
+        const normalizeAsyncReplayLifecycle = (entries: any[]) => {
+          const replayEntries = entries.filter((entry) => entry?.body?.data?.idempotent === true)
+          if (replayEntries.length !== 1) {
+            throw new Error(`Expected one async idempotent replay, received ${replayEntries.length}`)
+          }
+          const job = replayEntries[0]?.body?.data?.job
+          if (!job || typeof job !== 'object') {
+            throw new Error('Async idempotent replay is missing its job projection')
+          }
+          const status = String(job.status ?? '')
+          if (!['queued', 'running', 'completed'].includes(status)) {
+            throw new Error(`Unexpected async idempotent replay status: ${status || '<empty>'}`)
+          }
+          const total = Number(job.total)
+          const progress = Number(job.progress)
+          const processedRows = Number(job.processedRows)
+          const failedRows = Number(job.failedRows)
+          if (
+            !Number.isInteger(total) || total < 0 ||
+            !Number.isInteger(progress) || progress < 0 || progress > total ||
+            !Number.isInteger(processedRows) || processedRows < 0 || processedRows > total ||
+            !Number.isInteger(failedRows) || failedRows < 0 || failedRows > total
+          ) {
+            throw new Error('Async idempotent replay contains an invalid lifecycle counter')
+          }
+          if (status === 'queued' && (progress !== 0 || job.startedAt !== null || job.finishedAt !== null)) {
+            throw new Error('Queued async idempotent replay contains a started or finished lifecycle')
+          }
+          if (status === 'running' && (job.startedAt === null || job.finishedAt !== null)) {
+            throw new Error('Running async idempotent replay contains an invalid lifecycle timestamp')
+          }
+          if (status === 'completed' && (progress !== total || job.startedAt === null || job.finishedAt === null)) {
+            throw new Error('Completed async idempotent replay contains an incomplete lifecycle')
+          }
+
+          // The replay can legally observe the worker before, during, or after completion. Keep the
+          // created response byte-locked and normalize only these lifecycle values on the replay;
+          // its key set, identity, engine, strategies, error, and every other field remain golden-bound.
+          for (const key of [
+            'elapsedMs',
+            'failedRows',
+            'finishedAt',
+            'processedRows',
+            'progress',
+            'progressPercent',
+            'startedAt',
+            'status',
+            'throughputRowsPerSec',
+          ]) {
+            if (!Object.prototype.hasOwnProperty.call(job, key)) {
+              throw new Error(`Async idempotent replay is missing lifecycle field: ${key}`)
+            }
+            job[key] = `<async-replay-${key}>`
+          }
+        }
         sortRace(copy.sync.lockedRace)
         sortRace(copy.async.lockedRace)
+        normalizeAsyncReplayLifecycle(copy.async.lockedRace)
         copy.database.batches.sort((left: any, right: any) =>
           compareText(left.idempotency_key, right.idempotency_key))
         for (const item of copy.database.items) {

--- a/packages/core-backend/tests/integration/attendance-plugin.test.ts
+++ b/packages/core-backend/tests/integration/attendance-plugin.test.ts
@@ -19375,17 +19375,50 @@ attendanceIntegrationDescribe(
           if (!['queued', 'running', 'completed'].includes(status)) {
             throw new Error(`Unexpected async idempotent replay status: ${status || '<empty>'}`)
           }
-          const total = Number(job.total)
-          const progress = Number(job.progress)
-          const processedRows = Number(job.processedRows)
-          const failedRows = Number(job.failedRows)
+          const total = job.total
+          const progress = job.progress
+          const processedRows = job.processedRows
+          const failedRows = job.failedRows
           if (
             !Number.isInteger(total) || total < 0 ||
             !Number.isInteger(progress) || progress < 0 || progress > total ||
             !Number.isInteger(processedRows) || processedRows < 0 || processedRows > total ||
-            !Number.isInteger(failedRows) || failedRows < 0 || failedRows > total
+            !Number.isInteger(failedRows) || failedRows < 0 || failedRows > total ||
+            processedRows + failedRows !== total
           ) {
             throw new Error('Async idempotent replay contains an invalid lifecycle counter')
+          }
+          const progressPercent = job.progressPercent
+          // Mirrors mapImportJobRow's public projection formula. The same projection derives
+          // failedRows as total - processedRows until a terminal summary replaces both values.
+          const expectedProgressPercent = total > 0
+            ? Math.round((progress / total) * 100)
+            : 0
+          if (
+            typeof progressPercent !== 'number' ||
+            !Number.isInteger(progressPercent) ||
+            progressPercent !== expectedProgressPercent
+          ) {
+            throw new Error('Async idempotent replay contains an invalid progress percentage')
+          }
+          if (
+            typeof job.throughputRowsPerSec !== 'number' ||
+            !Number.isFinite(job.throughputRowsPerSec) ||
+            job.throughputRowsPerSec < 0
+          ) {
+            throw new Error('Async idempotent replay contains an invalid throughput')
+          }
+          // canonicalizeGolden receives the output of normalize(), which preserves zero and turns
+          // every positive elapsed duration into this relation marker before either side is compared.
+          const elapsedMsIsValid = job.elapsedMs === 0 || (
+            job.elapsedMs &&
+            typeof job.elapsedMs === 'object' &&
+            job.elapsedMs.type === 'number' &&
+            job.elapsedMs.relation === 'nonnegative' &&
+            Object.keys(job.elapsedMs).length === 2
+          )
+          if (!elapsedMsIsValid) {
+            throw new Error('Async idempotent replay contains an invalid elapsed duration')
           }
           if (status === 'queued' && (progress !== 0 || job.startedAt !== null || job.finishedAt !== null)) {
             throw new Error('Queued async idempotent replay contains a started or finished lifecycle')

--- a/packages/core-backend/tests/unit/attendance-legacy-membership-overlap-audit.test.ts
+++ b/packages/core-backend/tests/unit/attendance-legacy-membership-overlap-audit.test.ts
@@ -1,0 +1,120 @@
+import type { QueryResult, QueryResultRow } from 'pg'
+import { describe, expect, it, vi } from 'vitest'
+import {
+  ATTENDANCE_LEGACY_MEMBERSHIP_AUDIT_INTEGRITY_ERROR,
+  ATTENDANCE_LEGACY_MEMBERSHIP_AUDIT_SCHEMA_NOT_READY,
+  AttendanceLegacyMembershipAuditError,
+  auditAttendanceLegacyMembershipOverlaps,
+} from '../../src/services/AttendanceLegacyMembershipOverlapAudit'
+
+function result(rows: QueryResultRow[]): QueryResult<QueryResultRow> {
+  return {
+    command: 'SELECT',
+    rowCount: rows.length,
+    oid: 0,
+    fields: [],
+    rows,
+  }
+}
+
+describe('attendance legacy membership overlap audit', () => {
+  const readySchema = {
+    members_table: 'attendance_group_members',
+    groups_table: 'attendance_groups',
+    member_columns: ['group_id', 'id', 'org_id', 'user_id'],
+    group_columns: ['id', 'org_id'],
+  }
+
+  it('emits a deterministic, minimal manual-repair manifest', async () => {
+    const rows = [
+      { source_row_id: 'row-b', org_id: 'org-a', user_id: 'user-a', group_id: 'group-b', group_found: true },
+      { source_row_id: 'row-a', org_id: 'org-a', user_id: 'user-a', group_id: 'group-a', group_found: true },
+      { source_row_id: 'row-c', org_id: 'org-a', user_id: 'user-b', group_id: 'group-a', group_found: true },
+    ]
+    const runQuery = vi.fn()
+      .mockResolvedValueOnce(result([readySchema]))
+      .mockResolvedValueOnce(result(rows))
+      .mockResolvedValueOnce(result([readySchema]))
+      .mockResolvedValueOnce(result([...rows].reverse()))
+
+    const first = await auditAttendanceLegacyMembershipOverlaps(' org-a ', runQuery)
+    const second = await auditAttendanceLegacyMembershipOverlaps('org-a', runQuery)
+
+    expect(second).toEqual(first)
+    expect(first).toEqual({
+      manifestVersion: 'attendance-legacy-membership-overlap-v1',
+      orgId: 'org-a',
+      sourceTable: 'attendance_group_members',
+      intervalPosture: 'legacy_effective_interval_unknown',
+      scannedRows: 3,
+      conflictCount: 1,
+      zeroConflicts: false,
+      conflicts: [{
+        orgId: 'org-a',
+        userId: 'user-a',
+        interval: {
+          posture: 'legacy_effective_interval_unknown',
+          effectiveFrom: null,
+          effectiveTo: null,
+        },
+        remediation: {
+          posture: 'manual_transfer_required',
+          transitionService: 'transitionAttendanceCalculationGroupMembership',
+          requiredInput: ['targetGroupId', 'effectiveOn', 'actorId', 'reason', 'correlationId'],
+        },
+        candidates: [
+          { groupId: 'group-a', sourceRowIds: ['row-a'] },
+          { groupId: 'group-b', sourceRowIds: ['row-b'] },
+        ],
+      }],
+    })
+    expect(runQuery.mock.calls[1][1]).toEqual(['org-a'])
+    expect(runQuery.mock.calls[3][1]).toEqual(['org-a'])
+    const statements = runQuery.mock.calls.map(([statement]) => String(statement)).join('\n')
+    expect(statements).toMatch(/WHERE m\.org_id = \$1/)
+    expect(statements).not.toMatch(/\b(?:INSERT|UPDATE|DELETE|MERGE|TRUNCATE|ALTER|DROP|CREATE)\b/i)
+  })
+
+  it('returns a stable zero-conflict manifest', async () => {
+    const runQuery = vi.fn()
+      .mockResolvedValueOnce(result([readySchema]))
+      .mockResolvedValueOnce(result([
+        { source_row_id: 'row-a', org_id: 'org-a', user_id: 'user-a', group_id: 'group-a', group_found: true },
+      ]))
+
+    const manifest = await auditAttendanceLegacyMembershipOverlaps('org-a', runQuery)
+    expect(manifest).toMatchObject({ scannedRows: 1, conflictCount: 0, zeroConflicts: true, conflicts: [] })
+  })
+
+  it('fails closed for a missing schema, corrupt group link, or absent org', async () => {
+    await expect(auditAttendanceLegacyMembershipOverlaps('org-a', async () => result([
+      { members_table: null, groups_table: null, member_columns: [], group_columns: [] },
+    ]))).rejects.toMatchObject({
+      code: ATTENDANCE_LEGACY_MEMBERSHIP_AUDIT_SCHEMA_NOT_READY,
+      status: 503,
+    })
+
+    const corruptQuery = vi.fn()
+      .mockResolvedValueOnce(result([readySchema]))
+      .mockResolvedValueOnce(result([
+        { source_row_id: 'row-a', org_id: 'org-a', user_id: 'user-a', group_id: 'missing', group_found: false },
+      ]))
+    await expect(auditAttendanceLegacyMembershipOverlaps('org-a', corruptQuery)).rejects.toMatchObject({
+      code: ATTENDANCE_LEGACY_MEMBERSHIP_AUDIT_INTEGRITY_ERROR,
+      status: 409,
+    })
+    await expect(auditAttendanceLegacyMembershipOverlaps('   ')).rejects.toBeInstanceOf(
+      AttendanceLegacyMembershipAuditError,
+    )
+  })
+
+  it('fails closed when a required legacy column is absent', async () => {
+    await expect(auditAttendanceLegacyMembershipOverlaps('org-a', async () => result([{
+      ...readySchema,
+      member_columns: ['id', 'org_id', 'user_id'],
+    }]))).rejects.toMatchObject({
+      code: ATTENDANCE_LEGACY_MEMBERSHIP_AUDIT_SCHEMA_NOT_READY,
+      status: 503,
+    })
+  })
+})

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -470,6 +470,9 @@ export default defineConfig({
       // #4561 W1: database exclusion/concurrency and effective-date transition proof.
       // Kept out of the no-DB run and explicitly wired into plugin-tests.yml.
       'tests/integration/attendance-calculation-group-membership-w1.db.test.ts',
+      // #4710: isolated scratch-database proof for the SELECT-only legacy overlap audit.
+      // Explicitly wired into the attendance real-DB step; exclusion prevents skip-green.
+      'tests/integration/attendance-legacy-membership-overlap-audit.db.test.ts',
       // #4556 W2: shared work-date resolver real-DB matrix (overlap precedence, overnight,
       // multi-shift ambiguity, frozen recompute, overtime anchor, adapter parity).
       // DATABASE_URL-gated; excluded here so the no-DB job cannot skip-green it; wired

--- a/plugins/plugin-integration-core/lib/sealed-export/vectors/s6a-package-provenance-pins.json
+++ b/plugins/plugin-integration-core/lib/sealed-export/vectors/s6a-package-provenance-pins.json
@@ -86,6 +86,6 @@
     "s6aAcceptancePs51Test": "835c7c6ce943d82e0378a40a27c7fd1e8b79b526faa8ca4c8066e4231a4bfb0f",
     "s6aProductRuntimeTest": "de978adafa8b89772cefa921c2051f434bf346bf5c2978bef3424ee70f51ba3f",
     "multitableOnpremPackageBuild": "463c7d73c6c7f2d1b6cdf0820d7a06974a9c463dd5e98bbbaf1c996e1dc4ed99",
-    "pluginTestsWorkflow": "44b8f44e103b46822357cb1125d7242539453a5f82999d9ab7520033d6149d20"
+    "pluginTestsWorkflow": "b8ae10b091f05f29e3b9486ce3c4ef2c7ceb39a47d750c7256217203e84805f3"
   }
 }

--- a/scripts/ops/attendance-legacy-membership-overlap-audit-contract.test.mjs
+++ b/scripts/ops/attendance-legacy-membership-overlap-audit-contract.test.mjs
@@ -1,0 +1,39 @@
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import { readFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+import test from 'node:test'
+
+const servicePath = 'packages/core-backend/src/services/AttendanceLegacyMembershipOverlapAudit.ts'
+const cliPath = 'scripts/ops/attendance-legacy-membership-overlap-audit.ts'
+const realDbPath = 'tests/integration/attendance-legacy-membership-overlap-audit.db.test.ts'
+const tsxCli = resolve('node_modules/tsx/dist/cli.mjs')
+
+test('legacy membership audit stays SELECT-only and wired into required CI', async () => {
+  const [service, cli, workflow, vitest] = await Promise.all([
+    readFile(servicePath, 'utf8'),
+    readFile(cliPath, 'utf8'),
+    readFile('.github/workflows/plugin-tests.yml', 'utf8'),
+    readFile('packages/core-backend/vitest.config.ts', 'utf8'),
+  ])
+
+  assert.match(service, /WHERE m\.org_id = \$1/)
+  assert.match(service, /LEFT JOIN attendance_groups g/)
+  assert.match(service, /information_schema\.columns/)
+  assert.doesNotMatch(service, /\b(?:INSERT|UPDATE|DELETE|MERGE|TRUNCATE|ALTER|DROP|CREATE)\b/i)
+  assert.match(cli, /auditAttendanceLegacyMembershipOverlaps/)
+  assert.match(cli, /manifest\.zeroConflicts \? 0 : 4/)
+  assert.match(workflow, new RegExp(realDbPath.replaceAll('.', '\\.')))
+  assert.match(workflow, /attendance-legacy-membership-overlap-audit\.test\.ts/)
+  assert.match(vitest, new RegExp(realDbPath.replaceAll('.', '\\.')))
+})
+
+test('legacy membership audit CLI fails closed when org is absent', () => {
+  const result = spawnSync(process.execPath, [tsxCli, cliPath], {
+    encoding: 'utf8',
+    timeout: 30_000,
+  })
+
+  assert.equal(result.status, 2, result.stderr)
+  assert.match(result.stderr, /ORG_ID_REQUIRED/)
+})

--- a/scripts/ops/attendance-legacy-membership-overlap-audit.ts
+++ b/scripts/ops/attendance-legacy-membership-overlap-audit.ts
@@ -1,0 +1,61 @@
+#!/usr/bin/env -S pnpm exec tsx
+import { pathToFileURL } from 'node:url'
+
+const connectionPoolNamespace = await import(
+  '../../packages/core-backend/src/integration/db/connection-pool'
+)
+const auditNamespace = await import(
+  '../../packages/core-backend/src/services/AttendanceLegacyMembershipOverlapAudit.ts'
+)
+const connectionPoolModule = (
+  'poolManager' in connectionPoolNamespace
+    ? connectionPoolNamespace
+    : (connectionPoolNamespace as unknown as { default: typeof connectionPoolNamespace }).default
+)
+const auditModule = (
+  'AttendanceLegacyMembershipAuditError' in auditNamespace
+    ? auditNamespace
+    : (auditNamespace as unknown as { default: typeof auditNamespace }).default
+)
+const { poolManager } = connectionPoolModule
+const {
+  ATTENDANCE_LEGACY_MEMBERSHIP_AUDIT_SCHEMA_NOT_READY,
+  AttendanceLegacyMembershipAuditError,
+  auditAttendanceLegacyMembershipOverlaps,
+} = auditModule
+
+function readOrgId(args: string[]): string {
+  const index = args.indexOf('--org')
+  if (index < 0 || !args[index + 1]?.trim()) {
+    throw new AttendanceLegacyMembershipAuditError(
+      'ORG_ID_REQUIRED',
+      400,
+      'Usage: pnpm exec tsx scripts/ops/attendance-legacy-membership-overlap-audit.ts --org <orgId>',
+    )
+  }
+  return args[index + 1].trim()
+}
+
+export async function main(args = process.argv.slice(2)): Promise<number> {
+  try {
+    const manifest = await auditAttendanceLegacyMembershipOverlaps(readOrgId(args))
+    process.stdout.write(`${JSON.stringify(manifest, null, 2)}\n`)
+    return manifest.zeroConflicts ? 0 : 4
+  } catch (error) {
+    if (error instanceof AttendanceLegacyMembershipAuditError) {
+      process.stderr.write(`${error.code}: ${error.message}\n`)
+      if (error.code === 'ORG_ID_REQUIRED') return 2
+      if (error.code === ATTENDANCE_LEGACY_MEMBERSHIP_AUDIT_SCHEMA_NOT_READY) return 3
+      return 3
+    }
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`)
+    return 1
+  }
+}
+
+const entry = process.argv[1] ? pathToFileURL(process.argv[1]).href : ''
+if (entry === import.meta.url) {
+  const exitCode = await main()
+  await poolManager.close()
+  process.exitCode = exitCode
+}


### PR DESCRIPTION
## Summary

- add a deterministic, org-scoped, SELECT-only audit for legacy `attendance_group_members` rows that place one user in multiple calculation groups
- fail closed on missing schema and missing/cross-org group references; emit an explicit manual-transfer manifest without inventing an effective interval or silently selecting a winner
- add an operator CLI with exercised exit codes `0` (clean), `2` (missing org), `3` (schema/integrity hold), and `4` (conflicts found)
- wire contract, unit, and isolated real-PostgreSQL coverage into the required plugin test workflow
- refresh the sealed-export provenance pin for the intentionally changed `plugin-tests.yml`; no sealed-export runtime or contract semantics change

## Scope

This is the read-only upgrade audit for #4710. It performs no automatic repair, migration deployment, flag change, production/customer-data access, or issue closure. The manifest points operators to the existing `transitionAttendanceCalculationGroupMembership` service and requires an explicit target group, effective date, actor, reason, and correlation id.

## Verification

- `node --test scripts/ops/attendance-legacy-membership-overlap-audit-contract.test.mjs` (2/2)
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/attendance-legacy-membership-overlap-audit.test.ts --reporter=dot` (4/4)
- `pnpm --filter @metasheet/core-backend type-check`
- isolated PostgreSQL test on local port 5435 (1/1), including fresh-schema hold, CLI `3/4/0`, deterministic rerun, two-org isolation, real cross-org FK shape, and concurrent `23P01` exclusion
- `node plugins/plugin-integration-core/__tests__/sealed-export-package-provenance.test.cjs`
- `pnpm --filter plugin-integration-core test:sealed-export-s5`
- `pnpm --filter plugin-integration-core test`
- post-test scratch-database residue: 0
- independent Kimi exact-delta review found two assertion-strength P2s; both are fixed in `dbd6ee1a12606fdb8e21554546b6cf5c351cae15`. Its remaining second-round concerns were independently checked by Codex against the production projector, one-SELECT loader, and atomic terminal UPDATE and found not applicable; no Kimi final APPROVE is claimed.

## Review posture

Draft only. Do not merge, deploy, enable flags, run on customer/production data, or close #4710 without the next explicit owner decision.