### PR TITLE
test(pact): CAD review approve without sealed evidence is 409

### DIFF
--- a/packages/core-backend/tests/contract/pacts/metasheet2-yuantus-plm.json
+++ b/packages/core-backend/tests/contract/pacts/metasheet2-yuantus-plm.json
@@ -1497,7 +1497,7 @@
           "properties": [
             {
               "name": "item_number",
-              "label": "料号",
+              "label": "\u6599\u53f7",
               "type": "string",
               "required": true,
               "length": 64,
@@ -3177,10 +3177,10 @@
       }
     },
     {
-      "description": "submit an approved CAD review comment",
+      "description": "reject a CAD approval without sealed evidence",
       "providerStates": [
         {
-          "name": "CAD file 01H000000000000000000000F7 accepts approved review updates"
+          "name": "CAD file 01H000000000000000000000F7 requires sealed approval evidence"
         }
       ],
       "request": {
@@ -3208,15 +3208,12 @@
         }
       },
       "response": {
-        "status": 200,
+        "status": 409,
         "headers": {
           "Content-Type": "application/json"
         },
         "body": {
-          "file_id": "01H000000000000000000000F7",
-          "state": "approved",
-          "note": "Looks good",
-          "reviewed_by_id": 1
+          "detail": "cad_review_evidence_id_required"
         }
       }
     },

--- a/packages/core-backend/tests/contract/plm-adapter-yuantus.pact.test.ts
+++ b/packages/core-backend/tests/contract/plm-adapter-yuantus.pact.test.ts
@@ -888,6 +888,13 @@ describe('Pact: Metasheet2 consumer -> YuantusPLM provider (Wave 1 + Wave 2 docu
       state: 'approved',
       note: 'Looks good',
     })
+    expect(reviewPost!.response.status).toBe(409)
+    expect(reviewPost!.response.body).toEqual({
+      detail: 'cad_review_evidence_id_required',
+    })
+    expect(reviewPost!.providerStates?.[0]?.name).toBe(
+      'CAD file 01H000000000000000000000F7 requires sealed approval evidence',
+    )
     expect((historyGet!.response.body as Record<string, unknown>).entries).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ action: 'cad_properties_update' }),


### PR DESCRIPTION
## Summary
Align Metasheet2↔YuantusPLM CAD review consumer pact with pilot safety foundation (yuantus-plm #120):

- Provider state: `CAD file …F7 requires sealed approval evidence`
- Response: **409** `{ detail: cad_review_evidence_id_required }` when approve has no sealed evidence id

## Why
Yuantus #120 fail-closes approved CAD review without sealed evidence. Broker still has the old 200 happy-path consumer interaction, so provider verification + can-i-deploy fail.

## Follow-up
- Publish this pact to Pact broker after merge (existing consumer publish path)
- Re-run yuantus-plm #120 required-ci / pact-broker-gate
- Adapter UX for evidence-required 409 is separate (not this PR)

## Test plan
- [ ] contract test `plm-adapter-yuantus.pact.test.ts` CAD section
- [ ] broker publish on merge if configured