### PR TITLE
docs(stock-prep): window runbook pinned a package that PREDATES the security gates

### DIFF
--- a/docs/development/stock-preparation-k3wise-development-and-verification-20260805.md
+++ b/docs/development/stock-preparation-k3wise-development-and-verification-20260805.md
@@ -37,7 +37,7 @@ Submit/Audit、BOM 写、定时任务、批量自动写、MES、全面通用化 
 
 | 验证物 | 方式 | 证据 |
 |---|---|---|
-| 从 main 出包可验证 | lane **两次**运行时证据 | run 30975655789(首绿)、**run 30979764981(候选包,7/7)**;074/075 于 PG 15/16/17 逐字 `executed successfully`;一字节篡改负控排他失败;排除集与 migration-replay 逐字对齐 |
+| 从 main 出包可验证 | lane **两次**运行时证据 | run 30975655789(首绿)、**run 30979764981(7/7)** —— 二者证明的是**通道可用**;30979764981 当时被指认为候选包,现已因 #4769 合入而**过期**(见 §6 步 6 的自检);074/075 于 PG 15/16/17 逐字 `executed successfully`;一字节篡改负控排他失败;排除集与 migration-replay 逐字对齐 |
 | 首跑失败的价值 | shakedown 抓真缺陷 | 五检器代际钉漂移(冻结代 vs R12 措辞)⇒ #4764 闭集双值修复;**全类机械横扫恰一处失配** |
 | 写路径三重锁 | 套件 + mutation | profile 字面量删/merge 钉删/守卫短路/FE 常量差一位/payload 去 profile ⇒ 各自红;3 行正控放行 `1 login+3 Save+0 Submit/Audit` |
 | C6 内容绑定 | 真 planner×真 adapter×mock 线 | 批准后改行 ⇒ 409 `C6_WRITE_DRY_RUN_TOKEN_MISMATCH` 且零 Save;第 4 源行 ⇒ `not_applyable` 不发 token |
@@ -105,7 +105,12 @@ replay ⇒ K3_WISE_REPLAY_DISABLED(先于任何读/run 记录/adapter 创建)
 5. **回读**:重复步骤 1 的 read-smoke(single-record preset,按写入行键)⇒ 业务成功 + 记录存在;
    **值级确认**:操作员在客户 K3 客户端打开该物料核对名称/规格。
 6. **留证**:dry-run/apply 响应的 values-free 字段(counts、status、closed tokens)+ run 引用
-   归档;三元组(B4 mint 时已记)与 `serviceRuntimeSha e1b91594e`、候选包 digest 并列。
+   归档;三元组(B4 mint 时已记)与**实际部署的** `serviceRuntimeSha`、包 digest 并列。
+   ⚠️ **不要照抄任何历史 SHA。** 本步原文钉的是 `e1b91594e`,那是 #4769 门**合入之前**的
+   候选包 —— 其树中不含 `K3_WISE_PIPELINE_RUN_DISABLED` 与 `assertWireEndpointIntent`
+   (各 0 文件,已核)。装它等于把 owner 在 #4768 复审中点名的两个敞口原样带进不可重试的窗口。
+   **部署前自检**:所选包的 `serviceRuntimeSha` 必须是 `65edb98c6`(#4769 合入点)**之后**的
+   提交;`git merge-base --is-ancestor <sha> 65edb98c6` 成立即为**过期包**,不得使用。
 
 **PASS 判据**:1–6 全绿且 `0 Submit / 0 Audit`。
 


### PR DESCRIPTION
Found by sweeping for the superseded candidate-package SHA rather than patching the one place I first noticed it. Two references existed on `main`, and the dangerous one is an **operator instruction inside the non-retryable window runbook**.

## The defect

§6 step 6 told the operator to archive the provenance triple alongside `serviceRuntimeSha e1b91594e`.

```
e1b91594e is an ancestor of 65edb98c6 (the #4769 merge)  ⇒ the package is OLDER than the gates
K3_WISE_PIPELINE_RUN_DISABLED  in that tree: 0 files
assertWireEndpointIntent       in that tree: 0 files
```

An operator following the step as written would have recorded — and plausibly deployed — a build in which **both openings the owner named in the #4768 review are still live**: `/run` bypassing the C6 token, and a named profile's `savePath` overridable to `Submit`/`Audit`. Into a window that cannot be retried.

The package isn't defective. It is simply of an **earlier generation** than the fixes, and nothing in the authorization checklist would have caught that — it names a valid SHA and the SHA resolves. This is the standing hazard of *freeze a candidate, then merge security work to main*.

## The fix

Step 6 now carries a **mechanical self-check** instead of a literal SHA:

```
git merge-base --is-ancestor <candidate-sha> 65edb98c6   # true ⇒ STALE, do not deploy
```

Verified to discriminate in both directions:

| candidate | result | verdict |
|---|---|---|
| `e1b91594e` | ancestor | correctly **refused** |
| `1303309b6` | not ancestor | correctly **usable** |

§3's evidence row is corrected too: runs `30975655789` / `30979764981` still prove **the lane works**, which remains true and useful. What expired is the identification of that run's artifact as *"the candidate package"* — relabelled as historical evidence rather than deleted.

## Scope

Docs only, one file. A companion note is posted on #4628 so the authorization step doesn't consume the stale pointer.