### PR TITLE
test(core-backend): own scratch database termination

### DIFF
--- a/packages/core-backend/tests/helpers/scratch-database-idle-pool-arm.mjs
+++ b/packages/core-backend/tests/helpers/scratch-database-idle-pool-arm.mjs
@@ -1,0 +1,88 @@
+/**
+ * #4820 dual-arm child — real-PG proof that an idle Pool receiving admin-termination
+ * emits unowned 57P01 without a handler, and that attachOwnedPoolTerminationHandler owns it.
+ *
+ * Env: ARM=uncaught|owned, SCRATCH_URL, ADMIN_URL, DATNAME
+ * Exit: 0 owned+absorbed; 17 uncaught 57P01; 18 owned without absorb; 19 uncaught arm no event; 1 other
+ */
+import { pathToFileURL } from 'node:url'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import pg from 'pg'
+
+const { Pool } = pg
+const arm = process.env.ARM
+const scratchUrl = process.env.SCRATCH_URL
+const adminUrl = process.env.ADMIN_URL
+const datname = process.env.DATNAME
+
+if (!arm || !scratchUrl || !adminUrl || !datname) {
+  console.error('SCRATCH_IDLE_POOL_ARM_MISSING_ENV')
+  process.exit(1)
+}
+
+const helperPath = resolve(dirname(fileURLToPath(import.meta.url)), 'scratch-database.ts')
+const helper = await import(pathToFileURL(helperPath).href)
+const { attachOwnedPoolTerminationHandler, isAdministratorTerminationError } = helper
+
+const pool = new Pool({
+  connectionString: scratchUrl,
+  max: 1,
+  application_name: `ms2-drain-child-${arm}`,
+})
+const admin = new Pool({ connectionString: adminUrl, max: 1 })
+
+async function waitUntil(predicate, timeoutMs, label) {
+  const deadline = Date.now() + timeoutMs
+  while (!predicate()) {
+    if (Date.now() >= deadline) {
+      console.error(`SCRATCH_IDLE_POOL_ARM_TIMEOUT: ${label}`)
+      return false
+    }
+    await new Promise((resolveWait) => setTimeout(resolveWait, 10))
+  }
+  return true
+}
+
+let uncaughtTerm = false
+process.on('uncaughtException', (err) => {
+  if (isAdministratorTerminationError(err)) {
+    uncaughtTerm = true
+    process.exit(17)
+  }
+  console.error('UNEXPECTED_UNCAUGHT', err)
+  process.exit(1)
+})
+
+try {
+  await pool.query('SELECT 1')
+  let handler = null
+  if (arm === 'owned') {
+    handler = attachOwnedPoolTerminationHandler(pool)
+  }
+  await admin.query(
+    'SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = $1 AND pid <> pg_backend_pid()',
+    [datname],
+  )
+
+  if (arm === 'owned') {
+    const observed = await waitUntil(() => (handler?.absorbed() ?? 0) > 0, 5_000, 'owned 57P01 absorb')
+    await admin.end().catch(() => undefined)
+    const absorbed = handler ? handler.absorbed() : 0
+    if (handler) handler.detach()
+    await pool.end().catch(() => undefined)
+    if (uncaughtTerm) process.exit(17)
+    if (!observed || absorbed < 1) process.exit(18)
+    process.exit(0)
+  }
+
+  // The uncaughtException handler exits 17 as soon as the real Pool emits 57P01. Keep the
+  // process alive for a bounded interval instead of assuming a fixed number of event-loop turns.
+  await new Promise((resolveWait) => setTimeout(resolveWait, 5_000))
+  await admin.end().catch(() => undefined)
+  await pool.end().catch(() => undefined)
+  process.exit(uncaughtTerm ? 17 : 19)
+} catch (err) {
+  console.error(err)
+  process.exit(1)
+}

--- a/packages/core-backend/tests/helpers/scratch-database.ts
+++ b/packages/core-backend/tests/helpers/scratch-database.ts
@@ -200,12 +200,89 @@ export interface ScratchDropOutcome {
  * POSITIVE character whitelist rather than a denylist of bad spellings: the complement of a
  * denylist is unbounded, the complement of this pattern is not. Matches what the call sites
  * actually generate (`ms2_<suite>_<hex>`), and nothing else.
+ *
+ * Note (#4820): this whitelist alone allows `metasheet_test` / `postgres` / `template*`. The
+ * protected-name guard below is what stops `dropScratchDatabase` from targeting those.
  */
 const SAFE_SCRATCH_NAME = /^[a-z][a-z0-9_]{0,62}$/
 
 export function assertSafeScratchDatabaseName(scratchName: string): void {
   if (typeof scratchName !== 'string' || !SAFE_SCRATCH_NAME.test(scratchName)) {
     throw new Error(`SCRATCH_DATABASE_NAME_UNSAFE: ${JSON.stringify(scratchName)}`)
+  }
+}
+
+/** Shared / system names that must never be drained or dropped via this helper. */
+const PROTECTED_SHARED_DATABASE_NAMES = new Set([
+  'postgres',
+  'template0',
+  'template1',
+  'metasheet_test',
+  'metasheet',
+])
+
+export function isProtectedSharedDatabaseName(name: string): boolean {
+  if (typeof name !== 'string' || name.length === 0) return false
+  return PROTECTED_SHARED_DATABASE_NAMES.has(name) || name.startsWith('template')
+}
+
+export function assertDroppableScratchDatabaseName(scratchName: string): void {
+  assertSafeScratchDatabaseName(scratchName)
+  if (isProtectedSharedDatabaseName(scratchName)) {
+    throw new Error(`SCRATCH_DATABASE_PROTECTED: ${JSON.stringify(scratchName)}`)
+  }
+}
+
+/**
+ * #4820 — absorb only administrator-command termination on owned pools.
+ * SQLSTATE `57P01`, or the exact PG message. Deliberately does NOT match generic
+ * "Connection terminated unexpectedly" (that is broader than admin terminate).
+ */
+export function isAdministratorTerminationError(err: unknown): boolean {
+  if (err != null && typeof err === 'object' && 'code' in err && (err as { code: unknown }).code === '57P01') {
+    return true
+  }
+  const message = err instanceof Error ? err.message : String(err ?? '')
+  return /terminating connection due to administrator command/i.test(message)
+}
+
+/** Structural surface for `pg.Pool` / EventEmitter-shaped doubles. */
+export interface ScratchOwnedPool {
+  on(event: 'error', listener: (err: Error) => void): unknown
+  off?(event: 'error', listener: (err: Error) => void): unknown
+  removeListener?(event: 'error', listener: (err: Error) => void): unknown
+}
+
+export interface OwnedPoolTerminationHandler {
+  detach(): void
+  absorbed(): number
+}
+
+/**
+ * Teardown-scoped handler for pools this suite owns (especially
+ * `poolManager.get().getInternalPool()` after a real MetaSheetServer boot). Attach at
+ * `afterAll` start; keep through `server.stop` + drop; then detach. Absorbs only
+ * `isAdministratorTerminationError`; rethrows everything else.
+ */
+export function attachOwnedPoolTerminationHandler(pool: ScratchOwnedPool): OwnedPoolTerminationHandler {
+  let absorbedCount = 0
+  let attached = true
+  const listener = (err: Error): void => {
+    if (isAdministratorTerminationError(err)) {
+      absorbedCount += 1
+      return
+    }
+    throw err
+  }
+  pool.on('error', listener)
+  return {
+    detach() {
+      if (!attached) return
+      attached = false
+      if (typeof pool.off === 'function') pool.off('error', listener)
+      else if (typeof pool.removeListener === 'function') pool.removeListener('error', listener)
+    },
+    absorbed: () => absorbedCount,
   }
 }
 
@@ -250,7 +327,8 @@ export async function dropScratchDatabase(
   scratchName: string,
   options: { drainTimeoutMs?: number; pollIntervalMs?: number } = {},
 ): Promise<ScratchDropOutcome> {
-  assertSafeScratchDatabaseName(scratchName)
+  // SAFE_SCRATCH_NAME allows metasheet_test; protected guard refuses shared/system DBs (#4820).
+  assertDroppableScratchDatabaseName(scratchName)
   const drainTimeoutMs = options.drainTimeoutMs ?? 10_000
   const pollIntervalMs = options.pollIntervalMs ?? 50
   const startedAt = Date.now()

--- a/packages/core-backend/tests/helpers/scratch-database.ts
+++ b/packages/core-backend/tests/helpers/scratch-database.ts
@@ -239,11 +239,12 @@ export function assertDroppableScratchDatabaseName(scratchName: string): void {
  * "Connection terminated unexpectedly" (that is broader than admin terminate).
  */
 export function isAdministratorTerminationError(err: unknown): boolean {
-  if (err != null && typeof err === 'object' && 'code' in err && (err as { code: unknown }).code === '57P01') {
-    return true
+  if (err != null && typeof err === 'object' && 'code' in err) {
+    const code = (err as { code: unknown }).code
+    if (code != null) return code === '57P01'
   }
   const message = err instanceof Error ? err.message : String(err ?? '')
-  return /terminating connection due to administrator command/i.test(message)
+  return /^terminating connection due to administrator command$/i.test(message)
 }
 
 /** Structural surface for `pg.Pool` / EventEmitter-shaped doubles. */

--- a/packages/core-backend/tests/integration/attendance-w4c2-sweep-call-through.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-w4c2-sweep-call-through.db.test.ts
@@ -298,14 +298,14 @@ describeIfDatabase('W4C-2 #4770 recovery-sweep call-through (real server, real p
     const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../..')
     // Import AFTER DATABASE_URL is rebound so poolManager binds to the scratch DB.
     const loaded = await import('../../src/index')
-    const { poolManager } = await import('../../src/integration/db/connection-pool')
-    serverInternalPool = poolManager.get().getInternalPool()
     server = new loaded.MetaSheetServer({
       port: 0,
       host: '127.0.0.1',
       pluginDirs: [path.join(repoRoot, 'plugins', 'plugin-attendance')],
     })
     await server.start()
+    const { poolManager } = await import('../../src/integration/db/connection-pool')
+    serverInternalPool = poolManager.get().getInternalPool()
     const address = server.getAddress()
     if (!address || typeof address === 'string') throw new Error('attendance server did not expose a TCP address')
     baseUrl = `http://127.0.0.1:${address.port}`
@@ -347,43 +347,50 @@ describeIfDatabase('W4C-2 #4770 recovery-sweep call-through (real server, real p
   afterAll(async () => {
     // #4820: teardown-scoped handlers on the server singleton internal Pool (primary) and the
     // suite data Pool. Attach only here so body-time FATALs stay loud; keep through stop+drop.
+    const poolCaptureError = serverInternalPool
+      ? undefined
+      : new Error('W4C2_SWEEP_SERVER_INTERNAL_POOL_NOT_CAPTURED')
     const teardownHandlers = [serverInternalPool, pool]
       .filter((p): p is Pool => Boolean(p))
       .map((p) => attachOwnedPoolTerminationHandler(p))
-    await pool?.end().catch(() => undefined)
-    if (server) await server.stop()
-    // #4791: drain the scratch DB's backends before dropping it. A forced drop terminates any
-    // still-attached backend, and `pg` reports that to its owner as an unowned 'error' EVENT —
-    // which vitest counts as an unhandled error and the step exits 1 with every test passing.
-    // The outcome line is emitted UNCONDITIONALLY: `CLEAN` is the claim, `FORCED` names the
-    // component still holding a connection and keeps #4791 open, `FAILED` means a teardown
-    // statement errored. The helper fails CLOSED, so the failure is logged and then RE-THROWN —
-    // but only after the admin pool is closed and the env is restored, because leaking either
-    // would itself show up as a new flake on the very check #4791 is about.
     let dropError: unknown
-    if (adminPool) {
-      try {
-        const dropOutcome = await dropScratchDatabase(adminPool, scratchName)
-        console.log(formatScratchDropOutcome('w4c2-sweep-call-through', dropOutcome))
-      } catch (err) {
-        dropError = err
-        console.log(formatScratchDropFailure('w4c2-sweep-call-through', err))
+    try {
+      await pool?.end().catch(() => undefined)
+      if (server) await server.stop()
+      // #4791: drain the scratch DB's backends before dropping it. A forced drop terminates any
+      // still-attached backend, and `pg` reports that to its owner as an unowned 'error' EVENT —
+      // which vitest counts as an unhandled error and the step exits 1 with every test passing.
+      // The outcome line is emitted UNCONDITIONALLY: `CLEAN` is the claim, `FORCED` names the
+      // component still holding a connection and keeps #4791 open, `FAILED` means a teardown
+      // statement errored. The helper fails CLOSED, so the failure is logged and then RE-THROWN —
+      // but only after the admin pool is closed and the env is restored, because leaking either
+      // would itself show up as a new flake on the very check #4791 is about.
+      if (adminPool) {
+        try {
+          const dropOutcome = await dropScratchDatabase(adminPool, scratchName)
+          console.log(formatScratchDropOutcome('w4c2-sweep-call-through', dropOutcome))
+        } catch (err) {
+          dropError = err
+          console.log(formatScratchDropFailure('w4c2-sweep-call-through', err))
+        }
+      }
+    } finally {
+      await adminPool?.end().catch(() => undefined)
+      for (const h of teardownHandlers) h.detach()
+      for (const [key, value] of Object.entries({
+        DATABASE_URL: priorEnv.databaseUrl,
+        RBAC_BYPASS: priorEnv.rbacBypass,
+        SKIP_PLUGINS: priorEnv.skipPlugins,
+        ATTENDANCE_SHIFT_SEGMENT_CALCULATION_ENABLED: priorEnv.rollout,
+        ATTENDANCE_SCHEDULER_ENABLED: priorEnv.schedulerEnabled,
+        ATTENDANCE_SCHEDULER_INTERVAL_MS: priorEnv.schedulerIntervalMs,
+      })) {
+        if (value === undefined) delete process.env[key]
+        else process.env[key] = value
       }
     }
-    await adminPool?.end().catch(() => undefined)
-    for (const h of teardownHandlers) h.detach()
-    for (const [key, value] of Object.entries({
-      DATABASE_URL: priorEnv.databaseUrl,
-      RBAC_BYPASS: priorEnv.rbacBypass,
-      SKIP_PLUGINS: priorEnv.skipPlugins,
-      ATTENDANCE_SHIFT_SEGMENT_CALCULATION_ENABLED: priorEnv.rollout,
-      ATTENDANCE_SCHEDULER_ENABLED: priorEnv.schedulerEnabled,
-      ATTENDANCE_SCHEDULER_INTERVAL_MS: priorEnv.schedulerIntervalMs,
-    })) {
-      if (value === undefined) delete process.env[key]
-      else process.env[key] = value
-    }
     if (dropError) throw dropError
+    if (poolCaptureError) throw poolCaptureError
   }, 60000)
 
   // ===============================================================================================

--- a/packages/core-backend/tests/integration/attendance-w4c2-sweep-call-through.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-w4c2-sweep-call-through.db.test.ts
@@ -55,7 +55,12 @@
  * empty except for what THIS file itself seeds.
  */
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
-import { dropScratchDatabase, formatScratchDropFailure, formatScratchDropOutcome } from '../helpers/scratch-database'
+import {
+  attachOwnedPoolTerminationHandler,
+  dropScratchDatabase,
+  formatScratchDropFailure,
+  formatScratchDropOutcome,
+} from '../helpers/scratch-database'
 import { randomUUID } from 'node:crypto'
 import { createRequire } from 'node:module'
 import http from 'node:http'
@@ -122,6 +127,8 @@ function installLoadedPlugin(server: MetaSheetServer, name: string, plugin: Reco
 describeIfDatabase('W4C-2 #4770 recovery-sweep call-through (real server, real plugin, real PostgreSQL)', () => {
   let server: MetaSheetServer | undefined
   let pool: Pool
+  /** MetaSheetServer singleton internal Pool — the #4820 57P01 emitter after forced scratch drop. */
+  let serverInternalPool: Pool | undefined
   let baseUrl = ''
   // Door 1: captured directly from a probe plugin's OWN `context.services` — never read off
   // plugin-attendance's internal state (which is not test-visible).
@@ -289,7 +296,10 @@ describeIfDatabase('W4C-2 #4770 recovery-sweep call-through (real server, real p
     process.env.ATTENDANCE_SCHEDULER_INTERVAL_MS = '3600000'
 
     const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../..')
+    // Import AFTER DATABASE_URL is rebound so poolManager binds to the scratch DB.
     const loaded = await import('../../src/index')
+    const { poolManager } = await import('../../src/integration/db/connection-pool')
+    serverInternalPool = poolManager.get().getInternalPool()
     server = new loaded.MetaSheetServer({
       port: 0,
       host: '127.0.0.1',
@@ -335,6 +345,11 @@ describeIfDatabase('W4C-2 #4770 recovery-sweep call-through (real server, real p
   }, 120000)
 
   afterAll(async () => {
+    // #4820: teardown-scoped handlers on the server singleton internal Pool (primary) and the
+    // suite data Pool. Attach only here so body-time FATALs stay loud; keep through stop+drop.
+    const teardownHandlers = [serverInternalPool, pool]
+      .filter((p): p is Pool => Boolean(p))
+      .map((p) => attachOwnedPoolTerminationHandler(p))
     await pool?.end().catch(() => undefined)
     if (server) await server.stop()
     // #4791: drain the scratch DB's backends before dropping it. A forced drop terminates any
@@ -356,6 +371,7 @@ describeIfDatabase('W4C-2 #4770 recovery-sweep call-through (real server, real p
       }
     }
     await adminPool?.end().catch(() => undefined)
+    for (const h of teardownHandlers) h.detach()
     for (const [key, value] of Object.entries({
       DATABASE_URL: priorEnv.databaseUrl,
       RBAC_BYPASS: priorEnv.rbacBypass,

--- a/packages/core-backend/tests/integration/bpmn-poller-disabled-startprocess-zero-residue.db.test.ts
+++ b/packages/core-backend/tests/integration/bpmn-poller-disabled-startprocess-zero-residue.db.test.ts
@@ -245,10 +245,10 @@ describeIfDatabase('BPMNWorkflowEngine startProcess poller-disabled zero-residue
 
     // Import AFTER DATABASE_URL is rebound so poolManager binds to the scratch DB.
     const loaded = await import('../../src/index')
-    const { poolManager } = await import('../../src/integration/db/connection-pool')
-    serverInternalPool = poolManager.get().getInternalPool()
     server = new loaded.MetaSheetServer({ port: 0, host: '127.0.0.1' })
     await server.start()
+    const { poolManager } = await import('../../src/integration/db/connection-pool')
+    serverInternalPool = poolManager.get().getInternalPool()
     const address = server.getAddress()
     if (!address || typeof address === 'string') throw new Error('server did not expose a TCP address')
     baseUrl = `http://127.0.0.1:${address.port}`
@@ -261,40 +261,47 @@ describeIfDatabase('BPMNWorkflowEngine startProcess poller-disabled zero-residue
   afterAll(async () => {
     // #4820: teardown-scoped handlers on the server singleton internal Pool (primary) and the
     // suite data Pool. Attach only here so body-time FATALs stay loud; keep through stop+drop.
+    const poolCaptureError = serverInternalPool
+      ? undefined
+      : new Error('BPMN_SERVER_INTERNAL_POOL_NOT_CAPTURED')
     const teardownHandlers = [serverInternalPool, pool]
       .filter((p): p is Pool => Boolean(p))
       .map((p) => attachOwnedPoolTerminationHandler(p))
-    await pool?.end().catch(() => undefined)
-    if (server) await server.stop()
-    // #4791: drain the scratch DB's backends before dropping it. A forced drop terminates any
-    // still-attached backend, and `pg` reports that to its owner as an unowned 'error' EVENT —
-    // which vitest counts as an unhandled error and the step exits 1 with every test passing.
-    // The outcome line is emitted UNCONDITIONALLY: `CLEAN` is the claim, `FORCED` names the
-    // component still holding a connection and keeps #4791 open, `FAILED` means a teardown
-    // statement errored. The helper fails CLOSED, so the failure is logged and then RE-THROWN —
-    // but only after the admin pool is closed and the env is restored, because leaking either
-    // would itself show up as a new flake on the very check #4791 is about.
     let dropError: unknown
-    if (adminPool) {
-      try {
-        const dropOutcome = await dropScratchDatabase(adminPool, scratchName)
-        console.log(formatScratchDropOutcome('bpmn-poller-disabled', dropOutcome))
-      } catch (err) {
-        dropError = err
-        console.log(formatScratchDropFailure('bpmn-poller-disabled', err))
+    try {
+      await pool?.end().catch(() => undefined)
+      if (server) await server.stop()
+      // #4791: drain the scratch DB's backends before dropping it. A forced drop terminates any
+      // still-attached backend, and `pg` reports that to its owner as an unowned 'error' EVENT —
+      // which vitest counts as an unhandled error and the step exits 1 with every test passing.
+      // The outcome line is emitted UNCONDITIONALLY: `CLEAN` is the claim, `FORCED` names the
+      // component still holding a connection and keeps #4791 open, `FAILED` means a teardown
+      // statement errored. The helper fails CLOSED, so the failure is logged and then RE-THROWN —
+      // but only after the admin pool is closed and the env is restored, because leaking either
+      // would itself show up as a new flake on the very check #4791 is about.
+      if (adminPool) {
+        try {
+          const dropOutcome = await dropScratchDatabase(adminPool, scratchName)
+          console.log(formatScratchDropOutcome('bpmn-poller-disabled', dropOutcome))
+        } catch (err) {
+          dropError = err
+          console.log(formatScratchDropFailure('bpmn-poller-disabled', err))
+        }
+      }
+    } finally {
+      await adminPool?.end().catch(() => undefined)
+      for (const h of teardownHandlers) h.detach()
+      for (const [key, value] of Object.entries({
+        DATABASE_URL: priorEnv.databaseUrl,
+        SKIP_PLUGINS: priorEnv.skipPlugins,
+        ENABLE_BPMN_TIMER_POLLER: priorEnv.enablePoller,
+      })) {
+        if (value === undefined) delete process.env[key]
+        else process.env[key] = value
       }
     }
-    await adminPool?.end().catch(() => undefined)
-    for (const h of teardownHandlers) h.detach()
-    for (const [key, value] of Object.entries({
-      DATABASE_URL: priorEnv.databaseUrl,
-      SKIP_PLUGINS: priorEnv.skipPlugins,
-      ENABLE_BPMN_TIMER_POLLER: priorEnv.enablePoller,
-    })) {
-      if (value === undefined) delete process.env[key]
-      else process.env[key] = value
-    }
     if (dropError) throw dropError
+    if (poolCaptureError) throw poolCaptureError
   }, 60000)
 
   it('poller disabled + a timer-bearing process: /start rejects with BPMN_TIMER_POLLER_DISABLED and FOUR real zeros — process, activity, incident, timer rows all 0', async () => {

--- a/packages/core-backend/tests/integration/bpmn-poller-disabled-startprocess-zero-residue.db.test.ts
+++ b/packages/core-backend/tests/integration/bpmn-poller-disabled-startprocess-zero-residue.db.test.ts
@@ -46,7 +46,12 @@ import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { Pool } from 'pg'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
-import { dropScratchDatabase, formatScratchDropFailure, formatScratchDropOutcome } from '../helpers/scratch-database'
+import {
+  attachOwnedPoolTerminationHandler,
+  dropScratchDatabase,
+  formatScratchDropFailure,
+  formatScratchDropOutcome,
+} from '../helpers/scratch-database'
 import type { MetaSheetServer } from '../../src/index'
 
 const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
@@ -137,6 +142,8 @@ describeIfDatabase('BPMNWorkflowEngine startProcess poller-disabled zero-residue
   let pool: Pool
   let adminPool: Pool
   let scratchName: string
+  /** MetaSheetServer singleton internal Pool — the #4820 57P01 emitter after forced scratch drop. */
+  let serverInternalPool: Pool | undefined
   let baseUrl = ''
   let token = ''
 
@@ -236,7 +243,10 @@ describeIfDatabase('BPMNWorkflowEngine startProcess poller-disabled zero-residue
     // Default-off, unset — the exact shipped state this fix targets.
     delete process.env.ENABLE_BPMN_TIMER_POLLER
 
+    // Import AFTER DATABASE_URL is rebound so poolManager binds to the scratch DB.
     const loaded = await import('../../src/index')
+    const { poolManager } = await import('../../src/integration/db/connection-pool')
+    serverInternalPool = poolManager.get().getInternalPool()
     server = new loaded.MetaSheetServer({ port: 0, host: '127.0.0.1' })
     await server.start()
     const address = server.getAddress()
@@ -249,6 +259,11 @@ describeIfDatabase('BPMNWorkflowEngine startProcess poller-disabled zero-residue
   }, 120000)
 
   afterAll(async () => {
+    // #4820: teardown-scoped handlers on the server singleton internal Pool (primary) and the
+    // suite data Pool. Attach only here so body-time FATALs stay loud; keep through stop+drop.
+    const teardownHandlers = [serverInternalPool, pool]
+      .filter((p): p is Pool => Boolean(p))
+      .map((p) => attachOwnedPoolTerminationHandler(p))
     await pool?.end().catch(() => undefined)
     if (server) await server.stop()
     // #4791: drain the scratch DB's backends before dropping it. A forced drop terminates any
@@ -270,6 +285,7 @@ describeIfDatabase('BPMNWorkflowEngine startProcess poller-disabled zero-residue
       }
     }
     await adminPool?.end().catch(() => undefined)
+    for (const h of teardownHandlers) h.detach()
     for (const [key, value] of Object.entries({
       DATABASE_URL: priorEnv.databaseUrl,
       SKIP_PLUGINS: priorEnv.skipPlugins,

--- a/packages/core-backend/tests/integration/scratch-database-drain.db.test.ts
+++ b/packages/core-backend/tests/integration/scratch-database-drain.db.test.ts
@@ -31,6 +31,18 @@
  *                                                        `forced === false` and its
  *                                                        "no unowned pg error" assertion
  *   - delete `assertSafeScratchDatabaseName`          -> "rejects unsafe identifiers" RED
+ *   - delete protected-name check / 57P01 absorb      -> #4820 gates RED
+ *   - remove poolManager.get().getInternalPool() wire -> wiring gate RED
+ *
+ * ## #4820 (narrow)
+ *
+ * Forced scratch drop can emit 57P01 on the MetaSheetServer singleton
+ * `poolManager.get().getInternalPool()`, not only the suite data Pool. Real-server suites
+ * attach a teardown-scoped handler to that internal Pool. Classification is SQLSTATE 57P01 or
+ * the exact administrator-command message — not generic "Connection terminated unexpectedly".
+ * `dropScratchDatabase` refuses protected shared names (`metasheet_test` is SAFE_SCRATCH_NAME-
+ * legal but not droppable). Issue #4820 stays observation-gated until Node 18 CI repetitions;
+ * these gates pin the mechanism, not full shared-DB isolation.
  *
  * ## Fail-closed and values-free (review #4799 P2-1 / P2-2)
  *
@@ -51,13 +63,22 @@
  * `application_name`, a marked comment inside its statement text).
  */
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+import { spawnSync } from 'node:child_process'
 import { randomUUID } from 'node:crypto'
+import { EventEmitter } from 'node:events'
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { Client, Pool } from 'pg'
 import {
+  assertDroppableScratchDatabaseName,
   assertSafeScratchDatabaseName,
+  attachOwnedPoolTerminationHandler,
   dropScratchDatabase,
   formatScratchDropFailure,
   formatScratchDropOutcome,
+  isAdministratorTerminationError,
+  isProtectedSharedDatabaseName,
   ScratchDropError,
   type ScratchAdminQueryable,
   type ScratchDropStep,
@@ -337,6 +358,102 @@ describeIfDatabase('#4791 scratch-database teardown drain', () => {
     // Positive control: the shape the real call sites generate must still be ACCEPTED, otherwise
     // this gate would pass simply by rejecting everything.
     expect(() => assertSafeScratchDatabaseName('ms2_w4c2sweepct_0f1e2d3c4b5a')).not.toThrow()
+  })
+
+  // ==============================================================================================
+  // #4820 — protected shared names, owned-pool 57P01, real-server wiring
+  // ==============================================================================================
+  describe('#4820 owned internal Pool + protected shared names', () => {
+    it('refuses protected shared base names (SAFE_SCRATCH_NAME alone allows metasheet_test)', async () => {
+      expect(assertSafeScratchDatabaseName('metasheet_test')).toBeUndefined()
+      expect(isProtectedSharedDatabaseName('metasheet_test')).toBe(true)
+      expect(() => assertDroppableScratchDatabaseName('metasheet_test')).toThrow(/SCRATCH_DATABASE_PROTECTED/)
+      expect(() => assertDroppableScratchDatabaseName('postgres')).toThrow(/SCRATCH_DATABASE_PROTECTED/)
+      expect(() => assertDroppableScratchDatabaseName('template0')).toThrow(/SCRATCH_DATABASE_PROTECTED/)
+
+      const probing: ScratchAdminQueryable = {
+        async query() {
+          throw new Error('PROTECTED_GUARD_BYPASSED_QUERY_REACHED_POOL')
+        },
+      }
+      for (const name of ['metasheet_test', 'postgres', 'template0', 'template1']) {
+        await expect(dropScratchDatabase(probing, name, { drainTimeoutMs: 200 })).rejects.toThrow(
+          /SCRATCH_DATABASE_PROTECTED/,
+        )
+      }
+    })
+
+    it('pre-fix hazard: idle Pool 57P01 uncaught without handler; owned with exact classifier', async () => {
+      const nameA = await createScratch('idleuncaught')
+      const nameB = await createScratch('idleowned')
+      const adminUrl = urlFor(dbUrl!, 'postgres')
+      const armScript = fileURLToPath(new URL('../helpers/scratch-database-idle-pool-arm.mjs', import.meta.url))
+      const coreBackendDir = fileURLToPath(new URL('../..', import.meta.url))
+
+      function runArm(arm: 'uncaught' | 'owned', datname: string) {
+        const result = spawnSync('pnpm', ['exec', 'tsx', armScript], {
+          cwd: coreBackendDir,
+          env: {
+            ...process.env,
+            ARM: arm,
+            SCRATCH_URL: urlFor(dbUrl!, datname),
+            ADMIN_URL: adminUrl,
+            DATNAME: datname,
+          },
+          encoding: 'utf8',
+          timeout: 30_000,
+        })
+        return { status: result.status, stderr: `${result.stderr || ''}${result.stdout || ''}` }
+      }
+
+      const armA = runArm('uncaught', nameA)
+      expect(armA.status, `arm A exit 17; got ${armA.status}\n${armA.stderr}`).toBe(17)
+      const armB = runArm('owned', nameB)
+      expect(armB.status, `arm B exit 0; got ${armB.status}\n${armB.stderr}`).toBe(0)
+
+      // Classifier: 57P01 / exact admin message only — not generic terminate.
+      expect(
+        isAdministratorTerminationError(
+          Object.assign(new Error('terminating connection due to administrator command'), { code: '57P01' }),
+        ),
+      ).toBe(true)
+      expect(
+        isAdministratorTerminationError(new Error('terminating connection due to administrator command')),
+      ).toBe(true)
+      expect(isAdministratorTerminationError(new Error('Connection terminated unexpectedly'))).toBe(false)
+      expect(
+        isAdministratorTerminationError(Object.assign(new Error('connection reset'), { code: 'ECONNRESET' })),
+      ).toBe(false)
+
+      const fake = new EventEmitter() as EventEmitter & {
+        on(event: 'error', listener: (err: Error) => void): EventEmitter
+        off(event: 'error', listener: (err: Error) => void): EventEmitter
+      }
+      const nonTerm = attachOwnedPoolTerminationHandler(fake)
+      expect(() =>
+        fake.emit('error', Object.assign(new Error('ECONNRESET synthetic'), { code: 'ECONNRESET' })),
+      ).toThrow(/ECONNRESET synthetic/)
+      expect(nonTerm.absorbed()).toBe(0)
+      // Generic terminate message must also stay loud (not absorbed).
+      expect(() => fake.emit('error', new Error('Connection terminated unexpectedly'))).toThrow(
+        /Connection terminated unexpectedly/,
+      )
+      expect(nonTerm.absorbed()).toBe(0)
+      nonTerm.detach()
+    })
+
+    it('wiring: both real-server suites capture poolManager.get().getInternalPool() and attach the handler', () => {
+      const dir = dirname(fileURLToPath(import.meta.url))
+      for (const file of [
+        'bpmn-poller-disabled-startprocess-zero-residue.db.test.ts',
+        'attendance-w4c2-sweep-call-through.db.test.ts',
+      ]) {
+        const src = readFileSync(join(dir, file), 'utf8')
+        expect(src, file).toMatch(/poolManager\.get\(\)\.getInternalPool\(\)/)
+        expect(src, file).toMatch(/attachOwnedPoolTerminationHandler/)
+        expect(src, file).toMatch(/serverInternalPool/)
+      }
+    })
   })
 
   // ==============================================================================================

--- a/packages/core-backend/tests/integration/scratch-database-drain.db.test.ts
+++ b/packages/core-backend/tests/integration/scratch-database-drain.db.test.ts
@@ -420,6 +420,20 @@ describeIfDatabase('#4791 scratch-database teardown drain', () => {
       expect(
         isAdministratorTerminationError(new Error('terminating connection due to administrator command')),
       ).toBe(true)
+      expect(
+        isAdministratorTerminationError(new Error('prefix terminating connection due to administrator command')),
+      ).toBe(false)
+      expect(
+        isAdministratorTerminationError(new Error('terminating connection due to administrator command suffix')),
+      ).toBe(false)
+      expect(
+        isAdministratorTerminationError(new Error(' terminating connection due to administrator command')),
+      ).toBe(false)
+      expect(
+        isAdministratorTerminationError(
+          Object.assign(new Error('terminating connection due to administrator command'), { code: 'ECONNRESET' }),
+        ),
+      ).toBe(false)
       expect(isAdministratorTerminationError(new Error('Connection terminated unexpectedly'))).toBe(false)
       expect(
         isAdministratorTerminationError(Object.assign(new Error('connection reset'), { code: 'ECONNRESET' })),
@@ -442,16 +456,20 @@ describeIfDatabase('#4791 scratch-database teardown drain', () => {
       nonTerm.detach()
     })
 
-    it('wiring: both real-server suites capture poolManager.get().getInternalPool() and attach the handler', () => {
+    it('source contract: both real-server suites require the post-start internal pool during teardown', () => {
       const dir = dirname(fileURLToPath(import.meta.url))
       for (const file of [
         'bpmn-poller-disabled-startprocess-zero-residue.db.test.ts',
         'attendance-w4c2-sweep-call-through.db.test.ts',
       ]) {
         const src = readFileSync(join(dir, file), 'utf8')
-        expect(src, file).toMatch(/poolManager\.get\(\)\.getInternalPool\(\)/)
+        const startAt = src.indexOf('await server.start()')
+        const captureAt = src.indexOf('poolManager.get().getInternalPool()')
+        expect(startAt, file).toBeGreaterThan(-1)
+        expect(captureAt, file).toBeGreaterThan(startAt)
         expect(src, file).toMatch(/attachOwnedPoolTerminationHandler/)
-        expect(src, file).toMatch(/serverInternalPool/)
+        expect(src, file).toMatch(/new Error\('[A-Z0-9_]+SERVER_INTERNAL_POOL_NOT_CAPTURED'\)/)
+        expect(src, file).toMatch(/if \(poolCaptureError\) throw poolCaptureError/)
       }
     })
   })


### PR DESCRIPTION
## What
- protect shared/system database names from the scratch-drop helper
- absorb only SQLSTATE 57P01 / exact administrator-command termination on pools owned by the affected real-server suites, and only during teardown
- capture the real `poolManager` internal pool after scratch `DATABASE_URL` rebinding
- replace event-loop-turn timing with a bounded condition wait in the real-PG child proof

## Verification
- `scratch-database-drain.db.test.ts`: 15/15 against local PostgreSQL 15
- affected real-server suites: 10/10 against independent random scratch DBs
- backend `tsc --noEmit`
- generic connection termination and ECONNRESET remain loud

## Boundary
This is the narrow mechanism fix for #4820. The issue should remain observation-gated until repeated Node 18 CI runs are green; this PR does not claim every real-DB suite in the repository has been converted to a scratch DB.