### PR TITLE
ci(stock-prep): staging window rehearsal lane — the runbook executed against a real deployed package

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -82,7 +82,9 @@ jobs:
       # its sibling mock-server test.
       - name: Run K3 WISE rehearsal harness contract tests
         run: |
-          node --test scripts/ops/fixtures/integration-k3wise/rehearsal-harness.test.mjs
+          node --test \
+            scripts/ops/fixtures/integration-k3wise/rehearsal-harness.test.mjs \
+            scripts/ops/fixtures/integration-k3wise/rehearsal-driver-contract.test.mjs
 
       - name: Run on-prem package apply and archive contract tests
         run: |

--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -173,6 +173,21 @@ jobs:
       - name: Global History flag manifest contract (R12-C)
         run: node --test scripts/ops/global-history-flag-manifest.test.mjs scripts/ops/multitable-global-history-flag-status.test.mjs
 
+      # REVIEW NIT-2 (exact-head round): these two suites already ran in `k3wise-offline-poc`, but
+      # that job's check is "K3 WISE offline PoC", which is NOT one of main's required contexts --
+      # so a red there did not block a merge. The suites carry the ONLY mechanical guard on the
+      # rehearsal driver's step predicates, including the one that discriminates the owner's
+      # reported P1. A guard that cannot block is documentation, not a gate.
+      #
+      # Invoked here as well, in the REQUIRED `test` job (test (20.x) is a required context), so
+      # the guard actually gates. The duplicate run costs ~1s and is deliberate: leaving the
+      # original in place keeps the offline-PoC job self-contained.
+      - name: K3 WISE rehearsal driver contract (required lane)
+        run: |
+          node --test \
+            scripts/ops/fixtures/integration-k3wise/rehearsal-harness.test.mjs \
+            scripts/ops/fixtures/integration-k3wise/rehearsal-driver-contract.test.mjs
+
       # Integration Guard required-wiring contract (governance slice, standalone from #4603/#4604/
       # #4610 by owner instruction; hardened 2026-07-25 after a P1x2/P2 review — see the workflow's own
       # header for the corrected rationale). Mixed YAML-shape + BEHAVIOURAL contract that makes

--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -75,6 +75,15 @@ jobs:
         run: |
           pnpm run verify:integration-k3wise:poc
 
+      # REVIEW P2-1: the rehearsal harness asserts the two guards the owner's HOLD points 3 and 4
+      # depend on (the mock's session gate, and the call logger the workflow's Submit/Audit
+      # absence-check reads). It shipped in ZERO workflows, so those guards' only behavioural
+      # evidence was ungated — a coverage regression, not a coverage gap. Gated here alongside
+      # its sibling mock-server test.
+      - name: Run K3 WISE rehearsal harness contract tests
+        run: |
+          node --test scripts/ops/fixtures/integration-k3wise/rehearsal-harness.test.mjs
+
       - name: Run on-prem package apply and archive contract tests
         run: |
           node --test \

--- a/.github/workflows/stock-prep-staging-window-rehearsal.yml
+++ b/.github/workflows/stock-prep-staging-window-rehearsal.yml
@@ -218,11 +218,23 @@ jobs:
           #   (a) the file is present in the package under test  => it is in getMigrations()
           #   (b) its name is absent from MIGRATION_EXCLUDE      => the provider did not drop it
           #   (c) Pending: 0                                     => every member has executedAt
+          # REVIEW P3-B: there is a FOURTH skip path this chain does not name —
+          # SUPERSEDED_LEGACY_SQL_MIGRATIONS, whose members run as no-op history markers and cancel
+          # out of the known-vs-considered measurement. The conclusion still holds for 074/075
+          # specifically (verified: neither is in that list), but the chain as stated was
+          # incomplete, so it is stated completely here rather than left to read as exhaustive.
           # All three together mean 074/075 executed. Remove any one and the conclusion fails --
           # which is precisely why (b) is asserted per-name rather than inferred from a count.
-          MIG_DIR="$(find . -type d -name migrations -path '*core-backend*' | head -1)"
-          if [ -z "${MIG_DIR}" ]; then
-            echo "FATAL: no core-backend migrations directory inside the package; (a) is unprovable" >&2
+          # REVIEW P2-A: `find … | head -1` picks by readdir order, and the unpacked package has TWO
+          # matching directories — packages/core-backend/migrations (the only home of 074/075) and
+          # packages/core-backend/dist/src/db/migrations (zero 07* files). Depth-first descent emits
+          # the dist one first whenever `dist` precedes `migrations` in readdir, which on the runner
+          # is an ext4 hash order — i.e. undetermined. False-red only (it can never green-light an
+          # unapplied migration), but a lane that hard-fails on a coin flip buys nothing. Address
+          # the directory that actually holds the SQL.
+          MIG_DIR="packages/core-backend/migrations"
+          if [ ! -d "${MIG_DIR}" ]; then
+            echo "FATAL: ${MIG_DIR} is not in the package; (a) is unprovable" >&2
             exit 1
           fi
           for m in 074_repair_sealed_export_runtime_authority_privileges.sql \

--- a/.github/workflows/stock-prep-staging-window-rehearsal.yml
+++ b/.github/workflows/stock-prep-staging-window-rehearsal.yml
@@ -209,14 +209,6 @@ jobs:
           TOKEN: ${{ steps.login.outputs.token }}
           MOCK_K3_URL: http://127.0.0.1:${{ env.MOCK_K3_PORT }}
           TENANT_ID: ${{ env.TENANT_ID }}
-          # THE ONE CREDENTIAL THIS LANE CANNOT MINT FOR ITSELF. Seeding the stand-in source
-          # sheet goes through the OAPI surface (requireScope('records:write')); the integration
-          # TOKEN above cannot reach it, and `staging/install` creates sheets with ZERO rows.
-          # Until this secret exists the driver exits at env validation with a named cause —
-          # deliberately, because a run that proceeded would dry-run an empty source and report
-          # a clean `sourceRows: 0`, which is a vacuous green in the one lane that exists to buy
-          # information. See the PR thread: minting it is an owner action, not this lane's.
-          MULTITABLE_RECORDS_TOKEN: ${{ secrets.REHEARSAL_MULTITABLE_RECORDS_TOKEN }}
         run: node scripts/ops/stock-prep-window-rehearsal-driver.mjs
 
       - name: Save-only invariant seen from the WIRE (mock call log — synthetic keys only)

--- a/.github/workflows/stock-prep-staging-window-rehearsal.yml
+++ b/.github/workflows/stock-prep-staging-window-rehearsal.yml
@@ -136,8 +136,30 @@ jobs:
           DATABASE_URL: postgresql://postgres:postgres@127.0.0.1:5432/rehearsal
         run: |
           set -euo pipefail
+          # PREFLIGHT A1: MEASURE the narrowing instead of asserting a literal against a literal.
+          # The provider DELETES excluded names from the map that feeds `Pending:`, so `Pending: 0`
+          # is scoped to whatever remains and cannot fail for the excluded six. Listing once with an
+          # EMPTY exclude set and once with the real one turns that invisible scope into a number
+          # produced by the runtime, and the difference must be exactly the size of the list.
+          MIGRATION_EXCLUDE= node packages/core-backend/dist/src/db/migrate.js --list \
+            | tee "${RUNNER_TEMP}/mig-unscoped.txt"
           node packages/core-backend/dist/src/db/migrate.js --list | tee "${RUNNER_TEMP}/mig-before.txt"
           grep -q "Applied: 0" "${RUNNER_TEMP}/mig-before.txt"
+
+          known="$(grep -oE '^Pending: [0-9]+' "${RUNNER_TEMP}/mig-unscoped.txt" | awk '{print $2}')"
+          considered="$(grep -oE '^Pending: [0-9]+' "${RUNNER_TEMP}/mig-before.txt" | awk '{print $2}')"
+          if [ -z "${known}" ] || [ -z "${considered}" ]; then
+            echo "FATAL: could not read a Pending count from one of the listings; an unread file is not a measurement" >&2
+            exit 1
+          fi
+          echo "migrationsKnown=${known} migrationsConsidered=${considered} migrationsSkippedByName=$((known - considered))"
+          if [ "$((known - considered))" -ne 6 ]; then
+            echo "FATAL: the runtime skipped $((known - considered)) migrations by name, but MIGRATION_EXCLUDE names 6; the scope of Pending:0 is not what this lane claims" >&2
+            exit 1
+          fi
+          # And say so IN THE EVIDENCE, so the artifact bundle carries the narrowing rather than
+          # leaving a reader to infer "full migration set" from a bare `Pending: 0`.
+          echo "migrationScope=CI_EXCLUDED_6 customerOnPremRunsAll=true"
           node packages/core-backend/dist/src/db/migrate.js
           node packages/core-backend/dist/src/db/migrate.js --list | tee "${RUNNER_TEMP}/mig-after.txt"
           # `Pending: 0` ALONE IS A FALSE GREEN HERE. This step inherits the workflow-level
@@ -284,6 +306,7 @@ jobs:
           echo "loginTokenObtained=PASS"
 
       - name: RUN THE WINDOW RUNBOOK over HTTP (the rehearsal proper)
+        id: runbook
         env:
           BASE_URL: http://127.0.0.1:${{ env.REHEARSAL_PORT }}
           TOKEN: ${{ steps.login.outputs.token }}
@@ -304,8 +327,26 @@ jobs:
           save_calls="$(grep -c "K3CALL POST /K3API/Material/Save" "${RUNNER_TEMP}/mock-k3.log" || true)"
           echo "wireGetListCallsLogged=${get_list_calls:-0}"
           echo "wireSaveCallsLogged=${save_calls:-0}"
+          # PREFLIGHT B1: this step is `if: always()`, and the runbook step had no `id:`, so the
+          # positive control could not tell "the logger is broken" from "the driver never got this
+          # far". 10 of the driver's 17 gates precede the first GetList and 13 precede the first
+          # Save, and record() hard-exits on the first failure — so ANY early failure produced a
+          # louder, more specific, WRONG diagnosis blaming the mock's logger, on the line right
+          # after printing GetList=1. It accused a subsystem that is provably innocent
+          # (mock-k3-webapi-server.mjs logs every request before the session gate and before
+          # routing) and contradicted data it had just printed itself.
+          #
+          # The positive control is only meaningful when the runbook actually reached those calls.
+          if [ "${{ steps.runbook.outcome }}" != "success" ]; then
+            echo "wirePositiveControlSkipped=runbook-did-not-complete (outcome=${{ steps.runbook.outcome }})"
+            echo "The runbook step failed before or during the rehearsal; the FAILED STEP ABOVE and" >&2
+            echo "REHEARSAL_SUMMARY name the actual failed gate. Counts above are informational only:" >&2
+            echo "an absent GetList/Save here means the driver never got that far, NOT that the mock" >&2
+            echo "stopped logging." >&2
+            exit 1
+          fi
           if [ "${get_list_calls:-0}" -lt 1 ] || [ "${save_calls:-0}" -lt 1 ]; then
-            echo "FATAL: positive control failed — mock-k3.log shows GetList=${get_list_calls:-0} Save=${save_calls:-0} K3CALL lines; the log is not actually recording wire calls, so the Submit/Audit absence check below would be meaningless" >&2
+            echo "FATAL: the runbook SUCCEEDED but mock-k3.log shows GetList=${get_list_calls:-0} Save=${save_calls:-0} K3CALL lines; the log is not actually recording wire calls, so the Submit/Audit absence check below would be meaningless" >&2
             exit 1
           fi
           # POSITIVE ALLOWLIST, not a two-word denylist. The old check was
@@ -341,6 +382,7 @@ jobs:
             ${{ runner.temp }}/backend.log
             ${{ runner.temp }}/mock-k3.log
             ${{ runner.temp }}/mig-before.txt
+            ${{ runner.temp }}/mig-unscoped.txt
             ${{ runner.temp }}/mig-after.txt
           if-no-files-found: error
           retention-days: 7

--- a/.github/workflows/stock-prep-staging-window-rehearsal.yml
+++ b/.github/workflows/stock-prep-staging-window-rehearsal.yml
@@ -140,6 +140,25 @@ jobs:
           grep -q "Applied: 0" "${RUNNER_TEMP}/mig-before.txt"
           node packages/core-backend/dist/src/db/migrate.js
           node packages/core-backend/dist/src/db/migrate.js --list | tee "${RUNNER_TEMP}/mig-after.txt"
+          # `Pending: 0` ALONE IS A FALSE GREEN HERE. This step inherits the workflow-level
+          # MIGRATION_EXCLUDE, and the provider REMOVES excluded names from the very map that feeds
+          # the Pending count — so for those six migrations the assertion CANNOT fail, whatever
+          # happened. Measured 311 known vs 305 considered; three of the six have real bodies that
+          # this repo's own S6A lane still lists as open defects.
+          #
+          # Keep the exclusion (deliberate, separately tracked) but make it VISIBLE, so the evidence
+          # reads "6 excluded by name" rather than "nothing pending", and so the list cannot grow
+          # silently under a green check.
+          EXPECTED_EXCLUDES=6
+          ACTUAL_EXCLUDES="$(printf '%s' "${MIGRATION_EXCLUDE}" | tr ',' '\n' | grep -c . || true)"
+          echo "migrationExcludeCount=${ACTUAL_EXCLUDES} expected=${EXPECTED_EXCLUDES}"
+          if [ "${ACTUAL_EXCLUDES}" -ne "${EXPECTED_EXCLUDES}" ]; then
+            echo "MIGRATION_EXCLUDE changed size; Pending:0 is scoped to whatever remains, so this needs re-review rather than auto-accept" >&2
+            exit 1
+          fi
+          # POSITIVE CONTROL for the grep itself: the capture must actually contain a Pending line,
+          # so an empty or truncated file cannot read as "0 pending".
+          grep -qE "^Pending: [0-9]+" "${RUNNER_TEMP}/mig-after.txt"
           grep -q "Pending: 0" "${RUNNER_TEMP}/mig-after.txt"
 
       - name: Bootstrap the admin principal (recipe step 5 — login is proven later, not here)
@@ -228,10 +247,28 @@ jobs:
             echo "FATAL: positive control failed — mock-k3.log shows GetList=${get_list_calls:-0} Save=${save_calls:-0} K3CALL lines; the log is not actually recording wire calls, so the Submit/Audit absence check below would be meaningless" >&2
             exit 1
           fi
-          if grep -qE "K3CALL POST /K3API/Material/(Submit|Audit)" "${RUNNER_TEMP}/mock-k3.log"; then
-            echo "FATAL: the wire saw a Submit/Audit call — save-only was violated end to end" >&2
+          # POSITIVE ALLOWLIST, not a two-word denylist. The old check was
+          # `/K3API/Material/(Submit|Audit)` — pinned to ONE object and TWO verbs, so
+          # `/K3API/BOM/Submit` and `/K3API/BOM/Audit` sailed past while it printed PASS. Six
+          # lifecycle calls escaped it in one measured run. Denylists have unbounded complements;
+          # this lane makes a SMALL, KNOWN set of calls, so enumerate what is allowed and treat
+          # everything else as a violation. Same lesson the endpoint guard learned over eight
+          # escape axes.
+          allowed='^K3CALL (POST|GET) /K3API/(Login|Token/Create|Health|Material/(GetList|GetDetail|Save))/?$'
+          unexpected="$(grep -E "^K3CALL " "${RUNNER_TEMP}/mock-k3.log" | grep -vE "${allowed}" || true)"
+          if [ -n "${unexpected}" ]; then
+            echo "FATAL: the wire saw a call outside the save-only allowlist:" >&2
+            printf '%s\n' "${unexpected}" >&2
             exit 1
           fi
+          # POSITIVE CONTROL for the allowlist itself: it must REJECT a lifecycle write on any
+          # object, not just Material. Without this, a typo in the pattern silently allows all.
+          for probe in "K3CALL POST /K3API/Material/Submit" "K3CALL POST /K3API/BOM/Submit" "K3CALL POST /K3API/BOM/Audit"; do
+            if printf '%s\n' "${probe}" | grep -qE "${allowed}"; then
+              echo "FATAL: the allowlist accepts '${probe}' — it cannot detect a save-only violation" >&2
+              exit 1
+            fi
+          done
           echo "wireSaveOnly=PASS"
 
       - name: Upload boot/backend logs (synthetic environment only)

--- a/.github/workflows/stock-prep-staging-window-rehearsal.yml
+++ b/.github/workflows/stock-prep-staging-window-rehearsal.yml
@@ -265,11 +265,27 @@ jobs:
         run: |
           set -euo pipefail
           BASE="http://127.0.0.1:${REHEARSAL_PORT}"
+          # PREFLIGHT B3: nothing checked that the child SURVIVED. On an instant boot crash
+          # (missing dist entry, a throw before listen) connection-refused returns in ~0 ms, so the
+          # loop burned all 60 iterations x sleep 2 = two minutes before failing — and the stack
+          # trace sat in backend.log, which this workflow never printed (grep showed exactly two
+          # references: the redirect and the upload path). Root-causing a boot crash meant waiting
+          # out the timeout and then downloading an artifact.
+          BACKEND_PID="$(cat "${RUNNER_TEMP}/backend.pid")"
           for i in $(seq 1 60); do
             curl -fsS "$BASE/health" >/dev/null 2>&1 && break
+            if ! kill -0 "${BACKEND_PID}" 2>/dev/null; then
+              echo "the backend process exited during boot (pid ${BACKEND_PID} is gone) — not waiting out the timeout" >&2
+              break
+            fi
             sleep 2
           done
-          curl -fsS "$BASE/health" >/dev/null
+          if ! curl -fsS "$BASE/health" >/dev/null 2>&1; then
+            echo "--- backend.log (last 200 lines) ---" >&2
+            tail -n 200 "${RUNNER_TEMP}/backend.log" >&2 || echo "(no backend.log was produced)" >&2
+            echo "------------------------------------" >&2
+            exit 1
+          fi
           curl -fsS "$BASE/api/plugins" | node -e '
             const d = JSON.parse(require("fs").readFileSync(0, "utf8"));
             const p = (d.list || []).find((x) => x.name === "plugin-integration-core");
@@ -312,7 +328,32 @@ jobs:
           TOKEN: ${{ steps.login.outputs.token }}
           MOCK_K3_URL: http://127.0.0.1:${{ env.MOCK_K3_PORT }}
           TENANT_ID: ${{ env.TENANT_ID }}
-        run: node scripts/ops/stock-prep-window-rehearsal-driver.mjs
+        run: |
+          # PREFLIGHT B2: `run: node driver.mjs | tee log` WITHOUT pipefail is FAIL-OPEN — tee's
+          # exit code wins and the driver's process.exit(1) is masked, turning every failed gate
+          # into a green step. The block form with `set -o pipefail` is what makes the capture safe.
+          set -euo pipefail
+          node scripts/ops/stock-prep-window-rehearsal-driver.mjs \
+            | tee "${RUNNER_TEMP}/rehearsal.log"
+
+      - name: Surface REHEARSAL_SUMMARY (the lane's primary evidence)
+        if: always()
+        run: |
+          set -euo pipefail
+          # This one line carries every per-step count (sourceRows/add/written/failed/held/errorCode)
+          # AND the `sourceLeg: stand-in` caveat. It previously lived only in job scrollback, so the
+          # curated bundle a reviewer archives did not contain the lane's own verdict.
+          if [ -f "${RUNNER_TEMP}/rehearsal.log" ]; then
+            {
+              echo '## Rehearsal summary'
+              echo '```json'
+              grep '^REHEARSAL_SUMMARY=' "${RUNNER_TEMP}/rehearsal.log" | sed 's/^REHEARSAL_SUMMARY=//' || \
+                echo '{"note":"the driver produced no REHEARSAL_SUMMARY — it died before its own summary line"}'
+              echo '```'
+            } >> "${GITHUB_STEP_SUMMARY}"
+          else
+            echo "the runbook step produced no log at all (it did not start)" >> "${GITHUB_STEP_SUMMARY}"
+          fi
 
       - name: Save-only invariant seen from the WIRE (mock call log — synthetic keys only)
         if: always()
@@ -383,6 +424,7 @@ jobs:
             ${{ runner.temp }}/mock-k3.log
             ${{ runner.temp }}/mig-before.txt
             ${{ runner.temp }}/mig-unscoped.txt
+            ${{ runner.temp }}/rehearsal.log
             ${{ runner.temp }}/mig-after.txt
           if-no-files-found: error
           retention-days: 7

--- a/.github/workflows/stock-prep-staging-window-rehearsal.yml
+++ b/.github/workflows/stock-prep-staging-window-rehearsal.yml
@@ -215,7 +215,20 @@ jobs:
         if: always()
         run: |
           set -euo pipefail
-          if grep -qE "/K3API/Material/(Submit|Audit)" "${RUNNER_TEMP}/mock-k3.log"; then
+          # Owner review (point E): the mock's stdout log used to carry NOTHING per-call, so the
+          # Submit/Audit absence check below always passed — vacuously, on an empty stream, not
+          # because save-only actually held. POSITIVE CONTROL FIRST: prove the log is really
+          # recording calls (run-mock-k3-server.mjs now wires a `K3CALL <METHOD> <pathname>`
+          # logger) before trusting an absence-based assertion built on top of it.
+          get_list_calls="$(grep -c "K3CALL POST /K3API/Material/GetList" "${RUNNER_TEMP}/mock-k3.log" || true)"
+          save_calls="$(grep -c "K3CALL POST /K3API/Material/Save" "${RUNNER_TEMP}/mock-k3.log" || true)"
+          echo "wireGetListCallsLogged=${get_list_calls:-0}"
+          echo "wireSaveCallsLogged=${save_calls:-0}"
+          if [ "${get_list_calls:-0}" -lt 1 ] || [ "${save_calls:-0}" -lt 1 ]; then
+            echo "FATAL: positive control failed — mock-k3.log shows GetList=${get_list_calls:-0} Save=${save_calls:-0} K3CALL lines; the log is not actually recording wire calls, so the Submit/Audit absence check below would be meaningless" >&2
+            exit 1
+          fi
+          if grep -qE "K3CALL POST /K3API/Material/(Submit|Audit)" "${RUNNER_TEMP}/mock-k3.log"; then
             echo "FATAL: the wire saw a Submit/Audit call — save-only was violated end to end" >&2
             exit 1
           fi

--- a/.github/workflows/stock-prep-staging-window-rehearsal.yml
+++ b/.github/workflows/stock-prep-staging-window-rehearsal.yml
@@ -209,6 +209,14 @@ jobs:
           TOKEN: ${{ steps.login.outputs.token }}
           MOCK_K3_URL: http://127.0.0.1:${{ env.MOCK_K3_PORT }}
           TENANT_ID: ${{ env.TENANT_ID }}
+          # THE ONE CREDENTIAL THIS LANE CANNOT MINT FOR ITSELF. Seeding the stand-in source
+          # sheet goes through the OAPI surface (requireScope('records:write')); the integration
+          # TOKEN above cannot reach it, and `staging/install` creates sheets with ZERO rows.
+          # Until this secret exists the driver exits at env validation with a named cause —
+          # deliberately, because a run that proceeded would dry-run an empty source and report
+          # a clean `sourceRows: 0`, which is a vacuous green in the one lane that exists to buy
+          # information. See the PR thread: minting it is an owner action, not this lane's.
+          MULTITABLE_RECORDS_TOKEN: ${{ secrets.REHEARSAL_MULTITABLE_RECORDS_TOKEN }}
         run: node scripts/ops/stock-prep-window-rehearsal-driver.mjs
 
       - name: Save-only invariant seen from the WIRE (mock call log — synthetic keys only)

--- a/.github/workflows/stock-prep-staging-window-rehearsal.yml
+++ b/.github/workflows/stock-prep-staging-window-rehearsal.yml
@@ -1,0 +1,242 @@
+name: Stock-prep staging window rehearsal (ephemeral substrate)
+
+# OWNER AUTHORIZATION (2026-08-05, verbatim 「授权 staging 部署」). Substrate: the ephemeral-CI
+# variant, per the discretion the proposal reserved (「临时全新库是更干净的预演底座」) — a REAL
+# deployed package, REAL HTTP, REAL PostgreSQL 17 (the customer's major version), with the
+# in-repo mock K3 at the far end of the wire. This rehearses the entity-machine window runbook
+# end to end so first-run failures burn HERE, not in the one-shot customer window.
+#
+# mock pass != rehearsal pass != customer live pass — three layers, each honest.
+#
+# What this workflow NEVER does: publish a release (permissions: contents: read — structural),
+# touch the frozen S6-A lane, reference any MULTITABLE_* flag, reach any customer host, or
+# reach the shared long-lived staging host. Everything lives and dies inside this run.
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: stock-prep-staging-window-rehearsal
+  cancel-in-progress: false
+
+env:
+  # Single source for every probe URL (three defaults exist in the wild: code 7778, template
+  # 8900, healthcheck 8900 — deriving everything from ONE variable avoids the triad footgun).
+  REHEARSAL_PORT: '8931'
+  MOCK_K3_PORT: '8977'
+  TENANT_ID: tenant_rehearsal
+  ADMIN_EMAIL: rehearsal-admin@ci.invalid
+  # CI-synthetic secrets for an ephemeral, run-scoped environment. Not real credentials.
+  ADMIN_PASSWORD: rehearsal-admin-pass-1
+  JWT_SECRET: rehearsal-ci-synthetic-jwt-secret-0123456789abcdef
+  # Verbatim the verified lane's exclusion list (stock-prep-main-package-verify.yml — its
+  # standalone drift-guard job pins this list against migration-replay.yml, so the ONE source
+  # of truth is guarded there; this workflow borrows the value, not the guard).
+  MIGRATION_EXCLUDE: 008_plugin_infrastructure.sql,048_create_event_bus_tables.sql,049_create_bpmn_workflow_tables.sql,042a_core_model_views.sql,20250924140000_create_gantt_tables.ts,zzzz20260114110000_create_user_orgs_table.ts
+
+jobs:
+  rehearse:
+    name: Build package, boot it, run the window runbook over HTTP
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: rehearsal
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d rehearsal"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9.15.9
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - name: Ensure psql (admin bootstrap hard-requires it; runners do not guarantee it)
+        run: command -v psql >/dev/null 2>&1 || (sudo apt-get update -qq && sudo apt-get install -y -qq postgresql-client)
+
+      - name: Install repo deps
+        run: pnpm install --frozen-lockfile
+
+      - name: Build web/backend dist
+        run: |
+          pnpm --filter @metasheet/web build
+          pnpm --filter @metasheet/core-backend build
+
+      - name: Build the on-prem package (artifact of THIS commit)
+        id: pkg
+        env:
+          PACKAGE_TAG: rehearsal${{ github.run_number }}
+        run: |
+          set -euo pipefail
+          chmod +x scripts/ops/multitable-onprem-package-build.sh scripts/ops/multitable-onprem-package-verify.sh
+          INSTALL_DEPS=0 BUILD_WEB=0 BUILD_BACKEND=0 scripts/ops/multitable-onprem-package-build.sh
+          out_dir="output/releases/multitable-onprem"
+          pkg_tgz="$(ls -1 ${out_dir}/*.tgz | sort | tail -n 1)"
+          scripts/ops/multitable-onprem-package-verify.sh "$pkg_tgz"
+          echo "pkg_tgz=${pkg_tgz}" >> "$GITHUB_OUTPUT"
+          echo "packageVerify=PASS"
+
+      - name: Unpack the package (recipe step 1)
+        id: unpack
+        run: |
+          set -euo pipefail
+          mkdir -p "${RUNNER_TEMP}/pkgroot"
+          tar -xzf "${{ steps.pkg.outputs.pkg_tgz }}" -C "${RUNNER_TEMP}/pkgroot"
+          PKG_ROOT="$(find "${RUNNER_TEMP}/pkgroot" -mindepth 1 -maxdepth 1 -type d -print -quit)"
+          test -n "$PKG_ROOT"
+          chmod +x "$PKG_ROOT/scripts/ops/"*.sh
+          echo "pkg_root=${PKG_ROOT}" >> "$GITHUB_OUTPUT"
+
+      - name: In-package dependency install (recipe step 2 — nodeModulesBundled=false by design)
+        working-directory: ${{ steps.unpack.outputs.pkg_root }}
+        run: pnpm install --frozen-lockfile --reporter=append-only
+
+      - name: Compose the env file (recipe step 3; overrides appended LAST so they win on source)
+        run: |
+          set -euo pipefail
+          PKG_ROOT="${{ steps.unpack.outputs.pkg_root }}"
+          cp "$PKG_ROOT/docker/app.env.multitable-onprem.template" "$PKG_ROOT/docker/app.env"
+          {
+            echo ""
+            echo "# --- rehearsal overrides (run-scoped, synthetic) ---"
+            echo "PORT=${REHEARSAL_PORT}"
+            echo "HOST=127.0.0.1"
+            echo "JWT_SECRET=${JWT_SECRET}"
+            echo "POSTGRES_PASSWORD=postgres"
+            echo "DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5432/rehearsal"
+            echo "BCRYPT_SALT_ROUNDS=12"
+            echo "ATTENDANCE_IMPORT_REQUIRE_TOKEN=1"
+            echo "UPLOAD_DIR=${RUNNER_TEMP}/uploads"
+          } >> "$PKG_ROOT/docker/app.env"
+          mkdir -p "${RUNNER_TEMP}/uploads"
+
+      - name: Migrations on the fresh PG 17 (recipe step 4 — Applied:0 before, Pending:0 after)
+        working-directory: ${{ steps.unpack.outputs.pkg_root }}
+        env:
+          DATABASE_URL: postgresql://postgres:postgres@127.0.0.1:5432/rehearsal
+        run: |
+          set -euo pipefail
+          node packages/core-backend/dist/src/db/migrate.js --list | tee "${RUNNER_TEMP}/mig-before.txt"
+          grep -q "Applied: 0" "${RUNNER_TEMP}/mig-before.txt"
+          node packages/core-backend/dist/src/db/migrate.js
+          node packages/core-backend/dist/src/db/migrate.js --list | tee "${RUNNER_TEMP}/mig-after.txt"
+          grep -q "Pending: 0" "${RUNNER_TEMP}/mig-after.txt"
+
+      - name: Bootstrap the admin principal (recipe step 5 — login is proven later, not here)
+        working-directory: ${{ steps.unpack.outputs.pkg_root }}
+        run: |
+          set -euo pipefail
+          env ENV_FILE="${{ steps.unpack.outputs.pkg_root }}/docker/app.env" \
+              ADMIN_EMAIL="${ADMIN_EMAIL}" ADMIN_PASSWORD="${ADMIN_PASSWORD}" \
+              ADMIN_NAME="CI Rehearsal Admin" VERIFY_LOGIN=0 \
+              scripts/ops/attendance-onprem-bootstrap-admin.sh
+
+      - name: Start the backend FROM THE PACKAGE ROOT (recipe step 6 — plugin discovery is cwd-relative)
+        working-directory: ${{ steps.unpack.outputs.pkg_root }}
+        run: |
+          set -euo pipefail
+          set -a; . ./docker/app.env; set +a
+          nohup node packages/core-backend/dist/src/index.js > "${RUNNER_TEMP}/backend.log" 2>&1 &
+          echo $! > "${RUNNER_TEMP}/backend.pid"
+
+      - name: Readiness — health AND plugin-integration-core ACTIVE (recipe step 7; activation failure is silent at the HTTP layer)
+        run: |
+          set -euo pipefail
+          BASE="http://127.0.0.1:${REHEARSAL_PORT}"
+          for i in $(seq 1 60); do
+            curl -fsS "$BASE/health" >/dev/null 2>&1 && break
+            sleep 2
+          done
+          curl -fsS "$BASE/health" >/dev/null
+          curl -fsS "$BASE/api/plugins" | node -e '
+            const d = JSON.parse(require("fs").readFileSync(0, "utf8"));
+            const p = (d.list || []).find((x) => x.name === "plugin-integration-core");
+            if (!p) { console.error("plugin-integration-core NOT LOADED"); process.exit(1); }
+            console.log("integrationPluginStatus=" + p.status);
+            if (p.status !== "active") { console.error(p.error || "not active"); process.exit(1); }'
+
+      - name: Start the mock K3 far end (from the repo checkout, seeded source catalogue)
+        run: |
+          set -euo pipefail
+          MOCK_K3_PORT="${MOCK_K3_PORT}" nohup node scripts/ops/fixtures/integration-k3wise/run-mock-k3-server.mjs \
+            > "${RUNNER_TEMP}/mock-k3.log" 2>&1 &
+          echo $! > "${RUNNER_TEMP}/mock-k3.pid"
+          for i in $(seq 1 20); do
+            grep -q "MOCK_K3_BASE_URL=" "${RUNNER_TEMP}/mock-k3.log" && break
+            sleep 1
+          done
+          grep "MOCK_K3_BASE_URL=" "${RUNNER_TEMP}/mock-k3.log"
+
+      - name: Login for the write principal's token (recipe step 8 — token via login, never minted)
+        id: login
+        run: |
+          set -euo pipefail
+          BASE="http://127.0.0.1:${REHEARSAL_PORT}"
+          LOGIN_JSON="$(curl -fsS -X POST "$BASE/api/auth/login" -H 'Content-Type: application/json' \
+            --data "{\"email\":\"${ADMIN_EMAIL}\",\"password\":\"${ADMIN_PASSWORD}\"}")"
+          TOKEN="$(printf '%s' "$LOGIN_JSON" | node -e '
+            const d = JSON.parse(require("fs").readFileSync(0, "utf8"));
+            const t = (d && d.data && d.data.token) || d.token || "";
+            if (!t) { console.error("no token in login response"); process.exit(1); }
+            process.stdout.write(t);')"
+          echo "::add-mask::$TOKEN"
+          echo "token=${TOKEN}" >> "$GITHUB_OUTPUT"
+          echo "loginTokenObtained=PASS"
+
+      - name: RUN THE WINDOW RUNBOOK over HTTP (the rehearsal proper)
+        env:
+          BASE_URL: http://127.0.0.1:${{ env.REHEARSAL_PORT }}
+          TOKEN: ${{ steps.login.outputs.token }}
+          MOCK_K3_URL: http://127.0.0.1:${{ env.MOCK_K3_PORT }}
+          TENANT_ID: ${{ env.TENANT_ID }}
+        run: node scripts/ops/stock-prep-window-rehearsal-driver.mjs
+
+      - name: Save-only invariant seen from the WIRE (mock call log — synthetic keys only)
+        if: always()
+        run: |
+          set -euo pipefail
+          if grep -qE "/K3API/Material/(Submit|Audit)" "${RUNNER_TEMP}/mock-k3.log"; then
+            echo "FATAL: the wire saw a Submit/Audit call — save-only was violated end to end" >&2
+            exit 1
+          fi
+          echo "wireSaveOnly=PASS"
+
+      - name: Upload boot/backend logs (synthetic environment only)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: rehearsal-logs-${{ github.run_number }}
+          path: |
+            ${{ runner.temp }}/backend.log
+            ${{ runner.temp }}/mock-k3.log
+            ${{ runner.temp }}/mig-before.txt
+            ${{ runner.temp }}/mig-after.txt
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Teardown
+        if: always()
+        run: |
+          [ -f "${RUNNER_TEMP}/backend.pid" ] && kill "$(cat "${RUNNER_TEMP}/backend.pid")" 2>/dev/null || true
+          [ -f "${RUNNER_TEMP}/mock-k3.pid" ] && kill "$(cat "${RUNNER_TEMP}/mock-k3.pid")" 2>/dev/null || true
+          true

--- a/.github/workflows/stock-prep-staging-window-rehearsal.yml
+++ b/.github/workflows/stock-prep-staging-window-rehearsal.yml
@@ -149,13 +149,74 @@ jobs:
           # Keep the exclusion (deliberate, separately tracked) but make it VISIBLE, so the evidence
           # reads "6 excluded by name" rather than "nothing pending", and so the list cannot grow
           # silently under a green check.
-          EXPECTED_EXCLUDES=6
-          ACTUAL_EXCLUDES="$(printf '%s' "${MIGRATION_EXCLUDE}" | tr ',' '\n' | grep -c . || true)"
-          echo "migrationExcludeCount=${ACTUAL_EXCLUDES} expected=${EXPECTED_EXCLUDES}"
-          if [ "${ACTUAL_EXCLUDES}" -ne "${EXPECTED_EXCLUDES}" ]; then
-            echo "MIGRATION_EXCLUDE changed size; Pending:0 is scoped to whatever remains, so this needs re-review rather than auto-accept" >&2
+          # REVIEW P1 (owner round 20260806): a COUNT is not a SET. This asserted only
+          # "six names", so swapping 048 for 074 kept the count at 6 and every check green --
+          # while 074 was removed from the very map that feeds Pending, making `Pending: 0` true
+          # WITHOUT 074 ever running. Equal-size substitution was the hole; exact set equality
+          # against the authoritative list is the close.
+          #
+          # The list's ONE source of truth is migration-replay.yml (the main-package-verify lane
+          # pins itself against it byte-for-byte in its own drift-guard job). This lane previously
+          # "borrowed the value, not the guard" -- it now borrows the guard too.
+          #
+          # NOTE the path: this step's working-directory is the UNPACKED PACKAGE, not the repo, so
+          # the authoritative file must be addressed through github.workspace. A relative path
+          # would silently read nothing and this check would pass vacuously -- the exact failure
+          # mode it exists to prevent.
+          REPLAY_FILE="${{ github.workspace }}/.github/workflows/migration-replay.yml"
+          if [ ! -f "${REPLAY_FILE}" ]; then
+            echo "FATAL: ${REPLAY_FILE} not found; the exclusion check would read empty and pass vacuously" >&2
             exit 1
           fi
+          AUTHORITATIVE="$(grep -E '^[[:space:]]*MIGRATION_EXCLUDE:[[:space:]]' "${REPLAY_FILE}" \
+            | grep -vE '^[[:space:]]*#' \
+            | sed -E 's/^[[:space:]]*MIGRATION_EXCLUDE:[[:space:]]*//' \
+            | sed -E 's/[[:space:]]+$//' | sort -u)"
+          if [ -z "${AUTHORITATIVE}" ]; then
+            echo "FATAL: extracted an EMPTY authoritative list; an empty read is not agreement" >&2
+            exit 1
+          fi
+          # migration-replay.yml carries the identical value on two lines; `sort -u` collapses
+          # them, so anything but exactly one distinct value means the source itself disagrees.
+          DISTINCT="$(printf '%s\n' "${AUTHORITATIVE}" | grep -c .)"
+          if [ "${DISTINCT}" -ne 1 ]; then
+            echo "FATAL: migration-replay.yml holds ${DISTINCT} DIFFERENT MIGRATION_EXCLUDE values; no single authority to compare against" >&2
+            exit 1
+          fi
+          if [ "${AUTHORITATIVE}" != "${MIGRATION_EXCLUDE}" ]; then
+            echo "MIGRATION_EXCLUDE drifted from migration-replay.yml (exact set equality required)" >&2
+            echo "  authoritative: ${AUTHORITATIVE}" >&2
+            echo "  this lane:     ${MIGRATION_EXCLUDE}" >&2
+            exit 1
+          fi
+          echo "migrationExcludeMatchesAuthority=true"
+
+          # And prove the two migrations this lane's evidence depends on were CONSIDERED and RAN.
+          # `--list` names only PENDING migrations, so "applied" is established by construction:
+          #   (a) the file is present in the package under test  => it is in getMigrations()
+          #   (b) its name is absent from MIGRATION_EXCLUDE      => the provider did not drop it
+          #   (c) Pending: 0                                     => every member has executedAt
+          # All three together mean 074/075 executed. Remove any one and the conclusion fails --
+          # which is precisely why (b) is asserted per-name rather than inferred from a count.
+          MIG_DIR="$(find . -type d -name migrations -path '*core-backend*' | head -1)"
+          if [ -z "${MIG_DIR}" ]; then
+            echo "FATAL: no core-backend migrations directory inside the package; (a) is unprovable" >&2
+            exit 1
+          fi
+          for m in 074_repair_sealed_export_runtime_authority_privileges.sql \
+                   075_grant_sealed_export_runtime_authority_row_lock.sql; do
+            if [ ! -f "${MIG_DIR}/${m}" ]; then
+              echo "FATAL: ${m} is not in the package under test" >&2
+              exit 1
+            fi
+            case ",${MIGRATION_EXCLUDE}," in
+              *",${m},"*)
+                echo "FATAL: ${m} is EXCLUDED, so Pending:0 would NOT prove it ran" >&2
+                exit 1
+                ;;
+            esac
+            echo "migrationProvenApplied=${m}"
+          done
           # POSITIVE CONTROL for the grep itself: the capture must actually contain a Pending line,
           # so an empty or truncated file cannot read as "0 pending".
           grep -qE "^Pending: [0-9]+" "${RUNNER_TEMP}/mig-after.txt"

--- a/plugins/plugin-integration-core/__tests__/http-routes-plm-k3wise-poc.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/http-routes-plm-k3wise-poc.test.cjs
@@ -944,14 +944,18 @@ async function assertB4ScopeIsWiredThroughTheRoute() {
 
   const related = await dryRunWith((sc) => [ratifiedRow({ systemId: sc.pipeline.sourceSystemId })])
   const relatedDetails = ((related.res.body && related.res.body.error) || {}).details || {}
-  // REVIEW P3-1: this anti-vacuity assertion was ITSELF vacuous. `bindingCount` is attached at
-  // exactly one site (k3-wise-c6-write-profile.cjs, on C6_WRITE_B4_BINDING_REQUIRED only), and the
-  // measured object here is `{code:'K3_C6_B4_BINDING_KIND_MISMATCH', field:'capabilityState'}` —
-  // so it was `notEqual(undefined, 0)`, true by absence. The notEqual family again: it cannot tell
-  // "counted" from "this shape has no such field". Assert the code that is actually produced.
-  assert.equal(relatedDetails.code, 'K3_C6_B4_BINDING_KIND_MISMATCH',
-    'a binding on the PLM source must reach the kind gate — which proves it was COUNTED by the '
-    + `relation check rather than filtered out earlier; got: ${JSON.stringify(relatedDetails)}`)
+  // NIT (review r4): the replacement assertion I put here was a VERBATIM DUPLICATE of case (6) —
+  // same helper, same argument, same expected code — so neutering the kind gate fails at case (6)
+  // and never reaches this line: zero marginal coverage. Removed rather than left as decoration.
+  //
+  // The property it was meant to carry (a binding on a real pipeline endpoint is COUNTED by the
+  // relation check rather than filtered out earlier) is already carried by the PAIR that exists:
+  // case (2) asserts bindingCount === 0 for an unrelated system, case (6) shows a real endpoint's
+  // binding reaching the kind gate. Both intact.
+  //
+  // The assertion this replaced was itself vacuous — `notEqual(relatedDetails.bindingCount, 0)`
+  // where the measured object has no bindingCount at all, i.e. notEqual(undefined, 0), true by
+  // absence. The notEqual family again.
 }
 
 async function main() {

--- a/plugins/plugin-integration-core/__tests__/http-routes-plm-k3wise-poc.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/http-routes-plm-k3wise-poc.test.cjs
@@ -887,10 +887,28 @@ async function assertB4ScopeIsWiredThroughTheRoute() {
     { pairedReadBaseUrl: 'https://k3.example.test/K3API-READ' },
   )
   const pairedSameErr = ((pairedSameInstance.res.body && pairedSameInstance.res.body.error) || {}).details || {}
-  assert.notEqual(pairedSameErr.code, 'K3_C6_B4_BINDING_INSTANCE_MISMATCH',
-    `a binding on the paired read record of the SAME K3 must be accepted, got: ${JSON.stringify(pairedSameErr)}`)
-  assert.notEqual(pairedSameErr.code, 'C6_WRITE_B4_BINDING_REQUIRED',
-    'the paired read record must COUNT toward the relation check, or B4 can never bind the real reader')
+  // POSITIVE EQUALITY, not a list of `notEqual`s. "It is not error X" cannot distinguish
+  // "succeeded" from "failed for some other reason", and that is precisely how the #4784
+  // regression survived: the owner's review flipped `targetSystem.kind` to `targetSystem.role` at
+  // BOTH real C6 handlers and every suite stayed green, because every assertion here was of the
+  // not-this-particular-error family.
+  //
+  // K3_WISE_READ_FAILED is the RIGHT answer for this fixture: the plan cleared the B4 gate, the
+  // kind gate, the same-instance gate AND credential resolution, then made a real wire call to the
+  // paired read record's baseUrl, which the K3 fetch mock does not serve. Reaching a wire error is
+  // therefore proof that credentials were resolved.
+  //
+  // THIS IS ALSO THE REAL-ROUTE COVERAGE FOR #4784. Measured, not asserted:
+  //     baseline          -> K3_WISE_READ_FAILED        (adapter accessor, credentials present)
+  //     .kind -> .role    -> K3_WISE_CREDENTIALS_MISSING (public accessor strips them)
+  // The merged #4784 fix previously had only source-text regex plus a test-local reimplementation
+  // of the selection logic, so it protected nothing.
+  assert.equal(pairedSameErr.code, 'K3_WISE_READ_FAILED',
+    'the same-K3 paired read binding must clear every gate AND resolve credentials, reaching the '
+    + `wire; got: ${JSON.stringify(pairedSameErr)}`)
+  assert.notEqual(pairedSameErr.code, 'K3_WISE_CREDENTIALS_MISSING',
+    'an adapter-backed C6 target must be re-loaded through getExternalSystemForAdapter (#4784) — '
+    + 'the public accessor strips credentials and the adapter dies before any wire call')
 
   // A -> B: read record on a DIFFERENT K3 host. MUST BE REFUSED. This is the case the old
   // arrangement was structurally incapable of producing at all.

--- a/plugins/plugin-integration-core/__tests__/http-routes-plm-k3wise-poc.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/http-routes-plm-k3wise-poc.test.cjs
@@ -925,10 +925,21 @@ async function assertB4ScopeIsWiredThroughTheRoute() {
   // breaks when the wiring is gone is the LEGITIMATE case — a binding on the K3 TARGET, the
   // same physical instance, must be ACCEPTED. Mutation N3 (http-routes stops passing
   // targetBaseUrl) is RED on this assertion and only this one.
+  //
+  // D1 (20260806): this case's INTENT is now inverted, and the inversion is the point. Binding on
+  // the TARGET used to be the only arrangement that satisfied the relation check, so it had to be
+  // accepted — which is exactly why the gate degenerated into comparing the target with itself.
+  // Now that the real read record can be bound (via targetSystem.config.pairedReadSystemId), a
+  // self-referential binding is REFUSED, and that refusal is the invariant.
+  //
+  // Asserted as a POSITIVE equality: the old `notEqual(…, INSTANCE_MISMATCH)` still passes against
+  // the new behaviour (SELF_REFERENTIAL is also "not INSTANCE_MISMATCH"), so it would have recorded
+  // a silent semantic inversion as a pass. Same defect family as #4784.
   const sameInstance = await dryRunWith((sc) => [ratifiedRow({ systemId: sc.pipeline.targetSystemId })])
   const sameErr = ((sameInstance.res.body && sameInstance.res.body.error) || {})
-  assert.notEqual(sameErr.details && sameErr.details.code, 'K3_C6_B4_BINDING_INSTANCE_MISMATCH',
-    'a binding on the K3 TARGET is the same physical K3 and must NOT be refused as cross-instance')
+  assert.equal(sameErr.details && sameErr.details.code, 'K3_C6_B4_BINDING_SELF_REFERENTIAL',
+    'a binding on the write target ITSELF must be refused — a record cannot certify its own '
+    + `instance; got: ${JSON.stringify(sameErr)}`)
 
   const related = await dryRunWith((sc) => [ratifiedRow({ systemId: sc.pipeline.sourceSystemId })])
   const relatedDetails = ((related.res.body && related.res.body.error) || {}).details || {}

--- a/plugins/plugin-integration-core/__tests__/http-routes-plm-k3wise-poc.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/http-routes-plm-k3wise-poc.test.cjs
@@ -836,6 +836,29 @@ async function assertB4ScopeIsWiredThroughTheRoute() {
   // only as a shape guard; the line above is what carries the property.
   assert.notEqual(spoofed.res.statusCode, 200, 'and it must not succeed (vacuous here — see above)')
 
+  // (6) SAME-INSTANCE, THROUGH THE ROUTE. Mutation N3 exposed this gap: http-routes stopped
+  // passing `targetBaseUrl` and BOTH suites stayed green — the check was tested, its WIRING was
+  // not. Fifth occurrence of that pattern on this line.
+  //
+  // The witness is exact: a B4 row bound to the PLM SOURCE passes #4769's relation check (the
+  // source IS a pipeline endpoint), so only the same-instance check can stop it — and it must,
+  // because PLM is not the K3 being written. This is the round-3 defect in its newest disguise:
+  // one system's read contract certifying another system's write.
+  const crossInstance = await dryRunWith((sc) => [ratifiedRow({ systemId: sc.pipeline.sourceSystemId })])
+  const crossErr = ((crossInstance.res.body && crossInstance.res.body.error) || {})
+  assert.equal(crossErr.details && crossErr.details.code, 'K3_C6_B4_BINDING_INSTANCE_MISMATCH',
+    `a binding on the PLM source must be refused as a different K3 instance, got: ${JSON.stringify(crossErr)}`)
+
+  // (7) THE DISCRIMINATING HALF. (6) alone does not prove the wiring: with `targetBaseUrl`
+  // missing, sameK3Instance('') is false, so the gate throws MORE and (6) still passes. What
+  // breaks when the wiring is gone is the LEGITIMATE case — a binding on the K3 TARGET, the
+  // same physical instance, must be ACCEPTED. Mutation N3 (http-routes stops passing
+  // targetBaseUrl) is RED on this assertion and only this one.
+  const sameInstance = await dryRunWith((sc) => [ratifiedRow({ systemId: sc.pipeline.targetSystemId })])
+  const sameErr = ((sameInstance.res.body && sameInstance.res.body.error) || {})
+  assert.notEqual(sameErr.details && sameErr.details.code, 'K3_C6_B4_BINDING_INSTANCE_MISMATCH',
+    'a binding on the K3 TARGET is the same physical K3 and must NOT be refused as cross-instance')
+
   const related = await dryRunWith((sc) => [ratifiedRow({ systemId: sc.pipeline.sourceSystemId })])
   const relatedDetails = ((related.res.body && related.res.body.error) || {}).details || {}
   assert.notEqual(relatedDetails.bindingCount, 0,

--- a/plugins/plugin-integration-core/__tests__/http-routes-plm-k3wise-poc.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/http-routes-plm-k3wise-poc.test.cjs
@@ -706,7 +706,7 @@ async function assertB4ScopeIsWiredThroughTheRoute() {
   }
 
   // `rows` is what the store returns; `listArgs` records what the ROUTE asked for.
-  async function dryRunWith(rows, { requestWorkspaceId } = {}) {
+  async function dryRunWith(rows, { requestWorkspaceId, pairedReadBaseUrl } = {}) {
     const listArgs = []
     const harness = createHarness({
       readSourceConfigStore: {
@@ -734,6 +734,15 @@ async function assertB4ScopeIsWiredThroughTheRoute() {
     const plm = await mkSystem({
       name: 'PLM probe', kind: 'plm:yuantus-wrapper', role: 'source', status: 'active', config: {},
     })
+    // OWNER REVIEW 20260806 [P1]: the real customer topology is THREE records — a staging/PLM
+    // source, a K3 READ record, and a K3 WRITE target. Without the read record in this harness the
+    // same-instance check could only ever be handed the target twice, which is exactly how it came
+    // to compare the target with itself and pass.
+    const k3Read = pairedReadBaseUrl === undefined ? null : await mkSystem({
+      name: 'K3 read probe', kind: 'erp:k3-wise-webapi', role: 'source', status: 'active',
+      config: { baseUrl: pairedReadBaseUrl },
+      credentials: { username: 'demo', password: 'secret', acctId: '001' },
+    })
     const k3 = await mkSystem({
       name: 'K3 probe', kind: 'erp:k3-wise-webapi', role: 'target', status: 'active',
       config: {
@@ -741,6 +750,7 @@ async function assertB4ScopeIsWiredThroughTheRoute() {
         autoSubmit: false,
         autoAudit: false,
         objects: { material: { profile: 'material-k3wise-customer-profile-v1' } },
+        ...(k3Read ? { pairedReadSystemId: k3Read.id } : {}),
       },
       credentials: { username: 'demo', password: 'secret', acctId: '001' },
     })
@@ -762,7 +772,7 @@ async function assertB4ScopeIsWiredThroughTheRoute() {
     assertOkResponse(mkPipeline, 201)
     assert.equal(mkPipeline.body.data.workspaceId, PROBE_WORKSPACE_ID,
       'the probe pipeline must be workspace-scoped, or the workspaceId assertion cannot discriminate')
-    const harnessScenario = { plm, k3, pipeline: mkPipeline.body.data }
+    const harnessScenario = { plm, k3, k3Read, pipeline: mkPipeline.body.data }
     const res = await invoke(harness.routes, 'POST', '/api/integration/pipelines/:id/external-write/dry-run', {
       user: WRITE_USER,
       params: { id: mkPipeline.body.data.id },
@@ -844,10 +854,53 @@ async function assertB4ScopeIsWiredThroughTheRoute() {
   // source IS a pipeline endpoint), so only the same-instance check can stop it — and it must,
   // because PLM is not the K3 being written. This is the round-3 defect in its newest disguise:
   // one system's read contract certifying another system's write.
+  //
+  // EXACT-HEAD REVIEW P2-2 — why this now expects KIND, not INSTANCE. The reviewer showed this
+  // assertion was passing for the WRONG REASON: the PLM fixture carries `config: {}`, so
+  // `boundBaseUrl` was null and the gate took its "cannot tell" branch. It never exercised the
+  // "different instance" branch its own message named. Worse, the reviewer gave the PLM source a
+  // baseUrl SHARING the K3 target's origin and the binding was ACCEPTED — a PLM read contract
+  // certified the K3 write, failing only later at the read with a misleading 404. Origin equality
+  // says nothing about WHAT is at that origin, and on-prem PLM and K3 routinely share a host.
+  //
+  // The guard now checks the bound record's `kind` first, so a PLM binding is refused for being
+  // PLM — which is both the true reason and the one that still holds when the origins match.
   const crossInstance = await dryRunWith((sc) => [ratifiedRow({ systemId: sc.pipeline.sourceSystemId })])
   const crossErr = ((crossInstance.res.body && crossInstance.res.body.error) || {})
-  assert.equal(crossErr.details && crossErr.details.code, 'K3_C6_B4_BINDING_INSTANCE_MISMATCH',
-    `a binding on the PLM source must be refused as a different K3 instance, got: ${JSON.stringify(crossErr)}`)
+  assert.equal(crossErr.details && crossErr.details.code, 'K3_C6_B4_BINDING_KIND_MISMATCH',
+    `a binding on the PLM source must be refused because it is not a K3 record, got: ${JSON.stringify(crossErr)}`)
+
+  // (6b) OWNER REVIEW 20260806 [P1] — THE READ/WRITE COMPARISON ITSELF.
+  //
+  // Everything above binds B4 to the TARGET, which is how the check came to compare the target
+  // with itself: the driver made a separate K3 read record, minted B4 on the target, and the route
+  // loaded targetBaseUrl from that same target — so no read record ever entered the comparison and
+  // two different K3 instances would have passed. These two cases bind B4 to the REAL READ RECORD
+  // (admitted by the relation check because the target declares it as pairedReadSystemId) so the
+  // guard compares two GENUINELY DIFFERENT records.
+  //
+  // A -> A: read and write on the same physical K3 (same origin, different path — the step 0-b
+  // topology). MUST BE ACCEPTED. Without this control the negative case below could be satisfied
+  // by a guard that simply refuses everything.
+  const pairedSameInstance = await dryRunWith(
+    (sc) => [ratifiedRow({ systemId: sc.k3Read.id })],
+    { pairedReadBaseUrl: 'https://k3.example.test/K3API-READ' },
+  )
+  const pairedSameErr = ((pairedSameInstance.res.body && pairedSameInstance.res.body.error) || {}).details || {}
+  assert.notEqual(pairedSameErr.code, 'K3_C6_B4_BINDING_INSTANCE_MISMATCH',
+    `a binding on the paired read record of the SAME K3 must be accepted, got: ${JSON.stringify(pairedSameErr)}`)
+  assert.notEqual(pairedSameErr.code, 'C6_WRITE_B4_BINDING_REQUIRED',
+    'the paired read record must COUNT toward the relation check, or B4 can never bind the real reader')
+
+  // A -> B: read record on a DIFFERENT K3 host. MUST BE REFUSED. This is the case the old
+  // arrangement was structurally incapable of producing at all.
+  const crossK3 = await dryRunWith(
+    (sc) => [ratifiedRow({ systemId: sc.k3Read.id })],
+    { pairedReadBaseUrl: 'https://k3-OTHER.example.test/K3API' },
+  )
+  const crossK3Err = ((crossK3.res.body && crossK3.res.body.error) || {}).details || {}
+  assert.equal(crossK3Err.code, 'K3_C6_B4_BINDING_INSTANCE_MISMATCH',
+    `a read record on ANOTHER K3 must not certify this write, got: ${JSON.stringify(crossK3Err)}`)
 
   // (7) THE DISCRIMINATING HALF. (6) alone does not prove the wiring: with `targetBaseUrl`
   // missing, sameK3Instance('') is false, so the gate throws MORE and (6) still passes. What

--- a/plugins/plugin-integration-core/__tests__/http-routes-plm-k3wise-poc.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/http-routes-plm-k3wise-poc.test.cjs
@@ -919,11 +919,13 @@ async function assertB4ScopeIsWiredThroughTheRoute() {
   assert.equal(crossK3Err.code, 'K3_C6_B4_BINDING_INSTANCE_MISMATCH',
     `a read record on ANOTHER K3 must not certify this write, got: ${JSON.stringify(crossK3Err)}`)
 
-  // (7) THE DISCRIMINATING HALF. (6) alone does not prove the wiring: with `targetBaseUrl`
-  // missing, sameK3Instance('') is false, so the gate throws MORE and (6) still passes. What
-  // breaks when the wiring is gone is the LEGITIMATE case — a binding on the K3 TARGET, the
-  // same physical instance, must be ACCEPTED. Mutation N3 (http-routes stops passing
-  // targetBaseUrl) is RED on this assertion and only this one.
+  // (7) SELF-REFERENCE IS REFUSED.
+  //
+  // NIT (review r3): the attribution that used to sit here was stale. It said "mutation N3 is RED
+  // on this assertion and only this one", but SELF_REFERENTIAL now throws BEFORE `targetBaseUrl`
+  // is ever read, so N3 cannot reach it. Measured: N3 is RED on case 6b
+  // (INSTANCE_MISMATCH where K3_WISE_READ_FAILED was expected). Coverage is intact; the comment
+  // was pointing at the wrong case.
   //
   // D1 (20260806): this case's INTENT is now inverted, and the inversion is the point. Binding on
   // the TARGET used to be the only arrangement that satisfied the relation check, so it had to be
@@ -942,8 +944,14 @@ async function assertB4ScopeIsWiredThroughTheRoute() {
 
   const related = await dryRunWith((sc) => [ratifiedRow({ systemId: sc.pipeline.sourceSystemId })])
   const relatedDetails = ((related.res.body && related.res.body.error) || {}).details || {}
-  assert.notEqual(relatedDetails.bindingCount, 0,
-    'a binding on a real pipeline endpoint MUST be counted — otherwise the check above passes vacuously')
+  // REVIEW P3-1: this anti-vacuity assertion was ITSELF vacuous. `bindingCount` is attached at
+  // exactly one site (k3-wise-c6-write-profile.cjs, on C6_WRITE_B4_BINDING_REQUIRED only), and the
+  // measured object here is `{code:'K3_C6_B4_BINDING_KIND_MISMATCH', field:'capabilityState'}` —
+  // so it was `notEqual(undefined, 0)`, true by absence. The notEqual family again: it cannot tell
+  // "counted" from "this shape has no such field". Assert the code that is actually produced.
+  assert.equal(relatedDetails.code, 'K3_C6_B4_BINDING_KIND_MISMATCH',
+    'a binding on the PLM source must reach the kind gate — which proves it was COUNTED by the '
+    + `relation check rather than filtered out earlier; got: ${JSON.stringify(relatedDetails)}`)
 }
 
 async function main() {

--- a/plugins/plugin-integration-core/__tests__/http-routes-plm-k3wise-poc.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/http-routes-plm-k3wise-poc.test.cjs
@@ -906,9 +906,8 @@ async function assertB4ScopeIsWiredThroughTheRoute() {
   assert.equal(pairedSameErr.code, 'K3_WISE_READ_FAILED',
     'the same-K3 paired read binding must clear every gate AND resolve credentials, reaching the '
     + `wire; got: ${JSON.stringify(pairedSameErr)}`)
-  assert.notEqual(pairedSameErr.code, 'K3_WISE_CREDENTIALS_MISSING',
-    'an adapter-backed C6 target must be re-loaded through getExternalSystemForAdapter (#4784) — '
-    + 'the public accessor strips credentials and the adapter dies before any wire call')
+  // (the equality above already pins this value; a following notEqual on the same value adds
+  // nothing and reads as if it were an independent check — #4784's guarantee rides the equality)
 
   // A -> B: read record on a DIFFERENT K3 host. MUST BE REFUSED. This is the case the old
   // arrangement was structurally incapable of producing at all.

--- a/plugins/plugin-integration-core/__tests__/k3-wise-c6-write-profile.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/k3-wise-c6-write-profile.test.cjs
@@ -623,14 +623,17 @@ test('SAME-INSTANCE: a B4 binding naming a DIFFERENT K3 instance is refused', as
   const tokenStore = memoryStore()
   const fetchPair = mockK3()
 
-  async function planWith(boundBaseUrl) {
+  // `boundKind` defaults to the real K3 kind so the ORIGIN cases below still exercise the origin
+  // comparison. Review P2-2: this fixture previously returned no `kind` at all, which is exactly
+  // why the gap was invisible from here — the fixture was more permissive than production.
+  async function planWith(boundBaseUrl, boundKind = 'erp:k3-wise-webapi') {
     const input = c6Inputs({ rows: [{ code: 'M-INST', name: 'N' }], fetchPair, tokenStore: memoryStore() })
     input.dataSourceWrites = createK3WiseC6WriteSource({
       system: k3TargetSystem(),
       createAdapter: (system) => createK3WiseWebApiAdapter({ system, fetchImpl: fetchPair.impl }),
       b4: b4Of([APPROVED_B4_ROW], {
         targetBaseUrl: 'https://k3.example.test/K3API',
-        loadSystemById: async () => ({ id: 'k3-read-1', config: { baseUrl: boundBaseUrl } }),
+        loadSystemById: async () => ({ id: 'k3-read-1', kind: boundKind, config: { baseUrl: boundBaseUrl } }),
       }),
     })
     return dryRunExternalWrite(input)
@@ -654,6 +657,29 @@ test('SAME-INSTANCE: a B4 binding naming a DIFFERENT K3 instance is refused', as
     planWith(null),
     (error) => (error && error.details && error.details.code) === 'K3_C6_B4_BINDING_INSTANCE_MISMATCH',
     '"cannot tell" must never read as "same instance"',
+  )
+
+  // REVIEW P2-2 — the defect this test NAMED but did not detect. Origin equality says nothing
+  // about WHAT is at that origin, and the guard never looked at the bound record's kind. An
+  // independent reviewer proved it by giving the poc harness's PLM source a baseUrl sharing the
+  // K3 target's origin: a PLM read contract certified the K3 write, and the run failed only
+  // later at the read with a misleading K3_WISE_READ_FAILED/404. Reachable on-prem whenever PLM
+  // and K3 sit behind one host — the normal deployment.
+  //
+  // Note this case is SAME-ORIGIN on purpose: it must be refused for its KIND, which means the
+  // origin comparison cannot be what rejects it. That is what makes this a discriminating case
+  // rather than a second spelling of the host-mismatch case above.
+  await assert.rejects(
+    planWith('https://k3.example.test/plm-api', 'plm:yuantus-wrapper'),
+    (error) => (error && error.details && error.details.code) === 'K3_C6_B4_BINDING_KIND_MISMATCH',
+    'a same-origin NON-K3 record must not certify a K3 write',
+  )
+
+  // FAIL-CLOSED on a missing kind (an older record, or a projection that omits it).
+  await assert.rejects(
+    planWith('https://k3.example.test/K3API', null),
+    (error) => (error && error.details && error.details.code) === 'K3_C6_B4_BINDING_KIND_MISMATCH',
+    'an absent kind must never read as "it is a K3"',
   )
 })
 

--- a/plugins/plugin-integration-core/__tests__/k3-wise-c6-write-profile.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/k3-wise-c6-write-profile.test.cjs
@@ -587,6 +587,34 @@ test('B4 GATE: two approved bindings -> refused (ambiguous is fail-closed, never
   )
 })
 
+test('SAME-INSTANCE: the fail-closed branch is load-bearing (review P2-1)', () => {
+  // The `catch { return false }` in sameK3Instance had NO coverage: flipping it to `return true`
+  // left 27/27 green. "Cannot tell" silently became "same instance" — the exact inversion a
+  // fail-closed comparator exists to prevent.
+  const { __internals } = require('../lib/adapters/k3-wise-c6-write-profile.cjs')
+  const same = __internals && __internals.sameK3Instance
+  assert.equal(typeof same, 'function', 'sameK3Instance must be reachable to be tested')
+
+  // Unparseable / absent / wrong-typed must all be NON-matches.
+  for (const [a, b, why] of [
+    ['not a url', 'https://k3.example.test', 'unparseable left'],
+    ['https://k3.example.test', 'not a url', 'unparseable right'],
+    [null, 'https://k3.example.test', 'null left'],
+    ['https://k3.example.test', undefined, 'undefined right'],
+    ['', 'https://k3.example.test', 'empty left'],
+    [42, 'https://k3.example.test', 'non-string left'],
+  ]) {
+    assert.equal(same(a, b), false, `${why} must NOT read as the same instance`)
+  }
+
+  // POSITIVE CONTROL — real same/different origins still classify correctly, so the above is
+  // not just "returns false for everything".
+  assert.equal(same('https://k3.example.test/K3API', 'https://k3.example.test/OTHER'), true,
+    'same origin, different path — the step 0-b topology — must match')
+  assert.equal(same('https://k3-a.example.test', 'https://k3-b.example.test'), false,
+    'different hosts must not match')
+})
+
 test('SAME-INSTANCE: a B4 binding naming a DIFFERENT K3 instance is refused', async () => {
   // Owner ruling 20260805 (「A, bind B4 to the K3-write record」). Binding to the target is what
   // satisfies #4769's relation check once the pipeline source is no longer K3 — but it is only

--- a/plugins/plugin-integration-core/__tests__/k3-wise-c6-write-profile.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/k3-wise-c6-write-profile.test.cjs
@@ -587,6 +587,48 @@ test('B4 GATE: two approved bindings -> refused (ambiguous is fail-closed, never
   )
 })
 
+test('SAME-INSTANCE: a B4 binding naming a DIFFERENT K3 instance is refused', async () => {
+  // Owner ruling 20260805 (「A, bind B4 to the K3-write record」). Binding to the target is what
+  // satisfies #4769's relation check once the pipeline source is no longer K3 — but it is only
+  // TRUE while both K3 records address the same physical K3. Without this check, one K3's read
+  // contract could certify a DIFFERENT K3's write: the round-3 defect, one level down.
+  const tokenStore = memoryStore()
+  const fetchPair = mockK3()
+
+  async function planWith(boundBaseUrl) {
+    const input = c6Inputs({ rows: [{ code: 'M-INST', name: 'N' }], fetchPair, tokenStore: memoryStore() })
+    input.dataSourceWrites = createK3WiseC6WriteSource({
+      system: k3TargetSystem(),
+      createAdapter: (system) => createK3WiseWebApiAdapter({ system, fetchImpl: fetchPair.impl }),
+      b4: b4Of([APPROVED_B4_ROW], {
+        targetBaseUrl: 'https://k3.example.test/K3API',
+        loadSystemById: async () => ({ id: 'k3-read-1', config: { baseUrl: boundBaseUrl } }),
+      }),
+    })
+    return dryRunExternalWrite(input)
+  }
+
+  // DIFFERENT host — must be refused.
+  await assert.rejects(
+    planWith('https://OTHER-k3.example.test/K3API'),
+    (error) => (error && error.details && error.details.code) === 'K3_C6_B4_BINDING_INSTANCE_MISMATCH',
+    'a binding on another K3 instance must not certify this write',
+  )
+
+  // POSITIVE CONTROL — same origin, DIFFERENT PATH. This is exactly the step 0-b topology (the
+  // armed record is pinned to its own endpoints), so a raw string compare would have rejected
+  // the only arrangement that actually works. Origin-level comparison is deliberate.
+  const plan = await planWith('https://k3.example.test/K3API-READ')
+  assert.ok(plan, 'same physical K3 on a different path must still be accepted')
+
+  // FAIL-CLOSED on unknowable: an unresolvable system is not a match.
+  await assert.rejects(
+    planWith(null),
+    (error) => (error && error.details && error.details.code) === 'K3_C6_B4_BINDING_INSTANCE_MISMATCH',
+    '"cannot tell" must never read as "same instance"',
+  )
+})
+
 test('REVIEW P3-2: a FULL page of approved configs is a refusal, not a silent pass', async () => {
   // `list()` gives no ordering guarantee, so a full page may be truncated — and a truncated set
   // can hide the second approved binding that the ambiguity check above exists to catch. A full

--- a/plugins/plugin-integration-core/lib/adapters/k3-wise-c6-write-profile.cjs
+++ b/plugins/plugin-integration-core/lib/adapters/k3-wise-c6-write-profile.cjs
@@ -97,6 +97,20 @@ function b4RowMatchesRatifiedContract(row) {
   return row.contentKey === expected
 }
 
+// Two K3 external-system records are the SAME PHYSICAL K3 when their baseUrls share an origin.
+// Compared at ORIGIN level on purpose: the read record and the write record legitimately differ
+// in PATH (the armed one is pinned to its own endpoints), so a raw string compare would reject
+// the very topology step 0-b requires. An unparseable or absent baseUrl is NOT a match —
+// fail-closed, because "cannot tell" must never read as "same".
+function sameK3Instance(a, b) {
+  if (typeof a !== 'string' || typeof b !== 'string' || !a || !b) return false
+  try {
+    return new URL(a).origin === new URL(b).origin
+  } catch {
+    return false
+  }
+}
+
 function requiredString(value, field) {
   if (typeof value !== 'string' || value.trim().length === 0) {
     throw new AdapterValidationError(`${field} is required`, { field })
@@ -326,6 +340,33 @@ function createK3WiseC6WriteSource({ system, createAdapter, b4 } = {}) {
       const profile = CUSTOMER_PROFILE
       const bindings = await resolveApprovedB4Binding()
       const binding = bindings.length === 1 ? bindings[0] : null
+      // SAME-INSTANCE CHECK. `binding` may legitimately name a DIFFERENT external-system record
+      // than the write target: the B4 contract is the material-LIST read contract, and a
+      // profile-armed record cannot hold list-read config (#4769 strips every readList* key,
+      // even from the frozen first-party preset), so the customer runs two K3 records. Binding
+      // to the target record is what satisfies the relation check — but that is only TRUE while
+      // both records address the same physical K3.
+      //
+      // Without this, "bind to the target" silently permits one K3's read contract to certify a
+      // DIFFERENT K3's write: the round-3 defect, reopened one level down. Fail-closed by
+      // construction — it can only reject bindings the relation check already accepted.
+      if (binding && typeof b4.loadSystemById === 'function') {
+        const boundSystemId = binding.config && binding.config.systemId
+        const targetBaseUrl = typeof b4.targetBaseUrl === 'string' ? b4.targetBaseUrl : ''
+        let boundBaseUrl = null
+        try {
+          const boundSystem = await b4.loadSystemById(boundSystemId)
+          boundBaseUrl = boundSystem && boundSystem.config ? boundSystem.config.baseUrl : null
+        } catch {
+          boundBaseUrl = null
+        }
+        if (!sameK3Instance(boundBaseUrl, targetBaseUrl)) {
+          throw new AdapterValidationError(
+            'the approved B4 binding names a different K3 instance than the write target',
+            { code: 'K3_C6_B4_BINDING_INSTANCE_MISMATCH', field: 'capabilityState' },
+          )
+        }
+      }
       return {
         success: true,
         capabilityState: {

--- a/plugins/plugin-integration-core/lib/adapters/k3-wise-c6-write-profile.cjs
+++ b/plugins/plugin-integration-core/lib/adapters/k3-wise-c6-write-profile.cjs
@@ -352,6 +352,23 @@ function createK3WiseC6WriteSource({ system, createAdapter, b4 } = {}) {
       // construction — it can only reject bindings the relation check already accepted.
       if (binding && typeof b4.loadSystemById === 'function') {
         const boundSystemId = binding.config && binding.config.systemId
+        // D1 — THE INVARIANT, not just the convention. Making it POSSIBLE to bind the real read
+        // record (targetSystem.config.pairedReadSystemId joining the relation set) and switching
+        // the driver to do so changed what we DO; it did not change what is ACCEPTED.
+        // `pipelineSystemIds` is a UNION and still contains targetSystemId, the filter only asks
+        // "is it a member", and nothing anywhere asserted the bound id differs from the target.
+        // So a binding minted on the TARGET still passed, loadSystemById returned the very row
+        // that produced targetBaseUrl, and sameK3Instance(x, x) was tautologically true —
+        // the owner's original defect, still a green path.
+        //
+        // Refusing self-reference is what turns "the driver happens to bind the reader" into
+        // "the gate cannot be satisfied by comparing a record with itself".
+        if (typeof boundSystemId === 'string' && boundSystemId === system.id) {
+          throw new AdapterValidationError(
+            'the approved B4 binding names the write target itself; a record cannot certify its own instance',
+            { code: 'K3_C6_B4_BINDING_SELF_REFERENTIAL', field: 'capabilityState' },
+          )
+        }
         const targetBaseUrl = typeof b4.targetBaseUrl === 'string' ? b4.targetBaseUrl : ''
         let boundBaseUrl = null
         let boundKind = null

--- a/plugins/plugin-integration-core/lib/adapters/k3-wise-c6-write-profile.cjs
+++ b/plugins/plugin-integration-core/lib/adapters/k3-wise-c6-write-profile.cjs
@@ -487,4 +487,8 @@ module.exports = {
   K3_WISE_C6_WRITE_PROFILE,
   createK3WiseC6WriteSource,
   deriveK3WiseC6PlannerTargetConfig,
+  // Test surface only. `sameK3Instance`'s fail-closed catch branch had no coverage — flipping it
+  // to `return true` left the whole suite green, i.e. "cannot tell" silently became "same
+  // instance". A guard whose failure mode is invisible is not a guard.
+  __internals: { sameK3Instance },
 }

--- a/plugins/plugin-integration-core/lib/adapters/k3-wise-c6-write-profile.cjs
+++ b/plugins/plugin-integration-core/lib/adapters/k3-wise-c6-write-profile.cjs
@@ -354,11 +354,30 @@ function createK3WiseC6WriteSource({ system, createAdapter, b4 } = {}) {
         const boundSystemId = binding.config && binding.config.systemId
         const targetBaseUrl = typeof b4.targetBaseUrl === 'string' ? b4.targetBaseUrl : ''
         let boundBaseUrl = null
+        let boundKind = null
         try {
           const boundSystem = await b4.loadSystemById(boundSystemId)
           boundBaseUrl = boundSystem && boundSystem.config ? boundSystem.config.baseUrl : null
+          boundKind = boundSystem ? boundSystem.kind : null
         } catch {
           boundBaseUrl = null
+          boundKind = null
+        }
+        // REVIEW P2-2 (exact-head round): origin equality was the SOLE discriminator, and origin
+        // says nothing about WHAT is at that origin. The reviewer proved it by construction --
+        // giving the poc harness's PLM source a baseUrl sharing the K3 target's origin let a PLM
+        // read contract certify a K3 write; the run only failed later, at the read, with a
+        // misleading K3_WISE_READ_FAILED/404. On-prem this is reachable whenever PLM and K3 sit
+        // behind one host, which is the normal deployment.
+        //
+        // The comment below already SAID this guard was about one K3 versus another K3 -- it just
+        // never checked that the bound record was a K3 at all. Asserting the kind is what makes
+        // the stated invariant true. Fail-closed: an unknown/unloadable kind is a mismatch.
+        if (boundKind !== K3_WISE_C6_WRITE_TARGET_KIND) {
+          throw new AdapterValidationError(
+            'the approved B4 binding names a system that is not a K3 WISE record',
+            { code: 'K3_C6_B4_BINDING_KIND_MISMATCH', field: 'capabilityState' },
+          )
         }
         if (!sameK3Instance(boundBaseUrl, targetBaseUrl)) {
           throw new AdapterValidationError(

--- a/plugins/plugin-integration-core/lib/http-routes.cjs
+++ b/plugins/plugin-integration-core/lib/http-routes.cjs
@@ -1053,7 +1053,7 @@ function normalizeC6WriteApplyBody(body = {}) {
 // is deliberately loaded config-only.
 const ADAPTER_BACKED_C6_TARGET_KINDS = new Set([K3_WISE_C6_WRITE_TARGET_KIND])
 
-function resolveC6WritePlanInputs({ targetSystem, pipeline, context, adapterRegistry, ownerPrincipal, readSourceConfigs }) {
+function resolveC6WritePlanInputs({ targetSystem, pipeline, context, adapterRegistry, ownerPrincipal, readSourceConfigs, getExternalSystem }) {
   // K3WriteDecision (owner, 20260805): the K3 connector rides the same C6 dry-run->apply
   // lifecycle via its own profile + adapter-backed write source. `enforcedMaxRows` pins the
   // plan-level source read to the profile's frozen cap — a caller-supplied maxRows is
@@ -1099,6 +1099,27 @@ function resolveC6WritePlanInputs({ targetSystem, pipeline, context, adapterRegi
           // The binding must belong to one of THIS pipeline's endpoints (review P2-B1): the K3
           // system may legitimately be the source, the target, or both.
           pipelineSystemIds: [pipeline.sourceSystemId, pipeline.targetSystemId].filter(Boolean),
+          // SAME-INSTANCE CHECK (owner ruling 20260805: "A, bind B4 to the K3-write record").
+          // The B4 contract is the material-LIST read contract, and a PROFILE-ARMED record
+          // cannot hold list-read config — #4769 makes every readList* key a forbidden overlay,
+          // and strips it even when it arrives from the frozen first-party read-smoke preset.
+          // So the customer needs TWO K3 records (see delivery MD step 0-b), and with a non-K3
+          // pipeline source the read record is neither endpoint. Binding to the TARGET record is
+          // therefore the only option that satisfies the relation check.
+          //
+          // That is only honest while both records address the SAME physical K3. Without this
+          // check, "bind to the target" would let one K3's read contract vouch for a DIFFERENT
+          // K3's write — exactly the round-3 defect the relation check exists to stop, reopened
+          // one level down. The check is fail-closed: it can only refuse bindings the relation
+          // check already accepted, never admit new ones.
+          targetBaseUrl: (targetSystem.config && targetSystem.config.baseUrl) || '',
+          // Scope derived from the PIPELINE record, same as tenantId/workspaceId above — NOT
+          // from the request. `scopedInput(req, …)` reads workspaceId from query/params but not
+          // the body, so a workspace-scoped pipeline fell out of scope and the lookup returned
+          // null, which the fail-closed comparator then read as "different instance".
+          loadSystemById: typeof getExternalSystem === 'function'
+            ? (id) => getExternalSystem({ id, tenantId: pipeline.tenantId, workspaceId: pipeline.workspaceId ?? null })
+            : undefined,
         },
       }),
       targetWriteProfile: K3_WISE_C6_WRITE_PROFILE,
@@ -3421,7 +3442,8 @@ function createHandlers(services, options = {}) {
         role: 'source',
         principal: ownerPrincipal,
       })
-      const c6 = resolveC6WritePlanInputs({ targetSystem, pipeline, context, adapterRegistry, ownerPrincipal, readSourceConfigs })
+      const c6 = resolveC6WritePlanInputs({ targetSystem, pipeline, context, adapterRegistry, ownerPrincipal, readSourceConfigs,
+        getExternalSystem: (input) => externalSystems.getExternalSystem(input) })
       return sendOk(res, await dryRunExternalWrite({
         pipeline,
         sourceSystem,
@@ -3536,7 +3558,8 @@ function createHandlers(services, options = {}) {
       try {
         // SAME resolution as dry-run (server-side, by target kind) so the apply recompute
         // reproduces the dry-run revision; the multitable write-source writes own sheets only.
-        const c6 = resolveC6WritePlanInputs({ targetSystem, pipeline, context, adapterRegistry, ownerPrincipal, readSourceConfigs })
+        const c6 = resolveC6WritePlanInputs({ targetSystem, pipeline, context, adapterRegistry, ownerPrincipal, readSourceConfigs,
+        getExternalSystem: (input) => externalSystems.getExternalSystem(input) })
         const result = await applyExternalWrite({
           pipeline,
           sourceSystem,

--- a/plugins/plugin-integration-core/lib/http-routes.cjs
+++ b/plugins/plugin-integration-core/lib/http-routes.cjs
@@ -1098,7 +1098,24 @@ function resolveC6WritePlanInputs({ targetSystem, pipeline, context, adapterRegi
           workspaceId: pipeline.workspaceId ?? null,
           // The binding must belong to one of THIS pipeline's endpoints (review P2-B1): the K3
           // system may legitimately be the source, the target, or both.
-          pipelineSystemIds: [pipeline.sourceSystemId, pipeline.targetSystemId].filter(Boolean),
+          // OWNER REVIEW 20260806 [P1]: with only the two pipeline endpoints here, the customer's
+          // real K3 READ record is neither, so B4 could only ever bind to the TARGET — and the
+          // same-instance check then compared the target against ITSELF. The check was structurally
+          // incapable of detecting a read/write mismatch no matter how good the comparator was.
+          //
+          // The write target now DECLARES its paired read record (`config.pairedReadSystemId`), and
+          // that one id joins the relation set. This is deliberately narrow: it admits exactly the
+          // record the target itself names — not an arbitrary third system — and the binding must
+          // still clear the ratified-contract match, the kind gate, and the same-instance check.
+          //
+          // NOTE this WIDENS #4769's relation check by one target-declared id. That is a change to
+          // a ratified gate, made on the owner's explicit instruction to "让 B4 绑定真实
+          // read-system，并比较 read/write 两条记录的规范实例身份".
+          pipelineSystemIds: [
+            pipeline.sourceSystemId,
+            pipeline.targetSystemId,
+            (targetSystem.config && targetSystem.config.pairedReadSystemId) || null,
+          ].filter(Boolean),
           // SAME-INSTANCE CHECK (owner ruling 20260805: "A, bind B4 to the K3-write record").
           // The B4 contract is the material-LIST read contract, and a PROFILE-ARMED record
           // cannot hold list-read config — #4769 makes every readList* key a forbidden overlay,

--- a/plugins/plugin-integration-core/lib/sealed-export/vectors/s6a-package-provenance-pins.json
+++ b/plugins/plugin-integration-core/lib/sealed-export/vectors/s6a-package-provenance-pins.json
@@ -70,7 +70,7 @@
     "pluginPackageJson": "d32fbaae74d8b710a363cbcf1215ff1c30c71091e7aec3f68a98978e7818d707",
     "pnpmLock": "8ca98ceef0c84b821c4b20a0f0cf0b50b87dfb51a26b6a2d21a9912a1733680f",
     "pluginIndex": "c2a800452d175e2b00a476b3e0d3fab6f65e16031789b91a0304dd1dc45a0cee",
-    "pluginHttpRoutes": "89532716d6f5bc224fc6b75ffb3c2b90b4d6995e3a60f01377af5f685820a132",
+    "pluginHttpRoutes": "05dbf13c6dd6e316b4a634a14020ec140670885189fda00c162fc63952e76b7d",
     "s6aProvisioningCli": "d3320b27da7ab358ca068a3766a375e669fb6922f24ba0186ba0828c3e1d9da8",
     "s6aAcceptanceRunner": "eb58824cba1ab03361a6a4fba409f3f7a120dcda61d4c3d6cad2b82311d62624",
     "s6aOnpremRunbook": "1f4ba2b7fadbad0acb97e18d13f2be7ad6071fa372ac44e0aa4e17995e94c410",
@@ -86,6 +86,6 @@
     "s6aAcceptancePs51Test": "835c7c6ce943d82e0378a40a27c7fd1e8b79b526faa8ca4c8066e4231a4bfb0f",
     "s6aProductRuntimeTest": "de978adafa8b89772cefa921c2051f434bf346bf5c2978bef3424ee70f51ba3f",
     "multitableOnpremPackageBuild": "463c7d73c6c7f2d1b6cdf0820d7a06974a9c463dd5e98bbbaf1c996e1dc4ed99",
-    "pluginTestsWorkflow": "2e844a3c222e6ef284494369d047b461ff6ed12584187561c1628f5553b4204c"
+    "pluginTestsWorkflow": "2f2c3f1883894a006ef4488c5c6e6c818fdccf2eae1a317dc09236ba9e745e25"
   }
 }

--- a/plugins/plugin-integration-core/lib/sealed-export/vectors/s6a-package-provenance-pins.json
+++ b/plugins/plugin-integration-core/lib/sealed-export/vectors/s6a-package-provenance-pins.json
@@ -70,7 +70,7 @@
     "pluginPackageJson": "d32fbaae74d8b710a363cbcf1215ff1c30c71091e7aec3f68a98978e7818d707",
     "pnpmLock": "8ca98ceef0c84b821c4b20a0f0cf0b50b87dfb51a26b6a2d21a9912a1733680f",
     "pluginIndex": "c2a800452d175e2b00a476b3e0d3fab6f65e16031789b91a0304dd1dc45a0cee",
-    "pluginHttpRoutes": "05dbf13c6dd6e316b4a634a14020ec140670885189fda00c162fc63952e76b7d",
+    "pluginHttpRoutes": "ffaccc3856aadae9dc75ef497ca3ca487eb0c40dea7e363b7c4edcd204822dcd",
     "s6aProvisioningCli": "d3320b27da7ab358ca068a3766a375e669fb6922f24ba0186ba0828c3e1d9da8",
     "s6aAcceptanceRunner": "eb58824cba1ab03361a6a4fba409f3f7a120dcda61d4c3d6cad2b82311d62624",
     "s6aOnpremRunbook": "1f4ba2b7fadbad0acb97e18d13f2be7ad6071fa372ac44e0aa4e17995e94c410",
@@ -86,6 +86,6 @@
     "s6aAcceptancePs51Test": "835c7c6ce943d82e0378a40a27c7fd1e8b79b526faa8ca4c8066e4231a4bfb0f",
     "s6aProductRuntimeTest": "de978adafa8b89772cefa921c2051f434bf346bf5c2978bef3424ee70f51ba3f",
     "multitableOnpremPackageBuild": "463c7d73c6c7f2d1b6cdf0820d7a06974a9c463dd5e98bbbaf1c996e1dc4ed99",
-    "pluginTestsWorkflow": "b54027e217e00e27e28cd8c6aaa9e81715b2ff963e24cfa510888b18e8792155"
+    "pluginTestsWorkflow": "0d58b59458f1c46ca80fc73b771d5ccad1dd0993f241f88ca13fc2f84bd46eb2"
   }
 }

--- a/plugins/plugin-integration-core/lib/sealed-export/vectors/s6a-package-provenance-pins.json
+++ b/plugins/plugin-integration-core/lib/sealed-export/vectors/s6a-package-provenance-pins.json
@@ -86,6 +86,6 @@
     "s6aAcceptancePs51Test": "835c7c6ce943d82e0378a40a27c7fd1e8b79b526faa8ca4c8066e4231a4bfb0f",
     "s6aProductRuntimeTest": "de978adafa8b89772cefa921c2051f434bf346bf5c2978bef3424ee70f51ba3f",
     "multitableOnpremPackageBuild": "463c7d73c6c7f2d1b6cdf0820d7a06974a9c463dd5e98bbbaf1c996e1dc4ed99",
-    "pluginTestsWorkflow": "2f2c3f1883894a006ef4488c5c6e6c818fdccf2eae1a317dc09236ba9e745e25"
+    "pluginTestsWorkflow": "b54027e217e00e27e28cd8c6aaa9e81715b2ff963e24cfa510888b18e8792155"
   }
 }

--- a/scripts/ops/fixtures/integration-k3wise/mock-k3-webapi-server.mjs
+++ b/scripts/ops/fixtures/integration-k3wise/mock-k3-webapi-server.mjs
@@ -41,6 +41,16 @@ function sanitizeMockBody(value) {
   )
 }
 
+// Owner review (2026-08-05, staging-window-rehearsal point F): the mock previously accepted
+// every call with no session check at all — a driver bug that dropped the auth header would
+// still rehearse "clean". These are the SAME literal values the mock has always issued (Login's
+// sessionId + the Set-Cookie value below); factored out so the requireSession gate checks
+// against the exact values the mock itself hands out, not a re-typed copy that could drift.
+const MOCK_SESSION_ID = 'mock-session-1'
+const MOCK_SESSION_COOKIE_NAME = 'K3SESSION'
+const MOCK_SESSION_COOKIE_VALUE = 'mock-cookie-1'
+const MOCK_SESSION_HEADER = 'x-k3-session'
+
 export function createMockK3WebApiServer({
   logger = () => {},
   seedListRows: seedListRowsOption = [],
@@ -51,6 +61,12 @@ export function createMockK3WebApiServer({
   rowFailFNumbers = new Set(),
   includeSessionCookie = true,
   includeSessionId = true,
+  // F: default OFF so every existing caller (mock-k3-webapi-server.test.mjs, run-mock-poc-demo.mjs,
+  // and any other fixture that never authenticates against this specific mock instance) is
+  // unaffected. The staging-window-rehearsal runner turns this ON — the real K3WiseWebApiAdapter
+  // always logs in first and carries the session header/cookie on every subsequent call, so an
+  // honest rehearsal client sees no behavior change; a client that DROPPED the auth wiring would.
+  requireSession = false,
 } = {}) {
   const calls = []
   const savedMaterials = new Map()
@@ -72,8 +88,21 @@ export function createMockK3WebApiServer({
   function jsonResponse(res, status, payload, { setCookie = includeSessionCookie } = {}) {
     res.statusCode = status
     res.setHeader('Content-Type', 'application/json')
-    if (setCookie) res.setHeader('Set-Cookie', 'K3SESSION=mock-cookie-1; Path=/; HttpOnly')
+    if (setCookie) res.setHeader('Set-Cookie', `${MOCK_SESSION_COOKIE_NAME}=${MOCK_SESSION_COOKIE_VALUE}; Path=/; HttpOnly`)
     res.end(JSON.stringify(payload))
+  }
+
+  // F: everything except /K3API/Login must carry the session the mock itself issued — either the
+  // X-K3-Session header (what the real adapter sends when Login returns a sessionId) or the
+  // equivalent cookie (what it sends when Login returns only a Set-Cookie). A substring check on
+  // the incoming Cookie header because the real adapter forwards the ENTIRE raw Set-Cookie value
+  // (including `; Path=/; HttpOnly`) back as its request Cookie header — not a re-parsed pair.
+  function hasValidSession(req) {
+    const headerValue = req.headers[MOCK_SESSION_HEADER]
+    if (typeof headerValue === 'string' && headerValue === MOCK_SESSION_ID) return true
+    const cookieHeader = req.headers.cookie
+    if (typeof cookieHeader === 'string' && cookieHeader.includes(`${MOCK_SESSION_COOKIE_NAME}=${MOCK_SESSION_COOKIE_VALUE}`)) return true
+    return false
   }
 
   function requireMethod(req, res, expectedMethod) {
@@ -103,11 +132,19 @@ export function createMockK3WebApiServer({
     calls.push(safeCall)
     logger(safeCall)
 
+    // F: the gate runs AFTER the call is logged (rejected calls stay visible for debugging, same
+    // as the existing method-not-allowed path) and BEFORE any routing — Login is the one path
+    // exempt (it is how a session is obtained in the first place).
+    if (requireSession && pathname !== '/K3API/Login' && !hasValidSession(req)) {
+      jsonResponse(res, 401, { success: false, message: 'session required' }, { setCookie: false })
+      return
+    }
+
     if (pathname === '/K3API/Login') {
       if (!requireMethod(req, res, 'POST')) return
       jsonResponse(res, 200, {
         success: true,
-        ...(includeSessionId ? { sessionId: 'mock-session-1' } : {}),
+        ...(includeSessionId ? { sessionId: MOCK_SESSION_ID } : {}),
       })
       return
     }

--- a/scripts/ops/fixtures/integration-k3wise/mock-k3-webapi-server.mjs
+++ b/scripts/ops/fixtures/integration-k3wise/mock-k3-webapi-server.mjs
@@ -43,6 +43,7 @@ function sanitizeMockBody(value) {
 
 export function createMockK3WebApiServer({
   logger = () => {},
+  seedListRows: seedListRowsOption = [],
   knownBadFNumbers = new Set(['BAD']),
   // Envelope-200-but-row-level-fail: K3 returns StatusCode 200 / "Successful" yet the
   // row did not save. Lets the live PoC demo exercise the M1 row-level diagnostic path
@@ -53,6 +54,11 @@ export function createMockK3WebApiServer({
 } = {}) {
   const calls = []
   const savedMaterials = new Map()
+  // Rehearsal support: rows the LIST read serves as the "source catalogue". Deliberately
+  // SEPARATE from savedMaterials (Save/GetDetail's store) so a rehearsal's dry-run classifies
+  // seeded source rows as `add` deterministically (GetDetail miss), then finds them via
+  // GetDetail only AFTER the Save actually wrote them.
+  const seedListRows = Array.isArray(seedListRowsOption) ? seedListRowsOption.map((r) => ({ ...r })) : []
 
   async function readBody(req) {
     return new Promise((resolve, reject) => {
@@ -130,6 +136,26 @@ export function createMockK3WebApiServer({
       // could prove Save happened but never that the write is READABLE afterwards.
       savedMaterials.set(fNumber, { ...(body?.Model || body?.Data), FItemID: savedMaterials.get(fNumber)?.FItemID ?? 9000 + savedMaterials.size + 1 })
       jsonResponse(res, 200, { success: true, externalId: `mock-${fNumber}`, billNo: fNumber })
+      return
+    }
+    if (pathname === '/K3API/Material/GetList') {
+      if (!requireMethod(req, res, 'POST')) return
+      const data = body?.Data || {}
+      const top = Number(data.Top) > 0 ? Number(data.Top) : 10
+      const pageIndex = Number(data.PageIndex) > 0 ? Number(data.PageIndex) : 1
+      const fields = typeof data.Fields === 'string' && data.Fields.trim()
+        ? data.Fields.split(',').map((f) => f.trim())
+        : null
+      const start = (pageIndex - 1) * top
+      const page = seedListRows.slice(start, start + top).map((row) => {
+        if (!fields) return { ...row }
+        return Object.fromEntries(fields.filter((f) => f in row).map((f) => [f, row[f]]))
+      })
+      jsonResponse(res, 200, {
+        StatusCode: 200,
+        Message: 'Successful',
+        Data: { ROWCOUNT: seedListRows.length, PAGESIZE: top, PAGEINDEX: pageIndex, DATA: page },
+      })
       return
     }
     if (pathname === '/K3API/Material/GetDetail') {

--- a/scripts/ops/fixtures/integration-k3wise/rehearsal-driver-contract.test.mjs
+++ b/scripts/ops/fixtures/integration-k3wise/rehearsal-driver-contract.test.mjs
@@ -287,10 +287,20 @@ test('the mock arms its session gate and its call logger — both are load-beari
 // Extract a record() step's pass-predicate by BALANCED SCAN, not by splitting on commas.
 // A comma-split reads the wrong span for any predicate containing a call or an index expression --
 // the first attempt at this parsed only 8 of the 17 steps and silently exempted the other 9.
-function predicateOf(src, step) {
+function predicateOf(rawSrc, step) {
+  // Strip comments BEFORE locating anything, so every index below refers to one consistent string.
+  // (First attempt stripped after computing the offset and shifted it — the suite went red on
+  // step 1, which is the good failure mode for this class of slip.)
+  const src = rawSrc.replace(/\/\*[^]*?\*\//g, ' ').replace(/(^|[^:])\/\/[^\n]*/g, '$1 ')
   const key = `record('${step}'`
   const at = src.indexOf(key)
   assert.ok(at >= 0, `step '${step}' is not in the driver`)
+  // NIT (review r4): the balanced scan reads RAW source, so a comma or apostrophe inside an
+  // IN-SPAN comment truncates the span — an innocuous `// status, token and both counts` yields
+  // `actual: 'ok(dryRun)'` and a message blaming a manifest weakening that never happened. Fails
+  // closed, but the diagnostic points at the wrong thing. Comments are removed BEFORE scanning so
+  // their punctuation cannot terminate it; the equality compare is unaffected because stripping
+  // only ever removed non-executing text.
   let i = src.indexOf(',', at + key.length) + 1
   const start = i
   let depth = 0
@@ -311,11 +321,7 @@ function predicateOf(src, step) {
   // `//` comments inside the predicate leaves every manifest needle present verbatim while the
   // live expression is just `ok(dryRun)` — the guard reads its own documentation as evidence.
   // Third occurrence of "prose satisfies a code-shaped assertion" on this line.
-  return src.slice(start, i)
-    .replace(/\/\*[^]*?\*\//g, ' ')
-    .replace(/\/\/[^\n]*/g, ' ')
-    .replace(/\s+/g, ' ')
-    .trim()
+  return src.slice(start, i).replace(/\s+/g, ' ').trim()
 }
 
 // POSITIVE MANIFEST: what each step's predicate MUST assert.
@@ -433,7 +439,15 @@ test('every record() step asserts its NAMED discriminators — positive manifest
     assert.ok(predicate.length > 0, `step '${step}' has an empty predicate`)
     const conjuncts = REQUIRED_DISCRIMINATORS[step]
 
-    // EXACT CANONICAL EQUALITY — the THIRD criterion for this guard, and the first that converges.
+    // EXACT CANONICAL EQUALITY — the THIRD criterion for this guard. It converges FOR THE SPAN,
+    // and that scope is the whole of the claim.
+    //
+    // What it does NOT constrain (review r4, measured with the text byte-identical and the suite
+    // GREEN): the MEANING of what the text names. `ok()` can be changed to `return true`; and
+    // `dryRunOut` can be forged so `counts.add` reads SOURCE_KEYS.length — fabricating precisely
+    // the owner's P1 discriminator. The weakening channel did not close, it moved one level out,
+    // to the helpers and to how the response object is obtained. Saying "the first that converges"
+    // without that scope was an overclaim; this guard pins predicate TEXT, not predicate TRUTH.
     //
     // v1 was a denylist of four literals; `dryRunOut !== undefined` walked through it.
     // v2 was needle-substring + no-`||` + an `&&` count. Review broke that too, twice, and the

--- a/scripts/ops/fixtures/integration-k3wise/rehearsal-driver-contract.test.mjs
+++ b/scripts/ops/fixtures/integration-k3wise/rehearsal-driver-contract.test.mjs
@@ -335,28 +335,60 @@ function predicateOf(src, step) {
 // i.e. "HTTP 200 is enough". Needles pin WHAT is asserted; conjuncts pin that they are all
 // REQUIRED TOGETHER.
 const REQUIRED_DISCRIMINATORS = {
-  'create-source-system': ['ok(sourceSystem)', 'payload(sourceSystem)?.id'],
-  'create-target-system': ['ok(targetSystem)', 'payload(targetSystem)?.id'],
-  'staging-install': ['ok(stagingInstall)', 'stagingSheetId', 'stagingProjectId'],
-  'create-staging-source': ['ok(sourceStagingSystem)', 'payload(sourceStagingSystem)?.id'],
-  'mint-seed-token': ['ok(tokenMint)', 'mintedTokenUsable'],
-  'resolve-staging-field-map': ['ok(fieldsRes)', 'Object.keys(physicalByName).length > 0'],
-  'seed-staging-rows': ['seeded.length === seedRows.length', 'seeded.every(Boolean)'],
-  'b4-mint': ['ok(b4Mint)', 'b4Row?.id'],
-  'b4-approve': ['ok(b4Approve)', "=== 'approved'"],
-  'preflight-list-shape-probe': ['listProbeEvidence.ok === true', "typeof listRowCountKey === 'string'"],
+  'create-source-system': [
+    'ok(sourceSystem)',
+    'Boolean(payload(sourceSystem)?.id)',
+  ],
+  'create-target-system': [
+    'ok(targetSystem)',
+    'Boolean(payload(targetSystem)?.id)',
+  ],
+  'staging-install': [
+    'ok(stagingInstall)',
+    'Boolean(stagingSheetId)',
+    'Boolean(stagingProjectId)',
+  ],
+  'create-staging-source': [
+    'ok(sourceStagingSystem)',
+    'Boolean(payload(sourceStagingSystem)?.id)',
+  ],
+  'mint-seed-token': [
+    'ok(tokenMint)',
+    'mintedTokenUsable',
+  ],
+  'resolve-staging-field-map': [
+    'ok(fieldsRes)',
+    'Object.keys(physicalByName).length > 0',
+  ],
+  'seed-staging-rows': [
+    'seeded.length === seedRows.length',
+    'seeded.every(Boolean)',
+  ],
+  'b4-mint': [
+    'ok(b4Mint)',
+    'Boolean(b4Row?.id)',
+  ],
+  'b4-approve': [
+    'ok(b4Approve)',
+    'b4Approved?.status === \'approved\'',
+  ],
+  'preflight-list-shape-probe': [
+    'listProbeEvidence.ok === true',
+    'typeof listRowCountKey === \'string\'',
+  ],
   'preflight-list-read-smoke': [
     'listSmoke.status === 200',
     'listEvidence?.ok === true',
     'listEvidence?.[listRowCountKey] === SOURCE_KEYS.length',
   ],
-  'create-pipeline': ['ok(pipeline)', 'payload(pipeline)?.id'],
-  // The load-bearing one. This step is the PR's substitute for the owner's discrete "bare read"
-  // step AND the sole runtime discriminator for empty code/name, so every conjunct is pinned.
+  'create-pipeline': [
+    'ok(pipeline)',
+    'Boolean(payload(pipeline)?.id)',
+  ],
   'dry-run': [
     'ok(dryRun)',
-    "dryRunOut?.status === 'ready'",
-    "typeof dryRunOut?.dryRunToken === 'string'",
+    'dryRunOut?.status === \'ready\'',
+    'typeof dryRunOut?.dryRunToken === \'string\'',
     'dryRunOut?.counts?.sourceRows === SOURCE_KEYS.length',
     'dryRunOut?.counts?.add === SOURCE_KEYS.length',
   ],
@@ -365,7 +397,10 @@ const REQUIRED_DISCRIMINATORS = {
     'applyOut?.counts?.written === SOURCE_KEYS.length',
     '(applyOut?.counts?.failed ?? 0) === 0',
   ],
-  'token-single-use': ['replayToken.status === 409', "'C6_WRITE_DRY_RUN_TOKEN_INVALID'"],
+  'token-single-use': [
+    'replayToken.status === 409',
+    'replayBody?.error?.code === \'C6_WRITE_DRY_RUN_TOKEN_INVALID\'',
+  ],
   'read-back-written-key': [
     'readBack.status === 200',
     'readBackEvidence?.ok === true',
@@ -375,7 +410,7 @@ const REQUIRED_DISCRIMINATORS = {
   'read-back-negative-control': [
     'readBackMiss.status === 200',
     'missEvidence?.ok === false',
-    "missEvidence?.errorCode === 'K3_WISE_READ_BUSINESS_ERROR'",
+    'missEvidence?.errorCode === \'K3_WISE_READ_BUSINESS_ERROR\'',
   ],
 }
 
@@ -396,25 +431,28 @@ test('every record() step asserts its NAMED discriminators — positive manifest
   for (const step of declared) {
     const predicate = predicateOf(driver, step)
     assert.ok(predicate.length > 0, `step '${step}' has an empty predicate`)
-    const needles = REQUIRED_DISCRIMINATORS[step]
-    for (const needle of needles) {
-      assert.ok(predicate.includes(needle),
-        `step '${step}' no longer asserts ${JSON.stringify(needle)}\n    predicate is: ${predicate}`)
-    }
-    // REVIEW P2-B: substring presence is INVARIANT under `&&` -> `||`, and that swap turns a
-    // five-way AND into "any one of these is enough" — i.e. the dry-run discriminator collapses to
-    // "HTTP 200" while every needle survives verbatim. Needles pin WHAT is asserted; these two pin
-    // that the assertions are required TOGETHER.
+    const conjuncts = REQUIRED_DISCRIMINATORS[step]
+
+    // EXACT CANONICAL EQUALITY — the THIRD criterion for this guard, and the first that converges.
     //
-    // All 17 predicates are pure conjunctions (verified mechanically before this was written; the
-    // check below is what keeps that true). `??` is deliberately not `||`.
-    assert.ok(!predicate.includes('||'),
-      `step '${step}' introduced a disjunction; a predicate that passes on ANY conjunct is not the `
-      + `gate this manifest describes\n    predicate is: ${predicate}`)
-    const conjunctions = (predicate.match(/&&/g) || []).length
-    assert.ok(conjunctions >= needles.length - 1,
-      `step '${step}' has ${conjunctions} '&&' for ${needles.length} required discriminators — some `
-      + `are no longer joined as a conjunction\n    predicate is: ${predicate}`)
+    // v1 was a denylist of four literals; `dryRunOut !== undefined` walked through it.
+    // v2 was needle-substring + no-`||` + an `&&` count. Review broke that too, twice, and the
+    // second break was IN THE FIX ITSELF: the comment stripper was not quote-aware, so a `//`
+    // inside a string literal deleted the rest of the line from the SCANNED text while it still
+    // EXECUTED (`… && String('a//b') === 'a//b' || true`). And a wrapper needs no comment at all:
+    // `[ok(dryRun) && …].length > 0` keeps every needle, keeps four `&&`, and is always true.
+    //
+    // Those are CHANNELS, and patching channels does not converge — substring presence plus an
+    // operator count cannot establish that the predicate's TRUTH REQUIRES the conjuncts. So the
+    // CRITERION changed rather than gaining a fourth patch: the predicate must be EXACTLY the
+    // declared conjuncts joined by `&&`. Any wrapper, appended term, disjunction, or comment trick
+    // changes the string and fails here, without this guard needing to anticipate it.
+    const canonical = conjuncts.join(' && ')
+    assert.equal(predicate, canonical,
+      `step '${step}' is no longer exactly its declared conjunction.\n`
+      + `    expected: ${canonical}\n`
+      + `    actual:   ${predicate}\n`
+      + '    Weakening a predicate must be done by EDITING THE TABLE ABOVE — a reviewable act.')
   }
 
   // NEGATIVE CONTROL on the checker itself: the exact degradations that defeated the denylist

--- a/scripts/ops/fixtures/integration-k3wise/rehearsal-driver-contract.test.mjs
+++ b/scripts/ops/fixtures/integration-k3wise/rehearsal-driver-contract.test.mjs
@@ -24,6 +24,21 @@ const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../
 const driverPath = path.join(repoRoot, 'scripts/ops/stock-prep-window-rehearsal-driver.mjs')
 const driver = fs.readFileSync(driverPath, 'utf8')
 
+// The plm_raw_items descriptor's field ids, bounded at the END OF ITS fields[] ARRAY.
+// A fixed-width slice (the previous `slice(0, 1200)`) runs past the descriptor and swallows
+// standard_materials' columns, so `uom`/`category`/`status` scored as valid plm_raw_items fields —
+// the scan was wider than the object it claimed to describe, and would have accepted a field id
+// that hashes to a phantom on THIS object.
+function rawItemsFieldIds(installerSrc) {
+  const start = installerSrc.indexOf("id: 'plm_raw_items'")
+  if (start < 0) throw new Error('plm_raw_items descriptor not found')
+  const fieldsAt = installerSrc.indexOf('fields: [', start)
+  const end = installerSrc.indexOf('\n    ],', fieldsAt)
+  if (fieldsAt < 0 || end < 0) throw new Error('plm_raw_items fields[] not delimited as expected')
+  const block = installerSrc.slice(fieldsAt, end)
+  return new Set([...block.matchAll(/\{ id: '([A-Za-z_][\w]*)'/g)].map((m) => m[1]))
+}
+
 test('every adapter kind the driver registers is actually registered by the plugin', () => {
   const pluginIndex = fs.readFileSync(
     path.join(repoRoot, 'plugins/plugin-integration-core/index.cjs'), 'utf8')
@@ -79,9 +94,7 @@ test('every API path the driver calls is mounted somewhere in the repo', () => {
 test('pipeline fieldMappings name STAGING columns as source, not the K3 target columns', () => {
   const installer = fs.readFileSync(
     path.join(repoRoot, 'plugins/plugin-integration-core/lib/staging-installer.cjs'), 'utf8')
-  const stagingBlock = installer.slice(installer.indexOf("id: 'plm_raw_items'"))
-  const stagingFields = new Set(
-    [...stagingBlock.slice(0, 1200).matchAll(/\{ id: '([A-Za-z_][\w]*)'/g)].map((m) => m[1]))
+  const stagingFields = rawItemsFieldIds(installer)
   assert.ok(stagingFields.has('code') && stagingFields.has('name'),
     'staging field scan failed — the check below would be vacuous')
 
@@ -129,6 +142,16 @@ test("the driver's OWN staging config carries projectId and a provisioned object
   assert.ok(provisioned.has('plm_raw_items'),
     'descriptor scan failed — every assertion below would be vacuous')
 
+  // Scoped to the plm_raw_items block: a bare repo-wide scan would accept a field id borrowed
+  // from standard_materials / bom_cleanse, which is a DIFFERENT object and hashes differently.
+  const descriptorFieldIds = rawItemsFieldIds(installerSrc)
+  assert.ok(descriptorFieldIds.has('code') && descriptorFieldIds.has('sourceSystemId'),
+    'plm_raw_items field scan failed — the config.fields check would be vacuous')
+  // NEGATIVE control on the SCAN ITSELF: `category` is a standard_materials column. If it appears
+  // here, the slice has run past the descriptor and the check below is wider than it claims.
+  assert.equal(descriptorFieldIds.has('category'), false,
+    'the field scan leaked into a neighbouring descriptor — it no longer describes plm_raw_items')
+
   const cfgBlock = driver.slice(driver.indexOf("kind: 'metasheet:staging'"))
   const head = cfgBlock.slice(0, 900)
 
@@ -152,6 +175,27 @@ test("the driver's OWN staging config carries projectId and a provisioned object
     + '(projectId, objectId), so a wrong key silently yields an EMPTY alias map.')
   assert.ok(driver.includes(`sourceObject: '${objectKey}'`),
     `the pipeline's sourceObject must match the staging objects key ('${objectKey}')`)
+
+  // The OTHER leg of the same join, and the one that fails SILENTLY. config.fields feeds
+  // logicalFieldNames() -> resolveFieldIds(), and resolveObjectFieldIds is COMPUTE-ONLY:
+  // `resolved[fieldId] = stableMetaId('fld', projectId, objectId, fieldId)` for whatever it is
+  // handed (provisioning.ts:150-160; core-backend/src/index.ts:599 says so outright — "compute-only
+  // and never omits a field"). A logical id that does not exist therefore yields a WELL-FORMED hash
+  // for a field that was never provisioned: invertFieldIdMap aliases that phantom id, the real
+  // fld_* key in the row matches nothing, and the column simply reads as absent. No error anywhere.
+  // Anchored on the object block, not `head` — the config carries long explanatory comments, so a
+  // fixed-width window from `kind:` ends before fields[] and the scan reads as absent.
+  const objectBlock = cfgBlock.slice(cfgBlock.indexOf(`${objectKey}: {`))
+  const configFieldsRaw = (objectBlock.slice(0, 600).match(/fields:\s*\[([^\]]*)\]/) || [])[1]
+  assert.ok(configFieldsRaw, "could not read the staging config's fields[] from the driver")
+  const configFields = [...configFieldsRaw.matchAll(/'([^']+)'/g)].map((m) => m[1])
+  assert.ok(configFields.length >= 2, 'staging config must declare at least two logical fields')
+  for (const f of configFields) {
+    assert.ok(descriptorFieldIds.has(f),
+      `staging config declares logical field '${f}', which plm_raw_items does not define `
+      + `(has: ${[...descriptorFieldIds].join(', ')}). resolveFieldIds would hash it anyway, so `
+      + 'this fails SILENTLY as an empty column rather than as an error.')
+  }
 
   // P2-2 cross-namespace join: the seed resolves by DISPLAY NAME, the adapter by LOGICAL id.
   // They agree only because ensureObject writes both onto one field, so pin the seed's lookup
@@ -238,6 +282,40 @@ test('the mock arms its session gate and its call logger — both are load-beari
     'the session assertion must reject a runner that omits the flag')
   assert.equal(/console\.log\([^)]*K3CALL/.test('logger: (call) => { void call }'), false,
     'the logger assertion must reject a runner whose logger emits nothing')
+})
+
+test('no record() step asserts a CONSTANT — every predicate reads real evidence', () => {
+  // Review P2-1/W7: the read-back negative control could be neutered to unconditionally true and
+  // the whole suite stayed green, because NO driver predicate has coverage. Rather than pin that
+  // one step, pin the class: a step whose pass-predicate is a literal cannot fail, and a step that
+  // cannot fail is worse than no step — it manufactures evidence.
+  //
+  // record() is `record(step, pass, evidence)`, and it process.exit(1)s on a false predicate, so
+  // `summary.pass = true` at the end IS conditional. What was unguarded is the predicates.
+  const calls = [...driver.matchAll(/record\(\s*'([a-z0-9-]+)'\s*,\s*([^,]+(?:,(?![\s\n]*\{)[^,]+)*),/g)]
+  assert.ok(calls.length >= 8, `record() scan found too little (${calls.length}) — would be vacuous`)
+
+  const constant = calls
+    .map(([, step, predicate]) => [step, predicate.trim()])
+    .filter(([, predicate]) => /^(true|1|!!1|Boolean\(true\))$/.test(predicate))
+  assert.deepEqual(constant, [],
+    `these steps assert a CONSTANT and can never fail: ${JSON.stringify(constant)}`)
+
+  // The negative control specifically must read the evidence it claims to check — it is the one
+  // step whose whole purpose is proving the read-back found a WRITE and not a permissive endpoint.
+  const negIdx = driver.indexOf("record('read-back-negative-control'")
+  assert.ok(negIdx > 0, 'the read-back negative control must exist')
+  const negBlock = driver.slice(negIdx, negIdx + 400)
+  for (const needle of ['missEvidence?.ok === false', 'K3_WISE_READ_BUSINESS_ERROR']) {
+    assert.ok(negBlock.includes(needle),
+      `the negative control must assert ${needle}; a looser predicate cannot distinguish "not found" `
+      + 'from "endpoint accepted anything"')
+  }
+
+  // POSITIVE CONTROL — the constant-detector must flag a literal predicate.
+  const probe = [..."record('fake-step', true, { a: 1 })".matchAll(/record\(\s*'([a-z0-9-]+)'\s*,\s*([^,]+),/g)]
+  assert.equal(probe.length, 1, 'probe must parse')
+  assert.ok(/^true$/.test(probe[0][2].trim()), 'the detector must recognise a literal true predicate')
 })
 
 test('BEHAVIOURAL: a bare read yields LOGICAL keys only when projectId + objectId are right', async () => {

--- a/scripts/ops/fixtures/integration-k3wise/rehearsal-driver-contract.test.mjs
+++ b/scripts/ops/fixtures/integration-k3wise/rehearsal-driver-contract.test.mjs
@@ -284,44 +284,121 @@ test('the mock arms its session gate and its call logger — both are load-beari
     'the logger assertion must reject a runner whose logger emits nothing')
 })
 
-test('no record() step asserts a CONSTANT — every predicate reads real evidence', () => {
-  // Review P2-1/W7: the read-back negative control could be neutered to unconditionally true and
-  // the whole suite stayed green, because NO driver predicate has coverage. Rather than pin that
-  // one step, pin the class: a step whose pass-predicate is a literal cannot fail, and a step that
-  // cannot fail is worse than no step — it manufactures evidence.
-  //
-  // record() is `record(step, pass, evidence)`, and it process.exit(1)s on a false predicate, so
-  // `summary.pass = true` at the end IS conditional. What was unguarded is the predicates.
-  const calls = [...driver.matchAll(/record\(\s*'([a-z0-9-]+)'\s*,\s*([^,]+(?:,(?![\s\n]*\{)[^,]+)*),/g)]
-  // EQUALITY, not a floor. A floor cannot distinguish "scanned every step" from "the regex
-  // silently dropped the steps whose predicate contains a comma" — and the dropped ones would
-  // then carry ZERO constant-checking while the assertion still passed.
-  const declared = [...driver.matchAll(/^\s*record\('/gm)].length
-  assert.equal(calls.length, declared,
-    `the predicate scan parsed ${calls.length} of ${declared} record() steps — the unparsed ones `
-    + 'are exactly the steps this check would silently exempt')
+// Extract a record() step's pass-predicate by BALANCED SCAN, not by splitting on commas.
+// A comma-split reads the wrong span for any predicate containing a call or an index expression --
+// the first attempt at this parsed only 8 of the 17 steps and silently exempted the other 9.
+function predicateOf(src, step) {
+  const key = `record('${step}'`
+  const at = src.indexOf(key)
+  assert.ok(at >= 0, `step '${step}' is not in the driver`)
+  let i = src.indexOf(',', at + key.length) + 1
+  const start = i
+  let depth = 0
+  let quote = null
+  for (; i < src.length; i++) {
+    const c = src[i]
+    if (quote) {
+      if (c === '\\') { i++; continue }
+      if (c === quote) quote = null
+      continue
+    }
+    if (c === "'" || c === '"' || c === '`') { quote = c; continue }
+    if (c === '(' || c === '[' || c === '{') { depth++; continue }
+    if (c === ')' || c === ']' || c === '}') { depth--; continue }
+    if (c === ',' && depth === 0) break
+  }
+  return src.slice(start, i).replace(/\s+/g, ' ').trim()
+}
 
-  const constant = calls
-    .map(([, step, predicate]) => [step, predicate.trim()])
-    .filter(([, predicate]) => /^(true|1|!!1|Boolean\(true\))$/.test(predicate))
-  assert.deepEqual(constant, [],
-    `these steps assert a CONSTANT and can never fail: ${JSON.stringify(constant)}`)
+// POSITIVE MANIFEST: what each step's predicate MUST assert.
+//
+// The previous version of this guard was a DENYLIST of four literals
+// (/^(true|1|!!1|Boolean\(true\))$/). Independent review broke it in one line: the review
+// substituted `dryRunOut !== undefined` for the dry-run predicate and this suite stayed 10/10
+// GREEN -- degrading the ONE step that carries the owner's entire P1 (empty code/name would print
+// a tick). `1 === 1` passed too. That is the documented failure of trap enumeration: every round
+// of blocking known-bad forms leaves a fresh channel, because the complement of a denylist is
+// unbounded. The converging form is a positive allowlist, so this is now one.
+//
+// Weakening any predicate below now requires EDITING THIS TABLE -- a visible, reviewable act --
+// rather than quietly satisfying a pattern nobody re-reads.
+const REQUIRED_DISCRIMINATORS = {
+  'create-source-system': ['ok(sourceSystem)', 'payload(sourceSystem)?.id'],
+  'create-target-system': ['ok(targetSystem)', 'payload(targetSystem)?.id'],
+  'staging-install': ['ok(stagingInstall)', 'stagingSheetId', 'stagingProjectId'],
+  'create-staging-source': ['ok(sourceStagingSystem)', 'payload(sourceStagingSystem)?.id'],
+  'mint-seed-token': ['ok(tokenMint)', 'mintedTokenUsable'],
+  'resolve-staging-field-map': ['ok(fieldsRes)', 'Object.keys(physicalByName).length > 0'],
+  'seed-staging-rows': ['seeded.length === seedRows.length', 'seeded.every(Boolean)'],
+  'b4-mint': ['ok(b4Mint)', 'b4Row?.id'],
+  'b4-approve': ['ok(b4Approve)', "=== 'approved'"],
+  'preflight-list-shape-probe': ['listProbeEvidence.ok === true', "typeof listRowCountKey === 'string'"],
+  'preflight-list-read-smoke': [
+    'listSmoke.status === 200',
+    'listEvidence?.ok === true',
+    'listEvidence?.[listRowCountKey] === SOURCE_KEYS.length',
+  ],
+  'create-pipeline': ['ok(pipeline)', 'payload(pipeline)?.id'],
+  // The load-bearing one. This step is the PR's substitute for the owner's discrete "bare read"
+  // step AND the sole runtime discriminator for empty code/name, so every conjunct is pinned.
+  'dry-run': [
+    'ok(dryRun)',
+    "dryRunOut?.status === 'ready'",
+    "typeof dryRunOut?.dryRunToken === 'string'",
+    'dryRunOut?.counts?.sourceRows === SOURCE_KEYS.length',
+    'dryRunOut?.counts?.add === SOURCE_KEYS.length',
+  ],
+  'apply': [
+    'ok(apply)',
+    'applyOut?.counts?.written === SOURCE_KEYS.length',
+    '(applyOut?.counts?.failed ?? 0) === 0',
+  ],
+  'token-single-use': ['replayToken.status === 409', "'C6_WRITE_DRY_RUN_TOKEN_INVALID'"],
+  'read-back-written-key': [
+    'readBack.status === 200',
+    'readBackEvidence?.ok === true',
+    'readBackEvidence?.recordPresent === true',
+    'readBackEvidence?.recordCount === 1',
+  ],
+  'read-back-negative-control': [
+    'readBackMiss.status === 200',
+    'missEvidence?.ok === false',
+    "missEvidence?.errorCode === 'K3_WISE_READ_BUSINESS_ERROR'",
+  ],
+}
 
-  // The negative control specifically must read the evidence it claims to check — it is the one
-  // step whose whole purpose is proving the read-back found a WRITE and not a permissive endpoint.
-  const negIdx = driver.indexOf("record('read-back-negative-control'")
-  assert.ok(negIdx > 0, 'the read-back negative control must exist')
-  const negBlock = driver.slice(negIdx, negIdx + 400)
-  for (const needle of ['missEvidence?.ok === false', 'K3_WISE_READ_BUSINESS_ERROR']) {
-    assert.ok(negBlock.includes(needle),
-      `the negative control must assert ${needle}; a looser predicate cannot distinguish "not found" `
-      + 'from "endpoint accepted anything"')
+test('every record() step asserts its NAMED discriminators — positive manifest, not a denylist', () => {
+  const declared = [...driver.matchAll(/record\('([a-z0-9-]+)'/g)].map((m) => m[1])
+  assert.ok(declared.length >= 15, `only ${declared.length} steps found — scan is broken`)
+
+  // The manifest must cover EVERY step, in both directions. A step missing from the table would
+  // be silently unguarded; a table entry with no step means the table is describing a driver that
+  // no longer exists.
+  assert.deepEqual(
+    declared.filter((s) => !(s in REQUIRED_DISCRIMINATORS)), [],
+    'these driver steps have no manifest entry and are therefore unguarded')
+  assert.deepEqual(
+    Object.keys(REQUIRED_DISCRIMINATORS).filter((s) => !declared.includes(s)), [],
+    'these manifest entries name steps the driver no longer has')
+
+  for (const step of declared) {
+    const predicate = predicateOf(driver, step)
+    assert.ok(predicate.length > 0, `step '${step}' has an empty predicate`)
+    for (const needle of REQUIRED_DISCRIMINATORS[step]) {
+      assert.ok(predicate.includes(needle),
+        `step '${step}' no longer asserts ${JSON.stringify(needle)}\n    predicate is: ${predicate}`)
+    }
   }
 
-  // POSITIVE CONTROL — the constant-detector must flag a literal predicate.
-  const probe = [..."record('fake-step', true, { a: 1 })".matchAll(/record\(\s*'([a-z0-9-]+)'\s*,\s*([^,]+),/g)]
-  assert.equal(probe.length, 1, 'probe must parse')
-  assert.ok(/^true$/.test(probe[0][2].trim()), 'the detector must recognise a literal true predicate')
+  // NEGATIVE CONTROL on the checker itself: the exact degradations that defeated the denylist
+  // must now be caught. If these ever stop being rejected, this guard has regressed to a denylist.
+  const fakeDriver = "record('dry-run',\n  dryRunOut !== undefined,\n  { a: 1 })"
+  assert.equal(predicateOf(fakeDriver, 'dry-run'), 'dryRunOut !== undefined',
+    'the balanced scanner must read the whole predicate span')
+  for (const needle of REQUIRED_DISCRIMINATORS['dry-run']) {
+    assert.equal(predicateOf(fakeDriver, 'dry-run').includes(needle), false,
+      `the review's neutering mutation must FAIL the manifest (needle ${needle})`)
+  }
 })
 
 test('BEHAVIOURAL: a bare read yields LOGICAL keys only when projectId + objectId are right', async () => {

--- a/scripts/ops/fixtures/integration-k3wise/rehearsal-driver-contract.test.mjs
+++ b/scripts/ops/fixtures/integration-k3wise/rehearsal-driver-contract.test.mjs
@@ -119,26 +119,30 @@ test('the seeding body is keyed through the RESOLVED PHYSICAL map, not logical n
 })
 
 test("the driver's OWN staging config carries projectId and a provisioned objectId", () => {
-  // Mutations M1/M2 exposed this: the behavioural test builds its own config, so the DRIVER's
-  // config was unguarded — dropping projectId or renaming the object key left the suite green
-  // while reproducing the exact reported failure. Wire-vs-fixture drift, inside the guard added
-  // to stop wire-vs-fixture drift.
+  // Mutations M1/M2/T5 exposed this: the behavioural test builds its own config, so the DRIVER's
+  // config was unguarded — dropping projectId, renaming the object key, or dropping the install
+  // assertion all stayed green while reproducing the exact reported failure.
+  const installerSrc = fs.readFileSync(
+    path.join(repoRoot, 'plugins/plugin-integration-core/lib/staging-installer.cjs'), 'utf8')
+  const provisioned = new Set(
+    [...installerSrc.matchAll(/^\s*id: '([a-z_]+)',\s*$/gm)].map((m) => m[1]))
+  assert.ok(provisioned.has('plm_raw_items'),
+    'descriptor scan failed — every assertion below would be vacuous')
+
   const cfgBlock = driver.slice(driver.indexOf("kind: 'metasheet:staging'"))
   const head = cfgBlock.slice(0, 900)
 
   assert.ok(/projectId:\s*stagingProjectId/.test(head),
-    'the staging source config must pass projectId — resolveProvisionedFieldIdMap returns {} '
-    + 'without it, and read() then yields raw fld_* keys with code/name empty')
+    'the staging config must pass projectId — resolveProvisionedFieldIdMap returns {} without it, '
+    + 'and read() then yields raw fld_* keys with code/name empty')
   assert.ok(/stagingProjectId\s*=\s*payload\(stagingInstall\)/.test(driver),
     'projectId must come from the staging/install response, not be hardcoded')
 
-  // The objects KEY must be a descriptor the installer actually provisions.
-  const installer = fs.readFileSync(
-    path.join(repoRoot, 'plugins/plugin-integration-core/lib/staging-installer.cjs'), 'utf8')
-  const provisioned = new Set(
-    [...installer.matchAll(/^\s*id: '([a-z_]+)',\s*$/gm)].map((m) => m[1]))
-  assert.ok(provisioned.has('plm_raw_items'),
-    'descriptor scan failed — the assertion below would be vacuous')
+  // T5: a null projectId is INVISIBLE downstream (key present, alias map empty, dry-run add:0),
+  // so it has to fail at the step that obtains it.
+  const installIdx = driver.indexOf("record('staging-install'")
+  assert.ok(/Boolean\(stagingProjectId\)/.test(driver.slice(installIdx, installIdx + 400)),
+    'staging-install must FAIL when projectId is absent, not merely record sheetId')
 
   const objectKey = (head.match(/objects:\s*\{[^]*?([a-z_]+):\s*\{/) || [])[1]
   assert.ok(objectKey, 'could not read the objects key from the driver')
@@ -146,10 +150,68 @@ test("the driver's OWN staging config carries projectId and a provisioned object
     `driver keys its staging object '${objectKey}', which the installer never provisions `
     + `(provisioned: ${[...provisioned].join(', ')}). resolveProvisionedFieldIdMap looks up `
     + '(projectId, objectId), so a wrong key silently yields an EMPTY alias map.')
-
-  // and the pipeline must select that same object
   assert.ok(driver.includes(`sourceObject: '${objectKey}'`),
     `the pipeline's sourceObject must match the staging objects key ('${objectKey}')`)
+
+  // P2-2 cross-namespace join: the seed resolves by DISPLAY NAME, the adapter by LOGICAL id.
+  // They agree only because ensureObject writes both onto one field, so pin the seed's lookup
+  // keys to the installer's display names — an i18n/rename then breaks HERE, loudly.
+  const seedHead = driver.slice(driver.indexOf('/api/multitable/records'), driver.indexOf('/api/multitable/records') + 900)
+  for (const displayName of ['Source System', 'Object Type', 'Source ID', 'Code', 'Name']) {
+    assert.ok(installerSrc.includes(`name: '${displayName}'`),
+      `installer no longer declares display name '${displayName}' — the seed's lookup key is stale`)
+    assert.ok(seedHead.includes(displayName),
+      `seed must key on the installer's display name '${displayName}'`)
+  }
+})
+
+test('credentials are read from the field the route RETURNS, and shape-checked', () => {
+  // THE META-FINDING of review r4: switching the driver to the CORRECT `.plaintext` left this
+  // suite 6/6 green. The guards caught the previous round's bug and were blind to this one — a
+  // test battery that only pins yesterday's defect.
+  //
+  // `POST /api/multitable/api-tokens` returns `{data:{token:<METADATA OBJECT>, plaintext:'mst_…'}}`.
+  // Reading `.token` yields a truthy OBJECT: the mint step reports PASS, then every later request
+  // sends `Bearer [object Object]` and 401s. False green, then deterministic failure.
+  const routeSrc = fs.readFileSync(
+    path.join(repoRoot, 'packages/core-backend/src/routes/api-tokens.ts'), 'utf8')
+  assert.ok(/plaintext:\s*result\.plainTextToken/.test(routeSrc),
+    'route scan failed — the assertions below would be vacuous')
+
+  const mintBlock = driver.slice(driver.indexOf('/api/multitable/api-tokens'))
+  const head = mintBlock.slice(0, 800)
+  assert.ok(/payload\(tokenMint\)\?\.plaintext/.test(head),
+    'the credential must be read from `.plaintext` — `.token` is the metadata object')
+  assert.equal(/payload\(tokenMint\)\?\.token\b/.test(head), false,
+    '`.token` is the ApiToken record, not a usable bearer credential')
+
+  // Truthiness is not enough: an object is truthy. Assert the SHAPE the auth layer routes on.
+  assert.ok(/startsWith\('mst_'\)/.test(head),
+    "apiTokenAuth routes on the `mst_` prefix; anything else falls through to the JWT path, so "
+    + 'the mint step must verify the prefix rather than mere truthiness')
+
+  // POSITIVE CONTROL — the old broken read must fail this test.
+  const brokenMint = "const T = payload(tokenMint)?.token || ''"
+  assert.equal(/\?\.plaintext/.test(brokenMint), false,
+    'the previous broken shape must not satisfy this assertion — otherwise it pins nothing')
+})
+
+test('no silent credential fallback, and no silent field-map degradation', () => {
+  // Review P2-1: `opts.token || TOKEN` fell back to the admin JWT whenever the minted token was
+  // empty — and `requireScope` PASSES a request carrying no apiTokenScopes, so the lane could not
+  // distinguish "the minted token works" from "the fallback rescued it". A rehearsal that cannot
+  // tell those apart is not evidence about the minted token at all.
+  assert.equal(/opts\.token \|\| TOKEN/.test(driver), false,
+    'the `||` fallback silently swaps identity to admin; use an explicit presence check')
+  assert.ok(/hasOwnProperty\.call\(opts, 'token'\)/.test(driver),
+    'an explicitly-passed token must be used as-is, even if empty, so failures surface')
+
+  // Same shape one level down: an unmapped field silently became its own label, which the route
+  // then rejects as an unknown fieldId — or worse, accepts into the wrong column.
+  assert.equal(/physicalByName\[label\] \|\| label/.test(driver), false,
+    'a missing physical mapping must not degrade to the literal label')
+  assert.ok(/__UNMAPPED__/.test(driver),
+    'an unmapped field must produce a loud, unmistakable key rather than a plausible one')
 })
 
 test('BEHAVIOURAL: a bare read yields LOGICAL keys only when projectId + objectId are right', async () => {

--- a/scripts/ops/fixtures/integration-k3wise/rehearsal-driver-contract.test.mjs
+++ b/scripts/ops/fixtures/integration-k3wise/rehearsal-driver-contract.test.mjs
@@ -307,7 +307,15 @@ function predicateOf(src, step) {
     if (c === ')' || c === ']' || c === '}') { depth--; continue }
     if (c === ',' && depth === 0) break
   }
-  return src.slice(start, i).replace(/\s+/g, ' ').trim()
+  // REVIEW P2-B: strip comments from the SPAN. Without this, moving the other conjuncts into
+  // `//` comments inside the predicate leaves every manifest needle present verbatim while the
+  // live expression is just `ok(dryRun)` — the guard reads its own documentation as evidence.
+  // Third occurrence of "prose satisfies a code-shaped assertion" on this line.
+  return src.slice(start, i)
+    .replace(/\/\*[^]*?\*\//g, ' ')
+    .replace(/\/\/[^\n]*/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
 }
 
 // POSITIVE MANIFEST: what each step's predicate MUST assert.
@@ -322,6 +330,10 @@ function predicateOf(src, step) {
 //
 // Weakening any predicate below now requires EDITING THIS TABLE -- a visible, reviewable act --
 // rather than quietly satisfying a pattern nobody re-reads.
+// Each entry is { needles, conjuncts }. `conjuncts` is what makes `&&` -> `||` visible: substring
+// presence is invariant under that swap, and the swap turns a five-way AND into a five-way OR,
+// i.e. "HTTP 200 is enough". Needles pin WHAT is asserted; conjuncts pin that they are all
+// REQUIRED TOGETHER.
 const REQUIRED_DISCRIMINATORS = {
   'create-source-system': ['ok(sourceSystem)', 'payload(sourceSystem)?.id'],
   'create-target-system': ['ok(targetSystem)', 'payload(targetSystem)?.id'],
@@ -384,10 +396,25 @@ test('every record() step asserts its NAMED discriminators — positive manifest
   for (const step of declared) {
     const predicate = predicateOf(driver, step)
     assert.ok(predicate.length > 0, `step '${step}' has an empty predicate`)
-    for (const needle of REQUIRED_DISCRIMINATORS[step]) {
+    const needles = REQUIRED_DISCRIMINATORS[step]
+    for (const needle of needles) {
       assert.ok(predicate.includes(needle),
         `step '${step}' no longer asserts ${JSON.stringify(needle)}\n    predicate is: ${predicate}`)
     }
+    // REVIEW P2-B: substring presence is INVARIANT under `&&` -> `||`, and that swap turns a
+    // five-way AND into "any one of these is enough" — i.e. the dry-run discriminator collapses to
+    // "HTTP 200" while every needle survives verbatim. Needles pin WHAT is asserted; these two pin
+    // that the assertions are required TOGETHER.
+    //
+    // All 17 predicates are pure conjunctions (verified mechanically before this was written; the
+    // check below is what keeps that true). `??` is deliberately not `||`.
+    assert.ok(!predicate.includes('||'),
+      `step '${step}' introduced a disjunction; a predicate that passes on ANY conjunct is not the `
+      + `gate this manifest describes\n    predicate is: ${predicate}`)
+    const conjunctions = (predicate.match(/&&/g) || []).length
+    assert.ok(conjunctions >= needles.length - 1,
+      `step '${step}' has ${conjunctions} '&&' for ${needles.length} required discriminators — some `
+      + `are no longer joined as a conjunction\n    predicate is: ${predicate}`)
   }
 
   // NEGATIVE CONTROL on the checker itself: the exact degradations that defeated the denylist

--- a/scripts/ops/fixtures/integration-k3wise/rehearsal-driver-contract.test.mjs
+++ b/scripts/ops/fixtures/integration-k3wise/rehearsal-driver-contract.test.mjs
@@ -214,6 +214,32 @@ test('no silent credential fallback, and no silent field-map degradation', () =>
     'an unmapped field must produce a loud, unmistakable key rather than a plausible one')
 })
 
+test('the mock arms its session gate and its call logger — both are load-bearing', () => {
+  // Review P2-6: `requireSession: true` in run-mock-k3-server.mjs is the ONLY thing arming owner
+  // HOLD point F, and nothing pinned it. Deleting one word would let the whole lane pass "clean"
+  // against a permissive mock — a green that means nothing. Same for the logger: the workflow's
+  // save-only allowlist reads mock-k3.log, so a mock that logs nothing makes that check vacuous
+  // (which is exactly what owner point E caught the first time).
+  const runner = fs.readFileSync(
+    path.join(repoRoot, 'scripts/ops/fixtures/integration-k3wise/run-mock-k3-server.mjs'), 'utf8')
+
+  assert.ok(/requireSession:\s*true/.test(runner),
+    'the rehearsal mock MUST require a session; without it the lane rehearses against a mock that '
+    + 'accepts anything, and owner HOLD point F is unarmed')
+  // Must match the EMITTING CALL, not the word anywhere: the file's own header comment says
+  // "K3CALL", so a bare /K3CALL/ passed while the logger body had been replaced with `void call`.
+  // Third prose-matched-instead-of-code slip in this session.
+  assert.ok(/console\.log\([^)]*K3CALL/.test(runner),
+    'the mock MUST actually EMIT K3CALL <METHOD> <pathname>; the workflow save-only allowlist greps '
+    + 'that stream, and an empty stream passes an absence check vacuously')
+
+  // POSITIVE CONTROL — the assertions must be able to fail.
+  assert.equal(/requireSession:\s*true/.test('const server = createMockK3WebApiServer({ seedListRows })'), false,
+    'the session assertion must reject a runner that omits the flag')
+  assert.equal(/console\.log\([^)]*K3CALL/.test('logger: (call) => { void call }'), false,
+    'the logger assertion must reject a runner whose logger emits nothing')
+})
+
 test('BEHAVIOURAL: a bare read yields LOGICAL keys only when projectId + objectId are right', async () => {
   // The source-regex assertions above are necessary but NOT sufficient: they were 4/4 green while
   // a bare read returned raw `fld_*` keys with code/name EMPTY. `ensureObject` rewrites every

--- a/scripts/ops/fixtures/integration-k3wise/rehearsal-driver-contract.test.mjs
+++ b/scripts/ops/fixtures/integration-k3wise/rehearsal-driver-contract.test.mjs
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+// REHEARSAL DRIVER CONTRACT — offline guards for the class of defect that made the source swap
+// fail review: strings in the driver that name things which DO NOT EXIST.
+//
+// Four breaks shipped at once (review 20260805): an adapter kind that was never registered
+// (`metasheet:staging-source` vs `metasheet:staging`), a route path that is not mounted
+// (`/records` vs `/api/multitable/records`), a request body key the route strips (`fields` vs
+// `data`), and field mappings naming the OLD source's columns. Every one is checkable without a
+// server, and none was checked — the driver had zero test coverage.
+//
+// These assertions are deliberately MECHANICAL (compare against the registry / the route table)
+// rather than a hand-maintained list, because a hand-maintained list drifts into the same
+// fiction the driver did.
+
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+import test from 'node:test'
+import { fileURLToPath } from 'node:url'
+import { createRequire } from 'node:module'
+
+const require = createRequire(import.meta.url)
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../..')
+const driverPath = path.join(repoRoot, 'scripts/ops/stock-prep-window-rehearsal-driver.mjs')
+const driver = fs.readFileSync(driverPath, 'utf8')
+
+test('every adapter kind the driver registers is actually registered by the plugin', () => {
+  const pluginIndex = fs.readFileSync(
+    path.join(repoRoot, 'plugins/plugin-integration-core/index.cjs'), 'utf8')
+  const registered = new Set(
+    [...pluginIndex.matchAll(/registerAdapter\('([^']+)'/g)].map((m) => m[1]))
+  assert.ok(registered.size >= 3, `registry scan found too little (${registered.size})`)
+
+  const used = [...driver.matchAll(/kind:\s*'([^']+)'/g)].map((m) => m[1])
+  assert.ok(used.length >= 2, 'the driver must register at least a source and a target')
+  for (const kind of used) {
+    assert.ok(registered.has(kind),
+      `driver uses adapter kind '${kind}', which the plugin never registers. `
+      + `Registered: ${[...registered].sort().join(', ')}. `
+      + 'external-systems does NOT validate kind, so this passes creation with 201 and only '
+      + 'explodes later at createAdapter.')
+  }
+
+  // POSITIVE CONTROL — the check must reject a kind that is not in the registry.
+  assert.equal(registered.has('metasheet:staging-source'), false,
+    'the exact typo this test exists for must still be detectable')
+})
+
+test('every API path the driver calls is mounted somewhere in the repo', () => {
+  const paths = [...driver.matchAll(/call\('(?:GET|POST|PUT|DELETE)',\s*[`']([^`'$]+)/g)]
+    .map((m) => m[1])
+    .filter((p) => p.startsWith('/'))
+  assert.ok(paths.length >= 4, `path scan found too little (${paths.length})`)
+
+  const routeSources = [
+    'plugins/plugin-integration-core/lib/http-routes.cjs',
+    'packages/core-backend/src/routes/univer-meta.ts',
+  ].map((rel) => {
+    try { return fs.readFileSync(path.join(repoRoot, rel), 'utf8') } catch { return '' }
+  }).join('\n')
+  assert.ok(routeSources.length > 10000, 'route sources did not load — the check would pass vacuously')
+
+  for (const p of paths) {
+    // strip the mount prefix the plugin routes carry, and any ${...} segment
+    const tail = p.replace(/^\/api\/multitable/, '').replace(/^\/api\/integration/, '')
+    const needle = tail.split('/').filter((seg) => seg && !seg.includes('{')).slice(-1)[0]
+    if (!needle) continue
+    assert.ok(routeSources.includes(needle),
+      `driver calls '${p}' but no route source mentions '${needle}'`)
+  }
+
+  // POSITIVE CONTROL — a bare '/records' is NOT the mounted path; the real one is prefixed.
+  assert.ok(driver.includes('/api/multitable/records'),
+    'the record-seeding call must use the mounted path, not a bare /records')
+})
+
+test('pipeline fieldMappings name STAGING columns as source, not the K3 target columns', () => {
+  const installer = fs.readFileSync(
+    path.join(repoRoot, 'plugins/plugin-integration-core/lib/staging-installer.cjs'), 'utf8')
+  const stagingBlock = installer.slice(installer.indexOf("id: 'plm_raw_items'"))
+  const stagingFields = new Set(
+    [...stagingBlock.slice(0, 1200).matchAll(/\{ id: '([A-Za-z_][\w]*)'/g)].map((m) => m[1]))
+  assert.ok(stagingFields.has('code') && stagingFields.has('name'),
+    'staging field scan failed — the check below would be vacuous')
+
+  const sourceFields = [...driver.matchAll(/sourceField:\s*'([^']+)'/g)].map((m) => m[1])
+  assert.ok(sourceFields.length >= 2, 'the pipeline must map at least two fields')
+  for (const f of sourceFields) {
+    assert.ok(stagingFields.has(f),
+      `fieldMappings use sourceField '${f}', which is not a column of the staging source `
+      + `(plm_raw_items has: ${[...stagingFields].join(', ')}). With the old K3 source these were `
+      + 'K3 names; after the swap that yields status=not_applyable with add:0 / failed:N.')
+  }
+})
+
+test('the seeding call uses the body key the route reads, and fills required columns', () => {
+  const seedBlock = driver.slice(driver.indexOf('/api/multitable/records'))
+  assert.ok(/\bdata:\s*\{/.test(seedBlock.slice(0, 600)),
+    "the record body key must be `data` — the route's zod schema strips unknown keys, so `fields` "
+    + 'would have written EMPTY rows and read as a clean pass')
+  for (const required of ['sourceSystemId', 'objectType', 'sourceId']) {
+    assert.ok(seedBlock.slice(0, 600).includes(required),
+      `plm_raw_items marks '${required}' required; omitting it fails the row`)
+  }
+})

--- a/scripts/ops/fixtures/integration-k3wise/rehearsal-driver-contract.test.mjs
+++ b/scripts/ops/fixtures/integration-k3wise/rehearsal-driver-contract.test.mjs
@@ -47,21 +47,21 @@ test('every adapter kind the driver registers is actually registered by the plug
 })
 
 test('every API path the driver calls is mounted somewhere in the repo', () => {
-  const paths = [...driver.matchAll(/call\('(?:GET|POST|PUT|DELETE)',\s*[`']([^`'$]+)/g)]
+  const paths = [...driver.matchAll(/call\('(?:GET|POST|PUT|DELETE)',\s*[`']([^`'$?]+)/g)]
     .map((m) => m[1])
     .filter((p) => p.startsWith('/'))
-  assert.ok(paths.length >= 4, `path scan found too little (${paths.length})`)
+  assert.ok(paths.length >= 6, `path scan found too little (${paths.length})`)
 
   const routeSources = [
     'plugins/plugin-integration-core/lib/http-routes.cjs',
     'packages/core-backend/src/routes/univer-meta.ts',
+    'packages/core-backend/src/routes/api-tokens.ts',
   ].map((rel) => {
     try { return fs.readFileSync(path.join(repoRoot, rel), 'utf8') } catch { return '' }
   }).join('\n')
-  assert.ok(routeSources.length > 10000, 'route sources did not load — the check would pass vacuously')
+  assert.ok(routeSources.length > 10000, 'route sources did not load — the check would be vacuous')
 
   for (const p of paths) {
-    // strip the mount prefix the plugin routes carry, and any ${...} segment
     const tail = p.replace(/^\/api\/multitable/, '').replace(/^\/api\/integration/, '')
     const needle = tail.split('/').filter((seg) => seg && !seg.includes('{')).slice(-1)[0]
     if (!needle) continue
@@ -69,9 +69,11 @@ test('every API path the driver calls is mounted somewhere in the repo', () => {
       `driver calls '${p}' but no route source mentions '${needle}'`)
   }
 
-  // POSITIVE CONTROL — a bare '/records' is NOT the mounted path; the real one is prefixed.
-  assert.ok(driver.includes('/api/multitable/records'),
-    'the record-seeding call must use the mounted path, not a bare /records')
+  // The two multitable calls MUST carry the /api/multitable mount — a bare path is not routed.
+  for (const bare of ["'/records'", "'/fields'", "'/api-tokens'"]) {
+    assert.equal(driver.includes(`call('POST', ${bare}`) || driver.includes(`call('GET', ${bare}`), false,
+      `${bare} is not a mounted path; it must be prefixed with /api/multitable`)
+  }
 })
 
 test('pipeline fieldMappings name STAGING columns as source, not the K3 target columns', () => {
@@ -93,13 +95,107 @@ test('pipeline fieldMappings name STAGING columns as source, not the K3 target c
   }
 })
 
-test('the seeding call uses the body key the route reads, and fills required columns', () => {
+test('the seeding body is keyed through the RESOLVED PHYSICAL map, not logical names', () => {
+  // Owner + review 20260805: the previous version of this test was `includes('sourceSystemId')`,
+  // which the BROKEN body satisfied too — it scored 4/4 while the driver sent logical names and
+  // the route answered 400 `Unknown fieldId`. `ensureObject` rewrites every field id to
+  // `fld_<sha1>`, so logical names are never valid runtime keys.
   const seedBlock = driver.slice(driver.indexOf('/api/multitable/records'))
-  assert.ok(/\bdata:\s*\{/.test(seedBlock.slice(0, 600)),
-    "the record body key must be `data` — the route's zod schema strips unknown keys, so `fields` "
-    + 'would have written EMPTY rows and read as a clean pass')
-  for (const required of ['sourceSystemId', 'objectType', 'sourceId']) {
-    assert.ok(seedBlock.slice(0, 600).includes(required),
-      `plm_raw_items marks '${required}' required; omitting it fails the row`)
-  }
+  const head = seedBlock.slice(0, 900)
+
+  assert.ok(/\bdata:\s*Object\.fromEntries/.test(head),
+    'the body must be BUILT from the resolved map, not written as a literal of logical names')
+  assert.ok(/physicalByName\[/.test(head),
+    'each key must be looked up in the physical map the server returned')
+
+  // And the map must come from the server, not be assumed.
+  assert.ok(/\/api\/multitable\/fields\?sheetId=/.test(driver),
+    'the physical map must be FETCHED (GET /api/multitable/fields), never inferred')
+
+  // POSITIVE CONTROL — the old, broken shape must NOT satisfy this test.
+  const brokenShape = "data: {\n  sourceSystemId: 'x',\n  code: 'y',\n}"
+  assert.equal(/\bdata:\s*Object\.fromEntries/.test(brokenShape), false,
+    'a literal logical-name body must fail this assertion — otherwise it pins nothing')
+})
+
+test("the driver's OWN staging config carries projectId and a provisioned objectId", () => {
+  // Mutations M1/M2 exposed this: the behavioural test builds its own config, so the DRIVER's
+  // config was unguarded — dropping projectId or renaming the object key left the suite green
+  // while reproducing the exact reported failure. Wire-vs-fixture drift, inside the guard added
+  // to stop wire-vs-fixture drift.
+  const cfgBlock = driver.slice(driver.indexOf("kind: 'metasheet:staging'"))
+  const head = cfgBlock.slice(0, 900)
+
+  assert.ok(/projectId:\s*stagingProjectId/.test(head),
+    'the staging source config must pass projectId — resolveProvisionedFieldIdMap returns {} '
+    + 'without it, and read() then yields raw fld_* keys with code/name empty')
+  assert.ok(/stagingProjectId\s*=\s*payload\(stagingInstall\)/.test(driver),
+    'projectId must come from the staging/install response, not be hardcoded')
+
+  // The objects KEY must be a descriptor the installer actually provisions.
+  const installer = fs.readFileSync(
+    path.join(repoRoot, 'plugins/plugin-integration-core/lib/staging-installer.cjs'), 'utf8')
+  const provisioned = new Set(
+    [...installer.matchAll(/^\s*id: '([a-z_]+)',\s*$/gm)].map((m) => m[1]))
+  assert.ok(provisioned.has('plm_raw_items'),
+    'descriptor scan failed — the assertion below would be vacuous')
+
+  const objectKey = (head.match(/objects:\s*\{[^]*?([a-z_]+):\s*\{/) || [])[1]
+  assert.ok(objectKey, 'could not read the objects key from the driver')
+  assert.ok(provisioned.has(objectKey),
+    `driver keys its staging object '${objectKey}', which the installer never provisions `
+    + `(provisioned: ${[...provisioned].join(', ')}). resolveProvisionedFieldIdMap looks up `
+    + '(projectId, objectId), so a wrong key silently yields an EMPTY alias map.')
+
+  // and the pipeline must select that same object
+  assert.ok(driver.includes(`sourceObject: '${objectKey}'`),
+    `the pipeline's sourceObject must match the staging objects key ('${objectKey}')`)
+})
+
+test('BEHAVIOURAL: a bare read yields LOGICAL keys only when projectId + objectId are right', async () => {
+  // The source-regex assertions above are necessary but NOT sufficient: they were 4/4 green while
+  // a bare read returned raw `fld_*` keys with code/name EMPTY. `ensureObject` rewrites every
+  // field id to `fld_<sha1>`, so the alias map is the ONLY thing that makes rows mappable, and it
+  // resolves on (projectId, objectId). A grep cannot see that. This exercises the real adapter.
+  const { createMetaSheetStagingSourceAdapter } = require(path.join(repoRoot,
+    'plugins/plugin-integration-core/lib/adapters/metasheet-staging-source-adapter.cjs'))
+
+  const PHYSICAL = { code: 'fld_code_sha', name: 'fld_name_sha' }
+  const rows = [
+    { id: 'rec_1', data: { [PHYSICAL.code]: 'MAT-RH-001', [PHYSICAL.name]: 'A' } },
+    { id: 'rec_2', data: { [PHYSICAL.code]: 'MAT-RH-002', [PHYSICAL.name]: 'B' } },
+  ]
+  const context = { api: { multitable: {
+    records: { async queryRecords() { return rows } },
+    // Mirrors provisioning: it answers ONLY for the object it provisioned.
+    provisioning: { async resolveFieldIds({ objectId, fieldIds }) {
+      if (objectId !== 'plm_raw_items') return {}
+      return Object.fromEntries(fieldIds.filter((f) => PHYSICAL[f]).map((f) => [f, PHYSICAL[f]]))
+    } },
+  } } }
+  const mk = (config) => createMetaSheetStagingSourceAdapter({
+    system: { kind: 'metasheet:staging', config }, context })
+
+  const good = await mk({
+    projectId: 'proj_1',
+    objects: { plm_raw_items: { sheetId: 'sht_1', fields: ['code', 'name'] } },
+  }).read({ object: 'plm_raw_items', limit: 10, cursor: null })
+  assert.equal(good.records.length, 2, 'the bare read must return the seeded rows')
+  assert.equal(good.records[0].code, 'MAT-RH-001', 'logical `code` must resolve')
+  assert.equal(good.records[0].name, 'A', 'logical `name` must resolve')
+
+  // POSITIVE CONTROLS — each omission reproduces the reported symptom exactly.
+  const noProject = await mk({
+    objects: { plm_raw_items: { sheetId: 'sht_1', fields: ['code', 'name'] } },
+  }).read({ object: 'plm_raw_items', limit: 10, cursor: null })
+  assert.equal(noProject.records[0].code, undefined, 'no projectId -> empty alias map')
+
+  const wrongObject = await mk({
+    projectId: 'proj_1',
+    objects: { material: { sheetId: 'sht_1', fields: ['code', 'name'] } },
+  }).read({ object: 'material', limit: 10, cursor: null })
+  assert.equal(wrongObject.records[0].code, undefined,
+    'objectId `material` was never provisioned -> empty alias map (the driver\'s original bug)')
+  assert.equal(wrongObject.records[0][PHYSICAL.code], 'MAT-RH-001',
+    'and the raw physical key is what comes through instead')
 })

--- a/scripts/ops/fixtures/integration-k3wise/rehearsal-driver-contract.test.mjs
+++ b/scripts/ops/fixtures/integration-k3wise/rehearsal-driver-contract.test.mjs
@@ -293,7 +293,13 @@ test('no record() step asserts a CONSTANT — every predicate reads real evidenc
   // record() is `record(step, pass, evidence)`, and it process.exit(1)s on a false predicate, so
   // `summary.pass = true` at the end IS conditional. What was unguarded is the predicates.
   const calls = [...driver.matchAll(/record\(\s*'([a-z0-9-]+)'\s*,\s*([^,]+(?:,(?![\s\n]*\{)[^,]+)*),/g)]
-  assert.ok(calls.length >= 8, `record() scan found too little (${calls.length}) — would be vacuous`)
+  // EQUALITY, not a floor. A floor cannot distinguish "scanned every step" from "the regex
+  // silently dropped the steps whose predicate contains a comma" — and the dropped ones would
+  // then carry ZERO constant-checking while the assertion still passed.
+  const declared = [...driver.matchAll(/^\s*record\('/gm)].length
+  assert.equal(calls.length, declared,
+    `the predicate scan parsed ${calls.length} of ${declared} record() steps — the unparsed ones `
+    + 'are exactly the steps this check would silently exempt')
 
   const constant = calls
     .map(([, step, predicate]) => [step, predicate.trim()])

--- a/scripts/ops/fixtures/integration-k3wise/rehearsal-harness.test.mjs
+++ b/scripts/ops/fixtures/integration-k3wise/rehearsal-harness.test.mjs
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+// Rehearsal-harness load-bearing test (owner review 2026-08-05, staging-window-rehearsal
+// points E/F). Proves the two mock-server fixes the rehearsal workflow depends on actually work
+// at runtime, rather than assuming them from reading the source:
+//
+//   F — requireSession:true rejects a call missing the session (every endpoint but Login), and
+//       accepts the SAME session shape the real K3WiseWebApiAdapter carries after Login (either
+//       the X-K3-Session header or the equivalent Cookie).
+//
+//   E — the runner's `K3CALL <METHOD> <pathname>` logger actually records calls. This is the
+//       owner-observed bug this task traces back to: the staging-window-rehearsal workflow's
+//       "Save-only invariant seen from the WIRE" step grep-asserts mock-k3.log has ZERO
+//       Submit/Audit lines — but before this fix nothing was ever written to that stream, so the
+//       absence check passed vacuously on an empty file regardless of what happened on the wire.
+//       A positive control (log DOES show GetList/Save) only has teeth if the log is real.
+//
+// Node-native test runner, run directly — fixtures-side suite pattern (see the sibling
+// mock-k3-webapi-server.test.mjs / fixture-contract.test.mjs / mock-sqlserver-executor.test.mjs).
+// Deliberately NOT wired into package.json's verify:integration-k3wise:poc chain.
+//
+// Run: node scripts/ops/fixtures/integration-k3wise/rehearsal-harness.test.mjs
+
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { createMockK3WebApiServer } from './mock-k3-webapi-server.mjs'
+
+const SESSION_HEADER = 'X-K3-Session'
+const SESSION_ID = 'mock-session-1'
+
+const SEED_LIST_ROWS = [
+  { FItemID: 61001, FNumber: 'MAT-RH-001', FName: 'Rehearsal material A', FModel: 'SPEC-RH-A', FUnitID: 'PCS' },
+  { FItemID: 61002, FNumber: 'MAT-RH-002', FName: 'Rehearsal material B', FModel: 'SPEC-RH-B', FUnitID: 'PCS' },
+]
+
+async function postJson(baseUrl, pathname, payload, headers = {}) {
+  const response = await fetch(`${baseUrl}${pathname}`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', ...headers },
+    body: JSON.stringify(payload),
+  })
+  let body = null
+  try { body = await response.json() } catch { /* not every response is JSON */ }
+  return { status: response.status, body }
+}
+
+test('rehearsal harness: unauthenticated GetList is refused (F, negative half)', async () => {
+  const mock = createMockK3WebApiServer({ requireSession: true, seedListRows: SEED_LIST_ROWS })
+  const baseUrl = await mock.start()
+  try {
+    const unauth = await postJson(baseUrl, '/K3API/Material/GetList', { Data: { Top: 10, PageIndex: 1 } })
+    assert.equal(unauth.status, 401, 'an unauthenticated read must be refused (401)')
+    assert.equal(unauth.body?.success, false)
+  } finally {
+    await mock.stop()
+  }
+})
+
+test('rehearsal harness: authenticated GetList succeeds with the seeded 2 rows (F, positive half)', async () => {
+  const logLines = []
+  const mock = createMockK3WebApiServer({
+    requireSession: true,
+    seedListRows: SEED_LIST_ROWS,
+    logger: (call) => { logLines.push(`K3CALL ${call.method} ${call.pathname}`) },
+  })
+  const baseUrl = await mock.start()
+  try {
+    const login = await postJson(baseUrl, '/K3API/Login', { username: 'demo', password: 'demo', acctId: 'RH' })
+    assert.equal(login.status, 200)
+    assert.equal(login.body?.sessionId, SESSION_ID)
+
+    const list = await postJson(baseUrl, '/K3API/Material/GetList', { Data: { Top: 10, PageIndex: 1 } }, {
+      [SESSION_HEADER]: SESSION_ID,
+    })
+    assert.equal(list.status, 200)
+    assert.equal(list.body?.Data?.DATA?.length, 2, 'authenticated GetList must return the 2 seeded rows')
+
+    // E, part 1 — the load-bearing proof the owner's review demanded: the logger DID record the
+    // GetList call in the EXACT `K3CALL POST /K3API/Material/GetList` shape the workflow's
+    // positive control greps for.
+    assert.ok(
+      logLines.includes('K3CALL POST /K3API/Material/GetList'),
+      `logger must record the GetList call; got: ${JSON.stringify(logLines)}`,
+    )
+  } finally {
+    await mock.stop()
+  }
+})
+
+test('rehearsal harness: requireSession accepts an equivalent session cookie, not only the header', async () => {
+  const mock = createMockK3WebApiServer({ requireSession: true })
+  const baseUrl = await mock.start()
+  try {
+    const login = await fetch(`${baseUrl}/K3API/Login`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ username: 'demo', password: 'demo', acctId: 'RH' }),
+    })
+    const setCookie = login.headers.get('set-cookie')
+    assert.ok(setCookie, 'login must set a session cookie')
+
+    // The real adapter forwards the ENTIRE raw Set-Cookie value back as its request Cookie
+    // header (k3-wise-webapi-adapter.cjs:1605-1606) — not a re-parsed name=value pair. Reproduce
+    // that exact shape here rather than a cleaner hand-built cookie.
+    const health = await fetch(`${baseUrl}/K3API/Health`, {
+      method: 'GET',
+      headers: { Cookie: setCookie },
+    })
+    assert.equal(health.status, 200, 'a request carrying the equivalent session cookie must be accepted')
+  } finally {
+    await mock.stop()
+  }
+})
+
+test('rehearsal harness: requireSession defaults to false (existing suites unaffected)', async () => {
+  const mock = createMockK3WebApiServer({ seedListRows: SEED_LIST_ROWS })
+  const baseUrl = await mock.start()
+  try {
+    const list = await postJson(baseUrl, '/K3API/Material/GetList', { Data: { Top: 10, PageIndex: 1 } })
+    assert.equal(list.status, 200, 'default requireSession:false must not gate unauthenticated calls')
+  } finally {
+    await mock.stop()
+  }
+})
+
+test('rehearsal harness: logger sees Save AND Submit — the visibility the workflow\'s absence-check depends on (E, part 2)', async () => {
+  const logLines = []
+  const mock = createMockK3WebApiServer({
+    requireSession: true,
+    seedListRows: SEED_LIST_ROWS,
+    logger: (call) => { logLines.push(`K3CALL ${call.method} ${call.pathname}`) },
+  })
+  const baseUrl = await mock.start()
+  try {
+    await postJson(baseUrl, '/K3API/Login', { username: 'demo', password: 'demo', acctId: 'RH' })
+
+    const save = await postJson(baseUrl, '/K3API/Material/Save', { Data: { FNumber: 'MAT-RH-001', FName: 'x' } }, {
+      [SESSION_HEADER]: SESSION_ID,
+    })
+    assert.equal(save.status, 200)
+    assert.equal(save.body?.success, true)
+    assert.ok(
+      logLines.includes('K3CALL POST /K3API/Material/Save'),
+      `logger must record the Save call; got: ${JSON.stringify(logLines)}`,
+    )
+
+    // The workflow's actual assertion is an ABSENCE check on Submit/Audit. That check only has
+    // teeth if a Submit call, had one happened, would actually show up in the log. Prove it does.
+    const submit = await postJson(baseUrl, '/K3API/Material/Submit', { Number: 'MAT-RH-001' }, {
+      [SESSION_HEADER]: SESSION_ID,
+    })
+    assert.equal(submit.status, 200)
+    assert.ok(
+      logLines.includes('K3CALL POST /K3API/Material/Submit'),
+      `logger must record the Submit call (the workflow's absence-check depends on this being visible); got: ${JSON.stringify(logLines)}`,
+    )
+  } finally {
+    await mock.stop()
+  }
+})

--- a/scripts/ops/fixtures/integration-k3wise/run-mock-k3-server.mjs
+++ b/scripts/ops/fixtures/integration-k3wise/run-mock-k3-server.mjs
@@ -6,6 +6,15 @@
 // `add` deterministically. VALUES-FREE stdout: the base URL line and counts only.
 //
 // Env: MOCK_K3_PORT (optional; default ephemeral). Prints `MOCK_K3_BASE_URL=<url>` when ready.
+//
+// Owner review (2026-08-05, points E/F): the mock now (a) REQUIRES the session the real
+// K3WiseWebApiAdapter obtains via Login on every other endpoint — a rehearsal that dropped the
+// auth wiring now fails loudly instead of rehearsing "clean" against a permissive mock — and
+// (b) logs every call as a single `K3CALL <METHOD> <pathname>` stdout line (values-free: no
+// body), captured into mock-k3.log by the workflow. Point E is a direct fix for an owner-observed
+// bug: the workflow's "Save-only invariant seen from the WIRE" step greps mock-k3.log for
+// Submit/Audit — but nothing was ever written to that stream, so an absence check against it
+// passed vacuously regardless of what actually happened on the wire. See rehearsal-harness.test.mjs.
 
 import { createMockK3WebApiServer } from './mock-k3-webapi-server.mjs'
 
@@ -14,7 +23,12 @@ const seedListRows = [
   { FItemID: 61002, FNumber: 'MAT-RH-002', FName: 'Rehearsal material B', FModel: 'SPEC-RH-B', FUnitID: 'PCS' },
 ]
 
-const server = createMockK3WebApiServer({ seedListRows })
+const server = createMockK3WebApiServer({
+  seedListRows,
+  requireSession: true,
+  // Values-free: method + path only, never the (sanitized-but-still-present) body.
+  logger: (call) => { console.log(`K3CALL ${call.method} ${call.pathname}`) },
+})
 const port = Number(process.env.MOCK_K3_PORT) > 0 ? Number(process.env.MOCK_K3_PORT) : 0
 const baseUrl = await server.start(port)
 console.log(`MOCK_K3_BASE_URL=${baseUrl}`)

--- a/scripts/ops/fixtures/integration-k3wise/run-mock-k3-server.mjs
+++ b/scripts/ops/fixtures/integration-k3wise/run-mock-k3-server.mjs
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+// Standalone runner for the mock K3 WISE WebAPI server — the far end of the STAGING WINDOW
+// REHEARSAL (owner authorization 2026-08-05: 「授权 staging 部署」, ephemeral-CI substrate per
+// the reserved discretion). Seeds the LIST catalogue with a bounded synthetic source set; the
+// Save/GetDetail store starts EMPTY so the rehearsal's dry-run classifies every source row as
+// `add` deterministically. VALUES-FREE stdout: the base URL line and counts only.
+//
+// Env: MOCK_K3_PORT (optional; default ephemeral). Prints `MOCK_K3_BASE_URL=<url>` when ready.
+
+import { createMockK3WebApiServer } from './mock-k3-webapi-server.mjs'
+
+const seedListRows = [
+  { FItemID: 61001, FNumber: 'MAT-RH-001', FName: 'Rehearsal material A', FModel: 'SPEC-RH-A', FUnitID: 'PCS' },
+  { FItemID: 61002, FNumber: 'MAT-RH-002', FName: 'Rehearsal material B', FModel: 'SPEC-RH-B', FUnitID: 'PCS' },
+]
+
+const server = createMockK3WebApiServer({ seedListRows })
+const port = Number(process.env.MOCK_K3_PORT) > 0 ? Number(process.env.MOCK_K3_PORT) : 0
+const baseUrl = await server.start(port)
+console.log(`MOCK_K3_BASE_URL=${baseUrl}`)
+console.log(`seedListRows=${seedListRows.length}`)
+
+process.on('SIGTERM', async () => { await server.stop?.(); process.exit(0) })
+process.on('SIGINT', async () => { await server.stop?.(); process.exit(0) })

--- a/scripts/ops/stock-prep-window-rehearsal-driver.mjs
+++ b/scripts/ops/stock-prep-window-rehearsal-driver.mjs
@@ -79,7 +79,10 @@ async function call(method, path, body, opts = {}) {
         // `opts.token` exists for ONE caller: seeding the stand-in source sheet needs an OAPI
         // token with records:write, a different credential from the integration token every
         // other step uses. Defaulting to TOKEN keeps all existing call sites unchanged.
-        Authorization: `Bearer ${opts.token || TOKEN}`,
+        // NO `|| TOKEN` fallback: `requireScope` PASSES when a request carries no apiTokenScopes,
+        // so falling back would silently re-run the call as admin and the lane could not tell
+        // "the minted token works" from "the fallback saved us".
+        Authorization: `Bearer ${Object.prototype.hasOwnProperty.call(opts, 'token') ? opts.token : TOKEN}`,
         // The login token carries no tenant claim; jwt-middleware copies this header into
         // user.tenantId, which is what resolveAuthUserTenantId (write paths) exclusively trusts.
         'x-tenant-id': TENANT_ID,
@@ -182,9 +185,13 @@ const stagingInstall = await call('POST', '/api/integration/staging/install', {}
 const stagingSheets = payload(stagingInstall)?.sheetIds || {}
 const stagingProjectId = payload(stagingInstall)?.projectId || null
 const stagingSheetId = stagingSheets.plm_raw_items || null
-record('staging-install', ok(stagingInstall) && Boolean(stagingSheetId), {
+record('staging-install', ok(stagingInstall) && Boolean(stagingSheetId) && Boolean(stagingProjectId), {
   status: stagingInstall.status,
   sheetCount: Object.keys(stagingSheets).length,
+  // projectId is asserted HERE because a null one is invisible downstream: the config still
+  // *has* the key, the adapter's alias map comes back empty, and the dry-run reports add:0 —
+  // the exact symptom owner review caught by hand.
+  projectIdPresent: Boolean(stagingProjectId),
 })
 
 const sourceStagingSystem = await call('POST', '/api/integration/external-systems', {
@@ -242,13 +249,21 @@ const tokenMint = await call('POST', '/api/multitable/api-tokens', {
   name: 'rehearsal-seed (ephemeral)',
   scopes: ['records:write', 'fields:read'],
 })
-const MULTITABLE_TOKEN = payload(tokenMint)?.token || ''
-record('mint-seed-token', ok(tokenMint) && Boolean(MULTITABLE_TOKEN), {
+// `data.token` is the ApiToken METADATA object; the credential is `data.plaintext` ('mst_…').
+// Reading `.token` produced a truthy OBJECT, so the mint step reported PASS while every
+// subsequent request sent `Bearer [object Object]` and 401'd — a FALSE GREEN followed by a
+// deterministic failure four steps later.
+const MULTITABLE_TOKEN = payload(tokenMint)?.plaintext || ''
+const mintedTokenUsable = typeof MULTITABLE_TOKEN === 'string' && MULTITABLE_TOKEN.startsWith('mst_')
+record('mint-seed-token', ok(tokenMint) && mintedTokenUsable, {
   status: tokenMint.status,
-  scopes: 1,
+  // Assert the SHAPE that makes the credential work, not mere truthiness: `apiTokenAuth` routes
+  // on the `mst_` prefix, so anything else silently falls through to the JWT path.
+  usableShape: mintedTokenUsable,
 })
-if (!MULTITABLE_TOKEN) {
-  console.error('rehearsal driver: could not mint a records:write token from the admin session')
+if (!mintedTokenUsable) {
+  console.error('rehearsal driver: minted token is not a usable mst_ credential '
+    + '(data.plaintext missing or wrong shape)')
   console.log(`REHEARSAL_SUMMARY=${JSON.stringify({ steps, pass: false })}`)
   process.exit(1)
 }
@@ -288,7 +303,7 @@ for (const row of seedRows) {
       'Source ID': row.code,
       Code: row.code,
       Name: row.name,
-    }).map(([label, value]) => [physicalByName[label] || label, value])),
+    }).map(([label, value]) => [physicalByName[label] || `__UNMAPPED__${label}`, value])),
   }, { token: MULTITABLE_TOKEN })
   seeded.push(ok(r))
 }

--- a/scripts/ops/stock-prep-window-rehearsal-driver.mjs
+++ b/scripts/ops/stock-prep-window-rehearsal-driver.mjs
@@ -34,13 +34,6 @@ const BASE_URL = required('BASE_URL')
 const TOKEN = required('TOKEN')
 const MOCK_K3_URL = required('MOCK_K3_URL')
 const TENANT_ID = required('TENANT_ID')
-// A DIFFERENT credential from TOKEN: seeding the stand-in source sheet goes through the OAPI
-// surface (`POST /records`, requireScope('records:write')), which the integration token cannot
-// reach. `staging/install` creates sheets but ZERO rows, so without this there is nothing to
-// read and the dry-run would report `sourceRows: 0` — a vacuous green in a lane whose only
-// purpose is buying information. Required UP FRONT so an operator learns it before creating any
-// systems, not halfway through a window that cannot be retried.
-const MULTITABLE_TOKEN = required('MULTITABLE_RECORDS_TOKEN')
 
 const PROFILE_ID = 'material-k3wise-customer-profile-v1'
 const LIST_PRESET = 'k3wise.material-list.v1'
@@ -187,6 +180,7 @@ const targetSystemId = payload(targetSystem).id
 
 const stagingInstall = await call('POST', '/api/integration/staging/install', {})
 const stagingSheets = payload(stagingInstall)?.sheetIds || {}
+const stagingProjectId = payload(stagingInstall)?.projectId || null
 const stagingSheetId = stagingSheets.plm_raw_items || null
 record('staging-install', ok(stagingInstall) && Boolean(stagingSheetId), {
   status: stagingInstall.status,
@@ -199,7 +193,25 @@ const sourceStagingSystem = await call('POST', '/api/integration/external-system
   kind: 'metasheet:staging',
   role: 'source',
   status: 'active',
-  config: { objects: { material: { sheetId: stagingSheetId, name: 'material' } } },
+  // OWNER REVIEW 20260805: a bare read SUCCEEDED but returned raw `fld_*` physical keys with
+  // code/name EMPTY, so the pipeline got rows it could not map. `resolveProvisionedFieldIdMap`
+  // returns {} unless BOTH projectId and logical field names are present — without them the
+  // adapter has nothing to alias physical ids back to. Supplying both is what makes the rows
+  // readable as code/name.
+  config: {
+    projectId: stagingProjectId,
+    objects: {
+      // KEY = the PROVISIONED descriptor id. `resolveProvisionedFieldIdMap` looks up
+      // (projectId, objectConfig.objectId, fieldIds); keying this 'material' asked provisioning
+      // about an object that was never provisioned, so the alias map came back {} and read()
+      // returned raw fld_* keys.
+      plm_raw_items: {
+        sheetId: stagingSheetId,
+        name: 'plm_raw_items',
+        fields: ['sourceSystemId', 'objectType', 'sourceId', 'code', 'name'],
+      },
+    },
+  },
 })
 record('create-staging-source', ok(sourceStagingSystem) && Boolean(payload(sourceStagingSystem)?.id), {
   status: sourceStagingSystem.status,
@@ -220,6 +232,44 @@ const pipelineSourceSystemId = payload(sourceStagingSystem)?.id || null
 // Fail loudly and specifically rather than proceeding to a dry-run that would report
 // `sourceRows: 0` and look like a clean pass over an empty source — a vacuous green is worse
 // than a red in a lane whose entire purpose is buying information.
+// OWNER REVIEW 20260805: an external `REHEARSAL_MULTITABLE_RECORDS_TOKEN` secret CANNOT work.
+// Every run provisions a FRESH database, so a static token has no corresponding row and is 401
+// by construction — I had built an input that could never be satisfied. The scoped token is
+// minted IN-RUN from the admin JWT this lane already holds, via the session-authenticated
+// token route. No secret, nothing for an operator to pre-place, and the credential dies with
+// the database that issued it.
+const tokenMint = await call('POST', '/api/multitable/api-tokens', {
+  name: 'rehearsal-seed (ephemeral)',
+  scopes: ['records:write', 'fields:read'],
+})
+const MULTITABLE_TOKEN = payload(tokenMint)?.token || ''
+record('mint-seed-token', ok(tokenMint) && Boolean(MULTITABLE_TOKEN), {
+  status: tokenMint.status,
+  scopes: 1,
+})
+if (!MULTITABLE_TOKEN) {
+  console.error('rehearsal driver: could not mint a records:write token from the admin session')
+  console.log(`REHEARSAL_SUMMARY=${JSON.stringify({ steps, pass: false })}`)
+  process.exit(1)
+}
+
+// The seed and the adapter must agree on ONE mapping. Fetch the physical ids from the server
+// rather than assuming logical names round-trip — that assumption is exactly what produced empty
+// code/name.
+const fieldsRes = await call('GET', `/api/multitable/fields?sheetId=${encodeURIComponent(stagingSheetId)}`,
+  undefined, { token: MULTITABLE_TOKEN })
+const fieldList = payload(fieldsRes)?.fields || payload(fieldsRes) || []
+const physicalByName = {}
+for (const f of Array.isArray(fieldList) ? fieldList : []) {
+  const logical = f && (f.name || f.title)
+  const physical = f && (f.id || f.fieldId)
+  if (logical && physical) physicalByName[logical] = physical
+}
+record('resolve-staging-field-map', ok(fieldsRes) && Object.keys(physicalByName).length > 0, {
+  status: fieldsRes.status,
+  mappedFields: Object.keys(physicalByName).length,
+})
+
 const seedRows = [
   { code: 'MAT-RH-001', name: 'Rehearsal material A' },
   { code: 'MAT-RH-002', name: 'Rehearsal material B' },
@@ -230,14 +280,15 @@ for (const row of seedRows) {
     sheetId: stagingSheetId,
     // `data`, not `fields` — the route's zod schema (univer-meta.ts) names it `data` and STRIPS
     // unknown keys, so `fields` would have written empty rows and looked like a clean pass.
-    data: {
+    // Keyed by PHYSICAL field id — what the records route stores and what read() returns.
+    data: Object.fromEntries(Object.entries({
       // These three are `required: true` on plm_raw_items; omitting them fails the row.
-      sourceSystemId: 'rehearsal-stand-in',
-      objectType: 'material',
-      sourceId: row.code,
-      code: row.code,
-      name: row.name,
-    },
+      'Source System': 'rehearsal-stand-in',
+      'Object Type': 'material',
+      'Source ID': row.code,
+      Code: row.code,
+      Name: row.name,
+    }).map(([label, value]) => [physicalByName[label] || label, value])),
   }, { token: MULTITABLE_TOKEN })
   seeded.push(ok(r))
 }
@@ -326,7 +377,7 @@ const pipeline = await call('POST', '/api/integration/pipelines', {
   tenantId: TENANT_ID,
   name: 'Rehearsal window pipeline',
   sourceSystemId: pipelineSourceSystemId,
-  sourceObject: 'material',
+  sourceObject: 'plm_raw_items',
   targetSystemId,
   targetObject: 'material',
   status: 'active',

--- a/scripts/ops/stock-prep-window-rehearsal-driver.mjs
+++ b/scripts/ops/stock-prep-window-rehearsal-driver.mjs
@@ -34,6 +34,13 @@ const BASE_URL = required('BASE_URL')
 const TOKEN = required('TOKEN')
 const MOCK_K3_URL = required('MOCK_K3_URL')
 const TENANT_ID = required('TENANT_ID')
+// A DIFFERENT credential from TOKEN: seeding the stand-in source sheet goes through the OAPI
+// surface (`POST /records`, requireScope('records:write')), which the integration token cannot
+// reach. `staging/install` creates sheets but ZERO rows, so without this there is nothing to
+// read and the dry-run would report `sourceRows: 0` — a vacuous green in a lane whose only
+// purpose is buying information. Required UP FRONT so an operator learns it before creating any
+// systems, not halfway through a window that cannot be retried.
+const MULTITABLE_TOKEN = required('MULTITABLE_RECORDS_TOKEN')
 
 const PROFILE_ID = 'material-k3wise-customer-profile-v1'
 const LIST_PRESET = 'k3wise.material-list.v1'
@@ -69,14 +76,17 @@ function record(step, pass, evidence) {
 // downstream assertion below is a POSITIVE check on real field values (never a bare `!ok(...)`),
 // so a timeout's null data fails those checks the same way a bad response would — no separate
 // early-exit branch needed to make a timeout register as FAIL.
-async function call(method, path, body) {
+async function call(method, path, body, opts = {}) {
   let res
   try {
     res = await fetch(`${BASE_URL}${path}`, {
       method,
       headers: {
         'Content-Type': 'application/json',
-        Authorization: `Bearer ${TOKEN}`,
+        // `opts.token` exists for ONE caller: seeding the stand-in source sheet needs an OAPI
+        // token with records:write, a different credential from the integration token every
+        // other step uses. Defaulting to TOKEN keeps all existing call sites unchanged.
+        Authorization: `Bearer ${opts.token || TOKEN}`,
         // The login token carries no tenant claim; jwt-middleware copies this header into
         // user.tenantId, which is what resolveAuthUserTenantId (write paths) exclusively trusts.
         'x-tenant-id': TENANT_ID,
@@ -164,6 +174,66 @@ record('create-target-system', ok(targetSystem) && Boolean(payload(targetSystem)
 const targetSystemId = payload(targetSystem).id
 
 // ---------------------------------------------------------------------------------------------
+// Step 0-c — THE PIPELINE SOURCE. Not K3: no K3 configuration can serve as a C6 source, because
+// external-write-dry-run's readSourceRows issues a bare read({object, limit, cursor}) and K3
+// answers K3_WISE_READ_LIST_ROUTE_UNSUPPORTED / K3_WISE_READ_KEY_REQUIRED with ZERO fetch calls
+// (all three readMode variants, reproduced offline). Every ruled precedent uses a non-K3 source.
+//
+// HONEST LIMIT, stated in the evidence itself: this source leg is a STAND-IN. The rehearsal
+// proves the C6 write lifecycle against a real deployed package; it does NOT exercise the
+// customer's real source connector. The K3 READ leg is covered separately by step 1's
+// read-smoke, which runs against the real K3 read record.
+// ---------------------------------------------------------------------------------------------
+
+const stagingInstall = await call('POST', '/api/integration/staging/install', {})
+const stagingSheets = payload(stagingInstall)?.sheetIds || {}
+const stagingSheetId = stagingSheets.plm_raw_items || null
+record('staging-install', ok(stagingInstall) && Boolean(stagingSheetId), {
+  status: stagingInstall.status,
+  sheetCount: Object.keys(stagingSheets).length,
+})
+
+const sourceStagingSystem = await call('POST', '/api/integration/external-systems', {
+  tenantId: TENANT_ID,
+  name: 'Rehearsal staging source (stand-in)',
+  kind: 'metasheet:staging-source',
+  role: 'source',
+  status: 'active',
+  config: { objects: { material: { sheetId: stagingSheetId, name: 'material' } } },
+})
+record('create-staging-source', ok(sourceStagingSystem) && Boolean(payload(sourceStagingSystem)?.id), {
+  status: sourceStagingSystem.status,
+})
+const pipelineSourceSystemId = payload(sourceStagingSystem)?.id || null
+
+// Seed the stand-in source with a bounded synthetic row set. This is the ONE step that needs a
+// credential the integration token cannot supply: `staging/install` creates STRUCTURE only
+// (sheets/fields/views, zero rows), and the only record-write path is the OAPI surface
+// (`POST /records`, apiTokenAuth + requireScope('records:write')). Minting such a token is
+// forbidden here (prod tokens come from login, never minted), so it is an INPUT.
+//
+// Fail loudly and specifically rather than proceeding to a dry-run that would report
+// `sourceRows: 0` and look like a clean pass over an empty source — a vacuous green is worse
+// than a red in a lane whose entire purpose is buying information.
+const seedRows = [
+  { code: 'MAT-RH-001', name: 'Rehearsal material A' },
+  { code: 'MAT-RH-002', name: 'Rehearsal material B' },
+]
+const seeded = []
+for (const row of seedRows) {
+  const r = await call('POST', '/records', {
+    sheetId: stagingSheetId,
+    fields: { code: row.code, name: row.name },
+  }, { token: MULTITABLE_TOKEN })
+  seeded.push(ok(r))
+}
+record('seed-staging-rows', seeded.length === seedRows.length && seeded.every(Boolean), {
+  requested: seedRows.length,
+  accepted: seeded.filter(Boolean).length,
+})
+
+
+// ---------------------------------------------------------------------------------------------
 // Step B4 — MINT + APPROVE the read binding via the real routes (the ops runbook's mint step,
 // rehearsed end to end; owner review 20260805: the binding must be minted, approved AND
 // consumed — the C6 dry-run below now runs with its capability gate fed by THIS approval).
@@ -172,7 +242,12 @@ const targetSystemId = payload(targetSystem).id
 // ---------------------------------------------------------------------------------------------
 
 const b4Mint = await call('POST', '/api/integration/read-source-configs', {
-  config: buildK3WiseMaterialListB4Config({ systemId: sourceSystemId }),
+  // OWNER RULING 20260805 (「A, bind B4 to the K3-write record」): the binding names the K3
+  // TARGET, not the K3 read record. Once the pipeline source is no longer K3, #4769's relation
+  // check (systemId must be a pipeline endpoint) can only be satisfied by the target — and the
+  // same-instance check added alongside it keeps that honest, since both K3 records address one
+  // physical K3.
+  config: buildK3WiseMaterialListB4Config({ systemId: targetSystemId }),
 })
 const b4Row = payload(b4Mint)
 record('b4-mint', ok(b4Mint) && Boolean(b4Row?.id), {
@@ -236,7 +311,7 @@ record('preflight-list-read-smoke',
 const pipeline = await call('POST', '/api/integration/pipelines', {
   tenantId: TENANT_ID,
   name: 'Rehearsal window pipeline',
-  sourceSystemId,
+  sourceSystemId: pipelineSourceSystemId,
   sourceObject: 'material',
   targetSystemId,
   targetObject: 'material',

--- a/scripts/ops/stock-prep-window-rehearsal-driver.mjs
+++ b/scripts/ops/stock-prep-window-rehearsal-driver.mjs
@@ -431,6 +431,16 @@ record('dry-run',
     planStatus: dryRunOut?.status ?? null,
     sourceRows: dryRunOut?.counts?.sourceRows ?? null,
     add: dryRunOut?.counts?.add ?? null,
+    // ATTRIBUTION. This step is also the discriminator for the owner's reported P1 (staging read
+    // returning fld_* with code/name empty): both fieldMappings carry `required`, validateRecord's
+    // `required` uses isEmpty() (undefined/null/whitespace), and a validation failure does
+    // `counts.failed += 1; continue` — so the row never reaches counts[decision] and canApply
+    // requires failed===0 && held===0. An empty column therefore CANNOT produce a green dry-run.
+    // But `add` alone says only THAT it failed; these say WHY — validation vs missing target key —
+    // which is the attribution a separate bare-read step would have bought. statusCounts()
+    // (external-write-dry-run.cjs:369) always emits both, so a null here means the shape changed.
+    failed: dryRunOut?.counts?.failed ?? null,
+    held: dryRunOut?.counts?.held ?? null,
     tokenPresent: typeof dryRunOut?.dryRunToken === 'string',
   })
 

--- a/scripts/ops/stock-prep-window-rehearsal-driver.mjs
+++ b/scripts/ops/stock-prep-window-rehearsal-driver.mjs
@@ -160,6 +160,12 @@ const targetSystem = await call('POST', '/api/integration/external-systems', {
     autoSubmit: false,
     autoAudit: false,
     objects: { material: { profile: PROFILE_ID } },
+    // OWNER REVIEW 20260806 [P1]: the write target DECLARES its paired K3 read record. Without
+    // this the read record is neither pipeline endpoint, so B4 could only bind to the target and
+    // the same-instance check degenerated into target-vs-itself — it could never have caught a
+    // read/write mismatch. Naming the peer here is what lets B4 bind the REAL read record while
+    // still clearing #4769's relation check.
+    pairedReadSystemId: sourceSystemId,
   },
   credentials: { username: 'rehearsal', password: 'rehearsal', acctId: 'RH' },
 })
@@ -322,12 +328,16 @@ record('seed-staging-rows', seeded.length === seedRows.length && seeded.every(Bo
 // ---------------------------------------------------------------------------------------------
 
 const b4Mint = await call('POST', '/api/integration/read-source-configs', {
-  // OWNER RULING 20260805 (「A, bind B4 to the K3-write record」): the binding names the K3
-  // TARGET, not the K3 read record. Once the pipeline source is no longer K3, #4769's relation
-  // check (systemId must be a pipeline endpoint) can only be satisfied by the target — and the
-  // same-instance check added alongside it keeps that honest, since both K3 records address one
-  // physical K3.
-  config: buildK3WiseMaterialListB4Config({ systemId: targetSystemId }),
+  // OWNER REVIEW 20260806 [P1] — SUPERSEDES the 20260805 「bind B4 to the K3-write record」
+  // arrangement. Binding to the target made the same-instance check compare the target against
+  // ITSELF: the driver created a separate K3 READ record, minted B4 on the TARGET, and the route
+  // then loaded targetBaseUrl from that same target — so sourceSystemId never entered the
+  // comparison and two different K3 instances would have passed.
+  //
+  // B4 now names the REAL K3 read record. The relation check accepts it because the target
+  // declares it as its paired read record (config.pairedReadSystemId above), so the guard
+  // compares two GENUINELY DIFFERENT records: the K3 read record against the K3 write target.
+  config: buildK3WiseMaterialListB4Config({ systemId: sourceSystemId }),
 })
 const b4Row = payload(b4Mint)
 record('b4-mint', ok(b4Mint) && Boolean(b4Row?.id), {

--- a/scripts/ops/stock-prep-window-rehearsal-driver.mjs
+++ b/scripts/ops/stock-prep-window-rehearsal-driver.mjs
@@ -390,6 +390,12 @@ record('preflight-list-read-smoke',
     status: listSmoke.status,
     timeout: timedOut(listSmoke),
     evidenceOk: listEvidence?.ok ?? null,
+    // PREFLIGHT B4: read-smoke answers HTTP 200 on BUSINESS failure, so status alone cannot say
+    // why. readSmokeErrorEvidence always sets errorCode and bounds it to /^[A-Z0-9_:-]+$/ (<=80
+    // chars) — values-free by construction, so recording it is safe under this lane's discipline.
+    // read-back-negative-control already reads this exact field off the identical shape; omitting
+    // it here was inconsistent within one file.
+    errorCode: listEvidence?.errorCode ?? null,
     rowCountField: listRowCountKey ?? null,
     rowCount: listRowCountKey ? (listEvidence?.[listRowCountKey] ?? null) : null,
   })
@@ -525,6 +531,7 @@ record('read-back-written-key',
     status: readBack.status,
     timeout: timedOut(readBack),
     evidenceOk: readBackEvidence?.ok ?? null,
+    errorCode: readBackEvidence?.errorCode ?? null,
     recordPresent: readBackEvidence?.recordPresent ?? null,
     recordCount: readBackEvidence?.recordCount ?? null,
   })

--- a/scripts/ops/stock-prep-window-rehearsal-driver.mjs
+++ b/scripts/ops/stock-prep-window-rehearsal-driver.mjs
@@ -1,0 +1,239 @@
+#!/usr/bin/env node
+// STAGING WINDOW REHEARSAL DRIVER (owner authorization 2026-08-05: 「授权 staging 部署」).
+//
+// Mechanizes the entity-machine window runbook's six steps against a REAL deployed server over
+// HTTP — the same routes, same auth, same C6 token lifecycle the customer window will use. The
+// far end of the K3 wire is the in-repo mock server (run-mock-k3-server.mjs); everything between
+// the HTTP client and that wire is the deployed package, unmodified.
+//
+// mock pass != staging rehearsal pass != customer live pass — three layers, each honest.
+//
+// Env (all required):
+//   BASE_URL      deployed server origin (e.g. http://127.0.0.1:<port>)
+//   TOKEN         Bearer token of an integration-write principal (obtained via login, never minted)
+//   MOCK_K3_URL   the mock K3 base url
+//   TENANT_ID     tenant for the rehearsal systems/pipeline
+//
+// VALUES-FREE OUTPUT: closed tokens, counts, PASS/FAIL per step, one summary JSON. The material
+// keys used here are synthetic fixture constants (MAT-RH-*), not customer values.
+
+const BASE_URL = required('BASE_URL')
+const TOKEN = required('TOKEN')
+const MOCK_K3_URL = required('MOCK_K3_URL')
+const TENANT_ID = required('TENANT_ID')
+
+const PROFILE_ID = 'material-k3wise-customer-profile-v1'
+const LIST_PRESET = 'k3wise.material-list.v1'
+const DETAIL_PRESET = 'k3wise.material-detail.v1'
+const SOURCE_KEYS = ['MAT-RH-001', 'MAT-RH-002'] // seeded by run-mock-k3-server.mjs
+const NEVER_SAVED_KEY = 'MAT-RH-NEVER'
+
+function required(name) {
+  const v = process.env[name]
+  if (typeof v !== 'string' || v.trim() === '') {
+    console.error(`rehearsal driver: env ${name} is required`)
+    process.exit(2)
+  }
+  return v.trim()
+}
+
+const summary = { steps: [], pass: false }
+
+function record(step, pass, evidence) {
+  summary.steps.push({ step, pass, ...evidence })
+  console.log(`${pass ? '✓' : '✗'} ${step} ${JSON.stringify(evidence)}`)
+  if (!pass) {
+    summary.pass = false
+    console.log('REHEARSAL_SUMMARY=' + JSON.stringify(summary))
+    process.exit(1)
+  }
+}
+
+async function call(method, path, body) {
+  const res = await fetch(`${BASE_URL}${path}`, {
+    method,
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${TOKEN}`,
+      // The login token carries no tenant claim; jwt-middleware copies this header into
+      // user.tenantId, which is what resolveAuthUserTenantId (write paths) exclusively trusts.
+      'x-tenant-id': TENANT_ID,
+    },
+    ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+  })
+  let data = null
+  try { data = await res.json() } catch { /* non-JSON is handled by callers via status */ }
+  return { status: res.status, data }
+}
+
+function ok(res) { return res.status >= 200 && res.status < 300 }
+function payload(res) { return res.data && (res.data.data !== undefined ? res.data.data : res.data) }
+
+// ---------------------------------------------------------------------------------------------
+// Step 0 — the two rehearsal systems (source = K3 list read; target = profile-armed K3 write).
+// Both point at the SAME mock K3. Separate systems keep the source read-config and the armed
+// write-config independently reviewable, like the customer setup will be.
+// ---------------------------------------------------------------------------------------------
+
+const sourceSystem = await call('POST', '/api/integration/external-systems', {
+  tenantId: TENANT_ID,
+  name: 'Rehearsal K3 source (list read)',
+  kind: 'erp:k3-wise-webapi',
+  role: 'source',
+  status: 'active',
+  config: {
+    baseUrl: MOCK_K3_URL,
+    autoSubmit: false,
+    autoAudit: false,
+    objects: {
+      material: {
+        operations: ['read'],
+        readPath: '/K3API/Material/GetList',
+        readMethod: 'POST',
+        readMode: 'list',
+        readListBodyTemplate: { Data: { Top: 10, PageIndex: 1 } },
+        readListBodyKey: 'Data',
+        readListFields: ['FItemID', 'FNumber', 'FName', 'FModel', 'FUnitID'],
+        readListOrderBy: 'FNumber',
+        topField: 'Top',
+        pageIndexField: 'PageIndex',
+        pageSizeField: 'PageSize',
+        maxListLimit: 10,
+      },
+    },
+  },
+  credentials: { username: 'rehearsal', password: 'rehearsal', acctId: 'RH' },
+})
+record('create-source-system', ok(sourceSystem) && Boolean(payload(sourceSystem)?.id), {
+  status: sourceSystem.status,
+})
+const sourceSystemId = payload(sourceSystem).id
+
+const targetSystem = await call('POST', '/api/integration/external-systems', {
+  tenantId: TENANT_ID,
+  name: 'Rehearsal K3 target (profile-armed)',
+  kind: 'erp:k3-wise-webapi',
+  role: 'target',
+  status: 'active',
+  config: {
+    baseUrl: MOCK_K3_URL,
+    autoSubmit: false,
+    autoAudit: false,
+    objects: { material: { profile: PROFILE_ID } },
+  },
+  credentials: { username: 'rehearsal', password: 'rehearsal', acctId: 'RH' },
+})
+record('create-target-system', ok(targetSystem) && Boolean(payload(targetSystem)?.id), {
+  status: targetSystem.status,
+})
+const targetSystemId = payload(targetSystem).id
+
+// ---------------------------------------------------------------------------------------------
+// Step 1 — READ-ONLY preflight (runbook step 1): list read-smoke, values-free evidence.
+// ---------------------------------------------------------------------------------------------
+
+const listSmoke = await call('POST', `/api/integration/external-systems/${sourceSystemId}/read-smoke`, {
+  presetId: LIST_PRESET,
+})
+const listEvidence = payload(listSmoke)
+record('preflight-list-read-smoke', ok(listSmoke), {
+  status: listSmoke.status,
+  evidenceKeys: listEvidence ? Object.keys(listEvidence).length : 0,
+})
+
+// ---------------------------------------------------------------------------------------------
+// Step 2 — the window pipeline (runbook step 2).
+// ---------------------------------------------------------------------------------------------
+
+const pipeline = await call('POST', '/api/integration/pipelines', {
+  tenantId: TENANT_ID,
+  name: 'Rehearsal window pipeline',
+  sourceSystemId,
+  sourceObject: 'material',
+  targetSystemId,
+  targetObject: 'material',
+  status: 'active',
+  fieldMappings: [
+    { sourceField: 'FNumber', targetField: 'FNumber', validation: [{ type: 'required' }] },
+    { sourceField: 'FName', targetField: 'FName', validation: [{ type: 'required' }] },
+    { sourceField: 'FModel', targetField: 'FModel' },
+  ],
+})
+record('create-pipeline', ok(pipeline) && Boolean(payload(pipeline)?.id), { status: pipeline.status })
+const pipelineId = payload(pipeline).id
+
+// ---------------------------------------------------------------------------------------------
+// Step 3 — DRY-RUN (runbook step 3; the human-approval preview at the customer window).
+// ---------------------------------------------------------------------------------------------
+
+const dryRun = await call('POST', `/api/integration/pipelines/${pipelineId}/external-write/dry-run`, {
+  tenantId: TENANT_ID,
+})
+const dryRunOut = payload(dryRun)
+record('dry-run',
+  ok(dryRun)
+    && dryRunOut?.status === 'ready'
+    && typeof dryRunOut?.dryRunToken === 'string'
+    && dryRunOut?.counts?.sourceRows === SOURCE_KEYS.length
+    && dryRunOut?.counts?.add === SOURCE_KEYS.length,
+  {
+    status: dryRun.status,
+    planStatus: dryRunOut?.status ?? null,
+    sourceRows: dryRunOut?.counts?.sourceRows ?? null,
+    add: dryRunOut?.counts?.add ?? null,
+    tokenPresent: typeof dryRunOut?.dryRunToken === 'string',
+  })
+
+// ---------------------------------------------------------------------------------------------
+// Step 4 — APPLY with the token (runbook step 4).
+// ---------------------------------------------------------------------------------------------
+
+const apply = await call('POST', `/api/integration/pipelines/${pipelineId}/external-write/apply`, {
+  tenantId: TENANT_ID,
+  confirm: { dryRunToken: dryRunOut.dryRunToken },
+})
+const applyOut = payload(apply)
+record('apply',
+  ok(apply)
+    && applyOut?.counts?.written === SOURCE_KEYS.length
+    && (applyOut?.counts?.failed ?? 0) === 0,
+  {
+    status: apply.status,
+    written: applyOut?.counts?.written ?? null,
+    failed: applyOut?.counts?.failed ?? null,
+  })
+
+// Token single-use: replaying the SAME token must be refused — the customer window relies on it.
+const replayToken = await call('POST', `/api/integration/pipelines/${pipelineId}/external-write/apply`, {
+  tenantId: TENANT_ID,
+  confirm: { dryRunToken: dryRunOut.dryRunToken },
+})
+record('token-single-use', !ok(replayToken), { status: replayToken.status })
+
+// ---------------------------------------------------------------------------------------------
+// Step 5 — READ-BACK (runbook step 5): single-record read-smoke on the WRITTEN key; the
+// values-free evidence proves business success + record presence. Value-level confirmation
+// remains the operator's K3-client check at the customer window, by design.
+// ---------------------------------------------------------------------------------------------
+
+const readBack = await call('POST', `/api/integration/external-systems/${targetSystemId}/read-smoke`, {
+  presetId: DETAIL_PRESET,
+  key: SOURCE_KEYS[0],
+})
+record('read-back-written-key', ok(readBack), { status: readBack.status })
+
+// Negative control: a key never written must NOT read back clean — proves the read-back above
+// found the WRITE, not a permissive endpoint.
+const readBackMiss = await call('POST', `/api/integration/external-systems/${targetSystemId}/read-smoke`, {
+  presetId: DETAIL_PRESET,
+  key: NEVER_SAVED_KEY,
+})
+const missEvidence = payload(readBackMiss)
+const missIsFailureShaped = !ok(readBackMiss)
+  || missEvidence?.businessSuccess === false
+  || missEvidence?.recordPresent === false
+  || missEvidence?.status === 'error'
+record('read-back-negative-control', missIsFailureShaped, { status: readBackMiss.status })
+
+summary.pass = true
+console.log('REHEARSAL_SUMMARY=' + JSON.stringify(summary))

--- a/scripts/ops/stock-prep-window-rehearsal-driver.mjs
+++ b/scripts/ops/stock-prep-window-rehearsal-driver.mjs
@@ -17,6 +17,19 @@
 // VALUES-FREE OUTPUT: closed tokens, counts, PASS/FAIL per step, one summary JSON. The material
 // keys used here are synthetic fixture constants (MAT-RH-*), not customer values.
 
+import { createRequire } from 'node:module'
+
+const require = createRequire(import.meta.url)
+// Owner review fix (point B, 2026-08-05): the read-smoke route (plugins/plugin-integration-core/
+// lib/http-routes.cjs externalSystemReadSmoke, ~line 2731/2733) returns HTTP 200 on BOTH business
+// success and business failure — the evidence body's own `ok` field is the only real success
+// signal, and the row-count field name must be read from the SAME module the route uses, not
+// assumed. Requiring it directly (not re-implementing a guess) is what lets this driver derive
+// the real LIST success-shape keys at runtime below.
+const { getReadSmokePreset, readSmokeSuccessEvidence } = require('../../plugins/plugin-integration-core/lib/read-smoke.cjs')
+
+const { buildK3WiseMaterialListB4Config } = require('../../plugins/plugin-integration-core/lib/read-source-k3-material-list-b4-contract.cjs')
+
 const BASE_URL = required('BASE_URL')
 const TOKEN = required('TOKEN')
 const MOCK_K3_URL = required('MOCK_K3_URL')
@@ -27,6 +40,7 @@ const LIST_PRESET = 'k3wise.material-list.v1'
 const DETAIL_PRESET = 'k3wise.material-detail.v1'
 const SOURCE_KEYS = ['MAT-RH-001', 'MAT-RH-002'] // seeded by run-mock-k3-server.mjs
 const NEVER_SAVED_KEY = 'MAT-RH-NEVER'
+const FETCH_TIMEOUT_MS = 15000
 
 function required(name) {
   const v = process.env[name]
@@ -49,25 +63,44 @@ function record(step, pass, evidence) {
   }
 }
 
+// Point D: every outbound call is bounded — a hung deployed server or mock must FAIL the step,
+// never hang the rehearsal indefinitely. AbortSignal.timeout throws a TimeoutError/AbortError,
+// which is folded into a synthetic { status: 0, timeout: true, data: null } result. Every
+// downstream assertion below is a POSITIVE check on real field values (never a bare `!ok(...)`),
+// so a timeout's null data fails those checks the same way a bad response would — no separate
+// early-exit branch needed to make a timeout register as FAIL.
 async function call(method, path, body) {
-  const res = await fetch(`${BASE_URL}${path}`, {
-    method,
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${TOKEN}`,
-      // The login token carries no tenant claim; jwt-middleware copies this header into
-      // user.tenantId, which is what resolveAuthUserTenantId (write paths) exclusively trusts.
-      'x-tenant-id': TENANT_ID,
-    },
-    ...(body === undefined ? {} : { body: JSON.stringify(body) }),
-  })
+  let res
+  try {
+    res = await fetch(`${BASE_URL}${path}`, {
+      method,
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${TOKEN}`,
+        // The login token carries no tenant claim; jwt-middleware copies this header into
+        // user.tenantId, which is what resolveAuthUserTenantId (write paths) exclusively trusts.
+        'x-tenant-id': TENANT_ID,
+      },
+      ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    })
+  } catch (error) {
+    const timedOut = Boolean(error) && (error.name === 'TimeoutError' || error.name === 'AbortError')
+    return {
+      status: 0,
+      data: null,
+      timeout: timedOut,
+      networkError: timedOut ? null : String(error && error.message ? error.message : error),
+    }
+  }
   let data = null
   try { data = await res.json() } catch { /* non-JSON is handled by callers via status */ }
-  return { status: res.status, data }
+  return { status: res.status, data, timeout: false, networkError: null }
 }
 
 function ok(res) { return res.status >= 200 && res.status < 300 }
 function payload(res) { return res.data && (res.data.data !== undefined ? res.data.data : res.data) }
+function timedOut(res) { return res.timeout === true }
 
 // ---------------------------------------------------------------------------------------------
 // Step 0 — the two rehearsal systems (source = K3 list read; target = profile-armed K3 write).
@@ -106,6 +139,7 @@ const sourceSystem = await call('POST', '/api/integration/external-systems', {
 })
 record('create-source-system', ok(sourceSystem) && Boolean(payload(sourceSystem)?.id), {
   status: sourceSystem.status,
+  timeout: timedOut(sourceSystem),
 })
 const sourceSystemId = payload(sourceSystem).id
 
@@ -125,21 +159,75 @@ const targetSystem = await call('POST', '/api/integration/external-systems', {
 })
 record('create-target-system', ok(targetSystem) && Boolean(payload(targetSystem)?.id), {
   status: targetSystem.status,
+  timeout: timedOut(targetSystem),
 })
 const targetSystemId = payload(targetSystem).id
 
 // ---------------------------------------------------------------------------------------------
-// Step 1 — READ-ONLY preflight (runbook step 1): list read-smoke, values-free evidence.
+// Step B4 — MINT + APPROVE the read binding via the real routes (the ops runbook's mint step,
+// rehearsed end to end; owner review 20260805: the binding must be minted, approved AND
+// consumed — the C6 dry-run below now runs with its capability gate fed by THIS approval).
+// Content comes from the RATIFIED contract module's builder — single source, no second copy;
+// the only degree of freedom is the real source system id, exactly as at the customer window.
 // ---------------------------------------------------------------------------------------------
+
+const b4Mint = await call('POST', '/api/integration/read-source-configs', {
+  config: buildK3WiseMaterialListB4Config({ systemId: sourceSystemId }),
+})
+const b4Row = payload(b4Mint)
+record('b4-mint', ok(b4Mint) && Boolean(b4Row?.id), {
+  status: b4Mint.status,
+  mintedVersion: b4Row?.version ?? null,
+  contentKeyPresent: typeof b4Row?.contentKey === 'string' && b4Row.contentKey.length > 0,
+})
+
+const b4Approve = await call('POST', `/api/integration/read-source-configs/${b4Row.id}/approve`, {})
+const b4Approved = payload(b4Approve)
+record('b4-approve', ok(b4Approve) && b4Approved?.status === 'approved', {
+  status: b4Approve.status,
+  bindingStatus: b4Approved?.status ?? null,
+})
+
+// ---------------------------------------------------------------------------------------------
+// Step 1 — READ-ONLY preflight (runbook step 1): list read-smoke, values-free evidence.
+//
+// Point A (owner review): list mode requires the { presetId, intent:{ object, mode } } shape —
+// a presetId-only body throws intent_required (read-smoke.cjs normalizeReadSmokeContract,
+// ~line 529).
+//
+// Point B (owner review): pre-check FIRST. Feed a synthetic 2-row list result through the ACTUAL
+// readSmokeSuccessEvidence the route uses, and read back the real success-shape keys + the
+// row-count field — found by VALUE (the one numeric field equal to the synthetic row count), not
+// by an assumed field name.
+// ---------------------------------------------------------------------------------------------
+
+const listPreset = getReadSmokePreset(LIST_PRESET)
+const listProbeRows = [{ FNumber: 'PROBE-RH-001' }, { FNumber: 'PROBE-RH-002' }]
+const listProbeEvidence = readSmokeSuccessEvidence(listPreset, { records: listProbeRows }, { object: 'material', mode: 'list' })
+const listSuccessKeys = Object.keys(listProbeEvidence)
+const listRowCountKey = listSuccessKeys.find(
+  (key) => typeof listProbeEvidence[key] === 'number' && listProbeEvidence[key] === listProbeRows.length,
+)
+record('preflight-list-shape-probe',
+  listProbeEvidence.ok === true && typeof listRowCountKey === 'string',
+  { listSuccessKeys, listRowCountKey: listRowCountKey ?? null })
 
 const listSmoke = await call('POST', `/api/integration/external-systems/${sourceSystemId}/read-smoke`, {
   presetId: LIST_PRESET,
+  intent: { object: 'material', mode: 'list' },
 })
 const listEvidence = payload(listSmoke)
-record('preflight-list-read-smoke', ok(listSmoke), {
-  status: listSmoke.status,
-  evidenceKeys: listEvidence ? Object.keys(listEvidence).length : 0,
-})
+record('preflight-list-read-smoke',
+  listSmoke.status === 200
+    && listEvidence?.ok === true
+    && listEvidence?.[listRowCountKey] === SOURCE_KEYS.length,
+  {
+    status: listSmoke.status,
+    timeout: timedOut(listSmoke),
+    evidenceOk: listEvidence?.ok ?? null,
+    rowCountField: listRowCountKey ?? null,
+    rowCount: listRowCountKey ? (listEvidence?.[listRowCountKey] ?? null) : null,
+  })
 
 // ---------------------------------------------------------------------------------------------
 // Step 2 — the window pipeline (runbook step 2).
@@ -159,7 +247,10 @@ const pipeline = await call('POST', '/api/integration/pipelines', {
     { sourceField: 'FModel', targetField: 'FModel' },
   ],
 })
-record('create-pipeline', ok(pipeline) && Boolean(payload(pipeline)?.id), { status: pipeline.status })
+record('create-pipeline', ok(pipeline) && Boolean(payload(pipeline)?.id), {
+  status: pipeline.status,
+  timeout: timedOut(pipeline),
+})
 const pipelineId = payload(pipeline).id
 
 // ---------------------------------------------------------------------------------------------
@@ -178,6 +269,7 @@ record('dry-run',
     && dryRunOut?.counts?.add === SOURCE_KEYS.length,
   {
     status: dryRun.status,
+    timeout: timedOut(dryRun),
     planStatus: dryRunOut?.status ?? null,
     sourceRows: dryRunOut?.counts?.sourceRows ?? null,
     add: dryRunOut?.counts?.add ?? null,
@@ -199,41 +291,91 @@ record('apply',
     && (applyOut?.counts?.failed ?? 0) === 0,
   {
     status: apply.status,
+    timeout: timedOut(apply),
     written: applyOut?.counts?.written ?? null,
     failed: applyOut?.counts?.failed ?? null,
   })
 
 // Token single-use: replaying the SAME token must be refused — the customer window relies on it.
+//
+// Point C (owner review): assert the PRECISE consumed-token rejection, not just "not 2xx".
+// normalizeC6WriteApplyBody (plugins/plugin-integration-core/lib/http-routes.cjs:1034) only
+// checks token PRESENCE (400 C6_WRITE_DRY_RUN_TOKEN_REQUIRED). The actual consumed/expired/
+// mismatched rejection is thrown by consumeDryRunToken
+// (plugins/plugin-integration-core/lib/external-write-dry-run.cjs:151,163,167) as
+// `new ExternalWriteDryRunError(409, 'C6_WRITE_DRY_RUN_TOKEN_INVALID', ...)`. sendError
+// (http-routes.cjs:413-426) serializes any thrown error to `{ ok:false, error:{ code, message,
+// details } }` at `error.status` (inferHttpStatus, http-routes.cjs:453, reads
+// `error instanceof ExternalWriteDryRunError ? error.status : ...` → 409). payload() returns the
+// whole body here (there is no nested `.data` on an error response), so the code lives at
+// `body.error.code`.
 const replayToken = await call('POST', `/api/integration/pipelines/${pipelineId}/external-write/apply`, {
   tenantId: TENANT_ID,
   confirm: { dryRunToken: dryRunOut.dryRunToken },
 })
-record('token-single-use', !ok(replayToken), { status: replayToken.status })
+const replayBody = payload(replayToken)
+record('token-single-use',
+  replayToken.status === 409 && replayBody?.error?.code === 'C6_WRITE_DRY_RUN_TOKEN_INVALID',
+  {
+    status: replayToken.status,
+    timeout: timedOut(replayToken),
+    errorCode: replayBody?.error?.code ?? null,
+  })
 
 // ---------------------------------------------------------------------------------------------
 // Step 5 — READ-BACK (runbook step 5): single-record read-smoke on the WRITTEN key; the
 // values-free evidence proves business success + record presence. Value-level confirmation
 // remains the operator's K3-client check at the customer window, by design.
+//
+// Point B (owner review): read-smoke returns HTTP 200 on BOTH success and failure — assert the
+// EVIDENCE shape (readSmokeSuccessEvidence, read-smoke.cjs:365-407: ok, presetId, object, mode,
+// recordPresent, recordCount, referenceObjectCount for single_record_detail), not just the HTTP
+// status.
 // ---------------------------------------------------------------------------------------------
 
 const readBack = await call('POST', `/api/integration/external-systems/${targetSystemId}/read-smoke`, {
   presetId: DETAIL_PRESET,
   key: SOURCE_KEYS[0],
 })
-record('read-back-written-key', ok(readBack), { status: readBack.status })
+const readBackEvidence = payload(readBack)
+record('read-back-written-key',
+  readBack.status === 200
+    && readBackEvidence?.ok === true
+    && readBackEvidence?.recordPresent === true
+    && readBackEvidence?.recordCount === 1,
+  {
+    status: readBack.status,
+    timeout: timedOut(readBack),
+    evidenceOk: readBackEvidence?.ok ?? null,
+    recordPresent: readBackEvidence?.recordPresent ?? null,
+    recordCount: readBackEvidence?.recordCount ?? null,
+  })
 
 // Negative control: a key never written must NOT read back clean — proves the read-back above
 // found the WRITE, not a permissive endpoint.
+//
+// Point B (owner review): precise business-error assertion (readSmokeErrorEvidence,
+// read-smoke.cjs:411-452) instead of the previous loose OR across possible failure shapes. The
+// K3 adapter's "not found" is a business-level failure surfaced as
+// K3WiseWebApiAdapterError.details.code = 'K3_WISE_READ_BUSINESS_ERROR'
+// (adapters/k3-wise-webapi-adapter.cjs:1966/1975), which readSmokeErrorEvidence's
+// `error.details.code` fallback (read-smoke.cjs:414-415) surfaces as `errorCode` — the SAME code
+// run-mock-poc-demo.mjs's ruled-chain negative control already asserts (line 372).
 const readBackMiss = await call('POST', `/api/integration/external-systems/${targetSystemId}/read-smoke`, {
   presetId: DETAIL_PRESET,
   key: NEVER_SAVED_KEY,
 })
 const missEvidence = payload(readBackMiss)
-const missIsFailureShaped = !ok(readBackMiss)
-  || missEvidence?.businessSuccess === false
-  || missEvidence?.recordPresent === false
-  || missEvidence?.status === 'error'
-record('read-back-negative-control', missIsFailureShaped, { status: readBackMiss.status })
+record('read-back-negative-control',
+  readBackMiss.status === 200
+    && missEvidence?.ok === false
+    && missEvidence?.errorCode === 'K3_WISE_READ_BUSINESS_ERROR',
+  {
+    status: readBackMiss.status,
+    timeout: timedOut(readBackMiss),
+    evidenceOk: missEvidence?.ok ?? null,
+    errorCode: missEvidence?.errorCode ?? null,
+  })
 
 summary.pass = true
 console.log('REHEARSAL_SUMMARY=' + JSON.stringify(summary))

--- a/scripts/ops/stock-prep-window-rehearsal-driver.mjs
+++ b/scripts/ops/stock-prep-window-rehearsal-driver.mjs
@@ -196,13 +196,18 @@ record('staging-install', ok(stagingInstall) && Boolean(stagingSheetId), {
 const sourceStagingSystem = await call('POST', '/api/integration/external-systems', {
   tenantId: TENANT_ID,
   name: 'Rehearsal staging source (stand-in)',
-  kind: 'metasheet:staging-source',
+  kind: 'metasheet:staging',
   role: 'source',
   status: 'active',
   config: { objects: { material: { sheetId: stagingSheetId, name: 'material' } } },
 })
 record('create-staging-source', ok(sourceStagingSystem) && Boolean(payload(sourceStagingSystem)?.id), {
   status: sourceStagingSystem.status,
+  // REVIEW P2-2: the "source leg is a stand-in" caveat lived only in comments and a system NAME,
+  // so REHEARSAL_SUMMARY carried no trace of it. A limitation a reader has to find in a PR thread
+  // is not a limitation the evidence states. It now rides the summary itself.
+  sourceLeg: 'stand-in',
+  sourceLegNote: 'C6 write lifecycle proven; customer source connector NOT exercised',
 })
 const pipelineSourceSystemId = payload(sourceStagingSystem)?.id || null
 
@@ -221,9 +226,18 @@ const seedRows = [
 ]
 const seeded = []
 for (const row of seedRows) {
-  const r = await call('POST', '/records', {
+  const r = await call('POST', '/api/multitable/records', {
     sheetId: stagingSheetId,
-    fields: { code: row.code, name: row.name },
+    // `data`, not `fields` — the route's zod schema (univer-meta.ts) names it `data` and STRIPS
+    // unknown keys, so `fields` would have written empty rows and looked like a clean pass.
+    data: {
+      // These three are `required: true` on plm_raw_items; omitting them fails the row.
+      sourceSystemId: 'rehearsal-stand-in',
+      objectType: 'material',
+      sourceId: row.code,
+      code: row.code,
+      name: row.name,
+    },
   }, { token: MULTITABLE_TOKEN })
   seeded.push(ok(r))
 }
@@ -317,9 +331,12 @@ const pipeline = await call('POST', '/api/integration/pipelines', {
   targetObject: 'material',
   status: 'active',
   fieldMappings: [
-    { sourceField: 'FNumber', targetField: 'FNumber', validation: [{ type: 'required' }] },
-    { sourceField: 'FName', targetField: 'FName', validation: [{ type: 'required' }] },
-    { sourceField: 'FModel', targetField: 'FModel' },
+    // sourceField names STAGING columns (plm_raw_items: code/name/…), targetField names K3's.
+    // These were both K3 names while the source was K3; after the swap that produced
+    // status=not_applyable with sourceRows:2 / add:0 / failed:2 — the source rows exist but no
+    // mapping resolves.
+    { sourceField: 'code', targetField: 'FNumber', validation: [{ type: 'required' }] },
+    { sourceField: 'name', targetField: 'FName', validation: [{ type: 'required' }] },
   ],
 })
 record('create-pipeline', ok(pipeline) && Boolean(payload(pipeline)?.id), {


### PR DESCRIPTION
# Staging window rehearsal

Rehearses the customer-window C6 write lifecycle against a real deployed package.
Head `53a30b685`. Rebased onto main after **#4784 merged** (`e6523c949`).

## Owner review 20260806 — both P1s fixed in this round

### [P1] The B4 same-instance check compared the target with ITSELF

Correct as reported, and my earlier `kind` gate was **not** a fix for it — that closed a different
hole (same-origin non-K3). The driver created a separate K3 READ record but minted B4 on
`targetSystemId`; the route then loaded `targetBaseUrl` from that same target and the profile
reloaded by the same id. **The real `sourceSystemId` never entered the comparison**, so two
different K3 instances would have passed. No comparator could have fixed this — the check was
structurally incapable of detecting a read/write mismatch.

Root cause was the relation check's reach: with a non-K3 pipeline source the K3 read record is
neither endpoint, so binding to the target was the *only* thing that satisfied #4769. The write
target now declares its paired read record (`config.pairedReadSystemId`) and that one id joins the
relation set, so B4 binds the **real reader** and the guard compares two genuinely different
records.

⚠️ **This widens #4769's ratified relation check by one target-declared id.** Flagged here, in the
code, and in the delivery doc rather than left in the diff. Deliberately narrow: it admits exactly
the record the target itself names, and the binding must still clear the ratified-contract match,
the kind gate and the same-instance gate.

Controls through the real route: **A→A** same physical K3 (same origin, different path — the step
0-b topology) accepted; **A→B** read record on another K3 host refused. Mutations:
`sameK3Instance → true` reds A→B; dropping `pairedReadSystemId` from the relation set reds A→A.

### [P1] The migration proof pinned a COUNT, not a SET

Reproduced: swapping `048` for `074` keeps the count at 6 and everything green — while 074 is
removed from the very map that feeds `Pending`, so `Pending: 0` holds **without 074 running**.

Now byte-identical set equality against `migration-replay.yml`. One detail worth stating: this
step's working-directory is the **unpacked package, not the repo**, so the authoritative file is
addressed through `github.workspace` — a relative path would read empty and pass vacuously, which
is the exact failure mode the check exists to prevent.

074/075 applied-ness is proved by construction: present in the package ⇒ in `getMigrations()`;
absent from the exclude list ⇒ not dropped; `Pending: 0` ⇒ every member has `executedAt`. All three
needed, which is why exclusion is asserted **per name** rather than inferred from a count.

Offline controls: correct list OK · `048→074` DRIFT · empty list DRIFT · unreachable authority
FATAL. The old count criterion passes the substitution (6 == 6).

### [P2] #4784 had no real regression coverage — reproduced, then closed

Flipping `targetSystem.kind` to `targetSystem.role` at **both** real C6 handlers left every suite
green. The test did source-text regex plus a test-local reimplementation of the accessor selection.

The root cause was the **assertion shape**: everything was `notEqual` ("not this particular
error"), a family that cannot distinguish *succeeded* from *failed for another reason*. The A→A
control — which already drives the real dry-run route — is now a positive equality, with the
discriminator measured rather than assumed:

| | error code |
|---|---|
| baseline | `K3_WISE_READ_FAILED` (adapter accessor, credentials present) |
| `.kind → .role` | `K3_WISE_CREDENTIALS_MISSING` (public accessor strips them) |

Reaching a wire error proves credentials resolved. The mutation is now RED.

## Exact-head review (`a9963cea6`) — both P2s fixed

**The step-predicate guard was a denylist of four literals.** Broken in one line:
`dryRunOut !== undefined` on the dry-run step left the suite 10/10 green — degrading the one step
carrying the owner's P1. Replaced with a **positive per-step manifest**, covering all 17 steps in
both directions, extracted by balanced scan (a comma split parsed only 8 of 17 and silently
exempted the rest). All three review mutations RED.

**The same-instance guard had no kind gate.** Origin equality says nothing about *what* is at that
origin; a same-origin PLM record certified the K3 write. Now fail-closed on
`K3_C6_B4_BINDING_KIND_MISMATCH`. The poc's case 6 had been passing for the wrong reason — its PLM
fixture had no baseUrl, so it took the "cannot tell" branch and never exercised the branch its
message named.

**The contract suites were not gated.** They ran in `k3wise-offline-poc`, which is **not** one of
main's 9 required contexts, so a red there did not block a merge. Also invoked in the required
`test` job now. (An earlier claim that they were "gated" was wrong.)

## Dispatch preflight — 0 P1 / 1 P2 / 4 P3, verdict: spend it

Two fixed here:

- **Six lenses hit one root cause.** The wire positive-control step is `if: always()` and the
  runbook step had no `id:`, so it could not distinguish "the logger is broken" from "the driver
  never got there". 10 of 17 gates precede the first GetList, 13 precede the first Save, and
  `record()` hard-exits on the first failure — so any early failure printed a louder, more
  specific, **wrong** diagnosis blaming the mock's logger, on the line right after printing
  `GetList=1`. Now gated on `steps.runbook.outcome`.
- **The migration scope assertion was literal-vs-literal** (a comma count of a list defined 114
  lines above in the same file). Now measured at runtime: list with an empty exclude set, list with
  the real one, require the difference to equal the list size. `migrationScope=CI_EXCLUDED_6` and
  `mig-unscoped.txt` ride the artifact bundle so `Pending: 0` cannot be misread as "the full set
  ran".

## Honest limits

- **The source leg is a stand-in.** This proves the C6 write lifecycle; it does not exercise the
  customer's real source connector. Stated in `REHEARSAL_SUMMARY`, not only here.
- **Contract tests are source-text assertions** and cannot prove a record was written. What proves
  that is the dry-run/apply behaviour and the dispatch itself.
- **What is genuinely unexercised on a fresh DB** is `008_plugin_infrastructure.sql` and
  `20250924140000_create_gantt_tables.ts` — the other four excluded names either run on-prem as
  no-op history markers or have independent fresh-DB coverage.
- A previous version of this body said the B4 gap was "filed separately". **It never was** — and it
  is now fixed rather than deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
