### PR TITLE
fix(integration): require exact K3 lookup key match

### DIFF
--- a/plugins/plugin-integration-core/__tests__/k3-wise-c6-write-profile.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/k3-wise-c6-write-profile.test.cjs
@@ -123,7 +123,7 @@ function jsonResponse(status, body) {
 
 // Mock K3: login, GetDetail (existing row for MAT-C6-EXIST, business-fail for everything
 // else — K3's real "not found" shape), Save success. Counts every path.
-function mockK3({ existing = {} } = {}) {
+function mockK3({ existing = {}, fallbackDetail = null } = {}) {
   const calls = []
   const impl = async (url, init) => {
     const parsed = new URL(url)
@@ -141,6 +141,13 @@ function mockK3({ existing = {} } = {}) {
           StatusCode: 200,
           Message: 'Successful',
           Data: [{ FStatus: true, FItemID: row.FItemID, Data: row }],
+        })
+      }
+      if (fallbackDetail) {
+        return jsonResponse(200, {
+          StatusCode: 200,
+          Message: 'Successful',
+          Data: [{ FStatus: true, FItemID: fallbackDetail.FItemID, Data: fallbackDetail }],
         })
       }
       // K3's business-level miss: FStatus false — businessSuccess() is false for this shape.
@@ -363,6 +370,75 @@ test('roundtrip: dry-run plans add+update, mints a token; apply consumes it and 
   assert.deepEqual(savedNumbers, ['MAT-C6-EXIST', 'MAT-C6-NEW'])
   assert.equal(fetchPair.calls.filter((c) => /\/(Submit|Audit)$/.test(c.pathname)).length, 0,
     'save-only must survive the entire C6 lifecycle')
+})
+
+test('lookup ignores a successful GetDetail record whose normalized key does not exactly match', async () => {
+  const fetchPair = mockK3({
+    // Reproduces the onsite failure shape: an unknown requested key receives a successful
+    // default/template detail record for a different material. That record is not existence
+    // evidence for the requested key and must therefore plan as add.
+    fallbackDetail: { FNumber: '  TEMPLATE-MATERIAL  ', FItemID: 7001, FName: 'Template' },
+  })
+  const dryRun = await dryRunExternalWrite(c6Inputs({
+    rows: [{ code: 'NEW-MATERIAL', name: 'New material', spec: 'SPEC-N' }],
+    fetchPair,
+    tokenStore: memoryStore(),
+  }))
+
+  assert.equal(dryRun.counts.add, 1)
+  assert.equal(dryRun.counts.update, 0)
+  assert.equal(dryRun.counts.held, 0)
+})
+
+test('lookup keeps a returned record whose normalized key exactly matches the request', async () => {
+  const fetchPair = mockK3({
+    existing: {
+      'MATCHED-MATERIAL': {
+        FNumber: '  MATCHED-MATERIAL  ',
+        FItemID: 7002,
+        FName: 'Old name',
+        FModel: 'SPEC-OLD',
+      },
+    },
+  })
+  const dryRun = await dryRunExternalWrite(c6Inputs({
+    rows: [{ code: 'MATCHED-MATERIAL', name: 'New name', spec: 'SPEC-OLD' }],
+    fetchPair,
+    tokenStore: memoryStore(),
+  }))
+
+  assert.equal(dryRun.counts.add, 0)
+  assert.equal(dryRun.counts.update, 1)
+  assert.equal(dryRun.counts.held, 0)
+})
+
+test('lookup preserves multiple exact key matches so the planner holds the ambiguous row', async () => {
+  const input = c6Inputs({
+    rows: [{ code: 'AMBIGUOUS-MATERIAL', name: 'New name', spec: 'SPEC-N' }],
+    fetchPair: mockK3(),
+    tokenStore: memoryStore(),
+  })
+  const targetSystem = k3TargetSystem()
+  input.dataSourceWrites = createK3WiseC6WriteSource({
+    system: targetSystem,
+    createAdapter: () => ({
+      async read() {
+        return {
+          records: [
+            { FNumber: 'AMBIGUOUS-MATERIAL', FName: 'First' },
+            { FNumber: '  AMBIGUOUS-MATERIAL  ', FName: 'Second' },
+          ],
+        }
+      },
+    }),
+    b4: b4Of([APPROVED_B4_ROW]),
+  })
+
+  const dryRun = await dryRunExternalWrite(input)
+  assert.equal(dryRun.counts.add, 0)
+  assert.equal(dryRun.counts.update, 0)
+  assert.equal(dryRun.counts.held, 1)
+  assert.equal(dryRun.canApply, false)
 })
 
 test('CONTENT BINDING: source rows changed between dry-run and apply -> 409, nothing written', async () => {

--- a/plugins/plugin-integration-core/lib/adapters/k3-wise-c6-write-profile.cjs
+++ b/plugins/plugin-integration-core/lib/adapters/k3-wise-c6-write-profile.cjs
@@ -303,6 +303,12 @@ function createK3WiseC6WriteSource({ system, createAdapter, b4 } = {}) {
     return out
   }
 
+  function normalizeLookupKey(value) {
+    if (value === undefined || value === null) return null
+    const normalized = String(value).trim()
+    return normalized.length > 0 ? normalized : null
+  }
+
   function saveFailure() {
     const error = new Error('K3 WISE Save reported row failure')
     // Review #4761 P2: UNCONDITIONALLY the registered closed token. Passing through the
@@ -430,13 +436,25 @@ function createK3WiseC6WriteSource({ system, createAdapter, b4 } = {}) {
 
     async lookupByKey(dataSourceId, object, key, policy) {
       const keyField = policy.keyFields[0]
+      const requestedKey = normalizeLookupKey(key[keyField])
       try {
         const read = await targetAdapter().read({
           object,
           filters: { [keyField]: key[keyField] },
         })
         const records = Array.isArray(read && read.records) ? read.records : []
-        return { data: records.map(unwrapReferenceShapes) }
+        // GetDetail is only evidence that a material exists when the returned material key
+        // identifies the material we asked for. Some K3 deployments return a successful
+        // default/template detail record for an unknown key; passing that unrelated record to
+        // classifyExisting turns a genuinely new material into `update`. Normalize only the
+        // outer string representation (trim, case-sensitive) and keep every exact match so the
+        // planner can still fail closed as `held` if an adapter ever reports duplicates.
+        const matching = records
+          .map(unwrapReferenceShapes)
+          .filter((record) => requestedKey !== null
+            && record && typeof record === 'object'
+            && normalizeLookupKey(record[keyField]) === requestedKey)
+        return { data: matching }
       } catch (error) {
         const code = error && error.details && error.details.code
         if (code === 'K3_WISE_READ_BUSINESS_ERROR') {


### PR DESCRIPTION
## Summary

- normalize the requested K3 material key and each returned `FNumber` by trimming outer whitespace while preserving case
- discard successful GetDetail records whose key does not exactly match the requested key
- preserve all exact matches so duplicate evidence still reaches the planner as `held`
- add regression coverage for mismatched → `add`, matched → existing (`update`), and duplicate matches → `held`

## Why

The controlled `_02` preview in #4628 returned `add=0/update=2` even after both operation-private source keys were rotated. The frozen C6 lookup passed every successful GetDetail record to `classifyExisting`, so an unrelated default/template detail record was treated as proof that the requested key already existed.

This patch makes returned-key equality the evidence boundary. It does not change Save-only locks, Submit/Audit disablement, row caps, B4 binding, token handling, transport/login behavior, or Apply behavior.

Related to #4628. The issue must remain open for owner review, package refresh, and controlled retest.

## Verification

- `node __tests__/k3-wise-c6-write-profile.test.cjs` — 32/32 pass
- `node __tests__/k3-wise-adapters.test.cjs` — pass
- `node __tests__/external-write-dry-run.test.cjs` — pass
- `node __tests__/k3-write-approval-posture.test.cjs` — 8/8 pass
- `node --check` on both changed files — pass
- `git diff --check` — pass

`k3-wise-apply-row-limit.test.cjs` passes 24/25 locally; its existing sweep-contract assertion compares POSIX `/` paths with Windows `\` paths and is unrelated to this diff.

## Operational boundary

No code from this PR has been deployed to the controlled host. No K3 Apply, Submit, or Audit was executed. A reviewed merge and new frozen package are still required before the onsite retest.