### PR TITLE
fix(integration): reject echo-only K3 lookup identity

### DIFF
--- a/plugins/plugin-integration-core/__tests__/k3-wise-c6-write-profile.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/k3-wise-c6-write-profile.test.cjs
@@ -123,7 +123,7 @@ function jsonResponse(status, body) {
 
 // Mock K3: login, GetDetail (existing row for MAT-C6-EXIST, business-fail for everything
 // else — K3's real "not found" shape), Save success. Counts every path.
-function mockK3({ existing = {}, fallbackDetail = null } = {}) {
+function mockK3({ existing = {}, fallbackDetail = null, echoOnly = false } = {}) {
   const calls = []
   const impl = async (url, init) => {
     const parsed = new URL(url)
@@ -141,6 +141,13 @@ function mockK3({ existing = {}, fallbackDetail = null } = {}) {
           StatusCode: 200,
           Message: 'Successful',
           Data: [{ FStatus: true, FItemID: row.FItemID, Data: row }],
+        })
+      }
+      if (echoOnly) {
+        return jsonResponse(200, {
+          StatusCode: 200,
+          Message: 'Successful',
+          Data: [{ FStatus: true, Data: { FNumber: number } }],
         })
       }
       if (fallbackDetail) {
@@ -382,6 +389,35 @@ test('lookup ignores a successful GetDetail record whose normalized key does not
   const dryRun = await dryRunExternalWrite(c6Inputs({
     rows: [{ code: 'NEW-MATERIAL', name: 'New material', spec: 'SPEC-N' }],
     fetchPair,
+    tokenStore: memoryStore(),
+  }))
+
+  assert.equal(dryRun.counts.add, 1)
+  assert.equal(dryRun.counts.update, 0)
+  assert.equal(dryRun.counts.held, 0)
+})
+
+test('lookup ignores an echo-only successful GetDetail envelope with no independent material identity', async () => {
+  const fetchPair = mockK3({
+    // Live-shape regression: the endpoint accepts the request and echoes FNumber, but neither
+    // a stable material id nor FName was independently returned.
+    echoOnly: true,
+  })
+  const dryRun = await dryRunExternalWrite(c6Inputs({
+    rows: [{ code: 'ECHO-ONLY-MATERIAL', name: 'New material', spec: 'SPEC-N' }],
+    fetchPair,
+    tokenStore: memoryStore(),
+  }))
+
+  assert.equal(dryRun.counts.add, 1)
+  assert.equal(dryRun.counts.update, 0)
+  assert.equal(dryRun.counts.held, 0)
+})
+
+test('lookup ignores an empty successful GetDetail detail even when the adapter correlates its request key', async () => {
+  const dryRun = await dryRunExternalWrite(c6Inputs({
+    rows: [{ code: 'SYNTHETIC-KEY-MATERIAL', name: 'New material', spec: 'SPEC-N' }],
+    fetchPair: mockK3({ fallbackDetail: {} }),
     tokenStore: memoryStore(),
   }))
 

--- a/plugins/plugin-integration-core/__tests__/k3-wise-c6-write-profile.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/k3-wise-c6-write-profile.test.cjs
@@ -484,6 +484,34 @@ for (const { label, value } of [
   })
 }
 
+test('lookup never treats the request-key correlation fallback as raw material identity', async () => {
+  const input = c6Inputs({
+    rows: [{ code: 'REQUEST-KEY-ONLY', name: 'New material', spec: 'SPEC-N' }],
+    fetchPair: mockK3(),
+    tokenStore: memoryStore(),
+  })
+  const targetSystem = k3TargetSystem()
+  input.dataSourceWrites = createK3WiseC6WriteSource({
+    system: targetSystem,
+    createAdapter: () => ({
+      async read() {
+        return {
+          // The normalized read record is correlated with the request, but neither raw
+          // response layer independently returned the key. A raw ID alone is insufficient.
+          records: [{ FNumber: 'REQUEST-KEY-ONLY', FItemID: 7005 }],
+          raw: { Data: [{ FStatus: true, FItemID: 7005, Data: {} }] },
+        }
+      },
+    }),
+    b4: b4Of([APPROVED_B4_ROW]),
+  })
+
+  const dryRun = await dryRunExternalWrite(input)
+  assert.equal(dryRun.counts.add, 1)
+  assert.equal(dryRun.counts.update, 0)
+  assert.equal(dryRun.counts.held, 0)
+})
+
 test('lookup rejects a malformed raw Data container even when a normalized record is present', async () => {
   const input = c6Inputs({
     rows: [{ code: 'MALFORMED-RAW-MATERIAL', name: 'New material', spec: 'SPEC-N' }],

--- a/plugins/plugin-integration-core/__tests__/k3-wise-c6-write-profile.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/k3-wise-c6-write-profile.test.cjs
@@ -123,7 +123,7 @@ function jsonResponse(status, body) {
 
 // Mock K3: login, GetDetail (existing row for MAT-C6-EXIST, business-fail for everything
 // else — K3's real "not found" shape), Save success. Counts every path.
-function mockK3({ existing = {}, fallbackDetail = null, echoOnly = false } = {}) {
+function mockK3({ existing = {}, fallbackDetail = null, echoOnly = false, outerIdentity = false, placeholderId = null } = {}) {
   const calls = []
   const impl = async (url, init) => {
     const parsed = new URL(url)
@@ -148,6 +148,20 @@ function mockK3({ existing = {}, fallbackDetail = null, echoOnly = false } = {})
           StatusCode: 200,
           Message: 'Successful',
           Data: [{ FStatus: true, Data: { FNumber: number } }],
+        })
+      }
+      if (outerIdentity) {
+        return jsonResponse(200, {
+          StatusCode: 200,
+          Message: 'Successful',
+          Data: [{ FStatus: true, FNumber: number, FItemID: 7003, Data: { FName: 'Old name' } }],
+        })
+      }
+      if (placeholderId !== null) {
+        return jsonResponse(200, {
+          StatusCode: 200,
+          Message: 'Successful',
+          Data: [{ FStatus: true, Data: { FNumber: number, FItemID: placeholderId } }],
         })
       }
       if (fallbackDetail) {
@@ -421,6 +435,58 @@ test('lookup ignores an empty successful GetDetail detail even when the adapter 
     tokenStore: memoryStore(),
   }))
 
+  assert.equal(dryRun.counts.add, 1)
+  assert.equal(dryRun.counts.update, 0)
+  assert.equal(dryRun.counts.held, 0)
+})
+
+test('lookup accepts the supported outer-key and outer-id GetDetail shape as existing', async () => {
+  const dryRun = await dryRunExternalWrite(c6Inputs({
+    rows: [{ code: 'OUTER-IDENTITY-MATERIAL', name: 'New name', spec: 'SPEC-N' }],
+    fetchPair: mockK3({ outerIdentity: true }),
+    tokenStore: memoryStore(),
+  }))
+
+  assert.equal(dryRun.counts.add, 0)
+  assert.equal(dryRun.counts.update, 1)
+  assert.equal(dryRun.counts.held, 0)
+})
+
+for (const placeholderId of ['null', 'UNDEFINED', 'None']) {
+  test(`lookup rejects placeholder material identifier ${placeholderId} as independent identity`, async () => {
+    const dryRun = await dryRunExternalWrite(c6Inputs({
+      rows: [{ code: 'PLACEHOLDER-ID-MATERIAL', name: 'New material', spec: 'SPEC-N' }],
+      fetchPair: mockK3({ placeholderId }),
+      tokenStore: memoryStore(),
+    }))
+
+    assert.equal(dryRun.counts.add, 1)
+    assert.equal(dryRun.counts.update, 0)
+    assert.equal(dryRun.counts.held, 0)
+  })
+}
+
+test('lookup rejects a malformed raw Data container even when a normalized record is present', async () => {
+  const input = c6Inputs({
+    rows: [{ code: 'MALFORMED-RAW-MATERIAL', name: 'New material', spec: 'SPEC-N' }],
+    fetchPair: mockK3(),
+    tokenStore: memoryStore(),
+  })
+  const targetSystem = k3TargetSystem()
+  input.dataSourceWrites = createK3WiseC6WriteSource({
+    system: targetSystem,
+    createAdapter: () => ({
+      async read() {
+        return {
+          records: [{ FNumber: 'MALFORMED-RAW-MATERIAL', FItemID: 7004, FName: 'Old name' }],
+          raw: { Data: 'malformed' },
+        }
+      },
+    }),
+    b4: b4Of([APPROVED_B4_ROW]),
+  })
+
+  const dryRun = await dryRunExternalWrite(input)
   assert.equal(dryRun.counts.add, 1)
   assert.equal(dryRun.counts.update, 0)
   assert.equal(dryRun.counts.held, 0)

--- a/plugins/plugin-integration-core/__tests__/k3-wise-c6-write-profile.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/k3-wise-c6-write-profile.test.cjs
@@ -466,6 +466,24 @@ for (const placeholderId of ['null', 'UNDEFINED', 'None']) {
   })
 }
 
+for (const { label, value } of [
+  { label: 'boolean', value: true },
+  { label: 'object', value: {} },
+  { label: 'array', value: [] },
+]) {
+  test(`lookup rejects a non-scalar ${label} material identifier as independent identity`, async () => {
+    const dryRun = await dryRunExternalWrite(c6Inputs({
+      rows: [{ code: 'NON-SCALAR-ID-MATERIAL', name: 'New material', spec: 'SPEC-N' }],
+      fetchPair: mockK3({ placeholderId: value }),
+      tokenStore: memoryStore(),
+    }))
+
+    assert.equal(dryRun.counts.add, 1)
+    assert.equal(dryRun.counts.update, 0)
+    assert.equal(dryRun.counts.held, 0)
+  })
+}
+
 test('lookup rejects a malformed raw Data container even when a normalized record is present', async () => {
   const input = c6Inputs({
     rows: [{ code: 'MALFORMED-RAW-MATERIAL', name: 'New material', spec: 'SPEC-N' }],

--- a/plugins/plugin-integration-core/__tests__/k3-wise-c6-write-profile.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/k3-wise-c6-write-profile.test.cjs
@@ -123,7 +123,7 @@ function jsonResponse(status, body) {
 
 // Mock K3: login, GetDetail (existing row for MAT-C6-EXIST, business-fail for everything
 // else — K3's real "not found" shape), Save success. Counts every path.
-function mockK3({ existing = {}, fallbackDetail = null, echoOnly = false, outerIdentity = false, placeholderId = null } = {}) {
+function mockK3({ existing = {}, fallbackDetail = null, echoOnly = false, innerIdOnly = false, outerIdentity = false, placeholderId = null } = {}) {
   const calls = []
   const impl = async (url, init) => {
     const parsed = new URL(url)
@@ -150,11 +150,18 @@ function mockK3({ existing = {}, fallbackDetail = null, echoOnly = false, outerI
           Data: [{ FStatus: true, Data: { FNumber: number } }],
         })
       }
+      if (innerIdOnly) {
+        return jsonResponse(200, {
+          StatusCode: 200,
+          Message: 'Successful',
+          Data: [{ FStatus: true, Data: { FNumber: number, FItemID: 7006 } }],
+        })
+      }
       if (outerIdentity) {
         return jsonResponse(200, {
           StatusCode: 200,
           Message: 'Successful',
-          Data: [{ FStatus: true, FNumber: number, FItemID: 7003, Data: { FName: 'Old name' } }],
+          Data: [{ FStatus: true, FNumber: number, FItemID: 7003, Data: {} }],
         })
       }
       if (placeholderId !== null) {
@@ -444,6 +451,18 @@ test('lookup accepts the supported outer-key and outer-id GetDetail shape as exi
   const dryRun = await dryRunExternalWrite(c6Inputs({
     rows: [{ code: 'OUTER-IDENTITY-MATERIAL', name: 'New name', spec: 'SPEC-N' }],
     fetchPair: mockK3({ outerIdentity: true }),
+    tokenStore: memoryStore(),
+  }))
+
+  assert.equal(dryRun.counts.add, 0)
+  assert.equal(dryRun.counts.update, 1)
+  assert.equal(dryRun.counts.held, 0)
+})
+
+test('lookup accepts an inner-key and inner-id GetDetail shape without a name as existing', async () => {
+  const dryRun = await dryRunExternalWrite(c6Inputs({
+    rows: [{ code: 'INNER-IDENTITY-MATERIAL', name: 'New name', spec: 'SPEC-N' }],
+    fetchPair: mockK3({ innerIdOnly: true }),
     tokenStore: memoryStore(),
   }))
 

--- a/plugins/plugin-integration-core/lib/adapters/k3-wise-c6-write-profile.cjs
+++ b/plugins/plugin-integration-core/lib/adapters/k3-wise-c6-write-profile.cjs
@@ -315,7 +315,13 @@ function createK3WiseC6WriteSource({ system, createAdapter, b4 } = {}) {
   function hasMeaningfulMaterialIdentifier(record) {
     if (!record || typeof record !== 'object') return false
     return ['FItemID', 'FItemId', 'FID', 'FId', 'Id', 'id']
-      .some((field) => isMeaningfulK3Identifier(record[field]))
+      .some((field) => {
+        const value = record[field]
+        // The adapter predicate also supports structured identifiers in generic response
+        // extraction. Material existence proof is narrower: a stable ID must be scalar.
+        if (typeof value !== 'number' && typeof value !== 'string') return false
+        return isMeaningfulK3Identifier(value)
+      })
   }
 
   // Some live K3 GetDetail endpoints return HTTP/business success for an unknown material while

--- a/plugins/plugin-integration-core/lib/adapters/k3-wise-c6-write-profile.cjs
+++ b/plugins/plugin-integration-core/lib/adapters/k3-wise-c6-write-profile.cjs
@@ -309,6 +309,45 @@ function createK3WiseC6WriteSource({ system, createAdapter, b4 } = {}) {
     return normalized.length > 0 ? normalized : null
   }
 
+  function meaningfulMaterialIdentifier(record) {
+    if (!record || typeof record !== 'object') return false
+    for (const field of ['FItemID', 'FItemId', 'FID', 'FId', 'Id', 'id']) {
+      const value = record[field]
+      if (typeof value === 'number' && Number.isFinite(value) && value > 0) return true
+      if (typeof value === 'string') {
+        const normalized = value.trim()
+        if (normalized && normalized !== '0') return true
+      }
+    }
+    return false
+  }
+
+  // Some live K3 GetDetail endpoints return HTTP/business success for an unknown material while
+  // echoing only the requested FNumber. The WebAPI adapter deliberately fills a missing FNumber
+  // from that request so ordinary read callers retain correlation, but that synthesized field is
+  // not existence evidence for C6. When the raw envelope is available, require the raw key plus
+  // one independently returned material fact. Test doubles without raw envelopes follow the same
+  // identity rule on their record instead of receiving a production-only bypass.
+  function hasIndependentMaterialIdentity(read, record, keyField, requestedKey) {
+    let candidate = record
+    let wrapper = null
+    if (read && read.raw && typeof read.raw === 'object') {
+      const data = read.raw.Data
+      wrapper = Array.isArray(data)
+        ? data.find((item) => item && typeof item === 'object' && !Array.isArray(item))
+        : (data && typeof data === 'object' && !Array.isArray(data) ? data : null)
+      if (!wrapper) return false
+      candidate = wrapper.Data && typeof wrapper.Data === 'object' && !Array.isArray(wrapper.Data)
+        ? wrapper.Data
+        : wrapper
+    }
+    if (!candidate || typeof candidate !== 'object') return false
+    if (normalizeLookupKey(candidate[keyField]) !== requestedKey) return false
+    return meaningfulMaterialIdentifier(candidate)
+      || meaningfulMaterialIdentifier(wrapper)
+      || normalizeLookupKey(candidate.FName) !== null
+  }
+
   function saveFailure() {
     const error = new Error('K3 WISE Save reported row failure')
     // Review #4761 P2: UNCONDITIONALLY the registered closed token. Passing through the
@@ -453,7 +492,8 @@ function createK3WiseC6WriteSource({ system, createAdapter, b4 } = {}) {
           .map(unwrapReferenceShapes)
           .filter((record) => requestedKey !== null
             && record && typeof record === 'object'
-            && normalizeLookupKey(record[keyField]) === requestedKey)
+            && normalizeLookupKey(record[keyField]) === requestedKey
+            && hasIndependentMaterialIdentity(read, record, keyField, requestedKey))
         return { data: matching }
       } catch (error) {
         const code = error && error.details && error.details.code

--- a/plugins/plugin-integration-core/lib/adapters/k3-wise-c6-write-profile.cjs
+++ b/plugins/plugin-integration-core/lib/adapters/k3-wise-c6-write-profile.cjs
@@ -23,7 +23,10 @@
 
 const { AdapterValidationError } = require('../contracts.cjs')
 const { K3_WISE_MATERIAL_PROFILES } = require('./k3-wise-document-templates.cjs')
-const { resolveEffectiveK3WiseObjects } = require('./k3-wise-webapi-adapter.cjs')
+const {
+  isMeaningfulK3Identifier,
+  resolveEffectiveK3WiseObjects,
+} = require('./k3-wise-webapi-adapter.cjs')
 const {
   K3WISE_MATERIAL_LIST_ACTION_PROFILE_VERSION,
   K3WISE_MATERIAL_LIST_B4_TEMPLATE,
@@ -309,17 +312,10 @@ function createK3WiseC6WriteSource({ system, createAdapter, b4 } = {}) {
     return normalized.length > 0 ? normalized : null
   }
 
-  function meaningfulMaterialIdentifier(record) {
+  function hasMeaningfulMaterialIdentifier(record) {
     if (!record || typeof record !== 'object') return false
-    for (const field of ['FItemID', 'FItemId', 'FID', 'FId', 'Id', 'id']) {
-      const value = record[field]
-      if (typeof value === 'number' && Number.isFinite(value) && value > 0) return true
-      if (typeof value === 'string') {
-        const normalized = value.trim()
-        if (normalized && normalized !== '0') return true
-      }
-    }
-    return false
+    return ['FItemID', 'FItemId', 'FID', 'FId', 'Id', 'id']
+      .some((field) => isMeaningfulK3Identifier(record[field]))
   }
 
   // Some live K3 GetDetail endpoints return HTTP/business success for an unknown material while
@@ -342,9 +338,15 @@ function createK3WiseC6WriteSource({ system, createAdapter, b4 } = {}) {
         : wrapper
     }
     if (!candidate || typeof candidate !== 'object') return false
-    if (normalizeLookupKey(candidate[keyField]) !== requestedKey) return false
-    return meaningfulMaterialIdentifier(candidate)
-      || meaningfulMaterialIdentifier(wrapper)
+    // Mirror extractMaterialDetailRecord's supported response shapes without its final
+    // request-key correlation fallback: an independently returned inner key wins; otherwise
+    // use an independently returned outer-wrapper key. Never use record[keyField] here because
+    // the adapter may have synthesized it from the request.
+    const rawKey = normalizeLookupKey(candidate[keyField])
+      ?? normalizeLookupKey(wrapper && wrapper[keyField])
+    if (rawKey !== requestedKey) return false
+    return hasMeaningfulMaterialIdentifier(candidate)
+      || hasMeaningfulMaterialIdentifier(wrapper)
       || normalizeLookupKey(candidate.FName) !== null
   }
 

--- a/plugins/plugin-integration-core/lib/adapters/k3-wise-webapi-adapter.cjs
+++ b/plugins/plugin-integration-core/lib/adapters/k3-wise-webapi-adapter.cjs
@@ -2590,6 +2590,7 @@ function resolveEffectiveK3WiseObjects(config) {
 
 module.exports = {
   K3_WISE_WEBAPI_ADAPTER_METADATA,
+  isMeaningfulK3Identifier: isMeaningfulIdentifier,
   resolveEffectiveK3WiseObjects,
   K3_PROFILE_PINNED_REQUEST_KEYS,
   K3_PROFILE_FORBIDDEN_OVERLAY_KEYS,


### PR DESCRIPTION
## Summary

- reject K3 GetDetail responses that only echo the requested material key without independently returning a stable material identifier or nonblank `FName`
- evaluate the raw GetDetail envelope when available, avoiding the adapter's request-correlation `FNumber` fallback as existence evidence
- preserve exact matching records and duplicate-match fail-closed behavior
- add regressions for the live echo-only shape and for an empty detail whose key is synthesized by the adapter

## Why

The controlled #4628 preflight observed two successful GetDetail responses with requested-key echoes but zero meaningful stable identifiers and zero nonblank returned names. The frozen package would classify those unknown high-entropy keys as existing and deterministically produce `update=2`, consuming the sole `_04` dry-run contrary to its exact `add=2` gate.

Values-free operation state:

```text
operationId=stockprep_7fb0862f_e2e_test_window_20260811_04
prior03DryRunTokenCreated=NO
prior03ApplyCalls=0
prior03ExternalWrites=0
operation04DryRun=NOT_RUN
operation04Apply=NOT_RUN
operation04ExternalWrites=0
```

## Verification

```text
k3WiseC6WriteProfileTests=34/34_PASS
k3WiseAdapters=PASS
testChainCompleteness=161_SUITES_PASS
k3ApplyRowLimitBehavioralTests=24_PASS
k3ApplyRowLimitSweepContract=WINDOWS_PATH_SEPARATOR_BASELINE_FAILURE
gitDiffCheck=PASS
```

No entity-machine hot patch, K3 write, Apply, Submit, or Audit was performed. After review and merge, a new complete frozen package and a newly bound operation id are required; the current `_04` package identity must not be silently changed.
