### PR TITLE
fix(integration): C6 loaded the write TARGET with the credential-stripped accessor

### DIFF
--- a/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
@@ -3,6 +3,17 @@
 const assert = require('node:assert/strict')
 const path = require('node:path')
 
+// MODEL THE PRODUCT, NOT A CONVENIENCE. The real `getExternalSystem` is the PUBLIC accessor and
+// STRIPS credentials; only `getExternalSystemForAdapter` returns them. These fixtures used to hand
+// back the whole object, so every C6 test was green while the product loaded an adapter-backed
+// target with NO credentials — the dry-run died with K3_WISE_CREDENTIALS_MISSING before any wire
+// call, and five review rounds never saw it because the mock was more permissive than production.
+function publicTargetView(system) {
+  if (!system) return null
+  const { credentials, credentialsEncrypted, ...publicView } = system
+  return { ...publicView, hasCredentials: Boolean(credentials || credentialsEncrypted) }
+}
+
 const HTTP_ROUTES_PATH = path.join(__dirname, '..', 'lib', 'http-routes.cjs')
 const httpRoutes = require(HTTP_ROUTES_PATH)
 const { MAX_LIST_LIMIT } = httpRoutes
@@ -1645,7 +1656,7 @@ async function testPipelineExternalWriteDryRunRoute() {
       },
       async getExternalSystem(input) {
         calls.push(['getExternalSystem', input])
-        if (input.id === targetSystem.id) return { ...targetSystem }
+        if (input.id === targetSystem.id) return publicTargetView(targetSystem)
         return null
       },
     },
@@ -1816,7 +1827,7 @@ async function testPipelineExternalWriteApplyRoute() {
       },
       async getExternalSystem(input) {
         calls.push(['getExternalSystem', input])
-        if (input.id === targetSystem.id) return { ...targetSystem }
+        if (input.id === targetSystem.id) return publicTargetView(targetSystem)
         return null
       },
     },
@@ -2033,7 +2044,7 @@ async function testPipelineExternalWriteApplyTestFailureInjectionRoute() {
         return null
       },
       async getExternalSystem(input) {
-        if (input.id === targetSystem.id) return { ...targetSystem }
+        if (input.id === targetSystem.id) return publicTargetView(targetSystem)
         return null
       },
     },
@@ -2259,7 +2270,7 @@ async function testPipelineExternalWriteApplyPersistsDeadLetterAndProvenance() {
       },
       async getExternalSystem(input) {
         calls.push(['getExternalSystem', input])
-        if (input.id === targetSystem.id) return { ...targetSystem }
+        if (input.id === targetSystem.id) return publicTargetView(targetSystem)
         return null
       },
     },
@@ -2450,7 +2461,7 @@ async function testPipelineExternalWriteApplyDoesNotOverstateProvenancePersisten
         return null
       },
       async getExternalSystem(input) {
-        if (input.id === targetSystem.id) return { ...targetSystem }
+        if (input.id === targetSystem.id) return publicTargetView(targetSystem)
         return null
       },
     },
@@ -5598,7 +5609,7 @@ async function testPipelineExternalWriteMultitableRoute() {
   const { services } = createMockServices({
     externalSystemRegistry: {
       async getExternalSystemForAdapter(input) { calls.push(['getExternalSystemForAdapter', input]); return input.id === sourceSystem.id ? { ...sourceSystem } : null },
-      async getExternalSystem(input) { calls.push(['getExternalSystem', input]); return input.id === targetSystem.id ? { ...targetSystem } : null },
+      async getExternalSystem(input) { calls.push(['getExternalSystem', input]); return input.id === targetSystem.id ? publicTargetView(targetSystem) : null },
     },
     adapterRegistry: {
       createAdapter(system, deps) {
@@ -8449,7 +8460,65 @@ async function testStockPreparationSqlServerSealedSnapshotInternalRoute() {
   assert.equal(calls.length, 1)
 }
 
+async function testC6AdapterBackedTargetLoadsWithCredentials() {
+  // The C6 route loaded the SOURCE via getExternalSystemForAdapter but the TARGET via
+  // getExternalSystem — the PUBLIC accessor, which STRIPS credentials. For targets served by
+  // dataSourceWrites (SQL write-gated, multitable) that is correct and deliberate. For an
+  // ADAPTER-BACKED target it is fatal: the K3 write source builds a real adapter, which then
+  // throws K3_WISE_CREDENTIALS_MISSING before a single wire call.
+  //
+  // No existing test caught it: none used an adapter-backed target, AND the fixtures returned the
+  // whole system from getExternalSystem — a mock more permissive than production. This asserts the
+  // ACCESSOR CHOICE, which is the property, rather than a downstream symptom.
+  const routesSrc = require('node:fs').readFileSync(HTTP_ROUTES_PATH, 'utf8')
+  assert.ok(
+    /ADAPTER_BACKED_C6_TARGET_KINDS\s*=\s*new Set\(\[K3_WISE_C6_WRITE_TARGET_KIND\]\)/.test(routesSrc),
+    'the route must declare which C6 target kinds build an adapter',
+  )
+  assert.ok(
+    /getExternalSystemForAdapter\(targetSystemScope\)/.test(routesSrc),
+    'an adapter-backed C6 target must be re-loaded through the adapter-capable accessor',
+  )
+  // Both C6 handlers (dry-run and apply) must do it — one alone leaves apply broken.
+  const reloads = (routesSrc.match(/getExternalSystemForAdapter\(targetSystemScope\)/g) || []).length
+  assert.equal(reloads, 2, `both C6 handlers must re-load the target (found ${reloads})`)
+
+  // Behavioural half: the selection logic the route performs, against a registry that strips
+  // credentials exactly like production.
+  const targetSystem = {
+    id: 'k3_target', tenantId: 'tenant_1', kind: 'erp:k3-wise-webapi', role: 'target',
+    status: 'active', config: { baseUrl: 'https://k3.example.test' },
+    credentials: { username: 'u', password: 'p', acctId: 'A' },
+  }
+  const seen = []
+  const registry = {
+    async getExternalSystemForAdapter(input) { seen.push(['forAdapter', input.id]); return { ...targetSystem } },
+    async getExternalSystem(input) { seen.push(['public', input.id]); return publicTargetView(targetSystem) },
+  }
+  const ADAPTER_BACKED = new Set(['erp:k3-wise-webapi'])
+  const scope = { id: targetSystem.id, tenantId: 'tenant_1', workspaceId: null }
+  let loaded = await registry.getExternalSystem(scope)
+  assert.equal(loaded.credentials, undefined, 'precondition: the public accessor strips credentials')
+  if (loaded && ADAPTER_BACKED.has(loaded.kind)) loaded = await registry.getExternalSystemForAdapter(scope)
+  assert.ok(loaded.credentials, 'an adapter-backed C6 target MUST end up with credentials')
+
+  // POSITIVE CONTROL — a dataSourceWrites target must NOT reach the credentialed accessor.
+  const sqlTarget = { ...targetSystem, id: 'sql_target', kind: 'data-source:sql-write-gated' }
+  const seen2 = []
+  const registry2 = {
+    async getExternalSystemForAdapter(input) { seen2.push(['forAdapter', input.id]); return { ...sqlTarget } },
+    async getExternalSystem(input) { seen2.push(['public', input.id]); return publicTargetView(sqlTarget) },
+  }
+  let loaded2 = await registry2.getExternalSystem({ id: sqlTarget.id })
+  if (loaded2 && ADAPTER_BACKED.has(loaded2.kind)) loaded2 = await registry2.getExternalSystemForAdapter({ id: sqlTarget.id })
+  assert.equal(loaded2.credentials, undefined, 'a dataSourceWrites target stays config-only')
+  assert.equal(seen2.some(([fn]) => fn === 'forAdapter'), false,
+    'the credentialed accessor must NOT be reached for a non-adapter-backed target')
+  console.log('  PASS  C6 adapter-backed target loads with credentials')
+}
+
 async function main() {
+  await testC6AdapterBackedTargetLoadsWithCredentials()
   await testTemplatesCrudRoutes()
   await testUnauthenticatedWriteRequestIsRejected()
   await testStockPreparationTargetProvisioningRoutes()

--- a/plugins/plugin-integration-core/lib/http-routes.cjs
+++ b/plugins/plugin-integration-core/lib/http-routes.cjs
@@ -1048,6 +1048,11 @@ function normalizeC6WriteApplyBody(body = {}) {
 // write-source (zero external write); any other (default) target uses the host SQL write
 // facade unchanged. Used by BOTH the dry-run and apply handlers with identical inputs so the
 // apply recompute reproduces the same dry-run revision (the revision fence).
+// C6 targets whose write source builds a TARGET ADAPTER, and therefore need credentials on the
+// loaded system. Everything else (SQL write-gated, multitable) is served by dataSourceWrites and
+// is deliberately loaded config-only.
+const ADAPTER_BACKED_C6_TARGET_KINDS = new Set([K3_WISE_C6_WRITE_TARGET_KIND])
+
 function resolveC6WritePlanInputs({ targetSystem, pipeline, context, adapterRegistry, ownerPrincipal, readSourceConfigs }) {
   // K3WriteDecision (owner, 20260805): the K3 connector rides the same C6 dry-run->apply
   // lifecycle via its own profile + adapter-backed write source. `enforcedMaxRows` pins the
@@ -3372,11 +3377,28 @@ function createHandlers(services, options = {}) {
         tenantId: body.tenantId,
         workspaceId: body.workspaceId,
       }))
-      const targetSystem = await externalSystems.getExternalSystem(scopedInput(req, {
+      // `getExternalSystem` is the credential-STRIPPED public accessor. The SOURCE has always used
+      // the adapter-capable one (a few lines above); the TARGET never did — so an adapter-backed
+      // target (K3) arrived with NO credentials and the C6 dry-run died with
+      // K3_WISE_CREDENTIALS_MISSING before a single wire call. Reproduced against the real
+      // registry: flipping this one accessor makes the whole lifecycle pass.
+      //
+      // Peek first, then re-load WITH credentials only for kinds that actually build a target
+      // adapter. Kinds served by dataSourceWrites keep the config-only load they were designed
+      // for, so this does not widen credential exposure for them.
+      const targetSystemScope = scopedInput(req, {
         id: pipeline.targetSystemId,
         tenantId: body.tenantId,
         workspaceId: body.workspaceId,
-      }))
+      })
+      let targetSystem = await externalSystems.getExternalSystem(targetSystemScope)
+      if (
+        targetSystem
+        && ADAPTER_BACKED_C6_TARGET_KINDS.has(targetSystem.kind)
+        && typeof externalSystems.getExternalSystemForAdapter === 'function'
+      ) {
+        targetSystem = await externalSystems.getExternalSystemForAdapter(targetSystemScope)
+      }
       if (!sourceSystem) {
         throw new HttpRouteError(404, 'SOURCE_SYSTEM_NOT_FOUND', 'source external system not found')
       }
@@ -3452,11 +3474,28 @@ function createHandlers(services, options = {}) {
         tenantId: body.tenantId,
         workspaceId: body.workspaceId,
       }))
-      const targetSystem = await externalSystems.getExternalSystem(scopedInput(req, {
+      // `getExternalSystem` is the credential-STRIPPED public accessor. The SOURCE has always used
+      // the adapter-capable one (a few lines above); the TARGET never did — so an adapter-backed
+      // target (K3) arrived with NO credentials and the C6 dry-run died with
+      // K3_WISE_CREDENTIALS_MISSING before a single wire call. Reproduced against the real
+      // registry: flipping this one accessor makes the whole lifecycle pass.
+      //
+      // Peek first, then re-load WITH credentials only for kinds that actually build a target
+      // adapter. Kinds served by dataSourceWrites keep the config-only load they were designed
+      // for, so this does not widen credential exposure for them.
+      const targetSystemScope = scopedInput(req, {
         id: pipeline.targetSystemId,
         tenantId: body.tenantId,
         workspaceId: body.workspaceId,
-      }))
+      })
+      let targetSystem = await externalSystems.getExternalSystem(targetSystemScope)
+      if (
+        targetSystem
+        && ADAPTER_BACKED_C6_TARGET_KINDS.has(targetSystem.kind)
+        && typeof externalSystems.getExternalSystemForAdapter === 'function'
+      ) {
+        targetSystem = await externalSystems.getExternalSystemForAdapter(targetSystemScope)
+      }
       if (!sourceSystem) {
         throw new HttpRouteError(404, 'SOURCE_SYSTEM_NOT_FOUND', 'source external system not found')
       }

--- a/plugins/plugin-integration-core/lib/sealed-export/vectors/s6a-package-provenance-pins.json
+++ b/plugins/plugin-integration-core/lib/sealed-export/vectors/s6a-package-provenance-pins.json
@@ -70,7 +70,7 @@
     "pluginPackageJson": "d32fbaae74d8b710a363cbcf1215ff1c30c71091e7aec3f68a98978e7818d707",
     "pnpmLock": "8ca98ceef0c84b821c4b20a0f0cf0b50b87dfb51a26b6a2d21a9912a1733680f",
     "pluginIndex": "c2a800452d175e2b00a476b3e0d3fab6f65e16031789b91a0304dd1dc45a0cee",
-    "pluginHttpRoutes": "de8d96505c3ef8c7d6854d224fac44b0acf42947f575f06f7228a68c6a60c181",
+    "pluginHttpRoutes": "89532716d6f5bc224fc6b75ffb3c2b90b4d6995e3a60f01377af5f685820a132",
     "s6aProvisioningCli": "d3320b27da7ab358ca068a3766a375e669fb6922f24ba0186ba0828c3e1d9da8",
     "s6aAcceptanceRunner": "eb58824cba1ab03361a6a4fba409f3f7a120dcda61d4c3d6cad2b82311d62624",
     "s6aOnpremRunbook": "1f4ba2b7fadbad0acb97e18d13f2be7ad6071fa372ac44e0aa4e17995e94c410",


### PR DESCRIPTION
Found by a six-lens adversarial review of #4768, and it survived independent refutation. **Pre-existing on `main`, outside that PR's diff** — but it is why the rehearsal lane would have been inert on first dispatch, and **the customer window runbook drives the same two routes**.

## The defect

Both C6 handlers loaded the **source** through `getExternalSystemForAdapter` (credentials included) and the **target** through `getExternalSystem` — the public accessor, which **strips** them.

For targets served by `dataSourceWrites` (SQL write-gated, multitable) that is correct and deliberate: they never build an adapter. For an **adapter-backed** target it is fatal — the K3 write source calls `adapterRegistry.createAdapter(system, …)`, and the adapter throws `K3_WISE_CREDENTIALS_MISSING` **before a single wire call**.

Fixed narrowly: peek with the public accessor, re-load through the adapter-capable one **only** for kinds in `ADAPTER_BACKED_C6_TARGET_KINDS`. Config-only loading is preserved for every other kind, so this does not widen credential exposure.

## Why five review rounds missed it

`http-routes.test.cjs` fixtures returned the **whole system** from `getExternalSystem`, credentials included. The mock was more permissive than production, so every C6 test was green while the product shipped a target with none.

That defeats review by construction — no amount of reading the diff finds a bug the fixture is actively concealing. All six fixture sites now model the public accessor through one shared `publicTargetView` helper.

I had also **seen the symptom and explained it away**: while probing B4 wiring on #4768 I hit `K3WiseWebApiAdapterError: credentials … are required` in the K3 PoC harness — which, unlike these fixtures, always modelled production correctly — and recorded it as *"the gate is satisfied, it now fails later on credentials."* The evidence was on screen and I read it as someone else's problem.

## Coverage

`testC6AdapterBackedTargetLoadsWithCredentials` asserts the **accessor choice** — the property — rather than a downstream symptom, with a behavioural half against a credential-stripping registry and a positive control proving a `dataSourceWrites` target still does *not* reach the credentialed accessor.

| mutation | result |
|---|---|
| route fix reverted entirely | **RED** |
| only the **apply** handler reverted | **RED** — a one-handler fix leaves apply broken |
| restored | GREEN |

Stated because it matters: the **fixture correction alone does not go red**. No pre-existing test used an adapter-backed target, so the fixtures were necessary but not sufficient — the new test is what carries the property.

`pluginHttpRoutes` re-pinned in the same commit. Sweep: 146 pass / 13 env-only (`Cannot find module`, this bare worktree) / **0 assertion failures**.

Blocks #4768.