### PR TITLE
fix(attendance): W4C-2 recovery-sweep fairness + values-free observability + call-through proof (#4770) [HOLD]

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -1128,6 +1128,8 @@ jobs:
             tests/integration/attendance-w4c2-p12-migration-schema-gates.db.test.ts \
             tests/integration/attendance-w4c2-p12-run-transactions.db.test.ts \
             tests/integration/attendance-w4c2-p12-durable-lock-gates.db.test.ts \
+            tests/integration/attendance-w4c2-sweep-fairness.db.test.ts \
+            tests/integration/attendance-w4c2-sweep-call-through.db.test.ts \
             tests/integration/attendance-w4c3a-durable-legacy-plan-migration.db.test.ts \
             tests/integration/attendance-w4c3a-canonical-import-kernel.db.test.ts \
             tests/integration/attendance-w4c3a-durable-plan-enqueue.db.test.ts \

--- a/packages/core-backend/src/attendance/w4c2-scheduled-run-ops-worker.ts
+++ b/packages/core-backend/src/attendance/w4c2-scheduled-run-ops-worker.ts
@@ -50,6 +50,27 @@ export interface AttendanceScheduledRunSweepTickResultV1 {
   readonly notReady: number
   readonly skipped: number
   readonly errored: number
+  /** Total `state='running'` rows at scan time (includes the `scanned` candidates themselves)
+   *  — the operator-facing starvation signal the fixed-prefix scan never exposed: a
+   *  `backlogRemaining` that stays >= `limit` tick after tick means the sweep is not draining. */
+  readonly backlogRemaining: number
+}
+
+/**
+ * #4770: values-free observability for the sweep tick — counts and closed-set outcome codes
+ * ONLY, never an org id / user id / work date / run id (audit-surface values-free discipline).
+ * `meta`'s type (`Record<string, number>`) makes this values-free BY CONSTRUCTION, not by
+ * caller discipline: TypeScript refuses to compile a caller that slips a string business value
+ * into `meta`.
+ */
+export interface AttendanceScheduledRunSweepTickLoggerV1 {
+  info(event: string, meta: Record<string, number>): void
+  warn(event: string, meta: Record<string, number>): void
+}
+
+const noopSweepTickLogger: AttendanceScheduledRunSweepTickLoggerV1 = {
+  info: () => undefined,
+  warn: () => undefined,
 }
 
 const SWEEP_DEFAULT_LIMIT = 25
@@ -57,10 +78,14 @@ const SWEEP_DEFAULT_LIMIT = 25
 export interface AttendanceScheduledRunSweepOptionsV1 {
   readonly limit?: number
   readonly recoverCandidate: (candidate: AttendanceScheduledRunSweepCandidateV1) => Promise<void>
+  /** Default: a no-op logger (byte-identical to the pre-#4770 silent tick for any caller that
+   *  does not opt in). */
+  readonly logger?: AttendanceScheduledRunSweepTickLoggerV1
 }
 
 /**
- * One sweep tick: the scan runs in its OWN transaction, then EACH candidate gets its OWN fresh
+ * One sweep tick: the scan runs in its OWN transaction (alongside a `backlogRemaining` read of
+ * the SAME `state='running'` snapshot the scan used), then EACH candidate gets its OWN fresh
  * connection and its OWN transaction — never batched (section 1.7's own comment on
  * `sweepAttendanceScheduledRunCandidateV1`: "Intended to run as ONE candidate per its OWN
  * `runAttendanceResultOperationTransactionV1` call, never batched, so one stuck candidate
@@ -68,6 +93,11 @@ export interface AttendanceScheduledRunSweepOptionsV1 {
  * never rethrown — values-free containment, independent of (and in addition to) the cron
  * caller's own per-(org, workDate) isolation one level up
  * (`plugins/plugin-attendance/index.cjs`'s `scheduleAutoAbsence`).
+ *
+ * #4770: emits exactly one values-free tick-summary log line per call (via `options.logger`,
+ * default no-op) — the prior silence meant "the scheduler ignores the tick's return counts...
+ * only a whole-job throw is logged", so a starving backlog produced zero signal short of a
+ * hard failure. `errored > 0` additionally logs at `warn`.
  */
 export async function sweepAttendanceScheduledRunsOnceV1(
   pool: Pick<Pool, 'connect'>,
@@ -75,14 +105,23 @@ export async function sweepAttendanceScheduledRunsOnceV1(
 ): Promise<AttendanceScheduledRunSweepTickResultV1> {
   const limit =
     Number.isInteger(options.limit) && (options.limit as number) > 0 ? (options.limit as number) : SWEEP_DEFAULT_LIMIT
+  const logger = options.logger ?? noopSweepTickLogger
 
   const scanClient = (await pool.connect()) as unknown as PoolClient
   let candidates: readonly { orgId: string; initiator: string; workDate: string; runId: string }[]
+  let backlogRemaining: number
   try {
-    candidates = await runAttendanceResultOperationTransactionV1(
+    ;({ candidates, backlogRemaining } = await runAttendanceResultOperationTransactionV1(
       scanClient as unknown as AttendanceW4TransactionClientV1,
-      (trx) => scanAttendanceScheduledRunSweepCandidatesV1(trx, limit),
-    )
+      async (trx) => {
+        const scanned = await scanAttendanceScheduledRunSweepCandidatesV1(trx, limit)
+        const backlog = await trx.query(
+          `SELECT count(*)::int AS n FROM attendance_scheduled_runs WHERE state = 'running'`,
+        )
+        const backlogRow = backlog.rows[0] as { n?: number | string } | undefined
+        return { candidates: scanned, backlogRemaining: Number(backlogRow?.n ?? 0) }
+      },
+    ))
   } finally {
     scanClient.release()
   }
@@ -121,7 +160,12 @@ export async function sweepAttendanceScheduledRunsOnceV1(
     skipped += 1
   }
 
-  return { scanned: candidates.length, finalized, notReady, skipped, errored }
+  const result = { scanned: candidates.length, finalized, notReady, skipped, errored, backlogRemaining }
+  logger.info('attendance.w4_scheduled_run_sweep.tick', result)
+  if (errored > 0) {
+    logger.warn('attendance.w4_scheduled_run_sweep.tick_errors', result)
+  }
+  return result
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/core-backend/src/attendance/w4c2-scheduled-run-ops-worker.ts
+++ b/packages/core-backend/src/attendance/w4c2-scheduled-run-ops-worker.ts
@@ -59,9 +59,18 @@ export interface AttendanceScheduledRunSweepTickResultV1 {
 /**
  * #4770: values-free observability for the sweep tick — counts and closed-set outcome codes
  * ONLY, never an org id / user id / work date / run id (audit-surface values-free discipline).
- * `meta`'s type (`Record<string, number>`) makes this values-free BY CONSTRUCTION, not by
- * caller discipline: TypeScript refuses to compile a caller that slips a string business value
- * into `meta`.
+ * `meta`'s type (`Record<string, number>`) makes this values-free BY CONSTRUCTION for STRING
+ * values — TypeScript refuses to compile a caller that slips a string business value (an org id,
+ * a user id) into `meta`. The type alone does NOT block a numeric business value (an epoch
+ * timestamp, a numeric id) — a caller could type-check while doing that. What actually closes
+ * that gap is this file's own PRODUCER (`sweepAttendanceScheduledRunsOnceV1` below emits ONLY
+ * the six named counters below, never a caller-supplied field) together with the RUNTIME checks
+ * `attendance-w4c2-sweep-fairness.db.test.ts`'s "gate 3" describe block asserts against that
+ * producer's actual output: a closed key set (`Object.keys(...).sort()` deep-equal against the
+ * six named keys, not a subset check — an extra key fails it) and a `typeof === 'number'` check
+ * on every value (a smuggled string fails it). Those two RUNTIME assertions, not the `meta` type
+ * alone, are what is actually load-bearing; the type is a compile-time deterrent for the obvious
+ * mistake, not a proof.
  */
 export interface AttendanceScheduledRunSweepTickLoggerV1 {
   info(event: string, meta: Record<string, number>): void

--- a/packages/core-backend/src/attendance/w4c2-scheduled-run.ts
+++ b/packages/core-backend/src/attendance/w4c2-scheduled-run.ts
@@ -1186,6 +1186,20 @@ export interface AttendanceScheduledRunSweepCandidateV1 {
  * Section 1.7's scan predicate — `state = 'running'`, deliberately NOT scoped to today's
  * `work_date` (a run stranded on a prior calendar day must still be visible), bounded by
  * `limit`.
+ *
+ * #4770 fairness fix: the prior fixed-prefix form (`ORDER BY created_at ASC LIMIT $1`, no
+ * write-back) let the oldest N candidates occupy the scan window on EVERY tick forever if they
+ * never reach a terminal state — candidate N+1 could starve indefinitely. This is a durable
+ * ROTATION, not an `OFFSET` (owner constraint: `OFFSET` is unstable once rows leave `running`
+ * concurrently — an offset computed against one tick's row count is meaningless against the
+ * next tick's shrunken/grown set). The scan and the write-back happen in the SAME statement
+ * (`UPDATE ... WHERE run_id IN (SELECT ...)`), so the rotation is durable across ticks/process
+ * restarts, not an in-memory cursor: every candidate this tick selects has its
+ * `last_attempt_at` stamped to `now()` in the same statement, which demotes it below any
+ * candidate this tick did NOT reach (`NULLS FIRST` keeps never-attempted rows — including
+ * brand-new ones — ahead of anything already attempted). Steady state (backlog <= limit) is
+ * byte-behaviorally the prior FIFO order: every row starts `last_attempt_at IS NULL`, so the
+ * `created_at ASC` tiebreak alone decides the order, identical to the old query.
  */
 export async function scanAttendanceScheduledRunSweepCandidatesV1(
   trx: AttendanceW4TransactionClientV1,
@@ -1193,11 +1207,16 @@ export async function scanAttendanceScheduledRunSweepCandidatesV1(
 ): Promise<readonly AttendanceScheduledRunSweepCandidateV1[]> {
   if (!Number.isInteger(limit) || limit < 1) fail('W4C2_SCHEDULED_RUN_SWEEP_LIMIT_INVALID')
   const result = await trx.query(
-    `SELECT org_id, initiator, work_date::text AS work_date, run_id::text AS run_id
-       FROM attendance_scheduled_runs
-      WHERE state = 'running'
-      ORDER BY created_at ASC
-      LIMIT $1`,
+    `UPDATE attendance_scheduled_runs
+        SET last_attempt_at = now()
+      WHERE run_id IN (
+        SELECT run_id
+          FROM attendance_scheduled_runs
+         WHERE state = 'running'
+         ORDER BY last_attempt_at ASC NULLS FIRST, created_at ASC
+         LIMIT $1
+      )
+      RETURNING org_id, initiator, work_date::text AS work_date, run_id::text AS run_id`,
     [limit],
   )
   return result.rows.map((row) => {

--- a/packages/core-backend/src/attendance/w4c2-scheduled-run.ts
+++ b/packages/core-backend/src/attendance/w4c2-scheduled-run.ts
@@ -1197,9 +1197,31 @@ export interface AttendanceScheduledRunSweepCandidateV1 {
  * restarts, not an in-memory cursor: every candidate this tick selects has its
  * `last_attempt_at` stamped to `now()` in the same statement, which demotes it below any
  * candidate this tick did NOT reach (`NULLS FIRST` keeps never-attempted rows — including
- * brand-new ones — ahead of anything already attempted). Steady state (backlog <= limit) is
- * byte-behaviorally the prior FIFO order: every row starts `last_attempt_at IS NULL`, so the
- * `created_at ASC` tiebreak alone decides the order, identical to the old query.
+ * brand-new ones — ahead of anything already attempted). Steady state (backlog <= limit)
+ * selects the SAME candidate SET the old fixed-prefix query did: every row starts
+ * `last_attempt_at IS NULL`, so the `created_at ASC` tiebreak alone decides which rows the
+ * inner `ORDER BY ... LIMIT` picks. It does NOT guarantee the same RETURNED order —
+ * PostgreSQL does not promise `UPDATE ... RETURNING` preserves a subquery's `ORDER BY`, so
+ * downstream processing order is not oldest-first even in steady state (each candidate is its
+ * own independent transaction below and nothing here depends on order).
+ *
+ * #4774 fix (gate P1-1/P2-2): the inner `SELECT` carries `FOR UPDATE SKIP LOCKED`. Without it,
+ * this query was a row-lock WAITER — any concurrent holder of a row lock on one selected
+ * `running` row (the sweep's OWN per-candidate `finalizeAttendanceScheduledRunV1`/
+ * `abandonAttendanceScheduledRunV1` step-3 `SELECT ... FOR UPDATE`, or a second concurrent scan
+ * worker) blocked this `UPDATE` until `lock_timeout` (5000ms) aborted it with `55P03` — a
+ * SQLSTATE `isRetryableSqlState()` does not cover — which propagated out of
+ * `sweepAttendanceScheduledRunsOnceV1` (whose scan transaction sits OUTSIDE the per-candidate
+ * try/catch) and killed the ENTIRE tick, 0 candidates processed. `FOR UPDATE SKIP LOCKED` is
+ * the standard durable-queue claim idiom: a currently-locked row is simply excluded from THIS
+ * tick's candidate set (never stamped, never counted as `errored`) and remains at the front of
+ * the rotation (`last_attempt_at IS NULL`) to be retried next tick — fully compatible with the
+ * fairness rotation above, and restores section 1.7's containment invariant for the scan phase
+ * ("one stuck candidate cannot block the others in the same scan"). It also makes two
+ * concurrent scan workers claim disjoint candidate sets instead of duplicating work (a locked
+ * row is skipped by the other worker's scan rather than raced/retried onto the same rows) — see
+ * `attendance-w4c2-sweep-fairness.db.test.ts`'s "tick-level containment under a concurrent row
+ * lock" and "multi-worker exclusivity" regression guards.
  */
 export async function scanAttendanceScheduledRunSweepCandidatesV1(
   trx: AttendanceW4TransactionClientV1,
@@ -1215,6 +1237,7 @@ export async function scanAttendanceScheduledRunSweepCandidatesV1(
          WHERE state = 'running'
          ORDER BY last_attempt_at ASC NULLS FIRST, created_at ASC
          LIMIT $1
+         FOR UPDATE SKIP LOCKED
       )
       RETURNING org_id, initiator, work_date::text AS work_date, run_id::text AS run_id`,
     [limit],

--- a/packages/core-backend/src/db/migrations/zzzz20260805120000_w4c2_scheduled_run_sweep_fairness.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260805120000_w4c2_scheduled_run_sweep_fairness.ts
@@ -1,0 +1,104 @@
+/**
+ * #4770 (W4C-2 recovery-sweep fairness/observability/call-through; owner ruling 2026-08-05,
+ * baseline `db74bd8667df1084797c97d872fe53ef845e3803`) — the DURABLE-ROTATION column the
+ * fairness fix in `w4c2-scheduled-run.ts`'s `scanAttendanceScheduledRunSweepCandidatesV1`
+ * needs.
+ *
+ * `attendance_scheduled_runs` was created by a zzzz-prefixed migration
+ * (`zzzz20260727100000_w4c2_scheduled_run_identity_and_outbox_union.ts`), so this ADD COLUMN
+ * must also be zzzz-prefixed to sort after it (house rule: a new column on a zzzz table is
+ * itself a zzzz migration).
+ *
+ * Adds:
+ *  - `last_attempt_at timestamptz NULL` on `attendance_scheduled_runs` — stamped to `now()`
+ *    by the scan/write-back statement every time a `running` row is selected as a sweep
+ *    candidate (whether or not that tick's step actually progresses it). `NULL` for a run
+ *    that has never been scanned, so a brand-new `running` row still sorts ahead of any
+ *    previously-attempted row (`ORDER BY last_attempt_at ASC NULLS FIRST`) — never touched by
+ *    resume/finalize/abandon, only by the scan itself.
+ *  - widens `attendance_w4_scheduled_run_update_guard()`'s mutable-key allowlist to include
+ *    `last_attempt_at` (otherwise the existing generic jsonb-minus guard rejects the scan's
+ *    own write-back as a frozen-column mutation) — same function name, so the existing
+ *    `trg_asr_update_guard` trigger picks up the new body without being re-created.
+ *
+ * `chk_asr_terminal_shape` is untouched: it does not enumerate `last_attempt_at`, and the new
+ * column has no terminal-state constraint (a completed/abandoned run can carry a stale
+ * `last_attempt_at` value harmlessly — the guard's `OLD.state IN ('completed','abandoned')`
+ * branch already refuses ANY further update to a terminal row, `last_attempt_at` included).
+ */
+import type { Kysely } from 'kysely'
+import { sql } from 'kysely'
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`
+    ALTER TABLE attendance_scheduled_runs
+      ADD COLUMN IF NOT EXISTS last_attempt_at timestamptz
+  `.execute(db)
+
+  await sql`
+    CREATE OR REPLACE FUNCTION attendance_w4_scheduled_run_update_guard()
+    RETURNS trigger
+    LANGUAGE plpgsql
+    AS $fn$
+    DECLARE
+      mutable_keys text[] := ARRAY['state','completed_user_count','generated_count',
+                                    'abandon_reason_code','abandoned_by_actor_posture',
+                                    'finalized_at','last_attempt_at'];
+    BEGIN
+      IF OLD.state IN ('completed', 'abandoned') THEN
+        RAISE EXCEPTION 'W4C2_RUN_STATE: % row is immutable after terminal state on %', OLD.state, TG_TABLE_NAME;
+      END IF;
+      IF NEW.state NOT IN ('running', 'completed', 'abandoned') THEN
+        RAISE EXCEPTION 'W4C2_RUN_STATE: illegal run state value on %', TG_TABLE_NAME;
+      END IF;
+      IF (to_jsonb(NEW) - mutable_keys) IS DISTINCT FROM (to_jsonb(OLD) - mutable_keys) THEN
+        RAISE EXCEPTION 'W4C2_RUN_STATE: frozen run columns are immutable on %', TG_TABLE_NAME;
+      END IF;
+      RETURN NEW;
+    END;
+    $fn$
+  `.execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  // Fail-closed guard, same discipline as the parent migration's own down(): refuse to lose
+  // rotation history for a run this sweep has actually touched (a partial down here would
+  // otherwise silently drop a fairness-load-bearing column while runs are mid-rotation).
+  const result = await sql`
+    SELECT count(*)::int AS n FROM attendance_scheduled_runs WHERE last_attempt_at IS NOT NULL
+  `.execute(db)
+  const row = (result.rows[0] ?? {}) as { n?: number | string }
+  const count = Number(row.n ?? 0)
+  if (count > 0) {
+    throw new Error(
+      'W4C2_SWEEP_FAIRNESS_DOWN_BLOCKED: refusing to drop last_attempt_at while ' +
+        String(count) +
+        ' attendance_scheduled_runs row(s) carry a stamped value. Down never clears history to pass.',
+    )
+  }
+
+  await sql`
+    CREATE OR REPLACE FUNCTION attendance_w4_scheduled_run_update_guard()
+    RETURNS trigger
+    LANGUAGE plpgsql
+    AS $fn$
+    DECLARE
+      mutable_keys text[] := ARRAY['state','completed_user_count','generated_count',
+                                    'abandon_reason_code','abandoned_by_actor_posture','finalized_at'];
+    BEGIN
+      IF OLD.state IN ('completed', 'abandoned') THEN
+        RAISE EXCEPTION 'W4C2_RUN_STATE: % row is immutable after terminal state on %', OLD.state, TG_TABLE_NAME;
+      END IF;
+      IF NEW.state NOT IN ('running', 'completed', 'abandoned') THEN
+        RAISE EXCEPTION 'W4C2_RUN_STATE: illegal run state value on %', TG_TABLE_NAME;
+      END IF;
+      IF (to_jsonb(NEW) - mutable_keys) IS DISTINCT FROM (to_jsonb(OLD) - mutable_keys) THEN
+        RAISE EXCEPTION 'W4C2_RUN_STATE: frozen run columns are immutable on %', TG_TABLE_NAME;
+      END IF;
+      RETURN NEW;
+    END;
+    $fn$
+  `.execute(db)
+
+  await sql`ALTER TABLE attendance_scheduled_runs DROP COLUMN IF EXISTS last_attempt_at`.execute(db)
+}

--- a/packages/core-backend/src/index.ts
+++ b/packages/core-backend/src/index.ts
@@ -2246,6 +2246,10 @@ export class MetaSheetServer {
                     recoverCandidate: options.recoverCandidate,
                     // #4770: values-free tick-summary observability (counts/backlog only —
                     // `Logger` never receives an org id / user id / work date / run id here).
+                    // #4774 P2-1: this line is the ONLY thing that makes the tick line actually
+                    // emit in production — covered by leg 4 in
+                    // attendance-w4c2-sweep-call-through.db.test.ts (deleting it turns that leg
+                    // red while every other test in both new files stays green).
                     logger: this.logger,
                   }),
                 // W4C-2 P1-1 fix (#4612 verdict second gate round; amendment section 1.1.2, the

--- a/packages/core-backend/src/index.ts
+++ b/packages/core-backend/src/index.ts
@@ -2244,6 +2244,9 @@ export class MetaSheetServer {
                   sweepAttendanceScheduledRunsOnceV1(poolManager.get().getInternalPool(), {
                     limit: options.limit,
                     recoverCandidate: options.recoverCandidate,
+                    // #4770: values-free tick-summary observability (counts/backlog only —
+                    // `Logger` never receives an org id / user id / work date / run id here).
+                    logger: this.logger,
                   }),
                 // W4C-2 P1-1 fix (#4612 verdict second gate round; amendment section 1.1.2, the
                 // `abandoned` transition). `adminActorId` is the route's OWN authenticated actor

--- a/packages/core-backend/src/types/plugin.ts
+++ b/packages/core-backend/src/types/plugin.ts
@@ -1257,6 +1257,8 @@ export interface PluginServices {
       notReady: number
       skipped: number
       errored: number
+      /** #4770: total `state='running'` rows at scan time — the starvation signal. */
+      backlogRemaining: number
     }>
     /**
      * W4C-2 P1-1 fix (#4612 verdict second gate round; amendment section 1.1.2, the `abandoned`

--- a/packages/core-backend/tests/integration/attendance-w4c2-p12-run-transactions.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-w4c2-p12-run-transactions.db.test.ts
@@ -23,6 +23,7 @@ import { Pool, type PoolClient } from 'pg'
 import ts from 'typescript'
 import { up as w4c0Up } from '../../src/db/migrations/zzzz20260725120000_w4c0_attendance_segment_calculation_durable_storage'
 import { up as w4c2Up } from '../../src/db/migrations/zzzz20260727100000_w4c2_scheduled_run_identity_and_outbox_union'
+import { up as w4c2SweepFairnessUp } from '../../src/db/migrations/zzzz20260805120000_w4c2_scheduled_run_sweep_fairness'
 import {
   createOrResumeAttendanceScheduledRunV1,
   finalizeAttendanceScheduledRunV1,
@@ -132,6 +133,10 @@ describeIfDatabase('W4C-2 P1-2 — run-creation/resume/finalization/abandoned tr
 
     await w4c0Up(scratchDb)
     await w4c2Up(scratchDb)
+    // #4770: the fairness-fix migration adds `last_attempt_at` (required by
+    // `scanAttendanceScheduledRunSweepCandidatesV1`'s durable-rotation write-back) and widens
+    // the run update-guard's mutable-key allowlist to match.
+    await w4c2SweepFairnessUp(scratchDb)
     await pool.query(`
       CREATE OR REPLACE FUNCTION attendance_w4c2_option_a_source_dml_sentinel()
       RETURNS trigger

--- a/packages/core-backend/tests/integration/attendance-w4c2-sweep-call-through.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-w4c2-sweep-call-through.db.test.ts
@@ -1,0 +1,491 @@
+/**
+ * #4770 (W4C-2 recovery-sweep fairness/observability/call-through; owner ruling 2026-08-05,
+ * baseline `db74bd8667df1084797c97d872fe53ef845e3803`) — the THREE named call-through legs, each
+ * proven against a REAL booted `MetaSheetServer` + REAL `plugin-attendance` (loaded from
+ * `pluginDirs`, not mocked) and a REAL PostgreSQL connection. Source-string assertions (as the
+ * pre-existing `attendance-w4c2-recovery-wiring.test.ts` uses) do not go red when a route or
+ * scheduler registration is REMOVED — this file does, by construction, because each leg's
+ * positive assertion depends on the production wiring actually executing:
+ *
+ *  1. **core host sweep/abandon port wiring** — a probe plugin captures
+ *     `context.services.attendanceW4SegmentCalculation` directly (the SAME object
+ *     `plugin-attendance` itself reads at activation) and invokes `.sweepScheduledRuns()` /
+ *     `.abandonScheduledRun()` WITHOUT going through the plugin's own route/scheduler layer at
+ *     all — removing either property from `packages/core-backend/src/index.ts`'s port object
+ *     makes the captured method `undefined`, and calling it throws `TypeError`.
+ *  2. **`attendance-w4-scheduled-run-sweep` scheduled job — real registration & execution** —
+ *     the REAL plugin's `activate()` registers the job with the REAL shared
+ *     `AttendanceScheduler`; this file forces ONE cycle (`getSharedAttendanceScheduler()!.
+ *     runCycle()`, bypassing the real interval) and asserts a REAL seeded `running` row got
+ *     durably touched (`last_attempt_at` stamped) — impossible unless the job is both
+ *     registered AND actually invoked by the scheduler's job loop.
+ *  3. **abandon HTTP route — auth/org/host chain** — real HTTP requests through the booted
+ *     server (real JWT via the dev-token mint route, real DB-backed RBAC — `RBAC_BYPASS` is
+ *     deliberately OFF in this file, unlike sibling route-test files, specifically so the
+ *     permission-denied leg is genuine, not bypassed) covering: success (state flips to
+ *     `abandoned`), missing token (401), insufficient permission (403, zero DML), and a
+ *     wrong-org run id (404 `ATTENDANCE_SCHEDULED_RUN_NOT_FOUND`-shaped, zero DML on the real
+ *     row — the org-scoped SQL lookup, not a body-supplied org match, is what actually refuses
+ *     it).
+ *
+ * Mutation self-checks for all three legs (removing the port property / the scheduler
+ * registration block / the route registration block) were run by hand during review — see the
+ * PR body — not automated here (permanently shipping "delete my own wiring" as a CI leg would
+ * just re-test the pre-#4770 code path forever).
+ *
+ * Isolation: `attendance-w4-scheduled-run-sweep`'s PRODUCTION registration hardcodes the
+ * default scan limit (25, no caller-supplied override) — unlike the fairness-fix file, leg 2
+ * cannot widen its own limit to outrun backlog noise. Several PRE-EXISTING sibling
+ * "(real DB, route-level)" suites in this same directory boot a server against the SHARED
+ * `DATABASE_URL` and leave `attendance_scheduled_runs` rows in `state='running'` (fixtures for
+ * their own, unrelated assertions) — in CI these files run in the SAME workflow step against
+ * the SAME `metasheet_test` database, so relying on "the shared DB has fewer than 25 stray
+ * running rows" would be exactly the kind of shared-DB collision this repo's fixture-isolation
+ * doctrine forbids. This file therefore provisions its OWN freshly-migrated scratch database
+ * (full migration set, not a hand-picked subset) so its `attendance_scheduled_runs` table is
+ * empty except for what THIS file itself seeds.
+ */
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { randomUUID } from 'node:crypto'
+import { createRequire } from 'node:module'
+import http from 'node:http'
+import net from 'node:net'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { Pool } from 'pg'
+import type { MetaSheetServer } from '../../src/index'
+
+const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
+const describeIfDatabase = dbUrl ? describe : describe.skip
+
+type JsonResponse = { status: number; body: Record<string, any> | null; raw: string }
+
+function canListen(): Promise<boolean> {
+  const probe = net.createServer()
+  return new Promise((resolve) => {
+    probe.once('error', () => resolve(false))
+    probe.listen(0, '127.0.0.1', () => probe.close(() => resolve(true)))
+  })
+}
+
+function requestJson(
+  url: string,
+  options: { method?: string; headers?: Record<string, string>; body?: Record<string, unknown> } = {},
+): Promise<JsonResponse> {
+  return new Promise((resolve, reject) => {
+    const target = new URL(url)
+    const payload = options.body ? JSON.stringify(options.body) : null
+    const request = http.request({
+      method: options.method ?? 'GET',
+      hostname: target.hostname,
+      port: target.port,
+      path: `${target.pathname}${target.search}`,
+      headers: {
+        ...(payload ? { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(payload) } : {}),
+        ...options.headers,
+      },
+    }, (response) => {
+      let raw = ''
+      response.on('data', (chunk) => { raw += String(chunk) })
+      response.on('end', () => {
+        let body: Record<string, any> | null = null
+        try { body = raw ? JSON.parse(raw) as Record<string, any> : null } catch { body = null }
+        resolve({ status: response.statusCode ?? 0, body, raw })
+      })
+    })
+    request.on('error', reject)
+    if (payload) request.write(payload)
+    request.end()
+  })
+}
+
+function installLoadedPlugin(server: MetaSheetServer, name: string, plugin: Record<string, unknown>) {
+  const loader = (server as unknown as { pluginLoader: { loadedPlugins: Map<string, unknown> } }).pluginLoader
+  loader.loadedPlugins.set(name, {
+    manifest: { name, version: '1.0.0', displayName: name, description: `${name} #4770 probe` },
+    plugin,
+    path: `/tmp/${name}`,
+    loadedAt: new Date(),
+  })
+}
+
+describeIfDatabase('W4C-2 #4770 recovery-sweep call-through (real server, real plugin, real PostgreSQL)', () => {
+  let server: MetaSheetServer | undefined
+  let pool: Pool
+  let baseUrl = ''
+  // Door 1: captured directly from a probe plugin's OWN `context.services` — never read off
+  // plugin-attendance's internal state (which is not test-visible).
+  let hostPort: {
+    sweepScheduledRuns: (options: {
+      limit?: number
+      recoverCandidate(candidate: { orgId: string; initiator: string; workDate: string; runId: string }): Promise<void>
+    }) => Promise<{ scanned: number; finalized: number; notReady: number; skipped: number; errored: number; backlogRemaining: number }>
+    abandonScheduledRun: (input: {
+      orgId: string
+      runId: string
+      adminActorId: string
+      reasonCode: string
+    }) => Promise<{ kind: string; [key: string]: unknown }>
+  } | null = null
+
+  const priorEnv = {
+    databaseUrl: process.env.DATABASE_URL,
+    rbacBypass: process.env.RBAC_BYPASS,
+    skipPlugins: process.env.SKIP_PLUGINS,
+    rollout: process.env.ATTENDANCE_SHIFT_SEGMENT_CALCULATION_ENABLED,
+    schedulerEnabled: process.env.ATTENDANCE_SCHEDULER_ENABLED,
+    schedulerIntervalMs: process.env.ATTENDANCE_SCHEDULER_INTERVAL_MS,
+  }
+
+  async function mintToken(userId: string): Promise<string> {
+    const response = await requestJson(`${baseUrl}/api/auth/dev-token?userId=${encodeURIComponent(userId)}`)
+    const token = response.body?.token
+    if (typeof token !== 'string' || !token) throw new Error(`failed to mint token: ${response.raw}`)
+    return token
+  }
+
+  async function seedRolloutOrg(orgId: string): Promise<void> {
+    await pool.query(
+      `INSERT INTO attendance_calculation_rollout_state (org_id, state, engine_version, reason_code, actor_id, version, prior_state)
+       VALUES ($1,'legacy','v1','w4c2sweepcallthrough-seed','w4c2sweepcallthrough-actor',1,NULL)`,
+      [orgId],
+    )
+    await pool.query(
+      `UPDATE attendance_calculation_rollout_state SET state = 'shadow', prior_state = 'legacy', version = 2 WHERE org_id = $1`,
+      [orgId],
+    )
+  }
+
+  /** DB-backed `user_roles`/`user_permissions` — genuine RBAC (RBAC_BYPASS is OFF in this
+   *  file), unlike `users.permissions` JSONB (which `withAnyPermission`'s own DB check never
+   *  reads). */
+  async function seedUser(opts: { admin?: boolean; permissionCode?: string }): Promise<{ userId: string; token: string }> {
+    const userId = randomUUID()
+    await pool.query(
+      `INSERT INTO users (id, email, username, name, password_hash, role, permissions, is_active, is_admin, activation_status)
+       VALUES ($1, $2, $1, 'W4C-2 #4770 call-through fixture', 'x', 'user', '[]'::jsonb, TRUE, FALSE, 'activated')`,
+      [userId, `w4c2sweepcallthrough-${userId}@example.test`],
+    )
+    if (opts.admin) {
+      await pool.query(`INSERT INTO user_roles (user_id, role_id) VALUES ($1, 'admin')`, [userId])
+    }
+    if (opts.permissionCode) {
+      await pool.query(`INSERT INTO user_permissions (user_id, permission_code) VALUES ($1, $2)`, [userId, opts.permissionCode])
+    }
+    return { userId, token: await mintToken(userId) }
+  }
+
+  async function withAllowlist<T>(orgIds: readonly string[], fn: () => Promise<T>): Promise<T> {
+    const prior = process.env.ATTENDANCE_SHIFT_SEGMENT_CALCULATION_ENABLED
+    process.env.ATTENDANCE_SHIFT_SEGMENT_CALCULATION_ENABLED = [prior, ...orgIds].filter(Boolean).join(',')
+    try {
+      return await fn()
+    } finally {
+      if (prior === undefined) delete process.env.ATTENDANCE_SHIFT_SEGMENT_CALCULATION_ENABLED
+      else process.env.ATTENDANCE_SHIFT_SEGMENT_CALCULATION_ENABLED = prior
+    }
+  }
+
+  /** Seeds ONE stuck `running` scheduled run directly through the real core transactional
+   *  functions (never a raw INSERT — the table's own triggers reject anything that does not
+   *  look like a real run). Its target is never sealed, so it stays `not_ready`/`running`
+   *  forever — a genuine "cannot progress" fixture, not a timing artifact. */
+  async function createStuckRun(orgId: string, workDate: string): Promise<{ runId: string; userId: string }> {
+    const {
+      createOrResumeAttendanceScheduledRunV1,
+    } = await import('../../src/attendance/w4c2-scheduled-run')
+    const { runAttendanceResultOperationTransactionV1 } = await import('../../src/attendance/w4c0-operation-registry')
+    const userId = randomUUID()
+    const client = await pool.connect()
+    try {
+      const created = await withAllowlist([orgId], () =>
+        runAttendanceResultOperationTransactionV1(client as any, (trx) =>
+          createOrResumeAttendanceScheduledRunV1(
+            trx,
+            { orgId, initiator: 'cron', workDate },
+            async () => [{ userId, targetKind: 'generate', reviewReasonCode: null }],
+          ),
+        ),
+      )
+      if (created.kind !== 'created_running') throw new Error(`expected created_running, got ${created.kind}`)
+      return { runId: created.runId, userId }
+    } finally {
+      client.release()
+    }
+  }
+
+  async function runRow(runId: string): Promise<{ state: string; last_attempt_at: string | null; abandon_reason_code: string | null }> {
+    const r = await pool.query(
+      'SELECT state, last_attempt_at, abandon_reason_code FROM attendance_scheduled_runs WHERE run_id = $1::uuid',
+      [runId],
+    )
+    return r.rows[0]
+  }
+
+  let adminPool: Pool
+  let scratchName: string
+
+  beforeAll(async () => {
+    if (!dbUrl || !(await canListen())) throw new Error('W4C2_SWEEP_CALL_THROUGH_TEST_REQUIRES_DATABASE_AND_LOOPBACK')
+
+    // Provision an isolated, freshly-migrated scratch database (see file-header isolation
+    // note) BEFORE anything imports `../../src/index` (whose `poolManager`/`db` singletons bind
+    // to `process.env.DATABASE_URL` at MODULE LOAD TIME).
+    scratchName = `ms2_w4c2sweepct_${randomUUID().slice(0, 12).replace(/-/g, '')}`
+    const adminUrl = new URL(dbUrl)
+    adminUrl.pathname = '/postgres'
+    adminPool = new Pool({ connectionString: adminUrl.toString() })
+    await adminPool.query(`DROP DATABASE IF EXISTS ${scratchName}`)
+    await adminPool.query(`CREATE DATABASE ${scratchName}`)
+    const scratchUrl = new URL(dbUrl)
+    scratchUrl.pathname = `/${scratchName}`
+    const scratchConnectionString = scratchUrl.toString()
+
+    // Migrate via the SAME CLI script `pnpm migrate` uses (`tsx src/db/migrate.ts`), as a child
+    // process — NOT an in-process `Migrator` (kysely's `FileMigrationProvider` dynamically
+    // `import()`s each migration file from `node_modules` code, which is outside vitest/vite-
+    // node's own TS transform graph; `tsx`'s loader hook resolves those nested extensionless
+    // relative imports — e.g. one migration's `./_patterns` — correctly, while running the same
+    // dynamic import from inside the vitest process does not).
+    const coreBackendDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
+    const { execFileSync } = await import('node:child_process')
+    execFileSync('pnpm', ['exec', 'tsx', 'src/db/migrate.ts'], {
+      cwd: coreBackendDir,
+      env: { ...process.env, DATABASE_URL: scratchConnectionString },
+      stdio: 'pipe',
+    })
+
+    process.env.DATABASE_URL = scratchConnectionString
+    // Deliberately OFF (unlike sibling route-test files) — the permission-denied leg (door 3)
+    // needs GENUINE DB-backed RBAC, not a bypass.
+    process.env.RBAC_BYPASS = 'false'
+    process.env.SKIP_PLUGINS = 'false'
+    // Non-empty at plugin-activation time only to get BOTH env-gated jobs (outbox-drain, sweep)
+    // registered once — the actual per-org allowlist check happens live at call time via
+    // `withAllowlist` (see #4770 fairness-test file's own doc comment).
+    process.env.ATTENDANCE_SHIFT_SEGMENT_CALCULATION_ENABLED = `w4c2sweepcallthrough-bootstrap-${randomUUID()}`
+    process.env.ATTENDANCE_SCHEDULER_ENABLED = 'true'
+    // Long enough that the real interval never fires during this file's run; door 2 forces a
+    // single cycle directly via `runCycle()`.
+    process.env.ATTENDANCE_SCHEDULER_INTERVAL_MS = '3600000'
+
+    const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../..')
+    const loaded = await import('../../src/index')
+    server = new loaded.MetaSheetServer({
+      port: 0,
+      host: '127.0.0.1',
+      pluginDirs: [path.join(repoRoot, 'plugins', 'plugin-attendance')],
+    })
+    await server.start()
+    const address = server.getAddress()
+    if (!address || typeof address === 'string') throw new Error('attendance server did not expose a TCP address')
+    baseUrl = `http://127.0.0.1:${address.port}`
+    pool = new Pool({ connectionString: scratchConnectionString })
+
+    // Door 1 setup: `attendanceW4SegmentCalculation` is LEAST-PRIVILEGE gated in
+    // `packages/core-backend/src/index.ts` (`manifest.name === 'plugin-attendance' ? {...} :
+    // undefined`) — only the plugin literally named `plugin-attendance` ever receives it, so an
+    // arbitrarily-named probe plugin cannot capture it. Instead: deactivate the REAL
+    // plugin-attendance (already loaded from `pluginDirs` above), then reinstall + reactivate
+    // the SAME cached CJS module (Node's require cache is per-path, so this is the identical
+    // module instance the loader used — its own internal `attendanceW4SegmentCalculationPort`
+    // closure state gets reset cleanly by this deactivate/reactivate round-trip, matching the
+    // plugin runtime's own designed teardown/reload contract) under a THIN wrapper that ALSO
+    // stashes the real, freshly-granted port for this file's direct-call assertions.
+    const pluginRequire = createRequire(import.meta.url)
+    const pluginModulePath = path.join(repoRoot, 'plugins', 'plugin-attendance', 'index.cjs')
+    const realPluginModule = pluginRequire(pluginModulePath) as {
+      activate(context: unknown): Promise<void>
+      deactivate?(): Promise<void>
+    }
+    await (server as unknown as { deactivatePluginByName(name: string): Promise<unknown> }).deactivatePluginByName(
+      'plugin-attendance',
+    )
+    installLoadedPlugin(server, 'plugin-attendance', {
+      async activate(context: any) {
+        hostPort = context.services?.attendanceW4SegmentCalculation ?? null
+        return realPluginModule.activate(context)
+      },
+      async deactivate() {
+        return realPluginModule.deactivate ? realPluginModule.deactivate() : undefined
+      },
+    })
+    await (server as unknown as { activatePluginByName(name: string): Promise<unknown> }).activatePluginByName(
+      'plugin-attendance',
+    )
+  }, 120000)
+
+  afterAll(async () => {
+    await pool?.end().catch(() => undefined)
+    if (server) await server.stop()
+    await adminPool?.query(`DROP DATABASE IF EXISTS ${scratchName} WITH (FORCE)`).catch(() => undefined)
+    await adminPool?.end().catch(() => undefined)
+    for (const [key, value] of Object.entries({
+      DATABASE_URL: priorEnv.databaseUrl,
+      RBAC_BYPASS: priorEnv.rbacBypass,
+      SKIP_PLUGINS: priorEnv.skipPlugins,
+      ATTENDANCE_SHIFT_SEGMENT_CALCULATION_ENABLED: priorEnv.rollout,
+      ATTENDANCE_SCHEDULER_ENABLED: priorEnv.schedulerEnabled,
+      ATTENDANCE_SCHEDULER_INTERVAL_MS: priorEnv.schedulerIntervalMs,
+    })) {
+      if (value === undefined) delete process.env[key]
+      else process.env[key] = value
+    }
+  }, 60000)
+
+  // ===============================================================================================
+  // Leg 1 — core host sweep/abandon port wiring.
+  // ===============================================================================================
+  describe('leg 1 — core host port wiring (direct, bypassing the plugin route/scheduler layer)', () => {
+    it('port.sweepScheduledRuns performs a REAL sweep against a REAL seeded row', async () => {
+      expect(hostPort, 'probe plugin must have captured context.services.attendanceW4SegmentCalculation').not.toBeNull()
+      const orgId = randomUUID()
+      await seedRolloutOrg(orgId)
+      const stuck = await createStuckRun(orgId, '2026-04-01')
+      expect((await runRow(stuck.runId)).last_attempt_at).toBeNull()
+
+      const result = await withAllowlist([orgId], () =>
+        hostPort!.sweepScheduledRuns({ limit: 25, async recoverCandidate() {} }),
+      )
+      expect(result.scanned).toBeGreaterThanOrEqual(1)
+      const row = await runRow(stuck.runId)
+      expect(row.last_attempt_at).not.toBeNull()
+      expect(row.state).toBe('running')
+    })
+
+    it('port.abandonScheduledRun performs a REAL abandon against a REAL seeded row', async () => {
+      expect(hostPort).not.toBeNull()
+      const orgId = randomUUID()
+      await seedRolloutOrg(orgId)
+      const stuck = await createStuckRun(orgId, '2026-04-02')
+      const adminActorId = randomUUID()
+
+      const outcome = await withAllowlist([orgId], () =>
+        hostPort!.abandonScheduledRun({
+          orgId,
+          runId: stuck.runId,
+          adminActorId,
+          reasonCode: 'ATTENDANCE_SCHEDULED_RUN_OPERATOR_ABANDONED',
+        }),
+      )
+      expect(outcome.kind).toBe('abandoned')
+      const row = await runRow(stuck.runId)
+      expect(row.state).toBe('abandoned')
+      expect(row.abandon_reason_code).toBe('ATTENDANCE_SCHEDULED_RUN_OPERATOR_ABANDONED')
+    })
+  })
+
+  // ===============================================================================================
+  // Leg 2 — `attendance-w4-scheduled-run-sweep` scheduled job: real registration & real execution.
+  // ===============================================================================================
+  describe('leg 2 — scheduled job real registration and execution', () => {
+    it('forcing ONE real scheduler cycle sweeps a REAL seeded row through the REGISTERED plugin job (not a direct call)', async () => {
+      const { getSharedAttendanceScheduler } = await import('../../src/services/AttendanceScheduler')
+      const scheduler = getSharedAttendanceScheduler()
+      expect(scheduler, 'ATTENDANCE_SCHEDULER_ENABLED=true at boot must have started the shared scheduler').not.toBeNull()
+
+      const orgId = randomUUID()
+      await seedRolloutOrg(orgId)
+      const stuck = await createStuckRun(orgId, '2026-04-03')
+      expect((await runRow(stuck.runId)).last_attempt_at).toBeNull()
+
+      // The tick loop's own job list is NOT scoped to this org — other registered jobs
+      // (report-digest, annual-leave-accrual, etc.) also run this cycle; each is independently
+      // try/caught by `runCycle()`, so this is a genuine unscoped production cycle, not a
+      // synthetic single-job invocation.
+      await withAllowlist([orgId], () => scheduler!.runCycle())
+
+      const row = await runRow(stuck.runId)
+      expect(row.last_attempt_at, 'the REGISTERED attendance-w4-scheduled-run-sweep job must have scanned this row').not.toBeNull()
+      expect(row.state).toBe('running')
+    }, 30000)
+  })
+
+  // ===============================================================================================
+  // Leg 3 — abandon HTTP route: auth/org/host chain.
+  // ===============================================================================================
+  describe('leg 3 — abandon HTTP route auth/org/host chain', () => {
+    it('a genuine attendance:admin holder abandons their own org\'s run: 200, state flips, reason recorded', async () => {
+      const orgId = randomUUID()
+      await seedRolloutOrg(orgId)
+      const stuck = await createStuckRun(orgId, '2026-04-04')
+      const admin = await seedUser({ permissionCode: 'attendance:admin' })
+
+      const response = await withAllowlist([orgId], () =>
+        requestJson(`${baseUrl}/api/attendance/auto-absence/scheduled-runs/${stuck.runId}/abandon`, {
+          method: 'POST',
+          headers: { Authorization: `Bearer ${admin.token}` },
+          body: { orgId, reasonCode: 'ATTENDANCE_SCHEDULED_RUN_OPERATOR_ABANDONED' },
+        }),
+      )
+      expect(response.status, response.raw).toBe(200)
+      expect(response.body?.data?.kind).toBe('abandoned')
+      const row = await runRow(stuck.runId)
+      expect(row.state).toBe('abandoned')
+      expect(row.abandon_reason_code).toBe('ATTENDANCE_SCHEDULED_RUN_OPERATOR_ABANDONED')
+    })
+
+    it('no token: 401, zero DML', async () => {
+      const orgId = randomUUID()
+      await seedRolloutOrg(orgId)
+      const stuck = await createStuckRun(orgId, '2026-04-05')
+
+      const response = await withAllowlist([orgId], () =>
+        requestJson(`${baseUrl}/api/attendance/auto-absence/scheduled-runs/${stuck.runId}/abandon`, {
+          method: 'POST',
+          body: { orgId, reasonCode: 'ATTENDANCE_SCHEDULED_RUN_OPERATOR_ABANDONED' },
+        }),
+      )
+      expect(response.status).toBe(401)
+      const row = await runRow(stuck.runId)
+      expect(row.state).toBe('running')
+      expect(row.abandon_reason_code).toBeNull()
+    })
+
+    it('authenticated but lacking attendance:admin: 403 FORBIDDEN, zero DML — genuine RBAC, not a bypass', async () => {
+      const orgId = randomUUID()
+      await seedRolloutOrg(orgId)
+      const stuck = await createStuckRun(orgId, '2026-04-06')
+      const nonAdmin = await seedUser({})
+
+      const response = await withAllowlist([orgId], () =>
+        requestJson(`${baseUrl}/api/attendance/auto-absence/scheduled-runs/${stuck.runId}/abandon`, {
+          method: 'POST',
+          headers: { Authorization: `Bearer ${nonAdmin.token}` },
+          body: { orgId, reasonCode: 'ATTENDANCE_SCHEDULED_RUN_OPERATOR_ABANDONED' },
+        }),
+      )
+      expect(response.status, response.raw).toBe(403)
+      expect(response.body?.error?.code).toBe('FORBIDDEN')
+      const row = await runRow(stuck.runId)
+      expect(row.state).toBe('running')
+      expect(row.abandon_reason_code).toBeNull()
+    })
+
+    it('a real admin, wrong org + a DIFFERENT org\'s run id: 404 ATTENDANCE_SCHEDULED_RUN_NOT_FOUND, zero DML on the real row', async () => {
+      const victimOrgId = randomUUID()
+      const callerOrgId = randomUUID()
+      await seedRolloutOrg(victimOrgId)
+      await seedRolloutOrg(callerOrgId)
+      const victimRun = await createStuckRun(victimOrgId, '2026-04-07')
+      const admin = await seedUser({ permissionCode: 'attendance:admin' })
+
+      // The route accepts `orgId` in the body; the caller claims `callerOrgId` (NOT the run's
+      // real org) while pointing at the victim org's run id. The org-scoped SQL lookup
+      // (`WHERE org_id = $1 AND run_id = $2`) finds zero rows under `callerOrgId` — the SAME
+      // not-found shape as a nonexistent run — never touching the victim row.
+      const response = await withAllowlist([victimOrgId, callerOrgId], () =>
+        requestJson(`${baseUrl}/api/attendance/auto-absence/scheduled-runs/${victimRun.runId}/abandon`, {
+          method: 'POST',
+          headers: { Authorization: `Bearer ${admin.token}` },
+          body: { orgId: callerOrgId, reasonCode: 'ATTENDANCE_SCHEDULED_RUN_OPERATOR_ABANDONED' },
+        }),
+      )
+      expect(response.status, response.raw).toBe(404)
+      expect(response.body?.error?.code).toBe('ATTENDANCE_SCHEDULED_RUN_NOT_FOUND')
+      const row = await runRow(victimRun.runId)
+      expect(row.state).toBe('running')
+      expect(row.abandon_reason_code).toBeNull()
+    })
+  })
+})

--- a/packages/core-backend/tests/integration/attendance-w4c2-sweep-call-through.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-w4c2-sweep-call-through.db.test.ts
@@ -27,6 +27,15 @@
  *     wrong-org run id (404 `ATTENDANCE_SCHEDULED_RUN_NOT_FOUND`-shaped, zero DML on the real
  *     row — the org-scoped SQL lookup, not a body-supplied org match, is what actually refuses
  *     it).
+ *  4. **production tick-observability wiring (#4774 P2-1 closure)** — `index.ts:2249`'s
+ *     `logger: this.logger` is the ONLY line that makes the #4770 tick/backlog/error
+ *     observability actually emit in production; the pre-existing gate-3 tests all inject their
+ *     OWN fake logger, which stays green even if that one production line is deleted (proven by
+ *     mutation during review — 13/13 + 3/3 + 102/102 all green with the line removed). This leg
+ *     spies on the REAL `Logger` instance the booted `MetaSheetServer` constructed (never a
+ *     test-supplied logger) and calls `hostPort.sweepScheduledRuns()` (door 1's real port) —
+ *     deleting `logger: this.logger` makes the sweep fall back to its silent no-op logger, and
+ *     this spy would never observe the tick line.
  *
  * Mutation self-checks for all three legs (removing the port property / the scheduler
  * registration block / the route registration block) were run by hand during review — see the
@@ -45,7 +54,7 @@
  * (full migration set, not a hand-picked subset) so its `attendance_scheduled_runs` table is
  * empty except for what THIS file itself seeds.
  */
-import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
 import { randomUUID } from 'node:crypto'
 import { createRequire } from 'node:module'
 import http from 'node:http'
@@ -486,6 +495,56 @@ describeIfDatabase('W4C-2 #4770 recovery-sweep call-through (real server, real p
       const row = await runRow(victimRun.runId)
       expect(row.state).toBe('running')
       expect(row.abandon_reason_code).toBeNull()
+    })
+  })
+
+  // ===============================================================================================
+  // Leg 4 — production tick-observability wiring (#4774 P2-1 closure).
+  // ===============================================================================================
+  describe('leg 4 — production Logger call-through (#4774 P2-1)', () => {
+    it('port.sweepScheduledRuns emits the tick-summary line through the SAME production Logger instance index.ts wires in (`logger: this.logger`)', async () => {
+      expect(hostPort).not.toBeNull()
+      const orgId = randomUUID()
+      await seedRolloutOrg(orgId)
+      await createStuckRun(orgId, '2026-04-08')
+
+      // Door 4: the REAL `MetaSheetServer` instance's own `Logger` (`private logger: Logger`,
+      // constructed once at server boot as `new Logger('MetaSheetServer')`) — never a
+      // test-supplied stand-in. `index.ts`'s port object passes THIS SAME reference through as
+      // `logger: this.logger`; spying on it (rather than substituting a fake) is what makes this
+      // leg discriminate on the wiring LINE itself, not on the sweep's own logger-shaped
+      // contract (already covered by the fairness file's gate-3 tests).
+      const productionLogger = (
+        server as unknown as {
+          logger: { info: (event: string, meta?: Record<string, unknown>) => void }
+        }
+      ).logger
+      const infoCalls: Array<{ event: string; meta: Record<string, unknown> | undefined }> = []
+      const infoSpy = vi
+        .spyOn(productionLogger, 'info')
+        .mockImplementation((event: string, meta?: Record<string, unknown>) => {
+          infoCalls.push({ event, meta })
+        })
+      try {
+        const result = await withAllowlist([orgId], () =>
+          hostPort!.sweepScheduledRuns({ limit: 25, async recoverCandidate() {} }),
+        )
+        expect(result.scanned).toBeGreaterThanOrEqual(1)
+
+        const tickCall = infoCalls.find((c) => c.event === 'attendance.w4_scheduled_run_sweep.tick')
+        expect(
+          tickCall,
+          'the production Logger must have received the tick-summary line — proves index.ts:2249 `logger: this.logger` is actually wired into the booted server, not just declared in source',
+        ).toBeDefined()
+        expect(Object.keys(tickCall!.meta ?? {}).sort()).toEqual(
+          ['backlogRemaining', 'errored', 'finalized', 'notReady', 'scanned', 'skipped'].sort(),
+        )
+        for (const value of Object.values(tickCall!.meta ?? {})) {
+          expect(typeof value, 'production-emitted meta must stay values-free: numbers only').toBe('number')
+        }
+      } finally {
+        infoSpy.mockRestore()
+      }
     })
   })
 })

--- a/packages/core-backend/tests/integration/attendance-w4c2-sweep-fairness.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-w4c2-sweep-fairness.db.test.ts
@@ -435,10 +435,13 @@ describeIfDatabase('W4C-2 #4770 recovery-sweep fairness/observability (real DB)'
       const b = await createStuckRun('lockguard-b', workDate)
       const c = await createStuckRun('lockguard-c', workDate)
 
-      // A separate connection durably holds a row lock on candidate `b` — modeling the sweep's
-      // OWN per-candidate `finalizeAttendanceScheduledRunV1`/`abandonAttendanceScheduledRunV1`
-      // step-3 `SELECT ... FOR UPDATE` (both reachable, default-multi-worker topology per the
-      // gate's Orientation section), or a second concurrent scan worker.
+      // A separate connection holds an open, uncommitted row lock on candidate `b` — modeling
+      // the sweep's OWN per-candidate `finalizeAttendanceScheduledRunV1`/
+      // `abandonAttendanceScheduledRunV1` step-3 `SELECT ... FOR UPDATE` (both reachable,
+      // default-multi-worker topology per the gate's Orientation section), or a second
+      // concurrent scan worker. (Deliberately NOT "durably" — an open transaction's lock is the
+      // opposite of durable; it vanishes on rollback/crash, unlike this fix's `last_attempt_at`
+      // rotation stamp.)
       const lockConn = await pool.connect()
       await lockConn.query('BEGIN')
       await lockConn.query('SELECT * FROM attendance_scheduled_runs WHERE run_id = $1::uuid FOR UPDATE', [b.runId])

--- a/packages/core-backend/tests/integration/attendance-w4c2-sweep-fairness.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-w4c2-sweep-fairness.db.test.ts
@@ -414,4 +414,108 @@ describeIfDatabase('W4C-2 #4770 recovery-sweep fairness/observability (real DB)'
       expect(await lastAttemptAt(b.runId)).not.toBeNull()
     }, 60000)
   })
+
+  // =============================================================================================
+  // #4774 P1-1 regression guard — the scan became a row-lock WAITER when it was converted from a
+  // pure `SELECT` to `UPDATE ... RETURNING`, and the scan's transaction sits OUTSIDE the
+  // per-candidate try/catch in `sweepAttendanceScheduledRunsOnceV1`. Before the `FOR UPDATE SKIP
+  // LOCKED` fix, a concurrent holder of a row lock on ONE selected `running` row blocked the
+  // scan's `UPDATE` statement until `lock_timeout` (5000ms, `W4_TRANSACTION_LOCK_TIMEOUT_MS`)
+  // aborted it with `55P03` — a SQLSTATE `isRetryableSqlState()` does NOT cover — which propagated
+  // out of the tick and killed ALL candidates for that tick (0 processed), where the pre-#4770
+  // plain-`SELECT` scan never waited on a row lock at all. This is a strict regression of section
+  // 1.7's own containment invariant ("one stuck candidate cannot block the others in the same
+  // scan") for the scan phase specifically.
+  // =============================================================================================
+  describe('tick-level containment under a concurrent row lock (regression guard, #4774 P1-1)', () => {
+    it('one candidate row-locked by a concurrent connection does not kill the tick; it is excluded THIS tick and the other candidates are still processed', async () => {
+      const workDate = '2026-03-07'
+      const a = await createStuckRun('lockguard-a', workDate)
+      const b = await createStuckRun('lockguard-b', workDate)
+      const c = await createStuckRun('lockguard-c', workDate)
+
+      // A separate connection durably holds a row lock on candidate `b` — modeling the sweep's
+      // OWN per-candidate `finalizeAttendanceScheduledRunV1`/`abandonAttendanceScheduledRunV1`
+      // step-3 `SELECT ... FOR UPDATE` (both reachable, default-multi-worker topology per the
+      // gate's Orientation section), or a second concurrent scan worker.
+      const lockConn = await pool.connect()
+      await lockConn.query('BEGIN')
+      await lockConn.query('SELECT * FROM attendance_scheduled_runs WHERE run_id = $1::uuid FOR UPDATE', [b.runId])
+
+      try {
+        const started = Date.now()
+        const result = await withAllowlist([a.orgId, b.orgId, c.orgId], () =>
+          sweepAttendanceScheduledRunsOnceV1(pool, { limit: 25, async recoverCandidate() {} }),
+        )
+        const elapsedMs = Date.now() - started
+
+        // Must not have waited out the 5000ms `lock_timeout` — `FOR UPDATE SKIP LOCKED` excludes
+        // the locked candidate from the scan instead of blocking on its row lock. (Pre-fix this
+        // assertion is moot — the call above throws `55P03` before returning at all.)
+        expect(elapsedMs).toBeLessThan(4000)
+
+        // `b` (locked) is excluded from THIS tick's candidate set entirely; `a` and `c` are
+        // unaffected and processed normally — values-free containment restored.
+        expect(result).toEqual({ scanned: 2, finalized: 0, notReady: 2, skipped: 0, errored: 0, backlogRemaining: 3 })
+        expect(await lastAttemptAt(a.runId)).not.toBeNull()
+        expect(await lastAttemptAt(c.runId)).not.toBeNull()
+        // `b` was never reached by this tick — still un-stamped, still running, NOT counted as
+        // `errored` (it is simply deferred to a later tick once the lock releases).
+        expect(await lastAttemptAt(b.runId)).toBeNull()
+        expect(await runState(b.runId)).toBe('running')
+      } finally {
+        await lockConn.query('ROLLBACK').catch(() => undefined)
+        lockConn.release()
+      }
+    }, 30000)
+  })
+
+  // =============================================================================================
+  // #4774 P2-2 regression guard — the PR's "Fairness design" claim ("two concurrent scans cannot
+  // both durably 'own' the same candidate") was empirically FALSE at head `76ecd793e` (measured
+  // overlap 6/6 — the inner `SELECT` took no lock, so both scans read the same `state='running'`
+  // rows; the SERIALIZABLE write-conflict that followed was absorbed by the helper's own `40001`
+  // retry, which then re-selected the same still-`running` rows). `FOR UPDATE SKIP LOCKED` (the
+  // SAME fix as P1-1) makes the claim true: a row already locked by a concurrent scan is skipped,
+  // not duplicated.
+  // =============================================================================================
+  describe('multi-worker exclusivity (regression guard, #4774 P2-2)', () => {
+    it('two concurrent scans against the same backlog claim disjoint candidate sets — zero overlap, full coverage', async () => {
+      const workDate = '2026-03-08'
+      const seeded: Array<{ orgId: string; runId: string }> = []
+      for (let i = 0; i < 6; i += 1) {
+        // eslint-disable-next-line no-await-in-loop -- sequential seeding, same rationale as gate 1.
+        seeded.push(await createStuckRun(`overlap-${i}`, workDate))
+      }
+      const orgIds = seeded.map((r) => r.orgId)
+
+      const clientA = await pool.connect()
+      const clientB = await pool.connect()
+      try {
+        const [candidatesA, candidatesB] = await withAllowlist(orgIds, () =>
+          Promise.all([
+            runAttendanceResultOperationTransactionV1(clientA as unknown as AttendanceW4TransactionClientV1, (trx) =>
+              scanAttendanceScheduledRunSweepCandidatesV1(trx, 25),
+            ),
+            runAttendanceResultOperationTransactionV1(clientB as unknown as AttendanceW4TransactionClientV1, (trx) =>
+              scanAttendanceScheduledRunSweepCandidatesV1(trx, 25),
+            ),
+          ]),
+        )
+        const idsA = new Set(candidatesA.map((c) => c.runId))
+        const idsB = new Set(candidatesB.map((c) => c.runId))
+        const overlap = [...idsA].filter((id) => idsB.has(id))
+        expect(overlap, 'FOR UPDATE SKIP LOCKED must make two concurrent scans claim disjoint rows').toEqual([])
+
+        // Nobody starved, nobody double-counted: the union of both scans' claims covers exactly
+        // the seeded backlog.
+        const union = new Set([...idsA, ...idsB])
+        expect(union.size).toBe(seeded.length)
+        for (const s of seeded) expect(union.has(s.runId)).toBe(true)
+      } finally {
+        clientA.release()
+        clientB.release()
+      }
+    }, 30000)
+  })
 })

--- a/packages/core-backend/tests/integration/attendance-w4c2-sweep-fairness.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-w4c2-sweep-fairness.db.test.ts
@@ -42,6 +42,7 @@ import {
   scanAttendanceScheduledRunSweepCandidatesV1,
   type AttendanceScheduledRunMemberInputV1,
   type AttendanceScheduledRunMembershipResolverV1,
+  type AttendanceScheduledRunSweepCandidateV1,
 } from '../../src/attendance/w4c2-scheduled-run'
 import {
   sweepAttendanceScheduledRunsOnceV1,
@@ -478,9 +479,35 @@ describeIfDatabase('W4C-2 #4770 recovery-sweep fairness/observability (real DB)'
   // retry, which then re-selected the same still-`running` rows). `FOR UPDATE SKIP LOCKED` (the
   // SAME fix as P1-1) makes the claim true: a row already locked by a concurrent scan is skipped,
   // not duplicated.
+  //
+  // Construction note: a naive `Promise.all([scanA(), scanB()])` against two SEPARATE fresh
+  // connections is RACY on localhost — a whole SERIALIZABLE scan transaction (BEGIN + 2x
+  // `set_config` + the scan + COMMIT) can complete in under a millisecond, so it is possible for
+  // worker A to fully commit (releasing its row locks) before worker B's scan even attempts to
+  // lock anything; B then legitimately re-scans the SAME (only) backlog, which is correct
+  // ROTATION behavior, not a SKIP LOCKED failure, and would show up as a false "overlap" that has
+  // nothing to do with exclusivity. (Measured directly: a `Promise.all` version of this test
+  // still showed a rare 6/6 overlap AFTER the fix, purely from that race — not from SKIP LOCKED
+  // not working.)
+  //
+  // A second construction pitfall (also measured directly): manually holding worker A's
+  // transaction open with a BARE `BEGIN`/`COMMIT` (bypassing the production retry wrapper) makes
+  // `COMMIT` fail with SQLSTATE `40001` ("could not serialize access due to read/write
+  // dependencies... Canceled on identification as a pivot") — because BOTH scans' `SeqScan`
+  // (a 6-row scratch table has no index to make the plan narrower) touches the WHOLE
+  // `state='running'` predicate range even though `SKIP LOCKED` makes their WRITES disjoint, so
+  // PostgreSQL's serializable-snapshot-isolation conflict detector sees a genuine two-transaction
+  // rw-antidependency cycle and aborts the later committer. This is EXPECTED SERIALIZABLE
+  // behavior, not a defect — and exactly why `runAttendanceResultOperationTransactionV1` retries
+  // on `40001`/`40P01` in the first place. This test goes through that SAME production retry
+  // wrapper for BOTH workers (not a bare `BEGIN`/`COMMIT`), with an explicit signal so worker A's
+  // scan-claim is guaranteed to still be open when worker B's independent scan runs, modeling a
+  // worker mid-flight between its scan and its per-candidate processing — the exact window P1-1's
+  // mechanism (and a real second sweep replica) exploits. On A's `40001`, the wrapper transparently
+  // retries the WHOLE callback (rollback + rescan), matching real production behavior.
   // =============================================================================================
   describe('multi-worker exclusivity (regression guard, #4774 P2-2)', () => {
-    it('two concurrent scans against the same backlog claim disjoint candidate sets — zero overlap, full coverage', async () => {
+    it('a concurrent worker holding an uncommitted scan-claim on part of the backlog does not let a second worker durably double-claim those same rows', async () => {
       const workDate = '2026-03-08'
       const seeded: Array<{ orgId: string; runId: string }> = []
       for (let i = 0; i < 6; i += 1) {
@@ -489,30 +516,62 @@ describeIfDatabase('W4C-2 #4770 recovery-sweep fairness/observability (real DB)'
       }
       const orgIds = seeded.map((r) => r.orgId)
 
+      // Signals: `scanADone` resolves once worker A's scan-claim transaction has taken its
+      // locks (but is still open); `releaseASignal` is held until worker B has finished, so A's
+      // COMMIT (or its post-`40001`-retry rescan+COMMIT) cannot happen before B's scan runs.
+      let scanADoneResolve!: (v: readonly AttendanceScheduledRunSweepCandidateV1[]) => void
+      const scanADone = new Promise<readonly AttendanceScheduledRunSweepCandidateV1[]>((resolve) => {
+        scanADoneResolve = resolve
+      })
+      let releaseA!: () => void
+      const releaseASignal = new Promise<void>((resolve) => {
+        releaseA = resolve
+      })
+
       const clientA = await pool.connect()
       const clientB = await pool.connect()
+      const workerAPromise = withAllowlist(orgIds, () =>
+        runAttendanceResultOperationTransactionV1(
+          clientA as unknown as AttendanceW4TransactionClientV1,
+          async (trx) => {
+            const candidates = await scanAttendanceScheduledRunSweepCandidatesV1(trx, 3)
+            scanADoneResolve(candidates)
+            await releaseASignal
+            return candidates
+          },
+        ),
+      )
+
       try {
-        const [candidatesA, candidatesB] = await withAllowlist(orgIds, () =>
-          Promise.all([
-            runAttendanceResultOperationTransactionV1(clientA as unknown as AttendanceW4TransactionClientV1, (trx) =>
-              scanAttendanceScheduledRunSweepCandidatesV1(trx, 25),
-            ),
-            runAttendanceResultOperationTransactionV1(clientB as unknown as AttendanceW4TransactionClientV1, (trx) =>
-              scanAttendanceScheduledRunSweepCandidatesV1(trx, 25),
-            ),
-          ]),
+        const candidatesA = await scanADone
+        expect(candidatesA).toHaveLength(3)
+
+        // Worker B: a fully independent second scan while A's claim is STILL uncommitted.
+        const candidatesB = await withAllowlist(orgIds, () =>
+          runAttendanceResultOperationTransactionV1(clientB as unknown as AttendanceW4TransactionClientV1, (trx) =>
+            scanAttendanceScheduledRunSweepCandidatesV1(trx, 25),
+          ),
         )
-        const idsA = new Set(candidatesA.map((c) => c.runId))
+
+        releaseA()
+        const finalCandidatesA = await workerAPromise
+
+        const idsA = new Set(finalCandidatesA.map((c) => c.runId))
         const idsB = new Set(candidatesB.map((c) => c.runId))
         const overlap = [...idsA].filter((id) => idsB.has(id))
-        expect(overlap, 'FOR UPDATE SKIP LOCKED must make two concurrent scans claim disjoint rows').toEqual([])
-
-        // Nobody starved, nobody double-counted: the union of both scans' claims covers exactly
-        // the seeded backlog.
+        expect(overlap, 'FOR UPDATE SKIP LOCKED must make a concurrent scan skip rows another worker already holds').toEqual([])
+        // B's scan (limit 25, only 3 unlocked rows available) claims exactly the OTHER 3.
+        expect(idsB.size).toBe(3)
+        expect(idsA.size).toBe(3)
         const union = new Set([...idsA, ...idsB])
-        expect(union.size).toBe(seeded.length)
+        expect(union.size).toBe(6)
         for (const s of seeded) expect(union.has(s.runId)).toBe(true)
       } finally {
+        // Always unstick A even on assertion failure, so afterEach's DROP DATABASE cannot hang
+        // behind a leaked open transaction — and always AWAIT its settlement before releasing
+        // the connection back to the pool.
+        releaseA()
+        await workerAPromise.catch(() => undefined)
         clientA.release()
         clientB.release()
       }

--- a/packages/core-backend/tests/integration/attendance-w4c2-sweep-fairness.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-w4c2-sweep-fairness.db.test.ts
@@ -1,0 +1,417 @@
+/**
+ * #4770 (W4C-2 recovery-sweep fairness/observability/call-through; owner ruling 2026-08-05,
+ * baseline `db74bd8667df1084797c97d872fe53ef845e3803`) — real-DB proof for:
+ *
+ *  - the durable-rotation scan fix in `w4c2-scheduled-run.ts`'s
+ *    `scanAttendanceScheduledRunSweepCandidatesV1` (owner completion gate 1: with >25
+ *    persistently-blocked candidates ahead, a later candidate still gets processed within a
+ *    bounded number of ticks — never OFFSET, per the owner's explicit constraint: a durable
+ *    `last_attempt_at` column stamped in the SAME statement as the scan);
+ *  - gate 2's mutation control (reverting the scan to the fixed prefix `ORDER BY created_at ASC
+ *    LIMIT 25` must turn this file's fairness test red — exercised by hand during review, not
+ *    automated here, since automating "revert my own fix" as a permanent CI leg would just be
+ *    re-testing the pre-#4770 code path forever; the fairness test itself IS the mutation
+ *    oracle);
+ *  - gate 3's values-free tick/backlog/error observability shape
+ *    (`AttendanceScheduledRunSweepTickLoggerV1`).
+ *
+ * Call-through legs (host port wiring / scheduler job registration / abandon HTTP route) are a
+ * SEPARATE file (`attendance-w4c2-sweep-call-through.db.test.ts`) — this file proves the PURE
+ * algorithm against a self-provisioned scratch database.
+ *
+ * Isolation: `scanAttendanceScheduledRunSweepCandidatesV1`'s predicate is deliberately GLOBAL
+ * (`state='running'`, not scoped to an org — section 1.7's own cross-`work_date` requirement),
+ * so this file's exact-count assertions (`scanned`, `backlogRemaining`) would be corrupted by
+ * `running` rows left over from an EARLIER `it()` in the SAME database — unlike the sibling
+ * `attendance-w4c2-p12-run-transactions.db.test.ts`, which sidesteps this by always scanning
+ * with a large limit and `.find()`-ing its own candidate. This file needs the SMALL limit
+ * (`25`, matching the real default) to exercise congestion, so it gets a FRESH scratch database
+ * per `it()` (`beforeEach`/`afterEach`, not `beforeAll`/`afterAll`) — the DDL cost is paid once
+ * per test, not shared, on purpose.
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import crypto from 'node:crypto'
+import { Kysely, PostgresDialect } from 'kysely'
+import { Pool, type PoolClient } from 'pg'
+import { up as w4c0Up } from '../../src/db/migrations/zzzz20260725120000_w4c0_attendance_segment_calculation_durable_storage'
+import { up as w4c2Up } from '../../src/db/migrations/zzzz20260727100000_w4c2_scheduled_run_identity_and_outbox_union'
+import { up as w4c2SweepFairnessUp } from '../../src/db/migrations/zzzz20260805120000_w4c2_scheduled_run_sweep_fairness'
+import {
+  createOrResumeAttendanceScheduledRunV1,
+  recordAttendanceScheduledRunTargetOutcomeV1,
+  scanAttendanceScheduledRunSweepCandidatesV1,
+  type AttendanceScheduledRunMemberInputV1,
+  type AttendanceScheduledRunMembershipResolverV1,
+} from '../../src/attendance/w4c2-scheduled-run'
+import {
+  sweepAttendanceScheduledRunsOnceV1,
+  type AttendanceScheduledRunSweepTickLoggerV1,
+} from '../../src/attendance/w4c2-scheduled-run-ops-worker'
+import { createVerifiedAttendanceOperationIdentityV1, createVerifiedAttendanceOrgIdentityV1, resolveSegmentCalculationPosture } from '../../src/attendance/w4c0-identity'
+import { runAttendanceResultOperationTransactionV1 } from '../../src/attendance/w4c0-operation-registry'
+import type { AttendanceW4TransactionClientV1 } from '../../src/attendance/w4c0-identity'
+
+const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
+const describeIfDatabase = dbUrl ? describe : describe.skip
+
+const FILE_RUN = crypto.randomUUID().slice(0, 8)
+
+function uuid(): string {
+  return crypto.randomUUID()
+}
+
+describeIfDatabase('W4C-2 #4770 recovery-sweep fairness/observability (real DB)', () => {
+  let adminPool: Pool
+  let pool: Pool
+  let kyselyPool: Pool
+  let scratchDb: Kysely<unknown>
+  let scratchName: string
+  let testRun: string
+
+  function orgIdFor(label: string): string {
+    return crypto.createHash('sha1').update(testRun + ':org:' + label).digest('hex').slice(0, 32).replace(
+      /^(.{8})(.{4})(.{4})(.{4})(.{12})$/,
+      '$1-$2-$3-$4-$5',
+    )
+  }
+
+  beforeEach(async () => {
+    testRun = 'w4c2sweepfair' + FILE_RUN + crypto.randomUUID().slice(0, 8)
+    scratchName = `ms2_w4c2sf_${crypto.randomUUID().slice(0, 12).replace(/-/g, '')}`
+    const adminUrl = new URL(dbUrl as string)
+    adminUrl.pathname = '/postgres'
+    adminPool = new Pool({ connectionString: adminUrl.toString() })
+    await adminPool.query(`DROP DATABASE IF EXISTS ${scratchName}`)
+    await adminPool.query(`CREATE DATABASE ${scratchName}`)
+    const scratchUrl = new URL(dbUrl as string)
+    scratchUrl.pathname = `/${scratchName}`
+    pool = new Pool({ connectionString: scratchUrl.toString() })
+    kyselyPool = new Pool({ connectionString: scratchUrl.toString() })
+    scratchDb = new Kysely<unknown>({ dialect: new PostgresDialect({ pool: kyselyPool }) })
+
+    await pool.query('CREATE EXTENSION IF NOT EXISTS pgcrypto')
+    await pool.query(`
+      CREATE TABLE attendance_records (
+        id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+        user_id text NOT NULL, work_date date NOT NULL, first_in_at timestamptz, last_out_at timestamptz,
+        work_minutes integer NOT NULL DEFAULT 0, late_minutes integer NOT NULL DEFAULT 0,
+        early_leave_minutes integer NOT NULL DEFAULT 0, status varchar(64) NOT NULL DEFAULT 'normal',
+        org_id text NOT NULL DEFAULT 'default')`)
+    await pool.query(`
+      CREATE TABLE attendance_requests (
+        id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+        user_id text NOT NULL, work_date date NOT NULL, request_type varchar(30) NOT NULL,
+        status varchar(20) NOT NULL DEFAULT 'pending', org_id text NOT NULL DEFAULT 'default')`)
+    await pool.query(`
+      CREATE TABLE attendance_import_jobs (
+        id uuid PRIMARY KEY DEFAULT gen_random_uuid(), org_id text NOT NULL DEFAULT 'default',
+        batch_id uuid NOT NULL, created_by text NOT NULL, idempotency_key text,
+        status varchar(20) NOT NULL DEFAULT 'queued', progress integer NOT NULL DEFAULT 0,
+        total integer NOT NULL DEFAULT 0, payload jsonb NOT NULL DEFAULT '{}'::jsonb)`)
+
+    await w4c0Up(scratchDb)
+    await w4c2Up(scratchDb)
+    await w4c2SweepFairnessUp(scratchDb)
+  }, 60000)
+
+  afterEach(async () => {
+    for (const p of [pool, kyselyPool, adminPool]) p?.on('error', () => undefined)
+    await scratchDb?.destroy()
+    await pool?.end()
+    await adminPool?.query(`DROP DATABASE IF EXISTS ${scratchName} WITH (FORCE)`).catch(() => undefined)
+    await adminPool?.end()
+  }, 60000)
+
+  async function setRolloutState(orgId: string, state: 'shadow'): Promise<void> {
+    await pool.query(
+      `INSERT INTO attendance_calculation_rollout_state (org_id, state, engine_version, reason_code, actor_id, version, prior_state)
+       VALUES ($1,'legacy','v1','w4c2sweepfair-seed','w4c2sweepfair-actor',1,NULL)`,
+      [orgId],
+    )
+    await pool.query(
+      `UPDATE attendance_calculation_rollout_state SET state = $2, prior_state = 'legacy', version = 2 WHERE org_id = $1`,
+      [orgId, state],
+    )
+  }
+
+  async function withAllowlist<T>(orgIds: readonly string[], fn: () => Promise<T>): Promise<T> {
+    const prior = process.env.ATTENDANCE_SHIFT_SEGMENT_CALCULATION_ENABLED
+    process.env.ATTENDANCE_SHIFT_SEGMENT_CALCULATION_ENABLED = [prior, ...orgIds].filter(Boolean).join(',')
+    try {
+      return await fn()
+    } finally {
+      if (prior === undefined) delete process.env.ATTENDANCE_SHIFT_SEGMENT_CALCULATION_ENABLED
+      else process.env.ATTENDANCE_SHIFT_SEGMENT_CALCULATION_ENABLED = prior
+    }
+  }
+
+  function memberResolverFor(
+    members: readonly AttendanceScheduledRunMemberInputV1[],
+  ): AttendanceScheduledRunMembershipResolverV1 {
+    return async () => members
+  }
+
+  async function withTxn<T>(fn: (trx: AttendanceW4TransactionClientV1) => Promise<T>): Promise<T> {
+    const c: PoolClient = await pool.connect()
+    try {
+      return await runAttendanceResultOperationTransactionV1(c as unknown as AttendanceW4TransactionClientV1, fn)
+    } finally {
+      c.release()
+    }
+  }
+
+  /** Seals a `generate` target's per-user operation as `completed` — mirrors the sibling
+   *  file's `sealGenerateTarget` helper (duplicated locally per this file's own scratch-DB
+   *  isolation, not shared across test files). */
+  async function sealGenerateTargetCompleted(orgId: string, runId: string, userId: string, workDate: string): Promise<void> {
+    const t = await pool.query(
+      `SELECT operation_id::text AS operation_id FROM attendance_scheduled_run_targets
+        WHERE org_id = $1 AND run_id = $2::uuid AND user_id = $3::uuid AND target_kind = 'generate'`,
+      [orgId, runId, userId],
+    )
+    const operationId = t.rows[0].operation_id as string
+    await withTxn(async (trx) => {
+      await trx.query(
+        `INSERT INTO attendance_result_operations (
+            org_id, entrypoint, operation_id, identity_source_kind, source_root_id, proof_user_id, proof_work_date,
+            source_ref, actor_id, actor_posture, capability, subject_scope, command_fingerprint, accepted_write_posture, state
+          ) VALUES ($1,'scheduled',$2,'scheduled',$3,$4,$5,'ref:w4c2sweepfair','actor-w4c2sweepfair','scheduler','scheduled','{}'::jsonb,$6,'shadow','claimed')`,
+        [orgId, operationId, runId, userId, workDate, 'a'.repeat(64)],
+      )
+      const org = createVerifiedAttendanceOrgIdentityV1({
+        orgKey: orgId,
+        posture: await resolveSegmentCalculationPosture(trx, orgId),
+      })
+      const identity = createVerifiedAttendanceOperationIdentityV1({
+        org,
+        kind: 'item',
+        entrypoint: 'scheduled',
+        source: { sourceKind: 'scheduled', scheduledRunId: runId, userId, workDate },
+      })
+      await trx.query(
+        `UPDATE attendance_result_operations
+            SET state = 'completed', response_snapshot = $3::jsonb, version = version + 1, updated_at = now()
+          WHERE org_id = $1 AND entrypoint = 'scheduled' AND operation_id = $2::uuid AND state = 'claimed'`,
+        [orgId, operationId, JSON.stringify({ inserted: true })],
+      )
+      await recordAttendanceScheduledRunTargetOutcomeV1(trx, identity, { terminalOutcome: 'completed' })
+    })
+  }
+
+  async function createStuckRun(label: string, workDate: string): Promise<{ orgId: string; runId: string; userId: string }> {
+    const orgId = orgIdFor(label)
+    await setRolloutState(orgId, 'shadow')
+    const userId = uuid()
+    const created = await withAllowlist([orgId], () =>
+      withTxn((trx) =>
+        createOrResumeAttendanceScheduledRunV1(
+          trx,
+          { orgId, initiator: 'cron', workDate },
+          memberResolverFor([{ userId, targetKind: 'generate', reviewReasonCode: null }]),
+        ),
+      ),
+    )
+    if (created.kind !== 'created_running') throw new Error(`expected created_running for ${label}, got ${created.kind}`)
+    // Deliberately NEVER sealed — the target has no outcome row, so
+    // `sweepAttendanceScheduledRunCandidateV1` reports `not_ready` on every scan forever
+    // (a real "cannot progress" candidate, not a timing artifact).
+    return { orgId, runId: created.runId, userId }
+  }
+
+  async function runState(runId: string): Promise<string> {
+    const r = await pool.query('SELECT state FROM attendance_scheduled_runs WHERE run_id = $1::uuid', [runId])
+    return r.rows[0].state as string
+  }
+
+  async function lastAttemptAt(runId: string): Promise<string | null> {
+    const r = await pool.query('SELECT last_attempt_at FROM attendance_scheduled_runs WHERE run_id = $1::uuid', [runId])
+    return r.rows[0].last_attempt_at
+  }
+
+  // =============================================================================================
+  // Gate 1 — >25 persistently-blocked candidates ahead; a later candidate still gets processed.
+  // =============================================================================================
+  describe('gate 1 — durable rotation over a >25 persistently-blocked backlog', () => {
+    it('26 stuck candidates occupy the front of the queue; a 27th (healthy, newest) candidate finalizes on the SECOND tick', async () => {
+      const workDate = '2026-03-01'
+      const STUCK_COUNT = 26
+      const stuck: Array<{ orgId: string; runId: string; userId: string }> = []
+      for (let i = 0; i < STUCK_COUNT; i += 1) {
+        // eslint-disable-next-line no-await-in-loop -- ordering-sensitive: created_at must be
+        // strictly increasing across these rows, which requires SEQUENTIAL (not parallel) inserts.
+        stuck.push(await createStuckRun(`stuck-${i}`, workDate))
+      }
+      const healthyOrgId = orgIdFor('healthy')
+      await setRolloutState(healthyOrgId, 'shadow')
+      const healthyUserId = uuid()
+      const healthyCreated = await withAllowlist([healthyOrgId], () =>
+        withTxn((trx) =>
+          createOrResumeAttendanceScheduledRunV1(
+            trx,
+            { orgId: healthyOrgId, initiator: 'cron', workDate },
+            memberResolverFor([{ userId: healthyUserId, targetKind: 'generate', reviewReasonCode: null }]),
+          ),
+        ),
+      )
+      if (healthyCreated.kind !== 'created_running') throw new Error('expected created_running for healthy run')
+      // Sealed BEFORE any sweep runs — once scanned, it finalizes on the SAME tick (no second
+      // recovery round-trip needed), isolating "did rotation reach it" from "did recovery work".
+      await sealGenerateTargetCompleted(healthyOrgId, healthyCreated.runId, healthyUserId, workDate)
+
+      const allOrgIds = [...stuck.map((s) => s.orgId), healthyOrgId]
+      const recovered: string[] = []
+      const tick = () =>
+        withAllowlist(allOrgIds, () =>
+          sweepAttendanceScheduledRunsOnceV1(pool, {
+            limit: 25,
+            async recoverCandidate(candidate) {
+              recovered.push(candidate.runId)
+              // No-op: the stuck candidates' targets are never sealed, so this "recovery
+              // attempt" never actually unblocks them — modeling a genuinely-stuck run
+              // (e.g. permanently failing shift resolution), not a timing artifact.
+            },
+          }),
+        )
+
+      const tick1 = await tick()
+      expect(tick1).toEqual({ scanned: 25, finalized: 0, notReady: 25, skipped: 0, errored: 0, backlogRemaining: 27 })
+      // The healthy run and the 26th stuck run were NOT reached by tick 1 (still un-stamped).
+      expect(await lastAttemptAt(healthyCreated.runId)).toBeNull()
+      expect(await runState(healthyCreated.runId)).toBe('running')
+
+      const tick2 = await tick()
+      expect(tick2).toEqual({ scanned: 25, finalized: 1, notReady: 24, skipped: 0, errored: 0, backlogRemaining: 27 })
+
+      // The healthy run finalized on tick 2 — durable rotation reached it despite 26
+      // persistently-blocked candidates having occupied every earlier scan window.
+      expect(await runState(healthyCreated.runId)).toBe('completed')
+      expect(await lastAttemptAt(healthyCreated.runId)).not.toBeNull()
+      // The healthy run never went through `recoverCandidate` — it finalized straight off the
+      // scan (its target was pre-sealed), confirming rotation (not recovery-callback luck) is
+      // what got it processed.
+      expect(recovered).not.toContain(healthyCreated.runId)
+
+      // All 26 stuck candidates remain 'running' — the sweep never fabricates progress for a
+      // genuinely-stuck run.
+      for (const s of stuck) {
+        expect(await runState(s.runId)).toBe('running')
+      }
+    }, 60000)
+  })
+
+  // =============================================================================================
+  // Steady state (backlog <= limit): un-congested behavior is unchanged — every row starts
+  // `last_attempt_at IS NULL`, so `created_at ASC` alone decides order, byte-identical to the
+  // pre-#4770 fixed-prefix query. Anchors that the fairness fix does not alter the common case.
+  // =============================================================================================
+  describe('steady state — no backlog congestion', () => {
+    it('a lone stuck candidate is scanned on tick 1 and stamped, with zero fabricated progress', async () => {
+      const workDate = '2026-03-02'
+      const solo = await createStuckRun('solo', workDate)
+      const result = await withAllowlist([solo.orgId], () =>
+        sweepAttendanceScheduledRunsOnceV1(pool, { limit: 25, async recoverCandidate() {} }),
+      )
+      expect(result).toEqual({ scanned: 1, finalized: 0, notReady: 1, skipped: 0, errored: 0, backlogRemaining: 1 })
+      expect(await lastAttemptAt(solo.runId)).not.toBeNull()
+      expect(await runState(solo.runId)).toBe('running')
+    }, 60000)
+  })
+
+  // =============================================================================================
+  // Gate 3 — values-free tick/backlog/error observability.
+  // =============================================================================================
+  describe('gate 3 — values-free tick observability', () => {
+    function captureLogger(): AttendanceScheduledRunSweepTickLoggerV1 & {
+      infoCalls: Array<{ event: string; meta: Record<string, number> }>
+      warnCalls: Array<{ event: string; meta: Record<string, number> }>
+    } {
+      const infoCalls: Array<{ event: string; meta: Record<string, number> }> = []
+      const warnCalls: Array<{ event: string; meta: Record<string, number> }> = []
+      return {
+        infoCalls,
+        warnCalls,
+        info: (event, meta) => infoCalls.push({ event, meta }),
+        warn: (event, meta) => warnCalls.push({ event, meta }),
+      }
+    }
+
+    const EXPECTED_META_KEYS = ['scanned', 'finalized', 'notReady', 'skipped', 'errored', 'backlogRemaining'].sort()
+
+    it('logs exactly one info tick-summary with a closed, all-numeric, values-free key set — and no warn when nothing errors', async () => {
+      const workDate = '2026-03-03'
+      const solo = await createStuckRun('obs-clean', workDate)
+      const logger = captureLogger()
+      await withAllowlist([solo.orgId], () =>
+        sweepAttendanceScheduledRunsOnceV1(pool, { limit: 25, logger, async recoverCandidate() {} }),
+      )
+
+      expect(logger.infoCalls).toHaveLength(1)
+      expect(logger.infoCalls[0].event).toBe('attendance.w4_scheduled_run_sweep.tick')
+      expect(Object.keys(logger.infoCalls[0].meta).sort()).toEqual(EXPECTED_META_KEYS)
+      for (const [key, value] of Object.entries(logger.infoCalls[0].meta)) {
+        expect(typeof value, `meta.${key} must be a number, never a business value`).toBe('number')
+      }
+      expect(logger.warnCalls).toHaveLength(0)
+    }, 60000)
+
+    it('additionally logs a warn tick_errors line, same closed shape, when a recovery callback throws', async () => {
+      const workDate = '2026-03-04'
+      const failing = await createStuckRun('obs-error', workDate)
+      const logger = captureLogger()
+      const result = await withAllowlist([failing.orgId], () =>
+        sweepAttendanceScheduledRunsOnceV1(pool, {
+          limit: 25,
+          logger,
+          async recoverCandidate() {
+            throw new Error('W4C2_TEST_SWEEP_OBSERVABILITY_RECOVERY_FAILURE')
+          },
+        }),
+      )
+      expect(result.errored).toBe(1)
+
+      expect(logger.infoCalls).toHaveLength(1)
+      expect(logger.warnCalls).toHaveLength(1)
+      expect(logger.warnCalls[0].event).toBe('attendance.w4_scheduled_run_sweep.tick_errors')
+      expect(Object.keys(logger.warnCalls[0].meta).sort()).toEqual(EXPECTED_META_KEYS)
+      expect(logger.warnCalls[0].meta).toEqual(logger.infoCalls[0].meta)
+      for (const value of Object.values(logger.warnCalls[0].meta)) {
+        expect(typeof value).toBe('number')
+      }
+    }, 60000)
+
+    it('the default (no logger supplied) tick is silent — byte-identical to the pre-#4770 caller contract', async () => {
+      const workDate = '2026-03-05'
+      const solo = await createStuckRun('obs-default', workDate)
+      // No `logger` field at all — must not throw, must not require the field.
+      const result = await withAllowlist([solo.orgId], () =>
+        sweepAttendanceScheduledRunsOnceV1(pool, { limit: 25, async recoverCandidate() {} }),
+      )
+      expect(result.scanned).toBe(1)
+    }, 60000)
+  })
+
+  // =============================================================================================
+  // Scan-level unit proof: the rotation write-back is visible even when called directly (not
+  // just through the tick wrapper) — pins the exact query contract
+  // `scanAttendanceScheduledRunSweepCandidatesV1` now has, independent of
+  // `sweepAttendanceScheduledRunsOnceV1`'s own connection/transaction wrapping.
+  // =============================================================================================
+  describe('scanAttendanceScheduledRunSweepCandidatesV1 — direct rotation contract', () => {
+    it('stamps last_attempt_at on every returned candidate in the SAME statement as the scan', async () => {
+      const workDate = '2026-03-06'
+      const a = await createStuckRun('scan-direct-a', workDate)
+      const b = await createStuckRun('scan-direct-b', workDate)
+      expect(await lastAttemptAt(a.runId)).toBeNull()
+      expect(await lastAttemptAt(b.runId)).toBeNull()
+
+      const candidates = await withAllowlist([a.orgId, b.orgId], () =>
+        withTxn((trx) => scanAttendanceScheduledRunSweepCandidatesV1(trx, 500)),
+      )
+      const ids = candidates.map((c) => c.runId)
+      expect(ids).toContain(a.runId)
+      expect(ids).toContain(b.runId)
+      expect(await lastAttemptAt(a.runId)).not.toBeNull()
+      expect(await lastAttemptAt(b.runId)).not.toBeNull()
+    }, 60000)
+  })
+})

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -589,6 +589,25 @@ export default defineConfig({
       // gated; excluded here so the no-DB job cannot skip-green it; wired whole-file into
       // the attendance real-DB step in plugin-tests.yml (two-point wiring).
       'tests/integration/attendance-w4c2-p12-durable-lock-gates.db.test.ts',
+      // #4770 (W4C-2 recovery-sweep fairness/observability; owner ruling 2026-08-05) — the
+      // durable-rotation scan fix (gate 1: >25 persistently-blocked candidates + a healthy
+      // candidate finalizes within a bounded number of ticks; the mutation-red control is the
+      // same test reverted by hand, not automated here), a steady-state parity check, and the
+      // values-free tick/backlog/error observability shape (gate 3). Self-provisioned scratch
+      // DB per test (the scan predicate is deliberately GLOBAL, not org-scoped — a shared DB
+      // would corrupt this file's exact-count assertions). DATABASE_URL-gated; excluded here
+      // so the no-DB job cannot skip-green it; wired whole-file into the attendance real-DB
+      // step in plugin-tests.yml (two-point wiring).
+      'tests/integration/attendance-w4c2-sweep-fairness.db.test.ts',
+      // #4770 — the three named call-through legs (core host sweep/abandon port wiring, the
+      // `attendance-w4-scheduled-run-sweep` scheduled job's real registration + real
+      // execution, and the abandon HTTP route's auth/org/host chain), each proven against a
+      // REAL booted MetaSheetServer + REAL plugin-attendance + REAL PostgreSQL (own freshly-
+      // migrated scratch DB, for the same global-scan isolation reason as the fairness-fix
+      // file above). DATABASE_URL-gated; excluded here so the no-DB job cannot skip-green it;
+      // wired whole-file into the attendance real-DB step in plugin-tests.yml (two-point
+      // wiring).
+      'tests/integration/attendance-w4c2-sweep-call-through.db.test.ts',
       // W4C-3a durable legacy-plan migration: exact manifest/chunk/terminal
       // constraints, V1 frozen idempotency, direct-corruption congruence, and
       // guarded down. DATABASE_URL-gated; excluded here so the no-DB lane

--- a/plugins/plugin-integration-core/lib/sealed-export/vectors/s6a-package-provenance-pins.json
+++ b/plugins/plugin-integration-core/lib/sealed-export/vectors/s6a-package-provenance-pins.json
@@ -86,6 +86,6 @@
     "s6aAcceptancePs51Test": "835c7c6ce943d82e0378a40a27c7fd1e8b79b526faa8ca4c8066e4231a4bfb0f",
     "s6aProductRuntimeTest": "de978adafa8b89772cefa921c2051f434bf346bf5c2978bef3424ee70f51ba3f",
     "multitableOnpremPackageBuild": "463c7d73c6c7f2d1b6cdf0820d7a06974a9c463dd5e98bbbaf1c996e1dc4ed99",
-    "pluginTestsWorkflow": "453a364e6475c760a3115637b7c3a39ee1ac3c968bf677f5f92b8266593a592a"
+    "pluginTestsWorkflow": "2e844a3c222e6ef284494369d047b461ff6ed12584187561c1628f5553b4204c"
   }
 }

--- a/scripts/ops/attendance-w4c2-ci-wiring.test.mjs
+++ b/scripts/ops/attendance-w4c2-ci-wiring.test.mjs
@@ -87,6 +87,15 @@ const FILES = Object.freeze([
   // durable delivery / lock-order / atomicity gates (section 2 gates 2-8, 15, 17, 19,
   // 22-23 controls) — same two-point discipline as the nine above.
   'tests/integration/attendance-w4c2-p12-durable-lock-gates.db.test.ts',
+  // #4770 (recovery-sweep fairness/observability, owner ruling 2026-08-05) — the durable-
+  // rotation scan fix, steady-state parity, and values-free tick/backlog/error observability.
+  // Same two-point discipline as the suites above.
+  'tests/integration/attendance-w4c2-sweep-fairness.db.test.ts',
+  // #4770 — the three named call-through legs (core host port wiring, the scheduled job's
+  // real registration/execution, and the abandon HTTP route's auth/org/host chain) against a
+  // real booted server + real plugin + real PostgreSQL. Same two-point discipline as the
+  // suites above.
+  'tests/integration/attendance-w4c2-sweep-call-through.db.test.ts',
   // W4C-3a durable enqueue and record-target preconditions: SERIALIZABLE
   // reservation/freeze plus present/missing commit-order and lock-hold proofs.
   // Keep the same two-point wiring and file-exists contract as the suites above.


### PR DESCRIPTION
## HOLD — Draft, not for merge

**Authorization (owner ruling, 2026-08-05, recorded verbatim in issue body):** independent Draft/HOLD PR
— explicitly NOT folded into the W4C-5 transition-hardening PR (#4747's contract scope is atomic
rollout transition, not W4C-2 recovery). This issue is a **hard prerequisite for actual W4C-5
staging/soak**; it does not block the currently authorized lanes. Baseline
`db74bd8667df1084797c97d872fe53ef845e3803`.

This PR does **not** authorize: merge, staging, soak, any flag flip, deployment, or production/customer
data use. Refs #4770 (parent #4556).

## What this is

Recovery-sweep fairness, values-free observability, and real call-through proof for the W4C-2 scheduled-
run recovery sweep (`docs/development/attendance-issue-4556-w4c2-scheduled-run-identity-amendment-20260726.md`
section 1.7). Section 1.7 requires the scan be "bounded (a `LIMIT`/batch cap per tick)" but does not
mandate a specific ordering — the fixed-prefix `ORDER BY created_at ASC LIMIT 25` (no write-back) that
shipped is a starvation bug: candidates 26+ never got scanned while the oldest 25 kept failing/waiting.

## What changed

1. **Durable-rotation fairness fix** (`packages/core-backend/src/attendance/w4c2-scheduled-run.ts`,
   `scanAttendanceScheduledRunSweepCandidatesV1`): the scan is now
   `UPDATE attendance_scheduled_runs SET last_attempt_at = now() WHERE run_id IN (SELECT ... ORDER BY
   last_attempt_at ASC NULLS FIRST, created_at ASC LIMIT $1 FOR UPDATE SKIP LOCKED) RETURNING ...` — one
   statement, so the rotation write-back is durable across ticks/process restarts (never an in-memory
   cursor, never `OFFSET`, per the owner's explicit constraint that `OFFSET` is unstable under
   concurrent state changes). `FOR UPDATE SKIP LOCKED` was added in the independent gate-fix round below
   (P1-1) — see that section for why.
2. **New migration** `zzzz20260805120000_w4c2_scheduled_run_sweep_fairness.ts` — adds
   `attendance_scheduled_runs.last_attempt_at timestamptz NULL` and widens the existing generic-
   allowlist update-guard trigger's `mutable_keys` array to include it (otherwise the guard rejects the
   scan's own write-back as a frozen-column mutation). `up`/`down` round-trip verified locally
   (down is fail-closed while any row carries a stamped value, same discipline as the parent migration).
3. **Values-free tick/backlog/error observability**
   (`w4c2-scheduled-run-ops-worker.ts`, `sweepAttendanceScheduledRunsOnceV1`): an optional
   `AttendanceScheduledRunSweepTickLoggerV1` (`info`/`warn`, `Record<string, number>` meta — values-free
   by construction for STRING values; the closed key set + runtime `typeof === 'number'` check, both
   mutation-tested, are what actually close the numeric-business-value gap — see NIT-1 in the gate-fix
   round below), default no-op (byte-identical silent tick unless a caller opts in). Emits one
   `attendance.w4_scheduled_run_sweep.tick` info line per tick
   (`scanned/finalized/notReady/skipped/errored/backlogRemaining`), plus a `tick_errors` warn line when
   `errored > 0`. `backlogRemaining` (`COUNT(*) WHERE state='running'`) is read in the SAME transaction
   as the scan. The host (`packages/core-backend/src/index.ts`) wires `this.logger` through — now covered
   by a real call-through leg (leg 4, gate-fix round below, P2-1).
4. **Two new real-DB test files** — see gates/legs tables below.

## Fairness design: rotation key

`last_attempt_at` (nullable timestamp), stamped in the SAME UPDATE that performs the scan, ordered
`ASC NULLS FIRST` with `created_at ASC` as the tiebreak. Reasoning:

- **Durable, not in-process**: the rotation state lives in the row itself, so it survives process
  restarts. **Multi-worker exclusivity — corrected in the gate-fix round below (P2-2):** the ORIGINAL
  text here claimed "two concurrent scans cannot both durably own the same candidate without one of them
  losing the row-lock race on the UPDATE" — that was FALSE as shipped (measured overlap 6/6, see P2-2).
  It is now true, but the mechanism is `FOR UPDATE SKIP LOCKED` on the inner `SELECT`, not a row-lock
  race on the `UPDATE`: a row already locked by a concurrent scan (or by the sweep's own per-candidate
  `finalize`/`abandon` step) is skipped by the other scan, not raced onto.
- **Not `OFFSET`**: an offset computed against one tick's row count is meaningless once rows leave
  `state='running'` concurrently (the owner's explicit constraint) — a durable per-row marker has no
  such invalidation window.
- **Same candidate SET in the common case — corrected in the gate-fix round below (P3-1):** every row
  starts `last_attempt_at IS NULL`, so when the backlog never exceeds `limit`, `NULLS FIRST` +
  `created_at ASC` selects the SAME candidates the old `ORDER BY created_at ASC` did. It does **not**
  guarantee the same RETURNED order — `UPDATE ... RETURNING` does not preserve a subquery's `ORDER BY`
  in PostgreSQL (measured: same set, different order) — so this is no longer claimed as
  "byte-behaviorally the prior FIFO order". No correctness impact found (each candidate is its own
  independent transaction and nothing depends on order).
- **Self-correcting starvation bound**: after a row is scanned, it is durably demoted below every
  not-yet-attempted row (including brand-new ones) until every other `running` row has had at least one
  attempt this "round" — an untouched newcomer always outranks a previously-attempted straggler.

## Completion gates (owner's minimum set)

| # | Gate | Result |
| --- | --- | --- |
| 1 | >25 persistently-blocked candidates ahead; a later candidate still gets processed | **PASS** — 26 stuck (never-progressing) candidates + 1 healthy (pre-sealed, newest) candidate: tick 1 scans the oldest 25 stuck candidates (`{scanned:25, finalized:0, notReady:25, backlogRemaining:27}`); tick 2's rotation reaches the healthy candidate and finalizes it (`{scanned:25, finalized:1, notReady:24, backlogRemaining:27}`) — within 2 ticks, all 26 stuck candidates still `running`. `attendance-w4c2-sweep-fairness.db.test.ts`, "gate 1" describe block |
| 2 | Mutation reverting the scan to the fixed prefix (`ORDER BY created_at ASC LIMIT 25`) goes red | **PASS (hand-verified, not automated as a permanent CI leg)** — reverted `scanAttendanceScheduledRunSweepCandidatesV1` to the pre-fix query, reran gate 1's test: `finalized` stayed `0` on tick 2 (expected `1`) — the healthy candidate never gets reached because the fixed-prefix scan has no write-back and keeps re-selecting the same 25 stuck candidates forever. 3 of the file's 6 tests went red (gate 1, steady-state, and the direct scan-rotation-contract test); the 3 observability tests (gate 3, independent of ordering) stayed green. Reverted via `git checkout HEAD --` (committed before mutating); rerun confirmed clean/green again |
| 3 | Values-free tick/backlog/error metrics/logs exist and are values-free | **PASS** — `attendance-w4c2-sweep-fairness.db.test.ts`, "gate 3" describe block: injected fake logger asserts (a) exactly one `info` call per tick with event `attendance.w4_scheduled_run_sweep.tick` and a **closed** key set (`scanned/finalized/notReady/skipped/errored/backlogRemaining`, `Object.keys(...).sort()` deep-equal, not a subset check), (b) every value is `typeof === 'number'` (runtime check, not just the TS type), (c) an additional `warn` `tick_errors` line (same closed shape) only when `errored > 0`, (d) no `logger` supplied → silent, no throw. **The independent gate-fix round below (P2-1) closes the remaining gap**: the ORIGINAL gate-3 tests all injected their OWN fake logger, so the ONE production line that actually wires observability in (`index.ts:2249`, `logger: this.logger`) had zero discriminating coverage — leg 4 (call-through file) now spies on the REAL server `Logger` instance and is mutation-tested against that exact line |
| 4 | Removal mutations for each of the three production call chains go red | **PASS** — see table below |

## Three call-through legs — mutation self-check

Each proven against a REAL booted `MetaSheetServer` + REAL `plugin-attendance` (loaded from
`pluginDirs`, never mocked) + REAL PostgreSQL, in `attendance-w4c2-sweep-call-through.db.test.ts` (own
freshly-migrated scratch DB — the scan predicate is deliberately global/non-org-scoped, so a database
shared with sibling "(real DB, route-level)" suites would corrupt this file's exact assertions).
Mutations were applied by hand, one at a time, on top of the committed state; each was reverted via
`git checkout HEAD --` and reconfirmed clean before the next.

| Leg | Production wiring | Mutation | Result |
| --- | --- | --- | --- |
| 1. Core host sweep/abandon port | `packages/core-backend/src/index.ts`, the `attendanceW4SegmentCalculation` port object's `sweepScheduledRuns`/`abandonScheduledRun` properties | Removed both properties | **RED** — leg 1's 2 direct-call tests (`TypeError: ... is not a function`); leg 2 also went red (job registration itself is gated on `typeof port.sweepScheduledRuns === 'function'`, so no job registers); 2 of leg 3's 4 tests went red (503 `W4_WRITE_BOUNDARY_UNAVAILABLE` instead of 200/404) — the two tests that never reach the port (401 no-token, 403 wrong-permission) correctly stayed green |
| 2. `attendance-w4-scheduled-run-sweep` scheduled job registration | `plugins/plugin-attendance/index.cjs`, the `context.services?.attendanceScheduler?.registerJob?.({name: 'attendance-w4-scheduled-run-sweep', ...})` call | Neutered the registration `if` condition to `false && ...` | **RED, exclusively leg 2** — 1 failure (`last_attempt_at` stayed `null` after a forced real `AttendanceScheduler.runCycle()`); leg 1 (2/2) and leg 3 (4/4) stayed fully green — this is the leg's OWN discriminating test, not incidental coverage from leg 1's mutation |
| 3. Abandon HTTP route registration | `plugins/plugin-attendance/index.cjs`, `context.api.http.addRoute('POST', '/api/attendance/auto-absence/scheduled-runs/:runId/abandon', ...)` | Renamed the registered path (route effectively gone) | **RED** — 3 of leg 3's 4 tests (success 200→404, 403-permission→404, wrong-org-run 404-shaped→generic-404-HTML); leg 1 (2/2) and leg 2 (1/1) stayed fully green. The 4th leg-3 test ("no token → 401") stayed green because an earlier, route-independent authentication gate 401s before route dispatch — a genuine finding, not a gap in this leg's coverage (see self-report below) |
| 4. Production tick-observability wiring (added in the gate-fix round, P2-1) | `packages/core-backend/src/index.ts:2249`, `logger: this.logger` inside the `sweepScheduledRuns` port method | Deleted the line | **RED, exclusively leg 4** — 7 passed / 1 failed in the call-through file; leg 1 (2/2), leg 2 (1/1), leg 3 (4/4) stayed green, AND the fairness file's own gate-3 tests (which inject their own fake logger) stayed fully green (8/8) — proving leg 4 is the ONLY thing that would catch this production wiring regressing |

All reverts confirmed via `git diff HEAD` (empty) before proceeding to the next mutation; final state
re-run green (16/16 across both new files after the gate-fix round, see test evidence below).

## Design-lock / issue-body compliance (provenance)

| Issue #4770 requirement | Where | Status |
| --- | --- | --- |
| Fairness via durable rotation/attempt-time, not `OFFSET` | `w4c2-scheduled-run.ts` §"Fairness design" above | Done |
| New column → new zzzz migration (zzzz-ordering rule) | `zzzz20260805120000_w4c2_scheduled_run_sweep_fairness.ts` | Done |
| Values-free tick/backlog/error observability | `w4c2-scheduled-run-ops-worker.ts`, gate 3 | Done |
| 3 named call-through legs, each with a removal mutation | `attendance-w4c2-sweep-call-through.db.test.ts` | Done |
| Independent Draft/HOLD PR, not folded into #4747 | This PR | Done |
| "Refs #4770", no closing keyword | This PR body | Done (self-scanned, see below) |

## Test evidence (local, real Postgres 15, `postgresql://postgres@localhost:5432/<fresh scratch>`)

```
tests/integration/attendance-w4c2-sweep-fairness.db.test.ts        6 passed
tests/integration/attendance-w4c2-sweep-call-through.db.test.ts    7 passed
tests/integration/attendance-w4c2-p12-run-transactions.db.test.ts       31 passed (regression check — its own
  scratch DB now also runs the new migration since it calls the scan/sweep functions directly)
tests/integration/attendance-w4c2-p12-migration-schema-gates.db.test.ts 30 passed (regression check, unmodified)
tests/integration/attendance-w4c2-p12-durable-lock-gates.db.test.ts     17 passed (regression check, unmodified)
tests/unit/attendance-w4c2-recovery-wiring.test.ts                      3 passed (pre-existing source-string
  wiring test, unmodified — still valid, just insufficient alone per the issue's own framing)
node --test scripts/ops/attendance-w4c2-ci-wiring.test.mjs             102 passed (three-point wiring guard,
  extended with both new files)
```
Broader regression sweep (25 attendance real-DB files, 347 tests) and the full no-DB unit suite
(`tests/unit`, 472 files / 6557 tests) both green against this branch.
`pnpm exec tsc --noEmit -p packages/core-backend` — clean.
Migration `up`→`--rollback`→`--latest` round-trip verified by hand via `tsx src/db/migrate.ts`
(`down` also verified fail-closed against a populated `last_attempt_at`).

(See "Independent gate-fix round" below for the updated counts after the P1/P2 fixes — 8 passed in
the fairness file, 8 passed in the call-through file.)

## RETRACTION — `integration-guard` was NOT pre-existing/unrelated

First CI push showed `integration-guard` red. I initially reasoned (never stated in this body, but it
was my working assumption while investigating) that this was pre-existing on `origin/main` because my
diff touches zero files under `plugins/plugin-integration-core/` — that reasoning was **wrong**, caught
by the coordinator before I acted on it. Root cause: `sealed-export-package-provenance.cjs` pins
`.github/workflows/plugin-tests.yml`'s SHA-256 (id `pluginTestsWorkflow`) against
`plugins/plugin-integration-core/lib/sealed-export/vectors/s6a-package-provenance-pins.json` as a drift
detector — and this PR's ci-wiring commit DOES edit that workflow file (adding the two new test files to
the attendance real-DB step), which is exactly the file whose hash is pinned. Direct precedent:
`7da5d9e55` (#4748) and `14dbe4927` (#4772) hit this identical pin for the identical reason and fixed it
by recomputing and writing only the one `pluginTestsWorkflow` digest in the same commit — this PR does
the same (commit `76ecd793e`): recomputed
`96c5b64517e1ca0abe354f2752f0c357e1b977598bb6cbdbab13501b6505c736` from the actual current workflow file
content, wrote only that field. Verified: reverting only that one field to its stale value turns
`node plugins/plugin-integration-core/__tests__/sealed-export-package-provenance.test.cjs` red;
restored cleanly (`git diff --stat`: 1 file, 1 line); `pnpm --filter plugin-integration-core test` (full
CJS chain, 158 files) exits 0 at the restored value.

## Checks (as of head `76ecd793e`, second CI push after the re-pin fix)

First push (`0be263fad`) showed `integration-guard` red for the reason retracted above; all other checks
that had completed by that point were green (`contracts (strict/dashboard/openapi)`, `pr-validate`,
`attendance-web-guard`, `telemetry-plugin`, `core-backend-cache`, `DingTalk P4 ops regression gate`, `K3
WISE offline PoC`, `after-sales integration`, `e2e`, `migration-replay`, `stock-prep PowerShell 5.1
acceptance`); at head `76ecd793e`, all 24 applicable checks passed (1 `skipping`,
`Strict E2E with Enhanced Gates`) — see the independent gate review linked in the round below for the
re-verified count.

## Self-reported weak spots (original round)

- **Leg 3's "no token" test doesn't discriminate on route removal** (see mutation table above) — an
  earlier, route-independent authentication gate returns 401 before Express even attempts route
  dispatch, so removing this specific route doesn't turn that ONE test red. The other 3 of leg 3's 4
  tests do, so the leg as a whole is still discriminating; flagging this asymmetry rather than silently
  presenting all 4 as equally load-bearing for that specific mutation.
- **Gate 2's mutation-red control is hand-verified, not an automated CI leg** (see gate 2 above) —
  automating "revert my own fix" as a permanent test would just re-assert the pre-#4770 code path
  forever; the fairness test itself is the oracle, and the revert was performed and reverted cleanly
  during this review, not left as a standing assertion.
- **Leg 1's direct-port-call tests required deactivating and reinstalling the real `plugin-attendance`
  module** under a thin wrapper (`packages/core-backend/src/index.ts` grants
  `attendanceW4SegmentCalculation` only to a plugin literally named `plugin-attendance` —
  least-privilege by design) rather than a simple named probe plugin. This is a legitimate call-through
  path (same cached CJS module, same require-cache instance, real deactivate/reactivate round-trip) but
  it is more surgery than the other two legs needed, worth a second pair of eyes.
- I did not re-derive whether `abandonScheduledRunOnceV1`'s org-anchor check
  (`key.orgId !== verifiedCaller.orgId`) is reachable as a genuine mismatch through the actual HTTP
  route — by inspection it is not (the route mints the witness FROM the same `orgId` it later compares
  against), so leg 3's "wrong org" test instead exercises the org-scoped SQL lookup finding zero rows
  for a real cross-org run id, which is the reachable, real-world version of that isolation guarantee.
  This is pre-existing behavior from the #4612/#4617 landing, not something this PR changes or was
  asked to change.

## Independent gate-fix round (2026-08-05, addresses the independent gate CHANGES-REQUESTED review)

An independent review at head `76ecd793e` found 1 P1, 2 P2, 2 P3, 1 NIT. All addressed on top of that
head, each as its own commit:

| ID | Finding | Fix | Commit(s) |
| --- | --- | --- | --- |
| P1-1 | The scan's `UPDATE...RETURNING` had no `FOR UPDATE SKIP LOCKED` on the inner `SELECT`, so a concurrent row lock on one selected candidate (the sweep's own `finalize`/`abandon` step, or a second scan worker) blocked the whole scan statement until `lock_timeout` (5000ms) aborted it with `55P03` — not covered by `isRetryableSqlState()` — killing the ENTIRE tick, 0 candidates processed. Regression of section 1.7's containment invariant for the scan phase (`main` costs one `errored` candidate for the same condition) | Added `FOR UPDATE SKIP LOCKED` to the inner `SELECT` — the standard durable-queue claim idiom; a locked row is excluded this tick (not stamped, not counted `errored`) and stays at the front of the rotation for next tick | New regression-guard test added FIRST against the unfixed code (confirmed red: `55P03` at ~5.5s), fix applied in the next commit (confirmed green) |
| P2-1 | Zero discriminating test coverage for `index.ts:2249`'s `logger: this.logger` — the ONLY line that makes tick/backlog/error observability emit in production; all existing gate-3 tests inject their own fake logger and stay green (13/13+3/3+102/102) even with that line deleted | Added leg 4 to the call-through file: spies on the REAL booted server's `Logger` instance (not a test-supplied one) and asserts the real emission | New leg 4 test; mutation self-check performed (delete the line → leg 4 exclusively red, 7/8; restore → 8/8) |
| P2-2 | "Two concurrent scans cannot both durably own the same candidate" was empirically false (measured overlap 6/6) | Same fix as P1-1 (`FOR UPDATE SKIP LOCKED`) makes the claim true; corrected the source docstring and this PR body's wording to describe the actual mechanism | Covered by the P1-1 fix commit; new deterministic regression-guard test (a naive `Promise.all` version was racy and even hit a genuine `40001` false-positive via SSI — the committed test holds one worker's claim open through the SAME production retry wrapper instead) |
| P3-1 | "Byte-behaviorally the prior FIFO order" is false for the RETURNED order (`UPDATE...RETURNING` doesn't preserve a subquery's `ORDER BY`) — true only for the candidate SET | Narrowed the docstring and this PR body's wording to "same candidate set", not order | Included in the P1-1 fix commit |
| P3-2 | This PR body previously carried two `## Checks` sections; the second, stale one said "Not yet triggered on GitHub" contradicting 24 green checks | Removed the stale section (see "Checks" above, now the only one) | This edit |
| NIT-1 | "Values-free BY CONSTRUCTION" is true only for string values, not numeric ones | Docstring narrowed to name what's actually load-bearing: the producer's closed field set + gate-3's runtime closed-key-set/`typeof` checks | Included in the P2-1 leg-4 commit round |

Updated test evidence after the gate-fix round (same local Postgres 15 setup):
```
tests/integration/attendance-w4c2-sweep-fairness.db.test.ts        8 passed (was 6; +2 regression guards)
tests/integration/attendance-w4c2-sweep-call-through.db.test.ts    8 passed (was 7; +1 call-through leg)
```
Both P1-1 regression guards (row-lock containment, multi-worker exclusivity) were confirmed RED against
the unfixed code before the fix commit, then GREEN after — not just asserted. Leg 4's mutation
self-check (delete `logger: this.logger`) was confirmed to fail EXCLUSIVELY that leg, with every other
test in both new files (15 of 16) staying green — then restored.

This PR remains Draft/HOLD; the above does not change the authorization scope in the first section.
