### PR TITLE
feat(dingtalk): add production readiness inventory

### DIFF
--- a/.github/workflows/dingtalk-oauth-stability-recording-lite.yml
+++ b/.github/workflows/dingtalk-oauth-stability-recording-lite.yml
@@ -4,6 +4,9 @@ name: DingTalk OAuth Stability Recording (Lite)
 # Alertmanager + webhook alert-DELIVERY topology is NOT deployable from current main and is
 # DEFERRED (the check soft-reports it, the verdict does not depend on it). This workflow does
 # NOT claim alert-delivery observability is restored — only OAuth-stability metrics observability.
+#
+# Host identity is pinned via DEPLOY_KNOWN_HOSTS (raw or base64 known_hosts). SSH in the
+# called scripts enforces StrictHostKeyChecking=yes + UserKnownHostsFile + GlobalKnownHostsFile=/dev/null.
 
 on:
   schedule:
@@ -27,11 +30,21 @@ jobs:
       - name: Prepare SSH key
         env:
           DEPLOY_SSH_KEY_B64: ${{ secrets.DEPLOY_SSH_KEY_B64 }}
+          DEPLOY_KNOWN_HOSTS: ${{ secrets.DEPLOY_KNOWN_HOSTS }}
         run: |
           set -euo pipefail
           mkdir -p ~/.ssh
+          [[ -n "${DEPLOY_KNOWN_HOSTS:-}" ]] || { echo "DEPLOY_KNOWN_HOSTS is required" >&2; exit 2; }
           printf '%s' "$DEPLOY_SSH_KEY_B64" | base64 -d > ~/.ssh/deploy_key
-          chmod 600 ~/.ssh/deploy_key
+          decoded_known_hosts="$(printf '%s' "$DEPLOY_KNOWN_HOSTS" | base64 -d 2>/dev/null || true)"
+          if printf '%s' "$decoded_known_hosts" | grep -Eq 'ssh-ed25519|ssh-rsa|ecdsa-sha2|ssh-dss'; then
+            printf '%s\n' "$decoded_known_hosts" > ~/.ssh/known_hosts
+          else
+            printf '%s\n' "$DEPLOY_KNOWN_HOSTS" > ~/.ssh/known_hosts
+          fi
+          grep -Eq 'ssh-ed25519|ssh-rsa|ecdsa-sha2|ssh-dss' ~/.ssh/known_hosts \
+            || { echo "DEPLOY_KNOWN_HOSTS did not resolve to a recognizable key" >&2; exit 2; }
+          chmod 600 ~/.ssh/deploy_key ~/.ssh/known_hosts
 
       - name: Reapply Alertmanager webhook config
         id: webhook_self_heal
@@ -50,6 +63,7 @@ jobs:
 
           SSH_USER_HOST="${DEPLOY_USER}@${DEPLOY_HOST}" \
           SSH_KEY="${HOME}/.ssh/deploy_key" \
+          SSH_KNOWN_HOSTS_FILE="${HOME}/.ssh/known_hosts" \
           bash scripts/ops/set-dingtalk-onprem-alertmanager-webhook-config.sh set
 
       - name: Run remote stability check
@@ -68,6 +82,7 @@ jobs:
           JSON_OUTPUT=true \
           SSH_USER_HOST="${DEPLOY_USER}@${DEPLOY_HOST}" \
           SSH_KEY="${HOME}/.ssh/deploy_key" \
+          SSH_KNOWN_HOSTS_FILE="${HOME}/.ssh/known_hosts" \
           bash scripts/ops/dingtalk-oauth-stability-check.sh >"${JSON_PATH}" 2>"${LOG_PATH}"
           rc=$?
           set -e

--- a/.github/workflows/dingtalk-production-readiness-inventory.yml
+++ b/.github/workflows/dingtalk-production-readiness-inventory.yml
@@ -1,0 +1,181 @@
+name: DingTalk Production Readiness Inventory
+
+# Manual-only, READ-ONLY production inventory for DingTalk readiness.
+# Values-free artifacts only (booleans / counts / enum reasons / deployed SHA).
+# Never writes env/DB, never flips lifecycle flags, never sends DingTalk traffic,
+# never auto-selects a user or integration.
+#
+# Host identity is pinned via DEPLOY_KNOWN_HOSTS (raw or base64 known_hosts).
+# SSH uses StrictHostKeyChecking=yes + UserKnownHostsFile + GlobalKnownHostsFile=/dev/null.
+
+on:
+  workflow_dispatch: {}
+
+concurrency:
+  group: dingtalk-production-readiness-inventory
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  inventory:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate embedded inventory script
+        run: |
+          set -euo pipefail
+          bash -n scripts/ops/dingtalk-production-readiness-inventory-remote.sh
+          node --test scripts/ops/dingtalk-production-readiness-inventory-contract.test.mjs
+          echo "inventory script + contract OK"
+
+      - name: Prepare SSH host identity
+        env:
+          DEPLOY_SSH_KEY_B64: ${{ secrets.DEPLOY_SSH_KEY_B64 }}
+          DEPLOY_KNOWN_HOSTS: ${{ secrets.DEPLOY_KNOWN_HOSTS }}
+        run: |
+          set -euo pipefail
+          mkdir -p ~/.ssh
+          [[ -n "${DEPLOY_KNOWN_HOSTS:-}" ]] || { echo "DEPLOY_KNOWN_HOSTS is required" >&2; exit 2; }
+          printf '%s' "$DEPLOY_SSH_KEY_B64" | base64 -d > ~/.ssh/deploy_key
+          decoded_known_hosts="$(printf '%s' "$DEPLOY_KNOWN_HOSTS" | base64 -d 2>/dev/null || true)"
+          if printf '%s' "$decoded_known_hosts" | grep -Eq 'ssh-ed25519|ssh-rsa|ecdsa-sha2|ssh-dss'; then
+            printf '%s\n' "$decoded_known_hosts" > ~/.ssh/known_hosts
+          else
+            printf '%s\n' "$DEPLOY_KNOWN_HOSTS" > ~/.ssh/known_hosts
+          fi
+          grep -Eq 'ssh-ed25519|ssh-rsa|ecdsa-sha2|ssh-dss' ~/.ssh/known_hosts \
+            || { echo "DEPLOY_KNOWN_HOSTS did not resolve to a recognizable key" >&2; exit 2; }
+          chmod 600 ~/.ssh/deploy_key ~/.ssh/known_hosts
+
+      - name: Sync inventory script to deploy host
+        id: sync
+        env:
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+        run: |
+          set -euo pipefail
+          ssh_opts="-o BatchMode=yes -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes -o UserKnownHostsFile=$HOME/.ssh/known_hosts -o GlobalKnownHostsFile=/dev/null -i $HOME/.ssh/deploy_key"
+          runner_dir="/tmp/dingtalk-prod-inventory-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          echo "runner_dir=$runner_dir" >> "$GITHUB_OUTPUT"
+          tar -czf - \
+            scripts/ops/dingtalk-production-readiness-inventory-remote.sh \
+          | ssh $ssh_opts \
+              "$DEPLOY_USER@$DEPLOY_HOST" \
+              "bash -o pipefail -c 'set -euo pipefail; rm -rf ${runner_dir}; mkdir -p ${runner_dir}; tar -xzf - -C ${runner_dir} --strip-components=2'"
+
+      - name: Run remote read-only inventory
+        id: remote
+        continue-on-error: true
+        env:
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+          DEPLOY_PATH: ${{ secrets.DEPLOY_PATH }}
+          DEPLOY_COMPOSE_FILE: ${{ secrets.DEPLOY_COMPOSE_FILE }}
+          RUNNER_DIR: ${{ steps.sync.outputs.runner_dir }}
+        run: |
+          set -euo pipefail
+          ssh_opts="-o BatchMode=yes -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes -o UserKnownHostsFile=$HOME/.ssh/known_hosts -o GlobalKnownHostsFile=/dev/null -i $HOME/.ssh/deploy_key"
+          DEPLOY_PATH="${DEPLOY_PATH:-metasheet2}"
+          DEPLOY_COMPOSE_FILE="${DEPLOY_COMPOSE_FILE:-docker-compose.app.yml}"
+          for pair in "DEPLOY_PATH=$DEPLOY_PATH" "DEPLOY_COMPOSE_FILE=$DEPLOY_COMPOSE_FILE"; do
+            value="${pair#*=}"
+            if [[ ! "$value" =~ ^[A-Za-z0-9._/~-]+$ ]]; then
+              echo "refusing unsafe characters in ${pair%%=*}: '$value'" >&2
+              exit 2
+            fi
+          done
+          remote_output_dir="/tmp/dingtalk-prod-inventory-out-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          artifact_name="dingtalk-production-readiness-inventory-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          echo "artifact_name=$artifact_name" >> "$GITHUB_OUTPUT"
+          mkdir -p output/dingtalk-production-readiness-inventory
+
+          remote_script="set -euo pipefail
+          export DEPLOY_PATH='${DEPLOY_PATH}'
+          export DEPLOY_COMPOSE_FILE='${DEPLOY_COMPOSE_FILE}'
+          export OUTPUT_DIR='${remote_output_dir}'
+          export RUN_STAMP='gh${GITHUB_RUN_ID}a${GITHUB_RUN_ATTEMPT}'
+          rm -rf '${remote_output_dir}'
+          mkdir -p '${remote_output_dir}'
+          bash '${RUNNER_DIR}/dingtalk-production-readiness-inventory-remote.sh'"
+          escaped_script="$(printf '%s' "$remote_script" | sed "s/'/'\\\\''/g")"
+
+          set +e
+          ssh_log="$RUNNER_TEMP/dingtalk-production-readiness-inventory-ssh.log"
+          ssh $ssh_opts "$DEPLOY_USER@$DEPLOY_HOST" "bash -o pipefail -c '${escaped_script}'" 2>&1 \
+            | tee "$ssh_log"
+          rc=${PIPESTATUS[0]}
+          scp $ssh_opts -r "$DEPLOY_USER@$DEPLOY_HOST:${remote_output_dir}/." output/dingtalk-production-readiness-inventory/ 2>&1 \
+            | tee -a "$ssh_log"
+          scp_rc=${PIPESTATUS[0]}
+          # Cleanup removes ONLY per-run dirs. NEVER touch persistent env/overrides.
+          ssh $ssh_opts "$DEPLOY_USER@$DEPLOY_HOST" \
+            "bash -o pipefail -c 'rm -rf ${remote_output_dir} ${RUNNER_DIR}'" \
+            >> "$ssh_log" 2>&1
+          set -e
+
+          if [[ "$rc" == "0" && "$scp_rc" != "0" ]]; then
+            rc="$scp_rc"
+          fi
+          echo "remote_rc=$rc" >> "$GITHUB_OUTPUT"
+          exit 0
+
+      - name: Build step summary
+        if: always()
+        env:
+          REMOTE_RC: ${{ steps.remote.outputs.remote_rc }}
+        run: |
+          set -euo pipefail
+          INV_JSON="output/dingtalk-production-readiness-inventory/inventory.json"
+          INV_TXT="output/dingtalk-production-readiness-inventory/inventory.txt"
+          {
+            echo "# DingTalk Production Readiness Inventory"
+            echo
+            echo "- remote_rc: \`${REMOTE_RC:-missing}\`"
+            echo "- mode: **read-only** (manual workflow_dispatch only)"
+            echo "- lifecycle flags: must report exact OFF (never flipped by this lane)"
+            echo
+            if [[ -f "$INV_TXT" ]]; then
+              echo "## Inventory (values-free)"
+              echo
+              echo '```'
+              cat "$INV_TXT"
+              echo '```'
+            elif [[ -f "$INV_JSON" ]]; then
+              echo "## Inventory JSON"
+              echo
+              echo '```json'
+              cat "$INV_JSON"
+              echo '```'
+            else
+              echo "No inventory artifact collected."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload values-free inventory artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: dingtalk-production-readiness-inventory-${{ github.run_id }}-${{ github.run_attempt }}
+          path: output/dingtalk-production-readiness-inventory/
+          if-no-files-found: warn
+          retention-days: 14
+
+      - name: Fail if remote inventory failed
+        if: always()
+        env:
+          REMOTE_RC: ${{ steps.remote.outputs.remote_rc }}
+        run: |
+          set -euo pipefail
+          if [[ "${REMOTE_RC:-1}" != "0" ]]; then
+            echo "remote inventory failed: rc=${REMOTE_RC:-missing}" >&2
+            exit 1
+          fi
+          if [[ ! -f output/dingtalk-production-readiness-inventory/inventory.json ]]; then
+            echo "inventory.json missing from artifacts" >&2
+            exit 1
+          fi

--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -185,6 +185,16 @@ jobs:
         if: matrix.node-version == '20.x'
         run: node --test scripts/ops/attendance-remote-docker-gc-workflow-contract.test.mjs
 
+      # DingTalk production-readiness inventory (manual-only, values-free, read-only) + OAuth
+      # stability SSH host-identity hardening. Wired into required test (20.x) so host-key
+      # pinning and values-free/read-only rails cannot regress behind a green PR.
+      - name: DingTalk production-readiness inventory contract (required lane)
+        id: dingtalk-production-readiness-inventory-contract
+        if: matrix.node-version == '20.x'
+        run: |
+          node --test scripts/ops/dingtalk-production-readiness-inventory-contract.test.mjs
+          node --test scripts/ops/dingtalk-oauth-stability-workflow-contract.test.mjs
+
       # REVIEW NIT-2 (exact-head round): these two suites already ran in `k3wise-offline-poc`, but
       # that job's check is "K3 WISE offline PoC", which is NOT one of main's required contexts --
       # so a red there did not block a merge. The suites carry the ONLY mechanical guard on the

--- a/plugins/plugin-integration-core/lib/sealed-export/vectors/s6a-package-provenance-pins.json
+++ b/plugins/plugin-integration-core/lib/sealed-export/vectors/s6a-package-provenance-pins.json
@@ -86,6 +86,6 @@
     "s6aAcceptancePs51Test": "835c7c6ce943d82e0378a40a27c7fd1e8b79b526faa8ca4c8066e4231a4bfb0f",
     "s6aProductRuntimeTest": "de978adafa8b89772cefa921c2051f434bf346bf5c2978bef3424ee70f51ba3f",
     "multitableOnpremPackageBuild": "463c7d73c6c7f2d1b6cdf0820d7a06974a9c463dd5e98bbbaf1c996e1dc4ed99",
-    "pluginTestsWorkflow": "33e8a2d11f33744c001420ae038bddafdfeed74710b74c05356246cc726d2998"
+    "pluginTestsWorkflow": "b5957a36eae740c0b3601730f02f0ca2ba1573577a2b77adc58c7f8c3b289aa0"
   }
 }

--- a/scripts/ops/dingtalk-oauth-stability-check.sh
+++ b/scripts/ops/dingtalk-oauth-stability-check.sh
@@ -32,8 +32,18 @@ cleanup_payload_dir() {
 }
 trap cleanup_payload_dir EXIT
 
+# Host identity is pinned by the caller (workflow prepares ~/.ssh/known_hosts from
+# DEPLOY_KNOWN_HOSTS). Refuse TOFU / global known_hosts so only the pinned file is trusted.
+SSH_KNOWN_HOSTS_FILE="${SSH_KNOWN_HOSTS_FILE:-${HOME}/.ssh/known_hosts}"
+
 ssh_cmd() {
-  ssh -i "${SSH_KEY}" -o BatchMode=yes -o StrictHostKeyChecking=no "${SSH_USER_HOST}" "$@"
+  ssh -i "${SSH_KEY}" \
+    -o BatchMode=yes \
+    -o IdentitiesOnly=yes \
+    -o StrictHostKeyChecking=yes \
+    -o "UserKnownHostsFile=${SSH_KNOWN_HOSTS_FILE}" \
+    -o GlobalKnownHostsFile=/dev/null \
+    "${SSH_USER_HOST}" "$@"
 }
 
 # Scrape a token-gated endpoint on the deploy host. The token is read from the backend container's

--- a/scripts/ops/dingtalk-oauth-stability-workflow-contract.test.mjs
+++ b/scripts/ops/dingtalk-oauth-stability-workflow-contract.test.mjs
@@ -6,12 +6,37 @@ import { fileURLToPath } from 'node:url'
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
 const workflowPath = path.join(repoRoot, '.github', 'workflows', 'dingtalk-oauth-stability-recording-lite.yml')
+const checkScriptPath = path.join(repoRoot, 'scripts', 'ops', 'dingtalk-oauth-stability-check.sh')
+const webhookScriptPath = path.join(repoRoot, 'scripts', 'ops', 'set-dingtalk-onprem-alertmanager-webhook-config.sh')
 
 function assertContains(haystack, needle, label) {
   assert.ok(
     String(haystack).includes(needle),
     `${label} must include ${needle}`,
   )
+}
+
+function assertPinnedHostIdentity(raw, label = 'workflow') {
+  // Workflow prepares a pinned known_hosts from DEPLOY_KNOWN_HOSTS and hands
+  // SSH_KNOWN_HOSTS_FILE to the scripts; StrictHostKeyChecking=yes lives in the
+  // called scripts (assertHardenedSshScript), not as an inline ssh_opts string.
+  assert.match(raw, /DEPLOY_KNOWN_HOSTS: \$\{\{ secrets\.DEPLOY_KNOWN_HOSTS \}\}/, `${label} must wire DEPLOY_KNOWN_HOSTS`)
+  assert.match(raw, /DEPLOY_KNOWN_HOSTS is required/, `${label} must require DEPLOY_KNOWN_HOSTS`)
+  assert.match(raw, /decoded_known_hosts=.*base64 -d/, `${label} must accept base64 known_hosts`)
+  assert.match(raw, /ssh-ed25519\|ssh-rsa\|ecdsa-sha2\|ssh-dss/, `${label} must validate recognizable key types`)
+  assert.match(raw, /did not resolve to a recognizable key/, `${label} must fail closed on unrecognizable keys`)
+  assert.match(raw, /SSH_KNOWN_HOSTS_FILE=/, `${label} must pass SSH_KNOWN_HOSTS_FILE into scripts`)
+  assert.match(raw, /known_hosts/, `${label} must materialize known_hosts`)
+  assert.doesNotMatch(raw, /StrictHostKeyChecking=no/, `${label} must not use StrictHostKeyChecking=no`)
+}
+
+function assertHardenedSshScript(raw, label) {
+  assert.match(raw, /StrictHostKeyChecking=yes/, `${label} must set StrictHostKeyChecking=yes`)
+  assert.match(raw, /UserKnownHostsFile=/, `${label} must set UserKnownHostsFile`)
+  assert.match(raw, /GlobalKnownHostsFile=\/dev\/null/, `${label} must set GlobalKnownHostsFile=/dev/null`)
+  assert.match(raw, /BatchMode=yes/, `${label} must set BatchMode=yes`)
+  assert.match(raw, /IdentitiesOnly=yes/, `${label} must set IdentitiesOnly=yes`)
+  assert.doesNotMatch(raw, /StrictHostKeyChecking=no/, `${label} must not use StrictHostKeyChecking=no`)
 }
 
 test('DingTalk OAuth stability workflow reapplies Alertmanager webhook before checking health', () => {
@@ -43,4 +68,37 @@ test('DingTalk OAuth stability workflow reapplies Alertmanager webhook before ch
   assertContains(raw, '- name: Fail if stability check is unhealthy', 'final hard gate')
   assertContains(raw, "WEBHOOK_SECRET_AVAILABLE: ${{ steps.webhook_self_heal.outputs.webhook_secret_available || 'false' }}", 'summary env')
   assertContains(raw, 'stability check completed but reported healthy=false', 'final hard gate')
+})
+
+test('DingTalk OAuth stability workflow pins deploy-host identity (DEPLOY_KNOWN_HOSTS)', () => {
+  assertPinnedHostIdentity(readFileSync(workflowPath, 'utf8'))
+})
+
+test('OAuth stability production SSH scripts refuse StrictHostKeyChecking=no', () => {
+  assertHardenedSshScript(readFileSync(checkScriptPath, 'utf8'), 'dingtalk-oauth-stability-check.sh')
+  assertHardenedSshScript(
+    readFileSync(webhookScriptPath, 'utf8'),
+    'set-dingtalk-onprem-alertmanager-webhook-config.sh',
+  )
+})
+
+test('host-identity contract is load-bearing (mutation would fail)', () => {
+  const raw = readFileSync(workflowPath, 'utf8')
+  assert.throws(
+    () => assertPinnedHostIdentity(raw.replace(/SSH_KNOWN_HOSTS_FILE=/g, 'SSH_HOSTS_FILE=')),
+    /must pass SSH_KNOWN_HOSTS_FILE|did not match/,
+  )
+  assert.throws(
+    () => assertPinnedHostIdentity(raw.replace('DEPLOY_KNOWN_HOSTS: ${{ secrets.DEPLOY_KNOWN_HOSTS }}', '')),
+    /must wire DEPLOY_KNOWN_HOSTS|did not match/,
+  )
+  assert.throws(
+    () => assertPinnedHostIdentity(`${raw}\n-o StrictHostKeyChecking=no\n`),
+    /must not use StrictHostKeyChecking=no|input was expected not to match|did not match/,
+  )
+  const check = readFileSync(checkScriptPath, 'utf8')
+  assert.throws(
+    () => assertHardenedSshScript(check.replace(/StrictHostKeyChecking=yes/g, 'StrictHostKeyChecking=no'), 'mutated'),
+    /must set StrictHostKeyChecking=yes|must not use StrictHostKeyChecking=no|input was expected not to match|did not match/,
+  )
 })

--- a/scripts/ops/dingtalk-production-readiness-inventory-contract.test.mjs
+++ b/scripts/ops/dingtalk-production-readiness-inventory-contract.test.mjs
@@ -1,0 +1,401 @@
+#!/usr/bin/env node
+// dingtalk-production-readiness-inventory-contract.test.mjs
+//
+// Contract for the manual-only, values-free, READ-ONLY DingTalk production
+// readiness inventory lane. No network, no secrets, no workflow dispatch.
+
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import { existsSync, readFileSync } from 'node:fs'
+import path from 'node:path'
+import test from 'node:test'
+import { fileURLToPath } from 'node:url'
+import { createRequire } from 'node:module'
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
+const workflowPath = path.join(repoRoot, '.github', 'workflows', 'dingtalk-production-readiness-inventory.yml')
+const remoteScriptPath = path.join(repoRoot, 'scripts', 'ops', 'dingtalk-production-readiness-inventory-remote.sh')
+const oauthWorkflowPath = path.join(repoRoot, '.github', 'workflows', 'dingtalk-oauth-stability-recording-lite.yml')
+const oauthCheckPath = path.join(repoRoot, 'scripts', 'ops', 'dingtalk-oauth-stability-check.sh')
+const oauthWebhookPath = path.join(repoRoot, 'scripts', 'ops', 'set-dingtalk-onprem-alertmanager-webhook-config.sh')
+const pluginTestsPath = path.join(repoRoot, '.github', 'workflows', 'plugin-tests.yml')
+
+function read(p) {
+  return readFileSync(p, 'utf8')
+}
+
+function loadYaml(text) {
+  const require = createRequire(import.meta.url)
+  const candidates = [
+    () => require('js-yaml'),
+    () => require(path.join(repoRoot, 'node_modules/js-yaml')),
+    () => require(path.join(repoRoot, 'packages/openapi/node_modules/js-yaml')),
+  ]
+  for (const load of candidates) {
+    try {
+      return load().load(text)
+    } catch {
+      // try next
+    }
+  }
+  const py = spawnSync(
+    'python3',
+    ['-c', 'import sys,yaml,json; print(json.dumps(yaml.safe_load(sys.stdin.read())))'],
+    { input: text, encoding: 'utf8' },
+  )
+  if (py.status !== 0) {
+    throw new Error(`YAML parse failed: ${py.stderr || py.stdout}`)
+  }
+  return JSON.parse(py.stdout)
+}
+
+function workflowOn(doc) {
+  return doc.on ?? doc.true ?? doc[true]
+}
+
+function runSourcedInventoryShell(body, env = {}) {
+  return spawnSync('bash', ['-c', `source "$INVENTORY_SCRIPT"\n${body}`], {
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      DINGTALK_PRODUCTION_READINESS_SOURCE_ONLY: 'true',
+      INVENTORY_SCRIPT: remoteScriptPath,
+      ...env,
+    },
+  })
+}
+
+function assertPinnedHostIdentity(raw, label = 'surface') {
+  assert.match(raw, /DEPLOY_KNOWN_HOSTS/, `${label}: DEPLOY_KNOWN_HOSTS required`)
+  assert.match(raw, /DEPLOY_KNOWN_HOSTS is required/, `${label}: fail closed when missing`)
+  assert.match(raw, /decoded_known_hosts=.*base64 -d/, `${label}: accept base64`)
+  assert.match(raw, /ssh-ed25519\|ssh-rsa\|ecdsa-sha2\|ssh-dss/, `${label}: key type check`)
+  assert.match(raw, /did not resolve to a recognizable key/, `${label}: unrecognizable key fails`)
+  assert.match(raw, /StrictHostKeyChecking=yes/, `${label}: StrictHostKeyChecking=yes`)
+  assert.match(raw, /UserKnownHostsFile/, `${label}: UserKnownHostsFile`)
+  assert.match(raw, /GlobalKnownHostsFile=\/dev\/null/, `${label}: GlobalKnownHostsFile=/dev/null`)
+  assert.match(raw, /BatchMode=yes/, `${label}: BatchMode`)
+  assert.match(raw, /IdentitiesOnly=yes/, `${label}: IdentitiesOnly`)
+  assert.doesNotMatch(raw, /StrictHostKeyChecking=no/, `${label}: no StrictHostKeyChecking=no`)
+}
+
+// --- presence / parse -----------------------------------------------------------------
+
+test('inventory workflow + remote script exist', () => {
+  assert.ok(existsSync(workflowPath))
+  assert.ok(existsSync(remoteScriptPath))
+})
+
+test('remote inventory script parses (bash -n)', () => {
+  const result = spawnSync('bash', ['-n', remoteScriptPath], { encoding: 'utf8' })
+  assert.equal(result.status, 0, result.stderr)
+})
+
+test('inventory workflow YAML parses', () => {
+  const doc = loadYaml(read(workflowPath))
+  assert.equal(doc.name, 'DingTalk Production Readiness Inventory')
+  assert.ok(workflowOn(doc)?.workflow_dispatch !== undefined)
+  assert.ok(doc.jobs?.inventory)
+})
+
+// --- manual-only / read-only ----------------------------------------------------------
+
+test('inventory workflow is manual-only (no schedule/push/pull_request)', () => {
+  const raw = read(workflowPath)
+  const doc = loadYaml(raw)
+  const on = workflowOn(doc)
+  assert.ok(on.workflow_dispatch !== undefined && on.workflow_dispatch !== null)
+  assert.equal(on.schedule, undefined)
+  assert.equal(on.push, undefined)
+  assert.equal(on.pull_request, undefined)
+  assert.doesNotMatch(raw, /schedule:/)
+  assert.doesNotMatch(raw, /cron:/)
+  assert.doesNotMatch(raw, /\bpush:/)
+  assert.doesNotMatch(raw, /\bpull_request:/)
+})
+
+test('inventory lane is read-only: never writes env/DB or flips lifecycle flags', () => {
+  const script = read(remoteScriptPath)
+  const workflow = read(workflowPath)
+
+  assert.match(script, /READ-ONLY|read-only|read_only=true/i)
+  assert.match(workflow, /READ-ONLY|read-only/i)
+
+  // No mutating SQL verbs in the remote inventory path.
+  assert.doesNotMatch(script, /\bINSERT\b/i)
+  assert.doesNotMatch(script, /\bUPDATE\b/i)
+  assert.doesNotMatch(script, /\bDELETE\b/i)
+  assert.doesNotMatch(script, /\bDROP\b/i)
+  assert.doesNotMatch(script, /\bTRUNCATE\b/i)
+  assert.doesNotMatch(script, /\bALTER\b/i)
+
+  // Never write env files or lifecycle overrides.
+  assert.doesNotMatch(script, />>\s*['"]?\$\{?.*\.env/)
+  assert.doesNotMatch(script, /docker-compose\..*override\.yml/)
+  assert.doesNotMatch(script, /AUTH_LOGIN_USE_ALIASES=true/)
+  assert.doesNotMatch(script, /DIRECTORY_PENDING_ACTIVATION_ENABLED=true/)
+  assert.doesNotMatch(script, /DIRECTORY_DEPROVISION_ENABLED=true/)
+  assert.doesNotMatch(script, /DINGTALK_INTERACTIVE_CARD_STREAM_ENABLED=true/)
+
+  // Must report the four flags as exact OFF state (read, not write).
+  for (const flag of [
+    'AUTH_LOGIN_USE_ALIASES',
+    'DIRECTORY_PENDING_ACTIVATION_ENABLED',
+    'DIRECTORY_DEPROVISION_ENABLED',
+    'DINGTALK_INTERACTIVE_CARD_STREAM_ENABLED',
+  ]) {
+    assert.match(script, new RegExp(flag))
+  }
+  assert.match(script, /lifecycle_flags_all_off/)
+})
+
+test('inventory never emits or chooses a canary subject/integration', () => {
+  const script = read(remoteScriptPath)
+  assert.doesNotMatch(script, /canary_subject/i)
+  assert.doesNotMatch(script, /canary_integration/i)
+  // Selecting the same config row as runtime is required for truthful readiness;
+  // the selected row's identifier is never projected or emitted.
+  assert.match(script, /WITH selected AS/)
+  assert.doesNotMatch(script, /SELECT id, status, config[\s\S]{0,120}WITH selected AS/i)
+  // Counts only — no SELECT of identifying columns into the artifact path.
+  assert.match(script, /count\(\*\)/i)
+  assert.match(script, /Counts \+ presence only/)
+})
+
+// --- host key enforcement -------------------------------------------------------------
+
+test('inventory workflow pins deploy-host identity like production maintenance lanes', () => {
+  assertPinnedHostIdentity(read(workflowPath), 'inventory workflow')
+})
+
+test('OAuth stability production path also pins host identity (cross-lane consistency)', () => {
+  // OAuth workflow prepares known_hosts + SSH_KNOWN_HOSTS_FILE; SSH options live in scripts.
+  const oauthWorkflow = read(oauthWorkflowPath)
+  assert.match(oauthWorkflow, /DEPLOY_KNOWN_HOSTS: \$\{\{ secrets\.DEPLOY_KNOWN_HOSTS \}\}/)
+  assert.match(oauthWorkflow, /DEPLOY_KNOWN_HOSTS is required/)
+  assert.match(oauthWorkflow, /decoded_known_hosts=.*base64 -d/)
+  assert.match(oauthWorkflow, /ssh-ed25519\|ssh-rsa\|ecdsa-sha2\|ssh-dss/)
+  assert.match(oauthWorkflow, /SSH_KNOWN_HOSTS_FILE=/)
+  assert.doesNotMatch(oauthWorkflow, /StrictHostKeyChecking=no/)
+  for (const [label, p] of [
+    ['oauth check', oauthCheckPath],
+    ['oauth webhook config', oauthWebhookPath],
+  ]) {
+    const raw = read(p)
+    assert.match(raw, /StrictHostKeyChecking=yes/, `${label}`)
+    assert.match(raw, /UserKnownHostsFile=/, `${label}`)
+    assert.match(raw, /GlobalKnownHostsFile=\/dev\/null/, `${label}`)
+    assert.match(raw, /BatchMode=yes/, `${label}`)
+    assert.match(raw, /IdentitiesOnly=yes/, `${label}`)
+    assert.doesNotMatch(raw, /StrictHostKeyChecking=no/, `${label}`)
+  }
+})
+
+// --- values-free / required inventory fields ------------------------------------------
+
+const REQUIRED_INVENTORY_KEYS = [
+  'schema=dingtalk-production-readiness-inventory-v1',
+  'deployed_sha=',
+  'deployed_sha_verified=',
+  'app_key_present=',
+  'app_secret_present=',
+  'agent_id_present=',
+  'app_credentials_ready=',
+  'allowed_corp_allowlist_ready=',
+  'allowed_corp_allowlist_reason=',
+  'active_dingtalk_integration_count=',
+  'active_corp_anchored_integration_count=',
+  'active_directory_account_count=',
+  'active_linked_local_user_count=',
+  'password_capable_alias_admin_count=',
+  'pending_user_count=',
+  'at_least_two_linked_users_ready=',
+  'directory_uat_baseline_ready=',
+  'log_level_ready=',
+  'log_level_reason=',
+  'stream_client_id_present=',
+  'stream_client_secret_present=',
+  'stream_template_id_present=',
+  'stream_integration_id_present=',
+  'stream_credentials_ready=',
+  'auth_login_use_aliases=',
+  'directory_pending_activation_enabled=',
+  'directory_deprovision_enabled=',
+  'dingtalk_interactive_card_stream_enabled=',
+  'lifecycle_flags_all_off=',
+  'read_only=true',
+]
+
+test('inventory artifact keys cover required readiness signals', () => {
+  const script = read(remoteScriptPath)
+  for (const key of REQUIRED_INVENTORY_KEYS) {
+    assert.match(script, new RegExp(key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')), `missing inventory key ${key}`)
+  }
+})
+
+test('inventory forbids secret/PII/id field emission in artifact contract', () => {
+  const script = read(remoteScriptPath)
+  // Artifact writing block must not echo secret-bearing env values or PII columns.
+  const forbiddenArtifactPatterns = [
+    /echo\s+[\"']?(app_key|app_secret|client_secret|corp_id|email|mobile|password)=/i,
+    /echo\s+[\"']?DINGTALK_APP_(KEY|SECRET)=/,
+    /echo\s+[\"']?DINGTALK_ALLOWED_CORP_IDS=/,
+    /printenv\s+DINGTALK_APP_KEY\s*>>/,
+  ]
+  // Presence checks of config keys are OK; selecting/printing secret values is not.
+  // stored credentials readiness uses nullif(trim(config->>'appSecret'), '') IS NOT NULL — presence only.
+  assert.match(script, /nullif\(trim\(config->>'appSecret'\), ''\) IS NOT NULL/)
+  // Executable SQL must not project secret/PII columns (comments are ignored by stripping # lines).
+  const executable = script
+    .split('\n')
+    .filter((line) => !/^\s*#/.test(line) && !/^\s*\/\//.test(line))
+    .join('\n')
+  assert.doesNotMatch(executable, /SELECT\s+config->>'appSecret'/i)
+  assert.doesNotMatch(executable, /SELECT\s+[^`]*\bu\.email\b/i)
+  assert.doesNotMatch(executable, /SELECT\s+[^`]*\bu\.mobile\b/i)
+  assert.doesNotMatch(executable, /SELECT\s+password_hash\b/i)
+  assert.doesNotMatch(executable, /SELECT\s+corp_id\b/i)
+  assert.doesNotMatch(executable, /SELECT\s+[^`]*\bas\s+email\b/i)
+  for (const re of forbiddenArtifactPatterns) {
+    assert.doesNotMatch(script, re)
+  }
+})
+
+test('inventory uses docker compose exec and fail-closed unknown on query errors', () => {
+  const script = read(remoteScriptPath)
+  assert.match(script, /docker compose/)
+  assert.match(script, /exec -T/)
+  assert.match(script, /BEGIN READ ONLY/)
+  assert.match(script, /ROLLBACK/)
+  assert.match(script, /to_regclass/)
+  assert.match(script, /unknown/)
+  assert.match(script, /docker-compose\.app\.yml/)
+})
+
+test('inventory counts only active integration-backed users and rejects mixed placeholder allowlists', () => {
+  const script = read(remoteScriptPath)
+  assert.match(script, /JOIN directory_integrations i ON i\.id = a\.integration_id/)
+  assert.match(script, /JOIN users u ON u\.id = l\.local_user_id/)
+  assert.match(script, /i\.status = 'active'/)
+  assert.match(script, /u\.is_active = TRUE/)
+  assert.match(script, /count\(DISTINCT u\.id\)::int AS n/)
+  assert.match(script, /GROUP BY i\.id/)
+  assert.match(script, /HAVING count\(DISTINCT l\.local_user_id\) >= 2/)
+  assert.match(script, /i\.corp_id = ANY\(\$1::text\[\]\)/)
+  assert.match(script, /hasPlaceholderCorpId/)
+  assert.match(script, /effective_app_credentials_ready/)
+  assert.match(script, /directory_uat_baseline_ready/)
+  assert.match(script, /WITH selected AS \([\s\S]*SELECT id, status, corp_id, config[\s\S]*GROUP BY i\.id/)
+  assert.match(script, /INVENTORY_ENV_APP_KEY_PRESENT/)
+  assert.match(script, /INVENTORY_ENV_APP_SECRET_PRESENT/)
+  assert.match(script, /INVENTORY_ENV_AGENT_ID_PRESENT/)
+  assert.match(script, /has_placeholder=true/)
+  assert.doesNotMatch(script, /COALESCE\(u\.role, ''\) = 'admin'/)
+})
+
+test('credential readiness is coherent within one active DingTalk integration', () => {
+  const script = read(remoteScriptPath)
+  const effectiveStart = script.indexOf('result.effective_app_credentials_ready')
+  const effectiveEnd = script.indexOf('    }\n    if ((await tableExists', effectiveStart)
+  assert.ok(effectiveStart >= 0 && effectiveEnd > effectiveStart)
+  const effective = script.slice(effectiveStart, effectiveEnd)
+  assert.match(effective, /WITH selected AS/)
+  assert.match(effective, /FROM directory_integrations/)
+  assert.match(effective, /provider = 'dingtalk'/)
+  assert.match(effective, /status = 'active'/)
+  assert.match(effective, /ORDER BY CASE WHEN status = 'active' THEN 0 ELSE 1 END, updated_at DESC/)
+  assert.match(effective, /LIMIT 1/)
+  assert.match(effective, /config->>'appKey'/)
+  assert.match(effective, /config->>'appSecret'/)
+  assert.match(effective, /config->>'workNotificationAgentId'/)
+  assert.doesNotMatch(script, /APP_CREDS_READY="\$\(tri_and/)
+})
+
+test('allowlist classifier matches runtime comma-or-whitespace tokenization', () => {
+  const cases = [
+    ['replace-me changeme', 'false|placeholder'],
+    ['real-corp placeholder', 'false|placeholder'],
+    ['real-corp,second-corp', 'true|configured'],
+    ['real-corp\nsecond-corp', 'true|configured'],
+    ['  \t\n', 'false|empty'],
+  ]
+  for (const [input, expected] of cases) {
+    const result = runSourcedInventoryShell(
+      `read_env_raw_or_empty() { printf '%s' "$ALLOWLIST_UNDER_TEST"; }\nclassify_allowlist\nprintf '%s|%s' "$ALLOWLIST_READY" "$ALLOWLIST_REASON"`,
+      { ALLOWLIST_UNDER_TEST: input },
+    )
+    assert.equal(result.status, 0, result.stderr)
+    assert.equal(result.stdout, expected, JSON.stringify(input))
+  }
+})
+
+test('deployed SHA is exact only when image and health sources agree', () => {
+  const shaA = 'a'.repeat(40)
+  const shaB = 'b'.repeat(40)
+  const cases = [
+    [`repo:${shaA}`, JSON.stringify({ build: { commit: shaA } }), `${shaA}|true`],
+    [`repo:${shaA}`, '{}', 'unknown|false'],
+    ['repo:latest', JSON.stringify({ build: { commit: shaA } }), 'unknown|false'],
+    [`repo:${shaA}`, JSON.stringify({ build: { commit: shaB } }), 'conflict|false'],
+  ]
+  for (const [image, health, expected] of cases) {
+    const result = runSourcedInventoryShell(
+      `docker() { printf '%s' "$IMAGE_REF"; }\ncurl() { printf '%s' "$HEALTH_BODY"; }\nBACKEND_CONTAINER_ID=test\nresolve_deployed_sha\nprintf '%s|%s' "$DEPLOYED_SHA" "$DEPLOYED_SHA_VERIFIED"`,
+      { IMAGE_REF: image, HEALTH_BODY: health },
+    )
+    assert.equal(result.status, 0, result.stderr)
+    assert.equal(result.stdout, expected, image)
+  }
+})
+
+test('values-free artifacts exclude SSH transport logs', () => {
+  const workflow = read(workflowPath)
+  assert.match(workflow, /ssh_log="\$RUNNER_TEMP\//)
+  assert.doesNotMatch(workflow, /output\/dingtalk-production-readiness-inventory\/ssh\.log/)
+})
+
+// --- required CI wiring (test 20.x) ----------------------------------------------------
+
+test('inventory contract is wired into required plugin-tests test (20.x) lane', () => {
+  const raw = read(pluginTestsPath)
+  const requiredJobStart = raw.indexOf('\n  test:\n')
+  const requiredJobEnd = raw.indexOf('\n  after-sales-integration:\n')
+  assert.ok(requiredJobStart >= 0 && requiredJobEnd > requiredJobStart, 'required test job bounds')
+  const requiredJob = raw.slice(requiredJobStart, requiredJobEnd)
+
+  const stepMarker = 'DingTalk production-readiness inventory contract (required lane)'
+  const stepStart = requiredJob.indexOf(stepMarker)
+  assert.ok(stepStart >= 0, 'required-lane step must exist in test job')
+  // Grab from the step name line through the next step.
+  const nameIdx = requiredJob.lastIndexOf('\n      - name:', stepStart)
+  const stepEnd = requiredJob.indexOf('\n      - name:', stepStart + 1)
+  assert.ok(nameIdx >= 0 && stepEnd > nameIdx)
+  const step = requiredJob.slice(nameIdx, stepEnd)
+
+  assert.match(
+    step,
+    /if: matrix\.node-version == '20\.x'/,
+    'must run only on the required 20.x leg',
+  )
+  assert.match(
+    step,
+    /node --test scripts\/ops\/dingtalk-production-readiness-inventory-contract\.test\.mjs/,
+  )
+  assert.match(
+    step,
+    /node --test scripts\/ops\/dingtalk-oauth-stability-workflow-contract\.test\.mjs/,
+  )
+  assert.doesNotMatch(step, /continue-on-error:/)
+})
+
+test('host-identity mutation would fail the inventory contract', () => {
+  const raw = read(workflowPath)
+  assert.throws(
+    () => assertPinnedHostIdentity(raw.replace(/StrictHostKeyChecking=yes/g, 'StrictHostKeyChecking=no')),
+    /StrictHostKeyChecking=yes|must not use StrictHostKeyChecking=no|input was expected not to match|did not match/,
+  )
+  assert.throws(
+    () => assertPinnedHostIdentity(raw.replace(/DEPLOY_KNOWN_HOSTS is required/g, 'DEPLOY_KNOWN_HOSTS optional')),
+    /fail closed when missing|did not match/,
+  )
+})

--- a/scripts/ops/dingtalk-production-readiness-inventory-remote.sh
+++ b/scripts/ops/dingtalk-production-readiness-inventory-remote.sh
@@ -1,0 +1,730 @@
+#!/usr/bin/env bash
+# dingtalk-production-readiness-inventory-remote.sh
+#
+# READ-ONLY production inventory for DingTalk readiness. Runs on the deploy host
+# under the same host-authenticated SSH path as the OAuth stability lane.
+#
+# Safety rails:
+#   * Never writes env files, never mutates DB, never flips lifecycle flags.
+#   * Counts + presence only (no row picking of a user/integration).
+#   * Artifacts are values-free: booleans, counts, enum reasons, deployed SHA only.
+#   * No secret material, corp values, integration ids, or PII in output.
+#   * Missing tables or query errors => fail-closed "unknown", not zero.
+#
+# Invoked as: bash -o pipefail -c '<script path>'
+set -euo pipefail
+
+log() { echo "[dingtalk-prod-inventory] $*"; }
+fail() { echo "[dingtalk-prod-inventory][error] $*" >&2; exit 1; }
+
+DEPLOY_PATH="${DEPLOY_PATH:-metasheet2}"
+DEPLOY_COMPOSE_FILE="${DEPLOY_COMPOSE_FILE:-docker-compose.app.yml}"
+OUTPUT_DIR="${OUTPUT_DIR:-}"
+RUN_STAMP="${RUN_STAMP:-manual}"
+BACKEND_HEALTH_URL="${BACKEND_HEALTH_URL:-http://127.0.0.1:8900/health}"
+WEB_HEALTH_URL="${WEB_HEALTH_URL:-http://127.0.0.1:8081/api/health}"
+
+resolve_home_path() {
+  local raw="$1"
+  if [[ "$raw" == /* ]]; then
+    printf '%s' "$raw"
+  elif [[ "$raw" == "~/"* ]]; then
+    printf '%s' "${HOME}/${raw#"~/"}"
+  else
+    printf '%s' "${HOME}/${raw}"
+  fi
+}
+
+REPO_DIR="$(resolve_home_path "$DEPLOY_PATH")"
+
+require_compose() {
+  if docker compose version >/dev/null 2>&1; then
+    COMPOSE=(docker compose)
+    return 0
+  fi
+  if command -v docker-compose >/dev/null 2>&1; then
+    COMPOSE=(docker-compose)
+    return 0
+  fi
+  fail "docker compose is required"
+}
+
+compose_exec() {
+  # compose_exec <service> <remote command...>
+  local service="$1"
+  shift
+  (cd "$REPO_DIR" && "${COMPOSE[@]}" -f "$DEPLOY_COMPOSE_FILE" exec -T "$service" "$@") </dev/null
+}
+
+is_truthy() {
+  local v
+  v="$(printf '%s' "${1:-}" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')"
+  case "$v" in
+    true|1|yes|on) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+flag_state_from_env() {
+  # Prints true|false|unknown for a lifecycle flag. Missing => false (code default OFF).
+  local key="$1" raw
+  if ! raw="$(compose_exec backend sh -lc "if printenv $(printf '%q' "$key") >/dev/null 2>&1; then printenv $(printf '%q' "$key"); else printf '__MISSING__'; fi" 2>/dev/null)"; then
+    printf 'unknown'
+    return 0
+  fi
+  if [[ "$raw" == "__MISSING__" ]]; then
+    printf 'false'
+    return 0
+  fi
+  if is_truthy "$raw"; then
+    printf 'true'
+  else
+    printf 'false'
+  fi
+}
+
+env_present() {
+  # Prints true|false|unknown — presence only, never the value.
+  local keys=("$@") key raw
+  for key in "${keys[@]}"; do
+    if ! raw="$(compose_exec backend sh -lc "if printenv $(printf '%q' "$key") >/dev/null 2>&1; then v=\$(printenv $(printf '%q' "$key")); if [ -n \"\$(printf '%s' \"\$v\" | tr -d '[:space:]')\" ]; then printf 'yes'; else printf 'empty'; fi; else printf 'missing'; fi" 2>/dev/null)"; then
+      printf 'unknown'
+      return 0
+    fi
+    if [[ "$raw" == "yes" ]]; then
+      printf 'true'
+      return 0
+    fi
+  done
+  printf 'false'
+}
+
+read_env_raw_or_empty() {
+  # Used only for closed enum classification (never printed). On probe failure => empty + caller sets unknown.
+  local key="$1" raw
+  if ! raw="$(compose_exec backend sh -lc "printenv $(printf '%q' "$key") 2>/dev/null || true" 2>/dev/null)"; then
+    printf ''
+    return 1
+  fi
+  printf '%s' "$raw"
+  return 0
+}
+
+classify_allowlist() {
+  # Sets ALLOWLIST_READY and ALLOWLIST_REASON (configured|empty|placeholder|unknown).
+  # Never emits the corp id list.
+  local raw rc=0
+  raw="$(read_env_raw_or_empty DINGTALK_ALLOWED_CORP_IDS)" || rc=$?
+  if [[ "$rc" -ne 0 ]]; then
+    ALLOWLIST_READY="unknown"
+    ALLOWLIST_REASON="unknown"
+    return 0
+  fi
+  # Match runtime-policy.ts: split on commas or whitespace, then trim tokens.
+  local normalized
+  normalized="$(printf '%s' "$raw" | tr '[:upper:]' '[:lower:]')"
+  if [[ -z "$normalized" ]]; then
+    ALLOWLIST_READY="false"
+    ALLOWLIST_REASON="empty"
+    return 0
+  fi
+  # Placeholder tokens (staging templates / example values).
+  local token placeholders
+  placeholders='replace-me changeme change-me placeholder todo xxx your-corp-id example'
+  local has_placeholder=false has_any=false
+  while IFS= read -r token; do
+    [[ -z "$token" ]] && continue
+    has_any=true
+    case " $placeholders " in
+      *" $token "*) has_placeholder=true ;;
+      *) ;;
+    esac
+  done < <(printf '%s\n' "$normalized" | tr ',[:space:]' '\n' | sed '/^$/d')
+  if [[ "$has_any" != "true" ]]; then
+    ALLOWLIST_READY="false"
+    ALLOWLIST_REASON="empty"
+    return 0
+  fi
+  if [[ "$has_placeholder" == "true" ]]; then
+    ALLOWLIST_READY="false"
+    ALLOWLIST_REASON="placeholder"
+    return 0
+  fi
+  ALLOWLIST_READY="true"
+  ALLOWLIST_REASON="configured"
+}
+
+classify_log_level() {
+  # Sets LOG_LEVEL_READY and LOG_LEVEL_REASON (info|debug|other|missing|unknown).
+  local raw rc=0
+  raw="$(read_env_raw_or_empty LOG_LEVEL)" || rc=$?
+  if [[ "$rc" -ne 0 ]]; then
+    LOG_LEVEL_READY="unknown"
+    LOG_LEVEL_REASON="unknown"
+    return 0
+  fi
+  local normalized
+  normalized="$(printf '%s' "$raw" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')"
+  if [[ -z "$normalized" ]]; then
+    # core/logger.ts defaults to info when unset/empty.
+    LOG_LEVEL_READY="true"
+    LOG_LEVEL_REASON="missing"
+    return 0
+  fi
+  case "$normalized" in
+    info)
+      LOG_LEVEL_READY="true"
+      LOG_LEVEL_REASON="info"
+      ;;
+    debug)
+      LOG_LEVEL_READY="true"
+      LOG_LEVEL_REASON="debug"
+      ;;
+    *)
+      LOG_LEVEL_READY="false"
+      LOG_LEVEL_REASON="other"
+      ;;
+  esac
+}
+
+resolve_deployed_sha() {
+  local live_image image_commit="" health_commit="" body
+  live_image="$(docker inspect -f '{{.Config.Image}}' "$BACKEND_CONTAINER_ID" 2>/dev/null || true)"
+  if [[ "$live_image" =~ :([0-9a-f]{40})$ ]]; then
+    image_commit="${BASH_REMATCH[1]}"
+  fi
+  if body="$(curl -fsS --max-time 10 "$WEB_HEALTH_URL" 2>/dev/null || curl -fsS --max-time 10 "$BACKEND_HEALTH_URL" 2>/dev/null)"; then
+    health_commit="$(printf '%s' "$body" | python3 -c 'import json,sys
+try:
+  d=json.load(sys.stdin)
+  print((d.get("build") or {}).get("commit") or d.get("commit") or "")
+except Exception:
+  print("")' 2>/dev/null || true)"
+  fi
+  DEPLOYED_SHA='unknown'
+  DEPLOYED_SHA_VERIFIED='false'
+  if [[ -n "$image_commit" && "$health_commit" =~ ^[0-9a-f]{40}$ ]]; then
+    if [[ "$image_commit" == "$health_commit" ]]; then
+      DEPLOYED_SHA="$image_commit"
+      DEPLOYED_SHA_VERIFIED='true'
+    else
+      DEPLOYED_SHA='conflict'
+    fi
+  fi
+}
+
+# SQL inventory: values-free counts only. Fail closed to "unknown" on any error/missing table.
+# Uses backend+node+pg (DATABASE_URL already in the backend container) so we never need
+# to surface DB credentials. Queries return counts/EXISTS only — never secret or PII columns.
+run_sql_inventory() {
+  local env_app_key_present="$1"
+  local env_app_secret_present="$2"
+  local env_agent_id_present="$3"
+  local out sql_probe
+  sql_probe="$(cat <<'NODE'
+const { Client } = require('pg')
+const unknown = {
+  active_dingtalk_integration_count: 'unknown',
+  active_corp_anchored_integration_count: 'unknown',
+  active_directory_account_count: 'unknown',
+  active_linked_local_user_count: 'unknown',
+  same_integration_two_linked_users_ready: 'unknown',
+  directory_uat_baseline_ready: 'unknown',
+  password_capable_alias_admin_count: 'unknown',
+  pending_user_count: 'unknown',
+  stored_app_key_present: 'unknown',
+  stored_app_secret_present: 'unknown',
+  stored_agent_id_present: 'unknown',
+  effective_app_credentials_ready: 'unknown',
+}
+function emit(obj) {
+  process.stdout.write(JSON.stringify(obj))
+}
+;(async () => {
+  const url = process.env.DATABASE_URL
+  if (!url) {
+    emit(unknown)
+    return
+  }
+  const c = new Client({ connectionString: url, connectionTimeoutMillis: 8000 })
+  let connected = false
+  try {
+    await c.connect()
+    connected = true
+    await c.query('BEGIN READ ONLY')
+  } catch {
+    if (connected) {
+      try { await c.end() } catch { /* ignore */ }
+    }
+    emit(unknown)
+    return
+  }
+  async function tableExists(name) {
+    const r = await c.query('SELECT to_regclass($1) IS NOT NULL AS ok', ['public.' + name])
+    return Boolean(r.rows[0] && r.rows[0].ok)
+  }
+  async function countOrUnknown(sql) {
+    try {
+      const r = await c.query(sql)
+      const n = Number(r.rows[0] && r.rows[0].n)
+      return Number.isFinite(n) ? String(n) : 'unknown'
+    } catch {
+      return 'unknown'
+    }
+  }
+  async function boolOrUnknown(sql, params = []) {
+    try {
+      const r = await c.query(sql, params)
+      return r.rows[0] && r.rows[0].ok ? 'true' : 'false'
+    } catch {
+      return 'unknown'
+    }
+  }
+  try {
+    const result = Object.assign({}, unknown)
+    const placeholderCorpIds = new Set([
+      'replace-me', 'changeme', 'change-me', 'placeholder',
+      'todo', 'xxx', 'your-corp-id', 'example',
+    ])
+    const rawAllowedCorpIds = String(process.env.DINGTALK_ALLOWED_CORP_IDS || '')
+      .split(/[\s,]+/)
+      .map((value) => value.trim())
+      .filter(Boolean)
+    const hasPlaceholderCorpId = rawAllowedCorpIds.some(
+      (value) => placeholderCorpIds.has(value.toLowerCase()),
+    )
+    const allowedCorpIds = hasPlaceholderCorpId
+      ? []
+      : Array.from(new Set(rawAllowedCorpIds))
+    let envKey = false
+    let envSecret = false
+    let envAgent = false
+    let envStatesKnown = false
+    if (await tableExists('directory_integrations')) {
+      result.active_dingtalk_integration_count = await countOrUnknown(`
+        SELECT count(*)::int AS n
+          FROM directory_integrations
+         WHERE provider = 'dingtalk'
+           AND status = 'active'
+      `)
+      // Corp-anchored: active DingTalk integration with non-empty, non-placeholder corp_id.
+      // Presence/shape only — never returns the corp_id value.
+      result.active_corp_anchored_integration_count = await countOrUnknown(`
+        SELECT count(*)::int AS n
+          FROM directory_integrations
+         WHERE provider = 'dingtalk'
+           AND status = 'active'
+           AND corp_id IS NOT NULL
+           AND length(trim(corp_id)) > 0
+           AND lower(trim(corp_id)) NOT IN (
+             'replace-me', 'changeme', 'change-me',
+             'placeholder', 'todo', 'xxx', 'your-corp-id', 'example'
+           )
+      `)
+      result.stored_app_key_present = await boolOrUnknown(`
+        SELECT EXISTS (
+          SELECT 1 FROM directory_integrations
+           WHERE provider = 'dingtalk' AND status = 'active'
+             AND nullif(trim(config->>'appKey'), '') IS NOT NULL
+        ) AS ok
+      `)
+      result.stored_app_secret_present = await boolOrUnknown(`
+        SELECT EXISTS (
+          SELECT 1 FROM directory_integrations
+           WHERE provider = 'dingtalk' AND status = 'active'
+             AND nullif(trim(config->>'appSecret'), '') IS NOT NULL
+        ) AS ok
+      `)
+      result.stored_agent_id_present = await boolOrUnknown(`
+        SELECT EXISTS (
+          SELECT 1 FROM directory_integrations
+           WHERE provider = 'dingtalk' AND status = 'active'
+             AND (
+               nullif(trim(config->>'workNotificationAgentId'), '') IS NOT NULL
+               OR nullif(trim(config->>'agentId'), '') IS NOT NULL
+             )
+        ) AS ok
+      `)
+      const envStates = [
+        process.env.INVENTORY_ENV_APP_KEY_PRESENT,
+        process.env.INVENTORY_ENV_APP_SECRET_PRESENT,
+        process.env.INVENTORY_ENV_AGENT_ID_PRESENT,
+      ]
+      if (!envStates.includes('unknown')) {
+        ;[envKey, envSecret, envAgent] = envStates.map((value) => value === 'true')
+        envStatesKnown = true
+        result.effective_app_credentials_ready = await boolOrUnknown(`
+        WITH selected AS (
+          SELECT status, config
+            FROM directory_integrations
+           WHERE provider = 'dingtalk'
+           ORDER BY CASE WHEN status = 'active' THEN 0 ELSE 1 END, updated_at DESC
+           LIMIT 1
+        )
+        SELECT EXISTS (
+          SELECT 1 FROM selected
+           WHERE status = 'active'
+             AND (${envKey ? 'TRUE' : "nullif(trim(config->>'appKey'), '') IS NOT NULL"})
+             AND (${envSecret ? 'TRUE' : "nullif(trim(config->>'appSecret'), '') IS NOT NULL"})
+             AND (${envAgent ? 'TRUE' : "nullif(trim(config->>'workNotificationAgentId'), '') IS NOT NULL OR nullif(trim(config->>'agentId'), '') IS NOT NULL"})
+        ) AS ok
+        `)
+      }
+    }
+    if ((await tableExists('directory_accounts')) && (await tableExists('directory_integrations'))) {
+      result.active_directory_account_count = await countOrUnknown(`
+        SELECT count(*)::int AS n
+          FROM directory_accounts a
+          JOIN directory_integrations i ON i.id = a.integration_id
+         WHERE a.provider = 'dingtalk'
+           AND a.is_active = TRUE
+           AND i.provider = 'dingtalk'
+           AND i.status = 'active'
+      `)
+    }
+    if ((await tableExists('directory_account_links')) && (await tableExists('directory_accounts')) &&
+        (await tableExists('directory_integrations')) && (await tableExists('users'))) {
+      result.active_linked_local_user_count = await countOrUnknown(`
+        SELECT count(DISTINCT l.local_user_id)::int AS n
+          FROM directory_account_links l
+          JOIN directory_accounts a ON a.id = l.directory_account_id
+          JOIN directory_integrations i ON i.id = a.integration_id
+          JOIN users u ON u.id = l.local_user_id
+         WHERE a.provider = 'dingtalk'
+           AND a.is_active = TRUE
+           AND i.provider = 'dingtalk'
+           AND i.status = 'active'
+           AND u.is_active = TRUE
+           AND COALESCE(u.activation_status, 'activated') = 'activated'
+           AND l.link_status = 'linked'
+           AND l.local_user_id IS NOT NULL
+           AND length(trim(l.local_user_id)) > 0
+      `)
+      result.same_integration_two_linked_users_ready = await boolOrUnknown(`
+        SELECT EXISTS (
+          SELECT 1
+            FROM directory_account_links l
+            JOIN directory_accounts a ON a.id = l.directory_account_id
+            JOIN directory_integrations i ON i.id = a.integration_id
+            JOIN users u ON u.id = l.local_user_id
+           WHERE a.provider = 'dingtalk'
+             AND a.is_active = TRUE
+             AND i.provider = 'dingtalk'
+             AND i.status = 'active'
+             AND i.corp_id = ANY($1::text[])
+             AND u.is_active = TRUE
+             AND COALESCE(u.activation_status, 'activated') = 'activated'
+             AND l.link_status = 'linked'
+             AND l.local_user_id IS NOT NULL
+           GROUP BY i.id
+          HAVING count(DISTINCT l.local_user_id) >= 2
+        ) AS ok
+      `, [allowedCorpIds])
+      if (envStatesKnown) {
+        result.directory_uat_baseline_ready = await boolOrUnknown(`
+          WITH selected AS (
+            SELECT id, status, corp_id, config
+              FROM directory_integrations
+             WHERE provider = 'dingtalk'
+             ORDER BY CASE WHEN status = 'active' THEN 0 ELSE 1 END, updated_at DESC
+             LIMIT 1
+          )
+          SELECT EXISTS (
+            SELECT 1
+              FROM selected i
+              JOIN directory_accounts a ON a.integration_id = i.id
+              JOIN directory_account_links l ON l.directory_account_id = a.id
+              JOIN users u ON u.id = l.local_user_id
+             WHERE i.status = 'active'
+               AND i.corp_id = ANY($1::text[])
+               AND (${envKey ? 'TRUE' : "nullif(trim(i.config->>'appKey'), '') IS NOT NULL"})
+               AND (${envSecret ? 'TRUE' : "nullif(trim(i.config->>'appSecret'), '') IS NOT NULL"})
+               AND (${envAgent ? 'TRUE' : "nullif(trim(i.config->>'workNotificationAgentId'), '') IS NOT NULL OR nullif(trim(i.config->>'agentId'), '') IS NOT NULL"})
+               AND a.provider = 'dingtalk'
+               AND a.is_active = TRUE
+               AND u.is_active = TRUE
+               AND COALESCE(u.activation_status, 'activated') = 'activated'
+               AND l.link_status = 'linked'
+               AND l.local_user_id IS NOT NULL
+             GROUP BY i.id
+            HAVING count(DISTINCT l.local_user_id) >= 2
+          ) AS ok
+        `, [allowedCorpIds])
+      }
+    }
+    if ((await tableExists('users')) && (await tableExists('user_login_aliases'))) {
+      // Platform-admin identity is authoritative only through user_roles.role_id = admin.
+      const hasRoles = await tableExists('user_roles')
+      if (hasRoles) {
+        result.password_capable_alias_admin_count = await countOrUnknown(`
+          SELECT count(DISTINCT u.id)::int AS n
+            FROM users u
+            JOIN user_login_aliases a ON a.user_id = u.id
+            JOIN user_roles ur ON ur.user_id = u.id AND ur.role_id = 'admin'
+           WHERE u.is_active = TRUE
+             AND COALESCE(u.local_password_set, TRUE) = TRUE
+             AND COALESCE(u.activation_status, 'activated') = 'activated'
+             AND u.password_hash IS NOT NULL
+             AND length(trim(u.password_hash)) > 0
+             AND u.password_hash NOT LIKE 'unusable:%'
+        `)
+      }
+    }
+    if (await tableExists('users')) {
+      result.pending_user_count = await countOrUnknown(`
+        SELECT count(*)::int AS n
+          FROM users
+         WHERE activation_status = 'pending_activation'
+      `)
+    }
+    emit(result)
+  } finally {
+    try { await c.query('ROLLBACK') } catch { /* ignore */ }
+    try { await c.end() } catch { /* ignore */ }
+  }
+})().catch(() => emit(unknown))
+NODE
+)"
+  # Pipe the probe via stdin so docker compose exec does not need complex argv quoting.
+  if ! out="$(
+    (cd "$REPO_DIR" && "${COMPOSE[@]}" -f "$DEPLOY_COMPOSE_FILE" exec -T \
+      -e "INVENTORY_ENV_APP_KEY_PRESENT=${env_app_key_present}" \
+      -e "INVENTORY_ENV_APP_SECRET_PRESENT=${env_app_secret_present}" \
+      -e "INVENTORY_ENV_AGENT_ID_PRESENT=${env_agent_id_present}" \
+      backend node -) \
+      <<<"$sql_probe" 2>/dev/null
+  )"; then
+    printf '%s' '{"active_dingtalk_integration_count":"unknown","active_corp_anchored_integration_count":"unknown","active_directory_account_count":"unknown","active_linked_local_user_count":"unknown","same_integration_two_linked_users_ready":"unknown","directory_uat_baseline_ready":"unknown","password_capable_alias_admin_count":"unknown","pending_user_count":"unknown","stored_app_key_present":"unknown","stored_app_secret_present":"unknown","stored_agent_id_present":"unknown","effective_app_credentials_ready":"unknown"}'
+    return 0
+  fi
+  # Accept only a single JSON object line; otherwise fail closed.
+  if ! printf '%s' "$out" | python3 -c 'import json,sys; json.loads(sys.stdin.read())' >/dev/null 2>&1; then
+    printf '%s' '{"active_dingtalk_integration_count":"unknown","active_corp_anchored_integration_count":"unknown","active_directory_account_count":"unknown","active_linked_local_user_count":"unknown","same_integration_two_linked_users_ready":"unknown","directory_uat_baseline_ready":"unknown","password_capable_alias_admin_count":"unknown","pending_user_count":"unknown","stored_app_key_present":"unknown","stored_app_secret_present":"unknown","stored_agent_id_present":"unknown","effective_app_credentials_ready":"unknown"}'
+    return 0
+  fi
+  printf '%s' "$out"
+}
+
+tri_and() {
+  # AND of true|false|unknown values. unknown propagates.
+  local a="$1" b="$2" c="${3:-true}"
+  if [[ "$a" == "unknown" || "$b" == "unknown" || "$c" == "unknown" ]]; then
+    printf 'unknown'
+    return 0
+  fi
+  if [[ "$a" == "true" && "$b" == "true" && "$c" == "true" ]]; then
+    printf 'true'
+  else
+    printf 'false'
+  fi
+}
+
+tri_or() {
+  local a="$1" b="$2"
+  if [[ "$a" == "true" || "$b" == "true" ]]; then
+    printf 'true'
+    return 0
+  fi
+  if [[ "$a" == "unknown" || "$b" == "unknown" ]]; then
+    printf 'unknown'
+    return 0
+  fi
+  printf 'false'
+}
+
+json_get() {
+  local json="$1" key="$2"
+  printf '%s' "$json" | python3 -c 'import json,sys
+try:
+  d=json.loads(sys.stdin.read())
+  v=d.get(sys.argv[1], "unknown")
+  print("unknown" if v is None else v)
+except Exception:
+  print("unknown")' "$key" 2>/dev/null || printf 'unknown'
+}
+
+# --- main -------------------------------------------------------------------------
+if [[ "${DINGTALK_PRODUCTION_READINESS_SOURCE_ONLY:-false}" == "true" ]]; then
+  return 0 2>/dev/null || exit 0
+fi
+
+[[ -n "$OUTPUT_DIR" ]] || fail "OUTPUT_DIR is required"
+[[ -d "$REPO_DIR" ]] || fail "DEPLOY_PATH missing: ${DEPLOY_PATH} (resolved: ${REPO_DIR})"
+[[ -f "${REPO_DIR}/${DEPLOY_COMPOSE_FILE}" ]] || fail "compose file missing: ${REPO_DIR}/${DEPLOY_COMPOSE_FILE}"
+require_compose
+mkdir -p "$OUTPUT_DIR"
+
+BACKEND_CONTAINER_ID="$(cd "$REPO_DIR" && "${COMPOSE[@]}" -f "$DEPLOY_COMPOSE_FILE" ps -q backend 2>/dev/null || true)"
+if [[ -z "$BACKEND_CONTAINER_ID" ]] || ! docker inspect -f '{{.State.Running}}' "$BACKEND_CONTAINER_ID" 2>/dev/null | grep -qx 'true'; then
+  fail "production backend service is not running"
+fi
+
+log "read-only inventory start run_stamp=${RUN_STAMP} repo=${REPO_DIR}"
+
+resolve_deployed_sha
+
+ENV_APP_KEY_PRESENT="$(env_present DINGTALK_APP_KEY DINGTALK_CLIENT_ID)"
+ENV_APP_SECRET_PRESENT="$(env_present DINGTALK_APP_SECRET DINGTALK_CLIENT_SECRET)"
+ENV_AGENT_ID_PRESENT="$(env_present DINGTALK_AGENT_ID DINGTALK_NOTIFY_AGENT_ID)"
+
+STREAM_CLIENT_ID_PRESENT="$(env_present DINGTALK_INTERACTIVE_CARD_CLIENT_ID)"
+STREAM_CLIENT_SECRET_PRESENT="$(env_present DINGTALK_INTERACTIVE_CARD_CLIENT_SECRET)"
+STREAM_TEMPLATE_ID_PRESENT="$(env_present DINGTALK_INTERACTIVE_CARD_TEMPLATE_ID)"
+STREAM_INTEGRATION_ID_PRESENT="$(env_present DINGTALK_INTERACTIVE_CARD_STREAM_INTEGRATION_ID)"
+STREAM_BASE_READY="$(tri_and "$STREAM_CLIENT_ID_PRESENT" "$STREAM_CLIENT_SECRET_PRESENT" "$STREAM_TEMPLATE_ID_PRESENT")"
+STREAM_CREDS_READY="$(tri_and "$STREAM_BASE_READY" "$STREAM_INTEGRATION_ID_PRESENT")"
+
+classify_allowlist
+classify_log_level
+
+FLAG_ALIAS="$(flag_state_from_env AUTH_LOGIN_USE_ALIASES)"
+FLAG_PENDING="$(flag_state_from_env DIRECTORY_PENDING_ACTIVATION_ENABLED)"
+FLAG_DEPROVISION="$(flag_state_from_env DIRECTORY_DEPROVISION_ENABLED)"
+FLAG_STREAM="$(flag_state_from_env DINGTALK_INTERACTIVE_CARD_STREAM_ENABLED)"
+
+# Exact OFF required for all four lifecycle/stream gates.
+if [[ "$FLAG_ALIAS" == "false" && "$FLAG_PENDING" == "false" && "$FLAG_DEPROVISION" == "false" && "$FLAG_STREAM" == "false" ]]; then
+  LIFECYCLE_FLAGS_ALL_OFF="true"
+elif [[ "$FLAG_ALIAS" == "unknown" || "$FLAG_PENDING" == "unknown" || "$FLAG_DEPROVISION" == "unknown" || "$FLAG_STREAM" == "unknown" ]]; then
+  LIFECYCLE_FLAGS_ALL_OFF="unknown"
+else
+  LIFECYCLE_FLAGS_ALL_OFF="false"
+fi
+
+SQL_JSON="$(run_sql_inventory "$ENV_APP_KEY_PRESENT" "$ENV_APP_SECRET_PRESENT" "$ENV_AGENT_ID_PRESENT")"
+ACTIVE_INT_COUNT="$(json_get "$SQL_JSON" active_dingtalk_integration_count)"
+ACTIVE_CORP_INT_COUNT="$(json_get "$SQL_JSON" active_corp_anchored_integration_count)"
+ACTIVE_DIR_ACCT_COUNT="$(json_get "$SQL_JSON" active_directory_account_count)"
+ACTIVE_LINKED_USER_COUNT="$(json_get "$SQL_JSON" active_linked_local_user_count)"
+ALIAS_ADMIN_COUNT="$(json_get "$SQL_JSON" password_capable_alias_admin_count)"
+PENDING_USER_COUNT="$(json_get "$SQL_JSON" pending_user_count)"
+STORED_APP_KEY_PRESENT="$(json_get "$SQL_JSON" stored_app_key_present)"
+STORED_APP_SECRET_PRESENT="$(json_get "$SQL_JSON" stored_app_secret_present)"
+STORED_AGENT_ID_PRESENT="$(json_get "$SQL_JSON" stored_agent_id_present)"
+APP_CREDS_READY="$(json_get "$SQL_JSON" effective_app_credentials_ready)"
+AT_LEAST_TWO_LINKED="$(json_get "$SQL_JSON" same_integration_two_linked_users_ready)"
+DIRECTORY_UAT_BASELINE_READY="$(json_get "$SQL_JSON" directory_uat_baseline_ready)"
+
+APP_KEY_PRESENT="$(tri_or "$ENV_APP_KEY_PRESENT" "$STORED_APP_KEY_PRESENT")"
+APP_SECRET_PRESENT="$(tri_or "$ENV_APP_SECRET_PRESENT" "$STORED_APP_SECRET_PRESENT")"
+AGENT_ID_PRESENT="$(tri_or "$ENV_AGENT_ID_PRESENT" "$STORED_AGENT_ID_PRESENT")"
+
+# STATUS ARTIFACT CONTRACT: closed booleans / counts / enum reasons / SHA only.
+{
+  echo "schema=dingtalk-production-readiness-inventory-v1"
+  echo "run_stamp=${RUN_STAMP}"
+  echo "deployed_sha=${DEPLOYED_SHA}"
+  echo "deployed_sha_verified=${DEPLOYED_SHA_VERIFIED}"
+  echo "app_key_present=${APP_KEY_PRESENT}"
+  echo "app_secret_present=${APP_SECRET_PRESENT}"
+  echo "agent_id_present=${AGENT_ID_PRESENT}"
+  echo "app_credentials_ready=${APP_CREDS_READY}"
+  echo "allowed_corp_allowlist_ready=${ALLOWLIST_READY}"
+  echo "allowed_corp_allowlist_reason=${ALLOWLIST_REASON}"
+  echo "active_dingtalk_integration_count=${ACTIVE_INT_COUNT}"
+  echo "active_corp_anchored_integration_count=${ACTIVE_CORP_INT_COUNT}"
+  echo "active_directory_account_count=${ACTIVE_DIR_ACCT_COUNT}"
+  echo "active_linked_local_user_count=${ACTIVE_LINKED_USER_COUNT}"
+  echo "password_capable_alias_admin_count=${ALIAS_ADMIN_COUNT}"
+  echo "pending_user_count=${PENDING_USER_COUNT}"
+  echo "at_least_two_linked_users_ready=${AT_LEAST_TWO_LINKED}"
+  echo "directory_uat_baseline_ready=${DIRECTORY_UAT_BASELINE_READY}"
+  echo "log_level_ready=${LOG_LEVEL_READY}"
+  echo "log_level_reason=${LOG_LEVEL_REASON}"
+  echo "stream_client_id_present=${STREAM_CLIENT_ID_PRESENT}"
+  echo "stream_client_secret_present=${STREAM_CLIENT_SECRET_PRESENT}"
+  echo "stream_template_id_present=${STREAM_TEMPLATE_ID_PRESENT}"
+  echo "stream_integration_id_present=${STREAM_INTEGRATION_ID_PRESENT}"
+  echo "stream_credentials_ready=${STREAM_CREDS_READY}"
+  echo "auth_login_use_aliases=${FLAG_ALIAS}"
+  echo "directory_pending_activation_enabled=${FLAG_PENDING}"
+  echo "directory_deprovision_enabled=${FLAG_DEPROVISION}"
+  echo "dingtalk_interactive_card_stream_enabled=${FLAG_STREAM}"
+  echo "lifecycle_flags_all_off=${LIFECYCLE_FLAGS_ALL_OFF}"
+  echo "read_only=true"
+} > "${OUTPUT_DIR}/inventory.txt"
+
+OUTPUT_DIR_FOR_JSON="${OUTPUT_DIR}" \
+python3 - <<'PY'
+import json
+from pathlib import Path
+import os
+
+out_dir = Path(os.environ['OUTPUT_DIR_FOR_JSON'])
+fields = {}
+for line in (out_dir / 'inventory.txt').read_text(encoding='utf-8').splitlines():
+    if '=' not in line:
+        continue
+    k, v = line.split('=', 1)
+    fields[k] = v
+
+def tri(v):
+    if v == 'true':
+        return True
+    if v == 'false':
+        return False
+    return None
+
+def count(v):
+    if v is None or v == 'unknown':
+        return None
+    try:
+        return int(v)
+    except Exception:
+        return None
+
+report = {
+    'schema': fields.get('schema', 'dingtalk-production-readiness-inventory-v1'),
+    'run_stamp': fields.get('run_stamp', ''),
+    'deployed_sha': fields.get('deployed_sha', 'unknown'),
+    'deployed_sha_verified': tri(fields.get('deployed_sha_verified')),
+    'read_only': True,
+    'app_credentials': {
+        'app_key_present': tri(fields.get('app_key_present')),
+        'app_secret_present': tri(fields.get('app_secret_present')),
+        'agent_id_present': tri(fields.get('agent_id_present')),
+        'ready': tri(fields.get('app_credentials_ready')),
+    },
+    'allowed_corp_allowlist': {
+        'ready': tri(fields.get('allowed_corp_allowlist_ready')),
+        'reason': fields.get('allowed_corp_allowlist_reason', 'unknown'),
+    },
+    'counts': {
+        'active_dingtalk_integration_count': count(fields.get('active_dingtalk_integration_count')),
+        'active_corp_anchored_integration_count': count(fields.get('active_corp_anchored_integration_count')),
+        'active_directory_account_count': count(fields.get('active_directory_account_count')),
+        'active_linked_local_user_count': count(fields.get('active_linked_local_user_count')),
+        'password_capable_alias_admin_count': count(fields.get('password_capable_alias_admin_count')),
+        'pending_user_count': count(fields.get('pending_user_count')),
+    },
+    'at_least_two_linked_users_ready': tri(fields.get('at_least_two_linked_users_ready')),
+    'directory_uat_baseline_ready': tri(fields.get('directory_uat_baseline_ready')),
+    'log_level': {
+        'ready': tri(fields.get('log_level_ready')),
+        'reason': fields.get('log_level_reason', 'unknown'),
+    },
+    'stream': {
+        'client_id_present': tri(fields.get('stream_client_id_present')),
+        'client_secret_present': tri(fields.get('stream_client_secret_present')),
+        'template_id_present': tri(fields.get('stream_template_id_present')),
+        'integration_id_present': tri(fields.get('stream_integration_id_present')),
+        'credentials_ready': tri(fields.get('stream_credentials_ready')),
+    },
+    'lifecycle_flags': {
+        'auth_login_use_aliases': tri(fields.get('auth_login_use_aliases')),
+        'directory_pending_activation_enabled': tri(fields.get('directory_pending_activation_enabled')),
+        'directory_deprovision_enabled': tri(fields.get('directory_deprovision_enabled')),
+        'dingtalk_interactive_card_stream_enabled': tri(fields.get('dingtalk_interactive_card_stream_enabled')),
+        'all_off': tri(fields.get('lifecycle_flags_all_off')),
+    },
+}
+(out_dir / 'inventory.json').write_text(
+    json.dumps(report, ensure_ascii=False, indent=2) + '\n',
+    encoding='utf-8',
+)
+print(json.dumps({'ok': True, 'schema': report['schema'], 'deployed_sha': report['deployed_sha']}))
+PY
+
+log "inventory written to ${OUTPUT_DIR} (values-free; read_only=true)"
+# Explicit non-mutating exit.
+exit 0

--- a/scripts/ops/set-dingtalk-onprem-alertmanager-webhook-config.sh
+++ b/scripts/ops/set-dingtalk-onprem-alertmanager-webhook-config.sh
@@ -10,8 +10,18 @@ REMOTE_CONFIG_FILE="${REMOTE_APP_DIR}/docker/observability/alertmanager/alertman
 MODE="${1:-set}"
 WEBHOOK_URL="${ALERTMANAGER_WEBHOOK_URL:-}"
 
+# Host identity is pinned by the caller (workflow prepares ~/.ssh/known_hosts from
+# DEPLOY_KNOWN_HOSTS). Refuse TOFU / global known_hosts so only the pinned file is trusted.
+SSH_KNOWN_HOSTS_FILE="${SSH_KNOWN_HOSTS_FILE:-${HOME}/.ssh/known_hosts}"
+
 ssh_cmd() {
-  ssh -i "${SSH_KEY}" -o BatchMode=yes -o StrictHostKeyChecking=no "${SSH_USER_HOST}" "$@"
+  ssh -i "${SSH_KEY}" \
+    -o BatchMode=yes \
+    -o IdentitiesOnly=yes \
+    -o StrictHostKeyChecking=yes \
+    -o "UserKnownHostsFile=${SSH_KNOWN_HOSTS_FILE}" \
+    -o GlobalKnownHostsFile=/dev/null \
+    "${SSH_USER_HOST}" "$@"
 }
 
 validate_webhook_url() {


### PR DESCRIPTION
## What

- add a manual-only, read-only production readiness inventory for the existing DingTalk deployment
- report only booleans, counts, closed reasons, and a dual-source verified deployed SHA
- pin production SSH host identity for both the inventory and OAuth stability lanes
- wire the inventory and SSH contracts into required Node 20 CI

## Safety boundary

- does not read secret values into artifacts
- does not emit corp IDs, integration IDs, user identifiers, email, mobile, or credentials
- does not write the database or environment
- does not select canary subjects
- does not flip `AUTH_LOGIN_USE_ALIASES`, `DIRECTORY_PENDING_ACTIVATION_ENABLED`, `DIRECTORY_DEPROVISION_ENABLED`, or `DINGTALK_INTERACTIVE_CARD_STREAM_ENABLED`

## Readiness semantics

- allowlist parsing matches runtime comma-or-whitespace tokenization and rejects placeholder-bearing lists
- credential readiness follows the same newest-active integration selection as runtime
- directory UAT baseline requires that selected allowed-corp integration to have coherent credentials and at least two active linked users
- deployed SHA is verified only when image tag and health endpoint report the same 40-hex commit
- missing tables, probes, or evidence fail closed to `unknown`

## Verification

- `bash -n scripts/ops/dingtalk-production-readiness-inventory-remote.sh`
- `node --test scripts/ops/dingtalk-production-readiness-inventory-contract.test.mjs scripts/ops/dingtalk-oauth-stability-workflow-contract.test.mjs` (22/22)
- existing OAuth stability contract battery (12/12)
- sealed-export package provenance contract
- workflow YAML parse
- independent Grok 4.5 adversarial review: 0 P1/P2 after two fix rounds

Production inventory and OAuth workflow dispatches are intentionally deferred until this exact code is merged. Lifecycle flags remain OFF.
