### PR TITLE
docs(attendance): prepare W4C-5 transition safety

### DIFF
--- a/docs/deployment/attendance-issue-4556-w4c5-synthetic-soak-runbook-20260804.md
+++ b/docs/deployment/attendance-issue-4556-w4c5-synthetic-soak-runbook-20260804.md
@@ -1,0 +1,162 @@
+# Attendance #4556 W4C-5 Synthetic Soak Runbook
+
+Date: 2026-08-04
+Status: **DRAFT / NOT EXECUTABLE**
+
+This is a preparation-only runbook for the W4C-5 named synthetic staging soak.
+It must not be used until the transition-safety amendment is RATIFIED, its core
+hardening is on `main`, the operator tools pass an exact-head gate, and the
+owner separately authorizes the exact staging org, image SHA, and start time.
+
+## 0. Current Stop Conditions
+
+At publication time every transition is blocked:
+
+- `OD-W4C-61` is open;
+- no safe operator transition command is accepted;
+- no staging org is named here;
+- no image SHA or observation window is approved here;
+- no flag, deployment, staging access, or soak authorization is granted here.
+
+Do not replace those missing inputs with defaults, wildcards, production data,
+customer data, or a tunnel/browser session. Do not run direct SQL against
+rollout, operation, result, pointer, source, or review tables.
+
+## 1. Required Owner Packet
+
+Before any staging command, record one durable owner decision containing:
+
+- exact synthetic org ID;
+- exact 40-character deployed backend and web image SHA;
+- authorized first target (`shadow` only for a new campaign);
+- approved start timestamp and minimum seven calendar-day window;
+- confirmation that the data is synthetic and externally isolated;
+- confirmation that external notifications and destinations are disabled;
+- authorization limited to the named org/image/campaign;
+- explicit exclusions for production, customer data, release tags, and issue
+  closure.
+
+An old campaign, old image, agent-authored approval, or broad “continue” does
+not satisfy this packet.
+
+## 2. Evidence Directory
+
+Use one immutable campaign directory outside the repository. The future tool
+must create, never overwrite, these redacted artifacts:
+
+```text
+manifest.json
+status/day-N.json
+shadow/day-N.json
+entrypoints/day-N.json
+reviews/day-N.json
+drills/suspend.json
+drills/resume.json
+drills/reversal.json
+integrity/pointers.json
+integrity/history-hashes.json
+cleanup/residue.json
+summary.json
+```
+
+Each file is bound to campaign ID, org ID, exact image SHA, UTC capture time,
+and tool SHA. Artifacts contain counts, hashes, closed codes, and synthetic IDs
+only; no credentials, raw tokens, employee names, notification content, or
+customer data.
+
+## 3. Read-Only Preflight
+
+After separate staging authorization, collect the existing attendance staging
+`status` action first. It must show the exact backend/web image SHA, pending
+migrations `0`, and healthy services. Status failure or ambiguity stops the
+campaign without any repair, restart, deployment, or flag change.
+
+The future W4C-5 `plan` command then reports every transition predicate without
+DML. Required `PASS` facts before `legacy -> shadow` include:
+
+- exact allowlisted synthetic org and `scope='synthetic_staging'`;
+- legal current/target pair and expected rollout version;
+- no unsafe legacy async job or incomplete operation/batch;
+- every pre-W4 import batch closed or preimaged;
+- no posture mismatch;
+- complete P16 staging helper and cleanup inventory;
+- manifest hash matches the owner packet and status artifact.
+
+Any `BLOCKED`, unknown enum, missing table, malformed artifact, or stale version
+stops. Plan output never authorizes apply.
+
+## 4. Transition Discipline
+
+No transition command exists in this runbook yet. After `OD-W4C-61=(a)` and the
+hardening lands, the final runbook must name one canonical command that:
+
+1. accepts explicit current state/version and target state;
+2. requires the owner packet and evidence manifest;
+3. prints the full plan and requires an exact confirmation token derived from
+   its hash;
+4. invokes only the hardened core boundary;
+5. stores and returns the committed event/state/version;
+6. immediately performs a read-only post-transition comparison.
+
+There is no `--force`, wildcard org, direct SQL, skip-gate, or automatic next
+transition. Every transition is one separately evidenced operation.
+
+## 5. Observation Days
+
+For seven distinct calendar days, collect status, shadow diff, entrypoint
+coverage, review backlog, pointer validity, and history hashes. Synthetic events
+must cover every W4 entrypoint. Product tests may create only campaign-scoped
+synthetic users, groups, shifts, records, requests, imports, and approvals.
+
+Daily acceptance requires:
+
+- exact image and tool SHAs unchanged;
+- services healthy and migrations pending `0`;
+- zero critical shadow codes;
+- zero unresolved review items;
+- zero external notification/destination attempts;
+- no unknown entrypoint, reason, posture, or schema;
+- campaign residue accounted for.
+
+A failed day is recorded, not rerun into disappearance. Repair, image change,
+or contract change ends the campaign; a new separately authorized campaign is
+required.
+
+## 6. Drills
+
+The campaign must include separately recorded synthetic-only drills:
+
+- reversal restores the exact frozen predecessor and preserves append-only
+  history;
+- suspend blocks new source/result writes and preserves authoritative pointer;
+- retryable authoritative jobs remain durable without operation rows;
+- offline replay during suspension is read-only and has zero critical or
+  unresolved diffs;
+- resume returns authoritative and the first changed punch supersedes the
+  preserved pointer;
+- a mismatched frozen posture and source-bearing mismatch both block.
+
+Drills do not authorize production incident procedures.
+
+## 7. Cleanup and Final Report
+
+Cleanup uses only canonical reversal/retirement paths enumerated by the P16
+inventory. Direct deletes or dynamic SQL against W4-backed data are forbidden.
+The final residue report must show zero campaign-owned live data and list every
+retained append-only audit/history row by count and hash.
+
+The final summary may state only “internal synthetic W4C-5 soak evidence PASS”
+when all gates are proven. It must not state customer UAT, production
+acceptance, deployment approval, release readiness, or issue closure.
+
+## 8. Independent Gates
+
+Before the runbook becomes executable:
+
+1. transition hardening passes exact-head real-PostgreSQL, race, and mutation
+   review;
+2. tool plan/apply tests prove zero-DML fail-closed behavior;
+3. the staging workflow/package contains the exact reviewed tools;
+4. owner separately authorizes the exact campaign packet;
+5. a final read-only boundary audit confirms no staging action has occurred
+   during preparation.

--- a/docs/development/attendance-issue-4556-w4c5-transition-safety-amendment-20260804.md
+++ b/docs/development/attendance-issue-4556-w4c5-transition-safety-amendment-20260804.md
@@ -1,0 +1,186 @@
+# Attendance #4556 W4C-5 Transition Safety Amendment
+
+Date: 2026-08-04
+Status: **PROPOSED / staging HOLD**
+Decision: `OD-W4C-61`
+Baseline: `783eb72fe038083e21d896bc220c7afcaffaf88d`
+
+This amendment was discovered while preparing the owner-authorized W4C-5 tools
+and runbook. It authorizes no transition, flag, staging access, deployment,
+soak, production/customer data use, external notification, or issue closure.
+
+## 0. Finding
+
+The RATIFIED W4 lock requires each rollout transition to enforce a closed legal
+transition matrix and all mutable database preconditions while holding the
+exclusive org rollout lock. The current internal command is not yet a safe
+operator transition boundary:
+
+1. `packages/core-backend/src/attendance/w4c3a-rollout-control.ts:36-42`
+   accepts every rollout state as a target. The command rejects only a no-op;
+   it does not enforce the seven legal source/target pairs in the lock.
+2. `:261-286` silently creates a missing org row as
+   `scope='synthetic_staging'` without proving that the org is the exact named
+   allowlisted synthetic org.
+3. `:332-363` locks source operation rows, jobs, batches, items, targets, and
+   records, but it does not inspect request snapshots, legacy request facts,
+   unresolved ingress reviews, all incomplete operations, or the full
+   retryable-job posture matrix required by the lock.
+4. `:474-509` checks only legacy batch closure/preimage before updating state.
+   Its rollout event stores empty evidence and the normalized `correlationId`
+   is not persisted.
+5. The existing tests prove closure/transition serialization and legacy-batch
+   blocking. They do not prove illegal-pair rejection or the complete
+   eligibility/authority/suspend/resume gate.
+
+A read-only CLI preflight followed by the current command would not repair this
+gap. State can change between those transactions, so that shape contains a
+time-of-check/time-of-use window. A direct SQL wrapper would be a larger bypass.
+
+## 1. Closed Transition Matrix
+
+Only these pairs are legal:
+
+| Current | Target | Comparison write posture |
+| --- | --- | --- |
+| `legacy` | `shadow` | `shadow` |
+| `shadow` | `eligible` | `shadow` |
+| `eligible` | `shadow` | `shadow` |
+| `eligible` | `authoritative` | `authoritative` |
+| `shadow` | `legacy` | `legacy_projection_only` |
+| `authoritative` | `suspended` | preserved `authoritative` |
+| `suspended` | `authoritative` | preserved `authoritative` |
+
+Every other pair fails before rollout-state/event DML. The comparison posture
+is obtained from the same canonical posture resolver used by source writers;
+the command must not compare persisted rollout values directly with normalized
+write postures.
+
+## 2. Safe Command Boundary
+
+The canonical transition function must perform the following in one database
+transaction:
+
+1. Validate an exact org ID, actor ID, correlation ID, engine version, expected
+   current state/version, target state, and evidence-manifest SHA-256.
+2. Acquire the canonical exclusive org rollout advisory lock first.
+3. Lock and reload the rollout row. Missing state may be created only for the
+   exact allowlisted synthetic org and only as part of `legacy -> shadow`.
+4. Reject a stale expected state/version and any pair absent from section 1.
+5. Acquire the existing operation/batch/target lock domain in canonical order.
+6. Re-evaluate every database-backed transition predicate in section 3 under
+   those locks.
+7. Insert one event containing the exact manifest hash, correlation ID,
+   precondition counters, source/target states, comparison posture, and the
+   external evidence references from section 4.
+8. Update the rollout state only after the event insert succeeds. Event and
+   state update commit or roll back together.
+
+No route or generic plugin service is added. The command stays an internal
+core-backend boundary invoked only by a separately authorized operator tool.
+The current function is hardened in place or replaced with one private
+fail-closed boundary; two competing transition implementations are forbidden.
+
+## 3. Database-Backed Predicates
+
+The transaction returns `BLOCKED` and performs zero rollout DML unless all
+predicates required for the requested pair are satisfied:
+
+- exact named org and `scope='synthetic_staging'`;
+- no nonterminal null-version legacy async job for entry into
+  `shadow|eligible|authoritative`;
+- no incomplete operation, operation batch, import batch, or source-bearing
+  mismatch required by the pair;
+- every retryable job has the comparison posture from section 1;
+- every pre-W4 import batch has an immutable closure or frozen preimage;
+- eligibility/authority has zero pending or reversible calculation-affecting
+  request whose latest snapshot is missing, unsupported, payload-stale, or
+  reversal-incomplete;
+- eligibility/authority has zero unresolved
+  `legacy_time_ingress_not_authoritative` review;
+- suspend has serialized every source writer and changes no operation,
+  source, result, pointer, or job row;
+- resume proves the prior state was authoritative, preserved authoritative jobs
+  remain retryable without operation rows, and the referenced offline replay
+  artifact reports zero critical/unresolved diffs.
+
+The command returns typed per-predicate counts in its result. It does not accept
+a caller-supplied aggregate `ready=true` as a substitute for these queries.
+
+## 4. External Evidence Manifest
+
+Facts outside the database cannot be made transactional. The operator tool
+collects them immediately before transition, hashes the canonical manifest,
+and passes only the exact manifest plus hash into the command:
+
+- exact deployed backend/web image SHA;
+- pending migrations `0` and service health;
+- owner authorization reference and authorized target state;
+- exact synthetic org ID and explicit `customerData=false`;
+- external notifications disabled and zero external destinations;
+- every-entrypoint inventory and observation dates;
+- seven distinct calendar days for authority promotion;
+- zero critical diffs and unresolved reviews;
+- suspend/resume, reversal, pointer/hash, and residue evidence references.
+
+The tool fails if a required field is absent, malformed, stale, or names a
+different org/image/target. The database event stores the manifest hash and
+redacted references, never secrets or raw evidence payloads.
+
+## 5. Tooling Contract
+
+Preparation may add:
+
+- a read-only `status`/`plan` command that emits `PASS|BLOCKED` per predicate;
+- a local canonical manifest validator and hasher;
+- a transition command that is compiled but refuses execution unless the safe
+  boundary from sections 1-4 is present and explicit owner/staging authorization
+  inputs are supplied;
+- status, shadow-diff, eligibility, authority, suspend, resume, reversal, and
+  residue report renderers.
+
+Preparation must not add direct rollout DML, a raw SQL escape hatch, a wildcard
+org, an implicit `--yes`, or a default target. The transition command is absent
+or hard-blocked until this amendment is RATIFIED and the core hardening has
+passed a separate exact-head gate.
+
+## 6. Completion Gates
+
+1. Seven legal pairs pass and every other pair fails with zero rollout DML.
+2. Removing one pair guard makes its negative mutation red.
+3. Missing state for a non-allowlisted org cannot create a rollout row.
+4. A read-only preflight cannot be reused after any locked predicate changes;
+   the transition transaction re-evaluates and blocks.
+5. Each section 3 predicate has a positive, negative, and remove-the-predicate
+   mutation leg on real PostgreSQL.
+6. Two-connection races cover request snapshot, review, operation, retryable
+   job, legacy batch, suspend, and resume changes while transition waits.
+7. A failed event insert leaves state/version unchanged; a failed state update
+   leaves no event.
+8. Event evidence exact-key tests require manifest hash and correlation ID and
+   reject secrets/raw payloads.
+9. Repository inventory proves no second transition DML or direct tooling DML.
+10. Tool plan mode performs zero DML; apply mode remains hard-blocked without
+    exact owner/staging authorization and the expected state/version.
+
+## 7. Owner Decision
+
+`OD-W4C-61` remains **OPEN**.
+
+- **(a) RECOMMENDED:** harden the canonical transition boundary according to
+  sections 1-6 before any executable W4C-5 transition tooling is accepted.
+- **(b):** keep W4C-5 tooling read-only and defer every transition command. No
+  soak can start until a later amendment supplies an equivalent atomic gate.
+
+Option (a) preserves the already RATIFIED W4C-5 goal without accepting the
+current TOCTOU gap. Option (b) is safe but leaves W4C-5 operationally blocked.
+
+## 8. Landing Sequence
+
+1. Merge this document as `PROPOSED` after exact-head independent review.
+2. Owner RATIFYs the exact merged SHA and selects `OD-W4C-61`.
+3. If `(a)`, land the core transition hardening in a Draft/HOLD PR after a real
+   PostgreSQL and concurrency gate.
+4. Land read-only/tooling and runbook completion in a separate Draft/HOLD PR.
+5. Stop. Actual staging access, flag changes, transitions, seven-day soak, and
+   issue closure remain separately owner-gated.

--- a/docs/development/attendance-issue-4556-w4c5-transition-safety-amendment-20260804.md
+++ b/docs/development/attendance-issue-4556-w4c5-transition-safety-amendment-20260804.md
@@ -19,14 +19,14 @@ operator transition boundary:
 1. `packages/core-backend/src/attendance/w4c3a-rollout-control.ts:36-42`
    accepts every rollout state as a target. The command rejects only a no-op;
    it does not enforce the seven legal source/target pairs in the lock.
-2. `:261-286` silently creates a missing org row as
+2. `:261-288` silently creates a missing org row as
    `scope='synthetic_staging'` without proving that the org is the exact named
    allowlisted synthetic org.
-3. `:332-363` locks source operation rows, jobs, batches, items, targets, and
+3. `:332-370` locks source operation rows, jobs, batches, items, targets, and
    records, but it does not inspect request snapshots, legacy request facts,
    unresolved ingress reviews, all incomplete operations, or the full
    retryable-job posture matrix required by the lock.
-4. `:474-509` checks only legacy batch closure/preimage before updating state.
+4. `:474-505` checks only legacy batch closure/preimage before updating state.
    Its rollout event stores empty evidence and the normalized `correlationId`
    is not persisted.
 5. The existing tests prove closure/transition serialization and legacy-batch


### PR DESCRIPTION
## Scope

Preparation-only W4C-5 transition-safety amendment and synthetic-soak runbook. No executable transition command is added.

## Finding

The current internal rollout helper locks part of the W4 domain but does not enforce the closed seven-pair transition matrix or the complete eligibility/authority/suspend/resume predicates in the same transaction. Wrapping it with an external read-only preflight would leave a TOCTOU gap.

## Proposed decision

OD-W4C-61 remains OPEN. Option (a) is recommended: harden the canonical transition boundary transactionally before any executable W4C-5 tool is accepted.

## Verification

- Baseline: 783eb72fe038083e21d896bc220c7afcaffaf88d
- Current transition source and real-PostgreSQL tests inspected
- git diff --check: PASS
- Independent exact-head review: pending

## HOLD

Docs-only Draft/HOLD. No staging access, transition, flag, deployment, soak, production/customer data, external notification, or issue closure is authorized.