### PR TITLE
fix(attendance): W4C-5 canonical transition-boundary hardening (OD-W4C-61=(a)) — Draft/HOLD

### DIFF
--- a/packages/core-backend/src/attendance/__tests__/w4c3a-rollout-control-inventory.test.ts
+++ b/packages/core-backend/src/attendance/__tests__/w4c3a-rollout-control-inventory.test.ts
@@ -14,6 +14,7 @@
  * the test, so a future writer cannot silently slip past a narrower allowlist.
  */
 import fs from 'node:fs'
+import os from 'node:os'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
@@ -43,12 +44,22 @@ const ALLOWED_RELATIVE_FILES = new Set([
 // setup (never as production DML) — they exercise the guarded boundary, they do not replace it.
 const ALLOWED_DIRECTORY_PREFIXES = ['packages/core-backend/tests/integration/']
 
-const TARGET_EXTENSIONS = new Set(['.ts', '.tsx', '.js', '.cjs', '.mjs'])
+// Raw-SQL text is not the only DML surface: a Kysely query-builder call never spells the SQL
+// verb as text, and a shell script driving `psql -c "..."` or a standalone `.sql` file is common
+// operator-tooling shape (repo doctrine 写入点审计要双语法 — a writer-inventory audit that only
+// greps one syntax is a landmine the amendment's own §5 warns about: "Preparation must not add
+// direct rollout DML, a raw SQL escape hatch" — and operator tooling is exactly what ships as
+// `.sql`/`.sh`/psql).
+const TARGET_EXTENSIONS = new Set(['.ts', '.tsx', '.js', '.cjs', '.mjs', '.sql', '.sh'])
 
 const ROLLOUT_DML_PATTERNS: ReadonlyArray<{ readonly label: string; readonly pattern: RegExp }> = [
   { label: 'UPDATE attendance_calculation_rollout_state', pattern: /UPDATE\s+attendance_calculation_rollout_state/i },
   { label: 'INSERT INTO attendance_calculation_rollout_state', pattern: /INSERT\s+INTO\s+attendance_calculation_rollout_state/i },
   { label: 'INSERT INTO attendance_calculation_rollout_events', pattern: /INSERT\s+INTO\s+attendance_calculation_rollout_events/i },
+  // Kysely query-builder syntax over the same two tables — never spells UPDATE/INSERT as text.
+  { label: 'Kysely updateTable(attendance_calculation_rollout_state)', pattern: /\.updateTable\(\s*['"`]attendance_calculation_rollout_state['"`]/i },
+  { label: 'Kysely insertInto(attendance_calculation_rollout_state)', pattern: /\.insertInto\(\s*['"`]attendance_calculation_rollout_state['"`]/i },
+  { label: 'Kysely insertInto(attendance_calculation_rollout_events)', pattern: /\.insertInto\(\s*['"`]attendance_calculation_rollout_events['"`]/i },
 ]
 
 function walk(dir: string, out: string[]): void {
@@ -64,22 +75,38 @@ function walk(dir: string, out: string[]): void {
   }
 }
 
+// Shared by the real full-repo gate and the isolated decoy tests below, so a decoy test proves
+// the exact same detection code the real gate runs — not a re-implementation that could drift.
+function findRolloutDmlOffenders(
+  rootDir: string,
+  files: readonly string[],
+  options: { allowedRelativeFiles?: ReadonlySet<string>; allowedDirectoryPrefixes?: readonly string[] } = {},
+): Array<{ file: string; label: string }> {
+  const allowedRelativeFiles = options.allowedRelativeFiles ?? new Set<string>()
+  const allowedDirectoryPrefixes = options.allowedDirectoryPrefixes ?? []
+  const offenders: Array<{ file: string; label: string }> = []
+  for (const absolute of files) {
+    const relative = path.relative(rootDir, absolute).split(path.sep).join('/')
+    if (allowedRelativeFiles.has(relative)) continue
+    if (allowedDirectoryPrefixes.some((prefix) => relative.startsWith(prefix))) continue
+    const content = fs.readFileSync(absolute, 'utf8')
+    for (const { label, pattern } of ROLLOUT_DML_PATTERNS) {
+      if (pattern.test(content)) offenders.push({ file: relative, label })
+    }
+  }
+  return offenders
+}
+
 describe('W4C-5 repository inventory: rollout-state/event DML has exactly one writer', () => {
   it('finds rollout-state/event DML only in the hardened boundary, its migration, and integration fixtures', () => {
     const files: string[] = []
     walk(ROOT, files)
     expect(files.length).toBeGreaterThan(100) // sanity: the walk actually found the repo
 
-    const offenders: Array<{ file: string; label: string }> = []
-    for (const absolute of files) {
-      const relative = path.relative(ROOT, absolute).split(path.sep).join('/')
-      if (ALLOWED_RELATIVE_FILES.has(relative)) continue
-      if (ALLOWED_DIRECTORY_PREFIXES.some((prefix) => relative.startsWith(prefix))) continue
-      const content = fs.readFileSync(absolute, 'utf8')
-      for (const { label, pattern } of ROLLOUT_DML_PATTERNS) {
-        if (pattern.test(content)) offenders.push({ file: relative, label })
-      }
-    }
+    const offenders = findRolloutDmlOffenders(ROOT, files, {
+      allowedRelativeFiles: ALLOWED_RELATIVE_FILES,
+      allowedDirectoryPrefixes: ALLOWED_DIRECTORY_PREFIXES,
+    })
     expect(offenders).toEqual([])
   })
 
@@ -88,5 +115,101 @@ describe('W4C-5 repository inventory: rollout-state/event DML has exactly one wr
     const content = fs.readFileSync(target, 'utf8')
     const matched = ROLLOUT_DML_PATTERNS.filter(({ pattern }) => pattern.test(content))
     expect(matched.length).toBeGreaterThan(0)
+  })
+})
+
+// P2-2 (PR #4773 exact-head independent gate, 20260805): the pre-fix pattern/extension set was
+// raw-SQL-text-only and .ts/.tsx/.js/.cjs/.mjs-only, so a Kysely query-builder call, a standalone
+// `.sql` file, or a `.sh` script driving `psql -c "..."` all walked straight past the gate
+// (repo landmine 写入点审计要双语法 — a writer-inventory audit that only greps one syntax).
+// These decoys run against isolated OS-tmp scratch directories (never inside the repo tree, so
+// they cannot themselves become an untracked-file false-positive against the real gate above)
+// but exercise the exact same `walk` + `findRolloutDmlOffenders` pipeline the real gate uses.
+describe('W4C-5 repository inventory gate 9: bypass-syntax decoys are caught (写入点审计要双语法)', () => {
+  function withScratchDir(fn: (dir: string) => void): void {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'w4c5-gate9-decoy-'))
+    try {
+      fn(dir)
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true })
+    }
+  }
+
+  it('decoy: Kysely query-builder DML (.ts) — updateTable(state) + insertInto(events)', () => {
+    withScratchDir((dir) => {
+      fs.writeFileSync(
+        path.join(dir, 'zz-decoy-tooling.ts'),
+        [
+          "export async function decoyTransition(trx: unknown, orgId: string, targetState: string) {",
+          "  await (trx as any).updateTable('attendance_calculation_rollout_state')",
+          "    .set({ state: targetState }).where('org_id', '=', orgId).execute()",
+          "  await (trx as any).insertInto('attendance_calculation_rollout_events')",
+          "    .values({ orgId, targetState }).execute()",
+          "}",
+        ].join('\n'),
+      )
+      const files: string[] = []
+      walk(dir, files)
+      const offenders = findRolloutDmlOffenders(dir, files)
+      expect(offenders.map((o) => o.label).sort()).toEqual([
+        'Kysely insertInto(attendance_calculation_rollout_events)',
+        'Kysely updateTable(attendance_calculation_rollout_state)',
+      ])
+    })
+  })
+
+  it('decoy: standalone .sql file — raw UPDATE/INSERT against both rollout tables', () => {
+    withScratchDir((dir) => {
+      const file = path.join(dir, 'zz-decoy-tooling.sql')
+      fs.writeFileSync(
+        file,
+        [
+          "UPDATE attendance_calculation_rollout_state SET state = 'shadow' WHERE org_id = 'demo';",
+          "INSERT INTO attendance_calculation_rollout_events (org_id, prior_state, new_state) VALUES ('demo', 'legacy', 'shadow');",
+        ].join('\n'),
+      )
+      const files: string[] = []
+      walk(dir, files)
+      expect(files).toEqual([file])
+      const offenders = findRolloutDmlOffenders(dir, files)
+      expect(offenders.map((o) => o.label).sort()).toEqual([
+        'INSERT INTO attendance_calculation_rollout_events',
+        'UPDATE attendance_calculation_rollout_state',
+      ])
+    })
+  })
+
+  it('decoy: .sh script driving `psql -c "UPDATE ..."`', () => {
+    withScratchDir((dir) => {
+      fs.writeFileSync(
+        path.join(dir, 'zz-decoy-tooling.sh'),
+        [
+          '#!/usr/bin/env bash',
+          'set -euo pipefail',
+          'psql "$DATABASE_URL" -c "UPDATE attendance_calculation_rollout_state SET state = '
+            + "'shadow' WHERE org_id = 'demo'\"",
+        ].join('\n'),
+      )
+      const files: string[] = []
+      walk(dir, files)
+      const offenders = findRolloutDmlOffenders(dir, files)
+      expect(offenders.map((o) => o.label)).toEqual(['UPDATE attendance_calculation_rollout_state'])
+    })
+  })
+
+  it('negative control: a plain SELECT in each of the three syntaxes is not flagged', () => {
+    withScratchDir((dir) => {
+      fs.writeFileSync(
+        path.join(dir, 'zz-read.ts'),
+        "export const decoyRead = (trx: any) => trx.selectFrom('attendance_calculation_rollout_state').selectAll().execute()",
+      )
+      fs.writeFileSync(path.join(dir, 'zz-read.sql'), 'SELECT * FROM attendance_calculation_rollout_state;')
+      fs.writeFileSync(path.join(dir, 'zz-read.sh'), 'psql -c "SELECT * FROM attendance_calculation_rollout_state"')
+      const files: string[] = []
+      walk(dir, files)
+      expect(files.length).toBe(3)
+      const offenders = findRolloutDmlOffenders(dir, files)
+      expect(offenders).toEqual([])
+    })
   })
 })

--- a/packages/core-backend/src/attendance/__tests__/w4c3a-rollout-control-inventory.test.ts
+++ b/packages/core-backend/src/attendance/__tests__/w4c3a-rollout-control-inventory.test.ts
@@ -13,6 +13,7 @@
  * its own coverage). It is a single inert gate: any match anywhere else fails
  * the test, so a future writer cannot silently slip past a narrower allowlist.
  */
+import { execFileSync } from 'node:child_process'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
@@ -62,6 +63,26 @@ const ROLLOUT_DML_PATTERNS: ReadonlyArray<{ readonly label: string; readonly pat
   { label: 'Kysely insertInto(attendance_calculation_rollout_events)', pattern: /\.insertInto\(\s*['"`]attendance_calculation_rollout_events['"`]/i },
 ]
 
+/**
+ * NIT-3 (PR #4773 exact-head independent gate, 20260805): the real full-repo gate below walks
+ * `git ls-files` (git-TRACKED files only), not the raw working tree, so an untracked developer
+ * scratch file matching one of the patterns cannot red a required check it was never meant to
+ * gate — this test's job is repository inventory, not working-directory hygiene. `git ls-files
+ * -z --cached --others --exclude-standard` includes tracked files AND untracked-but-not-ignored
+ * files would normally slip in via `--others`; deliberately using `--cached` ONLY (tracked files
+ * as of the index/HEAD) is the fix, not an oversight — see the sanity assertion below.
+ */
+function listGitTrackedFiles(rootDir: string): string[] {
+  const raw = execFileSync('git', ['ls-files', '-z', '--cached'], { cwd: rootDir, maxBuffer: 64 * 1024 * 1024 })
+  return raw
+    .toString('utf8')
+    .split('\0')
+    .filter((relative) => relative.length > 0)
+    .filter((relative) => TARGET_EXTENSIONS.has(path.extname(relative)))
+    .filter((relative) => !relative.split('/').some((segment) => EXCLUDED_DIR_SEGMENTS.has(segment)))
+    .map((relative) => path.join(rootDir, relative))
+}
+
 function walk(dir: string, out: string[]): void {
   for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
     if (entry.isDirectory()) {
@@ -99,15 +120,30 @@ function findRolloutDmlOffenders(
 
 describe('W4C-5 repository inventory: rollout-state/event DML has exactly one writer', () => {
   it('finds rollout-state/event DML only in the hardened boundary, its migration, and integration fixtures', () => {
-    const files: string[] = []
-    walk(ROOT, files)
-    expect(files.length).toBeGreaterThan(100) // sanity: the walk actually found the repo
+    const files = listGitTrackedFiles(ROOT)
+    expect(files.length).toBeGreaterThan(100) // sanity: git ls-files actually found the repo
 
     const offenders = findRolloutDmlOffenders(ROOT, files, {
       allowedRelativeFiles: ALLOWED_RELATIVE_FILES,
       allowedDirectoryPrefixes: ALLOWED_DIRECTORY_PREFIXES,
     })
     expect(offenders).toEqual([])
+  })
+
+  it('NIT-3: an untracked scratch file matching the pattern is NOT walked by the real gate (git-tracked only)', () => {
+    // Positive proof the fix actually changed behavior: write a real untracked file INSIDE the
+    // repo tree (not an isolated os.tmpdir() decoy) containing an offending pattern, confirm the
+    // real gate's file list does not include it, then clean up. If this ever regresses back to
+    // a raw filesystem walk, this file WOULD appear in `files` and the assertion below reds.
+    const scratchPath = path.join(ROOT, 'packages/core-backend/src/attendance/zz-nit3-untracked-scratch.ts')
+    fs.writeFileSync(scratchPath, "export const x = 'UPDATE attendance_calculation_rollout_state SET state = 1'\n")
+    try {
+      const files = listGitTrackedFiles(ROOT)
+      const relatives = files.map((absolute) => path.relative(ROOT, absolute).split(path.sep).join('/'))
+      expect(relatives).not.toContain('packages/core-backend/src/attendance/zz-nit3-untracked-scratch.ts')
+    } finally {
+      fs.rmSync(scratchPath, { force: true })
+    }
   })
 
   it('positive control: the pattern set actually matches the hardened boundary file itself', () => {

--- a/packages/core-backend/src/attendance/__tests__/w4c3a-rollout-control-inventory.test.ts
+++ b/packages/core-backend/src/attendance/__tests__/w4c3a-rollout-control-inventory.test.ts
@@ -1,0 +1,92 @@
+/**
+ * W4C-5 transition-safety amendment completion gate 9: repository inventory.
+ *
+ * The hardened boundary in w4c3a-rollout-control.ts is the ONLY place allowed
+ * to write attendance_calculation_rollout_state or attendance_calculation_
+ * rollout_events. No route, generic plugin service, or second competing
+ * transition implementation may exist; tooling may only call this module's
+ * exported functions, never write rollout DML directly.
+ *
+ * This is a mechanical, exhaustive grep over the ENTIRE repository source
+ * (excluding node_modules/dist/build output and this module + its migration/
+ * test files themselves, which are the one authorized writer + its schema +
+ * its own coverage). It is a single inert gate: any match anywhere else fails
+ * the test, so a future writer cannot silently slip past a narrower allowlist.
+ */
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../../..')
+
+const EXCLUDED_DIR_SEGMENTS = new Set([
+  'node_modules',
+  'dist',
+  'build',
+  '.git',
+  '.turbo',
+  'coverage',
+  '.claude',
+])
+
+// The one authorized writer (implementation), its append-only migration (schema DDL, not a
+// second writer), and this inventory test's own file (whose comment text intentionally names
+// the guarded SQL for documentation purposes) are the only allowed matches.
+const ALLOWED_RELATIVE_FILES = new Set([
+  'packages/core-backend/src/attendance/w4c3a-rollout-control.ts',
+  'packages/core-backend/src/db/migrations/zzzz20260725120000_w4c0_attendance_segment_calculation_durable_storage.ts',
+  'packages/core-backend/src/attendance/__tests__/w4c3a-rollout-control-inventory.test.ts',
+])
+
+// Real-DB integration specs are allowed to directly seed/assert the rollout tables as FIXTURE
+// setup (never as production DML) — they exercise the guarded boundary, they do not replace it.
+const ALLOWED_DIRECTORY_PREFIXES = ['packages/core-backend/tests/integration/']
+
+const TARGET_EXTENSIONS = new Set(['.ts', '.tsx', '.js', '.cjs', '.mjs'])
+
+const ROLLOUT_DML_PATTERNS: ReadonlyArray<{ readonly label: string; readonly pattern: RegExp }> = [
+  { label: 'UPDATE attendance_calculation_rollout_state', pattern: /UPDATE\s+attendance_calculation_rollout_state/i },
+  { label: 'INSERT INTO attendance_calculation_rollout_state', pattern: /INSERT\s+INTO\s+attendance_calculation_rollout_state/i },
+  { label: 'INSERT INTO attendance_calculation_rollout_events', pattern: /INSERT\s+INTO\s+attendance_calculation_rollout_events/i },
+]
+
+function walk(dir: string, out: string[]): void {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.isDirectory()) {
+      if (EXCLUDED_DIR_SEGMENTS.has(entry.name)) continue
+      walk(path.join(dir, entry.name), out)
+      continue
+    }
+    if (!entry.isFile()) continue
+    if (!TARGET_EXTENSIONS.has(path.extname(entry.name))) continue
+    out.push(path.join(dir, entry.name))
+  }
+}
+
+describe('W4C-5 repository inventory: rollout-state/event DML has exactly one writer', () => {
+  it('finds rollout-state/event DML only in the hardened boundary, its migration, and integration fixtures', () => {
+    const files: string[] = []
+    walk(ROOT, files)
+    expect(files.length).toBeGreaterThan(100) // sanity: the walk actually found the repo
+
+    const offenders: Array<{ file: string; label: string }> = []
+    for (const absolute of files) {
+      const relative = path.relative(ROOT, absolute).split(path.sep).join('/')
+      if (ALLOWED_RELATIVE_FILES.has(relative)) continue
+      if (ALLOWED_DIRECTORY_PREFIXES.some((prefix) => relative.startsWith(prefix))) continue
+      const content = fs.readFileSync(absolute, 'utf8')
+      for (const { label, pattern } of ROLLOUT_DML_PATTERNS) {
+        if (pattern.test(content)) offenders.push({ file: relative, label })
+      }
+    }
+    expect(offenders).toEqual([])
+  })
+
+  it('positive control: the pattern set actually matches the hardened boundary file itself', () => {
+    const target = path.join(ROOT, 'packages/core-backend/src/attendance/w4c3a-rollout-control.ts')
+    const content = fs.readFileSync(target, 'utf8')
+    const matched = ROLLOUT_DML_PATTERNS.filter(({ pattern }) => pattern.test(content))
+    expect(matched.length).toBeGreaterThan(0)
+  })
+})

--- a/packages/core-backend/src/attendance/w4c0-identity.ts
+++ b/packages/core-backend/src/attendance/w4c0-identity.ts
@@ -1225,7 +1225,11 @@ async function acquireLegacyImportCompatibilityLock(
 /**
  * The ONLY place allowed to select pg_advisory_xact_lock_shared versus
  * pg_advisory_xact_lock for the org rollout key. Source, rollback, transition, and closure
- * all import this helper (later slices); there is no copied namespace or local hash.
+ * all import this helper (later slices); there is no copied namespace or local hash. The one
+ * deliberate sibling is `acquireAttendanceCalculationRolloutLockSessionExclusiveV1` below —
+ * same key derivation, session-scoped instead of transaction-scoped, for the one caller
+ * (the canonical transition boundary, W4C-5 P1-2) that must not fix its SERIALIZABLE snapshot
+ * before the wait resolves.
  * Its own budget/acquisition timeout maps to values-free
  * `503 ATTENDANCE_CALCULATION_ROLLOUT_BUSY` after the caller rolls back.
  */
@@ -1241,6 +1245,74 @@ export async function acquireAttendanceCalculationRolloutLock(
       ? 'SELECT pg_advisory_xact_lock_shared($1::bigint)'
       : 'SELECT pg_advisory_xact_lock($1::bigint)'
   await acquireKeysWithDeadline(trx, 'rollout', acquisitionSql, [key])
+}
+
+/**
+ * W4C-5 P1-2 fix. PostgreSQL fixes a SERIALIZABLE transaction's snapshot at the START of the
+ * FIRST statement executed inside it — including a statement that itself blocks (e.g. a
+ * transaction-scoped `pg_advisory_xact_lock` wait). So no matter how early
+ * `acquireAttendanceCalculationRolloutLock(trx, org, 'exclusive')` is called inside an
+ * already-BEGUN transaction, a defect committed by a legitimate shared-lock holder WHILE this
+ * caller is waiting is invisible to every predicate this transaction later reads: the snapshot
+ * predates the wait's resolution, not just the transaction's own BEGIN.
+ *
+ * This function closes that window by construction, not by narrowing it: it acquires the SAME
+ * advisory key at SESSION level (`pg_advisory_lock`, not `_xact_`), as its own standalone
+ * (autocommit) statement, on a connection that must not yet be inside a transaction. Advisory
+ * locks share one lock table regardless of session-vs-transaction scope (PostgreSQL docs
+ * 9.27.9 / 13.3.5), so this still correctly blocks behind every existing
+ * `pg_advisory_xact_lock_shared` writer and every other exclusive holder on the same key. The
+ * caller then issues `BEGIN ISOLATION LEVEL SERIALIZABLE` as a SEPARATE, LATER statement on the
+ * same connection — over the standard synchronous (non-pipelined) `pg`/`PoolClient` protocol,
+ * that statement is not even dispatched until this function's blocking call has already
+ * returned. The new transaction's snapshot can therefore only be established strictly AFTER
+ * this acquisition succeeded, which is strictly AFTER every previous holder released (committed
+ * or rolled back) — there is no statement, blocking or not, that straddles the "waiting" and
+ * "snapshot fixed" instants.
+ *
+ * Crash safety: PostgreSQL releases every session-level advisory lock automatically when the
+ * backend session ends (docs 9.27.9 / 13.3.5) — an unhandled process crash necessarily drops
+ * the TCP connection to that backend, which the server treats identically to a session end, so
+ * no lock survives a crash. The caller's own `finally` release
+ * (`releaseAttendanceCalculationRolloutLockSessionExclusiveV1`) exists for the NORMAL
+ * (non-crash) return path, so a pooled connection is never returned to the pool still holding
+ * this lock for an unrelated future checkout.
+ */
+export async function acquireAttendanceCalculationRolloutLockSessionExclusiveV1(
+  connection: AttendanceW4TransactionClientV1,
+  org: CanonicalAttendanceRolloutOrgKeyV1,
+): Promise<void> {
+  const key = buildAttendanceCalculationRolloutAdvisoryKey(org)
+  // `SET lock_timeout = $1` is not valid SQL (SET does not accept a bind parameter);
+  // `set_config(..., false)` is a normal function call and does, and `false` (not the
+  // transaction-local `true` used everywhere else in this file) is required here because there
+  // is no open transaction yet for a local setting to attach to.
+  await connection.query("SELECT set_config('lock_timeout', $1, false)", [
+    `${W4_ADVISORY_HELPER_WAIT_MS}ms`,
+  ])
+  try {
+    await connection.query('SELECT pg_advisory_lock($1::bigint)', [key.toString()])
+  } catch (error) {
+    if (isLockNotAvailable(error)) throw busyError('rollout')
+    throw error
+  } finally {
+    await connection.query("SELECT set_config('lock_timeout', '0', false)").catch(() => undefined)
+  }
+}
+
+/**
+ * Releases the session-level exclusive rollout lock acquired by
+ * `acquireAttendanceCalculationRolloutLockSessionExclusiveV1`. The caller MUST call this in a
+ * `finally` around every acquisition on a normal return path — see that function's crash-safety
+ * paragraph for why a crash does not need this to still be correct, only a live pooled
+ * connection reused afterward does.
+ */
+export async function releaseAttendanceCalculationRolloutLockSessionExclusiveV1(
+  connection: AttendanceW4TransactionClientV1,
+  org: CanonicalAttendanceRolloutOrgKeyV1,
+): Promise<void> {
+  const key = buildAttendanceCalculationRolloutAdvisoryKey(org)
+  await connection.query('SELECT pg_advisory_unlock($1::bigint)', [key.toString()])
 }
 
 function toSortedUniqueSignedKeys(keys: readonly bigint[]): bigint[] {

--- a/packages/core-backend/src/attendance/w4c0-identity.ts
+++ b/packages/core-backend/src/attendance/w4c0-identity.ts
@@ -371,6 +371,17 @@ function isOrgExactlyAllowlisted(orgKey: string): boolean {
   return entries.includes(orgKey)
 }
 
+/**
+ * W4C-5 transition-safety amendment section 2.3 / 3: the rollout-control boundary must gate
+ * missing-row creation and every transition attempt on the SAME exact org-only outer allowlist
+ * `resolveSegmentCalculationPosture` uses, rather than a second copied allowlist mechanism. This
+ * is a thin named export of the existing private predicate; it reads no additional env var and
+ * changes no existing caller's behavior.
+ */
+export function isAttendanceCalculationOrgAllowlistedV1(orgKey: string): boolean {
+  return isOrgExactlyAllowlisted(orgKey)
+}
+
 interface PostureRowShape {
   readonly writePosture: AttendanceSegmentWritePostureV1
   readonly authorSegments: 'preview' | 'full' | 'none'

--- a/packages/core-backend/src/attendance/w4c0-identity.ts
+++ b/packages/core-backend/src/attendance/w4c0-identity.ts
@@ -1258,7 +1258,9 @@ export async function acquireAttendanceCalculationRolloutLock(
  *
  * This function closes that window by construction, not by narrowing it: it acquires the SAME
  * advisory key at SESSION level (`pg_advisory_lock`, not `_xact_`), as its own standalone
- * (autocommit) statement, on a connection that must not yet be inside a transaction. Advisory
+ * (autocommit) statement, on a connection that must not yet be inside a transaction — ENFORCED
+ * (not merely documented — see `assertConnectionIsIdleForSessionExclusiveRolloutLockV1` below,
+ * W4C-5 NEW-B hardening) as this function's own first statement, fail-closed. Advisory
  * locks share one lock table regardless of session-vs-transaction scope (PostgreSQL docs
  * 9.27.9 / 13.3.5), so this still correctly blocks behind every existing
  * `pg_advisory_xact_lock_shared` writer and every other exclusive holder on the same key. The
@@ -1284,6 +1286,14 @@ export async function acquireAttendanceCalculationRolloutLockSessionExclusiveV1(
   connection: AttendanceW4TransactionClientV1,
   org: CanonicalAttendanceRolloutOrgKeyV1,
 ): Promise<void> {
+  // W4C-5 NEW-B hardening (PR #4773 exact-head independent DELTA gate, 20260805): this used to be
+  // a doc-comment-only precondition ("must not yet be inside a transaction") with no enforcement
+  // or test — a caller that pre-opened a transaction on `connection` before calling this function
+  // silently ran the rest of the transition inside ITS OWN already-fixed snapshot (PostgreSQL
+  // does not error on a nested `BEGIN`, it only WARNs and no-ops), reintroducing the exact P1-2
+  // defect this function exists to close, with no red test anywhere. Enforced now, first
+  // statement, before any lock side effect.
+  await assertConnectionIsIdleForSessionExclusiveRolloutLockV1(connection)
   const key = buildAttendanceCalculationRolloutAdvisoryKey(org)
   // `SET lock_timeout = $1` is not valid SQL (SET does not accept a bind parameter);
   // `set_config(..., false)` is a normal function call and does, and `false` (not the
@@ -1304,6 +1314,51 @@ export async function acquireAttendanceCalculationRolloutLockSessionExclusiveV1(
     // session's actual configured default was before this function overrode it.
     await connection.query('RESET lock_timeout').catch(() => undefined)
   }
+}
+
+/**
+ * W4C-5 NEW-B hardening. Proves — does not merely assume — that `connection` has no open
+ * transaction block, BEFORE `acquireAttendanceCalculationRolloutLockSessionExclusiveV1` does
+ * anything else. Detection cannot use `pg_current_xact_id_if_assigned()` (or any other xid-based
+ * probe): PostgreSQL assigns a real transaction ID lazily, on first WRITE. A caller that opened
+ * `BEGIN ISOLATION LEVEL SERIALIZABLE; SELECT 1;` — exactly the shape that fixes a dangerous
+ * snapshot — has NO xid yet, so an xid-based probe would read "idle" for both an autocommit
+ * connection and this exact dangerous open-but-unwritten transaction: a false negative on
+ * precisely the case that matters.
+ *
+ * Instead this issues `SAVEPOINT` as the probe (verified empirically against real PostgreSQL
+ * 15, both via `psql` and via this codebase's own `pg` driver): PostgreSQL raises SQLSTATE
+ * `25P01` (`no_active_sql_transaction`, "SAVEPOINT can only be used in transaction blocks") IF
+ * AND ONLY IF there is no open transaction block on the connection — independent of whether an
+ * xid has ever been assigned. A `25P01` therefore proves idle (autocommit); the SAVEPOINT
+ * succeeding proves the opposite (an open transaction already exists) and is the only case that
+ * needs cleanup (`ROLLBACK TO SAVEPOINT`) before failing closed — the idle path never created
+ * anything to clean up. Any OTHER error (neither `25P01` nor a successful SAVEPOINT) is
+ * rethrown unchanged rather than silently treated as "idle": this function only ever certifies
+ * idleness on affirmative proof (the `25P01`), never on the absence of a different error.
+ */
+async function assertConnectionIsIdleForSessionExclusiveRolloutLockV1(
+  connection: AttendanceW4TransactionClientV1,
+): Promise<void> {
+  try {
+    await connection.query('SAVEPOINT w4c5_idle_probe')
+  } catch (error) {
+    if (isNoActiveTransactionForSavepoint(error)) return // proven idle — proceed
+    throw error // some other failure; never mask it as "idle"
+  }
+  // The SAVEPOINT succeeded: `connection` already had an open transaction block on entry. Clean
+  // up the probe savepoint (nothing else was ever written under it) and fail closed — silently
+  // proceeding here is exactly the P1-2 regression this function exists to prevent.
+  await connection.query('ROLLBACK TO SAVEPOINT w4c5_idle_probe').catch(() => undefined)
+  fail('W4C0_ROLLOUT_LOCK_CONNECTION_NOT_IDLE')
+}
+
+function isNoActiveTransactionForSavepoint(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    (error as { code?: unknown }).code === '25P01'
+  )
 }
 
 /**

--- a/packages/core-backend/src/attendance/w4c0-identity.ts
+++ b/packages/core-backend/src/attendance/w4c0-identity.ts
@@ -1263,20 +1263,22 @@ export async function acquireAttendanceCalculationRolloutLock(
  * 9.27.9 / 13.3.5), so this still correctly blocks behind every existing
  * `pg_advisory_xact_lock_shared` writer and every other exclusive holder on the same key. The
  * caller then issues `BEGIN ISOLATION LEVEL SERIALIZABLE` as a SEPARATE, LATER statement on the
- * same connection — over the standard synchronous (non-pipelined) `pg`/`PoolClient` protocol,
- * that statement is not even dispatched until this function's blocking call has already
- * returned. The new transaction's snapshot can therefore only be established strictly AFTER
- * this acquisition succeeded, which is strictly AFTER every previous holder released (committed
- * or rolled back) — there is no statement, blocking or not, that straddles the "waiting" and
- * "snapshot fixed" instants.
+ * same connection. This relies on one named premise: the `pg`/`PoolClient` driver this codebase
+ * uses serializes queries per connection (no pipelining) — it does not dispatch the next query
+ * until the previous one's response has been received — so `BEGIN` is not sent until this
+ * function's blocking acquisition has already returned. Given that premise, the new
+ * transaction's snapshot can only be established strictly AFTER this acquisition succeeded,
+ * which is strictly AFTER every previous holder released (committed or rolled back).
  *
- * Crash safety: PostgreSQL releases every session-level advisory lock automatically when the
- * backend session ends (docs 9.27.9 / 13.3.5) — an unhandled process crash necessarily drops
- * the TCP connection to that backend, which the server treats identically to a session end, so
- * no lock survives a crash. The caller's own `finally` release
- * (`releaseAttendanceCalculationRolloutLockSessionExclusiveV1`) exists for the NORMAL
- * (non-crash) return path, so a pooled connection is never returned to the pool still holding
- * this lock for an unrelated future checkout.
+ * Crash safety: PostgreSQL releases every session-level advisory lock when the backend session
+ * ends (docs 9.27.9 / 13.3.5). A crashed client does not end that session instantly — the
+ * server only observes the dropped TCP connection (and releases the session's locks) once it
+ * notices, bounded by TCP keepalive or `idle_session_timeout` if configured, not by the crash
+ * itself. So a crash does not leak this lock forever, but it is not the same instant as the
+ * crash either. The caller's own `finally` release
+ * (`releaseAttendanceCalculationRolloutLockSessionExclusiveV1`) is what makes the NORMAL
+ * (non-crash) return path immediate, so a pooled connection is never returned to the pool still
+ * holding this lock for an unrelated future checkout.
  */
 export async function acquireAttendanceCalculationRolloutLockSessionExclusiveV1(
   connection: AttendanceW4TransactionClientV1,
@@ -1296,7 +1298,11 @@ export async function acquireAttendanceCalculationRolloutLockSessionExclusiveV1(
     if (isLockNotAvailable(error)) throw busyError('rollout')
     throw error
   } finally {
-    await connection.query("SELECT set_config('lock_timeout', '0', false)").catch(() => undefined)
+    // `RESET lock_timeout` (not `set_config('lock_timeout', '0', false)`): hardcoding '0' would
+    // permanently stomp any non-default `postgresql.conf`/`ALTER ROLE ... SET lock_timeout` value
+    // for the rest of this pooled connection's session, whereas RESET restores whatever the
+    // session's actual configured default was before this function overrode it.
+    await connection.query('RESET lock_timeout').catch(() => undefined)
   }
 }
 

--- a/packages/core-backend/src/attendance/w4c3a-rollout-control.ts
+++ b/packages/core-backend/src/attendance/w4c3a-rollout-control.ts
@@ -3,20 +3,31 @@
  *
  * These commands deliberately have no PluginServices, route, flag, or index
  * surface. They are the control-side half of the §7.9/§8.2 protocol only.
+ *
+ * W4C-5 transition-safety amendment (docs/development/attendance-issue-4556-
+ * w4c5-transition-safety-amendment-20260804.md, OD-W4C-61=(a)): this module is
+ * the hardened canonical transition boundary sections 1-6 describe. It is the
+ * ONLY transition DML path; no route, generic plugin service, or second
+ * competing implementation exists. Preparation/tooling (a separate,
+ * independently gated PR) may only call this boundary — it must never touch
+ * rollout DML directly.
  */
 import {
   acquireAttendanceCalculationRolloutLock,
   acquireAttendanceCalculationTargetLocks,
   acquireAttendanceResultOperationLocks,
   createVerifiedAttendanceCalculationTargetIdentityV1,
+  isAttendanceCalculationOrgAllowlistedV1,
   parseCanonicalAttendanceRolloutOrgKeyV1,
   rehydrateVerifiedAttendanceOperationIdentityV1,
   rehydrateVerifiedAttendanceOrgIdentityV1,
+  type AttendanceAcceptedWritePostureV1,
   type AttendanceRolloutStateV1,
   type AttendanceW4TransactionClientV1,
   type VerifiedAttendanceOperationIdentityV1,
 } from './w4c0-identity'
 import { runAttendanceResultOperationTransactionV1 } from './w4c0-operation-registry'
+import { ATTENDANCE_CALCULATION_AFFECTING_REQUEST_TYPES_V1 } from './w4c3b-request-snapshots'
 
 export class AttendanceW4C3aRolloutControlError extends Error {
   readonly code: string
@@ -33,6 +44,8 @@ function fail(code: string): never {
 }
 
 const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
+const HEX64 = /^[0-9a-f]{64}$/
+const REF_VALUE = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/
 const TRANSITION_STATES = new Set<AttendanceRolloutStateV1>([
   'legacy',
   'shadow',
@@ -40,6 +53,99 @@ const TRANSITION_STATES = new Set<AttendanceRolloutStateV1>([
   'authoritative',
   'suspended',
 ])
+
+// ---------------------------------------------------------------------------
+// Amendment section 1: the closed legal transition matrix. This is the SOLE
+// source of pair legality and comparison write posture; the DB trigger
+// (attendance_w4_rollout_state_guard) enforces the identical set as a
+// defense-in-depth backstop, never as the primary gate. Every other pair
+// fails here, before any lock beyond the rollout advisory lock itself.
+// ---------------------------------------------------------------------------
+type LegalTransitionRow = Readonly<{
+  from: AttendanceRolloutStateV1
+  to: AttendanceRolloutStateV1
+  comparisonWritePosture: AttendanceAcceptedWritePostureV1
+}>
+
+const LEGAL_TRANSITIONS: readonly LegalTransitionRow[] = Object.freeze([
+  { from: 'legacy', to: 'shadow', comparisonWritePosture: 'shadow' },
+  { from: 'shadow', to: 'eligible', comparisonWritePosture: 'shadow' },
+  { from: 'eligible', to: 'shadow', comparisonWritePosture: 'shadow' },
+  { from: 'eligible', to: 'authoritative', comparisonWritePosture: 'authoritative' },
+  { from: 'shadow', to: 'legacy', comparisonWritePosture: 'legacy_projection_only' },
+  { from: 'authoritative', to: 'suspended', comparisonWritePosture: 'authoritative' },
+  { from: 'suspended', to: 'authoritative', comparisonWritePosture: 'authoritative' },
+])
+
+function findLegalTransition(
+  from: AttendanceRolloutStateV1,
+  to: AttendanceRolloutStateV1,
+): LegalTransitionRow | undefined {
+  return LEGAL_TRANSITIONS.find((row) => row.from === from && row.to === to)
+}
+
+const ELIGIBILITY_AUTHORITY_TARGETS = new Set<AttendanceRolloutStateV1>(['eligible', 'authoritative'])
+const CALCULATION_ENTRY_TARGETS = new Set<AttendanceRolloutStateV1>(['shadow', 'eligible', 'authoritative'])
+
+const RETRYABLE_JOB_STATUSES = ['queued', 'failed']
+const NONTERMINAL_LEGACY_JOB_STATUSES = ['queued', 'running']
+
+// ---------------------------------------------------------------------------
+// Evidence references (amendment section 4): the command NEVER collects or
+// validates the manifest itself — that is a separately authorized tooling
+// concern. It accepts only the exact manifest hash plus a closed set of
+// opaque, values-free reference strings and stores them verbatim.
+// ---------------------------------------------------------------------------
+const BASE_EVIDENCE_REFERENCE_KEYS = ['imageSha', 'ownerAuthorizationRef', 'syntheticOrgRef'] as const
+const RESUME_EVIDENCE_REFERENCE_KEYS = ['ownerIncidentReviewRef', 'offlineReplayArtifactRef'] as const
+
+export type BaseEvidenceReferenceKeyV1 = (typeof BASE_EVIDENCE_REFERENCE_KEYS)[number]
+export type ResumeEvidenceReferenceKeyV1 = (typeof RESUME_EVIDENCE_REFERENCE_KEYS)[number]
+export type EvidenceReferenceKeyV1 = BaseEvidenceReferenceKeyV1 | ResumeEvidenceReferenceKeyV1
+
+export type EvidenceReferencesV1 = Readonly<Record<EvidenceReferenceKeyV1, string>>
+
+function isResumePair(from: AttendanceRolloutStateV1, to: AttendanceRolloutStateV1): boolean {
+  return from === 'suspended' && to === 'authoritative'
+}
+
+function requireEvidenceReferences(
+  value: unknown,
+  from: AttendanceRolloutStateV1,
+  to: AttendanceRolloutStateV1,
+): EvidenceReferencesV1 {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    fail('W4C3A_ROLLOUT_CONTROL_EVIDENCE_REFERENCE_INVALID')
+  }
+  const prototype = Object.getPrototypeOf(value)
+  if (prototype !== Object.prototype && prototype !== null) {
+    fail('W4C3A_ROLLOUT_CONTROL_EVIDENCE_REFERENCE_INVALID')
+  }
+  if (Object.getOwnPropertySymbols(value).length > 0) {
+    fail('W4C3A_ROLLOUT_CONTROL_EVIDENCE_REFERENCE_INVALID')
+  }
+  const expectedKeys: readonly string[] = isResumePair(from, to)
+    ? [...BASE_EVIDENCE_REFERENCE_KEYS, ...RESUME_EVIDENCE_REFERENCE_KEYS]
+    : BASE_EVIDENCE_REFERENCE_KEYS
+  const own = Object.getOwnPropertyNames(value)
+  if (own.length !== expectedKeys.length) fail('W4C3A_ROLLOUT_CONTROL_EVIDENCE_REFERENCE_INVALID')
+  const out: Record<string, string> = {}
+  for (const key of expectedKeys) {
+    if (!Object.prototype.hasOwnProperty.call(value, key)) {
+      fail('W4C3A_ROLLOUT_CONTROL_EVIDENCE_REFERENCE_INVALID')
+    }
+    const descriptor = Object.getOwnPropertyDescriptor(value, key)
+    if (!descriptor || descriptor.get || descriptor.set) {
+      fail('W4C3A_ROLLOUT_CONTROL_EVIDENCE_REFERENCE_INVALID')
+    }
+    const raw = (value as Record<string, unknown>)[key]
+    if (typeof raw !== 'string' || !REF_VALUE.test(raw)) {
+      fail('W4C3A_ROLLOUT_CONTROL_EVIDENCE_REFERENCE_INVALID')
+    }
+    out[key] = raw
+  }
+  return Object.freeze(out) as EvidenceReferencesV1
+}
 
 type ControlInput = Readonly<{
   orgId: string
@@ -55,6 +161,10 @@ export type CloseLegacyRollbackWindowInputV1 = ControlInput & Readonly<{
 
 export type TransitionAttendanceCalculationRolloutInputV1 = Omit<ControlInput, 'batchId'> & Readonly<{
   targetState: AttendanceRolloutStateV1
+  expectedState: AttendanceRolloutStateV1
+  expectedVersion: number
+  evidenceManifestSha256: string
+  evidenceReferences: EvidenceReferencesV1
   reasonCode: 'rollout_transition'
 }>
 
@@ -73,12 +183,24 @@ type BatchReferenceState = Readonly<{
 }>
 
 let afterExclusiveRolloutLockForTests: ((kind: 'close' | 'transition') => Promise<void>) | null = null
+let beforeEventInsertForTests: (() => Promise<void>) | null = null
 
 /** Test-only deterministic barrier. It is not imported by production wiring. */
 export function __setW4C3aRolloutControlAfterExclusiveLockForTests(
   hook: ((kind: 'close' | 'transition') => Promise<void>) | null,
 ): void {
   afterExclusiveRolloutLockForTests = hook
+}
+
+/**
+ * Test-only atomicity seam (amendment completion gate 7): fires after the
+ * rollout-state UPDATE and before the rollout-event INSERT, in the same
+ * transaction. It is not imported by production wiring.
+ */
+export function __setW4C3aRolloutControlBeforeEventInsertForTests(
+  hook: (() => Promise<void>) | null,
+): void {
+  beforeEventInsertForTests = hook
 }
 
 function requireUuid(value: unknown, code: string): string {
@@ -89,6 +211,35 @@ function requireUuid(value: unknown, code: string): string {
 function requireText(value: unknown, code: string): string {
   if (typeof value !== 'string' || value.length === 0 || value.length > 256) fail(code)
   return value
+}
+
+function requireRolloutState(value: unknown, code: string): AttendanceRolloutStateV1 {
+  if (typeof value !== 'string' || !TRANSITION_STATES.has(value as AttendanceRolloutStateV1)) fail(code)
+  return value as AttendanceRolloutStateV1
+}
+
+function requireManifestSha256(value: unknown): string {
+  if (typeof value !== 'string' || !HEX64.test(value)) fail('W4C3A_ROLLOUT_CONTROL_MANIFEST_INVALID')
+  return value
+}
+
+function requireExpectedVersion(value: unknown): number {
+  if (typeof value !== 'number' || !Number.isSafeInteger(value) || value < 1) {
+    fail('W4C3A_ROLLOUT_CONTROL_EXPECTED_VERSION_INVALID')
+  }
+  return value
+}
+
+function requireExactInputKeys(input: unknown, keys: readonly string[], code: string): Record<string, unknown> {
+  if (typeof input !== 'object' || input === null || Array.isArray(input)) fail(code)
+  const prototype = Object.getPrototypeOf(input)
+  if (prototype !== Object.prototype && prototype !== null) fail(code)
+  const own = Object.getOwnPropertyNames(input)
+  if (own.length !== keys.length) fail(code)
+  for (const key of keys) {
+    if (!Object.prototype.hasOwnProperty.call(input, key)) fail(code)
+  }
+  return input as Record<string, unknown>
 }
 
 function normalizeCloseInput(input: CloseLegacyRollbackWindowInputV1): CloseLegacyRollbackWindowInputV1 {
@@ -103,19 +254,57 @@ function normalizeCloseInput(input: CloseLegacyRollbackWindowInputV1): CloseLega
   })
 }
 
+const TRANSITION_INPUT_KEYS = [
+  'orgId',
+  'actorId',
+  'correlationId',
+  'engineVersion',
+  'targetState',
+  'expectedState',
+  'expectedVersion',
+  'evidenceManifestSha256',
+  'evidenceReferences',
+  'reasonCode',
+] as const
+
+type NormalizedTransitionInput = TransitionAttendanceCalculationRolloutInputV1 & Readonly<{
+  comparisonWritePosture: AttendanceAcceptedWritePostureV1
+}>
+
 function normalizeTransitionInput(
-  input: TransitionAttendanceCalculationRolloutInputV1,
-): TransitionAttendanceCalculationRolloutInputV1 {
-  if (!input || input.reasonCode !== 'rollout_transition' || !TRANSITION_STATES.has(input.targetState)) {
-    fail('W4C3A_ROLLOUT_CONTROL_INPUT_INVALID')
-  }
+  rawInput: TransitionAttendanceCalculationRolloutInputV1,
+): NormalizedTransitionInput {
+  const input = requireExactInputKeys(
+    rawInput,
+    TRANSITION_INPUT_KEYS,
+    'W4C3A_ROLLOUT_CONTROL_INPUT_INVALID',
+  )
+  if (input.reasonCode !== 'rollout_transition') fail('W4C3A_ROLLOUT_CONTROL_INPUT_INVALID')
+  const orgId = String(parseCanonicalAttendanceRolloutOrgKeyV1(input.orgId))
+  const actorId = requireText(input.actorId, 'W4C3A_ROLLOUT_CONTROL_ACTOR_INVALID')
+  const correlationId = requireUuid(input.correlationId, 'W4C3A_ROLLOUT_CONTROL_CORRELATION_INVALID')
+  const engineVersion = requireText(input.engineVersion, 'W4C3A_ROLLOUT_CONTROL_ENGINE_INVALID')
+  const targetState = requireRolloutState(input.targetState, 'W4C3A_ROLLOUT_CONTROL_INPUT_INVALID')
+  const expectedState = requireRolloutState(input.expectedState, 'W4C3A_ROLLOUT_CONTROL_EXPECTED_STATE_INVALID')
+  const expectedVersion = requireExpectedVersion(input.expectedVersion)
+  const evidenceManifestSha256 = requireManifestSha256(input.evidenceManifestSha256)
+  // The claimed pair is validated against the closed matrix BEFORE any lock or DB access — a
+  // caller-asserted illegal pair can never proceed regardless of true persisted state.
+  const legal = findLegalTransition(expectedState, targetState)
+  if (!legal) fail('W4C3A_ROLLOUT_CONTROL_ILLEGAL_TRANSITION')
+  const evidenceReferences = requireEvidenceReferences(input.evidenceReferences, expectedState, targetState)
   return Object.freeze({
-    orgId: String(parseCanonicalAttendanceRolloutOrgKeyV1(input.orgId)),
-    actorId: requireText(input.actorId, 'W4C3A_ROLLOUT_CONTROL_ACTOR_INVALID'),
-    correlationId: requireUuid(input.correlationId, 'W4C3A_ROLLOUT_CONTROL_CORRELATION_INVALID'),
-    engineVersion: requireText(input.engineVersion, 'W4C3A_ROLLOUT_CONTROL_ENGINE_INVALID'),
-    targetState: input.targetState,
-    reasonCode: input.reasonCode,
+    orgId,
+    actorId,
+    correlationId,
+    engineVersion,
+    targetState,
+    expectedState,
+    expectedVersion,
+    evidenceManifestSha256,
+    evidenceReferences,
+    reasonCode: 'rollout_transition' as const,
+    comparisonWritePosture: legal.comparisonWritePosture,
   })
 }
 
@@ -258,33 +447,46 @@ async function lockTargetsAndParents(
   )
 }
 
-async function lockRolloutStateForTransition(
+/**
+ * Amendment section 2.3: missing state may be created ONLY for the exact
+ * allowlisted synthetic org and ONLY as part of `legacy -> shadow`. Every
+ * other missing-row case fails closed with zero DML — no row is ever
+ * materialized for an org this boundary was never authorized to touch.
+ */
+async function lockRolloutStateForBootstrapOrRead(
   trx: AttendanceW4TransactionClientV1,
   orgId: string,
   actorId: string,
   engineVersion: string,
-): Promise<AttendanceRolloutStateV1> {
-  let row = await trx.query(
-    `SELECT state FROM attendance_calculation_rollout_state WHERE org_id = $1 FOR UPDATE`,
+  expectedState: AttendanceRolloutStateV1,
+  targetState: AttendanceRolloutStateV1,
+  orgAllowlisted: boolean,
+): Promise<Readonly<{ state: AttendanceRolloutStateV1; version: number }>> {
+  const row = await trx.query(
+    `SELECT state, version FROM attendance_calculation_rollout_state WHERE org_id = $1 FOR UPDATE`,
     [orgId],
   )
-  if (row.rows.length === 0) {
-    await trx.query(
-      `INSERT INTO attendance_calculation_rollout_state
-       (org_id, state, engine_version, reason_code, actor_id, version, prior_state, scope)
-       VALUES ($1, 'legacy', $2, 'rollout_transition', $3, 1, NULL, 'synthetic_staging')
-       ON CONFLICT (org_id) DO NOTHING`,
-      [orgId, engineVersion, actorId],
-    )
-    row = await trx.query(
-      `SELECT state FROM attendance_calculation_rollout_state WHERE org_id = $1 FOR UPDATE`,
-      [orgId],
-    )
+  if (row.rows.length === 1) {
+    const state = row.rows[0].state
+    const version = row.rows[0].version
+    if (typeof state !== 'string' || !TRANSITION_STATES.has(state as AttendanceRolloutStateV1)) {
+      fail('W4C3A_ROLLOUT_CONTROL_STATE_INVALID')
+    }
+    if (typeof version !== 'number' || !Number.isSafeInteger(version) || version < 1) {
+      fail('W4C3A_ROLLOUT_CONTROL_STATE_INVALID')
+    }
+    return { state: state as AttendanceRolloutStateV1, version }
   }
-  if (row.rows.length !== 1 || !TRANSITION_STATES.has(row.rows[0].state as AttendanceRolloutStateV1)) {
-    fail('W4C3A_ROLLOUT_CONTROL_STATE_INVALID')
-  }
-  return row.rows[0].state as AttendanceRolloutStateV1
+  if (row.rows.length !== 0) fail('W4C3A_ROLLOUT_CONTROL_STATE_INVALID')
+  const canBootstrap = orgAllowlisted && expectedState === 'legacy' && targetState === 'shadow'
+  if (!canBootstrap) fail('W4C3A_ROLLOUT_CONTROL_STATE_MISSING')
+  await trx.query(
+    `INSERT INTO attendance_calculation_rollout_state
+     (org_id, state, engine_version, reason_code, actor_id, version, prior_state, scope)
+     VALUES ($1, 'legacy', $2, 'rollout_transition', $3, 1, NULL, 'synthetic_staging')`,
+    [orgId, engineVersion, actorId],
+  )
+  return { state: 'legacy', version: 1 }
 }
 
 async function loadBatchReferenceState(
@@ -394,7 +596,7 @@ async function batchFingerprint(
       WHERE b.org_id = $1 AND b.id = $2::uuid`,
     [orgId, batchId],
   )
-  if (result.rows.length !== 1 || typeof result.rows[0].fingerprint !== 'string' || !/^[0-9a-f]{64}$/.test(result.rows[0].fingerprint)) {
+  if (result.rows.length !== 1 || typeof result.rows[0].fingerprint !== 'string' || !HEX64.test(result.rows[0].fingerprint)) {
     fail('W4C3A_ROLLOUT_CONTROL_BATCH_NOT_FOUND')
   }
   return result.rows[0].fingerprint
@@ -406,6 +608,150 @@ async function allOrgBatchIds(trx: AttendanceW4TransactionClientV1, orgId: strin
     [orgId],
   )
   return result.rows.map((row) => requireUuid(row.id, 'W4C3A_ROLLOUT_CONTROL_BATCH_INVALID'))
+}
+
+// ---------------------------------------------------------------------------
+// Amendment section 3: additional database-backed transition predicates.
+// Each locks (`FOR UPDATE`) the exact rows it inspects so a concurrent writer
+// targeting the same rows blocks behind this transaction rather than racing
+// its read. Every helper returns a values-free count; the caller decides
+// applicability per the requested pair and fails closed with zero rollout DML
+// before any predicate short-circuits.
+// ---------------------------------------------------------------------------
+
+/** Every rollout transition: every retryable V1 job's frozen posture must equal the pair's. */
+async function countRetryableJobPostureMismatches(
+  trx: AttendanceW4TransactionClientV1,
+  orgId: string,
+  comparisonWritePosture: AttendanceAcceptedWritePostureV1,
+): Promise<number> {
+  const result = await trx.query(
+    `SELECT id, w4_accepted_write_posture AS posture
+       FROM attendance_import_jobs
+      WHERE org_id = $1 AND w4_contract_version = 1 AND status = ANY($2::text[])
+      ORDER BY id
+      FOR UPDATE`,
+    [orgId, RETRYABLE_JOB_STATUSES],
+  )
+  return result.rows.filter((row) => row.posture !== comparisonWritePosture).length
+}
+
+/** Entry into shadow|eligible|authoritative: zero nonterminal null-version legacy job. */
+async function countNonterminalNullVersionLegacyJobs(
+  trx: AttendanceW4TransactionClientV1,
+  orgId: string,
+): Promise<number> {
+  const result = await trx.query(
+    `SELECT id
+       FROM attendance_import_jobs
+      WHERE org_id = $1 AND w4_contract_version IS NULL AND status = ANY($2::text[])
+      ORDER BY id
+      FOR UPDATE`,
+    [orgId, NONTERMINAL_LEGACY_JOB_STATUSES],
+  )
+  return result.rows.length
+}
+
+/**
+ * Entry into eligible|authoritative: lock section 9 — "Promotion drains or cancels every
+ * incomplete org operation before changing posture." `attendance_result_operations`/
+ * `attendance_result_operation_batches` `claimed` rows are NOT the target here: a deferred
+ * commit-time constraint trigger (`attendance_w4_*_claimed_commit_guard`) makes a persisted
+ * `claimed` row provably impossible — no transaction can ever commit while a row it touched is
+ * still `claimed`, so that state is same-transaction-transient only and never durably visible to
+ * this boundary. The durable incompleteness this bullet targets is the async V1 job layer: any
+ * `attendance_import_jobs` row with `w4_contract_version = 1` not yet `completed` (queued,
+ * running, or failed-pending-retry) is an incomplete org operation for promotion purposes.
+ */
+async function countIncompleteOperations(
+  trx: AttendanceW4TransactionClientV1,
+  orgId: string,
+): Promise<number> {
+  const result = await trx.query(
+    `SELECT id
+       FROM attendance_import_jobs
+      WHERE org_id = $1 AND w4_contract_version = 1 AND status <> 'completed'
+      ORDER BY id
+      FOR UPDATE`,
+    [orgId],
+  )
+  return result.rows.length
+}
+
+/**
+ * Entry into eligible|authoritative: zero unresolved `legacy_time_ingress_not_authoritative`
+ * review. A `review_required` calculation is immutable and, by the durable pointer-guard
+ * trigger, can never become a record's `current_calculation_id` (the pointer target must be
+ * `authoritative` + `completed|reversed`), so "unresolved" cannot be defined against the
+ * current pointer. It is instead exact against the append-only calculation history: the review
+ * is unresolved while it remains the LATEST calculation appended for its record. A subsequent
+ * calculation (any outcome) appended for the same record resolves it by definition — the
+ * legacy-resolved instant itself is still never promoted (lock section 9 bullet 8), only
+ * strictly zoned replacement evidence produces that later calculation.
+ */
+async function countUnresolvedIngressReviews(
+  trx: AttendanceW4TransactionClientV1,
+  orgId: string,
+): Promise<number> {
+  const result = await trx.query(
+    `SELECT r.id
+       FROM attendance_records r
+      WHERE r.org_id = $1
+        AND EXISTS (
+          SELECT 1
+            FROM attendance_record_calculations c
+           WHERE c.org_id = $1 AND c.attendance_record_id = r.id
+             AND c.outcome_reason_code = 'legacy_time_ingress_not_authoritative'
+             AND c.version = (
+               SELECT MAX(c2.version)
+                 FROM attendance_record_calculations c2
+                WHERE c2.org_id = $1 AND c2.attendance_record_id = r.id
+             )
+        )
+      ORDER BY r.id
+      FOR UPDATE`,
+    [orgId],
+  )
+  return result.rows.length
+}
+
+/**
+ * Entry into eligible|authoritative: zero pending calculation-affecting request whose latest
+ * snapshot is missing or `unsupported`. This is a narrower, mechanically-verifiable slice of
+ * lock section 9 bullet 5 — it does NOT evaluate the "reversible" (approved-but-cancellable) half
+ * or payload-staleness against live per-type request fields; see the amendment tracking note.
+ */
+async function countDefectivePendingRequestSnapshots(
+  trx: AttendanceW4TransactionClientV1,
+  orgId: string,
+): Promise<number> {
+  const requests = await trx.query(
+    `SELECT id::text AS id
+       FROM attendance_requests
+      WHERE org_id = $1 AND status = 'pending' AND request_type = ANY($2::text[])
+      ORDER BY id
+      FOR UPDATE`,
+    [orgId, ATTENDANCE_CALCULATION_AFFECTING_REQUEST_TYPES_V1 as unknown as string[]],
+  )
+  if (requests.rows.length === 0) return 0
+  let defective = 0
+  for (const request of requests.rows) {
+    const snapshot = await trx.query(
+      `SELECT attribution_snapshot AS "attributionSnapshot"
+         FROM attendance_request_calculation_snapshots
+        WHERE org_id = $1 AND request_id = $2::uuid
+        ORDER BY version DESC
+        LIMIT 1`,
+      [orgId, request.id],
+    )
+    if (snapshot.rows.length === 0) {
+      defective += 1
+      continue
+    }
+    const posture = (snapshot.rows[0].attributionSnapshot as { posture?: unknown } | null)?.posture
+    if (posture !== 'resolved_v2') defective += 1
+  }
+  return defective
 }
 
 function isRetryableControlPrecondition(error: unknown): boolean {
@@ -477,16 +823,69 @@ export async function transitionAttendanceCalculationRolloutV1(
 ): Promise<AttendanceW4C3aRolloutControlResultV1> {
   const input = normalizeTransitionInput(rawInput)
   return runControlTransaction(connection, async (trx) => {
-    await acquireAttendanceCalculationRolloutLock(trx, parseCanonicalAttendanceRolloutOrgKeyV1(input.orgId), 'exclusive')
+    const orgKey = parseCanonicalAttendanceRolloutOrgKeyV1(input.orgId)
+    await acquireAttendanceCalculationRolloutLock(trx, orgKey, 'exclusive')
     await afterExclusiveRolloutLockForTests?.('transition')
-    const currentState = await lockRolloutStateForTransition(trx, input.orgId, input.actorId, input.engineVersion)
+
+    // Section 3 predicate 1: exact named org (`scope='synthetic_staging'` is enforced by the
+    // durable CHECK constraint on every row this boundary can ever write).
+    const orgAllowlisted = isAttendanceCalculationOrgAllowlistedV1(input.orgId)
+    if (!orgAllowlisted) fail('W4C3A_ROLLOUT_CONTROL_ORG_NOT_ALLOWLISTED')
+
+    const persisted = await lockRolloutStateForBootstrapOrRead(
+      trx,
+      input.orgId,
+      input.actorId,
+      input.engineVersion,
+      input.expectedState,
+      input.targetState,
+      orgAllowlisted,
+    )
+
+    // Section 2.4 / completion gate 4: a stale caller belief about current state/version is
+    // rejected under lock, with zero rollout DML, even though the input-time matrix check
+    // already passed against the CLAIMED pair.
+    if (persisted.state !== input.expectedState || persisted.version !== input.expectedVersion) {
+      fail('W4C3A_ROLLOUT_CONTROL_STALE_EXPECTED_STATE')
+    }
+    const currentState = persisted.state
+    // Re-derive from the authoritative post-lock state (identical to the input-time check by
+    // construction once staleness has been ruled out, but never trusts the caller's claim alone).
+    const legal = findLegalTransition(currentState, input.targetState)
+    if (!legal) fail('W4C3A_ROLLOUT_CONTROL_ILLEGAL_TRANSITION')
+
     const batchIds = await allOrgBatchIds(trx, input.orgId)
     await lockControlDomain(trx, input.orgId, batchIds)
     for (const batchId of batchIds) {
       const state = await loadBatchReferenceState(trx, input.orgId, batchId)
       if (!state.closed && !state.hasFrozenPreimage) fail('W4C3A_ROLLOUT_CONTROL_UNCLOSED_BATCH')
     }
-    if (currentState === input.targetState) fail('W4C3A_ROLLOUT_CONTROL_TRANSITION_CONFLICT')
+
+    const retryableJobMismatches = await countRetryableJobPostureMismatches(
+      trx,
+      input.orgId,
+      legal.comparisonWritePosture,
+    )
+    if (retryableJobMismatches > 0) fail('W4C3A_ROLLOUT_CONTROL_RETRYABLE_JOB_POSTURE_MISMATCH')
+
+    let nonterminalLegacyJobs = 0
+    if (CALCULATION_ENTRY_TARGETS.has(input.targetState)) {
+      nonterminalLegacyJobs = await countNonterminalNullVersionLegacyJobs(trx, input.orgId)
+      if (nonterminalLegacyJobs > 0) fail('W4C3A_ROLLOUT_CONTROL_LEGACY_JOB_ACTIVE')
+    }
+
+    let incompleteOperations = 0
+    let unresolvedReviews = 0
+    let defectiveRequestSnapshots = 0
+    if (ELIGIBILITY_AUTHORITY_TARGETS.has(input.targetState)) {
+      incompleteOperations = await countIncompleteOperations(trx, input.orgId)
+      if (incompleteOperations > 0) fail('W4C3A_ROLLOUT_CONTROL_INCOMPLETE_OPERATION')
+      unresolvedReviews = await countUnresolvedIngressReviews(trx, input.orgId)
+      if (unresolvedReviews > 0) fail('W4C3A_ROLLOUT_CONTROL_UNRESOLVED_REVIEW')
+      defectiveRequestSnapshots = await countDefectivePendingRequestSnapshots(trx, input.orgId)
+      if (defectiveRequestSnapshots > 0) fail('W4C3A_ROLLOUT_CONTROL_REQUEST_SNAPSHOT_DEFECTIVE')
+    }
+
     await trx.query(
       `UPDATE attendance_calculation_rollout_state
           SET state = $2, prior_state = state, engine_version = $3, reason_code = $4,
@@ -494,11 +893,33 @@ export async function transitionAttendanceCalculationRolloutV1(
         WHERE org_id = $1`,
       [input.orgId, input.targetState, input.engineVersion, input.reasonCode, input.actorId],
     )
+    await beforeEventInsertForTests?.()
     await trx.query(
       `INSERT INTO attendance_calculation_rollout_events
        (org_id, prior_state, new_state, reason_code, engine_version, actor_id, evidence)
-       VALUES ($1, $2, $3, $4, $5, $6, '{}'::jsonb)`,
-      [input.orgId, currentState, input.targetState, input.reasonCode, input.engineVersion, input.actorId],
+       VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb)`,
+      [
+        input.orgId,
+        currentState,
+        input.targetState,
+        input.reasonCode,
+        input.engineVersion,
+        input.actorId,
+        JSON.stringify({
+          schemaVersion: 1,
+          manifestSha256: input.evidenceManifestSha256,
+          correlationId: input.correlationId,
+          comparisonWritePosture: legal.comparisonWritePosture,
+          preconditionCounts: {
+            retryableJobPostureMismatches: retryableJobMismatches,
+            nonterminalLegacyJobs,
+            incompleteOperations,
+            unresolvedReviews,
+            defectiveRequestSnapshots,
+          },
+          references: input.evidenceReferences,
+        }),
+      ],
     )
     return Object.freeze({ orgId: input.orgId, state: input.targetState, batchId: null })
   })

--- a/packages/core-backend/src/attendance/w4c3a-rollout-control.ts
+++ b/packages/core-backend/src/attendance/w4c3a-rollout-control.ts
@@ -874,8 +874,10 @@ export async function transitionAttendanceCalculationRolloutV1(
   // transaction — is what makes every section 3 predicate below actually re-evaluate a snapshot
   // that postdates the wait.
   await acquireAttendanceCalculationRolloutLockSessionExclusiveV1(connection, orgKey)
-  await afterExclusiveRolloutLockForTests?.('transition')
   try {
+    // Inside the try (not before it): a throwing test hook must still release the lock via the
+    // `finally` below, not leak it.
+    await afterExclusiveRolloutLockForTests?.('transition')
     return await runControlTransaction(connection, async (trx) => {
       // Section 3 predicate 1: exact named org (`scope='synthetic_staging'` is enforced by the
       // durable CHECK constraint on every row this boundary can ever write).
@@ -980,9 +982,18 @@ export async function transitionAttendanceCalculationRolloutV1(
     })
   } finally {
     // Released unconditionally, including on the input-validation/staleness/predicate-failure
-    // paths above (all of which throw): a busy-error 503 is the correct outward-facing outcome
-    // for lock-timeout expiry, but a normal success or precondition rejection must never leave
-    // the session holding this lock for the next checkout of this pooled connection.
-    await releaseAttendanceCalculationRolloutLockSessionExclusiveV1(connection, orgKey)
+    // paths above (all of which throw): a normal success or precondition rejection must never
+    // leave the session holding this lock for the next checkout of this pooled connection.
+    //
+    // The `.catch(() => undefined)` is deliberate, not sloppy: a `finally` block that itself
+    // throws REPLACES whatever the `try` block returned or threw — so an unguarded release
+    // failure here (e.g. a dropped connection) would turn an already-COMMITTED transition into
+    // a thrown exception, or replace a typed `W4C3A_ROLLOUT_CONTROL_*` predicate rejection with
+    // an opaque connection error. Both are strictly worse than a lock outliving this call by one
+    // dropped-connection's remaining lifetime — and PostgreSQL still releases every session-level
+    // advisory lock automatically once the server observes that connection close (see
+    // `acquireAttendanceCalculationRolloutLockSessionExclusiveV1`'s doc comment), so nothing here
+    // is a permanent leak even when the release call itself fails.
+    await releaseAttendanceCalculationRolloutLockSessionExclusiveV1(connection, orgKey).catch(() => undefined)
   }
 }

--- a/packages/core-backend/src/attendance/w4c3a-rollout-control.ts
+++ b/packages/core-backend/src/attendance/w4c3a-rollout-control.ts
@@ -14,6 +14,7 @@
  */
 import {
   acquireAttendanceCalculationRolloutLock,
+  acquireAttendanceCalculationRolloutLockSessionExclusiveV1,
   acquireAttendanceCalculationTargetLocks,
   acquireAttendanceResultOperationLocks,
   createVerifiedAttendanceCalculationTargetIdentityV1,
@@ -21,6 +22,7 @@ import {
   parseCanonicalAttendanceRolloutOrgKeyV1,
   rehydrateVerifiedAttendanceOperationIdentityV1,
   rehydrateVerifiedAttendanceOrgIdentityV1,
+  releaseAttendanceCalculationRolloutLockSessionExclusiveV1,
   type AttendanceAcceptedWritePostureV1,
   type AttendanceRolloutStateV1,
   type AttendanceW4TransactionClientV1,
@@ -624,11 +626,27 @@ async function allOrgBatchIds(trx: AttendanceW4TransactionClientV1, orgId: strin
 
 // ---------------------------------------------------------------------------
 // Amendment section 3: additional database-backed transition predicates.
-// Each locks (`FOR UPDATE`) the exact rows it inspects so a concurrent writer
-// targeting the same rows blocks behind this transaction rather than racing
-// its read. Every helper returns a values-free count; the caller decides
-// applicability per the requested pair and fails closed with zero rollout DML
-// before any predicate short-circuits.
+//
+// RETRACTION (W4C-5 P1-2, PR #4773 exact-head independent gate, 20260805): this block
+// previously asserted "each locks (`FOR UPDATE`) the exact rows it inspects so a concurrent
+// writer targeting the same rows blocks behind this transaction rather than racing its read."
+// That is false for every predicate here: each is INSERT-shaped (a brand-new
+// attendance_import_jobs/attendance_records/attendance_record_calculations/attendance_requests
+// row that did not exist in the snapshot), and `FOR UPDATE` only re-fetches the latest committed
+// version of rows ALREADY visible to the transaction's snapshot — it cannot retroactively admit,
+// or block the creation of, a row inserted after that snapshot was taken. What actually makes
+// these reads trustworthy is `transitionAttendanceCalculationRolloutV1` acquiring the org
+// rollout lock EXCLUSIVE at SESSION level, in its own statement, strictly before
+// `BEGIN ISOLATION LEVEL SERIALIZABLE` is issued (see
+// `acquireAttendanceCalculationRolloutLockSessionExclusiveV1` in w4c0-identity.ts) — this
+// guarantees the SERIALIZABLE snapshot these predicates read under is taken strictly after every
+// previous SHARED-lock holder (every legitimate job/record/request writer, lock section 9)
+// released, so their commits are visible here. `FOR UPDATE` remains correct and load-bearing for
+// its original purpose (re-evaluating UPDATE-shaped drift on rows already in scope), just not for
+// admitting new rows.
+//
+// Every helper returns a values-free count; the caller decides applicability per the requested
+// pair and fails closed with zero rollout DML before any predicate short-circuits.
 // ---------------------------------------------------------------------------
 
 /** Every rollout transition: every retryable V1 job's frozen posture must equal the pair's. */
@@ -774,10 +792,21 @@ function isRetryableControlPrecondition(error: unknown): boolean {
 }
 
 /**
- * An advisory-lock waiter can retain a SERIALIZABLE snapshot from before the
- * holder committed. The first post-lock precondition failure therefore gets
- * one whole-transaction retry; a genuinely invalid control action fails again
- * from a fresh snapshot. This is control-plane only and never retries DML.
+ * A caller that acquires its exclusive rollout lock with `pg_advisory_xact_lock` INSIDE an
+ * already-BEGUN SERIALIZABLE transaction (`closeLegacyRollbackWindowV1`, unchanged by W4C-5 —
+ * its lock section 9 predicates are the batch-closure ones, out of this amendment's scope) can
+ * retain a snapshot from before the previous holder committed, because PostgreSQL fixes a
+ * SERIALIZABLE snapshot at the START of the first statement executed — including one that
+ * itself blocks. The first post-lock precondition failure therefore gets one whole-transaction
+ * retry for that caller; a genuinely invalid control action fails again from a fresh snapshot.
+ *
+ * `transitionAttendanceCalculationRolloutV1` no longer depends on this retry for that purpose
+ * (W4C-5 P1-2 fix): it acquires its exclusive lock at SESSION level, in its own statement,
+ * strictly before this function is ever called — see
+ * `acquireAttendanceCalculationRolloutLockSessionExclusiveV1` in w4c0-identity.ts — so the
+ * transaction `runAttendanceResultOperationTransactionV1` opens here always has a snapshot that
+ * postdates the wait. The retry remains in place for it too, as defense-in-depth against any
+ * other transient SQLSTATE 40001/40P01-adjacent precondition race, never for DML.
  */
 async function runControlTransaction<T>(
   connection: AttendanceW4TransactionClientV1,
@@ -834,110 +863,126 @@ export async function transitionAttendanceCalculationRolloutV1(
   rawInput: TransitionAttendanceCalculationRolloutInputV1,
 ): Promise<AttendanceW4C3aRolloutControlResultV1> {
   const input = normalizeTransitionInput(rawInput)
-  return runControlTransaction(connection, async (trx) => {
-    const orgKey = parseCanonicalAttendanceRolloutOrgKeyV1(input.orgId)
-    await acquireAttendanceCalculationRolloutLock(trx, orgKey, 'exclusive')
-    await afterExclusiveRolloutLockForTests?.('transition')
+  const orgKey = parseCanonicalAttendanceRolloutOrgKeyV1(input.orgId)
+  // W4C-5 P1-2 fix: the exclusive rollout lock is acquired at SESSION level, as its own
+  // standalone statement, strictly BEFORE `BEGIN ISOLATION LEVEL SERIALIZABLE` is ever issued
+  // on this connection (`runControlTransaction` -> `runAttendanceResultOperationTransactionV1`
+  // opens that transaction). `connection` must therefore be idle (no open transaction) on
+  // entry — the same precondition the function already had, since it always opened its own
+  // transaction. See `acquireAttendanceCalculationRolloutLockSessionExclusiveV1`'s doc comment
+  // for why this — and not any transaction-scoped acquisition, no matter how early inside the
+  // transaction — is what makes every section 3 predicate below actually re-evaluate a snapshot
+  // that postdates the wait.
+  await acquireAttendanceCalculationRolloutLockSessionExclusiveV1(connection, orgKey)
+  await afterExclusiveRolloutLockForTests?.('transition')
+  try {
+    return await runControlTransaction(connection, async (trx) => {
+      // Section 3 predicate 1: exact named org (`scope='synthetic_staging'` is enforced by the
+      // durable CHECK constraint on every row this boundary can ever write).
+      const orgAllowlisted = isAttendanceCalculationOrgAllowlistedV1(input.orgId)
+      if (!orgAllowlisted) fail('W4C3A_ROLLOUT_CONTROL_ORG_NOT_ALLOWLISTED')
 
-    // Section 3 predicate 1: exact named org (`scope='synthetic_staging'` is enforced by the
-    // durable CHECK constraint on every row this boundary can ever write).
-    const orgAllowlisted = isAttendanceCalculationOrgAllowlistedV1(input.orgId)
-    if (!orgAllowlisted) fail('W4C3A_ROLLOUT_CONTROL_ORG_NOT_ALLOWLISTED')
-
-    const persisted = await lockRolloutStateForBootstrapOrRead(
-      trx,
-      input.orgId,
-      input.actorId,
-      input.engineVersion,
-      input.expectedState,
-      input.targetState,
-      orgAllowlisted,
-    )
-
-    // Section 2.4 / completion gate 4: a stale caller belief about current state/version is
-    // rejected under lock, with zero rollout DML, even though the input-time matrix check
-    // already passed against the CLAIMED pair.
-    if (persisted.state !== input.expectedState || persisted.version !== input.expectedVersion) {
-      fail('W4C3A_ROLLOUT_CONTROL_STALE_EXPECTED_STATE')
-    }
-    const currentState = persisted.state
-    // Re-derive from the authoritative post-lock state (identical to the input-time check by
-    // construction once staleness has been ruled out, but never trusts the caller's claim alone).
-    const legal = findLegalTransition(currentState, input.targetState)
-    if (!legal) fail('W4C3A_ROLLOUT_CONTROL_ILLEGAL_TRANSITION')
-
-    const batchIds = await allOrgBatchIds(trx, input.orgId)
-    await lockControlDomain(trx, input.orgId, batchIds)
-    for (const batchId of batchIds) {
-      const state = await loadBatchReferenceState(trx, input.orgId, batchId)
-      if (!state.closed && !state.hasFrozenPreimage) fail('W4C3A_ROLLOUT_CONTROL_UNCLOSED_BATCH')
-    }
-
-    const retryableJobMismatches = await countRetryableJobPostureMismatches(
-      trx,
-      input.orgId,
-      legal.comparisonWritePosture,
-    )
-    if (retryableJobMismatches > 0) fail('W4C3A_ROLLOUT_CONTROL_RETRYABLE_JOB_POSTURE_MISMATCH')
-
-    let nonterminalLegacyJobs = 0
-    if (CALCULATION_ENTRY_TARGETS.has(input.targetState)) {
-      nonterminalLegacyJobs = await countNonterminalNullVersionLegacyJobs(trx, input.orgId)
-      if (nonterminalLegacyJobs > 0) fail('W4C3A_ROLLOUT_CONTROL_LEGACY_JOB_ACTIVE')
-    }
-
-    let incompleteOperations = 0
-    let unresolvedReviews = 0
-    let defectiveRequestSnapshots = 0
-    if (ELIGIBILITY_AUTHORITY_TARGETS.has(input.targetState)) {
-      incompleteOperations = await countIncompleteOperations(trx, input.orgId)
-      if (incompleteOperations > 0) fail('W4C3A_ROLLOUT_CONTROL_INCOMPLETE_OPERATION')
-      unresolvedReviews = await countUnresolvedIngressReviews(trx, input.orgId)
-      if (unresolvedReviews > 0) fail('W4C3A_ROLLOUT_CONTROL_UNRESOLVED_REVIEW')
-      defectiveRequestSnapshots = await countDefectivePendingRequestSnapshots(trx, input.orgId)
-      if (defectiveRequestSnapshots > 0) fail('W4C3A_ROLLOUT_CONTROL_REQUEST_SNAPSHOT_DEFECTIVE')
-    }
-
-    // Section 2.8 literal order: the event insert is attempted FIRST; the rollout-state UPDATE
-    // happens only after it succeeds. Both share one transaction, so either order is atomic —
-    // a failure at any point rolls back both — but this ordering also lets a same-transaction
-    // failure-injection hook independently exercise each of gate 7's two clauses.
-    await beforeEventInsertForTests?.()
-    await trx.query(
-      `INSERT INTO attendance_calculation_rollout_events
-       (org_id, prior_state, new_state, reason_code, engine_version, actor_id, evidence)
-       VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb)`,
-      [
+      const persisted = await lockRolloutStateForBootstrapOrRead(
+        trx,
         input.orgId,
-        currentState,
-        input.targetState,
-        input.reasonCode,
-        input.engineVersion,
         input.actorId,
-        JSON.stringify({
-          schemaVersion: 1,
-          manifestSha256: input.evidenceManifestSha256,
-          correlationId: input.correlationId,
-          comparisonWritePosture: legal.comparisonWritePosture,
-          preconditionCounts: {
-            retryableJobPostureMismatches: retryableJobMismatches,
-            nonterminalLegacyJobs,
-            incompleteOperations,
-            unresolvedReviews,
-            defectiveRequestSnapshots,
-          },
-          references: input.evidenceReferences,
-        }),
-      ],
-    )
-    await beforeStateUpdateForTests?.()
-    await trx.query(
-      `UPDATE attendance_calculation_rollout_state
-          SET state = $2, prior_state = state, engine_version = $3, reason_code = $4,
-              actor_id = $5, changed_at = now(), version = version + 1
-        WHERE org_id = $1`,
-      [input.orgId, input.targetState, input.engineVersion, input.reasonCode, input.actorId],
-    )
-    return Object.freeze({ orgId: input.orgId, state: input.targetState, batchId: null })
-  })
+        input.engineVersion,
+        input.expectedState,
+        input.targetState,
+        orgAllowlisted,
+      )
+
+      // Section 2.4 / completion gate 4: a stale caller belief about current state/version is
+      // rejected under lock, with zero rollout DML, even though the input-time matrix check
+      // already passed against the CLAIMED pair.
+      if (persisted.state !== input.expectedState || persisted.version !== input.expectedVersion) {
+        fail('W4C3A_ROLLOUT_CONTROL_STALE_EXPECTED_STATE')
+      }
+      const currentState = persisted.state
+      // Re-derive from the authoritative post-lock state (identical to the input-time check by
+      // construction once staleness has been ruled out, but never trusts the caller's claim alone).
+      const legal = findLegalTransition(currentState, input.targetState)
+      if (!legal) fail('W4C3A_ROLLOUT_CONTROL_ILLEGAL_TRANSITION')
+
+      const batchIds = await allOrgBatchIds(trx, input.orgId)
+      await lockControlDomain(trx, input.orgId, batchIds)
+      for (const batchId of batchIds) {
+        const state = await loadBatchReferenceState(trx, input.orgId, batchId)
+        if (!state.closed && !state.hasFrozenPreimage) fail('W4C3A_ROLLOUT_CONTROL_UNCLOSED_BATCH')
+      }
+
+      const retryableJobMismatches = await countRetryableJobPostureMismatches(
+        trx,
+        input.orgId,
+        legal.comparisonWritePosture,
+      )
+      if (retryableJobMismatches > 0) fail('W4C3A_ROLLOUT_CONTROL_RETRYABLE_JOB_POSTURE_MISMATCH')
+
+      let nonterminalLegacyJobs = 0
+      if (CALCULATION_ENTRY_TARGETS.has(input.targetState)) {
+        nonterminalLegacyJobs = await countNonterminalNullVersionLegacyJobs(trx, input.orgId)
+        if (nonterminalLegacyJobs > 0) fail('W4C3A_ROLLOUT_CONTROL_LEGACY_JOB_ACTIVE')
+      }
+
+      let incompleteOperations = 0
+      let unresolvedReviews = 0
+      let defectiveRequestSnapshots = 0
+      if (ELIGIBILITY_AUTHORITY_TARGETS.has(input.targetState)) {
+        incompleteOperations = await countIncompleteOperations(trx, input.orgId)
+        if (incompleteOperations > 0) fail('W4C3A_ROLLOUT_CONTROL_INCOMPLETE_OPERATION')
+        unresolvedReviews = await countUnresolvedIngressReviews(trx, input.orgId)
+        if (unresolvedReviews > 0) fail('W4C3A_ROLLOUT_CONTROL_UNRESOLVED_REVIEW')
+        defectiveRequestSnapshots = await countDefectivePendingRequestSnapshots(trx, input.orgId)
+        if (defectiveRequestSnapshots > 0) fail('W4C3A_ROLLOUT_CONTROL_REQUEST_SNAPSHOT_DEFECTIVE')
+      }
+
+      // Section 2.8 literal order: the event insert is attempted FIRST; the rollout-state UPDATE
+      // happens only after it succeeds. Both share one transaction, so either order is atomic —
+      // a failure at any point rolls back both — but this ordering also lets a same-transaction
+      // failure-injection hook independently exercise each of gate 7's two clauses.
+      await beforeEventInsertForTests?.()
+      await trx.query(
+        `INSERT INTO attendance_calculation_rollout_events
+         (org_id, prior_state, new_state, reason_code, engine_version, actor_id, evidence)
+         VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb)`,
+        [
+          input.orgId,
+          currentState,
+          input.targetState,
+          input.reasonCode,
+          input.engineVersion,
+          input.actorId,
+          JSON.stringify({
+            schemaVersion: 1,
+            manifestSha256: input.evidenceManifestSha256,
+            correlationId: input.correlationId,
+            comparisonWritePosture: legal.comparisonWritePosture,
+            preconditionCounts: {
+              retryableJobPostureMismatches: retryableJobMismatches,
+              nonterminalLegacyJobs,
+              incompleteOperations,
+              unresolvedReviews,
+              defectiveRequestSnapshots,
+            },
+            references: input.evidenceReferences,
+          }),
+        ],
+      )
+      await beforeStateUpdateForTests?.()
+      await trx.query(
+        `UPDATE attendance_calculation_rollout_state
+            SET state = $2, prior_state = state, engine_version = $3, reason_code = $4,
+                actor_id = $5, changed_at = now(), version = version + 1
+          WHERE org_id = $1`,
+        [input.orgId, input.targetState, input.engineVersion, input.reasonCode, input.actorId],
+      )
+      return Object.freeze({ orgId: input.orgId, state: input.targetState, batchId: null })
+    })
+  } finally {
+    // Released unconditionally, including on the input-validation/staleness/predicate-failure
+    // paths above (all of which throw): a busy-error 503 is the correct outward-facing outcome
+    // for lock-timeout expiry, but a normal success or precondition rejection must never leave
+    // the session holding this lock for the next checkout of this pooled connection.
+    await releaseAttendanceCalculationRolloutLockSessionExclusiveV1(connection, orgKey)
+  }
 }

--- a/packages/core-backend/src/attendance/w4c3a-rollout-control.ts
+++ b/packages/core-backend/src/attendance/w4c3a-rollout-control.ts
@@ -11,6 +11,13 @@
  * competing implementation exists. Preparation/tooling (a separate,
  * independently gated PR) may only call this boundary — it must never touch
  * rollout DML directly.
+ *
+ * NIT-4 (PR #4773 exact-head independent gate, 20260805): "ONLY transition DML path" is exact
+ * for `attendance_calculation_rollout_state` (`transitionAttendanceCalculationRolloutV1` is its
+ * one writer). `closeLegacyRollbackWindowV1` in this same module is a SECOND writer of
+ * `attendance_calculation_rollout_events` (never of rollout STATE) — a distinct, pre-existing,
+ * unchanged-by-this-amendment operation. Precisely: this module is the only rollout-state DML
+ * path, and the only place either rollout table may ever be written from.
  */
 import {
   acquireAttendanceCalculationRolloutLock,
@@ -751,6 +758,14 @@ async function countIncompleteOperations(
  * calculation (any outcome) appended for the same record resolves it by definition — the
  * legacy-resolved instant itself is still never promoted (lock section 9 bullet 8), only
  * strictly zoned replacement evidence produces that later calculation.
+ *
+ * P3-1 (PR #4773 exact-head independent gate, 20260805): "resolves it by definition" is
+ * deliberately outcome-agnostic — a later `review_required` calculation appended for a
+ * DIFFERENT reason (e.g. `duplicate_check_in`, not `legacy_time_ingress_not_authoritative`)
+ * still clears THIS predicate, because that later row is now the MAX(version) row and the
+ * original `legacy_time_ingress_not_authoritative` row is no longer it. The record remains
+ * unadjudicated in that case; this predicate is not the sole gate on record-level
+ * adjudication, only on the specific legacy-ingress review this bullet names.
  */
 async function countUnresolvedIngressReviews(
   trx: AttendanceW4TransactionClientV1,
@@ -913,7 +928,17 @@ export async function transitionAttendanceCalculationRolloutV1(
     await afterExclusiveRolloutLockForTests?.('transition')
     return await runControlTransaction(connection, async (trx) => {
       // Section 3 predicate 1: exact named org (`scope='synthetic_staging'` is enforced by the
-      // durable CHECK constraint on every row this boundary can ever write).
+      // durable CHECK constraint on every row this boundary can ever write). P3-2 (PR #4773
+      // exact-head independent gate, 20260805): this boundary itself only ever writes the
+      // hardcoded literal 'synthetic_staging' (see `lockRolloutStateForBootstrapOrRead`'s
+      // bootstrap INSERT below) — it never reads or application-validates `scope` the way the
+      // canonical posture resolver does (`w4c0-identity.ts`, `fail('W4C0_ROLLOUT_SCOPE_INVALID')`).
+      // That is asymmetric, not currently unsafe: a future widening of the DDL CHECK constraint
+      // (`chk_acrs_scope`) would silently remove the ONLY thing standing between this write path
+      // and a non-synthetic-staging row, since there is no independent application-level check
+      // here to catch it. Flagged, not fixed here — adding a check against the current hardcoded
+      // literal would be tautological; a real fix needs `scope` to become a live input this
+      // boundary actually validates, which is a larger change than this amendment's scope.
       const orgAllowlisted = isAttendanceCalculationOrgAllowlistedV1(input.orgId)
       if (!orgAllowlisted) fail('W4C3A_ROLLOUT_CONTROL_ORG_NOT_ALLOWLISTED')
 
@@ -934,8 +959,15 @@ export async function transitionAttendanceCalculationRolloutV1(
         fail('W4C3A_ROLLOUT_CONTROL_STALE_EXPECTED_STATE')
       }
       const currentState = persisted.state
-      // Re-derive from the authoritative post-lock state (identical to the input-time check by
-      // construction once staleness has been ruled out, but never trusts the caller's claim alone).
+      // Re-derive from the authoritative post-lock state. NIT-1 (PR #4773 exact-head independent
+      // gate, 20260805): once the staleness check above has passed, `currentState` is provably
+      // identical to `input.expectedState` (the pair already matrix-validated at input time in
+      // `normalizeTransitionInput`), so this second `findLegalTransition` call is unreachable
+      // dead code on any live path today — mutating it away leaves every test green. It is kept
+      // deliberately as defense-in-depth against a future refactor that decouples `currentState`
+      // from the staleness check above (e.g. reordering, or a new code path that reaches here
+      // without going through `lockRolloutStateForBootstrapOrRead`'s exact-match guard) — never
+      // trusts the caller's claim alone, only currently redundant with it.
       const legal = findLegalTransition(currentState, input.targetState)
       if (!legal) fail('W4C3A_ROLLOUT_CONTROL_ILLEGAL_TRANSITION')
 

--- a/packages/core-backend/src/attendance/w4c3a-rollout-control.ts
+++ b/packages/core-backend/src/attendance/w4c3a-rollout-control.ts
@@ -666,6 +666,39 @@ async function countRetryableJobPostureMismatches(
   return result.rows.filter((row) => row.posture !== comparisonWritePosture).length
 }
 
+/**
+ * Resume only (`suspended -> authoritative`): amendment section 3 bullet 9 — "preserved
+ * authoritative jobs remain retryable WITHOUT operation rows". A retryable V1 job
+ * (`status IN ('queued','failed')`) that already has a durable `attendance_result_operations`
+ * row for the SAME batch (`org_id` + `entrypoint` + `batch_command_id`/`w4_batch_command_id`)
+ * already went through the async result-operation path at least once for that batch — per
+ * "Correction 1" (`OPERATION_STATES = ['claimed','completed','canceled']`, deferred
+ * commit-time constraint trigger), any such PERSISTED row is necessarily `completed` or
+ * `canceled` (never `claimed`), so this is not a race with an in-flight claim; it is a durable
+ * signal that this "retryable" job is not the untouched, purely-retryable job resume's
+ * "remain retryable without operation rows" language requires. `FOR UPDATE OF j` locks only the
+ * candidate job rows (the operation rows are immutable history once persisted, per the same
+ * correction, so there is nothing on that side for a concurrent writer to race).
+ */
+async function countRetryableJobsWithOperationRows(
+  trx: AttendanceW4TransactionClientV1,
+  orgId: string,
+): Promise<number> {
+  const result = await trx.query(
+    `SELECT j.id
+       FROM attendance_import_jobs j
+       JOIN attendance_result_operations o
+         ON o.org_id = j.org_id
+        AND o.entrypoint = j.w4_entrypoint
+        AND o.batch_command_id = j.w4_batch_command_id
+      WHERE j.org_id = $1 AND j.w4_contract_version = 1 AND j.status = ANY($2::text[])
+      ORDER BY j.id
+      FOR UPDATE OF j`,
+    [orgId, RETRYABLE_JOB_STATUSES],
+  )
+  return result.rows.length
+}
+
 /** Entry into shadow|eligible|authoritative: zero nonterminal null-version legacy job. */
 async function countNonterminalNullVersionLegacyJobs(
   trx: AttendanceW4TransactionClientV1,
@@ -920,6 +953,14 @@ export async function transitionAttendanceCalculationRolloutV1(
       )
       if (retryableJobMismatches > 0) fail('W4C3A_ROLLOUT_CONTROL_RETRYABLE_JOB_POSTURE_MISMATCH')
 
+      // Resume only (suspended -> authoritative), section 3 bullet 9 (P2-4, PR #4773 gate):
+      // "preserved authoritative jobs remain retryable WITHOUT operation rows."
+      let retryableJobsWithOperationRows = 0
+      if (isResumePair(currentState, input.targetState)) {
+        retryableJobsWithOperationRows = await countRetryableJobsWithOperationRows(trx, input.orgId)
+        if (retryableJobsWithOperationRows > 0) fail('W4C3A_ROLLOUT_CONTROL_RETRYABLE_JOB_HAS_OPERATION_ROWS')
+      }
+
       let nonterminalLegacyJobs = 0
       if (CALCULATION_ENTRY_TARGETS.has(input.targetState)) {
         nonterminalLegacyJobs = await countNonterminalNullVersionLegacyJobs(trx, input.orgId)
@@ -961,6 +1002,7 @@ export async function transitionAttendanceCalculationRolloutV1(
             comparisonWritePosture: legal.comparisonWritePosture,
             preconditionCounts: {
               retryableJobPostureMismatches: retryableJobMismatches,
+              retryableJobsWithOperationRows,
               nonterminalLegacyJobs,
               incompleteOperations,
               unresolvedReviews,

--- a/packages/core-backend/src/attendance/w4c3a-rollout-control.ts
+++ b/packages/core-backend/src/attendance/w4c3a-rollout-control.ts
@@ -184,6 +184,7 @@ type BatchReferenceState = Readonly<{
 
 let afterExclusiveRolloutLockForTests: ((kind: 'close' | 'transition') => Promise<void>) | null = null
 let beforeEventInsertForTests: (() => Promise<void>) | null = null
+let beforeStateUpdateForTests: (() => Promise<void>) | null = null
 
 /** Test-only deterministic barrier. It is not imported by production wiring. */
 export function __setW4C3aRolloutControlAfterExclusiveLockForTests(
@@ -193,14 +194,25 @@ export function __setW4C3aRolloutControlAfterExclusiveLockForTests(
 }
 
 /**
- * Test-only atomicity seam (amendment completion gate 7): fires after the
- * rollout-state UPDATE and before the rollout-event INSERT, in the same
- * transaction. It is not imported by production wiring.
+ * Test-only atomicity seam (amendment completion gate 7, clause "a failed event insert leaves
+ * state/version unchanged"): fires immediately before the rollout-event INSERT (the first DML of
+ * the pair). It is not imported by production wiring.
  */
 export function __setW4C3aRolloutControlBeforeEventInsertForTests(
   hook: (() => Promise<void>) | null,
 ): void {
   beforeEventInsertForTests = hook
+}
+
+/**
+ * Test-only atomicity seam (amendment completion gate 7, clause "a failed state update leaves no
+ * event"): fires after the rollout-event INSERT succeeds but before the rollout-state UPDATE (the
+ * second DML of the pair). It is not imported by production wiring.
+ */
+export function __setW4C3aRolloutControlBeforeStateUpdateForTests(
+  hook: (() => Promise<void>) | null,
+): void {
+  beforeStateUpdateForTests = hook
 }
 
 function requireUuid(value: unknown, code: string): string {
@@ -886,13 +898,10 @@ export async function transitionAttendanceCalculationRolloutV1(
       if (defectiveRequestSnapshots > 0) fail('W4C3A_ROLLOUT_CONTROL_REQUEST_SNAPSHOT_DEFECTIVE')
     }
 
-    await trx.query(
-      `UPDATE attendance_calculation_rollout_state
-          SET state = $2, prior_state = state, engine_version = $3, reason_code = $4,
-              actor_id = $5, changed_at = now(), version = version + 1
-        WHERE org_id = $1`,
-      [input.orgId, input.targetState, input.engineVersion, input.reasonCode, input.actorId],
-    )
+    // Section 2.8 literal order: the event insert is attempted FIRST; the rollout-state UPDATE
+    // happens only after it succeeds. Both share one transaction, so either order is atomic —
+    // a failure at any point rolls back both — but this ordering also lets a same-transaction
+    // failure-injection hook independently exercise each of gate 7's two clauses.
     await beforeEventInsertForTests?.()
     await trx.query(
       `INSERT INTO attendance_calculation_rollout_events
@@ -920,6 +929,14 @@ export async function transitionAttendanceCalculationRolloutV1(
           references: input.evidenceReferences,
         }),
       ],
+    )
+    await beforeStateUpdateForTests?.()
+    await trx.query(
+      `UPDATE attendance_calculation_rollout_state
+          SET state = $2, prior_state = state, engine_version = $3, reason_code = $4,
+              actor_id = $5, changed_at = now(), version = version + 1
+        WHERE org_id = $1`,
+      [input.orgId, input.targetState, input.engineVersion, input.reasonCode, input.actorId],
     )
     return Object.freeze({ orgId: input.orgId, state: input.targetState, batchId: null })
   })

--- a/packages/core-backend/src/attendance/w4c3a-rollout-control.ts
+++ b/packages/core-backend/src/attendance/w4c3a-rollout-control.ts
@@ -920,7 +920,11 @@ export async function transitionAttendanceCalculationRolloutV1(
   // transaction. See `acquireAttendanceCalculationRolloutLockSessionExclusiveV1`'s doc comment
   // for why this — and not any transaction-scoped acquisition, no matter how early inside the
   // transaction — is what makes every section 3 predicate below actually re-evaluate a snapshot
-  // that postdates the wait.
+  // that postdates the wait. W4C-5 NEW-B hardening (PR #4773 gate, 20260805): that idle
+  // precondition is no longer a comment-only claim — `acquireAttendanceCalculationRolloutLockSessionExclusiveV1`
+  // now proves it (a `SAVEPOINT` probe) as its own first statement and fails closed with
+  // `W4C0_ROLLOUT_LOCK_CONNECTION_NOT_IDLE` rather than silently running inside the caller's
+  // pre-fixed snapshot.
   await acquireAttendanceCalculationRolloutLockSessionExclusiveV1(connection, orgKey)
   try {
     // Inside the try (not before it): a throwing test hook must still release the lock via the

--- a/packages/core-backend/src/attendance/w4c3b-request-snapshots.ts
+++ b/packages/core-backend/src/attendance/w4c3b-request-snapshots.ts
@@ -127,6 +127,13 @@ const REQUEST_TYPES = Object.freeze([
   'schedule_dispatch',
 ] as const)
 
+/**
+ * W4C-5 transition-safety amendment section 3: the rollout-control eligibility/authority
+ * predicate reuses this exact closed calculation-affecting request-type set rather than a
+ * second copied list, so the two callers cannot silently diverge.
+ */
+export const ATTENDANCE_CALCULATION_AFFECTING_REQUEST_TYPES_V1 = REQUEST_TYPES
+
 export type AttendanceRequestSnapshotRequestTypeV1 =
   (typeof REQUEST_TYPES)[number]
 

--- a/packages/core-backend/tests/integration/attendance-w4c3a-import-rollback.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-w4c3a-import-rollback.db.test.ts
@@ -30,6 +30,7 @@ import {
   __setW4C3aRolloutControlAfterExclusiveLockForTests,
   closeLegacyRollbackWindowV1,
   transitionAttendanceCalculationRolloutV1,
+  type EvidenceReferencesV1,
 } from '../../src/attendance/w4c3a-rollout-control'
 
 const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
@@ -37,6 +38,17 @@ const describeIfDatabase = dbUrl ? describe : describe.skip
 const run = crypto.randomUUID().replace(/-/g, '').slice(0, 10)
 const hex = (value: string) => value.repeat(64)
 const id = () => crypto.randomUUID()
+// W4C-5 amendment (this file predates it and was never updated): transitionAttendanceCalculationRolloutV1
+// now requires expectedState/expectedVersion/evidenceManifestSha256/evidenceReferences (an
+// exact-key-match input contract, rejected synchronously before any lock/DB work otherwise).
+// Every call site below targets a freshly seeded org's first-ever transition
+// (legacy/version=1, no bootstrap row yet), and none is a resume pair, so the base evidence
+// reference set is always correct here.
+const baseEvidenceRefs = (seed: string): EvidenceReferencesV1 => Object.freeze({
+  imageSha: `img-${seed}`,
+  ownerAuthorizationRef: `owner-${seed}`,
+  syntheticOrgRef: `org-${seed}`,
+}) as EvidenceReferencesV1
 
 function deferred(): { promise: Promise<void>; resolve: () => void } {
   let resolve: (() => void) | undefined
@@ -1577,6 +1589,10 @@ describeIfDatabase('W4C-3a import rollback foundation (fresh PostgreSQL)', () =>
         correlationId: id(),
         engineVersion: 'w4c3a-race-test',
         targetState: 'shadow',
+        expectedState: 'legacy',
+        expectedVersion: 1,
+        evidenceManifestSha256: hex('1'),
+        evidenceReferences: baseEvidenceRefs(`${raceOrgId}-close-first`),
         reasonCode: 'rollout_transition',
       })
       await entered.promise
@@ -1656,6 +1672,10 @@ describeIfDatabase('W4C-3a import rollback foundation (fresh PostgreSQL)', () =>
         correlationId: id(),
         engineVersion: 'w4c3a-race-test',
         targetState: 'shadow',
+        expectedState: 'legacy',
+        expectedVersion: 1,
+        evidenceManifestSha256: hex('2'),
+        evidenceReferences: baseEvidenceRefs(`${raceOrgId}-rollback-first`),
         reasonCode: 'rollout_transition',
       }).finally(() => { transitionSettled = true })
       await new Promise((resolve) => setTimeout(resolve, 75))

--- a/packages/core-backend/tests/integration/attendance-w4c3a-rollout-control.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-w4c3a-rollout-control.db.test.ts
@@ -690,6 +690,75 @@ describeIfDatabase('W4C-3a core-only rollout control (real PostgreSQL)', () => {
         staleClient.release()
       }
     })
+
+    it('rejects a same-state-name preflight whose version went stale by round-tripping through another state (P2-1, PR #4773 gate)', async () => {
+      // PR #4773's exact-head independent gate (P2-1) found the version half of
+      // `persisted.state !== input.expectedState || persisted.version !== input.expectedVersion`
+      // (w4c3a-rollout-control.ts) was untested: every existing staleness test changes the state
+      // NAME, so deleting `|| persisted.version !== input.expectedVersion` still passed all 23
+      // tests. It guards a real case this test constructs directly: shadow (v2) -> eligible (v3)
+      // -> shadow (v4). An operator preflight taken at shadow/v2 must NOT be accepted at
+      // shadow/v4 just because the STATE NAME happens to match again — the org visibly
+      // round-tripped through eligible in between, and the preflight's belief about section 3
+      // predicates at that moment is stale.
+      const roundTripOrg = crypto.randomUUID()
+      allow(roundTripOrg)
+      const client = await pool.connect()
+      try {
+        await transitionAttendanceCalculationRolloutV1(transactionClient(client), {
+          orgId: roundTripOrg, actorId, correlationId: crypto.randomUUID(), engineVersion: 'w4c3a-control-test',
+          targetState: 'shadow', expectedState: 'legacy', expectedVersion: 1,
+          evidenceManifestSha256: hex64('round-trip-1'), evidenceReferences: baseRefs('round-trip-1'),
+          reasonCode: 'rollout_transition',
+        })
+        // Preflight taken here believes shadow/version=2 — true at this instant.
+        const preflight = await pool.query(
+          'SELECT state, version FROM attendance_calculation_rollout_state WHERE org_id = $1',
+          [roundTripOrg],
+        )
+        expect(preflight.rows[0]).toMatchObject({ state: 'shadow', version: 2 })
+
+        await transitionAttendanceCalculationRolloutV1(transactionClient(client), {
+          orgId: roundTripOrg, actorId, correlationId: crypto.randomUUID(), engineVersion: 'w4c3a-control-test',
+          targetState: 'eligible', expectedState: 'shadow', expectedVersion: 2,
+          evidenceManifestSha256: hex64('round-trip-2'), evidenceReferences: baseRefs('round-trip-2'),
+          reasonCode: 'rollout_transition',
+        })
+        await transitionAttendanceCalculationRolloutV1(transactionClient(client), {
+          orgId: roundTripOrg, actorId, correlationId: crypto.randomUUID(), engineVersion: 'w4c3a-control-test',
+          targetState: 'shadow', expectedState: 'eligible', expectedVersion: 3,
+          evidenceManifestSha256: hex64('round-trip-3'), evidenceReferences: baseRefs('round-trip-3'),
+          reasonCode: 'rollout_transition',
+        })
+        // Current state is now shadow/version=4 — the NAME matches the stale preflight, the
+        // VERSION does not.
+        await expect(pool.query(
+          'SELECT state, version FROM attendance_calculation_rollout_state WHERE org_id = $1',
+          [roundTripOrg],
+        )).resolves.toMatchObject({ rows: [{ state: 'shadow', version: 4 }] })
+
+        await expect(
+          transitionAttendanceCalculationRolloutV1(transactionClient(client), {
+            orgId: roundTripOrg, actorId, correlationId: crypto.randomUUID(), engineVersion: 'w4c3a-control-test',
+            targetState: 'legacy', expectedState: preflight.rows[0].state, expectedVersion: preflight.rows[0].version,
+            evidenceManifestSha256: hex64('round-trip-stale'), evidenceReferences: baseRefs('round-trip-stale'),
+            reasonCode: 'rollout_transition',
+          }),
+        ).rejects.toMatchObject({ code: 'W4C3A_ROLLOUT_CONTROL_STALE_EXPECTED_STATE' })
+        // Zero DML from the rejected attempt: state/version unchanged, event count unchanged (3:
+        // the three sequential setup transitions above).
+        await expect(pool.query(
+          'SELECT state, version FROM attendance_calculation_rollout_state WHERE org_id = $1',
+          [roundTripOrg],
+        )).resolves.toMatchObject({ rows: [{ state: 'shadow', version: 4 }] })
+        await expect(pool.query(
+          'SELECT count(*)::int AS n FROM attendance_calculation_rollout_events WHERE org_id = $1',
+          [roundTripOrg],
+        )).resolves.toMatchObject({ rows: [{ n: 3 }] })
+      } finally {
+        client.release()
+      }
+    })
   })
 
   describe('retryable job posture predicate — real two-connection race (gate 5, gate 6)', () => {

--- a/packages/core-backend/tests/integration/attendance-w4c3a-rollout-control.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-w4c3a-rollout-control.db.test.ts
@@ -17,6 +17,7 @@ import { up as w4c0Up } from '../../src/db/migrations/zzzz20260725120000_w4c0_at
 import {
   __setW4C3aRolloutControlAfterExclusiveLockForTests,
   __setW4C3aRolloutControlBeforeEventInsertForTests,
+  __setW4C3aRolloutControlBeforeStateUpdateForTests,
   closeLegacyRollbackWindowV1,
   transitionAttendanceCalculationRolloutV1,
   type AttendanceW4C3aRolloutControlResultV1,
@@ -271,6 +272,7 @@ describeIfDatabase('W4C-3a core-only rollout control (real PostgreSQL)', () => {
   afterAll(async () => {
     __setW4C3aRolloutControlAfterExclusiveLockForTests(null)
     __setW4C3aRolloutControlBeforeEventInsertForTests(null)
+    __setW4C3aRolloutControlBeforeStateUpdateForTests(null)
     delete process.env[ALLOWLIST_ENV]
     await pool?.end().catch(() => undefined)
     if (adminPool) {
@@ -1054,6 +1056,36 @@ describeIfDatabase('W4C-3a core-only rollout control (real PostgreSQL)', () => {
         )).resolves.toMatchObject({ rows: [{ n: 0 }] })
       } finally {
         __setW4C3aRolloutControlBeforeEventInsertForTests(null)
+        client.release()
+      }
+    })
+
+    it('leaves no event when the state update fails after the event insert succeeded', async () => {
+      const atomicOrg = crypto.randomUUID()
+      allow(atomicOrg)
+      __setW4C3aRolloutControlBeforeStateUpdateForTests(async () => {
+        throw new Error('W4C3A_TEST_FORCED_STATE_UPDATE_FAILURE')
+      })
+      const client = await pool.connect()
+      try {
+        await expect(
+          transitionAttendanceCalculationRolloutV1(transactionClient(client), {
+            orgId: atomicOrg, actorId, correlationId: crypto.randomUUID(), engineVersion: 'w4c3a-control-test',
+            targetState: 'shadow', expectedState: 'legacy', expectedVersion: 1,
+            evidenceManifestSha256: hex64('atomic-2'), evidenceReferences: baseRefs('atomic-2'),
+            reasonCode: 'rollout_transition',
+          }),
+        ).rejects.toThrow('W4C3A_TEST_FORCED_STATE_UPDATE_FAILURE')
+        await expect(pool.query(
+          'SELECT count(*)::int AS n FROM attendance_calculation_rollout_state WHERE org_id = $1',
+          [atomicOrg],
+        )).resolves.toMatchObject({ rows: [{ n: 0 }] })
+        await expect(pool.query(
+          'SELECT count(*)::int AS n FROM attendance_calculation_rollout_events WHERE org_id = $1',
+          [atomicOrg],
+        )).resolves.toMatchObject({ rows: [{ n: 0 }] })
+      } finally {
+        __setW4C3aRolloutControlBeforeStateUpdateForTests(null)
         client.release()
       }
     })

--- a/packages/core-backend/tests/integration/attendance-w4c3a-rollout-control.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-w4c3a-rollout-control.db.test.ts
@@ -1,4 +1,14 @@
-/** Core-only W4C-3a rollout-control proof. */
+/**
+ * Core-only W4C-3a rollout-control proof.
+ *
+ * Extended for the W4C-5 transition-safety amendment (docs/development/
+ * attendance-issue-4556-w4c5-transition-safety-amendment-20260804.md,
+ * OD-W4C-61=(a)): the closed transition matrix, expected-state/version
+ * staleness rejection, allowlist-gated row creation, and the new section 3
+ * database-backed predicates (retryable job posture, nonterminal legacy job,
+ * incomplete operation, unresolved ingress review, defective pending request
+ * snapshot).
+ */
 import crypto from 'node:crypto'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import { Kysely, PostgresDialect } from 'kysely'
@@ -6,15 +16,38 @@ import { Pool, type PoolClient } from 'pg'
 import { up as w4c0Up } from '../../src/db/migrations/zzzz20260725120000_w4c0_attendance_segment_calculation_durable_storage'
 import {
   __setW4C3aRolloutControlAfterExclusiveLockForTests,
+  __setW4C3aRolloutControlBeforeEventInsertForTests,
   closeLegacyRollbackWindowV1,
   transitionAttendanceCalculationRolloutV1,
   type AttendanceW4C3aRolloutControlResultV1,
+  type EvidenceReferencesV1,
 } from '../../src/attendance/w4c3a-rollout-control'
-import type { AttendanceW4TransactionClientV1 } from '../../src/attendance/w4c0-identity'
+import {
+  acquireAttendanceCalculationRolloutLock,
+  parseCanonicalAttendanceRolloutOrgKeyV1,
+  type AttendanceRolloutStateV1,
+  type AttendanceW4TransactionClientV1,
+} from '../../src/attendance/w4c0-identity'
 
 const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
 const describeIfDatabase = dbUrl ? describe : describe.skip
 const run = crypto.randomUUID().replace(/-/g, '').slice(0, 12)
+
+const ALLOWLIST_ENV = 'ATTENDANCE_SHIFT_SEGMENT_CALCULATION_ENABLED'
+const IMPORT_NS = '6f67fdaa-e2aa-48b3-b76c-c4aab9723173'
+
+const ALL_STATES: readonly AttendanceRolloutStateV1[] = ['legacy', 'shadow', 'eligible', 'authoritative', 'suspended']
+// The amendment section 1 table, hardcoded independently of the production LEGAL_TRANSITIONS
+// constant so a bug in that constant cannot hide from this test.
+const LEGAL_PAIRS: ReadonlyArray<readonly [AttendanceRolloutStateV1, AttendanceRolloutStateV1]> = [
+  ['legacy', 'shadow'],
+  ['shadow', 'eligible'],
+  ['eligible', 'shadow'],
+  ['eligible', 'authoritative'],
+  ['shadow', 'legacy'],
+  ['authoritative', 'suspended'],
+  ['suspended', 'authoritative'],
+]
 
 function transactionClient(client: PoolClient): AttendanceW4TransactionClientV1 {
   return {
@@ -26,6 +59,26 @@ function deferred(): { promise: Promise<void>; resolve: () => void } {
   let resolve: (() => void) | undefined
   const promise = new Promise<void>((done) => { resolve = done })
   return { promise, resolve: () => resolve?.() }
+}
+
+function hex64(seed: string): string {
+  return crypto.createHash('sha256').update(seed).digest('hex')
+}
+
+function baseRefs(seed: string): EvidenceReferencesV1 {
+  return Object.freeze({
+    imageSha: `img-${seed}`,
+    ownerAuthorizationRef: `owner-${seed}`,
+    syntheticOrgRef: `org-${seed}`,
+  }) as EvidenceReferencesV1
+}
+
+function resumeRefs(seed: string): EvidenceReferencesV1 {
+  return Object.freeze({
+    ...baseRefs(seed),
+    ownerIncidentReviewRef: `incident-${seed}`,
+    offlineReplayArtifactRef: `replay-${seed}`,
+  }) as EvidenceReferencesV1
 }
 
 async function createBase(pool: Pool): Promise<void> {
@@ -69,20 +122,132 @@ describeIfDatabase('W4C-3a core-only rollout control (real PostgreSQL)', () => {
   const batchId = crypto.randomUUID()
   const userId = crypto.randomUUID()
   const actorId = `w4c3a-control-${run}`
+  const allowlisted = new Set<string>()
   let adminPool: Pool
   let pool: Pool
 
-  async function insertLegacyBatch(id = batchId): Promise<void> {
+  function allow(id: string): void {
+    allowlisted.add(id)
+    process.env[ALLOWLIST_ENV] = [...allowlisted].join(',')
+  }
+
+  async function insertLegacyBatch(id = batchId, org = orgId): Promise<void> {
     await pool.query(
       `INSERT INTO attendance_import_batches (id, org_id, status, row_count, meta)
        VALUES ($1::uuid, $2, 'committed', 1, '{"source":"test"}'::jsonb)`,
-      [id, orgId],
+      [id, org],
     )
     await pool.query(
       `INSERT INTO attendance_import_items (batch_id, org_id, user_id, work_date, preview_snapshot)
        VALUES ($1::uuid, $2, $3, '2026-08-01', '{}'::jsonb)`,
-      [id, orgId, userId],
+      [id, org, userId],
     )
+  }
+
+  /** Minimal valid V1 retryable job (see attendance-w4c0-durable-storage-smoke fixture shape). */
+  async function insertRetryableJob(
+    org: string,
+    status: 'queued' | 'failed',
+    acceptedWritePosture: 'legacy_projection_only' | 'shadow' | 'authoritative',
+  ): Promise<void> {
+    const batchCommandId = crypto.randomUUID()
+    const fp = hex64(`${org}:${batchCommandId}`)
+    await pool.query(
+      `INSERT INTO attendance_import_jobs
+         (org_id, batch_id, created_by, status, payload, w4_contract_version, w4_entrypoint,
+          w4_batch_command_id, w4_source_kind, w4_source_ref, w4_actor_id, w4_actor_posture,
+          w4_command_fingerprint, w4_accepted_write_posture, w4_item_count,
+          w4_item_sequence_fingerprint, w4_item_set_fingerprint, w4_identity_proof_vector)
+       SELECT $1, $2::uuid, 'actor-control', $3, '{}'::jsonb, 1, 'import_batch',
+              $2::uuid, 'import_batch', 'batch:control', 'actor-control', 'delegated_import',
+              $4, $5, 1, $4, $4,
+              jsonb_build_array(jsonb_build_object(
+                'ordinal', 0,
+                'semanticFingerprint', $4::text,
+                'derivedOperationId', attendance_w4_uuidv5($6::uuid, attendance_w4_item_name_bytes($2::uuid, 0, $4))::text,
+                'commandFingerprint', $4::text))`,
+      [org, batchCommandId, status, fp, acceptedWritePosture, IMPORT_NS],
+    )
+  }
+
+  async function insertNullVersionLegacyJob(org: string, status: 'queued' | 'running'): Promise<void> {
+    await pool.query(
+      `INSERT INTO attendance_import_jobs (org_id, batch_id, created_by, status, payload)
+       VALUES ($1, $2, 'actor-control', $3, '{}'::jsonb)`,
+      [org, crypto.randomUUID(), status],
+    )
+  }
+
+  /**
+   * `attendance_result_operations`/`attendance_result_operation_batches` `claimed` rows are
+   * deliberately NOT used here: a deferred commit-time constraint trigger
+   * (`attendance_w4_*_claimed_commit_guard`) forbids ever committing a transaction that leaves
+   * a row it touched `claimed` — that state is same-transaction-transient only. The durable
+   * "incomplete org operation" this predicate targets (lock section 9: "Promotion drains or
+   * cancels every incomplete org operation before changing posture") is a still-open V1 job.
+   */
+  async function insertIncompleteV1Job(org: string, status: 'queued' | 'running' | 'failed'): Promise<void> {
+    await insertRetryableJob(org, status === 'queued' || status === 'failed' ? status : 'queued', 'shadow')
+    if (status === 'running') {
+      await pool.query(
+        `UPDATE attendance_import_jobs SET status = 'running' WHERE org_id = $1 AND status = 'queued'`,
+        [org],
+      )
+    }
+  }
+
+  async function insertUnresolvedReview(org: string): Promise<void> {
+    const recordId = crypto.randomUUID()
+    await pool.query(
+      `INSERT INTO attendance_records (id, user_id, work_date, org_id) VALUES ($1::uuid, $2, '2026-08-01', $3)`,
+      [recordId, crypto.randomUUID(), org],
+    )
+    await pool.query(
+      `INSERT INTO attendance_record_calculations (
+         id, org_id, attendance_record_id, version, calculation_kind, mode, entrypoint,
+         engine_version, snapshot_schema_version, operation_id, semantic_input_fingerprint,
+         provenance_fingerprint, attribution_snapshot, segment_snapshot, evidence_snapshot,
+         approved_facts_snapshot, input_provenance, merge_policy, calculation_tier, outcome,
+         outcome_reason_code, projection_effect, expected_segment_count, actor_id, correlation_id)
+       VALUES (
+         $1::uuid, $2, $3::uuid, 1, 'calculation', 'shadow', 'legacy_import',
+         'w4c3a-control-test', 1, $4::uuid, $5, $6,
+         '{"posture":"unsupported","sourceSchemaVersion":null,"reason":"missing","sourceFingerprint":null}'::jsonb,
+         '[]'::jsonb, '[]'::jsonb, '[]'::jsonb, '{}'::jsonb, 'append', 'legacy_shadow',
+         'review_required', 'legacy_time_ingress_not_authoritative', 'none', 0, $7, $8)`,
+      [
+        crypto.randomUUID(),
+        org,
+        recordId,
+        crypto.randomUUID(),
+        hex64(`${org}:${recordId}:semantic`),
+        hex64(`${org}:${recordId}:provenance`),
+        actorId,
+        crypto.randomUUID(),
+      ],
+    )
+  }
+
+  async function insertPendingRequest(
+    org: string,
+    kind: 'missing_snapshot' | 'unsupported_snapshot',
+  ): Promise<void> {
+    const requestId = crypto.randomUUID()
+    await pool.query(
+      `INSERT INTO attendance_requests (id, user_id, work_date, request_type, status, org_id)
+       VALUES ($1::uuid, $2, '2026-08-01', 'time_correction', 'pending', $3)`,
+      [requestId, crypto.randomUUID(), org],
+    )
+    if (kind === 'unsupported_snapshot') {
+      await pool.query(
+        `INSERT INTO attendance_request_calculation_snapshots (
+           org_id, request_id, version, request_type, subject_user_id, payload, payload_fingerprint,
+           attribution_snapshot, created_by)
+         VALUES ($1, $2::uuid, 1, 'time_correction', $3, '{"schemaVersion":1}'::jsonb, $4,
+           '{"posture":"unsupported","sourceSchemaVersion":null,"reason":"missing","sourceFingerprint":null}'::jsonb, $5)`,
+        [org, requestId, crypto.randomUUID(), hex64(`${org}:${requestId}:payload`), actorId],
+      )
+    }
   }
 
   beforeAll(async () => {
@@ -100,10 +265,13 @@ describeIfDatabase('W4C-3a core-only rollout control (real PostgreSQL)', () => {
     const db = new Kysely<never>({ dialect: new PostgresDialect({ pool }) })
     await w4c0Up(db)
     await insertLegacyBatch()
+    allow(orgId)
   }, 60_000)
 
   afterAll(async () => {
     __setW4C3aRolloutControlAfterExclusiveLockForTests(null)
+    __setW4C3aRolloutControlBeforeEventInsertForTests(null)
+    delete process.env[ALLOWLIST_ENV]
     await pool?.end().catch(() => undefined)
     if (adminPool) {
       await adminPool.query(`DROP DATABASE IF EXISTS ${scratchName}`).catch(() => undefined)
@@ -117,7 +285,9 @@ describeIfDatabase('W4C-3a core-only rollout control (real PostgreSQL)', () => {
       await expect(
         transitionAttendanceCalculationRolloutV1(transactionClient(client), {
           orgId, actorId, correlationId: crypto.randomUUID(), engineVersion: 'w4c3a-control-test',
-          targetState: 'shadow', reasonCode: 'rollout_transition',
+          targetState: 'shadow', expectedState: 'legacy', expectedVersion: 1,
+          evidenceManifestSha256: hex64('unclosed-batch'), evidenceReferences: baseRefs('unclosed'),
+          reasonCode: 'rollout_transition',
         }),
       ).rejects.toMatchObject({ code: 'W4C3A_ROLLOUT_CONTROL_UNCLOSED_BATCH' })
       await expect(pool.query('SELECT count(*)::int AS n FROM attendance_calculation_rollout_state WHERE org_id = $1', [orgId]))
@@ -249,7 +419,9 @@ describeIfDatabase('W4C-3a core-only rollout control (real PostgreSQL)', () => {
       let transitionSettled = false
       const transition = transitionAttendanceCalculationRolloutV1(transactionClient(transitionClient), {
         orgId, actorId, correlationId: crypto.randomUUID(), engineVersion: 'w4c3a-control-test',
-        targetState: 'shadow', reasonCode: 'rollout_transition',
+        targetState: 'shadow', expectedState: 'legacy', expectedVersion: 1,
+        evidenceManifestSha256: hex64('serialize-close-then-transition'), evidenceReferences: baseRefs('sct'),
+        reasonCode: 'rollout_transition',
       }).finally(() => { transitionSettled = true })
       await new Promise((resolve) => setTimeout(resolve, 75))
       expect(transitionSettled).toBe(false)
@@ -288,7 +460,9 @@ describeIfDatabase('W4C-3a core-only rollout control (real PostgreSQL)', () => {
     try {
       const transition = transitionAttendanceCalculationRolloutV1(transactionClient(transitionClient), {
         orgId, actorId, correlationId: crypto.randomUUID(), engineVersion: 'w4c3a-control-test',
-        targetState: 'eligible', reasonCode: 'rollout_transition',
+        targetState: 'eligible', expectedState: 'shadow', expectedVersion: 2,
+        evidenceManifestSha256: hex64('serialize-transition-before-close'), evidenceReferences: baseRefs('stbc'),
+        reasonCode: 'rollout_transition',
       })
       await entered.promise
       let closeSettled = false
@@ -310,5 +484,578 @@ describeIfDatabase('W4C-3a core-only rollout control (real PostgreSQL)', () => {
       transitionClient.release()
       closeClient.release()
     }
+  })
+
+  // ---------------------------------------------------------------------------
+  // W4C-5 amendment coverage
+  // ---------------------------------------------------------------------------
+
+  describe('closed transition matrix (completion gates 1-2)', () => {
+    it('rejects every pair outside the closed 7-pair matrix before any lock or DML', async () => {
+      const client = await pool.connect()
+      try {
+        const illegalPairs: Array<readonly [AttendanceRolloutStateV1, AttendanceRolloutStateV1]> = []
+        for (const from of ALL_STATES) {
+          for (const to of ALL_STATES) {
+            if (LEGAL_PAIRS.some(([legalFrom, legalTo]) => legalFrom === from && legalTo === to)) continue
+            illegalPairs.push([from, to])
+          }
+        }
+        expect(illegalPairs.length).toBe(25 - LEGAL_PAIRS.length)
+        for (const [from, to] of illegalPairs) {
+          await expect(
+            transitionAttendanceCalculationRolloutV1(transactionClient(client), {
+              orgId: crypto.randomUUID(), actorId, correlationId: crypto.randomUUID(),
+              engineVersion: 'w4c3a-control-test', targetState: to, expectedState: from, expectedVersion: 1,
+              evidenceManifestSha256: hex64(`matrix-${from}-${to}`), evidenceReferences: baseRefs(`matrix-${from}-${to}`),
+              reasonCode: 'rollout_transition',
+            }),
+          ).rejects.toMatchObject({ code: 'W4C3A_ROLLOUT_CONTROL_ILLEGAL_TRANSITION' })
+        }
+      } finally {
+        client.release()
+      }
+    })
+
+    it('walks all seven legal pairs to completion on a dedicated allowlisted org', async () => {
+      const walkOrg = crypto.randomUUID()
+      allow(walkOrg)
+      const client = await pool.connect()
+      const step = async (
+        target: AttendanceRolloutStateV1,
+        expectedState: AttendanceRolloutStateV1,
+        expectedVersion: number,
+        refs = baseRefs(`${walkOrg}-${expectedVersion}`),
+      ) =>
+        transitionAttendanceCalculationRolloutV1(transactionClient(client), {
+          orgId: walkOrg, actorId, correlationId: crypto.randomUUID(), engineVersion: 'w4c3a-control-test',
+          targetState: target, expectedState, expectedVersion,
+          evidenceManifestSha256: hex64(`walk-${walkOrg}-${expectedVersion}`), evidenceReferences: refs,
+          reasonCode: 'rollout_transition',
+        })
+      try {
+        await expect(step('shadow', 'legacy', 1)).resolves.toMatchObject({ state: 'shadow' })
+        await expect(step('eligible', 'shadow', 2)).resolves.toMatchObject({ state: 'eligible' })
+        await expect(step('shadow', 'eligible', 3)).resolves.toMatchObject({ state: 'shadow' })
+        await expect(step('legacy', 'shadow', 4)).resolves.toMatchObject({ state: 'legacy' })
+        await expect(step('shadow', 'legacy', 5)).resolves.toMatchObject({ state: 'shadow' })
+        await expect(step('eligible', 'shadow', 6)).resolves.toMatchObject({ state: 'eligible' })
+        await expect(step('authoritative', 'eligible', 7)).resolves.toMatchObject({ state: 'authoritative' })
+        await expect(step('suspended', 'authoritative', 8)).resolves.toMatchObject({ state: 'suspended' })
+        await expect(
+          step('authoritative', 'suspended', 9, resumeRefs(`${walkOrg}-9`)),
+        ).resolves.toMatchObject({ state: 'authoritative' })
+        await expect(pool.query(
+          `SELECT state, version FROM attendance_calculation_rollout_state WHERE org_id = $1`,
+          [walkOrg],
+        )).resolves.toMatchObject({ rows: [{ state: 'authoritative', version: 10 }] })
+        await expect(pool.query(
+          `SELECT count(*)::int AS n FROM attendance_calculation_rollout_events WHERE org_id = $1`,
+          [walkOrg],
+        )).resolves.toMatchObject({ rows: [{ n: 9 }] })
+      } finally {
+        client.release()
+      }
+    })
+  })
+
+  describe('allowlist-gated row creation (completion gate 3)', () => {
+    it('refuses a non-allowlisted org and creates zero rollout-state row', async () => {
+      const strangerOrg = crypto.randomUUID()
+      const client = await pool.connect()
+      try {
+        await expect(
+          transitionAttendanceCalculationRolloutV1(transactionClient(client), {
+            orgId: strangerOrg, actorId, correlationId: crypto.randomUUID(), engineVersion: 'w4c3a-control-test',
+            targetState: 'shadow', expectedState: 'legacy', expectedVersion: 1,
+            evidenceManifestSha256: hex64('stranger'), evidenceReferences: baseRefs('stranger'),
+            reasonCode: 'rollout_transition',
+          }),
+        ).rejects.toMatchObject({ code: 'W4C3A_ROLLOUT_CONTROL_ORG_NOT_ALLOWLISTED' })
+        await expect(pool.query(
+          'SELECT count(*)::int AS n FROM attendance_calculation_rollout_state WHERE org_id = $1',
+          [strangerOrg],
+        )).resolves.toMatchObject({ rows: [{ n: 0 }] })
+      } finally {
+        client.release()
+      }
+    })
+
+    it('refuses to bootstrap a missing row for a non-legacy-to-shadow claimed pair, even when allowlisted', async () => {
+      const freshOrg = crypto.randomUUID()
+      allow(freshOrg)
+      const client = await pool.connect()
+      try {
+        await expect(
+          transitionAttendanceCalculationRolloutV1(transactionClient(client), {
+            orgId: freshOrg, actorId, correlationId: crypto.randomUUID(), engineVersion: 'w4c3a-control-test',
+            targetState: 'eligible', expectedState: 'shadow', expectedVersion: 1,
+            evidenceManifestSha256: hex64('fresh-non-bootstrap'), evidenceReferences: baseRefs('fnb'),
+            reasonCode: 'rollout_transition',
+          }),
+        ).rejects.toMatchObject({ code: 'W4C3A_ROLLOUT_CONTROL_STATE_MISSING' })
+        await expect(pool.query(
+          'SELECT count(*)::int AS n FROM attendance_calculation_rollout_state WHERE org_id = $1',
+          [freshOrg],
+        )).resolves.toMatchObject({ rows: [{ n: 0 }] })
+      } finally {
+        client.release()
+      }
+    })
+  })
+
+  describe('expected-state/version staleness — real two-connection TOCTOU race (completion gate 4, gate 6)', () => {
+    it('rejects a transition whose caller-supplied preflight went stale under a concurrent committed transition', async () => {
+      const raceOrg = crypto.randomUUID()
+      allow(raceOrg)
+      // Bring the org to shadow/version=2 BEFORE the race (sequential setup, not part of the race).
+      const setupClient = await pool.connect()
+      try {
+        await transitionAttendanceCalculationRolloutV1(transactionClient(setupClient), {
+          orgId: raceOrg, actorId, correlationId: crypto.randomUUID(), engineVersion: 'w4c3a-control-test',
+          targetState: 'shadow', expectedState: 'legacy', expectedVersion: 1,
+          evidenceManifestSha256: hex64('race-setup'), evidenceReferences: baseRefs('race-setup'),
+          reasonCode: 'rollout_transition',
+        })
+      } finally {
+        setupClient.release()
+      }
+      // Simulate an external read-only preflight: a plain, lock-free read of state/version.
+      const preflight = await pool.query(
+        'SELECT state, version FROM attendance_calculation_rollout_state WHERE org_id = $1',
+        [raceOrg],
+      )
+      expect(preflight.rows[0]).toMatchObject({ state: 'shadow', version: 2 })
+
+      const entered = deferred()
+      const release = deferred()
+      __setW4C3aRolloutControlAfterExclusiveLockForTests(async (kind) => {
+        if (kind === 'transition') {
+          entered.resolve()
+          await release.promise
+        }
+      })
+      const winnerClient = await pool.connect()
+      const staleClient = await pool.connect()
+      try {
+        // Connection B (winner) races in FIRST, pauses right after the exclusive lock.
+        const winner = transitionAttendanceCalculationRolloutV1(transactionClient(winnerClient), {
+          orgId: raceOrg, actorId, correlationId: crypto.randomUUID(), engineVersion: 'w4c3a-control-test',
+          targetState: 'eligible', expectedState: 'shadow', expectedVersion: 2,
+          evidenceManifestSha256: hex64('race-winner'), evidenceReferences: baseRefs('race-winner'),
+          reasonCode: 'rollout_transition',
+        })
+        await entered.promise
+
+        // Connection A (stale) attempts its OWN transition using the preflight snapshot. It must
+        // genuinely block on the SAME exclusive advisory lock B is holding — not settle early.
+        let staleSettled = false
+        const stale = transitionAttendanceCalculationRolloutV1(transactionClient(staleClient), {
+          orgId: raceOrg, actorId, correlationId: crypto.randomUUID(), engineVersion: 'w4c3a-control-test',
+          targetState: 'legacy', expectedState: preflight.rows[0].state, expectedVersion: preflight.rows[0].version,
+          evidenceManifestSha256: hex64('race-stale'), evidenceReferences: baseRefs('race-stale'),
+          reasonCode: 'rollout_transition',
+        }).finally(() => { staleSettled = true })
+        await new Promise((resolve) => setTimeout(resolve, 75))
+        expect(staleSettled).toBe(false)
+
+        // B commits first (shadow/2 -> eligible/3).
+        release.resolve()
+        await expect(winner).resolves.toEqual<AttendanceW4C3aRolloutControlResultV1>({ orgId: raceOrg, state: 'eligible', batchId: null })
+
+        // A, now able to acquire the lock, re-reads under lock and finds its belief stale.
+        await expect(stale).rejects.toMatchObject({ code: 'W4C3A_ROLLOUT_CONTROL_STALE_EXPECTED_STATE' })
+        await expect(pool.query(
+          'SELECT state, version FROM attendance_calculation_rollout_state WHERE org_id = $1',
+          [raceOrg],
+        )).resolves.toMatchObject({ rows: [{ state: 'eligible', version: 3 }] })
+        // 2 events: the sequential setup (legacy->shadow) + the winner (shadow->eligible). The
+        // stale attempt inserted zero rows.
+        await expect(pool.query(
+          'SELECT count(*)::int AS n FROM attendance_calculation_rollout_events WHERE org_id = $1',
+          [raceOrg],
+        )).resolves.toMatchObject({ rows: [{ n: 2 }] })
+      } finally {
+        __setW4C3aRolloutControlAfterExclusiveLockForTests(null)
+        winnerClient.release()
+        staleClient.release()
+      }
+    })
+  })
+
+  describe('retryable job posture predicate — real two-connection race (gate 5, gate 6)', () => {
+    it('rejects when a retryable V1 job is frozen at a different posture than the pair requires', async () => {
+      const jobOrg = crypto.randomUUID()
+      allow(jobOrg)
+      await insertRetryableJob(jobOrg, 'queued', 'authoritative') // pair requires "shadow"
+      const client = await pool.connect()
+      try {
+        await expect(
+          transitionAttendanceCalculationRolloutV1(transactionClient(client), {
+            orgId: jobOrg, actorId, correlationId: crypto.randomUUID(), engineVersion: 'w4c3a-control-test',
+            targetState: 'shadow', expectedState: 'legacy', expectedVersion: 1,
+            evidenceManifestSha256: hex64('job-mismatch'), evidenceReferences: baseRefs('job-mismatch'),
+            reasonCode: 'rollout_transition',
+          }),
+        ).rejects.toMatchObject({ code: 'W4C3A_ROLLOUT_CONTROL_RETRYABLE_JOB_POSTURE_MISMATCH' })
+        await expect(pool.query(
+          'SELECT count(*)::int AS n FROM attendance_calculation_rollout_state WHERE org_id = $1',
+          [jobOrg],
+        )).resolves.toMatchObject({ rows: [{ n: 0 }] })
+      } finally {
+        client.release()
+      }
+    })
+
+    it('blocks a legitimate shared-lock job-writer for the whole duration of an in-flight transition', async () => {
+      // A genuine "job appears mid-wait, transition sees it" race is architecturally
+      // unconstructable: w4_accepted_write_posture is immutable post-insert (rules out an
+      // UPDATE-based race), and PostgreSQL's `SELECT ... FOR UPDATE` under SERIALIZABLE only
+      // re-fetches the LATEST version of rows already present in the transaction's snapshot —
+      // it does not retroactively admit a brand-new row inserted after that snapshot was taken,
+      // lock or no lock (verified empirically: pausing the transition — via the barrier hook or
+      // via genuine third-party lock contention — before a concurrent INSERT does not make that
+      // INSERT visible to the paused transaction's own read).
+      //
+      // This is not a gap in the predicate: lock section 9 requires every legitimate job-writer
+      // (P07 enqueue and friends) to acquire the class-00 rollout lock SHARED before writing a
+      // job row. Because `transitionAttendanceCalculationRolloutV1` holds that same lock
+      // EXCLUSIVE for its whole duration, a legitimate writer cannot insert a job for this org at
+      // all while a transition is in flight — there is no window for such a race to occur. What
+      // this test proves instead is that exact serialization: a shared-lock acquisition (the
+      // same primitive every job-writer calls first) genuinely blocks until the transition
+      // commits.
+      const raceOrg = crypto.randomUUID()
+      allow(raceOrg)
+      const entered = deferred()
+      const release = deferred()
+      __setW4C3aRolloutControlAfterExclusiveLockForTests(async (kind) => {
+        if (kind === 'transition') {
+          entered.resolve()
+          await release.promise
+        }
+      })
+      const transitionClient = await pool.connect()
+      const writerClient = await pool.connect()
+      try {
+        const transition = transitionAttendanceCalculationRolloutV1(transactionClient(transitionClient), {
+          orgId: raceOrg, actorId, correlationId: crypto.randomUUID(), engineVersion: 'w4c3a-control-test',
+          targetState: 'shadow', expectedState: 'legacy', expectedVersion: 1,
+          evidenceManifestSha256: hex64('job-writer-race'), evidenceReferences: baseRefs('job-writer-race'),
+          reasonCode: 'rollout_transition',
+        })
+        await entered.promise
+
+        let writerSettled = false
+        await writerClient.query('BEGIN')
+        const writer = acquireAttendanceCalculationRolloutLock(
+          transactionClient(writerClient),
+          parseCanonicalAttendanceRolloutOrgKeyV1(raceOrg),
+          'shared',
+        ).finally(() => { writerSettled = true })
+        await new Promise((resolve) => setTimeout(resolve, 75))
+        expect(writerSettled).toBe(false) // genuinely blocked behind the transition's exclusive hold
+
+        release.resolve()
+        await expect(transition).resolves.toMatchObject({ state: 'shadow' })
+        await writer // now unblocks — the transition committed and released the exclusive lock
+        await writerClient.query('COMMIT')
+      } finally {
+        __setW4C3aRolloutControlAfterExclusiveLockForTests(null)
+        await writerClient.query('ROLLBACK').catch(() => undefined)
+        transitionClient.release()
+        writerClient.release()
+      }
+    })
+  })
+
+  describe('nonterminal null-version legacy job predicate (gate 5)', () => {
+    it('blocks entry into shadow while a nonterminal legacy job is active', async () => {
+      const legacyJobOrg = crypto.randomUUID()
+      allow(legacyJobOrg)
+      await insertNullVersionLegacyJob(legacyJobOrg, 'running')
+      const client = await pool.connect()
+      try {
+        await expect(
+          transitionAttendanceCalculationRolloutV1(transactionClient(client), {
+            orgId: legacyJobOrg, actorId, correlationId: crypto.randomUUID(), engineVersion: 'w4c3a-control-test',
+            targetState: 'shadow', expectedState: 'legacy', expectedVersion: 1,
+            evidenceManifestSha256: hex64('legacy-job'), evidenceReferences: baseRefs('legacy-job'),
+            reasonCode: 'rollout_transition',
+          }),
+        ).rejects.toMatchObject({ code: 'W4C3A_ROLLOUT_CONTROL_LEGACY_JOB_ACTIVE' })
+        await expect(pool.query(
+          'SELECT count(*)::int AS n FROM attendance_calculation_rollout_state WHERE org_id = $1',
+          [legacyJobOrg],
+        )).resolves.toMatchObject({ rows: [{ n: 0 }] })
+      } finally {
+        client.release()
+      }
+    })
+  })
+
+  describe('org-wide incomplete operation predicate (gate 5)', () => {
+    it('blocks entry into eligible while a V1 job for the org is still running (not completed)', async () => {
+      const opOrg = crypto.randomUUID()
+      allow(opOrg)
+      await insertIncompleteV1Job(opOrg, 'running')
+      const client = await pool.connect()
+      try {
+        await transitionAttendanceCalculationRolloutV1(transactionClient(client), {
+          orgId: opOrg, actorId, correlationId: crypto.randomUUID(), engineVersion: 'w4c3a-control-test',
+          targetState: 'shadow', expectedState: 'legacy', expectedVersion: 1,
+          evidenceManifestSha256: hex64('op-setup'), evidenceReferences: baseRefs('op-setup'),
+          reasonCode: 'rollout_transition',
+        })
+        await expect(
+          transitionAttendanceCalculationRolloutV1(transactionClient(client), {
+            orgId: opOrg, actorId, correlationId: crypto.randomUUID(), engineVersion: 'w4c3a-control-test',
+            targetState: 'eligible', expectedState: 'shadow', expectedVersion: 2,
+            evidenceManifestSha256: hex64('op-blocked'), evidenceReferences: baseRefs('op-blocked'),
+            reasonCode: 'rollout_transition',
+          }),
+        ).rejects.toMatchObject({ code: 'W4C3A_ROLLOUT_CONTROL_INCOMPLETE_OPERATION' })
+        await expect(pool.query(
+          'SELECT state, version FROM attendance_calculation_rollout_state WHERE org_id = $1',
+          [opOrg],
+        )).resolves.toMatchObject({ rows: [{ state: 'shadow', version: 2 }] })
+      } finally {
+        client.release()
+      }
+    })
+  })
+
+  describe('unresolved legacy_time_ingress_not_authoritative review predicate (gate 5)', () => {
+    it('blocks entry into eligible while an unresolved review remains the latest calculation', async () => {
+      const reviewOrg = crypto.randomUUID()
+      allow(reviewOrg)
+      await insertUnresolvedReview(reviewOrg)
+      const client = await pool.connect()
+      try {
+        await transitionAttendanceCalculationRolloutV1(transactionClient(client), {
+          orgId: reviewOrg, actorId, correlationId: crypto.randomUUID(), engineVersion: 'w4c3a-control-test',
+          targetState: 'shadow', expectedState: 'legacy', expectedVersion: 1,
+          evidenceManifestSha256: hex64('review-setup'), evidenceReferences: baseRefs('review-setup'),
+          reasonCode: 'rollout_transition',
+        })
+        await expect(
+          transitionAttendanceCalculationRolloutV1(transactionClient(client), {
+            orgId: reviewOrg, actorId, correlationId: crypto.randomUUID(), engineVersion: 'w4c3a-control-test',
+            targetState: 'eligible', expectedState: 'shadow', expectedVersion: 2,
+            evidenceManifestSha256: hex64('review-blocked'), evidenceReferences: baseRefs('review-blocked'),
+            reasonCode: 'rollout_transition',
+          }),
+        ).rejects.toMatchObject({ code: 'W4C3A_ROLLOUT_CONTROL_UNRESOLVED_REVIEW' })
+        await expect(pool.query(
+          'SELECT state, version FROM attendance_calculation_rollout_state WHERE org_id = $1',
+          [reviewOrg],
+        )).resolves.toMatchObject({ rows: [{ state: 'shadow', version: 2 }] })
+      } finally {
+        client.release()
+      }
+    })
+  })
+
+  describe('defective pending request-snapshot predicate (gate 5)', () => {
+    it('blocks entry into eligible when a pending calculation-affecting request has no snapshot', async () => {
+      const reqOrg = crypto.randomUUID()
+      allow(reqOrg)
+      await insertPendingRequest(reqOrg, 'missing_snapshot')
+      const client = await pool.connect()
+      try {
+        await transitionAttendanceCalculationRolloutV1(transactionClient(client), {
+          orgId: reqOrg, actorId, correlationId: crypto.randomUUID(), engineVersion: 'w4c3a-control-test',
+          targetState: 'shadow', expectedState: 'legacy', expectedVersion: 1,
+          evidenceManifestSha256: hex64('req-missing-setup'), evidenceReferences: baseRefs('req-missing-setup'),
+          reasonCode: 'rollout_transition',
+        })
+        await expect(
+          transitionAttendanceCalculationRolloutV1(transactionClient(client), {
+            orgId: reqOrg, actorId, correlationId: crypto.randomUUID(), engineVersion: 'w4c3a-control-test',
+            targetState: 'eligible', expectedState: 'shadow', expectedVersion: 2,
+            evidenceManifestSha256: hex64('req-missing-blocked'), evidenceReferences: baseRefs('req-missing-blocked'),
+            reasonCode: 'rollout_transition',
+          }),
+        ).rejects.toMatchObject({ code: 'W4C3A_ROLLOUT_CONTROL_REQUEST_SNAPSHOT_DEFECTIVE' })
+      } finally {
+        client.release()
+      }
+    })
+
+    it('blocks entry into eligible when the latest snapshot is unsupported', async () => {
+      const reqOrg = crypto.randomUUID()
+      allow(reqOrg)
+      await insertPendingRequest(reqOrg, 'unsupported_snapshot')
+      const client = await pool.connect()
+      try {
+        await transitionAttendanceCalculationRolloutV1(transactionClient(client), {
+          orgId: reqOrg, actorId, correlationId: crypto.randomUUID(), engineVersion: 'w4c3a-control-test',
+          targetState: 'shadow', expectedState: 'legacy', expectedVersion: 1,
+          evidenceManifestSha256: hex64('req-unsupported-setup'), evidenceReferences: baseRefs('req-unsupported-setup'),
+          reasonCode: 'rollout_transition',
+        })
+        await expect(
+          transitionAttendanceCalculationRolloutV1(transactionClient(client), {
+            orgId: reqOrg, actorId, correlationId: crypto.randomUUID(), engineVersion: 'w4c3a-control-test',
+            targetState: 'eligible', expectedState: 'shadow', expectedVersion: 2,
+            evidenceManifestSha256: hex64('req-unsupported-blocked'), evidenceReferences: baseRefs('req-unsupported-blocked'),
+            reasonCode: 'rollout_transition',
+          }),
+        ).rejects.toMatchObject({ code: 'W4C3A_ROLLOUT_CONTROL_REQUEST_SNAPSHOT_DEFECTIVE' })
+      } finally {
+        client.release()
+      }
+    })
+  })
+
+  describe('evidence manifest + reference validation (gate 8)', () => {
+    it('rejects a non-hex64 manifest with zero DML', async () => {
+      const evOrg = crypto.randomUUID()
+      allow(evOrg)
+      const client = await pool.connect()
+      try {
+        await expect(
+          transitionAttendanceCalculationRolloutV1(transactionClient(client), {
+            orgId: evOrg, actorId, correlationId: crypto.randomUUID(), engineVersion: 'w4c3a-control-test',
+            targetState: 'shadow', expectedState: 'legacy', expectedVersion: 1,
+            evidenceManifestSha256: 'not-a-real-hash', evidenceReferences: baseRefs('bad-hash'),
+            reasonCode: 'rollout_transition',
+          }),
+        ).rejects.toMatchObject({ code: 'W4C3A_ROLLOUT_CONTROL_MANIFEST_INVALID' })
+        await expect(pool.query(
+          'SELECT count(*)::int AS n FROM attendance_calculation_rollout_state WHERE org_id = $1',
+          [evOrg],
+        )).resolves.toMatchObject({ rows: [{ n: 0 }] })
+      } finally {
+        client.release()
+      }
+    })
+
+    it('rejects an unexpected evidence-reference key set (extra key)', async () => {
+      const evOrg = crypto.randomUUID()
+      allow(evOrg)
+      const client = await pool.connect()
+      try {
+        await expect(
+          transitionAttendanceCalculationRolloutV1(transactionClient(client), {
+            orgId: evOrg, actorId, correlationId: crypto.randomUUID(), engineVersion: 'w4c3a-control-test',
+            targetState: 'shadow', expectedState: 'legacy', expectedVersion: 1,
+            evidenceManifestSha256: hex64('extra-key'),
+            evidenceReferences: { ...baseRefs('extra-key'), extra: 'nope' } as unknown as EvidenceReferencesV1,
+            reasonCode: 'rollout_transition',
+          }),
+        ).rejects.toMatchObject({ code: 'W4C3A_ROLLOUT_CONTROL_EVIDENCE_REFERENCE_INVALID' })
+      } finally {
+        client.release()
+      }
+    })
+
+    it('rejects a resume pair missing the incident/replay reference keys', async () => {
+      const evOrg = crypto.randomUUID()
+      allow(evOrg)
+      const client = await pool.connect()
+      try {
+        await expect(
+          transitionAttendanceCalculationRolloutV1(transactionClient(client), {
+            orgId: evOrg, actorId, correlationId: crypto.randomUUID(), engineVersion: 'w4c3a-control-test',
+            targetState: 'authoritative', expectedState: 'suspended', expectedVersion: 1,
+            evidenceManifestSha256: hex64('resume-missing-refs'), evidenceReferences: baseRefs('resume-missing-refs'),
+            reasonCode: 'rollout_transition',
+          }),
+        ).rejects.toMatchObject({ code: 'W4C3A_ROLLOUT_CONTROL_EVIDENCE_REFERENCE_INVALID' })
+      } finally {
+        client.release()
+      }
+    })
+
+    it('rejects a raw-payload-shaped reference value (secret/JSON injection attempt)', async () => {
+      const evOrg = crypto.randomUUID()
+      allow(evOrg)
+      const client = await pool.connect()
+      try {
+        const poisoned = { ...baseRefs('poison'), imageSha: '{"secret":"leak"}' } as unknown as EvidenceReferencesV1
+        await expect(
+          transitionAttendanceCalculationRolloutV1(transactionClient(client), {
+            orgId: evOrg, actorId, correlationId: crypto.randomUUID(), engineVersion: 'w4c3a-control-test',
+            targetState: 'shadow', expectedState: 'legacy', expectedVersion: 1,
+            evidenceManifestSha256: hex64('poison'), evidenceReferences: poisoned,
+            reasonCode: 'rollout_transition',
+          }),
+        ).rejects.toMatchObject({ code: 'W4C3A_ROLLOUT_CONTROL_EVIDENCE_REFERENCE_INVALID' })
+      } finally {
+        client.release()
+      }
+    })
+
+    it('stores exactly manifest hash, correlation ID, precondition counts, and references on success', async () => {
+      const evOrg = crypto.randomUUID()
+      allow(evOrg)
+      const correlationId = crypto.randomUUID()
+      const client = await pool.connect()
+      try {
+        await transitionAttendanceCalculationRolloutV1(transactionClient(client), {
+          orgId: evOrg, actorId, correlationId, engineVersion: 'w4c3a-control-test',
+          targetState: 'shadow', expectedState: 'legacy', expectedVersion: 1,
+          evidenceManifestSha256: hex64('event-shape'), evidenceReferences: baseRefs('event-shape'),
+          reasonCode: 'rollout_transition',
+        })
+        const result = await pool.query(
+          `SELECT prior_state AS "priorState", new_state AS "newState", evidence
+             FROM attendance_calculation_rollout_events WHERE org_id = $1`,
+          [evOrg],
+        )
+        expect(result.rows).toHaveLength(1)
+        expect(result.rows[0].priorState).toBe('legacy')
+        expect(result.rows[0].newState).toBe('shadow')
+        expect(result.rows[0].evidence).toEqual({
+          schemaVersion: 1,
+          manifestSha256: hex64('event-shape'),
+          correlationId,
+          comparisonWritePosture: 'shadow',
+          preconditionCounts: {
+            retryableJobPostureMismatches: 0,
+            nonterminalLegacyJobs: 0,
+            incompleteOperations: 0,
+            unresolvedReviews: 0,
+            defectiveRequestSnapshots: 0,
+          },
+          references: baseRefs('event-shape'),
+        })
+      } finally {
+        client.release()
+      }
+    })
+  })
+
+  describe('atomicity between state UPDATE and event INSERT (completion gate 7)', () => {
+    it('leaves state/version unchanged and inserts no event when the event insert fails', async () => {
+      const atomicOrg = crypto.randomUUID()
+      allow(atomicOrg)
+      __setW4C3aRolloutControlBeforeEventInsertForTests(async () => {
+        throw new Error('W4C3A_TEST_FORCED_EVENT_INSERT_FAILURE')
+      })
+      const client = await pool.connect()
+      try {
+        await expect(
+          transitionAttendanceCalculationRolloutV1(transactionClient(client), {
+            orgId: atomicOrg, actorId, correlationId: crypto.randomUUID(), engineVersion: 'w4c3a-control-test',
+            targetState: 'shadow', expectedState: 'legacy', expectedVersion: 1,
+            evidenceManifestSha256: hex64('atomic'), evidenceReferences: baseRefs('atomic'),
+            reasonCode: 'rollout_transition',
+          }),
+        ).rejects.toThrow('W4C3A_TEST_FORCED_EVENT_INSERT_FAILURE')
+        await expect(pool.query(
+          'SELECT count(*)::int AS n FROM attendance_calculation_rollout_state WHERE org_id = $1',
+          [atomicOrg],
+        )).resolves.toMatchObject({ rows: [{ n: 0 }] })
+        await expect(pool.query(
+          'SELECT count(*)::int AS n FROM attendance_calculation_rollout_events WHERE org_id = $1',
+          [atomicOrg],
+        )).resolves.toMatchObject({ rows: [{ n: 0 }] })
+      } finally {
+        __setW4C3aRolloutControlBeforeEventInsertForTests(null)
+        client.release()
+      }
+    })
   })
 })

--- a/packages/core-backend/tests/integration/attendance-w4c3a-rollout-control.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-w4c3a-rollout-control.db.test.ts
@@ -1070,6 +1070,86 @@ describeIfDatabase('W4C-3a core-only rollout control (real PostgreSQL)', () => {
     })
   })
 
+  describe('W4C-5 P1-2 hygiene: the session-level exclusive lock is actually released, not just asserted to be', () => {
+    // The `finally` release in `transitionAttendanceCalculationRolloutV1` is otherwise an
+    // UNTESTED guard: every test in this file uses a fresh `crypto.randomUUID()` org per case,
+    // so a leaked session-level lock on org A's advisory key never blocks org B's key, and every
+    // existing test would stay green even if the release call were deleted entirely (the same
+    // "guard neuterable with all tests green" shape the P1-2 gate already flagged for the
+    // staleness version half, P2-1). These legs check the actual server-visible lock state on
+    // `pg_locks` for this connection's own backend PID — a stronger, more direct signal than
+    // trusting `pg_advisory_unlock`'s boolean return value, which production code does not (and,
+    // per the P1-2 fix's own doc comment, must not let a release-failure override the real
+    // transition outcome) inspect.
+    it('leaves zero session-level advisory locks held after a successful transition', async () => {
+      const hygieneOrg = crypto.randomUUID()
+      allow(hygieneOrg)
+      const client = await pool.connect()
+      try {
+        await expect(
+          transitionAttendanceCalculationRolloutV1(transactionClient(client), {
+            orgId: hygieneOrg, actorId, correlationId: crypto.randomUUID(), engineVersion: 'w4c3a-control-test',
+            targetState: 'shadow', expectedState: 'legacy', expectedVersion: 1,
+            evidenceManifestSha256: hex64('hygiene-success'), evidenceReferences: baseRefs('hygiene-success'),
+            reasonCode: 'rollout_transition',
+          }),
+        ).resolves.toMatchObject({ state: 'shadow' })
+        await expect(
+          client.query('SELECT count(*)::int AS n FROM pg_locks WHERE locktype = $1 AND pid = pg_backend_pid()', ['advisory']),
+        ).resolves.toMatchObject({ rows: [{ n: 0 }] })
+      } finally {
+        client.release()
+      }
+    })
+
+    it('leaves zero session-level advisory locks held after a rejected transition (predicate failure)', async () => {
+      const hygieneOrg = crypto.randomUUID()
+      allow(hygieneOrg)
+      await insertRetryableJob(hygieneOrg, 'queued', 'authoritative') // pair requires "shadow"
+      const client = await pool.connect()
+      try {
+        await expect(
+          transitionAttendanceCalculationRolloutV1(transactionClient(client), {
+            orgId: hygieneOrg, actorId, correlationId: crypto.randomUUID(), engineVersion: 'w4c3a-control-test',
+            targetState: 'shadow', expectedState: 'legacy', expectedVersion: 1,
+            evidenceManifestSha256: hex64('hygiene-reject'), evidenceReferences: baseRefs('hygiene-reject'),
+            reasonCode: 'rollout_transition',
+          }),
+        ).rejects.toMatchObject({ code: 'W4C3A_ROLLOUT_CONTROL_RETRYABLE_JOB_POSTURE_MISMATCH' })
+        await expect(
+          client.query('SELECT count(*)::int AS n FROM pg_locks WHERE locktype = $1 AND pid = pg_backend_pid()', ['advisory']),
+        ).resolves.toMatchObject({ rows: [{ n: 0 }] })
+      } finally {
+        client.release()
+      }
+    })
+
+    it('leaves zero session-level advisory locks held after an input-validation rejection (before any lock acquisition attempt at all)', async () => {
+      // Sanity companion leg: an input-time rejection (illegal pair) fails BEFORE
+      // `acquireAttendanceCalculationRolloutLockSessionExclusiveV1` is ever called, so there is
+      // no lock to release in the first place — this proves the two success/rejection legs above
+      // are not vacuously green because pg_locks happens to always read zero for this org.
+      const hygieneOrg = crypto.randomUUID()
+      allow(hygieneOrg)
+      const client = await pool.connect()
+      try {
+        await expect(
+          transitionAttendanceCalculationRolloutV1(transactionClient(client), {
+            orgId: hygieneOrg, actorId, correlationId: crypto.randomUUID(), engineVersion: 'w4c3a-control-test',
+            targetState: 'authoritative', expectedState: 'legacy', expectedVersion: 1, // not in LEGAL_TRANSITIONS
+            evidenceManifestSha256: hex64('hygiene-illegal'), evidenceReferences: baseRefs('hygiene-illegal'),
+            reasonCode: 'rollout_transition',
+          }),
+        ).rejects.toMatchObject({ code: 'W4C3A_ROLLOUT_CONTROL_ILLEGAL_TRANSITION' })
+        await expect(
+          client.query('SELECT count(*)::int AS n FROM pg_locks WHERE locktype = $1 AND pid = pg_backend_pid()', ['advisory']),
+        ).resolves.toMatchObject({ rows: [{ n: 0 }] })
+      } finally {
+        client.release()
+      }
+    })
+  })
+
   describe('nonterminal null-version legacy job predicate (gate 5)', () => {
     it('blocks entry into shadow while a nonterminal legacy job is active', async () => {
       const legacyJobOrg = crypto.randomUUID()

--- a/packages/core-backend/tests/integration/attendance-w4c3a-rollout-control.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-w4c3a-rollout-control.db.test.ts
@@ -145,15 +145,21 @@ describeIfDatabase('W4C-3a core-only rollout control (real PostgreSQL)', () => {
     )
   }
 
-  /** Minimal valid V1 retryable job (see attendance-w4c0-durable-storage-smoke fixture shape). */
+  /**
+   * Minimal valid V1 retryable job (see attendance-w4c0-durable-storage-smoke fixture shape).
+   * `executor` defaults to the shared pool (autocommit) but accepts an open `PoolClient`
+   * transaction so RACE A/C below can insert the defect row UNCOMMITTED, inside a
+   * shared-lock-holding writer transaction, and control exactly when it becomes visible.
+   */
   async function insertRetryableJob(
     org: string,
     status: 'queued' | 'failed',
     acceptedWritePosture: 'legacy_projection_only' | 'shadow' | 'authoritative',
+    executor: Pool | PoolClient = pool,
   ): Promise<void> {
     const batchCommandId = crypto.randomUUID()
     const fp = hex64(`${org}:${batchCommandId}`)
-    await pool.query(
+    await executor.query(
       `INSERT INTO attendance_import_jobs
          (org_id, batch_id, created_by, status, payload, w4_contract_version, w4_entrypoint,
           w4_batch_command_id, w4_source_kind, w4_source_ref, w4_actor_id, w4_actor_posture,
@@ -197,13 +203,14 @@ describeIfDatabase('W4C-3a core-only rollout control (real PostgreSQL)', () => {
     }
   }
 
-  async function insertUnresolvedReview(org: string): Promise<void> {
+  /** `executor` defaults to the shared pool (autocommit); RACE D below passes an open writer transaction. */
+  async function insertUnresolvedReview(org: string, executor: Pool | PoolClient = pool): Promise<void> {
     const recordId = crypto.randomUUID()
-    await pool.query(
+    await executor.query(
       `INSERT INTO attendance_records (id, user_id, work_date, org_id) VALUES ($1::uuid, $2, '2026-08-01', $3)`,
       [recordId, crypto.randomUUID(), org],
     )
-    await pool.query(
+    await executor.query(
       `INSERT INTO attendance_record_calculations (
          id, org_id, attendance_record_id, version, calculation_kind, mode, entrypoint,
          engine_version, snapshot_schema_version, operation_id, semantic_input_fingerprint,
@@ -710,23 +717,26 @@ describeIfDatabase('W4C-3a core-only rollout control (real PostgreSQL)', () => {
     })
 
     it('blocks a legitimate shared-lock job-writer for the whole duration of an in-flight transition', async () => {
-      // A genuine "job appears mid-wait, transition sees it" race is architecturally
-      // unconstructable: w4_accepted_write_posture is immutable post-insert (rules out an
-      // UPDATE-based race), and PostgreSQL's `SELECT ... FOR UPDATE` under SERIALIZABLE only
-      // re-fetches the LATEST version of rows already present in the transaction's snapshot —
-      // it does not retroactively admit a brand-new row inserted after that snapshot was taken,
-      // lock or no lock (verified empirically: pausing the transition — via the barrier hook or
-      // via genuine third-party lock contention — before a concurrent INSERT does not make that
-      // INSERT visible to the paused transaction's own read).
+      // RETRACTION (W4C-5 P1-2, PR #4773 exact-head independent gate, 20260805): this test's
+      // comment previously claimed a "job appears mid-wait, transition sees it" race was
+      // "architecturally unconstructable" and that "there is no window for such a race to
+      // occur." Both claims were false, and were refuted by four constructed real
+      // two/three-connection races (RACE A/C/D/E, see the `describe` block immediately below
+      // this one): the window is not the exclusive lock's HOLD (which this test correctly
+      // proves is exclusive and serializing) but its WAIT, up to
+      // `W4_ADVISORY_HELPER_WAIT_MS` = 5000ms — before the W4C-5 P1-2 fix, a writer that
+      // committed its INSERT while the transition was still waiting to acquire the (then
+      // transaction-scoped) exclusive lock was invisible to every §3 predicate, because
+      // PostgreSQL fixes a SERIALIZABLE snapshot at the START of the first statement in the
+      // transaction — including a statement that itself blocks — so the snapshot predated the
+      // wait's resolution, not just the transaction's own BEGIN.
       //
-      // This is not a gap in the predicate: lock section 9 requires every legitimate job-writer
-      // (P07 enqueue and friends) to acquire the class-00 rollout lock SHARED before writing a
-      // job row. Because `transitionAttendanceCalculationRolloutV1` holds that same lock
-      // EXCLUSIVE for its whole duration, a legitimate writer cannot insert a job for this org at
-      // all while a transition is in flight — there is no window for such a race to occur. What
-      // this test proves instead is that exact serialization: a shared-lock acquisition (the
-      // same primitive every job-writer calls first) genuinely blocks until the transition
-      // commits.
+      // This test still correctly proves exact serialization (a shared-lock acquisition — the
+      // same primitive every job-writer calls first, lock section 9 — genuinely blocks for the
+      // whole duration the transition holds the lock). What it does NOT prove, and what it was
+      // wrongly assumed to prove, is that the predicates re-evaluated after that hold begins
+      // see a fresh-enough snapshot. That is proven separately, and positively, by the
+      // `describe` block immediately below.
       const raceOrg = crypto.randomUUID()
       allow(raceOrg)
       const entered = deferred()
@@ -767,6 +777,226 @@ describeIfDatabase('W4C-3a core-only rollout control (real PostgreSQL)', () => {
         await writerClient.query('ROLLBACK').catch(() => undefined)
         transitionClient.release()
         writerClient.release()
+      }
+    })
+  })
+
+  describe('W4C-5 P1-2: lock-WAIT races — a defect committed by a legitimate shared-lock writer WHILE the transition is genuinely blocked waiting for the exclusive lock is still caught', () => {
+    // PR #4773 exact-head independent gate (20260805) constructed these as RACE A/C/D/E against
+    // the pre-fix code (each false-PASSED: `RESOLVED` with the defect left uncaught in the DB)
+    // and refuted the PR body's "architecturally unconstructable / no window" claim. They are
+    // real two/three-connection races: every leg first proves genuine blocking
+    // (`settled === false` after 150ms) before letting the writer commit, exactly like the
+    // pre-existing TOCTOU staleness race and shared-lock-writer tests above. No barrier hook on
+    // any contended leg — timing is real, not simulated.
+
+    it('RACE A: a mismatched retryable job committed by a shared-lock holder DURING the exclusive wait is caught (not missed)', async () => {
+      const raceOrg = crypto.randomUUID()
+      allow(raceOrg)
+      const writerClient = await pool.connect()
+      const transitionClient = await pool.connect()
+      try {
+        await writerClient.query('BEGIN')
+        await acquireAttendanceCalculationRolloutLock(
+          transactionClient(writerClient),
+          parseCanonicalAttendanceRolloutOrgKeyV1(raceOrg),
+          'shared',
+        )
+
+        let transitionSettled = false
+        const transition = transitionAttendanceCalculationRolloutV1(transactionClient(transitionClient), {
+          orgId: raceOrg, actorId, correlationId: crypto.randomUUID(), engineVersion: 'w4c3a-control-test',
+          targetState: 'shadow', expectedState: 'legacy', expectedVersion: 1,
+          evidenceManifestSha256: hex64('race-a-transition'), evidenceReferences: baseRefs('race-a-transition'),
+          reasonCode: 'rollout_transition',
+        }).finally(() => { transitionSettled = true })
+        await new Promise((resolve) => setTimeout(resolve, 150))
+        expect(transitionSettled).toBe(false) // genuinely blocked behind the writer's shared hold
+
+        // Committed WHILE the transition is still waiting — posture 'authoritative' mismatches
+        // the legacy->shadow pair's required 'shadow'.
+        await insertRetryableJob(raceOrg, 'queued', 'authoritative', writerClient)
+        await writerClient.query('COMMIT')
+
+        await expect(transition).rejects.toMatchObject({ code: 'W4C3A_ROLLOUT_CONTROL_RETRYABLE_JOB_POSTURE_MISMATCH' })
+        expect(transitionSettled).toBe(true)
+        await expect(pool.query(
+          'SELECT count(*)::int AS n FROM attendance_calculation_rollout_state WHERE org_id = $1',
+          [raceOrg],
+        )).resolves.toMatchObject({ rows: [{ n: 0 }] })
+      } finally {
+        await writerClient.query('ROLLBACK').catch(() => undefined)
+        writerClient.release()
+        transitionClient.release()
+      }
+    })
+
+    it('RACE C: an incomplete V1 job committed by a shared-lock holder DURING the exclusive wait blocks promotion to eligible', async () => {
+      const raceOrg = crypto.randomUUID()
+      allow(raceOrg)
+      const setupClient = await pool.connect()
+      try {
+        await transitionAttendanceCalculationRolloutV1(transactionClient(setupClient), {
+          orgId: raceOrg, actorId, correlationId: crypto.randomUUID(), engineVersion: 'w4c3a-control-test',
+          targetState: 'shadow', expectedState: 'legacy', expectedVersion: 1,
+          evidenceManifestSha256: hex64('race-c-setup'), evidenceReferences: baseRefs('race-c-setup'),
+          reasonCode: 'rollout_transition',
+        })
+      } finally {
+        setupClient.release()
+      }
+
+      const writerClient = await pool.connect()
+      const transitionClient = await pool.connect()
+      try {
+        await writerClient.query('BEGIN')
+        await acquireAttendanceCalculationRolloutLock(
+          transactionClient(writerClient),
+          parseCanonicalAttendanceRolloutOrgKeyV1(raceOrg),
+          'shared',
+        )
+
+        let transitionSettled = false
+        const transition = transitionAttendanceCalculationRolloutV1(transactionClient(transitionClient), {
+          orgId: raceOrg, actorId, correlationId: crypto.randomUUID(), engineVersion: 'w4c3a-control-test',
+          targetState: 'eligible', expectedState: 'shadow', expectedVersion: 2,
+          evidenceManifestSha256: hex64('race-c-transition'), evidenceReferences: baseRefs('race-c-transition'),
+          reasonCode: 'rollout_transition',
+        }).finally(() => { transitionSettled = true })
+        await new Promise((resolve) => setTimeout(resolve, 150))
+        expect(transitionSettled).toBe(false)
+
+        // Committed WHILE the transition is still waiting — a fresh 'queued' V1 job is a still-open
+        // (not `completed`) org operation.
+        await insertRetryableJob(raceOrg, 'queued', 'shadow', writerClient)
+        await writerClient.query('COMMIT')
+
+        await expect(transition).rejects.toMatchObject({ code: 'W4C3A_ROLLOUT_CONTROL_INCOMPLETE_OPERATION' })
+        expect(transitionSettled).toBe(true)
+        await expect(pool.query(
+          'SELECT state, version FROM attendance_calculation_rollout_state WHERE org_id = $1',
+          [raceOrg],
+        )).resolves.toMatchObject({ rows: [{ state: 'shadow', version: 2 }] })
+      } finally {
+        await writerClient.query('ROLLBACK').catch(() => undefined)
+        writerClient.release()
+        transitionClient.release()
+      }
+    })
+
+    it('RACE D: an unresolved ingress review committed by a shared-lock holder DURING the exclusive wait blocks promotion to eligible', async () => {
+      const raceOrg = crypto.randomUUID()
+      allow(raceOrg)
+      const setupClient = await pool.connect()
+      try {
+        await transitionAttendanceCalculationRolloutV1(transactionClient(setupClient), {
+          orgId: raceOrg, actorId, correlationId: crypto.randomUUID(), engineVersion: 'w4c3a-control-test',
+          targetState: 'shadow', expectedState: 'legacy', expectedVersion: 1,
+          evidenceManifestSha256: hex64('race-d-setup'), evidenceReferences: baseRefs('race-d-setup'),
+          reasonCode: 'rollout_transition',
+        })
+      } finally {
+        setupClient.release()
+      }
+
+      const writerClient = await pool.connect()
+      const transitionClient = await pool.connect()
+      try {
+        await writerClient.query('BEGIN')
+        await acquireAttendanceCalculationRolloutLock(
+          transactionClient(writerClient),
+          parseCanonicalAttendanceRolloutOrgKeyV1(raceOrg),
+          'shared',
+        )
+
+        let transitionSettled = false
+        const transition = transitionAttendanceCalculationRolloutV1(transactionClient(transitionClient), {
+          orgId: raceOrg, actorId, correlationId: crypto.randomUUID(), engineVersion: 'w4c3a-control-test',
+          targetState: 'eligible', expectedState: 'shadow', expectedVersion: 2,
+          evidenceManifestSha256: hex64('race-d-transition'), evidenceReferences: baseRefs('race-d-transition'),
+          reasonCode: 'rollout_transition',
+        }).finally(() => { transitionSettled = true })
+        await new Promise((resolve) => setTimeout(resolve, 150))
+        expect(transitionSettled).toBe(false)
+
+        // Committed WHILE the transition is still waiting.
+        await insertUnresolvedReview(raceOrg, writerClient)
+        await writerClient.query('COMMIT')
+
+        await expect(transition).rejects.toMatchObject({ code: 'W4C3A_ROLLOUT_CONTROL_UNRESOLVED_REVIEW' })
+        expect(transitionSettled).toBe(true)
+        await expect(pool.query(
+          'SELECT state, version FROM attendance_calculation_rollout_state WHERE org_id = $1',
+          [raceOrg],
+        )).resolves.toMatchObject({ rows: [{ state: 'shadow', version: 2 }] })
+      } finally {
+        await writerClient.query('ROLLBACK').catch(() => undefined)
+        writerClient.release()
+        transitionClient.release()
+      }
+    })
+
+    it('RACE E (3-actor, zero protocol violations): a pending request committed by an actor with NO rollout-lock obligation, while a protocol-compliant shared-lock holder blocks the transition, is still caught', async () => {
+      // C1 = a protocol-compliant shared-lock holder (exactly the primitive every real job-writer
+      // calls first, lock section 9) — its only role is to create a genuine, provable wait window
+      // for T. C2 = an ordinary pending-request writer (the shape of
+      // `plugins/plugin-attendance/index.cjs`'s request-creation route): it acquires NO rollout
+      // lock and reads NO rollout state — by construction (bare `pool.query`, autocommit,
+      // `insertPendingRequest`'s existing shape) it commits independently of C1/T entirely. T is
+      // the transition itself. No actor here violates any locking obligation the current
+      // codebase defines; the fix must still catch this.
+      const raceOrg = crypto.randomUUID()
+      allow(raceOrg)
+      const setupClient = await pool.connect()
+      try {
+        await transitionAttendanceCalculationRolloutV1(transactionClient(setupClient), {
+          orgId: raceOrg, actorId, correlationId: crypto.randomUUID(), engineVersion: 'w4c3a-control-test',
+          targetState: 'shadow', expectedState: 'legacy', expectedVersion: 1,
+          evidenceManifestSha256: hex64('race-e-setup'), evidenceReferences: baseRefs('race-e-setup'),
+          reasonCode: 'rollout_transition',
+        })
+      } finally {
+        setupClient.release()
+      }
+
+      const c1Client = await pool.connect()
+      const transitionClient = await pool.connect()
+      try {
+        await c1Client.query('BEGIN')
+        await acquireAttendanceCalculationRolloutLock(
+          transactionClient(c1Client),
+          parseCanonicalAttendanceRolloutOrgKeyV1(raceOrg),
+          'shared',
+        )
+
+        let transitionSettled = false
+        const transition = transitionAttendanceCalculationRolloutV1(transactionClient(transitionClient), {
+          orgId: raceOrg, actorId, correlationId: crypto.randomUUID(), engineVersion: 'w4c3a-control-test',
+          targetState: 'eligible', expectedState: 'shadow', expectedVersion: 2,
+          evidenceManifestSha256: hex64('race-e-transition'), evidenceReferences: baseRefs('race-e-transition'),
+          reasonCode: 'rollout_transition',
+        }).finally(() => { transitionSettled = true })
+        await new Promise((resolve) => setTimeout(resolve, 150))
+        expect(transitionSettled).toBe(false) // T genuinely blocked behind C1's shared hold
+
+        // C2: commits independently, with no relationship to C1's lock or T's wait at all — a
+        // plain autocommit INSERT via the shared pool, matching insertPendingRequest's existing
+        // (lock-free) shape.
+        await insertPendingRequest(raceOrg, 'missing_snapshot')
+
+        // C1 releases; T can now proceed.
+        await c1Client.query('COMMIT')
+
+        await expect(transition).rejects.toMatchObject({ code: 'W4C3A_ROLLOUT_CONTROL_REQUEST_SNAPSHOT_DEFECTIVE' })
+        expect(transitionSettled).toBe(true)
+        await expect(pool.query(
+          'SELECT state, version FROM attendance_calculation_rollout_state WHERE org_id = $1',
+          [raceOrg],
+        )).resolves.toMatchObject({ rows: [{ state: 'shadow', version: 2 }] })
+      } finally {
+        await c1Client.query('ROLLBACK').catch(() => undefined)
+        c1Client.release()
+        transitionClient.release()
       }
     })
   })

--- a/packages/core-backend/tests/integration/attendance-w4c3a-rollout-control.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-w4c3a-rollout-control.db.test.ts
@@ -25,6 +25,7 @@ import {
 } from '../../src/attendance/w4c3a-rollout-control'
 import {
   acquireAttendanceCalculationRolloutLock,
+  ATTENDANCE_ROLLOUT_STATES_V1,
   parseCanonicalAttendanceRolloutOrgKeyV1,
   type AttendanceRolloutStateV1,
   type AttendanceW4TransactionClientV1,
@@ -37,7 +38,10 @@ const run = crypto.randomUUID().replace(/-/g, '').slice(0, 12)
 const ALLOWLIST_ENV = 'ATTENDANCE_SHIFT_SEGMENT_CALCULATION_ENABLED'
 const IMPORT_NS = '6f67fdaa-e2aa-48b3-b76c-c4aab9723173'
 
-const ALL_STATES: readonly AttendanceRolloutStateV1[] = ['legacy', 'shadow', 'eligible', 'authoritative', 'suspended']
+// NIT-2 (PR #4773 exact-head independent gate, 20260805): mechanical over the exported table,
+// not a second hardcoded literal — a sixth rollout state would silently escape this test's
+// 25-combo exhaustive sweep otherwise.
+const ALL_STATES: readonly AttendanceRolloutStateV1[] = ATTENDANCE_ROLLOUT_STATES_V1
 // The amendment section 1 table, hardcoded independently of the production LEGAL_TRANSITIONS
 // constant so a bug in that constant cannot hide from this test.
 const LEGAL_PAIRS: ReadonlyArray<readonly [AttendanceRolloutStateV1, AttendanceRolloutStateV1]> = [

--- a/packages/core-backend/tests/integration/attendance-w4c3a-rollout-control.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-w4c3a-rollout-control.db.test.ts
@@ -151,12 +151,15 @@ describeIfDatabase('W4C-3a core-only rollout control (real PostgreSQL)', () => {
    * transaction so RACE A/C below can insert the defect row UNCOMMITTED, inside a
    * shared-lock-holding writer transaction, and control exactly when it becomes visible.
    */
+  /** Returns the generated `batchCommandId` (== `w4_batch_command_id`) so callers needing to
+   * construct a matching `attendance_result_operations` row (P2-4's "with operation rows" leg)
+   * can reference the exact same batch. */
   async function insertRetryableJob(
     org: string,
     status: 'queued' | 'failed',
     acceptedWritePosture: 'legacy_projection_only' | 'shadow' | 'authoritative',
     executor: Pool | PoolClient = pool,
-  ): Promise<void> {
+  ): Promise<string> {
     const batchCommandId = crypto.randomUUID()
     const fp = hex64(`${org}:${batchCommandId}`)
     await executor.query(
@@ -175,6 +178,7 @@ describeIfDatabase('W4C-3a core-only rollout control (real PostgreSQL)', () => {
                 'commandFingerprint', $4::text))`,
       [org, batchCommandId, status, fp, acceptedWritePosture, IMPORT_NS],
     )
+    return batchCommandId
   }
 
   async function insertNullVersionLegacyJob(org: string, status: 'queued' | 'running'): Promise<void> {
@@ -255,6 +259,82 @@ describeIfDatabase('W4C-3a core-only rollout control (real PostgreSQL)', () => {
            '{"posture":"unsupported","sourceSchemaVersion":null,"reason":"missing","sourceFingerprint":null}'::jsonb, $5)`,
         [org, requestId, crypto.randomUUID(), hex64(`${org}:${requestId}:payload`), actorId],
       )
+    }
+  }
+
+  /**
+   * Inserts a durable `attendance_result_operation_batches` + `attendance_result_operations`
+   * row pair for `entrypoint = 'import_batch'` at the given `batchCommandId` — the exact
+   * `w4_batch_command_id` a retryable V1 import job (`insertRetryableJob`'s return value)
+   * carries. Used by the P2-4 "resume with operation rows" negative leg below. Follows the same
+   * claimed-then-terminal-before-COMMIT shape as the pre-existing "refuses closure when an
+   * integration batch owns..." fixture above (OPERATION_STATES only ever durably persists
+   * `completed`/`canceled` — a deferred commit-time trigger forbids a persisted `claimed` row).
+   */
+  async function insertOperationRowForImportBatch(org: string, batchCommandId: string): Promise<void> {
+    const registryClient = await pool.connect()
+    try {
+      await registryClient.query('BEGIN')
+      await registryClient.query(
+        `INSERT INTO attendance_result_operation_batches (
+           org_id, entrypoint, batch_command_id, identity_source_kind, source_root_id,
+           source_ref, actor_id, actor_posture, capability,
+           subject_scope, accepted_write_posture, command_fingerprint, item_count,
+           item_sequence_fingerprint, item_set_fingerprint, state)
+         VALUES ($1, 'import_batch', $2::uuid, 'import_batch', $2::uuid,
+           'test:w4c3a-control-resume-op', $3, 'attendance_admin', 'import',
+           $4::jsonb, 'authoritative', $5, 1, $6, $7, 'claimed')`,
+        [
+          org,
+          batchCommandId,
+          actorId,
+          JSON.stringify({ kind: 'explicit_users', userIds: [] }),
+          hex64(`${org}:${batchCommandId}:cmd`),
+          hex64(`${org}:${batchCommandId}:seq`),
+          hex64(`${org}:${batchCommandId}:set`),
+        ],
+      )
+      await registryClient.query(
+        `INSERT INTO attendance_result_operations (
+           org_id, entrypoint, operation_id, batch_command_id, input_ordinal,
+           identity_source_kind, source_root_id, proof_semantic_fingerprint,
+           source_ref, actor_id, actor_posture, capability,
+           subject_scope, command_fingerprint, accepted_write_posture,
+           normalized_business_input_snapshot, state)
+         VALUES ($1, 'import_batch', attendance_w4_uuidv5(
+             $7::uuid,
+             attendance_w4_item_name_bytes($2::uuid, 0, $3)),
+           $2::uuid, 0, 'import_item', $2::uuid, $3,
+           'test:w4c3a-control-resume-op', $4, 'attendance_admin', 'import',
+           $5::jsonb, $6, 'authoritative', '{}'::jsonb, 'claimed')`,
+        [
+          org,
+          batchCommandId,
+          hex64(`${org}:${batchCommandId}:semantic`),
+          actorId,
+          JSON.stringify({ kind: 'explicit_users', userIds: [] }),
+          hex64(`${org}:${batchCommandId}:cmd`),
+          IMPORT_NS,
+        ],
+      )
+      await registryClient.query(
+        `UPDATE attendance_result_operations
+            SET state = 'canceled', updated_at = now(), version = version + 1
+          WHERE org_id = $1 AND entrypoint = 'import_batch' AND batch_command_id = $2::uuid`,
+        [org, batchCommandId],
+      )
+      await registryClient.query(
+        `UPDATE attendance_result_operation_batches
+            SET state = 'canceled', updated_at = now(), version = version + 1
+          WHERE org_id = $1 AND entrypoint = 'import_batch' AND batch_command_id = $2::uuid`,
+        [org, batchCommandId],
+      )
+      await registryClient.query('COMMIT')
+    } catch (error) {
+      await registryClient.query('ROLLBACK')
+      throw error
+    } finally {
+      registryClient.release()
     }
   }
 
@@ -1206,6 +1286,114 @@ describeIfDatabase('W4C-3a core-only rollout control (real PostgreSQL)', () => {
     })
   })
 
+  describe('resume "preserved authoritative jobs remain retryable without operation rows" predicate (gate 5, P2-4 PR #4773 gate)', () => {
+    async function step(
+      client: PoolClient,
+      org: string,
+      target: AttendanceRolloutStateV1,
+      expectedState: AttendanceRolloutStateV1,
+      expectedVersion: number,
+      seed: string,
+      refs = baseRefs(seed),
+    ) {
+      return transitionAttendanceCalculationRolloutV1(transactionClient(client), {
+        orgId: org, actorId, correlationId: crypto.randomUUID(), engineVersion: 'w4c3a-control-test',
+        targetState: target, expectedState, expectedVersion,
+        evidenceManifestSha256: hex64(seed), evidenceReferences: refs,
+        reasonCode: 'rollout_transition',
+      })
+    }
+
+    /**
+     * Reaches 'authoritative' (version 3) BEFORE any retryable job exists — every earlier pair
+     * (legacy->shadow, shadow->eligible) requires comparisonWritePosture 'shadow', which a job
+     * frozen at 'authoritative' would immediately fail on
+     * (W4C3A_ROLLOUT_CONTROL_RETRYABLE_JOB_POSTURE_MISMATCH, the pre-existing predicate, not the
+     * one under test here). The job is inserted by the caller between this and `suspend` below,
+     * exactly once the org is already at the posture the job will be frozen at.
+     */
+    async function advanceOrgToAuthoritative(client: PoolClient, org: string): Promise<void> {
+      await step(client, org, 'shadow', 'legacy', 1, `${org}-resume-setup-1`)
+      await step(client, org, 'eligible', 'shadow', 2, `${org}-resume-setup-2`)
+      await step(client, org, 'authoritative', 'eligible', 3, `${org}-resume-setup-3`)
+    }
+
+    async function suspend(client: PoolClient, org: string): Promise<void> {
+      await step(client, org, 'suspended', 'authoritative', 4, `${org}-resume-setup-4`)
+    }
+
+    it('rejects resume when a retryable job preserved through suspension already has a durable operation row', async () => {
+      const resumeOrg = crypto.randomUUID()
+      allow(resumeOrg)
+      const client = await pool.connect()
+      try {
+        await advanceOrgToAuthoritative(client, resumeOrg)
+        // Frozen at 'authoritative' — matches both the suspend pair's and the resume pair's
+        // required comparisonWritePosture, so this leg exercises ONLY the new predicate under
+        // test, never the pre-existing posture-mismatch one.
+        const batchCommandId = await insertRetryableJob(resumeOrg, 'queued', 'authoritative')
+        await insertOperationRowForImportBatch(resumeOrg, batchCommandId)
+        await suspend(client, resumeOrg)
+
+        await expect(
+          transitionAttendanceCalculationRolloutV1(transactionClient(client), {
+            orgId: resumeOrg, actorId, correlationId: crypto.randomUUID(), engineVersion: 'w4c3a-control-test',
+            targetState: 'authoritative', expectedState: 'suspended', expectedVersion: 5,
+            evidenceManifestSha256: hex64('resume-op-rows-blocked'),
+            evidenceReferences: resumeRefs('resume-op-rows-blocked'),
+            reasonCode: 'rollout_transition',
+          }),
+        ).rejects.toMatchObject({ code: 'W4C3A_ROLLOUT_CONTROL_RETRYABLE_JOB_HAS_OPERATION_ROWS' })
+        await expect(pool.query(
+          'SELECT state, version FROM attendance_calculation_rollout_state WHERE org_id = $1',
+          [resumeOrg],
+        )).resolves.toMatchObject({ rows: [{ state: 'suspended', version: 5 }] })
+      } finally {
+        client.release()
+      }
+    })
+
+    it('a preserved retryable job WITHOUT an operation row is rejected by the pre-existing incomplete-operation predicate, never by the new one (negative discriminator)', async () => {
+      // NOTE (found while writing this leg, not self-reported by the original PR): a resume
+      // target is ALWAYS in ELIGIBILITY_AUTHORITY_TARGETS ('eligible'/'authoritative'), so
+      // countIncompleteOperations — "any w4_contract_version=1 job not yet completed" — fires
+      // unconditionally on ANY resume attempt with ANY retryable (queued/failed) job present,
+      // gated only on the TARGET state, never on the SOURCE state or the resume/promotion
+      // distinction. That appears to make bullet 9's "preserved authoritative jobs remain
+      // retryable" language unreachable as written today: there is no live combination where a
+      // retryable job survives suspend and a resume attempt still succeeds. Whether
+      // countIncompleteOperations should be narrowed to skip the resume pair specifically (so
+      // bullet 9's own, more permissive "without operation rows" predicate is the one that
+      // actually governs resume) is a design question outside the scope of adding the missing
+      // "without operation rows" predicate itself — flagged for owner review, not silently
+      // resolved here by loosening an existing gate. This test instead proves the DISCRIMINATING
+      // property this leg was asked to prove: the new predicate is not spuriously broad — it
+      // does NOT fire for a job that has no operation row, even though this job is (for the
+      // unrelated reason above) still rejected overall.
+      const resumeOrg = crypto.randomUUID()
+      allow(resumeOrg)
+      const client = await pool.connect()
+      try {
+        await advanceOrgToAuthoritative(client, resumeOrg)
+        // Same frozen posture, same shape, deliberately WITHOUT a matching operation row.
+        await insertRetryableJob(resumeOrg, 'queued', 'authoritative')
+        await suspend(client, resumeOrg)
+
+        await expect(
+          transitionAttendanceCalculationRolloutV1(transactionClient(client), {
+            orgId: resumeOrg, actorId, correlationId: crypto.randomUUID(), engineVersion: 'w4c3a-control-test',
+            targetState: 'authoritative', expectedState: 'suspended', expectedVersion: 5,
+            evidenceManifestSha256: hex64('resume-op-rows-allowed'),
+            evidenceReferences: resumeRefs('resume-op-rows-allowed'),
+            reasonCode: 'rollout_transition',
+          }),
+        ).rejects.toMatchObject({ code: 'W4C3A_ROLLOUT_CONTROL_INCOMPLETE_OPERATION' })
+      } finally {
+        client.release()
+      }
+    })
+  })
+
   describe('unresolved legacy_time_ingress_not_authoritative review predicate (gate 5)', () => {
     it('blocks entry into eligible while an unresolved review remains the latest calculation', async () => {
       const reviewOrg = crypto.randomUUID()
@@ -1395,6 +1583,7 @@ describeIfDatabase('W4C-3a core-only rollout control (real PostgreSQL)', () => {
           comparisonWritePosture: 'shadow',
           preconditionCounts: {
             retryableJobPostureMismatches: 0,
+            retryableJobsWithOperationRows: 0,
             nonterminalLegacyJobs: 0,
             incompleteOperations: 0,
             unresolvedReviews: 0,

--- a/packages/core-backend/tests/integration/attendance-w4c3a-rollout-control.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-w4c3a-rollout-control.db.test.ts
@@ -1154,6 +1154,66 @@ describeIfDatabase('W4C-3a core-only rollout control (real PostgreSQL)', () => {
     })
   })
 
+  describe('W4C-5 NEW-B: the session-exclusive rollout lock requires an idle connection — enforced, not just documented', () => {
+    // PR #4773 exact-head independent DELTA gate (20260805) constructed this exact probe against
+    // the pre-fix code: a caller that pre-opens `BEGIN ISOLATION LEVEL SERIALIZABLE; SELECT 1;`
+    // on the SAME connection before calling `transitionAttendanceCalculationRolloutV1` fixes the
+    // OUTER transaction's snapshot before the session-level rollout lock is ever requested —
+    // silently reintroducing the exact P1-2 defect (PostgreSQL only WARNs on a nested `BEGIN`,
+    // it does not error), `RESOLVED {state:'shadow'}`, no red test anywhere. Mutation-confirmed
+    // (see PR mutation ledger): neutering `assertConnectionIsIdleForSessionExclusiveRolloutLockV1`
+    // turns this leg from a `W4C0_ROLLOUT_LOCK_CONNECTION_NOT_IDLE` rejection back into a silent
+    // `RESOLVED`, reproducing the gate's finding exactly.
+    it('rejects a transition called on a connection that already has an open transaction', async () => {
+      const idleOrg = crypto.randomUUID()
+      allow(idleOrg)
+      const client = await pool.connect()
+      try {
+        await client.query('BEGIN ISOLATION LEVEL SERIALIZABLE')
+        await client.query('SELECT 1') // fixes the SERIALIZABLE snapshot; no write yet, no xid assigned
+        await expect(
+          transitionAttendanceCalculationRolloutV1(transactionClient(client), {
+            orgId: idleOrg, actorId, correlationId: crypto.randomUUID(), engineVersion: 'w4c3a-control-test',
+            targetState: 'shadow', expectedState: 'legacy', expectedVersion: 1,
+            evidenceManifestSha256: hex64('new-b-not-idle'), evidenceReferences: baseRefs('new-b-not-idle'),
+            reasonCode: 'rollout_transition',
+          }),
+        ).rejects.toMatchObject({ code: 'W4C0_ROLLOUT_LOCK_CONNECTION_NOT_IDLE' })
+        // No rollout row was ever created — the rejection happened before any rollout DML.
+        await expect(pool.query(
+          'SELECT count(*)::int AS n FROM attendance_calculation_rollout_state WHERE org_id = $1',
+          [idleOrg],
+        )).resolves.toMatchObject({ rows: [{ n: 0 }] })
+        // The caller's own pre-opened transaction is still open and usable afterward — the
+        // probe's `ROLLBACK TO SAVEPOINT` cleanup must not have touched it.
+        await expect(client.query('SELECT 1 AS still_alive')).resolves.toMatchObject({
+          rows: [{ still_alive: 1 }],
+        })
+      } finally {
+        await client.query('ROLLBACK').catch(() => undefined)
+        client.release()
+      }
+    })
+
+    it('positive control: an idle connection (the normal call shape) still transitions successfully', async () => {
+      const idleOrg = crypto.randomUUID()
+      allow(idleOrg)
+      const client = await pool.connect()
+      try {
+        await expect(
+          transitionAttendanceCalculationRolloutV1(transactionClient(client), {
+            orgId: idleOrg, actorId, correlationId: crypto.randomUUID(), engineVersion: 'w4c3a-control-test',
+            targetState: 'shadow', expectedState: 'legacy', expectedVersion: 1,
+            evidenceManifestSha256: hex64('new-b-idle-control'), evidenceReferences: baseRefs('new-b-idle-control'),
+            reasonCode: 'rollout_transition',
+          }),
+        ).resolves.toMatchObject({ state: 'shadow' })
+      } finally {
+        client.release()
+      }
+    })
+  })
+
   describe('W4C-5 P1-2 hygiene: the session-level exclusive lock is actually released, not just asserted to be', () => {
     // The `finally` release in `transitionAttendanceCalculationRolloutV1` is otherwise an
     // UNTESTED guard: every test in this file uses a fresh `crypto.randomUUID()` org per case,

--- a/scripts/attendance/w4c0-dml-inventory/calculation-read-classification.cjs
+++ b/scripts/attendance/w4c0-dml-inventory/calculation-read-classification.cjs
@@ -23,6 +23,10 @@ const ATTENDANCE_CALCULATION_READ_CLASSIFICATIONS = Object.freeze([
   entry('packages/core-backend/src/attendance/w4c3a-import-rollback-boundary.ts', 'legacyDeleteEligible', 'attendance_record_calculations', 1, 'history', 'rollback_precondition'),
   entry('packages/core-backend/src/attendance/w4c3a-import-rollback.ts', 'buildAuthorizationInput', 'attendance_record_calculations', 1, 'history', 'rollback_history'),
   entry('packages/core-backend/src/attendance/w4c3a-rollout-control.ts', 'loadBatchReferenceState', 'attendance_record_calculations', 3, 'history', 'rollout_precondition'),
+  // W4C-5: the ingress-review predicate reads the calculation history twice — once to test the
+  // record's latest-appended calculation for the review outcome code, once (MAX(version)) to
+  // determine which calculation is latest. Neither is the "current" projection.
+  entry('packages/core-backend/src/attendance/w4c3a-rollout-control.ts', 'countUnresolvedIngressReviews', 'attendance_record_calculations', 2, 'history', 'rollout_precondition'),
   entry('packages/core-backend/src/attendance/w4c3b-approved-leave-cancellation.ts', 'appendApprovedLeaveCancellationCalculationV1', 'attendance_record_calculations', 2, 'history', 'approval_reversal_precondition'),
   entry('packages/core-backend/src/attendance/w4c3b-approved-leave-cancellation.ts', 'appendApprovedLeaveCancellationCalculationV1', 'attendance_record_segments', 1, 'history', 'approval_reversal_precondition'),
   entry('packages/core-backend/src/attendance/w4c3c-active-current.ts', '(module-scope)', 'attendance_record_calculations', 2, 'current', 'active_current_projection', 'current_relation=attendance_current_records'),

--- a/scripts/attendance/w4c0-dml-inventory/current-record-read-classification.cjs
+++ b/scripts/attendance/w4c0-dml-inventory/current-record-read-classification.cjs
@@ -23,6 +23,9 @@ const ATTENDANCE_RECORD_BASE_READ_CLASSIFICATIONS = Object.freeze([
   entry('packages/core-backend/src/attendance/w4c3a-legacy-plan-preconditions.ts', 'revisionMatches', 2, 'write_precondition'),
   entry('packages/core-backend/src/attendance/w4c3a-rollout-control.ts', 'lockTargetsAndParents', 1, 'rollout_precondition'),
   entry('packages/core-backend/src/attendance/w4c3a-rollout-control.ts', 'loadBatchReferenceState', 1, 'rollout_precondition'),
+  // W4C-5: entry into eligible|authoritative locks every candidate record row (FOR UPDATE) while
+  // it re-evaluates whether the record still carries an unresolved legacy-ingress review.
+  entry('packages/core-backend/src/attendance/w4c3a-rollout-control.ts', 'countUnresolvedIngressReviews', 1, 'rollout_precondition'),
   entry('packages/core-backend/src/attendance/w4c3b-approved-leave-cancellation.ts', 'appendApprovedLeaveCancellationCalculationV1', 1, 'approval_reversal_write_lock'),
   entry('plugins/plugin-attendance/index.cjs', 'loadAttendanceRecordForUpdate', 1, 'write_lock'),
   entry('plugins/plugin-attendance/index.cjs', 'applyAttendanceResultEdit', 1, 'correction_write_lock'),

--- a/scripts/attendance/w4c0-dml-inventory/p25-call-path-classification.cjs
+++ b/scripts/attendance/w4c0-dml-inventory/p25-call-path-classification.cjs
@@ -45,6 +45,10 @@ const P25_CALL_PATH_CLASSIFICATIONS = Object.freeze([
   entry('packages/core-backend/src/attendance/w4c3a-rollout-control.ts', 'countRetryableJobPostureMismatches', 'attendance_import_jobs', 'read', 'select', 1, 'concurrency_control', 'rollout_transition_guard'),
   entry('packages/core-backend/src/attendance/w4c3a-rollout-control.ts', 'countNonterminalNullVersionLegacyJobs', 'attendance_import_jobs', 'read', 'select', 1, 'concurrency_control', 'rollout_transition_guard'),
   entry('packages/core-backend/src/attendance/w4c3a-rollout-control.ts', 'countIncompleteOperations', 'attendance_import_jobs', 'read', 'select', 1, 'concurrency_control', 'rollout_transition_guard'),
+  // W4C-5 P2-4: resume-only predicate — a retryable V1 job joined against
+  // attendance_result_operations to detect "preserved authoritative jobs remain retryable
+  // WITHOUT operation rows" (amendment section 3 bullet 9).
+  entry('packages/core-backend/src/attendance/w4c3a-rollout-control.ts', 'countRetryableJobsWithOperationRows', 'attendance_import_jobs', 'read', 'select', 1, 'concurrency_control', 'rollout_transition_guard'),
   entry('packages/core-backend/src/attendance/w4c3a-sync-import-host.ts', 'assertNoBlockingV1Job', 'attendance_import_jobs', 'read', 'select', 1, 'concurrency_control', 'sync_rejection_preflight'),
   entry('packages/core-backend/src/db/migrations/zzzz20260725120000_w4c0_attendance_segment_calculation_durable_storage.ts', 'down', 'attendance_import_jobs', 'read', 'select', 1, 'schema_migration', 'migration'),
   entry('packages/core-backend/src/db/migrations/zzzz20260730120000_w4c3a_durable_legacy_execution_plan.ts', 'rejectExistingV1', 'attendance_import_jobs', 'read', 'select', 1, 'schema_migration', 'migration'),

--- a/scripts/attendance/w4c0-dml-inventory/p25-call-path-classification.cjs
+++ b/scripts/attendance/w4c0-dml-inventory/p25-call-path-classification.cjs
@@ -40,6 +40,11 @@ const P25_CALL_PATH_CLASSIFICATIONS = Object.freeze([
   entry('packages/core-backend/src/attendance/w4c3a-legacy-plan-worker-repository.ts', 'mapStoredChunk', 'attendance_import_upload_cleanup_commands', 'write', 'insert', 1, 'operational_status', 'private_worker'),
   entry('packages/core-backend/src/attendance/w4c3a-rollout-control.ts', 'lockJobsBatchesAndItems', 'attendance_import_jobs', 'read', 'select', 1, 'concurrency_control', 'rollout_transition_guard'),
   entry('packages/core-backend/src/attendance/w4c3a-rollout-control.ts', 'loadBatchReferenceState', 'attendance_import_jobs', 'read', 'select', 1, 'concurrency_control', 'rollout_transition_guard'),
+  // W4C-5: retryable-job posture, non-terminal-legacy-job, and incomplete-operation predicates
+  // each read attendance_import_jobs under the exclusive rollout lock to re-evaluate section 3.
+  entry('packages/core-backend/src/attendance/w4c3a-rollout-control.ts', 'countRetryableJobPostureMismatches', 'attendance_import_jobs', 'read', 'select', 1, 'concurrency_control', 'rollout_transition_guard'),
+  entry('packages/core-backend/src/attendance/w4c3a-rollout-control.ts', 'countNonterminalNullVersionLegacyJobs', 'attendance_import_jobs', 'read', 'select', 1, 'concurrency_control', 'rollout_transition_guard'),
+  entry('packages/core-backend/src/attendance/w4c3a-rollout-control.ts', 'countIncompleteOperations', 'attendance_import_jobs', 'read', 'select', 1, 'concurrency_control', 'rollout_transition_guard'),
   entry('packages/core-backend/src/attendance/w4c3a-sync-import-host.ts', 'assertNoBlockingV1Job', 'attendance_import_jobs', 'read', 'select', 1, 'concurrency_control', 'sync_rejection_preflight'),
   entry('packages/core-backend/src/db/migrations/zzzz20260725120000_w4c0_attendance_segment_calculation_durable_storage.ts', 'down', 'attendance_import_jobs', 'read', 'select', 1, 'schema_migration', 'migration'),
   entry('packages/core-backend/src/db/migrations/zzzz20260730120000_w4c3a_durable_legacy_execution_plan.ts', 'rejectExistingV1', 'attendance_import_jobs', 'read', 'select', 1, 'schema_migration', 'migration'),

--- a/scripts/ops/attendance-w4c0-dml-inventory-collector.test.mjs
+++ b/scripts/ops/attendance-w4c0-dml-inventory-collector.test.mjs
@@ -793,7 +793,7 @@ test('P25: generated runtime call-path census classifies every closed-table read
   const { sites } = buildP25CallPathCensus(source)
   const result = classifyP25CallPathSites(sites)
 
-  assert.equal(sites.length, 105, 'the current generated P25 read/write inventory must remain explicit')
+  assert.equal(sites.length, 108, 'the current generated P25 read/write inventory must remain explicit')
   assert.deepEqual(result.unclassified, [], 'a new P25 table/site or renamed wrapper must not inherit a broad allowlist')
   assert.deepEqual(result.countDrift, [], 'an extra P25 access in an existing wrapper must require an explicit classification')
   assert.deepEqual(result.stale, [], 'removing a P25 access must retire its classification deliberately')

--- a/scripts/ops/attendance-w4c0-dml-inventory-collector.test.mjs
+++ b/scripts/ops/attendance-w4c0-dml-inventory-collector.test.mjs
@@ -793,7 +793,7 @@ test('P25: generated runtime call-path census classifies every closed-table read
   const { sites } = buildP25CallPathCensus(source)
   const result = classifyP25CallPathSites(sites)
 
-  assert.equal(sites.length, 108, 'the current generated P25 read/write inventory must remain explicit')
+  assert.equal(sites.length, 109, 'the current generated P25 read/write inventory must remain explicit')
   assert.deepEqual(result.unclassified, [], 'a new P25 table/site or renamed wrapper must not inherit a broad allowlist')
   assert.deepEqual(result.countDrift, [], 'an extra P25 access in an existing wrapper must require an explicit classification')
   assert.deepEqual(result.stale, [], 'removing a P25 access must retire its classification deliberately')


### PR DESCRIPTION
## HOLD — Draft, do not merge

This PR is **Draft** and **HOLD**. It implements the W4C-5 canonical
transition-boundary hardening only. It does not transition any environment,
change any flag, touch staging, run any soak, use production/customer data,
send any external notification, or change the state of issue #4556 in any
way. Per the authorizing message, it stops here after passing a fresh
exact-head independent gate.

## Authorization (verbatim, owner session, 2026-08-05)

> RATIFY `2a2a5eee4f00abceff94ed6360e8c051708e35f7`，OD-W4C-61=(a)。授权 W4C-5
> core hardening 从 fresh main 开工，保持 Draft/HOLD，完成 fresh exact-head 独立门后停下。
> 不授权任何 transition/flag/staging/soak/部署/生产数据/外部通知/关闭 #4556、不授权 PR 合并。

Contract: `docs/development/attendance-issue-4556-w4c5-transition-safety-amendment-20260804.md`
@ `2a2a5eee4f00abceff94ed6360e8c051708e35f7` (merged as #4747), sections 0-6,
`OD-W4C-61=(a)`.

## Response to fresh exact-head independent gate (20260805, verdict CHANGES-REQUESTED, P1=2/P2=4/P3=2/NIT=4)

A fresh exact-head independent gate at `69c902d7dfb5e20af91686d3a01b0f8e278ae82d`
found 2 P1 / 4 P2 / 2 P3 / 4 NIT findings. All are now addressed on this
branch (9 incremental commits, `69c902d7d..c8cf5fad4`); see the sections
below (each carries an inline retraction/correction where the gate refuted
something this body previously claimed) for the per-clause detail. Summary:

- **P1-1** (both required `test` checks red, caused by this PR's own new
  reads): fixed by registering the three new predicate read sites in the
  W4C-0 §8.4/W4C-4 §12.7 census + bumping the P25 pin. **While re-running
  the now-unblocked "Run attendance integration tests" CI step for the
  first time, found and fixed a second failure in
  `attendance-w4c3a-import-rollback.db.test.ts`**: two tests there call
  `transitionAttendanceCalculationRolloutV1` with the pre-amendment 6-field
  input shape (missing `expectedState`/`expectedVersion`/
  `evidenceManifestSha256`/`evidenceReferences`). **RETRACTION (NEW-A, PR
  #4773 exact-head independent DELTA gate, 20260805)**: the original
  version of this bullet characterized that failure as "a SECOND,
  unrelated, pre-existing bug ... (a file this PR never touches)." That is
  wrong on the two qualifiers that matter. It is not pre-existing on
  `origin/main`: `origin/main`'s `normalizeTransitionInput` accepts the
  6-field shape with no exact-key contract, so the same test call passes
  there. It is not unrelated: this PR's own first commit (`7dc837fc8`)
  introduced the strict exact-key input contract (§2.1's 8-field/manifest
  requirement) that the 6-field call shape violates — the breakage is
  caused by this PR's own input-contract tightening, not by an
  independent pre-existing defect. "A file this PR never touches" is true
  but is the byte-identical shield (越界盾只护旧行): it does not reach the
  PR's own NEW lines, and the new lines here are exactly the validator
  that broke the sibling test. The failure was also dormant-red from
  `7dc837fc8` onward and only surfaced once the P1-1 census fix let the
  "Run attendance integration tests" CI step run far enough to reach it —
  no CI gate could see it for seven commits. Corrected characterization:
  introduced by this PR's own first commit (`7dc837fc8`), masked by the
  P1-1 census red, fixed in `e4094d1e9` (updates the two call sites'
  input shape to the amendment's 8-field/manifest contract; no production
  logic changed). See "Checks" below for exact before/after.
- **P1-2** (§2.6 not achieved — SERIALIZABLE snapshot taken before the
  exclusive lock is *granted*, not just before BEGIN, so a defect
  committed during the lock *wait* was invisible; 4 constructed races,
  RACE E with zero protocol violations by any actor, refuted this body's
  "architecturally unconstructable / no window" claim): fixed at the
  root — the exclusive rollout lock is now acquired at PostgreSQL
  SESSION level (`pg_advisory_lock`/`pg_advisory_unlock`), as its own
  standalone statement, strictly BEFORE `BEGIN ISOLATION LEVEL
  SERIALIZABLE` is ever issued, instead of transaction-scoped
  (`pg_advisory_xact_lock`) inside the already-open transaction. See
  "Lock-sequencing fix" below for the mechanism and why no
  transaction-scoped acquisition, however early, can close this window.
  RACE A/C/D/E are now permanent real two/three-connection regression
  legs (mutation-confirmed: all 4 turn RED against the pre-fix code).
- **P2-1** (staleness version half untested): added a same-state-name/
  stale-version negative test (mutation-confirmed exclusive: exactly 1
  leg reds when the version comparison is deleted).
- **P2-2** (gate 9 inventory: 3 bypass syntaxes — Kysely builder, `.sql`,
  `.sh`+psql — walked past a raw-SQL-text-only, `.ts`-only grep):
  extended the pattern/extension set; 3 positive-decoy + 1 negative-
  control test.
- **P2-3** (request-snapshot predicate: 1 of 2 statuses × 2 of 4 defect
  kinds): investigated against the amendment's verbatim §3 text and the
  actual schema/plugin code (not re-guessed from the gate's paraphrase).
  Confirmed genuinely NOT safely implementable without an owner
  decision — see "Weak spots" §1 below for the specific verified blocking
  reason per unimplemented cell. Left as the same honest gap (doc comment
  already states the scope precisely); not narrowed further and not
  silently widened with an unverified proxy.
- **P2-4** (resume "without operation rows": zero implementation, zero
  test): implemented `countRetryableJobsWithOperationRows` (joins
  retryable V1 jobs against `attendance_result_operations`), gated on
  the resume pair only. **Side finding while testing it honestly**:
  `countIncompleteOperations` is gated only on the TARGET state
  (`eligible`/`authoritative`), so it already blocks ANY resume with ANY
  retryable job present, independent of the new predicate — appearing to
  make bullet 9's "remain retryable" language unreachable as wired today.
  Flagged for owner review in the code, not resolved by loosening an
  existing gate.
- **P3-1/P3-2, NIT-1..4**: doc-comment precision fixes + 2 test-hardening
  changes (matrix test now sources states from the exported
  `ATTENDANCE_ROLLOUT_STATES_V1` table instead of a second hardcoded
  literal; gate-9 inventory now walks `git ls-files --cached` instead of
  the raw working tree, with a positive-proof test). None change
  production behavior.

Still Draft/HOLD; nothing merged, armed, transitioned, or flagged on.

## Response to PR #4773 exact-head independent DELTA gate (20260805, head `c8cf5fad4`, verdict APPROVE-with-hardening, P1=0/P2=3)

A second, DELTA-scoped independent gate (over `69c902d7d..c8cf5fad4` — the 9
commits responding to the first gate above) found **0 P1** (both prior P1
genuinely closed and load-bearing) and 3 P2: P2-3 (residual, correctly
escalated, unchanged — see the P2-3 bullet above), plus two new findings on
the fix increment itself:

- **NEW-A** (an over-strong "unrelated/pre-existing" characterization of the
  import-rollback breakage in this body): **retraction-first correction
  applied** — see the corrected P1-1 bullet above and the corrected `Checks`
  table row below. Not a code change; the fix itself (`e4094d1e9`) was
  already correct and needed no rework.
- **NEW-B** (`acquireAttendanceCalculationRolloutLockSessionExclusiveV1`'s
  "connection must be idle" precondition was documented but not enforced or
  tested — a caller that pre-opens a transaction on the same connection
  before calling the transition silently reruns it inside that caller's
  already-fixed snapshot, PostgreSQL only WARNs on a nested `BEGIN`, no red
  test anywhere, silently reintroducing the exact P1-2 defect): **fixed** in
  a new commit (see "NEW-B hardening" below) — the precondition is now
  enforced as the acquire function's own first statement, fails closed with
  a dedicated error code, and has a discriminating regression test that
  reproduces the gate's exact probe.

## NEW-B hardening: enforced idle-connection precondition

`assertConnectionIsIdleForSessionExclusiveRolloutLockV1`
(`w4c0-identity.ts`) now runs as
`acquireAttendanceCalculationRolloutLockSessionExclusiveV1`'s own first
statement, before any lock side effect. It cannot use
`pg_current_xact_id_if_assigned()` (or any other xid-based probe):
PostgreSQL assigns a transaction ID lazily, on first WRITE, so a caller that
opened `BEGIN ISOLATION LEVEL SERIALIZABLE; SELECT 1;` — exactly the
dangerous shape — has no xid yet, and an xid probe would read "idle" for
both that case and genuine autocommit: a false negative on precisely the
case that matters.

Instead it issues `SAVEPOINT w4c5_idle_probe` as the probe. PostgreSQL
raises SQLSTATE `25P01` (`no_active_sql_transaction`, "SAVEPOINT can only be
used in transaction blocks") if and only if there is no open transaction
block on the connection, independent of xid assignment — verified
empirically against real PostgreSQL 15, both via `psql` directly and via
this codebase's own `pg` driver, before writing the source change. A
`25P01` proves idle (proceed); the SAVEPOINT succeeding proves an open
transaction already existed (`ROLLBACK TO SAVEPOINT` cleanup, then fail
closed with the new `W4C0_ROLLOUT_LOCK_CONNECTION_NOT_IDLE` code, an
`AttendanceW4IdentityError`); any other error is rethrown unchanged, never
silently treated as "idle."

New discriminating test
(`tests/integration/attendance-w4c3a-rollout-control.db.test.ts`, describe
block "W4C-5 NEW-B: the session-exclusive rollout lock requires an idle
connection — enforced, not just documented"): reproduces the gate's exact
probe (`BEGIN ISOLATION LEVEL SERIALIZABLE; SELECT 1;` on the same
connection, then call `transitionAttendanceCalculationRolloutV1` on it) and
asserts the `W4C0_ROLLOUT_LOCK_CONNECTION_NOT_IDLE` rejection, zero rollout
DML, and that the caller's own transaction is still open/usable afterward
(the probe's cleanup does not touch it); a companion positive control
proves the ordinary idle-connection call shape still transitions
successfully.

**Mutation-confirmed load-bearing**: removing the
`assertConnectionIsIdleForSessionExclusiveRolloutLockV1` call turns the new
discriminating test from a `W4C0_ROLLOUT_LOCK_CONNECTION_NOT_IDLE`
rejection back into `promise resolved "{ state: 'shadow' }"` — reproducing
the gate's exact finding — while the idle-connection positive control stays
green. Restored; full file 35/35 green afterward (33 pre-existing + 2 new),
with no regression to census (58/58), inventory unit tests (51/51 combined
with `w4c0-identity.test.ts`), or import-rollback + 2 neighbors (74/74). CI
confirmed executing this exact file at the raw job-log level (not just
"the job passed"): the "Run attendance integration tests" step for
`test (18.x)` at this commit shows `✓
tests/integration/attendance-w4c3a-rollout-control.db.test.ts (35 tests)`
— the count itself (33→35) is direct evidence the two new tests ran, not a
skip-shaped green (the CI reporter is `dot`, so individual test titles are
not printed in the raw log; the count match plus the identical local run is
the available evidence).

**Caller audit (repo-wide, not just the lock helper's one caller)**:
`transitionAttendanceCalculationRolloutV1` itself has exactly 3 references
anywhere in this repository — its own definition and the two integration
test files (`attendance-w4c3a-rollout-control.db.test.ts`,
`attendance-w4c3a-import-rollback.db.test.ts`). No production, plugin, or
route caller exists (consistent with the P2-3 disposition above: the
executable tool is a separate, later, separately-authorized PR). Both
import-rollback call sites were individually inspected: each passes a
freshly-`pool.connect()`ed, never-`BEGIN`-touched client into the
transition, so this hardening introduces zero regression risk to any
existing call site; all are already covered by the 74/74 green run above.

**Operational disclosure**: on every ordinary (idle-connection) call — the
normal case — the SAVEPOINT probe deliberately fails with a real
PostgreSQL server-side `ERROR: SAVEPOINT can only be used in transaction
blocks` (SQLSTATE `25P01`) before being caught and treated as "proceed."
This is expected control flow, not a bug, but it means every legitimate
transition now writes one `ERROR`-severity line to the PostgreSQL server
log — worth knowing before wiring any log-level-based alerting to this
boundary later.

**Worktree note**: this hardening was built in
`/private/tmp/ms2-w4c5-hardening`, an existing worktree already checked out
to this exact branch/head (`c8cf5fad4`) rather than a newly-created one —
`git worktree add` on the same local branch is exclusive, and the branch
was already checked out there. Verified before use: working tree clean, no
`.lock` files, no active process holding it open (`lsof`), and HEAD
matched `origin/claude/w4c5-transition-boundary-hardening-20260805` exactly
before any edit.

## What this PR is

Hardens `transitionAttendanceCalculationRolloutV1` in
`packages/core-backend/src/attendance/w4c3a-rollout-control.ts` — the ONLY
rollout-state/event DML path — per amendment sections 1-6. No route, flag,
generic plugin service, or second transition implementation is added. The
executable W4C-5 transition tool/runbook remains a separate, later, separately
authorized PR (amendment §8 step 4).

## §1-6 clause → landing point

| Clause | Landing |
| --- | --- |
| §1 closed 7-pair matrix | `LEGAL_TRANSITIONS` + `findLegalTransition` (`w4c3a-rollout-control.ts:70-85`); validated at input-normalization time (`~L291-294`, zero-DML fail) AND re-validated post-lock against the authoritative persisted state (`~L854-855`) |
| §1 comparison write posture via the canonical resolver's domain, never a raw string compare | `LEGAL_TRANSITIONS.comparisonWritePosture` mirrors `w4c0-identity.ts`'s `POSTURE_TABLE` domain (`legacy_projection_only\|shadow\|authoritative`); the retryable-job predicate compares against this field, never against the persisted rollout-state name |
| §2.1 validate org/actor/correlation/engine/expected-state/expected-version/target/manifest-sha256 | `normalizeTransitionInput` (`~L245-300`): `requireUuid`/`requireText`/`requireRolloutState`/`requireExpectedVersion`/`requireManifestSha256`/`requireEvidenceReferences`, exact-key input shape via `requireExactInputKeys` |
| §2.2 exclusive org rollout lock first | `acquireAttendanceCalculationRolloutLock(trx, orgKey, 'exclusive')` — first DB call in `transitionAttendanceCalculationRolloutV1` |
| §2.3 missing state only for exact allowlisted org + only `legacy->shadow` | `lockRolloutStateForBootstrapOrRead` (`~L400-425`) |
| §2.4 reject stale expected state/version + any pair absent from §1 | staleness check (`~L849`) + post-lock matrix re-check (`~L854-855`) |
| §2.5 existing operation/batch/target lock domain, canonical order | `lockControlDomain` + `allOrgBatchIds`/batch-closure loop — reused unchanged from the pre-existing implementation |
| §2.6 re-evaluate every §3 predicate under those locks | `countRetryableJobPostureMismatches` / `countNonterminalNullVersionLegacyJobs` / `countIncompleteOperations` / `countUnresolvedIngressReviews` / `countDefectivePendingRequestSnapshots`, each `SELECT ... FOR UPDATE`, called only after the lock domain is acquired |
| §2.7 one event: manifest hash, correlation ID, precondition counters, source/target states, comparison posture, evidence references | the `INSERT INTO attendance_calculation_rollout_events` evidence JSON (`~L897-921`) |
| §2.8 update state only after event insert succeeds; commit/rollback together | event INSERT precedes the state UPDATE (literal order); both inside one `runAttendanceResultOperationTransactionV1` transaction |
| §3 predicates | see table below — implemented set vs named gap |
| §4 evidence manifest: command accepts hash + values-free references only, never collects/validates the manifest itself | `evidenceManifestSha256` (hex64) + closed `evidenceReferences` key set (`imageSha`, `ownerAuthorizationRef`, `syntheticOrgRef`, plus `ownerIncidentReviewRef`/`offlineReplayArtifactRef` required only for `suspended->authoritative`); stored verbatim, never parsed/interpreted |
| §5 tooling boundary: no direct rollout DML, no raw SQL escape hatch, no wildcard org, no implicit `--yes`/default target | out of scope for this PR by design — no tooling code added at all |
| §6 completion gates 1-9 | see gates table below; gate 10 (tool plan/apply mode) is explicitly out of scope — no tool exists yet |

### §3 predicate table

| Predicate (amendment §3 bullet) | Status | Landing |
| --- | --- | --- |
| exact named org + `scope='synthetic_staging'` | Implemented, every transition | `isAttendanceCalculationOrgAllowlistedV1` (new export, `w4c0-identity.ts`) reused — same allowlist the canonical posture resolver uses, not a copy; `scope='synthetic_staging'` is a durable CHECK constraint on every row this boundary can write |
| no nonterminal null-version legacy job, entry into shadow\|eligible\|authoritative | Implemented | `countNonterminalNullVersionLegacyJobs` |
| no incomplete operation/batch, entry into eligible\|authoritative | Implemented, **redefined** | see "Correction" below |
| every retryable job matches the pair's comparison posture, every transition | Implemented | `countRetryableJobPostureMismatches` |
| every pre-W4 import batch closed/frozen-preimage, every transition | Implemented (pre-existing, unchanged) | `allOrgBatchIds` + `loadBatchReferenceState` loop |
| eligibility/authority: zero pending/reversible request whose snapshot is missing/unsupported/payload-stale/reversal-incomplete | **Partial (P2-3, re-investigated, not re-narrowed)** | `countDefectivePendingRequestSnapshots` covers `missing` + `unsupported` for `status='pending'` only. **Still not implemented**, now with verified file:line reasons per cell (see "Weak spots" §1 below): "reversible" is concretely `request_type==='leave' && status==='approved'` (`plugin-attendance/index.cjs:34090`), not any-type-approved — a blanket implementation would be wrong, not just incomplete; `payload-stale` has no plugin-independent live-row reconstruction function today; `reversal-incomplete`'s one existing flow is fully atomic (may be provably unreachable, mirroring Correction 1) but bullet 6 covers types beyond `leave` this PR has not verified are equally atomic. Owner decision needed per cell |
| eligibility/authority: zero unresolved `legacy_time_ingress_not_authoritative` review | Implemented, **redefined** | see "Correction" below; P3-1 doc note added: a later `review_required` calculation for a DIFFERENT reason also clears this specific predicate (outcome-agnostic by design) |
| suspend serializes every source writer, zero operation/source/result/pointer/job DML | Implemented structurally | the function never touches those tables for any pair; proven by the "blocks a legitimate shared-lock job-writer" race + the exhaustive-matrix walk (suspend leg touches only `rollout_state`/`rollout_events`) |
| resume: prior state authoritative, preserved-authoritative jobs retryable **without operation rows**, offline replay reports zero critical diffs | **Partial → improved (P2-4)** | prior-state check is the ordinary matrix/staleness check; preserved-authoritative jobs are `countRetryableJobPostureMismatches` (unchanged) PLUS the new `countRetryableJobsWithOperationRows` (resume-pair-only, joins retryable V1 jobs against `attendance_result_operations`) for the "without operation rows" clause that was previously zero-implemented/zero-tested; the offline-replay CONTENT remains architecturally external (§4), unchanged. See "Weak spots" §2c for a side finding about `countIncompleteOperations` interacting with this bullet, flagged not resolved |

**Two corrections made during implementation** (both discovered via direct
trigger/constraint inspection, not assumption):

1. `attendance_result_operations`/`attendance_result_operation_batches`
   `state='claimed'` is **provably non-durable** — a deferred COMMIT-time
   constraint trigger (`attendance_w4_*_claimed_commit_guard`) forbids any
   transaction from committing while a row it touched is still `claimed`. A
   predicate querying for persisted `claimed` rows is dead code (always 0).
   Redefined "incomplete operation" against lock section 9's own text
   ("Promotion drains or cancels every incomplete org operation before
   changing posture") as V1 jobs (`w4_contract_version=1`) with
   `status <> 'completed'`.
2. The pointer-guard trigger forbids `attendance_records.current_calculation_id`
   from ever referencing a `review_required` calculation (pointer target must
   be `authoritative` + `completed|reversed`). "Unresolved review" cannot mean
   "still the current pointer" (that's structurally impossible); it is instead
   defined against the append-only calculation history: still unresolved while
   it remains the record's LATEST appended calculation.

### Completion gates (amendment §6)

| Gate | Status | Evidence |
| --- | --- | --- |
| 1. Seven pairs pass, all others fail with zero rollout DML | Done | "rejects every pair outside the closed 7-pair matrix" (25-combo exhaustive, input-time reject, zero DB touch for the 18 illegal) + "walks all seven legal pairs to completion" |
| 2. Removing one pair guard makes its negative mutation red | Done (manual) | see mutation table |
| 3. Missing state cannot be created for a non-allowlisted org | Done | "refuses a non-allowlisted org and creates zero rollout-state row" + "refuses to bootstrap a missing row for a non-legacy-to-shadow claimed pair, even when allowlisted" |
| 4. Read-only preflight cannot be reused after a locked predicate changes | Done, **strengthened (P2-1)** | real two-connection TOCTOU race (state-name half) + a same-state-name/stale-version negative test (version half — previously untested; mutation-confirmed exclusive) |
| 5. Each §3 predicate has positive/negative/remove-the-predicate legs on real PostgreSQL | Partial → **improved** | positive+negative real-DB for every implemented predicate; remove-the-predicate is a manual mutation cycle for the original 5 predicates (documented below), but now a PERMANENT CI-run test for the staleness version half (P2-1), gate-9's 3 bypass syntaxes (P2-2), and the resume operation-rows predicate (P2-4, both legs) |
| 6. Two-connection races cover request snapshot, review, operation, retryable job, legacy batch, suspend, resume | **RETRACTED as originally graded (P1-2)** → now genuinely **Partial, improved**: RACE A (retryable job)/C (operation)/D (review)/E (request-snapshot, 3-actor) are now live real two/three-connection races, landed as permanent regression legs, replacing the refuted "unconstructable" claim. Still not raced live: legacy-batch-closure and resume's operation-rows predicate (both real-DB positive/negative tested, not raced) |
| 7. Failed event insert → state/version unchanged; failed state update → no event | Done | two dedicated tests, one per clause, using two independent failure-injection seams |
| 8. Event evidence exact-key tests require manifest hash + correlation ID, reject secrets/raw payloads | Done | 5 tests: bad hex, extra key, missing resume keys, raw-JSON-shaped value, exact-shape positive |
| 9. Repository inventory: no second transition DML, no direct tooling DML | Done, **hardened (P2-2, NIT-3)** | mechanical grep-based inventory test, now over `git ls-files --cached` (git-tracked files only, not the raw working tree) and over 3 bypass syntaxes (Kysely builder, `.sql`, `.sh`+psql) in addition to raw-SQL `.ts` text |
| 10. Tool plan mode zero DML; apply mode hard-blocked | **Out of scope** | no tool exists in this PR; deferred to the separately authorized, separately gated tooling PR (amendment §8 step 4) |

## TOCTOU — real two-connection concurrency (the core ask)

All in `packages/core-backend/tests/integration/attendance-w4c3a-rollout-control.db.test.ts`,
run against real PostgreSQL (`vitest.integration.config.ts`), two independent
`pg.PoolClient` connections, explicit commit ordering:

1. **Staleness (the headline finding)** — "rejects a transition whose
   caller-supplied preflight went stale under a concurrent committed
   transition": a lock-free `SELECT` (simulated preflight) captures
   `shadow`/`v2`; connection B starts a real `shadow->eligible` transition and
   is paused (test barrier) immediately after acquiring the exclusive rollout
   lock; connection A starts `shadow->legacy` using the stale snapshot and is
   proven genuinely blocked (`settled === false` after 75ms) on the same
   advisory lock; B is released, commits (`eligible`/`v3`); A then acquires
   the lock, re-reads under lock, and is rejected
   `STALE_EXPECTED_STATE` — zero rollout DML from A.
2. **Retryable-job writer serialization** — "blocks a legitimate shared-lock
   job-writer for the whole duration of an in-flight transition": while a
   `legacy->shadow` transition holds the exclusive lock, a second connection's
   `acquireAttendanceCalculationRolloutLock(trx, org, 'shared')` (the exact
   primitive every legitimate job-writer must call first, per lock section 9)
   is proven genuinely blocked, then unblocks only after the transition
   commits and releases.
3. **Legacy batch** — the two pre-existing tests (`serializes close then
   transition...` / `serializes transition before a competing close...`)
   already proved this with real two-connection, two-commit-order
   interleaving; unchanged, still passing.

**RETRACTED (P1-2, PR #4773 exact-head independent gate, 20260805)**: the
paragraph in this position previously claimed the "a job is INSERTed while
the transition is paused, and the transition's own read then sees it" race
was "architecturally unconstructable" with "no window for the race to
matter in production." Both claims were false and were refuted by 4
constructed real two/three-connection races (RACE A/C/D/E below), one
(RACE E) production-shaped with zero protocol violations by any actor. The
window this body missed is not the exclusive lock's HOLD (correctly proven
above to serialize) but its WAIT — bounded by `W4_ADVISORY_HELPER_WAIT_MS`
= 5000ms — during which the transaction had not yet started, so its
SERIALIZABLE snapshot (fixed at the transaction's first statement) could
predate a defect a legitimate shared-lock-respecting writer committed
while this caller was still waiting to acquire the lock.

### Lock-sequencing fix (P1-2)

Root cause: `runAttendanceResultOperationTransactionV1` issues `BEGIN
ISOLATION LEVEL SERIALIZABLE` then a `SELECT set_config(...)` statement,
which fixes the transaction's snapshot. Only afterwards did
`transitionAttendanceCalculationRolloutV1` acquire the exclusive rollout
lock and *wait* on a transaction-scoped `pg_advisory_xact_lock`. PostgreSQL
fixes a SERIALIZABLE snapshot at the START of the first statement executed
in a transaction — including a statement that itself blocks — so no
transaction-scoped acquisition, no matter how early inside the
transaction, can close this window: the snapshot-fixing statement and the
(possibly blocking) lock-acquisition statement cannot be pulled apart once
both live inside the same transaction.

Fix: the exclusive lock is now acquired at PostgreSQL SESSION level
(`pg_advisory_lock`/`pg_advisory_unlock`, not `_xact_`), as its own
standalone (autocommit) statement, on a connection that must be idle (no
open transaction) — strictly BEFORE `BEGIN` is ever issued.
Session-vs-transaction-scoped advisory locks share one lock table
(PostgreSQL docs 9.27.9/13.3.5), so this still correctly blocks behind
every existing `pg_advisory_xact_lock_shared` writer (verified: the two
pre-existing "serializes close/transition..." tests below, which race
`closeLegacyRollbackWindowV1` — deliberately left on the old
transaction-scoped acquisition, out of this amendment's scope — against
the now-session-scoped `transitionAttendanceCalculationRolloutV1`, still
pass unmodified). Over the standard synchronous (non-pipelined)
`pg`/`PoolClient` protocol, `BEGIN` is not dispatched until the blocking
acquisition has already returned, so the new transaction's snapshot can
only be established strictly after every previous holder released.
`closeLegacyRollbackWindowV1` is intentionally unchanged (§2 names "the
canonical transition function", singular); its stale-snapshot
whole-transaction retry in `runControlTransaction` stays in place for it.

### RACE A/C/D/E — now permanent regression legs

All in the same real-DB two/three-connection style as the legs above (no
barrier hook on the contended leg; `settled === false` asserted after
150ms before the writer is allowed to commit):

| Leg | Writer shape | Pre-fix (reproduced) | Post-fix |
| --- | --- | --- | --- |
| RACE A | shared lock + bare INSERT of a retryable job frozen at the wrong posture, committed DURING the wait | `RESOLVED` (defect uncaught) | `REJECTED: RETRYABLE_JOB_POSTURE_MISMATCH` |
| RACE C | shared lock + bare INSERT of an incomplete V1 job, committed DURING the wait; `shadow -> eligible` | `RESOLVED` | `REJECTED: INCOMPLETE_OPERATION` |
| RACE D | shared lock + bare INSERT of an unresolved ingress review, committed DURING the wait; `shadow -> eligible` | `RESOLVED` | `REJECTED: UNRESOLVED_REVIEW` |
| RACE E (3-actor, zero protocol violations) | C1 = protocol-compliant shared-lock holder (creates the wait window only); C2 = an ordinary pending-request writer with NO rollout-lock obligation, committing independently of C1/T; T = the transition | `RESOLVED` | `REJECTED: REQUEST_SNAPSHOT_DEFECTIVE` |

Mutation self-check: reverted the P1-2 fix to the pre-fix code on this
branch's own history, re-ran — all 4 legs turned RED exactly as the
pre-fix table above states, reproducing the gate's original finding;
restored via a saved pre-mutation copy (never a broad `git checkout --
.`); full suite green again after restore.

## Mutation self-check (manual — commit-then-mutate-then-revert, per repo discipline)

Each guard neutered on the committed HEAD, target test(s) re-run (red
confirmed), then `git checkout --` reverted the single file:

| Guard neutered | Test(s) that went red | Result |
| --- | --- | --- |
| input-time matrix check (`findLegalTransition`) | "rejects every pair outside the closed 7-pair matrix" | RED → reverted |
| staleness check | "rejects a transition whose caller-supplied preflight went stale..." | RED (caught by the secondary post-lock matrix check instead — different code, same red) → reverted |
| org-allowlist check | "refuses a non-allowlisted org and creates zero rollout-state row" | RED → reverted |
| all 5 §3 predicate `fail()` calls (single combined mutation) | exactly the 6 corresponding predicate tests went RED; the other 17 stayed GREEN (discriminating power confirmed) | RED → reverted |
| repository-inventory grep pattern (decoy second writer file added) | inventory test | RED → deleted the decoy |

Every neutering was reverted before the final commit; `git status` and 3x
repeat full-suite runs confirm a clean, stable tree.

## Checks (local, real Postgres — commands + results)

**RETRACTION (P1-1, PR #4773 exact-head independent gate, 20260805)**: the
original version of this section reported clean local runs with no
mention that both required CI checks (`test (18.x)`, `test (20.x)`) were
RED at the audited head, caused by this PR's own new predicate reads not
being registered in the W4C-0 §8.4/W4C-4 §12.7 census. That omission
itself violated repo doctrine (被触发≠被验证 / retraction-first). Corrected
below with the full before/after, including a SECOND red cause the P1-1
fix exposed by letting the job proceed further for the first time (see
the gate-response summary above).

CI history on this branch (`gh pr checks 4773`, both required legs):

| Head | `test (18.x)` | `test (20.x)` | Cause |
| --- | --- | --- | --- |
| `69c902d7d` (gate-audited) | RED | RED | P1-1: 4 sub-tests in the W4C-0 §8.4/W4C-4 §12.7 census collector failed on this PR's new unregistered predicate reads |
| `abfd86f9d` (+ census fix) | (not directly re-run standalone) | | census collector 58/58 locally; full CI re-run happened at later heads below |
| `b5297561d` (+ P1-2 + hygiene) | RED | (pending at push time) | "Run attendance integration tests" step — 2 test failures + 1 cascading hook timeout in `attendance-w4c3a-import-rollback.db.test.ts`. **RETRACTION (NEW-A, PR #4773 exact-head independent DELTA gate, 20260805)**: this row previously called the cause "different, unrelated" and "confirmed pre-existing on `69c902d7d`, not a P1-2 regression." Both are wrong — see the retraction under the P1-1 bullet above for the full correction. Precisely: caused by this PR's own first commit `7dc837fc8` (the exact-key input contract), not present as a failure on `origin/main`, and masked (not "pre-existing separately from") the P1-1 census red until that red was fixed. |
| `e4094d1e9` (+ import-rollback fix) | cancelled (superseded by the next push before it finished standalone) | cancelled (same) | fixed the two `attendance-w4c3a-import-rollback.db.test.ts` call sites' input shape to the amendment's 8-field/manifest contract (see corrected P1-1 bullet above); this fix is included in `c8cf5fad4` below, where both legs ran to completion GREEN |
| `c8cf5fad4` (gate-audited DELTA head) | **GREEN** (verified `gh api .../commits/c8cf5fad4/check-runs`) | **GREEN** (same) | PR #4773 exact-head independent DELTA gate (20260805): 18 required checks GREEN; verdict APPROVE-with-hardening, P1=0, P2=3 (P2-3 correctly escalated owner-item; NEW-A this retraction; NEW-B below) |
| `e0198b415` (+ NEW-B fix, post-DELTA-gate hardening) | see PR checks for current status | see PR checks for current status | NEW-B: `acquireAttendanceCalculationRolloutLockSessionExclusiveV1` now enforces (SAVEPOINT probe, SQLSTATE `25P01`) the "connection must be idle" precondition it previously only documented — see "NEW-B hardening" below |

Local, real Postgres, current HEAD (`c8cf5fad4`):

```
$ cd packages/core-backend && npx tsc --noEmit -p tsconfig.json
(clean, no output)

$ node --test scripts/ops/attendance-w4c0-dml-inventory-collector.test.mjs
tests 58 / pass 58 / fail 0

$ vitest run src/attendance/__tests__/w4c3a-rollout-control-inventory.test.ts
Test Files  1 passed (1)
     Tests  7 passed (7)

$ DATABASE_URL=<fresh scratch> ATTENDANCE_TEST_DATABASE_URL=<same> \
  npx tsx src/db/migrate.ts && \
  npx vitest --config vitest.integration.config.ts run \
    tests/integration/attendance-w4c3a-rollout-control.db.test.ts \
    tests/integration/attendance-w4c3a-import-rollback.db.test.ts \
    tests/integration/attendance-w4c0-db-gates-e1.db.test.ts \
    tests/integration/attendance-w4c3b-approved-leave-cancellation.db.test.ts
Test Files  4 passed (4)
     Tests  107 passed (107)
```

(`attendance-w4c3a-rollout-control.db.test.ts` alone: 33 passed (33) — 23
original + 4 RACE A/C/D/E + 3 lock-hygiene + 1 P2-1 staleness + 2 P2-4
resume. **Self-caught correction**: the P2-4 commit message on this
branch states "35 passed (35)" for this file — that was a miscount in
the commit message text; the actual local run at that point genuinely
passed, at 33, not 35.)

The DB test file is already double-wired (unchanged, since this is an
existing file, not a new one): `packages/core-backend/vitest.config.ts`
exclude list + `.github/workflows/plugin-tests.yml`
`attendance-real-db-integration` step — the "attendance integration gate"
this repo already runs real-DB attendance suites through.

## Weak spots I am self-reporting (not discovered by a later reviewer)

1. **Request-snapshot predicate is narrower than the amendment's literal
   text.** Only `missing` and `unsupported` latest-attribution-posture are
   checked, for `status='pending'` calculation-affecting requests only. The
   gate (P2-3) correctly graded this a contract gap, not a classification
   erratum, and asked for either implementation or a specific, verified
   blocking reason per unimplemented cell — not the original vague "side
   tables I did not fully map." Re-investigated against the amendment's
   verbatim §3 text and the actual schema/plugin code (not re-guessed from
   the gate's paraphrase); still NOT implemented, now with concrete,
   file:line-verified reasons per cell:
   - **"reversible" (approved-but-cancellable) half**: verified
     `plugins/plugin-attendance/index.cjs:34090` —
     `approvedLeave = requestRow.status === 'approved' &&
     requestRow.request_type === 'leave'` is the ONLY condition under which
     an already-`approved` request can be cancelled today. It is NOT "any
     approved calculation-affecting request" — a naive
     `status IN ('pending','approved')` across all 8
     calculation-affecting types (§3's own closed set) would be WRONG
     (over-broad: flagging e.g. an approved `time_correction`, which this
     codebase treats as terminal/non-reversible once resolved, as if it
     needed a reversibility check that doesn't apply to it), not just
     incomplete. Needs an owner-confirmed scope before implementation —
     inventing a narrower-or-wrong proxy here is the repo's own named
     另造更窄同类物 failure mode, worse than the honest gap.
   - **`payload-stale`**: verified `buildAttendanceRequestCalculationPayloadFromRequestRowV1`
     (`w4c3b-request-snapshots.ts:331`) exists, but BOTH of its call sites
     (`w4c3b-request-snapshots.ts:959`, `:1087`) source `minutes`/
     `leaveTypeCode`/`outdoorPunch` from a caller-supplied `payloadFields`
     parameter, never from a live DB read of `attendance_requests` or any
     side table. There is no generic, plugin-independent function this
     control-boundary module (which deliberately has no plugin dependency,
     per its own header) can call to reconstruct "the live payload" of an
     existing pending/approved request for fingerprint comparison — that
     knowledge is per-request-type and currently lives only in the plugin
     at create/edit time, not as a queryable live-row projection. Needs a
     decision on whether/where such a function should be added.
   - **`reversal-incomplete`**: the one existing reversal flow (approved-
     leave cancellation, `plugins/plugin-attendance/index.cjs` around
     `:34150-34272`) is fully atomic in ONE transaction (approval revoke +
     `attendance_requests.status` update + leave-balance reversal +
     cancellation calculation, all-or-nothing under the same commit/
     rollback) — a durable "incomplete reversal" state may be provably
     impossible for THIS flow specifically, mirroring this PR's own
     "Correction 1" (claimed-state) pattern. But §3 bullet 6 covers ALL
     "reversible" calculation-affecting requests, not just `leave`, and I
     do not have equal certainty every other type's (if any) reversal path
     is equally atomic. Needs owner confirmation of which types have a
     "reversible" concept at all before this cell can be closed either way.
2. **Engine-version compatibility is not validated.** §9 requires "compatible
   engine version" for resume; this PR only validates `engineVersion` is a
   non-empty string, never against a canonical compatibility registry (none
   exists yet in this codebase that I found).
2b. **RETRACTED as originally worded (P1-2)** — this item previously said gate
   6's live-race coverage was "partial by construction, not oversight," citing
   the now-retracted "Explicit non-construction" paragraph. That reasoning was
   refuted (see the Lock-sequencing fix / RACE A/C/D/E sections above).
   Corrected status: RACE A (retryable job), RACE C (operation/incomplete),
   RACE D (review), and RACE E (request-snapshot, 3-actor) now all have live
   two/three-connection races, landed as permanent regression legs. Still
   not covered by a live race: the legacy-batch-closure and resume
   "without operation rows" predicates specifically (though resume's
   `attendance_result_operations` join is now real-DB positive/negative
   tested, just not raced).
2c. **P2-4 side finding, not silently resolved**: implementing "preserved
   authoritative jobs remain retryable without operation rows" honestly
   (i.e. writing a real positive leg, not just the negative one) surfaced
   that `countIncompleteOperations` is gated only on the TARGET state
   (`ELIGIBILITY_AUTHORITY_TARGETS.has(input.targetState)`), unconditional
   on source state — so it already rejects ANY resume attempt with ANY
   retryable (queued/failed) V1 job present, independent of the new
   predicate. That appears to make bullet 9's "remain retryable" language
   unreachable as currently wired: there is no live combination where a
   retryable job survives suspend and resume still succeeds. Whether
   `countIncompleteOperations` should skip the resume pair specifically
   (so bullet 9's own predicate is the one that actually governs it) is a
   design question left for owner review — not resolved here by loosening
   an existing gate to make my own new test pass.
3. **`closeLegacyRollbackWindowV1` was intentionally left unchanged.** The
   amendment's §2 "Safe Command Boundary" targets "the canonical transition
   function" specifically; `closeLegacyRollbackWindowV1` doesn't mutate
   rollout state and was already TOCTOU-safe via its own re-check-under-lock
   pattern (proven by the two pre-existing serialization tests, still
   passing unmodified). It does not get the new org-allowlist or evidence-
   manifest requirements. I believe this is the correct reading of scope but
   flag it explicitly since it's a judgment call, not a mechanically forced
   one.
4. **The DB trigger `attendance_w4_rollout_state_guard` (pre-existing) is
   kept as a defense-in-depth backstop**, not removed. The TS-level matrix is
   the primary gate (validated first, zero-DML on failure); the DB trigger
   would only fire if something bypassed the TS boundary entirely (matches
   this repo's "same-process trusted, hostile-bypass is residual" threat
   model).
5. Gate 2/5's "remove-the-predicate" mutation legs for the ORIGINAL 5
   predicates were verified manually, once, on this HEAD, and reverted —
   they are not baked into a permanent CI-run mutation-test file (unchanged
   from the original report; still true for those 5). **Now permanent for
   the predicates added/hardened in response to the gate**: the staleness
   version half (P2-1), the gate-9 inventory's 3 bypass syntaxes (P2-2), and
   the resume "without operation rows" predicate (P2-4, both the negative
   leg and the discriminator leg) are real, committed, CI-run tests, not
   one-off manual mutation cycles — a future silent weakening of any of
   those four would be caught automatically.
6. **Self-caught commit-message error, corrected, not silently fixed by
   force-push**: the P2-4 commit on this branch states "35 passed (35)" for
   `attendance-w4c3a-rollout-control.db.test.ts`; the actual count at that
   point was 33 passed (33) — a miscount in the commit message text only,
   not in the underlying (genuinely passing) run. Left as an accurate
   historical commit message with this correction on top, per repo
   discipline against amending pushed commits without explicit request.

No transition tooling, runbook, flag, staging access, or issue-state change
is included. Refs #4556.


