### PR TITLE
fix(test-infra): #4791 — scratch-DB teardown 排空后再 drop(带判据)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -1248,6 +1248,7 @@ jobs:
             tests/integration/attendance-result-edit.test.ts \
             tests/integration/attendance-shift-segments-migration.db.test.ts \
             tests/integration/attendance-shift-segments-writer-matrix.db.test.ts \
+            tests/integration/scratch-database-drain.db.test.ts \
             --reporter=dot
 
       - name: Upload test results

--- a/packages/core-backend/tests/helpers/scratch-database.ts
+++ b/packages/core-backend/tests/helpers/scratch-database.ts
@@ -29,13 +29,156 @@
  * discriminator: callers log it unconditionally, `CLEAN` is the claim this helper makes, and a
  * `FORCED` line names the component still holding a connection (that is the root cause #4791
  * asks for, and it is not knowable any other way).
+ *
+ * ## Fail-closed, and evidence-based (review #4799 P2-1)
+ *
+ * Every statement this helper issues is REQUIRED to succeed. An earlier revision wrapped the
+ * `ALTER`, the plain `DROP` and the forced `DROP` in `.catch(() => undefined)` and then returned
+ * `CLEAN`/`FORCED` anyway — so a DDL failure was reported as a terminal-clean teardown. There is
+ * no swallowing left: any statement error becomes a `ScratchDropError` carrying the `step` that
+ * failed, and it propagates. In particular there is deliberately NO "plain DROP failed, retry
+ * with FORCE" fallback — that would make `CLEAN` vs `FORCED` unfalsifiable, which is the exact
+ * ambiguity this helper exists to remove.
+ *
+ * And a terminal status is never assumed: before returning CLEAN or FORCED the helper re-queries
+ * `pg_database` and requires the row to be GONE. `DROP DATABASE IF EXISTS` reports success when
+ * it dropped nothing, so "the statement did not error" is not evidence that the database is
+ * actually gone — only the read-back is.
+ *
+ * ## Values-free logging, by construction (review #4799 P2-2)
+ *
+ * An earlier revision selected `left(query, 200)` from `pg_stat_activity` and put that SQL text
+ * into the log line that is documented as values-free. SQL text can embed row values (literals in
+ * a statement), so that log could leak data. `query` is no longer selected AT ALL — it cannot be
+ * logged because it is never read. What remains is closure status, connection counts, and closed
+ * enum categories (`state`, `wait_event_type`) plus the connection-identity `application_name`,
+ * which is a label our own call sites set — not SQL and not a row value. Every field that reaches
+ * the log is passed through a positive charset whitelist and truncated, so the emitted line is
+ * bounded by construction rather than by the good behaviour of its inputs.
  */
-import type { Pool } from 'pg'
+
+/**
+ * The only capability this helper needs from its admin handle. Declared structurally (rather than
+ * as `pg.Pool`) so a test can substitute a genuinely type-checked failure-injecting proxy without
+ * an `as unknown as Pool` cast — an injection that has to be cast into place is an injection whose
+ * shape nobody checked. A real `pg.Pool` satisfies this.
+ */
+export interface ScratchAdminQueryable {
+  query(text: string, values?: unknown[]): Promise<{ rows: unknown[] }>
+}
+
+/** The statement being issued when a teardown failed. Closed set — safe to put in a log line. */
+export type ScratchDropStep =
+  | 'probe_exists'
+  | 'revoke_connections'
+  | 'count_attached'
+  | 'inspect_residual'
+  | 'terminate_backends'
+  | 'drop_plain'
+  | 'drop_forced'
+  | 'confirm_absent'
+
+export const SCRATCH_DROP_STEPS: readonly ScratchDropStep[] = [
+  'probe_exists',
+  'revoke_connections',
+  'count_attached',
+  'inspect_residual',
+  'terminate_backends',
+  'drop_plain',
+  'drop_forced',
+  'confirm_absent',
+]
+
+/**
+ * Thrown for EVERY teardown failure. `step` is what makes the failure diagnosable without the
+ * caller having to parse a driver message, and it is the only failure detail that reaches the
+ * values-free log — the underlying driver message travels in `message`/`cause`, i.e. to the test
+ * runner's failure output, never to the teardown log line.
+ */
+export class ScratchDropError extends Error {
+  readonly step: ScratchDropStep
+  readonly drainMs: number
+
+  constructor(step: ScratchDropStep, detail: string, drainMs: number, options?: { cause?: unknown }) {
+    super(`SCRATCH_DROP_FAILED step=${step} detail=${detail}`, options)
+    this.name = 'ScratchDropError'
+    this.step = step
+    this.drainMs = drainMs
+  }
+}
+
+/**
+ * `pg_stat_activity.state`, mapped onto a closed snake_case enum. The raw values contain spaces
+ * and parentheses (`idle in transaction (aborted)`), which would put unbounded-shaped text into a
+ * log line whose grammar is asserted; the enum keeps the grammar decidable.
+ */
+export type ScratchBackendCategory =
+  | 'active'
+  | 'idle'
+  | 'idle_in_transaction'
+  | 'idle_in_transaction_aborted'
+  | 'fastpath_function_call'
+  | 'disabled'
+  | 'unknown'
+
+const BACKEND_CATEGORY_BY_PG_STATE: Readonly<Record<string, ScratchBackendCategory>> = {
+  active: 'active',
+  idle: 'idle',
+  'idle in transaction': 'idle_in_transaction',
+  'idle in transaction (aborted)': 'idle_in_transaction_aborted',
+  'fastpath function call': 'fastpath_function_call',
+  disabled: 'disabled',
+}
+
+export function categoriseBackendState(state: string | null | undefined): ScratchBackendCategory {
+  if (typeof state !== 'string') return 'unknown'
+  return BACKEND_CATEGORY_BY_PG_STATE[state] ?? 'unknown'
+}
+
+/** `pg_stat_activity.wait_event_type` domain in PG 15, plus the two out-of-band cases. */
+const WAIT_EVENT_TYPES = new Set([
+  'Activity',
+  'BufferPin',
+  'Client',
+  'Extension',
+  'IO',
+  'IPC',
+  'Lock',
+  'LWLock',
+  'Timeout',
+])
+
+export function categoriseWaitEventType(waitEventType: string | null | undefined): string {
+  if (typeof waitEventType !== 'string' || waitEventType === '') return 'none'
+  return WAIT_EVENT_TYPES.has(waitEventType) ? waitEventType : 'other'
+}
+
+/**
+ * Positive charset whitelist for anything that reaches the log line. `/`, `|`, `[`, `]` and `=`
+ * are the log's structural separators and are therefore NOT in the whitelist, so no field value
+ * can forge structure. The complement of a whitelist is bounded; the complement of a denylist of
+ * bad spellings is not.
+ */
+const LOG_TOKEN_ALLOWED = /[^A-Za-z0-9_.-]/g
+
+function logToken(value: string | null | undefined, fallback: string, maxLength = 48): string {
+  const raw = typeof value === 'string' ? value : ''
+  const sanitised = raw.replace(LOG_TOKEN_ALLOWED, '_').slice(0, maxLength)
+  return sanitised.length > 0 ? sanitised : fallback
+}
 
 export interface ScratchResidualBackend {
+  /**
+   * `pg_stat_activity.application_name` — a connection-identity label set by the connecting
+   * component, which is why it survives into the log: it is the only channel that NAMES the
+   * component still holding a connection. It is not SQL text and not a row value. It is
+   * nevertheless charset-bounded at format time, because it is set by whoever connected.
+   */
   applicationName: string
-  state: string
-  query: string
+  /** Closed enum, from `pg_stat_activity.state`. */
+  category: ScratchBackendCategory
+  /** Closed enum, from `pg_stat_activity.wait_event_type`. */
+  waitEventType: string
 }
 
 export interface ScratchDropOutcome {
@@ -70,16 +213,40 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms))
 }
 
+function messageOf(err: unknown): string {
+  if (err instanceof Error && typeof err.message === 'string') return err.message
+  return String(err)
+}
+
+/**
+ * Run one teardown statement. NOTHING here swallows: a driver error is re-thrown as a
+ * `ScratchDropError` naming the step. This function is the single choke point for that rule, so
+ * "is any teardown statement still fail-open?" is answerable by reading the call sites below
+ * rather than by auditing N independent `.catch()` clauses.
+ */
+async function step<R>(
+  stepName: ScratchDropStep,
+  startedAt: number,
+  run: () => Promise<R>,
+): Promise<R> {
+  try {
+    return await run()
+  } catch (err) {
+    throw new ScratchDropError(stepName, messageOf(err), Date.now() - startedAt, { cause: err })
+  }
+}
+
 /**
  * Drop a scratch database after draining its backends. See the file header for why the ordering
- * (revoke → drain → drop) matters and why the return value is the deliverable.
+ * (revoke → drain → drop) matters, why the return value is the deliverable, and why every step
+ * fails closed.
  *
- * Never throws for the ordinary paths (absent database, backends that refuse to leave); an
- * unsafe identifier DOES throw, because that is a caller bug and silently proceeding would run
- * caller-shaped text as DDL.
+ * Throws `ScratchDropError` if any statement fails, or if the database is still present after the
+ * drop. Returns only when the database is CONFIRMED gone. An unsafe identifier throws too — that
+ * is a caller bug, and proceeding would run caller-shaped text as DDL.
  */
 export async function dropScratchDatabase(
-  adminPool: Pool,
+  adminPool: ScratchAdminQueryable,
   scratchName: string,
   options: { drainTimeoutMs?: number; pollIntervalMs?: number } = {},
 ): Promise<ScratchDropOutcome> {
@@ -88,22 +255,35 @@ export async function dropScratchDatabase(
   const pollIntervalMs = options.pollIntervalMs ?? 50
   const startedAt = Date.now()
 
-  const exists = await adminPool.query('SELECT 1 FROM pg_database WHERE datname = $1', [scratchName])
-  if (exists.rowCount === 0) {
+  const stillPresent = async (stepName: ScratchDropStep): Promise<boolean> => {
+    const res = await step(stepName, startedAt, () =>
+      adminPool.query('SELECT 1 FROM pg_database WHERE datname = $1', [scratchName]),
+    )
+    // `rows.length`, not `rowCount`: `rowCount` is nullable in the pg typings, and `=== 0` on a
+    // null would report "absent" for a query that returned rows — a fail-OPEN read-back.
+    return res.rows.length > 0
+  }
+
+  if (!(await stillPresent('probe_exists'))) {
     return { drained: true, forced: false, residualBackends: 0, drainMs: 0, residual: [] }
   }
 
   // (1) Revoke connect rights BEFORE counting, so a reconnecting pool cannot re-attach between
   // the count and the DROP. Without this the drain below is a TOCTOU check, not a guarantee.
-  await adminPool.query(`ALTER DATABASE "${scratchName}" ALLOW_CONNECTIONS false`).catch(() => undefined)
+  await step('revoke_connections', startedAt, () =>
+    adminPool.query(`ALTER DATABASE "${scratchName}" ALLOW_CONNECTIONS false`),
+  )
 
   // (2) Wait for the backends that are already attached to finish and detach on their own.
   const countAttached = async (): Promise<number> => {
-    const r = await adminPool.query<{ n: string }>(
-      'SELECT count(*)::text AS n FROM pg_stat_activity WHERE datname = $1 AND pid <> pg_backend_pid()',
-      [scratchName],
+    const res = await step('count_attached', startedAt, () =>
+      adminPool.query(
+        'SELECT count(*)::text AS n FROM pg_stat_activity WHERE datname = $1 AND pid <> pg_backend_pid()',
+        [scratchName],
+      ),
     )
-    return Number(r.rows[0]?.n ?? 0)
+    const row = res.rows[0] as { n?: string } | undefined
+    return Number(row?.n ?? 0)
   }
 
   let attached = await countAttached()
@@ -113,46 +293,104 @@ export async function dropScratchDatabase(
   }
 
   if (attached === 0) {
-    const drainMs = Date.now() - startedAt
-    await adminPool.query(`DROP DATABASE IF EXISTS "${scratchName}"`).catch(() => undefined)
-    return { drained: true, forced: false, residualBackends: 0, drainMs, residual: [] }
+    await step('drop_plain', startedAt, () => adminPool.query(`DROP DATABASE IF EXISTS "${scratchName}"`))
+    // Read-back. `DROP DATABASE IF EXISTS` succeeds when it drops nothing, so a non-throwing
+    // statement is NOT evidence the database is gone. CLEAN is only reported against evidence.
+    if (await stillPresent('confirm_absent')) {
+      throw new ScratchDropError(
+        'confirm_absent',
+        'database still present after plain DROP',
+        Date.now() - startedAt,
+      )
+    }
+    return { drained: true, forced: false, residualBackends: 0, drainMs: Date.now() - startedAt, residual: [] }
   }
 
   // (3) Deadline expired. Name the holders BEFORE terminating them — this is the only place the
-  // identity of the component that keeps the connection open is observable.
-  const residualRows = await adminPool
-    .query<{ application_name: string | null; state: string | null; query: string | null }>(
-      `SELECT application_name, state, left(query, 200) AS query
+  // identity of the component that keeps the connection open is observable. `query` is
+  // deliberately NOT selected: it is SQL text, it can embed row values, and it would end up in a
+  // log line documented as values-free (review #4799 P2-2).
+  const residualRes = await step('inspect_residual', startedAt, () =>
+    adminPool.query(
+      `SELECT application_name, state, wait_event_type
          FROM pg_stat_activity
         WHERE datname = $1 AND pid <> pg_backend_pid()`,
       [scratchName],
-    )
-    .catch(() => ({ rows: [] as Array<{ application_name: string | null; state: string | null; query: string | null }> }))
-  const residual: ScratchResidualBackend[] = residualRows.rows.map((row) => ({
+    ),
+  )
+  const residual: ScratchResidualBackend[] = (
+    residualRes.rows as Array<{
+      application_name?: string | null
+      state?: string | null
+      wait_event_type?: string | null
+    }>
+  ).map((row) => ({
     applicationName: row.application_name ?? '',
-    state: row.state ?? '',
-    query: row.query ?? '',
+    category: categoriseBackendState(row.state),
+    waitEventType: categoriseWaitEventType(row.wait_event_type),
   }))
 
-  await adminPool
-    .query('SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = $1 AND pid <> pg_backend_pid()', [
-      scratchName,
-    ])
-    .catch(() => undefined)
-  await adminPool.query(`DROP DATABASE IF EXISTS "${scratchName}" WITH (FORCE)`).catch(() => undefined)
+  await step('terminate_backends', startedAt, () =>
+    adminPool.query(
+      'SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = $1 AND pid <> pg_backend_pid()',
+      [scratchName],
+    ),
+  )
+  await step('drop_forced', startedAt, () =>
+    adminPool.query(`DROP DATABASE IF EXISTS "${scratchName}" WITH (FORCE)`),
+  )
+  if (await stillPresent('confirm_absent')) {
+    throw new ScratchDropError('confirm_absent', 'database still present after forced DROP', Date.now() - startedAt)
+  }
 
-  return { drained: false, forced: true, residualBackends: residual.length || attached, drainMs: Date.now() - startedAt, residual }
+  return {
+    drained: false,
+    forced: true,
+    residualBackends: residual.length || attached,
+    drainMs: Date.now() - startedAt,
+    residual,
+  }
 }
 
 /**
  * Values-free one-liner for the CI log. `CLEAN` is the claim; `FORCED` is the counter-evidence
  * that keeps #4791 open and names the holder. Emitted unconditionally by both call sites — a
  * line that only appears on failure cannot distinguish "drain worked" from "drain never ran".
+ *
+ * Contains NO SQL text and NO row values: only the closure status, the drain duration, the
+ * connection count, and per-holder `application_name` / state category / wait-event category —
+ * every one of them charset-bounded by `logToken`.
  */
 export function formatScratchDropOutcome(label: string, outcome: ScratchDropOutcome): string {
-  if (!outcome.forced) return `scratchDrain=CLEAN suite=${label} drainMs=${outcome.drainMs}`
+  const suite = logToken(label, 'unlabelled')
+  const drainMs = Math.max(0, Math.trunc(outcome.drainMs))
+  if (!outcome.forced) {
+    return `scratchDrain=CLEAN suite=${suite} drainMs=${drainMs} residualBackends=0`
+  }
   const holders = outcome.residual
-    .map((r) => `${r.applicationName || '<unnamed>'}:${r.state || '<nostate>'}:${r.query.replace(/\s+/g, ' ').slice(0, 120)}`)
-    .join(' | ')
-  return `scratchDrain=FORCED suite=${label} drainMs=${outcome.drainMs} residualBackends=${outcome.residualBackends} holders=[${holders}]`
+    .map(
+      (r) =>
+        `${logToken(r.applicationName, 'unnamed')}/${logToken(r.category, 'unknown', 32)}/${logToken(
+          r.waitEventType,
+          'none',
+          32,
+        )}`,
+    )
+    .join('|')
+  const count = Math.max(0, Math.trunc(outcome.residualBackends))
+  return `scratchDrain=FORCED suite=${suite} drainMs=${drainMs} residualBackends=${count} holders=[${holders}]`
+}
+
+/**
+ * The third status. Teardown now fails closed, so a caller that logs only CLEAN/FORCED would go
+ * SILENT on exactly the case worth seeing. Call sites log this and then RE-THROW, which keeps the
+ * "one line, unconditionally" property without converting a failure into a pass.
+ *
+ * Carries the `step` enum only — never the driver message, which can quote statement text.
+ */
+export function formatScratchDropFailure(label: string, err: unknown): string {
+  const suite = logToken(label, 'unlabelled')
+  const step = err instanceof ScratchDropError ? err.step : undefined
+  const drainMs = err instanceof ScratchDropError ? Math.max(0, Math.trunc(err.drainMs)) : 0
+  return `scratchDrain=FAILED suite=${suite} drainMs=${drainMs} step=${logToken(step, 'unknown', 32)}`
 }

--- a/packages/core-backend/tests/helpers/scratch-database.ts
+++ b/packages/core-backend/tests/helpers/scratch-database.ts
@@ -1,0 +1,158 @@
+/**
+ * #4791 — teardown drain for real-server scratch databases.
+ *
+ * The failure this closes: a suite that boots a REAL `MetaSheetServer` against its OWN
+ * freshly-migrated scratch database ends `afterAll` with
+ * `DROP DATABASE <scratch> WITH (FORCE)`. `FORCE` calls `pg_terminate_backend` on every
+ * backend still attached. If a real-server background component still has a query in flight
+ * on one of those backends, PG answers that query with
+ * `57P01 terminating connection due to administrator command`; the rejection has no owner, so
+ * vitest reports `Unhandled Errors: 1` and the step exits 1 **even though every test passed**.
+ * Because the run is load-sensitive it only manifests under the full CI suite (a local A/B over
+ * 36 runs reproduced it 0/18 on both `main` and the PR head), so it reds the REQUIRED `test`
+ * check on unrelated PRs.
+ *
+ * Shape of the fix — remove the cause, do not mute the symptom:
+ *
+ *  1. `ALLOW_CONNECTIONS false` **first**. Draining and then dropping leaves a window in which
+ *     a reconnecting pool re-attaches between the count and the DDL; revoking connect rights
+ *     closes that window instead of narrowing it. (`DROP DATABASE` itself still works on a
+ *     database with `datallowconn = false`.)
+ *  2. Poll `pg_stat_activity` until no backend but ours is attached. A plain `DROP DATABASE`
+ *     then terminates nothing, so nothing can raise 57P01.
+ *  3. Only if the drain deadline expires: capture who is still attached, `pg_terminate_backend`
+ *     them, and fall back to `WITH (FORCE)`.
+ *
+ * Step 3 is the reason this returns a value rather than `void`. A forced drop is exactly the
+ * pre-fix behaviour, so "CI went green" cannot by itself distinguish a working drain from a
+ * lucky run — the race was never reproducible on demand. `ScratchDropOutcome.forced` is the
+ * discriminator: callers log it unconditionally, `CLEAN` is the claim this helper makes, and a
+ * `FORCED` line names the component still holding a connection (that is the root cause #4791
+ * asks for, and it is not knowable any other way).
+ */
+import type { Pool } from 'pg'
+
+export interface ScratchResidualBackend {
+  applicationName: string
+  state: string
+  query: string
+}
+
+export interface ScratchDropOutcome {
+  /** Every backend other than ours detached on its own before the deadline. */
+  drained: boolean
+  /** We had to `pg_terminate_backend` + `DROP ... WITH (FORCE)` — i.e. 57P01 was possible. */
+  forced: boolean
+  /** Backends still attached when the deadline expired (0 whenever `drained`). */
+  residualBackends: number
+  /** Observed drain duration, for the CI log line. */
+  drainMs: number
+  /** Populated only on the forced path — who was still holding a connection. */
+  residual: ScratchResidualBackend[]
+}
+
+/**
+ * Identifier guard. `scratchName` is interpolated into DDL (`DROP DATABASE` and
+ * `ALTER DATABASE` take no bind parameters for the database name), so it is validated against a
+ * POSITIVE character whitelist rather than a denylist of bad spellings: the complement of a
+ * denylist is unbounded, the complement of this pattern is not. Matches what the call sites
+ * actually generate (`ms2_<suite>_<hex>`), and nothing else.
+ */
+const SAFE_SCRATCH_NAME = /^[a-z][a-z0-9_]{0,62}$/
+
+export function assertSafeScratchDatabaseName(scratchName: string): void {
+  if (typeof scratchName !== 'string' || !SAFE_SCRATCH_NAME.test(scratchName)) {
+    throw new Error(`SCRATCH_DATABASE_NAME_UNSAFE: ${JSON.stringify(scratchName)}`)
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+/**
+ * Drop a scratch database after draining its backends. See the file header for why the ordering
+ * (revoke → drain → drop) matters and why the return value is the deliverable.
+ *
+ * Never throws for the ordinary paths (absent database, backends that refuse to leave); an
+ * unsafe identifier DOES throw, because that is a caller bug and silently proceeding would run
+ * caller-shaped text as DDL.
+ */
+export async function dropScratchDatabase(
+  adminPool: Pool,
+  scratchName: string,
+  options: { drainTimeoutMs?: number; pollIntervalMs?: number } = {},
+): Promise<ScratchDropOutcome> {
+  assertSafeScratchDatabaseName(scratchName)
+  const drainTimeoutMs = options.drainTimeoutMs ?? 10_000
+  const pollIntervalMs = options.pollIntervalMs ?? 50
+  const startedAt = Date.now()
+
+  const exists = await adminPool.query('SELECT 1 FROM pg_database WHERE datname = $1', [scratchName])
+  if (exists.rowCount === 0) {
+    return { drained: true, forced: false, residualBackends: 0, drainMs: 0, residual: [] }
+  }
+
+  // (1) Revoke connect rights BEFORE counting, so a reconnecting pool cannot re-attach between
+  // the count and the DROP. Without this the drain below is a TOCTOU check, not a guarantee.
+  await adminPool.query(`ALTER DATABASE "${scratchName}" ALLOW_CONNECTIONS false`).catch(() => undefined)
+
+  // (2) Wait for the backends that are already attached to finish and detach on their own.
+  const countAttached = async (): Promise<number> => {
+    const r = await adminPool.query<{ n: string }>(
+      'SELECT count(*)::text AS n FROM pg_stat_activity WHERE datname = $1 AND pid <> pg_backend_pid()',
+      [scratchName],
+    )
+    return Number(r.rows[0]?.n ?? 0)
+  }
+
+  let attached = await countAttached()
+  while (attached > 0 && Date.now() - startedAt < drainTimeoutMs) {
+    await sleep(pollIntervalMs)
+    attached = await countAttached()
+  }
+
+  if (attached === 0) {
+    const drainMs = Date.now() - startedAt
+    await adminPool.query(`DROP DATABASE IF EXISTS "${scratchName}"`).catch(() => undefined)
+    return { drained: true, forced: false, residualBackends: 0, drainMs, residual: [] }
+  }
+
+  // (3) Deadline expired. Name the holders BEFORE terminating them — this is the only place the
+  // identity of the component that keeps the connection open is observable.
+  const residualRows = await adminPool
+    .query<{ application_name: string | null; state: string | null; query: string | null }>(
+      `SELECT application_name, state, left(query, 200) AS query
+         FROM pg_stat_activity
+        WHERE datname = $1 AND pid <> pg_backend_pid()`,
+      [scratchName],
+    )
+    .catch(() => ({ rows: [] as Array<{ application_name: string | null; state: string | null; query: string | null }> }))
+  const residual: ScratchResidualBackend[] = residualRows.rows.map((row) => ({
+    applicationName: row.application_name ?? '',
+    state: row.state ?? '',
+    query: row.query ?? '',
+  }))
+
+  await adminPool
+    .query('SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = $1 AND pid <> pg_backend_pid()', [
+      scratchName,
+    ])
+    .catch(() => undefined)
+  await adminPool.query(`DROP DATABASE IF EXISTS "${scratchName}" WITH (FORCE)`).catch(() => undefined)
+
+  return { drained: false, forced: true, residualBackends: residual.length || attached, drainMs: Date.now() - startedAt, residual }
+}
+
+/**
+ * Values-free one-liner for the CI log. `CLEAN` is the claim; `FORCED` is the counter-evidence
+ * that keeps #4791 open and names the holder. Emitted unconditionally by both call sites — a
+ * line that only appears on failure cannot distinguish "drain worked" from "drain never ran".
+ */
+export function formatScratchDropOutcome(label: string, outcome: ScratchDropOutcome): string {
+  if (!outcome.forced) return `scratchDrain=CLEAN suite=${label} drainMs=${outcome.drainMs}`
+  const holders = outcome.residual
+    .map((r) => `${r.applicationName || '<unnamed>'}:${r.state || '<nostate>'}:${r.query.replace(/\s+/g, ' ').slice(0, 120)}`)
+    .join(' | ')
+  return `scratchDrain=FORCED suite=${label} drainMs=${outcome.drainMs} residualBackends=${outcome.residualBackends} holders=[${holders}]`
+}

--- a/packages/core-backend/tests/integration/attendance-w4c2-sweep-call-through.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-w4c2-sweep-call-through.db.test.ts
@@ -55,7 +55,7 @@
  * empty except for what THIS file itself seeds.
  */
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
-import { dropScratchDatabase, formatScratchDropOutcome } from '../helpers/scratch-database'
+import { dropScratchDatabase, formatScratchDropFailure, formatScratchDropOutcome } from '../helpers/scratch-database'
 import { randomUUID } from 'node:crypto'
 import { createRequire } from 'node:module'
 import http from 'node:http'
@@ -341,10 +341,19 @@ describeIfDatabase('W4C-2 #4770 recovery-sweep call-through (real server, real p
     // still-attached backend, and `pg` reports that to its owner as an unowned 'error' EVENT —
     // which vitest counts as an unhandled error and the step exits 1 with every test passing.
     // The outcome line is emitted UNCONDITIONALLY: `CLEAN` is the claim, `FORCED` names the
-    // component still holding a connection and keeps #4791 open.
+    // component still holding a connection and keeps #4791 open, `FAILED` means a teardown
+    // statement errored. The helper fails CLOSED, so the failure is logged and then RE-THROWN —
+    // but only after the admin pool is closed and the env is restored, because leaking either
+    // would itself show up as a new flake on the very check #4791 is about.
+    let dropError: unknown
     if (adminPool) {
-      const dropOutcome = await dropScratchDatabase(adminPool, scratchName)
-      console.log(formatScratchDropOutcome('w4c2-sweep-call-through', dropOutcome))
+      try {
+        const dropOutcome = await dropScratchDatabase(adminPool, scratchName)
+        console.log(formatScratchDropOutcome('w4c2-sweep-call-through', dropOutcome))
+      } catch (err) {
+        dropError = err
+        console.log(formatScratchDropFailure('w4c2-sweep-call-through', err))
+      }
     }
     await adminPool?.end().catch(() => undefined)
     for (const [key, value] of Object.entries({
@@ -358,6 +367,7 @@ describeIfDatabase('W4C-2 #4770 recovery-sweep call-through (real server, real p
       if (value === undefined) delete process.env[key]
       else process.env[key] = value
     }
+    if (dropError) throw dropError
   }, 60000)
 
   // ===============================================================================================

--- a/packages/core-backend/tests/integration/attendance-w4c2-sweep-call-through.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-w4c2-sweep-call-through.db.test.ts
@@ -55,6 +55,7 @@
  * empty except for what THIS file itself seeds.
  */
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
+import { dropScratchDatabase, formatScratchDropOutcome } from '../helpers/scratch-database'
 import { randomUUID } from 'node:crypto'
 import { createRequire } from 'node:module'
 import http from 'node:http'
@@ -336,7 +337,15 @@ describeIfDatabase('W4C-2 #4770 recovery-sweep call-through (real server, real p
   afterAll(async () => {
     await pool?.end().catch(() => undefined)
     if (server) await server.stop()
-    await adminPool?.query(`DROP DATABASE IF EXISTS ${scratchName} WITH (FORCE)`).catch(() => undefined)
+    // #4791: drain the scratch DB's backends before dropping it. A forced drop terminates any
+    // still-attached backend, and `pg` reports that to its owner as an unowned 'error' EVENT —
+    // which vitest counts as an unhandled error and the step exits 1 with every test passing.
+    // The outcome line is emitted UNCONDITIONALLY: `CLEAN` is the claim, `FORCED` names the
+    // component still holding a connection and keeps #4791 open.
+    if (adminPool) {
+      const dropOutcome = await dropScratchDatabase(adminPool, scratchName)
+      console.log(formatScratchDropOutcome('w4c2-sweep-call-through', dropOutcome))
+    }
     await adminPool?.end().catch(() => undefined)
     for (const [key, value] of Object.entries({
       DATABASE_URL: priorEnv.databaseUrl,

--- a/packages/core-backend/tests/integration/bpmn-poller-disabled-startprocess-zero-residue.db.test.ts
+++ b/packages/core-backend/tests/integration/bpmn-poller-disabled-startprocess-zero-residue.db.test.ts
@@ -46,6 +46,7 @@ import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { Pool } from 'pg'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { dropScratchDatabase, formatScratchDropOutcome } from '../helpers/scratch-database'
 import type { MetaSheetServer } from '../../src/index'
 
 const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
@@ -250,7 +251,15 @@ describeIfDatabase('BPMNWorkflowEngine startProcess poller-disabled zero-residue
   afterAll(async () => {
     await pool?.end().catch(() => undefined)
     if (server) await server.stop()
-    await adminPool?.query(`DROP DATABASE IF EXISTS ${scratchName} WITH (FORCE)`).catch(() => undefined)
+    // #4791: drain the scratch DB's backends before dropping it. A forced drop terminates any
+    // still-attached backend, and `pg` reports that to its owner as an unowned 'error' EVENT —
+    // which vitest counts as an unhandled error and the step exits 1 with every test passing.
+    // The outcome line is emitted UNCONDITIONALLY: `CLEAN` is the claim, `FORCED` names the
+    // component still holding a connection and keeps #4791 open.
+    if (adminPool) {
+      const dropOutcome = await dropScratchDatabase(adminPool, scratchName)
+      console.log(formatScratchDropOutcome('bpmn-poller-disabled', dropOutcome))
+    }
     await adminPool?.end().catch(() => undefined)
     for (const [key, value] of Object.entries({
       DATABASE_URL: priorEnv.databaseUrl,

--- a/packages/core-backend/tests/integration/bpmn-poller-disabled-startprocess-zero-residue.db.test.ts
+++ b/packages/core-backend/tests/integration/bpmn-poller-disabled-startprocess-zero-residue.db.test.ts
@@ -46,7 +46,7 @@ import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { Pool } from 'pg'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
-import { dropScratchDatabase, formatScratchDropOutcome } from '../helpers/scratch-database'
+import { dropScratchDatabase, formatScratchDropFailure, formatScratchDropOutcome } from '../helpers/scratch-database'
 import type { MetaSheetServer } from '../../src/index'
 
 const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
@@ -255,10 +255,19 @@ describeIfDatabase('BPMNWorkflowEngine startProcess poller-disabled zero-residue
     // still-attached backend, and `pg` reports that to its owner as an unowned 'error' EVENT —
     // which vitest counts as an unhandled error and the step exits 1 with every test passing.
     // The outcome line is emitted UNCONDITIONALLY: `CLEAN` is the claim, `FORCED` names the
-    // component still holding a connection and keeps #4791 open.
+    // component still holding a connection and keeps #4791 open, `FAILED` means a teardown
+    // statement errored. The helper fails CLOSED, so the failure is logged and then RE-THROWN —
+    // but only after the admin pool is closed and the env is restored, because leaking either
+    // would itself show up as a new flake on the very check #4791 is about.
+    let dropError: unknown
     if (adminPool) {
-      const dropOutcome = await dropScratchDatabase(adminPool, scratchName)
-      console.log(formatScratchDropOutcome('bpmn-poller-disabled', dropOutcome))
+      try {
+        const dropOutcome = await dropScratchDatabase(adminPool, scratchName)
+        console.log(formatScratchDropOutcome('bpmn-poller-disabled', dropOutcome))
+      } catch (err) {
+        dropError = err
+        console.log(formatScratchDropFailure('bpmn-poller-disabled', err))
+      }
     }
     await adminPool?.end().catch(() => undefined)
     for (const [key, value] of Object.entries({
@@ -269,6 +278,7 @@ describeIfDatabase('BPMNWorkflowEngine startProcess poller-disabled zero-residue
       if (value === undefined) delete process.env[key]
       else process.env[key] = value
     }
+    if (dropError) throw dropError
   }, 60000)
 
   it('poller disabled + a timer-bearing process: /start rejects with BPMN_TIMER_POLLER_DISABLED and FOUR real zeros — process, activity, incident, timer rows all 0', async () => {

--- a/packages/core-backend/tests/integration/scratch-database-drain.db.test.ts
+++ b/packages/core-backend/tests/integration/scratch-database-drain.db.test.ts
@@ -1,0 +1,205 @@
+/**
+ * #4791 — behavioural gates for the scratch-database teardown drain
+ * (`tests/helpers/scratch-database.ts`).
+ *
+ * ## The mechanism, reproduced
+ *
+ * #4791 records the failure as load-sensitive and not reproducible on demand (a local A/B over
+ * 36 runs: 0/18 on both `main` and the PR head). What is reproducible on demand — and what the
+ * first draft of THIS file hit by accident — is the mechanism underneath it:
+ *
+ *   `DROP DATABASE ... WITH (FORCE)` calls `pg_terminate_backend` on every attached backend.
+ *   `pg` surfaces that to the owning `Client`/`Pool` as an `'error'` EVENT (57P01 /
+ *   "Connection terminated unexpectedly"), not as a rejection of the in-flight query promise.
+ *   A `.catch()` on the query therefore does NOT own it. With no `'error'` listener, node
+ *   reports an uncaught exception, vitest prints `Errors: 2`, and the run exits 1 with every
+ *   test passing — which is verbatim the #4791 CI signature.
+ *
+ * That is why the fix drains instead of muting: on the drained path nothing is terminated, so
+ * no such event is ever emitted and there is nothing to own. The "clean drop" case below asserts
+ * exactly that, with a lagging connection present — it is the payoff test, not a smoke test.
+ *
+ * ## Constructed, not argued
+ *
+ * The repo's discipline for races is that a sequential argument proves nothing. So the holder
+ * cases really do keep a live backend busy (`pg_sleep`) across the drain window, and the
+ * connect-refusal case really does race a fresh connection against a drain still in progress.
+ *
+ * Each gate is paired with the mutation that makes it red (run by hand, recorded in the PR):
+ *   - delete the `ALLOW_CONNECTIONS false` statement  -> "refuses new connections" RED
+ *   - delete the poll loop (force immediately)        -> "clean drop" RED, on BOTH its
+ *                                                        `forced === false` and its
+ *                                                        "no unowned pg error" assertion
+ *   - delete `assertSafeScratchDatabaseName`          -> "rejects unsafe identifiers" RED
+ */
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { randomUUID } from 'node:crypto'
+import { Client, Pool } from 'pg'
+import {
+  assertSafeScratchDatabaseName,
+  dropScratchDatabase,
+  formatScratchDropOutcome,
+} from '../helpers/scratch-database'
+
+const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
+const describeIfDatabase = dbUrl ? describe : describe.skip
+
+const TERMINATION_SIGNATURE = /57P01|terminating connection|Connection terminated/i
+
+function scratchNameFor(tag: string): string {
+  return `ms2_drain${tag}_${randomUUID().slice(0, 8).replace(/-/g, '')}`
+}
+
+function urlFor(base: string, database: string): string {
+  const u = new URL(base)
+  u.pathname = `/${database}`
+  return u.toString()
+}
+
+/**
+ * A client whose backend-termination `'error'` EVENT is captured rather than left unowned.
+ * Owning it is what keeps this suite from reproducing #4791 in its own process; capturing it
+ * is what lets the assertions below distinguish "was terminated" from "was allowed to finish".
+ */
+async function connectWatched(
+  database: string,
+  applicationName: string,
+): Promise<{ client: Client; errors: Error[] }> {
+  const client = new Client({ connectionString: urlFor(dbUrl!, database), application_name: applicationName })
+  const errors: Error[] = []
+  client.on('error', (err: Error) => errors.push(err))
+  await client.connect()
+  return { client, errors }
+}
+
+describeIfDatabase('#4791 scratch-database teardown drain', () => {
+  let adminPool: Pool
+
+  beforeAll(async () => {
+    if (!dbUrl) throw new Error('SCRATCH_DRAIN_TEST_REQUIRES_DATABASE')
+    adminPool = new Pool({ connectionString: urlFor(dbUrl, 'postgres') })
+  })
+
+  afterAll(async () => {
+    await adminPool?.end().catch(() => undefined)
+  })
+
+  async function createScratch(tag: string): Promise<string> {
+    const name = scratchNameFor(tag)
+    await adminPool.query(`CREATE DATABASE ${name}`)
+    return name
+  }
+
+  async function databaseExists(name: string): Promise<boolean> {
+    const r = await adminPool.query('SELECT 1 FROM pg_database WHERE datname = $1', [name])
+    return (r.rowCount ?? 0) > 0
+  }
+
+  it('waits for a LAGGING connection and drops without terminating it (no unowned pg error)', async () => {
+    const name = await createScratch('lagging')
+    // Models the real teardown: `server.stop()` has been called, but one background component's
+    // connection has not finished closing yet. Pre-fix, FORCE killed it here.
+    const { client, errors } = await connectWatched(name, 'ms2-drain-lagging')
+    const lagging = new Promise<void>((resolve) => {
+      setTimeout(() => {
+        client
+          .query('SELECT 1')
+          .then(() => client.end())
+          .catch(() => undefined)
+          .finally(() => resolve())
+      }, 150)
+    })
+
+    const outcome = await dropScratchDatabase(adminPool, name, { drainTimeoutMs: 5_000, pollIntervalMs: 25 })
+    await lagging
+
+    expect(outcome.drained).toBe(true)
+    expect(outcome.forced).toBe(false)
+    expect(outcome.residualBackends).toBe(0)
+    // THE payoff assertion. This is the error that reds the required `test` check in #4791;
+    // on the drained path it must never be emitted at all.
+    expect(errors.map((e) => e.message)).toEqual([])
+    // And the drain genuinely waited for the lagging client rather than racing past it.
+    expect(outcome.drainMs).toBeGreaterThanOrEqual(140)
+    expect(await databaseExists(name)).toBe(false)
+    expect(formatScratchDropOutcome('lagging', outcome)).toMatch(/^scratchDrain=CLEAN /)
+  })
+
+  it('reports FORCED, names the holder, and DOES emit the termination error', async () => {
+    const name = await createScratch('held')
+    const { client, errors } = await connectWatched(name, 'ms2-drain-holder')
+    // Deliberately not awaited: the backend must still be busy while the helper drains.
+    const held = client.query('SELECT pg_sleep(30)').catch(() => undefined)
+
+    const outcome = await dropScratchDatabase(adminPool, name, { drainTimeoutMs: 400, pollIntervalMs: 25 })
+
+    expect(outcome.drained).toBe(false)
+    expect(outcome.forced).toBe(true)
+    expect(outcome.residualBackends).toBeGreaterThanOrEqual(1)
+    // The holder is IDENTIFIED, not merely counted — that identification is the root-cause
+    // channel #4791 asks for, and a count alone cannot provide it.
+    expect(outcome.residual.some((r) => r.applicationName === 'ms2-drain-holder')).toBe(true)
+    expect(outcome.residual.some((r) => r.query.includes('pg_sleep'))).toBe(true)
+    expect(formatScratchDropOutcome('held', outcome)).toMatch(/^scratchDrain=FORCED .*ms2-drain-holder/)
+    expect(await databaseExists(name)).toBe(false)
+
+    await held
+    // Negative control for the payoff assertion above: forcing really does produce the error
+    // that the drained path must not. Without this, "no error on the clean path" could just as
+    // well mean this suite is incapable of observing the error at all.
+    expect(errors.length).toBeGreaterThanOrEqual(1)
+    expect(errors.some((e) => TERMINATION_SIGNATURE.test(e.message))).toBe(true)
+    await client.end().catch(() => undefined)
+  })
+
+  it('refuses NEW connections while the drain is still in progress (the TOCTOU window)', async () => {
+    const name = await createScratch('toctou')
+    const { client, errors } = await connectWatched(name, 'ms2-drain-toctou-holder')
+    const held = client.query('SELECT pg_sleep(30)').catch(() => undefined)
+
+    // Started but NOT awaited: the assertion below has to land while the helper sits between
+    // "revoked connect rights" and "dropped" — exactly the window a reconnecting pool would slip
+    // through if step (1) of the helper were missing.
+    const dropping = dropScratchDatabase(adminPool, name, { drainTimeoutMs: 4_000, pollIntervalMs: 25 })
+    await new Promise((resolve) => setTimeout(resolve, 250))
+
+    const latecomer = new Client({ connectionString: urlFor(dbUrl!, name), application_name: 'ms2-drain-latecomer' })
+    latecomer.on('error', () => undefined)
+    let connectError: Error | null = null
+    try {
+      await latecomer.connect()
+      await latecomer.end().catch(() => undefined)
+    } catch (err) {
+      connectError = err as Error
+    }
+
+    // Positive assertion on WHY it failed. "connect threw" alone would also be satisfied by the
+    // database having already been dropped, which is a different and strictly later state.
+    expect(connectError).not.toBeNull()
+    expect(String(connectError?.message)).toMatch(/not currently accepting connections/i)
+
+    const outcome = await dropping
+    expect(outcome.forced).toBe(true)
+    await held
+    expect(errors.some((e) => TERMINATION_SIGNATURE.test(e.message))).toBe(true)
+    await client.end().catch(() => undefined)
+  })
+
+  it('is a no-op (not an error) when the database is already gone', async () => {
+    const outcome = await dropScratchDatabase(adminPool, scratchNameFor('absent'), { drainTimeoutMs: 200 })
+    expect(outcome.drained).toBe(true)
+    expect(outcome.forced).toBe(false)
+    expect(outcome.drainMs).toBe(0)
+  })
+
+  it('rejects unsafe identifiers instead of interpolating them into DDL', () => {
+    // The database name cannot be a bind parameter, so this guard is the only thing standing
+    // between a caller-shaped string and executed DDL.
+    for (const bad of ['ms2_x; DROP DATABASE postgres', 'MS2_UPPER', 'ms2-dash', '1leading', '', 'ms2_x"y']) {
+      expect(() => assertSafeScratchDatabaseName(bad), bad).toThrow(/SCRATCH_DATABASE_NAME_UNSAFE/)
+    }
+    // Positive control: the shape the real call sites generate must still be ACCEPTED, otherwise
+    // this gate would pass simply by rejecting everything.
+    expect(() => assertSafeScratchDatabaseName('ms2_w4c2sweepct_0f1e2d3c4b5a')).not.toThrow()
+  })
+})

--- a/packages/core-backend/tests/integration/scratch-database-drain.db.test.ts
+++ b/packages/core-backend/tests/integration/scratch-database-drain.db.test.ts
@@ -31,20 +31,56 @@
  *                                                        `forced === false` and its
  *                                                        "no unowned pg error" assertion
  *   - delete `assertSafeScratchDatabaseName`          -> "rejects unsafe identifiers" RED
+ *
+ * ## Fail-closed and values-free (review #4799 P2-1 / P2-2)
+ *
+ * The `describe('fails closed …')` block below injects a failure into each of the three DDL
+ * statements the finding named (ALTER / plain DROP / forced DROP) and asserts the helper does NOT
+ * report CLEAN or FORCED. Each injection is proved to have reached its TARGET statement, not some
+ * neighbouring one, by two independent means:
+ *
+ *   1. the thrown error carries the injection's UNIQUE signature, so a test that failed for any
+ *      other reason cannot pass; and
+ *   2. the proxy records the ORDERED sequence of statement categories it saw, asserted exactly —
+ *      which is what discriminates the plain DROP from the forced DROP. A hit COUNT would not:
+ *      `/DROP DATABASE/` matches both, so a mis-aimed matcher firing on the wrong statement would
+ *      still satisfy `count >= 1`.
+ *
+ * `describe('values-free log')` gates P2-2 mechanically: the emitted line must FULLY match an
+ * anchored whitelist grammar, asserted with a holder that is deliberately hostile (SQL-shaped
+ * `application_name`, a marked comment inside its statement text).
  */
-import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
 import { randomUUID } from 'node:crypto'
 import { Client, Pool } from 'pg'
 import {
   assertSafeScratchDatabaseName,
   dropScratchDatabase,
+  formatScratchDropFailure,
   formatScratchDropOutcome,
+  ScratchDropError,
+  type ScratchAdminQueryable,
+  type ScratchDropStep,
 } from '../helpers/scratch-database'
 
 const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
 const describeIfDatabase = dbUrl ? describe : describe.skip
 
 const TERMINATION_SIGNATURE = /57P01|terminating connection|Connection terminated/i
+
+/**
+ * The log grammar, anchored. Written HERE and not exported from the helper on purpose: a gate
+ * that shares its pattern with the implementation can be widened by a single edit that keeps both
+ * sides agreeing. The charsets are positive whitelists, and the structural separators
+ * (`=`, ` `, `[`, `]`, `/`, `|`) are excluded from the field charset, so no field value can forge
+ * structure. Any SQL text or row value reaching the line would have to be spelled entirely in
+ * `[A-Za-z0-9_.-]` AND survive truncation — and the leak tests below check the stronger property
+ * that it never enters the outcome object at all.
+ */
+const CLEAN_LINE = /^scratchDrain=CLEAN suite=[A-Za-z0-9_.-]{1,48} drainMs=\d{1,10} residualBackends=0$/
+const FORCED_LINE =
+  /^scratchDrain=FORCED suite=[A-Za-z0-9_.-]{1,48} drainMs=\d{1,10} residualBackends=\d{1,6} holders=\[[A-Za-z0-9_.\-/|]{0,4000}\]$/
+const FAILED_LINE = /^scratchDrain=FAILED suite=[A-Za-z0-9_.-]{1,48} drainMs=\d{1,10} step=[A-Za-z0-9_.-]{1,32}$/
 
 function scratchNameFor(tag: string): string {
   return `ms2_drain${tag}_${randomUUID().slice(0, 8).replace(/-/g, '')}`
@@ -72,12 +108,108 @@ async function connectWatched(
   return { client, errors }
 }
 
+// ================================================================================================
+// Failure injection
+// ================================================================================================
+
+/** Closed category set for every statement the helper is allowed to issue. */
+type StatementKind =
+  | 'exists'
+  | 'revoke'
+  | 'count'
+  | 'inspect'
+  | 'terminate'
+  | 'drop_plain'
+  | 'drop_forced'
+  | 'other'
+
+/**
+ * First match wins; the ordering makes the predicates mutually exclusive by construction
+ * (`drop_forced` before `drop_plain`, `terminate` before the other `pg_stat_activity` readers).
+ * A statement the helper starts issuing that is not in this set lands in `other`, which every
+ * sequence assertion below will reject — the classifier fails loud rather than silently lumping a
+ * new statement in with an existing category.
+ */
+function classify(sql: string): StatementKind {
+  const s = sql.replace(/\s+/g, ' ').trim()
+  if (/DROP DATABASE/i.test(s) && /WITH \(FORCE\)/i.test(s)) return 'drop_forced'
+  if (/DROP DATABASE/i.test(s)) return 'drop_plain'
+  if (/ALTER DATABASE/i.test(s) && /ALLOW_CONNECTIONS false/i.test(s)) return 'revoke'
+  if (/pg_terminate_backend/i.test(s)) return 'terminate'
+  if (/FROM pg_database/i.test(s)) return 'exists'
+  if (/count\(\*\)/i.test(s) && /pg_stat_activity/i.test(s)) return 'count'
+  if (/application_name/i.test(s) && /pg_stat_activity/i.test(s)) return 'inspect'
+  return 'other'
+}
+
+/** Collapse consecutive duplicates — the drain poll issues `count` an unbounded number of times. */
+function collapse(kinds: StatementKind[]): StatementKind[] {
+  return kinds.filter((k, i) => i === 0 || k !== kinds[i - 1])
+}
+
+interface Injection {
+  /** Which statement to interfere with. */
+  on: StatementKind
+  /**
+   * `throw` — the statement errors, as a failing DDL would.
+   * `silent_success` — the statement is NEVER sent to PG but reports success, which is exactly
+   * what `DROP DATABASE IF EXISTS` looks like when it drops nothing. This is the mutation that
+   * proves the read-back is load-bearing rather than decorative.
+   */
+  mode: 'throw' | 'silent_success'
+  signature: string
+}
+
+interface InjectingPool {
+  proxy: ScratchAdminQueryable
+  /** Ordered statement categories actually issued, consecutive duplicates collapsed. */
+  sequence(): StatementKind[]
+  /** Raw count of statements matching the injection target, for a "did it ever fire?" check. */
+  targetHits(): number
+}
+
+function injectingPool(real: Pool, injection?: Injection): InjectingPool {
+  const seen: StatementKind[] = []
+  let hits = 0
+  const proxy: ScratchAdminQueryable = {
+    async query(text: string, values?: unknown[]) {
+      const kind = classify(text)
+      seen.push(kind)
+      if (injection && injection.on === kind) {
+        hits += 1
+        if (injection.mode === 'throw') throw new Error(injection.signature)
+        return { rows: [] }
+      }
+      return await real.query(text, values as unknown[])
+    },
+  }
+  return { proxy, sequence: () => collapse(seen), targetHits: () => hits }
+}
+
 describeIfDatabase('#4791 scratch-database teardown drain', () => {
   let adminPool: Pool
 
   beforeAll(async () => {
     if (!dbUrl) throw new Error('SCRATCH_DRAIN_TEST_REQUIRES_DATABASE')
     adminPool = new Pool({ connectionString: urlFor(dbUrl, 'postgres') })
+  })
+
+  /**
+   * The fail-closed cases deliberately leave the scratch database UNDROPPED (that is the point:
+   * the helper refused to claim a clean teardown), several of them with `datallowconn = false`.
+   * Without this sweep they accumulate on a developer's local PG across runs.
+   *
+   * Scoped to the names THIS process created, not to a `LIKE 'ms2_drain%'` prefix: a prefix sweep
+   * on a shared database would drop a concurrently-running copy of this suite's live scratch DB.
+   */
+  const createdScratchNames = new Set<string>()
+
+  afterEach(async () => {
+    for (const datname of createdScratchNames) {
+      assertSafeScratchDatabaseName(datname)
+      await adminPool.query(`DROP DATABASE IF EXISTS "${datname}" WITH (FORCE)`).catch(() => undefined)
+      createdScratchNames.delete(datname)
+    }
   })
 
   afterAll(async () => {
@@ -87,12 +219,13 @@ describeIfDatabase('#4791 scratch-database teardown drain', () => {
   async function createScratch(tag: string): Promise<string> {
     const name = scratchNameFor(tag)
     await adminPool.query(`CREATE DATABASE ${name}`)
+    createdScratchNames.add(name)
     return name
   }
 
   async function databaseExists(name: string): Promise<boolean> {
     const r = await adminPool.query('SELECT 1 FROM pg_database WHERE datname = $1', [name])
-    return (r.rowCount ?? 0) > 0
+    return r.rows.length > 0
   }
 
   it('waits for a LAGGING connection and drops without terminating it (no unowned pg error)', async () => {
@@ -122,7 +255,7 @@ describeIfDatabase('#4791 scratch-database teardown drain', () => {
     // And the drain genuinely waited for the lagging client rather than racing past it.
     expect(outcome.drainMs).toBeGreaterThanOrEqual(140)
     expect(await databaseExists(name)).toBe(false)
-    expect(formatScratchDropOutcome('lagging', outcome)).toMatch(/^scratchDrain=CLEAN /)
+    expect(formatScratchDropOutcome('lagging', outcome)).toMatch(CLEAN_LINE)
   })
 
   it('reports FORCED, names the holder, and DOES emit the termination error', async () => {
@@ -137,10 +270,13 @@ describeIfDatabase('#4791 scratch-database teardown drain', () => {
     expect(outcome.forced).toBe(true)
     expect(outcome.residualBackends).toBeGreaterThanOrEqual(1)
     // The holder is IDENTIFIED, not merely counted — that identification is the root-cause
-    // channel #4791 asks for, and a count alone cannot provide it.
+    // channel #4791 asks for, and a count alone cannot provide it. Post-P2-2 the identification
+    // is `application_name` + state CATEGORY; the statement text is gone.
     expect(outcome.residual.some((r) => r.applicationName === 'ms2-drain-holder')).toBe(true)
-    expect(outcome.residual.some((r) => r.query.includes('pg_sleep'))).toBe(true)
-    expect(formatScratchDropOutcome('held', outcome)).toMatch(/^scratchDrain=FORCED .*ms2-drain-holder/)
+    expect(outcome.residual.some((r) => r.category === 'active')).toBe(true)
+    const line = formatScratchDropOutcome('held', outcome)
+    expect(line).toMatch(FORCED_LINE)
+    expect(line).toContain('ms2-drain-holder/active/')
     expect(await databaseExists(name)).toBe(false)
 
     await held
@@ -201,5 +337,260 @@ describeIfDatabase('#4791 scratch-database teardown drain', () => {
     // Positive control: the shape the real call sites generate must still be ACCEPTED, otherwise
     // this gate would pass simply by rejecting everything.
     expect(() => assertSafeScratchDatabaseName('ms2_w4c2sweepct_0f1e2d3c4b5a')).not.toThrow()
+  })
+
+  // ==============================================================================================
+  // Review #4799 P2-1 — a DDL failure must never be reported as CLEAN or FORCED
+  // ==============================================================================================
+  describe('fails closed when a teardown statement fails (P2-1)', () => {
+    /**
+     * Shared assertion for all three injections. Deliberately does NOT use `instanceof` alone as
+     * the criterion — the criterion itself has to be attackable. It requires (a) that the helper
+     * did not RESOLVE at all (so no outcome exists that could be formatted CLEAN/FORCED),
+     * (b) the rejection to carry the targeted step, and (c) the message to carry the injection's
+     * unique signature, proving the injection reached the TARGETED statement rather than the test
+     * passing on some unrelated failure.
+     */
+    async function runFailClosed(args: {
+      pool: InjectingPool
+      name: string
+      step: ScratchDropStep
+      signature: string
+      sequence: StatementKind[]
+      drainTimeoutMs?: number
+    }): Promise<void> {
+      let caught: unknown = null
+      let resolvedOutcome: unknown = null
+      try {
+        resolvedOutcome = await dropScratchDatabase(args.pool.proxy, args.name, {
+          drainTimeoutMs: args.drainTimeoutMs ?? 400,
+          pollIntervalMs: 25,
+        })
+      } catch (err) {
+        caught = err
+      }
+
+      // (1) No outcome — so there is nothing that could be formatted as CLEAN or FORCED.
+      expect(resolvedOutcome, 'must not resolve to an outcome').toBeNull()
+      expect(caught, 'must reject').not.toBeNull()
+
+      // (2) The failure is the INJECTED one, at the TARGETED step. Without this the test would
+      //     also pass if the helper had failed for an unrelated reason (or if the injection never
+      //     fired and something else broke).
+      const err = caught as ScratchDropError
+      expect(err.step).toBe(args.step)
+      expect(String((err as Error).message)).toContain(args.signature)
+      expect(args.pool.targetHits(), 'injection must actually have fired').toBeGreaterThanOrEqual(1)
+
+      // (3) The injection reached the statement it aimed at and no other. This is what separates
+      //     the plain DROP case from the forced DROP case: both match /DROP DATABASE/.
+      expect(args.pool.sequence()).toEqual(args.sequence)
+
+      // (4) Nothing downstream can turn this into a success line.
+      const failedLine = formatScratchDropFailure('injected', caught)
+      expect(failedLine).toMatch(FAILED_LINE)
+      expect(failedLine).toContain(`step=${args.step}`)
+      expect(failedLine).not.toMatch(/CLEAN|FORCED/)
+      // And the driver message never reaches the values-free log.
+      expect(failedLine).not.toContain(args.signature)
+
+      // (5) The database is still there — the helper refused to claim a teardown it did not do.
+      expect(await databaseExists(args.name), 'database must still exist after a failed teardown').toBe(true)
+    }
+
+    it('POSITIVE CONTROL — the same proxy, with no injection, still reports CLEAN', async () => {
+      const name = await createScratch('ctrl')
+      const pool = injectingPool(adminPool)
+      const outcome = await dropScratchDatabase(pool.proxy, name, { drainTimeoutMs: 4_000, pollIntervalMs: 25 })
+
+      expect(outcome.forced).toBe(false)
+      expect(formatScratchDropOutcome('ctrl', outcome)).toMatch(CLEAN_LINE)
+      expect(await databaseExists(name)).toBe(false)
+      // The happy path's full statement sequence, INCLUDING the post-drop read-back. If the
+      // read-back were removed, the trailing `exists` would disappear and this goes red.
+      expect(pool.sequence()).toEqual(['exists', 'revoke', 'count', 'drop_plain', 'exists'])
+      expect(pool.targetHits()).toBe(0)
+    })
+
+    it('(a) a failing ALTER ... ALLOW_CONNECTIONS false is NOT reported as CLEAN', async () => {
+      const name = await createScratch('injalter')
+      const signature = `INJECTED_ALTER_FAILURE_${randomUUID()}`
+      const pool = injectingPool(adminPool, { on: 'revoke', mode: 'throw', signature })
+
+      await runFailClosed({
+        pool,
+        name,
+        step: 'revoke_connections',
+        signature,
+        // Stops dead at the revoke: the drain never starts, nothing is dropped.
+        sequence: ['exists', 'revoke'],
+      })
+    })
+
+    it('(b) a failing plain DROP DATABASE is NOT reported as CLEAN', async () => {
+      const name = await createScratch('injdrop')
+      const signature = `INJECTED_PLAIN_DROP_FAILURE_${randomUUID()}`
+      const pool = injectingPool(adminPool, { on: 'drop_plain', mode: 'throw', signature })
+
+      await runFailClosed({
+        pool,
+        name,
+        step: 'drop_plain',
+        signature,
+        // No holder, so the drain completes and the PLAIN drop is the statement reached —
+        // `drop_forced` must NOT appear anywhere in this sequence.
+        sequence: ['exists', 'revoke', 'count', 'drop_plain'],
+        drainTimeoutMs: 4_000,
+      })
+      // Explicit: fail-closed must not silently escalate to a forced drop, which would make
+      // CLEAN vs FORCED unfalsifiable.
+      expect(pool.sequence()).not.toContain('drop_forced')
+    })
+
+    it('(c) a failing forced DROP DATABASE ... WITH (FORCE) is NOT reported as FORCED', async () => {
+      const name = await createScratch('injforce')
+      const signature = `INJECTED_FORCED_DROP_FAILURE_${randomUUID()}`
+      const pool = injectingPool(adminPool, { on: 'drop_forced', mode: 'throw', signature })
+
+      // A holder that stays busy past the deadline is what routes execution to the forced branch.
+      const { client } = await connectWatched(name, 'ms2-drain-injforce-holder')
+      const held = client.query('SELECT pg_sleep(30)').catch(() => undefined)
+
+      await runFailClosed({
+        pool,
+        name,
+        step: 'drop_forced',
+        signature,
+        sequence: ['exists', 'revoke', 'count', 'inspect', 'terminate', 'drop_forced'],
+        drainTimeoutMs: 400,
+      })
+      // Reached via the forced branch, not the plain one — the counterpart of case (b).
+      expect(pool.sequence()).not.toContain('drop_plain')
+
+      await held
+      await client.end().catch(() => undefined)
+    })
+
+    it('(d) READ-BACK is load-bearing — a DROP that "succeeds" without dropping is NOT CLEAN', async () => {
+      // The mutation that would otherwise be invisible: `DROP DATABASE IF EXISTS` reports success
+      // when it drops nothing. Here the statement never reaches PG at all but reports success, so
+      // the ONLY thing that can catch it is re-querying `pg_database`.
+      const name = await createScratch('injnoop')
+      const pool = injectingPool(adminPool, {
+        on: 'drop_plain',
+        mode: 'silent_success',
+        signature: 'unused',
+      })
+
+      let caught: unknown = null
+      let resolvedOutcome: unknown = null
+      try {
+        resolvedOutcome = await dropScratchDatabase(pool.proxy, name, { drainTimeoutMs: 4_000, pollIntervalMs: 25 })
+      } catch (err) {
+        caught = err
+      }
+
+      expect(resolvedOutcome).toBeNull()
+      expect(caught).not.toBeNull()
+      expect((caught as ScratchDropError).step).toBe('confirm_absent')
+      expect(String((caught as Error).message)).toContain('database still present after plain DROP')
+      // The read-back really ran: a second `exists` after the drop.
+      expect(pool.sequence()).toEqual(['exists', 'revoke', 'count', 'drop_plain', 'exists'])
+      expect(await databaseExists(name)).toBe(true)
+      expect(formatScratchDropFailure('injnoop', caught)).toMatch(FAILED_LINE)
+    })
+  })
+
+  // ==============================================================================================
+  // Review #4799 P2-2 — the teardown log must carry no SQL text and no row values
+  // ==============================================================================================
+  describe('values-free log (P2-2)', () => {
+    it('never reads the holder SQL, and stays inside the grammar for a HOSTILE application_name', async () => {
+      const name = await createScratch('leak')
+      const marker = `LEAKMARKER${randomUUID().replace(/-/g, '')}`
+
+      // Two holders, probing the two properties separately — they must not be conflated.
+      //  A: a benign identity running SQL that carries a unique marker. Probes "statement text is
+      //     never read". Its `application_name` is clean so that the marker's presence in the
+      //     outcome could ONLY have come from the statement text.
+      //  B: a hostile `application_name`. That field IS kept (it is the root-cause channel), so
+      //     the property it must satisfy is different: charset-bounded at format time. It carries
+      //     no SQL keywords, so it cannot contaminate A's assertions.
+      const holderA = await connectWatched(name, 'ms2-drain-leakprobe')
+      const heldA = holderA.client.query(`SELECT pg_sleep(30) /* ${marker} */`).catch(() => undefined)
+      const holderB = await connectWatched(name, 'evil" name; ok --|/[]=')
+      const heldB = holderB.client.query('SELECT pg_sleep(30)').catch(() => undefined)
+
+      const outcome = await dropScratchDatabase(adminPool, name, { drainTimeoutMs: 400, pollIntervalMs: 25 })
+      expect(outcome.forced).toBe(true)
+      expect(outcome.residual.length).toBeGreaterThanOrEqual(2)
+
+      // (1) Holder A's statement text is not merely absent from the LINE — it never entered the
+      //     outcome object, because `query` is no longer selected from `pg_stat_activity` at all.
+      //     That is the "by construction" half: a formatter that merely stopped PRINTING it would
+      //     still leave it in memory for the next caller to log.
+      const serialised = JSON.stringify(outcome)
+      expect(serialised).not.toContain('pg_sleep')
+      expect(serialised).not.toContain(marker)
+      expect(serialised).not.toMatch(/SELECT|FROM|DROP|ALTER/i)
+
+      // (2) Holder B: the line matches the anchored whitelist grammar even with a hostile name.
+      //     That anchored match IS the gate — it bounds the charset mechanically rather than by
+      //     enumerating bad spellings, which is the only form that converges. The named checks
+      //     below are the specific hostile inputs, not the criterion.
+      //
+      //     `-` is deliberately IN the whitelist (real labels are hyphenated:
+      //     `w4c2-sweep-call-through`, `ms2-drain-holder`), so a literal `--` can survive. It is
+      //     inert here: this line is never parsed as SQL, and none of the log's structural
+      //     separators (`=`, ` `, `[`, `]`, `/`, `|`) nor any newline can survive the whitelist,
+      //     so no field value can forge structure or inject a second log line.
+      const line = formatScratchDropOutcome('leak', outcome)
+      expect(line).toMatch(FORCED_LINE)
+      expect(line.split('\n')).toHaveLength(1)
+      for (const forbidden of ['"', ';', '\n', '\r', marker, 'pg_sleep', 'SELECT']) {
+        expect(line, `log line must not contain ${JSON.stringify(forbidden)}`).not.toContain(forbidden)
+      }
+
+      // (3) Positive control on the sanitiser: it must still be USEFUL. A sanitiser that emitted a
+      //     constant, or a formatter that dropped holders entirely, would satisfy every assertion
+      //     above — so the surviving, recognisable holder identities and the diagnostic category
+      //     are asserted PRESENT.
+      expect(line).toMatch(/holders=\[[^\]]*evil__name/)
+      expect(line).toMatch(/holders=\[[^\]]*ms2-drain-leakprobe\/active\//)
+      expect(line).toMatch(/residualBackends=[1-9]/)
+
+      await heldA
+      await heldB
+      expect(holderA.errors.some((e) => TERMINATION_SIGNATURE.test(e.message))).toBe(true)
+      expect(holderB.errors.some((e) => TERMINATION_SIGNATURE.test(e.message))).toBe(true)
+      await holderA.client.end().catch(() => undefined)
+      await holderB.client.end().catch(() => undefined)
+    })
+
+    it('the CLEAN and FAILED lines are inside the grammar too', () => {
+      const clean = formatScratchDropOutcome('bpmn-poller-disabled', {
+        drained: true,
+        forced: false,
+        residualBackends: 0,
+        drainMs: 12,
+        residual: [],
+      })
+      expect(clean).toMatch(CLEAN_LINE)
+
+      const failed = formatScratchDropFailure(
+        'w4c2-sweep-call-through',
+        new ScratchDropError('drop_forced', 'database "x" is being accessed by other users', 42),
+      )
+      expect(failed).toMatch(FAILED_LINE)
+      expect(failed).toBe('scratchDrain=FAILED suite=w4c2-sweep-call-through drainMs=42 step=drop_forced')
+      // The driver detail travels on the Error (to the runner's failure output), never here.
+      expect(failed).not.toContain('accessed by other users')
+
+      // A non-ScratchDropError still produces a grammar-valid line rather than interpolating an
+      // arbitrary message.
+      const foreign = formatScratchDropFailure('suite', new Error('boom "; DROP TABLE users --'))
+      expect(foreign).toMatch(FAILED_LINE)
+      expect(foreign).toBe('scratchDrain=FAILED suite=suite drainMs=0 step=unknown')
+    })
   })
 })

--- a/plugins/plugin-integration-core/lib/sealed-export/vectors/s6a-package-provenance-pins.json
+++ b/plugins/plugin-integration-core/lib/sealed-export/vectors/s6a-package-provenance-pins.json
@@ -86,6 +86,6 @@
     "s6aAcceptancePs51Test": "835c7c6ce943d82e0378a40a27c7fd1e8b79b526faa8ca4c8066e4231a4bfb0f",
     "s6aProductRuntimeTest": "de978adafa8b89772cefa921c2051f434bf346bf5c2978bef3424ee70f51ba3f",
     "multitableOnpremPackageBuild": "463c7d73c6c7f2d1b6cdf0820d7a06974a9c463dd5e98bbbaf1c996e1dc4ed99",
-    "pluginTestsWorkflow": "45f6f561a446146cf0444ce948b0fd377e440640e699d6e4b681a8b49559993c"
+    "pluginTestsWorkflow": "0f3f9ee2dcc6514ee560f1c1c5ced78c2f25e54ff02fba0b1a6c153e6575fea6"
   }
 }


### PR DESCRIPTION
关闭 #4791 报告的机制,并把「是否真的关掉了」变成 CI 每次可读的判据。

## 机制:已确定性复现

#4791 记的是"负载相关、无法按需复现"(本地 A/B 36 次:main 与 PR head 各 0/18)。
**能按需复现的是它底下的机制** —— 本 PR 新套件的第一版无意中撞上了它:

> `DROP DATABASE <scratch> WITH (FORCE)` 会对每个仍挂着的 backend 调
> `pg_terminate_backend`。`pg` 把这件事以 **`'error'` 事件**的形式交给拥有该连接的
> Client/Pool,**不是**以在途 query promise 的 rejection。所以 query 上的 `.catch()`
> **拿不到它**;没有 `'error'` 监听器时 node 报 uncaught exception,vitest 打
> `Errors: N`,**全部测试通过但退出码 1** —— 与 #4791 的 CI 签名逐字一致。

第一版实测:`5 passed / Errors 2 / exit 1`。

## 修法:去因,不是消音

1. **先** `ALTER DATABASE … ALLOW_CONNECTIONS false`。"先排空再 drop"之间存在一个重连
   窗口 —— 撤销连接权是**关掉**这个窗口,而不是把它变窄。(`datallowconn=false` 下
   `DROP DATABASE` 仍可执行,已在 PG 15 实测。)
2. 轮询 `pg_stat_activity` 直到除自己外无 backend,然后**普通** `DROP DATABASE` ——
   什么都没被终止,也就不存在无主的 error 事件。
3. 仅当排空超时:**先记下持有者**,再 `pg_terminate_backend` + `WITH (FORCE)`。

## 为什么它返回值而不是 void

强制 drop **就是**修复前的行为。所以"CI 变绿了"**无法区分**排空生效与这一跑运气好 ——
这个竞态本来就不能按需复现。两个调用点因此**无条件**打一行:

```
scratchDrain=CLEAN  suite=… drainMs=…
scratchDrain=FORCED suite=… drainMs=… residualBackends=N holders=[app:state:query]
```

`CLEAN` 是本 PR 的声明;`FORCED` 则**点名**那个还握着连接的组件 —— 那正是 #4791 要的根因,
且没有别的途径能知道。**#4791 不随本 PR 关闭**,要等 CI 实际报出 `CLEAN` 才关。

## 范围

21 个用 scratch DB 的套件里,只有 **2 个**启动真实 `MetaSheetServer`(才有后台组件持连接):
`attendance-w4c2-sweep-call-through` 与 `bpmn-poller-disabled-startprocess-zero-residue`。
其余 19 个无后台 worker,碰不到这条路径,**不动** —— 改它们是更大的 diff、修不了任何失败,
还会让改动多次经过正在 flaky 的 `test (20.x)`。

## 门与变异(逐条亲跑,全部落在预测的那一条上)

新套件 `scratch-database-drain.db.test.ts` 本地 5/5 绿、**零 unhandled error**。

| 变异 | 变红的门 |
|---|---|
| 删掉 `ALLOW_CONNECTIONS false` | 「排空进行中拒绝新连接(TOCTOU 窗口)」 |
| 删掉轮询循环(立即 force) | 「等待滞后连接…」**与** TOCTOU 两条 |
| 删掉 `assertSafeScratchDatabaseName` | 「拒绝不安全标识符」 |

竞态是**构造出来的,不是论证出来的**:持有者用 `pg_sleep` 让 backend 在整个排空窗口里真的
忙着;拒连那条真的拿一个新连接去撞仍在进行中的排空。

关键的一对**互为对照**:
- clean 路径断言那个终止 error **没有**被发出(这正是 #4791 里让 CI 变红的东西);
- forced 路径断言它**确实**被发出。

没有后者,「clean 路径没有 error」也可能只是因为这套件**根本观测不到**该 error。

标识符守卫用**正向字符白名单**(数据库名不能做 bind 参数,只能拼进 DDL):黑名单的补集无界,
白名单的补集有界且已知。附带正控:调用点真实生成的形状必须仍被**接受**,否则"全部拒绝"也能让
这条门变绿。

## 验证

- PostgreSQL 15(`postgres` 超级用户,与 CI 同形)本地实跑:两个接入套件 + 新套件
  **15/15 绿**,两行都报 `scratchDrain=CLEAN`。
- `tsc --noEmit` exit 0。
- 新套件已加入 CI 显式文件清单(该步骤逐个列文件,不是 glob 发现 —— 不加就是没门)。

Refs #4791, #4796

🤖 Generated with [Claude Code](https://claude.com/claude-code)
