### PR TITLE
feat(integration): RATIFIED guards — material writes require the named profile; K3 replay disabled

### DIFF
--- a/docs/development/k3wise-material-list-b4-binding-draft-20260805.md
+++ b/docs/development/k3wise-material-list-b4-binding-draft-20260805.md
@@ -1,8 +1,9 @@
 # B4 绑定物草案 — K3 WISE material-list 读绑定(待 RATIFY)
 
-> 状态:**DRAFT — 待 owner RATIFY**。本文件是 S5 的批准对象;代码层冻结已由
-> `read-source-k3-material-list-b4-contract.cjs` + 其测试(链内)承载,本文只陈述与对照,
-> 不另立记录点。RATIFY 后本节头改为 RATIFIED 并注 SHA。
+> 状态:**RATIFIED — owner 2026-08-05,原文「同意 + RATIFY」**(五项清单整体批准,连同
+> replay 禁用与存量无 profile config 关死两守卫、`fieldMapDigest` 首版不加)。
+> 代码层冻结由 `read-source-k3-material-list-b4-contract.cjs` + 其测试(链内)承载,
+> 本文只陈述与对照,不另立记录点。守卫落地记录见交付计划附录 E.5。
 
 ## 1. 四参数(对应裁决点名的 profileId/configVersion/数据子集/行数上限)
 
@@ -35,11 +36,11 @@ mutation 证实偷放第二自由度即红。
 
 ## 5. RATIFY 清单(逐项可答)
 
-- [ ] profileId 下划线形 `k3wise.material_list.v1`(含对此前建议的勘误)
-- [ ] 数据子集五列 + FNumber contains_like + `Data.DATA`
-- [ ] fieldMap 仅 `FUnitID→baseUnit`
-- [ ] 读上限沿用 10/次(不另发明)
-- [ ] 两层冻结语义(模板 pin + mint 记录)
+- [x] profileId 下划线形 `k3wise.material_list.v1`(含对此前建议的勘误)
+- [x] 数据子集五列 + FNumber contains_like + `Data.DATA`
+- [x] fieldMap 仅 `FUnitID→baseUnit`
+- [x] 读上限沿用 10/次(不另发明)
+- [x] 两层冻结语义(模板 pin + mint 记录)
 
 ## 6. RATIFY 后的链路(裁决既定序)
 

--- a/docs/development/stock-preparation-k3wise-first-profile-delivery-plan-20260804.md
+++ b/docs/development/stock-preparation-k3wise-first-profile-delivery-plan-20260804.md
@@ -994,3 +994,28 @@ B.5 称「Submit/Audit 关闭是运行期不变量」——**过强**。真相:
 (ii) **fieldMapDigest 首版不加** —— `contentKeyFor` 只排除 caller version
 (`read-source-config-store.cjs:98-102`),fieldMap 逐字节已在 contentKey;resolver 现场重算比对
 (`gip-approved-binding-resolver.cjs:575-577`);另立字段=同一事实两个记录点。需要时是纯增量字段。
+
+
+### E.5 RATIFY 记录与两守卫落地(2026-08-05)
+
+owner 原文「**同意 + RATIFY**」,批准对象与随附裁项:
+
+1. **B4 绑定物**(`k3wise-material-list-b4-binding-draft-20260805.md` 五项清单)——
+   含 profileId 勘误:actionProfileVersion = `k3wise.material_list.v1`(下划线;连字符形不合
+   `PROFILE_ID_PATTERN`,预设 id 保持连字符,两语法域由合同测试双向钉死)。
+2. **Guard A(存量关死)**:K3 material upsert 一律要求命名 profile ——
+   adapter 内 Symbol 武装标记(JSON config 无法伪造),login 前拒绝
+   (`K3_WISE_MATERIAL_PROFILE_REQUIRED`,零网络副作用)。一个守卫同时关掉:
+   存量无 profile config、replay、任何未来入口的未武装写。
+3. **Guard B(replay 禁用)**:K3 目标死信 replay 在 `replayDeadLetter` 内、`runPipeline` 之前
+   fail-closed(`K3_WISE_REPLAY_DISABLED`)—— 先于任何读、任何 run 记录、任何 adapter 创建;
+   拒绝不消费死信(letter 保持 open)。首版恢复路径 = 重走 dry-run 重新人工批准。
+4. **`fieldMapDigest` 首版不加**(contentKey 已逐字节含 fieldMap;需要时纯增量)。
+
+**测试语义变换记录**(deliberate,非删除):
+- `k3-wise-apply-row-limit` 的"profile-less 无 cap"边界测试翻转为守卫拒绝断言(零网络);
+- `k3-wise-adapters` 中对象无关的写机制测试(tri-state/Submit-after-Save)迁至 BOM 对象
+  (机制逐条保留),material 专属写测试武装 profile;
+- `pipeline-runner` 新增 K3 replay 拒绝用例,以既有 mock-target replay 成功为**正控**。
+
+双守卫 mutation 双向承重(武装移除⇒正控红;判定短路⇒拒绝红)。

--- a/plugins/plugin-integration-core/__tests__/e2e-plm-k3wise-writeback.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/e2e-plm-k3wise-writeback.test.cjs
@@ -231,6 +231,7 @@ function createExternalSystemRegistry({ k3FetchMock }) {
         baseUrl: 'https://k3.example.test',
         autoSubmit: false,
         autoAudit: false,
+        objects: { material: { profile: 'material-k3wise-customer-profile-v1' } },
       },
       credentials: {
         username: 'demo',

--- a/plugins/plugin-integration-core/__tests__/http-routes-plm-k3wise-poc.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/http-routes-plm-k3wise-poc.test.cjs
@@ -612,6 +612,8 @@ async function createRouteControlPlaneScenario(routes) {
         baseUrl: 'https://k3.example.test',
         autoSubmit: false,
         autoAudit: false,
+        // RATIFIED (owner, 20260805): material writes require the named customer profile.
+        objects: { material: { profile: 'material-k3wise-customer-profile-v1' } },
       },
       credentials: {
         username: 'demo',

--- a/plugins/plugin-integration-core/__tests__/k3-wise-adapters.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/k3-wise-adapters.test.cjs
@@ -201,6 +201,24 @@ function createK3FetchMock() {
     if (parsed.pathname === '/K3API/Material/Audit') {
       return jsonResponse(200, { success: true, audited: body.Number })
     }
+    // BOM write mechanics mirror Material's (same Save/Submit/Audit shape), keyed on
+    // FParentItemNumber (the BOM keyField) instead of FNumber — BOM is NOT behind the
+    // material profile guard, so these back the "pure write-mechanics" cases migrated off
+    // material (tri-state autoSubmit/autoAudit, Submit-after-Save ordering, etc).
+    if (parsed.pathname === '/K3API/BOM/Save') {
+      const record = body.Model || body.Data
+      const parentKey = record.FParentItemNumber
+      if (parentKey === 'BAD') {
+        return jsonResponse(200, { success: false, message: 'invalid bom' })
+      }
+      return jsonResponse(200, { success: true, externalId: `item-${parentKey}`, billNo: parentKey })
+    }
+    if (parsed.pathname === '/K3API/BOM/Submit') {
+      return jsonResponse(200, { success: true, submitted: body.Number })
+    }
+    if (parsed.pathname === '/K3API/BOM/Audit') {
+      return jsonResponse(200, { success: true, audited: body.Number })
+    }
     return jsonResponse(404, { success: false, message: 'not found' })
   }
   return { calls, fetchImpl }
@@ -541,33 +559,51 @@ async function testK3WebApiAdapter() {
     },
   }, 'material reference fields preserve object values and wrap scalar values')
 
-  const upsert = await adapter.upsert({
+  // RATIFIED GUARD (owner, 20260805): a material upsert with no named customer profile must
+  // be refused before any network call — login itself never fires. Legacy/unprofiled configs
+  // hit this the first time they try to write.
+  const callsBeforeGuardRejection = calls.length
+  const guardRejection = await adapter.upsert({
     object: 'material',
-    records: [
-      { FNumber: 'MAT-001', FName: 'Bolt' },
-      { FNumber: 'BAD', FName: 'Broken' },
-    ],
+    records: [{ FNumber: 'MAT-001', FName: 'Bolt' }],
     keyFields: ['FNumber'],
+  }).catch((error) => error)
+  assert.ok(guardRejection instanceof AdapterValidationError, 'unprofiled material upsert is refused')
+  assert.equal(guardRejection.details.code, 'K3_WISE_MATERIAL_PROFILE_REQUIRED')
+  assert.equal(calls.length, callsBeforeGuardRejection, 'unprofiled material upsert makes zero K3 calls (not even login)')
+
+  // BOM is NOT behind the material profile guard, and its Save/Submit/Audit mechanism is the
+  // same as material's — this exercises the write mechanics (tri-state autoSubmit/autoAudit,
+  // Submit-after-Save ordering, body assembly) that are unrelated to material semantics.
+  const upsert = await adapter.upsert({
+    object: 'bom',
+    records: [
+      { FParentItemNumber: 'BOM-001', FChildItemNumber: 'MAT-001', FQty: 1, FUnitID: 'PCS', FEntryID: 1 },
+      { FParentItemNumber: 'BAD', FChildItemNumber: 'MAT-002', FQty: 1, FUnitID: 'PCS', FEntryID: 2 },
+    ],
+    keyFields: ['FParentItemNumber'],
   })
   assert.equal(upsert.written, 1)
   assert.equal(upsert.failed, 1)
-  assert.equal(upsert.results[0].key, 'MAT-001')
-  assert.equal(upsert.results[0].externalId, 'item-MAT-001')
-  assert.equal(upsert.results[0].billNo, 'MAT-001')
+  assert.equal(upsert.results[0].key, 'BOM-001')
+  assert.equal(upsert.results[0].externalId, 'item-BOM-001')
+  assert.equal(upsert.results[0].billNo, 'BOM-001')
   assert.equal(upsert.results[0].responseMessage, 'K3 WISE save succeeded')
   assert.equal(upsert.errors[0].code, 'K3_WISE_SAVE_FAILED')
   assert.equal(upsert.metadata.autoSubmit, true)
   assert.equal(upsert.metadata.autoAudit, true)
 
-  const saveCalls = calls.filter((call) => call.pathname === '/K3API/Material/Save')
-  const submitCalls = calls.filter((call) => call.pathname === '/K3API/Material/Submit')
-  const auditCalls = calls.filter((call) => call.pathname === '/K3API/Material/Audit')
+  const saveCalls = calls.filter((call) => call.pathname === '/K3API/BOM/Save')
+  const submitCalls = calls.filter((call) => call.pathname === '/K3API/BOM/Submit')
+  const auditCalls = calls.filter((call) => call.pathname === '/K3API/BOM/Audit')
   assert.equal(saveCalls.length, 2)
   assert.equal(submitCalls.length, 1, 'submit runs only after successful save')
   assert.equal(auditCalls.length, 1, 'audit runs only after successful save')
   assert.equal(saveCalls[0].options.headers['X-K3-Session'], 'k3-session-1')
-  assert.deepEqual(saveCalls[0].body, { Data: { FNumber: 'MAT-001', FName: 'Bolt' } })
-  assert.deepEqual(submitCalls[0].body, { Number: 'MAT-001' })
+  assert.deepEqual(saveCalls[0].body, {
+    Data: { FParentItemNumber: 'BOM-001', FChildItemNumber: 'MAT-001', FQty: 1, FUnitID: 'PCS', FEntryID: 1 },
+  })
+  assert.deepEqual(submitCalls[0].body, { Number: 'BOM-001' })
 
   const targetOnlyRead = await adapter.read({ object: 'material' }).catch((error) => error)
   assert.ok(targetOnlyRead instanceof UnsupportedAdapterOperationError, 'K3 WebAPI target rejects read')
@@ -1417,6 +1453,7 @@ async function testK3WebApiAuthorityCodeToken() {
         tokenPath: '/K3API/Token/Create',
         autoSubmit: false,
         autoAudit: false,
+        objects: { material: { profile: 'material-k3wise-customer-profile-v1' } },
       },
     }),
     fetchImpl,
@@ -1452,46 +1489,64 @@ async function testK3WebApiSaveBusinessEvidence() {
         baseUrl: 'https://k3.example.test',
         autoSubmit: false,
         autoAudit: false,
+        objects: { material: { profile: 'material-k3wise-customer-profile-v1' } },
       },
     }),
     fetchImpl,
   })
 
-  const upsert = await adapter.upsert({
+  // Split across two calls: the customer profile pins maxApplyRows=3 (K3WriteDecision), so a
+  // single 5-record batch would be refused before login. The row-level business-response
+  // parsing under test is per-row and independent of batch boundaries.
+  const upsertA = await adapter.upsert({
     object: 'material',
     records: [
       { FNumber: 'ROWOK', FName: 'Positive row' },
       { FNumber: 'ROWFAIL', FName: 'Business row fail' },
       { FNumber: 'STATUS201', FName: 'Envelope fail' },
+    ],
+    keyFields: ['FNumber'],
+  })
+  const upsertB = await adapter.upsert({
+    object: 'material',
+    records: [
       { FNumber: 'AMBIGUOUSFAIL', FName: 'Envelope-success row fail' },
       { FNumber: 'CHINESENEGFAIL', FName: 'Chinese negated success row fail' },
     ],
     keyFields: ['FNumber'],
   })
 
-  assert.equal(upsert.written, 1, 'only K3 business-positive row counts as written')
-  assert.equal(upsert.failed, 4, 'K3 row-level failures are counted as failed')
-  assert.equal(upsert.results[0].externalId, 1001, 'positive FItemID is surfaced as external id')
-  assert.equal(upsert.results[0].responseSummary.success, true)
-  assert.equal(upsert.results[0].responseSummary.externalIdPresent, true)
-  assert.equal(upsert.errors[0].code, 'K3_WISE_SAVE_FAILED')
-  assert.match(upsert.errors[0].message, /unit group/i)
-  assert.equal(upsert.errors[0].responseSummary.success, false)
-  assert.equal(upsert.errors[0].responseSummary.failedRowCount, 1)
-  assert.equal(upsert.errors[1].code, 'K3_WISE_SAVE_FAILED')
-  assert.match(upsert.errors[1].message, /required unit/i)
-  assert.equal(upsert.errors[2].code, 'K3_WISE_SAVE_FAILED')
-  assert.notEqual(upsert.errors[2].message, 'Successful')
-  assert.match(upsert.errors[2].message, /row-level success gate/i)
-  assert.match(upsert.errors[2].message, /failedRowCount=1/)
-  assert.equal(upsert.errors[2].diagnostic.validationMessage, upsert.errors[2].message)
-  assert.equal(upsert.errors[3].code, 'K3_WISE_SAVE_FAILED')
-  assert.equal(upsert.errors[3].message, '操作不成功')
-  assert.equal(upsert.errors[3].diagnostic.validationMessage, '操作不成功')
-  assert.equal(upsert.metadata.businessResponses.length, 5)
+  assert.equal(upsertA.written, 1, 'only K3 business-positive row counts as written')
+  assert.equal(upsertA.failed, 2, 'K3 row-level failures are counted as failed')
+  assert.equal(upsertB.written, 0, 'both rows in the second batch are row-level failures')
+  assert.equal(upsertB.failed, 2, 'K3 row-level failures are counted as failed')
+  assert.equal(upsertA.results[0].externalId, 1001, 'positive FItemID is surfaced as external id')
+  assert.equal(upsertA.results[0].responseSummary.success, true)
+  assert.equal(upsertA.results[0].responseSummary.externalIdPresent, true)
+  assert.equal(upsertA.errors[0].code, 'K3_WISE_SAVE_FAILED')
+  assert.match(upsertA.errors[0].message, /unit group/i)
+  assert.equal(upsertA.errors[0].responseSummary.success, false)
+  assert.equal(upsertA.errors[0].responseSummary.failedRowCount, 1)
+  assert.equal(upsertA.errors[1].code, 'K3_WISE_SAVE_FAILED')
+  assert.match(upsertA.errors[1].message, /required unit/i)
+  assert.equal(upsertB.errors[0].code, 'K3_WISE_SAVE_FAILED')
+  assert.notEqual(upsertB.errors[0].message, 'Successful')
+  assert.match(upsertB.errors[0].message, /row-level success gate/i)
+  assert.match(upsertB.errors[0].message, /failedRowCount=1/)
+  assert.equal(upsertB.errors[0].diagnostic.validationMessage, upsertB.errors[0].message)
+  assert.equal(upsertB.errors[1].code, 'K3_WISE_SAVE_FAILED')
+  assert.equal(upsertB.errors[1].message, '操作不成功')
+  assert.equal(upsertB.errors[1].diagnostic.validationMessage, '操作不成功')
+  assert.equal(upsertA.metadata.businessResponses.length, 3)
+  assert.equal(upsertB.metadata.businessResponses.length, 2)
   assert.deepEqual(
-    upsert.metadata.businessResponses.map((summary) => summary.success),
-    [true, false, false, false, false],
+    upsertA.metadata.businessResponses.map((summary) => summary.success),
+    [true, false, false],
+    'business response summaries preserve one entry per attempted save',
+  )
+  assert.deepEqual(
+    upsertB.metadata.businessResponses.map((summary) => summary.success),
+    [false, false],
     'business response summaries preserve one entry per attempted save',
   )
 }
@@ -1503,7 +1558,12 @@ async function testK3WebApiNestedDataSaveParse() {
   const { fetchImpl } = createK3FetchMock()
   const adapter = createK3WiseWebApiAdapter({
     system: createK3WebApiSystem({
-      config: { baseUrl: 'https://k3.example.test', autoSubmit: false, autoAudit: false },
+      config: {
+        baseUrl: 'https://k3.example.test',
+        autoSubmit: false,
+        autoAudit: false,
+        objects: { material: { profile: 'material-k3wise-customer-profile-v1' } },
+      },
     }),
     fetchImpl,
   })
@@ -1948,11 +2008,14 @@ async function testK3WebApiAutoFlagCoercion() {
     return { adapter, calls }
   }
 
+  // BOM is unaffected by the material profile guard and shares material's write mechanism
+  // (Save/Submit/Audit) — used here because this scenario set is about generic tri-state
+  // autoSubmit/autoAudit resolution, not material semantics.
   async function upsertOne(adapter, options = {}) {
     return adapter.upsert({
-      object: 'material',
-      records: [{ FNumber: 'MAT-COERCE-001', FName: 'Coercion test bolt' }],
-      keyFields: ['FNumber'],
+      object: 'bom',
+      records: [{ FParentItemNumber: 'BOM-COERCE-001', FChildItemNumber: 'MAT-COERCE-002', FQty: 1, FUnitID: 'PCS', FEntryID: 1 }],
+      keyFields: ['FParentItemNumber'],
       options,
     })
   }
@@ -1979,8 +2042,8 @@ async function testK3WebApiAutoFlagCoercion() {
     const upsert = await upsertOne(adapter, { autoSubmit: 'false', autoAudit: '否' })
     assert.equal(upsert.metadata.autoSubmit, false, 'request.options.autoSubmit="false" overrides config true')
     assert.equal(upsert.metadata.autoAudit, false, 'request.options.autoAudit="否" overrides config true')
-    const submitCalls = calls.filter((call) => call.pathname === '/K3API/Material/Submit')
-    const auditCalls = calls.filter((call) => call.pathname === '/K3API/Material/Audit')
+    const submitCalls = calls.filter((call) => call.pathname === '/K3API/BOM/Submit')
+    const auditCalls = calls.filter((call) => call.pathname === '/K3API/BOM/Audit')
     assert.equal(submitCalls.length, 0, 'Submit must NOT fire when operator hand-edited "false"')
     assert.equal(auditCalls.length, 0, 'Audit must NOT fire when operator hand-edited "否"')
   }

--- a/plugins/plugin-integration-core/__tests__/k3-wise-apply-row-limit.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/k3-wise-apply-row-limit.test.cjs
@@ -126,10 +126,11 @@ test('an operator overlay can neither raise nor remove the pinned cap', async ()
   assert.deepEqual(fetchPair.calls, [], 'overlay-raised cap must not open the network either')
 })
 
-test('the cap is profile-scoped by design: a profile-less material object has no cap', async () => {
-  // Documents the boundary: the cap arrives ONLY via the named profile pin. A generic
-  // template config (no `profile` key) is the pre-existing behaviour, untouched by this
-  // slice — the FE setup change is what makes the profile selection unconditional.
+test('RATIFIED FLIP: a profile-less material object cannot write AT ALL — zero network', async () => {
+  // The previous version of this test DOCUMENTED the boundary it did not endorse: no
+  // profile -> no cap, written=4. The owner ratified closing it (20260805): K3 material
+  // upsert requires the named customer profile, one guard shutting every unarmed entry
+  // (legacy stored configs, replay, future routes). Updated deliberately, not deleted.
   const fetchPair = countingFetch()
   const adapter = adapterWith(
     {
@@ -142,6 +143,10 @@ test('the cap is profile-scoped by design: a profile-less material object has no
     },
     fetchPair,
   )
-  const result = await adapter.upsert({ object: 'material', records: records(4), keyFields: ['FNumber'] })
-  assert.equal(result.written, 4, 'no profile -> no cap (this test documents the boundary, it does not endorse it)')
+  await assert.rejects(
+    adapter.upsert({ object: 'material', records: records(1), keyFields: ['FNumber'] }),
+    (error) => error.details && error.details.code === 'K3_WISE_MATERIAL_PROFILE_REQUIRED',
+    'even a single-row write must be refused without the profile',
+  )
+  assert.deepEqual(fetchPair.calls, [], 'refusal precedes login — K3 never sees the attempt')
 })

--- a/plugins/plugin-integration-core/__tests__/pipeline-runner.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/pipeline-runner.test.cjs
@@ -133,10 +133,10 @@ function createPipelineRegistry(pipeline, db) {
   }
 }
 
-function createExternalSystemRegistry({ sourceSystemKind = 'mock-source' } = {}) {
+function createExternalSystemRegistry({ sourceSystemKind = 'mock-source', targetSystemKind = 'mock-target' } = {}) {
   const systems = new Map([
     ['source_1', { id: 'source_1', name: 'PLM mock', kind: sourceSystemKind, role: 'source', config: {} }],
-    ['target_1', { id: 'target_1', name: 'ERP mock', kind: 'mock-target', role: 'target', config: {} }],
+    ['target_1', { id: 'target_1', name: 'ERP mock', kind: targetSystemKind, role: 'target', config: {} }],
   ])
   return {
     async getExternalSystem(input) {
@@ -149,7 +149,7 @@ function createExternalSystemRegistry({ sourceSystemKind = 'mock-source' } = {})
   }
 }
 
-function createRunnerHarness({ sourceRecords, pipelineOverrides = {}, sourceRead, sourceSystemKind = 'mock-source', targetUpsert, erpFeedbackWriter } = {}) {
+function createRunnerHarness({ sourceRecords, pipelineOverrides = {}, sourceRead, sourceSystemKind = 'mock-source', targetSystemKind = 'mock-target', targetUpsert, erpFeedbackWriter } = {}) {
   const db = createMockDb()
   const targetRows = new Map()
   const adapterSystems = []
@@ -231,7 +231,7 @@ function createRunnerHarness({ sourceRecords, pipelineOverrides = {}, sourceRead
   const pipelineRegistry = createPipelineRegistry(pipeline, db)
   const runner = createPipelineRunner({
     pipelineRegistry,
-    externalSystemRegistry: createExternalSystemRegistry({ sourceSystemKind }),
+    externalSystemRegistry: createExternalSystemRegistry({ sourceSystemKind, targetSystemKind }),
     adapterRegistry,
     deadLetterStore: createDeadLetterStore({ db, idGenerator: () => `dl_${db.tables.get('integration_dead_letters').length + 1}` }),
     watermarkStore: createWatermarkStore({ db }),
@@ -1211,6 +1211,36 @@ async function main() {
   // --- 6. Dead-letter status guard — already-replayed letter is rejected --
   // The first replay in scenario 5 left dl_1 in status='replayed'. A second
   // replay attempt must throw before any ERP call happens.
+  // --- RATIFIED (owner, 20260805): replay is DISABLED for K3 WISE targets ---
+  // The guard fires in replayDeadLetter BEFORE runPipeline — before any read, any run
+  // record, any adapter creation — so the unregistered K3 kind never reaches the registry.
+  // The successful replay above (mock-target) is the POSITIVE CONTROL: the refusal below is
+  // attributable to the KIND, not to replay being broken.
+  {
+    const k3Replay = createRunnerHarness({ sourceRecords: [], targetSystemKind: 'erp:k3-wise-webapi' })
+    const k3Letters = createDeadLetterStore({ db: k3Replay.db, idGenerator: () => 'dl_k3' })
+    await k3Letters.createDeadLetter({
+      tenantId: 'tenant_1',
+      workspaceId: null,
+      runId: 'run_k3',
+      pipelineId: 'pipe_1',
+      sourcePayload: { code: 'c-k3', revision: 'r1', qty: '1', name: 'K3 row', updatedAt: '2026-08-05T00:00:00.000Z' },
+      transformedPayload: null,
+      errorCode: 'VALIDATION_FAILED',
+      errorMessage: 'k3 row failed',
+    })
+    const k3Refusal = await k3Replay.runner.replayDeadLetter({
+      tenantId: 'tenant_1',
+      workspaceId: null,
+      id: 'dl_k3',
+    }).catch((error) => error)
+    assert.ok(k3Refusal instanceof Error, 'K3-target replay must refuse')
+    assert.equal(k3Refusal.details && k3Refusal.details.code, 'K3_WISE_REPLAY_DISABLED')
+    assert.equal(k3Replay.targetRows.size, 0, 'nothing may be written by a refused replay')
+    const k3LetterAfter = await k3Letters.getDeadLetter({ tenantId: 'tenant_1', workspaceId: null, id: 'dl_k3' })
+    assert.equal(k3LetterAfter.status, 'open', 'the letter stays open — refusal is not consumption')
+  }
+
   const doubleReplay = await replay.runner.replayDeadLetter({
     tenantId: 'tenant_1',
     workspaceId: null,

--- a/plugins/plugin-integration-core/lib/adapters/k3-wise-webapi-adapter.cjs
+++ b/plugins/plugin-integration-core/lib/adapters/k3-wise-webapi-adapter.cjs
@@ -49,6 +49,13 @@ class K3WiseWebApiAdapterError extends Error {
   }
 }
 
+// RATIFIED (owner, 20260805): K3 material upsert REQUIRES the named customer profile —
+// one guard closing every unarmed write entry at once (legacy stored configs with no
+// profile, replay, any future route). A Symbol marker set only by the post-merge profile
+// pin: a JSON-carried config can never forge a Symbol key, so a smuggled
+// `profileArmed: true` in operator config is inert by construction.
+const K3_PROFILE_ARMED = Symbol('k3CustomerProfileArmed')
+
 const DEFAULT_OBJECTS = getK3WiseDocumentObjectDefaults()
 const DEFAULT_MATERIAL_LIST_MAX_LIMIT = 10
 // Bounded LIST page selection (#3703, owner-approved 2026-07-06): mirrors READ_SMOKE_LIST_MAX_PAGE_INDEX
@@ -419,6 +426,7 @@ function normalizeObjects(config) {
     // `lifecycle === 'save-only'` to force autoSubmit/autoAudit off regardless of request/config.
     if (saveOnlyProfile) {
       normalized[name].lifecycle = 'save-only'
+      normalized[name][K3_PROFILE_ARMED] = true
       delete normalized[name].submitPath
       delete normalized[name].auditPath
       // HARD LOCK (K3WriteDecision): the profile's apply row cap is pinned AFTER the merge,
@@ -1991,6 +1999,17 @@ function createK3WiseWebApiAdapter({ system, fetchImpl = globalThis.fetch, logge
       throw new AdapterValidationError(`K3 WISE object is not configured: ${request.object}`, { object: request.object })
     }
     ensureOperation(normalizedSystem.kind, request.object, objectConfig, 'upsert')
+
+    // RATIFIED GUARD (owner, 20260805): a material write with NO named profile means the
+    // save-only lifecycle lock and the frozen row cap are simply not armed — refuse before
+    // anything else (before login: zero external side effects). Legacy stored configs
+    // provisioned before the profile era hit this the first time they try to write.
+    if (request.object === 'material' && objectConfig[K3_PROFILE_ARMED] !== true) {
+      throw new AdapterValidationError('K3 WISE material upsert requires the named customer profile', {
+        code: 'K3_WISE_MATERIAL_PROFILE_REQUIRED',
+        object: request.object,
+      })
+    }
 
     // HARD LOCK (M1): a save-only profile forces autoSubmit/autoAudit OFF and drops any
     // submit/audit endpoint, regardless of what request or config set. This is the lock the

--- a/plugins/plugin-integration-core/lib/pipeline-runner.cjs
+++ b/plugins/plugin-integration-core/lib/pipeline-runner.cjs
@@ -843,6 +843,30 @@ function createPipelineRunner(deps = {}) {
         reason: 'INVALID_PAYLOAD_TYPE',
       })
     }
+    // RATIFIED (owner, 20260805): dead-letter replay is DISABLED for K3 WISE targets.
+    // After the C6 content-bound approval landed, replay was the only K3 write entry that
+    // carried no approval token, and with no row-level idempotency ledger a replay is a
+    // re-write. The first-version recovery for a failed K3 row is to re-run the chain from
+    // dry-run with fresh human approval. Fail-closed HERE (before any read, any run record,
+    // any K3 session) rather than at the route, so a future second route cannot bypass it.
+    {
+      const replayPipeline = await pipelineRegistry.getPipeline({
+        tenantId: deadLetter.tenantId,
+        workspaceId: deadLetter.workspaceId,
+        id: deadLetter.pipelineId,
+      })
+      const replayTarget = replayPipeline && await loadExternalSystemForAdapter({
+        tenantId: deadLetter.tenantId,
+        workspaceId: deadLetter.workspaceId,
+        id: replayPipeline.targetSystemId,
+      })
+      if (replayTarget && replayTarget.kind === 'erp:k3-wise-webapi') {
+        throw new PipelineRunnerError('dead-letter replay is disabled for K3 WISE targets', {
+          code: 'K3_WISE_REPLAY_DISABLED',
+          id: deadLetter.id,
+        })
+      }
+    }
     const result = await runPipeline({
       tenantId: deadLetter.tenantId,
       workspaceId: deadLetter.workspaceId,

--- a/scripts/ops/fixtures/integration-k3wise/run-mock-poc-demo.mjs
+++ b/scripts/ops/fixtures/integration-k3wise/run-mock-poc-demo.mjs
@@ -92,6 +92,10 @@ async function main() {
         healthPath: '/K3API/Health',
         autoSubmit: false,
         autoAudit: false,
+        // RATIFIED (owner, 20260805): material writes require the named customer profile —
+        // the save-only lock and maxApplyRows=3 arm through it. BOM (step 6b) is out of the
+        // guard's scope and keeps the generic template.
+        objects: { material: { profile: 'material-k3wise-customer-profile-v1' } },
       },
     }
     const k3Adapter = createK3WiseWebApiAdapter({ system: k3System, fetchImpl: globalThis.fetch })


### PR DESCRIPTION
落地 owner 2026-08-05「**同意 + RATIFY**」:B4 五项 + 两守卫 + fieldMapDigest 不加。

## Guard A — material 写一律要求命名 profile

一个守卫同时关掉:**存量无 profile config、replay、任何未来入口**的未武装写。武装靠 **Symbol 标记**(仅 merge 后 profile pin 设置)—— JSON config **构造上无法伪造** Symbol 键,走私 `profileArmed:true` 天然失效。拒绝(`K3_WISE_MATERIAL_PROFILE_REQUIRED`)在 **login 之前**:零网络,K3 无感知。

## Guard B — K3 目标死信 replay 禁用

落在 `replayDeadLetter` 内、`runPipeline` **之前** —— 先于任何读、任何 run 记录、任何 adapter 创建,未来第二条路由也绕不开。拒绝**不消费**死信(保持 open)。C6 落地后 replay 是唯一不带 token 的 K3 写入口;无幂等账本时重放=重写。

## 测试语义变换(deliberate,零降级)

| 类 | 处理 |
|---|---|
| 对象无关写机制(tri-state / Submit-after-Save / body 组装) | **迁 BOM**,断言语义逐条保留 |
| material 专属写测试 | **武装 profile**;一处 5 行夹具被 cap=3 逼拆 3+2 —— **上限真咬** |
| "profile-less 无 cap" 边界测试 | 翻转为裁决拒绝(旧文本自称"记录不背书") |
| 新增 | 无 profile 写拒绝(**零网络**断言);K3 replay 拒绝(mock-target replay 成功为**正控**) |

## Mutation(各自复原)

Symbol 武装移除 → 带 profile 的正控红;守卫短路 → 拒绝测试红;replay kind 判定短路 → replay 测试红。

## 记录

B4 草案盖章 **RATIFIED**(五勾 + owner 原文);计划附录 **E.5**(守卫 + profileId 勘误确认 + 变换台账);demo step-6 武装 profile(BOM 步骤留通用模板 —— 守卫范围外,刻意)。

14/14 本地全绿(含 demo 整链与三个 fixture 套件)。