### PR TITLE
feat(attendance): add fixed-schedule effectiveness read model

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -1149,6 +1149,7 @@ jobs:
             tests/integration/attendance-w4c3c-record-operation-routes.db.test.ts \
             tests/integration/attendance-w4c4-calculation-detail.db.test.ts \
             tests/integration/attendance-group-fixed-schedule-config-migration.db.test.ts \
+            tests/integration/attendance-group-fixed-schedule-effectiveness.db.test.ts \
             tests/integration/attendance-expiry-service.test.ts \
             tests/integration/attendance-unscheduled-reminder.test.ts \
             tests/integration/attendance-outdoor-punch.test.ts \

--- a/packages/core-backend/tests/integration/attendance-group-fixed-schedule-effectiveness.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-group-fixed-schedule-effectiveness.db.test.ts
@@ -226,13 +226,30 @@ describeDb('attendance group fixed-schedule effectiveness (real DB)', () => {
     // becomes an eligible different key, changing the result to configuration_changed.
   })
 
-  it('16: the canonical producer-key builder receives the desired values', async () => {
+  it('16: a foreign-org membership for the same group cannot affect target coverage', async () => {
+    await configure(); await members('member-a'); await assignment()
+    await pool.query(
+      'INSERT INTO attendance_group_members (org_id, group_id, user_id) VALUES ($1, $2, $3)',
+      ['foreign-org', groupId, 'foreign-member'],
+    )
+    const result = await read()
+    expect(result).toMatchObject({
+      state: 'effective',
+      reasonCodes: ['EFFECTIVE'],
+      coverage: { targetMembers: 1, matchingMembers: 1, missingMembers: 0 },
+    })
+    expect(JSON.stringify(result)).not.toContain('foreign-member')
+    // Mutation proof: remove `org_id = $1` from the membership query and the
+    // foreign member becomes a missing target, changing the state to pending_apply.
+  })
+
+  it('17: the canonical producer-key builder receives the desired values', async () => {
     await configure(); await members('member-a'); await assignment()
     expect(await read()).toMatchObject({ desired: { shiftId, startDate: '2026-08-01', endDate: '2026-08-31', revision: 1 }, evaluatedAt: now })
     expect(canonicalBuilderCalls).toEqual([{ groupId, shiftId, startDate: '2026-08-01', endDate: '2026-08-31' }])
   })
 
-  it('17: group ownership is org-scoped before dependent reads', async () => {
+  it('18: group ownership is org-scoped before dependent reads', async () => {
     await expect(service.getEffectiveness(db(), { orgId: 'foreign-org', groupId })).rejects.toMatchObject({ status: 404, code: 'NOT_FOUND' })
     expect(queryLog).toHaveLength(1)
   })

--- a/packages/core-backend/tests/integration/attendance-group-fixed-schedule-effectiveness.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-group-fixed-schedule-effectiveness.db.test.ts
@@ -1,0 +1,239 @@
+import { randomUUID } from 'node:crypto'
+import { createRequire } from 'node:module'
+
+import { Pool } from 'pg'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+const require = createRequire(import.meta.url)
+const {
+  createAttendanceGroupFixedScheduleEffectivenessService,
+} = require('../../../../plugins/plugin-attendance/lib/attendance-group-fixed-schedule-effectiveness-service.cjs') as {
+  createAttendanceGroupFixedScheduleEffectivenessService: (input: Record<string, unknown>) => { getEffectiveness: (db: unknown, input: Record<string, string>) => Promise<any> }
+}
+
+class FakeHttpError extends Error {
+  constructor(public status: number, public code: string, message: string) {
+    super(message)
+  }
+}
+
+const databaseUrl = process.env.DATABASE_URL
+const describeDb = databaseUrl ? describe : describe.skip
+const producerType = 'attendance_group_fixed_schedule'
+
+function producerKey(input: { groupId: string; shiftId: string; startDate: string; endDate: string | null }) {
+  return [producerType, input.groupId, input.shiftId, input.startDate, input.endDate ?? 'null'].join(':')
+}
+
+describeDb('attendance group fixed-schedule effectiveness (real DB)', () => {
+  let adminPool: Pool
+  let pool: Pool
+  let schema: string
+  let orgId: string
+  let groupId: string
+  let shiftId: string
+  let queryLog: string[]
+  let canonicalBuilderCalls: Array<{ groupId: string; shiftId: string; startDate: string; endDate: string | null }>
+  const now = '2026-08-04T00:00:00.000Z'
+
+  const service = createAttendanceGroupFixedScheduleEffectivenessService({
+    HttpError: FakeHttpError,
+    buildAttendanceGroupFixedScheduleProducerKey: (input: { groupId: string; shiftId: string; startDate: string; endDate: string | null }) => {
+      canonicalBuilderCalls.push(input)
+      return producerKey(input)
+    },
+    now: () => now,
+  })
+
+  beforeEach(async () => {
+    adminPool = new Pool({ connectionString: databaseUrl })
+    schema = `fser2_${randomUUID().replace(/-/g, '')}`
+    await adminPool.query(`CREATE SCHEMA "${schema}"`)
+    pool = new Pool({ connectionString: databaseUrl, options: `-c search_path=${schema}` })
+    queryLog = []
+    canonicalBuilderCalls = []
+    orgId = `org-${randomUUID()}`
+    groupId = randomUUID()
+    shiftId = randomUUID()
+    await pool.query(`
+      CREATE TABLE attendance_groups (id uuid PRIMARY KEY, org_id text NOT NULL);
+      CREATE TABLE attendance_group_fixed_schedule_configs (
+        org_id text NOT NULL, group_id uuid NOT NULL, shift_id uuid NOT NULL,
+        start_date date NOT NULL, end_date date NOT NULL, revision integer NOT NULL,
+        PRIMARY KEY (org_id, group_id)
+      );
+      CREATE TABLE attendance_group_members (org_id text NOT NULL, group_id uuid NOT NULL, user_id text NOT NULL);
+      CREATE TABLE attendance_shift_assignments (
+        id uuid PRIMARY KEY, org_id text NOT NULL, user_id text NOT NULL, shift_id uuid NOT NULL,
+        start_date date NOT NULL, end_date date, is_active boolean, publish_status text,
+        producer_type text, producer_ref_id uuid, producer_key text, created_at timestamptz NOT NULL DEFAULT now()
+      );
+    `)
+    await pool.query('INSERT INTO attendance_groups (id, org_id) VALUES ($1, $2)', [groupId, orgId])
+  })
+
+  afterEach(async () => {
+    await pool.end()
+    await adminPool.query(`DROP SCHEMA IF EXISTS "${schema}" CASCADE`)
+    await adminPool.end()
+  })
+
+  function db() {
+    return {
+      async query(statement: string, params?: unknown[]) {
+        queryLog.push(statement)
+        return (await pool.query(statement, params as unknown[])).rows
+      },
+    }
+  }
+
+  async function configure(overrides: Partial<{ shiftId: string; startDate: string; endDate: string; revision: number }> = {}) {
+    await pool.query(
+      `INSERT INTO attendance_group_fixed_schedule_configs (org_id, group_id, shift_id, start_date, end_date, revision)
+       VALUES ($1, $2, $3, $4, $5, $6)`,
+      [orgId, groupId, overrides.shiftId ?? shiftId, overrides.startDate ?? '2026-08-01', overrides.endDate ?? '2026-08-31', overrides.revision ?? 1],
+    )
+  }
+
+  async function members(...userIds: string[]) {
+    for (const userId of userIds) {
+      await pool.query('INSERT INTO attendance_group_members (org_id, group_id, user_id) VALUES ($1, $2, $3)', [orgId, groupId, userId])
+    }
+  }
+
+  async function assignment(overrides: Partial<{ userId: string; shiftId: string; startDate: string; endDate: string | null; producerKey: string; publishStatus: string; active: boolean }> = {}) {
+    const startDate = overrides.startDate ?? '2026-08-01'
+    const endDate = overrides.endDate ?? '2026-08-31'
+    await pool.query(
+      `INSERT INTO attendance_shift_assignments
+         (id, org_id, user_id, shift_id, start_date, end_date, is_active, publish_status, producer_type, producer_ref_id, producer_key)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)`,
+      [
+        randomUUID(), orgId, overrides.userId ?? 'member-a', overrides.shiftId ?? shiftId, startDate, endDate,
+        overrides.active ?? true, overrides.publishStatus ?? 'published', producerType, groupId,
+        overrides.producerKey ?? producerKey({ groupId, shiftId: overrides.shiftId ?? shiftId, startDate, endDate }),
+      ],
+    )
+  }
+
+  async function read() {
+    queryLog = []
+    const tableNames = [
+      'attendance_groups',
+      'attendance_group_fixed_schedule_configs',
+      'attendance_group_members',
+      'attendance_shift_assignments',
+    ]
+    const countRows = () => Promise.all(tableNames.map(async tableName => {
+      const result = await pool.query(`SELECT count(*)::int AS total FROM ${tableName}`)
+      return result.rows[0].total
+    }))
+    const before = await countRows()
+    const result = await service.getEffectiveness(db(), { orgId, groupId })
+    const after = await countRows()
+    expect(after).toEqual(before)
+    expect(queryLog).toHaveLength(4)
+    expect(queryLog.every(statement => /^\s*SELECT\b/i.test(statement))).toBe(true)
+    return result
+  }
+
+  it('1: no config is not_configured', async () => {
+    await members('member-a')
+    expect((await read()).state).toBe('not_configured')
+  })
+
+  it('2: historical managed rows without config remain drift, not intent', async () => {
+    await assignment()
+    const result = await read()
+    expect(result).toMatchObject({ state: 'not_configured', reasonCodes: ['NO_DESIRED_CONFIG'], drift: { unconfiguredManagedRows: 1 } })
+  })
+
+  it('3: newly saved config is pending_apply', async () => {
+    await configure(); await members('member-a')
+    expect(await read()).toMatchObject({ state: 'pending_apply', reasonCodes: ['TARGET_MEMBER_MISSING'] })
+  })
+
+  it('4: configured group without members is pending_apply', async () => {
+    await configure()
+    expect(await read()).toMatchObject({ state: 'pending_apply', reasonCodes: ['NO_TARGET_MEMBERS'] })
+  })
+
+  it('5: exact complete published coverage is effective', async () => {
+    await configure(); await members('member-a', 'member-b'); await assignment(); await assignment({ userId: 'member-b' })
+    expect(await read()).toMatchObject({ state: 'effective', reasonCodes: ['EFFECTIVE'], coverage: { matchingMembers: 2 } })
+  })
+
+  it('6: an eligible old key is configuration_changed', async () => {
+    await configure(); await members('member-a'); await assignment({ shiftId: randomUUID(), startDate: '2026-07-01', endDate: '2026-07-31' })
+    expect(await read()).toMatchObject({ state: 'configuration_changed', reasonCodes: ['DIFFERENT_MANAGED_KEY_ACTIVE', 'TARGET_MEMBER_MISSING'] })
+  })
+
+  it('7: configuration_changed takes precedence over missing coverage', async () => {
+    await configure(); await members('member-a', 'member-b'); await assignment({ shiftId: randomUUID(), startDate: '2026-07-01', endDate: '2026-07-31' })
+    expect(await read()).toMatchObject({ state: 'configuration_changed', reasonCodes: ['DIFFERENT_MANAGED_KEY_ACTIVE', 'TARGET_MEMBER_MISSING'] })
+  })
+
+  it('8: a missing current member is pending_apply', async () => {
+    await configure(); await members('member-a', 'member-b'); await assignment()
+    expect(await read()).toMatchObject({ state: 'pending_apply', reasonCodes: ['TARGET_MEMBER_MISSING'] })
+  })
+
+  it('9: a desired-key row for a former member is pending_apply', async () => {
+    await configure(); await members('member-a'); await assignment(); await assignment({ userId: 'former-member' })
+    expect(await read()).toMatchObject({ state: 'pending_apply', reasonCodes: ['NON_MEMBER_TARGET_ACTIVE'] })
+  })
+
+  it('10: duplicate matching assignments are never effective', async () => {
+    await configure(); await members('member-a'); await assignment(); await assignment()
+    expect(await read()).toMatchObject({ state: 'pending_apply', reasonCodes: ['DUPLICATE_MATCHING_ASSIGNMENT'] })
+  })
+
+  it('11: a matching key with corrupt assignment values is pending_apply', async () => {
+    await configure(); await members('member-a'); await assignment({ shiftId: randomUUID(), producerKey: producerKey({ groupId, shiftId, startDate: '2026-08-01', endDate: '2026-08-31' }) })
+    expect(await read()).toMatchObject({ state: 'pending_apply', reasonCodes: ['TARGET_MEMBER_MISSING', 'ASSIGNMENT_VALUE_MISMATCH'] })
+  })
+
+  it('12: unpublished managed rows are reported but do not cover members', async () => {
+    await configure(); await members('member-a'); await assignment({ publishStatus: 'pending' })
+    expect(await read()).toMatchObject({ state: 'pending_apply', reasonCodes: ['TARGET_MEMBER_MISSING', 'UNPUBLISHED_MANAGED_ROW'], drift: { unpublishedManagedRows: 1 } })
+  })
+
+  it('13: inactive rows are ignored', async () => {
+    await configure(); await members('member-a'); await assignment({ active: false })
+    expect(await read()).toMatchObject({ state: 'pending_apply', reasonCodes: ['TARGET_MEMBER_MISSING'], drift: { unpublishedManagedRows: 0 } })
+  })
+
+  it('14: managed-set metadata is values-only and deterministic', async () => {
+    await configure(); await members('member-a'); await assignment({ shiftId: randomUUID(), startDate: '2026-07-01', endDate: '2026-07-31' })
+    const result = await read()
+    expect(result.drift.managedSets).toHaveLength(1)
+    expect(JSON.stringify(result)).not.toContain('member-a')
+  })
+
+  it('15: a foreign-org row targeting this group cannot affect this group', async () => {
+    await configure(); await members('member-a'); await assignment()
+    const foreignShiftId = randomUUID()
+    await pool.query(
+      `INSERT INTO attendance_shift_assignments
+         (id, org_id, user_id, shift_id, start_date, end_date, is_active, publish_status, producer_type, producer_ref_id, producer_key)
+       VALUES ($1, 'foreign-org', 'foreign-member', $2, '2026-07-01', '2026-07-31', true, 'published', $3, $4, $5)`,
+      [randomUUID(), foreignShiftId, producerType, groupId, producerKey({ groupId, shiftId: foreignShiftId, startDate: '2026-07-01', endDate: '2026-07-31' })],
+    )
+    const result = await read()
+    expect(result).toMatchObject({ state: 'effective', reasonCodes: ['EFFECTIVE'] })
+    expect(JSON.stringify(result)).not.toContain('foreign-member')
+    // Mutation proof: remove `org_id = $1` from the managed-row query and this row
+    // becomes an eligible different key, changing the result to configuration_changed.
+  })
+
+  it('16: the canonical producer-key builder receives the desired values', async () => {
+    await configure(); await members('member-a'); await assignment()
+    expect(await read()).toMatchObject({ desired: { shiftId, startDate: '2026-08-01', endDate: '2026-08-31', revision: 1 }, evaluatedAt: now })
+    expect(canonicalBuilderCalls).toEqual([{ groupId, shiftId, startDate: '2026-08-01', endDate: '2026-08-31' }])
+  })
+
+  it('17: group ownership is org-scoped before dependent reads', async () => {
+    await expect(service.getEffectiveness(db(), { orgId: 'foreign-org', groupId })).rejects.toMatchObject({ status: 404, code: 'NOT_FOUND' })
+    expect(queryLog).toHaveLength(1)
+  })
+})

--- a/packages/core-backend/tests/unit/attendance-group-fixed-schedule-effectiveness-service.test.ts
+++ b/packages/core-backend/tests/unit/attendance-group-fixed-schedule-effectiveness-service.test.ts
@@ -1,0 +1,69 @@
+import { createRequire } from 'node:module'
+
+import { describe, expect, it } from 'vitest'
+
+const require = createRequire(import.meta.url)
+const {
+  deriveAttendanceGroupFixedScheduleEffectiveness,
+} = require('../../../../plugins/plugin-attendance/lib/attendance-group-fixed-schedule-effectiveness-service.cjs') as {
+  deriveAttendanceGroupFixedScheduleEffectiveness: (input: Record<string, unknown>) => Record<string, unknown>
+}
+
+const desired = { shiftId: 'shift-current', startDate: '2026-08-01', endDate: '2026-08-31', revision: 2 }
+const producerKey = 'attendance_group_fixed_schedule:group-1:shift-current:2026-08-01:2026-08-31'
+const oldProducerKey = 'attendance_group_fixed_schedule:group-1:shift-old:2026-07-01:2026-07-31'
+
+function assignment(overrides: Record<string, unknown> = {}) {
+  return {
+    user_id: 'member-a',
+    shift_id: desired.shiftId,
+    start_date: desired.startDate,
+    end_date: desired.endDate,
+    publish_status: 'published',
+    producer_key: producerKey,
+    ...overrides,
+  }
+}
+
+function derive(overrides: Record<string, unknown> = {}) {
+  return deriveAttendanceGroupFixedScheduleEffectiveness({
+    desired,
+    targetMemberIds: ['member-a'],
+    managedRows: [],
+    producerKey,
+    evaluatedAt: '2026-08-04T00:00:00.000Z',
+    ...overrides,
+  })
+}
+
+describe('attendance group fixed-schedule effectiveness derivation', () => {
+  // Mutation proofs: removing configuration-changed precedence, treating duplicate
+  // matching rows as effective, or changing the reason-order filter each reds a case.
+  it.each([
+    ['no config', { desired: null }, 'not_configured', ['NO_DESIRED_CONFIG']],
+    ['no config with historical rows', { desired: null, managedRows: [assignment({ producer_key: oldProducerKey })] }, 'not_configured', ['NO_DESIRED_CONFIG']],
+    ['new desired config', {}, 'pending_apply', ['TARGET_MEMBER_MISSING']],
+    ['configured group without members', { targetMemberIds: [] }, 'pending_apply', ['NO_TARGET_MEMBERS']],
+    ['complete exact coverage', { managedRows: [assignment()] }, 'effective', ['EFFECTIVE']],
+    ['different managed key', { managedRows: [assignment({ producer_key: oldProducerKey })] }, 'configuration_changed', ['DIFFERENT_MANAGED_KEY_ACTIVE', 'TARGET_MEMBER_MISSING']],
+    ['different key takes precedence over duplicate and missing coverage', { managedRows: [assignment({ producer_key: oldProducerKey }), assignment(), assignment()] }, 'configuration_changed', ['DIFFERENT_MANAGED_KEY_ACTIVE', 'DUPLICATE_MATCHING_ASSIGNMENT']],
+    ['missing target member', { targetMemberIds: ['member-a', 'member-b'], managedRows: [assignment()] }, 'pending_apply', ['TARGET_MEMBER_MISSING']],
+    ['non-member target', { managedRows: [assignment(), assignment({ user_id: 'former-member' })] }, 'pending_apply', ['NON_MEMBER_TARGET_ACTIVE']],
+    ['duplicate matching assignment', { managedRows: [assignment(), assignment()] }, 'pending_apply', ['DUPLICATE_MATCHING_ASSIGNMENT']],
+    ['matching key with mismatched values', { managedRows: [assignment({ shift_id: 'shift-corrupt' })] }, 'pending_apply', ['TARGET_MEMBER_MISSING', 'ASSIGNMENT_VALUE_MISMATCH']],
+    ['unpublished desired row', { managedRows: [assignment({ publish_status: 'pending' })] }, 'pending_apply', ['TARGET_MEMBER_MISSING', 'UNPUBLISHED_MANAGED_ROW']],
+    ['unpublished historical row without config', { desired: null, managedRows: [assignment({ producer_key: oldProducerKey, publish_status: 'reopened' })] }, 'not_configured', ['NO_DESIRED_CONFIG']],
+    ['unpublished row does not override eligible old key precedence', { managedRows: [assignment({ producer_key: oldProducerKey }), assignment({ publish_status: 'pending' })] }, 'configuration_changed', ['DIFFERENT_MANAGED_KEY_ACTIVE', 'TARGET_MEMBER_MISSING', 'UNPUBLISHED_MANAGED_ROW']],
+    ['inactive historical row is absent from the evaluator input', { managedRows: [assignment()] }, 'effective', ['EFFECTIVE']],
+    ['reason ordering is stable', { targetMemberIds: [], managedRows: [assignment({ producer_key: oldProducerKey, publish_status: 'pending' })] }, 'pending_apply', ['NO_TARGET_MEMBERS', 'UNPUBLISHED_MANAGED_ROW']],
+  ])('%s', (_name, input, state, reasonCodes) => {
+    const result = derive(input as Record<string, unknown>)
+    expect(result.state).toBe(state)
+    expect(result.reasonCodes).toEqual(reasonCodes)
+  })
+
+  it('never includes member identifiers in its projection', () => {
+    const result = JSON.stringify(derive({ managedRows: [assignment()] }))
+    expect(result).not.toContain('member-a')
+  })
+})

--- a/packages/core-backend/tests/unit/attendance-uuid-validation-routes.test.ts
+++ b/packages/core-backend/tests/unit/attendance-uuid-validation-routes.test.ts
@@ -4138,7 +4138,10 @@ describe('attendance UUID route validation', () => {
   })
 
   it('rejects every forged actor selector on every existing fixed-schedule route', async () => {
+    // Mutation proof: moving fixed-schedule actor resolution behind scoped work makes
+    // the effectiveness GET leg call db.query before its 403 assertion.
     const cases = [
+      { key: 'GET /api/attendance/groups/:groupId/fixed-schedule/effectiveness', params: { groupId: attendanceGroupId } },
       { key: 'POST /api/attendance/groups/:id/fixed-schedule/preview', params: { id: attendanceGroupId } },
       { key: 'POST /api/attendance/groups/:id/fixed-schedule/apply', params: { id: attendanceGroupId } },
       { key: 'POST /api/attendance/groups/:id/fixed-schedule/rebuild', params: { id: attendanceGroupId } },
@@ -4192,6 +4195,7 @@ describe('attendance UUID route validation', () => {
   it('fails every fixed-schedule route closed when authenticated actor context is incomplete', async () => {
     const cases = [
       { key: 'PUT /api/attendance/groups/:groupId/fixed-schedule/config', params: { groupId: attendanceGroupId } },
+      { key: 'GET /api/attendance/groups/:groupId/fixed-schedule/effectiveness', params: { groupId: attendanceGroupId } },
       { key: 'POST /api/attendance/groups/:id/fixed-schedule/preview', params: { id: attendanceGroupId } },
       { key: 'POST /api/attendance/groups/:id/fixed-schedule/apply', params: { id: attendanceGroupId } },
       { key: 'POST /api/attendance/groups/:id/fixed-schedule/rebuild', params: { id: attendanceGroupId } },
@@ -4224,5 +4228,20 @@ describe('attendance UUID route validation', () => {
       expect(missingOrgDb.query, `${testCase.key} (missing org)`).not.toHaveBeenCalled()
       expect(missingOrgDb.transaction, `${testCase.key} (missing org)`).not.toHaveBeenCalled()
     }
+  })
+
+  it('fails the effectiveness route closed for missing schema after trusted actor resolution', async () => {
+    // Mutation proof: removing the route's schema-error branch changes this 503 to 500.
+    const { db, routes } = await createHarness()
+    db.query.mockRejectedValue(Object.assign(new Error('relation does not exist'), { code: '42P01' }))
+
+    const res = await invokeRoute(routes, 'GET /api/attendance/groups/:groupId/fixed-schedule/effectiveness', {
+      params: { groupId: attendanceGroupId },
+      user: { id: 'admin-1', orgId: 'default' },
+    })
+
+    expect(res.statusCode).toBe(503)
+    expect(res.body).toMatchObject({ error: { code: 'DB_NOT_READY' } })
+    expect(db.query).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/core-backend/tests/unit/attendance-uuid-validation-routes.test.ts
+++ b/packages/core-backend/tests/unit/attendance-uuid-validation-routes.test.ts
@@ -4244,4 +4244,34 @@ describe('attendance UUID route validation', () => {
     expect(res.body).toMatchObject({ error: { code: 'DB_NOT_READY' } })
     expect(db.query).toHaveBeenCalledTimes(1)
   })
+
+  it('requires attendance admin permission for effectiveness reads and admits an authenticated admin', async () => {
+    const invokeEffectiveness = async (admin: boolean) => {
+      const { db, routes } = await createHarness('false')
+      db.query.mockImplementation(async (sql: string, params: unknown[] = []) => {
+        const rbac = rbacQueryResult(sql, params, admin)
+        if (rbac !== undefined) return rbac
+        if (sql.includes('SELECT id FROM attendance_groups')) return [{ id: attendanceGroupId }]
+        if (sql.includes('FROM attendance_group_fixed_schedule_configs')) return []
+        if (sql.includes('FROM attendance_group_members')) return []
+        if (sql.includes('FROM attendance_shift_assignments')) return []
+        throw new Error(`unexpected query: ${sql}`)
+      })
+      const res = await invokeRoute(routes, 'GET /api/attendance/groups/:groupId/fixed-schedule/effectiveness', {
+        params: { groupId: attendanceGroupId },
+        user: { id: 'admin-1', orgId: 'default' },
+      })
+      return { db, res }
+    }
+
+    const denied = await invokeEffectiveness(false)
+    expect(denied.res.statusCode).toBe(403)
+    expect(denied.res.body).toMatchObject({ ok: false, error: { code: 'FORBIDDEN' } })
+    expect(denied.db.query.mock.calls.some(([sql]) => String(sql).includes('attendance_groups'))).toBe(false)
+
+    const allowed = await invokeEffectiveness(true)
+    expect(allowed.res.statusCode).toBe(200)
+    expect(allowed.res.body).toMatchObject({ ok: true, data: { state: 'not_configured' } })
+    expect(allowed.db.query.mock.calls.some(([sql]) => String(sql).includes('attendance_groups'))).toBe(true)
+  })
 })

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -645,6 +645,9 @@ export default defineConfig({
       // #4709 FSER-1 desired-config migration, composite FKs, idempotent writes,
       // and reference-writer/delete lock protocol against real PostgreSQL.
       'tests/integration/attendance-group-fixed-schedule-config-migration.db.test.ts',
+      // #4709 FSER-2 effectiveness read model requires real PostgreSQL and is run as a
+      // whole file in the attendance real-DB workflow step.
+      'tests/integration/attendance-group-fixed-schedule-effectiveness.db.test.ts',
       // #4556 W2 adds route-level work-date attribution legs to this whole-file real-DB
       // suite. Keep it out of the no-DB lane so describeDb cannot report skipped green;
       // plugin-tests.yml executes the complete file with ATTENDANCE_TEST_DATABASE_URL.

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -14,6 +14,7 @@ const attendanceWorkDateResolverLib = require('./lib/attendance-work-date-resolv
 const attendanceWorkDateAdaptersLib = require('./lib/attendance-work-date-adapters.cjs')
 const attendanceShiftServiceLib = require('./lib/attendance-shift-service.cjs')
 const attendanceGroupFixedScheduleConfigServiceLib = require('./lib/attendance-group-fixed-schedule-config-service.cjs')
+const attendanceGroupFixedScheduleEffectivenessServiceLib = require('./lib/attendance-group-fixed-schedule-effectiveness-service.cjs')
 const {
   DEFAULT_ATTRIBUTION_TAIL_MINUTES,
   MAX_ATTRIBUTION_TAIL_MINUTES,
@@ -8329,6 +8330,18 @@ function getAttendanceGroupFixedScheduleConfigService() {
       .createAttendanceGroupFixedScheduleConfigService({ HttpError })
   }
   return attendanceGroupFixedScheduleConfigService
+}
+
+let attendanceGroupFixedScheduleEffectivenessService = null
+function getAttendanceGroupFixedScheduleEffectivenessService() {
+  if (!attendanceGroupFixedScheduleEffectivenessService) {
+    attendanceGroupFixedScheduleEffectivenessService = attendanceGroupFixedScheduleEffectivenessServiceLib
+      .createAttendanceGroupFixedScheduleEffectivenessService({
+        HttpError,
+        buildAttendanceGroupFixedScheduleProducerKey,
+      })
+  }
+  return attendanceGroupFixedScheduleEffectivenessService
 }
 
 function assertWorkContextSegmentCalculationAllowed(orgId, workContext) {
@@ -44212,6 +44225,40 @@ module.exports = {
           res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to remove group manager' } })
         }
       })
+    )
+
+    context.api.http.addRoute(
+      'GET',
+      '/api/attendance/groups/:groupId/fixed-schedule/effectiveness',
+      async (req, res, next) => {
+        const actorAccess = await resolveAttendanceFixedScheduleRouteActorContext(req, res)
+        if (!actorAccess) return
+        return withPermission('attendance:admin', async (permissionReq, permissionRes) => {
+          const groupId = normalizeUuidString(permissionReq.params.groupId)
+          if (!groupId) {
+            respondInvalidUuid(permissionRes, 'groupId')
+            return
+          }
+          try {
+            const effectiveness = await getAttendanceGroupFixedScheduleEffectivenessService().getEffectiveness(db, {
+              orgId: actorAccess.orgId,
+              groupId,
+            })
+            permissionRes.json({ ok: true, data: effectiveness })
+          } catch (error) {
+            if (error instanceof HttpError) {
+              permissionRes.status(error.status).json({ ok: false, error: { code: error.code, message: error.message } })
+              return
+            }
+            if (isDatabaseSchemaError(error)) {
+              permissionRes.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: 'Attendance fixed schedule tables missing' } })
+              return
+            }
+            logger.error('Attendance group fixed schedule effectiveness read failed', error)
+            permissionRes.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to read fixed schedule effectiveness' } })
+          }
+        })(req, res, next)
+      }
     )
 
     context.api.http.addRoute(

--- a/plugins/plugin-attendance/lib/attendance-group-fixed-schedule-effectiveness-service.cjs
+++ b/plugins/plugin-attendance/lib/attendance-group-fixed-schedule-effectiveness-service.cjs
@@ -1,0 +1,218 @@
+'use strict'
+
+const REASON_ORDER = [
+  'NO_DESIRED_CONFIG',
+  'NO_TARGET_MEMBERS',
+  'DIFFERENT_MANAGED_KEY_ACTIVE',
+  'TARGET_MEMBER_MISSING',
+  'NON_MEMBER_TARGET_ACTIVE',
+  'DUPLICATE_MATCHING_ASSIGNMENT',
+  'ASSIGNMENT_VALUE_MISMATCH',
+  'UNPUBLISHED_MANAGED_ROW',
+  'EFFECTIVE',
+]
+
+function formatDateOnly(value) {
+  if (value == null) return null
+  if (value instanceof Date) {
+    return [value.getFullYear(), value.getMonth() + 1, value.getDate()]
+      .map((part, index) => index === 0 ? String(part) : String(part).padStart(2, '0'))
+      .join('-')
+  }
+  const normalized = String(value)
+  const match = normalized.match(/^\d{4}-\d{2}-\d{2}/)
+  return match ? match[0] : normalized
+}
+
+function mapDesired(row) {
+  if (!row) return null
+  return {
+    shiftId: row.shift_id,
+    startDate: formatDateOnly(row.start_date),
+    endDate: formatDateOnly(row.end_date),
+    revision: Number(row.revision),
+  }
+}
+
+function isPublished(row) {
+  return (row.publish_status ?? 'published') === 'published'
+}
+
+function assignmentMatchesDesired(row, desired) {
+  return String(row.shift_id) === String(desired.shiftId)
+    && formatDateOnly(row.start_date) === desired.startDate
+    && formatDateOnly(row.end_date) === desired.endDate
+}
+
+function buildManagedSets(rows) {
+  const sets = new Map()
+  for (const row of rows) {
+    const key = [row.producer_key, row.shift_id, formatDateOnly(row.start_date), formatDateOnly(row.end_date)].join('|')
+    const current = sets.get(key)
+    if (current) {
+      current.rowCount += 1
+      continue
+    }
+    sets.set(key, {
+      shiftId: row.shift_id,
+      startDate: formatDateOnly(row.start_date),
+      endDate: formatDateOnly(row.end_date),
+      producerKey: row.producer_key,
+      rowCount: 1,
+    })
+  }
+  return [...sets.values()].sort((left, right) => {
+    const leftKey = `${left.producerKey}|${left.shiftId}|${left.startDate}|${left.endDate}`
+    const rightKey = `${right.producerKey}|${right.shiftId}|${right.startDate}|${right.endDate}`
+    return leftKey.localeCompare(rightKey)
+  })
+}
+
+function deriveAttendanceGroupFixedScheduleEffectiveness({ desired, targetMemberIds, managedRows, producerKey, evaluatedAt }) {
+  const members = new Set(targetMemberIds.map(String))
+  const publishedRows = managedRows.filter(isPublished)
+  const unpublishedRows = managedRows.filter(row => !isPublished(row))
+  const coverage = {
+    targetMembers: members.size,
+    matchingMembers: 0,
+    missingMembers: members.size,
+    nonMemberTargets: 0,
+    differentKeyRows: 0,
+  }
+
+  if (!desired) {
+    return {
+      state: 'not_configured',
+      reasonCodes: ['NO_DESIRED_CONFIG'],
+      desired: null,
+      coverage,
+      drift: {
+        unconfiguredManagedRows: managedRows.length,
+        unpublishedManagedRows: unpublishedRows.length,
+        managedSets: buildManagedSets(managedRows),
+      },
+      evaluatedAt,
+    }
+  }
+
+  const differentKeyRows = publishedRows.filter(row => row.producer_key !== producerKey)
+  const matchingKeyRows = publishedRows.filter(row => row.producer_key === producerKey)
+  const matchingRowsByMember = new Map()
+  let duplicateMatchingAssignment = false
+  let assignmentValueMismatch = false
+
+  for (const row of matchingKeyRows) {
+    const userId = String(row.user_id)
+    if (!members.has(userId)) {
+      coverage.nonMemberTargets += 1
+      continue
+    }
+    if (!assignmentMatchesDesired(row, desired)) {
+      assignmentValueMismatch = true
+      continue
+    }
+    const rows = matchingRowsByMember.get(userId) ?? []
+    rows.push(row)
+    matchingRowsByMember.set(userId, rows)
+  }
+
+  for (const userId of members) {
+    const rows = matchingRowsByMember.get(userId) ?? []
+    if (rows.length) coverage.matchingMembers += 1
+    if (rows.length > 1) duplicateMatchingAssignment = true
+  }
+  coverage.missingMembers = coverage.targetMembers - coverage.matchingMembers
+  coverage.differentKeyRows = differentKeyRows.length
+
+  const reasons = new Set()
+  if (!coverage.targetMembers) reasons.add('NO_TARGET_MEMBERS')
+  if (differentKeyRows.length) reasons.add('DIFFERENT_MANAGED_KEY_ACTIVE')
+  if (coverage.missingMembers) reasons.add('TARGET_MEMBER_MISSING')
+  if (coverage.nonMemberTargets) reasons.add('NON_MEMBER_TARGET_ACTIVE')
+  if (duplicateMatchingAssignment) reasons.add('DUPLICATE_MATCHING_ASSIGNMENT')
+  if (assignmentValueMismatch) reasons.add('ASSIGNMENT_VALUE_MISMATCH')
+  if (unpublishedRows.length) reasons.add('UNPUBLISHED_MANAGED_ROW')
+
+  const effective = coverage.targetMembers > 0
+    && !differentKeyRows.length
+    && !coverage.missingMembers
+    && !coverage.nonMemberTargets
+    && !duplicateMatchingAssignment
+    && !assignmentValueMismatch
+  if (effective) reasons.add('EFFECTIVE')
+
+  return {
+    state: differentKeyRows.length ? 'configuration_changed' : effective ? 'effective' : 'pending_apply',
+    reasonCodes: REASON_ORDER.filter(reason => reasons.has(reason)),
+    desired,
+    coverage,
+    drift: {
+      unconfiguredManagedRows: 0,
+      unpublishedManagedRows: unpublishedRows.length,
+      managedSets: buildManagedSets(differentKeyRows),
+    },
+    evaluatedAt,
+  }
+}
+
+function createAttendanceGroupFixedScheduleEffectivenessService({ HttpError, buildAttendanceGroupFixedScheduleProducerKey, now = () => new Date().toISOString() }) {
+  async function getEffectiveness(db, input) {
+    const groupRows = await db.query(
+      'SELECT id FROM attendance_groups WHERE id = $1 AND org_id = $2 LIMIT 1',
+      [input.groupId, input.orgId],
+    )
+    if (!groupRows.length) throw new HttpError(404, 'NOT_FOUND', 'Group not found')
+
+    const configRows = await db.query(
+      `SELECT shift_id, start_date, end_date, revision
+         FROM attendance_group_fixed_schedule_configs
+        WHERE org_id = $1 AND group_id = $2
+        LIMIT 1`,
+      [input.orgId, input.groupId],
+    )
+    const memberRows = await db.query(
+      `SELECT DISTINCT user_id
+         FROM attendance_group_members
+        WHERE org_id = $1 AND group_id = $2
+        ORDER BY user_id ASC`,
+      [input.orgId, input.groupId],
+    )
+    const managedRows = await db.query(
+      `SELECT user_id, shift_id, start_date, end_date, publish_status, producer_key
+         FROM attendance_shift_assignments
+        WHERE org_id = $1
+          AND producer_type = 'attendance_group_fixed_schedule'
+          AND producer_ref_id = $2
+          AND COALESCE(is_active, true) = true
+        ORDER BY producer_key ASC, user_id ASC, start_date ASC, created_at ASC, id ASC`,
+      [input.orgId, input.groupId],
+    )
+    const desired = mapDesired(configRows[0])
+    const producerKey = desired
+      ? buildAttendanceGroupFixedScheduleProducerKey({
+        groupId: input.groupId,
+        shiftId: desired.shiftId,
+        startDate: desired.startDate,
+        endDate: desired.endDate,
+      })
+      : null
+    return {
+      groupId: input.groupId,
+      ...deriveAttendanceGroupFixedScheduleEffectiveness({
+        desired,
+        targetMemberIds: memberRows.map(row => row.user_id),
+        managedRows,
+        producerKey,
+        evaluatedAt: now(),
+      }),
+    }
+  }
+
+  return { getEffectiveness }
+}
+
+module.exports = {
+  REASON_ORDER,
+  deriveAttendanceGroupFixedScheduleEffectiveness,
+  createAttendanceGroupFixedScheduleEffectivenessService,
+}

--- a/plugins/plugin-integration-core/lib/sealed-export/vectors/s6a-package-provenance-pins.json
+++ b/plugins/plugin-integration-core/lib/sealed-export/vectors/s6a-package-provenance-pins.json
@@ -86,6 +86,6 @@
     "s6aAcceptancePs51Test": "835c7c6ce943d82e0378a40a27c7fd1e8b79b526faa8ca4c8066e4231a4bfb0f",
     "s6aProductRuntimeTest": "de978adafa8b89772cefa921c2051f434bf346bf5c2978bef3424ee70f51ba3f",
     "multitableOnpremPackageBuild": "463c7d73c6c7f2d1b6cdf0820d7a06974a9c463dd5e98bbbaf1c996e1dc4ed99",
-    "pluginTestsWorkflow": "e53fa3439f43d5fe43ac5f635bc1d69e576995195a5d4ca4885fa5c8a1fb071f"
+    "pluginTestsWorkflow": "1bbf2e384dccf5afd5810c81daf3ce0e71a928e581325fd050dc0d70eaed83dc"
   }
 }


### PR DESCRIPTION
## ⛔ DRAFT / OWNER MERGE HOLD

This PR implements authorized FSER-2 only. It is not authorized to merge, enable flags, deploy, start soak, use production/customer data, or close issue #4556.

## What changed

- add an org-scoped, SELECT-only fixed-schedule effectiveness service
- add `GET /api/attendance/groups/:groupId/fixed-schedule/effectiveness`
- require authenticated `attendance:admin` access before any effectiveness SQL
- derive the locked four states and deterministic values-free reason codes
- fail closed on forged actor/org selectors and missing schema
- add pure derivation, route, and isolated PostgreSQL coverage
- wire the real-DB suite into the required plugin test job and refresh its sealed workflow provenance pin

## Contract

Implements FSER-2 from `docs/development/attendance-4709-fixed-schedule-effectiveness-read-model-design-lock-20260801.md` against base `ebeafc08be265e458013077887d4b422ee15c09b`.

## Verification

Exact local head: `ac56e466c973e24c939fb028e4e8a9a1fee5403f`.

- `103/103` focused unit + route tests PASS
- `18/18` isolated PostgreSQL tests PASS; per-test schemas removed
- backend type-check PASS
- CJS syntax checks PASS
- `git diff --check` PASS
- independent mutations killed:
  - remove `configuration_changed` precedence -> 3 focused failures
  - remove assignment `org_id` filter -> two-org assignment pollution leg fails
  - replace first SELECT with DELETE -> residue/SELECT-only leg fails
  - alter canonical producer-key input -> canonical builder leg fails
  - remove `attendance:admin` permission wrapper -> non-admin route leg changes 403 to 200
  - remove membership `org_id` filter -> foreign membership changes effective coverage to pending_apply

## Gate status

Fresh exact-head GitHub checks are all green. Independent review: APPROVE, 0 P1 / 0 P2 / 0 P3. This PR remains Draft/HOLD pending a separate owner merge decision.
