### PR TITLE
ci(stock-prep): T1 — PostgreSQL 17 validation for frozen S6-A package (#4695 gap 2)

### DIFF
--- a/.github/workflows/stock-prep-s6a-postgres17-validation.yml
+++ b/.github/workflows/stock-prep-s6a-postgres17-validation.yml
@@ -1,0 +1,414 @@
+name: Stock-prep S6-A PostgreSQL 17 validation (frozen package)
+
+# EVIDENCE ONLY — T1 for issue #4695 gap 2 ("PostgreSQL is 17 while the
+# unchanged packet is validated only on 15/16").
+#
+# This workflow downloads the ALREADY-PUBLISHED, FROZEN S6-A release asset
+# named below, verifies its bytes against the pinned SHA-256 before any use
+# (fail closed), runs the existing scripts/ops/multitable-onprem-package-verify.sh
+# five-check verifier against it unmodified, and exercises the package's own
+# migration runner (packages/core-backend/dist/src/db/migrate.js) against
+# ephemeral, isolated PostgreSQL 15/16/17 service containers so the same
+# migrations proven on 15/16 elsewhere are also proven to apply cleanly on 17.
+#
+# It never rebuilds or repacks the package, never sets or flips
+# MULTITABLE_STOCK_PREP_SQLSERVER_SEALED_SNAPSHOT_ENABLED (the flag stays
+# default/OFF and is never referenced here), never connects a customer
+# source, never provisions SQL Server or any customer-facing role, and never
+# touches an entity machine. A passing run here is CONTROLLED SYNTHETIC
+# FUNCTIONAL evidence only — it does not establish real-customer production,
+# sealed-snapshot semantics, high scale, external write, rollout, or
+# PLM/ERP/CRM/SRM generalization (see #4695). It also does not close #4695
+# gap 3 (isolated-database / SELECT-only-principal creation) — the ephemeral
+# CI database here is not a DBA-provisioned entity-machine database.
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  RELEASE_TAG: stock-prep-onprem-s6a-20260731-a45a2fe3f
+  PACKAGE_FILE: metasheet-multitable-onprem-v2.5.0-s6a-a45a2fe3f-20260731.zip
+  # FROZEN S6-A PINS (#4695). LAW — never recomputed, only verified against.
+  PACKAGE_SHA256_PIN: 0b80d927732e4866296e053a88958fc0b9fb44ee648cb200ee7116a3cdd72759
+  SERVICE_RUNTIME_SHA_PIN: a45a2fe3fa818b6b90830418a55a6b9f635e91c9
+  PACKAGE_PROVENANCE_MANIFEST_DIGEST_PIN: b5f40b3c9d56c04d4ff9001678f2cd9603c1bb1665bfe27decc0411a0e0270e6
+
+jobs:
+  # ---------------------------------------------------------------------
+  # Job 1: download the frozen asset, verify it fail-closed, and prove the
+  # negative control actually discriminates (mandatory per task spec).
+  # ---------------------------------------------------------------------
+  verify-frozen-package:
+    name: Verify frozen package (fail-closed) + one-byte negative control
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Environment guard (pwsh required by the packaged zip verifier)
+        run: |
+          set -euo pipefail
+          command -v pwsh >/dev/null 2>&1 || {
+            echo "ENVIRONMENT GAP: pwsh not found on this runner; the packaged"
+            echo "verifier's Windows ZipFile extraction smoke cannot run."
+            exit 1
+          }
+
+      - name: Download frozen release assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          gh release download "$RELEASE_TAG" \
+            --repo "${{ github.repository }}" \
+            -p "$PACKAGE_FILE" \
+            -p "SHA256SUMS" \
+            --clobber
+
+      - name: Fail-closed — downloaded bytes must equal the frozen pin
+        run: |
+          set -euo pipefail
+          actual="$(sha256sum "$PACKAGE_FILE" | awk '{print $1}')"
+          echo "computedPackageSha256=${actual}"
+          if [[ "$actual" != "$PACKAGE_SHA256_PIN" ]]; then
+            echo "FATAL: downloaded package SHA-256 does not equal the frozen packageSha256 pin. Aborting — never proceeding to 'test it anyway'." >&2
+            exit 1
+          fi
+          echo "packageSha256PinMatch=PASS"
+
+      - name: Run existing multitable-onprem-package-verify.sh (report-comparable with postfreeze-zip.verify.json)
+        run: |
+          set -euo pipefail
+          chmod +x scripts/ops/multitable-onprem-package-verify.sh
+          mkdir -p "${RUNNER_TEMP}/pkgroot-verify"
+          EXTRACT_ROOT="${RUNNER_TEMP}/pkgroot-verify" \
+          VERIFY_REPORT_JSON="${RUNNER_TEMP}/verify-report.json" \
+          VERIFY_REPORT_MD="${RUNNER_TEMP}/verify-report.md" \
+            scripts/ops/multitable-onprem-package-verify.sh "$PACKAGE_FILE"
+          echo "PKG_ROOT=${RUNNER_TEMP}/pkgroot-verify/${PACKAGE_FILE%.zip}" >> "$GITHUB_ENV"
+
+      - name: Build provenance gitCommit must equal serviceRuntimeSha pin
+        run: |
+          set -euo pipefail
+          actual_git_commit="$(node -e "console.log(JSON.parse(require('fs').readFileSync(process.argv[1],'utf8')).gitCommit)" "${PKG_ROOT}/BUILD_PROVENANCE.json")"
+          echo "buildProvenanceGitCommit=${actual_git_commit}"
+          if [[ "$actual_git_commit" != "$SERVICE_RUNTIME_SHA_PIN" ]]; then
+            echo "FATAL: BUILD_PROVENANCE.json gitCommit does not equal the frozen serviceRuntimeSha pin." >&2
+            exit 1
+          fi
+          echo "buildProvenanceGitCommitPinMatch=PASS"
+
+      - name: Sealed-export frozenManifestDigest must equal packageProvenanceManifestDigest pin
+        run: |
+          set -euo pipefail
+          actual_digest="$(node -e "
+            const p = require(process.argv[1]);
+            const r = p.verifySealedExportRuntimePackageProvenance({ repoRoot: process.argv[2] });
+            if (r.verified !== true) { process.exit(1); }
+            console.log(r.frozenManifestDigest);
+          " "${PKG_ROOT}/plugins/plugin-integration-core/lib/sealed-export/sealed-export-package-provenance.cjs" "${PKG_ROOT}")"
+          echo "frozenManifestDigest=${actual_digest}"
+          if [[ "$actual_digest" != "$PACKAGE_PROVENANCE_MANIFEST_DIGEST_PIN" ]]; then
+            echo "FATAL: frozenManifestDigest does not equal the frozen packageProvenanceManifestDigest pin." >&2
+            exit 1
+          fi
+          echo "frozenManifestDigestPinMatch=PASS"
+
+      - name: One-byte negative control — mandatory, exclusive, hard-fails the job if it does not fire
+        run: |
+          set -euo pipefail
+          mkdir -p neg-control/positive neg-control/negative
+          cp "$PACKAGE_FILE" "neg-control/positive/$PACKAGE_FILE"
+          cp SHA256SUMS "neg-control/positive/SHA256SUMS"
+          cp "$PACKAGE_FILE" "neg-control/negative/$PACKAGE_FILE"
+          cp SHA256SUMS "neg-control/negative/SHA256SUMS"
+
+          # Flip exactly one byte (bitwise complement, i.e. XOR 0xFF) at a fixed
+          # offset in the negative copy only. Pure dd/od/printf — no heredoc, so
+          # there is no risk of YAML block-scalar indentation corrupting a
+          # nested script (e.g. a Python IndentationError from inherited spaces).
+          negfile="neg-control/negative/$PACKAGE_FILE"
+          offset=2048
+          orig_byte_dec="$(dd if="$negfile" bs=1 skip="$offset" count=1 2>/dev/null | od -An -tu1 | tr -d ' ')"
+          flipped_byte_dec=$(( 255 - orig_byte_dec ))
+          flipped_octal_escape="$(printf '\\%03o' "$flipped_byte_dec")"
+          printf "$flipped_octal_escape" | dd of="$negfile" bs=1 seek="$offset" count=1 conv=notrunc 2>/dev/null
+
+          pos_sha="$(sha256sum "neg-control/positive/$PACKAGE_FILE" | awk '{print $1}')"
+          neg_sha="$(sha256sum "neg-control/negative/$PACKAGE_FILE" | awk '{print $1}')"
+          echo "positiveArmSha256=${pos_sha}"
+          echo "negativeArmSha256=${neg_sha}"
+          if [[ "$pos_sha" != "$PACKAGE_SHA256_PIN" ]]; then
+            echo "FATAL: positive arm (unmutated copy) does not match the pin — negative control setup is broken." >&2
+            exit 1
+          fi
+          if [[ "$neg_sha" == "$PACKAGE_SHA256_PIN" ]]; then
+            echo "FATAL: one-byte mutation did not change the SHA-256 (should be impossible)." >&2
+            exit 1
+          fi
+
+          set +e
+          scripts/ops/multitable-onprem-package-verify.sh "neg-control/positive/$PACKAGE_FILE" >pos.log 2>&1
+          pos_rc=$?
+          scripts/ops/multitable-onprem-package-verify.sh "neg-control/negative/$PACKAGE_FILE" >neg.log 2>&1
+          neg_rc=$?
+          set -e
+
+          echo "positiveArmExitCode=${pos_rc}"
+          echo "negativeArmExitCode=${neg_rc}"
+          echo "--- positive arm output ---"
+          cat pos.log
+          echo "--- negative arm output ---"
+          cat neg.log
+
+          if [[ "$pos_rc" -ne 0 ]]; then
+            echo "FATAL: positive arm (identical layout, unmutated bytes) unexpectedly failed verification." >&2
+            exit 1
+          fi
+          if [[ "$neg_rc" -eq 0 ]]; then
+            echo "FATAL P0: one-byte mutation did NOT cause verification to fail. The negative control did not fire — 'verification passed' would be indistinguishable from 'verification did not run'." >&2
+            exit 1
+          fi
+          if ! grep -qiE "checksum mismatch|FAILED|did NOT match" neg.log; then
+            echo "FATAL: negative arm failed for a reason other than the checksum (not exclusive to the byte flip) — cannot attribute the failure to the mutation." >&2
+            exit 1
+          fi
+          echo "oneByteNegativeCheck=PASS"
+
+      - name: Upload verify evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: t1-verify-frozen-package-evidence
+          retention-days: 14
+          if-no-files-found: warn
+          path: |
+            ${{ runner.temp }}/verify-report.json
+            ${{ runner.temp }}/verify-report.md
+            pos.log
+            neg.log
+
+      - name: Values-free evidence (this job)
+        run: |
+          {
+            echo "releaseTag=${RELEASE_TAG}"
+            echo "packageFile=${PACKAGE_FILE}"
+            echo "packageSha256=${PACKAGE_SHA256_PIN}"
+            echo "packageSha256PinMatch=PASS"
+            echo "packageVerification=PASS"
+            echo "buildProvenanceGitCommitPinMatch=PASS"
+            echo "frozenManifestDigestPinMatch=PASS"
+            echo "oneByteNegativeCheck=PASS"
+          } | tee -a "$GITHUB_STEP_SUMMARY"
+
+  # ---------------------------------------------------------------------
+  # Job 2: exercise the frozen, verified package's own migration runner
+  # against ephemeral PostgreSQL 15/16/17 so a reader sees the matrix, not
+  # a single green cell. 15/16 are the already-validated control legs; 17
+  # is the gap this workflow exists to close.
+  # ---------------------------------------------------------------------
+  migrate-postgres:
+    name: Migrate on PostgreSQL ${{ matrix.pg }}
+    needs: verify-frozen-package
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        pg: ['15', '16', '17']
+    services:
+      postgres:
+        image: postgres:${{ matrix.pg }}
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: metasheet_s6a_t1
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d metasheet_s6a_t1"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 20
+    env:
+      DATABASE_URL: postgresql://postgres:postgres@127.0.0.1:5432/metasheet_s6a_t1
+      JWT_SECRET: t1-ci-synthetic-not-a-secret
+      PGPASSWORD: postgres
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download frozen release assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          gh release download "$RELEASE_TAG" \
+            --repo "${{ github.repository }}" \
+            -p "$PACKAGE_FILE" \
+            -p "SHA256SUMS" \
+            --clobber
+
+      - name: Fail-closed — downloaded bytes must equal the frozen pin
+        run: |
+          set -euo pipefail
+          actual="$(sha256sum "$PACKAGE_FILE" | awk '{print $1}')"
+          if [[ "$actual" != "$PACKAGE_SHA256_PIN" ]]; then
+            echo "FATAL: downloaded package SHA-256 does not equal the frozen packageSha256 pin. Aborting." >&2
+            exit 1
+          fi
+          echo "packageSha256PinMatch=PASS"
+
+      - name: Run existing multitable-onprem-package-verify.sh
+        run: |
+          set -euo pipefail
+          chmod +x scripts/ops/multitable-onprem-package-verify.sh
+          mkdir -p "${RUNNER_TEMP}/pkgroot"
+          EXTRACT_ROOT="${RUNNER_TEMP}/pkgroot" \
+            scripts/ops/multitable-onprem-package-verify.sh "$PACKAGE_FILE"
+          echo "PKG_ROOT=${RUNNER_TEMP}/pkgroot/${PACKAGE_FILE%.zip}" >> "$GITHUB_ENV"
+
+      - name: Confirm the live server actually is PostgreSQL ${{ matrix.pg }}
+        run: |
+          set -euo pipefail
+          command -v psql >/dev/null 2>&1 || { sudo apt-get update -qq && sudo apt-get install -y -qq postgresql-client; }
+          server_version_num="$(psql -h 127.0.0.1 -U postgres -d metasheet_s6a_t1 -tAc 'SHOW server_version_num')"
+          server_major=$(( server_version_num / 10000 ))
+          echo "postgresServerVersionMajor=${server_major}"
+          if [[ "${server_major}" != "${{ matrix.pg }}" ]]; then
+            echo "FATAL: live server major version (${server_major}) does not match the matrix leg (${{ matrix.pg }}) — evidence would not actually distinguish PostgreSQL versions." >&2
+            exit 1
+          fi
+          echo "postgresServerVersionPinMatch=PASS"
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          # Matches the package's own package.json packageManager pin
+          # (verified by multitable-onprem-package-verify.sh) and the
+          # multitable-onprem-package-build.yml build/apply contract.
+          version: 9.15.9
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install the frozen package's own pinned dependencies (frozen lockfile — never relaxed)
+        working-directory: ${{ env.PKG_ROOT }}
+        run: pnpm install --frozen-lockfile --reporter=append-only
+
+      - name: Migration status before apply (expect a fresh, unmigrated database)
+        working-directory: ${{ env.PKG_ROOT }}
+        run: |
+          set -euo pipefail
+          node packages/core-backend/dist/src/db/migrate.js --list | tee "${RUNNER_TEMP}/migrate-list-pre.log"
+          applied_pre="$(grep -oE '^Applied: [0-9]+' "${RUNNER_TEMP}/migrate-list-pre.log" | awk '{print $2}')"
+          echo "migrationsAppliedPre=${applied_pre}"
+          if [[ "${applied_pre}" != "0" ]]; then
+            echo "FATAL: database was not fresh before apply (Applied != 0) — a positive result afterward would not prove real work happened." >&2
+            exit 1
+          fi
+
+      - name: Apply all migrations (packages/core-backend/dist/src/db/migrate.js, default latest)
+        working-directory: ${{ env.PKG_ROOT }}
+        run: node packages/core-backend/dist/src/db/migrate.js
+
+      - name: Migration status after apply (expect zero pending)
+        working-directory: ${{ env.PKG_ROOT }}
+        run: |
+          set -euo pipefail
+          node packages/core-backend/dist/src/db/migrate.js --list | tee "${RUNNER_TEMP}/migrate-list-post.log"
+          pending_post="$(grep -oE '^Pending: [0-9]+' "${RUNNER_TEMP}/migrate-list-post.log" | awk '{print $2}')"
+          applied_post="$(grep -oE '^Applied: [0-9]+' "${RUNNER_TEMP}/migrate-list-post.log" | awk '{print $2}')"
+          echo "migrationsAppliedPost=${applied_post}"
+          echo "migrationsPendingPost=${pending_post}"
+          if [[ "${pending_post}" != "0" ]]; then
+            echo "FATAL: migrations did not apply cleanly end to end (Pending != 0 after latest)." >&2
+            exit 1
+          fi
+
+      - name: Confirm migration 073 (sealed-export stock-prep runtime authority) specifically applied
+        working-directory: ${{ env.PKG_ROOT }}
+        run: node packages/core-backend/dist/src/db/migrate.js --confirm 073_create_sealed_export_stock_prep_runtime_authority
+
+      - name: Idempotent replay — re-run latest against an already-migrated database
+        working-directory: ${{ env.PKG_ROOT }}
+        run: node packages/core-backend/dist/src/db/migrate.js
+
+      - name: Upload per-version evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: t1-migrate-postgres-${{ matrix.pg }}-evidence
+          retention-days: 14
+          if-no-files-found: warn
+          path: |
+            ${{ runner.temp }}/migrate-list-pre.log
+            ${{ runner.temp }}/migrate-list-post.log
+
+      - name: Values-free evidence (this leg)
+        run: |
+          {
+            echo "postgresMajorVersion=${{ matrix.pg }}"
+            echo "postgresServerVersionPinMatch=PASS"
+            echo "packageSha256PinMatch=PASS"
+            echo "dependencyInstall=PASS"
+            echo "migrationsAppliedPre=0"
+            echo "migrationApply=PASS"
+            echo "migrationsPendingPost=0"
+            echo "migration073Confirmed=PASS"
+            echo "migrationReplayIdempotent=PASS"
+          } | tee -a "$GITHUB_STEP_SUMMARY"
+
+  # ---------------------------------------------------------------------
+  # Job 3: gate on both jobs above and publish one combined, values-free
+  # evidence block.
+  # ---------------------------------------------------------------------
+  evidence-summary:
+    name: T1 evidence summary
+    needs: [verify-frozen-package, migrate-postgres]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Require both upstream jobs to have fully succeeded
+        env:
+          VERIFY_RESULT: ${{ needs.verify-frozen-package.result }}
+          MIGRATE_RESULT: ${{ needs.migrate-postgres.result }}
+        run: |
+          set -euo pipefail
+          echo "verify-frozen-package result: ${VERIFY_RESULT}"
+          echo "migrate-postgres (all of 15/16/17) result: ${MIGRATE_RESULT}"
+          if [[ "${VERIFY_RESULT}" != "success" || "${MIGRATE_RESULT}" != "success" ]]; then
+            echo "One or more T1 gates did not pass; overall FAIL." >&2
+            exit 1
+          fi
+
+      - name: Values-free combined evidence block
+        run: |
+          {
+            echo "evidenceKind=CONTROLLED_SYNTHETIC_FUNCTIONAL"
+            echo "serviceRuntimeSha=${SERVICE_RUNTIME_SHA_PIN}"
+            echo "releaseTag=${RELEASE_TAG}"
+            echo "packageFile=${PACKAGE_FILE}"
+            echo "packageSha256=${PACKAGE_SHA256_PIN}"
+            echo "packageProvenanceManifestDigest=${PACKAGE_PROVENANCE_MANIFEST_DIGEST_PIN}"
+            echo "packageVerification=PASS"
+            echo "oneByteNegativeCheck=PASS"
+            echo "postgresMajorVersionsExercised=15,16,17"
+            echo "postgresGapVersion=17"
+            echo "postgresGapVersionValidation=PASS"
+            echo "migrationApplyAllVersions=PASS"
+            echo "migrationReplayIdempotentAllVersions=PASS"
+            echo "customerSourceAccess=NOT_INVOLVED"
+            echo "entityMachineInvolved=false"
+            echo "flagChanged=false"
+            echo "flagDefaultAndFinal=OFF"
+            echo "externalWrite=false"
+            echo "overallT1Result=PASS"
+          } | tee -a "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/stock-prep-s6a-postgres17-validation.yml
+++ b/.github/workflows/stock-prep-s6a-postgres17-validation.yml
@@ -173,7 +173,15 @@ jobs:
             echo "FATAL P0: one-byte mutation did NOT cause verification to fail. The negative control did not fire — 'verification passed' would be indistinguishable from 'verification did not run'." >&2
             exit 1
           fi
-          if ! grep -qiE "checksum mismatch|FAILED|did NOT match" neg.log; then
+          # Checksum-specific strings only. A bare "FAILED"/"-i" pattern would
+          # also match unrelated failures (e.g. verify_windows_zip_zipfile_smoke's
+          # "Windows ZipFile extraction smoke failed for zip package"), which
+          # would let an environment problem masquerade as the negative control
+          # firing. verify_sha() runs before any archive/pwsh checks in
+          # multitable-onprem-package-verify.sh, so on a genuine byte flip only
+          # these checksum-specific strings can appear — but the guard must
+          # assert that itself, not rely on step ordering silently holding.
+          if ! grep -qE "did NOT match|Checksum mismatch for" neg.log; then
             echo "FATAL: negative arm failed for a reason other than the checksum (not exclusive to the byte flip) — cannot attribute the failure to the mutation." >&2
             exit 1
           fi

--- a/.github/workflows/stock-prep-s6a-postgres17-validation.yml
+++ b/.github/workflows/stock-prep-s6a-postgres17-validation.yml
@@ -246,6 +246,29 @@ jobs:
       DATABASE_URL: postgresql://postgres:postgres@127.0.0.1:5432/metasheet_s6a_t1
       JWT_SECRET: t1-ci-synthetic-not-a-secret
       PGPASSWORD: postgres
+      # WHY THIS EXISTS, and why the list is migration-replay.yml's and not plugin-tests.yml's.
+      #
+      # Without it this job cannot go green, for reasons that have nothing to do with
+      # PostgreSQL 17. The frozen S6-A package ships migrations that EVERY fresh-database
+      # lane in this repository already excludes for documented, still-open defects
+      # (008 idempotency on the scope column; the gantt FK pointing at pre-fix text view
+      # ids; the legacy user_orgs is_active incompatibility). They are NOT neutralised by
+      # SUPERSEDED_LEGACY_SQL_MIGRATIONS, which only no-ops 042a/048/049.
+      #
+      # This repository keeps TWO deliberately different lists (they are documented as
+      # solving different problems and as not required to converge — see
+      # packages/core-backend/MIGRATION_EXCLUDE_TRACKING.md). This job's shape — fresh
+      # database, apply latest, assert Pending 0, then re-run latest and assert
+      # idempotency — is migration-replay.yml's shape, so it takes migration-replay.yml's
+      # list verbatim. plugin-tests.yml's list differs in its final entry and is the
+      # per-PR gate's, not this one's.
+      #
+      # WHAT THIS NARROWS THE CLAIM TO. Evidence from this job means: the frozen
+      # package's migrations, MINUS the six excluded below, apply cleanly and idempotently
+      # on the matrix PostgreSQL major version. It does NOT mean the full unexcluded set
+      # applies on any version — that has never had a green run on any version in this
+      # repository (see #4162), so it is not a PostgreSQL 17 question.
+      MIGRATION_EXCLUDE: 008_plugin_infrastructure.sql,048_create_event_bus_tables.sql,049_create_bpmn_workflow_tables.sql,042a_core_model_views.sql,20250924140000_create_gantt_tables.ts,zzzz20260114110000_create_user_orgs_table.ts
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Scope

T1 for #4695: adds `.github/workflows/stock-prep-s6a-postgres17-validation.yml`, a `workflow_dispatch`-only workflow that closes gap 2 recorded in #4695 ("PostgreSQL is 17 while the unchanged packet is validated only on 15/16").

It:
1. downloads the already-published, frozen `stock-prep-onprem-s6a-20260731-a45a2fe3f` release `.zip` + `SHA256SUMS` — never rebuilds/repacks;
2. verifies the downloaded bytes equal the pinned `packageSha256` before any use (fail closed);
3. runs the existing `scripts/ops/multitable-onprem-package-verify.sh` five-check verifier unmodified, so the report is comparable with the release's own `postfreeze-zip.verify.json`;
4. additionally verifies `BUILD_PROVENANCE.json.gitCommit == serviceRuntimeSha` and the packaged sealed-export provenance verifier's `frozenManifestDigest == packageProvenanceManifestDigest`, both against the frozen pins — never recomputed-and-overwritten, only checked against;
5. runs a **mandatory one-byte negative control**: an identical positive/negative directory layout, one bitwise-flipped byte in the negative copy only, and a hard fail (`exit 1`) if the mutation does *not* cause verification to fail, or if it fails for an unrelated reason;
6. exercises the package's own `packages/core-backend/dist/src/db/migrate.js` against ephemeral PostgreSQL **15/16/17** service containers (matrix, `fail-fast: false`) — with a live `SHOW server_version_num` check so the evidence is tied to the server actually running, not just the matrix label — proving `Applied: 0` before, migrations apply with exit 0, `Pending: 0` after, migration `073_create_sealed_export_stock_prep_runtime_authority` is specifically confirmed applied, and a replay is idempotent.

## What this does NOT do

- Does not rebuild, repack, or regenerate the package.
- Does not change `MULTITABLE_STOCK_PREP_SQLSERVER_SEALED_SNAPSHOT_ENABLED` (stays default OFF; never referenced).
- Does not connect a customer source, provision SQL Server, or touch an entity machine.
- Does not close #4695 gap 3 (isolated-database / SELECT-only-principal creation) — the ephemeral CI database is not a DBA-provisioned entity-machine database.
- Does not merge, push to main, or touch branch protection.

A passing run is **controlled synthetic functional evidence only**; it does not establish real-customer production, sealed-snapshot semantics, high scale, external write, rollout, or PLM/ERP/CRM/SRM generalization.

## Execution status — read before trusting any "PASS" line above

**The in-CI workflow (`stock-prep-s6a-postgres17-validation.yml`) has never executed. There is no run URL and no CI-produced evidence at this head.** GitHub's `workflow_dispatch` API only lists/dispatches a workflow whose file already exists on the **default branch**; this repo's standing constraint is no merge to `main` in this pass, so dispatch was attempted and rejected exactly as expected:

```
$ gh workflow run stock-prep-s6a-postgres17-validation.yml --repo zensgit/metasheet2 --ref claude/t1-stock-prep-4695-postgres17-validation-20260802
HTTP 404: workflow stock-prep-s6a-postgres17-validation.yml not found on the default branch (https://api.github.com/repos/zensgit/metasheet2/actions/workflows/stock-prep-s6a-postgres17-validation.yml)
```

**Remedy**: the workflow file must land on `main` (via merging this PR, or another authorized route) before `gh workflow run ... --ref <any-branch>` — including this one — will succeed. That is out of scope for this draft under the standing no-merge constraint. Once it lands, the *same* dispatch command against this branch's ref will work without further changes to the file.

Consequently, every `echo "...=PASS"` line inside the workflow YAML (the job step summaries and the combined evidence block) is an **unexecuted string literal**, not a measured result. Treat the file as the evidence the workflow *will* emit on a successful post-landing run, not as evidence that already exists.

### What was actually, separately verified in this pass (real, executed, off-CI)

Two things were independently confirmed against the real frozen release bytes, outside the (not-yet-dispatchable) workflow, precisely to give the one-byte negative control real teeth before merge:

- **Pin cross-check**: downloaded `SHA256SUMS` and the `.zip.sha256` sidecar from the release both read `packageSha256=0b80d927732e4866296e053a88958fc0b9fb44ee648cb200ee7116a3cdd72759` — the frozen pin matches the published bytes.
- **Real, both-arms one-byte negative control**, run locally against the downloaded frozen zip using the unmodified `scripts/ops/multitable-onprem-package-verify.sh` (same script the workflow calls, same offset/flip logic as the workflow step):
  - positive arm (unmutated copy): `positiveArmExitCode=0`, verifier reports `Package verify OK`.
  - negative arm (byte 2048 bitwise-flipped): `negativeArmExitCode=1`, verifier output: `sha256sum: WARNING: 1 computed checksum did NOT match` / `...zip: FAILED`.
  - the verifier keys off `SHA256SUMS` (not the `.sha256` sidecar) via `sha256sum -c -`, which is why the workflow step copies `SHA256SUMS` (not the sidecar) into both arm directories.

This is real, currently-executed evidence for the checksum-verification half of the design. It is **not** a substitute for the in-CI job (which also matters for the pnpm/Node toolchain, the PostgreSQL 15/16/17 migration matrix, and the provenance-digest checks) — those remain **NOT RUN** until the workflow can be dispatched post-landing.

### Fixed during this pass: exclusivity-guard was word-level, not door-level

The negative control's exclusivity check originally read `grep -qiE "checksum mismatch|FAILED|did NOT match"`. The bare, case-insensitive `FAILED` alternative also matches an unrelated failure string from the same script — `verify_windows_zip_zipfile_smoke`'s `"Windows ZipFile extraction smoke failed for zip package"` (fires when `pwsh` is missing or the Windows-extraction smoke itself breaks). That would let an environment failure masquerade as "the negative control fired for the intended reason." It was unreachable in practice only because `verify_sha()` runs before any archive/pwsh checks in `multitable-onprem-package-verify.sh` — but the assertion didn't establish that itself, it relied on step ordering holding silently.

Fixed to `grep -qE "did NOT match|Checksum mismatch for"` (checksum-specific strings, case-sensitive, no bare `FAILED`). Verified both directions locally: the real negative-arm output above (`did NOT match` / `...zip: FAILED`) still matches; the unrelated pwsh-smoke failure string no longer does.

### Unvalidated until the workflow actually dispatches

These are plausible-but-unproven aspects of job 2 (the PostgreSQL 15/16/17 migration matrix) that no static read or local check can settle — only a real dispatch:

- `pnpm install --frozen-lockfile` inside the extracted package root — unverified whether the package ships `node_modules` already (which could make this step redundant but shouldn't break it) or expects a clean install.
- `migrate.js --list` behavior against a database with no migrations-tracking table yet (first run ever) — assumed to report `Applied: 0` cleanly rather than erroring.
- `working-directory: ${{ env.PKG_ROOT }}` resolves from a value written to `$GITHUB_ENV` in an earlier step in the *same* job — standard GitHub Actions behavior, but only a real run confirms it resolves as intended here.

None of these are rebuild/repack workarounds and none were exercised in this pass; they are named so a reader does not read job 2's absence of failure as evidence of its correctness.

## Status

Draft — evidence-gathering PR only, not for merge in this pass.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>



---

## 追加(审阅后修正,2026-08-03)

### 加入 `MIGRATION_EXCLUDE` —— 否则这个 job 不可能变绿

复审指出 job 2 以**无 `MIGRATION_EXCLUDE`** 的方式跑迁移。冻结的 S6-A 包里带着**本仓每一条 fresh-database 通道都已排除**的迁移,原因都还开着:`008` 的 scope 列幂等问题、gantt 外键指向修复前的 text view id、legacy `user_orgs` 的 `is_active` 不兼容。它们**不被 `SUPERSEDED_LEGACY_SQL_MIGRATIONS` 中和**——那个只 no-op 掉 042a/048/049。

所以第一次 dispatch 会红在**与 PostgreSQL 17 完全无关**的三个已知缺陷上,白跑一轮。

**用的是 `migration-replay.yml` 的清单,不是 `plugin-tests.yml` 的。** 两份清单**最后一项不同**,且仓内文档明确写着它们「解决不同问题、不要求收敛」。本 job 的形状——干净库 → apply latest → 断言 Pending 归零 → 再跑一次断言幂等——**正是 `migration-replay` 的形状**,所以逐字取它那份。已核验:与 `migration-replay.yml` 的值**逐字节相同**。

### 这把结论收窄成什么(必须照此表述)

本 job 的证据含义是:**冻结包的迁移集合、减去被排除的那六个,在矩阵所指的 PostgreSQL 主版本上干净且幂等地应用。**

它**不**意味着完整未排除集合能在任何版本上应用——那**在本仓任何版本上都从未有过绿色运行**(见 #4162),**所以那不是一个 PostgreSQL 17 的问题**,不能被本 job 回答,也不该被本 job 声称。

### 仍未验证(补入本 PR 原有清单)

- 上述排除生效后 job 2 是否真能在 15/16/17 上走完 —— **本 workflow 至今一次都没执行过**;
- 迁移 073 的**角色相关分支**:干净 CI 库上两个 GUC 都没设,073 走 NOTICE-and-RETURN 路径,**其版本敏感的 `pg_roles` / `pg_has_role` / `pg_auth_members` 代码从未在 PG17 上执行**。因此 `migration073Confirmed=PASS` 只能读作「迁移集合在 17 上应用成功」,**不能**读作「073 的角色姿态在 17 上可用」。**不得**通过在 CI 里设置那两个 GUC 来「修复」——那是 provisioning,超出本 PR 约束。
