### PR TITLE
feat(integration): add values-free K3 call audit

### DIFF
--- a/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
@@ -622,6 +622,37 @@ async function testUnauthenticatedWriteRequestIsRejected() {
   assert.equal(calls.length, 0, 'unauthenticated write did not reach services')
 }
 
+async function testK3WiseCallAuditRouteIsAdminOnlyAndValuesFree() {
+  const { services } = createMockServices()
+  const { routes, registered } = mountRoutes(services)
+  const routePath = '/api/integration/internal/k3-wise/call-audit'
+  assert.ok(registered.includes(`GET ${routePath}`), 'K3 values-free call-audit route registered')
+
+  for (const user of [undefined, READ_USER, WRITE_USER]) {
+    const denied = await invoke(routes, 'GET', routePath, { user })
+    assertErrorResponse(denied, user ? [403] : [401])
+  }
+
+  const allowed = await invoke(routes, 'GET', routePath, { user: ADMIN_USER })
+  assertOkResponse(allowed, 200)
+  assert.equal(allowed.body.data.version, '2026.08.v1')
+  assert.equal(allowed.body.data.scope, 'process')
+  assert.deepEqual(Object.keys(allowed.body.data.counts), [
+    'materialGetDetail',
+    'materialGetList',
+    'materialSave',
+    'materialSubmit',
+    'materialAudit',
+    'otherRead',
+    'otherLifecycleWrite',
+  ])
+  assert.ok(Object.values(allowed.body.data.counts).every(Number.isSafeInteger))
+  const serialized = JSON.stringify(allowed.body.data)
+  for (const forbidden of ['url', 'path', 'query', 'credential', 'request', 'response', 'tenant']) {
+    assert.equal(serialized.toLowerCase().includes(forbidden), false, `audit response excludes ${forbidden}`)
+  }
+}
+
 async function testExternalSystemRoutes() {
   const { calls, services } = createMockServices()
   const { routes, registered } = mountRoutes(services)
@@ -8521,6 +8552,7 @@ async function main() {
   await testC6AdapterBackedTargetLoadsWithCredentials()
   await testTemplatesCrudRoutes()
   await testUnauthenticatedWriteRequestIsRejected()
+  await testK3WiseCallAuditRouteIsAdminOnlyAndValuesFree()
   await testStockPreparationTargetProvisioningRoutes()
   await testStockPreparationOptionSyncRoute()
   await testStockPreparationErpMaterialSyncRoute()

--- a/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
@@ -635,8 +635,9 @@ async function testK3WiseCallAuditRouteIsAdminOnlyAndValuesFree() {
 
   const allowed = await invoke(routes, 'GET', routePath, { user: ADMIN_USER })
   assertOkResponse(allowed, 200)
-  assert.equal(allowed.body.data.version, '2026.08.v1')
+  assert.equal(allowed.body.data.version, '2026.08.v2')
   assert.equal(allowed.body.data.scope, 'process')
+  assert.match(allowed.body.data.processEpoch, /^[0-9a-f]{32}$/)
   assert.deepEqual(Object.keys(allowed.body.data.counts), [
     'materialGetDetail',
     'materialGetList',
@@ -651,6 +652,12 @@ async function testK3WiseCallAuditRouteIsAdminOnlyAndValuesFree() {
   for (const forbidden of ['url', 'path', 'query', 'credential', 'request', 'response', 'tenant']) {
     assert.equal(serialized.toLowerCase().includes(forbidden), false, `audit response excludes ${forbidden}`)
   }
+
+  const crossTenant = await invoke(routes, 'GET', routePath, {
+    user: ADMIN_USER,
+    query: { tenantId: 'tenant_other' },
+  })
+  assertErrorResponse(crossTenant, [403])
 }
 
 async function testExternalSystemRoutes() {

--- a/plugins/plugin-integration-core/__tests__/k3-wise-adapters.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/k3-wise-adapters.test.cjs
@@ -232,6 +232,7 @@ function createK3FetchMock() {
 function createK3WebApiSystem(overrides = {}) {
   return {
     id: 'k3_webapi_1',
+    tenantId: 'tenant_1',
     name: 'K3 WISE WebAPI',
     kind: 'erp:k3-wise-webapi',
     role: 'target',
@@ -881,7 +882,7 @@ async function testK3WebApiMaterialDetailReadSmoke() {
   assert.equal(auditInternals.classifyK3WiseCall('/K3API/BOM/Save', 'lifecycle-write'), 'otherLifecycleWrite')
   assert.equal(auditInternals.classifyK3WiseCall('/K3API/Token/Create', 'read'), 'otherRead')
   const { calls, fetchImpl } = createK3FetchMock()
-  const auditBefore = getK3WiseCallAuditSnapshot()
+  const auditBefore = getK3WiseCallAuditSnapshot({ tenantId: 'tenant_1' })
   const adapter = createK3WiseWebApiAdapter({
     system: createK3WebApiSystem({
       config: {
@@ -943,7 +944,9 @@ async function testK3WebApiMaterialDetailReadSmoke() {
   assert.equal(calls.some((call) => call.pathname === '/K3API/Material/Submit'), false, 'read smoke must not Submit')
   assert.equal(calls.some((call) => call.pathname === '/K3API/Material/Audit'), false, 'read smoke must not Audit')
 
-  const auditAfter = getK3WiseCallAuditSnapshot()
+  const auditAfter = getK3WiseCallAuditSnapshot({ tenantId: 'tenant_1' })
+  assert.match(auditAfter.processEpoch, /^[0-9a-f]{32}$/)
+  assert.equal(auditAfter.processEpoch, auditBefore.processEpoch, 'same-process snapshots carry the same epoch')
   assert.deepEqual(
     Object.keys(auditAfter.counts),
     [...K3_WISE_CALL_AUDIT_OPERATIONS],
@@ -957,6 +960,8 @@ async function testK3WebApiMaterialDetailReadSmoke() {
   for (const forbidden of ['MAT-GATE-001', 'k3.example.test', 'k3-session-1', 'k3-token-1']) {
     assert.equal(auditText.includes(forbidden), false, `call-audit snapshot must not expose ${forbidden}`)
   }
+  const otherTenantAudit = getK3WiseCallAuditSnapshot({ tenantId: 'tenant_other' })
+  assert.ok(Object.values(otherTenantAudit.counts).every((count) => count === 0), 'another tenant sees an isolated partition')
 
   const missingKey = await adapter.read({ object: 'material' }).catch((error) => error)
   assert.ok(missingKey instanceof AdapterValidationError, 'Material read requires a concrete FNumber/template key')

--- a/plugins/plugin-integration-core/__tests__/k3-wise-adapters.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/k3-wise-adapters.test.cjs
@@ -12,6 +12,11 @@ const {
   createK3WiseWebApiAdapter,
 } = require(path.join(__dirname, '..', 'lib', 'adapters', 'k3-wise-webapi-adapter.cjs'))
 const {
+  __internals: auditInternals,
+  K3_WISE_CALL_AUDIT_OPERATIONS,
+  getK3WiseCallAuditSnapshot,
+} = require(path.join(__dirname, '..', 'lib', 'adapters', 'k3-wise-call-audit.cjs'))
+const {
   createK3WiseSqlServerChannel,
   createK3WiseSqlServerChannelFactory,
 } = require(path.join(__dirname, '..', 'lib', 'adapters', 'k3-wise-sqlserver-channel.cjs'))
@@ -868,7 +873,15 @@ async function testK3WebApiAdapter() {
 }
 
 async function testK3WebApiMaterialDetailReadSmoke() {
+  assert.equal(auditInternals.classifyK3WiseCall('/K3API/Material/GetDetail', 'read'), 'materialGetDetail')
+  assert.equal(auditInternals.classifyK3WiseCall('/K3API/Material/GetList', 'read'), 'materialGetList')
+  assert.equal(auditInternals.classifyK3WiseCall('/K3API/Material/Save.ashx', 'lifecycle-write'), 'materialSave')
+  assert.equal(auditInternals.classifyK3WiseCall('/K3API/Material/Submit', 'lifecycle-write'), 'materialSubmit')
+  assert.equal(auditInternals.classifyK3WiseCall('/K3API/Material/Audit', 'lifecycle-write'), 'materialAudit')
+  assert.equal(auditInternals.classifyK3WiseCall('/K3API/BOM/Save', 'lifecycle-write'), 'otherLifecycleWrite')
+  assert.equal(auditInternals.classifyK3WiseCall('/K3API/Token/Create', 'read'), 'otherRead')
   const { calls, fetchImpl } = createK3FetchMock()
+  const auditBefore = getK3WiseCallAuditSnapshot()
   const adapter = createK3WiseWebApiAdapter({
     system: createK3WebApiSystem({
       config: {
@@ -929,6 +942,21 @@ async function testK3WebApiMaterialDetailReadSmoke() {
   assert.equal(calls.some((call) => call.pathname === '/K3API/Material/Save'), false, 'read smoke must not Save')
   assert.equal(calls.some((call) => call.pathname === '/K3API/Material/Submit'), false, 'read smoke must not Submit')
   assert.equal(calls.some((call) => call.pathname === '/K3API/Material/Audit'), false, 'read smoke must not Audit')
+
+  const auditAfter = getK3WiseCallAuditSnapshot()
+  assert.deepEqual(
+    Object.keys(auditAfter.counts),
+    [...K3_WISE_CALL_AUDIT_OPERATIONS],
+    'the operational evidence uses a closed values-free key set',
+  )
+  assert.equal(auditAfter.counts.materialGetDetail - auditBefore.counts.materialGetDetail, 1)
+  assert.equal(auditAfter.counts.materialSave - auditBefore.counts.materialSave, 0)
+  assert.equal(auditAfter.counts.materialSubmit - auditBefore.counts.materialSubmit, 0)
+  assert.equal(auditAfter.counts.materialAudit - auditBefore.counts.materialAudit, 0)
+  const auditText = JSON.stringify(auditAfter)
+  for (const forbidden of ['MAT-GATE-001', 'k3.example.test', 'k3-session-1', 'k3-token-1']) {
+    assert.equal(auditText.includes(forbidden), false, `call-audit snapshot must not expose ${forbidden}`)
+  }
 
   const missingKey = await adapter.read({ object: 'material' }).catch((error) => error)
   assert.ok(missingKey instanceof AdapterValidationError, 'Material read requires a concrete FNumber/template key')

--- a/plugins/plugin-integration-core/lib/adapters/k3-wise-call-audit.cjs
+++ b/plugins/plugin-integration-core/lib/adapters/k3-wise-call-audit.cjs
@@ -1,11 +1,16 @@
 'use strict'
 
+const crypto = require('node:crypto')
+
 // Process-local, values-free K3 wire-attempt counters. The adapter records only a
 // closed operation name and an integer. Raw paths, URLs, query parameters,
-// credentials, request bodies, responses, tenant ids, and business values never
-// enter this state. A process restart intentionally resets the counters.
+// credentials, request bodies, responses, and business values never enter this
+// state. Counts are partitioned by the adapter's existing tenant scope; tenant ids
+// are never returned by the snapshot. A process restart intentionally resets both
+// the counters and epoch so consumers can reject cross-restart comparisons.
 
-const K3_WISE_CALL_AUDIT_VERSION = '2026.08.v1'
+const K3_WISE_CALL_AUDIT_VERSION = '2026.08.v2'
+const PROCESS_EPOCH = crypto.randomBytes(16).toString('hex')
 const K3_WISE_CALL_AUDIT_OPERATIONS = Object.freeze([
   'materialGetDetail',
   'materialGetList',
@@ -16,7 +21,22 @@ const K3_WISE_CALL_AUDIT_OPERATIONS = Object.freeze([
   'otherLifecycleWrite',
 ])
 const OPERATION_SET = new Set(K3_WISE_CALL_AUDIT_OPERATIONS)
-const counts = Object.fromEntries(K3_WISE_CALL_AUDIT_OPERATIONS.map((operation) => [operation, 0]))
+const countsByTenant = new Map()
+
+function createCounts() {
+  return Object.fromEntries(K3_WISE_CALL_AUDIT_OPERATIONS.map((operation) => [operation, 0]))
+}
+
+function tenantKey(tenantId) {
+  return typeof tenantId === 'string' && tenantId.trim() ? tenantId.trim() : null
+}
+
+function countsForTenant(tenantId, { create = false } = {}) {
+  const key = tenantKey(tenantId)
+  if (!key) return null
+  if (!countsByTenant.has(key) && create) countsByTenant.set(key, createCounts())
+  return countsByTenant.get(key) || null
+}
 
 function endpointStem(segment) {
   return String(segment || '').split('.')[0].toLowerCase()
@@ -38,16 +58,20 @@ function classifyK3WiseCall(wirePathname, intent) {
   return intent === 'lifecycle-write' ? 'otherLifecycleWrite' : 'otherRead'
 }
 
-function recordK3WiseCall(wirePathname, intent) {
+function recordK3WiseCall(wirePathname, intent, tenantId) {
   const operation = classifyK3WiseCall(wirePathname, intent)
   if (!OPERATION_SET.has(operation)) return
+  const counts = countsForTenant(tenantId, { create: true })
+  if (!counts) return
   counts[operation] = Math.min(Number.MAX_SAFE_INTEGER, counts[operation] + 1)
 }
 
-function getK3WiseCallAuditSnapshot() {
+function getK3WiseCallAuditSnapshot({ tenantId } = {}) {
+  const counts = countsForTenant(tenantId) || createCounts()
   return Object.freeze({
     version: K3_WISE_CALL_AUDIT_VERSION,
     scope: 'process',
+    processEpoch: PROCESS_EPOCH,
     counts: Object.freeze(Object.fromEntries(
       K3_WISE_CALL_AUDIT_OPERATIONS.map((operation) => [operation, counts[operation]]),
     )),
@@ -61,5 +85,6 @@ module.exports = {
   recordK3WiseCall,
   __internals: {
     classifyK3WiseCall,
+    tenantKey,
   },
 }

--- a/plugins/plugin-integration-core/lib/adapters/k3-wise-call-audit.cjs
+++ b/plugins/plugin-integration-core/lib/adapters/k3-wise-call-audit.cjs
@@ -1,0 +1,65 @@
+'use strict'
+
+// Process-local, values-free K3 wire-attempt counters. The adapter records only a
+// closed operation name and an integer. Raw paths, URLs, query parameters,
+// credentials, request bodies, responses, tenant ids, and business values never
+// enter this state. A process restart intentionally resets the counters.
+
+const K3_WISE_CALL_AUDIT_VERSION = '2026.08.v1'
+const K3_WISE_CALL_AUDIT_OPERATIONS = Object.freeze([
+  'materialGetDetail',
+  'materialGetList',
+  'materialSave',
+  'materialSubmit',
+  'materialAudit',
+  'otherRead',
+  'otherLifecycleWrite',
+])
+const OPERATION_SET = new Set(K3_WISE_CALL_AUDIT_OPERATIONS)
+const counts = Object.fromEntries(K3_WISE_CALL_AUDIT_OPERATIONS.map((operation) => [operation, 0]))
+
+function endpointStem(segment) {
+  return String(segment || '').split('.')[0].toLowerCase()
+}
+
+function classifyK3WiseCall(wirePathname, intent) {
+  const segments = String(wirePathname || '')
+    .split('/')
+    .filter(Boolean)
+    .map(endpointStem)
+  const materialIndex = segments.lastIndexOf('material')
+  const materialOperation = materialIndex >= 0 ? segments.slice(materialIndex + 1) : []
+
+  if (materialOperation.includes('getdetail')) return 'materialGetDetail'
+  if (materialOperation.includes('getlist')) return 'materialGetList'
+  if (materialOperation.includes('save')) return 'materialSave'
+  if (materialOperation.includes('submit')) return 'materialSubmit'
+  if (materialOperation.includes('audit')) return 'materialAudit'
+  return intent === 'lifecycle-write' ? 'otherLifecycleWrite' : 'otherRead'
+}
+
+function recordK3WiseCall(wirePathname, intent) {
+  const operation = classifyK3WiseCall(wirePathname, intent)
+  if (!OPERATION_SET.has(operation)) return
+  counts[operation] = Math.min(Number.MAX_SAFE_INTEGER, counts[operation] + 1)
+}
+
+function getK3WiseCallAuditSnapshot() {
+  return Object.freeze({
+    version: K3_WISE_CALL_AUDIT_VERSION,
+    scope: 'process',
+    counts: Object.freeze(Object.fromEntries(
+      K3_WISE_CALL_AUDIT_OPERATIONS.map((operation) => [operation, counts[operation]]),
+    )),
+  })
+}
+
+module.exports = {
+  K3_WISE_CALL_AUDIT_OPERATIONS,
+  K3_WISE_CALL_AUDIT_VERSION,
+  getK3WiseCallAuditSnapshot,
+  recordK3WiseCall,
+  __internals: {
+    classifyK3WiseCall,
+  },
+}

--- a/plugins/plugin-integration-core/lib/adapters/k3-wise-webapi-adapter.cjs
+++ b/plugins/plugin-integration-core/lib/adapters/k3-wise-webapi-adapter.cjs
@@ -1830,7 +1830,7 @@ function createK3WiseWebApiAdapter({ system, fetchImpl = globalThis.fetch, logge
     try {
       // The counter receives the canonical wire pathname only long enough to map it
       // into a closed operation vocabulary. It retains no URL or request value.
-      recordK3WiseCall(wirePathname, intent)
+      recordK3WiseCall(wirePathname, intent, normalizedSystem.tenantId)
       const response = await fetchImpl(url, {
         method,
         headers: requestHeaders,

--- a/plugins/plugin-integration-core/lib/adapters/k3-wise-webapi-adapter.cjs
+++ b/plugins/plugin-integration-core/lib/adapters/k3-wise-webapi-adapter.cjs
@@ -39,6 +39,7 @@ const { scrubSecretStringValue } = require('../payload-redaction.cjs')
 // preview (http-routes.cjs). Placeholder detection (findUnfilledPlaceholders) is shared; the
 // Save path below owns the throw disposition, the preview owns the valid:false disposition.
 const { composeSchemaBody, findUnfilledPlaceholders, projectRecordForBody } = require('./k3-save-body-composer.cjs')
+const { recordK3WiseCall } = require('./k3-wise-call-audit.cjs')
 
 class K3WiseWebApiAdapterError extends Error {
   constructor(message, details = {}) {
@@ -1810,7 +1811,8 @@ function createK3WiseWebApiAdapter({ system, fetchImpl = globalThis.fetch, logge
     // Build ONCE, then gate the pathname that was actually produced. Re-deriving it here would
     // reintroduce exactly the check-vs-use gap that axes 4, 5 and 6 all exploited.
     const endpointUrl = buildEndpointUrl(baseUrl, path)
-    assertWireEndpointIntent(toWireEndpointPathname(endpointUrl.pathname), intent)
+    const wirePathname = toWireEndpointPathname(endpointUrl.pathname)
+    assertWireEndpointIntent(wirePathname, intent)
     for (const [key, value] of Object.entries(query || {})) {
       if (value === undefined || value === null || value === '') continue
       endpointUrl.searchParams.set(key, String(value))
@@ -1826,6 +1828,9 @@ function createK3WiseWebApiAdapter({ system, fetchImpl = globalThis.fetch, logge
     )
 
     try {
+      // The counter receives the canonical wire pathname only long enough to map it
+      // into a closed operation vocabulary. It retains no URL or request value.
+      recordK3WiseCall(wirePathname, intent)
       const response = await fetchImpl(url, {
         method,
         headers: requestHeaders,

--- a/plugins/plugin-integration-core/lib/contracts.cjs
+++ b/plugins/plugin-integration-core/lib/contracts.cjs
@@ -70,6 +70,7 @@ function normalizeExternalSystemForAdapter(system) {
   }
   return {
     id: optionalString(system.id, 'system.id'),
+    tenantId: optionalString(system.tenantId, 'system.tenantId'),
     name: optionalString(system.name, 'system.name') || requiredString(system.kind, 'system.kind'),
     kind: requiredString(system.kind, 'system.kind'),
     role: optionalString(system.role, 'system.role') || 'bidirectional',

--- a/plugins/plugin-integration-core/lib/http-routes.cjs
+++ b/plugins/plugin-integration-core/lib/http-routes.cjs
@@ -2730,9 +2730,11 @@ function createHandlers(services, options = {}) {
 
     async k3WiseCallAudit(req, res) {
       // Internal operational evidence only. The snapshot is process-local and
-      // values-free, but still reveals connector activity, so keep it admin-only.
+      // values-free, but still reveals connector activity, so keep it admin-only
+      // and reuse the existing tenant boundary before selecting its partition.
       requireAccess(req, 'admin')
-      return sendOk(res, getK3WiseCallAuditSnapshot())
+      const tenantId = resolveTenantId(req, requestQuery(req))
+      return sendOk(res, getK3WiseCallAuditSnapshot({ tenantId }))
     },
 
     async adaptersList(req, res) {

--- a/plugins/plugin-integration-core/lib/http-routes.cjs
+++ b/plugins/plugin-integration-core/lib/http-routes.cjs
@@ -10,6 +10,7 @@
 
 const ROUTES = [
   ['GET', '/api/integration/status', 'status'],
+  ['GET', '/api/integration/internal/k3-wise/call-audit', 'k3WiseCallAudit'],
   ['GET', '/api/integration/adapters', 'adaptersList'],
   ['GET', '/api/integration/external-systems', 'externalSystemsList'],
   ['POST', '/api/integration/external-systems', 'externalSystemsUpsert'],
@@ -154,6 +155,7 @@ const { getPath, setPath, transformRecord } = require('./transform-engine.cjs')
 // DF-T1 reuses applyReferenceShape (shaping) + findUnfilledPlaceholders (detection); it does
 // NOT introduce a new K3 shaper/projector.
 const { projectRecordForBody, findUnfilledPlaceholders, applyReferenceShape, isBlankValue } = require('./adapters/k3-save-body-composer.cjs')
+const { getK3WiseCallAuditSnapshot } = require('./adapters/k3-wise-call-audit.cjs')
 // DF-T3b-2a: from_reference_table resolves a per-material reference via the shared resolver (the
 // SAME decision both the preview and the record materializer use, so they cannot diverge).
 const { resolveReferenceRuleValue } = require('./reference-mapping-resolver.cjs')
@@ -2724,6 +2726,13 @@ function createHandlers(services, options = {}) {
         adapters: adapterRegistry.listAdapterKinds(),
         routes: ROUTES.map(([method, path]) => ({ method, path })),
       })
+    },
+
+    async k3WiseCallAudit(req, res) {
+      // Internal operational evidence only. The snapshot is process-local and
+      // values-free, but still reveals connector activity, so keep it admin-only.
+      requireAccess(req, 'admin')
+      return sendOk(res, getK3WiseCallAuditSnapshot())
     },
 
     async adaptersList(req, res) {

--- a/plugins/plugin-integration-core/lib/sealed-export/vectors/s6a-package-provenance-pins.json
+++ b/plugins/plugin-integration-core/lib/sealed-export/vectors/s6a-package-provenance-pins.json
@@ -70,7 +70,7 @@
     "pluginPackageJson": "19900cc7df6b75da92ce6f69e4932e4ce5a707930d58c32bd67ba27f8ffef401",
     "pnpmLock": "8ca98ceef0c84b821c4b20a0f0cf0b50b87dfb51a26b6a2d21a9912a1733680f",
     "pluginIndex": "c2a800452d175e2b00a476b3e0d3fab6f65e16031789b91a0304dd1dc45a0cee",
-    "pluginHttpRoutes": "ed8953d0e9b64b5953cb1fb398dcf9251437f704d55f5175f9d018c8d410b4f0",
+    "pluginHttpRoutes": "a314e2e5f911f8da9e164e858c87846ff55ea2777f15b258da37a0842eef156f",
     "s6aProvisioningCli": "d3320b27da7ab358ca068a3766a375e669fb6922f24ba0186ba0828c3e1d9da8",
     "s6aAcceptanceRunner": "eb58824cba1ab03361a6a4fba409f3f7a120dcda61d4c3d6cad2b82311d62624",
     "s6aOnpremRunbook": "1f4ba2b7fadbad0acb97e18d13f2be7ad6071fa372ac44e0aa4e17995e94c410",

--- a/plugins/plugin-integration-core/lib/sealed-export/vectors/s6a-package-provenance-pins.json
+++ b/plugins/plugin-integration-core/lib/sealed-export/vectors/s6a-package-provenance-pins.json
@@ -70,7 +70,7 @@
     "pluginPackageJson": "19900cc7df6b75da92ce6f69e4932e4ce5a707930d58c32bd67ba27f8ffef401",
     "pnpmLock": "8ca98ceef0c84b821c4b20a0f0cf0b50b87dfb51a26b6a2d21a9912a1733680f",
     "pluginIndex": "c2a800452d175e2b00a476b3e0d3fab6f65e16031789b91a0304dd1dc45a0cee",
-    "pluginHttpRoutes": "a314e2e5f911f8da9e164e858c87846ff55ea2777f15b258da37a0842eef156f",
+    "pluginHttpRoutes": "4f9214ef15a858a6c9c0a27a39bdb87595b019d0b59b130f153f2ab554d153d8",
     "s6aProvisioningCli": "d3320b27da7ab358ca068a3766a375e669fb6922f24ba0186ba0828c3e1d9da8",
     "s6aAcceptanceRunner": "eb58824cba1ab03361a6a4fba409f3f7a120dcda61d4c3d6cad2b82311d62624",
     "s6aOnpremRunbook": "1f4ba2b7fadbad0acb97e18d13f2be7ad6071fa372ac44e0aa4e17995e94c410",


### PR DESCRIPTION
## What changed

- add process-local K3 wire-attempt counters with a closed operation vocabulary
- classify and count at the adapter's canonical wire choke point after endpoint-intent validation and immediately before `fetch`
- expose an admin-only, read-only snapshot at `GET /api/integration/internal/k3-wise/call-audit`
- add coverage for GetDetail positive control, zero Save/Submit/Audit deltas, fixed response keys, value non-disclosure, and admin-only access

The snapshot contains only a version, `scope=process`, fixed operation names, and safe integers. It stores and returns no URL, path, query, credential, request body, response, tenant id, or business value. Counters reset on process restart. No database migration is added.

## Why

The controlled read-only closure in #4628 repeatedly reached a valid dry-run plan but could not prove independent K3 zero-write counters because Windows `pktmon` stop/convert parsing was unstable. This gives the server wrapper a deterministic baseline/after evidence source without packet capture.

## Verification

- `node plugins/plugin-integration-core/__tests__/k3-wise-adapters.test.cjs`
- `node plugins/plugin-integration-core/__tests__/http-routes.test.cjs`
- `node plugins/plugin-integration-core/__tests__/test-chain-completeness.test.cjs`
- syntax checks for all changed runtime files
- plugin test list executed item-by-item on Windows: all tests through the changed HTTP/K3 suites passed; unrelated repository sweeps that compare POSIX literal paths fail on Windows backslash paths and remain for Linux CI

## Operational boundaries

- no Apply/run/replay behavior is changed
- no K3 Save/Submit/Audit call is introduced
- no deployment, migration, or business-row read is authorized by this PR
- rollback is a code revert plus service restart; counters are process-local
