### PR TITLE
feat(integration): client materialReadPath — close the P3 read-back gap the P1 mirror recorded

### DIFF
--- a/apps/web/src/services/integration/k3WiseSetup.ts
+++ b/apps/web/src/services/integration/k3WiseSetup.ts
@@ -164,6 +164,10 @@ export interface K3WiseSetupForm {
   autoSubmit: boolean
   autoAudit: boolean
   materialSavePath: string
+  // P3 read-back: the server template has declared Material readPath
+  // (/K3API/Material/GetDetail) all along; the client form had no counterpart, so the post-save
+  // verification had nothing to call. Recorded as a KNOWN GAP by the P1 endpoint mirror and closed here.
+  materialReadPath: string
   materialSubmitPath: string
   materialAuditPath: string
   // A4: per-reference-field Save shape for Material (field name → shape); empty/unset ⇒ {FNumber}.
@@ -973,6 +977,7 @@ export function createDefaultK3WiseSetupForm(): K3WiseSetupForm {
     autoSubmit: false,
     autoAudit: false,
     materialSavePath: '/K3API/Material/Save',
+    materialReadPath: '/K3API/Material/GetDetail',
     materialSubmitPath: '/K3API/Material/Submit',
     materialAuditPath: '/K3API/Material/Audit',
     materialReferenceShapes: defaultMaterialReferenceShapes(),
@@ -1048,6 +1053,9 @@ export function validateK3WiseSetupForm(form: K3WiseSetupForm): K3WiseSetupValid
   if (trim(form.healthPath)) assertRelativePath(form.healthPath, 'healthPath', issues)
   assertRelativePath(form.materialSavePath, 'materialSavePath', issues)
   assertRelativePath(form.bomSavePath, 'bomSavePath', issues)
+  // Optional like Submit, not required like Save: read-back is a verification step, and a deployment that
+  // has not enabled it must not be blocked from saving. Filled in, it must still be a relative path.
+  if (trim(form.materialReadPath)) assertRelativePath(form.materialReadPath, 'materialReadPath', issues)
   if (trim(form.materialSubmitPath)) assertRelativePath(form.materialSubmitPath, 'materialSubmitPath', issues)
   if (trim(form.materialAuditPath)) assertRelativePath(form.materialAuditPath, 'materialAuditPath', issues)
   if (trim(form.bomSubmitPath)) assertRelativePath(form.bomSubmitPath, 'bomSubmitPath', issues)
@@ -1968,6 +1976,7 @@ export function buildK3WiseSetupPayloads(form: K3WiseSetupForm): K3WiseSetupPayl
       objects: {
         material: {
           savePath: trim(form.materialSavePath),
+          ...(optionalString(form.materialReadPath) ? { readPath: trim(form.materialReadPath) } : {}),
           ...(optionalString(form.materialSubmitPath) ? { submitPath: trim(form.materialSubmitPath) } : {}),
           ...(optionalString(form.materialAuditPath) ? { auditPath: trim(form.materialAuditPath) } : {}),
           keyField: 'FNumber',

--- a/apps/web/tests/k3-endpoint-vocab-mirror.spec.ts
+++ b/apps/web/tests/k3-endpoint-vocab-mirror.spec.ts
@@ -31,10 +31,10 @@ const CORRESPONDENCE: ReadonlyArray<
   ['material', 'savePath', 'materialSavePath', 'the only write this first version performs'],
   ['material', 'submitPath', 'materialSubmitPath', 'declared; Submit is OFF in the first version'],
   ['material', 'auditPath', 'materialAuditPath', 'declared; Audit is OFF in the first version'],
-  // Documented gap, found by writing this test: the server declares a Material read path and the client
-  // form has no counterpart. GetDetail is exactly what the first version's post-save read-back needs, so
-  // this null is a KNOWN GAP to close in P3 — recorded here rather than left invisible.
-  ['material', 'readPath', null, 'KNOWN GAP: no client field; P3 read-back needs it'],
+  // Was a KNOWN GAP when this test was written — the server declared readPath and the client had no
+  // counterpart, so the post-save read-back had nothing to call. CLOSED in P3: materialReadPath now exists
+  // and is mirrored here, which is what turns "we added a field" into "the field agrees with the server".
+  ['material', 'readPath', 'materialReadPath', 'P3 post-save GetDetail read-back'],
   ['bom', 'savePath', 'bomSavePath', 'declared; BOM writes are OFF in the first version'],
   ['bom', 'submitPath', 'bomSubmitPath', 'declared; BOM Submit is OFF'],
   ['bom', 'auditPath', 'bomAuditPath', 'declared; BOM Audit is OFF'],


### PR DESCRIPTION
Closes the **KNOWN GAP** the P1 endpoint mirror (#4750) recorded rather than hid.

The server template has declared Material `readPath: '/K3API/Material/GetDetail'` all along. **The client form had no counterpart** — so the first version's post-save verification had nothing to call. P1 recorded that as a `null` entry annotated `KNOWN GAP` instead of quietly skipping it. This closes it.

> Stacked on #4750 (its commit is included). Merge that first, or this carries it.

## Four declaration sites, all four changed

A field added to only three of them is how a form silently drops a value:

| site | change |
|---|---|
| `interface K3WiseSetupForm` | `materialReadPath: string` |
| `createDefaultK3WiseSetupForm` | `'/K3API/Material/GetDetail'` — byte-identical to the server template |
| validation | optional-but-relative, **same tier as Submit** |
| `buildK3WiseSetupPayloads` | emitted as `readPath` only when non-empty |

**Optional like Submit, not required like Save.** Read-back is a *verification* step; a deployment that has not enabled it must not be blocked from saving. Filled in, it must still be a relative path.

## The mirror entry is what makes this real

Adding a field proves nothing on its own. Flipping the `CORRESPONDENCE` entry from `null` to `'materialReadPath'` is what makes the **required check** assert the client value equals the server template.

| mutation | result |
|---|---|
| baseline | 3 passed |
| **read endpoint mistyped** (`/Get` vs `/GetDetail`) | **1 failed — RED** |
| **the field deleted again** | **1 failed — RED** |
| restore | 3 passed |

## Pre-existing red — measured, not assumed

`tests/k3WiseSetup.spec.ts` has **3 failures on untouched `main`**. Verified by stashing and re-running:

- failure **set** is byte-identical before and after (diff of sorted unique `FAIL` lines: **empty**)
- passing count rises **70 → 73** (the new assertions are all green)

That file sits in `apps/web/scripts/run-required-web-tests.sh`'s **quarantine list** — which is precisely why its red has gone unseen, and precisely the finding P1's survey made about this file having no required-check coverage. Fixing those three is separate work; this PR does not smuggle it in and does not add to it.

No product/server code. No flag default changed, nothing armed, nothing deployed, no external write.
