### PR TITLE
fix(attendance): #4770 follow-up — values-free neverAttemptedRunning + oldestRunningAttemptAgeSeconds sweep counters [HOLD]

### DIFF
--- a/packages/core-backend/src/attendance/w4c2-scheduled-run-ops-worker.ts
+++ b/packages/core-backend/src/attendance/w4c2-scheduled-run-ops-worker.ts
@@ -54,6 +54,122 @@ export interface AttendanceScheduledRunSweepTickResultV1 {
    *  — the operator-facing starvation signal the fixed-prefix scan never exposed: a
    *  `backlogRemaining` that stays >= `limit` tick after tick means the sweep is not draining. */
   readonly backlogRemaining: number
+  /**
+   * #4770 follow-up (issue #4770; second-opinion NIT-refine on `attendance-4556-w4c2-scheduled-
+   * run-identity-amendment`'s W4C-2 recovery-sweep, 2026-08-05): count of `state='running'` rows
+   * that have NEVER been claimed by a scan (`last_attempt_at IS NULL`), read from the SAME
+   * snapshot as `backlogRemaining` — same query, same transaction, taken AFTER this tick's own
+   * scan/write-back (a row this tick just claimed is already stamped by the time this is read,
+   * so it does not count itself; pinned by the gate-1 tick-2 assertion in
+   * `attendance-w4c2-sweep-fairness.db.test.ts`, which goes red if this read moves before the
+   * scan).
+   *
+   * `backlogRemaining` alone cannot separate "N rows still legitimately churning through a large
+   * backlog" from "one row is permanently excluded from every scan": once `backlogRemaining >
+   * limit`, `scanned < backlogRemaining` holds on EVERY tick regardless of which case is true.
+   * `neverAttemptedRunning` is the un-claimable count, read as a TREND across ticks (same idiom
+   * as `backlogRemaining`'s own doc comment), in two regimes:
+   *  - `backlogRemaining <= limit` (steady state): every row is scanned this tick, so this reads
+   *    the exact un-claimable count from tick 1 — no warm-up window at all.
+   *  - `backlogRemaining > limit` (congested): under ordinary churn it drains toward 0 within
+   *    `ceil(backlogRemaining / limit)` ticks, because every row eventually gets a first scan
+   *    pass (`FOR UPDATE SKIP LOCKED` willing). Under a genuinely stuck candidate — a row lock
+   *    held open forever by a hung/leaked transaction — `SKIP LOCKED` excludes that row from
+   *    every scan, so it is never stamped and this counter FLOORS at (at least) the stuck count
+   *    instead of ever reaching 0.
+   * Values-free: a count, never the stuck run's id/org/date.
+   */
+  readonly neverAttemptedRunning: number
+  /**
+   * Owner-review P2 on #4779 (2026-08-05): `neverAttemptedRunning` has its own blind spot —
+   * `MIN()` ignores NULL, so it structurally cannot see a row that WAS scanned/stamped once
+   * (`last_attempt_at` already non-NULL) and is THEN excluded from every later scan by a
+   * permanent row lock. That row's `last_attempt_at` freezes at its one-and-only stamp; it
+   * never re-enters the never-attempted bucket (it is not NULL) and it is never re-selected
+   * (`FOR UPDATE SKIP LOCKED` keeps skipping it), so `neverAttemptedRunning` reads 0 for it on
+   * every subsequent tick — silently. `oldestRunningAttemptAgeSeconds` closes that gap: the age,
+   * in seconds, of the STALEST `last_attempt_at` among `state='running'` rows (`now() - MIN(last_
+   * attempt_at)`, same snapshot/transaction as `backlogRemaining` and `neverAttemptedRunning`,
+   * same post-scan read ordering). A row this tick just (re-)stamped reads exactly `0` — `now()`
+   * is transaction-stable in PostgreSQL (`transaction_timestamp()`), so a fresh stamp and this
+   * read are the IDENTICAL value within one tick's transaction, not an epsilon.
+   *
+   * THREE regimes — not two; the operator-facing signal is BOUNDED-PLATEAU vs. UNBOUNDED-GROWTH,
+   * never merely "zero vs. nonzero" (a congested-but-healthy backlog is legitimately nonzero on
+   * most ticks; alerting on any nonzero reading pages an operator for nothing broken):
+   *  - Steady state (`backlogRemaining <= limit`), healthy: every tick restamps every row, so
+   *    this reads exactly `0` on EVERY tick — "does not grow" is the positive-control signature,
+   *    not merely "stays low" (verified: `attendance-w4c2-sweep-fairness.db.test.ts`'s
+   *    "owner-review P2" describe block, positive-control leg).
+   *  - Congested (`backlogRemaining > limit`), healthy — no row permanently excluded: rotation
+   *    can only touch `limit` rows per tick, so SOME rows are always "one tick behind" and this
+   *    reads NONZERO on most ticks — but BOUNDED, not ever-growing, as long as every row keeps
+   *    being re-selected on some bounded cadence. (The pre-existing 30-row/limit-25 fixtures in
+   *    the SAME test file — both the `neverAttemptedRunning`-discriminating leg's locked case and
+   *    its own positive control — are consistent with this: nonzero on ticks 2-3, not
+   *    monotonically increasing between them. That is 3 ticks of evidence, not a proof of a
+   *    specific plateau bound — no test in this file pins an exact tick-count formula for this
+   *    regime; only "bounded vs. unbounded" is asserted, via the `>= 0` checks alongside those
+   *    pre-existing fixtures' unchanged 7-field values.)
+   *  - UNBOUNDED-GROWTH: a `running` row is PERMANENTLY EXCLUDED from every scan — its stamp
+   *    never advances while every other row's does, so it becomes (and stays) the `MIN`, and the
+   *    age climbs, tick after tick, by however much real wall-clock time has elapsed, with NONE of
+   *    the other seven counters moving at all once the row's own scan-eligible siblings settle
+   *    into their own steady rotation (see the "owner-review P2" discriminating-leg describe block
+   *    in `attendance-w4c2-sweep-fairness.db.test.ts`). This is a REAL fault either way — the row
+   *    genuinely never gets another resume/finalize attempt — but this field CANNOT tell you why,
+   *    and there is more than one known mechanism (this list is not claimed closed):
+   *     1. A held row lock excludes the row from `FOR UPDATE SKIP LOCKED` on every subsequent
+   *        scan (the discriminating-leg fixture above constructs exactly this case).
+   *     2. Sustained NULLS-FIRST arrival starvation, WITH NO LOCK HELD AT ALL: the scan's own
+   *        `ORDER BY last_attempt_at ASC NULLS FIRST` (`w4c2-scheduled-run.ts`'s scan docstring:
+   *        "keeps never-attempted rows — including brand-new ones — ahead of anything already
+   *        attempted") means a sustained stream of brand-new `running` rows preempts an
+   *        already-stamped row for every scan slot, indefinitely. Empirically reproduced at the
+   *        production default `limit=25` (owner-review P2 on #4779, 2026-08-05): with a flat
+   *        backlog and >=25 fresh never-attempted arrivals injected before each tick, a
+   *        previously-stamped victim row's `last_attempt_at` freezes at its one scan while
+   *        `scanned`/`backlogRemaining`/`neverAttemptedRunning` all stay flat — the IDENTICAL
+   *        stuck signature this field exists to surface, produced with no lock anywhere.
+   *    An earlier version of this comment claimed the `NULLS FIRST` rotation "guarantees every
+   *    row is eventually re-selected" in the congested-healthy regime, and attributed
+   *    UNBOUNDED-GROWTH solely to a held lock. RETRACTED (owner-review, fresh-gate pass,
+   *    2026-08-05) — both claims are false and contradict `w4c2-scheduled-run.ts`'s own scan
+   *    docstring, which mechanism 2 above exploits directly. Do NOT use "no lock found" to
+   *    dismiss a climbing reading. Eliminating mechanism 2 (e.g. guaranteeing every row is
+   *    re-selected within some bounded number of ticks) is a candidate fix to #4774's rotation —
+   *    tracked as an owner-deferred #4770 follow-up, OUT OF SCOPE for this field and this PR.
+   * `neverAttemptedRunning`'s own doc comment enumerates two regimes (steady state / congested)
+   * for ITS OWN reading, not three — that pair is about whether IT reaches zero; this field's own
+   * three-way split above is about whether IT plateaus or keeps climbing. Do not conflate the two
+   * fields' regime lists.
+   *
+   * Complementary to, not a replacement for, `neverAttemptedRunning`: a row locked BEFORE its
+   * first scan ever runs has `last_attempt_at IS NULL` forever, which `MIN()` ignores — that
+   * case is invisible to THIS field by construction and remains `neverAttemptedRunning`'s job
+   * alone. The two counters cover disjoint halves of "permanently UNSCANNED" — never-claimed vs.
+   * claimed-once-then-frozen — NOT every way a run can become permanently stuck. A row that IS
+   * re-scanned every tick but never reaches a terminal state (target-set-drift / `not_ready`
+   * forever — the sweep design's own `abandoned`-transition escape hatch, not this sweep's job)
+   * reads HEALTHY on BOTH counters: re-stamped every tick keeps this field near `0`, and it was
+   * never NULL so `neverAttemptedRunning` reads `0` for it too. That state has its own signature
+   * elsewhere (`finalized=0`, `notReady==scanned`, flat backlog) — do not read "both counters
+   * flat/low" as proof nothing is stuck. Values-free: a derived duration (seconds), never the
+   * stuck row's `last_attempt_at` timestamp itself, its id/org/date.
+   *
+   * Weak spots this gauge does NOT close (disclose to operators; do not silently assume away):
+   *  - Single MIN aggregate, not per-row: once ANY post-scan-stuck row exists, `MIN` pins to it
+   *    and climbs; a second/third stuck row that appears later is invisible underneath it
+   *    (1-vs-many blindness) — this field can only say "at least one row is stuck", never how many.
+   *  - Does not self-clear on partial recovery: when the OLDEST stuck row finally resolves, the
+   *    gauge DROPS to the next-oldest stamp even though other rows may still be stuck — an
+   *    absolute-threshold alert can be spuriously reset by an unrelated row's recovery.
+   *  - Under concurrent scan workers, `now() - MIN(last_attempt_at)` can read slightly NEGATIVE:
+   *    `now()` is this transaction's start time, and a second worker's scan can stamp a row after
+   *    this transaction began but before this `MIN` is read. Cosmetic only — a genuinely stale row
+   *    always dominates the `MIN`, so a negative reading cannot mask a stuck row.
+   */
+  readonly oldestRunningAttemptAgeSeconds: number
 }
 
 /**
@@ -64,10 +180,10 @@ export interface AttendanceScheduledRunSweepTickResultV1 {
  * a user id) into `meta`. The type alone does NOT block a numeric business value (an epoch
  * timestamp, a numeric id) — a caller could type-check while doing that. What actually closes
  * that gap is this file's own PRODUCER (`sweepAttendanceScheduledRunsOnceV1` below emits ONLY
- * the six named counters below, never a caller-supplied field) together with the RUNTIME checks
+ * the eight named counters below, never a caller-supplied field) together with the RUNTIME checks
  * `attendance-w4c2-sweep-fairness.db.test.ts`'s "gate 3" describe block asserts against that
  * producer's actual output: a closed key set (`Object.keys(...).sort()` deep-equal against the
- * six named keys, not a subset check — an extra key fails it) and a `typeof === 'number'` check
+ * eight named keys, not a subset check — an extra key fails it) and a `typeof === 'number'` check
  * on every value (a smuggled string fails it). Those two RUNTIME assertions, not the `meta` type
  * alone, are what is actually load-bearing; the type is a compile-time deterrent for the obvious
  * mistake, not a proof.
@@ -93,8 +209,9 @@ export interface AttendanceScheduledRunSweepOptionsV1 {
 }
 
 /**
- * One sweep tick: the scan runs in its OWN transaction (alongside a `backlogRemaining` read of
- * the SAME `state='running'` snapshot the scan used), then EACH candidate gets its OWN fresh
+ * One sweep tick: the scan runs in its OWN transaction (alongside a `backlogRemaining` /
+ * `neverAttemptedRunning` read of the SAME `state='running'` snapshot the scan used), then EACH
+ * candidate gets its OWN fresh
  * connection and its OWN transaction — never batched (section 1.7's own comment on
  * `sweepAttendanceScheduledRunCandidateV1`: "Intended to run as ONE candidate per its OWN
  * `runAttendanceResultOperationTransactionV1` call, never batched, so one stuck candidate
@@ -119,18 +236,38 @@ export async function sweepAttendanceScheduledRunsOnceV1(
   const scanClient = (await pool.connect()) as unknown as PoolClient
   let candidates: readonly { orgId: string; initiator: string; workDate: string; runId: string }[]
   let backlogRemaining: number
+  let neverAttemptedRunning: number
+  let oldestRunningAttemptAgeSeconds: number
   try {
-    ;({ candidates, backlogRemaining } = await runAttendanceResultOperationTransactionV1(
-      scanClient as unknown as AttendanceW4TransactionClientV1,
-      async (trx) => {
-        const scanned = await scanAttendanceScheduledRunSweepCandidatesV1(trx, limit)
-        const backlog = await trx.query(
-          `SELECT count(*)::int AS n FROM attendance_scheduled_runs WHERE state = 'running'`,
-        )
-        const backlogRow = backlog.rows[0] as { n?: number | string } | undefined
-        return { candidates: scanned, backlogRemaining: Number(backlogRow?.n ?? 0) }
-      },
-    ))
+    ;({ candidates, backlogRemaining, neverAttemptedRunning, oldestRunningAttemptAgeSeconds } =
+      await runAttendanceResultOperationTransactionV1(
+        scanClient as unknown as AttendanceW4TransactionClientV1,
+        async (trx) => {
+          // Scan (and its own durable-rotation write-back) FIRST, then read the post-scan
+          // snapshot below — ordering is load-bearing, see `neverAttemptedRunning`'s doc comment
+          // on `AttendanceScheduledRunSweepTickResultV1`.
+          const scanned = await scanAttendanceScheduledRunSweepCandidatesV1(trx, limit)
+          const backlog = await trx.query(
+            `SELECT count(*)::int AS n,
+                    count(*) FILTER (WHERE last_attempt_at IS NULL) AS never_attempted,
+                    EXTRACT(EPOCH FROM (now() - MIN(last_attempt_at)))::float8 AS oldest_attempt_age_seconds
+               FROM attendance_scheduled_runs WHERE state = 'running'`,
+          )
+          const backlogRow = backlog.rows[0] as
+            | { n?: number | string; never_attempted?: number | string; oldest_attempt_age_seconds?: number | string | null }
+            | undefined
+          return {
+            candidates: scanned,
+            backlogRemaining: Number(backlogRow?.n ?? 0),
+            neverAttemptedRunning: Number(backlogRow?.never_attempted ?? 0),
+            // `MIN(last_attempt_at)` is NULL when every `running` row is still un-stamped (or
+            // there are no `running` rows at all) — `EXTRACT(EPOCH FROM NULL)` is then also NULL,
+            // which `Number(... ?? 0)` floors to `0` (nothing stale to report, same "no signal"
+            // convention the other two counters already use for their own empty case).
+            oldestRunningAttemptAgeSeconds: Number(backlogRow?.oldest_attempt_age_seconds ?? 0),
+          }
+        },
+      ))
   } finally {
     scanClient.release()
   }
@@ -169,7 +306,16 @@ export async function sweepAttendanceScheduledRunsOnceV1(
     skipped += 1
   }
 
-  const result = { scanned: candidates.length, finalized, notReady, skipped, errored, backlogRemaining }
+  const result = {
+    scanned: candidates.length,
+    finalized,
+    notReady,
+    skipped,
+    errored,
+    backlogRemaining,
+    neverAttemptedRunning,
+    oldestRunningAttemptAgeSeconds,
+  }
   logger.info('attendance.w4_scheduled_run_sweep.tick', result)
   if (errored > 0) {
     logger.warn('attendance.w4_scheduled_run_sweep.tick_errors', result)

--- a/packages/core-backend/src/types/plugin.ts
+++ b/packages/core-backend/src/types/plugin.ts
@@ -1259,6 +1259,30 @@ export interface PluginServices {
       errored: number
       /** #4770: total `state='running'` rows at scan time — the starvation signal. */
       backlogRemaining: number
+      /** #4770 follow-up: `state='running'` rows never yet claimed by a scan
+       *  (`last_attempt_at IS NULL`) — a stuck-vs-churn signal, see
+       *  `AttendanceScheduledRunSweepTickResultV1`'s doc comment in
+       *  `w4c2-scheduled-run-ops-worker.ts` for the full trend semantics. */
+      neverAttemptedRunning: number
+      /** Owner-review P2 on #4779: age (seconds) of the STALEST `last_attempt_at` among
+       *  `state='running'` rows — closes `neverAttemptedRunning`'s own blind spot for a row
+       *  scanned once then PERMANENTLY EXCLUDED from later scans (non-NULL, so invisible to
+       *  `MIN()`-ignores-NULL above). Read as BOUNDED-PLATEAU (healthy, even a congested backlog)
+       *  vs. UNBOUNDED-GROWTH — never merely "zero vs. nonzero": a congested-but-healthy backlog
+       *  legitimately reads nonzero on most ticks without anything being stuck.
+       *  UNBOUNDED-GROWTH does NOT mean "locked" specifically: a held row lock is one known
+       *  mechanism, sustained `NULLS FIRST` arrival starvation (a stream of brand-new `running`
+       *  rows preempting an already-stamped one for every scan slot, indefinitely — NO LOCK AT
+       *  ALL) is another, empirically reproduced at the production default `limit=25`; this field
+       *  cannot tell them apart, and the mechanism list is not claimed closed. (A prior version of
+       *  this comment attributed UNBOUNDED-GROWTH solely to "a row permanently locked after its
+       *  first scan" — RETRACTED, fresh-gate pass 2026-08-05: false, and it was the SAME
+       *  overclaim as the worker-doc mirror this field's own doc comment already corrects; see
+       *  below.) See `AttendanceScheduledRunSweepTickResultV1`'s doc comment in
+       *  `w4c2-scheduled-run-ops-worker.ts` for the full three-regime breakdown, the
+       *  arrival-starvation mechanism and its owner-deferred #4770 follow-up, and the two
+       *  counters' actual (narrower-than-"permanently stuck") coverage. */
+      oldestRunningAttemptAgeSeconds: number
     }>
     /**
      * W4C-2 P1-1 fix (#4612 verdict second gate round; amendment section 1.1.2, the `abandoned`

--- a/packages/core-backend/tests/integration/attendance-w4c2-sweep-call-through.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-w4c2-sweep-call-through.db.test.ts
@@ -128,7 +128,16 @@ describeIfDatabase('W4C-2 #4770 recovery-sweep call-through (real server, real p
     sweepScheduledRuns: (options: {
       limit?: number
       recoverCandidate(candidate: { orgId: string; initiator: string; workDate: string; runId: string }): Promise<void>
-    }) => Promise<{ scanned: number; finalized: number; notReady: number; skipped: number; errored: number; backlogRemaining: number }>
+    }) => Promise<{
+      scanned: number
+      finalized: number
+      notReady: number
+      skipped: number
+      errored: number
+      backlogRemaining: number
+      neverAttemptedRunning: number
+      oldestRunningAttemptAgeSeconds: number
+    }>
     abandonScheduledRun: (input: {
       orgId: string
       runId: string
@@ -537,7 +546,16 @@ describeIfDatabase('W4C-2 #4770 recovery-sweep call-through (real server, real p
           'the production Logger must have received the tick-summary line — proves index.ts:2249 `logger: this.logger` is actually wired into the booted server, not just declared in source',
         ).toBeDefined()
         expect(Object.keys(tickCall!.meta ?? {}).sort()).toEqual(
-          ['backlogRemaining', 'errored', 'finalized', 'notReady', 'scanned', 'skipped'].sort(),
+          [
+            'backlogRemaining',
+            'errored',
+            'finalized',
+            'neverAttemptedRunning',
+            'notReady',
+            'oldestRunningAttemptAgeSeconds',
+            'scanned',
+            'skipped',
+          ].sort(),
         )
         for (const value of Object.values(tickCall!.meta ?? {})) {
           expect(typeof value, 'production-emitted meta must stay values-free: numbers only').toBe('number')

--- a/packages/core-backend/tests/integration/attendance-w4c2-sweep-fairness.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-w4c2-sweep-fairness.db.test.ts
@@ -275,13 +275,50 @@ describeIfDatabase('W4C-2 #4770 recovery-sweep fairness/observability (real DB)'
         )
 
       const tick1 = await tick()
-      expect(tick1).toEqual({ scanned: 25, finalized: 0, notReady: 25, skipped: 0, errored: 0, backlogRemaining: 27 })
+      // #4770 follow-up: 27 running rows, 25 scanned/stamped this tick — the 26th stuck run and
+      // the healthy run are the 2 rows still `last_attempt_at IS NULL` after this tick's scan.
+      // `oldestRunningAttemptAgeSeconds` is asserted separately below (not inlined into this
+      // `toEqual`): all 25 stamped rows share the SAME `now()` this tick's transaction saw
+      // (PostgreSQL's `now()` is transaction-stable), so it is deterministically exactly `0` —
+      // an exact assertion, not a bound.
+      const { oldestRunningAttemptAgeSeconds: tick1Age, ...tick1Rest } = tick1
+      expect(tick1Rest).toEqual({
+        scanned: 25,
+        finalized: 0,
+        notReady: 25,
+        skipped: 0,
+        errored: 0,
+        backlogRemaining: 27,
+        neverAttemptedRunning: 2,
+      })
+      expect(tick1Age).toBe(0)
       // The healthy run and the 26th stuck run were NOT reached by tick 1 (still un-stamped).
       expect(await lastAttemptAt(healthyCreated.runId)).toBeNull()
       expect(await runState(healthyCreated.runId)).toBe('running')
 
       const tick2 = await tick()
-      expect(tick2).toEqual({ scanned: 25, finalized: 1, notReady: 24, skipped: 0, errored: 0, backlogRemaining: 27 })
+      // Tick 2's scan durably prioritizes `last_attempt_at IS NULL` rows FIRST (`NULLS FIRST`),
+      // so both previously-unstamped rows are claimed this tick — `neverAttemptedRunning` drops
+      // to 0 even though 2 of the 26 stuck rows from tick 1 are not re-scanned this tick (they
+      // already carry a non-null `last_attempt_at` from tick 1, so they do not count here; this
+      // is the read-AFTER-scan ordering `AttendanceScheduledRunSweepTickResultV1`'s doc comment
+      // pins — computing this BEFORE the scan would read 2, not 0). The SAME 2 leftover rows are
+      // now the `MIN(last_attempt_at)` (still at tick 1's stamp), so `oldestRunningAttemptAgeSeconds`
+      // is positive here — real wall-clock elapsed time between tick 1's and tick 2's OWN
+      // transactions, not a value this test can predict exactly (see the dedicated discriminating-
+      // leg describe block below for the tight, deterministic monotonic-growth proof this field
+      // exists for).
+      const { oldestRunningAttemptAgeSeconds: tick2Age, ...tick2Rest } = tick2
+      expect(tick2Rest).toEqual({
+        scanned: 25,
+        finalized: 1,
+        notReady: 24,
+        skipped: 0,
+        errored: 0,
+        backlogRemaining: 27,
+        neverAttemptedRunning: 0,
+      })
+      expect(tick2Age).toBeGreaterThan(0)
 
       // The healthy run finalized on tick 2 — durable rotation reached it despite 26
       // persistently-blocked candidates having occupied every earlier scan window.
@@ -312,7 +349,19 @@ describeIfDatabase('W4C-2 #4770 recovery-sweep fairness/observability (real DB)'
       const result = await withAllowlist([solo.orgId], () =>
         sweepAttendanceScheduledRunsOnceV1(pool, { limit: 25, async recoverCandidate() {} }),
       )
-      expect(result).toEqual({ scanned: 1, finalized: 0, notReady: 1, skipped: 0, errored: 0, backlogRemaining: 1 })
+      expect(result).toEqual({
+        scanned: 1,
+        finalized: 0,
+        notReady: 1,
+        skipped: 0,
+        errored: 0,
+        backlogRemaining: 1,
+        // Steady state: the lone row is scanned (and stamped) THIS tick, so it no longer counts
+        // as never-attempted by the time the post-scan read happens — 0, not 1.
+        neverAttemptedRunning: 0,
+        // Freshly stamped THIS tick — `now()` is transaction-stable, so this is exactly `0`.
+        oldestRunningAttemptAgeSeconds: 0,
+      })
       expect(await lastAttemptAt(solo.runId)).not.toBeNull()
       expect(await runState(solo.runId)).toBe('running')
     }, 60000)
@@ -336,7 +385,16 @@ describeIfDatabase('W4C-2 #4770 recovery-sweep fairness/observability (real DB)'
       }
     }
 
-    const EXPECTED_META_KEYS = ['scanned', 'finalized', 'notReady', 'skipped', 'errored', 'backlogRemaining'].sort()
+    const EXPECTED_META_KEYS = [
+      'scanned',
+      'finalized',
+      'notReady',
+      'skipped',
+      'errored',
+      'backlogRemaining',
+      'neverAttemptedRunning',
+      'oldestRunningAttemptAgeSeconds',
+    ].sort()
 
     it('logs exactly one info tick-summary with a closed, all-numeric, values-free key set — and no warn when nothing errors', async () => {
       const workDate = '2026-03-03'
@@ -459,8 +517,25 @@ describeIfDatabase('W4C-2 #4770 recovery-sweep fairness/observability (real DB)'
         expect(elapsedMs).toBeLessThan(4000)
 
         // `b` (locked) is excluded from THIS tick's candidate set entirely; `a` and `c` are
-        // unaffected and processed normally — values-free containment restored.
-        expect(result).toEqual({ scanned: 2, finalized: 0, notReady: 2, skipped: 0, errored: 0, backlogRemaining: 3 })
+        // unaffected and processed normally — values-free containment restored. `b` is also the
+        // #4770-follow-up `neverAttemptedRunning` signal in miniature: it is `state='running'`
+        // and was never stamped (excluded by SKIP LOCKED, not merely deferred to later in the
+        // scan window), so it reads 1 — a single-tick preview of the multi-tick "stably >0"
+        // starvation signature exercised in full below.
+        expect(result).toEqual({
+          scanned: 2,
+          finalized: 0,
+          notReady: 2,
+          skipped: 0,
+          errored: 0,
+          backlogRemaining: 3,
+          neverAttemptedRunning: 1,
+          // `b`'s `last_attempt_at` is NULL (locked BEFORE ever being scanned) — `MIN()` ignores
+          // NULL, so only `a`/`c`'s fresh THIS-tick stamps count, giving an exact `0`. `b` is
+          // invisible to this field by construction (that is `neverAttemptedRunning`'s case, not
+          // this field's — see the disjoint-coverage note on `AttendanceScheduledRunSweepTickResultV1`).
+          oldestRunningAttemptAgeSeconds: 0,
+        })
         expect(await lastAttemptAt(a.runId)).not.toBeNull()
         expect(await lastAttemptAt(c.runId)).not.toBeNull()
         // `b` was never reached by this tick — still un-stamped, still running, NOT counted as
@@ -578,6 +653,286 @@ describeIfDatabase('W4C-2 #4770 recovery-sweep fairness/observability (real DB)'
         clientA.release()
         clientB.release()
       }
+    }, 30000)
+  })
+
+  // =============================================================================================
+  // #4770 follow-up (issue #4770; second-opinion NIT-refine, 2026-08-05) — `neverAttemptedRunning`
+  // is meant to separate "permanently stuck" from "ordinary large-backlog churn", something
+  // `backlogRemaining` alone cannot do once `backlogRemaining > limit` (`scanned < backlogRemaining`
+  // holds every tick either way — see the second opinion's Probe C). These two tests are the SAME
+  // 30-row/limit-25 backlog, differing in EXACTLY one variable — whether a connection holds an
+  // open, never-released `FOR UPDATE` lock on one row — so the observed `neverAttemptedRunning`
+  // sequences are the discriminating signal itself, not an artifact of different fixtures.
+  // =============================================================================================
+  describe('#4770 follow-up — neverAttemptedRunning discriminates permanent-lock starvation from ordinary churn', () => {
+    it('a row held under a never-released lock floors neverAttemptedRunning at 1 across ticks; every other row still drains', async () => {
+      const workDate = '2026-03-09'
+      const ROWS = 30
+      const rows: Array<{ orgId: string; runId: string }> = []
+      for (let i = 0; i < ROWS; i += 1) {
+        // eslint-disable-next-line no-await-in-loop -- sequential seeding: created_at must be
+        // strictly increasing, same rationale as gate 1's and the overlap test's seeding loops.
+        rows.push(await createStuckRun(`starve-${i}`, workDate))
+      }
+      const orgIds = rows.map((r) => r.orgId)
+
+      // Row 0 (oldest — sorts first in the rotation) is held under an open, uncommitted `FOR
+      // UPDATE` lock for the ENTIRE test — modeling a genuinely hung/leaked transaction, not a
+      // timing artifact (same construction as the "tick-level containment" regression guard
+      // above, held across THREE ticks here instead of one). `FOR UPDATE SKIP LOCKED` excludes
+      // it from every tick's scan, so it is NEVER stamped — this is the second opinion's Probe C
+      // scenario (120 rows/8 ticks, manual), pinned here as an automated multi-tick regression
+      // at a smaller scale (30 rows/3 ticks, limit 25).
+      const lockConn = await pool.connect()
+      await lockConn.query('BEGIN')
+      await lockConn.query('SELECT * FROM attendance_scheduled_runs WHERE run_id = $1::uuid FOR UPDATE', [
+        rows[0].runId,
+      ])
+
+      try {
+        const tick = () =>
+          withAllowlist(orgIds, () =>
+            sweepAttendanceScheduledRunsOnceV1(pool, { limit: 25, async recoverCandidate() {} }),
+          )
+        const observed: Array<Awaited<ReturnType<typeof tick>>> = []
+        for (let t = 0; t < 3; t += 1) {
+          // eslint-disable-next-line no-await-in-loop -- ticks are inherently sequential: each
+          // reads the durable write-back the previous tick left behind.
+          observed.push(await tick())
+        }
+
+        // 30 rows, limit 25, none ever finalize (targets never sealed — every candidate reports
+        // `not_ready`, so `scanned`/`notReady`/`backlogRemaining` are flat across all 3 ticks).
+        // Tick 1 scans the 25 oldest UNLOCKED rows (row 0 is skip-locked, invisible to the
+        // selection entirely), leaving 4 unlocked rows + the locked row un-stamped (5). Tick 2's
+        // `last_attempt_at ASC NULLS FIRST` ordering claims those 4 remaining unlocked rows
+        // FIRST, so only the permanently-locked row is left (1) — and it STAYS at 1 on tick 3,
+        // because it is never claimable. This is the stuck-vs-churn signature: FLOORS nonzero
+        // instead of draining to 0 (contrast the positive-control test immediately below, whose
+        // sequence is [5, 0, 0] off the identical fixture minus the held lock).
+        const restObserved = observed.map(({ oldestRunningAttemptAgeSeconds, ...rest }) => rest)
+        expect(restObserved).toEqual([
+          { scanned: 25, finalized: 0, notReady: 25, skipped: 0, errored: 0, backlogRemaining: 30, neverAttemptedRunning: 5 },
+          { scanned: 25, finalized: 0, notReady: 25, skipped: 0, errored: 0, backlogRemaining: 30, neverAttemptedRunning: 1 },
+          { scanned: 25, finalized: 0, notReady: 25, skipped: 0, errored: 0, backlogRemaining: 30, neverAttemptedRunning: 1 },
+        ])
+
+        // `oldestRunningAttemptAgeSeconds` is NOT this test's discriminator: row 0's
+        // `last_attempt_at` is NULL forever (locked BEFORE its first scan) — `MIN()` ignores
+        // NULL, so this field structurally cannot see row 0 (that is `neverAttemptedRunning`'s
+        // exclusive coverage, already proven above). At this 30-row/limit-25 SCALE, the 29 other
+        // (unlocked, genuinely churning) rows themselves leave a handful of rows one tick
+        // "behind" every tick (rotation can only touch `limit` rows per tick — same dynamic the
+        // positive-control test below also shows), so no exact or monotonic claim holds for
+        // ticks 2-3 here. Tick 1 is the one exception: every stamped row shares that tick's OWN
+        // transaction-stable `now()`, so it is deterministically `0`. The tight, deterministic
+        // monotonic-growth proof this field exists for uses a STEADY-STATE (backlog <= limit)
+        // fixture instead, where every unlocked row genuinely IS re-touched every tick — see the
+        // "owner-review P2" describe block below.
+        expect(observed[0].oldestRunningAttemptAgeSeconds).toBe(0)
+        for (const o of observed) {
+          expect(o.oldestRunningAttemptAgeSeconds).toBeGreaterThanOrEqual(0)
+        }
+
+        expect(await lastAttemptAt(rows[0].runId)).toBeNull()
+        expect(await runState(rows[0].runId)).toBe('running')
+      } finally {
+        await lockConn.query('ROLLBACK').catch(() => undefined)
+        lockConn.release()
+      }
+    }, 90000)
+
+    it('positive control — the SAME 30-row backlog with NO held lock drains neverAttemptedRunning to 0 and stays there', async () => {
+      const workDate = '2026-03-10'
+      const ROWS = 30
+      const rows: Array<{ orgId: string; runId: string }> = []
+      for (let i = 0; i < ROWS; i += 1) {
+        // eslint-disable-next-line no-await-in-loop -- sequential seeding, same rationale as the
+        // sibling (locked) test above.
+        rows.push(await createStuckRun(`churn-${i}`, workDate))
+      }
+      const orgIds = rows.map((r) => r.orgId)
+
+      // No lock held anywhere — every row is genuinely claimable. `createStuckRun`'s targets are
+      // deliberately never sealed (see its own doc comment), so every row reports `not_ready` on
+      // every scan forever and STAYS `state='running'` — a real positive control (an ongoing,
+      // never-terminal backlog under legitimate rotation churn), not "an empty queue reads 0".
+      const tick = () =>
+        withAllowlist(orgIds, () =>
+          sweepAttendanceScheduledRunsOnceV1(pool, { limit: 25, async recoverCandidate() {} }),
+        )
+      const observed: Array<Awaited<ReturnType<typeof tick>>> = []
+      for (let t = 0; t < 3; t += 1) {
+        // eslint-disable-next-line no-await-in-loop -- ticks are inherently sequential.
+        observed.push(await tick())
+      }
+
+      // Identical 30/25 split to the locked sibling test's tick 1 (5 un-stamped after tick 1),
+      // but with nothing permanently un-claimable, tick 2 claims the remaining 5 rows and it
+      // stays 0 on tick 3 — the discriminating counter-signature to the sibling test's
+      // [5, 1, 1] above.
+      const restObserved = observed.map(({ oldestRunningAttemptAgeSeconds, ...rest }) => rest)
+      expect(restObserved).toEqual([
+        { scanned: 25, finalized: 0, notReady: 25, skipped: 0, errored: 0, backlogRemaining: 30, neverAttemptedRunning: 5 },
+        { scanned: 25, finalized: 0, notReady: 25, skipped: 0, errored: 0, backlogRemaining: 30, neverAttemptedRunning: 0 },
+        { scanned: 25, finalized: 0, notReady: 25, skipped: 0, errored: 0, backlogRemaining: 30, neverAttemptedRunning: 0 },
+      ])
+
+      // Same caveat as the locked sibling test above: at this congested (backlog > limit) scale,
+      // even this fully-healthy churn leaves a handful of rows one tick "behind" every tick
+      // (rotation can only touch `limit` rows per tick), so `oldestRunningAttemptAgeSeconds` is
+      // NOT pinned to `0` on ticks 2-3 here despite there being no lock anywhere — only tick 1
+      // (every row fresh-stamped in its OWN transaction) is exactly `0`. The clean "stays at `0`,
+      // every tick" signature this field gives for genuinely healthy churn needs a STEADY-STATE
+      // (backlog <= limit) fixture, where literally every row is re-touched every tick — see the
+      // "owner-review P2" describe block below.
+      expect(observed[0].oldestRunningAttemptAgeSeconds).toBe(0)
+      for (const o of observed) {
+        expect(o.oldestRunningAttemptAgeSeconds).toBeGreaterThanOrEqual(0)
+      }
+    }, 90000)
+  })
+
+  // =============================================================================================
+  // Owner-review P2 on #4779 (2026-08-05) — `neverAttemptedRunning`'s OWN blind spot: it counts
+  // `last_attempt_at IS NULL`, so a row locked BEFORE its first-ever scan is caught (the describe
+  // block above), but a row that WAS scanned/stamped once and is THEN locked forever is NOT — its
+  // `last_attempt_at` is non-NULL, so it never re-enters the never-attempted bucket, and `FOR
+  // UPDATE SKIP LOCKED` means it is never re-selected either. `neverAttemptedRunning` reads `0`
+  // for it on every subsequent tick, silently.
+  //
+  // Fixture is deliberately STEADY STATE (backlog <= limit, 4 rows vs. limit 25) rather than the
+  // 30-row congested scale above — that is what makes the positive control's signature exactly
+  // `[0, 0, 0]` (every row, including the one under test before it is locked, is genuinely
+  // re-touched every tick) rather than merely bounded, and makes the locked leg's damning form
+  // sharpest: from tick 2 to tick 3, NOT ONE of the seven pre-existing counters moves at all
+  // (`scanned`/`notReady`/`backlogRemaining`/`neverAttemptedRunning` are byte-identical) — a
+  // dashboard watching only those seven would see a perfectly ordinary, unchanging 3-row backlog,
+  // tick after tick, forever. Only `oldestRunningAttemptAgeSeconds` reveals the row that's been
+  // frozen since tick 1.
+  // =============================================================================================
+  describe('owner-review P2 on #4779 — oldestRunningAttemptAgeSeconds discriminates a row scanned once then permanently locked', () => {
+    const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms))
+
+    it('a row locked AFTER its first successful scan freezes there — neverAttemptedRunning reads 0 (the blind spot) while oldestRunningAttemptAgeSeconds climbs, tick after tick, with the other seven counters unchanged', async () => {
+      const workDate = '2026-03-11'
+      const ROWS = 4
+      const rows: Array<{ orgId: string; runId: string }> = []
+      for (let i = 0; i < ROWS; i += 1) {
+        // eslint-disable-next-line no-await-in-loop -- sequential seeding, same rationale as the
+        // sibling 30-row tests above.
+        rows.push(await createStuckRun(`p2starve-${i}`, workDate))
+      }
+      const orgIds = rows.map((r) => r.orgId)
+      const tick = () =>
+        withAllowlist(orgIds, () => sweepAttendanceScheduledRunsOnceV1(pool, { limit: 25, async recoverCandidate() {} }))
+
+      // Tick 1: steady state (4 rows <= limit 25) — every row is scanned and stamped THIS tick,
+      // including the row about to be locked. `oldestRunningAttemptAgeSeconds` is exactly `0`
+      // (transaction-stable `now()`, same as the steady-state and gate-1-tick-1 tests above).
+      const tick1 = await tick()
+      expect(tick1).toEqual({
+        scanned: 4,
+        finalized: 0,
+        notReady: 4,
+        skipped: 0,
+        errored: 0,
+        backlogRemaining: 4,
+        neverAttemptedRunning: 0,
+        oldestRunningAttemptAgeSeconds: 0,
+      })
+      const frozenStamp = await lastAttemptAt(rows[0].runId)
+      expect(frozenStamp).not.toBeNull()
+
+      // NOW — only AFTER rows[0] already carries a non-NULL `last_attempt_at` from tick 1 — a
+      // separate connection takes an open, never-released `FOR UPDATE` lock on it. This is the
+      // exact ordering the sibling `neverAttemptedRunning`-discriminating leg above does NOT
+      // cover (there, the lock is acquired BEFORE tick 1 ever runs).
+      const lockConn = await pool.connect()
+      await lockConn.query('BEGIN')
+      await lockConn.query('SELECT * FROM attendance_scheduled_runs WHERE run_id = $1::uuid FOR UPDATE', [
+        rows[0].runId,
+      ])
+
+      try {
+        await sleep(300)
+        const tick2 = await tick()
+        const { oldestRunningAttemptAgeSeconds: age2, ...rest2 } = tick2
+        // `rows[0]` is excluded by SKIP LOCKED; the other 3 are re-scanned/re-stamped normally.
+        expect(rest2).toEqual({
+          scanned: 3,
+          finalized: 0,
+          notReady: 3,
+          skipped: 0,
+          errored: 0,
+          backlogRemaining: 4,
+          // THE BLIND SPOT, reproduced: `rows[0]` has been permanently unclaimable since tick 1,
+          // yet this reads `0` — its `last_attempt_at` is non-NULL (stamped once, at tick 1), so
+          // it never counts as "never attempted".
+          neverAttemptedRunning: 0,
+        })
+        // THE FIX, observable: `rows[0]`'s frozen tick-1 stamp is now the STALEST — age is
+        // strictly positive (real wall-clock time elapsed since tick 1), where the blind-spot
+        // counter above read a flat `0`.
+        expect(age2).toBeGreaterThanOrEqual(0.2)
+
+        await sleep(300)
+        const tick3 = await tick()
+        const { oldestRunningAttemptAgeSeconds: age3, ...rest3 } = tick3
+        // Identical to tick 2's seven-counter shape — NOT ONE of them moved. A dashboard reading
+        // only the pre-#4779-P2 fields would see nothing wrong, tick after tick, forever.
+        expect(rest3).toEqual(rest2)
+        // Monotonic growth: strictly larger than tick 2's reading, because `rows[0]`'s stamp is
+        // STILL frozen at tick 1 while real time keeps advancing.
+        expect(age3).toBeGreaterThan(age2)
+
+        // Mechanism pin: rows[0]'s `last_attempt_at` genuinely never moved across either tick —
+        // this is not a coincidence of the aggregate reading.
+        expect(await lastAttemptAt(rows[0].runId)).toEqual(frozenStamp)
+        expect(await runState(rows[0].runId)).toBe('running')
+      } finally {
+        await lockConn.query('ROLLBACK').catch(() => undefined)
+        lockConn.release()
+      }
+    }, 30000)
+
+    it('positive control — the SAME 4-row steady-state backlog with NO held lock reads oldestRunningAttemptAgeSeconds as exactly 0 on every tick (never grows)', async () => {
+      const workDate = '2026-03-12'
+      const ROWS = 4
+      const rows: Array<{ orgId: string; runId: string }> = []
+      for (let i = 0; i < ROWS; i += 1) {
+        // eslint-disable-next-line no-await-in-loop -- sequential seeding, same rationale as the
+        // sibling (locked) test above.
+        rows.push(await createStuckRun(`p2churn-${i}`, workDate))
+      }
+      const orgIds = rows.map((r) => r.orgId)
+      const tick = () =>
+        withAllowlist(orgIds, () => sweepAttendanceScheduledRunsOnceV1(pool, { limit: 25, async recoverCandidate() {} }))
+
+      // Nothing locked anywhere — every row is genuinely re-claimable every tick (steady state,
+      // 4 <= limit 25), so EVERY tick restamps EVERY row: `oldestRunningAttemptAgeSeconds` is
+      // exactly `0`, every single time — the discriminating counter-signature to the locked
+      // sibling test's strictly-growing `age2 < age3` above ("normal progress ⇒ never grows").
+      const tick1 = await tick()
+      expect(tick1).toEqual({
+        scanned: 4,
+        finalized: 0,
+        notReady: 4,
+        skipped: 0,
+        errored: 0,
+        backlogRemaining: 4,
+        neverAttemptedRunning: 0,
+        oldestRunningAttemptAgeSeconds: 0,
+      })
+
+      await sleep(300)
+      const tick2 = await tick()
+      expect(tick2).toEqual(tick1)
+
+      await sleep(300)
+      const tick3 = await tick()
+      expect(tick3).toEqual(tick1)
     }, 30000)
   })
 })


### PR DESCRIPTION
## [HOLD] Draft — not for merge

This PR is a **Draft/HOLD**. It is not armed for auto-merge and should not be merged without an explicit owner ruling. Refs #4770 (parent #4556). Follow-up to #4774 (merged `523d254b8`).

## What this is

#4774 (W4C-2 recovery-sweep fairness) landed with zero P1/P2 findings on both the front-door gate and an independent second opinion. The second opinion's own MD (`pr4774-second-opinion-20260805.md`) added one non-blocking suggestion it explicitly deferred to this follow-up:

> 建议(可后补, 非合并前必修): emit 一个仍 values-free 的信号,如 `neverAttemptedRunning`(=`count WHERE state='running' AND last_attempt_at IS NULL`,永久锁下稳定 >0)或 `oldestRunningAttemptAgeSeconds`,把"卡住 vs churn"分开。留待 W4C-5 soak 前的 observability 细化即可。

Owner authorized implementing it now ("按建议执行", 2026-08-05) as one of the hard prerequisites for W4C-5 soak.

## Problem this addresses

> **⚠️ SUPERSEDED (fresh-gate P2, see "Addendum — fresh-gate P2/P3/NIT" at the bottom of this
> body).** The parenthetical below — "(a hung/leaked transaction holding a row lock forever)" —
> names a lock as though it were the only mechanism that can permanently exclude a row from
> every scan. It is not: sustained `NULLS FIRST` arrival preemption produces the identical
> exclusion with no lock anywhere. Left in place for the audit trail; do not read the
> parenthetical as an exhaustive cause list.

`backlogRemaining` cannot separate "N rows still legitimately churning through a large backlog" from "one row is permanently excluded from every scan" (a hung/leaked transaction holding a row lock forever). Once `backlogRemaining > limit`, `scanned < backlogRemaining` is true on EVERY tick regardless of which case holds — the second opinion's Probe C measured this directly (120 rows / 8 ticks, one permanently-locked row, manual probe against a scratch DB).

## Counter selection — why `neverAttemptedRunning`, and what it actually proves

`neverAttemptedRunning` = `count(*) FILTER (WHERE last_attempt_at IS NULL) WHERE state = 'running'`, read in the **same transaction/snapshot** as `backlogRemaining`, computed **after** the scan's own write-back (a row this tick just claimed is already stamped by the time this is read, so it does not count itself).

- **Zero new migration.** `last_attempt_at` already exists (added by #4774's `zzzz20260805120000_w4c2_scheduled_run_sweep_fairness`). This is the minimal-schema-footprint option — reuses the existing rotation-stamp column instead of adding a new one.
- **Works in both regimes**, not just the large-backlog one `scanned < backlogRemaining` was already (uselessly) informative in:
  - `backlogRemaining <= limit` (steady state): every row is scanned this tick, so this reads the exact un-claimable count from **tick 1** — no warm-up window.
  - `backlogRemaining > limit` (congested): under ordinary churn it drains toward 0 within `ceil(backlogRemaining / limit)` ticks, because every row eventually gets a first scan pass (`FOR UPDATE SKIP LOCKED` willing). Under a genuinely stuck candidate, `SKIP LOCKED` excludes that row from every scan forever, so it is never stamped and the counter **floors** at (at least) the stuck count instead of ever reaching 0.
- **Must be read as a trend across ticks, not a single-tick absolute** (same idiom the existing `backlogRemaining` doc comment already uses) — the qualifier is spelled out in the field's own doc comment in `w4c2-scheduled-run-ops-worker.ts`, not just in this PR body, so it doesn't erode on the next edit.

## Discriminating leg (real DB, `attendance-w4c2-sweep-fairness.db.test.ts`, new describe block)

Two tests over the **identical** 30-row / limit-25 backlog, differing in exactly one variable — whether a connection holds an open, never-released `FOR UPDATE` lock on one row for the whole test:

| Scenario | `neverAttemptedRunning` sequence (3 ticks) |
| --- | --- |
| One row permanently locked | `[5, 1, 1]` — floors nonzero, never reaches 0 |
| Positive control — same fixture, no lock (real churn, nothing ever finalizes) | `[5, 0, 0]` — drains to 0 and stays there |

Both tests assert the **full result object** each tick (`scanned`/`finalized`/`notReady`/`skipped`/`errored`/`backlogRemaining`/`neverAttemptedRunning`), not just the new field in isolation.

## Values-free proof

- `neverAttemptedRunning` is a `count(*)` — never an org id / user id / work date / run id.
- It flows through the SAME `AttendanceScheduledRunSweepTickResultV1` → `logger.info/warn(event, meta: Record<string, number>)` path #4770 already established: `meta`'s type blocks string business values at compile time; the runtime "gate 3" closed-key-set + `typeof === 'number'` assertions (now updated to the 7-key closed set including `neverAttemptedRunning`) block a numeric business value from slipping in as an extra key.
- `attendance-w4c2-sweep-call-through.db.test.ts`'s leg 4 (production `Logger` call-through against a real booted server) closed-key-set assertion was updated the same way and still passes — proves the field reaches the *actual* production logger call site (`index.ts`'s `logger: this.logger`), not just the pure function's return value.

## Mutation self-test (both restored via `Edit`, never `git checkout --`, after committing the real implementation first)

1. **Hardcode `neverAttemptedRunning: 0`** (neuter the new counter) → 4 tests red: gate 1 tick-1 assertion, the lock-guard regression assertion, and **both** new discriminating-leg tests (the positive-control test also goes red here because it asserts the true nonzero tick-1 value, `5`, not just the converged `0`).
2. **Drop the `FILTER (WHERE last_attempt_at IS NULL)`** (count all `running` rows, collapsing the new field onto `backlogRemaining`'s value) → 5 tests red: the 4 above plus the steady-state test (whose true value is `0` but the mutated one reads `1`, the total backlog count).

Both mutations turn the discriminating leg red, as required. Restored cleanly after each (`git diff --stat` empty).

## Test evidence (this session, local scratch DB `ms2_w4c2obs_20260805`, PostgreSQL 15)

```
$ pnpm run type-check                                                    # packages/core-backend — clean, no errors

$ vitest --config vitest.integration.config.ts run \
    tests/integration/attendance-w4c2-sweep-fairness.db.test.ts \
    tests/integration/attendance-w4c2-sweep-call-through.db.test.ts \
    tests/integration/attendance-w4c2-p12-run-transactions.db.test.ts
 Test Files  3 passed (3)
      Tests  49 passed (49)

$ vitest run src/attendance/__tests__/w4c2-scheduled-run.test.ts          # unit, no DB
 Test Files  1 passed (1)
      Tests  6 passed (6)
```

## Design-lock / completion-gate cross-check (issue #4770)

| #4770 completion gate | Status | Where |
| --- | --- | --- |
| >25 persistently-blocked candidates ahead, later candidates still processed | Landed in #4774 (unchanged here) | gate 1, `attendance-w4c2-sweep-fairness.db.test.ts` |
| Mutation reverting scan to fixed prefix goes red | Landed in #4774 (unchanged here) | same file, mutation oracle doc comment |
| values-free metrics/logs for tick/backlog/error | Landed in #4774; **this PR extends the closed key set to 7 keys, still values-free** | gate 3 + leg 4, both updated |
| Removal mutations for the 3 call-through legs go red | Landed in #4774 (unchanged here) | `attendance-w4c2-sweep-call-through.db.test.ts` |
| **Second-opinion NIT-refine: stuck-vs-churn distinguishing counter** (this PR's scope) | **Delivered** | new describe block, discriminating leg above |

## Files touched

- `packages/core-backend/src/attendance/w4c2-scheduled-run-ops-worker.ts` — new `neverAttemptedRunning` field + computation (single merged query, no extra round-trip)
- `packages/core-backend/src/types/plugin.ts` — port return-shape doc update (~L1261)
- `packages/core-backend/tests/integration/attendance-w4c2-sweep-fairness.db.test.ts` — 4 exact-shape assertions updated, closed-key-set updated, new discriminating-leg describe block
- `packages/core-backend/tests/integration/attendance-w4c2-sweep-call-through.db.test.ts` — leg-4 closed-key-set updated, `hostPort` type annotation updated

No new migration. No frontend change (`attendance-web-guard.yml` does not apply). Both DB test files were already wired into `plugin-tests.yml`'s explicit run list by #4774 — no new wiring needed since no new test file was added.

## Weak spots (self-reported)

1. **Did not re-verify the three call-through legs' own exclusivity** (leg 2 registration, leg 3 HTTP route, leg 4 production Logger) beyond re-running the existing suite green — this PR only touches the closed-key-set assertion in leg 4 and the type annotation; the underlying exclusivity proofs are #4774's, unchanged here.
2. **The discriminating-leg tests use `createStuckRun`'s existing never-sealed-target churn shape** (candidates report `not_ready` forever, never finalize) rather than a mix of finalizing and non-finalizing rows — a real production backlog would have some rows actually completing each tick. This does not affect `neverAttemptedRunning`'s correctness (it only depends on `last_attempt_at`, not on `state` transitions away from `running` for OTHER rows), but it is a narrower fixture shape than the full production mix.
3. **Local Postgres 15, not CI's Postgres version** — `FOR UPDATE SKIP LOCKED` and `NULLS FIRST` are standard, version-independent SQL semantics, but this was not re-run against the CI runner's Postgres image in this session.
4. **The "trend across ticks" semantics live only in the doc comment and the PR body, not in a runtime assertion that a caller reads it correctly** — nothing in this codebase can enforce that an operator dashboard graphs this as a trend rather than alerting on a single-tick nonzero read; that is an ops/dashboard-configuration concern outside this PR's scope (core/pure-function boundary).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

## Follow-up commit `1ff5f1aff` — fixed the 57P01 teardown race flagged below

Owner ruling: fix the race in this same PR rather than opening a separate issue (it touches the same file this PR's own leg-4 assertion already lives in). Root-caused and closed by `1ff5f1aff`, three files:

- `packages/core-backend/src/workflow/BPMNWorkflowEngine.ts` — `startTimerProcessor()`'s `node-cron` minute poller previously discarded the `ScheduledTaskType` `cron.schedule` returned, so nothing could ever `.stop()` it; it kept firing against the shared `db` pool for the life of the process, independent of any one engine instance's own `shutdown()`. Now stored under a well-known key in `timerJobs` (so `shutdown()`'s existing sweep stops it too), each tick's promise tracked in a new `timerProcessorTick` field (so `shutdown()` can drain an in-flight tick before returning), and the tick body wrapped in try/catch (mirroring `startHealthCheck`'s own guard) so a connection failure mid-tick is caught and logged instead of surfacing as an unhandled rejection.
- `packages/core-backend/src/routes/workflow.ts` — exports `shutdownWorkflowEngine()` (the module-level `workflowEngine` singleton's own shutdown, previously only reachable via this file's `process.on('SIGTERM', ...)` listener — a REAL OS signal. No test file in this repo's `tests/unit`/`tests/integration` sends one itself (grepped for `SIGTERM`: zero hits outside `src/`); `server.stop()` — the way every test invokes it, directly, as a plain async call — does not raise one either. A real SIGTERM can still separately reach the process from outside test code, e.g. the test runner's own fork-process teardown, which is a distinct, uncontrolled event this fix does not depend on).
- `packages/core-backend/src/index.ts` — `MetaSheetServer.stop()` now calls `shutdownWorkflowEngine()` as one more concurrent shutdown task, so every test that boots the real server stops this poller deterministically, not just on a real SIGTERM.

**Evidence (this session, local PostgreSQL 15):**
- Genuine A/B on the actual code (not a synthetic mutant): checked out the pre-fix 3 files via `git checkout <parent-sha> -- <files>`, ran the full `plugin-tests.yml` "Run attendance integration tests" explicit list (97 files / 1261 tests) against a fresh `metasheet_test` DB twice — once pre-fix, once post-fix (`git checkout HEAD -- <files>` to restore). Both runs hit the SAME 2 pre-existing failures in `attendance-plugin.test.ts` (an unrelated async-replay/auto-shift-matching flake, confirmed identical assertion + error text in both runs — not caused by this fix). The pre-fix run additionally logged `[NODE-CRON][ERROR] Cannot use a pool after calling end on the pool`, stack-traced at `BPMNWorkflowEngine.ts:1535` (the poller's own `.execute()` call), TWICE, at real wall-clock minute boundaries (`02:20:00.003Z`, `02:21:00.013Z`) during the ~197s run — a natural-timing local reproduction of the same class of bug CI hit as 57P01. The post-fix run of the identical 97-file list: **zero** such occurrences.
- Adversarial amplification on `attendance-w4c2-sweep-call-through.db.test.ts` alone (the file whose `afterAll` triggers the race): temporarily changed the poller's cron expression from `'* * * * *'` to `'* * * * * *'` (every second, 60x the production frequency) to force a tick to almost certainly be in flight at `server.stop()` + `DROP DATABASE ... WITH (FORCE)` time. Pre-fix: 5/5 runs logged the same `Cannot use a pool after calling end on the pool` node-cron error (harmlessly swallowed by node-cron's own internal handler in this exact form, `EXIT=0` — a different failure surface than CI's unhandled-rejection 57P01, same root cause). Post-fix, same amplification: **10/10 runs, 8/8 tests passed each time, zero cron/pool errors.** Amplification reverted before committing (`git diff --stat` empty against the real fix commit).
- `server-lifecycle.test.ts` (pre-existing unit test, unmodified) still passes and its own log output now shows `Shutting down BPMN Workflow Engine` / `BPMN Workflow Engine shutdown complete` firing during `server.stop()` — direct confirmation the new wiring fires in the ordinary unit-test path too, not just this file's own integration test. 9 workflow-adjacent unit test files / 85 tests, all pass.
- `pnpm run type-check`: clean throughout.

Scope check: of the ~10 integration test files using `WITH (FORCE)` scratch-DB teardown, only `attendance-w4c2-sweep-call-through.db.test.ts` also boots the real server via `../../src/index` — the others never touch `BPMNWorkflowEngine`. `routes/workflow.ts`'s sibling singleton in `routes/workflow-designer.ts` is lazily initialized (only on first designer-route call) and is not implicated by this bug or touched by this fix.

Still Draft/HOLD — this commit does not change that.



---

## Addendum (2026-08-05) — owner Plan B: BPMN fix carved out to its own PR

Owner ruling (2026-08-05): the BPMN poller fix in `1ff5f1aff` ("stop BPMN workflow-engine minute poller on server.stop()") does not belong in this attendance-scoped PR. Root cause of the 57P01 flake is that the production BPMN engine — self-described as **"in development"** (`src/index.ts:1473`) and with **zero consumers** in this codebase — runs an unconditional minute poller against `bpmn_timer_jobs` regardless of whether anything uses it. The owner-directed fix is **env-gate the poller off by default** (a dormant subsystem should not poll), not just make it stoppable. That is a production BPMN-engine lifecycle change and is out of scope for an attendance sweep-observability PR.

Action taken: `1ff5f1aff` reverted (`f89621480`, clean `git revert`, touches only the 3 BPMN files it added — `index.ts`, `routes/workflow.ts`, `workflow/BPMNWorkflowEngine.ts`). Verified: all 3 files are now byte-identical (SHA-256) to `origin/main`; this PR's diff vs `origin/main` is now byte-identical to `3d101168f` alone (the `neverAttemptedRunning` observability commit — unchanged, still 0P1/0P2).

**Known consequence:** `attendance-w4c2-sweep-call-through.db.test.ts` boots the real server, which re-enables the un-gated BPMN poller, so the CI-observed 57P01 teardown race can recur on this branch's own suite runs. This is expected and tracked — not a regression to chase here. It is superseded once the sibling env-gate PR (`claude/bpmn-poller-env-gate-20260805`, refs #4770) lands on `main` (poller off by default) and this branch rebases onto it.

**Merge order:** env-gate PR → this PR (rebase) → any further #4770 follow-up. This PR remains Draft/HOLD; no auto-merge armed.

Refs #4770. Not closing any issue from this PR.


---

## Follow-up (2026-08-05) — two corrections from #4783's independent review

**1. "Zero consumers" retracted.** The addendum above (and #4783's first commit) originally
stated the BPMN engine has zero consumers. That was an overclaim, caught during #4783's own
adversarial self-review: `apps/web/src/views/workflowDesignerPersistence.ts` posts to the real
`/api/workflow/deploy` route from the shipped Workflow Designer UI, gated only by
`authenticate` — not by `WORKFLOW_ENABLED` (which only hides frontend UI, never gates the
backend route). The accurate claim, with full evidence, is in #4783's PR body: no seed/migration
ever creates a process definition, `WORKFLOW_ENABLED=true` appears in no deploy config (only
7 local-dev verification docs, none staging/production), and the poller is the only code path
that ever reads/updates `bpmn_timer_jobs` — so this is "no evidence of use", not "structurally
impossible", and gating the poller off pauses (never drops) any such row.

**2. CI on this revert (`f89621480`) actually came back green, not flaky.** `test (20.x)`
passed (23m18s) at this exact commit — the 57P01 teardown race did not reproduce on this
particular CI run. This is expected for a genuinely flaky/timing-dependent race (the poller
fires on real minute boundaries; whether a tick is in flight exactly when
`attendance-w4c2-sweep-call-through.db.test.ts`'s `afterAll` runs `server.stop()` + `DROP
DATABASE ... WITH (FORCE)` depends on wall-clock alignment CI does not control) — a single
green run does not retract the risk #4779's own earlier CI note observed, it just means this
run didn't hit the window. #4783's PR body has a genuine (non-flaky) A/B reproduction of the
same failure under a forced amplified cadence, for anyone who wants deterministic evidence
rather than waiting on timing luck.

Merge order unchanged: #4783 (env-gate) → this PR (rebase) → next #4770 follow-up.


---

## Addendum (2026-08-05) — owner-review P2: `oldestRunningAttemptAgeSeconds`

**[HOLD] Draft — still not for merge.** Same posture as the rest of this PR.

Branch rebased onto current `origin/main` (`fbb54db3c`) — this PR was flagged BEHIND before this
round; re-verified the 3 BPMN revert files (`index.ts`, `routes/workflow.ts`,
`BPMNWorkflowEngine.ts`) are still byte-identical (SHA-256, both sides) to the NEW `origin/main`
head, not just the pre-rebase one. New head: `54283a4b7`.

### The P2

Owner review of this PR found `neverAttemptedRunning` (`count(*) FILTER (WHERE last_attempt_at IS
NULL)`) has its own blind spot: it structurally cannot see a row that WAS scanned/stamped once
(`last_attempt_at` already non-NULL) and is THEN excluded from every later scan by a permanent row
lock. That row's `last_attempt_at` freezes at its one-and-only stamp — it never re-enters the
never-attempted bucket (not NULL) and it is never re-selected (`FOR UPDATE SKIP LOCKED` keeps
skipping it), so `neverAttemptedRunning` reads `0` for it on every subsequent tick, silently. The
existing discriminating leg in `attendance-w4c2-sweep-fairness.db.test.ts` (added earlier in this
same PR) only covers the OTHER ordering — locked BEFORE the first scan ever runs, so
`last_attempt_at` stays NULL forever — and does not reproduce this one.

### The fix

`oldestRunningAttemptAgeSeconds`: the age, in seconds, of the STALEST `last_attempt_at` among
`state='running'` rows (`now() - MIN(last_attempt_at)`), read in the SAME snapshot/transaction as
`backlogRemaining` and `neverAttemptedRunning`, after the scan's own write-back (same ordering
discipline the existing fields already use). No new migration — `last_attempt_at` already exists
from #4774's `zzzz20260805120000` migration; this is purely a read-side derived duration.

**Trap avoided (verified, not assumed):** `EXTRACT(EPOCH FROM interval)` is PostgreSQL `numeric`,
which `node-pg` parses as a JS **string** by default:
```
SELECT pg_typeof(EXTRACT(EPOCH FROM (now() - now())))  →  numeric
node-pg, no cast:   typeof === 'string'  ("0.000000")
node-pg, ::float8:  typeof === 'number'  (0)
```
The query casts `::float8` and the TS side additionally wraps `Number(... ?? 0)` — belt-and-braces,
matching this file's existing idiom for the neighboring bigint `count(*) FILTER` read. Both layers
were verified independently load-bearing/redundant by mutation (below) — neither one ALONE is
strictly necessary (each independently prevents the trap), but removing BOTH simultaneously (with
an explicit `as number` to bypass the compiler, since dropping just the runtime coercion alone does
not even typecheck) reproduces a smuggled string and turns 10 tests red, including gate 3's
`typeof === 'number'` loop and leg 4's production-Logger call-through — proving the type alone is
NOT what's protecting this, same discipline the file's own existing doc comment on `meta`'s type
already spells out for the pre-existing counters.

**`now()` is transaction-stable in PostgreSQL** (verified: `BEGIN; SELECT now(); pg_sleep(0.2);
SELECT now(); COMMIT;` returns the SAME timestamp twice) — a row stamped THIS tick's transaction
reads EXACTLY `0` for this field, not an epsilon. That is what makes an exact-`0` positive control
possible instead of a bound.

### Discriminating leg (real DB, `attendance-w4c2-sweep-fairness.db.test.ts`, new "owner-review P2
on #4779" describe block) — reproduces the blind spot, then closes it

Fixture is deliberately STEADY STATE (4 rows, limit 25 — unlike the existing 30-row/limit-25
congested fixture above it) so every unlocked row is genuinely re-touched every tick, which is what
makes the locked leg's signature sharpest and the positive control's exact:

| Tick | `neverAttemptedRunning` (blind spot) | `oldestRunningAttemptAgeSeconds` (the fix) | other 7 counters |
| --- | --- | --- | --- |
| 1 (fresh stamp, all 4 rows) | 0 | **0** (exact — same-tx `now()`) | scanned:4, notReady:4, backlogRemaining:4 |
| *(row 0 locked AFTER tick 1, held for the rest of the test)* | | | |
| 2 | **0** ← blind spot reproduced: row 0 has been permanently unclaimable since tick 1, this still reads 0 | **> 0.2** (real elapsed time since the frozen tick-1 stamp) | scanned:3, notReady:3, backlogRemaining:4 |
| 3 | **0** ← still 0 | **> tick 2's value** (strictly growing) | **byte-identical to tick 2** — not one of the 7 pre-existing fields moved |

Row 0's own `last_attempt_at` is asserted unchanged (`toEqual(frozenStamp)`) across ticks 2 and 3 —
the mechanism, not just the aggregate reading.

**Positive control** — identical 4-row fixture, no lock ever held: every tick restamps every row
(steady state), so `oldestRunningAttemptAgeSeconds` reads exactly `0` on EVERY tick
(`tick2` / `tick3` both `toEqual(tick1)`, full 8-field exact shape) — "normal progress ⇒ never
grows", literally.

All pre-existing exact-shape `toEqual()` assertions across both gate 1, steady-state, tick-level
containment, and the earlier `neverAttemptedRunning`-discriminating leg (locked-before-tick-1) were
updated: the new field is destructured out and asserted separately wherever its exact value is
wall-clock-dependent (impossible to predict without controlling real time), asserted `toBe(0)`
inline wherever a fresh-same-transaction stamp makes it deterministic. None of the original 7-field
values changed — verified by keeping those `toEqual()` objects byte-identical to what they asserted
before this commit.

### Mutation self-test (implementation committed first at `54283a4b7`, each mutation restored via
`Edit`, never `git checkout --`, `git diff --stat` empty after each)

1. **Hardcode `oldestRunningAttemptAgeSeconds: 0`** → 2 tests red (the new discriminating leg's
   `age2`/`age3` growth assertions, and gate 1's `tick2Age > 0` check). The new leg's own positive
   control test stays GREEN — it already expects exactly `0` (the correct positive-control
   asymmetry, not a false negative).
2. **`MIN(last_attempt_at)` → `MAX(...)`** → same 2 tests red, for a different reason: `MAX` reads
   the MOST-recently-touched row (always the freshly-stamped ones), so it reads `0` in scenarios
   where `MIN` should read a growing positive value — proves the field is load-bearing in the
   RIGHT direction, not merely present.
3. **Smuggled-string mutation** — drop the SQL `::float8` cast AND replace the TS `Number(...)`
   coercion with an unsafe `as number` cast (the minimal change that still compiles, since dropping
   the runtime coercion alone without the cast is a compile error: `Type 'string | number' is not
   assignable to type 'number'`) → 10 tests red, including gate 3's `typeof === 'number'` loop
   (both the "no warn" and "warn" tests) and leg 4's production-Logger call-through closed-key-set
   check in the sibling file. Independently verified each layer ALONE (SQL cast only, or TS
   coercion only) is individually sufficient — neither one alone breaks any test, only removing
   both together does — so the "belt-and-braces" description above is a verified claim, not an
   assumption.

Restored cleanly after each (`git diff --stat` empty; confirmed by direct diff, not just visual
inspection).

### Test evidence (this session, local scratch DB `ms2_w4c2p2_20260805`, PostgreSQL 15.17)

```
$ pnpm run type-check                                                    # packages/core-backend — clean

$ vitest --config vitest.integration.config.ts run \
    tests/integration/attendance-w4c2-sweep-fairness.db.test.ts \
    tests/integration/attendance-w4c2-sweep-call-through.db.test.ts \
    tests/integration/attendance-w4c2-p12-run-transactions.db.test.ts
 Test Files  3 passed (3)
      Tests  51 passed (51)

$ vitest run tests/unit/attendance-w4c2-recovery-wiring.test.ts           # unrelated source-text guard, unaffected
 Test Files  1 passed (1)
      Tests  3 passed (3)

$ vitest run src/attendance/__tests__/w4c2-scheduled-run.test.ts          # unit, no DB
 Test Files  1 passed (1)
      Tests  6 passed (6)
```

Grepped the whole repo for every other reference to `AttendanceScheduledRunSweepTickResultV1` /
`neverAttemptedRunning` (`rg -rln` over `packages` and `apps`) to confirm the 4 touched files are
the COMPLETE set of call sites needing an update — no fifth file silently assumes a 7-key shape.

### Values-free proof

- `oldestRunningAttemptAgeSeconds` is a derived duration (`now() - MIN(timestamp)`, in seconds) —
  never the `last_attempt_at` timestamp itself, never an org id / user id / work date / run id.
- Flows through the SAME `AttendanceScheduledRunSweepTickResultV1` → `logger.info/warn(event,
  meta: Record<string, number>)` path the rest of this field's siblings already use; gate 3's
  closed-key-set (now 8 keys) + `typeof === 'number'` runtime checks were updated the same way and
  still pass; leg 4's production-Logger closed-key-set assertion (against the REAL booted server,
  `logger: this.logger`) was updated identically and still passes.

### Complementarity, stated explicitly (not left implicit)

> **⚠️ SUPERSEDED (fresh-gate P3-a, see "Addendum — fresh-gate P2/P3/NIT" at the bottom of this
> body).** The paragraph below overclaims exhaustiveness: the two counters cover disjoint halves
> of "permanently **unscanned**", not every way a run can become "permanently stuck" — a row
> re-scanned every tick but never reaching a terminal state reads healthy on both. Left in place
> for the audit trail; do not read it as current.

`neverAttemptedRunning` and `oldestRunningAttemptAgeSeconds` cover DISJOINT halves of "permanently
stuck": never-claimed-at-all (caught by the first, invisible to the second — `MIN()` ignores NULL)
vs. claimed-once-then-frozen (invisible to the first, caught by the second). Neither replaces the
other; both ship. Documented in `AttendanceScheduledRunSweepTickResultV1`'s own doc comment, not
just here.

### Design-lock / completion-gate cross-check (issue #4770, this round)

| Owner-review P2 finding | Status | Where |
| --- | --- | --- |
| `neverAttemptedRunning` blind spot: row scanned once then permanently locked | **Fixed** — `oldestRunningAttemptAgeSeconds` | `w4c2-scheduled-run-ops-worker.ts` |
| Discriminating leg reproducing the blind spot, real DB | **Delivered** | new describe block, `attendance-w4c2-sweep-fairness.db.test.ts` |
| Positive control (normal progress ⇒ never grows) | **Delivered** — exact `[0, 0, 0]` | same describe block |
| Mutation red on the new counter | **Delivered** — 3 mutations, all red as expected | this addendum, above |
| Values-free | **Delivered** — count/duration only, never a value | this addendum, above |
| Pre-existing legs (`neverAttemptedRunning` discrimination, gate 1/3, tick-level containment) not retrograded | **Verified unchanged** | all pre-existing `toEqual()` objects byte-identical to their pre-this-commit values |

### Weak spots (self-reported)

1. **The 30-row pre-existing tests' `oldestRunningAttemptAgeSeconds` readings are only bounded
   (`>= 0`), not tightly asserted**, because at that congested (backlog > limit) scale even fully
   healthy churn leaves a few rows one tick "behind" every tick — the exact value is a function of
   real wall-clock timing between transactions that this test suite does not (and should not)
   attempt to pin exactly. The tight, deterministic, monotonic-growth proof lives in the NEW
   steady-state fixture instead, by design (see the code comments left in place at each loosened
   assertion explaining why).
2. **The two new `sleep(300)` calls are a real-time dependency**, same category as other timing
   -sensitive tests already in this file/repo (e.g. the existing `elapsedMs < 4000` bound in the
   tick-level-containment test) — not novel risk, but still a source of rare CI slowness-driven
   flakiness in principle. 300ms was chosen to comfortably clear the sub-millisecond noise floor
   two sequential DB round-trips would otherwise risk.
3. **Did not re-run against CI's own PostgreSQL image this session** (same disclosed limitation as
   the earlier round of this PR) — local Postgres 15.17. `EXTRACT`/`FOR UPDATE SKIP LOCKED`/
   `NULLS FIRST` are version-independent standard SQL, and `now()` transaction-stability is core
   MVCC behavior, not a version-specific quirk, but this is asserted, not re-verified against CI's
   exact image in this session.
4. **`oldestRunningAttemptAgeSeconds` is a float, not rounded** — deliberately (rounding to whole
   seconds would floor the new test's sub-second growth to `0` and defeat the discriminating leg;
   real production staleness is measured in minutes/hours where the fractional part is noise). A
   dashboard/alerting consumer should round for display; this PR does not do that for them (same
   "ops/dashboard-configuration concern outside this PR's scope" boundary the earlier round of
   this PR already drew for the "trend, not a single-tick read" semantics).

Refs #4770, #4779. Not closing any issue from this PR — still Draft/HOLD, not armed for
auto-merge, merge order unchanged (env-gate PR → this PR → next #4770 follow-up).


---

## Addendum (2026-08-05, second pass) — doc-comment correction: three regimes, not two

**New head: `119929e96`.** Still Draft/HOLD, not armed.

An advisor pass on the P2 fix above (`54283a4b7`) caught an overclaim in
`oldestRunningAttemptAgeSeconds`'s own doc comment: it enumerated only TWO regimes
("steady-state healthy -> exactly 0" / "locked after first scan -> grows"). But that SAME commit's
own 30-row congested-backlog tests (both the `neverAttemptedRunning`-discriminating leg's locked
case and its positive control, both pre-existing in this file) already prove a THIRD: a healthy
backlog with `backlogRemaining > limit` reads **nonzero on most ticks with no lock anywhere**,
because rotation can only touch `limit` rows per tick, so some rows are always "one tick behind".
The test comments already said this (that's why those assertions were loosened to `>= 0` instead of
an exact `0`) — the interface doc comment never caught up. Left as-is, an operator building
alerting straight off the doc would page on every congested-but-healthy backlog: "nonzero" is not
the discriminator, "does it plateau or keep climbing" is.

Corrected both `w4c2-scheduled-run-ops-worker.ts`'s `AttendanceScheduledRunSweepTickResultV1` doc
comment and `plugin.ts`'s mirrored port doc to three regimes, with the real operator-facing signal
stated explicitly:

| Regime | Reading | Discriminator |
| --- | --- | --- |
| Steady state (`backlogRemaining <= limit`), healthy | exactly `0`, every tick | — |
| Congested (`backlogRemaining > limit`), healthy, no lock | nonzero on most ticks | **BOUNDED** — plateaus within one rotation span (`ceil(backlogRemaining / limit)` ticks) |
| Locked after first successful scan | grows tick after tick | **UNBOUNDED** — never plateaus |

> **⚠️ SUPERSEDED (fresh-gate P2, see "Addendum — fresh-gate P2/P3/NIT" at the bottom of this
> body).** The "Congested … no lock" row's implicit claim — that this regime is ALWAYS bounded
> because rotation eventually reaches every row — is FALSE: sustained arrival of brand-new
> `running` rows under `NULLS FIRST` can starve an already-stamped row indefinitely, with no lock
> anywhere, producing the identical UNBOUNDED signature the third row attributes only to a lock.
> The "Locked after first successful scan" row's causal attribution is also incomplete for the
> same reason — that is not the only mechanism. Left in place for the audit trail; do not read
> this table as current.

Doc-comment-only change; no test file touched; all 51 tests across the 3 targeted integration files
still pass unmodified.

**Ordering-pin claim, verified empirically (not just asserted):** the doc comment states the
backlog/`neverAttemptedRunning`/`oldestRunningAttemptAgeSeconds` read must happen AFTER the scan's
own write-back, never before. Rather than take that on faith, moved the read BEFORE the scan as a
temporary mutation probe and re-ran `attendance-w4c2-sweep-fairness.db.test.ts`: **12 assertions
went red**, including the new field's own positive-control leg specifically (tick 2's
`oldestRunningAttemptAgeSeconds` read `~0.3` instead of the pinned exact `0`, since the pre-scan
snapshot still sees the row that's ABOUT to be re-stamped as stale). Reverted the probe
(`git diff --stat` empty) before this commit.

Refs #4770, #4779. Not closing any issue — still Draft/HOLD.


---

## Addendum (2026-08-05, third pass) — retract an unmeasured plateau formula

**New head: `9eb998566`.** Still Draft/HOLD, not armed.

A second advisor pass on the three-regime doc fix above caught a residual overclaim: the
congested-regime paragraph stated the plateau follows `ceil(backlogRemaining / limit)` ticks as if
that specific tick-count formula were verified for `oldestRunningAttemptAgeSeconds`. It was not —
the 30-row/limit-25 fixtures that paragraph leaned on only run 3 ticks and only assert `>= 0` on
this field (a deliberately loose bound, since those pre-existing tests are not this field's own
discriminating leg). That is evidence of "bounded, not ever-growing" over 3 ticks, not a proof of
the specific formula. (The *existing*, unrelated `neverAttemptedRunning` paragraph a few lines
above keeps its own `ceil()` formula — that one IS exactly matched by the pre-existing 30-row
test's `[5, 1, 1]` / `[5, 0, 0]` sequences, `ceil(30/25) = 2` ticks to drain. This retraction is
scoped to the new field's paragraph only.)

Reworded to state what is actually established: the `last_attempt_at ASC NULLS FIRST` rotation
ordering guarantees every row is eventually re-selected, which is WHY the reading cannot climb
without limit outside the permanently-locked case — without asserting a specific tick-count bound
no test in this file pins. `plugin.ts`'s mirrored doc already said only "bounded vs. unbounded"
with no formula, so it needed no edit.

> **⚠️ BOTH claims in the paragraph above are RETRACTED** (fresh-gate P2, see "Addendum —
> fresh-gate P2/P3/NIT" at the bottom of this body). "The `NULLS FIRST` rotation ordering
> guarantees every row is eventually re-selected" is FALSE — sustained arrival of brand-new
> `running` rows preempts an already-stamped row indefinitely, empirically reproduced at the
> production default `limit=25`. And **`plugin.ts`'s "needed no edit" is RETRACTED — it did**:
> this third-pass self-correction checked the mirror only for the `ceil()` tick-count formula
> and missed that it independently carried the SAME false causal attribution
> ("UNBOUNDED-GROWTH (a row permanently locked after its first scan)") the fresh gate's P2
> finding refutes. Both files are corrected below. Left in place for the audit trail; do not
> read this paragraph as current.

Re-verified BPMN byte-identity at this NEW head against the current `origin/main` (`e6523c949` at
verification time — 1 commit ahead of this branch's rebase point, unrelated integration/C6 fix,
not touching attendance or the 3 BPMN files) — still byte-identical (SHA-256, all 3 files, both
sides).

Doc-comment-only change; re-ran both targeted integration test files (20 tests) unmodified, still
green.

Refs #4770, #4779. Not closing any issue — still Draft/HOLD.



---

## Addendum (2026-08-06, fourth pass) — fresh gate: retract the false NULLS-FIRST bounding guarantee (1 P2 + 2 P3 + 1 NIT)

**New head: `d2e6bcc8c3695bff7adc569d4b507b8e8229782a`.** Still Draft/HOLD, not armed, not
merged. Two commits (`0609bdc9f`, `d2e6bcc8c`), each a doc-comment-only change.

**Rebase SHA mapping (gate verdict is head-scoped — the gate's cited SHAs are not ancestors of
this head after the branch was rebased onto current `origin/main` before this round):**

| Gate MD cites | Now (post-rebase, same content) |
| --- | --- |
| `54283a4b7` (owner-review P2) | `f6e8a84cb` |
| `119929e96` (three-regime doc fix) | `de4876b37` |
| `9eb998566` (retract ceil() formula — this round's starting point) | `4c695b8c3` |

Content-identity proof: `git diff 9eb998566d18c3fef9d7583a3719805884e6feef 4c695b8c3283f967639026442e9befe4fe1f38e8
-- packages/core-backend/src/attendance/w4c2-scheduled-run-ops-worker.ts packages/core-backend/src/types/plugin.ts
packages/core-backend/tests/integration/attendance-w4c2-sweep-fairness.db.test.ts
packages/core-backend/tests/integration/attendance-w4c2-sweep-call-through.db.test.ts` — **empty**
(the gate's scope carried through the rebase byte-for-byte). The UNSCOPED diff between those two
SHAs is NOT empty (119 lines across 3 files), but that is entirely main's new commit `e6523c949`
(the unrelated C6 credential-accessor fix) flowing in via the rebase — `git diff --stat` on the
same pair confirms only `plugin-integration-core`'s `http-routes.cjs`/`http-routes.test.cjs`/a
provenance-pins JSON changed, none of them in this PR's scope.

A fresh independent gate on the last 3 addenda (owner-review P2, gate-cited `54283a4b7` = current
`f6e8a84cb` + the two doc-comment corrections, gate-cited `119929e96`/`9eb998566` = current
`de4876b37`/`4c695b8c3`) found `0 P1, 1 P2, 2 P3, 1 NIT` — metric computation, discriminating leg,
mutation posture, values-free, and the owner counterexample reproduction were all CORRECT and
re-verified; the blocker was a **false invariant claim in the doc text itself** that the named
soak (W4C-5) discriminator banks on. This addendum is the fix — doc/semantics only, no
code-behavior change, exactly as the gate scoped it.

### RETRACTION FIRST — what was false

`w4c2-scheduled-run-ops-worker.ts`'s congested-regime paragraph claimed: "the `last_attempt_at
ASC NULLS FIRST` rotation ordering **guarantees every row is eventually re-selected**", and
attributed UNBOUNDED-GROWTH solely to "**a row permanently locked** after its first successful
scan." `plugin.ts`'s mirrored port doc carried the identical narrow attribution. **Both are
FALSE**, and both contradict this codebase's OWN scan docstring
(`w4c2-scheduled-run.ts`:~1199: "`NULLS FIRST` keeps never-attempted rows — including brand-new
ones — ahead of anything already attempted"). Under a sustained influx of brand-new `running`
rows, an already-stamped row is **never** re-selected — its stamp freezes and its age climbs
without limit, **with no lock anywhere** ("arrival starvation"). The gate reproduced this at the
production default `limit=25` with a flat backlog (>= 25 fresh NULL arrivals injected per tick):
`scanned`/`backlogRemaining`/`neverAttemptedRunning` all stayed flat while the victim's age
climbed unboundedly — the identical stuck signature the field exists to surface, no lock held.

**Independently re-verified this session** (not just re-cited from the gate MD) by replaying the
EXACT production scan `UPDATE` (`w4c2-scheduled-run.ts`'s `scanAttendanceScheduledRunSweepCandidatesV1`)
and the EXACT backlog/`MIN` `SELECT` (`ops-worker.ts`'s snapshot query) against a minimal scratch
table, `limit=25`, 3 ticks, retiring the prior tick's 25 arrivals and injecting 25 fresh ones
before each tick (flat backlog, sustained NULL churn), no lock taken anywhere in the script:

| Tick | scanned | backlog | neverAttemptedRunning | oldestRunningAttemptAgeSeconds | victim `last_attempt_at` |
| --- | --- | --- | --- | --- | --- |
| 1 | 25 | 26 | 1 | 0.001 | stamped (scanned this tick) |
| 2 | 25 | 26 | 0 | 0.504 | unchanged since tick 1 |
| 3 | 25 | 26 | 0 | 1.009 | unchanged since tick 1, `state='running'` |

Matches the gate's own table shape (flat scanned/backlog, climbing age, frozen victim stamp) —
independent confirmation, not a repeat of the gate's own numbers.

### The fix (doc/semantics only, per gate scope — no code-fix; that is owner's call)

1. **P2** — Reworded UNBOUNDED-GROWTH to mean "a `running` row is **permanently excluded from
   every scan**", with TWO known mechanisms (list explicitly **not** claimed closed): (1) a held
   row lock, or (2) sustained `NULLS FIRST` arrival preemption — neither of which this field can
   distinguish. The alarm stays legitimate either way (the row genuinely never gets another
   resume/finalize attempt); only the causal attribution and the "healthy is always bounded"
   guarantee were wrong — an operator should not use "no lock found" to dismiss a climbing
   reading. Named the arrival-starvation mechanism as a known property of #4774's `NULLS FIRST`
   rotation; its elimination (e.g. guaranteeing re-selection within a bounded tick count) is
   flagged as an **owner-deferred #4770 follow-up, out of scope for this field and this PR**.
2. **P3-a** — "the two counters cover disjoint halves of **permanently stuck**" overclaimed
   exhaustiveness. Tightened to disjoint halves of permanently **UNSCANNED** (never-claimed vs.
   claimed-once-then-frozen), and named the third class both counters read as healthy: a row
   re-scanned every tick but never reaching a terminal state (target-set drift / `not_ready`
   forever — the sweep design's own `abandoned`-transition escape hatch, not this sweep's job).
   Per the fresh gate's own framing, this is a wording-precision fix, not a new exhaustiveness
   claim — the corrected text explicitly does NOT assert the new list is complete either.
3. **P3-b** — Disclosed the `MIN` gauge's weak spots in the doc itself: single-aggregate
   1-vs-many blindness (a second/third stuck row is invisible under the oldest one — the field
   can only say "at least one row is stuck", never how many), and non-self-clearing behavior
   (resolving the OLDEST stuck row drops the gauge to the next-oldest stamp even though other
   rows may still be stuck — an absolute-threshold alert can be spuriously reset).
4. **NIT** — Disclosed that `now() - MIN(last_attempt_at)` can read slightly negative under
   concurrent scan workers (a second worker can stamp a row after this transaction's `now()` but
   before this `MIN` is read) — cosmetic, since a genuinely stale row always dominates the `MIN`
   by definition and a negative reading therefore cannot mask a stuck row.

Both `w4c2-scheduled-run-ops-worker.ts`'s `AttendanceScheduledRunSweepTickResultV1` doc comment
and `plugin.ts`'s mirrored port doc were corrected — the gate specifically named the mirror as a
place a prior round's retraction missed (see next section).

### Overclaim self-correction — `9eb998566`'s "needed no edit" is retracted

Addendum `9eb998566` (third pass) checked `plugin.ts` ONLY for the `ceil()` tick-count formula
and concluded "already said only 'bounded vs. unbounded' with no formula, so it needed no edit."
That check missed that the mirror independently carried the SAME false causal attribution this
round's P2 finding refutes (`plugin.ts`:~1270-1271: "UNBOUNDED-GROWTH (a row permanently locked
after its first scan)"). **"Needed no edit" is retracted — it did.** This is the recurring
species this line has hit before (addendum-checks-one-pattern-and-misses-another) — the retracted
sentence is marked in place above rather than deleted, per this line's own "retraction must be
readable from the decision surface, not just asserted" discipline.

### SWEEP v4 (self-scan, mandatory three tables — this round's code diff, `4c695b8c3..d2e6bcc8c`)

**Table 1 — delta absolute-word table** (`git diff -U0 4c695b8c3..HEAD` on the 2 touched files,
`^+` lines only; pattern1 = exactly/nowhere/only/never/always/solely/none/unaffected/unchanged/
identical/zero/forever/guarantee(d/s)/no other/every/all/cannot/100%/complete): **75** added
lines, **37** pattern1 hits. Every one of the 37 checked individually against 5 mutually exclusive
buckets — counts sum to 37, none is a new unscoped overclaim:

| Bucket | Count | What it means | Example hit |
| --- | --- | --- | --- |
| A — Retraction-labeled quotes of the now-false claim | 3 | The text being retracted has to contain the absolute words it retracts, immediately followed by RETRACTED/FALSE | "guarantees every row is eventually re-selected"; "solely to a held lock"; "already said... needed no edit" |
| B — Definitional/tautological, true by construction or verified by direct source/analytical check | 11 | Follows necessarily from the SQL scan shape, an exact quote of existing verified code, or MIN()/aggregate semantics — not an empirical claim needing a fresh test | "a row is PERMANENTLY EXCLUDED from every scan" (defines the state being named); "keeps never-attempted rows... ahead of anything already attempted" (exact quote of `w4c2-scheduled-run.ts`'s pre-existing scan docstring); "can only say 'at least one row is stuck'" (MIN is a scalar, mathematically cannot report a count) |
| C — Explicitly conditional/scoped absolute words | 7 | The absolute word sits inside an "as long as" / "IS" / hedge / non-closure disclaimer, not asserted unconditionally | "BOUNDED... **as long as** every row keeps being re-selected"; "the mechanism list is **not claimed closed**"; "keeps this field **near** `0`" (hedged, not "exactly") |
| D — Pre-existing carryover, unchanged in substance | 10 | Already verified in an earlier round of this PR; reappears as a `+` line only because the surrounding paragraph was restructured | "3 ticks of evidence"; "the SAME test file... both... locked case and its own positive control"; "pre-existing fixtures' unchanged 7-field values" |
| E — New empirical claims, independently verified THIS session (not merely re-cited from the gate) | 6 | The arrival-starvation mechanism/reproduction specifics — matched against this session's own independent SQL re-verification, not just the gate's numbers | "with a flat backlog and >= 25 fresh never-attempted arrivals injected before each tick"; "empirically reproduced at the production default `limit=25`" |
| **Total** | **37** | | |

Bucket-by-bucket, no hit landed outside these 5 categories; Bucket A's 3 are the retraction
itself, so their absolute language is the OBJECT being corrected, not a new claim.

**Table 2 — delta count-word table** (pattern2 = `exactly N` / `N <keys|counters|regimes|
mechanisms|ticks|…>` on the same `^+` lines): **1** hit — "That is **3 ticks** of evidence, not a
proof of a specific plateau bound" — pre-existing carryover (present verbatim in the pre-round
text at `4c695b8c3`, already verified against the 30-row/limit-25 fixture's 3-tick run in an
earlier round of this PR; unaffected by this round's edits).

**Table 3 — edited-node full-text rescan** (SWEEP v4's own §8 addition: diff-only scanning is
structurally blind to a count elsewhere in the SAME doc block invalidated by this round's edit;
re-ran pattern2 against the CURRENT, complete text of the touched file regions, not just the
diff): **16** hits total (**15** in `w4c2-scheduled-run-ops-worker.ts` lines 1-336, **1** in
`plugin.ts`'s `sweepScheduledRuns` return-shape block), every one individually re-derived against
current source. Two are pattern1-style false positives for pattern2 (matched a keyword, not an
actual quantifier claim) and are marked N/A rather than silently dropped; the remaining 14 are
genuine count claims, all MATCH:

| # | Location | Hit | Mechanical check | Result |
| --- | --- | --- | --- | --- |
| 1 | worker:8 | "**both** (…transactions and the sweep step)" | Enumerates 2 named things | MATCH (pre-existing, outside this round's edited node) |
| 2 | worker:63 | "gate-1 **tick**-2 assertion" | Not a quantity — "tick-2" is a test-leg label | N/A (false positive) |
| 3 | worker:97 | "**THREE** regimes — not two" | Counted top-level `*  -` regime bullets in the field's own doc block | 3 (Steady state / Congested / UNBOUNDED-GROWTH) — MATCH |
| 4 | worker:108 | "**both** the …locked case and its own positive control" | Enumerates 2 named tests | MATCH (pre-existing carryover) |
| 5 | worker:110 | "**3** ticks of evidence" | Matches the 30-row fixture's own 3-tick loop | MATCH (pre-existing carryover) |
| 6 | worker:117 | "the other **seven** counters" | Counted `readonly <field>: number` lines before `oldestRunningAttemptAgeSeconds` | 7 — MATCH |
| 7 | worker:123 | "constructs **exactly** this case" | Not a quantity — "exactly" is a precision word, no N follows | N/A (false positive) |
| 8 | worker:137 | "**both** claims are false" | Enumerates the 2 retracted claims (guarantee + solely-lock attribution) | MATCH |
| 9 | worker:143 | "not **three**" (`neverAttemptedRunning`'s own regime count) | Counted its own `*  -` bullets | 2 (steady state / congested) — MATCH |
| 10 | worker:144 | "the **two** fields' regime lists" | Refers to `neverAttemptedRunning` + `oldestRunningAttemptAgeSeconds` | 2 — MATCH |
| 11 | worker:154 | "**BOTH** counters" | Same 2 fields as #10 | MATCH |
| 12 | worker:156 | "**both** counters flat/low" | Same 2 fields | MATCH |
| 13 | worker:183 | "the **eight** named counters" | Counted `readonly` fields in the interface (7 + itself) | 8 — MATCH |
| 14 | worker:186 | "**eight** named keys" | Same interface, same count | 8 — MATCH |
| 15 | worker:223 | "emits **exactly one** …log line per call" | Single `logger.info(...)` call site, not looped | MATCH (pre-existing, unrelated to this round) |
| 16 | plugin.ts:~1282 | "the full **three**-regime breakdown" (cross-ref to worker doc) | Same 3-bullet count as #3 | MATCH |

No count-word claim in either file's touched region was found stale after this round's
restructuring; N == 16 (table rows) == raw grep hits, with the 2 non-quantifier false positives
explicitly carried rather than dropped.

**Reverse-grep of edited/retracted sentences' cross-file references** (does anything ELSE in the
repo quote a sentence this round rewrote or retracted?): `"guarantees every row is eventually
re-selected"` — 0 hits anywhere else in the repo (the false guarantee was never quoted verbatim
outside these two doc blocks, both now corrected). `"disjoint-coverage note"` — 1 hit,
`attendance-w4c2-sweep-fairness.db.test.ts:536`, a cross-reference into the worker doc's
complementarity paragraph — still resolves correctly (the paragraph still exists, scope narrowed
from "permanently stuck" to "permanently UNSCANNED", not deleted). `"permanently locked"` — the
only remaining code hit is inside `plugin.ts`'s own retraction quote (labeled RETRACTED in the
same sentence); the test file's uses are scoped fixture descriptions ("a row scanned once then
permanently locked" as the NAME of that specific test's own constructed scenario, not a general
claim about the field's exhaustive causes) and were left unchanged — checked individually, none
asserts exhaustiveness of causes. Widened one level up: `grep -rlnE "BOUNDED-PLATEAU|
UNBOUNDED-GROWTH|disjoint halves|eventually re-selected" docs/` — **0 hits** — the false claim was
never mirrored into a design-lock or the #4770 tracker doc, so there is no third copy to correct.

### PR-body decision-surface propagation (per this line's own "撤回必须传播到决策面" discipline)

Four earlier passages in this PR body independently carried the same overclaim (owner review
reads top-to-bottom; an addendum-only fix at the bottom would leave those readable as still-live
claims). Rather than delete PR history, each was marked in place with a `⚠️ SUPERSEDED` /
`⚠️ RETRACTED` blockquote pointing to this addendum, so a reader reaches ONE conclusion regardless
of where they stop reading:
- The "Problem this addresses" section's opening paragraph — the FIRST substantive claim in this
  PR body, easy to miss precisely because it precedes everything else (parenthetical "a
  hung/leaked transaction holding a row lock forever" as the named cause).
- The "Complementarity, stated explicitly" section (disjoint-halves-of-"permanently stuck").
- The second-pass addendum's three-regime table (the "Congested … no lock" / "Locked after first
  successful scan" rows).
- The third-pass addendum's own retraction paragraph (which itself restated "guarantees every row
  is eventually re-selected" as the CORRECTED text, and asserted `plugin.ts` "needed no edit").

`rg -io "(close[sd]?|fix(es|ed)?|resolve[sd]?) #?[0-9]+"` re-run against this full body (including
this addendum): 1 hit, `"pre-fix 3 files"` in the BPMN evidence section — not a closing-keyword
match (no `#N` follows "fix"), pre-existing, unaffected by this round.

### Test evidence (this session, local PostgreSQL 15.17)

```
$ pnpm run type-check                              # packages/core-backend — clean, no errors

$ DATABASE_URL=postgresql://chouhua@localhost:5432/postgres \
  pnpm exec vitest --config vitest.integration.config.ts run \
    tests/integration/attendance-w4c2-sweep-fairness.db.test.ts \
    tests/integration/attendance-w4c2-sweep-call-through.db.test.ts \
    tests/integration/attendance-w4c2-p12-run-transactions.db.test.ts
 Test Files  3 passed (3)
      Tests  51 passed (51)
```

Doc-comment-only change — no code-behavior diff, so no new mutation self-test this round (nothing
new to neuter); the gate's own mutation posture for the underlying metric was already re-verified
by the gate and is unchanged by this round.

### Weak spots (self-reported, this round)

1. **This round's own independent SQL re-verification uses a minimal scratch table** (only the
   columns the two production queries reference), same category of narrowing the gate itself
   disclosed for its own probe — faithful for the SQL semantics under test (`NULLS FIRST`,
   `MIN`, `EXTRACT`), not an end-to-end `sweepAttendanceScheduledRunsOnceV1` run.
2. **Whether P3-a's "third stuck class" (target-set-drift / `not_ready` forever) deserves the
   SAME empirical-reproduction rigor as arrival starvation got is not established this round** —
   it is asserted from the module's own existing docstring (`ops-worker.ts`:24-28, "closed by the
   explicit `abandoned` transition, not the sweep") and the sweep's `not_ready` branch logic, not
   a fresh DB reproduction. If an owner wants it soak-relevant, it needs its own probe.
3. **This is a doc/semantics fix only, per the gate's explicit scope** ("Fix is doc/semantics-
   level, not a code change") — whether to ALSO close the arrival-starvation gap in code (e.g.
   guaranteeing bounded re-selection) is an owner decision tracked as an #4770 follow-up, not
   attempted here.
4. **`plugin.ts`'s corrected doc now defers to the worker doc** ("See ... for the full
   three-regime breakdown") rather than re-stating the arrival-starvation mechanism in full —
   deliberate, to avoid the two mirrors drifting apart again (the exact failure mode this
   addendum exists to fix), but it means a reader who only opens `plugin.ts` gets a pointer, not
   the full mechanism description, without following the reference.
5. **Candidate follow-up, NOT verified as the same severity, NOT fixed here — flagging for
   owner/next round only**: `neverAttemptedRunning`'s own (untouched) doc comment a few lines
   above this round's edit makes a structurally similar claim — "under ordinary churn it drains
   toward 0... because every row eventually gets a first scan pass" and names a held lock as the
   floor case, without qualifying it as the only one. Probed this session (sustained arrivals exceeding scan capacity, `limit`
   25, zero retirement, no lock): `neverAttemptedRunning` DOES grow unboundedly (5 → 10 → 15 over
   3 ticks) with no lock. BUT unlike this round's P2 finding, `backlogRemaining` grew in lockstep
   in the same probe (30 → 60 → 90) — the backlog itself already signals "not draining", so this
   may not have the same silent/flat-backlog insidiousness the gate's P2 finding does; whether a
   flat-backlog, no-lock variant exists for THIS counter is not established. Reported, not fixed
   — out of scope of the gate's 4 findings for this PR.

Refs #4770, #4779. Not closing any issue from this PR — still Draft/HOLD, not armed for
auto-merge, merge order unchanged (env-gate PR → this PR → next #4770 follow-up).
