### PR TITLE
docs(approval): stamp #4806 merge closeout on canvas final-eligibility MDs

### DIFF
--- a/.grok/workflows/approval-canvas-final-gate.rhai
+++ b/.grok/workflows/approval-canvas-final-gate.rhai
@@ -1,13 +1,13 @@
 let meta = #{
     name: "approval-canvas-final-gate",
-    description: "Unattended gate for approval Canvas final-eligibility: residual ledger, focused tests, flag defaults, no product-FINAL overclaim, PR #4806 CI awareness",
+    description: "Unattended gate for approval Canvas final-eligibility: residual ledger, focused tests, flag defaults, no product-FINAL overclaim (post #4806 merge on main)",
     phases: [
         #{ title: "Scan", detail: "ledger + MD honesty + residual OPEN items" },
         #{ title: "Test", detail: "web authoring + backend flag/number canaries" },
         #{ title: "Structure", detail: "D0 edge+/palette/list structural pins" },
         #{ title: "Verify", detail: "flags OFF + docs do not overclaim FINAL" },
     ],
-    when_to_use: "After approval canvas commits, before claiming ENGINEERING-READY, or when babysitting PR #4806",
+    when_to_use: "After approval canvas commits on main, before claiming ENGINEERING-READY, or when re-checking post-#4806 land",
 };
 
 let scan_schema = #{
@@ -57,7 +57,8 @@ let scan = agent(
         + "docs/development/approval-canvas-data-closure-final-eligibility-verification-20260808.md status lines. "
         + "Summarize DONE vs OPEN vs BLOCKED. "
         + "open_prs must list only OPEN execute-plan nodes (e.g. PR3, PR4) not DONE ones. "
-        + "blockers = owner-only items that prevent product FINAL (G0, UAT, flags) plus any OPEN engineering still required for ENGINEERING-READY if CI is red. "
+        + "blockers = owner-only items that prevent product FINAL (G0, UAT, flags) plus any OPEN engineering still required for ENGINEERING-READY if regressions appear on main. "
+        + "If #4806 is MERGED and ledger shows all engineering PRs DONE, open_prs must be empty. "
         + "Do not invent blockers.",
     #{
         label: "scan-residuals",

--- a/docs/development/approval-canvas-data-closure-final-eligibility-development-20260808.md
+++ b/docs/development/approval-canvas-data-closure-final-eligibility-development-20260808.md
@@ -1,9 +1,10 @@
 # Approval Canvas + Data Closure — Final Eligibility Development (2026-08-08)
 
 **Status:** ENGINEERING-READY FOR PRODUCT FINAL (owner UAT + staged flag ON still required)  
-**Branch:** `claude/approval-canvas-final-engineering-20260808`  
-**Base:** `origin/main@7c7d550dbfba175a8c29afe0f59ba06b2287303d`  
-**Exact product head (this delivery):** `0bfaeddeb180f25a05ea83563d43769cb4f4369b`  
+**Landed:** https://github.com/zensgit/metasheet2/pull/4806 → `main` squash `323d7e1afe` (2026-08-08T04:20:48Z)  
+**Pre-merge branch family:** `claude/approval-canvas-final-engineering-20260808`  
+**Pre-merge product tip (examples):** `0bfaeddeb180f25a05ea83563d43769cb4f4369b` (and later heads on the PR)  
+**Authoritative land SHA:** `323d7e1afef407f68c8ff2a6bfa940f175300f59`  
 **Authority:**  
 - `docs/development/approval-canvas-v2-development-plan-20260720.md` (D0–D11 + G gates; status remains PROPOSED for G0 owner ratify)  
 - `docs/development/approval-canvas-v2-interaction-design-lock-20260721.md` (D0 interaction contract; still PROPOSED until G0)  
@@ -97,7 +98,7 @@ These residuals do **not** block the engineering claim “G5-C product-path alge
 
 ## 6. Verdict
 
-**ENGINEERING-READY FOR PRODUCT FINAL eligibility** — remaining engineering for G5-C path tests, mounted undo/history, canvas-first under flag, and G5-R regression is complete on this head.
+**ENGINEERING-READY FOR PRODUCT FINAL eligibility** — remaining engineering for G5-C path tests, mounted undo/history, canvas-first under flag, edge `+` / form palette / shell extract, and G5-R regression is **complete and merged to main** (`323d7e1afe` via #4806).
 
 **NOT product FINAL** until:
 

--- a/docs/development/approval-canvas-data-closure-final-eligibility-verification-20260808.md
+++ b/docs/development/approval-canvas-data-closure-final-eligibility-verification-20260808.md
@@ -1,9 +1,9 @@
 # Approval Canvas + Data Closure — Final Eligibility Verification (2026-08-08)
 
 **Status:** ENGINEERING-READY FOR PRODUCT FINAL (owner UAT + staged flag ON **not** done)  
-**Product-code base:** `origin/main@7c7d550dbfba175a8c29afe0f59ba06b2287303d`  
-**Exact product head (this delivery):** `0bfaeddeb180f25a05ea83563d43769cb4f4369b`  
-**Branch:** `claude/approval-canvas-final-engineering-20260808`  
+**Landed:** https://github.com/zensgit/metasheet2/pull/4806 → `main` squash `323d7e1afe` (2026-08-08T04:20:48Z)  
+**Authoritative land SHA:** `323d7e1afef407f68c8ff2a6bfa940f175300f59`  
+**Pre-merge branch family:** `claude/approval-canvas-final-engineering-20260808`  
 **Development companion:** `docs/development/approval-canvas-data-closure-final-eligibility-development-20260808.md`
 
 This verification MD maps acceptance criteria to exact commands and counts. It does **not** claim product FINAL while owner gates remain open.
@@ -150,4 +150,4 @@ No product-code change in this delivery flips a default to ON.
 1. G0 ratify of `approval-canvas-v2-interaction-design-lock-20260721.md` (and O3 layout engine choice if renderer migration is desired).  
 2. Real-tenant UAT: form authoring, linear/condition/parallel publish+execute, route preview, FWB create/update, attachments, version restore.  
 3. Staged enablement: durable → Class A → Class B → FWB → attachments / Canvas V2, with observation windows.  
-4. Optional residual product polish: retire node button clusters; form palette drag; editor-embedded dual-canvas version UX.
+4. Optional residual product polish (not blocking ENGINEERING-READY): form palette drag affordances; full editor-embedded dual-canvas version UX (beyond TemplateDetailView summary). Edge `+` / no canvas node clusters / form palette / shell extract already landed in #4806.

--- a/docs/development/approval-canvas-remaining-engineering-design-20260808.md
+++ b/docs/development/approval-canvas-remaining-engineering-design-20260808.md
@@ -1,8 +1,8 @@
 # Approval Canvas Remaining Engineering — Design + PR Plan (2026-08-08)
 
-**Status:** AUTHORITATIVE FOR AUTONOMOUS EXECUTION  
-**Tracking PR:** https://github.com/zensgit/metasheet2/pull/4806 (draft)  
-**Head family:** `claude/approval-canvas-final-engineering-20260808`  
+**Status:** ENGINEERING CLOSED ON MAIN (owner product FINAL gates remain)  
+**Tracking PR:** https://github.com/zensgit/metasheet2/pull/4806 (**MERGED** squash `323d7e1afe`, 2026-08-08T04:20:48Z)  
+**Landed head family:** `claude/approval-canvas-final-engineering-20260808` → `main`  
 **Authority locks:** D0 interaction lock (written contract; G0 owner ratify still open), canvas V2 plan D-items, final-eligibility MDs  
 **Flags:** remain default OFF. No production enablement. No real-tenant UAT in this plan.
 
@@ -23,26 +23,26 @@ Close residual **product engineering** against the written D0 lock without mid-s
 - Number FWB unlock  
 - Optional D7 runtimes  
 - Production flag ON / real-tenant UAT execution  
-- Merge of #4806 without green required checks  
+- Product FINAL claim without G0 + real-tenant UAT + staged flags  
 
 ## Autonomy policy
 
-Agents may implement, test, commit, push to the tracking branch, and update the draft PR. Agents **must not** merge to main, flip env flags, or claim product FINAL. Owner gates are recorded as blockers only.
+Engineering stack for this line is **landed on main** via #4806. Further agent work is limited to honest doc/gate maintenance, regressions, and **new** OPEN design nodes only. Agents **must not** flip env flags or claim product FINAL. Owner gates (G0 / UAT / staged flags) remain blockers only.
 
-## Ledger vs #4806
+## Ledger vs #4806 (merged)
 
-| Item | Status on #4806 | Notes |
+| Item | Status | Notes |
 |---|---|---|
-| Session history + undo/redo + live graph + topology merge | **DONE** | `approvalAuthoringHistory.ts` + view wiring + tests |
-| Canvas-first default under flag | **DONE** | `canvasViewMode = 'canvas'` |
-| Linear promote into preservedGraph | **DONE** | flow section entry |
-| Edge `+` insert + retire node clusters | **DONE** | inspector topology keeps load-bearing testids |
-| Form field palette (D6-f2 slice) | **DONE** | `approval-field-palette` |
-| Final-eligibility MD + gate workflow | **DONE** | docs + `.grok/workflows/approval-canvas-final-gate.rhai` |
-| G5-C S1–S12 product-path suite | **DONE** | `approval-g5c-authoring-scenarios.test.ts` (CI-wired) |
-| CI: approval-web-guard / web-tests green | **GREEN** (a25e65 + 0bfaed head re-runs) | canaries: history/G5-C/version-read-summary; PR4 shells in path filter |
+| Session history + undo/redo + live graph + topology merge | **DONE on main** | `approvalAuthoringHistory.ts` + view wiring + tests |
+| Canvas-first default under flag | **DONE on main** | `canvasViewMode = 'canvas'` |
+| Linear promote into preservedGraph | **DONE on main** | flow section entry |
+| Edge `+` insert + retire node clusters | **DONE on main** | inspector topology keeps load-bearing testids |
+| Form field palette (D6-f2 slice) | **DONE on main** | `approval-field-palette` |
+| Final-eligibility MD + gate workflow | **DONE on main** | docs + `.grok/workflows/approval-canvas-final-gate.rhai` |
+| G5-C S1–S12 product-path suite | **DONE on main** | `approval-g5c-authoring-scenarios.test.ts` (CI-wired) |
+| CI: approval-web-guard / web-tests green | **GREEN then MERGED** | squash `323d7e1afe` after required checks (incl. plugin `test` 18.x/20.x) |
 | Version dual-canvas shell (full D8-b) | **PARTIAL→UI wired** | pure summary + TemplateDetailView read summary lines/overlay tallies; full dual-canvas product shell not claimed |
-| Extract `ApprovalFlowCanvas` / inspector modules | **DONE** | `ApprovalFlowCanvas.vue` + `ApprovalCanvasNodeInspector.vue`; draft/history remain in parent |
+| Extract `ApprovalFlowCanvas` / inspector modules | **DONE on main** | `ApprovalFlowCanvas.vue` + `ApprovalCanvasNodeInspector.vue`; draft/history remain in parent |
 | D3 Vue Flow/ELK | **BLOCKED (O3)** | do not start |
 
 ## PR Plan (execute-plan ready)
@@ -93,20 +93,19 @@ Linearized remaining stack:
 (all engineering PRs 0–4 DONE on #4806)
 ```
 
-Optional follow-ups (not blocking ENGINEERING-READY):
+Optional follow-ups (not blocking ENGINEERING-READY; **not** product FINAL):
 
-- Wire `buildApprovalVersionReadSummary` into TemplateDetailView UI (display-only).  
+- Full dual-canvas version UX (editor-embedded) if product wants beyond TemplateDetailView summary.  
 - D3 Vue Flow/ELK after O3.  
-- Owner: G0 / UAT / staged flags / merge.  
+- Owner: G0 ratify, real-tenant UAT, staged flag enablement with observation.  
 
 - Suggested gate: `/workflow approval-canvas-final-gate`  
-- Suggested dry-run after new OPEN items only.  
+- Suggested dry-run only after new OPEN engineering items.  
 
 ## Verification
 
 - Web focused suites green (history, G5-C, inspector, form/canvas commands, approvalTemplateAuthoring, ui-foundation-style-guard).  
-- `approval-web-guard` + `web-tests` green on #4806.  
-- `vue-tsc --noEmit` pass.  
-- Flags default OFF unchanged.  
+- #4806 required checks green; squash-merged to `main` as `323d7e1afe`.  
+- Flags default OFF unchanged (`approvalCanvasV2: false`).  
 - Structural: edge insert testids; no `template-authoring__canvas-node-actions` on canvas; palette present; list topology retained.  
-- Workflow `approval-canvas-final-gate` reports `product_final: false` always; `engineering_ready` only when tests + flags + honest docs hold.
+- Workflow `approval-canvas-final-gate` reports `product_final: false` always; `engineering_ready` when tests + flags + honest docs hold.


### PR DESCRIPTION
## Summary
- Post-merge honesty for approval Canvas final-eligibility docs after #4806 squash-landed on `main` as `323d7e1afe`.
- Design ledger + development/verification MDs + gate workflow now record **MERGED**, engineering closed, product FINAL still owner-gated (G0 / UAT / staged flags).
- Flags remain default OFF; no product code changes.

## Why
#4806 is already on main; docs still described a draft PR / pre-merge head. Close that gap without reopening product FINAL claims.

## Test plan
- [x] Docs-only diff (no app/runtime changes)
- [ ] CI green on this PR
- [x] Status strings still say ENGINEERING-READY / not product FINAL