### PR TITLE
fix(dingtalk): OAuth grant read fails CLOSED — deprovision deny row can't be bypassed by a query blip (review P1)

### DIFF
--- a/packages/core-backend/src/auth/dingtalk-oauth.ts
+++ b/packages/core-backend/src/auth/dingtalk-oauth.ts
@@ -739,8 +739,18 @@ async function findIdentityUser(dtUser: DingTalkUserInfo): Promise<LocalUserRow 
     )
     return result.rows[0] ?? null
   } catch (error) {
-    logger.warn('Failed to resolve DingTalk external identity', error instanceof Error ? error : undefined)
-    return null
+    // Fail CLOSED (post-merge review P2-2): the same collapse readGrantState fixes lived here
+    // too — a swallowed read error returned null, indistinguishable from "no linked identity",
+    // so a failed identity read let the login fall through to the email-link / auto-provision
+    // path as if the DingTalk person were unknown (defeating the deny row their real identity
+    // carries; the identity unique constraint stopped a full bypass, but it is a latent
+    // fail-open and mints stray grants). "No identity" is still a legitimate null (new user);
+    // only a read FAILURE now throws.
+    logger.warn('Failed to resolve DingTalk external identity; failing closed', error instanceof Error ? error : undefined)
+    throw createPolicyError(
+      'Unable to verify DingTalk login authorization; please retry',
+      { statusCode: 503, code: 'grant_state_unavailable' },
+    )
   }
 }
 

--- a/packages/core-backend/src/auth/dingtalk-oauth.ts
+++ b/packages/core-backend/src/auth/dingtalk-oauth.ts
@@ -456,21 +456,45 @@ function isValidStateRecord(record: StateRecord): boolean {
   return false
 }
 
-async function readGrantEnabled(localUserId: string): Promise<boolean | null> {
+/**
+ * Grant read state — TRI-STATE ON PURPOSE.
+ *
+ * The prior `boolean | null` shape collapsed three genuinely different states — `enabled`,
+ * explicitly `disabled`, and `absent` (no row) — into two, and its catch returned `null`, the
+ * SAME value as "no row". So a transient query failure was indistinguishable from "this user
+ * has no grant", and the deny gate below (`state === 'disabled'`) fell through: a deprovisioned
+ * user's Rev 4.4 explicit disabled row could be bypassed by a single failed read while
+ * DINGTALK_AUTH_REQUIRE_GRANT is off (its default). Post-merge review 2026-08-10 P1.
+ *
+ * A read failure now FAILS CLOSED (throws a policy error → login denied), because "we could not
+ * verify the grant" must never be treated as "the grant permits login". `absent` stays a
+ * distinct, allowed state: brand-new / auto-linked users legitimately have no row and must
+ * still log in under the default non-strict mode.
+ */
+type GrantReadState = 'enabled' | 'disabled' | 'absent'
+
+async function readGrantState(localUserId: string): Promise<GrantReadState> {
+  let result: { rows: Array<{ enabled: boolean }> }
   try {
-    const result = await query<{ enabled: boolean }>(
+    result = await query<{ enabled: boolean }>(
       `SELECT enabled
        FROM user_external_auth_grants
        WHERE provider = $1 AND local_user_id = $2
        LIMIT 1`,
       [PROVIDER, localUserId],
     )
-    if (result.rows.length === 0) return null
-    return result.rows[0]?.enabled === true
   } catch (error) {
-    logger.warn('Failed to read DingTalk auth grant; treating as optional', error instanceof Error ? error : undefined)
-    return null
+    logger.warn(
+      'Failed to read DingTalk auth grant; failing closed',
+      error instanceof Error ? error : undefined,
+    )
+    throw createPolicyError(
+      'Unable to verify DingTalk login authorization; please retry',
+      { statusCode: 503, code: 'grant_state_unavailable' },
+    )
   }
+  if (result.rows.length === 0) return 'absent'
+  return result.rows[0]?.enabled === true ? 'enabled' : 'disabled'
 }
 
 /**
@@ -859,15 +883,15 @@ async function resolveLocalUser(dtUser: DingTalkUserInfo): Promise<{ localUser: 
   const identityUser = await findIdentityUser(dtUser)
   if (identityUser) {
     assertLocalUserLoginAllowed(identityUser)
-    const grantEnabled = await readGrantEnabled(identityUser.id)
-    if (requireGrant && grantEnabled !== true) {
+    const grantState = await readGrantState(identityUser.id)
+    if (requireGrant && grantState !== 'enabled') {
       await enrichMissingOpenIdForRejectedLogin(identityUser.id, dtUser)
       throw createPolicyError('DingTalk login is not enabled for this user', {
         statusCode: 403,
         code: 'grant_required',
       })
     }
-    if (grantEnabled === false) {
+    if (grantState === 'disabled') {
       await enrichMissingOpenIdForRejectedLogin(identityUser.id, dtUser)
       throw createPolicyError(DINGTALK_LOGIN_DISABLED_ERROR, {
         statusCode: 403,
@@ -882,14 +906,14 @@ async function resolveLocalUser(dtUser: DingTalkUserInfo): Promise<{ localUser: 
     const emailUser = await findUserByEmail(dtUser.email)
     if (emailUser) {
       assertLocalUserLoginAllowed(emailUser)
-      const grantEnabled = await readGrantEnabled(emailUser.id)
-      if (requireGrant && grantEnabled !== true) {
+      const grantState = await readGrantState(emailUser.id)
+      if (requireGrant && grantState !== 'enabled') {
         throw createPolicyError('DingTalk login is not enabled for this user', {
           statusCode: 403,
           code: 'grant_required',
         })
       }
-      if (grantEnabled === false) {
+      if (grantState === 'disabled') {
         throw createPolicyError(DINGTALK_LOGIN_DISABLED_ERROR, {
           statusCode: 403,
           code: 'grant_disabled',

--- a/packages/core-backend/tests/unit/dingtalk-oauth-login-gates.test.ts
+++ b/packages/core-backend/tests/unit/dingtalk-oauth-login-gates.test.ts
@@ -293,9 +293,11 @@ describe('dingtalk oauth login gates', () => {
       statusCode: 503,
       code: 'grant_state_unavailable',
     })
-    // Fail-closed means nothing downstream ran: no grant creation, no identity upsert.
-    expect(pgMocks.query.mock.calls.some((call) =>
-      /INSERT INTO user_external_auth_grants/i.test(String(call[0])))).toBe(false)
+    // Fail-closed means nothing downstream ran. Grant/identity writes run on the TRANSACTION
+    // client, so assert against its capture (a pgMocks.query check would be vacuous — those
+    // INSERTs never touch pgMocks.query).
+    expect(defaultTransactionStatements.some((sql) =>
+      /INSERT INTO user_external_auth_grants/i.test(sql))).toBe(false)
     expect(defaultTransactionStatements.some((sql) =>
       /UPDATE user_external_identities|INSERT INTO user_external_identities/i.test(sql))).toBe(false)
   })
@@ -344,8 +346,69 @@ describe('dingtalk oauth login gates', () => {
       statusCode: 403,
       code: 'grant_disabled',
     })
-    expect(pgMocks.query.mock.calls.some((call) =>
-      /INSERT INTO user_external_auth_grants/i.test(String(call[0])))).toBe(false)
+    expect(defaultTransactionStatements.some((sql) =>
+      /INSERT INTO user_external_auth_grants/i.test(sql))).toBe(false)
+  })
+
+  // Post-merge review P2-1: the three tests above take the EMAIL-linked branch (query #1 =
+  // findIdentityUser miss). The IDENTITY-direct path has its OWN readGrantState gates — and the
+  // deprovision SWEEP writes the deny row while touching no identity rows, so a swept user's
+  // next login hits exactly this path. Neutering the identity deny/read gates left all tests
+  // green until these. Also P2-2: findIdentityUser itself now fails closed on a read error.
+  const IDENTITY_USER = {
+    id: 'user-1',
+    email: 'alpha@example.com',
+    name: 'Alpha',
+    role: 'user',
+    is_active: true,
+    activation_status: 'activated',
+  }
+
+  it('identity-direct path: a DISABLED grant denies login (grant_disabled) even with requireGrant OFF', async () => {
+    // No-op transaction client so the rejected-login openId enrichment is harmless here.
+    pgMocks.transaction.mockImplementation(
+      async (callback: (client: { query: typeof pgMocks.query }) => Promise<unknown>) =>
+        callback({ query: (async () => ({ rows: [] })) as unknown as typeof pgMocks.query }),
+    )
+    pgMocks.query
+      .mockResolvedValueOnce({ rows: [IDENTITY_USER] }) // findIdentityUser: HIT
+      .mockResolvedValueOnce({ rows: [{ enabled: false }] }) // readGrantState → disabled
+
+    await expect(exchangeCodeForUser('code-identity-disabled')).rejects.toMatchObject({
+      name: 'DingTalkLoginPolicyError',
+      statusCode: 403,
+      code: 'grant_disabled',
+    })
+  })
+
+  it('identity-direct path: a grant read failure fails CLOSED (grant_state_unavailable)', async () => {
+    pgMocks.query
+      .mockResolvedValueOnce({ rows: [IDENTITY_USER] }) // findIdentityUser: HIT
+      .mockRejectedValueOnce(new Error('terminating connection due to administrator command'))
+
+    await expect(exchangeCodeForUser('code-identity-read-fails')).rejects.toMatchObject({
+      name: 'DingTalkLoginPolicyError',
+      statusCode: 503,
+      code: 'grant_state_unavailable',
+    })
+    expect(defaultTransactionStatements.some((sql) =>
+      /INSERT INTO user_external_auth_grants|user_external_identities/i.test(sql))).toBe(false)
+  })
+
+  it('findIdentityUser fails CLOSED on a read error — no fall-through to email/provision (P2-2)', async () => {
+    vi.stubEnv('DINGTALK_AUTH_AUTO_LINK_EMAIL', '1')
+    vi.stubEnv('DINGTALK_AUTH_AUTO_PROVISION', '1')
+    vi.stubEnv('DINGTALK_ALLOWED_CORP_IDS', 'ding-corp')
+    pgMocks.query.mockRejectedValueOnce(new Error('terminating connection due to administrator command')) // findIdentityUser blows up
+
+    await expect(exchangeCodeForUser('code-identity-lookup-fails')).rejects.toMatchObject({
+      name: 'DingTalkLoginPolicyError',
+      statusCode: 503,
+      code: 'grant_state_unavailable',
+    })
+    // Fail-closed: the login did NOT fall through to auto-provision a fresh account.
+    expect(defaultTransactionStatements.some((sql) =>
+      /INSERT INTO users\b/i.test(sql))).toBe(false)
   })
 
   it('allows email-linked login when strict grant mode is enabled and grant is present', async () => {

--- a/packages/core-backend/tests/unit/dingtalk-oauth-login-gates.test.ts
+++ b/packages/core-backend/tests/unit/dingtalk-oauth-login-gates.test.ts
@@ -267,6 +267,87 @@ describe('dingtalk oauth login gates', () => {
     expect(txCalls.some(call => call.sql.includes('UPDATE user_external_identities'))).toBe(false)
   })
 
+  // Post-merge review 2026-08-10 P1: readGrantEnabled caught any DB error and returned null,
+  // which is the SAME value as "no grant row"; the deny gate is `=== disabled`, so null slipped
+  // through and (with DINGTALK_AUTH_REQUIRE_GRANT off — its default) a deprovisioned user with
+  // an explicit disabled deny row would log in on a transient read failure. The read now fails
+  // CLOSED. These three lock the tri-state: error → deny; absent → allow; disabled → deny.
+  it('FAILS CLOSED when the grant read errors — a deprovision deny row cannot be bypassed by a query blip', async () => {
+    vi.stubEnv('DINGTALK_AUTH_AUTO_LINK_EMAIL', '1') // requireGrant defaults OFF — the vulnerable config
+    pgMocks.query
+      .mockResolvedValueOnce({ rows: [] }) // findIdentityUser: none
+      .mockResolvedValueOnce({
+        rows: [{
+          id: 'user-1',
+          email: 'alpha@example.com',
+          name: 'Alpha',
+          role: 'user',
+          is_active: true,
+          activation_status: 'activated',
+        }],
+      }) // findUserByEmail
+      .mockRejectedValueOnce(new Error('terminating connection due to administrator command')) // grant read blows up
+
+    await expect(exchangeCodeForUser('code-grant-read-fails')).rejects.toMatchObject({
+      name: 'DingTalkLoginPolicyError',
+      statusCode: 503,
+      code: 'grant_state_unavailable',
+    })
+    // Fail-closed means nothing downstream ran: no grant creation, no identity upsert.
+    expect(pgMocks.query.mock.calls.some((call) =>
+      /INSERT INTO user_external_auth_grants/i.test(String(call[0])))).toBe(false)
+    expect(defaultTransactionStatements.some((sql) =>
+      /UPDATE user_external_identities|INSERT INTO user_external_identities/i.test(sql))).toBe(false)
+  })
+
+  it('POSITIVE CONTROL: an ABSENT grant (no row) still logs in under the default non-strict mode', async () => {
+    vi.stubEnv('DINGTALK_AUTH_AUTO_LINK_EMAIL', '1') // requireGrant defaults OFF
+    pgMocks.query
+      .mockResolvedValueOnce({ rows: [] }) // findIdentityUser: none
+      .mockResolvedValueOnce({
+        rows: [{
+          id: 'user-1',
+          email: 'alpha@example.com',
+          name: 'Alpha',
+          role: 'user',
+          is_active: true,
+          activation_status: 'activated',
+        }],
+      }) // findUserByEmail
+      .mockResolvedValueOnce({ rows: [] }) // grant read → ABSENT (must NOT be treated as denial)
+
+    const result = await exchangeCodeForUser('code-grant-absent')
+    expect(result).toMatchObject({ localUserId: 'user-1', isNewUser: false })
+    // Absent under non-strict mode auto-grants (ensureGrant runs in the transaction).
+    expect(defaultTransactionStatements.some((sql) =>
+      /INSERT INTO user_external_auth_grants/i.test(sql))).toBe(true)
+  })
+
+  it('a DISABLED grant row still denies login with grant_disabled (Rev 4.4 deny gate intact)', async () => {
+    vi.stubEnv('DINGTALK_AUTH_AUTO_LINK_EMAIL', '1') // requireGrant defaults OFF — deny must fire anyway
+    pgMocks.query
+      .mockResolvedValueOnce({ rows: [] }) // findIdentityUser: none
+      .mockResolvedValueOnce({
+        rows: [{
+          id: 'user-1',
+          email: 'alpha@example.com',
+          name: 'Alpha',
+          role: 'user',
+          is_active: true,
+          activation_status: 'activated',
+        }],
+      }) // findUserByEmail
+      .mockResolvedValueOnce({ rows: [{ enabled: false }] }) // grant read → DISABLED deny row
+
+    await expect(exchangeCodeForUser('code-grant-disabled')).rejects.toMatchObject({
+      name: 'DingTalkLoginPolicyError',
+      statusCode: 403,
+      code: 'grant_disabled',
+    })
+    expect(pgMocks.query.mock.calls.some((call) =>
+      /INSERT INTO user_external_auth_grants/i.test(String(call[0])))).toBe(false)
+  })
+
   it('allows email-linked login when strict grant mode is enabled and grant is present', async () => {
     vi.stubEnv('DINGTALK_AUTH_REQUIRE_GRANT', '1')
     vi.stubEnv('DINGTALK_AUTH_AUTO_LINK_EMAIL', '1')

--- a/packages/core-backend/tests/unit/dingtalk-oauth-login-gates.test.ts
+++ b/packages/core-backend/tests/unit/dingtalk-oauth-login-gates.test.ts
@@ -406,9 +406,10 @@ describe('dingtalk oauth login gates', () => {
       statusCode: 503,
       code: 'grant_state_unavailable',
     })
-    // Fail-closed: the login did NOT fall through to auto-provision a fresh account.
-    expect(defaultTransactionStatements.some((sql) =>
-      /INSERT INTO users\b/i.test(sql))).toBe(false)
+    // Fail-closed and DISCRIMINATING (review NIT): exactly ONE query ran — findIdentityUser —
+    // and it threw. Under the fail-open mutation control reaches findUserByEmail (a 2nd query),
+    // so this call-count is what actually proves no fall-through to email-link/auto-provision.
+    expect(pgMocks.query).toHaveBeenCalledTimes(1)
   })
 
   it('allows email-linked login when strict grant mode is enabled and grant is present', async () => {


### PR DESCRIPTION
Post-merge review P1: readGrantEnabled caught any DB error and returned null (same as "no row"); the deny gate is `=== false`, so null slipped through and a deprovisioned user's Rev 4.4 disabled deny row was bypassable by one failed read (DINGTALK_AUTH_REQUIRE_GRANT defaults off). Fix: tri-state 'enabled'|'disabled'|'absent'; a read failure now fails CLOSED (grant_state_unavailable/503). Absent stays allowed so new/auto-linked users still log in. Tests: fail-closed on rejecting read; positive control (absent still logs in); disabled still denies; mutation reverting the catch reddens the fail-closed test. 6791 unit green, tsc green. One of two narrow fixes from the 2026-08-10 review (main=d78b27d37c); switches remain OFF.

https://claude.ai/code/session_014dQjSzR5ecniF1mRay4wEE
