### PR TITLE
fix(ops): pin production maintenance host identity

### DIFF
--- a/.github/workflows/attendance-remote-docker-gc-prod.yml
+++ b/.github/workflows/attendance-remote-docker-gc-prod.yml
@@ -37,15 +37,25 @@ jobs:
           DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
           DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
           DEPLOY_SSH_KEY_B64: ${{ secrets.DEPLOY_SSH_KEY_B64 }}
+          DEPLOY_KNOWN_HOSTS: ${{ secrets.DEPLOY_KNOWN_HOSTS }}
           DEPLOY_PATH: ${{ secrets.DEPLOY_PATH }}
           PRUNE: ${{ github.event.inputs.prune || 'false' }}
           SKIP_HOST_SYNC: ${{ github.event.inputs.skip_host_sync || 'false' }}
         run: |
           set -euo pipefail
           mkdir -p ~/.ssh
+          [[ -n "$DEPLOY_KNOWN_HOSTS" ]] || { echo "DEPLOY_KNOWN_HOSTS is required" >&2; exit 2; }
           printf '%s' "$DEPLOY_SSH_KEY_B64" | base64 -d > ~/.ssh/deploy_key
-          chmod 600 ~/.ssh/deploy_key
-          ssh_opts="-o StrictHostKeyChecking=no -o IdentitiesOnly=yes -o ServerAliveInterval=30 -o ServerAliveCountMax=6 -i ~/.ssh/deploy_key"
+          decoded_known_hosts="$(printf '%s' "$DEPLOY_KNOWN_HOSTS" | base64 -d 2>/dev/null || true)"
+          if printf '%s' "$decoded_known_hosts" | grep -Eq 'ssh-ed25519|ssh-rsa|ecdsa-sha2|ssh-dss'; then
+            printf '%s\n' "$decoded_known_hosts" > ~/.ssh/known_hosts
+          else
+            printf '%s\n' "$DEPLOY_KNOWN_HOSTS" > ~/.ssh/known_hosts
+          fi
+          grep -Eq 'ssh-ed25519|ssh-rsa|ecdsa-sha2|ssh-dss' ~/.ssh/known_hosts \
+            || { echo "DEPLOY_KNOWN_HOSTS did not resolve to a recognizable key" >&2; exit 2; }
+          chmod 600 ~/.ssh/deploy_key ~/.ssh/known_hosts
+          ssh_opts="-o StrictHostKeyChecking=yes -o UserKnownHostsFile=$HOME/.ssh/known_hosts -o GlobalKnownHostsFile=/dev/null -o IdentitiesOnly=yes -o ServerAliveInterval=30 -o ServerAliveCountMax=6 -i ~/.ssh/deploy_key"
 
           DEPLOY_PATH="${DEPLOY_PATH:-metasheet2}"
           PRUNE="${PRUNE:-false}"

--- a/.github/workflows/attendance-remote-storage-prod.yml
+++ b/.github/workflows/attendance-remote-storage-prod.yml
@@ -64,6 +64,7 @@ jobs:
           DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
           DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
           DEPLOY_SSH_KEY_B64: ${{ secrets.DEPLOY_SSH_KEY_B64 }}
+          DEPLOY_KNOWN_HOSTS: ${{ secrets.DEPLOY_KNOWN_HOSTS }}
           DEPLOY_PATH: ${{ secrets.DEPLOY_PATH }}
           DEPLOY_COMPOSE_FILE: ${{ secrets.DEPLOY_COMPOSE_FILE }}
           DRILL_FAIL: ${{ github.event.inputs.drill_fail || 'false' }}
@@ -74,9 +75,18 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p ~/.ssh
+          [[ -n "$DEPLOY_KNOWN_HOSTS" ]] || { echo "DEPLOY_KNOWN_HOSTS is required" >&2; exit 2; }
           printf '%s' "$DEPLOY_SSH_KEY_B64" | base64 -d > ~/.ssh/deploy_key
-          chmod 600 ~/.ssh/deploy_key
-          ssh_opts="-o StrictHostKeyChecking=no -o IdentitiesOnly=yes -i ~/.ssh/deploy_key"
+          decoded_known_hosts="$(printf '%s' "$DEPLOY_KNOWN_HOSTS" | base64 -d 2>/dev/null || true)"
+          if printf '%s' "$decoded_known_hosts" | grep -Eq 'ssh-ed25519|ssh-rsa|ecdsa-sha2|ssh-dss'; then
+            printf '%s\n' "$decoded_known_hosts" > ~/.ssh/known_hosts
+          else
+            printf '%s\n' "$DEPLOY_KNOWN_HOSTS" > ~/.ssh/known_hosts
+          fi
+          grep -Eq 'ssh-ed25519|ssh-rsa|ecdsa-sha2|ssh-dss' ~/.ssh/known_hosts \
+            || { echo "DEPLOY_KNOWN_HOSTS did not resolve to a recognizable key" >&2; exit 2; }
+          chmod 600 ~/.ssh/deploy_key ~/.ssh/known_hosts
+          ssh_opts="-o StrictHostKeyChecking=yes -o UserKnownHostsFile=$HOME/.ssh/known_hosts -o GlobalKnownHostsFile=/dev/null -o IdentitiesOnly=yes -i ~/.ssh/deploy_key"
 
           DEPLOY_PATH="${DEPLOY_PATH:-metasheet2}"
           DEPLOY_COMPOSE_FILE="${DEPLOY_COMPOSE_FILE:-docker-compose.app.yml}"

--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -99,6 +99,7 @@ jobs:
       - name: Run DingTalk closeout env-contract test (DT-CLOSE-02)
         run: |
           node --test scripts/ops/dingtalk-closeout-env-contract.test.mjs
+          node --test scripts/ops/attendance-remote-docker-gc-workflow-contract.test.mjs
           node --test scripts/ops/directory-grant-table-ci-wiring.test.mjs
           node --test scripts/ops/directory-activation-source-lock-ci-wiring.test.mjs
           node --test scripts/ops/directory-deprovision-ledger-ci-wiring.test.mjs
@@ -176,6 +177,13 @@ jobs:
       # manifest/source drift fails the required `test` check fast, before the pnpm install/build.
       - name: Global History flag manifest contract (R12-C)
         run: node --test scripts/ops/global-history-flag-manifest.test.mjs scripts/ops/multitable-global-history-flag-status.test.mjs
+
+      # Production maintenance can prune Docker data on the deploy host. Keep its SSH host-identity
+      # contract in the required Node 20 context so host-key pinning cannot regress behind a green PR.
+      - name: Production maintenance SSH host-identity contract (required lane)
+        id: production-maintenance-ssh-host-identity-contract
+        if: matrix.node-version == '20.x'
+        run: node --test scripts/ops/attendance-remote-docker-gc-workflow-contract.test.mjs
 
       # REVIEW NIT-2 (exact-head round): these two suites already ran in `k3wise-offline-poc`, but
       # that job's check is "K3 WISE offline PoC", which is NOT one of main's required contexts --

--- a/plugins/plugin-integration-core/lib/sealed-export/vectors/s6a-package-provenance-pins.json
+++ b/plugins/plugin-integration-core/lib/sealed-export/vectors/s6a-package-provenance-pins.json
@@ -86,6 +86,6 @@
     "s6aAcceptancePs51Test": "835c7c6ce943d82e0378a40a27c7fd1e8b79b526faa8ca4c8066e4231a4bfb0f",
     "s6aProductRuntimeTest": "de978adafa8b89772cefa921c2051f434bf346bf5c2978bef3424ee70f51ba3f",
     "multitableOnpremPackageBuild": "463c7d73c6c7f2d1b6cdf0820d7a06974a9c463dd5e98bbbaf1c996e1dc4ed99",
-    "pluginTestsWorkflow": "be24c3b218cf6d373b6c9840bae9a346c6cf763910232ccb6889fe2652d39a52"
+    "pluginTestsWorkflow": "33e8a2d11f33744c001420ae038bddafdfeed74710b74c05356246cc726d2998"
   }
 }

--- a/scripts/ops/attendance-remote-docker-gc-workflow-contract.test.mjs
+++ b/scripts/ops/attendance-remote-docker-gc-workflow-contract.test.mjs
@@ -6,6 +6,20 @@ import { fileURLToPath } from 'node:url'
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
 const workflowPath = path.join(repoRoot, '.github', 'workflows', 'attendance-remote-docker-gc-prod.yml')
+const storageWorkflowPath = path.join(repoRoot, '.github', 'workflows', 'attendance-remote-storage-prod.yml')
+const pluginTestsWorkflowPath = path.join(repoRoot, '.github', 'workflows', 'plugin-tests.yml')
+
+function assertPinnedHostIdentity(raw) {
+  assert.match(raw, /DEPLOY_KNOWN_HOSTS: \$\{\{ secrets\.DEPLOY_KNOWN_HOSTS \}\}/)
+  assert.match(raw, /DEPLOY_KNOWN_HOSTS is required/)
+  assert.match(raw, /decoded_known_hosts=.*base64 -d/)
+  assert.match(raw, /ssh-ed25519\|ssh-rsa\|ecdsa-sha2\|ssh-dss/)
+  assert.match(raw, /did not resolve to a recognizable key/)
+  assert.match(raw, /StrictHostKeyChecking=yes/)
+  assert.match(raw, /UserKnownHostsFile=\$HOME\/\.ssh\/known_hosts/)
+  assert.match(raw, /GlobalKnownHostsFile=\/dev\/null/)
+  assert.doesNotMatch(raw, /StrictHostKeyChecking=no/)
+}
 
 test('remote Docker GC summary caps snippets without pipefail-sensitive head pipeline', () => {
   const raw = readFileSync(workflowPath, 'utf8')
@@ -15,4 +29,44 @@ test('remote Docker GC summary caps snippets without pipefail-sensitive head pip
   assert.ok(raw.includes('^=== DOCKER GC START ===$'))
   assert.ok(raw.includes('printing && count < 120 { print; count++ }'))
   assert.ok(!raw.includes("' \"$gc_log\" | head -n 120"))
+})
+
+test('production Docker GC and storage health pin the deploy-host identity', () => {
+  for (const target of [workflowPath, storageWorkflowPath]) {
+    assertPinnedHostIdentity(readFileSync(target, 'utf8'))
+  }
+})
+
+test('host identity contract is load-bearing for both production workflows', () => {
+  for (const target of [workflowPath, storageWorkflowPath]) {
+    const raw = readFileSync(target, 'utf8')
+    assert.throws(
+      () => assertPinnedHostIdentity(raw.replace('StrictHostKeyChecking=yes', 'StrictHostKeyChecking=no')),
+      /input was expected not to match|did not match/,
+    )
+    assert.throws(
+      () => assertPinnedHostIdentity(raw.replace('DEPLOY_KNOWN_HOSTS: ${{ secrets.DEPLOY_KNOWN_HOSTS }}', '')),
+      /did not match/,
+    )
+  }
+})
+
+test('host identity contract runs in the required Node 20 test context', () => {
+  const raw = readFileSync(pluginTestsWorkflowPath, 'utf8')
+  const requiredJobStart = raw.indexOf('\n  test:\n')
+  const requiredJobEnd = raw.indexOf('\n  after-sales-integration:\n')
+  assert.ok(requiredJobStart >= 0 && requiredJobEnd > requiredJobStart)
+  const requiredJob = raw.slice(requiredJobStart, requiredJobEnd)
+  const requiredStepStart = requiredJob.indexOf(
+    '      - name: Production maintenance SSH host-identity contract (required lane)',
+  )
+  const requiredStepEnd = requiredJob.indexOf('\n      - name:', requiredStepStart + 1)
+  assert.ok(requiredStepStart >= 0 && requiredStepEnd > requiredStepStart)
+  const requiredStep = requiredJob.slice(requiredStepStart, requiredStepEnd)
+
+  assert.match(
+    requiredStep,
+    /- name: Production maintenance SSH host-identity contract \(required lane\)\n        id: production-maintenance-ssh-host-identity-contract\n        if: matrix\.node-version == '20\.x'\n        run: node --test scripts\/ops\/attendance-remote-docker-gc-workflow-contract\.test\.mjs/,
+  )
+  assert.doesNotMatch(requiredStep, /continue-on-error:/)
 })


### PR DESCRIPTION
## Summary
- require the existing `DEPLOY_KNOWN_HOSTS` secret for production Docker GC and Storage Health
- pin OpenSSH to that per-run known_hosts file with strict checking and no global fallback
- run and pin the host-identity contract in required `test (20.x)`
- refresh the sealed-export provenance digest for the changed required workflow

## Why
Production Storage Health is failing at 96% filesystem usage. Docker GC is authorized, but the maintenance workflow previously disabled SSH host-key verification. This PR closes that prerequisite before any destructive production action.

## Verification
- `node --test scripts/ops/attendance-remote-docker-gc-workflow-contract.test.mjs scripts/ops/remote-summary-pipefail-contract.test.mjs` (5/5)
- `node plugins/plugin-integration-core/__tests__/sealed-export-package-provenance.test.cjs`
- Ruby YAML parse for both production workflows and `plugin-tests.yml`
- `git diff --check`
- independent Grok 4.5 adversarial review: APPROVE; prior required-lane P2 closed

The full local `test:sealed-export-s5` command reached the SQL Server action suite but could not continue because this clean worktree has no `node_modules`/`mssql`; exact-head CI supplies dependencies. The provenance suite itself passes locally, and both S5 SQL Server product-action legs pass on the current head.

## Operational boundary
No production workflow was dispatched and no lifecycle flag was changed by this PR. After exact-head required CI is green and this lands, run Docker GC first, then rerun Storage Health without changing thresholds.