### PR TITLE
feat(attendance): #4709 FSER-4 prerequisite — member-safe self effectiveness projection [DRAFT/HOLD]

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -1151,6 +1151,7 @@ jobs:
             tests/integration/attendance-group-fixed-schedule-config-migration.db.test.ts \
             tests/integration/attendance-group-fixed-schedule-effectiveness.db.test.ts \
             tests/integration/attendance-group-fixed-schedule-config-consume.db.test.ts \
+            tests/integration/attendance-group-fixed-schedule-self-effectiveness.db.test.ts \
             tests/integration/attendance-shift-flex-policy-migration.db.test.ts \
             tests/integration/attendance-expiry-service.test.ts \
             tests/integration/attendance-unscheduled-reminder.test.ts \

--- a/packages/core-backend/tests/integration/attendance-group-fixed-schedule-self-effectiveness.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-group-fixed-schedule-self-effectiveness.db.test.ts
@@ -1,0 +1,364 @@
+import { randomUUID } from 'node:crypto'
+import { createRequire } from 'node:module'
+
+import { Pool } from 'pg'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+const require = createRequire(import.meta.url)
+const {
+  createAttendanceGroupFixedScheduleEffectivenessService,
+} = require('../../../../plugins/plugin-attendance/lib/attendance-group-fixed-schedule-effectiveness-service.cjs') as {
+  createAttendanceGroupFixedScheduleEffectivenessService: (input: Record<string, unknown>) => {
+    getEffectiveness: (db: unknown, input: Record<string, string>) => Promise<any>
+    getSelfEffectiveness: (db: unknown, input: Record<string, string>) => Promise<any>
+  }
+}
+
+class FakeHttpError extends Error {
+  constructor(public status: number, public code: string, message: string) {
+    super(message)
+  }
+}
+
+const databaseUrl = process.env.DATABASE_URL
+const describeDb = databaseUrl ? describe : describe.skip
+const producerType = 'attendance_group_fixed_schedule'
+
+function producerKey(input: { groupId: string; shiftId: string; startDate: string; endDate: string | null }) {
+  return [producerType, input.groupId, input.shiftId, input.startDate, input.endDate ?? 'null'].join(':')
+}
+
+// #4709 FSER-4 prerequisite (contract amendment `docs/development/
+// attendance-4709-fser4-member-projection-contract-amendment-20260804.md` §2,
+// RATIFIED `45d71c4209af35a63768ce7ce9f576377f6b8ce4`, OD-4709-2=(a)): real-DB
+// authorization matrix + parity + exact-key proof for `getSelfEffectiveness`.
+// File-level fixture namespace (`fser4pre_<uuid>` schema) so this can run
+// concurrently with every other attendance real-DB suite sharing the test
+// database, per this line's shared-DB fixture-collision discipline.
+describeDb('attendance group fixed-schedule self effectiveness (real DB, #4709 FSER-4 prerequisite)', () => {
+  let adminPool: Pool
+  let pool: Pool
+  let schema: string
+  let orgId: string
+  let otherOrgId: string
+  let groupId: string
+  let shiftId: string
+  let queryLog: string[]
+  const now = '2026-08-05T00:00:00.000Z'
+
+  const service = createAttendanceGroupFixedScheduleEffectivenessService({
+    HttpError: FakeHttpError,
+    buildAttendanceGroupFixedScheduleProducerKey: (input: { groupId: string; shiftId: string; startDate: string; endDate: string | null }) =>
+      producerKey(input),
+    now: () => now,
+  })
+
+  beforeEach(async () => {
+    adminPool = new Pool({ connectionString: databaseUrl })
+    schema = `fser4pre_${randomUUID().replace(/-/g, '')}`
+    await adminPool.query(`CREATE SCHEMA "${schema}"`)
+    pool = new Pool({ connectionString: databaseUrl, options: `-c search_path=${schema}` })
+    queryLog = []
+    orgId = `org-${randomUUID()}`
+    otherOrgId = `other-org-${randomUUID()}`
+    groupId = randomUUID()
+    shiftId = randomUUID()
+    await pool.query(`
+      CREATE TABLE users (
+        id text PRIMARY KEY,
+        is_active boolean NOT NULL DEFAULT true,
+        activation_status text NOT NULL DEFAULT 'activated'
+      );
+      CREATE TABLE user_orgs (
+        user_id text NOT NULL, org_id text NOT NULL, is_active boolean NOT NULL DEFAULT true,
+        PRIMARY KEY (user_id, org_id)
+      );
+      CREATE TABLE attendance_groups (id uuid PRIMARY KEY, org_id text NOT NULL);
+      CREATE TABLE attendance_group_fixed_schedule_configs (
+        org_id text NOT NULL, group_id uuid NOT NULL, shift_id uuid NOT NULL,
+        start_date date NOT NULL, end_date date NOT NULL, revision integer NOT NULL,
+        PRIMARY KEY (org_id, group_id)
+      );
+      CREATE TABLE attendance_group_members (org_id text NOT NULL, group_id uuid NOT NULL, user_id text NOT NULL);
+      CREATE TABLE attendance_shift_assignments (
+        id uuid PRIMARY KEY, org_id text NOT NULL, user_id text NOT NULL, shift_id uuid NOT NULL,
+        start_date date NOT NULL, end_date date, is_active boolean, publish_status text,
+        producer_type text, producer_ref_id uuid, producer_key text, created_at timestamptz NOT NULL DEFAULT now()
+      );
+    `)
+    await pool.query('INSERT INTO attendance_groups (id, org_id) VALUES ($1, $2)', [groupId, orgId])
+  })
+
+  afterEach(async () => {
+    await pool.end()
+    await adminPool.query(`DROP SCHEMA IF EXISTS "${schema}" CASCADE`)
+    await adminPool.end()
+  })
+
+  function db() {
+    return {
+      async query(statement: string, params?: unknown[]) {
+        queryLog.push(statement)
+        return (await pool.query(statement, params as unknown[])).rows
+      },
+    }
+  }
+
+  async function user(userId: string, overrides: Partial<{ isActive: boolean; activationStatus: string }> = {}) {
+    await pool.query('INSERT INTO users (id, is_active, activation_status) VALUES ($1, $2, $3)', [
+      userId,
+      overrides.isActive ?? true,
+      overrides.activationStatus ?? 'activated',
+    ])
+  }
+
+  async function orgMembership(userId: string, org: string, overrides: Partial<{ isActive: boolean }> = {}) {
+    await pool.query('INSERT INTO user_orgs (user_id, org_id, is_active) VALUES ($1, $2, $3)', [
+      userId,
+      org,
+      overrides.isActive ?? true,
+    ])
+  }
+
+  async function groupMembership(userId: string, org: string, group: string) {
+    await pool.query('INSERT INTO attendance_group_members (org_id, group_id, user_id) VALUES ($1, $2, $3)', [org, group, userId])
+  }
+
+  /** A fully live, activated, org-member, group-member subject — the positive-control baseline every negative leg mutates exactly one predicate away from. */
+  async function liveMember(userId: string, overrides: { isActive?: boolean; activationStatus?: string; orgActive?: boolean; skipOrgMembership?: boolean; skipGroupMembership?: boolean } = {}) {
+    await user(userId, { isActive: overrides.isActive, activationStatus: overrides.activationStatus })
+    if (!overrides.skipOrgMembership) await orgMembership(userId, orgId, { isActive: overrides.orgActive })
+    if (!overrides.skipGroupMembership) await groupMembership(userId, orgId, groupId)
+  }
+
+  async function configure(overrides: Partial<{ shiftId: string; startDate: string; endDate: string; revision: number }> = {}) {
+    await pool.query(
+      `INSERT INTO attendance_group_fixed_schedule_configs (org_id, group_id, shift_id, start_date, end_date, revision)
+       VALUES ($1, $2, $3, $4, $5, $6)`,
+      [orgId, groupId, overrides.shiftId ?? shiftId, overrides.startDate ?? '2026-08-01', overrides.endDate ?? '2026-08-31', overrides.revision ?? 1],
+    )
+  }
+
+  async function assignment(overrides: Partial<{ userId: string; shiftId: string; startDate: string; endDate: string | null; producerKey: string; publishStatus: string; active: boolean }> = {}) {
+    const startDate = overrides.startDate ?? '2026-08-01'
+    const endDate = overrides.endDate ?? '2026-08-31'
+    await pool.query(
+      `INSERT INTO attendance_shift_assignments
+         (id, org_id, user_id, shift_id, start_date, end_date, is_active, publish_status, producer_type, producer_ref_id, producer_key)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)`,
+      [
+        randomUUID(), orgId, overrides.userId ?? 'member-a', overrides.shiftId ?? shiftId, startDate, endDate,
+        overrides.active ?? true, overrides.publishStatus ?? 'published', producerType, groupId,
+        overrides.producerKey ?? producerKey({ groupId, shiftId: overrides.shiftId ?? shiftId, startDate, endDate }),
+      ],
+    )
+  }
+
+  const tableNames = ['users', 'user_orgs', 'attendance_groups', 'attendance_group_fixed_schedule_configs', 'attendance_group_members', 'attendance_shift_assignments']
+  async function countRows() {
+    return Promise.all(tableNames.map(async tableName => {
+      const result = await pool.query(`SELECT count(*)::int AS total FROM ${tableName}`)
+      return result.rows[0].total
+    }))
+  }
+
+  async function readSelf(userId: string, forOrg: string = orgId, forGroup: string = groupId) {
+    queryLog = []
+    const before = await countRows()
+    const result = await service.getSelfEffectiveness(db(), { orgId: forOrg, groupId: forGroup, userId })
+    const after = await countRows()
+    expect(after).toEqual(before)
+    expect(queryLog.every(statement => /^\s*SELECT\b/i.test(statement))).toBe(true)
+    return result
+  }
+
+  // ---------------------------------------------------------------------
+  // Authorization matrix — every negative leg fails BEFORE any config/member/
+  // assignment SQL (queryLog length 1, the proof query only) and returns the
+  // SAME values-free 404 shape (contract §2, gate #4).
+  // ---------------------------------------------------------------------
+
+  it('AUTHZ-1: missing group (no membership row at all) is 404, one query', async () => {
+    await liveMember('member-a')
+    queryLog = []
+    await expect(service.getSelfEffectiveness(db(), { orgId, groupId: randomUUID(), userId: 'member-a' }))
+      .rejects.toMatchObject({ status: 404, code: 'NOT_FOUND' })
+    expect(queryLog).toHaveLength(1)
+  })
+
+  it('AUTHZ-2: non-member subject (live user, active org membership, no group membership) is the same 404, one query', async () => {
+    await liveMember('member-a', { skipGroupMembership: true })
+    queryLog = []
+    await expect(service.getSelfEffectiveness(db(), { orgId, groupId, userId: 'member-a' }))
+      .rejects.toMatchObject({ status: 404, code: 'NOT_FOUND' })
+    expect(queryLog).toHaveLength(1)
+  })
+
+  it('AUTHZ-3: inactive subject (users.is_active=false) is the same 404, one query', async () => {
+    await liveMember('member-a', { isActive: false })
+    queryLog = []
+    await expect(service.getSelfEffectiveness(db(), { orgId, groupId, userId: 'member-a' }))
+      .rejects.toMatchObject({ status: 404, code: 'NOT_FOUND' })
+    expect(queryLog).toHaveLength(1)
+  })
+
+  it('AUTHZ-4: non-activated subject (activation_status=pending_activation) is the same 404, one query', async () => {
+    await liveMember('member-a', { activationStatus: 'pending_activation' })
+    queryLog = []
+    await expect(service.getSelfEffectiveness(db(), { orgId, groupId, userId: 'member-a' }))
+      .rejects.toMatchObject({ status: 404, code: 'NOT_FOUND' })
+    expect(queryLog).toHaveLength(1)
+  })
+
+  it('AUTHZ-5: missing user_orgs row entirely is the same 404, one query', async () => {
+    await liveMember('member-a', { skipOrgMembership: true })
+    queryLog = []
+    await expect(service.getSelfEffectiveness(db(), { orgId, groupId, userId: 'member-a' }))
+      .rejects.toMatchObject({ status: 404, code: 'NOT_FOUND' })
+    expect(queryLog).toHaveLength(1)
+  })
+
+  it('AUTHZ-6: inactive user_orgs row (org membership deactivated) is the same 404, one query', async () => {
+    await liveMember('member-a', { orgActive: false })
+    queryLog = []
+    await expect(service.getSelfEffectiveness(db(), { orgId, groupId, userId: 'member-a' }))
+      .rejects.toMatchObject({ status: 404, code: 'NOT_FOUND' })
+    expect(queryLog).toHaveLength(1)
+  })
+
+  it('AUTHZ-7 (forged witness / cross-org): a subject live in orgId cannot read this group under a forged otherOrgId, before SQL, same 404 shape', async () => {
+    await liveMember('member-a')
+    queryLog = []
+    await expect(service.getSelfEffectiveness(db(), { orgId: otherOrgId, groupId, userId: 'member-a' }))
+      .rejects.toMatchObject({ status: 404, code: 'NOT_FOUND' })
+    expect(queryLog).toHaveLength(1)
+  })
+
+  it('AUTHZ-8 (cross-org isolation, positive control): a live member of a DIFFERENT org\'s own group reads only that org\'s (unconfigured) state, never orgId\'s config', async () => {
+    const foreignGroupId = randomUUID()
+    await pool.query('INSERT INTO attendance_groups (id, org_id) VALUES ($1, $2)', [foreignGroupId, otherOrgId])
+    await user('member-x')
+    await orgMembership('member-x', otherOrgId)
+    await groupMembership('member-x', otherOrgId, foreignGroupId)
+    await configure() // desired config lives under orgId/groupId only — otherOrgId's group has none
+    queryLog = []
+    await expect(service.getSelfEffectiveness(db(), { orgId: otherOrgId, groupId: foreignGroupId, userId: 'member-x' }))
+      .resolves.toMatchObject({ applicability: 'not_configured', desired: null })
+    // Positive control: the same otherOrgId member never sees orgId's config — proves isolation
+    // is genuine (not merely "always 404s"), matching this line's positive-control discipline.
+    // And the forged-org attempt against orgId's actual groupId (AUTHZ-7) still 404s for this
+    // same subject identity shape, confirming the isolation is symmetric.
+  })
+
+  it('AUTHZ-9 mutation-style: an active member missing ONLY the group-membership row still 404s (isolates the group-membership predicate)', async () => {
+    await user('member-a')
+    await orgMembership('member-a', orgId)
+    // deliberately no groupMembership call
+    queryLog = []
+    await expect(service.getSelfEffectiveness(db(), { orgId, groupId, userId: 'member-a' }))
+      .rejects.toMatchObject({ status: 404, code: 'NOT_FOUND' })
+    expect(queryLog).toHaveLength(1)
+  })
+
+  it('AUTHZ-10: the 404 message never discloses which predicate failed (values-free, byte-identical across all failure reasons)', async () => {
+    await liveMember('m1', { isActive: false })
+    await liveMember('m2', { activationStatus: 'pending_activation' })
+    await liveMember('m3', { orgActive: false })
+    await liveMember('m4', { skipGroupMembership: true })
+    const messages = new Set<string>()
+    for (const userId of ['m1', 'm2', 'm3', 'm4', randomUUID()]) {
+      try {
+        await service.getSelfEffectiveness(db(), { orgId, groupId, userId })
+        throw new Error('expected rejection')
+      } catch (error: any) {
+        messages.add(`${error.status}:${error.code}:${error.message}`)
+      }
+    }
+    expect(messages.size).toBe(1)
+  })
+
+  // ---------------------------------------------------------------------
+  // Positive matrix + applicability + parity + exact-key projection
+  // ---------------------------------------------------------------------
+
+  it('POS-1: two members in the same org/group — each subject sees only their own applicability, never the other\'s', async () => {
+    await liveMember('member-a')
+    await liveMember('member-b')
+    await configure()
+    await assignment({ userId: 'member-a' }) // member-a: matching
+    // member-b has no assignment: non_matching
+
+    const selfA = await readSelf('member-a')
+    const selfB = await readSelf('member-b')
+
+    expect(selfA).toMatchObject({ applicability: 'matching', state: 'pending_apply' })
+    expect(selfB).toMatchObject({ applicability: 'non_matching', state: 'pending_apply' })
+    expect(JSON.stringify(selfA)).not.toContain('member-b')
+    expect(JSON.stringify(selfB)).not.toContain('member-a')
+  })
+
+  it('POS-2: not_configured applicability when no desired config exists', async () => {
+    await liveMember('member-a')
+    const self = await readSelf('member-a')
+    expect(self).toMatchObject({ applicability: 'not_configured', state: 'not_configured', desired: null })
+  })
+
+  it('POS-3: matching applicability when the group state is fully effective', async () => {
+    await liveMember('member-a')
+    await configure()
+    await assignment({ userId: 'member-a' })
+    const self = await readSelf('member-a')
+    expect(self).toMatchObject({ applicability: 'matching', state: 'effective', reasonCodes: ['EFFECTIVE'] })
+  })
+
+  it('POS-4: non_matching when the subject only has a stale different-key row (group state configuration_changed)', async () => {
+    await liveMember('member-a')
+    await configure()
+    await assignment({ shiftId: randomUUID(), startDate: '2026-07-01', endDate: '2026-07-31' })
+    const self = await readSelf('member-a')
+    expect(self).toMatchObject({ applicability: 'non_matching', state: 'configuration_changed' })
+  })
+
+  it('PARITY: admin getEffectiveness and self getSelfEffectiveness return byte-identical state/reasonCodes/desired/evaluatedAt over the same fixture', async () => {
+    await liveMember('member-a')
+    await liveMember('member-b')
+    await configure()
+    await assignment({ userId: 'member-a' })
+
+    const admin = await service.getEffectiveness(db(), { orgId, groupId })
+    const self = await service.getSelfEffectiveness(db(), { orgId, groupId, userId: 'member-a' })
+
+    expect(self.state).toBe(admin.state)
+    expect(self.reasonCodes).toEqual(admin.reasonCodes)
+    expect(self.desired).toEqual(admin.desired)
+    expect(self.evaluatedAt).toBe(admin.evaluatedAt)
+    expect(self.evaluatedAt).toBe(now)
+  })
+
+  it('EXACT-KEY: the self response has exactly the contract-declared keys, no coverage/drift/managedSets/producerKey/raw user ids at any depth', async () => {
+    await liveMember('member-a')
+    await liveMember('unrelated-member')
+    await configure()
+    await assignment({ userId: 'member-a' })
+    await assignment({ userId: 'unrelated-member', shiftId: randomUUID(), startDate: '2026-07-01', endDate: '2026-07-31' })
+
+    const self = await readSelf('member-a')
+    expect(Object.keys(self).sort()).toEqual(['applicability', 'desired', 'evaluatedAt', 'groupId', 'reasonCodes', 'state'].sort())
+
+    const serialized = JSON.stringify(self)
+    expect(serialized).not.toContain('coverage')
+    expect(serialized).not.toContain('drift')
+    expect(serialized).not.toContain('managedSets')
+    expect(serialized).not.toContain('producerKey')
+    expect(serialized).not.toContain('unrelated-member')
+    expect(serialized).not.toContain('member-a')
+  })
+
+  it('the canonical producer-key builder inputs match the admin path (desired shift/window)', async () => {
+    await liveMember('member-a')
+    await configure({ shiftId, startDate: '2026-08-01', endDate: '2026-08-31', revision: 3 })
+    await assignment({ userId: 'member-a' })
+    const self = await readSelf('member-a')
+    expect(self.desired).toEqual({ shiftId, startDate: '2026-08-01', endDate: '2026-08-31', revision: 3 })
+  })
+})

--- a/packages/core-backend/tests/integration/attendance-group-fixed-schedule-self-effectiveness.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-group-fixed-schedule-self-effectiveness.db.test.ts
@@ -260,6 +260,52 @@ describeDb('attendance group fixed-schedule self effectiveness (real DB, #4709 F
     expect(queryLog).toHaveLength(1)
   })
 
+  // -------------------------------------------------------------------
+  // #4709 FSER-4 prerequisite — P2-2 gate fix from the exact-head independent
+  // review of PR #4772 (`pr4772-gate-20260805-opus5-mutationlane.md`): the
+  // proof query joins BOTH `uo.org_id = $1` and `agm.org_id = $1`. Deleting
+  // either predicate alone left all 17 existing db tests green — every prior
+  // negative leg either has no user_orgs row at all for this user (so
+  // removing `uo.org_id = $1` still finds no row), or no
+  // attendance_group_members row at all (so removing `agm.org_id = $1` still
+  // finds no row). None of them isolates ONE org column while leaving a
+  // matching row on the OTHER table under a DIFFERENT org — exactly the shape
+  // an org-transfer/deprovision-by-delete-not-deactivate bug would produce.
+  // These two legs are per-predicate exclusive: EXCL-uo.org_id only reds when
+  // `uo.org_id = $1` is removed (not when `agm.org_id = $1` is removed), and
+  // EXCL-agm.org_id only reds the other way — proving the two org predicates
+  // no longer cover for each other (this line's "门级排他 ≠ 词级排他"
+  // discipline).
+  // -------------------------------------------------------------------
+
+  it('EXCL-uo.org_id: an orphan attendance_group_members row scoped to THIS org, but the subject\'s only active org membership is in ANOTHER org, still 404s (isolates the uo.org_id predicate)', async () => {
+    await user('member-a')
+    await orgMembership('member-a', otherOrgId) // active membership, but NOT in orgId
+    await groupMembership('member-a', orgId, groupId) // orphan agm row scoped to orgId despite no orgId membership
+    queryLog = []
+    await expect(service.getSelfEffectiveness(db(), { orgId, groupId, userId: 'member-a' }))
+      .rejects.toMatchObject({ status: 404, code: 'NOT_FOUND' })
+    expect(queryLog).toHaveLength(1)
+  })
+
+  it('EXCL-agm.org_id: an active org membership in THIS org, but the group-membership row is scoped to ANOTHER org, still 404s (isolates the agm.org_id predicate)', async () => {
+    await user('member-a')
+    await orgMembership('member-a', orgId) // active membership in this org
+    await groupMembership('member-a', otherOrgId, groupId) // agm row scoped to a DIFFERENT org, same group/user id
+    queryLog = []
+    await expect(service.getSelfEffectiveness(db(), { orgId, groupId, userId: 'member-a' }))
+      .rejects.toMatchObject({ status: 404, code: 'NOT_FOUND' })
+    expect(queryLog).toHaveLength(1)
+  })
+
+  it('POS-CONTROL (org-predicate legs): a fully legitimate member of this org and group reads the desired config, unaffected by the org-predicate exclusion legs above', async () => {
+    await liveMember('member-a')
+    await configure({ revision: 7 })
+    await assignment({ userId: 'member-a' })
+    const self = await readSelf('member-a')
+    expect(self.desired).toMatchObject({ revision: 7 })
+  })
+
   it('AUTHZ-10: the 404 message never discloses which predicate failed (values-free, byte-identical across all failure reasons)', async () => {
     await liveMember('m1', { isActive: false })
     await liveMember('m2', { activationStatus: 'pending_activation' })

--- a/packages/core-backend/tests/unit/attendance-fixed-schedule-self-route-identity.test.ts
+++ b/packages/core-backend/tests/unit/attendance-fixed-schedule-self-route-identity.test.ts
@@ -1,0 +1,92 @@
+import { createRequire } from 'node:module'
+
+import { describe, expect, it } from 'vitest'
+
+const require = createRequire(import.meta.url)
+const {
+  resolveAttendanceFixedScheduleSelfRouteIdentity,
+} = require('../../../../plugins/plugin-attendance/lib/attendance-fixed-schedule-self-route-identity.cjs') as {
+  resolveAttendanceFixedScheduleSelfRouteIdentity: (input: Record<string, unknown>) => Record<string, unknown>
+}
+
+const authenticated = { authenticatedUserId: 'user-a', authenticatedOrgId: 'org-a' }
+
+function resolve(overrides: Record<string, unknown> = {}) {
+  return resolveAttendanceFixedScheduleSelfRouteIdentity({
+    ...authenticated,
+    body: {},
+    query: {},
+    headers: {},
+    ...overrides,
+  })
+}
+
+describe('attendance fixed-schedule self route identity (#4709 FSER-4 prerequisite, §2)', () => {
+  it('accepts an authenticated principal with no selectors at all', () => {
+    expect(resolve()).toEqual({ ok: true, userId: 'user-a', orgId: 'org-a' })
+  })
+
+  it('401s when no authenticated user id is present, before any org/selector check', () => {
+    expect(resolve({ authenticatedUserId: null, authenticatedOrgId: null, body: { userId: 'x' } }))
+      .toEqual({ ok: false, status: 401, code: 'UNAUTHORIZED', message: 'User ID not found' })
+  })
+
+  it('403s values-free when the authenticated user has no organization', () => {
+    const result = resolve({ authenticatedOrgId: null })
+    expect(result).toEqual({ ok: false, status: 403, code: 'FORBIDDEN', message: 'Authenticated organization not found' })
+    expect(JSON.stringify(result)).not.toContain('user-a')
+  })
+
+  it.each([
+    ['body.userId', { body: { userId: 'user-b' } }],
+    ['body.orgId', { body: { orgId: 'org-b' } }],
+    ['query.userId', { query: { userId: 'user-b' } }],
+    ['query.orgId', { query: { orgId: 'org-b' } }],
+    ['body.userId byte-equal to the authenticated subject (still rejected — no selector is accepted, matching or not)', { body: { userId: 'user-a' } }],
+    ['query.orgId as an array', { query: { orgId: ['org-b'] } }],
+    ['body.userId as an empty string (presence, not truthiness, triggers 400)', { body: { userId: '' } }],
+  ])('400s a %s selector before any SQL', (_name, overrides) => {
+    const result = resolve(overrides)
+    expect(result).toMatchObject({ ok: false, status: 400, code: 'VALIDATION_ERROR' })
+  })
+
+  it('tolerates a byte-equal x-user-id/x-org-id header pair (legacy clients that always echo it)', () => {
+    expect(resolve({ headers: { 'x-user-id': 'user-a', 'x-org-id': 'org-a' } }))
+      .toEqual({ ok: true, userId: 'user-a', orgId: 'org-a' })
+  })
+
+  it('403s a mismatched x-user-id header', () => {
+    expect(resolve({ headers: { 'x-user-id': 'user-b' } }))
+      .toEqual({ ok: false, status: 403, code: 'FORBIDDEN', message: 'Insufficient permissions' })
+  })
+
+  it('403s a mismatched x-org-id header', () => {
+    expect(resolve({ headers: { 'x-org-id': 'org-b' } }))
+      .toEqual({ ok: false, status: 403, code: 'FORBIDDEN', message: 'Insufficient permissions' })
+  })
+
+  it('403s when any array value in a repeated x-user-id header mismatches', () => {
+    expect(resolve({ headers: { 'x-user-id': ['user-a', 'user-b'] } }))
+      .toEqual({ ok: false, status: 403, code: 'FORBIDDEN', message: 'Insufficient permissions' })
+  })
+
+  it('never returns the header value as identity even when it happens to be tolerated', () => {
+    // Header is byte-equal to the authenticated principal; returned identity must be the
+    // authenticated principal object identity's value, not a header-derived copy — this test
+    // pins the VALUE, which is the only thing distinguishable at this boundary.
+    const result = resolve({ headers: { 'x-user-id': 'user-a' } })
+    expect(result).toEqual({ ok: true, userId: 'user-a', orgId: 'org-a' })
+  })
+
+  it('mutation proof: removing the header-mismatch check would let a forged x-user-id through as ok:true', () => {
+    // This test's OWN job is to fail loudly if resolve({headers:{'x-user-id':'user-b'}}) ever
+    // returns ok:true — i.e. it is the negative leg for the header-mismatch predicate.
+    const result = resolve({ headers: { 'x-user-id': 'attacker' } })
+    expect(result.ok).toBe(false)
+  })
+
+  it('does not disclose the rejected body/query value in its message (values-free)', () => {
+    const result = resolve({ body: { userId: 'super-secret-user-id' } })
+    expect(JSON.stringify(result)).not.toContain('super-secret-user-id')
+  })
+})

--- a/packages/core-backend/tests/unit/attendance-fixed-schedule-self-route-wiring.test.ts
+++ b/packages/core-backend/tests/unit/attendance-fixed-schedule-self-route-wiring.test.ts
@@ -1,0 +1,213 @@
+import { createRequire } from 'node:module'
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const require = createRequire(import.meta.url)
+const attendancePlugin = require('../../../../plugins/plugin-attendance/index.cjs')
+
+// #4709 FSER-4 prerequisite (contract amendment `docs/development/
+// attendance-4709-fser4-member-projection-contract-amendment-20260804.md` §2,
+// RATIFIED `45d71c4209af35a63768ce7ce9f576377f6b8ce4`, OD-4709-2=(a)) — P2-1
+// gate fix from the exact-head independent review of PR #4772
+// (`pr4772-gate-20260805-opus5-mutationlane.md`): the identity resolver in
+// `attendance-fixed-schedule-self-route-identity.cjs` has 17 pure-function
+// unit tests, but NOTHING previously proved the route
+// (`GET /api/attendance/groups/:groupId/fixed-schedule/effectiveness/me` in
+// `plugins/plugin-attendance/index.cjs`) actually calls it and obeys its
+// verdict. A route that dropped the `if (!identity.ok)` check, or swapped the
+// resolver for the loose same-family `getUserId`/`getOrgId` helpers (which DO
+// fall back to attacker-controlled `x-user-id` header / body / query), passed
+// every existing test file untouched. These probes invoke the REAL route
+// handler through the plugin's own route table (not the pure resolver
+// directly — "verify follow the delegation", not a second unit test of the
+// function already covered) and assert BOTH the HTTP outcome AND that no SQL
+// was reached on every rejection leg, mirroring the harness pattern in
+// `attendance-uuid-validation-routes.test.ts`.
+
+type RouteHandler = (req: any, res: any, next: any) => Promise<void>
+
+const originalRbacBypass = process.env.RBAC_BYPASS
+
+function createResponse() {
+  return {
+    statusCode: 200,
+    body: undefined as unknown,
+    status(code: number) {
+      this.statusCode = code
+      return this
+    },
+    json(body: unknown) {
+      this.body = body
+      return this
+    },
+  }
+}
+
+async function createHarness() {
+  process.env.RBAC_BYPASS = 'true'
+
+  const routes = new Map<string, RouteHandler>()
+  const db = {
+    query: vi.fn(async () => {
+      throw new Error('db disabled in unit harness')
+    }),
+    transaction: vi.fn(async (callback: (client: unknown) => unknown) => callback(db)),
+  }
+  const logger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }
+
+  await attendancePlugin.activate({
+    api: {
+      database: db,
+      events: { emit: vi.fn() },
+      http: {
+        addRoute(method: string, path: string, handler: RouteHandler) {
+          routes.set(`${method.toUpperCase()} ${path}`, handler)
+        },
+      },
+    },
+    services: {
+      attendanceW4SegmentCalculation: {
+        resolveOrgSegmentCalculationPosture: async () => ({
+          effectiveState: 'legacy',
+          referenceSegments: false,
+        }),
+        createRequestOperationBoundary: ({ adapters }: { adapters: Record<string, any> }) => ({
+          execute: async (input: Record<string, any>) => db.transaction(async (trx: any) => {
+            const operation = {
+              operationId: input.operationId ?? null,
+              correlationId: input.correlationId,
+              acceptedWritePosture: 'legacy_projection_only',
+              routeVariant: input.routeVariant ?? null,
+            }
+            const adapter = adapters[input.kind]
+            const prepared = await adapter.prepare(trx, input.routeInput, operation)
+            const result = await adapter.execute(trx, prepared, operation)
+            return { kind: 'legacy', response: result.response }
+          }),
+        }),
+      },
+    },
+    logger,
+  })
+
+  db.query.mockClear()
+  db.transaction.mockClear()
+
+  return { db, routes }
+}
+
+async function invokeRoute(
+  routes: Map<string, RouteHandler>,
+  key: string,
+  options: { params?: Record<string, string>; body?: unknown; query?: Record<string, unknown>; headers?: Record<string, unknown>; user?: Record<string, unknown> | null } = {},
+) {
+  const handler = routes.get(key)
+  expect(handler, key).toBeTypeOf('function')
+  const res = createResponse()
+  await handler?.(
+    {
+      params: options.params ?? {},
+      body: options.body ?? {},
+      query: options.query ?? {},
+      headers: options.headers ?? {},
+      user: 'user' in options ? options.user : { id: 'self-route-user-1', orgId: 'self-route-org' },
+      ip: '127.0.0.1',
+      get: vi.fn(() => undefined),
+    },
+    res,
+    vi.fn(),
+  )
+  return res
+}
+
+afterEach(async () => {
+  if (originalRbacBypass === undefined) delete process.env.RBAC_BYPASS
+  else process.env.RBAC_BYPASS = originalRbacBypass
+  await attendancePlugin.deactivate()
+  vi.restoreAllMocks()
+})
+
+const routeKey = 'GET /api/attendance/groups/:groupId/fixed-schedule/effectiveness/me'
+const groupId = '00000000-0000-4000-8000-000000000701'
+
+describe('attendance fixed-schedule self route — identity guard wiring (#4709 FSER-4 prerequisite, §2, P2-1)', () => {
+  it('rejects a body.userId selector with 400 before any SQL', async () => {
+    const { db, routes } = await createHarness()
+    const res = await invokeRoute(routes, routeKey, { params: { groupId }, body: { userId: 'attacker' } })
+    expect(res.statusCode).toBe(400)
+    expect(res.body).toMatchObject({ ok: false, error: { code: 'VALIDATION_ERROR' } })
+    expect(db.query).not.toHaveBeenCalled()
+  })
+
+  it('rejects a query.orgId selector with 400 before any SQL', async () => {
+    const { db, routes } = await createHarness()
+    const res = await invokeRoute(routes, routeKey, { params: { groupId }, query: { orgId: 'other-org' } })
+    expect(res.statusCode).toBe(400)
+    expect(res.body).toMatchObject({ ok: false, error: { code: 'VALIDATION_ERROR' } })
+    expect(db.query).not.toHaveBeenCalled()
+  })
+
+  it('rejects a mismatched x-user-id header with 403 before any SQL', async () => {
+    const { db, routes } = await createHarness()
+    const res = await invokeRoute(routes, routeKey, { params: { groupId }, headers: { 'x-user-id': 'victim' } })
+    expect(res.statusCode).toBe(403)
+    expect(res.body).toMatchObject({ ok: false, error: { code: 'FORBIDDEN' } })
+    expect(db.query).not.toHaveBeenCalled()
+  })
+
+  it('rejects a mismatched x-org-id header with 403 before any SQL', async () => {
+    const { db, routes } = await createHarness()
+    const res = await invokeRoute(routes, routeKey, { params: { groupId }, headers: { 'x-org-id': 'other-org' } })
+    expect(res.statusCode).toBe(403)
+    expect(res.body).toMatchObject({ ok: false, error: { code: 'FORBIDDEN' } })
+    expect(db.query).not.toHaveBeenCalled()
+  })
+
+  it('rejects an authenticated principal with no organization — values-free 403 before any SQL', async () => {
+    const { db, routes } = await createHarness()
+    const res = await invokeRoute(routes, routeKey, { params: { groupId }, user: { id: 'self-route-user-1' } })
+    expect(res.statusCode).toBe(403)
+    expect(res.body).toMatchObject({ ok: false, error: { code: 'FORBIDDEN' } })
+    expect(JSON.stringify(res.body)).not.toContain('self-route-user-1')
+    expect(db.query).not.toHaveBeenCalled()
+  })
+
+  it('rejects a request with no authenticated user — 401 before any SQL', async () => {
+    const { db, routes } = await createHarness()
+    const res = await invokeRoute(routes, routeKey, { params: { groupId }, user: null })
+    expect(res.statusCode).toBe(401)
+    expect(res.body).toMatchObject({ ok: false, error: { code: 'UNAUTHORIZED' } })
+    expect(db.query).not.toHaveBeenCalled()
+  })
+
+  it('positive control: a fully legitimate self request (no selectors, no header) reaches the proof SQL and succeeds', async () => {
+    const { db, routes } = await createHarness()
+    db.query
+      .mockResolvedValueOnce([{ present: 1 }]) // proof query
+      .mockResolvedValueOnce([]) // desired config
+      .mockResolvedValueOnce([]) // target member ids
+      .mockResolvedValueOnce([]) // managed assignment rows
+
+    const res = await invokeRoute(routes, routeKey, { params: { groupId } })
+
+    expect(res.statusCode).toBe(200)
+    expect(res.body).toMatchObject({
+      ok: true,
+      data: { groupId, applicability: 'not_configured', state: 'not_configured' },
+    })
+    // Proves the route reached the SERVICE's proof SQL with the AUTHENTICATED
+    // principal's identity — not a header/body/query-derived one. If the
+    // route stopped calling the identity resolver, or called the loose
+    // getUserId/getOrgId helpers instead, this exact call shape would not
+    // occur for a request that supplies no user object override.
+    expect(db.query).toHaveBeenCalledWith(
+      expect.stringContaining('FROM users u'),
+      ['self-route-org', groupId, 'self-route-user-1'],
+    )
+  })
+})

--- a/packages/core-backend/tests/unit/attendance-group-fixed-schedule-effectiveness-service.test.ts
+++ b/packages/core-backend/tests/unit/attendance-group-fixed-schedule-effectiveness-service.test.ts
@@ -5,8 +5,10 @@ import { describe, expect, it } from 'vitest'
 const require = createRequire(import.meta.url)
 const {
   deriveAttendanceGroupFixedScheduleEffectiveness,
+  deriveAttendanceGroupFixedScheduleSelfApplicability,
 } = require('../../../../plugins/plugin-attendance/lib/attendance-group-fixed-schedule-effectiveness-service.cjs') as {
   deriveAttendanceGroupFixedScheduleEffectiveness: (input: Record<string, unknown>) => Record<string, unknown>
+  deriveAttendanceGroupFixedScheduleSelfApplicability: (input: Record<string, unknown>) => string
 }
 
 const desired = { shiftId: 'shift-current', startDate: '2026-08-01', endDate: '2026-08-31', revision: 2 }
@@ -65,5 +67,60 @@ describe('attendance group fixed-schedule effectiveness derivation', () => {
   it('never includes member identifiers in its projection', () => {
     const result = JSON.stringify(derive({ managedRows: [assignment()] }))
     expect(result).not.toContain('member-a')
+  })
+})
+
+// #4709 FSER-4 prerequisite (contract amendment §2): self-projection applicability.
+// Mutation proofs: dropping the `producer_key === producerKey` filter would let a
+// stale/different-key row count as "matching"; dropping `=== 1` (using `>= 1` instead)
+// would let a duplicate-matching-row member read as "matching" though the group-level
+// derivation reports DUPLICATE_MATCHING_ASSIGNMENT for that same member; dropping
+// `isPublished` would let an unpublished row count.
+describe('attendance group fixed-schedule self applicability derivation (#4709 FSER-4 prerequisite §2)', () => {
+  function applicability(overrides: Record<string, unknown> = {}) {
+    return deriveAttendanceGroupFixedScheduleSelfApplicability({
+      desired,
+      producerKey,
+      managedRows: [],
+      userId: 'member-a',
+      ...overrides,
+    })
+  }
+
+  it('is not_configured when no desired config exists, regardless of managed rows', () => {
+    expect(applicability({ desired: null, managedRows: [assignment()] })).toBe('not_configured')
+  })
+
+  it('is non_matching when the subject has zero managed rows', () => {
+    expect(applicability({ managedRows: [] })).toBe('non_matching')
+  })
+
+  it('is matching when the subject has exactly one eligible row matching the desired key and values', () => {
+    expect(applicability({ managedRows: [assignment()] })).toBe('matching')
+  })
+
+  it('is non_matching for a duplicate matching row (exactly-one, not at-least-one)', () => {
+    expect(applicability({ managedRows: [assignment(), assignment()] })).toBe('non_matching')
+  })
+
+  it('is non_matching when the subject only has a different-producer-key (stale) row', () => {
+    expect(applicability({ managedRows: [assignment({ producer_key: oldProducerKey })] })).toBe('non_matching')
+  })
+
+  it('is non_matching when the subject only has an unpublished row', () => {
+    expect(applicability({ managedRows: [assignment({ publish_status: 'pending' })] })).toBe('non_matching')
+  })
+
+  it('is non_matching when the subject only has a value-corrupt row on the desired key', () => {
+    expect(applicability({ managedRows: [assignment({ shift_id: 'shift-corrupt' })] })).toBe('non_matching')
+  })
+
+  it('ignores another member\'s matching row entirely', () => {
+    expect(applicability({ userId: 'member-b', managedRows: [assignment({ user_id: 'member-a' })] })).toBe('non_matching')
+  })
+
+  it('never includes a raw user identifier in its return value (it is a bare enum string)', () => {
+    const result = applicability({ managedRows: [assignment()] })
+    expect(['not_configured', 'matching', 'non_matching']).toContain(result)
   })
 })

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -651,6 +651,12 @@ export default defineConfig({
       // #4709 FSER-3 first-config atomicity and true two-connection convergence require
       // real PostgreSQL; the whole file is explicitly run in plugin-tests.yml.
       'tests/integration/attendance-group-fixed-schedule-config-consume.db.test.ts',
+      // #4709 FSER-4 prerequisite (member-safe self projection, contract amendment §2):
+      // real-DB authorization matrix (liveness/activation/org-membership/group-membership,
+      // cross-org isolation) and admin/self parity require real PostgreSQL; excluded here
+      // so the no-DB job cannot skip-green it, and the whole file is explicitly run in
+      // plugin-tests.yml's attendance-real-db-integration step.
+      'tests/integration/attendance-group-fixed-schedule-self-effectiveness.db.test.ts',
       // #4556 W5 flex persistence and canonical writer proof requires real PostgreSQL;
       // the whole file is explicitly run in plugin-tests.yml.
       'tests/integration/attendance-shift-flex-policy-migration.db.test.ts',

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -15,6 +15,7 @@ const attendanceWorkDateAdaptersLib = require('./lib/attendance-work-date-adapte
 const attendanceShiftServiceLib = require('./lib/attendance-shift-service.cjs')
 const attendanceGroupFixedScheduleConfigServiceLib = require('./lib/attendance-group-fixed-schedule-config-service.cjs')
 const attendanceGroupFixedScheduleEffectivenessServiceLib = require('./lib/attendance-group-fixed-schedule-effectiveness-service.cjs')
+const { resolveAttendanceFixedScheduleSelfRouteIdentity } = require('./lib/attendance-fixed-schedule-self-route-identity.cjs')
 const {
   DEFAULT_ATTRIBUTION_TAIL_MINUTES,
   MAX_ATTRIBUTION_TAIL_MINUTES,
@@ -44395,6 +44396,62 @@ module.exports = {
               return
             }
             logger.error('Attendance group fixed schedule effectiveness read failed', error)
+            permissionRes.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to read fixed schedule effectiveness' } })
+          }
+        })(req, res, next)
+      }
+    )
+
+    // #4709 FSER-4 prerequisite (contract amendment §2, RATIFIED
+    // `45d71c4209af35a63768ce7ce9f576377f6b8ce4`, OD-4709-2=(a)): a member-safe
+    // self projection beside the admin aggregate above. Uses `attendance:read`
+    // (not `attendance:admin`) and never accepts a caller-supplied subject/org
+    // selector — `resolveAttendanceFixedScheduleSelfRouteIdentity` rejects a
+    // body/query `userId`/`orgId` with 400 and a mismatched `x-user-id`/
+    // `x-org-id` header with 403, both before any scoped SQL; only the
+    // authenticated principal names the subject and org. The service itself
+    // (`getSelfEffectiveness`) then proves group membership + subject/org
+    // liveness in one query before loading any config or assignment fact, and
+    // returns a distinct exact-key projection — never the admin response's
+    // `coverage`/`drift`/`managedSets` or any raw user id.
+    context.api.http.addRoute(
+      'GET',
+      '/api/attendance/groups/:groupId/fixed-schedule/effectiveness/me',
+      async (req, res, next) => {
+        const identity = resolveAttendanceFixedScheduleSelfRouteIdentity({
+          authenticatedUserId: getAuthenticatedUserId(req),
+          authenticatedOrgId: getAuthenticatedOrgId(req),
+          body: req.body,
+          query: req.query,
+          headers: req.headers,
+        })
+        if (!identity.ok) {
+          res.status(identity.status).json({ ok: false, error: { code: identity.code, message: identity.message } })
+          return
+        }
+        return withPermission('attendance:read', async (permissionReq, permissionRes) => {
+          const groupId = normalizeUuidString(permissionReq.params.groupId)
+          if (!groupId) {
+            respondInvalidUuid(permissionRes, 'groupId')
+            return
+          }
+          try {
+            const effectiveness = await getAttendanceGroupFixedScheduleEffectivenessService().getSelfEffectiveness(db, {
+              orgId: identity.orgId,
+              groupId,
+              userId: identity.userId,
+            })
+            permissionRes.json({ ok: true, data: effectiveness })
+          } catch (error) {
+            if (error instanceof HttpError) {
+              permissionRes.status(error.status).json({ ok: false, error: { code: error.code, message: error.message } })
+              return
+            }
+            if (isDatabaseSchemaError(error)) {
+              permissionRes.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: 'Attendance fixed schedule tables missing' } })
+              return
+            }
+            logger.error('Attendance group fixed schedule self effectiveness read failed', error)
             permissionRes.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to read fixed schedule effectiveness' } })
           }
         })(req, res, next)

--- a/plugins/plugin-attendance/lib/attendance-fixed-schedule-self-route-identity.cjs
+++ b/plugins/plugin-attendance/lib/attendance-fixed-schedule-self-route-identity.cjs
@@ -1,0 +1,82 @@
+'use strict'
+
+// #4709 FSER-4 prerequisite (contract amendment `docs/development/
+// attendance-4709-fser4-member-projection-contract-amendment-20260804.md` §2,
+// RATIFIED `45d71c4209af35a63768ce7ce9f576377f6b8ce4`, OD-4709-2=(a)):
+// GET /api/attendance/groups/:groupId/fixed-schedule/effectiveness/me is a
+// member-safe self-service read. Its identity resolution is deliberately
+// narrower than the admin FSER route's `resolveAttendanceFixedScheduleRouteActorContext`
+// (plugins/plugin-attendance/index.cjs) — that resolver folds a body/query/header
+// org mismatch into one 403. The contract instead requires THREE distinct
+// postures for this route, in this order:
+//   1. no authenticated user            -> 401 (unchanged)
+//   2. no authenticated org             -> 403, values-free, before any SQL
+//   3. a body/query `userId` or `orgId` selector, present at all -> 400
+//      (this route never accepts a caller-supplied subject/org selector —
+//      not even a byte-equal one; only the authenticated principal may name
+//      the subject/org)
+//   4. an `x-user-id`/`x-org-id` header that mismatches the authenticated
+//      principal -> 403; a header that is byte-equal is tolerated (existing
+//      bearer/dev-token clients that always echo the header keep working)
+//      but is NEVER used as an identity source — the returned identity is
+//      always the authenticated principal, never the header value.
+//
+// Kept as a pure function (no Express req/res) so it is unit-testable without
+// mocking HTTP, per this line's "no fake switch tests" discipline — every
+// negative leg here has a corresponding exact-shape unit test in
+// packages/core-backend/tests/unit/attendance-fixed-schedule-self-route-identity.test.ts.
+
+function flattenSelectorValues(value) {
+  if (value === undefined || value === null) return []
+  return Array.isArray(value) ? value.filter(item => item !== undefined && item !== null) : [value]
+}
+
+function hasSelector(value) {
+  return flattenSelectorValues(value).length > 0
+}
+
+/**
+ * @param {{
+ *   authenticatedUserId: string | null,
+ *   authenticatedOrgId: string | null,
+ *   body: Record<string, unknown> | null | undefined,
+ *   query: Record<string, unknown> | null | undefined,
+ *   headers: Record<string, unknown> | null | undefined,
+ * }} input
+ * @returns {{ ok: true, userId: string, orgId: string } | { ok: false, status: number, code: string, message: string }}
+ */
+function resolveAttendanceFixedScheduleSelfRouteIdentity(input) {
+  const { authenticatedUserId, authenticatedOrgId, body, query, headers } = input
+
+  if (!authenticatedUserId) {
+    return { ok: false, status: 401, code: 'UNAUTHORIZED', message: 'User ID not found' }
+  }
+  if (!authenticatedOrgId) {
+    return { ok: false, status: 403, code: 'FORBIDDEN', message: 'Authenticated organization not found' }
+  }
+
+  const forbiddenSelectorPresent = hasSelector(body?.userId)
+    || hasSelector(body?.orgId)
+    || hasSelector(query?.userId)
+    || hasSelector(query?.orgId)
+  if (forbiddenSelectorPresent) {
+    return {
+      ok: false,
+      status: 400,
+      code: 'VALIDATION_ERROR',
+      message: 'userId and orgId are not accepted on this route; the authenticated principal is the only identity source',
+    }
+  }
+
+  const headerUserIdValues = flattenSelectorValues(headers?.['x-user-id'])
+  const headerOrgIdValues = flattenSelectorValues(headers?.['x-org-id'])
+  const headerMismatch = headerUserIdValues.some(value => value !== authenticatedUserId)
+    || headerOrgIdValues.some(value => value !== authenticatedOrgId)
+  if (headerMismatch) {
+    return { ok: false, status: 403, code: 'FORBIDDEN', message: 'Insufficient permissions' }
+  }
+
+  return { ok: true, userId: authenticatedUserId, orgId: authenticatedOrgId }
+}
+
+module.exports = { resolveAttendanceFixedScheduleSelfRouteIdentity }

--- a/plugins/plugin-attendance/lib/attendance-fixed-schedule-self-route-identity.cjs
+++ b/plugins/plugin-attendance/lib/attendance-fixed-schedule-self-route-identity.cjs
@@ -25,6 +25,16 @@
 // mocking HTTP, per this line's "no fake switch tests" discipline — every
 // negative leg here has a corresponding exact-shape unit test in
 // packages/core-backend/tests/unit/attendance-fixed-schedule-self-route-identity.test.ts.
+// That file proves ONLY this resolver's own logic in isolation. It does NOT
+// prove that the route (plugins/plugin-attendance/index.cjs) actually calls
+// this function or obeys its verdict — a route that dropped the
+// `if (!identity.ok)` check, or called this resolver but ignored the result,
+// would still pass every test in that file untouched. That separate,
+// route-level claim is proven by the harness-based probes in
+// packages/core-backend/tests/unit/attendance-fixed-schedule-self-route-wiring.test.ts,
+// which invoke the real route handler end to end (not this function
+// directly) and assert both the HTTP outcome and that no SQL is reached on
+// every rejection leg.
 
 function flattenSelectorValues(value) {
   if (value === undefined || value === null) return []

--- a/plugins/plugin-attendance/lib/attendance-group-fixed-schedule-effectiveness-service.cjs
+++ b/plugins/plugin-attendance/lib/attendance-group-fixed-schedule-effectiveness-service.cjs
@@ -155,27 +155,43 @@ function deriveAttendanceGroupFixedScheduleEffectiveness({ desired, targetMember
   }
 }
 
-function createAttendanceGroupFixedScheduleEffectivenessService({ HttpError, buildAttendanceGroupFixedScheduleProducerKey, now = () => new Date().toISOString() }) {
-  async function getEffectiveness(db, input) {
-    const groupRows = await db.query(
-      'SELECT id FROM attendance_groups WHERE id = $1 AND org_id = $2 LIMIT 1',
-      [input.groupId, input.orgId],
-    )
-    if (!groupRows.length) throw new HttpError(404, 'NOT_FOUND', 'Group not found')
+// #4709 FSER-4 prerequisite (contract amendment, §2, RATIFIED
+// `45d71c4209af35a63768ce7ce9f576377f6b8ce4`, OD-4709-2=(a)): applicability for
+// the member-safe self projection. Deliberately kept in this module — not in
+// the route file and not re-derived per-caller — because it reuses the exact
+// same `isPublished`/`assignmentMatchesDesired` predicates the group four-state
+// derivation above uses, so there is exactly one place that knows what
+// "matching" means. `matching` requires EXACTLY ONE eligible row: a member
+// with zero matching rows is obviously `non_matching`, and a member with a
+// duplicate matching row (the group-level `DUPLICATE_MATCHING_ASSIGNMENT` case)
+// is `non_matching` too — the contract's "exactly one" is stricter than the
+// group-level `coverage.matchingMembers` count, which only requires "at least
+// one" and reports duplicates as a separate reason code.
+function deriveAttendanceGroupFixedScheduleSelfApplicability({ desired, producerKey, managedRows, userId }) {
+  if (!desired) return 'not_configured'
+  const subject = String(userId)
+  const ownEligibleMatchingRows = managedRows.filter(row => String(row.user_id) === subject
+    && isPublished(row)
+    && row.producer_key === producerKey
+    && assignmentMatchesDesired(row, desired))
+  return ownEligibleMatchingRows.length === 1 ? 'matching' : 'non_matching'
+}
 
+function createAttendanceGroupFixedScheduleEffectivenessService({ HttpError, buildAttendanceGroupFixedScheduleProducerKey, now = () => new Date().toISOString() }) {
+  async function loadEffectivenessFacts(db, { orgId, groupId }) {
     const configRows = await db.query(
       `SELECT shift_id, start_date, end_date, revision
          FROM attendance_group_fixed_schedule_configs
         WHERE org_id = $1 AND group_id = $2
         LIMIT 1`,
-      [input.orgId, input.groupId],
+      [orgId, groupId],
     )
     const memberRows = await db.query(
       `SELECT DISTINCT user_id
          FROM attendance_group_members
         WHERE org_id = $1 AND group_id = $2
         ORDER BY user_id ASC`,
-      [input.orgId, input.groupId],
+      [orgId, groupId],
     )
     const managedRows = await db.query(
       `SELECT user_id, shift_id, start_date, end_date, publish_status, producer_key
@@ -185,34 +201,96 @@ function createAttendanceGroupFixedScheduleEffectivenessService({ HttpError, bui
           AND producer_ref_id = $2
           AND COALESCE(is_active, true) = true
         ORDER BY producer_key ASC, user_id ASC, start_date ASC, created_at ASC, id ASC`,
-      [input.orgId, input.groupId],
+      [orgId, groupId],
     )
     const desired = mapDesired(configRows[0])
     const producerKey = desired
       ? buildAttendanceGroupFixedScheduleProducerKey({
-        groupId: input.groupId,
+        groupId,
         shiftId: desired.shiftId,
         startDate: desired.startDate,
         endDate: desired.endDate,
       })
       : null
+    return { desired, producerKey, targetMemberIds: memberRows.map(row => row.user_id), managedRows }
+  }
+
+  async function getEffectiveness(db, input) {
+    const groupRows = await db.query(
+      'SELECT id FROM attendance_groups WHERE id = $1 AND org_id = $2 LIMIT 1',
+      [input.groupId, input.orgId],
+    )
+    if (!groupRows.length) throw new HttpError(404, 'NOT_FOUND', 'Group not found')
+
+    const facts = await loadEffectivenessFacts(db, { orgId: input.orgId, groupId: input.groupId })
     return {
       groupId: input.groupId,
       ...deriveAttendanceGroupFixedScheduleEffectiveness({
-        desired,
-        targetMemberIds: memberRows.map(row => row.user_id),
-        managedRows,
-        producerKey,
+        ...facts,
         evaluatedAt: now(),
       }),
     }
   }
 
-  return { getEffectiveness }
+  // #4709 FSER-4 prerequisite, contract §2: member-safe self projection. The
+  // route (plugins/plugin-attendance/index.cjs) has already resolved the
+  // caller's identity solely from the authenticated principal (never a
+  // body/query/header selector) before calling this. This function itself
+  // proves — in exactly one org-scoped query, before loading any config or
+  // assignment fact — that the subject is a live, activated user with an
+  // active org membership AND a member of the named group in that same org.
+  // Any failure of that proof (missing group, non-membership, inactive or
+  // non-activated subject, inactive or missing org membership) throws the
+  // SAME values-free 404: this function never discloses which predicate
+  // failed. Only after the proof passes does it load the desired config and
+  // managed rows, reusing the exact same `loadEffectivenessFacts` and
+  // `deriveAttendanceGroupFixedScheduleEffectiveness` the admin route uses —
+  // one `now()` call feeds both the state derivation and the response, so a
+  // parity check against the admin projection over the same fixture is a
+  // same-instant comparison, not two independent wall-clock calls.
+  async function getSelfEffectiveness(db, { orgId, groupId, userId }) {
+    const proofRows = await db.query(
+      `SELECT 1
+         FROM users u
+         JOIN user_orgs uo ON uo.user_id = u.id AND uo.org_id = $1
+         JOIN attendance_group_members agm ON agm.user_id = u.id AND agm.org_id = $1 AND agm.group_id = $2
+        WHERE u.id = $3
+          AND u.is_active = true
+          AND COALESCE(u.activation_status, 'activated') = 'activated'
+          AND uo.is_active = true
+        LIMIT 1`,
+      [orgId, groupId, userId],
+    )
+    if (!proofRows.length) throw new HttpError(404, 'NOT_FOUND', 'Not found')
+
+    const facts = await loadEffectivenessFacts(db, { orgId, groupId })
+    const evaluatedAt = now()
+    const derived = deriveAttendanceGroupFixedScheduleEffectiveness({ ...facts, evaluatedAt })
+    const applicability = deriveAttendanceGroupFixedScheduleSelfApplicability({
+      desired: facts.desired,
+      producerKey: facts.producerKey,
+      managedRows: facts.managedRows,
+      userId,
+    })
+
+    // Exact-key projection (contract §2): never `coverage`, `drift`,
+    // `managedSets`, `producerKey`, or a raw user identifier.
+    return {
+      groupId,
+      state: derived.state,
+      reasonCodes: derived.reasonCodes,
+      desired: derived.desired,
+      applicability,
+      evaluatedAt,
+    }
+  }
+
+  return { getEffectiveness, getSelfEffectiveness }
 }
 
 module.exports = {
   REASON_ORDER,
   deriveAttendanceGroupFixedScheduleEffectiveness,
+  deriveAttendanceGroupFixedScheduleSelfApplicability,
   createAttendanceGroupFixedScheduleEffectivenessService,
 }

--- a/plugins/plugin-integration-core/lib/sealed-export/vectors/s6a-package-provenance-pins.json
+++ b/plugins/plugin-integration-core/lib/sealed-export/vectors/s6a-package-provenance-pins.json
@@ -86,6 +86,6 @@
     "s6aAcceptancePs51Test": "835c7c6ce943d82e0378a40a27c7fd1e8b79b526faa8ca4c8066e4231a4bfb0f",
     "s6aProductRuntimeTest": "de978adafa8b89772cefa921c2051f434bf346bf5c2978bef3424ee70f51ba3f",
     "multitableOnpremPackageBuild": "463c7d73c6c7f2d1b6cdf0820d7a06974a9c463dd5e98bbbaf1c996e1dc4ed99",
-    "pluginTestsWorkflow": "6fed350ad05b35e49bdb1039bc7003411f9ebe5ddd557f48eff71c883040cba1"
+    "pluginTestsWorkflow": "453a364e6475c760a3115637b7c3a39ee1ac3c968bf677f5f92b8266593a592a"
   }
 }


### PR DESCRIPTION
## HOLD — Draft, not for merge

**Authorization (owner, in-session, 2026-08-05, recorded verbatim):**
> RATIFY `45d71c4209af35a63768ce7ce9f576377f6b8ce4`，OD-4709-2=(a)。授权 FSER-4 prerequisite 从 fresh main 开工，保持 Draft/HOLD，完成 fresh exact-head 独立门后停下。不授权 PR 合并/staging/soak/flag/部署/生产数据/关闭 #4556。

This PR does **not** authorize: merge, staging, soak, any flag flip, deployment, production/customer data use, or closing `#4556` or `#4709`. It stays Draft/HOLD until the owner separately authorizes the merge decision, per the amendment's own §7 landing sequence step 3→4 boundary.

## What this is

Landing step 3 of `docs/development/attendance-4709-fser4-member-projection-contract-amendment-20260804.md`
(RATIFIED at merged SHA `45d71c4209af35a63768ce7ce9f576377f6b8ce4`, `OD-4709-2=(a)`): implements
**only** the amendment's §2 — the narrow authenticated-member effectiveness projection, including its
declared values-free desired shift/window/revision projection — plus its real-DB authorization matrix.

§3-4 (surface wiring: shared client/composable, group/employee/trace/report UI projections, browser
evidence, OpenAPI) are explicitly **out of scope** here and deferred to the follow-up FSER-4 frontend PR,
per the amendment's own landing sequence (step 3 = this PR; step 4 = the frontend PR, authorized
separately after this one merges).

## What changed

New route: `GET /api/attendance/groups/:groupId/fixed-schedule/effectiveness/me` — read-only,
`attendance:read` (not the admin `attendance:admin` aggregate route), subject/org resolved only from
the authenticated principal.

- **New pure module** `plugins/plugin-attendance/lib/attendance-fixed-schedule-self-route-identity.cjs`
  — identity resolution, unit-testable without Express. A body/query `userId`/`orgId` is a typed 400; a
  mismatched `x-user-id`/`x-org-id` header is 403; a byte-equal header is tolerated but never used as an
  identity source; a missing authenticated org is a values-free 403 — all before any scoped SQL.
- **Extended** `plugins/plugin-attendance/lib/attendance-group-fixed-schedule-effectiveness-service.cjs`
  with `getSelfEffectiveness` (one org-scoped proof query — live/activated subject + active `user_orgs`
  membership + `attendance_group_members` membership — before loading any config/assignment fact) and
  `deriveAttendanceGroupFixedScheduleSelfApplicability` (closed enum `not_configured`/`matching`/
  `non_matching`, reusing the existing `isPublished`/`assignmentMatchesDesired` predicates rather than
  re-deriving the four-state contract). The admin `getEffectiveness` query set is **unchanged** (refactored
  into a shared `loadEffectivenessFacts` helper); its existing real-DB test still asserts the same 4-query
  shape with zero modification.
- **Route wiring** in `plugins/plugin-attendance/index.cjs` (~L44405, right after the existing admin
  effectiveness route), mirroring that route's existing actor-context-before-`withPermission` shape.
- Self response is a distinct exact-key projection: `groupId`, `state`, `reasonCodes`, `desired`,
  `applicability`, `evaluatedAt` — never `coverage`, `drift`, `managedSets`, `producerKey`, or a raw user id.

## Contract clause → implementation mapping

| Contract clause (§2) | Implementation | Evidence |
| --- | --- | --- |
| Route path, read-only, `attendance:read` | `GET .../effectiveness/me` registered with `withPermission('attendance:read', ...)` | `index.cjs` symbol `context.api.http.addRoute('GET', '/api/attendance/groups/:groupId/fixed-schedule/effectiveness/me', ...)` ~L44419 |
| Subject/org come only from the authenticated principal | `resolveAttendanceFixedScheduleSelfRouteIdentity` uses only `getAuthenticatedUserId`/`getAuthenticatedOrgId` | `attendance-fixed-schedule-self-route-identity.cjs` fn `resolveAttendanceFixedScheduleSelfRouteIdentity` ~L48 |
| No body/`userId`/`orgId`; any such selector → typed 400 before SQL | `forbiddenSelectorPresent` check → `400 VALIDATION_ERROR` | same file, symbol `forbiddenSelectorPresent` ~L58; unit tests `400s a %s selector` |
| `x-user-id`/`x-org-id` never an identity source; mismatch → 403; byte-equal tolerated | header check compares against the authenticated values only, never returns the header value | same file, symbol `headerMismatch` ~L73; unit tests `403s a mismatched … header`, `tolerates a byte-equal … pair` |
| No-org → values-free 403 before SQL | checked immediately after the 401 check, before any selector/SQL logic | same file, symbol `if (!authenticatedOrgId)` ~L54; unit test `403s values-free …` |
| One org-scoped proof query: live+activated subject, active `user_orgs`, `attendance_group_members` membership, before config/assignment SQL | single `SELECT 1 FROM users JOIN user_orgs JOIN attendance_group_members …` | `attendance-group-fixed-schedule-effectiveness-service.cjs` fn `getSelfEffectiveness` ~L251, proof query ~L253-264; DB tests AUTHZ-1..10 (`queryLog` length 1 on every negative leg) |
| Missing group/non-member/inactive-or-non-activated subject/inactive-or-missing org membership → same values-free 404 | single `HttpError(404, 'NOT_FOUND', 'Not found')` on any proof failure | same file, symbol `if (!proofRows.length)` ~L264; DB test AUTHZ-10 (message-set size 1 across 5 distinct failure fixtures) |
| `state`/`reasonCodes` byte-identical to the admin route's derivation | both call the same `deriveAttendanceGroupFixedScheduleEffectiveness` via the shared `loadEffectivenessFacts` | same file, `loadEffectivenessFacts` ~L159, both callers ~L226 (`getEffectiveness`) and ~L266 (`getSelfEffectiveness`); DB test `PARITY` |
| Applicability derived in the same module from already-loaded facts, not re-deriving the four-state contract | `deriveAttendanceGroupFixedScheduleSelfApplicability` reuses `isPublished`/`assignmentMatchesDesired` | same file, fn `deriveAttendanceGroupFixedScheduleSelfApplicability` ~L170; unit tests `self applicability derivation` |
| `applicability` closed enum (`not_configured`/`matching`/`non_matching`), "exactly one" for `matching` | `ownEligibleMatchingRows.length === 1 ? 'matching' : 'non_matching'` | same file ~L177; unit test `is non_matching for a duplicate matching row` (mutated to `>=1`, red, reverted) |
| One injected evaluation instant feeds both derivation and response (no two-wall-clock-call parity) | single `now()` call in `getSelfEffectiveness`, reused for both `derived.evaluatedAt` and the response | same file, symbol `const evaluatedAt = now()` ~L267; DB test `PARITY` (`self.evaluatedAt === admin.evaluatedAt === now`) |
| Self response exact-key projection; rejects `coverage`/`drift`/`managedSets`/`producerKey`/raw user ids | explicit 6-key object literal | same file, `getSelfEffectiveness`'s final `return { groupId, state, reasonCodes, desired, applicability, evaluatedAt }` ~L278; DB test `EXACT-KEY` |
| §5 non-scope (no new writable status/membership model/auto-apply/wildcard read/raw member list/flag/deploy/staging/prod data/issue closure) | no schema change, no write path, no flag introduced | diff is additive-only across two `.cjs` lib files + route registration + tests |
| §7 step 3: implement server projection + real-DB authorization matrix in one Draft/HOLD prerequisite PR | this PR | — |
| §3-4 (surface wiring, shared composable, browser evidence, OpenAPI) | **explicitly not touched** — no `apps/web` file in this diff | `git diff --stat` below |

## Authorization matrix (real Postgres, isolated per-test schema)

New file `packages/core-backend/tests/integration/attendance-group-fixed-schedule-self-effectiveness.db.test.ts`,
17 tests, all passing:

| Leg | Fixture | Expected |
| --- | --- | --- |
| AUTHZ-1 | random unmapped `groupId` | 404, 1 query |
| AUTHZ-2 | live/activated subject, active org membership, **no** group membership | 404, 1 query |
| AUTHZ-3 | `users.is_active=false` | 404, 1 query |
| AUTHZ-4 | `activation_status='pending_activation'` | 404, 1 query |
| AUTHZ-5 | no `user_orgs` row at all | 404, 1 query |
| AUTHZ-6 | `user_orgs.is_active=false` | 404, 1 query |
| AUTHZ-7 (forged witness / cross-org) | live subject in `orgId`, call made with forged `otherOrgId` | 404, 1 query |
| AUTHZ-8 (cross-org isolation, positive control) | live member of `otherOrgId`'s **own** group | resolves `not_configured`, never sees `orgId`'s config |
| AUTHZ-9 | active user + org membership, no group-membership row (isolates that one predicate) | 404, 1 query |
| AUTHZ-10 | 5 distinct failure fixtures (incl. missing group) | byte-identical 404 message set (size 1) |
| POS-1 | two members, same org/group, one matching one not | each subject sees only their own applicability |
| POS-2..4 | not_configured / matching-effective / non_matching-configuration_changed | applicability tracks group state correctly |
| PARITY | same fixture, one injected `now` | `self.{state,reasonCodes,desired,evaluatedAt}` === `admin.{…}` |
| EXACT-KEY | populated fixture with an unrelated member | exact 6-key set; no `coverage`/`drift`/`managedSets`/`producerKey`/raw ids at any depth |

Existing FSER-1/2/3 real-DB suites re-run unmodified and still green (regression check on the shared
`loadEffectivenessFacts` refactor): `attendance-group-fixed-schedule-effectiveness.db.test.ts` 18/18,
`attendance-group-fixed-schedule-config-migration.db.test.ts` 7/7,
`attendance-group-fixed-schedule-config-consume.db.test.ts` 5/5.

## Mutation self-check (commit-then-mutate-then-revert; working tree byte-identical to the commit after each revert, confirmed via `git diff --stat`)

| Guard neutered | Test(s) that must flip red | Result |
| --- | --- | --- |
| `x-user-id`/`x-org-id` mismatch check (`headerMismatch = false`) | 4 identity-resolver unit tests | red → reverted, clean diff |
| `uo.is_active = true` predicate in the proof query | `AUTHZ-6`, `AUTHZ-10` (real DB) | red → reverted, clean diff |
| Applicability `=== 1` → `>= 1` | `is non_matching for a duplicate matching row` | red → reverted, clean diff |
| Body/query selector-presence check (`forbiddenSelectorPresent = false`) | 7 identity-resolver unit tests (`400s a … selector`) | red → reverted, clean diff |

## Test evidence (local, real Postgres 15 at `postgresql://postgres@localhost:5432/metasheet_test`)

```
tests/unit/attendance-fixed-schedule-self-route-identity.test.ts          17 passed
tests/unit/attendance-group-fixed-schedule-effectiveness-service.test.ts  26 passed (17 pre-existing + 9 new applicability)
tests/integration/attendance-group-fixed-schedule-self-effectiveness.db.test.ts  17 passed (new)
tests/integration/attendance-group-fixed-schedule-effectiveness.db.test.ts       18 passed (unmodified, regression check)
tests/integration/attendance-group-fixed-schedule-config-migration.db.test.ts     7 passed (unmodified, regression check)
tests/integration/attendance-group-fixed-schedule-config-consume.db.test.ts       5 passed (unmodified, regression check)
```
`pnpm exec tsc --noEmit -p packages/core-backend` — clean.

Not locally evaluated (resolved by CI, see below): `tests/integration/attendance-plugin.test.ts` (the
large shared-schema suite) failed locally against my local `metasheet_test`, which carries partial/stale
schema from unrelated prior local sessions on the same machine (pre-existing `DB_NOT_READY` failures
unrelated to this diff, confirmed by `grep` finding zero references to this PR's route/service in that
file). CI's `attendance-real-db-integration` step runs against a freshly migrated database and is the
authoritative gate for that file — **confirmed green**: `✓ tests/integration/attendance-plugin.test.ts
(163 tests) 69737ms`, part of the CI run cited below.

## CI status (fresh exact-head `cf0b48299ab6916be2a5cfd5f30c778c3bca5723`)

`test (18.x)`'s `attendance-real-db-integration` step ran this PR's new file against a **freshly
migrated** CI Postgres and confirms the local run above:
`✓ tests/integration/attendance-group-fixed-schedule-self-effectiveness.db.test.ts (17 tests) 521ms`,
inside that step's full 95-file/1209-test green run.

**Green** (17, all terminal): `contracts (strict)`, `contracts (dashboard)`, `contracts (openapi)`,
`pr-validate`, `test (18.x)`, `test (20.x)`, `web-tests`, `coverage`, `stock-prep PowerShell 5.1
acceptance`, `attendance-web-guard`, `e2e`, `migration-replay`, `core-backend-cache`, `telemetry-plugin`,
`after-sales integration`, `DingTalk P4 ops regression gate`, `K3 WISE offline PoC` — plus `Strict E2E
with Enhanced Gates` (skipped by design, not a failure). Of the 9 currently-required contexts
(`contracts (strict)`, `contracts (dashboard)`, `pr-validate`, `test (20.x)`, `contracts (openapi)`,
`web-tests`, `stock-prep PowerShell 5.1 acceptance`, `attendance-web-guard`, `integration-guard`) as of
head `cf0b48299` (before the fix below), 8/9 passed; `integration-guard` was the one red required check.
Fix pushed at `14dbe4927`; CI re-run status for the new head is in the next section.

### `integration-guard` — RETRACTION and corrected root cause (fixed at `14dbe4927`)

**Retracting my earlier claim that `integration-guard`'s failure was "pre-existing and unrelated to this
diff."** That was wrong, and the way I reached it was exactly the `failing consistently is not evidence
of cause` trap this line has been burned by before: I reproduced the same failure both in CI and in my
own local worktree and concluded "pre-existing" — but my local worktree already carried this PR's own
diff. I never actually tested a truly clean `origin/main` checkout before making that claim. The
coordinator caught this with real lateral evidence (same-baseline `#4771`/`#4773` and recent `main` runs
all green; only this PR red) that I should have gathered myself before asserting "pre-existing."

**Corrected root cause, verified by direct A/B isolation** (checked out `origin/main` at `db74bd866` in a
separate clean worktree):

- `node plugins/plugin-integration-core/__tests__/sealed-export-package-provenance.test.cjs` — **passes**
  on unmodified `origin/main`, **fails** on this PR's commit `cf0b48299`.
- Isolating further: reverting *only* `.github/workflows/plugin-tests.yml` to `origin/main`'s content
  (every other file from `cf0b48299` left in place, including the new
  `attendance-fixed-schedule-self-route-identity.cjs`) makes the test pass again. The new `.cjs` file is
  not the cause; the workflow-file edit is.
- Mechanism, exact site:
  `plugins/plugin-integration-core/lib/sealed-export/sealed-export-package-provenance.cjs`'s
  `PINNED_EVIDENCE_FILES` list (~L286-289) pins `.github/workflows/plugin-tests.yml`'s SHA-256 under id
  `pluginTestsWorkflow`, checked in `verifyPinnedFileEntries` (~L552) → `assertEqualDigest` (~L353) against
  the frozen manifest `plugins/plugin-integration-core/lib/sealed-export/vectors/s6a-package-provenance-pins.json`.
  This PR's original commit added one line to that workflow file (the `attendance-real-db-integration`
  step's file list — this line's own two-point-wiring convention, not optional), which changed the file's
  digest and broke the pin.

**Fix classification: mechanical re-pin, not a guard change.** This is the sealed-export subsystem's own
documented contract, not something I'm overriding: the pinning module's own header comment states
"Mutating a pinned module/migration without updating that manifest fails closed" — mutate-then-repin is
the intended flow. There is also a direct, non-self-serving precedent already on `main`: commit
`7da5d9e55` (`#4748`, an unrelated attendance W5 PR) hit this exact same pin for the exact same reason
(its own edit to `plugin-tests.yml`) and updated only the `pluginTestsWorkflow` field of the pins
manifest in the same commit — no other pin field or guard logic. (Retraction: an earlier revision of this
paragraph said "updated only the `pluginTestsWorkflow` digest in the same commit — nothing else", which
read as a claim about the whole commit; `7da5d9e55` is itself a ~20-file squash. The intended and accurate
claim is scoped to the pins manifest file only, per the independent exact-head review's NIT-1.) Commit
`14dbe4927` on this branch does the same: recomputes that one digest from the actual current file content
and writes only that one JSON field. No pin scope was widened or narrowed, no guard logic changed, no
other subsystem file touched.

**Verification**: `node plugins/plugin-integration-core/__tests__/sealed-export-package-provenance.test.cjs`
now `OK`; `pnpm --filter plugin-integration-core test` (full CJS chain, every `__tests__/*.test.cjs` file)
exits 0. Mutation self-check: reverted the digest back to the old (pre-fix) value → the same test failed
red with the identical `SEALED_EXPORT_INTERNAL_ERROR` stack → restored via `git checkout --` from the
committed fix (safe once committed) → verified green again.

**The two `Sealed-export S5 SQL Server 2019/2022 product action` checks were the same root cause, not a
second pre-existing issue** — checked, not assumed: their workflow
(`.github/workflows/sealed-export-s5-sqlserver.yml`, job `Sealed-export S5 SQL Server ${{ matrix.mssql }}
product action`) runs `pnpm --filter plugin-integration-core test:sealed-export-s5`, and that script (see
`plugins/plugin-integration-core/package.json`) is a `&&`-chain that includes
`node __tests__/sealed-export-package-provenance.test.cjs` — the exact file the `integration-guard` fix
above repairs. These two were never independently-verified pre-existing failures; they were the identical
`pluginTestsWorkflow` pin mismatch. (`Sealed-export S5 evidence and S6-A runtime-authority gate` gates on
those two matrix legs succeeding, so it followed the same resolution.)

### CI, confirmed all-green at fixed head `14dbe4927cf660896bb7100c725fde489c8bf222`

Re-ran after the re-pin fix. **23/23 checks pass** (plus `Strict E2E with Enhanced Gates` skipping by
design, unchanged): `contracts (strict)`, `contracts (dashboard)`, `contracts (openapi)`, `pr-validate`,
`test (18.x)`, `test (20.x)`, `web-tests`, `coverage`, `stock-prep PowerShell 5.1 acceptance`,
`attendance-web-guard`, `integration-guard`, `e2e`, `migration-replay`, `core-backend-cache`,
`telemetry-plugin`, `after-sales integration`, `DingTalk P4 ops regression gate`, `K3 WISE offline PoC`,
`Sealed-export S2 SQL Server 2019/2022 producer`, `Sealed-export S2 gate-check`, `Sealed-export S5 SQL
Server 2019/2022 product action`, `Sealed-export S5 evidence and S6-A runtime-authority gate`. **9/9
currently-required contexts pass.** `test (18.x)`'s `attendance-real-db-integration` step reconfirms this
PR's own 17 new tests plus the full 95-file/1209-test attendance real-DB suite (unchanged from the
pre-fix run — the re-pin touched only `plugin-integration-core`'s own vectors file, not any attendance
test or fixture).

## Two-point wiring

- Excluded from the no-DB vitest run: `packages/core-backend/vitest.config.ts` (new entry beside the
  FSER-1/2/3 exclude lines).
- Whole-file wired into CI: `.github/workflows/plugin-tests.yml`'s `attendance-real-db-integration` step
  (stable `id`), added beside `attendance-group-fixed-schedule-config-consume.db.test.ts`.

## Independent exact-head review response — gate hardening (2026-08-05)

Fresh exact-head independent review at `14dbe4927` (`pr4772-gate-20260805-opus5-mutationlane.md`,
Claude/Opus 5, mutation lane) scored **APPROVE-with-hardening: 0 P1 / 2 P2 / 2 P3 / 2 NIT**. Both P2s
were proof-coverage gaps, not business-logic defects — the reviewer confirmed the underlying behavior was
already correct and asked only for missing negative legs. Both are fixed in this same PR, each with an
independent mutation self-check (commit-then-mutate-then-revert, `git checkout --` only after the fix
commit landed).

**P2-1 — route-level identity guard wiring had zero coverage.** The identity resolver had 17 pure-function
unit tests, but nothing proved the route (`GET .../effectiveness/me` in `index.cjs`) actually calls it or
obeys its verdict. The reviewer's own Mutation A (neuter `if (!identity.ok)`) and Mutation B (swap the
resolver for the loose same-family `getUserId`/`getOrgId` helpers, which fall back to
attacker-controlled `x-user-id`/body/query) both left all 147 pre-existing tests green.
Fix (`913297305`): new file
`packages/core-backend/tests/unit/attendance-fixed-schedule-self-route-wiring.test.ts`, 7 harness-based
probes (`createHarness`/`invokeRoute`, mirroring `attendance-uuid-validation-routes.test.ts`) invoking the
real route handler end to end. Clean head: 7/7 green. Mutation self-check (Mutation B reproduced, then
reverted via `git checkout --` since it touched only the already-committed `index.cjs`, confirmed
byte-identical to HEAD after): **5/7 red** (body/query selector, both header-mismatch legs, no-org leg);
the unauthenticated leg and the positive control stayed green, matching the gate's own probe-design table
exactly (the unauthenticated leg is independently caught by `withPermission`'s own `getUserId` null check,
so it stays green even with the identity resolver fully bypassed).

**P2-2 — the proof query's two org predicates covered for each other.** `getSelfEffectiveness`'s proof
query joins both `uo.org_id = $1` and `agm.org_id = $1`; deleting either alone left all 17 db tests green.
None of the 17 pre-existing negative legs isolates exactly one org column while leaving a correctly
org-scoped matching row on the OTHER table under a DIFFERENT org: `AUTHZ-1/2/9` have no
`attendance_group_members` row at all for the queried group; `AUTHZ-5` has no `user_orgs` row at all;
`AUTHZ-7` still fails because `agm.org_id=$1` finds no row for the forged org even after `uo.org_id=$1` is
removed; and `AUTHZ-3/4/6` are gated by the unrelated `u.is_active`/`activation_status`/`uo.is_active`
predicates, which don't depend on either org column and stay failing regardless. Contract §4 gate 2
requires the authenticated-org predicate to have a named negative leg — a literal FAIL against the
RATIFIED text. Fix (`96b53756f`): two new per-predicate-exclusive legs plus a labeled positive control in
the existing db test file (no new file, no new CI wiring needed — same already-wired file):
- `EXCL-uo.org_id`: an orphan `attendance_group_members` row scoped to this org, but the subject's only
  active org membership is in ANOTHER org — reds only when `uo.org_id=$1` is removed.
- `EXCL-agm.org_id`: an active org membership in this org, but the group-membership row is scoped to
  ANOTHER org — reds only when `agm.org_id=$1` is removed.
- `POS-CONTROL`: a fully legitimate member reads `desired.revision === 7`, unaffected by either mutation.

Mutation self-check, both directions, each reverted via `git checkout --` (file was unmodified/committed
before mutating): deleting `uo.org_id = $1` → exactly `EXCL-uo.org_id` red (19/20 pass); deleting
`agm.org_id = $1` → exactly `EXCL-agm.org_id` red (19/20 pass). Full file re-run clean after each revert
(20/20). No production code changed — the query was already correct; only the missing negative legs were
added. Reachability is argued, not demonstrated with a real producer (directory-sync deprovisioning sets
`user_orgs.is_active=false`, never deletes the row, and nothing in `packages/core-backend` deletes
`attendance_group_members`), which is why the reviewer scored this P2 rather than P1 — the legs exist so a
future producer of this shape trips a named alarm instead of silently passing.

**P3-1 ("accepts no body" reading) — not changed, left for owner erratum.** The reviewer found the
implementation's read of §2/§4 gate 3 (reject only a named `userId`/`orgId` selector, not any non-empty
body) is DEFENSIBLE against the contract's own operative gate-3 text, but flagged the stricter literal
reading of §2's first clause ("accepts no body") as unimplemented, with no live exploit (this route reads
neither body nor query for anything). Recorded here as a pending-owner-erratum item, not resolved by this
PR — see "Weak points" item 1 below, which predates this review and already flagged the same ambiguity
independently.

**P3-2 (no OpenAPI entry for the new route) — confirmed correctly deferred, not a defect.** The reviewer's
own conclusion: gate 10's OpenAPI requirement is "reasonably deferred to step 4" given this PR's declared
scope (§3-4, including OpenAPI, is explicitly out of scope per the amendment's own landing sequence — see
the contract-mapping table above). Flagged only so it isn't dropped at the step 3→4 boundary; the
follow-up FSER-4 frontend PR is where this lands. No code change here.

**NIT-1 (an absolute claim in this PR body was imprecise) — fixed.** "updated only the
`pluginTestsWorkflow` digest in the same commit — nothing else" read as a claim about the whole commit;
`7da5d9e55` is itself a ~20-file squash. Corrected above (retraction-first) to scope the claim to the pins
manifest file, which is what was actually true and intended.

**NIT-2 (a source comment implied more test completeness than existed) — fixed.** Commit `f6f884773`
scopes `attendance-fixed-schedule-self-route-identity.cjs`'s header comment to the pure-function claim it
can actually support, and now points to the new `…self-route-wiring.test.ts` (P2-1) for the separate
route-level claim.

## SWEEP v4 (three tables — self-defined operationalization; the advisor tool was unavailable this
session for all three attempted consultations, so this is my own mechanical self-audit, not a
previously-ratified template; flagged below as a weak point)

**1. Absolute/strong-claim sweep** (`rg -i "全部|所有|从不|总是|一定|必须|唯一|always|never|every|all |completely|exactly|guarantee"` over this PR body + new source-file comments):

| Hit | Location | Assessment |
| --- | --- | --- |
| "never" (x-user-id/x-org-id never an identity source) | PR body, source comment | Structural: the returned identity object is always `{userId: authenticatedUserId, orgId: authenticatedOrgId}` — the header value is read only for comparison, never assigned. Verified by code inspection + unit test `never returns the header value as identity…`. Retained. |
| "never" (returns a raw user id) | PR body, EXACT-KEY row | Scoped to the 6-key object literal in `getSelfEffectiveness`'s return; verified by the `EXACT-KEY` DB test's `Object.keys` + substring assertions. Retained. |
| "always" (byte-identical 404) | PR body, contract table | Scoped to the single `HttpError(404,'NOT_FOUND','Not found')` throw site — there is exactly one, verified by AUTHZ-10 testing 5 distinct failure fixtures land on one message set. Retained. |
| "exactly one" (`matching` predicate) | PR body, contract table | This is a literal quote of the contract's own wording (§2), not my claim — code matches via `=== 1`, mutation-proved. Retained. |
| "unmodified" (admin route query set) | PR body, mapping table | Verified: `git diff` shows the admin `getEffectiveness` function body only moved into `loadEffectivenessFacts`, no SQL text changed; existing 18-test real-DB suite (including its own `queryLog` length/SELECT-only assertions) passes unmodified. Retained. |

No hit required retraction; every absolute word above is either a direct contract quote or is scoped to a single, tested code site.

**2. Closing-keyword sweep**

`rg -io "(close[sd]?|fix(es|ed)?|resolve[sd]?) #?[0-9]+"` against this PR body's actual text (run before
opening the PR): **ZERO HITS**. The two `#4556`/`#4709` mentions above are both bare issue references
inside a `not authorize: … or closing #N` negation clause, never a bare closing verb + `#N`.

**3. Values-free audit-surface check** (grep of the two new/changed `.cjs` lib files for any place a raw
request-supplied value is interpolated into a thrown/logged message):

`rg -n '\$\{.*(userId|orgId|body|query|header)' plugins/plugin-attendance/lib/attendance-fixed-schedule-self-route-identity.cjs plugins/plugin-attendance/lib/attendance-group-fixed-schedule-effectiveness-service.cjs`
— **ZERO HITS**. Manual listing of every `message:`/`HttpError(...)` string literal in both files (6
sites) confirms each is a fixed static string (`'User ID not found'`, `'Authenticated organization not
found'`, `'userId and orgId are not accepted on this route; …'`, `'Insufficient permissions'`, `'Group
not found'`, `'Not found'`) — none echoes a request-supplied `userId`/`orgId`/header/body value.

## Weak points I am self-reporting

1. **"No body" reading of the contract text.** §2 says "It accepts no body, `userId`, or `orgId`". I
   implemented this as "reject if `body.userId`/`body.orgId`/`query.userId`/`query.orgId` is present",
   matching every existing sibling resolver's selector-field pattern in this file — not "reject any
   non-empty request body regardless of its keys". A stricter reading (any non-empty body object at all
   → 400) is defensible from the literal text and was not what I built. Flagging for owner/reviewer call.
2. **"SWEEP v4 三表" is my own operationalization**, not a verified prior artifact — I could not find any
   prior use of that exact term in `origin/main`'s history or in recent PR bodies I could inspect, and the
   advisor tool was unavailable (3 attempts, all "temporarily overloaded") throughout this session, so I
   was not able to get a second opinion on either this interpretation or the implementation before
   opening this PR. I proceeded on the ratified contract text alone, cross-checked myself as carefully as
   I could (mutation self-checks, parity/exact-key/authorization-matrix tests, regression run of every
   sibling FSER real-DB suite), but this PR has not had the usual pre-delivery advisor pass.
3. ~~`attendance-plugin.test.ts` not locally green~~ — **resolved**: CI's `test (18.x)` ran it against a
   freshly migrated database and it passed, 163/163 (see "CI status" above). The local failure was
   confirmed to be my machine's stale `metasheet_test`, not a regression.
4. ~~`integration-guard` and the two `Sealed-export S5 SQL Server` checks are red, pre-existing, and
   outside this PR's scope to fix~~ — **wrong, retracted**. Real root cause: this PR's own edit to
   `.github/workflows/plugin-tests.yml` broke a byte-pin (`pluginTestsWorkflow`) the sealed-export
   subsystem holds on that shared workflow file. Fixed at `14dbe4927` by recomputing and writing that one
   digest into `plugins/plugin-integration-core/lib/sealed-export/vectors/s6a-package-provenance-pins.json`
   — the subsystem's own documented re-pin contract, with a direct non-self-serving precedent (`7da5d9e55`,
   `#4748`) doing the identical thing for the identical reason. See the "CI status" section's retraction
   above for the full trail (what I originally claimed, why it was wrong, and the A/B isolation that found
   the real cause).
5. **The proof query does not independently re-check `attendance_groups.org_id = orgId`** — it trusts
   `attendance_group_members.org_id`/`attendance_shift_assignments.producer_ref_id` scoping the same way
   the existing admin `getEffectiveness` already does (no composite FK there either). This is consistent
   with the pre-existing trust boundary, not a new gap, but it means a hypothetical data-integrity bug
   where a membership row's `org_id` diverges from its `group_id`'s actual owning org would be shared
   between both routes, not newly introduced or newly closed by this PR.

---
Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

