### PR TITLE
feat(attendance): consume fixed schedule config in apply/rebuild

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -1150,6 +1150,7 @@ jobs:
             tests/integration/attendance-w4c4-calculation-detail.db.test.ts \
             tests/integration/attendance-group-fixed-schedule-config-migration.db.test.ts \
             tests/integration/attendance-group-fixed-schedule-effectiveness.db.test.ts \
+            tests/integration/attendance-group-fixed-schedule-config-consume.db.test.ts \
             tests/integration/attendance-expiry-service.test.ts \
             tests/integration/attendance-unscheduled-reminder.test.ts \
             tests/integration/attendance-outdoor-punch.test.ts \

--- a/docs/development/attendance-4709-fser3-apply-rebuild-config-consumption-verification-20260804.md
+++ b/docs/development/attendance-4709-fser3-apply-rebuild-config-consumption-verification-20260804.md
@@ -1,0 +1,111 @@
+# Attendance #4709 FSER-3 Apply/Rebuild Config Consumption Verification
+
+Status: **IMPLEMENTED / HOLD FOR FRESH-MAIN EXACT-HEAD GATE**
+
+- Ratified contract: `attendance-4709-fixed-schedule-effectiveness-read-model-design-lock-20260801.md`
+- Original implementation base: `6b439a1ab05a8b2588e42f59499f9849bd3242b1`
+- Fresh-main verification base: `e3dfe59d2e6038f96762865ad98bad42ad92920f`
+- Scope: FSER-3 apply/rebuild desired-config consumption only
+- Explicitly excluded: FSER-4, merge authorization, feature flags, deployment,
+  soak, production or customer data, and closing #4556
+
+## 1. Delivered behavior
+
+Apply and rebuild now consume the desired fixed-schedule config inside their
+existing transaction. They validate the group and finite date window, lock an
+existing config row before target locks, reject stale revision or legacy-value
+candidates with typed `409 ATTENDANCE_FIXED_SCHEDULE_CONFIG_CHANGED`, and use
+the transactionally reloaded config as the materialization input.
+
+When no config exists, the same path validates the candidate shift and a
+non-empty current target set before `INSERT ... ON CONFLICT DO NOTHING`, reloads
+the winner `FOR UPDATE`, and distinguishes identical from different concurrent
+candidates. The existing canonical producer-key builder, result shape, target
+lock ordering, overlap checks, and transaction boundary remain authoritative.
+Route-level business failures are converted into an internal transaction-abort
+exception so the database rolls back before the HTTP layer restores the exact
+typed response shape.
+
+The HTTP request accepts optional `expectedConfigRevision`; legacy finite
+candidates remain compatible only when all three values equal the locked row.
+Open-ended direct apply is now rejected because the ratified desired-config
+record requires a finite start and end date.
+
+## 2. Focused automated evidence
+
+Results run locally on 2026-08-04 and repeated after the fresh-main rebase:
+
+| Spec | Result | Contract |
+| --- | ---: | --- |
+| `attendance-group-fixed-schedule-config-consume.test.ts` | 21/21 PASS | first-create, stale 409, transaction rollback, lock order, canonical builder, response shape |
+| `attendance-scheduling-assignment-conflict.test.ts` | 22/22 PASS | existing producer/conflict/rebuild behavior under config consumption |
+| `attendance-uuid-validation-routes.test.ts` | 87/87 PASS | HTTP schema, typed stale response, permission and zero-write route behavior |
+| `attendance-group-fixed-schedule-config-consume.db.test.ts` | 5/5 PASS | real PostgreSQL atomicity and two-connection convergence |
+| `attendance-plugin.test.ts` | 163/163 PASS | complete HTTP integration, actual apply/rebuild config/assignment success and rollback residue |
+| FSER migration/effectiveness + W3 writer matrix | 63/63 PASS | existing schema/read model and writer behavior |
+| sealed-export package provenance | PASS | required pin refreshed for the changed `plugin-tests.yml` evidence file |
+
+The real-DB suite uses a fresh schema and proves both identical-candidate
+convergence and different-candidate one-winner/typed-409 behavior without a
+losing materialization effect. The full HTTP integration suite also contains
+the stronger actual-table assertions: successful first legacy apply creates
+both config and managed assignment; a first apply that hits a real assignment
+conflict leaves zero config and zero managed assignment residue.
+
+That HTTP leg found and closed one real implementation defect before this
+record was finalized. The first draft returned a business-error object from the
+transaction callback, so PostgreSQL committed the first-created config while
+the route rendered a `409`. The route now throws an internal sentinel inside
+the transaction and renders the same response only after rollback. A focused
+unit leg kills removal of that throw, and separate real HTTP apply and rebuild
+assertions prove zero config and zero assignment rows after each conflict.
+
+## 3. Existing-call compatibility correction
+
+The first broad regression run exposed six old direct-call fixtures that knew
+nothing about the new config lock, plus one real HTTP scenario that changed a
+group window by calling apply directly. Those were not waived:
+
+1. direct-call fixtures now model the finite desired config and its pre-target
+   lock;
+2. the obsolete open-ended direct apply expectation is now a validation-negative
+   while the producer-key builder retains its separate null-window unit proof;
+3. the HTTP scenario saves the changed desired config first, reads revision 2,
+   and passes that revision to apply/rebuild.
+
+The repaired existing unit suite is included in the 22/22 result above.
+
+## 4. Mutation evidence
+
+Five focused mutations were executed against the restored baseline:
+
+1. removing `ON CONFLICT DO NOTHING` makes both real concurrent legs fail with
+   PostgreSQL `23505` instead of convergence / typed `409`;
+2. weakening the config row lock from `FOR UPDATE` to `FOR SHARE` makes both
+   apply and rebuild lock-order legs fail;
+3. replacing the canonical producer-key call with raw concatenation makes the
+   dedicated canonical-source leg fail;
+4. returning the business error from the transaction callback instead of
+   throwing makes the rollback leg fail because the promise resolves and the
+   staged write commits;
+5. bypassing the aborting wrapper on the rebuild route makes the real HTTP
+   rebuild-conflict leg fail (`500` instead of the typed `409`) before it can
+   accept any residue claim.
+
+All mutations were restored; the focused unit suite returned to 21/21 and the
+real concurrency suite returned to 5/5.
+
+## 5. Honest remaining gates
+
+Before FSER-3 may be presented for merge consideration, the final rebased PR
+head still requires:
+
+1. rebase onto fresh `main` and repeat the affected focused / real-DB evidence;
+2. backend typecheck, diff check, and fresh required GitHub checks;
+3. independent exact-head review with zero open P1/P2.
+
+An earlier complete-HTTP attempt was discarded after the local Docker engine
+stopped with `no space left on device`; it is infrastructure evidence only and
+is not counted as a product result. The 163/163 result above came from a newly
+created, fully migrated isolated database after that incident. Passing all
+remaining gates still does not authorize merge or FSER-4.

--- a/packages/core-backend/tests/integration/attendance-group-fixed-schedule-config-consume.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-group-fixed-schedule-config-consume.db.test.ts
@@ -1,0 +1,226 @@
+import { randomUUID } from 'node:crypto'
+import { createRequire } from 'node:module'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import path from 'node:path'
+
+import { Kysely, PostgresDialect, sql } from 'kysely'
+import { Pool, type PoolClient } from 'pg'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { up as createFixedScheduleConfigs } from '../../src/db/migrations/zzzz20260803120000_create_attendance_group_fixed_schedule_configs'
+
+const require = createRequire(import.meta.url)
+const configServiceLib = require('../../../../plugins/plugin-attendance/lib/attendance-group-fixed-schedule-config-service.cjs') as {
+  ATTENDANCE_FIXED_SCHEDULE_CONFIG_CHANGED: string
+  createAttendanceGroupFixedScheduleConfigService(input: Record<string, unknown>): {
+    resolveConfigForApplyRebuild(
+      trx: { query(text: string, values?: unknown[]): Promise<Array<Record<string, unknown>>> },
+      input: Record<string, unknown>,
+    ): Promise<{ config: { shiftId: string }; created: boolean }>
+  }
+}
+
+class FakeHttpError extends Error {
+  constructor(public status: number, public code: string, message: string) {
+    super(message)
+  }
+}
+
+const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
+const describeDb = dbUrl ? describe : describe.skip
+const filename = 'attendance-group-fixed-schedule-config-consume.db.test.ts'
+
+describe('FSER-3 real-DB CI wiring', () => {
+  it('is excluded from the no-DB lane and explicitly included in the attendance real-DB lane', () => {
+    const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../..')
+    const vitestConfig = readFileSync(path.join(repoRoot, 'packages/core-backend/vitest.config.ts'), 'utf8')
+    const workflow = readFileSync(path.join(repoRoot, '.github/workflows/plugin-tests.yml'), 'utf8')
+    expect(vitestConfig).toContain(`tests/integration/${filename}`)
+    expect(workflow).toContain(`tests/integration/${filename}`)
+  })
+})
+
+describeDb('FSER-3 apply/rebuild config consumption (real DB)', () => {
+  let adminPool: Pool
+  let pool: Pool
+  let schema: string
+  let db: Kysely<unknown>
+  let groupId: string
+  let shiftA: string
+  let shiftB: string
+  const orgId = 'fser3-org'
+  const userId = 'fser3-member'
+
+  const service = configServiceLib.createAttendanceGroupFixedScheduleConfigService({ HttpError: FakeHttpError })
+
+  beforeEach(async () => {
+    adminPool = new Pool({ connectionString: dbUrl })
+    schema = `fser3_${randomUUID().replace(/-/g, '')}`
+    await adminPool.query(`CREATE SCHEMA "${schema}"`)
+    pool = new Pool({
+      connectionString: dbUrl,
+      max: 4,
+      options: `-c search_path=${schema} -c statement_timeout=10000`,
+    })
+    db = new Kysely<unknown>({ dialect: new PostgresDialect({ pool }) })
+
+    await sql`
+      CREATE TABLE attendance_groups (
+        id uuid PRIMARY KEY,
+        org_id text NOT NULL,
+        CONSTRAINT attendance_groups_id_org_unique UNIQUE (id, org_id)
+      )
+    `.execute(db)
+    await sql`
+      CREATE TABLE attendance_shifts (
+        id uuid PRIMARY KEY,
+        org_id text NOT NULL,
+        CONSTRAINT attendance_shifts_id_org_unique UNIQUE (id, org_id)
+      )
+    `.execute(db)
+    await sql`
+      CREATE TABLE attendance_group_members (
+        org_id text NOT NULL,
+        group_id uuid NOT NULL,
+        user_id text NOT NULL
+      )
+    `.execute(db)
+    await sql`
+      CREATE TABLE fser3_assignment_effects (
+        org_id text NOT NULL,
+        group_id uuid NOT NULL,
+        user_id text NOT NULL,
+        shift_id uuid NOT NULL,
+        CONSTRAINT fser3_assignment_effects_unique UNIQUE (org_id, group_id, user_id)
+      )
+    `.execute(db)
+    await createFixedScheduleConfigs(db)
+
+    groupId = randomUUID()
+    shiftA = randomUUID()
+    shiftB = randomUUID()
+    await pool.query('INSERT INTO attendance_groups (id, org_id) VALUES ($1, $2)', [groupId, orgId])
+    await pool.query('INSERT INTO attendance_shifts (id, org_id) VALUES ($1, $3), ($2, $3)', [shiftA, shiftB, orgId])
+    await pool.query(
+      'INSERT INTO attendance_group_members (org_id, group_id, user_id) VALUES ($1, $2, $3)',
+      [orgId, groupId, userId],
+    )
+  })
+
+  afterEach(async () => {
+    await db.destroy()
+    await adminPool.query(`DROP SCHEMA IF EXISTS "${schema}" CASCADE`)
+    await adminPool.end()
+  })
+
+  function candidate(shiftId = shiftA) {
+    return {
+      orgId,
+      groupId,
+      shiftId,
+      startDate: '2026-08-01',
+      endDate: '2026-08-31',
+      updatedBy: 'fser3-admin',
+    }
+  }
+
+  function createFirstReadBarrier(parties: number) {
+    let arrivals = 0
+    let release: (() => void) | undefined
+    const opened = new Promise<void>((resolve) => { release = resolve })
+    return async (statement: string, rows: Array<Record<string, unknown>>) => {
+      if (!statement.includes('FROM attendance_group_fixed_schedule_configs')
+        || !statement.includes('FOR UPDATE')
+        || rows.length !== 0) return
+      arrivals += 1
+      if (arrivals === parties) release?.()
+      await opened
+    }
+  }
+
+  function transactionClient(client: PoolClient, firstReadBarrier?: ReturnType<typeof createFirstReadBarrier>) {
+    return {
+      async query(statement: string, values: unknown[] = []) {
+        const rows = (await client.query(statement, values)).rows as Array<Record<string, unknown>>
+        await firstReadBarrier?.(statement, rows)
+        return rows
+      },
+    }
+  }
+
+  async function materialize(
+    desired: ReturnType<typeof candidate>,
+    firstReadBarrier?: ReturnType<typeof createFirstReadBarrier>,
+    failAfterAssignment = false,
+  ) {
+    const client = await pool.connect()
+    try {
+      await client.query('BEGIN')
+      const resolved = await service.resolveConfigForApplyRebuild(transactionClient(client, firstReadBarrier), desired)
+      await client.query(
+        `INSERT INTO fser3_assignment_effects (org_id, group_id, user_id, shift_id)
+         VALUES ($1, $2, $3, $4)
+         ON CONFLICT (org_id, group_id, user_id) DO NOTHING`,
+        [orgId, groupId, userId, resolved.config.shiftId],
+      )
+      if (failAfterAssignment) throw new Error('synthetic materialization failure')
+      await client.query('COMMIT')
+      return resolved
+    } catch (error) {
+      await client.query('ROLLBACK').catch(() => undefined)
+      throw error
+    } finally {
+      client.release()
+    }
+  }
+
+  async function counts() {
+    const configs = await pool.query('SELECT count(*)::int AS total FROM attendance_group_fixed_schedule_configs')
+    const effects = await pool.query('SELECT count(*)::int AS total FROM fser3_assignment_effects')
+    return { configs: configs.rows[0].total as number, effects: effects.rows[0].total as number }
+  }
+
+  it('creates desired config and assignment effect in one successful transaction', async () => {
+    const result = await materialize(candidate())
+    expect(result).toMatchObject({ created: true, config: { shiftId: shiftA } })
+    expect(await counts()).toEqual({ configs: 1, effects: 1 })
+  })
+
+  it('rolls back both the first-created config and assignment effect when materialization fails', async () => {
+    await expect(materialize(candidate(), undefined, true)).rejects.toThrow('synthetic materialization failure')
+    expect(await counts()).toEqual({ configs: 0, effects: 0 })
+  })
+
+  it('converges two real concurrent identical first candidates without a uniqueness error', async () => {
+    const barrier = createFirstReadBarrier(2)
+    const results = await Promise.all([materialize(candidate(), barrier), materialize(candidate(), barrier)])
+    expect(results.filter(result => result.created)).toHaveLength(1)
+    expect(await counts()).toEqual({ configs: 1, effects: 1 })
+  })
+
+  it('lets one different concurrent candidate win and rejects the loser with typed 409 and no losing effect', async () => {
+    const barrier = createFirstReadBarrier(2)
+    const results = await Promise.allSettled([
+      materialize(candidate(shiftA), barrier),
+      materialize(candidate(shiftB), barrier),
+    ])
+    expect(results.filter(result => result.status === 'fulfilled')).toHaveLength(1)
+    const rejected = results.find(result => result.status === 'rejected')
+    expect(rejected).toMatchObject({
+      status: 'rejected',
+      reason: {
+        status: 409,
+        code: configServiceLib.ATTENDANCE_FIXED_SCHEDULE_CONFIG_CHANGED,
+      },
+    })
+    expect(await counts()).toEqual({ configs: 1, effects: 1 })
+    const stored = await pool.query(
+      `SELECT c.shift_id::text AS config_shift, e.shift_id::text AS effect_shift
+         FROM attendance_group_fixed_schedule_configs c
+         JOIN fser3_assignment_effects e USING (org_id, group_id)`,
+    )
+    expect(stored.rows).toHaveLength(1)
+    expect(stored.rows[0].effect_shift).toBe(stored.rows[0].config_shift)
+  })
+})

--- a/packages/core-backend/tests/integration/attendance-plugin.test.ts
+++ b/packages/core-backend/tests/integration/attendance-plugin.test.ts
@@ -4042,6 +4042,8 @@ attendanceIntegrationDescribe(
     let originalSettings: Record<string, unknown> = {}
     const shiftIds: string[] = []
     let fixedGroupId: string | undefined
+    let failedFirstApplyGroupId: string | undefined
+    let failedFirstRebuildGroupId: string | undefined
 
     const tokenRes = await requestJson(
       `${baseUrl}/api/auth/dev-token?userId=${encodeURIComponent(adminUserId)}&tenantId=default&roles=admin&perms=attendance:read,attendance:write,attendance:admin`
@@ -4361,6 +4363,109 @@ attendanceIntegrationDescribe(
       const fixedBaseAssignmentId = fixedBaseRows.rows[0]?.id
       expect(fixedBaseAssignmentId).toBeTruthy()
       if (!fixedBaseAssignmentId) return
+      const fixedConfigRows = await pool.query(
+        `SELECT shift_id, start_date::text, end_date::text, revision
+           FROM attendance_group_fixed_schedule_configs
+          WHERE org_id = 'default' AND group_id = $1`,
+        [fixedGroupId],
+      )
+      expect(fixedConfigRows.rows).toEqual([expect.objectContaining({
+        shift_id: baseShiftId,
+        start_date: fixedDate,
+        end_date: fixedDate,
+        revision: 1,
+      })])
+
+      const failedGroupRes = await requestJson(`${baseUrl}/api/attendance/groups`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          name: `temp-shift-failed-first-${runSuffix}`,
+          timezone: 'UTC',
+          attendanceType: 'fixed_shift',
+          description: 'first apply rollback proof',
+        }),
+      })
+      expect(failedGroupRes.status, JSON.stringify(failedGroupRes.body)).toBe(200)
+      failedFirstApplyGroupId = (failedGroupRes.body as { data?: { id?: string } } | undefined)?.data?.id
+      expect(failedFirstApplyGroupId).toBeTruthy()
+      if (!failedFirstApplyGroupId) return
+      const failedMemberRes = await requestJson(
+        `${baseUrl}/api/attendance/groups/${failedFirstApplyGroupId}/members`,
+        {
+          method: 'POST',
+          headers,
+          body: JSON.stringify({ userIds: [fixedUserId] }),
+        },
+      )
+      expect(failedMemberRes.status, JSON.stringify(failedMemberRes.body)).toBe(200)
+      const failedFirstApplyRes = await requestJson(
+        `${baseUrl}/api/attendance/groups/${failedFirstApplyGroupId}/fixed-schedule/apply`,
+        {
+          method: 'POST',
+          headers,
+          body: JSON.stringify({ shiftId: replacementShiftId, startDate: fixedDate, endDate: fixedDate }),
+        },
+      )
+      expect(failedFirstApplyRes.status, JSON.stringify(failedFirstApplyRes.body)).toBe(409)
+      expect((failedFirstApplyRes.body as { error?: { code?: string } } | undefined)?.error?.code)
+        .toBe('ATTENDANCE_GROUP_FIXED_SCHEDULE_BLOCKING_CONFLICT')
+      const failedFirstApplyResidue = await pool.query(
+        `SELECT
+           (SELECT COUNT(*)::int FROM attendance_group_fixed_schedule_configs WHERE org_id = 'default' AND group_id = $1) AS configs,
+           (SELECT COUNT(*)::int FROM attendance_shift_assignments
+             WHERE org_id = 'default'
+               AND producer_type = 'attendance_group_fixed_schedule'
+               AND producer_ref_id = $1) AS assignments`,
+        [failedFirstApplyGroupId],
+      )
+      expect(failedFirstApplyResidue.rows[0]).toEqual({ configs: 0, assignments: 0 })
+
+      const failedRebuildGroupRes = await requestJson(`${baseUrl}/api/attendance/groups`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          name: `temp-shift-failed-first-rebuild-${runSuffix}`,
+          timezone: 'UTC',
+          attendanceType: 'fixed_shift',
+          description: 'first rebuild rollback proof',
+        }),
+      })
+      expect(failedRebuildGroupRes.status, JSON.stringify(failedRebuildGroupRes.body)).toBe(200)
+      failedFirstRebuildGroupId = (failedRebuildGroupRes.body as { data?: { id?: string } } | undefined)?.data?.id
+      expect(failedFirstRebuildGroupId).toBeTruthy()
+      if (!failedFirstRebuildGroupId) return
+      const failedRebuildMemberRes = await requestJson(
+        `${baseUrl}/api/attendance/groups/${failedFirstRebuildGroupId}/members`,
+        {
+          method: 'POST',
+          headers,
+          body: JSON.stringify({ userIds: [fixedUserId] }),
+        },
+      )
+      expect(failedRebuildMemberRes.status, JSON.stringify(failedRebuildMemberRes.body)).toBe(200)
+      const failedFirstRebuildRes = await requestJson(
+        `${baseUrl}/api/attendance/groups/${failedFirstRebuildGroupId}/fixed-schedule/rebuild`,
+        {
+          method: 'POST',
+          headers,
+          body: JSON.stringify({ shiftId: replacementShiftId, startDate: fixedDate, endDate: fixedDate }),
+        },
+      )
+      expect(failedFirstRebuildRes.status, JSON.stringify(failedFirstRebuildRes.body)).toBe(409)
+      expect((failedFirstRebuildRes.body as { error?: { code?: string } } | undefined)?.error?.code)
+        .toBe('ATTENDANCE_GROUP_FIXED_SCHEDULE_BLOCKING_CONFLICT')
+      const failedFirstRebuildResidue = await pool.query(
+        `SELECT
+           (SELECT COUNT(*)::int FROM attendance_group_fixed_schedule_configs WHERE org_id = 'default' AND group_id = $1) AS configs,
+           (SELECT COUNT(*)::int FROM attendance_shift_assignments
+             WHERE org_id = 'default'
+               AND producer_type = 'attendance_group_fixed_schedule'
+               AND producer_ref_id = $1) AS assignments`,
+        [failedFirstRebuildGroupId],
+      )
+      expect(failedFirstRebuildResidue.rows[0]).toEqual({ configs: 0, assignments: 0 })
+
       const fixedTempDraftRes = await requestJson(`${baseUrl}/api/attendance/schedule-drafts/assignments`, {
         method: 'POST',
         headers,
@@ -4394,10 +4499,23 @@ attendanceIntegrationDescribe(
         replaces: { assignmentId: fixedBaseAssignmentId },
       })
 
+      const changedConfigRes = await requestJson(`${baseUrl}/api/attendance/groups/${fixedGroupId}/fixed-schedule/config`, {
+        method: 'PUT',
+        headers,
+        body: JSON.stringify({ shiftId: baseShiftId, startDate: staleTempDate, endDate: staleTempDate }),
+      })
+      expect(changedConfigRes.status, JSON.stringify(changedConfigRes.body)).toBe(200)
+      const changedConfigRevision = (changedConfigRes.body as { data?: { revision?: number } } | undefined)?.data?.revision
+      expect(changedConfigRevision).toBe(2)
       const staleApplyRes = await requestJson(`${baseUrl}/api/attendance/groups/${fixedGroupId}/fixed-schedule/apply`, {
         method: 'POST',
         headers,
-        body: JSON.stringify({ shiftId: baseShiftId, startDate: staleTempDate, endDate: staleTempDate }),
+        body: JSON.stringify({
+          shiftId: baseShiftId,
+          startDate: staleTempDate,
+          endDate: staleTempDate,
+          expectedConfigRevision: changedConfigRevision,
+        }),
       })
       expect(staleApplyRes.status, JSON.stringify(staleApplyRes.body)).toBe(201)
       await pool.query(
@@ -4412,7 +4530,12 @@ attendanceIntegrationDescribe(
       const staleRebuildRes = await requestJson(`${baseUrl}/api/attendance/groups/${fixedGroupId}/fixed-schedule/rebuild`, {
         method: 'POST',
         headers,
-        body: JSON.stringify({ shiftId: baseShiftId, startDate: staleTempDate, endDate: staleTempDate }),
+        body: JSON.stringify({
+          shiftId: baseShiftId,
+          startDate: staleTempDate,
+          endDate: staleTempDate,
+          expectedConfigRevision: changedConfigRevision,
+        }),
       })
       expect(staleRebuildRes.status, JSON.stringify(staleRebuildRes.body)).toBe(409)
       expect((staleRebuildRes.body as { error?: { code?: string } } | undefined)?.error?.code).toBe('ATTENDANCE_GROUP_FIXED_SCHEDULE_BLOCKING_CONFLICT')
@@ -4442,6 +4565,14 @@ attendanceIntegrationDescribe(
       if (fixedGroupId) {
         await pool.query('DELETE FROM attendance_group_members WHERE group_id = $1', [fixedGroupId]).catch(() => undefined)
         await pool.query('DELETE FROM attendance_groups WHERE id = $1', [fixedGroupId]).catch(() => undefined)
+      }
+      if (failedFirstApplyGroupId) {
+        await pool.query('DELETE FROM attendance_group_members WHERE group_id = $1', [failedFirstApplyGroupId]).catch(() => undefined)
+        await pool.query('DELETE FROM attendance_groups WHERE id = $1', [failedFirstApplyGroupId]).catch(() => undefined)
+      }
+      if (failedFirstRebuildGroupId) {
+        await pool.query('DELETE FROM attendance_group_members WHERE group_id = $1', [failedFirstRebuildGroupId]).catch(() => undefined)
+        await pool.query('DELETE FROM attendance_groups WHERE id = $1', [failedFirstRebuildGroupId]).catch(() => undefined)
       }
       if (shiftIds.length > 0) {
         await pool.query('DELETE FROM attendance_shifts WHERE id = ANY($1::uuid[])', [shiftIds]).catch(() => undefined)

--- a/packages/core-backend/tests/unit/attendance-group-fixed-schedule-config-consume.test.ts
+++ b/packages/core-backend/tests/unit/attendance-group-fixed-schedule-config-consume.test.ts
@@ -1,0 +1,460 @@
+import { randomUUID } from 'node:crypto'
+import { createRequire } from 'node:module'
+import { readFileSync } from 'node:fs'
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const require = createRequire(import.meta.url)
+const configServiceLib = require('../../../../plugins/plugin-attendance/lib/attendance-group-fixed-schedule-config-service.cjs') as {
+  ATTENDANCE_FIXED_SCHEDULE_CONFIG_CHANGED: string
+  createAttendanceGroupFixedScheduleConfigService: (input: Record<string, unknown>) => {
+    resolveConfigForApplyRebuild: (trx: unknown, input: Record<string, unknown>) => Promise<{ config: any; created: boolean }>
+  }
+}
+const attendancePlugin = require('../../../../plugins/plugin-attendance/index.cjs') as {
+  resetAttendanceSettingsCacheForTests?: () => void
+  __attendanceGroupFixedScheduleForTests: {
+    applyAttendanceGroupFixedSchedule: (db: unknown, input: Record<string, unknown>) => Promise<any>
+    rebuildAttendanceGroupFixedSchedule: (db: unknown, input: Record<string, unknown>) => Promise<any>
+    buildAttendanceGroupFixedScheduleProducerKey: (input: { groupId: string; shiftId: string; startDate: string; endDate: string | null }) => string
+    runAttendanceGroupFixedScheduleTransaction: (db: unknown, operation: (trx: unknown) => Promise<any>) => Promise<any>
+  }
+}
+
+class FakeHttpError extends Error {
+  constructor(public status: number, public code: string, message: string) {
+    super(message)
+  }
+}
+
+const service = configServiceLib.createAttendanceGroupFixedScheduleConfigService({ HttpError: FakeHttpError })
+const seam = attendancePlugin.__attendanceGroupFixedScheduleForTests
+const attendancePluginSource = readFileSync(
+  new URL('../../../../plugins/plugin-attendance/index.cjs', import.meta.url),
+  'utf8',
+)
+
+const orgId = 'org-a'
+const groupId = randomUUID()
+const shiftId = randomUUID()
+const candidate = {
+  orgId,
+  groupId,
+  shiftId,
+  startDate: '2026-08-01',
+  endDate: '2026-08-31',
+  updatedBy: 'admin-1',
+}
+
+function configRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: randomUUID(),
+    org_id: orgId,
+    group_id: groupId,
+    shift_id: shiftId,
+    start_date: '2026-08-01',
+    end_date: '2026-08-31',
+    revision: 2,
+    updated_by: 'admin-1',
+    created_at: '2026-08-01T00:00:00.000Z',
+    updated_at: '2026-08-01T00:00:00.000Z',
+    ...overrides,
+  }
+}
+
+type FakeTrx = {
+  query: ReturnType<typeof vi.fn>
+  statements: string[]
+}
+
+// Script-driven fake trx: each entry matches a statement substring and returns rows.
+function makeTrx(script: Array<{ match: string; rows: unknown[] }>): FakeTrx {
+  const statements: string[] = []
+  const queue = [...script]
+  const query = vi.fn(async (text: string) => {
+    statements.push(text)
+    const index = queue.findIndex(entry => text.includes(entry.match))
+    if (index === -1) throw new Error(`unexpected statement: ${text}`)
+    const [entry] = queue.splice(index, 1)
+    return entry.rows
+  })
+  return { query, statements }
+}
+
+function validationScript() {
+  return [
+    { match: 'SELECT id FROM attendance_groups', rows: [{ id: groupId }] },
+    { match: 'SELECT id FROM attendance_shifts', rows: [{ id: shiftId }] },
+    { match: 'FROM attendance_group_members', rows: [{ present: 1 }] },
+  ]
+}
+
+describe('attendance group fixed-schedule config consumption (unit)', () => {
+  it('creates the desired config atomically when none exists and reloads the winner FOR UPDATE', async () => {
+    const winner = configRow({ revision: 1 })
+    const trx = makeTrx([
+      ...validationScript(),
+      { match: 'FROM attendance_group_fixed_schedule_configs', rows: [] },
+      { match: 'INSERT INTO attendance_group_fixed_schedule_configs', rows: [{ id: winner.id }] },
+      { match: 'FROM attendance_group_fixed_schedule_configs', rows: [winner] },
+    ])
+
+    const result = await service.resolveConfigForApplyRebuild(trx, candidate)
+
+    expect(result.created).toBe(true)
+    expect(result.config).toMatchObject({ shiftId, startDate: '2026-08-01', endDate: '2026-08-31', revision: 1 })
+    const insertIndex = trx.statements.findIndex(statement => statement.includes('INSERT INTO attendance_group_fixed_schedule_configs'))
+    const membersIndex = trx.statements.findIndex(statement => statement.includes('FROM attendance_group_members'))
+    const winnerSelect = trx.statements[trx.statements.length - 1]
+    // Mutation proof: validating after the config insert, or reloading without FOR
+    // UPDATE, reds this case.
+    expect(membersIndex).toBeGreaterThanOrEqual(0)
+    expect(insertIndex).toBeGreaterThan(membersIndex)
+    expect(winnerSelect).toContain('FOR UPDATE')
+    expect(trx.statements.filter(statement => statement.includes('ON CONFLICT (org_id, group_id) DO NOTHING'))).toHaveLength(1)
+  })
+
+  it('lets an identical concurrent first-create candidate continue without its own insert', async () => {
+    const winner = configRow({ revision: 1 })
+    const trx = makeTrx([
+      ...validationScript(),
+      { match: 'FROM attendance_group_fixed_schedule_configs', rows: [] },
+      // ON CONFLICT DO NOTHING lost the race: no row returned.
+      { match: 'INSERT INTO attendance_group_fixed_schedule_configs', rows: [] },
+      { match: 'FROM attendance_group_fixed_schedule_configs', rows: [winner] },
+    ])
+
+    const result = await service.resolveConfigForApplyRebuild(trx, candidate)
+
+    expect(result.created).toBe(false)
+    expect(result.config.revision).toBe(1)
+  })
+
+  it('returns the typed 409 when the concurrent winner holds a different candidate', async () => {
+    const winner = configRow({ revision: 1, shift_id: randomUUID() })
+    const trx = makeTrx([
+      ...validationScript(),
+      { match: 'FROM attendance_group_fixed_schedule_configs', rows: [] },
+      { match: 'INSERT INTO attendance_group_fixed_schedule_configs', rows: [] },
+      { match: 'FROM attendance_group_fixed_schedule_configs', rows: [winner] },
+    ])
+
+    await expect(service.resolveConfigForApplyRebuild(trx, candidate))
+      .rejects.toMatchObject({ status: 409, code: configServiceLib.ATTENDANCE_FIXED_SCHEDULE_CONFIG_CHANGED })
+    expect(trx.statements.some(statement => statement.includes('attendance_shift_assignments'))).toBe(false)
+  })
+
+  it('accepts a matching expectedConfigRevision against an existing config without any write', async () => {
+    const trx = makeTrx([
+      ...validationScript(),
+      { match: 'FROM attendance_group_fixed_schedule_configs', rows: [configRow()] },
+    ])
+
+    const result = await service.resolveConfigForApplyRebuild(trx, { ...candidate, expectedConfigRevision: 2 })
+
+    expect(result).toMatchObject({ created: false, config: { revision: 2 } })
+    const configSelect = trx.statements.find(statement => statement.includes('FROM attendance_group_fixed_schedule_configs'))
+    expect(configSelect).toContain('FOR UPDATE')
+    expect(trx.statements.some(statement => /^\s*(INSERT|UPDATE|DELETE)/i.test(statement))).toBe(false)
+  })
+
+  it('rejects a stale expectedConfigRevision with the typed 409 and zero writes', async () => {
+    const trx = makeTrx([
+      ...validationScript(),
+      { match: 'FROM attendance_group_fixed_schedule_configs', rows: [configRow()] },
+    ])
+
+    await expect(service.resolveConfigForApplyRebuild(trx, { ...candidate, expectedConfigRevision: 1 }))
+      .rejects.toMatchObject({ status: 409, code: configServiceLib.ATTENDANCE_FIXED_SCHEDULE_CONFIG_CHANGED })
+    expect(trx.statements.some(statement => /^\s*(INSERT|UPDATE|DELETE)/i.test(statement))).toBe(false)
+  })
+
+  it('accepts a legacy candidate whose three values equal the locked config row', async () => {
+    const trx = makeTrx([
+      ...validationScript(),
+      { match: 'FROM attendance_group_fixed_schedule_configs', rows: [configRow()] },
+    ])
+
+    const result = await service.resolveConfigForApplyRebuild(trx, candidate)
+
+    expect(result.created).toBe(false)
+    expect(trx.statements.some(statement => /^\s*(INSERT|UPDATE|DELETE)/i.test(statement))).toBe(false)
+  })
+
+  it.each(['shiftId', 'startDate', 'endDate'])('rejects a legacy candidate with a mismatched %s', async (field) => {
+    const mismatched = {
+      ...candidate,
+      [field]: field === 'shiftId'
+        ? randomUUID()
+        : field === 'startDate'
+          ? '2026-07-31'
+          : '2026-09-01',
+    }
+    const trx = makeTrx([
+      ...validationScript(),
+      { match: 'FROM attendance_group_fixed_schedule_configs', rows: [configRow()] },
+    ])
+
+    await expect(service.resolveConfigForApplyRebuild(trx, mismatched))
+      .rejects.toMatchObject({ status: 409, code: configServiceLib.ATTENDANCE_FIXED_SCHEDULE_CONFIG_CHANGED })
+    expect(trx.statements.some(statement => /^\s*(INSERT|UPDATE|DELETE)/i.test(statement))).toBe(false)
+  })
+
+  it('rejects an inverted date window before any config statement', async () => {
+    const trx = makeTrx([])
+
+    await expect(service.resolveConfigForApplyRebuild(trx, { ...candidate, startDate: '2026-09-01' }))
+      .rejects.toMatchObject({ status: 400, code: 'VALIDATION_ERROR' })
+    expect(trx.statements).toHaveLength(0)
+  })
+
+  it('rejects a missing group before any config statement', async () => {
+    const trx = makeTrx([{ match: 'SELECT id FROM attendance_groups', rows: [] }])
+
+    await expect(service.resolveConfigForApplyRebuild(trx, candidate))
+      .rejects.toMatchObject({ status: 404, code: 'NOT_FOUND' })
+    expect(trx.statements).toHaveLength(1)
+  })
+
+  it('rejects a missing shift before any config statement', async () => {
+    const trx = makeTrx([
+      { match: 'SELECT id FROM attendance_groups', rows: [{ id: groupId }] },
+      { match: 'FROM attendance_group_fixed_schedule_configs', rows: [] },
+      { match: 'SELECT id FROM attendance_shifts', rows: [] },
+    ])
+
+    await expect(service.resolveConfigForApplyRebuild(trx, candidate))
+      .rejects.toMatchObject({ status: 404, code: 'NOT_FOUND' })
+    expect(trx.statements.some(statement => statement.includes('INSERT INTO attendance_group_fixed_schedule_configs'))).toBe(false)
+  })
+
+  it('rejects an empty target set before the config insert', async () => {
+    const trx = makeTrx([
+      { match: 'SELECT id FROM attendance_groups', rows: [{ id: groupId }] },
+      { match: 'FROM attendance_group_fixed_schedule_configs', rows: [] },
+      { match: 'SELECT id FROM attendance_shifts', rows: [{ id: shiftId }] },
+      { match: 'FROM attendance_group_members', rows: [] },
+    ])
+
+    await expect(service.resolveConfigForApplyRebuild(trx, candidate))
+      .rejects.toMatchObject({ status: 400, code: 'VALIDATION_ERROR' })
+    expect(trx.statements.some(statement => statement.includes('INSERT INTO attendance_group_fixed_schedule_configs'))).toBe(false)
+  })
+})
+
+// Full apply/rebuild write paths through the plugin seam with a statement-matching
+// fake db. Proves FSER-3 orchestration: the config row is locked before any per-user
+// advisory target lock, materialization uses the canonical producer-key builder, and
+// the successful response keeps its pre-FSER-3 shape.
+describe('attendance group fixed-schedule apply/rebuild config consumption (unit seam)', () => {
+  const APPLY_RESPONSE_KEYS = [
+    'applied',
+    'blockingConflicts',
+    'created',
+    'group',
+    'shift',
+    'skipped',
+    'skippedManaged',
+    'skippedExternalManaged',
+    'skippedUnmanaged',
+    'target',
+    'window',
+    'wouldCreate',
+  ]
+
+  function makeApplyDb({ lockedConfig, concurrentWinner }: { lockedConfig: Record<string, unknown> | null; concurrentWinner?: Record<string, unknown> | null }) {
+    const statements: string[] = []
+    const insertedAssignments: unknown[][] = []
+    let configSelects = 0
+    const db = {
+      statements,
+      insertedAssignments,
+      async query(text: string, params?: unknown[]) {
+        statements.push(text)
+        if (text.includes('INSERT INTO attendance_group_fixed_schedule_configs')) {
+          return concurrentWinner === undefined ? [{ id: randomUUID() }] : []
+        }
+        if (text.includes('FROM attendance_group_fixed_schedule_configs')) {
+          configSelects += 1
+          if (lockedConfig) return [lockedConfig]
+          if (configSelects === 1) return []
+          return [concurrentWinner ?? configRow({ revision: 1 })]
+        }
+        if (text.includes('SELECT id FROM attendance_groups')) return [{ id: groupId }]
+        if (text.includes('SELECT * FROM attendance_groups')) {
+          return [{ id: groupId, org_id: orgId, name: 'Group' }]
+        }
+        if (text.includes('FROM attendance_shifts') && text.includes('FOR SHARE')) return [{ id: shiftId }]
+        if (text.includes('FROM attendance_shift_segments')) return [{ total: 0 }]
+        if (text.includes('SELECT 1 AS present FROM attendance_group_members')) return [{ present: 1 }]
+        if (text.includes('SELECT DISTINCT user_id')) return [{ user_id: 'member-a' }]
+        if (text.includes('SELECT * FROM attendance_shifts')) {
+          return [{ id: shiftId, org_id: orgId, name: 'Shift', work_start_time: '09:00', work_end_time: '17:00', is_overnight: false }]
+        }
+        if (text.includes('pg_advisory_xact_lock')) return []
+        if (text.includes('FROM system_configs')) return []
+        if (text.includes('INSERT INTO attendance_shift_assignments')) {
+          insertedAssignments.push(params ?? [])
+          return [{
+            id: randomUUID(),
+            org_id: orgId,
+            user_id: 'member-a',
+            shift_id: shiftId,
+            slot_index: 0,
+            start_date: candidate.startDate,
+            end_date: candidate.endDate,
+            is_active: true,
+            publish_status: 'published',
+            producer_type: 'attendance_group_fixed_schedule',
+            producer_ref_id: groupId,
+            producer_key: params?.[8],
+            producer_run_id: params?.[9],
+          }]
+        }
+        if (text.includes('FROM attendance_shift_assignments')) return []
+        if (text.includes('UPDATE attendance_shift_assignments')) return []
+        if (text.includes('FROM attendance_rotation_assignments')) return []
+        throw new Error(`unexpected statement: ${text}`)
+      },
+    }
+    return db
+  }
+
+  function configLockIndex(statements: string[]) {
+    return statements.findIndex(statement => statement.includes('FROM attendance_group_fixed_schedule_configs') && statement.includes('FOR UPDATE'))
+  }
+
+  function firstTargetLockIndex(statements: string[]) {
+    return statements.findIndex(statement => statement.includes('pg_advisory_xact_lock'))
+  }
+
+  beforeEach(() => {
+    attendancePlugin.resetAttendanceSettingsCacheForTests?.()
+  })
+
+  it('rolls back staged writes when an apply/rebuild operation returns a business error', async () => {
+    const committed: string[] = []
+    const db = {
+      async transaction(operation: (trx: { write: (value: string) => void }) => Promise<unknown>) {
+        const staged: string[] = []
+        const result = await operation({ write: value => staged.push(value) })
+        committed.push(...staged)
+        return result
+      },
+    }
+
+    await expect(seam.runAttendanceGroupFixedScheduleTransaction(db, async (trx: any) => {
+      trx.write('config')
+      return {
+        ok: false,
+        status: 409,
+        code: 'ATTENDANCE_GROUP_FIXED_SCHEDULE_BLOCKING_CONFLICT',
+        message: 'Fixed schedule apply has blocking conflicts',
+      }
+    })).rejects.toMatchObject({
+      result: {
+        status: 409,
+        code: 'ATTENDANCE_GROUP_FIXED_SCHEDULE_BLOCKING_CONFLICT',
+      },
+    })
+    expect(committed).toEqual([])
+  })
+
+  it('keeps producer metadata wired to the canonical producer-key builder', () => {
+    const start = attendancePluginSource.indexOf('function buildAttendanceGroupFixedScheduleProducerMetadata')
+    const end = attendancePluginSource.indexOf('\n}', start)
+    expect(start).toBeGreaterThanOrEqual(0)
+    expect(attendancePluginSource.slice(start, end)).toContain(
+      'producerKey: buildAttendanceGroupFixedScheduleProducerKey(input)',
+    )
+  })
+
+  it('apply with a matching configured candidate keeps the response shape, canonical key, and lock order', async () => {
+    const db = makeApplyDb({ lockedConfig: configRow() })
+
+    const result = await seam.applyAttendanceGroupFixedSchedule(db, { ...candidate, expectedConfigRevision: 2 })
+
+    expect(result.ok).toBe(true)
+    // Byte-compatible response shape: exactly the pre-FSER-3 key set.
+    expect(Object.keys(result.data).sort()).toEqual([...APPLY_RESPONSE_KEYS].sort())
+    expect(result.data.applied).toBe(true)
+    expect(result.data.window).toEqual({ startDate: candidate.startDate, endDate: candidate.endDate })
+    expect(result.data.shift.id).toBe(shiftId)
+    expect(result.data.created).toHaveLength(1)
+    // Canonical producer-key parity: the inserted row key is the canonical builder output.
+    const canonicalKey = seam.buildAttendanceGroupFixedScheduleProducerKey({
+      groupId,
+      shiftId,
+      startDate: candidate.startDate,
+      endDate: candidate.endDate,
+    })
+    expect(db.insertedAssignments).toHaveLength(1)
+    expect(db.insertedAssignments[0]?.[8]).toBe(canonicalKey)
+    // Lock order: config FOR UPDATE strictly before the first per-user target lock.
+    // Mutation proof: resolving the config after buildPlan(lockTargets) reds this.
+    expect(configLockIndex(db.statements)).toBeGreaterThanOrEqual(0)
+    expect(firstTargetLockIndex(db.statements)).toBeGreaterThan(configLockIndex(db.statements))
+    // Existing config: no first-create insert was issued.
+    expect(db.statements.some(statement => statement.includes('INSERT INTO attendance_group_fixed_schedule_configs'))).toBe(false)
+  })
+
+  it('apply with a stale revision returns the typed 409 before any target lock or write', async () => {
+    const db = makeApplyDb({ lockedConfig: configRow() })
+
+    await expect(seam.applyAttendanceGroupFixedSchedule(db, { ...candidate, expectedConfigRevision: 1 }))
+      .rejects.toMatchObject({ status: 409, code: configServiceLib.ATTENDANCE_FIXED_SCHEDULE_CONFIG_CHANGED })
+    expect(firstTargetLockIndex(db.statements)).toBe(-1)
+    expect(db.insertedAssignments).toHaveLength(0)
+    expect(db.statements.some(statement => /^\s*(INSERT|UPDATE|DELETE)/i.test(statement))).toBe(false)
+  })
+
+  it('apply with a legacy candidate value mismatch returns the typed 409 with zero writes', async () => {
+    const db = makeApplyDb({ lockedConfig: configRow() })
+
+    await expect(seam.applyAttendanceGroupFixedSchedule(db, { ...candidate, endDate: '2026-09-30' }))
+      .rejects.toMatchObject({ status: 409, code: configServiceLib.ATTENDANCE_FIXED_SCHEDULE_CONFIG_CHANGED })
+    expect(firstTargetLockIndex(db.statements)).toBe(-1)
+    expect(db.insertedAssignments).toHaveLength(0)
+    expect(db.statements.some(statement => /^\s*(INSERT|UPDATE|DELETE)/i.test(statement))).toBe(false)
+  })
+
+  it('apply with no existing config first-creates it inside the same path and then applies', async () => {
+    const db = makeApplyDb({ lockedConfig: null })
+
+    const result = await seam.applyAttendanceGroupFixedSchedule(db, candidate)
+
+    expect(result.ok).toBe(true)
+    expect(result.data.created).toHaveLength(1)
+    const insertIndex = db.statements.findIndex(statement => statement.includes('INSERT INTO attendance_group_fixed_schedule_configs'))
+    expect(insertIndex).toBeGreaterThanOrEqual(0)
+    expect(insertIndex).toBeLessThan(firstTargetLockIndex(db.statements))
+  })
+
+  it('rebuild with a matching configured candidate keeps canonical key semantics and lock order', async () => {
+    const db = makeApplyDb({ lockedConfig: configRow() })
+
+    const result = await seam.rebuildAttendanceGroupFixedSchedule(db, { ...candidate, expectedConfigRevision: 2 })
+
+    expect(result.ok).toBe(true)
+    expect(result.data.rebuilt).toBe(true)
+    const canonicalKey = seam.buildAttendanceGroupFixedScheduleProducerKey({
+      groupId,
+      shiftId,
+      startDate: candidate.startDate,
+      endDate: candidate.endDate,
+    })
+    expect(db.insertedAssignments[0]?.[8]).toBe(canonicalKey)
+    expect(configLockIndex(db.statements)).toBeGreaterThanOrEqual(0)
+    expect(firstTargetLockIndex(db.statements)).toBeGreaterThan(configLockIndex(db.statements))
+    expect(db.statements.some(statement => statement.includes('INSERT INTO attendance_group_fixed_schedule_configs'))).toBe(false)
+  })
+
+  it('rebuild with a stale revision returns the typed 409 with zero assignment or config mutation', async () => {
+    const db = makeApplyDb({ lockedConfig: configRow() })
+
+    await expect(seam.rebuildAttendanceGroupFixedSchedule(db, { ...candidate, expectedConfigRevision: 99 }))
+      .rejects.toMatchObject({ status: 409, code: configServiceLib.ATTENDANCE_FIXED_SCHEDULE_CONFIG_CHANGED })
+    expect(firstTargetLockIndex(db.statements)).toBe(-1)
+    expect(db.statements.some(statement => /^\s*(INSERT|UPDATE|DELETE)/i.test(statement))).toBe(false)
+  })
+})

--- a/packages/core-backend/tests/unit/attendance-scheduling-assignment-conflict.test.ts
+++ b/packages/core-backend/tests/unit/attendance-scheduling-assignment-conflict.test.ts
@@ -6,6 +6,22 @@ const require = createRequire(import.meta.url)
 const attendancePlugin = require('../../../../plugins/plugin-attendance/index.cjs')
 const helpers = attendancePlugin.__attendanceReportFieldCatalogForTests
 
+function fixedScheduleConfigRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: '00000000-0000-4000-8000-000000000401',
+    org_id: 'org-a',
+    group_id: 'group-a',
+    shift_id: 'shift-a',
+    start_date: '2026-06-01',
+    end_date: '2026-06-30',
+    revision: 1,
+    updated_by: 'operator-a',
+    created_at: '2026-06-01T00:00:00.000Z',
+    updated_at: '2026-06-01T00:00:00.000Z',
+    ...overrides,
+  }
+}
+
 const provenanceMigrationSource = readFileSync(
   new URL('../../src/db/migrations/zzzz20260528200000_add_attendance_shift_assignment_provenance.ts', import.meta.url),
   'utf8',
@@ -447,6 +463,10 @@ describe('attendance scheduling assignment conflict guard', () => {
 
   it('applies fixed-schedule group plans by locking users, skipping exact matches, and inserting only missing rows', async () => {
     const pendingRows = [
+      [{ id: 'group-a' }],
+      [fixedScheduleConfigRow()],
+      [{ id: 'shift-a' }],
+      [{ present: 1 }],
       // W3 canonical assignability guard runs first: shift FOR SHARE + segment count.
       [{ id: 'shift-a' }],
       [{ total: 0 }],
@@ -533,6 +553,10 @@ describe('attendance scheduling assignment conflict guard', () => {
 
   it('uses one producer run id across multiple fixed-schedule creates without mutating skips', async () => {
     const pendingRows = [
+      [{ id: 'group-a' }],
+      [fixedScheduleConfigRow()],
+      [{ id: 'shift-a' }],
+      [{ present: 1 }],
       // W3 canonical assignability guard runs first: shift FOR SHARE + segment count.
       [{ id: 'shift-a' }],
       [{ total: 0 }],
@@ -598,63 +622,26 @@ describe('attendance scheduling assignment conflict guard', () => {
     expect(queries.join('\n')).not.toMatch(/\bUPDATE attendance_shift_assignments\b/i)
   })
 
-  it('leaves open-ended fixed-schedule creates under an explicit null-ended producer key', async () => {
-    const pendingRows = [
-      // W3 canonical assignability guard runs first: shift FOR SHARE + segment count.
-      [{ id: 'shift-a' }],
-      [{ total: 0 }],
-      [{ id: 'group-a', org_id: 'org-a', name: 'Operations', timezone: 'UTC' }],
-      [{ id: 'shift-a', org_id: 'org-a', name: 'Day shift', timezone: 'UTC' }],
-      [{ user_id: 'user-a' }],
-      [],
-      [],
-      [],
-      [],
-    ]
-    const db = {
-      query: vi.fn(async (sql: string, params: any[] = []) => {
-        if (/\bINSERT INTO attendance_shift_assignments\b/i.test(String(sql))) {
-          return [
-            {
-              id: params[0],
-              org_id: params[1],
-              user_id: params[2],
-              shift_id: params[3],
-              start_date: params[4],
-              end_date: params[5],
-              is_active: true,
-              producer_type: params[6],
-              producer_ref_id: params[7],
-              producer_key: params[8],
-              producer_run_id: params[9],
-            },
-          ]
-        }
-        return pendingRows.shift() ?? []
-      }),
-    }
+  it('rejects open-ended direct applies because desired config windows are finite', async () => {
+    const db = { query: vi.fn() }
 
-    const result = await helpers.applyAttendanceGroupFixedSchedule(db, {
+    await expect(helpers.applyAttendanceGroupFixedSchedule(db, {
       orgId: 'org-a',
       groupId: 'group-a',
       shiftId: 'shift-a',
       startDate: '2026-06-01',
       endDate: null,
-    })
-
-    expect(result.ok).toBe(true)
-    expect(result.data.created).toEqual([
-      expect.objectContaining({
-        userId: 'user-a',
-        endDate: null,
-        producerKey: 'attendance_group_fixed_schedule:group-a:shift-a:2026-06-01:null',
-      }),
-    ])
+    })).rejects.toMatchObject({ status: 400, code: 'VALIDATION_ERROR' })
+    expect(db.query).not.toHaveBeenCalled()
   })
 
   it('refuses fixed-schedule group applies without inserting when a blocking conflict exists', async () => {
     const db = {
       query: vi.fn()
+        .mockResolvedValueOnce([{ id: 'group-a' }])
+        .mockResolvedValueOnce([fixedScheduleConfigRow()])
+        .mockResolvedValueOnce([{ id: 'shift-a' }])
+        .mockResolvedValueOnce([{ present: 1 }])
         // W3 canonical assignability guard runs first: shift FOR SHARE + segment count.
         .mockResolvedValueOnce([{ id: 'shift-a' }])
         .mockResolvedValueOnce([{ total: 0 }])
@@ -726,6 +713,7 @@ describe('attendance scheduling assignment conflict guard', () => {
     const db = {
       query: vi.fn(async (sql: string, params: any[] = []) => {
         const text = String(sql)
+        if (/FROM attendance_group_fixed_schedule_configs/.test(text)) return [fixedScheduleConfigRow()]
         if (/FROM attendance_groups/.test(text)) return [{ id: 'group-a', org_id: 'org-a', name: 'Operations', timezone: 'UTC' }]
         if (/FROM attendance_shifts/.test(text)) return [{ id: 'shift-a', org_id: 'org-a', name: 'Day shift', timezone: 'UTC' }]
         if (/FROM attendance_group_members/.test(text)) return [{ user_id: 'user-create' }, { user_id: 'user-managed' }, { user_id: 'user-unmanaged' }]
@@ -799,6 +787,7 @@ describe('attendance scheduling assignment conflict guard', () => {
     const db = {
       query: vi.fn(async (sql: string) => {
         const text = String(sql)
+        if (/FROM attendance_group_fixed_schedule_configs/.test(text)) return [fixedScheduleConfigRow()]
         if (/FROM attendance_groups/.test(text)) return [{ id: 'group-a', org_id: 'org-a', name: 'Operations', timezone: 'UTC' }]
         if (/FROM attendance_shifts/.test(text)) return [{ id: 'shift-a', org_id: 'org-a', name: 'Day shift', timezone: 'UTC' }]
         if (/FROM attendance_group_members/.test(text)) return [{ user_id: 'user-a' }]

--- a/packages/core-backend/tests/unit/attendance-uuid-validation-routes.test.ts
+++ b/packages/core-backend/tests/unit/attendance-uuid-validation-routes.test.ts
@@ -519,12 +519,30 @@ function approvalInstanceRow(overrides: Record<string, unknown> = {}) {
   }
 }
 
-function fixedScheduleQueryResult(sql: string) {
+function fixedScheduleConfigRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: '00000000-0000-4000-8000-000000000399',
+    org_id: 'default',
+    group_id: attendanceGroupId,
+    shift_id: shiftId,
+    start_date: '2026-06-01',
+    end_date: '2026-06-30',
+    revision: 1,
+    updated_by: 'admin-1',
+    created_at: '2026-08-03T00:00:00.000Z',
+    updated_at: '2026-08-03T00:00:00.000Z',
+    ...overrides,
+  }
+}
+
+function fixedScheduleQueryResult(sql: string, config = fixedScheduleConfigRow()) {
   if (sql.includes('SELECT id FROM attendance_groups WHERE id = $1')) return { handled: true, rows: [{ id: attendanceGroupId }] }
   if (sql.includes('SELECT * FROM attendance_groups WHERE id = $1')) return { handled: true, rows: [attendanceGroupRow()] }
   if (sql.includes('SELECT * FROM attendance_shifts WHERE id = $1')) return { handled: true, rows: [shiftRow()] }
   // W3 canonical assignability guard: shift FOR SHARE + persisted segment count.
   if (sql.includes('FROM attendance_shifts') && sql.includes('FOR SHARE')) return { handled: true, rows: [shiftRow()] }
+  if (sql.includes('SELECT 1 AS present') && sql.includes('FROM attendance_group_members')) return { handled: true, rows: [{ present: 1 }] }
+  if (sql.includes('FROM attendance_group_fixed_schedule_configs') && sql.includes('FOR UPDATE')) return { handled: true, rows: [config] }
   if (sql.includes('FROM attendance_shift_segments')) return { handled: true, rows: [{ total: 1 }] }
   if (sql.includes('SELECT DISTINCT user_id') && sql.includes('FROM attendance_group_members')) {
     return { handled: true, rows: [{ user_id: 'worker-1' }] }
@@ -3076,6 +3094,31 @@ describe('attendance UUID route validation', () => {
     })
     expect(db.transaction).toHaveBeenCalledTimes(1)
     expect(db.query).not.toHaveBeenCalledWith(expect.stringContaining('FROM attendance_scheduler_scopes'), expect.anything())
+  })
+
+  it('returns the typed config-changed 409 before assignment writes for a stale apply revision', async () => {
+    const { db, routes } = await createHarness('false')
+
+    db.query.mockImplementation(async (sql: string, params: unknown[] = []) => {
+      const rbac = rbacQueryResult(sql, params, true)
+      if (rbac !== undefined) return rbac
+      const fixedSchedule = fixedScheduleQueryResult(sql, fixedScheduleConfigRow({ revision: 2 }))
+      if (fixedSchedule.handled) return fixedSchedule.rows
+      throw new Error(`unexpected query: ${sql}`)
+    })
+
+    const res = await invokeRoute(routes, 'POST /api/attendance/groups/:id/fixed-schedule/apply', {
+      params: { id: attendanceGroupId },
+      body: { shiftId, startDate: '2026-06-01', endDate: '2026-06-30', expectedConfigRevision: 1 },
+      user: { id: 'admin-1', orgId: 'default' },
+    })
+
+    expect(res.statusCode).toBe(409)
+    expect(res.body).toMatchObject({
+      ok: false,
+      error: { code: 'ATTENDANCE_FIXED_SCHEDULE_CONFIG_CHANGED' },
+    })
+    expect(db.query.mock.calls.map(([sql]) => String(sql)).some(sql => sql.includes('INSERT INTO attendance_shift_assignments'))).toBe(false)
   })
 
   it('lets scoped non-admin schedulers apply fixed schedules inside their attendance group dispatch scope', async () => {

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -648,6 +648,9 @@ export default defineConfig({
       // #4709 FSER-2 effectiveness read model requires real PostgreSQL and is run as a
       // whole file in the attendance real-DB workflow step.
       'tests/integration/attendance-group-fixed-schedule-effectiveness.db.test.ts',
+      // #4709 FSER-3 first-config atomicity and true two-connection convergence require
+      // real PostgreSQL; the whole file is explicitly run in plugin-tests.yml.
+      'tests/integration/attendance-group-fixed-schedule-config-consume.db.test.ts',
       // #4556 W2 adds route-level work-date attribution legs to this whole-file real-DB
       // suite. Keep it out of the no-DB lane so describeDb cannot report skipped green;
       // plugin-tests.yml executes the complete file with ATTENDANCE_TEST_DATABASE_URL.

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -11041,15 +11041,63 @@ async function softDeactivateAttendanceGroupFixedScheduleManagedRows(db, input, 
   return rows.map(mapAssignmentRow)
 }
 
+class AttendanceGroupFixedScheduleTransactionAbort extends Error {
+  constructor(result) {
+    super(result.message)
+    this.result = result
+  }
+}
+
+async function runAttendanceGroupFixedScheduleTransaction(db, operation) {
+  return db.transaction(async (trx) => {
+    const result = await operation(trx)
+    if (!result.ok) {
+      throw new AttendanceGroupFixedScheduleTransactionAbort(result)
+    }
+    return result
+  })
+}
+
+function respondAttendanceGroupFixedScheduleTransactionAbort(res, error) {
+  if (!(error instanceof AttendanceGroupFixedScheduleTransactionAbort)) return false
+  const result = error.result
+  res.status(result.status).json({
+    ok: false,
+    error: {
+      code: result.code,
+      message: result.message,
+      ...(result.details === undefined ? {} : { details: result.details }),
+    },
+  })
+  return true
+}
+
 async function applyAttendanceGroupFixedSchedule(db, input) {
+  // FSER-3 (#4709): consume the desired config inside this transaction. Validation of
+  // group/shift/date/targets and the config row lock (or first-create insert) happen
+  // here, BEFORE any per-user target lock taken by the plan builder below; a failed
+  // apply rolls the first-create config insert back with every other write.
+  const { config } = await getAttendanceGroupFixedScheduleConfigService().resolveConfigForApplyRebuild(db, {
+    orgId: input.orgId,
+    groupId: input.groupId,
+    shiftId: input.shiftId,
+    startDate: input.startDate,
+    endDate: input.endDate,
+    expectedConfigRevision: input.expectedConfigRevision,
+    updatedBy: input.updatedBy,
+  })
+  // The transactionally reloaded config row is authoritative; never materialize from a
+  // client-supplied shadow copy once the config exists. For a matching candidate these
+  // values are identical, preserving the existing producer key and response shape.
+  const effectiveInput = { ...input, shiftId: config.shiftId, startDate: config.startDate, endDate: config.endDate }
   // W3 erratum: typed 422 + zero writes when a multi-segment shift is applied while
   // authoritative segment calculation is OFF for the org.
   await getAttendanceShiftService().assertShiftReferenceAllowed(db, {
-    orgId: input.orgId,
-    shiftId: input.shiftId,
+    orgId: effectiveInput.orgId,
+    shiftId: effectiveInput.shiftId,
     producer: 'fixed_schedule_apply',
   })
-  const result = await buildAttendanceGroupFixedSchedulePlan(db, input, { lockTargets: true })
+  const result = await buildAttendanceGroupFixedSchedulePlan(db, effectiveInput, { lockTargets: true })
   if (!result.ok) return result
   const plan = result.data
   if (plan.blockingConflicts.length > 0) {
@@ -11062,18 +11110,18 @@ async function applyAttendanceGroupFixedSchedule(db, input) {
     }
   }
 
-  const producerMetadata = buildAttendanceGroupFixedScheduleProducerMetadata(input, randomUUID())
-  const created = await insertAttendanceGroupFixedScheduleAssignments(db, input, plan.wouldCreate, producerMetadata)
+  const producerMetadata = buildAttendanceGroupFixedScheduleProducerMetadata(effectiveInput, randomUUID())
+  const created = await insertAttendanceGroupFixedScheduleAssignments(db, effectiveInput, plan.wouldCreate, producerMetadata)
 
   // S1 daily compliance cap: project every user that received a managed row over the apply window and
   // roll the whole apply back (throw → txn rollback → 422) if any day would exceed the cap. Guards the
   // bulk side-door alongside the per-record save routes (no known bypass window).
   for (const targetUserId of new Set(plan.wouldCreate.map((item) => item.userId))) {
     await enforceShiftComplianceCap(db, {
-      orgId: input.orgId,
+      orgId: effectiveInput.orgId,
       userId: targetUserId,
-      fromDate: input.startDate,
-      toDate: input.endDate,
+      fromDate: effectiveInput.startDate,
+      toDate: effectiveInput.endDate,
     })
   }
 
@@ -11088,14 +11136,27 @@ async function applyAttendanceGroupFixedSchedule(db, input) {
 }
 
 async function rebuildAttendanceGroupFixedSchedule(db, input) {
+  // FSER-3 (#4709): same config-consumption contract as apply — the config row is
+  // locked (or atomically first-created) before any target lock, and the reloaded row
+  // is the only authoritative source of the materialized values.
+  const { config } = await getAttendanceGroupFixedScheduleConfigService().resolveConfigForApplyRebuild(db, {
+    orgId: input.orgId,
+    groupId: input.groupId,
+    shiftId: input.shiftId,
+    startDate: input.startDate,
+    endDate: input.endDate,
+    expectedConfigRevision: input.expectedConfigRevision,
+    updatedBy: input.updatedBy,
+  })
+  const effectiveInput = { ...input, shiftId: config.shiftId, startDate: config.startDate, endDate: config.endDate }
   // W3 erratum: typed 422 + zero writes when a multi-segment shift is rebuilt while
   // authoritative segment calculation is OFF for the org.
   await getAttendanceShiftService().assertShiftReferenceAllowed(db, {
-    orgId: input.orgId,
-    shiftId: input.shiftId,
+    orgId: effectiveInput.orgId,
+    shiftId: effectiveInput.shiftId,
     producer: 'fixed_schedule_rebuild',
   })
-  const result = await buildAttendanceGroupFixedSchedulePlan(db, input, {
+  const result = await buildAttendanceGroupFixedSchedulePlan(db, effectiveInput, {
     lockTargets: true,
     lockManagedRowsForProducerKey: true,
   })
@@ -11111,26 +11172,26 @@ async function rebuildAttendanceGroupFixedSchedule(db, input) {
     }
   }
 
-  const activeManagedRows = await loadAttendanceGroupFixedScheduleManagedRows(db, input)
-  await acquireAttendanceScheduleAssignmentLocks(db, input.orgId, activeManagedRows.map(row => row.user_id))
-  const lockedManagedRows = await loadAttendanceGroupFixedScheduleManagedRows(db, input)
+  const activeManagedRows = await loadAttendanceGroupFixedScheduleManagedRows(db, effectiveInput)
+  await acquireAttendanceScheduleAssignmentLocks(db, effectiveInput.orgId, activeManagedRows.map(row => row.user_id))
+  const lockedManagedRows = await loadAttendanceGroupFixedScheduleManagedRows(db, effectiveInput)
   const targetUserIds = new Set(plan.target.userIds)
   const deactivateIds = lockedManagedRows
     .filter(row => !targetUserIds.has(String(row.user_id || '').trim()))
     .map(row => row.id)
 
-  const producerMetadata = buildAttendanceGroupFixedScheduleProducerMetadata(input, randomUUID())
-  const created = await insertAttendanceGroupFixedScheduleAssignments(db, input, plan.wouldCreate, producerMetadata)
-  const deactivated = await softDeactivateAttendanceGroupFixedScheduleManagedRows(db, input, deactivateIds)
+  const producerMetadata = buildAttendanceGroupFixedScheduleProducerMetadata(effectiveInput, randomUUID())
+  const created = await insertAttendanceGroupFixedScheduleAssignments(db, effectiveInput, plan.wouldCreate, producerMetadata)
+  const deactivated = await softDeactivateAttendanceGroupFixedScheduleManagedRows(db, effectiveInput, deactivateIds)
 
   // S1 daily compliance cap: project after BOTH insert + deactivate so the resolver sees the final
   // active set (stale managed rows already deactivated). Throw → txn rollback → 422 on any over-cap day.
   for (const targetUserId of new Set(plan.wouldCreate.map((item) => item.userId))) {
     await enforceShiftComplianceCap(db, {
-      orgId: input.orgId,
+      orgId: effectiveInput.orgId,
       userId: targetUserId,
-      fromDate: input.startDate,
-      toDate: input.endDate,
+      fromDate: effectiveInput.startDate,
+      toDate: effectiveInput.endDate,
     })
   }
 
@@ -23855,6 +23916,16 @@ module.exports = {
   __attendanceShiftServiceForTests: {
     lib: attendanceShiftServiceLib,
     getService: getAttendanceShiftService,
+  },
+  // FSER-3 (#4709): direct-call seam for the fixed-schedule apply/rebuild write paths
+  // so lock-order (config FOR UPDATE before any per-user advisory target lock) and
+  // canonical producer-key parity can be proven without a full HTTP harness.
+  __attendanceGroupFixedScheduleForTests: {
+    applyAttendanceGroupFixedSchedule,
+    rebuildAttendanceGroupFixedSchedule,
+    buildAttendanceGroupFixedScheduleProducerKey,
+    runAttendanceGroupFixedScheduleTransaction,
+    configServiceLib: attendanceGroupFixedScheduleConfigServiceLib,
   },
   __attendanceLivePunchWorkDateForTests: {
     getPunchShiftWindow,
@@ -44423,6 +44494,7 @@ module.exports = {
           startDate: z.string().min(1),
           endDate: z.string().min(1),
           orgId: z.string().optional(),
+          expectedConfigRevision: z.number().int().min(1).optional(),
         }).strict()
 
         const parsed = schema.safeParse(req.body ?? {})
@@ -44463,29 +44535,21 @@ module.exports = {
           const access = await assertAttendanceGroupFixedScheduleDispatchAllowed(req, res, { groupId, actorAccess })
           if (!access) return
 
-          const result = await db.transaction((trx) => applyAttendanceGroupFixedSchedule(trx, {
+          const result = await runAttendanceGroupFixedScheduleTransaction(db, (trx) => applyAttendanceGroupFixedSchedule(trx, {
             orgId,
             groupId,
             shiftId,
             startDate,
             endDate,
+            expectedConfigRevision: parsed.data.expectedConfigRevision,
+            updatedBy: access.userId,
           }))
-          if (!result.ok) {
-            res.status(result.status).json({
-              ok: false,
-              error: {
-                code: result.code,
-                message: result.message,
-                details: result.details,
-              },
-            })
-            return
-          }
           for (const assignment of result.data.created) {
             emitEvent('attendance.assignment.created', { orgId, assignmentId: assignment.id })
           }
           res.status(201).json({ ok: true, data: result.data })
         } catch (error) {
+          if (respondAttendanceGroupFixedScheduleTransactionAbort(res, error)) return
           if (respondAttendanceShiftServiceError(res, error)) return
           if (respondShiftComplianceCapExceeded(res, error)) return
           if (isDatabaseSchemaError(error)) {
@@ -44509,6 +44573,7 @@ module.exports = {
           startDate: z.string().min(1),
           endDate: z.string().min(1),
           orgId: z.string().optional(),
+          expectedConfigRevision: z.number().int().min(1).optional(),
         }).strict()
 
         const parsed = schema.safeParse(req.body ?? {})
@@ -44549,24 +44614,15 @@ module.exports = {
           const access = await assertAttendanceGroupFixedScheduleRebuildAllowed(req, res, { groupId, actorAccess })
           if (!access) return
 
-          const result = await db.transaction((trx) => rebuildAttendanceGroupFixedSchedule(trx, {
+          const result = await runAttendanceGroupFixedScheduleTransaction(db, (trx) => rebuildAttendanceGroupFixedSchedule(trx, {
             orgId,
             groupId,
             shiftId,
             startDate,
             endDate,
+            expectedConfigRevision: parsed.data.expectedConfigRevision,
+            updatedBy: access.userId,
           }))
-          if (!result.ok) {
-            res.status(result.status).json({
-              ok: false,
-              error: {
-                code: result.code,
-                message: result.message,
-                details: result.details,
-              },
-            })
-            return
-          }
           for (const assignment of result.data.created) {
             emitEvent('attendance.assignment.created', { orgId, assignmentId: assignment.id })
           }
@@ -44575,6 +44631,7 @@ module.exports = {
           }
           res.json({ ok: true, data: result.data })
         } catch (error) {
+          if (respondAttendanceGroupFixedScheduleTransactionAbort(res, error)) return
           if (respondAttendanceShiftServiceError(res, error)) return
           if (respondShiftComplianceCapExceeded(res, error)) return
           if (isDatabaseSchemaError(error)) {

--- a/plugins/plugin-attendance/lib/attendance-group-fixed-schedule-config-service.cjs
+++ b/plugins/plugin-attendance/lib/attendance-group-fixed-schedule-config-service.cjs
@@ -1,5 +1,8 @@
 'use strict'
 
+const CONFIG_CHANGED_ERROR_CODE = 'ATTENDANCE_FIXED_SCHEDULE_CONFIG_CHANGED'
+const CONFIG_CHANGED_ERROR_MESSAGE = 'Fixed schedule desired configuration changed; reload the configuration and retry'
+
 function createAttendanceGroupFixedScheduleConfigService({ HttpError }) {
   function formatDateOnly(value) {
     if (value instanceof Date) {
@@ -79,7 +82,120 @@ function createAttendanceGroupFixedScheduleConfigService({ HttpError }) {
     return mapConfigRow(rows[0])
   }
 
-  return { upsertConfig, mapConfigRow }
+  function throwConfigChanged() {
+    throw new HttpError(409, CONFIG_CHANGED_ERROR_CODE, CONFIG_CHANGED_ERROR_MESSAGE)
+  }
+
+  function configValuesMatchCandidate(row, input) {
+    return String(row.shift_id) === String(input.shiftId)
+      && formatDateOnly(row.start_date) === input.startDate
+      && formatDateOnly(row.end_date) === input.endDate
+  }
+
+  // FSER-3 (#4709): apply/rebuild consume the desired config inside their write
+  // transaction. Date and group validation precede the config lock; an existing row is
+  // locked and checked for staleness before its authoritative shift and targets are
+  // validated. On first create, candidate shift and non-empty target validation precede
+  // every config write. The config lock always precedes any per-user target lock taken
+  // by the caller. When no config exists, the validated candidate is
+  // inserted with INSERT ... ON CONFLICT DO NOTHING and the winning row is reloaded
+  // FOR UPDATE: an identical concurrent candidate continues idempotently, a different
+  // one gets the typed 409 instead of a leaked uniqueness error. When a config exists,
+  // a stale expectedConfigRevision or a legacy candidate value mismatch throws the same
+  // typed 409 before any assignment/config write. The returned row is the only
+  // authoritative source of the values the caller may materialize.
+  async function resolveConfigForApplyRebuild(trx, input) {
+    if (typeof input.startDate !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(input.startDate)
+      || typeof input.endDate !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(input.endDate)
+      || input.startDate > input.endDate) {
+      throw new HttpError(400, 'VALIDATION_ERROR', 'A valid startDate on or before endDate is required.')
+    }
+
+    const groupRows = await trx.query(
+      'SELECT id FROM attendance_groups WHERE id = $1 AND org_id = $2 LIMIT 1',
+      [input.groupId, input.orgId],
+    )
+    if (!groupRows.length) {
+      throw new HttpError(404, 'NOT_FOUND', 'Group not found')
+    }
+
+    const lockedRows = await trx.query(
+      `SELECT *
+        FROM attendance_group_fixed_schedule_configs
+       WHERE org_id = $1 AND group_id = $2
+        FOR UPDATE`,
+      [input.orgId, input.groupId],
+    )
+    if (lockedRows.length) {
+      const locked = lockedRows[0]
+      if (input.expectedConfigRevision !== undefined && input.expectedConfigRevision !== null) {
+        if (Number(locked.revision) !== Number(input.expectedConfigRevision)) {
+          throwConfigChanged()
+        }
+      } else if (!configValuesMatchCandidate(locked, input)) {
+        throwConfigChanged()
+      }
+      const shiftRows = await trx.query(
+        'SELECT id FROM attendance_shifts WHERE id = $1 AND org_id = $2 FOR SHARE',
+        [locked.shift_id, input.orgId],
+      )
+      if (!shiftRows.length) {
+        throw new HttpError(404, 'NOT_FOUND', 'Shift not found')
+      }
+      const targetRows = await trx.query(
+        'SELECT 1 AS present FROM attendance_group_members WHERE org_id = $1 AND group_id = $2 LIMIT 1',
+        [input.orgId, input.groupId],
+      )
+      if (!targetRows.length) {
+        throw new HttpError(400, 'VALIDATION_ERROR', 'Group has no members to schedule')
+      }
+      return { config: mapConfigRow(locked), created: false }
+    }
+
+    const shiftRows = await trx.query(
+      'SELECT id FROM attendance_shifts WHERE id = $1 AND org_id = $2 FOR SHARE',
+      [input.shiftId, input.orgId],
+    )
+    if (!shiftRows.length) {
+      throw new HttpError(404, 'NOT_FOUND', 'Shift not found')
+    }
+    const targetRows = await trx.query(
+      'SELECT 1 AS present FROM attendance_group_members WHERE org_id = $1 AND group_id = $2 LIMIT 1',
+      [input.orgId, input.groupId],
+    )
+    if (!targetRows.length) {
+      throw new HttpError(400, 'VALIDATION_ERROR', 'Group has no members to schedule')
+    }
+
+    const insertedRows = await trx.query(
+      `INSERT INTO attendance_group_fixed_schedule_configs
+         (org_id, group_id, shift_id, start_date, end_date, revision, updated_by, created_at, updated_at)
+       VALUES ($1, $2, $3, $4, $5, 1, $6, now(), now())
+       ON CONFLICT (org_id, group_id) DO NOTHING
+       RETURNING id`,
+      [input.orgId, input.groupId, input.shiftId, input.startDate, input.endDate, input.updatedBy ?? null],
+    )
+    const winnerRows = await trx.query(
+      `SELECT *
+         FROM attendance_group_fixed_schedule_configs
+        WHERE org_id = $1 AND group_id = $2
+        FOR UPDATE`,
+      [input.orgId, input.groupId],
+    )
+    const winner = winnerRows[0]
+    if (!winner) {
+      throw new HttpError(409, CONFIG_CHANGED_ERROR_CODE, CONFIG_CHANGED_ERROR_MESSAGE)
+    }
+    if (!configValuesMatchCandidate(winner, input)) {
+      throwConfigChanged()
+    }
+    return { config: mapConfigRow(winner), created: insertedRows.length > 0 }
+  }
+
+  return { upsertConfig, resolveConfigForApplyRebuild, mapConfigRow }
 }
 
-module.exports = { createAttendanceGroupFixedScheduleConfigService }
+module.exports = {
+  ATTENDANCE_FIXED_SCHEDULE_CONFIG_CHANGED: CONFIG_CHANGED_ERROR_CODE,
+  createAttendanceGroupFixedScheduleConfigService,
+}

--- a/plugins/plugin-integration-core/lib/sealed-export/vectors/s6a-package-provenance-pins.json
+++ b/plugins/plugin-integration-core/lib/sealed-export/vectors/s6a-package-provenance-pins.json
@@ -86,6 +86,6 @@
     "s6aAcceptancePs51Test": "835c7c6ce943d82e0378a40a27c7fd1e8b79b526faa8ca4c8066e4231a4bfb0f",
     "s6aProductRuntimeTest": "de978adafa8b89772cefa921c2051f434bf346bf5c2978bef3424ee70f51ba3f",
     "multitableOnpremPackageBuild": "463c7d73c6c7f2d1b6cdf0820d7a06974a9c463dd5e98bbbaf1c996e1dc4ed99",
-    "pluginTestsWorkflow": "1bbf2e384dccf5afd5810c81daf3ce0e71a928e581325fd050dc0d70eaed83dc"
+    "pluginTestsWorkflow": "53e63c4f721308e01d26dd73e232a4d3a75374c95c885fc38ddbd889c271f913"
   }
 }


### PR DESCRIPTION
## HOLD — do not merge

FSER-3 implementation for #4709 / #4556. This PR is intentionally Draft and unarmed. It does not authorize FSER-4, flags, deployment, soak, production/customer data, or closing #4556.

## What changed

- apply/rebuild lock and consume the durable desired config inside the existing write transaction
- absent config first-creates with `ON CONFLICT DO NOTHING`, reloads the winner `FOR UPDATE`, and preserves typed 409 convergence
- stale revisions and mismatched legacy candidates fail before assignment writes
- business-error results abort the transaction before the HTTP layer restores the existing response shape
- canonical producer-key and existing result shape remain authoritative

## Verification

- focused unit/route suites: 130/130
- complete attendance HTTP integration: 163/163 on a fresh migrated isolated database
- FSER migration/effectiveness + W3 writer matrix: 63/63
- four focused mutations killed: conflict clause, config lock, canonical key call, transaction-abort throw
- backend typecheck and diff check pass

Evidence: `docs/development/attendance-4709-fser3-apply-rebuild-config-consumption-verification-20260804.md`

Fresh exact-head CI and independent review are still required. Passing them does not authorize merge.