### PR TITLE
fix(sealed-export): S6-A migration 074 — grant the row-lock and RETURNING privileges 073 omitted

### DIFF
--- a/.github/workflows/sealed-export-s5-sqlserver.yml
+++ b/.github/workflows/sealed-export-s5-sqlserver.yml
@@ -33,8 +33,10 @@ on:
       - 'packages/core-backend/migrations/071_harden_integration_sealed_export_authority_lifecycle.sql'
       - 'packages/core-backend/migrations/072_harden_integration_sealed_export_terminal_signer_history.sql'
       - 'packages/core-backend/migrations/073_create_sealed_export_stock_prep_runtime_authority.sql'
+      - 'packages/core-backend/migrations/074_repair_sealed_export_runtime_authority_privileges.sql'
       - 'packages/core-backend/tests/integration/sealed-export-signer-authority-lifecycle-migration.db.test.ts'
       - 'packages/core-backend/tests/integration/sealed-export-s6a-runtime-authority.db.test.ts'
+      - 'packages/core-backend/tests/integration/sealed-export-s6a-grant-repair.db.test.ts'
       - 'scripts/ops/run-sealed-export-s5-sqlserver-evidence.cjs'
       - 'scripts/ops/verify-sealed-export-s5-sqlserver-evidence.cjs'
       - 'scripts/ops/stock-preparation-s6a-onprem-acceptance.ps1'
@@ -202,6 +204,13 @@ jobs:
           pnpm --filter @metasheet/core-backend exec vitest
           --config vitest.integration.config.ts run
           tests/integration/sealed-export-s6a-runtime-authority.db.test.ts
+          --reporter=dot
+
+      - name: Run real-Postgres S6-A grant-repair gate (migration 074)
+        run: >-
+          pnpm --filter @metasheet/core-backend exec vitest
+          --config vitest.integration.config.ts run
+          tests/integration/sealed-export-s6a-grant-repair.db.test.ts
           --reporter=dot
 
       - name: Download sealed-export S5 evidence

--- a/.github/workflows/sealed-export-s5-sqlserver.yml
+++ b/.github/workflows/sealed-export-s5-sqlserver.yml
@@ -33,10 +33,8 @@ on:
       - 'packages/core-backend/migrations/071_harden_integration_sealed_export_authority_lifecycle.sql'
       - 'packages/core-backend/migrations/072_harden_integration_sealed_export_terminal_signer_history.sql'
       - 'packages/core-backend/migrations/073_create_sealed_export_stock_prep_runtime_authority.sql'
-      - 'packages/core-backend/migrations/074_repair_sealed_export_runtime_authority_privileges.sql'
       - 'packages/core-backend/tests/integration/sealed-export-signer-authority-lifecycle-migration.db.test.ts'
       - 'packages/core-backend/tests/integration/sealed-export-s6a-runtime-authority.db.test.ts'
-      - 'packages/core-backend/tests/integration/sealed-export-s6a-grant-repair.db.test.ts'
       - 'scripts/ops/run-sealed-export-s5-sqlserver-evidence.cjs'
       - 'scripts/ops/verify-sealed-export-s5-sqlserver-evidence.cjs'
       - 'scripts/ops/stock-preparation-s6a-onprem-acceptance.ps1'
@@ -204,13 +202,6 @@ jobs:
           pnpm --filter @metasheet/core-backend exec vitest
           --config vitest.integration.config.ts run
           tests/integration/sealed-export-s6a-runtime-authority.db.test.ts
-          --reporter=dot
-
-      - name: Run real-Postgres S6-A grant-repair gate (migration 074)
-        run: >-
-          pnpm --filter @metasheet/core-backend exec vitest
-          --config vitest.integration.config.ts run
-          tests/integration/sealed-export-s6a-grant-repair.db.test.ts
           --reporter=dot
 
       - name: Download sealed-export S5 evidence

--- a/.github/workflows/sealed-export-s6a-grant-repair.yml
+++ b/.github/workflows/sealed-export-s6a-grant-repair.yml
@@ -1,0 +1,98 @@
+name: Sealed-export S6-A grant repair (migration 074) gate
+
+# EVIDENCE ONLY. Ephemeral first-party PostgreSQL container. This workflow
+# proves that migration 074 grants exactly the privileges migration 073 omitted
+# and nothing more. It does not connect a customer source, deploy a package,
+# enable a flag, or authorize rollout.
+#
+# This gate deliberately lives in its own workflow file:
+# .github/workflows/sealed-export-s5-sqlserver.yml is a PINNED evidence input
+# of the frozen S6-A package (sealed-export-package-provenance.cjs
+# PINNED_EVIDENCE_FILES 's5EvidenceWorkflow'), so editing it would change frozen
+# package-provenance evidence. It is left byte-identical.
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - 'packages/core-backend/migrations/057_create_integration_core_tables.sql'
+      - 'packages/core-backend/migrations/068_create_integration_sealed_export_ingestion.sql'
+      - 'packages/core-backend/migrations/069_create_integration_sealed_export_generation_kernel.sql'
+      - 'packages/core-backend/migrations/070_create_integration_sealed_export_signer_authority.sql'
+      - 'packages/core-backend/migrations/071_harden_integration_sealed_export_authority_lifecycle.sql'
+      - 'packages/core-backend/migrations/072_harden_integration_sealed_export_terminal_signer_history.sql'
+      - 'packages/core-backend/migrations/073_create_sealed_export_stock_prep_runtime_authority.sql'
+      - 'packages/core-backend/migrations/074_repair_sealed_export_runtime_authority_privileges.sql'
+      - 'packages/core-backend/tests/integration/sealed-export-s6a-grant-repair.db.test.ts'
+      - 'plugins/plugin-integration-core/lib/db.cjs'
+      - 'plugins/plugin-integration-core/lib/sealed-export/sealed-export-lifecycle-provisioning.cjs'
+      - 'plugins/plugin-integration-core/lib/sealed-export/stock-preparation-runtime-database.cjs'
+      - '.github/workflows/sealed-export-s6a-grant-repair.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  grant-repair-gate:
+    name: Sealed-export S6-A grant repair gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: metasheet_s6a_grant_repair
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d metasheet_s6a_grant_repair"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 20
+    env:
+      DATABASE_URL: postgresql://postgres:postgres@127.0.0.1:5432/metasheet_s6a_grant_repair
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js 20.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.16.1
+          run_install: false
+
+      - name: Use empty npmrc for pnpm
+        run: |
+          echo "" > /tmp/empty-npmrc
+          echo "NPM_CONFIG_USERCONFIG=/tmp/empty-npmrc" >> "$GITHUB_ENV"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run real-Postgres S6-A grant-repair gate (migration 074)
+        run: >-
+          pnpm --filter @metasheet/core-backend exec vitest
+          --config vitest.integration.config.ts run
+          tests/integration/sealed-export-s6a-grant-repair.db.test.ts
+          --reporter=dot
+
+      - name: Confirm the pinned S5 evidence workflow was not modified
+        run: |
+          pinned="$(node -e "
+            const pins = require('./plugins/plugin-integration-core/lib/sealed-export/vectors/s6a-package-provenance-pins.json');
+            process.stdout.write(pins.evidenceFiles.s5EvidenceWorkflow);
+          ")"
+          actual="$(sha256sum .github/workflows/sealed-export-s5-sqlserver.yml | cut -d' ' -f1)"
+          if [ "$pinned" != "$actual" ]; then
+            echo "pinned S5 evidence workflow digest drifted"
+            exit 1
+          fi
+          echo "pinned S5 evidence workflow digest unchanged"

--- a/packages/core-backend/migrations/074_repair_sealed_export_runtime_authority_privileges.sql
+++ b/packages/core-backend/migrations/074_repair_sealed_export_runtime_authority_privileges.sql
@@ -1,0 +1,162 @@
+-- 074_repair_sealed_export_runtime_authority_privileges.sql
+-- S6-A privilege repair for migration 073 (#4693 follow-up).
+--
+-- 073 is already applied on main and is a pinned input of the frozen S6-A
+-- package, so it MUST NOT be amended in place. This migration adds only the
+-- privileges 073 omitted; it creates no object and revokes nothing.
+--
+-- Gap 1 — provisioning role cannot lock signer public-key rows.
+--   073:619-624 grants SELECT, INSERT on
+--   integration_sealed_export_signer_public_keys to the provisioning role, but
+--   plugins/plugin-integration-core/lib/sealed-export/
+--   sealed-export-lifecycle-provisioning.cjs:505
+--   (provisionInitialStockPreparationBinding) reads that row with
+--   trx.selectOneForUpdate(PUBLIC_KEY_TABLE, ...), and
+--   plugins/plugin-integration-core/lib/db.cjs:212 emits
+--   `SELECT * FROM <table> WHERE ... LIMIT 1 FOR UPDATE`.
+--   PostgreSQL requires UPDATE on AT LEAST ONE COLUMN, in addition to SELECT,
+--   for row-level locking clauses. The minimal grant is therefore a
+--   column-level UPDATE, not table-level UPDATE. `updated_at` is chosen because
+--   the BEFORE UPDATE trigger installed by
+--   070_create_integration_sealed_export_signer_authority.sql:62-65
+--   (integration_set_updated_at, 057:182-188) overwrites it unconditionally
+--   with NOW(), so the only capability added is "acquire the row lock": no
+--   column carrying key material becomes writable, and no row becomes
+--   deletable. Note that has_table_privilege(role, table, 'UPDATE') stays FALSE
+--   for a column-level grant — that is expected, not a missing grant.
+--
+-- Gap 2 — runtime role cannot read back its own audit insert.
+--   073:583-588 grants INSERT only on
+--   integration_sealed_export_generation_audit to the runtime role, but every
+--   write helper in db.cjs appends RETURNING (insertOne db.cjs:231, insertMany
+--   db.cjs:261, updateRow db.cjs:281, deleteRows db.cjs:291), and
+--   generation-store.cjs:318/364/436/518 consume the returned row
+--   (`if (inserted === null) return null`). PostgreSQL requires SELECT on every
+--   column named in RETURNING; `RETURNING *` names all of them, so table-level
+--   SELECT is the minimal grant. Audit rows stay append-only: the UPDATE/DELETE
+--   guard trigger from 069:582 is untouched and no UPDATE/DELETE privilege is
+--   granted here.
+--
+-- Deliberately NOT repaired here (see the PR body): the runtime role holds only
+-- SELECT on integration_sealed_export_authority_state (073:571-576) while
+-- generation-kernel.cjs:934 locks that row via generation-store.cjs:383 on the
+-- activation path (stock-preparation-runtime-core.cjs:470/480). Granting that
+-- lock would invert a ratified assertion —
+-- packages/core-backend/tests/integration/
+-- sealed-export-s6a-runtime-authority.db.test.ts:497-503 asserts the refusal —
+-- so it is an owner contract decision, not an omission this migration may fix.
+--
+-- Role names are deployment inputs, not repository constants, exactly as in
+-- 073. Supply both settings through PGOPTIONS when migrations run:
+--
+--   -c metasheet.sealed_export_runtime_role=<runtime role>
+--   -c metasheet.sealed_export_provisioning_role=<provisioning role>
+--
+-- The validation preamble below is copied from 073 deliberately so both
+-- migrations fail closed identically: with neither setting the migration
+-- NOTICEs and returns (a fresh CI database stays installable); supplying only
+-- one setting, a missing role, an unsafe role, mutually inheriting roles, or
+-- the same role for both duties fails the migration closed with ERRCODE 55000.
+
+DO $$
+DECLARE
+  runtime_role TEXT := NULLIF(
+    current_setting('metasheet.sealed_export_runtime_role', TRUE),
+    ''
+  );
+  provisioning_role TEXT := NULLIF(
+    current_setting('metasheet.sealed_export_provisioning_role', TRUE),
+    ''
+  );
+  schema_name TEXT := current_schema();
+  candidate TEXT;
+  candidate_row RECORD;
+BEGIN
+  IF runtime_role IS NULL AND provisioning_role IS NULL THEN
+    RAISE NOTICE
+      'sealed-export roles are not configured; privilege grants remain latent';
+    RETURN;
+  END IF;
+  IF runtime_role IS NULL OR provisioning_role IS NULL THEN
+    RAISE EXCEPTION
+      'sealed-export runtime and provisioning roles must be configured together'
+      USING ERRCODE = '55000';
+  END IF;
+  IF runtime_role = provisioning_role THEN
+    RAISE EXCEPTION
+      'sealed-export runtime and provisioning roles must be distinct'
+      USING ERRCODE = '55000';
+  END IF;
+
+  FOREACH candidate IN ARRAY ARRAY[runtime_role, provisioning_role]
+  LOOP
+    SELECT
+      oid,
+      rolname,
+      rolsuper,
+      rolcreatedb,
+      rolcreaterole,
+      rolreplication,
+      rolbypassrls,
+      rolcanlogin,
+      rolinherit
+    INTO candidate_row
+    FROM pg_roles
+    WHERE rolname = candidate;
+
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'sealed-export role does not exist'
+        USING ERRCODE = '55000';
+    END IF;
+    IF
+      candidate_row.rolsuper
+      OR candidate_row.rolcreatedb
+      OR candidate_row.rolcreaterole
+      OR candidate_row.rolreplication
+      OR candidate_row.rolbypassrls
+      OR NOT candidate_row.rolcanlogin
+      OR candidate_row.rolinherit
+      OR candidate = current_user
+      OR pg_has_role(candidate, current_user, 'MEMBER')
+      OR EXISTS (
+        SELECT 1
+        FROM pg_auth_members membership
+        WHERE
+          membership.member = candidate_row.oid
+          OR membership.roleid = candidate_row.oid
+      )
+    THEN
+      RAISE EXCEPTION 'sealed-export role has unsafe authority'
+        USING ERRCODE = '55000';
+    END IF;
+  END LOOP;
+
+  IF
+    pg_has_role(runtime_role, provisioning_role, 'MEMBER')
+    OR pg_has_role(provisioning_role, runtime_role, 'MEMBER')
+  THEN
+    RAISE EXCEPTION
+      'sealed-export runtime and provisioning roles must not inherit each other'
+      USING ERRCODE = '55000';
+  END IF;
+
+  -- Gap 1: row-lock capability only. Column-level UPDATE is the minimal
+  -- privilege PostgreSQL accepts for SELECT ... FOR UPDATE; table-level UPDATE
+  -- would additionally expose the public-key material columns.
+  EXECUTE format(
+    'GRANT UPDATE (%I) ON TABLE %I.%I TO %I',
+    'updated_at',
+    schema_name,
+    'integration_sealed_export_signer_public_keys',
+    provisioning_role
+  );
+
+  -- Gap 2: read-back of the runtime's own INSERT ... RETURNING on the audit
+  -- ledger. No UPDATE/DELETE is granted, so audit rows stay append-only.
+  EXECUTE format(
+    'GRANT SELECT ON TABLE %I.%I TO %I',
+    schema_name,
+    'integration_sealed_export_generation_audit',
+    runtime_role
+  );
+END $$;

--- a/packages/core-backend/migrations/074_repair_sealed_export_runtime_authority_privileges.sql
+++ b/packages/core-backend/migrations/074_repair_sealed_export_runtime_authority_privileges.sql
@@ -25,7 +25,7 @@
 --   deletable. Note that has_table_privilege(role, table, 'UPDATE') stays FALSE
 --   for a column-level grant — that is expected, not a missing grant.
 --
--- Gap 2 — runtime role cannot read back its own audit insert.
+-- Gap 3 — runtime role cannot read back its own audit insert.
 --   073:583-588 grants INSERT only on
 --   integration_sealed_export_generation_audit to the runtime role, but every
 --   write helper in db.cjs appends RETURNING (insertOne db.cjs:231, insertMany
@@ -37,8 +37,8 @@
 --   guard trigger from 069:582 is untouched and no UPDATE/DELETE privilege is
 --   granted here.
 --
--- Deliberately NOT repaired here (see the PR body): the runtime role holds only
--- SELECT on integration_sealed_export_authority_state (073:571-576) while
+-- Gap 2 — deliberately NOT repaired here (see the PR body). The runtime role
+-- holds only SELECT on integration_sealed_export_authority_state (073:571-576) while
 -- generation-kernel.cjs:934 locks that row via generation-store.cjs:383 on the
 -- activation path (stock-preparation-runtime-core.cjs:470/480). Granting that
 -- lock would invert a ratified assertion —
@@ -151,7 +151,7 @@ BEGIN
     provisioning_role
   );
 
-  -- Gap 2: read-back of the runtime's own INSERT ... RETURNING on the audit
+  -- Gap 3: read-back of the runtime's own INSERT ... RETURNING on the audit
   -- ledger. No UPDATE/DELETE is granted, so audit rows stay append-only.
   EXECUTE format(
     'GRANT SELECT ON TABLE %I.%I TO %I',

--- a/packages/core-backend/tests/integration/sealed-export-s6a-grant-repair.db.test.ts
+++ b/packages/core-backend/tests/integration/sealed-export-s6a-grant-repair.db.test.ts
@@ -1,0 +1,710 @@
+import crypto from 'node:crypto'
+import fs from 'node:fs/promises'
+import { createRequire } from 'node:module'
+import path from 'node:path'
+
+import { Pool, type PoolClient } from 'pg'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+// S6-A privilege repair (migration 074) behavioural gate.
+//
+// 073 granted the provisioning role SELECT, INSERT on
+// integration_sealed_export_signer_public_keys while
+// provisionInitialStockPreparationBinding locks that row with
+// SELECT ... FOR UPDATE, and granted the runtime role INSERT only on
+// integration_sealed_export_generation_audit while every db.cjs write helper
+// appends RETURNING *. Both arms below run the frozen product code against a
+// real PostgreSQL: one schema WITHOUT 074 (must be refused with 42501) and one
+// WITH it (must complete). Values-free: counts, SQLSTATEs and closed reason
+// tokens only.
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const repoRoot = path.resolve(__dirname, '..', '..', '..', '..')
+const require = createRequire(import.meta.url)
+
+function libPath(...segments: string[]): string {
+  return path.join(
+    repoRoot,
+    'plugins',
+    'plugin-integration-core',
+    'lib',
+    ...segments,
+  )
+}
+
+const { createDb } = require(libPath('db.cjs'))
+const {
+  createSealedExportLifecycleProvisioning,
+} = require(libPath('sealed-export', 'sealed-export-lifecycle-provisioning.cjs'))
+const {
+  createStockPreparationProvisioningDatabase,
+} = require(libPath('sealed-export', 'stock-preparation-runtime-database.cjs'))
+const {
+  OBJECT_KEY,
+  RELATION_ID,
+} = require(libPath('sealed-export', 'stock-preparation-runtime-store.cjs'))
+const {
+  CANONICAL_OBJECT_VERSION,
+} = require(libPath('sealed-export', 'stock-preparation-sqlserver-source-authority.cjs'))
+
+const baseMigrations = [
+  '057_create_integration_core_tables.sql',
+  '068_create_integration_sealed_export_ingestion.sql',
+  '069_create_integration_sealed_export_generation_kernel.sql',
+  '070_create_integration_sealed_export_signer_authority.sql',
+  '071_harden_integration_sealed_export_authority_lifecycle.sql',
+  '072_harden_integration_sealed_export_terminal_signer_history.sql',
+  '073_create_sealed_export_stock_prep_runtime_authority.sql',
+]
+const repairMigration =
+  '074_repair_sealed_export_runtime_authority_privileges.sql'
+
+const PUBLIC_KEY_TABLE = 'integration_sealed_export_signer_public_keys'
+const AUDIT_TABLE = 'integration_sealed_export_generation_audit'
+const INSUFFICIENT_PRIVILEGE = '42501'
+
+interface DriverFailure {
+  code?: string
+  sql: string
+}
+
+function quotedIdentifier(value: string): string {
+  return `"${value.replaceAll('"', '""')}"`
+}
+
+function roleConnectionString(
+  source: string,
+  role: string,
+  password: string,
+): string {
+  const url = new URL(source)
+  if (url.hostname) {
+    url.username = role
+    url.password = password
+  } else {
+    url.searchParams.set('user', role)
+    url.searchParams.set('password', password)
+  }
+  return url.toString()
+}
+
+function digest(seed: string): string {
+  return crypto.createHash('sha256').update(seed).digest('hex')
+}
+
+function futureIso(daysAhead: number): string {
+  return new Date(Date.now() + daysAhead * 86400000)
+    .toISOString()
+    .replace(/\.\d{3}Z$/, 'Z')
+}
+
+const scope = Object.freeze({
+  tenantId: 'tenant-grant-repair',
+  workspaceId: null,
+  tenantDomainBinding: digest('grant-repair-tenant-domain'),
+  systemContentKey: digest('grant-repair-system-content'),
+  roleBindingFingerprint: digest('grant-repair-role-binding'),
+})
+
+function provisionInput(publicKey: crypto.KeyObject): unknown {
+  return {
+    authority: {
+      bindingExpiresAt: futureIso(30),
+      publicKey,
+      qualificationDigest: digest('grant-repair-qualification'),
+      qualificationExpiresAt: futureIso(20),
+      scope: { ...scope },
+      signerExpiresAt: futureIso(60),
+    },
+    binding: {
+      approvedConfigVersionId: 'config-version-grant-repair',
+      bindingId: 'binding-grant-repair',
+      bindingVersion: 'binding-grant-repair-v1',
+      canonicalObjectVersion: CANONICAL_OBJECT_VERSION,
+      configContentKey: digest('grant-repair-config-content'),
+      expiresAt: futureIso(25),
+      externalSystemId: 'external-system-grant-repair',
+      objectKey: OBJECT_KEY,
+      relationId: RELATION_ID,
+      roleBindingFingerprint: scope.roleBindingFingerprint,
+      systemContentKey: scope.systemContentKey,
+      tableRef: 'dbo.stock_prep_sealed_rows',
+      tenantDomainBinding: scope.tenantDomainBinding,
+      tenantId: scope.tenantId,
+      workspaceId: null,
+    },
+  }
+}
+
+// Same statement shapes as stock-preparation-runtime-database.cjs, plus a
+// recorder for the raw driver error that the sealed-export failure vocabulary
+// deliberately masks (dbBoundary maps everything untrusted to
+// SEALED_EXPORT_INTERNAL_ERROR).
+function instrumentedDatabase(pool: Pool, failures: DriverFailure[]) {
+  async function run(
+    executor: { query: (sql: string, params?: unknown[]) => Promise<{ rows: unknown[] }> },
+    sql: string,
+    params?: unknown[],
+  ): Promise<unknown[]> {
+    try {
+      const result = await executor.query(sql, params)
+      return result.rows
+    } catch (error) {
+      failures.push({
+        code: (error as { code?: string }).code,
+        sql: sql.replace(/\s+/g, ' ').trim(),
+      })
+      throw error
+    }
+  }
+  return {
+    async query(sql: string, params?: unknown[]) {
+      return run(pool, sql, params)
+    },
+    async transaction(callback: (trx: unknown) => Promise<unknown>) {
+      const client = await pool.connect()
+      let finished = false
+      try {
+        await client.query('BEGIN')
+        const trx = {
+          query: (sql: string, params?: unknown[]) => run(client, sql, params),
+          async commit() {
+            if (finished) return
+            await client.query('COMMIT')
+            finished = true
+          },
+          async rollback() {
+            if (finished) return
+            await client.query('ROLLBACK')
+            finished = true
+          },
+        }
+        const result = await callback(trx)
+        if (!finished) {
+          await client.query('COMMIT')
+          finished = true
+        }
+        return result
+      } catch (error) {
+        if (!finished) await client.query('ROLLBACK').catch(() => {})
+        throw error
+      } finally {
+        client.release()
+      }
+    },
+  }
+}
+
+interface Arm {
+  schema: string
+  runtimeRole: string
+  runtimePassword: string
+  provisioningRole: string
+  provisioningPassword: string
+}
+
+describeIfDatabase('sealed-export S6-A grant repair (real Postgres)', () => {
+  let pool: Pool
+  let client: PoolClient
+  let absent: Arm
+  let present: Arm
+  let publicKey: crypto.KeyObject
+
+  function makeArm(name: string, suffix: string): Arm {
+    return {
+      schema: `s6a_repair_${name}_${suffix}`,
+      runtimeRole: `s6a_rep_rt_${name}_${suffix}`,
+      runtimePassword: `S6aRepairRt_${name}_${suffix}`,
+      provisioningRole: `s6a_rep_pv_${name}_${suffix}`,
+      provisioningPassword: `S6aRepairPv_${name}_${suffix}`,
+    }
+  }
+
+  async function buildArm(arm: Arm, withRepair: boolean): Promise<void> {
+    await client.query(
+      `CREATE ROLE ${quotedIdentifier(arm.runtimeRole)}
+       LOGIN NOINHERIT PASSWORD '${arm.runtimePassword}'`,
+    )
+    await client.query(
+      `CREATE ROLE ${quotedIdentifier(arm.provisioningRole)}
+       LOGIN NOINHERIT PASSWORD '${arm.provisioningPassword}'`,
+    )
+    await client.query(`CREATE SCHEMA ${quotedIdentifier(arm.schema)}`)
+    const database = (
+      await client.query<{ name: string }>('SELECT current_database() AS name')
+    ).rows[0].name
+    for (const role of [arm.runtimeRole, arm.provisioningRole]) {
+      await client.query(
+        `ALTER ROLE ${quotedIdentifier(role)}
+         IN DATABASE ${quotedIdentifier(database)}
+         SET search_path TO ${quotedIdentifier(arm.schema)}`,
+      )
+    }
+    await client.query(`SET search_path TO ${quotedIdentifier(arm.schema)}`)
+    await client.query(
+      "SELECT set_config('metasheet.sealed_export_runtime_role', $1, false)",
+      [arm.runtimeRole],
+    )
+    await client.query(
+      "SELECT set_config('metasheet.sealed_export_provisioning_role', $1, false)",
+      [arm.provisioningRole],
+    )
+    const names = withRepair
+      ? [...baseMigrations, repairMigration]
+      : [...baseMigrations]
+    for (const name of names) {
+      const sql = await fs.readFile(
+        path.join(repoRoot, 'packages', 'core-backend', 'migrations', name),
+        'utf8',
+      )
+      await client.query(sql)
+    }
+    await client.query('SET search_path TO public')
+  }
+
+  async function dropArm(arm: Arm): Promise<void> {
+    await client.query(
+      `DROP SCHEMA IF EXISTS ${quotedIdentifier(arm.schema)} CASCADE`,
+    ).catch(() => {})
+    for (const role of [arm.runtimeRole, arm.provisioningRole]) {
+      await client.query(
+        `DROP OWNED BY ${quotedIdentifier(role)} CASCADE`,
+      ).catch(() => {})
+      await client.query(
+        `DROP ROLE IF EXISTS ${quotedIdentifier(role)}`,
+      ).catch(() => {})
+    }
+  }
+
+  function provisioningPool(arm: Arm): Pool {
+    return new Pool({
+      connectionString: roleConnectionString(
+        process.env.DATABASE_URL!,
+        arm.provisioningRole,
+        arm.provisioningPassword,
+      ),
+      max: 2,
+    })
+  }
+
+  function runtimePool(arm: Arm): Pool {
+    return new Pool({
+      connectionString: roleConnectionString(
+        process.env.DATABASE_URL!,
+        arm.runtimeRole,
+        arm.runtimePassword,
+      ),
+      max: 2,
+    })
+  }
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: process.env.DATABASE_URL, max: 1 })
+    client = await pool.connect()
+    const suffix = `${process.pid}_${Date.now().toString(36)}`
+    absent = makeArm('absent', suffix)
+    present = makeArm('present', suffix)
+    publicKey = crypto.generateKeyPairSync('ed25519').publicKey
+    await buildArm(absent, false)
+    await buildArm(present, true)
+  }, 120000)
+
+  afterAll(async () => {
+    if (client) {
+      await client.query('SET search_path TO public').catch(() => {})
+      if (absent) await dropArm(absent)
+      if (present) await dropArm(present)
+      client.release()
+    }
+    if (pool) await pool.end()
+  })
+
+  it('refuses the locking read without migration 074 and completes with it', async () => {
+    const withoutRepair = provisioningPool(absent)
+    const withoutFailures: DriverFailure[] = []
+    try {
+      const lifecycle = createSealedExportLifecycleProvisioning({
+        db: createDb({ database: instrumentedDatabase(withoutRepair, withoutFailures) }),
+      })
+      await expect(
+        lifecycle.provisionInitialStockPreparationBinding(
+          provisionInput(publicKey),
+        ),
+      ).rejects.toMatchObject({ reason: 'SEALED_EXPORT_INTERNAL_ERROR' })
+    } finally {
+      await withoutRepair.end()
+    }
+    expect(withoutFailures).toHaveLength(1)
+    expect(withoutFailures[0].code).toBe(INSUFFICIENT_PRIVILEGE)
+    expect(withoutFailures[0].sql).toContain(PUBLIC_KEY_TABLE)
+    expect(withoutFailures[0].sql.endsWith('LIMIT 1 FOR UPDATE')).toBe(true)
+
+    const withRepair = provisioningPool(present)
+    const withFailures: DriverFailure[] = []
+    try {
+      const lifecycle = createSealedExportLifecycleProvisioning({
+        db: createDb({ database: instrumentedDatabase(withRepair, withFailures) }),
+      })
+      await expect(
+        lifecycle.provisionInitialStockPreparationBinding(
+          provisionInput(publicKey),
+        ),
+      ).resolves.toMatchObject({
+        changed: true,
+        externalWrite: false,
+        operation: 'INITIAL_PROVISIONED',
+        valuesFree: true,
+      })
+    } finally {
+      await withRepair.end()
+    }
+    expect(withFailures).toEqual([])
+  }, 60000)
+
+  it('provisions through the frozen role-bound database handle and replays idempotently', async () => {
+    const handle = createStockPreparationProvisioningDatabase({
+      applicationName: 's6a-grant-repair-gate',
+      connectionString: roleConnectionString(
+        process.env.DATABASE_URL!,
+        present.provisioningRole,
+        present.provisioningPassword,
+      ),
+      expectedRole: present.provisioningRole,
+    })
+    try {
+      await expect(handle.assertReady()).resolves.toMatchObject({
+        roleVerified: true,
+        valuesFree: true,
+      })
+      const lifecycle = createSealedExportLifecycleProvisioning({ db: handle.db })
+      await expect(
+        lifecycle.provisionInitialStockPreparationBinding(
+          provisionInput(publicKey),
+        ),
+      ).resolves.toMatchObject({
+        changed: false,
+        operation: 'INITIAL_PROVISIONED',
+      })
+    } finally {
+      await handle.close()
+    }
+
+    await client.query(`SET search_path TO ${quotedIdentifier(present.schema)}`)
+    const counts = await client.query<{
+      bindings: number
+      authority: number
+      public_keys: number
+    }>(
+      `SELECT
+         (SELECT COUNT(*)::int FROM integration_sealed_export_stock_prep_bindings) AS bindings,
+         (SELECT COUNT(*)::int FROM integration_sealed_export_authority_state) AS authority,
+         (SELECT COUNT(*)::int FROM integration_sealed_export_signer_public_keys) AS public_keys`,
+    )
+    await client.query('SET search_path TO public')
+    expect(counts.rows).toEqual([{ bindings: 1, authority: 1, public_keys: 1 }])
+  }, 60000)
+
+  it('lets the runtime role read back its own audit insert only with migration 074', async () => {
+    const generationId = 'generation-grant-repair'
+    const manifestDigest = digest('grant-repair-manifest')
+    const auditRow = (auditId: string) => ({
+      audit_id: auditId,
+      generation_id: generationId,
+      tenant_id: scope.tenantId,
+      workspace_id: null,
+      tenant_domain_binding: scope.tenantDomainBinding,
+      system_content_key: scope.systemContentKey,
+      role_binding_fingerprint: scope.roleBindingFingerprint,
+      manifest_digest: manifestDigest,
+      event_type: 'SEALED',
+      reason: null,
+      row_count: 1,
+      external_write: false,
+      occurred_at: futureIso(0),
+    })
+
+    for (const arm of [absent, present]) {
+      await client.query(`SET search_path TO ${quotedIdentifier(arm.schema)}`)
+      await client.query(
+        `INSERT INTO integration_sealed_export_generations (
+           generation_id, session_id, tenant_id, workspace_id,
+           tenant_domain_binding, system_content_key, role_binding_fingerprint,
+           manifest_digest, signer_key_id, qualification_digest,
+           canonical_object_version, approved_config_version_id,
+           config_content_key, status, manifest_row_count, manifest_byte_count,
+           manifest_chunk_count, manifest_artifact_digest,
+           manifest_rowset_digest, manifest_chunk_set_digest,
+           manifest_expires_at
+         ) VALUES (
+           $1, $2, $3, NULL, $4, $5, $6, $7, $8, $9, $10, $11, $12,
+           'STAGING', 1, 1, 1, $13, $14, $15, $16
+         )`,
+        [
+          generationId,
+          'session-grant-repair',
+          scope.tenantId,
+          scope.tenantDomainBinding,
+          scope.systemContentKey,
+          scope.roleBindingFingerprint,
+          manifestDigest,
+          digest('grant-repair-signer'),
+          digest('grant-repair-qualification'),
+          CANONICAL_OBJECT_VERSION,
+          'config-version-grant-repair',
+          digest('grant-repair-config-content'),
+          digest('grant-repair-manifest-artifact'),
+          digest('grant-repair-manifest-rowset'),
+          digest('grant-repair-manifest-chunkset'),
+          futureIso(90),
+        ],
+      )
+    }
+    await client.query('SET search_path TO public')
+
+    const withoutRepair = runtimePool(absent)
+    try {
+      const db = createDb({ database: instrumentedDatabase(withoutRepair, []) })
+      await expect(
+        db.insertOne(AUDIT_TABLE, auditRow('audit-grant-repair-absent')),
+      ).rejects.toMatchObject({ code: INSUFFICIENT_PRIVILEGE })
+    } finally {
+      await withoutRepair.end()
+    }
+
+    const withRepair = runtimePool(present)
+    try {
+      const db = createDb({ database: instrumentedDatabase(withRepair, []) })
+      const inserted = await db.insertOne(
+        AUDIT_TABLE,
+        auditRow('audit-grant-repair-present'),
+      )
+      const rows = Array.isArray(inserted) ? inserted : inserted.rows
+      expect(rows).toHaveLength(1)
+      // Append-only stays append-only: no UPDATE/DELETE privilege is granted.
+      await expect(
+        withRepair.query(`UPDATE ${AUDIT_TABLE} SET row_count = row_count + 1`),
+      ).rejects.toMatchObject({ code: INSUFFICIENT_PRIVILEGE })
+      await expect(
+        withRepair.query(`DELETE FROM ${AUDIT_TABLE}`),
+      ).rejects.toMatchObject({ code: INSUFFICIENT_PRIVILEGE })
+    } finally {
+      await withRepair.end()
+    }
+  }, 60000)
+
+  it('adds row-lock capability without adding write capability', async () => {
+    const provisioning = provisioningPool(present)
+    const runtime = runtimePool(present)
+    try {
+      for (const statement of [
+        `UPDATE ${PUBLIC_KEY_TABLE} SET public_key_spki_der = decode('02','hex')`,
+        `UPDATE ${PUBLIC_KEY_TABLE} SET signature_algorithm = 'ED25519'`,
+        `UPDATE ${PUBLIC_KEY_TABLE} SET signer_key_id = repeat('0', 64)`,
+        `DELETE FROM ${PUBLIC_KEY_TABLE}`,
+        'SELECT 1 FROM integration_sealed_export_stock_prep_runs',
+        'INSERT INTO integration_sealed_export_ingestion_sessions DEFAULT VALUES',
+      ]) {
+        await expect(provisioning.query(statement)).rejects.toMatchObject({
+          code: INSUFFICIENT_PRIVILEGE,
+        })
+      }
+
+      // The one column the repair opens is overwritten by the BEFORE UPDATE
+      // trigger from migration 070, so even the granted write is inert.
+      await provisioning.query(
+        `UPDATE ${PUBLIC_KEY_TABLE}
+         SET updated_at = TIMESTAMPTZ '1999-01-01T00:00:00Z'`,
+      )
+      const stale = await provisioning.query<{ stale: number }>(
+        `SELECT COUNT(*)::int AS stale
+         FROM ${PUBLIC_KEY_TABLE}
+         WHERE updated_at = TIMESTAMPTZ '1999-01-01T00:00:00Z'`,
+      )
+      expect(stale.rows[0].stale).toBe(0)
+
+      // The runtime side of the frozen matrix is untouched, including the
+      // authority-state lock that 073 deliberately refuses.
+      for (const statement of [
+        "UPDATE integration_sealed_export_authority_state SET signer_status = 'REVOKED'",
+        'SELECT * FROM integration_sealed_export_authority_state FOR UPDATE',
+      ]) {
+        await expect(runtime.query(statement)).rejects.toMatchObject({
+          code: INSUFFICIENT_PRIVILEGE,
+        })
+      }
+    } finally {
+      await provisioning.end()
+      await runtime.end()
+    }
+
+    const view = await client.query<{
+      prov_table_update: boolean
+      prov_col_updated_at: boolean
+      prov_col_key_material: boolean
+      prov_table_delete: boolean
+      runtime_audit_select: boolean
+      runtime_audit_update: boolean
+      runtime_authority_update: boolean
+    }>(
+      `SELECT
+         has_table_privilege($1, $3, 'UPDATE') AS prov_table_update,
+         has_column_privilege($1, $3, 'updated_at', 'UPDATE') AS prov_col_updated_at,
+         has_column_privilege($1, $3, 'public_key_spki_der', 'UPDATE') AS prov_col_key_material,
+         has_table_privilege($1, $3, 'DELETE') AS prov_table_delete,
+         has_table_privilege($2, $4, 'SELECT') AS runtime_audit_select,
+         has_table_privilege($2, $4, 'UPDATE') AS runtime_audit_update,
+         has_table_privilege($2, $5, 'UPDATE') AS runtime_authority_update`,
+      [
+        present.provisioningRole,
+        present.runtimeRole,
+        `${present.schema}.${PUBLIC_KEY_TABLE}`,
+        `${present.schema}.${AUDIT_TABLE}`,
+        `${present.schema}.integration_sealed_export_authority_state`,
+      ],
+    )
+    expect(view.rows).toEqual([{
+      prov_table_update: false,
+      prov_col_updated_at: true,
+      prov_col_key_material: false,
+      prov_table_delete: false,
+      runtime_audit_select: true,
+      runtime_audit_update: false,
+      runtime_authority_update: false,
+    }])
+  }, 60000)
+
+  it('leaves the ratified 073 capability matrix identical', async () => {
+    const matrix = `SELECT
+        has_table_privilege($1, $3 || '.integration_sealed_export_stock_prep_bindings', 'SELECT') AS runtime_binding_select,
+        has_table_privilege($1, $3 || '.integration_sealed_export_stock_prep_bindings', 'INSERT') AS runtime_binding_insert,
+        has_table_privilege($1, $3 || '.integration_sealed_export_authority_state', 'SELECT') AS runtime_authority_select,
+        has_table_privilege($1, $3 || '.integration_sealed_export_authority_state', 'UPDATE') AS runtime_authority_update,
+        has_table_privilege($1, $3 || '.integration_sealed_export_stock_prep_runs', 'INSERT') AS runtime_run_insert,
+        has_table_privilege($1, $3 || '.integration_sealed_export_stock_prep_runs', 'UPDATE') AS runtime_run_update,
+        has_table_privilege($2, $3 || '.integration_sealed_export_stock_prep_bindings', 'INSERT') AS provisioning_binding_insert,
+        has_table_privilege($2, $3 || '.integration_sealed_export_generations', 'INSERT') AS provisioning_generation_insert,
+        has_table_privilege($2, $3 || '.integration_sealed_export_stock_prep_runs', 'SELECT') AS provisioning_run_select,
+        has_table_privilege($2, $3 || '.integration_sealed_export_terminal_signer_keys', 'SELECT') AS provisioning_terminal_select,
+        has_table_privilege($2, $3 || '.integration_sealed_export_terminal_signer_keys', 'INSERT') AS provisioning_terminal_insert`
+    const ratified = {
+      runtime_binding_select: true,
+      runtime_binding_insert: false,
+      runtime_authority_select: true,
+      runtime_authority_update: false,
+      runtime_run_insert: true,
+      runtime_run_update: true,
+      provisioning_binding_insert: true,
+      provisioning_generation_insert: false,
+      provisioning_run_select: false,
+      provisioning_terminal_select: true,
+      provisioning_terminal_insert: true,
+    }
+    for (const arm of [absent, present]) {
+      const result = await client.query(
+        matrix,
+        [arm.runtimeRole, arm.provisioningRole, arm.schema],
+      )
+      expect(result.rows).toEqual([ratified])
+    }
+  }, 60000)
+
+  it('fails closed on partial, identical, missing and unsafe role inputs', async () => {
+    const sql = await fs.readFile(
+      path.join(
+        repoRoot,
+        'packages',
+        'core-backend',
+        'migrations',
+        repairMigration,
+      ),
+      'utf8',
+    )
+    const suffix = `${process.pid}_${Date.now().toString(36)}`
+    const unsafeRole = `s6a_rep_unsafe_${suffix}`
+    const latentSchema = `s6a_repair_latent_${suffix}`
+
+    await client.query(`SET search_path TO ${quotedIdentifier(present.schema)}`)
+    try {
+      // Only one setting supplied.
+      await client.query(
+        "SELECT set_config('metasheet.sealed_export_provisioning_role', '', false)",
+      )
+      await client.query(
+        "SELECT set_config('metasheet.sealed_export_runtime_role', $1, false)",
+        [present.runtimeRole],
+      )
+      await expect(client.query(sql)).rejects.toMatchObject({ code: '55000' })
+
+      // The same role for both duties.
+      await client.query(
+        "SELECT set_config('metasheet.sealed_export_provisioning_role', $1, false)",
+        [present.runtimeRole],
+      )
+      await expect(client.query(sql)).rejects.toMatchObject({ code: '55000' })
+
+      // A role that does not exist.
+      await client.query(
+        "SELECT set_config('metasheet.sealed_export_provisioning_role', $1, false)",
+        [`${unsafeRole}_absent`],
+      )
+      await expect(client.query(sql)).rejects.toMatchObject({ code: '55000' })
+
+      // A role with unsafe authority.
+      await client.query(
+        `CREATE ROLE ${quotedIdentifier(unsafeRole)} LOGIN SUPERUSER`,
+      )
+      await client.query(
+        "SELECT set_config('metasheet.sealed_export_provisioning_role', $1, false)",
+        [unsafeRole],
+      )
+      await expect(client.query(sql)).rejects.toMatchObject({ code: '55000' })
+      const unsafeGrants = await client.query<{ grants: number }>(
+        `SELECT COUNT(*)::int AS grants
+         FROM information_schema.role_table_grants
+         WHERE grantee = $1`,
+        [unsafeRole],
+      )
+      expect(unsafeGrants.rows[0].grants).toBe(0)
+
+      // Neither setting supplied: a fresh database stays installable and no
+      // grant is issued.
+      await client.query(`CREATE SCHEMA ${quotedIdentifier(latentSchema)}`)
+      await client.query(`SET search_path TO ${quotedIdentifier(latentSchema)}`)
+      await client.query(
+        "SELECT set_config('metasheet.sealed_export_runtime_role', '', false)",
+      )
+      await client.query(
+        "SELECT set_config('metasheet.sealed_export_provisioning_role', '', false)",
+      )
+      for (const name of baseMigrations) {
+        await client.query(await fs.readFile(
+          path.join(repoRoot, 'packages', 'core-backend', 'migrations', name),
+          'utf8',
+        ))
+      }
+      await expect(client.query(sql)).resolves.toBeDefined()
+      const latentGrants = await client.query<{ grants: number }>(
+        `SELECT COUNT(*)::int AS grants
+         FROM information_schema.role_table_grants
+         WHERE table_schema = $1
+           AND grantee NOT IN (current_user, 'PUBLIC')`,
+        [latentSchema],
+      )
+      expect(latentGrants.rows[0].grants).toBe(0)
+    } finally {
+      await client.query(
+        `DROP SCHEMA IF EXISTS ${quotedIdentifier(latentSchema)} CASCADE`,
+      ).catch(() => {})
+      await client.query(
+        `DROP ROLE IF EXISTS ${quotedIdentifier(unsafeRole)}`,
+      ).catch(() => {})
+      await client.query('SET search_path TO public').catch(() => {})
+      await client.query(
+        "SELECT set_config('metasheet.sealed_export_runtime_role', '', false)",
+      ).catch(() => {})
+      await client.query(
+        "SELECT set_config('metasheet.sealed_export_provisioning_role', '', false)",
+      ).catch(() => {})
+    }
+  }, 120000)
+})


### PR DESCRIPTION
## What this is

A **new** migration, `packages/core-backend/migrations/074_repair_sealed_export_runtime_authority_privileges.sql`, granting the two privileges migration 073 omitted. 073 is **not** edited: it is already applied on `main` and is a pinned input of the frozen S6-A package.

DRAFT. Not ready-for-review, not armed, nothing merged, no flag default changed, no deployment.

---

## ⚠️ The frozen package still contains this defect

Migration 073 is byte-identical between the frozen S6-A runtime SHA `a45a2fe3fa818b6b90830418a55a6b9f635e91c9` and current `origin/main` (verified: sha256-16 `fc0f01bd26b00efb` on both). The frozen package `packageSha256=0b80d927…` therefore **contains this defect and is not fixed by this PR**.

A new migration lands on `main`. It does **not** change `0b80d927…`:

- `sealed-export-package-provenance.cjs:58` pins a **closed** `PINNED_MIGRATIONS` list of `068`–`073`; 074 is deliberately not added to it.
- `scripts/ops/multitable-onprem-package-verify.sh:984` packages an explicit file list that names 073 only; 074 is not in the on-prem package either.

So: **an S6-B controlled run executed with the current frozen package will still hit this.** Whether to re-freeze (and repackage) is an **owner decision that I am not making** — #4695's frozen inputs are ratified and are untouched here. **This PR does not unblock S6-B.**

There is a second way the repair can be absent in a real deployment, and the owner needs both for the re-freeze question: **074 is a silent no-op unless both GUCs are supplied on the run that applies it.** Like 073, it NOTICEs and returns when neither `metasheet.sealed_export_runtime_role` nor `..._provisioning_role` is set. On an existing S6-A database where 073 already granted, an operator who applies 074 without `PGOPTIONS` gets a clean-looking migration and **no repair** — the defect then resurfaces as a runtime `42501`, not as a migration error. The S6-A runbook that carries the `PGOPTIONS` instruction (`docs/operations/stock-preparation-s6a-sqlserver-onprem-runbook-20260731.md`) is itself a pinned frozen input and is not amended here.

---

## The defect

**Gap 1 — provisioning role cannot take the row lock it needs.**

| side | evidence |
|---|---|
| grant | `packages/core-backend/migrations/073_create_sealed_export_stock_prep_runtime_authority.sql:619-624` — `GRANT SELECT, INSERT ON ... integration_sealed_export_signer_public_keys` to the **provisioning** role |
| code | `plugins/plugin-integration-core/lib/sealed-export/sealed-export-lifecycle-provisioning.cjs:505` — `provisionInitialStockPreparationBinding` calls `trx.selectOneForUpdate(PUBLIC_KEY_TABLE, …)` |
| table identity | `plugins/plugin-integration-core/lib/sealed-export/sealed-export-signer-authority-store.cjs:20` — `PUBLIC_KEY_TABLE = 'integration_sealed_export_signer_public_keys'` |
| SQL emitted | `plugins/plugin-integration-core/lib/db.cjs:212` — `SELECT * FROM <table> WHERE … LIMIT 1 FOR UPDATE` |

It is an omission, not a design choice: the grant immediately after it (`073:625-630`, terminal signer keys) is `SELECT, INSERT`, and the one after that (`073:631-636`, stock-prep bindings) is `SELECT, INSERT, UPDATE`; the two sibling locking reads in the same function (`:491` bindings, `:501` authority state) both land on tables that *do* carry UPDATE.

**Gap 2 — found by the enumeration, deliberately NOT fixed here** (see the matrix below).

**Gap 3 — runtime role cannot read back its own audit insert.**

| side | evidence |
|---|---|
| grant | `073:583-588` — `GRANT INSERT ON ... integration_sealed_export_generation_audit` to the **runtime** role (the only INSERT-only grant in 073) |
| code | `plugins/plugin-integration-core/lib/db.cjs:231` — `insertOne` always emits `INSERT … RETURNING *` (so do `insertMany` :261, `updateRow` :281, `deleteRows` :291) |
| consumption | `generation-store.cjs:318, 364, 436, 518` — `firstRow(await trx.insertOne(AUDIT_TABLE, audit))`, then `if (inserted === null) return null` |

PostgreSQL requires SELECT on every column named in `RETURNING`. INSERT-only *looks* like append-only intent, but the wrapper the frozen code must use makes that intent unimplementable — a gap, not a choice. Append-only is preserved by the trigger (`069:582`, `BEFORE UPDATE OR DELETE`) and by granting no UPDATE/DELETE.

---

## The minimal privilege chosen, and why

**Gap 1 → `GRANT UPDATE (updated_at)`, column-level, not table-level.**

PostgreSQL requires `UPDATE` **on at least one column** — not table-wide — in addition to SELECT, for a row-locking clause. Measured, not assumed (PostgreSQL 16.14):

```
--- ARM1: SELECT FOR UPDATE with SELECT,INSERT only ---
ERROR:  permission denied for table probe_t
--- ARM1b: SELECT FOR SHARE with SELECT,INSERT only ---
ERROR:  permission denied for table probe_t
--- ARM2: SELECT FOR UPDATE after column-level UPDATE(updated_at) ---
 id
----
 a
(1 row)
--- ARM3: attempt to modify payload with column-only grant ---
ERROR:  permission denied for table probe_t
--- ARM5: DELETE still refused ---
ERROR:  permission denied for table probe_t
```

`updated_at` is the column chosen because the `BEFORE UPDATE` trigger installed by `070:62-65` (`integration_set_updated_at`, `057:182-188`) overwrites it unconditionally with `NOW()`. The added capability is therefore **"acquire the row lock" and nothing else**: no column carrying key material becomes writable, no row becomes deletable, and even the one granted column cannot be set to a chosen value. Table-level `UPDATE` would have exposed `public_key_spki_der`, `public_key_spki_sha256`, `signer_key_id` and `signature_algorithm` for rewrite — that would be a regression, not a fix.

Note for future readers: `has_table_privilege(role, table, 'UPDATE')` stays **false** for a column-level grant (measured below). That is expected, not a missing grant — do not "re-fix" it by widening to table level.

**Gap 3 → `GRANT SELECT`, table-level.** `RETURNING *` expands to every column, so column-level SELECT would have to name all of them and would silently rot as columns are added. Table-level SELECT is the minimal durable grant. No UPDATE/DELETE is granted.

---

## Full grant-matrix comparison

Every table on the provisioning and runtime paths, every locking read (`selectOneForUpdate` / `FOR UPDATE` / `FOR SHARE`) in `plugins/plugin-integration-core/lib/sealed-export/`, and every write helper (all of which append `RETURNING`), against 073's grants.

**Locking reads — complete enumeration (9 sites; zero `FOR SHARE` sites in the lib):**

| site | table | role | 073 grant | verdict |
|---|---|---|---|---|
| `sealed-export-lifecycle-provisioning.cjs:491` | stock_prep_bindings | provisioning | S,I,U | OK |
| `sealed-export-lifecycle-provisioning.cjs:501` | authority_state | provisioning | S,I,U | OK |
| **`sealed-export-lifecycle-provisioning.cjs:505`** | **signer_public_keys** | **provisioning** | **S,I** | **GAP 1 → fixed here** |
| `sealed-export-lifecycle-provisioning.cjs:559` | authority_state | provisioning | S,I,U | OK |
| `sealed-export-lifecycle-provisioning.cjs:598` | authority_state | provisioning | S,I,U | OK |
| `sealed-export-lifecycle-provisioning.cjs:628` | authority_state | provisioning | S,I,U | OK |
| `stock-preparation-runtime-store.cjs:423` | stock_prep_runs | runtime | S,I,U | OK |
| `stock-preparation-runtime-store.cjs:484` | stock_prep_runs | runtime | S,I,U | OK |
| **`generation-store.cjs:383`** | **authority_state** | **runtime** | **S only** | **GAP 2 → reported, NOT fixed** |

**Table matrix — what the frozen code needs vs what 073 grants:**

| role | table | 073 grant | operations the frozen code emits | verdict |
|---|---|---|---|---|
| runtime | ingestion_sessions | S,I,U,D | select / insert+RET / update+RET / delete+RET | OK |
| runtime | ingestion_receipts | S,I,D | select / insert+RET / delete+RET | OK |
| runtime | ingestion_tombstones | S,I | insert+RET | OK |
| runtime | generations | S,I,U | select / insert+RET / update+RET | OK |
| runtime | generation_staging_rows | S,I,D | select / count / insertMany+RET / delete+RET | OK |
| runtime | generation_rows | S,I | select / count / insertMany+RET | OK |
| runtime | authority_state | **S** | select, **SELECT … FOR UPDATE** | **GAP 2** |
| runtime | active_pointers | S,I,U | insert+RET / update+RET | OK |
| runtime | generation_audit | **I** | **insert+RETURNING \*** | **GAP 3 → fixed here** |
| runtime | signer_public_keys | S | select | OK |
| runtime | stock_prep_bindings | S | select | OK |
| runtime | stock_prep_runs | S,I,U | insert+RET / update+RET / FOR UPDATE | OK |
| provisioning | authority_state | S,I,U | insert+RET / update+RET / FOR UPDATE | OK |
| provisioning | signer_public_keys | **S,I** | insert+RET, **FOR UPDATE** | **GAP 1 → fixed here** |
| provisioning | terminal_signer_keys | S,I | written by the 072 trigger on authority_state UPDATE (no RETURNING) | OK |
| provisioning | stock_prep_bindings | S,I,U | insert+RET / FOR UPDATE | OK |

Checked negatives (stated so the sweep is auditable): schema `USAGE` is granted to both roles by 073; migrations 068–073 declare **no** `SERIAL` / identity / sequence columns, so no sequence grants are required; there are **no** `FOR SHARE` call sites; `updateRow`/`deleteRows` are only used on tables that already hold SELECT.

### Gap 2 — why it is reported, not fixed

Call chain: `stock-preparation-runtime-core.cjs:470` and `:480` (`kernel.activateWithExpectation`, on the unconditional activation path) → `generation-kernel.cjs:934` (`trx.readAuthorityStateForUpdate`) → `generation-store.cjs:383` (`selectOneForUpdate(AUTHORITY_STATE_TABLE, …)`), executed under the **runtime** role, which `073:571-576` grants `SELECT` only.

I am not fixing it here because the repository already contains a **ratified assertion that this refusal is intended**: `packages/core-backend/tests/integration/sealed-export-s6a-runtime-authority.db.test.ts:497-503` asserts `SELECT * FROM integration_sealed_export_authority_state FOR UPDATE` under the runtime role rejects with `42501`, inside a test named *"allows first-party provisioning but denies direct runtime authority writes"*. Gap 1 and Gap 3 have adjacent-grant / mechanical evidence of omission; Gap 2 has evidence pointing the other way, and the resolution may not even be a grant (the kernel could use the non-locking `readAuthorityState`, or activation could run under a different role). **That is an owner contract decision.** The test is untouched, and the gate below proves the refusal is still in place.

This is also a concrete second reason an S6-B controlled run remains blocked.

---

## Proof — real PostgreSQL, both control arms

Container: `postgres:16-alpine`, server_version **16.14** (CI's own S6-A gate uses `postgres:16`). Both roles created `LOGIN NOINHERIT`, both GUCs set, migrations `057, 068–073` applied to one schema and `057, 068–073 + 074` to another, then `provisionInitialStockPreparationBinding` executed end to end through the frozen code.

### Negative arm — migration 074 ABSENT

```
[absent/frozen-path] assertReady roleVerified=true
[absent/frozen-path] provisionInitialStockPreparationBinding REJECTED reason=SEALED_EXPORT_INTERNAL_ERROR name=SealedExportError
[absent] instrumented REJECTED reason=SEALED_EXPORT_INTERNAL_ERROR
[absent] driver SQLSTATE=42501 sql=SELECT * FROM "integration_sealed_export_signer_public_keys" WHERE "tenant_id" = $1 AND "workspace_id" IS NULL AND "tenant_domain_binding" = $2 AND "system_content_key" = $3 AND "role_binding_fingerprint" = $4 AND "signer_key_id" = $5 LIMIT 1 FOR UPDATE
[absent] row counts {"bindings":0,"authority":0,"public_keys":0,"audit":0}
```

The sealed-export failure vocabulary masks driver errors (`dbBoundary` maps anything untrusted to `SEALED_EXPORT_INTERNAL_ERROR`), so the arm is two-layer: the frozen path shows the product-visible token, and an instrumented driver — same `db.cjs` wrapper, same lifecycle module — records the raw `42501`. Exactly **one** statement failed, and it is the public-keys `FOR UPDATE`: the two preceding locking reads (bindings, authority state) succeeded, which localises the defect rather than merely observing a failure.

### Positive arm — migration 074 PRESENT

```
[present/frozen-path] assertReady roleVerified=true
[present/frozen-path] provisionInitialStockPreparationBinding RESOLVED operation=INITIAL_PROVISIONED changed=true externalWrite=false valuesFree=true
--- replay (idempotence) ---
[present/replay] assertReady roleVerified=true
[present/replay] provisionInitialStockPreparationBinding RESOLVED operation=INITIAL_PROVISIONED changed=false externalWrite=false valuesFree=true
[present] row counts {"bindings":1,"authority":1,"public_keys":1,"audit":0}
```

### Gap 3 arms — the audit ledger, same two schemas

```
[absent] runtime insertOne(audit) THREW SQLSTATE=42501
[absent] audit driver SQLSTATE=42501 sql=INSERT INTO "integration_sealed_export_generation_audit" (...) VALUES ($1, ..., $13) RETURNING *
[present] runtime insertOne(audit) RESOLVED returnedRows=1
```

Scope of this arm, stated plainly: it exercises the **frozen `db.cjs` wrapper's own statement** (`insertOne` on the audit table under the runtime role), not `generation-store`/`generation-kernel` end to end — the kernel path needs SQL Server, which this lane does not have. The statement is the one the frozen code emits, and the privilege is what refuses it; the arm proves that, not a full kernel run.

Conversely, the Gap 1 positive arm is stronger than a privilege check: it ran the **entire provisioning transaction to commit**, so the 071/072 trigger-side privileges (authority-state guard, terminal-signer history) are covered empirically rather than by inspection.

### Least-privilege check — with 074 applied

Operations 073 deliberately withholds are still refused, and the repair adds no write capability:

```
[present] provisioning UPDATE public_key_spki_der -> REFUSED SQLSTATE=42501
[present] provisioning UPDATE signature_algorithm -> REFUSED SQLSTATE=42501
[present] provisioning DELETE signer_public_keys -> REFUSED SQLSTATE=42501
[present] provisioning SELECT stock_prep_runs -> REFUSED SQLSTATE=42501
[present] provisioning INSERT generations (withheld by 073) -> REFUSED SQLSTATE=42501
[present] provisioning INSERT ingestion_sessions (withheld by 073) -> REFUSED SQLSTATE=42501
[present] provisioning UPDATE updated_at (the granted column) -> ALLOWED rows=1
[present] trigger neutralises the granted column: rowsHoldingAttemptedValue=0
[present] runtime UPDATE authority_state -> REFUSED SQLSTATE=42501
[present] runtime SELECT authority_state FOR UPDATE (gap 2, deliberately unchanged) -> REFUSED SQLSTATE=42501
[present] runtime INSERT stock_prep_bindings -> REFUSED SQLSTATE=42501
[present] runtime UPDATE generation_audit (append-only retained) -> REFUSED SQLSTATE=42501
[present] runtime DELETE generation_audit (append-only retained) -> REFUSED SQLSTATE=42501
[present] privilege view {"prov_table_update":false,"prov_col_updated_at":true,"prov_col_key_material":false,"prov_table_delete":false,"runtime_audit_select":true,"runtime_audit_update":false,"runtime_authority_update":false}
[present-final] row counts {"bindings":1,"authority":1,"public_keys":1,"audit":1}
```

### The ratified 073 matrix is undisturbed

The capability matrix from `sealed-export-s6a-runtime-authority.db.test.ts:153-223`, replayed verbatim against both arms:

```
[073 only] ratified matrix identical=PASS {"runtime_binding_select":true,"runtime_binding_insert":false,"runtime_authority_select":true,"runtime_authority_update":false,"runtime_run_insert":true,"runtime_run_update":true,"provisioning_binding_insert":true,"provisioning_generation_insert":false,"provisioning_run_select":false,"provisioning_terminal_select":true,"provisioning_terminal_insert":true}
[073+074] ratified matrix identical=PASS {"runtime_binding_select":true,"runtime_binding_insert":false,"runtime_authority_select":true,"runtime_authority_update":false,"runtime_run_insert":true,"runtime_run_update":true,"provisioning_binding_insert":true,"provisioning_generation_insert":false,"provisioning_run_select":false,"provisioning_terminal_select":true,"provisioning_terminal_insert":true}
matrix unchanged by 074: PASS
```

### 074's fail-closed preamble behaves exactly like 073's

The preamble is copied from 073 deliberately, so both migrations fail closed identically:

```
[no GUC set] 074 APPLIED (no error)
[no GUC set] non-owner grants on the two repaired tables=0
[only runtime GUC] 074 REFUSED SQLSTATE=55000
[same role for both] 074 REFUSED SQLSTATE=55000
[missing role] 074 REFUSED SQLSTATE=55000
[unsafe (superuser) role] 074 REFUSED SQLSTATE=55000
[unsafe role] grants held by the unsafe role=0
[replay 074 twice] 074 APPLIED (no error)
```

A fresh CI database with neither GUC set stays installable and receives **zero** grants.

---

## What is in CI

`packages/core-backend/tests/integration/sealed-export-s6a-grant-repair.db.test.ts` carries all of the above as a real-Postgres gate (two schema-scoped arms, frozen role-bound handle, audit arms, least-privilege arm, ratified-matrix arm, fail-closed arm). Every arm was rehearsed locally against PostgreSQL 16.14 in a faithful transcription before pushing. The existing ratified test file is **not** modified.

It runs from a **new** workflow, `.github/workflows/sealed-export-s6a-grant-repair.yml` (its own `postgres:16` service), not from the existing S5 workflow — see the finding below.

### Finding: the S5 evidence workflow is itself a pinned frozen input

The first push of this PR wired the gate into `.github/workflows/sealed-export-s5-sqlserver.yml`, the natural home. CI refused it: `sealed-export-package-provenance.test.cjs` failed at `verifyPinnedFileEntries` → `assertEqualDigest`, because that workflow is pinned as `s5EvidenceWorkflow` in `PINNED_EVIDENCE_FILES` (`sealed-export-package-provenance.cjs:246-248`) with sha256 `214ebb056db7d93d683328db4bf4c5ea9a553a65321039aaf984d0dbaf4a17d3` in `vectors/s6a-package-provenance-pins.json`. **Editing it changes frozen package-provenance evidence.**

It has been restored byte-identical to `origin/main` (measured digest `214ebb05…` = the pin), and the new workflow additionally asserts that digest on every run so this class of drift fails loudly next time. **This PR now adds three new files and modifies nothing** (`git diff --stat` vs `origin/main`: 3 files changed, 970 insertions, 0 deletions).

Note that the *other* natural home is pinned too: `sealed-export-s6a-runtime-authority.db.test.ts` is `s6aRuntimeAuthorityRealDbTest` in the same `PINNED_EVIDENCE_FILES` list, so extending the ratified test in place would have failed identically. Both obvious places to put this gate are frozen inputs — which is why the gate is a new file in a new workflow.

### The gate is not skip-green

`describeIfDatabase` degrades to `describe.skip` without `DATABASE_URL`, and a fully-skipped file still exits 0. The run on this head reports:

```
✓ tests/integration/sealed-export-s6a-grant-repair.db.test.ts  (6 tests) 842ms
 Test Files  1 passed (1)
      Tests  6 passed (6)
```

---

## What I did NOT do

- Did **not** edit migration 073, and did **not** touch any of #4695's frozen inputs. An early attempt to wire the gate into the pinned S5 evidence workflow was reverted byte-identically once CI proved that file is pinned; the PR now modifies **no** existing file.
- Did **not** add 074 to `PINNED_MIGRATIONS` or to the on-prem package file list — that would change package identity, which is an owner decision.
- Did **not** claim the frozen package is fixed, and did **not** claim S6-B is unblocked.
- Did **not** decide whether to re-freeze — raised as a question only.
- Did **not** fix Gap 2 (runtime → `authority_state` `FOR UPDATE`), because a ratified test asserts that refusal; escalated instead.
- Did **not** modify `sealed-export-s6a-runtime-authority.db.test.ts` or any other ratified assertion.
- Did **not** change any flag default (`MULTITABLE_STOCK_PREP_SQLSERVER_SEALED_SNAPSHOT_ENABLED` stays default-OFF), touch branch protection, merge, push to `main`, mark this ready-for-review, deploy, arm, or act on any entity machine.

Values-free throughout: counts, SQLSTATEs, closed tokens and PASS/FAIL only.
