### PR TITLE
feat(approval): a11y edge-insert controls on ApprovalFlowCanvas

### DIFF
--- a/apps/web/src/approvals/components/ApprovalFlowCanvas.vue
+++ b/apps/web/src/approvals/components/ApprovalFlowCanvas.vue
@@ -217,7 +217,8 @@ function nodePosStyle(pos: NodeLayout): CSSProperties {
               <button
                 type="button"
                 class="template-authoring__canvas-edge-insert-btn"
-                aria-label="在连线后插入节点"
+                aria-label="在此连线插入节点"
+                title="在此连线插入节点"
                 :aria-expanded="edgeInsertMenuEdgeKey === line.key"
                 :data-testid="`approval-canvas-edge-insert-${line.key}`"
                 @click.stop="emit('toggle-edge-insert', line.key)"

--- a/apps/web/tests/approval-flow-canvas-a11y.test.ts
+++ b/apps/web/tests/approval-flow-canvas-a11y.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Wave-2 PR4 — ApprovalFlowCanvas edge-insert / node-card a11y lock.
+ * Pure structural source-scan (G5-C style): no jsdom mount of the full canvas tree.
+ */
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const CANVAS_SRC = readFileSync(
+  join(__dirname, '../src/approvals/components/ApprovalFlowCanvas.vue'),
+  'utf8',
+)
+
+describe('ApprovalFlowCanvas a11y (structural)', () => {
+  it('edge mid-point insert control has business aria-label (no raw edge keys)', () => {
+    expect(CANVAS_SRC).toMatch(/aria-label="在此连线插入节点"/)
+    // Stable shell testid for the edge-insert control family
+    expect(CANVAS_SRC).toMatch(/data-testid="approval-canvas-edge-insert"/)
+    // Per-edge testid remains for e2e targeting, but must not be the accessible name
+    expect(CANVAS_SRC).toMatch(/:data-testid="`approval-canvas-edge-insert-\$\{line\.key\}`"/)
+  })
+
+  it('edge insert + is a native focusable button (not a bare div)', () => {
+    // Button with business label lives under the edge-insert shell
+    expect(CANVAS_SRC).toMatch(
+      /class="template-authoring__canvas-edge-insert-btn"[\s\S]*?type="button"|type="button"[\s\S]*?class="template-authoring__canvas-edge-insert-btn"/,
+    )
+    expect(CANVAS_SRC).toMatch(
+      /class="template-authoring__canvas-edge-insert-btn"[\s\S]{0,200}aria-label="在此连线插入节点"/,
+    )
+  })
+
+  it('does not bind edge-key-only strings as aria-label on edge insert', () => {
+    // Forbidden: accessible name is only the raw edge key
+    expect(CANVAS_SRC).not.toMatch(/:aria-label="line\.key"/)
+    expect(CANVAS_SRC).not.toMatch(/aria-label="\$\{line\.key\}"/)
+    expect(CANVAS_SRC).not.toMatch(
+      /canvas-edge-insert-btn[\s\S]{0,300}:aria-label="[^"]*\$\{line\.key\}/,
+    )
+  })
+
+  it('node selector exposes display-name accessible name and keyboard activation', () => {
+    expect(CANVAS_SRC).toMatch(/role="button"/)
+    expect(CANVAS_SRC).toMatch(/tabindex="0"/)
+    // Accessible name derived from graphNodeLabel (display name), not raw node key alone
+    expect(CANVAS_SRC).toMatch(/:aria-label="`编辑\$\{graphNodeLabel\(pos\.key\)\}节点`"/)
+    expect(CANVAS_SRC).toMatch(/@keydown\.enter/)
+    expect(CANVAS_SRC).toMatch(/@keydown\.space/)
+    expect(CANVAS_SRC).toMatch(/:aria-pressed="selectedCanvasNode === pos\.key"/)
+  })
+})

--- a/docs/development/approval-canvas-residual-parallel-wave2-design-20260808.md
+++ b/docs/development/approval-canvas-residual-parallel-wave2-design-20260808.md
@@ -1,0 +1,43 @@
+# Approval Canvas Residual Parallel — Wave 2 (2026-08-08)
+
+**Status:** AUTHORITATIVE FOR WAVE-2 PARALLEL EXECUTION  
+**PLAN_ID:** `6fa2fbf6-w2`  
+**Depends on wave-1 PRs:** none for file ownership (wave-1 is #4815 form history, #4816 dual canvas, #4817 CI/smoke)  
+**Flags:** default OFF. No product FINAL.
+
+## Goal
+
+While wave-1 CI runs, ship **two more independent a11y/polish lanes** that do **not** touch:
+
+- `TemplateAuthoringView.vue` (#4815)
+- `TemplateDetailView.vue` (#4816)
+- CI / smoke scripts (#4817)
+
+| Lane | Owns | Parallel with |
+|---|---|---|
+| **PR4** Flow canvas a11y | `ApprovalFlowCanvas.vue` + focused tests | PR5, wave-1 |
+| **PR5** Inspector topology a11y | `ApprovalCanvasNodeInspector.vue` + focused tests | PR4, wave-1 |
+
+## Non-goals
+
+G0 / UAT / flags / D3 / product FINAL / form undo wiring / dual-canvas detail panel.
+
+## PR Plan
+
+### PR 4: Flow canvas edge-insert a11y — OPEN
+
+- **Description:** Ensure every edge mid-point `+` control has an explicit accessible name (aria-label business copy, no edge keys). Keyboard focusable (`tabindex=0` or native button). Add/extend pure structural or shallow mount tests under `apps/web/tests/`. No graph semantic changes.
+- **Files/components affected:** `apps/web/src/approvals/components/ApprovalFlowCanvas.vue`, `apps/web/tests/approval-flow-canvas-a11y.test.ts` (new) or extend existing canvas inspector tests without touching TemplateAuthoringView  
+- **Dependencies:** None  
+
+### PR 5: Inspector topology a11y — OPEN
+
+- **Description:** Topology insert/remove controls in `ApprovalCanvasNodeInspector` get stable `data-testid` (if missing) + aria-labels in business language. No command algebra change. Tests structural or shallow.
+- **Files/components affected:** `apps/web/src/approvals/components/ApprovalCanvasNodeInspector.vue`, `apps/web/tests/approval-canvas-inspector-a11y.test.ts` (new)  
+- **Dependencies:** None  
+
+## Execute order
+
+```text
+Level 0: PR4 || PR5   (and continue babysit wave-1 #4815||#4816||#4817)
+```


### PR DESCRIPTION
## Summary
- Business-language aria-label on canvas edge mid-point insert (`在此连线插入节点`).
- Structural a11y tests for ApprovalFlowCanvas.
- Wave-2 design ledger (PLAN `6fa2fbf6-w2`).

Independent of #4815/#4816/#4817 (no TemplateAuthoringView/Detail/CI). Flags OFF. Not product FINAL.

## Test plan
- [x] `vitest tests/approval-flow-canvas-a11y.test.ts`
- [ ] CI green