### PR TITLE
feat(integration): add entity read-only Apply gate

### DIFF
--- a/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
@@ -1941,11 +1941,11 @@ async function testPipelineExternalWriteApplyRoute() {
     assert.equal(calls.length, 0, 'deployment read-only gate refuses before loading pipeline/systems/adapters')
     assert.equal(storage.map.size, 0, 'deployment read-only gate cannot consume a token')
   } finally {
-    if (priorApplyDisabled === undefined) delete process.env.INTEGRATION_C6_WRITE_APPLY_DISABLED
-    else process.env.INTEGRATION_C6_WRITE_APPLY_DISABLED = priorApplyDisabled
+    delete process.env.INTEGRATION_C6_WRITE_APPLY_DISABLED
   }
 
-  let res = await invoke(routes, 'POST', '/api/integration/pipelines/:id/external-write/apply', {
+  try {
+    let res = await invoke(routes, 'POST', '/api/integration/pipelines/:id/external-write/apply', {
     user: WRITE_USER,
     params: { id: pipeline.id },
     body: { tenantId: 'tenant_1', workspaceId: 'workspace_1', confirm: {} },
@@ -2046,7 +2046,11 @@ async function testPipelineExternalWriteApplyRoute() {
   })
   assert.equal(res.statusCode, 400)
   assert.equal(res.body.error.code, 'C6_WRITE_APPLY_REQUEST_INVALID')
-  assert.equal(calls.length, callsBeforeNestedInject, 'client-supplied injection control is rejected before loading the pipeline')
+    assert.equal(calls.length, callsBeforeNestedInject, 'client-supplied injection control is rejected before loading the pipeline')
+  } finally {
+    if (priorApplyDisabled === undefined) delete process.env.INTEGRATION_C6_WRITE_APPLY_DISABLED
+    else process.env.INTEGRATION_C6_WRITE_APPLY_DISABLED = priorApplyDisabled
+  }
 }
 
 async function testPipelineExternalWriteApplyTestFailureInjectionRoute() {
@@ -8573,6 +8577,9 @@ async function testC6AdapterBackedTargetLoadsWithCredentials() {
 }
 
 async function main() {
+  const priorApplyDisabled = process.env.INTEGRATION_C6_WRITE_APPLY_DISABLED
+  delete process.env.INTEGRATION_C6_WRITE_APPLY_DISABLED
+  try {
   await testC6AdapterBackedTargetLoadsWithCredentials()
   await testTemplatesCrudRoutes()
   await testUnauthenticatedWriteRequestIsRejected()
@@ -8652,6 +8659,10 @@ async function main() {
   await testStagingInstallSteeringHasNoEffect()
 
   console.log('http-routes: REST auth/list/upsert/run/dry-run/staging/replay tests passed')
+  } finally {
+    if (priorApplyDisabled === undefined) delete process.env.INTEGRATION_C6_WRITE_APPLY_DISABLED
+    else process.env.INTEGRATION_C6_WRITE_APPLY_DISABLED = priorApplyDisabled
+  }
 }
 
 // W5b (#3890) P2-1: the headline fail-closed claim — WITHOUT the audit store every stock-prep write

--- a/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
@@ -1928,6 +1928,23 @@ async function testPipelineExternalWriteApplyRoute() {
     'external-write apply route registered',
   )
 
+  const priorApplyDisabled = process.env.INTEGRATION_C6_WRITE_APPLY_DISABLED
+  process.env.INTEGRATION_C6_WRITE_APPLY_DISABLED = ' true '
+  try {
+    const disabled = await invoke(routes, 'POST', '/api/integration/pipelines/:id/external-write/apply', {
+      user: WRITE_USER,
+      params: { id: pipeline.id },
+      body: { tenantId: 'tenant_1', workspaceId: 'workspace_1', confirm: { dryRunToken: 'must-not-be-consumed' } },
+    })
+    assert.equal(disabled.statusCode, 403)
+    assert.equal(disabled.body.error.code, 'C6_WRITE_APPLY_DISABLED')
+    assert.equal(calls.length, 0, 'deployment read-only gate refuses before loading pipeline/systems/adapters')
+    assert.equal(storage.map.size, 0, 'deployment read-only gate cannot consume a token')
+  } finally {
+    if (priorApplyDisabled === undefined) delete process.env.INTEGRATION_C6_WRITE_APPLY_DISABLED
+    else process.env.INTEGRATION_C6_WRITE_APPLY_DISABLED = priorApplyDisabled
+  }
+
   let res = await invoke(routes, 'POST', '/api/integration/pipelines/:id/external-write/apply', {
     user: WRITE_USER,
     params: { id: pipeline.id },

--- a/plugins/plugin-integration-core/lib/http-routes.cjs
+++ b/plugins/plugin-integration-core/lib/http-routes.cjs
@@ -621,6 +621,14 @@ function stockPreparationPlmAutoPersistEnabled() {
   return String(process.env.MULTITABLE_STOCK_PREP_PLM_AUTOPERSIST_ENABLED ?? '').trim().toLowerCase() === 'true'
 }
 
+// Entity-level delivery containment. This negative gate is intentionally
+// independent from the dry-run route: an internal evaluation environment can
+// keep previews usable while refusing every C6 Apply before request parsing,
+// token consumption, pipeline loading, or adapter/network activity.
+function c6WriteApplyDisabled() {
+  return String(process.env.INTEGRATION_C6_WRITE_APPLY_DISABLED ?? '').trim().toLowerCase() === 'true'
+}
+
 // T3b OD-2 (layered semantics — deliberately NOT a copy of the ERP guard): with auto-persist ON the
 // PLM source-run gains a write side-effect, so an explicit tenantId on ANY carrier is a steering
 // vector and is rejected fail-closed BEFORE body normalization and any I/O. projectId differs from
@@ -3514,6 +3522,9 @@ function createHandlers(services, options = {}) {
 
     async pipelinesExternalWriteApply(req, res) {
       requireAccess(req, 'write')
+      if (c6WriteApplyDisabled()) {
+        throw new HttpRouteError(403, 'C6_WRITE_APPLY_DISABLED', 'C6 external-write Apply is disabled for this deployment')
+      }
       const body = normalizeC6WriteApplyBody(requestBody(req))
       const scope = scopedInput(req, {
         id: requestParams(req).id,

--- a/plugins/plugin-integration-core/lib/sealed-export/vectors/s6a-package-provenance-pins.json
+++ b/plugins/plugin-integration-core/lib/sealed-export/vectors/s6a-package-provenance-pins.json
@@ -70,7 +70,7 @@
     "pluginPackageJson": "19900cc7df6b75da92ce6f69e4932e4ce5a707930d58c32bd67ba27f8ffef401",
     "pnpmLock": "8ca98ceef0c84b821c4b20a0f0cf0b50b87dfb51a26b6a2d21a9912a1733680f",
     "pluginIndex": "c2a800452d175e2b00a476b3e0d3fab6f65e16031789b91a0304dd1dc45a0cee",
-    "pluginHttpRoutes": "4f9214ef15a858a6c9c0a27a39bdb87595b019d0b59b130f153f2ab554d153d8",
+    "pluginHttpRoutes": "acb99c38856ccb11a9308d7995761cc9abd47c86edaf7b01c4f655a2405012d1",
     "s6aProvisioningCli": "d3320b27da7ab358ca068a3766a375e669fb6922f24ba0186ba0828c3e1d9da8",
     "s6aAcceptanceRunner": "eb58824cba1ab03361a6a4fba409f3f7a120dcda61d4c3d6cad2b82311d62624",
     "s6aOnpremRunbook": "1f4ba2b7fadbad0acb97e18d13f2be7ad6071fa372ac44e0aa4e17995e94c410",


### PR DESCRIPTION
## Summary

- add an entity-level `INTEGRATION_C6_WRITE_APPLY_DISABLED=true` containment gate
- reject C6 Apply with a fixed 403 before body parsing, token consumption, pipeline/system loading, adapter creation, or network activity
- keep the external-write dry-run route unchanged and usable for internal read-only delivery
- refresh the sealed `pluginHttpRoutes` pin from the staged Git blob

## Safety boundary

This PR performs no deployment, migration, K3 call, credential change, or business-row read. The flag is opt-in and affects only C6 external-write Apply. Existing authorization, token, Save-only, Submit/Audit and row-limit gates remain unchanged when the flag is absent/false.

## Verification

- `node --check plugins/plugin-integration-core/lib/http-routes.cjs`
- `node plugins/plugin-integration-core/__tests__/http-routes.test.cjs`
- `node plugins/plugin-integration-core/__tests__/test-chain-completeness.test.cjs`
- `git diff --check`

Target delivery context: #4861. This PR enables the immediate internal read-only release path; it does not authorize the write-bearing Apply/rollback operation described there.
