### PR TITLE
test(stock-prep): make the negative-control job self-enforcing — assert it went RED for the right reason (R6)

### DIFF
--- a/.github/workflows/stock-preparation-e2e-functional-smoke.yml
+++ b/.github/workflows/stock-preparation-e2e-functional-smoke.yml
@@ -31,9 +31,15 @@ name: Stock Preparation E2E Functional Smoke
 #                         relation. Any part that cannot complete is reported NOT_RUN in the values-free
 #                         result block — never as PASS — and the job goes red if any check that DID run
 #                         failed.
-#   negative-control     — workflow_dispatch only, deliberately RED. Reuses the SAME assertion machinery
-#                         as functional-smoke and asserts a wrong expectation on purpose, proving the
+#   negative-control     — workflow_dispatch only. Reuses the SAME assertion machinery as
+#                         functional-smoke and asserts a wrong expectation on purpose, proving the
 #                         harness can genuinely fail (not a check "that did not happen").
+#                         The SCRIPT is expected to exit non-zero; this JOB is green exactly when the
+#                         discriminator is intact, and red when it is not. Non-zero exit alone is NOT
+#                         the criterion — a crash also exits non-zero — so the job additionally pins
+#                         observed==expected==RED, reachedAssertion, checksRecorded, and
+#                         redBecause==ASSERTION_FAILED_AS_INTENDED. Previously nothing asserted this
+#                         job's colour at all, so a neutered must() would have flipped it green unseen.
 
 on:
   pull_request:
@@ -203,7 +209,7 @@ jobs:
           retention-days: 14
 
   negative-control:
-    name: negative control (deliberately RED — proves the harness can fail)
+    name: negative control (green iff the harness can still genuinely fail)
     if: github.event_name == 'workflow_dispatch'
     needs: contract
     runs-on: ubuntu-latest
@@ -262,9 +268,56 @@ jobs:
             echo "E2E_INTEGRATION_ENCRYPTION_KEY=$enc_key"
           } >> "$GITHUB_ENV"
 
-      - name: Run negative control (this step is EXPECTED to fail)
+      - name: Run negative control and assert it went RED for the RIGHT reason
         env:
           DATABASE_URL: postgresql://postgres:postgres@127.0.0.1:5432/metasheet
           E2E_JWT_SECRET: ${{ env.E2E_JWT_SECRET }}
           E2E_INTEGRATION_ENCRYPTION_KEY: ${{ env.E2E_INTEGRATION_ENCRYPTION_KEY }}
-        run: node scripts/ops/stock-preparation-e2e-negative-control.mjs
+        run: |
+          set -uo pipefail
+          out_file="$RUNNER_TEMP/negative-control.out"
+          node scripts/ops/stock-preparation-e2e-negative-control.mjs | tee "$out_file"
+          script_exit=${PIPESTATUS[0]}
+
+          # Read a field, or the sentinel <ABSENT>. An absent field must FAIL, never silently pass:
+          # a check that could not be evaluated is not a check that passed.
+          field() {
+            local v
+            v=$(grep -E "^$1=" "$out_file" | tail -1 | cut -d= -f2-)
+            if [[ -z "$v" ]]; then echo "<ABSENT>"; else echo "$v"; fi
+          }
+          observed=$(field negativeControlObservedConclusion)
+          expected=$(field expectedConclusion)
+          reached=$(field negativeControlReachedAssertion)
+          recorded=$(field negativeControlChecksRecorded)
+          because=$(field negativeControlRedBecause)
+
+          fail=0
+          note() { echo "FATAL: $1" >&2; fail=1; }
+
+          # 1. The script must have exited non-zero. Necessary, NOT sufficient — a crash also does this,
+          #    which is exactly why the remaining conditions exist.
+          [[ "$script_exit" -ne 0 ]] || note "negative control exited 0 — the harness can no longer fail (a neutered must() does this)"
+          # 2. Observed conclusion must be RED and must equal what the script itself declared it expects.
+          [[ "$observed" == "RED" ]]   || note "observedConclusion=$observed (want RED)"
+          [[ "$expected" == "RED" ]]   || note "expectedConclusion=$expected (want RED)"
+          [[ "$observed" == "$expected" ]] || note "observed/expected diverged: $observed vs $expected"
+          # 3. The assertion must actually have been reached, and exactly one must() call recorded.
+          #    Guards the crash path (reached=false) and the deleted-assertion path (recorded=0).
+          [[ "$reached" == "true" ]]   || note "reachedAssertion=$reached — the script died before asserting; a crash is not a working discriminator"
+          [[ "$recorded" == "1" ]]     || note "checksRecorded=$recorded (want exactly 1)"
+          # 4. RED for the RIGHT reason. HARNESS_ERROR is a crash; GATE_BROKEN_PROBE_RETURNED_200 is a
+          #    live product bug that must surface as a product bug, not be absorbed into "harness can fail".
+          [[ "$because" == "ASSERTION_FAILED_AS_INTENDED" ]] || note "redBecause=$because (want ASSERTION_FAILED_AS_INTENDED)"
+
+          {
+            echo "negativeControlScriptExit=${script_exit}"
+            echo "negativeControlObservedConclusion=${observed}"
+            echo "negativeControlExpectedConclusion=${expected}"
+            echo "negativeControlReachedAssertion=${reached}"
+            echo "negativeControlChecksRecorded=${recorded}"
+            echo "negativeControlRedBecause=${because}"
+            echo "negativeControlDiscriminatorIntact=$([[ $fail -eq 0 ]] && echo PASS || echo FAIL)"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          exit "$fail"

--- a/.github/workflows/stock-preparation-e2e-functional-smoke.yml
+++ b/.github/workflows/stock-preparation-e2e-functional-smoke.yml
@@ -274,7 +274,14 @@ jobs:
           E2E_JWT_SECRET: ${{ env.E2E_JWT_SECRET }}
           E2E_INTEGRATION_ENCRYPTION_KEY: ${{ env.E2E_INTEGRATION_ENCRYPTION_KEY }}
         run: |
-          set -uo pipefail
+          # `set +e` is deliberate and load-bearing. GitHub runs `run:` under `bash -e`, and the script
+          # below is EXPECTED to exit non-zero — under `-e` the step dies on that pipeline before a single
+          # assertion runs, which is exactly how the first attempt at this gate failed (run 30870041141:
+          # the script emitted all-correct fields, no FATAL was printed, step still exited 1).
+          # `-e` must therefore be OFF here; every failure path below is explicit and ends at `exit "$fail"`.
+          # Do not "tidy" this back to `set -e`.
+          set +e
+          set -u
           out_file="$RUNNER_TEMP/negative-control.out"
           node scripts/ops/stock-preparation-e2e-negative-control.mjs | tee "$out_file"
           script_exit=${PIPESTATUS[0]}


### PR DESCRIPTION
## What this closes

The `negative-control` job proves the harness can genuinely fail. Until now **nothing asserted the job's own
colour.** The script was already load-bearing — it imports the real `must()` and derives its exit code from the
recorded checks — but the workflow just ran it and let the job inherit the exit code. A neutered `must()` would
have flipped the job green and nobody would have seen it. That is exactly the property this job exists to detect.

This was disclosed rather than hidden in the S6-A work ("a readable discriminator, not an enforced gate"). This PR
makes it enforced.

## Why "assert it exited non-zero" would NOT have been a fix

**A crash also exits non-zero.** That criterion reads a dead harness as a working discriminator — the same shape as
the skip-green failures this repo already has on record. The script fortunately already emits everything needed to
tell the cases apart, so the job now pins all of them:

| condition | rules out |
|---|---|
| `script_exit != 0` | a neutered `must()` |
| `observedConclusion == expectedConclusion == RED` | the script and its own declared expectation diverging |
| `reachedAssertion == true` | the crash path |
| `checksRecorded == 1` | a deleted assertion ("a check that did not happen") |
| `redBecause == ASSERTION_FAILED_AS_INTENDED` | `HARNESS_ERROR`, and keeps `GATE_BROKEN_PROBE_RETURNED_200` surfacing as the live product bug it is rather than being absorbed into "the harness can fail" |

An absent field reads as `<ABSENT>` and fails — a check that could not be evaluated is not a check that passed.

## The first attempt was RED in CI — and that is the most useful evidence in this PR

`bash -e` is GitHub's default for `run:`. The script being gated is **expected to exit non-zero**, so `-e`
killed the step on that pipeline **before a single assertion executed**. `set -uo pipefail` does not clear `-e`.

Dispatched run **30870041141** — the script emitted entirely correct fields and **not one `FATAL` line**, yet
the step exited 1:

```
negativeControlReachedAssertion=true
negativeControlRedBecause=ASSERTION_FAILED_AS_INTENDED
negativeControlChecksRecorded=1
negativeControlObservedConclusion=RED
##[error]Process completed with exit code 1.
```

The local matrix had passed only because it invoked `bash step.sh` — **without GitHub's flags**. A runner that
does not reproduce the production shell proves nothing about production. Fixed with an explicit `set +e`
carrying a comment that names that run, so it is not "tidied" back later.

**Differential proof that the assertions now execute and pass:** dispatched run **30870228012**, same script
output, only `set +e` changed → step **success**, no skipped steps. RED → GREEN with the script's behaviour
held constant is what shows the assertion block runs; the matrix below is what shows it discriminates.

## Discrimination evidence — 8 arms under GitHub's own shell flags

The `run:` text is **extracted from this YAML** and executed under **`bash -e -o pipefail`** — the same flags
GitHub uses — rather than a hand-copied approximation, so the thing tested is the thing that ships. `node` is
stubbed per arm to emit that scenario's field set.

| arm | job |
|---|---|
| intended behaviour | ✅ GREEN |
| neutered `must()` | ❌ RED |
| script crash | ❌ RED |
| gate broken (probe returned 200) | ❌ RED |
| assertion deleted | ❌ RED |
| field absent from output | ❌ RED |
| **only `reachedAssertion` wrong** | ❌ RED — single distinct FATAL |
| **only exit code wrong** | ❌ RED — single distinct FATAL |

The last two are **exclusivity** arms: each condition fails on its own with its own diagnostic, so no sibling
condition is covering for another. Without those, "all six arms are red" would be consistent with one over-broad
check doing all the work.

## Side effect worth calling out

The job is now green when the discriminator is intact, so **the run's aggregate conclusion is no longer `failure`
by design.** That removes a documented foot-gun — readers previously had to know to ignore the run badge and open
job conclusions individually, and evidence blocks had to carry a warning about it.

## ⚠️ This PR's own CI does not exercise the change

`negative-control` is `if: github.event_name == 'workflow_dispatch'`, so it is **skipped** on this pull request.
**A green badge here proves nothing about the new step.** The evidence is the matrix above plus dispatched run
**30870228012** (`negative-control` = success, no skipped steps). Run **30870041141** is the pre-fix red.

That same dispatched run also re-confirmed the S6-A walk (`containerized functional smoke` = success) on top of
current `main`.

No flag default changed, nothing armed, nothing deployed, no external write, no frozen input touched.

