### PR TITLE
test(sealed-export): run the 074/075 migration gates on PostgreSQL 16 and 17 (R10)

### DIFF
--- a/.github/workflows/sealed-export-s6a-authority-row-lock.yml
+++ b/.github/workflows/sealed-export-s6a-authority-row-lock.yml
@@ -55,12 +55,19 @@ permissions:
 
 jobs:
   authority-row-lock-gate:
-    name: Sealed-export S6-A authority row-lock gate
+    name: Sealed-export S6-A authority row-lock gate (pg${{ matrix.pg }})
+    strategy:
+      fail-fast: false
+      matrix:
+        # 074/075 had ZERO PostgreSQL 17 coverage: the only pg17 lane in the repo validates the
+        # FROZEN package, whose migration tree stops at 073. Column-level GRANT semantics are
+        # exactly the kind of thing that can differ across majors, so the gate must run on both.
+        pg: ['16', '17']
     runs-on: ubuntu-latest
     timeout-minutes: 20
     services:
       postgres:
-        image: postgres:16
+        image: postgres:${{ matrix.pg }}
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres

--- a/.github/workflows/sealed-export-s6a-grant-repair.yml
+++ b/.github/workflows/sealed-export-s6a-grant-repair.yml
@@ -35,12 +35,19 @@ permissions:
 
 jobs:
   grant-repair-gate:
-    name: Sealed-export S6-A grant repair gate
+    name: Sealed-export S6-A grant repair gate (pg${{ matrix.pg }})
+    strategy:
+      fail-fast: false
+      matrix:
+        # 074/075 had ZERO PostgreSQL 17 coverage: the only pg17 lane in the repo validates the
+        # FROZEN package, whose migration tree stops at 073. Column-level GRANT semantics are
+        # exactly the kind of thing that can differ across majors, so the gate must run on both.
+        pg: ['16', '17']
     runs-on: ubuntu-latest
     timeout-minutes: 15
     services:
       postgres:
-        image: postgres:16
+        image: postgres:${{ matrix.pg }}
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres


### PR DESCRIPTION
Migrations **074** and **075** are the two that unblocked the S6-A walk, and **neither has ever run against PostgreSQL 17**.

The repo's only pg17 lane (`stock-prep-s6a-postgres17-validation.yml`) validates the **frozen package**, whose migration tree stops at **073** — and it is fail-closed on that package's SHA-256, so 074/075 cannot be added there even in principle.

Both migrations grant **column-level** privileges (`GRANT UPDATE (updated_at)`), and both gates assert **exact** refusal codes (`42501` vs `42P01` vs `42703`) rather than merely "it failed". Column-privilege semantics and error-code surfaces are exactly the kind of thing that can differ across a major version. A gate that only ever ran on 16 is not evidence for 17.

Change: `pg: ['16','17']` matrix with `fail-fast: false`, service image parameterised. The arms, probes and assertions are untouched.

**Checked before renaming the jobs** (the matrix suffix changes the check-run name):
- neither job name is in `main`'s required status checks;
- the only repo references to these names are **three comments**, all pointing at the `.db.test.ts` file rather than the workflow;
- both workflows already list themselves in their own `paths:` filter, so editing the workflow triggers it rather than skipping green.

⚠️ **A green badge on this PR would only mean the gate ran — not that 17 behaves like 16.** The evidence has to come from the dispatched runs, reported below once they finish.

No flag default changed, nothing armed, nothing deployed, no external write, no frozen input touched.