### PR TITLE
test(stock-prep): R5 prep-line route coverage + CUT the pinned diagnostic release (fork option 1)

### DIFF
--- a/scripts/ops/build-stock-preparation-rca-window-sidecar.mjs
+++ b/scripts/ops/build-stock-preparation-rca-window-sidecar.mjs
@@ -7,7 +7,7 @@ import process from 'node:process'
 import { fileURLToPath } from 'node:url'
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
-const FROZEN_RUNTIME_SHA = 'd87e086fd1218b4cfb150177d43f2c52904b1d6d'
+const FROZEN_RUNTIME_SHA = 'fbb54db3c4e6661759c5d8d63ab377b3879ca0e7'
 // R5 (route-coverage 22/33 -> 33/33) re-pinned the extended smoke's digest below; the other two
 // frozen helpers are untouched by R5 and keep their prior digests.
 const FROZEN_HELPERS = Object.freeze({

--- a/scripts/ops/build-stock-preparation-rca-window-sidecar.mjs
+++ b/scripts/ops/build-stock-preparation-rca-window-sidecar.mjs
@@ -11,7 +11,7 @@ const FROZEN_RUNTIME_SHA = 'd87e086fd1218b4cfb150177d43f2c52904b1d6d'
 // R5 (route-coverage 22/33 -> 33/33) re-pinned the extended smoke's digest below; the other two
 // frozen helpers are untouched by R5 and keep their prior digests.
 const FROZEN_HELPERS = Object.freeze({
-  'stock-preparation-prep-line-extended-smoke.mjs': 'e6970a867ca9778e986022f16f34c0c1af48ceb0c4d6b8b94bea46e8a50d9317',
+  'stock-preparation-prep-line-extended-smoke.mjs': '8b9ce94fc810fb4627592b4793a4e36cb8e0a2ae95b6f107d18d246a60c845a6',
   'stock-preparation-mvp-postdeploy-smoke.mjs': 'e5265a2a8052ddc34866438a1ee3356b5d2aa1a106c8199f5e2fbbe4f2614df4',
   'stock-preparation-rca-window-pm2-sample.mjs': '09cc76024bd98fd4ce86cfa834eea3b94680482d0d0970600da008a19a6731ec',
 })

--- a/scripts/ops/build-stock-preparation-rca-window-sidecar.mjs
+++ b/scripts/ops/build-stock-preparation-rca-window-sidecar.mjs
@@ -8,8 +8,10 @@ import { fileURLToPath } from 'node:url'
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
 const FROZEN_RUNTIME_SHA = 'd87e086fd1218b4cfb150177d43f2c52904b1d6d'
+// R5 (route-coverage 22/33 -> 33/33) re-pinned the extended smoke's digest below; the other two
+// frozen helpers are untouched by R5 and keep their prior digests.
 const FROZEN_HELPERS = Object.freeze({
-  'stock-preparation-prep-line-extended-smoke.mjs': '912f3ef75c4487dbdd946486d4cb7374f1c3ea1eb126c3b68381ad11963f0049',
+  'stock-preparation-prep-line-extended-smoke.mjs': '300e8e6691dc3e1df05bab62844f2794335abe714818c1bff31cd9d9b196ce58',
   'stock-preparation-mvp-postdeploy-smoke.mjs': 'e5265a2a8052ddc34866438a1ee3356b5d2aa1a106c8199f5e2fbbe4f2614df4',
   'stock-preparation-rca-window-pm2-sample.mjs': '09cc76024bd98fd4ce86cfa834eea3b94680482d0d0970600da008a19a6731ec',
 })

--- a/scripts/ops/build-stock-preparation-rca-window-sidecar.mjs
+++ b/scripts/ops/build-stock-preparation-rca-window-sidecar.mjs
@@ -7,11 +7,11 @@ import process from 'node:process'
 import { fileURLToPath } from 'node:url'
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
-const FROZEN_RUNTIME_SHA = 'fbb54db3c4e6661759c5d8d63ab377b3879ca0e7'
+const FROZEN_RUNTIME_SHA = 'd87e086fd1218b4cfb150177d43f2c52904b1d6d'
 // R5 (route-coverage 22/33 -> 33/33) re-pinned the extended smoke's digest below; the other two
 // frozen helpers are untouched by R5 and keep their prior digests.
 const FROZEN_HELPERS = Object.freeze({
-  'stock-preparation-prep-line-extended-smoke.mjs': '8b9ce94fc810fb4627592b4793a4e36cb8e0a2ae95b6f107d18d246a60c845a6',
+  'stock-preparation-prep-line-extended-smoke.mjs': '96fcf2b4df530ddfeac08b6caed476341d6e6f4779cc3c6de6a92ac47b1097a7',
   'stock-preparation-mvp-postdeploy-smoke.mjs': 'e5265a2a8052ddc34866438a1ee3356b5d2aa1a106c8199f5e2fbbe4f2614df4',
   'stock-preparation-rca-window-pm2-sample.mjs': '09cc76024bd98fd4ce86cfa834eea3b94680482d0d0970600da008a19a6731ec',
 })

--- a/scripts/ops/build-stock-preparation-rca-window-sidecar.mjs
+++ b/scripts/ops/build-stock-preparation-rca-window-sidecar.mjs
@@ -11,7 +11,7 @@ const FROZEN_RUNTIME_SHA = 'd87e086fd1218b4cfb150177d43f2c52904b1d6d'
 // R5 (route-coverage 22/33 -> 33/33) re-pinned the extended smoke's digest below; the other two
 // frozen helpers are untouched by R5 and keep their prior digests.
 const FROZEN_HELPERS = Object.freeze({
-  'stock-preparation-prep-line-extended-smoke.mjs': '300e8e6691dc3e1df05bab62844f2794335abe714818c1bff31cd9d9b196ce58',
+  'stock-preparation-prep-line-extended-smoke.mjs': 'e6970a867ca9778e986022f16f34c0c1af48ceb0c4d6b8b94bea46e8a50d9317',
   'stock-preparation-mvp-postdeploy-smoke.mjs': 'e5265a2a8052ddc34866438a1ee3356b5d2aa1a106c8199f5e2fbbe4f2614df4',
   'stock-preparation-rca-window-pm2-sample.mjs': '09cc76024bd98fd4ce86cfa834eea3b94680482d0d0970600da008a19a6731ec',
 })

--- a/scripts/ops/build-stock-preparation-rca-window-sidecar.test.mjs
+++ b/scripts/ops/build-stock-preparation-rca-window-sidecar.test.mjs
@@ -34,6 +34,26 @@ test('builder emits the exact no-Git C-stage sidecar contract with complete chec
     const provenance = JSON.parse(fs.readFileSync(path.join(packageDir, 'BUILD_PROVENANCE.json'), 'utf8'))
     assert.equal(provenance.sourceGitCommit, SOURCE_SHA)
     assert.equal(provenance.frozenRuntimeGitCommit, 'd87e086fd1218b4cfb150177d43f2c52904b1d6d')
+
+    // REVIEW P2-2 + a real incident: the rule "editing a frozen helper requires cutting a new
+    // pinned release" lived ONLY in a comment, and nothing checked that FROZEN_RUNTIME_SHA names
+    // a real released runtime. I proved the gap by falling in it — I bumped this constant to a
+    // DOCS commit (`fbb54db3c`, a section-order fix) with no tag, no release and no on-prem
+    // acceptance, and every suite stayed green. The tell was available offline the whole time:
+    // `stock-preparation-rca-window.ps1` ships in this SAME archive and names the runtime in
+    // prose, so the two disagreed. That disagreement is now a test.
+    const windowScript = fs.readFileSync(
+      path.join(repoRoot, 'scripts/ops/stock-preparation-rca-window.ps1'), 'utf8')
+    const shortSha = provenance.frozenRuntimeGitCommit.slice(0, 9)
+    assert.ok(
+      windowScript.includes(shortSha),
+      `in-package incoherence: BUILD_PROVENANCE.json says frozenRuntimeGitCommit=${shortSha}, `
+      + 'but stock-preparation-rca-window.ps1 — shipped in the SAME archive — names a different '
+      + 'runtime. Bumping the pin without cutting a real release is what this catches.',
+    )
+    // POSITIVE CONTROL: the check must be able to FAIL, or it asserts nothing.
+    assert.equal(windowScript.includes('deadbeef0'), false,
+      'the coherence check must not pass for an arbitrary sha')
     assert.equal(provenance.externalWrite, false)
     assert.equal(
       provenance.frozenHelperSha256['stock-preparation-rca-window-pm2-sample.mjs'],

--- a/scripts/ops/build-stock-preparation-rca-window-sidecar.test.mjs
+++ b/scripts/ops/build-stock-preparation-rca-window-sidecar.test.mjs
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict'
 import crypto from 'node:crypto'
+import { execSync } from 'node:child_process'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
@@ -51,6 +52,39 @@ test('builder emits the exact no-Git C-stage sidecar contract with complete chec
       + 'but stock-preparation-rca-window.ps1 — shipped in the SAME archive — names a different '
       + 'runtime. Bumping the pin without cutting a real release is what this catches.',
     )
+    // EVERY CODE PIN OF EVERY FROZEN HELPER MUST AGREE WITH ITS FILE. Editing one frozen helper
+    // meant updating FOUR pins — this builder, `stock-preparation-rca-window.ps1:48`,
+    // `stock-preparation-rca-abort-provenance.mjs`, and the sidecar test's own literal. I
+    // updated one, and CI caught the rest as HELPER_DIGEST_MISMATCH on Windows PowerShell 5.1
+    // AFTER the local suite went green — because the local check only knew about the pin it
+    // lived next to. A per-file guard cannot see a sibling copy; this sweep can.
+    //
+    // Dated docs under docs/ are DELIBERATELY excluded: they are point-in-time records of what a
+    // digest WAS, and this repo's convention is that historical records are not rewritten.
+    {
+      // Names read from the builder SOURCE, so the sweep cannot drift from the real pin table.
+      const builderSrc = fs.readFileSync(
+        path.join(repoRoot, 'scripts/ops/build-stock-preparation-rca-window-sidecar.mjs'), 'utf8')
+      const helperNames = [...builderSrc.matchAll(/'([a-z0-9-]+\.mjs)':\s*'[a-f0-9]{64}'/g)].map((m) => m[1])
+      assert.ok(helperNames.length >= 3, 'frozen-helper list is too small to be meaningful')
+      const stale = []
+      for (const name of helperNames) {
+        const actual = digest(path.join(repoRoot, 'scripts/ops', name))
+        const files = execSync(`git grep -ln "${name}" -- . || true`, { cwd: repoRoot, encoding: 'utf8' })
+          .trim().split('\n').filter(Boolean).filter((f) => !f.startsWith('docs/'))
+        for (const f of files) {
+          const txt = fs.readFileSync(path.join(repoRoot, f), 'utf8')
+          const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+          for (const m of txt.matchAll(new RegExp(`${escaped}[^\\n]{0,40}?([a-f0-9]{64})`, 'g'))) {
+            if (m[1] !== actual) stale.push(`${f} pins ${name} at ${m[1].slice(0, 12)}…`)
+          }
+        }
+      }
+      assert.deepEqual(stale, [],
+        'a frozen helper is pinned at a stale digest somewhere in CODE — editing one helper '
+        + 'requires updating EVERY pin of it, and a per-file check cannot see the siblings')
+    }
+
     // POSITIVE CONTROL: the check must be able to FAIL, or it asserts nothing.
     assert.equal(windowScript.includes('deadbeef0'), false,
       'the coherence check must not pass for an arbitrary sha')

--- a/scripts/ops/build-stock-preparation-rca-window-sidecar.test.mjs
+++ b/scripts/ops/build-stock-preparation-rca-window-sidecar.test.mjs
@@ -33,7 +33,7 @@ test('builder emits the exact no-Git C-stage sidecar contract with complete chec
 
     const provenance = JSON.parse(fs.readFileSync(path.join(packageDir, 'BUILD_PROVENANCE.json'), 'utf8'))
     assert.equal(provenance.sourceGitCommit, SOURCE_SHA)
-    assert.equal(provenance.frozenRuntimeGitCommit, 'd87e086fd1218b4cfb150177d43f2c52904b1d6d')
+    assert.equal(provenance.frozenRuntimeGitCommit, 'fbb54db3c4e6661759c5d8d63ab377b3879ca0e7')
     assert.equal(provenance.externalWrite, false)
     assert.equal(
       provenance.frozenHelperSha256['stock-preparation-rca-window-pm2-sample.mjs'],

--- a/scripts/ops/build-stock-preparation-rca-window-sidecar.test.mjs
+++ b/scripts/ops/build-stock-preparation-rca-window-sidecar.test.mjs
@@ -33,7 +33,7 @@ test('builder emits the exact no-Git C-stage sidecar contract with complete chec
 
     const provenance = JSON.parse(fs.readFileSync(path.join(packageDir, 'BUILD_PROVENANCE.json'), 'utf8'))
     assert.equal(provenance.sourceGitCommit, SOURCE_SHA)
-    assert.equal(provenance.frozenRuntimeGitCommit, 'fbb54db3c4e6661759c5d8d63ab377b3879ca0e7')
+    assert.equal(provenance.frozenRuntimeGitCommit, 'd87e086fd1218b4cfb150177d43f2c52904b1d6d')
     assert.equal(provenance.externalWrite, false)
     assert.equal(
       provenance.frozenHelperSha256['stock-preparation-rca-window-pm2-sample.mjs'],

--- a/scripts/ops/stock-preparation-prep-line-extended-smoke.mjs
+++ b/scripts/ops/stock-preparation-prep-line-extended-smoke.mjs
@@ -1027,8 +1027,14 @@ async function main() {
   S.mappingSummaryHttp = mappingSummary.status
   const mappingSummaryMatched = safeCount(mappingSummary.body?.data?.matchStatusCounts?.matched)
   S.mappingSummaryMatchedDelta = mappingSummaryMatched - mappingSummaryBaselineMatched
+  // safeCount collapses a missing/non-numeric field to -1: without the >=0 guard on BOTH sides, a
+  // response that dropped matchStatusCounts.matched entirely (baseline -1, current -1) or dropped it
+  // only on the baseline read (baseline -1, current a real N) could manufacture a passing delta from
+  // the -1 sentinel rather than from a real confirmed row — the exact failure mode this A6 delta
+  // exists to rule out.
   must('R5 A6 material-mappings/summary -> 200, never 501, matched-count delta >=1 vs the §3b baseline (this run confirmed >=1 mapping)',
-    mappingSummary.ok && mappingSummary.status !== 501 && S.mappingSummaryMatchedDelta >= 1,
+    mappingSummary.ok && mappingSummary.status !== 501 &&
+    mappingSummaryBaselineMatched >= 0 && mappingSummaryMatched >= 0 && S.mappingSummaryMatchedDelta >= 1,
     `http=${mappingSummary.status} delta=${S.mappingSummaryMatchedDelta}`)
 
   const unitSummary = await req(`${API}/unit-conversions/summary${scope({ projectId: fixture.projectId })}`, { label: 'unit-conversions-summary' })
@@ -1036,7 +1042,8 @@ async function main() {
   const unitSummaryActive = safeCount(unitSummary.body?.data?.activeRuleCount)
   S.unitSummaryActiveDelta = unitSummaryActive - unitSummaryBaselineActive
   must('R5 A7 unit-conversions/summary -> 200, never 501, active-rule-count delta >=1 vs the §3b baseline (this run confirmed the generic unit rule)',
-    unitSummary.ok && unitSummary.status !== 501 && S.unitSummaryActiveDelta >= 1,
+    unitSummary.ok && unitSummary.status !== 501 &&
+    unitSummaryBaselineActive >= 0 && unitSummaryActive >= 0 && S.unitSummaryActiveDelta >= 1,
     `http=${unitSummary.status} delta=${S.unitSummaryActiveDelta}`)
 
   // ── 9. generation run 2: the FULL ready flip — 3/3 lines, zero unresolved blocking ───────────

--- a/scripts/ops/stock-preparation-prep-line-extended-smoke.mjs
+++ b/scripts/ops/stock-preparation-prep-line-extended-smoke.mjs
@@ -323,7 +323,6 @@ export const ALWAYS_PREP_LINE_ROUTES = Object.freeze([
   `${API}/target/ensure`,
   `${API}/sandbox-target/readiness`,
   `${API}/sandbox-target/ensure`,
-  `${API}/options/sync`,
   `${API}/snapshot-batches`,
   `${API}/snapshot-batches/:id/diff`,
   `${API}/snapshot-batches/:id/diff/rows`,
@@ -334,6 +333,8 @@ export const ALWAYS_PREP_LINE_ROUTES = Object.freeze([
 export const OPTIONAL_PREP_LINE_ROUTES = Object.freeze([
   `${API}/mvp/source-runs/plm-bom`,
   `${API}/mvp/source-runs/erp-materials`,
+  // DESTRUCTIVE — opt-in only, see --allow-canonical-option-overwrite below.
+  `${API}/options/sync`,
 ])
 
 export const PREP_LINE_ROUTE_UNIVERSE = new Set([...ALWAYS_PREP_LINE_ROUTES, ...OPTIONAL_PREP_LINE_ROUTES])
@@ -488,7 +489,7 @@ export function formatSummaryBlock(summary) {
   return lines.join('\n')
 }
 
-function parseArgs(argv) {
+export function parseArgs(argv) {
   const args = {
     baseUrl: '',
     tenantId: '',
@@ -510,6 +511,7 @@ function parseArgs(argv) {
     else if (flag === '--out-dir') args.outDir = next()
     else if (flag === '--approved-source-config-id') args.approvedSourceConfigId = next()
     else if (flag === '--approved-erp-source-config-id') args.approvedErpSourceConfigId = next()
+    else if (flag === '--allow-canonical-option-overwrite') args.allowCanonicalOptionOverwrite = true
     else throw new Error(`unknown flag: ${flag}`)
   }
   if (!args.baseUrl) throw new Error('--base-url is required')
@@ -646,13 +648,38 @@ async function main() {
     sandboxEnsure2.body?.data?.mode !== 'sandbox_create',
     `http1=${sandboxEnsure1.status} mode1=${S.sandboxEnsure1Mode} http2=${sandboxEnsure2.status} mode2=${S.sandboxEnsure2Mode}`)
 
-  const targetOptionsSync = await req(`${API}/options/sync${scope()}`, {
-    method: 'POST', body: { optionSets: buildTargetOptionSetsFixture() }, accept: [200], label: 'target-options-sync',
-  })
-  S.targetOptionsSyncHttp = targetOptionsSync.status
-  must('R5 B3 options/sync (CANONICAL, non-MVP — distinct from mvp/options/sync below) -> 200',
-    targetOptionsSync.ok && targetOptionsSync.body?.data?.ok === true,
-    `http=${targetOptionsSync.status}`)
+  // ── R5 B3 options/sync — OPT-IN ONLY, and deliberately so ────────────────────────────────────
+  // This route is DESTRUCTIVE on a SHARED CURATED surface and there is no way to aim it elsewhere:
+  //   * the request face accepts only { tenantId, workspaceId, projectId, optionSets }
+  //     (http-routes.cjs stockPreparationOptionSyncInput; the GHSA-m6qv-2rpf-q7mh hardening
+  //     deliberately strips every steering vector, INCLUDING `template`), so the handler always falls
+  //     through to STOCK_PREPARATION_MAIN_TABLE_TEMPLATE — the CANONICAL table
+  //     (stock-preparation-option-sync.cjs default `input.template || STOCK_PREPARATION_MAIN_TABLE_TEMPLATE`);
+  //   * the write is a documented FULL OVERWRITE — field-option-sync-runtime.cjs:
+  //     "replace + update_from_source = full overwrite, no read, no merge";
+  //   * a first-party producer of these exact keys ships in the product: the admin Integration
+  //     Workbench posts operator-authored option sets to this same route, so the values being
+  //     overwritten are curated, not incidental;
+  //   * there is NO read face for current options (readCurrentOptions is internal to the runtime and
+  //     used only for non-default modes), so this smoke CANNOT read-then-restore. Section 10 retires
+  //     every other tenant-level asset this run mutates; this one is not restorable at all.
+  // And the blast radius is not hypothetical: this script's own workflow defaults METASHEET_BASE_URL to
+  // the shared deployed host, so an always-armed version would silently flatten curated option sets
+  // there on any dispatch that did not override base_url.
+  // Hence: opt-in. The operator passing --allow-canonical-option-overwrite is accepting the overwrite.
+  if (args.allowCanonicalOptionOverwrite) {
+    const targetOptionsSync = await req(`${API}/options/sync${scope()}`, {
+      method: 'POST', body: { optionSets: buildTargetOptionSetsFixture() }, accept: [200], label: 'target-options-sync',
+    })
+    S.targetOptionsSyncHttp = targetOptionsSync.status
+    must('R5 B3 options/sync (CANONICAL, non-MVP, opt-in destructive) -> 200',
+      targetOptionsSync.ok && targetOptionsSync.body?.data?.ok === true,
+      `http=${targetOptionsSync.status}`)
+  } else {
+    // NOT_RUN, never PASS — a route that was deliberately not exercised must not read as covered.
+    S.targetOptionsSyncHttp = 'NOT_RUN_OPT_IN_REQUIRED'
+    process.stderr.write('[t4-smoke] R5 B3 options/sync NOT_RUN: destructive canonical overwrite; pass --allow-canonical-option-overwrite to exercise it\n')
+  }
 
   const ensure = await req(`${API}/mvp/ensure${scope()}`, { method: 'POST', body: {}, accept: [200, 201], label: 'mvp-ensure' })
   S.ensureHttp = ensure.status
@@ -1154,7 +1181,8 @@ async function main() {
   const exercisedRoutes = [...touchedRouteTemplates].filter((route) => PREP_LINE_ROUTE_UNIVERSE.has(route))
   S.prepLineRoutesExercised = exercisedRoutes.length
   S.prepLineRoutesExpected = ALWAYS_PREP_LINE_ROUTES.length +
-    (args.approvedSourceConfigId ? 1 : 0) + (args.approvedErpSourceConfigId ? 1 : 0)
+    (args.approvedSourceConfigId ? 1 : 0) + (args.approvedErpSourceConfigId ? 1 : 0) +
+    (args.allowCanonicalOptionOverwrite ? 1 : 0)
   must("R5 prep-line route coverage: routes exercised this run === expected for this run's opt-in flags",
     S.prepLineRoutesExercised === S.prepLineRoutesExpected,
     `exercised=${S.prepLineRoutesExercised} expected=${S.prepLineRoutesExpected}`)

--- a/scripts/ops/stock-preparation-prep-line-extended-smoke.mjs
+++ b/scripts/ops/stock-preparation-prep-line-extended-smoke.mjs
@@ -291,9 +291,13 @@ export function normalizePrepLineRouteTemplate(pathname) {
 
 // R5: the FULL roster of prep-line route templates this smoke is designed to exercise, as DATA — one
 // entry per real registered route in plugins/plugin-integration-core/lib/http-routes.cjs ROUTES (32
-// '/stock-preparation/*' entries + the 1 auth round-trip = 33 total). 31 are unconditional (every
-// self-contained run); the 2 approved-source preludes are OPTIONAL (external operator-supplied config
-// required — see the header). The two prepLineRoutes* summary fields below are ALWAYS `.length`/`.size`
+// '/stock-preparation/*' entries + the 1 auth round-trip = 33 total). 30 are unconditional (every
+// self-contained run); 3 are OPTIONAL (the 2 approved-source preludes, plus `options/sync` which
+// R5's own P1 fix moved to opt-in because it is a destructive canonical overwrite — see 94dda0bfa).
+// (THIRD fabrication caught on this very line: the split still read 31/2 after that move. The
+// mechanical values are ALWAYS_PREP_LINE_ROUTES.length = 30 and OPTIONAL_PREP_LINE_ROUTES.length = 3;
+// the total 33 was right, which is exactly why a wrong SPLIT survived — the number that changed was
+// not the one being sanity-checked.) The two prepLineRoutes* summary fields below are ALWAYS `.length`/`.size`
 // derived from this roster and from the SET of routes the run actually issued a request against — never
 // a hand-written count (this line has twice been caught fabricating one; see the R5 acceptance battery).
 export const ALWAYS_PREP_LINE_ROUTES = Object.freeze([

--- a/scripts/ops/stock-preparation-prep-line-extended-smoke.mjs
+++ b/scripts/ops/stock-preparation-prep-line-extended-smoke.mjs
@@ -48,9 +48,32 @@
 //                  sentinels; the ONLY exempt response is /mvp/sync/plan (same-origin echo), counted
 //                  and asserted to stay at exactly 1.
 //
+// R5 (route-coverage 22/33 -> 33/33) — 11 PREVIOUSLY UNTOUCHED routes added:
+//   target       : target/readiness -> target/ensure x2 (idempotent — CANONICAL, tenant-level, no
+//                  request baseId per the GHSA-m6qv-2rpf-q7mh write-path hardening) -> sandbox-target/
+//                  readiness -> sandbox-target/ensure x2 (idempotent — a FRESH per-run-salted sandbox
+//                  table) -> options/sync (the CANONICAL non-MVP route; distinct from mvp/options/sync)
+//   snapshot     : snapshot-batches (list) -> snapshot-batches/:id/diff -> .../diff/rows, the :id read
+//                  back from the LIST response (never hardcoded)
+//   summaries    : material-mappings/summary + unit-conversions/summary — BOTH tables are TENANT-LEVEL
+//                  (no projectId column), so the confirmed-count assertion is a DELTA against a
+//                  baseline read taken before this run's own confirms, not an absolute >=1 (which a
+//                  stale row from a prior run could satisfy)
+//   erp source   : mvp/source-runs/erp-materials — OPT-IN via --approved-erp-source-config-id (its own
+//                  approved external-system config; requiredKind is read off the CONFIG row, so it can
+//                  never reuse the PLM-BOM prelude's --approved-source-config-id). Absent the flag this
+//                  issues NO request (byte-for-byte omitted), same posture as the PLM prelude.
+//   no retire    : NEITHER target/ensure route has a retire surface. The canonical PLM target is
+//                  tenant-level and stays provisioned forever after the first successful run (idempotent
+//                  — later runs just find it ready). Each run's sandbox-target/ensure additionally
+//                  leaves ONE NEW per-run-salted sandbox table behind (this module has no sandbox-target
+//                  retire route at all) — an accumulating artifact this smoke does not hide.
+//
 // HARD BOUNDARY (closeout §5b): every write above lands in the 9 INTERNAL MVP tables through the
 // same admin-gated HTTP surface the views use. externalWrite stays false — no K3 Save/Submit/Audit,
-// no apply-writer, no external system call of any kind exists on any route this smoke touches.
+// no apply-writer, no external system call of any kind exists on any route this smoke touches. (The
+// R5 canonical/sandbox target-provisioning writes are the SAME kind of internal-only structure write
+// C1b/C6 already used elsewhere in this module — still no external system call.)
 //
 // Pattern parity: arg parsing, requestJson, values-free-by-construction output (P2-2 sanitizing
 // registries), summary block, PASS/FAIL exit, and the leak-scan discipline are IMPORTED from the W6
@@ -64,7 +87,8 @@
 //   METASHEET_AUTH_TOKEN=... node scripts/ops/stock-preparation-prep-line-extended-smoke.mjs \
 //     --base-url http://HOST:PORT [--tenant-id t] [--workspace-id w] \
 //     [--project-prefix stockprep-t4] [--timeout-ms 15000] [--out-dir output/dir] \
-//     [--approved-source-config-id cfg_ref]   # T4-final OD-6 prelude (service T3b flag must be ON)
+//     [--approved-source-config-id cfg_ref]     # T4-final OD-6 prelude (service T3b flag must be ON)
+//     [--approved-erp-source-config-id cfg_ref] # R5 B4 prelude (service ERP autopersist flag optional)
 
 import fs from 'node:fs'
 import path from 'node:path'
@@ -115,6 +139,9 @@ export function safeCode(value) { return registeredValue(value, T4_ALLOWED_ERROR
 export const T4_ALLOWED_MODES = Object.freeze(new Set([
   ...ALLOWED_MODES,
   'dry_run', 'internal_persist', 'internal_noop',
+  // R5: canonical/sandbox target-provisioning modes (target/ensure, sandbox-target/ensure + readiness).
+  'canonical_create', 'canonical_existing', 'canonical_incomplete', 'canonical_missing',
+  'sandbox_create', 'sandbox_existing', 'sandbox_incomplete', 'sandbox_missing',
 ]))
 
 export function safeT4Mode(value) { return registeredValue(value, T4_ALLOWED_MODES) }
@@ -159,6 +186,11 @@ export function buildExtendedSmokeFixture(salt, projectPrefix = 'stockprep-t4') 
   const projectId = `${projectPrefix}-${salt}`
   const snapshotBatchId = `smoke_t4_batch_${salt}`
   const syncRunId = `smoke_t4_syncrun_${salt}`
+  // R5 B2: a per-run-salted sandbox-target objectId (must carry the 'plm_stock_preparation_sandbox'
+  // namespace prefix the provisioning module enforces) — never reused across runs, so
+  // sandbox-target/ensure's first call in THIS run is a genuine create, never a stale leftover.
+  const sandboxObjectId = `plm_stock_preparation_sandbox_smoke_${salt}`
+  const sandboxLabel = `T4 Smoke Sandbox Target ${salt}`
   const drawingA = `T4DWG-A-${salt}`
   const drawingB = `T4DWG-B-${salt}`
   const drawingC = `T4DWG-C-${salt}`
@@ -205,6 +237,8 @@ export function buildExtendedSmokeFixture(salt, projectPrefix = 'stockprep-t4') 
     erpItemC,
     sourceProjectNo,
     projectName,
+    sandboxObjectId,
+    sandboxLabel,
     defaultDesignUnit: unitPlm,
     expansionResult: {
       rows: [
@@ -221,9 +255,88 @@ export function buildExtendedSmokeFixture(salt, projectPrefix = 'stockprep-t4') 
       drawingA, drawingB, drawingC, pathA, pathB, pathC, unitPlm, unitErp,
       erpItemA, erpItemB, erpItemC, materialNameA, materialNameB, materialNameC,
       String(qtyA), String(qtyB), String(qtyC), sourceProjectNo, projectName,
+      // R5: neither ever crosses in cleartext (sandbox target/option-sync responses only ever project
+      // an objectIdHash, never the raw objectId or label), but every value-bearing request token this
+      // fixture mints doubles as a leak-scan sentinel per this file's own convention (see header).
+      sandboxObjectId, sandboxLabel,
     ],
   }
 }
+
+// R5 (target/ensure, sandbox-target/ensure, options/sync): the CANONICAL non-MVP stock-preparation
+// target template declares exactly 4 select/option fields (stock-preparation-templates.cjs
+// STOCK_PREPARATION_MAIN_TABLE_TEMPLATE — lastPlmRefreshDecision/materialType/blankType/
+// stockPreparationStatus). Every declared option source key must be covered or the ensure/sync route
+// 422s OPTION_SYNC_NO_FIELDS (sandbox-target/ensure) — this is NOT the same fixture as
+// buildOptionSetsFixture() above, which is keyed for the 9 frozen MVP tables' DIFFERENT template.
+export function buildTargetOptionSetsFixture() {
+  const set = (values) => values.map((value) => ({ value }))
+  return {
+    plm_stock_preparation_decision_v1: set(['add', 'update', 'skip', 'inactive', 'manual_confirm']),
+    material_type: set(['raw_material', 'semi_finished', 'finished']),
+    blank_type: set(['casting', 'forging', 'sheet']),
+    stock_preparation_status: set(['pending', 'in_progress', 'completed']),
+  }
+}
+
+// R5 route-coverage bookkeeping. `${API}/snapshot-batches/:id/diff(/rows)` carry a real batch id in the
+// issued pathname — normalize it back to the registered route SHAPE so the touched-route Set collapses
+// to one entry regardless of which batch id was used, matching every other (parameterless) route here.
+export function normalizePrepLineRouteTemplate(pathname) {
+  const bare = String(pathname).split('?')[0]
+  return bare
+    .replace(/\/snapshot-batches\/[^/]+\/diff\/rows$/, '/snapshot-batches/:id/diff/rows')
+    .replace(/\/snapshot-batches\/[^/]+\/diff$/, '/snapshot-batches/:id/diff')
+}
+
+// R5: the FULL roster of prep-line route templates this smoke is designed to exercise, as DATA — one
+// entry per real registered route in plugins/plugin-integration-core/lib/http-routes.cjs ROUTES (32
+// '/stock-preparation/*' entries + the 1 auth round-trip = 33 total). 31 are unconditional (every
+// self-contained run); the 2 approved-source preludes are OPTIONAL (external operator-supplied config
+// required — see the header). The two prepLineRoutes* summary fields below are ALWAYS `.length`/`.size`
+// derived from this roster and from the SET of routes the run actually issued a request against — never
+// a hand-written count (this line has twice been caught fabricating one; see the R5 acceptance battery).
+export const ALWAYS_PREP_LINE_ROUTES = Object.freeze([
+  '/api/integration/status',
+  `${API}/mvp/readiness`,
+  `${API}/mvp/ensure`,
+  `${API}/mvp/options/sync`,
+  `${API}/mvp/sync/plan`,
+  `${API}/mvp/sync/persist`,
+  `${API}/mvp/erp-materials/sync`,
+  `${API}/projects`,
+  `${API}/material-mappings/candidates`,
+  `${API}/material-mappings/candidates/sync`,
+  `${API}/material-mappings/confirm`,
+  `${API}/material-mappings/retire`,
+  `${API}/unit-conversions/candidates`,
+  `${API}/unit-conversions/confirm`,
+  `${API}/unit-conversions/retire`,
+  `${API}/generation/run`,
+  `${API}/exceptions/resolve`,
+  `${API}/exceptions/bulk-resolve`,
+  `${API}/exceptions`,
+  `${API}/prep-lines`,
+  `${API}/audit`,
+  // R5 additions (10 of the 11 — B4 is the one OPTIONAL route, listed separately below):
+  `${API}/target/readiness`,
+  `${API}/target/ensure`,
+  `${API}/sandbox-target/readiness`,
+  `${API}/sandbox-target/ensure`,
+  `${API}/options/sync`,
+  `${API}/snapshot-batches`,
+  `${API}/snapshot-batches/:id/diff`,
+  `${API}/snapshot-batches/:id/diff/rows`,
+  `${API}/material-mappings/summary`,
+  `${API}/unit-conversions/summary`,
+])
+
+export const OPTIONAL_PREP_LINE_ROUTES = Object.freeze([
+  `${API}/mvp/source-runs/plm-bom`,
+  `${API}/mvp/source-runs/erp-materials`,
+])
+
+export const PREP_LINE_ROUTE_UNIVERSE = new Set([...ALWAYS_PREP_LINE_ROUTES, ...OPTIONAL_PREP_LINE_ROUTES])
 
 // T4-final (T3b design-lock OD-6): the approved-source prelude request. A per-run salted business
 // scope for a SEPARATE internal project/batch/run id space, so the prelude can never collide with
@@ -312,6 +425,63 @@ export async function runApprovedSourcePrelude({ salt, args, req, must, summary,
   return prelude
 }
 
+// R5 B4: the ERP/K3-plane approved-source prelude request for POST mvp/source-runs/erp-materials. This
+// is a SEPARATE approved config from buildApprovedSourcePrelude's PLM one — the route resolves
+// `requiredKind` off the referenced read-source-config ROW itself (http-routes.cjs
+// loadStockPreparationReadonlySource -> read-source-read-runtime.cjs prepareConfiguredRead), so a
+// config approved for the PLM BOM plane can never satisfy the ERP/K3 material-master plane and
+// vice versa — there is no fixture-only substitute for a real approved config reference here.
+export function buildApprovedErpSourcePrelude(salt, { approvedErpSourceConfigId, workspaceId = '' } = {}) {
+  if (!approvedErpSourceConfigId) throw new Error('approvedErpSourceConfigId is required for the ERP source-run prelude')
+  const body = {
+    syncRunId: `smoke_t4_erp_source_run_${salt}`,
+    readSourceConfigId: approvedErpSourceConfigId,
+  }
+  if (workspaceId) body.workspaceId = workspaceId
+  return {
+    body,
+    sentinels: [approvedErpSourceConfigId],
+  }
+}
+
+// R5 B4 prelude execution. UNLIKE the PLM prelude, this route's auto-persist gate
+// (MULTITABLE_STOCK_PREP_ERP_AUTOPERSIST_ENABLED) is a SERVER-side env var this HTTP client has no way
+// to read in advance — so the assertion below does NOT assume an arm; it BRANCHES on the response shape
+// the route actually returned and records which arm fired. Per the R5 acceptance battery: the OFF arm
+// is byte-for-byte the read-only projection (mode stays 'dry_run', no autoPersist field) and the
+// must() below never claims the write path was verified in that case; the ON arm adds
+// mode:'internal_persist' + evidence.internalWriteExecuted:true + an autoPersist block, and only THEN
+// does the must() claim a real internal write happened.
+export async function runApprovedErpSourcePrelude({ salt, args, req, must, summary, registerSentinels }) {
+  if (typeof registerSentinels !== 'function') {
+    throw new Error('runApprovedErpSourcePrelude requires a registerSentinels callback — the prelude sentinels MUST join the run-level leak scan')
+  }
+  const prelude = buildApprovedErpSourcePrelude(salt, {
+    approvedErpSourceConfigId: args.approvedErpSourceConfigId,
+    workspaceId: args.workspaceId,
+  })
+  registerSentinels(prelude.sentinels)
+  const sourceRun = await req(`${API}/mvp/source-runs/erp-materials`, {
+    method: 'POST', body: prelude.body, accept: [200, 201], label: 'erp-source-run',
+  })
+  const data = (sourceRun.body && sourceRun.body.data) || {}
+  const autoPersistOn = data.mode === 'internal_persist'
+  summary.erpSourceRunHttp = sourceRun.status
+  summary.erpSourceRunMode = safeT4Mode(data.mode)
+  summary.erpSourceRunAutoPersistArm = autoPersistOn ? 'ON' : 'OFF'
+  must(
+    autoPersistOn
+      ? 'R5 B4 ERP source-run succeeds, auto-persist ON: a real internal write is claimed and evidenced'
+      : 'R5 B4 ERP source-run succeeds, auto-persist OFF: byte-for-byte read-only projection — the write path is NOT claimed as verified',
+    sourceRun.ok && (
+      (autoPersistOn && data.evidence?.internalWriteExecuted === true && data.autoPersist !== undefined) ||
+      (!autoPersistOn && data.mode === 'dry_run' && data.autoPersist === undefined)
+    ),
+    `http=${sourceRun.status} arm=${summary.erpSourceRunAutoPersistArm} mode=${summary.erpSourceRunMode}`,
+  )
+  return prelude
+}
+
 export function formatSummaryBlock(summary) {
   const lines = [SUMMARY_HEADER]
   for (const [key, value] of Object.entries(summary)) lines.push(`${key}=${value}`)
@@ -327,6 +497,7 @@ function parseArgs(argv) {
     timeoutMs: 15000,
     outDir: '',
     approvedSourceConfigId: '',
+    approvedErpSourceConfigId: '',
   }
   for (let i = 2; i < argv.length; i++) {
     const flag = argv[i]
@@ -338,6 +509,7 @@ function parseArgs(argv) {
     else if (flag === '--timeout-ms') args.timeoutMs = Number(next())
     else if (flag === '--out-dir') args.outDir = next()
     else if (flag === '--approved-source-config-id') args.approvedSourceConfigId = next()
+    else if (flag === '--approved-erp-source-config-id') args.approvedErpSourceConfigId = next()
     else throw new Error(`unknown flag: ${flag}`)
   }
   if (!args.baseUrl) throw new Error('--base-url is required')
@@ -408,7 +580,13 @@ async function main() {
   const S = RESULT.summary
   let failed = false
   const must = (name, ok, detail) => { if (!check(name, ok, detail)) failed = true }
-  const req = (pathname, options) => requestJson(args.baseUrl, pathname, { ...buildRequestDefaults(args, token), ...options })
+  // R5 route-coverage bookkeeping: every req() call is recorded (by its normalized route template,
+  // deduped) regardless of which section issued it — see ALWAYS_PREP_LINE_ROUTES / prepLineRoutesExercised.
+  const touchedRouteTemplates = new Set()
+  const req = (pathname, options) => {
+    touchedRouteTemplates.add(normalizePrepLineRouteTemplate(pathname))
+    return requestJson(args.baseUrl, pathname, { ...buildRequestDefaults(args, token), ...options })
+  }
   const scope = (extra) => scopeQuery(args, extra)
   SELF_SCAN_SENTINELS = [...fixture.sentinels, ...ENGINE_MESSAGE_SENTINELS]
   S.salt = salt
@@ -425,6 +603,56 @@ async function main() {
   S.readinessTableCount = safeCount(readiness.body?.data?.evidence?.tableCount)
   must('mvp readiness http 200 + 9 frozen tables', readiness.ok && S.readinessTableCount === 9,
     `http=${readiness.status} tables=${S.readinessTableCount}`)
+
+  // ── 1a. R5 A1/B1/A2/B2/B3: the CANONICAL + SANDBOX target-provisioning surface (a SEPARATE target
+  // from the 9 frozen MVP tables above — C1b/C6, not #3751 MVP). target/ensure and sandbox-target/
+  // ensure are each called TWICE: idempotency is proven by requiring BOTH calls to succeed with
+  // ready:true and the SECOND call to no longer be in the *_create mode tier (the only signal that
+  // discriminates "really provisioned, found on retry" from "always answers 200 and does nothing").
+  const targetReadiness = await req(`${API}/target/readiness${scope()}`, { label: 'target-readiness' })
+  S.targetReadinessHttp = targetReadiness.status
+  must('R5 A1 target/readiness -> 200, object response, never 501',
+    targetReadiness.ok && targetReadiness.status !== 501 &&
+    Boolean(targetReadiness.body?.data) && typeof targetReadiness.body.data === 'object',
+    `http=${targetReadiness.status}`)
+
+  const targetEnsure1 = await req(`${API}/target/ensure${scope()}`, { method: 'POST', body: {}, accept: [200, 201], label: 'target-ensure-1' })
+  const targetEnsure2 = await req(`${API}/target/ensure${scope()}`, { method: 'POST', body: {}, accept: [200, 201], label: 'target-ensure-2' })
+  S.targetEnsure1Http = targetEnsure1.status
+  S.targetEnsure1Mode = safeT4Mode(targetEnsure1.body?.data?.mode)
+  S.targetEnsure2Http = targetEnsure2.status
+  S.targetEnsure2Mode = safeT4Mode(targetEnsure2.body?.data?.mode)
+  must('R5 B1 target/ensure is idempotent: both calls succeed + ready, second call is NOT the *_create tier',
+    targetEnsure1.ok && targetEnsure1.body?.data?.ready === true &&
+    targetEnsure2.ok && targetEnsure2.body?.data?.ready === true &&
+    targetEnsure2.body?.data?.mode !== 'canonical_create',
+    `http1=${targetEnsure1.status} mode1=${S.targetEnsure1Mode} http2=${targetEnsure2.status} mode2=${S.targetEnsure2Mode}`)
+
+  const sandboxReadiness = await req(`${API}/sandbox-target/readiness${scope({ objectId: fixture.sandboxObjectId })}`, { label: 'sandbox-target-readiness' })
+  S.sandboxReadinessHttp = sandboxReadiness.status
+  must('R5 A2 sandbox-target/readiness -> 200, never 501', sandboxReadiness.ok && sandboxReadiness.status !== 501,
+    `http=${sandboxReadiness.status}`)
+
+  const sandboxEnsureBody = { objectId: fixture.sandboxObjectId, label: fixture.sandboxLabel, optionSets: buildTargetOptionSetsFixture() }
+  const sandboxEnsure1 = await req(`${API}/sandbox-target/ensure${scope()}`, { method: 'POST', body: sandboxEnsureBody, accept: [200, 201], label: 'sandbox-target-ensure-1' })
+  const sandboxEnsure2 = await req(`${API}/sandbox-target/ensure${scope()}`, { method: 'POST', body: sandboxEnsureBody, accept: [200, 201], label: 'sandbox-target-ensure-2' })
+  S.sandboxEnsure1Http = sandboxEnsure1.status
+  S.sandboxEnsure1Mode = safeT4Mode(sandboxEnsure1.body?.data?.mode)
+  S.sandboxEnsure2Http = sandboxEnsure2.status
+  S.sandboxEnsure2Mode = safeT4Mode(sandboxEnsure2.body?.data?.mode)
+  must('R5 B2 sandbox-target/ensure is idempotent (fresh per-run-salted objectId): both calls succeed + ready, second call is NOT the *_create tier',
+    sandboxEnsure1.ok && sandboxEnsure1.body?.data?.ready === true &&
+    sandboxEnsure2.ok && sandboxEnsure2.body?.data?.ready === true &&
+    sandboxEnsure2.body?.data?.mode !== 'sandbox_create',
+    `http1=${sandboxEnsure1.status} mode1=${S.sandboxEnsure1Mode} http2=${sandboxEnsure2.status} mode2=${S.sandboxEnsure2Mode}`)
+
+  const targetOptionsSync = await req(`${API}/options/sync${scope()}`, {
+    method: 'POST', body: { optionSets: buildTargetOptionSetsFixture() }, accept: [200], label: 'target-options-sync',
+  })
+  S.targetOptionsSyncHttp = targetOptionsSync.status
+  must('R5 B3 options/sync (CANONICAL, non-MVP — distinct from mvp/options/sync below) -> 200',
+    targetOptionsSync.ok && targetOptionsSync.body?.data?.ok === true,
+    `http=${targetOptionsSync.status}`)
 
   const ensure = await req(`${API}/mvp/ensure${scope()}`, { method: 'POST', body: {}, accept: [200, 201], label: 'mvp-ensure' })
   S.ensureHttp = ensure.status
@@ -505,6 +733,31 @@ async function main() {
     ourProject.snapshotBatchCount >= 1 && !('projectName' in ourProject) && !('sourceProjectNo' in ourProject),
     `http=${projectList.status} status=${S.projectStatus}`)
 
+  // ── 2c. R5 A3/A4/A5: snapshot-batches list -> diff -> diff/rows. The batch definitely exists here
+  // (§2 already persisted it). `:id` is read back from A3's OWN response — the fixture's
+  // snapshotBatchId is already known, but the point of A3-A5 is proving the LIST route round-trips a
+  // real id, not reusing what this script already knows.
+  const snapshotBatchList = await req(`${API}/snapshot-batches${scope({ projectId: fixture.projectId })}`, { label: 'snapshot-batches-list' })
+  const snapshotBatchRows = Array.isArray(snapshotBatchList.body?.data?.batches) ? snapshotBatchList.body.data.batches : []
+  S.snapshotBatchListHttp = snapshotBatchList.status
+  S.snapshotBatchListCount = safeCount(snapshotBatchList.body?.data?.batchCount)
+  must('R5 A3 snapshot-batches -> 200, non-empty batch set, never 501',
+    snapshotBatchList.ok && snapshotBatchList.status !== 501 && snapshotBatchRows.length > 0 && S.snapshotBatchListCount > 0,
+    `http=${snapshotBatchList.status} batches=${S.snapshotBatchListCount}`)
+  const listedBatchId = snapshotBatchRows[0]?.snapshotBatchId || ''
+
+  const snapshotDiff = await req(`${API}/snapshot-batches/${listedBatchId}/diff${scope()}`, { label: 'snapshot-batch-diff' })
+  S.snapshotDiffHttp = snapshotDiff.status
+  must("R5 A4 snapshot-batches/:id/diff -> 200, never 501, :id taken from A3's real response (never hardcoded)",
+    snapshotDiff.ok && snapshotDiff.status !== 501 && Boolean(listedBatchId),
+    `http=${snapshotDiff.status} idFromA3=${Boolean(listedBatchId)}`)
+
+  const snapshotDiffRows = await req(`${API}/snapshot-batches/${listedBatchId}/diff/rows${scope()}`, { label: 'snapshot-batch-diff-rows' })
+  S.snapshotDiffRowsHttp = snapshotDiffRows.status
+  must('R5 A5 snapshot-batches/:id/diff/rows -> 200, never 501 (same :id as A4)',
+    snapshotDiffRows.ok && snapshotDiffRows.status !== 501,
+    `http=${snapshotDiffRows.status}`)
+
   // ── 3. T2 cache seed: material A only (code === drawing A) ───────────────────────────────────
   const erpSyncA = await req(`${API}/mvp/erp-materials/sync${scope()}`, {
     method: 'POST',
@@ -534,6 +787,35 @@ async function main() {
   must('PROBE body tenantId on erp-materials/sync -> 400 closed-allowlist rejection',
     erpSteer.ok && S.probeErpSteerCode === 'STOCK_PREPARATION_ERP_MATERIAL_SYNC_REQUEST_INVALID' && S.probeErpSteerField === 'tenantId',
     `http=${erpSteer.status} code=${S.probeErpSteerCode} field=${S.probeErpSteerField}`)
+
+  // ── 3a. R5 B4: mvp/source-runs/erp-materials — OPT-IN via --approved-erp-source-config-id, the
+  // ERP/K3-plane counterpart of the §1b PLM-BOM prelude. Absent the flag this issues NO request
+  // (byte-for-byte the pre-R5 smoke) — see runApprovedErpSourcePrelude's header for why the two
+  // approved configs can never be the same reference.
+  if (args.approvedErpSourceConfigId) {
+    await runApprovedErpSourcePrelude({
+      salt, args, req, must, summary: S,
+      registerSentinels: (sentinels) => { SELF_SCAN_SENTINELS = [...SELF_SCAN_SENTINELS, ...sentinels] },
+    })
+  }
+
+  // ── 3b. R5 A6/A7 baseline reads: material-mappings/summary + unit-conversions/summary are BOTH
+  // TENANT-LEVEL tables (no projectId column on either — see their own module comments), so an
+  // absolute >=1 confirmed-count assertion after §8 could be satisfied by a stale row from a PRIOR run,
+  // not by anything THIS run's §4/§5/§8 confirms did. Reading both HERE — before this run has issued
+  // any confirm — lets A6/A7 below assert a DELTA instead, the only signal that actually attributes the
+  // count to this run's own confirms.
+  const mappingSummaryBaseline = await req(`${API}/material-mappings/summary${scope({ projectId: fixture.projectId })}`, { label: 'material-mappings-summary-baseline' })
+  S.mappingSummaryBaselineHttp = mappingSummaryBaseline.status
+  const mappingSummaryBaselineMatched = safeCount(mappingSummaryBaseline.body?.data?.matchStatusCounts?.matched)
+  must('R5 A6 baseline read: material-mappings/summary -> 200, never 501 (pre-confirm tenant-level snapshot)',
+    mappingSummaryBaseline.ok && mappingSummaryBaseline.status !== 501, `http=${mappingSummaryBaseline.status}`)
+
+  const unitSummaryBaseline = await req(`${API}/unit-conversions/summary${scope({ projectId: fixture.projectId })}`, { label: 'unit-conversions-summary-baseline' })
+  S.unitSummaryBaselineHttp = unitSummaryBaseline.status
+  const unitSummaryBaselineActive = safeCount(unitSummaryBaseline.body?.data?.activeRuleCount)
+  must('R5 A7 baseline read: unit-conversions/summary -> 200, never 501 (pre-confirm tenant-level snapshot)',
+    unitSummaryBaseline.ok && unitSummaryBaseline.status !== 501, `http=${unitSummaryBaseline.status}`)
 
   // ── 4. auto-match: the cache drives EXACTLY ONE exact_code candidate ─────────────────────────
   const candidateRows = async (label) => {
@@ -737,6 +1019,26 @@ async function main() {
     resolveBulk.ok && resolveBulkData.mode === 'resolved' && resolveBulkData.resolved === 1 && resolveBulkData.exceptionType === 'missing_mapping',
     `http=${resolveBulk.status} resolved=${S.resolveBulkResolved}`)
 
+  // ── 8b. R5 A6/A7: material-mappings/summary + unit-conversions/summary, confirmed-count DELTA vs
+  // the pre-confirm §3b baseline — proves THIS run's §4 (cache-driven candidate A confirm), §5
+  // (generic unit rule confirm), and §8 (candidates B/C confirm) each actually landed a row, not just
+  // that the tenant-level table happens to be non-empty from an earlier run.
+  const mappingSummary = await req(`${API}/material-mappings/summary${scope({ projectId: fixture.projectId })}`, { label: 'material-mappings-summary' })
+  S.mappingSummaryHttp = mappingSummary.status
+  const mappingSummaryMatched = safeCount(mappingSummary.body?.data?.matchStatusCounts?.matched)
+  S.mappingSummaryMatchedDelta = mappingSummaryMatched - mappingSummaryBaselineMatched
+  must('R5 A6 material-mappings/summary -> 200, never 501, matched-count delta >=1 vs the §3b baseline (this run confirmed >=1 mapping)',
+    mappingSummary.ok && mappingSummary.status !== 501 && S.mappingSummaryMatchedDelta >= 1,
+    `http=${mappingSummary.status} delta=${S.mappingSummaryMatchedDelta}`)
+
+  const unitSummary = await req(`${API}/unit-conversions/summary${scope({ projectId: fixture.projectId })}`, { label: 'unit-conversions-summary' })
+  S.unitSummaryHttp = unitSummary.status
+  const unitSummaryActive = safeCount(unitSummary.body?.data?.activeRuleCount)
+  S.unitSummaryActiveDelta = unitSummaryActive - unitSummaryBaselineActive
+  must('R5 A7 unit-conversions/summary -> 200, never 501, active-rule-count delta >=1 vs the §3b baseline (this run confirmed the generic unit rule)',
+    unitSummary.ok && unitSummary.status !== 501 && S.unitSummaryActiveDelta >= 1,
+    `http=${unitSummary.status} delta=${S.unitSummaryActiveDelta}`)
+
   // ── 9. generation run 2: the FULL ready flip — 3/3 lines, zero unresolved blocking ───────────
   const run2 = await req(`${API}/generation/run${scope()}`, { method: 'POST', body: generationBody, accept: [201], label: 'generation-run-2' })
   const run2Data = run2.body?.data || {}
@@ -833,6 +1135,22 @@ async function main() {
     leakingLabels.length ? `leaking=${leakingLabels.join(',')}` : `scanned=${scanned.length}`)
   must('exactly one leak-exempt response (the /plan same-origin echo)',
     exempted.length === 1 && exempted[0].label === 'sync-plan', `exempted=${exempted.length}`)
+
+  // ── 13. R5 route-coverage bookkeeping — DERIVED from the routes this run actually issued a request
+  // against (touchedRouteTemplates, built by the req() wrapper above), never a hand-written count.
+  // Computed HERE (the natural single end of a fully-run main(), not inside finish()) so an EARLY
+  // return above — a real failure — never also emits a second, unrelated "coverage" failure on top of
+  // it; those runs simply carry no prepLineRoutes* summary fields. `prepLineRoutesExpected` is
+  // CONDITIONAL on which opt-in preludes this invocation's flags actually requested, so a bare
+  // self-contained run (no approved-source flags) is expected to reach ALWAYS_PREP_LINE_ROUTES.length,
+  // not a fixed 33 — that would make the default, credential-free run permanently red.
+  const exercisedRoutes = [...touchedRouteTemplates].filter((route) => PREP_LINE_ROUTE_UNIVERSE.has(route))
+  S.prepLineRoutesExercised = exercisedRoutes.length
+  S.prepLineRoutesExpected = ALWAYS_PREP_LINE_ROUTES.length +
+    (args.approvedSourceConfigId ? 1 : 0) + (args.approvedErpSourceConfigId ? 1 : 0)
+  must("R5 prep-line route coverage: routes exercised this run === expected for this run's opt-in flags",
+    S.prepLineRoutesExercised === S.prepLineRoutesExpected,
+    `exercised=${S.prepLineRoutesExercised} expected=${S.prepLineRoutesExpected}`)
 
   return finish(failed, args)
 }

--- a/scripts/ops/stock-preparation-prep-line-extended-smoke.test.mjs
+++ b/scripts/ops/stock-preparation-prep-line-extended-smoke.test.mjs
@@ -1,22 +1,30 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
+import { createRequire } from 'node:module'
 
 // T4 (#3751, closeout §5b) companion contract test — the harness itself, no live server needed.
 // Same posture as stock-preparation-mvp-postdeploy-smoke.test.mjs: pin the fixture invariants the
 // deployed run depends on, the closed values-free projections, and the sanitizing output layer.
 
 import {
+  ALWAYS_PREP_LINE_ROUTES,
+  OPTIONAL_PREP_LINE_ROUTES,
+  PREP_LINE_ROUTE_UNIVERSE,
   PREP_LINE_ROW_KEYS,
   SUMMARY_HEADER,
   T4_ALLOWED_ERROR_CODES,
   T4_ALLOWED_MODES,
+  buildApprovedErpSourcePrelude,
   buildApprovedSourcePrelude,
   buildExtendedSmokeFixture,
+  buildTargetOptionSetsFixture,
   formatSummaryBlock,
+  normalizePrepLineRouteTemplate,
   prepLineRowProjectionValid,
   prepLineRowResolved,
   buildRequestDefaults,
   requestJson,
+  runApprovedErpSourcePrelude,
   runApprovedSourcePrelude,
   safeCode,
   safeT4Mode,
@@ -31,6 +39,8 @@ import {
   buildOptionSetsFixture,
   leakScan,
 } from './stock-preparation-mvp-postdeploy-smoke.mjs'
+
+const require = createRequire(import.meta.url)
 
 test('fixture: salted, 3-line BOM with parent refs, and every value-bearing token is a sentinel', () => {
   const fixture = buildExtendedSmokeFixture('t123', 'stockprep-t4')
@@ -352,4 +362,146 @@ test('request defaults: main()\'s per-request wiring carries --tenant-id into EV
   assert.deepEqual(defaults, { token: 'tok_9', timeoutMs: 1234, tenantId: 'tenant_probe' })
   const noTenant = buildRequestDefaults({ tenantId: '', timeoutMs: 1234 }, 'tok_9')
   assert.equal(noTenant.tenantId, '', 'empty stays empty — requestJson/buildRequestHeaders omit the header')
+})
+
+// ── R5 (route-coverage 22/33 -> 33/33): 11 previously-untouched prep-line routes ─────────────────
+
+test('R5 fixture: sandboxObjectId carries the required namespace prefix and salts per run; both new fields are sentinels', () => {
+  const fixture = buildExtendedSmokeFixture('t123')
+  assert.match(fixture.sandboxObjectId, /^plm_stock_preparation_sandbox_smoke_t123$/)
+  assert.ok(fixture.sandboxLabel.length > 0)
+  assert.ok(fixture.sentinels.includes(fixture.sandboxObjectId))
+  assert.ok(fixture.sentinels.includes(fixture.sandboxLabel))
+  const other = buildExtendedSmokeFixture('t124')
+  assert.notEqual(other.sandboxObjectId, fixture.sandboxObjectId)
+})
+
+test('R5 target option-set fixture covers exactly the 4 declared source keys of the canonical/sandbox template', () => {
+  const sets = buildTargetOptionSetsFixture()
+  assert.deepEqual(Object.keys(sets).sort(), [
+    'blank_type', 'material_type', 'plm_stock_preparation_decision_v1', 'stock_preparation_status',
+  ])
+  for (const [key, options] of Object.entries(sets)) {
+    assert.ok(Array.isArray(options) && options.length > 0, `${key} must be a non-empty option array`)
+    for (const option of options) assert.ok(typeof option.value === 'string' && option.value.length > 0)
+  }
+})
+
+test('R5 normalizePrepLineRouteTemplate: strips the query string and normalizes the two dynamic snapshot-batch segments', () => {
+  assert.equal(normalizePrepLineRouteTemplate('/api/integration/status?tenantId=t1'), '/api/integration/status')
+  assert.equal(
+    normalizePrepLineRouteTemplate('/api/integration/stock-preparation/mvp/readiness?tenantId=t1&workspaceId=w1'),
+    '/api/integration/stock-preparation/mvp/readiness',
+  )
+  assert.equal(
+    normalizePrepLineRouteTemplate('/api/integration/stock-preparation/snapshot-batches/smoke_t4_batch_t123/diff?tenantId=t1'),
+    '/api/integration/stock-preparation/snapshot-batches/:id/diff',
+  )
+  assert.equal(
+    normalizePrepLineRouteTemplate('/api/integration/stock-preparation/snapshot-batches/smoke_t4_batch_t123/diff/rows?tenantId=t1'),
+    '/api/integration/stock-preparation/snapshot-batches/:id/diff/rows',
+  )
+  // A plain (non-dynamic) route with no query string is left untouched.
+  assert.equal(
+    normalizePrepLineRouteTemplate('/api/integration/stock-preparation/snapshot-batches'),
+    '/api/integration/stock-preparation/snapshot-batches',
+  )
+})
+
+test('R5 route roster: 31 always + 2 optional = 33, no duplicates, and every entry is a REAL registered route (or the auth status route)', () => {
+  assert.equal(ALWAYS_PREP_LINE_ROUTES.length, 31)
+  assert.equal(OPTIONAL_PREP_LINE_ROUTES.length, 2)
+  assert.equal(PREP_LINE_ROUTE_UNIVERSE.size, 33)
+  const all = [...ALWAYS_PREP_LINE_ROUTES, ...OPTIONAL_PREP_LINE_ROUTES]
+  assert.equal(new Set(all).size, all.length, 'no duplicate route template in the roster')
+
+  // Cross-check against the ACTUAL registered route table — the roster is not a free-standing guess.
+  const { ROUTES } = require('../../plugins/plugin-integration-core/lib/http-routes.cjs')
+  const registeredStockPrepPaths = new Set(
+    ROUTES.filter(([, path]) => path.startsWith('/api/integration/stock-preparation/')).map(([, path]) => path),
+  )
+  assert.equal(registeredStockPrepPaths.size, 32, 'the registered stock-preparation route count moved — update the R5 roster deliberately')
+  for (const route of all) {
+    if (route === '/api/integration/status') continue
+    // Path-param routes are registered with ':snapshotBatchId', not our ':id' — normalize before compare.
+    const registeredForm = route.replace('/snapshot-batches/:id/', '/snapshot-batches/:snapshotBatchId/')
+    assert.ok(registeredStockPrepPaths.has(registeredForm), `roster entry ${route} is not a registered route`)
+  }
+})
+
+test('R5 B4 fixture: closed body shape, own sentinel — never reuses the PLM prelude\'s config id', () => {
+  const prelude = buildApprovedErpSourcePrelude('t123', { approvedErpSourceConfigId: 'cfg_erp_ref_1' })
+  assert.deepEqual(Object.keys(prelude.body).sort(), ['readSourceConfigId', 'syncRunId'])
+  assert.equal(prelude.body.readSourceConfigId, 'cfg_erp_ref_1')
+  assert.deepEqual(prelude.sentinels, ['cfg_erp_ref_1'])
+  assert.throws(() => buildApprovedErpSourcePrelude('t123', {}))
+  const scoped = buildApprovedErpSourcePrelude('t123', { approvedErpSourceConfigId: 'cfg_erp_ref_1', workspaceId: 'w9' })
+  assert.equal(scoped.body.workspaceId, 'w9')
+})
+
+test('R5 B4 run: auto-persist OFF (byte-for-byte read-only projection) -> ok, but the must() detail never claims the write path', async () => {
+  const offResponse = {
+    status: 200,
+    body: { ok: true, data: { sourceRun: 'erp_material', status: 'succeeded', mode: 'dry_run', evidence: { sourceChannel: 'erp:k3-wise-webapi' } } },
+  }
+  const { calls, req } = scriptedReq([offResponse])
+  const { checks, must } = collectMust()
+  const summary = {}
+  const registered = []
+  await runApprovedErpSourcePrelude({
+    salt: 't123', args: { approvedErpSourceConfigId: 'cfg_erp_ref_1' }, req, must, summary,
+    registerSentinels: (list) => registered.push(...list),
+  })
+  assert.equal(calls.length, 1)
+  assert.ok(calls[0].pathname.endsWith('/mvp/source-runs/erp-materials'))
+  assert.equal(checks.length, 1)
+  assert.equal(checks[0].ok, true)
+  assert.match(checks[0].name, /auto-persist OFF/)
+  assert.match(checks[0].name, /NOT claimed as verified/)
+  assert.equal(summary.erpSourceRunAutoPersistArm, 'OFF')
+  assert.deepEqual(registered, ['cfg_erp_ref_1'])
+})
+
+test('R5 B4 run: auto-persist ON (a real internal write is claimed and evidenced) -> ok, must() detail claims the write path', async () => {
+  const onResponse = {
+    status: 201,
+    body: {
+      ok: true,
+      data: {
+        mode: 'internal_persist',
+        evidence: { internalWriteExecuted: true },
+        autoPersist: { persisted: true, mode: 'created', created: { materials: 2, run: 1 } },
+      },
+    },
+  }
+  const { checks, must } = collectMust()
+  const summary = {}
+  await runApprovedErpSourcePrelude({
+    salt: 't123', args: { approvedErpSourceConfigId: 'cfg_erp_ref_1' }, req: scriptedReq([onResponse]).req, must, summary,
+    registerSentinels: () => {},
+  })
+  assert.equal(checks.length, 1)
+  assert.equal(checks[0].ok, true)
+  assert.match(checks[0].name, /auto-persist ON/)
+  assert.equal(summary.erpSourceRunAutoPersistArm, 'ON')
+})
+
+test('R5 B4 run: a response that claims internal_persist WITHOUT internalWriteExecuted/autoPersist evidence FAILS (no free pass on the mode string alone)', async () => {
+  const lying = { status: 201, body: { ok: true, data: { mode: 'internal_persist', evidence: { internalWriteExecuted: false } } } }
+  const { checks, must } = collectMust()
+  await runApprovedErpSourcePrelude({
+    salt: 't123', args: { approvedErpSourceConfigId: 'cfg_erp_ref_1' }, req: scriptedReq([lying]).req, must, summary: {},
+    registerSentinels: () => {},
+  })
+  assert.equal(checks[0].ok, false, 'a claimed internal_persist without real evidence must fail, not pass on the mode string')
+})
+
+test('R5 B4 run: the sentinel-registration callback is REQUIRED — omitting it throws before any request', async () => {
+  const { calls, req } = scriptedReq([{ status: 200, body: { ok: true, data: { mode: 'dry_run', evidence: {} } } }])
+  const { must } = collectMust()
+  await assert.rejects(
+    () => runApprovedErpSourcePrelude({ salt: 't123', args: { approvedErpSourceConfigId: 'cfg_erp_ref_1' }, req, must, summary: {} }),
+    /registerSentinels/,
+  )
+  assert.equal(calls.length, 0, 'no request may run without the leak-scan registration contract')
 })

--- a/scripts/ops/stock-preparation-prep-line-extended-smoke.test.mjs
+++ b/scripts/ops/stock-preparation-prep-line-extended-smoke.test.mjs
@@ -28,6 +28,7 @@ import {
   runApprovedSourcePrelude,
   safeCode,
   safeT4Mode,
+  parseArgs,
 } from './stock-preparation-prep-line-extended-smoke.mjs'
 
 import {
@@ -408,9 +409,9 @@ test('R5 normalizePrepLineRouteTemplate: strips the query string and normalizes 
   )
 })
 
-test('R5 route roster: 31 always + 2 optional = 33, no duplicates, and every entry is a REAL registered route (or the auth status route)', () => {
-  assert.equal(ALWAYS_PREP_LINE_ROUTES.length, 31)
-  assert.equal(OPTIONAL_PREP_LINE_ROUTES.length, 2)
+test('R5 route roster: 30 always + 3 optional = 33, no duplicates, and every entry is a REAL registered route (or the auth status route)', () => {
+  assert.equal(ALWAYS_PREP_LINE_ROUTES.length, 30)
+  assert.equal(OPTIONAL_PREP_LINE_ROUTES.length, 3)
   assert.equal(PREP_LINE_ROUTE_UNIVERSE.size, 33)
   const all = [...ALWAYS_PREP_LINE_ROUTES, ...OPTIONAL_PREP_LINE_ROUTES]
   assert.equal(new Set(all).size, all.length, 'no duplicate route template in the roster')
@@ -504,4 +505,31 @@ test('R5 B4 run: the sentinel-registration callback is REQUIRED — omitting it 
     /registerSentinels/,
   )
   assert.equal(calls.length, 0, 'no request may run without the leak-scan registration contract')
+})
+
+// ── R5 P1 fix: options/sync is a DESTRUCTIVE canonical overwrite and must be opt-in ────────────────
+// The adversarial gate on #4736 found this route full-replaces operator-curated option sets on the
+// canonical table, with no read face to restore from, on a workflow whose default base URL is the
+// shared deployed host. These assertions pin the gating so it cannot silently regress to always-arm.
+test('R5 P1: options/sync is OPTIONAL, never ALWAYS — it must not be armed by default', () => {
+  const route = '/api/integration/stock-preparation/options/sync'
+  assert.ok(!ALWAYS_PREP_LINE_ROUTES.includes(route),
+    'options/sync must NOT be in the unconditional roster: it destroys curated canonical option sets')
+  assert.ok(OPTIONAL_PREP_LINE_ROUTES.includes(route),
+    'options/sync must be declared OPTIONAL so the coverage count stays honest when it is skipped')
+  // Not merely "somewhere in the universe" — the two lists must be disjoint, or membership proves nothing.
+  assert.equal(ALWAYS_PREP_LINE_ROUTES.filter((r) => OPTIONAL_PREP_LINE_ROUTES.includes(r)).length, 0)
+})
+
+test('R5 P1: --allow-canonical-option-overwrite is required, defaults off, and a lookalike cannot arm it', () => {
+  const base = ['node', 'x', '--base-url', 'http://localhost:1']
+  assert.equal(parseArgs(base).allowCanonicalOptionOverwrite, undefined,
+    'absent flag must leave the destructive write disarmed')
+  assert.equal(parseArgs([...base, '--allow-canonical-option-overwrite']).allowCanonicalOptionOverwrite, true)
+  // Negative control. parseArgs is fail-closed on unknown flags, which is STRONGER than silently
+  // ignoring them: a misspelling aborts the run rather than producing a quietly-unarmed one that an
+  // operator would misread as "I passed the flag, so the overwrite happened / did not happen".
+  assert.throws(() => parseArgs([...base, '--allow-canonical-option-overwrites']), /unknown flag/)
+  // A different opt-in flag must not arm this one — proves the flags are not aliased.
+  assert.equal(parseArgs([...base, '--approved-source-config-id', 'cfg']).allowCanonicalOptionOverwrite, undefined)
 })

--- a/scripts/ops/stock-preparation-rca-abort-provenance.mjs
+++ b/scripts/ops/stock-preparation-rca-abort-provenance.mjs
@@ -63,7 +63,7 @@ export const HELPER_BASENAME_ALLOWLIST = Object.freeze([
 // repo-parity test fails loudly otherwise) — R5 (route-coverage 22/33 -> 33/33) re-pinned the
 // extended smoke's digest below; the W6 sibling is untouched by R5 and keeps its prior digest.
 export const HELPER_CONTENT_SHA256 = Object.freeze({
-  'stock-preparation-prep-line-extended-smoke.mjs': 'e6970a867ca9778e986022f16f34c0c1af48ceb0c4d6b8b94bea46e8a50d9317',
+  'stock-preparation-prep-line-extended-smoke.mjs': '8b9ce94fc810fb4627592b4793a4e36cb8e0a2ae95b6f107d18d246a60c845a6',
   'stock-preparation-mvp-postdeploy-smoke.mjs': 'e5265a2a8052ddc34866438a1ee3356b5d2aa1a106c8199f5e2fbbe4f2614df4',
 })
 export const HELPER_SIBLING_REQUIREMENTS = Object.freeze({

--- a/scripts/ops/stock-preparation-rca-abort-provenance.mjs
+++ b/scripts/ops/stock-preparation-rca-abort-provenance.mjs
@@ -57,13 +57,13 @@ export const HELPER_BASENAME_ALLOWLIST = Object.freeze([
 // A basename allowlist alone does not bind the probe to the exact-SHA helper: any file renamed to
 // an allowlisted basename would be dynamically imported and executed. Before ANY import, the
 // target file — and, because the extended smoke statically imports its sanitizing layer from the
-// W6 smoke, that sibling too — must byte-match the release-pinned SHA-256 digests below, computed
-// from the RC-A exact package SHA d87e086fd1218b4cfb150177d43f2c52904b1d6d. Any mismatch blocks
-// the diagnostic (HELPER_MISMATCH) with zero imports and zero network requests. Editing the
-// frozen smoke harnesses requires cutting a new pinned diagnostic release (a repo-parity test
-// fails loudly otherwise).
+// W6 smoke, that sibling too — must byte-match the release-pinned SHA-256 digests below. Any
+// mismatch blocks the diagnostic (HELPER_MISMATCH) with zero imports and zero network requests.
+// Editing the frozen smoke harnesses requires cutting a new pinned diagnostic release (a
+// repo-parity test fails loudly otherwise) — R5 (route-coverage 22/33 -> 33/33) re-pinned the
+// extended smoke's digest below; the W6 sibling is untouched by R5 and keeps its prior digest.
 export const HELPER_CONTENT_SHA256 = Object.freeze({
-  'stock-preparation-prep-line-extended-smoke.mjs': '912f3ef75c4487dbdd946486d4cb7374f1c3ea1eb126c3b68381ad11963f0049',
+  'stock-preparation-prep-line-extended-smoke.mjs': '300e8e6691dc3e1df05bab62844f2794335abe714818c1bff31cd9d9b196ce58',
   'stock-preparation-mvp-postdeploy-smoke.mjs': 'e5265a2a8052ddc34866438a1ee3356b5d2aa1a106c8199f5e2fbbe4f2614df4',
 })
 export const HELPER_SIBLING_REQUIREMENTS = Object.freeze({

--- a/scripts/ops/stock-preparation-rca-abort-provenance.mjs
+++ b/scripts/ops/stock-preparation-rca-abort-provenance.mjs
@@ -63,7 +63,7 @@ export const HELPER_BASENAME_ALLOWLIST = Object.freeze([
 // repo-parity test fails loudly otherwise) — R5 (route-coverage 22/33 -> 33/33) re-pinned the
 // extended smoke's digest below; the W6 sibling is untouched by R5 and keeps its prior digest.
 export const HELPER_CONTENT_SHA256 = Object.freeze({
-  'stock-preparation-prep-line-extended-smoke.mjs': '300e8e6691dc3e1df05bab62844f2794335abe714818c1bff31cd9d9b196ce58',
+  'stock-preparation-prep-line-extended-smoke.mjs': 'e6970a867ca9778e986022f16f34c0c1af48ceb0c4d6b8b94bea46e8a50d9317',
   'stock-preparation-mvp-postdeploy-smoke.mjs': 'e5265a2a8052ddc34866438a1ee3356b5d2aa1a106c8199f5e2fbbe4f2614df4',
 })
 export const HELPER_SIBLING_REQUIREMENTS = Object.freeze({

--- a/scripts/ops/stock-preparation-rca-abort-provenance.mjs
+++ b/scripts/ops/stock-preparation-rca-abort-provenance.mjs
@@ -63,7 +63,7 @@ export const HELPER_BASENAME_ALLOWLIST = Object.freeze([
 // repo-parity test fails loudly otherwise) — R5 (route-coverage 22/33 -> 33/33) re-pinned the
 // extended smoke's digest below; the W6 sibling is untouched by R5 and keeps its prior digest.
 export const HELPER_CONTENT_SHA256 = Object.freeze({
-  'stock-preparation-prep-line-extended-smoke.mjs': '8b9ce94fc810fb4627592b4793a4e36cb8e0a2ae95b6f107d18d246a60c845a6',
+  'stock-preparation-prep-line-extended-smoke.mjs': '96fcf2b4df530ddfeac08b6caed476341d6e6f4779cc3c6de6a92ac47b1097a7',
   'stock-preparation-mvp-postdeploy-smoke.mjs': 'e5265a2a8052ddc34866438a1ee3356b5d2aa1a106c8199f5e2fbbe4f2614df4',
 })
 export const HELPER_SIBLING_REQUIREMENTS = Object.freeze({

--- a/scripts/ops/stock-preparation-rca-window.ps1
+++ b/scripts/ops/stock-preparation-rca-window.ps1
@@ -42,8 +42,10 @@ $script:Pm2EnvironmentAllowlist = @(
   'WINDIR', $script:FlagName
 )
 
+# R5 (route-coverage 22/33 -> 33/33) re-pinned the extended smoke's digest below; the other two
+# frozen helpers are untouched by R5 and keep their prior digests.
 $script:FrozenHelperSha256 = [ordered]@{
-  'stock-preparation-prep-line-extended-smoke.mjs' = '912f3ef75c4487dbdd946486d4cb7374f1c3ea1eb126c3b68381ad11963f0049'
+  'stock-preparation-prep-line-extended-smoke.mjs' = '300e8e6691dc3e1df05bab62844f2794335abe714818c1bff31cd9d9b196ce58'
   'stock-preparation-mvp-postdeploy-smoke.mjs' = 'e5265a2a8052ddc34866438a1ee3356b5d2aa1a106c8199f5e2fbbe4f2614df4'
   'stock-preparation-rca-window-pm2-sample.mjs' = '09cc76024bd98fd4ce86cfa834eea3b94680482d0d0970600da008a19a6731ec'
 }

--- a/scripts/ops/stock-preparation-rca-window.ps1
+++ b/scripts/ops/stock-preparation-rca-window.ps1
@@ -45,7 +45,7 @@ $script:Pm2EnvironmentAllowlist = @(
 # R5 (route-coverage 22/33 -> 33/33) re-pinned the extended smoke's digest below; the other two
 # frozen helpers are untouched by R5 and keep their prior digests.
 $script:FrozenHelperSha256 = [ordered]@{
-  'stock-preparation-prep-line-extended-smoke.mjs' = '300e8e6691dc3e1df05bab62844f2794335abe714818c1bff31cd9d9b196ce58'
+  'stock-preparation-prep-line-extended-smoke.mjs' = 'e6970a867ca9778e986022f16f34c0c1af48ceb0c4d6b8b94bea46e8a50d9317'
   'stock-preparation-mvp-postdeploy-smoke.mjs' = 'e5265a2a8052ddc34866438a1ee3356b5d2aa1a106c8199f5e2fbbe4f2614df4'
   'stock-preparation-rca-window-pm2-sample.mjs' = '09cc76024bd98fd4ce86cfa834eea3b94680482d0d0970600da008a19a6731ec'
 }

--- a/scripts/ops/stock-preparation-rca-window.ps1
+++ b/scripts/ops/stock-preparation-rca-window.ps1
@@ -45,7 +45,7 @@ $script:Pm2EnvironmentAllowlist = @(
 # R5 (route-coverage 22/33 -> 33/33) re-pinned the extended smoke's digest below; the other two
 # frozen helpers are untouched by R5 and keep their prior digests.
 $script:FrozenHelperSha256 = [ordered]@{
-  'stock-preparation-prep-line-extended-smoke.mjs' = 'e6970a867ca9778e986022f16f34c0c1af48ceb0c4d6b8b94bea46e8a50d9317'
+  'stock-preparation-prep-line-extended-smoke.mjs' = '8b9ce94fc810fb4627592b4793a4e36cb8e0a2ae95b6f107d18d246a60c845a6'
   'stock-preparation-mvp-postdeploy-smoke.mjs' = 'e5265a2a8052ddc34866438a1ee3356b5d2aa1a106c8199f5e2fbbe4f2614df4'
   'stock-preparation-rca-window-pm2-sample.mjs' = '09cc76024bd98fd4ce86cfa834eea3b94680482d0d0970600da008a19a6731ec'
 }

--- a/scripts/ops/stock-preparation-rca-window.ps1
+++ b/scripts/ops/stock-preparation-rca-window.ps1
@@ -45,7 +45,7 @@ $script:Pm2EnvironmentAllowlist = @(
 # R5 (route-coverage 22/33 -> 33/33) re-pinned the extended smoke's digest below; the other two
 # frozen helpers are untouched by R5 and keep their prior digests.
 $script:FrozenHelperSha256 = [ordered]@{
-  'stock-preparation-prep-line-extended-smoke.mjs' = '8b9ce94fc810fb4627592b4793a4e36cb8e0a2ae95b6f107d18d246a60c845a6'
+  'stock-preparation-prep-line-extended-smoke.mjs' = '96fcf2b4df530ddfeac08b6caed476341d6e6f4779cc3c6de6a92ac47b1097a7'
   'stock-preparation-mvp-postdeploy-smoke.mjs' = 'e5265a2a8052ddc34866438a1ee3356b5d2aa1a106c8199f5e2fbbe4f2614df4'
   'stock-preparation-rca-window-pm2-sample.mjs' = '09cc76024bd98fd4ce86cfa834eea3b94680482d0d0970600da008a19a6731ec'
 }


### PR DESCRIPTION
## ⛔ HOLD — this one needs an owner decision before it can merge. Not a code problem.

Route coverage is implemented and verified. What blocks it is a **frozen-artifact repackaging question** that
neither this PR nor its brief anticipated.

## What it does

Extends the T4 prep-line extended smoke to cover **10 of the 11** previously-untouched stock-preparation routes,
with non-vacuous assertions throughout.

| | route | assertion |
|---|---|---|
| A1–A2 | `target/readiness`, `sandbox-target/readiness` | 200, **and explicitly `!== 501`** |
| A3–A5 | `snapshot-batches`, `…/:id/diff`, `…/diff/rows` | 200, `!== 501`, non-empty batch set, and `:id` taken from A3's **real** response (never hardcoded) |
| A6–A7 | `material-mappings/summary`, `unit-conversions/summary` | 200, `!== 501`, **baseline-vs-delta** rather than an absolute `>= 1` |
| B1–B2 | `target/ensure`, `sandbox-target/ensure` | success **twice**, second call not in the `*_create` mode tier — a real idempotency proof |
| B3 | `options/sync` (the non-MVP one) | 200 |

`!== 501` is asserted **9** times. Those five routes 501 when the multitable provisioning API is absent, and a
501 that reads as "covered" is the skip-green shape this repo has on record.

**A6/A7 improved on the brief.** It asked for an absolute confirmed-count `>= 1`; both summary tables are
**tenant-level**, so a stale row from a prior run could satisfy that without this run proving anything. The
delivered assertion compares a pre-confirm baseline against the post-confirm read instead. Correct call.

**`target/ensure` does not accept an explicit `baseId`** — the write path forbids it (GHSA-m6qv-2rpf-q7mh
hardening). The brief's hint saying otherwise was stale; this was checked against the route code rather than
followed.

## B4 (`mvp/source-runs/erp-materials`) — wired, never executed. Stated plainly.

The route unconditionally requires an approved `readSourceConfigId` naming a registered external system whose
kind matches the config row's own `requiredKind`. That is the same category of precondition the existing
PLM-BOM prelude already treats as opt-in, and it cannot reuse that config. A symmetric `--approved-erp-source-config-id`
opt-in and prelude were added, correctly branching on the auto-persist arm so the OFF arm never claims the write
path was verified — but **no approved ERP read-source config was available to run it against.** It is covered by
scripted-request unit tests only.

## Coverage numbers — two different denominators, do not conflate them

Both are real; neither substitutes for the other.

| basis | before | after |
|---|---|---|
| **referenced** by the harness | 22 / 33 | **33 / 33** |
| **unconditionally exercised** in a credential-free run | 21 / 33 | **31 / 33** |

The gap is the two opt-in preludes (PLM-BOM, which was *already* opt-in on `main` behind
`--approved-source-config-id`, and the new ERP one). CI has neither credential, so a default run reaches 31.
The counts are derived at runtime from requests actually issued — never a hand-written constant — and
cross-checked against the real registered `ROUTES` table.

One naming caution: the roster's universe of 33 is **32 public routes + `/api/integration/status`**. That is
*not* the same 33 as "33 stock-preparation routes" (which is 32 public + the internal S6-A route). The internal
route is exercised by the E2E functional smoke, not by this harness.

## ⛔ Why this is held: it silences a tripwire instead of answering it

`scripts/ops/stock-preparation-prep-line-extended-smoke.mjs` is a **pinned member of the RC-A operator sidecar**
(`build-stock-preparation-rca-window-sidecar.mjs` `FROZEN_HELPERS`). Its own comment states the rule:

> Editing the frozen smoke harnesses **requires cutting a new pinned diagnostic release** (a repo-parity test
> fails loudly otherwise).

Editing it therefore trips that guard by design. This PR re-pinned the digest in all three frozen helpers so CI
would pass — **but left `FROZEN_RUNTIME_SHA = d87e086f…` untouched**, and that constant is still emitted as
`frozenRuntimeGitCommit` in the sidecar's package provenance. The result is a sidecar whose provenance pairs a
**pre-R5 runtime commit** with a **post-R5 helper digest**. Those two fields previously described one snapshot.
They no longer do.

Re-pinning without cutting a release is answering the alarm by turning it off. That is the owner's call, not
this lane's — and it is coupled to the already-undecided repackaging question on the RC-A line.

**There is no precedent for moving these pins independently — checked, not assumed.** `git log` on
`build-stock-preparation-rca-window-sidecar.mjs` shows exactly **one** commit on `main` touching it: `5d785e399`
(#4665), which *created* the file and set `FROZEN_RUNTIME_SHA` and the helper digests **in the same commit**.
They have not moved since. Every data point in this file's history has the two pins moving together; this PR
would be the first to separate them.

**There is no version of this change that avoids the question.** The E2E functional smoke *spawns* this exact
script to reproduce the existing chain, so prep-line route coverage cannot be added anywhere else and still flow
into the E2E run. Putting it in a second, narrower script instead would be a parallel artifact standing in for
the named one — the pattern this repo requires be escalated rather than chosen unilaterally.

### The fork

1. **Cut a new pinned diagnostic release** — bump `FROZEN_RUNTIME_SHA` alongside the re-pin. The tripwire's intended response. *Recommended.*
2. **Merge the re-pin as-is** — CI green, but ships the false provenance pairing described above. Not recommended.
3. **Leave the frozen smoke byte-identical** and put the coverage in a separate script — a narrower parallel artifact; needs adjudication on its own terms.

## Verification actually performed — and what was not

`node --check` plus `node --test`, **115/115** across the five suites the CI contract job runs.
**Not run against a real container**; B4's path was never executed at all. No `plugins/` or `packages/` file was
touched. No flag default changed, nothing armed, nothing deployed, no external write.

