### PR TITLE
fix(integration): K3 WISE adapter 声明 source 角色(修复 UI 授权路径的元数据滞后)

### DIFF
--- a/plugins/plugin-integration-core/__tests__/k3-wise-adapters.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/k3-wise-adapters.test.cjs
@@ -2277,7 +2277,41 @@ async function main() {
   testK3SqlServerExecutorKeepsK3IdentifierPolicy()
   await testK3SqlServerChannel()
   await testK3WebApiAutoFlagCoercion()
+  await testAdapterMetadataDeclaresBothSides()
+
   console.log('✓ k3-wise-adapters: WebAPI, SQL Server channel, and auto-flag coercion tests passed')
+}
+
+async function testAdapterMetadataDeclaresBothSides() {
+  const { K3_WISE_WEBAPI_ADAPTER_METADATA: meta } =
+    require('../lib/adapters/k3-wise-webapi-adapter.cjs')
+
+  // WHY THIS IS PINNED. `roles` is the ONLY gate on which sides the adapter may be AUTHORED for
+  // (IntegrationWorkbenchView's adapterSupportsSide; `supports` is unset so its capability branch
+  // already passes). Declaring `target` alone made a K3 READ record unauthorable through the UI,
+  // which blocked the customer-window configuration repair — the runbook requires TWO K3 records
+  // because #4769 strips every readList* key from a profile-armed one. The read capability was
+  // never missing; only this declaration was stale.
+  assert.ok(Array.isArray(meta.roles), 'metadata.roles must be an array')
+  for (const side of ['source', 'target']) {
+    assert.ok(meta.roles.includes(side),
+      `metadata.roles must include '${side}' — dropping it makes that side unauthorable in the UI `
+      + 'while the backend still accepts it, which is exactly how the read record became '
+      + 'impossible to create')
+  }
+
+  // And the inverse property, so this change cannot be read as loosening the write-side lock:
+  // the readList* strip is keyed on the ARMED PROFILE, not on the record's role. If a `role`
+  // branch ever appears in the adapter, that assumption needs re-checking rather than inheriting.
+  const src = require('node:fs').readFileSync(
+    require.resolve('../lib/adapters/k3-wise-webapi-adapter.cjs'), 'utf8')
+  const code = src.replace(/\/\*[^]*?\*\//g, ' ').split('\n')
+    .filter((l) => !l.trim().startsWith('//')).join('\n')
+  assert.ok(!/\brole\s*===|\brole\s*!==|system\.role\b/.test(code),
+    'the adapter must stay role-agnostic: the readList* strip is profile-keyed, and a role branch '
+    + 'here would mean adding the source role could change write-side behaviour')
+
+  console.log('  k3-wise metadata: both sides declared, adapter stays role-agnostic OK')
 }
 
 main().catch((err) => {

--- a/plugins/plugin-integration-core/lib/adapters/k3-wise-webapi-adapter.cjs
+++ b/plugins/plugin-integration-core/lib/adapters/k3-wise-webapi-adapter.cjs
@@ -2574,9 +2574,23 @@ function createK3WiseWebApiAdapterFactory(defaults = {}) {
   return (input = {}) => createK3WiseWebApiAdapter({ ...defaults, ...input })
 }
 
+// `roles` is the ONLY thing gating which sides this adapter may be authored for:
+// IntegrationWorkbenchView's `adapterSupportsSide` reads it, and `supports` is unset here, so the
+// source-side capability branch already passes. Declaring `target` alone therefore made a K3
+// READ record unauthorable through the UI — while the backend has no such check at all and the
+// staging rehearsal has been creating `role: 'source'` K3 records (and passing 17/17) all along.
+//
+// That gap blocked the customer-window配置修复: the runbook requires TWO K3 records (one read,
+// one armed write, per #4769 which strips every readList* key from a profile-armed record), and
+// the UI refused to create the read one. The read capability was never missing — GetList /
+// GetDetail / read-smoke all run through this adapter, and #4757 specifically fixed its GetList
+// projection — only this declaration was stale.
+//
+// This does NOT loosen the write-side lock: the readList* strip is keyed on the armed PROFILE,
+// and this file contains no `role`-dependent branch, so an armed write record gains nothing.
 const K3_WISE_WEBAPI_ADAPTER_METADATA = {
   label: 'K3 WISE WebAPI',
-  roles: ['target'],
+  roles: ['source', 'target'],
   advanced: false,
 }
 


### PR DESCRIPTION
> ## ⚠️ 撤回(2026-08-07)
>
> 本 PR 原标题与原「阻塞关系」段声称**合并即解除 #4628 的配置修复阻塞**。**该声明过强,现撤回。**
>
> `roles` 是 adapter 模块常量,**随构建烘焙**。配置负责人操作的受控配置面若不是跟随 main 的部署,
> 合并**不改变**那个环境;而 `packageDeployment=NOT_AUTHORIZED`。
>
> 另有一条**与本 PR 无关、且本 PR 修不掉**的第二道门:`upsertExternalSystem` 对已存在记录抛
> `kind and role cannot be changed after creation`(在 `7bf2bd7a1` / `aa48c3f18` / 本 head 三个构建上
> 均已核验)。⇒ 修复必须**新建**一条 K3-read 记录,而不是把现有 target 记录改成 source ——
> **这条要求在本 PR 合并并重部署之后依然成立。**
>
> 完整分析与待裁的三个分支见 [#4628 comment](https://github.com/zensgit/metasheet2/issues/4628#issuecomment-5213929502)。
> **本 PR 的真实范围 = 修复 UI 授权路径上的元数据滞后**,不是解除窗口阻塞。

---

K3 WebAPI adapter 被声明为 **target-only**,把草稿改成 `role=source` 立刻禁用保存,于是
**K3-read 记录无法经批准的 UI 路径创建**。

## 这是元数据滞后,不是设计意图

| 事实 | 位置 |
|---|---|
| adapter 声明 `roles: ['target']` | `k3-wise-webapi-adapter.cjs:2577` |
| FE 据此拦下 `role=source` | `IntegrationWorkbenchView.vue:1265` → `adapterSupportsSide` |
| **后端零校验**(`role` 与 `adapter.roles` 无关联检查) | 全仓 grep 无命中 |
| **彩排一直用 `role:'source'` 建 K3 读记录并跑通 17/17** | `stock-prep-window-rehearsal-driver.mjs:121` |
| adapter 实现了完整读路径 | GetList / GetDetail / read-smoke;#4757 专门修过 GetList 投影 |

**读能力从未缺失,只有这一行声明是旧的。** 且 `supports` 未声明 ⇒ `adapterSupportsSide` 的
source 侧能力分支本就放行 ⇒ **`roles` 是唯一的闸**,改它即可,无需动 `supports`。

## 不放宽写入面锁

#4769 剥 `readList*` 的守卫**按 armed profile 判定**,与记录 `role` 无关;adapter 内**零处**按
`role` 分支。所以加 source 角色**不会**让 armed 写记录获得 list 读。

这一点不靠断言,靠守卫钉住 —— 见下面第 2 条。

## 守卫的守卫(2 条,变异各自见红)

| 守卫 | 变异 | 结果 |
|---|---|---|
| `roles` 必须同时含 source 与 target | 改回 `['target']` | **RED** |
| adapter 必须保持 **role-agnostic**(去注释后源码不得出现 `role` 分支) | 引入 `defaults.role === 'source'` | **RED** |

第 2 条钉的是「不放宽写入面锁」的**前提**:前提若变,守卫先红,而不是等现场出事。

## 验证

`k3-wise-adapters` 套件绿;`plugin-integration-core` 整链 exit 0;provenance pins 已扫(0 变动)。
required checks 9/9 绿,红 0。

## 放行

这是**能力声明变更**,auto-merge 未 arm,放行由 owner 判。合并会经 `docker-build.yml`
(push main ⇒ build+deploy,`paths-ignore` 只排除 `docs/**`/`output/**`,本 PR 改 `plugins/**`)
触发一次自动重部署 —— 这属于放行决定的一部分,请一并考虑。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
