### PR TITLE
fix(dingtalk): #4833 — dual-ACTIVE-source org disambiguation for T3 activation

### DIFF
--- a/docs/development/dingtalk-deprovision-reactivation-and-evidence-chain-design-20260723.md
+++ b/docs/development/dingtalk-deprovision-reactivation-and-evidence-chain-design-20260723.md
@@ -78,7 +78,8 @@ DELETE 逆转仅在其事件仍为 `applied` 时可用。任何后续 access-gra
 离岗 planner 见行已存在也不再补记 creation effect。该 supersede 语义为 main 既有合同（本勘误
 未触碰那两道门），故 Rev 4.4 的承诺应读作：「**在事件被 supersede 之前**，deny 行的存在性变化
 可被 restore 安全逆转」。残留行的补偿路径（人工清理 or 再证据化）列入 owner 会签清单（验证 MD
-§4 第 3 项）。另：多 active 源的 org 派生消歧为 follow-up hardening（#4833）。
+§4 第 3 项）。另：多 active 源的 org 派生消歧已落地（#4833）：请求 orgId 对照 active eligible 源的**集合**匹配，
+未指名且集合含多个不同 org 时拒绝（409 `ACTIVATE_ORG_AMBIGUOUS`），单一 org（含同 org 多源去重）照常派生。
 
 产品方向见 companion — **已赞成**。  
 **Implementation design lock 已于 2026-07-23 批准。**  

--- a/docs/development/dingtalk-lifecycle-line-completion-and-verification-20260808.md
+++ b/docs/development/dingtalk-lifecycle-line-completion-and-verification-20260808.md
@@ -65,7 +65,9 @@ Sonnet 侦察（restack 预案）全部命中：唯一真冲突 #4658、#4659 �
 
 Mutation 六连杀（每条先证锚点命中、后证目标测试转红、cp 还原）：restore DELETE 分支、planner creation 规划、no-op 豁免、writer creation INSERT、`ACTIVATE_ORG_MISMATCH` 校验、激活源门控回退（原 P1 复刻）。
 
-**独立对抗审 verdict（Opus，2026-08-09，绑 head 467ae34b57）**：**APPROVE-with-hardening，0 P1** —— 三条 refute-first 目标（T3 绕过 / writer 非 1:1 / restore drift）构造攻击后均未证伪；六条 mutation 独立复现全转红；immutability 函数与 20260728 版程序化逐行比对一列未丢；迁移在全新 DB 干净跑通且不在 9 处 MIGRATION_EXCLUDE。两条 P2 已落账：①**可逆性边界**——supersede（如管理员重新启用）后 restore 按既有门拒绝（`EVENT_NOT_APPLIED`），deny 行成无证据残留：锁文 §0.7 已按此限定措辞（main 既有语义，非本 PR 引入），补偿路径列入 §4 owner 清单第 3 项；②**双 ACTIVE 源 org 派生歧义**（今日无 web 调用点可达）→ follow-up #4833，**已落地**：集合匹配 + `ACTIVATE_ORG_AMBIGUOUS`（409）+ 双 org 真库金标（对 find-first 变异确定性击杀——金标故意选非 `da.id` 首行的 org，避免 uuid 排序掷硬币）。层级事实：mutation (d)（writer INSERT）只有真库 golden 能杀（6666 unit 全绿）；mutation (f)（源门控回退）只有 unit 层能杀（grant-table 真库 17/17 仍绿）——两层缺一不可。
+**独立对抗审 verdict（Opus，2026-08-09，绑 head 467ae34b57）**：**APPROVE-with-hardening，0 P1** —— 三条 refute-first 目标（T3 绕过 / writer 非 1:1 / restore drift）构造攻击后均未证伪；六条 mutation 独立复现全转红；immutability 函数与 20260728 版程序化逐行比对一列未丢；迁移在全新 DB 干净跑通且不在 9 处 MIGRATION_EXCLUDE。两条 P2 已落账：①**可逆性边界**——supersede（如管理员重新启用）后 restore 按既有门拒绝（`EVENT_NOT_APPLIED`），deny 行成无证据残留：锁文 §0.7 已按此限定措辞（main 既有语义，非本 PR 引入），补偿路径列入 §4 owner 清单第 3 项；②**双 ACTIVE 源 org 派生歧义**（今日无 web 调用点可达）→ follow-up #4833。层级事实：mutation (d)（writer INSERT）只有真库 golden 能杀（6666 unit 全绿）；mutation (f)（源门控回退）只有 unit 层能杀（grant-table 真库 17/17 仍绿）——两层缺一不可。
+
+**#4833 落地记录（2026-08-10，PR #4843 — 本段不属于上面绑定 467ae34b57 的 verdict）**：org 派生改为对 active eligible 源**集合**匹配；无 orgId 且集合含多个不同 org → 409 `ACTIVATE_ORG_AMBIGUOUS`（错误闭集 14，HTTP leak 链全 14 驱动）；同 org 多源去重照常派生；空 org 源不参与投票（单独 fail-closed 测试）；审计 meta 记录实际落位 org（`membershipOrgId`）。双 org 真库金标故意选非 `da.id` 首行的 org，使 find-first 变异确定性转红（3/3），避免 uuid 排序掷硬币。
 
 ## 5. 过程事故诚实档（含撤回）
 

--- a/docs/development/dingtalk-lifecycle-line-completion-and-verification-20260808.md
+++ b/docs/development/dingtalk-lifecycle-line-completion-and-verification-20260808.md
@@ -65,7 +65,7 @@ Sonnet 侦察（restack 预案）全部命中：唯一真冲突 #4658、#4659 �
 
 Mutation 六连杀（每条先证锚点命中、后证目标测试转红、cp 还原）：restore DELETE 分支、planner creation 规划、no-op 豁免、writer creation INSERT、`ACTIVATE_ORG_MISMATCH` 校验、激活源门控回退（原 P1 复刻）。
 
-**独立对抗审 verdict（Opus，2026-08-09，绑 head 467ae34b57）**：**APPROVE-with-hardening，0 P1** —— 三条 refute-first 目标（T3 绕过 / writer 非 1:1 / restore drift）构造攻击后均未证伪；六条 mutation 独立复现全转红；immutability 函数与 20260728 版程序化逐行比对一列未丢；迁移在全新 DB 干净跑通且不在 9 处 MIGRATION_EXCLUDE。两条 P2 已落账：①**可逆性边界**——supersede（如管理员重新启用）后 restore 按既有门拒绝（`EVENT_NOT_APPLIED`），deny 行成无证据残留：锁文 §0.7 已按此限定措辞（main 既有语义，非本 PR 引入），补偿路径列入 §4 owner 清单第 3 项；②**双 ACTIVE 源 org 派生歧义**（今日无 web 调用点可达）→ follow-up #4833。层级事实：mutation (d)（writer INSERT）只有真库 golden 能杀（6666 unit 全绿）；mutation (f)（源门控回退）只有 unit 层能杀（grant-table 真库 17/17 仍绿）——两层缺一不可。
+**独立对抗审 verdict（Opus，2026-08-09，绑 head 467ae34b57）**：**APPROVE-with-hardening，0 P1** —— 三条 refute-first 目标（T3 绕过 / writer 非 1:1 / restore drift）构造攻击后均未证伪；六条 mutation 独立复现全转红；immutability 函数与 20260728 版程序化逐行比对一列未丢；迁移在全新 DB 干净跑通且不在 9 处 MIGRATION_EXCLUDE。两条 P2 已落账：①**可逆性边界**——supersede（如管理员重新启用）后 restore 按既有门拒绝（`EVENT_NOT_APPLIED`），deny 行成无证据残留：锁文 §0.7 已按此限定措辞（main 既有语义，非本 PR 引入），补偿路径列入 §4 owner 清单第 3 项；②**双 ACTIVE 源 org 派生歧义**（今日无 web 调用点可达）→ follow-up #4833，**已落地**：集合匹配 + `ACTIVATE_ORG_AMBIGUOUS`（409）+ 双 org 真库金标（对 find-first 变异确定性击杀——金标故意选非 `da.id` 首行的 org，避免 uuid 排序掷硬币）。层级事实：mutation (d)（writer INSERT）只有真库 golden 能杀（6666 unit 全绿）；mutation (f)（源门控回退）只有 unit 层能杀（grant-table 真库 17/17 仍绿）——两层缺一不可。
 
 ## 5. 过程事故诚实档（含撤回）
 

--- a/packages/core-backend/src/auth/user-activate.ts
+++ b/packages/core-backend/src/auth/user-activate.ts
@@ -94,6 +94,8 @@ export type ActivateErrorCode =
   | 'ACTIVATE_SOURCE_INELIGIBLE'
   /** Caller-supplied orgId disagrees with the org derived from the directory-source integration. */
   | 'ACTIVATE_ORG_MISMATCH'
+  /** Multiple ACTIVE directory sources in different orgs; the caller must name one (#4833). */
+  | 'ACTIVATE_ORG_AMBIGUOUS'
 
 function throwCoded(message: string, code: ActivateErrorCode): never {
   const err = new Error(message)
@@ -152,18 +154,17 @@ export async function activatePendingUser(input: ActivateUserInput): Promise<Act
     // The membership org DERIVES from the source integration in every mode; a client-supplied
     // orgId may only CONFIRM it. The gated form discarded the DB's org for non-SSO modes and
     // trusted the client's — "org A 的目录账号 + org B 的 orgId" wrote a cross-org membership.
+    // #4833: when the person has ACTIVE sources in more than one org, "derive" has no unique
+    // answer — the helper validates a caller-supplied orgId against the SET of active eligible
+    // sources (mismatch → ACTIVATE_ORG_MISMATCH) and refuses a caller who names none
+    // (ACTIVATE_ORG_AMBIGUOUS) instead of silently picking the lowest account id.
     const sourceOrgId = await assertDirectorySourceActiveForActivate(client, {
       userId,
       directoryAccountId: input.directoryAccountId ?? null,
       requireDingTalkSso: input.mode === 'sso',
       expectedDingTalkIdentity: input.expectedDingTalkIdentity ?? null,
+      requestedOrgId: input.orgId ?? null,
     })
-    if (input.orgId && input.orgId !== sourceOrgId) {
-      throwCoded(
-        'orgId does not match the directory source integration for this user',
-        'ACTIVATE_ORG_MISMATCH',
-      )
-    }
     membershipOrgId = sourceOrgId
 
     const updated = await client.query(
@@ -305,6 +306,7 @@ async function assertDirectorySourceActiveForActivate(
     directoryAccountId: string | null
     requireDingTalkSso: boolean
     expectedDingTalkIdentity: ActivateUserInput['expectedDingTalkIdentity']
+    requestedOrgId: string | null
   },
 ): Promise<string> {
   // Closed set: linked directory account must be active; integration active.
@@ -411,17 +413,44 @@ async function assertDirectorySourceActiveForActivate(
       'ACTIVATE_SOURCE_INELIGIBLE',
     )
   }
-  const activeEligible = eligibleRows.find(
+  const activeEligibleRows = eligibleRows.filter(
     (candidate) =>
       candidate.account_active === true
       && String(candidate.integration_status || '').toLowerCase() === 'active',
   )
-  if (activeEligible) {
-    const sourceOrgId = String(activeEligible.integration_org_id || '').trim()
-    if (sourceOrgId) return sourceOrgId
+  if (activeEligibleRows.length > 0) {
+    // #4833: derive against the SET of active eligible sources, not the first row. An active
+    // source whose integration carries no org is misconfigured — it cannot anchor a membership
+    // write, so it never joins the candidate set.
+    const candidateOrgIds = [...new Set(
+      activeEligibleRows
+        .map((candidate) => String(candidate.integration_org_id || '').trim())
+        .filter((orgId) => orgId.length > 0),
+    )]
+    if (candidateOrgIds.length === 0) {
+      throwCoded(
+        'Directory source is not a DingTalk account eligible for SSO activation',
+        'ACTIVATE_SOURCE_INELIGIBLE',
+      )
+    }
+    if (options.requestedOrgId) {
+      if (candidateOrgIds.includes(options.requestedOrgId)) {
+        return options.requestedOrgId
+      }
+      // The caller named an org none of the person's ACTIVE sources belongs to — steering.
+      throwCoded(
+        'orgId does not match the directory source integration for this user',
+        'ACTIVATE_ORG_MISMATCH',
+      )
+    }
+    if (candidateOrgIds.length === 1) {
+      return candidateOrgIds[0]
+    }
+    // No orgId and more than one legitimate answer: refusing beats silently picking one —
+    // activation would otherwise write an arbitrary org's membership (#4833).
     throwCoded(
-      'Directory source is not a DingTalk account eligible for SSO activation',
-      'ACTIVATE_SOURCE_INELIGIBLE',
+      'Multiple active directory sources in different orgs; orgId is required to disambiguate',
+      'ACTIVATE_ORG_AMBIGUOUS',
     )
   }
   if (eligibleRows.some(

--- a/packages/core-backend/src/auth/user-activate.ts
+++ b/packages/core-backend/src/auth/user-activate.ts
@@ -64,6 +64,8 @@ export type ActivateUserResult = {
   isActive: true
   temporaryPassword?: string
   localPasswordSet: boolean
+  /** The org the membership was actually written to — derived from the directory source (#4833 audit surface). */
+  membershipOrgId: string | null
 }
 
 /**
@@ -90,7 +92,10 @@ export type ActivateErrorCode =
   | 'ACTIVATE_SOURCE_INACTIVE'
   | 'ACTIVATE_INTEGRATION_INACTIVE'
   | 'ACTIVATE_LINK_MISMATCH'
-  /** SSO-only: account/integration provider is not DingTalk, or corp_id is inconsistent. */
+  /**
+   * SSO: provider is not DingTalk or corp_id is inconsistent. Any mode: every active eligible
+   * source carries an empty integration org_id (nothing can anchor a membership write).
+   */
   | 'ACTIVATE_SOURCE_INELIGIBLE'
   /** Caller-supplied orgId disagrees with the org derived from the directory-source integration. */
   | 'ACTIVATE_ORG_MISMATCH'
@@ -114,7 +119,9 @@ export async function activatePendingUser(input: ActivateUserInput): Promise<Act
   let passwordHash: string | null = null
   let localPasswordSet = false
   let mustChangePassword = false
-  let membershipOrgId = input.orgId ?? null
+  // Derived-only: seeded null so no refactor can ever revive the client-orgId-as-membership
+  // shape by skipping the source resolution — the ONLY assignment is from the helper's return.
+  let membershipOrgId: string | null = null
 
   if (input.mode === 'temp_password') {
     temporaryPassword = input.temporaryPassword?.trim() || generateTempPassword()
@@ -163,7 +170,7 @@ export async function activatePendingUser(input: ActivateUserInput): Promise<Act
       directoryAccountId: input.directoryAccountId ?? null,
       requireDingTalkSso: input.mode === 'sso',
       expectedDingTalkIdentity: input.expectedDingTalkIdentity ?? null,
-      requestedOrgId: input.orgId ?? null,
+      requestedOrgId: input.orgId?.trim() || null,
     })
     membershipOrgId = sourceOrgId
 
@@ -282,6 +289,7 @@ export async function activatePendingUser(input: ActivateUserInput): Promise<Act
     isActive: true,
     temporaryPassword,
     localPasswordSet,
+    membershipOrgId,
   }
 }
 

--- a/packages/core-backend/src/routes/admin-users.ts
+++ b/packages/core-backend/src/routes/admin-users.ts
@@ -2062,6 +2062,10 @@ async function auditActivateSuccess(
       localPasswordSet: result.localPasswordSet,
       // Boolean only: plaintext passwords and provider identity values are forbidden in audit.
       temporaryPasswordIssued: Boolean(result.temporaryPassword),
+      // #4833: with several ACTIVE sources the admin's orgId CHOOSES among orgs — the audit row
+      // must record which org the membership actually landed in, or the forensic question
+      // "who placed this user in org B" has no answer. An org id is placement, not identity.
+      membershipOrgId: result.membershipOrgId,
     },
   })
 }

--- a/packages/core-backend/src/routes/admin-users.ts
+++ b/packages/core-backend/src/routes/admin-users.ts
@@ -1848,6 +1848,12 @@ const ACTIVATE_ERROR_POLICY_SOURCE: Record<ActivateErrorCode, { status: number; 
     status: 409,
     message: 'orgId does not match the directory source integration for this user',
   },
+  // 409 (#4833): several ACTIVE sources in different orgs — "derive" has no unique answer, so
+  // the caller must name one; refusing beats silently picking the lowest account id.
+  ACTIVATE_ORG_AMBIGUOUS: {
+    status: 409,
+    message: 'Multiple active directory sources in different orgs; orgId is required to disambiguate',
+  },
 }
 
 type ActivatePolicyRow = Readonly<{ status: number; message: string }>

--- a/packages/core-backend/src/routes/auth.ts
+++ b/packages/core-backend/src/routes/auth.ts
@@ -597,6 +597,11 @@ function mapDingTalkActivationFailure(error: unknown): DingTalkActivationIntentE
     || code === 'ACTIVATE_SOURCE_INELIGIBLE'
     || code === 'ACTIVATE_ALIAS_CONFLICT'
     || code === 'ACTIVATE_ALIAS_REQUIRED'
+    // Unreachable today (the callback passes an explicit directoryAccountId and no orgId), but
+    // the closed set must track the enum: falling through to 500 for a caller-resolvable
+    // conflict is the exact drift the admin-route closure tests exist to prevent (#4833).
+    || code === 'ACTIVATE_ORG_MISMATCH'
+    || code === 'ACTIVATE_ORG_AMBIGUOUS'
   ) {
     return new DingTalkActivationIntentError(
       409,

--- a/packages/core-backend/tests/integration/directory-deprovision-grant-table.db.test.ts
+++ b/packages/core-backend/tests/integration/directory-deprovision-grant-table.db.test.ts
@@ -24,6 +24,7 @@ import { restoreDeprovisionEvent } from '../../src/directory/deprovision-evidenc
 const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
 
 const ORG = 'org-grant-fix-test'
+const ORG_B = 'org-grant-fix-test-b'
 const USER = 'u-grant-fix-test'
 const USER_A = 'u-grant-fix-owner'
 const USER_B = 'u-grant-fix-pending'
@@ -39,11 +40,13 @@ async function cleanup() {
     await query(`DELETE FROM user_orgs WHERE user_id = $1`, [uid])
     await query(`DELETE FROM users WHERE id = $1`, [uid])
   }
-  await query(`DELETE FROM directory_sync_runs WHERE integration_id IN
-                 (SELECT id FROM directory_integrations WHERE org_id = $1)`, [ORG])
-  await query(`DELETE FROM directory_accounts WHERE integration_id IN
-                 (SELECT id FROM directory_integrations WHERE org_id = $1)`, [ORG])
-  await query(`DELETE FROM directory_integrations WHERE org_id = $1`, [ORG])
+  for (const org of [ORG, ORG_B]) {
+    await query(`DELETE FROM directory_sync_runs WHERE integration_id IN
+                   (SELECT id FROM directory_integrations WHERE org_id = $1)`, [org])
+    await query(`DELETE FROM directory_accounts WHERE integration_id IN
+                   (SELECT id FROM directory_integrations WHERE org_id = $1)`, [org])
+    await query(`DELETE FROM directory_integrations WHERE org_id = $1`, [org])
+  }
 }
 
 async function seedDirectory(opts: { sourceActive: boolean }) {
@@ -85,8 +88,13 @@ async function seedActivationSource(options: {
   integrationStatus?: string
   openId?: string
   unionId?: string
+  /** #4833: seed the source under a different org (dual-active-source disambiguation golden). */
+  orgId?: string
+  externalKey?: string
 }) {
-  const integrationCorpId = options.integrationCorpId ?? `corp-${ORG}`
+  const orgId = options.orgId ?? ORG
+  const integrationCorpId = options.integrationCorpId ?? `corp-${orgId}`
+  const externalKey = options.externalKey ?? `dingtalk:activation-source:ext-${orgId}`
   const integration = await query<{ id: string }>(
     `INSERT INTO directory_integrations
        (name, corp_id, org_id, provider, status, default_deprovision_policy)
@@ -94,7 +102,7 @@ async function seedActivationSource(options: {
      RETURNING id::text AS id`,
     [
       integrationCorpId,
-      ORG,
+      orgId,
       options.integrationProvider ?? 'dingtalk',
       options.integrationStatus ?? 'active',
     ],
@@ -104,7 +112,7 @@ async function seedActivationSource(options: {
        (integration_id, provider, corp_id, external_user_id, external_key, name,
         open_id, union_id, is_active)
      VALUES ($1::uuid, $2, $3, 'ext-activation-source',
-             'dingtalk:activation-source:ext', 'Activation Source', $4, $5, $6)
+             $7, 'Activation Source', $4, $5, $6)
      RETURNING id::text AS id`,
     [
       integration.rows[0].id,
@@ -113,6 +121,7 @@ async function seedActivationSource(options: {
       options.openId ?? null,
       options.unionId ?? null,
       options.accountActive ?? true,
+      externalKey,
     ],
   )
   if (options.linkedUserId !== undefined) {
@@ -956,6 +965,51 @@ describeIfDatabase('DingTalk grant/membership writes target the real tables (rea
       effect_status: 'reversed',
       reversed_by: 'admin-test',
     })
+  })
+
+  // #4833: with ACTIVE sources in TWO orgs, "derive" has no unique answer. Naming no org must
+  // refuse with zero residue; naming the second org must land the membership exactly there.
+  it('#4833 dual-ACTIVE orgs: no orgId refuses with zero residue; naming the second org activates there', async () => {
+    await query(
+      `INSERT INTO users (id, email, name, password_hash, is_active, activation_status, local_password_set)
+       VALUES ($1, 'dual-org@example.com', 'Dual Org', 'x', FALSE, 'pending_activation', FALSE)`,
+      [USER],
+    )
+    await seedActivationSource({ linkedUserId: USER })
+    await seedActivationSource({ linkedUserId: USER, orgId: ORG_B })
+
+    await expect(
+      activatePendingUser({ userId: USER, mode: 'admin_no_password', adminUserId: 'admin-test' }),
+    ).rejects.toMatchObject({ code: 'ACTIVATE_ORG_AMBIGUOUS' })
+    const afterRefusal = await query<{ activation_status: string; is_active: boolean }>(
+      `SELECT activation_status, is_active FROM users WHERE id = $1`, [USER])
+    expect(afterRefusal.rows[0]).toEqual({ activation_status: 'pending_activation', is_active: false })
+    const residue = await query(`SELECT 1 FROM user_orgs WHERE user_id = $1`, [USER])
+    expect(residue.rows).toHaveLength(0)
+
+    // Deterministic kill for the find-first/first-only mutation: da.id is a uuid, so which row
+    // sorts first is a coin flip — asking for a FIXED org would only catch the mutation half
+    // the time. Ask for whichever org is NOT first in the helper's own ORDER BY da.id order.
+    const firstByAccountId = await query<{ org_id: string }>(
+      `SELECT di.org_id
+         FROM directory_account_links l
+         JOIN directory_accounts da ON da.id = l.directory_account_id
+         JOIN directory_integrations di ON di.id = da.integration_id
+        WHERE l.local_user_id = $1 AND l.link_status = 'linked'
+        ORDER BY da.id
+        LIMIT 1`,
+      [USER],
+    )
+    const nonFirstOrg = firstByAccountId.rows[0].org_id === ORG ? ORG_B : ORG
+    await activatePendingUser({
+      userId: USER,
+      mode: 'admin_no_password',
+      adminUserId: 'admin-test',
+      orgId: nonFirstOrg,
+    })
+    const memberships = await query<{ org_id: string; is_active: boolean }>(
+      `SELECT org_id, is_active FROM user_orgs WHERE user_id = $1 ORDER BY org_id`, [USER])
+    expect(memberships.rows).toEqual([{ org_id: nonFirstOrg, is_active: true }])
   })
 
   it('alias conflict rolls back users/membership/grant (real Postgres transaction)', async () => {

--- a/packages/core-backend/tests/unit/admin-users-activate-error-closure.test.ts
+++ b/packages/core-backend/tests/unit/admin-users-activate-error-closure.test.ts
@@ -260,7 +260,7 @@ describe('activate error closure — LAYER 3: static consistency, NOT a behaviou
       + `site, so their row is unreachable and untested: ${JSON.stringify(tableNotThrown)}`,
     ).toEqual([])
 
-    expect(reasons.size).toBe(13)
+    expect(reasons.size).toBe(14)
   })
 
   it('mapActivateError reads ONLY `.code` off its error parameter — never `.message`', () => {

--- a/packages/core-backend/tests/unit/admin-users-activate-error-leak.test.ts
+++ b/packages/core-backend/tests/unit/admin-users-activate-error-leak.test.ts
@@ -255,6 +255,49 @@ describe('activate error surface — HTTP-level leak control (behaviour, not syn
     })
   })
 
+  // Verify-workflow finding on #4843: the mapping/closure chains enumerate all 14 authored
+  // reasons but the HTTP surface drove only a subset — a route-layer special-case for any
+  // undriven code would have left every test green. Longhand on purpose (reading the table
+  // under test would assert the table equals itself); driver text walked on EVERY row.
+  it('ALL 14 authored reasons answer their ruled status over HTTP with our message and zero driver text', () => {
+    const cases: Array<[string, number, string]> = [
+      ['ACTIVATE_USER_REQUIRED', 400, 'A target user id is required to activate'],
+      ['ACTIVATE_USER_NOT_FOUND', 404, 'User not found'],
+      ['ACTIVATE_NOT_PENDING', 409, 'User is not pending activation'],
+      ['ACTIVATE_RACE', 409, 'User is no longer pending activation'],
+      ['ACTIVATE_ALIAS_CONFLICT', 409, 'A login identifier is already claimed by another account'],
+      ['ACTIVATE_ALIAS_REQUIRED', 409, 'Activation requires at least one usable login identifier'],
+      ['ACTIVATE_ALIAS_FAILED', 500, 'Failed to claim login alias during activation'],
+      ['ACTIVATE_SOURCE_MISSING', 409, 'No linked active directory account for activation'],
+      ['ACTIVATE_SOURCE_INACTIVE', 409, 'Directory account is inactive; cannot activate'],
+      ['ACTIVATE_INTEGRATION_INACTIVE', 409, 'Directory integration is not active; cannot activate'],
+      ['ACTIVATE_LINK_MISMATCH', 409, 'Directory link points to a different user'],
+      ['ACTIVATE_SOURCE_INELIGIBLE', 409, 'Directory source is not eligible for DingTalk SSO activation'],
+      ['ACTIVATE_ORG_MISMATCH', 409, 'orgId does not match the directory source integration for this user'],
+      ['ACTIVATE_ORG_AMBIGUOUS', 409, 'Multiple active directory sources in different orgs; orgId is required to disambiguate'],
+    ]
+    expect(cases).toHaveLength(14)
+    return cases.reduce(
+      (chain, [code, status, message]) => chain.then(async () => {
+        state.activateImpl = () => {
+          throw Object.assign(new Error(DRIVER_TEXT), { code })
+        }
+        const res = await invokeActivate('user-1')
+        for (const fragment of DRIVER_FRAGMENTS) {
+          expect(
+            findStringOccurrences(res.body, fragment),
+            `DRIVER TEXT LEAK on ${code}: '${fragment}' reached the client.`,
+          ).toEqual([])
+        }
+        expect({ status: res.statusCode, body: res.body }).toEqual({
+          status,
+          body: { ok: false, error: { code, message, details: undefined } },
+        })
+      }),
+      Promise.resolve(),
+    )
+  })
+
   it('the other two newly-ruled reasons answer 409 over HTTP as well', () => {
     const cases: Array<[string, number, string]> = [
       ['ACTIVATE_INTEGRATION_INACTIVE', 409, 'Directory integration is not active; cannot activate'],

--- a/packages/core-backend/tests/unit/admin-users-activate-error-leak.test.ts
+++ b/packages/core-backend/tests/unit/admin-users-activate-error-leak.test.ts
@@ -261,6 +261,8 @@ describe('activate error surface — HTTP-level leak control (behaviour, not syn
       ['ACTIVATE_SOURCE_MISSING', 409, 'No linked active directory account for activation'],
       // Closeout review P1: derived-org confirmation failure surfaces as 409 with OUR message.
       ['ACTIVATE_ORG_MISMATCH', 409, 'orgId does not match the directory source integration for this user'],
+      // #4833: dual-ACTIVE-source ambiguity surfaces as 409 with OUR message.
+      ['ACTIVATE_ORG_AMBIGUOUS', 409, 'Multiple active directory sources in different orgs; orgId is required to disambiguate'],
     ]
     return cases.reduce(
       (chain, [code, status, message]) => chain.then(async () => {

--- a/packages/core-backend/tests/unit/admin-users-activate-error-mapping.test.ts
+++ b/packages/core-backend/tests/unit/admin-users-activate-error-mapping.test.ts
@@ -64,6 +64,11 @@ describe('mapActivateError (activate endpoint error surface)', () => {
       status: 409,
       message: 'orgId does not match the directory source integration for this user',
     },
+    // #4833: ambiguity is a configuration conflict the caller can resolve — 409.
+    ACTIVATE_ORG_AMBIGUOUS: {
+      status: 409,
+      message: 'Multiple active directory sources in different orgs; orgId is required to disambiguate',
+    },
     ACTIVATE_SOURCE_INACTIVE: {
       status: 409,
       message: 'Directory account is inactive; cannot activate',
@@ -104,7 +109,7 @@ describe('mapActivateError (activate endpoint error surface)', () => {
 
   it('asserts the RULED transcription covers exactly the policy table (no silent drift)', () => {
     expect(Object.keys(RULED).sort()).toEqual(Object.keys(ACTIVATE_ERROR_POLICY).sort())
-    expect(Object.keys(RULED)).toHaveLength(13)
+    expect(Object.keys(RULED)).toHaveLength(14)
   })
 
   it('collapses an unauthored but ACTIVATE_-shaped code — the fail-open the owner reproduced', () => {

--- a/packages/core-backend/tests/unit/admin-users-routes.test.ts
+++ b/packages/core-backend/tests/unit/admin-users-routes.test.ts
@@ -4051,6 +4051,66 @@ describe('admin-users routes', () => {
     expect(activateMocks.activatePendingUser).not.toHaveBeenCalled()
   })
 
+  // #4833 + verify-workflow findings: (a) the bulk envelope must carry ACTIVATE_ORG_AMBIGUOUS
+  // per-item; (b) no test asserted the routes actually THREAD the parsed orgId into
+  // activatePendingUser — a route that dropped it would leave every mapping test green.
+  it('POST bulk activate surfaces ACTIVATE_ORG_AMBIGUOUS per-item and threads each item orgId', async () => {
+    rbacMocks.isAdmin.mockResolvedValue(true)
+    activateMocks.activatePendingUser
+      .mockRejectedValueOnce(Object.assign(
+        new Error('dual active sources detail: da-1 da-2 DETAIL: secret'),
+        { code: 'ACTIVATE_ORG_AMBIGUOUS' },
+      ))
+      .mockResolvedValueOnce({
+        userId: 'pending-user-2',
+        activationStatus: 'activated',
+        isActive: true,
+        localPasswordSet: false,
+        membershipOrgId: 'org-b',
+      })
+
+    const response = await invokeRoute('post', '/api/admin/users/activate/bulk', {
+      body: {
+        items: [
+          { userId: 'pending-user-1', mode: 'admin_no_password' },
+          { userId: 'pending-user-2', mode: 'admin_no_password', orgId: 'org-b' },
+        ],
+      },
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(response.body).toMatchObject({
+      ok: true,
+      data: {
+        successCount: 1,
+        failureCount: 1,
+        items: [
+          {
+            userId: 'pending-user-1',
+            ok: false,
+            error: {
+              status: 409,
+              code: 'ACTIVATE_ORG_AMBIGUOUS',
+              message: 'Multiple active directory sources in different orgs; orgId is required to disambiguate',
+            },
+          },
+          { userId: 'pending-user-2', ok: true },
+        ],
+      },
+    })
+    expect(JSON.stringify(response.body)).not.toMatch(/secret|da-1/i)
+    // Threading: the parsed orgId reached the activation service verbatim, item by item.
+    expect(activateMocks.activatePendingUser).toHaveBeenNthCalledWith(1,
+      expect.objectContaining({ userId: 'pending-user-1', orgId: undefined }))
+    expect(activateMocks.activatePendingUser).toHaveBeenNthCalledWith(2,
+      expect.objectContaining({ userId: 'pending-user-2', orgId: 'org-b' }))
+    // #4833 audit surface: the successful item's audit row records WHICH org was chosen.
+    const activateAudit = auditMocks.auditLog.mock.calls
+      .map((call) => call[0])
+      .find((entry) => entry?.resourceId === 'pending-user-2')
+    expect(activateAudit?.meta).toMatchObject({ membershipOrgId: 'org-b' })
+  })
+
   // Closeout review P1: the bulk route inherits the derived-org rule through the SAME
   // activatePendingUser + mapActivateError pair as the single route — a steered orgId fails
   // per-item as a safe 409 while the rest of the batch proceeds.

--- a/packages/core-backend/tests/unit/user-activate.test.ts
+++ b/packages/core-backend/tests/unit/user-activate.test.ts
@@ -631,6 +631,62 @@ describe('activatePendingUser (T3)', () => {
     expect(membershipWrite?.[1]).toEqual(['u1', 'org-src'])
   })
 
+  // Empty-org sub-branch (verify-workflow finding: this fail-closed branch survived every
+  // mutation probe untested). An active source whose integration carries no org cannot anchor
+  // a membership write: alone it must refuse; alongside a real org it must simply not vote.
+  it('sole ACTIVE source with empty integration org: refuses ACTIVATE_SOURCE_INELIGIBLE, writing nothing', async () => {
+    pgMocks.query
+      .mockResolvedValueOnce({
+        rows: [{
+          id: 'u1',
+          email: 'a@x.com',
+          username: null,
+          mobile: null,
+          activation_status: 'pending_activation',
+          is_active: false,
+        }],
+      })
+      .mockResolvedValueOnce({ rows: [{ ...LINKED_ACTIVE_SOURCE, integration_org_id: '  ' }] })
+
+    await expect(
+      activatePendingUser({ userId: 'u1', mode: 'admin_no_password', orgId: 'org-src' }),
+    ).rejects.toMatchObject({ code: 'ACTIVATE_SOURCE_INELIGIBLE' })
+    expect(pgMocks.query.mock.calls.some((call) =>
+      String(call[0]).includes('UPDATE users'))).toBe(false)
+  })
+
+  it('empty-org ACTIVE source next to a real one: does not vote — the real org derives without ambiguity', async () => {
+    pgMocks.query
+      .mockResolvedValueOnce({
+        rows: [{
+          id: 'u1',
+          email: 'a@x.com',
+          username: null,
+          mobile: null,
+          activation_status: 'pending_activation',
+          is_active: false,
+        }],
+      })
+      .mockResolvedValueOnce({
+        rows: [
+          { ...LINKED_ACTIVE_SOURCE, id: 'da-1', integration_org_id: '' },
+          { ...LINKED_ACTIVE_SOURCE, id: 'da-2', integration_org_id: 'org-2' },
+        ],
+      })
+      .mockResolvedValueOnce({ rows: [{ id: 'u1' }] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ access_generation: 1 }] })
+
+    await expect(
+      activatePendingUser({ userId: 'u1', mode: 'admin_no_password' }),
+    ).resolves.toMatchObject({ activationStatus: 'activated', membershipOrgId: 'org-2' })
+    const membershipWrite = pgMocks.query.mock.calls.find((call) =>
+      String(call[0]).includes('INSERT INTO user_orgs'))
+    expect(membershipWrite?.[1]).toEqual(['u1', 'org-2'])
+  })
+
   // Dual-org: the person's ACTIVE source lives in org-2; a caller pointing at org-1 (their
   // other, inactive badge's org — or any org at all) must not be able to steer the membership.
   it('dual-org: derives the ACTIVE source org and refuses a caller steering to the other org', async () => {

--- a/packages/core-backend/tests/unit/user-activate.test.ts
+++ b/packages/core-backend/tests/unit/user-activate.test.ts
@@ -516,6 +516,121 @@ describe('activatePendingUser (T3)', () => {
     expect(membershipWrite?.[1]).toEqual(['u1', 'org-src'])
   })
 
+  // #4833 quartet: with several ACTIVE sources, "derive" has no unique answer — the caller's
+  // orgId is validated against the SET; naming none is a refusal, not a silent pick.
+  it('dual-ACTIVE different orgs + no orgId: refuses with ACTIVATE_ORG_AMBIGUOUS, writing nothing', async () => {
+    const dualActive = [
+      { ...LINKED_ACTIVE_SOURCE, id: 'da-1', integration_org_id: 'org-1' },
+      { ...LINKED_ACTIVE_SOURCE, id: 'da-2', integration_org_id: 'org-2' },
+    ]
+    pgMocks.query
+      .mockResolvedValueOnce({
+        rows: [{
+          id: 'u1',
+          email: 'a@x.com',
+          username: null,
+          mobile: null,
+          activation_status: 'pending_activation',
+          is_active: false,
+        }],
+      })
+      .mockResolvedValueOnce({ rows: dualActive })
+
+    await expect(
+      activatePendingUser({ userId: 'u1', mode: 'admin_no_password' }),
+    ).rejects.toMatchObject({ code: 'ACTIVATE_ORG_AMBIGUOUS' })
+    expect(pgMocks.query.mock.calls.some((call) =>
+      String(call[0]).includes('UPDATE users'))).toBe(false)
+  })
+
+  it('dual-ACTIVE different orgs + orgId naming the SECOND org: activates into exactly that org', async () => {
+    const dualActive = [
+      { ...LINKED_ACTIVE_SOURCE, id: 'da-1', integration_org_id: 'org-1' },
+      { ...LINKED_ACTIVE_SOURCE, id: 'da-2', integration_org_id: 'org-2' },
+    ]
+    pgMocks.query
+      .mockResolvedValueOnce({
+        rows: [{
+          id: 'u1',
+          email: 'a@x.com',
+          username: null,
+          mobile: null,
+          activation_status: 'pending_activation',
+          is_active: false,
+        }],
+      })
+      .mockResolvedValueOnce({ rows: dualActive })
+      .mockResolvedValueOnce({ rows: [{ id: 'u1' }] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ access_generation: 1 }] })
+
+    // Under the pre-#4833 find-first shape this legitimate request answered 409.
+    await expect(
+      activatePendingUser({ userId: 'u1', mode: 'admin_no_password', orgId: 'org-2' }),
+    ).resolves.toMatchObject({ activationStatus: 'activated' })
+    const membershipWrite = pgMocks.query.mock.calls.find((call) =>
+      String(call[0]).includes('INSERT INTO user_orgs'))
+    expect(membershipWrite?.[1]).toEqual(['u1', 'org-2'])
+  })
+
+  it('dual-ACTIVE different orgs + orgId outside the set: ACTIVATE_ORG_MISMATCH', async () => {
+    const dualActive = [
+      { ...LINKED_ACTIVE_SOURCE, id: 'da-1', integration_org_id: 'org-1' },
+      { ...LINKED_ACTIVE_SOURCE, id: 'da-2', integration_org_id: 'org-2' },
+    ]
+    pgMocks.query
+      .mockResolvedValueOnce({
+        rows: [{
+          id: 'u1',
+          email: 'a@x.com',
+          username: null,
+          mobile: null,
+          activation_status: 'pending_activation',
+          is_active: false,
+        }],
+      })
+      .mockResolvedValueOnce({ rows: dualActive })
+
+    await expect(
+      activatePendingUser({ userId: 'u1', mode: 'admin_no_password', orgId: 'org-3' }),
+    ).rejects.toMatchObject({ code: 'ACTIVATE_ORG_MISMATCH' })
+    expect(pgMocks.query.mock.calls.some((call) =>
+      String(call[0]).includes('UPDATE users'))).toBe(false)
+  })
+
+  it('dual-ACTIVE SAME org: no ambiguity — the set dedupes and the org derives', async () => {
+    const dualSameOrg = [
+      { ...LINKED_ACTIVE_SOURCE, id: 'da-1' },
+      { ...LINKED_ACTIVE_SOURCE, id: 'da-2' },
+    ]
+    pgMocks.query
+      .mockResolvedValueOnce({
+        rows: [{
+          id: 'u1',
+          email: 'a@x.com',
+          username: null,
+          mobile: null,
+          activation_status: 'pending_activation',
+          is_active: false,
+        }],
+      })
+      .mockResolvedValueOnce({ rows: dualSameOrg })
+      .mockResolvedValueOnce({ rows: [{ id: 'u1' }] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ access_generation: 1 }] })
+
+    await expect(
+      activatePendingUser({ userId: 'u1', mode: 'admin_no_password' }),
+    ).resolves.toMatchObject({ activationStatus: 'activated' })
+    const membershipWrite = pgMocks.query.mock.calls.find((call) =>
+      String(call[0]).includes('INSERT INTO user_orgs'))
+    expect(membershipWrite?.[1]).toEqual(['u1', 'org-src'])
+  })
+
   // Dual-org: the person's ACTIVE source lives in org-2; a caller pointing at org-1 (their
   // other, inactive badge's org — or any org at all) must not be able to steer the membership.
   it('dual-org: derives the ACTIVE source org and refuses a caller steering to the other org', async () => {


### PR DESCRIPTION
## What

Lands follow-up #4833 from the adversarial review of #4831 (its P2-2): when a pending user has ACTIVE directory sources in **more than one org**, "derive the membership org from the integration" had no unique answer — the helper silently took the first row of `ORDER BY da.id` (uuid, arbitrary), so:
- activation **without** an `orgId` wrote an arbitrary org's membership;
- a caller naming the **other**, equally-legitimate active org was refused 409.

`assertDirectorySourceActiveForActivate` now resolves against the **set** of active+eligible sources:
- caller `orgId` present → must be a member of the set (else `ACTIVATE_ORG_MISMATCH`; the mismatch check moved inside the helper — same file, closure test intact);
- no `orgId` + one distinct org (same-org multi-source dedupes) → derives as before;
- no `orgId` + several distinct orgs → **409 `ACTIVATE_ORG_AMBIGUOUS`** (new code: union + closed policy table + closure/mapping/HTTP-leak chains extended to 14).

Single-source behaviour is unchanged. (Reachability note, corrected per review: T3 activation currently has NO web-UI caller at all — `apps/web` has zero call sites for the activate routes or the DingTalk `intent=activate` chain; this is a pure API/ops surface today.)

## Verification

- **Unit quartet**: ambiguous refusal writes nothing / naming the second org activates exactly there / outside-set → mismatch / same-org dedupe derives.
- **Real-DB golden** (grant-table suite): two ACTIVE sources in two orgs; no-orgId refusal leaves zero residue (user still pending, no membership); then activation into whichever org is **NOT first by `da.id`** — deterministic kill for the find-first mutation instead of a uuid coin flip (verified red 3/3 under the mutation). `seedActivationSource` gains an `orgId` option; `external_key` made org-unique under the partial `UNIQUE(provider, corp_id, external_key)`.
- **Three mutation probes** run locally, each red at a named test, restored via cp: first-only match / silent-pick on ambiguity / dedupe removal.
- Full unit sweep **6670 green**; grant-table 18/18 + five neighbour real-DB suites (writer-ledger, access-graph-mutex, container-login, alias-writers, orchestration) **81 green**; `tsc --noEmit` green.

## Docs

Lock §0.7 and the completion MD's #4833 reference updated from "follow-up" to landed (values-free description of the rule).

## Constraints

Three lifecycle switches remain OFF; canary stays per-item ops GO; U1-U13 / Transfer T3-T5 remain separate gates. No migration in this PR.

Closes #4833

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014dQjSzR5ecniF1mRay4wEE

## 双重独立验证 (2026-08-10, both bound to code head 673165eb2e)

- **Opus adversarial review: APPROVE, 0 P1 / 0 P2** — 17-cell behaviour matrix run against a real DB (not reasoned): no cell writes membership to an org outside the person's active-eligible set, none refuses a legitimate one; the #4831 invariants still red 3 named tests when their guard is removed; single-source baseline identical to pre-PR cell-by-cell. Independently validated the golden's non-first-org construction (first-only mutation red 3/3).
- **Three-lens verify workflow + completeness critic** (contract / bypass / test-adequacy): converged on the same finding set.

All P3/NIT findings from both passes absorbed in commit 994d2b1d1d: empty-org guard test coverage (was a surviving mutation — now reds 2 named tests), bulk per-item `ACTIVATE_ORG_AMBIGUOUS` envelope + route orgId call-arg threading assertions, audit meta records the chosen `membershipOrgId` (forensic "who placed this user in org B"), HTTP leak chain drives all 14 authored reasons longhand, second mapper (`mapDingTalkActivationFailure`) gains both new codes, dead-store init + boundary trim + enum-doc precision, completion-MD verdict-paragraph provenance restored. Battery at the new head: tsc green, 6674 unit green, 40 real-DB green.
