### PR TITLE
fix(directory): compensate superseded DingTalk deny evidence

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -1119,6 +1119,7 @@ jobs:
             tests/integration/directory-sync-alert-coverage.db.test.ts \
             tests/integration/directory-deprovision-selection.db.test.ts \
             tests/integration/directory-deprovision-grant-table.db.test.ts \
+            tests/integration/directory-deprovision-compensation.db.test.ts \
             tests/integration/directory-activation-source-lock.db.test.ts \
             tests/integration/login-alias-writers.db.test.ts \
             tests/integration/directory-deprovision-ledger-schema.db.test.ts \

--- a/apps/web/src/components/directory/DirectoryDeprovisionEvidencePanel.vue
+++ b/apps/web/src/components/directory/DirectoryDeprovisionEvidencePanel.vue
@@ -127,10 +127,11 @@
     </section>
 
     <section v-if="selectedEvent" class="deprov-evidence__section" data-testid="deprovision-restore-panel">
-      <h3>恢复 · 事件 {{ shortId(selectedEvent.id) }}</h3>
+      <h3>事件操作 · {{ shortId(selectedEvent.id) }}</h3>
       <ul v-if="effects.length" class="deprov-evidence__list">
         <li v-for="fx in effects" :key="fx.id">
           {{ fx.effect_type }} · {{ fx.status }} · after={{ fx.after_active }} · gen={{ fx.access_generation_at_apply }}
+          <span v-if="fx.grant_row_created"> · deny-row creation</span>
         </li>
       </ul>
 
@@ -168,6 +169,32 @@
       <p v-if="!canRestore" class="deprov-evidence__hint">
         该事件没有可恢复的 applied effects。
       </p>
+      <div v-if="canCompensate" class="deprov-evidence__card" data-testid="deprovision-compensation-panel">
+        <strong>OPS-01 残留 deny 行补偿</strong>
+        <p class="deprov-evidence__hint">
+          仅删除 superseded creation effect 留下的 disabled grant；不会恢复用户或成员关系。
+        </p>
+        <label class="deprov-evidence__check">
+          <input v-model="compensationConfirm" type="checkbox" data-testid="deprovision-compensation-confirm" />
+          我确认源、成员关系与当前 grant 状态已复核
+        </label>
+        <textarea
+          v-model="compensationNote"
+          class="deprov-evidence__textarea"
+          rows="2"
+          placeholder="补偿原因（≥8 字）"
+          data-testid="deprovision-compensation-note"
+        />
+        <button
+          class="deprov-evidence__btn deprov-evidence__btn--danger"
+          type="button"
+          :disabled="compensating || !compensationConfirm || compensationNote.trim().length < 8"
+          data-testid="deprovision-compensate-orphan-deny"
+          @click="void compensateOrphanDeny()"
+        >
+          {{ compensating ? '补偿中…' : '补偿残留 deny 行' }}
+        </button>
+      </div>
       <p v-if="restoreConflict" class="deprov-evidence__status deprov-evidence__status--error" data-testid="deprovision-drift-conflict">
         {{ restoreConflict }}
       </p>
@@ -220,9 +247,10 @@ type DeprovisionEvent = {
 type DeprovisionEffect = {
   id: string
   effect_type: string
-  status: 'applied' | 'reversed' | 'superseded'
+  status: 'applied' | 'reversed' | 'superseded' | 'compensated'
   after_active: boolean
   access_generation_at_apply: number
+  grant_row_created?: boolean
 }
 
 const props = defineProps<{
@@ -249,11 +277,24 @@ const effects = ref<DeprovisionEffect[]>([])
 const restoring = ref(false)
 const forceConfirm = ref(false)
 const forceNote = ref('')
+const compensating = ref(false)
+const compensationConfirm = ref(false)
+const compensationNote = ref('')
 const restoreConflict = ref('')
 const canRestore = computed(
   () =>
     selectedEvent.value?.status === 'applied'
     && effects.value.some((effect) => effect.status === 'applied'),
+)
+const canCompensate = computed(
+  () =>
+    selectedEvent.value?.status === 'superseded'
+    && effects.value.some(
+      (effect) =>
+        effect.effect_type === 'grant_changed'
+        && effect.grant_row_created === true
+        && effect.status === 'superseded',
+    ),
 )
 
 function shortId(id: string): string {
@@ -353,6 +394,8 @@ async function selectEvent(ev: DeprovisionEvent) {
   restoreConflict.value = ''
   forceConfirm.value = false
   forceNote.value = ''
+  compensationConfirm.value = false
+  compensationNote.value = ''
   try {
     const response = await apiFetch(
       `/api/admin/directory/deprovision-events/${encodeURIComponent(ev.id)}/effects`,
@@ -366,6 +409,55 @@ async function selectEvent(ev: DeprovisionEvent) {
     effects.value = (body?.data?.items || []) as DeprovisionEffect[]
   } catch (error) {
     setError(error instanceof Error ? error.message : '加载 effects 失败')
+  }
+}
+
+async function compensateOrphanDeny() {
+  if (!selectedEvent.value || !canCompensate.value) return
+  compensating.value = true
+  restoreConflict.value = ''
+  try {
+    const response = await apiFetch(
+      `/api/admin/directory/deprovision-events/${encodeURIComponent(selectedEvent.value.id)}/compensate-orphan-deny`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          confirm: compensationConfirm.value,
+          note: compensationNote.value,
+        }),
+      },
+    )
+    const body = await response.json().catch(() => ({}))
+    if (!response.ok) {
+      const code = body?.error?.code || 'ERROR'
+      const message = body?.error?.message || '补偿失败'
+      if (
+        code === 'DRIFT_CONFLICT'
+        || code === 'COMPENSATION_EVENT_NOT_SUPERSEDED'
+        || code === 'COMPENSATION_NOT_APPLICABLE'
+        || code === 'COMPENSATION_USER_INACTIVE'
+        || code === 'COMPENSATION_SOURCE_INACTIVE'
+        || code === 'COMPENSATION_MEMBERSHIP_INACTIVE'
+        || code === 'COMPENSATION_LIVE_EVIDENCE'
+      ) {
+        restoreConflict.value = `${code}: ${message}`
+      } else {
+        setError(`${code}: ${message}`)
+      }
+      return
+    }
+    setOk(
+      body?.data?.alreadyCompensated
+        ? '残留 deny 行此前已完成补偿'
+        : `残留 deny 行补偿成功 · gen=${body?.data?.accessGeneration}`,
+    )
+    await loadEvents()
+    if (selectedEvent.value) await selectEvent(selectedEvent.value)
+  } catch (error) {
+    setError(error instanceof Error ? error.message : '补偿失败')
+  } finally {
+    compensating.value = false
   }
 }
 

--- a/apps/web/tests/DirectoryDeprovisionEvidencePanel.spec.ts
+++ b/apps/web/tests/DirectoryDeprovisionEvidencePanel.spec.ts
@@ -250,4 +250,86 @@ describe('DirectoryDeprovisionEvidencePanel (D7)', () => {
       note: 'confirmed by owner',
     })
   })
+
+  it('offers explicit compensation only for a superseded deny-row creation effect', async () => {
+    apiFetchMock.mockImplementation(async (url: string, init?: { method?: string; body?: string }) => {
+      if (String(url).includes('/deprovision/flags')) {
+        return jsonResponse({ enabled: false, maxBatch: 25, policyNote: 'n' })
+      }
+      if (String(url).includes('/deprovision-events?')) {
+        return jsonResponse({
+          items: [
+            {
+              id: 'ev-compensate',
+              local_user_id: 'u1',
+              access_generation_at_apply: 3,
+              status: 'superseded',
+              open_effect_count: 0,
+            },
+          ],
+        })
+      }
+      if (String(url).includes('/effects')) {
+        return jsonResponse({
+          items: [
+            {
+              id: 'fx-creation',
+              effect_type: 'grant_changed',
+              status: 'superseded',
+              after_active: false,
+              grant_row_created: true,
+              access_generation_at_apply: 3,
+            },
+          ],
+        })
+      }
+      if (String(url).includes('/compensate-orphan-deny') && init?.method === 'POST') {
+        return jsonResponse({
+          eventId: 'ev-compensate',
+          effectId: 'fx-creation',
+          alreadyCompensated: false,
+          accessGeneration: 5,
+        })
+      }
+      return jsonResponse({})
+    })
+
+    const root = mountPanel({ integrationId: 'int-1' })
+    ;(root.querySelector('[data-testid="deprovision-evidence-toggle"]') as HTMLButtonElement).click()
+    await flushUi()
+    const detailBtn = Array.from(root.querySelectorAll('button')).find((button) =>
+      button.textContent?.includes('详情'))
+    detailBtn!.click()
+    await flushUi()
+
+    expect(root.querySelector('[data-testid="deprovision-compensation-panel"]')).toBeTruthy()
+    const compensate = root.querySelector(
+      '[data-testid="deprovision-compensate-orphan-deny"]',
+    ) as HTMLButtonElement
+    const confirm = root.querySelector(
+      '[data-testid="deprovision-compensation-confirm"]',
+    ) as HTMLInputElement
+    const note = root.querySelector(
+      '[data-testid="deprovision-compensation-note"]',
+    ) as HTMLTextAreaElement
+    expect(compensate.disabled).toBe(true)
+
+    confirm.click()
+    note.value = 'owner verified cleanup'
+    note.dispatchEvent(new Event('input'))
+    await flushUi(2)
+    expect(compensate.disabled).toBe(false)
+    compensate.click()
+    await flushUi()
+
+    const call = apiFetchMock.mock.calls.find((args) =>
+      String(args[0]).includes('/compensate-orphan-deny'))
+    expect(call?.[0]).toContain(
+      '/api/admin/directory/deprovision-events/ev-compensate/compensate-orphan-deny',
+    )
+    expect(JSON.parse(String(call?.[1]?.body))).toEqual({
+      confirm: true,
+      note: 'owner verified cleanup',
+    })
+  })
 })

--- a/docs/development/dingtalk-deprovision-reactivation-and-evidence-chain-design-20260723.md
+++ b/docs/development/dingtalk-deprovision-reactivation-and-evidence-chain-design-20260723.md
@@ -1,7 +1,7 @@
 # DingTalk Deprovision 恢复 + Preview/UI 证据链 — 实现级设计
 
 - Date: 2026-07-23
-- Status: **implementation design lock / Rev 4.4**（Rev 4.3 已终签；Rev 4.4 为 OPS-01 证据模型勘误，见 §0.7）
+- Status: **implementation design lock / Rev 4.5**（Rev 4.3 已终签；Rev 4.4 为 OPS-01 证据模型勘误；Rev 4.5 为 supersede 残留补偿裁决，见 §0.8）
 - Locked: 2026-07-23（owner 批准两篇一并升 lock）
 - Scope: 打开 `DIRECTORY_DEPROVISION_ENABLED` 之前，把「权威 effect 账本 + prospective planner + 全写者 per-user 锁 + event 恢复（含 drift）」设计正确
 - Baseline: **`origin/main @ 1bcfc86b8`**；相对 `ca625f14a` 本线相关代码 **scoped diff = 0**（membership + globally-clear 事实基线仍成立）
@@ -85,6 +85,21 @@ DELETE 逆转仅在其事件仍为 `applied` 时可用。任何后续 access-gra
 **Implementation design lock 已于 2026-07-23 批准。**  
 序：lock → T1→T2→T3 → D1…D7 → canary。  
 **design lock ≠ T1 GO — 本次不授权启动 T1。**
+
+### 0.8 Rev 4.4 → Rev 4.5（OPS-01 supersede compensation）
+
+**Owner 裁决（2026-08-10）**：采用「显式、审计化补偿」，禁止在任意 supersede 时自动删除 deny 行。
+
+仅当下列条件在同一事务内全部成立，平台管理员才可执行专用补偿：
+
+1. 先持有 canonical per-user access-graph mutex，再锁 event/effects；
+2. event 与唯一 `grant_changed + grant_row_created=TRUE` effect 均为 `superseded`；
+3. 用户为 `activated + active`，原 event 的 directory account / integration / link 仍 `active + active + linked`；源行以 `FOR SHARE ... NOWAIT` 读取，若 sync 正持有源行则 409 busy，禁止持 user mutex 反向等待源行；
+4. 原 event 的组织 membership 仍 active；该用户不存在任何 `applied` deprovision event/effect；
+5. 当前 DingTalk grant 必须恰为 `enabled=FALSE` 且 `granted_by='system:directory-deprovision'`；任何缺失、启用或 provenance 漂移均 409；
+6. DELETE deny 行、effect → `compensated`、写入不可改的补偿 actor/time/note、generation CAS `+1` 在同一事务完成；event 保持 `superseded`，不得伪装成 full restore。
+
+补偿入口要求 `confirm=true` 与至少 8 字符备注。已完成补偿且 grant 仍不存在时可幂等重试；若补偿后又出现 grant 行，则按 drift 拒绝。迁移 down 在存在 `compensated` evidence 时 fail-closed。该代码落地不授权打开任何生命周期开关。
 
 ---
 
@@ -273,10 +288,20 @@ directory_deprovision_event_effects (
   access_generation_at_apply bigint NOT NULL,
   reversed_at timestamptz,
   reversed_by text,
+  compensation_note text,
   created_at timestamptz NOT NULL DEFAULT now(),
 
   CHECK (effect_type IN ('membership_changed','grant_changed','user_changed')),
-  CHECK (status IN ('applied','reversed','superseded')),
+  CHECK (status IN ('applied','reversed','superseded','compensated')),
+  CHECK (
+    (status = 'compensated'
+      AND effect_type = 'grant_changed'
+      AND grant_row_created = TRUE
+      AND reversed_at IS NOT NULL
+      AND COALESCE(length(btrim(reversed_by)), 0) > 0
+      AND COALESCE(length(btrim(compensation_note)), 0) >= 8)
+    OR (status <> 'compensated' AND compensation_note IS NULL)
+  ),
   CHECK (
     (effect_type = 'membership_changed' AND org_id IS NOT NULL)
     OR (effect_type IN ('grant_changed','user_changed') AND org_id IS NULL)
@@ -291,7 +316,7 @@ directory_deprovision_event_effects (
 |------|------|
 | **BEFORE INSERT ON events** | 在 **已持有对应 `users` 行锁的同一事务** 内校验：**当时** 存在 linked 行（`link_status='linked'` 且 account/user 匹配）；account ∈ integration；integration.org_id 匹配；sync 时 run 存在且同 integration。失败 → **拒绝 INSERT**。 |
 | **BEFORE INSERT ON effects** | `membership_changed` ⇒ `NEW.org_id = parent event.org_id`；grant/user effect 的 `org_id` 必须为 NULL；effect 的 user/generation 必须与 parent event 一致。 |
-| **Immutability** | events：INSERT 后禁止改身份字段（含 `directory_account_id`, `local_user_id`, `link_witness_*`, policy, globally_clear, generation, event_origin, run_id, org_id, integration_id, triggered_by）。仅允许 resolve 列。effects：INSERT 后禁止改 type/org/before_active/after_active/generation；仅 status/reversed_*。 |
+| **Immutability** | events：INSERT 后禁止改身份字段（含 `directory_account_id`, `local_user_id`, `link_witness_*`, policy, globally_clear, generation, event_origin, run_id, org_id, integration_id, triggered_by）。仅允许 resolve 列。effects：INSERT 后禁止改 type/org/before_active/after_active/generation；进入 `compensated` 后 `status/reversed_at/reversed_by/compensation_note` 整组不可再改。 |
 | **禁止** | event→**current** `directory_account_links` FK；partial unique 作 FK 目标；仅靠 witness=自身 CHECK 充当“当时已 linked”（CHECK 只防自相矛盾，**trigger 才验 live link**）。 |
 
 **Mutation / 集成必过：**

--- a/docs/development/dingtalk-lifecycle-line-completion-and-verification-20260808.md
+++ b/docs/development/dingtalk-lifecycle-line-completion-and-verification-20260808.md
@@ -53,7 +53,11 @@ Sonnet 侦察（restack 预案）全部命中：唯一真冲突 #4658、#4659 �
 
 1. **Rev 4.3 勘误已按 owner 指令落账**（#4646 锁文 §0.6 含 provenance）：每 event 仅一条源组织 `membership_changed`；`globally_clear` 只门控 grant/user。与 main 既有 W4-PRE-1d owner 裁决同轴，非新语义。**请 owner 终签。**
 2. **OPS-01 行形制裁定 — 已被 Rev 4.4 取代（closeout 复审会签指令）**：复审裁定「OPS-01 暂不签——ledger 必须记录『grant 行从不存在到 disabled』的存在性变化，restore 时才能安全删除；不能仅调整 upsert 位置」。原「无条件 disabled 行、ledger 外写入」形制即复审 P1-2 的根因（从未有 grant 的人 rehire 后被孤儿 deny 行永久挡死 OAuth）。Rev 4.4（锁文 §0.7）改为**纯 effect 驱动**：creation effect（`grant_row_created=TRUE`）→ writer INSERT deny 行 → restore DELETE 恢复无行态；deny 闸本身不变（ensureGrant 仍 creation-only，被显式 disabled 行挡住）。**该项不再等 owner 会签原语义——按会签指令已重做。**
-3. **OPS-01 supersede 残留的补偿路径（新增，对抗审 P2-1）**：deny 行的 DELETE 逆转仅在事件 `applied` 期间可用；被 supersede 后行成无证据残留（rehire/admin_force 均 `EVENT_NOT_APPLIED`，后续离岗不补证据）。此为 main 既有 supersede 合同的推论。**请 owner 裁定补偿路径**：残留 deny 行是否允许人工/运维清理，或引入「再证据化」机制。三开关 OFF 期间无生产暴露。
+3. **OPS-01 supersede 残留补偿 — owner 已裁（2026-08-10）**：采用 Rev 4.5 的显式、审计化专用补偿；不在 supersede 中自动删除。实现候选在本 PR，只有合入 main 且 exact-head required CI 通过后才可把代码缺口记为关闭。入口持 canonical per-user mutex，重验 active+linked 源、active membership、无 live evidence、generation 与 grant provenance；源行被 sync 占用时以 `NOWAIT` fail-fast 409，避免 user/source 反向锁序；只删除 `grant_row_created` 对应的 `system:directory-deprovision` disabled 行，漂移 409；effect 记 `compensated` 且 actor/time/note 不可再改，event 保持 `superseded`。三开关继续 OFF，合入不等于 canary GO。
+
+### 4quater. OPS-01 compensation implementation candidate（2026-08-10）
+
+本轮新增 migration、事务服务、平台管理员 API、D7 最小 UI 与真库/并发/迁移/CI 接线证据。当前文档在实现分支上，**merge SHA / exact-head CI 均待 PR 落地后回填**；不得据此提前宣告 main 已关闭 OPS-01。完整状态见 `dingtalk-lifecycle-six-step-closeout-execution-20260810.md`。
 
 ## 4bis. Closeout 复审吸收记录（2026-08-08，CHANGES REQUESTED → 修复）
 

--- a/docs/development/dingtalk-lifecycle-six-step-closeout-execution-20260810.md
+++ b/docs/development/dingtalk-lifecycle-six-step-closeout-execution-20260810.md
@@ -1,0 +1,110 @@
+# DingTalk lifecycle six-step closeout execution
+
+- Date: 2026-08-10
+- Status: **CODE CANDIDATE / OPS AND EXTERNAL GATES NOT EXECUTED**
+- Baseline: `origin/main @ 775d537e616e325000c7578d7e2432d838da0801`
+- Scope: close the OPS-01 superseded creation-effect residue without enabling lifecycle traffic
+
+## 1. OPS-01 explicit compensation
+
+Owner decision: do not delete deny rows automatically when evidence is superseded. A platform administrator uses a dedicated endpoint with `confirm=true` and a reason of at least eight characters.
+
+The write transaction:
+
+1. Resolves the event owner, then takes the canonical per-user access-graph mutex.
+2. Locks the event and all effects.
+3. Accepts exactly one superseded `grant_changed` creation effect.
+4. Rechecks active/activated user, the exact active integration/account/linked source, active event-org membership, and absence of any live applied deprovision evidence. Source rows use `NOWAIT`: sync owns account rows before it reaches the user mutex, so compensation returns a values-free 409 busy response instead of waiting in the reverse lock order.
+5. Deletes only a disabled DingTalk grant whose provenance is exactly `system:directory-deprovision`.
+6. Marks the effect `compensated`, records actor/time/immutable compensation note, and advances `access_generation` by CAS in the same transaction.
+
+The event remains `superseded`; this operation is not a full restore. Missing, enabled, differently attributed, or concurrently changed state returns 409 and rolls back. A retry after committed compensation is idempotent only while the grant remains absent.
+
+API:
+
+```text
+POST /api/admin/directory/deprovision-events/:eventId/compensate-orphan-deny
+```
+
+The route is platform-admin-only. Unexpected backend failures return a fixed message rather than PostgreSQL details. The general audit record is values-free; durable evidence lives on the compensated effect.
+
+## 2. Verification ledger
+
+| Gate | Current evidence |
+|---|---|
+| Fresh DB migration | PASS on isolated `codex_ops01_comp2_20260810` |
+| Migration replay | PASS; second migrate is a no-op |
+| Down safety | PASS; refuses downgrade while compensated evidence exists |
+| Real DB lifecycle | PASS: deprovision → supersede → compensate → OAuth ensureGrant |
+| Drift matrix | PASS: enabled grant, wrong provenance, inactive source, busy source, inactive membership, and live evidence all reject without partial write |
+| Concurrency | PASS: two callers queue behind the user-row holder with one transition/increment; a separately locked source row yields fail-fast 409 rather than a user/source deadlock |
+| Regression | PASS: 66/66 across seven neighboring real-DB files |
+| Backend route | PASS: 110/110, including malformed-ID preflight, source-busy 409, SQLSTATE-safe fixed 500, and values-free audit |
+| D7 UI | PASS: 5/5 |
+| TypeScript | PASS: core-backend `tsc --noEmit` |
+| CI wiring | PASS: suite excluded from no-DB Vitest and run as a whole file in approval real-DB step |
+| Independent review | APPROVE after delta re-review; no remaining P1/P2 |
+| Exact-head required CI | PENDING until the held PR is pushed |
+
+Load-bearing mutations reproduced before restoration:
+
+- remove grant provenance predicate → wrong-provenance test fails;
+- remove live event/effect veto → live-evidence test fails;
+- remove exact source gate → inactive-source test fails;
+- remove active membership gate → membership test fails;
+- remove canonical `FOR UPDATE` mutex → two-waiter barrier times out;
+- remove source `NOWAIT` → the holder test waits, mutates after release, and fails instead of returning busy;
+- remove compensated-evidence immutability → raw note tampering succeeds and the schema test fails;
+- pass an unknown PostgreSQL SQLSTATE through as the response code → the HTTP error-surface test fails;
+- remove the `COALESCE` fail-closed terms from compensation evidence checks → raw NULL actor/note inserts succeed.
+
+## 3. Lifecycle flags and canary
+
+The repository defaults and closeout contract continue to require all three flags OFF:
+
+```text
+AUTH_LOGIN_USE_ALIASES=false
+DIRECTORY_PENDING_ACTIVATION_ENABLED=false
+DIRECTORY_DEPROVISION_ENABLED=false
+```
+
+Merge is not an enablement instruction. Canary execution is **NOT EXECUTED** and remains a separate ops GO. When authorized, execute only one stage at a time:
+
+| Stage | Enable | Required rollback proof before proceeding |
+|---|---|---|
+| 1 | alias-only | turn alias read path off and prove the pre-cutover login path is restored |
+| 2 | pending admission | turn pending admission off and prove new admissions return to activated baseline behavior |
+| 3 | deprovision | turn writer off and prove a new sync cannot create an event/effect or mutate access state |
+
+Deprovision is last. Do not overlap flag changes.
+
+## 4. Owner and ops acceptance
+
+Real enterprise evidence is unavailable in this development lane. Therefore these are explicitly **NOT EXECUTED**, not simulated PASS:
+
+- U1-U13 interactive-card acceptance;
+- U11-a real callback corp-anchor;
+- named owners and final production switch decisions;
+- actual staged rollback exercises from section 3.
+
+The procedure of record remains `dingtalk-hardening-real-uat-evidence-pack-20260713.md`.
+
+## 5. Transfer decision gate
+
+Transfer T3-T5 remains **FROZEN**. The real two-corp T2-Gate has not run in this lane:
+
+| T2-Gate verdict | Consequence |
+|---|---|
+| CONFIRMED | implement T2.5 tenant-scoped key migration before T3 |
+| DISPROVED | T3 may be considered after owner authorization |
+| INCONCLUSIVE / NOT EXECUTED | keep T3-T5 frozen |
+
+The runbook of record is `canonical-org-t2-gate-two-corp-staging-runbook-20260717.md`.
+
+## 6. Test infrastructure lane
+
+Issue #4820 remains a separate test-infrastructure item. Shared `metasheet_test` can be reset by parallel sessions, so this implementation used the lane-owned scratch database `codex_ops01_comp2_20260810`. The durable follow-up is per-lane scratch DB provisioning and cleanup; it does not change the lifecycle product verdict, but future runtime evidence must not rely on a concurrently shared database.
+
+## 7. Closure rule
+
+This goal is complete only when the held PR has independent review, exact-head required CI, and a reviewable head. It remains unarmed. Canary, U1-U13/corp-anchor, T2-Gate, Transfer T3-T5, and #4820 are deliberately external or separate gates and are not represented as completed by this code PR.

--- a/packages/core-backend/src/db/migrations/zzzz20260810100000_deprovision_effect_compensation_status.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260810100000_deprovision_effect_compensation_status.ts
@@ -1,0 +1,134 @@
+import type { Kysely } from 'kysely'
+import { sql } from 'kysely'
+
+const COMPENSATED_EFFECT_IMMUTABILITY = `
+        IF OLD.status = 'compensated'
+           AND (
+             NEW.status IS DISTINCT FROM OLD.status
+             OR NEW.reversed_at IS DISTINCT FROM OLD.reversed_at
+             OR NEW.reversed_by IS DISTINCT FROM OLD.reversed_by
+             OR NEW.compensation_note IS DISTINCT FROM OLD.compensation_note
+           ) THEN
+          RAISE EXCEPTION 'compensated deprovision effect evidence is immutable';
+        END IF;
+`
+
+function immutabilityFunction(compensationGuard: string): string {
+  return `
+    CREATE OR REPLACE FUNCTION directory_deprovision_reject_identity_update()
+    RETURNS trigger AS $$
+    BEGIN
+      IF TG_TABLE_NAME = 'directory_deprovision_events' THEN
+        IF NEW.org_id IS DISTINCT FROM OLD.org_id
+           OR NEW.integration_id IS DISTINCT FROM OLD.integration_id
+           OR NEW.directory_account_id IS DISTINCT FROM OLD.directory_account_id
+           OR NEW.local_user_id IS DISTINCT FROM OLD.local_user_id
+           OR NEW.link_witness_account_id IS DISTINCT FROM OLD.link_witness_account_id
+           OR NEW.link_witness_local_user_id IS DISTINCT FROM OLD.link_witness_local_user_id
+           OR NEW.policy IS DISTINCT FROM OLD.policy
+           OR NEW.globally_clear IS DISTINCT FROM OLD.globally_clear
+           OR NEW.access_generation_at_apply IS DISTINCT FROM OLD.access_generation_at_apply
+           OR NEW.event_origin IS DISTINCT FROM OLD.event_origin
+           OR NEW.run_id IS DISTINCT FROM OLD.run_id
+           OR NEW.triggered_by IS DISTINCT FROM OLD.triggered_by THEN
+          RAISE EXCEPTION 'directory_deprovision_events identity fields are immutable';
+        END IF;
+      ELSIF TG_TABLE_NAME = 'directory_deprovision_effects' THEN
+${compensationGuard}
+        IF NEW.event_id IS DISTINCT FROM OLD.event_id
+           OR NEW.local_user_id IS DISTINCT FROM OLD.local_user_id
+           OR NEW.effect_type IS DISTINCT FROM OLD.effect_type
+           OR NEW.org_id IS DISTINCT FROM OLD.org_id
+           OR NEW.before_active IS DISTINCT FROM OLD.before_active
+           OR NEW.after_active IS DISTINCT FROM OLD.after_active
+           OR NEW.grant_row_created IS DISTINCT FROM OLD.grant_row_created
+           OR NEW.access_generation_at_apply IS DISTINCT FROM OLD.access_generation_at_apply THEN
+          RAISE EXCEPTION 'directory_deprovision_effects identity fields are immutable';
+        END IF;
+      END IF;
+      RETURN NEW;
+    END;
+    $$ LANGUAGE plpgsql
+`
+}
+
+const IMMUTABILITY_FN_WITH_COMPENSATION_NOTE = immutabilityFunction(
+  COMPENSATED_EFFECT_IMMUTABILITY,
+)
+const IMMUTABILITY_FN_PRIOR = immutabilityFunction('')
+
+/**
+ * OPS-01: record cleanup of a superseded grant-row creation without claiming
+ * that the full deprovision event was restored.
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`
+    ALTER TABLE directory_deprovision_effects
+      ADD COLUMN IF NOT EXISTS compensation_note text
+  `.execute(db)
+  await sql`
+    ALTER TABLE directory_deprovision_effects
+      DROP CONSTRAINT IF EXISTS ddef_status_check
+  `.execute(db)
+  await sql`
+    ALTER TABLE directory_deprovision_effects
+      ADD CONSTRAINT ddef_status_check
+      CHECK (status IN ('applied','reversed','superseded','compensated'))
+  `.execute(db)
+  await sql`
+    ALTER TABLE directory_deprovision_effects
+      DROP CONSTRAINT IF EXISTS ddfx_compensation_scope_check
+  `.execute(db)
+  await sql`
+    ALTER TABLE directory_deprovision_effects
+      ADD CONSTRAINT ddfx_compensation_scope_check
+      CHECK (
+        (
+          status = 'compensated'
+          AND effect_type = 'grant_changed'
+          AND grant_row_created = TRUE
+          AND reversed_at IS NOT NULL
+          AND COALESCE(length(btrim(reversed_by)), 0) > 0
+          AND COALESCE(length(btrim(compensation_note)), 0) >= 8
+        )
+        OR (
+          status <> 'compensated'
+          AND compensation_note IS NULL
+        )
+      )
+  `.execute(db)
+  await sql.raw(IMMUTABILITY_FN_WITH_COMPENSATION_NOTE).execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  const witness = await sql`
+    SELECT 1 AS present
+      FROM directory_deprovision_effects
+     WHERE status = 'compensated'
+     LIMIT 1
+  `.execute(db)
+  if (witness.rows.length > 0) {
+    throw new Error(
+      'refusing to drop compensated effect status: OPS-01 compensation evidence exists',
+    )
+  }
+
+  await sql.raw(IMMUTABILITY_FN_PRIOR).execute(db)
+  await sql`
+    ALTER TABLE directory_deprovision_effects
+      DROP CONSTRAINT IF EXISTS ddfx_compensation_scope_check
+  `.execute(db)
+  await sql`
+    ALTER TABLE directory_deprovision_effects
+      DROP CONSTRAINT IF EXISTS ddef_status_check
+  `.execute(db)
+  await sql`
+    ALTER TABLE directory_deprovision_effects
+      ADD CONSTRAINT ddef_status_check
+      CHECK (status IN ('applied','reversed','superseded'))
+  `.execute(db)
+  await sql`
+    ALTER TABLE directory_deprovision_effects
+      DROP COLUMN IF EXISTS compensation_note
+  `.execute(db)
+}

--- a/packages/core-backend/src/directory/deprovision-evidence-api.ts
+++ b/packages/core-backend/src/directory/deprovision-evidence-api.ts
@@ -12,6 +12,7 @@ import {
   evaluateDeprovisionRestoreEligibility,
   type RestoreEffectView,
 } from './deprovision-restore'
+import { lockUsersForAccessGraphWrite } from './access-graph-mutex'
 
 export function readDeprovisionRuntimeFlags() {
   const enabled = ['true', '1', 'yes'].includes(
@@ -196,7 +197,8 @@ export async function listDeprovisionEffects(eventId: string) {
     `SELECT id, event_id, local_user_id, org_id, effect_type,
             before_active, after_active, grant_row_created,
             access_generation_at_apply,
-            status, reversed_at, created_at, updated_at
+            status, reversed_at, reversed_by, compensation_note,
+            created_at, updated_at
        FROM directory_deprovision_effects
       WHERE event_id = $1
       ORDER BY created_at ASC`,
@@ -229,6 +231,337 @@ function restoreError(code: string, message: string): Error {
   const error = new Error(message)
   ;(error as Error & { code?: string }).code = code
   return error
+}
+
+type CompensationEventRow = {
+  directory_account_id: string
+  globally_clear: boolean
+  id: string
+  integration_id: string
+  local_user_id: string
+  org_id: string
+  status: string
+}
+
+type CompensationEffectRow = {
+  effect_type: string
+  grant_row_created: boolean
+  id: string
+  status: string
+}
+
+/**
+ * Remove only the orphan deny row created by a superseded Rev 4.4 creation
+ * effect. This is deliberately separate from restore: it never changes the
+ * user or membership and it never runs automatically during supersede.
+ */
+export async function compensateSupersededDenyGrant(options: {
+  eventId: string
+  adminUserId: string
+  confirm?: boolean
+  note?: string
+}) {
+  if (options.confirm !== true) {
+    throw restoreError(
+      'COMPENSATION_CONFIRM_REQUIRED',
+      'orphan deny compensation requires confirm=true',
+    )
+  }
+  const note = options.note?.trim() ?? ''
+  if (note.length < 8) {
+    throw restoreError(
+      'COMPENSATION_NOTE_REQUIRED',
+      'orphan deny compensation requires a note (min 8 chars)',
+    )
+  }
+  const adminUserId = String(options.adminUserId ?? '').trim()
+  if (!adminUserId) {
+    throw restoreError(
+      'COMPENSATION_ACTOR_REQUIRED',
+      'orphan deny compensation requires an administrator identity',
+    )
+  }
+
+  const compensated = await transaction(async (client) => {
+    const ownerResult = await client.query(
+      `SELECT local_user_id
+         FROM directory_deprovision_events
+        WHERE id = $1::uuid`,
+      [options.eventId],
+    )
+    const eventOwner = String(ownerResult.rows[0]?.local_user_id ?? '')
+    if (!eventOwner) {
+      throw restoreError('EVENT_NOT_FOUND', 'Deprovision event not found')
+    }
+
+    const lockedUsers = await lockUsersForAccessGraphWrite(client, [eventOwner])
+    const user = lockedUsers.get(eventOwner)
+    if (!user) throw restoreError('USER_NOT_FOUND', 'User not found')
+
+    const eventResult = await client.query(
+      `SELECT id::text AS id,
+              org_id,
+              integration_id::text AS integration_id,
+              directory_account_id::text AS directory_account_id,
+              local_user_id,
+              globally_clear,
+              status
+         FROM directory_deprovision_events
+        WHERE id = $1::uuid
+        FOR UPDATE`,
+      [options.eventId],
+    )
+    const event = eventResult.rows[0] as CompensationEventRow | undefined
+    if (!event) throw restoreError('EVENT_NOT_FOUND', 'Deprovision event not found')
+    if (event.local_user_id !== eventOwner) {
+      throw restoreError(
+        'DRIFT_CONFLICT',
+        'Deprovision event owner changed while acquiring the user mutex',
+      )
+    }
+
+    const effectsResult = await client.query(
+      `SELECT id::text AS id, effect_type, grant_row_created, status
+         FROM directory_deprovision_effects
+        WHERE event_id = $1::uuid
+        ORDER BY id
+        FOR UPDATE`,
+      [options.eventId],
+    )
+    const effects = effectsResult.rows as CompensationEffectRow[]
+    const candidates = effects.filter(
+      (effect) =>
+        effect.effect_type === 'grant_changed'
+        && effect.grant_row_created === true,
+    )
+    if (candidates.length !== 1) {
+      throw restoreError(
+        'COMPENSATION_NOT_APPLICABLE',
+        'event does not contain exactly one grant-row creation effect',
+      )
+    }
+    const effect = candidates[0]
+
+    if (effect.status === 'compensated') {
+      const residual = await client.query(
+        `SELECT 1
+           FROM user_external_auth_grants
+          WHERE provider = 'dingtalk'
+            AND local_user_id = $1::text
+          LIMIT 1
+          FOR UPDATE`,
+        [event.local_user_id],
+      )
+      if (residual.rows[0]) {
+        throw restoreError(
+          'DRIFT_CONFLICT',
+          'compensated deny-row evidence conflicts with a live DingTalk grant row',
+        )
+      }
+      return {
+        event,
+        effectId: effect.id,
+        accessGeneration: user.accessGeneration,
+        alreadyCompensated: true,
+      }
+    }
+
+    if (event.status !== 'superseded' || effect.status !== 'superseded') {
+      throw restoreError(
+        'COMPENSATION_EVENT_NOT_SUPERSEDED',
+        'only superseded grant-row creation evidence can be compensated',
+      )
+    }
+    if (event.globally_clear !== true) {
+      throw restoreError(
+        'COMPENSATION_NOT_APPLICABLE',
+        'grant-row creation event was not globally clear',
+      )
+    }
+    if (user.isActive !== true || user.activationStatus !== 'activated') {
+      throw restoreError(
+        'COMPENSATION_USER_INACTIVE',
+        'local user must be active and activated before deny-row compensation',
+      )
+    }
+
+    const liveEvidence = await client.query(
+      `SELECT event.id
+         FROM directory_deprovision_events event
+        WHERE event.local_user_id = $1::text
+          AND event.status = 'applied'
+        LIMIT 1
+        FOR UPDATE`,
+      [event.local_user_id],
+    )
+    if (liveEvidence.rows[0]) {
+      throw restoreError(
+        'COMPENSATION_LIVE_EVIDENCE',
+        'an applied deprovision event still protects this user',
+      )
+    }
+    const liveEffect = await client.query(
+      `SELECT effect.id
+         FROM directory_deprovision_effects effect
+        WHERE effect.local_user_id = $1::text
+          AND effect.status = 'applied'
+        LIMIT 1
+        FOR UPDATE`,
+      [event.local_user_id],
+    )
+    if (liveEffect.rows[0]) {
+      throw restoreError(
+        'COMPENSATION_LIVE_EVIDENCE',
+        'an applied deprovision effect still protects this user',
+      )
+    }
+
+    let sourceResult: { rows: Array<Record<string, unknown>> }
+    try {
+      sourceResult = await client.query(
+        `SELECT account.is_active AS account_active,
+                integration.status AS integration_status,
+                link.link_status = 'linked' AS link_matches
+           FROM directory_accounts account
+           JOIN directory_integrations integration
+             ON integration.id = account.integration_id
+           JOIN directory_account_links link
+             ON link.directory_account_id = account.id
+            AND link.local_user_id = $3::text
+          WHERE account.id = $1::uuid
+            AND integration.id = $2::uuid
+          FOR SHARE OF account, integration, link NOWAIT`,
+        [
+          event.directory_account_id,
+          event.integration_id,
+          event.local_user_id,
+        ],
+      )
+    } catch (error) {
+      // Directory sync locks account rows before it reaches the canonical user
+      // mutex. Never wait here while holding that mutex: fail closed and let the
+      // operator retry after the source write commits.
+      if ((error as { code?: unknown })?.code === '55P03') {
+        throw restoreError(
+          'COMPENSATION_SOURCE_BUSY',
+          'the evidenced DingTalk source is being updated; retry compensation',
+        )
+      }
+      throw error
+    }
+    const source = sourceResult.rows[0] as
+      | {
+          account_active: boolean
+          integration_status: string
+          link_matches: boolean
+        }
+      | undefined
+    if (
+      source?.account_active !== true
+      || String(source.integration_status).toLowerCase() !== 'active'
+      || source.link_matches !== true
+    ) {
+      throw restoreError(
+        'COMPENSATION_SOURCE_INACTIVE',
+        'the evidenced DingTalk source must be active and linked before compensation',
+      )
+    }
+
+    const membershipResult = await client.query(
+      `SELECT COALESCE(is_active, TRUE) AS is_active
+         FROM user_orgs
+        WHERE user_id = $1::text
+          AND org_id = $2::text
+        FOR SHARE`,
+      [event.local_user_id, event.org_id],
+    )
+    if (membershipResult.rows[0]?.is_active !== true) {
+      throw restoreError(
+        'COMPENSATION_MEMBERSHIP_INACTIVE',
+        'the evidenced organization membership must be active before compensation',
+      )
+    }
+
+    const removed = await client.query(
+      `DELETE FROM user_external_auth_grants
+        WHERE provider = 'dingtalk'
+          AND local_user_id = $1::text
+          AND enabled = FALSE
+          AND granted_by = 'system:directory-deprovision'
+        RETURNING local_user_id`,
+      [event.local_user_id],
+    )
+    if (!removed.rows[0]) {
+      throw restoreError(
+        'DRIFT_CONFLICT',
+        'DingTalk deny grant row is missing, enabled, or has different provenance',
+      )
+    }
+
+    const effectResult = await client.query(
+      `UPDATE directory_deprovision_effects
+          SET status = 'compensated',
+              reversed_at = NOW(),
+              reversed_by = $3::text,
+              compensation_note = $4::text,
+              updated_at = NOW()
+        WHERE id = $1::uuid
+          AND event_id = $2::uuid
+          AND effect_type = 'grant_changed'
+          AND grant_row_created = TRUE
+          AND status = 'superseded'
+        RETURNING id`,
+      [effect.id, options.eventId, adminUserId, note],
+    )
+    if (!effectResult.rows[0]) {
+      throw restoreError(
+        'DRIFT_CONFLICT',
+        'grant-row creation effect changed before compensation',
+      )
+    }
+
+    const generationResult = await client.query(
+      `UPDATE users
+          SET access_generation = COALESCE(access_generation, 0) + 1,
+              updated_at = NOW()
+        WHERE id = $1::text
+          AND COALESCE(access_generation, 0) = $2::bigint
+        RETURNING access_generation`,
+      [event.local_user_id, user.accessGeneration],
+    )
+    const nextGeneration = Number(generationResult.rows[0]?.access_generation)
+    if (!Number.isFinite(nextGeneration)) {
+      throw restoreError(
+        'DRIFT_CONFLICT',
+        'access_generation changed before compensation completion',
+      )
+    }
+
+    return {
+      event,
+      effectId: effect.id,
+      accessGeneration: nextGeneration,
+      alreadyCompensated: false,
+    }
+  })
+
+  if (!compensated.alreadyCompensated) {
+    invalidateUserPerms(compensated.event.local_user_id)
+  }
+  return {
+    eventId: options.eventId,
+    effectId: compensated.effectId,
+    localUserId: compensated.event.local_user_id,
+    compensationMode: 'orphan_deny_creation' as const,
+    grantRow: compensated.alreadyCompensated
+      ? ('already_absent' as const)
+      : ('deleted' as const),
+    effectStatus: 'compensated' as const,
+    accessGeneration: compensated.accessGeneration,
+    alreadyCompensated: compensated.alreadyCompensated,
+    adminUserId,
+    note,
+  }
 }
 
 /**

--- a/packages/core-backend/src/routes/admin-directory.ts
+++ b/packages/core-backend/src/routes/admin-directory.ts
@@ -42,6 +42,7 @@ import {
 } from '../integrations/dingtalk/approval-card-config'
 import { refreshDirectoryIntegrationSchedule } from '../directory/directory-sync-scheduler'
 import {
+  compensateSupersededDenyGrant,
   listDeprovisionEffects,
   listDeprovisionEvents,
   previewDeprovisionForUser,
@@ -58,6 +59,7 @@ import { isValidDirectoryScheduleTimezone, resolveDirectoryScheduleTimezone } fr
 import { jsonError, jsonOk, parsePagination } from '../util/response'
 
 const logger = new Logger('AdminDirectoryRoutes')
+const UUID_SHAPE_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
 function normalizeAlertFilter(value: unknown): 'all' | 'pending' | 'acknowledged' {
   const normalized = typeof value === 'string' ? value.trim() : ''
@@ -1374,6 +1376,74 @@ export function adminDirectoryRouter(): Router {
     }
   }
 
+  async function compensateSupersededDenyGrantForRequest(
+    req: Request,
+    res: Response,
+  ): Promise<void> {
+    const adminUserId = await ensurePlatformAdmin(req, res)
+    if (!adminUserId) return
+    if (!UUID_SHAPE_RE.test(req.params.eventId)) {
+      jsonError(res, 400, 'COMPENSATION_EVENT_ID_INVALID', 'eventId must be a UUID')
+      return
+    }
+    try {
+      const result = await compensateSupersededDenyGrant({
+        eventId: req.params.eventId,
+        adminUserId,
+        confirm: req.body?.confirm === true,
+        note: typeof req.body?.note === 'string' ? req.body.note : undefined,
+      })
+      await auditLog({
+        actorId: adminUserId,
+        actorType: 'user',
+        action: 'update',
+        resourceType: 'directory-deprovision-event',
+        resourceId: req.params.eventId,
+        meta: {
+          compensationMode: result.compensationMode,
+          effectId: result.effectId,
+          localUserId: result.localUserId,
+          grantRow: result.grantRow,
+          alreadyCompensated: result.alreadyCompensated,
+          noteLength: result.note.length,
+        },
+      })
+      jsonOk(res, result)
+    } catch (error) {
+      const errorCode =
+        (error as { code?: string })?.code
+        || 'DEPROVISION_COMPENSATION_FAILED'
+      const status =
+        errorCode === 'EVENT_NOT_FOUND' || errorCode === 'USER_NOT_FOUND'
+          ? 404
+          : errorCode === 'COMPENSATION_CONFIRM_REQUIRED'
+              || errorCode === 'COMPENSATION_NOTE_REQUIRED'
+              || errorCode === 'COMPENSATION_ACTOR_REQUIRED'
+            ? 400
+            : errorCode === 'DRIFT_CONFLICT'
+                || errorCode === 'COMPENSATION_EVENT_NOT_SUPERSEDED'
+                || errorCode === 'COMPENSATION_NOT_APPLICABLE'
+                || errorCode === 'COMPENSATION_USER_INACTIVE'
+                || errorCode === 'COMPENSATION_SOURCE_INACTIVE'
+                || errorCode === 'COMPENSATION_SOURCE_BUSY'
+                || errorCode === 'COMPENSATION_MEMBERSHIP_INACTIVE'
+                || errorCode === 'COMPENSATION_LIVE_EVIDENCE'
+              ? 409
+              : 500
+      const responseCode = status === 500
+        ? 'DEPROVISION_COMPENSATION_FAILED'
+        : errorCode
+      jsonError(
+        res,
+        status,
+        responseCode,
+        status === 500
+          ? 'Deny-row compensation failed'
+          : (error as Error)?.message || 'Deny-row compensation failed',
+      )
+    }
+  }
+
   router.get('/deprovision/flags', async (req: Request, res: Response) => {
     const adminUserId = await ensurePlatformAdmin(req, res)
     if (!adminUserId) return
@@ -1475,6 +1545,13 @@ export function adminDirectoryRouter(): Router {
     '/deprovision-events/:eventId/force-reactivate',
     async (req: Request, res: Response) => {
       await restoreDeprovisionEventForRequest(req, res, 'admin_force')
+    },
+  )
+
+  router.post(
+    '/deprovision-events/:eventId/compensate-orphan-deny',
+    async (req: Request, res: Response) => {
+      await compensateSupersededDenyGrantForRequest(req, res)
     },
   )
 

--- a/packages/core-backend/tests/integration/directory-deprovision-compensation.db.test.ts
+++ b/packages/core-backend/tests/integration/directory-deprovision-compensation.db.test.ts
@@ -1,0 +1,608 @@
+import { randomUUID } from 'node:crypto'
+import { Client } from 'pg'
+import { afterAll, beforeEach, describe, expect, it } from 'vitest'
+import { __dingtalkOAuthInternalsForTests } from '../../src/auth/dingtalk-oauth'
+import { query, transaction } from '../../src/db/pg'
+import {
+  lockUsersForAccessGraphWrite,
+  supersedeDeprovisionEvidenceForAccessGraphWrite,
+} from '../../src/directory/access-graph-mutex'
+import {
+  compensateSupersededDenyGrant,
+} from '../../src/directory/deprovision-evidence-api'
+import { applyDirectoryDeprovisionCandidate } from '../../src/directory/deprovision-ledger'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const PREFIX = `ops01-compensation-${Date.now()}`
+
+type Seeded = {
+  accountId: string
+  eventId: string
+  integrationId: string
+  orgId: string
+  userId: string
+}
+
+async function cleanup(): Promise<void> {
+  await query(
+    `DELETE FROM directory_deprovision_events WHERE local_user_id LIKE $1`,
+    [`${PREFIX}-%`],
+  )
+  await query(
+    `DELETE FROM user_external_auth_grants WHERE local_user_id LIKE $1`,
+    [`${PREFIX}-%`],
+  )
+  await query(`DELETE FROM user_orgs WHERE user_id LIKE $1`, [`${PREFIX}-%`])
+  await query(`DELETE FROM directory_integrations WHERE org_id LIKE $1`, [
+    `${PREFIX}-%`,
+  ])
+  await query(`DELETE FROM users WHERE id LIKE $1`, [`${PREFIX}-%`])
+}
+
+async function seedAppliedCreationEvent(): Promise<Seeded> {
+  const orgId = `${PREFIX}-org-${randomUUID()}`
+  const userId = `${PREFIX}-user-${randomUUID()}`
+  const integration = await query<{ id: string }>(
+    `INSERT INTO directory_integrations (
+       name, corp_id, org_id, provider, status, default_deprovision_policy
+     ) VALUES ($1, $2, $3, 'dingtalk', 'active', 'mark_inactive')
+     RETURNING id::text AS id`,
+    [
+      `${PREFIX}-integration-${randomUUID()}`,
+      `${PREFIX}-corp-${randomUUID()}`,
+      orgId,
+    ],
+  )
+  const integrationId = integration.rows[0].id
+  const run = await query<{ id: string }>(
+    `INSERT INTO directory_sync_runs (
+       integration_id, status, triggered_by, trigger_source
+     ) VALUES ($1::uuid, 'success', 'test:ops01-compensation', 'manual')
+     RETURNING id::text AS id`,
+    [integrationId],
+  )
+  await query(
+    `INSERT INTO users (
+       id, password_hash, is_active, activation_status, access_generation
+     ) VALUES ($1, 'x', TRUE, 'activated', 7)`,
+    [userId],
+  )
+  await query(
+    `INSERT INTO user_orgs (user_id, org_id, is_active)
+     VALUES ($1, $2, TRUE)`,
+    [userId, orgId],
+  )
+  const account = await query<{ id: string }>(
+    `INSERT INTO directory_accounts (
+       integration_id, provider, external_user_id, external_key, name, is_active
+     ) VALUES ($1::uuid, 'dingtalk', $2, $3, 'OPS-01 Compensation', FALSE)
+     RETURNING id::text AS id`,
+    [
+      integrationId,
+      `${PREFIX}-external-${randomUUID()}`,
+      `dingtalk:${PREFIX}:${randomUUID()}`,
+    ],
+  )
+  const accountId = account.rows[0].id
+  await query(
+    `INSERT INTO directory_account_links (
+       directory_account_id, local_user_id, link_status
+     ) VALUES ($1::uuid, $2, 'linked')`,
+    [accountId, userId],
+  )
+
+  const applied = await transaction(async (client) =>
+    applyDirectoryDeprovisionCandidate(
+      {
+        query: async (statement, params) => {
+          const result = await client.query(statement, params)
+          return { rows: result.rows as Array<Record<string, unknown>> }
+        },
+      },
+      {
+        localUserId: userId,
+        orgId,
+        integrationId,
+        directoryAccountId: accountId,
+        runId: run.rows[0].id,
+        triggeredBy: 'test:ops01-compensation',
+        policy: 'mark_inactive',
+        write: true,
+      },
+    ),
+  )
+  if (!applied.eventId) throw new Error('deprovision event was not created')
+  return { accountId, eventId: applied.eventId, integrationId, orgId, userId }
+}
+
+async function reactivateAndSupersede(
+  seeded: Seeded,
+  options: { sourceActive?: boolean } = {},
+): Promise<void> {
+  await transaction(async (client) => {
+    const locked = await lockUsersForAccessGraphWrite(client, [seeded.userId])
+    if (!locked.has(seeded.userId)) throw new Error('test user vanished')
+    await client.query(
+      `UPDATE users
+          SET is_active = TRUE, activation_status = 'activated', updated_at = NOW()
+        WHERE id = $1::text`,
+      [seeded.userId],
+    )
+    await client.query(
+      `UPDATE user_orgs SET is_active = TRUE
+        WHERE user_id = $1::text AND org_id = $2::text`,
+      [seeded.userId, seeded.orgId],
+    )
+    if (options.sourceActive !== false) {
+      await client.query(
+        `UPDATE directory_accounts SET is_active = TRUE
+          WHERE id = $1::uuid`,
+        [seeded.accountId],
+      )
+    }
+    await supersedeDeprovisionEvidenceForAccessGraphWrite(client, {
+      userIds: [seeded.userId],
+      actorId: 'test:manual-rehire',
+      reason: 'test access graph reactivation superseded deprovision evidence',
+    })
+  })
+}
+
+async function waitForCompensationWaiters(
+  holderPid: number,
+  expected: number,
+  timeoutMs = 8_000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    const waiting = await query<{ blocked: number; rooted: number }>(
+      `SELECT
+         count(*) FILTER (
+           WHERE wait_event_type = 'Lock'
+             AND query ILIKE '%activation_status%'
+             AND query ILIKE '%FROM users%'
+             AND query ILIKE '%FOR UPDATE%'
+         )::int AS blocked,
+         count(*) FILTER (
+           WHERE $1 = ANY(pg_blocking_pids(pid))
+             AND query ILIKE '%activation_status%'
+             AND query ILIKE '%FROM users%'
+             AND query ILIKE '%FOR UPDATE%'
+         )::int AS rooted
+       FROM pg_stat_activity
+       WHERE datname = current_database()
+         AND state = 'active'
+         AND pid <> pg_backend_pid()`,
+      [holderPid],
+    )
+    if (
+      (waiting.rows[0]?.blocked ?? 0) >= expected
+      && (waiting.rows[0]?.rooted ?? 0) >= 1
+    ) {
+      return
+    }
+    await new Promise((resolve) => setTimeout(resolve, 20))
+  }
+  throw new Error(
+    `timed out waiting for ${expected} compensation transaction(s) behind holder ${holderPid}`,
+  )
+}
+
+describeIfDatabase('OPS-01 superseded deny-row compensation (real DB)', () => {
+  beforeEach(cleanup)
+  afterAll(cleanup)
+
+  it('rejects an empty compensation actor before opening a transaction', async () => {
+    await expect(
+      compensateSupersededDenyGrant({
+        eventId: randomUUID(),
+        adminUserId: '   ',
+        confirm: true,
+        note: 'owner verified safe cleanup',
+      }),
+    ).rejects.toMatchObject({ code: 'COMPENSATION_ACTOR_REQUIRED' })
+  })
+
+  it('closes the deprovision -> supersede -> compensate -> OAuth chain without a full restore', async () => {
+    const seeded = await seedAppliedCreationEvent()
+    await reactivateAndSupersede(seeded)
+
+    const before = await query<{
+      access_generation: string
+      effect_status: string
+      event_status: string
+      grant_enabled: boolean
+      grant_row_created: boolean
+    }>(
+      `SELECT users.access_generation::text,
+              event.status AS event_status,
+              effect.status AS effect_status,
+              effect.grant_row_created,
+              grant_row.enabled AS grant_enabled
+         FROM users
+         JOIN directory_deprovision_events event ON event.local_user_id = users.id
+         JOIN directory_deprovision_effects effect ON effect.event_id = event.id
+         JOIN user_external_auth_grants grant_row
+           ON grant_row.local_user_id = users.id
+          AND grant_row.provider = 'dingtalk'
+        WHERE event.id = $1::uuid AND effect.effect_type = 'grant_changed'`,
+      [seeded.eventId],
+    )
+    expect(before.rows[0]).toEqual({
+      access_generation: '9',
+      event_status: 'superseded',
+      effect_status: 'superseded',
+      grant_row_created: true,
+      grant_enabled: false,
+    })
+
+    const result = await compensateSupersededDenyGrant({
+      eventId: seeded.eventId,
+      adminUserId: 'admin-test',
+      confirm: true,
+      note: 'owner verified safe cleanup',
+    })
+    expect(result).toMatchObject({
+      alreadyCompensated: false,
+      grantRow: 'deleted',
+      effectStatus: 'compensated',
+      accessGeneration: 10,
+    })
+    const ledger = await query<{
+      access_generation: string
+      compensation_note: string
+      effect_status: string
+      event_status: string
+      reversed_by: string
+    }>(
+      `SELECT users.access_generation::text,
+              event.status AS event_status,
+              effect.status AS effect_status,
+              effect.compensation_note,
+              effect.reversed_by
+         FROM users
+         JOIN directory_deprovision_events event ON event.local_user_id = users.id
+         JOIN directory_deprovision_effects effect ON effect.event_id = event.id
+        WHERE event.id = $1::uuid AND effect.effect_type = 'grant_changed'`,
+      [seeded.eventId],
+    )
+    expect(ledger.rows[0]).toEqual({
+      access_generation: '10',
+      compensation_note: 'owner verified safe cleanup',
+      event_status: 'superseded',
+      effect_status: 'compensated',
+      reversed_by: 'admin-test',
+    })
+    expect(
+      (
+        await query(
+          `SELECT 1 FROM user_external_auth_grants
+            WHERE provider = 'dingtalk' AND local_user_id = $1`,
+          [seeded.userId],
+        )
+      ).rows,
+    ).toHaveLength(0)
+
+    await __dingtalkOAuthInternalsForTests.ensureGrant(seeded.userId)
+    const oauthGrant = await query<{ enabled: boolean }>(
+      `SELECT enabled FROM user_external_auth_grants
+        WHERE provider = 'dingtalk' AND local_user_id = $1`,
+      [seeded.userId],
+    )
+    expect(oauthGrant.rows).toEqual([{ enabled: true }])
+  })
+
+  it('is idempotent after a committed compensation and does not advance generation twice', async () => {
+    const seeded = await seedAppliedCreationEvent()
+    await reactivateAndSupersede(seeded)
+    await compensateSupersededDenyGrant({
+      eventId: seeded.eventId,
+      adminUserId: 'admin-test',
+      confirm: true,
+      note: 'first owner compensation',
+    })
+
+    const retry = await compensateSupersededDenyGrant({
+      eventId: seeded.eventId,
+      adminUserId: 'admin-test',
+      confirm: true,
+      note: 'retry after response loss',
+    })
+    expect(retry).toMatchObject({
+      alreadyCompensated: true,
+      grantRow: 'already_absent',
+      accessGeneration: 10,
+    })
+  })
+
+  it('rejects an enabled grant without changing the ledger', async () => {
+    const seeded = await seedAppliedCreationEvent()
+    await reactivateAndSupersede(seeded)
+    await query(
+      `UPDATE user_external_auth_grants
+          SET enabled = TRUE
+        WHERE provider = 'dingtalk' AND local_user_id = $1`,
+      [seeded.userId],
+    )
+
+    await expect(
+      compensateSupersededDenyGrant({
+        eventId: seeded.eventId,
+        adminUserId: 'admin-test',
+        confirm: true,
+        note: 'owner verified safe cleanup',
+      }),
+    ).rejects.toMatchObject({ code: 'DRIFT_CONFLICT' })
+    const state = await query<{
+      access_generation: string
+      effect_status: string
+      enabled: boolean
+      granted_by: string
+    }>(
+      `SELECT users.access_generation::text,
+              effect.status AS effect_status,
+              grant_row.enabled,
+              grant_row.granted_by
+         FROM users
+         JOIN directory_deprovision_effects effect ON effect.local_user_id = users.id
+         JOIN user_external_auth_grants grant_row
+           ON grant_row.local_user_id = users.id
+          AND grant_row.provider = 'dingtalk'
+        WHERE users.id = $1 AND effect.effect_type = 'grant_changed'`,
+      [seeded.userId],
+    )
+    expect(state.rows[0]).toEqual({
+      access_generation: '9',
+      effect_status: 'superseded',
+      enabled: true,
+      granted_by: 'system:directory-deprovision',
+    })
+  })
+
+  it('rejects a disabled grant with different provenance without changing the ledger', async () => {
+    const seeded = await seedAppliedCreationEvent()
+    await reactivateAndSupersede(seeded)
+    await query(
+      `UPDATE user_external_auth_grants
+          SET granted_by = 'admin:later-write'
+        WHERE provider = 'dingtalk' AND local_user_id = $1`,
+      [seeded.userId],
+    )
+
+    await expect(
+      compensateSupersededDenyGrant({
+        eventId: seeded.eventId,
+        adminUserId: 'admin-test',
+        confirm: true,
+        note: 'owner verified safe cleanup',
+      }),
+    ).rejects.toMatchObject({ code: 'DRIFT_CONFLICT' })
+    const state = await query<{
+      access_generation: string
+      effect_status: string
+      enabled: boolean
+      granted_by: string
+    }>(
+      `SELECT users.access_generation::text,
+              effect.status AS effect_status,
+              grant_row.enabled,
+              grant_row.granted_by
+         FROM users
+         JOIN directory_deprovision_effects effect ON effect.local_user_id = users.id
+         JOIN user_external_auth_grants grant_row
+           ON grant_row.local_user_id = users.id
+          AND grant_row.provider = 'dingtalk'
+        WHERE users.id = $1 AND effect.effect_type = 'grant_changed'`,
+      [seeded.userId],
+    )
+    expect(state.rows[0]).toEqual({
+      access_generation: '9',
+      effect_status: 'superseded',
+      enabled: false,
+      granted_by: 'admin:later-write',
+    })
+  })
+
+  it('requires the exact evidenced directory source to be active and linked', async () => {
+    const seeded = await seedAppliedCreationEvent()
+    await reactivateAndSupersede(seeded, { sourceActive: false })
+
+    await expect(
+      compensateSupersededDenyGrant({
+        eventId: seeded.eventId,
+        adminUserId: 'admin-test',
+        confirm: true,
+        note: 'owner verified safe cleanup',
+      }),
+    ).rejects.toMatchObject({ code: 'COMPENSATION_SOURCE_INACTIVE' })
+    expect(
+      (
+        await query(
+          `SELECT enabled FROM user_external_auth_grants
+            WHERE provider = 'dingtalk' AND local_user_id = $1`,
+          [seeded.userId],
+        )
+      ).rows,
+    ).toEqual([{ enabled: false }])
+  })
+
+  it('fails fast when directory sync holds the source row instead of inverting the user/source lock order', async () => {
+    const seeded = await seedAppliedCreationEvent()
+    await reactivateAndSupersede(seeded)
+    const holder = new Client({ connectionString: process.env.DATABASE_URL })
+    await holder.connect()
+    let holderReleased = false
+    try {
+      await holder.query('BEGIN')
+      await holder.query(
+        `SELECT id FROM directory_accounts WHERE id = $1::uuid FOR UPDATE`,
+        [seeded.accountId],
+      )
+
+      const startedAt = Date.now()
+      const release = new Promise<void>((resolve, reject) => {
+        setTimeout(() => {
+          holder
+            .query('ROLLBACK')
+            .then(() => {
+              holderReleased = true
+              resolve()
+            })
+            .catch(reject)
+        }, 500)
+      })
+      const outcome = await compensateSupersededDenyGrant({
+        eventId: seeded.eventId,
+        adminUserId: 'admin-test',
+        confirm: true,
+        note: 'owner verified safe cleanup',
+      }).then(
+        (value) => ({ value, error: undefined, elapsedMs: Date.now() - startedAt }),
+        (error: unknown) => ({ value: undefined, error, elapsedMs: Date.now() - startedAt }),
+      )
+      await release
+
+      expect(outcome.error).toMatchObject({ code: 'COMPENSATION_SOURCE_BUSY' })
+      expect(outcome.value).toBeUndefined()
+      expect(outcome.elapsedMs).toBeLessThan(400)
+      const state = await query<{
+        access_generation: string
+        effect_status: string
+        enabled: boolean
+      }>(
+        `SELECT users.access_generation::text,
+                effect.status AS effect_status,
+                grant_row.enabled
+           FROM users
+           JOIN directory_deprovision_effects effect
+             ON effect.local_user_id = users.id
+            AND effect.effect_type = 'grant_changed'
+           JOIN user_external_auth_grants grant_row
+             ON grant_row.local_user_id = users.id
+            AND grant_row.provider = 'dingtalk'
+          WHERE users.id = $1`,
+        [seeded.userId],
+      )
+      expect(state.rows[0]).toEqual({
+        access_generation: '9',
+        effect_status: 'superseded',
+        enabled: false,
+      })
+    } finally {
+      if (!holderReleased) {
+        await holder.query('ROLLBACK')
+      }
+      await holder.end()
+    }
+  })
+
+  it('requires an active membership in the evidenced organization', async () => {
+    const seeded = await seedAppliedCreationEvent()
+    await reactivateAndSupersede(seeded)
+    await query(
+      `UPDATE user_orgs SET is_active = FALSE
+        WHERE user_id = $1 AND org_id = $2`,
+      [seeded.userId, seeded.orgId],
+    )
+
+    await expect(
+      compensateSupersededDenyGrant({
+        eventId: seeded.eventId,
+        adminUserId: 'admin-test',
+        confirm: true,
+        note: 'owner verified safe cleanup',
+      }),
+    ).rejects.toMatchObject({ code: 'COMPENSATION_MEMBERSHIP_INACTIVE' })
+    const effect = await query<{ status: string }>(
+      `SELECT status FROM directory_deprovision_effects
+        WHERE event_id = $1::uuid AND effect_type = 'grant_changed'`,
+      [seeded.eventId],
+    )
+    expect(effect.rows).toEqual([{ status: 'superseded' }])
+  })
+
+  it('refuses cleanup while another applied deprovision event protects the user', async () => {
+    const seeded = await seedAppliedCreationEvent()
+    await reactivateAndSupersede(seeded)
+    const liveEvent = await query<{ id: string }>(
+      `INSERT INTO directory_deprovision_events (
+         org_id, integration_id, directory_account_id, local_user_id,
+         run_id, triggered_by, event_origin, link_witness_account_id,
+         link_witness_local_user_id, policy, globally_clear,
+         access_generation_at_apply, status
+       )
+       SELECT org_id, integration_id, directory_account_id, local_user_id,
+              run_id, 'test:live-veto', event_origin, link_witness_account_id,
+              link_witness_local_user_id, policy, globally_clear,
+              9, 'applied'
+         FROM directory_deprovision_events
+        WHERE id = $1::uuid
+       RETURNING id::text AS id`,
+      [seeded.eventId],
+    )
+    await query(
+      `INSERT INTO directory_deprovision_effects (
+         event_id, local_user_id, effect_type, org_id,
+         before_active, after_active, grant_row_created,
+         access_generation_at_apply, status
+       ) VALUES ($1::uuid, $2, 'user_changed', NULL,
+                 TRUE, FALSE, FALSE, 9, 'applied')`,
+      [liveEvent.rows[0].id, seeded.userId],
+    )
+
+    await expect(
+      compensateSupersededDenyGrant({
+        eventId: seeded.eventId,
+        adminUserId: 'admin-test',
+        confirm: true,
+        note: 'owner verified safe cleanup',
+      }),
+    ).rejects.toMatchObject({ code: 'COMPENSATION_LIVE_EVIDENCE' })
+    expect(
+      (
+        await query(
+          `SELECT enabled FROM user_external_auth_grants
+            WHERE provider = 'dingtalk' AND local_user_id = $1`,
+          [seeded.userId],
+        )
+      ).rows,
+    ).toEqual([{ enabled: false }])
+  })
+
+  it('queues both concurrent calls behind the user mutex and applies one generation change', async () => {
+    const seeded = await seedAppliedCreationEvent()
+    await reactivateAndSupersede(seeded)
+    const holder = new Client({ connectionString: process.env.DATABASE_URL })
+    await holder.connect()
+    try {
+      await holder.query('BEGIN')
+      const pid = await holder.query<{ pid: number }>('SELECT pg_backend_pid() AS pid')
+      await holder.query(`SELECT id FROM users WHERE id = $1 FOR UPDATE`, [seeded.userId])
+
+      const calls = Array.from({ length: 2 }, (_, index) =>
+        compensateSupersededDenyGrant({
+          eventId: seeded.eventId,
+          adminUserId: `admin-${index + 1}`,
+          confirm: true,
+          note: `concurrent owner compensation ${index + 1}`,
+        }),
+      )
+      await waitForCompensationWaiters(pid.rows[0].pid, 2)
+      await holder.query('COMMIT')
+      const results = await Promise.all(calls)
+
+      expect(results.filter((result) => !result.alreadyCompensated)).toHaveLength(1)
+      expect(results.filter((result) => result.alreadyCompensated)).toHaveLength(1)
+      expect(new Set(results.map((result) => result.accessGeneration))).toEqual(
+        new Set([10]),
+      )
+    } finally {
+      try {
+        await holder.query('ROLLBACK')
+      } catch {
+        // The holder may already be committed.
+      }
+      await holder.end()
+    }
+  })
+})

--- a/packages/core-backend/tests/integration/directory-deprovision-ledger-schema.db.test.ts
+++ b/packages/core-backend/tests/integration/directory-deprovision-ledger-schema.db.test.ts
@@ -20,6 +20,10 @@ import {
   down as grantRowCreatedDown,
   up as grantRowCreatedUp,
 } from '../../src/db/migrations/zzzz20260808090000_deprovision_effect_grant_row_created'
+import {
+  down as compensationStatusDown,
+  up as compensationStatusUp,
+} from '../../src/db/migrations/zzzz20260810100000_deprovision_effect_compensation_status'
 
 const dbUrl = process.env.DATABASE_URL
 const describeDb = dbUrl ? describe : describe.skip
@@ -231,6 +235,137 @@ describeDb('directory deprovision ledger hardening (real DB, isolated schema)', 
     await sql`DELETE FROM directory_deprovision_effects WHERE grant_row_created = TRUE`.execute(db)
     await grantRowCreatedDown(db)
     expect(await columnExists('directory_deprovision_effects', 'grant_row_created')).toBe(false)
+  })
+
+  it('OPS-01 compensation status replays and refuses downgrade while compensation evidence exists', async () => {
+    await hardenedLedgerUp(db)
+    await grantRowCreatedUp(db)
+    await compensationStatusUp(db)
+    await compensationStatusUp(db)
+    expect(
+      await constraintDefinition('directory_deprovision_effects', 'ddef_status_check'),
+    ).toMatch(/compensated/)
+    expect(await columnDataType('directory_deprovision_effects', 'compensation_note')).toBe('text')
+    expect(
+      await constraintDefinition(
+        'directory_deprovision_effects',
+        'ddfx_compensation_scope_check',
+      ),
+    ).toMatch(/grant_row_created/)
+
+    const authority = await seedAuthority()
+    const eventId = await insertValidEvent(authority)
+    await expect(
+      sql`
+        INSERT INTO directory_deprovision_effects (
+          event_id, local_user_id, org_id, effect_type, before_active,
+          after_active, grant_row_created, access_generation_at_apply, status,
+          reversed_at, reversed_by, compensation_note
+        ) VALUES (
+          ${eventId}, ${authority.userId}, ${authority.orgId}, 'membership_changed',
+          TRUE, FALSE, FALSE, 1, 'compensated', NOW(), 'admin-test',
+          'invalid compensation target'
+        )
+      `.execute(db),
+    ).rejects.toThrow(/ddfx_compensation_scope_check/)
+    await sql`
+      INSERT INTO directory_deprovision_effects (
+        event_id, local_user_id, org_id, effect_type, before_active,
+        after_active, grant_row_created, access_generation_at_apply, status,
+        reversed_at, reversed_by, compensation_note
+      ) VALUES (
+        ${eventId}, ${authority.userId}, NULL, 'grant_changed',
+        FALSE, FALSE, TRUE, 1, 'compensated', NOW(), 'admin-test',
+        'owner verified cleanup'
+      )
+    `.execute(db)
+    await expect(
+      sql`
+        UPDATE directory_deprovision_effects
+           SET compensation_note = 'tampered owner note'
+         WHERE event_id = ${eventId}
+      `.execute(db),
+    ).rejects.toThrow(/compensated deprovision effect evidence is immutable/)
+    await expect(
+      sql`
+        UPDATE directory_deprovision_effects
+           SET reversed_by = 'different-admin'
+         WHERE event_id = ${eventId}
+      `.execute(db),
+    ).rejects.toThrow(/compensated deprovision effect evidence is immutable/)
+    await expect(
+      sql`
+        UPDATE directory_deprovision_effects
+           SET reversed_at = NOW() + INTERVAL '1 hour'
+         WHERE event_id = ${eventId}
+      `.execute(db),
+    ).rejects.toThrow(/compensated deprovision effect evidence is immutable/)
+    await expect(
+      sql`
+        UPDATE directory_deprovision_effects
+           SET status = 'superseded'
+         WHERE event_id = ${eventId}
+      `.execute(db),
+    ).rejects.toThrow(/compensated deprovision effect evidence is immutable/)
+
+    const secondEventId = await insertValidEvent(authority)
+    await expect(
+      sql`
+        INSERT INTO directory_deprovision_effects (
+          event_id, local_user_id, org_id, effect_type, before_active,
+          after_active, grant_row_created, access_generation_at_apply, status,
+          reversed_at, reversed_by, compensation_note
+        ) VALUES (
+          ${secondEventId}, ${authority.userId}, NULL, 'grant_changed',
+          FALSE, FALSE, TRUE, 1, 'compensated', NOW(), '   ',
+          'owner verified cleanup'
+        )
+      `.execute(db),
+    ).rejects.toThrow(/ddfx_compensation_scope_check/)
+
+    const nullActorEventId = await insertValidEvent(authority)
+    await expect(
+      sql`
+        INSERT INTO directory_deprovision_effects (
+          event_id, local_user_id, org_id, effect_type, before_active,
+          after_active, grant_row_created, access_generation_at_apply, status,
+          reversed_at, reversed_by, compensation_note
+        ) VALUES (
+          ${nullActorEventId}, ${authority.userId}, NULL, 'grant_changed',
+          FALSE, FALSE, TRUE, 1, 'compensated', NOW(), NULL,
+          'owner verified cleanup'
+        )
+      `.execute(db),
+    ).rejects.toThrow(/ddfx_compensation_scope_check/)
+
+    const nullNoteEventId = await insertValidEvent(authority)
+    await expect(
+      sql`
+        INSERT INTO directory_deprovision_effects (
+          event_id, local_user_id, org_id, effect_type, before_active,
+          after_active, grant_row_created, access_generation_at_apply, status,
+          reversed_at, reversed_by, compensation_note
+        ) VALUES (
+          ${nullNoteEventId}, ${authority.userId}, NULL, 'grant_changed',
+          FALSE, FALSE, TRUE, 1, 'compensated', NOW(), 'admin-test', NULL
+        )
+      `.execute(db),
+    ).rejects.toThrow(/ddfx_compensation_scope_check/)
+
+    await expect(compensationStatusDown(db)).rejects.toThrow(
+      /refusing to drop compensated effect status/,
+    )
+    expect(
+      await constraintDefinition('directory_deprovision_effects', 'ddef_status_check'),
+    ).toMatch(/compensated/)
+
+    await sql`DELETE FROM directory_deprovision_effects WHERE event_id = ${eventId}`.execute(db)
+    await compensationStatusDown(db)
+    expect(
+      await constraintDefinition('directory_deprovision_effects', 'ddef_status_check'),
+    ).not.toMatch(/compensated/)
+    expect(await columnExists('directory_deprovision_effects', 'compensation_note')).toBe(false)
+    await compensationStatusUp(db)
   })
 
   it('upgrades the weak scaffold to the exact typed FK/check vocabulary', async () => {

--- a/packages/core-backend/tests/unit/admin-directory-routes.test.ts
+++ b/packages/core-backend/tests/unit/admin-directory-routes.test.ts
@@ -9,6 +9,8 @@ import { DirectorySyncInProgressError } from '../../src/directory/directory-sync
 // job. Importing it directly here pins its actual acceptance semantics, independent of any route-level mock.
 import { SimpleCronExpression } from '../../src/services/SchedulerService'
 
+const COMPENSATION_EVENT_ID = '11111111-1111-4111-8111-111111111111'
+
 const rbacMocks = vi.hoisted(() => ({
   isRbacAdmin: vi.fn(),
 }))
@@ -52,6 +54,7 @@ const workNotificationMocks = vi.hoisted(() => ({
 }))
 
 const deprovisionMocks = vi.hoisted(() => ({
+  compensateSupersededDenyGrant: vi.fn(),
   listDeprovisionEffects: vi.fn(),
   listDeprovisionEvents: vi.fn(),
   previewDeprovisionForUser: vi.fn(),
@@ -139,6 +142,7 @@ vi.mock('../../src/integrations/dingtalk/approval-card-config', () => ({
 }))
 
 vi.mock('../../src/directory/deprovision-evidence-api', () => ({
+  compensateSupersededDenyGrant: deprovisionMocks.compensateSupersededDenyGrant,
   listDeprovisionEffects: deprovisionMocks.listDeprovisionEffects,
   listDeprovisionEvents: deprovisionMocks.listDeprovisionEvents,
   previewDeprovisionForUser: deprovisionMocks.previewDeprovisionForUser,
@@ -249,6 +253,7 @@ describe('adminDirectoryRouter', () => {
     approvalCardConfigMocks.generateApprovalCardLinkSecret.mockReset()
     approvalCardConfigMocks.getApprovalCardConfigStatus.mockReset()
     approvalCardConfigMocks.saveApprovalCardPublicAppUrl.mockReset()
+    deprovisionMocks.compensateSupersededDenyGrant.mockReset()
     deprovisionMocks.listDeprovisionEffects.mockReset()
     deprovisionMocks.listDeprovisionEvents.mockReset()
     deprovisionMocks.previewDeprovisionForUser.mockReset()
@@ -354,6 +359,168 @@ describe('adminDirectoryRouter', () => {
       note: 'confirmed by owner',
     })
     expect(auditMocks.auditLog).toHaveBeenCalledTimes(2)
+  })
+
+  it('maps orphan deny compensation drift to 409 without auditing success', async () => {
+    deprovisionMocks.compensateSupersededDenyGrant.mockRejectedValue(
+      Object.assign(new Error('grant provenance changed'), {
+        code: 'DRIFT_CONFLICT',
+      }),
+    )
+
+    const response = await invokeRoute(
+      'post',
+      '/deprovision-events/:eventId/compensate-orphan-deny',
+      {
+        params: { eventId: COMPENSATION_EVENT_ID },
+        body: { confirm: true, note: 'owner verified drift' },
+        user: { id: 'admin-1', role: 'admin' },
+      },
+    )
+
+    expect(response.statusCode).toBe(409)
+    expect(response.body).toMatchObject({
+      ok: false,
+      error: { code: 'DRIFT_CONFLICT' },
+    })
+    expect(auditMocks.auditLog).not.toHaveBeenCalled()
+  })
+
+  it('maps a busy directory source to a retryable 409 without database details', async () => {
+    deprovisionMocks.compensateSupersededDenyGrant.mockRejectedValue(
+      Object.assign(new Error('the evidenced DingTalk source is being updated; retry compensation'), {
+        code: 'COMPENSATION_SOURCE_BUSY',
+      }),
+    )
+
+    const response = await invokeRoute(
+      'post',
+      '/deprovision-events/:eventId/compensate-orphan-deny',
+      {
+        params: { eventId: COMPENSATION_EVENT_ID },
+        body: { confirm: true, note: 'owner verified busy source' },
+        user: { id: 'admin-1', role: 'admin' },
+      },
+    )
+
+    expect(response.statusCode).toBe(409)
+    expect(response.body).toMatchObject({
+      ok: false,
+      error: {
+        code: 'COMPENSATION_SOURCE_BUSY',
+        message: 'the evidenced DingTalk source is being updated; retry compensation',
+      },
+    })
+    expect(JSON.stringify(response.body)).not.toMatch(/55P03|lock_not_available/i)
+    expect(auditMocks.auditLog).not.toHaveBeenCalled()
+  })
+
+  it('does not expose database details from an unexpected compensation failure', async () => {
+    deprovisionMocks.compensateSupersededDenyGrant.mockRejectedValue(
+      Object.assign(
+        new Error(
+          'duplicate key value violates unique constraint user_external_auth_grants_pkey DETAIL: connection localhost:5432',
+        ),
+        { code: '23505' },
+      ),
+    )
+
+    const response = await invokeRoute(
+      'post',
+      '/deprovision-events/:eventId/compensate-orphan-deny',
+      {
+        params: { eventId: COMPENSATION_EVENT_ID },
+        body: { confirm: true, note: 'owner verified failure' },
+        user: { id: 'admin-1', role: 'admin' },
+      },
+    )
+
+    expect(response.statusCode).toBe(500)
+    expect(response.body).toMatchObject({
+      ok: false,
+      error: {
+        code: 'DEPROVISION_COMPENSATION_FAILED',
+        message: 'Deny-row compensation failed',
+      },
+    })
+    expect(JSON.stringify(response.body)).not.toMatch(
+      /23505|duplicate key|DETAIL|localhost|5432|user_external_auth_grants/i,
+    )
+    expect(auditMocks.auditLog).not.toHaveBeenCalled()
+  })
+
+  it('rejects a malformed compensation event id before the service or audit', async () => {
+    const response = await invokeRoute(
+      'post',
+      '/deprovision-events/:eventId/compensate-orphan-deny',
+      {
+        params: { eventId: 'not-a-uuid' },
+        body: { confirm: true, note: 'owner verified cleanup' },
+        user: { id: 'admin-1', role: 'admin' },
+      },
+    )
+
+    expect(response.statusCode).toBe(400)
+    expect(response.body).toMatchObject({
+      ok: false,
+      error: {
+        code: 'COMPENSATION_EVENT_ID_INVALID',
+        message: 'eventId must be a UUID',
+      },
+    })
+    expect(deprovisionMocks.compensateSupersededDenyGrant).not.toHaveBeenCalled()
+    expect(auditMocks.auditLog).not.toHaveBeenCalled()
+  })
+
+  it('runs confirmed orphan deny compensation and audits only values-free metadata', async () => {
+    deprovisionMocks.compensateSupersededDenyGrant.mockResolvedValue({
+      eventId: COMPENSATION_EVENT_ID,
+      effectId: 'effect-1',
+      localUserId: 'user-1',
+      compensationMode: 'orphan_deny_creation',
+      grantRow: 'deleted',
+      effectStatus: 'compensated',
+      accessGeneration: 8,
+      alreadyCompensated: false,
+      adminUserId: 'admin-1',
+      note: 'owner verified cleanup',
+    })
+
+    const response = await invokeRoute(
+      'post',
+      '/deprovision-events/:eventId/compensate-orphan-deny',
+      {
+        params: { eventId: COMPENSATION_EVENT_ID },
+        body: { confirm: true, note: 'owner verified cleanup' },
+        user: { id: 'admin-1', role: 'admin' },
+      },
+    )
+
+    expect(response.statusCode).toBe(200)
+    expect(deprovisionMocks.compensateSupersededDenyGrant).toHaveBeenCalledWith({
+      eventId: COMPENSATION_EVENT_ID,
+      adminUserId: 'admin-1',
+      confirm: true,
+      note: 'owner verified cleanup',
+    })
+    expect(auditMocks.auditLog).toHaveBeenCalledWith({
+      actorId: 'admin-1',
+      actorType: 'user',
+      action: 'update',
+      resourceType: 'directory-deprovision-event',
+      resourceId: COMPENSATION_EVENT_ID,
+      meta: {
+        compensationMode: 'orphan_deny_creation',
+        effectId: 'effect-1',
+        localUserId: 'user-1',
+        grantRow: 'deleted',
+        alreadyCompensated: false,
+        noteLength: 22,
+      },
+    })
+    expect(JSON.stringify(auditMocks.auditLog.mock.calls[0])).not.toContain(
+      'owner verified cleanup',
+    )
   })
 
   it('lists integration-scoped events and rejects an unknown status before querying', async () => {

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -227,6 +227,10 @@ export default defineConfig({
       // wired into the approval real-DB step (both points asserted by
       // scripts/ops/directory-grant-table-ci-wiring.test.mjs).
       'tests/integration/directory-deprovision-grant-table.db.test.ts',
+      // OPS-01 superseded creation-effect compensation: full deprovision/OAuth chain,
+      // provenance drift, live-evidence veto, idempotency, and a two-connection user-mutex
+      // barrier. Wired beside the grant-table suite and pinned by the same wiring contract.
+      'tests/integration/directory-deprovision-compensation.db.test.ts',
       // T3 activation source read serialises against a concurrent integration deactivation
       // (post-merge review P1, FOR SHARE). Constructed pg_locks race — meaningless without a DB.
       // DATABASE_URL-gated; excluded so the no-DB job cannot skip-green; whole-file wired into

--- a/plugins/plugin-integration-core/lib/sealed-export/vectors/s6a-package-provenance-pins.json
+++ b/plugins/plugin-integration-core/lib/sealed-export/vectors/s6a-package-provenance-pins.json
@@ -86,6 +86,6 @@
     "s6aAcceptancePs51Test": "835c7c6ce943d82e0378a40a27c7fd1e8b79b526faa8ca4c8066e4231a4bfb0f",
     "s6aProductRuntimeTest": "de978adafa8b89772cefa921c2051f434bf346bf5c2978bef3424ee70f51ba3f",
     "multitableOnpremPackageBuild": "463c7d73c6c7f2d1b6cdf0820d7a06974a9c463dd5e98bbbaf1c996e1dc4ed99",
-    "pluginTestsWorkflow": "2bf3d80bc1f5c193638fb037cdf8141d7d403e18a9b2e3f8bfa456c180d15e0e"
+    "pluginTestsWorkflow": "be24c3b218cf6d373b6c9840bae9a346c6cf763910232ccb6889fe2652d39a52"
   }
 }

--- a/scripts/ops/directory-grant-table-ci-wiring.test.mjs
+++ b/scripts/ops/directory-grant-table-ci-wiring.test.mjs
@@ -9,36 +9,45 @@ import {
   realDbStepWholeFileArgs,
 } from './ci-realdb-step-contract.mjs'
 
-// Two-point wiring for directory-deprovision-grant-table.db.test.ts (#4581):
+// Two-point wiring for the grant-table and OPS-01 compensation real-DB suites:
 // (1) vitest.config.ts test.exclude — no-DB job cannot skip-green
 // (2) plugin-tests.yml approval real-DB whole-file step — required 20.x + DATABASE_URL
 // Removing either point must red this contract.
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const repoRoot = join(__dirname, '..', '..')
-const FILE = 'tests/integration/directory-deprovision-grant-table.db.test.ts'
+const FILES = [
+  'tests/integration/directory-deprovision-grant-table.db.test.ts',
+  'tests/integration/directory-deprovision-compensation.db.test.ts',
+]
 const STEP_ID = REAL_DB_STEP_IDS.approval
 
-test('vitest.config.ts excludes the grant-table suite from the no-DB job', () => {
+test('vitest.config.ts excludes both grant suites from the no-DB job', () => {
   const cfg = readFileSync(join(repoRoot, 'packages/core-backend/vitest.config.ts'), 'utf8')
-  assert.ok(cfg.includes(`'${FILE}'`), `vitest.config.ts must exclude ${FILE}`)
+  for (const file of FILES) {
+    assert.ok(cfg.includes(`'${file}'`), `vitest.config.ts must exclude ${file}`)
+  }
 })
 
-test('plugin-tests.yml runs the grant-table suite as a whole file in the approval real-DB step', () => {
+test('plugin-tests.yml runs both grant suites as whole files in the approval real-DB step', () => {
   const wf = readFileSync(join(repoRoot, '.github/workflows/plugin-tests.yml'), 'utf8')
-  assert.ok(
-    isSuiteWiredInRealDbStep(wf, STEP_ID, FILE),
-    `plugin-tests.yml real-DB step id "${STEP_ID}" must run ${FILE} as a whole-file vitest arg`,
-  )
-  assert.equal(
-    realDbStepWholeFileArgs(wf, REAL_DB_STEP_IDS.multitable).includes(FILE),
-    false,
-    `${FILE} must not be wired into the multitable real-DB step`,
-  )
+  for (const file of FILES) {
+    assert.ok(
+      isSuiteWiredInRealDbStep(wf, STEP_ID, file),
+      `plugin-tests.yml real-DB step id "${STEP_ID}" must run ${file} as a whole-file vitest arg`,
+    )
+    assert.equal(
+      realDbStepWholeFileArgs(wf, REAL_DB_STEP_IDS.multitable).includes(file),
+      false,
+      `${file} must not be wired into the multitable real-DB step`,
+    )
+  }
 })
 
-test('the grant-table suite file exists on disk', () => {
-  assert.ok(
-    existsSync(join(repoRoot, 'packages/core-backend', FILE)),
-    `wired suite packages/core-backend/${FILE} must exist on disk`,
-  )
+test('both wired grant suite files exist on disk', () => {
+  for (const file of FILES) {
+    assert.ok(
+      existsSync(join(repoRoot, 'packages/core-backend', file)),
+      `wired suite packages/core-backend/${file} must exist on disk`,
+    )
+  }
 })


### PR DESCRIPTION
## Summary

- add an explicit platform-admin compensation for the orphan disabled DingTalk grant row created by a superseded `grant_row_created` effect
- require the canonical per-user mutex, exact superseded evidence, active/linked source and membership, no live deprovision evidence, exact deny provenance, generation CAS, and immutable actor/time/note evidence
- fail fast with a values-free 409 when directory sync owns a source row; keep the event superseded and never treat compensation as full restore
- expose the narrowly scoped operation in the D7 evidence panel and update Rev 4.5 / six-step closeout documentation

## Verification

- fresh isolated PostgreSQL migration and no-op replay
- 66/66 across seven lifecycle real-DB suites
- 110/110 admin-directory route tests
- 5/5 D7 UI tests
- core-backend `tsc --noEmit`
- CI wiring + DingTalk OFF-default contracts: 11/11
- load-bearing mutations: provenance, live evidence, source gate, membership gate, user mutex, source NOWAIT, immutable evidence, SQLSTATE redaction, and NULL actor/note checks
- independent Kimi K3 adversarial review: APPROVE after delta, no remaining P1/P2

## Operational boundary

This PR is intentionally **held/unarmed**. It does not enable or authorize:

- `AUTH_LOGIN_USE_ALIASES`
- `DIRECTORY_PENDING_ACTIVATION_ENABLED`
- `DIRECTORY_DEPROVISION_ENABLED`
- alias/pending/deprovision canary execution
- U1-U13 or real callback/corp-anchor acceptance
- the two-corp T2-Gate or Transfer T3-T5

Those items remain OFF, NOT EXECUTED, or FROZEN exactly as recorded in the six-step closeout document. Issue #4820 / per-lane scratch DB remains a separate test-infrastructure lane.