### PR TITLE
docs(stock-prep): runbook §2 must name 074 and 075, and prove the grants actually landed (R12)

### DIFF
--- a/docs/operations/stock-preparation-s6a-sqlserver-onprem-runbook-20260731.md
+++ b/docs/operations/stock-preparation-s6a-sqlserver-onprem-runbook-20260731.md
@@ -70,7 +70,7 @@ or source rows in GitHub comments or evidence artifacts.
 
 Any mismatch is a terminal `STOP_AND_REPORT`; do not deploy.
 
-## 2. Create PostgreSQL Roles Before Migration 073
+## 2. Create PostgreSQL Roles Before Migrations 073, 074 And 075
 
 Migration `073_create_sealed_export_stock_prep_runtime_authority` is recorded
 once by Kysely. The two roles and both PostgreSQL settings must exist before
@@ -104,11 +104,39 @@ Then run the packaged migration entry point and confirm the exact migration:
 node packages/core-backend/dist/src/db/migrate.js --list
 node packages/core-backend/dist/src/db/migrate.js
 node packages/core-backend/dist/src/db/migrate.js --confirm 073_create_sealed_export_stock_prep_runtime_authority
+node packages/core-backend/dist/src/db/migrate.js --confirm 074_repair_sealed_export_runtime_authority_privileges
+node packages/core-backend/dist/src/db/migrate.js --confirm 075_grant_sealed_export_runtime_authority_row_lock
 Remove-Item Env:PGOPTIONS -ErrorAction SilentlyContinue
 ```
 
-If migration 073 was already recorded without the two grants, stop. Do not
-rerun the SQL file manually and do not enable the feature flag.
+`PGOPTIONS` must stay set for the WHOLE migration run, not just around 073.
+Migrations 074 and 075 read the SAME two settings and take the SAME
+NOTICE-and-return branch when those settings are absent (074 lines 64-78, 075
+lines 107-121). A run that sets them only for 073 records 074 and 075 as
+applied while their grants are latent, and reports NOTHING wrong.
+
+If migration 073, 074 or 075 was already recorded without the two grants, stop.
+Do not rerun the SQL file manually and do not enable the feature flag.
+
+Then confirm the grants actually landed. `--confirm` proves a migration was
+RECORDED; it does not prove the grants exist, because the latent branch records
+the migration too. All three predicates must return true:
+
+```sql
+SELECT
+  has_column_privilege('<provisioning-role>',
+    'integration_sealed_export_signer_public_keys', 'updated_at', 'UPDATE') AS grant_074,
+  has_column_privilege('<runtime-role>',
+    'integration_sealed_export_authority_state', 'updated_at', 'UPDATE')    AS grant_075,
+  has_table_privilege('<runtime-role>',
+    'integration_sealed_export_generation_audit', 'SELECT')                 AS grant_073;
+```
+
+Why these two migrations exist, so a reader can judge whether a latent grant
+matters: without 074 provisioning fails at the signer-key row lock; without 075
+the final activation transaction fails to lock the authority state. Both surface
+at RUNTIME as a bare PostgreSQL `42501`, already wrapped by the time an operator
+sees it. Both were verified on PostgreSQL 16 AND 17.
 
 ## 3. Deploy With The Feature Flag Off
 

--- a/plugins/plugin-integration-core/lib/sealed-export/vectors/s6a-package-provenance-pins.json
+++ b/plugins/plugin-integration-core/lib/sealed-export/vectors/s6a-package-provenance-pins.json
@@ -73,7 +73,7 @@
     "pluginHttpRoutes": "b288d7dc4e51362bdd3f74c578510ce46378c83116ae0e34723e81519baf62eb",
     "s6aProvisioningCli": "d3320b27da7ab358ca068a3766a375e669fb6922f24ba0186ba0828c3e1d9da8",
     "s6aAcceptanceRunner": "eb58824cba1ab03361a6a4fba409f3f7a120dcda61d4c3d6cad2b82311d62624",
-    "s6aOnpremRunbook": "e0df59fc16dddf749497eb285b9937a45cf0931c30d18cf09a447543a88c09bf",
+    "s6aOnpremRunbook": "979fb89d0d8dc141c17d450329b976e90427219b136e0bd9e0f8e6f631e07ca7",
     "multitableOnpremPackageVerify": "98169fa2860078054a2f3fc61e72a7598d62bc3376bc5a0e30f9867170ee9f1e"
   },
   "evidenceFiles": {


### PR DESCRIPTION
## The gap is not cosmetic

The on-prem runbook mentions **073 nine times** and **074 / 075 zero times** — it predates both.

074 and 075 read the **same two** PostgreSQL settings as 073 and take the **same NOTICE-and-return branch** when those settings are absent (`074:64-78`, `075:107-121`). So a migration run that sets `PGOPTIONS` only around 073 records 074 and 075 as **applied**, while their grants are **latent** — and reports nothing wrong.

The failure then surfaces at **runtime** as a bare PostgreSQL `42501`:

- without **074**, provisioning fails at the signer-key row lock;
- without **075**, the final activation transaction fails to lock the authority state.

Those are precisely the two blockers that stopped the S6-A walk, and both were found only by executing it. An operator following this runbook literally would rediscover them inside the one non-repeatable window.

## Three changes

1. §2 title and body name all three migrations.
2. `--confirm` lines added for 074 and 075.
3. **A grant-verification query** — because `--confirm` proves a migration was **RECORDED**, and the latent branch records it too. *Recorded is not granted*, and the runbook previously offered no way to tell those apart:

```sql
SELECT
  has_column_privilege('<provisioning-role>',
    'integration_sealed_export_signer_public_keys', 'updated_at', 'UPDATE') AS grant_074,
  has_column_privilege('<runtime-role>',
    'integration_sealed_export_authority_state', 'updated_at', 'UPDATE')    AS grant_075,
  has_table_privilege('<runtime-role>',
    'integration_sealed_export_generation_audit', 'SELECT')                 AS grant_073;
```

## On the re-pin — and a correction I owe

The runbook is a pinned runtime file, so its digest is re-pinned here and the package-provenance suite passes.

**This is the sealed-export manifest that tracks HEAD** — 6 of its 65 entries have already moved since the frozen build (one from an unrelated attendance lane), and both #4732 and #4737 re-pinned entries in it.

It is **not** the RC-A sidecar's `FROZEN_RUNTIME_SHA`, which has never moved and where re-pinning alone would silence a tripwire. **I conflated those two earlier in this line and told the owner this file was blocked on that decision. It is not.** The two look alike and are governed differently.

No product code touched. No flag default changed, nothing armed, nothing deployed, no external write.