### PR TITLE
feat(stock-prep): RD-E2E — containerized entity-machine-free functional smoke

### DIFF
--- a/.github/workflows/stock-preparation-e2e-functional-smoke.yml
+++ b/.github/workflows/stock-preparation-e2e-functional-smoke.yml
@@ -132,16 +132,24 @@ jobs:
           echo "SQL Server never became ready within timeout"
           exit 1
 
-      - name: Generate CI-local ephemeral secrets (never logged, scoped to this run only)
+      - name: Generate CI-local ephemeral secrets (masked, never logged, scoped to this run only)
         run: |
           set -euo pipefail
+          jwt_secret="$(openssl rand -hex 32)"
+          enc_key="$(openssl rand -hex 32)"
+          runtime_password="$(openssl rand -hex 16)"
+          provisioning_password="$(openssl rand -hex 16)"
+          echo "::add-mask::$jwt_secret"
+          echo "::add-mask::$enc_key"
+          echo "::add-mask::$runtime_password"
+          echo "::add-mask::$provisioning_password"
           {
-            echo "E2E_JWT_SECRET=$(openssl rand -hex 32)"
-            echo "E2E_INTEGRATION_ENCRYPTION_KEY=$(openssl rand -hex 32)"
+            echo "E2E_JWT_SECRET=$jwt_secret"
+            echo "E2E_INTEGRATION_ENCRYPTION_KEY=$enc_key"
             echo "E2E_S6A_RUNTIME_DB_ROLE=e2e_s6a_runtime"
-            echo "E2E_S6A_RUNTIME_DB_PASSWORD=$(openssl rand -hex 16)"
+            echo "E2E_S6A_RUNTIME_DB_PASSWORD=$runtime_password"
             echo "E2E_S6A_PROVISIONING_DB_ROLE=e2e_s6a_provision"
-            echo "E2E_S6A_PROVISIONING_DB_PASSWORD=$(openssl rand -hex 16)"
+            echo "E2E_S6A_PROVISIONING_DB_PASSWORD=$provisioning_password"
           } >> "$GITHUB_ENV"
 
       - name: Provision sealed-export Postgres roles, then run migrations with both roles visible
@@ -241,12 +249,16 @@ jobs:
           DATABASE_URL: postgresql://postgres:postgres@127.0.0.1:5432/metasheet
         run: pnpm --filter @metasheet/core-backend run migrate
 
-      - name: Generate CI-local ephemeral secrets (never logged, scoped to this run only)
+      - name: Generate CI-local ephemeral secrets (masked, never logged, scoped to this run only)
         run: |
           set -euo pipefail
+          jwt_secret="$(openssl rand -hex 32)"
+          enc_key="$(openssl rand -hex 32)"
+          echo "::add-mask::$jwt_secret"
+          echo "::add-mask::$enc_key"
           {
-            echo "E2E_JWT_SECRET=$(openssl rand -hex 32)"
-            echo "E2E_INTEGRATION_ENCRYPTION_KEY=$(openssl rand -hex 32)"
+            echo "E2E_JWT_SECRET=$jwt_secret"
+            echo "E2E_INTEGRATION_ENCRYPTION_KEY=$enc_key"
           } >> "$GITHUB_ENV"
 
       - name: Run negative control (this step is EXPECTED to fail)

--- a/.github/workflows/stock-preparation-e2e-functional-smoke.yml
+++ b/.github/workflows/stock-preparation-e2e-functional-smoke.yml
@@ -89,6 +89,7 @@ jobs:
         image: mcr.microsoft.com/mssql/server:2022-latest
         env:
           ACCEPT_EULA: 'Y'
+          # Ephemeral, throwaway container password (destroyed with the job) — not a real credential.
           MSSQL_SA_PASSWORD: 'E2eFunc!Probe2026'
         ports:
           - 1433:1433

--- a/.github/workflows/stock-preparation-e2e-functional-smoke.yml
+++ b/.github/workflows/stock-preparation-e2e-functional-smoke.yml
@@ -15,26 +15,60 @@ name: Stock Preparation E2E Functional Smoke
 # core-backend server-process environment for the duration of one arm — never in a committed file, never
 # as a repository/environment variable default, and the process is always restarted flag-OFF afterward.
 #
-# Two jobs:
-#   functional-smoke   — the real lane: flag-OFF arm, exact-match arm ('1'/'yes' must NOT enable it),
-#                         the EXISTING T4 extended-smoke chain reproduced against this local server, and
-#                         a best-effort real S6-A flag-ON run (capture -> ingestion -> generation kernel
-#                         -> apply) over a first-party ephemeral SQL Server relation. Any part that
-#                         cannot complete is reported NOT_RUN in the values-free result block — never as
-#                         PASS — and the job goes red if any check that DID run failed.
-#   negative-control    — deliberately RED. Reuses the SAME assertion machinery as functional-smoke and
-#                         asserts a wrong expectation on purpose, proving the harness can genuinely fail
-#                         (not a check "that did not happen").
+# Three jobs:
+#   contract            — pull_request only: syntax-checks the harness scripts (no server, no DB, no
+#                         secrets). Exists ONLY so GitHub registers this workflow_dispatch workflow while
+#                         it lives on a feature branch — GitHub will not let a brand-new workflow_dispatch
+#                         workflow be manually dispatched until it has run at least once via a trigger it
+#                         responds to (docs: a workflow_dispatch workflow must be on the default branch,
+#                         OR have already executed via another trigger, to appear as dispatchable). This
+#                         is the SAME idiom stock-preparation-prep-line-extended-smoke.yml and the
+#                         sealed-export-s2/s5 workflows already use in this repo.
+#   functional-smoke     — the real lane, workflow_dispatch only: flag-OFF arm, exact-match arm
+#                         ('1'/'yes' must NOT enable it), the EXISTING T4 extended-smoke chain reproduced
+#                         against this local server, and a best-effort real S6-A flag-ON run (capture ->
+#                         ingestion -> generation kernel -> apply) over a first-party ephemeral SQL Server
+#                         relation. Any part that cannot complete is reported NOT_RUN in the values-free
+#                         result block — never as PASS — and the job goes red if any check that DID run
+#                         failed.
+#   negative-control     — workflow_dispatch only, deliberately RED. Reuses the SAME assertion machinery
+#                         as functional-smoke and asserts a wrong expectation on purpose, proving the
+#                         harness can genuinely fail (not a check "that did not happen").
 
 on:
+  pull_request:
+    paths:
+      - '.github/workflows/stock-preparation-e2e-functional-smoke.yml'
+      - 'scripts/ops/stock-preparation-e2e-functional-smoke.mjs'
+      - 'scripts/ops/stock-preparation-e2e-negative-control.mjs'
+      - 'scripts/ops/stock-preparation-e2e-provision-postgres-roles-and-migrate.mjs'
   workflow_dispatch:
 
 permissions:
   contents: read
 
 jobs:
+  contract:
+    name: harness syntax contract (no server, no DB, no secrets)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Setup Node.js 20.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+      - name: Syntax-check the E2E harness scripts
+        run: |
+          node --check scripts/ops/stock-preparation-e2e-functional-smoke.mjs
+          node --check scripts/ops/stock-preparation-e2e-negative-control.mjs
+          node --check scripts/ops/stock-preparation-e2e-provision-postgres-roles-and-migrate.mjs
+
   functional-smoke:
     name: containerized functional smoke (existing chain + S6-A flag arms)
+    if: github.event_name == 'workflow_dispatch'
+    needs: contract
     runs-on: ubuntu-latest
     timeout-minutes: 45
     services:
@@ -161,6 +195,8 @@ jobs:
 
   negative-control:
     name: negative control (deliberately RED — proves the harness can fail)
+    if: github.event_name == 'workflow_dispatch'
+    needs: contract
     runs-on: ubuntu-latest
     timeout-minutes: 15
     services:

--- a/.github/workflows/stock-preparation-e2e-functional-smoke.yml
+++ b/.github/workflows/stock-preparation-e2e-functional-smoke.yml
@@ -1,0 +1,221 @@
+name: Stock Preparation E2E Functional Smoke
+
+# RD-E2E: containerized, entity-machine-free FUNCTIONAL testing of the stock-preparation feature surface
+# (32 routes under /api/integration/stock-preparation/... plus the flag-gated S6-A internal route). This
+# is functional testing on synthetic data ONLY. It is NOT the #4695 controlled acceptance (one real
+# customer, the entity machine, an S6-B owner-gated single flag-on window — see
+# docs/operations/stock-preparation-s6a-sqlserver-onprem-runbook-20260731.md) and does NOT substitute for
+# it: no real-customer claim, no scale claim, no external-write claim, no rollout claim is established
+# here. This lane never deploys, never arms, and never touches any #4695 frozen input or the deployed
+# entity host.
+#
+# Dispatch-only. Postgres and SQL Server are ephemeral, first-party GitHub Actions service containers
+# seeded ONLY with synthetic fixture rows generated inside this job. The S6-A feature flag
+# (MULTITABLE_STOCK_PREP_SQLSERVER_SEALED_SNAPSHOT_ENABLED) is set ONLY inside this job's own spawned
+# core-backend server-process environment for the duration of one arm — never in a committed file, never
+# as a repository/environment variable default, and the process is always restarted flag-OFF afterward.
+#
+# Two jobs:
+#   functional-smoke   — the real lane: flag-OFF arm, exact-match arm ('1'/'yes' must NOT enable it),
+#                         the EXISTING T4 extended-smoke chain reproduced against this local server, and
+#                         a best-effort real S6-A flag-ON run (capture -> ingestion -> generation kernel
+#                         -> apply) over a first-party ephemeral SQL Server relation. Any part that
+#                         cannot complete is reported NOT_RUN in the values-free result block — never as
+#                         PASS — and the job goes red if any check that DID run failed.
+#   negative-control    — deliberately RED. Reuses the SAME assertion machinery as functional-smoke and
+#                         asserts a wrong expectation on purpose, proving the harness can genuinely fail
+#                         (not a check "that did not happen").
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  functional-smoke:
+    name: containerized functional smoke (existing chain + S6-A flag arms)
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: metasheet
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
+      mssql:
+        image: mcr.microsoft.com/mssql/server:2022-latest
+        env:
+          ACCEPT_EULA: 'Y'
+          MSSQL_SA_PASSWORD: 'E2eFunc!Probe2026'
+        ports:
+          - 1433:1433
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js 20.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.16.1
+          run_install: false
+
+      - name: Use empty npmrc for pnpm
+        run: |
+          echo "" > /tmp/empty-npmrc
+          echo "NPM_CONFIG_USERCONFIG=/tmp/empty-npmrc" >> "$GITHUB_ENV"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Wait for SQL Server
+        run: |
+          for i in $(seq 1 40); do
+            if pnpm --filter plugin-integration-core exec node -e "
+              const sql = require('mssql');
+              new sql.ConnectionPool({server:'127.0.0.1',port:1433,user:'sa',password:'E2eFunc!Probe2026',database:'master',options:{encrypt:true,trustServerCertificate:true},connectionTimeout:3000})
+                .connect().then(p => p.close()).then(() => process.exit(0)).catch(() => process.exit(1));
+            "; then
+              echo "SQL Server ready on attempt $i"
+              exit 0
+            fi
+            echo "attempt $i: SQL Server not ready yet; sleeping 5s"
+            sleep 5
+          done
+          echo "SQL Server never became ready within timeout"
+          exit 1
+
+      - name: Generate CI-local ephemeral secrets (never logged, scoped to this run only)
+        run: |
+          set -euo pipefail
+          {
+            echo "E2E_JWT_SECRET=$(openssl rand -hex 32)"
+            echo "E2E_INTEGRATION_ENCRYPTION_KEY=$(openssl rand -hex 32)"
+            echo "E2E_S6A_RUNTIME_DB_ROLE=e2e_s6a_runtime"
+            echo "E2E_S6A_RUNTIME_DB_PASSWORD=$(openssl rand -hex 16)"
+            echo "E2E_S6A_PROVISIONING_DB_ROLE=e2e_s6a_provision"
+            echo "E2E_S6A_PROVISIONING_DB_PASSWORD=$(openssl rand -hex 16)"
+          } >> "$GITHUB_ENV"
+
+      - name: Provision sealed-export Postgres roles, then run migrations with both roles visible
+        env:
+          PG_SUPERUSER_URL: postgresql://postgres:postgres@127.0.0.1:5432/metasheet
+          RUNTIME_ROLE: ${{ env.E2E_S6A_RUNTIME_DB_ROLE }}
+          RUNTIME_PASSWORD: ${{ env.E2E_S6A_RUNTIME_DB_PASSWORD }}
+          PROVISIONING_ROLE: ${{ env.E2E_S6A_PROVISIONING_DB_ROLE }}
+          PROVISIONING_PASSWORD: ${{ env.E2E_S6A_PROVISIONING_DB_PASSWORD }}
+        run: node scripts/ops/stock-preparation-e2e-provision-postgres-roles-and-migrate.mjs
+
+      - name: Run containerized functional smoke
+        id: smoke
+        env:
+          DATABASE_URL: postgresql://postgres:postgres@127.0.0.1:5432/metasheet
+          E2E_JWT_SECRET: ${{ env.E2E_JWT_SECRET }}
+          E2E_INTEGRATION_ENCRYPTION_KEY: ${{ env.E2E_INTEGRATION_ENCRYPTION_KEY }}
+          E2E_S6A_RUNTIME_DB_ROLE: ${{ env.E2E_S6A_RUNTIME_DB_ROLE }}
+          E2E_S6A_RUNTIME_DB_URL: postgresql://${{ env.E2E_S6A_RUNTIME_DB_ROLE }}:${{ env.E2E_S6A_RUNTIME_DB_PASSWORD }}@127.0.0.1:5432/metasheet
+          E2E_S6A_PROVISIONING_DB_ROLE: ${{ env.E2E_S6A_PROVISIONING_DB_ROLE }}
+          E2E_S6A_PROVISIONING_DB_URL: postgresql://${{ env.E2E_S6A_PROVISIONING_DB_ROLE }}:${{ env.E2E_S6A_PROVISIONING_DB_PASSWORD }}@127.0.0.1:5432/metasheet
+          MSSQL_HOST: 127.0.0.1
+          MSSQL_PORT: '1433'
+          MSSQL_USERNAME: sa
+          MSSQL_PASSWORD: 'E2eFunc!Probe2026'
+        run: node scripts/ops/stock-preparation-e2e-functional-smoke.mjs
+
+      - name: Write step summary
+        if: always()
+        run: |
+          echo "## Stock Preparation E2E Functional Smoke" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Functional testing on synthetic data only. Does NOT substitute for the #4695 controlled" >> "$GITHUB_STEP_SUMMARY"
+          echo "acceptance and establishes no real-customer, scale, external-write, or rollout claim." >> "$GITHUB_STEP_SUMMARY"
+          echo '```text' >> "$GITHUB_STEP_SUMMARY"
+          cat output/stock-preparation-e2e-functional-smoke/summary.txt 2>/dev/null >> "$GITHUB_STEP_SUMMARY" || echo "no summary produced" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload values-free evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: stock-preparation-e2e-functional-smoke
+          path: |
+            output/stock-preparation-e2e-functional-smoke/summary.txt
+            output/stock-preparation-e2e-functional-smoke/checks.json
+            output/stock-preparation-e2e-functional-smoke/existing-chain/summary.txt
+            output/stock-preparation-e2e-functional-smoke/existing-chain/checks.json
+          if-no-files-found: warn
+          retention-days: 14
+
+  negative-control:
+    name: negative control (deliberately RED — proves the harness can fail)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: metasheet
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js 20.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.16.1
+          run_install: false
+
+      - name: Use empty npmrc for pnpm
+        run: |
+          echo "" > /tmp/empty-npmrc
+          echo "NPM_CONFIG_USERCONFIG=/tmp/empty-npmrc" >> "$GITHUB_ENV"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run migrations (plain — no sealed-export roles needed; flag stays absent in this job)
+        env:
+          DATABASE_URL: postgresql://postgres:postgres@127.0.0.1:5432/metasheet
+        run: pnpm --filter @metasheet/core-backend run migrate
+
+      - name: Generate CI-local ephemeral secrets (never logged, scoped to this run only)
+        run: |
+          set -euo pipefail
+          {
+            echo "E2E_JWT_SECRET=$(openssl rand -hex 32)"
+            echo "E2E_INTEGRATION_ENCRYPTION_KEY=$(openssl rand -hex 32)"
+          } >> "$GITHUB_ENV"
+
+      - name: Run negative control (this step is EXPECTED to fail)
+        env:
+          DATABASE_URL: postgresql://postgres:postgres@127.0.0.1:5432/metasheet
+          E2E_JWT_SECRET: ${{ env.E2E_JWT_SECRET }}
+          E2E_INTEGRATION_ENCRYPTION_KEY: ${{ env.E2E_INTEGRATION_ENCRYPTION_KEY }}
+        run: node scripts/ops/stock-preparation-e2e-negative-control.mjs

--- a/scripts/ops/stock-preparation-e2e-functional-smoke.mjs
+++ b/scripts/ops/stock-preparation-e2e-functional-smoke.mjs
@@ -686,6 +686,30 @@ async function assertS6ARunDatabaseObservable(operationId, expectedBusinessLineC
   }
 }
 
+// Diagnostic-only counterpart for the first-run FAILURE path — see the call site's comment. Never
+// asserts (no must()); purely reports closed tokens/booleans into the values-free evidence.
+async function assertS6ARunDatabaseObservableOnFailure(operationId) {
+  const pg = requireFromPlugin('pg')
+  const pool = new pg.Pool({ connectionString: process.env.DATABASE_URL, max: 1 })
+  try {
+    const runRows = await pool.query(
+      `SELECT status, failure_reason FROM integration_sealed_export_stock_prep_runs
+       WHERE tenant_id = $1 AND operation_id = $2`,
+      [TENANT_ID, operationId],
+    )
+    const run = runRows.rows[0] || null
+    S.s6aDbRunRowFoundOnFailure = String(run !== null)
+    S.s6aDbRunStatusOnFailure = run ? run.status : '<none>'
+    S.s6aDbRunFailureReason = run && run.failure_reason ? run.failure_reason : '<none>'
+  } catch {
+    S.s6aDbRunRowFoundOnFailure = '<query-failed>'
+    S.s6aDbRunStatusOnFailure = '<query-failed>'
+    S.s6aDbRunFailureReason = '<query-failed>'
+  } finally {
+    await pool.end()
+  }
+}
+
 async function attemptS6ARealRun() {
   const salt = `t${Math.floor(Date.now() / 1000)}`
   const systemId = `e2efunc-s6a-source-${salt}`
@@ -744,6 +768,17 @@ async function attemptS6ARealRun() {
       const baseToken = await getDevToken()
       const registered = await registerExternalSystem(baseToken, systemId)
       registeredOk = must('S6-A: external system registered', registered.ok, `http=${registered.status}`)
+      // Diagnostic (Step 1 discipline applied to this next layer, not a guess): the run-time re-resolves
+      // this SAME external system from the DB (externalSystemRegistry.getExternalSystemForAdapter), and
+      // its credential lookup returns `undefined` — silently dropping the `credentials` property entirely
+      // — if the stored ciphertext is missing or empty. `hasCredentials` is a boolean already exposed by
+      // the ordinary GET route (rowToPublicExternalSystem) — never the credential content itself — so
+      // this is safe to read directly into the values-free evidence.
+      if (registeredOk) {
+        const fetched = await requestJson(`/api/integration/external-systems/${encodeURIComponent(systemId)}`,
+          { token: baseToken, accept: [200] })
+        S.s6aExternalSystemHasCredentials = String(fetched.body?.data?.hasCredentials === true)
+      }
     } finally {
       await stopServer()
     }
@@ -934,6 +969,12 @@ async function attemptS6ARealRun() {
       `http=${firstRun.status} mode=${S.s6aFirstRunMode} status=${S.s6aFirstRunStatus} lines=${S.s6aBusinessLineCount} code=${S.s6aFirstRunErrorCode}`)
     S.s6aFirstRun = firstOk ? 'PASS' : 'FAIL'
     if (!firstOk) {
+      // Diagnostic: does a run row exist at all for this (tenant, operationId)? A refusal upstream of
+      // any capture attempt (binding/qualification resolution) leaves NO row; a refusal DURING capture
+      // leaves a CAPTURE_FAILED row with a persisted `failure_reason` token (migration 073's own CHECK
+      // constraint requires one). This splits which half of the pipeline to look at — the closed
+      // `error.code` alone cannot, since many call sites across the codebase share the same token.
+      await assertS6ARunDatabaseObservableOnFailure(operationId)
       S.s6aDatabaseObservable = 'NOT_RUN'
       S.s6aReplayRun = 'NOT_RUN'
       return

--- a/scripts/ops/stock-preparation-e2e-functional-smoke.mjs
+++ b/scripts/ops/stock-preparation-e2e-functional-smoke.mjs
@@ -475,7 +475,7 @@ CREATE TABLE ${MSSQL_TABLE} (
 // regardless of how correct the fixture data is. This function only OBSERVES; it does not change what the
 // production code does.
 async function diagnoseOrderingKeyProbeShape() {
-  const { CERTIFIED_RELATIONS } = requireFromPlugin(
+  const { CERTIFIED_RELATIONS } = require_(
     'plugins/plugin-integration-core/lib/sealed-export/sqlserver-sealed-snapshot-action.cjs',
   )
   const relation = CERTIFIED_RELATIONS['sqlserver.relation.rowid_payload.v1']

--- a/scripts/ops/stock-preparation-e2e-functional-smoke.mjs
+++ b/scripts/ops/stock-preparation-e2e-functional-smoke.mjs
@@ -575,6 +575,31 @@ async function runProvisioningScript(env) {
 // performs — same modules, same env — in-process, so `error.stack` (never surfaced by the script itself)
 // is visible here for diagnosis only. Does not change what the production script or its dependencies do.
 async function diagnoseProvisioningFailureStack(provisioningEnv) {
+  // dbBoundary (sealed-export-lifecycle-provisioning.cjs) catches EVERY error from db.transaction() and,
+  // unless it is already a trusted sealed-export error, discards it and throws a fresh
+  // SEALED_EXPORT_INTERNAL_ERROR — the real driver-level exception (e.g. a Postgres permission/relation
+  // error) never reaches error.stack. Patch pg.Client.prototype.query for the lifetime of this ONE
+  // diagnostic call only (restored in `finally`, values-free: only the driver's own error MESSAGE — schema
+  // shape, never row data — is logged, job-log only) to see what it actually was.
+  const pg = requireFromPlugin('pg')
+  let originalQuery
+  try {
+    originalQuery = pg.Client.prototype.query
+    pg.Client.prototype.query = function patchedQuery(...args) {
+      const result = originalQuery.apply(this, args)
+      if (result && typeof result.catch === 'function') {
+        return result.catch((error) => {
+          note('DIAGNOSTIC (job log only): raw pg query error (message only, no row data)',
+            String(error && error.message || error))
+          throw error
+        })
+      }
+      return result
+    }
+  } catch (error) {
+    originalQuery = null
+    note('DIAGNOSTIC (job log only): could not patch pg.Client.prototype.query', String(error && error.message || error))
+  }
   try {
     const { loadStockPreparationProvisioningConfig } = require_(
       'plugins/plugin-integration-core/lib/sealed-export/stock-preparation-runtime-config.cjs',
@@ -610,6 +635,8 @@ async function diagnoseProvisioningFailureStack(provisioningEnv) {
     }
   } catch (error) {
     note('DIAGNOSTIC (job log only): in-process provisioning replay stack', String(error && error.stack || error))
+  } finally {
+    if (originalQuery) pg.Client.prototype.query = originalQuery
   }
 }
 

--- a/scripts/ops/stock-preparation-e2e-functional-smoke.mjs
+++ b/scripts/ops/stock-preparation-e2e-functional-smoke.mjs
@@ -460,7 +460,53 @@ CREATE TABLE ${MSSQL_TABLE} (
       await dbPool.close()
     }
   })
+  await diagnoseOrderingKeyProbeShape()
   return { rows, projectId: rows[0].projectId, snapshotBatchId: rows[0].snapshotBatchId }
+}
+
+// TEMPORARY bounded diagnostic (job-log only, never in uploaded evidence) for the
+// SEALED_EXPORT_BINDING_UNQUALIFIED root-cause investigation: runs the SAME
+// buildOrderingKeyUniquenessProbeSql SQL text the production capture path (proveOrderingKey in
+// sqlserver-sealed-snapshot-service-core.cjs) runs, as the SAME reader login, and reports the JS typeof of
+// each returned bigint-cast column. normalizeProbeCount(value) in that file only accepts
+// Number.isSafeInteger(value) or a decimal string — if the mssql/tedious driver decodes `CAST(... AS
+// bigint)` as a native JS `bigint` primitive (typeof 'bigint'), normalizeProbeCount returns null for every
+// field and proveOrderingKey's `nullKeyRows === null` branch fails closed with BINDING_UNQUALIFIED
+// regardless of how correct the fixture data is. This function only OBSERVES; it does not change what the
+// production code does.
+async function diagnoseOrderingKeyProbeShape() {
+  const { CERTIFIED_RELATIONS } = requireFromPlugin(
+    'plugins/plugin-integration-core/lib/sealed-export/sqlserver-sealed-snapshot-action.cjs',
+  )
+  const relation = CERTIFIED_RELATIONS['sqlserver.relation.rowid_payload.v1']
+  const probeSql = relation.buildOrderingKeyUniquenessProbeSql(MSSQL_TABLE)
+  const sql = requireFromPlugin('mssql')
+  const pool = new sql.ConnectionPool({
+    server: MSSQL_HOST,
+    port: MSSQL_PORT,
+    user: MSSQL_READER_LOGIN,
+    password: MSSQL_READER_PASSWORD,
+    database: MSSQL_DATABASE,
+    options: { encrypt: true, trustServerCertificate: true },
+    connectionTimeout: 15000,
+  })
+  try {
+    await pool.connect()
+    const result = await pool.request().query(probeSql)
+    const row = result.recordset && result.recordset[0]
+    const shape = row
+      ? Object.keys(row).map((key) => `${key}:${typeof row[key]}`).join(',')
+      : '<no-row>'
+    note('DIAGNOSTIC (job log only): ordering-key probe column JS types', shape)
+  } catch (error) {
+    note('DIAGNOSTIC (job log only): ordering-key probe query itself failed', String(error && error.message || error))
+  } finally {
+    try {
+      await pool.close()
+    } catch {
+      // best-effort
+    }
+  }
 }
 
 async function registerExternalSystem(token, systemId) {

--- a/scripts/ops/stock-preparation-e2e-functional-smoke.mjs
+++ b/scripts/ops/stock-preparation-e2e-functional-smoke.mjs
@@ -494,10 +494,12 @@ async function diagnoseOrderingKeyProbeShape() {
     await pool.connect()
     const result = await pool.request().query(probeSql)
     const row = result.recordset && result.recordset[0]
+    // Values here are closed-vocabulary counts (0..3), never business data — safe even outside the
+    // job-log-only boundary, but kept there anyway for consistency with the rest of this diagnostic.
     const shape = row
-      ? Object.keys(row).map((key) => `${key}:${typeof row[key]}`).join(',')
+      ? Object.keys(row).map((key) => `${key}:${typeof row[key]}=${JSON.stringify(row[key])}`).join(',')
       : '<no-row>'
-    note('DIAGNOSTIC (job log only): ordering-key probe column JS types', shape)
+    note('DIAGNOSTIC (job log only): ordering-key probe column JS types+values', shape)
   } catch (error) {
     note('DIAGNOSTIC (job log only): ordering-key probe query itself failed', String(error && error.message || error))
   } finally {
@@ -552,6 +554,52 @@ async function runProvisioningScript(env) {
     proc.stderr.on('data', (c) => { stderr += c.toString() })
     proc.on('close', (code) => resolve({ code, stdout, stderr }))
   })
+}
+
+// TEMPORARY bounded diagnostic (job-log only, never in uploaded evidence): the provisioning SCRIPT
+// (plugins/plugin-integration-core/scripts/provision-stock-preparation-sqlserver-sealed-snapshot.cjs)
+// deliberately discards everything except a closed `code` enum on failure (values-free by design — see
+// its own header). To find WHICH of the many failSealedExport('SEALED_EXPORT_BINDING_UNQUALIFIED') call
+// sites in the S5/S6-A authority chain is actually firing, this replays the SAME construction the script
+// performs — same modules, same env — in-process, so `error.stack` (never surfaced by the script itself)
+// is visible here for diagnosis only. Does not change what the production script or its dependencies do.
+async function diagnoseProvisioningFailureStack(provisioningEnv) {
+  try {
+    const { loadStockPreparationProvisioningConfig } = require_(
+      'plugins/plugin-integration-core/lib/sealed-export/stock-preparation-runtime-config.cjs',
+    )
+    const { createStockPreparationProvisioningDatabase } = require_(
+      'plugins/plugin-integration-core/lib/sealed-export/stock-preparation-runtime-database.cjs',
+    )
+    const { createStockPreparationRuntimeProvisioning } = require_(
+      'plugins/plugin-integration-core/lib/sealed-export/stock-preparation-runtime-provisioning.cjs',
+    )
+    const mergedEnv = { ...process.env, ...provisioningEnv }
+    const config = loadStockPreparationProvisioningConfig({ env: mergedEnv })
+    const database = createStockPreparationProvisioningDatabase({
+      connectionString: config.provisioningDatabaseUrl,
+      expectedRole: config.provisioningDatabaseRole,
+    })
+    try {
+      const service = createStockPreparationRuntimeProvisioning({
+        artifactRoot: config.artifactRoot,
+        identityKey: config.identityKey,
+        privateSignerMaterial: config.privateSignerMaterial,
+        provisioningDatabase: database,
+        qualificationKeyring: config.qualificationKeyring,
+      })
+      await service.provisionInitial(config.spec)
+      note('DIAGNOSTIC (job log only): in-process provisioning replay unexpectedly SUCCEEDED')
+    } finally {
+      try {
+        await database.close()
+      } catch {
+        // best-effort
+      }
+    }
+  } catch (error) {
+    note('DIAGNOSTIC (job log only): in-process provisioning replay stack', String(error && error.stack || error))
+  }
 }
 
 async function attemptS6ARealRun() {
@@ -677,6 +725,7 @@ async function attemptS6ARealRun() {
   if (!provisionedOk) {
     note('S6-A: provisioning script failure detail (job log only, not in uploaded evidence)',
       `code=${provisioningFailureCode}`)
+    await diagnoseProvisioningFailureStack(provisioningEnv)
   }
   must('S6-A: provisioning script -> ok:true, externalWrite:false, valuesFree:true', provisionedOk,
     `exit=${provisioned.code}`)

--- a/scripts/ops/stock-preparation-e2e-functional-smoke.mjs
+++ b/scripts/ops/stock-preparation-e2e-functional-smoke.mjs
@@ -235,6 +235,26 @@ export async function s6aRunProbe(token, operationId) {
   })
 }
 
+// NOTE on the DISABLED error code: plugin-integration-core only ADDS the S6-A route to the Express app
+// (registerIntegrationRoutes, http-routes.cjs ~5003-5006) when services.stockPreparationSqlServerRuntime
+// is truthy at plugin-construction time — i.e. only when the flag was already 'true' at boot. When the
+// flag is off, the route is never mounted at all, so a request to it falls through to the framework's
+// generic unmatched-route 404 (no JSON error envelope, no `error.code`) — it does NOT reach the
+// `STOCK_PREPARATION_SQLSERVER_SEALED_SNAPSHOT_DISABLED` HttpRouteError inside the handler
+// (http-routes.cjs ~4900-4911), because that handler is unreachable code under this wiring: the same
+// truthy/falsy check gates both route registration and the handler's local runtime reference. This is
+// confirmed by the existing unit test plugin-integration-core/__tests__/http-routes.test.cjs
+// `testStockPreparationSqlServerSealedSnapshotInternalRoute`, which asserts
+// `disabled.routes.has('POST ' + routePath) === false` for the flag-off construction. So this arm does
+// NOT assert the specific JSON error code (that would be asserting dead code) — it asserts three things
+// together, which is what actually distinguishes "genuinely gated" from "route never wired / auth or
+// prefix broken / typo'd path", none of which a bare `http === 404` can rule out on its own:
+//   1. /api/integration/health capability boolean reads false (a deliberate signal — Boolean(runtime) —
+//      not an absence: plugin-integration-core/index.cjs ~96)
+//   2. a SIBLING route that is ALWAYS registered regardless of the flag (mvp/readiness) answers 200 in
+//      the SAME server process — proving the server, auth, and /api/integration prefix are alive, so the
+//      S6-A 404 cannot be explained by "nothing is mounted"
+//   3. the S6-A path itself returns 404
 async function runFlagArm(flagValue, expectEnabled, label) {
   await startServer(
     flagValue === undefined
@@ -246,15 +266,20 @@ async function runFlagArm(flagValue, expectEnabled, label) {
     const token = await getDevToken()
     const health = await requestJson('/api/integration/health', { token })
     const flagOn = health.body?.capabilities?.stockPreparationSqlServerSealedSnapshot === true
+    const sibling = await requestJson('/api/integration/stock-preparation/mvp/readiness', { token, accept: [200] })
     const probe = await s6aRunProbe(token, `probe-${label}-${crypto.randomUUID()}`)
     S[`${label}HealthFlagOn`] = flagOn
+    S[`${label}SiblingRouteHttp`] = sibling.status
     S[`${label}Http`] = probe.status
+    // Informational only (kept for evidence/debuggability) — NOT part of the pass condition. See the
+    // block comment above: this code is unreachable dead code under current route-registration wiring
+    // when the flag is off, so requiring it here would assert a claim the shipped code cannot make true.
     S[`${label}Code`] = probe.body?.error?.code || '<none>'
     const pass = expectEnabled
-      ? flagOn === true
-      : flagOn === false && probe.status === 404 && probe.body?.error?.code === 'STOCK_PREPARATION_SQLSERVER_SEALED_SNAPSHOT_DISABLED'
-    must(`flag arm ${label}: ${expectEnabled ? 'flag reads enabled' : '404 DISABLED (flag not enabled)'}`, pass,
-      `flagOn=${flagOn} http=${probe.status} code=${S[`${label}Code`]}`)
+      ? flagOn === true && sibling.ok
+      : flagOn === false && sibling.ok && probe.status === 404
+    must(`flag arm ${label}: ${expectEnabled ? 'flag reads enabled (+ sibling route alive)' : 'flag reads disabled + sibling route alive + S6-A 404'}`,
+      pass, `flagOn=${flagOn} siblingHttp=${sibling.status} http=${probe.status} code=${S[`${label}Code`]}`)
     S[`${label}Pass`] = pass ? 'PASS' : 'FAIL'
   } finally {
     await stopServer()
@@ -566,12 +591,24 @@ async function attemptS6ARealRun() {
   }
   const provisioned = await runProvisioningScript(provisioningEnv)
   let provisionedOk = false
+  let provisioningFailureCode = '<unparseable>'
   try {
     const parsed = JSON.parse(provisioned.stdout.trim().split('\n').pop() || '{}')
     provisionedOk = provisioned.code === 0 && parsed.ok === true && parsed.externalWrite === false && parsed.valuesFree === true
     S.s6aProvisioningChanged = typeof parsed.changed === 'boolean' ? String(parsed.changed) : '<unregistered>'
+    // The provisioning script's own failure contract declares `valuesFree: true` on its `code` field
+    // (plugins/plugin-integration-core/scripts/provision-stock-preparation-sqlserver-sealed-snapshot.cjs)
+    // — safe to surface for diagnosis. Job-log only (process.stderr): this is NOT written to
+    // summary.txt/checks.json, which are uploaded as CI artifacts and must stay strictly values-free —
+    // the failure-vocabulary `code` enum is trusted, but keeping it out of the retained evidence artifact
+    // is the conservative choice.
+    if (!provisionedOk && typeof parsed.code === 'string') provisioningFailureCode = parsed.code
   } catch {
     provisionedOk = false
+  }
+  if (!provisionedOk) {
+    note('S6-A: provisioning script failure detail (job log only, not in uploaded evidence)',
+      `code=${provisioningFailureCode}`)
   }
   must('S6-A: provisioning script -> ok:true, externalWrite:false, valuesFree:true', provisionedOk,
     `exit=${provisioned.code}`)

--- a/scripts/ops/stock-preparation-e2e-functional-smoke.mjs
+++ b/scripts/ops/stock-preparation-e2e-functional-smoke.mjs
@@ -922,10 +922,16 @@ async function attemptS6ARealRun() {
     S.s6aFirstRunStatus = firstData.status || '<unregistered>'
     S.s6aBusinessLineCount = Number.isInteger(firstData.businessLineCount) ? firstData.businessLineCount : -1
     S.s6aFirstRunExternalWrite = firstData.externalWrite === false ? 'false' : '<unregistered>'
+    // A refusal's `error.code` here is ALWAYS a member of the frozen sealed-export failure vocabulary (or
+    // the http-routes.cjs error-code set) — never caller-derived text (failure-vocabulary.cjs's own
+    // details discipline guarantees that) — so it is safe to surface directly in the values-free evidence,
+    // the same way the flag-arm probes already surface `${label}Code` above.
+    S.s6aFirstRunErrorCode = firstRun.body?.error?.code || '<none>'
     const firstOk = firstRun.ok && firstData.status === 'COMPLETED' && firstData.mode === 'internal_persist' &&
       firstData.externalWrite === false && firstData.businessLineCount === relation.rows.length
     must('S6-A: first run -> COMPLETED, internal_persist, externalWrite=false, businessLineCount matches',
-      firstOk, `http=${firstRun.status} mode=${S.s6aFirstRunMode} status=${S.s6aFirstRunStatus} lines=${S.s6aBusinessLineCount}`)
+      firstOk,
+      `http=${firstRun.status} mode=${S.s6aFirstRunMode} status=${S.s6aFirstRunStatus} lines=${S.s6aBusinessLineCount} code=${S.s6aFirstRunErrorCode}`)
     S.s6aFirstRun = firstOk ? 'PASS' : 'FAIL'
     if (!firstOk) {
       S.s6aDatabaseObservable = 'NOT_RUN'

--- a/scripts/ops/stock-preparation-e2e-functional-smoke.mjs
+++ b/scripts/ops/stock-preparation-e2e-functional-smoke.mjs
@@ -164,6 +164,9 @@ export async function startServer(extraEnv, label) {
   if (currentServer) throw new Error('a server is already running; stop it before starting another')
   const env = { ...BASE_ENV, ...extraEnv }
   const logPath = path.join(OUT_DIR, `server-${label}.log`)
+  // Self-sufficient regardless of caller: main() mkdir's OUT_DIR, but the negative-control entry point
+  // calls startServer() directly without ever creating it first.
+  fs.mkdirSync(OUT_DIR, { recursive: true })
   const logFd = fs.openSync(logPath, 'a')
   const proc = spawn('pnpm', ['--filter', '@metasheet/core-backend', 'run', 'dev:core'], {
     cwd: REPO_ROOT,

--- a/scripts/ops/stock-preparation-e2e-functional-smoke.mjs
+++ b/scripts/ops/stock-preparation-e2e-functional-smoke.mjs
@@ -423,7 +423,7 @@ async function runFlagArm(flagValue, expectEnabled, label) {
 // attempt, using only the runtime-database role/URL the workflow already provisioned.
 async function runFlagNormalizationArm(flagValue, label) {
   if (!RUNTIME_DB_ROLE || !RUNTIME_DB_URL) {
-    S[`${label}Run`] = 'NOT_RUN'
+    S[`${label}Pass`] = 'NOT_RUN'
     S[`${label}Reason`] = 'RUNTIME_DB_ENV_MISSING'
     must(`flag normalization arm ${label}: runtime constructed`, false, 'runtime DB env not provided by workflow')
     return
@@ -453,7 +453,7 @@ async function runFlagNormalizationArm(flagValue, label) {
   try {
     await startServer(runtimeEnv, label)
   } catch (error) {
-    S[`${label}Run`] = 'NOT_RUN'
+    S[`${label}Pass`] = 'NOT_RUN'
     S[`${label}Reason`] = 'RUNTIME_SERVER_START_FAILED'
     must(`flag normalization arm ${label}: runtime constructed`, false, String(error && error.message || error))
     return
@@ -465,7 +465,7 @@ async function runFlagNormalizationArm(flagValue, label) {
     S[`${label}HealthFlagOn`] = flagOn
     must(`flag normalization arm ${label}: string variant normalises to enabled (runtime CONSTRUCTED, not just flag-string-present)`,
       flagOn, `flagOn=${flagOn}`)
-    S[`${label}Run`] = flagOn ? 'PASS' : 'FAIL'
+    S[`${label}Pass`] = flagOn ? 'PASS' : 'FAIL'
   } finally {
     await stopServer()
   }
@@ -1063,8 +1063,10 @@ async function attemptS6ARealRun() {
       // Finding (review #4724): this early return used to fall straight through to main()'s evidence
       // write with NO s6aFlagOnRun key at all — absence of a key is not distinguishable from
       // not-applicable, and this IS the path that actually executes today. Always emit it, on every exit
-      // out of this function, not just the ones above.
-      S.s6aFlagOnRun = 'FAIL'
+      // out of this function, not just the ones above. NOT_RUN (not FAIL): this is the phase ROLL-UP key,
+      // and its vocabulary elsewhere in this function is PASS/NOT_RUN — "the walk did not establish its
+      // claim", not "the walk ran and failed" (that per-step verdict is S.s6aFirstRun, set above).
+      S.s6aFlagOnRun = 'NOT_RUN'
       S.s6aFlagOnReason = 'FIRST_RUN_FAILED'
       return
     }
@@ -1075,6 +1077,10 @@ async function attemptS6ARealRun() {
     const dbOk = await assertS6ARunDatabaseObservable(operationId, relation.rows.length)
     if (!dbOk) {
       S.s6aReplayRun = 'NOT_RUN'
+      // Same rationale as the !firstOk branch above: always emit the roll-up key on every exit out of
+      // this function.
+      S.s6aFlagOnRun = 'NOT_RUN'
+      S.s6aFlagOnReason = 'DATABASE_OBSERVABLE_FAILED'
       return
     }
 

--- a/scripts/ops/stock-preparation-e2e-functional-smoke.mjs
+++ b/scripts/ops/stock-preparation-e2e-functional-smoke.mjs
@@ -889,6 +889,23 @@ async function attemptS6ARealRun() {
       `flagOn=${flagOn}`)) {
       S.s6aFlagOnRun = 'NOT_RUN'
       S.s6aFlagOnReason = 'RUNTIME_NOT_CONSTRUCTED'
+      // Step 1 diagnostic: index.cjs's try/catch around runtime construction discards the actual cause
+      // and logs ONE fixed warning line on ANY failure (index.cjs, "sealed-snapshot runtime
+      // initialization refused; capability disabled") — by design, not a bug to route around. This does
+      // not change that discard on the production path; it only reports, as closed presence booleans
+      // (never the log's own text, which can carry MULTITABLE_..._RUNTIME_DATABASE_URL's password), which
+      // of two disjoint explanations the flag-on server's OWN log shows: the plugin's catch fired
+      // (construction was attempted and refused) vs. it never fired at all (the server did not even reach
+      // that code path — e.g. it crashed on boot for an unrelated reason such as a port conflict).
+      const flagOnLogPath = path.join(OUT_DIR, 'server-flag-on.log')
+      let logText = ''
+      try {
+        logText = fs.readFileSync(flagOnLogPath, 'utf8')
+      } catch {
+        // log not readable — both presence booleans stay false, which is itself an honest signal
+      }
+      S.s6aFlagOnCatchFired = String(logText.includes('sealed-snapshot runtime initialization refused'))
+      S.s6aFlagOnLogHasEaddrinuse = String(logText.includes('EADDRINUSE'))
       return
     }
 

--- a/scripts/ops/stock-preparation-e2e-functional-smoke.mjs
+++ b/scripts/ops/stock-preparation-e2e-functional-smoke.mjs
@@ -71,6 +71,17 @@ function delay(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms))
 }
 
+// The S6-A authority chain's requiredFutureInstant (sealed-export-lifecycle-provisioning.cjs) requires
+// SECONDS-precision UTC ISO-8601 (`/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/`) — a plain
+// `new Date(...).toISOString()` carries a milliseconds component and fails that format check, which
+// surfaces as SEALED_EXPORT_BINDING_UNQUALIFIED with no further detail (confirmed via
+// diagnoseProvisioningFailureStack's error.stack: failSealedExport -> requiredFutureInstant ->
+// normalizeAuthorityInput -> provisionInitialStockPreparationBinding). This mirrors the SAME
+// seconds-truncation the production code's own toUtcSecondsIso helper performs.
+function toUtcSecondsIso(ms) {
+  return new Date(Math.floor(ms / 1000) * 1000).toISOString().replace(/\.\d{3}Z$/, 'Z')
+}
+
 // ── config ──────────────────────────────────────────────────────────────────────────────────────────
 const PORT = Number(process.env.E2E_SERVER_PORT || 7801)
 const BASE_URL = `http://127.0.0.1:${PORT}`
@@ -655,14 +666,19 @@ async function attemptS6ARealRun() {
 
   // 3. provisioning spec (inline external-system connection material — no DB registry lookup at
   // provisioning time; the runtime independently re-resolves the SAME record at run time).
+  // bindingExpiresAt and signerExpiresAt share ONE `nowMs` snapshot: normalizeAuthorityInput
+  // (sealed-export-lifecycle-provisioning.cjs) also fail-closes if bindingExpiresAt > signerExpiresAt,
+  // and two separate Date.now() calls truncated to seconds could straddle a second boundary and make
+  // bindingExpiresAt the later of the two by one second — rare but avoidable.
+  const expiresAtIso = toUtcSecondsIso(Date.now() + 24 * 60 * 60 * 1000)
   const provisioningSpec = {
     binding: {
       approvedConfigVersionId,
-      bindingExpiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
+      bindingExpiresAt: expiresAtIso,
       bindingId: `e2efunc-binding-id-${salt}`,
       bindingVersion,
       externalSystemId: systemId,
-      signerExpiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
+      signerExpiresAt: expiresAtIso,
       tableRef: MSSQL_TABLE,
       tenantId: TENANT_ID,
       workspaceId: null,

--- a/scripts/ops/stock-preparation-e2e-functional-smoke.mjs
+++ b/scripts/ops/stock-preparation-e2e-functional-smoke.mjs
@@ -387,6 +387,26 @@ async function withSqlServerAdmin(fn) {
   }
 }
 
+// The S6-A capture path's own snapshot-capability proof (sqlserver-sealed-snapshot-source-session.cjs
+// assertSnapshotCapability) REQUIRES sys.databases.snapshot_isolation_state = 1 for the target database
+// — it is OFF by default on a freshly CREATE DATABASE'd database, so a fixture that skips this step gets
+// SEALED_EXPORT_SNAPSHOT_PROOF_UNAVAILABLE regardless of how correct its role/grant setup is. This is the
+// SAME incantation + poll-for-effect pattern the existing sealed-export S2/S5 CI evidence scripts already
+// use (scripts/ops/run-sealed-export-s5-sqlserver-evidence.cjs waitForSnapshotState) — reused here rather
+// than re-derived, since ALLOW_SNAPSHOT_ISOLATION can take a moment to actually apply.
+async function waitForSnapshotIsolationOn(pool) {
+  for (let attempt = 0; attempt < 30; attempt += 1) {
+    const result = await pool.request().query(`
+SELECT snapshot_isolation_state AS snapshotIsolationState
+FROM sys.databases
+WHERE name = N'${MSSQL_DATABASE}'`)
+    const state = Number(result.recordset?.[0]?.snapshotIsolationState)
+    if (state === 1) return
+    await delay(250)
+  }
+  throw new Error('SQL Server database never reported snapshot_isolation_state=1 after ALLOW_SNAPSHOT_ISOLATION ON')
+}
+
 async function prepareSqlServerRelation(salt) {
   const rows = [0, 1, 2].map((index) => buildBomPayload(index, salt))
   await withSqlServerAdmin(async (pool, sql) => {
@@ -395,6 +415,8 @@ IF DB_ID(N'${MSSQL_DATABASE}') IS NULL
 BEGIN
   CREATE DATABASE ${MSSQL_DATABASE};
 END`)
+    await pool.request().batch(`ALTER DATABASE [${MSSQL_DATABASE}] SET ALLOW_SNAPSHOT_ISOLATION ON;`)
+    await waitForSnapshotIsolationOn(pool)
     await pool.request().batch(`
 IF NOT EXISTS (SELECT 1 FROM sys.server_principals WHERE name = N'${MSSQL_READER_LOGIN}')
 BEGIN

--- a/scripts/ops/stock-preparation-e2e-functional-smoke.mjs
+++ b/scripts/ops/stock-preparation-e2e-functional-smoke.mjs
@@ -1,0 +1,708 @@
+#!/usr/bin/env node
+'use strict'
+
+// Stock-preparation E2E functional smoke (RD-E2E, #4695-adjacent — functional testing, NOT the #4695
+// controlled acceptance).
+//
+// Stands up a containerized, synthetic-data-only, entity-machine-free harness against a LOCALLY-booted
+// core-backend server (Postgres + SQL Server service containers, dispatched job only) and proves:
+//
+//   1. the EXISTING chain (scripts/ops/stock-preparation-prep-line-extended-smoke.mjs, T4) reproduces its
+//      documented 8/8 audit-action coverage over real HTTP against this local server;
+//   2. the S6-A sealed-snapshot route's flag gate is real — a flag-OFF arm (404 DISABLED), an exact-match
+//      arm ('1' and 'yes' must NOT enable it), and (when the full runtime can be provisioned in-job) a
+//      flag-ON arm that walks capture -> private ingestion -> generation kernel -> apply over a REAL,
+//      first-party, ephemeral SQL Server container — never a customer source, never the #4695 entity
+//      machine, never a production flag default.
+//
+// Honesty discipline (repo standing instruction): any phase that cannot complete in this CI job is
+// reported NOT_RUN, never PASS. A non-zero script exit is itself not evidence — the values-free result
+// block below is the evidence, and every field there is either a fixed enum, a count, or a boolean.
+//
+// This script assumes it runs INSIDE the isolated CI job described by
+// .github/workflows/stock-preparation-e2e-functional-smoke.yml: Postgres + SQL Server service containers,
+// dependencies installed, and the two sealed-export Postgres roles + all migrations already applied. It
+// manages its OWN core-backend server process lifecycle (multiple restarts, one per env-var arm) and never
+// touches the deployed entity host or any `origin`-tracked production configuration.
+
+import { spawn } from 'node:child_process'
+import { once } from 'node:events'
+import crypto from 'node:crypto'
+import fs from 'node:fs'
+import { createRequire } from 'node:module'
+import os from 'node:os'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const REPO_ROOT = path.resolve(__dirname, '..', '..')
+const requireFromPlugin = createRequire(
+  path.join(REPO_ROOT, 'plugins/plugin-integration-core/package.json'),
+)
+
+const canonicalCodec = require_(
+  'plugins/plugin-integration-core/lib/sealed-export/canonical-json.cjs',
+)
+
+function require_(relativePath) {
+  return requireFromPlugin(path.join(REPO_ROOT, relativePath))
+}
+
+const SUMMARY_HEADER = 'STOCK_PREPARATION_E2E_FUNCTIONAL_SMOKE'
+const S = {
+  mode: 'functional_testing_synthetic_data',
+  substituteForEntityAcceptance: false,
+}
+const CHECKS = []
+
+export function must(name, ok, detail = '') {
+  CHECKS.push({ name, ok: ok === true, detail })
+  const mark = ok === true ? 'ok' : 'FAIL'
+  process.stderr.write(`[e2e] ${name}: ${mark}${detail ? ` (${detail})` : ''}\n`)
+  return ok === true
+}
+
+function note(name, detail = '') {
+  process.stderr.write(`[e2e] ${name}${detail ? ` (${detail})` : ''}\n`)
+}
+
+function delay(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+// ── config ──────────────────────────────────────────────────────────────────────────────────────────
+const PORT = Number(process.env.E2E_SERVER_PORT || 7801)
+const BASE_URL = `http://127.0.0.1:${PORT}`
+const TENANT_ID = 'e2efunc-tenant'
+const ADMIN_USER_ID = 'e2efunc-admin'
+const REQUEST_TIMEOUT_MS = 20000
+const HEALTH_TIMEOUT_MS = 90000
+const ARTIFACT_ROOT = process.env.E2E_ARTIFACT_ROOT || path.join(os.tmpdir(), 'stock-prep-e2e-artifact-root')
+const OUT_DIR = process.env.E2E_OUT_DIR || path.join(REPO_ROOT, 'output/stock-preparation-e2e-functional-smoke')
+
+// Postgres sealed-export authority roles the workflow already created + migrated against.
+const RUNTIME_DB_ROLE = process.env.E2E_S6A_RUNTIME_DB_ROLE || ''
+const RUNTIME_DB_URL = process.env.E2E_S6A_RUNTIME_DB_URL || ''
+const PROVISIONING_DB_ROLE = process.env.E2E_S6A_PROVISIONING_DB_ROLE || ''
+const PROVISIONING_DB_URL = process.env.E2E_S6A_PROVISIONING_DB_URL || ''
+
+// SQL Server service container (first-party, ephemeral, synthetic data only).
+const MSSQL_HOST = process.env.MSSQL_HOST || '127.0.0.1'
+const MSSQL_PORT = Number(process.env.MSSQL_PORT || 1433)
+const MSSQL_SA_USER = process.env.MSSQL_USERNAME || 'sa'
+const MSSQL_SA_PASSWORD = process.env.MSSQL_PASSWORD || ''
+const MSSQL_DATABASE = 'metasheet_e2e_stock_prep'
+const MSSQL_TABLE = 'dbo.stock_prep_e2e_rows'
+const MSSQL_READER_LOGIN = 'e2e_s6a_reader'
+const MSSQL_READER_PASSWORD = `E2eReader_${crypto.randomBytes(9).toString('hex')}!Aa1`
+
+const BASE_ENV = Object.freeze({
+  ...process.env,
+  DISABLE_WORKFLOW: 'true',
+  DISABLE_EVENT_BUS: 'true',
+  NODE_ENV: 'development',
+  LOG_LEVEL: process.env.E2E_LOG_LEVEL || 'warn',
+  PORT: String(PORT),
+  RBAC_TOKEN_TRUST: 'true',
+  JWT_SECRET: process.env.E2E_JWT_SECRET,
+  INTEGRATION_ENCRYPTION_KEY: process.env.E2E_INTEGRATION_ENCRYPTION_KEY,
+})
+
+if (!BASE_ENV.JWT_SECRET || BASE_ENV.JWT_SECRET.length < 32) {
+  throw new Error('E2E_JWT_SECRET must be set (>=32 chars) by the workflow before this script runs')
+}
+if (!process.env.DATABASE_URL) {
+  throw new Error('DATABASE_URL must be set (the application database, NOT the sealed-export authority roles)')
+}
+
+// ── tiny HTTP helper ────────────────────────────────────────────────────────────────────────────────
+export async function requestJson(pathname, { method = 'GET', body, token, accept = [200] } = {}) {
+  const headers = { 'x-tenant-id': TENANT_ID }
+  if (token) headers.Authorization = `Bearer ${token}`
+  if (body !== undefined) headers['Content-Type'] = 'application/json'
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS)
+  try {
+    const response = await fetch(`${BASE_URL}${pathname}`, {
+      method,
+      headers,
+      body: body !== undefined ? JSON.stringify(body) : undefined,
+      signal: controller.signal,
+    })
+    const text = await response.text()
+    let parsed = null
+    try {
+      parsed = text ? JSON.parse(text) : null
+    } catch {
+      parsed = null
+    }
+    return { status: response.status, body: parsed, ok: accept.includes(response.status) }
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+// ── server process lifecycle ────────────────────────────────────────────────────────────────────────
+let currentServer = null
+
+async function waitForHealth(deadlineMs) {
+  const deadline = Date.now() + deadlineMs
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(`${BASE_URL}/health`, { signal: AbortSignal.timeout(2000) })
+      if (res.ok) return true
+    } catch {
+      // not up yet
+    }
+    await delay(1000)
+  }
+  return false
+}
+
+export async function startServer(extraEnv, label) {
+  if (currentServer) throw new Error('a server is already running; stop it before starting another')
+  const env = { ...BASE_ENV, ...extraEnv }
+  const logPath = path.join(OUT_DIR, `server-${label}.log`)
+  const logFd = fs.openSync(logPath, 'a')
+  const proc = spawn('pnpm', ['--filter', '@metasheet/core-backend', 'run', 'dev:core'], {
+    cwd: REPO_ROOT,
+    env,
+    stdio: ['ignore', logFd, logFd],
+  })
+  currentServer = { proc, logFd, label }
+  const healthy = await waitForHealth(HEALTH_TIMEOUT_MS)
+  if (!healthy) {
+    await stopServer()
+    throw new Error(`server (${label}) did not become healthy within ${HEALTH_TIMEOUT_MS}ms — see server-${label}.log`)
+  }
+  note(`server (${label}) healthy`, `port=${PORT}`)
+  return true
+}
+
+export async function stopServer() {
+  if (!currentServer) return
+  const { proc, logFd, label } = currentServer
+  currentServer = null
+  try {
+    proc.kill('SIGTERM')
+    await Promise.race([once(proc, 'exit'), delay(8000)])
+  } catch {
+    // ignore
+  }
+  if (proc.exitCode === null && proc.signalCode === null) {
+    try {
+      proc.kill('SIGKILL')
+      await Promise.race([once(proc, 'exit'), delay(3000)])
+    } catch {
+      // ignore
+    }
+  }
+  try {
+    fs.closeSync(logFd)
+  } catch {
+    // ignore
+  }
+  note(`server (${label}) stopped`)
+  // Give the OS a beat to release the port before the next spawn.
+  await delay(1500)
+}
+
+// ── auth ─────────────────────────────────────────────────────────────────────────────────────────────
+export async function getDevToken() {
+  const res = await fetch(
+    `${BASE_URL}/api/auth/dev-token?userId=${encodeURIComponent(ADMIN_USER_ID)}&tenantId=${encodeURIComponent(TENANT_ID)}&roles=admin&expiresIn=2h`,
+    { signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS) },
+  )
+  if (!res.ok) throw new Error(`dev-token request failed: http=${res.status}`)
+  const parsed = await res.json()
+  if (!parsed || typeof parsed.token !== 'string' || parsed.token.length < 1) {
+    throw new Error('dev-token response missing token')
+  }
+  return parsed.token
+}
+
+// ── control arms ─────────────────────────────────────────────────────────────────────────────────────
+export async function s6aRunProbe(token, operationId) {
+  return requestJson('/api/integration/internal/stock-preparation/sqlserver-sealed-snapshot/run', {
+    method: 'POST',
+    token,
+    body: { operationId },
+    accept: [200, 201, 404, 400, 403, 409, 422, 503],
+  })
+}
+
+async function runFlagArm(flagValue, expectEnabled, label) {
+  await startServer(
+    flagValue === undefined
+      ? {}
+      : { MULTITABLE_STOCK_PREP_SQLSERVER_SEALED_SNAPSHOT_ENABLED: flagValue },
+    `arm-${label}`,
+  )
+  try {
+    const token = await getDevToken()
+    const health = await requestJson('/api/integration/health', { token })
+    const flagOn = health.body?.capabilities?.stockPreparationSqlServerSealedSnapshot === true
+    const probe = await s6aRunProbe(token, `probe-${label}-${crypto.randomUUID()}`)
+    S[`${label}HealthFlagOn`] = flagOn
+    S[`${label}Http`] = probe.status
+    S[`${label}Code`] = probe.body?.error?.code || '<none>'
+    const pass = expectEnabled
+      ? flagOn === true
+      : flagOn === false && probe.status === 404 && probe.body?.error?.code === 'STOCK_PREPARATION_SQLSERVER_SEALED_SNAPSHOT_DISABLED'
+    must(`flag arm ${label}: ${expectEnabled ? 'flag reads enabled' : '404 DISABLED (flag not enabled)'}`, pass,
+      `flagOn=${flagOn} http=${probe.status} code=${S[`${label}Code`]}`)
+    S[`${label}Pass`] = pass ? 'PASS' : 'FAIL'
+  } finally {
+    await stopServer()
+  }
+}
+
+// ── existing chain (T4 extended smoke) ──────────────────────────────────────────────────────────────
+async function runExistingChain(token) {
+  const outDir = path.join(OUT_DIR, 'existing-chain')
+  fs.mkdirSync(outDir, { recursive: true })
+  const args = [
+    path.join(REPO_ROOT, 'scripts/ops/stock-preparation-prep-line-extended-smoke.mjs'),
+    '--base-url', BASE_URL,
+    '--tenant-id', TENANT_ID,
+    '--project-prefix', 'stockprep-e2efunc',
+    '--timeout-ms', String(REQUEST_TIMEOUT_MS),
+    '--out-dir', outDir,
+  ]
+  const exitCode = await new Promise((resolve) => {
+    const proc = spawn(process.execPath, args, {
+      cwd: REPO_ROOT,
+      env: { ...process.env, METASHEET_AUTH_TOKEN: token },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+    let stdout = ''
+    proc.stdout.on('data', (chunk) => {
+      stdout += chunk.toString()
+    })
+    proc.stderr.on('data', (chunk) => {
+      process.stderr.write(chunk)
+    })
+    proc.on('close', (code) => resolve({ code, stdout }))
+  }).then(({ code, stdout }) => {
+    fs.writeFileSync(path.join(outDir, 'stdout.txt'), stdout)
+    return code
+  })
+  let summary = {}
+  try {
+    const summaryText = fs.readFileSync(path.join(outDir, 'summary.txt'), 'utf8')
+    for (const line of summaryText.split('\n').slice(1)) {
+      const idx = line.indexOf('=')
+      if (idx === -1) continue
+      summary[line.slice(0, idx)] = line.slice(idx + 1)
+    }
+  } catch {
+    summary = {}
+  }
+  S.existingChainScriptExit = exitCode
+  S.existingChainAuditActionsCovered = summary.auditActionsCovered || '<not-run>'
+  S.existingChainExternalWrite = summary.externalWrite || '<not-run>'
+  S.existingChainLeakScanClean = summary.leakScanClean || '<not-run>'
+  const pass = exitCode === 0 && summary.pass === 'true' && summary.auditActionsCovered === '8/8' &&
+    summary.externalWrite === 'false'
+  must('existing chain (T4 extended smoke) reproduces 8/8 audit coverage, externalWrite=false',
+    pass, `exit=${exitCode} audit=${S.existingChainAuditActionsCovered} externalWrite=${S.existingChainExternalWrite}`)
+  S.existingChainPass = pass ? 'PASS' : 'FAIL'
+  return pass
+}
+
+// ── S6-A real flag-ON attempt (best-effort; every step reports NOT_RUN, not PASS, on failure) ────────
+function canonicalText(value) {
+  const result = canonicalCodec.tryCanonicalJson(value)
+  if (!result.ok) throw new Error('failed to canonicalize S6-A fixture value')
+  return result.bytes.toString('utf8')
+}
+
+function buildBomPayload(index, salt) {
+  const projectId = `s6a-e2e-${salt}`
+  return {
+    bomLevel: index === 0 ? 0 : 1,
+    childDrawingNo: `E2E-CHILD-${index + 1}-${salt}`,
+    childVersion: null,
+    designQty: '1.5',
+    designUnit: 'EA',
+    lineStatus: 'active',
+    parentDrawingNo: index === 0 ? null : `E2E-CHILD-1-${salt}`,
+    parentVersion: null,
+    pathKey: `root/${index + 1}`,
+    projectId,
+    projectName: `S6A E2E Project ${salt}`,
+    snapshotBatchId: `s6a-e2e-batch-${salt}`,
+    snapshotVersion: 1,
+    sourceBomId: `s6a-e2e-bom-${salt}`,
+    sourceProjectNo: `S6A-E2E-${salt}`,
+    syncRunId: `s6a-e2e-sync-${salt}`,
+  }
+}
+
+async function withSqlServerAdmin(fn) {
+  const sql = requireFromPlugin('mssql')
+  const pool = new sql.ConnectionPool({
+    server: MSSQL_HOST,
+    port: MSSQL_PORT,
+    user: MSSQL_SA_USER,
+    password: MSSQL_SA_PASSWORD,
+    database: 'master',
+    options: { encrypt: true, trustServerCertificate: true },
+    connectionTimeout: 15000,
+  })
+  await pool.connect()
+  try {
+    return await fn(pool, sql)
+  } finally {
+    await pool.close()
+  }
+}
+
+async function prepareSqlServerRelation(salt) {
+  const rows = [0, 1, 2].map((index) => buildBomPayload(index, salt))
+  await withSqlServerAdmin(async (pool, sql) => {
+    await pool.request().batch(`
+IF DB_ID(N'${MSSQL_DATABASE}') IS NULL
+BEGIN
+  CREATE DATABASE ${MSSQL_DATABASE};
+END`)
+    await pool.request().batch(`
+IF NOT EXISTS (SELECT 1 FROM sys.server_principals WHERE name = N'${MSSQL_READER_LOGIN}')
+BEGIN
+  CREATE LOGIN [${MSSQL_READER_LOGIN}] WITH PASSWORD = N'${MSSQL_READER_PASSWORD}', CHECK_POLICY = OFF;
+END`)
+    const dbPool = new sql.ConnectionPool({
+      server: MSSQL_HOST,
+      port: MSSQL_PORT,
+      user: MSSQL_SA_USER,
+      password: MSSQL_SA_PASSWORD,
+      database: MSSQL_DATABASE,
+      options: { encrypt: true, trustServerCertificate: true },
+      connectionTimeout: 15000,
+    })
+    await dbPool.connect()
+    try {
+      await dbPool.request().batch(`
+IF NOT EXISTS (SELECT 1 FROM sys.database_principals WHERE name = N'${MSSQL_READER_LOGIN}')
+BEGIN
+  CREATE USER [${MSSQL_READER_LOGIN}] FOR LOGIN [${MSSQL_READER_LOGIN}];
+END`)
+      await dbPool.request().batch(`
+IF OBJECT_ID(N'${MSSQL_TABLE}', N'U') IS NOT NULL DROP TABLE ${MSSQL_TABLE};
+CREATE TABLE ${MSSQL_TABLE} (
+  row_id int NOT NULL PRIMARY KEY,
+  payload_version int NOT NULL,
+  payload nvarchar(4000) NOT NULL
+);`)
+      const request = dbPool.request()
+      const values = []
+      rows.forEach((rowPayload, index) => {
+        const rowIdParam = `rowId${index}`
+        const payloadParam = `payload${index}`
+        request.input(rowIdParam, sql.Int, index + 1)
+        request.input(payloadParam, sql.NVarChar(4000), canonicalText(rowPayload))
+        values.push(`(@${rowIdParam}, 1, @${payloadParam})`)
+      })
+      await request.query(`INSERT INTO ${MSSQL_TABLE} (row_id, payload_version, payload) VALUES ${values.join(',')}`)
+      await dbPool.request().batch(`GRANT SELECT ON OBJECT::${MSSQL_TABLE} TO [${MSSQL_READER_LOGIN}];`)
+    } finally {
+      await dbPool.close()
+    }
+  })
+  return { rows, projectId: rows[0].projectId, snapshotBatchId: rows[0].snapshotBatchId }
+}
+
+async function registerExternalSystem(token, systemId) {
+  const body = {
+    id: systemId,
+    name: 'e2e-func-s6a-source',
+    kind: 'data-source:sql-readonly',
+    role: 'source',
+    status: 'active',
+    config: {
+      sealedSnapshotSqlServer: {
+        database: MSSQL_DATABASE,
+        encrypt: true,
+        instanceName: null,
+        port: MSSQL_PORT,
+        server: MSSQL_HOST,
+        trustServerCertificate: true,
+      },
+    },
+    credentials: {
+      sealedSnapshotSqlServer: {
+        password: MSSQL_READER_PASSWORD,
+        user: MSSQL_READER_LOGIN,
+      },
+    },
+  }
+  const res = await requestJson('/api/integration/external-systems', {
+    method: 'POST', token, body, accept: [200, 201],
+  })
+  return res
+}
+
+async function runProvisioningScript(env) {
+  return new Promise((resolve) => {
+    const proc = spawn(
+      process.execPath,
+      [path.join(REPO_ROOT, 'plugins/plugin-integration-core/scripts/provision-stock-preparation-sqlserver-sealed-snapshot.cjs')],
+      { cwd: REPO_ROOT, env: { ...process.env, ...env }, stdio: ['ignore', 'pipe', 'pipe'] },
+    )
+    let stdout = ''
+    let stderr = ''
+    proc.stdout.on('data', (c) => { stdout += c.toString() })
+    proc.stderr.on('data', (c) => { stderr += c.toString() })
+    proc.on('close', (code) => resolve({ code, stdout, stderr }))
+  })
+}
+
+async function attemptS6ARealRun() {
+  const salt = `t${Math.floor(Date.now() / 1000)}`
+  const systemId = `e2efunc-s6a-source-${salt}`
+  const bindingVersion = `e2efunc-binding-${salt}`
+  const approvedConfigVersionId = `e2efunc-config-${salt}`
+  const qualificationKeyId = 'e2efunc-qual-key-v1'
+
+  if (!RUNTIME_DB_ROLE || !RUNTIME_DB_URL || !PROVISIONING_DB_ROLE || !PROVISIONING_DB_URL) {
+    S.s6aFlagOnRun = 'NOT_RUN'
+    S.s6aFlagOnReason = 'RUNTIME_DB_ENV_MISSING'
+    must('S6-A flag-ON real run attempted', false, 'runtime/provisioning DB env not provided by workflow')
+    return
+  }
+
+  const keysDir = fs.mkdtempSync(path.join(os.tmpdir(), 's6a-e2e-keys-'))
+  const identityKeyFile = path.join(keysDir, 'identity.key')
+  const evidenceKeyFile = path.join(keysDir, 'evidence.key')
+  const qualificationKeyFile = path.join(keysDir, 'qualification.key')
+  const signerKeyFile = path.join(keysDir, 'signer.pem')
+  fs.writeFileSync(identityKeyFile, crypto.randomBytes(32))
+  fs.writeFileSync(evidenceKeyFile, crypto.randomBytes(32))
+  fs.writeFileSync(qualificationKeyFile, crypto.randomBytes(32))
+  const { privateKey } = crypto.generateKeyPairSync('ed25519')
+  fs.writeFileSync(signerKeyFile, privateKey.export({ type: 'pkcs8', format: 'pem' }))
+  fs.mkdirSync(ARTIFACT_ROOT, { recursive: true })
+
+  // 1. real SQL Server relation (ephemeral, first-party, synthetic rows only)
+  let relation
+  try {
+    relation = await prepareSqlServerRelation(salt)
+    must('S6-A: SQL Server relation + SELECT-only login prepared', true,
+      `rows=${relation.rows.length}`)
+  } catch (error) {
+    S.s6aFlagOnRun = 'NOT_RUN'
+    S.s6aFlagOnReason = 'SQLSERVER_RELATION_SETUP_FAILED'
+    must('S6-A: SQL Server relation + SELECT-only login prepared', false, String(error && error.message || error))
+    return
+  }
+
+  // 2. real external system record (must exist BEFORE the runtime attempts a run; visible via the
+  // ordinary external-systems HTTP surface, credentials plaintext only inside this request body).
+  const baseToken = await getDevToken()
+  const registered = await registerExternalSystem(baseToken, systemId)
+  const registeredOk = must('S6-A: external system registered', registered.ok, `http=${registered.status}`)
+  S.s6aExternalSystemRegistered = registeredOk ? 'PASS' : 'FAIL'
+  if (!registeredOk) {
+    S.s6aFlagOnRun = 'NOT_RUN'
+    S.s6aFlagOnReason = 'EXTERNAL_SYSTEM_REGISTRATION_FAILED'
+    return
+  }
+
+  // 3. provisioning spec (inline external-system connection material — no DB registry lookup at
+  // provisioning time; the runtime independently re-resolves the SAME record at run time).
+  const provisioningSpec = {
+    binding: {
+      approvedConfigVersionId,
+      bindingExpiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
+      bindingId: `e2efunc-binding-id-${salt}`,
+      bindingVersion,
+      externalSystemId: systemId,
+      signerExpiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
+      tableRef: MSSQL_TABLE,
+      tenantId: TENANT_ID,
+      workspaceId: null,
+    },
+    externalSystem: {
+      config: {
+        sealedSnapshotSqlServer: {
+          database: MSSQL_DATABASE,
+          encrypt: true,
+          instanceName: null,
+          port: MSSQL_PORT,
+          server: MSSQL_HOST,
+          trustServerCertificate: true,
+        },
+      },
+      credentials: {
+        sealedSnapshotSqlServer: {
+          password: MSSQL_READER_PASSWORD,
+          user: MSSQL_READER_LOGIN,
+        },
+      },
+      id: systemId,
+      kind: 'data-source:sql-readonly',
+      role: 'source',
+      status: 'active',
+      tenantId: TENANT_ID,
+      workspaceId: null,
+    },
+  }
+  const specFile = path.join(keysDir, 'provisioning-spec.json')
+  fs.writeFileSync(specFile, JSON.stringify(provisioningSpec))
+
+  const provisioningEnv = {
+    MULTITABLE_STOCK_PREP_SQLSERVER_SEALED_SNAPSHOT_ARTIFACT_ROOT: ARTIFACT_ROOT,
+    MULTITABLE_STOCK_PREP_SQLSERVER_SEALED_SNAPSHOT_IDENTITY_KEY_FILE: identityKeyFile,
+    MULTITABLE_STOCK_PREP_SQLSERVER_SEALED_SNAPSHOT_QUALIFICATION_KEY_FILE: qualificationKeyFile,
+    MULTITABLE_STOCK_PREP_SQLSERVER_SEALED_SNAPSHOT_QUALIFICATION_KEY_ID: qualificationKeyId,
+    MULTITABLE_STOCK_PREP_SQLSERVER_SEALED_SNAPSHOT_SIGNER_PRIVATE_KEY_FILE: signerKeyFile,
+    MULTITABLE_STOCK_PREP_SQLSERVER_SEALED_SNAPSHOT_PROVISIONING_DATABASE_ROLE: PROVISIONING_DB_ROLE,
+    MULTITABLE_STOCK_PREP_SQLSERVER_SEALED_SNAPSHOT_PROVISIONING_DATABASE_URL: PROVISIONING_DB_URL,
+    MULTITABLE_STOCK_PREP_SQLSERVER_SEALED_SNAPSHOT_PROVISIONING_SPEC_FILE: specFile,
+  }
+  const provisioned = await runProvisioningScript(provisioningEnv)
+  let provisionedOk = false
+  try {
+    const parsed = JSON.parse(provisioned.stdout.trim().split('\n').pop() || '{}')
+    provisionedOk = provisioned.code === 0 && parsed.ok === true && parsed.externalWrite === false && parsed.valuesFree === true
+    S.s6aProvisioningChanged = typeof parsed.changed === 'boolean' ? String(parsed.changed) : '<unregistered>'
+  } catch {
+    provisionedOk = false
+  }
+  must('S6-A: provisioning script -> ok:true, externalWrite:false, valuesFree:true', provisionedOk,
+    `exit=${provisioned.code}`)
+  S.s6aProvisioning = provisionedOk ? 'PASS' : 'FAIL'
+  if (!provisionedOk) {
+    S.s6aFlagOnRun = 'NOT_RUN'
+    S.s6aFlagOnReason = 'PROVISIONING_FAILED'
+    return
+  }
+
+  // 4. flag-ON restart with the full runtime authority wired.
+  const runtimeEnv = {
+    MULTITABLE_STOCK_PREP_SQLSERVER_SEALED_SNAPSHOT_ENABLED: 'true',
+    MULTITABLE_STOCK_PREP_SQLSERVER_SEALED_SNAPSHOT_ARTIFACT_ROOT: ARTIFACT_ROOT,
+    MULTITABLE_STOCK_PREP_SQLSERVER_SEALED_SNAPSHOT_EVIDENCE_KEY_FILE: evidenceKeyFile,
+    MULTITABLE_STOCK_PREP_SQLSERVER_SEALED_SNAPSHOT_IDENTITY_KEY_FILE: identityKeyFile,
+    MULTITABLE_STOCK_PREP_SQLSERVER_SEALED_SNAPSHOT_QUALIFICATION_KEY_FILE: qualificationKeyFile,
+    MULTITABLE_STOCK_PREP_SQLSERVER_SEALED_SNAPSHOT_QUALIFICATION_KEY_ID: qualificationKeyId,
+    MULTITABLE_STOCK_PREP_SQLSERVER_SEALED_SNAPSHOT_RUNTIME_DATABASE_ROLE: RUNTIME_DB_ROLE,
+    MULTITABLE_STOCK_PREP_SQLSERVER_SEALED_SNAPSHOT_RUNTIME_DATABASE_URL: RUNTIME_DB_URL,
+    MULTITABLE_STOCK_PREP_SQLSERVER_SEALED_SNAPSHOT_SIGNER_PRIVATE_KEY_FILE: signerKeyFile,
+  }
+  try {
+    await startServer(runtimeEnv, 'flag-on')
+  } catch (error) {
+    S.s6aFlagOnRun = 'NOT_RUN'
+    S.s6aFlagOnReason = 'RUNTIME_SERVER_START_FAILED'
+    must('S6-A: flag-ON server started with runtime authority constructed', false, String(error && error.message || error))
+    return
+  }
+
+  try {
+    const token = await getDevToken()
+    const health = await requestJson('/api/integration/health', { token })
+    const flagOn = health.body?.capabilities?.stockPreparationSqlServerSealedSnapshot === true
+    S.s6aHealthFlagOn = flagOn ? 'PASS' : 'FAIL'
+    if (!must('S6-A: health reports runtime CONSTRUCTED (not just flag-string-true)', flagOn,
+      `flagOn=${flagOn}`)) {
+      S.s6aFlagOnRun = 'NOT_RUN'
+      S.s6aFlagOnReason = 'RUNTIME_NOT_CONSTRUCTED'
+      return
+    }
+
+    // mvp/ensure is idempotent per tenant/workspace — defensive re-provisioning of the underlying
+    // multitable object/field templates the persist step needs (the existing-chain phase already ran
+    // this once for the SAME tenant, but this phase can run standalone).
+    await requestJson('/api/integration/stock-preparation/mvp/ensure', { method: 'POST', token, body: {}, accept: [200, 201] })
+
+    const operationId = `s6a-e2e-op-${salt}`
+    const firstRun = await s6aRunProbe(token, operationId)
+    const firstData = firstRun.body?.data || {}
+    S.s6aFirstRunHttp = firstRun.status
+    S.s6aFirstRunMode = firstData.mode || '<unregistered>'
+    S.s6aFirstRunStatus = firstData.status || '<unregistered>'
+    S.s6aBusinessLineCount = Number.isInteger(firstData.businessLineCount) ? firstData.businessLineCount : -1
+    S.s6aFirstRunExternalWrite = firstData.externalWrite === false ? 'false' : '<unregistered>'
+    const firstOk = firstRun.ok && firstData.status === 'COMPLETED' && firstData.mode === 'internal_persist' &&
+      firstData.externalWrite === false && firstData.businessLineCount === relation.rows.length
+    must('S6-A: first run -> COMPLETED, internal_persist, externalWrite=false, businessLineCount matches',
+      firstOk, `http=${firstRun.status} mode=${S.s6aFirstRunMode} status=${S.s6aFirstRunStatus} lines=${S.s6aBusinessLineCount}`)
+    S.s6aFirstRun = firstOk ? 'PASS' : 'FAIL'
+    if (!firstOk) {
+      S.s6aReplayRun = 'NOT_RUN'
+      return
+    }
+
+    const replay = await s6aRunProbe(token, operationId)
+    const replayData = replay.body?.data || {}
+    S.s6aReplayHttp = replay.status
+    S.s6aReplayMode = replayData.mode || '<unregistered>'
+    const replayOk = replay.ok && replayData.mode === 'internal_noop' && replayData.replay === true &&
+      replayData.sourceReadCount === 1 && replayData.businessLineCount === relation.rows.length &&
+      replayData.externalWrite === false
+    must('S6-A: replay same operationId -> internal_noop, sourceReadCount=1, same businessLineCount',
+      replayOk, `http=${replay.status} mode=${S.s6aReplayMode}`)
+    S.s6aReplayRun = replayOk ? 'PASS' : 'FAIL'
+    S.s6aFlagOnRun = (firstOk && replayOk) ? 'PASS' : 'FAIL'
+  } finally {
+    await stopServer()
+  }
+}
+
+// ── negative arm helper (exported for the workflow's separate negative-control job) ───────────────────
+export async function main() {
+  fs.mkdirSync(OUT_DIR, { recursive: true })
+
+  // Phase 1: flag-OFF arm.
+  await runFlagArm(undefined, false, 'flagOff')
+
+  // Phase 2: exact-match arms — '1' and 'yes' must NOT enable the route.
+  await runFlagArm('1', false, 'exactMatch1')
+  await runFlagArm('yes', false, 'exactMatchYes')
+
+  // Phase 3: existing chain (T4 extended smoke) against a fresh flag-OFF server.
+  await startServer({}, 'existing-chain')
+  try {
+    const token = await getDevToken()
+    await runExistingChain(token)
+  } finally {
+    await stopServer()
+  }
+
+  // Phase 4: S6-A real flag-ON attempt (best-effort; every failure point reports NOT_RUN honestly).
+  try {
+    await attemptS6ARealRun()
+  } catch (error) {
+    S.s6aFlagOnRun = S.s6aFlagOnRun || 'NOT_RUN'
+    S.s6aFlagOnReason = S.s6aFlagOnReason || 'UNEXPECTED_ERROR'
+    must('S6-A flag-ON real run attempted', false, String(error && error.message || error))
+    await stopServer()
+  }
+
+  // Overall PASS requires every check that ran to have passed — including the S6-A real-run attempt.
+  // A S6-A step that legitimately could not proceed is recorded as NOT_RUN in the result block (never
+  // as PASS), but the `must()` that reports it still counts toward the job's own conclusion: this
+  // script does not manufacture a green job out of an incomplete real-run attempt. The values-free
+  // result block below is the durable evidence regardless of which way the exit code goes.
+  const anyFail = CHECKS.some((c) => !c.ok)
+  S.overallPass = !anyFail ? 'PASS' : 'FAIL'
+
+  const lines = [SUMMARY_HEADER]
+  for (const [key, value] of Object.entries(S)) lines.push(`${key}=${value}`)
+  const block = lines.join('\n')
+  process.stdout.write(`${block}\n`)
+  fs.writeFileSync(path.join(OUT_DIR, 'summary.txt'), `${block}\n`)
+  fs.writeFileSync(path.join(OUT_DIR, 'checks.json'), JSON.stringify(CHECKS, null, 2))
+  process.exitCode = anyFail ? 1 : 0
+}
+
+const invokedDirectly = process.argv[1] && import.meta.url.endsWith(path.basename(process.argv[1]))
+if (invokedDirectly) {
+  main().catch(async (error) => {
+    process.stderr.write(`[e2e] fatal: ${error && error.stack ? error.stack : error}\n`)
+    await stopServer().catch(() => {})
+    process.exitCode = 1
+  })
+}

--- a/scripts/ops/stock-preparation-e2e-functional-smoke.mjs
+++ b/scripts/ops/stock-preparation-e2e-functional-smoke.mjs
@@ -30,6 +30,7 @@ import { once } from 'node:events'
 import crypto from 'node:crypto'
 import fs from 'node:fs'
 import { createRequire } from 'node:module'
+import net from 'node:net'
 import os from 'node:os'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -159,6 +160,29 @@ export async function requestJson(pathname, { method = 'GET', body, token, accep
 }
 
 // ── server process lifecycle ────────────────────────────────────────────────────────────────────────
+//
+// RD-E2E finding (this lane, S6-A flag-ON arm): `stopServer()` used to send SIGTERM to the `pnpm`
+// wrapper process only, then wait a flat 1500ms and declare the server stopped. Killing that ONE pid is
+// not proof the actual `tsx src/index.ts` process it spawned (via `pnpm run dev:core`) went down with
+// it — a package-manager wrapper does not always forward signals to, or die together with, its own
+// child. When it didn't, the OLD process kept listening on PORT, and the NEXT `startServer()` call's
+// `waitForHealth()` — which only checks "does something answer /health", not "does MY spawn answer" —
+// passed instantly by hitting the STALE process instead of the one it just spawned. Every arm before
+// the flag-ON one expects flagOn===false, so a stale flag-OFF process answering in its place was
+// invisible; only the flag-ON arm (the one arm expecting a DIFFERENT value) exposed it, as
+// `s6aHealthFlagOn=FAIL` with the underlying route never having been restarted at all. Evidence: dispatched
+// run 30831507305 job 91746459841 shows "server (flag-on) healthy" logged 4ms after the provisioning
+// script's own completion line — every other arm transition in that SAME run took ~1.5s (the
+// stopServer→startServer round trip), which a freshly spawned server cannot beat; the only process that
+// could answer in 4ms is one that was ALREADY running the whole time.
+//
+// Fix, entirely inside this harness (no production code touched): (1) spawn detached so the whole
+// process TREE pnpm creates can be signalled as one group, not just the wrapper pid; (2) `stopServer()`
+// now ACTIVELY CONFIRMS the port stopped accepting connections — with a last-resort OS-level sweep for
+// anything still bound to it — instead of assuming a flat delay was enough; a port that will not free is
+// a loud thrown error, never a silent return. This makes "the next arm's health check passed" mean what
+// it says: MY spawn is the one that answered, because nothing else could have been listening on that
+// port when the check began.
 let currentServer = null
 
 async function waitForHealth(deadlineMs) {
@@ -175,6 +199,59 @@ async function waitForHealth(deadlineMs) {
   return false
 }
 
+function isPortFree(port) {
+  return new Promise((resolve) => {
+    let settled = false
+    const socket = net.createConnection({ port, host: '127.0.0.1' })
+    const finish = (free) => {
+      if (settled) return
+      settled = true
+      socket.removeAllListeners()
+      socket.destroy()
+      resolve(free)
+    }
+    socket.once('connect', () => finish(false)) // something accepted the connection — still bound
+    socket.once('error', () => finish(true)) // nothing there (ECONNREFUSED) — free
+    socket.setTimeout(1000, () => finish(true))
+  })
+}
+
+async function waitForPortFree(port, deadlineMs) {
+  const deadline = Date.now() + deadlineMs
+  while (Date.now() < deadline) {
+    if (await isPortFree(port)) return true
+    await delay(250)
+  }
+  return false
+}
+
+// Last-resort fallback if the process-group signal above did not reach whatever is still listening
+// (e.g. it re-parented into a session of its own). Best-effort only: a missing/failing `lsof` here is a
+// no-op, not a crash — `waitForPortFree()` is what actually decides pass/fail for stopServer(), not this.
+async function killAnyProcessOnPort(port) {
+  await new Promise((resolve) => {
+    const finder = spawn('sh', ['-c', `lsof -ti tcp:${port} 2>/dev/null || true`], {
+      stdio: ['ignore', 'pipe', 'ignore'],
+    })
+    let out = ''
+    finder.stdout.on('data', (chunk) => { out += chunk.toString() })
+    finder.on('close', () => {
+      for (const pidText of out.split('\n').map((s) => s.trim()).filter(Boolean)) {
+        const foundPid = Number(pidText)
+        if (Number.isInteger(foundPid) && foundPid > 0) {
+          try {
+            process.kill(foundPid, 'SIGKILL')
+          } catch {
+            // already gone
+          }
+        }
+      }
+      resolve()
+    })
+    finder.on('error', () => resolve())
+  })
+}
+
 export async function startServer(extraEnv, label) {
   if (currentServer) throw new Error('a server is already running; stop it before starting another')
   const env = { ...BASE_ENV, ...extraEnv }
@@ -187,6 +264,9 @@ export async function startServer(extraEnv, label) {
     cwd: REPO_ROOT,
     env,
     stdio: ['ignore', logFd, logFd],
+    // Its own process group leader, so stopServer() can signal the WHOLE tree pnpm spawns underneath it
+    // (see the block comment above) instead of only the wrapper pid.
+    detached: true,
   })
   currentServer = { proc, logFd, label }
   const healthy = await waitForHealth(HEALTH_TIMEOUT_MS)
@@ -202,15 +282,26 @@ export async function stopServer() {
   if (!currentServer) return
   const { proc, logFd, label } = currentServer
   currentServer = null
+  const pid = proc.pid
+  function killGroup(signal) {
+    if (!pid) return
+    try {
+      // `-pid` targets the whole process group (valid because startServer() spawns with detached: true),
+      // not just the pnpm wrapper — see the block comment above this section.
+      process.kill(-pid, signal)
+    } catch {
+      // ESRCH (already gone) or no process-group support on this platform — best effort either way.
+    }
+  }
   try {
-    proc.kill('SIGTERM')
+    killGroup('SIGTERM')
     await Promise.race([once(proc, 'exit'), delay(8000)])
   } catch {
     // ignore
   }
   if (proc.exitCode === null && proc.signalCode === null) {
+    killGroup('SIGKILL')
     try {
-      proc.kill('SIGKILL')
       await Promise.race([once(proc, 'exit'), delay(3000)])
     } catch {
       // ignore
@@ -221,9 +312,22 @@ export async function stopServer() {
   } catch {
     // ignore
   }
-  note(`server (${label}) stopped`)
-  // Give the OS a beat to release the port before the next spawn.
-  await delay(1500)
+  // The wrapper process exiting is NOT proof the actual server process is gone (that is exactly the bug
+  // this section fixes — see the block comment above). Confirm the port itself stopped accepting
+  // connections before declaring this server stopped; a stale listener here would silently hand the
+  // NEXT startServer()'s health check a WRONG process to talk to instead of the one it is about to spawn.
+  let portFree = await waitForPortFree(PORT, 5000)
+  if (!portFree) {
+    await killAnyProcessOnPort(PORT)
+    portFree = await waitForPortFree(PORT, 5000)
+  }
+  if (!portFree) {
+    throw new Error(
+      `server (${label}) process group did not release port ${PORT} — a stale server may still be listening; ` +
+      'refusing to continue, since the next arm would silently talk to the wrong process',
+    )
+  }
+  note(`server (${label}) stopped`, `port=${PORT} confirmedFree=true`)
 }
 
 // ── auth ─────────────────────────────────────────────────────────────────────────────────────────────
@@ -526,6 +630,57 @@ async function runProvisioningScript(env) {
   })
 }
 
+// ── Step 3 (database-observable proof) ──────────────────────────────────────────────────────────────
+// A 200 with a COMPLETED-looking response body is not evidence the generation kernel actually wrote
+// anything — it is only evidence the HTTP layer said so. This queries the rows the kernel is supposed
+// to have written directly, over a SEPARATE connection using the APPLICATION's own DATABASE_URL (the
+// migration/superuser role) rather than the S6-A runtime role, so the proof does not depend on the same
+// identity that (allegedly) wrote the rows also being the one asked to confirm they exist. Values-free:
+// only fixed status tokens and counts are read into the evidence block, no row payload content.
+async function assertS6ARunDatabaseObservable(operationId) {
+  const pg = requireFromPlugin('pg')
+  const pool = new pg.Pool({ connectionString: process.env.DATABASE_URL, max: 1 })
+  try {
+    const runRows = await pool.query(
+      `SELECT status, source_read_count, business_line_count, generation_id
+       FROM integration_sealed_export_stock_prep_runs
+       WHERE tenant_id = $1 AND operation_id = $2`,
+      [TENANT_ID, operationId],
+    )
+    const run = runRows.rows[0] || null
+    S.s6aDbRunRowFound = run ? 'true' : 'false'
+    S.s6aDbRunStatus = run ? run.status : '<none>'
+    S.s6aDbRunSourceReadCount = run ? Number(run.source_read_count) : -1
+    S.s6aDbRunBusinessLineCount = run ? Number(run.business_line_count) : -1
+
+    let generationFound = false
+    let generationStatus = '<none>'
+    if (run && run.generation_id) {
+      const generationRows = await pool.query(
+        `SELECT status FROM integration_sealed_export_generations WHERE generation_id = $1 AND tenant_id = $2`,
+        [run.generation_id, TENANT_ID],
+      )
+      generationFound = generationRows.rows.length === 1
+      generationStatus = generationFound ? generationRows.rows[0].status : '<none>'
+    }
+    S.s6aDbGenerationRowFound = generationFound ? 'true' : 'false'
+    S.s6aDbGenerationStatus = generationStatus
+
+    const dbOk = run !== null && run.status === 'COMPLETED' && Number(run.source_read_count) === 1 &&
+      generationFound
+    must(
+      'S6-A: database-observable proof — stock_prep_runs row COMPLETED (source_read_count=1) + a matching ' +
+      'generations row exist, queried over a SEPARATE (superuser, non-runtime-role) connection',
+      dbOk,
+      `runFound=${S.s6aDbRunRowFound} runStatus=${S.s6aDbRunStatus} genFound=${S.s6aDbGenerationRowFound} genStatus=${S.s6aDbGenerationStatus}`,
+    )
+    S.s6aDatabaseObservable = dbOk ? 'PASS' : 'FAIL'
+    return dbOk
+  } finally {
+    await pool.end()
+  }
+}
+
 async function attemptS6ARealRun() {
   const salt = `t${Math.floor(Date.now() / 1000)}`
   const systemId = `e2efunc-s6a-source-${salt}`
@@ -727,6 +882,16 @@ async function attemptS6ARealRun() {
       firstOk, `http=${firstRun.status} mode=${S.s6aFirstRunMode} status=${S.s6aFirstRunStatus} lines=${S.s6aBusinessLineCount}`)
     S.s6aFirstRun = firstOk ? 'PASS' : 'FAIL'
     if (!firstOk) {
+      S.s6aDatabaseObservable = 'NOT_RUN'
+      S.s6aReplayRun = 'NOT_RUN'
+      return
+    }
+
+    // Step 3: the HTTP response saying COMPLETED is not proof anything was written — confirm the
+    // generation kernel's own rows exist, over a connection independent of the runtime role that wrote
+    // them.
+    const dbOk = await assertS6ARunDatabaseObservable(operationId)
+    if (!dbOk) {
       S.s6aReplayRun = 'NOT_RUN'
       return
     }
@@ -741,7 +906,7 @@ async function attemptS6ARealRun() {
     must('S6-A: replay same operationId -> internal_noop, sourceReadCount=1, same businessLineCount',
       replayOk, `http=${replay.status} mode=${S.s6aReplayMode}`)
     S.s6aReplayRun = replayOk ? 'PASS' : 'FAIL'
-    S.s6aFlagOnRun = (firstOk && replayOk) ? 'PASS' : 'FAIL'
+    S.s6aFlagOnRun = (firstOk && dbOk && replayOk) ? 'PASS' : 'FAIL'
   } finally {
     await stopServer()
   }

--- a/scripts/ops/stock-preparation-e2e-functional-smoke.mjs
+++ b/scripts/ops/stock-preparation-e2e-functional-smoke.mjs
@@ -637,7 +637,7 @@ async function runProvisioningScript(env) {
 // migration/superuser role) rather than the S6-A runtime role, so the proof does not depend on the same
 // identity that (allegedly) wrote the rows also being the one asked to confirm they exist. Values-free:
 // only fixed status tokens and counts are read into the evidence block, no row payload content.
-async function assertS6ARunDatabaseObservable(operationId) {
+async function assertS6ARunDatabaseObservable(operationId, expectedBusinessLineCount) {
   const pg = requireFromPlugin('pg')
   const pool = new pg.Pool({ connectionString: process.env.DATABASE_URL, max: 1 })
   try {
@@ -666,13 +666,18 @@ async function assertS6ARunDatabaseObservable(operationId) {
     S.s6aDbGenerationRowFound = generationFound ? 'true' : 'false'
     S.s6aDbGenerationStatus = generationStatus
 
+    // Not just "a row exists" — the row the kernel was supposed to write for THIS fixture: the same
+    // business-line count the HTTP-level assertion already checked on the response body, now confirmed
+    // independently against the persisted row.
     const dbOk = run !== null && run.status === 'COMPLETED' && Number(run.source_read_count) === 1 &&
-      generationFound
+      Number(run.business_line_count) === expectedBusinessLineCount && generationFound
     must(
-      'S6-A: database-observable proof — stock_prep_runs row COMPLETED (source_read_count=1) + a matching ' +
-      'generations row exist, queried over a SEPARATE (superuser, non-runtime-role) connection',
+      'S6-A: database-observable proof — stock_prep_runs row COMPLETED (source_read_count=1, ' +
+      'business_line_count matches the fixture) + a matching generations row exist, queried over a ' +
+      'SEPARATE (superuser, non-runtime-role) connection',
       dbOk,
-      `runFound=${S.s6aDbRunRowFound} runStatus=${S.s6aDbRunStatus} genFound=${S.s6aDbGenerationRowFound} genStatus=${S.s6aDbGenerationStatus}`,
+      `runFound=${S.s6aDbRunRowFound} runStatus=${S.s6aDbRunStatus} lines=${S.s6aDbRunBusinessLineCount} ` +
+      `genFound=${S.s6aDbGenerationRowFound} genStatus=${S.s6aDbGenerationStatus}`,
     )
     S.s6aDatabaseObservable = dbOk ? 'PASS' : 'FAIL'
     return dbOk
@@ -722,9 +727,33 @@ async function attemptS6ARealRun() {
 
   // 2. real external system record (must exist BEFORE the runtime attempts a run; visible via the
   // ordinary external-systems HTTP surface, credentials plaintext only inside this request body).
-  const baseToken = await getDevToken()
-  const registered = await registerExternalSystem(baseToken, systemId)
-  const registeredOk = must('S6-A: external system registered', registered.ok, `http=${registered.status}`)
+  //
+  // RD-E2E finding: this step calls the HTTP API, which needs a server actually listening — this file
+  // previously had NO startServer() call here at all. That was masked for a long time by the
+  // stopServer() bug fixed above (the "existing chain" server from the PREVIOUS phase was leaking and
+  // silently answering these requests instead), so this gap was invisible until that masking bug was
+  // fixed: with stopServer() now actually killing the previous server and confirming the port is free,
+  // this step failed outright with a raw "fetch failed" (nothing listening at all) — see dispatched run
+  // 30833734088. A flag-OFF server is sufficient (registration is unrelated to the S6-A flag), and it
+  // MUST be fully stopped again before step 4's flag-ON restart — two servers cannot hold PORT at once,
+  // and stopServer() now enforces exactly that.
+  let registeredOk = false
+  try {
+    await startServer({}, 'pre-flag-on-registration')
+    try {
+      const baseToken = await getDevToken()
+      const registered = await registerExternalSystem(baseToken, systemId)
+      registeredOk = must('S6-A: external system registered', registered.ok, `http=${registered.status}`)
+    } finally {
+      await stopServer()
+    }
+  } catch (error) {
+    S.s6aExternalSystemRegistered = 'FAIL'
+    S.s6aFlagOnRun = 'NOT_RUN'
+    S.s6aFlagOnReason = 'EXTERNAL_SYSTEM_REGISTRATION_FAILED'
+    must('S6-A: external system registered', false, String(error && error.message || error))
+    return
+  }
   S.s6aExternalSystemRegistered = registeredOk ? 'PASS' : 'FAIL'
   if (!registeredOk) {
     S.s6aFlagOnRun = 'NOT_RUN'
@@ -890,7 +919,7 @@ async function attemptS6ARealRun() {
     // Step 3: the HTTP response saying COMPLETED is not proof anything was written — confirm the
     // generation kernel's own rows exist, over a connection independent of the runtime role that wrote
     // them.
-    const dbOk = await assertS6ARunDatabaseObservable(operationId)
+    const dbOk = await assertS6ARunDatabaseObservable(operationId, relation.rows.length)
     if (!dbOk) {
       S.s6aReplayRun = 'NOT_RUN'
       return
@@ -916,20 +945,32 @@ async function attemptS6ARealRun() {
 export async function main() {
   fs.mkdirSync(OUT_DIR, { recursive: true })
 
-  // Phase 1: flag-OFF arm.
-  await runFlagArm(undefined, false, 'flagOff')
-
-  // Phase 2: exact-match arms — '1' and 'yes' must NOT enable the route.
-  await runFlagArm('1', false, 'exactMatch1')
-  await runFlagArm('yes', false, 'exactMatchYes')
-
-  // Phase 3: existing chain (T4 extended smoke) against a fresh flag-OFF server.
-  await startServer({}, 'existing-chain')
+  // Phases 1-3 run inside their own try/catch for the SAME reason Phase 4 already had one: an unexpected
+  // throw here (including from stopServer()'s own port-free assertion — see the block comment above
+  // startServer()/stopServer()) must not skip the evidence write at the bottom of this function. A red
+  // job with NO summary.txt/checks.json artifact at all is strictly worse than one that at least names
+  // which phase failed and why — `must()` below records it as a failed check so `overallPass` still
+  // reflects it, and CHECKS already accumulated by any phase that DID complete is preserved, not lost.
   try {
-    const token = await getDevToken()
-    await runExistingChain(token)
-  } finally {
-    await stopServer()
+    // Phase 1: flag-OFF arm.
+    await runFlagArm(undefined, false, 'flagOff')
+
+    // Phase 2: exact-match arms — '1' and 'yes' must NOT enable the route.
+    await runFlagArm('1', false, 'exactMatch1')
+    await runFlagArm('yes', false, 'exactMatchYes')
+
+    // Phase 3: existing chain (T4 extended smoke) against a fresh flag-OFF server.
+    await startServer({}, 'existing-chain')
+    try {
+      const token = await getDevToken()
+      await runExistingChain(token)
+    } finally {
+      await stopServer()
+    }
+  } catch (error) {
+    must('phases 1-3 (flag-gate arms + existing chain) completed without an unexpected harness error',
+      false, String(error && error.message || error))
+    await stopServer().catch(() => {})
   }
 
   // Phase 4: S6-A real flag-ON attempt (best-effort; every failure point reports NOT_RUN honestly).
@@ -939,7 +980,11 @@ export async function main() {
     S.s6aFlagOnRun = S.s6aFlagOnRun || 'NOT_RUN'
     S.s6aFlagOnReason = S.s6aFlagOnReason || 'UNEXPECTED_ERROR'
     must('S6-A flag-ON real run attempted', false, String(error && error.message || error))
-    await stopServer()
+    // .catch(), not a bare await: stopServer() can itself throw (its own port-free assertion — see the
+    // block comment above startServer()/stopServer()), and a throw HERE would escape this catch and skip
+    // the evidence write below entirely, which is exactly the failure mode this whole block exists to
+    // avoid.
+    await stopServer().catch(() => {})
   }
 
   // Overall PASS requires every check that ran to have passed — including the S6-A real-run attempt.

--- a/scripts/ops/stock-preparation-e2e-functional-smoke.mjs
+++ b/scripts/ops/stock-preparation-e2e-functional-smoke.mjs
@@ -71,11 +71,11 @@ function delay(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms))
 }
 
-// The S6-A authority chain's requiredFutureInstant (sealed-export-lifecycle-provisioning.cjs) requires
-// SECONDS-precision UTC ISO-8601 (`/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/`) — a plain
+// The S6-A authority chain's requiredFutureInstant (sealed-export-lifecycle-provisioning.cjs:168-180)
+// requires SECONDS-precision UTC ISO-8601 (`/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/`) — a plain
 // `new Date(...).toISOString()` carries a milliseconds component and fails that format check, which
-// surfaces as SEALED_EXPORT_BINDING_UNQUALIFIED with no further detail (confirmed via
-// diagnoseProvisioningFailureStack's error.stack: failSealedExport -> requiredFutureInstant ->
+// surfaces as SEALED_EXPORT_BINDING_UNQUALIFIED with no further detail (root-caused via a temporary
+// error.stack replay of provisionInitial, since removed: failSealedExport -> requiredFutureInstant ->
 // normalizeAuthorityInput -> provisionInitialStockPreparationBinding). This mirrors the SAME
 // seconds-truncation the production code's own toUtcSecondsIso helper performs.
 function toUtcSecondsIso(ms) {
@@ -471,55 +471,7 @@ CREATE TABLE ${MSSQL_TABLE} (
       await dbPool.close()
     }
   })
-  await diagnoseOrderingKeyProbeShape()
   return { rows, projectId: rows[0].projectId, snapshotBatchId: rows[0].snapshotBatchId }
-}
-
-// TEMPORARY bounded diagnostic (job-log only, never in uploaded evidence) for the
-// SEALED_EXPORT_BINDING_UNQUALIFIED root-cause investigation: runs the SAME
-// buildOrderingKeyUniquenessProbeSql SQL text the production capture path (proveOrderingKey in
-// sqlserver-sealed-snapshot-service-core.cjs) runs, as the SAME reader login, and reports the JS typeof of
-// each returned bigint-cast column. normalizeProbeCount(value) in that file only accepts
-// Number.isSafeInteger(value) or a decimal string — if the mssql/tedious driver decodes `CAST(... AS
-// bigint)` as a native JS `bigint` primitive (typeof 'bigint'), normalizeProbeCount returns null for every
-// field and proveOrderingKey's `nullKeyRows === null` branch fails closed with BINDING_UNQUALIFIED
-// regardless of how correct the fixture data is. This function only OBSERVES; it does not change what the
-// production code does.
-async function diagnoseOrderingKeyProbeShape() {
-  const { CERTIFIED_RELATIONS } = require_(
-    'plugins/plugin-integration-core/lib/sealed-export/sqlserver-sealed-snapshot-action.cjs',
-  )
-  const relation = CERTIFIED_RELATIONS['sqlserver.relation.rowid_payload.v1']
-  const probeSql = relation.buildOrderingKeyUniquenessProbeSql(MSSQL_TABLE)
-  const sql = requireFromPlugin('mssql')
-  const pool = new sql.ConnectionPool({
-    server: MSSQL_HOST,
-    port: MSSQL_PORT,
-    user: MSSQL_READER_LOGIN,
-    password: MSSQL_READER_PASSWORD,
-    database: MSSQL_DATABASE,
-    options: { encrypt: true, trustServerCertificate: true },
-    connectionTimeout: 15000,
-  })
-  try {
-    await pool.connect()
-    const result = await pool.request().query(probeSql)
-    const row = result.recordset && result.recordset[0]
-    // Values here are closed-vocabulary counts (0..3), never business data — safe even outside the
-    // job-log-only boundary, but kept there anyway for consistency with the rest of this diagnostic.
-    const shape = row
-      ? Object.keys(row).map((key) => `${key}:${typeof row[key]}=${JSON.stringify(row[key])}`).join(',')
-      : '<no-row>'
-    note('DIAGNOSTIC (job log only): ordering-key probe column JS types+values', shape)
-  } catch (error) {
-    note('DIAGNOSTIC (job log only): ordering-key probe query itself failed', String(error && error.message || error))
-  } finally {
-    try {
-      await pool.close()
-    } catch {
-      // best-effort
-    }
-  }
 }
 
 async function registerExternalSystem(token, systemId) {
@@ -565,79 +517,6 @@ async function runProvisioningScript(env) {
     proc.stderr.on('data', (c) => { stderr += c.toString() })
     proc.on('close', (code) => resolve({ code, stdout, stderr }))
   })
-}
-
-// TEMPORARY bounded diagnostic (job-log only, never in uploaded evidence): the provisioning SCRIPT
-// (plugins/plugin-integration-core/scripts/provision-stock-preparation-sqlserver-sealed-snapshot.cjs)
-// deliberately discards everything except a closed `code` enum on failure (values-free by design — see
-// its own header). To find WHICH of the many failSealedExport('SEALED_EXPORT_BINDING_UNQUALIFIED') call
-// sites in the S5/S6-A authority chain is actually firing, this replays the SAME construction the script
-// performs — same modules, same env — in-process, so `error.stack` (never surfaced by the script itself)
-// is visible here for diagnosis only. Does not change what the production script or its dependencies do.
-async function diagnoseProvisioningFailureStack(provisioningEnv) {
-  // dbBoundary (sealed-export-lifecycle-provisioning.cjs) catches EVERY error from db.transaction() and,
-  // unless it is already a trusted sealed-export error, discards it and throws a fresh
-  // SEALED_EXPORT_INTERNAL_ERROR — the real driver-level exception (e.g. a Postgres permission/relation
-  // error) never reaches error.stack. Patch pg.Client.prototype.query for the lifetime of this ONE
-  // diagnostic call only (restored in `finally`, values-free: only the driver's own error MESSAGE — schema
-  // shape, never row data — is logged, job-log only) to see what it actually was.
-  const pg = requireFromPlugin('pg')
-  let originalQuery
-  try {
-    originalQuery = pg.Client.prototype.query
-    pg.Client.prototype.query = function patchedQuery(...args) {
-      const result = originalQuery.apply(this, args)
-      if (result && typeof result.catch === 'function') {
-        return result.catch((error) => {
-          note('DIAGNOSTIC (job log only): raw pg query error (message only, no row data)',
-            String(error && error.message || error))
-          throw error
-        })
-      }
-      return result
-    }
-  } catch (error) {
-    originalQuery = null
-    note('DIAGNOSTIC (job log only): could not patch pg.Client.prototype.query', String(error && error.message || error))
-  }
-  try {
-    const { loadStockPreparationProvisioningConfig } = require_(
-      'plugins/plugin-integration-core/lib/sealed-export/stock-preparation-runtime-config.cjs',
-    )
-    const { createStockPreparationProvisioningDatabase } = require_(
-      'plugins/plugin-integration-core/lib/sealed-export/stock-preparation-runtime-database.cjs',
-    )
-    const { createStockPreparationRuntimeProvisioning } = require_(
-      'plugins/plugin-integration-core/lib/sealed-export/stock-preparation-runtime-provisioning.cjs',
-    )
-    const mergedEnv = { ...process.env, ...provisioningEnv }
-    const config = loadStockPreparationProvisioningConfig({ env: mergedEnv })
-    const database = createStockPreparationProvisioningDatabase({
-      connectionString: config.provisioningDatabaseUrl,
-      expectedRole: config.provisioningDatabaseRole,
-    })
-    try {
-      const service = createStockPreparationRuntimeProvisioning({
-        artifactRoot: config.artifactRoot,
-        identityKey: config.identityKey,
-        privateSignerMaterial: config.privateSignerMaterial,
-        provisioningDatabase: database,
-        qualificationKeyring: config.qualificationKeyring,
-      })
-      await service.provisionInitial(config.spec)
-      note('DIAGNOSTIC (job log only): in-process provisioning replay unexpectedly SUCCEEDED')
-    } finally {
-      try {
-        await database.close()
-      } catch {
-        // best-effort
-      }
-    }
-  } catch (error) {
-    note('DIAGNOSTIC (job log only): in-process provisioning replay stack', String(error && error.stack || error))
-  } finally {
-    if (originalQuery) pg.Client.prototype.query = originalQuery
-  }
 }
 
 async function attemptS6ARealRun() {
@@ -766,9 +645,19 @@ async function attemptS6ARealRun() {
     provisionedOk = false
   }
   if (!provisionedOk) {
+    // Known finding (root-caused via a temporary error.stack + pg-driver replay, since removed from this
+    // script): if this code is SEALED_EXPORT_INTERNAL_ERROR, the underlying cause — confirmed against a
+    // real Postgres 16 container — is a raw "permission denied for table
+    // integration_sealed_export_signer_public_keys" that migrations/073_create_sealed_export_stock_prep_
+    // runtime_authority.sql's own GRANT statement causes: it grants the provisioning role only
+    // SELECT, INSERT on that table, but provisionInitialStockPreparationBinding
+    // (sealed-export-lifecycle-provisioning.cjs) runs `SELECT ... FOR UPDATE` against it
+    // (trx.selectOneForUpdate, via db.cjs:212) — a locking read that Postgres requires UPDATE privilege
+    // for, independent of whether a row exists to lock. This reproduces for ANY tenant's first S6-A
+    // provisioning attempt under migration 073's grants as written, not just this harness's fixture; it is
+    // a production finding to report, not something this E2E harness can or should paper over.
     note('S6-A: provisioning script failure detail (job log only, not in uploaded evidence)',
       `code=${provisioningFailureCode}`)
-    await diagnoseProvisioningFailureStack(provisioningEnv)
   }
   must('S6-A: provisioning script -> ok:true, externalWrite:false, valuesFree:true', provisionedOk,
     `exit=${provisioned.code}`)

--- a/scripts/ops/stock-preparation-e2e-functional-smoke.mjs
+++ b/scripts/ops/stock-preparation-e2e-functional-smoke.mjs
@@ -408,6 +408,69 @@ async function runFlagArm(flagValue, expectEnabled, label) {
   }
 }
 
+// ── S6-A flag NORMALIZATION arms (finding: no arm discriminated the two implementations) ──────────────
+// stock-preparation-runtime-config.cjs's featureEnabled() is
+// `String(env[FLAG] ?? '').trim().toLowerCase() === 'true'` — it NORMALISES before comparing. The
+// exact-match arms above ('1', 'yes') only prove values that fail BOTH a strict `=== 'true'` AND the
+// real normalising comparison stay disabled — every arm before this one happens to agree on the SAME
+// (disabled) answer, so none of them can tell the two implementations apart. 'TRUE', ' true ' (leading +
+// trailing whitespace), and 'True' all normalise to 'true' under trim+lowercase but would NOT survive a
+// naive strict-equals — only arms built from these three values pin the normalising comparison.
+// Each arm builds its OWN throwaway runtime-construction material (never the SQL Server relation, the
+// external-system record, or the provisioning spec attemptS6ARealRun() below sets up — this only proves
+// the runtime CONSTRUCTS for a given flag string, the same signal S6-A's own health capability boolean
+// already carries, not that a run succeeds) so it can run standalone, before the heavier real-run
+// attempt, using only the runtime-database role/URL the workflow already provisioned.
+async function runFlagNormalizationArm(flagValue, label) {
+  if (!RUNTIME_DB_ROLE || !RUNTIME_DB_URL) {
+    S[`${label}Run`] = 'NOT_RUN'
+    S[`${label}Reason`] = 'RUNTIME_DB_ENV_MISSING'
+    must(`flag normalization arm ${label}: runtime constructed`, false, 'runtime DB env not provided by workflow')
+    return
+  }
+  const keysDir = fs.mkdtempSync(path.join(os.tmpdir(), `s6a-e2e-normkeys-${label}-`))
+  const identityKeyFile = path.join(keysDir, 'identity.key')
+  const evidenceKeyFile = path.join(keysDir, 'evidence.key')
+  const qualificationKeyFile = path.join(keysDir, 'qualification.key')
+  const signerKeyFile = path.join(keysDir, 'signer.pem')
+  fs.writeFileSync(identityKeyFile, crypto.randomBytes(32))
+  fs.writeFileSync(evidenceKeyFile, crypto.randomBytes(32))
+  fs.writeFileSync(qualificationKeyFile, crypto.randomBytes(32))
+  const { privateKey } = crypto.generateKeyPairSync('ed25519')
+  fs.writeFileSync(signerKeyFile, privateKey.export({ type: 'pkcs8', format: 'pem' }))
+  const normArtifactRoot = fs.mkdtempSync(path.join(os.tmpdir(), `s6a-e2e-normroot-${label}-`))
+  const runtimeEnv = {
+    MULTITABLE_STOCK_PREP_SQLSERVER_SEALED_SNAPSHOT_ENABLED: flagValue,
+    MULTITABLE_STOCK_PREP_SQLSERVER_SEALED_SNAPSHOT_ARTIFACT_ROOT: normArtifactRoot,
+    MULTITABLE_STOCK_PREP_SQLSERVER_SEALED_SNAPSHOT_EVIDENCE_KEY_FILE: evidenceKeyFile,
+    MULTITABLE_STOCK_PREP_SQLSERVER_SEALED_SNAPSHOT_IDENTITY_KEY_FILE: identityKeyFile,
+    MULTITABLE_STOCK_PREP_SQLSERVER_SEALED_SNAPSHOT_QUALIFICATION_KEY_FILE: qualificationKeyFile,
+    MULTITABLE_STOCK_PREP_SQLSERVER_SEALED_SNAPSHOT_QUALIFICATION_KEY_ID: `${label}-qual-key-v1`,
+    MULTITABLE_STOCK_PREP_SQLSERVER_SEALED_SNAPSHOT_RUNTIME_DATABASE_ROLE: RUNTIME_DB_ROLE,
+    MULTITABLE_STOCK_PREP_SQLSERVER_SEALED_SNAPSHOT_RUNTIME_DATABASE_URL: RUNTIME_DB_URL,
+    MULTITABLE_STOCK_PREP_SQLSERVER_SEALED_SNAPSHOT_SIGNER_PRIVATE_KEY_FILE: signerKeyFile,
+  }
+  try {
+    await startServer(runtimeEnv, label)
+  } catch (error) {
+    S[`${label}Run`] = 'NOT_RUN'
+    S[`${label}Reason`] = 'RUNTIME_SERVER_START_FAILED'
+    must(`flag normalization arm ${label}: runtime constructed`, false, String(error && error.message || error))
+    return
+  }
+  try {
+    const token = await getDevToken()
+    const health = await requestJson('/api/integration/health', { token })
+    const flagOn = health.body?.capabilities?.stockPreparationSqlServerSealedSnapshot === true
+    S[`${label}HealthFlagOn`] = flagOn
+    must(`flag normalization arm ${label}: string variant normalises to enabled (runtime CONSTRUCTED, not just flag-string-present)`,
+      flagOn, `flagOn=${flagOn}`)
+    S[`${label}Run`] = flagOn ? 'PASS' : 'FAIL'
+  } finally {
+    await stopServer()
+  }
+}
+
 // ── existing chain (T4 extended smoke) ──────────────────────────────────────────────────────────────
 async function runExistingChain(token) {
   const outDir = path.join(OUT_DIR, 'existing-chain')
@@ -896,31 +959,25 @@ async function attemptS6ARealRun() {
 
   // 4. flag-ON restart with the full runtime authority wired.
   //
-  // Temporary diagnostic (same in-process-replay idiom this file's own history already used once —
-  // see the removed error.stack replay noted in the toUtcSecondsIso comment above — captured, then
-  // deleted once the finding lands): `SEALED_EXPORT_BINDING_UNQUALIFIED` is thrown from ~45 call sites
-  // across two files, and this arm's flag-ON server runs in a SEPARATE spawned process, so a monkeypatch
-  // in THIS script's own process cannot see it. A `--require` preload injected into ONLY that spawned
-  // process wraps failSealedExport (patching failure-vocabulary.cjs's export before any other module
-  // requires it, so every downstream destructured reference picks up the wrapped version) and appends a
-  // fresh stack to a file for this reason ONLY — still throws exactly as before, changes no behavior.
-  // Read job-log only (via note()), never written to summary.txt/checks.json.
-  const stackCapturePath = path.join(keysDir, 'binding-unqualified-stacks.txt')
-  const preloadPath = path.join(keysDir, 'capture-binding-unqualified-stack.cjs')
-  fs.writeFileSync(preloadPath, `
-'use strict'
-const fs = require('node:fs')
-const vocab = require(${JSON.stringify(path.join(REPO_ROOT, 'plugins/plugin-integration-core/lib/sealed-export/failure-vocabulary.cjs'))})
-const original = vocab.failSealedExport
-vocab.failSealedExport = function patched(reason, details) {
-  if (reason === 'SEALED_EXPORT_BINDING_UNQUALIFIED') {
-    try {
-      fs.appendFileSync(${JSON.stringify(stackCapturePath)}, new Error('capture').stack + '\\n---\\n')
-    } catch {}
-  }
-  return original(reason, details)
-}
-`)
+  // RD-E2E finding (root-caused via a temporary --require preload that wrapped failSealedExport and
+  // captured a stack for SEALED_EXPORT_BINDING_UNQUALIFIED — since REMOVED; the preload only ever
+  // observed, it never changed behavior, but any green obtained with production modules monkey-patched
+  // is a green under instrumented modules, so it does not belong in the merged harness). The captured
+  // stack pinned the refusal to stock-preparation-sqlserver-source-authority.cjs's normalizeExternalSystem
+  // -> ownedCanonical -> canonicalCodec.tryFreezeCanonical(raw), called with the FULL adapter-shaped
+  // object external-systems.cjs's rowToAdapterExternalSystem returns for a real DB row (id, tenantId,
+  // workspaceId, kind, role, status, config, credentials, PLUS projectId, name, capabilities,
+  // lastTestedAt, lastError, createdAt, updatedAt). createdAt/updatedAt are always non-null JS `Date`
+  // instances (integration_external_systems.created_at/updated_at are `TIMESTAMPTZ NOT NULL DEFAULT
+  // NOW()`, and no `pg` type-parser override exists anywhere in this repo, confirmed by grep), and the
+  // canonical-json codec's domain explicitly refuses Date (`EXOTIC_OBJECT`) — confirmed locally by
+  // feeding canonical-json.cjs the exact adapter shape with and without Date-typed createdAt/updatedAt
+  // (identical otherwise): `ok:false, violation:'EXOTIC_OBJECT'` with them, `ok:true` without. This
+  // reproduces for ANY external-system row created through the ordinary product API, not just this
+  // harness's fixture — no external-system fixture value can change what rowToAdapterExternalSystem
+  // returns, since createdAt/updatedAt are populated by the database itself on every insert. This is a
+  // genuine product defect (a production-file fix is required — out of scope for this harness-only PR,
+  // and this PR does not attempt one), not a fixture defect; see the PR body for the full report.
   const runtimeEnv = {
     MULTITABLE_STOCK_PREP_SQLSERVER_SEALED_SNAPSHOT_ENABLED: 'true',
     MULTITABLE_STOCK_PREP_SQLSERVER_SEALED_SNAPSHOT_ARTIFACT_ROOT: ARTIFACT_ROOT,
@@ -931,7 +988,6 @@ vocab.failSealedExport = function patched(reason, details) {
     MULTITABLE_STOCK_PREP_SQLSERVER_SEALED_SNAPSHOT_RUNTIME_DATABASE_ROLE: RUNTIME_DB_ROLE,
     MULTITABLE_STOCK_PREP_SQLSERVER_SEALED_SNAPSHOT_RUNTIME_DATABASE_URL: RUNTIME_DB_URL,
     MULTITABLE_STOCK_PREP_SQLSERVER_SEALED_SNAPSHOT_SIGNER_PRIVATE_KEY_FILE: signerKeyFile,
-    NODE_OPTIONS: `--require ${preloadPath}`,
   }
   try {
     await startServer(runtimeEnv, 'flag-on')
@@ -1002,16 +1058,14 @@ vocab.failSealedExport = function patched(reason, details) {
       // constraint requires one). This splits which half of the pipeline to look at — the closed
       // `error.code` alone cannot, since many call sites across the codebase share the same token.
       await assertS6ARunDatabaseObservableOnFailure(operationId)
-      // Job-log only (never in the uploaded evidence): the exact call-site stack(s) captured by the
-      // temporary --require preload above, if this failure was SEALED_EXPORT_BINDING_UNQUALIFIED.
-      try {
-        const stacks = fs.readFileSync(stackCapturePath, 'utf8')
-        note('S6-A: BINDING_UNQUALIFIED call-site stack(s) (job log only, not in uploaded evidence)', `\n${stacks}`)
-      } catch {
-        // no capture file — this failure was not BINDING_UNQUALIFIED, or the preload never loaded
-      }
       S.s6aDatabaseObservable = 'NOT_RUN'
       S.s6aReplayRun = 'NOT_RUN'
+      // Finding (review #4724): this early return used to fall straight through to main()'s evidence
+      // write with NO s6aFlagOnRun key at all — absence of a key is not distinguishable from
+      // not-applicable, and this IS the path that actually executes today. Always emit it, on every exit
+      // out of this function, not just the ones above.
+      S.s6aFlagOnRun = 'FAIL'
+      S.s6aFlagOnReason = 'FIRST_RUN_FAILED'
       return
     }
 
@@ -1057,6 +1111,14 @@ export async function main() {
     // Phase 2: exact-match arms — '1' and 'yes' must NOT enable the route.
     await runFlagArm('1', false, 'exactMatch1')
     await runFlagArm('yes', false, 'exactMatchYes')
+
+    // Phase 2b: normalization arms — 'TRUE', ' true ', 'True' MUST enable the route (they normalise to
+    // 'true' under trim+lowercase). Unlike phase 2's arms, these actually distinguish a strict
+    // `=== 'true'` comparison from the real normalising one — see the block comment above
+    // runFlagNormalizationArm().
+    await runFlagNormalizationArm('TRUE', 'normTrueUpper')
+    await runFlagNormalizationArm(' true ', 'normTrueSpaced')
+    await runFlagNormalizationArm('True', 'normTrueTitle')
 
     // Phase 3: existing chain (T4 extended smoke) against a fresh flag-OFF server.
     await startServer({}, 'existing-chain')

--- a/scripts/ops/stock-preparation-e2e-functional-smoke.mjs
+++ b/scripts/ops/stock-preparation-e2e-functional-smoke.mjs
@@ -895,6 +895,32 @@ async function attemptS6ARealRun() {
   }
 
   // 4. flag-ON restart with the full runtime authority wired.
+  //
+  // Temporary diagnostic (same in-process-replay idiom this file's own history already used once —
+  // see the removed error.stack replay noted in the toUtcSecondsIso comment above — captured, then
+  // deleted once the finding lands): `SEALED_EXPORT_BINDING_UNQUALIFIED` is thrown from ~45 call sites
+  // across two files, and this arm's flag-ON server runs in a SEPARATE spawned process, so a monkeypatch
+  // in THIS script's own process cannot see it. A `--require` preload injected into ONLY that spawned
+  // process wraps failSealedExport (patching failure-vocabulary.cjs's export before any other module
+  // requires it, so every downstream destructured reference picks up the wrapped version) and appends a
+  // fresh stack to a file for this reason ONLY — still throws exactly as before, changes no behavior.
+  // Read job-log only (via note()), never written to summary.txt/checks.json.
+  const stackCapturePath = path.join(keysDir, 'binding-unqualified-stacks.txt')
+  const preloadPath = path.join(keysDir, 'capture-binding-unqualified-stack.cjs')
+  fs.writeFileSync(preloadPath, `
+'use strict'
+const fs = require('node:fs')
+const vocab = require(${JSON.stringify(path.join(REPO_ROOT, 'plugins/plugin-integration-core/lib/sealed-export/failure-vocabulary.cjs'))})
+const original = vocab.failSealedExport
+vocab.failSealedExport = function patched(reason, details) {
+  if (reason === 'SEALED_EXPORT_BINDING_UNQUALIFIED') {
+    try {
+      fs.appendFileSync(${JSON.stringify(stackCapturePath)}, new Error('capture').stack + '\\n---\\n')
+    } catch {}
+  }
+  return original(reason, details)
+}
+`)
   const runtimeEnv = {
     MULTITABLE_STOCK_PREP_SQLSERVER_SEALED_SNAPSHOT_ENABLED: 'true',
     MULTITABLE_STOCK_PREP_SQLSERVER_SEALED_SNAPSHOT_ARTIFACT_ROOT: ARTIFACT_ROOT,
@@ -905,6 +931,7 @@ async function attemptS6ARealRun() {
     MULTITABLE_STOCK_PREP_SQLSERVER_SEALED_SNAPSHOT_RUNTIME_DATABASE_ROLE: RUNTIME_DB_ROLE,
     MULTITABLE_STOCK_PREP_SQLSERVER_SEALED_SNAPSHOT_RUNTIME_DATABASE_URL: RUNTIME_DB_URL,
     MULTITABLE_STOCK_PREP_SQLSERVER_SEALED_SNAPSHOT_SIGNER_PRIVATE_KEY_FILE: signerKeyFile,
+    NODE_OPTIONS: `--require ${preloadPath}`,
   }
   try {
     await startServer(runtimeEnv, 'flag-on')
@@ -975,6 +1002,14 @@ async function attemptS6ARealRun() {
       // constraint requires one). This splits which half of the pipeline to look at — the closed
       // `error.code` alone cannot, since many call sites across the codebase share the same token.
       await assertS6ARunDatabaseObservableOnFailure(operationId)
+      // Job-log only (never in the uploaded evidence): the exact call-site stack(s) captured by the
+      // temporary --require preload above, if this failure was SEALED_EXPORT_BINDING_UNQUALIFIED.
+      try {
+        const stacks = fs.readFileSync(stackCapturePath, 'utf8')
+        note('S6-A: BINDING_UNQUALIFIED call-site stack(s) (job log only, not in uploaded evidence)', `\n${stacks}`)
+      } catch {
+        // no capture file — this failure was not BINDING_UNQUALIFIED, or the preload never loaded
+      }
       S.s6aDatabaseObservable = 'NOT_RUN'
       S.s6aReplayRun = 'NOT_RUN'
       return

--- a/scripts/ops/stock-preparation-e2e-functional-smoke.mjs
+++ b/scripts/ops/stock-preparation-e2e-functional-smoke.mjs
@@ -54,7 +54,11 @@ const S = {
   mode: 'functional_testing_synthetic_data',
   substituteForEntityAcceptance: false,
 }
-const CHECKS = []
+// Exported (not just module-private) so other scripts in this lane — specifically
+// stock-preparation-e2e-negative-control.mjs — can derive their own exit code from the SAME array via
+// the SAME `CHECKS.some((c) => !c.ok)` formula main() uses below, instead of hardcoding an exit code that
+// does not actually depend on whether any check failed.
+export const CHECKS = []
 
 export function must(name, ok, detail = '') {
   CHECKS.push({ name, ok: ok === true, detail })
@@ -252,8 +256,11 @@ export async function s6aRunProbe(token, operationId) {
 // flag is off, the route is never mounted at all, so a request to it falls through to the framework's
 // generic unmatched-route 404 (no JSON error envelope, no `error.code`) — it does NOT reach the
 // `STOCK_PREPARATION_SQLSERVER_SEALED_SNAPSHOT_DISABLED` HttpRouteError inside the handler
-// (http-routes.cjs ~4900-4911), because that handler is unreachable code under this wiring: the same
-// truthy/falsy check gates both route registration and the handler's local runtime reference. This is
+// (http-routes.cjs ~4900-4911) IN THIS SPECIFIC ARM, because that branch is unreachable when the flag is
+// off (route registration checks only Boolean(runtime); the DISABLED branch fires on falsy runtime). That
+// branch is NOT unreachable in general, though: it also fires when `typeof runtime.run !== 'function'`,
+// which registration does not check — so a truthy-but-malformed runtime still registers the route AND
+// still hits DISABLED at request time. This arm just never constructs that runtime shape. This is
 // confirmed by the existing unit test plugin-integration-core/__tests__/http-routes.test.cjs
 // `testStockPreparationSqlServerSealedSnapshotInternalRoute`, which asserts
 // `disabled.routes.has('POST ' + routePath) === false` for the flag-off construction. So this arm does

--- a/scripts/ops/stock-preparation-e2e-negative-control.mjs
+++ b/scripts/ops/stock-preparation-e2e-negative-control.mjs
@@ -8,22 +8,30 @@
 // re-implementation — and asserts the WRONG expectation on purpose: that the flag-OFF S6-A route
 // returns 200 instead of the real 404 (the route is not registered at all when the flag is off — see the
 // block comment above runFlagArm() in stock-preparation-e2e-functional-smoke.mjs; it is a generic
-// unmatched-route 404, not the STOCK_PREPARATION_SQLSERVER_SEALED_SNAPSHOT_DISABLED JSON error, which is
-// unreachable dead code under current wiring). Because the route genuinely 404s when the flag is absent,
-// this assertion genuinely fails and the process exits non-zero, so the CI job it runs in genuinely goes
-// RED.
+// unmatched-route 404, not the STOCK_PREPARATION_SQLSERVER_SEALED_SNAPSHOT_DISABLED JSON error. That
+// branch is unreachable when the flag is off — the route is only registered when the runtime is truthy
+// (http-routes.cjs ~5003-5006), while the DISABLED branch fires when it is falsy — but it is NOT
+// unreachable dead code in general: the same branch also fires when `typeof runtime.run !== 'function'`,
+// which route registration does not check, so it stays reachable for a truthy-but-malformed runtime. This
+// arm just never constructs that runtime shape). Because the route genuinely 404s when the flag is
+// absent, this assertion genuinely fails, `must()` genuinely records it as a failed check, and the exit
+// code below is derived from that CHECKS entry — never hardcoded — so the CI job it runs in genuinely
+// goes RED.
 //
 // Purpose: prove the harness's real assertion machinery (the same `must()` used everywhere else in this
-// lane) is load-bearing — a harness that can only ever report PASS proves nothing (repo standing
-// instruction: "a check that did not happen is indistinguishable from a check that came back clean").
-// This script's own RED conclusion is the deliverable, not a bug to fix.
+// lane, AND the same CHECKS-derived exit-code formula the main harness uses) is load-bearing — a harness
+// that can only ever report PASS proves nothing (repo standing instruction: "a check that did not happen
+// is indistinguishable from a check that came back clean"). This script's own RED conclusion is the
+// deliverable, not a bug to fix. Concretely: swap in a neutered `must()` that always records `ok: true`
+// regardless of its `ok` argument, and this script's exit code must flip to 0 — if it does not, the exit
+// code is not actually derived from the assertion and this lane proves nothing.
 //
 // Attribution matters: a RED job here could ALSO mean the harness crashed before reaching the
 // assertion, or (worst case) that the S6-A gate is actually broken and returned 200 for real. Those are
 // bugs, not the deliverable. The `negativeControlRedBecause` field distinguishes them so a RED
 // conclusion is never read as proof-of-concept by itself.
 
-import { getDevToken, must, s6aRunProbe, startServer, stopServer } from './stock-preparation-e2e-functional-smoke.mjs'
+import { CHECKS, getDevToken, must, s6aRunProbe, startServer, stopServer } from './stock-preparation-e2e-functional-smoke.mjs'
 
 async function main() {
   const result = { probeHttp: -1, reachedAssertion: false, redBecause: 'HARNESS_ERROR' }
@@ -51,8 +59,15 @@ async function main() {
   process.stdout.write(`negativeControlReachedAssertion=${result.reachedAssertion}\n`)
   process.stdout.write(`negativeControlRedBecause=${result.redBecause}\n`)
   process.stdout.write('expectedConclusion=RED\n')
-  // Always non-zero: this script exists to prove the job can fail, never to pass.
-  process.exitCode = 1
+  // Derived from CHECKS the SAME way the main harness derives its own exit code
+  // (stock-preparation-e2e-functional-smoke.mjs main(): `anyFail = CHECKS.some((c) => !c.ok)`) — NOT
+  // hardcoded. This is load-bearing, not cosmetic: a neutered `must()` that always records `ok: true`
+  // makes `anyFail` false here too, so the exit code flips to 0. In the intended real run the single
+  // `must()` call above is designed to fail (the flag-OFF route genuinely 404s, so `deliberatelyWrong` is
+  // false), so `anyFail` is expected to be true and this exits non-zero — but that RED conclusion is now
+  // earned by the assertion actually failing, not asserted unconditionally regardless of it.
+  const anyFail = CHECKS.some((c) => !c.ok)
+  process.exitCode = anyFail ? 1 : 0
 }
 
 main().catch(async (error) => {

--- a/scripts/ops/stock-preparation-e2e-negative-control.mjs
+++ b/scripts/ops/stock-preparation-e2e-negative-control.mjs
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+'use strict'
+
+// Stock-preparation E2E functional smoke — NEGATIVE CONTROL.
+//
+// This is deliberately a FAILING run. It reuses the SAME startServer/stopServer/getDevToken/
+// s6aRunProbe/must functions the main harness (stock-preparation-e2e-functional-smoke.mjs) uses — not a
+// re-implementation — and asserts the WRONG expectation on purpose: that the flag-OFF S6-A route
+// returns 200 instead of the real 404 STOCK_PREPARATION_SQLSERVER_SEALED_SNAPSHOT_DISABLED. Because the
+// route genuinely 404s when the flag is absent, this assertion genuinely fails and the process exits
+// non-zero, so the CI job it runs in genuinely goes RED.
+//
+// Purpose: prove the harness's real assertion machinery (the same `must()` used everywhere else in this
+// lane) is load-bearing — a harness that can only ever report PASS proves nothing (repo standing
+// instruction: "a check that did not happen is indistinguishable from a check that came back clean").
+// This script's own RED conclusion is the deliverable, not a bug to fix.
+
+import { getDevToken, must, s6aRunProbe, startServer, stopServer } from './stock-preparation-e2e-functional-smoke.mjs'
+
+async function main() {
+  await startServer({}, 'negative-control')
+  try {
+    const token = await getDevToken()
+    const probe = await s6aRunProbe(token, `negative-control-${Date.now()}`)
+    // INTENTIONALLY WRONG expectation — the route is flag-OFF here, so this MUST be false, and this
+    // script MUST therefore fail. Do not "fix" this by changing the expectation to 404; that would
+    // remove the one deliberately-red arm this lane is required to carry.
+    const deliberatelyWrong = probe.status === 200
+    must('NEGATIVE CONTROL (expected to fail): flag-OFF S6-A route returns 200', deliberatelyWrong,
+      `http=${probe.status} (real behavior is 404 DISABLED; this arm asserts the wrong thing on purpose)`)
+  } finally {
+    await stopServer()
+  }
+  process.stdout.write('STOCK_PREPARATION_E2E_NEGATIVE_CONTROL\nexpectedConclusion=RED\n')
+  // Always non-zero: this script exists to prove the job can fail, never to pass.
+  process.exitCode = 1
+}
+
+main().catch(async (error) => {
+  process.stderr.write(`[negative-control] fatal: ${error && error.stack ? error.stack : error}\n`)
+  await stopServer().catch(() => {})
+  process.exitCode = 1
+})

--- a/scripts/ops/stock-preparation-e2e-negative-control.mjs
+++ b/scripts/ops/stock-preparation-e2e-negative-control.mjs
@@ -14,30 +14,51 @@
 // lane) is load-bearing — a harness that can only ever report PASS proves nothing (repo standing
 // instruction: "a check that did not happen is indistinguishable from a check that came back clean").
 // This script's own RED conclusion is the deliverable, not a bug to fix.
+//
+// Attribution matters: a RED job here could ALSO mean the harness crashed before reaching the
+// assertion, or (worst case) that the S6-A gate is actually broken and returned 200 for real. Those are
+// bugs, not the deliverable. The `negativeControlRedBecause` field distinguishes them so a RED
+// conclusion is never read as proof-of-concept by itself.
 
 import { getDevToken, must, s6aRunProbe, startServer, stopServer } from './stock-preparation-e2e-functional-smoke.mjs'
 
 async function main() {
+  const result = { probeHttp: -1, reachedAssertion: false, redBecause: 'HARNESS_ERROR' }
   await startServer({}, 'negative-control')
   try {
     const token = await getDevToken()
     const probe = await s6aRunProbe(token, `negative-control-${Date.now()}`)
+    result.probeHttp = probe.status
+    result.reachedAssertion = true
     // INTENTIONALLY WRONG expectation — the route is flag-OFF here, so this MUST be false, and this
     // script MUST therefore fail. Do not "fix" this by changing the expectation to 404; that would
     // remove the one deliberately-red arm this lane is required to carry.
     const deliberatelyWrong = probe.status === 200
     must('NEGATIVE CONTROL (expected to fail): flag-OFF S6-A route returns 200', deliberatelyWrong,
       `http=${probe.status} (real behavior is 404 DISABLED; this arm asserts the wrong thing on purpose)`)
+    // If the probe genuinely came back 200, the S6-A gate is broken for real — that is NOT the intended
+    // negative-control signal, it is a live product bug, and must be reported as such, not folded into
+    // "the harness can fail" story.
+    result.redBecause = probe.status === 200 ? 'GATE_BROKEN_PROBE_RETURNED_200' : 'ASSERTION_FAILED_AS_INTENDED'
   } finally {
     await stopServer()
   }
-  process.stdout.write('STOCK_PREPARATION_E2E_NEGATIVE_CONTROL\nexpectedConclusion=RED\n')
+  process.stdout.write('STOCK_PREPARATION_E2E_NEGATIVE_CONTROL\n')
+  process.stdout.write(`negativeControlProbeHttp=${result.probeHttp}\n`)
+  process.stdout.write(`negativeControlReachedAssertion=${result.reachedAssertion}\n`)
+  process.stdout.write(`negativeControlRedBecause=${result.redBecause}\n`)
+  process.stdout.write('expectedConclusion=RED\n')
   // Always non-zero: this script exists to prove the job can fail, never to pass.
   process.exitCode = 1
 }
 
 main().catch(async (error) => {
   process.stderr.write(`[negative-control] fatal: ${error && error.stack ? error.stack : error}\n`)
+  process.stdout.write('STOCK_PREPARATION_E2E_NEGATIVE_CONTROL\n')
+  process.stdout.write('negativeControlProbeHttp=-1\n')
+  process.stdout.write('negativeControlReachedAssertion=false\n')
+  process.stdout.write('negativeControlRedBecause=HARNESS_ERROR\n')
+  process.stdout.write('expectedConclusion=RED\n')
   await stopServer().catch(() => {})
   process.exitCode = 1
 })

--- a/scripts/ops/stock-preparation-e2e-negative-control.mjs
+++ b/scripts/ops/stock-preparation-e2e-negative-control.mjs
@@ -6,9 +6,12 @@
 // This is deliberately a FAILING run. It reuses the SAME startServer/stopServer/getDevToken/
 // s6aRunProbe/must functions the main harness (stock-preparation-e2e-functional-smoke.mjs) uses — not a
 // re-implementation — and asserts the WRONG expectation on purpose: that the flag-OFF S6-A route
-// returns 200 instead of the real 404 STOCK_PREPARATION_SQLSERVER_SEALED_SNAPSHOT_DISABLED. Because the
-// route genuinely 404s when the flag is absent, this assertion genuinely fails and the process exits
-// non-zero, so the CI job it runs in genuinely goes RED.
+// returns 200 instead of the real 404 (the route is not registered at all when the flag is off — see the
+// block comment above runFlagArm() in stock-preparation-e2e-functional-smoke.mjs; it is a generic
+// unmatched-route 404, not the STOCK_PREPARATION_SQLSERVER_SEALED_SNAPSHOT_DISABLED JSON error, which is
+// unreachable dead code under current wiring). Because the route genuinely 404s when the flag is absent,
+// this assertion genuinely fails and the process exits non-zero, so the CI job it runs in genuinely goes
+// RED.
 //
 // Purpose: prove the harness's real assertion machinery (the same `must()` used everywhere else in this
 // lane) is load-bearing — a harness that can only ever report PASS proves nothing (repo standing
@@ -35,7 +38,7 @@ async function main() {
     // remove the one deliberately-red arm this lane is required to carry.
     const deliberatelyWrong = probe.status === 200
     must('NEGATIVE CONTROL (expected to fail): flag-OFF S6-A route returns 200', deliberatelyWrong,
-      `http=${probe.status} (real behavior is 404 DISABLED; this arm asserts the wrong thing on purpose)`)
+      `http=${probe.status} (real behavior is 404, route not registered; this arm asserts the wrong thing on purpose)`)
     // If the probe genuinely came back 200, the S6-A gate is broken for real — that is NOT the intended
     // negative-control signal, it is a live product bug, and must be reported as such, not folded into
     // "the harness can fail" story.

--- a/scripts/ops/stock-preparation-e2e-negative-control.mjs
+++ b/scripts/ops/stock-preparation-e2e-negative-control.mjs
@@ -66,7 +66,18 @@ async function main() {
   // `must()` call above is designed to fail (the flag-OFF route genuinely 404s, so `deliberatelyWrong` is
   // false), so `anyFail` is expected to be true and this exits non-zero — but that RED conclusion is now
   // earned by the assertion actually failing, not asserted unconditionally regardless of it.
-  const anyFail = CHECKS.some((c) => !c.ok)
+  //
+  // Deliberate delta from the main harness's exact formula: `CHECKS.length === 0` also counts as failing
+  // here. The main harness always accumulates many checks, so it never hits that edge; this script makes
+  // exactly one `must()` call, so an empty CHECKS array can ONLY mean the one call above never ran (e.g.
+  // it was deleted) — a check that did not happen is not evidence of PASS, and must not silently exit 0.
+  const anyFail = CHECKS.length === 0 || CHECKS.some((c) => !c.ok)
+  // Values-free observed-outcome fields — the evidence, not the exit code by itself (same discipline as
+  // the main harness's own doctrine that "a non-zero script exit is itself not evidence"). These are what
+  // a neutered `must()` actually flips: CHECKS.length stays 1, but every recorded `ok` becomes `true`, so
+  // `negativeControlObservedConclusion` flips from RED to GREEN and diverges from `expectedConclusion`.
+  process.stdout.write(`negativeControlChecksRecorded=${CHECKS.length}\n`)
+  process.stdout.write(`negativeControlObservedConclusion=${anyFail ? 'RED' : 'GREEN'}\n`)
   process.exitCode = anyFail ? 1 : 0
 }
 
@@ -77,6 +88,13 @@ main().catch(async (error) => {
   process.stdout.write('negativeControlReachedAssertion=false\n')
   process.stdout.write('negativeControlRedBecause=HARNESS_ERROR\n')
   process.stdout.write('expectedConclusion=RED\n')
+  // Crash path, not the CHECKS-derivation path: the harness never reached must(), so CHECKS is whatever
+  // it was at the moment of the throw (likely 0). Reported for the same field-shape consistency as the
+  // normal path, not because a crash is "derived from CHECKS" — it is reported here unconditionally
+  // because a fatal error before any assertion ran is itself a failure, same as the main harness's own
+  // top-level .catch().
+  process.stdout.write(`negativeControlChecksRecorded=${CHECKS.length}\n`)
+  process.stdout.write('negativeControlObservedConclusion=RED\n')
   await stopServer().catch(() => {})
   process.exitCode = 1
 })

--- a/scripts/ops/stock-preparation-e2e-provision-postgres-roles-and-migrate.mjs
+++ b/scripts/ops/stock-preparation-e2e-provision-postgres-roles-and-migrate.mjs
@@ -43,6 +43,13 @@ function quotedIdentifier(value) {
   return `"${value.replaceAll('"', '""')}"`
 }
 
+// CREATE ROLE is a utility (DDL) statement — PostgreSQL's grammar does not accept a $n bind parameter
+// in the PASSWORD clause of a utility statement (only DML goes through the parameterized executor
+// path), so the password must be inlined as a quoted SQL string literal.
+function quotedLiteral(value) {
+  return `'${value.replaceAll("'", "''")}'`
+}
+
 async function main() {
   const superuserUrl = requiredEnv('PG_SUPERUSER_URL')
   const runtimeRole = requiredEnv('RUNTIME_ROLE')
@@ -55,12 +62,10 @@ async function main() {
     const client = await pool.connect()
     try {
       await client.query(
-        `CREATE ROLE ${quotedIdentifier(runtimeRole)} LOGIN NOSUPERUSER NOCREATEDB NOCREATEROLE NOREPLICATION NOBYPASSRLS NOINHERIT PASSWORD $1`,
-        [runtimePassword],
+        `CREATE ROLE ${quotedIdentifier(runtimeRole)} LOGIN NOSUPERUSER NOCREATEDB NOCREATEROLE NOREPLICATION NOBYPASSRLS NOINHERIT PASSWORD ${quotedLiteral(runtimePassword)}`,
       )
       await client.query(
-        `CREATE ROLE ${quotedIdentifier(provisioningRole)} LOGIN NOSUPERUSER NOCREATEDB NOCREATEROLE NOREPLICATION NOBYPASSRLS NOINHERIT PASSWORD $1`,
-        [provisioningPassword],
+        `CREATE ROLE ${quotedIdentifier(provisioningRole)} LOGIN NOSUPERUSER NOCREATEDB NOCREATEROLE NOREPLICATION NOBYPASSRLS NOINHERIT PASSWORD ${quotedLiteral(provisioningPassword)}`,
       )
     } finally {
       client.release()

--- a/scripts/ops/stock-preparation-e2e-provision-postgres-roles-and-migrate.mjs
+++ b/scripts/ops/stock-preparation-e2e-provision-postgres-roles-and-migrate.mjs
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+'use strict'
+
+// Stock-preparation E2E functional smoke — Postgres role setup + migration runner.
+//
+// The sealed-export S6-A migration (073_create_sealed_export_stock_prep_runtime_authority.sql) grants
+// its runtime/provisioning privilege matrix ONLY if the two `metasheet.sealed_export_*_role` settings
+// are visible to the connection that FIRST applies that migration — see
+// docs/operations/stock-preparation-s6a-sqlserver-onprem-runbook-20260731.md §2. In an ephemeral CI
+// Postgres this script:
+//   1. creates the two login roles (NOSUPERUSER/NOCREATEDB/NOCREATEROLE/NOREPLICATION/NOBYPASSRLS/
+//      NOINHERIT, neither a member of the other, neither equal to the migration owner);
+//   2. runs the ordinary core-backend migration entry point against a connection string carrying both
+//      role names via the standard libpq `options` query parameter (`-c name=value`), so every
+//      migration — including 073 — sees them from the very first connection.
+//
+// Env in: PG_SUPERUSER_URL, RUNTIME_ROLE, RUNTIME_PASSWORD, PROVISIONING_ROLE, PROVISIONING_PASSWORD.
+// Never logs a password or a full connection string.
+
+import { spawn } from 'node:child_process'
+import { createRequire } from 'node:module'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const REPO_ROOT = path.resolve(__dirname, '..', '..')
+// pnpm's strict node_modules means `pg` (a core-backend dependency) is not resolvable from a plain
+// repo-root `import` — resolve it the same way the T4/S2/S5 harnesses resolve their own scoped deps.
+const requireFromCoreBackend = createRequire(
+  path.join(REPO_ROOT, 'packages/core-backend/package.json'),
+)
+const pg = requireFromCoreBackend('pg')
+
+function requiredEnv(name) {
+  const value = process.env[name]
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new Error(`${name} is required`)
+  }
+  return value
+}
+
+function quotedIdentifier(value) {
+  return `"${value.replaceAll('"', '""')}"`
+}
+
+async function main() {
+  const superuserUrl = requiredEnv('PG_SUPERUSER_URL')
+  const runtimeRole = requiredEnv('RUNTIME_ROLE')
+  const runtimePassword = requiredEnv('RUNTIME_PASSWORD')
+  const provisioningRole = requiredEnv('PROVISIONING_ROLE')
+  const provisioningPassword = requiredEnv('PROVISIONING_PASSWORD')
+
+  const pool = new pg.Pool({ connectionString: superuserUrl, max: 1 })
+  try {
+    const client = await pool.connect()
+    try {
+      await client.query(
+        `CREATE ROLE ${quotedIdentifier(runtimeRole)} LOGIN NOSUPERUSER NOCREATEDB NOCREATEROLE NOREPLICATION NOBYPASSRLS NOINHERIT PASSWORD $1`,
+        [runtimePassword],
+      )
+      await client.query(
+        `CREATE ROLE ${quotedIdentifier(provisioningRole)} LOGIN NOSUPERUSER NOCREATEDB NOCREATEROLE NOREPLICATION NOBYPASSRLS NOINHERIT PASSWORD $1`,
+        [provisioningPassword],
+      )
+    } finally {
+      client.release()
+    }
+  } finally {
+    await pool.end()
+  }
+  process.stderr.write('[e2e-provision] sealed-export authority roles created\n')
+
+  const options = `-c metasheet.sealed_export_runtime_role=${runtimeRole} -c metasheet.sealed_export_provisioning_role=${provisioningRole}`
+  const migrateUrl = new URL(superuserUrl)
+  migrateUrl.searchParams.set('options', options)
+
+  const exitCode = await new Promise((resolve) => {
+    const proc = spawn('pnpm', ['--filter', '@metasheet/core-backend', 'run', 'migrate'], {
+      cwd: REPO_ROOT,
+      env: { ...process.env, DATABASE_URL: migrateUrl.toString() },
+      stdio: 'inherit',
+    })
+    proc.on('close', (code) => resolve(code))
+  })
+  if (exitCode !== 0) {
+    throw new Error(`migration run exited ${exitCode}`)
+  }
+  process.stderr.write('[e2e-provision] migrations applied with sealed-export roles visible\n')
+}
+
+main().catch((error) => {
+  process.stderr.write(`[e2e-provision] fatal: ${error && error.message ? error.message : error}\n`)
+  process.exitCode = 1
+})


### PR DESCRIPTION
## Summary

Adds a `workflow_dispatch`-only CI lane (`.github/workflows/stock-preparation-e2e-functional-smoke.yml`) that stands up **real Postgres + SQL Server service containers** and functionally tests the stock-preparation feature **without an entity machine, without customer data, and without touching any production default**.

**This is functional testing on synthetic data only.** It is NOT the #4695 controlled acceptance (one real customer, the entity machine, an S6-B owner-gated single flag-on window — see `docs/operations/stock-preparation-s6a-sqlserver-onprem-runbook-20260731.md`) and does not substitute for it: no real-customer, scale, external-write, or rollout claim is established here.

### ⚠️ R2b update (2026-08-03) — retraction of the migration-073 claim + the actual current blocker

**Retraction, stated plainly first:** the "Two findings" section below (and the evidence block that
followed it, from dispatch run 30822049245) said `s6aProvisioning=FAIL`, `s6aFlagOnReason=PROVISIONING_FAILED`,
and described migration 073's under-scoped grant as reproducing "for any tenant's first S6-A provisioning
attempt" as a **live** blocker. **That is no longer true and should not be read as describing current
`main` or this branch.** Migration `074_...` (merged to `main` at `59579d5e6`, PR #4728) repairs exactly the
grant migration 073 left short. `grep -rn 074` against this PR's own diff returns 0 hits — 074 lives
upstream on `main`, not in this PR — and a fresh dispatch confirms `s6aProvisioning=PASS` now that this
branch is based on top of it. The FAIL/PROVISIONING_FAILED text below is a superseded, point-in-time
artifact kept only because deleting history is worse than labeling it stale; treat it as historical, not
current.

**What actually happens now that 074 has landed:** provisioning passes, and the S6-A flag-ON server
genuinely **CONSTRUCTS** the runtime (`s6aHealthFlagOn=PASS` — the internal route no longer 404s). The
walk gets substantially further than the old evidence block shows: it opens a run and writes a database
row before refusing. The new, real blocker is a refusal at the **first capture attempt**:
`s6aFirstRunErrorCode=SEALED_EXPORT_BINDING_UNQUALIFIED`, with a `CAPTURE_FAILED` row persisted
(`s6aDbRunStatusOnFailure=CAPTURE_FAILED`).

**Root cause (confirmed against the real code and reproduced locally, not guessed):**
`stock-preparation-sqlserver-source-authority.cjs`'s `normalizeExternalSystem()` (line 167) calls
`ownedCanonical(raw)` — i.e. `canonicalCodec.tryFreezeCanonical(value)` — on the **entire** external-system
object the runtime resolves at request time via `externalSystemRegistry.getExternalSystemForAdapter()`
(`stock-preparation-runtime-core.cjs:237`, `loadSource`). That adapter-shaped object
(`external-systems.cjs`'s `rowToAdapterExternalSystem`) always carries two members that break
canonicalization: **`createdAt` and `updatedAt`, both native JS `Date` instances** — because
`integration_external_systems.created_at`/`updated_at` are `TIMESTAMPTZ NOT NULL DEFAULT NOW()` (confirmed
in `packages/core-backend/migrations/057_create_integration_core_tables.sql`), no `pg` type-parser override
exists anywhere in this repo (grepped for `setTypeParser` repo-wide — zero hits), and
`rowToAdapterExternalSystem` copies the row's timestamps straight through with no serialization step.
`canonical-json.cjs`'s domain explicitly refuses `Date` (violation token `EXOTIC_OBJECT`) — confirmed by
feeding `canonicalCodec.tryFreezeCanonical()` the exact adapter shape twice, identical except for the two
`Date` members: `{ ok: false, violation: 'EXOTIC_OBJECT' }` with them present, `{ ok: true }` without them.
The existing unit test `sealed-export-s6a-source-authority.test.cjs` never caught this because its own
`externalSystem()` fixture hand-builds `createdAt`/`updatedAt` as **ISO strings**, not the `Date` objects
the real registry actually returns — that fixture was never exercised against a real DB round-trip.

**This is a genuine product defect, not a fixture-fixable one — confirmed, not assumed, before writing
this.** Two checks rule out a narrower explanation: (1) `plugin-integration-core/index.cjs` (~L236, ~L345)
constructs `externalSystemRegistry` exactly once and passes the SAME instance, unmodified, to both the HTTP
routes and `createStockPreparationSqlServerRuntime` — there is no narrowing wrapper anywhere on this path;
(2) the only existing unit-test stubs of `getExternalSystemForAdapter` in this plugin either omit
`createdAt`/`updatedAt` entirely or hand-supply them as strings — none exercises the real row shape. No
value this harness's external-system fixture supplies can change what `rowToAdapterExternalSystem` returns:
`created_at`/`updated_at` are populated by the database itself on every insert, are never null, and are
always `Date`-typed on read, for any external-system row created through the ordinary product API — real
customer data included. Fixing this needs a **production-file** change (e.g. projecting the external-system
value down to a canonical-safe shape before `ownedCanonical()`, either in `loadSource()` or inside
`normalizeExternalSystem()` itself) — genuinely required, and explicitly out of scope for this harness-only
PR. This PR does **not** attempt that fix; it reports the finding for owner triage instead.

**Findings cleared in this update (PR review, same PR):**
- The diagnostic `--require` preload used to root-cause the above (a stack-capturing monkey-patch of
  `failSealedExport`, observe-only, never changed behavior) has been **removed**. The evidence below was
  captured **without** it.
- `attemptS6ARealRun()`'s `if (!firstOk)` early-return path — the path that actually executes today — now
  always sets `S.s6aFlagOnRun` (`NOT_RUN`, the phase roll-up's own vocabulary — the per-step verdict that
  it genuinely ran and failed lives in `S.s6aFirstRun`) and `S.s6aFlagOnReason` (`FIRST_RUN_FAILED`) before
  returning. It previously fell through to the evidence write with that key entirely absent. The sibling
  `if (!dbOk)` early return had the same gap and was fixed the same way.
- Three flag-**normalization** arms were added (`'TRUE'`, `' true '`, `'True'`, all of which must ENABLE the
  route). The existing exact-match arms (`'1'`, `'yes'`) only prove values that fail **both** a naive strict
  `=== 'true'` comparison and the real `.trim().toLowerCase() === 'true'` comparison stay disabled — they
  cannot tell the two implementations apart, since every arm before this one happens to agree on the same
  (disabled) answer. These three values normalise to `'true'` under trim+lowercase but would not survive a
  naive strict-equals, so they are what actually pins the normalising comparison. Each arm constructs its
  own throwaway runtime material (no SQL Server/external-system/provisioning fixture) and asserts the health
  capability boolean reads `true` — the runtime genuinely constructed, not merely that the string was
  accepted.

Zero production files touched by this update — all four fixes are confined to
`scripts/ops/stock-preparation-e2e-functional-smoke.mjs`.

**Current values-free result block** (verbatim, dispatch run [30840756972](https://github.com/zensgit/metasheet2/actions/runs/30840756972), job `containerized functional smoke`, head `bbff82e614a29dd394a5d98222a3855bba50d7b1` — captured WITHOUT the removed diagnostic preload; supersedes the block further down this PR body, which is kept only as superseded history):

```
STOCK_PREPARATION_E2E_FUNCTIONAL_SMOKE
mode=functional_testing_synthetic_data
substituteForEntityAcceptance=false
flagOffHealthFlagOn=false
flagOffSiblingRouteHttp=200
flagOffHttp=404
flagOffCode=<none>
flagOffPass=PASS
exactMatch1HealthFlagOn=false
exactMatch1SiblingRouteHttp=200
exactMatch1Http=404
exactMatch1Code=<none>
exactMatch1Pass=PASS
exactMatchYesHealthFlagOn=false
exactMatchYesSiblingRouteHttp=200
exactMatchYesHttp=404
exactMatchYesCode=<none>
exactMatchYesPass=PASS
normTrueUpperHealthFlagOn=true
normTrueUpperPass=PASS
normTrueSpacedHealthFlagOn=true
normTrueSpacedPass=PASS
normTrueTitleHealthFlagOn=true
normTrueTitlePass=PASS
existingChainScriptExit=0
existingChainAuditActionsCovered=8/8
existingChainExternalWrite=false
existingChainLeakScanClean=true
existingChainPass=PASS
s6aExternalSystemHasCredentials=true
s6aExternalSystemRegistered=PASS
s6aProvisioningChanged=true
s6aProvisioning=PASS
s6aHealthFlagOn=PASS
s6aFirstRunHttp=422
s6aFirstRunMode=<unregistered>
s6aFirstRunStatus=<unregistered>
s6aBusinessLineCount=-1
s6aFirstRunExternalWrite=<unregistered>
s6aFirstRunErrorCode=SEALED_EXPORT_BINDING_UNQUALIFIED
s6aFirstRun=FAIL
s6aDbRunRowFoundOnFailure=true
s6aDbRunStatusOnFailure=CAPTURE_FAILED
s6aDbRunFailureReason=SEALED_EXPORT_BINDING_UNQUALIFIED
s6aDatabaseObservable=NOT_RUN
s6aReplayRun=NOT_RUN
s6aFlagOnRun=NOT_RUN
s6aFlagOnReason=FIRST_RUN_FAILED
overallPass=FAIL
```

Read together with the negative control from the SAME dispatch run (job `negative control`):

```
STOCK_PREPARATION_E2E_NEGATIVE_CONTROL
negativeControlProbeHttp=404
negativeControlReachedAssertion=true
negativeControlRedBecause=ASSERTION_FAILED_AS_INTENDED
expectedConclusion=RED
negativeControlChecksRecorded=1
negativeControlObservedConclusion=RED
```

Read this block as: **three blockers now cleared** (`PROVISIONING_FAILED` → `RUNTIME_NOT_CONSTRUCTED` →
now past both — the runtime genuinely constructs and a run genuinely opens and writes a database row), **one
blocker remains** (`SEALED_EXPORT_BINDING_UNQUALIFIED` at first capture, root-caused above as a product
defect this PR does not patch). `existingChainPass=PASS` — the 21-route chain is not regressed by any of
this. `s6aFlagOnRun=NOT_RUN` is the phase roll-up (the walk did not establish its claim); the per-step
verdict that it genuinely ran and was genuinely refused is `s6aFirstRun=FAIL` +
`s6aFirstRunErrorCode=SEALED_EXPORT_BINDING_UNQUALIFIED`. `s6aDatabaseObservable=NOT_RUN` and
`s6aReplayRun=NOT_RUN` are honest, and there is a caveat worth stating plainly rather than implying
"ready and waiting": the database-observable success-path assertion and the idempotent-replay arm this
task asked for (`assertS6ARunDatabaseObservable`, and the replay probe in `attemptS6ARealRun`) are wired
into the script but have **never once executed** — they carry no evidence of their own correctness, and
must be re-verified (not just trusted) once the `createdAt`/`updatedAt` defect is fixed and capture can
actually succeed. `overallPass=FAIL` is expected and by design (same doctrine as the earlier evidence
block): a real blocker stayed a real blocker across this update, honestly reported as `NOT_RUN`/`FAIL`
on the fields that own that meaning, not laundered into a partial `PASS`.

### Feature surface: 32 routes + 1 internal route

`http-routes.cjs` exposes 32 routes under `/api/integration/stock-preparation/...` plus the flag-gated `POST /api/integration/internal/stock-preparation/sqlserver-sealed-snapshot/run`.

**Exercised by this lane (22/33):** the existing T4 chain (`scripts/ops/stock-preparation-prep-line-extended-smoke.mjs`) drives 21 of the 32 —
`mvp/readiness`, `mvp/ensure`, `mvp/options/sync`, `mvp/sync/plan`, `mvp/sync/persist`, `mvp/source-runs/plm-bom`, `mvp/erp-materials/sync`, `projects`, `material-mappings/candidates`, `unit-conversions/candidates`, `material-mappings/candidates/sync`, `material-mappings/confirm`, `material-mappings/retire`, `unit-conversions/confirm`, `unit-conversions/retire`, `generation/run`, `exceptions/resolve`, `exceptions/bulk-resolve`, `exceptions`, `prep-lines`, `audit` — reproducing its documented `auditActionsCovered=8/8`, `externalWrite=false`. The internal S6-A route is separately exercised for its **gate** behavior (3 arms, all real HTTP POSTs, all real 404s).

**NOT exercised (11/32, honest gap — not a claim of completeness):**
- `GET target/readiness`, `POST target/ensure`
- `GET sandbox-target/readiness`, `POST sandbox-target/ensure`
- `POST options/sync` (top-level; only the `mvp/options/sync` alias is exercised)
- `POST mvp/source-runs/erp-materials` (only the `plm-bom` source-run variant is exercised)
- `GET snapshot-batches`, `GET snapshot-batches/:id/diff`, `GET snapshot-batches/:id/diff/rows` — **these ARE covered by the separate W6 postdeploy smoke** (`stock-preparation-mvp-postdeploy-smoke.mjs`), which this lane does not drive; T4 only imports pure helper functions from that module, not its route-calling `main()`
- `GET material-mappings/summary`
- `GET unit-conversions/summary`

This list was derived mechanically (grepping the `${API}/...` call sites in the T4 script and diffing against the `ROUTES` table in `http-routes.cjs`), not eyeballed off a CI log.

### What it drives

1. **Existing chain** — T4 run against a locally-booted core-backend server, reproducing 8/8 audit coverage over real HTTP.
2. **S6-A flag-OFF arm** — real HTTP call to the sealed-snapshot run route with the flag absent. Asserts a **conjunction**, not a bare 404: the `/api/integration/health` capability boolean reads `false`, a sibling **always-registered** route (`mvp/readiness`) answers `200` in the same server process (proving the server/auth/prefix are alive), and the S6-A path itself 404s. (See "S6-A DISABLED code" finding below for why the bare error-code assertion the original plan called for cannot be made truthfully.)
3. **S6-A exact-match arm** — `'1'` and `'yes'` must NOT enable the route (only `'true'`, after trim/lowercase, does) — same three-part conjunction.
4. **S6-A flag-ON real run** — provisions a first-party ephemeral SQL Server relation + external-system record + the two sealed-export Postgres authority roles, then attempts capture → private ingestion → generation kernel → apply. Provisioning now passes and the runtime genuinely constructs (see the R2b update above); the walk **still does not complete** — it is refused at first capture with `SEALED_EXPORT_BINDING_UNQUALIFIED`, a confirmed product defect this PR reports but does not patch. `s6aFlagOnRun=NOT_RUN` (the roll-up key; the per-step verdict `s6aFirstRun=FAIL` is what records that an HTTP call was genuinely made and genuinely refused), never falsely `PASS`.
5. **Negative control** (separate job) — reuses the SAME assertion machinery (`must()`, `startServer`, `s6aRunProbe`) with a deliberately wrong expectation, genuinely reddening (`negativeControlRedBecause=ASSERTION_FAILED_AS_INTENDED`).

### Update — the negative control was not actually load-bearing (now fixed)

A review found that `stock-preparation-e2e-negative-control.mjs`'s `process.exitCode = 1` was **unconditional** — it never read `CHECKS`/`anyFail`, and `must()` itself contains zero throws (it only pushes to `CHECKS` and returns a boolean). Proof: running the negative control with the real `must()` and with a fully neutered `must()` (always records `ok: true`) produced **byte-identical output**, including `negativeControlRedBecause=ASSERTION_FAILED_AS_INTENDED` and `exitCode=1`. The script's own stated purpose — "prove the harness's real assertion machinery is load-bearing" — was not achieved: this arm's RED conclusion never actually depended on the assertion failing. This mattered more once the main harness's `functional-smoke` job goes green (its RED currently rests entirely on the migration-073 grant failure below): once that's fixed, this lane would retain **no genuine can-fail demonstration**.

**Fixed**: `CHECKS` is now exported from the main harness (`stock-preparation-e2e-functional-smoke.mjs`), and the negative control derives its exit code the same way `main()` does — `anyFail = CHECKS.some((c) => !c.ok)` (plus a disclosed, deliberate delta: an empty `CHECKS` array also counts as failing, since this script makes exactly one `must()` call and an empty array can only mean that call never ran). Two new values-free fields, `negativeControlChecksRecorded` (count) and `negativeControlObservedConclusion` (`RED`/`GREEN`), are now printed alongside `expectedConclusion` so the evidence block itself — not just the process exit status — discriminates a real failure from a decorative one.

**Re-proved the same way**: copied the negative-control script verbatim into a proof harness that re-exports the real, committed `must`/`CHECKS` and stubs only the four infra functions (`s6aRunProbe` fixed at `404`, reproducing the exact flag-OFF scenario). Three arms:
- **Arm A (real `must()`)** → `exitCode=1`, `negativeControlChecksRecorded=1`, `negativeControlObservedConclusion=RED`.
- **Arm B (`must()` mutated in place to force `ok: true`)** → `exitCode=0`, `negativeControlChecksRecorded=1`, `negativeControlObservedConclusion=GREEN`; `probeHttp`/`redBecause`/`expectedConclusion` unchanged from Arm A (they describe the scenario, not the assertion verdict). Mutation reverted; `git diff` on the mutated file is empty.
- **Arm C (the one `must()` call deleted entirely, in the proof copy only)** → `exitCode=1`, `negativeControlChecksRecorded=0`, `negativeControlObservedConclusion=RED` — closes the disclosed `CHECKS.length === 0` fail-closed delta with its own mutation, rather than leaving it an untested assertion.

Arm A independently reproduced end-to-end in CI: dispatch run [30822049245](https://github.com/zensgit/metasheet2/actions/runs/30822049245), job `negative control` — `negativeControlChecksRecorded=1`, `negativeControlObservedConclusion=RED`, step concludes "Process completed with exit code 1." Real vs. neutered now genuinely differ, where before they did not.

### Two findings against the task brief's stated "verified facts"

**1. The S6-A route's DISABLED error code is unreachable when the flag is off — it is not unreachable dead code in general.** `registerIntegrationRoutes` (`http-routes.cjs` ~5003-5006) only adds the S6-A route to the Express app when `services.stockPreparationSqlServerRuntime` is truthy at plugin-construction time — i.e. only when the flag was already `'true'` at boot. When the flag is off, the route is never mounted, so a request to it falls through to the framework's generic unmatched-route 404 (no JSON envelope, no `error.code`) — it never reaches the `STOCK_PREPARATION_SQLSERVER_SEALED_SNAPSHOT_DISABLED` `HttpRouteError` inside the handler **in this specific arm**, because route registration checks only `Boolean(runtime)` while the DISABLED branch fires when the runtime is falsy. That branch is **not** unreachable in general, though: it also fires when `typeof runtime.run !== 'function'`, which route registration does not check — so a truthy-but-malformed runtime still gets its route registered AND still hits DISABLED at request time. This lane just never constructs that runtime shape, so it correctly never asserts the specific error code here. Confirmed by the existing unit test `testStockPreparationSqlServerSealedSnapshotInternalRoute` (`http-routes.test.cjs`), which asserts `disabled.routes.has('POST ' + routePath) === false` for the flag-off construction, and by this lane's own CI runs (`code=<none>` on all three flag-off/exact-match arms). The flag-OFF/exact-match arms were rewritten to assert the three-part conjunction above instead of a code that cannot fire in this arm.

**2. [RESOLVED by #4728/migration 074 — kept for history, see the R2b update above] Migration 073's provisioning-role grant was under-scoped for the initial-provisioning path it exists to serve.** `migrations/073_create_sealed_export_stock_prep_runtime_authority.sql` granted the provisioning role only `SELECT, INSERT` on `integration_sealed_export_signer_public_keys`, but `provisionInitialStockPreparationBinding` (`sealed-export-lifecycle-provisioning.cjs`) runs `trx.selectOneForUpdate(PUBLIC_KEY_TABLE, ...)` against it (`db.cjs:212`, `SELECT ... FOR UPDATE`) — a locking read that PostgreSQL requires `UPDATE` privilege for, independent of whether a conflicting row exists to lock. Confirmed against a real Postgres 16 service container: the raw driver error was `permission denied for table integration_sealed_export_signer_public_keys`, surfacing through the production failure contract only as the closed-vocabulary `SEALED_EXPORT_INTERNAL_ERROR`. This reproduced for any tenant's first S6-A provisioning attempt under migration 073's grants as written — it was not specific to this harness's fixture. **Migration `074_...` (merged to `main` at `59579d5e6`, PR #4728) has since repaired this grant; `s6aProvisioning=PASS` in the current evidence block confirms it.**

Two other, narrower fixture bugs were found and fixed along the way (both fully in this harness's own code, not production): the SQL Server fixture database needs `ALTER DATABASE ... SET ALLOW_SNAPSHOT_ISOLATION ON` (the capture path's own snapshot-capability proof requires it, off by default on a fresh `CREATE DATABASE`), and the provisioning spec's `bindingExpiresAt`/`signerExpiresAt` need seconds-precision ISO-8601 (`sealed-export-lifecycle-provisioning.cjs`'s `requiredFutureInstant` rejects the milliseconds a plain `.toISOString()` produces).

### Consequence for the S6-A flag-ON positive control [SUPERSEDED — see the R2b update above]

*(As of the original evidence block below, before 074 landed:)* Because provisioning never completed, the flag-ON HTTP walk (capture → private ingestion → generation kernel → apply, plus the idempotent replay) never ran. *(Current status, R2b:)* provisioning now passes and the runtime genuinely constructs — the missing half of the 404 control **is now established** (`s6aHealthFlagOn=PASS`: the route answers non-404 when the runtime is genuinely constructed). What remains missing is the **capture-success** control: the walk is refused at first capture (`SEALED_EXPORT_BINDING_UNQUALIFIED`, root-caused in the R2b update above as a product defect), so `s6aDatabaseObservable` and `s6aReplayRun` stay `NOT_RUN` — there is nothing to observe or replay until that refusal is fixed in a production file, which this PR does not do.

### Original values-free result block [SUPERSEDED — see "Current values-free result block" in the R2b update above] (verbatim, dispatch run [30822049245](https://github.com/zensgit/metasheet2/actions/runs/30822049245) — confirmed field-for-field against that run's job logs, not carried over unchecked from an earlier dispatch)

```
STOCK_PREPARATION_E2E_FUNCTIONAL_SMOKE
mode=functional_testing_synthetic_data
substituteForEntityAcceptance=false
flagOffHealthFlagOn=false
flagOffSiblingRouteHttp=200
flagOffHttp=404
flagOffCode=<none>
flagOffPass=PASS
exactMatch1HealthFlagOn=false
exactMatch1SiblingRouteHttp=200
exactMatch1Http=404
exactMatch1Code=<none>
exactMatch1Pass=PASS
exactMatchYesHealthFlagOn=false
exactMatchYesSiblingRouteHttp=200
exactMatchYesHttp=404
exactMatchYesCode=<none>
exactMatchYesPass=PASS
existingChainScriptExit=0
existingChainAuditActionsCovered=8/8
existingChainExternalWrite=false
existingChainLeakScanClean=true
existingChainPass=PASS
s6aExternalSystemRegistered=PASS
s6aProvisioningChanged=<unregistered>
s6aProvisioning=FAIL
s6aFlagOnRun=NOT_RUN
s6aFlagOnReason=PROVISIONING_FAILED
overallPass=FAIL
```

```
STOCK_PREPARATION_E2E_NEGATIVE_CONTROL
negativeControlProbeHttp=404
negativeControlReachedAssertion=true
negativeControlRedBecause=ASSERTION_FAILED_AS_INTENDED
expectedConclusion=RED
negativeControlChecksRecorded=1
negativeControlObservedConclusion=RED
```

(the last two fields are new — see "Update — the negative control was not actually load-bearing" above)

`overallPass=FAIL` is **expected and by design** (documented in the script): the job's own conclusion never reports green while a real-run attempt is incomplete, even though 3 of the 4 control arms plus the existing chain are fully green. A RED `containerized functional smoke` job here means "one arm honestly could not complete," not "the harness is broken" — the values-free block above is what actually carries the evidence either way.

### Explicitly out of scope / not done

- Does not deploy, arm, or touch the deployed entity host.
- Does not touch `#4695`'s frozen inputs or the S6-B owner-gated acceptance process.
- Does not change any production flag default — `MULTITABLE_STOCK_PREP_SQLSERVER_SEALED_SNAPSHOT_ENABLED` is set only inside this job's own spawned server-process environment.
- Does not touch branch protection or the `integration-guard` required check (verified still present in `required_status_checks.contexts`).
- Migration 073's grant scoping is fixed on `main` (migration 074, PR #4728) — no action needed here.
- The S6-A flag-ON positive control (route returns non-404 with the runtime actually constructed) **is now established** (`s6aHealthFlagOn=PASS`).
- Does **not** fix the `createdAt`/`updatedAt` canonicalization defect (R2b update above) — a production-file change, genuinely required, out of scope for this harness-only PR. Reported for owner triage, not patched here.
- Does not add a `pg` type-parser override, a monkey-patch, or any other workaround for that defect inside this harness — that would hide the bug rather than surface it.

Also added the same "ephemeral, throwaway container password — not a real credential" comment `sqlserver-smoke.yml` already carries, next to this workflow's `MSSQL_SA_PASSWORD` (it was the one committed service-container password in this repo missing that note).

**Note on which channel this proof lives in**: none of `harness syntax contract`, `negative control`, or `containerized functional smoke` are among the 9 `required_status_checks.contexts` on `main` (verified unchanged by this PR). The `pull_request`-triggered check suite for this PR is fully green; the negative-control fix's actual can-fail demonstration lives entirely in the `workflow_dispatch`-only channel (dispatch run 30822049245 above), which is not gated. "All PR checks pass" is not itself evidence for this fix — the dispatch-run log excerpts are.

## Test plan

- [x] Dispatch `functional-smoke`; confirm flag-OFF arm: capability=false + sibling route 200 + S6-A 404 (PASS)
- [x] Confirm exact-match arm: `'1'`/`'yes'` do not enable the route (PASS, same conjunction)
- [x] Confirm the new normalization arms `'TRUE'`/`' true '`/`'True'` DO enable the route + construct the runtime (PASS, run 30840756972)
- [x] Confirm existing-chain reproduces `auditActionsCovered=8/8`, `externalWrite=false` (PASS, still not regressed)
- [x] Migration 074 (main, PR #4728) confirmed to fix migration 073's grant: `s6aProvisioning=PASS` (was `FAIL`)
- [x] Confirm the S6-A flag-ON runtime genuinely CONSTRUCTS: `s6aHealthFlagOn=PASS` (was blocked on `RUNTIME_NOT_CONSTRUCTED`)
- [x] Root-cause the remaining `SEALED_EXPORT_BINDING_UNQUALIFIED` refusal at first capture: confirmed as `createdAt`/`updatedAt` (`Date`-typed) breaking `ownedCanonical`'s `EXOTIC_OBJECT` check — a production defect, reported not patched (R2b update above)
- [x] Remove the diagnostic `--require` preload used to root-cause the above; reproduce the same finding, and the same green arms, WITHOUT it (run 30840756972)
- [x] `s6aFlagOnRun` (+ reason) now always present in the evidence block, including on the `if (!firstOk)` early-return path that actually executes today
- [x] `s6aDbRunRowFoundOnFailure=true`, `s6aDbRunStatusOnFailure=CAPTURE_FAILED` — the run row IS written before the refusal (database-observable, on the failure path)
- [x] `s6aDatabaseObservable`/`s6aReplayRun` honestly `NOT_RUN` (not PASS, not silently dropped) — nothing to observe or replay while capture itself is refused
- [x] Dispatch `negative-control`; confirm it concludes RED for the intended reason (`ASSERTION_FAILED_AS_INTENDED`)
- [x] Negative control now derives its exit code from `CHECKS` (not hardcoded): proved real vs. neutered `must()` now produce **different** exit codes and `negativeControlObservedConclusion` (previously byte-identical)
- [x] The disclosed `CHECKS.length === 0` fail-closed delta is itself mutation-tested (Arm C above: `must()` call deleted → still `exitCode=1`/`RED`, not a silent PASS)
- [x] `node --check` both harness scripts and the workflow's `contract` job pass after the fix
- [x] Full PR check suite green (`gh pr checks 4724`); `negative-control`/`functional-smoke` correctly `skipping` on the `pull_request` event (workflow_dispatch-only) — exercised separately via dispatch run 30840756972

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>


