### PR TITLE
feat(approval): focus newly added form field from palette

### DIFF
--- a/apps/web/src/views/approval/TemplateAuthoringView.vue
+++ b/apps/web/src/views/approval/TemplateAuthoringView.vue
@@ -273,10 +273,17 @@
 
         <div
           v-for="(field, index) in draft.fields"
+          :id="`approval-field-row-${field.localId}`"
           :key="field.localId"
           class="template-authoring__item"
+          :class="{ 'template-authoring__item--focused': formFieldFocusLocalId === field.localId }"
           data-testid="approval-template-field-row"
+          :data-field-local-id="field.localId"
+          :data-selected="formFieldFocusLocalId === field.localId ? 'true' : undefined"
+          :aria-current="formFieldFocusLocalId === field.localId ? 'true' : undefined"
+          tabindex="-1"
           :draggable="!readOnly"
+          @focusin="selectFormFieldFocus(field.localId)"
           @dragstart="onFieldDragStart(index)"
           @dragover.prevent
           @drop="onFieldDrop(index)"
@@ -2039,6 +2046,30 @@ function applyFormFieldsStructural(
   formFieldFocusLocalId.value = next.focusLocalId
 }
 
+/** UI selection only — does not push form history (focus-only; structural stack unchanged). */
+function selectFormFieldFocus(localId: string): void {
+  if (formFieldFocusLocalId.value === localId) return
+  formFieldFocusLocalId.value = localId
+}
+
+/**
+ * After palette/add, land keyboard authors on the new field row (selection already set via
+ * form history focusLocalId). Prefer the label input; fall back to the row shell.
+ */
+async function focusFormFieldRow(localId: string): Promise<void> {
+  formFieldFocusLocalId.value = localId
+  await nextTick()
+  const row = document.getElementById(`approval-field-row-${localId}`)
+  if (!row) return
+  row.scrollIntoView?.({ behavior: 'smooth', block: 'nearest' })
+  const labelInput = row.querySelector('input') as HTMLInputElement | null
+  if (labelInput && !labelInput.disabled) {
+    labelInput.focus()
+    return
+  }
+  row.focus()
+}
+
 function onFormFieldUndo(): void {
   if (readOnly.value) return
   // Align tip with live draft so in-place edits since last structural op redo correctly.
@@ -2686,7 +2717,9 @@ const fieldPaletteEntries = AUTHORABLE_FIELD_TYPES.map((type) => ({
 function addField() {
   if (readOnly.value) return
   const added = createEmptyFieldDraft(draft.value.fields.length + 1)
+  // Structural push carries focusLocalId so undo restores prior focus (#4815).
   applyFormFieldsStructural([...draft.value.fields, added], added.localId)
+  void focusFormFieldRow(added.localId)
 }
 
 /** D6-f2 palette: add a field of the chosen kind without ordinary-user ID entry. */
@@ -2705,7 +2738,9 @@ function addFieldOfType(type: AuthorableFieldType) {
       optionsText: '',
     }]
   }
+  // Structural push sets form history focusLocalId to the new field; UI selection follows.
   applyFormFieldsStructural([...draft.value.fields, next], next.localId)
+  void focusFormFieldRow(next.localId)
 }
 
 function removeField(index: number) {
@@ -3409,6 +3444,17 @@ onUnmounted(() => {
 .template-authoring__item--highlighted {
   border-color: var(--el-color-primary);
   box-shadow: 0 0 0 2px var(--el-color-primary-light-5);
+}
+
+/* Form palette focus-return: selected field row (formFieldFocusLocalId). */
+.template-authoring__item--focused {
+  border-color: var(--el-color-primary);
+  box-shadow: 0 0 0 1px var(--el-color-primary-light-5);
+}
+
+.template-authoring__item--focused:focus {
+  outline: 2px solid var(--el-color-primary);
+  outline-offset: 2px;
 }
 
 /* G-B2-06 read-only linear flow spine. */

--- a/apps/web/tests/approval-form-palette-focus.test.ts
+++ b/apps/web/tests/approval-form-palette-focus.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Wave-3 PR8 — Form palette focus-return after add.
+ * Pure structural source-scan (G5-C style): no full TemplateAuthoringView mount.
+ *
+ * Pins: addFieldOfType / addField push new field localId into form history focus,
+ * UI selection follows formFieldFocusLocalId, and DOM focus lands on the new row.
+ * Structural mutations still go through applyFormFieldsStructural (#4815 undo/redo).
+ */
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const VIEW_SRC = readFileSync(
+  join(__dirname, '../src/views/approval/TemplateAuthoringView.vue'),
+  'utf8',
+)
+
+describe('TemplateAuthoringView form palette focus-return (structural)', () => {
+  it('addFieldOfType sets form history focus to the new field localId', () => {
+    // Palette add must pass next.localId as nextFocus into structural push.
+    expect(VIEW_SRC).toMatch(/function addFieldOfType\s*\(/)
+    expect(VIEW_SRC).toMatch(
+      /applyFormFieldsStructural\(\[\.\.\.draft\.value\.fields,\s*next\],\s*next\.localId\)/,
+    )
+    // DOM focus-return after structural push (keyboard authors land on created field).
+    expect(VIEW_SRC).toMatch(
+      /applyFormFieldsStructural\(\[\.\.\.draft\.value\.fields,\s*next\],\s*next\.localId\)\s*\n\s*void focusFormFieldRow\(next\.localId\)/,
+    )
+  })
+
+  it('addField also focuses the newly added field', () => {
+    expect(VIEW_SRC).toMatch(
+      /applyFormFieldsStructural\(\[\.\.\.draft\.value\.fields,\s*added\],\s*added\.localId\)/,
+    )
+    expect(VIEW_SRC).toMatch(
+      /applyFormFieldsStructural\(\[\.\.\.draft\.value\.fields,\s*added\],\s*added\.localId\)\s*\n\s*void focusFormFieldRow\(added\.localId\)/,
+    )
+  })
+
+  it('field row UI selection follows formFieldFocusLocalId (data-selected / aria-current)', () => {
+    expect(VIEW_SRC).toMatch(/data-testid="approval-template-field-row"/)
+    expect(VIEW_SRC).toMatch(
+      /:data-selected="formFieldFocusLocalId === field\.localId \? 'true' : undefined"/,
+    )
+    expect(VIEW_SRC).toMatch(
+      /:aria-current="formFieldFocusLocalId === field\.localId \? 'true' : undefined"/,
+    )
+    expect(VIEW_SRC).toMatch(
+      /'template-authoring__item--focused': formFieldFocusLocalId === field\.localId/,
+    )
+    expect(VIEW_SRC).toMatch(/:id="`approval-field-row-\$\{field\.localId\}`"/)
+  })
+
+  it('focusFormFieldRow lands keyboard focus on the new row / label input', () => {
+    expect(VIEW_SRC).toMatch(/async function focusFormFieldRow\s*\(\s*localId:\s*string\s*\)/)
+    expect(VIEW_SRC).toMatch(/getElementById\(`approval-field-row-\$\{localId\}`\)/)
+    expect(VIEW_SRC).toMatch(/labelInput\.focus\(\)/)
+    // Selection sync without structural history stack pollution.
+    expect(VIEW_SRC).toMatch(/function selectFormFieldFocus\s*\(\s*localId:\s*string\s*\)/)
+    expect(VIEW_SRC).toMatch(/@focusin="selectFormFieldFocus\(field\.localId\)"/)
+  })
+
+  it('structural field mutations still go through form history (undo/redo safe)', () => {
+    expect(VIEW_SRC).toMatch(/function applyFormFieldsStructural\s*\(/)
+    expect(VIEW_SRC).toMatch(/pushFormSnapshot\(/)
+    expect(VIEW_SRC).toMatch(/formFieldFocusLocalId\.value = next\.focusLocalId/)
+    // Undo/redo restore focusLocalId from history tip.
+    expect(VIEW_SRC).toMatch(/formFieldFocusLocalId\.value = result\.focusLocalId/)
+    expect(VIEW_SRC).toMatch(/data-testid="approval-form-undo"/)
+    expect(VIEW_SRC).toMatch(/data-testid="approval-form-redo"/)
+  })
+})


### PR DESCRIPTION
## Summary
- Palette/add focuses new field row (selection + DOM focus); form history focusLocalId preserved.
- Structural tests. PLAN `6fa2fbf6-w3` PR8.

## Test plan
- [x] vitest approval-form-palette-focus + form-authoring-history
- [ ] CI green