### PR TITLE
feat(ops): add fail-closed DingTalk lifecycle staging lane

### DIFF
--- a/.github/workflows/dingtalk-lifecycle-staging-canary-contract.yml
+++ b/.github/workflows/dingtalk-lifecycle-staging-canary-contract.yml
@@ -1,0 +1,31 @@
+name: DingTalk Lifecycle Staging Canary Contract
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/dingtalk-lifecycle-staging-canary.yml'
+      - '.github/workflows/dingtalk-lifecycle-staging-canary-contract.yml'
+      - 'docker-compose.app.staging.yml'
+      - 'docker/app.staging.env.example'
+      - 'scripts/ops/dingtalk-lifecycle-staging-canary-contract.test.mjs'
+      - 'scripts/ops/dingtalk-lifecycle-staging-canary-remote.sh'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  contract:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Verify runner YAML parser
+        run: python3 -c 'import yaml'
+      - name: Run lifecycle staging canary contract
+        run: node --test scripts/ops/dingtalk-lifecycle-staging-canary-contract.test.mjs

--- a/.github/workflows/dingtalk-lifecycle-staging-canary.yml
+++ b/.github/workflows/dingtalk-lifecycle-staging-canary.yml
@@ -1,0 +1,251 @@
+name: DingTalk Lifecycle Staging Canary
+
+run-name: "DingTalk Lifecycle Staging Canary: ${{ inputs.action }}${{ inputs.action == 'preflight' && format(' -> {0}', inputs.target_mode) || '' }}"
+
+# Staging-only MINIMAL SAFE operator lane for DingTalk lifecycle env gates.
+# One dispatch = ONE action. All lifecycle flags remain OFF by default.
+#
+# EXECUTABLE: status | preflight | off
+#   off = emergency env-gate clear of the three lifecycle flags only (with
+#   previous-override restore on restart/health/mode failure).
+#
+# NOT EXECUTABLE: alias | pending | deprovision
+#   Fail-closed preflight-only. Env flip alone is not a canary — there is no
+#   secret-backed real verifier for password-login proof, admit→activate, or
+#   sync→deprovision. transition_applied is always false for these actions.
+#
+# See:
+#   docs/development/dingtalk-lifecycle-canary-separate-go-20260724.md
+#   docs/development/dingtalk-lifecycle-six-step-closeout-execution-20260810.md
+#   scripts/ops/dingtalk-lifecycle-staging-canary-remote.sh
+#
+# STAGING ONLY + shared concurrency with attendance-staging-window-runner.
+
+on:
+  workflow_dispatch:
+    inputs:
+      action:
+        description: 'status/preflight/off = executable; alias/pending/deprovision = NOT EXECUTABLE (fail-closed preflight-only)'
+        required: true
+        type: choice
+        # Quote 'off' — YAML 1.1 bare off becomes boolean false.
+        options: [status, preflight, 'off', alias, pending, deprovision]
+        default: status
+      target_mode:
+        description: 'preflight only: target mode to assess (off|alias|pending|deprovision). ON targets assess readiness only — never apply.'
+        required: false
+        type: choice
+        options: ['off', alias, pending, deprovision]
+        default: 'off'
+      expected_current_mode:
+        description: 'Required for action=off: live mode before clear (off|alias|pending|deprovision|multi-on). Optional for preflight.'
+        required: false
+        type: string
+        default: ''
+      deploy_sha:
+        description: 'FULL 40-char lowercase commit SHA currently deployed on staging. Required for action=off; optional exact-match for preflight.'
+        required: false
+        default: ''
+
+# Share the attendance staging runner concurrency group so compose override races
+# cannot interleave on the same staging stack.
+concurrency:
+  group: attendance-staging-window-runner
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate inputs and embedded scripts
+        env:
+          ACTION: ${{ inputs.action }}
+          TARGET_MODE: ${{ inputs.target_mode }}
+          EXPECTED_CURRENT_MODE: ${{ inputs.expected_current_mode }}
+          DEPLOY_SHA: ${{ inputs.deploy_sha }}
+        run: |
+          set -euo pipefail
+          case "$ACTION" in status|preflight|off|alias|pending|deprovision) ;; *)
+            echo "invalid action: $ACTION" >&2; exit 2
+          ;; esac
+
+          case "$TARGET_MODE" in off|alias|pending|deprovision) ;; *)
+            echo "invalid target_mode: $TARGET_MODE" >&2; exit 2
+          ;; esac
+
+          if [[ -n "$EXPECTED_CURRENT_MODE" ]]; then
+            case "$EXPECTED_CURRENT_MODE" in off|alias|pending|deprovision|multi-on) ;; *)
+              echo "invalid expected_current_mode: $EXPECTED_CURRENT_MODE" >&2; exit 2
+            ;; esac
+          fi
+
+          # Only action=off is an executable transition (env write).
+          if [[ "$ACTION" == "off" ]]; then
+            if [[ -z "$EXPECTED_CURRENT_MODE" ]]; then
+              echo "expected_current_mode is required for action=off (use multi-on when live is multi-on)" >&2
+              exit 2
+            fi
+            if [[ ! "$DEPLOY_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+              echo "deploy_sha must be the FULL 40-char lowercase commit SHA for action=off, got: '$DEPLOY_SHA'" >&2
+              exit 2
+            fi
+          fi
+
+          if [[ -n "$DEPLOY_SHA" && ! "$DEPLOY_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "deploy_sha must be empty or the FULL 40-char lowercase commit SHA, got: '$DEPLOY_SHA'" >&2
+            exit 2
+          fi
+
+          # Document that alias/pending/deprovision are NOT EXECUTABLE (remote fails closed).
+          if [[ "$ACTION" == "alias" || "$ACTION" == "pending" || "$ACTION" == "deprovision" ]]; then
+            echo "NOTE: action=$ACTION is NOT EXECUTABLE in this lane (no real verifier). Remote will fail-closed with transition_applied=false." >&2
+          fi
+
+          bash -n scripts/ops/dingtalk-lifecycle-staging-canary-remote.sh
+          echo "inputs and embedded scripts OK"
+
+      - name: Run pipeline self-test (contract suite)
+        run: node --test scripts/ops/dingtalk-lifecycle-staging-canary-contract.test.mjs
+
+      - name: Sync runner scripts to deploy host
+        id: sync
+        env:
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+          DEPLOY_SSH_KEY_B64: ${{ secrets.DEPLOY_SSH_KEY_B64 }}
+          DEPLOY_KNOWN_HOSTS: ${{ secrets.DEPLOY_KNOWN_HOSTS }}
+        run: |
+          set -euo pipefail
+          mkdir -p ~/.ssh
+          [[ -n "$DEPLOY_KNOWN_HOSTS" ]] || { echo "DEPLOY_KNOWN_HOSTS is required" >&2; exit 2; }
+          printf '%s' "$DEPLOY_SSH_KEY_B64" | base64 -d > ~/.ssh/deploy_key
+          printf '%s\n' "$DEPLOY_KNOWN_HOSTS" > ~/.ssh/known_hosts
+          [[ -s ~/.ssh/known_hosts ]] || { echo "known_hosts is empty" >&2; exit 2; }
+          chmod 600 ~/.ssh/deploy_key ~/.ssh/known_hosts
+          runner_dir="/tmp/dingtalk-lifecycle-canary-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          echo "runner_dir=$runner_dir" >> "$GITHUB_OUTPUT"
+          tar -czf - \
+            scripts/ops/dingtalk-lifecycle-staging-canary-remote.sh \
+          | ssh -o StrictHostKeyChecking=yes -o UserKnownHostsFile=~/.ssh/known_hosts -o IdentitiesOnly=yes -i ~/.ssh/deploy_key \
+              "$DEPLOY_USER@$DEPLOY_HOST" \
+              "bash -o pipefail -c 'set -euo pipefail; rm -rf ${runner_dir}; mkdir -p ${runner_dir}; tar -xzf - -C ${runner_dir} --strip-components=2'"
+
+      - name: Run remote action
+        id: remote
+        continue-on-error: true
+        env:
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+          DEPLOY_PATH: ${{ secrets.DEPLOY_PATH }}
+          STAGING_DEPLOY_PATH: ${{ vars.STAGING_DEPLOY_PATH || 'metasheet2-dingtalk-staging' }}
+          ACTION: ${{ inputs.action }}
+          TARGET_MODE: ${{ inputs.target_mode }}
+          EXPECTED_CURRENT_MODE: ${{ inputs.expected_current_mode }}
+          DEPLOY_SHA: ${{ inputs.deploy_sha }}
+          RUNNER_DIR: ${{ steps.sync.outputs.runner_dir }}
+        run: |
+          set -euo pipefail
+          ssh_opts="-o StrictHostKeyChecking=yes -o UserKnownHostsFile=$HOME/.ssh/known_hosts -o IdentitiesOnly=yes -i $HOME/.ssh/deploy_key"
+          DEPLOY_PATH="${DEPLOY_PATH:-metasheet2}"
+          for pair in "DEPLOY_PATH=$DEPLOY_PATH" "STAGING_DEPLOY_PATH=$STAGING_DEPLOY_PATH"; do
+            value="${pair#*=}"
+            if [[ ! "$value" =~ ^[A-Za-z0-9._/~-]+$ ]]; then
+              echo "refusing unsafe characters in ${pair%%=*}: '$value'" >&2
+              exit 2
+            fi
+          done
+          remote_output_dir="/tmp/dingtalk-lifecycle-canary-out-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          artifact_name="dingtalk-lifecycle-staging-canary-${ACTION}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          echo "artifact_name=$artifact_name" >> "$GITHUB_OUTPUT"
+          mkdir -p output/lifecycle-canary
+
+          remote_script="set -euo pipefail
+          export ACTION='${ACTION}'
+          export TARGET_MODE='${TARGET_MODE}'
+          export EXPECTED_CURRENT_MODE='${EXPECTED_CURRENT_MODE}'
+          export DEPLOY_SHA='${DEPLOY_SHA}'
+          export STAGING_DEPLOY_PATH='${STAGING_DEPLOY_PATH}'
+          export DEPLOY_PATH='${DEPLOY_PATH}'
+          export OUTPUT_DIR='${remote_output_dir}'
+          export RUN_STAMP='gh${GITHUB_RUN_ID}a${GITHUB_RUN_ATTEMPT}'
+          rm -rf '${remote_output_dir}'
+          mkdir -p '${remote_output_dir}'
+          bash '${RUNNER_DIR}/dingtalk-lifecycle-staging-canary-remote.sh'"
+          escaped_script="$(printf '%s' "$remote_script" | sed "s/'/'\\\\''/g")"
+
+          set +e
+          ssh $ssh_opts "$DEPLOY_USER@$DEPLOY_HOST" "bash -o pipefail -c '${escaped_script}'" 2>&1 \
+            | tee output/lifecycle-canary/ssh.log
+          rc=${PIPESTATUS[0]}
+          scp $ssh_opts -r "$DEPLOY_USER@$DEPLOY_HOST:${remote_output_dir}/." output/lifecycle-canary/ 2>&1 \
+            | tee -a output/lifecycle-canary/ssh.log
+          scp_rc=${PIPESTATUS[0]}
+          # Cleanup removes ONLY per-run dirs. NEVER touch persistent overrides.
+          ssh $ssh_opts "$DEPLOY_USER@$DEPLOY_HOST" \
+            "bash -o pipefail -c 'rm -rf ${remote_output_dir} ${RUNNER_DIR}'" \
+            >> output/lifecycle-canary/ssh.log 2>&1
+          set -e
+
+          if [[ "$rc" == "0" && "$scp_rc" != "0" ]]; then
+            rc="$scp_rc"
+          fi
+          echo "remote_rc=$rc" >> "$GITHUB_OUTPUT"
+          exit 0
+
+      - name: Write step summary
+        if: always()
+        env:
+          REMOTE_RC: ${{ steps.remote.outputs.remote_rc }}
+          ARTIFACT_NAME: ${{ steps.remote.outputs.artifact_name }}
+          ACTION: ${{ inputs.action }}
+          TARGET_MODE: ${{ inputs.target_mode }}
+          EXPECTED_CURRENT_MODE: ${{ inputs.expected_current_mode }}
+          DEPLOY_SHA: ${{ inputs.deploy_sha }}
+        run: |
+          set -euo pipefail
+          {
+            echo "## DingTalk Lifecycle Staging Canary (minimal safe lane)"
+            echo ""
+            echo "- Action: \`${ACTION}\`"
+            if [[ "$ACTION" == "preflight" ]]; then echo "- Target mode: \`${TARGET_MODE}\`"; fi
+            echo "- Expected current mode: \`${EXPECTED_CURRENT_MODE:-<none>}\`"
+            echo "- Deploy SHA: \`${DEPLOY_SHA:-<none>}\`"
+            echo "- Remote rc: \`${REMOTE_RC:-missing}\`"
+            echo "- Artifact: \`${ARTIFACT_NAME:-missing}\`"
+            echo ""
+            echo "**Executable:** status / preflight / off only."
+            echo "**NOT EXECUTABLE:** alias / pending / deprovision (no real canary verifier)."
+            echo "OFF is emergency env-gate rollback only — not OR-column design reintroduction."
+            if [[ -f output/lifecycle-canary/summary.txt ]]; then
+              echo ""
+              echo '```text'
+              cat output/lifecycle-canary/summary.txt
+              echo '```'
+            fi
+            if [[ -f output/lifecycle-canary/lifecycle-status.txt ]]; then
+              echo ""
+              echo "### Status (values-free)"
+              echo '```text'
+              cat output/lifecycle-canary/lifecycle-status.txt
+              echo '```'
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.remote.outputs.artifact_name || format('dingtalk-lifecycle-staging-canary-{0}-{1}-{2}', inputs.action, github.run_id, github.run_attempt) }}
+          retention-days: 30
+          path: output/lifecycle-canary
+
+      - name: Fail on remote error
+        if: steps.remote.outputs.remote_rc != '0'
+        run: exit 1

--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -99,6 +99,7 @@ jobs:
       - name: Run DingTalk closeout env-contract test (DT-CLOSE-02)
         run: |
           node --test scripts/ops/dingtalk-closeout-env-contract.test.mjs
+          node --test scripts/ops/dingtalk-lifecycle-staging-canary-contract.test.mjs
           node --test scripts/ops/directory-grant-table-ci-wiring.test.mjs
           node --test scripts/ops/directory-activation-source-lock-ci-wiring.test.mjs
           node --test scripts/ops/directory-deprovision-ledger-ci-wiring.test.mjs

--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -99,7 +99,6 @@ jobs:
       - name: Run DingTalk closeout env-contract test (DT-CLOSE-02)
         run: |
           node --test scripts/ops/dingtalk-closeout-env-contract.test.mjs
-          node --test scripts/ops/dingtalk-lifecycle-staging-canary-contract.test.mjs
           node --test scripts/ops/directory-grant-table-ci-wiring.test.mjs
           node --test scripts/ops/directory-activation-source-lock-ci-wiring.test.mjs
           node --test scripts/ops/directory-deprovision-ledger-ci-wiring.test.mjs

--- a/docker-compose.app.staging.yml
+++ b/docker-compose.app.staging.yml
@@ -30,6 +30,11 @@ services:
     container_name: metasheet-staging-backend
     env_file:
       - ${APP_ENV_FILE:-./docker/app.staging.env}
+    # Staging deploys are pinned to an exact IMAGE_TAG. Do not let stale values in the
+    # long-lived env_file override immutable image identity in /api/health.
+    environment:
+      METASHEET_BUILD_COMMIT: ${IMAGE_TAG:-unknown}
+      METASHEET_BUILD_IMAGE_TAG: ${IMAGE_TAG:-unknown}
     volumes:
       - metasheet-staging-attendance-import-data:/app/uploads/attendance-import
     ports:

--- a/docker/app.staging.env.example
+++ b/docker/app.staging.env.example
@@ -193,6 +193,33 @@ DIRECTORY_SYNC_HEARTBEAT_INTERVAL_MS=60000
 # pause cannot cause a false reclaim.
 DIRECTORY_SYNC_LEASE_STALE_MINUTES=10
 
+# --- DingTalk lifecycle canary (minimal safe lane; values-free prerequisites) ---
+# Operator lane (NOT auto-run): .github/workflows/dingtalk-lifecycle-staging-canary.yml
+# + scripts/ops/dingtalk-lifecycle-staging-canary-remote.sh. Default action is read-only
+# status. All three flags below MUST stay false in this template.
+#
+# EXECUTABLE: status | preflight | off (emergency env-gate clear of these three keys
+# only, via a SEPARATE override under $HOME/.metasheet2/lifecycle-canary, composed with
+# the attendance window-runner override when present; previous-override restore on
+# restart/health/mode failure).
+# NOT EXECUTABLE: alias | pending | deprovision ON — no secret-backed real verifier
+# (password-login / admit→activate / sync→deprovision). Env flip alone is refused;
+# canary remains NOT EXECUTED. Presence tokens are not ON enablers.
+#
+# Before action=off (recorded as closed booleans only — never paste credentials, corp
+# IDs, subject PII, or DATABASE_URL into evidence):
+#   * exact full-SHA staging deploy match, with image tag and health build metadata agreeing
+#   * migrations_pending_zero exactly true (unknown fails; 2026-08-11 run 31407444155
+#     migrated staging 296/18 -> 314/0 through backup + clone rehearsal)
+#   * backend health true after restart
+# Current blocker: image tag is b55c682... but /api/health still reports 59c24a1...;
+# provenance conflict fails closed until build metadata is repaired and re-proven.
+# Workflow also requires owner-provisioned DEPLOY_KNOWN_HOSTS; no trust-on-first-use.
+# OFF is emergency env-gate rollback only — design lock Rev 4.2 forbids reintroducing
+# OR-column login fallback as a long-term design after T2b.
+# See docs/development/dingtalk-lifecycle-canary-separate-go-20260724.md and
+# docs/development/dingtalk-lifecycle-six-step-closeout-execution-20260810.md.
+
 # T1: pending admission create (default off; do not enable without GO)
 DIRECTORY_PENDING_ACTIVATION_ENABLED=false
 

--- a/docs/development/dingtalk-directory-corp-scope-staging-uat-20260725.md
+++ b/docs/development/dingtalk-directory-corp-scope-staging-uat-20260725.md
@@ -4,9 +4,22 @@ Status: OWNER-GATED / NOT EXECUTED
 
 Date: 2026-07-25
 
+**T2-Gate procedure of record (post-fix).** Supersedes
+`canonical-org-t2-gate-two-corp-staging-runbook-20260717.md` for acceptance. The 20260717
+runbook remains historical provenance only.
+
+**After Phase B migration has already been applied:** §1 steps 5–6 and all of §2 (Phase B
+values-free preflight that requires the legacy global index and “no Phase B replacement
+index/CHECK already present”) **cannot be re-run as executable current steps**. Their
+PASS reports, SHAs, and exit codes become **provenance requirements** that must already be
+on file for the cutover window. Re-running §2 against a post-Phase-B schema is expected to
+BLOCKED/ERROR and must not be treated as a live gate. Continue from §3 only when those
+provenance artifacts exist; do not invent a re-preflight path on the migrated database.
+
 ## 1. Pre-UAT cutover gate
 
-Run this owner/ops gate before UAT:
+Run this owner/ops gate before UAT (pre-Phase-B window only for steps 5–6; after Phase B see
+the provenance note above):
 
 1. Phase A matcher/callback hardening is merged and deployed to staging.
 2. Build the exact Phase A SHA through the trusted operator path. Keep the provenance file owned

--- a/docs/development/dingtalk-lifecycle-canary-separate-go-20260724.md
+++ b/docs/development/dingtalk-lifecycle-canary-separate-go-20260724.md
@@ -1,27 +1,69 @@
 # DingTalk lifecycle canary — separate ops GO (not auto-enabled)
 
-**Date:** 2026-07-24  
-**Related locks:**  
-- `dingtalk-directory-admission-activation-lifecycle-design-20260723.md` Rev 4.2  
-- `dingtalk-deprovision-reactivation-and-evidence-chain-design-20260723.md` Rev 4.2  
+**Date:** 2026-07-24
+**Updated:** 2026-08-11 (minimal safe lane; ON transitions **NOT EXECUTABLE**; canary **NOT EXECUTED**)
+**Related locks:**
+- `dingtalk-directory-admission-activation-lifecycle-design-20260723.md` Rev 4.2
+- `dingtalk-deprovision-reactivation-and-evidence-chain-design-20260723.md` Rev 4.2
+- Closeout execution: `dingtalk-lifecycle-six-step-closeout-execution-20260810.md`
 
 ## What is NOT enabled by merge
 
-| Flag / action | Default after code land | Requires |
-|---------------|-------------------------|----------|
-| `DIRECTORY_PENDING_ACTIVATION_ENABLED` | **OFF** | Explicit owner **ops GO** + canary plan |
-| `AUTH_LOGIN_USE_ALIASES` (T2b cutover) | **OFF** | Admin password-alias readiness gate + ops GO |
-| `DIRECTORY_DEPROVISION_ENABLED` | **OFF** (writer no-op when false) | Ops GO after D1–D7 goldens green |
+| Flag / action | Default after code land | Executable in this lane? |
+|---------------|-------------------------|--------------------------|
+| `DIRECTORY_PENDING_ACTIVATION_ENABLED` ON | **OFF** | **NOT EXECUTABLE** — no admit→activate verifier |
+| `AUTH_LOGIN_USE_ALIASES` ON (T2b cutover) | **OFF** | **NOT EXECUTABLE** — no password-login success/rollback proof |
+| `DIRECTORY_DEPROVISION_ENABLED` ON | **OFF** | **NOT EXECUTABLE** — no sync→deprovision verifier |
+| Env-gate clear (`action=off`) | n/a | Executable emergency only (after migrations true + exact SHA) |
 
-## Canary sequence (when authorized)
+Presence of canary subject/integration/owner tokens is **not** a real canary and is **not** accepted as an ON enabler.
 
-1. Staging: migrate T1→T2a→T3→D* schemas; leave pending-create OFF.  
-2. T2a backfill + review collision report.  
-3. Confirm ≥1 active admin has alias; enable `AUTH_LOGIN_USE_ALIASES` on staging only.  
-4. Enable pending-create for a single test org; exercise admit → activate.  
-5. Deprovision canary with `enabled=true` on non-prod first.  
-6. Production enablement only after staging sign-off — **separate GO**, not PR merge.
+## Staging operator lane (minimal safe)
+
+| Piece | Path |
+|-------|------|
+| Workflow | `.github/workflows/dingtalk-lifecycle-staging-canary.yml` |
+| Remote script | `scripts/ops/dingtalk-lifecycle-staging-canary-remote.sh` |
+| Contract suite | `scripts/ops/dingtalk-lifecycle-staging-canary-contract.test.mjs` |
+
+| Action | Executable? | Behavior |
+|--------|-------------|----------|
+| `status` | yes | values-free snapshot; multi-on fail-closed after report |
+| `preflight` | yes | readiness only; `migrations_pending_zero` must be exactly `true` (unknown fails) |
+| `off` | yes | emergency clear of the three env gates; previous-override restore on failure; health true after restart required |
+| `alias` / `pending` / `deprovision` | **NOT EXECUTABLE** | fail-closed preflight-only; `transition_applied=false` always |
+
+Shared concurrency with `attendance-staging-window-runner`. Status artifacts stay values-free.
+
+### Alias OFF vs design lock (no OR-column fallback)
+
+`action=off` is an **emergency operational rollback of the env gate only**. Design lock Rev 4.2 §4.2 / §4.4 forbids reintroducing OR-column fallback on `users.email` / `username` / `mobile` as a long-term design after T2b. OFF is not canary completion and is not product permission to restore pre-T2b OR login.
+
+## Current staging blockers (canary NOT EXECUTED)
+
+As of 2026-08-11 this lane remains **NOT EXECUTED** for lifecycle ON canaries. Staging preparation evidence:
+
+1. Attendance staging runner [run 31407444155](https://github.com/zensgit/metasheet2/actions/runs/31407444155) completed backup + clone rehearsal + real apply: migration state `296 applied / 18 pending` -> `314 applied / 0 pending`; rehearsal isolation held and auth round-trip returned 200.
+2. **Build provenance conflict remains:** the running backend image tag is `b55c682748e3010cb70837770c298843a96e1019`, while `/api/health` still reports build commit `59c24a1d21cfc70b76867da7d0ac15590d558c72`. The operator lane refuses exact-SHA proof when image and health metadata disagree. Repair/rebuild and re-prove this before any write action.
+3. The existing `DEPLOY_KNOWN_HOSTS` secret is the independently verified deploy-host identity. The lane uses `StrictHostKeyChecking=yes`; missing host identity blocks dispatch rather than producing forgeable evidence.
+
+Until a **secret-backed real verifier** exists for:
+
+- alias: real password-login success + documented emergency off proof (without OR fallback),
+- pending: real admit→activate on an explicit canary subject,
+- deprovision: real sync→deprovision on an explicit canary integration,
+
+the ON actions stay **NOT EXECUTABLE**. Do not treat env flips or presence tokens as canary completion.
+
+## Future canary sequence (when a real verifier + ops GO exist)
+
+1. Staging: deploy exact SHA; image and health provenance agree; migrations pending=0 via backup/clone-rehearsal.
+2. T2a backfill + collision report.
+3. Real alias login proof → only then an executable alias ON (not this lane today).
+4. Real admit→activate on explicit ids → only then pending ON.
+5. Real deprovision proof → only then deprovision ON.
+6. Production = separate GO.
 
 ## Owner note
 
-Implementation PRs may land default-off code. **Merging code ≠ authorizing traffic.**
+Landing this lane ≠ authorizing traffic. **Canary NOT EXECUTED.** Merging code does not complete lifecycle canary.

--- a/docs/development/dingtalk-lifecycle-canary-separate-go-20260724.md
+++ b/docs/development/dingtalk-lifecycle-canary-separate-go-20260724.md
@@ -44,7 +44,7 @@ Shared concurrency with `attendance-staging-window-runner`. Status artifacts sta
 As of 2026-08-11 this lane remains **NOT EXECUTED** for lifecycle ON canaries. Staging preparation evidence:
 
 1. Attendance staging runner [run 31407444155](https://github.com/zensgit/metasheet2/actions/runs/31407444155) completed backup + clone rehearsal + real apply: migration state `296 applied / 18 pending` -> `314 applied / 0 pending`; rehearsal isolation held and auth round-trip returned 200.
-2. **Build provenance conflict remains:** the running backend image tag is `b55c682748e3010cb70837770c298843a96e1019`, while `/api/health` still reports build commit `59c24a1d21cfc70b76867da7d0ac15590d558c72`. The operator lane refuses exact-SHA proof when image and health metadata disagree. Repair/rebuild and re-prove this before any write action.
+2. **Build provenance conflict remains live:** the running backend image tag is `b55c682748e3010cb70837770c298843a96e1019`, while `/api/health` still reports build commit `59c24a1d21cfc70b76867da7d0ac15590d558c72`. This PR fixes the source by making staging compose derive both build metadata variables from the exact `IMAGE_TAG`; after merge, redeploy/recreate and re-prove agreement before any write action.
 3. The existing `DEPLOY_KNOWN_HOSTS` secret is the independently verified deploy-host identity. The lane uses `StrictHostKeyChecking=yes`; missing host identity blocks dispatch rather than producing forgeable evidence.
 
 Until a **secret-backed real verifier** exists for:

--- a/docs/development/dingtalk-lifecycle-six-step-closeout-execution-20260810.md
+++ b/docs/development/dingtalk-lifecycle-six-step-closeout-execution-20260810.md
@@ -93,7 +93,7 @@ Merge is not an enablement instruction. **Lifecycle canary is NOT EXECUTED** and
 Lifecycle ON canaries remain **NOT EXECUTED**. Current staging preparation evidence and blocker:
 
 1. [Attendance staging runner 31407444155](https://github.com/zensgit/metasheet2/actions/runs/31407444155) completed host backup, clone rehearsal, isolation check, real migration, and auth round-trip. Migration state is now `314 applied / 0 pending` (`migrations_pending_zero=true`).
-2. **Exact-build provenance is still blocked:** the running image tag is `b55c682748e3010cb70837770c298843a96e1019`, but `/api/health` reports old commit `59c24a1d21cfc70b76867da7d0ac15590d558c72`. Image/health disagreement is a hard `build_provenance_conflict`; the lane must not select either value as exact proof.
+2. **Exact-build provenance is still blocked live:** the running image tag is `b55c682748e3010cb70837770c298843a96e1019`, but `/api/health` reports old commit `59c24a1d21cfc70b76867da7d0ac15590d558c72`. Image/health disagreement is a hard `build_provenance_conflict`. This PR makes staging compose override stale env-file metadata from the exact `IMAGE_TAG`; merge + redeploy/recreate + agreement proof is still required.
 3. The existing `DEPLOY_KNOWN_HOSTS` secret supplies the independently verified host key. SSH and SCP require `StrictHostKeyChecking=yes`; this evidence lane does not accept first-use trust.
 
 Until those clear **and** a real verifier exists, do not claim lifecycle canary progress. Future ON sequence (alias → pending → deprovision) is documentation-only and **NOT EXECUTABLE** here.

--- a/docs/development/dingtalk-lifecycle-six-step-closeout-execution-20260810.md
+++ b/docs/development/dingtalk-lifecycle-six-step-closeout-execution-20260810.md
@@ -4,6 +4,7 @@
 - Status: **CODE CANDIDATE / OPS AND EXTERNAL GATES NOT EXECUTED**
 - Baseline: `origin/main @ 775d537e616e325000c7578d7e2432d838da0801`
 - Scope: close the OPS-01 superseded creation-effect residue without enabling lifecycle traffic
+- Operator lane (staging only, default-off): `.github/workflows/dingtalk-lifecycle-staging-canary.yml` + `scripts/ops/dingtalk-lifecycle-staging-canary-remote.sh` — **not executed** by this closeout
 
 ## 1. OPS-01 explicit compensation
 
@@ -58,7 +59,7 @@ Load-bearing mutations reproduced before restoration:
 - pass an unknown PostgreSQL SQLSTATE through as the response code → the HTTP error-surface test fails;
 - remove the `COALESCE` fail-closed terms from compensation evidence checks → raw NULL actor/note inserts succeed.
 
-## 3. Lifecycle flags and canary
+## 3. Lifecycle flags and canary (minimal safe lane)
 
 The repository defaults and closeout contract continue to require all three flags OFF:
 
@@ -68,15 +69,42 @@ DIRECTORY_PENDING_ACTIVATION_ENABLED=false
 DIRECTORY_DEPROVISION_ENABLED=false
 ```
 
-Merge is not an enablement instruction. Canary execution is **NOT EXECUTED** and remains a separate ops GO. When authorized, execute only one stage at a time:
+Merge is not an enablement instruction. **Lifecycle canary is NOT EXECUTED** and must not be implied complete by this PR or by the operator lane landing.
 
-| Stage | Enable | Required rollback proof before proceeding |
+### 3.1 Staging operator lane (what is actually executable)
+
+| Piece | Path |
+|---|---|
+| Workflow | `.github/workflows/dingtalk-lifecycle-staging-canary.yml` (manual only; default `status`) |
+| Remote | `scripts/ops/dingtalk-lifecycle-staging-canary-remote.sh` |
+| Contract | `scripts/ops/dingtalk-lifecycle-staging-canary-contract.test.mjs` |
+
+| Action | Executable? | Notes |
 |---|---|---|
-| 1 | alias-only | turn alias read path off and prove the pre-cutover login path is restored |
-| 2 | pending admission | turn pending admission off and prove new admissions return to activated baseline behavior |
-| 3 | deprovision | turn writer off and prove a new sync cannot create an event/effect or mutate access state |
+| `status` | yes | values-free snapshot; multi-on reports then fail-closed |
+| `preflight` | yes | readiness only; `migrations_pending_zero` must be **exactly `true`** (`unknown` fails — never treated as success) |
+| `off` | yes | **sole env write**: emergency clear of the three gates; previous-override backup + restore on restart/health/mode failure; backend health must be true after restart; exact mode `off` proven |
+| `alias` / `pending` / `deprovision` | **NOT EXECUTABLE** | fail-closed preflight-only; `transition_applied=false` always. Env flip alone is not a canary — no secret-backed password-login / admit→activate / sync→deprovision verifier exists in this lane. Presence tokens are not ON enablers. |
 
-Deprovision is last. Do not overlap flag changes.
+`action=off` is an **emergency operational rollback of the env gate only**. Design lock Rev 4.2 §4.2 / §4.4 permanently forbids reintroducing OR-column fallback on `users.email` / `username` / `mobile` as a long-term design after T2b. OFF is not “canary stage 1 complete.”
+
+### 3.2 Current staging blockers (owner review 2026-08-11)
+
+Lifecycle ON canaries remain **NOT EXECUTED**. Current staging preparation evidence and blocker:
+
+1. [Attendance staging runner 31407444155](https://github.com/zensgit/metasheet2/actions/runs/31407444155) completed host backup, clone rehearsal, isolation check, real migration, and auth round-trip. Migration state is now `314 applied / 0 pending` (`migrations_pending_zero=true`).
+2. **Exact-build provenance is still blocked:** the running image tag is `b55c682748e3010cb70837770c298843a96e1019`, but `/api/health` reports old commit `59c24a1d21cfc70b76867da7d0ac15590d558c72`. Image/health disagreement is a hard `build_provenance_conflict`; the lane must not select either value as exact proof.
+3. The existing `DEPLOY_KNOWN_HOSTS` secret supplies the independently verified host key. SSH and SCP require `StrictHostKeyChecking=yes`; this evidence lane does not accept first-use trust.
+
+Until those clear **and** a real verifier exists, do not claim lifecycle canary progress. Future ON sequence (alias → pending → deprovision) is documentation-only and **NOT EXECUTABLE** here.
+
+### 3.3 Future stages (NOT EXECUTABLE in this lane today)
+
+| Stage | Desired enable | Required real proof (missing today) |
+|---|---|---|
+| 1 | alias-only | password-login success against aliases + emergency `off` proof without OR-column fallback |
+| 2 | pending admission | admit→activate on an explicit canary subject (not a presence token) |
+| 3 | deprovision | sync→deprovision on an explicit canary integration; then `off` clears the writer |
 
 ## 4. Owner and ops acceptance
 
@@ -85,11 +113,12 @@ Real enterprise evidence is unavailable in this development lane. Therefore thes
 - U1-U13 interactive-card acceptance;
 - U11-a real callback corp-anchor;
 - named owners and final production switch decisions;
-- actual staged rollback exercises from section 3.
+- lifecycle canary ON stages (alias/pending/deprovision);
+- live staging status/preflight/off dispatches from this development lane (blockers in §3.2).
 
-The procedure of record remains `dingtalk-hardening-real-uat-evidence-pack-20260713.md`.
+The interactive-card procedure of record remains `dingtalk-hardening-real-uat-evidence-pack-20260713.md`.
 
-## 5. Transfer decision gate
+## 5. Transfer decision gate (T2-Gate)
 
 Transfer T3-T5 remains **FROZEN**. The real two-corp T2-Gate has not run in this lane:
 
@@ -99,7 +128,9 @@ Transfer T3-T5 remains **FROZEN**. The real two-corp T2-Gate has not run in this
 | DISPROVED | T3 may be considered after owner authorization |
 | INCONCLUSIVE / NOT EXECUTED | keep T3-T5 frozen |
 
-The runbook of record is `canonical-org-t2-gate-two-corp-staging-runbook-20260717.md`.
+**Procedure of record (post-fix):** `dingtalk-directory-corp-scope-staging-uat-20260725.md` (and closeout ledger `dingtalk-directory-corp-scope-closeout-verification-20260725.md`). Use that UAT after Phase A + Phase B deployment gates pass.
+
+**Historical provenance only (not the current executable procedure):** `canonical-org-t2-gate-two-corp-staging-runbook-20260717.md` is the pre-fix evidence runbook. It is self-superseded for acceptance after corp-scope Phase B. Steps that described legacy global-key collision preflight against the pre-Phase-B schema **cannot be re-run as executable current steps after Phase B** — they remain **provenance requirements** (what was proven / what SHA and gate outputs must already be on file), not a procedure to re-execute on a post-Phase-B database. Do not point operators at the 20260717 runbook as the live T2-Gate gate.
 
 ## 6. Test infrastructure lane
 

--- a/scripts/ops/dingtalk-lifecycle-staging-canary-contract.test.mjs
+++ b/scripts/ops/dingtalk-lifecycle-staging-canary-contract.test.mjs
@@ -192,6 +192,32 @@ test('remote pins staging compose/containers only', () => {
   assert.match(source, /assert_staging_only\(\)/)
 })
 
+test('production path resolver expands an explicit ~/ prefix instead of nesting a literal tilde', () => {
+  const result = spawnSync(
+    'bash',
+    [
+      '-o',
+      'pipefail',
+      '-c',
+      'source "$1"; HOME=/tmp/lifecycle-home; resolve_home_path "~/staging"',
+      'bash',
+      REMOTE_SH,
+    ],
+    {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        ACTION: 'status',
+        OUTPUT_DIR: '/tmp/lifecycle-canary-contract-source-only',
+        RUN_STAMP: 'contract',
+        LIFECYCLE_CANARY_SOURCE_ONLY: 'true',
+      },
+    },
+  )
+  assert.equal(result.status, 0, result.stderr)
+  assert.equal(result.stdout, '/tmp/lifecycle-home/staging')
+})
+
 test('staging compose derives health build identity from the exact image tag, not stale env_file values', () => {
   const compose = read(STAGING_COMPOSE)
   assert.match(compose, /METASHEET_BUILD_COMMIT: \$\{IMAGE_TAG:-unknown\}/)

--- a/scripts/ops/dingtalk-lifecycle-staging-canary-contract.test.mjs
+++ b/scripts/ops/dingtalk-lifecycle-staging-canary-contract.test.mjs
@@ -433,6 +433,8 @@ test('P1 recreate_backend_only requires health true after restart (returns 1 oth
   // action=off must not claim success without recreate success
   assert.match(source, /if ! recreate_backend_only; then/)
   assert.match(source, /fail_transition_restore "backend_health_not_true_after_restart"/)
+  assert.match(source, /resolve_deployed_sha\)" != "\$DEPLOY_SHA"/)
+  assert.match(source, /fail_transition_restore "post_restart_sha_mismatch"/)
 })
 
 test('MUTATION: dropping health requirement after recreate turns contract red', () => {

--- a/scripts/ops/dingtalk-lifecycle-staging-canary-contract.test.mjs
+++ b/scripts/ops/dingtalk-lifecycle-staging-canary-contract.test.mjs
@@ -201,6 +201,51 @@ test('staging compose derives health build identity from the exact image tag, no
   assert.ok(envFileIndex >= 0 && environmentIndex > envFileIndex)
 })
 
+test('P1 backend recreate reuses the exact running image pin instead of latest or unknown', () => {
+  const source = read(REMOTE_SH)
+  assert.match(source, /resolve_live_backend_image_pin\(\)/)
+  assert.match(source, /metasheet2-backend:\(\[0-9a-f\]\{40\}\)/)
+  assert.match(source, /IMAGE_OWNER="\$image_owner" IMAGE_TAG="\$image_tag" docker compose/)
+  assert.match(source, /refusing compose/)
+
+  const sha = 'a'.repeat(40)
+  const result = spawnSync(
+    'bash',
+    [
+      '-o',
+      'pipefail',
+      '-c',
+      `source "$1"
+       STAGING_DIR=/tmp
+       STAGING_COMPOSE_FILE=/tmp/docker-compose.app.staging.yml
+       ATTENDANCE_OVERRIDE_FILE=/tmp/not-present-attendance
+       LIFECYCLE_OVERRIDE_FILE=/tmp/not-present-lifecycle
+       docker() {
+         if [[ "$1" == "inspect" ]]; then
+           printf 'ghcr.io/zensgit/metasheet2-backend:${sha}'
+         else
+           printf '%s|%s|%s' "$IMAGE_OWNER" "$IMAGE_TAG" "$*"
+         fi
+       }
+       compose_staging_cmd "" config`,
+      'bash',
+      REMOTE_SH,
+    ],
+    {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        ACTION: 'status',
+        OUTPUT_DIR: '/tmp/lifecycle-canary-contract-source-only',
+        RUN_STAMP: 'contract',
+        LIFECYCLE_CANARY_SOURCE_ONLY: 'true',
+      },
+    },
+  )
+  assert.equal(result.status, 0, result.stderr)
+  assert.match(result.stdout, new RegExp(`^zensgit\\|${sha}\\|compose `))
+})
+
 test('P1 deployed SHA provenance conflicts fail closed instead of selecting one source', () => {
   const source = read(REMOTE_SH)
   assert.match(source, /image_commit.*health_commit/s)

--- a/scripts/ops/dingtalk-lifecycle-staging-canary-contract.test.mjs
+++ b/scripts/ops/dingtalk-lifecycle-staging-canary-contract.test.mjs
@@ -258,6 +258,45 @@ test('P1 deployed SHA provenance conflicts fail closed instead of selecting one 
   assert.doesNotMatch(source, /if \[\[ "\$health_commit" =~ \^\[0-9a-f\]\{40\}\$ \]\]; then printf/)
 })
 
+test('production preflight accepts only an exact resolved SHA; unknown and conflict fail closed', () => {
+  function run(buildSha) {
+    return spawnSync(
+      'bash',
+      [
+        '-o',
+        'pipefail',
+        '-c',
+        `source "$1"
+         SNAP_MIGRATIONS_ZERO=true
+         SNAP_MODE=off
+         SNAP_BUILD_SHA="$2"
+         SNAP_HEALTH_OK=true
+         EXPECTED_CURRENT_MODE=''
+         DEPLOY_SHA=''
+         preflight_for_target off
+         printf '%s|%s' "$PREFLIGHT_OK" "$PREFLIGHT_NOTE"`,
+        'bash',
+        REMOTE_SH,
+        buildSha,
+      ],
+      {
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          ACTION: 'status',
+          OUTPUT_DIR: '/tmp/lifecycle-canary-contract-source-only',
+          RUN_STAMP: 'contract',
+          LIFECYCLE_CANARY_SOURCE_ONLY: 'true',
+        },
+      },
+    )
+  }
+  assert.equal(run('a'.repeat(40)).stdout, 'true|ok')
+  assert.equal(run('unknown').stdout, 'false|build_provenance_unknown')
+  assert.equal(run('conflict').stdout, 'false|build_provenance_conflict')
+  assert.equal(run('not-a-sha').stdout, 'false|build_provenance_unknown')
+})
+
 test('backend health proof never falls back to the web health endpoint', () => {
   const source = read(REMOTE_SH)
   const start = source.indexOf('capture_live_snapshot()')

--- a/scripts/ops/dingtalk-lifecycle-staging-canary-contract.test.mjs
+++ b/scripts/ops/dingtalk-lifecycle-staging-canary-contract.test.mjs
@@ -272,6 +272,53 @@ test('P1 backend recreate reuses the exact running image pin instead of latest o
   assert.match(result.stdout, new RegExp(`^zensgit\\|${sha}\\|compose `))
 })
 
+test('P1 rollback recreate retains the proven image pin after the backend container disappears', () => {
+  const sha = 'b'.repeat(40)
+  const result = spawnSync(
+    'bash',
+    [
+      '-o',
+      'pipefail',
+      '-c',
+      `source "$1"
+       STAGING_DIR=/tmp
+       STAGING_COMPOSE_FILE=/tmp/docker-compose.app.staging.yml
+       ATTENDANCE_OVERRIDE_FILE=/tmp/not-present-attendance
+       LIFECYCLE_OVERRIDE_FILE=/tmp/not-present-lifecycle
+       PINNED_IMAGE_OWNER=zensgit
+       PINNED_IMAGE_TAG=${sha}
+       docker() {
+         if [[ "$1" == "inspect" ]]; then
+           return 1
+         fi
+         printf '%s|%s|%s' "$IMAGE_OWNER" "$IMAGE_TAG" "$*"
+       }
+       compose_staging_cmd "" config`,
+      'bash',
+      REMOTE_SH,
+    ],
+    {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        ACTION: 'status',
+        OUTPUT_DIR: '/tmp/lifecycle-canary-contract-source-only',
+        RUN_STAMP: 'contract',
+        LIFECYCLE_CANARY_SOURCE_ONLY: 'true',
+      },
+    },
+  )
+  assert.equal(result.status, 0, result.stderr)
+  assert.match(result.stdout, new RegExp(`^zensgit\\|${sha}\\|compose `))
+
+  const source = read(REMOTE_SH)
+  const actionBody = source.slice(source.indexOf('action_off()'), source.indexOf('\n# --- main'))
+  assert.ok(
+    actionBody.indexOf('pin_live_backend_image_for_transition') < actionBody.indexOf('backup_lifecycle_override'),
+    'image pin must be captured before the first write',
+  )
+})
+
 test('P1 deployed SHA provenance conflicts fail closed instead of selecting one source', () => {
   const source = read(REMOTE_SH)
   assert.match(source, /image_commit.*health_commit/s)

--- a/scripts/ops/dingtalk-lifecycle-staging-canary-contract.test.mjs
+++ b/scripts/ops/dingtalk-lifecycle-staging-canary-contract.test.mjs
@@ -48,6 +48,7 @@ const CANARY_GO_DOC = join(
   'dingtalk-lifecycle-canary-separate-go-20260724.md',
 )
 const STAGING_ENV_EXAMPLE = join(REPO_ROOT, 'docker', 'app.staging.env.example')
+const STAGING_COMPOSE = join(REPO_ROOT, 'docker-compose.app.staging.yml')
 
 function read(path) {
   return readFileSync(path, 'utf8')
@@ -174,6 +175,15 @@ test('remote pins staging compose/containers only', () => {
     /docker-compose\.app\.yml/,
   )
   assert.match(source, /assert_staging_only\(\)/)
+})
+
+test('staging compose derives health build identity from the exact image tag, not stale env_file values', () => {
+  const compose = read(STAGING_COMPOSE)
+  assert.match(compose, /METASHEET_BUILD_COMMIT: \$\{IMAGE_TAG:-unknown\}/)
+  assert.match(compose, /METASHEET_BUILD_IMAGE_TAG: \$\{IMAGE_TAG:-unknown\}/)
+  const envFileIndex = compose.indexOf('env_file:')
+  const environmentIndex = compose.indexOf('environment:', envFileIndex)
+  assert.ok(envFileIndex >= 0 && environmentIndex > envFileIndex)
 })
 
 test('P1 deployed SHA provenance conflicts fail closed instead of selecting one source', () => {

--- a/scripts/ops/dingtalk-lifecycle-staging-canary-contract.test.mjs
+++ b/scripts/ops/dingtalk-lifecycle-staging-canary-contract.test.mjs
@@ -29,6 +29,12 @@ const HERE = dirname(fileURLToPath(import.meta.url))
 const REPO_ROOT = join(HERE, '..', '..')
 const REMOTE_SH = join(HERE, 'dingtalk-lifecycle-staging-canary-remote.sh')
 const WORKFLOW = join(REPO_ROOT, '.github', 'workflows', 'dingtalk-lifecycle-staging-canary.yml')
+const CONTRACT_WORKFLOW = join(
+  REPO_ROOT,
+  '.github',
+  'workflows',
+  'dingtalk-lifecycle-staging-canary-contract.yml',
+)
 const ATTENDANCE_WORKFLOW = join(
   REPO_ROOT,
   '.github',
@@ -89,6 +95,7 @@ function workflowOn(doc) {
 test('remote script and workflow files exist', () => {
   assert.ok(existsSync(REMOTE_SH))
   assert.ok(existsSync(WORKFLOW))
+  assert.ok(existsSync(CONTRACT_WORKFLOW))
 })
 
 test('embedded remote script parses (bash -n)', () => {
@@ -101,6 +108,14 @@ test('workflow YAML parses with repository-available parser', () => {
   assert.equal(doc.name, 'DingTalk Lifecycle Staging Canary')
   assert.ok(workflowOn(doc)?.workflow_dispatch?.inputs?.action)
   assert.ok(doc.jobs?.run)
+})
+
+test('PR contract workflow executes this exact suite without changing the sealed plugin-tests pin', () => {
+  const workflow = read(CONTRACT_WORKFLOW)
+  assert.match(workflow, /pull_request:/)
+  assert.match(workflow, /node --test scripts\/ops\/dingtalk-lifecycle-staging-canary-contract\.test\.mjs/)
+  const pluginTests = read(join(REPO_ROOT, '.github', 'workflows', 'plugin-tests.yml'))
+  assert.doesNotMatch(pluginTests, /dingtalk-lifecycle-staging-canary-contract\.test\.mjs/)
 })
 
 // --- workflow shape -------------------------------------------------------------------

--- a/scripts/ops/dingtalk-lifecycle-staging-canary-contract.test.mjs
+++ b/scripts/ops/dingtalk-lifecycle-staging-canary-contract.test.mjs
@@ -1,0 +1,523 @@
+#!/usr/bin/env node
+// dingtalk-lifecycle-staging-canary-contract.test.mjs
+//
+// Durable synthetic contract for the MINIMAL SAFE staging lifecycle lane:
+//   EXECUTABLE: status | preflight | off
+//   NOT EXECUTABLE: alias | pending | deprovision (fail-closed preflight-only)
+//
+// Load-bearing mutations for owner P1/P2 gaps:
+//   * migrations_pending_zero unknown must fail preflight/off (never success)
+//   * alias/pending/deprovision never apply (transition_applied=false; NOT EXECUTABLE)
+//   * recreate requires health true after restart
+//   * previous-override restore on transition failure
+//   * multi-on: status/preflight fail closed; off still clears via classify_mode
+//
+// No network, no secrets, no workflow execution.
+
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import {
+  existsSync,
+  readFileSync,
+} from 'node:fs'
+import { dirname, join } from 'node:path'
+import { createRequire } from 'node:module'
+import { fileURLToPath } from 'node:url'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const REPO_ROOT = join(HERE, '..', '..')
+const REMOTE_SH = join(HERE, 'dingtalk-lifecycle-staging-canary-remote.sh')
+const WORKFLOW = join(REPO_ROOT, '.github', 'workflows', 'dingtalk-lifecycle-staging-canary.yml')
+const ATTENDANCE_WORKFLOW = join(
+  REPO_ROOT,
+  '.github',
+  'workflows',
+  'attendance-staging-window-runner.yml',
+)
+const CLOSEOUT_DOC = join(
+  REPO_ROOT,
+  'docs',
+  'development',
+  'dingtalk-lifecycle-six-step-closeout-execution-20260810.md',
+)
+const CANARY_GO_DOC = join(
+  REPO_ROOT,
+  'docs',
+  'development',
+  'dingtalk-lifecycle-canary-separate-go-20260724.md',
+)
+const STAGING_ENV_EXAMPLE = join(REPO_ROOT, 'docker', 'app.staging.env.example')
+
+function read(path) {
+  return readFileSync(path, 'utf8')
+}
+
+function loadYaml(text) {
+  const require = createRequire(import.meta.url)
+  const candidates = [
+    () => require('js-yaml'),
+    () => require(join(REPO_ROOT, 'node_modules/js-yaml')),
+    () => require(join(REPO_ROOT, 'packages/openapi/node_modules/js-yaml')),
+  ]
+  for (const load of candidates) {
+    try {
+      return load().load(text)
+    } catch {
+      // try next
+    }
+  }
+  const py = spawnSync(
+    'python3',
+    ['-c', 'import sys,yaml,json; print(json.dumps(yaml.safe_load(sys.stdin.read())))'],
+    { input: text, encoding: 'utf8' },
+  )
+  if (py.status !== 0) {
+    throw new Error(`YAML parse failed: ${py.stderr || py.stdout}`)
+  }
+  return JSON.parse(py.stdout)
+}
+
+/** GitHub Actions `on:` is boolean true under YAML 1.1. */
+function workflowOn(doc) {
+  return doc.on ?? doc.true ?? doc[true]
+}
+
+// --- parse / presence -----------------------------------------------------------------
+
+test('remote script and workflow files exist', () => {
+  assert.ok(existsSync(REMOTE_SH))
+  assert.ok(existsSync(WORKFLOW))
+})
+
+test('embedded remote script parses (bash -n)', () => {
+  const result = spawnSync('bash', ['-n', REMOTE_SH], { encoding: 'utf8' })
+  assert.equal(result.status, 0, result.stderr)
+})
+
+test('workflow YAML parses with repository-available parser', () => {
+  const doc = loadYaml(read(WORKFLOW))
+  assert.equal(doc.name, 'DingTalk Lifecycle Staging Canary')
+  assert.ok(workflowOn(doc)?.workflow_dispatch?.inputs?.action)
+  assert.ok(doc.jobs?.run)
+})
+
+// --- workflow shape -------------------------------------------------------------------
+
+test('workflow action choices include status/preflight/off and non-executable ON names', () => {
+  const options = workflowOn(loadYaml(read(WORKFLOW))).workflow_dispatch.inputs.action.options
+  assert.deepEqual(options, ['status', 'preflight', 'off', 'alias', 'pending', 'deprovision'])
+  assert.ok(options.every((o) => typeof o === 'string'), 'quote off so YAML 1.1 keeps string')
+})
+
+test('workflow default is read-only status; no schedule', () => {
+  const doc = loadYaml(read(WORKFLOW))
+  assert.equal(workflowOn(doc).workflow_dispatch.inputs.action.default, 'status')
+  const yaml = read(WORKFLOW)
+  assert.doesNotMatch(yaml, /schedule:/)
+  assert.doesNotMatch(yaml, /cron:/)
+})
+
+test('workflow shares concurrency with attendance staging runner', () => {
+  const lifecycle = loadYaml(read(WORKFLOW))
+  const attendance = loadYaml(read(ATTENDANCE_WORKFLOW))
+  assert.equal(lifecycle.concurrency.group, attendance.concurrency.group)
+  assert.equal(lifecycle.concurrency.group, 'attendance-staging-window-runner')
+  assert.equal(lifecycle.concurrency['cancel-in-progress'], false)
+})
+
+test('workflow remote commands use bash -o pipefail -c', () => {
+  const yaml = read(WORKFLOW)
+  assert.ok((yaml.match(/bash -o pipefail -c/g) || []).length >= 2)
+  assert.doesNotMatch(yaml, /bash\s+-s\b/)
+})
+
+test('SSH transport requires a pinned known_hosts secret', () => {
+  const yaml = read(WORKFLOW)
+  assert.match(yaml, /DEPLOY_KNOWN_HOSTS/)
+  assert.match(yaml, /StrictHostKeyChecking=yes/)
+  assert.match(yaml, /UserKnownHostsFile=/)
+  assert.doesNotMatch(yaml, /StrictHostKeyChecking=no/)
+})
+
+test('workflow only requires deploy_sha + expected_current_mode for action=off (not for ON names)', () => {
+  const yaml = read(WORKFLOW)
+  assert.match(yaml, /expected_current_mode is required for action=off/)
+  assert.match(yaml, /NOT EXECUTABLE/)
+  // Must not require canary subject/integration for a pretend ON transition.
+  assert.doesNotMatch(yaml, /canary_subject_id:/)
+  assert.doesNotMatch(yaml, /canary_integration_id:/)
+  assert.doesNotMatch(yaml, /owner_confirm:/)
+})
+
+test('workflow cleanup never deletes persistent .metasheet2 overrides', () => {
+  const yaml = read(WORKFLOW)
+  assert.match(yaml, /rm -rf \$\{remote_output_dir\} \$\{RUNNER_DIR\}/)
+  assert.doesNotMatch(yaml, /rm -rf[^\n]*\.metasheet2/)
+})
+
+// --- staging-only rails ---------------------------------------------------------------
+
+test('remote pins staging compose/containers only', () => {
+  const source = read(REMOTE_SH)
+  for (const name of [
+    'metasheet-staging-backend',
+    'metasheet-staging-web',
+    'metasheet-staging-postgres',
+    'metasheet-staging-redis',
+  ]) {
+    assert.match(source, new RegExp(name))
+  }
+  assert.match(source, /docker-compose\.app\.staging\.yml/)
+  assert.doesNotMatch(
+    source.replaceAll('docker-compose.app.staging.yml', ''),
+    /docker-compose\.app\.yml/,
+  )
+  assert.match(source, /assert_staging_only\(\)/)
+})
+
+test('P1 deployed SHA provenance conflicts fail closed instead of selecting one source', () => {
+  const source = read(REMOTE_SH)
+  assert.match(source, /image_commit.*health_commit/s)
+  assert.match(source, /image_commit.*==.*health_commit/s)
+  assert.match(source, /printf 'conflict'/)
+  assert.match(source, /build_provenance_conflict/)
+  assert.match(source, /deployed staging SHA provenance conflict/)
+  assert.match(source, /printf 'unknown'/)
+  assert.doesNotMatch(source, /if \[\[ -n "\$image_commit" \]\]; then printf/)
+  assert.doesNotMatch(source, /if \[\[ "\$health_commit" =~ \^\[0-9a-f\]\{40\}\$ \]\]; then printf/)
+})
+
+test('backend health proof never falls back to the web health endpoint', () => {
+  const source = read(REMOTE_SH)
+  const start = source.indexOf('capture_live_snapshot()')
+  const end = source.indexOf('\nbackup_lifecycle_override()', start)
+  const body = source.slice(start, end)
+  assert.match(body, /SNAP_HEALTH_OK="\$\(fetch_backend_health_ok\)"/)
+  assert.doesNotMatch(body, /STAGING_WEB_HEALTH_URL/)
+})
+
+// --- P1: migrations unknown is never success ------------------------------------------
+
+test('P1 migrations: probe returns true|false|unknown and require_migrations rejects unknown', () => {
+  const source = read(REMOTE_SH)
+  assert.match(source, /probe_migration_pending_zero\(\)/)
+  assert.match(source, /printf 'unknown'/)
+  assert.match(source, /require_migrations_pending_zero_true/)
+  assert.match(
+    source,
+    /migrations_pending_zero must be exactly true \(got '\$\{v\}' — probe unknown/,
+  )
+  // preflight fails on unknown
+  assert.match(source, /migrations_probe_unknown/)
+  assert.match(
+    source,
+    /if \[\[ "\$SNAP_MIGRATIONS_ZERO" != "true" \]\]/,
+  )
+})
+
+test('MUTATION: treating unknown migrations as success would fail require_migrations contract', () => {
+  const original = read(REMOTE_SH)
+  // If someone softens require to accept unknown as ok, the exact fail string disappears.
+  const mutated = original.replaceAll(
+    'migrations_pending_zero must be exactly true (got \'${v}\' — probe unknown/failed; refuse, do not treat unknown as success)',
+    'migrations probe soft-pass',
+  )
+  let failed = false
+  try {
+    assert.match(mutated, /do not treat unknown as success/)
+  } catch {
+    failed = true
+  }
+  assert.equal(failed, true)
+})
+
+test('production function: require_migrations_pending_zero_true accepts only true', () => {
+  function run(v) {
+    return spawnSync(
+      'bash',
+      ['-o', 'pipefail', '-c', `source "$1"; require_migrations_pending_zero_true "$2" test`, 'bash', REMOTE_SH, v],
+      {
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          ACTION: 'status',
+          OUTPUT_DIR: '/tmp/lifecycle-canary-contract-source-only',
+          RUN_STAMP: 'contract',
+          LIFECYCLE_CANARY_SOURCE_ONLY: 'true',
+        },
+      },
+    )
+  }
+  assert.equal(run('true').status, 0)
+  assert.notEqual(run('false').status, 0)
+  assert.notEqual(run('unknown').status, 0)
+  assert.match(run('unknown').stderr, /unknown/)
+})
+
+// --- P1: ON actions NOT EXECUTABLE ----------------------------------------------------
+
+test('P1 ON not executable: alias/pending/deprovision route to action_not_executable_on', () => {
+  const source = read(REMOTE_SH)
+  assert.match(source, /alias\) action_not_executable_on alias/)
+  assert.match(source, /pending\) action_not_executable_on pending/)
+  assert.match(source, /deprovision\) action_not_executable_on deprovision/)
+  assert.match(source, /NOT EXECUTABLE/)
+  assert.match(source, /not_executable_no_real_verifier/)
+  assert.match(source, /transition_applied=false/)
+  // Must not call write_lifecycle_override from the not-executable path with true flags.
+  const start = source.indexOf('action_not_executable_on()')
+  const end = source.indexOf('\naction_off()', start)
+  assert.notEqual(start, -1)
+  assert.notEqual(end, -1)
+  const body = source.slice(start, end)
+  assert.doesNotMatch(body, /write_lifecycle_override/)
+  assert.doesNotMatch(body, /recreate_backend_only/)
+  assert.match(body, /transition_applied.*false|false" "false"/)
+  const preflightStart = source.indexOf('preflight_for_target()')
+  const preflightEnd = source.indexOf('\naction_preflight()', preflightStart)
+  const preflightBody = source.slice(preflightStart, preflightEnd)
+  assert.match(preflightBody, /PREFLIGHT_OK="false"[\s\S]*not_executable_no_real_verifier/)
+})
+
+test('P1 only action=off writes lifecycle override (executable transition)', () => {
+  const source = read(REMOTE_SH)
+  assert.match(source, /off\) action_off/)
+  assert.match(source, /action_off\(\)/)
+  // write_lifecycle_override only with all false for off
+  assert.match(source, /write_lifecycle_override "false" "false" "false"/)
+  // No flags_for_mode true for alias in executable path
+  assert.doesNotMatch(source, /write_lifecycle_override "true"/)
+})
+
+test('MUTATION: re-enabling alias as action_transition would fail NOT EXECUTABLE contract', () => {
+  const original = read(REMOTE_SH)
+  const mutated = original.replace(
+    'alias) action_not_executable_on alias ;;',
+    'alias) action_off ;;', // wrong — would break the not-executable contract
+  )
+  let failed = false
+  try {
+    assert.match(mutated, /alias\) action_not_executable_on alias/)
+  } catch {
+    failed = true
+  }
+  assert.equal(failed, true)
+})
+
+test('workflow and remote do not export or require canary presence tokens as ON enablers', () => {
+  const yaml = read(WORKFLOW)
+  const source = read(REMOTE_SH)
+  assert.doesNotMatch(yaml, /CANARY_SUBJECT_ID/)
+  assert.doesNotMatch(yaml, /OWNER_CONFIRM/)
+  assert.doesNotMatch(source, /has_canary_inputs/)
+  assert.match(source, /NOT used/)
+})
+
+// --- P1: health true required after restart -------------------------------------------
+
+test('P1 recreate_backend_only requires health true after restart (returns 1 otherwise)', () => {
+  const source = read(REMOTE_SH)
+  assert.match(source, /recreate_backend_only\(\)/)
+  assert.match(source, /backend health not true after restart — refuse transition success/)
+  assert.match(source, /return 1/)
+  // action=off must not claim success without recreate success
+  assert.match(source, /if ! recreate_backend_only; then/)
+  assert.match(source, /fail_transition_restore "backend_health_not_true_after_restart"/)
+})
+
+test('MUTATION: dropping health requirement after recreate turns contract red', () => {
+  const original = read(REMOTE_SH)
+  const mutated = original.replaceAll(
+    'backend health not true after restart — refuse transition success',
+    'loop ended ok',
+  )
+  let failed = false
+  try {
+    assert.match(mutated, /backend health not true after restart — refuse transition success/)
+  } catch {
+    failed = true
+  }
+  assert.equal(failed, true)
+})
+
+// --- P1: previous-override restore on failure -----------------------------------------
+
+test('P1 off backs up previous override and restores on restart/health/mode failure', () => {
+  const source = read(REMOTE_SH)
+  assert.match(source, /backup_lifecycle_override/)
+  assert.match(source, /restore_lifecycle_override/)
+  assert.match(source, /fail_transition_restore/)
+  assert.match(source, /LIFECYCLE_PREV_STATE/)
+  assert.match(source, /previous override restored/)
+  // Order must be measured inside the production action body, never against definitions.
+  const actionStart = source.indexOf('action_off()')
+  const actionEnd = source.indexOf('\n# --- main', actionStart)
+  const actionBody = source.slice(actionStart, actionEnd)
+  const backupIdx = actionBody.indexOf('backup_lifecycle_override')
+  const writeIdx = actionBody.indexOf('write_lifecycle_override "false" "false" "false"')
+  const restoreIdx = actionBody.indexOf('fail_transition_restore')
+  assert.ok(backupIdx > 0 && writeIdx > backupIdx, 'backup before write')
+  assert.ok(restoreIdx > 0)
+})
+
+test('MUTATION: removing restore-on-failure path turns rollback contract red', () => {
+  const original = read(REMOTE_SH)
+  const mutated = original.replaceAll('fail_transition_restore', 'fail_no_restore')
+  let failed = false
+  try {
+    assert.match(mutated, /fail_transition_restore/)
+  } catch {
+    failed = true
+  }
+  assert.equal(failed, true)
+})
+
+// --- P2: multi-on status/preflight fail closed; off still clears ----------------------
+
+test('P2 classify_mode returns multi-on without dying; status/preflight fail closed; off clears', () => {
+  const source = read(REMOTE_SH)
+  assert.match(source, /classify_mode_from_flags/)
+  assert.match(source, /printf 'multi-on'/)
+  // Must NOT fail inside classify (old derive_mode_from_flags fail closed blocked off)
+  const classifyStart = source.indexOf('classify_mode_from_flags()')
+  const classifyEnd = source.indexOf('\nread_live_flags()', classifyStart)
+  const classifyBody = source.slice(classifyStart, classifyEnd)
+  assert.doesNotMatch(classifyBody, /\bfail\b/)
+  assert.match(source, /multi_on_fail_closed/)
+  assert.match(source, /status fail-closed: \$\{note\}/)
+  assert.match(source, /write_lifecycle_override "false" "false" "false"/)
+})
+
+test('production function: classify_mode_from_flags multi-on vs single modes', () => {
+  function run(a, p, d) {
+    return spawnSync(
+      'bash',
+      [
+        '-o',
+        'pipefail',
+        '-c',
+        'source "$1"; classify_mode_from_flags "$2" "$3" "$4"',
+        'bash',
+        REMOTE_SH,
+        a,
+        p,
+        d,
+      ],
+      {
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          ACTION: 'status',
+          OUTPUT_DIR: '/tmp/lifecycle-canary-contract-source-only',
+          RUN_STAMP: 'contract',
+          LIFECYCLE_CANARY_SOURCE_ONLY: 'true',
+        },
+      },
+    )
+  }
+  assert.equal(run('false', 'false', 'false').stdout.trim(), 'off')
+  assert.equal(run('true', 'false', 'false').stdout.trim(), 'alias')
+  assert.equal(run('true', 'true', 'false').stdout.trim(), 'multi-on')
+  assert.equal(run('true', 'false', 'true').status, 0) // does not die
+  assert.equal(run('true', 'false', 'true').stdout.trim(), 'multi-on')
+})
+
+test('MUTATION: reintroducing fail inside classify_mode blocks off path (contract red)', () => {
+  const original = read(REMOTE_SH)
+  const mutated = original.replace(
+    "printf 'multi-on'\n    return 0",
+    'fail "multi-on blocked in classify"\n    return 1',
+  )
+  const classifyStart = mutated.indexOf('classify_mode_from_flags()')
+  const classifyEnd = mutated.indexOf('\nread_live_flags()', classifyStart)
+  const classifyBody = mutated.slice(classifyStart, classifyEnd)
+  let failed = false
+  try {
+    assert.doesNotMatch(classifyBody, /\bfail\b/)
+  } catch {
+    failed = true
+  }
+  assert.equal(failed, true)
+})
+
+// --- override atomic + attendance compose ---------------------------------------------
+
+test('lifecycle override separate from attendance; atomic mktemp+validate+mv', () => {
+  const source = read(REMOTE_SH)
+  assert.match(source, /LIFECYCLE_PERSIST_DIR="\$\{HOME\}\/\.metasheet2\/lifecycle-canary"/)
+  assert.match(source, /ATTENDANCE_OVERRIDE_FILE=/)
+  assert.match(source, /override_tmp="\$\(mktemp "\$\{LIFECYCLE_PERSIST_DIR\}\/\.override\.XXXXXX"\)"/)
+  assert.match(source, /mv -f "\$override_tmp" "\$LIFECYCLE_OVERRIDE_FILE"/)
+  assert.match(source, /up -d --no-deps --force-recreate backend/)
+})
+
+// --- status artifact redaction --------------------------------------------------------
+
+test('status artifact is values-free (no credentials/PII/canary ids)', () => {
+  const source = read(REMOTE_SH)
+  const start = source.indexOf('write_status_artifact()')
+  const end = source.indexOf('\ncapture_live_snapshot()', start)
+  const body = source.slice(start, end)
+  assert.match(body, /schema=dingtalk-lifecycle-staging-canary-status-v1/)
+  assert.match(body, /migrations_pending_zero=/)
+  assert.doesNotMatch(body, /DATABASE_URL/)
+  assert.doesNotMatch(body, /JWT_SECRET/)
+  assert.doesNotMatch(body, /CANARY_SUBJECT/)
+  assert.doesNotMatch(body, /printenv/)
+})
+
+// --- docs / staging blockers ----------------------------------------------------------
+
+test('docs mark alias/pending/deprovision NOT EXECUTABLE and canary NOT EXECUTED', () => {
+  const closeout = read(CLOSEOUT_DOC)
+  const go = read(CANARY_GO_DOC)
+  for (const doc of [closeout, go]) {
+    assert.match(doc, /NOT EXECUTABLE/)
+    assert.match(doc, /NOT EXECUTED/)
+  }
+  // Current live evidence and remaining provenance blocker are called out.
+  assert.match(closeout, /314\/0|Pending: 0|migrations_pending_zero=true/i)
+  assert.match(closeout, /provenance conflict|metadata.*old|image.*health/i)
+})
+
+test('docs distinguish emergency off env-gate from OR-column fallback reintroduction', () => {
+  const closeout = read(CLOSEOUT_DOC)
+  assert.match(closeout, /emergency|env gate|env-gate/i)
+  assert.match(closeout, /OR-column|OR fallback|OR 三列/i)
+  assert.doesNotMatch(
+    closeout,
+    /turn alias read path off and prove the pre-cutover login path is restored/,
+  )
+})
+
+test('six-step T2-Gate still points at post-fix 20260725 UAT', () => {
+  const closeout = read(CLOSEOUT_DOC)
+  assert.match(closeout, /dingtalk-directory-corp-scope-staging-uat-20260725\.md/)
+})
+
+test('staging env example keeps three flags OFF and documents minimal safe lane', () => {
+  const env = read(STAGING_ENV_EXAMPLE)
+  assert.match(env, /^AUTH_LOGIN_USE_ALIASES=false$/m)
+  assert.match(env, /^DIRECTORY_PENDING_ACTIVATION_ENABLED=false$/m)
+  assert.match(env, /^DIRECTORY_DEPROVISION_ENABLED=false$/m)
+  assert.match(env, /NOT EXECUTABLE|lifecycle.*canary|canary.*lifecycle/i)
+})
+
+test('workflow exports only safe remote env keys (no canary tokens)', () => {
+  const yaml = read(WORKFLOW)
+  for (const key of [
+    'ACTION',
+    'TARGET_MODE',
+    'EXPECTED_CURRENT_MODE',
+    'DEPLOY_SHA',
+    'STAGING_DEPLOY_PATH',
+    'DEPLOY_PATH',
+    'OUTPUT_DIR',
+    'RUN_STAMP',
+  ]) {
+    assert.match(yaml, new RegExp(`export ${key}=`))
+  }
+  assert.doesNotMatch(yaml, /export CANARY_/)
+  assert.doesNotMatch(yaml, /export OWNER_CONFIRM=/)
+})

--- a/scripts/ops/dingtalk-lifecycle-staging-canary-contract.test.mjs
+++ b/scripts/ops/dingtalk-lifecycle-staging-canary-contract.test.mjs
@@ -573,6 +573,50 @@ test('P2 classify_mode returns multi-on without dying; status/preflight fail clo
   assert.match(source, /write_lifecycle_override "false" "false" "false"/)
 })
 
+test('P1 lifecycle flag reads distinguish a missing key from docker exec failure', () => {
+  function runDocker(body) {
+    return spawnSync(
+      'bash',
+      [
+        '-o',
+        'pipefail',
+        '-c',
+        `source "$1"
+         docker() { ${body}; }
+         if value="$(read_flag_from_container "$FLAG_ALIAS")"; then
+           printf 'accepted:%s' "$value"
+         else
+           printf 'rejected'
+         fi`,
+        'bash',
+        REMOTE_SH,
+      ],
+      {
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          ACTION: 'status',
+          OUTPUT_DIR: '/tmp/lifecycle-canary-contract-source-only',
+          RUN_STAMP: 'contract',
+          LIFECYCLE_CANARY_SOURCE_ONLY: 'true',
+        },
+      },
+    )
+  }
+
+  const missing = runDocker('printf "__MISSING__"; return 0')
+  assert.equal(missing.status, 0, missing.stderr)
+  assert.equal(missing.stdout, 'accepted:false')
+
+  const execFailure = runDocker('return 125')
+  assert.equal(execFailure.status, 0, execFailure.stderr)
+  assert.equal(execFailure.stdout, 'rejected')
+
+  const source = read(REMOTE_SH)
+  assert.doesNotMatch(source, /printenv "\$key"[^\n]*\|\| true/)
+  assert.match(source, /failed to read lifecycle flags from the running staging backend/)
+})
+
 test('production function: classify_mode_from_flags multi-on vs single modes', () => {
   function run(a, p, d) {
     return spawnSync(

--- a/scripts/ops/dingtalk-lifecycle-staging-canary-remote.sh
+++ b/scripts/ops/dingtalk-lifecycle-staging-canary-remote.sh
@@ -1,0 +1,813 @@
+#!/usr/bin/env bash
+# dingtalk-lifecycle-staging-canary-remote.sh
+#
+# Remote (deploy-host) half of .github/workflows/dingtalk-lifecycle-staging-canary.yml.
+# Executes ONE action per invocation against the STAGING stack only.
+#
+# EXECUTABLE (minimal safe lane):
+#   status     — read-only snapshot (values-free closed booleans / SHA / health)
+#   preflight  — read-only readiness for a target mode; never applies env flips
+#   off        — emergency operational rollback of the THREE lifecycle env gates
+#                to OFF (only permitted env write). Atomic previous-override
+#                backup + restore on restart/health/mode failure.
+#
+# NOT EXECUTABLE (fail-closed preflight-only; transition_applied always false):
+#   alias / pending / deprovision
+#     Env flips alone are NOT a canary. There is no secret-backed real verifier
+#     for password-login success/rollback, admit→activate, or sync→deprovision.
+#     Presence tokens must not pretend to drive those paths. These actions only
+#     emit a preflight assessment and refuse apply.
+#
+# HARD SAFETY RAILS:
+#   * Staging compose + metasheet-staging-* containers only; no prod fallback.
+#   * migrations_pending_zero must be exactly "true" for preflight_ok and for
+#     action=off (unknown is a fail, never treated as success).
+#   * action=off: recreate backend only; prove postgres/redis IDs unchanged;
+#     require backend health true after restart; prove exact mode=off; restore
+#     previous override and re-recreate on any failure after the write.
+#   * multi-on: status/preflight report and fail closed; action=off still clears
+#     the exact three flags (does not die in derive_mode before clear).
+#   * Artifacts never contain env values, credentials, subject ids, or PII.
+#   * Invoked as `bash -o pipefail -c '<script>'`.
+set -euo pipefail
+
+log() { echo "[lifecycle-canary] $*"; }
+fail() { echo "[lifecycle-canary][error] $*" >&2; exit 1; }
+
+ACTION="${ACTION:?ACTION is required (status|preflight|off|alias|pending|deprovision)}"
+TARGET_MODE="${TARGET_MODE:-}"
+EXPECTED_CURRENT_MODE="${EXPECTED_CURRENT_MODE:-}"
+DEPLOY_SHA="${DEPLOY_SHA:-}"
+STAGING_DEPLOY_PATH="${STAGING_DEPLOY_PATH:-metasheet2-dingtalk-staging}"
+DEPLOY_PATH="${DEPLOY_PATH:-metasheet2}"
+OUTPUT_DIR="${OUTPUT_DIR:?OUTPUT_DIR is required}"
+RUN_STAMP="${RUN_STAMP:?RUN_STAMP is required (workflow run id marker)}"
+
+# Intentionally ignored: not a real verifier path. Kept empty so accidental
+# exports cannot be mistaken for canary completion evidence.
+# CANARY_SUBJECT_ID / CANARY_INTEGRATION_ID / OWNER_CONFIRM are NOT used.
+
+BACKEND_CONTAINER="metasheet-staging-backend"
+WEB_CONTAINER="metasheet-staging-web"
+POSTGRES_CONTAINER="metasheet-staging-postgres"
+REDIS_CONTAINER="metasheet-staging-redis"
+STAGING_WEB_HEALTH_URL="http://127.0.0.1:8082/api/health"
+STAGING_BACKEND_HEALTH_URL="http://127.0.0.1:18900/health"
+MIGRATE_JS="packages/core-backend/dist/src/db/migrate.js"
+
+FLAG_ALIAS="AUTH_LOGIN_USE_ALIASES"
+FLAG_PENDING="DIRECTORY_PENDING_ACTIVATION_ENABLED"
+FLAG_DEPROVISION="DIRECTORY_DEPROVISION_ENABLED"
+
+resolve_home_path() {
+  local raw="$1"
+  if [[ "$raw" == /* ]]; then
+    printf '%s' "$raw"
+  elif [[ "$raw" == ~/* ]]; then
+    printf '%s' "${HOME}/${raw#~/}"
+  else
+    printf '%s' "${HOME}/${raw}"
+  fi
+}
+
+STAGING_DIR="$(resolve_home_path "$STAGING_DEPLOY_PATH")"
+PROD_REPO_DIR="$(resolve_home_path "$DEPLOY_PATH")"
+STAGING_COMPOSE_FILE="${STAGING_DIR}/docker-compose.app.staging.yml"
+
+ATTENDANCE_PERSIST_DIR="${HOME}/.metasheet2/window-runner"
+ATTENDANCE_OVERRIDE_FILE="${ATTENDANCE_PERSIST_DIR}/docker-compose.window-runner.override.yml"
+
+LIFECYCLE_PERSIST_DIR="${HOME}/.metasheet2/lifecycle-canary"
+LIFECYCLE_OVERRIDE_FILE="${LIFECYCLE_PERSIST_DIR}/docker-compose.lifecycle-canary.override.yml"
+# Previous-override backup used only during action=off for restore-on-failure.
+LIFECYCLE_PREV_BACKUP=""
+LIFECYCLE_PREV_STATE="absent" # absent | present
+
+is_truthy() {
+  local v
+  v="$(printf '%s' "${1:-}" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')"
+  case "$v" in
+    true|1|yes|on) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# --- staging-only guard (fail closed) -------------------------------------------------
+assert_staging_only() {
+  [[ -d "$STAGING_DIR" ]] || fail "staging stack directory missing: ${STAGING_DIR} (set STAGING_DEPLOY_PATH); refusing to guess"
+  [[ -f "$STAGING_COMPOSE_FILE" ]] || fail "staging compose file missing: ${STAGING_COMPOSE_FILE}; fail closed — this runner never falls back to another compose file"
+  grep -q "container_name: ${BACKEND_CONTAINER}" "$STAGING_COMPOSE_FILE" \
+    || fail "compose file does not define ${BACKEND_CONTAINER}; refusing (wrong file?)"
+  grep -q "container_name: ${WEB_CONTAINER}" "$STAGING_COMPOSE_FILE" \
+    || fail "compose file does not define ${WEB_CONTAINER}; refusing (wrong file?)"
+  grep -q "container_name: ${POSTGRES_CONTAINER}" "$STAGING_COMPOSE_FILE" \
+    || fail "compose file does not define ${POSTGRES_CONTAINER}; refusing (wrong file?)"
+  grep -q "container_name: ${REDIS_CONTAINER}" "$STAGING_COMPOSE_FILE" \
+    || fail "compose file does not define ${REDIS_CONTAINER}; refusing (wrong file?)"
+  if grep -qE 'container_name: metasheet-(backend|web|postgres|redis)[[:space:]]*$' "$STAGING_COMPOSE_FILE"; then
+    fail "compose file defines PROD-track container names; refusing"
+  fi
+  if [[ "$STAGING_DIR" == "$PROD_REPO_DIR" ]]; then
+    fail "staging stack dir equals the prod-track repo dir (${STAGING_DIR}); refusing"
+  fi
+  if [[ "$(basename "$STAGING_COMPOSE_FILE")" != "docker-compose.app.staging.yml" ]]; then
+    fail "compose basename is not docker-compose.app.staging.yml; refusing production fallback"
+  fi
+  log "staging-only guard OK: dir=${STAGING_DIR} compose=$(basename "$STAGING_COMPOSE_FILE")"
+}
+
+require_compose_v2() {
+  if docker compose version >/dev/null 2>&1; then
+    return 0
+  fi
+  fail "docker compose v2 plugin is required"
+}
+
+compose_staging_cmd() {
+  # compose_staging_cmd [override_file_or_empty] <compose args...>
+  local override_arg="${1:-}"
+  shift || true
+  local -a files=(-f "$STAGING_COMPOSE_FILE")
+  if [[ -f "$ATTENDANCE_OVERRIDE_FILE" ]]; then
+    files+=(-f "$ATTENDANCE_OVERRIDE_FILE")
+  fi
+  if [[ -n "$override_arg" ]]; then
+    files+=(-f "$override_arg")
+  elif [[ -f "$LIFECYCLE_OVERRIDE_FILE" ]]; then
+    files+=(-f "$LIFECYCLE_OVERRIDE_FILE")
+  fi
+  (cd "$STAGING_DIR" && docker compose "${files[@]}" "$@")
+}
+
+require_sha() {
+  [[ "$DEPLOY_SHA" =~ ^[0-9a-f]{40}$ ]] \
+    || fail "deploy_sha must be the FULL 40-char lowercase commit SHA, got: '${DEPLOY_SHA}'"
+}
+
+fetch_health_commit() {
+  local body
+  if ! body="$(curl -fsS --max-time 10 "$STAGING_WEB_HEALTH_URL" 2>/dev/null)"; then
+    printf ''
+    return 0
+  fi
+  printf '%s' "$body" | python3 -c 'import json,sys
+try:
+    print(json.load(sys.stdin).get("build", {}).get("commit", ""))
+except Exception:
+    print("")'
+}
+
+fetch_backend_health_ok() {
+  local body
+  if ! body="$(curl -fsS --max-time 10 "$STAGING_BACKEND_HEALTH_URL" 2>/dev/null)"; then
+    printf 'false'
+    return 0
+  fi
+  printf '%s' "$body" | python3 -c 'import json,sys
+try:
+    d=json.load(sys.stdin)
+    print("true" if d.get("ok") is True or d.get("status")=="ok" else "false")
+except Exception:
+    print("false")'
+}
+
+resolve_deployed_sha() {
+  local live_image image_commit="" health_commit=""
+  live_image="$(docker inspect -f '{{.Config.Image}}' "$BACKEND_CONTAINER" 2>/dev/null || true)"
+  if [[ "$live_image" =~ :([0-9a-f]{40})$ ]]; then
+    image_commit="${BASH_REMATCH[1]}"
+  fi
+  health_commit="$(fetch_health_commit)"
+
+  # Exact proof requires both sources and agreement. Accepting either source alone would turn
+  # missing/stale health metadata or an unpinned image tag into a false exact-SHA proof.
+  if [[ -n "$image_commit" && "$health_commit" =~ ^[0-9a-f]{40}$ ]]; then
+    if [[ "$image_commit" == "$health_commit" ]]; then
+      printf '%s' "$image_commit"
+    else
+      printf 'conflict'
+    fi
+    return 0
+  fi
+  printf 'unknown'
+}
+
+read_flag_from_container() {
+  local key="$1" val
+  val="$(docker exec "$BACKEND_CONTAINER" printenv "$key" 2>/dev/null || true)"
+  if is_truthy "$val"; then
+    printf 'true'
+  else
+    printf 'false'
+  fi
+}
+
+# Classify mode. NEVER fails on multi-on — returns mode "multi-on" so action=off
+# can still clear. status/preflight fail closed separately after reporting.
+classify_mode_from_flags() {
+  local alias_on="$1" pending_on="$2" deprov_on="$3"
+  local count=0 mode="off"
+  if [[ "$alias_on" == "true" ]]; then count=$((count + 1)); mode="alias"; fi
+  if [[ "$pending_on" == "true" ]]; then count=$((count + 1)); mode="pending"; fi
+  if [[ "$deprov_on" == "true" ]]; then count=$((count + 1)); mode="deprovision"; fi
+  if [[ "$count" -gt 1 ]]; then
+    printf 'multi-on'
+    return 0
+  fi
+  printf '%s' "$mode"
+}
+
+read_live_flags() {
+  # stdout: "alias_on pending_on deprov_on mode" — mode may be multi-on
+  local a p d m
+  a="$(read_flag_from_container "$FLAG_ALIAS")"
+  p="$(read_flag_from_container "$FLAG_PENDING")"
+  d="$(read_flag_from_container "$FLAG_DEPROVISION")"
+  m="$(classify_mode_from_flags "$a" "$p" "$d")"
+  printf '%s %s %s %s' "$a" "$p" "$d" "$m"
+}
+
+probe_alias_readiness() {
+  local out
+  if ! docker inspect -f '{{.State.Running}}' "$BACKEND_CONTAINER" 2>/dev/null | grep -qx 'true'; then
+    printf 'false'
+    return 0
+  fi
+  out="$(docker exec "$BACKEND_CONTAINER" node -e '
+const { Client } = require("pg");
+(async () => {
+  const url = process.env.DATABASE_URL;
+  if (!url) { process.stdout.write("false"); process.exit(0); }
+  const c = new Client({ connectionString: url, connectionTimeoutMillis: 5000 });
+  try {
+    await c.connect();
+    const r = await c.query(`
+      SELECT count(*)::int AS n
+        FROM users u
+        JOIN user_login_aliases a ON a.user_id = u.id
+        JOIN user_roles ur ON ur.user_id = u.id AND ur.role_id = $1
+       WHERE u.is_active = TRUE
+         AND COALESCE(u.local_password_set, TRUE) = TRUE
+         AND COALESCE(u.activation_status, $2) = $2
+         AND u.password_hash IS NOT NULL
+         AND length(trim(u.password_hash)) > 0
+         AND u.password_hash NOT LIKE $3
+    `, ["admin", "activated", "unusable:%"]);
+    process.stdout.write((r.rows[0]?.n ?? 0) > 0 ? "true" : "false");
+  } catch {
+    process.stdout.write("false");
+  } finally {
+    try { await c.end(); } catch { /* ignore */ }
+  }
+})().catch(() => { process.stdout.write("false"); });
+' 2>/dev/null || true)"
+  if [[ "$out" == "true" ]]; then
+    printf 'true'
+  else
+    printf 'false'
+  fi
+}
+
+# Returns exactly one of: true | false | unknown
+# unknown MUST fail preflight and transitions — never treated as success.
+probe_migration_pending_zero() {
+  if ! docker inspect -f '{{.State.Running}}' "$BACKEND_CONTAINER" 2>/dev/null | grep -qx 'true'; then
+    printf 'unknown'
+    return 0
+  fi
+  local list
+  if ! list="$(docker exec "$BACKEND_CONTAINER" node "$MIGRATE_JS" --list < /dev/null 2>/dev/null)"; then
+    printf 'unknown'
+    return 0
+  fi
+  if ! printf '%s\n' "$list" | grep -qE '^Pending:'; then
+    # list ran but did not emit the expected contract line → probe failed
+    printf 'unknown'
+    return 0
+  fi
+  if printf '%s\n' "$list" | grep -q '^Pending: 0$'; then
+    printf 'true'
+  else
+    printf 'false'
+  fi
+}
+
+require_migrations_pending_zero_true() {
+  # Load-bearing for every transition (currently only action=off) and for preflight_ok.
+  local v="$1" context="$2"
+  if [[ "$v" == "true" ]]; then
+    return 0
+  fi
+  if [[ "$v" == "false" ]]; then
+    fail "${context}: migrations_pending_zero must be exactly true (got false — pending migrations; run attendance staging migrate backup/clone-rehearsal first)"
+  fi
+  fail "${context}: migrations_pending_zero must be exactly true (got '${v}' — probe unknown/failed; refuse, do not treat unknown as success)"
+}
+
+validate_mode_name() {
+  local m="$1" label="$2"
+  case "$m" in
+    off|alias|pending|deprovision|multi-on) ;;
+    *) fail "${label} must be one of off|alias|pending|deprovision|multi-on, got: '${m}'" ;;
+  esac
+}
+
+write_status_artifact() {
+  local build_sha="$1"
+  local alias_on="$2" pending_on="$3" deprov_on="$4" mode="$5"
+  local alias_ready="$6" can_enable_alias="$7"
+  local migrations_pending_zero="$8" health_ok="$9"
+  local preflight_target="${10:-}"
+  local preflight_ok="${11:-}"
+  local transition_applied="${12:-false}"
+  local note="${13:-}"
+
+  # STATUS ARTIFACT CONTRACT: only closed booleans / SHAs / health. Never dump env,
+  # credentials, canary subject ids, integration ids, or PII.
+  {
+    echo "schema=dingtalk-lifecycle-staging-canary-status-v1"
+    echo "build_sha=${build_sha}"
+    echo "mode=${mode}"
+    echo "auth_login_use_aliases=${alias_on}"
+    echo "directory_pending_activation_enabled=${pending_on}"
+    echo "directory_deprovision_enabled=${deprov_on}"
+    echo "alias_admin_password_ready=${alias_ready}"
+    echo "alias_can_enable_cutover=${can_enable_alias}"
+    echo "migrations_pending_zero=${migrations_pending_zero}"
+    echo "backend_health_ok=${health_ok}"
+    if [[ -n "$preflight_target" ]]; then
+      echo "preflight_target_mode=${preflight_target}"
+      echo "preflight_ok=${preflight_ok}"
+    fi
+    echo "transition_applied=${transition_applied}"
+    if [[ -n "$note" ]]; then
+      echo "note=${note}"
+    fi
+  } > "${OUTPUT_DIR}/lifecycle-status.txt"
+
+  local mig_json
+  case "$migrations_pending_zero" in
+    true) mig_json=true ;;
+    false) mig_json=false ;;
+    *) mig_json=null ;; # unknown
+  esac
+
+  {
+    echo "{"
+    echo "  \"schema\": \"dingtalk-lifecycle-staging-canary-status-v1\","
+    echo "  \"build_sha\": $(python3 -c 'import json,sys; print(json.dumps(sys.argv[1]))' "$build_sha"),"
+    echo "  \"mode\": $(python3 -c 'import json,sys; print(json.dumps(sys.argv[1]))' "$mode"),"
+    echo "  \"flags\": {"
+    echo "    \"auth_login_use_aliases\": ${alias_on},"
+    echo "    \"directory_pending_activation_enabled\": ${pending_on},"
+    echo "    \"directory_deprovision_enabled\": ${deprov_on}"
+    echo "  },"
+    echo "  \"alias_readiness\": {"
+    echo "    \"admin_password_alias_ready\": ${alias_ready},"
+    echo "    \"can_enable_cutover\": ${can_enable_alias}"
+    echo "  },"
+    echo "  \"migrations_pending_zero\": ${mig_json},"
+    echo "  \"migrations_probe\": $(python3 -c 'import json,sys; print(json.dumps(sys.argv[1]))' "$migrations_pending_zero"),"
+    echo "  \"backend_health_ok\": ${health_ok},"
+    if [[ -n "$preflight_target" ]]; then
+      echo "  \"preflight_target_mode\": $(python3 -c 'import json,sys; print(json.dumps(sys.argv[1]))' "$preflight_target"),"
+      echo "  \"preflight_ok\": ${preflight_ok},"
+    fi
+    echo "  \"transition_applied\": ${transition_applied}"
+    echo "}"
+  } > "${OUTPUT_DIR}/lifecycle-status.json"
+}
+
+capture_live_snapshot() {
+  # Sets globals: SNAP_*. Never fails solely because mode is multi-on.
+  if ! docker inspect -f '{{.State.Running}}' "$BACKEND_CONTAINER" 2>/dev/null | grep -qx 'true'; then
+    fail "staging backend container is not running: ${BACKEND_CONTAINER}"
+  fi
+  read -r SNAP_ALIAS SNAP_PENDING SNAP_DEPROV SNAP_MODE <<< "$(read_live_flags)"
+  SNAP_BUILD_SHA="$(resolve_deployed_sha)"
+  SNAP_ALIAS_READY="$(probe_alias_readiness)"
+  if [[ "$SNAP_ALIAS_READY" == "true" ]]; then
+    SNAP_CAN_ENABLE_ALIAS="true"
+  else
+    SNAP_CAN_ENABLE_ALIAS="false"
+  fi
+  SNAP_MIGRATIONS_ZERO="$(probe_migration_pending_zero)"
+  SNAP_HEALTH_OK="$(fetch_backend_health_ok)"
+}
+
+backup_lifecycle_override() {
+  mkdir -p "$LIFECYCLE_PERSIST_DIR"
+  LIFECYCLE_PREV_BACKUP="$(mktemp "${LIFECYCLE_PERSIST_DIR}/.prev.XXXXXX")"
+  if [[ -f "$LIFECYCLE_OVERRIDE_FILE" ]]; then
+    cp -p "$LIFECYCLE_OVERRIDE_FILE" "$LIFECYCLE_PREV_BACKUP"
+    LIFECYCLE_PREV_STATE="present"
+    log "previous lifecycle override backed up for restore-on-failure"
+  else
+    : > "$LIFECYCLE_PREV_BACKUP"
+    LIFECYCLE_PREV_STATE="absent"
+    log "no previous lifecycle override (rollback will remove candidate on failure)"
+  fi
+}
+
+restore_lifecycle_override() {
+  # Restore previous override state after a failed transition.
+  if [[ "$LIFECYCLE_PREV_STATE" == "present" && -n "$LIFECYCLE_PREV_BACKUP" && -s "$LIFECYCLE_PREV_BACKUP" ]]; then
+    cp -p "$LIFECYCLE_PREV_BACKUP" "$LIFECYCLE_OVERRIDE_FILE"
+    log "restored previous lifecycle override from backup"
+  else
+    rm -f "$LIFECYCLE_OVERRIDE_FILE"
+    log "removed lifecycle override (previous state was absent)"
+  fi
+}
+
+cleanup_prev_backup() {
+  if [[ -n "$LIFECYCLE_PREV_BACKUP" ]]; then
+    rm -f "$LIFECYCLE_PREV_BACKUP"
+    LIFECYCLE_PREV_BACKUP=""
+  fi
+}
+
+write_lifecycle_override() {
+  local alias_val="$1" pending_val="$2" deprov_val="$3"
+  require_compose_v2
+  mkdir -p "$LIFECYCLE_PERSIST_DIR"
+  local override_tmp
+  override_tmp="$(mktemp "${LIFECYCLE_PERSIST_DIR}/.override.XXXXXX")"
+  {
+    echo "# Written by dingtalk-lifecycle-staging-canary (run ${RUN_STAMP})."
+    echo "# SEPARATE from attendance window-runner override. Atomic rewrite only."
+    echo "# OFF is an emergency operational rollback of these env gates only —"
+    echo "# it does NOT reintroduce OR-column login fallback as a long-term design"
+    echo "# (design lock Rev 4.2 §4.2 / §4.4: after T2b cutover, Auth reads aliases only)."
+    echo "# alias/pending/deprovision ON are NOT EXECUTABLE in this lane."
+    echo "services:"
+    echo "  backend:"
+    echo "    environment:"
+    echo "      ${FLAG_ALIAS}: \"${alias_val}\""
+    echo "      ${FLAG_PENDING}: \"${pending_val}\""
+    echo "      ${FLAG_DEPROVISION}: \"${deprov_val}\""
+  } > "$override_tmp"
+
+  local -a val_files=(-f "$STAGING_COMPOSE_FILE")
+  if [[ -f "$ATTENDANCE_OVERRIDE_FILE" ]]; then
+    val_files+=(-f "$ATTENDANCE_OVERRIDE_FILE")
+  fi
+  val_files+=(-f "$override_tmp")
+  if ! (cd "$STAGING_DIR" && docker compose "${val_files[@]}" config) >/dev/null 2>&1; then
+    rm -f "$override_tmp"
+    fail "candidate lifecycle override failed 'docker compose config' validation; kept previous override at ${LIFECYCLE_OVERRIDE_FILE}"
+  fi
+  mv -f "$override_tmp" "$LIFECYCLE_OVERRIDE_FILE"
+  log "lifecycle override written (persistent, atomic): ${LIFECYCLE_OVERRIDE_FILE}"
+}
+
+# Recreate backend only. Returns 0 only when health is proven true after restart.
+# Does NOT call fail() itself so callers can restore previous override first.
+recreate_backend_only() {
+  local pg_id_before redis_id_before pg_id_after redis_id_after
+  local i health
+
+  pg_id_before="$(docker inspect -f '{{.Id}}' "$POSTGRES_CONTAINER")" \
+    || { log "staging postgres container not found"; return 1; }
+  redis_id_before="$(docker inspect -f '{{.Id}}' "$REDIS_CONTAINER")" \
+    || { log "staging redis container not found"; return 1; }
+
+  if ! compose_staging_cmd "" up -d --no-deps --force-recreate backend 2>&1 \
+    | tee "${OUTPUT_DIR}/compose-up-backend.log"; then
+    log "compose up backend failed"
+    return 1
+  fi
+
+  pg_id_after="$(docker inspect -f '{{.Id}}' "$POSTGRES_CONTAINER" 2>/dev/null || true)"
+  redis_id_after="$(docker inspect -f '{{.Id}}' "$REDIS_CONTAINER" 2>/dev/null || true)"
+  if [[ "$pg_id_before" != "$pg_id_after" ]]; then
+    log "staging postgres container was recreated — hard constraint violated"
+    return 1
+  fi
+  if [[ "$redis_id_before" != "$redis_id_after" ]]; then
+    log "staging redis container was recreated — hard constraint violated"
+    return 1
+  fi
+  log "postgres/redis untouched (container ids unchanged)"
+
+  # Require health true after restart — do not claim success on loop exit alone.
+  for ((i = 1; i <= 30; i += 1)); do
+    if docker inspect -f '{{.State.Running}}' "$BACKEND_CONTAINER" 2>/dev/null | grep -qx 'true'; then
+      health="$(fetch_backend_health_ok)"
+      if [[ "$health" == "true" ]]; then
+        log "backend health true after restart (attempt ${i}/30)"
+        return 0
+      fi
+    fi
+    log "waiting for backend health true (attempt ${i}/30)"
+    sleep 2
+  done
+  log "backend health not true after restart — refuse transition success"
+  return 1
+}
+
+assert_exact_mode_off() {
+  local a p d m
+  read -r a p d m <<< "$(read_live_flags)"
+  if [[ "$a" == "false" && "$p" == "false" && "$d" == "false" && "$m" == "off" ]]; then
+    log "exact mode proven after restart: off (all three flags false)"
+    return 0
+  fi
+  log "post-restart mode is '${m}' (alias=${a} pending=${p} deprovision=${d}), expected off with all false"
+  return 1
+}
+
+assert_exact_sha() {
+  require_sha
+  local live
+  live="$(resolve_deployed_sha)"
+  [[ "$live" != "conflict" ]] \
+    || fail "deployed staging SHA provenance conflict (image tag and health commit disagree)"
+  [[ "$live" =~ ^[0-9a-f]{40}$ ]] \
+    || fail "could not resolve one exact deployed staging SHA (image tag / health commit)"
+  [[ "$live" == "$DEPLOY_SHA" ]] \
+    || fail "deployed SHA '${live}' does not match required exact deploy_sha '${DEPLOY_SHA}'"
+  log "exact deployed SHA OK: ${live}"
+}
+
+fail_transition_restore() {
+  local reason="$1"
+  log "transition failure (${reason}); restoring previous lifecycle override and re-recreating backend"
+  restore_lifecycle_override
+  # Best-effort recreate after restore so live env matches restored override.
+  recreate_backend_only || log "restore recreate did not reach health true; operator must inspect staging"
+  cleanup_prev_backup
+  fail "action=off failed: ${reason} (previous override restored)"
+}
+
+# --- actions ---------------------------------------------------------------------------
+
+action_status() {
+  capture_live_snapshot
+  local note="read-only status"
+  local rc=0
+  if [[ "$SNAP_MODE" == "multi-on" ]]; then
+    note="multi_on_fail_closed"
+    rc=1
+  fi
+  if [[ "$SNAP_BUILD_SHA" == "conflict" ]]; then
+    note="${note};build_provenance_conflict"
+    rc=1
+  elif [[ "$SNAP_BUILD_SHA" == "unknown" ]]; then
+    note="${note};build_provenance_unknown"
+    rc=1
+  fi
+  if [[ "$SNAP_MIGRATIONS_ZERO" == "unknown" ]]; then
+    note="${note};migrations_probe_unknown"
+    # status still reports; do not hard-fail solely on unknown unless multi-on already fails
+  fi
+  write_status_artifact \
+    "${SNAP_BUILD_SHA:-unknown}" \
+    "$SNAP_ALIAS" "$SNAP_PENDING" "$SNAP_DEPROV" "$SNAP_MODE" \
+    "$SNAP_ALIAS_READY" "$SNAP_CAN_ENABLE_ALIAS" \
+    "$SNAP_MIGRATIONS_ZERO" "$SNAP_HEALTH_OK" \
+    "" "" "false" "$note"
+  {
+    echo "action=status"
+    echo "mode=${SNAP_MODE}"
+    echo "build_sha=${SNAP_BUILD_SHA:-unknown}"
+    echo "migrations_pending_zero=${SNAP_MIGRATIONS_ZERO}"
+    echo "transition_applied=false"
+    echo "note=${note}"
+  } > "${OUTPUT_DIR}/summary.txt"
+  if [[ "$rc" -ne 0 ]]; then
+    fail "status fail-closed: ${note}"
+  fi
+  log "status OK mode=${SNAP_MODE}"
+}
+
+preflight_for_target() {
+  # Sets PREFLIGHT_OK=true|false and PREFLIGHT_NOTE (values-free reason codes only).
+  local target="$1"
+  PREFLIGHT_OK="true"
+  PREFLIGHT_NOTE="ok"
+  validate_mode_name "$target" "target_mode"
+
+  # migrations: exactly true required — unknown is a fail (never acceptable success).
+  if [[ "$SNAP_MIGRATIONS_ZERO" != "true" ]]; then
+    PREFLIGHT_OK="false"
+    if [[ "$SNAP_MIGRATIONS_ZERO" == "unknown" ]]; then
+      PREFLIGHT_NOTE="migrations_probe_unknown"
+    else
+      PREFLIGHT_NOTE="migrations_pending"
+    fi
+    return 0
+  fi
+
+  if [[ "$SNAP_MODE" == "multi-on" ]]; then
+    PREFLIGHT_OK="false"
+    PREFLIGHT_NOTE="multi_on_fail_closed"
+    return 0
+  fi
+
+  if [[ "$SNAP_BUILD_SHA" == "conflict" || -z "$SNAP_BUILD_SHA" ]]; then
+    PREFLIGHT_OK="false"
+    if [[ "$SNAP_BUILD_SHA" == "conflict" ]]; then
+      PREFLIGHT_NOTE="build_provenance_conflict"
+    else
+      PREFLIGHT_NOTE="build_provenance_unknown"
+    fi
+    return 0
+  fi
+
+  if [[ -n "$EXPECTED_CURRENT_MODE" ]]; then
+    validate_mode_name "$EXPECTED_CURRENT_MODE" "expected_current_mode"
+    if [[ "$SNAP_MODE" != "$EXPECTED_CURRENT_MODE" ]]; then
+      PREFLIGHT_OK="false"
+      PREFLIGHT_NOTE="expected_current_mode_mismatch"
+      return 0
+    fi
+  fi
+
+  if [[ -n "$DEPLOY_SHA" ]]; then
+    if [[ ! "$DEPLOY_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+      PREFLIGHT_OK="false"
+      PREFLIGHT_NOTE="deploy_sha_invalid"
+      return 0
+    fi
+    if [[ "${SNAP_BUILD_SHA:-}" != "$DEPLOY_SHA" ]]; then
+      PREFLIGHT_OK="false"
+      PREFLIGHT_NOTE="deploy_sha_mismatch"
+      return 0
+    fi
+  fi
+
+  if [[ "$SNAP_HEALTH_OK" != "true" ]]; then
+    PREFLIGHT_OK="false"
+    PREFLIGHT_NOTE="backend_unhealthy"
+    return 0
+  fi
+
+  case "$target" in
+    off)
+      # Emergency env-gate clear is the only executable write path (handled by action=off).
+      ;;
+    alias)
+      if [[ "$SNAP_MODE" != "off" && "$SNAP_MODE" != "alias" ]]; then
+        PREFLIGHT_OK="false"
+        PREFLIGHT_NOTE="other_lifecycle_flag_on"
+        return 0
+      fi
+      if [[ "$SNAP_ALIAS_READY" != "true" ]]; then
+        PREFLIGHT_OK="false"
+        PREFLIGHT_NOTE="alias_cutover_not_ready"
+        return 0
+      fi
+      # Even when stack looks ready: ON is NOT EXECUTABLE (no password-login proof).
+      PREFLIGHT_OK="false"
+      PREFLIGHT_NOTE="not_executable_no_real_verifier"
+      ;;
+    pending|deprovision)
+      if [[ "$SNAP_MODE" != "off" && "$SNAP_MODE" != "$target" ]]; then
+        PREFLIGHT_OK="false"
+        PREFLIGHT_NOTE="other_lifecycle_flag_on"
+        return 0
+      fi
+      # ON is NOT EXECUTABLE (no admit/activate or sync/deprovision proof).
+      PREFLIGHT_OK="false"
+      PREFLIGHT_NOTE="not_executable_no_real_verifier"
+      ;;
+    multi-on)
+      PREFLIGHT_OK="false"
+      PREFLIGHT_NOTE="multi_on_fail_closed"
+      ;;
+  esac
+}
+
+action_preflight() {
+  local target="${TARGET_MODE:-${EXPECTED_CURRENT_MODE:-}}"
+  [[ -n "$target" ]] || fail "preflight requires target_mode (or expected_current_mode as the inspected mode)"
+  case "$target" in
+    off|alias|pending|deprovision) ;;
+    *) fail "preflight target_mode must be off|alias|pending|deprovision, got: '${target}'" ;;
+  esac
+  capture_live_snapshot
+  preflight_for_target "$target"
+  write_status_artifact \
+    "${SNAP_BUILD_SHA:-unknown}" \
+    "$SNAP_ALIAS" "$SNAP_PENDING" "$SNAP_DEPROV" "$SNAP_MODE" \
+    "$SNAP_ALIAS_READY" "$SNAP_CAN_ENABLE_ALIAS" \
+    "$SNAP_MIGRATIONS_ZERO" "$SNAP_HEALTH_OK" \
+    "$target" "$PREFLIGHT_OK" "false" "$PREFLIGHT_NOTE"
+  {
+    echo "action=preflight"
+    echo "target_mode=${target}"
+    echo "mode=${SNAP_MODE}"
+    echo "preflight_ok=${PREFLIGHT_OK}"
+    echo "migrations_pending_zero=${SNAP_MIGRATIONS_ZERO}"
+    echo "note=${PREFLIGHT_NOTE}"
+    echo "transition_applied=false"
+  } > "${OUTPUT_DIR}/summary.txt"
+  if [[ "$PREFLIGHT_OK" != "true" ]]; then
+    fail "preflight failed: ${PREFLIGHT_NOTE}"
+  fi
+  # Ready-looking preflight for alias/pending/deprovision still means NOT EXECUTABLE ON.
+  if [[ "$target" == "alias" || "$target" == "pending" || "$target" == "deprovision" ]]; then
+    log "preflight assessed target=${target} note=${PREFLIGHT_NOTE} (ON transition NOT EXECUTABLE)"
+  else
+    log "preflight OK target=${target} note=${PREFLIGHT_NOTE}"
+  fi
+}
+
+# Fail-closed: alias/pending/deprovision never apply. Preflight assessment only.
+action_not_executable_on() {
+  local target="$1"
+  capture_live_snapshot
+  preflight_for_target "$target"
+  # Force not-executable note even if stack would look "ready".
+  local note="not_executable_no_real_verifier"
+  if [[ "$PREFLIGHT_OK" != "true" ]]; then
+    note="${PREFLIGHT_NOTE};not_executable_no_real_verifier"
+  fi
+  write_status_artifact \
+    "${SNAP_BUILD_SHA:-unknown}" \
+    "$SNAP_ALIAS" "$SNAP_PENDING" "$SNAP_DEPROV" "$SNAP_MODE" \
+    "$SNAP_ALIAS_READY" "$SNAP_CAN_ENABLE_ALIAS" \
+    "$SNAP_MIGRATIONS_ZERO" "$SNAP_HEALTH_OK" \
+    "$target" "false" "false" "$note"
+  {
+    echo "action=${target}"
+    echo "mode=${SNAP_MODE}"
+    echo "preflight_ok=false"
+    echo "note=${note}"
+    echo "transition_applied=false"
+    echo "executable=false"
+  } > "${OUTPUT_DIR}/summary.txt"
+  fail "action=${target} is NOT EXECUTABLE: no secret-backed real verifier for canary proof (password-login / admit-activate / sync-deprovision). Env flip alone is refused. Use status|preflight|off only. transition_applied=false"
+}
+
+# Sole executable env write: clear the exact three lifecycle flags to false.
+action_off() {
+  require_sha
+  [[ -n "$EXPECTED_CURRENT_MODE" ]] || fail "expected_current_mode is required for action=off (use multi-on when live flags are multi-on)"
+  validate_mode_name "$EXPECTED_CURRENT_MODE" "expected_current_mode"
+
+  capture_live_snapshot
+  assert_exact_sha
+  require_migrations_pending_zero_true "$SNAP_MIGRATIONS_ZERO" "action=off"
+
+  if [[ "$SNAP_HEALTH_OK" != "true" ]]; then
+    fail "action=off refused: backend_health_ok must be true before transition"
+  fi
+
+  # Strict expected-current, including multi-on so operators acknowledge the live mess.
+  if [[ "$SNAP_MODE" != "$EXPECTED_CURRENT_MODE" ]]; then
+    fail "strict expected-current-mode transition failed: live='${SNAP_MODE}' expected_current_mode='${EXPECTED_CURRENT_MODE}'"
+  fi
+
+  # Backup → write OFF → recreate → prove health+mode; restore on any post-write failure.
+  backup_lifecycle_override
+  write_lifecycle_override "false" "false" "false"
+
+  if ! recreate_backend_only; then
+    fail_transition_restore "backend_health_not_true_after_restart"
+  fi
+  if ! assert_exact_mode_off; then
+    fail_transition_restore "post_restart_mode_not_off"
+  fi
+
+  cleanup_prev_backup
+  capture_live_snapshot
+  write_status_artifact \
+    "${SNAP_BUILD_SHA:-unknown}" \
+    "$SNAP_ALIAS" "$SNAP_PENDING" "$SNAP_DEPROV" "$SNAP_MODE" \
+    "$SNAP_ALIAS_READY" "$SNAP_CAN_ENABLE_ALIAS" \
+    "$SNAP_MIGRATIONS_ZERO" "$SNAP_HEALTH_OK" \
+    "off" "true" "true" "emergency_env_gate_off"
+  {
+    echo "action=off"
+    echo "mode=${SNAP_MODE}"
+    echo "build_sha=${SNAP_BUILD_SHA:-unknown}"
+    echo "transition_applied=true"
+    echo "from_mode=${EXPECTED_CURRENT_MODE}"
+    echo "to_mode=off"
+    echo "note=emergency_env_gate_off_only"
+  } > "${OUTPUT_DIR}/summary.txt"
+  log "action=off OK (emergency env-gate clear; NOT a design reintroduction of OR-column fallback)"
+}
+
+# --- main ------------------------------------------------------------------------------
+
+main() {
+  mkdir -p "$OUTPUT_DIR"
+  assert_staging_only
+
+  case "$ACTION" in
+    status) action_status ;;
+    preflight) action_preflight ;;
+    off) action_off ;;
+    alias) action_not_executable_on alias ;;
+    pending) action_not_executable_on pending ;;
+    deprovision) action_not_executable_on deprovision ;;
+    *) fail "invalid ACTION='${ACTION}' (status|preflight|off|alias|pending|deprovision)" ;;
+  esac
+}
+
+if [[ "${LIFECYCLE_CANARY_SOURCE_ONLY:-false}" != "true" ]]; then
+  main
+fi

--- a/scripts/ops/dingtalk-lifecycle-staging-canary-remote.sh
+++ b/scripts/ops/dingtalk-lifecycle-staging-canary-remote.sh
@@ -82,6 +82,8 @@ LIFECYCLE_OVERRIDE_FILE="${LIFECYCLE_PERSIST_DIR}/docker-compose.lifecycle-canar
 # Previous-override backup used only during action=off for restore-on-failure.
 LIFECYCLE_PREV_BACKUP=""
 LIFECYCLE_PREV_STATE="absent" # absent | present
+PINNED_IMAGE_OWNER=""
+PINNED_IMAGE_TAG=""
 
 is_truthy() {
   local v
@@ -147,12 +149,27 @@ compose_staging_cmd() {
   elif [[ -f "$LIFECYCLE_OVERRIDE_FILE" ]]; then
     files+=(-f "$LIFECYCLE_OVERRIDE_FILE")
   fi
-  if ! image_pin="$(resolve_live_backend_image_pin)"; then
-    echo "[lifecycle-canary][error] running backend image is not an exact ghcr.io owner/metasheet2-backend:<40-sha> pin; refusing compose" >&2
-    return 1
+  if [[ -n "$PINNED_IMAGE_OWNER" && -n "$PINNED_IMAGE_TAG" ]]; then
+    image_owner="$PINNED_IMAGE_OWNER"
+    image_tag="$PINNED_IMAGE_TAG"
+  else
+    if ! image_pin="$(resolve_live_backend_image_pin)"; then
+      echo "[lifecycle-canary][error] running backend image is not an exact ghcr.io owner/metasheet2-backend:<40-sha> pin; refusing compose" >&2
+      return 1
+    fi
+    read -r image_owner image_tag <<< "$image_pin"
   fi
-  read -r image_owner image_tag <<< "$image_pin"
   (cd "$STAGING_DIR" && IMAGE_OWNER="$image_owner" IMAGE_TAG="$image_tag" docker compose "${files[@]}" "$@")
+}
+
+pin_live_backend_image_for_transition() {
+  local image_pin
+  if ! image_pin="$(resolve_live_backend_image_pin)"; then
+    fail "running backend image is not an exact ghcr.io owner/metasheet2-backend:<40-sha> pin; refusing transition"
+  fi
+  read -r PINNED_IMAGE_OWNER PINNED_IMAGE_TAG <<< "$image_pin"
+  [[ "$PINNED_IMAGE_TAG" == "$DEPLOY_SHA" ]] \
+    || fail "running backend image tag '${PINNED_IMAGE_TAG}' does not match deploy_sha '${DEPLOY_SHA}'"
 }
 
 require_sha() {
@@ -760,6 +777,9 @@ action_off() {
 
   capture_live_snapshot
   assert_exact_sha
+  # A failed force-recreate may leave no backend container to inspect. Keep the
+  # already-proven pin for both the forward recreate and any rollback recreate.
+  pin_live_backend_image_for_transition
   require_migrations_pending_zero_true "$SNAP_MIGRATIONS_ZERO" "action=off"
 
   if [[ "$SNAP_HEALTH_OK" != "true" ]]; then

--- a/scripts/ops/dingtalk-lifecycle-staging-canary-remote.sh
+++ b/scripts/ops/dingtalk-lifecycle-staging-canary-remote.sh
@@ -227,7 +227,19 @@ resolve_deployed_sha() {
 
 read_flag_from_container() {
   local key="$1" val
-  val="$(docker exec "$BACKEND_CONTAINER" printenv "$key" 2>/dev/null || true)"
+  if ! val="$(docker exec "$BACKEND_CONTAINER" sh -c '
+key="$1"
+if printenv "$key" >/dev/null 2>&1; then
+  exec printenv "$key"
+fi
+printf "__MISSING__"
+' sh "$key" 2>/dev/null)"; then
+    return 1
+  fi
+  if [[ "$val" == "__MISSING__" ]]; then
+    printf 'false'
+    return 0
+  fi
   if is_truthy "$val"; then
     printf 'true'
   else
@@ -253,9 +265,9 @@ classify_mode_from_flags() {
 read_live_flags() {
   # stdout: "alias_on pending_on deprov_on mode" — mode may be multi-on
   local a p d m
-  a="$(read_flag_from_container "$FLAG_ALIAS")"
-  p="$(read_flag_from_container "$FLAG_PENDING")"
-  d="$(read_flag_from_container "$FLAG_DEPROVISION")"
+  a="$(read_flag_from_container "$FLAG_ALIAS")" || return 1
+  p="$(read_flag_from_container "$FLAG_PENDING")" || return 1
+  d="$(read_flag_from_container "$FLAG_DEPROVISION")" || return 1
   m="$(classify_mode_from_flags "$a" "$p" "$d")"
   printf '%s %s %s %s' "$a" "$p" "$d" "$m"
 }
@@ -413,10 +425,14 @@ write_status_artifact() {
 
 capture_live_snapshot() {
   # Sets globals: SNAP_*. Never fails solely because mode is multi-on.
+  local live_flags
   if ! docker inspect -f '{{.State.Running}}' "$BACKEND_CONTAINER" 2>/dev/null | grep -qx 'true'; then
     fail "staging backend container is not running: ${BACKEND_CONTAINER}"
   fi
-  read -r SNAP_ALIAS SNAP_PENDING SNAP_DEPROV SNAP_MODE <<< "$(read_live_flags)"
+  if ! live_flags="$(read_live_flags)"; then
+    fail "failed to read lifecycle flags from the running staging backend"
+  fi
+  read -r SNAP_ALIAS SNAP_PENDING SNAP_DEPROV SNAP_MODE <<< "$live_flags"
   SNAP_BUILD_SHA="$(resolve_deployed_sha)"
   SNAP_ALIAS_READY="$(probe_alias_readiness)"
   if [[ "$SNAP_ALIAS_READY" == "true" ]]; then

--- a/scripts/ops/dingtalk-lifecycle-staging-canary-remote.sh
+++ b/scripts/ops/dingtalk-lifecycle-staging-canary-remote.sh
@@ -123,9 +123,20 @@ require_compose_v2() {
   fail "docker compose v2 plugin is required"
 }
 
+resolve_live_backend_image_pin() {
+  local live_image
+  live_image="$(docker inspect -f '{{.Config.Image}}' "$BACKEND_CONTAINER" 2>/dev/null || true)"
+  if [[ "$live_image" =~ ^ghcr\.io/([A-Za-z0-9._-]+)/metasheet2-backend:([0-9a-f]{40})$ ]]; then
+    printf '%s %s' "${BASH_REMATCH[1]}" "${BASH_REMATCH[2]}"
+    return 0
+  fi
+  return 1
+}
+
 compose_staging_cmd() {
   # compose_staging_cmd [override_file_or_empty] <compose args...>
   local override_arg="${1:-}"
+  local image_pin image_owner image_tag
   shift || true
   local -a files=(-f "$STAGING_COMPOSE_FILE")
   if [[ -f "$ATTENDANCE_OVERRIDE_FILE" ]]; then
@@ -136,7 +147,12 @@ compose_staging_cmd() {
   elif [[ -f "$LIFECYCLE_OVERRIDE_FILE" ]]; then
     files+=(-f "$LIFECYCLE_OVERRIDE_FILE")
   fi
-  (cd "$STAGING_DIR" && docker compose "${files[@]}" "$@")
+  if ! image_pin="$(resolve_live_backend_image_pin)"; then
+    echo "[lifecycle-canary][error] running backend image is not an exact ghcr.io owner/metasheet2-backend:<40-sha> pin; refusing compose" >&2
+    return 1
+  fi
+  read -r image_owner image_tag <<< "$image_pin"
+  (cd "$STAGING_DIR" && IMAGE_OWNER="$image_owner" IMAGE_TAG="$image_tag" docker compose "${files[@]}" "$@")
 }
 
 require_sha() {
@@ -448,12 +464,7 @@ write_lifecycle_override() {
     echo "      ${FLAG_DEPROVISION}: \"${deprov_val}\""
   } > "$override_tmp"
 
-  local -a val_files=(-f "$STAGING_COMPOSE_FILE")
-  if [[ -f "$ATTENDANCE_OVERRIDE_FILE" ]]; then
-    val_files+=(-f "$ATTENDANCE_OVERRIDE_FILE")
-  fi
-  val_files+=(-f "$override_tmp")
-  if ! (cd "$STAGING_DIR" && docker compose "${val_files[@]}" config) >/dev/null 2>&1; then
+  if ! compose_staging_cmd "$override_tmp" config >/dev/null 2>&1; then
     rm -f "$override_tmp"
     fail "candidate lifecycle override failed 'docker compose config' validation; kept previous override at ${LIFECYCLE_OVERRIDE_FILE}"
   fi

--- a/scripts/ops/dingtalk-lifecycle-staging-canary-remote.sh
+++ b/scripts/ops/dingtalk-lifecycle-staging-canary-remote.sh
@@ -63,8 +63,8 @@ resolve_home_path() {
   local raw="$1"
   if [[ "$raw" == /* ]]; then
     printf '%s' "$raw"
-  elif [[ "$raw" == ~/* ]]; then
-    printf '%s' "${HOME}/${raw#~/}"
+  elif [[ "$raw" == "~/"* ]]; then
+    printf '%s' "${HOME}/${raw#"~/"}"
   else
     printf '%s' "${HOME}/${raw}"
   fi

--- a/scripts/ops/dingtalk-lifecycle-staging-canary-remote.sh
+++ b/scripts/ops/dingtalk-lifecycle-staging-canary-remote.sh
@@ -778,6 +778,9 @@ action_off() {
   if ! recreate_backend_only; then
     fail_transition_restore "backend_health_not_true_after_restart"
   fi
+  if [[ "$(resolve_deployed_sha)" != "$DEPLOY_SHA" ]]; then
+    fail_transition_restore "post_restart_sha_mismatch"
+  fi
   if ! assert_exact_mode_off; then
     fail_transition_restore "post_restart_mode_not_off"
   fi

--- a/scripts/ops/dingtalk-lifecycle-staging-canary-remote.sh
+++ b/scripts/ops/dingtalk-lifecycle-staging-canary-remote.sh
@@ -616,7 +616,7 @@ preflight_for_target() {
     return 0
   fi
 
-  if [[ "$SNAP_BUILD_SHA" == "conflict" || -z "$SNAP_BUILD_SHA" ]]; then
+  if [[ "$SNAP_BUILD_SHA" == "conflict" || ! "$SNAP_BUILD_SHA" =~ ^[0-9a-f]{40}$ ]]; then
     PREFLIGHT_OK="false"
     if [[ "$SNAP_BUILD_SHA" == "conflict" ]]; then
       PREFLIGHT_NOTE="build_provenance_conflict"


### PR DESCRIPTION
## What
- add a staging-only manual lifecycle operator lane
- permit only read-only `status`/`preflight` and emergency `off`; ON actions fail closed
- require exact image+health SHA agreement, pending migrations zero, backend health, strict current mode, and pinned SSH host identity
- persist honest UAT/T2-Gate/canary boundaries and current staging evidence

## Live evidence
- staging migration runner 31407444155: backup + clone rehearsal + isolation + real apply, 296/18 -> 314/0
- running image is b55c682748e3010cb70837770c298843a96e1019, but health metadata reports 59c24a1d21cfc70b76867da7d0ac15590d558c72; all write actions remain blocked by `build_provenance_conflict`
- lifecycle ON canaries remain NOT EXECUTED; all three flags remain OFF

## Verification
- `bash -n scripts/ops/dingtalk-lifecycle-staging-canary-remote.sh`
- `node --test scripts/ops/dingtalk-lifecycle-staging-canary-contract.test.mjs` (34/34)
- contract wired into required plugin-tests job
- Kimi K3 adversarial review: no P1; three P2 fixed (host pinning, dual-source SHA, real-function/order tests)

## External gates
U1-U13, real callback corp-anchor, secret-backed ON verifiers, and two-corp post-fix UAT are unavailable here and remain NOT EXECUTED. Transfer T3-T5 stays frozen.