### PR TITLE
feat(attendance): persist fixed schedule desired config

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -1148,6 +1148,7 @@ jobs:
             tests/integration/attendance-w4c3c-manual-recompute-retirement.db.test.ts \
             tests/integration/attendance-w4c3c-record-operation-routes.db.test.ts \
             tests/integration/attendance-w4c4-calculation-detail.db.test.ts \
+            tests/integration/attendance-group-fixed-schedule-config-migration.db.test.ts \
             tests/integration/attendance-expiry-service.test.ts \
             tests/integration/attendance-unscheduled-reminder.test.ts \
             tests/integration/attendance-outdoor-punch.test.ts \

--- a/packages/core-backend/src/db/migrations/zzzz20260723140000_create_attendance_calculation_group_memberships.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260723140000_create_attendance_calculation_group_memberships.ts
@@ -191,8 +191,29 @@ export async function down(db: Kysely<unknown>): Promise<void> {
     .ifExists()
     .execute()
   await sql.raw(`DROP FUNCTION IF EXISTS ${MEMBERSHIP_USER_ORG_FUNCTION}()`).execute(db)
-  await sql`
-    ALTER TABLE attendance_groups
-      DROP CONSTRAINT IF EXISTS attendance_groups_id_org_unique
-  `.execute(db)
+  await sql.raw(`
+    DO $$
+    DECLARE
+      group_org_unique_index oid;
+    BEGIN
+      SELECT conindid
+        INTO group_org_unique_index
+        FROM pg_constraint
+       WHERE conname = '${GROUP_ORG_UNIQUE}'
+         AND conrelid = 'attendance_groups'::regclass;
+
+      IF group_org_unique_index IS NOT NULL
+         AND NOT EXISTS (
+           SELECT 1
+             FROM pg_depend dependency
+             JOIN pg_constraint dependent_constraint
+               ON dependent_constraint.oid = dependency.objid
+            WHERE dependency.refobjid = group_org_unique_index
+              AND dependent_constraint.contype = 'f'
+         ) THEN
+        ALTER TABLE attendance_groups
+          DROP CONSTRAINT attendance_groups_id_org_unique;
+      END IF;
+    END $$;
+  `).execute(db)
 }

--- a/packages/core-backend/src/db/migrations/zzzz20260803120000_create_attendance_group_fixed_schedule_configs.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260803120000_create_attendance_group_fixed_schedule_configs.ts
@@ -1,0 +1,44 @@
+import type { Kysely } from 'kysely'
+import { sql } from 'kysely'
+
+const TABLE = 'attendance_group_fixed_schedule_configs'
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`CREATE EXTENSION IF NOT EXISTS pgcrypto`.execute(db)
+  await sql`
+    CREATE TABLE IF NOT EXISTS attendance_group_fixed_schedule_configs (
+      id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+      org_id text NOT NULL,
+      group_id uuid NOT NULL,
+      shift_id uuid NOT NULL,
+      start_date date NOT NULL,
+      end_date date NOT NULL,
+      revision integer NOT NULL DEFAULT 1,
+      updated_by text NOT NULL,
+      created_at timestamptz NOT NULL DEFAULT now(),
+      updated_at timestamptz NOT NULL DEFAULT now(),
+      CONSTRAINT attendance_group_fixed_schedule_configs_org_group_unique
+        UNIQUE (org_id, group_id),
+      CONSTRAINT attendance_group_fixed_schedule_configs_dates_valid
+        CHECK (start_date <= end_date),
+      CONSTRAINT attendance_group_fixed_schedule_configs_revision_valid
+        CHECK (revision >= 1),
+      CONSTRAINT attendance_group_fixed_schedule_configs_group_org_fk
+        FOREIGN KEY (group_id, org_id)
+        REFERENCES attendance_groups(id, org_id)
+        ON DELETE CASCADE,
+      CONSTRAINT attendance_group_fixed_schedule_configs_shift_org_fk
+        FOREIGN KEY (shift_id, org_id)
+        REFERENCES attendance_shifts(id, org_id)
+        ON DELETE RESTRICT
+    )
+  `.execute(db)
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_attendance_group_fixed_schedule_configs_org_shift
+      ON attendance_group_fixed_schedule_configs(org_id, shift_id)
+  `.execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema.dropTable(TABLE).ifExists().execute()
+}

--- a/packages/core-backend/tests/integration/attendance-group-fixed-schedule-config-migration.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-group-fixed-schedule-config-migration.db.test.ts
@@ -11,6 +11,7 @@ import {
 
 const require = createRequire(import.meta.url)
 const configServiceLib = require('../../../../plugins/plugin-attendance/lib/attendance-group-fixed-schedule-config-service.cjs')
+const shiftServiceLib = require('../../../../plugins/plugin-attendance/lib/attendance-shift-service.cjs')
 
 class FakeHttpError extends Error {
   constructor(public status: number, public code: string, message: string) {
@@ -47,6 +48,25 @@ describeDb('attendance group fixed-schedule config migration (real DB)', () => {
         org_id text NOT NULL,
         name text NOT NULL,
         UNIQUE (id, org_id)
+      )
+    `.execute(db)
+    await sql`CREATE TABLE attendance_shift_segments (org_id text NOT NULL, shift_id uuid NOT NULL)`.execute(db)
+    await sql`CREATE TABLE attendance_shift_assignments (org_id text NOT NULL, shift_id uuid NOT NULL)`.execute(db)
+    await sql`CREATE TABLE attendance_rotation_rules (org_id text NOT NULL, shift_sequence jsonb NOT NULL DEFAULT '[]'::jsonb)`.execute(db)
+    await sql`CREATE TABLE attendance_requests (id uuid PRIMARY KEY, status text NOT NULL)`.execute(db)
+    await sql`
+      CREATE TABLE attendance_shift_swap_requests (
+        org_id text NOT NULL,
+        request_id uuid NOT NULL,
+        requester_shift_id uuid,
+        counterparty_shift_id uuid
+      )
+    `.execute(db)
+    await sql`
+      CREATE TABLE attendance_schedule_dispatch_requests (
+        org_id text NOT NULL,
+        target_shift_id uuid NOT NULL,
+        publish_status text NOT NULL
       )
     `.execute(db)
   })
@@ -142,5 +162,91 @@ describeDb('attendance group fixed-schedule config migration (real DB)', () => {
     expect(statements.filter(statement => statement.includes('FROM attendance_shifts'))).toHaveLength(3)
     expect(statements.filter(statement => statement.includes('FROM attendance_shifts'))
       .every(statement => statement.includes('FOR SHARE'))).toBe(true)
+  })
+
+  it('holds the shift reference lock through config commit so canonical delete returns typed 409', async () => {
+    const { groupId, shiftId } = await insertParents('org-a')
+    await up(db)
+    const configService = configServiceLib.createAttendanceGroupFixedScheduleConfigService({ HttpError: FakeHttpError })
+    const shiftService = shiftServiceLib.createAttendanceShiftService({
+      HttpError: FakeHttpError,
+      randomUUID,
+      resolveShiftTiming: () => { throw new Error('not used') },
+      normalizeWorkingDays: (value: unknown) => value,
+      mapShiftRow: (row: Record<string, unknown>) => row,
+      DEFAULT_SHIFT: {},
+      DEFAULT_ORG_ID: 'default',
+      normalizeLegacyRotationRulesForShiftName: (value: unknown) => value,
+    })
+
+    let releaseWriter!: () => void
+    const writerCanFinish = new Promise<void>((resolve) => { releaseWriter = resolve })
+    let signalWriterLocked!: () => void
+    const writerLocked = new Promise<void>((resolve) => { signalWriterLocked = resolve })
+    const writerClient = await pool.connect()
+    const writer = (async () => {
+      await writerClient.query('BEGIN')
+      try {
+        const result = await configService.upsertConfig({
+          query: async (text: string, values: unknown[]) => {
+            const response = await writerClient.query(text, values)
+            if (text.includes('FROM attendance_shifts')) {
+              signalWriterLocked()
+              await writerCanFinish
+            }
+            return response.rows
+          },
+        }, {
+          orgId: 'org-a',
+          groupId,
+          shiftId,
+          startDate: '2026-08-01',
+          endDate: '2026-08-31',
+          updatedBy: 'admin-1',
+        })
+        await writerClient.query('COMMIT')
+        return result
+      } catch (error) {
+        await writerClient.query('ROLLBACK')
+        throw error
+      } finally {
+        writerClient.release()
+      }
+    })()
+
+    await writerLocked
+    const deleteDb = {
+      transaction: async (callback: (trx: { query: (text: string, values?: unknown[]) => Promise<unknown[]> }) => Promise<unknown>) => {
+        const client = await pool.connect()
+        await client.query('BEGIN')
+        try {
+          const result = await callback({
+            query: async (text: string, values: unknown[] = []) => (await client.query(text, values)).rows,
+          })
+          await client.query('COMMIT')
+          return result
+        } catch (error) {
+          await client.query('ROLLBACK')
+          throw error
+        } finally {
+          client.release()
+        }
+      },
+    }
+    const deletion = shiftService.deleteShift(deleteDb, { orgId: 'org-a', shiftId })
+    await new Promise(resolve => setTimeout(resolve, 50))
+    releaseWriter()
+
+    await expect(writer).resolves.toMatchObject({ revision: 1 })
+    await expect(deletion).rejects.toMatchObject({ status: 409, code: 'ATTENDANCE_SHIFT_DELETE_BLOCKED' })
+    const configRows = await sql<{ total: string }>`
+      SELECT COUNT(*)::text AS total FROM attendance_group_fixed_schedule_configs
+       WHERE org_id = 'org-a' AND group_id = ${groupId} AND shift_id = ${shiftId}
+    `.execute(db)
+    const shiftRows = await sql<{ total: string }>`
+      SELECT COUNT(*)::text AS total FROM attendance_shifts WHERE org_id = 'org-a' AND id = ${shiftId}
+    `.execute(db)
+    expect(configRows.rows[0]!.total).toBe('1')
+    expect(shiftRows.rows[0]!.total).toBe('1')
   })
 })

--- a/packages/core-backend/tests/integration/attendance-group-fixed-schedule-config-migration.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-group-fixed-schedule-config-migration.db.test.ts
@@ -8,6 +8,9 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import {
   up,
 } from '../../src/db/migrations/zzzz20260803120000_create_attendance_group_fixed_schedule_configs'
+import {
+  down as membershipMigrationDown,
+} from '../../src/db/migrations/zzzz20260723140000_create_attendance_calculation_group_memberships'
 
 const require = createRequire(import.meta.url)
 const configServiceLib = require('../../../../plugins/plugin-attendance/lib/attendance-group-fixed-schedule-config-service.cjs')
@@ -39,7 +42,7 @@ describeDb('attendance group fixed-schedule config migration (real DB)', () => {
         id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
         org_id text NOT NULL,
         name text NOT NULL,
-        UNIQUE (id, org_id)
+        CONSTRAINT attendance_groups_id_org_unique UNIQUE (id, org_id)
       )
     `.execute(db)
     await sql`
@@ -106,6 +109,29 @@ describeDb('attendance group fixed-schedule config migration (real DB)', () => {
       SELECT revision FROM attendance_group_fixed_schedule_configs
     `.execute(db)
     expect(rows.rows).toEqual([{ revision: 1 }])
+  })
+
+  it('keeps the shared group-org key when the earlier membership migration rolls back', async () => {
+    const { groupId, shiftId } = await insertParents('org-a')
+    await up(db)
+    await sql`CREATE TABLE attendance_calculation_group_memberships (id uuid PRIMARY KEY)`.execute(db)
+    await sql`CREATE TABLE attendance_calculation_group_membership_operations (id uuid PRIMARY KEY)`.execute(db)
+
+    await membershipMigrationDown(db)
+
+    const constraints = await sql<{ conname: string }>`
+      SELECT conname
+        FROM pg_constraint
+       WHERE conname IN (
+         'attendance_groups_id_org_unique',
+         'attendance_group_fixed_schedule_configs_group_org_fk'
+       )
+    `.execute(db)
+    expect(constraints.rows.map(row => row.conname)).toEqual(expect.arrayContaining([
+      'attendance_groups_id_org_unique',
+      'attendance_group_fixed_schedule_configs_group_org_fk',
+    ]))
+    await insertConfig('org-a', groupId, shiftId)
   })
 
   it('enforces composite organization integrity for both group and shift', async () => {

--- a/packages/core-backend/tests/integration/attendance-group-fixed-schedule-config-migration.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-group-fixed-schedule-config-migration.db.test.ts
@@ -1,0 +1,139 @@
+import { randomUUID } from 'node:crypto'
+import { createRequire } from 'node:module'
+
+import { Kysely, PostgresDialect, sql } from 'kysely'
+import { Pool } from 'pg'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import {
+  up,
+} from '../../src/db/migrations/zzzz20260803120000_create_attendance_group_fixed_schedule_configs'
+
+const require = createRequire(import.meta.url)
+const configServiceLib = require('../../../../plugins/plugin-attendance/lib/attendance-group-fixed-schedule-config-service.cjs')
+
+class FakeHttpError extends Error {
+  constructor(public status: number, public code: string, message: string) {
+    super(message)
+  }
+}
+
+const dbUrl = process.env.DATABASE_URL
+const describeDb = dbUrl ? describe : describe.skip
+
+describeDb('attendance group fixed-schedule config migration (real DB)', () => {
+  let adminPool: Pool
+  let schema: string
+  let pool: Pool
+  let db: Kysely<unknown>
+
+  beforeEach(async () => {
+    adminPool = new Pool({ connectionString: dbUrl })
+    schema = `fser1_${randomUUID().replace(/-/g, '')}`
+    await adminPool.query(`CREATE SCHEMA "${schema}"`)
+    pool = new Pool({ connectionString: dbUrl, options: `-c search_path=${schema}` })
+    db = new Kysely<unknown>({ dialect: new PostgresDialect({ pool }) })
+    await sql`
+      CREATE TABLE attendance_groups (
+        id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+        org_id text NOT NULL,
+        name text NOT NULL,
+        UNIQUE (id, org_id)
+      )
+    `.execute(db)
+    await sql`
+      CREATE TABLE attendance_shifts (
+        id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+        org_id text NOT NULL,
+        name text NOT NULL,
+        UNIQUE (id, org_id)
+      )
+    `.execute(db)
+  })
+
+  afterEach(async () => {
+    await db.destroy()
+    await adminPool.query(`DROP SCHEMA IF EXISTS "${schema}" CASCADE`)
+    await adminPool.end()
+  })
+
+  async function insertParents(orgId: string) {
+    const group = await sql<{ id: string }>`
+      INSERT INTO attendance_groups (org_id, name) VALUES (${orgId}, 'Group') RETURNING id
+    `.execute(db)
+    const shift = await sql<{ id: string }>`
+      INSERT INTO attendance_shifts (org_id, name) VALUES (${orgId}, 'Shift') RETURNING id
+    `.execute(db)
+    return { groupId: group.rows[0]!.id, shiftId: shift.rows[0]!.id }
+  }
+
+  async function insertConfig(orgId: string, groupId: string, shiftId: string) {
+    return sql`
+      INSERT INTO attendance_group_fixed_schedule_configs
+        (org_id, group_id, shift_id, start_date, end_date, updated_by)
+      VALUES (${orgId}, ${groupId}, ${shiftId}, '2026-08-01', '2026-08-31', 'admin-1')
+    `.execute(db)
+  }
+
+  it('is replay-safe and permits only one desired config per organization and group', async () => {
+    const { groupId, shiftId } = await insertParents('org-a')
+    await up(db)
+    await up(db)
+    await insertConfig('org-a', groupId, shiftId)
+    await expect(insertConfig('org-a', groupId, shiftId)).rejects.toThrow(/attendance_group_fixed_schedule_configs_org_group_unique/)
+
+    const rows = await sql<{ revision: number }>`
+      SELECT revision FROM attendance_group_fixed_schedule_configs
+    `.execute(db)
+    expect(rows.rows).toEqual([{ revision: 1 }])
+  })
+
+  it('enforces composite organization integrity for both group and shift', async () => {
+    const orgA = await insertParents('org-a')
+    const orgB = await insertParents('org-b')
+    await up(db)
+
+    await expect(insertConfig('org-a', orgB.groupId, orgA.shiftId)).rejects.toThrow(/attendance_group_fixed_schedule_configs_group_org_fk/)
+    await expect(insertConfig('org-a', orgA.groupId, orgB.shiftId)).rejects.toThrow(/attendance_group_fixed_schedule_configs_shift_org_fk/)
+    await insertConfig('org-a', orgA.groupId, orgA.shiftId)
+  })
+
+  it('cascades group deletion but restricts deletion of a referenced shift', async () => {
+    const { groupId, shiftId } = await insertParents('org-a')
+    await up(db)
+    await insertConfig('org-a', groupId, shiftId)
+
+    await expect(sql`DELETE FROM attendance_shifts WHERE id = ${shiftId}`.execute(db))
+      .rejects.toThrow(/attendance_group_fixed_schedule_configs_shift_org_fk/)
+    await sql`DELETE FROM attendance_groups WHERE id = ${groupId}`.execute(db)
+    const rows = await sql<{ total: string }>`
+      SELECT COUNT(*)::text AS total FROM attendance_group_fixed_schedule_configs
+    `.execute(db)
+    expect(rows.rows[0]!.total).toBe('0')
+  })
+
+  it('keeps identical saves idempotent and increments revision only when desired values change', async () => {
+    const { groupId, shiftId } = await insertParents('org-a')
+    await up(db)
+    const service = configServiceLib.createAttendanceGroupFixedScheduleConfigService({ HttpError: FakeHttpError })
+    const client = {
+      query: async (text: string, values: unknown[]) => (await pool.query(text, values)).rows,
+    }
+    const desired = {
+      orgId: 'org-a',
+      groupId,
+      shiftId,
+      startDate: '2026-08-01',
+      endDate: '2026-08-31',
+      updatedBy: 'admin-1',
+    }
+
+    const first = await service.upsertConfig(client, desired)
+    const replay = await service.upsertConfig(client, { ...desired, updatedBy: 'admin-2' })
+    const changed = await service.upsertConfig(client, { ...desired, endDate: '2026-09-30', updatedBy: 'admin-2' })
+
+    expect(first).toMatchObject({ revision: 1, updatedBy: 'admin-1' })
+    expect(replay).toMatchObject({ revision: 1, updatedBy: 'admin-1' })
+    expect(changed).toMatchObject({ revision: 2, endDate: '2026-09-30', updatedBy: 'admin-2' })
+  })
+})

--- a/packages/core-backend/tests/integration/attendance-group-fixed-schedule-config-migration.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-group-fixed-schedule-config-migration.db.test.ts
@@ -116,8 +116,12 @@ describeDb('attendance group fixed-schedule config migration (real DB)', () => {
     const { groupId, shiftId } = await insertParents('org-a')
     await up(db)
     const service = configServiceLib.createAttendanceGroupFixedScheduleConfigService({ HttpError: FakeHttpError })
+    const statements: string[] = []
     const client = {
-      query: async (text: string, values: unknown[]) => (await pool.query(text, values)).rows,
+      query: async (text: string, values: unknown[]) => {
+        statements.push(text)
+        return (await pool.query(text, values)).rows
+      },
     }
     const desired = {
       orgId: 'org-a',
@@ -135,5 +139,8 @@ describeDb('attendance group fixed-schedule config migration (real DB)', () => {
     expect(first).toMatchObject({ revision: 1, updatedBy: 'admin-1' })
     expect(replay).toMatchObject({ revision: 1, updatedBy: 'admin-1' })
     expect(changed).toMatchObject({ revision: 2, endDate: '2026-09-30', updatedBy: 'admin-2' })
+    expect(statements.filter(statement => statement.includes('FROM attendance_shifts'))).toHaveLength(3)
+    expect(statements.filter(statement => statement.includes('FROM attendance_shifts'))
+      .every(statement => statement.includes('FOR SHARE'))).toBe(true)
   })
 })

--- a/packages/core-backend/tests/integration/attendance-group-fixed-schedule-config-migration.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-group-fixed-schedule-config-migration.db.test.ts
@@ -111,6 +111,23 @@ describeDb('attendance group fixed-schedule config migration (real DB)', () => {
     expect(rows.rows).toEqual([{ revision: 1 }])
   })
 
+  it('removes the group-org key when no later foreign key depends on it', async () => {
+    await sql`CREATE TABLE attendance_calculation_group_memberships (id uuid PRIMARY KEY)`.execute(db)
+    await sql`CREATE TABLE attendance_calculation_group_membership_operations (id uuid PRIMARY KEY)`.execute(db)
+
+    await membershipMigrationDown(db)
+
+    const constraint = await sql<{ constraint_present: boolean }>`
+      SELECT EXISTS (
+        SELECT 1
+          FROM pg_constraint
+         WHERE conname = 'attendance_groups_id_org_unique'
+           AND conrelid = 'attendance_groups'::regclass
+      ) AS constraint_present
+    `.execute(db)
+    expect(constraint.rows[0]?.constraint_present).toBe(false)
+  })
+
   it('keeps the shared group-org key when the earlier membership migration rolls back', async () => {
     const { groupId, shiftId } = await insertParents('org-a')
     await up(db)

--- a/packages/core-backend/tests/integration/attendance-group-fixed-schedule-config-migration.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-group-fixed-schedule-config-migration.db.test.ts
@@ -215,13 +215,20 @@ describeDb('attendance group fixed-schedule config migration (real DB)', () => {
     })()
 
     await writerLocked
+    let signalDeleteLockAttempted!: () => void
+    const deleteLockAttempted = new Promise<void>((resolve) => { signalDeleteLockAttempted = resolve })
     const deleteDb = {
       transaction: async (callback: (trx: { query: (text: string, values?: unknown[]) => Promise<unknown[]> }) => Promise<unknown>) => {
         const client = await pool.connect()
         await client.query('BEGIN')
         try {
           const result = await callback({
-            query: async (text: string, values: unknown[] = []) => (await client.query(text, values)).rows,
+            query: async (text: string, values: unknown[] = []) => {
+              if (text.includes('FROM attendance_shifts') && text.includes('FOR UPDATE')) {
+                signalDeleteLockAttempted()
+              }
+              return (await client.query(text, values)).rows
+            },
           })
           await client.query('COMMIT')
           return result
@@ -234,7 +241,13 @@ describeDb('attendance group fixed-schedule config migration (real DB)', () => {
       },
     }
     const deletion = shiftService.deleteShift(deleteDb, { orgId: 'org-a', shiftId })
-    await new Promise(resolve => setTimeout(resolve, 50))
+    let deletionSettled = false
+    void deletion.then(
+      () => { deletionSettled = true },
+      () => { deletionSettled = true },
+    )
+    await deleteLockAttempted
+    expect(deletionSettled).toBe(false)
     releaseWriter()
 
     await expect(writer).resolves.toMatchObject({ revision: 1 })

--- a/packages/core-backend/tests/unit/attendance-advanced-scheduling-scope.test.ts
+++ b/packages/core-backend/tests/unit/attendance-advanced-scheduling-scope.test.ts
@@ -28,6 +28,16 @@ function expectDirectAsyncRoute(method: string, path: string) {
   expect(pluginSource).toMatch(pattern)
 }
 
+function expectTrustedAdminRoute(method: string, path: string) {
+  const escaped = path.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  const pattern = new RegExp(
+    `['"]${method}['"],\\s*\\n\\s*['"]${escaped}['"],\\s*\\n\\s*async \\(req, res\\) => \\{\\s*`
+      + 'const actorAccess = await resolveAttendanceFixedScheduleRouteActorContext\\(req, res\\)\\s*'
+      + 'if \\(!actorAccess\\) return\\s*if \\(!actorAccess\\.fullAdmin\\)',
+  )
+  expect(pluginSource).toMatch(pattern)
+}
+
 describe('attendance advanced scheduling scope foundation', () => {
   it('creates separate scheduling tables without mutating existing attendance group membership tables', () => {
     expect(migrationSource).toContain("createTable('attendance_schedule_groups')")
@@ -47,12 +57,12 @@ describe('attendance advanced scheduling scope foundation', () => {
       ['POST', '/api/attendance/scheduler-scopes'],
       ['PUT', '/api/attendance/scheduler-scopes/:id'],
       ['DELETE', '/api/attendance/scheduler-scopes/:id'],
-      ['POST', '/api/attendance/groups/:id/fixed-schedule/preview'],
-      ['POST', '/api/attendance/groups/:id/fixed-schedule/apply'],
-      ['POST', '/api/attendance/groups/:id/fixed-schedule/rebuild'],
-      ['POST', '/api/attendance/groups/:id/fixed-schedule/clear'],
     ].forEach(([method, path]) => expectAdminRoute(method, path))
     expect(pluginSource).toContain('SCHEDULER_SCOPE_FORBIDDEN')
+    expectTrustedAdminRoute('POST', '/api/attendance/groups/:id/fixed-schedule/preview')
+    expectDirectAsyncRoute('POST', '/api/attendance/groups/:id/fixed-schedule/apply')
+    expectDirectAsyncRoute('POST', '/api/attendance/groups/:id/fixed-schedule/rebuild')
+    expectDirectAsyncRoute('POST', '/api/attendance/groups/:id/fixed-schedule/clear')
     expectDirectAsyncRoute('POST', '/api/attendance/requests/:id/approve')
     expectDirectAsyncRoute('POST', '/api/attendance/requests/:id/reject')
     expectDirectAsyncRoute('GET', '/api/attendance/schedule-groups')

--- a/packages/core-backend/tests/unit/attendance-shift-segments-service.test.ts
+++ b/packages/core-backend/tests/unit/attendance-shift-segments-service.test.ts
@@ -410,3 +410,29 @@ describe('applyShiftReferenceLabels (historical evidence reads)', () => {
     expect(rows[1]).toEqual({ requesterShiftId: 'kept', requesterShiftLabel: 'Day Shift', requesterShiftStatus: 'available' })
   })
 })
+
+describe('deleteShift fixed-schedule config blocker', () => {
+  it('returns the canonical typed 409 before deleting a referenced shift', async () => {
+    const shiftId = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+    const statements: string[] = []
+    const trx = {
+      query: async (sql: string) => {
+        statements.push(sql)
+        if (sql.includes('SELECT id, name FROM attendance_shifts')) return [{ id: shiftId, name: 'Day' }]
+        if (sql.includes('attendance_group_fixed_schedule_configs')) return [{ total: 1 }]
+        if (sql.includes('COUNT(*)::int AS total')) return [{ total: 0 }]
+        throw new Error(`unexpected SQL: ${sql}`)
+      },
+    }
+    const db = {
+      transaction: async (callback: (client: typeof trx) => Promise<unknown>) => callback(trx),
+    }
+
+    await expect(service.deleteShift(db, { orgId: 'org-a', shiftId })).rejects.toMatchObject({
+      status: 409,
+      code: ERR.DELETE_BLOCKED,
+      details: [{ field: 'fixed_schedule_configs', message: 'fixed_schedule_configs: 1 reference(s)' }],
+    })
+    expect(statements.some(statement => statement.startsWith('DELETE FROM'))).toBe(false)
+  })
+})

--- a/packages/core-backend/tests/unit/attendance-uuid-validation-routes.test.ts
+++ b/packages/core-backend/tests/unit/attendance-uuid-validation-routes.test.ts
@@ -4016,7 +4016,7 @@ describe('attendance UUID route validation', () => {
     for (const testCase of cases) {
       for (const selector of selectors) {
         const label = `${testCase.key} (${selector.name})`
-        const { db, routes } = await createHarness()
+        const { db, routes } = await createHarness('false')
         const res = await invokeRoute(routes, testCase.key, {
           params: testCase.params,
           body: { ...body, ...(selector.body ?? {}) },
@@ -4031,6 +4031,25 @@ describe('attendance UUID route validation', () => {
     }
   })
 
+  it('admits a real RBAC attendance admin to preview only after trusted actor resolution', async () => {
+    const { db, routes } = await createHarness('false')
+    db.query.mockImplementation(async (sql: string, params: unknown[] = []) => {
+      const rbac = rbacQueryResult(sql, params, true)
+      if (rbac !== undefined) return rbac
+      throw new Error(`unexpected query: ${sql}`)
+    })
+
+    const res = await invokeRoute(routes, 'POST /api/attendance/groups/:id/fixed-schedule/preview', {
+      params: { id: 'not-a-uuid' },
+      body: { shiftId, startDate: '2026-06-01', endDate: '2026-06-30' },
+      user: { id: 'admin-1', orgId: 'default' },
+    })
+
+    expect(res.statusCode).toBe(400)
+    expect(db.query).toHaveBeenCalled()
+    expect(db.transaction).not.toHaveBeenCalled()
+  })
+
   it('fails every fixed-schedule route closed when authenticated actor context is incomplete', async () => {
     const cases = [
       { key: 'PUT /api/attendance/groups/:groupId/fixed-schedule/config', params: { groupId: attendanceGroupId } },
@@ -4042,17 +4061,18 @@ describe('attendance UUID route validation', () => {
     const body = { shiftId, startDate: '2026-06-01', endDate: '2026-06-30' }
 
     for (const testCase of cases) {
-      const { db: missingUserDb, routes: missingUserRoutes } = await createHarness()
+      const { db: missingUserDb, routes: missingUserRoutes } = await createHarness('false')
       const missingUser = await invokeRoute(missingUserRoutes, testCase.key, {
         params: testCase.params,
         body,
+        headers: { 'x-user-id': 'forged-header-user' },
         user: { orgId: 'default' },
       })
       expect(missingUser.statusCode, `${testCase.key} (missing user)`).toBe(401)
       expect(missingUserDb.query, `${testCase.key} (missing user)`).not.toHaveBeenCalled()
       expect(missingUserDb.transaction, `${testCase.key} (missing user)`).not.toHaveBeenCalled()
 
-      const { db: missingOrgDb, routes: missingOrgRoutes } = await createHarness()
+      const { db: missingOrgDb, routes: missingOrgRoutes } = await createHarness('false')
       const missingOrg = await invokeRoute(missingOrgRoutes, testCase.key, {
         params: testCase.params,
         body,

--- a/packages/core-backend/tests/unit/attendance-uuid-validation-routes.test.ts
+++ b/packages/core-backend/tests/unit/attendance-uuid-validation-routes.test.ts
@@ -2991,12 +2991,17 @@ describe('attendance UUID route validation', () => {
     expect(db.query).not.toHaveBeenCalledWith(expect.stringContaining('FROM attendance_scheduler_scopes'), expect.anything())
   })
 
-  it('keeps fixed-schedule clear admin-only even inside scheduler scope', async () => {
+  it('lets scoped non-admin schedulers clear fixed schedule rows inside their attendance group scope', async () => {
     const { db, routes } = await createHarness('false')
 
     db.query.mockImplementation(async (sql: string, params: unknown[] = []) => {
       const rbac = rbacQueryResult(sql, params)
       if (rbac !== undefined) return rbac
+      const actor = actorContextQueryResult(sql)
+      if (actor !== undefined) return actor
+      if (sql.includes('SELECT id FROM attendance_groups')) return [{ id: attendanceGroupId }]
+      if (sql.includes('FROM attendance_scheduler_scopes')) return [schedulerScopeClearRow()]
+      if (sql.includes('FROM attendance_shift_assignments') && sql.includes('producer_type = $2')) return []
       throw new Error(`unexpected query: ${sql}`)
     })
 
@@ -3006,10 +3011,13 @@ describe('attendance UUID route validation', () => {
       user: { id: 'scheduler-1', orgId: 'default' },
     })
 
-    expect(res.statusCode).toBe(403)
-    expect(res.body).toMatchObject({ ok: false, error: { code: 'FORBIDDEN' } })
-    expect(db.query.mock.calls.map(([sql]) => String(sql)).some(sql => sql.includes('FROM attendance_scheduler_scopes'))).toBe(false)
-    expect(db.transaction).not.toHaveBeenCalled()
+    expect(res.statusCode).toBe(200)
+    expect(res.body).toMatchObject({ ok: true, data: { cleared: true } })
+    expect(db.query).toHaveBeenCalledWith(
+      expect.stringContaining('FROM attendance_scheduler_scopes'),
+      ['default', 'scheduler-1', [], []],
+    )
+    expect(db.transaction).toHaveBeenCalledTimes(1)
   })
 
   it('rejects scoped fixed schedule clears outside the attendance group scope and does not clear', async () => {
@@ -3021,6 +3029,7 @@ describe('attendance UUID route validation', () => {
       if (rbac !== undefined) return rbac
       const actor = actorContextQueryResult(sql)
       if (actor !== undefined) return actor
+      if (sql.includes('SELECT id FROM attendance_groups')) return [{ id: attendanceGroupId }]
       if (sql.includes('FROM attendance_scheduler_scopes')) {
         return [schedulerScopeClearRow({ scope: { attendanceGroupIds: [otherAttendanceGroupId] } })]
       }
@@ -3034,9 +3043,8 @@ describe('attendance UUID route validation', () => {
     })
 
     expect(res.statusCode).toBe(403)
-    expect(res.body).toMatchObject({ ok: false, error: { code: 'FORBIDDEN' } })
+    expect(res.body).toMatchObject({ ok: false, error: { code: 'SCHEDULER_SCOPE_FORBIDDEN' } })
     expect(db.transaction).not.toHaveBeenCalled()
-    expect(db.query.mock.calls.map(([sql]) => String(sql)).some(sql => sql.includes('FROM attendance_scheduler_scopes'))).toBe(false)
     expect(db.query.mock.calls.map(([sql]) => String(sql)).some(sql => sql.includes('producer_type = $2'))).toBe(false)
   })
 
@@ -3069,12 +3077,18 @@ describe('attendance UUID route validation', () => {
     expect(db.query).not.toHaveBeenCalledWith(expect.stringContaining('FROM attendance_scheduler_scopes'), expect.anything())
   })
 
-  it('keeps fixed-schedule apply admin-only even inside scheduler dispatch scope', async () => {
+  it('lets scoped non-admin schedulers apply fixed schedules inside their attendance group dispatch scope', async () => {
     const { db, routes } = await createHarness('false')
 
     db.query.mockImplementation(async (sql: string, params: unknown[] = []) => {
       const rbac = rbacQueryResult(sql, params)
       if (rbac !== undefined) return rbac
+      const actor = actorContextQueryResult(sql)
+      if (actor !== undefined) return actor
+      if (sql.includes('SELECT id FROM attendance_groups')) return [{ id: attendanceGroupId }]
+      if (sql.includes('FROM attendance_scheduler_scopes')) return [schedulerScopeFixedScheduleRow(['dispatch'])]
+      const fixedSchedule = fixedScheduleQueryResult(sql)
+      if (fixedSchedule.handled) return fixedSchedule.rows
       throw new Error(`unexpected query: ${sql}`)
     })
 
@@ -3084,10 +3098,13 @@ describe('attendance UUID route validation', () => {
       user: { id: 'scheduler-1', orgId: 'default' },
     })
 
-    expect(res.statusCode).toBe(403)
-    expect(res.body).toMatchObject({ ok: false, error: { code: 'FORBIDDEN' } })
-    expect(db.query.mock.calls.map(([sql]) => String(sql)).some(sql => sql.includes('FROM attendance_scheduler_scopes'))).toBe(false)
-    expect(db.transaction).not.toHaveBeenCalled()
+    expect(res.statusCode).toBe(201)
+    expect(res.body).toMatchObject({ ok: true, data: { applied: true } })
+    expect(db.query).toHaveBeenCalledWith(
+      expect.stringContaining('FROM attendance_scheduler_scopes'),
+      ['default', 'scheduler-1', [], []],
+    )
+    expect(db.transaction).toHaveBeenCalledTimes(1)
   })
 
   it('rejects scoped fixed schedule applies without dispatch scope and does not apply', async () => {
@@ -3098,6 +3115,7 @@ describe('attendance UUID route validation', () => {
       if (rbac !== undefined) return rbac
       const actor = actorContextQueryResult(sql)
       if (actor !== undefined) return actor
+      if (sql.includes('SELECT id FROM attendance_groups')) return [{ id: attendanceGroupId }]
       if (sql.includes('FROM attendance_scheduler_scopes')) return [schedulerScopeFixedScheduleRow(['clear'])]
       throw new Error(`unexpected query: ${sql}`)
     })
@@ -3109,18 +3127,23 @@ describe('attendance UUID route validation', () => {
     })
 
     expect(res.statusCode).toBe(403)
-    expect(res.body).toMatchObject({ ok: false, error: { code: 'FORBIDDEN' } })
+    expect(res.body).toMatchObject({ ok: false, error: { code: 'SCHEDULER_SCOPE_FORBIDDEN' } })
     expect(db.transaction).not.toHaveBeenCalled()
-    expect(db.query.mock.calls.map(([sql]) => String(sql)).some(sql => sql.includes('FROM attendance_scheduler_scopes'))).toBe(false)
     expect(db.query.mock.calls.map(([sql]) => String(sql)).some(sql => sql.includes('INSERT INTO attendance_shift_assignments'))).toBe(false)
   })
 
-  it('keeps fixed-schedule rebuild admin-only even with clear and dispatch scope', async () => {
+  it('requires both clear and dispatch scope before scoped fixed schedule rebuilds', async () => {
     const { db, routes } = await createHarness('false')
 
     db.query.mockImplementation(async (sql: string, params: unknown[] = []) => {
       const rbac = rbacQueryResult(sql, params)
       if (rbac !== undefined) return rbac
+      const actor = actorContextQueryResult(sql)
+      if (actor !== undefined) return actor
+      if (sql.includes('SELECT id FROM attendance_groups')) return [{ id: attendanceGroupId }]
+      if (sql.includes('FROM attendance_scheduler_scopes')) return [schedulerScopeFixedScheduleRow(['clear', 'dispatch'])]
+      const fixedSchedule = fixedScheduleQueryResult(sql)
+      if (fixedSchedule.handled) return fixedSchedule.rows
       throw new Error(`unexpected query: ${sql}`)
     })
 
@@ -3130,10 +3153,9 @@ describe('attendance UUID route validation', () => {
       user: { id: 'scheduler-1', orgId: 'default' },
     })
 
-    expect(res.statusCode).toBe(403)
-    expect(res.body).toMatchObject({ ok: false, error: { code: 'FORBIDDEN' } })
-    expect(db.query.mock.calls.map(([sql]) => String(sql)).some(sql => sql.includes('FROM attendance_scheduler_scopes'))).toBe(false)
-    expect(db.transaction).not.toHaveBeenCalled()
+    expect(res.statusCode).toBe(200)
+    expect(res.body).toMatchObject({ ok: true, data: { rebuilt: true } })
+    expect(db.transaction).toHaveBeenCalledTimes(1)
   })
 
   it('rejects scoped fixed schedule rebuilds without clear scope and does not rebuild', async () => {
@@ -3144,6 +3166,7 @@ describe('attendance UUID route validation', () => {
       if (rbac !== undefined) return rbac
       const actor = actorContextQueryResult(sql)
       if (actor !== undefined) return actor
+      if (sql.includes('SELECT id FROM attendance_groups')) return [{ id: attendanceGroupId }]
       if (sql.includes('FROM attendance_scheduler_scopes')) return [schedulerScopeFixedScheduleRow(['dispatch'])]
       throw new Error(`unexpected query: ${sql}`)
     })
@@ -3155,9 +3178,8 @@ describe('attendance UUID route validation', () => {
     })
 
     expect(res.statusCode).toBe(403)
-    expect(res.body).toMatchObject({ ok: false, error: { code: 'FORBIDDEN' } })
+    expect(res.body).toMatchObject({ ok: false, error: { code: 'SCHEDULER_SCOPE_FORBIDDEN' } })
     expect(db.transaction).not.toHaveBeenCalled()
-    expect(db.query.mock.calls.map(([sql]) => String(sql)).some(sql => sql.includes('FROM attendance_scheduler_scopes'))).toBe(false)
     expect(db.query.mock.calls.map(([sql]) => String(sql)).some(sql => sql.includes('INSERT INTO attendance_shift_assignments'))).toBe(false)
   })
 
@@ -3520,10 +3542,10 @@ describe('attendance UUID route validation', () => {
       { key: 'GET /api/attendance/groups/:id/managers' },
       { key: 'POST /api/attendance/groups/:id/managers', body: { userId: 'manager-1', role: 'owner' } },
       { key: 'DELETE /api/attendance/groups/:id/managers/:managerId', params: { id: attendanceGroupId, managerId: scheduleGroupMemberId } },
-      { key: 'POST /api/attendance/groups/:id/fixed-schedule/preview', body: { shiftId, startDate: '2026-06-01', endDate: '2026-06-30' } },
-      { key: 'POST /api/attendance/groups/:id/fixed-schedule/apply', body: { shiftId, startDate: '2026-06-01', endDate: '2026-06-30' } },
-      { key: 'POST /api/attendance/groups/:id/fixed-schedule/rebuild', body: { shiftId, startDate: '2026-06-01', endDate: '2026-06-30' } },
-      { key: 'POST /api/attendance/groups/:id/fixed-schedule/clear', body: { shiftId, startDate: '2026-06-01', endDate: '2026-06-30' } },
+      { key: 'POST /api/attendance/groups/:id/fixed-schedule/preview', body: { shiftId, startDate: '2026-06-01', endDate: '2026-06-30' }, expectedStatus: 403 },
+      { key: 'POST /api/attendance/groups/:id/fixed-schedule/apply', body: { shiftId, startDate: '2026-06-01', endDate: '2026-06-30' }, expectedStatus: 403 },
+      { key: 'POST /api/attendance/groups/:id/fixed-schedule/rebuild', body: { shiftId, startDate: '2026-06-01', endDate: '2026-06-30' }, expectedStatus: 403 },
+      { key: 'POST /api/attendance/groups/:id/fixed-schedule/clear', body: { shiftId, startDate: '2026-06-01', endDate: '2026-06-30' }, expectedStatus: 403 },
       { key: 'GET /api/attendance/rule-sets' },
       { key: 'POST /api/attendance/rule-sets/preview', body: { config: {} } },
       { key: 'GET /api/attendance/advanced-scheduling/workbench' },
@@ -3616,11 +3638,11 @@ describe('attendance UUID route validation', () => {
           headers: selector.headers,
           user: { id: 'admin-1', orgId: 'default' },
         })
-        expect(res.statusCode, label).toBe(404)
-        expect(res.body, label).toEqual({
-          ok: false,
-          error: { code: 'NOT_FOUND', message: 'Group not found' },
-        })
+        const expectedStatus = 'expectedStatus' in testCase ? testCase.expectedStatus : 404
+        expect(res.statusCode, label).toBe(expectedStatus)
+        expect(res.body, label).toEqual(expectedStatus === 403
+          ? { ok: false, error: { code: 'FORBIDDEN', message: 'Insufficient permissions' } }
+          : { ok: false, error: { code: 'NOT_FOUND', message: 'Group not found' } })
         expect(db.query.mock.calls.map(([sql]) => String(sql)).some(sql => sql.includes('attendance_')), label).toBe(false)
         expect(db.transaction, label).not.toHaveBeenCalled()
       }

--- a/packages/core-backend/tests/unit/attendance-uuid-validation-routes.test.ts
+++ b/packages/core-backend/tests/unit/attendance-uuid-validation-routes.test.ts
@@ -95,11 +95,12 @@ async function createHarness(
     warn: vi.fn(),
     error: vi.fn(),
   }
+  const eventEmit = vi.fn()
 
   await attendancePlugin.activate({
     api: {
       database: db,
-      events: { emit: vi.fn() },
+      events: { emit: eventEmit },
       http: {
         addRoute(method: string, path: string, handler: RouteHandler) {
           routes.set(`${method.toUpperCase()} ${path}`, handler)
@@ -140,7 +141,7 @@ async function createHarness(
   db.query.mockClear()
   db.transaction.mockClear()
 
-  return { db, logger, routes }
+  return { db, eventEmit, logger, routes }
 }
 
 async function invokeRoute(
@@ -3845,6 +3846,71 @@ describe('attendance UUID route validation', () => {
     }
   })
 
+  it('checks foreign fixed-schedule groups before scheduler-scope SQL for non-admin actors', async () => {
+    const cases = [
+      { key: 'PUT /api/attendance/groups/:groupId/fixed-schedule/config', params: { groupId: attendanceGroupId } },
+      { key: 'POST /api/attendance/groups/:id/fixed-schedule/apply', params: { id: attendanceGroupId } },
+      { key: 'POST /api/attendance/groups/:id/fixed-schedule/rebuild', params: { id: attendanceGroupId } },
+      { key: 'POST /api/attendance/groups/:id/fixed-schedule/clear', params: { id: attendanceGroupId } },
+    ]
+
+    for (const testCase of cases) {
+      const { db, routes } = await createHarness('false')
+      db.query.mockImplementation(async (sql: string, params: unknown[] = []) => {
+        const rbac = rbacQueryResult(sql, params)
+        if (rbac !== undefined) return rbac
+        if (sql.includes('SELECT id FROM attendance_groups')) {
+          expect(params, testCase.key).toEqual([attendanceGroupId, 'default'])
+          return []
+        }
+        throw new Error(`unexpected scoped SQL: ${sql}`)
+      })
+
+      const res = await invokeRoute(routes, testCase.key, {
+        params: testCase.params,
+        body: { shiftId, startDate: '2026-06-01', endDate: '2026-06-30' },
+        user: { id: 'scheduler-1', orgId: 'default' },
+      })
+
+      expect(res.statusCode, testCase.key).toBe(404)
+      expect(res.body, testCase.key).toEqual({
+        ok: false,
+        error: { code: 'NOT_FOUND', message: 'Group not found' },
+      })
+      const attendanceSql = db.query.mock.calls
+        .map(([sql]) => String(sql))
+        .filter(sql => sql.includes('attendance_'))
+      expect(attendanceSql, testCase.key).toHaveLength(1)
+      expect(attendanceSql[0], testCase.key).toContain('FROM attendance_groups')
+      expect(attendanceSql[0], testCase.key).not.toContain('attendance_scheduler_scopes')
+      expect(db.transaction, testCase.key).not.toHaveBeenCalled()
+    }
+  })
+
+  it('keeps fixed-schedule preview admin-only at runtime before group SQL', async () => {
+    const { db, eventEmit, routes } = await createHarness('false')
+    db.query.mockImplementation(async (sql: string, params: unknown[] = []) => {
+      const rbac = rbacQueryResult(sql, params)
+      if (rbac !== undefined) return rbac
+      throw new Error(`unexpected scoped SQL: ${sql}`)
+    })
+
+    const res = await invokeRoute(routes, 'POST /api/attendance/groups/:id/fixed-schedule/preview', {
+      params: { id: attendanceGroupId },
+      body: { shiftId, startDate: '2026-06-01', endDate: '2026-06-30' },
+      user: { id: 'scheduler-1', orgId: 'default' },
+    })
+
+    expect(res.statusCode).toBe(403)
+    expect(res.body).toEqual({
+      ok: false,
+      error: { code: 'FORBIDDEN', message: 'Insufficient permissions' },
+    })
+    expect(db.query.mock.calls.map(([sql]) => String(sql)).some(sql => sql.includes('attendance_'))).toBe(false)
+    expect(db.transaction).not.toHaveBeenCalled()
+    expect(eventEmit).not.toHaveBeenCalled()
+  })
+
   it('admits attendance admins through every R0 group-route endpoint without scheduler scope', async () => {
     const cases = [
       { key: 'GET /api/attendance/groups/:id', status: 200 },
@@ -3934,7 +4000,7 @@ describe('attendance UUID route validation', () => {
   })
 
   it('saves fixed-schedule desired config through dispatch authorization without assignment writes', async () => {
-    const { db, routes } = await createHarness('false')
+    const { db, eventEmit, routes } = await createHarness('false')
     const configId = '00000000-0000-4000-8000-000000000399'
     db.query.mockImplementation(async (sql: string, params: unknown[] = []) => {
       const rbac = rbacQueryResult(sql, params, true)
@@ -3972,6 +4038,57 @@ describe('attendance UUID route validation', () => {
     expect(sql).not.toContain('attendance_shift_assignments')
     expect(sql).not.toContain('attendance_notification')
     expect(sql).not.toContain('attendance_outbox')
+    expect(eventEmit).not.toHaveBeenCalled()
+  })
+
+  it('lets a dispatch-scoped non-admin scheduler save fixed-schedule desired config', async () => {
+    const { db, eventEmit, routes } = await createHarness('false')
+    const configId = '00000000-0000-4000-8000-000000000399'
+    db.query.mockImplementation(async (sql: string, params: unknown[] = []) => {
+      const rbac = rbacQueryResult(sql, params)
+      if (rbac !== undefined) return rbac
+      const actor = actorContextQueryResult(sql)
+      if (actor !== undefined) return actor
+      if (sql.includes('SELECT id FROM attendance_groups')) return [{ id: attendanceGroupId }]
+      if (sql.includes('FROM attendance_scheduler_scopes')) {
+        expect(params).toEqual(['default', 'scheduler-1', [], []])
+        return [schedulerScopeFixedScheduleRow(['dispatch'])]
+      }
+      if (sql.includes('SELECT id FROM attendance_shifts')) {
+        expect(params).toEqual([shiftId, 'default'])
+        return [{ id: shiftId }]
+      }
+      if (sql.includes('INSERT INTO attendance_group_fixed_schedule_configs')) {
+        expect(params).toEqual(['default', attendanceGroupId, shiftId, '2026-06-01', '2026-06-30', 'scheduler-1'])
+        return [{
+          id: configId,
+          org_id: 'default',
+          group_id: attendanceGroupId,
+          shift_id: shiftId,
+          start_date: '2026-06-01',
+          end_date: '2026-06-30',
+          revision: 1,
+          updated_by: 'scheduler-1',
+          created_at: '2026-08-03T00:00:00.000Z',
+          updated_at: '2026-08-03T00:00:00.000Z',
+        }]
+      }
+      throw new Error(`unexpected query: ${sql}`)
+    })
+
+    const res = await invokeRoute(routes, 'PUT /api/attendance/groups/:groupId/fixed-schedule/config', {
+      params: { groupId: attendanceGroupId },
+      body: { shiftId, startDate: '2026-06-01', endDate: '2026-06-30' },
+      user: { id: 'scheduler-1', orgId: 'default' },
+    })
+
+    expect(res.statusCode).toBe(200)
+    expect(res.body).toMatchObject({
+      ok: true,
+      data: { id: configId, orgId: 'default', updatedBy: 'scheduler-1' },
+    })
+    expect(db.transaction).toHaveBeenCalledTimes(1)
+    expect(eventEmit).not.toHaveBeenCalled()
   })
 
   it('requires fixed-schedule dispatch authority before saving desired config', async () => {

--- a/packages/core-backend/tests/unit/attendance-uuid-validation-routes.test.ts
+++ b/packages/core-backend/tests/unit/attendance-uuid-validation-routes.test.ts
@@ -3998,8 +3998,42 @@ describe('attendance UUID route validation', () => {
     }
   })
 
-  it('uses authenticated actor context on every existing fixed-schedule route', async () => {
+  it('rejects every forged actor selector on every existing fixed-schedule route', async () => {
     const cases = [
+      { key: 'POST /api/attendance/groups/:id/fixed-schedule/preview', params: { id: attendanceGroupId } },
+      { key: 'POST /api/attendance/groups/:id/fixed-schedule/apply', params: { id: attendanceGroupId } },
+      { key: 'POST /api/attendance/groups/:id/fixed-schedule/rebuild', params: { id: attendanceGroupId } },
+      { key: 'POST /api/attendance/groups/:id/fixed-schedule/clear', params: { id: attendanceGroupId } },
+    ]
+    const body = { shiftId, startDate: '2026-06-01', endDate: '2026-06-30' }
+    const selectors = [
+      { name: 'body org', body: { orgId: 'other-org' } },
+      { name: 'query org', query: { orgId: 'other-org' } },
+      { name: 'header org', headers: { 'x-org-id': 'other-org' } },
+      { name: 'header user', headers: { 'x-user-id': 'forged-user' } },
+    ]
+
+    for (const testCase of cases) {
+      for (const selector of selectors) {
+        const label = `${testCase.key} (${selector.name})`
+        const { db, routes } = await createHarness()
+        const res = await invokeRoute(routes, testCase.key, {
+          params: testCase.params,
+          body: { ...body, ...(selector.body ?? {}) },
+          query: selector.query,
+          headers: selector.headers,
+          user: { id: 'admin-1', orgId: 'default' },
+        })
+        expect(res.statusCode, label).toBe(403)
+        expect(db.query, label).not.toHaveBeenCalled()
+        expect(db.transaction, label).not.toHaveBeenCalled()
+      }
+    }
+  })
+
+  it('fails every fixed-schedule route closed when authenticated actor context is incomplete', async () => {
+    const cases = [
+      { key: 'PUT /api/attendance/groups/:groupId/fixed-schedule/config', params: { groupId: attendanceGroupId } },
       { key: 'POST /api/attendance/groups/:id/fixed-schedule/preview', params: { id: attendanceGroupId } },
       { key: 'POST /api/attendance/groups/:id/fixed-schedule/apply', params: { id: attendanceGroupId } },
       { key: 'POST /api/attendance/groups/:id/fixed-schedule/rebuild', params: { id: attendanceGroupId } },
@@ -4008,38 +4042,28 @@ describe('attendance UUID route validation', () => {
     const body = { shiftId, startDate: '2026-06-01', endDate: '2026-06-30' }
 
     for (const testCase of cases) {
-      const { db, routes } = await createHarness()
-      const res = await invokeRoute(routes, testCase.key, {
+      const { db: missingUserDb, routes: missingUserRoutes } = await createHarness()
+      const missingUser = await invokeRoute(missingUserRoutes, testCase.key, {
         params: testCase.params,
         body,
-        headers: { 'x-user-id': 'forged-user' },
-        user: { id: 'admin-1', orgId: 'default' },
+        user: { orgId: 'default' },
       })
-      expect(res.statusCode, testCase.key).toBe(403)
-      expect(db.query, testCase.key).not.toHaveBeenCalled()
-      expect(db.transaction, testCase.key).not.toHaveBeenCalled()
+      expect(missingUser.statusCode, `${testCase.key} (missing user)`).toBe(401)
+      expect(missingUserDb.query, `${testCase.key} (missing user)`).not.toHaveBeenCalled()
+      expect(missingUserDb.transaction, `${testCase.key} (missing user)`).not.toHaveBeenCalled()
+
+      const { db: missingOrgDb, routes: missingOrgRoutes } = await createHarness()
+      const missingOrg = await invokeRoute(missingOrgRoutes, testCase.key, {
+        params: testCase.params,
+        body,
+        user: { id: 'admin-1' },
+      })
+      expect(missingOrg.statusCode, `${testCase.key} (missing org)`).toBe(403)
+      expect(missingOrg.body, `${testCase.key} (missing org)`).toMatchObject({
+        error: { message: 'Authenticated organization not found' },
+      })
+      expect(missingOrgDb.query, `${testCase.key} (missing org)`).not.toHaveBeenCalled()
+      expect(missingOrgDb.transaction, `${testCase.key} (missing org)`).not.toHaveBeenCalled()
     }
-  })
-
-  it('fails fixed-schedule routes closed when authenticated actor context is incomplete', async () => {
-    const body = { shiftId, startDate: '2026-06-01', endDate: '2026-06-30' }
-    const { db: missingUserDb, routes: missingUserRoutes } = await createHarness()
-    const missingUser = await invokeRoute(missingUserRoutes, 'PUT /api/attendance/groups/:groupId/fixed-schedule/config', {
-      params: { groupId: attendanceGroupId },
-      body,
-      user: { orgId: 'default' },
-    })
-    expect(missingUser.statusCode).toBe(401)
-    expect(missingUserDb.query).not.toHaveBeenCalled()
-
-    const { db: missingOrgDb, routes: missingOrgRoutes } = await createHarness()
-    const missingOrg = await invokeRoute(missingOrgRoutes, 'PUT /api/attendance/groups/:groupId/fixed-schedule/config', {
-      params: { groupId: attendanceGroupId },
-      body,
-      user: { id: 'admin-1' },
-    })
-    expect(missingOrg.statusCode).toBe(403)
-    expect(missingOrg.body).toMatchObject({ error: { message: 'Authenticated organization not found' } })
-    expect(missingOrgDb.query).not.toHaveBeenCalled()
   })
 })

--- a/packages/core-backend/tests/unit/attendance-uuid-validation-routes.test.ts
+++ b/packages/core-backend/tests/unit/attendance-uuid-validation-routes.test.ts
@@ -3910,4 +3910,136 @@ describe('attendance UUID route validation', () => {
     expect(res.statusCode).toBe(200)
     expect(res.body).toMatchObject({ ok: true, data: { id: attendanceGroupId } })
   })
+
+  it('saves fixed-schedule desired config through dispatch authorization without assignment writes', async () => {
+    const { db, routes } = await createHarness('false')
+    const configId = '00000000-0000-4000-8000-000000000399'
+    db.query.mockImplementation(async (sql: string, params: unknown[] = []) => {
+      const rbac = rbacQueryResult(sql, params, true)
+      if (rbac !== undefined) return rbac
+      if (sql.includes('SELECT id FROM attendance_groups')) return [{ id: attendanceGroupId }]
+      if (sql.includes('SELECT id FROM attendance_shifts')) return [{ id: shiftId }]
+      if (sql.includes('INSERT INTO attendance_group_fixed_schedule_configs')) {
+        expect(params).toEqual(['default', attendanceGroupId, shiftId, '2026-06-01', '2026-06-30', 'admin-1'])
+        return [{
+          id: configId,
+          org_id: 'default',
+          group_id: attendanceGroupId,
+          shift_id: shiftId,
+          start_date: '2026-06-01',
+          end_date: '2026-06-30',
+          revision: 1,
+          updated_by: 'admin-1',
+          created_at: '2026-08-03T00:00:00.000Z',
+          updated_at: '2026-08-03T00:00:00.000Z',
+        }]
+      }
+      throw new Error(`unexpected query: ${sql}`)
+    })
+
+    const res = await invokeRoute(routes, 'PUT /api/attendance/groups/:groupId/fixed-schedule/config', {
+      params: { groupId: attendanceGroupId },
+      body: { shiftId, startDate: '2026-06-01', endDate: '2026-06-30' },
+      user: { id: 'admin-1', orgId: 'default' },
+    })
+
+    expect(res.statusCode).toBe(200)
+    expect(res.body).toMatchObject({ ok: true, data: { id: configId, revision: 1, updatedBy: 'admin-1' } })
+    expect(db.transaction).toHaveBeenCalledTimes(1)
+    const sql = db.query.mock.calls.map(([statement]) => String(statement)).join('\n')
+    expect(sql).not.toContain('attendance_shift_assignments')
+    expect(sql).not.toContain('attendance_notification')
+    expect(sql).not.toContain('attendance_outbox')
+  })
+
+  it('requires fixed-schedule dispatch authority before saving desired config', async () => {
+    const { db, routes } = await createHarness('false')
+    db.query.mockImplementation(async (sql: string, params: unknown[] = []) => {
+      const rbac = rbacQueryResult(sql, params)
+      if (rbac !== undefined) return rbac
+      const actor = actorContextQueryResult(sql)
+      if (actor !== undefined) return actor
+      if (sql.includes('SELECT id FROM attendance_groups')) return [{ id: attendanceGroupId }]
+      if (sql.includes('FROM attendance_scheduler_scopes')) return [schedulerScopeFixedScheduleRow(['clear'])]
+      throw new Error(`unexpected query: ${sql}`)
+    })
+
+    const res = await invokeRoute(routes, 'PUT /api/attendance/groups/:groupId/fixed-schedule/config', {
+      params: { groupId: attendanceGroupId },
+      body: { shiftId, startDate: '2026-06-01', endDate: '2026-06-30' },
+      user: { id: 'scheduler-1', orgId: 'default' },
+    })
+
+    expect(res.statusCode).toBe(403)
+    expect(res.body).toMatchObject({ ok: false, error: { code: 'SCHEDULER_SCOPE_FORBIDDEN' } })
+    expect(db.transaction).not.toHaveBeenCalled()
+  })
+
+  it('rejects fixed-schedule actor and organization spoofing before scoped SQL', async () => {
+    const cases = [
+      { name: 'body org', options: { body: { shiftId, startDate: '2026-06-01', endDate: '2026-06-30', orgId: 'other-org' } } },
+      { name: 'query org', options: { query: { orgId: 'other-org' } } },
+      { name: 'header org', options: { headers: { 'x-org-id': 'other-org' } } },
+      { name: 'header user', options: { headers: { 'x-user-id': 'other-user' } } },
+    ]
+    const defaultBody = { shiftId, startDate: '2026-06-01', endDate: '2026-06-30' }
+
+    for (const testCase of cases) {
+      const { db, routes } = await createHarness()
+      const res = await invokeRoute(routes, 'PUT /api/attendance/groups/:groupId/fixed-schedule/config', {
+        params: { groupId: attendanceGroupId },
+        body: defaultBody,
+        ...testCase.options,
+        user: { id: 'admin-1', orgId: 'default' },
+      })
+      expect(res.statusCode, testCase.name).toBe(403)
+      expect(db.query, testCase.name).not.toHaveBeenCalled()
+      expect(db.transaction, testCase.name).not.toHaveBeenCalled()
+    }
+  })
+
+  it('uses authenticated actor context on every existing fixed-schedule route', async () => {
+    const cases = [
+      { key: 'POST /api/attendance/groups/:id/fixed-schedule/preview', params: { id: attendanceGroupId } },
+      { key: 'POST /api/attendance/groups/:id/fixed-schedule/apply', params: { id: attendanceGroupId } },
+      { key: 'POST /api/attendance/groups/:id/fixed-schedule/rebuild', params: { id: attendanceGroupId } },
+      { key: 'POST /api/attendance/groups/:id/fixed-schedule/clear', params: { id: attendanceGroupId } },
+    ]
+    const body = { shiftId, startDate: '2026-06-01', endDate: '2026-06-30' }
+
+    for (const testCase of cases) {
+      const { db, routes } = await createHarness()
+      const res = await invokeRoute(routes, testCase.key, {
+        params: testCase.params,
+        body,
+        headers: { 'x-user-id': 'forged-user' },
+        user: { id: 'admin-1', orgId: 'default' },
+      })
+      expect(res.statusCode, testCase.key).toBe(403)
+      expect(db.query, testCase.key).not.toHaveBeenCalled()
+      expect(db.transaction, testCase.key).not.toHaveBeenCalled()
+    }
+  })
+
+  it('fails fixed-schedule routes closed when authenticated actor context is incomplete', async () => {
+    const body = { shiftId, startDate: '2026-06-01', endDate: '2026-06-30' }
+    const { db: missingUserDb, routes: missingUserRoutes } = await createHarness()
+    const missingUser = await invokeRoute(missingUserRoutes, 'PUT /api/attendance/groups/:groupId/fixed-schedule/config', {
+      params: { groupId: attendanceGroupId },
+      body,
+      user: { orgId: 'default' },
+    })
+    expect(missingUser.statusCode).toBe(401)
+    expect(missingUserDb.query).not.toHaveBeenCalled()
+
+    const { db: missingOrgDb, routes: missingOrgRoutes } = await createHarness()
+    const missingOrg = await invokeRoute(missingOrgRoutes, 'PUT /api/attendance/groups/:groupId/fixed-schedule/config', {
+      params: { groupId: attendanceGroupId },
+      body,
+      user: { id: 'admin-1' },
+    })
+    expect(missingOrg.statusCode).toBe(403)
+    expect(missingOrg.body).toMatchObject({ error: { message: 'Authenticated organization not found' } })
+    expect(missingOrgDb.query).not.toHaveBeenCalled()
+  })
 })

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -642,6 +642,9 @@ export default defineConfig({
       // DecisionTrace evidence and strict persisted-schema parsing against real Postgres.
       // Kept out of the no-DB run and invoked by whole filename in plugin-tests.yml.
       'tests/integration/attendance-w4c4-calculation-detail.db.test.ts',
+      // #4709 FSER-1 desired-config migration, composite FKs, idempotent writes,
+      // and reference-writer/delete lock protocol against real PostgreSQL.
+      'tests/integration/attendance-group-fixed-schedule-config-migration.db.test.ts',
       // #4556 W2 adds route-level work-date attribution legs to this whole-file real-DB
       // suite. Keep it out of the no-DB lane so describeDb cannot report skipped green;
       // plugin-tests.yml executes the complete file with ATTENDANCE_TEST_DATABASE_URL.

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -13,6 +13,7 @@ const { DEFAULT_TEMPLATES } = require('./engine/template-library.cjs')
 const attendanceWorkDateResolverLib = require('./lib/attendance-work-date-resolver.cjs')
 const attendanceWorkDateAdaptersLib = require('./lib/attendance-work-date-adapters.cjs')
 const attendanceShiftServiceLib = require('./lib/attendance-shift-service.cjs')
+const attendanceGroupFixedScheduleConfigServiceLib = require('./lib/attendance-group-fixed-schedule-config-service.cjs')
 const {
   DEFAULT_ATTRIBUTION_TAIL_MINUTES,
   MAX_ATTRIBUTION_TAIL_MINUTES,
@@ -8319,6 +8320,15 @@ function getAttendanceShiftService() {
     })
   }
   return attendanceShiftService
+}
+
+let attendanceGroupFixedScheduleConfigService = null
+function getAttendanceGroupFixedScheduleConfigService() {
+  if (!attendanceGroupFixedScheduleConfigService) {
+    attendanceGroupFixedScheduleConfigService = attendanceGroupFixedScheduleConfigServiceLib
+      .createAttendanceGroupFixedScheduleConfigService({ HttpError })
+  }
+  return attendanceGroupFixedScheduleConfigService
 }
 
 function assertWorkContextSegmentCalculationAllowed(orgId, workContext) {
@@ -24692,6 +24702,38 @@ module.exports = {
       if (!violation) return true
       respondShiftEditWindowExceeded(res, violation)
       return false
+    }
+
+    async function resolveAttendanceFixedScheduleRouteActorContext(req, res) {
+      const userId = getAuthenticatedUserId(req)
+      if (!userId) {
+        res.status(401).json({ ok: false, error: { code: 'UNAUTHORIZED', message: 'User ID not found' } })
+        return null
+      }
+      const orgId = getAuthenticatedOrgId(req)
+      if (!orgId) {
+        res.status(403).json({ ok: false, error: { code: 'FORBIDDEN', message: 'Authenticated organization not found' } })
+        return null
+      }
+
+      const orgSelectors = [req.body?.orgId, req.query?.orgId, req.headers['x-org-id']]
+        .flatMap(value => Array.isArray(value) ? value : [value])
+        .filter(value => value !== undefined && value !== null)
+      const userSelectors = [req.headers['x-user-id']]
+        .flatMap(value => Array.isArray(value) ? value : [value])
+        .filter(value => value !== undefined && value !== null)
+      if (orgSelectors.some(value => value !== orgId) || userSelectors.some(value => value !== userId)) {
+        res.status(403).json({ ok: false, error: { code: 'FORBIDDEN', message: 'Insufficient permissions' } })
+        return null
+      }
+
+      try {
+        return { userId, orgId, fullAdmin: await hasAttendanceAdminAccess(userId) }
+      } catch (error) {
+        logger.error('Attendance fixed schedule actor resolution failed', error)
+        res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Permission check failed' } })
+        return null
+      }
     }
 
     async function resolveAttendanceSchedulerScopeActor(req, res) {
@@ -44173,10 +44215,80 @@ module.exports = {
     )
 
     context.api.http.addRoute(
+      'PUT',
+      '/api/attendance/groups/:groupId/fixed-schedule/config',
+      async (req, res) => {
+        const actorAccess = await resolveAttendanceFixedScheduleRouteActorContext(req, res)
+        if (!actorAccess) return
+        const schema = z.object({
+          shiftId: z.string().min(1),
+          startDate: z.string().min(1),
+          endDate: z.string().min(1),
+          orgId: z.string().optional(),
+        }).strict()
+        const parsed = schema.safeParse(req.body ?? {})
+        if (!parsed.success) {
+          res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: parsed.error.message } })
+          return
+        }
+
+        const groupId = normalizeUuidString(req.params.groupId)
+        if (!groupId) {
+          respondInvalidUuid(res, 'groupId')
+          return
+        }
+        const shiftId = normalizeUuidString(parsed.data.shiftId)
+        if (!shiftId) {
+          respondInvalidUuid(res, 'shiftId')
+          return
+        }
+        const startDate = normalizeDateOnlyStrict(parsed.data.startDate)
+        const endDate = normalizeDateOnlyStrict(parsed.data.endDate)
+        if (!startDate || !endDate || startDate > endDate) {
+          res.status(400).json({
+            ok: false,
+            error: { code: 'VALIDATION_ERROR', message: 'A valid startDate on or before endDate is required.' },
+          })
+          return
+        }
+
+        try {
+          const groupExists = await assertAttendanceGroupInActorOrg(db, res, {
+            groupId,
+            orgId: actorAccess.orgId,
+          })
+          if (!groupExists) return
+          const access = await assertAttendanceGroupFixedScheduleDispatchAllowed(req, res, { groupId, actorAccess })
+          if (!access) return
+          const config = await db.transaction(trx => getAttendanceGroupFixedScheduleConfigService().upsertConfig(trx, {
+            orgId: access.orgId,
+            groupId,
+            shiftId,
+            startDate,
+            endDate,
+            updatedBy: access.userId,
+          }))
+          res.json({ ok: true, data: config })
+        } catch (error) {
+          if (error instanceof HttpError) {
+            res.status(error.status).json({ ok: false, error: { code: error.code, message: error.message } })
+            return
+          }
+          if (isDatabaseSchemaError(error)) {
+            res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: 'Attendance tables missing' } })
+            return
+          }
+          logger.error('Attendance group fixed schedule config save failed', error)
+          res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to save fixed schedule config' } })
+        }
+      }
+    )
+
+    context.api.http.addRoute(
       'POST',
       '/api/attendance/groups/:id/fixed-schedule/preview',
       withPermission('attendance:admin', async (req, res) => {
-        const actorAccess = resolveAttendanceGroupRouteActorContext(req, res)
+        const actorAccess = await resolveAttendanceFixedScheduleRouteActorContext(req, res)
         if (!actorAccess) return
         const schema = z.object({
           shiftId: z.string().min(1),
@@ -44252,8 +44364,8 @@ module.exports = {
     context.api.http.addRoute(
       'POST',
       '/api/attendance/groups/:id/fixed-schedule/apply',
-      withPermission('attendance:admin', async (req, res) => {
-        const actorAccess = resolveAttendanceGroupRouteActorContext(req, res)
+      async (req, res) => {
+        const actorAccess = await resolveAttendanceFixedScheduleRouteActorContext(req, res)
         if (!actorAccess) return
         const schema = z.object({
           shiftId: z.string().min(1),
@@ -44297,7 +44409,7 @@ module.exports = {
         try {
           const groupExists = await assertAttendanceGroupInActorOrg(db, res, { groupId, orgId })
           if (!groupExists) return
-          const access = await assertAttendanceGroupFixedScheduleDispatchAllowed(req, res, { groupId })
+          const access = await assertAttendanceGroupFixedScheduleDispatchAllowed(req, res, { groupId, actorAccess })
           if (!access) return
 
           const result = await db.transaction((trx) => applyAttendanceGroupFixedSchedule(trx, {
@@ -44332,14 +44444,14 @@ module.exports = {
           logger.error('Attendance group fixed schedule apply failed', error)
           res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to apply fixed schedule' } })
         }
-      })
+      }
     )
 
     context.api.http.addRoute(
       'POST',
       '/api/attendance/groups/:id/fixed-schedule/rebuild',
-      withPermission('attendance:admin', async (req, res) => {
-        const actorAccess = resolveAttendanceGroupRouteActorContext(req, res)
+      async (req, res) => {
+        const actorAccess = await resolveAttendanceFixedScheduleRouteActorContext(req, res)
         if (!actorAccess) return
         const schema = z.object({
           shiftId: z.string().min(1),
@@ -44383,7 +44495,7 @@ module.exports = {
         try {
           const groupExists = await assertAttendanceGroupInActorOrg(db, res, { groupId, orgId })
           if (!groupExists) return
-          const access = await assertAttendanceGroupFixedScheduleRebuildAllowed(req, res, { groupId })
+          const access = await assertAttendanceGroupFixedScheduleRebuildAllowed(req, res, { groupId, actorAccess })
           if (!access) return
 
           const result = await db.transaction((trx) => rebuildAttendanceGroupFixedSchedule(trx, {
@@ -44421,14 +44533,14 @@ module.exports = {
           logger.error('Attendance group fixed schedule rebuild failed', error)
           res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to rebuild fixed schedule' } })
         }
-      })
+      }
     )
 
     context.api.http.addRoute(
       'POST',
       '/api/attendance/groups/:id/fixed-schedule/clear',
-      withPermission('attendance:admin', async (req, res) => {
-        const actorAccess = resolveAttendanceGroupRouteActorContext(req, res)
+      async (req, res) => {
+        const actorAccess = await resolveAttendanceFixedScheduleRouteActorContext(req, res)
         if (!actorAccess) return
         const schema = z.object({
           shiftId: z.string().min(1),
@@ -44472,7 +44584,7 @@ module.exports = {
         try {
           const groupExists = await assertAttendanceGroupInActorOrg(db, res, { groupId, orgId })
           if (!groupExists) return
-          const access = await assertAttendanceGroupFixedScheduleClearAllowed(req, res, { groupId })
+          const access = await assertAttendanceGroupFixedScheduleClearAllowed(req, res, { groupId, actorAccess })
           if (!access) return
 
           const result = await db.transaction((trx) => clearAttendanceGroupFixedScheduleManagedRows(trx, {
@@ -44494,7 +44606,7 @@ module.exports = {
           logger.error('Attendance group fixed schedule clear failed', error)
           res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to clear fixed schedule' } })
         }
-      })
+      }
     )
 
     const scheduleGroupSchema = z.object({

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -44287,9 +44287,13 @@ module.exports = {
     context.api.http.addRoute(
       'POST',
       '/api/attendance/groups/:id/fixed-schedule/preview',
-      withPermission('attendance:admin', async (req, res) => {
+      async (req, res) => {
         const actorAccess = await resolveAttendanceFixedScheduleRouteActorContext(req, res)
         if (!actorAccess) return
+        if (!actorAccess.fullAdmin) {
+          res.status(403).json({ ok: false, error: { code: 'FORBIDDEN', message: 'Insufficient permissions' } })
+          return
+        }
         const schema = z.object({
           shiftId: z.string().min(1),
           startDate: z.string().min(1),
@@ -44358,7 +44362,7 @@ module.exports = {
           logger.error('Attendance group fixed schedule preview failed', error)
           res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to preview fixed schedule' } })
         }
-      })
+      }
     )
 
     context.api.http.addRoute(

--- a/plugins/plugin-attendance/lib/attendance-group-fixed-schedule-config-service.cjs
+++ b/plugins/plugin-attendance/lib/attendance-group-fixed-schedule-config-service.cjs
@@ -1,0 +1,85 @@
+'use strict'
+
+function createAttendanceGroupFixedScheduleConfigService({ HttpError }) {
+  function formatDateOnly(value) {
+    if (value instanceof Date) {
+      return [value.getFullYear(), value.getMonth() + 1, value.getDate()]
+        .map((part, index) => index === 0 ? String(part) : String(part).padStart(2, '0'))
+        .join('-')
+    }
+    const normalized = String(value)
+    const match = normalized.match(/^\d{4}-\d{2}-\d{2}/)
+    return match ? match[0] : normalized
+  }
+
+  function mapConfigRow(row) {
+    return {
+      id: row.id,
+      orgId: row.org_id,
+      groupId: row.group_id,
+      shiftId: row.shift_id,
+      startDate: formatDateOnly(row.start_date),
+      endDate: formatDateOnly(row.end_date),
+      revision: Number(row.revision),
+      updatedBy: row.updated_by,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+    }
+  }
+
+  async function upsertConfig(trx, input) {
+    const groupRows = await trx.query(
+      'SELECT id FROM attendance_groups WHERE id = $1 AND org_id = $2 LIMIT 1',
+      [input.groupId, input.orgId],
+    )
+    if (!groupRows.length) {
+      throw new HttpError(404, 'NOT_FOUND', 'Group not found')
+    }
+
+    const shiftRows = await trx.query(
+      'SELECT id FROM attendance_shifts WHERE id = $1 AND org_id = $2 LIMIT 1',
+      [input.shiftId, input.orgId],
+    )
+    if (!shiftRows.length) {
+      throw new HttpError(404, 'NOT_FOUND', 'Shift not found')
+    }
+
+    const rows = await trx.query(
+      `INSERT INTO attendance_group_fixed_schedule_configs
+         (org_id, group_id, shift_id, start_date, end_date, revision, updated_by, created_at, updated_at)
+       VALUES ($1, $2, $3, $4, $5, 1, $6, now(), now())
+       ON CONFLICT (org_id, group_id) DO UPDATE
+       SET shift_id = EXCLUDED.shift_id,
+           start_date = EXCLUDED.start_date,
+           end_date = EXCLUDED.end_date,
+           revision = CASE
+             WHEN attendance_group_fixed_schedule_configs.shift_id IS DISTINCT FROM EXCLUDED.shift_id
+               OR attendance_group_fixed_schedule_configs.start_date IS DISTINCT FROM EXCLUDED.start_date
+               OR attendance_group_fixed_schedule_configs.end_date IS DISTINCT FROM EXCLUDED.end_date
+             THEN attendance_group_fixed_schedule_configs.revision + 1
+             ELSE attendance_group_fixed_schedule_configs.revision
+           END,
+           updated_by = CASE
+             WHEN attendance_group_fixed_schedule_configs.shift_id IS DISTINCT FROM EXCLUDED.shift_id
+               OR attendance_group_fixed_schedule_configs.start_date IS DISTINCT FROM EXCLUDED.start_date
+               OR attendance_group_fixed_schedule_configs.end_date IS DISTINCT FROM EXCLUDED.end_date
+             THEN EXCLUDED.updated_by
+             ELSE attendance_group_fixed_schedule_configs.updated_by
+           END,
+           updated_at = CASE
+             WHEN attendance_group_fixed_schedule_configs.shift_id IS DISTINCT FROM EXCLUDED.shift_id
+               OR attendance_group_fixed_schedule_configs.start_date IS DISTINCT FROM EXCLUDED.start_date
+               OR attendance_group_fixed_schedule_configs.end_date IS DISTINCT FROM EXCLUDED.end_date
+             THEN now()
+             ELSE attendance_group_fixed_schedule_configs.updated_at
+           END
+       RETURNING *`,
+      [input.orgId, input.groupId, input.shiftId, input.startDate, input.endDate, input.updatedBy],
+    )
+    return mapConfigRow(rows[0])
+  }
+
+  return { upsertConfig, mapConfigRow }
+}
+
+module.exports = { createAttendanceGroupFixedScheduleConfigService }

--- a/plugins/plugin-attendance/lib/attendance-group-fixed-schedule-config-service.cjs
+++ b/plugins/plugin-attendance/lib/attendance-group-fixed-schedule-config-service.cjs
@@ -37,7 +37,7 @@ function createAttendanceGroupFixedScheduleConfigService({ HttpError }) {
     }
 
     const shiftRows = await trx.query(
-      'SELECT id FROM attendance_shifts WHERE id = $1 AND org_id = $2 LIMIT 1',
+      'SELECT id FROM attendance_shifts WHERE id = $1 AND org_id = $2 FOR SHARE',
       [input.shiftId, input.orgId],
     )
     if (!shiftRows.length) {

--- a/plugins/plugin-attendance/lib/attendance-shift-service.cjs
+++ b/plugins/plugin-attendance/lib/attendance-shift-service.cjs
@@ -639,7 +639,7 @@ function createAttendanceShiftService(deps) {
    * ended/inactive history), any rotation-rule shift_sequence reference (id or
    * legacy name; rotation assignments are protected indirectly through their
    * rule), a pending swap requester/counterparty snapshot, or a
-   * pending/published dispatch target. Rejected swap snapshots, cancelled
+   * pending/published dispatch target, or desired fixed-schedule config. Rejected swap snapshots, cancelled
    * dispatch snapshots, and auto-write candidate ids are immutable historical
    * evidence and deliberately NOT blockers.
    */
@@ -651,6 +651,13 @@ function createAttendanceShiftService(deps) {
     )
     const assignmentCount = Number(assignmentRows[0]?.total ?? 0)
     if (assignmentCount > 0) blockers.push({ blocker: 'shift_assignments', count: assignmentCount })
+
+    const fixedConfigRows = await trx.query(
+      'SELECT COUNT(*)::int AS total FROM attendance_group_fixed_schedule_configs WHERE org_id = $1 AND shift_id = $2',
+      [orgId, shiftId],
+    )
+    const fixedConfigCount = Number(fixedConfigRows[0]?.total ?? 0)
+    if (fixedConfigCount > 0) blockers.push({ blocker: 'fixed_schedule_configs', count: fixedConfigCount })
 
     const rotationRows = await trx.query(
       `SELECT COUNT(*)::int AS total

--- a/plugins/plugin-integration-core/lib/sealed-export/vectors/s6a-package-provenance-pins.json
+++ b/plugins/plugin-integration-core/lib/sealed-export/vectors/s6a-package-provenance-pins.json
@@ -86,6 +86,6 @@
     "s6aAcceptancePs51Test": "835c7c6ce943d82e0378a40a27c7fd1e8b79b526faa8ca4c8066e4231a4bfb0f",
     "s6aProductRuntimeTest": "de978adafa8b89772cefa921c2051f434bf346bf5c2978bef3424ee70f51ba3f",
     "multitableOnpremPackageBuild": "463c7d73c6c7f2d1b6cdf0820d7a06974a9c463dd5e98bbbaf1c996e1dc4ed99",
-    "pluginTestsWorkflow": "1711522e4459ebb8f1dfd71b7a0d38e4f7bc316f7cf03ee497a8a142a3cf66a6"
+    "pluginTestsWorkflow": "e53fa3439f43d5fe43ac5f635bc1d69e576995195a5d4ca4885fa5c8a1fb071f"
   }
 }

--- a/scripts/attendance/w4c0-dml-inventory/table-classification.cjs
+++ b/scripts/attendance/w4c0-dml-inventory/table-classification.cjs
@@ -83,6 +83,7 @@ const TABLE_BUCKETS = Object.freeze({
   attendance_groups: 'reference',
   attendance_group_members: 'reference',
   attendance_group_managers: 'reference',
+  attendance_group_fixed_schedule_configs: 'reference',
   attendance_schedule_groups: 'reference',
   attendance_schedule_group_members: 'reference',
   attendance_holidays: 'reference',

--- a/scripts/ops/attendance-w4c2-ci-wiring.test.mjs
+++ b/scripts/ops/attendance-w4c2-ci-wiring.test.mjs
@@ -118,6 +118,9 @@ const FILES = Object.freeze([
   'tests/integration/attendance-w4c3c-manual-recompute-retirement.db.test.ts',
   // W4C-3c plugin HTTP routes through actual loader (auth/capability/operationId).
   'tests/integration/attendance-w4c3c-record-operation-routes.db.test.ts',
+  // #4709 FSER-1 desired-config schema, lifecycle, and reference-lock proof.
+  // Keep it excluded from the no-DB lane and whole-file wired into the attendance step.
+  'tests/integration/attendance-group-fixed-schedule-config-migration.db.test.ts',
 ])
 
 /**


### PR DESCRIPTION
## Status

**READY \/ MERGE AUTHORIZED.** Exact-head gates are complete. Downstream FSER-2\/3 merge, flags, deployment, soak, production\/customer data, and issue closure remain unauthorized./

## What changed

- Add one desired fixed-schedule config per organization/group with composite organization FKs and replay-safe migration.
- Add the dispatch-authorized config PUT route using only authenticated actor and organization context.
- Preserve identical replays and increment revision only when shift/start/end changes.
- Protect the referenced shift between validation and upsert with a transaction-scoped `FOR SHARE` lock.
- Resolve trusted actor/selectors before preview permission SQL; header fallback cannot preempt the authenticated-principal gate.
- Add the canonical typed shift-delete blocker for referenced desired configs.
- Register the new table as a reference writer in the generated W4 DML inventory.
- Keep config persistence separate from assignment, event, notification, and outbox writes.
- Wire the PostgreSQL suite into the required attendance real-DB step and exclude it from the no-DB skip-green lane.
- Preserve the shared attendance group organization key when an earlier migration rolls back while this slice's foreign key still depends on it.

## Verification

- Fixed-schedule route/source suites: 84\/84 PASS, including real-RBAC selector, missing-principal ordering, and actor-first preview admin guard.
- Isolated real PostgreSQL migration/service suite: 7\/7 PASS, including writer-versus-delete locking and cross-migration rollback dependency preservation.
- The four CI paths that previously stopped at `Authenticated organization not found` now reach their intended fixed-schedule outcomes: 4/4 PASS.
- `FOR SHARE` mutation: removing the lock makes the concurrency leg fail with a deleted-parent FK violation instead of typed 409.
- Attendance real-DB two-point wiring contract: 93/93 PASS; removing the workflow whole-file entry or no-DB exclusion makes the guard red.
- W4 DML inventory collector: 58/58 PASS.
- Sealed-export workflow provenance pin: SHA-256 matches and the hermetic package-provenance test PASS.
- Backend type-check: PASS.
- `git diff --check`: PASS.

## Contract

- Ratified lock: `docs/development/attendance-4709-fixed-schedule-effectiveness-read-model-design-lock-20260801.md`.
- Contract residual recorded honestly: section 5 says the first slice adds GET effectiveness while section 8 assigns pure derivation/read route to FSER-2. This PR follows the ratified slice table and owner authorization: it adds no GET, derivation, or stub.
- No FSER-2/3 runtime, assignment/event/outbox side effect, flag, deployment, soak, production data, or customer data change is included.