### PR TITLE
feat(approval): a11y labels on canvas edge-insert menu items

### DIFF
--- a/apps/web/src/approvals/components/ApprovalFlowCanvas.vue
+++ b/apps/web/src/approvals/components/ApprovalFlowCanvas.vue
@@ -149,7 +149,12 @@ function nodePosStyle(pos: NodeLayout): CSSProperties {
           @click="emit('zoom-in')"
         />
       </el-button-group>
-      <el-button :icon="FullScreen" data-testid="approval-canvas-fit" @click="emit('fit')">
+      <el-button
+        :icon="FullScreen"
+        aria-label="适应画布"
+        data-testid="approval-canvas-fit"
+        @click="emit('fit')"
+      >
         适应画布
       </el-button>
     </div>
@@ -234,6 +239,7 @@ function nodePosStyle(pos: NodeLayout): CSSProperties {
                 <button
                   type="button"
                   role="menuitem"
+                  aria-label="插入审批节点"
                   data-testid="approval-canvas-edge-insert-approval"
                   @click.stop="emit('edge-insert-approval', line.key)"
                 >
@@ -242,6 +248,7 @@ function nodePosStyle(pos: NodeLayout): CSSProperties {
                 <button
                   type="button"
                   role="menuitem"
+                  aria-label="插入条件分支"
                   data-testid="approval-canvas-edge-insert-condition"
                   @click.stop="emit('edge-insert-condition', line.key)"
                 >
@@ -251,6 +258,7 @@ function nodePosStyle(pos: NodeLayout): CSSProperties {
                   v-if="canInsertParallelOnEdge(line.key)"
                   type="button"
                   role="menuitem"
+                  aria-label="插入并行分支"
                   data-testid="approval-canvas-edge-insert-parallel"
                   @click.stop="emit('edge-insert-parallel', line.key)"
                 >

--- a/apps/web/tests/approval-flow-canvas-a11y.test.ts
+++ b/apps/web/tests/approval-flow-canvas-a11y.test.ts
@@ -48,4 +48,24 @@ describe('ApprovalFlowCanvas a11y (structural)', () => {
     expect(CANVAS_SRC).toMatch(/@keydown\.space/)
     expect(CANVAS_SRC).toMatch(/:aria-pressed="selectedCanvasNode === pos\.key"/)
   })
+
+  it('edge-insert menu items use business-language aria-labels (no edge keys)', () => {
+    expect(CANVAS_SRC).toMatch(/aria-label="插入审批节点"/)
+    expect(CANVAS_SRC).toMatch(/aria-label="插入条件分支"/)
+    expect(CANVAS_SRC).toMatch(/aria-label="插入并行分支"/)
+    // Menu item labels must not interpolate edge keys into accessible names
+    expect(CANVAS_SRC).not.toMatch(
+      /edge-insert-(approval|condition|parallel)[\s\S]{0,200}:aria-label="[^"]*\$\{line\.key\}/,
+    )
+    expect(CANVAS_SRC).not.toMatch(
+      /aria-label="[^"]*\$\{line\.key\}[^"]*"[\s\S]{0,120}edge-insert-(approval|condition|parallel)/,
+    )
+  })
+
+  it('fit-to-view toolbar control has business aria-label', () => {
+    expect(CANVAS_SRC).toMatch(/data-testid="approval-canvas-fit"/)
+    expect(CANVAS_SRC).toMatch(
+      /data-testid="approval-canvas-fit"[\s\S]{0,120}aria-label="适应画布"|aria-label="适应画布"[\s\S]{0,120}data-testid="approval-canvas-fit"/,
+    )
+  })
 })


### PR DESCRIPTION
## Summary
- Business aria-labels on edge-insert menu (审批/条件/并行) + fit control.
- Structural a11y test pins. PLAN `6fa2fbf6-w3` PR7.

## Test plan
- [x] vitest approval-flow-canvas-a11y
- [ ] CI green