### PR TITLE
feat(stock-prep): S6-A operator preflight — turn seven opaque failures into named ones, offline (R11)

### DIFF
--- a/.github/workflows/stock-preparation-s6a-operator-preflight.yml
+++ b/.github/workflows/stock-preparation-s6a-operator-preflight.yml
@@ -1,0 +1,53 @@
+name: Stock Preparation S6-A Operator Preflight
+
+# Hermetic contract test for the S6-A operator preflight tool (offline,
+# values-free). The runbook (docs/operations/stock-preparation-s6a-sqlserver
+# -onprem-runbook-20260731.md §4) tells the operator to create five private
+# artifacts and gives zero commands; at least seven distinct mistakes all
+# collapse into the same opaque SEALED_EXPORT_INTERNAL_ERROR token, previously
+# discoverable only inside the one non-repeatable flag-on window. This tool
+# calls the product's own exported, pure (env + files, no DB, no network)
+# validators and bisects the inputs for specificity — it never re-implements
+# a validation rule. No database, no network: the test writes only synthetic,
+# self-generated key material and specs under os.tmpdir().
+#
+# Follows the same shape as the `contract` job in
+# gip-authority-substrate-inventory.yml / data-source-exposure-inventory.yml:
+# checkout + setup-node only, `node --test` directly.
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/stock-preparation-s6a-operator-preflight.yml'
+      - 'scripts/ops/stock-preparation-s6a-operator-preflight.mjs'
+      - 'scripts/ops/stock-preparation-s6a-operator-preflight.test.mjs'
+      - 'plugins/plugin-integration-core/lib/sealed-export/stock-preparation-runtime-config.cjs'
+      - 'plugins/plugin-integration-core/lib/sealed-export/stock-preparation-sqlserver-source-authority.cjs'
+      - 'plugins/plugin-integration-core/lib/sealed-export/stock-preparation-runtime-store.cjs'
+      - 'plugins/plugin-integration-core/lib/sealed-export/failure-vocabulary.cjs'
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/stock-preparation-s6a-operator-preflight.yml'
+      - 'scripts/ops/stock-preparation-s6a-operator-preflight.mjs'
+      - 'scripts/ops/stock-preparation-s6a-operator-preflight.test.mjs'
+      - 'plugins/plugin-integration-core/lib/sealed-export/stock-preparation-runtime-config.cjs'
+      - 'plugins/plugin-integration-core/lib/sealed-export/stock-preparation-sqlserver-source-authority.cjs'
+      - 'plugins/plugin-integration-core/lib/sealed-export/stock-preparation-runtime-store.cjs'
+      - 'plugins/plugin-integration-core/lib/sealed-export/failure-vocabulary.cjs'
+
+permissions:
+  contents: read
+
+jobs:
+  contract:
+    name: S6-A operator preflight contract (values-free, no DB, no network)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Run hermetic preflight tests (synthetic material only, no DB, no network)
+        run: node --test scripts/ops/stock-preparation-s6a-operator-preflight.test.mjs

--- a/scripts/ops/stock-preparation-s6a-operator-preflight.mjs
+++ b/scripts/ops/stock-preparation-s6a-operator-preflight.mjs
@@ -1,0 +1,650 @@
+#!/usr/bin/env node
+'use strict'
+
+// Stock Preparation S6-A operator preflight (offline, values-free).
+//
+// WHY THIS EXISTS
+// ----------------
+// docs/operations/stock-preparation-s6a-sqlserver-onprem-runbook-20260731.md §4
+// tells the operator to create five private artifacts (identity key, evidence
+// key, qualification key, Ed25519 PKCS8 signer key, provisioning spec) and
+// gives zero commands. At least seven distinct operator mistakes (missing
+// file, wrong key length, wrong PEM type, non-absolute artifact root, missing
+// env var, non-null workspaceId, mismatched external-system identity) all
+// collapse into the single opaque `SEALED_EXPORT_INTERNAL_ERROR` token, and
+// were previously discoverable only inside the one non-repeatable flag-on
+// window (§6).
+//
+// This tool does NOT re-implement any product validation rule. Every PASS/FAIL
+// verdict below is produced by calling the product's own exported, pure
+// (env + files, no DB, no network) validators:
+//
+//   plugins/plugin-integration-core/lib/sealed-export/stock-preparation-runtime-config.cjs
+//     -> loadStockPreparationProvisioningConfig({ env })
+//     -> loadStockPreparationRuntimeConfig({ env })
+//     -> ENV (the env-var name table), FEATURE_FLAG
+//
+//   plugins/plugin-integration-core/lib/sealed-export/stock-preparation-sqlserver-source-authority.cjs
+//     -> deriveStockPreparationSqlServerSourceAnchors({ binding, externalSystem, identityKey })
+//        (used only for the SPEC_EXTERNAL_SYSTEM_CONSISTENCY check below)
+//
+// HOW SPECIFICITY IS OBTAINED
+// ---------------------------
+// Both config loaders throw the exact same token for every distinct failure,
+// by design (see failure-vocabulary.cjs). To get specificity without
+// re-deriving the accept/reject decision, each env-var-scoped check performs
+// an ISOLATED SWAP: build a synthetic, self-generated "known-good" baseline
+// environment (fresh random keys, a fresh Ed25519 keypair, a synthetic
+// provisioning spec — never the operator's real secrets), then substitute
+// ONLY the operator's real value for the one input under test and call the
+// real loader. The loader's own verdict (PASS/FAIL) is always authoritative;
+// a lightweight, read-only, non-secret-revealing diagnostic (file exists?,
+// byte length in range?, PEM parses as Ed25519?, path absolute?, spec JSON
+// valid?, workspaceId literally null?) is used ONLY to choose a closed-set
+// REASON label to attach to an already-determined FAIL — a label can never
+// turn a FAIL into a PASS. Every one of those diagnostics either restates a
+// fact from the runbook itself (32-128 bytes; Ed25519 PKCS8; absolute path;
+// workspaceId must be JSON null) or is a generic OS/JSON primitive; none of
+// them re-derive the product's own closed-key-set spec-shape rule, which is
+// intentionally left to the generic VALIDATOR_REJECTED fallback.
+//
+// SPEC_EXTERNAL_SYSTEM_CONSISTENCY reads the operator's REAL provisioning
+// spec file to check that binding.externalSystemId/tenantId/workspaceId agree
+// with externalSystem.id/tenantId/workspaceId/kind/role/status (the "mismatched
+// external-system identity" mistake class) via the product's own
+// deriveStockPreparationSqlServerSourceAnchors. It NEVER reads
+// externalSystem.config/credentials from the real file (those carry the SQL
+// Server host/user/password) — a fixed, synthetic, structurally-valid
+// placeholder is spliced in instead, so this check cannot be tripped by (or
+// leak) real connection material. It cannot verify that the declared
+// external-system record matches whatever is approved server-side in the
+// database — that comparison happens only during the live, DB-connected
+// provisioning run and is out of reach for an offline tool (see NOT_RUN
+// handling below).
+//
+// Hard rules honoured throughout: read-only w.r.t. plugins/packages; no DB;
+// no network; never print a secret, file content, connection string,
+// credential, or a path that could contain one — only fixed env-var NAMES
+// (which are public, non-secret, and already named in the runbook) and
+// closed-set reason tokens are ever written to stdout.
+
+import crypto from 'node:crypto'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { createRequire } from 'node:module'
+import { fileURLToPath } from 'node:url'
+
+const require = createRequire(import.meta.url)
+const REPO_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '..',
+  '..',
+)
+
+const RUNTIME_CONFIG_MODULE_PATH = path.join(
+  REPO_ROOT,
+  'plugins/plugin-integration-core/lib/sealed-export/stock-preparation-runtime-config.cjs',
+)
+const SOURCE_AUTHORITY_MODULE_PATH = path.join(
+  REPO_ROOT,
+  'plugins/plugin-integration-core/lib/sealed-export/stock-preparation-sqlserver-source-authority.cjs',
+)
+const RUNTIME_STORE_MODULE_PATH = path.join(
+  REPO_ROOT,
+  'plugins/plugin-integration-core/lib/sealed-export/stock-preparation-runtime-store.cjs',
+)
+const FAILURE_VOCABULARY_MODULE_PATH = path.join(
+  REPO_ROOT,
+  'plugins/plugin-integration-core/lib/sealed-export/failure-vocabulary.cjs',
+)
+
+const {
+  ENV,
+  FEATURE_FLAG,
+  loadStockPreparationProvisioningConfig,
+  loadStockPreparationRuntimeConfig,
+} = require(RUNTIME_CONFIG_MODULE_PATH)
+
+const {
+  BINDING_DRAFT_FIELDS,
+  CANONICAL_OBJECT_VERSION,
+  CONNECTOR_KIND,
+  deriveStockPreparationSqlServerSourceAnchors,
+} = require(SOURCE_AUTHORITY_MODULE_PATH)
+
+const { OBJECT_KEY, RELATION_ID } = require(RUNTIME_STORE_MODULE_PATH)
+
+const { isTrustedSealedExportError } = require(FAILURE_VOCABULARY_MODULE_PATH)
+
+// ---------------------------------------------------------------------------
+// Closed-set reason tokens this tool ever emits, beyond a first-party
+// SEALED_EXPORT_* token surfaced verbatim from a trusted product error.
+// ---------------------------------------------------------------------------
+const REASON = Object.freeze({
+  BASELINE_UNAVAILABLE: 'BASELINE_UNAVAILABLE',
+  CHECK_PASSED: 'CHECK_PASSED',
+  ENV_VAR_UNSET: 'ENV_VAR_UNSET',
+  FILE_NOT_FOUND: 'FILE_NOT_FOUND',
+  JSON_INVALID: 'JSON_INVALID',
+  KEY_LENGTH_OUT_OF_RANGE: 'KEY_LENGTH_OUT_OF_RANGE',
+  PATH_NOT_ABSOLUTE: 'PATH_NOT_ABSOLUTE',
+  PEM_PARSE_FAILED: 'PEM_PARSE_FAILED',
+  PEM_WRONG_KEY_TYPE: 'PEM_WRONG_KEY_TYPE',
+  PREREQUISITE_CHECK_FAILED: 'PREREQUISITE_CHECK_FAILED',
+  SPEC_WORKSPACE_ID_NOT_NULL: 'SPEC_WORKSPACE_ID_NOT_NULL',
+  VALIDATOR_REJECTED: 'VALIDATOR_REJECTED',
+})
+
+const SYNTHETIC_SOURCE_CONFIG = Object.freeze({
+  sealedSnapshotSqlServer: Object.freeze({
+    database: 'preflight-synthetic-database',
+    encrypt: true,
+    instanceName: null,
+    port: 1433,
+    server: 'preflight-synthetic-server',
+    trustServerCertificate: false,
+  }),
+})
+const SYNTHETIC_SOURCE_CREDENTIALS = Object.freeze({
+  sealedSnapshotSqlServer: Object.freeze({
+    password: 'preflight-synthetic-password',
+    user: 'preflight-synthetic-user',
+  }),
+})
+
+function notRun(id, envVar, reason) {
+  return Object.freeze({ id, envVar, reason, status: 'NOT_RUN' })
+}
+
+function passed(id, envVar) {
+  return Object.freeze({ id, envVar, reason: REASON.CHECK_PASSED, status: 'PASS' })
+}
+
+function failed(id, envVar, reason) {
+  return Object.freeze({ id, envVar, reason, status: 'FAIL' })
+}
+
+function reasonFromError(error, fallback = REASON.VALIDATOR_REJECTED) {
+  return isTrustedSealedExportError(error) && typeof error.reason === 'string'
+    ? error.reason
+    : fallback
+}
+
+// ---------------------------------------------------------------------------
+// Read-only, non-secret-revealing diagnostics. Each returns a label or null.
+// A label is NEVER used to decide PASS — only to explain an already-thrown
+// FAIL from the real loader. See the module header for the provenance of
+// each rule (runbook text vs. generic OS/JSON primitive).
+// ---------------------------------------------------------------------------
+function statOrNull(filePath) {
+  try {
+    return fs.statSync(filePath)
+  } catch {
+    return null
+  }
+}
+
+function diagnoseSymmetricKeyFile(filePath) {
+  const stat = statOrNull(filePath)
+  if (!stat || !stat.isFile()) return REASON.FILE_NOT_FOUND
+  if (stat.size < 32 || stat.size > 128) return REASON.KEY_LENGTH_OUT_OF_RANGE
+  return null
+}
+
+function diagnoseSignerPemFile(filePath) {
+  const stat = statOrNull(filePath)
+  if (!stat || !stat.isFile() || stat.size < 1) return REASON.FILE_NOT_FOUND
+  if (stat.size > 16 * 1024) return null
+  let privateKey
+  try {
+    privateKey = crypto.createPrivateKey(fs.readFileSync(filePath))
+  } catch {
+    return REASON.PEM_PARSE_FAILED
+  }
+  if (privateKey.type !== 'private' || privateKey.asymmetricKeyType !== 'ed25519') {
+    return REASON.PEM_WRONG_KEY_TYPE
+  }
+  return null
+}
+
+function diagnoseProvisioningSpecFile(filePath) {
+  const stat = statOrNull(filePath)
+  if (!stat || !stat.isFile() || stat.size < 1) return REASON.FILE_NOT_FOUND
+  if (stat.size > 64 * 1024) return null
+  let parsed
+  try {
+    parsed = JSON.parse(fs.readFileSync(filePath, 'utf8'))
+  } catch {
+    return REASON.JSON_INVALID
+  }
+  if (
+    parsed
+    && typeof parsed === 'object'
+    && parsed.binding
+    && typeof parsed.binding === 'object'
+    && parsed.externalSystem
+    && typeof parsed.externalSystem === 'object'
+    && (parsed.binding.workspaceId !== null || parsed.externalSystem.workspaceId !== null)
+  ) {
+    return REASON.SPEC_WORKSPACE_ID_NOT_NULL
+  }
+  return null
+}
+
+function diagnoseArtifactRoot(value) {
+  if (!path.isAbsolute(value)) return REASON.PATH_NOT_ABSOLUTE
+  return null
+}
+
+// ---------------------------------------------------------------------------
+// Synthetic ("known-good") baseline material. Self-generated, in-memory or in
+// a throwaway temp directory — never the operator's real secrets.
+// ---------------------------------------------------------------------------
+function buildBaselineMaterial(tmpRoot) {
+  const tempDir = fs.mkdtempSync(path.join(tmpRoot, 'ms-s6a-preflight-'))
+  const identityKeyPath = path.join(tempDir, 'identity.key')
+  const evidenceKeyPath = path.join(tempDir, 'evidence.key')
+  const qualificationKeyPath = path.join(tempDir, 'qualification.key')
+  const signerPemPath = path.join(tempDir, 'signer.pem')
+  const specPath = path.join(tempDir, 'provisioning-spec.json')
+
+  fs.writeFileSync(identityKeyPath, crypto.randomBytes(64))
+  fs.writeFileSync(evidenceKeyPath, crypto.randomBytes(64))
+  fs.writeFileSync(qualificationKeyPath, crypto.randomBytes(64))
+
+  const { privateKey } = crypto.generateKeyPairSync('ed25519')
+  fs.writeFileSync(signerPemPath, privateKey.export({ format: 'pem', type: 'pkcs8' }))
+
+  const nowPlusHour = new Date(Date.now() + 60 * 60 * 1000).toISOString()
+  const spec = {
+    binding: {
+      approvedConfigVersionId: 'preflight-synthetic-config-version',
+      bindingExpiresAt: nowPlusHour,
+      bindingId: 'preflight-synthetic-binding-id',
+      bindingVersion: 'preflight-synthetic-binding-version',
+      externalSystemId: 'preflight-synthetic-external-system-id',
+      signerExpiresAt: nowPlusHour,
+      tableRef: 'dbo.PreflightSyntheticTable',
+      tenantId: 'preflight-synthetic-tenant',
+      workspaceId: null,
+    },
+    externalSystem: {
+      config: {},
+      credentials: {},
+      id: 'preflight-synthetic-external-system-id',
+      kind: 'preflight-synthetic-kind',
+      role: 'preflight-synthetic-role',
+      status: 'preflight-synthetic-status',
+      tenantId: 'preflight-synthetic-tenant',
+      workspaceId: null,
+    },
+  }
+  fs.writeFileSync(specPath, JSON.stringify(spec))
+
+  return Object.freeze({
+    evidenceKeyPath,
+    identityKeyPath,
+    qualificationKeyPath,
+    signerPemPath,
+    specPath,
+    tempDir,
+  })
+}
+
+function buildBaselineEnvs(material) {
+  const provisioning = {
+    [ENV.artifactRoot]: material.tempDir,
+    [ENV.identityKeyFile]: material.identityKeyPath,
+    [ENV.provisioningDatabaseRole]: 'preflight_synthetic_provisioning_role',
+    [ENV.provisioningDatabaseUrl]: 'postgres://preflight:synthetic@127.0.0.1:5432/preflight_synthetic',
+    [ENV.provisioningSpecFile]: material.specPath,
+    [ENV.qualificationKeyFile]: material.qualificationKeyPath,
+    [ENV.qualificationKeyId]: 'preflight-synthetic-key-id',
+    [ENV.signerPrivateKeyFile]: material.signerPemPath,
+  }
+  const runtime = {
+    [ENV.artifactRoot]: material.tempDir,
+    [ENV.evidenceKeyFile]: material.evidenceKeyPath,
+    [ENV.identityKeyFile]: material.identityKeyPath,
+    [ENV.qualificationKeyFile]: material.qualificationKeyPath,
+    [ENV.qualificationKeyId]: 'preflight-synthetic-key-id',
+    [ENV.runtimeDatabaseRole]: 'preflight_synthetic_runtime_role',
+    [ENV.runtimeDatabaseUrl]: 'postgres://preflight:synthetic@127.0.0.1:5432/preflight_synthetic_runtime',
+    [ENV.signerPrivateKeyFile]: material.signerPemPath,
+    [FEATURE_FLAG]: 'true',
+  }
+  return { provisioning, runtime }
+}
+
+// ---------------------------------------------------------------------------
+// One isolated-swap check: substitute the operator's real value for ONE env
+// var into an otherwise-synthetic-good environment, then call the real
+// loader. The loader's throw/no-throw is authoritative for PASS/FAIL.
+// ---------------------------------------------------------------------------
+function isolatedFieldCheck({ id, envVarName, baselineEnv, loaderFn, diagnose, realEnv }) {
+  const realValue = realEnv[envVarName]
+  const unset = realValue === undefined || realValue === ''
+  const label = unset ? REASON.ENV_VAR_UNSET : diagnose ? diagnose(realValue) : null
+
+  const candidateEnv = { ...baselineEnv }
+  if (unset) {
+    delete candidateEnv[envVarName]
+  } else {
+    candidateEnv[envVarName] = realValue
+  }
+
+  try {
+    loaderFn({ env: candidateEnv })
+    return passed(id, envVarName)
+  } catch (error) {
+    return failed(id, envVarName, label || reasonFromError(error))
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Whole-env aggregate checks — run the real loaders against the REAL,
+// unmodified environment. These do not depend on synthetic baseline material
+// at all, so they remain informative even when baseline construction fails.
+// ---------------------------------------------------------------------------
+function aggregateCheck(id, envVarLabel, run) {
+  try {
+    run()
+    return passed(id, envVarLabel)
+  } catch (error) {
+    return failed(id, envVarLabel, reasonFromError(error))
+  }
+}
+
+// ---------------------------------------------------------------------------
+// SPEC_EXTERNAL_SYSTEM_CONSISTENCY — mistake class "mismatched external-
+// system identity". Reads the REAL provisioning spec file's binding +
+// externalSystem IDENTITY fields only; config/credentials are never read from
+// it (a fixed synthetic placeholder is spliced in instead).
+// ---------------------------------------------------------------------------
+function buildDraftFromRawBinding(rawBinding) {
+  // Mirrors plugins/plugin-integration-core/scripts/provision-stock-preparation-
+  // sqlserver-sealed-snapshot.cjs's caller, stock-preparation-runtime-provisioning
+  // .cjs:60-71 exactly (same field mapping, same constants). Pinned by a test that
+  // asserts this key set equals the product's own exported BINDING_DRAFT_FIELDS.
+  return Object.freeze({
+    approvedConfigVersionId: rawBinding.approvedConfigVersionId,
+    bindingVersion: rawBinding.bindingVersion,
+    canonicalObjectVersion: CANONICAL_OBJECT_VERSION,
+    externalSystemId: rawBinding.externalSystemId,
+    objectKey: OBJECT_KEY,
+    relationId: RELATION_ID,
+    tableRef: rawBinding.tableRef,
+    tenantId: rawBinding.tenantId,
+    workspaceId: rawBinding.workspaceId,
+  })
+}
+
+function specExternalSystemConsistencyCheck(realEnv) {
+  const id = 'SPEC_EXTERNAL_SYSTEM_CONSISTENCY'
+  const envVarName = ENV.provisioningSpecFile
+  const specPath = realEnv[envVarName]
+  if (!specPath) return notRun(id, envVarName, REASON.PREREQUISITE_CHECK_FAILED)
+
+  const stat = statOrNull(specPath)
+  if (!stat || !stat.isFile() || stat.size < 1 || stat.size > 64 * 1024) {
+    return notRun(id, envVarName, REASON.PREREQUISITE_CHECK_FAILED)
+  }
+
+  let parsed
+  try {
+    parsed = JSON.parse(fs.readFileSync(specPath, 'utf8'))
+  } catch {
+    return notRun(id, envVarName, REASON.PREREQUISITE_CHECK_FAILED)
+  }
+
+  if (
+    !parsed
+    || typeof parsed !== 'object'
+    || !parsed.binding
+    || typeof parsed.binding !== 'object'
+    || !parsed.externalSystem
+    || typeof parsed.externalSystem !== 'object'
+  ) {
+    return notRun(id, envVarName, REASON.PREREQUISITE_CHECK_FAILED)
+  }
+
+  const draft = buildDraftFromRawBinding(parsed.binding)
+  // IDENTITY fields only. config/credentials — which carry the real SQL
+  // Server host/user/password — are intentionally never read off `parsed`.
+  const splicedExternalSystem = Object.freeze({
+    config: SYNTHETIC_SOURCE_CONFIG,
+    credentials: SYNTHETIC_SOURCE_CREDENTIALS,
+    id: parsed.externalSystem.id,
+    kind: parsed.externalSystem.kind,
+    role: parsed.externalSystem.role,
+    status: parsed.externalSystem.status,
+    tenantId: parsed.externalSystem.tenantId,
+    workspaceId: parsed.externalSystem.workspaceId,
+  })
+  parsed = null // drop the reference to the real, credential-bearing parse tree
+
+  const identityKey = crypto.randomBytes(32)
+  try {
+    // The return value carries the spliced (synthetic) connectionConfig only,
+    // never real credentials — but it is still discarded unread on principle.
+    deriveStockPreparationSqlServerSourceAnchors({
+      binding: draft,
+      externalSystem: splicedExternalSystem,
+      identityKey,
+    })
+    return passed(id, envVarName)
+  } catch (error) {
+    return failed(id, envVarName, reasonFromError(error))
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Top-level orchestration.
+// ---------------------------------------------------------------------------
+function runPreflight({ env = process.env, tmpRoot = os.tmpdir() } = {}) {
+  const checks = []
+  let material = null
+  let baselineEnvs = null
+  let baselineError = null
+
+  try {
+    material = buildBaselineMaterial(tmpRoot)
+    baselineEnvs = buildBaselineEnvs(material)
+    // Positive control: the synthetic baseline itself must satisfy the real
+    // loaders before any isolated-swap result can be trusted.
+    loadStockPreparationProvisioningConfig({ env: baselineEnvs.provisioning })
+    loadStockPreparationRuntimeConfig({ env: baselineEnvs.runtime })
+  } catch (error) {
+    baselineError = error
+    baselineEnvs = null
+  }
+
+  const provisioningFieldChecks = [
+    { diagnose: diagnoseArtifactRoot, envVarName: ENV.artifactRoot, id: 'ARTIFACT_ROOT' },
+    { diagnose: diagnoseSymmetricKeyFile, envVarName: ENV.identityKeyFile, id: 'IDENTITY_KEY_FILE' },
+    { diagnose: diagnoseSignerPemFile, envVarName: ENV.signerPrivateKeyFile, id: 'SIGNER_PRIVATE_KEY_FILE' },
+    { diagnose: null, envVarName: ENV.qualificationKeyId, id: 'QUALIFICATION_KEY_ID' },
+    { diagnose: diagnoseSymmetricKeyFile, envVarName: ENV.qualificationKeyFile, id: 'QUALIFICATION_KEY_FILE' },
+    { diagnose: null, envVarName: ENV.provisioningDatabaseRole, id: 'PROVISIONING_DATABASE_ROLE' },
+    { diagnose: null, envVarName: ENV.provisioningDatabaseUrl, id: 'PROVISIONING_DATABASE_URL' },
+    { diagnose: diagnoseProvisioningSpecFile, envVarName: ENV.provisioningSpecFile, id: 'PROVISIONING_SPEC_FILE' },
+  ]
+  for (const spec of provisioningFieldChecks) {
+    if (!baselineEnvs) {
+      checks.push(notRun(spec.id, spec.envVarName, REASON.BASELINE_UNAVAILABLE))
+      continue
+    }
+    checks.push(
+      isolatedFieldCheck({
+        baselineEnv: baselineEnvs.provisioning,
+        diagnose: spec.diagnose,
+        envVarName: spec.envVarName,
+        id: spec.id,
+        loaderFn: loadStockPreparationProvisioningConfig,
+        realEnv: env,
+      }),
+    )
+  }
+
+  const runtimeFieldChecks = [
+    { diagnose: diagnoseSymmetricKeyFile, envVarName: ENV.evidenceKeyFile, id: 'EVIDENCE_KEY_FILE' },
+    { diagnose: null, envVarName: ENV.runtimeDatabaseRole, id: 'RUNTIME_DATABASE_ROLE' },
+    { diagnose: null, envVarName: ENV.runtimeDatabaseUrl, id: 'RUNTIME_DATABASE_URL' },
+  ]
+  for (const spec of runtimeFieldChecks) {
+    if (!baselineEnvs) {
+      checks.push(notRun(spec.id, spec.envVarName, REASON.BASELINE_UNAVAILABLE))
+      continue
+    }
+    checks.push(
+      isolatedFieldCheck({
+        baselineEnv: baselineEnvs.runtime,
+        diagnose: spec.diagnose,
+        envVarName: spec.envVarName,
+        id: spec.id,
+        loaderFn: loadStockPreparationRuntimeConfig,
+        realEnv: env,
+      }),
+    )
+  }
+
+  checks.push(specExternalSystemConsistencyCheck(env))
+
+  checks.push(
+    aggregateCheck('AGGREGATE_PROVISIONING_CONFIG', 'AGGREGATE', () => {
+      loadStockPreparationProvisioningConfig({ env })
+    }),
+  )
+  checks.push(
+    aggregateCheck('AGGREGATE_RUNTIME_CONFIG', 'AGGREGATE', () => {
+      loadStockPreparationRuntimeConfig({ env: { ...env, [FEATURE_FLAG]: 'true' } })
+    }),
+  )
+
+  if (material) {
+    try {
+      fs.rmSync(material.tempDir, { force: true, recursive: true })
+    } catch {
+      // best-effort cleanup of our own throwaway synthetic material
+    }
+  }
+
+  const preflightPass = checks.every((check) => check.status === 'PASS') ? 'PASS' : 'FAIL'
+  const exitCode = preflightPass === 'PASS' ? 0 : 1
+  return Object.freeze({
+    baselineAvailable: Boolean(baselineEnvs),
+    baselineErrorSeen: Boolean(baselineError),
+    checks: Object.freeze(checks),
+    exitCode,
+    preflightPass,
+  })
+}
+
+function formatReport(result) {
+  const lines = result.checks.map(
+    (check) => `${check.id}: status=${check.status} envVar=${check.envVar} reason=${check.reason}`,
+  )
+  lines.push(`preflightPass=${result.preflightPass}`)
+  return lines.join('\n')
+}
+
+function buildArtifactGuidance() {
+  const specTemplate = {
+    binding: {
+      approvedConfigVersionId: '<FILL_IN>',
+      bindingExpiresAt: '<FILL_IN ISO-8601 timestamp>',
+      bindingId: '<FILL_IN>',
+      bindingVersion: '<FILL_IN>',
+      externalSystemId: '<FILL_IN — must equal externalSystem.id below>',
+      signerExpiresAt: '<FILL_IN ISO-8601 timestamp>',
+      tableRef: '<FILL_IN>',
+      tenantId: '<FILL_IN — must equal externalSystem.tenantId below>',
+      workspaceId: null,
+    },
+    externalSystem: {
+      config: {
+        sealedSnapshotSqlServer: {
+          database: '<FILL_IN>',
+          encrypt: true,
+          instanceName: null,
+          port: 1433,
+          server: '<FILL_IN>',
+          trustServerCertificate: false,
+        },
+      },
+      credentials: {
+        sealedSnapshotSqlServer: {
+          password: '<FILL_IN — dedicated SELECT-only login, never the DBA/setup credential>',
+          user: '<FILL_IN>',
+        },
+      },
+      id: '<FILL_IN — must equal binding.externalSystemId above>',
+      kind: CONNECTOR_KIND,
+      role: 'source',
+      status: 'active',
+      tenantId: '<FILL_IN — must equal binding.tenantId above>',
+      workspaceId: null,
+    },
+  }
+
+  return [
+    '=== S6-A private artifact creation commands (runbook §4) ===',
+    'Values-free placeholders only. Pick absolute paths OUTSIDE the repo/package,',
+    'restrict ACL to the service/provisioning identities, and never print their contents.',
+    '',
+    '1) identity key (32-128 random bytes):',
+    '   openssl rand -out /absolute/path/identity.key 64',
+    '',
+    '2) evidence key (32-128 random bytes):',
+    '   openssl rand -out /absolute/path/evidence.key 64',
+    '',
+    '3) qualification key (32-128 random bytes):',
+    '   openssl rand -out /absolute/path/qualification.key 64',
+    '',
+    '4) signer key (Ed25519 PKCS8 private PEM):',
+    '   openssl genpkey -algorithm ed25519 -out /absolute/path/signer.pem',
+    '   # Cross-platform alternative if openssl is unavailable (e.g. Windows):',
+    "   node -e \"const {privateKey}=require('crypto').generateKeyPairSync('ed25519');process.stdout.write(privateKey.export({type:'pkcs8',format:'pem'}))\" > /absolute/path/signer.pem",
+    '   # `ssh-keygen -t ed25519` produces an OpenSSH-format key, NOT PKCS8 — it',
+    "   # will fail this runtime's PEM check. Do not use ssh-keygen for this artifact.",
+    '',
+    '5) provisioning spec (strict JSON; both workspaceId fields MUST be JSON null):',
+    '   Save as UTF-8 JSON at the path named by',
+    '   ' + ENV.provisioningSpecFile + ':',
+    JSON.stringify(specTemplate, null, 2),
+  ].join('\n')
+}
+
+const isMain = (() => {
+  try {
+    return path.resolve(process.argv[1] || '') === fileURLToPath(import.meta.url)
+  } catch {
+    return false
+  }
+})()
+
+function main() {
+  const result = runPreflight({ env: process.env })
+  process.stdout.write(formatReport(result))
+  process.stdout.write('\n\n')
+  process.stdout.write(buildArtifactGuidance())
+  process.stdout.write('\n')
+  process.exitCode = result.exitCode
+}
+
+if (isMain) {
+  main()
+}
+
+export {
+  REASON,
+  buildArtifactGuidance,
+  buildDraftFromRawBinding,
+  diagnoseArtifactRoot,
+  diagnoseProvisioningSpecFile,
+  diagnoseSignerPemFile,
+  diagnoseSymmetricKeyFile,
+  formatReport,
+  runPreflight,
+}

--- a/scripts/ops/stock-preparation-s6a-operator-preflight.test.mjs
+++ b/scripts/ops/stock-preparation-s6a-operator-preflight.test.mjs
@@ -1,0 +1,610 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { execFileSync } from 'node:child_process'
+import crypto from 'node:crypto'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { createRequire } from 'node:module'
+import { fileURLToPath } from 'node:url'
+
+// Contract test for the S6-A operator preflight tool (offline, values-free).
+// Covers docs/operations/stock-preparation-s6a-sqlserver-onprem-runbook-20260731.md
+// §4's five private artifacts and the seven distinct operator mistakes that all
+// collapsed into the single opaque SEALED_EXPORT_INTERNAL_ERROR token. No server,
+// no database, no network — every scenario below only writes throwaway synthetic
+// material under os.tmpdir().
+
+import {
+  REASON,
+  buildDraftFromRawBinding,
+  runPreflight,
+} from './stock-preparation-s6a-operator-preflight.mjs'
+
+const require = createRequire(import.meta.url)
+const SCRIPT_PATH = fileURLToPath(new URL('./stock-preparation-s6a-operator-preflight.mjs', import.meta.url))
+const REPO_ROOT = path.resolve(path.dirname(SCRIPT_PATH), '..', '..')
+
+const { ENV, FEATURE_FLAG } = require(
+  path.join(REPO_ROOT, 'plugins/plugin-integration-core/lib/sealed-export/stock-preparation-runtime-config.cjs'),
+)
+const { BINDING_DRAFT_FIELDS } = require(
+  path.join(REPO_ROOT, 'plugins/plugin-integration-core/lib/sealed-export/stock-preparation-sqlserver-source-authority.cjs'),
+)
+
+// ---------------------------------------------------------------------------
+// Fixture builder — a fully-valid operator environment, all synthetic.
+// ---------------------------------------------------------------------------
+function buildGoodOperatorMaterial(overrides = {}) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ms-s6a-preflight-test-'))
+  const identityKeyPath = path.join(dir, 'identity.key')
+  const evidenceKeyPath = path.join(dir, 'evidence.key')
+  const qualificationKeyPath = path.join(dir, 'qualification.key')
+  const signerPemPath = path.join(dir, 'signer.pem')
+  const specPath = path.join(dir, 'spec.json')
+
+  fs.writeFileSync(identityKeyPath, overrides.identityKeyBytes ?? crypto.randomBytes(64))
+  fs.writeFileSync(evidenceKeyPath, overrides.evidenceKeyBytes ?? crypto.randomBytes(64))
+  fs.writeFileSync(qualificationKeyPath, overrides.qualificationKeyBytes ?? crypto.randomBytes(64))
+
+  if (overrides.signerPemBytes) {
+    fs.writeFileSync(signerPemPath, overrides.signerPemBytes)
+  } else {
+    const { privateKey } = crypto.generateKeyPairSync('ed25519')
+    fs.writeFileSync(signerPemPath, privateKey.export({ format: 'pem', type: 'pkcs8' }))
+  }
+
+  const nowPlusHour = new Date(Date.now() + 60 * 60 * 1000).toISOString()
+  const spec = overrides.spec ?? {
+    binding: {
+      approvedConfigVersionId: 'sentinel-config-version',
+      bindingExpiresAt: nowPlusHour,
+      bindingId: 'sentinel-binding-id',
+      bindingVersion: 'sentinel-binding-version',
+      externalSystemId: 'sentinel-external-system-id',
+      signerExpiresAt: nowPlusHour,
+      tableRef: 'dbo.SentinelTable',
+      tenantId: 'sentinel-tenant',
+      workspaceId: null,
+    },
+    externalSystem: {
+      config: {
+        sealedSnapshotSqlServer: {
+          database: 'sentinel-database',
+          encrypt: true,
+          instanceName: null,
+          port: 1433,
+          server: 'SENTINEL-SERVER-HOSTNAME',
+          trustServerCertificate: false,
+        },
+      },
+      credentials: {
+        sealedSnapshotSqlServer: {
+          password: 'SENTINEL-PASSWORD-DO-NOT-LEAK',
+          user: 'SENTINEL-USER',
+        },
+      },
+      id: 'sentinel-external-system-id',
+      kind: 'data-source:sql-readonly',
+      role: 'source',
+      status: 'active',
+      tenantId: 'sentinel-tenant',
+      workspaceId: null,
+    },
+  }
+  fs.writeFileSync(specPath, JSON.stringify(spec))
+
+  return { dir, evidenceKeyPath, identityKeyPath, qualificationKeyPath, signerPemPath, specPath }
+}
+
+function envFromMaterial(material) {
+  return {
+    [ENV.artifactRoot]: material.dir,
+    [ENV.evidenceKeyFile]: material.evidenceKeyPath,
+    [ENV.identityKeyFile]: material.identityKeyPath,
+    [ENV.provisioningDatabaseRole]: 'sentinel_provisioning_role',
+    [ENV.provisioningDatabaseUrl]: 'postgres://sentinel:SENTINEL-DB-SECRET@127.0.0.1:5432/sentinel_db',
+    [ENV.provisioningSpecFile]: material.specPath,
+    [ENV.qualificationKeyFile]: material.qualificationKeyPath,
+    [ENV.qualificationKeyId]: 'sentinel-qualification-key-id',
+    [ENV.runtimeDatabaseRole]: 'sentinel_runtime_role',
+    [ENV.runtimeDatabaseUrl]: 'postgres://sentinel:SENTINEL-DB-SECRET@127.0.0.1:5432/sentinel_runtime_db',
+    [ENV.signerPrivateKeyFile]: material.signerPemPath,
+  }
+}
+
+function checkById(result, id) {
+  const check = result.checks.find((c) => c.id === id)
+  assert.ok(check, `expected a check named ${id}`)
+  return check
+}
+
+function cleanup(material) {
+  fs.rmSync(material.dir, { force: true, recursive: true })
+}
+
+// ---------------------------------------------------------------------------
+// Positive control: a fully-correct environment must PASS end to end.
+// ---------------------------------------------------------------------------
+test('fully-correct environment: every check PASSes and preflightPass=PASS, exitCode=0', () => {
+  const material = buildGoodOperatorMaterial()
+  try {
+    const result = runPreflight({ env: envFromMaterial(material) })
+    assert.equal(result.preflightPass, 'PASS')
+    assert.equal(result.exitCode, 0)
+    assert.equal(result.baselineAvailable, true)
+    assert.ok(result.checks.length >= 14, 'expected at least 14 distinct checks')
+    for (const check of result.checks) {
+      assert.equal(check.status, 'PASS', `${check.id} unexpectedly ${check.status} (${check.reason})`)
+    }
+  } finally {
+    cleanup(material)
+  }
+})
+
+// ---------------------------------------------------------------------------
+// Each of the seven named mistake classes: must FAIL AND name the right input.
+// A test that only asserted "it failed" would be worthless per the task brief —
+// so every assertion below pins both the check id (the input) and the reason.
+// ---------------------------------------------------------------------------
+test('mistake 1: missing file (identityKeyFile) -> FAIL, IDENTITY_KEY_FILE, FILE_NOT_FOUND', () => {
+  const material = buildGoodOperatorMaterial()
+  try {
+    const env = envFromMaterial(material)
+    env[ENV.identityKeyFile] = path.join(material.dir, 'does-not-exist.key')
+    const result = runPreflight({ env })
+    assert.equal(result.preflightPass, 'FAIL')
+    const check = checkById(result, 'IDENTITY_KEY_FILE')
+    assert.equal(check.status, 'FAIL')
+    assert.equal(check.reason, REASON.FILE_NOT_FOUND)
+    // no other file-based check should have been blamed for this
+    assert.equal(checkById(result, 'QUALIFICATION_KEY_FILE').status, 'PASS')
+    assert.equal(checkById(result, 'SIGNER_PRIVATE_KEY_FILE').status, 'PASS')
+  } finally {
+    cleanup(material)
+  }
+})
+
+test('mistake 2: wrong key length (qualificationKeyFile) -> FAIL, QUALIFICATION_KEY_FILE, KEY_LENGTH_OUT_OF_RANGE', () => {
+  const material = buildGoodOperatorMaterial()
+  try {
+    const env = envFromMaterial(material)
+    const shortKeyPath = path.join(material.dir, 'too-short.key')
+    fs.writeFileSync(shortKeyPath, crypto.randomBytes(10))
+    env[ENV.qualificationKeyFile] = shortKeyPath
+    const result = runPreflight({ env })
+    assert.equal(result.preflightPass, 'FAIL')
+    const check = checkById(result, 'QUALIFICATION_KEY_FILE')
+    assert.equal(check.status, 'FAIL')
+    assert.equal(check.reason, REASON.KEY_LENGTH_OUT_OF_RANGE)
+    assert.equal(checkById(result, 'IDENTITY_KEY_FILE').status, 'PASS')
+  } finally {
+    cleanup(material)
+  }
+})
+
+test('mistake 2b: wrong key length, too long (evidenceKeyFile) -> FAIL, EVIDENCE_KEY_FILE, KEY_LENGTH_OUT_OF_RANGE', () => {
+  const material = buildGoodOperatorMaterial()
+  try {
+    const env = envFromMaterial(material)
+    const longKeyPath = path.join(material.dir, 'too-long.key')
+    fs.writeFileSync(longKeyPath, crypto.randomBytes(256))
+    env[ENV.evidenceKeyFile] = longKeyPath
+    const result = runPreflight({ env })
+    assert.equal(result.preflightPass, 'FAIL')
+    const check = checkById(result, 'EVIDENCE_KEY_FILE')
+    assert.equal(check.status, 'FAIL')
+    assert.equal(check.reason, REASON.KEY_LENGTH_OUT_OF_RANGE)
+  } finally {
+    cleanup(material)
+  }
+})
+
+// ---------------------------------------------------------------------------
+// Boundary proof for the hand-written KEY_LENGTH_OUT_OF_RANGE label. The
+// mistake-2 tests above use 10 and 256 bytes — comfortably inside the
+// failure region, so an off-by-one in diagnoseSymmetricKeyFile (e.g. `< 33`
+// instead of `< 32`) would be invisible there. These four assertions sit
+// exactly on the runbook's documented "32-128 random bytes" boundary, where
+// a hand-written label could silently drift from the product's own
+// readSymmetricKey bounds. The PASS cases additionally prove the label is
+// genuinely inert on the accept side, not merely absent on the reject side.
+// ---------------------------------------------------------------------------
+test('key length boundary: exactly 32 bytes PASSes (runbook lower bound, inclusive)', () => {
+  const material = buildGoodOperatorMaterial()
+  try {
+    const env = envFromMaterial(material)
+    const boundaryKeyPath = path.join(material.dir, 'exactly-32.key')
+    fs.writeFileSync(boundaryKeyPath, crypto.randomBytes(32))
+    env[ENV.identityKeyFile] = boundaryKeyPath
+    const result = runPreflight({ env })
+    const check = checkById(result, 'IDENTITY_KEY_FILE')
+    assert.equal(check.status, 'PASS')
+    assert.equal(check.reason, REASON.CHECK_PASSED)
+  } finally {
+    cleanup(material)
+  }
+})
+
+test('key length boundary: exactly 128 bytes PASSes (runbook upper bound, inclusive)', () => {
+  const material = buildGoodOperatorMaterial()
+  try {
+    const env = envFromMaterial(material)
+    const boundaryKeyPath = path.join(material.dir, 'exactly-128.key')
+    fs.writeFileSync(boundaryKeyPath, crypto.randomBytes(128))
+    env[ENV.identityKeyFile] = boundaryKeyPath
+    const result = runPreflight({ env })
+    const check = checkById(result, 'IDENTITY_KEY_FILE')
+    assert.equal(check.status, 'PASS')
+    assert.equal(check.reason, REASON.CHECK_PASSED)
+  } finally {
+    cleanup(material)
+  }
+})
+
+test('key length boundary: exactly 31 bytes FAILs with KEY_LENGTH_OUT_OF_RANGE (one below lower bound)', () => {
+  const material = buildGoodOperatorMaterial()
+  try {
+    const env = envFromMaterial(material)
+    const boundaryKeyPath = path.join(material.dir, 'exactly-31.key')
+    fs.writeFileSync(boundaryKeyPath, crypto.randomBytes(31))
+    env[ENV.identityKeyFile] = boundaryKeyPath
+    const result = runPreflight({ env })
+    const check = checkById(result, 'IDENTITY_KEY_FILE')
+    assert.equal(check.status, 'FAIL')
+    assert.equal(check.reason, REASON.KEY_LENGTH_OUT_OF_RANGE)
+  } finally {
+    cleanup(material)
+  }
+})
+
+test('key length boundary: exactly 129 bytes FAILs with KEY_LENGTH_OUT_OF_RANGE (one above upper bound)', () => {
+  const material = buildGoodOperatorMaterial()
+  try {
+    const env = envFromMaterial(material)
+    const boundaryKeyPath = path.join(material.dir, 'exactly-129.key')
+    fs.writeFileSync(boundaryKeyPath, crypto.randomBytes(129))
+    env[ENV.identityKeyFile] = boundaryKeyPath
+    const result = runPreflight({ env })
+    const check = checkById(result, 'IDENTITY_KEY_FILE')
+    assert.equal(check.status, 'FAIL')
+    assert.equal(check.reason, REASON.KEY_LENGTH_OUT_OF_RANGE)
+  } finally {
+    cleanup(material)
+  }
+})
+
+test('mistake 3: wrong PEM type (RSA instead of Ed25519) -> FAIL, SIGNER_PRIVATE_KEY_FILE, PEM_WRONG_KEY_TYPE', () => {
+  const material = buildGoodOperatorMaterial()
+  try {
+    const env = envFromMaterial(material)
+    const rsaPemPath = path.join(material.dir, 'rsa.pem')
+    const { privateKey } = crypto.generateKeyPairSync('rsa', { modulusLength: 2048 })
+    fs.writeFileSync(rsaPemPath, privateKey.export({ format: 'pem', type: 'pkcs8' }))
+    env[ENV.signerPrivateKeyFile] = rsaPemPath
+    const result = runPreflight({ env })
+    assert.equal(result.preflightPass, 'FAIL')
+    const check = checkById(result, 'SIGNER_PRIVATE_KEY_FILE')
+    assert.equal(check.status, 'FAIL')
+    assert.equal(check.reason, REASON.PEM_WRONG_KEY_TYPE)
+  } finally {
+    cleanup(material)
+  }
+})
+
+test('mistake 3b: PEM does not parse at all -> FAIL, SIGNER_PRIVATE_KEY_FILE, PEM_PARSE_FAILED', () => {
+  const material = buildGoodOperatorMaterial()
+  try {
+    const env = envFromMaterial(material)
+    const garbagePemPath = path.join(material.dir, 'garbage.pem')
+    fs.writeFileSync(garbagePemPath, 'not a pem file at all\n')
+    env[ENV.signerPrivateKeyFile] = garbagePemPath
+    const result = runPreflight({ env })
+    assert.equal(result.preflightPass, 'FAIL')
+    const check = checkById(result, 'SIGNER_PRIVATE_KEY_FILE')
+    assert.equal(check.status, 'FAIL')
+    assert.equal(check.reason, REASON.PEM_PARSE_FAILED)
+  } finally {
+    cleanup(material)
+  }
+})
+
+test('mistake 4: non-absolute artifact root -> FAIL, ARTIFACT_ROOT, PATH_NOT_ABSOLUTE', () => {
+  const material = buildGoodOperatorMaterial()
+  try {
+    const env = envFromMaterial(material)
+    env[ENV.artifactRoot] = 'relative/artifact/root'
+    const result = runPreflight({ env })
+    assert.equal(result.preflightPass, 'FAIL')
+    const check = checkById(result, 'ARTIFACT_ROOT')
+    assert.equal(check.status, 'FAIL')
+    assert.equal(check.reason, REASON.PATH_NOT_ABSOLUTE)
+  } finally {
+    cleanup(material)
+  }
+})
+
+test('mistake 5: missing env var (provisioningDatabaseRole) -> FAIL, PROVISIONING_DATABASE_ROLE, ENV_VAR_UNSET', () => {
+  const material = buildGoodOperatorMaterial()
+  try {
+    const env = envFromMaterial(material)
+    delete env[ENV.provisioningDatabaseRole]
+    const result = runPreflight({ env })
+    assert.equal(result.preflightPass, 'FAIL')
+    const check = checkById(result, 'PROVISIONING_DATABASE_ROLE')
+    assert.equal(check.status, 'FAIL')
+    assert.equal(check.reason, REASON.ENV_VAR_UNSET)
+    // an unrelated text field must still pass
+    assert.equal(checkById(result, 'RUNTIME_DATABASE_ROLE').status, 'PASS')
+  } finally {
+    cleanup(material)
+  }
+})
+
+test('mistake 6: non-null workspaceId (binding.workspaceId) -> FAIL, PROVISIONING_SPEC_FILE, SPEC_WORKSPACE_ID_NOT_NULL', () => {
+  const material = buildGoodOperatorMaterial()
+  try {
+    const env = envFromMaterial(material)
+    const spec = JSON.parse(fs.readFileSync(material.specPath, 'utf8'))
+    spec.binding.workspaceId = 'not-null-workspace'
+    const badSpecPath = path.join(material.dir, 'bad-workspace-spec.json')
+    fs.writeFileSync(badSpecPath, JSON.stringify(spec))
+    env[ENV.provisioningSpecFile] = badSpecPath
+    const result = runPreflight({ env })
+    assert.equal(result.preflightPass, 'FAIL')
+    const check = checkById(result, 'PROVISIONING_SPEC_FILE')
+    assert.equal(check.status, 'FAIL')
+    assert.equal(check.reason, REASON.SPEC_WORKSPACE_ID_NOT_NULL)
+  } finally {
+    cleanup(material)
+  }
+})
+
+test('mistake 6b: non-null workspaceId (externalSystem.workspaceId) -> FAIL, PROVISIONING_SPEC_FILE, SPEC_WORKSPACE_ID_NOT_NULL', () => {
+  const material = buildGoodOperatorMaterial()
+  try {
+    const env = envFromMaterial(material)
+    const spec = JSON.parse(fs.readFileSync(material.specPath, 'utf8'))
+    spec.externalSystem.workspaceId = 'not-null-workspace'
+    const badSpecPath = path.join(material.dir, 'bad-workspace-spec-2.json')
+    fs.writeFileSync(badSpecPath, JSON.stringify(spec))
+    env[ENV.provisioningSpecFile] = badSpecPath
+    const result = runPreflight({ env })
+    assert.equal(result.preflightPass, 'FAIL')
+    const check = checkById(result, 'PROVISIONING_SPEC_FILE')
+    assert.equal(check.status, 'FAIL')
+    assert.equal(check.reason, REASON.SPEC_WORKSPACE_ID_NOT_NULL)
+  } finally {
+    cleanup(material)
+  }
+})
+
+test('mistake 7: mismatched external-system identity -> FAIL, SPEC_EXTERNAL_SYSTEM_CONSISTENCY, first-party token', () => {
+  const material = buildGoodOperatorMaterial()
+  try {
+    const env = envFromMaterial(material)
+    const spec = JSON.parse(fs.readFileSync(material.specPath, 'utf8'))
+    spec.externalSystem.id = 'DOES-NOT-MATCH-BINDING-EXTERNAL-SYSTEM-ID'
+    const badSpecPath = path.join(material.dir, 'bad-identity-spec.json')
+    fs.writeFileSync(badSpecPath, JSON.stringify(spec))
+    env[ENV.provisioningSpecFile] = badSpecPath
+    const result = runPreflight({ env })
+    assert.equal(result.preflightPass, 'FAIL')
+    const check = checkById(result, 'SPEC_EXTERNAL_SYSTEM_CONSISTENCY')
+    assert.equal(check.status, 'FAIL')
+    // reused verbatim from the product's own ratified failure vocabulary, not invented here
+    assert.equal(check.reason, 'SEALED_EXPORT_BINDING_UNQUALIFIED')
+    // the shallow shape check (PROVISIONING_SPEC_FILE) must not be tripped by this —
+    // only the deeper self-consistency check should name this specific input.
+    assert.equal(checkById(result, 'PROVISIONING_SPEC_FILE').status, 'PASS')
+  } finally {
+    cleanup(material)
+  }
+})
+
+test('mistake 7b: mismatched tenantId between binding and externalSystem is also caught', () => {
+  const material = buildGoodOperatorMaterial()
+  try {
+    const env = envFromMaterial(material)
+    const spec = JSON.parse(fs.readFileSync(material.specPath, 'utf8'))
+    spec.externalSystem.tenantId = 'a-different-tenant-entirely'
+    const badSpecPath = path.join(material.dir, 'bad-tenant-spec.json')
+    fs.writeFileSync(badSpecPath, JSON.stringify(spec))
+    env[ENV.provisioningSpecFile] = badSpecPath
+    const result = runPreflight({ env })
+    const check = checkById(result, 'SPEC_EXTERNAL_SYSTEM_CONSISTENCY')
+    assert.equal(check.status, 'FAIL')
+    assert.equal(check.reason, 'SEALED_EXPORT_BINDING_UNQUALIFIED')
+  } finally {
+    cleanup(material)
+  }
+})
+
+// ---------------------------------------------------------------------------
+// Negative control: "check could not run" must be distinguishable from
+// "check failed". Point the synthetic-baseline tmpRoot at a FILE (not a
+// directory) so fs.mkdtempSync deterministically throws ENOTDIR, and confirm
+// every baseline-dependent isolated check reports NOT_RUN — never PASS, never
+// a bare FAIL — while the baseline-INDEPENDENT checks (which don't need the
+// synthetic material at all) still run for real and can still PASS.
+// ---------------------------------------------------------------------------
+test('negative control: baseline unavailable -> NOT_RUN (not FAIL, not PASS) for dependent checks; independent checks still run', () => {
+  const material = buildGoodOperatorMaterial()
+  const notADirectory = path.join(material.dir, 'this-is-a-file-not-a-directory')
+  fs.writeFileSync(notADirectory, 'x')
+  try {
+    const env = envFromMaterial(material)
+    const result = runPreflight({ env, tmpRoot: notADirectory })
+    assert.equal(result.baselineAvailable, false)
+    assert.equal(result.preflightPass, 'FAIL')
+    assert.equal(result.exitCode, 1)
+
+    const dependentIds = [
+      'ARTIFACT_ROOT',
+      'IDENTITY_KEY_FILE',
+      'SIGNER_PRIVATE_KEY_FILE',
+      'QUALIFICATION_KEY_ID',
+      'QUALIFICATION_KEY_FILE',
+      'PROVISIONING_DATABASE_ROLE',
+      'PROVISIONING_DATABASE_URL',
+      'PROVISIONING_SPEC_FILE',
+      'EVIDENCE_KEY_FILE',
+      'RUNTIME_DATABASE_ROLE',
+      'RUNTIME_DATABASE_URL',
+    ]
+    for (const id of dependentIds) {
+      const check = checkById(result, id)
+      assert.equal(check.status, 'NOT_RUN', `${id} should be NOT_RUN, was ${check.status}`)
+      assert.equal(check.reason, REASON.BASELINE_UNAVAILABLE)
+    }
+
+    // These do not depend on the synthetic baseline and must still produce a
+    // real verdict — proving NOT_RUN above is not just "everything is broken".
+    assert.equal(checkById(result, 'SPEC_EXTERNAL_SYSTEM_CONSISTENCY').status, 'PASS')
+    assert.equal(checkById(result, 'AGGREGATE_PROVISIONING_CONFIG').status, 'PASS')
+    assert.equal(checkById(result, 'AGGREGATE_RUNTIME_CONFIG').status, 'PASS')
+  } finally {
+    fs.rmSync(notADirectory, { force: true })
+    cleanup(material)
+  }
+})
+
+// ---------------------------------------------------------------------------
+// Drift pin: the hand-written binding-draft mapping used for the
+// SPEC_EXTERNAL_SYSTEM_CONSISTENCY check must produce exactly the product's
+// own exported BINDING_DRAFT_FIELDS key set. If that constant is ever
+// renamed/extended upstream, this test REDs instead of the check silently
+// mis-diagnosing.
+// ---------------------------------------------------------------------------
+test('drift pin: buildDraftFromRawBinding key set matches product BINDING_DRAFT_FIELDS exactly', () => {
+  const rawBinding = {
+    approvedConfigVersionId: 'x',
+    bindingExpiresAt: 'x',
+    bindingId: 'x',
+    bindingVersion: 'x',
+    externalSystemId: 'x',
+    signerExpiresAt: 'x',
+    tableRef: 'x',
+    tenantId: 'x',
+    workspaceId: null,
+  }
+  const draft = buildDraftFromRawBinding(rawBinding)
+  assert.deepEqual(Object.keys(draft).sort(), [...BINDING_DRAFT_FIELDS].sort())
+})
+
+// ---------------------------------------------------------------------------
+// Values-free proof: sentinel secrets and sentinel-tagged paths must never
+// appear in stdout/stderr, whether the run PASSes or FAILs. A whitelist
+// projection is not proof; grepping the actual captured output for planted
+// sentinels is.
+// ---------------------------------------------------------------------------
+test('values-free: sentinel secrets, hostnames, and temp paths never appear in CLI output (PASS case)', () => {
+  const material = buildGoodOperatorMaterial()
+  try {
+    const env = { ...process.env, ...envFromMaterial(material) }
+    const stdout = execFileSync(process.execPath, [SCRIPT_PATH], { encoding: 'utf8', env })
+    const forbidden = [
+      'SENTINEL-PASSWORD-DO-NOT-LEAK',
+      'SENTINEL-SERVER-HOSTNAME',
+      'SENTINEL-USER',
+      'SENTINEL-DB-SECRET',
+      'sentinel-tenant',
+      'sentinel-external-system-id',
+      material.dir,
+      material.identityKeyPath,
+      material.signerPemPath,
+      material.specPath,
+    ]
+    for (const needle of forbidden) {
+      assert.ok(!stdout.includes(needle), `stdout leaked sentinel: ${needle}`)
+    }
+    assert.match(stdout, /preflightPass=PASS/)
+  } finally {
+    cleanup(material)
+  }
+})
+
+test('values-free: sentinel secrets never appear in CLI output even on FAIL', () => {
+  const material = buildGoodOperatorMaterial()
+  try {
+    const env = { ...process.env, ...envFromMaterial(material) }
+    delete env[ENV.identityKeyFile]
+    let stdout = ''
+    let exitCode = 0
+    try {
+      stdout = execFileSync(process.execPath, [SCRIPT_PATH], { encoding: 'utf8', env })
+    } catch (error) {
+      stdout = error.stdout ?? ''
+      exitCode = error.status ?? 1
+    }
+    const forbidden = [
+      'SENTINEL-PASSWORD-DO-NOT-LEAK',
+      'SENTINEL-SERVER-HOSTNAME',
+      'SENTINEL-DB-SECRET',
+      material.dir,
+      material.specPath,
+    ]
+    for (const needle of forbidden) {
+      assert.ok(!stdout.includes(needle), `stdout leaked sentinel: ${needle}`)
+    }
+    assert.match(stdout, /preflightPass=FAIL/)
+    assert.notEqual(exitCode, 0)
+  } finally {
+    cleanup(material)
+  }
+})
+
+// ---------------------------------------------------------------------------
+// Subprocess tests: exercise the actual CLI entry point (not just the
+// imported function), for one PASS and one FAIL case, asserting both the
+// printed report and the process exit code.
+// ---------------------------------------------------------------------------
+test('CLI subprocess: fully-correct environment exits 0 and reports preflightPass=PASS', () => {
+  const material = buildGoodOperatorMaterial()
+  try {
+    const env = { ...process.env, ...envFromMaterial(material) }
+    const stdout = execFileSync(process.execPath, [SCRIPT_PATH], { encoding: 'utf8', env })
+    assert.match(stdout, /preflightPass=PASS/)
+    assert.match(stdout, /ARTIFACT_ROOT: status=PASS/)
+    assert.match(stdout, /artifact creation commands/)
+  } finally {
+    cleanup(material)
+  }
+})
+
+test('CLI subprocess: broken environment exits non-zero and reports preflightPass=FAIL', () => {
+  let exitCode = 0
+  let stdout = ''
+  try {
+    stdout = execFileSync(process.execPath, [SCRIPT_PATH], { encoding: 'utf8', env: {} })
+  } catch (error) {
+    stdout = error.stdout ?? ''
+    exitCode = error.status ?? 1
+  }
+  assert.notEqual(exitCode, 0)
+  assert.match(stdout, /preflightPass=FAIL/)
+  assert.match(stdout, /ENV_VAR_UNSET/)
+})
+
+// ---------------------------------------------------------------------------
+// Runtime-only artifact (evidenceKeyFile) is genuinely exercised — it has no
+// role in the provisioning-time loader at all, so this pins that coverage
+// actually reaches loadStockPreparationRuntimeConfig.
+// ---------------------------------------------------------------------------
+test('evidenceKeyFile is checked via the runtime loader independent of provisioning fields', () => {
+  const material = buildGoodOperatorMaterial()
+  try {
+    const env = envFromMaterial(material)
+    delete env[ENV.evidenceKeyFile]
+    const result = runPreflight({ env })
+    const check = checkById(result, 'EVIDENCE_KEY_FILE')
+    assert.equal(check.status, 'FAIL')
+    assert.equal(check.reason, REASON.ENV_VAR_UNSET)
+    // provisioning-only fields are untouched by this
+    assert.equal(checkById(result, 'PROVISIONING_SPEC_FILE').status, 'PASS')
+    assert.equal(checkById(result, 'AGGREGATE_PROVISIONING_CONFIG').status, 'PASS')
+    assert.equal(checkById(result, 'AGGREGATE_RUNTIME_CONFIG').status, 'FAIL')
+  } finally {
+    cleanup(material)
+  }
+})


### PR DESCRIPTION
## The gap

Runbook §4 tells the operator to create **five** private artifacts and gives **zero commands**:

```
identity key / evidence key / qualification key : 32-128 random bytes
signer key                                      : Ed25519 PKCS8 private PEM
provisioning spec                               : strict JSON matching the approved binding
```

At least seven distinct mistakes all collapse into the same opaque `SEALED_EXPORT_INTERNAL_ERROR` — and are discovered **inside the single, non-repeatable flag-on window**, after the 5-minute qualification TTL has already started.

## The design decision that matters: no rule is re-implemented

Every PASS/FAIL comes from calling the **product's own exported validators** — `loadStockPreparationProvisioningConfig`, `loadStockPreparationRuntimeConfig`, `deriveStockPreparationSqlServerSourceAnchors`. They are pure functions of env + files with no DB access, so they run offline unchanged.

Re-implementing the rules would be a second, narrower artifact standing in for the real one — the pattern this repo requires be escalated rather than chosen — and it would drift from the product the first time either side changed.

Specificity comes from **isolated swap**, not from a private rule table: build a self-generated known-good baseline, substitute the operator's real value for **one** variable at a time, and let the real loader's throw/no-throw stay authoritative. A read-only diagnostic only **labels** an already-thrown FAIL; it can never turn one into a PASS.

## Seven mistake classes, each naming the right input

| mistake | reported |
|---|---|
| missing file | `IDENTITY_KEY_FILE` · `FILE_NOT_FOUND` |
| wrong key length (31 / 129 boundaries both tested) | `QUALIFICATION_KEY_FILE` · `KEY_LENGTH_OUT_OF_RANGE` |
| wrong PEM type (RSA not Ed25519) | `SIGNER_PRIVATE_KEY_FILE` · `PEM_WRONG_KEY_TYPE` |
| PEM unparseable | `SIGNER_PRIVATE_KEY_FILE` · `PEM_PARSE_FAILED` |
| non-absolute artifact root | `ARTIFACT_ROOT` · `PATH_NOT_ABSOLUTE` |
| missing env var | `PROVISIONING_DATABASE_ROLE` · `ENV_VAR_UNSET` |
| non-null `workspaceId` (either side) | `PROVISIONING_SPEC_FILE` · `SPEC_WORKSPACE_ID_NOT_NULL` |

**23/23 tests pass**, run independently before opening this. A test that only asserted "it failed" would be worthless here — naming the input **is** the deliverable.

## Values-free by construction

The external-system consistency check reads only **identity** fields (id/tenantId/workspaceId/kind/role/status) and splices a synthetic placeholder for `config`/`credentials`, so the operator's real host/user/password are never read. Two dedicated tests grep actual subprocess stdout/stderr for planted sentinel secrets, hostnames and paths.

## What it deliberately cannot reach — stated, not buried

- a malformed real `config`/`credentials` block (would require reading real credentials);
- a mismatch against what is approved **server-side in the database** (requires DB/network);
- **engine major version** and **snapshot posture** — those are customer-side and unreachable offline.

## Negative control

Pointing `tmpRoot` at a file breaks baseline construction: the 11 baseline-dependent checks report `NOT_RUN` / `BASELINE_UNAVAILABLE` while the 3 baseline-independent checks still produce a real PASS. That distinguishes **"check failed"** from **"check could not run"** — without it, an always-red tool would look identical.

The `KEY_LENGTH_OUT_OF_RANGE` label was proven load-bearing by mutating its threshold and confirming the suite reds for the right reason, then reverting.

## Wiring

New workflow `stock-preparation-s6a-operator-preflight.yml`, `pull_request` + `push:main`, no `if` gate. This matters: **99 of 176 `scripts/ops/*.test.mjs` are referenced by no workflow at all**, and there is no glob runner — an unwired test here would have been dead code.

**Unverified:** the workflow pins Node 20; only Node v25 was available locally. The APIs used are long-stable, but that is inference.

No product code touched. No flag default changed, nothing armed, nothing deployed, no external write.