### PR TITLE
docs(stock-prep): window pre-check — the customer needs TWO K3 records, not one

### DIFF
--- a/docs/development/stock-preparation-k3wise-development-and-verification-20260805.md
+++ b/docs/development/stock-preparation-k3wise-development-and-verification-20260805.md
@@ -89,6 +89,33 @@ replay ⇒ K3_WISE_REPLAY_DISABLED(先于任何读/run 记录/adapter 创建)
 用了中文虚拟目录,在**窗口之前**协商改用 ASCII 别名站点/虚拟目录,或升 owner 裁决。
 **窗口不可重试**,而这条会在 adapter 构造期即失败(读、写都进不去),故必须前置排除。
 
+### 步 0-b(新增,窗口**开始前**做):客户侧必须建**两条** K3 external-system 记录
+
+**结论**:一条 K3 记录**不能**同时承担「list 读」与「armed 写」。窗口需要两条,指向**同一台**
+物理 K3(相同 baseUrl):
+
+| 记录 | config | 用途 |
+|---|---|---|
+| K3-read(**不选 profile**) | 带 list 读配置(`readMode:'list'`、`readList*` 一族) | 步骤 1 的 read-smoke;B4 契约描述的就是它 |
+| K3-write(**选 `material-k3wise-customer-profile-v1`**) | profile 武装,save-only + maxApplyRows=3 | C6 dry-run→apply 的写目标 |
+
+**为什么不能合并成一条**(实测,非推断):`#4769` 把 `readMode`、`readListBodyKey`、
+`readListFields`、`readListOrderBy`、`topField`、`pageIndexField`、`pageSizeField`、
+`maxListLimit`、`readListBodyTemplate` 全部列为 profile 的 forbidden overlay key。在一条
+armed 记录上,这些键在 adapter 归一化时被**静默剥除**(实测全部变 `undefined`,且 `readPath`
+被钉成 `/K3API/Material/GetDetail`)。
+
+**连首方冻结预设也被剥**:`read-smoke` 的 `k3wise.material-list.v1` 自带 `readConfigOverlay`
+(含完整 list 形状),`applyReadSmokePresetOverlay` 会把它并上去 —— 但随后的 adapter 归一化
+仍然剥掉。也就是说这道加固**不区分「操作员覆盖」与「首方预设覆盖」**。方向是 fail-closed
+(安全的那一侧),但后果是:**armed 记录做不了 list read-smoke**。
+
+**操作**:窗口前确认客户环境里这两条记录都已建、baseUrl 相同、且 K3-read 那条**没有**选
+profile。窗口不可重试,而这条会在步骤 1(read-smoke)当场失败。
+
+> 关联未决项:B4 绑定的 systemId 只能是 pipeline 的 source/target 之一(`#4769` 关系检查),
+> 而 K3-read 记录在「非 K3 source」的管道里两者都不是 —— 该冲突的处置见 §7.2。
+
 1. **只读预检**:`POST /api/integration/external-systems/<k3SystemId>/read-smoke`
    (preset `k3wise.material-list.v1`)⇒ 期望 values-free 证据:业务成功、行数 ≤10、零泄漏键。
 2. **建/核窗口 pipeline**:`POST /api/integration/pipelines` —— target=K3 系统(config 已含


### PR DESCRIPTION
Found while implementing #4768's source swap. It is a **product constraint the runbook never stated**, and it fails at step 1 of a window that cannot be retried — so it belongs in the pre-checks regardless of how the open #4768 decisions go.

## One K3 record cannot serve both roles

| record | config | used for |
|---|---|---|
| **K3-read** — *no profile* | list read config (`readMode:'list'`, `readList*`) | step 1 read-smoke; B4's contract describes this one |
| **K3-write** — *profile armed* | save-only + `maxApplyRows=3` | the C6 write target |

Both must point at the **same physical K3** (same `baseUrl`).

## Why — measured, not reasoned

#4769 lists every list-read key as a profile forbidden-overlay key. On an armed record the adapter's normalization **silently strips all of them** — I confirmed each comes back `undefined`, with `readPath` pinned to `/K3API/Material/GetDetail`.

**The first-party preset is stripped too.** `read-smoke`'s `k3wise.material-list.v1` carries its own `readConfigOverlay` with the full list shape, and `applyReadSmokePresetOverlay` does merge it on — but the adapter normalization that runs afterwards removes it anyway.

So the hardening does **not** distinguish an operator-supplied overlay from a frozen first-party preset. The direction is fail-closed, which is the safe side, but the consequence is concrete: **an armed record cannot perform a LIST read-smoke.**

## Why a pre-check and not a fix

It fails at step 1 of a **non-retryable** window, so it must be excluded beforehand. And relaxing the strip would reopen the class that took eleven review rounds to close — the wrong trade for an operational convenience.

## Related, not settled here

§7.2 records the open conflict: B4's `systemId` must be one of the pipeline's two endpoints, and with a non-K3 source the K3-read record is neither. That disposition is an owner decision; this note only documents the two-record requirement it rests on.

Docs only, one file. Heading order verified after insertion (步 0 → 步 0-b → numbered runbook) — the first attempt put 0-b ahead of 0, the same slip as §7.3/§7.2 in #4777.