### PR TITLE
feat(approval): a11y labels on ApprovalCanvasNodeInspector topology

### DIFF
--- a/apps/web/src/approvals/components/ApprovalCanvasNodeInspector.vue
+++ b/apps/web/src/approvals/components/ApprovalCanvasNodeInspector.vue
@@ -60,6 +60,7 @@ defineExpose({
         text
         size="small"
         data-testid="approval-canvas-inspector-close"
+        aria-label="关闭节点检查器"
         @click="emit('close')"
       >
         关闭
@@ -70,12 +71,15 @@ defineExpose({
         v-if="!readOnly"
         class="template-authoring__inspector-topology"
         data-testid="approval-canvas-inspector-topology"
+        role="toolbar"
+        :aria-label="`${graphNodeLabel(node.key)}节点拓扑操作`"
       >
         <template v-if="canMoveCanvasNode(node.key)">
           <el-button
             size="small"
             :disabled="!canvasStepMoveTarget(node.key, 'up')"
             :data-testid="`approval-canvas-move-up-${node.key}`"
+            :aria-label="`上移${graphNodeLabel(node.key)}节点`"
             @click="emit('move-up', node.key)"
           >
             上移
@@ -84,6 +88,7 @@ defineExpose({
             size="small"
             :disabled="!canvasStepMoveTarget(node.key, 'down')"
             :data-testid="`approval-canvas-move-down-${node.key}`"
+            :aria-label="`下移${graphNodeLabel(node.key)}节点`"
             @click="emit('move-down', node.key)"
           >
             下移
@@ -92,6 +97,7 @@ defineExpose({
             size="small"
             :type="movingCanvasNode === node.key ? 'primary' : undefined"
             :data-testid="`approval-canvas-move-${node.key}`"
+            :aria-label="`移动${graphNodeLabel(node.key)}节点`"
             @click="emit('begin-move', node.key)"
           >
             移动
@@ -101,6 +107,7 @@ defineExpose({
           v-if="node.type === 'condition'"
           size="small"
           :data-testid="`approval-canvas-add-condition-${node.key}`"
+          :aria-label="`为${graphNodeLabel(node.key)}添加条件分支`"
           @click="emit('add-condition-branch', node.key)"
         >
           +条件分支
@@ -109,6 +116,7 @@ defineExpose({
           v-if="node.type === 'parallel'"
           size="small"
           :data-testid="`approval-canvas-add-parallel-${node.key}`"
+          :aria-label="`为${graphNodeLabel(node.key)}添加并行分支`"
           @click="emit('add-parallel-branch', node.key)"
         >
           +并行分支
@@ -117,6 +125,7 @@ defineExpose({
           <el-button
             size="small"
             :data-testid="`approval-canvas-insert-${node.key}`"
+            :aria-label="`在${graphNodeLabel(node.key)}后插入审批节点`"
             @click="emit('insert-approval', node.key)"
           >
             +审批
@@ -124,6 +133,7 @@ defineExpose({
           <el-button
             size="small"
             :data-testid="`approval-canvas-insert-condition-${node.key}`"
+            :aria-label="`在${graphNodeLabel(node.key)}后插入条件节点`"
             @click="emit('insert-condition', node.key)"
           >
             +条件
@@ -132,6 +142,7 @@ defineExpose({
             v-if="canInsertParallelAfter(node)"
             size="small"
             :data-testid="`approval-canvas-insert-parallel-${node.key}`"
+            :aria-label="`在${graphNodeLabel(node.key)}后插入并行节点`"
             @click="emit('insert-parallel', node.key)"
           >
             +并行
@@ -142,6 +153,7 @@ defineExpose({
           size="small"
           type="danger"
           :data-testid="`approval-canvas-remove-${node.key}`"
+          :aria-label="`删除${graphNodeLabel(node.key)}节点`"
           @click="emit('remove', node.key)"
         >
           删除

--- a/apps/web/tests/approval-canvas-inspector-a11y.test.ts
+++ b/apps/web/tests/approval-canvas-inspector-a11y.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Wave-2 PR5 — ApprovalCanvasNodeInspector topology a11y (structural source scan).
+ * Pins stable data-testid strings (G5-C load-bearing) + business-language aria-labels
+ * that use graphNodeLabel (not raw node keys as the sole accessible name).
+ * No mount / command algebra — pure SFC source contract.
+ */
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const INSPECTOR_SRC = readFileSync(
+  join(HERE, '../src/approvals/components/ApprovalCanvasNodeInspector.vue'),
+  'utf8',
+)
+
+describe('ApprovalCanvasNodeInspector topology a11y (structural)', () => {
+  it('keeps stable topology data-testid prefixes (G5-C load-bearing)', () => {
+    expect(INSPECTOR_SRC).toMatch(/data-testid="approval-canvas-inspector"/)
+    expect(INSPECTOR_SRC).toMatch(/data-testid="approval-canvas-inspector-topology"/)
+    expect(INSPECTOR_SRC).toMatch(/data-testid="approval-canvas-inspector-close"/)
+
+    // Primary topology action testids — node.key suffix retained for existing specs.
+    expect(INSPECTOR_SRC).toMatch(/approval-canvas-move-up-\$\{node\.key\}/)
+    expect(INSPECTOR_SRC).toMatch(/approval-canvas-move-down-\$\{node\.key\}/)
+    expect(INSPECTOR_SRC).toMatch(/approval-canvas-move-\$\{node\.key\}/)
+    expect(INSPECTOR_SRC).toMatch(/approval-canvas-add-condition-\$\{node\.key\}/)
+    expect(INSPECTOR_SRC).toMatch(/approval-canvas-add-parallel-\$\{node\.key\}/)
+    expect(INSPECTOR_SRC).toMatch(/approval-canvas-insert-\$\{node\.key\}/)
+    expect(INSPECTOR_SRC).toMatch(/approval-canvas-insert-condition-\$\{node\.key\}/)
+    expect(INSPECTOR_SRC).toMatch(/approval-canvas-insert-parallel-\$\{node\.key\}/)
+    expect(INSPECTOR_SRC).toMatch(/approval-canvas-remove-\$\{node\.key\}/)
+  })
+
+  it('labels reorder / insert / remove actions with graphNodeLabel business copy', () => {
+    // Reorder
+    expect(INSPECTOR_SRC).toMatch(
+      /:aria-label="`上移\$\{graphNodeLabel\(node\.key\)\}节点`"/,
+    )
+    expect(INSPECTOR_SRC).toMatch(
+      /:aria-label="`下移\$\{graphNodeLabel\(node\.key\)\}节点`"/,
+    )
+    expect(INSPECTOR_SRC).toMatch(
+      /:aria-label="`移动\$\{graphNodeLabel\(node\.key\)\}节点`"/,
+    )
+
+    // Branch add
+    expect(INSPECTOR_SRC).toMatch(
+      /:aria-label="`为\$\{graphNodeLabel\(node\.key\)\}添加条件分支`"/,
+    )
+    expect(INSPECTOR_SRC).toMatch(
+      /:aria-label="`为\$\{graphNodeLabel\(node\.key\)\}添加并行分支`"/,
+    )
+
+    // Insert after
+    expect(INSPECTOR_SRC).toMatch(
+      /:aria-label="`在\$\{graphNodeLabel\(node\.key\)\}后插入审批节点`"/,
+    )
+    expect(INSPECTOR_SRC).toMatch(
+      /:aria-label="`在\$\{graphNodeLabel\(node\.key\)\}后插入条件节点`"/,
+    )
+    expect(INSPECTOR_SRC).toMatch(
+      /:aria-label="`在\$\{graphNodeLabel\(node\.key\)\}后插入并行节点`"/,
+    )
+
+    // Remove
+    expect(INSPECTOR_SRC).toMatch(
+      /:aria-label="`删除\$\{graphNodeLabel\(node\.key\)\}节点`"/,
+    )
+  })
+
+  it('does not use raw node.key as the sole accessible name on topology actions', () => {
+    // Forbid aria-label that is only the internal key (or only interpolates node.key).
+    expect(INSPECTOR_SRC).not.toMatch(/:aria-label="node\.key"/)
+    expect(INSPECTOR_SRC).not.toMatch(/:aria-label="`\$\{node\.key\}`"/)
+    // Every dynamic topology aria-label must go through graphNodeLabel.
+    const dynamicAriaLabels = [
+      ...INSPECTOR_SRC.matchAll(/:aria-label="`([^`]+)`"/g),
+    ].map((m) => m[1])
+    expect(dynamicAriaLabels.length).toBeGreaterThanOrEqual(9)
+    for (const label of dynamicAriaLabels) {
+      if (label.includes('node.key')) {
+        expect(label).toContain('graphNodeLabel(node.key)')
+      }
+    }
+  })
+
+  it('exposes topology toolbar and close control with static business aria-labels', () => {
+    expect(INSPECTOR_SRC).toMatch(/role="toolbar"/)
+    expect(INSPECTOR_SRC).toMatch(
+      /:aria-label="`\$\{graphNodeLabel\(node\.key\)\}节点拓扑操作`"/,
+    )
+    expect(INSPECTOR_SRC).toMatch(/aria-label="关闭节点检查器"/)
+  })
+
+  it('does not change emit contract for topology actions', () => {
+    expect(INSPECTOR_SRC).toMatch(/'move-up': \[nodeKey: string\]/)
+    expect(INSPECTOR_SRC).toMatch(/'move-down': \[nodeKey: string\]/)
+    expect(INSPECTOR_SRC).toMatch(/'begin-move': \[nodeKey: string\]/)
+    expect(INSPECTOR_SRC).toMatch(/'add-condition-branch': \[nodeKey: string\]/)
+    expect(INSPECTOR_SRC).toMatch(/'add-parallel-branch': \[nodeKey: string\]/)
+    expect(INSPECTOR_SRC).toMatch(/'insert-approval': \[nodeKey: string\]/)
+    expect(INSPECTOR_SRC).toMatch(/'insert-condition': \[nodeKey: string\]/)
+    expect(INSPECTOR_SRC).toMatch(/'insert-parallel': \[nodeKey: string\]/)
+    expect(INSPECTOR_SRC).toMatch(/remove: \[nodeKey: string\]/)
+  })
+})


### PR DESCRIPTION
## Summary
- Business-language aria-labels on inspector topology actions (insert/move/remove/branch).
- Load-bearing G5-C testids unchanged.
- Structural a11y tests.

Independent of form/detail/CI PRs. Flags OFF. Not product FINAL.

## Test plan
- [x] `vitest tests/approval-canvas-inspector-a11y.test.ts`
- [ ] CI green