### PR TITLE
docs(stock-prep): runbook §4 — the external-system record is a prerequisite nothing creates (R13)

### DIFF
--- a/docs/operations/stock-preparation-s6a-sqlserver-onprem-runbook-20260731.md
+++ b/docs/operations/stock-preparation-s6a-sqlserver-onprem-runbook-20260731.md
@@ -170,6 +170,28 @@ The provisioning spec contains private connection material. Store it only in
 the controlled secret area and remove the transient copy after successful
 provisioning. Its external-system identity and source configuration must match
 the approved server-side external-system record used by the runtime.
+
+That record is a PREREQUISITE this runbook does not create. Nothing earlier in
+this document, and nothing in the PostgreSQL readiness checklist, produces it —
+so treat it as an input to be confirmed BEFORE the window, not a step inside it.
+
+The first-party surface that creates and lists it is:
+
+```text
+POST /api/integration/external-systems     (create/update; admin)
+GET  /api/integration/external-systems     (list; admin — read-only, safe to run now)
+```
+
+Confirm with the GET, before the window, that a record exists whose identity
+fields equal the ones in the provisioning spec: `id`, `tenantId`,
+`workspaceId` (JSON `null`), `kind`, `role`, `status`. A mismatch on any of
+them is refused as `SEALED_EXPORT_BINDING_UNQUALIFIED` — a token that reads as
+"the binding is bad" and does not say which field disagreed.
+
+`scripts/ops/stock-preparation-s6a-operator-preflight.mjs` checks this same
+identity agreement offline and names the disagreeing input. It cannot check
+agreement against the DATABASE (that needs the running service), so the GET
+above and the preflight are complementary, not alternatives.
 This single-customer v1 route has no workspace selector: both
 `binding.workspaceId` and `externalSystem.workspaceId` must be JSON `null`.
 Any non-null workspace scope is refused before qualification.

--- a/plugins/plugin-integration-core/lib/sealed-export/vectors/s6a-package-provenance-pins.json
+++ b/plugins/plugin-integration-core/lib/sealed-export/vectors/s6a-package-provenance-pins.json
@@ -73,7 +73,7 @@
     "pluginHttpRoutes": "b288d7dc4e51362bdd3f74c578510ce46378c83116ae0e34723e81519baf62eb",
     "s6aProvisioningCli": "d3320b27da7ab358ca068a3766a375e669fb6922f24ba0186ba0828c3e1d9da8",
     "s6aAcceptanceRunner": "eb58824cba1ab03361a6a4fba409f3f7a120dcda61d4c3d6cad2b82311d62624",
-    "s6aOnpremRunbook": "979fb89d0d8dc141c17d450329b976e90427219b136e0bd9e0f8e6f631e07ca7",
+    "s6aOnpremRunbook": "1f4ba2b7fadbad0acb97e18d13f2be7ad6071fa372ac44e0aa4e17995e94c410",
     "multitableOnpremPackageVerify": "98169fa2860078054a2f3fc61e72a7598d62bc3376bc5a0e30f9867170ee9f1e"
   },
   "evidenceFiles": {


### PR DESCRIPTION
## A dangling prerequisite

§4 requires the provisioning spec to match *"the approved server-side external-system record used by the runtime"* — and **no step in this runbook, and nothing in the PostgreSQL readiness checklist, creates that record.** The operator is told to match something the document never produces.

Verified before writing rather than assumed:

| | |
|---|---|
| runbook mentions it | **once** — the line this change follows |
| readiness checklist mentions it | **zero** |
| other docs describing external-system creation | all belong to **different lines** (data-factory, integration-core external-API self-service) |

## What was added

The first-party surface, the fields that must agree, and what a mismatch looks like:

```text
POST /api/integration/external-systems     (create/update; admin)
GET  /api/integration/external-systems     (list; admin — read-only, safe to run now)
```

Identity fields that must equal the provisioning spec: `id`, `tenantId`, `workspaceId` (JSON `null`), `kind`, `role`, `status`.

A mismatch on any of them surfaces as `SEALED_EXPORT_BINDING_UNQUALIFIED` — a token that reads as *"the binding is bad"* and **never says which field disagreed**.

**The GET is read-only and can be run before the window. That is the entire point:** this is an input to confirm in advance, not a discovery to make inside a single non-repeatable window — and with a one-shot, irreversible binding, discovering it late is expensive.

## Relationship to #4741, stated so neither is mistaken for covering the other

The offline preflight checks this same identity agreement and names the disagreeing input, but **cannot** check agreement against the **database** — that needs the running service. The GET above and the preflight are **complementary, not alternatives**.

## Pin

Re-pinned `runtimeFiles.s6aOnpremRunbook`; the package-provenance suite passes. This is the sealed-export manifest that tracks HEAD — the same one #4732, #4737 and #4742 re-pinned — **not** the RC-A sidecar's `FROZEN_RUNTIME_SHA`.

No product code touched. No flag default changed, nothing armed, nothing deployed, no external write.