### PR TITLE
fix(core-backend): env-gate the BPMN workflow-engine minute poller (default off) [HOLD]

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -673,6 +673,44 @@ jobs:
           : "${DATABASE_URL:?DATABASE_URL is required for after-sales integration}"
           pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/after-sales-plugin.install.test.ts --reporter=dot
 
+      # #4783 owner review P1-1/P1-2: real-Postgres proof that (a) the timer poller's
+      # write gate leaves ZERO bpmn_timer_jobs rows when disabled (not just "the mock
+      # wasn't called") and a positive control that it still writes when enabled, and
+      # (b) the WAITING -> LOCKED claim is race-safe across two independent
+      # `BPMNWorkflowEngine` instances (the real `routes/workflow.ts` +
+      # `routes/workflow-designer.ts` topology) via a CONSTRUCTED concurrent claim, not
+      # sequential reasoning. Excluded from the no-DB default job (vitest.config.ts) so
+      # describeIfDatabase cannot skip-green it, and wired here as a WHOLE FILE.
+      - name: Run BPMN timer job write-and-claim safety
+        if: matrix.node-version == '20.x'
+        env:
+          DATABASE_URL: postgresql://postgres@localhost:5432/metasheet_test
+        run: |
+          : "${DATABASE_URL:?DATABASE_URL is required for BPMN timer job write-and-claim safety}"
+          pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run \
+            tests/integration/bpmn-timer-job-write-and-claim-safety.db.test.ts \
+            --reporter=verbose
+
+      # #4783 owner review batch 2: batch 1's write gate (createTimerJob throwing before its
+      # own INSERT) was too late — startProcess() had already persisted the
+      # bpmn_process_instances (ACTIVE) + activity rows by the time that throw fired, leaving
+      # permanent ACTIVE residue with an OPEN incident (owner-reproduced at 243db11f1). This
+      # proves startProcess()'s entry gate leaves FOUR real zeros (process/activity/incident/
+      # timer rows) via the REAL HTTP surface (POST /api/workflow/deploy + POST
+      # /api/workflow/start/:key) against a real booted MetaSheetServer, plus a positive
+      # control that a timer-free process still starts normally with the poller off.
+      # Excluded from the no-DB default job (vitest.config.ts) so describeIfDatabase cannot
+      # skip-green it, and wired here as a WHOLE FILE.
+      - name: Run BPMN startProcess poller-disabled zero-residue
+        if: matrix.node-version == '20.x'
+        env:
+          DATABASE_URL: postgresql://postgres@localhost:5432/metasheet_test
+        run: |
+          : "${DATABASE_URL:?DATABASE_URL is required for BPMN startProcess poller-disabled zero-residue}"
+          pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run \
+            tests/integration/bpmn-poller-disabled-startprocess-zero-residue.db.test.ts \
+            --reporter=verbose
+
       # Real-APP-ASSEMBLY guard. Route-level unit tests mount ONE router in isolation, so every path they
       # exercise belongs to that router — mount order and the SCOPE of middleware added inside a router are
       # structurally invisible to them. This boots the real MetaSheetServer and asserts that no router

--- a/packages/core-backend/.env.example
+++ b/packages/core-backend/.env.example
@@ -12,6 +12,15 @@ KANBAN_DB=false
 # Enable workflow engine
 WORKFLOW_ENABLED=false
 
+# Enable the BPMN workflow engine's node-cron minute poller (default OFF — refs
+# #4770/#4779, owner ruling 2026-08-05). This is a DIFFERENT flag from WORKFLOW_ENABLED
+# above: WORKFLOW_ENABLED only controls whether the frontend shows workflow UI, and does
+# NOT gate the backend engine or this poller. Independent of DISABLE_WORKFLOW too (that
+# one opts the WHOLE engine out; this one only gates the per-minute bpmn_timer_jobs poll).
+# Only set this to true if a deployment actually has live BPMN process instances with
+# date/duration timer events waiting to fire.
+ENABLE_BPMN_TIMER_POLLER=false
+
 # Enable ViewService unification layer (baseline stub)
 # This is a baseline abstraction for incremental ViewService rollout
 FEATURE_VIEWSERVICE_UNIFICATION=false

--- a/packages/core-backend/src/index.ts
+++ b/packages/core-backend/src/index.ts
@@ -258,8 +258,8 @@ import { canaryRoutes } from './routes/canary-routes'
 import { CanaryRouter } from './canary/CanaryRouter'
 import { createCanaryInterceptor } from './canary/CanaryInterceptor'
 import { PluginRuntimeSecurityService } from './security/plugin-runtime-security-service'
-import workflowRouter from './routes/workflow'
-import workflowDesignerRouter from './routes/workflow-designer'
+import workflowRouter, { shutdownWorkflowEngine } from './routes/workflow'
+import workflowDesignerRouter, { shutdownWorkflowDesignerEngine } from './routes/workflow-designer'
 import plmWorkbenchRouter from './routes/plm-workbench'
 import plmEmbedRouter from './routes/plm-embed'
 import plmEmbedDiscussionWriteRouter from './routes/plm-embed-discussion'
@@ -2694,6 +2694,34 @@ export class MetaSheetServer {
         stopAttendanceScheduler()
       } catch (err) {
         this.logger.warn(`Attendance scheduler shutdown failed: ${err instanceof Error ? err.message : String(err)}`)
+      }
+    })())
+
+    // BPMN workflow engine's `node-cron` minute poller (see `routes/workflow.ts` /
+    // `BPMNWorkflowEngine.shutdown()`; env-gated OFF by default via
+    // `ENABLE_BPMN_TIMER_POLLER`, see `bpmnTimerPollerConfig.ts`): previously only stopped
+    // on a real OS SIGTERM, never reached from a direct `.stop()` call (the common path in
+    // tests) — leaving it to keep querying the DB pool this same `stop()` closes just
+    // above. `BPMNWorkflowEngine.shutdown()` itself awaits any in-flight poller tick,
+    // which is the actual race-closing guarantee this needs.
+    shutdownTasks.push((async () => {
+      try {
+        await shutdownWorkflowEngine()
+      } catch (err) {
+        this.logger.warn(`Workflow engine shutdown failed: ${err instanceof Error ? err.message : String(err)}`)
+      }
+    })())
+
+    // Symmetric to the above (P3-a, #4783 review): `routes/workflow-designer.ts`
+    // constructs its OWN independent `BPMNWorkflowEngine` instance (lazily, on first
+    // designer-route call), which the shutdown call above does not reach. Same
+    // env-gated poller, same in-flight-tick drain guarantee via
+    // `BPMNWorkflowEngine.shutdown()`, and equally safe to call when never initialized.
+    shutdownTasks.push((async () => {
+      try {
+        await shutdownWorkflowDesignerEngine()
+      } catch (err) {
+        this.logger.warn(`Workflow designer engine shutdown failed: ${err instanceof Error ? err.message : String(err)}`)
       }
     })())
 

--- a/packages/core-backend/src/routes/workflow-designer.ts
+++ b/packages/core-backend/src/routes/workflow-designer.ts
@@ -54,6 +54,20 @@ const designer = new WorkflowDesigner()
 const workflowEngine = new BPMNWorkflowEngine(buildBpmnWorkflowEngineOptionsFromServerConfig())
 let workflowEngineReady: Promise<void> | null = null
 
+/**
+ * Stops this module's OWN `workflowEngine` singleton (P3-a, #4783 review). This is a
+ * SEPARATE `BPMNWorkflowEngine` instance from `routes/workflow.ts`'s — each module
+ * constructs its own (this one lazily, on first designer-route call via
+ * `ensureWorkflowEngineReady`) — so `routes/workflow.ts`'s `shutdownWorkflowEngine()`
+ * does not reach this instance's minute poller (only started when
+ * `ENABLE_BPMN_TIMER_POLLER=true`; see `bpmnTimerPollerConfig.ts`) or in-flight tick.
+ * Safe to call even when this instance was never initialized — `shutdown()` only touches
+ * its own already-populated maps.
+ */
+export async function shutdownWorkflowDesignerEngine(): Promise<void> {
+  await workflowEngine.shutdown()
+}
+
 interface WorkflowHubTeamViewConflictBuilder {
   columns(columns: string[]): {
     doUpdateSet(values: Record<string, unknown>): unknown

--- a/packages/core-backend/src/routes/workflow.ts
+++ b/packages/core-backend/src/routes/workflow.ts
@@ -35,6 +35,21 @@ if (process.env.DISABLE_WORKFLOW === 'true') {
   })
 }
 
+/**
+ * Stops this module's `workflowEngine` singleton (including its `node-cron` minute
+ * poller, when `ENABLE_BPMN_TIMER_POLLER=true` — see `BPMNWorkflowEngine.shutdown()`).
+ * Safe to call even when the engine was never initialized (e.g. `DISABLE_WORKFLOW=true`,
+ * or `initialize()` is still in flight — `shutdown()` only touches its own
+ * already-populated maps).
+ *
+ * Previously this only ran via the `process.on('SIGTERM', ...)` listener below, which
+ * fires on a REAL OS signal — `MetaSheetServer.stop()` (used directly in tests, with no
+ * signal involved) never reached it. `index.ts`'s `stop()` now calls this explicitly.
+ */
+export async function shutdownWorkflowEngine(): Promise<void> {
+  await workflowEngine.shutdown()
+}
+
 // Type definitions for database rows
 interface ProcessDefinition {
   id: string;
@@ -776,7 +791,7 @@ router.get(
 // Graceful shutdown
 process.on('SIGTERM', async () => {
   logger.info('SIGTERM received, shutting down workflow engine...')
-  await workflowEngine.shutdown()
+  await shutdownWorkflowEngine()
 })
 
 export default router

--- a/packages/core-backend/src/workflow/BPMNWorkflowEngine.ts
+++ b/packages/core-backend/src/workflow/BPMNWorkflowEngine.ts
@@ -17,6 +17,7 @@ import {
 } from '../guards/egress-dispatcher'
 import { defaultEgressPolicy, type EgressPolicy } from '../guards/egress-guard'
 import { createPinnedHttpsJsonTransport } from '../guards/egress-pinned-transport'
+import { BpmnTimerPollerDisabledError, isBpmnTimerPollerEnabled } from './bpmnTimerPollerConfig'
 
 // Types for optional dependencies
 type ScheduledTaskType = { start: () => void; stop: () => void }
@@ -136,6 +137,12 @@ function httpTaskError(reason: string): Error {
   return new Error(`BPMN_HTTP_EGRESS_DENIED: ${reason}`)
 }
 
+// `startTimerProcessor`'s minute poller is registered under this key in `timerJobs` so
+// `shutdown()`'s existing sweep also stops it. Never a prefix of a real `instanceId`
+// (UUID-shaped), so `cleanupInstanceTimers`'s `key.startsWith(instanceId)` check can never
+// match and delete it early.
+const TIMER_PROCESSOR_JOB_KEY = '__timer_processor_poller__'
+
 // Dynamic imports for optional dependencies
 let xml2js: Xml2JsModule | null = null
 let cron: CronModule | null = null
@@ -217,6 +224,9 @@ export class BPMNWorkflowEngine extends EventEmitter {
   private timerJobs: Map<string, ScheduledTaskType>
   private messageSubscriptions: Map<string, Set<string>>
   private signalSubscriptions: Map<string, Set<string>>
+  // Tracks the currently in-flight `startTimerProcessor` tick (or a resolved promise when
+  // none is running/the poller is env-gated off) so `shutdown()` can drain it before returning.
+  private timerProcessorTick: Promise<void> = Promise.resolve()
   private httpTaskEgressPolicy: EgressPolicy
   private httpTaskResolveAddresses: EgressAddressResolver
   private httpTaskTransport: PinnedEgressTransport
@@ -341,6 +351,38 @@ export class BPMNWorkflowEngine extends EventEmitter {
         throw new Error(`Process definition not found: ${processKey}`)
       }
 
+      // Parse definition BEFORE any write (moved up from below the `bpmn_process_instances`
+      // insert that used to follow it — owner P1 batch 2, #4783 review; see the fail-closed
+      // check immediately below for why this ordering matters).
+      const parsed = this.processDefinitions.get(definition.id) || await this.parseBPMN(definition.bpmn_xml)
+
+      // Fail-closed at the ENTRY, zero writes (owner P1 batch 2, #4783 review; batch 1's
+      // write gate on `createTimerJob` below was too late — by the time that throw fires,
+      // this method has ALREADY persisted the `bpmn_process_instances` row plus whatever
+      // `executeStartEvents`/`executeActivity` wrote on the way to the timer, and this
+      // method's own catch block only logs and rethrows, never marks anything terminated.
+      // Net result pre-fix: the instance is stuck `ACTIVE` forever with an `OPEN` incident
+      // nobody resolves — owner-reproduced at `243db11f1`).
+      //
+      // Owner's ruling (#4783 review, batch 2): fail-closed BEFORE any write if
+      // date/duration-timer reachability can be determined at the entry; only fall back to
+      // wrapping the whole start in one atomically-rolled-back transaction if it cannot.
+      // It CAN be determined here, exactly (not just conservatively): `createTimerJob`'s
+      // 'date'/'duration' branch has exactly ONE call site in this class
+      // (`handleIntermediateEvent`), itself reachable only from `executeActivity`'s
+      // `'intermediateCatchEvent'` case, whose `activityDef.properties.timerDefinition`
+      // `findActivity` extracts from this EXACT SAME static parse. So: if this scan finds
+      // no date/duration `bpmn:timerEventDefinition` anywhere in the definition, no
+      // execution path through it — whichever gateway branches get taken, whatever the
+      // input variables, however deep in a `bpmn:subProcess` — can EVER reach that throw,
+      // this call or any future one, for this process definition. (It may still reject a
+      // start whose timer branch would never actually have executed at runtime — that
+      // conservative direction is the correct tradeoff for a zero-write gate over a false
+      // "safe to start.") No transaction-wrap fallback is needed.
+      if (!isBpmnTimerPollerEnabled() && this.definitionHasPollerDependentTimer(parsed)) {
+        throw new BpmnTimerPollerDisabledError()
+      }
+
       // Create process instance
       await db
         .insertInto('bpmn_process_instances')
@@ -371,9 +413,6 @@ export class BPMNWorkflowEngine extends EventEmitter {
 
       // Cache the instance
       this.runningInstances.set(instanceId, instance)
-
-      // Parse definition
-      const parsed = this.processDefinitions.get(definition.id) || await this.parseBPMN(definition.bpmn_xml)
 
       // Execute start events
       await this.executeStartEvents(instanceId, parsed)
@@ -1450,6 +1489,17 @@ export class BPMNWorkflowEngine extends EventEmitter {
         return
     }
 
+    // Fail-closed (owner P1-1, #4783 review — see `bpmnTimerPollerConfig.ts` for the full
+    // rationale): a 'date'/'duration' `bpmn_timer_jobs` row is only ever read back by
+    // `startTimerProcessor`'s poller. Persisting it while that poller is env-gated off
+    // would silently create a timer that can never fire — an orphan created AFTER this
+    // deploy's poller-off state took effect, not a paused pre-existing one. Reject the
+    // write instead of the caller (deploy/start/task-complete/message/signal — any path
+    // that can drive process execution into a timer event) getting a silent no-op.
+    if (!isBpmnTimerPollerEnabled()) {
+      throw new BpmnTimerPollerDisabledError()
+    }
+
     await db
       .insertInto('bpmn_timer_jobs')
       .values({
@@ -1520,42 +1570,88 @@ export class BPMNWorkflowEngine extends EventEmitter {
   }
 
   private startTimerProcessor(): void {
+    // Env-gate (owner ruling 2026-08-05, Plan B — refs #4770/#4779): this poller is a
+    // dormant-subsystem side-effect channel (unconditional per-minute `bpmn_timer_jobs`
+    // query against the shared `db` pool) and stays OFF unless explicitly enabled. See
+    // `bpmnTimerPollerConfig.ts` for why this is its own dedicated flag rather than reusing
+    // `DISABLE_WORKFLOW` (opt-OUT, default-on, gates the whole engine) or `WORKFLOW_ENABLED`
+    // (frontend-display-only, never read by engine lifecycle code).
+    if (!isBpmnTimerPollerEnabled()) {
+      this.logger.info('BPMN timer poller disabled by default (set ENABLE_BPMN_TIMER_POLLER=true to enable)')
+      return
+    }
+
     if (!cron) {
       this.logger.warn('node-cron not available, timer processor not started')
       return
     }
 
-    // Process due timer jobs every minute
-    cron.schedule('* * * * *', async () => {
-      const dueJobs = await db
-        .selectFrom('bpmn_timer_jobs')
-        .selectAll()
-        .where('state', '=', 'WAITING')
-        .where('due_date', '<=', sql<Date>`now()`)
-        .execute()
+    // Process due timer jobs every minute. The returned task is stored under
+    // `TIMER_PROCESSOR_JOB_KEY` in `timerJobs` (previously discarded here, which meant
+    // nothing could ever `.stop()` it — it kept firing against the shared `db` pool for
+    // the life of the process, independent of any single engine instance's own
+    // `shutdown()`). Each tick's own promise is stashed in `timerProcessorTick` so
+    // `shutdown()` can await it — `.stop()` only prevents FUTURE dispatches, it does not
+    // abort a callback already executing. The try/catch mirrors `startHealthCheck`'s own
+    // guard: without it, a tick whose connection is severed mid-query (e.g. a test's
+    // scratch-database teardown) rejects with no catch anywhere in the call chain, which
+    // surfaces as an unhandled rejection instead of a caught, logged, values-free error.
+    const pollerJob = cron.schedule('* * * * *', async () => {
+      this.timerProcessorTick = (async () => {
+        try {
+          const dueJobs = await db
+            .selectFrom('bpmn_timer_jobs')
+            .selectAll()
+            .where('state', '=', 'WAITING')
+            .where('due_date', '<=', sql<Date>`now()`)
+            .execute()
 
-      for (const job of dueJobs) {
-        const timerJob: BPMNTimerJob = {
-          id: job.id,
-          process_instance_id: job.process_instance_id,
-          activity_id: job.activity_instance_id || '',
-          retries: 0
+          for (const job of dueJobs) {
+            const timerJob: BPMNTimerJob = {
+              id: job.id,
+              process_instance_id: job.process_instance_id,
+              activity_id: job.activity_instance_id || '',
+              retries: 0
+            }
+            await this.processTimerJob(timerJob)
+          }
+        } catch (error: unknown) {
+          this.logger.error('Timer job processor tick failed:', error as Error)
         }
-        await this.processTimerJob(timerJob)
-      }
+      })()
+      await this.timerProcessorTick
     })
+    this.timerJobs.set(TIMER_PROCESSOR_JOB_KEY, pollerJob)
   }
 
   private async processTimerJob(job: BPMNTimerJob): Promise<void> {
     try {
-      // Lock job
-      await db
+      // Atomic WAITING -> LOCKED claim (owner P1-2, #4783 review — same class as #4774's
+      // SKIP LOCKED finding). The poller's own `SELECT ... WHERE state = 'WAITING'`
+      // (startTimerProcessor) is not itself a lock: `routes/workflow.ts` and
+      // `routes/workflow-designer.ts` each construct their OWN independent
+      // `BPMNWorkflowEngine` instance, both sharing the same `db` pool, and both run this
+      // same poller when `ENABLE_BPMN_TIMER_POLLER=true` — two overlapping ticks (across
+      // instances, or across minutes of the same instance) can each read the identical
+      // WAITING row before either writes. Gating the UPDATE itself on `state = 'WAITING'`
+      // and checking `numUpdatedRows` makes the UPDATE the single atomic claim point:
+      // whichever call's UPDATE commits first flips the row's state away from 'WAITING',
+      // so every other concurrent claimant's WHERE clause matches zero rows.
+      const claim = await db
         .updateTable('bpmn_timer_jobs')
         .set({
           state: 'LOCKED'
         })
         .where('id', '=', job.id)
-        .execute()
+        .where('state', '=', 'WAITING')
+        .executeTakeFirst()
+
+      if (!claim || Number(claim.numUpdatedRows) === 0) {
+        // Lost the race: another claimant already owns this job. Exactly one caller must
+        // win the claim — backing off silently here is that invariant holding, not an
+        // error condition, so this returns without touching FAILED/metrics.
+        return
+      }
 
       // Fire timer
       await this.fireTimer(job.process_instance_id, job.activity_id)
@@ -1804,6 +1900,28 @@ export class BPMNWorkflowEngine extends EventEmitter {
   }
 
   /**
+   * Owner P1 batch 2 (#4783 review): true iff this parsed process definition contains ANY
+   * 'date' or 'duration' `bpmn:timerEventDefinition` anywhere in its element tree, at any
+   * nesting depth (`bpmn:subProcess` included — `findElementsByType`'s unconditional
+   * recursive `Object.values` walk does not stop at any particular element type),
+   * regardless of whether that element is actually reachable from the start event under
+   * any given set of gateway conditions/variables. Used by `startProcess()` to fail-closed
+   * BEFORE any write when the poller is disabled — see that method's own comment for the
+   * soundness argument.
+   *
+   * Deliberately does NOT flag 'cycle' timers: those use a separate in-memory
+   * `scheduleRecurringTimer`/`cron.schedule` path (see `createTimerJob`) that never
+   * touches `bpmn_timer_jobs` and is unaffected by the poller being off.
+   */
+  private definitionHasPollerDependentTimer(parsed: BPMNParsedDefinition): boolean {
+    const process = parsed.definitions?.process?.[0]
+    if (!process) return false
+
+    const timerDefs = this.findElementsByType(process, 'bpmn:timerEventDefinition')
+    return timerDefs.some((timerDef) => Boolean(timerDef?.['bpmn:timeDuration'] || timerDef?.['bpmn:timeDate']))
+  }
+
+  /**
    * Get latest version of process definition
    */
   private async getLatestVersion(key: string, _tenantId?: string): Promise<number> {
@@ -1938,10 +2056,18 @@ export class BPMNWorkflowEngine extends EventEmitter {
   async shutdown(): Promise<void> {
     this.logger.info('Shutting down BPMN Workflow Engine')
 
-    // Stop all timer jobs
+    // Stop all timer jobs — including the minute poller registered by
+    // `startTimerProcessor` under `TIMER_PROCESSOR_JOB_KEY` (only present when the poller
+    // was env-gated on; harmless no-op loop otherwise).
     for (const job of this.timerJobs.values()) {
       job.stop()
     }
+
+    // Drain whatever poller tick was already in flight the moment `.stop()` ran above —
+    // `.stop()` only prevents FUTURE dispatches, it does not abort a callback already
+    // executing. Waiting here keeps a caller that closes the DB pool / drops the database
+    // right after `shutdown()` resolves from racing that tick's own in-flight query.
+    await this.timerProcessorTick.catch(() => undefined)
 
     // Clear caches
     this.processDefinitions.clear()

--- a/packages/core-backend/src/workflow/__tests__/BPMNWorkflowEngine.timerPoller.test.ts
+++ b/packages/core-backend/src/workflow/__tests__/BPMNWorkflowEngine.timerPoller.test.ts
@@ -1,0 +1,156 @@
+/**
+ * #4770/#4779 owner ruling 2026-08-05 (Plan B): `BPMNWorkflowEngine`'s minute
+ * timer poller (`startTimerProcessor`) must stay OFF by default and, when
+ * enabled, must be trackable/stoppable via `shutdown()`.
+ *
+ * These are the discriminating legs for both halves of that ruling, at the
+ * lowest level that exercises the real production code path (no mocking of
+ * `BPMNWorkflowEngine` itself — only `node-cron`'s `schedule` call is spied
+ * on, via the SAME module-cache singleton `BPMNWorkflowEngine.ts` itself
+ * `require()`s, so a spy installed here observes calls made from inside the
+ * class):
+ *
+ *  - env unset (or any value other than the exact literal `'true'`) ⇒
+ *    `cron.schedule` is never called and nothing is registered under
+ *    `TIMER_PROCESSOR_JOB_KEY` in `timerJobs` — i.e. no poll query is ever
+ *    scheduled, not just "the query itself is skipped once running".
+ *  - env `=== 'true'` ⇒ `cron.schedule('* * * * *', ...)` is called exactly
+ *    once, the returned task is tracked in `timerJobs`, and `shutdown()`
+ *    calls `.stop()` on it.
+ *
+ * `cron.schedule` is stubbed to return a fake stoppable task (never a real
+ * `setInterval`-backed one) so this suite never schedules an actual
+ * repeating timer against a real (or absent) database connection. Because
+ * that stub's callback never runs, it cannot exercise `shutdown()`'s
+ * `timerProcessorTick` drain — the two tests at the bottom of this file
+ * cover that separately, by seeding `timerProcessorTick` directly.
+ */
+import { createRequire } from 'node:module'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { BPMNWorkflowEngine } from '../BPMNWorkflowEngine'
+import { BPMN_TIMER_POLLER_ENABLED_ENV } from '../bpmnTimerPollerConfig'
+
+const require = createRequire(import.meta.url)
+// The EXACT same require-cache singleton `BPMNWorkflowEngine.ts` itself binds to
+// its module-scope `cron` variable via `require('node-cron')` — Node's module
+// cache is keyed by resolved path, so this is not a separate copy.
+const cronModule = require('node-cron') as { schedule: (...args: unknown[]) => unknown }
+
+const TIMER_PROCESSOR_JOB_KEY = '__timer_processor_poller__'
+
+type EngineInternals = {
+  startTimerProcessor: () => void
+  timerJobs: Map<string, { start: () => void; stop: () => void }>
+  timerProcessorTick: Promise<void>
+}
+
+function internals(engine: BPMNWorkflowEngine): EngineInternals {
+  return engine as unknown as EngineInternals
+}
+
+describe('BPMNWorkflowEngine timer poller env-gate (#4770/#4779 Plan B)', () => {
+  let scheduleSpy: ReturnType<typeof vi.spyOn>
+  let fakeTask: { start: ReturnType<typeof vi.fn>; stop: ReturnType<typeof vi.fn> }
+  let originalEnv: string | undefined
+
+  beforeEach(() => {
+    originalEnv = process.env[BPMN_TIMER_POLLER_ENABLED_ENV]
+    delete process.env[BPMN_TIMER_POLLER_ENABLED_ENV]
+    fakeTask = { start: vi.fn(), stop: vi.fn() }
+    scheduleSpy = vi.spyOn(cronModule, 'schedule').mockReturnValue(fakeTask)
+  })
+
+  afterEach(() => {
+    scheduleSpy.mockRestore()
+    if (originalEnv === undefined) delete process.env[BPMN_TIMER_POLLER_ENABLED_ENV]
+    else process.env[BPMN_TIMER_POLLER_ENABLED_ENV] = originalEnv
+  })
+
+  it('does not call cron.schedule and does not register a poller job when the env flag is unset', () => {
+    const engine = new BPMNWorkflowEngine()
+    internals(engine).startTimerProcessor()
+
+    expect(scheduleSpy).not.toHaveBeenCalled()
+    expect(internals(engine).timerJobs.has(TIMER_PROCESSOR_JOB_KEY)).toBe(false)
+    expect(internals(engine).timerJobs.size).toBe(0)
+  })
+
+  it('does not call cron.schedule when the env flag is set to a near-miss value ("TRUE", not exact "true")', () => {
+    process.env[BPMN_TIMER_POLLER_ENABLED_ENV] = 'TRUE'
+    const engine = new BPMNWorkflowEngine()
+    internals(engine).startTimerProcessor()
+
+    expect(scheduleSpy).not.toHaveBeenCalled()
+    expect(internals(engine).timerJobs.size).toBe(0)
+  })
+
+  it('calls cron.schedule("* * * * *", fn) exactly once and tracks the returned task when the env flag is "true"', () => {
+    process.env[BPMN_TIMER_POLLER_ENABLED_ENV] = 'true'
+    const engine = new BPMNWorkflowEngine()
+    internals(engine).startTimerProcessor()
+
+    expect(scheduleSpy).toHaveBeenCalledTimes(1)
+    expect(scheduleSpy).toHaveBeenCalledWith('* * * * *', expect.any(Function))
+    expect(internals(engine).timerJobs.get(TIMER_PROCESSOR_JOB_KEY)).toBe(fakeTask)
+    expect(internals(engine).timerJobs.size).toBe(1)
+  })
+
+  it('shutdown() stops the tracked poller task when the poller was enabled', async () => {
+    process.env[BPMN_TIMER_POLLER_ENABLED_ENV] = 'true'
+    const engine = new BPMNWorkflowEngine()
+    internals(engine).startTimerProcessor()
+
+    expect(fakeTask.stop).not.toHaveBeenCalled()
+    await engine.shutdown()
+    expect(fakeTask.stop).toHaveBeenCalledTimes(1)
+  })
+
+  it('shutdown() is a no-op-safe call when the poller was never started (env unset)', async () => {
+    const engine = new BPMNWorkflowEngine()
+    internals(engine).startTimerProcessor()
+
+    await expect(engine.shutdown()).resolves.toBeUndefined()
+    expect(fakeTask.stop).not.toHaveBeenCalled()
+  })
+
+  // The two tests above stub `cron.schedule` to a task whose callback never runs, so they
+  // cannot exercise `shutdown()`'s `await this.timerProcessorTick.catch(() => undefined)`
+  // drain line — `timerProcessorTick` stays the constructor's initial `Promise.resolve()`
+  // regardless of whether that line exists. These two tests seed `timerProcessorTick`
+  // directly (bypassing `startTimerProcessor`/`cron` entirely) to assert the drain's actual
+  // observable behavior: shutdown() must not resolve before an in-flight tick does, and a
+  // REJECTED tick (a real production case — the tick body's own try/catch prevents this in
+  // practice, but the drain must not depend on that) must not make shutdown() reject either.
+  it('shutdown() awaits an in-flight timerProcessorTick before resolving (ordering, not just "was called")', async () => {
+    const engine = new BPMNWorkflowEngine()
+    const order: string[] = []
+    let releaseTick!: () => void
+    const pendingTick = new Promise<void>((resolve) => {
+      releaseTick = () => {
+        order.push('tick')
+        resolve()
+      }
+    })
+    internals(engine).timerProcessorTick = pendingTick
+
+    const shutdownDone = engine.shutdown().then(() => {
+      order.push('shutdown')
+    })
+
+    // Give shutdown() a chance to resolve prematurely if it does NOT await the tick.
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(order).toEqual([])
+
+    releaseTick()
+    await shutdownDone
+    expect(order).toEqual(['tick', 'shutdown'])
+  })
+
+  it('shutdown() resolves (not rejects) even when timerProcessorTick is a rejected promise', async () => {
+    const engine = new BPMNWorkflowEngine()
+    internals(engine).timerProcessorTick = Promise.reject(new Error('tick failed mid-flight'))
+
+    await expect(engine.shutdown()).resolves.toBeUndefined()
+  })
+})

--- a/packages/core-backend/src/workflow/__tests__/BPMNWorkflowEngine.timerWriteGate.test.ts
+++ b/packages/core-backend/src/workflow/__tests__/BPMNWorkflowEngine.timerWriteGate.test.ts
@@ -1,0 +1,187 @@
+/**
+ * #4783 owner review, P1-1 (2026-08-05): env-gating the POLLER off was not enough. The
+ * poller only ever READS `bpmn_timer_jobs`; `BPMNWorkflowEngine.createTimerJob()` (the
+ * only `INSERT INTO bpmn_timer_jobs` site in this codebase, see
+ * `bpmnTimerPollerConfig.ts`) still unconditionally persisted a `state: 'WAITING'` row
+ * for every `'date'`/`'duration'` timer regardless of the flag — and that write is
+ * reachable from any authenticated user via `/api/workflow/start/:key`, task-complete,
+ * message, and signal delivery (see `routes/workflow.ts`). "Current WAITING count is 0,
+ * therefore safe to merge" does not survive a single new call after merge: the poller
+ * being off means that new row can never be read back — a freshly-created orphan, not a
+ * paused pre-existing one.
+ *
+ * These are the discriminating legs for the fix: `createTimerJob` must throw
+ * `BpmnTimerPollerDisabledError` (a dedicated, values-free `code`) BEFORE the insert when
+ * the poller is disabled, for `'date'`/`'duration'` timers only — `'cycle'` timers never
+ * reach `bpmn_timer_jobs` at all (`scheduleRecurringTimer` is a separate, in-memory
+ * `cron.schedule` path) and must stay completely unaffected by this gate.
+ *
+ * `db` is module-mocked (not a real Postgres connection — this is a unit-level gate
+ * test) so the negative legs can assert `insertInto` is NEVER CALLED, not merely that its
+ * result is unawaited, and the positive-control leg proves the insert still happens
+ * (values-free assertion per repo doctrine "assert not happening always needs a positive
+ * control"). The real-DB counterpart of this same invariant (zero rows land in a REAL
+ * `bpmn_timer_jobs` table when disabled) lives in
+ * `tests/integration/bpmn-timer-job-write-and-claim-safety.db.test.ts` alongside the
+ * P1-2 atomic-claim proof.
+ */
+import { createRequire } from 'node:module'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { BPMNWorkflowEngine } from '../BPMNWorkflowEngine'
+import { BPMN_TIMER_POLLER_ENABLED_ENV, BpmnTimerPollerDisabledError } from '../bpmnTimerPollerConfig'
+
+const insertValuesMock = vi.fn().mockReturnThis()
+const insertExecuteMock = vi.fn().mockResolvedValue(undefined)
+const insertIntoMock = vi.fn().mockReturnValue({
+  values: insertValuesMock,
+  execute: insertExecuteMock,
+})
+
+vi.mock('../../db/db', () => ({
+  db: {
+    insertInto: (...args: unknown[]) => insertIntoMock(...args),
+  },
+}))
+
+const require = createRequire(import.meta.url)
+// Same require-cache singleton `BPMNWorkflowEngine.ts` itself binds to at module load —
+// spying here observes (and, for 'cycle', neutralizes) the class's own `cron.schedule`
+// call without creating a real repeating interval.
+const cronModule = require('node-cron') as { schedule: (...args: unknown[]) => unknown }
+
+type EngineInternals = {
+  createTimerJob: (
+    instanceId: string,
+    activityId: string,
+    timerDef: { type: 'date' | 'duration' | 'cycle'; value: string; activityId: string }
+  ) => Promise<void>
+}
+
+function internals(engine: InstanceType<typeof BPMNWorkflowEngine>): EngineInternals {
+  return engine as unknown as EngineInternals
+}
+
+describe('BPMNWorkflowEngine.createTimerJob write-gate (#4783 P1-1)', () => {
+  let originalEnv: string | undefined
+  let scheduleSpy: ReturnType<typeof vi.spyOn>
+  let fakeCronTask: { start: ReturnType<typeof vi.fn>; stop: ReturnType<typeof vi.fn> }
+
+  beforeEach(() => {
+    originalEnv = process.env[BPMN_TIMER_POLLER_ENABLED_ENV]
+    delete process.env[BPMN_TIMER_POLLER_ENABLED_ENV]
+    insertIntoMock.mockClear()
+    insertValuesMock.mockClear()
+    insertExecuteMock.mockClear()
+    fakeCronTask = { start: vi.fn(), stop: vi.fn() }
+    scheduleSpy = vi.spyOn(cronModule, 'schedule').mockReturnValue(fakeCronTask)
+  })
+
+  afterEach(() => {
+    scheduleSpy.mockRestore()
+    if (originalEnv === undefined) delete process.env[BPMN_TIMER_POLLER_ENABLED_ENV]
+    else process.env[BPMN_TIMER_POLLER_ENABLED_ENV] = originalEnv
+  })
+
+  it('poller disabled (env unset) + "date" timer: throws BpmnTimerPollerDisabledError, insertInto never called', async () => {
+    const engine = new BPMNWorkflowEngine()
+    await expect(
+      internals(engine).createTimerJob('inst-1', 'act-1', {
+        type: 'date',
+        value: '2026-01-01T00:00:00Z',
+        activityId: 'act-1',
+      })
+    ).rejects.toBeInstanceOf(BpmnTimerPollerDisabledError)
+    expect(insertIntoMock).not.toHaveBeenCalled()
+  })
+
+  it('poller disabled + "date" timer: rejection carries the exact dedicated code, no other message shape', async () => {
+    const engine = new BPMNWorkflowEngine()
+    await expect(
+      internals(engine).createTimerJob('inst-1', 'act-1', {
+        type: 'date',
+        value: '2026-01-01T00:00:00Z',
+        activityId: 'act-1',
+      })
+    ).rejects.toMatchObject({
+      name: 'BpmnTimerPollerDisabledError',
+      code: 'BPMN_TIMER_POLLER_DISABLED',
+      message: 'BPMN_TIMER_POLLER_DISABLED',
+    })
+  })
+
+  it('poller disabled + "duration" timer: throws BpmnTimerPollerDisabledError, insertInto never called', async () => {
+    const engine = new BPMNWorkflowEngine()
+    await expect(
+      internals(engine).createTimerJob('inst-1', 'act-1', {
+        type: 'duration',
+        value: 'PT5M',
+        activityId: 'act-1',
+      })
+    ).rejects.toBeInstanceOf(BpmnTimerPollerDisabledError)
+    expect(insertIntoMock).not.toHaveBeenCalled()
+  })
+
+  it('poller disabled + env set to a near-miss value ("TRUE"): still throws — enum-strict, not truthy coercion', async () => {
+    process.env[BPMN_TIMER_POLLER_ENABLED_ENV] = 'TRUE'
+    const engine = new BPMNWorkflowEngine()
+    await expect(
+      internals(engine).createTimerJob('inst-1', 'act-1', {
+        type: 'date',
+        value: '2026-01-01T00:00:00Z',
+        activityId: 'act-1',
+      })
+    ).rejects.toBeInstanceOf(BpmnTimerPollerDisabledError)
+    expect(insertIntoMock).not.toHaveBeenCalled()
+  })
+
+  it('poller disabled + "cycle" timer: NOT affected — never throws, never touches bpmn_timer_jobs, schedules via cron instead', async () => {
+    const engine = new BPMNWorkflowEngine()
+    await expect(
+      internals(engine).createTimerJob('inst-1', 'act-1', {
+        type: 'cycle',
+        value: '*/5 * * * *',
+        activityId: 'act-1',
+      })
+    ).resolves.toBeUndefined()
+    expect(insertIntoMock).not.toHaveBeenCalled()
+    expect(scheduleSpy).toHaveBeenCalledTimes(1)
+    expect(scheduleSpy).toHaveBeenCalledWith('*/5 * * * *', expect.any(Function))
+  })
+
+  it('poller ENABLED ("true") + "date" timer: does not throw, insertInto called once with state WAITING (positive control)', async () => {
+    process.env[BPMN_TIMER_POLLER_ENABLED_ENV] = 'true'
+    const engine = new BPMNWorkflowEngine()
+    await expect(
+      internals(engine).createTimerJob('inst-1', 'act-1', {
+        type: 'date',
+        value: '2026-01-01T00:00:00Z',
+        activityId: 'act-1',
+      })
+    ).resolves.toBeUndefined()
+
+    expect(insertIntoMock).toHaveBeenCalledTimes(1)
+    expect(insertIntoMock).toHaveBeenCalledWith('bpmn_timer_jobs')
+    expect(insertValuesMock).toHaveBeenCalledTimes(1)
+    const insertedValues = insertValuesMock.mock.calls[0][0] as Record<string, unknown>
+    expect(insertedValues.state).toBe('WAITING')
+    expect(insertedValues.process_instance_id).toBe('inst-1')
+    expect(insertExecuteMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('poller ENABLED ("true") + "duration" timer: does not throw, insertInto called once with state WAITING', async () => {
+    process.env[BPMN_TIMER_POLLER_ENABLED_ENV] = 'true'
+    const engine = new BPMNWorkflowEngine()
+    await expect(
+      internals(engine).createTimerJob('inst-1', 'act-1', {
+        type: 'duration',
+        value: 'PT5M',
+        activityId: 'act-1',
+      })
+    ).resolves.toBeUndefined()
+
+    expect(insertIntoMock).toHaveBeenCalledTimes(1)
+    const insertedValues = insertValuesMock.mock.calls[0][0] as Record<string, unknown>
+    expect(insertedValues.state).toBe('WAITING')
+  })
+})

--- a/packages/core-backend/src/workflow/__tests__/bpmnTimerPollerConfig.test.ts
+++ b/packages/core-backend/src/workflow/__tests__/bpmnTimerPollerConfig.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from 'vitest'
+
+import {
+  BPMN_TIMER_POLLER_ENABLED_ENV,
+  isBpmnTimerPollerEnabled,
+} from '../bpmnTimerPollerConfig'
+
+describe('BPMN timer poller env-gate config (#4770/#4779 Plan B)', () => {
+  test('env key is the documented ENABLE_BPMN_TIMER_POLLER name', () => {
+    expect(BPMN_TIMER_POLLER_ENABLED_ENV).toBe('ENABLE_BPMN_TIMER_POLLER')
+  })
+
+  test('unset env defaults to disabled', () => {
+    expect(isBpmnTimerPollerEnabled({})).toBe(false)
+  })
+
+  test.each([
+    'false',
+    'FALSE',
+    'TRUE',
+    'True',
+    '1',
+    'yes',
+    'on',
+    '',
+    ' true',
+    'true ',
+  ])('rejects every non-exact value %j as disabled (strict equality, not truthy coercion)', (value) => {
+    expect(isBpmnTimerPollerEnabled({ [BPMN_TIMER_POLLER_ENABLED_ENV]: value })).toBe(false)
+  })
+
+  test('only the exact literal "true" enables the poller', () => {
+    expect(isBpmnTimerPollerEnabled({ [BPMN_TIMER_POLLER_ENABLED_ENV]: 'true' })).toBe(true)
+  })
+
+  test('is indifferent to unrelated env keys (no accidental coupling to DISABLE_WORKFLOW or WORKFLOW_ENABLED)', () => {
+    expect(isBpmnTimerPollerEnabled({ DISABLE_WORKFLOW: 'true', WORKFLOW_ENABLED: 'true' })).toBe(false)
+    expect(isBpmnTimerPollerEnabled({
+      DISABLE_WORKFLOW: 'false',
+      WORKFLOW_ENABLED: 'false',
+      [BPMN_TIMER_POLLER_ENABLED_ENV]: 'true',
+    })).toBe(true)
+  })
+
+  test('defaults to reading process.env when no override is supplied', () => {
+    const original = process.env[BPMN_TIMER_POLLER_ENABLED_ENV]
+    try {
+      delete process.env[BPMN_TIMER_POLLER_ENABLED_ENV]
+      expect(isBpmnTimerPollerEnabled()).toBe(false)
+      process.env[BPMN_TIMER_POLLER_ENABLED_ENV] = 'true'
+      expect(isBpmnTimerPollerEnabled()).toBe(true)
+    } finally {
+      if (original === undefined) delete process.env[BPMN_TIMER_POLLER_ENABLED_ENV]
+      else process.env[BPMN_TIMER_POLLER_ENABLED_ENV] = original
+    }
+  })
+})

--- a/packages/core-backend/src/workflow/bpmnTimerPollerConfig.ts
+++ b/packages/core-backend/src/workflow/bpmnTimerPollerConfig.ts
@@ -1,0 +1,90 @@
+/**
+ * Env-gate for `BPMNWorkflowEngine`'s `startTimerProcessor()` minute poller.
+ *
+ * Owner ruling (2026-08-05, Plan B): the production BPMN workflow engine is
+ * self-described as "in development" (see `src/index.ts`'s
+ * `/api/workflow-mock/status` handler, `message: 'Workflow engine is in
+ * development. Use /api/workflow for real endpoints.'`), and there is no
+ * evidence of production use: no seed/migration ever inserts a
+ * `bpmn_process_definitions` row, and `WORKFLOW_ENABLED=true` (the frontend
+ * flag that surfaces the Workflow Designer UI) appears in no deploy config,
+ * docker-compose file, or CI workflow in this repo — only in two local-dev
+ * verification docs (20260309, `NODE_ENV=development`, port 7778).
+ *
+ * That is "no evidence of use", not "structurally impossible": the real
+ * `/api/workflow/deploy` route is reachable by any authenticated user
+ * regardless of `WORKFLOW_ENABLED` (that flag only hides frontend UI, see
+ * `routes/auth.ts`'s `buildFeaturePayload` — it is never read by engine
+ * lifecycle code), and `apps/web/src/views/workflowDesignerPersistence.ts`
+ * does call that real route from the shipped Workflow Designer UI. Whether
+ * any live deployment has actually used it to create a `bpmn_timer_jobs` row
+ * cannot be confirmed by static analysis. What IS structurally true:
+ * `startTimerProcessor`'s poll (one `selectFrom`, plus `processTimerJob`'s
+ * three `updateTable` calls) is the ONLY reader of `bpmn_timer_jobs` in this
+ * codebase — gating it off PAUSES processing of any such row (it stays
+ * `WAITING`, nothing is dropped or deleted) rather than losing it, and the
+ * pause is reversible by setting this flag. `'cycle'`-type recurring timers
+ * are a separate, unaffected code path (`scheduleRecurringTimer`, its own
+ * in-memory `cron.schedule`) — only persisted date/duration timers are
+ * affected. `resumeActiveInstances()` (also called from `initialize()`) only
+ * loads `bpmn_process_instances` into memory and does not depend on this
+ * poller either.
+ *
+ * A dormant subsystem should not poll regardless: previously
+ * `startTimerProcessor()` scheduled an unconditional `* * * * *` cron job
+ * against the shared `db` pool the moment `BPMNWorkflowEngine.initialize()`
+ * ran (both eager, at module-load time via `routes/workflow.ts`, and lazily
+ * on first designer-route call via `routes/workflow-designer.ts`), which is
+ * both needless standing load and — per issue #4770/#4779 — a source of
+ * teardown races in tests that boot the real server against a scratch
+ * database.
+ *
+ * This flag defaults OFF (unset or any value other than the literal string
+ * `'true'`). Deliberately narrower than `DISABLE_WORKFLOW` (which opts the
+ * WHOLE engine out — `loadProcessDefinitions`, `resumeActiveInstances`,
+ * metrics, health check, and the timer poller together) and unrelated to
+ * `WORKFLOW_ENABLED` (a frontend-only display flag, never read by engine
+ * lifecycle code) — this only ever governs whether the minute poller itself
+ * starts. If a deployment is known to have live BPMN process instances with
+ * date/duration timer events waiting to fire, set this to `'true'` in that
+ * deployment's environment.
+ */
+export const BPMN_TIMER_POLLER_ENABLED_ENV = 'ENABLE_BPMN_TIMER_POLLER'
+
+type BpmnTimerPollerEnv = Readonly<Record<string, string | undefined>>
+
+export function isBpmnTimerPollerEnabled(env: BpmnTimerPollerEnv = process.env): boolean {
+  return env[BPMN_TIMER_POLLER_ENABLED_ENV] === 'true'
+}
+
+/**
+ * Owner review P1-1 (2026-08-05, PR #4783): env-gating the POLLER off was not enough —
+ * `BPMNWorkflowEngine.createTimerJob()` (the only `INSERT INTO bpmn_timer_jobs` site in
+ * this codebase) still unconditionally persisted a `state: 'WAITING'` row for every
+ * `'date'`/`'duration'` timer, regardless of the flag. With the poller off, that row can
+ * never be read back — a NEWLY created orphan, not a paused pre-existing one, because
+ * poller-off was already the deploy's state when it was written. "Current WAITING count
+ * is 0, therefore safe to merge" does not hold once new writes keep happening after
+ * merge: `/api/workflow/start/:key`, task-complete, message, and signal delivery are all
+ * reachable by any authenticated user and can each drive process execution into a timer
+ * event.
+ *
+ * `createTimerJob` throws this BEFORE the insert when the poller is disabled, for
+ * `'date'`/`'duration'` timers only — `'cycle'` timers never reach this code path (see
+ * `scheduleRecurringTimer`, a separate in-memory `cron.schedule` that never touches
+ * `bpmn_timer_jobs`). The route layer's existing generic `catch (error) { ... 500 ...
+ * error.message }` pattern (see every handler in `routes/workflow.ts`) surfaces `code` as
+ * the response body's `error` field — a stable, enum-shaped signal, not a swallowed
+ * silent write. This mirrors the `readonly code: string` `Error` subclass convention used
+ * throughout `packages/core-backend/src/attendance/*` (e.g. `AttendanceW4AuthorizationError`).
+ */
+export const BPMN_TIMER_POLLER_DISABLED_ERROR_CODE = 'BPMN_TIMER_POLLER_DISABLED'
+
+export class BpmnTimerPollerDisabledError extends Error {
+  readonly code: string
+  constructor(code: string = BPMN_TIMER_POLLER_DISABLED_ERROR_CODE) {
+    super(code)
+    this.name = 'BpmnTimerPollerDisabledError'
+    this.code = code
+  }
+}

--- a/packages/core-backend/tests/integration/bpmn-poller-disabled-startprocess-zero-residue.db.test.ts
+++ b/packages/core-backend/tests/integration/bpmn-poller-disabled-startprocess-zero-residue.db.test.ts
@@ -1,0 +1,296 @@
+/**
+ * #4783 owner review batch 2 — the P1-1 write gate (`createTimerJob` throwing
+ * `BpmnTimerPollerDisabledError` before its own `INSERT`) was placed too late:
+ * `startProcess()` had ALREADY persisted the `bpmn_process_instances` row (`state:
+ * 'ACTIVE'`), and `executeStartEvents`/`executeActivity` had ALREADY persisted
+ * `bpmn_activity_instances` rows, by the time that throw fired. The catch block in
+ * `startProcess()` only logs and rethrows — nothing marks the instance terminated — so the
+ * owner's real repro against a fresh migrated database (`243db11f1`) showed:
+ *
+ *   process:     ACTIVE            (permanent residue)
+ *   activities:  startEvent=COMPLETED, intermediateCatchEvent=FAILED
+ *   incident:    OPEN
+ *   timer jobs:  0                 (P1-1 did stop THIS write)
+ *
+ * Batch 2's fix moves the gate to `startProcess()`'s own entry, BEFORE any write: if the
+ * poller is disabled and the process definition contains a 'date'/'duration' timer
+ * ANYWHERE in its structure (`BPMNWorkflowEngine.definitionHasPollerDependentTimer`, a
+ * sound full-definition scan, not a reachability analysis — see that method's own
+ * comment), `startProcess` throws immediately, before the `bpmn_process_instances` INSERT.
+ * The owner's completion door is literally FOUR zeros — process, activity, incident, AND
+ * timer rows all zero — not "cleaned up to a terminal state" (an earlier revision of this
+ * fix persisted-then-terminated with a RESOLVED incident; the owner explicitly rejected
+ * that shape because it still leaves non-zero activity/incident rows behind).
+ *
+ * This file drives the REAL production HTTP surface — `POST /api/workflow/deploy` then
+ * `POST /api/workflow/start/:key` against a REAL booted `MetaSheetServer` and REAL
+ * PostgreSQL — never `engine.createTimerJob(...)` or any other private method directly.
+ *
+ * BPMN XML fixture note: this codebase's `BPMNWorkflowEngine.deployProcess()` reads
+ * `parsed.definitions.process[0]` (UNPREFIXED keys), while `executeStartEvents` /
+ * `findActivity` read children via `'bpmn:startEvent'`/`'bpmn:sequenceFlow'`/etc.
+ * (PREFIXED keys) off that same `process` object. Verified directly against this
+ * project's actual `xml2js.parseString` (not assumed): a `<bpmn:definitions>`-prefixed
+ * root parses to a `'bpmn:definitions'` top-level key, which `deployProcess`'s own
+ * `parsed.definitions.process[0]` cannot see (`definitions` is `undefined`) — it would
+ * throw before persisting anything, unrelated to this PR. A fully unprefixed root parses
+ * cleanly for `deployProcess` but then `executeStartEvents`'s `'bpmn:startEvent'` lookup
+ * matches nothing, so nothing ever executes. The one shape that satisfies BOTH readers
+ * (confirmed by direct `xml2js.parseString` invocation) is what this file uses: unprefixed
+ * `<definitions>`/`<process>` root elements, `bpmn:`-prefixed descendants.
+ */
+import { randomUUID } from 'node:crypto'
+import http from 'node:http'
+import net from 'node:net'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { Pool } from 'pg'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import type { MetaSheetServer } from '../../src/index'
+
+const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
+const describeIfDatabase = dbUrl ? describe : describe.skip
+
+type JsonResponse = { status: number; body: Record<string, any> | null; raw: string }
+
+function canListen(): Promise<boolean> {
+  const probe = net.createServer()
+  return new Promise((resolve) => {
+    probe.once('error', () => resolve(false))
+    probe.listen(0, '127.0.0.1', () => probe.close(() => resolve(true)))
+  })
+}
+
+function requestJson(
+  url: string,
+  options: { method?: string; headers?: Record<string, string>; body?: Record<string, unknown> } = {},
+): Promise<JsonResponse> {
+  return new Promise((resolve, reject) => {
+    const target = new URL(url)
+    const payload = options.body ? JSON.stringify(options.body) : null
+    const request = http.request({
+      method: options.method ?? 'GET',
+      hostname: target.hostname,
+      port: target.port,
+      path: `${target.pathname}${target.search}`,
+      headers: {
+        ...(payload ? { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(payload) } : {}),
+        ...options.headers,
+      },
+    }, (response) => {
+      let raw = ''
+      response.on('data', (chunk) => { raw += String(chunk) })
+      response.on('end', () => {
+        let body: Record<string, any> | null = null
+        try { body = raw ? JSON.parse(raw) as Record<string, any> : null } catch { body = null }
+        resolve({ status: response.statusCode ?? 0, body, raw })
+      })
+    })
+    request.on('error', reject)
+    if (payload) request.write(payload)
+    request.end()
+  })
+}
+
+/** A process with a start event flowing directly into a 'duration' intermediateCatchEvent
+ *  timer — the exact shape of the owner's own repro (start completes, then the timer path
+ *  is what trips the gate). See file header for why this specific mixed prefix convention
+ *  is required for THIS engine's own deploy+execute code paths, both. */
+function timerBearingProcessXml(processKey: string): string {
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" id="defs_${processKey}">
+  <process id="${processKey}">
+    <bpmn:startEvent id="start1">
+      <bpmn:outgoing>flow1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="flow1" sourceRef="start1" targetRef="timer1" />
+    <bpmn:intermediateCatchEvent id="timer1">
+      <bpmn:incoming>flow1</bpmn:incoming>
+      <bpmn:timerEventDefinition>
+        <bpmn:timeDuration>PT5M</bpmn:timeDuration>
+      </bpmn:timerEventDefinition>
+    </bpmn:intermediateCatchEvent>
+  </process>
+</definitions>`
+}
+
+/** Structurally identical, but with no timer anywhere — the positive control proving the
+ *  entry gate does not over-block ordinary poller-off starts. */
+function timerFreeProcessXml(processKey: string): string {
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" id="defs_${processKey}">
+  <process id="${processKey}">
+    <bpmn:startEvent id="start1">
+      <bpmn:outgoing>flow1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="flow1" sourceRef="start1" targetRef="end1" />
+    <bpmn:endEvent id="end1">
+      <bpmn:incoming>flow1</bpmn:incoming>
+    </bpmn:endEvent>
+  </process>
+</definitions>`
+}
+
+describeIfDatabase('BPMNWorkflowEngine startProcess poller-disabled zero-residue (#4783 owner review batch 2, real HTTP + real PostgreSQL)', () => {
+  let server: MetaSheetServer | undefined
+  let pool: Pool
+  let adminPool: Pool
+  let scratchName: string
+  let baseUrl = ''
+  let token = ''
+
+  const priorEnv = {
+    databaseUrl: process.env.DATABASE_URL,
+    skipPlugins: process.env.SKIP_PLUGINS,
+    enablePoller: process.env.ENABLE_BPMN_TIMER_POLLER,
+  }
+
+  async function mintToken(userId: string): Promise<string> {
+    const response = await requestJson(`${baseUrl}/api/auth/dev-token?userId=${encodeURIComponent(userId)}`)
+    const minted = response.body?.token
+    if (typeof minted !== 'string' || !minted) throw new Error(`failed to mint token: ${response.raw}`)
+    return minted
+  }
+
+  async function seedUser(): Promise<string> {
+    const userId = randomUUID()
+    await pool.query(
+      `INSERT INTO users (id, email, username, name, password_hash, role, permissions, is_active, is_admin, activation_status)
+       VALUES ($1, $2, $1, 'BPMN #4783 batch-2 zero-residue fixture', 'x', 'user', '[]'::jsonb, TRUE, FALSE, 'activated')`,
+      [userId, `bpmnp1batch2-${userId}@example.test`],
+    )
+    return userId
+  }
+
+  async function deploy(bpmnXml: string, key: string): Promise<JsonResponse> {
+    return requestJson(`${baseUrl}/api/workflow/deploy`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}` },
+      body: { key, name: `#4783 batch-2 fixture ${key}`, bpmnXml },
+    })
+  }
+
+  async function start(key: string): Promise<JsonResponse> {
+    return requestJson(`${baseUrl}/api/workflow/start/${encodeURIComponent(key)}`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}` },
+      body: {},
+    })
+  }
+
+  async function counts(processKey: string): Promise<{ processes: number; activities: number; incidents: number; timers: number }> {
+    const proc = await pool.query(
+      `SELECT count(*)::int AS n FROM bpmn_process_instances WHERE process_definition_key = $1`,
+      [processKey],
+    )
+    // bpmn_activity_instances/bpmn_incidents/bpmn_timer_jobs key off process_instance_id,
+    // not process_definition_key — resolve instance ids for this key first (there should
+    // be zero of them in the fail-closed leg, and that absence IS the assertion; in the
+    // positive-control leg there is exactly one).
+    const instanceIds = await pool.query(
+      `SELECT id FROM bpmn_process_instances WHERE process_definition_key = $1`,
+      [processKey],
+    )
+    const ids: string[] = instanceIds.rows.map((r: { id: string }) => r.id)
+    const activities = ids.length
+      ? await pool.query(`SELECT count(*)::int AS n FROM bpmn_activity_instances WHERE process_instance_id = ANY($1::uuid[])`, [ids])
+      : { rows: [{ n: 0 }] }
+    const incidents = ids.length
+      ? await pool.query(`SELECT count(*)::int AS n FROM bpmn_incidents WHERE process_instance_id = ANY($1::uuid[])`, [ids])
+      : { rows: [{ n: 0 }] }
+    const timers = ids.length
+      ? await pool.query(`SELECT count(*)::int AS n FROM bpmn_timer_jobs WHERE process_instance_id = ANY($1::uuid[])`, [ids])
+      : { rows: [{ n: 0 }] }
+    return {
+      processes: proc.rows[0].n,
+      activities: activities.rows[0].n,
+      incidents: incidents.rows[0].n,
+      timers: timers.rows[0].n,
+    }
+  }
+
+  beforeAll(async () => {
+    if (!dbUrl || !(await canListen())) throw new Error('BPMN_P1_BATCH2_TEST_REQUIRES_DATABASE_AND_LOOPBACK')
+
+    scratchName = `ms2_bpmnp1b2_${randomUUID().slice(0, 12).replace(/-/g, '')}`
+    const adminUrl = new URL(dbUrl)
+    adminUrl.pathname = '/postgres'
+    adminPool = new Pool({ connectionString: adminUrl.toString() })
+    await adminPool.query(`DROP DATABASE IF EXISTS ${scratchName}`)
+    await adminPool.query(`CREATE DATABASE ${scratchName}`)
+    const scratchUrl = new URL(dbUrl)
+    scratchUrl.pathname = `/${scratchName}`
+    const scratchConnectionString = scratchUrl.toString()
+
+    const coreBackendDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
+    const { execFileSync } = await import('node:child_process')
+    execFileSync('pnpm', ['exec', 'tsx', 'src/db/migrate.ts'], {
+      cwd: coreBackendDir,
+      env: { ...process.env, DATABASE_URL: scratchConnectionString },
+      stdio: 'pipe',
+    })
+
+    process.env.DATABASE_URL = scratchConnectionString
+    process.env.SKIP_PLUGINS = 'true'
+    // Default-off, unset — the exact shipped state this fix targets.
+    delete process.env.ENABLE_BPMN_TIMER_POLLER
+
+    const loaded = await import('../../src/index')
+    server = new loaded.MetaSheetServer({ port: 0, host: '127.0.0.1' })
+    await server.start()
+    const address = server.getAddress()
+    if (!address || typeof address === 'string') throw new Error('server did not expose a TCP address')
+    baseUrl = `http://127.0.0.1:${address.port}`
+    pool = new Pool({ connectionString: scratchConnectionString })
+
+    const userId = await seedUser()
+    token = await mintToken(userId)
+  }, 120000)
+
+  afterAll(async () => {
+    await pool?.end().catch(() => undefined)
+    if (server) await server.stop()
+    await adminPool?.query(`DROP DATABASE IF EXISTS ${scratchName} WITH (FORCE)`).catch(() => undefined)
+    await adminPool?.end().catch(() => undefined)
+    for (const [key, value] of Object.entries({
+      DATABASE_URL: priorEnv.databaseUrl,
+      SKIP_PLUGINS: priorEnv.skipPlugins,
+      ENABLE_BPMN_TIMER_POLLER: priorEnv.enablePoller,
+    })) {
+      if (value === undefined) delete process.env[key]
+      else process.env[key] = value
+    }
+  }, 60000)
+
+  it('poller disabled + a timer-bearing process: /start rejects with BPMN_TIMER_POLLER_DISABLED and FOUR real zeros — process, activity, incident, timer rows all 0', async () => {
+    const processKey = `bpmn-p1b2-gate-${randomUUID()}`
+    const deployRes = await deploy(timerBearingProcessXml(processKey), processKey)
+    expect(deployRes.status, deployRes.raw).toBe(201)
+
+    const startRes = await start(processKey)
+    expect(startRes.status, startRes.raw).toBe(500)
+    expect(startRes.body?.error).toBe('BPMN_TIMER_POLLER_DISABLED')
+
+    const c = await counts(processKey)
+    expect(c, 'process/activity/incident/timer rows must ALL be zero — no ACTIVE residue, no orphaned activity, no incident, no timer row').toEqual({
+      processes: 0,
+      activities: 0,
+      incidents: 0,
+      timers: 0,
+    })
+  })
+
+  it('poller disabled + a timer-FREE process: /start still succeeds (positive control — the gate does not over-block ordinary starts)', async () => {
+    const processKey = `bpmn-p1b2-nogate-${randomUUID()}`
+    const deployRes = await deploy(timerFreeProcessXml(processKey), processKey)
+    expect(deployRes.status, deployRes.raw).toBe(201)
+
+    const startRes = await start(processKey)
+    expect(startRes.status, startRes.raw).toBe(201)
+    expect(typeof startRes.body?.data?.instanceId).toBe('string')
+
+    const c = await counts(processKey)
+    expect(c.processes).toBe(1)
+    expect(c.timers).toBe(0)
+  })
+})

--- a/packages/core-backend/tests/integration/bpmn-timer-job-write-and-claim-safety.db.test.ts
+++ b/packages/core-backend/tests/integration/bpmn-timer-job-write-and-claim-safety.db.test.ts
@@ -1,0 +1,247 @@
+/**
+ * #4783 owner review (2026-08-05) P1-1 + P1-2 — proved against REAL PostgreSQL, not a
+ * mocked `db`. The mocked-`db` unit-level counterparts
+ * (`src/workflow/__tests__/BPMNWorkflowEngine.timerWriteGate.test.ts` for P1-1,
+ * `src/workflow/__tests__/BPMNWorkflowEngine.timerPoller.test.ts` for the poller gate
+ * itself) prove the CALL shape; this file proves the actual DATABASE outcome, which is
+ * what the invariant is actually about ("the system contains no timer job that will
+ * never be processed").
+ *
+ * P1-1 (write gate): `createTimerJob` must reject a 'date'/'duration' timer write with
+ * `BpmnTimerPollerDisabledError` while the poller is disabled, and — the thing a mock
+ * cannot prove — the real `bpmn_timer_jobs` table must end up with ZERO rows for that
+ * call, not merely "the mock wasn't invoked". A positive control (poller enabled) proves
+ * the row DOES land when it's supposed to, per this repo's "assert-not-happening needs a
+ * positive control" doctrine.
+ *
+ * P1-2 (atomic claim): `processTimerJob`'s WAITING -> LOCKED transition must be race-safe
+ * across TWO INDEPENDENT `BPMNWorkflowEngine` instances sharing the same `db` pool — the
+ * exact production topology (`routes/workflow.ts`'s eager instance +
+ * `routes/workflow-designer.ts`'s lazy instance). This is proved with a CONSTRUCTED race,
+ * not sequential reasoning: both instances' `processTimerJob` are invoked for the SAME
+ * batch of already-WAITING rows via a single `Promise.all`, so their claim UPDATEs are
+ * genuinely in flight concurrently against real Postgres (default pool max 20 — see
+ * `src/integration/db/connection-pool.ts` — comfortably above this file's batch size).
+ * Each instance's own `fireTimer` is replaced with a call-recording spy (never the real
+ * `continueProcess` — no `bpmn_process_instances` fixture exists here; that machinery is
+ * covered elsewhere) so the discriminating assertion is "which engine's spy recorded the
+ * call", not merely "the row ended up COMPLETED" (both a correct claim and a double-fire
+ * bug converge on the same final `state`).
+ *
+ * Isolation: every row this file touches is looked up by its own randomly-generated
+ * UUID `id`/`process_instance_id` — `bpmn_timer_jobs` has no other reader/writer
+ * anywhere in this codebase (grep-verified) and no other test file in this repo
+ * references the table, so there is no shared-fixture collision risk even running in
+ * the same CI step as unrelated suites.
+ */
+import { randomUUID } from 'node:crypto'
+import { createRequire } from 'node:module'
+import { Pool } from 'pg'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { BPMNWorkflowEngine } from '../../src/workflow/BPMNWorkflowEngine'
+import { BPMN_TIMER_POLLER_ENABLED_ENV, BpmnTimerPollerDisabledError } from '../../src/workflow/bpmnTimerPollerConfig'
+
+const databaseUrl = process.env.DATABASE_URL
+const describeIfDatabase = databaseUrl ? describe : describe.skip
+
+const require = createRequire(import.meta.url)
+// Same require-cache singleton `BPMNWorkflowEngine.ts` itself binds to — spied here only
+// to keep this file's own timer-instance construction from EVER scheduling a real
+// repeating interval if any code path this file does not intend to exercise touches
+// `scheduleRecurringTimer`. Neither P1-1 nor P1-2 legs below use 'cycle' timers, so this
+// spy is not expected to be called; it exists purely as a safety net.
+const cronModule = require('node-cron') as { schedule: (...args: unknown[]) => unknown }
+
+interface EngineTimerInternals {
+  createTimerJob: (
+    instanceId: string,
+    activityId: string,
+    timerDef: { type: 'date' | 'duration' | 'cycle'; value: string; activityId: string }
+  ) => Promise<void>
+  processTimerJob: (job: { id: string; process_instance_id: string; activity_id: string; retries: number }) => Promise<void>
+  fireTimer: (instanceId: string, activityId: string) => Promise<void>
+}
+
+function internals(engine: InstanceType<typeof BPMNWorkflowEngine>): EngineTimerInternals {
+  return engine as unknown as EngineTimerInternals
+}
+
+function spiedEngine(label: string, calls: Array<{ engine: string; jobId: string }>): InstanceType<typeof BPMNWorkflowEngine> {
+  const engine = new BPMNWorkflowEngine()
+  internals(engine).fireTimer = async (instanceId: string) => {
+    calls.push({ engine: label, jobId: instanceId })
+  }
+  return engine
+}
+
+describeIfDatabase('BPMNWorkflowEngine bpmn_timer_jobs write-and-claim safety (#4783 P1-1/P1-2, real PostgreSQL)', () => {
+  let pool: Pool
+  let scheduleSpy: ReturnType<typeof vi.spyOn>
+  let originalEnv: string | undefined
+  const createdInstanceIds: string[] = []
+  const createdJobIds: string[] = []
+
+  beforeAll(() => {
+    pool = new Pool({ connectionString: databaseUrl })
+  })
+
+  afterAll(async () => {
+    if (createdInstanceIds.length > 0) {
+      await pool.query(`DELETE FROM bpmn_timer_jobs WHERE process_instance_id = ANY($1::uuid[])`, [createdInstanceIds])
+    }
+    if (createdJobIds.length > 0) {
+      await pool.query(`DELETE FROM bpmn_timer_jobs WHERE id = ANY($1::uuid[])`, [createdJobIds])
+    }
+    await pool.end()
+  })
+
+  beforeEach(() => {
+    originalEnv = process.env[BPMN_TIMER_POLLER_ENABLED_ENV]
+    delete process.env[BPMN_TIMER_POLLER_ENABLED_ENV]
+    scheduleSpy = vi.spyOn(cronModule, 'schedule').mockReturnValue({ start: vi.fn(), stop: vi.fn() })
+  })
+
+  afterEach(() => {
+    scheduleSpy.mockRestore()
+    if (originalEnv === undefined) delete process.env[BPMN_TIMER_POLLER_ENABLED_ENV]
+    else process.env[BPMN_TIMER_POLLER_ENABLED_ENV] = originalEnv
+  })
+
+  // =====================================================================================
+  // P1-1 — write gate, real database outcome.
+  // =====================================================================================
+  describe('P1-1 write gate', () => {
+    it('poller disabled: "date" timer create rejects, and ZERO rows land in real bpmn_timer_jobs', async () => {
+      const engine = new BPMNWorkflowEngine()
+      const instanceId = randomUUID()
+      createdInstanceIds.push(instanceId)
+
+      await expect(
+        internals(engine).createTimerJob(instanceId, randomUUID(), {
+          type: 'date',
+          value: '2026-01-01T00:00:00Z',
+          activityId: 'act-gate',
+        })
+      ).rejects.toBeInstanceOf(BpmnTimerPollerDisabledError)
+
+      const row = await pool.query('SELECT count(*)::int AS n FROM bpmn_timer_jobs WHERE process_instance_id = $1::uuid', [instanceId])
+      expect(row.rows[0].n).toBe(0)
+    })
+
+    it('poller disabled: "duration" timer create rejects, and ZERO rows land', async () => {
+      const engine = new BPMNWorkflowEngine()
+      const instanceId = randomUUID()
+      createdInstanceIds.push(instanceId)
+
+      await expect(
+        internals(engine).createTimerJob(instanceId, randomUUID(), {
+          type: 'duration',
+          value: 'PT5M',
+          activityId: 'act-gate',
+        })
+      ).rejects.toBeInstanceOf(BpmnTimerPollerDisabledError)
+
+      const row = await pool.query('SELECT count(*)::int AS n FROM bpmn_timer_jobs WHERE process_instance_id = $1::uuid', [instanceId])
+      expect(row.rows[0].n).toBe(0)
+    })
+
+    it('poller ENABLED: "date" timer create succeeds, exactly ONE real WAITING row lands (positive control)', async () => {
+      process.env[BPMN_TIMER_POLLER_ENABLED_ENV] = 'true'
+      const engine = new BPMNWorkflowEngine()
+      const instanceId = randomUUID()
+      createdInstanceIds.push(instanceId)
+
+      await expect(
+        internals(engine).createTimerJob(instanceId, randomUUID(), {
+          type: 'date',
+          value: '2026-01-01T00:00:00Z',
+          activityId: 'act-gate',
+        })
+      ).resolves.toBeUndefined()
+
+      const row = await pool.query('SELECT state FROM bpmn_timer_jobs WHERE process_instance_id = $1::uuid', [instanceId])
+      expect(row.rows).toHaveLength(1)
+      expect(row.rows[0].state).toBe('WAITING')
+    })
+  })
+
+  // =====================================================================================
+  // P1-2 — atomic claim, constructed real concurrency across TWO engine instances.
+  // =====================================================================================
+  describe('P1-2 atomic claim', () => {
+    it('two independent engine instances racing on the SAME batch of WAITING jobs: disjoint claims, zero double-fire, every job COMPLETED exactly once', async () => {
+      const BATCH_SIZE = 12
+      const jobs: Array<{ id: string; process_instance_id: string; activity_id: string; retries: number }> = []
+
+      for (let i = 0; i < BATCH_SIZE; i++) {
+        const jobId = randomUUID()
+        const processInstanceId = randomUUID()
+        const activityInstanceId = randomUUID()
+        createdJobIds.push(jobId)
+        await pool.query(
+          `INSERT INTO bpmn_timer_jobs (id, process_instance_id, activity_instance_id, timer_type, due_date, state)
+           VALUES ($1::uuid, $2::uuid, $3::uuid, 'date', now() - interval '1 minute', 'WAITING')`,
+          [jobId, processInstanceId, activityInstanceId],
+        )
+        jobs.push({ id: jobId, process_instance_id: processInstanceId, activity_id: activityInstanceId, retries: 0 })
+      }
+
+      const calls: Array<{ engine: string; jobId: string }> = []
+      const engineA = spiedEngine('A', calls)
+      const engineB = spiedEngine('B', calls)
+
+      // Genuine construction of the race: BOTH engines attempt EVERY job, all launched
+      // together in one Promise.all — not sequential awaits per job or per engine. Each
+      // call's first `await` is the claim UPDATE itself, so all 2*BATCH_SIZE claim
+      // attempts are in flight against real Postgres at (as close as Node gets to)
+      // the same moment.
+      const attempts = jobs.flatMap((job) => [
+        internals(engineA).processTimerJob(job),
+        internals(engineB).processTimerJob(job),
+      ])
+      await Promise.all(attempts)
+
+      // Disjoint claims: for every seeded job, EXACTLY one engine's fireTimer spy fired —
+      // not zero (the claim must eventually succeed for someone) and not two (the bug
+      // this fix closes).
+      for (const job of jobs) {
+        const firedFor = calls.filter((c) => c.jobId === job.process_instance_id)
+        expect(firedFor, `job ${job.id} must be fired exactly once, got ${firedFor.length} (engines: ${firedFor.map((c) => c.engine).join(',')})`).toHaveLength(1)
+      }
+      expect(calls).toHaveLength(BATCH_SIZE)
+
+      // Real database outcome: every job ends COMPLETED (the claimant that won ran
+      // fireTimer -> success path -> state = 'COMPLETED'), never left LOCKED (which would
+      // mean a claim succeeded but nothing ever completed it) or still WAITING.
+      const finalStates = await pool.query(
+        `SELECT id, state FROM bpmn_timer_jobs WHERE id = ANY($1::uuid[])`,
+        [jobs.map((j) => j.id)],
+      )
+      expect(finalStates.rows).toHaveLength(BATCH_SIZE)
+      for (const row of finalStates.rows) {
+        expect(row.state, `job ${row.id} must end COMPLETED`).toBe('COMPLETED')
+      }
+    })
+
+    it('a job already LOCKED by someone else: processTimerJob backs off (0 rows claimed), never fires, never marks FAILED', async () => {
+      const jobId = randomUUID()
+      const processInstanceId = randomUUID()
+      const activityInstanceId = randomUUID()
+      createdJobIds.push(jobId)
+      await pool.query(
+        `INSERT INTO bpmn_timer_jobs (id, process_instance_id, activity_instance_id, timer_type, due_date, state)
+         VALUES ($1::uuid, $2::uuid, $3::uuid, 'date', now() - interval '1 minute', 'LOCKED')`,
+        [jobId, processInstanceId, activityInstanceId],
+      )
+
+      const calls: Array<{ engine: string; jobId: string }> = []
+      const engine = spiedEngine('solo', calls)
+      await internals(engine).processTimerJob({ id: jobId, process_instance_id: processInstanceId, activity_id: activityInstanceId, retries: 0 })
+
+      expect(calls).toHaveLength(0)
+      const row = await pool.query('SELECT state FROM bpmn_timer_jobs WHERE id = $1::uuid', [jobId])
+      expect(row.rows[0].state).toBe('LOCKED')
+    })
+  })
+})

--- a/packages/core-backend/tests/unit/workflow-approval-automation-convergence.guard.test.ts
+++ b/packages/core-backend/tests/unit/workflow-approval-automation-convergence.guard.test.ts
@@ -114,6 +114,16 @@ const BPMN_IMPORT_ALLOWLIST: Array<{ file: string; disposition: 'LEGACY-RUNTIME'
     disposition: 'TEST',
     reason: 'A3/A4 values-free egress destination-authorization evidence tests only — exercises the shipped egress guard through the real env path, not a product runtime consumer.',
   },
+  {
+    file: 'workflow/__tests__/BPMNWorkflowEngine.timerPoller.test.ts',
+    disposition: 'TEST',
+    reason: '#4770/#4779 owner ruling (2026-08-05, Plan B) env-gate regression tests for the minute timer poller (startTimerProcessor/shutdown) only — not a product runtime consumer.',
+  },
+  {
+    file: 'workflow/__tests__/BPMNWorkflowEngine.timerWriteGate.test.ts',
+    disposition: 'TEST',
+    reason: '#4783 owner review P1-1 write-gate regression tests for createTimerJob (rejects date/duration timer persistence while the poller is disabled) only — not a product runtime consumer.',
+  },
 ]
 
 /**

--- a/packages/core-backend/tests/unit/workflow-designer-engine-shutdown.test.ts
+++ b/packages/core-backend/tests/unit/workflow-designer-engine-shutdown.test.ts
@@ -1,0 +1,42 @@
+/**
+ * #4783 owner review P3-a — `routes/workflow-designer.ts` constructs its OWN independent
+ * `BPMNWorkflowEngine` instance (separate from `routes/workflow.ts`'s), so
+ * `routes/workflow.ts`'s pre-existing `shutdownWorkflowEngine()` never reached it: its
+ * poller (when `ENABLE_BPMN_TIMER_POLLER=true`) and any in-flight tick were unstoppable
+ * from `index.ts`'s `stop()`. `shutdownWorkflowDesignerEngine()` closes that gap,
+ * mirrored from the existing `routes/workflow.ts` export and wired into `stop()`
+ * alongside it.
+ *
+ * This spies on the REAL `BPMNWorkflowEngine.prototype.shutdown` (never a mock of the
+ * whole class — a full-class mock would make this test pass even if the export called
+ * some OTHER object's `.shutdown()`, or nothing at all) to prove the new export actually
+ * calls through to THIS module's own engine instance, not merely that it resolves.
+ */
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../src/db/db', () => ({
+  db: {
+    selectFrom: vi.fn(),
+    insertInto: vi.fn(),
+    updateTable: vi.fn(),
+    deleteFrom: vi.fn(),
+  },
+}))
+
+describe('shutdownWorkflowDesignerEngine (#4783 P3-a)', () => {
+  it('calls through to this module\'s own BPMNWorkflowEngine instance\'s real shutdown()', async () => {
+    const { BPMNWorkflowEngine } = await import('../../src/workflow/BPMNWorkflowEngine')
+    const shutdownSpy = vi.spyOn(BPMNWorkflowEngine.prototype, 'shutdown')
+
+    const { shutdownWorkflowDesignerEngine } = await import('../../src/routes/workflow-designer')
+    await expect(shutdownWorkflowDesignerEngine()).resolves.toBeUndefined()
+
+    expect(shutdownSpy).toHaveBeenCalledTimes(1)
+    shutdownSpy.mockRestore()
+  })
+
+  it('is safe to call when the designer engine was never initialized (no route ever hit)', async () => {
+    const { shutdownWorkflowDesignerEngine } = await import('../../src/routes/workflow-designer')
+    await expect(shutdownWorkflowDesignerEngine()).resolves.toBeUndefined()
+  })
+})

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -960,6 +960,23 @@ export default defineConfig({
       // until then this is DECLARED debt, not invisible debt. Run it locally against a fully-migrated DB.
       'tests/integration/snapshot-protection.test.ts',
       'tests/integration/spreadsheet-integration.test.ts',
+      // #4783 owner review P1-1/P1-2: proves the BPMN timer poller write-gate (real
+      // bpmn_timer_jobs outcome, not a mocked db) and the WAITING -> LOCKED atomic-claim
+      // fix with a CONSTRUCTED real-Postgres race across two independent
+      // `BPMNWorkflowEngine` instances. DATABASE_URL-gated; excluded here so the no-DB
+      // default job cannot skip-green it, and wired as a WHOLE FILE into the
+      // `Run BPMN timer job write-and-claim safety` step in plugin-tests.yml.
+      'tests/integration/bpmn-timer-job-write-and-claim-safety.db.test.ts',
+      // #4783 owner review batch 2: proves startProcess()'s entry gate leaves FOUR real
+      // zeros (process/activity/incident/timer rows) — not "written then terminated" —
+      // when a timer-bearing process is started with the poller disabled, driven through
+      // the REAL HTTP surface (POST /api/workflow/deploy + POST /api/workflow/start/:key)
+      // against a real booted MetaSheetServer + fresh-migrated scratch PostgreSQL, plus a
+      // positive control that a timer-free process still starts normally. DATABASE_URL-
+      // gated; excluded here so the no-DB default job cannot skip-green it, and wired as a
+      // WHOLE FILE into the `Run BPMN startProcess poller-disabled zero-residue` step in
+      // plugin-tests.yml.
+      'tests/integration/bpmn-poller-disabled-startprocess-zero-residue.db.test.ts',
       // Playwright E2E suites run through their own harness, not Vitest.
       'tests/e2e/**',
     ],

--- a/plugins/plugin-integration-core/lib/sealed-export/vectors/s6a-package-provenance-pins.json
+++ b/plugins/plugin-integration-core/lib/sealed-export/vectors/s6a-package-provenance-pins.json
@@ -86,6 +86,6 @@
     "s6aAcceptancePs51Test": "835c7c6ce943d82e0378a40a27c7fd1e8b79b526faa8ca4c8066e4231a4bfb0f",
     "s6aProductRuntimeTest": "de978adafa8b89772cefa921c2051f434bf346bf5c2978bef3424ee70f51ba3f",
     "multitableOnpremPackageBuild": "463c7d73c6c7f2d1b6cdf0820d7a06974a9c463dd5e98bbbaf1c996e1dc4ed99",
-    "pluginTestsWorkflow": "0d58b59458f1c46ca80fc73b771d5ccad1dd0993f241f88ca13fc2f84bd46eb2"
+    "pluginTestsWorkflow": "45f6f561a446146cf0444ce948b0fd377e440640e699d6e4b681a8b49559993c"
   }
 }


### PR DESCRIPTION
## [HOLD] Draft — not for merge

This PR is a **Draft/HOLD**. It is not armed for auto-merge and should not be merged
without an explicit owner ruling. Refs #4770, #4779. Does not use a closing keyword
against either issue — both stay open independently of this PR's fate.

## Why this PR exists (owner ruling, 2026-08-05, Plan B)

#4779 (attendance W4C-2 sweep-observability follow-up, already 0P1/0P2 at `3d101168f`)
picked up a second commit, `1ff5f1aff`, that fixed a real CI flake (57P01, "terminating
connection due to administrator command") by making the BPMN workflow engine's minute
timer poller stoppable. The owner ruled that fix does not belong in an attendance-scoped
PR — it edits production BPMN engine/server lifecycle code (`src/index.ts`,
`src/routes/workflow.ts`, `src/workflow/BPMNWorkflowEngine.ts`) — and that the root cause
is architectural: **a dormant subsystem should not poll a production DB every minute by
default.** `1ff5f1aff` made the poller *stoppable*; it did not make it *off*.

This PR carves that fix out into its own, independently-reviewable change:
**env-gate the poller off by default**, keep the stoppability hygiene (folded in, same
lifecycle surface), and leave #4779 to just the observability commit it started as.
`claude/w4c2-sweep-observability-20260805` (#4779) has been reverted back to
`1ff5f1aff`'s parent and its own body updated to record this dependency.

## What "in development / zero consumers" actually means here (retraction-first)

An earlier commit on this branch (`2f17d9a0d`) originally stated the BPMN engine has
"zero consumers" and "no deployed feature reaches `/api/workflow/deploy` ... in
production traffic." **That was an overclaim, caught and retracted in `6b653085e`**
before this PR was opened — my own grep during the same session found
`apps/web/src/views/workflowDesignerPersistence.ts:363` posting to the real
`/api/workflow/deploy` route from the shipped Workflow Designer UI. What is actually
true, each independently verified:

| Claim | Evidence |
| --- | --- |
| The engine self-describes as "in development" | `src/index.ts`'s `/api/workflow-mock/status` handler: `message: 'Workflow engine is in development. Use /api/workflow for real endpoints.'` |
| No seed/migration ever inserts a `bpmn_process_definitions` row | `grep -rln "insertInto('bpmn_process_definitions')\|INSERT INTO bpmn_process_definitions"` over `src/db/` and `scripts/` — zero hits outside the engine's own deploy-route code |
| `WORKFLOW_ENABLED=true` (the frontend flag that surfaces the Designer UI) appears in no deploy config | `grep` over `docker-compose*.yml`, `.github/workflows/*.yml` — zero hits. It appears in 7 `docs/development/*.md` files (`grep -rl "WORKFLOW_ENABLED=true" docs/`); I inspected all 7 — every one is a 20260308-20260310 **local-dev verification-session log** (`PORT=7778`, `NODE_ENV=development`), none is a deploy/staging/production record |
| `WORKFLOW_ENABLED` does **not** gate the backend engine or this poller | It flows only into `routes/auth.ts`'s `buildFeaturePayload` (a JSON field the frontend reads to decide whether to show UI) — not read by `routes/workflow.ts`, `routes/workflow-designer.ts`, or `BPMNWorkflowEngine` (`grep -rn "workflowEnabled" packages/` — only hits in `config/flags.ts`, `config/index.ts`, `routes/auth.ts`, and its own unit test) |
| A reachable deploy path **does** exist regardless of that UI flag | `routes/workflow.ts`'s `/deploy` route is gated only by `authenticate` (any authenticated user) — not by `WORKFLOW_ENABLED`; `workflowDesignerPersistence.ts` calls it directly from the shipped Designer UI |
| The poller's tick is the only caller in the codebase that ever reads or updates `bpmn_timer_jobs` | `grep -n "bpmn_timer_jobs" src/workflow/BPMNWorkflowEngine.ts`: one `selectFrom` (inside `startTimerProcessor`, ~L1563) calls `processTimerJob`, which has the only 3 `updateTable` sites (~L1591/1603/1612) — `processTimerJob` has exactly one call site in the whole file (the poller's own tick loop, ~L1576), so gating `startTimerProcessor()` off blocks that entire read+update chain. The only OTHER `bpmn_timer_jobs` touch anywhere in the repo is a single `insertInto` (~L1464, in `scheduleTimer`, when a date/duration timer definition is first created) — unaffected by this gate, so newly-scheduled timers still get persisted, just not (yet) processed |
| `'cycle'`-type recurring timers are a separate, unaffected code path | `scheduleRecurringTimer` (called from `scheduleTimer`'s `'cycle'` case, ~L1457) does its own independent `cron.schedule`, never touches `bpmn_timer_jobs` |
| `resumeActiveInstances()` (also called from `initialize()`) does not depend on this poller | Reads `bpmn_process_instances` into an in-memory map only; no `bpmn_timer_jobs` reference |

**Row correction (retraction-first): the "unaffected by this gate" claim two rows up is
superseded.** That row described this PR's ORIGINAL state, before any P1 write-gate
existed — gating only `startTimerProcessor()` (the reader) left the `insertInto` (the
writer) completely untouched, so new timer writes really were "unaffected." That is no
longer true, in two layers (see the batch 1 and batch 2 sections below for the full
history): batch 1 gated the `insertInto` itself (`createTimerJob` throws before its own
write when the poller is off); batch 2 moved that gate to `startProcess()`'s own entry,
before ANY write — a 'date'/'duration' timer, poller off, now fails the START call
itself with zero rows written anywhere, not merely a skipped `bpmn_timer_jobs` row.

**Net conclusion:** "no evidence of production use", not "structurally impossible to be
in use". Gating the poller off **pauses** processing of any `bpmn_timer_jobs` row that
might exist (it stays `WAITING`; nothing is dropped, deleted, or lost) rather than
losing data, and the pause is reversible by setting `ENABLE_BPMN_TIMER_POLLER=true` in
a specific deployment's environment. **Residual unknown, stated plainly:** whether any
live (staging/production) database currently has `bpmn_timer_jobs` rows in `WAITING`
cannot be confirmed from this sandbox — it can't reach the deploy host. If the owner
has out-of-band knowledge that a live deployment has actually used the Workflow
Designer to deploy a process with a date/duration timer event, that deployment's
environment should get `ENABLE_BPMN_TIMER_POLLER=true` set explicitly before or
alongside this PR landing.

## The env-gate

New file `packages/core-backend/src/workflow/bpmnTimerPollerConfig.ts`:
`ENABLE_BPMN_TIMER_POLLER`, default OFF (unset or any value other than the exact
literal `'true'` — same enum-strict convention as `DISABLE_WORKFLOW`/`WORKFLOW_ENABLED`
elsewhere in this file). Deliberately its **own** flag, not a reuse of either existing
one:

- **`DISABLE_WORKFLOW`** — opt-**OUT**, default-on, gates the **whole** engine
  (`loadProcessDefinitions`, `resumeActiveInstances`, metrics, health check, AND the
  poller together). Wrong polarity and wrong scope for "just pause the poller."
- **`WORKFLOW_ENABLED`** — frontend-display-only (see table above), never read by
  engine lifecycle code. Reusing it would silently couple a UI-visibility flag to a
  backend cron job's existence — exactly the kind of hidden coupling this repo's
  env-gating discipline (`feedback_channel_env_gating.md`) warns against.

The check lives **inside** `BPMNWorkflowEngine.startTimerProcessor()` itself (not at
either call site), so it covers **both** production instantiations identically:
`routes/workflow.ts` (eager, module load) and `routes/workflow-designer.ts` (lazy,
first designer-route call) — each constructs its own `BPMNWorkflowEngine`, and both
share the same class method.

Documented in `.env.example` alongside the existing `WORKFLOW_ENABLED` entry, with an
explicit note on how it differs from both existing flags.

## Poller-stoppability hygiene (folded in from the reverted `1ff5f1aff`)

Since this PR already owns BPMN engine lifecycle code, the positive half of `1ff5f1aff`
travels with it rather than shipping twice: the poller's `cron.schedule()` return value
is tracked under `TIMER_PROCESSOR_JOB_KEY` in `timerJobs` (so `shutdown()`'s existing
sweep stops it), each tick's promise is stashed in `timerProcessorTick` (so
`shutdown()` can drain an in-flight tick before returning), the tick body is wrapped in
try/catch (mirroring `startHealthCheck`'s own guard), and `routes/workflow.ts` exports
`shutdownWorkflowEngine()` so `MetaSheetServer.stop()` reaches it deterministically —
not just on a real SIGTERM.

`startHealthCheck()`'s own 60s `setInterval` (also DB-querying `bpmn_process_instances`,
also untracked/unstoppable) is a **known sibling issue, explicitly out of scope** here —
this PR only touches the timer poller.

## Judge legs

**Env unset ⇒ poller never starts** (`BPMNWorkflowEngine.timerPoller.test.ts`, real
`node-cron` module — the exact singleton `BPMNWorkflowEngine.ts` itself `require()`s,
spied via `vi.spyOn`, not mocked out): `cron.schedule` is never called and nothing is
registered under `TIMER_PROCESSOR_JOB_KEY` in `timerJobs`. A near-miss value (`'TRUE'`)
is also rejected — enum-strict, not truthy coercion.

**Env `=== 'true'` ⇒ poller starts and is stoppable**: `cron.schedule('* * * * *', fn)`
called exactly once, task tracked in `timerJobs`, `shutdown()` calls `.stop()` on it.
Two additional tests seed `timerProcessorTick` directly (the `cron.schedule` stub's
callback never runs, so it can't otherwise exercise the drain): an **ordering** test
proving `shutdown()` does not resolve before an in-flight tick does, and a
**rejection-safety** test proving a rejected tick does not make `shutdown()` reject.

22 tests total (`bpmnTimerPollerConfig.test.ts` ×15, `BPMNWorkflowEngine.timerPoller.test.ts`
×7), all real production code paths, zero mocking of `BPMNWorkflowEngine` itself.

## Mutation self-tests (all restored via `Edit` after committing the real implementation; never `git checkout --`)

| Mutation | Result |
| --- | --- |
| `isBpmnTimerPollerEnabled` hardcoded to `return true` | 16/20 tests red (all of `bpmnTimerPollerConfig.test.ts` bar the env-key-name check, plus both "env unset" engine tests) |
| Gate check in `startTimerProcessor()` short-circuited off (`if (false && ...)`) | 3/5 engine tests red (exactly the "unset ⇒ no schedule" + one shutdown no-op test) |
| `shutdown()`'s `job.stop()` loop neutered (`for (const job of [])`) | Exactly 1/5 red — the "stops the tracked poller task" test |
| `await this.timerProcessorTick.catch(() => undefined)` deleted entirely | Ordering test red (`order` not `[]` before release) **and** an unhandled promise rejection surfaces from the rejection-safety test — the exact production failure mode this fix targets |
| Only the `.catch(() => undefined)` removed (kept the `await`) | Exactly 1/7 red — the rejection-safety test, cleanly, no unhandled-rejection noise |

Every mutation restored; `git diff --stat` empty after each, confirmed against the
commit.

## Real-DB evidence (local PostgreSQL 15, `chouhua` superuser role, fresh scratch DB per run — `ms2_w4c2sweepct_<random>`, dropped in `afterAll`)

**Regression check, default-off (env-gate's actual shipped state)** —
`tests/integration/attendance-w4c2-sweep-call-through.db.test.ts` (the file whose
`afterAll` triggered the original 57P01 in #4779's own CI run), 5 consecutive runs:
8/8 tests pass every time, exit 0 every time, zero occurrences of `57P01` /
`"Cannot use a pool after calling end on the pool"` / `Unhandled Error` across all 5
logs. This is presented as a **regression check**, not a discriminating leg — each run
is ~5s and the poller fires on real minute boundaries, so 5 clean runs at normal cadence
would likely also be clean pre-fix (that's exactly why `1ff5f1aff`'s own validation
amplified the cron cadence, below). The actual discriminating evidence for "default off"
is structural and unit-level: no `cron.schedule` call ⇒ no task object exists ⇒ nothing
can race against `server.stop()`, mutation-proved above.

**Genuine positive control (amplified cadence, `ENABLE_BPMN_TIMER_POLLER=true`)** —
temporarily changed `startTimerProcessor`'s cron expression to `'* * * * * *'`
(every-second, forcing a tick in flight at `server.stop()` + `DROP DATABASE ... WITH
(FORCE)` time, same method `1ff5f1aff` used), then two A/B runs of the same file:

- **With the hygiene fix intact** (shipped state, poller enabled): 5/5 runs, 8/8 tests
  pass each time, zero race markers.
- **With the hygiene fix ALSO reverted** (poller enabled, `cron.schedule`'s return
  value discarded — reproducing pre-`1ff5f1aff` behavior under the same amplification):
  3/3 runs **reproduced the exact original error**, `Timer job processor tick failed:
  ... "Cannot use a pool after calling end on the pool"`, logged at
  `BPMNWorkflowEngine.ts:1567` via the `node-cron` runner — same stack shape as the
  original CI failure. (Tests themselves still passed 8/8 in all 3 runs — the error is
  caught/logged by design post-#4770's error handling, matching #4779's own report of
  "1279/1279 tests passed; only a post-run Unhandled Error tripped the job" — this
  confirms the FAILURE MODE reproduces, independent of whether it also flips a green
  test red.)

Both amplification mutations were reverted via `Edit` before committing (`git diff
--stat` empty against the pushed commits).

## Workflow-neighbor regression (no scope creep into unrelated BPMN/workflow surfaces)

- Full targeted suite: `server-lifecycle.test.ts`, `workflow-job-contract.test.ts`,
  `workflow-egress-route-provenance.test.ts`, `workflow-designer-drafts.test.ts`,
  `workflow-designer-route-models.test.ts`, `workflow-hub-team-views.test.ts`,
  `workflow-approval-automation-convergence.guard.test.ts`,
  `workflow-designer-compile-preview-route.test.ts`,
  `after-sales-workflow-adapter.test.ts`, `bpmn-compile-preview.test.ts`,
  `BPMNWorkflowEngine.egress.test.ts`, `BPMNWorkflowEngine.a3-egress-evidence.test.ts`,
  `bpmnHttpTaskEgressPolicy.test.ts`, plus the 2 new files — **15 files, 116 tests,
  0 failures.**
- `server-lifecycle.test.ts` (pre-existing, unmodified) still shows
  "Shutting down BPMN Workflow Engine" / "BPMN Workflow Engine shutdown complete" firing
  during `server.stop()` — the hygiene wiring fires in the ordinary unit-test path too
  (poller itself stays off there, since `ENABLE_BPMN_TIMER_POLLER` is unset in that
  environment; `shutdown()` still runs and completes cleanly as a no-op for the poller).
- **Full default-discovery run** (`vitest run`, no path restriction — the actual glob
  `pnpm --filter @metasheet/core-backend test` uses in CI's "Run core-backend tests"
  step): **600 files passed, 190 skipped (DB-gated), 8298 tests passed, 0 failed.** Both
  new test files confirmed present in this default discovery (not just my own explicit
  file list) — `grep`-verified against the verbose test-name output.
- §5 legacy-BPMN-import structural guard (`workflow-approval-automation-convergence.guard.test.ts`,
  doctrine #2738/#2740): `BPMNWorkflowEngine.timerPoller.test.ts` imports
  `BPMNWorkflowEngine` directly (to exercise the real `startTimerProcessor`/`shutdown`
  code path) — correctly caught as an unaudited importer on first run, added to the
  frozen `BPMN_IMPORT_ALLOWLIST` with disposition `TEST`, same class as the two
  pre-existing sibling egress test files.
- `pnpm run type-check` (core-backend): clean throughout every commit.
- `eslint` on every touched file: 0 errors (pre-existing `no-explicit-any`/
  `no-unused-vars` warnings in `index.ts` are unrelated lines this PR does not touch).

## plugin-tests.yml

Not touched. Both new test files are plain unit tests (mock `node-cron`'s `schedule` at
the module level, no real DB) picked up by the existing default vitest discovery glob —
same wiring precedent as the pre-existing sibling `BPMNWorkflowEngine.egress.test.ts`
and `BPMNWorkflowEngine.a3-egress-evidence.test.ts` files, neither of which needed
explicit `plugin-tests.yml` wiring either. No `plugin-tests.yml` pin to recompute.

## Merge order

1. **This PR** (env-gate + hygiene) lands first.
2. `claude/w4c2-sweep-observability-20260805` (#4779) rebases onto `main` — its own
   `attendance-w4c2-sweep-call-through.db.test.ts` run will then be structurally clean
   (no `cron.schedule` call at all under the shipped default-off state) rather than
   merely "5/5 clean in this session's regression check."
3. #4780 (or whatever the next attendance slice is) proceeds from there.

`claude/w4c2-sweep-observability-20260805`'s current head (`f89621480310e51f2ad19c9a954b959bcedbcfad`)
has already been reverted to drop `1ff5f1aff`'s BPMN changes (all 3 files now
byte-identical, SHA-256-verified, to `origin/main`) and its PR body updated with this
dependency and the interim-flaky caveat.

## Weak spots (self-reported)

1. Cannot verify from this sandbox whether any live (staging/production) database
   currently has `bpmn_timer_jobs` rows in `WAITING` state — see "residual unknown"
   above. This is the single fact that would change the recommendation from "safe
   default-off" to "set `ENABLE_BPMN_TIMER_POLLER=true` in that deployment first."
2. `startHealthCheck()`'s own ungated 60s interval (queries `bpmn_process_instances`,
   also untracked/unstoppable) is a structurally similar issue, explicitly left
   out of scope — flagging it here rather than silently leaving it undiscovered.
3. The positive-control amplification (`* * * * * *`, every-second cron) was run
   locally against PostgreSQL 15 on this sandbox, not against CI's own Postgres image
   in an actual GitHub Actions run — the original 57P01 was a CI observation; this PR's
   local reproduction (3/3 pre-fix-repro) is the same failure class and same stack
   location, but not the identical CI environment.
4. `2f17d9a0d`'s commit message (already pushed, not rewritten) still carries the
   original "zero consumers"/"no deployed feature reaches" overclaim — the retraction
   lives in `6b653085e`'s commit message and in this PR body, not by rewriting history.
5. `startTimerProcessor`'s `this.timerProcessorTick = (async () => {...})()` is
   **reassigned every tick**, inherited unchanged from the carved-out `1ff5f1aff`. If
   tick N is still in flight when tick N+1 dispatches, `shutdown()`'s
   `await this.timerProcessorTick` only waits on N+1 — tick N is orphaned and could in
   principle still hold a connection past `.stop()`. Not fixed here (task scope was to
   reproduce `1ff5f1aff`'s hygiene, not improve on it), and unreachable under the
   shipped default-off state; only relevant if a deployment sets
   `ENABLE_BPMN_TIMER_POLLER=true` AND overlapping ticks occur (unlikely at the real
   `'* * * * *'` cadence, which is what makes the every-second amplification above a
   deliberate stress test rather than a realistic scenario).
6. `metrics.bpmnTimerJobsTotal` (`bpmn_timer_jobs_total`, both `success`/`failure`
   labels) is only incremented inside `processTimerJob` — reachable only from the
   poller's own tick loop (verified: single call site, ~L1576). Gating the poller off
   means this counter never increments while off — an ops-visible flatline, which is
   the semantically correct signal (nothing is being processed) but worth calling out
   explicitly next to the "pauses, never drops" argument above, in case a dashboard
   alerts on it going stale.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>


---

## Owner review response — batch 1 (2026-08-05, P1-1 / P1-2 / SQL fix / P3-a)

Owner review found the poller env-gate alone insufficient, plus a bad column name in
this PR's own pre-merge checklist below. All three (plus one bonus item) are fixed as
of `243db11f1` / `c0416f912` on this branch:

- **P1-1 (writer gap, fixed)** — env-gating `startTimerProcessor()` off only stopped the
  READER. `createTimerJob()` (the sole `INSERT INTO bpmn_timer_jobs` site) still
  unconditionally persisted a `state: 'WAITING'` row for every date/duration timer,
  reachable from any authenticated user via `/api/workflow/start/:key`, task-complete,
  message, and signal delivery. "Current WAITING count is 0" does not survive a single
  new call after merge. Fixed: `createTimerJob` now fails closed with a dedicated
  `BpmnTimerPollerDisabledError` (`code: 'BPMN_TIMER_POLLER_DISABLED'`) when the poller
  is disabled, for `'date'`/`'duration'` timers only — `'cycle'` timers are unaffected
  (separate in-memory `cron.schedule` path). Proved with a mocked-db unit suite
  (`BPMNWorkflowEngine.timerWriteGate.test.ts`, 7 tests) AND a real-Postgres suite
  (below) confirming ZERO rows land, not just "the mock wasn't called."

- **P1-2 (non-atomic claim, fixed)** — `processTimerJob`'s WAITING -> LOCKED transition
  was a bare unconditional `UPDATE` after a separate `SELECT` — the same bug class #4774
  caught. `routes/workflow.ts` and `routes/workflow-designer.ts` each construct their own
  independent `BPMNWorkflowEngine` instance sharing the same `db` pool; two overlapping
  poller ticks could both claim and double-fire the same timer job. Fixed: the claim
  `UPDATE` now gates on `state = 'WAITING'` and checks `numUpdatedRows`; whichever
  caller's UPDATE lands first wins, every other concurrent claimant matches zero rows and
  backs off silently. **Proved with a constructed real-PostgreSQL race**, not sequential
  reasoning: two independent engine instances race `Promise.all` over the SAME 12-job
  WAITING batch; disjoint claims (overlap = 0), every job fired exactly once, every job
  ends `COMPLETED`. Mutation self-check (reverted to the pre-fix unconditional UPDATE)
  reproduced the exact double-fire — `job … must be fired exactly once, got 2 (engines:
  A,B)` — against real Postgres before the fix was restored.

- **P3-a (bonus, fixed)** — `routes/workflow-designer.ts`'s own `BPMNWorkflowEngine`
  instance had no shutdown export, so `index.ts`'s `stop()` never reached its
  poller/in-flight tick. Added `shutdownWorkflowDesignerEngine()`, mirrored from
  `routes/workflow.ts`'s existing `shutdownWorkflowEngine()`, wired into `stop()`
  alongside it, with a dedicated call-through regression test (spies on the REAL
  `BPMNWorkflowEngine.prototype.shutdown`, not a full-class mock) and its own mutation
  self-check.

- **`plugin-tests.yml` touched** → the s6a package-provenance pin
  (`evidenceFiles.pluginTestsWorkflow` in
  `plugins/plugin-integration-core/lib/sealed-export/vectors/s6a-package-provenance-pins.json`)
  was recomputed via `computePackageProvenancePinSet()` in the same commit;
  `verifySealedExportPackageProvenance()` confirmed green afterward. No other pinned
  file changed.

New real-Postgres suite: `tests/integration/bpmn-timer-job-write-and-claim-safety.db.test.ts`
(5 tests — P1-1 negative + positive-control legs, P1-2's constructed-race leg, and an
already-LOCKED backoff leg). Wired into `plugin-tests.yml` as a whole file and excluded
from the no-DB default job in `vitest.config.ts` (two-point wiring).

**SQL error in the checklist below (mine) — fixed.** `bpmn_timer_jobs` has a `state`
column, not `status`; the original checklist query would 42703 in production. Corrected
below, and its meaning re-scoped now that P1-1 is fixed: **the checklist is no longer the
entire safety argument.** Before this batch, "WAITING count is 0 at merge time" was being
treated as sufficient because nothing was proven about writes AFTER merge. It is not —
new-orphan creation is now closed by P1-1 (the writer itself refuses while the poller is
off), independent of what the count is at merge time. What the checklist below still
covers, narrower and accurately: **pre-existing** `WAITING` rows (if a live deployment
already has any, from before this PR's poller-off default took effect) stay paused, not
processed, until `ENABLE_BPMN_TIMER_POLLER=true` is set for that deployment — the count
below tells an operator whether that pre-existing-row case applies, not whether it's safe
to merge.

## Owner review response — batch 2 (2026-08-06, P1 fail-closed placement)

Owner tested batch 1 against a **freshly migrated database** and found the write gate
placed too late. Batch 1's `createTimerJob` throw stops the `INSERT INTO
bpmn_timer_jobs` itself, but by the time it fires, `startProcess()` has ALREADY
persisted the `bpmn_process_instances` row (`state: 'ACTIVE'`) and `executeStartEvents`/
`executeActivity` have already persisted `bpmn_activity_instances` rows on the way to
the timer. `startProcess()`'s own catch block only logs and rethrows — nothing marks
anything terminated. Owner's real repro (`243db11f1`, fresh migration, real
`startProcess`/HTTP call — not a direct `createTimerJob` call):

```
error: BPMN_TIMER_POLLER_DISABLED
process: ACTIVE            ← permanent residue
activities: startEvent=COMPLETED, intermediateCatchEvent=FAILED
incident: OPEN             ← accumulates on every retry
timer jobs: 0               ← only this write was actually stopped
```

**Fix (owner gave two options; chose via code-reading, not by default): a zero-write
precheck at `startProcess()`'s own entry, before ANY write** — not the alternative
("wrap the whole start in one transaction that rolls back atomically") and explicitly
**not** "persist then transition to a terminal state" (an intermediate revision of this
fix during the same review round did exactly that — persisted the activity row and a
`RESOLVED` incident, then flipped the process to `INTERNALLY_TERMINATED` — and was
discarded before being pushed publicly, because it still leaves non-zero
activity/incident rows behind; the owner's bar is literally zero on all four counts, not
"cleaned up").

The owner's own conditional was: fail-closed at the entry if date/duration-timer
reachability is determinable there; only fall back to the transaction-wrap if it is not.
Read-code verdict: it **is** fully determinable, exactly (not just conservatively).
`createTimerJob`'s `'date'`/`'duration'` branch has exactly ONE call site in this class
(`handleIntermediateEvent`), itself reachable only from `executeActivity`'s
`'intermediateCatchEvent'` case, whose `activityDef.properties.timerDefinition`
`findActivity` extracts from the SAME static BPMN parse. New private helper
`BPMNWorkflowEngine.definitionHasPollerDependentTimer(parsed)` scans the ENTIRE parsed
process tree (any nesting depth, via the existing `findElementsByType`'s unconditional
recursive walk) for any `bpmn:timerEventDefinition` carrying `timeDuration`/`timeDate`
(never `timeCycle` — that's a separate in-memory `cron.schedule` path, unaffected).
Finding nothing means NO execution path through that definition — whichever gateway
branches, whatever the input variables, however deep in a `bpmn:subProcess` — can ever
reach `createTimerJob`'s date/duration branch, this call or any future one. `parseBPMN`
is now called BEFORE the `bpmn_process_instances` insert (previously it ran after), and
this scan runs immediately after that parse, before any write. No transaction-wrap
fallback was needed.

Batch 1's `createTimerJob`-level gate is **not removed** — it stays as defense-in-depth
for `executeActivity` (a `public` method) being invoked some other way outside
`startProcess()`'s own call in the future; today's call graph makes it currently
unreachable in practice (`completeUserTask`'s `continueProcess` re-invokes the SAME
userTask activity rather than advancing past it, and `deliverMessage`/`deliverSignal`
are no-op stubs that never call `executeActivity` at all — verified by reading, not
assumed), but removing it would trade a real safety net for no benefit.

**Completion proof — real HTTP path, not a direct `createTimerJob`/`executeActivity`
call:** new file
`tests/integration/bpmn-poller-disabled-startprocess-zero-residue.db.test.ts` boots a
real `MetaSheetServer` against a fresh-migrated scratch PostgreSQL, mints a real dev
JWT, `POST /api/workflow/deploy`s a process whose start event flows directly into a
`'duration'` `intermediateCatchEvent`, then `POST /api/workflow/start/:key`s it with the
poller disabled (unset). Asserts **FOUR real zeros**: `bpmn_process_instances`,
`bpmn_activity_instances`, `bpmn_incidents`, AND `bpmn_timer_jobs` row counts for that
process all `0` — not "cleaned up to a terminal state." A second test in the same file
is the positive control: the identical setup with a timer-FREE process still starts
normally (`201`, one `ACTIVE` row) — the entry gate does not over-block ordinary starts.

**Probe validity proved by mutation, against the owner's own repro shape.** Two
mutations, each committed-then-reverted via `Edit` (never `git checkout --`, per this
branch's own earlier commit note):
- Neutering the entry-gate condition (`if (false && ...)`) reproduces the owner's EXACT
  residue: `processes: 1, activities: 2, incidents: 1, timers: 0` — the real-DB stack
  trace shows the throw now originates from `createTimerJob` (batch 1's later gate)
  reached via `executeStartEvents → takeSequenceFlow → executeActivity →
  handleIntermediateEvent`, i.e. the identical call chain the owner's own repro walked.
- Neutering `definitionHasPollerDependentTimer` itself (forcing `return false`)
  reproduces the identical residue shape.
Both restored; `git diff --stat` empty against the committed state after each.

**`bpmn-timer-job-write-and-claim-safety.db.test.ts` (P1-1/P1-2, batch 1) re-run
unchanged and still 5/5 green** — the atomic WAITING→LOCKED claim fix and its
constructed-race proof are untouched by this batch.
`workflow-designer-engine-shutdown.test.ts` (P3-a) also re-run unchanged, still green.

**`plugin-tests.yml` touched again** → the s6a package-provenance pin
(`evidenceFiles.pluginTestsWorkflow`) recomputed via `computePackageProvenancePinSet()`
in the same commit; `verifySealedExportPackageProvenance()` confirmed
`candidateTreeVerified: true` afterward, and both
`sealed-export-package-provenance.test.cjs` and
`sealed-export-s5-public-export-surface.test.cjs` re-run green. No other pinned file
changed.

## ⚠️ 合并前 checklist（owner 原述，SQL 已订正，范围已收窄 — 2026-08-05 batch 1，batch 2 后依旧成立）

Before this batch: env-gating the poller off paused (never dropped) any `WAITING` timer
job, and the code could still create NEW orphaned `WAITING` rows after merge (P1-1). That
writer gap is now closed. What this checklist covers now is narrower: **pre-existing**
`WAITING` rows only — those already in the table before this PR's default-off state takes
effect in a given deployment (unlikely per this branch's earlier research: no seed
creates a process definition and no production workflow is known to run, but this sandbox
cannot reach the production DB to confirm). Run the read-only check against production
before enabling this default in that deployment:

```sql
SELECT count(*) FROM bpmn_timer_jobs WHERE state = 'WAITING';
```

- **= 0** → no pre-existing rows to worry about; the poller-off default has no
  operational side effect in that deployment.
- **> 0** → those are genuinely pending timers that default-off would leave paused (not
  processed, not dropped) until the flag is set. Decide first: set
  `ENABLE_BPMN_TIMER_POLLER=true` in that deployment at merge time, or drain/handle the
  rows, before relying on the poller-off default there.

This check is still not a code gate (CI cannot reach prod) — it is an owner/ops
pre-merge verification for the pre-existing-row case specifically, recorded here so it
is not lost at merge time. It is no longer the entire "is this safe to merge" argument —
batch 2's `startProcess()` entry gate is (zero writes for any NEW `'date'`/`'duration'`
timer start while the poller is off, proved as four real zeros above), with batch 1's
`createTimerJob`-level write gate as a second, narrower layer under it.

