### PR TITLE
feat(approval): dual-canvas version compare on template detail

### DIFF
--- a/apps/web/src/approvals/approvalVersionDualCanvas.ts
+++ b/apps/web/src/approvals/approvalVersionDualCanvas.ts
@@ -1,0 +1,88 @@
+/**
+ * D8-b residual — pure dual-canvas model for side-by-side version compare.
+ * Left = 对照版本 (before), right = 当前版本 (after). Each side lays out its own graph;
+ * change helpers resolve via optional VersionGraphOverlay or explicit node/edge maps.
+ * No network. No Vue.
+ */
+import type { ApprovalGraph } from '../types/approval'
+import type { TemplateVersionChangeKind } from './templateVersionDiff'
+import type { VersionGraphOverlay } from './versionGraphOverlay'
+import { computeLayout, type GraphLayout } from './graphLayout'
+
+const EMPTY_GRAPH: ApprovalGraph = { nodes: [], edges: [] }
+
+export interface ApprovalVersionDualCanvasSide {
+  title: string
+  graph: ApprovalGraph
+  layout: GraphLayout
+}
+
+export interface ApprovalVersionDualCanvasModel {
+  left: ApprovalVersionDualCanvasSide
+  right: ApprovalVersionDualCanvasSide
+  nodeChanges: Map<string, TemplateVersionChangeKind>
+  edgeChanges: Map<string, TemplateVersionChangeKind>
+  nodeChange: (key: string) => TemplateVersionChangeKind | undefined
+  edgeChange: (key: string) => TemplateVersionChangeKind | undefined
+}
+
+export interface ApprovalVersionDualCanvasOptions {
+  /** Preferred source of change maps (union overlay from buildVersionGraphOverlay). */
+  overlay?: VersionGraphOverlay | null
+  /** Explicit node change map when overlay is not supplied. */
+  nodeChanges?: Map<string, TemplateVersionChangeKind>
+  /** Explicit edge change map when overlay is not supplied. */
+  edgeChanges?: Map<string, TemplateVersionChangeKind>
+}
+
+function resolveGraph(graph: ApprovalGraph | null | undefined): ApprovalGraph {
+  if (!graph) return EMPTY_GRAPH
+  return {
+    nodes: graph.nodes ?? [],
+    edges: graph.edges ?? [],
+  }
+}
+
+/**
+ * Build a read-only dual-canvas model: independent layouts for before/after graphs,
+ * plus key→kind helpers for ghost/change styling on each side.
+ */
+export function buildApprovalVersionDualCanvas(
+  before: ApprovalGraph | null,
+  after: ApprovalGraph | null,
+  options: ApprovalVersionDualCanvasOptions = {},
+): ApprovalVersionDualCanvasModel {
+  const leftGraph = resolveGraph(before)
+  const rightGraph = resolveGraph(after)
+
+  const nodeChanges =
+    options.overlay?.nodeChanges
+    ?? options.nodeChanges
+    ?? new Map<string, TemplateVersionChangeKind>()
+  const edgeChanges =
+    options.overlay?.edgeChanges
+    ?? options.edgeChanges
+    ?? new Map<string, TemplateVersionChangeKind>()
+
+  const nodeChange = (key: string): TemplateVersionChangeKind | undefined =>
+    nodeChanges.get(key)
+  const edgeChange = (key: string): TemplateVersionChangeKind | undefined =>
+    edgeChanges.get(key)
+
+  return {
+    left: {
+      title: '对照版本',
+      graph: leftGraph,
+      layout: computeLayout(leftGraph),
+    },
+    right: {
+      title: '当前版本',
+      graph: rightGraph,
+      layout: computeLayout(rightGraph),
+    },
+    nodeChanges,
+    edgeChanges,
+    nodeChange,
+    edgeChange,
+  }
+}

--- a/apps/web/src/views/approval/TemplateDetailView.vue
+++ b/apps/web/src/views/approval/TemplateDetailView.vue
@@ -527,7 +527,138 @@
                   </li>
                 </ul>
                 <div
-                  v-else-if="versionOverlay && versionOverlayLayout"
+                  v-else-if="versionDiffMode === 'dual' && versionDualCanvas"
+                  class="template-detail__version-dual"
+                  data-testid="template-version-dual-canvas"
+                >
+                  <ul
+                    v-if="versionReadSummary && versionReadSummary.lines.length"
+                    class="template-detail__version-dual-summary-lines"
+                    data-testid="template-version-dual-summary-lines"
+                  >
+                    <li
+                      v-for="(line, idx) in versionReadSummary.lines"
+                      :key="`dual-sum-${idx}`"
+                    >
+                      {{ line }}
+                    </li>
+                  </ul>
+                  <p v-if="versionDiff.fieldChanges" class="template-detail__version-overlay-note">
+                    另有 {{ versionDiff.fieldChanges }} 项表单字段变化，请切回列表查看。
+                  </p>
+                  <div class="template-detail__version-dual-row">
+                    <div
+                      class="template-detail__version-dual-side"
+                      data-testid="template-version-dual-left"
+                    >
+                      <h4 class="template-detail__version-dual-title">{{ versionDualCanvas.left.title }}</h4>
+                      <div
+                        class="template-detail__version-overlay-canvas"
+                        :style="{
+                          width: `${versionDualCanvas.left.layout.width}px`,
+                          height: `${versionDualCanvas.left.layout.height}px`,
+                        }"
+                      >
+                        <svg
+                          class="template-detail__version-overlay-edges"
+                          :width="versionDualCanvas.left.layout.width"
+                          :height="versionDualCanvas.left.layout.height"
+                        >
+                          <defs>
+                            <marker id="approval-version-dual-left-arrow" markerWidth="8" markerHeight="8" refX="7" refY="3" orient="auto">
+                              <path d="M0,0 L7,3 L0,6 Z" fill="currentColor" />
+                            </marker>
+                          </defs>
+                          <path
+                            v-for="line in versionDualLeftEdgeLines"
+                            :key="line.key"
+                            :d="line.path"
+                            class="template-detail__version-overlay-edge"
+                            :class="line.change ? `is-${line.change}` : ''"
+                            marker-end="url(#approval-version-dual-left-arrow)"
+                          />
+                        </svg>
+                        <div
+                          v-for="pos in versionDualCanvas.left.layout.nodes"
+                          :key="pos.key"
+                          class="template-detail__version-overlay-node"
+                          :class="versionDualCanvas.nodeChange(pos.key) ? `is-${versionDualCanvas.nodeChange(pos.key)}` : ''"
+                          :style="{
+                            left: `${pos.x}px`,
+                            top: `${pos.y}px`,
+                            width: `${VERSION_OVERLAY_NODE_W}px`,
+                            minHeight: `${VERSION_OVERLAY_NODE_H}px`,
+                          }"
+                        >
+                          <strong>{{ versionDualNodeLabel('left', pos.key) }}</strong>
+                          <el-tag
+                            v-if="versionDualCanvas.nodeChange(pos.key)"
+                            size="small"
+                            :type="versionChangeTagType(versionDualCanvas.nodeChange(pos.key)!)"
+                          >
+                            {{ versionChangeKindLabel(versionDualCanvas.nodeChange(pos.key)!) }}
+                          </el-tag>
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      class="template-detail__version-dual-side"
+                      data-testid="template-version-dual-right"
+                    >
+                      <h4 class="template-detail__version-dual-title">{{ versionDualCanvas.right.title }}</h4>
+                      <div
+                        class="template-detail__version-overlay-canvas"
+                        :style="{
+                          width: `${versionDualCanvas.right.layout.width}px`,
+                          height: `${versionDualCanvas.right.layout.height}px`,
+                        }"
+                      >
+                        <svg
+                          class="template-detail__version-overlay-edges"
+                          :width="versionDualCanvas.right.layout.width"
+                          :height="versionDualCanvas.right.layout.height"
+                        >
+                          <defs>
+                            <marker id="approval-version-dual-right-arrow" markerWidth="8" markerHeight="8" refX="7" refY="3" orient="auto">
+                              <path d="M0,0 L7,3 L0,6 Z" fill="currentColor" />
+                            </marker>
+                          </defs>
+                          <path
+                            v-for="line in versionDualRightEdgeLines"
+                            :key="line.key"
+                            :d="line.path"
+                            class="template-detail__version-overlay-edge"
+                            :class="line.change ? `is-${line.change}` : ''"
+                            marker-end="url(#approval-version-dual-right-arrow)"
+                          />
+                        </svg>
+                        <div
+                          v-for="pos in versionDualCanvas.right.layout.nodes"
+                          :key="pos.key"
+                          class="template-detail__version-overlay-node"
+                          :class="versionDualCanvas.nodeChange(pos.key) ? `is-${versionDualCanvas.nodeChange(pos.key)}` : ''"
+                          :style="{
+                            left: `${pos.x}px`,
+                            top: `${pos.y}px`,
+                            width: `${VERSION_OVERLAY_NODE_W}px`,
+                            minHeight: `${VERSION_OVERLAY_NODE_H}px`,
+                          }"
+                        >
+                          <strong>{{ versionDualNodeLabel('right', pos.key) }}</strong>
+                          <el-tag
+                            v-if="versionDualCanvas.nodeChange(pos.key)"
+                            size="small"
+                            :type="versionChangeTagType(versionDualCanvas.nodeChange(pos.key)!)"
+                          >
+                            {{ versionChangeKindLabel(versionDualCanvas.nodeChange(pos.key)!) }}
+                          </el-tag>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  v-else-if="versionDiffMode === 'canvas' && versionOverlay && versionOverlayLayout"
                   class="template-detail__version-overlay"
                   data-testid="template-version-graph-overlay"
                 >
@@ -648,6 +779,7 @@ import {
 } from '../../approvals/templateVersionDiff'
 import { buildVersionGraphOverlay } from '../../approvals/versionGraphOverlay'
 import { buildApprovalVersionReadSummary } from '../../approvals/approvalVersionReadSummary'
+import { buildApprovalVersionDualCanvas } from '../../approvals/approvalVersionDualCanvas'
 import {
   computeLayout,
   GRAPH_LAYOUT_NODE_HEIGHT,
@@ -992,10 +1124,11 @@ const selectedVersion = ref<ApprovalTemplateVersionDetailDTO | null>(null)
 const selectedBaseline = ref<ApprovalTemplateVersionSummaryDTO | null>(null)
 const selectedBaselineSnapshot = ref<Pick<ApprovalTemplateVersionDetailDTO, 'formSchema' | 'approvalGraph'> | null>(null)
 const versionDiff = ref<TemplateVersionDiff | null>(null)
-const versionDiffMode = ref<'list' | 'canvas'>('list')
+const versionDiffMode = ref<'list' | 'canvas' | 'dual'>('list')
 const versionDiffModeOptions = [
   { label: '变化列表', value: 'list' },
   { label: '流程画布', value: 'canvas' },
+  { label: '双画布', value: 'dual' },
 ]
 const versionDiffLoading = ref(false)
 const versionDiffError = ref('')
@@ -1023,14 +1156,25 @@ const versionReadSummary = computed(() => {
   return buildApprovalVersionReadSummary(versionDiff.value, versionOverlay.value)
 })
 const versionOverlayLayout = computed(() => versionOverlay.value ? computeLayout(versionOverlay.value.graph) : null)
+/** D8-b residual: pure side-by-side before/after layouts (read-only). */
+const versionDualCanvas = computed(() => {
+  if (!selectedVersion.value) return null
+  return buildApprovalVersionDualCanvas(
+    selectedBaselineSnapshot.value?.approvalGraph ?? null,
+    selectedVersion.value.approvalGraph,
+    { overlay: versionOverlay.value },
+  )
+})
 const VERSION_OVERLAY_NODE_W = GRAPH_LAYOUT_NODE_WIDTH
 const VERSION_OVERLAY_NODE_H = GRAPH_LAYOUT_NODE_HEIGHT
-const versionOverlayEdgeLines = computed(() => {
-  const overlay = versionOverlay.value
-  const layout = versionOverlayLayout.value
-  if (!overlay || !layout) return []
+
+function versionCanvasEdgeLines(
+  graph: { edges: { key: string; source: string; target: string }[] },
+  layout: { nodes: { key: string; x: number; y: number }[] },
+  edgeChangeOf: (key: string) => TemplateVersionChangeKind | undefined,
+) {
   const positions = new Map(layout.nodes.map((node) => [node.key, node]))
-  return overlay.graph.edges.map((edge) => {
+  return graph.edges.map((edge) => {
     const source = positions.get(edge.source)
     const target = positions.get(edge.target)
     const x1 = (source?.x ?? 0) + GRAPH_LAYOUT_NODE_WIDTH / 2
@@ -1041,15 +1185,45 @@ const versionOverlayEdgeLines = computed(() => {
     return {
       key: edge.key,
       path: `M ${x1} ${y1} L ${x1} ${midY} L ${x2} ${midY} L ${x2} ${y2}`,
-      change: overlay.edgeChanges.get(edge.key),
+      change: edgeChangeOf(edge.key),
     }
   })
+}
+
+const versionOverlayEdgeLines = computed(() => {
+  const overlay = versionOverlay.value
+  const layout = versionOverlayLayout.value
+  if (!overlay || !layout) return []
+  return versionCanvasEdgeLines(overlay.graph, layout, (key) => overlay.edgeChanges.get(key))
 })
+
+const versionDualLeftEdgeLines = computed(() => {
+  const dual = versionDualCanvas.value
+  if (!dual) return []
+  return versionCanvasEdgeLines(dual.left.graph, dual.left.layout, dual.edgeChange)
+})
+
+const versionDualRightEdgeLines = computed(() => {
+  const dual = versionDualCanvas.value
+  if (!dual) return []
+  return versionCanvasEdgeLines(dual.right.graph, dual.right.layout, dual.edgeChange)
+})
+
 function versionOverlayNodeChange(nodeKey: string): TemplateVersionChangeKind | undefined {
   return versionOverlay.value?.nodeChanges.get(nodeKey)
 }
 function versionOverlayNodeLabel(nodeKey: string): string {
   const node = versionOverlay.value?.graph.nodes.find((candidate) => candidate.key === nodeKey)
+  return node?.name?.trim() || (node ? nodeTypeLabel(node.type) : '流程节点')
+}
+function versionDualNodeLabel(
+  side: 'left' | 'right',
+  nodeKey: string,
+): string {
+  const dual = versionDualCanvas.value
+  if (!dual) return '流程节点'
+  const graph = side === 'left' ? dual.left.graph : dual.right.graph
+  const node = graph.nodes.find((candidate) => candidate.key === nodeKey)
   return node?.name?.trim() || (node ? nodeTypeLabel(node.type) : '流程节点')
 }
 
@@ -1403,6 +1577,40 @@ onBeforeUnmount(() => {
   min-width: 0;
   max-height: min(66vh, 720px);
   overflow: auto;
+}
+
+.template-detail__version-dual {
+  min-width: 0;
+  max-height: min(66vh, 720px);
+  overflow: auto;
+}
+
+.template-detail__version-dual-summary-lines {
+  margin: 0 0 10px;
+  padding: 0 0 0 1.1em;
+  color: var(--el-text-color-secondary);
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.template-detail__version-dual-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  align-items: flex-start;
+}
+
+.template-detail__version-dual-side {
+  flex: 1 1 280px;
+  min-width: 0;
+  overflow: auto;
+}
+
+.template-detail__version-dual-title {
+  margin: 0 0 8px;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--el-text-color-regular);
 }
 
 .template-detail__version-overlay-note {

--- a/apps/web/tests/approval-version-dual-canvas.test.ts
+++ b/apps/web/tests/approval-version-dual-canvas.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest'
+import { buildApprovalVersionDualCanvas } from '../src/approvals/approvalVersionDualCanvas'
+import { buildVersionGraphOverlay } from '../src/approvals/versionGraphOverlay'
+import { diffApprovalTemplateVersions } from '../src/approvals/templateVersionDiff'
+import type { ApprovalGraph } from '../src/types/approval'
+
+const empty: ApprovalGraph = { nodes: [], edges: [] }
+
+const beforeLinear: ApprovalGraph = {
+  nodes: [
+    { key: 'start', type: 'start', name: '发起', config: {} },
+    { key: 'a1', type: 'approval', name: '经理', config: { approvalMode: 'single' } },
+    { key: 'end', type: 'end', name: '结束', config: {} },
+  ],
+  edges: [
+    { key: 'e1', source: 'start', target: 'a1' },
+    { key: 'e2', source: 'a1', target: 'end' },
+  ],
+}
+
+const afterWithNode: ApprovalGraph = {
+  nodes: [
+    { key: 'start', type: 'start', name: '发起', config: {} },
+    { key: 'a1', type: 'approval', name: '经理', config: { approvalMode: 'single' } },
+    { key: 'cc1', type: 'cc', name: '财务抄送', config: { targetType: 'role', targetIds: ['finance'] } },
+    { key: 'end', type: 'end', name: '结束', config: {} },
+  ],
+  edges: [
+    { key: 'e1', source: 'start', target: 'a1' },
+    { key: 'e3', source: 'a1', target: 'cc1' },
+    { key: 'e4', source: 'cc1', target: 'end' },
+  ],
+}
+
+const emptyForm = { fields: [] as [] }
+
+describe('buildApprovalVersionDualCanvas (D8-b residual)', () => {
+  it('handles empty / null graphs with dual titles and zero-size change maps', () => {
+    const model = buildApprovalVersionDualCanvas(null, empty)
+    expect(model.left.title).toBe('对照版本')
+    expect(model.right.title).toBe('当前版本')
+    expect(model.left.graph.nodes).toEqual([])
+    expect(model.right.graph.nodes).toEqual([])
+    expect(model.nodeChanges.size).toBe(0)
+    expect(model.edgeChanges.size).toBe(0)
+    expect(model.nodeChange('any')).toBeUndefined()
+    expect(model.edgeChange('any')).toBeUndefined()
+  })
+
+  it('linear before/after node add surfaces change map via overlay', () => {
+    const diff = diffApprovalTemplateVersions(
+      { formSchema: emptyForm, approvalGraph: beforeLinear },
+      { formSchema: emptyForm, approvalGraph: afterWithNode },
+    )
+    expect(diff.nodeChanges).toBeGreaterThanOrEqual(1)
+    const overlay = buildVersionGraphOverlay(beforeLinear, afterWithNode, diff)
+    const model = buildApprovalVersionDualCanvas(beforeLinear, afterWithNode, { overlay })
+
+    expect(model.left.graph.nodes.map((n) => n.key)).toEqual(['start', 'a1', 'end'])
+    expect(model.right.graph.nodes.map((n) => n.key)).toEqual(['start', 'a1', 'cc1', 'end'])
+    expect(model.nodeChange('cc1')).toBe('added')
+    // Removed edge from before should be marked when present in overlay maps
+    expect(model.edgeChange('e2')).toBe('removed')
+    expect(model.edgeChange('e3')).toBe('added')
+    expect(model.edgeChange('e4')).toBe('added')
+  })
+
+  it('accepts explicit node/edge maps without overlay', () => {
+    const nodeChanges = new Map([['cc1', 'added' as const]])
+    const edgeChanges = new Map([['e3', 'added' as const]])
+    const model = buildApprovalVersionDualCanvas(beforeLinear, afterWithNode, {
+      nodeChanges,
+      edgeChanges,
+    })
+    expect(model.nodeChange('cc1')).toBe('added')
+    expect(model.edgeChange('e3')).toBe('added')
+    expect(model.nodeChange('a1')).toBeUndefined()
+  })
+
+  it('layout widths are positive when graphs are non-empty', () => {
+    const model = buildApprovalVersionDualCanvas(beforeLinear, afterWithNode)
+    expect(model.left.layout.width).toBeGreaterThan(0)
+    expect(model.right.layout.width).toBeGreaterThan(0)
+    expect(model.left.layout.nodes.length).toBe(beforeLinear.nodes.length)
+    expect(model.right.layout.nodes.length).toBe(afterWithNode.nodes.length)
+    // Each laid-out node has finite coordinates
+    for (const side of [model.left, model.right]) {
+      for (const n of side.layout.nodes) {
+        expect(Number.isFinite(n.x)).toBe(true)
+        expect(Number.isFinite(n.y)).toBe(true)
+      }
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- Pure `approvalVersionDualCanvas` side-by-side before/after model using existing layout.
- TemplateDetailView version panel mode **双画布** with testids dual-left/right.
- Unit tests: 4 passed.

PLAN_ID `6fa2fbf6` residual parallel lane PR2. Flags remain OFF. Not product FINAL.

## Test plan
- [x] `pnpm --filter @metasheet/web exec vitest run --watch=false tests/approval-version-dual-canvas.test.ts`
- [ ] CI green