### PR TITLE
fix(dingtalk): closeout review — T3 source authority (all modes) + OPS-01 reversible deny-row evidence (Rev 4.4)

### DIFF
--- a/docs/development/dingtalk-deprovision-reactivation-and-evidence-chain-design-20260723.md
+++ b/docs/development/dingtalk-deprovision-reactivation-and-evidence-chain-design-20260723.md
@@ -71,6 +71,15 @@ CHANGES REQUESTED @ main=45cf3a7c51）会签裁决「Rev 4.3 可以终签」。�
 （`directory-deprovision-writer-ledger.db.test.ts`），mutation 六连杀（restore DELETE、creation 规划、
 no-op 豁免、writer INSERT、org 校验、激活源门控）。
 
+**可逆性边界（独立对抗审 P2，2026-08-09 落账 — 措辞限定，非行为变更）**：creation effect 的
+DELETE 逆转仅在其事件仍为 `applied` 时可用。任何后续 access-graph 写（例：管理员
+`PATCH /status` 重新启用、更新的离岗事件）按 §5.4 将证据 **supersede**，此后 `rehire` 与
+`admin_force` 均被既有门拒绝（`EVENT_NOT_APPLIED`），deny 行成为**无 live 证据的残留**——且后续
+离岗 planner 见行已存在也不再补记 creation effect。该 supersede 语义为 main 既有合同（本勘误
+未触碰那两道门），故 Rev 4.4 的承诺应读作：「**在事件被 supersede 之前**，deny 行的存在性变化
+可被 restore 安全逆转」。残留行的补偿路径（人工清理 or 再证据化）列入 owner 会签清单（验证 MD
+§4 第 3 项）。另：多 active 源的 org 派生消歧为 follow-up hardening（#4833）。
+
 产品方向见 companion — **已赞成**。  
 **Implementation design lock 已于 2026-07-23 批准。**  
 序：lock → T1→T2→T3 → D1…D7 → canary。  

--- a/docs/development/dingtalk-deprovision-reactivation-and-evidence-chain-design-20260723.md
+++ b/docs/development/dingtalk-deprovision-reactivation-and-evidence-chain-design-20260723.md
@@ -1,7 +1,7 @@
 # DingTalk Deprovision 恢复 + Preview/UI 证据链 — 实现级设计
 
 - Date: 2026-07-23
-- Status: **implementation design lock / Rev 4.3**
+- Status: **implementation design lock / Rev 4.4**（Rev 4.3 已终签；Rev 4.4 为 OPS-01 证据模型勘误，见 §0.7）
 - Locked: 2026-07-23（owner 批准两篇一并升 lock）
 - Scope: 打开 `DIRECTORY_DEPROVISION_ENABLED` 之前，把「权威 effect 账本 + prospective planner + 全写者 per-user 锁 + event 恢复（含 drift）」设计正确
 - Baseline: **`origin/main @ 1bcfc86b8`**；相对 `ca625f14a` 本线相关代码 **scoped diff = 0**（membership + globally-clear 事实基线仍成立）
@@ -51,6 +51,25 @@ Prospective planner、三 effect 意图、event 恢复、全写者锁意图、ma
 | **P1** | `globally_clear` 被误读为「清全部组织 membership」，与主写者的 org/global 双候选语义及 `UNIQUE(event_id,effect_type)` 冲突 | 每 event 只记源 integration 所属 org 的一条 `membership_changed`；`globally_clear` 只门控 `grant_changed` / `user_changed` |
 
 **Ratification 记录（2026-08-07）**：owner 于会话「钉钉同步业务功能开发-260721」下达收尾指令（「请排序并完成所有这条线剩余的开发」），采纳的收尾意见以「显式批准 Rev 4.3 的来源组织单 membership effect 语义」为第 1 步 —— 本勘误据此落账执行。该勘误使锁文与已落 main 的主写者语义（W4-PRE-1d owner P2 裁决，#4530 review issuecomment-5043752399：org 候选与 global 候选分立，global 守卫只门控 grant/`users.is_active`）一致，并非新语义。终版随验证 MD 提请 owner 会签。
+
+### 0.7 Rev 4.3 → Rev 4.4（OPS-01 evidence erratum — 会签指令）
+
+**Rev 4.3 终签记录（2026-08-08）**：closeout 复审（会话「钉钉同步业务功能开发-260721」，审阅结论
+CHANGES REQUESTED @ main=45cf3a7c51）会签裁决「Rev 4.3 可以终签」。§0.6 勘误自此为 RATIFIED。
+
+**Rev 4.4 勘误（同一复审的会签指令，逐字要点）**：「OPS-01 暂不签 — ledger 必须记录『grant 行
+从不存在到 disabled』的存在性变化，restore 时才能安全删除；不能仅调整 upsert 位置。」
+
+| # | 问题 | Rev 4.4 锁定 |
+|---|------|--------------|
+| **P1** | OPS-01 的显式 disabled grant 行由 writer 在 ledger 之外无条件写入：从未有过 grant 的人离岗后被留下孤儿 deny 行，rehire restore 无 effect 可逆转，OAuth `ensureGrant`（creation-only）被永久挡死 | grant 表的一切写入**纯 effect 驱动**：有 enabled 行 → `grant_changed` 翻转 effect（restore 翻回）；无任何行且 globally-clear → `grant_changed` **creation effect**（`before=after=FALSE`，新列 `grant_row_created=TRUE`），writer 据此 INSERT deny 行，restore 据此 **DELETE** 恢复「无行」态；deny 行已存在 → 无 effect、零写 |
+| **P2** | 零 effect 候选走了与有 effect 候选相反的 deny 语义（early return 跳过 bookkeeping upsert） | 语义统一后该分叉不复存在：globally-clear 且无行 ⇒ 必有 creation effect（不再是零 effect）；零 effect ⇒ 真正无事可改、零写（§5.3 不变量恢复干净），真库金标断言零 effect 运行前后 OAuth loginability 不变 |
+| schema | creation 标记必须与其余证据同等防篡改 | `directory_deprovision_effects.grant_row_created boolean NOT NULL DEFAULT FALSE` + CHECK（仅 `grant_changed` 且 `before=after=FALSE` 可为 TRUE）+ immutability trigger 扩列；migration down() 在存在 creation 证据时拒绝降级 |
+
+**§5.2/§5.3 的适用性**：本勘误不改 §5.3「零 effect 零写」不变量——它通过把 deny 行创建**变成 effect**
+使旧实现的违例（ledger 外写行）不可再现。金标：真库「无既有 grant → 离岗 → rehire → OAuth」
+（`directory-deprovision-writer-ledger.db.test.ts`），mutation 六连杀（restore DELETE、creation 规划、
+no-op 豁免、writer INSERT、org 校验、激活源门控）。
 
 产品方向见 companion — **已赞成**。  
 **Implementation design lock 已于 2026-07-23 批准。**  

--- a/docs/development/dingtalk-lifecycle-line-completion-and-verification-20260808.md
+++ b/docs/development/dingtalk-lifecycle-line-completion-and-verification-20260808.md
@@ -1,6 +1,6 @@
 # 钉钉生命周期线 — 收尾开发与验证 MD（2026-08-08）
 
-- Status: **代码侧收尾完成**（11/11 车全 MERGED；启用/canary/U1-13/Transfer 仍 owner/ops-gated）
+- Status: **代码侧收尾完成（Rev 4.4 修复轮后恢复）** — closeout 复审（2026-08-08，对 main=45cf3a7c51）曾裁 **CHANGES REQUESTED**（2 P1 + 1 P2，见 §4bis），按其收尾顺序本状态一度改回 CHANGES_REQUIRED；修复 PR（T3 源权威 + OPS-01 可逆证据 Rev 4.4）与本状态行原子落地。启用/canary/U1-13/Transfer 仍 owner/ops-gated；三开关 OFF。
 - 授权链：owner 2026-08-07/08 会话「钉钉同步业务功能开发-260721」指令 —— 「请排序并完成所有这条线剩余的开发，然后给出设计及验证 MD」，采纳含「显式批准 Rev 4.3」为第 1 步的收尾意见；模型分配按既有 model-split（Sonnet=机械/侦察、Fable=主循环+热文件语义、Opus=对抗门审）。
 - 权威锁：`dingtalk-deprovision-reactivation-and-evidence-chain-design-20260723.md`（Rev 4.3，ratification 记录见其 §0.6，**终版随本 MD 提请 owner 会签**）+ companion admission 锁 Rev 4.2。
 - 前情：`dingtalk-lifecycle-postmerge-findings-20260724.md`（07-24 实测「离岗零证据」P1 的完整证据链）与 honest closeout（#4587 修正版）。
@@ -52,7 +52,17 @@ Sonnet 侦察（restack 预案）全部命中：唯一真冲突 #4658、#4659 �
 ## 4. 两项合同级裁定（owner 会签清单）
 
 1. **Rev 4.3 勘误已按 owner 指令落账**（#4646 锁文 §0.6 含 provenance）：每 event 仅一条源组织 `membership_changed`；`globally_clear` 只门控 grant/user。与 main 既有 W4-PRE-1d owner 裁决同轴，非新语义。**请 owner 终签。**
-2. **OPS-01 行形制裁定**（#4647 落地时，行为级非锁文级）：离岗 globally-clear 候选**无条件**留下显式 disabled grant 行（行形制与 OPS-01 以来一致）；ledger `grant_changed` effect 仍以锁内「此前确实启用」为门。**承重理由**：oauth ensureGrant 是 `INSERT...enabled=TRUE...ON CONFLICT DO NOTHING` —— 无行则离岗者下次 OAuth 尝试被静默重新授权；显式 disabled 行即闸。#4653 曾把 ensureGrant 改成 `DO UPDATE→TRUE`（会绕开该闸）已回退 creation-only；离岗后重授权唯一路径=审计的 rehire/force-restore。**请 owner 确认此语义选择。**
+2. **OPS-01 行形制裁定 — 已被 Rev 4.4 取代（closeout 复审会签指令）**：复审裁定「OPS-01 暂不签——ledger 必须记录『grant 行从不存在到 disabled』的存在性变化，restore 时才能安全删除；不能仅调整 upsert 位置」。原「无条件 disabled 行、ledger 外写入」形制即复审 P1-2 的根因（从未有 grant 的人 rehire 后被孤儿 deny 行永久挡死 OAuth）。Rev 4.4（锁文 §0.7）改为**纯 effect 驱动**：creation effect（`grant_row_created=TRUE`）→ writer INSERT deny 行 → restore DELETE 恢复无行态；deny 闸本身不变（ensureGrant 仍 creation-only，被显式 disabled 行挡住）。**该项不再等 owner 会签原语义——按会签指令已重做。**
+
+## 4bis. Closeout 复审吸收记录（2026-08-08，CHANGES REQUESTED → 修复）
+
+| 判项 | 内容 | 修复 |
+|---|---|---|
+| **P1-1（T3 激活源权威）** | 仅 `sso`/显式 `directoryAccountId` 校验目录源；`temp_password`/`admin_no_password` 丢弃 `sourceOrgId`、直接信客户端 `orgId` → 可对 inactive 源静默开通 + 跨组织写 membership；单测 :44 还把「无源激活成功」钉成正控 | **所有激活模式**无条件解析并校验 active+linked 目录源；membership org 一律由 integration 派生，客户端 `orgId` 仅匹配校验（不符 → 409 `ACTIVATE_ORG_MISMATCH`，闭集错误表/HTTP/bulk 全链）；「无源成功」钉点翻转为拒绝 + 派生组织正控/错配负控/双组织 steering 负控 + 真库 fixture 补真实源 |
+| **P1-2（OPS-01 不可逆 deny 行）** | disabled grant 行在 ledger 外无条件写入；restore 只逆转既有 effect → 无 grant 者离岗+rehire 后永久无法 OAuth | Rev 4.4 证据模型（锁文 §0.7）：`grant_row_created` 列（CHECK+immutability+拒降级 down）、planner creation effect、writer 纯 effect 驱动、restore DELETE；真库金标「无既有 grant → 离岗 → rehire → OAuth」全链 + creation-only ensureGrant 挡/放两态断言 |
+| **P2（零 effect 语义分叉）** | 零 effect 早退跳过 bookkeeping upsert，与有 effect 路径 deny 语义相反；:450 测试不验 OAuth loginability | 语义统一（globally-clear 无行 ⇒ 必有 creation effect），两种零 effect 形态（deny 已在场 / not-globally-clear）均新增「运行前后 OAuth loginability 不变」真库断言 |
+
+Mutation 六连杀（每条先证锚点命中、后证目标测试转红、cp 还原）：restore DELETE 分支、planner creation 规划、no-op 豁免、writer creation INSERT、`ACTIVATE_ORG_MISMATCH` 校验、激活源门控回退（原 P1 复刻）。
 
 ## 5. 过程事故诚实档（含撤回）
 

--- a/docs/development/dingtalk-lifecycle-line-completion-and-verification-20260808.md
+++ b/docs/development/dingtalk-lifecycle-line-completion-and-verification-20260808.md
@@ -53,6 +53,7 @@ Sonnet 侦察（restack 预案）全部命中：唯一真冲突 #4658、#4659 �
 
 1. **Rev 4.3 勘误已按 owner 指令落账**（#4646 锁文 §0.6 含 provenance）：每 event 仅一条源组织 `membership_changed`；`globally_clear` 只门控 grant/user。与 main 既有 W4-PRE-1d owner 裁决同轴，非新语义。**请 owner 终签。**
 2. **OPS-01 行形制裁定 — 已被 Rev 4.4 取代（closeout 复审会签指令）**：复审裁定「OPS-01 暂不签——ledger 必须记录『grant 行从不存在到 disabled』的存在性变化，restore 时才能安全删除；不能仅调整 upsert 位置」。原「无条件 disabled 行、ledger 外写入」形制即复审 P1-2 的根因（从未有 grant 的人 rehire 后被孤儿 deny 行永久挡死 OAuth）。Rev 4.4（锁文 §0.7）改为**纯 effect 驱动**：creation effect（`grant_row_created=TRUE`）→ writer INSERT deny 行 → restore DELETE 恢复无行态；deny 闸本身不变（ensureGrant 仍 creation-only，被显式 disabled 行挡住）。**该项不再等 owner 会签原语义——按会签指令已重做。**
+3. **OPS-01 supersede 残留的补偿路径（新增，对抗审 P2-1）**：deny 行的 DELETE 逆转仅在事件 `applied` 期间可用；被 supersede 后行成无证据残留（rehire/admin_force 均 `EVENT_NOT_APPLIED`，后续离岗不补证据）。此为 main 既有 supersede 合同的推论。**请 owner 裁定补偿路径**：残留 deny 行是否允许人工/运维清理，或引入「再证据化」机制。三开关 OFF 期间无生产暴露。
 
 ## 4bis. Closeout 复审吸收记录（2026-08-08，CHANGES REQUESTED → 修复）
 
@@ -63,6 +64,8 @@ Sonnet 侦察（restack 预案）全部命中：唯一真冲突 #4658、#4659 �
 | **P2（零 effect 语义分叉）** | 零 effect 早退跳过 bookkeeping upsert，与有 effect 路径 deny 语义相反；:450 测试不验 OAuth loginability | 语义统一（globally-clear 无行 ⇒ 必有 creation effect），两种零 effect 形态（deny 已在场 / not-globally-clear）均新增「运行前后 OAuth loginability 不变」真库断言 |
 
 Mutation 六连杀（每条先证锚点命中、后证目标测试转红、cp 还原）：restore DELETE 分支、planner creation 规划、no-op 豁免、writer creation INSERT、`ACTIVATE_ORG_MISMATCH` 校验、激活源门控回退（原 P1 复刻）。
+
+**独立对抗审 verdict（Opus，2026-08-09，绑 head 467ae34b57）**：**APPROVE-with-hardening，0 P1** —— 三条 refute-first 目标（T3 绕过 / writer 非 1:1 / restore drift）构造攻击后均未证伪；六条 mutation 独立复现全转红；immutability 函数与 20260728 版程序化逐行比对一列未丢；迁移在全新 DB 干净跑通且不在 9 处 MIGRATION_EXCLUDE。两条 P2 已落账：①**可逆性边界**——supersede（如管理员重新启用）后 restore 按既有门拒绝（`EVENT_NOT_APPLIED`），deny 行成无证据残留：锁文 §0.7 已按此限定措辞（main 既有语义，非本 PR 引入），补偿路径列入 §4 owner 清单第 3 项；②**双 ACTIVE 源 org 派生歧义**（今日无 web 调用点可达）→ follow-up #4833。层级事实：mutation (d)（writer INSERT）只有真库 golden 能杀（6666 unit 全绿）；mutation (f)（源门控回退）只有 unit 层能杀（grant-table 真库 17/17 仍绿）——两层缺一不可。
 
 ## 5. 过程事故诚实档（含撤回）
 

--- a/packages/core-backend/src/auth/user-activate.ts
+++ b/packages/core-backend/src/auth/user-activate.ts
@@ -92,6 +92,8 @@ export type ActivateErrorCode =
   | 'ACTIVATE_LINK_MISMATCH'
   /** SSO-only: account/integration provider is not DingTalk, or corp_id is inconsistent. */
   | 'ACTIVATE_SOURCE_INELIGIBLE'
+  /** Caller-supplied orgId disagrees with the org derived from the directory-source integration. */
+  | 'ACTIVATE_ORG_MISMATCH'
 
 function throwCoded(message: string, code: ActivateErrorCode): never {
   const err = new Error(message)
@@ -140,17 +142,29 @@ export async function activatePendingUser(input: ActivateUserInput): Promise<Act
       )
     }
 
-    if (input.mode === 'sso' || input.directoryAccountId) {
-      const sourceOrgId = await assertDirectorySourceActiveForActivate(client, {
-        userId,
-        directoryAccountId: input.directoryAccountId ?? null,
-        requireDingTalkSso: input.mode === 'sso',
-        expectedDingTalkIdentity: input.expectedDingTalkIdentity ?? null,
-      })
-      if (input.mode === 'sso') {
-        membershipOrgId = sourceOrgId
-      }
+    // Closeout review P1: EVERY activation mode resolves and validates the authoritative
+    // directory source — the gated form (`sso || directoryAccountId`) let temp_password /
+    // admin_no_password activate an offboarded or source-dead pending user by simply not
+    // mentioning the source, which the design lock forbids ("admin 激活同样不得对 inactive
+    // 目录源静默开通"). Pending users exist only via directory admission, so a pending user
+    // with no linked active source is a refusal (ACTIVATE_SOURCE_MISSING), not a pass.
+    //
+    // The membership org DERIVES from the source integration in every mode; a client-supplied
+    // orgId may only CONFIRM it. The gated form discarded the DB's org for non-SSO modes and
+    // trusted the client's — "org A 的目录账号 + org B 的 orgId" wrote a cross-org membership.
+    const sourceOrgId = await assertDirectorySourceActiveForActivate(client, {
+      userId,
+      directoryAccountId: input.directoryAccountId ?? null,
+      requireDingTalkSso: input.mode === 'sso',
+      expectedDingTalkIdentity: input.expectedDingTalkIdentity ?? null,
+    })
+    if (input.orgId && input.orgId !== sourceOrgId) {
+      throwCoded(
+        'orgId does not match the directory source integration for this user',
+        'ACTIVATE_ORG_MISMATCH',
+      )
     }
+    membershipOrgId = sourceOrgId
 
     const updated = await client.query(
       `UPDATE users

--- a/packages/core-backend/src/db/migrations/zzzz20260808090000_deprovision_effect_grant_row_created.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260808090000_deprovision_effect_grant_row_created.ts
@@ -1,0 +1,107 @@
+import type { Kysely } from 'kysely'
+import { sql } from 'kysely'
+
+/**
+ * Rev 4.4 (closeout-review directive, 2026-08-08): the OPS-01 explicit disabled grant row must
+ * be ledger-evidenced as an EXISTENCE change, or restore cannot reverse it.
+ *
+ * Prior shape wrote the deny row unconditionally, outside the effects ledger: a person who
+ * never had a grant, deprovisioned and later rehired, was left with an orphan enabled=FALSE
+ * row that permanently blocked ensureGrant's creation-only OAuth auto-grant — with nothing in
+ * the ledger for restore to act on.
+ *
+ * `grant_row_created = TRUE` marks a grant_changed effect whose change is the CREATION of the
+ * disabled row (before_active = after_active = FALSE — nothing was ever enabled; the delta is
+ * the row's existence). Restore reverses it by deleting the row, restoring absence.
+ *
+ * The CHECK pins the shape at the schema layer (§5.2 schema authority), and the immutability
+ * trigger arm is extended so the creation flag is as tamper-proof as the rest of the evidence.
+ */
+
+const IMMUTABILITY_FN_WITH_GRANT_ROW_CREATED = `
+    CREATE OR REPLACE FUNCTION directory_deprovision_reject_identity_update()
+    RETURNS trigger AS $$
+    BEGIN
+      IF TG_TABLE_NAME = 'directory_deprovision_events' THEN
+        IF NEW.org_id IS DISTINCT FROM OLD.org_id
+           OR NEW.integration_id IS DISTINCT FROM OLD.integration_id
+           OR NEW.directory_account_id IS DISTINCT FROM OLD.directory_account_id
+           OR NEW.local_user_id IS DISTINCT FROM OLD.local_user_id
+           OR NEW.link_witness_account_id IS DISTINCT FROM OLD.link_witness_account_id
+           OR NEW.link_witness_local_user_id IS DISTINCT FROM OLD.link_witness_local_user_id
+           OR NEW.policy IS DISTINCT FROM OLD.policy
+           OR NEW.globally_clear IS DISTINCT FROM OLD.globally_clear
+           OR NEW.access_generation_at_apply IS DISTINCT FROM OLD.access_generation_at_apply
+           OR NEW.event_origin IS DISTINCT FROM OLD.event_origin
+           OR NEW.run_id IS DISTINCT FROM OLD.run_id
+           OR NEW.triggered_by IS DISTINCT FROM OLD.triggered_by THEN
+          RAISE EXCEPTION 'directory_deprovision_events identity fields are immutable';
+        END IF;
+      ELSIF TG_TABLE_NAME = 'directory_deprovision_effects' THEN
+        IF NEW.event_id IS DISTINCT FROM OLD.event_id
+           OR NEW.local_user_id IS DISTINCT FROM OLD.local_user_id
+           OR NEW.effect_type IS DISTINCT FROM OLD.effect_type
+           OR NEW.org_id IS DISTINCT FROM OLD.org_id
+           OR NEW.before_active IS DISTINCT FROM OLD.before_active
+           OR NEW.after_active IS DISTINCT FROM OLD.after_active
+           OR NEW.grant_row_created IS DISTINCT FROM OLD.grant_row_created
+           OR NEW.access_generation_at_apply IS DISTINCT FROM OLD.access_generation_at_apply THEN
+          RAISE EXCEPTION 'directory_deprovision_effects identity fields are immutable';
+        END IF;
+      END IF;
+      RETURN NEW;
+    END;
+    $$ LANGUAGE plpgsql
+`
+
+const IMMUTABILITY_FN_PRIOR = IMMUTABILITY_FN_WITH_GRANT_ROW_CREATED.replace(
+  "           OR NEW.grant_row_created IS DISTINCT FROM OLD.grant_row_created\n",
+  '',
+)
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`
+    ALTER TABLE directory_deprovision_effects
+      ADD COLUMN IF NOT EXISTS grant_row_created boolean NOT NULL DEFAULT FALSE
+  `.execute(db)
+  await sql`
+    ALTER TABLE directory_deprovision_effects
+      DROP CONSTRAINT IF EXISTS ddfx_grant_row_created_scope_check
+  `.execute(db)
+  await sql`
+    ALTER TABLE directory_deprovision_effects
+      ADD CONSTRAINT ddfx_grant_row_created_scope_check
+      CHECK (
+        grant_row_created = FALSE
+        OR (
+          effect_type = 'grant_changed'
+          AND before_active = FALSE
+          AND after_active = FALSE
+        )
+      )
+  `.execute(db)
+  await sql.raw(IMMUTABILITY_FN_WITH_GRANT_ROW_CREATED).execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  const witness = await sql`
+    SELECT 1 AS present
+      FROM directory_deprovision_effects
+     WHERE grant_row_created = TRUE
+     LIMIT 1
+  `.execute(db)
+  if (witness.rows.length > 0) {
+    throw new Error(
+      'refusing to drop grant_row_created: deny-row creation evidence exists and would become irreversible',
+    )
+  }
+  await sql.raw(IMMUTABILITY_FN_PRIOR).execute(db)
+  await sql`
+    ALTER TABLE directory_deprovision_effects
+      DROP CONSTRAINT IF EXISTS ddfx_grant_row_created_scope_check
+  `.execute(db)
+  await sql`
+    ALTER TABLE directory_deprovision_effects
+      DROP COLUMN IF EXISTS grant_row_created
+  `.execute(db)
+}

--- a/packages/core-backend/src/directory/deprovision-evidence-api.ts
+++ b/packages/core-backend/src/directory/deprovision-evidence-api.ts
@@ -194,7 +194,8 @@ export async function listDeprovisionEvents(options: {
 export async function listDeprovisionEffects(eventId: string) {
   const result = await query(
     `SELECT id, event_id, local_user_id, org_id, effect_type,
-            before_active, after_active, access_generation_at_apply,
+            before_active, after_active, grant_row_created,
+            access_generation_at_apply,
             status, reversed_at, created_at, updated_at
        FROM directory_deprovision_effects
       WHERE event_id = $1
@@ -218,6 +219,7 @@ type RestoreEffectRow = {
   after_active: boolean
   before_active: boolean
   effect_type: string
+  grant_row_created: boolean
   id: string
   org_id: string | null
   status: string
@@ -328,6 +330,7 @@ export async function restoreDeprovisionEvent(options: {
               org_id,
               before_active,
               after_active,
+              grant_row_created,
               access_generation_at_apply,
               status
          FROM directory_deprovision_effects
@@ -399,6 +402,22 @@ export async function restoreDeprovisionEvent(options: {
         )
         currentMatchesAfter[effect.id] =
           (membership.rows[0]?.is_active === true) === effect.after_active
+      } else if (
+        effect.effect_type === 'grant_changed'
+        && effect.grant_row_created === true
+      ) {
+        // Rev 4.4 creation effect: after-state is "row EXISTS and is disabled" — presence is
+        // the change, so a missing row is drift, not a match.
+        const grant = await client.query(
+          `SELECT enabled
+             FROM user_external_auth_grants
+            WHERE local_user_id = $1::text
+              AND provider = 'dingtalk'
+            LIMIT 1`,
+          [event.local_user_id],
+        )
+        currentMatchesAfter[effect.id] =
+          grant.rows[0] !== undefined && grant.rows[0].enabled !== true
       } else if (effect.effect_type === 'grant_changed') {
         const grant = await client.query(
           `SELECT enabled
@@ -478,6 +497,27 @@ export async function restoreDeprovisionEvent(options: {
           throw restoreError(
             'DRIFT_CONFLICT',
             `membership row missing or changed for org ${effect.org_id}`,
+          )
+        }
+      } else if (
+        effect.effect_type === 'grant_changed'
+        && effect.grant_row_created === true
+      ) {
+        // Rev 4.4 reversal of a deny-row CREATION: restore ABSENCE by deleting the row. The
+        // enabled = FALSE predicate is the drift gate — if the row was re-enabled or replaced
+        // since apply, deleting it would destroy state this ledger never created.
+        const removed = await client.query(
+          `DELETE FROM user_external_auth_grants
+            WHERE provider = 'dingtalk'
+              AND local_user_id = $1::text
+              AND enabled = FALSE
+            RETURNING local_user_id`,
+          [event.local_user_id],
+        )
+        if (!removed.rows[0]) {
+          throw restoreError(
+            'DRIFT_CONFLICT',
+            'DingTalk deny grant row missing or changed before restore',
           )
         }
       } else if (effect.effect_type === 'grant_changed') {

--- a/packages/core-backend/src/directory/deprovision-ledger.ts
+++ b/packages/core-backend/src/directory/deprovision-ledger.ts
@@ -58,6 +58,7 @@ export type DirectoryDeprovisionCandidateSnapshot = {
   orgCandidacyClear: boolean
   globallyClear: boolean
   dingtalkGrantEnabled: boolean
+  dingtalkGrantRowExists: boolean
 }
 
 export type ApplyDeprovisionCandidateResult = {
@@ -84,6 +85,7 @@ type CandidateStateRow = {
   org_candidacy_clear: boolean
   globally_clear: boolean
   dingtalk_grant_enabled: boolean
+  dingtalk_grant_row_exists: boolean
 }
 
 function hasEffect(
@@ -195,7 +197,13 @@ async function loadCandidateState(
           WHERE grant_row.provider = 'dingtalk'
             AND grant_row.local_user_id = candidate_user.id
           LIMIT 1
-       ), FALSE) AS dingtalk_grant_enabled
+       ), FALSE) AS dingtalk_grant_enabled,
+       EXISTS (
+         SELECT 1
+           FROM user_external_auth_grants grant_presence
+          WHERE grant_presence.provider = 'dingtalk'
+            AND grant_presence.local_user_id = candidate_user.id
+       ) AS dingtalk_grant_row_exists
      FROM users candidate_user
      WHERE candidate_user.id = $1::text`,
     [
@@ -241,6 +249,7 @@ export async function planDirectoryDeprovisionCandidate(
     orgCandidacyClear: state.org_candidacy_clear,
     globallyClear: state.globally_clear,
     dingtalkGrantEnabled: state.dingtalk_grant_enabled,
+    dingtalkGrantRowExists: state.dingtalk_grant_row_exists,
   }
   return {
     snapshot,
@@ -253,6 +262,7 @@ export async function planDirectoryDeprovisionCandidate(
       orgMembershipActive:
         snapshot.orgMembershipActive && snapshot.orgCandidacyClear,
       dingtalkGrantEnabled: snapshot.dingtalkGrantEnabled,
+      dingtalkGrantRowExists: snapshot.dingtalkGrantRowExists,
       globallyClear: snapshot.globallyClear,
     }),
   }
@@ -269,8 +279,9 @@ async function writeEffects(
     await client.query(
       `INSERT INTO directory_deprovision_effects (
          event_id, local_user_id, org_id, effect_type,
-         before_active, after_active, access_generation_at_apply, status
-       ) VALUES ($1::uuid, $2::text, $3::text, $4::text, $5, $6, $7, 'applied')`,
+         before_active, after_active, grant_row_created,
+         access_generation_at_apply, status
+       ) VALUES ($1::uuid, $2::text, $3::text, $4::text, $5, $6, $7, $8, 'applied')`,
       [
         eventId,
         localUserId,
@@ -278,6 +289,7 @@ async function writeEffects(
         effect.type,
         effect.beforeActive,
         effect.afterActive,
+        effect.grantRowCreated === true,
         generation,
       ],
     )
@@ -324,6 +336,7 @@ export async function applyDirectoryDeprovisionCandidate(
     orgMembershipActive:
       state.org_membership_active && state.org_candidacy_clear,
     dingtalkGrantEnabled: state.dingtalk_grant_enabled,
+    dingtalkGrantRowExists: state.dingtalk_grant_row_exists,
     globallyClear: state.globally_clear,
   })
   const currentGeneration = Number(state.access_generation)
@@ -400,23 +413,42 @@ export async function applyDirectoryDeprovisionCandidate(
     }
   }
 
-  // The bookkeeping upsert is deliberately UNCONDITIONAL for a globally-clear candidate, not
-  // gated on the grant effect: since OPS-01 the departed person's row shape has been "an
-  // explicit disabled grant", whether or not a grant ever existed (the orchestration suite pins
-  // exactly this). Writing a fresh enabled=FALSE row for someone who never had a grant takes
-  // nothing away from them — so `grant_changed` (the LEDGER effect) stays gated on the
-  // pre-locked "was actually enabled" read; only the row parity is unconditional.
-  if (state.globally_clear) {
-    await client.query(
-      `INSERT INTO user_external_auth_grants (
-         provider, local_user_id, enabled, granted_by, created_at, updated_at
-       ) VALUES ('dingtalk', $1::text, FALSE, 'system:directory-deprovision', NOW(), NOW())
-       ON CONFLICT (provider, local_user_id)
-       DO UPDATE SET enabled = FALSE,
-                     granted_by = EXCLUDED.granted_by,
-                     updated_at = NOW()`,
-      [input.localUserId],
-    )
+  // Rev 4.4: grant-table writes are purely EFFECT-DRIVEN — every mutation of
+  // user_external_auth_grants corresponds 1:1 to a grant_changed effect row, so restore can
+  // reverse it. (The prior OPS-01 shape wrote an unconditional disabled row for every
+  // globally-clear candidate outside the ledger; a rehired never-granted person was then
+  // permanently blocked from OAuth with no evidence to reverse — closeout review P1. The deny
+  // mark itself is unchanged: it still blocks ensureGrant's creation-only auto-grant.)
+  const grantEffect = plan.effects.find((effect) => effect.type === 'grant_changed')
+  if (grantEffect) {
+    if (grantEffect.grantRowCreated === true) {
+      // Deny-row CREATION for a person with no existing row. Plain INSERT, no ON CONFLICT:
+      // the per-user lock plus the same-transaction EXISTS read guarantee absence, so a
+      // conflict means the invariant broke — abort rather than write unevidenced state.
+      await client.query(
+        `INSERT INTO user_external_auth_grants (
+           provider, local_user_id, enabled, granted_by, created_at, updated_at
+         ) VALUES ('dingtalk', $1::text, FALSE, 'system:directory-deprovision', NOW(), NOW())`,
+        [input.localUserId],
+      )
+    } else {
+      const flipped = await client.query(
+        `UPDATE user_external_auth_grants
+            SET enabled = FALSE,
+                granted_by = 'system:directory-deprovision',
+                updated_at = NOW()
+          WHERE provider = 'dingtalk'
+            AND local_user_id = $1::text
+            AND enabled = TRUE
+          RETURNING local_user_id`,
+        [input.localUserId],
+      )
+      if (!flipped.rows[0]) {
+        throw new Error(
+          'directory deprovision grant changed after planning; transaction aborted',
+        )
+      }
+    }
   }
 
   await client.query(

--- a/packages/core-backend/src/directory/deprovision-planner.ts
+++ b/packages/core-backend/src/directory/deprovision-planner.ts
@@ -80,6 +80,13 @@ export function selectLeastDestructiveDirectoryDeprovisionPolicy(
 }
 
 export type PlannedEffect = {
+  /**
+   * Rev 4.4: TRUE when this grant_changed effect records the CREATION of an explicit disabled
+   * grant row for a person who had NO row (the OPS-01 deny mark). Reversal DELETES the row
+   * (restoring absence) instead of flipping enabled — closeout review P1: an unevidenced deny
+   * row left a rehired never-granted person permanently locked out of OAuth.
+   */
+  grantRowCreated?: boolean
   type: DeprovisionEffectType
   orgId?: string | null
   beforeActive: boolean
@@ -97,6 +104,8 @@ export type DirectoryDeprovisionPlanInput = {
   orgMembershipActive: boolean
   /** Whether DingTalk grant is currently enabled. */
   dingtalkGrantEnabled: boolean
+  /** Whether ANY grant row exists (enabled or not) — drives the Rev 4.4 creation effect. */
+  dingtalkGrantRowExists: boolean
   /**
    * No other active linked directory account exists anywhere. This gates the
    * grant/user effects only; the source-org membership is independently scoped.
@@ -155,6 +164,18 @@ export function planDirectoryDeprovision(input: DirectoryDeprovisionPlanInput): 
         beforeActive: true,
         afterActive: false,
       })
+    } else if (!input.dingtalkGrantRowExists) {
+      // Rev 4.4: the OPS-01 deny mark IS an access-graph change (it blocks ensureGrant's
+      // creation-only auto-grant on the person's next OAuth attempt) and therefore must be
+      // EVIDENCED, or restore cannot undo it. before/after both false: nothing was enabled at
+      // any point — the change is the row's existence, carried by grantRowCreated.
+      effects.push({
+        type: 'grant_changed',
+        orgId: null,
+        beforeActive: false,
+        afterActive: false,
+        grantRowCreated: true,
+      })
     }
     if (input.policy === 'mark_inactive' && input.isActive) {
       effects.push({
@@ -166,8 +187,9 @@ export function planDirectoryDeprovision(input: DirectoryDeprovisionPlanInput): 
     }
   }
 
-  // Drop no-ops (before==after) — prospective truth.
-  const meaningful = effects.filter((e) => e.beforeActive !== e.afterActive)
+  // Drop no-ops (before==after) — prospective truth. A Rev 4.4 creation effect is NOT a no-op
+  // even though both booleans are false: its change is the row's existence.
+  const meaningful = effects.filter((e) => e.beforeActive !== e.afterActive || e.grantRowCreated === true)
 
   return {
     localUserId: input.localUserId,

--- a/packages/core-backend/src/routes/admin-users.ts
+++ b/packages/core-backend/src/routes/admin-users.ts
@@ -1841,6 +1841,13 @@ const ACTIVATE_ERROR_POLICY_SOURCE: Record<ActivateErrorCode, { status: number; 
     status: 409,
     message: 'Directory source is not eligible for DingTalk SSO activation',
   },
+  // 409: membership org is DERIVED from the directory-source integration for every activation
+  // mode; a caller-supplied orgId is only ever match-validated, never trusted (closeout review
+  // P1 — non-SSO admin activation previously wrote the client's orgId unchecked).
+  ACTIVATE_ORG_MISMATCH: {
+    status: 409,
+    message: 'orgId does not match the directory source integration for this user',
+  },
 }
 
 type ActivatePolicyRow = Readonly<{ status: number; message: string }>

--- a/packages/core-backend/tests/integration/attendance-w4pre1c-departure-sweep-deprovision.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-w4pre1c-departure-sweep-deprovision.db.test.ts
@@ -224,9 +224,19 @@ describeIfDatabase('W4-PRE-1c case ① — real sync sweep composed with the dep
           GROUP BY event.run_id`,
         [fixture.localUserId],
       )
+      // Rev 4.4: the fixture person has NO grant row, so the globally-clear departure now
+      // plans a THIRD effect — the evidenced deny-row creation (grant_row_created) — on top of
+      // membership_changed + user_changed.
       expect(evidence.rows).toEqual([
-        { effect_count: 2, run_id: result.run.id },
+        { effect_count: 3, run_id: result.run.id },
       ])
+      const grantEffect = await query<{ grant_row_created: boolean }>(
+        `SELECT effect.grant_row_created
+           FROM directory_deprovision_effects effect
+          WHERE effect.local_user_id = $1 AND effect.effect_type = 'grant_changed'`,
+        [fixture.localUserId],
+      )
+      expect(grantEffect.rows).toEqual([{ grant_row_created: true }])
     }, 30_000)
   })
 

--- a/packages/core-backend/tests/integration/directory-deprovision-grant-table.db.test.ts
+++ b/packages/core-backend/tests/integration/directory-deprovision-grant-table.db.test.ts
@@ -267,6 +267,10 @@ describeIfDatabase('DingTalk grant/membership writes target the real tables (rea
       [USER],
     )
 
+    // Closeout review P1: every activation mode now requires the authoritative linked active
+    // source, and the membership org DERIVES from it (ORG here — the caller's orgId confirms).
+    await seedActivationSource({ linkedUserId: USER })
+
     // Positive control: nothing has granted anything yet.
     expect(await grantEnabled()).toBeUndefined()
 
@@ -975,6 +979,9 @@ describeIfDatabase('DingTalk grant/membership writes target the real tables (rea
        VALUES ($1, 'pending-b@example.com', 'Pending B', 'Shared_Login', 'hash-b', FALSE, 'pending_activation', FALSE)`,
       [USER_B],
     )
+
+    // Closeout review P1: activation requires the linked active source in every mode.
+    await seedActivationSource({ linkedUserId: USER_B })
 
     await expect(
       activatePendingUser({

--- a/packages/core-backend/tests/integration/directory-deprovision-ledger-schema.db.test.ts
+++ b/packages/core-backend/tests/integration/directory-deprovision-ledger-schema.db.test.ts
@@ -16,6 +16,10 @@ import {
   down as hardenedLedgerDown,
   up as hardenedLedgerUp,
 } from '../../src/db/migrations/zzzz20260728100000_harden_directory_deprovision_ledger'
+import {
+  down as grantRowCreatedDown,
+  up as grantRowCreatedUp,
+} from '../../src/db/migrations/zzzz20260808090000_deprovision_effect_grant_row_created'
 
 const dbUrl = process.env.DATABASE_URL
 const describeDb = dbUrl ? describe : describe.skip
@@ -157,6 +161,77 @@ describeDb('directory deprovision ledger hardening (real DB, isolated schema)', 
     `.execute(db)
     return event.rows[0]!.id
   }
+
+  // Rev 4.4 (closeout review, 2026-08-08): the deny-row CREATION evidence column. Shape is
+  // pinned by a CHECK (creation only on grant_changed with before/after both FALSE), the flag
+  // itself is immutable, and down() refuses to orphan existing creation evidence.
+  it('Rev 4.4: grant_row_created is shape-checked, immutable, and down() refuses to drop evidence', async () => {
+    await hardenedLedgerUp(db)
+    await grantRowCreatedUp(db)
+
+    expect(await columnDataType('directory_deprovision_effects', 'grant_row_created')).toBe('boolean')
+    expect(
+      await constraintDefinition('directory_deprovision_effects', 'ddfx_grant_row_created_scope_check'),
+    ).toMatch(/grant_changed/)
+
+    const a = await seedAuthority()
+    const eventId = await insertValidEvent(a)
+
+    // CHECK probe 1: creation flag on a non-grant effect type is rejected.
+    await expect(
+      sql`
+      INSERT INTO directory_deprovision_effects (
+        event_id, local_user_id, org_id, effect_type, before_active,
+        after_active, grant_row_created, access_generation_at_apply, status
+      ) VALUES (
+        ${eventId}, ${a.userId}, ${a.orgId}, 'membership_changed',
+        TRUE, FALSE, TRUE, 1, 'applied'
+      )
+    `.execute(db),
+    ).rejects.toThrow(/ddfx_grant_row_created_scope_check/)
+
+    // CHECK probe 2: a creation effect claiming something was enabled is a contradiction.
+    await expect(
+      sql`
+      INSERT INTO directory_deprovision_effects (
+        event_id, local_user_id, org_id, effect_type, before_active,
+        after_active, grant_row_created, access_generation_at_apply, status
+      ) VALUES (
+        ${eventId}, ${a.userId}, NULL, 'grant_changed',
+        TRUE, FALSE, TRUE, 1, 'applied'
+      )
+    `.execute(db),
+    ).rejects.toThrow(/ddfx_grant_row_created_scope_check/)
+
+    // Positive control: the authored creation shape is accepted…
+    await sql`
+      INSERT INTO directory_deprovision_effects (
+        event_id, local_user_id, org_id, effect_type, before_active,
+        after_active, grant_row_created, access_generation_at_apply, status
+      ) VALUES (
+        ${eventId}, ${a.userId}, NULL, 'grant_changed',
+        FALSE, FALSE, TRUE, 1, 'applied'
+      )
+    `.execute(db)
+
+    // …and the flag is evidence: flipping it after the fact is refused by the trigger.
+    await expect(
+      sql`
+      UPDATE directory_deprovision_effects
+         SET grant_row_created = FALSE
+       WHERE event_id = ${eventId} AND effect_type = 'grant_changed'
+    `.execute(db),
+    ).rejects.toThrow(/identity fields are immutable/)
+
+    // down() with creation evidence on file must refuse — dropping the column would make the
+    // deny row irreversible again (the exact P1 this revision closes).
+    await expect(grantRowCreatedDown(db)).rejects.toThrow(/refusing to drop grant_row_created/)
+
+    // With the evidence gone, down() succeeds and restores the pre-4.4 shape.
+    await sql`DELETE FROM directory_deprovision_effects WHERE grant_row_created = TRUE`.execute(db)
+    await grantRowCreatedDown(db)
+    expect(await columnExists('directory_deprovision_effects', 'grant_row_created')).toBe(false)
+  })
 
   it('upgrades the weak scaffold to the exact typed FK/check vocabulary', async () => {
     await hardenedLedgerUp(db)

--- a/packages/core-backend/tests/integration/directory-deprovision-writer-ledger.db.test.ts
+++ b/packages/core-backend/tests/integration/directory-deprovision-writer-ledger.db.test.ts
@@ -1,7 +1,8 @@
 import { randomUUID } from 'node:crypto'
 import { afterAll, beforeEach, describe, expect, it } from 'vitest'
 import { query, transaction } from '../../src/db/pg'
-import { previewDeprovisionForUser } from '../../src/directory/deprovision-evidence-api'
+import { previewDeprovisionForUser, restoreDeprovisionEvent } from '../../src/directory/deprovision-evidence-api'
+import { __dingtalkOAuthInternalsForTests } from '../../src/auth/dingtalk-oauth'
 import { applyDirectoryDeprovisionCandidate } from '../../src/directory/deprovision-ledger'
 import { applyDirectoryDeprovisionPolicies } from '../../src/directory/directory-sync'
 
@@ -38,6 +39,8 @@ async function cleanup(): Promise<void> {
 async function seedDirectory(
   options: {
     grantEnabled?: boolean
+    /** Rev 4.4: seed the explicit OPS-01 deny row (disabled grant) instead of no row at all. */
+    grantDisabledRow?: boolean
     membershipActive?: boolean
     policy?: 'manual_review' | 'disable_grant_only' | 'mark_inactive'
   } = {},
@@ -106,6 +109,13 @@ async function seedDirectory(
       `INSERT INTO user_external_auth_grants (
          provider, local_user_id, enabled, granted_by, created_at, updated_at
        ) VALUES ('dingtalk', $1, TRUE, 'test:d4-writer', NOW(), NOW())`,
+      [userId],
+    )
+  } else if (options.grantDisabledRow === true) {
+    await query(
+      `INSERT INTO user_external_auth_grants (
+         provider, local_user_id, enabled, granted_by, created_at, updated_at
+       ) VALUES ('dingtalk', $1, FALSE, 'system:directory-deprovision', NOW(), NOW())`,
       [userId],
     )
   }
@@ -447,9 +457,15 @@ describeIfDatabase(
       expect(evidence.rows[0].count).toBe('0')
     })
 
+    // Rev 4.4: a globally-clear candidate with NO grant row is no longer zero-effect (the deny
+    // mark must be evidenced — see the rehire golden below), so the zero-effect case is now
+    // "deny row already present": nothing left to change, nothing written, and the person's
+    // OAuth posture is asserted UNCHANGED — the exact loophole of closeout-review P2, where the
+    // zero-effect path and the effectful path disagreed about the deny row.
     it('writes no generation or evidence when the planner produces zero effects', async () => {
       const seeded = await seedDirectory({
         grantEnabled: false,
+        grantDisabledRow: true,
         membershipActive: false,
         policy: 'disable_grant_only',
       })
@@ -488,6 +504,147 @@ describeIfDatabase(
         [seeded.userId],
       )
       expect(evidence.rows[0].count).toBe('0')
+      // Closeout review P2: the zero-effect run must leave OAuth loginability EXACTLY as it
+      // found it — here the pre-existing deny row, which creation-only ensureGrant must honour.
+      await __dingtalkOAuthInternalsForTests.ensureGrant(seeded.userId)
+      const posture = await query<{ enabled: boolean; count: string }>(
+        `SELECT enabled, COUNT(*) OVER ()::text AS count
+           FROM user_external_auth_grants
+          WHERE provider = 'dingtalk' AND local_user_id = $1`,
+        [seeded.userId],
+      )
+      expect(posture.rows).toHaveLength(1)
+      expect(posture.rows[0].enabled).toBe(false)
+    })
+
+    // THE closeout-review golden (P1): 无既有 grant → 离岗 → rehire → OAuth. A person who never
+    // had a grant is deprovisioned; Rev 4.4 requires the deny row their departure creates to be
+    // ledger-evidenced (grant_row_created), so the rehire restore can DELETE it — after which
+    // OAuth's creation-only ensureGrant works again. Under the pre-4.4 writer the deny row was
+    // written outside the ledger and the rehired person was locked out of OAuth forever.
+    it('no-grant departure evidences the deny-row creation, and rehire restore deletes it so OAuth works again', async () => {
+      const seeded = await seedDirectory({
+        grantEnabled: false,
+        membershipActive: true,
+        policy: 'mark_inactive',
+      })
+
+      const outcome = await apply(seeded)
+      expect(outcome.affected).toEqual([
+        {
+          directoryAccountId: seeded.accountId,
+          localUserId: seeded.userId,
+          policy: 'mark_inactive',
+          globallyClear: true,
+        },
+      ])
+
+      // The deny row exists, is disabled, and its CREATION is evidenced.
+      const denyRow = await query<{ enabled: boolean; granted_by: string }>(
+        `SELECT enabled, granted_by FROM user_external_auth_grants
+          WHERE provider = 'dingtalk' AND local_user_id = $1`,
+        [seeded.userId],
+      )
+      expect(denyRow.rows).toHaveLength(1)
+      expect(denyRow.rows[0]).toEqual({ enabled: false, granted_by: 'system:directory-deprovision' })
+      const grantEffect = await query<{
+        before_active: boolean
+        after_active: boolean
+        grant_row_created: boolean
+      }>(
+        `SELECT before_active, after_active, grant_row_created
+           FROM directory_deprovision_effects
+          WHERE local_user_id = $1 AND effect_type = 'grant_changed'`,
+        [seeded.userId],
+      )
+      expect(grantEffect.rows).toEqual([
+        { before_active: false, after_active: false, grant_row_created: true },
+      ])
+
+      // While departed, OAuth stays blocked: creation-only ensureGrant honours the deny row.
+      await __dingtalkOAuthInternalsForTests.ensureGrant(seeded.userId)
+      const blocked = await query<{ enabled: boolean }>(
+        `SELECT enabled FROM user_external_auth_grants
+          WHERE provider = 'dingtalk' AND local_user_id = $1`,
+        [seeded.userId],
+      )
+      expect(blocked.rows[0].enabled).toBe(false)
+
+      // Rehire: the directory source comes back, and the restore reverses every effect —
+      // including the deny row's EXISTENCE.
+      await query(
+        `UPDATE directory_accounts SET is_active = TRUE WHERE id = $1::uuid`,
+        [seeded.accountId],
+      )
+      const eventRow = await query<{ id: string }>(
+        `SELECT id::text AS id FROM directory_deprovision_events
+          WHERE local_user_id = $1 AND status = 'applied'`,
+        [seeded.userId],
+      )
+      expect(eventRow.rows).toHaveLength(1)
+      await restoreDeprovisionEvent({
+        eventId: eventRow.rows[0].id,
+        mode: 'rehire',
+        adminUserId: 'admin-test',
+      })
+
+      const restored = await query<{ user_active: boolean; membership_active: boolean }>(
+        `SELECT u.is_active AS user_active, m.is_active AS membership_active
+           FROM users u JOIN user_orgs m ON m.user_id = u.id AND m.org_id = $2
+          WHERE u.id = $1`,
+        [seeded.userId, seeded.orgId],
+      )
+      expect(restored.rows[0]).toEqual({ user_active: true, membership_active: true })
+      const rowsAfterRestore = await query<{ count: string }>(
+        `SELECT COUNT(*)::text AS count FROM user_external_auth_grants
+          WHERE provider = 'dingtalk' AND local_user_id = $1`,
+        [seeded.userId],
+      )
+      expect(rowsAfterRestore.rows[0].count).toBe('0') // absence restored — the actual reversal
+
+      // And the rehired person can OAuth again: ensureGrant now CREATES the enabled grant.
+      await __dingtalkOAuthInternalsForTests.ensureGrant(seeded.userId)
+      const loginable = await query<{ enabled: boolean }>(
+        `SELECT enabled FROM user_external_auth_grants
+          WHERE provider = 'dingtalk' AND local_user_id = $1`,
+        [seeded.userId],
+      )
+      expect(loginable.rows[0].enabled).toBe(true)
+    })
+
+    // The other zero-effect flavour: NOT globally clear (still employed via another org's
+    // directory). No deny row may appear — and the never-granted person must REMAIN
+    // OAuth-loginable after the run. Kills any reintroduction of the unconditional deny write.
+    it('a not-globally-clear zero-effect run leaves a never-granted person OAuth-loginable', async () => {
+      const seeded = await seedDirectory({
+        grantEnabled: false,
+        membershipActive: false,
+        policy: 'mark_inactive',
+      })
+      await seedActiveSibling(seeded)
+
+      const outcome = await apply(seeded)
+      expect(outcome.affected).toEqual([])
+      const evidence = await query<{ count: string }>(
+        `SELECT COUNT(*)::text AS count FROM directory_deprovision_events
+          WHERE local_user_id = $1`,
+        [seeded.userId],
+      )
+      expect(evidence.rows[0].count).toBe('0')
+      const denyRows = await query<{ count: string }>(
+        `SELECT COUNT(*)::text AS count FROM user_external_auth_grants
+          WHERE provider = 'dingtalk' AND local_user_id = $1`,
+        [seeded.userId],
+      )
+      expect(denyRows.rows[0].count).toBe('0')
+
+      await __dingtalkOAuthInternalsForTests.ensureGrant(seeded.userId)
+      const loginable = await query<{ enabled: boolean }>(
+        `SELECT enabled FROM user_external_auth_grants
+          WHERE provider = 'dingtalk' AND local_user_id = $1`,
+        [seeded.userId],
+      )
+      expect(loginable.rows[0].enabled).toBe(true)
     })
 
     it('ignores a stale transition id when the source account is active again', async () => {

--- a/packages/core-backend/tests/unit/admin-users-activate-error-closure.test.ts
+++ b/packages/core-backend/tests/unit/admin-users-activate-error-closure.test.ts
@@ -260,7 +260,7 @@ describe('activate error closure — LAYER 3: static consistency, NOT a behaviou
       + `site, so their row is unreachable and untested: ${JSON.stringify(tableNotThrown)}`,
     ).toEqual([])
 
-    expect(reasons.size).toBe(12)
+    expect(reasons.size).toBe(13)
   })
 
   it('mapActivateError reads ONLY `.code` off its error parameter — never `.message`', () => {

--- a/packages/core-backend/tests/unit/admin-users-activate-error-leak.test.ts
+++ b/packages/core-backend/tests/unit/admin-users-activate-error-leak.test.ts
@@ -259,6 +259,8 @@ describe('activate error surface — HTTP-level leak control (behaviour, not syn
     const cases: Array<[string, number, string]> = [
       ['ACTIVATE_INTEGRATION_INACTIVE', 409, 'Directory integration is not active; cannot activate'],
       ['ACTIVATE_SOURCE_MISSING', 409, 'No linked active directory account for activation'],
+      // Closeout review P1: derived-org confirmation failure surfaces as 409 with OUR message.
+      ['ACTIVATE_ORG_MISMATCH', 409, 'orgId does not match the directory source integration for this user'],
     ]
     return cases.reduce(
       (chain, [code, status, message]) => chain.then(async () => {

--- a/packages/core-backend/tests/unit/admin-users-activate-error-mapping.test.ts
+++ b/packages/core-backend/tests/unit/admin-users-activate-error-mapping.test.ts
@@ -58,6 +58,12 @@ describe('mapActivateError (activate endpoint error surface)', () => {
       status: 409,
       message: 'No linked active directory account for activation',
     },
+    // Closeout review P1 (2026-08-08): org derives from the source integration in EVERY mode;
+    // a client orgId only confirms. 409 like the other configuration conflicts.
+    ACTIVATE_ORG_MISMATCH: {
+      status: 409,
+      message: 'orgId does not match the directory source integration for this user',
+    },
     ACTIVATE_SOURCE_INACTIVE: {
       status: 409,
       message: 'Directory account is inactive; cannot activate',
@@ -98,7 +104,7 @@ describe('mapActivateError (activate endpoint error surface)', () => {
 
   it('asserts the RULED transcription covers exactly the policy table (no silent drift)', () => {
     expect(Object.keys(RULED).sort()).toEqual(Object.keys(ACTIVATE_ERROR_POLICY).sort())
-    expect(Object.keys(RULED)).toHaveLength(12)
+    expect(Object.keys(RULED)).toHaveLength(13)
   })
 
   it('collapses an unauthored but ACTIVATE_-shaped code — the fail-open the owner reproduced', () => {

--- a/packages/core-backend/tests/unit/admin-users-routes.test.ts
+++ b/packages/core-backend/tests/unit/admin-users-routes.test.ts
@@ -4051,6 +4051,55 @@ describe('admin-users routes', () => {
     expect(activateMocks.activatePendingUser).not.toHaveBeenCalled()
   })
 
+  // Closeout review P1: the bulk route inherits the derived-org rule through the SAME
+  // activatePendingUser + mapActivateError pair as the single route — a steered orgId fails
+  // per-item as a safe 409 while the rest of the batch proceeds.
+  it('POST bulk activate surfaces ACTIVATE_ORG_MISMATCH per-item without killing the batch', async () => {
+    rbacMocks.isAdmin.mockResolvedValue(true)
+    activateMocks.activatePendingUser
+      .mockRejectedValueOnce(Object.assign(
+        new Error('org drift detail: integration org_id org-A DETAIL: secret'),
+        { code: 'ACTIVATE_ORG_MISMATCH' },
+      ))
+      .mockResolvedValueOnce({
+        userId: 'pending-user-2',
+        activationStatus: 'activated',
+        isActive: true,
+        localPasswordSet: false,
+      })
+
+    const response = await invokeRoute('post', '/api/admin/users/activate/bulk', {
+      body: {
+        items: [
+          { userId: 'pending-user-1', mode: 'admin_no_password', orgId: 'org-B' },
+          { userId: 'pending-user-2', mode: 'admin_no_password' },
+        ],
+      },
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(response.body).toMatchObject({
+      ok: true,
+      data: {
+        successCount: 1,
+        failureCount: 1,
+        items: [
+          {
+            userId: 'pending-user-1',
+            ok: false,
+            error: {
+              status: 409,
+              code: 'ACTIVATE_ORG_MISMATCH',
+              message: 'orgId does not match the directory source integration for this user',
+            },
+          },
+          { userId: 'pending-user-2', ok: true },
+        ],
+      },
+    })
+    expect(JSON.stringify(response.body)).not.toMatch(/secret|org drift detail/i)
+  })
+
   it('POST bulk activate keeps item transactions independent and returns only safe failures', async () => {
     rbacMocks.isAdmin.mockResolvedValue(true)
     activateMocks.activatePendingUser

--- a/packages/core-backend/tests/unit/deprovision-planner.test.ts
+++ b/packages/core-backend/tests/unit/deprovision-planner.test.ts
@@ -83,7 +83,10 @@ describe('planDirectoryDeprovision (D2 prospective)', () => {
     ])
   })
 
-  it('zero-effect when already inactive with no orgs/grant', () => {
+  // Rev 4.4 (closeout review P1): a globally-clear candidate with NO grant row is no longer
+  // zero-effect — the OPS-01 deny mark is an access-graph change (it blocks ensureGrant's
+  // creation-only auto-grant) and must be EVIDENCED so restore can delete the row again.
+  it('already inactive with no orgs and NO grant row: plans the evidenced deny-row creation', () => {
     const plan = planDirectoryDeprovision({
       localUserId: 'u3',
       policy: 'mark_inactive',
@@ -92,7 +95,48 @@ describe('planDirectoryDeprovision (D2 prospective)', () => {
       orgId: 'org-a',
       orgMembershipActive: false,
       dingtalkGrantEnabled: false,
+      dingtalkGrantRowExists: false,
       globallyClear: true,
+    })
+    expect(plan.effects).toEqual([
+      {
+        type: 'grant_changed',
+        orgId: null,
+        beforeActive: false,
+        afterActive: false,
+        grantRowCreated: true,
+      },
+    ])
+    expect(plan.skipReason).toBeNull()
+  })
+
+  it('zero-effect when already inactive with no orgs and the deny row already present', () => {
+    const plan = planDirectoryDeprovision({
+      localUserId: 'u3',
+      policy: 'mark_inactive',
+      activationStatus: 'activated',
+      isActive: false,
+      orgId: 'org-a',
+      orgMembershipActive: false,
+      dingtalkGrantEnabled: false,
+      dingtalkGrantRowExists: true,
+      globallyClear: true,
+    })
+    expect(plan.effects).toEqual([])
+    expect(plan.skipReason).toBe('zero_effect')
+  })
+
+  it('NOT globally clear never plans the deny-row creation (still employed elsewhere)', () => {
+    const plan = planDirectoryDeprovision({
+      localUserId: 'u3',
+      policy: 'mark_inactive',
+      activationStatus: 'activated',
+      isActive: false,
+      orgId: 'org-a',
+      orgMembershipActive: false,
+      dingtalkGrantEnabled: false,
+      dingtalkGrantRowExists: false,
+      globallyClear: false,
     })
     expect(plan.effects).toEqual([])
     expect(plan.skipReason).toBe('zero_effect')

--- a/packages/core-backend/tests/unit/directory-deprovision-policy.test.ts
+++ b/packages/core-backend/tests/unit/directory-deprovision-policy.test.ts
@@ -61,6 +61,11 @@ function stubClient(
       if (/INSERT INTO user_external_auth_grants/i.test(sql)) {
         return { rows: [] }
       }
+      // Rev 4.4: the grant flip is now a plain effect-driven UPDATE (RETURNING is its
+      // fail-closed "row was still enabled" witness — answer it, don't just silence it).
+      if (/UPDATE user_external_auth_grants/i.test(sql)) {
+        return { rows: [{ local_user_id: String(params?.[0] ?? '') }] }
+      }
       if (/SELECT org_id\s+FROM directory_integrations/i.test(sql)) {
         return { rows: [{ org_id: STUB_ORG_ID }] }
       }
@@ -82,6 +87,7 @@ function stubClient(
             org_candidacy_clear: true,
             globally_clear: !notGloballyClear.has(userId),
             dingtalk_grant_enabled: true,
+            dingtalk_grant_row_exists: true,
           }],
         }
       }
@@ -109,7 +115,10 @@ function stubClient(
 const wrote = (queries: string[], pattern: RegExp) => queries.some((sql) => pattern.test(sql))
 const DEACTIVATES_USER = /UPDATE users[\s\S]*is_active = FALSE/i
 const DEACTIVATES_USER_ORG = /UPDATE user_orgs\s+SET is_active = FALSE/i
-const DISABLES_GRANT = /INSERT INTO user_external_auth_grants/i
+// Rev 4.4: an ENABLED grant is closed by an effect-driven UPDATE … SET enabled = FALSE; the
+// INSERT shape is the deny-row CREATION for a person with no row (also matched so the
+// default-off test proves NEITHER write happens in preview).
+const DISABLES_GRANT = /(?:UPDATE user_external_auth_grants[\s\S]*SET enabled = FALSE|INSERT INTO user_external_auth_grants)/i
 
 const CANDIDATE = { directory_account_id: 'acct-1', local_user_id: 'user-1', deprovision_policy_override: null }
 

--- a/packages/core-backend/tests/unit/user-activate.test.ts
+++ b/packages/core-backend/tests/unit/user-activate.test.ts
@@ -18,6 +18,26 @@ vi.mock('../../src/auth/login-alias-service', () => ({
 
 import { activatePendingUser, isActivateMode } from '../../src/auth/user-activate'
 
+/**
+ * Closeout review P1 (2026-08-08): EVERY activation mode now resolves the authoritative
+ * directory source, so the ordinary positive controls carry a linked active source row and the
+ * membership org DERIVES from `integration_org_id` — never from the caller.
+ */
+const LINKED_ACTIVE_SOURCE = {
+  id: 'da-1',
+  account_active: true,
+  integration_status: 'active',
+  local_user_id: 'u1',
+  link_status: 'linked',
+  account_provider: 'dingtalk',
+  integration_provider: 'dingtalk',
+  account_corp_id: 'corp-1',
+  integration_corp_id: 'corp-1',
+  account_open_id: null,
+  account_union_id: null,
+  integration_org_id: 'org-src',
+}
+
 describe('activatePendingUser (T3)', () => {
   beforeEach(async () => {
     pgMocks.query.mockReset()
@@ -54,7 +74,9 @@ describe('activatePendingUser (T3)', () => {
           is_active: false,
         }],
       }) // FOR UPDATE
+      .mockResolvedValueOnce({ rows: [LINKED_ACTIVE_SOURCE] }) // directory source resolution
       .mockResolvedValueOnce({ rows: [{ id: 'u1' }] }) // UPDATE users RETURNING
+      .mockResolvedValueOnce({ rows: [] }) // user_orgs membership (derived org)
       .mockResolvedValueOnce({ rows: [] }) // supersede effects
       .mockResolvedValueOnce({ rows: [] }) // supersede events
       .mockResolvedValueOnce({ rows: [{ access_generation: 1 }] }) // generation
@@ -78,6 +100,10 @@ describe('activatePendingUser (T3)', () => {
       String(call[0]).includes('UPDATE directory_deprovision_events'))).toBe(true)
     expect(pgMocks.query.mock.calls.some((call) =>
       String(call[0]).includes('access_generation = COALESCE'))).toBe(true)
+    // Membership org comes from the SOURCE INTEGRATION (no orgId was supplied at all).
+    const membershipWrite = pgMocks.query.mock.calls.find((call) =>
+      String(call[0]).includes('INSERT INTO user_orgs'))
+    expect(membershipWrite?.[1]).toEqual(['u1', 'org-src'])
     // Alias claims must run inside the transaction client
     expect(claimLoginAlias).toHaveBeenCalled()
     expect(vi.mocked(claimLoginAlias).mock.calls[0]?.[0]).toMatchObject({
@@ -103,7 +129,10 @@ describe('activatePendingUser (T3)', () => {
         activation_status: 'pending_activation',
         is_active: false,
       }],
-    }).mockResolvedValueOnce({ rows: [{ id: 'u1' }] })
+    })
+      .mockResolvedValueOnce({ rows: [LINKED_ACTIVE_SOURCE] })
+      .mockResolvedValueOnce({ rows: [{ id: 'u1' }] })
+      .mockResolvedValueOnce({ rows: [] })
 
     let thrown: unknown
     try {
@@ -134,7 +163,10 @@ describe('activatePendingUser (T3)', () => {
         activation_status: 'pending_activation',
         is_active: false,
       }],
-    }).mockResolvedValueOnce({ rows: [{ id: 'u1' }] })
+    })
+      .mockResolvedValueOnce({ rows: [LINKED_ACTIVE_SOURCE] })
+      .mockResolvedValueOnce({ rows: [{ id: 'u1' }] })
+      .mockResolvedValueOnce({ rows: [] })
 
     await expect(
       activatePendingUser({ userId: 'u1', mode: 'temp_password', temporaryPassword: 'TempPass9A!' }),
@@ -379,10 +411,145 @@ describe('activatePendingUser (T3)', () => {
           is_active: false,
         }],
       })
+      .mockResolvedValueOnce({ rows: [LINKED_ACTIVE_SOURCE] })
       .mockResolvedValueOnce({ rows: [{ id: 'u1' }] })
+      .mockResolvedValueOnce({ rows: [] })
 
     await expect(
       activatePendingUser({ userId: 'u1', mode: 'admin_no_password' }),
     ).rejects.toMatchObject({ code: 'ACTIVATE_ALIAS_REQUIRED' })
+  })
+
+  // Closeout review P1 pin-flips: the suite previously pinned "sourceless temp activation
+  // succeeds" as its positive control. Pending users exist only via directory admission, and
+  // the admission lock forbids activating against a dead or missing source in ANY mode — so
+  // sourceless is now a REFUSAL, before any user write.
+  it('refuses sourceless temp_password activation (ACTIVATE_SOURCE_MISSING), writing nothing', async () => {
+    pgMocks.query
+      .mockResolvedValueOnce({
+        rows: [{
+          id: 'u1',
+          email: 'a@x.com',
+          username: 'alice',
+          mobile: null,
+          activation_status: 'pending_activation',
+          is_active: false,
+        }],
+      })
+      .mockResolvedValueOnce({ rows: [] }) // no linked source at all
+
+    await expect(
+      activatePendingUser({ userId: 'u1', mode: 'temp_password', temporaryPassword: 'TempPass9A!' }),
+    ).rejects.toMatchObject({ code: 'ACTIVATE_SOURCE_MISSING' })
+    expect(pgMocks.query.mock.calls.some((call) =>
+      String(call[0]).includes('UPDATE users'))).toBe(false)
+  })
+
+  it('refuses admin_no_password activation when the only source is inactive', async () => {
+    pgMocks.query
+      .mockResolvedValueOnce({
+        rows: [{
+          id: 'u1',
+          email: 'a@x.com',
+          username: null,
+          mobile: null,
+          activation_status: 'pending_activation',
+          is_active: false,
+        }],
+      })
+      .mockResolvedValueOnce({
+        rows: [{ ...LINKED_ACTIVE_SOURCE, account_active: false }],
+      })
+
+    await expect(
+      activatePendingUser({ userId: 'u1', mode: 'admin_no_password' }),
+    ).rejects.toMatchObject({ code: 'ACTIVATE_SOURCE_INACTIVE' })
+    expect(pgMocks.query.mock.calls.some((call) =>
+      String(call[0]).includes('UPDATE users'))).toBe(false)
+  })
+
+  it('rejects a client orgId that disagrees with the derived source org (ACTIVATE_ORG_MISMATCH)', async () => {
+    pgMocks.query
+      .mockResolvedValueOnce({
+        rows: [{
+          id: 'u1',
+          email: 'a@x.com',
+          username: null,
+          mobile: null,
+          activation_status: 'pending_activation',
+          is_active: false,
+        }],
+      })
+      .mockResolvedValueOnce({ rows: [LINKED_ACTIVE_SOURCE] }) // integration_org_id: 'org-src'
+
+    await expect(
+      activatePendingUser({ userId: 'u1', mode: 'admin_no_password', orgId: 'org-other' }),
+    ).rejects.toMatchObject({ code: 'ACTIVATE_ORG_MISMATCH' })
+    expect(pgMocks.query.mock.calls.some((call) =>
+      String(call[0]).includes('UPDATE users'))).toBe(false)
+  })
+
+  it('accepts a client orgId that CONFIRMS the derived org, and derives the membership write', async () => {
+    pgMocks.query
+      .mockResolvedValueOnce({
+        rows: [{
+          id: 'u1',
+          email: 'a@x.com',
+          username: null,
+          mobile: null,
+          activation_status: 'pending_activation',
+          is_active: false,
+        }],
+      })
+      .mockResolvedValueOnce({ rows: [LINKED_ACTIVE_SOURCE] })
+      .mockResolvedValueOnce({ rows: [{ id: 'u1' }] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ access_generation: 1 }] })
+
+    await expect(
+      activatePendingUser({ userId: 'u1', mode: 'admin_no_password', orgId: 'org-src' }),
+    ).resolves.toMatchObject({ activationStatus: 'activated' })
+    const membershipWrite = pgMocks.query.mock.calls.find((call) =>
+      String(call[0]).includes('INSERT INTO user_orgs'))
+    expect(membershipWrite?.[1]).toEqual(['u1', 'org-src'])
+  })
+
+  // Dual-org: the person's ACTIVE source lives in org-2; a caller pointing at org-1 (their
+  // other, inactive badge's org — or any org at all) must not be able to steer the membership.
+  it('dual-org: derives the ACTIVE source org and refuses a caller steering to the other org', async () => {
+    const dualRows = [
+      {
+        ...LINKED_ACTIVE_SOURCE,
+        id: 'da-1',
+        account_active: false,
+        integration_org_id: 'org-1',
+      },
+      {
+        ...LINKED_ACTIVE_SOURCE,
+        id: 'da-2',
+        account_active: true,
+        integration_org_id: 'org-2',
+      },
+    ]
+    pgMocks.query
+      .mockResolvedValueOnce({
+        rows: [{
+          id: 'u1',
+          email: 'a@x.com',
+          username: null,
+          mobile: null,
+          activation_status: 'pending_activation',
+          is_active: false,
+        }],
+      })
+      .mockResolvedValueOnce({ rows: dualRows })
+
+    await expect(
+      activatePendingUser({ userId: 'u1', mode: 'admin_no_password', orgId: 'org-1' }),
+    ).rejects.toMatchObject({ code: 'ACTIVATE_ORG_MISMATCH' })
+    expect(pgMocks.query.mock.calls.some((call) =>
+      String(call[0]).includes('UPDATE users'))).toBe(false)
   })
 })


### PR DESCRIPTION
## What

Absorbs the closeout re-review (**CHANGES REQUESTED** against main=45cf3a7c51: 2 P1 + 1 P2) per its prescribed 收尾顺序, and lands the countersign-directed **Rev 4.4** erratum.

### P1-1 — T3 activation source authority (`user-activate.ts`)
- Source resolution/validation is now **unconditional for every activation mode** (was gated on `sso || directoryAccountId`; temp_password / admin_no_password could activate against a dead or missing directory source).
- Membership org **derives from the source integration**; a client-supplied `orgId` is only match-validated → `ACTIVATE_ORG_MISMATCH` (409, closed policy table, HTTP leak-control + bulk per-item).
- Pin flip: the unit suite's "sourceless activation succeeds" positive control is now a **refusal** (`ACTIVATE_SOURCE_MISSING`), plus derived-org positive, mismatch + dual-org steering negatives; real-DB activation fixtures seed real sources.

### P1-2 — OPS-01 deny row becomes ledger-evidenced (Rev 4.4, lock §0.7)
- Was: deny row written unconditionally **outside** the ledger → a never-granted person, deprovisioned then rehired, kept an orphan `enabled=FALSE` row permanently blocking creation-only OAuth `ensureGrant`, with no effect for restore to reverse.
- Now: grant-table writes are **purely effect-driven**. New `directory_deprovision_effects.grant_row_created` (migration `zzzz20260808090000`): CHECK (only `grant_changed` with `before=after=FALSE`), immutability-trigger extension, down() refuses while creation evidence exists. Planner emits the creation effect (exempt from the no-op filter); writer INSERTs the deny row from it (flip stays a guarded UPDATE); restore **DELETEs** the row (drift gate: row exists AND disabled), restoring absence — **scoped**: reversal is available while the event remains `applied`; a later access-graph write supersedes the evidence per §5.4 (pre-existing main guards) and the residual's compensating path is now an owner countersign item (see review section below).

### P2 — zero-effect semantics unified
Globally-clear with no row is never zero-effect anymore; both remaining zero-effect flavours (deny already present / not-globally-clear) assert **OAuth loginability unchanged** by the run.

### Docs
- Design lock: §0.7 Rev 4.4 erratum + **Rev 4.3 终签记录** (per this review's countersign).
- #4827 completion MD: status records the CHANGES_REQUIRED interlude and returns to 代码侧收尾完成 atomically with this fix; §4 item 2 marked superseded by Rev 4.4; new §4bis absorption table.

## Verification

- **Killer golden** (real DB, `directory-deprovision-writer-ledger.db.test.ts`): 无既有 grant → 离岗（deny-row creation evidenced）→ OAuth blocked → rehire restore（row DELETEd, absence restored）→ `ensureGrant` works again.
- Schema probes: CHECK positive/negative, `grant_row_created` immutability, down() evidence-refusal.
- **Six mutation kill-proofs run locally** (each red at the intended test, then restored): restore DELETE branch / planner creation arm / no-op exemption / writer INSERT / `ACTIVATE_ORG_MISMATCH` check / re-gated source resolution (the original P1 replayed).
- Full unit sweep **6666 passed**; 15 touched-API real-DB suites green; `tsc --noEmit` green. Migration runs clean on a fresh test DB and is not in any CI `MIGRATION_EXCLUDE`.

## Constraints preserved

Three lifecycle switches stay **OFF** (`DIRECTORY_PENDING_ACTIVATION_ENABLED` / `AUTH_LOGIN_USE_ALIASES` / `DIRECTORY_DEPROVISION_ENABLED`); canary remains per-item ops GO (NO-GO until this lands and is re-reviewed); U1-U13, real callback/corp-anchor, Transfer T3-T5 remain separate gates.

Sequencing note: the review asked to flip #4827's status to CHANGES_REQUIRED first and restore it after the fix. Both edits land atomically here — at no post-merge state does main overclaim; a separate docs-only flip PR would have delayed the fix behind a full required-check run without changing any reachable state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014dQjSzR5ecniF1mRay4wEE

## 独立对抗审 (Opus, 2026-08-09, verdict 绑 head 467ae34b57)

**APPROVE-with-hardening, 0 P1.** Three refute-first targets (T3 bypass / writer↔effect 1:1 / restore drift) attacked and not falsified; all six mutation kill-proofs independently reproduced; immutability function diffed line-by-line against the 20260728 version (no column lost); migration clean on a fresh DB and absent from all 9 MIGRATION_EXCLUDE lists. Two P2s absorbed in commit 6d44a8c37f (docs-only delta since the reviewed head):
1. **Reversibility scoping** — the original body/§0.7 overclaimed unconditional reversibility; supersede (e.g. admin `PATCH /status` re-enable) voids the creation evidence through pre-existing guards (`EVENT_NOT_APPLIED`) leaving the deny row without live evidence. Lock §0.7 now scopes the promise; compensating path added to the owner countersign list (MD §4 item 3). Not a regression (on main the deny row NEVER had evidence).
2. **Dual-ACTIVE-source org derivation ambiguity** (no reachable web caller today) → follow-up #4833.
