### PR TITLE
fix(attendance): W4C-5 §3 request-snapshot precondition — complete the 8-cell closed set (#4775)

### DIFF
--- a/packages/core-backend/src/attendance/__tests__/w4c3b-request-snapshot-metadata-fields.test.ts
+++ b/packages/core-backend/src/attendance/__tests__/w4c3b-request-snapshot-metadata-fields.test.ts
@@ -1,0 +1,141 @@
+/**
+ * W4C-5 §3 payload-stale predicate support (issue #4775).
+ *
+ * `extractAttendanceRequestPayloadMetadataFieldsV1` (`w4c3b-request-snapshots.ts`) is a
+ * field-for-field port of the plugin's `buildRequestSnapshotPayloadFieldsFromDraft`
+ * (`plugins/plugin-attendance/index.cjs:24414-24445`). This file pins ITS OWN behavior against a
+ * fixture table mirroring every branch of that plugin function (nested `leaveType.code`, flat
+ * `leaveTypeCode` fallback, valid/invalid `outdoorPunch`, JSON-string metadata, non-object
+ * metadata, negative/non-integer minutes). It cannot reach into the CJS plugin closure to
+ * cross-check the plugin copy directly — see the exported function's own doc comment for that
+ * self-reported drift risk.
+ */
+import { describe, expect, it } from 'vitest'
+import { extractAttendanceRequestPayloadMetadataFieldsV1 } from '../w4c3b-request-snapshots'
+
+describe('extractAttendanceRequestPayloadMetadataFieldsV1', () => {
+  it('returns all-null fields for null/undefined/empty metadata', () => {
+    expect(extractAttendanceRequestPayloadMetadataFieldsV1(null)).toEqual({
+      minutes: null,
+      leaveTypeCode: null,
+      outdoorPunch: null,
+    })
+    expect(extractAttendanceRequestPayloadMetadataFieldsV1(undefined)).toEqual({
+      minutes: null,
+      leaveTypeCode: null,
+      outdoorPunch: null,
+    })
+    expect(extractAttendanceRequestPayloadMetadataFieldsV1({})).toEqual({
+      minutes: null,
+      leaveTypeCode: null,
+      outdoorPunch: null,
+    })
+  })
+
+  it('parses a JSON-string metadata value (matches normalizeMetadata)', () => {
+    expect(
+      extractAttendanceRequestPayloadMetadataFieldsV1('{"minutes":45}'),
+    ).toMatchObject({ minutes: 45 })
+  })
+
+  it('treats an unparsable JSON string as empty metadata (fail-closed, not throw)', () => {
+    expect(extractAttendanceRequestPayloadMetadataFieldsV1('not-json')).toEqual({
+      minutes: null,
+      leaveTypeCode: null,
+      outdoorPunch: null,
+    })
+  })
+
+  it('truncates a fractional non-negative minutes value', () => {
+    expect(extractAttendanceRequestPayloadMetadataFieldsV1({ minutes: 61.9 }).minutes).toBe(61)
+  })
+
+  it('rejects a negative minutes value as null (not a clamp)', () => {
+    expect(extractAttendanceRequestPayloadMetadataFieldsV1({ minutes: -5 }).minutes).toBeNull()
+  })
+
+  it('rejects a non-numeric minutes value as null', () => {
+    expect(extractAttendanceRequestPayloadMetadataFieldsV1({ minutes: '45' }).minutes).toBeNull()
+  })
+
+  it('prefers nested leaveType.code over the flat leaveTypeCode fallback', () => {
+    expect(
+      extractAttendanceRequestPayloadMetadataFieldsV1({
+        leaveType: { code: 'annual' },
+        leaveTypeCode: 'sick',
+      }).leaveTypeCode,
+    ).toBe('annual')
+  })
+
+  it('falls back to flat leaveTypeCode when leaveType.code is absent', () => {
+    expect(
+      extractAttendanceRequestPayloadMetadataFieldsV1({ leaveTypeCode: 'sick' }).leaveTypeCode,
+    ).toBe('sick')
+  })
+
+  it('trims leaveTypeCode and treats whitespace-only as absent', () => {
+    expect(
+      extractAttendanceRequestPayloadMetadataFieldsV1({ leaveTypeCode: '  annual  ' }).leaveTypeCode,
+    ).toBe('annual')
+    expect(
+      extractAttendanceRequestPayloadMetadataFieldsV1({ leaveTypeCode: '   ' }).leaveTypeCode,
+    ).toBeNull()
+  })
+
+  it('ignores leaveType when it is not an object (matches optional-chaining semantics)', () => {
+    expect(
+      extractAttendanceRequestPayloadMetadataFieldsV1({ leaveType: 'annual', leaveTypeCode: 'sick' })
+        .leaveTypeCode,
+    ).toBe('sick')
+  })
+
+  it('builds a complete outdoorPunch object with the mobile source default', () => {
+    expect(
+      extractAttendanceRequestPayloadMetadataFieldsV1({
+        outdoorPunch: { eventType: 'check_in', occurredAt: '2026-08-01T09:00:00.000Z', timezone: 'Asia/Shanghai' },
+      }).outdoorPunch,
+    ).toEqual({
+      eventType: 'check_in',
+      occurredAt: '2026-08-01T09:00:00.000Z',
+      timezone: 'Asia/Shanghai',
+      source: 'mobile',
+    })
+  })
+
+  it('preserves an explicit outdoorPunch source over the default', () => {
+    expect(
+      extractAttendanceRequestPayloadMetadataFieldsV1({
+        outdoorPunch: {
+          eventType: 'check_out',
+          occurredAt: '2026-08-01T18:00:00.000Z',
+          timezone: 'Asia/Shanghai',
+          source: 'web',
+        },
+      }).outdoorPunch?.source,
+    ).toBe('web')
+  })
+
+  it('rejects an outdoorPunch missing a required field as null (not partial)', () => {
+    expect(
+      extractAttendanceRequestPayloadMetadataFieldsV1({
+        outdoorPunch: { eventType: 'check_in', occurredAt: '2026-08-01T09:00:00.000Z' },
+      }).outdoorPunch,
+    ).toBeNull()
+  })
+
+  it('rejects an outdoorPunch with an invalid eventType as null', () => {
+    expect(
+      extractAttendanceRequestPayloadMetadataFieldsV1({
+        outdoorPunch: { eventType: 'lunch', occurredAt: '2026-08-01T09:00:00.000Z', timezone: 'Asia/Shanghai' },
+      }).outdoorPunch,
+    ).toBeNull()
+  })
+
+  it('parses an outdoorPunch value given as a JSON string (matches normalizeMetadata on the nested field)', () => {
+    expect(
+      extractAttendanceRequestPayloadMetadataFieldsV1({
+        outdoorPunch: '{"eventType":"check_in","occurredAt":"2026-08-01T09:00:00.000Z","timezone":"Asia/Shanghai"}',
+      }).outdoorPunch,
+    ).toMatchObject({ eventType: 'check_in' })
+  })
+})

--- a/packages/core-backend/src/attendance/w4c3a-rollout-control.ts
+++ b/packages/core-backend/src/attendance/w4c3a-rollout-control.ts
@@ -36,7 +36,13 @@ import {
   type VerifiedAttendanceOperationIdentityV1,
 } from './w4c0-identity'
 import { runAttendanceResultOperationTransactionV1 } from './w4c0-operation-registry'
-import { ATTENDANCE_CALCULATION_AFFECTING_REQUEST_TYPES_V1 } from './w4c3b-request-snapshots'
+import {
+  ATTENDANCE_CALCULATION_AFFECTING_REQUEST_TYPES_V1,
+  buildAttendanceRequestCalculationPayloadFromRequestRowV1,
+  computeAttendanceRequestPayloadFingerprintV1,
+  extractAttendanceRequestPayloadMetadataFieldsV1,
+  type AttendanceRequestCalculationPayloadV1,
+} from './w4c3b-request-snapshots'
 
 export class AttendanceW4C3aRolloutControlError extends Error {
   readonly code: string
@@ -793,29 +799,166 @@ async function countUnresolvedIngressReviews(
   return result.rows.length
 }
 
+// ---------------------------------------------------------------------------
+// W4C-5 §3 request-snapshot precondition — closed 8-cell set (issue #4775).
+//
+// The amendment (`docs/development/attendance-issue-4556-w4c5-transition-safety-amendment-
+// 20260804.md:96-98`) requires: "eligibility/authority has zero pending or reversible
+// calculation-affecting request whose latest snapshot is missing, unsupported, payload-stale, or
+// reversal-incomplete" = (pending | reversible) x (missing | unsupported | payload-stale |
+// reversal-incomplete). PR #4773 implemented 2 of 8 cells (pending x {missing, unsupported}) and
+// self-reported the remaining 6 as a verified, not-guessed, blocking gap (see that PR's "Weak
+// spots" §1). This section closes all 8.
+// ---------------------------------------------------------------------------
+
+export const ATTENDANCE_REQUEST_SNAPSHOT_DEFECT_CELLS_V1 = Object.freeze([
+  'pendingMissing',
+  'pendingUnsupported',
+  'pendingPayloadStale',
+  'pendingReversalIncomplete',
+  'reversibleMissing',
+  'reversibleUnsupported',
+  'reversiblePayloadStale',
+  'reversibleReversalIncomplete',
+] as const)
+
+export type AttendanceRequestSnapshotDefectCellV1 =
+  (typeof ATTENDANCE_REQUEST_SNAPSHOT_DEFECT_CELLS_V1)[number]
+
+export type AttendanceRequestSnapshotDefectCountsV1 =
+  Readonly<Record<AttendanceRequestSnapshotDefectCellV1, number>>
+
 /**
- * Entry into eligible|authoritative: zero pending calculation-affecting request whose latest
- * snapshot is missing or `unsupported`. This is a narrower, mechanically-verifiable slice of
- * lock section 9 bullet 5 — it does NOT evaluate the "reversible" (approved-but-cancellable) half
- * or payload-staleness against live per-type request fields; see the amendment tracking note.
+ * `byCell` counts (request, defect-kind) PAIRS — a single request row can independently land in
+ * more than one cell (e.g. `unsupported` and `reversal-incomplete` at once), since the four defect
+ * checks are evaluated independently, not as a priority chain (see
+ * `classifyAttendanceRequestSnapshotDefectsV1` below). `totalDefectiveRequests` counts DISTINCT
+ * defective requests (0 or 1 per row) — the pre-existing `defectiveRequestSnapshots` evidence
+ * field's semantic, preserved unchanged so the exact-shape evidence test's meaning does not shift
+ * under an unrelated rename.
  */
-async function countDefectivePendingRequestSnapshots(
+export type AttendanceRequestSnapshotDefectReportV1 = Readonly<{
+  totalDefectiveRequests: number
+  byCell: AttendanceRequestSnapshotDefectCountsV1
+}>
+
+function emptyAttendanceRequestSnapshotDefectCounts(): Record<AttendanceRequestSnapshotDefectCellV1, number> {
+  const out = {} as Record<AttendanceRequestSnapshotDefectCellV1, number>
+  for (const cell of ATTENDANCE_REQUEST_SNAPSHOT_DEFECT_CELLS_V1) out[cell] = 0
+  return out
+}
+
+/**
+ * Recomputes the fingerprint the STORED snapshot `payload` column would produce under the exact
+ * same domain-separated canonical-JSON hash the writers use
+ * (`computeAttendanceRequestPayloadFingerprintV1`), rather than trusting the stored
+ * `payload_fingerprint` column as a truthful proxy for the stored payload's own content (W4C-5 §3
+ * owner-review P2, PR #4780). Returns `null` when the stored payload does not decode under the
+ * writers' own closed-shape validator (`normalizeAttendanceRequestCalculationPayloadV1`, reached
+ * through `computeAttendanceRequestPayloadFingerprintV1`) — a payload that cannot even be
+ * re-hashed is itself proof the row is inconsistent, not something the caller should treat as a
+ * pass. Every writer-produced row (append-boundary create/edit) always re-hashes successfully;
+ * only a payload written or altered outside that boundary can fail here.
+ */
+function computeStoredRequestSnapshotPayloadFingerprintV1(rawPayload: unknown): string | null {
+  try {
+    return computeAttendanceRequestPayloadFingerprintV1(
+      rawPayload as AttendanceRequestCalculationPayloadV1,
+    )
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Entry into eligible|authoritative: zero pending or reversible calculation-affecting request
+ * whose latest snapshot is missing, unsupported, payload-stale, or reversal-incomplete.
+ *
+ * Bucket definitions (mechanically verified against the plugin, not assumed):
+ *  - pending: `status = 'pending'`. Every calculation-affecting type can reach this state and can
+ *    be cancelled from it through the shared cancel adapter.
+ *  - reversible: `status = 'approved' AND request_type = 'leave'` — the ONLY combination the
+ *    plugin's shared cancel adapter (`plugins/plugin-attendance/index.cjs`, `requestCancelAdapter`)
+ *    permits to cancel an ALREADY-terminal (already-decided) request. `:34091` sets
+ *    `approvedLeave = requestRow.status === 'approved' && requestRow.request_type === 'leave'`;
+ *    `:34174` hard-blocks every other already-resolved request from reaching cancellation
+ *    (`if (requestRow.status !== 'pending' && !approvedLeave) throw HttpError(400, ...)`). No
+ *    other writer in `plugins/` or `packages/` sets `attendance_requests.status = 'cancelled'`
+ *    (swept both raw-SQL and Kysely-builder syntax against current `origin/main`) — a request
+ *    reaching `status = 'approved'` for a non-`leave` type is, today, terminal and never
+ *    reversible. A future request type gaining a post-approval cancel path would need this bucket
+ *    definition revisited explicitly, not silently inherited.
+ *
+ * Defect kinds:
+ *  - missing: no snapshot row exists for the request.
+ *  - unsupported: the latest snapshot's attribution posture is not `resolved_v2`.
+ *  - payload-stale: a THREE-WAY hash join, not a one-sided fingerprint compare (W4C-5 §3
+ *    owner-review P2, PR #4780). The pre-#4780 check only compared the recomputed live
+ *    fingerprint against the STORED `payload_fingerprint` column — it never re-hashed the stored
+ *    `payload` column itself. `chk_arcs_payload_fp` only shape-checks that column (`^[0-9a-f]
+ *    {64}$`); nothing in the database binds it to the stored payload's actual content. A stored
+ *    row whose `payload` is genuinely stale but whose `payload_fingerprint` field was written (by
+ *    a bug, a direct write outside the append boundary, or tampering) to equal the LIVE row's
+ *    fingerprint instead of a hash of the stale payload actually stored would satisfy that
+ *    one-sided compare and pass through undetected — the whole point of a payload/fingerprint
+ *    PAIR is defeated if only one side of the pair is ever independently verified. The fixed
+ *    predicate instead requires `hash(storedPayload) == storedFingerprint == hash(livePayload)`;
+ *    any of the three being unequal (including the stored payload failing to decode under the
+ *    writers' own closed-shape validator at all) is `payload-stale`. Both hashes are computed via
+ *    the same closed-payload/fingerprint functions the create/edit snapshot writers use
+ *    (`buildAttendanceRequestCalculationPayloadFromRequestRowV1` +
+ *    `computeAttendanceRequestPayloadFingerprintV1`) fed by
+ *    `extractAttendanceRequestPayloadMetadataFieldsV1` for the type-specific
+ *    `minutes`/`leaveTypeCode`/`outdoorPunch` fields (that function's own doc comment records why
+ *    this is a full, not narrowed, live-payload reconstruction, and its one known weak spot: a
+ *    second, non-shared copy of the plugin's identical field-extraction logic). A break anywhere
+ *    in the three-way join means some writer mutated the request's calculation-affecting fields
+ *    without appending a new snapshot version, or the stored pair itself is internally
+ *    inconsistent — either way the OCC contract `appendAttendanceRequestEditSnapshotV1` requires
+ *    of every in-boundary edit has been violated.
+ *  - reversal-incomplete: the request's linked `approval_instances` row has been revoked
+ *    (`status = 'cancelled'`) while the request itself is still `pending`/`approved` (bucket
+ *    membership already guarantees "not yet cancelled/rejected"). This is the exact torn state a
+ *    crash between the approval-revoke UPDATE and the request-status UPDATE inside the shared
+ *    cancel adapter's single transaction (`index.cjs` `executeRequestCancel`, `:34208`-`:34250`)
+ *    would leave, if that transaction's atomicity were ever violated by something outside normal
+ *    PostgreSQL commit/rollback semantics (e.g. a legacy direct write). It is a data-consistency
+ *    detector over the two tables, not a claim that the shared adapter itself is non-atomic — see
+ *    this predicate-completion PR's body for the mechanical atomicity proof of that one adapter,
+ *    and the closed-bucket note above for why no OTHER calculation-affecting type has a reversal
+ *    path to prove atomic in the first place.
+ */
+async function classifyAttendanceRequestSnapshotDefectsV1(
   trx: AttendanceW4TransactionClientV1,
   orgId: string,
-): Promise<number> {
+): Promise<AttendanceRequestSnapshotDefectReportV1> {
+  const byCell = emptyAttendanceRequestSnapshotDefectCounts()
   const requests = await trx.query(
-    `SELECT id::text AS id
+    `SELECT id::text AS id,
+            status::text AS status,
+            work_date::text AS work_date,
+            requested_in_at,
+            requested_out_at,
+            reason,
+            metadata,
+            approval_instance_id::text AS approval_instance_id
        FROM attendance_requests
-      WHERE org_id = $1 AND status = 'pending' AND request_type = ANY($2::text[])
+      WHERE org_id = $1
+        AND request_type = ANY($2::text[])
+        AND (status = 'pending' OR (status = 'approved' AND request_type = 'leave'))
       ORDER BY id
       FOR UPDATE`,
     [orgId, ATTENDANCE_CALCULATION_AFFECTING_REQUEST_TYPES_V1 as unknown as string[]],
   )
-  if (requests.rows.length === 0) return 0
-  let defective = 0
+  let totalDefectiveRequests = 0
   for (const request of requests.rows) {
+    const bucket: 'pending' | 'reversible' = request.status === 'pending' ? 'pending' : 'reversible'
+    let requestDefective = false
+
     const snapshot = await trx.query(
-      `SELECT attribution_snapshot AS "attributionSnapshot"
+      `SELECT attribution_snapshot AS "attributionSnapshot",
+              payload AS "payload",
+              payload_fingerprint AS "payloadFingerprint"
          FROM attendance_request_calculation_snapshots
         WHERE org_id = $1 AND request_id = $2::uuid
         ORDER BY version DESC
@@ -823,13 +966,86 @@ async function countDefectivePendingRequestSnapshots(
       [orgId, request.id],
     )
     if (snapshot.rows.length === 0) {
-      defective += 1
-      continue
+      byCell[`${bucket}Missing`] += 1
+      requestDefective = true
+    } else {
+      const snapshotRow = snapshot.rows[0]
+      const posture = (snapshotRow.attributionSnapshot as { posture?: unknown } | null)?.posture
+      if (posture !== 'resolved_v2') {
+        byCell[`${bucket}Unsupported`] += 1
+        requestDefective = true
+      }
+      const liveMetadataFields = extractAttendanceRequestPayloadMetadataFieldsV1(request.metadata)
+      const livePayload = buildAttendanceRequestCalculationPayloadFromRequestRowV1({
+        workDate: request.work_date,
+        requestedInAt: request.requested_in_at,
+        requestedOutAt: request.requested_out_at,
+        reason: request.reason,
+        minutes: liveMetadataFields.minutes,
+        leaveTypeCode: liveMetadataFields.leaveTypeCode,
+        outdoorPunch: liveMetadataFields.outdoorPunch,
+      })
+      const liveFingerprint = computeAttendanceRequestPayloadFingerprintV1(livePayload)
+      const storedFingerprint = String(snapshotRow.payloadFingerprint ?? '')
+      const recomputedStoredFingerprint = computeStoredRequestSnapshotPayloadFingerprintV1(
+        snapshotRow.payload,
+      )
+      // Three-way join (W4C-5 §3 owner-review P2, PR #4780): hash(storedPayload) ==
+      // storedFingerprint == hash(livePayload). The pre-#4780 predicate compared only
+      // `liveFingerprint === storedFingerprint` — a stored `payload_fingerprint` forged (or
+      // corrupted) to equal the live value, while the stored `payload` itself stayed stale,
+      // passed that one-sided compare undetected. Recomputing the stored side closes that gap:
+      // it can no longer differ from what the row's OWN payload actually hashes to.
+      //
+      // Two conjuncts, not three: `recomputedStoredFingerprint !== null` is NOT a separate
+      // discriminating check — `storedFingerprint` is always a string (`String(x ?? '')` below
+      // never produces `null`), so `null === storedFingerprint` is already `false` without an
+      // explicit guard. A stored payload that fails to decode (the `computeStoredRequest
+      // SnapshotPayloadFingerprintV1` catch path) is caught by the FIRST conjunct failing to
+      // match, not by a dedicated null branch — self-review round 2 (owner-review P2, PR #4780)
+      // removed the redundant guard after a mutation leg showed no test could tell it apart from
+      // simply deleting it.
+      const storedPayloadSelfConsistent = recomputedStoredFingerprint === storedFingerprint
+      const storedMatchesLive = storedFingerprint === liveFingerprint
+      if (!storedPayloadSelfConsistent || !storedMatchesLive) {
+        byCell[`${bucket}PayloadStale`] += 1
+        requestDefective = true
+      }
     }
-    const posture = (snapshot.rows[0].attributionSnapshot as { posture?: unknown } | null)?.posture
-    if (posture !== 'resolved_v2') defective += 1
+
+    const approvalInstanceId =
+      typeof request.approval_instance_id === 'string' && request.approval_instance_id.length > 0
+        ? request.approval_instance_id
+        : null
+    if (approvalInstanceId) {
+      const approval = await trx.query(
+        `SELECT status::text AS status FROM approval_instances WHERE id = $1 FOR UPDATE`,
+        [approvalInstanceId],
+      )
+      if (approval.rows.length === 1 && approval.rows[0].status === 'cancelled') {
+        byCell[`${bucket}ReversalIncomplete`] += 1
+        requestDefective = true
+      }
+    }
+
+    if (requestDefective) totalDefectiveRequests += 1
   }
-  return defective
+  return Object.freeze({ totalDefectiveRequests, byCell: Object.freeze(byCell) })
+}
+
+/**
+ * §5-sanctioned read-only reporter shape ("a read-only `status`/`plan` command that emits
+ * `PASS|BLOCKED` per predicate"): exposes the exact same classification the transition boundary
+ * enforces, for direct per-cell assertion without needing to observe it indirectly through a
+ * blocked-transition error. Performs zero DML. Callers own the transaction/locking; a caller that
+ * wants a point-in-time read without contending the row locks below may run it in its own
+ * short-lived transaction and roll back.
+ */
+export async function readAttendanceRequestSnapshotDefectReportV1(
+  connection: AttendanceW4TransactionClientV1,
+  orgId: string,
+): Promise<AttendanceRequestSnapshotDefectReportV1> {
+  return classifyAttendanceRequestSnapshotDefectsV1(connection, orgId)
 }
 
 function isRetryableControlPrecondition(error: unknown): boolean {
@@ -1006,12 +1222,16 @@ export async function transitionAttendanceCalculationRolloutV1(
       let incompleteOperations = 0
       let unresolvedReviews = 0
       let defectiveRequestSnapshots = 0
+      let defectiveRequestSnapshotsByCell: AttendanceRequestSnapshotDefectCountsV1 =
+        emptyAttendanceRequestSnapshotDefectCounts()
       if (ELIGIBILITY_AUTHORITY_TARGETS.has(input.targetState)) {
         incompleteOperations = await countIncompleteOperations(trx, input.orgId)
         if (incompleteOperations > 0) fail('W4C3A_ROLLOUT_CONTROL_INCOMPLETE_OPERATION')
         unresolvedReviews = await countUnresolvedIngressReviews(trx, input.orgId)
         if (unresolvedReviews > 0) fail('W4C3A_ROLLOUT_CONTROL_UNRESOLVED_REVIEW')
-        defectiveRequestSnapshots = await countDefectivePendingRequestSnapshots(trx, input.orgId)
+        const snapshotDefects = await classifyAttendanceRequestSnapshotDefectsV1(trx, input.orgId)
+        defectiveRequestSnapshots = snapshotDefects.totalDefectiveRequests
+        defectiveRequestSnapshotsByCell = snapshotDefects.byCell
         if (defectiveRequestSnapshots > 0) fail('W4C3A_ROLLOUT_CONTROL_REQUEST_SNAPSHOT_DEFECTIVE')
       }
 
@@ -1043,6 +1263,7 @@ export async function transitionAttendanceCalculationRolloutV1(
               incompleteOperations,
               unresolvedReviews,
               defectiveRequestSnapshots,
+              defectiveRequestSnapshotsByCell,
             },
             references: input.evidenceReferences,
           }),

--- a/packages/core-backend/src/attendance/w4c3b-request-snapshots.ts
+++ b/packages/core-backend/src/attendance/w4c3b-request-snapshots.ts
@@ -354,6 +354,79 @@ export function buildAttendanceRequestCalculationPayloadFromRequestRowV1(input: 
   })
 }
 
+function coerceAttendanceRequestMetadataObjectV1(value: unknown): Record<string, unknown> {
+  if (!value) return {}
+  if (typeof value === 'string') {
+    try {
+      const parsed = JSON.parse(value)
+      return parsed && typeof parsed === 'object' ? (parsed as Record<string, unknown>) : {}
+    } catch {
+      return {}
+    }
+  }
+  return typeof value === 'object' ? (value as Record<string, unknown>) : {}
+}
+
+/**
+ * W4C-5 §3 payload-stale predicate support (issue #4775): reconstructs the type-specific
+ * `minutes`/`leaveTypeCode`/`outdoorPunch` payload fields from a live `attendance_requests.metadata`
+ * value, exactly mirroring `buildRequestSnapshotPayloadFieldsFromDraft`'s field extraction in
+ * `plugins/plugin-attendance/index.cjs:24414-24445` (called by both `buildRequestSnapshotPayloadFromDraft`
+ * and the request-creation/edit routes — the plugin's request-creation/edit payload builders).
+ * This is a DELIBERATE field-for-field port, not a re-derivation: the plugin call site
+ * builds these fields from the same `metadata` JSONB column this function reads, so the two must
+ * stay behaviorally identical or the payload-stale predicate below would compare against a payload
+ * the plugin could never actually have produced.
+ *
+ * KNOWN WEAK SPOT (self-reported, not owner-resolved): this is a second copy of that exact logic,
+ * not a shared call through the host port — refactoring the plugin's existing (already-shipped,
+ * heavily-exercised) creation/edit paths to call through the port instead was judged out of this
+ * predicate-completion issue's scope (higher blast radius than the control-boundary predicate it
+ * was asked to close). A future edit to either copy without the other is a real, mechanically
+ * undetected drift risk; `__tests__/w4c3b-request-snapshot-metadata-fields.test.ts` pins this
+ * function's own behavior against a fixture table but cannot reach into the CJS plugin closure to
+ * cross-check it directly.
+ */
+export function extractAttendanceRequestPayloadMetadataFieldsV1(metadataInput: unknown): Readonly<{
+  minutes: number | null
+  leaveTypeCode: string | null
+  outdoorPunch: AttendanceRequestCalculationPayloadV1['outdoorPunch']
+}> {
+  const meta = coerceAttendanceRequestMetadataObjectV1(metadataInput)
+  const minutesRaw = meta.minutes
+  const minutes =
+    typeof minutesRaw === 'number' && Number.isFinite(minutesRaw) && minutesRaw >= 0
+      ? Math.trunc(minutesRaw)
+      : null
+  const leaveTypeContainer = meta.leaveType
+  const leaveTypeCodeFromNested =
+    leaveTypeContainer && typeof leaveTypeContainer === 'object' && !Array.isArray(leaveTypeContainer)
+      ? (leaveTypeContainer as Record<string, unknown>).code
+      : undefined
+  const leaveTypeCodeFromFlat = meta.leaveTypeCode
+  const leaveTypeCode =
+    typeof leaveTypeCodeFromNested === 'string' && leaveTypeCodeFromNested.trim()
+      ? leaveTypeCodeFromNested.trim()
+      : typeof leaveTypeCodeFromFlat === 'string' && leaveTypeCodeFromFlat.trim()
+        ? leaveTypeCodeFromFlat.trim()
+        : null
+  const outdoor = coerceAttendanceRequestMetadataObjectV1(meta.outdoorPunch)
+  let outdoorPunch: AttendanceRequestCalculationPayloadV1['outdoorPunch'] = null
+  if (
+    (outdoor.eventType === 'check_in' || outdoor.eventType === 'check_out') &&
+    typeof outdoor.occurredAt === 'string' && outdoor.occurredAt &&
+    typeof outdoor.timezone === 'string' && outdoor.timezone
+  ) {
+    outdoorPunch = Object.freeze({
+      eventType: outdoor.eventType,
+      occurredAt: outdoor.occurredAt,
+      timezone: outdoor.timezone,
+      source: typeof outdoor.source === 'string' && outdoor.source ? outdoor.source : 'mobile',
+    })
+  }
+  return Object.freeze({ minutes, leaveTypeCode, outdoorPunch })
+}
+
 export function computeAttendanceRequestPayloadFingerprintV1(
   payload: AttendanceRequestCalculationPayloadV1,
 ): string {

--- a/packages/core-backend/tests/integration/attendance-w4c3a-rollout-control.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-w4c3a-rollout-control.db.test.ts
@@ -18,8 +18,12 @@ import {
   __setW4C3aRolloutControlAfterExclusiveLockForTests,
   __setW4C3aRolloutControlBeforeEventInsertForTests,
   __setW4C3aRolloutControlBeforeStateUpdateForTests,
+  ATTENDANCE_REQUEST_SNAPSHOT_DEFECT_CELLS_V1,
   closeLegacyRollbackWindowV1,
+  readAttendanceRequestSnapshotDefectReportV1,
   transitionAttendanceCalculationRolloutV1,
+  type AttendanceRequestSnapshotDefectCellV1,
+  type AttendanceRequestSnapshotDefectCountsV1,
   type AttendanceW4C3aRolloutControlResultV1,
   type EvidenceReferencesV1,
 } from '../../src/attendance/w4c3a-rollout-control'
@@ -30,6 +34,10 @@ import {
   type AttendanceRolloutStateV1,
   type AttendanceW4TransactionClientV1,
 } from '../../src/attendance/w4c0-identity'
+import {
+  buildAttendanceRequestCalculationPayloadFromRequestRowV1,
+  computeAttendanceRequestPayloadFingerprintV1,
+} from '../../src/attendance/w4c3b-request-snapshots'
 
 const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
 const describeIfDatabase = dbUrl ? describe : describe.skip
@@ -99,7 +107,17 @@ async function createBase(pool: Pool): Promise<void> {
   await pool.query(`
     CREATE TABLE attendance_requests (
       id uuid PRIMARY KEY DEFAULT gen_random_uuid(), user_id text NOT NULL, work_date date NOT NULL,
-      request_type varchar(30) NOT NULL, status varchar(20) NOT NULL DEFAULT 'pending', org_id text NOT NULL
+      request_type varchar(30) NOT NULL, status varchar(20) NOT NULL DEFAULT 'pending', org_id text NOT NULL,
+      requested_in_at timestamptz, requested_out_at timestamptz, reason text,
+      metadata jsonb NOT NULL DEFAULT '{}'::jsonb, approval_instance_id text
+    )`)
+  // W4C-5 §3 (issue #4775): the reversal-incomplete cell reads the request's linked approval
+  // instance. Minimal shape matching `20250924105000_create_approval_tables.ts` (`id text PRIMARY
+  // KEY, status text NOT NULL, version integer`) — the rollout-control predicate reads only `id`
+  // and `status`.
+  await pool.query(`
+    CREATE TABLE approval_instances (
+      id text PRIMARY KEY, status text NOT NULL, version integer NOT NULL DEFAULT 0
     )`)
   await pool.query(`
     CREATE TABLE attendance_import_jobs (
@@ -244,26 +262,137 @@ describeIfDatabase('W4C-3a core-only rollout control (real PostgreSQL)', () => {
     )
   }
 
-  async function insertPendingRequest(
-    org: string,
-    kind: 'missing_snapshot' | 'unsupported_snapshot',
-  ): Promise<void> {
+  /**
+   * `'unsupported_snapshot'` was retired (W4C-5 §3, issue #4775): its arbitrary `hex64(...)`
+   * fingerprint isn't congruent with the live row, so under the new payload-stale check it would
+   * ALSO trip `pendingPayloadStale`, defeating the exclusivity a mutation test needs (see the
+   * "unsupported" describe block below, now built on `insertRequestSnapshotFixture` instead). Only
+   * `'missing_snapshot'` remains — no live-row/snapshot payload comparison ever runs when the
+   * snapshot itself is absent, so that kind was never affected.
+   */
+  async function insertPendingRequest(org: string, kind: 'missing_snapshot'): Promise<void> {
+    void kind
     const requestId = crypto.randomUUID()
     await pool.query(
       `INSERT INTO attendance_requests (id, user_id, work_date, request_type, status, org_id)
        VALUES ($1::uuid, $2, '2026-08-01', 'time_correction', 'pending', $3)`,
       [requestId, crypto.randomUUID(), org],
     )
-    if (kind === 'unsupported_snapshot') {
-      await pool.query(
+  }
+
+  /**
+   * W4C-5 §3 (issue #4775): fixture builder for the full 2x4 = 8-cell closed request-snapshot
+   * defect set. `bucket` selects `status='pending'` (any calc-affecting type) or `status='approved'
+   * AND request_type='leave'` — the only combination the plugin's shared cancel adapter treats as
+   * reversible (`plugins/plugin-attendance/index.cjs:34091`/`:34174`).
+   *
+   * Each `kind` is built to be EXCLUSIVE — it trips exactly the one cell it names and none of the
+   * other three defect kinds for the same request — so a mutation that deletes one classification
+   * branch in production code can be told apart from another by which cell's counter moves.
+   */
+  const LIVE_ROW_REASON = 'fixture-reason'
+  const STALE_SNAPSHOT_REASON = 'fixture-reason-mismatch'
+
+  function fixtureLivePayloadFingerprint(): string {
+    const payload = buildAttendanceRequestCalculationPayloadFromRequestRowV1({
+      workDate: '2026-08-01',
+      requestedInAt: null,
+      requestedOutAt: null,
+      reason: LIVE_ROW_REASON,
+    })
+    return computeAttendanceRequestPayloadFingerprintV1(payload)
+  }
+
+  function fixtureStaleSnapshotFingerprint(): string {
+    const payload = buildAttendanceRequestCalculationPayloadFromRequestRowV1({
+      workDate: '2026-08-01',
+      requestedInAt: null,
+      requestedOutAt: null,
+      reason: STALE_SNAPSHOT_REASON,
+    })
+    return computeAttendanceRequestPayloadFingerprintV1(payload)
+  }
+
+  type RequestSnapshotFixtureBucket = 'pending' | 'reversible'
+  type RequestSnapshotFixtureKind =
+    | 'missing'
+    | 'unsupported'
+    | 'payload_stale'
+    | 'reversal_incomplete'
+
+  async function insertRequestSnapshotFixture(
+    org: string,
+    bucket: RequestSnapshotFixtureBucket,
+    kind: RequestSnapshotFixtureKind,
+    executor: Pool | PoolClient = pool,
+  ): Promise<{ requestId: string; approvalInstanceId: string }> {
+    const requestId = crypto.randomUUID()
+    const requestType = bucket === 'reversible' ? 'leave' : 'time_correction'
+    const status = bucket === 'reversible' ? 'approved' : 'pending'
+    const approvalInstanceId = `appr-${requestId}`
+    const approvalStatus = kind === 'reversal_incomplete' ? 'cancelled' : 'pending'
+    await executor.query(
+      `INSERT INTO attendance_requests
+         (id, user_id, work_date, request_type, status, org_id, requested_in_at, requested_out_at,
+          reason, metadata, approval_instance_id)
+       VALUES ($1::uuid, $2, '2026-08-01', $3, $4, $5, NULL, NULL, $6, '{}'::jsonb, $7)`,
+      [requestId, crypto.randomUUID(), requestType, status, org, LIVE_ROW_REASON, approvalInstanceId],
+    )
+    await executor.query(
+      `INSERT INTO approval_instances (id, status, version) VALUES ($1, $2, 1)`,
+      [approvalInstanceId, approvalStatus],
+    )
+    if (kind !== 'missing') {
+      const posture = kind === 'unsupported' ? 'unsupported' : 'resolved_v2'
+      const attributionSnapshot =
+        posture === 'unsupported'
+          ? '{"posture":"unsupported","sourceSchemaVersion":null,"reason":"missing","sourceFingerprint":null}'
+          : '{"posture":"resolved_v2"}'
+      const payloadFingerprint =
+        kind === 'payload_stale' ? fixtureStaleSnapshotFingerprint() : fixtureLivePayloadFingerprint()
+      const payloadReason = kind === 'payload_stale' ? STALE_SNAPSHOT_REASON : LIVE_ROW_REASON
+      await executor.query(
         `INSERT INTO attendance_request_calculation_snapshots (
            org_id, request_id, version, request_type, subject_user_id, payload, payload_fingerprint,
            attribution_snapshot, created_by)
-         VALUES ($1, $2::uuid, 1, 'time_correction', $3, '{"schemaVersion":1}'::jsonb, $4,
-           '{"posture":"unsupported","sourceSchemaVersion":null,"reason":"missing","sourceFingerprint":null}'::jsonb, $5)`,
-        [org, requestId, crypto.randomUUID(), hex64(`${org}:${requestId}:payload`), actorId],
+         VALUES ($1, $2::uuid, 1, $3, $4, $5::jsonb, $6, $7::jsonb, $8)`,
+        [
+          org,
+          requestId,
+          requestType,
+          crypto.randomUUID(),
+          JSON.stringify({
+            schemaVersion: 1,
+            workDate: '2026-08-01',
+            requestedInAt: null,
+            requestedOutAt: null,
+            reason: payloadReason,
+            minutes: null,
+            leaveTypeCode: null,
+            outdoorPunch: null,
+          }),
+          payloadFingerprint,
+          attributionSnapshot,
+          actorId,
+        ],
       )
     }
+    return { requestId, approvalInstanceId }
+  }
+
+  function emptyDefectCounts(): Record<AttendanceRequestSnapshotDefectCellV1, number> {
+    const out = {} as Record<AttendanceRequestSnapshotDefectCellV1, number>
+    for (const cell of ATTENDANCE_REQUEST_SNAPSHOT_DEFECT_CELLS_V1) out[cell] = 0
+    return out
+  }
+
+  function expectSingleCellDefect(
+    report: AttendanceRequestSnapshotDefectCountsV1,
+    cell: AttendanceRequestSnapshotDefectCellV1,
+  ): void {
+    const expected = emptyDefectCounts()
+    expected[cell] = 1
+    expect(report).toEqual(expected)
   }
 
   /**
@@ -1518,9 +1647,17 @@ describeIfDatabase('W4C-3a core-only rollout control (real PostgreSQL)', () => {
     it('blocks entry into eligible when the latest snapshot is unsupported', async () => {
       const reqOrg = crypto.randomUUID()
       allow(reqOrg)
-      await insertPendingRequest(reqOrg, 'unsupported_snapshot')
+      // W4C-5 §3 (issue #4775): uses the shared fixture builder (not the legacy `insertPendingRequest`
+      // helper's arbitrary `hex64(...)` fingerprint) so this fixture's stored `payload_fingerprint`
+      // EXACTLY matches what the live row would recompute — i.e. it trips ONLY `pendingUnsupported`,
+      // not `pendingPayloadStale` too. A mutation-test pass (self-reported in the PR body) found the
+      // legacy fixture's arbitrary fingerprint accidentally also tripped the new payload-stale check,
+      // masking an `unsupported`-only mutation behind a still-red `payload-stale` leg on the same row.
+      await insertRequestSnapshotFixture(reqOrg, 'pending', 'unsupported')
       const client = await pool.connect()
       try {
+        const report = await readAttendanceRequestSnapshotDefectReportV1(transactionClient(client), reqOrg)
+        expectSingleCellDefect(report.byCell, 'pendingUnsupported')
         await transitionAttendanceCalculationRolloutV1(transactionClient(client), {
           orgId: reqOrg, actorId, correlationId: crypto.randomUUID(), engineVersion: 'w4c3a-control-test',
           targetState: 'shadow', expectedState: 'legacy', expectedVersion: 1,
@@ -1535,6 +1672,413 @@ describeIfDatabase('W4C-3a core-only rollout control (real PostgreSQL)', () => {
             reasonCode: 'rollout_transition',
           }),
         ).rejects.toMatchObject({ code: 'W4C3A_ROLLOUT_CONTROL_REQUEST_SNAPSHOT_DEFECTIVE' })
+      } finally {
+        client.release()
+      }
+    })
+  })
+
+  describe('W4C-5 §3 (issue #4775): the remaining 6 request-snapshot defect cells', () => {
+    const CASES: ReadonlyArray<{
+      readonly label: string
+      readonly bucket: RequestSnapshotFixtureBucket
+      readonly kind: RequestSnapshotFixtureKind
+      readonly cell: AttendanceRequestSnapshotDefectCellV1
+    }> = [
+      { label: 'pending x payload-stale', bucket: 'pending', kind: 'payload_stale', cell: 'pendingPayloadStale' },
+      { label: 'pending x reversal-incomplete', bucket: 'pending', kind: 'reversal_incomplete', cell: 'pendingReversalIncomplete' },
+      { label: 'reversible x missing', bucket: 'reversible', kind: 'missing', cell: 'reversibleMissing' },
+      { label: 'reversible x unsupported', bucket: 'reversible', kind: 'unsupported', cell: 'reversibleUnsupported' },
+      { label: 'reversible x payload-stale', bucket: 'reversible', kind: 'payload_stale', cell: 'reversiblePayloadStale' },
+      { label: 'reversible x reversal-incomplete', bucket: 'reversible', kind: 'reversal_incomplete', cell: 'reversibleReversalIncomplete' },
+    ]
+
+    for (const testCase of CASES) {
+      it(`${testCase.label}: the read-only reporter flags exactly this cell and no other`, async () => {
+        const org = crypto.randomUUID()
+        allow(org)
+        await insertRequestSnapshotFixture(org, testCase.bucket, testCase.kind)
+        const client = await pool.connect()
+        try {
+          const report = await readAttendanceRequestSnapshotDefectReportV1(transactionClient(client), org)
+          expect(report.totalDefectiveRequests).toBe(1)
+          expectSingleCellDefect(report.byCell, testCase.cell)
+        } finally {
+          client.release()
+        }
+      })
+
+      it(`${testCase.label}: blocks entry into eligible with zero rollout DML`, async () => {
+        const org = crypto.randomUUID()
+        allow(org)
+        await insertRequestSnapshotFixture(org, testCase.bucket, testCase.kind)
+        const client = await pool.connect()
+        try {
+          await transitionAttendanceCalculationRolloutV1(transactionClient(client), {
+            orgId: org, actorId, correlationId: crypto.randomUUID(), engineVersion: 'w4c3a-control-test',
+            targetState: 'shadow', expectedState: 'legacy', expectedVersion: 1,
+            evidenceManifestSha256: hex64(`${testCase.cell}-setup`), evidenceReferences: baseRefs(`${testCase.cell}-setup`),
+            reasonCode: 'rollout_transition',
+          })
+          await expect(
+            transitionAttendanceCalculationRolloutV1(transactionClient(client), {
+              orgId: org, actorId, correlationId: crypto.randomUUID(), engineVersion: 'w4c3a-control-test',
+              targetState: 'eligible', expectedState: 'shadow', expectedVersion: 2,
+              evidenceManifestSha256: hex64(`${testCase.cell}-blocked`), evidenceReferences: baseRefs(`${testCase.cell}-blocked`),
+              reasonCode: 'rollout_transition',
+            }),
+          ).rejects.toMatchObject({ code: 'W4C3A_ROLLOUT_CONTROL_REQUEST_SNAPSHOT_DEFECTIVE' })
+          await expect(pool.query(
+            'SELECT state, version FROM attendance_calculation_rollout_state WHERE org_id = $1',
+            [org],
+          )).resolves.toMatchObject({ rows: [{ state: 'shadow', version: 2 }] })
+        } finally {
+          client.release()
+        }
+      })
+    }
+
+    it('POSITIVE CONTROL: a reversible (approved leave) request with a healthy, fresh, non-stale snapshot does not block promotion', async () => {
+      const org = crypto.randomUUID()
+      allow(org)
+      const requestId = crypto.randomUUID()
+      await pool.query(
+        `INSERT INTO attendance_requests
+           (id, user_id, work_date, request_type, status, org_id, requested_in_at, requested_out_at, reason, metadata, approval_instance_id)
+         VALUES ($1::uuid, $2, '2026-08-01', 'leave', 'approved', $3, NULL, NULL, $4, '{}'::jsonb, NULL)`,
+        [requestId, crypto.randomUUID(), org, LIVE_ROW_REASON],
+      )
+      await pool.query(
+        `INSERT INTO attendance_request_calculation_snapshots (
+           org_id, request_id, version, request_type, subject_user_id, payload, payload_fingerprint,
+           attribution_snapshot, created_by)
+         VALUES ($1, $2::uuid, 1, 'leave', $3, $4::jsonb, $5, '{"posture":"resolved_v2"}'::jsonb, $6)`,
+        [
+          org,
+          requestId,
+          crypto.randomUUID(),
+          JSON.stringify({
+            schemaVersion: 1, workDate: '2026-08-01', requestedInAt: null, requestedOutAt: null,
+            reason: LIVE_ROW_REASON, minutes: null, leaveTypeCode: null, outdoorPunch: null,
+          }),
+          fixtureLivePayloadFingerprint(),
+          actorId,
+        ],
+      )
+      const client = await pool.connect()
+      try {
+        const report = await readAttendanceRequestSnapshotDefectReportV1(transactionClient(client), org)
+        expect(report).toEqual({ totalDefectiveRequests: 0, byCell: emptyDefectCounts() })
+        await transitionAttendanceCalculationRolloutV1(transactionClient(client), {
+          orgId: org, actorId, correlationId: crypto.randomUUID(), engineVersion: 'w4c3a-control-test',
+          targetState: 'shadow', expectedState: 'legacy', expectedVersion: 1,
+          evidenceManifestSha256: hex64('healthy-reversible-setup'), evidenceReferences: baseRefs('healthy-reversible-setup'),
+          reasonCode: 'rollout_transition',
+        })
+        await expect(transitionAttendanceCalculationRolloutV1(transactionClient(client), {
+          orgId: org, actorId, correlationId: crypto.randomUUID(), engineVersion: 'w4c3a-control-test',
+          targetState: 'eligible', expectedState: 'shadow', expectedVersion: 2,
+          evidenceManifestSha256: hex64('healthy-reversible-ok'), evidenceReferences: baseRefs('healthy-reversible-ok'),
+          reasonCode: 'rollout_transition',
+        })).resolves.toEqual<AttendanceW4C3aRolloutControlResultV1>({ orgId: org, state: 'eligible', batchId: null })
+      } finally {
+        client.release()
+      }
+    })
+
+    it('bucket-exclusion control: an approved NON-leave request with a missing snapshot is NOT flagged (reversible is closed to leave)', async () => {
+      const org = crypto.randomUUID()
+      allow(org)
+      const requestId = crypto.randomUUID()
+      // Approved 'overtime' — never reversible (index.cjs:34174 hard-blocks cancelling any
+      // already-resolved non-leave request) — and has no snapshot at all. A predicate that
+      // mistakenly widened `reversible` to "any approved type" would flag this row.
+      await pool.query(
+        `INSERT INTO attendance_requests
+           (id, user_id, work_date, request_type, status, org_id, requested_in_at, requested_out_at, reason, metadata, approval_instance_id)
+         VALUES ($1::uuid, $2, '2026-08-01', 'overtime', 'approved', $3, NULL, NULL, $4, '{}'::jsonb, NULL)`,
+        [requestId, crypto.randomUUID(), org, LIVE_ROW_REASON],
+      )
+      const client = await pool.connect()
+      try {
+        const report = await readAttendanceRequestSnapshotDefectReportV1(transactionClient(client), org)
+        expect(report).toEqual({ totalDefectiveRequests: 0, byCell: emptyDefectCounts() })
+      } finally {
+        client.release()
+      }
+    })
+  })
+
+  describe('W4C-5 §3 (issue #4775): real two-connection races extended to the 6 new snapshot cells (gate 6)', () => {
+    const RACE_CASES: ReadonlyArray<{
+      readonly label: string
+      readonly bucket: RequestSnapshotFixtureBucket
+      readonly kind: RequestSnapshotFixtureKind
+      readonly cell: AttendanceRequestSnapshotDefectCellV1
+    }> = [
+      { label: 'RACE F (pending x payload-stale)', bucket: 'pending', kind: 'payload_stale', cell: 'pendingPayloadStale' },
+      { label: 'RACE G (pending x reversal-incomplete)', bucket: 'pending', kind: 'reversal_incomplete', cell: 'pendingReversalIncomplete' },
+      { label: 'RACE H (reversible x missing)', bucket: 'reversible', kind: 'missing', cell: 'reversibleMissing' },
+      { label: 'RACE I (reversible x unsupported)', bucket: 'reversible', kind: 'unsupported', cell: 'reversibleUnsupported' },
+      { label: 'RACE J (reversible x payload-stale)', bucket: 'reversible', kind: 'payload_stale', cell: 'reversiblePayloadStale' },
+      { label: 'RACE K (reversible x reversal-incomplete)', bucket: 'reversible', kind: 'reversal_incomplete', cell: 'reversibleReversalIncomplete' },
+    ]
+
+    for (const raceCase of RACE_CASES) {
+      it(`${raceCase.label}, 3-actor: a defect committed by an actor with NO rollout-lock obligation, while a protocol-compliant shared-lock holder blocks the transition, is still caught`, async () => {
+        const raceOrg = crypto.randomUUID()
+        allow(raceOrg)
+        const setupClient = await pool.connect()
+        try {
+          await transitionAttendanceCalculationRolloutV1(transactionClient(setupClient), {
+            orgId: raceOrg, actorId, correlationId: crypto.randomUUID(), engineVersion: 'w4c3a-control-test',
+            targetState: 'shadow', expectedState: 'legacy', expectedVersion: 1,
+            evidenceManifestSha256: hex64(`${raceCase.cell}-race-setup`), evidenceReferences: baseRefs(`${raceCase.cell}-race-setup`),
+            reasonCode: 'rollout_transition',
+          })
+        } finally {
+          setupClient.release()
+        }
+
+        const c1Client = await pool.connect()
+        const transitionClient = await pool.connect()
+        try {
+          await c1Client.query('BEGIN')
+          await acquireAttendanceCalculationRolloutLock(
+            transactionClient(c1Client),
+            parseCanonicalAttendanceRolloutOrgKeyV1(raceOrg),
+            'shared',
+          )
+
+          let transitionSettled = false
+          const transition = transitionAttendanceCalculationRolloutV1(transactionClient(transitionClient), {
+            orgId: raceOrg, actorId, correlationId: crypto.randomUUID(), engineVersion: 'w4c3a-control-test',
+            targetState: 'eligible', expectedState: 'shadow', expectedVersion: 2,
+            evidenceManifestSha256: hex64(`${raceCase.cell}-race-transition`), evidenceReferences: baseRefs(`${raceCase.cell}-race-transition`),
+            reasonCode: 'rollout_transition',
+          }).finally(() => { transitionSettled = true })
+          await new Promise((resolve) => setTimeout(resolve, 150))
+          expect(transitionSettled).toBe(false) // T genuinely blocked behind C1's shared hold
+
+          // C2: commits independently, lock-free, plain autocommit — matching
+          // `insertRequestSnapshotFixture`'s default (shared pool) executor.
+          await insertRequestSnapshotFixture(raceOrg, raceCase.bucket, raceCase.kind)
+
+          // C1 releases; T can now proceed.
+          await c1Client.query('COMMIT')
+
+          await expect(transition).rejects.toMatchObject({ code: 'W4C3A_ROLLOUT_CONTROL_REQUEST_SNAPSHOT_DEFECTIVE' })
+          expect(transitionSettled).toBe(true)
+          await expect(pool.query(
+            'SELECT state, version FROM attendance_calculation_rollout_state WHERE org_id = $1',
+            [raceOrg],
+          )).resolves.toMatchObject({ rows: [{ state: 'shadow', version: 2 }] })
+        } finally {
+          await c1Client.query('ROLLBACK').catch(() => undefined)
+          c1Client.release()
+          transitionClient.release()
+        }
+      })
+    }
+  })
+
+  describe('W4C-5 §3 owner-review P2 (PR #4780): forged payload_fingerprint cannot bypass payload-stale', () => {
+    /**
+     * Constructs the exact adversarial row the pre-#4780 one-sided
+     * `liveFingerprint === storedFingerprint` compare could not see: the stored `payload` column
+     * is genuinely stale (independently re-hashes to `fixtureStaleSnapshotFingerprint()`, NOT
+     * `fixtureLivePayloadFingerprint()`), but the stored `payload_fingerprint` column is FORGED
+     * to equal the LIVE row's fingerprint instead of a hash of the payload actually stored beside
+     * it. No writer in this codebase ever produces this shape —
+     * `appendAttendanceRequestEditSnapshotV1` always hashes the exact payload object it is about
+     * to store (`w4c3b-request-snapshots.ts` `payloadFingerprint:
+     * computeAttendanceRequestPayloadFingerprintV1(payload)`, same `payload` value written to the
+     * `payload` column two lines above) — this simulates a write outside that append boundary, or
+     * a forged/corrupted field: exactly the class of defect a payload/fingerprint PAIR exists to
+     * catch, and exactly what a one-sided fingerprint-only compare cannot.
+     */
+    async function insertForgedPayloadStaleFixture(
+      org: string,
+      bucket: RequestSnapshotFixtureBucket,
+    ): Promise<{ requestId: string }> {
+      const requestId = crypto.randomUUID()
+      const requestType = bucket === 'reversible' ? 'leave' : 'time_correction'
+      const status = bucket === 'reversible' ? 'approved' : 'pending'
+      await pool.query(
+        `INSERT INTO attendance_requests
+           (id, user_id, work_date, request_type, status, org_id, requested_in_at, requested_out_at,
+            reason, metadata, approval_instance_id)
+         VALUES ($1::uuid, $2, '2026-08-01', $3, $4, $5, NULL, NULL, $6, '{}'::jsonb, NULL)`,
+        [requestId, crypto.randomUUID(), requestType, status, org, LIVE_ROW_REASON],
+      )
+      await pool.query(
+        `INSERT INTO attendance_request_calculation_snapshots (
+           org_id, request_id, version, request_type, subject_user_id, payload, payload_fingerprint,
+           attribution_snapshot, created_by)
+         VALUES ($1, $2::uuid, 1, $3, $4, $5::jsonb, $6, '{"posture":"resolved_v2"}'::jsonb, $7)`,
+        [
+          org,
+          requestId,
+          requestType,
+          crypto.randomUUID(),
+          // STORED PAYLOAD: genuinely stale (mismatched `reason`).
+          JSON.stringify({
+            schemaVersion: 1, workDate: '2026-08-01', requestedInAt: null, requestedOutAt: null,
+            reason: STALE_SNAPSHOT_REASON, minutes: null, leaveTypeCode: null, outdoorPunch: null,
+          }),
+          // FORGED STORED FINGERPRINT: hash of the LIVE payload, not of the stale payload two
+          // lines above. The pre-#4780 predicate trusted this field as ground truth.
+          fixtureLivePayloadFingerprint(),
+          actorId,
+        ],
+      )
+      return { requestId }
+    }
+
+    it('pending x payload-stale, FORGED fingerprint: the read-only reporter still flags pendingPayloadStale', async () => {
+      const org = crypto.randomUUID()
+      allow(org)
+      await insertForgedPayloadStaleFixture(org, 'pending')
+      const client = await pool.connect()
+      try {
+        const report = await readAttendanceRequestSnapshotDefectReportV1(transactionClient(client), org)
+        expect(report.totalDefectiveRequests).toBe(1)
+        expectSingleCellDefect(report.byCell, 'pendingPayloadStale')
+      } finally {
+        client.release()
+      }
+    })
+
+    it('reversible x payload-stale, FORGED fingerprint: the read-only reporter still flags reversiblePayloadStale', async () => {
+      const org = crypto.randomUUID()
+      allow(org)
+      await insertForgedPayloadStaleFixture(org, 'reversible')
+      const client = await pool.connect()
+      try {
+        const report = await readAttendanceRequestSnapshotDefectReportV1(transactionClient(client), org)
+        expect(report.totalDefectiveRequests).toBe(1)
+        expectSingleCellDefect(report.byCell, 'reversiblePayloadStale')
+      } finally {
+        client.release()
+      }
+    })
+
+    it('pending x payload-stale, FORGED fingerprint: blocks entry into eligible with zero rollout DML', async () => {
+      const org = crypto.randomUUID()
+      allow(org)
+      await insertForgedPayloadStaleFixture(org, 'pending')
+      const client = await pool.connect()
+      try {
+        await transitionAttendanceCalculationRolloutV1(transactionClient(client), {
+          orgId: org, actorId, correlationId: crypto.randomUUID(), engineVersion: 'w4c3a-control-test',
+          targetState: 'shadow', expectedState: 'legacy', expectedVersion: 1,
+          evidenceManifestSha256: hex64('forged-fingerprint-setup'), evidenceReferences: baseRefs('forged-fingerprint-setup'),
+          reasonCode: 'rollout_transition',
+        })
+        await expect(
+          transitionAttendanceCalculationRolloutV1(transactionClient(client), {
+            orgId: org, actorId, correlationId: crypto.randomUUID(), engineVersion: 'w4c3a-control-test',
+            targetState: 'eligible', expectedState: 'shadow', expectedVersion: 2,
+            evidenceManifestSha256: hex64('forged-fingerprint-blocked'), evidenceReferences: baseRefs('forged-fingerprint-blocked'),
+            reasonCode: 'rollout_transition',
+          }),
+        ).rejects.toMatchObject({ code: 'W4C3A_ROLLOUT_CONTROL_REQUEST_SNAPSHOT_DEFECTIVE' })
+        await expect(pool.query(
+          'SELECT state, version FROM attendance_calculation_rollout_state WHERE org_id = $1',
+          [org],
+        )).resolves.toMatchObject({ rows: [{ state: 'shadow', version: 2 }] })
+      } finally {
+        client.release()
+      }
+    })
+
+    it('RACE L (pending x payload-stale, FORGED fingerprint), 3-actor: a forged-consistent defect committed by an actor with NO rollout-lock obligation, while a protocol-compliant shared-lock holder blocks the transition, is still caught', async () => {
+      const raceOrg = crypto.randomUUID()
+      allow(raceOrg)
+      const setupClient = await pool.connect()
+      try {
+        await transitionAttendanceCalculationRolloutV1(transactionClient(setupClient), {
+          orgId: raceOrg, actorId, correlationId: crypto.randomUUID(), engineVersion: 'w4c3a-control-test',
+          targetState: 'shadow', expectedState: 'legacy', expectedVersion: 1,
+          evidenceManifestSha256: hex64('forged-race-setup'), evidenceReferences: baseRefs('forged-race-setup'),
+          reasonCode: 'rollout_transition',
+        })
+      } finally {
+        setupClient.release()
+      }
+
+      const c1Client = await pool.connect()
+      const transitionClient = await pool.connect()
+      try {
+        await c1Client.query('BEGIN')
+        await acquireAttendanceCalculationRolloutLock(
+          transactionClient(c1Client),
+          parseCanonicalAttendanceRolloutOrgKeyV1(raceOrg),
+          'shared',
+        )
+
+        let transitionSettled = false
+        const transition = transitionAttendanceCalculationRolloutV1(transactionClient(transitionClient), {
+          orgId: raceOrg, actorId, correlationId: crypto.randomUUID(), engineVersion: 'w4c3a-control-test',
+          targetState: 'eligible', expectedState: 'shadow', expectedVersion: 2,
+          evidenceManifestSha256: hex64('forged-race-transition'), evidenceReferences: baseRefs('forged-race-transition'),
+          reasonCode: 'rollout_transition',
+        }).finally(() => { transitionSettled = true })
+        await new Promise((resolve) => setTimeout(resolve, 150))
+        expect(transitionSettled).toBe(false) // T genuinely blocked behind C1's shared hold
+
+        // C2: commits the forged-consistent defect independently, lock-free, plain autocommit.
+        await insertForgedPayloadStaleFixture(raceOrg, 'pending')
+
+        // C1 releases; T can now proceed.
+        await c1Client.query('COMMIT')
+
+        await expect(transition).rejects.toMatchObject({ code: 'W4C3A_ROLLOUT_CONTROL_REQUEST_SNAPSHOT_DEFECTIVE' })
+        expect(transitionSettled).toBe(true)
+        await expect(pool.query(
+          'SELECT state, version FROM attendance_calculation_rollout_state WHERE org_id = $1',
+          [raceOrg],
+        )).resolves.toMatchObject({ rows: [{ state: 'shadow', version: 2 }] })
+      } finally {
+        await c1Client.query('ROLLBACK').catch(() => undefined)
+        c1Client.release()
+        transitionClient.release()
+      }
+    })
+
+    it("DEFENSIVE: a stored payload that does not decode under the writers' own closed-shape validator is treated as inconsistent (payload-stale), not silently skipped", async () => {
+      const org = crypto.randomUUID()
+      allow(org)
+      const requestId = crypto.randomUUID()
+      await pool.query(
+        `INSERT INTO attendance_requests
+           (id, user_id, work_date, request_type, status, org_id, requested_in_at, requested_out_at,
+            reason, metadata, approval_instance_id)
+         VALUES ($1::uuid, $2, '2026-08-01', 'time_correction', 'pending', $3, NULL, NULL, $4, '{}'::jsonb, NULL)`,
+        [requestId, crypto.randomUUID(), org, LIVE_ROW_REASON],
+      )
+      await pool.query(
+        `INSERT INTO attendance_request_calculation_snapshots (
+           org_id, request_id, version, request_type, subject_user_id, payload, payload_fingerprint,
+           attribution_snapshot, created_by)
+         VALUES ($1, $2::uuid, 1, 'time_correction', $3, $4::jsonb, $5, '{"posture":"resolved_v2"}'::jsonb, $6)`,
+        [
+          org,
+          requestId,
+          crypto.randomUUID(),
+          // Malformed: does not carry the writers' exact PAYLOAD_KEYS shape, so
+          // normalizeAttendanceRequestCalculationPayloadV1 (reached through
+          // computeAttendanceRequestPayloadFingerprintV1) throws when re-hashing it.
+          JSON.stringify({ schemaVersion: 1, note: 'not a real payload' }),
+          fixtureLivePayloadFingerprint(),
+          actorId,
+        ],
+      )
+      const client = await pool.connect()
+      try {
+        const report = await readAttendanceRequestSnapshotDefectReportV1(transactionClient(client), org)
+        expect(report.totalDefectiveRequests).toBe(1)
+        expectSingleCellDefect(report.byCell, 'pendingPayloadStale')
       } finally {
         client.release()
       }
@@ -1652,6 +2196,7 @@ describeIfDatabase('W4C-3a core-only rollout control (real PostgreSQL)', () => {
             incompleteOperations: 0,
             unresolvedReviews: 0,
             defectiveRequestSnapshots: 0,
+            defectiveRequestSnapshotsByCell: emptyDefectCounts(),
           },
           references: baseRefs('event-shape'),
         })


### PR DESCRIPTION
## HOLD — Draft, do not merge

This PR is **Draft** and **HOLD**. Refs #4775, refs #4556. Does not transition any environment, change any flag, touch staging, run any soak, use production/customer data, send any external notification, or change the state of issue #4556 in any way. Whether issue #4775 stays open or gets ended is an owner call, not this PR's to decide — one sub-question below is explicitly left for the owner.

## Task

Issue #4775: complete the W4C-5 §3 request-snapshot precondition's closed 8-cell set
(`docs/development/attendance-issue-4556-w4c5-transition-safety-amendment-20260804.md:96-98`):
`(pending | reversible) x (missing | unsupported | payload-stale | reversal-incomplete)`.
#4773 (merged, `360181796`) implemented 2 of 8 cells (`pending x {missing, unsupported}`) and
self-reported the other 6 as a verified, not-guessed gap. This PR closes the remaining 6.

## What changed

`packages/core-backend/src/attendance/w4c3a-rollout-control.ts`:
- `countDefectivePendingRequestSnapshots` → `classifyAttendanceRequestSnapshotDefectsV1`, which
  scans both buckets in one query and evaluates all 4 defect kinds per row.
- **`reversible` bucket = `status='approved' AND request_type='leave'`** — mechanically verified,
  not assumed: `plugins/plugin-attendance/index.cjs:34091` sets
  `approvedLeave = requestRow.status === 'approved' && requestRow.request_type === 'leave'`;
  `:34174` hard-blocks every other already-resolved request from reaching cancellation. A full-repo
  sweep (raw SQL + Kysely `updateTable`, `packages/`, `plugins/`, `scripts/`, `apps/`) found exactly
  one writer of `attendance_requests.status = 'cancelled'` anywhere in the codebase
  (`index.cjs:34244`, inside that same adapter).
- **`payload-stale`** recomputes the live row's EXACT payload fingerprint — core columns
  (`work_date`/`requested_in_at`/`requested_out_at`/`reason`) plus `metadata`-derived
  `minutes`/`leaveTypeCode`/`outdoorPunch` via a new
  `extractAttendanceRequestPayloadMetadataFieldsV1` (in `w4c3b-request-snapshots.ts`) — rather than
  a subset. That function is a documented field-for-field port of the plugin's
  `buildRequestSnapshotPayloadFieldsFromDraft` (`index.cjs:24414-24445`); its own doc comment names
  the one known weak spot (a second, non-shared copy — see "Weak spots" below).
- **`reversal-incomplete`** detects the torn state (`approval_instances.status='cancelled'` while
  the request row is still `pending`/`approved`) the shared cancel adapter's single transaction
  (`index.cjs` `executeRequestCancel`, `:34208`-`:34250`) would leave if its atomicity were ever
  violated by something outside normal PostgreSQL commit/rollback.
- New `readAttendanceRequestSnapshotDefectReportV1` — the §5-sanctioned read-only reporter shape —
  exposes the exact per-cell counts through the SAME classification function the transition gate
  enforces, so tests assert exact single-cell shapes instead of only the shared error code.
- Evidence: `preconditionCounts.defectiveRequestSnapshotsByCell` (8 named counts, values-free)
  added alongside the pre-existing `defectiveRequestSnapshots` scalar (kept as "distinct defective
  requests," its original meaning — a row landing in more than one cell is a
  `(request, defect)`-pair count in `byCell`, never double-counted in the scalar).

## Per-cell falsification (neuter → only that cell's leg reds)

| Cell | Falsifying leg(s) | Confirmed exclusive |
|---|---|---|
| `pendingMissing` / `reversibleMissing` | `defective pending request-snapshot predicate` test, RACE E, RACE H | yes — neutering the missing-branch reds exactly those 5 legs (0 others) |
| `pendingUnsupported` / `reversibleUnsupported` | `blocks... unsupported` test, `reversible x unsupported` (2), RACE I | yes — reds exactly those 4 legs |
| `pendingPayloadStale` / `reversiblePayloadStale` | `pending x payload-stale` (2), `reversible x payload-stale` (2), RACE F, RACE J | yes — reds exactly those 6 legs |
| `pendingReversalIncomplete` / `reversibleReversalIncomplete` | `pending x reversal-incomplete` (2), `reversible x reversal-incomplete` (2), RACE G, RACE K | yes — reds exactly those 6 legs |
| bucket scope (`reversible` closed to leave) | `bucket-exclusion control` test | yes — widening the WHERE clause to `status='approved'` (dropping the type restriction) reds exactly that 1 leg |

Each mutation was applied with `if (false && ...)` (or, for the bucket-scope leg, dropping the
`AND request_type = 'leave'` clause), the full 55-test file re-run, the failing-test set recorded,
then reverted — confirmed zero residual diff (`git diff --stat` empty) before moving to the next.
Commit-before-mutate was followed: the implementation was committed first (`a487b5580`), all
mutation cycles ran against that committed baseline.

## Real two-connection races (gate 6 shape extended)

RACE F-K extend the existing RACE A-E 3-actor shape (`plugins/`-style lock-free writer commits a
defect WHILE a protocol-compliant shared-lock holder blocks the transition; the test proves genuine
blocking — `transitionSettled === false` after 150ms — before letting the writer commit) to all 6
new cells. All 6 pass; each asserts `rejects.toMatchObject({ code: 'W4C3A_ROLLOUT_CONTROL_REQUEST_SNAPSHOT_DEFECTIVE' })`
and zero rollout-state DML.

## `reversible x reversal-incomplete` atomicity — owner-scope question, answered but not self-ratified

Per the issue's own framing, whether every calculation-affecting request type's reversal path is
provably atomic is an owner-scope contract question, not something this PR self-decides. The
mechanical facts this PR verified (file:line, not assumed):

- **The set of types requiring an atomicity proof is the singleton `{leave}`.** Verified by the
  same hard-block that defines the bucket (`index.cjs:34174`): no other calculation-affecting type
  can ever reach a post-approval cancel path, so no other type has a "reversal" to be atomic or not.
- **`leave`'s one reversal flow is atomic.** `index.cjs` `executeRequestCancel` (`:34132`-`:34309`)
  performs the calculation append (`port.appendApprovedLeaveCancellationCalculation`), the approval
  revoke, the `attendance_requests.status` UPDATE, and the leave-balance reversal sequentially on
  the SAME `trx` parameter with no intermediate commit — ordinary PostgreSQL transaction semantics
  make a partial-commit of that sequence impossible. The one function inside it that can review-out
  (`appendApprovedLeaveCancellationCalculationV1`,
  `w4c3b-approved-leave-cancellation.ts`) returns EARLY, before any INSERT, on every review path —
  so it never leaves a partial calculation row either.
- **Consequence: `reversalIncomplete` is a data-consistency detector, not a claim the flow is
  non-atomic.** Under today's code, the torn state it queries for should never occur via the normal
  application path — it exists to catch an out-of-band write (legacy direct SQL, a future bug, a
  manual DB fix) that bypassed the adapter, mirroring this file's own existing discipline for the
  `attendance_result_operations` "claimed" state (queries the reachable proxy, not the provably
  unreachable state directly).

**What is left for the owner, not decided here**: whether this "defense-in-depth against an
out-of-band write" framing is what lock §3 bullet 6 actually intends for a type with a
provably-atomic single flow, or whether the owner wants a different predicate shape for that case.
This PR does not resolve that judgment call — it implements the predicate + falsifying leg either
way (the leg fires the moment the torn state exists in the DB, regardless of how it got there), and
reports the mechanical facts above so the owner's decision isn't blocked on re-deriving them.

## Weak spots (self-reported)

1. `extractAttendanceRequestPayloadMetadataFieldsV1` is a second, non-shared copy of the plugin's
   `buildRequestSnapshotPayloadFieldsFromDraft` field-extraction logic (both read
   `attendance_requests.metadata`, both must classify `minutes`/`leaveTypeCode`/`outdoorPunch`
   identically). Refactoring the plugin's live creation/edit paths to call through the port instead
   of keeping their own copy was judged out of this predicate-completion issue's scope — higher
   blast radius than the control-boundary predicate the issue asked to close. 15 unit tests pin the
   new copy's own behavior against every branch of the mirrored function; nothing can mechanically
   cross-check it against the CJS plugin closure. A future edit to either copy without the other is
   an undetected drift risk.
2. The read-only reporter (`readAttendanceRequestSnapshotDefectReportV1`) does not open its own
   transaction — it runs whatever locking the caller's connection is already under. Test callers use
   a bare `client.connect()` with no `BEGIN`, so each `FOR UPDATE` is its own implicit
   single-statement transaction (lock released immediately); documented in the function's own doc
   comment, not hidden.
3. Fixed during mutation self-check, not found by an external reviewer: the pre-existing
   `unsupported_snapshot` test fixture's arbitrary `hex64(...)` fingerprint was not congruent with
   the live row, so under the new payload-stale check it also tripped `pendingPayloadStale` — same
   error code, so the ORIGINAL test's assertion still passed, but its exclusivity as a mutation
   discriminator was silently diluted. Retired that fixture kind; the replacement computes a
   live-matching fingerprint.

## Checks (local, real PostgreSQL — `postgresql://postgres@localhost:5432/postgres`)

**~~Superseded by owner-review round 2 below~~ — the two items this section originally reported as
"did not run" / "unrelated to this PR" were re-run in round 2 against a properly migrated local DB
and both passed. The root cause was this session's own incomplete local migration state, not a
pre-existing repo issue — see the round-2 "Local verification" subsection for the corrected numbers
(60/60 for the rollout-control suite after round 2's additions, 145/145 across the 5-file regression
set including the two files below). Left the original text unedited beneath this note for the
record, per this repo's retraction discipline (don't silently rewrite a wrong prior claim).**

- `tests/integration/attendance-w4c3a-rollout-control.db.test.ts` via
  `vitest --config vitest.integration.config.ts`: **55/55 passed** (includes the pre-existing 2-cell
  tests, unchanged in behavior, plus 6 new cells x {reporter leg, blocking leg} = 12, 2 controls,
  RACE F-K = 6, evidence-shape + atomicity tests unchanged).
- `src/attendance/__tests__/w4c3b-request-snapshot-metadata-fields.test.ts` (new, pure unit):
  **15/15 passed**.
- `src/attendance/__tests__/w4c3a-rollout-control-inventory.test.ts` (gate 9 repository inventory,
  unchanged behavior — probed, not assumed, since this PR adds new reads against
  `attendance_requests`/`approval_instances`): **7/7 passed**.
- `scripts/ops/attendance-w4c0-dml-inventory-collector.test.mjs` (§8.4/§12.7 write-DML census —
  probed for the same reason; PR #4773 needed a pin bump for ITS new reads, this PR's new reads did
  not trip it since they are SELECT-only against tables outside the closed record/calculation-read
  census families): **58/58 passed**. No pin bump needed.
- `tsc --noEmit`: clean, 3 separate runs across the commit sequence.
- ~~Did not run `attendance-w4c3b-approved-leave-cancellation.db.test.ts` /
  `attendance-w4c3b-request-operation-routes.db.test.ts` to green locally — both fail on THIS
  sandbox's `metasheet_test` database for reasons unrelated to this PR (missing tables from a full
  migration chain this session didn't run / a pre-existing migration-tracking mismatch on a shared
  local DB), reproduced identically on a fresh worktree at the pre-PR baseline (`fbb54db3c`) with
  zero code changes applied. Did not touch that shared DB further. CI's dedicated migration step
  will exercise these for real; flagging so this isn't silently presented as "verified."~~ —
  **RETRACTED (round 2): both run green (5/5, 24/24) once the actual CI migration chain
  (`MIGRATION_EXCLUDE` list + `db:migrate`) was applied locally. The prior round's framing ("for
  reasons unrelated to this PR" / "pre-existing migration-tracking mismatch") was this session's own
  unverified guess, not a confirmed root cause — the real cause was simply that this session never
  ran the migrations CI runs. Correcting rather than leaving it standing.**
- `plugin-tests.yml` unchanged — `attendance-w4c3a-rollout-control.db.test.ts` was already in its
  explicit test list; no new file needed adding, no s6a pin recalculation triggered.

## Weakest link, if I had to name one

The payload-stale predicate's correctness rests on `extractAttendanceRequestPayloadMetadataFieldsV1`
staying behaviorally identical to the plugin's own field extraction forever, with no shared code
path enforcing that congruence — see weak spot 1. A silent edit to one copy without the other would
not be caught by any test in this PR or (as far as I found) elsewhere in the suite.

Refs #4775, refs #4556.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>


---

## Owner-review round 2 (2026-08-05): P2 fix — forged `payload_fingerprint` bypassed `payload-stale`

Owner review of the above found **1 P2**: the `payload-stale` classifier read only the STORED
`payload_fingerprint` column and compared it to the recomputed LIVE fingerprint. It never
independently re-hashed the STORED `payload` column. The database only shape-checks that column
(`chk_arcs_payload_fp: payload_fingerprint ~ '^[0-9a-f]{64}$'` — regex only, no content binding).
A row whose stored `payload` is genuinely stale but whose stored `payload_fingerprint` was written
to equal the LIVE fingerprint (bug, direct write outside the append boundary, or tampering) would
satisfy the old one-sided compare and be classified healthy — the exact "payload changed, live-value
fingerprint" bypass the owner named.

### Reproduction (bypass proven before touching the fix)

New fixture `insertForgedPayloadStaleFixture` (`attendance-w4c3a-rollout-control.db.test.ts`)
constructs the adversarial row directly: stored `payload` re-hashes to `fixtureStaleSnapshotFingerprint()`
(genuinely stale — different `reason` than the live row), but stored `payload_fingerprint` is set to
`fixtureLivePayloadFingerprint()` (forged to equal what the LIVE row would hash to). No writer in
this codebase ever produces this shape (`appendAttendanceRequestEditSnapshotV1` always hashes the
exact object it is about to store) — it simulates a write outside the append boundary.

Following commit-before-mutate: the fix was committed first (`b8ff97179`), then the fixed predicate
was reverted in-place to the pre-#4780 one-sided compare (`liveFingerprint !== storedFingerprint`
only, no re-hash of the stored payload) and the 5 new P2 tests re-run against that reverted code.
All 5 failed — the clearest failure is the transition-blocking leg, which shows the rollout actually
completing past the stale row:

```
AssertionError: promise resolved "{ …(3) }" instead of rejecting
- Expected
+ Received
- [Error: rejected promise]
+ Object {
+   "batchId": null,
+   "orgId": "408a7b00-cb2f-4e72-aa07-729d9f9e0343",
+   "state": "eligible",
+ }
```
(the reporter-level tests failed identically: `totalDefectiveRequests` `0` instead of `1`.)

The mutation was then restored via `git checkout -- <file>` against the committed baseline (safe —
committed first, nothing uncommitted was at risk) and the full 60-test file re-confirmed green.

### Fix: three-way hash join, same hash function the writers use — TWO real conjuncts, not three

`hash(storedPayload) == storedFingerprint == hash(livePayload)`: any inequality (including the
stored payload failing to decode under the writers' own closed-shape validator at all) is
`payload-stale`. New helper `computeStoredRequestSnapshotPayloadFingerprintV1` re-selects the
`payload` column (dropped as "unused" in an earlier self-review commit on this same branch, before
this recompute existed — re-added, this time actually read) and re-hashes it via the exact same
`computeAttendanceRequestPayloadFingerprintV1` the writers call, wrapped in try/catch so a payload
that cannot even be re-hashed (proof of inconsistency on its own) is treated as `payload-stale`
rather than crashing the classifier.

**First draft had a third, redundant conjunct — caught by adversarial self-review before this went
back to the owner, not left in.** The first commit (`b8ff97179`) wrote the join as
`recomputedStoredFingerprint !== null && recomputedStoredFingerprint === storedFingerprint &&
storedFingerprint === liveFingerprint`. `storedFingerprint` is always a string
(`String(x ?? '')`), so `null === storedFingerprint` is already `false` without the explicit
`!== null` guard — no input could make that guard the deciding conjunct. A follow-up commit
(`e94231a84`) collapsed it to the two conjuncts that actually discriminate something:
`storedPayloadSelfConsistent = recomputedStoredFingerprint === storedFingerprint` and
`storedMatchesLive = storedFingerprint === liveFingerprint`; `!storedPayloadSelfConsistent ||
!storedMatchesLive` ⇒ `payload-stale`. Kept as two named booleans specifically so each can be
mutation-tested independently (see below) instead of asserting "three-way" and only ever exercising
two conjuncts in practice.

**Hash-function parity with the write side (verified by code trace, not assumed):**
both snapshot-append call sites (`appendAttendanceRequestCreateSnapshotV1` at
`w4c3b-request-snapshots.ts:~1058` and `appendAttendanceRequestEditSnapshotV1` at `:~1196`) build
`payloadFingerprint: computeAttendanceRequestPayloadFingerprintV1(payload)` from the SAME `payload`
object then passed to the shared `insertSnapshotRow` helper (`:935-958`), which writes that exact
object (via `JSON.stringify`) into the `payload` column. The classifier's re-hash of the stored
`payload` column calls that identical function, so a genuinely-consistent writer-produced row
always satisfies the join (confirmed empirically: the pre-existing "healthy-reversible" positive
control and the pre-existing honest-stale fixture — both untouched by this fix — still pass
unchanged, see below).

### Four-leg proof matrix (all real PostgreSQL, `metasheet_test`, fully migrated)

| Leg | Stored payload | Stored fingerprint | Pre-fix verdict | Post-fix verdict |
|---|---|---|---|---|
| Forged bypass (new) | stale (`STALE_SNAPSHOT_REASON`) | forged = hash(live payload) | **not flagged (bypass)** | `pendingPayloadStale`/`reversiblePayloadStale`, transition BLOCKED, zero rollout DML |
| Positive control (pre-existing, re-verified) | matches live | hash(that same payload) = hash(live) | not flagged | not flagged, promotion succeeds (`healthy-reversible` test, line ~1739) |
| Honest stale (pre-existing, re-verified) | stale | hash(that same stale payload) — internally consistent, just old | flagged | flagged (`pending x payload-stale` / `reversible x payload-stale` CASES) |
| Malformed payload (new, defensive) | does not decode under `PAYLOAD_KEYS` shape | hash(live payload) | n/a (column was unread) | flagged `pendingPayloadStale` — re-hash throws, caught, returns `null`; `null` then fails `storedPayloadSelfConsistent` (conjunct 1) the same way any other mismatch does — NOT via a dedicated null-check branch (removed, see below) |

New tests added (`describe('W4C-5 §3 owner-review P2 (PR #4780): forged payload_fingerprint cannot
bypass payload-stale')`):
1. reporter-level, `pending` bucket — flags exactly `pendingPayloadStale`.
2. reporter-level, `reversible` bucket — flags exactly `reversiblePayloadStale`.
3. transition-blocking — `BLOCKED` with zero rollout DML (state/version unchanged).
4. RACE L — 3-actor real-concurrency variant reusing gate 6's shape (shared-lock holder genuinely
   blocks the transition for 150ms, an unlocked writer commits the forged row mid-block, release,
   transition still catches it) — extends, does not replace, RACE F/J (the existing honest-stale
   races for the same two cells).
5. Defensive: stored payload that fails to decode under the writers' shape validator.

**Other 6 cells / RACE A-K unaffected (regression check, not just non-interference by construction):**
full file re-run after the fix: **60/60 passed** (55 pre-existing + 5 new). The fix only changes the
internal `payload-stale` branch; `missing`/`unsupported`/`reversal-incomplete` code paths and their
15 existing tests + RACE A-E, G, H, I, K are untouched lines, re-run green.

### Per-conjunct mutation — proves WHICH conjunct catches WHICH scenario

Door-level mutation (the whole-block revert above) only proves "something in here is load-bearing."
The prior round's bar for this PR was per-cell exclusivity (a table showing which leg falsifies which
cell and no other); this section holds the P2 fix to the same bar, per conjunct.

The whole-block mutation above (revert to the pre-#4780 one-sided compare) only shows the new code as
a unit is load-bearing. Two further legs, each isolating one of the two real conjuncts named above,
committed-then-mutated-then-reverted against `e94231a84` the same way:

- **Neuter conjunct 1 only** (`storedPayloadSelfConsistent = true`, conjunct 2 untouched): re-ran the
  full 60-test file. Exactly the 5 new P2 tests went red (all 4 forged-fingerprint legs + the
  malformed-payload defensive leg) — **55 passed, 5 failed**. Every pre-existing test, including the
  honest-stale legs (`pending x payload-stale`, `reversible x payload-stale`, RACE F, RACE J) and all
  15 missing/unsupported/reversal-incomplete tests, stayed green. This is the proof that conjunct 1
  is what catches BOTH the forged-fingerprint bypass AND the malformed/non-decodable payload — and
  that it does so without touching the honest-stale detection at all.
- **Neuter conjunct 2 only** (`storedMatchesLive = true`, conjunct 1 untouched): re-ran the full file.
  Exactly the 6 pre-existing honest-stale legs went red (`pending x payload-stale` reporter + blocking,
  `reversible x payload-stale` reporter + blocking, RACE F, RACE J) — **54 passed, 6 failed**. All 5
  new P2 (forged-fingerprint + malformed) tests stayed GREEN — still caught, because a forged
  fingerprint or an undecodable payload both still fail conjunct 1 regardless of conjunct 2. This is
  the proof that fixing the forgery bypass did not fold into "detect forgery only" at the cost of
  weakening the pre-existing honest-stale detection — the two conjuncts are independently necessary
  and their failure sets do not overlap.

Both legs restored via `git checkout -- <file>` against the `e94231a84` baseline (committed first);
`tsc --noEmit` clean and the full 145-test 5-file regression set re-confirmed green after each
restore.

### Local verification (real PostgreSQL, brand-new local DB this session)

- Fresh `metasheet_test` database, migrated exactly as CI's "Run DB migrations" step does
  (`MIGRATION_EXCLUDE` list copied verbatim from `plugin-tests.yml`, `pnpm --filter
  @metasheet/core-backend db:migrate`) — this session's earlier draft of these checks (before the
  full migration chain was run) had reported two sibling files as "not run, unrelated DB gap"; with
  the full chain applied those two now also run and pass (see below), closing that earlier gap.
- `tsc --noEmit -p packages/core-backend/tsconfig.json`: clean, 3 runs across this round's 3 commits
  (initial three-conjunct fix, doc-comment placement self-fix, two-conjunct simplification).
- `eslint` on both changed files: 0 errors (test file is lint-ignored by pattern, as it already was).
- `tests/integration/attendance-w4c3a-rollout-control.db.test.ts`: **60/60 passed**.
- `tests/integration/attendance-w4c3a-import-rollback.db.test.ts`: **49/49 passed** (unchanged,
  shares no code path but exercises the same migration).
- `tests/integration/attendance-w4c3b-request-snapshots.db.test.ts`: **7/7 passed**.
- `tests/integration/attendance-w4c3b-request-operation-routes.db.test.ts`: **24/24 passed**.
- `tests/integration/attendance-w4c3b-approved-leave-cancellation.db.test.ts`: **5/5 passed**.
- Total across the 5-file regression set: **145/145 passed**.
- `plugin-tests.yml` unchanged — this PR does not touch that workflow file; the changed test file
  was already in its explicit list from the prior round, so no s6a pin recalculation applies.

### Self-review catches during this round (not owner-found)

1. The commit that added `computeStoredRequestSnapshotPayloadFingerprintV1` first inserted it (with
   its own JSDoc) directly between `classifyAttendanceRequestSnapshotDefectsV1`'s existing large doc
   comment and that function's declaration — two stacked block comments, which orphans the first one
   from its target (only the nearer comment reads as attached to a declaration in standard doc
   tooling). Fixed in a follow-up commit (`d3e927e01`, move-only diff, retested 60/60 + 145/145 after
   the move).
2. The first draft's three-conjunct join carried a redundant `!== null` guard that no test — and no
   adversarial input — could ever make the deciding conjunct (see "TWO real conjuncts" above). Caught
   by re-deriving what each conjunct actually contributes before writing the per-conjunct mutation
   legs, not by a test failing. Fixed in `e94231a84` (behavior-preserving; retested 60/60 + 145/145)
   before this went back to the owner. This is the same over-claim shape the owner's round-1 P2
   caught (asserting a check does something no test proves) — catching it on a second, self-inflicted
   instance in the SAME round is the concrete reason the per-conjunct mutation legs above exist,
   rather than stopping at the whole-block mutation.

### SWEEP v4 (self-scan)

Grepped every `^+` line in this round's diff for absolute/count words (`always`/`never`/`all`/`every`/
`only`/`exact(ly)`/`zero`/`cannot`/`guarantee`/`100%`/`complete`) and rechecked each against code:
- "the pre-#4780 check only compared... it never re-hashed the stored payload column itself" —
  verified against the pre-fix code (only `computeAttendanceRequestPayloadFingerprintV1(livePayload)`
  vs `snapshotRow.payloadFingerprint`; `payload` column was not even selected, confirmed via the
  branch's own prior commit `f7affe694`/current `db0f8b282` "drop unused payload column").
- "`chk_arcs_payload_fp` only shape-checks that column" — verified against the migration
  (`zzzz20260725120000_...ts:~641`: `CHECK (payload_fingerprint ~ '^[0-9a-f]{64}$')`, no other
  constraint on that column).
- "Every writer-produced row... always re-hashes successfully" — traced, not fuzzed: both
  `normalizeAttendanceRequestCalculationPayloadV1` call sites (create-from-row and edit) produce a
  frozen exact-`PAYLOAD_KEYS` object; `insertSnapshotRow` writes it via
  `JSON.stringify`/`::jsonb`, a lossless round trip for this payload's value types (strings, null,
  a small nested object, no `Date`s) — no test in this PR round exhaustively fuzzes that round trip
  beyond the existing fixtures and the malformed-payload negative leg above; flagged as a weak spot
  below rather than left as an unqualified claim.
- Full-text reread (not just `^+` lines) of the entire `payload-stale` doc-comment paragraph and the
  entire `classifyAttendanceRequestSnapshotDefectsV1`/reporter block after the placement fix — no
  stale pre-fix wording left describing the one-sided compare.

### Weak spots (self-reported, this round)

1. "Writer-produced rows always re-hash successfully" (used in the helper's own doc comment as the
   contrast case for "only out-of-boundary writes can fail here") is verified by code trace through
   `normalize→JSON.stringify→jsonb→read-back`, not by a dedicated round-trip fuzz test. If Postgres's
   `jsonb` normalization ever changed key ordering or numeric representation in a way `hasExactKeys`
   or a downstream comparison cared about, this claim would need re-verification — `hasExactKeys`
   checks membership/count, not order or value identity beyond `===`, so this is believed robust but
   not separately pinned by a test in this round. This specific claim is NOT the thing the
   malformed-payload test's discriminator proves (that test proves conjunct 1 / the try-catch, per
   the per-conjunct mutation above, not this round-trip-always-succeeds claim) — flagging the
   distinction explicitly after the redundant-conjunct self-catch above made clear how easy it is to
   let a doc-comment claim outrun what a test actually pins.
2. Same weak spot as the prior round (unchanged by this fix): `extractAttendanceRequestPayloadMetadataFieldsV1`
   remains a second, non-shared copy of the plugin's field-extraction logic.
3. The malformed-payload defensive leg is the only test exercising the `catch → null` path in
   `computeStoredRequestSnapshotPayloadFingerprintV1`; it uses one specific malformed shape (missing
   required keys). A payload that decodes but has a wrong *value* type in a field —
   `normalizeAttendanceRequestCalculationPayloadV1` doesn't currently have a field where a
   type-confused value both parses AND produces a *different* canonical JSON than intended, since
   every `PAYLOAD_KEYS` field has an explicit type check that rejects wrong types outright — is not
   separately exercised, because no such case exists to construct today.
4. ~~The try/catch itself has no dedicated mutation leg~~ — added and run: removing the `catch` block
   (`computeStoredRequestSnapshotPayloadFingerprintV1` re-throws instead of returning `null`) makes
   the DEFENSIVE test fail with an uncaught `AttendanceRequestSnapshotError
   (W4C3B_REQUEST_SNAPSHOT_INPUT_INVALID)` propagating out of `classifyAttendanceRequestSnapshotDefectsV1`
   instead of returning a graceful defect report — confirming the try/catch is load-bearing (turns a
   crash into a correctly-classified `payload-stale`, not merely "believed to"). Restored via `git
   checkout --` against the committed baseline; 60/60 re-confirmed green.

### CI (this round's push)

Rebased onto current `origin/main` (`06e456c52`) before starting this round — the prior head predated
several main commits and (per the task brief) had gone red on the Node 18/20 matrix; the rebase is
part of what this round verifies, not assumed fixed. Pushed 3 commits this round:
`b8ff97179` (three-conjunct fix + repro/mutation), `d3e927e01` (doc-comment placement self-fix),
`e94231a84` (drop the redundant conjunct + per-conjunct mutation). `test (18.x)` / `test (20.x)` (the `plugin-tests.yml` matrix job running the full attendance real-DB
integration list, including this file) — CI status for head `e94231a84` reported at the bottom of this
PR; not assumed from the local Node 20 runs above, which do not cover the 18.x leg at all.

Branch: `claude/w4c5-request-snapshot-8cell-20260805`. Still **Draft/HOLD** — this round fixes the P2,
does not merge, arm, or change scope beyond the owner's specific finding.

Refs #4775, refs #4556.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
