### PR TITLE
fix(ops): make stock-prep package artifact self-contained

### DIFF
--- a/.github/workflows/stock-prep-main-package-verify.yml
+++ b/.github/workflows/stock-prep-main-package-verify.yml
@@ -255,6 +255,9 @@ jobs:
           out_dir="output/releases/multitable-onprem"
           pkg_tgz="$(ls -1 ${out_dir}/*.tgz | sort | tail -n 1)"
           pkg_zip="$(ls -1 ${out_dir}/*.zip | sort | tail -n 1)"
+          pkg_meta="${pkg_tgz%.tgz}.json"
+          pkg_bootstrap_ps1="${pkg_tgz%.tgz}-deploy-bootstrap.ps1"
+          pkg_bootstrap_bat="${pkg_tgz%.tgz}-deploy-bootstrap.bat"
           pkg_name="$(basename "${pkg_tgz%.tgz}")"
           verify_dir="${out_dir}/verify"
           mkdir -p "$verify_dir"
@@ -289,16 +292,29 @@ jobs:
           tgz_sha="$(sha256sum "$pkg_tgz" | awk '{print $1}')"
           zip_sha="$(sha256sum "$pkg_zip" | awk '{print $1}')"
 
-          # Stage exactly what the downstream jobs need, in ONE directory, so the
-          # artifact's least-common-ancestor is unambiguous and SHA256SUMS lands
-          # as a SIBLING of the archives — multitable-onprem-package-verify.sh:827-828
-          # requires it adjacent to the package it is verifying.
+          # Stage the complete release bundle in ONE directory, so the artifact's
+          # least-common-ancestor is unambiguous and SHA256SUMS lands as a sibling
+          # of every file it indexes. The downstream verifier requires the index
+          # adjacent to the archives (multitable-onprem-package-verify.sh:827-828),
+          # while an entity-machine handoff also needs the bootstrap sidecars.
           stage="output/main-package-verify-artifact"
           mkdir -p "$stage"
-          cp "$pkg_tgz" "$pkg_zip" "${pkg_tgz}.sha256" "${pkg_zip}.sha256" "$stage/"
+          cp "$pkg_tgz" "$pkg_zip" "$pkg_meta" \
+            "$pkg_bootstrap_ps1" "$pkg_bootstrap_bat" \
+            "${pkg_tgz}.sha256" "${pkg_zip}.sha256" \
+            "${pkg_bootstrap_ps1}.sha256" "${pkg_bootstrap_bat}.sha256" \
+            "$stage/"
           cp "${out_dir}/SHA256SUMS" "$stage/"
           cp "${verify_dir}/${pkg_name}.tgz.verify.json" "${verify_dir}/${pkg_name}.tgz.verify.md" "$stage/"
           cp "${verify_dir}/${pkg_name}.zip.verify.json" "${verify_dir}/${pkg_name}.zip.verify.md" "$stage/"
+
+          # This is deliberately run against the staged upload, not out_dir. It
+          # catches a release-bundle file being generated and indexed but omitted
+          # from the artifact, which archive-only verification cannot detect.
+          (
+            cd "$stage"
+            sha256sum -c SHA256SUMS
+          )
 
           {
             echo "artifact_name=main-package-${{ github.run_id }}-${{ github.run_attempt }}"
@@ -332,6 +348,7 @@ jobs:
             echo "buildProvenanceGitCommitMatchesBuildSha=PASS"
             echo "packageVerificationTgz=PASS"
             echo "packageVerificationZip=PASS"
+            echo "stagedReleaseBundleChecksums=PASS"
             echo "dependencyPreflight=PASS"
             echo "releasePublished=false"
           } | tee -a "$GITHUB_STEP_SUMMARY"
@@ -372,6 +389,13 @@ jobs:
         with:
           name: ${{ needs.build-main-package.outputs.artifact_name }}
           path: pkg
+
+      - name: Verify the downloaded release bundle checksum index
+        working-directory: pkg
+        run: |
+          set -euo pipefail
+          sha256sum -c SHA256SUMS
+          echo "downloadedReleaseBundleChecksums=PASS"
 
       - name: PIN-3 — recomputed artifact SHA-256 must equal the build job's recorded value
         run: |
@@ -535,6 +559,7 @@ jobs:
         run: |
           {
             echo "sameArtifactAsBuildJob=PASS"
+            echo "downloadedReleaseBundleChecksums=PASS"
             echo "packageVerificationTgz=PASS"
             echo "packageVerificationZip=PASS"
             echo "packagedMigration074Present=PASS"
@@ -856,6 +881,8 @@ jobs:
             echo "migrationExcludeDriftCheck=PASS"
             echo "packageVerificationTgz=PASS"
             echo "packageVerificationZip=PASS"
+            echo "stagedReleaseBundleChecksums=PASS"
+            echo "downloadedReleaseBundleChecksums=PASS"
             echo "sameArtifactAcrossAllJobs=PASS"
             echo "packagedMigration074Present=PASS"
             echo "packagedMigration075Present=PASS"


### PR DESCRIPTION
## Problem

The successful main package run 31449908894 produced valid TGZ/ZIP bytes, but its downloaded Actions artifact omitted the generated deploy-bootstrap PS1/BAT files while `SHA256SUMS` still indexed them. A full `shasum -a 256 -c SHA256SUMS` therefore failed after download.

## Change

- stage the existing package metadata, deploy-bootstrap helpers, and their sidecar checksums with the archives
- verify the complete staged checksum index before upload
- verify the same checksum index again after `download-artifact`
- report staged and downloaded bundle checks separately

This changes only `.github/workflows/stock-prep-main-package-verify.yml`. It does not alter product runtime or package-builder composition; it only changes which already-generated release files the evidence workflow uploads and verifies. It does not deploy, change flags, access customer systems, or write externally.

## Verification

- `git diff --check`
- YAML parsed with Ruby Psych
- independent Grok 4.5 adversarial review: APPROVE; follow-up review of post-download gate: no blocker
- exact-head workflow [run 31450663002](https://github.com/zensgit/metasheet2/actions/runs/31450663002): SUCCESS
- downloaded artifact `9086241730`: 14 files; full `shasum -a 256 -c SHA256SUMS` reports TGZ, ZIP, PS1 and BAT all OK
- PG 15/16/17, migrations 074/075, replay and one-byte negative control: PASS

Relates to #4628; the issue remains open.