### PR TITLE
feat(approval): form session undo/redo for field list mutations

### DIFF
--- a/apps/web/src/approvals/approvalFormAuthoringHistory.ts
+++ b/apps/web/src/approvals/approvalFormAuthoringHistory.ts
@@ -51,7 +51,8 @@ function cloneJson<T>(value: T): T {
 }
 
 function cloneFields(fields: readonly FieldAuthoringDraft[]): FieldAuthoringDraft[] {
-  return cloneJson(fields)
+  // JSON clone yields a mutable array; cast input so T is not inferred as readonly[].
+  return cloneJson([...fields] as FieldAuthoringDraft[])
 }
 
 function fieldsEqual(

--- a/apps/web/src/approvals/approvalFormAuthoringHistory.ts
+++ b/apps/web/src/approvals/approvalFormAuthoringHistory.ts
@@ -1,0 +1,200 @@
+/**
+ * Session history for approval template form-field authoring.
+ *
+ * Scope is the field list + optional focused field `localId` only — canvas /
+ * topology history stays in `approvalAuthoringHistory`. Snapshots are deep-cloned
+ * via JSON so later in-place Vue edits cannot corrupt the stacks.
+ *
+ * `localId` is a view-model selection key only; it is never shown as ordinary-user
+ * input and is not a persisted identity API.
+ */
+
+import type { FieldAuthoringDraft } from './templateAuthoring'
+
+/** Default cap on undo (and redo) depth for a single authoring session. */
+export const FORM_AUTHORING_HISTORY_MAX_STACK = 100
+
+export interface FormAuthoringHistory {
+  /** Current field list tip (cloned). */
+  fields: FieldAuthoringDraft[]
+  /** Focused field localId, or null when none. */
+  focusLocalId: string | null
+  /** Prior tips; undo pops from the end. */
+  undoStack: FormAuthoringSnapshot[]
+  /** Tips restored by undo; redo pops from the end. */
+  redoStack: FormAuthoringSnapshot[]
+  maxStack: number
+}
+
+export interface FormAuthoringSnapshot {
+  fields: FieldAuthoringDraft[]
+  focusLocalId: string | null
+}
+
+export type FormAuthoringHistoryResult =
+  | {
+      ok: true
+      history: FormAuthoringHistory
+      fields: FieldAuthoringDraft[]
+      focusLocalId: string | null
+    }
+  | {
+      ok: false
+      reason: 'empty-undo' | 'empty-redo'
+      history: FormAuthoringHistory
+      fields: FieldAuthoringDraft[]
+      focusLocalId: string | null
+    }
+
+function cloneJson<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T
+}
+
+function cloneFields(fields: readonly FieldAuthoringDraft[]): FieldAuthoringDraft[] {
+  return cloneJson(fields)
+}
+
+function fieldsEqual(
+  left: readonly FieldAuthoringDraft[],
+  right: readonly FieldAuthoringDraft[],
+): boolean {
+  return JSON.stringify(left) === JSON.stringify(right)
+}
+
+function tipSnapshot(history: FormAuthoringHistory): FormAuthoringSnapshot {
+  return {
+    fields: cloneFields(history.fields),
+    focusLocalId: history.focusLocalId,
+  }
+}
+
+function trimStack(
+  stack: FormAuthoringSnapshot[],
+  maxStack: number,
+): FormAuthoringSnapshot[] {
+  if (stack.length <= maxStack) return stack
+  return stack.slice(stack.length - maxStack)
+}
+
+/**
+ * Seed a new form authoring session from the current field list.
+ * Stacks start empty (nothing to undo/redo).
+ */
+export function createFormAuthoringHistory(
+  fields: readonly FieldAuthoringDraft[],
+  focusLocalId: string | null = null,
+  maxStack: number = FORM_AUTHORING_HISTORY_MAX_STACK,
+): FormAuthoringHistory {
+  const cap = maxStack > 0 ? maxStack : FORM_AUTHORING_HISTORY_MAX_STACK
+  return {
+    fields: cloneFields(fields),
+    focusLocalId,
+    undoStack: [],
+    redoStack: [],
+    maxStack: cap,
+  }
+}
+
+/** True when at least one structural snapshot is on the undo stack. */
+export function canUndoFormHistory(history: FormAuthoringHistory): boolean {
+  return history.undoStack.length > 0
+}
+
+/** True when at least one snapshot is on the redo stack. */
+export function canRedoFormHistory(history: FormAuthoringHistory): boolean {
+  return history.redoStack.length > 0
+}
+
+/**
+ * Push a new field-list tip. When `nextFields` is byte-identical to the current tip,
+ * history is returned unchanged (no stack entry, redo preserved). On real change,
+ * the previous tip is pushed to undo, redo is cleared, and stacks are capped.
+ */
+export function pushFormSnapshot(
+  history: FormAuthoringHistory,
+  nextFields: readonly FieldAuthoringDraft[],
+  nextFocus: string | null = history.focusLocalId,
+): FormAuthoringHistory {
+  if (fieldsEqual(history.fields, nextFields)) {
+    // Focus-only changes do not create history entries (structural scope only).
+    if (history.focusLocalId === nextFocus) return history
+    return {
+      ...history,
+      focusLocalId: nextFocus,
+    }
+  }
+  const previous = tipSnapshot(history)
+  const undoStack = trimStack([...history.undoStack, previous], history.maxStack)
+  return {
+    fields: cloneFields(nextFields),
+    focusLocalId: nextFocus,
+    undoStack,
+    redoStack: [],
+    maxStack: history.maxStack,
+  }
+}
+
+/**
+ * Undo one structural snapshot. Fail-closed when the undo stack is empty
+ * (returns `ok: false` with unchanged history).
+ */
+export function undoFormHistory(
+  history: FormAuthoringHistory,
+): FormAuthoringHistoryResult {
+  if (history.undoStack.length === 0) {
+    return {
+      ok: false,
+      reason: 'empty-undo',
+      history,
+      fields: history.fields,
+      focusLocalId: history.focusLocalId,
+    }
+  }
+  const previous = history.undoStack[history.undoStack.length - 1]!
+  const current = tipSnapshot(history)
+  const nextHistory: FormAuthoringHistory = {
+    fields: cloneFields(previous.fields),
+    focusLocalId: previous.focusLocalId,
+    undoStack: history.undoStack.slice(0, -1),
+    redoStack: trimStack([...history.redoStack, current], history.maxStack),
+    maxStack: history.maxStack,
+  }
+  return {
+    ok: true,
+    history: nextHistory,
+    fields: nextHistory.fields,
+    focusLocalId: nextHistory.focusLocalId,
+  }
+}
+
+/**
+ * Redo one structural snapshot. Fail-closed when the redo stack is empty.
+ */
+export function redoFormHistory(
+  history: FormAuthoringHistory,
+): FormAuthoringHistoryResult {
+  if (history.redoStack.length === 0) {
+    return {
+      ok: false,
+      reason: 'empty-redo',
+      history,
+      fields: history.fields,
+      focusLocalId: history.focusLocalId,
+    }
+  }
+  const next = history.redoStack[history.redoStack.length - 1]!
+  const current = tipSnapshot(history)
+  const nextHistory: FormAuthoringHistory = {
+    fields: cloneFields(next.fields),
+    focusLocalId: next.focusLocalId,
+    undoStack: trimStack([...history.undoStack, current], history.maxStack),
+    redoStack: history.redoStack.slice(0, -1),
+    maxStack: history.maxStack,
+  }
+  return {
+    ok: true,
+    history: nextHistory,
+    fields: nextHistory.fields,
+    focusLocalId: nextHistory.focusLocalId,
+  }
+}

--- a/apps/web/src/views/approval/TemplateAuthoringView.vue
+++ b/apps/web/src/views/approval/TemplateAuthoringView.vue
@@ -222,15 +222,33 @@
         <template #header>
           <div class="template-authoring__panel-header">
             <strong>表单字段</strong>
-            <el-button
-              size="small"
-              :disabled="readOnly"
-              data-testid="approval-template-add-field"
-              @click="addField"
-            >
-              <el-icon><Plus /></el-icon>
-              添加字段
-            </el-button>
+            <div class="template-authoring__form-toolbar">
+              <el-button
+                size="small"
+                :disabled="readOnly || !canUndoFormFieldHistory"
+                data-testid="approval-form-undo"
+                @click="onFormFieldUndo"
+              >
+                撤销
+              </el-button>
+              <el-button
+                size="small"
+                :disabled="readOnly || !canRedoFormFieldHistory"
+                data-testid="approval-form-redo"
+                @click="onFormFieldRedo"
+              >
+                重做
+              </el-button>
+              <el-button
+                size="small"
+                :disabled="readOnly"
+                data-testid="approval-template-add-field"
+                @click="addField"
+              >
+                <el-icon><Plus /></el-icon>
+                添加字段
+              </el-button>
+            </div>
           </div>
         </template>
 
@@ -1314,6 +1332,15 @@ import {
   undoAuthoringSession,
   type AuthoringSessionHistory,
 } from '../../approvals/approvalAuthoringHistory'
+import {
+  canRedoFormHistory,
+  canUndoFormHistory,
+  createFormAuthoringHistory,
+  pushFormSnapshot,
+  redoFormHistory,
+  undoFormHistory,
+  type FormAuthoringHistory,
+} from '../../approvals/approvalFormAuthoringHistory'
 import type { ApprovalCanvasSelection } from '../../approvals/approvalCanvasCommands'
 import {
   computeLayout,
@@ -1977,6 +2004,70 @@ const canvasAuthoringHistory = ref<AuthoringSessionHistory>(
 const canUndoCanvasHistory = computed(() => canUndoAuthoring(canvasAuthoringHistory.value))
 const canRedoCanvasHistory = computed(() => canRedoAuthoring(canvasAuthoringHistory.value))
 
+// ── Form field list session history (separate from canvas) ──
+// Structural mutations only (add/remove/reorder). Label/type in-place edits are not snapshotted.
+// Tip is aligned from live draft before each structural push so those edits ride on the "before"
+// of the next structural op without polluting canvas history.
+const formAuthoringHistory = ref<FormAuthoringHistory>(
+  createFormAuthoringHistory([]),
+)
+const formFieldFocusLocalId = ref<string | null>(null)
+const canUndoFormFieldHistory = computed(() => canUndoFormHistory(formAuthoringHistory.value))
+const canRedoFormFieldHistory = computed(() => canRedoFormHistory(formAuthoringHistory.value))
+
+function reseedFormHistoryFromDraft(): void {
+  formAuthoringHistory.value = createFormAuthoringHistory(
+    draft.value.fields,
+    formFieldFocusLocalId.value,
+  )
+}
+
+function applyFormFieldsStructural(
+  nextFields: FieldAuthoringDraft[],
+  nextFocus: string | null = formFieldFocusLocalId.value,
+): void {
+  // Align tip with live draft so label/type edits since the last structural op survive as the
+  // undo "before" of this mutation (still one stack entry for the structural change).
+  const aligned: FormAuthoringHistory = {
+    ...formAuthoringHistory.value,
+    fields: draft.value.fields,
+    focusLocalId: formFieldFocusLocalId.value,
+  }
+  const next = pushFormSnapshot(aligned, nextFields, nextFocus)
+  formAuthoringHistory.value = next
+  draft.value.fields = next.fields
+  formFieldFocusLocalId.value = next.focusLocalId
+}
+
+function onFormFieldUndo(): void {
+  if (readOnly.value) return
+  // Align tip with live draft so in-place edits since last structural op redo correctly.
+  const aligned: FormAuthoringHistory = {
+    ...formAuthoringHistory.value,
+    fields: draft.value.fields,
+    focusLocalId: formFieldFocusLocalId.value,
+  }
+  const result = undoFormHistory(aligned)
+  if (!result.ok) return
+  formAuthoringHistory.value = result.history
+  draft.value.fields = result.fields
+  formFieldFocusLocalId.value = result.focusLocalId
+}
+
+function onFormFieldRedo(): void {
+  if (readOnly.value) return
+  const aligned: FormAuthoringHistory = {
+    ...formAuthoringHistory.value,
+    fields: draft.value.fields,
+    focusLocalId: formFieldFocusLocalId.value,
+  }
+  const result = redoFormHistory(aligned)
+  if (!result.ok) return
+  formAuthoringHistory.value = result.history
+  draft.value.fields = result.fields
+  formFieldFocusLocalId.value = result.focusLocalId
+}
+
 function currentCanvasSelection(): ApprovalCanvasSelection {
   return selectedCanvasNode.value
     ? { kind: 'node', nodeKey: selectedCanvasNode.value }
@@ -2593,7 +2684,9 @@ const fieldPaletteEntries = AUTHORABLE_FIELD_TYPES.map((type) => ({
 }))
 
 function addField() {
-  draft.value.fields = [...draft.value.fields, createEmptyFieldDraft(draft.value.fields.length + 1)]
+  if (readOnly.value) return
+  const added = createEmptyFieldDraft(draft.value.fields.length + 1)
+  applyFormFieldsStructural([...draft.value.fields, added], added.localId)
 }
 
 /** D6-f2 palette: add a field of the chosen kind without ordinary-user ID entry. */
@@ -2612,16 +2705,24 @@ function addFieldOfType(type: AuthorableFieldType) {
       optionsText: '',
     }]
   }
-  draft.value.fields = [...draft.value.fields, next]
+  applyFormFieldsStructural([...draft.value.fields, next], next.localId)
 }
 
 function removeField(index: number) {
-  if (draft.value.fields.length === 1) return
-  draft.value.fields = draft.value.fields.filter((_, i) => i !== index)
+  if (readOnly.value || draft.value.fields.length === 1) return
+  const removed = draft.value.fields[index]
+  const nextFields = draft.value.fields.filter((_, i) => i !== index)
+  const nextFocus = removed && formFieldFocusLocalId.value === removed.localId
+    ? (nextFields[Math.min(index, nextFields.length - 1)]?.localId ?? null)
+    : formFieldFocusLocalId.value
+  applyFormFieldsStructural(nextFields, nextFocus)
 }
 
 function moveField(index: number, delta: -1 | 1) {
-  draft.value.fields = swap(draft.value.fields, index, delta) ?? draft.value.fields
+  if (readOnly.value) return
+  const next = swap(draft.value.fields, index, delta)
+  if (!next) return
+  applyFormFieldsStructural(next, draft.value.fields[index]?.localId ?? formFieldFocusLocalId.value)
 }
 // D-4 drag-reorder: native HTML5 drag wires to the pure `moveItemToIndex` logic. (The drag GESTURE is
 // manual/E2E QA — jsdom DragEvent is unreliable; the reorder LOGIC is unit-covered in templateAuthoring.)
@@ -2631,8 +2732,11 @@ function onFieldDragStart(index: number) {
 }
 function onFieldDrop(index: number) {
   if (readOnly.value || draggedFieldIndex.value === null) return
-  draft.value.fields = moveItemToIndex(draft.value.fields, draggedFieldIndex.value, index)
+  const from = draggedFieldIndex.value
   draggedFieldIndex.value = null
+  if (from === index) return
+  const next = moveItemToIndex(draft.value.fields, from, index)
+  applyFormFieldsStructural(next, next[index]?.localId ?? formFieldFocusLocalId.value)
 }
 
 // detail / sub-form (明细) sub-field authoring. Sub-fields are LEAF types only (no nested
@@ -2737,7 +2841,9 @@ async function loadTemplateForEdit() {
     draft.value = createEmptyTemplateDraft()
     unsupportedReason.value = null
     graphReadOnlyMessage.value = null
+    formFieldFocusLocalId.value = null
     reseedCanvasHistoryFromDraft()
+    reseedFormHistoryFromDraft()
     snapshotDraft()
     return
   }
@@ -2748,10 +2854,12 @@ async function loadTemplateForEdit() {
     unsupportedReason.value = unsupportedTemplateAuthoringReason(template)
     graphReadOnlyMessage.value = graphReadOnlyReason(template)
     draft.value = draftFromTemplate(template)
+    formFieldFocusLocalId.value = null
     syncAllStepOptions()
     syncAllApprovalNodeOptions()
     syncAllCcOptions()
     reseedCanvasHistoryFromDraft()
+    reseedFormHistoryFromDraft()
     snapshotDraft()
   } catch (error: unknown) {
     loadError.value = describeTemplateAuthoringError(error, '加载审批模板失败')
@@ -2802,7 +2910,9 @@ async function persistDraft() {
       draft.value = draftFromTemplate(updated)
       unsupportedReason.value = unsupportedTemplateAuthoringReason(updated)
       graphReadOnlyMessage.value = graphReadOnlyReason(updated)
+      formFieldFocusLocalId.value = null
       reseedCanvasHistoryFromDraft()
+      reseedFormHistoryFromDraft()
       snapshotDraft()
       return updated
     }
@@ -2810,7 +2920,9 @@ async function persistDraft() {
     draft.value = draftFromTemplate(created)
     unsupportedReason.value = unsupportedTemplateAuthoringReason(created)
     graphReadOnlyMessage.value = graphReadOnlyReason(created)
+    formFieldFocusLocalId.value = null
     reseedCanvasHistoryFromDraft()
+    reseedFormHistoryFromDraft()
     snapshotDraft() // before the route replace so the leave guard stays quiet
     await router.replace({ path: `/approval-templates/${created.id}/edit` })
     return created
@@ -2831,9 +2943,12 @@ async function createFromPreset(presetId: CommonApprovalTemplatePresetId) {
     draft.value = draftFromTemplate(created)
     unsupportedReason.value = unsupportedTemplateAuthoringReason(created)
     graphReadOnlyMessage.value = graphReadOnlyReason(created)
+    formFieldFocusLocalId.value = null
     syncAllStepOptions()
     syncAllApprovalNodeOptions()
     syncAllCcOptions()
+    reseedCanvasHistoryFromDraft()
+    reseedFormHistoryFromDraft()
     snapshotDraft() // before the route replace so the leave guard stays quiet
     await router.replace({ path: `/approval-templates/${created.id}/edit` })
     ElMessage.success('模板草稿已创建')
@@ -3022,7 +3137,8 @@ onUnmounted(() => {
 .template-authoring__actions,
 .template-authoring__inline,
 .template-authoring__panel-header,
-.template-authoring__item-toolbar {
+.template-authoring__item-toolbar,
+.template-authoring__form-toolbar {
   display: flex;
   align-items: center;
   gap: 8px;

--- a/apps/web/tests/approval-form-authoring-history.test.ts
+++ b/apps/web/tests/approval-form-authoring-history.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  canRedoFormHistory,
+  canUndoFormHistory,
+  createFormAuthoringHistory,
+  pushFormSnapshot,
+  redoFormHistory,
+  undoFormHistory,
+} from '../src/approvals/approvalFormAuthoringHistory'
+import {
+  createEmptyFieldDraft,
+  type FieldAuthoringDraft,
+} from '../src/approvals/templateAuthoring'
+
+function field(index: number, overrides: Partial<FieldAuthoringDraft> = {}): FieldAuthoringDraft {
+  return {
+    ...createEmptyFieldDraft(index),
+    localId: `local_${index}`,
+    id: `field_${index}`,
+    label: `字段 ${index}`,
+    ...overrides,
+  }
+}
+
+function fieldIds(fields: readonly FieldAuthoringDraft[]): string[] {
+  return fields.map((f) => f.localId)
+}
+
+describe('approvalFormAuthoringHistory', () => {
+  it('undo restores prior fields', () => {
+    const initial = [field(1)]
+    let history = createFormAuthoringHistory(initial, 'local_1')
+    history = pushFormSnapshot(history, [field(1), field(2)], 'local_2')
+    expect(fieldIds(history.fields)).toEqual(['local_1', 'local_2'])
+    expect(canUndoFormHistory(history)).toBe(true)
+
+    const undone = undoFormHistory(history)
+    expect(undone.ok).toBe(true)
+    if (!undone.ok) return
+    expect(fieldIds(undone.fields)).toEqual(['local_1'])
+    expect(undone.focusLocalId).toBe('local_1')
+    expect(canRedoFormHistory(undone.history)).toBe(true)
+  })
+
+  it('redo after undo restores the newer field list', () => {
+    let history = createFormAuthoringHistory([field(1)])
+    history = pushFormSnapshot(history, [field(1), field(2)], 'local_2')
+    const undone = undoFormHistory(history)
+    expect(undone.ok).toBe(true)
+    if (!undone.ok) return
+
+    const redone = redoFormHistory(undone.history)
+    expect(redone.ok).toBe(true)
+    if (!redone.ok) return
+    expect(fieldIds(redone.fields)).toEqual(['local_1', 'local_2'])
+    expect(redone.focusLocalId).toBe('local_2')
+    expect(canUndoFormHistory(redone.history)).toBe(true)
+    expect(canRedoFormHistory(redone.history)).toBe(false)
+  })
+
+  it('empty undo/redo fail closed with unchanged history', () => {
+    const history = createFormAuthoringHistory([field(1)], 'local_1')
+    const snap = JSON.parse(JSON.stringify(history))
+
+    const emptyUndo = undoFormHistory(history)
+    expect(emptyUndo.ok).toBe(false)
+    if (emptyUndo.ok) return
+    expect(emptyUndo.reason).toBe('empty-undo')
+    expect(emptyUndo.history).toEqual(snap)
+    expect(fieldIds(emptyUndo.fields)).toEqual(['local_1'])
+
+    const emptyRedo = redoFormHistory(history)
+    expect(emptyRedo.ok).toBe(false)
+    if (emptyRedo.ok) return
+    expect(emptyRedo.reason).toBe('empty-redo')
+    expect(emptyRedo.history).toEqual(snap)
+  })
+
+  it('push is a no-op when fields are byte-identical', () => {
+    const fields = [field(1, { label: 'A' })]
+    let history = createFormAuthoringHistory(fields, 'local_1')
+    history = pushFormSnapshot(history, [field(1), field(2)], 'local_2')
+    const afterPush = JSON.parse(JSON.stringify(history))
+
+    // Same field list as current tip — redo stack would stay if we had one; stacks unchanged.
+    const noop = pushFormSnapshot(history, history.fields, 'local_2')
+    expect(noop).toEqual(afterPush)
+    expect(noop.undoStack.length).toBe(afterPush.undoStack.length)
+
+    // Explicit deep-equal nextFields also no-ops even if caller rebuilds objects.
+    const rebuild = pushFormSnapshot(
+      history,
+      [field(1), field(2)],
+      'local_2',
+    )
+    expect(rebuild.undoStack.length).toBe(1)
+    expect(fieldIds(rebuild.fields)).toEqual(['local_1', 'local_2'])
+  })
+
+  it('structural: multiple adds then undo steps back one by one', () => {
+    let history = createFormAuthoringHistory([field(1)], 'local_1')
+    history = pushFormSnapshot(history, [field(1), field(2)], 'local_2')
+    history = pushFormSnapshot(history, [field(1), field(2), field(3)], 'local_3')
+    history = pushFormSnapshot(
+      history,
+      [field(1), field(2), field(3), field(4)],
+      'local_4',
+    )
+    expect(fieldIds(history.fields)).toEqual(['local_1', 'local_2', 'local_3', 'local_4'])
+    expect(history.undoStack.length).toBe(3)
+
+    const u1 = undoFormHistory(history)
+    expect(u1.ok).toBe(true)
+    if (!u1.ok) return
+    expect(fieldIds(u1.fields)).toEqual(['local_1', 'local_2', 'local_3'])
+
+    const u2 = undoFormHistory(u1.history)
+    expect(u2.ok).toBe(true)
+    if (!u2.ok) return
+    expect(fieldIds(u2.fields)).toEqual(['local_1', 'local_2'])
+
+    const u3 = undoFormHistory(u2.history)
+    expect(u3.ok).toBe(true)
+    if (!u3.ok) return
+    expect(fieldIds(u3.fields)).toEqual(['local_1'])
+    expect(canUndoFormHistory(u3.history)).toBe(false)
+
+    const r1 = redoFormHistory(u3.history)
+    expect(r1.ok).toBe(true)
+    if (!r1.ok) return
+    expect(fieldIds(r1.fields)).toEqual(['local_1', 'local_2'])
+  })
+
+  it('push clears redo after a divergent mutation', () => {
+    let history = createFormAuthoringHistory([field(1)])
+    history = pushFormSnapshot(history, [field(1), field(2)], 'local_2')
+    const undone = undoFormHistory(history)
+    expect(undone.ok).toBe(true)
+    if (!undone.ok) return
+    expect(canRedoFormHistory(undone.history)).toBe(true)
+
+    history = pushFormSnapshot(undone.history, [field(1), field(9)], 'local_9')
+    expect(canRedoFormHistory(history)).toBe(false)
+    expect(fieldIds(history.fields)).toEqual(['local_1', 'local_9'])
+  })
+
+  it('clones fields so later in-place mutation does not corrupt stacks', () => {
+    const a = field(1, { label: 'original' })
+    let history = createFormAuthoringHistory([a], 'local_1')
+    const next = [field(1, { label: 'original' }), field(2)]
+    history = pushFormSnapshot(history, next, 'local_2')
+
+    // Mutate the live tip object the caller still holds.
+    next[0]!.label = 'mutated-live'
+    history.fields[0]!.label = 'mutated-tip'
+
+    const undone = undoFormHistory(history)
+    expect(undone.ok).toBe(true)
+    if (!undone.ok) return
+    expect(undone.fields[0]?.label).toBe('original')
+  })
+})


### PR DESCRIPTION
## Summary
- Pure `approvalFormAuthoringHistory` for form field list session undo/redo (structural mutations).
- Wire form undo/redo in `TemplateAuthoringView` (`approval-form-undo` / `approval-form-redo`); canvas history stays separate.
- Unit tests: 7 passed.

PLAN_ID `6fa2fbf6` residual parallel lane PR1. Flags remain OFF. Not product FINAL.

## Test plan
- [x] `pnpm --filter @metasheet/web exec vitest run --watch=false tests/approval-form-authoring-history.test.ts`
- [ ] CI green