### PR TITLE
fix(dingtalk): T3 activation source read locks against integration deactivation (FOR SHARE) — review P1

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -100,6 +100,7 @@ jobs:
         run: |
           node --test scripts/ops/dingtalk-closeout-env-contract.test.mjs
           node --test scripts/ops/directory-grant-table-ci-wiring.test.mjs
+          node --test scripts/ops/directory-activation-source-lock-ci-wiring.test.mjs
           node --test scripts/ops/directory-deprovision-ledger-ci-wiring.test.mjs
           node --test scripts/ops/directory-deprovision-writer-ci-wiring.test.mjs
           node --test scripts/ops/directory-access-graph-mutex-ci-wiring.test.mjs

--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -244,6 +244,13 @@ jobs:
       - name: Directory deprovision ledger CI-wiring contract (required lane)
         run: node --test scripts/ops/directory-deprovision-ledger-ci-wiring.test.mjs
 
+      # Same promotion (post-merge review of #4846, P2): the activation-source-lock wiring
+      # contract's original home is the k3wise-offline-poc job, whose check cannot block a merge,
+      # so de-listing the suite + repinning would pass all 9 required checks while the real-DB
+      # golden silently stops running. Invoked here in the required test lane so it actually gates.
+      - name: Directory activation source-lock CI-wiring contract (required lane)
+        run: node --test scripts/ops/directory-activation-source-lock-ci-wiring.test.mjs
+
       # Integration Guard required-wiring contract (governance slice, standalone from #4603/#4604/
       # #4610 by owner instruction; hardened 2026-07-25 after a P1x2/P2 review — see the workflow's own
       # header for the corrected rationale). Mixed YAML-shape + BEHAVIOURAL contract that makes

--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -1111,6 +1111,7 @@ jobs:
             tests/integration/directory-sync-alert-coverage.db.test.ts \
             tests/integration/directory-deprovision-selection.db.test.ts \
             tests/integration/directory-deprovision-grant-table.db.test.ts \
+            tests/integration/directory-activation-source-lock.db.test.ts \
             tests/integration/login-alias-writers.db.test.ts \
             tests/integration/directory-deprovision-ledger-schema.db.test.ts \
             tests/integration/directory-deprovision-writer-ledger.db.test.ts \

--- a/docs/development/dingtalk-lifecycle-line-completion-and-verification-20260808.md
+++ b/docs/development/dingtalk-lifecycle-line-completion-and-verification-20260808.md
@@ -1,6 +1,6 @@
 # 钉钉生命周期线 — 收尾开发与验证 MD（2026-08-08）
 
-- Status: **代码侧收尾完成（Rev 4.4 修复轮后恢复）** — closeout 复审（2026-08-08，对 main=45cf3a7c51）曾裁 **CHANGES REQUESTED**（2 P1 + 1 P2，见 §4bis），按其收尾顺序本状态一度改回 CHANGES_REQUIRED；修复 PR（T3 源权威 + OPS-01 可逆证据 Rev 4.4）与本状态行原子落地。启用/canary/U1-13/Transfer 仍 owner/ops-gated；三开关 OFF。
+- Status: **代码侧收尾进行中（第二轮 post-merge 复审吸收）** — 2026-08-08 复审（对 main=45cf3a7c51）裁 CHANGES REQUESTED（见 §4bis，已修复合入）；**2026-08-10 又一轮 post-merge 复审（对 main=d78b27d37c）再裁 CHANGES REQUIRED：2 个新 P1（OAuth grant 读 fail-open、T3 激活源 integration-status TOCTOU）+ 重申 owner-gated 的 supersede 补偿（§4 第 3 项），见 §4ter**。两 P1 分别由 #4845 与本 PR 修复。**撤回**：此前「可编码项正式清零」为过强声明——它只在这两张修复 PR 落地后成立，且始终**不含** owner 尚未裁决的 supersede 补偿（该裁决本身可能要求代码）。启用/canary/U1-13/Transfer 仍 owner/ops-gated；三开关 OFF。
 - 授权链：owner 2026-08-07/08 会话「钉钉同步业务功能开发-260721」指令 —— 「请排序并完成所有这条线剩余的开发，然后给出设计及验证 MD」，采纳含「显式批准 Rev 4.3」为第 1 步的收尾意见；模型分配按既有 model-split（Sonnet=机械/侦察、Fable=主循环+热文件语义、Opus=对抗门审）。
 - 权威锁：`dingtalk-deprovision-reactivation-and-evidence-chain-design-20260723.md`（Rev 4.3，ratification 记录见其 §0.6，**终版随本 MD 提请 owner 会签**）+ companion admission 锁 Rev 4.2。
 - 前情：`dingtalk-lifecycle-postmerge-findings-20260724.md`（07-24 实测「离岗零证据」P1 的完整证据链）与 honest closeout（#4587 修正版）。
@@ -68,6 +68,18 @@ Mutation 六连杀（每条先证锚点命中、后证目标测试转红、cp �
 **独立对抗审 verdict（Opus，2026-08-09，绑 head 467ae34b57）**：**APPROVE-with-hardening，0 P1** —— 三条 refute-first 目标（T3 绕过 / writer 非 1:1 / restore drift）构造攻击后均未证伪；六条 mutation 独立复现全转红；immutability 函数与 20260728 版程序化逐行比对一列未丢；迁移在全新 DB 干净跑通且不在 9 处 MIGRATION_EXCLUDE。两条 P2 已落账：①**可逆性边界**——supersede（如管理员重新启用）后 restore 按既有门拒绝（`EVENT_NOT_APPLIED`），deny 行成无证据残留：锁文 §0.7 已按此限定措辞（main 既有语义，非本 PR 引入），补偿路径列入 §4 owner 清单第 3 项；②**双 ACTIVE 源 org 派生歧义**（今日无 web 调用点可达）→ follow-up #4833。层级事实：mutation (d)（writer INSERT）只有真库 golden 能杀（6666 unit 全绿）；mutation (f)（源门控回退）只有 unit 层能杀（grant-table 真库 17/17 仍绿）——两层缺一不可。
 
 **#4833 落地记录（2026-08-10，PR #4843 — 本段不属于上面绑定 467ae34b57 的 verdict）**：org 派生改为对 active eligible 源**集合**匹配；无 orgId 且集合含多个不同 org → 409 `ACTIVATE_ORG_AMBIGUOUS`（错误闭集 14，HTTP leak 链全 14 驱动）；同 org 多源去重照常派生；空 org 源不参与投票（单独 fail-closed 测试）；审计 meta 记录实际落位 org（`membershipOrgId`）。双 org 真库金标故意选非 `da.id` 首行的 org，使 find-first 变异确定性转红（3/3），避免 uuid 排序掷硬币。
+
+## 4ter. 第二轮 post-merge 复审吸收（2026-08-10，对 main=d78b27d37c，CHANGES REQUIRED → 修复）
+
+独立复审（Grok 4.5 只读复核 + 源码判定）对 11 车 + #4831 + #4843 全落地态再审，确认 Rev 4.4 正常 writer/restore 链、T3 源权威、双 ACTIVE 消歧成立，但发现两个 P1 + 重申一个 P2：
+
+| 判项 | 内容 | 修复 |
+|---|---|---|
+| **P1-A（OAuth grant 读 fail-open）** | `readGrantEnabled` 捕获任意 DB 错误返回 `null`（与「无 grant 行」同值）；deny 门是 `=== false`，`null` 滑过；`DINGTALK_AUTH_REQUIRE_GRANT` 默认 false ⇒ 离岗者的 Rev 4.4 disabled deny 行可被一次读故障绕过登录 | **#4845**：改三态 `enabled`/`disabled`/`absent`，读失败 **fail-closed**（抛 `grant_state_unavailable`/503，与 `grant_disabled` 同 deny 通道）；`absent` 仍放行（新用户/自动关联）。测试：读故障 fail-closed、absent 正控放行、disabled 仍拒；变异复原 fail-open 转红 |
+| **P1-B（T3 激活源 integration-status TOCTOU）** | 激活事务只锁 `users`，源（account/link/integration）无锁读；READ COMMITTED 下管理员可在另一连接停用 integration 并提交于「读→提交」窗口间 ⇒ 对 inactive 源静默激活 | **本 PR**：源读加 `FOR SHARE OF ...`（两分支，integration 恒 INNER-join 故两分支皆锁）；载重不变量注释（status 在 TS 判非 WHERE，使 EPQ recheck 见新 inactive）；构造并发真库金标（pg_locks 屏障证激活阻塞于停用事务、提交后拒 `ACTIVATE_INTEGRATION_INACTIVE`、零写），mutation 去 `di` 锁确定性转红 |
+| **P2（supersede 残留补偿）** | 与 §4 第 3 项同——非新缺陷，owner-gated | 不改代码；待 owner 裁决（可能要求代码或运维合同）|
+
+两张修复均为窄 PR、独立对抗审 + exact-head CI；三开关继续 OFF；canary 逐项仍 NO-GO 待前述落地后再议。
 
 ## 5. 过程事故诚实档（含撤回）
 

--- a/packages/core-backend/src/auth/user-activate.ts
+++ b/packages/core-backend/src/auth/user-activate.ts
@@ -322,16 +322,24 @@ async function assertDirectorySourceActiveForActivate(
   // so we can distinguish SOURCE_MISSING account-not-found from LINK_MISMATCH).
   // Implicit: start from links with exact link_status='linked' (no COALESCE default).
   //
-  // FOR SHARE (post-merge review P1, 2026-08-10): the activation transaction locks `users` but
-  // read this source unlocked, so under READ COMMITTED an admin could deactivate the
+  // FOR SHARE OF di (post-merge review P1, 2026-08-10): the activation transaction locks
+  // `users` but read this source unlocked, so under READ COMMITTED an admin could deactivate the
   // integration on another connection and COMMIT between this read and the activation's own
   // commit — activating a user against a now-inactive source ("admin 激活不得对 inactive 目录源
-  // 静默开通"). FOR SHARE on the integration (and account/link) rows serialises against that
-  // deactivation: it either blocks the admin's UPDATE until activation commits, or — if the
-  // deactivation already committed — the shared-lock EPQ recheck refetches the latest row so
-  // the status test below sees the fresh 'inactive'. In the explicit branch the link is on the
-  // nullable side of the LEFT JOIN and cannot be locked; the integration (the row this review
-  // named) is INNER-joined in both branches and is locked in both.
+  // 静默开通"). FOR SHARE on the integration row serialises against that deactivation: it either
+  // blocks the admin's UPDATE until activation commits, or — if the deactivation already
+  // committed — the shared-lock EPQ recheck refetches the latest row so the status test below
+  // sees the fresh 'inactive'.
+  //
+  // ONLY `di` is locked, deliberately. The account/link rows need no lock HERE: every writer
+  // that changes them first takes `lockUsersForAccessGraphWrite` on this same user (directory
+  // sync, deprovision, OAuth bind), and the activation already holds that users lock — so those
+  // races are already serialised. Integration `status` is the sole field with no per-user cover
+  // (an admin deactivating an integration takes no user lock), which is exactly what this fix
+  // closes. Locking da/l too would be untested, redundant scope and needless deadlock surface.
+  //
+  // LOCK ORDER: users FIRST (above), THEN this integration FOR SHARE. Every writer that touches
+  // both must keep that order; no production writer takes them in reverse (verified 2026-08-10).
   //
   // LOAD-BEARING INVARIANT: integration `status` is checked in TypeScript below, NOT in this
   // WHERE. That placement is what makes the FOR SHARE recheck useful — under READ COMMITTED,
@@ -350,7 +358,7 @@ async function assertDirectorySourceActiveForActivate(
          JOIN directory_integrations di ON di.id = da.integration_id
          LEFT JOIN directory_account_links l ON l.directory_account_id = da.id
         WHERE da.id = $1
-          FOR SHARE OF da, di`
+          FOR SHARE OF di`
     : `SELECT da.id, da.is_active AS account_active, di.status AS integration_status,
               l.local_user_id, l.link_status,
               da.provider AS account_provider, di.provider AS integration_provider,
@@ -363,7 +371,7 @@ async function assertDirectorySourceActiveForActivate(
         WHERE l.local_user_id = $1
           AND l.link_status = 'linked'
         ORDER BY da.id
-          FOR SHARE OF l, da, di`
+          FOR SHARE OF di`
 
   const params = options.directoryAccountId
     ? [options.directoryAccountId]

--- a/packages/core-backend/src/auth/user-activate.ts
+++ b/packages/core-backend/src/auth/user-activate.ts
@@ -331,12 +331,20 @@ async function assertDirectorySourceActiveForActivate(
   // committed — the shared-lock EPQ recheck refetches the latest row so the status test below
   // sees the fresh 'inactive'.
   //
-  // ONLY `di` is locked, deliberately. The account/link rows need no lock HERE: every writer
-  // that changes them first takes `lockUsersForAccessGraphWrite` on this same user (directory
-  // sync, deprovision, OAuth bind), and the activation already holds that users lock — so those
-  // races are already serialised. Integration `status` is the sole field with no per-user cover
-  // (an admin deactivating an integration takes no user lock), which is exactly what this fix
-  // closes. Locking da/l too would be untested, redundant scope and needless deadlock surface.
+  // ONLY `di` is locked, deliberately. The account/link rows (`da.is_active`, `l.link_status`)
+  // need no lock HERE: every production writer of those columns on a linked row first takes
+  // `lockUsersForAccessGraphWrite` on this same user, which the activation already holds across
+  // read→commit — so those races are already serialised. The writers, audited 2026-08-10:
+  //   - directory sync sweep — backstopped by the link-table-driven recheck-throw at
+  //     directory-sync.ts:3341-3358 (aborts if the link changed under it);
+  //   - manual (un)bind — directory-sync.ts:6688 locks both the target and the prior holder;
+  //   - local provider create/archive — local-directory-org.ts:477 / :635.
+  // (Deprovision and OAuth bind do NOT write these columns — they were named in error in an
+  // earlier draft of this comment.) Integration `status` is the sole field with no per-user
+  // cover — an admin deactivating an integration takes no user lock — which is exactly what this
+  // FOR SHARE closes. A positive control pins the account-path mitigation:
+  // directory-activation-source-lock.db.test.ts asserts a users-lock-holding account
+  // deactivation makes this activation block on the users lock and refuse.
   //
   // LOCK ORDER: users FIRST (above), THEN this integration FOR SHARE. Every writer that touches
   // both must keep that order; no production writer takes them in reverse (verified 2026-08-10).

--- a/packages/core-backend/src/auth/user-activate.ts
+++ b/packages/core-backend/src/auth/user-activate.ts
@@ -321,6 +321,24 @@ async function assertDirectorySourceActiveForActivate(
   // Explicit id: account row + link fail-closed (INNER semantics enforced in TS after LEFT JOIN
   // so we can distinguish SOURCE_MISSING account-not-found from LINK_MISMATCH).
   // Implicit: start from links with exact link_status='linked' (no COALESCE default).
+  //
+  // FOR SHARE (post-merge review P1, 2026-08-10): the activation transaction locks `users` but
+  // read this source unlocked, so under READ COMMITTED an admin could deactivate the
+  // integration on another connection and COMMIT between this read and the activation's own
+  // commit — activating a user against a now-inactive source ("admin 激活不得对 inactive 目录源
+  // 静默开通"). FOR SHARE on the integration (and account/link) rows serialises against that
+  // deactivation: it either blocks the admin's UPDATE until activation commits, or — if the
+  // deactivation already committed — the shared-lock EPQ recheck refetches the latest row so
+  // the status test below sees the fresh 'inactive'. In the explicit branch the link is on the
+  // nullable side of the LEFT JOIN and cannot be locked; the integration (the row this review
+  // named) is INNER-joined in both branches and is locked in both.
+  //
+  // LOAD-BEARING INVARIANT: integration `status` is checked in TypeScript below, NOT in this
+  // WHERE. That placement is what makes the FOR SHARE recheck useful — under READ COMMITTED,
+  // EPQ refetches the concurrently-updated row and the TS check sees the new status and
+  // refuses. Pushing `AND di.status = 'active'` into the SQL would make EPQ DROP the row
+  // instead, turning ACTIVATE_INTEGRATION_INACTIVE into ACTIVATE_SOURCE_MISSING (or worse).
+  // Do not move the status predicate into the WHERE clause.
   const sql = options.directoryAccountId
     ? `SELECT da.id, da.is_active AS account_active, di.status AS integration_status,
               l.local_user_id, l.link_status,
@@ -331,7 +349,8 @@ async function assertDirectorySourceActiveForActivate(
          FROM directory_accounts da
          JOIN directory_integrations di ON di.id = da.integration_id
          LEFT JOIN directory_account_links l ON l.directory_account_id = da.id
-        WHERE da.id = $1`
+        WHERE da.id = $1
+          FOR SHARE OF da, di`
     : `SELECT da.id, da.is_active AS account_active, di.status AS integration_status,
               l.local_user_id, l.link_status,
               da.provider AS account_provider, di.provider AS integration_provider,
@@ -343,7 +362,8 @@ async function assertDirectorySourceActiveForActivate(
          JOIN directory_integrations di ON di.id = da.integration_id
         WHERE l.local_user_id = $1
           AND l.link_status = 'linked'
-        ORDER BY da.id`
+        ORDER BY da.id
+          FOR SHARE OF l, da, di`
 
   const params = options.directoryAccountId
     ? [options.directoryAccountId]

--- a/packages/core-backend/tests/integration/directory-activation-source-lock.db.test.ts
+++ b/packages/core-backend/tests/integration/directory-activation-source-lock.db.test.ts
@@ -200,4 +200,79 @@ describeIfDatabase('T3 activation source read serialises against integration dea
   it('EXPLICIT branch (directoryAccountId — the OAuth SSO activation path): blocks and refuses too', async () => {
     await proveRaceRefuses(true)
   }, 30_000)
+
+  // SAFE-path positive control (delta review P3-2): the fix locks ONLY the integration row,
+  // relying on the pre-existing users lock to serialise ACCOUNT/LINK races. This pins that
+  // premise: a writer holding this user's users lock while deactivating the account makes the
+  // activation block ON THE USERS LOCK and then refuse — so account deactivation cannot slip
+  // through unserialised despite the source read not locking `da`. If a future change dropped
+  // the users lock, the activation would read the stale-active account and this test reds.
+  it('an account deactivation under the users lock serialises the activation, which then refuses', async () => {
+    const seeded = await seed()
+    const holder = new pg.Client({ connectionString: process.env.DATABASE_URL })
+    await holder.connect()
+    let activation: Promise<unknown> | null = null
+    try {
+      await holder.query('BEGIN')
+      // Hold this user's access-graph lock, exactly as every real account/link writer does...
+      await holder.query(`SELECT id FROM users WHERE id = $1 FOR UPDATE`, [seeded.userId])
+      // ...then deactivate the account within that same locked transaction.
+      await holder.query(
+        `UPDATE directory_accounts SET is_active = FALSE WHERE id = $1::uuid`,
+        [seeded.accountId],
+      )
+      const holderPid = Number((await holder.query('SELECT pg_backend_pid() AS pid')).rows[0]?.pid)
+      const holderXid = String(
+        (
+          await holder.query(
+            `SELECT transactionid::text AS xid
+               FROM pg_locks
+              WHERE pid = $1 AND locktype = 'transactionid' AND granted
+              LIMIT 1`,
+            [holderPid],
+          )
+        ).rows[0]?.xid,
+      )
+
+      activation = activatePendingUser({
+        userId: seeded.userId,
+        mode: 'admin_no_password',
+        adminUserId: 'admin-test',
+      })
+      const settledEarly = { done: false }
+      activation.then(() => { settledEarly.done = true }, () => { settledEarly.done = true })
+
+      // The activation blocks on the USERS lock (its very first statement), waiting on the
+      // holder's transaction — proving the account race is serialised there, not at `da`.
+      let blockedPid = 0
+      for (let attempt = 0; attempt < 100 && blockedPid === 0; attempt += 1) {
+        const waiting = await holder.query(
+          `SELECT blocked.pid AS pid
+             FROM pg_locks blocked
+            WHERE NOT blocked.granted
+              AND blocked.locktype = 'transactionid'
+              AND blocked.transactionid::text = $1
+              AND blocked.pid <> $2
+            LIMIT 1`,
+          [holderXid, holderPid],
+        )
+        blockedPid = Number(waiting.rows[0]?.pid ?? 0)
+        if (blockedPid === 0) await new Promise((resolve) => setTimeout(resolve, 50))
+      }
+      expect(blockedPid).toBeGreaterThan(0)
+      expect(settledEarly.done).toBe(false)
+
+      await holder.query('COMMIT') // account now inactive; users lock released
+      // The activation proceeds, reads the committed-inactive account, and refuses.
+      await expect(activation).rejects.toMatchObject({ code: 'ACTIVATE_SOURCE_INACTIVE' })
+      activation = null
+    } finally {
+      try { await holder.query('ROLLBACK') } catch { /* already committed */ }
+      await holder.end()
+      if (activation) { await activation.catch(() => undefined) }
+    }
+    const user = await query<{ activation_status: string }>(
+      `SELECT activation_status FROM users WHERE id = $1`, [seeded.userId])
+    expect(user.rows[0]?.activation_status).toBe('pending_activation')
+  }, 30_000)
 })

--- a/packages/core-backend/tests/integration/directory-activation-source-lock.db.test.ts
+++ b/packages/core-backend/tests/integration/directory-activation-source-lock.db.test.ts
@@ -95,7 +95,11 @@ describeIfDatabase('T3 activation source read serialises against integration dea
   beforeEach(cleanup)
   afterAll(cleanup)
 
-  it('blocks on a concurrent integration deactivation and refuses once it commits (writing nothing)', async () => {
+  // Both branches of the source read must serialise. The IMPLICIT branch (no directoryAccountId,
+  // links-by-user) and the EXPLICIT branch (directoryAccountId, the path the production DingTalk
+  // OAuth SSO activation at routes/auth.ts takes — resolveDingTalkActivationSource passes an
+  // explicit account id) compile to different SQL, so a fix to one is not a fix to the other.
+  async function proveRaceRefuses(useExplicitAccount: boolean): Promise<void> {
     const seeded = await seed()
 
     const holder = new pg.Client({ connectionString: process.env.DATABASE_URL })
@@ -130,6 +134,7 @@ describeIfDatabase('T3 activation source read serialises against integration dea
         userId: seeded.userId,
         mode: 'admin_no_password',
         adminUserId: 'admin-test',
+        ...(useExplicitAccount ? { directoryAccountId: seeded.accountId } : {}),
       })
       const settledEarly = { done: false }
       activation.then(
@@ -186,5 +191,13 @@ describeIfDatabase('T3 activation source read serialises against integration dea
     expect(user.rows[0]).toEqual({ activation_status: 'pending_activation', is_active: false })
     const membership = await query(`SELECT 1 FROM user_orgs WHERE user_id = $1`, [seeded.userId])
     expect(membership.rows).toHaveLength(0)
+  }
+
+  it('IMPLICIT branch (no directoryAccountId): blocks on the deactivation and refuses once it commits', async () => {
+    await proveRaceRefuses(false)
+  }, 30_000)
+
+  it('EXPLICIT branch (directoryAccountId — the OAuth SSO activation path): blocks and refuses too', async () => {
+    await proveRaceRefuses(true)
   }, 30_000)
 })

--- a/packages/core-backend/tests/integration/directory-activation-source-lock.db.test.ts
+++ b/packages/core-backend/tests/integration/directory-activation-source-lock.db.test.ts
@@ -1,0 +1,190 @@
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { randomUUID } from 'node:crypto'
+import pg from 'pg'
+import { afterAll, beforeEach, describe, expect, it } from 'vitest'
+import { query } from '../../src/db/pg'
+import { activatePendingUser } from '../../src/auth/user-activate'
+
+// Two-point wiring self-check (feedback: an unwired *.db.test.ts skip-greens forever). This
+// suite must be BOTH excluded from the no-DB job (so it cannot skip-green there) AND listed in
+// the approval real-DB run list (so it actually executes). If either point is dropped, this
+// runs — and reds — in the real-DB job.
+describe('directory-activation-source-lock wiring', () => {
+  const filename = 'tests/integration/directory-activation-source-lock.db.test.ts'
+  const repoRoot = path.resolve(__dirname, '../../../..')
+  it('is excluded from the no-DB job and wired into the approval real-DB step', () => {
+    const vitestConfig = readFileSync(
+      path.join(repoRoot, 'packages/core-backend/vitest.config.ts'),
+      'utf8',
+    )
+    const workflow = readFileSync(path.join(repoRoot, '.github/workflows/plugin-tests.yml'), 'utf8')
+    expect(vitestConfig).toContain(filename)
+    expect(workflow).toContain(filename)
+  })
+})
+
+/**
+ * Post-merge review P1 (2026-08-10): T3 activation locks `users` but read the directory source
+ * (account/link/integration) UNLOCKED. Under READ COMMITTED an admin could deactivate the
+ * integration on another connection and COMMIT between the source read and the activation's own
+ * commit — activating a user against a now-inactive source, violating "admin 激活不得对 inactive
+ * 目录源静默开通". The fix adds `FOR SHARE OF ... di` to the source read.
+ *
+ * This is a CONSTRUCTED race, not a sequential argument: a second connection holds an
+ * uncommitted integration deactivation, and we prove — via pg_locks — that the real
+ * activatePendingUser BLOCKS on that transaction (its FOR SHARE cannot proceed). When the
+ * deactivation then commits, the FOR SHARE's READ COMMITTED EPQ recheck refetches the fresh
+ * 'inactive' status and the activation refuses ACTIVATE_INTEGRATION_INACTIVE, writing nothing.
+ */
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const TS = Date.now()
+const PREFIX = `t3-src-lock-${TS}`
+
+type Seeded = {
+  userId: string
+  orgId: string
+  integrationId: string
+  accountId: string
+}
+
+async function cleanup(): Promise<void> {
+  await query(`DELETE FROM user_login_aliases WHERE user_id LIKE $1`, [`${PREFIX}%`])
+  await query(`DELETE FROM user_orgs WHERE user_id LIKE $1`, [`${PREFIX}%`])
+  await query(`DELETE FROM directory_account_links WHERE local_user_id LIKE $1`, [`${PREFIX}%`])
+  await query(
+    `DELETE FROM directory_accounts WHERE integration_id IN
+       (SELECT id FROM directory_integrations WHERE org_id LIKE $1)`,
+    [`${PREFIX}%`],
+  )
+  await query(`DELETE FROM directory_integrations WHERE org_id LIKE $1`, [`${PREFIX}%`])
+  await query(`DELETE FROM users WHERE id LIKE $1`, [`${PREFIX}%`])
+}
+
+async function seed(): Promise<Seeded> {
+  const orgId = `${PREFIX}-org-${randomUUID()}`
+  const userId = `${PREFIX}-user-${randomUUID()}`
+  const integration = await query<{ id: string }>(
+    `INSERT INTO directory_integrations (name, corp_id, org_id, provider, status, default_deprovision_policy)
+     VALUES ($1, $2, $3, 'dingtalk', 'active', 'manual_review')
+     RETURNING id::text AS id`,
+    [`${PREFIX}-integration`, `${PREFIX}-corp-${randomUUID()}`, orgId],
+  )
+  const integrationId = integration.rows[0].id
+  await query(
+    `INSERT INTO users (id, email, password_hash, is_active, activation_status, local_password_set)
+     VALUES ($1, $2, 'x', FALSE, 'pending_activation', FALSE)`,
+    [userId, `${userId}@example.com`],
+  )
+  const account = await query<{ id: string }>(
+    `INSERT INTO directory_accounts (integration_id, provider, external_user_id, external_key, name, is_active)
+     VALUES ($1::uuid, 'dingtalk', $2, $3, 'Source', TRUE)
+     RETURNING id::text AS id`,
+    [integrationId, `${PREFIX}-ext-${randomUUID()}`, `dingtalk:${PREFIX}:${randomUUID()}`],
+  )
+  const accountId = account.rows[0].id
+  await query(
+    `INSERT INTO directory_account_links (directory_account_id, local_user_id, link_status)
+     VALUES ($1::uuid, $2, 'linked')`,
+    [accountId, userId],
+  )
+  return { userId, orgId, integrationId, accountId }
+}
+
+describeIfDatabase('T3 activation source read serialises against integration deactivation (real DB)', () => {
+  beforeEach(cleanup)
+  afterAll(cleanup)
+
+  it('blocks on a concurrent integration deactivation and refuses once it commits (writing nothing)', async () => {
+    const seeded = await seed()
+
+    const holder = new pg.Client({ connectionString: process.env.DATABASE_URL })
+    await holder.connect()
+    let activation: Promise<unknown> | null = null
+    try {
+      // Connection B: deactivate the integration but DO NOT commit — this holds an exclusive row
+      // lock on the integration tuple and assigns B a transaction id.
+      await holder.query('BEGIN')
+      await holder.query(
+        `UPDATE directory_integrations SET status = 'inactive' WHERE id = $1::uuid`,
+        [seeded.integrationId],
+      )
+      const holderPid = Number((await holder.query('SELECT pg_backend_pid() AS pid')).rows[0]?.pid)
+      const holderXid = String(
+        (
+          await holder.query(
+            `SELECT transactionid::text AS xid
+               FROM pg_locks
+              WHERE pid = $1 AND locktype = 'transactionid' AND granted
+              LIMIT 1`,
+            [holderPid],
+          )
+        ).rows[0]?.xid,
+      )
+      expect(holderXid).not.toBe('undefined')
+
+      // The real activation starts and MUST block: its FOR SHARE read of the integration row
+      // cannot proceed while B's uncommitted UPDATE holds the row. (Its own users lock is taken
+      // without contention, so any wait it has is on B's deactivation, not the user lock.)
+      activation = activatePendingUser({
+        userId: seeded.userId,
+        mode: 'admin_no_password',
+        adminUserId: 'admin-test',
+      })
+      const settledEarly = { done: false }
+      activation.then(
+        () => { settledEarly.done = true },
+        () => { settledEarly.done = true },
+      )
+
+      // Deterministic barrier (no sleep-and-hope): wait until a DIFFERENT backend is provably
+      // blocked WAITING ON B's transaction — i.e. on the integration deactivation specifically.
+      let blockedPid = 0
+      for (let attempt = 0; attempt < 100 && blockedPid === 0; attempt += 1) {
+        const waiting = await holder.query(
+          `SELECT blocked.pid AS pid
+             FROM pg_locks blocked
+            WHERE NOT blocked.granted
+              AND blocked.locktype = 'transactionid'
+              AND blocked.transactionid::text = $1
+              AND blocked.pid <> $2
+            LIMIT 1`,
+          [holderXid, holderPid],
+        )
+        blockedPid = Number(waiting.rows[0]?.pid ?? 0)
+        if (blockedPid === 0) await new Promise((resolve) => setTimeout(resolve, 50))
+      }
+      expect(blockedPid).toBeGreaterThan(0) // the activation is blocked on the deactivation
+      expect(settledEarly.done).toBe(false) // and therefore has NOT resolved
+
+      // Additionally pin that B's lock is on the integration relation (context for the wait).
+      const holderRel = await holder.query(
+        `SELECT 1
+           FROM pg_locks
+          WHERE pid = $1 AND relation = 'directory_integrations'::regclass AND granted
+          LIMIT 1`,
+        [holderPid],
+      )
+      expect(holderRel.rows.length).toBe(1)
+
+      // The deactivation commits. The activation's FOR SHARE EPQ recheck now sees 'inactive'.
+      await holder.query('COMMIT')
+
+      await expect(activation).rejects.toMatchObject({ code: 'ACTIVATE_INTEGRATION_INACTIVE' })
+      activation = null
+    } finally {
+      try { await holder.query('ROLLBACK') } catch { /* already committed */ }
+      await holder.end()
+      if (activation) { await activation.catch(() => undefined) }
+    }
+
+    // Fail-closed: nothing was written — the user is still pending, with no membership.
+    const user = await query<{ activation_status: string; is_active: boolean }>(
+      `SELECT activation_status, is_active FROM users WHERE id = $1`,
+      [seeded.userId],
+    )
+    expect(user.rows[0]).toEqual({ activation_status: 'pending_activation', is_active: false })
+    const membership = await query(`SELECT 1 FROM user_orgs WHERE user_id = $1`, [seeded.userId])
+    expect(membership.rows).toHaveLength(0)
+  }, 30_000)
+})

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -227,6 +227,11 @@ export default defineConfig({
       // wired into the approval real-DB step (both points asserted by
       // scripts/ops/directory-grant-table-ci-wiring.test.mjs).
       'tests/integration/directory-deprovision-grant-table.db.test.ts',
+      // T3 activation source read serialises against a concurrent integration deactivation
+      // (post-merge review P1, FOR SHARE). Constructed pg_locks race — meaningless without a DB.
+      // DATABASE_URL-gated; excluded so the no-DB job cannot skip-green; whole-file wired into
+      // the approval real-DB step (both points self-asserted inside the suite).
+      'tests/integration/directory-activation-source-lock.db.test.ts',
       // D3 Rev 4.3 evidence-ledger migration: isolated-schema upgrade, replay with evidence,
       // fail-before-DDL weak-data guard, FK/trigger invariants, and ownership-safe down.
       // DATABASE_URL-gated; excluded here and wired as a whole file into the approval real-DB

--- a/plugins/plugin-integration-core/lib/sealed-export/vectors/s6a-package-provenance-pins.json
+++ b/plugins/plugin-integration-core/lib/sealed-export/vectors/s6a-package-provenance-pins.json
@@ -86,6 +86,6 @@
     "s6aAcceptancePs51Test": "835c7c6ce943d82e0378a40a27c7fd1e8b79b526faa8ca4c8066e4231a4bfb0f",
     "s6aProductRuntimeTest": "de978adafa8b89772cefa921c2051f434bf346bf5c2978bef3424ee70f51ba3f",
     "multitableOnpremPackageBuild": "463c7d73c6c7f2d1b6cdf0820d7a06974a9c463dd5e98bbbaf1c996e1dc4ed99",
-    "pluginTestsWorkflow": "edddd9559aa44ecd4862442a45d10cf5325cea9a276b4c218210bce06d3a2946"
+    "pluginTestsWorkflow": "c62284f368598cf1fc2d556e2cb86c01f05e8dc773d09e0402ef512fefb1fc93"
   }
 }

--- a/plugins/plugin-integration-core/lib/sealed-export/vectors/s6a-package-provenance-pins.json
+++ b/plugins/plugin-integration-core/lib/sealed-export/vectors/s6a-package-provenance-pins.json
@@ -86,6 +86,6 @@
     "s6aAcceptancePs51Test": "835c7c6ce943d82e0378a40a27c7fd1e8b79b526faa8ca4c8066e4231a4bfb0f",
     "s6aProductRuntimeTest": "de978adafa8b89772cefa921c2051f434bf346bf5c2978bef3424ee70f51ba3f",
     "multitableOnpremPackageBuild": "463c7d73c6c7f2d1b6cdf0820d7a06974a9c463dd5e98bbbaf1c996e1dc4ed99",
-    "pluginTestsWorkflow": "c62284f368598cf1fc2d556e2cb86c01f05e8dc773d09e0402ef512fefb1fc93"
+    "pluginTestsWorkflow": "2bf3d80bc1f5c193638fb037cdf8141d7d403e18a9b2e3f8bfa456c180d15e0e"
   }
 }

--- a/plugins/plugin-integration-core/lib/sealed-export/vectors/s6a-package-provenance-pins.json
+++ b/plugins/plugin-integration-core/lib/sealed-export/vectors/s6a-package-provenance-pins.json
@@ -86,6 +86,6 @@
     "s6aAcceptancePs51Test": "835c7c6ce943d82e0378a40a27c7fd1e8b79b526faa8ca4c8066e4231a4bfb0f",
     "s6aProductRuntimeTest": "de978adafa8b89772cefa921c2051f434bf346bf5c2978bef3424ee70f51ba3f",
     "multitableOnpremPackageBuild": "463c7d73c6c7f2d1b6cdf0820d7a06974a9c463dd5e98bbbaf1c996e1dc4ed99",
-    "pluginTestsWorkflow": "d9cd40232f9f5e08a25238bc56f4c491ae0906f8b2aead20933d650bddeacf0a"
+    "pluginTestsWorkflow": "edddd9559aa44ecd4862442a45d10cf5325cea9a276b4c218210bce06d3a2946"
   }
 }

--- a/scripts/ops/directory-activation-source-lock-ci-wiring.test.mjs
+++ b/scripts/ops/directory-activation-source-lock-ci-wiring.test.mjs
@@ -1,0 +1,47 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { existsSync, readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+import {
+  REAL_DB_STEP_IDS,
+  isSuiteWiredInRealDbStep,
+  realDbStepWholeFileArgs,
+} from './ci-realdb-step-contract.mjs'
+
+// Two-point wiring for directory-activation-source-lock.db.test.ts (post-merge review P1 —
+// FOR SHARE on the T3 activation source read). External contract, mirroring the grant-table
+// sibling: the suite's own in-file self-check only runs IF the suite runs, so it cannot detect
+// its OWN removal from the run list. This contract runs in integration-guard (no DB), so
+// dropping EITHER wiring point reds a required check.
+// (1) vitest.config.ts test.exclude — the no-DB job cannot skip-green it
+// (2) plugin-tests.yml approval real-DB whole-file step — required 20.x + DATABASE_URL
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const repoRoot = join(__dirname, '..', '..')
+const FILE = 'tests/integration/directory-activation-source-lock.db.test.ts'
+const STEP_ID = REAL_DB_STEP_IDS.approval
+
+test('vitest.config.ts excludes the activation-source-lock suite from the no-DB job', () => {
+  const cfg = readFileSync(join(repoRoot, 'packages/core-backend/vitest.config.ts'), 'utf8')
+  assert.ok(cfg.includes(`'${FILE}'`), `vitest.config.ts must exclude ${FILE}`)
+})
+
+test('plugin-tests.yml runs the activation-source-lock suite as a whole file in the approval real-DB step', () => {
+  const wf = readFileSync(join(repoRoot, '.github/workflows/plugin-tests.yml'), 'utf8')
+  assert.ok(
+    isSuiteWiredInRealDbStep(wf, STEP_ID, FILE),
+    `plugin-tests.yml real-DB step id "${STEP_ID}" must run ${FILE} as a whole-file vitest arg`,
+  )
+  assert.equal(
+    realDbStepWholeFileArgs(wf, REAL_DB_STEP_IDS.multitable).includes(FILE),
+    false,
+    `${FILE} must not be wired into the multitable real-DB step`,
+  )
+})
+
+test('the activation-source-lock suite file exists on disk', () => {
+  assert.ok(
+    existsSync(join(repoRoot, 'packages/core-backend', FILE)),
+    `wired suite packages/core-backend/${FILE} must exist on disk`,
+  )
+})


### PR DESCRIPTION
Post-merge review P1 #2. The activation transaction locked `users` but read the directory source (account/link/integration) UNLOCKED; under READ COMMITTED an admin deactivating the integration on another connection could COMMIT between the source read and the activation commit, activating a user against a now-inactive source ("admin 激活不得对 inactive 目录源静默开通"). Fix: `FOR SHARE OF ...` on the source read in both branches (integration is INNER-joined in both → locked in both). Load-bearing invariant now commented: integration `status` is checked in TS, not in WHERE, so the FOR SHARE READ COMMITTED EPQ recheck sees the fresh 'inactive' and refuses; moving the predicate into WHERE would make EPQ drop the row. Verification: constructed real-DB pg_locks race (directory-activation-source-lock.db) proving the real activatePendingUser blocks on the deactivation transaction specifically, then refuses ACTIVATE_INTEGRATION_INACTIVE and writes nothing; two-point CI wired (no-DB exclusion + approval real-DB run list) with in-suite self-check; four directory wiring contracts stay green; mutations removing only the `di` lock and the whole clause each redden the golden. tsc + 6788 unit + 41 real-DB green. Also retracts the "可编码项清零" overclaim in the completion MD (§4ter). One of two narrow fixes from the 2026-08-10 review (main=d78b27d37c); switches remain OFF.

https://claude.ai/code/session_014dQjSzR5ecniF1mRay4wEE
