### PR TITLE
fix(ops): sync staging compose during deploy

### DIFF
--- a/.github/workflows/attendance-staging-window-runner.yml
+++ b/.github/workflows/attendance-staging-window-runner.yml
@@ -141,20 +141,33 @@ jobs:
           DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
           DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
           DEPLOY_SSH_KEY_B64: ${{ secrets.DEPLOY_SSH_KEY_B64 }}
+          DEPLOY_KNOWN_HOSTS: ${{ secrets.DEPLOY_KNOWN_HOSTS }}
         run: |
           set -euo pipefail
           mkdir -p ~/.ssh
+          [[ -n "$DEPLOY_KNOWN_HOSTS" ]] || { echo "DEPLOY_KNOWN_HOSTS is required" >&2; exit 2; }
           printf '%s' "$DEPLOY_SSH_KEY_B64" | base64 -d > ~/.ssh/deploy_key
-          chmod 600 ~/.ssh/deploy_key
+          decoded_known_hosts="$(printf '%s' "$DEPLOY_KNOWN_HOSTS" | base64 -d 2>/dev/null || true)"
+          if printf '%s' "$decoded_known_hosts" | grep -Eq 'ssh-ed25519|ssh-rsa|ecdsa-sha2|ssh-dss'; then
+            printf '%s\n' "$decoded_known_hosts" > ~/.ssh/known_hosts
+          else
+            printf '%s\n' "$DEPLOY_KNOWN_HOSTS" > ~/.ssh/known_hosts
+          fi
+          grep -Eq 'ssh-ed25519|ssh-rsa|ecdsa-sha2|ssh-dss' ~/.ssh/known_hosts \
+            || { echo "DEPLOY_KNOWN_HOSTS did not resolve to a recognizable key" >&2; exit 2; }
+          chmod 600 ~/.ssh/deploy_key ~/.ssh/known_hosts
           runner_dir="/tmp/attendance-window-runner-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           echo "runner_dir=$runner_dir" >> "$GITHUB_OUTPUT"
           tar -czf - \
             scripts/ops/attendance-staging-window-runner-remote.sh \
             scripts/ops/attendance-window-runner-pipeline.lib.sh \
             scripts/ops/attendance-window-runner-mint-token.mjs \
-          | ssh -o StrictHostKeyChecking=no -o IdentitiesOnly=yes -i ~/.ssh/deploy_key \
+          | ssh -o StrictHostKeyChecking=yes -o UserKnownHostsFile=~/.ssh/known_hosts -o IdentitiesOnly=yes -i ~/.ssh/deploy_key \
               "$DEPLOY_USER@$DEPLOY_HOST" \
               "bash -o pipefail -c 'set -euo pipefail; rm -rf ${runner_dir}; mkdir -p ${runner_dir}; tar -xzf - -C ${runner_dir} --strip-components=2'"
+          scp -o StrictHostKeyChecking=yes -o UserKnownHostsFile=~/.ssh/known_hosts -o IdentitiesOnly=yes -i ~/.ssh/deploy_key \
+            docker-compose.app.staging.yml \
+            "$DEPLOY_USER@$DEPLOY_HOST:${runner_dir}/docker-compose.app.staging.yml"
 
       - name: Run remote action
         id: remote
@@ -174,7 +187,7 @@ jobs:
           RUNNER_DIR: ${{ steps.sync.outputs.runner_dir }}
         run: |
           set -euo pipefail
-          ssh_opts="-o StrictHostKeyChecking=no -o IdentitiesOnly=yes -i ~/.ssh/deploy_key"
+          ssh_opts="-o StrictHostKeyChecking=yes -o UserKnownHostsFile=$HOME/.ssh/known_hosts -o IdentitiesOnly=yes -i $HOME/.ssh/deploy_key"
           DEPLOY_PATH="${DEPLOY_PATH:-metasheet2}"
           for pair in "DEPLOY_PATH=$DEPLOY_PATH" "STAGING_DEPLOY_PATH=$STAGING_DEPLOY_PATH" "SKIP_HOST_SYNC=$SKIP_HOST_SYNC"; do
             value="${pair#*=}"

--- a/scripts/ops/attendance-staging-window-runner-remote.sh
+++ b/scripts/ops/attendance-staging-window-runner-remote.sh
@@ -112,7 +112,7 @@ resolve_home_path() {
 
 STAGING_DIR="$(resolve_home_path "$STAGING_DEPLOY_PATH")"
 PROD_REPO_DIR="$(resolve_home_path "$DEPLOY_PATH")"
-STAGING_COMPOSE_FILE="${STAGING_DIR}/docker-compose.app.staging.yml"
+LEGACY_STAGING_COMPOSE_FILE="${STAGING_DIR}/docker-compose.app.staging.yml"
 # The override MUST persist across runs. `docker compose up -d` stamps each container's
 # com.docker.compose.project.config_files label with the -f paths it was given, so any later
 # `docker compose config` (e.g. the recovery-flag containment check) re-reads THIS file BY PATH.
@@ -125,6 +125,11 @@ STAGING_COMPOSE_FILE="${STAGING_DIR}/docker-compose.app.staging.yml"
 # preserving the removal semantic.
 RUNNER_PERSIST_DIR="${HOME}/.metasheet2/window-runner"
 OVERRIDE_FILE="${RUNNER_PERSIST_DIR}/docker-compose.window-runner.override.yml"
+PERSISTENT_STAGING_COMPOSE_FILE="${RUNNER_PERSIST_DIR}/docker-compose.app.staging.yml"
+STAGING_COMPOSE_FILE="$LEGACY_STAGING_COMPOSE_FILE"
+if [[ -f "$PERSISTENT_STAGING_COMPOSE_FILE" ]]; then
+  STAGING_COMPOSE_FILE="$PERSISTENT_STAGING_COMPOSE_FILE"
+fi
 
 # --- staging-only guard (fail closed) -------------------------------------------------
 assert_staging_only() {
@@ -152,7 +157,30 @@ require_compose_v2() {
 
 compose_staging() {
   # The ONLY compose entry point in this script: staging compose file + runner override.
-  (cd "$STAGING_DIR" && docker compose -f "$STAGING_COMPOSE_FILE" -f "$OVERRIDE_FILE" "$@")
+  (cd "$STAGING_DIR" && IMAGE_OWNER="$IMAGE_OWNER" IMAGE_TAG="$DEPLOY_SHA" \
+    docker compose --project-directory "$STAGING_DIR" -f "$STAGING_COMPOSE_FILE" -f "$OVERRIDE_FILE" "$@")
+}
+
+prepare_staging_compose_for_deploy() {
+  local candidate="${HERE}/docker-compose.app.staging.yml"
+  [[ -f "$candidate" ]] || fail "checked-out staging compose candidate missing: ${candidate}"
+  for name in "$BACKEND_CONTAINER" "$WEB_CONTAINER" "$POSTGRES_CONTAINER" "$REDIS_CONTAINER"; do
+    grep -q "container_name: ${name}" "$candidate" \
+      || fail "staging compose candidate does not define ${name}; refusing install"
+  done
+  if grep -qE 'container_name: metasheet-(backend|web|postgres|redis)[[:space:]]*$' "$candidate"; then
+    fail "staging compose candidate defines PROD-track container names; refusing install"
+  fi
+
+  mkdir -p "$RUNNER_PERSIST_DIR"
+  STAGING_COMPOSE_CANDIDATE_TMP="$(mktemp "${RUNNER_PERSIST_DIR}/.staging-compose.XXXXXX")"
+  cp "$candidate" "$STAGING_COMPOSE_CANDIDATE_TMP"
+  if ! (cd "$STAGING_DIR" && IMAGE_OWNER="$IMAGE_OWNER" IMAGE_TAG="$DEPLOY_SHA" \
+    docker compose --project-directory "$STAGING_DIR" -f "$STAGING_COMPOSE_CANDIDATE_TMP" config) >/dev/null 2>&1; then
+    rm -f "$STAGING_COMPOSE_CANDIDATE_TMP"
+    STAGING_COMPOSE_CANDIDATE_TMP=""
+    fail "checked-out staging compose candidate failed validation; kept ${STAGING_COMPOSE_FILE}"
+  fi
 }
 
 staging_exec() {
@@ -342,6 +370,8 @@ auth_round_trip() {
 action_deploy() {
   require_sha
   require_compose_v2
+  local STAGING_COMPOSE_CANDIDATE_TMP=""
+  prepare_staging_compose_for_deploy
 
   local backend_image="ghcr.io/${IMAGE_OWNER}/metasheet2-backend:${DEPLOY_SHA}"
   local web_image="ghcr.io/${IMAGE_OWNER}/metasheet2-web:${DEPLOY_SHA}"
@@ -381,15 +411,21 @@ action_deploy() {
   # Validate the candidate renders against the staging compose file BEFORE it goes live — a broken
   # override would otherwise dangle EVERY container's config_files label. On failure, keep the
   # previous known-good override untouched and fail closed.
-  # Validate in the SAME cwd as compose_staging() (line ~155): staging compose uses relative
+  # Validate in the SAME cwd as compose_staging() above: staging compose uses relative
   # env_file + .env interpolation, so `cd "$STAGING_DIR"` first — otherwise we'd validate a
   # different resolved config than the one `up -d` actually executes.
-  if ! (cd "$STAGING_DIR" && docker compose -f "$STAGING_COMPOSE_FILE" -f "$override_tmp" config) >/dev/null 2>&1; then
-    rm -f "$override_tmp"
-    fail "candidate override failed 'docker compose config' validation; kept previous override at ${OVERRIDE_FILE}"
+  if ! (cd "$STAGING_DIR" && IMAGE_OWNER="$IMAGE_OWNER" IMAGE_TAG="$DEPLOY_SHA" \
+    docker compose --project-directory "$STAGING_DIR" -f "$STAGING_COMPOSE_CANDIDATE_TMP" -f "$override_tmp" config) >/dev/null 2>&1; then
+    rm -f "$override_tmp" "$STAGING_COMPOSE_CANDIDATE_TMP"
+    fail "candidate base/override pair failed 'docker compose config' validation; kept previous persistent files"
   fi
-  # Same-directory rename ⇒ atomic replace; a concurrent reader never sees a partial file.
+  # Both candidates are validated as one pair before either persistent file changes. Each
+  # same-directory rename is atomic; workflow concurrency serializes staging transitions.
+  mv -f "$STAGING_COMPOSE_CANDIDATE_TMP" "$PERSISTENT_STAGING_COMPOSE_FILE"
+  STAGING_COMPOSE_FILE="$PERSISTENT_STAGING_COMPOSE_FILE"
   mv -f "$override_tmp" "$OVERRIDE_FILE"
+  hash_value "$STAGING_COMPOSE_FILE" > "${OUTPUT_DIR}/staging-compose.sha256"
+  log "staging compose installed atomically at persistent path: ${STAGING_COMPOSE_FILE}"
   log "override written (persistent, atomic): ${OVERRIDE_FILE} (env mode: ${SET_WINDOW_ENV})"
 
   compose_staging pull backend web 2>&1 | tee "${OUTPUT_DIR}/compose-pull.log"

--- a/scripts/ops/attendance-window-runner-pipeline.test.mjs
+++ b/scripts/ops/attendance-window-runner-pipeline.test.mjs
@@ -28,7 +28,9 @@ import { fileURLToPath } from 'node:url'
 const HERE = dirname(fileURLToPath(import.meta.url))
 const LIB = join(HERE, 'attendance-window-runner-pipeline.lib.sh')
 const REMOTE_SH = join(HERE, 'attendance-staging-window-runner-remote.sh')
+const LIFECYCLE_REMOTE_SH = join(HERE, 'dingtalk-lifecycle-staging-canary-remote.sh')
 const WORKFLOW = join(HERE, '..', '..', '.github', 'workflows', 'attendance-staging-window-runner.yml')
+const STAGING_COMPOSE = join(HERE, '..', '..', 'docker-compose.app.staging.yml')
 
 function runPipefailBash(script) {
   // Same shape as the workflow's remote invocation: bash -o pipefail -c '<script>'.
@@ -106,6 +108,117 @@ test('workflow shape contract: remote commands run under explicit `bash -o pipef
     `expected every remote (ssh) command to be wrapped in \`bash -o pipefail -c\` (sync + action), found ${pipefailInvocations.length}`,
   )
   assert.doesNotMatch(yaml, /bash\s+-s\b/, 'the workflow must not fall back to `ssh ... bash -s` (login-shell pipefail is not guaranteed)')
+})
+
+test('workflow pins deploy-host identity for every SSH and SCP operation', () => {
+  const workflow = readFileSync(WORKFLOW, 'utf8')
+  assert.match(workflow, /DEPLOY_KNOWN_HOSTS: \$\{\{ secrets\.DEPLOY_KNOWN_HOSTS \}\}/)
+  assert.match(workflow, /DEPLOY_KNOWN_HOSTS is required/)
+  assert.match(workflow, /decoded_known_hosts=.*base64 -d/)
+  assert.match(workflow, /ssh-ed25519\|ssh-rsa\|ecdsa-sha2\|ssh-dss/)
+  assert.match(workflow, /did not resolve to a recognizable key/)
+  assert.doesNotMatch(workflow, /StrictHostKeyChecking=no/)
+  const strictUses = workflow.match(/StrictHostKeyChecking=yes/g) || []
+  assert.ok(strictUses.length >= 3, `expected strict host checks on sync SSH, compose SCP, and remote action; found ${strictUses.length}`)
+  assert.match(workflow, /UserKnownHostsFile=~\/\.ssh\/known_hosts/)
+  assert.match(workflow, /UserKnownHostsFile=\$HOME\/\.ssh\/known_hosts/)
+})
+
+function assertPersistentComposeContract({ workflow, remote, lifecycleRemote, stagingCompose }) {
+  assert.match(
+    workflow,
+    /scp[^\n]*\\\n\s+docker-compose\.app\.staging\.yml \\\n\s+"\$DEPLOY_USER@\$DEPLOY_HOST:\$\{runner_dir\}\/docker-compose\.app\.staging\.yml"/,
+    'the remote action must receive the compose file from the exact workflow checkout',
+  )
+  assert.match(remote, /PERSISTENT_STAGING_COMPOSE_FILE="\$\{RUNNER_PERSIST_DIR\}\/docker-compose\.app\.staging\.yml"/)
+  assert.match(remote, /prepare_staging_compose_for_deploy\(\)/)
+  assert.match(remote, /candidate="\$\{HERE\}\/docker-compose\.app\.staging\.yml"/)
+  assert.match(remote, /mv -f "\$STAGING_COMPOSE_CANDIDATE_TMP" "\$PERSISTENT_STAGING_COMPOSE_FILE"/)
+
+  const deployStart = remote.indexOf('action_deploy() {')
+  const deployEnd = remote.indexOf('\naction_smoke() {', deployStart)
+  const deploy = remote.slice(deployStart, deployEnd)
+  const prepareIndex = deploy.indexOf('prepare_staging_compose_for_deploy')
+  const pairValidationIndex = deploy.indexOf('-f "$STAGING_COMPOSE_CANDIDATE_TMP" -f "$override_tmp" config')
+  const baseMoveIndex = deploy.indexOf('mv -f "$STAGING_COMPOSE_CANDIDATE_TMP" "$PERSISTENT_STAGING_COMPOSE_FILE"')
+  assert.ok(prepareIndex >= 0 && prepareIndex < pairValidationIndex, 'deploy must prepare the checked-out base before pair validation')
+  assert.ok(pairValidationIndex < baseMoveIndex, 'the base/override pair must validate before either persistent file changes')
+  assert.equal(
+    (remote.match(/prepare_staging_compose_for_deploy/g) || []).length,
+    2,
+    'only the function definition and action=deploy call may prepare the persistent compose',
+  )
+
+  assert.match(stagingCompose, /METASHEET_BUILD_COMMIT: \$\{IMAGE_TAG:-unknown\}/)
+  assert.match(stagingCompose, /METASHEET_BUILD_IMAGE_TAG: \$\{IMAGE_TAG:-unknown\}/)
+  assert.match(
+    remote,
+    /IMAGE_OWNER="\$IMAGE_OWNER" IMAGE_TAG="\$DEPLOY_SHA" \\\n\s+docker compose --project-directory "\$STAGING_DIR" -f "\$STAGING_COMPOSE_FILE" -f "\$OVERRIDE_FILE"/,
+    'live pull/up must render health identity from the exact deploy SHA',
+  )
+  assert.match(
+    deploy,
+    /IMAGE_OWNER="\$IMAGE_OWNER" IMAGE_TAG="\$DEPLOY_SHA" \\\n\s+docker compose --project-directory "\$STAGING_DIR" -f "\$STAGING_COMPOSE_CANDIDATE_TMP" -f "\$override_tmp" config/,
+    'base/override validation must use the same exact-SHA interpolation as live pull/up',
+  )
+  assert.equal(
+    (remote.match(/docker compose --project-directory "\$STAGING_DIR"/g) || []).length,
+    3,
+    'every non-version-check attendance compose invocation must pin the staging project directory',
+  )
+  assert.equal(
+    (lifecycleRemote.match(/docker compose --project-directory "\$STAGING_DIR"/g) || []).length,
+    1,
+    'the lifecycle compose entry point must pin the staging project directory',
+  )
+  for (const source of [remote, lifecycleRemote]) {
+    assert.match(source, /PERSISTENT_STAGING_COMPOSE_FILE=/)
+  }
+}
+
+test('deploy ships and atomically installs the checked-out staging compose at a persistent path', () => {
+  assertPersistentComposeContract({
+    workflow: readFileSync(WORKFLOW, 'utf8'),
+    remote: readFileSync(REMOTE_SH, 'utf8'),
+    lifecycleRemote: readFileSync(LIFECYCLE_REMOTE_SH, 'utf8'),
+    stagingCompose: readFileSync(STAGING_COMPOSE, 'utf8'),
+  })
+})
+
+test('MUTATION: removing the deploy compose preparation call turns the full contract red', () => {
+  const original = readFileSync(REMOTE_SH, 'utf8')
+  const deployStart = original.indexOf('action_deploy() {')
+  const deployEnd = original.indexOf('\naction_smoke() {', deployStart)
+  const mutated = `${original.slice(0, deployStart)}${original.slice(deployStart, deployEnd).replace(
+    '  prepare_staging_compose_for_deploy\n',
+    '',
+  )}${original.slice(deployEnd)}`
+  assert.throws(
+    () => assertPersistentComposeContract({
+      workflow: readFileSync(WORKFLOW, 'utf8'),
+      remote: mutated,
+      lifecycleRemote: readFileSync(LIFECYCLE_REMOTE_SH, 'utf8'),
+      stagingCompose: readFileSync(STAGING_COMPOSE, 'utf8'),
+    }),
+    /deploy must prepare the checked-out base/,
+  )
+})
+
+test('MUTATION: dropping exact-SHA interpolation from live compose turns the health contract red', () => {
+  const original = readFileSync(REMOTE_SH, 'utf8')
+  const mutated = original.replace(
+    'IMAGE_OWNER="$IMAGE_OWNER" IMAGE_TAG="$DEPLOY_SHA" \\\n    docker compose --project-directory "$STAGING_DIR" -f "$STAGING_COMPOSE_FILE" -f "$OVERRIDE_FILE"',
+    'docker compose --project-directory "$STAGING_DIR" -f "$STAGING_COMPOSE_FILE" -f "$OVERRIDE_FILE"',
+  )
+  assert.throws(
+    () => assertPersistentComposeContract({
+      workflow: readFileSync(WORKFLOW, 'utf8'),
+      remote: mutated,
+      lifecycleRemote: readFileSync(LIFECYCLE_REMOTE_SH, 'utf8'),
+      stagingCompose: readFileSync(STAGING_COMPOSE, 'utf8'),
+    }),
+    /live pull\/up must render health identity/,
+  )
 })
 
 test('dsn_database_name: extracts the db-name path segment, stripping the query string', () => {
@@ -306,15 +419,15 @@ test('persistent override: lives under $HOME/.metasheet2/window-runner, NOT the 
 test('persistent override: written atomically — mktemp candidate + docker compose config validation + rename, never a truncating write straight onto the live file', () => {
   const remote = readFileSync(REMOTE_SH, 'utf8')
   assert.match(remote, /override_tmp="\$\(mktemp "\$\{RUNNER_PERSIST_DIR\}\/\.override\.XXXXXX"\)"/, 'expected a mktemp candidate override in the persist dir (X placeholder at the END — no trailing suffix)')
-  const validateIdx = remote.indexOf('docker compose -f "$STAGING_COMPOSE_FILE" -f "$override_tmp" config')
+  const validateIdx = remote.indexOf('docker compose --project-directory "$STAGING_DIR" -f "$STAGING_COMPOSE_CANDIDATE_TMP" -f "$override_tmp" config')
   const mvIdx = remote.indexOf('mv -f "$override_tmp" "$OVERRIDE_FILE"')
   assert.notEqual(validateIdx, -1, 'candidate override must be validated with docker compose config before replacing the live file')
   // the validation MUST run in the same cwd as compose_staging() (cd "$STAGING_DIR"), or it
   // resolves relative env_file/.env differently than the config `up -d` actually executes
   assert.match(
-    remote.slice(Math.max(0, validateIdx - 40), validateIdx),
-    /\(cd "\$STAGING_DIR" &&\s*$/,
-    'candidate override validation must run inside (cd "$STAGING_DIR" && docker compose …), matching compose_staging()',
+    remote.slice(Math.max(0, validateIdx - 120), validateIdx),
+    /\(cd "\$STAGING_DIR" && IMAGE_OWNER="\$IMAGE_OWNER" IMAGE_TAG="\$DEPLOY_SHA" \\\n\s*$/,
+    'candidate pair validation must use the staging cwd and exact-SHA interpolation, matching compose_staging()',
   )
   assert.notEqual(mvIdx, -1, 'candidate override must be atomically renamed into place')
   assert.ok(validateIdx < mvIdx, 'validation must come BEFORE the atomic rename')

--- a/scripts/ops/dingtalk-lifecycle-staging-canary-contract.test.mjs
+++ b/scripts/ops/dingtalk-lifecycle-staging-canary-contract.test.mjs
@@ -231,7 +231,10 @@ test('P1 backend recreate reuses the exact running image pin instead of latest o
   const source = read(REMOTE_SH)
   assert.match(source, /resolve_live_backend_image_pin\(\)/)
   assert.match(source, /metasheet2-backend:\(\[0-9a-f\]\{40\}\)/)
-  assert.match(source, /IMAGE_OWNER="\$image_owner" IMAGE_TAG="\$image_tag" docker compose/)
+  assert.match(
+    source,
+    /IMAGE_OWNER="\$image_owner" IMAGE_TAG="\$image_tag" \\\n\s+docker compose --project-directory "\$STAGING_DIR"/,
+  )
   assert.match(source, /refusing compose/)
 
   const sha = 'a'.repeat(40)

--- a/scripts/ops/dingtalk-lifecycle-staging-canary-remote.sh
+++ b/scripts/ops/dingtalk-lifecycle-staging-canary-remote.sh
@@ -72,10 +72,15 @@ resolve_home_path() {
 
 STAGING_DIR="$(resolve_home_path "$STAGING_DEPLOY_PATH")"
 PROD_REPO_DIR="$(resolve_home_path "$DEPLOY_PATH")"
-STAGING_COMPOSE_FILE="${STAGING_DIR}/docker-compose.app.staging.yml"
+LEGACY_STAGING_COMPOSE_FILE="${STAGING_DIR}/docker-compose.app.staging.yml"
 
 ATTENDANCE_PERSIST_DIR="${HOME}/.metasheet2/window-runner"
 ATTENDANCE_OVERRIDE_FILE="${ATTENDANCE_PERSIST_DIR}/docker-compose.window-runner.override.yml"
+PERSISTENT_STAGING_COMPOSE_FILE="${ATTENDANCE_PERSIST_DIR}/docker-compose.app.staging.yml"
+STAGING_COMPOSE_FILE="$LEGACY_STAGING_COMPOSE_FILE"
+if [[ -f "$PERSISTENT_STAGING_COMPOSE_FILE" ]]; then
+  STAGING_COMPOSE_FILE="$PERSISTENT_STAGING_COMPOSE_FILE"
+fi
 
 LIFECYCLE_PERSIST_DIR="${HOME}/.metasheet2/lifecycle-canary"
 LIFECYCLE_OVERRIDE_FILE="${LIFECYCLE_PERSIST_DIR}/docker-compose.lifecycle-canary.override.yml"
@@ -159,7 +164,8 @@ compose_staging_cmd() {
     fi
     read -r image_owner image_tag <<< "$image_pin"
   fi
-  (cd "$STAGING_DIR" && IMAGE_OWNER="$image_owner" IMAGE_TAG="$image_tag" docker compose "${files[@]}" "$@")
+  (cd "$STAGING_DIR" && IMAGE_OWNER="$image_owner" IMAGE_TAG="$image_tag" \
+    docker compose --project-directory "$STAGING_DIR" "${files[@]}" "$@")
 }
 
 pin_live_backend_image_for_transition() {


### PR DESCRIPTION
## Why

Attendance staging deploy run 31414837881 pulled and recreated the exact images, but backend/web health still reported an older commit because the separate read-only staging directory retained an old `docker-compose.app.staging.yml`. The lifecycle provenance guard correctly refused to accept that conflict.

## What changed

- transfer the checked-out staging compose with strict pinned-host SSH/SCP
- validate the checked-out base plus generated override before replacing either persistent file
- keep the canonical compose under the deploy user's persistent runner directory
- force all out-of-tree compose calls back to the real staging project directory
- render build identity from the exact deploy SHA on live pull/up
- make the install and exact-SHA mutations re-run the full contract

## Verification

- `node --test scripts/ops/attendance-window-runner-pipeline.test.mjs` (27/27)
- `node --test scripts/ops/dingtalk-lifecycle-staging-canary-contract.test.mjs` (41/41)
- `bash -n scripts/ops/attendance-staging-window-runner-remote.sh scripts/ops/dingtalk-lifecycle-staging-canary-remote.sh`
- independent Grok 4.5 adversarial review: APPROVE, 0 P1/P2 after one P1 and two P2 evidence gaps were fixed

## Safety

No lifecycle flag is enabled. This PR only repairs staging deployment provenance; alias, pending admission, and deprovision remain OFF.