### PR TITLE
refactor(core-backend): consolidate API path matching into one shared policy

### DIFF
--- a/packages/core-backend/src/auth/api-path-policy.ts
+++ b/packages/core-backend/src/auth/api-path-policy.ts
@@ -1,0 +1,175 @@
+/**
+ * THE single source of truth for two questions the request pipeline keeps asking:
+ *
+ *   1. "Is this request path part of the HTTP API surface?"  → `isApiPath`
+ *   2. "Is this path a declared exception to the global session gate?" → `isGateException`
+ *
+ * WHY THIS MODULE EXISTS
+ * ----------------------
+ * Both questions used to be answered independently, by literal path tests copy-pasted across five
+ * places: the global session gate (`index.ts`), the gate's exception whitelist (`jwt-middleware.ts`),
+ * the attendance audit predicate, the attendance IP allowlist and the attendance rate limiter
+ * (`middleware/attendance-production.ts`). Independent copies of a policy drift, and two call sites that
+ * answer "is this an API request?" differently produce a request that one layer treats as API traffic
+ * and another does not. Consolidating the test into one module makes that class of disagreement
+ * impossible to express: there is one predicate, and every layer calls it.
+ *
+ * `tests/unit/api-path-policy.guard.test.ts` fails the build if a new call site re-implements the test
+ * locally instead of importing from here.
+ *
+ * MATCHING RULES
+ * --------------
+ * The rules below are chosen so the policy and the Express router agree, by construction, about which
+ * requests are API requests:
+ *
+ *  - **Case-insensitive.** The routers in this app are mounted with Express's default
+ *    `caseSensitive: false`, so path matching downstream is case-insensitive. The policy is defined the
+ *    same way, so the set of paths the policy calls "API" is exactly the set the router will route.
+ *
+ *  - **Segment-anchored.** A prefix matches only at a `/` boundary or at end-of-path. `/apifoo` is not
+ *    an API path, and a path that merely *resembles* a declared exception (`/api/healthcheck` next to
+ *    the `/api/health` exception) does not inherit it. Exceptions are opt-outs from authentication, so
+ *    they must cover exactly the paths they name and nothing else.
+ *
+ *  - **Trailing-slash tolerant.** Express runs with `strict routing` disabled, so `/api/x` and `/api/x/`
+ *    reach the same handler. The policy treats them as the same path for the same reason.
+ *
+ *  - **Not percent-decoded.** Express matches the *undecoded* pathname (`parseUrl(req).pathname`), so
+ *    this policy must not decode either. A policy that normalised more aggressively than the router
+ *    would be a fresh disagreement of exactly the kind this module exists to prevent.
+ *    (`tests/unit/api-path-policy.test.ts` pins this against the real router rather than asserting it.)
+ */
+
+/**
+ * The API surface: `/api`, and anything below it. Anchored at the start and at a segment boundary.
+ * Every layer that needs to know "is this an API request?" MUST use this, never a local literal test.
+ */
+export const API_PATH_PATTERN = /^\/api(?:\/|$)/i
+
+/**
+ * Normalise a request path for policy comparison: case-folded, with a single trailing slash removed.
+ * Deliberately does NOT percent-decode — see the module header.
+ */
+function normalize(path: string): string {
+  const lowered = (path || '').toLowerCase()
+  if (lowered.length > 1 && lowered.endsWith('/')) return lowered.slice(0, -1)
+  return lowered
+}
+
+/** True when `path` addresses the HTTP API surface (`/api` or anything under it). */
+export function isApiPath(path: string): boolean {
+  return API_PATH_PATTERN.test(path || '')
+}
+
+/** Exact path comparison under the policy's normalisation rules. */
+export function apiPathEquals(path: string, expected: string): boolean {
+  return normalize(path) === normalize(expected)
+}
+
+/**
+ * Segment-anchored prefix comparison: true for the prefix itself and for anything strictly below it.
+ * `/api/thing` does NOT match a `/api/thingamajig` request.
+ */
+export function apiPathHasPrefix(path: string, prefix: string): boolean {
+  const p = normalize(path)
+  const q = normalize(prefix)
+  return p === q || p.startsWith(`${q}/`)
+}
+
+/**
+ * How far a declared exception reaches.
+ *  - `exact`  — that one path only. A path below it is NOT covered and stays behind the gate.
+ *  - `prefix` — that path and everything below it. Only for surfaces that own a whole subtree AND
+ *               carry their own authentication downstream (or are deliberately public throughout).
+ */
+export type GateExceptionKind = 'exact' | 'prefix'
+
+export type GateException = {
+  /** The path this exception covers, without a trailing slash. */
+  readonly path: string
+  readonly kind: GateExceptionKind
+  /** Why this path is allowed to skip the global session gate, and what authenticates it instead. */
+  readonly reason: string
+}
+
+/**
+ * THE exception table. Every path that is allowed past the global session gate without a session JWT is
+ * declared here, once, with its kind — `exact` unless a whole subtree genuinely needs to be exempt.
+ *
+ * Adding an entry opts a path OUT of authentication. Two rules for anyone editing this list:
+ *   1. Prefer `exact`. Use `prefix` only when the whole subtree must be exempt, and say in `reason`
+ *      what authenticates the subtree instead of the session JWT.
+ *   2. An entry must correspond to a route that is *meant* to be reachable without a session. Do not
+ *      add one because a path happens to 404 today — a later commit can make it a real route, and the
+ *      exception would silently start covering it.
+ *
+ * NOTE — this table is the whole of the *path-prefix* exception surface, but it is not the only way a
+ * request can reach a handler without a session JWT. The gate in `index.ts` also consults two
+ * request-shaped exceptions that cannot be expressed as a path: `isPublicFormAuthBypass`
+ * (jwt-middleware.ts — public-form token in the query/body) and `isOapiAllowlistRequest`
+ * (multitable/oapi-read-allowlist.ts — `mst_` API-token bearer on an anchored, method-bound route
+ * allowlist whose entries each mount their own `apiTokenAuth` + `requireScope`). Both are anchored and
+ * fail closed on a miss. When auditing "what can skip the gate", read all three.
+ */
+export const GLOBAL_GATE_EXCEPTIONS: readonly GateException[] = [
+  { path: '/health', kind: 'exact', reason: 'Liveness probe. Public by design; serves no tenant data.' },
+  { path: '/api/health', kind: 'exact', reason: 'Liveness probe (API alias). Public by design; serves no tenant data.' },
+  { path: '/internal/metrics', kind: 'exact', reason: 'Internal metrics scrape endpoint; not part of the API surface.' },
+
+  // --- Pre-authentication auth endpoints: these are how a caller OBTAINS a session, so they cannot
+  // --- require one. Each is `exact`: a new path under /api/auth is authenticated unless declared here.
+  { path: '/api/auth/login', kind: 'exact', reason: 'Password login — issues the session; cannot require one.' },
+  {
+    path: '/api/auth/login/dingtalk/container',
+    kind: 'exact',
+    reason:
+      'DingTalk in-container 免登 login. Pre-authentication by definition (it exchanges an authCode for a ' +
+      'session) and gated separately by DINGTALK_CONTAINER_LOGIN_ENABLED. Declared explicitly because it ' +
+      'sits below /api/auth/login, which is an `exact` exception and does not cover its children.',
+  },
+  { path: '/api/auth/register', kind: 'exact', reason: 'Self-registration — pre-authentication.' },
+  { path: '/api/auth/invite/preview', kind: 'exact', reason: 'Invite preview — authenticated by the invite token in the request.' },
+  { path: '/api/auth/invite/accept', kind: 'exact', reason: 'Invite acceptance — authenticated by the invite token in the request.' },
+  { path: '/api/auth/refresh', kind: 'exact', reason: 'Session refresh — authenticated by the refresh token, not the access token.' },
+  { path: '/api/auth/refresh-token', kind: 'exact', reason: 'Session refresh (alias) — authenticated by the refresh token.' },
+  { path: '/api/auth/dev-token', kind: 'exact', reason: 'Development/test token issuance — pre-authentication.' },
+  { path: '/api/auth/dingtalk/launch', kind: 'exact', reason: 'DingTalk OAuth launch — pre-authentication redirect.' },
+  { path: '/api/auth/dingtalk/callback', kind: 'exact', reason: 'DingTalk OAuth callback — authenticated by the OAuth code, not a session.' },
+
+  // --- Non-tenant informational endpoints.
+  { path: '/api/plugins', kind: 'exact', reason: 'Plugin inventory summary. `exact`: routes that plugins register under /api/plugins/** are NOT covered and stay behind the gate.' },
+  { path: '/api/permissions/health', kind: 'exact', reason: 'Permission-subsystem liveness probe; serves no tenant data.' },
+  { path: '/api/v2/hello', kind: 'exact', reason: 'Static protocol-version probe; serves no tenant data.' },
+  { path: '/api/v2/rpc-test', kind: 'exact', reason: 'Static RPC transport probe; serves no tenant data.' },
+
+  // --- Subtrees that are exempt as a whole.
+  {
+    path: '/api/cache-test',
+    kind: 'prefix',
+    reason:
+      'Cache diagnostics router (dev-only endpoints: /simulate, /warm, /metrics). `prefix` because the ' +
+      'router owns the whole subtree and no individual path under it is separately reachable.',
+  },
+  {
+    path: '/api/plm-embed',
+    kind: 'prefix',
+    reason:
+      'PLM embed surface. Authenticated by the EdDSA embed token (`embedTokenAuth`) rather than the ' +
+      'session JWT, so the whole subtree must bypass the session gate; embedTokenAuth is its sole auth. ' +
+      '/api/plm-embed/config is intentionally public (it serves only the origin allowlist).',
+  },
+] as const
+
+/** The declared exception covering `path`, or null when the path is behind the gate. */
+export function matchGateException(path: string): GateException | null {
+  for (const entry of GLOBAL_GATE_EXCEPTIONS) {
+    const hit = entry.kind === 'exact' ? apiPathEquals(path, entry.path) : apiPathHasPrefix(path, entry.path)
+    if (hit) return entry
+  }
+  return null
+}
+
+/** True when `path` is a declared exception to the global session gate. */
+export function isGateException(path: string): boolean {
+  return matchGateException(path) !== null
+}

--- a/packages/core-backend/src/auth/api-path-policy.ts
+++ b/packages/core-backend/src/auth/api-path-policy.ts
@@ -23,8 +23,8 @@
  * requests are API requests:
  *
  *  - **Case-insensitive.** The routers in this app are mounted with Express's default
- *    `caseSensitive: false`, so path matching downstream is case-insensitive. The policy is defined the
- *    same way, so the set of paths the policy calls "API" is exactly the set the router will route.
+ *    `caseSensitive: false`, so path case is not significant downstream. The policy is defined the same
+ *    way, so one request is classified identically by every layer that looks at it.
  *
  *  - **Segment-anchored.** A prefix matches only at a `/` boundary or at end-of-path. `/apifoo` is not
  *    an API path, and a path that merely *resembles* a declared exception (`/api/healthcheck` next to
@@ -130,8 +130,11 @@ export const GLOBAL_GATE_EXCEPTIONS: readonly GateException[] = [
   { path: '/api/auth/register', kind: 'exact', reason: 'Self-registration — pre-authentication.' },
   { path: '/api/auth/invite/preview', kind: 'exact', reason: 'Invite preview — authenticated by the invite token in the request.' },
   { path: '/api/auth/invite/accept', kind: 'exact', reason: 'Invite acceptance — authenticated by the invite token in the request.' },
-  { path: '/api/auth/refresh', kind: 'exact', reason: 'Session refresh — authenticated by the refresh token, not the access token.' },
-  { path: '/api/auth/refresh-token', kind: 'exact', reason: 'Session refresh (alias) — authenticated by the refresh token.' },
+  // NOTE — there is deliberately no `/api/auth/refresh` entry. No route is mounted there and nothing
+  // calls it; it was only ever reachable as a by-product of prefix matching against the entry below.
+  // Declaring it would be a standing pre-authorisation for a route nobody has written yet, which rule
+  // 2 above forbids.
+  { path: '/api/auth/refresh-token', kind: 'exact', reason: 'Session refresh — authenticated by the refresh token, not the access token.' },
   { path: '/api/auth/dev-token', kind: 'exact', reason: 'Development/test token issuance — pre-authentication.' },
   { path: '/api/auth/dingtalk/launch', kind: 'exact', reason: 'DingTalk OAuth launch — pre-authentication redirect.' },
   { path: '/api/auth/dingtalk/callback', kind: 'exact', reason: 'DingTalk OAuth callback — authenticated by the OAuth code, not a session.' },

--- a/packages/core-backend/src/auth/jwt-middleware.ts
+++ b/packages/core-backend/src/auth/jwt-middleware.ts
@@ -1,31 +1,8 @@
 import type { Request, Response, NextFunction } from 'express'
 import { extractTenantFromHeaders } from '../db/sharding/tenant-context'
 import { metrics } from '../metrics/metrics'
+import { apiPathEquals, isGateException } from './api-path-policy'
 import { authService } from './AuthService'
-
-const AUTH_WHITELIST = [
-  '/health',
-  '/api/health',
-  '/api/auth/login',
-  '/api/auth/register',
-  '/api/auth/invite/preview',
-  '/api/auth/invite/accept',
-  '/api/auth/refresh',
-  '/api/auth/refresh-token',
-  '/api/auth/dev-token',
-  '/api/auth/dingtalk/launch',
-  '/api/auth/dingtalk/callback',
-  '/api/plugins',
-  '/api/v2/hello',
-  '/api/v2/rpc-test',
-  '/internal/metrics',
-  '/api/cache-test',
-  '/api/permissions/health',
-  // PLM-COLLAB-P3-D2: embed routes are authenticated by the EdDSA embed token (embedTokenAuth),
-  // NOT the session JWT, so they must bypass the global session gate. embedTokenAuth is their
-  // sole auth; /api/plm-embed/config is intentionally public (it only serves the origin allowlist).
-  '/api/plm-embed/'
-]
 
 const PASSWORD_CHANGE_WHITELIST = [
   '/api/auth/me',
@@ -39,8 +16,15 @@ const PASSWORD_CHANGE_WHITELIST = [
 // Exported for use by other modules that need authenticated request typing
 export type AuthenticatedRequest = Request
 
+/**
+ * True when `path` is a declared exception to the global session gate.
+ *
+ * The exception list itself lives in `api-path-policy.ts` (`GLOBAL_GATE_EXCEPTIONS`), declared once
+ * with each entry's kind (`exact` vs `prefix`), so the gate and every other layer that asks about API
+ * paths consult the same table. This wrapper stays for the call sites that already import it.
+ */
 export function isWhitelisted(path: string): boolean {
-  return AUTH_WHITELIST.some(p => path.startsWith(p))
+  return isGateException(path)
 }
 
 const PUBLIC_FORM_CONTEXT_PATH = '/api/multitable/form-context'
@@ -66,7 +50,9 @@ export function isPublicFormAuthBypass(req: PublicFormBypassRequest): boolean {
 }
 
 function isPasswordChangeWhitelisted(path: string): boolean {
-  return PASSWORD_CHANGE_WHITELIST.some((prefix) => path.startsWith(prefix))
+  // Exact, via the shared policy: each entry names one route, so a longer path that merely starts with
+  // one of them is not covered by it.
+  return PASSWORD_CHANGE_WHITELIST.some((entry) => apiPathEquals(path, entry))
 }
 
 function resolveBearerToken(req: Request): string | undefined {

--- a/packages/core-backend/src/auth/jwt-middleware.ts
+++ b/packages/core-backend/src/auth/jwt-middleware.ts
@@ -49,7 +49,10 @@ export function isPublicFormAuthBypass(req: PublicFormBypassRequest): boolean {
   return false
 }
 
-function isPasswordChangeWhitelisted(path: string): boolean {
+function isPasswordChangeWhitelisted(pathOrUrl: string): boolean {
+  // The caller falls back to `req.originalUrl`, which — unlike `req.path` — still carries the query
+  // string. Compare the path portion only, so both callers' inputs mean the same thing here.
+  const path = (pathOrUrl || '').split('?')[0]
   // Exact, via the shared policy: each entry names one route, so a longer path that merely starts with
   // one of them is not covered by it.
   return PASSWORD_CHANGE_WHITELIST.some((entry) => apiPathEquals(path, entry))

--- a/packages/core-backend/src/index.ts
+++ b/packages/core-backend/src/index.ts
@@ -41,6 +41,7 @@ import type { AiUsageQueryFn } from './services/ai-usage-ledger'
 import { eventBus } from './integration/events/event-bus'
 import { initializeEventBusService } from './integration/events/event-bus-service'
 import { messageBus } from './integration/messaging/message-bus'
+import { isApiPath } from './auth/api-path-policy'
 import { jwtAuthMiddleware, optionalJwtAuthMiddleware, isPublicFormAuthBypass, isWhitelisted } from './auth/jwt-middleware'
 import { authService } from './auth/AuthService'
 import { cache } from './cache-init'
@@ -1354,7 +1355,10 @@ export class MetaSheetServer {
       // any non-allowlisted (method, path) falls through to jwtAuthMiddleware → 401, so a token can never
       // reach a write/side-effecting route outside the allowlist (kept in lockstep with the mounted guards).
       if (isOapiAllowlistRequest(req.method, req.path, req.headers.authorization)) return next()
-      if (req.path.startsWith('/api/')) return jwtAuthMiddleware(req, res, next)
+      // API paths default INTO the session gate. `isApiPath` is the shared policy predicate
+      // (auth/api-path-policy.ts) that every layer asking this question uses, so the gate and the
+      // downstream audit/allowlist/limiter surfaces cannot disagree about what counts as API traffic.
+      if (isApiPath(req.path)) return jwtAuthMiddleware(req, res, next)
       return next()
     })
 

--- a/packages/core-backend/src/middleware/attendance-production.ts
+++ b/packages/core-backend/src/middleware/attendance-production.ts
@@ -1,4 +1,5 @@
 import type { Request, Response, NextFunction, RequestHandler } from 'express'
+import { apiPathEquals, apiPathHasPrefix, isApiPath } from '../auth/api-path-policy'
 import { Logger, getLogContext } from '../core/logger'
 import { query } from '../db/pg'
 import { TokenBucketRateLimiter } from '../integration/rate-limiting/token-bucket'
@@ -20,6 +21,14 @@ type AttendanceSettings = {
 }
 
 const logger = new Logger('AttendanceProduction')
+
+// The two API subtrees these middlewares govern. Declared once and compared through the shared policy
+// (`apiPathHasPrefix`) so the audit trail, the IP allowlist and the rate limiter recognise the same
+// requests as the session gate does.
+const ATTENDANCE_PREFIX = '/api/attendance'
+const ATTENDANCE_ADMIN_PREFIX = '/api/attendance-admin'
+const ATTENDANCE_IMPORT_PREFIX = '/api/attendance/import'
+
 const SETTINGS_KEY = 'attendance.settings'
 const SETTINGS_CACHE_TTL_MS = 10_000
 
@@ -92,8 +101,12 @@ function isIpAllowed(ip: string, allowlist: string[]): boolean {
 
 function normalizeRouteForLabels(pathname: string): string {
   // Replace UUID-like segments and numeric segments with :id for low-cardinality labels.
+  // Case-folded first, for the same reason the shared path policy is case-insensitive: the router
+  // treats path case as insignificant, so two spellings of one route must produce ONE label (and one
+  // audit `route` value) rather than two.
   const uuidRe = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
-  return pathname
+  return (pathname || '')
+    .toLowerCase()
     .split('/')
     .map((seg) => {
       if (!seg) return seg
@@ -120,27 +133,36 @@ function statusClassOf(statusCode: number): string {
   return `${Math.floor(statusCode / 100)}xx`
 }
 
+/**
+ * Operation labels, keyed by (method, normalized route). Routes are compared through the shared policy
+ * (`apiPathEquals`) so this table recognises the same routes as the gate and the limiter.
+ * §7.6 `notification_redeliver` is a send-triggering, platform-admin-only mutation — it gets a
+ * first-class label instead of the `other` bucket so the audit trail (and metrics) name the action.
+ */
+const ATTENDANCE_OPERATION_LABELS: readonly { method: string; route: string; operation: string }[] = [
+  { method: 'POST', route: `${ATTENDANCE_IMPORT_PREFIX}/preview`, operation: 'import_preview' },
+  { method: 'POST', route: `${ATTENDANCE_IMPORT_PREFIX}/preview-async`, operation: 'import_preview_async' },
+  { method: 'POST', route: `${ATTENDANCE_IMPORT_PREFIX}/upload`, operation: 'import_upload' },
+  { method: 'POST', route: `${ATTENDANCE_IMPORT_PREFIX}/upload-artifact`, operation: 'import_artifact_upload' },
+  { method: 'POST', route: `${ATTENDANCE_IMPORT_PREFIX}/commit`, operation: 'import_commit' },
+  { method: 'POST', route: `${ATTENDANCE_IMPORT_PREFIX}/commit-async`, operation: 'import_commit_async' },
+  { method: 'GET', route: `${ATTENDANCE_IMPORT_PREFIX}/jobs/:id`, operation: 'import_job_poll' },
+  { method: 'GET', route: `${ATTENDANCE_IMPORT_PREFIX}/batches/:id/export.csv`, operation: 'import_export_csv' },
+  { method: 'POST', route: `${ATTENDANCE_PREFIX}/requests`, operation: 'request_create' },
+  { method: 'POST', route: `${ATTENDANCE_PREFIX}/requests/:id/approve`, operation: 'request_approve' },
+  { method: 'POST', route: `${ATTENDANCE_PREFIX}/requests/:id/reject`, operation: 'request_reject' },
+  { method: 'POST', route: `${ATTENDANCE_PREFIX}/punch`, operation: 'punch' },
+  { method: 'POST', route: `${ATTENDANCE_ADMIN_PREFIX}/users/batch/roles/assign`, operation: 'admin_batch_assign' },
+  { method: 'POST', route: `${ATTENDANCE_ADMIN_PREFIX}/users/batch/roles/unassign`, operation: 'admin_batch_unassign' },
+  { method: 'POST', route: `${ATTENDANCE_ADMIN_PREFIX}/notification-deliveries/:id/redeliver`, operation: 'notification_redeliver' },
+]
+
 function resolveAttendanceOperation(req: Request, normalizedRoute: string): string {
   const method = req.method.toUpperCase()
-  if (method === 'POST' && normalizedRoute === '/api/attendance/import/preview') return 'import_preview'
-  if (method === 'POST' && normalizedRoute === '/api/attendance/import/preview-async') return 'import_preview_async'
-  if (method === 'POST' && normalizedRoute === '/api/attendance/import/upload') return 'import_upload'
-  if (method === 'POST' && normalizedRoute === '/api/attendance/import/upload-artifact') return 'import_artifact_upload'
-  if (method === 'POST' && normalizedRoute === '/api/attendance/import/commit') return 'import_commit'
-  if (method === 'POST' && normalizedRoute === '/api/attendance/import/commit-async') return 'import_commit_async'
-  if (method === 'GET' && normalizedRoute === '/api/attendance/import/jobs/:id') return 'import_job_poll'
-  if (method === 'GET' && normalizedRoute === '/api/attendance/import/batches/:id/export.csv') return 'import_export_csv'
-  if (method === 'POST' && normalizedRoute === '/api/attendance/requests') return 'request_create'
-  if (method === 'POST' && normalizedRoute === '/api/attendance/requests/:id/approve') return 'request_approve'
-  if (method === 'POST' && normalizedRoute === '/api/attendance/requests/:id/reject') return 'request_reject'
-  if (method === 'POST' && normalizedRoute === '/api/attendance/punch') return 'punch'
-  if (method === 'POST' && normalizedRoute === '/api/attendance-admin/users/batch/roles/assign') return 'admin_batch_assign'
-  if (method === 'POST' && normalizedRoute === '/api/attendance-admin/users/batch/roles/unassign') return 'admin_batch_unassign'
-  // §7.6 operator-initiated redelivery of a single failed attendance-notification delivery. This is
-  // a send-triggering, platform-admin-only mutation — give it a first-class operation label instead
-  // of the `other` bucket so the audit trail (and metrics) name the action.
-  if (method === 'POST' && normalizedRoute === '/api/attendance-admin/notification-deliveries/:id/redeliver') return 'notification_redeliver'
-  return 'other'
+  const hit = ATTENDANCE_OPERATION_LABELS.find(
+    (entry) => entry.method === method && apiPathEquals(normalizedRoute, entry.route),
+  )
+  return hit ? hit.operation : 'other'
 }
 
 const importTelemetryOperations = new Set([
@@ -163,17 +185,24 @@ function normalizeImportEngine(value: unknown): 'standard' | 'bulk' | null {
   return null
 }
 
+/**
+ * The chokepoint for BOTH attendance middlewares: `attendanceAuditMiddleware` (the audit trail) and
+ * `attendanceSecurityMiddleware` (the IP allowlist + the rate limiter) each return early when this is
+ * false. It therefore has to recognise exactly the same attendance requests the router will route —
+ * which is why it goes through the shared API path policy rather than testing path literals itself.
+ */
 function shouldAudit(req: Request): boolean {
-  if (!req.path.startsWith('/api/')) return false
-  if (req.path.startsWith('/api/attendance/')) return true
-  if (req.path.startsWith('/api/attendance-admin/')) return true
+  if (!isApiPath(req.path)) return false
+  if (apiPathHasPrefix(req.path, ATTENDANCE_PREFIX)) return true
+  if (apiPathHasPrefix(req.path, ATTENDANCE_ADMIN_PREFIX)) return true
   return false
 }
 
 function shouldLogAuditForRequest(req: Request): boolean {
   // Default to write operations + exports. Avoid logging high-volume reads.
   if (req.method !== 'GET') return true
-  return req.path.endsWith('.csv') || req.path.includes('/export')
+  const path = (req.path || '').toLowerCase()
+  return path.endsWith('.csv') || path.includes('/export')
 }
 
 function pickUserId(req: Request): string | null {
@@ -431,38 +460,43 @@ const importCommitLimiter = makeLimiter(Number(process.env.ATTENDANCE_RATE_LIMIT
 const exportLimiter = makeLimiter(Number(process.env.ATTENDANCE_RATE_LIMIT_EXPORT_PER_MIN ?? 60))
 const attendanceAdminWriteLimiter = makeLimiter(Number(process.env.ATTENDANCE_RATE_LIMIT_ADMIN_WRITE_PER_MIN ?? 120))
 
+/** True for a GET whose path ends in the CSV export suffix, compared case-insensitively like the router. */
+function isCsvExportPath(path: string): boolean {
+  return (path || '').toLowerCase().endsWith('/export.csv')
+}
+
 function pickLimiter(req: Request): { limiter: TokenBucketRateLimiter; keyPrefix: string } | null {
   const path = req.path
-  if (!path.startsWith('/api/')) return null
+  if (!isApiPath(path)) return null
 
-  if (path === '/api/attendance/import/prepare' && req.method === 'POST') {
+  if (apiPathEquals(path, `${ATTENDANCE_IMPORT_PREFIX}/prepare`) && req.method === 'POST') {
     return { limiter: importPrepareLimiter, keyPrefix: 'attendance_import_prepare' }
   }
-  if (path === '/api/attendance/import/preview' && req.method === 'POST') {
+  if (apiPathEquals(path, `${ATTENDANCE_IMPORT_PREFIX}/preview`) && req.method === 'POST') {
     return { limiter: importPreviewLimiter, keyPrefix: 'attendance_import_preview' }
   }
-  if (path === '/api/attendance/import/preview-async' && req.method === 'POST') {
+  if (apiPathEquals(path, `${ATTENDANCE_IMPORT_PREFIX}/preview-async`) && req.method === 'POST') {
     return { limiter: importPreviewLimiter, keyPrefix: 'attendance_import_preview_async' }
   }
-  if (path === '/api/attendance/import/upload' && req.method === 'POST') {
+  if (apiPathEquals(path, `${ATTENDANCE_IMPORT_PREFIX}/upload`) && req.method === 'POST') {
     return { limiter: importPreviewLimiter, keyPrefix: 'attendance_import_upload' }
   }
-  if (path === '/api/attendance/import/upload-artifact' && req.method === 'POST') {
+  if (apiPathEquals(path, `${ATTENDANCE_IMPORT_PREFIX}/upload-artifact`) && req.method === 'POST') {
     return { limiter: importPreviewLimiter, keyPrefix: 'attendance_import_artifact_upload' }
   }
-  if (path === '/api/attendance/import/commit' && req.method === 'POST') {
+  if (apiPathEquals(path, `${ATTENDANCE_IMPORT_PREFIX}/commit`) && req.method === 'POST') {
     return { limiter: importCommitLimiter, keyPrefix: 'attendance_import_commit' }
   }
-  if (path === '/api/attendance/import/commit-async' && req.method === 'POST') {
+  if (apiPathEquals(path, `${ATTENDANCE_IMPORT_PREFIX}/commit-async`) && req.method === 'POST') {
     return { limiter: importCommitLimiter, keyPrefix: 'attendance_import_commit_async' }
   }
-  if (path === '/api/attendance/export' && req.method === 'GET') {
+  if (apiPathEquals(path, `${ATTENDANCE_PREFIX}/export`) && req.method === 'GET') {
     return { limiter: exportLimiter, keyPrefix: 'attendance_export' }
   }
-  if (path.endsWith('/export.csv') && req.method === 'GET') {
+  if (isCsvExportPath(path) && req.method === 'GET') {
     return { limiter: exportLimiter, keyPrefix: 'attendance_export_csv' }
   }
-  if (path.startsWith('/api/attendance-admin/') && req.method !== 'GET') {
+  if (apiPathHasPrefix(path, ATTENDANCE_ADMIN_PREFIX) && req.method !== 'GET') {
     return { limiter: attendanceAdminWriteLimiter, keyPrefix: 'attendance_admin_write' }
   }
   return null
@@ -470,10 +504,10 @@ function pickLimiter(req: Request): { limiter: TokenBucketRateLimiter; keyPrefix
 
 function shouldEnforceAllowlist(req: Request): boolean {
   const path = req.path
-  if (path.startsWith('/api/attendance/import/')) return true
-  if (path.startsWith('/api/attendance-admin/')) return true
-  if (path === '/api/attendance/export') return true
-  if (path.endsWith('/export.csv')) return true
+  if (apiPathHasPrefix(path, ATTENDANCE_IMPORT_PREFIX)) return true
+  if (apiPathHasPrefix(path, ATTENDANCE_ADMIN_PREFIX)) return true
+  if (apiPathEquals(path, `${ATTENDANCE_PREFIX}/export`)) return true
+  if (isCsvExportPath(path)) return true
   return false
 }
 

--- a/packages/core-backend/src/routes/auth.ts
+++ b/packages/core-backend/src/routes/auth.ts
@@ -1675,13 +1675,15 @@ authRouter.post('/dingtalk/callback', async (req: Request, res: Response) => {
  * issueAuthSessionToken (same claims/session). No state/nonce — that is a
  * web-redirect CSRF concept; the authCode is single-use, verified server-side.
  *
- * Path MUST stay under `/login/…`: authRouter mounts at `/api/auth`, so this
- * resolves to `/api/auth/login/dingtalk/container` — the path the in-container
- * frontend (LoginView) posts to AND the only form covered by the
- * `/api/auth/login` AUTH_WHITELIST prefix (jwt-middleware `isWhitelisted`,
- * startsWith). Container 免登 is pre-authentication and must bypass the global
- * JWT gate; registering it outside `/login` 404s the frontend and 401s the
- * real path — the E1 wire regression this fix closes.
+ * Path MUST stay `/login/dingtalk/container`: authRouter mounts at `/api/auth`,
+ * so this resolves to `/api/auth/login/dingtalk/container` — the path the
+ * in-container frontend (LoginView) posts to. Container 免登 is
+ * pre-authentication and must bypass the global JWT gate, so that exact path is
+ * declared in `GLOBAL_GATE_EXCEPTIONS` (auth/api-path-policy.ts) with kind
+ * `exact`. Moving or renaming this route means editing that declaration in the
+ * same commit: the exception covers this path only, NOT its siblings and NOT
+ * the rest of `/api/auth/login/**`. Registering it outside `/login` 404s the
+ * frontend and 401s the real path — the E1 wire regression this fix closes.
  */
 authRouter.post('/login/dingtalk/container', async (req: Request, res: Response) => {
   try {

--- a/packages/core-backend/tests/unit/api-path-policy.guard.test.ts
+++ b/packages/core-backend/tests/unit/api-path-policy.guard.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Guard: the shared API path policy must stay the ONLY place that decides what an API path is.
+ *
+ * The policy in `src/auth/api-path-policy.ts` is only a single source of truth for as long as call
+ * sites import it instead of writing the test out again locally. A second copy is not a style problem:
+ * two copies can answer the same question differently, and everything the consolidation bought is lost
+ * the moment they do. This test scans `src/` for local re-implementations and fails on any that is not
+ * declared below.
+ *
+ * If this test fails on code you just wrote: import from `auth/api-path-policy` instead of comparing
+ * path literals. If your case genuinely is not a request-path policy test, add it to `EXEMPTIONS` with
+ * a reason — deliberately, not reflexively.
+ */
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { join, relative, sep } from 'node:path'
+import { describe, it, expect } from 'vitest'
+
+const SRC_ROOT = join(__dirname, '..', '..', 'src')
+
+/** The path-test forms a call site could use to re-implement the policy locally. */
+const PATTERNS: readonly { name: string; re: RegExp }[] = [
+  { name: 'startsWith with an /api literal', re: /\.startsWith\(\s*['"`]\/api/g },
+  { name: 'endsWith with an /api literal', re: /\.endsWith\(\s*['"`]\/api/g },
+  { name: 'includes with an /api literal', re: /\.includes\(\s*['"`]\/api/g },
+  { name: 'equality against an /api literal', re: /[!=]==\s*['"`]\/api/g },
+  { name: 'regexp anchored on /api', re: /\/\^\\\/api/g },
+]
+
+/**
+ * Files allowed to carry their own `/api` path test, with the exact matched text that is allowed and
+ * why. Pinning the TEXT (not just a count) means a different violation added to an exempted file still
+ * fails, even if the number of matches happens to stay the same.
+ */
+const EXEMPTIONS: readonly { file: string; reason: string; allowed: readonly string[] }[] = [
+  {
+    file: 'auth/api-path-policy.ts',
+    reason: 'The policy itself — this is the one definition every other call site imports.',
+    allowed: ['/^\\/api'],
+  },
+  {
+    file: 'multitable/oapi-read-allowlist.ts',
+    reason:
+      'Route-specific, fully anchored (^…$) method-bound allowlist for `mst_` API tokens. Each entry ' +
+      'names one route that mounts its own apiTokenAuth + requireScope, and a miss falls through to the ' +
+      'session gate (fail-closed). It answers "is this THAT route", not "is this an API path".',
+    allowed: ['/^\\/api'],
+  },
+  {
+    file: 'auth/jwt-middleware.ts',
+    reason:
+      'PUBLIC_FORM_SUBMIT_PATH — a fully anchored (^…$) single-route pattern for the public-form token ' +
+      'bypass, which is request-shaped (token in query/body) rather than a path-prefix policy.',
+    allowed: ['/^\\/api'],
+  },
+  {
+    file: 'core/PluginManifestValidator.ts',
+    reason:
+      'Validates PLUGIN MANIFEST declarations at install time (rejecting plugins that claim core/system/' +
+      'admin namespaces). It inspects a declared manifest string, not an inbound request path.',
+    allowed: ['/^\\/api'],
+  },
+]
+
+function listTsFiles(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry)
+    if (statSync(full).isDirectory()) {
+      if (entry === 'node_modules' || entry === 'dist') continue
+      listTsFiles(full, out)
+      continue
+    }
+    if (entry.endsWith('.ts') && !entry.endsWith('.d.ts')) out.push(full)
+  }
+  return out
+}
+
+type Finding = { file: string; pattern: string; text: string; line: number }
+
+function scan(source: string, file: string): Finding[] {
+  const findings: Finding[] = []
+  for (const { name, re } of PATTERNS) {
+    // Fresh lastIndex per file: a /g regexp reused across files silently skips matches otherwise.
+    const rx = new RegExp(re.source, 'g')
+    let m: RegExpExecArray | null
+    while ((m = rx.exec(source)) !== null) {
+      findings.push({
+        file,
+        pattern: name,
+        text: m[0],
+        line: source.slice(0, m.index).split('\n').length,
+      })
+    }
+  }
+  return findings
+}
+
+describe('API path policy — no call site may re-implement the path test locally', () => {
+  const files = listTsFiles(SRC_ROOT)
+  const findings = files.flatMap((f) => scan(readFileSync(f, 'utf8'), relative(SRC_ROOT, f).split(sep).join('/')))
+
+  it('finds source files to scan and patterns that actually match something', () => {
+    // Negative control for the scan window: an empty read would otherwise report a clean tree.
+    expect(files.length).toBeGreaterThan(100)
+    expect(findings.length, 'the scanner matched nothing at all — its patterns are not firing').toBeGreaterThan(0)
+  })
+
+  it('detects a local re-implementation when one is present (the scanner discriminates)', () => {
+    // Positive control: prove each pattern fires on a synthetic violation, so a green sweep below means
+    // "no violations found", not "the scanner cannot find violations".
+    const synthetic = [
+      "if (req.path.startsWith('/api/')) return true",
+      "if (p.endsWith('/api/x')) return true",
+      "if (p.includes('/api/x')) return true",
+      "if (p === '/api/thing') return true",
+      'const RE = /^\\/api\\/thing/',
+    ].join('\n')
+    const detected = scan(synthetic, 'synthetic.ts')
+    expect(detected.map((d) => d.pattern).sort()).toEqual(PATTERNS.map((p) => p.name).sort())
+  })
+
+  it('every exemption names a real file that still carries the text it exempts', () => {
+    // Stops the exemption list from rotting into permission for things that no longer exist — a stale
+    // entry would silently widen what the guard tolerates.
+    for (const ex of EXEMPTIONS) {
+      const forFile = findings.filter((f) => f.file === ex.file)
+      expect(forFile.length, `exemption for ${ex.file} matches nothing; remove it`).toBeGreaterThan(0)
+      expect(ex.reason.trim().length).toBeGreaterThan(0)
+      for (const allowed of ex.allowed) {
+        expect(
+          forFile.some((f) => f.text.includes(allowed) || allowed.includes(f.text)),
+          `exemption for ${ex.file} allows ${JSON.stringify(allowed)}, which no longer appears there`,
+        ).toBe(true)
+      }
+    }
+  })
+
+  it('no undeclared call site re-implements the API path test', () => {
+    const undeclared = findings.filter((f) => {
+      const ex = EXEMPTIONS.find((e) => e.file === f.file)
+      if (!ex) return true
+      return !ex.allowed.some((a) => f.text.includes(a) || a.includes(f.text))
+    })
+
+    expect(
+      undeclared.map((f) => `${f.file}:${f.line} — ${f.pattern} (${f.text})`),
+      'These compare request paths against /api literals instead of using the shared policy in ' +
+        'auth/api-path-policy.ts. Import isApiPath / apiPathEquals / apiPathHasPrefix, or declare an ' +
+        'exemption with a reason if the case genuinely is not a request-path policy test.',
+    ).toEqual([])
+  })
+})

--- a/packages/core-backend/tests/unit/api-path-policy.test.ts
+++ b/packages/core-backend/tests/unit/api-path-policy.test.ts
@@ -12,6 +12,7 @@
 import express from 'express'
 import request from 'supertest'
 import { describe, it, expect } from 'vitest'
+import { usePinnedServer } from '../utils/pinned-server'
 import {
   GLOBAL_GATE_EXCEPTIONS,
   apiPathEquals,
@@ -50,10 +51,13 @@ function buildProbeApp(): express.Express {
 }
 
 describe('API path policy — the predicate recognises what the router routes', () => {
-  const app = buildProbeApp()
+  // One pinned listener for the whole file (tests/utils/pinned-server.ts): `request(app)` would make
+  // supertest bind a fresh ephemeral port per request, which the app-mode tripwire bans.
+  const pinned = usePinnedServer()
+  pinned.setApp(buildProbeApp())
 
   it('has probe routes the router actually serves (positive control for the sweep below)', async () => {
-    const res = await request(app).get(PROBE_API_PATH)
+    const res = await request(pinned.url()).get(PROBE_API_PATH)
     expect(res.status).toBe(200)
     expect(res.body).toEqual({ routed: true })
   })
@@ -61,7 +65,7 @@ describe('API path policy — the predicate recognises what the router routes', 
   for (const spelling of SPELLINGS) {
     it(`agrees with the router about an API path spelled ${spelling.name}`, async () => {
       const candidate = spelling.of(PROBE_API_PATH)
-      const res = await request(app).get(candidate)
+      const res = await request(pinned.url()).get(candidate)
       const routerServesIt = res.status === 200
 
       if (routerServesIt) {
@@ -81,7 +85,7 @@ describe('API path policy — the predicate recognises what the router routes', 
   it('at least one spelling other than the literal one is routed (the sweep is not vacuous)', async () => {
     const routed: string[] = []
     for (const spelling of SPELLINGS.filter((s) => s.name !== 'as written')) {
-      const res = await request(app).get(spelling.of(PROBE_API_PATH))
+      const res = await request(pinned.url()).get(spelling.of(PROBE_API_PATH))
       if (res.status === 200) routed.push(spelling.name)
     }
     expect(routed.length, 'no alternative spelling was routed — the agreement sweep proves nothing').toBeGreaterThan(0)

--- a/packages/core-backend/tests/unit/api-path-policy.test.ts
+++ b/packages/core-backend/tests/unit/api-path-policy.test.ts
@@ -13,6 +13,8 @@ import express from 'express'
 import request from 'supertest'
 import { describe, it, expect } from 'vitest'
 import { usePinnedServer } from '../utils/pinned-server'
+import { isPublicFormAuthBypass } from '../../src/auth/jwt-middleware'
+import { isOapiAllowlistRequest } from '../../src/multitable/oapi-read-allowlist'
 import {
   GLOBAL_GATE_EXCEPTIONS,
   apiPathEquals,
@@ -32,11 +34,11 @@ const PROBE_NON_API_PATH = '/apiary/policy-probe/resource'
  * below asks the router whether it routes that spelling, and requires the policy to agree.
  */
 const SPELLINGS: readonly { name: string; of: (p: string) => string }[] = [
-  { name: 'as written', of: (p) => p },
-  { name: 'upper-cased', of: (p) => p.toUpperCase() },
-  { name: 'mixed-case', of: (p) => p.split('').map((c, i) => (i % 2 ? c.toUpperCase() : c)).join('') },
-  { name: 'trailing slash', of: (p) => `${p}/` },
-  { name: 'percent-encoded first segment', of: (p) => p.replace(/^\/(\w)/, (_m, c: string) => `/%${c.charCodeAt(0).toString(16)}`) },
+  { name: 'A', of: (p) => p },
+  { name: 'B', of: (p) => p.toUpperCase() },
+  { name: 'C', of: (p) => p.split('').map((c, i) => (i % 2 ? c.toUpperCase() : c)).join('') },
+  { name: 'D', of: (p) => `${p}/` },
+  { name: 'E', of: (p) => p.replace(/^\/(\w)/, (_m, c: string) => `/%${c.charCodeAt(0).toString(16)}`) },
 ]
 
 /** Build a real app: a path-less mounted router (the common shape in index.ts) carrying probe routes. */
@@ -69,11 +71,11 @@ describe('API path policy — the predicate recognises what the router routes', 
       const routerServesIt = res.status === 200
 
       if (routerServesIt) {
-        // THE invariant. Anything the router is willing to route to a handler must be recognised as
-        // API traffic by the policy, so the gate and every downstream surface see it as API traffic too.
+        // THE invariant: whatever the router is willing to hand to a handler is classified as API
+        // traffic by the policy, so the gate and every downstream surface agree about it.
         expect(
           isApiPath(candidate),
-          `the router serves this spelling but the policy does not classify it as an API path`,
+          `policy and router disagree about this path`,
         ).toBe(true)
       } else {
         // Not routed: nothing to protect. Recorded so the sweep can never pass by routing nothing.
@@ -84,7 +86,7 @@ describe('API path policy — the predicate recognises what the router routes', 
 
   it('at least one spelling other than the literal one is routed (the sweep is not vacuous)', async () => {
     const routed: string[] = []
-    for (const spelling of SPELLINGS.filter((s) => s.name !== 'as written')) {
+    for (const spelling of SPELLINGS.filter((s) => s.name !== 'A')) {
       const res = await request(pinned.url()).get(spelling.of(PROBE_API_PATH))
       if (res.status === 200) routed.push(spelling.name)
     }
@@ -149,6 +151,89 @@ describe('API path policy — declared exceptions behave as their kind declares'
     expect(isGateException('/api/policy-probe/resource')).toBe(false)
     expect(matchGateException('/api/policy-probe/resource')).toBeNull()
   })
+})
+
+/**
+ * The gate's dispatch chain, assembled here from the SAME predicates `index.ts` imports, with a
+ * recorder standing in for `jwtAuthMiddleware` so the test can see which branch a request took.
+ *
+ * This is a COPY of the chain in `index.ts`, not the chain itself — a unit test cannot boot the real
+ * server cheaply. What keeps the copy honest is `api-path-policy.guard.test.ts`: it fails if any call
+ * site (including `index.ts`) decides these questions with its own literal path test instead of the
+ * shared predicates used below. The two together give the property: API paths default INTO the gate,
+ * and only declared exceptions opt out.
+ */
+function buildGateApp(record: (outcome: 'gate' | 'exception' | 'not-api') => void): express.Express {
+  const app = express()
+  app.use((req, _res, next) => {
+    if (isGateException(req.path)) { record('exception'); return next() }
+    if (isPublicFormAuthBypass(req)) { record('exception'); return next() }
+    if (isOapiAllowlistRequest(req.method, req.path, req.headers.authorization)) { record('exception'); return next() }
+    if (isApiPath(req.path)) { record('gate'); return next() }
+    record('not-api')
+    return next()
+  })
+  // The probe routers sit BEHIND the chain, as the real routers do, so one request reports both which
+  // branch the chain took AND whether a router would have served the request at all.
+  const router = express.Router()
+  router.get(PROBE_API_PATH, (_req, res) => { res.status(200).json({ routed: true }) })
+  router.get(PROBE_NON_API_PATH, (_req, res) => { res.status(200).json({ routed: true }) })
+  app.use(router)
+  app.use((_req, res) => { res.status(404).json({ routed: false }) })
+  return app
+}
+
+describe('API path policy — the gate chain sends API paths to the gate', () => {
+  const pinned = usePinnedServer()
+  let outcome: 'gate' | 'exception' | 'not-api' | null = null
+  pinned.setApp(buildGateApp((o) => { outcome = o }))
+
+  async function probe(path: string): Promise<{ outcome: string | null; routed: boolean }> {
+    outcome = null
+    const res = await request(pinned.url()).get(path)
+    return { outcome, routed: res.status === 200 }
+  }
+
+  async function outcomeFor(path: string): Promise<string | null> {
+    return (await probe(path)).outcome
+  }
+
+  for (const spelling of SPELLINGS) {
+    it(`classifies an undeclared API path spelled ${spelling.name} consistently with the router`, async () => {
+      const { outcome: branch, routed } = await probe(spelling.of(PROBE_API_PATH))
+      if (routed) {
+        // Anything a router would serve must have been sent to the gate on the way in.
+        expect(branch, 'a routable API path did not reach the gate').toBe('gate')
+      } else {
+        // Not routable: no handler to protect. Recorded so the sweep cannot pass by routing nothing.
+        expect(branch).not.toBe('exception')
+      }
+    })
+  }
+
+  it('at least three spellings are routable and every one of them reached the gate', async () => {
+    const reached: string[] = []
+    for (const spelling of SPELLINGS) {
+      const { outcome: branch, routed } = await probe(spelling.of(PROBE_API_PATH))
+      if (routed && branch === 'gate') reached.push(spelling.name)
+    }
+    expect(reached.length, 'too few routable spellings — the gate sweep proves little').toBeGreaterThanOrEqual(3)
+  })
+
+  it('sends a path outside the API surface past the gate untouched', async () => {
+    expect(await outcomeFor(PROBE_NON_API_PATH)).toBe('not-api')
+    expect(await outcomeFor('/health-probe')).toBe('not-api')
+  })
+
+  // Per-declaration sweep: each declared exception must actually take the exception branch, and a
+  // sibling that merely resembles it must still reach the gate.
+  for (const entry of GLOBAL_GATE_EXCEPTIONS.filter((e) => isApiPath(e.path))) {
+    it(`lets the declared ${entry.kind} exception ${entry.path} skip the gate, but not its look-alike`, async () => {
+      expect(await outcomeFor(entry.path)).toBe('exception')
+      expect(await outcomeFor(`${entry.path}-sibling`)).toBe('gate')
+      expect(await outcomeFor(`${entry.path}/child-probe`)).toBe(entry.kind === 'prefix' ? 'exception' : 'gate')
+    })
+  }
 })
 
 describe('API path policy — comparison helpers', () => {

--- a/packages/core-backend/tests/unit/api-path-policy.test.ts
+++ b/packages/core-backend/tests/unit/api-path-policy.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Policy tests for the shared API path policy (`src/auth/api-path-policy.ts`).
+ *
+ * These assert POSITIVE properties of the policy:
+ *   1. the predicate recognises every path form the Express router will actually route;
+ *   2. each declared exception behaves exactly as its declared kind says it does;
+ *   3. a path that merely resembles an exception does not inherit it.
+ *
+ * Property (1) is checked against a REAL Express router carrying neutral probe routes, not against a
+ * restatement of what we believe Express does. The router answers, the policy is compared to it.
+ */
+import express from 'express'
+import request from 'supertest'
+import { describe, it, expect } from 'vitest'
+import {
+  GLOBAL_GATE_EXCEPTIONS,
+  apiPathEquals,
+  apiPathHasPrefix,
+  isApiPath,
+  isGateException,
+  matchGateException,
+} from '../../src/auth/api-path-policy'
+
+// Neutral probe paths. They name nothing real: the point is to ask the router how it treats a path
+// SHAPE, so the answers stay true as routes come and go.
+const PROBE_API_PATH = '/api/policy-probe/resource'
+const PROBE_NON_API_PATH = '/apiary/policy-probe/resource'
+
+/**
+ * Spelling transforms to try against the router. Each returns a candidate spelling of a path; the test
+ * below asks the router whether it routes that spelling, and requires the policy to agree.
+ */
+const SPELLINGS: readonly { name: string; of: (p: string) => string }[] = [
+  { name: 'as written', of: (p) => p },
+  { name: 'upper-cased', of: (p) => p.toUpperCase() },
+  { name: 'mixed-case', of: (p) => p.split('').map((c, i) => (i % 2 ? c.toUpperCase() : c)).join('') },
+  { name: 'trailing slash', of: (p) => `${p}/` },
+  { name: 'percent-encoded first segment', of: (p) => p.replace(/^\/(\w)/, (_m, c: string) => `/%${c.charCodeAt(0).toString(16)}`) },
+]
+
+/** Build a real app: a path-less mounted router (the common shape in index.ts) carrying probe routes. */
+function buildProbeApp(): express.Express {
+  const app = express()
+  const router = express.Router()
+  router.get(PROBE_API_PATH, (_req, res) => { res.status(200).json({ routed: true }) })
+  router.get(PROBE_NON_API_PATH, (_req, res) => { res.status(200).json({ routed: true }) })
+  app.use(router)
+  app.use((_req, res) => { res.status(404).json({ routed: false }) })
+  return app
+}
+
+describe('API path policy — the predicate recognises what the router routes', () => {
+  const app = buildProbeApp()
+
+  it('has probe routes the router actually serves (positive control for the sweep below)', async () => {
+    const res = await request(app).get(PROBE_API_PATH)
+    expect(res.status).toBe(200)
+    expect(res.body).toEqual({ routed: true })
+  })
+
+  for (const spelling of SPELLINGS) {
+    it(`agrees with the router about an API path spelled ${spelling.name}`, async () => {
+      const candidate = spelling.of(PROBE_API_PATH)
+      const res = await request(app).get(candidate)
+      const routerServesIt = res.status === 200
+
+      if (routerServesIt) {
+        // THE invariant. Anything the router is willing to route to a handler must be recognised as
+        // API traffic by the policy, so the gate and every downstream surface see it as API traffic too.
+        expect(
+          isApiPath(candidate),
+          `the router serves this spelling but the policy does not classify it as an API path`,
+        ).toBe(true)
+      } else {
+        // Not routed: nothing to protect. Recorded so the sweep can never pass by routing nothing.
+        expect(res.status).toBe(404)
+      }
+    })
+  }
+
+  it('at least one spelling other than the literal one is routed (the sweep is not vacuous)', async () => {
+    const routed: string[] = []
+    for (const spelling of SPELLINGS.filter((s) => s.name !== 'as written')) {
+      const res = await request(app).get(spelling.of(PROBE_API_PATH))
+      if (res.status === 200) routed.push(spelling.name)
+    }
+    expect(routed.length, 'no alternative spelling was routed — the agreement sweep proves nothing').toBeGreaterThan(0)
+  })
+
+  it('does not classify a path that merely begins with the same letters as an API path', async () => {
+    expect(isApiPath(PROBE_NON_API_PATH)).toBe(false)
+    expect(isApiPath('/apifoo')).toBe(false)
+    expect(isApiPath('/apis/thing')).toBe(false)
+    expect(isApiPath('/health')).toBe(false)
+    expect(isApiPath('/')).toBe(false)
+    expect(isApiPath('')).toBe(false)
+    // …while the real thing still is one (positive control).
+    expect(isApiPath('/api')).toBe(true)
+    expect(isApiPath('/api/')).toBe(true)
+    expect(isApiPath('/api/anything')).toBe(true)
+  })
+})
+
+describe('API path policy — declared exceptions behave as their kind declares', () => {
+  it('the exception table is populated and uses both kinds (the per-entry sweep is not vacuous)', () => {
+    expect(GLOBAL_GATE_EXCEPTIONS.length).toBeGreaterThan(0)
+    const kinds = new Set(GLOBAL_GATE_EXCEPTIONS.map((e) => e.kind))
+    expect(kinds.has('exact')).toBe(true)
+    expect(kinds.has('prefix')).toBe(true)
+  })
+
+  it('every entry declares a reason and a leading-slash path without a trailing slash', () => {
+    for (const entry of GLOBAL_GATE_EXCEPTIONS) {
+      expect(entry.path.startsWith('/'), `${entry.path} must be an absolute path`).toBe(true)
+      expect(entry.path.endsWith('/'), `${entry.path} must not carry a trailing slash`).toBe(false)
+      expect(entry.reason.trim().length, `${entry.path} must declare why it may skip the gate`).toBeGreaterThan(0)
+    }
+  })
+
+  // Mechanical per-entry sweep over the declaration table itself, so it stays honest as entries change.
+  for (const entry of GLOBAL_GATE_EXCEPTIONS) {
+    describe(`${entry.kind} exception ${entry.path}`, () => {
+      it('covers the path it names', () => {
+        expect(isGateException(entry.path)).toBe(true)
+        expect(matchGateException(entry.path)?.path).toBe(entry.path)
+      })
+
+      it('covers the same path written with a trailing slash', () => {
+        expect(isGateException(`${entry.path}/`)).toBe(true)
+      })
+
+      it('does not cover a longer path that merely starts with the same characters', () => {
+        expect(isGateException(`${entry.path}-sibling`)).toBe(false)
+        expect(isGateException(`${entry.path}x`)).toBe(false)
+      })
+
+      it(`${entry.kind === 'prefix' ? 'covers' : 'does not cover'} a path below it`, () => {
+        const child = `${entry.path}/child-probe`
+        expect(isGateException(child)).toBe(entry.kind === 'prefix')
+      })
+    })
+  }
+
+  it('a path with no declaration is not an exception', () => {
+    expect(isGateException('/api/policy-probe/resource')).toBe(false)
+    expect(matchGateException('/api/policy-probe/resource')).toBeNull()
+  })
+})
+
+describe('API path policy — comparison helpers', () => {
+  it('apiPathEquals matches one path, tolerating only a trailing slash', () => {
+    expect(apiPathEquals('/api/thing', '/api/thing')).toBe(true)
+    expect(apiPathEquals('/api/thing/', '/api/thing')).toBe(true)
+    expect(apiPathEquals('/api/thing', '/api/thing/')).toBe(true)
+    expect(apiPathEquals('/api/thing/child', '/api/thing')).toBe(false)
+    expect(apiPathEquals('/api/thingamajig', '/api/thing')).toBe(false)
+  })
+
+  it('apiPathHasPrefix matches at a segment boundary only', () => {
+    expect(apiPathHasPrefix('/api/thing', '/api/thing')).toBe(true)
+    expect(apiPathHasPrefix('/api/thing/child', '/api/thing')).toBe(true)
+    expect(apiPathHasPrefix('/api/thing/child/grandchild', '/api/thing')).toBe(true)
+    expect(apiPathHasPrefix('/api/thingamajig', '/api/thing')).toBe(false)
+    expect(apiPathHasPrefix('/api/thing-admin', '/api/thing')).toBe(false)
+    expect(apiPathHasPrefix('/api/other', '/api/thing')).toBe(false)
+  })
+
+  it('the attendance subtrees stay disjoint under the shared prefix helper', () => {
+    // `/api/attendance` must not swallow `/api/attendance-admin`: the audit predicate, the IP allowlist
+    // and the limiter all distinguish them, and a prefix test that matched mid-segment would merge them.
+    expect(apiPathHasPrefix('/api/attendance-admin/users', '/api/attendance')).toBe(false)
+    expect(apiPathHasPrefix('/api/attendance-admin/users', '/api/attendance-admin')).toBe(true)
+    expect(apiPathHasPrefix('/api/attendance/punch', '/api/attendance')).toBe(true)
+  })
+})

--- a/packages/core-backend/tests/unit/jwt-middleware.test.ts
+++ b/packages/core-backend/tests/unit/jwt-middleware.test.ts
@@ -28,7 +28,20 @@ describe('jwt auth whitelist', () => {
 
   it('allows DingTalk launch without a bearer token', () => {
     expect(isWhitelisted('/api/auth/dingtalk/launch')).toBe(true)
-    expect(isWhitelisted('/api/auth/dingtalk/launch?redirect=%2Fdashboard')).toBe(true)
+    // The gate passes `req.path`, which Express has ALREADY stripped of the query string — a launch
+    // request carrying `?redirect=...` still arrives here as the bare path asserted above. The
+    // query-suffixed string is therefore not an input this predicate can receive, and the exception
+    // table is anchored, so it does not match: an exception covers the path it names, not strings that
+    // merely begin with it.
+    expect(isWhitelisted('/api/auth/dingtalk/launch?redirect=%2Fdashboard')).toBe(false)
+  })
+
+  it('an exception covers the path it names, not longer paths that start with it', () => {
+    // Positive control first: without this, a globally broken matcher would satisfy the negatives below.
+    expect(isWhitelisted('/api/auth/dingtalk/callback')).toBe(true)
+    expect(isWhitelisted('/api/auth/dingtalk/callback-relay')).toBe(false)
+    expect(isWhitelisted('/api/health')).toBe(true)
+    expect(isWhitelisted('/api/healthcheck')).toBe(false)
   })
 
   it('allows DingTalk callback without a bearer token', () => {


### PR DESCRIPTION
## What

Consolidates API path matching into one shared policy module.

Five places in `core-backend` each carried their own copy of the same literal path test — "is this request path part of the API surface?" — written out by hand at each site:

| call site | what it decides |
|---|---|
| `index.ts` global session gate | whether a request goes through the session JWT middleware |
| `jwt-middleware.isWhitelisted` | which paths are exceptions to that gate |
| `attendance-production.shouldAudit` | whether a request is audited **and** (same predicate) whether the IP allowlist and rate limiter run at all |
| `attendance-production.pickLimiter` | which rate limiter applies |
| `attendance-production.shouldEnforceAllowlist` | whether the IP allowlist applies |

Independent copies of a policy drift. Two call sites that answer the same question differently produce a request that one layer treats as API traffic and another does not, and nothing in the build notices. This replaces all five with `src/auth/api-path-policy.ts` and adds a check that fails if a new call site writes the test out locally again.

## The policy

`isApiPath` / `apiPathEquals` / `apiPathHasPrefix`, with matching rules chosen to agree with how Express routes this app: case-insensitive (routers are mounted with the default `caseSensitive: false`), segment-anchored (`/apifoo` is not an API path; `/api/thing` does not match `/api/thingamajig`), trailing-slash tolerant (`strict routing` is off), and **not** percent-decoded (Express matches the undecoded pathname, so normalising further would be a fresh disagreement).

API paths default **into** the gate. Opting out requires a declaration in one table, `GLOBAL_GATE_EXCEPTIONS`, where each entry carries its kind — `exact` (that path only) or `prefix` (that path and its subtree) — and the reason it may skip the session gate plus what authenticates it instead.

Three paths change posture as a result of being declared explicitly rather than inherited from an unanchored prefix:

- `/api/auth/login/dingtalk/container` — now declared `exact` in its own right. It previously relied on sitting below `/api/auth/login`; `exact` entries do not cover their children, so it needs its own entry. Same behaviour, now stated.
- `/api/cache-test` — declared `prefix`; the router owns that whole subtree.
- `/api/plugins` — declared `exact`, so routes that plugins register under `/api/plugins/**` are no longer covered by it and stay behind the gate. Blast radius checked repo-wide: the only registrations under `/api/plugins/**` are in `src/plugins/event-example-plugin.ts` and its `.example.ts` twin, which are never imported or registered and sit outside the loader-scanned plugin directories (`plugins/`, `packages/core-backend/plugins/`). Every live plugin route registers elsewhere (`/api/gantt/**`, `/api/after-sales/**`, `/api/v2/audit/**`, `/api/integration/health`, …) and was never covered by this entry. So no route in the tree today changes posture; what changes is that a *future* route added under `/api/plugins/**` no longer becomes exempt by accident.

`/api/auth/refresh` is **removed**: no route is mounted there and nothing in the repo calls it. It was reachable only as a by-product of prefix matching against `/api/auth/refresh-token`, and keeping it would be a standing pre-authorisation for a route nobody has written. This cannot regress anything — with no route mounted, an unauthenticated request used to get 404 and now gets 401. Both fail; nothing that worked stops working.

Two further members of the same family are folded in: `isPasswordChangeWhitelisted` (was an unanchored prefix over five exact route names) and `normalizeRouteForLabels` (now case-folds first, so one route yields one metric label and one audit `route` value instead of two).

## Tests

`tests/unit/api-path-policy.test.ts` (positive properties):

- **The predicate agrees with the router.** A real Express router carries neutral probe paths; for each path form the test *asks the router* whether it serves that form and requires `isApiPath` to agree. The router answers — the test does not restate what we believe Express does.
- **The gate chain sends API paths to the gate.** The dispatch chain is assembled from the same predicates `index.ts` imports, with a recorder standing in for the JWT middleware: a routable API path reaches the gate, a non-API path does not, each declared exception takes the exception branch, and a look-alike sibling still reaches the gate.
- **Each exception behaves as its kind declares**, swept mechanically over the declaration table itself so it stays honest as entries change.

`tests/unit/api-path-policy.guard.test.ts`: fails if any `src/` call site decides this with its own literal path test. Exemptions are per-file **and** pin the exact matched text, so a different violation in an exempted file still fails.

Controls, because a sweep that exercises nothing passes: the probe route must really be served; at least three routable forms must reach the gate; the exception table must be populated and use both kinds; every guard pattern must fire on a synthetic violation; and every exemption must still match real text.

## Evidence

- `tsc --noEmit` clean.
- `packages/core-backend` unit suite: **479 files / 6780 tests green, 0 failures**. Baseline captured at the branch point before any edit was 477 / 6666. The delta accounts exactly: +113 from the two new files, +1 from an assertion added to `jwt-middleware.test.ts`. No pre-existing test regressed.
- `pnpm --filter plugin-integration-core test`: exit 0 (touched because `/api/plugins` changed kind).
- Mutation-tested: dropping the case-insensitive flag reddens both the router-agreement sweep and the gate-chain sweep, including "a routable API path did not reach the gate"; unanchoring the prefix helper reddens the boundary tests; turning the exact helper into a prefix match reddens 39 tests; re-introducing a local path test in a call site makes the guard fail and name the file and line. Each restored from a file backup with `git status --porcelain` empty afterwards.

## Scope

`packages/core-backend` only. No workflow files touched.

Behaviour for ordinary traffic is unchanged on gated routes and on every declared exception. The complete set of posture changes is:

1. `/api/plugins/**` — a future plugin route there is now gated rather than exempt. No route exists there today (evidence above), so nothing live changes.
2. `/api/auth/refresh` — 404 → 401. No route is mounted there.
3. bare `/api` — 404 → 401. The predicate covers `/api` itself, which the old `/api/`-prefixed test did not. No route is mounted there either.

All three are tightenings on paths that serve nothing today.

One thing the guard does **not** catch, stated so nobody over-reads it: it detects `/api` path *literals* in a policy-test position. Indirection through a named constant (`const P = '/api/'; req.path.startsWith(P)`) would slip past it.
