### PR TITLE
[HOLD] feat(attendance): W6-1 — group effective-policy READ aggregate backend (#4556)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -1278,6 +1278,8 @@ jobs:
             tests/integration/attendance-group-fixed-schedule-config-consume.db.test.ts \
             tests/integration/attendance-group-fixed-schedule-self-effectiveness.db.test.ts \
             tests/integration/attendance-shift-flex-policy-migration.db.test.ts \
+            tests/integration/attendance-w6-group-effective-policy.db.test.ts \
+            tests/integration/attendance-w6-group-effective-policy-membership-overlap.db.test.ts \
             tests/integration/attendance-expiry-service.test.ts \
             tests/integration/attendance-unscheduled-reminder.test.ts \
             tests/integration/attendance-outdoor-punch.test.ts \

--- a/packages/core-backend/src/attendance/w6-group-effective-policy-aggregate.ts
+++ b/packages/core-backend/src/attendance/w6-group-effective-policy-aggregate.ts
@@ -137,10 +137,19 @@ function scheduleRouteRef(
  * that single derivation, reconstructed here because the canonical
  * function is a private top-level declaration inside the (non-exporting)
  * plugin entry file and is not independently `require`-able without
- * loading that file's full activation surface. See the parity test
- * (`attendance-w6-group-effective-policy-aggregate.test.ts`,
- * "producer key parity") for the equivalence proof over the exact
- * input shapes this call site ever supplies.
+ * loading that file's full activation surface. See the "producer key
+ * parity" describe block in
+ * `attendance-w6-group-effective-policy-aggregate.test.ts` — it PINS this
+ * function's exact output format literally (so any accidental format
+ * change reds immediately, not just when it happens to disagree with the
+ * canonical builder), and independently, the real-DB fidelity test
+ * (`attendance-w6-group-effective-policy.db.test.ts`) seeds fixed-schedule
+ * rows keyed by a producer key computed with THIS function and confirms
+ * FSER still matches them (a format drift here would show up there as a
+ * `DIFFERENT_MANAGED_KEY_ACTIVE`-shaped failure). Neither test imports the
+ * canonical builder itself — see the equivalence ARGUMENT above for why
+ * that is not independently re-provable without loading index.cjs's full
+ * activation surface.
  */
 export function buildFixedScheduleProducerKey(input: { groupId: string; shiftId: string; startDate: string; endDate: string | null }): string {
   return ['attendance_group_fixed_schedule', input.groupId, input.shiftId, input.startDate, input.endDate ?? 'null'].join(':')

--- a/packages/core-backend/src/attendance/w6-group-effective-policy-aggregate.ts
+++ b/packages/core-backend/src/attendance/w6-group-effective-policy-aggregate.ts
@@ -1,0 +1,541 @@
+/**
+ * W6-1 (#4556) — group effective-policy aggregate: read-only service.
+ *
+ * Governing document:
+ *   docs/development/attendance-issue-4556-w6-group-effective-policy-design-lock-20260805.md
+ *   §4 (aggregate read-model contract), §3 (red lines W6-R1..R9), all OD-W6-*
+ *   resolved to option (a).
+ *
+ * This module owns EVERY read the aggregate performs. It is deliberately
+ * kept out of `attendance-admin.ts` (route wiring only) and out of
+ * `plugins/plugin-attendance/index.cjs` (no new separable logic added
+ * there) per this line's module-boundary convention.
+ *
+ * Authorization is NOT this module's job (W6-R3): the caller (the route)
+ * must resolve and verify the org/permission/membership BEFORE calling
+ * `getAggregate`. This module receives an already-authorized `orgId` and
+ * only ever issues `groupId + orgId`-scoped reads.
+ *
+ * GET-only (W6-R1): every exported query is a SELECT. There is no
+ * INSERT/UPDATE/DELETE anywhere in this file — see the DML-sweep test
+ * (`tests/unit/attendance-w6-group-effective-policy-aggregate-dml-sweep.test.ts`)
+ * for the mechanical proof.
+ *
+ * Fixed-schedule effectiveness (W6-R4, OD-W6-2(a)): this module calls the
+ * EXISTING FSER service (`attendance-group-fixed-schedule-effectiveness-service.cjs`,
+ * injected as `deps.fser`) and embeds its result verbatim (minus the
+ * redundant `groupId` key, already present at the aggregate's own top
+ * level) for `fixed_shift` groups. It introduces no second effectiveness
+ * predicate and no persisted second status.
+ */
+import { validateAttendanceGroupEffectivePolicyResponseV1 } from './w6-group-effective-policy-response-contract'
+import type {
+  AttendanceGroupEffectivePolicyAggregateV1,
+  AttendanceGroupEffectivePolicyCalculationPostureV1,
+  AttendanceGroupEffectivePolicyConflictCodeV1,
+  AttendanceGroupEffectivePolicyEditorRefV1,
+  AttendanceGroupEffectivePolicyGroupTypeV1,
+  AttendanceGroupFixedScheduleEffectivenessV1,
+} from './w6-group-effective-policy-contract'
+
+export type AttendanceGroupEffectivePolicyQueryFn = (sql: string, params?: unknown[]) => Promise<Record<string, unknown>[]>
+
+/** Structural type for the injected FSER service — matches
+ * `createAttendanceGroupFixedScheduleEffectivenessService(...)`'s
+ * `getEffectiveness` export exactly (see
+ * `plugins/plugin-attendance/lib/attendance-group-fixed-schedule-effectiveness-service.cjs`). */
+export interface AttendanceGroupEffectivePolicyFserServiceLike {
+  getEffectiveness(
+    db: { query: AttendanceGroupEffectivePolicyQueryFn },
+    input: { orgId: string; groupId: string },
+  ): Promise<{
+    groupId: string
+    state: 'not_configured' | 'pending_apply' | 'effective' | 'configuration_changed'
+    reasonCodes: readonly string[]
+    desired: { shiftId: string; startDate: string; endDate: string; revision: number } | null
+    coverage: {
+      targetMembers: number
+      matchingMembers: number
+      missingMembers: number
+      nonMemberTargets: number
+      differentKeyRows: number
+    }
+    drift: {
+      unconfiguredManagedRows: number
+      unpublishedManagedRows: number
+      managedSets: ReadonlyArray<{ shiftId: string; startDate: string; endDate: string; producerKey: string; rowCount: number }>
+    }
+    evaluatedAt: string
+  }>
+}
+
+export class AttendanceGroupEffectivePolicyServiceError extends Error {
+  readonly status: number
+  readonly code: string
+  constructor(status: number, code: string, message: string) {
+    super(message)
+    this.status = status
+    this.code = code
+  }
+}
+
+export interface AttendanceGroupEffectivePolicyServiceDeps {
+  query: AttendanceGroupEffectivePolicyQueryFn
+  fser: AttendanceGroupEffectivePolicyFserServiceLike
+  now?: () => string
+  /** Mirrors `SEGMENT_CALCULATION_IMPLEMENTED` from `attendance-shift-service.cjs`
+   * (currently `false` in production). Injected, not re-derived (W6-R4 spirit). */
+  segmentCalculationImplemented?: boolean
+}
+
+const GROUP_TYPES = new Set<AttendanceGroupEffectivePolicyGroupTypeV1>(['fixed_shift', 'scheduled_shift', 'free_time'])
+const MANAGER_ROLES = new Set(['owner', 'sub_owner'])
+const ROLLOUT_STATES = new Set<AttendanceGroupEffectivePolicyCalculationPostureV1>([
+  'legacy',
+  'shadow',
+  'eligible',
+  'authoritative',
+  'suspended',
+])
+
+function stageRef(stage: 'basics' | 'people' | 'schedule' | 'policies'): AttendanceGroupEffectivePolicyEditorRefV1 {
+  return { kind: 'group_stage', stage }
+}
+
+function scheduleRouteRef(
+  step: 'schedule' | 'calendar' | 'rules',
+  surface?: string,
+): AttendanceGroupEffectivePolicyEditorRefV1 {
+  if (step === 'calendar') return { kind: 'group_context_route', step: 'calendar' }
+  if (step === 'rules') {
+    return surface
+      ? ({ kind: 'group_context_route', step: 'rules', surface: 'rule-sets' } as AttendanceGroupEffectivePolicyEditorRefV1)
+      : ({ kind: 'group_context_route', step: 'rules' } as AttendanceGroupEffectivePolicyEditorRefV1)
+  }
+  return surface
+    ? ({ kind: 'group_context_route', step: 'schedule', surface } as AttendanceGroupEffectivePolicyEditorRefV1)
+    : { kind: 'group_context_route', step: 'schedule' }
+}
+
+/**
+ * W6-R4 note on the producer key: FSER's `loadEffectivenessFacts` always
+ * calls the injected `buildAttendanceGroupFixedScheduleProducerKey` with an
+ * ALREADY-canonicalized `YYYY-MM-DD` `startDate`/`endDate` pair (it comes
+ * from FSER's own `mapDesired`, which already ran `formatDateOnly`). For
+ * that restricted input domain, the canonical builder
+ * (`plugins/plugin-attendance/index.cjs` ~L10676,
+ * `buildAttendanceGroupFixedScheduleProducerKey` + its
+ * `normalizeAttendanceScheduleAssignmentEndDate`/`normalizeDateOnly`
+ * helpers) is provably equivalent to the flat join below: `normalizeDateOnly`
+ * re-parses an already-canonical `YYYY-MM-DD` string via its own
+ * `(\d{2,4})-(\d{1,2})-(\d{1,2})` branch and re-emits the identical string,
+ * and `null` stays `null`. This is NOT a second FSER state-machine
+ * derivation (R4's actual target) — it is one input-formatting helper to
+ * that single derivation, reconstructed here because the canonical
+ * function is a private top-level declaration inside the (non-exporting)
+ * plugin entry file and is not independently `require`-able without
+ * loading that file's full activation surface. See the parity test
+ * (`attendance-w6-group-effective-policy-aggregate.test.ts`,
+ * "producer key parity") for the equivalence proof over the exact
+ * input shapes this call site ever supplies.
+ */
+export function buildFixedScheduleProducerKey(input: { groupId: string; shiftId: string; startDate: string; endDate: string | null }): string {
+  return ['attendance_group_fixed_schedule', input.groupId, input.shiftId, input.startDate, input.endDate ?? 'null'].join(':')
+}
+
+export function createAttendanceGroupEffectivePolicyAggregateService(deps: AttendanceGroupEffectivePolicyServiceDeps) {
+  const now = deps.now ?? (() => new Date().toISOString())
+  const segmentCalculationImplemented = deps.segmentCalculationImplemented ?? false
+  const db = { query: deps.query }
+
+  async function loadGroup(orgId: string, groupId: string) {
+    const rows = await deps.query(
+      `SELECT id, attendance_type, timezone, rule_set_id
+         FROM attendance_groups
+        WHERE id = $1 AND org_id = $2
+        LIMIT 1`,
+      [groupId, orgId],
+    )
+    if (!rows.length) throw new AttendanceGroupEffectivePolicyServiceError(404, 'NOT_FOUND', 'Group not found')
+    const row = rows[0]
+    const groupType = row.attendance_type
+    if (typeof groupType !== 'string' || !GROUP_TYPES.has(groupType as AttendanceGroupEffectivePolicyGroupTypeV1)) {
+      throw new AttendanceGroupEffectivePolicyServiceError(500, 'GROUP_TYPE_UNRECOGNIZED', 'Group type is not a recognized value')
+    }
+    return {
+      groupType: groupType as AttendanceGroupEffectivePolicyGroupTypeV1,
+      timezone: typeof row.timezone === 'string' && row.timezone.trim() ? row.timezone : null,
+      ruleSetId: typeof row.rule_set_id === 'string' && row.rule_set_id.trim() ? row.rule_set_id : null,
+    }
+  }
+
+  async function loadActiveMemberCount(orgId: string, groupId: string): Promise<number> {
+    const rows = await deps.query(
+      `SELECT COUNT(*)::int AS cnt FROM attendance_group_members WHERE org_id = $1 AND group_id = $2`,
+      [orgId, groupId],
+    )
+    return Number(rows[0]?.cnt ?? 0)
+  }
+
+  async function loadManagerPosture(orgId: string, groupId: string) {
+    const rows = await deps.query(
+      `SELECT role, COUNT(*)::int AS cnt FROM attendance_group_managers WHERE org_id = $1 AND group_id = $2 GROUP BY role`,
+      [orgId, groupId],
+    )
+    let ownerCount = 0
+    let subOwnerCount = 0
+    for (const row of rows) {
+      const role = row.role
+      if (typeof role !== 'string' || !MANAGER_ROLES.has(role)) {
+        throw new AttendanceGroupEffectivePolicyServiceError(500, 'MANAGER_ROLE_UNRECOGNIZED', 'Manager role is not a recognized value')
+      }
+      if (role === 'owner') ownerCount = Number(row.cnt ?? 0)
+      else subOwnerCount = Number(row.cnt ?? 0)
+    }
+    return { ownerCount, subOwnerCount }
+  }
+
+  async function loadCalculationPosture(orgId: string): Promise<AttendanceGroupEffectivePolicyCalculationPostureV1> {
+    const rows = await deps.query(`SELECT state FROM attendance_calculation_rollout_state WHERE org_id = $1 LIMIT 1`, [orgId])
+    if (!rows.length) return 'legacy'
+    const state = rows[0].state
+    if (typeof state !== 'string' || !ROLLOUT_STATES.has(state as AttendanceGroupEffectivePolicyCalculationPostureV1)) {
+      throw new AttendanceGroupEffectivePolicyServiceError(500, 'ROLLOUT_STATE_UNRECOGNIZED', 'Rollout state is not a recognized value')
+    }
+    return state as AttendanceGroupEffectivePolicyCalculationPostureV1
+  }
+
+  async function loadOrgHasDefaultRuleSet(orgId: string): Promise<boolean> {
+    const rows = await deps.query(
+      `SELECT 1 FROM attendance_rule_sets WHERE org_id = $1 AND is_default = true LIMIT 1`,
+      [orgId],
+    )
+    return rows.length > 0
+  }
+
+  async function loadHasAdvancedSchedulingConfig(orgId: string, groupId: string): Promise<boolean> {
+    const rows = await deps.query(
+      `SELECT 1 FROM attendance_schedule_groups WHERE org_id = $1 AND attendance_group_id = $2 AND is_active = true LIMIT 1`,
+      [orgId, groupId],
+    )
+    return rows.length > 0
+  }
+
+  async function loadShiftSegmentProfile(shiftId: string): Promise<{ segmentCount: number; flexMode: 'strict' | 'flex_required_duration' }> {
+    const [segmentRows, shiftRows] = await Promise.all([
+      deps.query(`SELECT COUNT(*)::int AS cnt FROM attendance_shift_segments WHERE shift_id = $1`, [shiftId]),
+      deps.query(`SELECT flex_mode FROM attendance_shifts WHERE id = $1 LIMIT 1`, [shiftId]),
+    ])
+    const segmentCount = Number(segmentRows[0]?.cnt ?? 0)
+    const flexModeRaw = shiftRows[0]?.flex_mode
+    const flexMode = flexModeRaw === 'flex_required_duration' ? 'flex_required_duration' : 'strict'
+    return { segmentCount, flexMode }
+  }
+
+  /** The fixed-schedule config row's OWN id (distinct from the shift it
+   * targets) — FSER's own `loadEffectivenessFacts` never selects `id`
+   * (it only needs shift_id/dates/revision), so the aggregate reads it
+   * separately, purely for the `fixed_schedule_config` sourceRef. This is
+   * metadata about which config row is desired, not a second effectiveness
+   * derivation (W6-R4 governs the STATE derivation, not this id lookup). */
+  async function loadFixedScheduleConfigId(orgId: string, groupId: string): Promise<string | null> {
+    const rows = await deps.query(
+      `SELECT id FROM attendance_group_fixed_schedule_configs WHERE org_id = $1 AND group_id = $2 LIMIT 1`,
+      [orgId, groupId],
+    )
+    const id = rows[0]?.id
+    return typeof id === 'string' && id.trim() ? id : null
+  }
+
+  /**
+   * W6-R5 / OD-W6-8(a): bounded per-group, current-date-only membership
+   * overlap detection. Counts users who (a) hold an effective-today
+   * `attendance_calculation_group_memberships` row for THIS group, and (b)
+   * hold MORE THAN ONE effective-today row org-wide (any group) — i.e. the
+   * exact "two or more effective groups" conflict parent lock §3.4 names.
+   * Output is a bare COUNT; no member list is ever read out of this query
+   * or passed further.
+   */
+  async function countMembershipOverlap(orgId: string, groupId: string): Promise<number> {
+    const rows = await deps.query(
+      `SELECT COUNT(*)::int AS cnt
+         FROM (
+           SELECT m.user_id
+             FROM attendance_calculation_group_memberships m
+            WHERE m.org_id = $1
+              AND m.group_id = $2
+              AND m.effective_from <= CURRENT_DATE
+              AND (m.effective_to IS NULL OR m.effective_to >= CURRENT_DATE)
+            GROUP BY m.user_id
+         ) this_group
+        WHERE (
+          SELECT COUNT(*)
+            FROM attendance_calculation_group_memberships other
+           WHERE other.org_id = $1
+             AND other.user_id = this_group.user_id
+             AND other.effective_from <= CURRENT_DATE
+             AND (other.effective_to IS NULL OR other.effective_to >= CURRENT_DATE)
+        ) > 1`,
+      [orgId, groupId],
+    )
+    return Number(rows[0]?.cnt ?? 0)
+  }
+
+  function fserStateToScheduleLabel(state: string): {
+    label: AttendanceGroupEffectivePolicyAggregateV1['domains']['schedule']['label']
+    conflictCode: AttendanceGroupEffectivePolicyConflictCodeV1 | null
+  } {
+    switch (state) {
+      case 'effective':
+        return { label: 'effective', conflictCode: null }
+      case 'not_configured':
+        return { label: 'needs_configuration', conflictCode: null }
+      case 'pending_apply':
+        return { label: 'conflict_action_required', conflictCode: 'FIXED_SCHEDULE_PENDING_APPLY' }
+      case 'configuration_changed':
+        return { label: 'conflict_action_required', conflictCode: 'FIXED_SCHEDULE_CONFIGURATION_CHANGED' }
+      default:
+        throw new AttendanceGroupEffectivePolicyServiceError(500, 'FSER_STATE_UNRECOGNIZED', 'Fixed-schedule state is not a recognized value')
+    }
+  }
+
+  async function getAggregate(input: { orgId: string; groupId: string }): Promise<AttendanceGroupEffectivePolicyAggregateV1> {
+    const { orgId, groupId } = input
+    const group = await loadGroup(orgId, groupId)
+    const evaluatedAt = now()
+
+    const [activeMemberCount, managerPosture, calculationPosture] = await Promise.all([
+      loadActiveMemberCount(orgId, groupId),
+      loadManagerPosture(orgId, groupId),
+      loadCalculationPosture(orgId),
+    ])
+
+    const conflicts: AttendanceGroupEffectivePolicyAggregateV1['conflicts'][number][] = []
+
+    // ---- schedule + segments + flex --------------------------------------
+    let scheduleLabel: AttendanceGroupEffectivePolicyAggregateV1['domains']['schedule']['label'] = 'effective'
+    let scheduleReasonCodes: string[] = []
+    let scheduleSourceRefs: Array<{ kind: 'shift' | 'fixed_schedule_config'; id: string }> = []
+    let fixedSchedule: AttendanceGroupFixedScheduleEffectivenessV1 | null = null
+    let scheduleEditorRef = scheduleRouteRef('schedule', 'assignments')
+
+    let segmentLabel: AttendanceGroupEffectivePolicyAggregateV1['domains']['segments']['label'] = 'effective'
+    let segmentReasonCodes: string[] = []
+    let segmentSourceRefs: Array<{ kind: 'shift'; id: string }> = []
+
+    let flexLabel: AttendanceGroupEffectivePolicyAggregateV1['domains']['flex']['label'] = 'effective'
+    let flexReasonCodes: string[] = []
+    let flexMode: 'strict' | 'flex_required_duration' | undefined
+
+    if (group.groupType === 'fixed_shift') {
+      scheduleEditorRef = scheduleRouteRef('schedule', 'assignments')
+      const fser = await deps.fser.getEffectiveness(db, { orgId, groupId })
+      const { groupId: _fserGroupId, ...fserEmbed } = fser
+      fixedSchedule = fserEmbed as AttendanceGroupFixedScheduleEffectivenessV1
+
+      const mapped = fserStateToScheduleLabel(fser.state)
+      scheduleLabel = mapped.label
+      // Domain-summary reasonCodes carry ONE representative reason, not
+      // FSER's full diagnostic list (that stays inside the embedded
+      // `fixedSchedule` object verbatim). Fixture-pinned: EFFECTIVE fixed_shift
+      // groups show `[]` here even though FSER's own reasonCodes is
+      // `['EFFECTIVE']`, and the configuration_changed fixture shows only
+      // `['DIFFERENT_MANAGED_KEY_ACTIVE']` even though FSER's full list is
+      // `['DIFFERENT_MANAGED_KEY_ACTIVE','TARGET_MEMBER_MISSING']` — FSER
+      // already orders reasonCodes by its own REASON_ORDER, so "first
+      // non-EFFECTIVE entry" is FSER's own primary-cause ordering, not a
+      // second derivation.
+      scheduleReasonCodes = fser.reasonCodes.filter((code) => code !== 'EFFECTIVE').slice(0, 1)
+      if (mapped.conflictCode) {
+        conflicts.push({
+          code: mapped.conflictCode,
+          domain: 'schedule',
+          label: 'conflict_action_required',
+          editorRef: scheduleEditorRef,
+        })
+      }
+
+      if (fser.desired) {
+        const [configId, profile] = await Promise.all([
+          loadFixedScheduleConfigId(orgId, groupId),
+          loadShiftSegmentProfile(fser.desired.shiftId),
+        ])
+        scheduleSourceRefs = [{ kind: 'shift', id: fser.desired.shiftId }]
+        if (configId) scheduleSourceRefs.push({ kind: 'fixed_schedule_config', id: configId })
+        segmentSourceRefs = [{ kind: 'shift', id: fser.desired.shiftId }]
+        flexMode = profile.flexMode
+        const isSingleSegmentStrict = profile.segmentCount <= 1 && profile.flexMode === 'strict'
+        const authoritativeAndImplemented = calculationPosture === 'authoritative' && segmentCalculationImplemented
+        if (isSingleSegmentStrict || authoritativeAndImplemented) {
+          segmentLabel = 'effective'
+          flexLabel = 'effective'
+        } else {
+          segmentLabel = 'preview_only'
+          flexLabel = 'preview_only'
+          segmentReasonCodes = ['SEGMENT_CALCULATION_NOT_AUTHORITATIVE']
+          flexReasonCodes = ['SEGMENT_CALCULATION_NOT_AUTHORITATIVE']
+        }
+      } else {
+        segmentLabel = scheduleLabel === 'needs_configuration' ? 'needs_configuration' : 'effective'
+        flexLabel = segmentLabel
+      }
+    } else if (group.groupType === 'free_time') {
+      scheduleEditorRef = scheduleRouteRef('schedule')
+      scheduleLabel = 'effective'
+      scheduleReasonCodes = []
+      scheduleSourceRefs = []
+      fixedSchedule = null
+      segmentLabel = 'effective'
+      flexLabel = 'effective'
+    } else {
+      // scheduled_shift
+      scheduleEditorRef = scheduleRouteRef('schedule', 'advanced-scheduling')
+      const hasAdvancedScheduling = await loadHasAdvancedSchedulingConfig(orgId, groupId)
+      if (!hasAdvancedScheduling) {
+        scheduleLabel = 'needs_configuration'
+        scheduleReasonCodes = ['SCHEDULE_STRATEGY_INCOMPLETE']
+        conflicts.push({
+          code: 'SCHEDULE_STRATEGY_INCOMPLETE',
+          domain: 'schedule',
+          label: 'conflict_action_required',
+          editorRef: scheduleEditorRef,
+        })
+        segmentLabel = 'needs_configuration'
+        segmentReasonCodes = ['SCHEDULE_STRATEGY_INCOMPLETE']
+        flexLabel = 'needs_configuration'
+        flexReasonCodes = ['SCHEDULE_STRATEGY_INCOMPLETE']
+      } else {
+        // Not fixture-pinned (no `scheduled_shift`-configured fixture exists
+        // in the W6-0 pack): a configured scheduled_shift group has no
+        // resolvable single shift in v1, so segments/flex default to
+        // `effective` with no sourceRefs. Flagged in the W6-1 report.
+        scheduleLabel = 'effective'
+        segmentLabel = 'effective'
+        flexLabel = 'effective'
+      }
+    }
+
+    // ---- membership --------------------------------------------------------
+    const overlapCount = await countMembershipOverlap(orgId, groupId)
+    const membershipLabel: AttendanceGroupEffectivePolicyAggregateV1['domains']['membership']['label'] =
+      overlapCount > 0 ? 'conflict_action_required' : 'effective'
+    const membershipReasonCodes = overlapCount > 0 ? ['CALCULATION_GROUP_MEMBERSHIP_OVERLAP'] : []
+    if (overlapCount > 0) {
+      conflicts.push({
+        code: 'CALCULATION_GROUP_MEMBERSHIP_OVERLAP',
+        domain: 'membership',
+        label: 'conflict_action_required',
+        affectedUserCount: overlapCount,
+        editorRef: stageRef('people'),
+      })
+    }
+
+    // ---- rules ---------------------------------------------------------
+    let rulesLabel: AttendanceGroupEffectivePolicyAggregateV1['domains']['rules']['label']
+    let rulesReasonCodes: string[] = []
+    let rulesSourceRefs: Array<{ kind: 'rule_set'; id: string }> = []
+    const rulesSource: 'org_default' | 'group_rule_set' = group.ruleSetId ? 'group_rule_set' : 'org_default'
+    if (group.ruleSetId) {
+      rulesLabel = 'effective'
+      rulesSourceRefs = [{ kind: 'rule_set', id: group.ruleSetId }]
+    } else {
+      const hasDefault = await loadOrgHasDefaultRuleSet(orgId)
+      if (hasDefault) {
+        rulesLabel = 'org_inherited'
+      } else {
+        rulesLabel = 'needs_configuration'
+        rulesReasonCodes = ['RULE_SOURCE_MISSING']
+        // No conflicts[] entry: RULE_SOURCE_MISSING is a domain reasonCode
+        // only, per the fixture-pinned asymmetry in
+        // aggregate-needs-configuration.json (SCHEDULE_STRATEGY_INCOMPLETE
+        // is in both the domain AND conflicts[]; RULE_SOURCE_MISSING is
+        // domain-only). Reproduced byte-exactly, not normalized away.
+      }
+    }
+
+    // ---- timezone conflict -----------------------------------------------
+    if (group.timezone === null) {
+      conflicts.push({
+        code: 'TIMEZONE_MISSING',
+        domain: 'basics',
+        label: 'conflict_action_required',
+        editorRef: stageRef('basics'),
+      })
+    }
+
+    const aggregate: AttendanceGroupEffectivePolicyAggregateV1 = {
+      groupId,
+      groupType: group.groupType,
+      timezone: group.timezone,
+      activeMemberCount,
+      managerPosture,
+      calculationPosture,
+      domains: {
+        membership: {
+          label: membershipLabel,
+          reasonCodes: membershipReasonCodes,
+          editorRef: stageRef('people'),
+        },
+        schedule: {
+          label: scheduleLabel,
+          strategy: group.groupType,
+          reasonCodes: scheduleReasonCodes,
+          // sourceRefs is ALWAYS present on schedule/segments/rules (even
+          // `[]`) — fixture-pinned across all 6 aggregate-*.json fixtures.
+          sourceRefs: scheduleSourceRefs,
+          fixedSchedule,
+          editorRef: scheduleEditorRef,
+        },
+        segments: {
+          label: segmentLabel,
+          reasonCodes: segmentReasonCodes,
+          sourceRefs: segmentSourceRefs,
+          editorRef: scheduleRouteRef('schedule', 'shifts'),
+        },
+        flex: {
+          label: flexLabel,
+          ...(flexMode ? { mode: flexMode } : {}),
+          reasonCodes: flexReasonCodes,
+          editorRef: scheduleRouteRef('schedule', 'shifts'),
+        },
+        rules: {
+          label: rulesLabel,
+          source: rulesSource,
+          sourceRefs: rulesSourceRefs,
+          reasonCodes: rulesReasonCodes,
+          editorRef: scheduleRouteRef('rules', 'rule-sets'),
+        },
+        punchMethod: {
+          label: 'org_inherited',
+          source: 'org_inherited',
+          reasonCodes: [],
+          editorRef: stageRef('policies'),
+        },
+        requestPosture: {
+          label: 'org_inherited',
+          overtime: 'org_inherited',
+          makeupPunch: 'org_inherited',
+          outdoor: 'org_inherited',
+          reasonCodes: [],
+          editorRef: stageRef('policies'),
+        },
+      },
+      conflicts,
+      evaluatedAt,
+    }
+
+    // Belt-and-suspenders (R7 spirit): never hand the route a response this
+    // module's own contract validator would reject.
+    const validation = validateAttendanceGroupEffectivePolicyResponseV1({ ok: true, data: aggregate })
+    if (validation.ok === false) {
+      throw new AttendanceGroupEffectivePolicyServiceError(
+        500,
+        'AGGREGATE_CONTRACT_VIOLATION',
+        `Aggregate failed its own response contract: ${validation.reason}`,
+      )
+    }
+    return aggregate
+  }
+
+  return { getAggregate, countMembershipOverlap }
+}

--- a/packages/core-backend/src/attendance/w6-group-effective-policy-aggregate.ts
+++ b/packages/core-backend/src/attendance/w6-group-effective-policy-aggregate.ts
@@ -137,19 +137,28 @@ function scheduleRouteRef(
  * that single derivation, reconstructed here because the canonical
  * function is a private top-level declaration inside the (non-exporting)
  * plugin entry file and is not independently `require`-able without
- * loading that file's full activation surface. See the "producer key
- * parity" describe block in
- * `attendance-w6-group-effective-policy-aggregate.test.ts` — it PINS this
- * function's exact output format literally (so any accidental format
- * change reds immediately, not just when it happens to disagree with the
- * canonical builder), and independently, the real-DB fidelity test
- * (`attendance-w6-group-effective-policy.db.test.ts`) seeds fixed-schedule
- * rows keyed by a producer key computed with THIS function and confirms
- * FSER still matches them (a format drift here would show up there as a
- * `DIFFERENT_MANAGED_KEY_ACTIVE`-shaped failure). Neither test imports the
- * canonical builder itself — see the equivalence ARGUMENT above for why
- * that is not independently re-provable without loading index.cjs's full
- * activation surface.
+ * loading that file's full activation surface. Two INDEPENDENT tests back
+ * this function, deliberately not sharing an implementation with each
+ * other or with it:
+ *  (1) the "producer key parity" describe block in
+ *      `attendance-w6-group-effective-policy-aggregate.test.ts` PINS this
+ *      function's exact output format literally, so any accidental format
+ *      change here reds immediately; and
+ *  (2) the real-DB fidelity test (`attendance-w6-group-effective-policy.db.test.ts`,
+ *      ~L192) seeds fixed-schedule rows keyed by a producer key computed
+ *      from a HAND-WRITTEN literal of the same join format — NOT by calling
+ *      this function — and then confirms FSER still matches them. That
+ *      literal is a third, deliberately independent copy of the format;
+ *      DO NOT refactor it to call `buildFixedScheduleProducerKey` (that
+ *      would remove the only DB-level discrimination this function has —
+ *      confirmed by mutation: changing this function's separator while
+ *      leaving the DB seed's literal alone breaks FSER's row match and reds
+ *      the fidelity test; the parity-pin test in (1) would still catch a
+ *      format regression on its own, but only as a pinned-literal
+ *      comparison, not as a real FSER-derived behavioral consequence).
+ * Neither test imports the canonical `index.cjs` builder itself — see the
+ * equivalence ARGUMENT above for why that is not independently re-provable
+ * without loading index.cjs's full activation surface.
  */
 export function buildFixedScheduleProducerKey(input: { groupId: string; shiftId: string; startDate: string; endDate: string | null }): string {
   return ['attendance_group_fixed_schedule', input.groupId, input.shiftId, input.startDate, input.endDate ?? 'null'].join(':')

--- a/packages/core-backend/src/attendance/w6-group-effective-policy-aggregate.ts
+++ b/packages/core-backend/src/attendance/w6-group-effective-policy-aggregate.ts
@@ -97,6 +97,9 @@ const ROLLOUT_STATES = new Set<AttendanceGroupEffectivePolicyCalculationPostureV
   'authoritative',
   'suspended',
 ])
+// Mirrors `chk_attendance_shifts_flex_mode` — the only two values the
+// column's own CHECK constraint permits.
+const FLEX_MODES = new Set(['strict', 'flex_required_duration'])
 
 function stageRef(stage: 'basics' | 'people' | 'schedule' | 'policies'): AttendanceGroupEffectivePolicyEditorRefV1 {
   return { kind: 'group_stage', stage }
@@ -228,7 +231,10 @@ export function createAttendanceGroupEffectivePolicyAggregateService(deps: Atten
     ])
     const segmentCount = Number(segmentRows[0]?.cnt ?? 0)
     const flexModeRaw = shiftRows[0]?.flex_mode
-    const flexMode = flexModeRaw === 'flex_required_duration' ? 'flex_required_duration' : 'strict'
+    if (typeof flexModeRaw !== 'string' || !FLEX_MODES.has(flexModeRaw)) {
+      throw new AttendanceGroupEffectivePolicyServiceError(500, 'FLEX_MODE_UNRECOGNIZED', 'Shift flex mode is not a recognized value')
+    }
+    const flexMode = flexModeRaw as 'strict' | 'flex_required_duration'
     return { segmentCount, flexMode }
   }
 

--- a/packages/core-backend/src/attendance/w6-group-effective-policy-contract.ts
+++ b/packages/core-backend/src/attendance/w6-group-effective-policy-contract.ts
@@ -1,9 +1,21 @@
 /**
  * W6 (#4556) — group effective-policy aggregate read model: CONTRACT DRAFT.
  *
- * Status: PROPOSED / runtime HOLD. Types and closed enum constants only.
- * Nothing at runtime imports this module in W6-0; deleting it must leave
- * every existing test green (design lock red line W6-R9).
+ * Status update (W6-1, #4814): this file's TYPES and closed enum
+ * constants ARE imported and used at runtime by W6-1's aggregate service
+ * and response-contract validator — the "nothing at runtime imports this
+ * module" statement was accurate for W6-0 (#4771, when this file was
+ * prep-only and PROPOSED) and is superseded now that W6-1 wires the
+ * aggregate up. This does NOT authorize any new runtime BEHAVIOR beyond
+ * what W6-1's own red lines (W6-R1..R9) already govern — W6-R9 itself
+ * remains N/A to this file's PROPOSED contents (the OpenAPI-facing
+ * pieces, still unused).
+ *
+ * `ATTENDANCE_GROUP_EFFECTIVE_POLICY_REASON_CODES_V1` (added in #4814
+ * P2-2) is a module-scope `require()` of FSER's `.cjs` lib via
+ * `requirePluginAttendanceLib` — a real filesystem-touching call at
+ * import time, placed here alongside the other closed enum constants the
+ * validator already imports at runtime, not new "prep drift."
  *
  * Governing document:
  *   docs/development/attendance-issue-4556-w6-group-effective-policy-design-lock-20260805.md

--- a/packages/core-backend/src/attendance/w6-group-effective-policy-contract.ts
+++ b/packages/core-backend/src/attendance/w6-group-effective-policy-contract.ts
@@ -20,6 +20,7 @@
  *  - flex mode is the W5 union from w5-flex-policy.ts, read-only;
  *  - calculation posture is the W4 rollout state union, read-only.
  */
+import { requirePluginAttendanceLib } from '../util/resolve-plugin-attendance-lib'
 
 /** Parent lock §5.1 five display states — machine spelling per OD-W6-3(a). */
 export const ATTENDANCE_GROUP_EFFECTIVE_POLICY_SOURCE_LABELS_V1 = Object.freeze([
@@ -58,6 +59,38 @@ export const ATTENDANCE_GROUP_EFFECTIVE_POLICY_CONFLICT_CODES_V1 = Object.freeze
 ] as const)
 export type AttendanceGroupEffectivePolicyConflictCodeV1 =
   (typeof ATTENDANCE_GROUP_EFFECTIVE_POLICY_CONFLICT_CODES_V1)[number]
+
+/**
+ * Closed reason-code union per §4.2: *"Reason codes inside the embedded
+ * fixed-schedule object are the FSER lock's closed list, unchanged and in
+ * FSER order."* Used to validate BOTH `fixedSchedule.reasonCodes` (FSER's
+ * full list, embedded verbatim, including `EFFECTIVE`) and every
+ * `domains.*.reasonCodes` (always a strict subset — FSER's codes with
+ * `EFFECTIVE` filtered out for the `schedule` domain, plus the four
+ * W6-authored domain-level codes below that are not part of FSER's own
+ * vocabulary).
+ *
+ * FSER's `REASON_ORDER` is IMPORTED, not hand-copied — a second hand-typed
+ * copy is exactly the drift risk §7.3 forbids for W6-2's OpenAPI mint, and
+ * is exactly what R4's own fidelity test independently duplicates a third
+ * time (flagged separately, #4814 P3-5).
+ */
+const fserEffectivenessServiceLib = requirePluginAttendanceLib<{ REASON_ORDER: readonly string[] }>(
+  __dirname,
+  'attendance-group-fixed-schedule-effectiveness-service.cjs',
+)
+/** The four domain-level reason codes this aggregate mints itself — never
+ * part of FSER's vocabulary, so not present in `REASON_ORDER`. */
+const ATTENDANCE_GROUP_EFFECTIVE_POLICY_OWN_REASON_CODES_V1 = [
+  'SEGMENT_CALCULATION_NOT_AUTHORITATIVE',
+  'SCHEDULE_STRATEGY_INCOMPLETE',
+  'CALCULATION_GROUP_MEMBERSHIP_OVERLAP',
+  'RULE_SOURCE_MISSING',
+] as const
+export const ATTENDANCE_GROUP_EFFECTIVE_POLICY_REASON_CODES_V1: readonly string[] = Object.freeze([
+  ...fserEffectivenessServiceLib.REASON_ORDER,
+  ...ATTENDANCE_GROUP_EFFECTIVE_POLICY_OWN_REASON_CODES_V1,
+])
 
 /** Existing CHECK-constrained group type union (read-only mirror). */
 export type AttendanceGroupEffectivePolicyGroupTypeV1 =

--- a/packages/core-backend/src/attendance/w6-group-effective-policy-response-contract.ts
+++ b/packages/core-backend/src/attendance/w6-group-effective-policy-response-contract.ts
@@ -203,6 +203,20 @@ function validateFixedSchedule(value: unknown): AttendanceGroupEffectivePolicyVa
     if (!hasClosedKeys(set, ['shiftId', 'startDate', 'endDate', 'producerKey', 'rowCount'])) {
       return fail('fixedSchedule.drift.managedSets[]: unexpected key set')
     }
+    // #4814 NIT-3: keys alone were checked, not value TYPES — `rowCount: {}`
+    // or `producerKey: 42` passed.
+    const managedSet = set as Record<string, unknown>
+    if (
+      !isNonEmptyString(managedSet.shiftId) ||
+      !isNonEmptyString(managedSet.startDate) ||
+      !isNonEmptyString(managedSet.endDate) ||
+      !isNonEmptyString(managedSet.producerKey)
+    ) {
+      return fail('fixedSchedule.drift.managedSets[]: field type mismatch')
+    }
+    if (!isNonNegativeInt(managedSet.rowCount)) {
+      return fail('fixedSchedule.drift.managedSets[]: rowCount not a non-negative int')
+    }
   }
   if (!isIsoTimestamp(v.evaluatedAt)) return fail('fixedSchedule.evaluatedAt: not an ISO timestamp')
   return { ok: true }

--- a/packages/core-backend/src/attendance/w6-group-effective-policy-response-contract.ts
+++ b/packages/core-backend/src/attendance/w6-group-effective-policy-response-contract.ts
@@ -30,12 +30,15 @@
 import {
   ATTENDANCE_GROUP_EFFECTIVE_POLICY_CONFLICT_CODES_V1,
   ATTENDANCE_GROUP_EFFECTIVE_POLICY_DOMAINS_V1,
+  ATTENDANCE_GROUP_EFFECTIVE_POLICY_REASON_CODES_V1,
   ATTENDANCE_GROUP_EFFECTIVE_POLICY_SOURCE_LABELS_V1,
   type AttendanceGroupEffectivePolicyCalculationPostureV1,
   type AttendanceGroupEffectivePolicyEditorRefV1,
   type AttendanceGroupEffectivePolicyGroupTypeV1,
   type AttendanceGroupEffectivePolicyResponseV1,
 } from './w6-group-effective-policy-contract'
+
+const REASON_CODES = new Set(ATTENDANCE_GROUP_EFFECTIVE_POLICY_REASON_CODES_V1)
 
 const CALCULATION_POSTURES: readonly AttendanceGroupEffectivePolicyCalculationPostureV1[] = Object.freeze([
   'legacy',
@@ -113,6 +116,13 @@ function isStringArray(value: unknown): value is string[] {
   return Array.isArray(value) && value.every((item) => typeof item === 'string')
 }
 
+/** W6-R6: reason codes are closed end to end (§4.2), not merely
+ * "an array of strings" — every entry must be one of FSER's closed
+ * `REASON_ORDER` or the four W6-authored domain reason codes. */
+function isReasonCodeArray(value: unknown): value is string[] {
+  return isStringArray(value) && value.every((item) => REASON_CODES.has(item))
+}
+
 /**
  * W6-R8: the single closed-table parser for `editorRef`. Returns the parsed
  * value on success; `null` on ANY shape that is not exactly one of the two
@@ -166,7 +176,7 @@ function validateFixedSchedule(value: unknown): AttendanceGroupEffectivePolicyVa
   }
   const v = value as Record<string, unknown>
   if (typeof v.state !== 'string' || !FSER_STATES.includes(v.state)) return fail('fixedSchedule.state: unknown enum value')
-  if (!isStringArray(v.reasonCodes)) return fail('fixedSchedule.reasonCodes: not a string array')
+  if (!isReasonCodeArray(v.reasonCodes)) return fail('fixedSchedule.reasonCodes: not a closed-set string array')
   if (v.desired !== null) {
     if (!hasClosedKeys(v.desired, ['shiftId', 'startDate', 'endDate', 'revision'])) return fail('fixedSchedule.desired: unexpected key set')
     const d = v.desired as Record<string, unknown>
@@ -211,7 +221,7 @@ function validateDomainSummary(
   if (typeof v.label !== 'string' || !ATTENDANCE_GROUP_EFFECTIVE_POLICY_SOURCE_LABELS_V1.includes(v.label as never)) {
     return fail(`${name}.label: unknown enum value`)
   }
-  if (!isStringArray(v.reasonCodes)) return fail(`${name}.reasonCodes: not a string array`)
+  if (!isReasonCodeArray(v.reasonCodes)) return fail(`${name}.reasonCodes: not a closed-set string array`)
   if (Object.prototype.hasOwnProperty.call(v, 'sourceRefs') && !validateSourceRefs(v.sourceRefs)) {
     return fail(`${name}.sourceRefs: invalid shape`)
   }

--- a/packages/core-backend/src/attendance/w6-group-effective-policy-response-contract.ts
+++ b/packages/core-backend/src/attendance/w6-group-effective-policy-response-contract.ts
@@ -1,0 +1,351 @@
+/**
+ * W6 (#4556) — group effective-policy aggregate: response contract validator.
+ *
+ * Governing document:
+ *   docs/development/attendance-issue-4556-w6-group-effective-policy-design-lock-20260805.md
+ *   §3 (red lines W6-R2, W6-R6, W6-R7, W6-R8), §4.2-4.3.
+ *
+ * Pure, DB-free, exact-key + enum-strict structural validator for the W6-1
+ * aggregate response. It exists to give W6-R2/R6/R7/R8 a single mechanical
+ * judge:
+ *  - W6-R2 (values-free): any key outside the closed shape — `memberIds`,
+ *    `userId`, `ownerUserId`, `affectedUserIds`, ... — fails validation,
+ *    because the walker rejects ANY unlisted key, not a hand-maintained
+ *    deny-list of "known bad" names;
+ *  - W6-R6 (enum-strict): every enum field is checked against its closed
+ *    union; an unrecognized value fails rather than being coerced to a
+ *    default;
+ *  - W6-R7 (labels only from persisted facts): this module has no notion of
+ *    a client-suppliable override — it only judges shape, so a caller that
+ *    tried to inject one would already have to fabricate a value that must
+ *    still pass the closed-enum check;
+ *  - W6-R8 (closed editor navigation): `parseAttendanceGroupEffectivePolicyEditorRefV1`
+ *    is the single closed-table parser for the two-kind union.
+ *
+ * Also used (see `w6-group-effective-policy-aggregate.ts`) as a final,
+ * cheap runtime self-check before the service hands its result to the
+ * route: if the service's own output ever fails this contract, the route
+ * must 500 rather than serve a malformed body.
+ */
+import {
+  ATTENDANCE_GROUP_EFFECTIVE_POLICY_CONFLICT_CODES_V1,
+  ATTENDANCE_GROUP_EFFECTIVE_POLICY_DOMAINS_V1,
+  ATTENDANCE_GROUP_EFFECTIVE_POLICY_SOURCE_LABELS_V1,
+  type AttendanceGroupEffectivePolicyCalculationPostureV1,
+  type AttendanceGroupEffectivePolicyEditorRefV1,
+  type AttendanceGroupEffectivePolicyGroupTypeV1,
+  type AttendanceGroupEffectivePolicyResponseV1,
+} from './w6-group-effective-policy-contract'
+
+const CALCULATION_POSTURES: readonly AttendanceGroupEffectivePolicyCalculationPostureV1[] = Object.freeze([
+  'legacy',
+  'shadow',
+  'eligible',
+  'authoritative',
+  'suspended',
+])
+
+const GROUP_TYPES: readonly AttendanceGroupEffectivePolicyGroupTypeV1[] = Object.freeze([
+  'fixed_shift',
+  'scheduled_shift',
+  'free_time',
+])
+
+const FSER_STATES = Object.freeze(['not_configured', 'pending_apply', 'effective', 'configuration_changed'])
+
+const FLEX_MODES = Object.freeze(['strict', 'flex_required_duration'])
+const RULE_SOURCES = Object.freeze(['org_default', 'group_rule_set'])
+const SCHEDULE_ROUTE_SURFACES: Record<string, readonly string[] | null> = Object.freeze({
+  schedule: ['shifts', 'assignments', 'advanced-scheduling'],
+  calendar: null,
+  rules: ['rule-sets'],
+})
+const GROUP_STAGES = Object.freeze(['basics', 'people', 'schedule', 'policies'])
+const SOURCE_REF_KINDS = Object.freeze(['shift', 'rule_set', 'fixed_schedule_config', 'schedule_group'])
+
+export type AttendanceGroupEffectivePolicyValidationResult =
+  | { readonly ok: true }
+  | { readonly ok: false; readonly reason: string }
+
+function fail(reason: string): AttendanceGroupEffectivePolicyValidationResult {
+  return { ok: false, reason }
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return false
+  const proto = Object.getPrototypeOf(value)
+  return proto === null || proto === Object.prototype
+}
+
+/** Exact-key check: `value` must be a plain object whose own enumerable keys
+ * are exactly `required` plus zero or more of `optional` — nothing else. */
+function hasClosedKeys(
+  value: unknown,
+  required: readonly string[],
+  optional: readonly string[] = [],
+): value is Record<string, unknown> {
+  if (!isPlainObject(value)) return false
+  if (Object.getOwnPropertySymbols(value).length > 0) return false
+  const own = Object.getOwnPropertyNames(value)
+  const allowed = new Set([...required, ...optional])
+  for (const key of own) {
+    if (!allowed.has(key)) return false
+  }
+  for (const key of required) {
+    if (!Object.prototype.hasOwnProperty.call(value, key)) return false
+  }
+  return true
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0
+}
+
+function isNonNegativeInt(value: unknown): value is number {
+  return typeof value === 'number' && Number.isInteger(value) && value >= 0
+}
+
+function isIsoTimestamp(value: unknown): value is string {
+  return typeof value === 'string' && !Number.isNaN(Date.parse(value))
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((item) => typeof item === 'string')
+}
+
+/**
+ * W6-R8: the single closed-table parser for `editorRef`. Returns the parsed
+ * value on success; `null` on ANY shape that is not exactly one of the two
+ * kinds in the closed union, including a caller-supplied admin `section` id
+ * (the exact shape of `invalid-reject-open-editor-ref.json`).
+ */
+export function parseAttendanceGroupEffectivePolicyEditorRefV1(
+  value: unknown,
+): AttendanceGroupEffectivePolicyEditorRefV1 | null {
+  if (!isPlainObject(value)) return null
+  if (value.kind === 'group_stage') {
+    if (!hasClosedKeys(value, ['kind', 'stage'])) return null
+    if (typeof value.stage !== 'string' || !GROUP_STAGES.includes(value.stage)) return null
+    return { kind: 'group_stage', stage: value.stage as 'basics' | 'people' | 'schedule' | 'policies' }
+  }
+  if (value.kind === 'group_context_route') {
+    if (typeof value.step !== 'string' || !Object.prototype.hasOwnProperty.call(SCHEDULE_ROUTE_SURFACES, value.step)) {
+      return null
+    }
+    const step = value.step as 'schedule' | 'calendar' | 'rules'
+    const allowedSurfaces = SCHEDULE_ROUTE_SURFACES[step]
+    if (allowedSurfaces === null) {
+      if (!hasClosedKeys(value, ['kind', 'step'])) return null
+      return { kind: 'group_context_route', step: 'calendar' }
+    }
+    if (!hasClosedKeys(value, ['kind', 'step'], ['surface'])) return null
+    if (Object.prototype.hasOwnProperty.call(value, 'surface')) {
+      if (typeof value.surface !== 'string' || !allowedSurfaces.includes(value.surface)) return null
+      return { kind: 'group_context_route', step, surface: value.surface } as AttendanceGroupEffectivePolicyEditorRefV1
+    }
+    return { kind: 'group_context_route', step } as AttendanceGroupEffectivePolicyEditorRefV1
+  }
+  return null
+}
+
+function validateSourceRefs(value: unknown): boolean {
+  if (!Array.isArray(value)) return false
+  return value.every(
+    (item) =>
+      hasClosedKeys(item, ['kind', 'id']) &&
+      typeof (item as Record<string, unknown>).kind === 'string' &&
+      SOURCE_REF_KINDS.includes((item as Record<string, unknown>).kind as string) &&
+      isNonEmptyString((item as Record<string, unknown>).id),
+  )
+}
+
+function validateFixedSchedule(value: unknown): AttendanceGroupEffectivePolicyValidationResult {
+  if (value === null) return { ok: true }
+  if (!hasClosedKeys(value, ['state', 'reasonCodes', 'desired', 'coverage', 'drift', 'evaluatedAt'])) {
+    return fail('fixedSchedule: unexpected key set')
+  }
+  const v = value as Record<string, unknown>
+  if (typeof v.state !== 'string' || !FSER_STATES.includes(v.state)) return fail('fixedSchedule.state: unknown enum value')
+  if (!isStringArray(v.reasonCodes)) return fail('fixedSchedule.reasonCodes: not a string array')
+  if (v.desired !== null) {
+    if (!hasClosedKeys(v.desired, ['shiftId', 'startDate', 'endDate', 'revision'])) return fail('fixedSchedule.desired: unexpected key set')
+    const d = v.desired as Record<string, unknown>
+    if (!isNonEmptyString(d.shiftId) || !isNonEmptyString(d.startDate) || !isNonEmptyString(d.endDate) || typeof d.revision !== 'number') {
+      return fail('fixedSchedule.desired: field type mismatch')
+    }
+  }
+  if (!hasClosedKeys(v.coverage, ['targetMembers', 'matchingMembers', 'missingMembers', 'nonMemberTargets', 'differentKeyRows'])) {
+    return fail('fixedSchedule.coverage: unexpected key set')
+  }
+  const coverage = v.coverage as Record<string, unknown>
+  for (const key of ['targetMembers', 'matchingMembers', 'missingMembers', 'nonMemberTargets', 'differentKeyRows']) {
+    if (!isNonNegativeInt(coverage[key])) return fail(`fixedSchedule.coverage.${key}: not a non-negative int`)
+  }
+  if (!hasClosedKeys(v.drift, ['unconfiguredManagedRows', 'unpublishedManagedRows', 'managedSets'])) {
+    return fail('fixedSchedule.drift: unexpected key set')
+  }
+  const drift = v.drift as Record<string, unknown>
+  if (!isNonNegativeInt(drift.unconfiguredManagedRows) || !isNonNegativeInt(drift.unpublishedManagedRows)) {
+    return fail('fixedSchedule.drift: counts not a non-negative int')
+  }
+  if (!Array.isArray(drift.managedSets)) return fail('fixedSchedule.drift.managedSets: not an array')
+  for (const set of drift.managedSets) {
+    if (!hasClosedKeys(set, ['shiftId', 'startDate', 'endDate', 'producerKey', 'rowCount'])) {
+      return fail('fixedSchedule.drift.managedSets[]: unexpected key set')
+    }
+  }
+  if (!isIsoTimestamp(v.evaluatedAt)) return fail('fixedSchedule.evaluatedAt: not an ISO timestamp')
+  return { ok: true }
+}
+
+function validateDomainSummary(
+  name: string,
+  value: unknown,
+  extraRequired: readonly string[],
+  extraOptional: readonly string[] = [],
+): AttendanceGroupEffectivePolicyValidationResult {
+  if (!hasClosedKeys(value, ['label', 'reasonCodes', 'editorRef', ...extraRequired], ['sourceRefs', ...extraOptional])) {
+    return fail(`${name}: unexpected key set`)
+  }
+  const v = value as Record<string, unknown>
+  if (typeof v.label !== 'string' || !ATTENDANCE_GROUP_EFFECTIVE_POLICY_SOURCE_LABELS_V1.includes(v.label as never)) {
+    return fail(`${name}.label: unknown enum value`)
+  }
+  if (!isStringArray(v.reasonCodes)) return fail(`${name}.reasonCodes: not a string array`)
+  if (Object.prototype.hasOwnProperty.call(v, 'sourceRefs') && !validateSourceRefs(v.sourceRefs)) {
+    return fail(`${name}.sourceRefs: invalid shape`)
+  }
+  const editorRef = parseAttendanceGroupEffectivePolicyEditorRefV1(v.editorRef)
+  if (!editorRef) return fail(`${name}.editorRef: fails closed-table parse`)
+  return { ok: true }
+}
+
+/**
+ * W6-R2/R6/R7/R8 combined judge. Validates the FULL `{ ok: true, data }`
+ * envelope. Returns the first violation found; callers that need every
+ * violation should fix-and-rerun (matches this repo's other exact-shape
+ * validators).
+ */
+export function validateAttendanceGroupEffectivePolicyResponseV1(
+  candidate: unknown,
+): AttendanceGroupEffectivePolicyValidationResult {
+  if (!hasClosedKeys(candidate, ['ok', 'data'])) return fail('envelope: unexpected key set')
+  const envelope = candidate as Record<string, unknown>
+  if (envelope.ok !== true) return fail('envelope.ok: must be literal true')
+  const data = envelope.data
+  if (
+    !hasClosedKeys(data, [
+      'groupId',
+      'groupType',
+      'timezone',
+      'activeMemberCount',
+      'managerPosture',
+      'calculationPosture',
+      'domains',
+      'conflicts',
+      'evaluatedAt',
+    ])
+  ) {
+    return fail('data: unexpected key set')
+  }
+  const d = data as Record<string, unknown>
+  if (!isNonEmptyString(d.groupId)) return fail('data.groupId: not a non-empty string')
+  if (typeof d.groupType !== 'string' || !GROUP_TYPES.includes(d.groupType as never)) return fail('data.groupType: unknown enum value')
+  if (d.timezone !== null && !isNonEmptyString(d.timezone)) return fail('data.timezone: not string|null')
+  if (!isNonNegativeInt(d.activeMemberCount)) return fail('data.activeMemberCount: not a non-negative int')
+  if (!hasClosedKeys(d.managerPosture, ['ownerCount', 'subOwnerCount'])) return fail('data.managerPosture: unexpected key set')
+  const managerPosture = d.managerPosture as Record<string, unknown>
+  if (!isNonNegativeInt(managerPosture.ownerCount) || !isNonNegativeInt(managerPosture.subOwnerCount)) {
+    return fail('data.managerPosture: counts not a non-negative int')
+  }
+  if (typeof d.calculationPosture !== 'string' || !CALCULATION_POSTURES.includes(d.calculationPosture as never)) {
+    return fail('data.calculationPosture: unknown enum value')
+  }
+  if (
+    !hasClosedKeys(d.domains, [
+      'membership',
+      'schedule',
+      'segments',
+      'flex',
+      'rules',
+      'punchMethod',
+      'requestPosture',
+    ])
+  ) {
+    return fail('data.domains: unexpected key set')
+  }
+  const domains = d.domains as Record<string, unknown>
+
+  const membership = validateDomainSummary('domains.membership', domains.membership, [])
+  if (!membership.ok) return membership
+
+  const schedule = validateDomainSummary('domains.schedule', domains.schedule, ['strategy', 'fixedSchedule'])
+  if (!schedule.ok) return schedule
+  const scheduleValue = domains.schedule as Record<string, unknown>
+  if (typeof scheduleValue.strategy !== 'string' || !GROUP_TYPES.includes(scheduleValue.strategy as never)) {
+    return fail('domains.schedule.strategy: unknown enum value')
+  }
+  const fixedSchedule = validateFixedSchedule(scheduleValue.fixedSchedule)
+  if (!fixedSchedule.ok) return fixedSchedule
+
+  const segments = validateDomainSummary('domains.segments', domains.segments, [])
+  if (!segments.ok) return segments
+
+  const flex = validateDomainSummary('domains.flex', domains.flex, [], ['mode'])
+  if (!flex.ok) return flex
+  const flexValue = domains.flex as Record<string, unknown>
+  if (Object.prototype.hasOwnProperty.call(flexValue, 'mode') && !FLEX_MODES.includes(flexValue.mode as string)) {
+    return fail('domains.flex.mode: unknown enum value')
+  }
+
+  const rules = validateDomainSummary('domains.rules', domains.rules, ['source'])
+  if (!rules.ok) return rules
+  const rulesValue = domains.rules as Record<string, unknown>
+  if (!RULE_SOURCES.includes(rulesValue.source as string)) return fail('domains.rules.source: unknown enum value')
+
+  const punchMethod = validateDomainSummary('domains.punchMethod', domains.punchMethod, ['source'])
+  if (!punchMethod.ok) return punchMethod
+  const punchMethodValue = domains.punchMethod as Record<string, unknown>
+  if (punchMethodValue.source !== 'org_inherited') return fail('domains.punchMethod.source: must be org_inherited')
+
+  const requestPosture = validateDomainSummary('domains.requestPosture', domains.requestPosture, [
+    'overtime',
+    'makeupPunch',
+    'outdoor',
+  ])
+  if (!requestPosture.ok) return requestPosture
+  const requestPostureValue = domains.requestPosture as Record<string, unknown>
+  for (const key of ['overtime', 'makeupPunch', 'outdoor']) {
+    if (requestPostureValue[key] !== 'org_inherited') return fail(`domains.requestPosture.${key}: must be org_inherited`)
+  }
+
+  if (!Array.isArray(d.conflicts)) return fail('data.conflicts: not an array')
+  for (const conflict of d.conflicts) {
+    if (!hasClosedKeys(conflict, ['code', 'domain', 'label', 'editorRef'], ['affectedUserCount'])) {
+      return fail('conflicts[]: unexpected key set')
+    }
+    const c = conflict as Record<string, unknown>
+    if (typeof c.code !== 'string' || !ATTENDANCE_GROUP_EFFECTIVE_POLICY_CONFLICT_CODES_V1.includes(c.code as never)) {
+      return fail('conflicts[].code: unknown enum value')
+    }
+    if (typeof c.domain !== 'string' || !ATTENDANCE_GROUP_EFFECTIVE_POLICY_DOMAINS_V1.includes(c.domain as never)) {
+      return fail('conflicts[].domain: unknown enum value')
+    }
+    if (c.label !== 'conflict_action_required') return fail('conflicts[].label: must be conflict_action_required')
+    if (Object.prototype.hasOwnProperty.call(c, 'affectedUserCount') && !isNonNegativeInt(c.affectedUserCount)) {
+      return fail('conflicts[].affectedUserCount: not a non-negative int')
+    }
+    if (!parseAttendanceGroupEffectivePolicyEditorRefV1(c.editorRef)) return fail('conflicts[].editorRef: fails closed-table parse')
+  }
+
+  if (!isIsoTimestamp(d.evaluatedAt)) return fail('data.evaluatedAt: not an ISO timestamp')
+
+  return { ok: true }
+}
+
+/** Type-guard convenience wrapper. */
+export function isValidAttendanceGroupEffectivePolicyResponseV1(
+  candidate: unknown,
+): candidate is AttendanceGroupEffectivePolicyResponseV1 {
+  return validateAttendanceGroupEffectivePolicyResponseV1(candidate).ok
+}

--- a/packages/core-backend/src/routes/attendance-admin.ts
+++ b/packages/core-backend/src/routes/attendance-admin.ts
@@ -50,8 +50,80 @@ import {
   readAttendanceCalculationDetail,
   readAttendanceW4ShadowBacklog,
 } from '../services/AttendanceW4CalculationDetail'
+import {
+  AttendanceGroupEffectivePolicyServiceError,
+  buildFixedScheduleProducerKey as buildAttendanceGroupEffectivePolicyFixedScheduleProducerKey,
+  createAttendanceGroupEffectivePolicyAggregateService,
+  type AttendanceGroupEffectivePolicyFserServiceLike,
+} from '../attendance/w6-group-effective-policy-aggregate'
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+// W6-1 (#4556): the aggregate composes the EXISTING FSER service — required
+// directly from its canonical `.cjs` module (same pattern the real-DB tests
+// already use: `packages/core-backend/tests/integration/attendance-group-fixed-schedule-effectiveness.db.test.ts`).
+// No second effectiveness derivation (W6-R4) and no plugin-activation side
+// effects: this file only defines pure functions and a factory.
+// eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+const attendanceGroupFixedScheduleEffectivenessServiceLib = require(
+  '../../../../plugins/plugin-attendance/lib/attendance-group-fixed-schedule-effectiveness-service.cjs',
+) as {
+  createAttendanceGroupFixedScheduleEffectivenessService: (deps: {
+    HttpError: new (status: number, code: string, message: string) => Error
+    buildAttendanceGroupFixedScheduleProducerKey: (input: {
+      groupId: string
+      shiftId: string
+      startDate: string
+      endDate: string | null
+    }) => string
+    now?: () => string
+  }) => AttendanceGroupEffectivePolicyFserServiceLike
+}
+// eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+const attendanceShiftServiceLib = require('../../../../plugins/plugin-attendance/lib/attendance-shift-service.cjs') as {
+  SEGMENT_CALCULATION_IMPLEMENTED: boolean
+}
+
+const attendanceGroupEffectivePolicyFserService = attendanceGroupFixedScheduleEffectivenessServiceLib.createAttendanceGroupFixedScheduleEffectivenessService(
+  {
+    HttpError: AttendanceGroupEffectivePolicyServiceError,
+    buildAttendanceGroupFixedScheduleProducerKey: buildAttendanceGroupEffectivePolicyFixedScheduleProducerKey,
+  },
+)
+
+const attendanceGroupEffectivePolicyAggregateService = createAttendanceGroupEffectivePolicyAggregateService({
+  query: async (sql: string, params?: unknown[]) => (await query(sql, params)).rows,
+  fser: attendanceGroupEffectivePolicyFserService,
+  segmentCalculationImplemented: attendanceShiftServiceLib.SEGMENT_CALCULATION_IMPLEMENTED,
+})
+
+/**
+ * W6-1 (#4556) §4.1: org identity for the group effective-policy route comes
+ * ONLY from the authenticated principal — the #4711 §3.2 rules applied
+ * verbatim, mirroring `resolveAttendanceFixedScheduleRouteActorContext` in
+ * `plugins/plugin-attendance/index.cjs` so the SAME JWT authenticates
+ * identically on both the CJS FSER route and this TS route. Never
+ * `req.query.orgId` (that is the different, admin-lookup pattern this route
+ * deliberately does NOT use).
+ */
+function getAuthenticatedAttendanceGroupEffectivePolicyOrgId(req: Request): string | null {
+  const raw = req.user as Record<string, unknown> | undefined
+  const claim = raw?.orgId ?? raw?.workspaceId
+  if (typeof claim === 'string' && claim.trim()) return claim.trim()
+  if (typeof claim === 'number' && Number.isFinite(claim)) return String(claim)
+  const tenant = req.authenticatedTenantId
+  if (typeof tenant === 'string' && tenant.trim()) return tenant.trim()
+  return null
+}
+
+/** True when a client-supplied `x-org-id` header is present and does not
+ * byte-equal the authenticated org — the request must fail BEFORE any
+ * scoped SQL (W6-R3). */
+function attendanceGroupEffectivePolicyOrgSelectorMismatch(req: Request, orgId: string): boolean {
+  const headerValue = req.headers['x-org-id']
+  const header = Array.isArray(headerValue) ? headerValue[0] : headerValue
+  return header !== undefined && String(header) !== orgId
+}
 
 function readStrictString(value: unknown): string | null {
   return typeof value === 'string' ? value.trim() : null
@@ -1582,6 +1654,62 @@ export function attendanceAdminRouter(): Router {
       return jsonError(res, 500, 'CALCULATION_SHADOW_BACKLOG_FAILED', 'Failed to load shadow backlog')
     }
   })
+
+  // W6-1 (#4556): group effective-policy READ aggregate. GET-only (W6-R1);
+  // permission `attendance:admin` (aligned with the FSER v1 read route per
+  // design-lock §4.1); org identity from the authenticated principal only,
+  // with a delegated-admin active-org-membership gate on top (W6-R3, parent
+  // lock §3.5 final paragraph — full/platform admins bypass this SECOND
+  // gate via `canReadAttendanceDirectoryReadiness`'s own bypass, but never
+  // bypass org-identity derivation itself); composes the EXISTING FSER
+  // service (W6-R4); accepts no query params and no request body (W6-R7).
+  r.get(
+    '/api/attendance/groups/:groupId/effective-policy',
+    rbacGuard('attendance', 'admin'),
+    async (req: Request, res: Response) => {
+      try {
+        // R7: the route accepts no body and no state-selecting query
+        // parameter. Presence alone is rejected before any SQL — this also
+        // covers a `?orgId=` "query-org" spoofing attempt, since there is no
+        // legitimate query parameter on this route at all.
+        if (Object.keys(req.query).length > 0) {
+          return jsonError(res, 400, 'QUERY_NOT_ACCEPTED', 'This endpoint accepts no query parameters')
+        }
+        if (req.body && typeof req.body === 'object' && Object.keys(req.body as Record<string, unknown>).length > 0) {
+          return jsonError(res, 400, 'BODY_NOT_ACCEPTED', 'This endpoint accepts no request body')
+        }
+
+        const userId = getAttendanceAdminRequestUserId(req)
+        if (!userId) return jsonError(res, 401, 'UNAUTHENTICATED', 'Authentication required')
+
+        const orgId = getAuthenticatedAttendanceGroupEffectivePolicyOrgId(req)
+        if (!orgId) return jsonError(res, 403, 'FORBIDDEN', 'Authenticated organization not found')
+        if (attendanceGroupEffectivePolicyOrgSelectorMismatch(req, orgId)) {
+          return jsonError(res, 403, 'FORBIDDEN', 'Insufficient permissions')
+        }
+
+        const allowed = await canReadAttendanceDirectoryReadiness(req, userId, orgId)
+        if (!allowed) return jsonError(res, 403, 'FORBIDDEN', 'Org membership required for effective-policy')
+
+        const groupId = String(req.params.groupId || '').trim()
+        if (!UUID_RE.test(groupId)) {
+          return jsonError(res, 400, 'GROUP_ID_INVALID', 'groupId must be a UUID')
+        }
+
+        const aggregate = await attendanceGroupEffectivePolicyAggregateService.getAggregate({ orgId, groupId })
+        return jsonOk(res, aggregate)
+      } catch (error) {
+        if (error instanceof AttendanceGroupEffectivePolicyServiceError) {
+          return jsonError(res, error.status, error.code, error.message)
+        }
+        if (isDatabaseSchemaError(error)) {
+          return jsonError(res, 503, 'DB_NOT_READY', 'Attendance group tables missing')
+        }
+        // Values-free seam: never leak raw DB / driver messages to the client.
+        return jsonError(res, 500, 'EFFECTIVE_POLICY_FAILED', 'Failed to load group effective policy')
+      }
+    },
+  )
 
   return r
 }

--- a/packages/core-backend/src/routes/attendance-admin.ts
+++ b/packages/core-backend/src/routes/attendance-admin.ts
@@ -56,6 +56,7 @@ import {
   createAttendanceGroupEffectivePolicyAggregateService,
   type AttendanceGroupEffectivePolicyFserServiceLike,
 } from '../attendance/w6-group-effective-policy-aggregate'
+import { requirePluginAttendanceLib } from '../util/resolve-plugin-attendance-lib'
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
@@ -64,10 +65,14 @@ const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
 // already use: `packages/core-backend/tests/integration/attendance-group-fixed-schedule-effectiveness.db.test.ts`).
 // No second effectiveness derivation (W6-R4) and no plugin-activation side
 // effects: this file only defines pure functions and a factory.
-// eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
-const attendanceGroupFixedScheduleEffectivenessServiceLib = require(
-  '../../../../plugins/plugin-attendance/lib/attendance-group-fixed-schedule-effectiveness-service.cjs',
-) as {
+//
+// Resolved via `requirePluginAttendanceLib(__dirname, …)` rather than a
+// literal relative path: `tsconfig.json`'s `rootDir: "."` makes the compiled
+// output land at `dist/src/routes/`, one level deeper than `src/routes/`, so
+// a hard-coded `../../../../` is only correct for one of the two layouts
+// this file actually runs from (#4814 P1 — see
+// `../util/resolve-plugin-attendance-lib` for the full account).
+const attendanceGroupFixedScheduleEffectivenessServiceLib = requirePluginAttendanceLib<{
   createAttendanceGroupFixedScheduleEffectivenessService: (deps: {
     HttpError: new (status: number, code: string, message: string) => Error
     buildAttendanceGroupFixedScheduleProducerKey: (input: {
@@ -78,11 +83,10 @@ const attendanceGroupFixedScheduleEffectivenessServiceLib = require(
     }) => string
     now?: () => string
   }) => AttendanceGroupEffectivePolicyFserServiceLike
-}
-// eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
-const attendanceShiftServiceLib = require('../../../../plugins/plugin-attendance/lib/attendance-shift-service.cjs') as {
+}>(__dirname, 'attendance-group-fixed-schedule-effectiveness-service.cjs')
+const attendanceShiftServiceLib = requirePluginAttendanceLib<{
   SEGMENT_CALCULATION_IMPLEMENTED: boolean
-}
+}>(__dirname, 'attendance-shift-service.cjs')
 
 const attendanceGroupEffectivePolicyFserService = attendanceGroupFixedScheduleEffectivenessServiceLib.createAttendanceGroupFixedScheduleEffectivenessService(
   {

--- a/packages/core-backend/src/util/resolve-plugin-attendance-lib.ts
+++ b/packages/core-backend/src/util/resolve-plugin-attendance-lib.ts
@@ -1,0 +1,49 @@
+import * as fs from 'fs'
+import * as path from 'path'
+
+/**
+ * `packages/core-backend`'s compiled output lands ONE DIRECTORY DEEPER than
+ * its source tree: `tsconfig.json` sets `"rootDir": "."` (not `"src"`), so
+ * `tsc` emits to `dist/src/...`, not `dist/...`. A literal `../../../../`
+ * computed from `src/routes/` is therefore correct from the src tree and
+ * WRONG once the same file runs compiled from `dist/src/routes/` — it lands
+ * one level short of the repo root (`/app/packages/plugins/...` instead of
+ * `/app/plugins/...`) and throws `MODULE_NOT_FOUND` at module-init time,
+ * which crash-loops the whole backend on first boot after deploy (#4814 P1;
+ * `src/index.ts` imports the router that does this require statically, at
+ * module scope, so there is no route-level catch that can save it).
+ *
+ * This walks upward from the caller's `__dirname` looking for the first
+ * ancestor that actually contains `plugins/plugin-attendance/lib/`, so the
+ * SAME source resolves correctly from both the src tree (local dev, vitest)
+ * and the dist tree (production) without hard-coding a depth. It fails
+ * loudly — a named `Error`, not a silent fallback — if no ancestor within
+ * the search bound has the directory, rather than letting a bare
+ * `MODULE_NOT_FOUND` from an arbitrary guessed path stand in for it.
+ */
+export function resolvePluginAttendanceLibPath(startDir: string, relativeLibPath: string): string {
+  const MAX_ANCESTOR_LEVELS = 12
+  let dir = path.resolve(startDir)
+  for (let level = 0; level <= MAX_ANCESTOR_LEVELS; level += 1) {
+    const candidate = path.join(dir, 'plugins', 'plugin-attendance', 'lib', relativeLibPath)
+    if (fs.existsSync(candidate)) return candidate
+    const parent = path.dirname(dir)
+    if (parent === dir) break
+    dir = parent
+  }
+  throw new Error(
+    `resolvePluginAttendanceLibPath: cannot locate plugins/plugin-attendance/lib/${relativeLibPath} ` +
+      `by walking up from ${startDir} (searched ${MAX_ANCESTOR_LEVELS + 1} ancestor levels)`,
+  )
+}
+
+/**
+ * `require()`s a module inside `plugins/plugin-attendance/lib/`, resolved
+ * depth-tolerantly from the caller's `__dirname`. See
+ * {@link resolvePluginAttendanceLibPath} for why a hard-coded relative depth
+ * is unsafe here.
+ */
+export function requirePluginAttendanceLib<T>(startDir: string, relativeLibPath: string): T {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+  return require(resolvePluginAttendanceLibPath(startDir, relativeLibPath)) as T
+}

--- a/packages/core-backend/tests/integration/attendance-w6-group-effective-policy-membership-overlap.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-w6-group-effective-policy-membership-overlap.db.test.ts
@@ -49,9 +49,20 @@ describeIfDatabase('W6-1 group effective-policy — membership-overlap counter (
   const orgId = 'org-overlap'
   const groupId = randomUUID()
   const otherGroupId = randomUUID()
+  // #4814 P2-4: `otherGroupId` was seeded with the SAME two overlapping
+  // members as `groupId`, so per-group and per-org scoping produce
+  // IDENTICAL counts for it — the two hypotheses are indistinguishable, so
+  // asserting against `otherGroupId` alone proves nothing about
+  // boundedness (confirmed: neutering `AND m.group_id = $2` to `OR TRUE`
+  // left every existing assertion in this file green). `boundedGroupId`
+  // holds a member whose overlap set DIFFERS from groupId/otherGroupId's
+  // (zero org-wide overlap for them at all), so per-group vs per-org
+  // scoping diverge and the assertion actually discriminates.
+  const boundedGroupId = randomUUID()
   const overlapUserA = 'user-overlap-a'
   const overlapUserB = 'user-overlap-b'
   const cleanUser = 'user-clean'
+  const boundedGroupSoloUser = 'user-bounded-group-solo'
 
   beforeAll(async () => {
     await adminPool.query(`CREATE DATABASE ${databaseName}`)
@@ -76,7 +87,10 @@ describeIfDatabase('W6-1 group effective-policy — membership-overlap counter (
           )
       );
     `)
-    await pool.query('INSERT INTO attendance_groups (id, org_id) VALUES ($1, $2), ($3, $2)', [groupId, orgId, otherGroupId])
+    await pool.query(
+      'INSERT INTO attendance_groups (id, org_id) VALUES ($1, $4), ($2, $4), ($3, $4)',
+      [groupId, otherGroupId, boundedGroupId, orgId],
+    )
 
     // The constraint is airtight by design (confirmed under a concurrent
     // race in attendance-legacy-membership-overlap-audit.db.test.ts) — the
@@ -99,6 +113,18 @@ describeIfDatabase('W6-1 group effective-policy — membership-overlap counter (
       `INSERT INTO attendance_calculation_group_memberships (org_id, user_id, group_id, effective_from, effective_to)
        VALUES ($1, $2, $3, $4, NULL)`,
       [orgId, cleanUser, groupId, today],
+    )
+    // boundedGroupSoloUser: exactly ONE effective-today row, TOTAL, in
+    // `boundedGroupId` only — zero org-wide overlap and a member set
+    // entirely disjoint from overlapUserA/B. A per-group query must
+    // report 0 for boundedGroupId; a per-org (or group-filter-dropped)
+    // query would instead return 2 (overlapUserA + overlapUserB, who
+    // qualify org-wide regardless of which group is asked about) — the
+    // divergence P2-4 needs to actually discriminate the two.
+    await pool.query(
+      `INSERT INTO attendance_calculation_group_memberships (org_id, user_id, group_id, effective_from, effective_to)
+       VALUES ($1, $2, $3, $4, NULL)`,
+      [orgId, boundedGroupSoloUser, boundedGroupId, today],
     )
   })
 
@@ -125,16 +151,38 @@ describeIfDatabase('W6-1 group effective-policy — membership-overlap counter (
     expect(count).toBe(2) // overlapUserA + overlapUserB; cleanUser excluded
   })
 
-  it('a different, non-overlapping group in the same org reports 0', async () => {
+  it('a second group sharing the SAME two org-wide-overlapping members ALSO reports 2 (sanity/consistency check — NOT a per-group-boundedness proof, see the next test for that)', async () => {
     // otherGroupId's own members (A and B) also have exactly 2 rows each
-    // org-wide, so it reports 2 as well — reusing it as its own group
-    // confirms the query is bounded per-group, not per-org.
+    // org-wide, so it reports 2 as well. This is a consistency check that
+    // the query genuinely re-evaluates for a different $2 groupId value
+    // (not, say, an accidentally-cached first result) -- it does NOT by
+    // itself distinguish per-group scoping from per-org scoping, because
+    // both groups here have an IDENTICAL overlap set and so produce the
+    // same count either way (#4814 P2-4). Boundedness is proven by the
+    // next test, which uses a group with a DIFFERENT overlap set.
     const service = createAttendanceGroupEffectivePolicyAggregateService({
       query: db().query,
       fser: { getEffectiveness: async () => { throw new Error('not used') } },
     })
     const count = await service.countMembershipOverlap(orgId, otherGroupId)
     expect(count).toBe(2)
+  })
+
+  it('OD-W6-8(a): a group whose member has zero org-wide overlap reports 0 even though OTHER users in the same org DO overlap — proves the query is genuinely bounded per-group, not per-org', async () => {
+    // boundedGroupId's only member (boundedGroupSoloUser) holds exactly one
+    // effective-today membership, total -- no overlap. overlapUserA/B DO
+    // have org-wide overlap, but neither is a member of boundedGroupId. A
+    // per-group query must therefore report 0; a per-org (or
+    // group-filter-dropped) query would instead report 2, since
+    // overlapUserA/B qualify org-wide regardless of which group is asked
+    // about. This is the case the previous test's identical-overlap-set
+    // fixture could not discriminate.
+    const service = createAttendanceGroupEffectivePolicyAggregateService({
+      query: db().query,
+      fser: { getEffectiveness: async () => { throw new Error('not used') } },
+    })
+    const count = await service.countMembershipOverlap(orgId, boundedGroupId)
+    expect(count).toBe(0)
   })
 
   // W6-R5's "a choose-first/choose-latest mutation must fail" negative proof

--- a/packages/core-backend/tests/integration/attendance-w6-group-effective-policy-membership-overlap.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-w6-group-effective-policy-membership-overlap.db.test.ts
@@ -1,0 +1,147 @@
+/**
+ * W6-1 (#4556) — group effective-policy aggregate: membership-overlap
+ * counter (W6-R5, OD-W6-8(a)), real PostgreSQL, DEDICATED EPHEMERAL
+ * DATABASE (not the shared `metasheet_test`).
+ *
+ * Why a dedicated database rather than the shared harness (the pattern of
+ * `attendance-legacy-membership-overlap-audit.db.test.ts`): proving
+ * `countMembershipOverlap` counts correctly requires SEEDING a genuine
+ * overlap — two effective-today `attendance_calculation_group_memberships`
+ * rows for one user. The table's own `attendance_calc_group_memberships_no_overlap`
+ * EXCLUDE constraint makes that impossible via ordinary INSERT (confirmed:
+ * the constraint holds even under a concurrent-INSERT race in the legacy
+ * audit test). Parent lock §3.4 explicitly anticipates this must be provable
+ * anyway — "Runtime repeats the uniqueness check rather than trusting clean
+ * writes" — so this suite temporarily drops the constraint to seed the
+ * scenario the runtime check exists to catch. Doing that against the SHARED
+ * `metasheet_test` database would be cross-test pollution; a dedicated,
+ * disposable database (created in `beforeAll`, dropped in `afterAll`) makes
+ * it invisible to every other test file.
+ *
+ * On real, constraint-intact production/staging data this counter always
+ * returns 0 — that is the constraint doing its job, not evidence the check
+ * is unreachable. It is a defense-in-depth read matching §3.4's own
+ * "repeats the uniqueness check" mandate, surfaced to admins as
+ * `CALCULATION_GROUP_MEMBERSHIP_OVERLAP` if the invariant is ever violated
+ * (a stale row predating the constraint, a manual DB edit, a future bug).
+ *
+ * Governing document:
+ *   docs/development/attendance-issue-4556-w6-group-effective-policy-design-lock-20260805.md
+ */
+import { randomUUID } from 'node:crypto'
+import { Pool } from 'pg'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+import { createAttendanceGroupEffectivePolicyAggregateService } from '../../src/attendance/w6-group-effective-policy-aggregate'
+
+const serverUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
+const describeIfDatabase = serverUrl ? describe : describe.skip
+
+describeIfDatabase('W6-1 group effective-policy — membership-overlap counter (dedicated ephemeral DB)', () => {
+  const databaseName = `attendance_w6agg_overlap_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`
+  const adminUrl = new URL(serverUrl || 'postgresql://postgres@localhost/postgres')
+  adminUrl.pathname = '/postgres'
+  const scratchUrl = new URL(adminUrl)
+  scratchUrl.pathname = `/${databaseName}`
+  const adminPool = new Pool({ connectionString: adminUrl.toString() })
+  let pool: Pool
+
+  const orgId = 'org-overlap'
+  const groupId = randomUUID()
+  const otherGroupId = randomUUID()
+  const overlapUserA = 'user-overlap-a'
+  const overlapUserB = 'user-overlap-b'
+  const cleanUser = 'user-clean'
+
+  beforeAll(async () => {
+    await adminPool.query(`CREATE DATABASE ${databaseName}`)
+    pool = new Pool({ connectionString: scratchUrl.toString(), max: 4 })
+
+    await pool.query('CREATE EXTENSION IF NOT EXISTS pgcrypto')
+    await pool.query('CREATE EXTENSION IF NOT EXISTS btree_gist')
+    await pool.query(`
+      CREATE TABLE attendance_groups (id uuid PRIMARY KEY, org_id text NOT NULL);
+      CREATE TABLE attendance_calculation_group_memberships (
+        id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+        org_id text NOT NULL,
+        user_id text NOT NULL,
+        group_id uuid NOT NULL,
+        effective_from date NOT NULL,
+        effective_to date,
+        CONSTRAINT attendance_calc_group_memberships_no_overlap
+          EXCLUDE USING gist (
+            org_id WITH =,
+            user_id WITH =,
+            daterange(effective_from, COALESCE(effective_to, 'infinity'::date), '[]') WITH &&
+          )
+      );
+    `)
+    await pool.query('INSERT INTO attendance_groups (id, org_id) VALUES ($1, $2), ($3, $2)', [groupId, orgId, otherGroupId])
+
+    // The constraint is airtight by design (confirmed under a concurrent
+    // race in attendance-legacy-membership-overlap-audit.db.test.ts) — the
+    // ONLY way to seed the scenario §3.4's redundant runtime check exists
+    // for is to temporarily lift it, in this disposable database only.
+    await pool.query('ALTER TABLE attendance_calculation_group_memberships DROP CONSTRAINT attendance_calc_group_memberships_no_overlap')
+
+    const today = new Date().toISOString().slice(0, 10)
+    // overlapUserA and overlapUserB: each has TWO effective-today rows —
+    // one in `groupId` (the group under test), one in `otherGroupId`.
+    await pool.query(
+      `INSERT INTO attendance_calculation_group_memberships (org_id, user_id, group_id, effective_from, effective_to)
+       VALUES ($1, $2, $3, $5, NULL), ($1, $2, $4, $5, NULL),
+              ($1, $6, $3, $5, NULL), ($1, $6, $4, $5, NULL)`,
+      [orgId, overlapUserA, groupId, otherGroupId, today, overlapUserB],
+    )
+    // cleanUser: exactly ONE effective-today row, in `groupId` only — must
+    // NOT be counted.
+    await pool.query(
+      `INSERT INTO attendance_calculation_group_memberships (org_id, user_id, group_id, effective_from, effective_to)
+       VALUES ($1, $2, $3, $4, NULL)`,
+      [orgId, cleanUser, groupId, today],
+    )
+  })
+
+  afterAll(async () => {
+    await pool?.end()
+    await adminPool.query(
+      `SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = $1 AND pid <> pg_backend_pid()`,
+      [databaseName],
+    )
+    await adminPool.query(`DROP DATABASE IF EXISTS ${databaseName}`)
+    await adminPool.end()
+  })
+
+  function db() {
+    return { async query(sql: string, params?: unknown[]) { return (await pool.query(sql, params)).rows } }
+  }
+
+  it('counts exactly the users who are effective-today in THIS group AND hold more than one effective-today membership org-wide (never a member list)', async () => {
+    const service = createAttendanceGroupEffectivePolicyAggregateService({
+      query: db().query,
+      fser: { getEffectiveness: async () => { throw new Error('not used') } },
+    })
+    const count = await service.countMembershipOverlap(orgId, groupId)
+    expect(count).toBe(2) // overlapUserA + overlapUserB; cleanUser excluded
+  })
+
+  it('a different, non-overlapping group in the same org reports 0', async () => {
+    // otherGroupId's own members (A and B) also have exactly 2 rows each
+    // org-wide, so it reports 2 as well — reusing it as its own group
+    // confirms the query is bounded per-group, not per-org.
+    const service = createAttendanceGroupEffectivePolicyAggregateService({
+      query: db().query,
+      fser: { getEffectiveness: async () => { throw new Error('not used') } },
+    })
+    const count = await service.countMembershipOverlap(orgId, otherGroupId)
+    expect(count).toBe(2)
+  })
+
+  // W6-R5's "a choose-first/choose-latest mutation must fail" negative proof
+  // is run manually against the SHIPPED `countMembershipOverlap` SQL in
+  // `w6-group-effective-policy-aggregate.ts` (edit → rerun the first test in
+  // this file → confirm it reds → restore via file backup), not simulated
+  // here. A hand-rolled string-replace against a copy of the query would
+  // only prove the copy is mutable, not that the real module's behavior
+  // changes — see the W6-1 PR body/report for the transcript.
+})

--- a/packages/core-backend/tests/integration/attendance-w6-group-effective-policy.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-w6-group-effective-policy.db.test.ts
@@ -283,20 +283,30 @@ describeIfDatabase('W6-1 group effective-policy aggregate route (real PostgreSQL
       'users',
     ]
 
-    async function countRows(): Promise<number[]> {
+    // #4814 P2-3: a bare row-COUNT is structurally blind to an in-place
+    // UPDATE (row count is unchanged by definition). Every Postgres UPDATE
+    // — even one that writes back the same values — creates a NEW row
+    // version with a fresh `xmin` (the transaction-id system column), so
+    // `MAX(xmin)` per table changes even when the row count does not. This
+    // snapshot therefore catches the row-count-preserving mutation R1
+    // explicitly names as forbidden (a `last_*`/`updated_at` column touch)
+    // in addition to the INSERT/DELETE row-count leg it had before.
+    async function snapshotTables(): Promise<Array<{ table: string; count: number; maxXmin: string }>> {
       return Promise.all(
         TOUCHED_TABLES.map(async (table) => {
-          const result = await pool.query(`SELECT count(*)::int AS total FROM ${table}`)
-          return result.rows[0].total
+          const result = await pool.query(
+            `SELECT count(*)::int AS total, COALESCE(MAX(xmin::text::bigint), -1) AS max_xmin FROM ${table}`,
+          )
+          return { table, count: result.rows[0].total, maxXmin: String(result.rows[0].max_xmin) }
         }),
       )
     }
 
-    it('row counts across every touched table are unchanged after a full route round-trip', async () => {
-      const before = await countRows()
+    it('row counts AND row versions (xmin) across every touched table are unchanged after a full route round-trip', async () => {
+      const before = await snapshotTables()
       const res = await request(adminApp()).get(`/api/attendance/groups/${groupAId}/effective-policy`)
       expect(res.status).toBe(200)
-      const after = await countRows()
+      const after = await snapshotTables()
       expect(after).toEqual(before)
     })
   })

--- a/packages/core-backend/tests/integration/attendance-w6-group-effective-policy.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-w6-group-effective-policy.db.test.ts
@@ -1,0 +1,417 @@
+/**
+ * W6-1 (#4556) — group effective-policy aggregate: real-DB integration
+ * suite (shared `metasheet_test`/`DATABASE_URL` database, w4c4 harness
+ * style — file-namespaced fixture IDs, no isolated schema/database).
+ *
+ * Governing document:
+ *   docs/development/attendance-issue-4556-w6-group-effective-policy-design-lock-20260805.md
+ *
+ * Covers, against the ACTUAL Express route + real Postgres:
+ *  - happy-path exact-key response shapes (fixed_shift effective,
+ *    scheduled_shift needs_configuration);
+ *  - W6-R1: row counts across every touched table are byte-identical
+ *    before/after a full route round-trip;
+ *  - W6-R3: cross-org probe, delegated-non-member probe, spoofed
+ *    x-org-id probe, platform-admin bypass, missing-org 403, invalid
+ *    groupId 400, unknown-group 404 (all before/instead-of scoped SQL);
+ *  - W6-R4: the embedded `fixedSchedule` object is byte-identical to a
+ *    direct call to the SAME canonical FSER service on the same seeded
+ *    data (fidelity proof — one derivation, not a parallel one).
+ *
+ * The membership-overlap counter (W6-R5) is proved in its OWN dedicated
+ * ephemeral-database suite
+ * (`attendance-w6-group-effective-policy-membership-overlap.db.test.ts`)
+ * because seeding a genuine overlap requires temporarily dropping
+ * `attendance_calc_group_memberships_no_overlap`, which must never touch
+ * the shared `metasheet_test` database other test files run against.
+ *
+ * R3 mutation-red evidence (guard-removal) was run manually against this
+ * suite and reverted via file backup — NOT part of the committed file;
+ * see the W6-1 PR body / report for the transcript.
+ */
+import { randomUUID } from 'node:crypto'
+import express from 'express'
+import { Pool } from 'pg'
+import request from 'supertest'
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
+
+const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
+if (dbUrl) process.env.DATABASE_URL = dbUrl
+const describeIfDatabase = dbUrl ? describe : describe.skip
+
+vi.mock('../../src/rbac/rbac', () => ({
+  rbacGuard: (resource: string, action: string) => (
+    req: express.Request,
+    res: express.Response,
+    next: express.NextFunction,
+  ) => {
+    const permission = `${resource}:${action}`
+    const user = req.user as { role?: string; permissions?: string[] } | undefined
+    if (user?.role === 'admin' || user?.permissions?.includes(permission)) return next()
+    return res.status(403).json({ error: 'Insufficient permissions' })
+  },
+}))
+
+vi.mock('../../src/rbac/service', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/rbac/service')>()
+  return {
+    ...actual,
+    isAdmin: vi.fn(async () => false),
+    listUserPermissions: vi.fn(async () => []),
+  }
+})
+
+vi.mock('../../src/routes/admin-users', () => ({ ensurePlatformAdmin: vi.fn(async () => null) }))
+vi.mock('../../src/services/AttendanceScheduler', () => ({ getSharedAttendanceScheduler: vi.fn(() => null) }))
+vi.mock('../../src/services/AttendanceNotificationRedelivery', () => ({ redeliverFailedAttendanceNotification: vi.fn() }))
+vi.mock('../../src/services/ApprovalDirectoryOrg', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/services/ApprovalDirectoryOrg')>()
+  return { ...actual, MAX_MANAGER_CHAIN_LEVELS: 10 }
+})
+
+const { attendanceAdminRouter } = await import('../../src/routes/attendance-admin')
+
+describeIfDatabase('W6-1 group effective-policy aggregate route (real PostgreSQL)', () => {
+  const pool = new Pool({ connectionString: dbUrl })
+  const runstamp = randomUUID().slice(0, 8)
+  const orgA = `w6agg-a-${runstamp}`
+  const orgB = `w6agg-b-${runstamp}`
+  const adminUser = randomUUID()
+  const memberUser = randomUUID()
+  const outsiderUser = randomUUID()
+  const nonMemberAdminUser = randomUUID()
+  const platformAdminUser = randomUUID()
+  const noOrgUser = randomUUID()
+  const seededUserIds = [adminUser, memberUser, outsiderUser, nonMemberAdminUser, platformAdminUser, noOrgUser]
+
+  const groupAId = randomUUID()
+  const groupBId = randomUUID()
+  const shiftId = randomUUID()
+  const ruleSetId = randomUUID()
+
+  function makeApp(user: { id: string; permissions: string[]; role?: string; orgId?: string }): express.Express {
+    const app = express()
+    app.use(express.json())
+    app.use((req, _res, next) => {
+      ;(req as express.Request & { user?: unknown }).user = {
+        id: user.id,
+        permissions: user.permissions,
+        role: user.role,
+        ...(user.orgId !== undefined ? { orgId: user.orgId } : {}),
+      }
+      next()
+    })
+    app.use(attendanceAdminRouter())
+    return app
+  }
+
+  async function seedUser(userId: string): Promise<void> {
+    await pool.query(
+      `INSERT INTO users
+       (id, email, username, name, password_hash, role, permissions, is_active, is_admin, activation_status, created_at, updated_at)
+       VALUES ($1, $2, $1, 'W6-1 fixture', 'x', 'user', '[]'::jsonb,
+               true, false, 'activated', now(), now())`,
+      [userId, `w6agg-${userId}@example.test`],
+    )
+  }
+
+  async function seedMembership(userId: string, orgId: string, isActive = true): Promise<void> {
+    await pool.query('INSERT INTO user_orgs (user_id, org_id, is_active) VALUES ($1, $2, $3)', [userId, orgId, isActive])
+  }
+
+  beforeAll(async () => {
+    for (const userId of seededUserIds) await seedUser(userId)
+    await seedMembership(adminUser, orgA)
+    await seedMembership(memberUser, orgA)
+    await seedMembership(outsiderUser, orgB)
+    // nonMemberAdminUser: holds attendance:admin permission but NO active
+    // org_A membership row at all (delegated-non-member probe).
+    // platformAdminUser: global admin, ALSO no org_A membership row —
+    // proves the bypass.
+    // noOrgUser: no user_orgs row anywhere, no orgId claim either.
+
+    await pool.query(`INSERT INTO attendance_groups (id, org_id, name, timezone, attendance_type, rule_set_id) VALUES ($1, $2, 'W6 Group A', 'Asia/Shanghai', 'fixed_shift', $3)`, [
+      groupAId,
+      orgA,
+      ruleSetId,
+    ])
+    await pool.query(`INSERT INTO attendance_groups (id, org_id, name, timezone, attendance_type) VALUES ($1, $2, 'W6 Group B', 'UTC', 'scheduled_shift')`, [groupBId, orgB])
+
+    await pool.query('INSERT INTO attendance_group_members (org_id, group_id, user_id) VALUES ($1, $2, $3), ($1, $2, $4)', [
+      orgA,
+      groupAId,
+      memberUser,
+      adminUser,
+    ])
+    await pool.query('INSERT INTO attendance_group_managers (org_id, group_id, user_id, role) VALUES ($1, $2, $3, $4)', [
+      orgA,
+      groupAId,
+      adminUser,
+      'owner',
+    ])
+    await pool.query('INSERT INTO attendance_rule_sets (id, org_id, name, is_default) VALUES ($1, $2, $3, true)', [
+      ruleSetId,
+      orgA,
+      `w6agg-rule-set-${runstamp}`,
+    ])
+
+    await pool.query(
+      `INSERT INTO attendance_shifts (id, org_id, name, timezone, flex_mode) VALUES ($1, $2, 'W6 Shift', 'Asia/Shanghai', 'strict')`,
+      [shiftId, orgA],
+    )
+    await pool.query(
+      `INSERT INTO attendance_shift_segments (org_id, shift_id, segment_index, start_time, end_time) VALUES ($1, $2, 0, '09:00', '18:00')`,
+      [orgA, shiftId],
+    )
+    await pool.query(
+      `INSERT INTO attendance_group_fixed_schedule_configs (org_id, group_id, shift_id, start_date, end_date, revision, updated_by)
+       VALUES ($1, $2, $3, '2026-08-01', '2026-08-31', 1, $4)`,
+      [orgA, groupAId, shiftId, adminUser],
+    )
+    // FSER's effectiveness derivation requires a PUBLISHED, matching
+    // attendance_shift_assignments row per target member for `effective` —
+    // without these the desired config exists but nothing matches it
+    // (state `pending_apply`, not `effective`).
+    const producerKey = ['attendance_group_fixed_schedule', groupAId, shiftId, '2026-08-01', '2026-08-31'].join(':')
+    const producerRunId = randomUUID()
+    for (const userId of [memberUser, adminUser]) {
+      await pool.query(
+        `INSERT INTO attendance_shift_assignments
+           (id, org_id, user_id, shift_id, start_date, end_date, is_active, publish_status, producer_type, producer_ref_id, producer_key, producer_run_id)
+         VALUES ($1, $2, $3, $4, '2026-08-01', '2026-08-31', true, 'published', 'attendance_group_fixed_schedule', $5, $6, $7)`,
+        [randomUUID(), orgA, userId, shiftId, groupAId, producerKey, producerRunId],
+      )
+    }
+  })
+
+  afterAll(async () => {
+    await pool.query('DELETE FROM attendance_shift_assignments WHERE org_id = ANY($1::text[])', [[orgA, orgB]])
+    await pool.query('DELETE FROM attendance_group_fixed_schedule_configs WHERE org_id = ANY($1::text[])', [[orgA, orgB]])
+    await pool.query('DELETE FROM attendance_group_managers WHERE org_id = ANY($1::text[])', [[orgA, orgB]])
+    await pool.query('DELETE FROM attendance_group_members WHERE org_id = ANY($1::text[])', [[orgA, orgB]])
+    await pool.query('DELETE FROM attendance_groups WHERE org_id = ANY($1::text[])', [[orgA, orgB]])
+    await pool.query('DELETE FROM attendance_shifts WHERE org_id = ANY($1::text[])', [[orgA, orgB]])
+    await pool.query('DELETE FROM attendance_rule_sets WHERE org_id = ANY($1::text[])', [[orgA, orgB]])
+    await pool.query('DELETE FROM user_orgs WHERE user_id = ANY($1::text[])', [seededUserIds])
+    await pool.query('DELETE FROM users WHERE id = ANY($1::text[])', [seededUserIds])
+    await pool.end()
+  })
+
+  function adminApp() {
+    return makeApp({ id: adminUser, permissions: ['attendance:admin'], orgId: orgA })
+  }
+
+  describe('happy path', () => {
+    it('returns the exact-key aggregate for the fixed_shift group, values-free', async () => {
+      const res = await request(adminApp()).get(`/api/attendance/groups/${groupAId}/effective-policy`)
+      expect(res.status).toBe(200)
+      expect(res.body.ok).toBe(true)
+      const data = res.body.data
+      expect(Object.keys(data).sort()).toEqual(
+        ['groupId', 'groupType', 'timezone', 'activeMemberCount', 'managerPosture', 'calculationPosture', 'domains', 'conflicts', 'evaluatedAt'].sort(),
+      )
+      expect(data.groupId).toBe(groupAId)
+      expect(data.groupType).toBe('fixed_shift')
+      expect(data.timezone).toBe('Asia/Shanghai')
+      expect(data.activeMemberCount).toBe(2)
+      expect(data.managerPosture).toEqual({ ownerCount: 1, subOwnerCount: 0 })
+      expect(data.calculationPosture).toBe('legacy')
+      expect(data.domains.membership.label).toBe('effective')
+      expect(data.domains.schedule.label).toBe('effective')
+      expect(data.domains.schedule.fixedSchedule.state).toBe('effective')
+      expect(data.domains.segments.label).toBe('effective')
+      expect(data.domains.flex).toEqual({
+        label: 'effective',
+        mode: 'strict',
+        reasonCodes: [],
+        editorRef: { kind: 'group_context_route', step: 'schedule', surface: 'shifts' },
+      })
+      expect(data.domains.rules).toEqual({
+        label: 'effective',
+        source: 'group_rule_set',
+        sourceRefs: [{ kind: 'rule_set', id: ruleSetId }],
+        reasonCodes: [],
+        editorRef: { kind: 'group_context_route', step: 'rules', surface: 'rule-sets' },
+      })
+      expect(data.conflicts).toEqual([])
+
+      // W6-R2: no member list, no raw user id anywhere in the payload.
+      const raw = JSON.stringify(res.body)
+      expect(raw).not.toContain(memberUser)
+      expect(raw).not.toContain(adminUser)
+      expect(raw).not.toContain('memberIds')
+      expect(raw).not.toContain('userId')
+    })
+
+    it('returns needs_configuration for the unconfigured scheduled_shift group (as its own admin)', async () => {
+      const app = makeApp({ id: outsiderUser, permissions: ['attendance:admin'], orgId: orgB })
+      const res = await request(app).get(`/api/attendance/groups/${groupBId}/effective-policy`)
+      expect(res.status).toBe(200)
+      const data = res.body.data
+      expect(data.groupType).toBe('scheduled_shift')
+      expect(data.domains.schedule.label).toBe('needs_configuration')
+      expect(data.domains.schedule.reasonCodes).toEqual(['SCHEDULE_STRATEGY_INCOMPLETE'])
+      expect(data.conflicts).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ code: 'SCHEDULE_STRATEGY_INCOMPLETE', domain: 'schedule' }),
+        ]),
+      )
+    })
+  })
+
+  describe('W6-R1: GET-only, zero writes (behavioral)', () => {
+    const TOUCHED_TABLES = [
+      'attendance_groups',
+      'attendance_group_members',
+      'attendance_group_managers',
+      'attendance_rule_sets',
+      'attendance_shifts',
+      'attendance_shift_segments',
+      'attendance_group_fixed_schedule_configs',
+      'attendance_shift_assignments',
+      'attendance_calculation_group_memberships',
+      'attendance_calculation_rollout_state',
+      'user_orgs',
+      'users',
+    ]
+
+    async function countRows(): Promise<number[]> {
+      return Promise.all(
+        TOUCHED_TABLES.map(async (table) => {
+          const result = await pool.query(`SELECT count(*)::int AS total FROM ${table}`)
+          return result.rows[0].total
+        }),
+      )
+    }
+
+    it('row counts across every touched table are unchanged after a full route round-trip', async () => {
+      const before = await countRows()
+      const res = await request(adminApp()).get(`/api/attendance/groups/${groupAId}/effective-policy`)
+      expect(res.status).toBe(200)
+      const after = await countRows()
+      expect(after).toEqual(before)
+    })
+  })
+
+  describe('W6-R3: authorization precedes every aggregate SQL read', () => {
+    it('cross-org probe: org A admin requesting org B group gets the values-free 404 shape', async () => {
+      const res = await request(adminApp()).get(`/api/attendance/groups/${groupBId}/effective-policy`)
+      expect(res.status).toBe(404)
+      expect(res.body).toEqual({ ok: false, error: { code: 'NOT_FOUND', message: 'Group not found', details: undefined } })
+    })
+
+    it('delegated-non-member probe: attendance:admin permission WITHOUT active org_A membership is 403', async () => {
+      const app = makeApp({ id: nonMemberAdminUser, permissions: ['attendance:admin'], orgId: orgA })
+      const res = await request(app).get(`/api/attendance/groups/${groupAId}/effective-policy`)
+      expect(res.status).toBe(403)
+      expect(res.body.ok).toBe(false)
+    })
+
+    it('spoofed x-org-id probe: a header disagreeing with the authenticated org is rejected 403 BEFORE scoped SQL, regardless of which group is targeted', async () => {
+      const res = await request(adminApp())
+        .get(`/api/attendance/groups/${groupBId}/effective-policy`)
+        .set('x-org-id', orgB)
+      expect(res.status).toBe(403)
+      expect(res.body.ok).toBe(false)
+    })
+
+    it('spoofed x-org-id probe (mismatch on the caller\'s own accessible group): same 403, never falls through to the group SQL', async () => {
+      const res = await request(adminApp())
+        .get(`/api/attendance/groups/${groupAId}/effective-policy`)
+        .set('x-org-id', orgB)
+      expect(res.status).toBe(403)
+      expect(res.body.ok).toBe(false)
+    })
+
+    it('a header that BYTE-EQUALS the authenticated org has no effect (positive control — the check compares, it does not reject any header presence)', async () => {
+      const res = await request(adminApp())
+        .get(`/api/attendance/groups/${groupAId}/effective-policy`)
+        .set('x-org-id', orgA)
+      expect(res.status).toBe(200)
+    })
+
+    it('platform-admin bypass: global admin with NO org_A membership row still reaches the aggregate (permission bypass, org identity NOT bypassed)', async () => {
+      const app = makeApp({ id: platformAdminUser, permissions: [], role: 'admin', orgId: orgA })
+      const res = await request(app).get(`/api/attendance/groups/${groupAId}/effective-policy`)
+      expect(res.status).toBe(200)
+    })
+
+    it('missing authenticated org: 403 before any scoped SQL', async () => {
+      const app = makeApp({ id: noOrgUser, permissions: ['attendance:admin'] })
+      const res = await request(app).get(`/api/attendance/groups/${groupAId}/effective-policy`)
+      expect(res.status).toBe(403)
+      expect(res.body).toEqual({ ok: false, error: { code: 'FORBIDDEN', message: 'Authenticated organization not found', details: undefined } })
+    })
+
+    it('unknown groupId in the caller\'s own org shares the same 404 shape as cross-org', async () => {
+      const res = await request(adminApp()).get(`/api/attendance/groups/${randomUUID()}/effective-policy`)
+      expect(res.status).toBe(404)
+      expect(res.body).toEqual({ ok: false, error: { code: 'NOT_FOUND', message: 'Group not found', details: undefined } })
+    })
+
+    it('no attendance:admin permission: 403 before any org/group resolution', async () => {
+      const app = makeApp({ id: memberUser, permissions: [], orgId: orgA })
+      const res = await request(app).get(`/api/attendance/groups/${groupAId}/effective-policy`)
+      expect(res.status).toBe(403)
+    })
+  })
+
+  describe('W6-R6/R7: enum-strict, zero client-supplied state', () => {
+    it('invalid groupId format is rejected 400 before any group SQL', async () => {
+      const res = await request(adminApp()).get('/api/attendance/groups/not-a-uuid/effective-policy')
+      expect(res.status).toBe(400)
+      expect(res.body.error.code).toBe('GROUP_ID_INVALID')
+    })
+
+    it('any query parameter is rejected 400 before SQL (R7 — no state-selecting input accepted)', async () => {
+      const res = await request(adminApp()).get(`/api/attendance/groups/${groupAId}/effective-policy?label=effective`)
+      expect(res.status).toBe(400)
+      expect(res.body.error.code).toBe('QUERY_NOT_ACCEPTED')
+    })
+
+    it('a JSON body is rejected 400 before SQL (R7)', async () => {
+      const res = await request(adminApp())
+        .get(`/api/attendance/groups/${groupAId}/effective-policy`)
+        .send({ domains: { membership: { label: 'effective' } } })
+      expect(res.status).toBe(400)
+      expect(res.body.error.code).toBe('BODY_NOT_ACCEPTED')
+    })
+  })
+
+  describe('W6-R4: FSER fidelity (one derivation)', () => {
+    it('the embedded fixedSchedule object is byte-identical to a direct call to the canonical FSER service on the same data', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+      const fserLib = require('../../../../plugins/plugin-attendance/lib/attendance-group-fixed-schedule-effectiveness-service.cjs') as {
+        createAttendanceGroupFixedScheduleEffectivenessService: (deps: {
+          HttpError: new (status: number, code: string, message: string) => Error
+          buildAttendanceGroupFixedScheduleProducerKey: (input: { groupId: string; shiftId: string; startDate: string; endDate: string | null }) => string
+          now: () => string
+        }) => { getEffectiveness: (db: unknown, input: { orgId: string; groupId: string }) => Promise<Record<string, unknown>> }
+      }
+      const frozenNow = '2026-08-08T00:00:00.000Z'
+      class TestHttpError extends Error {
+        constructor(public status: number, public code: string, message: string) {
+          super(message)
+        }
+      }
+      const directFser = fserLib.createAttendanceGroupFixedScheduleEffectivenessService({
+        HttpError: TestHttpError,
+        buildAttendanceGroupFixedScheduleProducerKey: (input) =>
+          ['attendance_group_fixed_schedule', input.groupId, input.shiftId, input.startDate, input.endDate ?? 'null'].join(':'),
+        now: () => frozenNow,
+      })
+      const dbAdapter = { query: async (sql: string, params?: unknown[]) => (await pool.query(sql, params)).rows }
+      const direct = await directFser.getEffectiveness(dbAdapter, { orgId: orgA, groupId: groupAId })
+      const { groupId: _drop, ...directEmbed } = direct
+
+      const res = await request(adminApp()).get(`/api/attendance/groups/${groupAId}/effective-policy`)
+      expect(res.status).toBe(200)
+      const routeEmbed = { ...res.body.data.domains.schedule.fixedSchedule }
+      // evaluatedAt differs by wall-clock instant between the two independent
+      // calls; every OTHER field must be byte-identical.
+      delete (routeEmbed as Record<string, unknown>).evaluatedAt
+      delete (directEmbed as Record<string, unknown>).evaluatedAt
+      expect(routeEmbed).toStrictEqual(directEmbed)
+    })
+  })
+})

--- a/packages/core-backend/tests/integration/attendance-w6-group-effective-policy.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-w6-group-effective-policy.db.test.ts
@@ -82,7 +82,13 @@ describeIfDatabase('W6-1 group effective-policy aggregate route (real PostgreSQL
   const nonMemberAdminUser = randomUUID()
   const platformAdminUser = randomUUID()
   const noOrgUser = randomUUID()
-  const seededUserIds = [adminUser, memberUser, outsiderUser, nonMemberAdminUser, platformAdminUser, noOrgUser]
+  // Claims org A but is ALSO an active member of org B — the sharpest probe
+  // for "does a spoofed x-org-id header actually change which org's data is
+  // reachable" (a user who merely lacks ANY membership in the spoofed org
+  // cannot distinguish "header ignored" from "header honored, membership
+  // check correctly rejected the org anyway").
+  const dualOrgUser = randomUUID()
+  const seededUserIds = [adminUser, memberUser, outsiderUser, nonMemberAdminUser, platformAdminUser, noOrgUser, dualOrgUser]
 
   const groupAId = randomUUID()
   const groupBId = randomUUID()
@@ -124,6 +130,8 @@ describeIfDatabase('W6-1 group effective-policy aggregate route (real PostgreSQL
     await seedMembership(adminUser, orgA)
     await seedMembership(memberUser, orgA)
     await seedMembership(outsiderUser, orgB)
+    await seedMembership(dualOrgUser, orgA)
+    await seedMembership(dualOrgUser, orgB)
     // nonMemberAdminUser: holds attendance:admin permission but NO active
     // org_A membership row at all (delegated-non-member probe).
     // platformAdminUser: global admin, ALSO no org_A membership row —
@@ -328,6 +336,13 @@ describeIfDatabase('W6-1 group effective-policy aggregate route (real PostgreSQL
         .get(`/api/attendance/groups/${groupAId}/effective-policy`)
         .set('x-org-id', orgA)
       expect(res.status).toBe(200)
+    })
+
+    it('spoofed x-org-id probe, sharp form: claims org A but is ALSO an active member of org B — a header claiming org B must still 403, proving org identity is not merely "ignored because unreachable" but genuinely never sourced from the header', async () => {
+      const app = makeApp({ id: dualOrgUser, permissions: ['attendance:admin'], orgId: orgA })
+      const res = await request(app).get(`/api/attendance/groups/${groupBId}/effective-policy`).set('x-org-id', orgB)
+      expect(res.status).toBe(403)
+      expect(res.body.ok).toBe(false)
     })
 
     it('platform-admin bypass: global admin with NO org_A membership row still reaches the aggregate (permission bypass, org identity NOT bypassed)', async () => {

--- a/packages/core-backend/tests/integration/attendance-w6-group-effective-policy.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-w6-group-effective-policy.db.test.ts
@@ -189,6 +189,12 @@ describeIfDatabase('W6-1 group effective-policy aggregate route (real PostgreSQL
     // attendance_shift_assignments row per target member for `effective` —
     // without these the desired config exists but nothing matches it
     // (state `pending_apply`, not `effective`).
+    // Deliberately a hand-written literal of buildFixedScheduleProducerKey's
+    // join format, NOT a call to that function — this is what gives this
+    // DB-level test independent discriminating power over a format-change
+    // mutation in that function (see the doc comment above
+    // buildFixedScheduleProducerKey in w6-group-effective-policy-aggregate.ts).
+    // Do NOT "DRY" this into a call to the imported function.
     const producerKey = ['attendance_group_fixed_schedule', groupAId, shiftId, '2026-08-01', '2026-08-31'].join(':')
     const producerRunId = randomUUID()
     for (const userId of [memberUser, adminUser]) {

--- a/packages/core-backend/tests/integration/attendance-w6-group-effective-policy.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-w6-group-effective-policy.db.test.ts
@@ -34,6 +34,15 @@ import express from 'express'
 import { Pool } from 'pg'
 import request from 'supertest'
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
+// #4814 P3-5: imported from the module under test rather than reimplemented
+// a THIRD time here — the aggregate already reimplements the canonical
+// producer-key builder from plugins/plugin-attendance/index.cjs once
+// (documented equivalence argument in that file's header); a second,
+// independent reimplementation in this fidelity test would drift silently
+// alongside the aggregate's copy if the canonical builder ever changed,
+// since toStrictEqual would just keep comparing two copies that changed
+// together.
+import { buildFixedScheduleProducerKey } from '../../src/attendance/w6-group-effective-policy-aggregate'
 
 const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
 if (dbUrl) process.env.DATABASE_URL = dbUrl
@@ -421,8 +430,7 @@ describeIfDatabase('W6-1 group effective-policy aggregate route (real PostgreSQL
       }
       const directFser = fserLib.createAttendanceGroupFixedScheduleEffectivenessService({
         HttpError: TestHttpError,
-        buildAttendanceGroupFixedScheduleProducerKey: (input) =>
-          ['attendance_group_fixed_schedule', input.groupId, input.shiftId, input.startDate, input.endDate ?? 'null'].join(':'),
+        buildAttendanceGroupFixedScheduleProducerKey: buildFixedScheduleProducerKey,
         now: () => frozenNow,
       })
       const dbAdapter = { query: async (sql: string, params?: unknown[]) => (await pool.query(sql, params)).rows }

--- a/packages/core-backend/tests/unit/attendance-admin-plugin-lib-dist-layout-boot.test.ts
+++ b/packages/core-backend/tests/unit/attendance-admin-plugin-lib-dist-layout-boot.test.ts
@@ -43,10 +43,17 @@ describe('attendance-admin.ts plugin-attendance require — dist-layout boot (#4
       const tsc = path.join(coreBackendRoot, 'node_modules/.bin/tsc')
       const tsconfigPath = path.join(coreBackendRoot, 'tsconfig.json')
       const realPluginsDir = path.join(repoRoot, 'plugins/plugin-attendance')
+      const realNodeModulesDir = path.join(coreBackendRoot, 'node_modules')
 
       expect(fs.existsSync(tsc)).toBe(true)
       expect(fs.existsSync(tsconfigPath)).toBe(true)
       expect(fs.existsSync(realPluginsDir)).toBe(true)
+      // A dangling node_modules symlink below would surface as the probe's
+      // require() throwing MODULE_NOT_FOUND for an unrelated package (e.g.
+      // `express`/`pg`) -- indistinguishable, in the final assertions, from
+      // the #4814 P1 bug this test targets. Fail loudly and specifically
+      // here instead.
+      expect(fs.existsSync(realNodeModulesDir)).toBe(true)
 
       const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'w6-dist-layout-boot-'))
       try {
@@ -68,20 +75,28 @@ describe('attendance-admin.ts plugin-attendance require — dist-layout boot (#4
 
         // Real build: the exact `tsc` binary + `tsconfig.json` this package
         // ships, not a hand-simulated layout — emitted straight into the
-        // probe's `dist/`.
-        execFileSync(tsc, ['-p', tsconfigPath, '--outDir', probeDist], {
-          cwd: coreBackendRoot,
-          stdio: 'pipe',
-          timeout: 120_000,
-        })
+        // probe's `dist/`. `tsconfig.json` sets `noEmitOnError: false`, so
+        // `tsc` still emits (and this build should still be treated as
+        // successful for THIS test's purpose) even if it exits non-zero
+        // because of an unrelated type error anywhere else in
+        // `core-backend` -- this test is a boot-resolution gate, not a
+        // second `type-check` job, and must not fail opaquely on a type
+        // error somewhere else in the package. Only a missing emit (the
+        // thing `noEmitOnError` cannot save) is this test's failure.
+        let tscStderr = ''
+        try {
+          execFileSync(tsc, ['-p', tsconfigPath, '--outDir', probeDist], {
+            cwd: coreBackendRoot,
+            stdio: 'pipe',
+            timeout: 120_000,
+          })
+        } catch (e) {
+          tscStderr = String((e as { stderr?: Buffer | string })?.stderr ?? e)
+        }
         const routerPath = path.join(probeDist, 'src/routes/attendance-admin.js')
-        expect(fs.existsSync(routerPath)).toBe(true)
+        expect(fs.existsSync(routerPath), `tsc did not emit ${routerPath}. tsc output:\n${tscStderr}`).toBe(true)
 
-        fs.symlinkSync(
-          path.join(coreBackendRoot, 'node_modules'),
-          path.join(probeApp, 'packages/core-backend/node_modules'),
-          'dir',
-        )
+        fs.symlinkSync(realNodeModulesDir, path.join(probeApp, 'packages/core-backend/node_modules'), 'dir')
         fs.mkdirSync(path.join(probeApp, 'plugins'), { recursive: true })
         fs.symlinkSync(realPluginsDir, path.join(probeApp, 'plugins/plugin-attendance'), 'dir')
 
@@ -114,9 +129,12 @@ describe('attendance-admin.ts plugin-attendance require — dist-layout boot (#4
         })
         fs.rmSync(probeScriptPath, { force: true })
 
-        expect(stdout).not.toContain('MODULE_NOT_FOUND')
+        // Positive assertions FIRST: on failure, the reported message names
+        // the real cause (what stdout actually was) rather than leading
+        // with a `not.toContain` pass/fail that gives no diagnostic detail.
         expect(stdout).toContain('PROBE_RESULT: RESOLVED_OK')
         expect(stdout).toContain('attendanceAdminRouter')
+        expect(stdout).not.toContain('MODULE_NOT_FOUND')
       } finally {
         fs.rmSync(tmpRoot, { recursive: true, force: true })
       }

--- a/packages/core-backend/tests/unit/attendance-admin-plugin-lib-dist-layout-boot.test.ts
+++ b/packages/core-backend/tests/unit/attendance-admin-plugin-lib-dist-layout-boot.test.ts
@@ -1,0 +1,126 @@
+import { execFileSync } from 'node:child_process'
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * #4814 P1 — production boot crash.
+ *
+ * `attendance-admin.ts` module-scope-`require()`s two files inside
+ * `plugins/plugin-attendance/lib/`, resolved via
+ * `../../src/util/resolve-plugin-attendance-lib.ts`. `tsconfig.json`'s
+ * `rootDir: "."` puts the COMPILED output ONE DIRECTORY DEEPER than the
+ * source tree (`dist/src/routes/`, not `dist/routes/`), so a hard-coded
+ * relative-depth `require(...)` string that is correct from `src/routes/`
+ * is silently WRONG once compiled — and because `src/index.ts` imports this
+ * router statically at module scope, that wrongness throws during module
+ * init and crash-loops the whole backend on the first boot after deploy.
+ *
+ * Nothing else in the repo catches this class: `tsc --noEmit` never
+ * resolves `require(<string literal>)` at runtime (it is untyped, both call
+ * sites carry `@typescript-eslint/no-require-imports` disables), and
+ * `docker-build.yml` builds the image but never boots it.
+ *
+ * This test IS the boot gate. It runs the REAL `tsc` build (same compiler,
+ * same `tsconfig.json` used in production), lays the emitted output out
+ * EXACTLY like the production image (`Dockerfile.backend`: `WORKDIR /app`,
+ * `dist/src/routes/` sitting next to a sibling `/app/plugins/`), and — in a
+ * subprocess, so the real router's DB-pool / message-bus module-scope side
+ * effects can never leak into other tests in this worker — `require()`s the
+ * REAL compiled `attendance-admin.js` from that real layout. A regression
+ * to any hard-coded relative-depth `require` (in this file, or reintroduced
+ * directly inside `attendance-admin.ts` bypassing the resolver) reproduces
+ * #4814 P1 and reds this test with `MODULE_NOT_FOUND` — proven by running
+ * this exact test against the pre-fix source (see PR #4814 report).
+ */
+describe('attendance-admin.ts plugin-attendance require — dist-layout boot (#4814 P1)', () => {
+  it(
+    'the compiled router resolves plugins/plugin-attendance/lib/*.cjs from the production dist/src/routes/ layout',
+    () => {
+      const coreBackendRoot = path.resolve(__dirname, '../..')
+      const repoRoot = path.resolve(coreBackendRoot, '../..')
+      const tsc = path.join(coreBackendRoot, 'node_modules/.bin/tsc')
+      const tsconfigPath = path.join(coreBackendRoot, 'tsconfig.json')
+      const realPluginsDir = path.join(repoRoot, 'plugins/plugin-attendance')
+
+      expect(fs.existsSync(tsc)).toBe(true)
+      expect(fs.existsSync(tsconfigPath)).toBe(true)
+      expect(fs.existsSync(realPluginsDir)).toBe(true)
+
+      const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'w6-dist-layout-boot-'))
+      try {
+        // Production layout per `Dockerfile.backend`: WORKDIR /app,
+        // `packages/core-backend/dist/src/routes/` sitting four levels
+        // under a SIBLING `/app/plugins/` — not five, as a naive
+        // `../../../../` computed from `src/routes/` would assume.
+        //
+        // `dist` is built DIRECTLY into place (not built elsewhere and
+        // symlinked in): Node resolves a required file's real path before
+        // walking its `node_modules` ancestry, so a symlinked `dist`
+        // escapes this layout entirely and the `node_modules` symlink
+        // below would never be found — that failure mode is unrelated to
+        // the #4814 P1 bug this test targets, so the probe must not
+        // manufacture it.
+        const probeApp = path.join(tmpRoot, 'app')
+        const probeDist = path.join(probeApp, 'packages/core-backend/dist')
+        fs.mkdirSync(path.join(probeApp, 'packages/core-backend'), { recursive: true })
+
+        // Real build: the exact `tsc` binary + `tsconfig.json` this package
+        // ships, not a hand-simulated layout — emitted straight into the
+        // probe's `dist/`.
+        execFileSync(tsc, ['-p', tsconfigPath, '--outDir', probeDist], {
+          cwd: coreBackendRoot,
+          stdio: 'pipe',
+          timeout: 120_000,
+        })
+        const routerPath = path.join(probeDist, 'src/routes/attendance-admin.js')
+        expect(fs.existsSync(routerPath)).toBe(true)
+
+        fs.symlinkSync(
+          path.join(coreBackendRoot, 'node_modules'),
+          path.join(probeApp, 'packages/core-backend/node_modules'),
+          'dir',
+        )
+        fs.mkdirSync(path.join(probeApp, 'plugins'), { recursive: true })
+        fs.symlinkSync(realPluginsDir, path.join(probeApp, 'plugins/plugin-attendance'), 'dir')
+
+        // Runs in a CHILD PROCESS deliberately: requiring the real router
+        // executes real module-scope code (DB pool + message bus
+        // singletons) that must never run inside this test worker.
+        const probeScript = [
+          'process.exitCode = 0;',
+          'try {',
+          "  const mod = require('./dist/src/routes/attendance-admin.js');",
+          "  console.log('PROBE_RESULT: RESOLVED_OK ' + JSON.stringify(Object.keys(mod).sort()));",
+          '} catch (e) {',
+          "  console.log('PROBE_RESULT: FAILED ' + (e && e.code) + ' | ' + (e && e.message));",
+          '}',
+          'process.exit(process.exitCode);',
+        ].join('\n')
+        // The probe script's `require('./dist/...')` is resolved relative
+        // to ITS OWN file location (Node module resolution, not `cwd`), so
+        // it must live inside `probeApp/packages/core-backend/` — exactly
+        // where the real `index.js` that does the real
+        // `require('./dist/...')`-equivalent import lives in production.
+        const probeDir = path.join(probeApp, 'packages/core-backend')
+        const probeScriptPath = path.join(probeDir, 'probe.js')
+        fs.writeFileSync(probeScriptPath, probeScript, 'utf8')
+
+        const stdout = execFileSync('node', [probeScriptPath], {
+          cwd: probeDir,
+          encoding: 'utf8',
+          timeout: 30_000,
+        })
+        fs.rmSync(probeScriptPath, { force: true })
+
+        expect(stdout).not.toContain('MODULE_NOT_FOUND')
+        expect(stdout).toContain('PROBE_RESULT: RESOLVED_OK')
+        expect(stdout).toContain('attendanceAdminRouter')
+      } finally {
+        fs.rmSync(tmpRoot, { recursive: true, force: true })
+      }
+    },
+    180_000,
+  )
+})

--- a/packages/core-backend/tests/unit/attendance-w6-fser-single-source-caller-inventory.test.ts
+++ b/packages/core-backend/tests/unit/attendance-w6-fser-single-source-caller-inventory.test.ts
@@ -1,0 +1,109 @@
+/**
+ * W6-R4 (#4556) — mechanical repository inventory: the FSER derivation
+ * (`attendance-group-fixed-schedule-effectiveness-service.cjs`) has exactly
+ * one set of callers. Same idiom as
+ * `packages/core-backend/src/attendance/__tests__/w4c3a-rollout-control-inventory.test.ts`
+ * — a single inert gate over `git ls-files --cached` (tracked files only),
+ * not a hand-maintained narrower allowlist that a new caller could slip
+ * past.
+ *
+ * This is the CHEAP, literal-text tripwire the design lock's §7.2 wording
+ * asks for ("a mechanical inventory pins every caller"). The primary,
+ * behavioral proof that the aggregate does not RE-DERIVE fixed-schedule
+ * effectiveness lives in
+ * `attendance-w6-group-effective-policy.db.test.ts` (W6-R4: byte-identical
+ * to a direct FSER call on the same data) — a caller-inventory alone cannot
+ * catch a hand-rolled parallel state machine that never references FSER at
+ * all; the identity/fidelity real-DB proof does.
+ *
+ * Governing document:
+ *   docs/development/attendance-issue-4556-w6-group-effective-policy-design-lock-20260805.md
+ */
+import { execFileSync } from 'node:child_process'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../../')
+
+const EXCLUDED_DIR_SEGMENTS = new Set(['node_modules', 'dist', 'build', '.git', '.turbo', 'coverage', '.claude'])
+const TARGET_EXTENSIONS = new Set(['.ts', '.tsx', '.js', '.cjs', '.mjs'])
+
+// Every file that legitimately names the FSER module or its factory —
+// the canonical definition itself, W6-1's own composing module + contract
+// doc-comment + route wiring, existing FSER-owning tests, and W6-1's own
+// tests. ANY other match fails the gate.
+const ALLOWED_RELATIVE_FILES = new Set([
+  'plugins/plugin-attendance/lib/attendance-group-fixed-schedule-effectiveness-service.cjs',
+  'plugins/plugin-attendance/index.cjs',
+  'packages/core-backend/src/attendance/w6-group-effective-policy-aggregate.ts',
+  'packages/core-backend/src/attendance/w6-group-effective-policy-contract.ts',
+  'packages/core-backend/src/routes/attendance-admin.ts',
+  'packages/core-backend/tests/integration/attendance-group-fixed-schedule-effectiveness.db.test.ts',
+  'packages/core-backend/tests/integration/attendance-group-fixed-schedule-self-effectiveness.db.test.ts',
+  'packages/core-backend/tests/integration/attendance-w6-group-effective-policy.db.test.ts',
+  'packages/core-backend/tests/unit/attendance-group-fixed-schedule-effectiveness-service.test.ts',
+  // this inventory test's own file (names the guarded strings for documentation)
+  'packages/core-backend/tests/unit/attendance-w6-fser-single-source-caller-inventory.test.ts',
+])
+
+const FSER_REFERENCE_PATTERNS: ReadonlyArray<{ readonly label: string; readonly pattern: RegExp }> = [
+  { label: 'module path reference', pattern: /attendance-group-fixed-schedule-effectiveness-service\.cjs/ },
+  { label: 'factory call', pattern: /createAttendanceGroupFixedScheduleEffectivenessService/ },
+  { label: 'derivation function', pattern: /deriveAttendanceGroupFixedScheduleEffectiveness/ },
+]
+
+function listGitTrackedFiles(rootDir: string): string[] {
+  const raw = execFileSync('git', ['ls-files', '-z', '--cached'], { cwd: rootDir, maxBuffer: 64 * 1024 * 1024 })
+  return raw
+    .toString('utf8')
+    .split('\0')
+    .filter((relative) => relative.length > 0)
+    .filter((relative) => TARGET_EXTENSIONS.has(path.extname(relative)))
+    .filter((relative) => !relative.split('/').some((segment) => EXCLUDED_DIR_SEGMENTS.has(segment)))
+    .map((relative) => path.join(rootDir, relative))
+}
+
+function findOffenders(rootDir: string, files: readonly string[]): Array<{ file: string; label: string }> {
+  const offenders: Array<{ file: string; label: string }> = []
+  for (const absolute of files) {
+    const relative = path.relative(rootDir, absolute).split(path.sep).join('/')
+    if (ALLOWED_RELATIVE_FILES.has(relative)) continue
+    const content = fs.readFileSync(absolute, 'utf8')
+    for (const { label, pattern } of FSER_REFERENCE_PATTERNS) {
+      if (pattern.test(content)) offenders.push({ file: relative, label })
+    }
+  }
+  return offenders
+}
+
+describe('W6-R4 repository inventory: the FSER derivation has exactly one caller set', () => {
+  it('finds FSER references only in the allowlisted definition/composition/test files', () => {
+    const files = listGitTrackedFiles(ROOT)
+    expect(files.length).toBeGreaterThan(100) // sanity: git ls-files actually found the repo
+
+    const offenders = findOffenders(ROOT, files)
+    expect(offenders).toEqual([])
+  })
+
+  it('the allowlist itself is non-empty and includes the canonical definition (guards against a vacuously-passing empty scan)', () => {
+    expect(ALLOWED_RELATIVE_FILES.has('plugins/plugin-attendance/lib/attendance-group-fixed-schedule-effectiveness-service.cjs')).toBe(true)
+    expect(ALLOWED_RELATIVE_FILES.has('packages/core-backend/src/attendance/w6-group-effective-policy-aggregate.ts')).toBe(true)
+  })
+
+  it('a decoy file referencing the FSER factory OUTSIDE the allowlist is caught (positive control on the detector itself)', () => {
+    const scratchPath = path.join(ROOT, 'packages/core-backend/src/attendance/zz-w6r4-decoy-scratch.ts')
+    fs.writeFileSync(scratchPath, "export const decoy = 'createAttendanceGroupFixedScheduleEffectivenessService'\n")
+    try {
+      const files = listGitTrackedFiles(ROOT) // untracked scratch file — proves the git-tracked-only scope too
+      expect(files.some((f) => f.endsWith('zz-w6r4-decoy-scratch.ts'))).toBe(false)
+      // Directly exercise the detector against the untracked file to prove the PATTERN itself
+      // would catch it if it were ever committed outside the allowlist.
+      const offenders = findOffenders(ROOT, [scratchPath])
+      expect(offenders).toEqual([{ file: 'packages/core-backend/src/attendance/zz-w6r4-decoy-scratch.ts', label: 'factory call' }])
+    } finally {
+      fs.unlinkSync(scratchPath)
+    }
+  })
+})

--- a/packages/core-backend/tests/unit/attendance-w6-group-effective-policy-aggregate.test.ts
+++ b/packages/core-backend/tests/unit/attendance-w6-group-effective-policy-aggregate.test.ts
@@ -259,3 +259,122 @@ describe('W6-1 group effective-policy aggregate (fake-DB, exact fixture reproduc
     expect(result).toStrictEqual(fixture.data)
   })
 })
+
+/**
+ * W6-R6 (#4814 P2-1): "a silent-fallback mutation (unknown → `needs_configuration`
+ * or unknown → default) turns a test red." Each of the five internal
+ * enum reads the service does over data it does NOT itself validate on the
+ * way in (group type, manager role, rollout state, FSER state, shift flex
+ * mode) fails closed with a named error code rather than silently mapping
+ * an unrecognized value to a label or a default. None of these five is
+ * reachable through today's CHECK constraints or FSER's own closed state
+ * machine — that is exactly why they are defence in depth, and exactly why
+ * an untested one can rot silently (gate M1/M2). Each case below asserts
+ * the SPECIFIC error code (not a bare `toThrow()`, which would also pass on
+ * an unrelated crash) and is built by taking the minimal valid "effective
+ * fixed_shift" shape and flipping exactly one field to an out-of-enum
+ * value, so a revert of any one guard back to a silent fallback reds
+ * exactly its own case.
+ */
+describe('W6-1 group effective-policy aggregate — fail-closed enum guards (#4814 P2-1)', () => {
+  const groupId = 'a4556006-0009-4000-8000-000000000001'
+  const shiftId = 'a4556006-0009-4000-8000-000000000101'
+  const configId = 'a4556006-0009-4000-8000-000000000102'
+
+  /** A query router for a minimal valid "effective fixed_shift" group,
+   * with one override hook per SQL target so each test can flip exactly
+   * one field to an out-of-enum value. */
+  function makeQuery(overrides: {
+    groupType?: unknown
+    managerRole?: unknown
+    rolloutState?: unknown
+    flexMode?: unknown
+  }): AttendanceGroupEffectivePolicyQueryFn {
+    return async (sql) => {
+      const s = sql.toLowerCase()
+      if (s.includes('from attendance_groups')) {
+        return [{ id: groupId, attendance_type: overrides.groupType ?? 'fixed_shift', timezone: 'Asia/Shanghai', rule_set_id: null }]
+      }
+      if (s.includes('count(*)::int as cnt from attendance_group_members')) return [{ cnt: 1 }]
+      if (s.includes('from attendance_group_managers')) {
+        return overrides.managerRole !== undefined ? [{ role: overrides.managerRole, cnt: 1 }] : [{ role: 'owner', cnt: 1 }]
+      }
+      if (s.includes('from attendance_calculation_rollout_state')) {
+        return overrides.rolloutState !== undefined ? [{ state: overrides.rolloutState }] : []
+      }
+      if (s.includes('from attendance_group_fixed_schedule_configs')) return [{ id: configId }]
+      if (s.includes('count(*)::int as cnt from attendance_shift_segments')) return [{ cnt: 1 }]
+      if (s.includes('from attendance_shifts')) return [{ flex_mode: overrides.flexMode ?? 'strict' }]
+      if (s.includes('from attendance_calculation_group_memberships')) return []
+      if (s.includes('from attendance_rule_sets')) return []
+      throw new Error(`unexpected SQL: ${sql}`)
+    }
+  }
+
+  const validFser = makeFser({
+    groupId,
+    state: 'effective',
+    reasonCodes: ['EFFECTIVE'],
+    desired: { shiftId, startDate: '2026-08-01', endDate: '2026-08-31', revision: 1 },
+    coverage: { targetMembers: 1, matchingMembers: 1, missingMembers: 0, nonMemberTargets: 0, differentKeyRows: 0 },
+    drift: { unconfiguredManagedRows: 0, unpublishedManagedRows: 0, managedSets: [] },
+    evaluatedAt: NOW,
+  })
+
+  it('M1 — unrecognized FSER state fails closed with FSER_STATE_UNRECOGNIZED (not a silent needs_configuration)', async () => {
+    const query = makeQuery({})
+    const fser: AttendanceGroupEffectivePolicyFserServiceLike = {
+      getEffectiveness: async () => ({
+        groupId,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        state: 'quantum' as any,
+        reasonCodes: [],
+        desired: null,
+        coverage: { targetMembers: 0, matchingMembers: 0, missingMembers: 0, nonMemberTargets: 0, differentKeyRows: 0 },
+        drift: { unconfiguredManagedRows: 0, unpublishedManagedRows: 0, managedSets: [] },
+        evaluatedAt: NOW,
+      }),
+    }
+    const service = createAttendanceGroupEffectivePolicyAggregateService({ query, fser, now: () => NOW })
+    await expect(service.getAggregate({ orgId: 'org-1', groupId })).rejects.toMatchObject({
+      status: 500,
+      code: 'FSER_STATE_UNRECOGNIZED',
+    })
+  })
+
+  it('unrecognized group attendance_type fails closed with GROUP_TYPE_UNRECOGNIZED (not a silent free_time coercion)', async () => {
+    const query = makeQuery({ groupType: 'weird_type' })
+    const service = createAttendanceGroupEffectivePolicyAggregateService({ query, fser: validFser, now: () => NOW })
+    await expect(service.getAggregate({ orgId: 'org-1', groupId })).rejects.toMatchObject({
+      status: 500,
+      code: 'GROUP_TYPE_UNRECOGNIZED',
+    })
+  })
+
+  it('unrecognized manager role fails closed with MANAGER_ROLE_UNRECOGNIZED (not a silent skip)', async () => {
+    const query = makeQuery({ managerRole: 'captain' })
+    const service = createAttendanceGroupEffectivePolicyAggregateService({ query, fser: validFser, now: () => NOW })
+    await expect(service.getAggregate({ orgId: 'org-1', groupId })).rejects.toMatchObject({
+      status: 500,
+      code: 'MANAGER_ROLE_UNRECOGNIZED',
+    })
+  })
+
+  it('unrecognized rollout state fails closed with ROLLOUT_STATE_UNRECOGNIZED (not a silent "legacy" default)', async () => {
+    const query = makeQuery({ rolloutState: 'partially_enabled' })
+    const service = createAttendanceGroupEffectivePolicyAggregateService({ query, fser: validFser, now: () => NOW })
+    await expect(service.getAggregate({ orgId: 'org-1', groupId })).rejects.toMatchObject({
+      status: 500,
+      code: 'ROLLOUT_STATE_UNRECOGNIZED',
+    })
+  })
+
+  it('unrecognized shift flex_mode fails closed with FLEX_MODE_UNRECOGNIZED (not a silent "strict" default — #4814 P3-4)', async () => {
+    const query = makeQuery({ flexMode: 'lunar' })
+    const service = createAttendanceGroupEffectivePolicyAggregateService({ query, fser: validFser, now: () => NOW })
+    await expect(service.getAggregate({ orgId: 'org-1', groupId })).rejects.toMatchObject({
+      status: 500,
+      code: 'FLEX_MODE_UNRECOGNIZED',
+    })
+  })
+})

--- a/packages/core-backend/tests/unit/attendance-w6-group-effective-policy-aggregate.test.ts
+++ b/packages/core-backend/tests/unit/attendance-w6-group-effective-policy-aggregate.test.ts
@@ -26,6 +26,7 @@ import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 
 import {
+  buildFixedScheduleProducerKey,
   createAttendanceGroupEffectivePolicyAggregateService,
   type AttendanceGroupEffectivePolicyFserServiceLike,
   type AttendanceGroupEffectivePolicyQueryFn,
@@ -451,5 +452,44 @@ describe('OD-W6-6(a) authoritative-and-implemented branch (#4814 P3-2a — was u
     expect(result.domains.segments.reasonCodes).toEqual(['SEGMENT_CALCULATION_NOT_AUTHORITATIVE'])
     expect(result.domains.flex.label).toBe('preview_only')
     expect(result.domains.flex.reasonCodes).toEqual(['SEGMENT_CALCULATION_NOT_AUTHORITATIVE'])
+  })
+})
+
+/**
+ * `buildFixedScheduleProducerKey`'s own doc comment (this file's module
+ * header, ~L138-141) cites "the parity test
+ * (`attendance-w6-group-effective-policy-aggregate.test.ts`, 'producer key
+ * parity')" as where its equivalence-to-the-canonical-builder claim is
+ * proven — no such test existed (an asserted invariant with no test is a
+ * hidden bug waiting to happen). This is that test: it LITERALLY PINS the
+ * exact output format, so a format change (separator, field order,
+ * null-handling) reds here directly, rather than only being
+ * discriminated indirectly through a real-DB seed/match round-trip (as
+ * confirmed separately: mutating the join separator from ':' to '|' reds
+ * the real-DB happy-path fidelity test too, via FSER's own producer-key
+ * row-matching — this unit test is the FAST, DB-free version of that same
+ * discrimination).
+ */
+describe('producer key parity — buildFixedScheduleProducerKey literal pin', () => {
+  it('joins groupId:shiftId:startDate:endDate with the canonical "attendance_group_fixed_schedule" prefix', () => {
+    expect(
+      buildFixedScheduleProducerKey({
+        groupId: 'a4556006-000b-4000-8000-000000000001',
+        shiftId: 'a4556006-000b-4000-8000-000000000101',
+        startDate: '2026-08-01',
+        endDate: '2026-08-31',
+      }),
+    ).toBe('attendance_group_fixed_schedule:a4556006-000b-4000-8000-000000000001:a4556006-000b-4000-8000-000000000101:2026-08-01:2026-08-31')
+  })
+
+  it('a null endDate is joined as the literal string "null"', () => {
+    expect(
+      buildFixedScheduleProducerKey({
+        groupId: 'a4556006-000b-4000-8000-000000000001',
+        shiftId: 'a4556006-000b-4000-8000-000000000101',
+        startDate: '2026-08-01',
+        endDate: null,
+      }),
+    ).toBe('attendance_group_fixed_schedule:a4556006-000b-4000-8000-000000000001:a4556006-000b-4000-8000-000000000101:2026-08-01:null')
   })
 })

--- a/packages/core-backend/tests/unit/attendance-w6-group-effective-policy-aggregate.test.ts
+++ b/packages/core-backend/tests/unit/attendance-w6-group-effective-policy-aggregate.test.ts
@@ -378,3 +378,78 @@ describe('W6-1 group effective-policy aggregate — fail-closed enum guards (#48
     })
   })
 })
+
+/**
+ * OD-W6-6(a) (#4814 P3-2a): the lock's predicate is *"`preview_only` unless
+ * the org rollout posture is `authoritative` AND
+ * `SEGMENT_CALCULATION_IMPLEMENTED` is true."* Every `aggregate-*.json`
+ * fixture leaves `attendance_calculation_rollout_state` empty (posture
+ * always `legacy`) and no test injects `segmentCalculationImplemented:
+ * true`, so the `authoritativeAndImplemented` half of the disjunct in
+ * `getAggregate` never executed in this suite — a mutation neutering it
+ * would have stayed green. This case is built to be single-segment-strict
+ * FALSE (3 segments, `flex_required_duration`) so `effective` can ONLY be
+ * reached via the authoritative-and-implemented disjunct, isolating it
+ * from the already-covered single-segment-strict path.
+ */
+describe('OD-W6-6(a) authoritative-and-implemented branch (#4814 P3-2a — was untested)', () => {
+  const groupId = 'a4556006-000a-4000-8000-000000000001'
+  const shiftId = 'a4556006-000a-4000-8000-000000000101'
+  const configId = 'a4556006-000a-4000-8000-000000000102'
+
+  function makeAuthoritativeQuery(): AttendanceGroupEffectivePolicyQueryFn {
+    return async (sql) => {
+      const s = sql.toLowerCase()
+      if (s.includes('from attendance_groups')) return [{ id: groupId, attendance_type: 'fixed_shift', timezone: 'Asia/Shanghai', rule_set_id: null }]
+      if (s.includes('count(*)::int as cnt from attendance_group_members')) return [{ cnt: 4 }]
+      if (s.includes('from attendance_group_managers')) return [{ role: 'owner', cnt: 1 }]
+      if (s.includes('from attendance_calculation_rollout_state')) return [{ state: 'authoritative' }]
+      if (s.includes('from attendance_group_fixed_schedule_configs')) return [{ id: configId }]
+      // Deliberately NOT single-segment-strict: 3 segments, flex_required_duration.
+      if (s.includes('count(*)::int as cnt from attendance_shift_segments')) return [{ cnt: 3 }]
+      if (s.includes('from attendance_shifts')) return [{ flex_mode: 'flex_required_duration' }]
+      if (s.includes('from attendance_calculation_group_memberships')) return []
+      if (s.includes('from attendance_rule_sets')) return []
+      throw new Error(`unexpected SQL: ${sql}`)
+    }
+  }
+
+  const fser = makeFser({
+    groupId,
+    state: 'effective',
+    reasonCodes: ['EFFECTIVE'],
+    desired: { shiftId, startDate: '2026-08-01', endDate: '2026-08-31', revision: 1 },
+    coverage: { targetMembers: 4, matchingMembers: 4, missingMembers: 0, nonMemberTargets: 0, differentKeyRows: 0 },
+    drift: { unconfiguredManagedRows: 0, unpublishedManagedRows: 0, managedSets: [] },
+    evaluatedAt: NOW,
+  })
+
+  it('segments/flex land effective via the authoritative-and-implemented disjunct, not the (already-covered) single-segment-strict one', async () => {
+    const service = createAttendanceGroupEffectivePolicyAggregateService({
+      query: makeAuthoritativeQuery(),
+      fser,
+      now: () => NOW,
+      segmentCalculationImplemented: true,
+    })
+    const result = await service.getAggregate({ orgId: 'org-1', groupId })
+    expect(result.calculationPosture).toBe('authoritative')
+    expect(result.domains.segments.label).toBe('effective')
+    expect(result.domains.segments.reasonCodes).toEqual([])
+    expect(result.domains.flex.label).toBe('effective')
+    expect(result.domains.flex.reasonCodes).toEqual([])
+  })
+
+  it('the SAME shape with segmentCalculationImplemented: false (authoritative alone is not enough) lands preview_only', async () => {
+    const service = createAttendanceGroupEffectivePolicyAggregateService({
+      query: makeAuthoritativeQuery(),
+      fser,
+      now: () => NOW,
+      segmentCalculationImplemented: false,
+    })
+    const result = await service.getAggregate({ orgId: 'org-1', groupId })
+    expect(result.domains.segments.label).toBe('preview_only')
+    expect(result.domains.segments.reasonCodes).toEqual(['SEGMENT_CALCULATION_NOT_AUTHORITATIVE'])
+    expect(result.domains.flex.label).toBe('preview_only')
+    expect(result.domains.flex.reasonCodes).toEqual(['SEGMENT_CALCULATION_NOT_AUTHORITATIVE'])
+  })
+})

--- a/packages/core-backend/tests/unit/attendance-w6-group-effective-policy-aggregate.test.ts
+++ b/packages/core-backend/tests/unit/attendance-w6-group-effective-policy-aggregate.test.ts
@@ -1,0 +1,261 @@
+/**
+ * W6-1 (#4556) — group effective-policy aggregate service: fake-DB
+ * (in-memory) functional proof. Reproduces every `aggregate-*.json`
+ * fixture from the W6-0 pack via a scripted query router + a fake FSER
+ * service, byte-exact (`toStrictEqual`) against the fixture's `data`.
+ *
+ * This is the fast, DB-free correctness proof; the real-DB integration
+ * test (`tests/integration/attendance-w6-group-effective-policy.db.test.ts`)
+ * re-proves the same shapes against real PostgreSQL plus the red-line
+ * negative/mutation evidence (R1/R3/R4/R5).
+ *
+ * KNOWN FIXTURE DEVIATION (flagged, not silently reproduced): the W6-0
+ * `aggregate-conflict-membership-overlap.json` fixture's
+ * `domains.schedule.sourceRefs` omits the `fixed_schedule_config` ref that
+ * every other `fixed_shift`+FSER-effective fixture (1 and 6) includes,
+ * despite an identical `fixedSchedule.desired` shape. No trigger condition
+ * distinguishes it; this looks like an authoring omission in the
+ * never-executed PROPOSED pack (README: "nothing here comes from
+ * production"). This suite reproduces the CONSISTENT rule (always include
+ * `fixed_schedule_config` once a config row is resolved) and asserts
+ * against a corrected expectation for that one field only — see the test
+ * named accordingly.
+ */
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+import {
+  createAttendanceGroupEffectivePolicyAggregateService,
+  type AttendanceGroupEffectivePolicyFserServiceLike,
+  type AttendanceGroupEffectivePolicyQueryFn,
+} from '../../src/attendance/w6-group-effective-policy-aggregate'
+
+const FIXTURE_DIR = join(__dirname, '../fixtures/attendance/w6')
+function readFixture(name: string): { data: Record<string, unknown> } {
+  return JSON.parse(readFileSync(join(FIXTURE_DIR, `${name}.json`), 'utf8'))
+}
+
+function makeFser(result: {
+  groupId: string
+  state: 'not_configured' | 'pending_apply' | 'effective' | 'configuration_changed'
+  reasonCodes: string[]
+  desired: { shiftId: string; startDate: string; endDate: string; revision: number } | null
+  coverage: { targetMembers: number; matchingMembers: number; missingMembers: number; nonMemberTargets: number; differentKeyRows: number }
+  drift: { unconfiguredManagedRows: number; unpublishedManagedRows: number; managedSets: unknown[] }
+  evaluatedAt: string
+}): AttendanceGroupEffectivePolicyFserServiceLike {
+  return { getEffectiveness: async () => result }
+}
+
+const NOW = '2026-08-05T00:00:00.000Z'
+
+describe('W6-1 group effective-policy aggregate (fake-DB, exact fixture reproduction)', () => {
+  it('reproduces aggregate-effective-fixed-shift.json', async () => {
+    const fixture = readFixture('aggregate-effective-fixed-shift')
+    const groupId = 'a4556006-0001-4000-8000-000000000001'
+    const shiftId = 'a4556006-0001-4000-8000-000000000101'
+    const configId = 'a4556006-0001-4000-8000-000000000102'
+    const ruleSetId = 'a4556006-0001-4000-8000-000000000103'
+
+    const query: AttendanceGroupEffectivePolicyQueryFn = async (sql) => {
+      const s = sql.toLowerCase()
+      if (s.includes('from attendance_groups')) return [{ id: groupId, attendance_type: 'fixed_shift', timezone: 'Asia/Shanghai', rule_set_id: ruleSetId }]
+      if (s.includes('count(*)::int as cnt from attendance_group_members')) return [{ cnt: 12 }]
+      if (s.includes('from attendance_group_managers')) return [{ role: 'owner', cnt: 1 }, { role: 'sub_owner', cnt: 2 }]
+      if (s.includes('from attendance_calculation_rollout_state')) return []
+      if (s.includes('from attendance_group_fixed_schedule_configs')) return [{ id: configId }]
+      if (s.includes('count(*)::int as cnt from attendance_shift_segments')) return [{ cnt: 1 }]
+      if (s.includes('from attendance_shifts')) return [{ flex_mode: 'strict' }]
+      if (s.includes('from attendance_calculation_group_memberships')) return []
+      if (s.includes('from attendance_rule_sets')) return []
+      throw new Error(`unexpected SQL: ${sql}`)
+    }
+
+    const fser = makeFser({
+      groupId,
+      state: 'effective',
+      reasonCodes: ['EFFECTIVE'],
+      desired: { shiftId, startDate: '2026-08-01', endDate: '2026-08-31', revision: 2 },
+      coverage: { targetMembers: 12, matchingMembers: 12, missingMembers: 0, nonMemberTargets: 0, differentKeyRows: 0 },
+      drift: { unconfiguredManagedRows: 0, unpublishedManagedRows: 0, managedSets: [] },
+      evaluatedAt: NOW,
+    })
+
+    const service = createAttendanceGroupEffectivePolicyAggregateService({ query, fser, now: () => NOW })
+    const result = await service.getAggregate({ orgId: 'org-1', groupId })
+    expect(result).toStrictEqual(fixture.data)
+  })
+
+  it('reproduces aggregate-org-inherited-defaults.json', async () => {
+    const fixture = readFixture('aggregate-org-inherited-defaults')
+    const groupId = 'a4556006-0002-4000-8000-000000000001'
+
+    const query: AttendanceGroupEffectivePolicyQueryFn = async (sql) => {
+      const s = sql.toLowerCase()
+      if (s.includes('from attendance_groups')) return [{ id: groupId, attendance_type: 'free_time', timezone: 'Asia/Shanghai', rule_set_id: null }]
+      if (s.includes('count(*)::int as cnt from attendance_group_members')) return [{ cnt: 3 }]
+      if (s.includes('from attendance_group_managers')) return [{ role: 'owner', cnt: 1 }]
+      if (s.includes('from attendance_calculation_rollout_state')) return []
+      if (s.includes('from attendance_rule_sets')) return [{ '?column?': 1 }] // org HAS a default rule set
+      if (s.includes('from attendance_calculation_group_memberships')) return []
+      throw new Error(`unexpected SQL: ${sql}`)
+    }
+    const fser: AttendanceGroupEffectivePolicyFserServiceLike = {
+      getEffectiveness: async () => {
+        throw new Error('FSER must not be called for a free_time group')
+      },
+    }
+    const service = createAttendanceGroupEffectivePolicyAggregateService({ query, fser, now: () => NOW })
+    const result = await service.getAggregate({ orgId: 'org-1', groupId })
+    expect(result).toStrictEqual(fixture.data)
+  })
+
+  it('reproduces aggregate-preview-only-segments-flex.json', async () => {
+    const fixture = readFixture('aggregate-preview-only-segments-flex')
+    const groupId = 'a4556006-0003-4000-8000-000000000001'
+    const shiftId = 'a4556006-0003-4000-8000-000000000101'
+    const configId = 'a4556006-0003-4000-8000-000000000102'
+    const ruleSetId = 'a4556006-0003-4000-8000-000000000103'
+
+    const query: AttendanceGroupEffectivePolicyQueryFn = async (sql) => {
+      const s = sql.toLowerCase()
+      if (s.includes('from attendance_groups')) return [{ id: groupId, attendance_type: 'fixed_shift', timezone: 'Asia/Shanghai', rule_set_id: ruleSetId }]
+      if (s.includes('count(*)::int as cnt from attendance_group_members')) return [{ cnt: 8 }]
+      if (s.includes('from attendance_group_managers')) return [{ role: 'owner', cnt: 1 }, { role: 'sub_owner', cnt: 1 }]
+      if (s.includes('from attendance_calculation_rollout_state')) return []
+      if (s.includes('from attendance_group_fixed_schedule_configs')) return [{ id: configId }]
+      if (s.includes('count(*)::int as cnt from attendance_shift_segments')) return [{ cnt: 1 }]
+      if (s.includes('from attendance_shifts')) return [{ flex_mode: 'flex_required_duration' }]
+      if (s.includes('from attendance_calculation_group_memberships')) return []
+      if (s.includes('from attendance_rule_sets')) return []
+      throw new Error(`unexpected SQL: ${sql}`)
+    }
+    const fser = makeFser({
+      groupId,
+      state: 'effective',
+      reasonCodes: ['EFFECTIVE'],
+      desired: { shiftId, startDate: '2026-08-01', endDate: '2026-08-31', revision: 1 },
+      coverage: { targetMembers: 8, matchingMembers: 8, missingMembers: 0, nonMemberTargets: 0, differentKeyRows: 0 },
+      drift: { unconfiguredManagedRows: 0, unpublishedManagedRows: 0, managedSets: [] },
+      evaluatedAt: NOW,
+    })
+    const service = createAttendanceGroupEffectivePolicyAggregateService({ query, fser, now: () => NOW })
+    const result = await service.getAggregate({ orgId: 'org-1', groupId })
+    expect(result).toStrictEqual(fixture.data)
+  })
+
+  it('reproduces aggregate-needs-configuration.json', async () => {
+    const fixture = readFixture('aggregate-needs-configuration')
+    const groupId = 'a4556006-0004-4000-8000-000000000001'
+
+    const query: AttendanceGroupEffectivePolicyQueryFn = async (sql) => {
+      const s = sql.toLowerCase()
+      if (s.includes('from attendance_groups')) return [{ id: groupId, attendance_type: 'scheduled_shift', timezone: null, rule_set_id: null }]
+      if (s.includes('count(*)::int as cnt from attendance_group_members')) return [{ cnt: 5 }]
+      if (s.includes('from attendance_group_managers')) return []
+      if (s.includes('from attendance_calculation_rollout_state')) return []
+      if (s.includes('from attendance_schedule_groups')) return [] // no advanced-scheduling config
+      if (s.includes('from attendance_calculation_group_memberships')) return []
+      if (s.includes('from attendance_rule_sets')) return [] // no org default either
+      throw new Error(`unexpected SQL: ${sql}`)
+    }
+    const fser: AttendanceGroupEffectivePolicyFserServiceLike = {
+      getEffectiveness: async () => {
+        throw new Error('FSER must not be called for a scheduled_shift group')
+      },
+    }
+    const service = createAttendanceGroupEffectivePolicyAggregateService({ query, fser, now: () => NOW })
+    const result = await service.getAggregate({ orgId: 'org-1', groupId })
+    expect(result).toStrictEqual(fixture.data)
+  })
+
+  it('reproduces aggregate-conflict-membership-overlap.json EXCEPT the flagged sourceRefs deviation', async () => {
+    const fixture = readFixture('aggregate-conflict-membership-overlap')
+    const groupId = 'a4556006-0005-4000-8000-000000000001'
+    const shiftId = 'a4556006-0005-4000-8000-000000000101'
+    const configId = 'a4556006-0005-4000-8000-000000000199' // synthetic — fixture omits this ref (see file header)
+
+    const query: AttendanceGroupEffectivePolicyQueryFn = async (sql) => {
+      const s = sql.toLowerCase()
+      if (s.includes('from attendance_groups')) return [{ id: groupId, attendance_type: 'fixed_shift', timezone: 'Asia/Shanghai', rule_set_id: null }]
+      if (s.includes('count(*)::int as cnt from attendance_group_members')) return [{ cnt: 10 }]
+      if (s.includes('from attendance_group_managers')) return [{ role: 'owner', cnt: 1 }]
+      if (s.includes('from attendance_calculation_rollout_state')) return []
+      if (s.includes('from attendance_group_fixed_schedule_configs')) return [{ id: configId }]
+      if (s.includes('count(*)::int as cnt from attendance_shift_segments')) return [{ cnt: 1 }]
+      if (s.includes('from attendance_shifts')) return [{ flex_mode: 'strict' }]
+      if (s.includes('select count(*)::int as cnt') && s.includes('this_group')) return [{ cnt: 2 }]
+      // Fixture's `rules` domain is org_inherited, which requires an org
+      // default rule set — the fixture is silent on this fact, so the org
+      // world here honestly HAS one.
+      if (s.includes('from attendance_rule_sets')) return [{ exists: 1 }]
+      throw new Error(`unexpected SQL: ${sql}`)
+    }
+    const fser = makeFser({
+      groupId,
+      state: 'effective',
+      reasonCodes: ['EFFECTIVE'],
+      desired: { shiftId, startDate: '2026-08-01', endDate: '2026-08-31', revision: 1 },
+      coverage: { targetMembers: 10, matchingMembers: 10, missingMembers: 0, nonMemberTargets: 0, differentKeyRows: 0 },
+      drift: { unconfiguredManagedRows: 0, unpublishedManagedRows: 0, managedSets: [] },
+      evaluatedAt: NOW,
+    })
+    const service = createAttendanceGroupEffectivePolicyAggregateService({ query, fser, now: () => NOW })
+    const result = await service.getAggregate({ orgId: 'org-1', groupId })
+
+    const expected = structuredClone(fixture.data) as Record<string, unknown>
+    const domains = expected.domains as Record<string, unknown>
+    ;(domains.schedule as Record<string, unknown>).sourceRefs = [
+      { kind: 'shift', id: shiftId },
+      { kind: 'fixed_schedule_config', id: configId },
+    ]
+    expect(result).not.toStrictEqual(fixture.data) // proves the deviation is real, not a typo
+    expect(result).toStrictEqual(expected)
+  })
+
+  it('reproduces aggregate-conflict-fixed-schedule-changed.json', async () => {
+    const fixture = readFixture('aggregate-conflict-fixed-schedule-changed')
+    const groupId = 'a4556006-0006-4000-8000-000000000001'
+    const shiftId = 'a4556006-0006-4000-8000-000000000101'
+    const configId = 'a4556006-0006-4000-8000-000000000102'
+
+    const query: AttendanceGroupEffectivePolicyQueryFn = async (sql) => {
+      const s = sql.toLowerCase()
+      if (s.includes('from attendance_groups')) return [{ id: groupId, attendance_type: 'fixed_shift', timezone: 'Asia/Shanghai', rule_set_id: null }]
+      if (s.includes('count(*)::int as cnt from attendance_group_members')) return [{ cnt: 6 }]
+      if (s.includes('from attendance_group_managers')) return [{ role: 'owner', cnt: 1 }, { role: 'sub_owner', cnt: 1 }]
+      if (s.includes('from attendance_calculation_rollout_state')) return []
+      if (s.includes('from attendance_group_fixed_schedule_configs')) return [{ id: configId }]
+      if (s.includes('count(*)::int as cnt from attendance_shift_segments')) return [{ cnt: 1 }]
+      if (s.includes('from attendance_shifts')) return [{ flex_mode: 'strict' }]
+      if (s.includes('from attendance_calculation_group_memberships')) return []
+      if (s.includes('from attendance_rule_sets')) return [{ x: 1 }]
+      throw new Error(`unexpected SQL: ${sql}`)
+    }
+    const fser = makeFser({
+      groupId,
+      state: 'configuration_changed',
+      reasonCodes: ['DIFFERENT_MANAGED_KEY_ACTIVE', 'TARGET_MEMBER_MISSING'],
+      desired: { shiftId, startDate: '2026-09-01', endDate: '2026-09-30', revision: 3 },
+      coverage: { targetMembers: 6, matchingMembers: 0, missingMembers: 6, nonMemberTargets: 0, differentKeyRows: 6 },
+      drift: {
+        unconfiguredManagedRows: 0,
+        unpublishedManagedRows: 0,
+        managedSets: [
+          {
+            shiftId: 'a4556006-0006-4000-8000-000000000109',
+            startDate: '2026-08-01',
+            endDate: '2026-08-31',
+            producerKey: 'fixed:a4556006-0006-4000-8000-000000000109:2026-08-01:2026-08-31',
+            rowCount: 6,
+          },
+        ],
+      },
+      evaluatedAt: NOW,
+    })
+    const service = createAttendanceGroupEffectivePolicyAggregateService({ query, fser, now: () => NOW })
+    const result = await service.getAggregate({ orgId: 'org-1', groupId })
+    expect(result).toStrictEqual(fixture.data)
+  })
+})

--- a/packages/core-backend/tests/unit/attendance-w6-group-effective-policy-dml-sweep.test.ts
+++ b/packages/core-backend/tests/unit/attendance-w6-group-effective-policy-dml-sweep.test.ts
@@ -1,15 +1,22 @@
 /**
- * W6-R1 — GET-only, zero writes: static DML sweep over the W6-1 aggregate
- * module's OWN files (whole-file scope, not a positional window — this
- * repo has been burned before by "next sibling key" window scans that a
- * later addition silently escapes; see
- * `multitable-d2-sidedoor-txn-wiring.guard.test.ts`'s PROBE-1 history).
+ * W6-R1 — GET-only, zero writes: static DML sweep over the whole aggregate
+ * CALL PATH (whole-file scope for the two service files, not a positional
+ * window — this repo has been burned before by "next sibling key" window
+ * scans that a later addition silently escapes; see
+ * `multitable-d2-sidedoor-txn-wiring.guard.test.ts`'s PROBE-1 history —
+ * PLUS the route-handler block in `attendance-admin.ts`, extracted by
+ * anchoring on the route's own path string and balanced-paren scanning
+ * from the enclosing `r.get(...)` call, not a hand-picked line range
+ * (#4814 P2-3: the route handler is part of "the aggregate call path" R1
+ * governs and was previously entirely unswept — a raw `UPDATE` injected
+ * there passed every existing gate).
  *
  * Both query syntaxes this house's writer-audit rule requires (raw SQL AND
  * kysely query-builder) are swept. This is the CHEAP tripwire; the primary,
- * unfoolable proof is behavioral — the real-DB integration test asserts
- * row counts across every table the aggregate touches are byte-identical
- * before and after a full route round-trip
+ * unfoolable proof is behavioral — the real-DB integration test snapshots
+ * both row COUNTS and row VERSIONS (`xmin`) across every table the
+ * aggregate touches, so it also catches an in-place `UPDATE` that a
+ * count-only leg cannot see
  * (`tests/integration/attendance-w6-group-effective-policy.db.test.ts`).
  */
 import { readFileSync } from 'node:fs'
@@ -17,12 +24,57 @@ import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 
 const SRC_DIR = join(__dirname, '../../src/attendance')
+const ROUTES_DIR = join(__dirname, '../../src/routes')
 const SWEPT_FILES = ['w6-group-effective-policy-aggregate.ts', 'w6-group-effective-policy-response-contract.ts']
 
 // Raw-SQL DML verbs (word-boundary, case-insensitive).
 const RAW_SQL_DML = [/\bINSERT\s+INTO\b/i, /\bUPDATE\s+\w/i, /\bDELETE\s+FROM\b/i, /\bMERGE\s+INTO\b/i, /\bTRUNCATE\b/i]
 // Kysely query-builder DML entry points.
 const KYSELY_DML = [/\.insertInto\s*\(/, /\.updateTable\s*\(/, /\.deleteFrom\s*\(/, /\.replaceInto\s*\(/]
+
+/**
+ * Extracts the full source text of the `r.<method>(<routePath>, ...)` call
+ * registering one route, DERIVED from the route's own path string (a
+ * stable anchor that moves with the code) rather than a hand-picked line
+ * range. `attendance-admin.ts` is a single large file with many routes —
+ * legitimate writes elsewhere in it must stay out of scope, so the sweep
+ * is bounded to exactly this route's registration, from `r.<method>(` to
+ * its balanced closing `)` (string/template-literal-aware, so a `)`
+ * inside a string or backtick body does not end the scan early).
+ */
+function extractRouteHandlerSource(text: string, method: string, routePath: string): string {
+  const marker = `r.${method}(`
+  const pathNeedle = `'${routePath}'`
+  const pathIdx = text.indexOf(pathNeedle)
+  if (pathIdx === -1) throw new Error(`route path literal not found: ${routePath}`)
+  const callStart = text.lastIndexOf(marker, pathIdx)
+  if (callStart === -1) throw new Error(`no preceding "${marker}" found before route path ${routePath}`)
+  const openParenIdx = callStart + marker.length - 1
+  let depth = 0
+  let inString: '"' | "'" | '`' | false = false
+  let i = openParenIdx
+  for (; i < text.length; i += 1) {
+    const c = text[i]
+    if (inString) {
+      if (c === '\\') { i += 1; continue }
+      if (c === inString) inString = false
+      continue
+    }
+    if (c === '"' || c === "'" || c === '`') { inString = c; continue }
+    if (c === '(') depth += 1
+    else if (c === ')') {
+      depth -= 1
+      if (depth === 0) { i += 1; break }
+    }
+  }
+  if (depth !== 0) throw new Error(`unbalanced parens extracting route handler for ${routePath}`)
+  return text.slice(callStart, i)
+}
+
+const ROUTE_HANDLER_FILE = 'attendance-admin.ts'
+const ROUTE_HANDLER_PATH = '/api/attendance/groups/:groupId/effective-policy'
+const routeHandlerFullText = readFileSync(join(ROUTES_DIR, ROUTE_HANDLER_FILE), 'utf8')
+const routeHandlerSource = extractRouteHandlerSource(routeHandlerFullText, 'get', ROUTE_HANDLER_PATH)
 
 describe('W6-R1 — DML sweep (both query syntaxes) over the aggregate module files', () => {
   it('swept the expected file set (guards against a silently-empty scope)', () => {
@@ -56,4 +108,41 @@ describe('W6-R1 — DML sweep (both query syntaxes) over the aggregate module fi
       })
     }
   }
+})
+
+describe('W6-R1 — DML sweep over the route handler (#4814 P2-3: the aggregate call path, not just the service files)', () => {
+  it('extracted a non-trivial, correctly-bounded route handler block (guards against a silently-empty or mis-anchored scope)', () => {
+    expect(routeHandlerSource.length).toBeGreaterThan(500)
+    // Proves the extraction landed on the RIGHT route (not an earlier
+    // sibling that happens to share a prefix) and captured its full body.
+    expect(routeHandlerSource).toContain('attendanceGroupEffectivePolicyAggregateService.getAggregate')
+    expect(routeHandlerSource).toContain('QUERY_NOT_ACCEPTED')
+    expect(routeHandlerSource).toContain('BODY_NOT_ACCEPTED')
+  })
+
+  it('zero raw-SQL DML verbs in the route handler block', () => {
+    const hits = RAW_SQL_DML.filter((pattern) => pattern.test(routeHandlerSource))
+    expect(hits.map((p) => p.source)).toEqual([])
+  })
+
+  it('zero kysely DML calls in the route handler block', () => {
+    const hits = KYSELY_DML.filter((pattern) => pattern.test(routeHandlerSource))
+    expect(hits.map((p) => p.source)).toEqual([])
+  })
+
+  it('positive control: the extractor + sweep DOES catch a synthetic DML string inside the extracted block (proves the detector is not vacuously passing)', () => {
+    const poisoned = routeHandlerSource.replace(
+      'attendanceGroupEffectivePolicyAggregateService.getAggregate',
+      "await query(`UPDATE attendance_groups SET updated_at = now() WHERE id = $1`); attendanceGroupEffectivePolicyAggregateService.getAggregate",
+    )
+    expect(poisoned).not.toEqual(routeHandlerSource) // the replace actually matched something
+    const hits = RAW_SQL_DML.filter((pattern) => pattern.test(poisoned))
+    expect(hits.length).toBeGreaterThan(0)
+  })
+
+  it('extraction is anchored to the route path, not a line number: re-extracting after prepending unrelated text yields the identical block', () => {
+    const shifted = '// unrelated leading comment\n'.repeat(50) + routeHandlerFullText
+    const reExtracted = extractRouteHandlerSource(shifted, 'get', ROUTE_HANDLER_PATH)
+    expect(reExtracted).toEqual(routeHandlerSource)
+  })
 })

--- a/packages/core-backend/tests/unit/attendance-w6-group-effective-policy-dml-sweep.test.ts
+++ b/packages/core-backend/tests/unit/attendance-w6-group-effective-policy-dml-sweep.test.ts
@@ -1,0 +1,59 @@
+/**
+ * W6-R1 — GET-only, zero writes: static DML sweep over the W6-1 aggregate
+ * module's OWN files (whole-file scope, not a positional window — this
+ * repo has been burned before by "next sibling key" window scans that a
+ * later addition silently escapes; see
+ * `multitable-d2-sidedoor-txn-wiring.guard.test.ts`'s PROBE-1 history).
+ *
+ * Both query syntaxes this house's writer-audit rule requires (raw SQL AND
+ * kysely query-builder) are swept. This is the CHEAP tripwire; the primary,
+ * unfoolable proof is behavioral — the real-DB integration test asserts
+ * row counts across every table the aggregate touches are byte-identical
+ * before and after a full route round-trip
+ * (`tests/integration/attendance-w6-group-effective-policy.db.test.ts`).
+ */
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const SRC_DIR = join(__dirname, '../../src/attendance')
+const SWEPT_FILES = ['w6-group-effective-policy-aggregate.ts', 'w6-group-effective-policy-response-contract.ts']
+
+// Raw-SQL DML verbs (word-boundary, case-insensitive).
+const RAW_SQL_DML = [/\bINSERT\s+INTO\b/i, /\bUPDATE\s+\w/i, /\bDELETE\s+FROM\b/i, /\bMERGE\s+INTO\b/i, /\bTRUNCATE\b/i]
+// Kysely query-builder DML entry points.
+const KYSELY_DML = [/\.insertInto\s*\(/, /\.updateTable\s*\(/, /\.deleteFrom\s*\(/, /\.replaceInto\s*\(/]
+
+describe('W6-R1 — DML sweep (both query syntaxes) over the aggregate module files', () => {
+  it('swept the expected file set (guards against a silently-empty scope)', () => {
+    for (const file of SWEPT_FILES) {
+      const text = readFileSync(join(SRC_DIR, file), 'utf8')
+      expect(text.length).toBeGreaterThan(500)
+    }
+  })
+
+  for (const file of SWEPT_FILES) {
+    it(`${file}: zero raw-SQL DML verbs`, () => {
+      const text = readFileSync(join(SRC_DIR, file), 'utf8')
+      const hits = RAW_SQL_DML.filter((pattern) => pattern.test(text))
+      expect(hits.map((p) => p.source)).toEqual([])
+    })
+
+    it(`${file}: zero kysely DML calls`, () => {
+      const text = readFileSync(join(SRC_DIR, file), 'utf8')
+      const hits = KYSELY_DML.filter((pattern) => pattern.test(text))
+      expect(hits.map((p) => p.source)).toEqual([])
+    })
+
+    if (file === 'w6-group-effective-policy-aggregate.ts') {
+      it(`${file}: every SQL template literal starts with SELECT (positive control — proves the sweep can see real SQL text)`, () => {
+        const text = readFileSync(join(SRC_DIR, file), 'utf8')
+        const templateLiterals = [...text.matchAll(/`([^`]*)`/gs)].map((m) => m[1]).filter((s) => /\bFROM\b/i.test(s))
+        expect(templateLiterals.length).toBeGreaterThan(0) // positive control: SQL literals do exist here
+        for (const literal of templateLiterals) {
+          expect(literal.trim().toUpperCase().startsWith('SELECT')).toBe(true)
+        }
+      })
+    }
+  }
+})

--- a/packages/core-backend/tests/unit/attendance-w6-group-effective-policy-response-contract.test.ts
+++ b/packages/core-backend/tests/unit/attendance-w6-group-effective-policy-response-contract.test.ts
@@ -248,6 +248,34 @@ describe('W6 group effective-policy response contract validator', () => {
         reason: 'fixedSchedule.reasonCodes: not a closed-set string array',
       })
     })
+
+    // #4814 NIT-3: managedSets[] keys were checked but not value TYPES —
+    // `rowCount: {}` or `producerKey: 42` passed.
+    it('rejects a managedSets[] entry with a non-string producerKey', () => {
+      const fixture = readFixture('aggregate-conflict-fixed-schedule-changed.json') as {
+        ok: true
+        data: { domains: { schedule: { fixedSchedule: { drift: { managedSets: Array<Record<string, unknown>> } } } } }
+      }
+      expect(fixture.data.domains.schedule.fixedSchedule.drift.managedSets.length).toBeGreaterThan(0)
+      const patched = structuredClone(fixture)
+      patched.data.domains.schedule.fixedSchedule.drift.managedSets[0].producerKey = 42
+      expect(validateAttendanceGroupEffectivePolicyResponseV1(patched)).toEqual({
+        ok: false,
+        reason: 'fixedSchedule.drift.managedSets[]: field type mismatch',
+      })
+    })
+    it('rejects a managedSets[] entry with a non-numeric rowCount', () => {
+      const fixture = readFixture('aggregate-conflict-fixed-schedule-changed.json') as {
+        ok: true
+        data: { domains: { schedule: { fixedSchedule: { drift: { managedSets: Array<Record<string, unknown>> } } } } }
+      }
+      const patched = structuredClone(fixture)
+      patched.data.domains.schedule.fixedSchedule.drift.managedSets[0].rowCount = {}
+      expect(validateAttendanceGroupEffectivePolicyResponseV1(patched)).toEqual({
+        ok: false,
+        reason: 'fixedSchedule.drift.managedSets[]: rowCount not a non-negative int',
+      })
+    })
   })
 
   describe('editorRef closed-table parser (W6-R8)', () => {

--- a/packages/core-backend/tests/unit/attendance-w6-group-effective-policy-response-contract.test.ts
+++ b/packages/core-backend/tests/unit/attendance-w6-group-effective-policy-response-contract.test.ts
@@ -1,0 +1,271 @@
+/**
+ * W6-R2 / W6-R6 / W6-R7 / W6-R8 — pure response-contract validator, proved
+ * against the full W6-0 fixture pack (`tests/fixtures/attendance/w6/`).
+ *
+ * Governing document:
+ *   docs/development/attendance-issue-4556-w6-group-effective-policy-design-lock-20260805.md
+ *
+ * Every `aggregate-*.json` fixture MUST validate (they are the exact-key
+ * response shapes design-lock §4.3 requires); every `invalid-reject-*.json`
+ * fixture's `payload` MUST fail validation (each one is a named red-line
+ * violation per the fixture pack's own README table).
+ */
+import { readFileSync, readdirSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+import {
+  parseAttendanceGroupEffectivePolicyEditorRefV1,
+  validateAttendanceGroupEffectivePolicyResponseV1,
+} from '../../src/attendance/w6-group-effective-policy-response-contract'
+
+const FIXTURE_DIR = join(__dirname, '../fixtures/attendance/w6')
+
+function readFixture(name: string): unknown {
+  return JSON.parse(readFileSync(join(FIXTURE_DIR, name), 'utf8'))
+}
+
+function loadFixtureNames(prefix: string): string[] {
+  return readdirSync(FIXTURE_DIR)
+    .filter((name) => name.startsWith(prefix) && name.endsWith('.json'))
+    .sort()
+}
+
+describe('W6 group effective-policy response contract validator', () => {
+  describe('aggregate-*.json fixtures MUST validate (W6-R7 byte-exact per fixture)', () => {
+    const names = loadFixtureNames('aggregate-')
+    it('discovered the full fixture set (guards against a silently-empty directory)', () => {
+      expect(names).toEqual([
+        'aggregate-conflict-fixed-schedule-changed.json',
+        'aggregate-conflict-membership-overlap.json',
+        'aggregate-effective-fixed-shift.json',
+        'aggregate-needs-configuration.json',
+        'aggregate-org-inherited-defaults.json',
+        'aggregate-preview-only-segments-flex.json',
+      ])
+    })
+
+    for (const name of names) {
+      it(`${name} validates`, () => {
+        const fixture = readFixture(name)
+        const result = validateAttendanceGroupEffectivePolicyResponseV1(fixture)
+        expect(result).toEqual({ ok: true })
+      })
+    }
+  })
+
+  describe('invalid-reject-*.json fixtures MUST fail validation (W6-R2/R6/R8 negatives)', () => {
+    const names = loadFixtureNames('invalid-reject-')
+    it('discovered the full negative fixture set', () => {
+      expect(names).toEqual([
+        'invalid-reject-member-leak.json',
+        'invalid-reject-open-editor-ref.json',
+        'invalid-reject-unknown-label.json',
+      ])
+    })
+
+    for (const name of names) {
+      it(`${name} payload is rejected`, () => {
+        const fixture = readFixture(name) as { payload: unknown }
+        const result = validateAttendanceGroupEffectivePolicyResponseV1(fixture.payload)
+        expect(result.ok).toBe(false)
+      })
+    }
+
+    it('invalid-reject-member-leak.json is rejected specifically for a values-free violation (not merely "domains empty")', () => {
+      const fixture = readFixture('invalid-reject-member-leak.json') as { payload: { data: Record<string, unknown> } }
+      // Strip the leak keys and the (also-invalid) empty `domains: {}` so the
+      // ONLY remaining defect this sub-case exercises is the top-level
+      // member-ID/user-ID leak — proving the validator catches THAT
+      // specifically, not just the incidentally-empty domains object.
+      const leakOnly = {
+        ok: true,
+        data: {
+          groupId: fixture.payload.data.groupId,
+          groupType: fixture.payload.data.groupType,
+          timezone: fixture.payload.data.timezone,
+          activeMemberCount: fixture.payload.data.activeMemberCount,
+          memberIds: fixture.payload.data.memberIds,
+          managerPosture: fixture.payload.data.managerPosture,
+          calculationPosture: fixture.payload.data.calculationPosture,
+          domains: {
+            membership: { label: 'effective', reasonCodes: [], editorRef: { kind: 'group_stage', stage: 'people' } },
+            schedule: {
+              label: 'effective',
+              strategy: 'fixed_shift',
+              reasonCodes: [],
+              fixedSchedule: null,
+              editorRef: { kind: 'group_context_route', step: 'schedule', surface: 'assignments' },
+            },
+            segments: { label: 'effective', reasonCodes: [], editorRef: { kind: 'group_context_route', step: 'schedule', surface: 'shifts' } },
+            flex: { label: 'effective', reasonCodes: [], editorRef: { kind: 'group_context_route', step: 'schedule', surface: 'shifts' } },
+            rules: { label: 'org_inherited', source: 'org_default', reasonCodes: [], editorRef: { kind: 'group_context_route', step: 'rules', surface: 'rule-sets' } },
+            punchMethod: { label: 'org_inherited', source: 'org_inherited', reasonCodes: [], editorRef: { kind: 'group_stage', stage: 'policies' } },
+            requestPosture: { label: 'org_inherited', overtime: 'org_inherited', makeupPunch: 'org_inherited', outdoor: 'org_inherited', reasonCodes: [], editorRef: { kind: 'group_stage', stage: 'policies' } },
+          },
+          conflicts: [],
+          evaluatedAt: fixture.payload.data.evaluatedAt,
+        },
+      }
+      const result = validateAttendanceGroupEffectivePolicyResponseV1(leakOnly)
+      expect(result).toEqual({ ok: false, reason: 'data: unexpected key set' })
+    })
+  })
+
+  describe('positive control: a minimally-valid response passes (proves the validator is not vacuously false-only)', () => {
+    it('accepts a hand-built, fully closed-shape response', () => {
+      const minimal = {
+        ok: true,
+        data: {
+          groupId: 'g1',
+          groupType: 'free_time',
+          timezone: 'UTC',
+          activeMemberCount: 0,
+          managerPosture: { ownerCount: 0, subOwnerCount: 0 },
+          calculationPosture: 'legacy',
+          domains: {
+            membership: { label: 'effective', reasonCodes: [], editorRef: { kind: 'group_stage', stage: 'people' } },
+            schedule: {
+              label: 'effective',
+              strategy: 'free_time',
+              reasonCodes: [],
+              sourceRefs: [],
+              fixedSchedule: null,
+              editorRef: { kind: 'group_context_route', step: 'schedule' },
+            },
+            segments: { label: 'effective', reasonCodes: [], sourceRefs: [], editorRef: { kind: 'group_context_route', step: 'schedule', surface: 'shifts' } },
+            flex: { label: 'effective', reasonCodes: [], editorRef: { kind: 'group_context_route', step: 'schedule', surface: 'shifts' } },
+            rules: { label: 'org_inherited', source: 'org_default', sourceRefs: [], reasonCodes: [], editorRef: { kind: 'group_context_route', step: 'rules', surface: 'rule-sets' } },
+            punchMethod: { label: 'org_inherited', source: 'org_inherited', reasonCodes: [], editorRef: { kind: 'group_stage', stage: 'policies' } },
+            requestPosture: { label: 'org_inherited', overtime: 'org_inherited', makeupPunch: 'org_inherited', outdoor: 'org_inherited', reasonCodes: [], editorRef: { kind: 'group_stage', stage: 'policies' } },
+          },
+          conflicts: [],
+          evaluatedAt: '2026-08-05T00:00:00.000Z',
+        },
+      }
+      expect(validateAttendanceGroupEffectivePolicyResponseV1(minimal)).toEqual({ ok: true })
+    })
+  })
+
+  describe('W6-R6 enum-strict negatives (one per enum field)', () => {
+    const base = {
+      ok: true,
+      data: {
+        groupId: 'g1',
+        groupType: 'free_time',
+        timezone: 'UTC',
+        activeMemberCount: 0,
+        managerPosture: { ownerCount: 0, subOwnerCount: 0 },
+        calculationPosture: 'legacy',
+        domains: {
+          membership: { label: 'effective', reasonCodes: [], editorRef: { kind: 'group_stage', stage: 'people' } },
+          schedule: {
+            label: 'effective',
+            strategy: 'free_time',
+            reasonCodes: [],
+            fixedSchedule: null,
+            editorRef: { kind: 'group_context_route', step: 'schedule' },
+          },
+          segments: { label: 'effective', reasonCodes: [], editorRef: { kind: 'group_context_route', step: 'schedule', surface: 'shifts' } },
+          flex: { label: 'effective', reasonCodes: [], editorRef: { kind: 'group_context_route', step: 'schedule', surface: 'shifts' } },
+          rules: { label: 'org_inherited', source: 'org_default', reasonCodes: [], editorRef: { kind: 'group_context_route', step: 'rules', surface: 'rule-sets' } },
+          punchMethod: { label: 'org_inherited', source: 'org_inherited', reasonCodes: [], editorRef: { kind: 'group_stage', stage: 'policies' } },
+          requestPosture: { label: 'org_inherited', overtime: 'org_inherited', makeupPunch: 'org_inherited', outdoor: 'org_inherited', reasonCodes: [], editorRef: { kind: 'group_stage', stage: 'policies' } },
+        },
+        conflicts: [],
+        evaluatedAt: '2026-08-05T00:00:00.000Z',
+      },
+    }
+
+    function withData(patch: Record<string, unknown>) {
+      return { ok: true, data: { ...base.data, ...patch } }
+    }
+
+    it('rejects an unknown groupType', () => {
+      expect(validateAttendanceGroupEffectivePolicyResponseV1(withData({ groupType: 'nonexistent_type' })).ok).toBe(false)
+    })
+    it('rejects an unknown calculationPosture', () => {
+      expect(validateAttendanceGroupEffectivePolicyResponseV1(withData({ calculationPosture: 'partially_enabled' })).ok).toBe(false)
+    })
+    it('rejects an unknown domains.membership.label', () => {
+      const patched = structuredClone(base)
+      ;(patched.data.domains.membership as { label: string }).label = 'mostly_effective'
+      expect(validateAttendanceGroupEffectivePolicyResponseV1(patched).ok).toBe(false)
+    })
+    it('rejects an unknown domains.flex.mode', () => {
+      const patched = structuredClone(base)
+      ;(patched.data.domains.flex as Record<string, unknown>).mode = 'lenient'
+      expect(validateAttendanceGroupEffectivePolicyResponseV1(patched).ok).toBe(false)
+    })
+    it('rejects an unknown domains.rules.source', () => {
+      const patched = structuredClone(base)
+      ;(patched.data.domains.rules as Record<string, unknown>).source = 'inherited_elsewhere'
+      expect(validateAttendanceGroupEffectivePolicyResponseV1(patched).ok).toBe(false)
+    })
+    it('rejects an unknown conflicts[].code', () => {
+      const patched = structuredClone(base)
+      patched.data.conflicts = [
+        { code: 'NOT_A_REAL_CODE', domain: 'membership', label: 'conflict_action_required', editorRef: { kind: 'group_stage', stage: 'people' } },
+      ]
+      expect(validateAttendanceGroupEffectivePolicyResponseV1(patched).ok).toBe(false)
+    })
+    it('rejects an unknown conflicts[].domain', () => {
+      const patched = structuredClone(base)
+      patched.data.conflicts = [
+        { code: 'TIMEZONE_MISSING', domain: 'not_a_real_domain', label: 'conflict_action_required', editorRef: { kind: 'group_stage', stage: 'basics' } },
+      ]
+      expect(validateAttendanceGroupEffectivePolicyResponseV1(patched).ok).toBe(false)
+    })
+  })
+
+  describe('editorRef closed-table parser (W6-R8)', () => {
+    it('accepts every group_stage value', () => {
+      for (const stage of ['basics', 'people', 'schedule', 'policies']) {
+        expect(parseAttendanceGroupEffectivePolicyEditorRefV1({ kind: 'group_stage', stage })).toEqual({ kind: 'group_stage', stage })
+      }
+    })
+    it('accepts every schedule surface', () => {
+      for (const surface of ['shifts', 'assignments', 'advanced-scheduling']) {
+        expect(parseAttendanceGroupEffectivePolicyEditorRefV1({ kind: 'group_context_route', step: 'schedule', surface })).toEqual({
+          kind: 'group_context_route',
+          step: 'schedule',
+          surface,
+        })
+      }
+    })
+    it('accepts schedule with no surface', () => {
+      expect(parseAttendanceGroupEffectivePolicyEditorRefV1({ kind: 'group_context_route', step: 'schedule' })).toEqual({
+        kind: 'group_context_route',
+        step: 'schedule',
+      })
+    })
+    it('accepts calendar with no surface key at all', () => {
+      expect(parseAttendanceGroupEffectivePolicyEditorRefV1({ kind: 'group_context_route', step: 'calendar' })).toEqual({
+        kind: 'group_context_route',
+        step: 'calendar',
+      })
+    })
+    it('rejects calendar carrying a surface key (calendar has no surface table)', () => {
+      expect(parseAttendanceGroupEffectivePolicyEditorRefV1({ kind: 'group_context_route', step: 'calendar', surface: 'shifts' })).toBeNull()
+    })
+    it('accepts rules with rule-sets surface', () => {
+      expect(parseAttendanceGroupEffectivePolicyEditorRefV1({ kind: 'group_context_route', step: 'rules', surface: 'rule-sets' })).toEqual({
+        kind: 'group_context_route',
+        step: 'rules',
+        surface: 'rule-sets',
+      })
+    })
+    it('rejects an out-of-table surface for schedule', () => {
+      expect(parseAttendanceGroupEffectivePolicyEditorRefV1({ kind: 'group_context_route', step: 'schedule', surface: 'payroll' })).toBeNull()
+    })
+    it('rejects an out-of-table step', () => {
+      expect(parseAttendanceGroupEffectivePolicyEditorRefV1({ kind: 'group_context_route', step: 'payroll' })).toBeNull()
+    })
+    it('rejects an unknown kind (admin_section — the fixture-pinned attack shape)', () => {
+      expect(parseAttendanceGroupEffectivePolicyEditorRefV1({ kind: 'admin_section', section: 'attendance-admin-payroll' })).toBeNull()
+    })
+    it('rejects a caller-supplied extra key alongside a valid kind/stage pair', () => {
+      expect(parseAttendanceGroupEffectivePolicyEditorRefV1({ kind: 'group_stage', stage: 'people', section: 'evil' })).toBeNull()
+    })
+  })
+})

--- a/packages/core-backend/tests/unit/attendance-w6-group-effective-policy-response-contract.test.ts
+++ b/packages/core-backend/tests/unit/attendance-w6-group-effective-policy-response-contract.test.ts
@@ -216,6 +216,38 @@ describe('W6 group effective-policy response contract validator', () => {
       ]
       expect(validateAttendanceGroupEffectivePolicyResponseV1(patched).ok).toBe(false)
     })
+
+    // #4814 P2-2: reasonCodes was checked only with isStringArray (any
+    // array of strings), not against a closed list — §4.2 requires it
+    // closed end to end, same as every other enum field above.
+    it('rejects a made-up domains.*.reasonCodes value (not FSER-sourced, not W6-authored)', () => {
+      const patched = structuredClone(base)
+      ;(patched.data.domains.membership as Record<string, unknown>).reasonCodes = ['NOT_A_REAL_REASON_CODE']
+      expect(validateAttendanceGroupEffectivePolicyResponseV1(patched)).toEqual({
+        ok: false,
+        reason: 'domains.membership.reasonCodes: not a closed-set string array',
+      })
+    })
+    it('rejects a raw UUID smuggled into domains.*.reasonCodes (values-free judge does not stand in for enum closure)', () => {
+      const patched = structuredClone(base)
+      ;(patched.data.domains.membership as Record<string, unknown>).reasonCodes = ['3f7a1c2e-0000-4000-8000-000000000001']
+      expect(validateAttendanceGroupEffectivePolicyResponseV1(patched)).toEqual({
+        ok: false,
+        reason: 'domains.membership.reasonCodes: not a closed-set string array',
+      })
+    })
+    it('rejects a made-up fixedSchedule.reasonCodes value (must be FSER\'s own closed list, §4.2)', () => {
+      const fixture = readFixture('aggregate-effective-fixed-shift.json') as {
+        ok: true
+        data: { domains: { schedule: { fixedSchedule: { reasonCodes: string[] } } } }
+      }
+      const patched = structuredClone(fixture)
+      patched.data.domains.schedule.fixedSchedule.reasonCodes = ['MADE_UP_FSER_REASON']
+      expect(validateAttendanceGroupEffectivePolicyResponseV1(patched)).toEqual({
+        ok: false,
+        reason: 'fixedSchedule.reasonCodes: not a closed-set string array',
+      })
+    })
   })
 
   describe('editorRef closed-table parser (W6-R8)', () => {

--- a/packages/core-backend/tests/unit/attendance-w6-import-graph-no-calculation-consumer.test.ts
+++ b/packages/core-backend/tests/unit/attendance-w6-import-graph-no-calculation-consumer.test.ts
@@ -12,6 +12,12 @@
  * are new); this test exists to catch a FUTURE regression, not to prove
  * anything about the present.
  *
+ * #4814 P3-3: the original prefix list excluded `plugins/plugin-attendance/
+ * index.cjs` (the 41.5k-line file that owns most attendance calculation
+ * writes -- exactly where this line's runtime has historically been wired)
+ * and `packages/core-backend/src/services/`. A W7 consumer wired in either
+ * place would have escaped this gate entirely. Both are now in scope.
+ *
  * Governing document:
  *   docs/development/attendance-issue-4556-w6-group-effective-policy-design-lock-20260805.md
  */
@@ -28,14 +34,19 @@ const TARGET_EXTENSIONS = new Set(['.ts', '.tsx', '.js', '.cjs', '.mjs'])
 // The calculation write-path source trees: W4/W4C durable-storage,
 // rollout-control, scheduled-run, and record-effects modules (the ONLY
 // places that write attendance_records/attendance_record_calculations/
-// attendance_calculation_rollout_state), plus the canonical shift/segment
-// calculation service. W6-1's own files are intentionally NOT in this list
-// (they are the thing being scanned FOR, not scanned).
+// attendance_calculation_rollout_state), the canonical shift/segment
+// calculation service, the plugin's main entry file (the historical home
+// of most attendance calculation wiring), and every core-backend service
+// module (where a W7 consumer could equally be wired). W6-1's own files
+// are intentionally NOT in this list (they are the thing being scanned
+// FOR, not scanned).
 const CALCULATION_PATH_PREFIXES = [
   'packages/core-backend/src/attendance/',
+  'packages/core-backend/src/services/',
   'plugins/plugin-attendance/lib/attendance-shift-service.cjs',
   'plugins/plugin-attendance/lib/attendance-work-date-resolver.cjs',
   'plugins/plugin-attendance/lib/attendance-work-date-adapters.cjs',
+  'plugins/plugin-attendance/index.cjs',
 ]
 
 const W6_MODULE_MARKERS = ['w6-group-effective-policy-aggregate', 'w6-group-effective-policy-response-contract']
@@ -64,6 +75,24 @@ function isCalculationPathFile(relative: string): boolean {
   )
 }
 
+/** Same idiom as `attendance-w6-fser-single-source-caller-inventory.test.ts`'s
+ * `findOffenders`: runs the REAL classifier + REAL marker scan against an
+ * explicit file list, so a positive control can exercise this exact
+ * function (not a re-typed copy of its predicates) against a file that was
+ * never `git add`ed. */
+function findOffenders(rootDir: string, absoluteFiles: readonly string[]): Array<{ file: string; marker: string }> {
+  const offenders: Array<{ file: string; marker: string }> = []
+  for (const absolute of absoluteFiles) {
+    const relative = path.relative(rootDir, absolute).split(path.sep).join('/')
+    if (!isCalculationPathFile(relative)) continue
+    const content = fs.readFileSync(absolute, 'utf8')
+    for (const marker of W6_MODULE_MARKERS) {
+      if (content.includes(marker)) offenders.push({ file: relative, marker })
+    }
+  }
+  return offenders
+}
+
 describe('W6-R5 repository inventory: no calculation-path file imports the W6 aggregate', () => {
   it('zero calculation-write-path files reference either W6-1 module', () => {
     const relativeFiles = listGitTrackedFiles(ROOT)
@@ -72,26 +101,60 @@ describe('W6-R5 repository inventory: no calculation-path file imports the W6 ag
     const calculationFiles = relativeFiles.filter(isCalculationPathFile)
     expect(calculationFiles.length).toBeGreaterThan(5) // sanity: the calculation path itself is non-trivially sized
 
-    const offenders: Array<{ file: string; marker: string }> = []
-    for (const relative of calculationFiles) {
-      const content = fs.readFileSync(path.join(ROOT, relative), 'utf8')
-      for (const marker of W6_MODULE_MARKERS) {
-        if (content.includes(marker)) offenders.push({ file: relative, marker })
-      }
-    }
+    const offenders = findOffenders(
+      ROOT,
+      calculationFiles.map((relative) => path.join(ROOT, relative)),
+    )
     expect(offenders).toEqual([])
   })
 
-  it('positive control: the detector DOES catch a decoy calculation-path file that imports W6', () => {
-    const scratchPath = path.join(ROOT, 'packages/core-backend/src/attendance/zz-w6r5-decoy-scratch.ts')
-    fs.writeFileSync(scratchPath, "import { createAttendanceGroupEffectivePolicyAggregateService } from './w6-group-effective-policy-aggregate'\n")
+  it('#4814 P3-3: the widened prefixes are actually in scope (index.cjs and src/services/, not just src/attendance/)', () => {
+    expect(isCalculationPathFile('plugins/plugin-attendance/index.cjs')).toBe(true)
+    expect(isCalculationPathFile('packages/core-backend/src/services/AnyCalculationConsumer.ts')).toBe(true)
+    // sanity: an out-of-scope file (this test's own directory tree, outside
+    // the prefixes above) is NOT swept -- proves the classifier is not
+    // vacuously true.
+    expect(isCalculationPathFile('packages/core-backend/tests/unit/some-unrelated-file.ts')).toBe(false)
+  })
+
+  it('positive control: a decoy under the NEW src/services/ prefix that imports W6 is caught', () => {
+    const scratchPath = path.join(ROOT, 'packages/core-backend/src/services/zz-w6r5-decoy-services-scratch.ts')
+    fs.writeFileSync(scratchPath, "import { createAttendanceGroupEffectivePolicyAggregateService } from '../attendance/w6-group-effective-policy-aggregate'\n")
     try {
-      const relative = 'packages/core-backend/src/attendance/zz-w6r5-decoy-scratch.ts'
-      expect(isCalculationPathFile(relative)).toBe(true)
-      const content = fs.readFileSync(scratchPath, 'utf8')
-      expect(W6_MODULE_MARKERS.some((marker) => content.includes(marker))).toBe(true)
+      const relative = 'packages/core-backend/src/services/zz-w6r5-decoy-services-scratch.ts'
+      const files = listGitTrackedFiles(ROOT) // untracked scratch file — proves the git-tracked-only scope too
+      expect(files.includes(relative)).toBe(false)
+      // Directly exercise findOffenders (the REAL detector, not a re-typed
+      // predicate copy) against the untracked file.
+      const offenders = findOffenders(ROOT, [scratchPath])
+      expect(offenders).toEqual([{ file: relative, marker: 'w6-group-effective-policy-aggregate' }])
     } finally {
       fs.unlinkSync(scratchPath)
     }
   })
+
+  it('positive control: a decoy under the (pre-existing) src/attendance/ prefix that imports W6 is caught', () => {
+    const scratchPath = path.join(ROOT, 'packages/core-backend/src/attendance/zz-w6r5-decoy-scratch.ts')
+    fs.writeFileSync(scratchPath, "import { createAttendanceGroupEffectivePolicyAggregateService } from './w6-group-effective-policy-aggregate'\n")
+    try {
+      const relative = 'packages/core-backend/src/attendance/zz-w6r5-decoy-scratch.ts'
+      const files = listGitTrackedFiles(ROOT)
+      expect(files.includes(relative)).toBe(false)
+      const offenders = findOffenders(ROOT, [scratchPath])
+      expect(offenders).toEqual([{ file: relative, marker: 'w6-group-effective-policy-aggregate' }])
+    } finally {
+      fs.unlinkSync(scratchPath)
+    }
+  })
+
+  // `plugins/plugin-attendance/index.cjs` is matched by an EXACT-path rule
+  // (single real 41.5k-line production file, not a directory prefix) — a
+  // decoy cannot safely fabricate content there the way the two directory-
+  // prefix decoys above do. Its coverage is therefore split into two
+  // independently-proven halves: (1) the "in scope" assertion above proves
+  // `isCalculationPathFile` classifies this EXACT path as a calculation-
+  // path file: (2) the two decoys above prove `findOffenders`'s
+  // marker-scan fires for any file `isCalculationPathFile` accepts. A file
+  // that is in scope, scanned by a scanner proven to fire on in-scope
+  // matches, is covered without touching the real file's content.
 })

--- a/packages/core-backend/tests/unit/attendance-w6-import-graph-no-calculation-consumer.test.ts
+++ b/packages/core-backend/tests/unit/attendance-w6-import-graph-no-calculation-consumer.test.ts
@@ -1,0 +1,97 @@
+/**
+ * W6-R5 (#4556) — no calculation writer consumes the W6 aggregate. The
+ * aggregate is a read layer; winner selection, policy precedence, and any
+ * calculation-chain consumption of group policy remain W7 (design lock §0,
+ * §2.3; parent lock §9.8).
+ *
+ * Mechanical proof: a repository-wide, git-tracked-only scan (same idiom as
+ * `w4c3a-rollout-control-inventory.test.ts` /
+ * `attendance-w6-fser-single-source-caller-inventory.test.ts`) asserts that
+ * NOTHING under the known calculation-write-path source trees imports or
+ * requires either W6-1 module. Today that is trivially true (the modules
+ * are new); this test exists to catch a FUTURE regression, not to prove
+ * anything about the present.
+ *
+ * Governing document:
+ *   docs/development/attendance-issue-4556-w6-group-effective-policy-design-lock-20260805.md
+ */
+import { execFileSync } from 'node:child_process'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../../')
+const EXCLUDED_DIR_SEGMENTS = new Set(['node_modules', 'dist', 'build', '.git', '.turbo', 'coverage', '.claude'])
+const TARGET_EXTENSIONS = new Set(['.ts', '.tsx', '.js', '.cjs', '.mjs'])
+
+// The calculation write-path source trees: W4/W4C durable-storage,
+// rollout-control, scheduled-run, and record-effects modules (the ONLY
+// places that write attendance_records/attendance_record_calculations/
+// attendance_calculation_rollout_state), plus the canonical shift/segment
+// calculation service. W6-1's own files are intentionally NOT in this list
+// (they are the thing being scanned FOR, not scanned).
+const CALCULATION_PATH_PREFIXES = [
+  'packages/core-backend/src/attendance/',
+  'plugins/plugin-attendance/lib/attendance-shift-service.cjs',
+  'plugins/plugin-attendance/lib/attendance-work-date-resolver.cjs',
+  'plugins/plugin-attendance/lib/attendance-work-date-adapters.cjs',
+]
+
+const W6_MODULE_MARKERS = ['w6-group-effective-policy-aggregate', 'w6-group-effective-policy-response-contract']
+
+function listGitTrackedFiles(rootDir: string): string[] {
+  const raw = execFileSync('git', ['ls-files', '-z', '--cached'], { cwd: rootDir, maxBuffer: 64 * 1024 * 1024 })
+  return raw
+    .toString('utf8')
+    .split('\0')
+    .filter((relative) => relative.length > 0)
+    .filter((relative) => TARGET_EXTENSIONS.has(path.extname(relative)))
+    .filter((relative) => !relative.split('/').some((segment) => EXCLUDED_DIR_SEGMENTS.has(segment)))
+}
+
+function isCalculationPathFile(relative: string): boolean {
+  if (relative.includes('__tests__') || relative.includes('/tests/')) return false // tests are allowed to reference W6 as a test subject
+  // W6-1's OWN two files live in the same directory as the calculation-path
+  // modules; they are the thing being scanned FOR (they naturally
+  // cross-reference each other's names in doc comments and imports), not a
+  // calculation-path consumer of themselves.
+  if (relative.endsWith('/w6-group-effective-policy-aggregate.ts') || relative.endsWith('/w6-group-effective-policy-response-contract.ts')) {
+    return false
+  }
+  return CALCULATION_PATH_PREFIXES.some((prefix) =>
+    prefix.endsWith('.cjs') ? relative === prefix : relative.startsWith(prefix),
+  )
+}
+
+describe('W6-R5 repository inventory: no calculation-path file imports the W6 aggregate', () => {
+  it('zero calculation-write-path files reference either W6-1 module', () => {
+    const relativeFiles = listGitTrackedFiles(ROOT)
+    expect(relativeFiles.length).toBeGreaterThan(100)
+
+    const calculationFiles = relativeFiles.filter(isCalculationPathFile)
+    expect(calculationFiles.length).toBeGreaterThan(5) // sanity: the calculation path itself is non-trivially sized
+
+    const offenders: Array<{ file: string; marker: string }> = []
+    for (const relative of calculationFiles) {
+      const content = fs.readFileSync(path.join(ROOT, relative), 'utf8')
+      for (const marker of W6_MODULE_MARKERS) {
+        if (content.includes(marker)) offenders.push({ file: relative, marker })
+      }
+    }
+    expect(offenders).toEqual([])
+  })
+
+  it('positive control: the detector DOES catch a decoy calculation-path file that imports W6', () => {
+    const scratchPath = path.join(ROOT, 'packages/core-backend/src/attendance/zz-w6r5-decoy-scratch.ts')
+    fs.writeFileSync(scratchPath, "import { createAttendanceGroupEffectivePolicyAggregateService } from './w6-group-effective-policy-aggregate'\n")
+    try {
+      const relative = 'packages/core-backend/src/attendance/zz-w6r5-decoy-scratch.ts'
+      expect(isCalculationPathFile(relative)).toBe(true)
+      const content = fs.readFileSync(scratchPath, 'utf8')
+      expect(W6_MODULE_MARKERS.some((marker) => content.includes(marker))).toBe(true)
+    } finally {
+      fs.unlinkSync(scratchPath)
+    }
+  })
+})

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -696,6 +696,15 @@ export default defineConfig({
       // #4556 W5 flex persistence and canonical writer proof requires real PostgreSQL;
       // the whole file is explicitly run in plugin-tests.yml.
       'tests/integration/attendance-shift-flex-policy-migration.db.test.ts',
+      // #4556 W6-1 group effective-policy aggregate route: real Postgres via the shared
+      // metasheet_test database (R1/R3/R4 legs). Excluded here so describeIfDatabase cannot
+      // skip-green it; plugin-tests.yml runs the whole file with ATTENDANCE_TEST_DATABASE_URL.
+      'tests/integration/attendance-w6-group-effective-policy.db.test.ts',
+      // #4556 W6-1 membership-overlap counter (R5): a DEDICATED ephemeral database (not
+      // metasheet_test) because seeding a genuine overlap requires temporarily dropping
+      // attendance_calc_group_memberships_no_overlap. Excluded here for the same skip-green
+      // reason; plugin-tests.yml runs the whole file.
+      'tests/integration/attendance-w6-group-effective-policy-membership-overlap.db.test.ts',
       // #4556 W2 adds route-level work-date attribution legs to this whole-file real-DB
       // suite. Keep it out of the no-DB lane so describeDb cannot report skipped green;
       // plugin-tests.yml executes the complete file with ATTENDANCE_TEST_DATABASE_URL.

--- a/plugins/plugin-integration-core/lib/sealed-export/vectors/s6a-package-provenance-pins.json
+++ b/plugins/plugin-integration-core/lib/sealed-export/vectors/s6a-package-provenance-pins.json
@@ -86,6 +86,6 @@
     "s6aAcceptancePs51Test": "835c7c6ce943d82e0378a40a27c7fd1e8b79b526faa8ca4c8066e4231a4bfb0f",
     "s6aProductRuntimeTest": "de978adafa8b89772cefa921c2051f434bf346bf5c2978bef3424ee70f51ba3f",
     "multitableOnpremPackageBuild": "463c7d73c6c7f2d1b6cdf0820d7a06974a9c463dd5e98bbbaf1c996e1dc4ed99",
-    "pluginTestsWorkflow": "e86884d5366ea4cfb0291c671e399b3746f028ff0962b6495c18916f6b73159f"
+    "pluginTestsWorkflow": "072fe472bc5df90624b5a00b12a7791dd7c481d0cc0d52701177bf3cb84d4cc8"
   }
 }


### PR DESCRIPTION
## [HOLD] — Draft only. No merge, no flag flips, no staging.

**Slice**: W6-1 — group effective-policy READ aggregate backend (attendance #4556).

**Authority**: the owner RATIFIED the W6 design lock at exact SHA
`2967da018ceea41b91098e14d4c15a57236eb5f8`
(`docs/development/attendance-issue-4556-w6-group-effective-policy-design-lock-20260805.md`),
with **OD-W6-0 = 采纳 (adopt)** and **OD-W6-1..9 = all option (a)**. Authorized: W6-1 backend
aggregate only, Draft/HOLD, stop after a fresh exact-head gate. NOT authorized: W6-2 contract
wiring, W6-3 UI, W6-4 verification, staging, flags, soak, deployment, refs 4556 closure.

This PR implements §4 of the design lock (aggregate read-model contract) under the §3 red
lines (W6-R1..R9), reusing the W6-0 prep types/contract/fixtures from #4771
(`packages/core-backend/src/attendance/w6-group-effective-policy-contract.ts` and
`packages/core-backend/tests/fixtures/attendance/w6/`) rather than minting a second contract.

## Adversarial gate round 1 — findings fixed (this revision)

An independent adversarial gate against the prior head (`f2db0cc27`) returned
CHANGES-REQUESTED: 1 P1 (production boot crash), 4 P2, 5 P3, 4 NIT. Full report retained
separately; every finding is addressed below, retraction-first where the prior body overclaimed.
**This is a NEW head — the prior gate's verdict does not carry forward; a fresh gate is required
before this can move off HOLD.**

### P1 — compiled build could not resolve the module-scope plugin `require()` (production boot crash)

`tsconfig.json`'s `rootDir: "."` emits to `dist/src/routes/` — one directory DEEPER than
`src/routes/` — so the hard-coded `require('../../../../plugins/plugin-attendance/lib/...')`
in `attendance-admin.ts` was correct only from the source tree and pointed at a nonexistent
`/app/packages/plugins/...` once compiled. `src/index.ts` imports this router statically at
module scope, so the wrong path threw during module init and would have crash-looped the
backend on the first boot after deploy.

Fix: `packages/core-backend/src/util/resolve-plugin-attendance-lib.ts` — a new module that walks
upward from the caller's `__dirname` for the first ancestor containing
`plugins/plugin-attendance/lib/`, so the same source resolves from both the src tree and the
dist tree without a hard-coded depth. `attendance-admin.ts` now calls
`requirePluginAttendanceLib(__dirname, ...)` instead of the literal `require()`.

Proof: a real `tsc -p tsconfig.json` build laid out exactly like the production image
(`Dockerfile.backend`: `WORKDIR /app`, `dist/src/routes/` next to a sibling `/app/plugins/`) —
pre-fix, `require()`ing the real compiled router throws `MODULE_NOT_FOUND`; post-fix, it resolves
and returns `attendanceAdminRouter`. New regression test
`tests/unit/attendance-admin-plugin-lib-dist-layout-boot.test.ts` runs the real build, lays out
the real production dist layout, and `require()`s the real compiled router from a subprocess (so
its DB-pool/message-bus module-scope side effects never leak into the test worker) — verified RED
against the pre-fix source, GREEN against the fix. It is not excluded from `vitest.config.ts` and
needs no `DATABASE_URL`, so it runs in the default no-DB unit lane with no extra CI wiring.

### P2-1 — R6's lock-named silent-fallback mutation was untested; PR body overclaimed R6 coverage

**Retraction**: the prior body's R6 row cited the `hasClosedKeys` mutation as R6 evidence. That
mutation exercises the response validator's SHAPE gate, a different module and failure class from
the service's internal fail-closed enum derivation. The lock's actual named mutation (unknown FSER
state → silent `needs_configuration`) was never run and was green.

Fix: five negative unit cases in `attendance-w6-group-effective-policy-aggregate.test.ts`, each the
minimal valid "effective fixed_shift" shape with exactly one field flipped to an out-of-enum value,
asserting the specific `{status, code}`: `FSER_STATE_UNRECOGNIZED`, `GROUP_TYPE_UNRECOGNIZED`,
`MANAGER_ROLE_UNRECOGNIZED`, `ROLLOUT_STATE_UNRECOGNIZED`, and a new fifth guard,
`FLEX_MODE_UNRECOGNIZED` (P3-4 below — `flex_mode` was the one enum read that silently fell back
to `'strict'`, now symmetric with the other four). All five mutation-tested RED individually.

### P2-2 — `reasonCodes` was not a closed enum anywhere

Fix: `ATTENDANCE_GROUP_EFFECTIVE_POLICY_REASON_CODES_V1` in the contract module — FSER's own
`REASON_ORDER`, IMPORTED (not hand-copied) via the new `requirePluginAttendanceLib`, unioned with
the four W6-authored domain reason codes. Both `domains.*.reasonCodes` and
`fixedSchedule.reasonCodes` now validate against it. Three invalid-value negatives added (a made-up
domain code, a raw UUID smuggled into `reasonCodes`, a made-up FSER code), each mutation-tested RED.

### P2-3 — R1's DML sweep didn't cover the route handler; behavioral leg was blind to in-place UPDATE

**Retraction**: the prior body's R1 row described the sweep scope as the two service files only,
and the behavioral leg as row counts. Both were real gaps: a raw `UPDATE` injected in the route
handler passed every gate.

Fix, both halves: (a) the static sweep now also covers the route handler, extracted from
`attendance-admin.ts` by anchoring on the ROUTE'S OWN PATH STRING and a balanced-paren scan from
the enclosing `r.get(...)` — not a hand-picked line range, since the file is 41.5k-line-class and
whole-file sweep would flag legitimate writes elsewhere. (b) the real-DB behavioral leg
(`attendance-w6-group-effective-policy.db.test.ts`) now snapshots both row COUNT and `MAX(xmin)`
(Postgres's per-row transaction-id column, which changes on any UPDATE even when count and values
are unchanged) per touched table. A raw `UPDATE ... SET updated_at = now()` injected before
`getAggregate` now reds both legs; previously it passed both.

### P2-4 — OD-W6-8(a) "bounded per-group" test asserted `toBe(2)` under a title claiming "reports 0", and proved nothing

**Retraction**: the prior body's R5 row claimed "a second group in the same org independently
reports 2, proving the query is per-group not per-org." False — both seeded groups held the SAME
two overlapping members, so per-group and per-org scoping were indistinguishable by that fixture.

Fix: added a third group (`boundedGroupId`) seeded with an independent member holding exactly one
effective-today membership total (zero org-wide overlap, disjoint from the other two groups'
overlapping pair). A genuinely per-group query reports 0 for it; a per-org (or
group-filter-dropped) query would report 2. This divergence is what actually discriminates the two
hypotheses — mutation-tested RED (neutering `AND m.group_id = $2` to `OR TRUE` now reds exactly
this case). The old test is renamed to describe what it actually proves (a consistency check, not
boundedness).

### P3-2(a) — OD-W6-6's authoritative-and-implemented branch was untested

Fixed: two new cases, built single-segment-strict FALSE (3 segments, `flex_required_duration`) so
`effective` can only be reached via the `authoritative && segmentCalculationImplemented` disjunct,
isolating it from the already-covered single-segment-strict path. Mutation-tested RED.

**P3-2(b) deferred, not decided here**: `profile.segmentCount <= 1` treats a 0-segment shift as
"single-segment strict" → `effective`; the lock's literal wording is "a single-segment `strict`
shift." Changing this threshold changes real read-surface output for any 0-segment shift — design
discretion this implementation lane does not own, and it is not established whether a 0-segment
shift is reachable post the `attendance_shift_segments` migration without further schema/writer
investigation. Left for the owner at W6-4; no test was added asserting either reading (pinning the
current behavior would itself be a decision).

### P3-3 — R5's import-graph gate excluded `plugin-attendance/index.cjs` and `src/services/`

Fixed: both added to `CALCULATION_PATH_PREFIXES`; verified zero offenders today. Positive control
switched from re-checking predicates inline to the `findOffenders(ROOT, [scratchPath])` idiom
(same as the R4 FSER-caller inventory), which exercises the real detector function. `src/services/`
gets a live decoy; `plugins/plugin-attendance/index.cjs` is an exact-path single-file match (can't
safely fabricate content in the real 41.5k-line file), so its coverage is a direct
`isCalculationPathFile(...) === true` classification assertion combined with the decoys proving the
marker-scan fires for anything the classifier accepts — documented in the test as not the same
strength as a live decoy, not overclaimed as one.

### P3-4 — `flex_mode` silent fallback

Folded into P2-1 above: now a fifth fail-closed guard (`FLEX_MODE_UNRECOGNIZED`), symmetric with
the other four.

### P3-5 — producer-key builder: a third independent copy in the fidelity test

Fixed: the R4 fidelity test now imports `buildFixedScheduleProducerKey` from the module under test
instead of reimplementing the join logic a third time inline. Verified the real-DB fidelity test
still passes with the imported function.

**Follow-up self-review, before this could be called done**: importing the same function into both
sides of the fidelity comparison means a bug in it could in principle cancel out in the
`toStrictEqual`. Checked directly: mutated the join separator (`':'` → `'|'`) and re-ran the real-DB
suite against a fresh migrated scratch Postgres — the happy-path fidelity test STILL reds (FSER
matches seeded fixed-schedule rows by producer key; a format change breaks that match independently
of the `toStrictEqual` mechanism, state flips `effective` → `configuration_changed`). P3-5 is a net
improvement with no regression, via a mechanism the original gate reasoning didn't anticipate.
Restored via `cp`.

Also found and fixed while re-reading the surrounding doc comment: it claimed a "parity test
('producer key parity')" existed proving the equivalence argument — no such test existed (an
asserted invariant with no backing test). Added it: a literal pin of `buildFixedScheduleProducerKey`'s
exact output format (prefix, field order, separator, null-handling), which reds directly on a format
change rather than only indirectly via DB seed-matching. Mutation-tested RED on the same separator
mutation. Doc comment corrected to describe both proofs accurately instead of overclaiming a
canonical-builder re-proof that isn't possible without loading `index.cjs`'s full activation surface.

**Not done, reported not bulk-allowlisted**: adding the canonical builder's name to the R4
inventory's `FSER_REFERENCE_PATTERNS`. Checked first — this pattern also matches two PRE-EXISTING,
W6-unrelated tests (`attendance-group-fixed-schedule-config-consume.test.ts`,
`attendance-scheduling-assignment-conflict.test.ts`) that legitimately exercise the same shared
pure helper for their own FSER consumers. R4 polices "the FSER STATE DERIVATION has exactly one
caller set"; widening its pattern to this widely-shared helper would force allowlisting unrelated
files, diluting rather than sharpening what the gate polices.

**Second self-review catch, this head**: the doc comment above `buildFixedScheduleProducerKey`
additionally claimed the real-DB fidelity test's DB *seed* (`…db.test.ts` ~L192, the fixed-schedule
`producer_key` written into `attendance_shift_assignments`) was "computed with THIS function." It
isn't — that seed is a fourth, hand-written literal of the same join format, never calling the
function; only the *other* side of the fidelity comparison (line 439, FSER's injected
`buildAttendanceGroupFixedScheduleProducerKey` dependency) was actually switched to the imported
function above. The seed's independence is exactly why the separator-mutation self-check above
reds: the DB row stays seeded under the OLD separator while the route's live computation (which
calls the mutated function) no longer matches it. Fixed the doc comment to describe this correctly,
and added a "do not refactor to call the builder" comment at the seed site itself so a future DRY
pass doesn't quietly delete that DB-level discrimination. No behavioral change; comment text only
plus one added comment in a test file. `tsc --noEmit` clean on both files; the aggregate unit suite
(15/15, including the producer-key parity pin) still green.

### Disclosure: W6-R9's factual basis changed (found in self-review, not a gate line item)

The gate recorded W6-R9 as N-A, evidence "prep files untouched by this diff except by import." The
P2-2 commit adds `requirePluginAttendanceLib(__dirname, ...)` — a real filesystem-touching
`require()` at module-scope import time — to `w6-group-effective-policy-contract.ts`, whose own
header still claimed "Nothing at runtime imports this module in W6-0." That header sentence was
already stale before this PR (the aggregate and response-contract modules already import its
TYPES/constants at runtime), but the new `require()` is qualitatively different (a side-effecting
call, not a type import), and a gate reading "prep files untouched" against a diff that modifies
this file would treat it as undisclosed. Fixed the header to state plainly that W6-1 already uses
this file at runtime, that this authorizes no new BEHAVIOR beyond W6-1's own red lines, and that the
new `require()` is a deliberate placement alongside the other closed enums already imported here —
not silent prep-file drift. No functional change.

### P3-1 — fixture-vs-seeded-rows deviation: unchanged, still an owner escalation (see "Flagged rather than decided" #1 below)

### NIT-1 — PR body understated R7 evidence

**Retraction**: the prior body's R7 row said "a dedicated guard-removal mutation was not
separately run." Re-run this revision: removing the query-param rejection reds exactly the
`QUERY_NOT_ACCEPTED` test (`expected 200 to be 400`); removing the body rejection reds exactly the
`BODY_NOT_ACCEPTED` test. Both fire before any SQL.

### NIT-2 — overlap test title contradicted its assertion

Fixed as part of P2-4 above (test renamed).

### NIT-3 — `managedSets[]` values were untyped

Fixed: `rowCount`/`producerKey`/date fields now value-type-checked (`isNonEmptyString` /
`isNonNegativeInt`), not just key-shape-checked. Two negatives added, mutation-tested RED.

### NIT-4 — `sourceRefs[].id` accepts any non-empty string

**Deferred, with reason**: `rule_set`/`schedule_group` ids are not guaranteed to be UUIDs, so
tightening this to a stricter format risks rejecting real output. No live producer emits a
value-level leak here today (confirmed by the gate). Left as documented residual surface.

---

## Route + guard chain (call order, proving authorization precedes SQL)

```
GET /api/attendance/groups/:groupId/effective-policy
```

1. `rbacGuard('attendance', 'admin')` — RBAC permission gate (401/403), before the handler runs.
2. Reject any query parameter / any request body (400, `QUERY_NOT_ACCEPTED` / `BODY_NOT_ACCEPTED`) — R7, before any SQL.
3. `getAttendanceAdminRequestUserId` — 401 if missing.
4. Org identity from the **authenticated principal only** — `getAuthenticatedAttendanceGroupEffectivePolicyOrgId`: `user.orgId ?? user.workspaceId ?? req.authenticatedTenantId` (mirrors the CJS FSER route's `getAuthenticatedOrgId` so the same JWT authenticates identically on both surfaces) — 403 `Authenticated organization not found` if missing, before any SQL.
5. `x-org-id` header byte-equal-or-403 (`attendanceGroupEffectivePolicyOrgSelectorMismatch`) — before any SQL.
6. `canReadAttendanceDirectoryReadiness(req, userId, orgId)` — reused verbatim (already exists in this file for S7-5/W4-0): delegated attendance admin must additionally hold active `user_orgs` membership; full/platform admins bypass via its own existing bypass, org identity itself is never bypassed.
7. `groupId` UUID format check — 400.
8. `attendanceGroupEffectivePolicyAggregateService.getAggregate({orgId, groupId})` — the **only** scoped SQL; unknown/cross-org/inaccessible group share one values-free 404 shape.

New files (kept out of `plugins/plugin-attendance/index.cjs` and `AttendanceView.vue` per this line's module-boundary convention):
- `packages/core-backend/src/attendance/w6-group-effective-policy-aggregate.ts` — the read-only service (composes FSER, derives the other 7 domains).
- `packages/core-backend/src/attendance/w6-group-effective-policy-response-contract.ts` — pure exact-key/enum-strict/closed-editorRef validator, reused as a runtime self-check before the route ever serves a response.
- `packages/core-backend/src/routes/attendance-admin.ts` — route wiring only (~130 lines added, matches existing admin-aggregate conventions in this file).
- `packages/core-backend/src/util/resolve-plugin-attendance-lib.ts` — new (this revision): depth-tolerant `plugins/plugin-attendance/lib/` module resolver (P1 fix above).

## FSER composition (OD-W6-2(a), W6-R4)

Call site: `attendanceGroupEffectivePolicyAggregateService` → `deps.fser.getEffectiveness(db, {orgId, groupId})` inside `w6-group-effective-policy-aggregate.ts`. The FSER service instance is constructed **once at module scope** in `attendance-admin.ts`, resolved via `requirePluginAttendanceLib(__dirname, ...)` (P1 fix — depth-tolerant, not a literal relative path) rather than `require()` of a hard-coded string, injected with `AttendanceGroupEffectivePolicyServiceError` as its `HttpError` and a producer-key builder. Result is embedded verbatim (minus the redundant `groupId` key) for `fixed_shift` groups, `null` otherwise. No second effectiveness predicate, no persisted second status.

## Org opt-in + env gate default OFF

W6-1 is backend-only: there is **no UI mount** (that's W6-3) and **no org opt-in setting exists yet** to gate, because nothing client-facing is wired. The gate itself — `attendance:admin` permission requirement plus the delegated-admin active-membership check — is the access control that exists today; it is closed by default (nobody gets the aggregate without the admin permission), matching `disabled = byte-identical` in spirit: a caller with no `attendance:admin` grant sees byte-identical behavior to before this PR (404 on the whole route family, same as any unmounted route). OD-W6-7(a)'s org-opt-in setting is explicitly scoped to the **UI gate** (§5.2, W6-3) — out of this slice.

## Red-line → test:case → mutation evidence

| Red line | Test file : case | Mutation red → restore |
| --- | --- | --- |
| **W6-R1** (GET-only, zero writes) | `attendance-w6-group-effective-policy-dml-sweep.test.ts` (static, both raw-SQL + kysely syntax, whole-file scope over the two service files, **PLUS the route-handler block extracted by anchoring on the route's own path string — new this revision, P2-3**) + `attendance-w6-group-effective-policy.db.test.ts` › `W6-R1: GET-only, zero writes (behavioral)` › row counts **AND row versions (`MAX(xmin)`) — new this revision** across every touched table are unchanged after a full route round-trip | Injected `INSERT INTO attendance_group_effective_policy_audit ...` into `loadActiveMemberCount` → raw-SQL-DML sweep test reds. A raw `UPDATE ... SET updated_at = now()` injected into the ROUTE HANDLER now reds BOTH the widened static sweep and the xmin-aware behavioral leg (previously passed both). Restored via `cp` backup. |
| **W6-R2** (values-free) | `attendance-w6-group-effective-policy-response-contract.test.ts` › all 6 `aggregate-*.json` validate, all 3 `invalid-reject-*.json` payloads rejected, `invalid-reject-member-leak.json` isolated-defect case + `attendance-w6-group-effective-policy.db.test.ts` › happy path › payload never contains a raw user id / `memberIds`/`userId` keys | Neutered `hasClosedKeys`' exact-key rejection (`continue` instead of `return false`) → 3 tests red (leak fixture + 2 editorRef closed-table cases). Re-verified this revision. Restored via `Edit`. |
| **W6-R3** (auth precedes SQL) | `attendance-w6-group-effective-policy.db.test.ts` › `W6-R3: authorization precedes every aggregate SQL read` (cross-org 404; delegated-non-member 403; spoofed `x-org-id` 403 on both an inaccessible AND the caller's own accessible group; a dual-org-membership sharp-form probe; byte-equal header positive control; platform-admin bypass; missing-org 403; unknown-group 404; missing-permission 403) | Three separate mutations, each named to the leg it reds: (a) `loadGroup` SQL drop `AND org_id=$2` → **cross-org probe** 404→200; (b) route skip `canReadAttendanceDirectoryReadiness` (`const allowed = true`) → **delegated-non-member probe** 403→200; (c) org derivation honor `x-org-id` as override → **the sharp dual-org spoofed-header probe** 403→200. All three re-verified this revision, restored via `cp` backup. |
| **W6-R4** (one FSER derivation) | `attendance-w6-fser-single-source-caller-inventory.test.ts` (mechanical, git-tracked-only allowlist scan) + `attendance-w6-group-effective-policy.db.test.ts` › `W6-R4: FSER fidelity` › embedded `fixedSchedule` byte-identical (`toStrictEqual`, `evaluatedAt` excluded) to a direct call to the same canonical FSER `.cjs` service on the same seeded data — **the fidelity test now imports the shared producer-key builder instead of reimplementing it a third time (P3-5)** | Inventory: decoy file outside the allowlist referencing the FSER factory is a positive control (caught). Fidelity: hand-rolled parallel derivation would diverge from FSER's real output. |
| **W6-R5** (no calculation consumer; overlap → conflict, no choose-first) | `attendance-w6-import-graph-no-calculation-consumer.test.ts` (mechanical scan, **now also covering `plugins/plugin-attendance/index.cjs` and `packages/core-backend/src/services/` — P3-3**) + `attendance-w6-group-effective-policy-membership-overlap.db.test.ts` (dedicated ephemeral Postgres database — counts exactly the users effective-today in the target group who ALSO hold >1 effective-today membership org-wide; **a third group with a non-overlapping member reports 0, discriminating per-group from per-org — P2-4, replacing the prior non-discriminating claim**) | Import-graph: positive control via `findOffenders` against decoys under both the pre-existing and new prefixes. Overlap: genuine choose-first mutation (`ORDER BY m.user_id LIMIT 1` on the inner set) reds 2 tests; per-group→per-org mutation (`AND m.group_id = $2` → `OR TRUE`) now reds the new bounded-group case. Restored via `cp` backup. |
| **W6-R6** (enum-strict) | `attendance-w6-group-effective-policy-response-contract.test.ts` › `W6-R6 enum-strict negatives` (`groupType`, `calculationPosture`, `domains.membership.label`, `domains.flex.mode`, `domains.rules.source`, `conflicts[].code`, `conflicts[].domain`, **`domains.*.reasonCodes` + `fixedSchedule.reasonCodes` against a closed union — new, P2-2**) + `w6-group-effective-policy-aggregate.ts` fail-closed throws for `groupType`/role/rollout-state/FSER-state/**flex_mode (new, P3-4)** — **each now individually mutation-tested, P2-1** | The lock's own named mutation (unknown FSER state → silent `needs_configuration`) and the other four silent-fallback mutations now RED individually and exclusively. `reasonCodes` closed-set negatives RED individually. |
| **W6-R7** (labels only from persisted config + posture only) | `attendance-w6-group-effective-policy.db.test.ts` › `W6-R6/R7` › query param 400, body 400; response-contract validator's byte-exact assertions per fixture | Removing the query rejection reds exactly the `QUERY_NOT_ACCEPTED` test; removing the body rejection reds exactly the `BODY_NOT_ACCEPTED` test. Both fire before any SQL — re-verified this revision (NIT-1: the prior body understated this as "not separately run"). |
| **W6-R8** (editorRef closed union) | `attendance-w6-group-effective-policy-response-contract.test.ts` › `editorRef closed-table parser` (every `group_stage` value, every `schedule` surface, `schedule` with no surface, `calendar` with/without surface, `rules` with `rule-sets`, out-of-table surface/step, unknown `kind`, caller-supplied extra key) | Neutered `hasClosedKeys` reds 2 of these cases directly. Re-verified this revision. |
| **W6-R9** | Does not bind this slice (governed the W6-0 prep PR #4771); not regressed. |

## Fixture reproduction

All 6 `aggregate-*.json` W6-0 fixtures reproduced **byte-exact** (`toStrictEqual`) via a fake-DB
query router + fake FSER service in `attendance-w6-group-effective-policy-aggregate.test.ts` —
except one fixture-level deviation, explicitly flagged (see below) rather than silently
reproduced. All 3 `invalid-reject-*.json` fixtures fail the response-contract validator.

## Flagged rather than decided

1. **`aggregate-conflict-membership-overlap.json`'s `schedule.sourceRefs`** omits the
   `fixed_schedule_config` ref that every other `fixed_shift`+FSER-effective fixture (1, 6)
   includes for an identical `fixedSchedule.desired` shape — no discoverable trigger condition
   distinguishes it. This looks like an authoring omission in the never-executed PROPOSED pack
   (its own README: "nothing here comes from production"). Implemented the CONSISTENT rule
   (always include `fixed_schedule_config` once a config row resolves) and documented the
   deviation in the test rather than reproducing the omission. **Unresolved — owner tiebreak
   needed between the fixture and this implementation; the gate independently flagged the same
   ambiguity as P3-1.**
2. **`domains.schedule.reasonCodes`** for FSER-backed groups is FSER's own `reasonCodes` filtered
   to drop `EFFECTIVE` and truncated to the first remaining entry (FSER already orders by its own
   `REASON_ORDER`) — reverse-engineered from the only two fixtures that exercise a non-empty case
   (fixture 1: `['EFFECTIVE']` → `[]`; fixture 6: `['DIFFERENT_MANAGED_KEY_ACTIVE',
   'TARGET_MEMBER_MISSING']` → `['DIFFERENT_MANAGED_KEY_ACTIVE']`). Two data points support this
   rule; not independently owner-confirmed.
3. **FSER `pending_apply` state and the `FIXED_SCHEDULE_UNPUBLISHED_MANAGED_ROW` conflict code**:
   no fixture exercises either. Implemented `pending_apply → conflict_action_required /
   FIXED_SCHEDULE_PENDING_APPLY` and never distinguish `FIXED_SCHEDULE_UNPUBLISHED_MANAGED_ROW`
   from the general `FIXED_SCHEDULE_CONFIGURATION_CHANGED` (both closed-inventory codes exist;
   only the latter is currently reachable from this aggregate). Flagging rather than guessing the
   split between them.
4. **A configured (non-`needs_configuration`) `scheduled_shift` group**: no fixture covers this
   state. `segments`/`flex` default to `effective` with empty `sourceRefs` since v1 has no
   resolvable single shift for a `scheduled_shift` group's advanced-scheduling model.
5. **`RULE_SOURCE_MISSING`'s org-default-rule-set check** (`attendance_rule_sets.is_default`) and
   **`scheduled_shift`'s `SCHEDULE_STRATEGY_INCOMPLETE`** (`attendance_schedule_groups` existence
   for the group) are both narrow, defensible, fixture-consistent implementations of facts the
   design lock names conceptually but doesn't pin to a specific table/column.
6. **The producer-key builder** (`buildFixedScheduleProducerKey`) is a local reimplementation of
   `plugins/plugin-attendance/index.cjs`'s private, non-exported
   `buildAttendanceGroupFixedScheduleProducerKey` — provably equivalent for the restricted input
   domain this call site ever supplies (already-canonicalized `YYYY-MM-DD` strings from FSER's own
   `mapDesired`), documented in the file header. Extracting the canonical function to a shared
   `lib/` module was considered and rejected as out-of-scope surgery on a 41.5k-line file for this
   slice; flagging the reasoning for review rather than silently choosing either path. (This
   revision closed the fidelity test's THIRD independent copy of this logic — P3-5 — without
   changing this underlying flag.)
7. **`profile.segmentCount <= 1` vs. the lock's literal "a single-segment `strict` shift"
   wording** for a 0-segment shift (P3-2b, new this revision): currently reads as
   single-segment-strict → `effective`. Not changed here — a real output-changing behavior
   question or/is design discretion this lane does not own; left for the owner at W6-4.

## Test evidence (local, exact commands + results)

Unit (no DB, default `vitest run`, matches the required `test (20.x)` gate):
```
pnpm --filter @metasheet/core-backend exec vitest run \
  tests/unit/attendance-w6-group-effective-policy-response-contract.test.ts \
  tests/unit/attendance-w6-group-effective-policy-aggregate.test.ts \
  tests/unit/attendance-w6-group-effective-policy-dml-sweep.test.ts \
  tests/unit/attendance-w6-fser-single-source-caller-inventory.test.ts \
  tests/unit/attendance-w6-import-graph-no-calculation-consumer.test.ts \
  tests/unit/attendance-admin-plugin-lib-dist-layout-boot.test.ts
# Test Files  6 passed (6) / Tests  69 passed (69)   (was 5 files / 47 tests before this revision)
```

Real-DB (locally migrated scratch Postgres via `db:migrate`, run together with pre-existing
neighbor files sharing the same `metasheet_test`-style database, matching how
`plugin-tests.yml`'s `attendance-real-db-integration` step invokes them):
```
DATABASE_URL=... ATTENDANCE_TEST_DATABASE_URL=... \
pnpm exec vitest --config vitest.integration.config.ts run \
  tests/integration/attendance-group-fixed-schedule-effectiveness.db.test.ts \
  tests/integration/attendance-group-fixed-schedule-self-effectiveness.db.test.ts \
  tests/integration/attendance-w4c4-calculation-detail.db.test.ts \
  tests/integration/attendance-w6-group-effective-policy.db.test.ts \
  tests/integration/attendance-w6-group-effective-policy-membership-overlap.db.test.ts
# Test Files  5 passed (5) / Tests  66 passed (66)
```
Also ran the full core-backend `vitest run` (no filter): 609 files / 8393 tests passed, 4
pre-existing failures unrelated to this diff (`multitable-e2e-helper-env.test.ts`, missing
`@playwright/test` in this ad hoc worktree — environmental, confirmed unrelated by file/subject).

`tsc --noEmit` clean (0 errors) after every commit in this revision.

## CI wiring (two-point) + pin recompute

- `.github/workflows/plugin-tests.yml`: both `.db.test.ts` files added to the
  `attendance-real-db-integration` run-list (unchanged this revision — not touched).
- `packages/core-backend/vitest.config.ts`: both excluded from the no-DB default job (F1 lesson,
  #3487 — `describeIfDatabase` must not be allowed to skip-green).
- `plugins/plugin-integration-core/lib/sealed-export/vectors/s6a-package-provenance-pins.json`
  field `pluginTestsWorkflow`: unchanged this revision (workflow file not touched, so the pin was
  not recomputed — no diff to it).
- New this revision: `tests/unit/attendance-admin-plugin-lib-dist-layout-boot.test.ts` needs no
  wiring — it is not DB-gated and is not excluded from the default no-DB `vitest run`, so it runs
  automatically in the existing `test (20.x)` lane.

## Not authorized / not done here

W6-2 (OpenAPI contract wiring), W6-3 (UI mount + label chips + org opt-in setting), W6-4
(verification MD + independent adversarial review), staging, flags, soak, deployment, refs 4556
closure. This PR stops at Draft/HOLD pending a fresh exact-head gate.

Refs 4556.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

