### PR TITLE
chore(approval): wave-3 always-on residual canaries and smoke

### DIFF
--- a/.github/workflows/approval-web-guard.yml
+++ b/.github/workflows/approval-web-guard.yml
@@ -105,9 +105,11 @@ on:
       - 'apps/web/src/approvals/components/ApprovalCanvasNodeInspector.vue'
       - 'apps/web/tests/approval-authoring-history.test.ts'
       - 'apps/web/tests/approval-g5c-authoring-scenarios.test.ts'
-      # Residual parallel PLAN 6fa2fbf6: form history (PR1) + dual-canvas (PR2) — canaries no-op until present.
+      # Residual parallel PLAN 6fa2fbf6 / wave-3: always-on residual canaries + path filters.
       - 'apps/web/tests/approval-form-authoring-history.test.ts'
       - 'apps/web/tests/approval-version-dual-canvas.test.ts'
+      - 'apps/web/tests/approval-flow-canvas-a11y.test.ts'
+      - 'apps/web/tests/approval-canvas-inspector-a11y.test.ts'
       - 'apps/web/src/approvals/approvalFormAuthoringHistory.ts'
       - 'apps/web/src/approvals/approvalVersionDualCanvas.ts'
       - 'apps/web/src/approvals/approvalVersionReadSummary.ts'
@@ -296,9 +298,11 @@ on:
       - 'apps/web/src/approvals/components/ApprovalCanvasNodeInspector.vue'
       - 'apps/web/tests/approval-authoring-history.test.ts'
       - 'apps/web/tests/approval-g5c-authoring-scenarios.test.ts'
-      # Residual parallel PLAN 6fa2fbf6: form history (PR1) + dual-canvas (PR2) — canaries no-op until present.
+      # Residual parallel PLAN 6fa2fbf6 / wave-3: always-on residual canaries + path filters.
       - 'apps/web/tests/approval-form-authoring-history.test.ts'
       - 'apps/web/tests/approval-version-dual-canvas.test.ts'
+      - 'apps/web/tests/approval-flow-canvas-a11y.test.ts'
+      - 'apps/web/tests/approval-canvas-inspector-a11y.test.ts'
       - 'apps/web/src/approvals/approvalFormAuthoringHistory.ts'
       - 'apps/web/src/approvals/approvalVersionDualCanvas.ts'
       - 'apps/web/src/approvals/approvalVersionReadSummary.ts'
@@ -453,7 +457,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Run Canvas V2 command canaries
-        # Always-on canaries + residual PLAN 6fa2fbf6 optional files (test -f so PR3 lands green alone).
+        # Always-on canaries (Canvas V2 core + residual PLAN 6fa2fbf6 / wave-3 after files landed on main).
         run: |
           set -euo pipefail
           pnpm --filter @metasheet/web exec vitest run \
@@ -462,19 +466,11 @@ jobs:
             approval-authoring-history \
             approval-g5c-authoring-scenarios \
             approval-version-read-summary \
+            approval-form-authoring-history \
+            approval-version-dual-canvas \
+            approval-flow-canvas-a11y \
+            approval-canvas-inspector-a11y \
             --reporter=dot
-          residual=()
-          if [ -f apps/web/tests/approval-form-authoring-history.test.ts ]; then
-            residual+=(approval-form-authoring-history)
-          fi
-          if [ -f apps/web/tests/approval-version-dual-canvas.test.ts ]; then
-            residual+=(approval-version-dual-canvas)
-          fi
-          if [ "${#residual[@]}" -gt 0 ]; then
-            pnpm --filter @metasheet/web exec vitest run "${residual[@]}" --reporter=dot
-          else
-            echo "Residual form-history / dual-canvas canaries skipped (files not present yet)"
-          fi
 
       - name: Run FWB mapping authoring contract
         run: pnpm --filter @metasheet/web exec vitest run approval-fwb-mapping-config approval-fwb-mapping-editor --reporter=dot

--- a/apps/web/scripts/run-required-web-tests.sh
+++ b/apps/web/scripts/run-required-web-tests.sh
@@ -139,20 +139,18 @@
 # any existing token).
 set -euo pipefail
 cd "$(dirname "$0")/.."
-npx vitest run approval-canvas-commands approval-form-commands approval-authoring-history approval-g5c-authoring-scenarios approval-version-read-summary --reporter=dot
-# Residual parallel PLAN 6fa2fbf6 optional canaries (test -f so this gate stays green before PR1/PR2 land).
-residual=()
-if [ -f tests/approval-form-authoring-history.test.ts ]; then
-  residual+=(approval-form-authoring-history)
-fi
-if [ -f tests/approval-version-dual-canvas.test.ts ]; then
-  residual+=(approval-version-dual-canvas)
-fi
-if [ "${#residual[@]}" -gt 0 ]; then
-  npx vitest run "${residual[@]}" --reporter=dot
-else
-  echo "Residual form-history / dual-canvas canaries skipped (files not present yet)"
-fi
+# Always-on Canvas V2 + residual PLAN 6fa2fbf6 / wave-3 canaries (files landed on main via #4815–#4819).
+npx vitest run \
+  approval-canvas-commands \
+  approval-form-commands \
+  approval-authoring-history \
+  approval-g5c-authoring-scenarios \
+  approval-version-read-summary \
+  approval-form-authoring-history \
+  approval-version-dual-canvas \
+  approval-flow-canvas-a11y \
+  approval-canvas-inspector-a11y \
+  --reporter=dot
 npx vitest run featureFlagsApprovalAttachments --reporter=dot
 npx vitest run approval-fwb-mapping-config approval-fwb-mapping-editor --reporter=dot
 npx vitest run fwb-rule-authoring-helpers fwb-rule-authoring --reporter=dot

--- a/docs/development/approval-canvas-residual-parallel-design-20260808.md
+++ b/docs/development/approval-canvas-residual-parallel-design-20260808.md
@@ -1,8 +1,9 @@
 # Approval Canvas Residual Parallel Engineering (2026-08-08)
 
-**Status:** AUTHORITATIVE FOR PARALLEL EXECUTION  
+**Status:** DONE (wave-1)  
 **PLAN_ID:** `6fa2fbf6`  
 **Base:** `origin/main` at residual start (post #4806 / #4811 / #4812)  
+**Merged:** #4815 (PR1 form history), #4816 (PR2 dual canvas), #4817 (PR3 G5-C CI/smoke)  
 **Flags:** remain default OFF. No product FINAL claim. No G0 ratify flip.
 
 ## Goal
@@ -24,23 +25,23 @@ Ship residual product polish after Canvas final-eligibility land, as **three ind
 
 ## PR Plan
 
-### PR 1: Form session undo/redo — OPEN
+### PR 1: Form session undo/redo — DONE (#4815)
 
 - **Description:** Add pure `approvalFormAuthoringHistory` snapshot history for form field list mutations (add/remove/reorder/type change via existing helpers). Wire form-section undo/redo toolbar in `TemplateAuthoringView` (Canvas V2 or always-available for form section; keep canvas history separate). Fail closed on empty stacks. No field-id ordinary-user entry. Tests pure + mounted pin.
 - **Files/components affected:** `apps/web/src/approvals/approvalFormAuthoringHistory.ts` (new), `apps/web/src/views/approval/TemplateAuthoringView.vue`, `apps/web/tests/approval-form-authoring-history.test.ts` (new), optional G5-C structural pin  
 - **Dependencies:** None  
 
-### PR 2: Dual-canvas version compare (D8-b residual) — OPEN
+### PR 2: Dual-canvas version compare (D8-b residual) — DONE (#4816)
 
 - **Description:** Pure model builds side-by-side before/after graph layouts + change badges from existing diff/overlay inputs. Wire a **双画布** mode in `TemplateDetailView` version panel (in addition to list + single overlay). Read-only; no restore semantics change; no network contract change. Tests pure + lightweight mount/summary pins.
 - **Files/components affected:** `apps/web/src/approvals/approvalVersionDualCanvas.ts` (new), `apps/web/src/views/approval/TemplateDetailView.vue`, `apps/web/tests/approval-version-dual-canvas.test.ts` (new)  
 - **Dependencies:** None  
 
-### PR 3: G5-C CI canaries + owner smoke harness — OPEN
+### PR 3: G5-C CI canaries + owner smoke harness — DONE (#4817)
 
 - **Description:** Expand CI canaries for new residual test files once present; add `scripts/ops/approval-canvas-owner-uat-smoke.sh` checklist runner (values-free, flag-aware, does not flip env). Keep gate workflow honest. Update residual design ledger statuses after land.
 - **Files/components affected:** `.github/workflows/approval-web-guard.yml`, `apps/web/scripts/run-required-web-tests.sh`, `scripts/ops/approval-canvas-owner-uat-smoke.sh` (new), `.grok/workflows/approval-canvas-final-gate.rhai`, this design doc  
-- **Dependencies:** None (can land before PR1/PR2; canaries no-op if files missing until follow-up, or list only existing + document pending)
+- **Dependencies:** None (landed with optional `test -f` residual canaries; wave-3 PR6 promotes to always-on)
 
 ## Execute order
 
@@ -54,13 +55,20 @@ Max parallelism: 3. Stack assembly optional (independent PRs into main).
 
 Agents may implement, test, push, open draft PRs, arm auto-merge when green. Must not flip flags or claim product FINAL.
 
-## CI canary policy (PR3)
+## CI canary policy (PR3 → wave-3 PR6)
 
 - Existing Canvas V2 canaries remain required always-on:
   `approval-canvas-commands`, `approval-form-commands`, `approval-authoring-history`,
   `approval-g5c-authoring-scenarios`, `approval-version-read-summary`.
-- Residual canaries use `test -f` guards so this PR stays green alone:
-  - `apps/web/tests/approval-form-authoring-history.test.ts` (PR1)
-  - `apps/web/tests/approval-version-dual-canvas.test.ts` (PR2)
+- Residual canaries (promoted always-on in wave-3 after files landed):
+  - `approval-form-authoring-history` (#4815)
+  - `approval-version-dual-canvas` (#4816)
+  - `approval-flow-canvas-a11y` (#4818)
+  - `approval-canvas-inspector-a11y` (#4819)
 - Owner smoke: `SKIP_TESTS=1 scripts/ops/approval-canvas-owner-uat-smoke.sh` for values-free checks;
-  omit `SKIP_TESTS` to also run focused history + G5-C vitest when `pnpm` is available.
+  omit `SKIP_TESTS` to also run focused history + G5-C + residual vitest when `pnpm` is available.
+
+## Follow-on
+
+- Wave-2 a11y polish: see `approval-canvas-residual-parallel-wave2-design-20260808.md` (DONE #4818–#4819).
+- Wave-3 canaries/smoke + remaining polish: see `approval-canvas-residual-parallel-wave3-design-20260808.md` (`6fa2fbf6-w3`).

--- a/docs/development/approval-canvas-residual-parallel-wave2-design-20260808.md
+++ b/docs/development/approval-canvas-residual-parallel-wave2-design-20260808.md
@@ -1,8 +1,9 @@
 # Approval Canvas Residual Parallel — Wave 2 (2026-08-08)
 
-**Status:** AUTHORITATIVE FOR WAVE-2 PARALLEL EXECUTION  
+**Status:** DONE  
 **PLAN_ID:** `6fa2fbf6-w2`  
 **Depends on wave-1 PRs:** none for file ownership (wave-1 is #4815 form history, #4816 dual canvas, #4817 CI/smoke)  
+**Merged:** #4818 (PR4 flow canvas a11y), #4819 (PR5 inspector topology a11y)  
 **Flags:** default OFF. No product FINAL.
 
 ## Goal
@@ -24,13 +25,13 @@ G0 / UAT / flags / D3 / product FINAL / form undo wiring / dual-canvas detail pa
 
 ## PR Plan
 
-### PR 4: Flow canvas edge-insert a11y — OPEN
+### PR 4: Flow canvas edge-insert a11y — DONE (#4818)
 
 - **Description:** Ensure every edge mid-point `+` control has an explicit accessible name (aria-label business copy, no edge keys). Keyboard focusable (`tabindex=0` or native button). Add/extend pure structural or shallow mount tests under `apps/web/tests/`. No graph semantic changes.
 - **Files/components affected:** `apps/web/src/approvals/components/ApprovalFlowCanvas.vue`, `apps/web/tests/approval-flow-canvas-a11y.test.ts` (new) or extend existing canvas inspector tests without touching TemplateAuthoringView  
 - **Dependencies:** None  
 
-### PR 5: Inspector topology a11y — OPEN
+### PR 5: Inspector topology a11y — DONE (#4819)
 
 - **Description:** Topology insert/remove controls in `ApprovalCanvasNodeInspector` get stable `data-testid` (if missing) + aria-labels in business language. No command algebra change. Tests structural or shallow.
 - **Files/components affected:** `apps/web/src/approvals/components/ApprovalCanvasNodeInspector.vue`, `apps/web/tests/approval-canvas-inspector-a11y.test.ts` (new)  
@@ -41,3 +42,7 @@ G0 / UAT / flags / D3 / product FINAL / form undo wiring / dual-canvas detail pa
 ```text
 Level 0: PR4 || PR5   (and continue babysit wave-1 #4815||#4816||#4817)
 ```
+
+## Follow-on
+
+Wave-3 (`6fa2fbf6-w3`): promote residual canaries always-on + smoke honesty + additional polish lanes — see `approval-canvas-residual-parallel-wave3-design-20260808.md`.

--- a/docs/development/approval-canvas-residual-parallel-wave3-design-20260808.md
+++ b/docs/development/approval-canvas-residual-parallel-wave3-design-20260808.md
@@ -25,14 +25,9 @@ Four independent residual polish lanes with **no shared hot file**:
 
 ## PR Plan
 
-### PR 6: Promote residual canaries + smoke honesty — OPEN (this wave)
+### PR 6: Promote residual canaries + smoke honesty — OPEN
 
 - **Description:** Residual test files now exist on main. Promote form-history + dual-canvas from optional `test -f` to always-on canaries; add flow-canvas-a11y + inspector-a11y canaries. Update owner smoke to verify residual modules present. Stamp wave-1/2 design ledgers DONE with PR numbers.
-- **Always-on residual canaries:**
-  - `approval-form-authoring-history`
-  - `approval-version-dual-canvas`
-  - `approval-flow-canvas-a11y`
-  - `approval-canvas-inspector-a11y`
 - **Files/components affected:** `.github/workflows/approval-web-guard.yml`, `apps/web/scripts/run-required-web-tests.sh`, `scripts/ops/approval-canvas-owner-uat-smoke.sh`, residual design MDs (wave1/2/3)  
 - **Dependencies:** None  
 
@@ -63,10 +58,3 @@ Level 0 parallel: PR6 || PR7 || PR8 || PR9
 ## Autonomy
 
 Agents implement, test, push, open PRs, arm squash auto-merge. Must not flip flags or claim product FINAL.
-
-## Prior waves (closed)
-
-| Wave | PLAN_ID | PRs |
-|---|---|---|
-| Wave-1 | `6fa2fbf6` | #4815 form history, #4816 dual canvas, #4817 CI/smoke |
-| Wave-2 | `6fa2fbf6-w2` | #4818 flow canvas a11y, #4819 inspector a11y |

--- a/docs/development/approval-canvas-residual-parallel-wave3-design-20260808.md
+++ b/docs/development/approval-canvas-residual-parallel-wave3-design-20260808.md
@@ -1,0 +1,72 @@
+# Approval Canvas Residual Parallel — Wave 3 (2026-08-08)
+
+**Status:** AUTHORITATIVE FOR WAVE-3 PARALLEL EXECUTION  
+**PLAN_ID:** `6fa2fbf6-w3`  
+**Base:** `origin/main` after wave-1 (#4815–#4817) + wave-2 (#4818–#4819)  
+**Flags:** default OFF. No product FINAL. No G0 ratify flip.
+
+## Goal
+
+Four independent residual polish lanes with **no shared hot file**:
+
+| Lane | Owns | Does not touch |
+|---|---|---|
+| **PR6** CI canaries + smoke + ledger closeout | workflows, `run-required-web-tests.sh`, smoke script, residual design MDs | product Vue |
+| **PR7** Edge-insert **menu** a11y | `ApprovalFlowCanvas.vue` + a11y test | Authoring/Detail/CI |
+| **PR8** Form palette focus-return | `TemplateAuthoringView.vue` form section only | Detail / FlowCanvas / CI |
+| **PR9** G5-C structural pins | `approval-g5c-authoring-scenarios.test.ts` only | product Vue sources |
+
+## Non-goals
+
+- G0 / real-tenant UAT / staged flag ON  
+- D3 Vue Flow / ELK  
+- Product FINAL claim  
+- Full dual-canvas editor-embedded chrome beyond TemplateDetailView  
+
+## PR Plan
+
+### PR 6: Promote residual canaries + smoke honesty — OPEN (this wave)
+
+- **Description:** Residual test files now exist on main. Promote form-history + dual-canvas from optional `test -f` to always-on canaries; add flow-canvas-a11y + inspector-a11y canaries. Update owner smoke to verify residual modules present. Stamp wave-1/2 design ledgers DONE with PR numbers.
+- **Always-on residual canaries:**
+  - `approval-form-authoring-history`
+  - `approval-version-dual-canvas`
+  - `approval-flow-canvas-a11y`
+  - `approval-canvas-inspector-a11y`
+- **Files/components affected:** `.github/workflows/approval-web-guard.yml`, `apps/web/scripts/run-required-web-tests.sh`, `scripts/ops/approval-canvas-owner-uat-smoke.sh`, residual design MDs (wave1/2/3)  
+- **Dependencies:** None  
+
+### PR 7: Edge-insert menu item a11y — OPEN
+
+- **Description:** Menu buttons for insert approval/condition/parallel get business-language `aria-label` (no edge keys). Fit-to-view control gets aria-label if missing. Expand `approval-flow-canvas-a11y.test.ts` structural pins. No graph semantics.
+- **Files/components affected:** `apps/web/src/approvals/components/ApprovalFlowCanvas.vue`, `apps/web/tests/approval-flow-canvas-a11y.test.ts`  
+- **Dependencies:** None  
+
+### PR 8: Form palette focus return after add — OPEN
+
+- **Description:** After `addFieldOfType` / structural add, focus the new field row (or set selection) so keyboard/screen-reader authors land on the created field. Optional `aria-live` polite announcement. Wire through existing form history. Tests structural or focused mounted pin for focus/selection.
+- **Files/components affected:** `apps/web/src/views/approval/TemplateAuthoringView.vue`, optional `apps/web/tests/approval-form-palette-focus.test.ts`  
+- **Dependencies:** None  
+
+### PR 9: G5-C residual structural pins — OPEN
+
+- **Description:** Extend G5-C suite (source-scan style) to pin: form undo/redo testids, dual-canvas testids/module import, edge-insert + inspector a11y labels. No product code.
+- **Files/components affected:** `apps/web/tests/approval-g5c-authoring-scenarios.test.ts`  
+- **Dependencies:** None  
+
+## Execute order
+
+```text
+Level 0 parallel: PR6 || PR7 || PR8 || PR9
+```
+
+## Autonomy
+
+Agents implement, test, push, open PRs, arm squash auto-merge. Must not flip flags or claim product FINAL.
+
+## Prior waves (closed)
+
+| Wave | PLAN_ID | PRs |
+|---|---|---|
+| Wave-1 | `6fa2fbf6` | #4815 form history, #4816 dual canvas, #4817 CI/smoke |
+| Wave-2 | `6fa2fbf6-w2` | #4818 flow canvas a11y, #4819 inspector a11y |

--- a/scripts/ops/approval-canvas-owner-uat-smoke.sh
+++ b/scripts/ops/approval-canvas-owner-uat-smoke.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Approval Canvas residual G5-C owner UAT smoke harness (values-free).
 #
-# PLAN_ID=6fa2fbf6 PR3 — checklist runner for owner handoff preflight.
+# PLAN_ID=6fa2fbf6-w3 PR6 — checklist runner for owner handoff preflight.
 # Does NOT flip env flags, does NOT claim product FINAL, does NOT hit real tenants.
 #
 # Usage:
@@ -81,7 +81,7 @@ done < <(
 )
 
 # ---------------------------------------------------------------------------
-# 3) Owner handoff doc present
+# 3) Owner handoff + residual design ledgers present
 # ---------------------------------------------------------------------------
 HANDOFF="docs/development/approval-canvas-data-closure-owner-handoff-20260808.md"
 if [[ -f "$HANDOFF" ]]; then
@@ -90,7 +90,6 @@ else
   fail "missing owner handoff ${HANDOFF}"
 fi
 
-# Residual design ledger (PLAN 6fa2fbf6) present on this branch
 LEDGER="docs/development/approval-canvas-residual-parallel-design-20260808.md"
 if [[ -f "$LEDGER" ]]; then
   if grep -q '6fa2fbf6' "$LEDGER"; then
@@ -103,42 +102,45 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# 4) Optional focused vitest (history + g5c). Skippable via SKIP_TESTS=1.
+# 4) Residual modules + tests present (wave-1/2 landed; wave-3 promotes canaries)
+# ---------------------------------------------------------------------------
+require_file() {
+  local path="$1"
+  if [[ -f "$path" ]]; then
+    ok "present: ${path}"
+  else
+    fail "missing residual path: ${path}"
+  fi
+}
+
+require_file "apps/web/src/approvals/approvalFormAuthoringHistory.ts"
+require_file "apps/web/src/approvals/approvalVersionDualCanvas.ts"
+require_file "apps/web/tests/approval-form-authoring-history.test.ts"
+require_file "apps/web/tests/approval-version-dual-canvas.test.ts"
+require_file "apps/web/tests/approval-flow-canvas-a11y.test.ts"
+require_file "apps/web/tests/approval-canvas-inspector-a11y.test.ts"
+
+# ---------------------------------------------------------------------------
+# 5) Optional focused vitest. Skippable via SKIP_TESTS=1.
 # ---------------------------------------------------------------------------
 if [[ "$SKIP_TESTS" == "1" ]]; then
-  ok "SKIP_TESTS=1 — skipping focused vitest (history + g5c)"
+  ok "SKIP_TESTS=1 — skipping focused vitest (history + g5c + residual)"
 else
   if ! command -v pnpm >/dev/null 2>&1; then
     log "WARN: pnpm not available — skipping focused vitest"
   else
-    log "Running focused vitest: approval-authoring-history + approval-g5c-authoring-scenarios"
+    log "Running focused vitest: history + g5c + residual always-on canaries"
     if pnpm --filter @metasheet/web exec vitest run --watch=false \
       tests/approval-authoring-history.test.ts \
       tests/approval-g5c-authoring-scenarios.test.ts \
+      tests/approval-form-authoring-history.test.ts \
+      tests/approval-version-dual-canvas.test.ts \
+      tests/approval-flow-canvas-a11y.test.ts \
+      tests/approval-canvas-inspector-a11y.test.ts \
       --reporter=dot; then
-      ok "focused vitest (history + g5c) passed"
+      ok "focused vitest (history + g5c + residual) passed"
     else
-      fail "focused vitest (history + g5c) failed"
-    fi
-
-    # Residual PR1/PR2 canaries when present
-    residual=()
-    if [[ -f apps/web/tests/approval-form-authoring-history.test.ts ]]; then
-      residual+=(tests/approval-form-authoring-history.test.ts)
-    fi
-    if [[ -f apps/web/tests/approval-version-dual-canvas.test.ts ]]; then
-      residual+=(tests/approval-version-dual-canvas.test.ts)
-    fi
-    if [[ ${#residual[@]} -gt 0 ]]; then
-      log "Running residual canaries: ${residual[*]}"
-      if pnpm --filter @metasheet/web exec vitest run --watch=false \
-        "${residual[@]}" --reporter=dot; then
-        ok "residual canaries passed"
-      else
-        fail "residual canaries failed"
-      fi
-    else
-      ok "residual form-history / dual-canvas tests not present yet (skipped)"
+      fail "focused vitest (history + g5c + residual) failed"
     fi
   fi
 fi


### PR DESCRIPTION
## Summary
- Promote residual canaries always-on: form-history, dual-canvas, flow-canvas-a11y, inspector-a11y.
- Owner smoke verifies residual modules/tests; wave-1/2 ledgers stamped DONE; wave-3 design ledger.
- PLAN `6fa2fbf6-w3` PR6. Flags OFF. Not product FINAL.

## Test plan
- [x] `SKIP_TESTS=1 ./scripts/ops/approval-canvas-owner-uat-smoke.sh`
- [ ] CI green