### PR TITLE
feat(dingtalk): add staging alias cutover canary

### DIFF
--- a/.github/workflows/dingtalk-lifecycle-staging-canary.yml
+++ b/.github/workflows/dingtalk-lifecycle-staging-canary.yml
@@ -5,14 +5,21 @@ run-name: "DingTalk Lifecycle Staging Canary: ${{ inputs.action }}${{ inputs.act
 # Staging-only MINIMAL SAFE operator lane for DingTalk lifecycle env gates.
 # One dispatch = ONE action. All lifecycle flags remain OFF by default.
 #
-# EXECUTABLE: status | preflight | off
-#   off = emergency env-gate clear of the three lifecycle flags only (with
-#   previous-override restore on restart/health/mode failure).
+# EXECUTABLE: status | preflight | off | alias
+#   off   = emergency env-gate clear of the three lifecycle flags only (with
+#           previous-override restore on restart/health/mode failure).
+#   alias = TRANSIENT secret-backed alias cutover canary. Success requires/proves
+#           OFF; failure restores the OFF override before failing. Runtime OFF
+#           cannot be proven if rollback recreate itself fails. Requires full
+#           deploy SHA, expected_current_mode=off, secrets.ATTENDANCE_ADMIN_JWT
+#           + secrets.LIFECYCLE_CANARY_LOGIN_IDENTIFIER
+#           + secrets.LIFECYCLE_CANARY_LOGIN_PASSWORD (materialized as chmod-600
+#           files; never shell-interpolated into remote argv/logs).
 #
-# NOT EXECUTABLE: alias | pending | deprovision
+# NOT EXECUTABLE: pending | deprovision
 #   Fail-closed preflight-only. Env flip alone is not a canary — there is no
-#   secret-backed real verifier for password-login proof, admit→activate, or
-#   sync→deprovision. transition_applied is always false for these actions.
+#   secret-backed real verifier for admit→activate or sync→deprovision.
+#   transition_applied is always false for these actions.
 #
 # See:
 #   docs/development/dingtalk-lifecycle-canary-separate-go-20260724.md
@@ -25,25 +32,25 @@ on:
   workflow_dispatch:
     inputs:
       action:
-        description: 'status/preflight/off = executable; alias/pending/deprovision = NOT EXECUTABLE (fail-closed preflight-only)'
+        description: 'status/preflight/off/alias = executable; pending/deprovision = NOT EXECUTABLE (fail-closed preflight-only)'
         required: true
         type: choice
         # Quote 'off' — YAML 1.1 bare off becomes boolean false.
         options: [status, preflight, 'off', alias, pending, deprovision]
         default: status
       target_mode:
-        description: 'preflight only: target mode to assess (off|alias|pending|deprovision). ON targets assess readiness only — never apply.'
+        description: 'preflight only: target mode to assess (off|alias|pending|deprovision). pending/deprovision assess readiness only — never apply.'
         required: false
         type: choice
         options: ['off', alias, pending, deprovision]
         default: 'off'
       expected_current_mode:
-        description: 'Required for action=off: live mode before clear (off|alias|pending|deprovision|multi-on). Optional for preflight.'
+        description: 'Required for action=off (live mode before clear) and action=alias (must be off). Optional for preflight.'
         required: false
         type: string
         default: ''
       deploy_sha:
-        description: 'FULL 40-char lowercase commit SHA currently deployed on staging. Required for action=off; optional exact-match for preflight.'
+        description: 'FULL 40-char lowercase commit SHA currently deployed on staging. Required for action=off and action=alias; optional exact-match for preflight.'
         required: false
         default: ''
 
@@ -59,7 +66,7 @@ permissions:
 jobs:
   run:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -70,6 +77,9 @@ jobs:
           TARGET_MODE: ${{ inputs.target_mode }}
           EXPECTED_CURRENT_MODE: ${{ inputs.expected_current_mode }}
           DEPLOY_SHA: ${{ inputs.deploy_sha }}
+          # Intentionally NO alias login secrets here — presence is checked only in
+          # Run remote action after demoting env → non-exported shell vars + unset
+          # (bash -n and other children must not inherit raw secret env).
         run: |
           set -euo pipefail
           case "$ACTION" in status|preflight|off|alias|pending|deprovision) ;; *)
@@ -86,7 +96,7 @@ jobs:
             ;; esac
           fi
 
-          # Only action=off is an executable transition (env write).
+          # action=off is an executable emergency clear.
           if [[ "$ACTION" == "off" ]]; then
             if [[ -z "$EXPECTED_CURRENT_MODE" ]]; then
               echo "expected_current_mode is required for action=off (use multi-on when live is multi-on)" >&2
@@ -98,13 +108,26 @@ jobs:
             fi
           fi
 
+          # action=alias: structural inputs only here. Secret presence is checked in
+          # Run remote action (success requires/proves OFF; failure restores OFF override first).
+          if [[ "$ACTION" == "alias" ]]; then
+            if [[ "$EXPECTED_CURRENT_MODE" != "off" ]]; then
+              echo "expected_current_mode must be exactly 'off' for action=alias (no auto-selection)" >&2
+              exit 2
+            fi
+            if [[ ! "$DEPLOY_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+              echo "deploy_sha must be the FULL 40-char lowercase commit SHA for action=alias, got: '$DEPLOY_SHA'" >&2
+              exit 2
+            fi
+          fi
+
           if [[ -n "$DEPLOY_SHA" && ! "$DEPLOY_SHA" =~ ^[0-9a-f]{40}$ ]]; then
             echo "deploy_sha must be empty or the FULL 40-char lowercase commit SHA, got: '$DEPLOY_SHA'" >&2
             exit 2
           fi
 
-          # Document that alias/pending/deprovision are NOT EXECUTABLE (remote fails closed).
-          if [[ "$ACTION" == "alias" || "$ACTION" == "pending" || "$ACTION" == "deprovision" ]]; then
+          # Document that pending/deprovision are NOT EXECUTABLE (remote fails closed).
+          if [[ "$ACTION" == "pending" || "$ACTION" == "deprovision" ]]; then
             echo "NOTE: action=$ACTION is NOT EXECUTABLE in this lane (no real verifier). Remote will fail-closed with transition_applied=false." >&2
           fi
 
@@ -150,8 +173,24 @@ jobs:
           EXPECTED_CURRENT_MODE: ${{ inputs.expected_current_mode }}
           DEPLOY_SHA: ${{ inputs.deploy_sha }}
           RUNNER_DIR: ${{ steps.sync.outputs.runner_dir }}
+          # Alias secrets are materialized INSIDE this step under EXIT trap — never
+          # via a prior step secrets_dir output (cross-step leak / cancel gap).
+          ATTENDANCE_ADMIN_JWT: ${{ secrets.ATTENDANCE_ADMIN_JWT }}
+          LIFECYCLE_CANARY_LOGIN_IDENTIFIER: ${{ secrets.LIFECYCLE_CANARY_LOGIN_IDENTIFIER }}
+          LIFECYCLE_CANARY_LOGIN_PASSWORD: ${{ secrets.LIFECYCLE_CANARY_LOGIN_PASSWORD }}
         run: |
           set -euo pipefail
+          # --- SECRET DEMOTE (builtins only; no external child before unset) -------------
+          # GHA injects secrets as exported env for this step. Copy into non-exported
+          # shell variables, then unset the exported names so mktemp/ssh/scp/bash -n
+          # children never inherit raw secret env. Presence checks + printf use the
+          # shell vars only; those are unset immediately after materialize writes.
+          _CANARY_JWT="${ATTENDANCE_ADMIN_JWT-}"
+          _CANARY_IDENT="${LIFECYCLE_CANARY_LOGIN_IDENTIFIER-}"
+          _CANARY_PASS="${LIFECYCLE_CANARY_LOGIN_PASSWORD-}"
+          unset ATTENDANCE_ADMIN_JWT LIFECYCLE_CANARY_LOGIN_IDENTIFIER LIFECYCLE_CANARY_LOGIN_PASSWORD
+          # --- end secret demote; external commands allowed after this point ------------
+
           ssh_opts="-o StrictHostKeyChecking=yes -o UserKnownHostsFile=$HOME/.ssh/known_hosts -o IdentitiesOnly=yes -i $HOME/.ssh/deploy_key"
           DEPLOY_PATH="${DEPLOY_PATH:-metasheet2}"
           for pair in "DEPLOY_PATH=$DEPLOY_PATH" "STAGING_DEPLOY_PATH=$STAGING_DEPLOY_PATH"; do
@@ -166,6 +205,94 @@ jobs:
           echo "artifact_name=$artifact_name" >> "$GITHUB_OUTPUT"
           mkdir -p output/lifecycle-canary
 
+          # Per-run cleanup targets only. NEVER touch persistent ~/.metasheet2 overrides.
+          CLEAN_LOCAL_SECRETS_DIR=""
+          CLEAN_REMOTE_SECRETS_DIR=""
+          CLEAN_REMOTE_RUNNER_DIR="${RUNNER_DIR}"
+          CLEAN_REMOTE_OUTPUT_DIR="${remote_output_dir}"
+          # OUTPUT_COLLECTED gates whether trap may remove remote_output_dir before scp.
+          OUTPUT_COLLECTED=0
+
+          cleanup_canary_ephemeral_paths() {
+            # EXIT/INT/TERM: wipe local secret temp dir + per-run remote dirs.
+            # Does not delete persistent lifecycle/attendance overrides under .metasheet2.
+            set +e
+            if [[ -n "${CLEAN_LOCAL_SECRETS_DIR:-}" && -d "${CLEAN_LOCAL_SECRETS_DIR}" ]]; then
+              rm -rf "${CLEAN_LOCAL_SECRETS_DIR}"
+            fi
+            if [[ -n "${DEPLOY_USER:-}" && -n "${DEPLOY_HOST:-}" ]]; then
+              remote_rm=""
+              if [[ -n "${CLEAN_REMOTE_SECRETS_DIR:-}" ]]; then
+                remote_rm="${remote_rm} ${CLEAN_REMOTE_SECRETS_DIR}"
+              fi
+              if [[ -n "${CLEAN_REMOTE_RUNNER_DIR:-}" ]]; then
+                remote_rm="${remote_rm} ${CLEAN_REMOTE_RUNNER_DIR}"
+              fi
+              # Preserve remote_output_dir until artifacts are collected (or early fail).
+              if [[ "${OUTPUT_COLLECTED}" == "1" && -n "${CLEAN_REMOTE_OUTPUT_DIR:-}" ]]; then
+                remote_rm="${remote_rm} ${CLEAN_REMOTE_OUTPUT_DIR}"
+              fi
+              if [[ -n "${remote_rm// /}" ]]; then
+                # shellcheck disable=SC2086
+                ssh $ssh_opts "$DEPLOY_USER@$DEPLOY_HOST" \
+                  "bash -o pipefail -c 'rm -rf ${remote_rm}'" >/dev/null 2>&1
+              fi
+            fi
+            set -e
+          }
+
+          # For alias: materialize chmod-600 secret files LOCALLY under EXIT trap, then
+          # scp path-only into the per-run remote directory. Never pass secrets_dir
+          # across steps (cancel/failure gap). Password written with printf '%s' (exact bytes).
+          remote_secrets_dir=""
+          canary_jwt_export=""
+          canary_ident_export=""
+          canary_pass_export=""
+          if [[ "$ACTION" == "alias" ]]; then
+            # Install trap BEFORE any secret materialization (mktemp/write/chmod).
+            trap cleanup_canary_ephemeral_paths EXIT INT TERM
+            # Presence via non-exported shell vars only (env already unset above).
+            if [[ -z "${_CANARY_JWT}" || -z "${_CANARY_IDENT}" || -z "${_CANARY_PASS}" ]]; then
+              echo "alias requires ATTENDANCE_ADMIN_JWT + LIFECYCLE_CANARY_LOGIN_IDENTIFIER/PASSWORD (checked in Run remote action only)" >&2
+              unset _CANARY_JWT _CANARY_IDENT _CANARY_PASS
+              exit 2
+            fi
+            secrets_dir="$(mktemp -d "${RUNNER_TEMP}/lifecycle-canary-secrets.XXXXXX")"
+            # Register for trap wipe immediately after mktemp succeeds (before write/chmod).
+            CLEAN_LOCAL_SECRETS_DIR="${secrets_dir}"
+            chmod 700 "$secrets_dir"
+            umask 077
+            # Exact secret bytes from non-exported shell vars — printf '%s' preserves payload.
+            printf '%s' "${_CANARY_JWT}" > "${secrets_dir}/admin.jwt"
+            printf '%s' "${_CANARY_IDENT}" > "${secrets_dir}/login.identifier"
+            printf '%s' "${_CANARY_PASS}" > "${secrets_dir}/login.password"
+            # Drop shell-held secret values as soon as files are written.
+            unset _CANARY_JWT _CANARY_IDENT _CANARY_PASS
+            chmod 600 "${secrets_dir}/admin.jwt" "${secrets_dir}/login.identifier" "${secrets_dir}/login.password"
+            for f in admin.jwt login.identifier login.password; do
+              [[ -s "${secrets_dir}/${f}" ]] || { echo "secret file empty after materialize: ${f}" >&2; exit 2; }
+            done
+            remote_secrets_dir="${RUNNER_DIR}/.canary-secrets"
+            CLEAN_REMOTE_SECRETS_DIR="${remote_secrets_dir}"
+            # Remote copy only after local materialize succeeded under trap coverage.
+            ssh $ssh_opts "$DEPLOY_USER@$DEPLOY_HOST" \
+              "bash -o pipefail -c 'set -euo pipefail; mkdir -p ${remote_secrets_dir}; chmod 700 ${remote_secrets_dir}'"
+            scp $ssh_opts \
+              "${secrets_dir}/admin.jwt" \
+              "${secrets_dir}/login.identifier" \
+              "${secrets_dir}/login.password" \
+              "$DEPLOY_USER@$DEPLOY_HOST:${remote_secrets_dir}/"
+            ssh $ssh_opts "$DEPLOY_USER@$DEPLOY_HOST" \
+              "bash -o pipefail -c 'set -euo pipefail; chmod 600 ${remote_secrets_dir}/admin.jwt ${remote_secrets_dir}/login.identifier ${remote_secrets_dir}/login.password'"
+            canary_jwt_export="export CANARY_ADMIN_JWT_FILE='${remote_secrets_dir}/admin.jwt'"
+            canary_ident_export="export CANARY_LOGIN_IDENTIFIER_FILE='${remote_secrets_dir}/login.identifier'"
+            canary_pass_export="export CANARY_LOGIN_PASSWORD_FILE='${remote_secrets_dir}/login.password'"
+          else
+            # Non-alias: drop any unused shell copies; clean per-run runner/output on exit.
+            unset _CANARY_JWT _CANARY_IDENT _CANARY_PASS
+            trap cleanup_canary_ephemeral_paths EXIT INT TERM
+          fi
+
           remote_script="set -euo pipefail
           export ACTION='${ACTION}'
           export TARGET_MODE='${TARGET_MODE}'
@@ -175,9 +302,18 @@ jobs:
           export DEPLOY_PATH='${DEPLOY_PATH}'
           export OUTPUT_DIR='${remote_output_dir}'
           export RUN_STAMP='gh${GITHUB_RUN_ID}a${GITHUB_RUN_ATTEMPT}'
+          ${canary_jwt_export}
+          ${canary_ident_export}
+          ${canary_pass_export}
           rm -rf '${remote_output_dir}'
           mkdir -p '${remote_output_dir}'
-          bash '${RUNNER_DIR}/dingtalk-lifecycle-staging-canary-remote.sh'"
+          set +e
+          bash '${RUNNER_DIR}/dingtalk-lifecycle-staging-canary-remote.sh'
+          remote_action_rc=\$?
+          set -e
+          # Best-effort in-script secret wipe; EXIT trap also removes secrets/runner.
+          if [[ -n '${remote_secrets_dir}' ]]; then rm -rf '${remote_secrets_dir}'; fi
+          exit \"\${remote_action_rc}\""
           escaped_script="$(printf '%s' "$remote_script" | sed "s/'/'\\\\''/g")"
 
           set +e
@@ -187,7 +323,9 @@ jobs:
           scp $ssh_opts -r "$DEPLOY_USER@$DEPLOY_HOST:${remote_output_dir}/." output/lifecycle-canary/ 2>&1 \
             | tee -a output/lifecycle-canary/ssh.log
           scp_rc=${PIPESTATUS[0]}
-          # Cleanup removes ONLY per-run dirs. NEVER touch persistent overrides.
+          # Mark collected so EXIT trap may remove remote_output_dir (per-run only).
+          OUTPUT_COLLECTED=1
+          # Explicit cleanup (also covered by trap). NEVER touch persistent overrides.
           ssh $ssh_opts "$DEPLOY_USER@$DEPLOY_HOST" \
             "bash -o pipefail -c 'rm -rf ${remote_output_dir} ${RUNNER_DIR}'" \
             >> output/lifecycle-canary/ssh.log 2>&1
@@ -220,9 +358,11 @@ jobs:
             echo "- Remote rc: \`${REMOTE_RC:-missing}\`"
             echo "- Artifact: \`${ARTIFACT_NAME:-missing}\`"
             echo ""
-            echo "**Executable:** status / preflight / off only."
-            echo "**NOT EXECUTABLE:** alias / pending / deprovision (no real canary verifier)."
+            echo "**Executable:** status / preflight / off / alias (alias success requires/proves OFF; failure restores OFF override before failing)."
+            echo "**NOT EXECUTABLE:** pending / deprovision (no real canary verifier)."
             echo "OFF is emergency env-gate rollback only — not OR-column design reintroduction."
+            echo "Alias canary requires ATTENDANCE_ADMIN_JWT + LIFECYCLE_CANARY_LOGIN_IDENTIFIER/PASSWORD secrets (file transport)."
+            echo "Runtime OFF cannot be proven if alias rollback recreate itself fails (override restored on disk)."
             if [[ -f output/lifecycle-canary/summary.txt ]]; then
               echo ""
               echo '```text'

--- a/docs/development/dingtalk-lifecycle-canary-separate-go-20260724.md
+++ b/docs/development/dingtalk-lifecycle-canary-separate-go-20260724.md
@@ -1,7 +1,7 @@
 # DingTalk lifecycle canary — separate ops GO (not auto-enabled)
 
 **Date:** 2026-07-24
-**Updated:** 2026-08-11 (OFF baseline verified; ON transitions **NOT EXECUTABLE**; ON canary **NOT EXECUTED**)
+**Updated:** 2026-08-11 (alias lane made executable as a **transient** secret-backed cutover; success requires/proves OFF; failure restores the OFF override before failing; pending/deprovision remain **NOT EXECUTABLE**; no successful ON canary run claimed here)
 **Related locks:**
 - `dingtalk-directory-admission-activation-lifecycle-design-20260723.md` Rev 4.2
 - `dingtalk-deprovision-reactivation-and-evidence-chain-design-20260723.md` Rev 4.2
@@ -12,11 +12,11 @@
 | Flag / action | Default after code land | Executable in this lane? |
 |---------------|-------------------------|--------------------------|
 | `DIRECTORY_PENDING_ACTIVATION_ENABLED` ON | **OFF** | **NOT EXECUTABLE** — no admit→activate verifier |
-| `AUTH_LOGIN_USE_ALIASES` ON (T2b cutover) | **OFF** | **NOT EXECUTABLE** — no password-login success/rollback proof |
+| `AUTH_LOGIN_USE_ALIASES` ON (T2b cutover) | **OFF** | **Executable only as a transient canary** (`action=alias`). Success requires/proves OFF in the same run; failure restores the OFF override before failing. Runtime OFF cannot be proven if rollback recreate itself fails (override restored on disk). Requires secret-backed password login + admin JWT. |
 | `DIRECTORY_DEPROVISION_ENABLED` ON | **OFF** | **NOT EXECUTABLE** — no sync→deprovision verifier |
 | Env-gate clear (`action=off`) | n/a | Executable emergency only (after migrations true + exact SHA) |
 
-Presence of canary subject/integration/owner tokens is **not** a real canary and is **not** accepted as an ON enabler.
+Presence of canary subject/integration/owner tokens is **not** a real canary and is **not** accepted as an ON enabler. There is **no** auto-selection of login identities, **no** password reset path, and **no** production fallback.
 
 ## Staging operator lane (minimal safe)
 
@@ -31,17 +31,44 @@ Presence of canary subject/integration/owner tokens is **not** a real canary and
 | `status` | yes | values-free snapshot; multi-on fail-closed after report |
 | `preflight` | yes | readiness only; `migrations_pending_zero` must be exactly `true` (unknown fails) |
 | `off` | yes | emergency clear of the three env gates; previous-override restore on failure; health true after restart required |
-| `alias` / `pending` / `deprovision` | **NOT EXECUTABLE** | fail-closed preflight-only; `transition_applied=false` always |
+| `alias` | yes (transient) | secret-backed cutover canary; see sequence below; success requires/proves OFF |
+| `pending` / `deprovision` | **NOT EXECUTABLE** | fail-closed preflight-only; `transition_applied=false` always |
 
-Shared concurrency with `attendance-staging-window-runner`. Status artifacts stay values-free.
+Shared concurrency with `attendance-staging-window-runner`. Status artifacts stay values-free (booleans / counts / reason enums / SHA only).
 
 ### Alias OFF vs design lock (no OR-column fallback)
 
 `action=off` is an **emergency operational rollback of the env gate only**. Design lock Rev 4.2 §4.2 / §4.4 forbids reintroducing OR-column fallback on `users.email` / `username` / `mobile` as a long-term design after T2b. OFF is not canary completion and is not product permission to restore pre-T2b OR login.
 
+### `action=alias` — transient secret-backed cutover canary
+
+**Required inputs / secrets (no auto-selection):**
+
+- `deploy_sha` — full 40-char lowercase staging deploy SHA
+- `expected_current_mode=off` (strict; refuse other values)
+- `secrets.ATTENDANCE_ADMIN_JWT` — platform-admin JWT for `POST /api/admin/login-aliases/backfill` and `GET /api/admin/login-aliases/cutover-status`
+- `secrets.LIFECYCLE_CANARY_LOGIN_IDENTIFIER` — real staging login identifier (email/username/mobile already claimed or claimable)
+- `secrets.LIFECYCLE_CANARY_LOGIN_PASSWORD` — real password for that identifier (read exactly as stored; no CR/LF strip)
+
+**Secret transport:** only the **Run remote action** step receives the three alias secrets as step env. Its first lines (builtins only) copy them into **non-exported** shell variables and **unset** the exported names so no external child (`mktemp`, `ssh`, `scp`, `bash`) inherits raw secret env. Then it installs an `EXIT`/`INT`/`TERM` cleanup trap **before** `mktemp`, writes JWT/identifier/password as local `chmod 600` files via `printf '%s'` from the shell variables (exact password bytes), **unsets the shell variables immediately after the writes**, then remote `mkdir`/`scp` path-only into the per-run remote directory, exports **file paths only** (`CANARY_*_FILE`) to the remote script, and deletes local temp + per-run remote secrets/runner paths on every exit path. The **Validate inputs** step does **not** receive or check those secrets (so `bash -n` cannot inherit them). Secrets are **not** materialized in a prior step or passed via a `secrets_dir` output. Values must not appear in shell argv, process listings via exported env, logs, or artifacts. Persistent `~/.metasheet2` overrides are never deleted by this cleanup.
+
+**Remote sequence (fail closed; any post-write failure restores OFF override before failing):**
+
+1. Prove exact SHA (image tag + health commit agree), backend health true, `migrations_pending_zero=true`, live mode `off`.
+2. Real `POST /api/auth/login` with secret identifier/password (**pre-ON**).
+3. Authenticated `POST /api/admin/login-aliases/backfill` (admin JWT) — require success; **exact nonnegative integer counts** with **`collisions==0`** (nonzero collisions refuse env write; alias-only would lock collided users out).
+4. Authenticated `GET /api/admin/login-aliases/cutover-status` — require `ready=true` and `canEnableCutover=true`.
+5. Establish a **compose-validated explicit OFF** rollback baseline on disk (all three flags false) and snapshot it — **never** restore an arbitrary prior on-disk file (a stale unapplied `alias=true` override would re-enable alias after recreate). Arm the remote `EXIT`/`HUP`/`INT`/`TERM`/`PIPE` rollback guard **before** the persistent ON write; it remains armed until runtime OFF and the post-rollback login are proven. Emergency recovery logs to the remote per-run output file rather than the possibly broken SSH stream. Then write `AUTH_LOGIN_USE_ALIASES=true` with pending/deprovision false; recreate **backend only** (Postgres/Redis container IDs unchanged).
+6. Prove exact SHA, mode `alias`, health true, and real password login (**post-ON**).
+7. Restore the **explicit OFF baseline** (success and post-write failure paths); recreate backend only; prove exact mode `off`, health, SHA, and real password login (**post-rollback**). **Success requires/proves OFF.** The canary leaves the persistent lifecycle override **explicitly OFF**. If rollback recreate fails, **runtime OFF cannot be proven** (OFF baseline restored on disk; operator must inspect).
+
+Backfill alias rows **may persist** after the run. Artifacts report only booleans / counts / reason enums / SHA — never credentials, identifiers, tokens, or PII.
+
+**Repo state note:** `ATTENDANCE_ADMIN_JWT` may already exist; `LIFECYCLE_CANARY_LOGIN_IDENTIFIER` / `LIFECYCLE_CANARY_LOGIN_PASSWORD` are new secrets that must be configured before a real alias dispatch. Landing this code does **not** configure those secrets and does **not** claim a successful canary execution.
+
 ## Current staging baseline (ON canary NOT EXECUTED)
 
-As of 2026-08-11 this lane remains **NOT EXECUTED** for lifecycle ON canaries. Safe preparation evidence:
+As of 2026-08-11 this lane remains **NOT EXECUTED** for a completed alias cutover canary run (secrets for identifier/password may be absent; no invented success). Safe preparation evidence for the OFF baseline:
 
 1. Attendance staging runner [run 31407444155](https://github.com/zensgit/metasheet2/actions/runs/31407444155) completed backup + clone rehearsal + real apply: migration state `296 applied / 18 pending` -> `314 applied / 0 pending`; rehearsal isolation held and auth round-trip returned 200.
 2. [#4853](https://github.com/zensgit/metasheet2/pull/4853), merge commit `ddec28b12ebff97fae33af45553d77c149d816e1`, installs and validates the checked-out staging Compose file, pins Compose project-directory, and derives build metadata from the exact `IMAGE_TAG`.
@@ -50,25 +77,24 @@ As of 2026-08-11 this lane remains **NOT EXECUTED** for lifecycle ON canaries. S
 5. Lifecycle [preflight 31419066036](https://github.com/zensgit/metasheet2/actions/runs/31419066036) proved `preflight_target_mode=off`, `preflight_ok=true`, and `transition_applied=false`. No env write occurred.
 6. The existing `DEPLOY_KNOWN_HOSTS` secret is the independently verified deploy-host identity. The lane uses `StrictHostKeyChecking=yes`; missing host identity blocks dispatch rather than producing forgeable evidence.
 
-The former image-tag/health-commit provenance conflict is resolved. This establishes only the safe OFF baseline, not an ON canary.
+The former image-tag/health-commit provenance conflict is resolved. This establishes only the safe OFF baseline, not an executed alias canary.
 
 Until a **secret-backed real verifier** exists for:
 
-- alias: real password-login success + documented emergency off proof (without OR fallback),
 - pending: real admit→activate on an explicit canary subject,
 - deprovision: real sync→deprovision on an explicit canary integration,
 
-the ON actions stay **NOT EXECUTABLE**. Do not treat env flips or presence tokens as canary completion.
+those ON actions stay **NOT EXECUTABLE**. Alias now has a verifier path in this lane, but a successful run still requires configured secrets + operator dispatch and is **NOT EXECUTED** by this documentation alone.
 
-## Future canary sequence (when a real verifier + ops GO exist)
+## Future canary sequence (when secrets + ops GO exist)
 
 1. Staging: deploy exact SHA; image and health provenance agree; migrations pending=0 via backup/clone-rehearsal.
-2. T2a backfill + collision report.
-3. Real alias login proof → only then an executable alias ON (not this lane today).
-4. Real admit→activate on explicit ids → only then pending ON.
+2. Configure `LIFECYCLE_CANARY_LOGIN_IDENTIFIER` / `LIFECYCLE_CANARY_LOGIN_PASSWORD` (plus existing `ATTENDANCE_ADMIN_JWT`).
+3. Dispatch `action=alias` with full `deploy_sha` and `expected_current_mode=off` — transient ON proof + OFF success proof (or OFF override restore on failure).
+4. Real admit→activate on explicit ids → only then pending ON (still not this lane today).
 5. Real deprovision proof → only then deprovision ON.
 6. Production = separate GO.
 
 ## Owner note
 
-Landing this lane ≠ authorizing traffic. **Canary NOT EXECUTED.** Merging code does not complete lifecycle canary.
+Landing this lane ≠ authorizing traffic and ≠ completing canary. **Alias cutover canary NOT EXECUTED** until a real dispatch with secrets succeeds. Merging code does not leave `AUTH_LOGIN_USE_ALIASES` enabled and does not complete lifecycle canary.

--- a/scripts/ops/dingtalk-lifecycle-staging-canary-contract.test.mjs
+++ b/scripts/ops/dingtalk-lifecycle-staging-canary-contract.test.mjs
@@ -2,12 +2,17 @@
 // dingtalk-lifecycle-staging-canary-contract.test.mjs
 //
 // Durable synthetic contract for the MINIMAL SAFE staging lifecycle lane:
-//   EXECUTABLE: status | preflight | off
-//   NOT EXECUTABLE: alias | pending | deprovision (fail-closed preflight-only)
+//   EXECUTABLE: status | preflight | off | alias
+//   NOT EXECUTABLE: pending | deprovision (fail-closed preflight-only)
 //
+// Alias is a TRANSIENT secret-backed cutover canary: success requires/proves OFF;
+// failure restores the OFF override before failing. Runtime OFF cannot be proven
+// if rollback recreate itself fails.
 // Load-bearing mutations for owner P1/P2 gaps:
-//   * migrations_pending_zero unknown must fail preflight/off (never success)
-//   * alias/pending/deprovision never apply (transition_applied=false; NOT EXECUTABLE)
+//   * migrations_pending_zero unknown must fail preflight/off/alias (never success)
+//   * pending/deprovision never apply (transition_applied=false; NOT EXECUTABLE)
+//   * alias requires pre-login, backfill, readiness, post-ON login, rollback,
+//     post-rollback login, exact SHA, migrations, and secret-file transport
 //   * recreate requires health true after restart
 //   * previous-override restore on transition failure
 //   * multi-on: status/preflight fail closed; off still clears via classify_mode
@@ -16,11 +21,15 @@
 
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
-import { spawnSync } from 'node:child_process'
+import { spawn, spawnSync } from 'node:child_process'
 import {
   existsSync,
+  mkdtempSync,
   readFileSync,
+  writeFileSync,
+  rmSync,
 } from 'node:fs'
+import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { createRequire } from 'node:module'
 import { fileURLToPath } from 'node:url'
@@ -90,6 +99,22 @@ function workflowOn(doc) {
   return doc.on ?? doc.true ?? doc[true]
 }
 
+function actionAliasBody(source) {
+  const start = source.indexOf('action_alias()')
+  assert.notEqual(start, -1, 'action_alias() must exist')
+  const end = source.indexOf('\n# --- main', start)
+  assert.notEqual(end, -1, 'main marker after action_alias')
+  return source.slice(start, end)
+}
+
+function actionOffBody(source) {
+  const start = source.indexOf('action_off()')
+  assert.notEqual(start, -1, 'action_off() must exist')
+  const end = source.indexOf('\naction_alias()', start)
+  assert.notEqual(end, -1, 'action_alias after action_off')
+  return source.slice(start, end)
+}
+
 // --- parse / presence -----------------------------------------------------------------
 
 test('remote script and workflow files exist', () => {
@@ -120,7 +145,7 @@ test('PR contract workflow executes this exact suite without changing the sealed
 
 // --- workflow shape -------------------------------------------------------------------
 
-test('workflow action choices include status/preflight/off and non-executable ON names', () => {
+test('workflow action choices include status/preflight/off/alias and non-executable ON names', () => {
   const options = workflowOn(loadYaml(read(WORKFLOW))).workflow_dispatch.inputs.action.options
   assert.deepEqual(options, ['status', 'preflight', 'off', 'alias', 'pending', 'deprovision'])
   assert.ok(options.every((o) => typeof o === 'string'), 'quote off so YAML 1.1 keeps string')
@@ -156,14 +181,159 @@ test('SSH transport requires a pinned known_hosts secret', () => {
   assert.doesNotMatch(yaml, /StrictHostKeyChecking=no/)
 })
 
-test('workflow only requires deploy_sha + expected_current_mode for action=off (not for ON names)', () => {
+test('workflow requires deploy_sha + expected_current for off and alias; pending/deprovision NOT EXECUTABLE', () => {
   const yaml = read(WORKFLOW)
   assert.match(yaml, /expected_current_mode is required for action=off/)
+  assert.match(yaml, /expected_current_mode must be exactly 'off' for action=alias/)
+  assert.match(yaml, /deploy_sha must be the FULL 40-char lowercase commit SHA for action=alias/)
+  // Secret presence is checked only in Run remote action (not Validate inputs).
+  assert.match(yaml, /alias requires ATTENDANCE_ADMIN_JWT \+ LIFECYCLE_CANARY_LOGIN_IDENTIFIER\/PASSWORD \(checked in Run remote action only\)/)
   assert.match(yaml, /NOT EXECUTABLE/)
   // Must not require canary subject/integration for a pretend ON transition.
   assert.doesNotMatch(yaml, /canary_subject_id:/)
   assert.doesNotMatch(yaml, /canary_integration_id:/)
   assert.doesNotMatch(yaml, /owner_confirm:/)
+  // No password-reset API / admin reset path (prose saying "no password reset" is fine).
+  assert.doesNotMatch(yaml, /resetPassword|reset_password|\/api\/.*password-reset/i)
+  assert.doesNotMatch(yaml, /POST\s+\/api\/admin\/.*password/i)
+  // No unconditional always-OFF claim in structural validation comments.
+  assert.doesNotMatch(yaml, /always OFF after/i)
+})
+
+test('workflow alias secret transport uses chmod-600 files + scp, not secret values in remote argv', () => {
+  const yaml = read(WORKFLOW)
+  assert.match(yaml, /chmod 600/)
+  assert.match(yaml, /LIFECYCLE_CANARY_LOGIN_IDENTIFIER/)
+  assert.match(yaml, /LIFECYCLE_CANARY_LOGIN_PASSWORD/)
+  assert.match(yaml, /ATTENDANCE_ADMIN_JWT/)
+  assert.match(yaml, /CANARY_ADMIN_JWT_FILE=/)
+  assert.match(yaml, /CANARY_LOGIN_IDENTIFIER_FILE=/)
+  assert.match(yaml, /CANARY_LOGIN_PASSWORD_FILE=/)
+  assert.match(yaml, /\.canary-secrets/)
+  assert.match(yaml, /scp \$ssh_opts/)
+  // printf uses non-exported shell vars after env demote (not raw env names).
+  assert.match(yaml, /printf '%s' "\$\{_CANARY_PASS\}"/)
+  assert.match(yaml, /printf '%s' "\$\{_CANARY_JWT\}"/)
+  assert.match(yaml, /printf '%s' "\$\{_CANARY_IDENT\}"/)
+  // Must not export raw secret values into the remote script env.
+  assert.doesNotMatch(yaml, /export ATTENDANCE_ADMIN_JWT=/)
+  assert.doesNotMatch(yaml, /export LIFECYCLE_CANARY_LOGIN_IDENTIFIER=/)
+  assert.doesNotMatch(yaml, /export LIFECYCLE_CANARY_LOGIN_PASSWORD=/)
+  assert.doesNotMatch(yaml, /export CANARY_LOGIN_PASSWORD='/)
+})
+
+test('workflow Validate inputs does not receive alias secrets (no child inheritance gap)', () => {
+  const yaml = read(WORKFLOW)
+  const doc = loadYaml(yaml)
+  const validate = doc.jobs.run.steps.find((s) => s.name === 'Validate inputs and embedded scripts')
+  assert.ok(validate?.env, 'Validate inputs must declare env')
+  assert.equal(validate.env.ATTENDANCE_ADMIN_JWT, undefined)
+  assert.equal(validate.env.LIFECYCLE_CANARY_LOGIN_IDENTIFIER, undefined)
+  assert.equal(validate.env.LIFECYCLE_CANARY_LOGIN_PASSWORD, undefined)
+  // No secret presence checks in this step (they launch after bash -n otherwise).
+  assert.doesNotMatch(validate.run, /ATTENDANCE_ADMIN_JWT/)
+  assert.doesNotMatch(validate.run, /LIFECYCLE_CANARY_LOGIN_IDENTIFIER/)
+  assert.doesNotMatch(validate.run, /LIFECYCLE_CANARY_LOGIN_PASSWORD/)
+  assert.match(validate.run, /bash -n scripts\/ops\/dingtalk-lifecycle-staging-canary-remote\.sh/)
+  // Structural alias checks remain; secret presence does not.
+  assert.match(validate.run, /expected_current_mode must be exactly 'off' for action=alias/)
+})
+
+test('workflow materializes secrets inside Run remote action under EXIT trap (no separate secrets step)', () => {
+  const yaml = read(WORKFLOW)
+  const doc = loadYaml(yaml)
+  const steps = doc.jobs.run.steps
+  // Load-bearing: no separate materialize step (cross-step cancel/leak gap).
+  for (const step of steps) {
+    const name = String(step.name || '')
+    assert.doesNotMatch(name, /Materialize alias canary secrets/i)
+    assert.doesNotMatch(name, /^Materialize/i)
+  }
+  assert.doesNotMatch(yaml, /id:\s*secrets\b/)
+  assert.doesNotMatch(yaml, /steps\.secrets\.outputs\.secrets_dir/)
+  assert.doesNotMatch(yaml, /SECRETS_DIR:\s*\$\{\{\s*steps\.secrets/)
+
+  const runStart = yaml.indexOf('- name: Run remote action')
+  assert.notEqual(runStart, -1)
+  const runBody = yaml.slice(runStart, yaml.indexOf('- name: Write step summary', runStart))
+
+  // Parsed step must own materialize + trap (not a prior step).
+  const remoteStep = steps.find((s) => s.name === 'Run remote action')
+  assert.ok(remoteStep?.run)
+
+  // First lines of run script: demote secrets (builtins only) then unset env.
+  // No external command may appear before the unset of exported secret names.
+  const runLines = String(remoteStep.run).split('\n')
+  let sawSet = false
+  let sawEnvUnset = false
+  const linesBetweenSetAndEnvUnset = []
+  for (const line of runLines) {
+    const t = line.trim()
+    if (!sawSet) {
+      if (t === 'set -euo pipefail') sawSet = true
+      continue
+    }
+    if (t.startsWith('unset ATTENDANCE_ADMIN_JWT LIFECYCLE_CANARY_LOGIN_IDENTIFIER LIFECYCLE_CANARY_LOGIN_PASSWORD')) {
+      sawEnvUnset = true
+      break
+    }
+    linesBetweenSetAndEnvUnset.push(t)
+  }
+  assert.equal(sawSet, true)
+  assert.equal(sawEnvUnset, true, 'must unset exported secret env names early')
+  const demoteCode = linesBetweenSetAndEnvUnset.filter((t) => t && !t.startsWith('#'))
+  assert.deepEqual(
+    demoteCode,
+    [
+      '_CANARY_JWT="${ATTENDANCE_ADMIN_JWT-}"',
+      '_CANARY_IDENT="${LIFECYCLE_CANARY_LOGIN_IDENTIFIER-}"',
+      '_CANARY_PASS="${LIFECYCLE_CANARY_LOGIN_PASSWORD-}"',
+    ],
+    'only demote assignments (builtins) before secret env unset — no external commands',
+  )
+
+  // Order after demote: trap → mktemp → printf from shell vars → unset shell vars → remote scp.
+  const trapIdx = runBody.indexOf('trap cleanup_canary_ephemeral_paths EXIT INT TERM')
+  const envUnsetIdx = runBody.indexOf(
+    'unset ATTENDANCE_ADMIN_JWT LIFECYCLE_CANARY_LOGIN_IDENTIFIER LIFECYCLE_CANARY_LOGIN_PASSWORD',
+  )
+  const mktempIdx = runBody.indexOf('mktemp -d')
+  const printfPassIdx = runBody.indexOf("printf '%s' \"${_CANARY_PASS}\"")
+  // Post-write shell-var wipe (must follow password printf; fail-path unset is earlier).
+  const unsetShellIdx = runBody.indexOf(
+    'unset _CANARY_JWT _CANARY_IDENT _CANARY_PASS',
+    printfPassIdx,
+  )
+  const localCleanAssignIdx = runBody.indexOf('CLEAN_LOCAL_SECRETS_DIR="${secrets_dir}"')
+  const remoteMkdirIdx = runBody.indexOf('mkdir -p ${remote_secrets_dir}')
+  const scpIdx = runBody.indexOf('scp $ssh_opts')
+  assert.ok(envUnsetIdx > 0 && trapIdx > envUnsetIdx, 'trap after env demote/unset')
+  assert.ok(mktempIdx > trapIdx, 'trap must precede local secret mktemp/materialize')
+  assert.ok(localCleanAssignIdx > trapIdx && localCleanAssignIdx < remoteMkdirIdx, 'register local dir for trap before remote copy')
+  assert.ok(printfPassIdx > trapIdx, 'password materialize after trap')
+  assert.ok(printfPassIdx < remoteMkdirIdx, 'local password write before remote mkdir')
+  assert.ok(unsetShellIdx > printfPassIdx, 'unset shell secret vars immediately after printf writes')
+  assert.ok(unsetShellIdx < remoteMkdirIdx, 'shell secret vars cleared before remote copy')
+  assert.ok(remoteMkdirIdx > mktempIdx, 'remote secrets mkdir after local materialize')
+  assert.ok(scpIdx > remoteMkdirIdx, 'scp after remote mkdir')
+
+  assert.match(remoteStep.run, /trap cleanup_canary_ephemeral_paths EXIT INT TERM/)
+  assert.match(remoteStep.run, /mktemp -d/)
+  assert.match(remoteStep.run, /printf '%s' "\$\{_CANARY_PASS\}"/)
+  assert.match(remoteStep.run, /unset ATTENDANCE_ADMIN_JWT LIFECYCLE_CANARY_LOGIN_IDENTIFIER LIFECYCLE_CANARY_LOGIN_PASSWORD/)
+  assert.ok(remoteStep.env, 'Run remote action must declare env')
+  assert.ok(remoteStep.env.ATTENDANCE_ADMIN_JWT, 'JWT secret on Run remote action only')
+  assert.ok(remoteStep.env.LIFECYCLE_CANARY_LOGIN_IDENTIFIER, 'identifier secret on Run remote action only')
+  assert.ok(remoteStep.env.LIFECYCLE_CANARY_LOGIN_PASSWORD, 'password secret on Run remote action only')
+  assert.equal(remoteStep.env.SECRETS_DIR, undefined, 'no secrets_dir cross-step handoff')
+
+  assert.match(runBody, /CLEAN_REMOTE_SECRETS_DIR/)
+  assert.match(runBody, /CLEAN_REMOTE_RUNNER_DIR/)
+  assert.match(runBody, /NEVER touch persistent/)
+  assert.doesNotMatch(runBody, /rm -rf[^\n]*\.metasheet2/)
+  assert.match(runBody, /OUTPUT_COLLECTED=1/)
+  // Explicit: secrets_dir must not be a step output handoff.
+  assert.doesNotMatch(runBody, /secrets_dir=.*GITHUB_OUTPUT/)
 })
 
 test('workflow cleanup never deletes persistent .metasheet2 overrides', () => {
@@ -315,10 +485,16 @@ test('P1 rollback recreate retains the proven image pin after the backend contai
   assert.match(result.stdout, new RegExp(`^zensgit\\|${sha}\\|compose `))
 
   const source = read(REMOTE_SH)
-  const actionBody = source.slice(source.indexOf('action_off()'), source.indexOf('\n# --- main'))
+  const offBody = actionOffBody(source)
   assert.ok(
-    actionBody.indexOf('pin_live_backend_image_for_transition') < actionBody.indexOf('backup_lifecycle_override'),
-    'image pin must be captured before the first write',
+    offBody.indexOf('pin_live_backend_image_for_transition') < offBody.indexOf('backup_lifecycle_override'),
+    'action_off: image pin must be captured before the first write',
+  )
+  const aliasBody = actionAliasBody(source)
+  assert.ok(
+    aliasBody.indexOf('pin_live_backend_image_for_transition')
+      < aliasBody.indexOf('establish_alias_off_rollback_baseline'),
+    'action_alias: image pin must be captured before OFF baseline / ON write',
   )
 })
 
@@ -440,11 +616,11 @@ test('production function: require_migrations_pending_zero_true accepts only tru
   assert.match(run('unknown').stderr, /unknown/)
 })
 
-// --- P1: ON actions NOT EXECUTABLE ----------------------------------------------------
+// --- P1: pending/deprovision NOT EXECUTABLE; alias is executable ----------------------
 
-test('P1 ON not executable: alias/pending/deprovision route to action_not_executable_on', () => {
+test('P1 pending/deprovision route to action_not_executable_on; alias routes to action_alias', () => {
   const source = read(REMOTE_SH)
-  assert.match(source, /alias\) action_not_executable_on alias/)
+  assert.match(source, /alias\) action_alias/)
   assert.match(source, /pending\) action_not_executable_on pending/)
   assert.match(source, /deprovision\) action_not_executable_on deprovision/)
   assert.match(source, /NOT EXECUTABLE/)
@@ -462,28 +638,38 @@ test('P1 ON not executable: alias/pending/deprovision route to action_not_execut
   const preflightStart = source.indexOf('preflight_for_target()')
   const preflightEnd = source.indexOf('\naction_preflight()', preflightStart)
   const preflightBody = source.slice(preflightStart, preflightEnd)
-  assert.match(preflightBody, /PREFLIGHT_OK="false"[\s\S]*not_executable_no_real_verifier/)
+  // pending/deprovision still force not-executable; alias does not.
+  assert.match(preflightBody, /pending\|deprovision\)[\s\S]*not_executable_no_real_verifier/)
+  assert.doesNotMatch(
+    preflightBody,
+    /alias\)[\s\S]{0,400}not_executable_no_real_verifier/,
+  )
 })
 
-test('P1 only action=off writes lifecycle override (executable transition)', () => {
+test('P1 action=off and action=alias write lifecycle override; pending/deprovision do not', () => {
   const source = read(REMOTE_SH)
   assert.match(source, /off\) action_off/)
+  assert.match(source, /alias\) action_alias/)
   assert.match(source, /action_off\(\)/)
-  // write_lifecycle_override only with all false for off
+  assert.match(source, /action_alias\(\)/)
   assert.match(source, /write_lifecycle_override "false" "false" "false"/)
-  // No flags_for_mode true for alias in executable path
-  assert.doesNotMatch(source, /write_lifecycle_override "true"/)
+  assert.match(source, /write_lifecycle_override "true" "false" "false"/)
+  const notExec = source.slice(
+    source.indexOf('action_not_executable_on()'),
+    source.indexOf('\naction_off()'),
+  )
+  assert.doesNotMatch(notExec, /write_lifecycle_override/)
 })
 
-test('MUTATION: re-enabling alias as action_transition would fail NOT EXECUTABLE contract', () => {
+test('MUTATION: routing alias back to not-executable would fail action_alias contract', () => {
   const original = read(REMOTE_SH)
   const mutated = original.replace(
+    'alias) action_alias ;;',
     'alias) action_not_executable_on alias ;;',
-    'alias) action_off ;;', // wrong — would break the not-executable contract
   )
   let failed = false
   try {
-    assert.match(mutated, /alias\) action_not_executable_on alias/)
+    assert.match(mutated, /alias\) action_alias/)
   } catch {
     failed = true
   }
@@ -539,7 +725,7 @@ test('P1 off backs up previous override and restores on restart/health/mode fail
   assert.match(source, /previous override restored/)
   // Order must be measured inside the production action body, never against definitions.
   const actionStart = source.indexOf('action_off()')
-  const actionEnd = source.indexOf('\n# --- main', actionStart)
+  const actionEnd = source.indexOf('\naction_alias()', actionStart)
   const actionBody = source.slice(actionStart, actionEnd)
   const backupIdx = actionBody.indexOf('backup_lifecycle_override')
   const writeIdx = actionBody.indexOf('write_lifecycle_override "false" "false" "false"')
@@ -698,18 +884,1030 @@ test('status artifact is values-free (no credentials/PII/canary ids)', () => {
   assert.doesNotMatch(body, /printenv/)
 })
 
+test('alias summary reports only booleans/counts/reason enums/SHA (no secret fields)', () => {
+  const body = actionAliasBody(read(REMOTE_SH))
+  assert.match(body, /pre_login_ok=/)
+  assert.match(body, /post_on_login_ok=/)
+  assert.match(body, /post_rollback_login_ok=/)
+  assert.match(body, /rolled_back_to_off=/)
+  assert.match(body, /backfill_inserted=/)
+  assert.match(body, /backfill_collisions=/)
+  assert.match(body, /cutover_ready=/)
+  assert.match(body, /build_sha=/)
+  assert.doesNotMatch(body, /identifier=/)
+  assert.doesNotMatch(body, /password=/)
+  assert.doesNotMatch(body, /Authorization/)
+  assert.doesNotMatch(body, /Bearer /)
+})
+
+// --- alias canary load-bearing sequence -----------------------------------------------
+
+test('alias requires secret files, expected_current_mode=off, exact SHA, migrations, health', () => {
+  const body = actionAliasBody(read(REMOTE_SH))
+  assert.match(body, /require_canary_secret_files/)
+  assert.match(body, /require_sha/)
+  assert.match(body, /assert_exact_sha/)
+  assert.match(body, /require_migrations_pending_zero_true/)
+  assert.match(body, /expected_current_mode=off/)
+  assert.match(body, /backend_health_ok must be true before any env write/)
+  assert.match(body, /live mode must be off before cutover/)
+  // Refuse auto-selection explicitly; never implement password reset or prod containers.
+  assert.match(body, /refuse auto-selection/)
+  assert.doesNotMatch(body, /resetPassword|reset_password|password-reset/)
+  assert.doesNotMatch(body, /container_name: metasheet-backend/)
+  assert.doesNotMatch(body, /metasheet-backend:latest/)
+})
+
+test('alias proves pre-login before any env write; backfill and readiness before write', () => {
+  const body = actionAliasBody(read(REMOTE_SH))
+  const preLogin = body.indexOf('prove_canary_password_login "pre_on"')
+  const backfill = body.indexOf('run_alias_backfill')
+  const cutover = body.indexOf('run_alias_cutover_status')
+  const baseline = body.indexOf('establish_alias_off_rollback_baseline')
+  const write = body.indexOf('write_lifecycle_override "true" "false" "false"')
+  assert.ok(preLogin > 0, 'pre_on login required')
+  assert.ok(backfill > preLogin, 'backfill after pre-login')
+  assert.ok(cutover > backfill, 'cutover-status after backfill')
+  assert.ok(baseline > cutover, 'explicit OFF baseline after readiness')
+  assert.ok(write > baseline, 'ON write after OFF baseline')
+  assert.doesNotMatch(body, /backup_lifecycle_override/)
+  assert.match(body, /pre-ON password login failed \(no env write performed\)/)
+  assert.match(body, /login-aliases backfill failed \(no env write performed\)/)
+  assert.match(body, /cutover-status not ready\/canEnableCutover \(no env write performed\)/)
+})
+
+test('alias post-ON path requires recreate, exact SHA, mode alias, post-ON login; failures restore first', () => {
+  const body = actionAliasBody(read(REMOTE_SH))
+  assert.match(body, /fail_transition_restore "backend_health_not_true_after_restart"/)
+  assert.match(body, /fail_transition_restore "post_restart_sha_mismatch"/)
+  assert.match(body, /fail_transition_restore "post_restart_mode_not_alias"/)
+  assert.match(body, /fail_transition_restore "post_on_password_login_failed"/)
+  assert.match(body, /prove_canary_password_login "post_on"/)
+  assert.match(body, /assert_exact_mode_alias/)
+  const writeIdx = body.indexOf('write_lifecycle_override "true" "false" "false"')
+  const postOn = body.indexOf('prove_canary_password_login "post_on"')
+  const restoreSuccess = body.indexOf('restoring explicit OFF rollback baseline')
+  assert.ok(postOn > writeIdx)
+  assert.ok(restoreSuccess > postOn, 'success path restores explicit OFF after ON proof')
+})
+
+test('alias success requires/proves OFF and post-rollback login; admits unproven OFF if rollback recreate fails', () => {
+  const body = actionAliasBody(read(REMOTE_SH))
+  const source = read(REMOTE_SH)
+  assert.match(body, /restore_lifecycle_override/)
+  assert.match(body, /assert_exact_mode_off/)
+  assert.match(body, /prove_canary_password_login "post_rollback"/)
+  assert.match(body, /rolled_back_to_off="true"/)
+  assert.match(body, /alias_cutover_canary_success_proved_off/)
+  assert.match(body, /success requires\/proves OFF/)
+  assert.match(body, /runtime OFF cannot be proven/)
+  assert.match(body, /establish_alias_off_rollback_baseline/)
+  assert.doesNotMatch(source, /ALWAYS returns to OFF|ALWAYS restores OFF/)
+  const restoreIdx = body.indexOf('restoring explicit OFF rollback baseline')
+  const endSummary = body.indexOf('action=alias OK')
+  assert.ok(restoreIdx > 0 && endSummary > restoreIdx)
+})
+
+test('alias secret helpers never interpolate secret values into shell argv or logs', () => {
+  const source = read(REMOTE_SH)
+  assert.match(source, /require_canary_secret_files\(\)/)
+  assert.match(source, /prove_canary_password_login\(\)/)
+  assert.match(source, /admin_api_request\(\)/)
+  assert.match(source, /CANARY_ADMIN_JWT_FILE/)
+  assert.match(source, /CANARY_LOGIN_IDENTIFIER_FILE/)
+  assert.match(source, /CANARY_LOGIN_PASSWORD_FILE/)
+  // Python reads files from argv paths — values not passed as argv.
+  assert.match(
+    source,
+    /^\s*identifier = pathlib\.Path\(ident_path\)\.read_bytes\(\)\.decode\("utf-8"\)\.strip\(\)\s*$/m,
+  )
+  // Complete assignment line — trailing .strip() must not match.
+  assert.match(
+    source,
+    /^\s*password = pathlib\.Path\(pass_path\)\.read_bytes\(\)\.decode\("utf-8"\)\s*$/m,
+  )
+  assert.doesNotMatch(
+    source,
+    /^\s*password = pathlib\.Path\(pass_path\)\.read_bytes\(\)\.decode\("utf-8"\)\.strip\(\)\s*$/m,
+  )
+  assert.match(source, /pathlib\.Path\(jwt_path\)\.read_text/)
+  // Never curl -d with expanded password env or echo secret file contents.
+  assert.doesNotMatch(source, /curl[^\n]*\$\{?CANARY_LOGIN_PASSWORD\}?/)
+  assert.doesNotMatch(source, /curl[^\n]*\$\{?ATTENDANCE_ADMIN_JWT\}?/)
+  assert.doesNotMatch(source, /echo\s+[\"']?\$\{?(CANARY_LOGIN_PASSWORD|ATTENDANCE_ADMIN_JWT|CANARY_ADMIN_JWT)/)
+  assert.doesNotMatch(source, /cat\s+\"?\$\{?CANARY_LOGIN_PASSWORD_FILE/)
+  assert.match(source, /values never logged/)
+})
+
+test('alias admin calls target backfill and cutover-status endpoints', () => {
+  const source = read(REMOTE_SH)
+  assert.match(source, /\/api\/admin\/login-aliases\/backfill/)
+  assert.match(source, /\/api\/admin\/login-aliases\/cutover-status/)
+  assert.match(source, /\/api\/auth\/login/)
+  assert.match(source, /canEnableCutover/)
+})
+
+// Load-bearing MUTATION tests: removing any required gate turns the suite red.
+test('MUTATION: removing pre-ON login requirement turns alias contract red', () => {
+  const original = read(REMOTE_SH)
+  const mutated = original.replace('prove_canary_password_login "pre_on"', 'true # pre_on removed')
+  const body = actionAliasBody(mutated)
+  let failed = false
+  try {
+    assert.match(body, /prove_canary_password_login "pre_on"/)
+  } catch {
+    failed = true
+  }
+  assert.equal(failed, true)
+})
+
+test('MUTATION: removing post-ON login requirement turns alias contract red', () => {
+  const original = read(REMOTE_SH)
+  const mutated = original.replace('prove_canary_password_login "post_on"', 'true # post_on removed')
+  const body = actionAliasBody(mutated)
+  let failed = false
+  try {
+    assert.match(body, /prove_canary_password_login "post_on"/)
+  } catch {
+    failed = true
+  }
+  assert.equal(failed, true)
+})
+
+test('MUTATION: removing post-rollback login requirement turns alias contract red', () => {
+  const original = read(REMOTE_SH)
+  const mutated = original.replace(
+    'prove_canary_password_login "post_rollback"',
+    'true # post_rollback removed',
+  )
+  const body = actionAliasBody(mutated)
+  let failed = false
+  try {
+    assert.match(body, /prove_canary_password_login "post_rollback"/)
+  } catch {
+    failed = true
+  }
+  assert.equal(failed, true)
+})
+
+test('MUTATION: removing backfill requirement turns alias contract red', () => {
+  const original = read(REMOTE_SH)
+  const body = actionAliasBody(original)
+  const mutatedBody = body.replaceAll('run_alias_backfill', 'true_backfill_removed')
+  let failed = false
+  try {
+    assert.match(mutatedBody, /run_alias_backfill/)
+  } catch {
+    failed = true
+  }
+  assert.equal(failed, true)
+})
+
+test('MUTATION: removing cutover-status readiness requirement turns alias contract red', () => {
+  const original = read(REMOTE_SH)
+  const body = actionAliasBody(original)
+  const mutatedBody = body.replaceAll('run_alias_cutover_status', 'true_cutover_removed')
+  let failed = false
+  try {
+    assert.match(mutatedBody, /run_alias_cutover_status/)
+  } catch {
+    failed = true
+  }
+  assert.equal(failed, true)
+})
+
+test('MUTATION: removing success-path OFF restore after ON proof turns alias contract red', () => {
+  const original = read(REMOTE_SH)
+  const mutated = original.replace(
+    'restoring explicit OFF rollback baseline (success requires/proves OFF; canary must not leave alias enabled)',
+    'skip restore',
+  )
+  const body = actionAliasBody(mutated)
+  let failed = false
+  try {
+    assert.match(
+      body,
+      /restoring explicit OFF rollback baseline \(success requires\/proves OFF; canary must not leave alias enabled\)/,
+    )
+  } catch {
+    failed = true
+  }
+  assert.equal(failed, true)
+})
+
+test('MUTATION: using backup_lifecycle_override instead of explicit OFF baseline turns alias contract red', () => {
+  const original = read(REMOTE_SH)
+  const body = actionAliasBody(original)
+  const mutatedBody = body.replace(
+    'establish_alias_off_rollback_baseline',
+    'backup_lifecycle_override',
+  )
+  let failed = false
+  try {
+    assert.match(mutatedBody, /establish_alias_off_rollback_baseline/)
+  } catch {
+    failed = true
+  }
+  assert.equal(failed, true)
+  assert.match(mutatedBody, /backup_lifecycle_override/)
+})
+
+test('MUTATION: removing exact SHA assert from alias turns contract red', () => {
+  const original = read(REMOTE_SH)
+  const body = actionAliasBody(original)
+  const mutatedBody = body.replace('assert_exact_sha', 'true # sha removed')
+  let failed = false
+  try {
+    assert.match(mutatedBody, /assert_exact_sha/)
+  } catch {
+    failed = true
+  }
+  assert.equal(failed, true)
+})
+
+test('MUTATION: removing migrations require from alias turns contract red', () => {
+  const original = read(REMOTE_SH)
+  const body = actionAliasBody(original)
+  const mutatedBody = body.replace(
+    'require_migrations_pending_zero_true "$SNAP_MIGRATIONS_ZERO" "action=alias"',
+    'true # migrations removed',
+  )
+  let failed = false
+  try {
+    assert.match(mutatedBody, /require_migrations_pending_zero_true "\$SNAP_MIGRATIONS_ZERO" "action=alias"/)
+  } catch {
+    failed = true
+  }
+  assert.equal(failed, true)
+})
+
+test('MUTATION: removing secret-file requirement turns alias contract red', () => {
+  const original = read(REMOTE_SH)
+  const body = actionAliasBody(original)
+  const mutatedBody = body.replaceAll('require_canary_secret_files', 'true_secrets_removed')
+  let failed = false
+  try {
+    assert.match(mutatedBody, /require_canary_secret_files/)
+  } catch {
+    failed = true
+  }
+  assert.equal(failed, true)
+})
+
+test('production function: require_canary_secret_files rejects missing paths', () => {
+  const result = spawnSync(
+    'bash',
+    [
+      '-o',
+      'pipefail',
+      '-c',
+      'source "$1"; CANARY_ADMIN_JWT_FILE=; CANARY_LOGIN_IDENTIFIER_FILE=; CANARY_LOGIN_PASSWORD_FILE=; require_canary_secret_files',
+      'bash',
+      REMOTE_SH,
+    ],
+    {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        ACTION: 'status',
+        OUTPUT_DIR: '/tmp/lifecycle-canary-contract-source-only',
+        RUN_STAMP: 'contract',
+        LIFECYCLE_CANARY_SOURCE_ONLY: 'true',
+      },
+    },
+  )
+  assert.notEqual(result.status, 0)
+  assert.match(result.stderr, /CANARY_ADMIN_JWT_FILE|secret file/)
+})
+
+test('alias backfill requires exact nonnegative counts and collisions==0 before env write', () => {
+  const source = read(REMOTE_SH)
+  assert.match(source, /collisions_nonzero/)
+  assert.match(source, /collisions must be 0/)
+  assert.match(source, /type\(v\) is not int/)
+  assert.match(source, /nonneg_int/)
+  assert.match(source, /malformed/)
+  const body = actionAliasBody(source)
+  const backfillIdx = body.indexOf('run_alias_backfill')
+  const writeIdx = body.indexOf('write_lifecycle_override "true" "false" "false"')
+  assert.ok(backfillIdx > 0 && writeIdx > backfillIdx)
+})
+
+test('production function: run_alias_backfill refuses collisions>0 and malformed counts', () => {
+  function runWithBody(jsonBody) {
+    return spawnSync(
+      'bash',
+      [
+        '-o',
+        'pipefail',
+        '-c',
+        `source "$1"
+         BODY_JSON="$2"
+         admin_api_request() { printf '200\\n%s' "$BODY_JSON"; }
+         if run_alias_backfill; then
+           printf 'ok|%s|%s|%s' "$BACKFILL_INSERTED" "$BACKFILL_COLLISIONS" "$BACKFILL_SKIPPED"
+         else
+           printf 'fail|%s|%s|%s|%s' "$BACKFILL_NOTE" "$BACKFILL_INSERTED" "$BACKFILL_COLLISIONS" "$BACKFILL_SKIPPED"
+         fi`,
+        'bash',
+        REMOTE_SH,
+        jsonBody,
+      ],
+      {
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          ACTION: 'status',
+          OUTPUT_DIR: '/tmp/lifecycle-canary-contract-source-only',
+          RUN_STAMP: 'contract',
+          LIFECYCLE_CANARY_SOURCE_ONLY: 'true',
+          CANARY_ADMIN_JWT_FILE: '/dev/null',
+        },
+      },
+    )
+  }
+
+  const ok = runWithBody(
+    JSON.stringify({ ok: true, data: { inserted: 2, collisions: 0, skippedEmpty: 1 } }),
+  )
+  assert.equal(ok.status, 0, ok.stderr)
+  assert.match(ok.stdout, /(?:^|\n)ok\|2\|0\|1\s*$/)
+
+  const collisions = runWithBody(
+    JSON.stringify({ ok: true, data: { inserted: 2, collisions: 1, skippedEmpty: 0 } }),
+  )
+  assert.equal(collisions.status, 0, collisions.stderr)
+  assert.match(collisions.stdout, /(?:^|\n)fail\|collisions_nonzero\|/)
+
+  const malformed = runWithBody(
+    JSON.stringify({ ok: true, data: { inserted: 'x', collisions: 0, skippedEmpty: 0 } }),
+  )
+  assert.equal(malformed.status, 0, malformed.stderr)
+  assert.match(malformed.stdout, /(?:^|\n)fail\|malformed\|/)
+
+  const negative = runWithBody(
+    JSON.stringify({ ok: true, data: { inserted: -1, collisions: 0, skippedEmpty: 0 } }),
+  )
+  assert.equal(negative.status, 0, negative.stderr)
+  assert.match(negative.stdout, /(?:^|\n)fail\|malformed\|/)
+
+  // Fail closed: JSON float 1.0 and numeric string "1" are not Python int.
+  // (JSON.stringify(1.0) collapses to 1 — force a real float token in the body.)
+  const floatOne = runWithBody(
+    '{"ok":true,"data":{"inserted":1.0,"collisions":0,"skippedEmpty":0}}',
+  )
+  assert.equal(floatOne.status, 0, floatOne.stderr)
+  assert.match(floatOne.stdout, /(?:^|\n)fail\|malformed\|/)
+
+  const stringOne = runWithBody(
+    JSON.stringify({ ok: true, data: { inserted: '1', collisions: 0, skippedEmpty: 0 } }),
+  )
+  assert.equal(stringOne.status, 0, stringOne.stderr)
+  assert.match(stringOne.stdout, /(?:^|\n)fail\|malformed\|/)
+
+  // bool is an int subclass — must not be accepted via isinstance(int).
+  const boolTrue = runWithBody(
+    JSON.stringify({ ok: true, data: { inserted: true, collisions: 0, skippedEmpty: 0 } }),
+  )
+  assert.equal(boolTrue.status, 0, boolTrue.stderr)
+  assert.match(boolTrue.stdout, /(?:^|\n)fail\|malformed\|/)
+})
+
+test('MUTATION: accepting collisions>0 would fail backfill zero-collision contract', () => {
+  const original = read(REMOTE_SH)
+  const mutated = original.replaceAll('collisions_nonzero', 'collisions_ignored')
+  let failed = false
+  try {
+    assert.match(mutated, /collisions_nonzero/)
+  } catch {
+    failed = true
+  }
+  assert.equal(failed, true)
+})
+
+// Production password assignment must be the complete line (no trailing transforms).
+const PROD_PASSWORD_ASSIGN =
+  /^\s*password = pathlib\.Path\(pass_path\)\.read_bytes\(\)\.decode\("utf-8"\)\s*$/m
+const PROD_PASSWORD_ASSIGN_STRIPPED =
+  /^\s*password = pathlib\.Path\(pass_path\)\.read_bytes\(\)\.decode\("utf-8"\)\.strip\(\)\s*$/m
+const PROD_PASSWORD_LINE =
+  'password = pathlib.Path(pass_path).read_bytes().decode("utf-8")'
+
+test('prove_canary_password_login production assignment is exact (no trailing .strip)', () => {
+  const source = read(REMOTE_SH)
+  const start = source.indexOf('prove_canary_password_login()')
+  const end = source.indexOf('\nadmin_api_request()', start)
+  const body = source.slice(start, end)
+  assert.match(
+    body,
+    /^\s*identifier = pathlib\.Path\(ident_path\)\.read_bytes\(\)\.decode\("utf-8"\)\.strip\(\)\s*$/m,
+  )
+  // Anchored complete line: prefix-only match would still pass if .strip() is appended.
+  assert.match(body, PROD_PASSWORD_ASSIGN)
+  assert.doesNotMatch(body, PROD_PASSWORD_ASSIGN_STRIPPED)
+  assert.doesNotMatch(body, /password = pathlib\.Path\(pass_path\)\.read_text/)
+  assert.doesNotMatch(body, /password\s*=\s*[^\n]*\.strip\(\)/)
+})
+
+test('MUTATION: appending .strip() to password assignment turns exact-bytes contract red', () => {
+  const original = read(REMOTE_SH)
+  assert.match(original, PROD_PASSWORD_ASSIGN)
+  const mutated = original.replace(
+    PROD_PASSWORD_LINE,
+    `${PROD_PASSWORD_LINE}.strip()`,
+  )
+  // Mutation must break the anchored complete-line assertion (prefix-only would stay green).
+  let failed = false
+  try {
+    assert.match(mutated, PROD_PASSWORD_ASSIGN)
+  } catch {
+    failed = true
+  }
+  assert.equal(failed, true, 'anchored password line must reject trailing .strip()')
+  assert.match(mutated, PROD_PASSWORD_ASSIGN_STRIPPED)
+})
+
+/**
+ * Collect stdout/stderr and exit code from an async child process.
+ * @param {import('node:child_process').ChildProcessWithoutNullStreams} child
+ * @param {number} timeoutMs
+ */
+function collectChild(child, timeoutMs) {
+  return new Promise((resolve, reject) => {
+    let stdout = ''
+    let stderr = ''
+    let settled = false
+    const timer = setTimeout(() => {
+      if (settled) return
+      settled = true
+      try {
+        child.kill('SIGKILL')
+      } catch {
+        // ignore
+      }
+      reject(new Error(`child timed out after ${timeoutMs}ms stdout=${stdout} stderr=${stderr}`))
+    }, timeoutMs)
+    child.stdout.on('data', (c) => {
+      stdout += c.toString('utf8')
+    })
+    child.stderr.on('data', (c) => {
+      stderr += c.toString('utf8')
+    })
+    child.on('error', (err) => {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
+      reject(err)
+    })
+    child.on('close', (code, signal) => {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
+      resolve({ code: code ?? 1, signal, stdout, stderr })
+    })
+  })
+}
+
+test('FUNCTIONAL: prove_canary_password_login sends exact CR/LF password bytes on loopback', async () => {
+  // Loopback server AND the production helper both run as separate child processes.
+  // Never use in-process HTTP + spawnSync (event-loop deadlock → 20s request_failed).
+  const dir = mkdtempSync(join(tmpdir(), 'lifecycle-canary-login-'))
+  /** @type {import('node:child_process').ChildProcess | null} */
+  let serverProc = null
+  /** @type {import('node:child_process').ChildProcess | null} */
+  let helperProc = null
+  const overallMs = 8000
+  try {
+    const identFile = join(dir, 'ident')
+    const passFile = join(dir, 'pass')
+    const captureFile = join(dir, 'captured-request.json')
+    // Explicit CR bytes so the fixture cannot be newline-normalized by editors.
+    writeFileSync(
+      identFile,
+      Buffer.from([0x20, 0x20, ...Buffer.from('admin@example.com'), 0x0d, 0x0a]),
+    )
+    writeFileSync(
+      passFile,
+      Buffer.from([...Buffer.from('s3cret'), 0x0d, 0x0a, ...Buffer.from('trailing')]),
+    )
+
+    const serverPy = `
+import json
+import http.server
+import socketserver
+from pathlib import Path
+
+capture = Path(${JSON.stringify(captureFile)})
+
+class Handler(http.server.BaseHTTPRequestHandler):
+    def do_POST(self):
+        n = int(self.headers.get("Content-Length", "0"))
+        raw = self.rfile.read(n).decode("utf-8")
+        capture.write_text(
+            json.dumps({"method": "POST", "url": self.path, "rawBody": raw, "json": json.loads(raw)}),
+            encoding="utf-8",
+        )
+        body = json.dumps({"success": True, "data": {"token": "loopback-token"}}).encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *_args):
+        return
+
+with socketserver.TCPServer(("127.0.0.1", 0), Handler) as httpd:
+    print(httpd.server_address[1], flush=True)
+    httpd.handle_request()
+`
+    serverProc = spawn('python3', ['-c', serverPy], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: process.env,
+    })
+    const serverDone = collectChild(serverProc, overallMs)
+
+    const port = await new Promise((resolve, reject) => {
+      let buf = ''
+      const timer = setTimeout(() => reject(new Error('loopback server port timeout')), 3000)
+      const onData = (chunk) => {
+        buf += chunk.toString('utf8')
+        const line = buf.trim().split(/\r?\n/).filter(Boolean).pop() || ''
+        if (/^\d+$/.test(line)) {
+          clearTimeout(timer)
+          serverProc.stdout.off('data', onData)
+          resolve(Number(line))
+        }
+      }
+      serverProc.stdout.on('data', onData)
+      serverProc.on('error', (err) => {
+        clearTimeout(timer)
+        reject(err)
+      })
+      serverProc.on('exit', (code) => {
+        if (code && code !== 0) {
+          clearTimeout(timer)
+          reject(new Error(`loopback server exited early: ${code}`))
+        }
+      })
+    })
+    const base = `http://127.0.0.1:${port}`
+
+    // Async spawn of the real sourced production helper (not spawnSync).
+    helperProc = spawn(
+      'bash',
+      [
+        '-o',
+        'pipefail',
+        '-c',
+        `source "$1"
+         CANARY_LOGIN_IDENTIFIER_FILE="$2"
+         CANARY_LOGIN_PASSWORD_FILE="$3"
+         STAGING_API_BASE_URL="$4"
+         prove_canary_password_login loopback_exact_bytes`,
+        'bash',
+        REMOTE_SH,
+        identFile,
+        passFile,
+        base,
+      ],
+      {
+        env: {
+          ...process.env,
+          ACTION: 'status',
+          OUTPUT_DIR: '/tmp/lifecycle-canary-contract-source-only',
+          RUN_STAMP: 'contract',
+          LIFECYCLE_CANARY_SOURCE_ONLY: 'true',
+        },
+        stdio: ['ignore', 'pipe', 'pipe'],
+      },
+    )
+    const helperResult = await collectChild(helperProc, overallMs)
+    assert.equal(
+      helperResult.code,
+      0,
+      `helper failed: ${helperResult.stderr}${helperResult.stdout}`,
+    )
+    assert.match(helperResult.stdout, /password login OK \(loopback_exact_bytes\)/)
+
+    // Server should finish after one request; don't hang if capture already written.
+    await Promise.race([
+      serverDone,
+      new Promise((resolve) => setTimeout(resolve, 2000)),
+    ])
+
+    assert.ok(existsSync(captureFile), 'capture file missing — production helper never hit loopback')
+    const captured = JSON.parse(readFileSync(captureFile, 'utf8'))
+    assert.equal(captured.method, 'POST')
+    assert.equal(captured.url, '/api/auth/login')
+    assert.ok(captured.json, `expected JSON body, got: ${captured.rawBody}`)
+    // Identifier may trim; password must be exact stored bytes including CR/LF.
+    assert.equal(captured.json.identifier, 'admin@example.com')
+    assert.equal(captured.json.password, 's3cret\r\ntrailing')
+    assert.equal(Buffer.from(captured.json.password, 'utf8')[6], 0x0d)
+    // Raw body must contain json.dumps CR escape (\\r), not a stripped password.
+    assert.match(captured.rawBody, /s3cret\\r\\ntrailing/)
+  } finally {
+    for (const proc of [helperProc, serverProc]) {
+      if (proc && !proc.killed && proc.exitCode === null) {
+        try {
+          proc.kill('SIGKILL')
+        } catch {
+          // ignore
+        }
+      }
+    }
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('FUNCTIONAL harness: action_alias success call order pre-login→backfill→status→ON→OFF', () => {
+  const sha = 'c'.repeat(40)
+  const result = spawnSync(
+    'bash',
+    [
+      '-o',
+      'pipefail',
+      '-c',
+      `source "$1"
+       CALL_LOG=()
+       record() { CALL_LOG+=("\$1"); }
+       require_sha() { record require_sha; }
+       require_canary_secret_files() { record require_secrets; }
+       capture_live_snapshot() {
+         record capture_live_snapshot
+         SNAP_ALIAS=false; SNAP_PENDING=false; SNAP_DEPROV=false; SNAP_MODE=off
+         SNAP_BUILD_SHA="$DEPLOY_SHA"; SNAP_ALIAS_READY=true; SNAP_CAN_ENABLE_ALIAS=true
+         SNAP_MIGRATIONS_ZERO=true; SNAP_HEALTH_OK=true
+       }
+       assert_exact_sha() { record assert_exact_sha; }
+       pin_live_backend_image_for_transition() { record pin_image; }
+       require_migrations_pending_zero_true() { record require_migrations; }
+       prove_canary_password_login() { record "login:\$1"; return 0; }
+       run_alias_backfill() {
+         record backfill
+         BACKFILL_OK=true; BACKFILL_INSERTED=1; BACKFILL_COLLISIONS=0; BACKFILL_SKIPPED=0; BACKFILL_NOTE=ok
+         return 0
+       }
+       run_alias_cutover_status() {
+         record cutover_status
+         CUTOVER_READY=true; CUTOVER_CAN_ENABLE=true
+         return 0
+       }
+       establish_alias_off_rollback_baseline() { record off_baseline; }
+       backup_lifecycle_override() { record backup_stale; }
+       arm_alias_exit_rollback_guard() { record arm_exit_guard; }
+       disarm_alias_exit_rollback_guard() { record disarm_exit_guard; }
+       write_lifecycle_override() { record "write:\$1:\$2:\$3"; }
+       recreate_backend_only() { record recreate; return 0; }
+       resolve_deployed_sha() { record resolve_sha; printf '%s' "$DEPLOY_SHA"; }
+       assert_exact_mode_alias() { record mode_alias; return 0; }
+       assert_exact_mode_off() { record mode_off; return 0; }
+       restore_lifecycle_override() { record restore; }
+       fetch_backend_health_ok() { record health; printf 'true'; }
+       cleanup_prev_backup() { record cleanup_backup; }
+       write_status_artifact() { record write_status; }
+       OUTPUT_DIR="$2"
+       mkdir -p "$OUTPUT_DIR"
+       DEPLOY_SHA="$3"
+       EXPECTED_CURRENT_MODE=off
+       ACTION=alias
+       action_alias
+       printf '%s\\n' "\${CALL_LOG[@]}"`,
+      'bash',
+      REMOTE_SH,
+      '/tmp/lifecycle-canary-functional-success',
+      sha,
+    ],
+    {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        ACTION: 'alias',
+        OUTPUT_DIR: '/tmp/lifecycle-canary-functional-success',
+        RUN_STAMP: 'contract',
+        LIFECYCLE_CANARY_SOURCE_ONLY: 'true',
+        DEPLOY_SHA: sha,
+        EXPECTED_CURRENT_MODE: 'off',
+      },
+    },
+  )
+  assert.equal(result.status, 0, result.stderr + result.stdout)
+  const lines = result.stdout.trim().split('\n')
+  const idx = (name) => {
+    const i = lines.indexOf(name)
+    assert.ok(i >= 0, `missing call ${name} in ${lines.join(',')}`)
+    return i
+  }
+  assert.ok(idx('login:pre_on') < idx('backfill'))
+  assert.ok(idx('backfill') < idx('cutover_status'))
+  assert.ok(idx('cutover_status') < idx('off_baseline'))
+  assert.ok(idx('off_baseline') < idx('write:true:false:false'))
+  assert.ok(idx('off_baseline') < idx('arm_exit_guard'))
+  assert.ok(idx('arm_exit_guard') < idx('write:true:false:false'))
+  assert.ok(!lines.includes('backup_stale'), 'must not backup stale on-disk override')
+  assert.ok(idx('write:true:false:false') < idx('recreate'))
+  assert.ok(idx('recreate') < idx('mode_alias'))
+  assert.ok(idx('mode_alias') < idx('login:post_on'))
+  assert.ok(idx('login:post_on') < idx('restore'))
+  // Second recreate after restore for OFF proof.
+  const restoreI = idx('restore')
+  const secondRecreate = lines.indexOf('recreate', restoreI + 1)
+  assert.ok(secondRecreate > restoreI, 'rollback recreate after restore')
+  assert.ok(secondRecreate < idx('mode_off'))
+  assert.ok(idx('mode_off') < idx('login:post_rollback'))
+  assert.ok(idx('login:post_rollback') < idx('disarm_exit_guard'))
+})
+
+test('FUNCTIONAL: SIGTERM/SIGPIPE in alias ON window restore, recreate, and prove OFF before exit', () => {
+  const sha = 'e'.repeat(40)
+  for (const [signal, expectedStatus] of [['TERM', 143], ['PIPE', 141]]) {
+    const dir = mkdtempSync(join(tmpdir(), `lifecycle-alias-${signal.toLowerCase()}-`))
+    const calls = join(dir, 'calls.log')
+    try {
+      const result = spawnSync(
+        'bash',
+        [
+          '-o',
+          'pipefail',
+          '-c',
+          `source "$1"
+           CALLS="$2"
+           record() { printf '%s\\n' "$1" >> "$CALLS"; }
+           restore_lifecycle_override() { record restore_off; return 0; }
+           recreate_backend_only() { record recreate_backend; return 0; }
+           resolve_deployed_sha() { record resolve_sha; printf '%s' "$DEPLOY_SHA"; }
+           assert_exact_mode_off() { record mode_off; return 0; }
+           fetch_backend_health_ok() { record health_ok; printf 'true'; }
+           cleanup_prev_backup() { record cleanup_backup; }
+           DEPLOY_SHA="$3"
+           ACTION=alias
+           arm_alias_exit_rollback_guard
+           record alias_on_written
+           kill -${signal} $$
+           record after_signal`,
+          'bash',
+          REMOTE_SH,
+          calls,
+          sha,
+        ],
+        {
+          encoding: 'utf8',
+          env: {
+            ...process.env,
+            ACTION: 'alias',
+            OUTPUT_DIR: dir,
+            RUN_STAMP: `contract-${signal.toLowerCase()}`,
+            LIFECYCLE_CANARY_SOURCE_ONLY: 'true',
+          },
+        },
+      )
+      assert.equal(result.status, expectedStatus, result.stderr + result.stdout)
+      const lines = readFileSync(calls, 'utf8').trim().split('\n')
+      const idx = (name) => {
+        const i = lines.indexOf(name)
+        assert.ok(i >= 0, `signal=${signal} missing ${name}; calls=${lines.join(',')}`)
+        return i
+      }
+      assert.ok(idx('alias_on_written') < idx('restore_off'))
+      assert.ok(idx('restore_off') < idx('recreate_backend'))
+      assert.ok(idx('recreate_backend') < idx('mode_off'))
+      assert.ok(idx('mode_off') < idx('health_ok'))
+      assert.ok(idx('health_ok') < idx('cleanup_backup'))
+      assert.ok(!lines.includes('after_signal'))
+      assert.match(
+        readFileSync(join(dir, 'alias-emergency-rollback.log'), 'utf8'),
+        /alias rollback guard proved runtime OFF/,
+      )
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  }
+})
+
+test('MUTATION: removing alias EXIT guard wiring fails the ON-window contract', () => {
+  const body = actionAliasBody(read(REMOTE_SH))
+  const arm = body.indexOf('arm_alias_exit_rollback_guard')
+  const writeOn = body.indexOf('write_lifecycle_override "true" "false" "false"')
+  const postRollbackLogin = body.indexOf('prove_canary_password_login "post_rollback"')
+  const disarm = body.indexOf('disarm_alias_exit_rollback_guard')
+  assert.ok(arm >= 0 && arm < writeOn, 'guard must arm before persistent alias ON write')
+  assert.ok(disarm > postRollbackLogin, 'guard must remain armed through post-rollback login proof')
+
+  const mutated = body.replace(
+    '\n  arm_alias_exit_rollback_guard\n',
+    '\n  : # guard removed\n',
+  )
+  assert.doesNotMatch(mutated, /^\s*arm_alias_exit_rollback_guard\s*$/m)
+  assert.throws(
+    () => assert.match(mutated, /^\s*arm_alias_exit_rollback_guard\s*$/m),
+    /arm_alias_exit_rollback_guard/,
+  )
+})
+
+test('FUNCTIONAL harness: post-ON login failure invokes fail_transition_restore before termination', () => {
+  const sha = 'd'.repeat(40)
+  const result = spawnSync(
+    'bash',
+    [
+      '-o',
+      'pipefail',
+      '-c',
+      `source "$1"
+       CALL_LOG=()
+       record() { CALL_LOG+=("\$1"); }
+       require_sha() { :; }
+       require_canary_secret_files() { :; }
+       capture_live_snapshot() {
+         SNAP_ALIAS=false; SNAP_PENDING=false; SNAP_DEPROV=false; SNAP_MODE=off
+         SNAP_BUILD_SHA="$DEPLOY_SHA"; SNAP_ALIAS_READY=true; SNAP_CAN_ENABLE_ALIAS=true
+         SNAP_MIGRATIONS_ZERO=true; SNAP_HEALTH_OK=true
+       }
+       assert_exact_sha() { :; }
+       pin_live_backend_image_for_transition() { :; }
+       require_migrations_pending_zero_true() { :; }
+       prove_canary_password_login() {
+         record "login:\$1"
+         if [[ "\$1" == "post_on" ]]; then return 1; fi
+         return 0
+       }
+       run_alias_backfill() {
+         BACKFILL_OK=true; BACKFILL_INSERTED=0; BACKFILL_COLLISIONS=0; BACKFILL_SKIPPED=0
+         return 0
+       }
+       run_alias_cutover_status() { CUTOVER_READY=true; CUTOVER_CAN_ENABLE=true; return 0; }
+       establish_alias_off_rollback_baseline() { record off_baseline; }
+       arm_alias_exit_rollback_guard() { record arm_exit_guard; }
+       disarm_alias_exit_rollback_guard() { record disarm_exit_guard; }
+       backup_lifecycle_override() { record backup_stale; }
+       write_lifecycle_override() { record write_on; }
+       recreate_backend_only() { record recreate; return 0; }
+       resolve_deployed_sha() { printf '%s' "$DEPLOY_SHA"; }
+       assert_exact_mode_alias() { return 0; }
+       restore_lifecycle_override() { record restore; }
+       cleanup_prev_backup() { record cleanup_backup; }
+       # Keep production fail_transition_restore; only replace terminal fail().
+       fail() { record "fail:\$*"; printf '%s\\n' "\${CALL_LOG[@]}"; exit 1; }
+       OUTPUT_DIR="$2"
+       mkdir -p "$OUTPUT_DIR"
+       DEPLOY_SHA="$3"
+       EXPECTED_CURRENT_MODE=off
+       ACTION=alias
+       action_alias
+       printf '%s\\n' "\${CALL_LOG[@]}"
+       exit 0`,
+      'bash',
+      REMOTE_SH,
+      '/tmp/lifecycle-canary-functional-fail',
+      sha,
+    ],
+    {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        ACTION: 'alias',
+        OUTPUT_DIR: '/tmp/lifecycle-canary-functional-fail',
+        RUN_STAMP: 'contract',
+        LIFECYCLE_CANARY_SOURCE_ONLY: 'true',
+        DEPLOY_SHA: sha,
+        EXPECTED_CURRENT_MODE: 'off',
+      },
+    },
+  )
+  assert.notEqual(result.status, 0, 'post_on failure must fail the action')
+  const lines = result.stdout.trim().split('\n').filter(Boolean)
+  const baseline = lines.indexOf('off_baseline')
+  const postOn = lines.indexOf('login:post_on')
+  const restore = lines.indexOf('restore')
+  const failLine = lines.findIndex((l) => l.startsWith('fail:'))
+  assert.ok(baseline >= 0, `log=${lines.join(',')}`)
+  assert.ok(!lines.includes('backup_stale'), 'must not backup stale on-disk override')
+  assert.ok(postOn >= 0, `log=${lines.join(',')}`)
+  assert.ok(restore > postOn, 'fail_transition_restore must restore after post_on failure')
+  assert.ok(failLine > restore, 'termination must follow restore')
+  assert.match(lines[failLine], /post_on_password_login_failed/)
+})
+
+test('FUNCTIONAL: stale on-disk alias=true is discarded; alias rollback baseline is explicit OFF', () => {
+  // Live runtime is off, but a stale unapplied override file still has alias=true.
+  // establish_alias_off_rollback_baseline must write compose-validated OFF and use
+  // that as LIFECYCLE_PREV_BACKUP — never the stale prior file.
+  const dir = mkdtempSync(join(tmpdir(), 'lifecycle-stale-override-'))
+  try {
+    const overrideFile = join(dir, 'docker-compose.lifecycle-canary.override.yml')
+    const persistDir = dir
+    writeFileSync(
+      overrideFile,
+      [
+        'services:',
+        '  backend:',
+        '    environment:',
+        '      AUTH_LOGIN_USE_ALIASES: "true"',
+        '      DIRECTORY_PENDING_ACTIVATION_ENABLED: "false"',
+        '      DIRECTORY_DEPROVISION_ENABLED: "false"',
+        '',
+      ].join('\n'),
+      'utf8',
+    )
+    const result = spawnSync(
+      'bash',
+      [
+        '-o',
+        'pipefail',
+        '-c',
+        `source "$1"
+         LIFECYCLE_PERSIST_DIR="$2"
+         LIFECYCLE_OVERRIDE_FILE="$3"
+         RUN_STAMP=contract-stale
+         require_compose_v2() { return 0; }
+         compose_staging_cmd() { return 0; }
+         # Production establish writes OFF via write_lifecycle_override (mocked compose ok).
+         establish_alias_off_rollback_baseline
+         # After establish: live override + backup must be explicit OFF, not stale true.
+         if grep -q 'AUTH_LOGIN_USE_ALIASES: "true"' "\$LIFECYCLE_OVERRIDE_FILE"; then
+           echo 'FAIL:live_override_still_true' >&2
+           exit 3
+         fi
+         if ! grep -q 'AUTH_LOGIN_USE_ALIASES: "false"' "\$LIFECYCLE_OVERRIDE_FILE"; then
+           echo 'FAIL:live_override_missing_false' >&2
+           exit 4
+         fi
+         if [[ "\$LIFECYCLE_PREV_STATE" != "present" || ! -s "\$LIFECYCLE_PREV_BACKUP" ]]; then
+           echo 'FAIL:baseline_backup_missing' >&2
+           exit 5
+         fi
+         if grep -q 'AUTH_LOGIN_USE_ALIASES: "true"' "\$LIFECYCLE_PREV_BACKUP"; then
+           echo 'FAIL:baseline_backup_has_true' >&2
+           exit 6
+         fi
+         if ! grep -q 'AUTH_LOGIN_USE_ALIASES: "false"' "\$LIFECYCLE_PREV_BACKUP"; then
+           echo 'FAIL:baseline_backup_missing_false' >&2
+           exit 7
+         fi
+         # Simulate post-write ON, then restore: must reinstall OFF baseline, not stale true.
+         cat > "\$LIFECYCLE_OVERRIDE_FILE" <<'ON'
+services:
+  backend:
+    environment:
+      AUTH_LOGIN_USE_ALIASES: "true"
+      DIRECTORY_PENDING_ACTIVATION_ENABLED: "false"
+      DIRECTORY_DEPROVISION_ENABLED: "false"
+ON
+         restore_lifecycle_override
+         if grep -q 'AUTH_LOGIN_USE_ALIASES: "true"' "\$LIFECYCLE_OVERRIDE_FILE"; then
+           echo 'FAIL:restore_reinstalled_stale_true' >&2
+           exit 8
+         fi
+         if ! grep -q 'AUTH_LOGIN_USE_ALIASES: "false"' "\$LIFECYCLE_OVERRIDE_FILE"; then
+           echo 'FAIL:restore_not_explicit_off' >&2
+           exit 9
+         fi
+         echo 'OK:explicit_off_baseline'
+         cleanup_prev_backup`,
+        'bash',
+        REMOTE_SH,
+        persistDir,
+        overrideFile,
+      ],
+      {
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          ACTION: 'status',
+          OUTPUT_DIR: '/tmp/lifecycle-canary-contract-source-only',
+          RUN_STAMP: 'contract',
+          LIFECYCLE_CANARY_SOURCE_ONLY: 'true',
+        },
+      },
+    )
+    assert.equal(result.status, 0, result.stderr + result.stdout)
+    assert.match(result.stdout, /OK:explicit_off_baseline/)
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
 // --- docs / staging blockers ----------------------------------------------------------
 
-test('docs mark alias/pending/deprovision NOT EXECUTABLE and canary NOT EXECUTED', () => {
+test('docs mark pending/deprovision NOT EXECUTABLE; alias is executable transient canary', () => {
   const closeout = read(CLOSEOUT_DOC)
   const go = read(CANARY_GO_DOC)
-  for (const doc of [closeout, go]) {
-    assert.match(doc, /NOT EXECUTABLE/)
-    assert.match(doc, /NOT EXECUTED/)
-  }
-  // Current live evidence and remaining provenance blocker are called out.
-  assert.match(closeout, /314\/0|Pending: 0|migrations_pending_zero=true/i)
-  assert.match(closeout, /provenance conflict|metadata.*old|image.*health/i)
+  // Closeout may still describe historical NOT EXECUTABLE for ON names; go-doc is authoritative.
+  assert.match(closeout, /NOT EXECUTABLE/)
+  assert.match(go, /NOT EXECUTABLE/)
+  assert.match(go, /pending/)
+  assert.match(go, /deprovision/)
+  assert.match(go, /EXECUTABLE/)
+  assert.match(go, /alias/)
+  assert.match(go, /success requires\/proves OFF|Success requires\/proves OFF/i)
+  assert.match(go, /failure restores the OFF override before failing/i)
+  assert.match(go, /runtime OFF cannot be proven/i)
+  assert.doesNotMatch(go, /ALWAYS returns to OFF|always returns to OFF|always restores OFF/i)
+  assert.match(go, /LIFECYCLE_CANARY_LOGIN_IDENTIFIER|secret-backed/)
+  assert.match(go, /collisions==0|collisions must be 0|collisions==0/i)
+  // No invented successful canary execution evidence.
+  assert.doesNotMatch(go, /alias canary EXECUTED successfully|alias cutover canary PASSED on staging/i)
+  assert.match(go, /NOT EXECUTED/)
 })
 
 test('docs distinguish emergency off env-gate from OR-column fallback reintroduction', () => {
@@ -727,7 +1925,7 @@ test('six-step T2-Gate still points at post-fix 20260725 UAT', () => {
   assert.match(closeout, /dingtalk-directory-corp-scope-staging-uat-20260725\.md/)
 })
 
-test('staging env example keeps three flags OFF and documents minimal safe lane', () => {
+test('staging env example keeps three flags OFF and documents lifecycle canary', () => {
   const env = read(STAGING_ENV_EXAMPLE)
   assert.match(env, /^AUTH_LOGIN_USE_ALIASES=false$/m)
   assert.match(env, /^DIRECTORY_PENDING_ACTIVATION_ENABLED=false$/m)
@@ -735,7 +1933,7 @@ test('staging env example keeps three flags OFF and documents minimal safe lane'
   assert.match(env, /NOT EXECUTABLE|lifecycle.*canary|canary.*lifecycle/i)
 })
 
-test('workflow exports only safe remote env keys (no canary tokens)', () => {
+test('workflow exports only safe remote env keys (no raw secret values)', () => {
   const yaml = read(WORKFLOW)
   for (const key of [
     'ACTION',
@@ -749,6 +1947,8 @@ test('workflow exports only safe remote env keys (no canary tokens)', () => {
   ]) {
     assert.match(yaml, new RegExp(`export ${key}=`))
   }
-  assert.doesNotMatch(yaml, /export CANARY_/)
+  assert.doesNotMatch(yaml, /export CANARY_SUBJECT/)
   assert.doesNotMatch(yaml, /export OWNER_CONFIRM=/)
+  assert.doesNotMatch(yaml, /export ATTENDANCE_ADMIN_JWT=/)
+  assert.doesNotMatch(yaml, /export LIFECYCLE_CANARY_LOGIN_PASSWORD=/)
 })

--- a/scripts/ops/dingtalk-lifecycle-staging-canary-remote.sh
+++ b/scripts/ops/dingtalk-lifecycle-staging-canary-remote.sh
@@ -8,26 +8,39 @@
 #   status     — read-only snapshot (values-free closed booleans / SHA / health)
 #   preflight  — read-only readiness for a target mode; never applies env flips
 #   off        — emergency operational rollback of the THREE lifecycle env gates
-#                to OFF (only permitted env write). Atomic previous-override
-#                backup + restore on restart/health/mode failure.
+#                to OFF. Atomic previous-override backup + restore on
+#                restart/health/mode failure.
+#   alias      — TRANSIENT secret-backed alias cutover canary.
+#                Success requires/proves OFF (post-rollback mode+login).
+#                Failure restores the OFF override before failing (post-write).
+#                Runtime OFF cannot be proven if rollback recreate itself fails
+#                (override restored on disk; operator must inspect).
+#                Requires full deploy SHA, expected_current_mode=off, admin JWT
+#                file + login identifier/password files (chmod 600).
+#                Sequence: pre-login → backfill (collisions==0) → cutover-status
+#                ready → write alias ON → recreate backend only → post-ON login
+#                → restore OFF → recreate → post-rollback login.
+#                Backfill rows may persist.
 #
 # NOT EXECUTABLE (fail-closed preflight-only; transition_applied always false):
-#   alias / pending / deprovision
+#   pending / deprovision
 #     Env flips alone are NOT a canary. There is no secret-backed real verifier
-#     for password-login success/rollback, admit→activate, or sync→deprovision.
-#     Presence tokens must not pretend to drive those paths. These actions only
-#     emit a preflight assessment and refuse apply.
+#     for admit→activate or sync→deprovision. Presence tokens must not pretend
+#     to drive those paths.
 #
 # HARD SAFETY RAILS:
 #   * Staging compose + metasheet-staging-* containers only; no prod fallback.
 #   * migrations_pending_zero must be exactly "true" for preflight_ok and for
-#     action=off (unknown is a fail, never treated as success).
-#   * action=off: recreate backend only; prove postgres/redis IDs unchanged;
-#     require backend health true after restart; prove exact mode=off; restore
+#     action=off / action=alias (unknown is a fail, never treated as success).
+#   * action=off|alias: recreate backend only; prove postgres/redis IDs unchanged;
+#     require backend health true after restart; prove exact mode; restore
 #     previous override and re-recreate on any failure after the write.
 #   * multi-on: status/preflight report and fail closed; action=off still clears
 #     the exact three flags (does not die in derive_mode before clear).
-#   * Artifacts never contain env values, credentials, subject ids, or PII.
+#   * Artifacts never contain env values, credentials, subject ids, or PII —
+#     only booleans / counts / reason enums / SHA.
+#   * Secrets never appear in shell argv, process listings via export of values,
+#     or logs; only chmod-600 file paths are passed.
 #   * Invoked as `bash -o pipefail -c '<script>'`.
 set -euo pipefail
 
@@ -43,6 +56,12 @@ DEPLOY_PATH="${DEPLOY_PATH:-metasheet2}"
 OUTPUT_DIR="${OUTPUT_DIR:?OUTPUT_DIR is required}"
 RUN_STAMP="${RUN_STAMP:?RUN_STAMP is required (workflow run id marker)}"
 
+# Secret-backed alias canary inputs: FILE PATHS only (values never exported).
+# Workflow materializes chmod-600 files into the per-run remote directory.
+CANARY_ADMIN_JWT_FILE="${CANARY_ADMIN_JWT_FILE:-}"
+CANARY_LOGIN_IDENTIFIER_FILE="${CANARY_LOGIN_IDENTIFIER_FILE:-}"
+CANARY_LOGIN_PASSWORD_FILE="${CANARY_LOGIN_PASSWORD_FILE:-}"
+
 # Intentionally ignored: not a real verifier path. Kept empty so accidental
 # exports cannot be mistaken for canary completion evidence.
 # CANARY_SUBJECT_ID / CANARY_INTEGRATION_ID / OWNER_CONFIRM are NOT used.
@@ -53,6 +72,7 @@ POSTGRES_CONTAINER="metasheet-staging-postgres"
 REDIS_CONTAINER="metasheet-staging-redis"
 STAGING_WEB_HEALTH_URL="http://127.0.0.1:8082/api/health"
 STAGING_BACKEND_HEALTH_URL="http://127.0.0.1:18900/health"
+STAGING_API_BASE_URL="http://127.0.0.1:8082"
 MIGRATE_JS="packages/core-backend/dist/src/db/migrate.js"
 
 FLAG_ALIAS="AUTH_LOGIN_USE_ALIASES"
@@ -84,11 +104,13 @@ fi
 
 LIFECYCLE_PERSIST_DIR="${HOME}/.metasheet2/lifecycle-canary"
 LIFECYCLE_OVERRIDE_FILE="${LIFECYCLE_PERSIST_DIR}/docker-compose.lifecycle-canary.override.yml"
-# Previous-override backup used only during action=off for restore-on-failure.
+# Previous-override backup used during action=off|alias for restore-on-failure
+# (alias success path also restores OFF to prove rollback; failure restores first).
 LIFECYCLE_PREV_BACKUP=""
 LIFECYCLE_PREV_STATE="absent" # absent | present
 PINNED_IMAGE_OWNER=""
 PINNED_IMAGE_TAG=""
+ALIAS_ROLLBACK_ARMED="false"
 
 is_truthy() {
   local v
@@ -344,7 +366,7 @@ probe_migration_pending_zero() {
 }
 
 require_migrations_pending_zero_true() {
-  # Load-bearing for every transition (currently only action=off) and for preflight_ok.
+  # Load-bearing for every transition (action=off|alias) and for preflight_ok.
   local v="$1" context="$2"
   if [[ "$v" == "true" ]]; then
     return 0
@@ -353,6 +375,276 @@ require_migrations_pending_zero_true() {
     fail "${context}: migrations_pending_zero must be exactly true (got false — pending migrations; run attendance staging migrate backup/clone-rehearsal first)"
   fi
   fail "${context}: migrations_pending_zero must be exactly true (got '${v}' — probe unknown/failed; refuse, do not treat unknown as success)"
+}
+
+require_canary_secret_files() {
+  # Paths only — never read values into shell variables that get logged.
+  local f
+  for f in \
+    CANARY_ADMIN_JWT_FILE \
+    CANARY_LOGIN_IDENTIFIER_FILE \
+    CANARY_LOGIN_PASSWORD_FILE
+  do
+    local path="${!f:-}"
+    [[ -n "$path" ]] || fail "action=alias requires ${f} (chmod-600 secret file path); no auto-selection"
+    [[ -f "$path" ]] || fail "action=alias secret file missing for ${f}"
+    [[ -s "$path" ]] || fail "action=alias secret file empty for ${f}"
+  done
+  log "alias canary secret files present (paths only; values never logged)"
+}
+
+# Real password login via secret files. Values stay inside python; never argv/export/log.
+# Identifier may follow app trim semantics (strip ends). Password is read EXACTLY as
+# stored (no CR/LF strip, no transform). stdout: true|ok or false|<reason_enum>.
+prove_canary_password_login() {
+  local context="$1"
+  local result ok note
+  result="$(
+    python3 - "$CANARY_LOGIN_IDENTIFIER_FILE" "$CANARY_LOGIN_PASSWORD_FILE" "$STAGING_API_BASE_URL" <<'PY'
+import json
+import pathlib
+import sys
+import urllib.error
+import urllib.request
+
+ident_path, pass_path, base = sys.argv[1], sys.argv[2], sys.argv[3]
+try:
+    # read_bytes+decode avoids text-mode universal-newline translation.
+    # App sanitizeLoginIdentifier trims ends; password must not be transformed.
+    identifier = pathlib.Path(ident_path).read_bytes().decode("utf-8").strip()
+    password = pathlib.Path(pass_path).read_bytes().decode("utf-8")
+except Exception:
+    print("false|secret_file_read_failed")
+    raise SystemExit(0)
+if not identifier or password == "":
+    print("false|empty_credentials")
+    raise SystemExit(0)
+body = json.dumps({"identifier": identifier, "password": password}).encode("utf-8")
+req = urllib.request.Request(
+    base.rstrip("/") + "/api/auth/login",
+    data=body,
+    headers={"Content-Type": "application/json", "Accept": "application/json"},
+    method="POST",
+)
+try:
+    with urllib.request.urlopen(req, timeout=20) as resp:
+        raw = resp.read().decode("utf-8", errors="replace")
+        code = int(resp.getcode())
+except urllib.error.HTTPError as e:
+    print(f"false|http_{int(e.code)}")
+    raise SystemExit(0)
+except Exception:
+    print("false|request_failed")
+    raise SystemExit(0)
+try:
+    data = json.loads(raw)
+except Exception:
+    print(f"false|http_{code}_bad_json")
+    raise SystemExit(0)
+token = ""
+if isinstance(data, dict) and isinstance(data.get("data"), dict):
+    token = data["data"].get("token") or ""
+ok = (
+    code == 200
+    and data.get("success") is True
+    and isinstance(token, str)
+    and len(token) > 0
+)
+print("true|ok" if ok else f"false|http_{code}_login_rejected")
+PY
+  )"
+  ok="${result%%|*}"
+  note="${result#*|}"
+  if [[ "$ok" == "true" ]]; then
+    log "password login OK (${context})"
+    return 0
+  fi
+  log "password login FAILED (${context}): ${note}"
+  return 1
+}
+
+# Admin API via JWT file. Prints values-free result lines; never logs token.
+# Usage: admin_api_request METHOD PATH
+# stdout on transport success: HTTP_CODE\nBODY
+admin_api_request() {
+  local method="$1" path="$2"
+  python3 - "$CANARY_ADMIN_JWT_FILE" "$STAGING_API_BASE_URL" "$method" "$path" <<'PY'
+import pathlib
+import sys
+import urllib.error
+import urllib.request
+
+jwt_path, base, method, path = sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4]
+try:
+    token = pathlib.Path(jwt_path).read_text(encoding="utf-8").strip()
+except Exception:
+    sys.stderr.write("admin jwt file read failed\n")
+    raise SystemExit(2)
+if not token:
+    sys.stderr.write("admin jwt file empty\n")
+    raise SystemExit(2)
+url = base.rstrip("/") + path
+data = b"{}" if method.upper() == "POST" else None
+req = urllib.request.Request(
+    url,
+    data=data,
+    headers={
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+    },
+    method=method.upper(),
+)
+try:
+    with urllib.request.urlopen(req, timeout=60) as resp:
+        body = resp.read().decode("utf-8", errors="replace")
+        code = int(resp.getcode())
+except urllib.error.HTTPError as e:
+    body = e.read().decode("utf-8", errors="replace")
+    code = int(e.code)
+except Exception as e:
+    sys.stderr.write(f"admin api request failed: {type(e).__name__}\n")
+    raise SystemExit(2)
+sys.stdout.write(f"{code}\n{body}")
+PY
+}
+
+# POST /api/admin/login-aliases/backfill — success required; record counts only.
+# Requires Python int counts only (reject bool/float/string/missing/negative) and
+# collisions==0 before any env write (collisions would lock collided users out
+# under alias-only login). Production API returns JS numbers → JSON ints.
+# Sets: BACKFILL_OK BACKFILL_INSERTED BACKFILL_COLLISIONS BACKFILL_SKIPPED BACKFILL_NOTE
+run_alias_backfill() {
+  local raw code body parsed
+  BACKFILL_OK="false"
+  BACKFILL_INSERTED="0"
+  BACKFILL_COLLISIONS="0"
+  BACKFILL_SKIPPED="0"
+  BACKFILL_NOTE="unset"
+  if ! raw="$(admin_api_request POST /api/admin/login-aliases/backfill)"; then
+    BACKFILL_NOTE="transport_failed"
+    log "alias backfill request failed (transport)"
+    return 1
+  fi
+  code="$(printf '%s\n' "$raw" | head -n1)"
+  body="$(printf '%s\n' "$raw" | tail -n +2)"
+  if [[ "$code" != "200" ]]; then
+    BACKFILL_NOTE="http_${code}"
+    log "alias backfill HTTP ${code} (body redacted)"
+    return 1
+  fi
+  # Parse only counts / ok flag — never echo body (may contain unexpected fields).
+  # Fail closed: counts must be Python int only (not bool/float/str); collisions==0.
+  if ! parsed="$(printf '%s' "$body" | python3 -c 'import json,sys
+
+def nonneg_int(v, name):
+    # API emits JSON numbers as Python int. Reject bool (int subclass), float
+    # (including 1.0), string (including "1"), missing/None, and negatives.
+    if type(v) is not int:
+        raise ValueError(name)
+    if v < 0:
+        raise ValueError(name)
+    return v
+
+try:
+    d = json.load(sys.stdin)
+except Exception:
+    print("false|malformed|0|0|0")
+    raise SystemExit(0)
+if d.get("ok") is not True:
+    print("false|not_ok|0|0|0")
+    raise SystemExit(0)
+data = d.get("data") if isinstance(d.get("data"), dict) else None
+if not isinstance(data, dict):
+    print("false|malformed|0|0|0")
+    raise SystemExit(0)
+try:
+    # Missing keys → .get None → type is not int → malformed.
+    ins = nonneg_int(data.get("inserted"), "inserted")
+    col = nonneg_int(data.get("collisions"), "collisions")
+    sk = nonneg_int(
+        data["skippedEmpty"] if "skippedEmpty" in data else data.get("skipped_empty"),
+        "skippedEmpty",
+    )
+except Exception:
+    print("false|malformed|0|0|0")
+    raise SystemExit(0)
+if col != 0:
+    print(f"false|collisions_nonzero|{ins}|{col}|{sk}")
+    raise SystemExit(0)
+print(f"true|ok|{ins}|{col}|{sk}")
+')"; then
+    BACKFILL_NOTE="parse_failed"
+    log "alias backfill response parse failed"
+    return 1
+  fi
+  BACKFILL_OK="${parsed%%|*}"
+  local rest="${parsed#*|}"
+  BACKFILL_NOTE="${rest%%|*}"
+  rest="${rest#*|}"
+  BACKFILL_INSERTED="${rest%%|*}"
+  rest="${rest#*|}"
+  BACKFILL_COLLISIONS="${rest%%|*}"
+  BACKFILL_SKIPPED="${rest#*|}"
+  if [[ "$BACKFILL_OK" != "true" ]]; then
+    log "alias backfill refused: note=${BACKFILL_NOTE} inserted=${BACKFILL_INSERTED} collisions=${BACKFILL_COLLISIONS} skipped_empty=${BACKFILL_SKIPPED}"
+    return 1
+  fi
+  # Defense in depth: bash-side exact collisions==0 and nonnegative digit counts.
+  if [[ ! "$BACKFILL_INSERTED" =~ ^(0|[1-9][0-9]*)$ ]] \
+    || [[ ! "$BACKFILL_COLLISIONS" =~ ^(0|[1-9][0-9]*)$ ]] \
+    || [[ ! "$BACKFILL_SKIPPED" =~ ^(0|[1-9][0-9]*)$ ]]; then
+    BACKFILL_OK="false"
+    BACKFILL_NOTE="malformed_counts"
+    log "alias backfill refused: non-integer counts"
+    return 1
+  fi
+  if [[ "$BACKFILL_COLLISIONS" != "0" ]]; then
+    BACKFILL_OK="false"
+    BACKFILL_NOTE="collisions_nonzero"
+    log "alias backfill refused: collisions must be 0 (got ${BACKFILL_COLLISIONS}); refuse env write"
+    return 1
+  fi
+  log "alias backfill OK inserted=${BACKFILL_INSERTED} collisions=0 skipped_empty=${BACKFILL_SKIPPED}"
+  return 0
+}
+
+# GET /api/admin/login-aliases/cutover-status — require ready + canEnableCutover true.
+# Sets: CUTOVER_READY CUTOVER_CAN_ENABLE
+run_alias_cutover_status() {
+  local raw code body parsed
+  CUTOVER_READY="false"
+  CUTOVER_CAN_ENABLE="false"
+  if ! raw="$(admin_api_request GET /api/admin/login-aliases/cutover-status)"; then
+    log "alias cutover-status request failed (transport)"
+    return 1
+  fi
+  code="$(printf '%s\n' "$raw" | head -n1)"
+  body="$(printf '%s\n' "$raw" | tail -n +2)"
+  if [[ "$code" != "200" ]]; then
+    log "alias cutover-status HTTP ${code} (body redacted)"
+    return 1
+  fi
+  parsed="$(printf '%s' "$body" | python3 -c 'import json,sys
+try:
+    d=json.load(sys.stdin)
+except Exception:
+    print("false|false")
+    raise SystemExit(0)
+data = d.get("data") if isinstance(d.get("data"), dict) else {}
+# Prefer nested data; also accept top-level for resilience.
+ready = data.get("ready", d.get("ready"))
+can = data.get("canEnableCutover", d.get("canEnableCutover"))
+print(("true" if ready is True else "false") + "|" + ("true" if can is True else "false"))
+')"
+  CUTOVER_READY="${parsed%%|*}"
+  CUTOVER_CAN_ENABLE="${parsed#*|}"
+  if [[ "$CUTOVER_READY" != "true" || "$CUTOVER_CAN_ENABLE" != "true" ]]; then
+    log "alias cutover-status not ready (ready=${CUTOVER_READY} canEnableCutover=${CUTOVER_CAN_ENABLE})"
+    return 1
+  fi
+  log "alias cutover-status ready=true canEnableCutover=true"
+  return 0
 }
 
 validate_mode_name() {
@@ -451,6 +743,7 @@ capture_live_snapshot() {
 }
 
 backup_lifecycle_override() {
+  # action=off only: restore-on-failure returns to whatever was on disk before the write.
   mkdir -p "$LIFECYCLE_PERSIST_DIR"
   LIFECYCLE_PREV_BACKUP="$(mktemp "${LIFECYCLE_PERSIST_DIR}/.prev.XXXXXX")"
   if [[ -f "$LIFECYCLE_OVERRIDE_FILE" ]]; then
@@ -464,15 +757,42 @@ backup_lifecycle_override() {
   fi
 }
 
-restore_lifecycle_override() {
-  # Restore previous override state after a failed transition.
-  if [[ "$LIFECYCLE_PREV_STATE" == "present" && -n "$LIFECYCLE_PREV_BACKUP" && -s "$LIFECYCLE_PREV_BACKUP" ]]; then
-    cp -p "$LIFECYCLE_PREV_BACKUP" "$LIFECYCLE_OVERRIDE_FILE"
-    log "restored previous lifecycle override from backup"
-  else
-    rm -f "$LIFECYCLE_OVERRIDE_FILE"
-    log "removed lifecycle override (previous state was absent)"
+# action=alias only: never trust on-disk prior file as rollback target.
+# Runtime may be off while a stale unapplied override still has alias=true; restoring
+# that file after the canary would re-enable alias on recreate. Instead: write a
+# compose-validated explicit OFF (all three flags false) to disk and snapshot it as
+# the sole restore baseline used by restore_lifecycle_override / fail_transition_restore.
+establish_alias_off_rollback_baseline() {
+  log "establishing alias rollback baseline: explicit OFF (compose-validated; ignore stale on-disk)"
+  write_lifecycle_override "false" "false" "false"
+  mkdir -p "$LIFECYCLE_PERSIST_DIR"
+  LIFECYCLE_PREV_BACKUP="$(mktemp "${LIFECYCLE_PERSIST_DIR}/.alias-off-baseline.XXXXXX")"
+  cp -p "$LIFECYCLE_OVERRIDE_FILE" "$LIFECYCLE_PREV_BACKUP"
+  LIFECYCLE_PREV_STATE="present"
+  # Sanity: baseline file must encode all three flags false (defense in depth).
+  if ! grep -qE "${FLAG_ALIAS}:[[:space:]]*\"false\"" "$LIFECYCLE_PREV_BACKUP" \
+    || ! grep -qE "${FLAG_PENDING}:[[:space:]]*\"false\"" "$LIFECYCLE_PREV_BACKUP" \
+    || ! grep -qE "${FLAG_DEPROVISION}:[[:space:]]*\"false\"" "$LIFECYCLE_PREV_BACKUP"; then
+    cleanup_prev_backup
+    fail "alias OFF rollback baseline missing explicit false flags after write"
   fi
+  if grep -qE "${FLAG_ALIAS}:[[:space:]]*\"true\"" "$LIFECYCLE_PREV_BACKUP"; then
+    cleanup_prev_backup
+    fail "alias OFF rollback baseline must not contain AUTH_LOGIN_USE_ALIASES true"
+  fi
+  log "alias rollback baseline ready: explicit OFF on disk + backup (stale prior file discarded)"
+}
+
+restore_lifecycle_override() {
+  # Restore rollback baseline after a failed transition (or alias success path OFF return).
+  if [[ "$LIFECYCLE_PREV_STATE" == "present" && -n "$LIFECYCLE_PREV_BACKUP" && -s "$LIFECYCLE_PREV_BACKUP" ]]; then
+    cp -p "$LIFECYCLE_PREV_BACKUP" "$LIFECYCLE_OVERRIDE_FILE" || return 1
+    log "restored lifecycle override from rollback baseline backup" || true
+  else
+    rm -f "$LIFECYCLE_OVERRIDE_FILE" || return 1
+    log "removed lifecycle override (previous state was absent)" || true
+  fi
+  return 0
 }
 
 cleanup_prev_backup() {
@@ -494,7 +814,10 @@ write_lifecycle_override() {
     echo "# OFF is an emergency operational rollback of these env gates only —"
     echo "# it does NOT reintroduce OR-column login fallback as a long-term design"
     echo "# (design lock Rev 4.2 §4.2 / §4.4: after T2b cutover, Auth reads aliases only)."
-    echo "# alias/pending/deprovision ON are NOT EXECUTABLE in this lane."
+    echo "# action=alias may write AUTH_LOGIN_USE_ALIASES=true transiently; success"
+    echo "# requires/proves OFF; failure restores the compose-validated explicit OFF"
+    echo "# rollback baseline (never a stale on-disk prior file). Runtime OFF cannot be"
+    echo "# proven if rollback recreate fails. pending/deprovision ON remain NOT EXECUTABLE."
     echo "services:"
     echo "  backend:"
     echo "    environment:"
@@ -567,6 +890,17 @@ assert_exact_mode_off() {
   return 1
 }
 
+assert_exact_mode_alias() {
+  local a p d m
+  read -r a p d m <<< "$(read_live_flags)"
+  if [[ "$a" == "true" && "$p" == "false" && "$d" == "false" && "$m" == "alias" ]]; then
+    log "exact mode proven after restart: alias (only AUTH_LOGIN_USE_ALIASES true)"
+    return 0
+  fi
+  log "post-restart mode is '${m}' (alias=${a} pending=${p} deprovision=${d}), expected alias with only alias true"
+  return 1
+}
+
 assert_exact_sha() {
   require_sha
   local live
@@ -580,14 +914,73 @@ assert_exact_sha() {
   log "exact deployed SHA OK: ${live}"
 }
 
+alias_exit_rollback_guard() {
+  local original_rc=$?
+  local restored="false" recreated="false" proved_off="false"
+  local emergency_log="${OUTPUT_DIR}/alias-emergency-rollback.log"
+
+  # Prevent recursion while the guard performs best-effort recovery.
+  trap - EXIT HUP INT TERM PIPE
+  if [[ "$ALIAS_ROLLBACK_ARMED" != "true" ]]; then
+    exit "$original_rc"
+  fi
+  ALIAS_ROLLBACK_ARMED="false"
+  [[ "$original_rc" -ne 0 ]] || original_rc=1
+
+  set +e
+  # Keep all recovery output off the SSH stdout/stderr pipe. A broken transport
+  # may be the reason this guard fired; logging to that pipe must not block OFF.
+  {
+    log "alias rollback guard fired; restoring explicit OFF baseline before exit"
+    if restore_lifecycle_override; then
+      restored="true"
+      if recreate_backend_only; then
+        recreated="true"
+        if [[ "$(resolve_deployed_sha)" == "$DEPLOY_SHA" ]] \
+          && assert_exact_mode_off \
+          && [[ "$(fetch_backend_health_ok)" == "true" ]]; then
+          proved_off="true"
+        fi
+      fi
+    fi
+    cleanup_prev_backup
+
+    if [[ "$restored" == "true" && "$recreated" == "true" && "$proved_off" == "true" ]]; then
+      log "alias rollback guard proved runtime OFF after interrupted/failed canary"
+    else
+      echo "[lifecycle-canary][error] alias rollback guard could not prove runtime OFF (restored=${restored} recreated=${recreated} proved_off=${proved_off}); operator must inspect staging" >&2
+    fi
+  } >> "$emergency_log" 2>&1
+  exit "$original_rc"
+}
+
+arm_alias_exit_rollback_guard() {
+  ALIAS_ROLLBACK_ARMED="true"
+  trap alias_exit_rollback_guard EXIT
+  trap 'exit 129' HUP
+  trap 'exit 130' INT
+  trap 'exit 143' TERM
+  trap 'exit 141' PIPE
+}
+
+disarm_alias_exit_rollback_guard() {
+  ALIAS_ROLLBACK_ARMED="false"
+  trap - EXIT HUP INT TERM PIPE
+}
+
 fail_transition_restore() {
   local reason="$1"
   log "transition failure (${reason}); restoring previous lifecycle override and re-recreating backend"
   restore_lifecycle_override
   # Best-effort recreate after restore so live env matches restored override.
   recreate_backend_only || log "restore recreate did not reach health true; operator must inspect staging"
+  if [[ "$ACTION" == "alias" ]]; then
+    # This explicit failure path already attempted runtime restore. Avoid a
+    # second EXIT-handler recreate after its backup is cleaned below.
+    disarm_alias_exit_rollback_guard
+  fi
   cleanup_prev_backup
-  fail "action=off failed: ${reason} (previous override restored)"
+  fail "action=${ACTION} failed: ${reason} (previous override restored)"
 }
 
 # --- actions ---------------------------------------------------------------------------
@@ -695,9 +1088,11 @@ preflight_for_target() {
 
   case "$target" in
     off)
-      # Emergency env-gate clear is the only executable write path (handled by action=off).
+      # Emergency env-gate clear (handled by action=off).
       ;;
     alias)
+      # Stack readiness only. action=alias additionally requires secret files +
+      # real password-login / backfill / cutover-status proofs before any write.
       if [[ "$SNAP_MODE" != "off" && "$SNAP_MODE" != "alias" ]]; then
         PREFLIGHT_OK="false"
         PREFLIGHT_NOTE="other_lifecycle_flag_on"
@@ -708,9 +1103,6 @@ preflight_for_target() {
         PREFLIGHT_NOTE="alias_cutover_not_ready"
         return 0
       fi
-      # Even when stack looks ready: ON is NOT EXECUTABLE (no password-login proof).
-      PREFLIGHT_OK="false"
-      PREFLIGHT_NOTE="not_executable_no_real_verifier"
       ;;
     pending|deprovision)
       if [[ "$SNAP_MODE" != "off" && "$SNAP_MODE" != "$target" ]]; then
@@ -756,15 +1148,15 @@ action_preflight() {
   if [[ "$PREFLIGHT_OK" != "true" ]]; then
     fail "preflight failed: ${PREFLIGHT_NOTE}"
   fi
-  # Ready-looking preflight for alias/pending/deprovision still means NOT EXECUTABLE ON.
-  if [[ "$target" == "alias" || "$target" == "pending" || "$target" == "deprovision" ]]; then
+  # pending/deprovision remain NOT EXECUTABLE ON even when stack looks ready.
+  if [[ "$target" == "pending" || "$target" == "deprovision" ]]; then
     log "preflight assessed target=${target} note=${PREFLIGHT_NOTE} (ON transition NOT EXECUTABLE)"
   else
     log "preflight OK target=${target} note=${PREFLIGHT_NOTE}"
   fi
 }
 
-# Fail-closed: alias/pending/deprovision never apply. Preflight assessment only.
+# Fail-closed: pending/deprovision never apply. Preflight assessment only.
 action_not_executable_on() {
   local target="$1"
   capture_live_snapshot
@@ -788,7 +1180,7 @@ action_not_executable_on() {
     echo "transition_applied=false"
     echo "executable=false"
   } > "${OUTPUT_DIR}/summary.txt"
-  fail "action=${target} is NOT EXECUTABLE: no secret-backed real verifier for canary proof (password-login / admit-activate / sync-deprovision). Env flip alone is refused. Use status|preflight|off only. transition_applied=false"
+  fail "action=${target} is NOT EXECUTABLE: no secret-backed real verifier for canary proof (admit-activate / sync-deprovision). Env flip alone is refused. Use status|preflight|off|alias only. transition_applied=false"
 }
 
 # Sole executable env write: clear the exact three lifecycle flags to false.
@@ -847,6 +1239,137 @@ action_off() {
   log "action=off OK (emergency env-gate clear; NOT a design reintroduction of OR-column fallback)"
 }
 
+# Transient secret-backed alias cutover canary.
+# Success requires/proves OFF (mode+post-rollback login). Failure restores the
+# compose-validated explicit OFF rollback baseline before failing (never a stale
+# on-disk prior file). Persistent override is left explicitly OFF. Runtime OFF
+# cannot be proven if rollback recreate fails (OFF baseline restored on disk;
+# operator must inspect). Backfill rows may persist.
+action_alias() {
+  local pre_login_ok="false"
+  local post_on_login_ok="false"
+  local post_rollback_login_ok="false"
+  local rolled_back_to_off="false"
+  local alias_on_applied="false"
+  local note="alias_cutover_canary"
+
+  require_sha
+  require_canary_secret_files
+  [[ -n "$EXPECTED_CURRENT_MODE" ]] || fail "expected_current_mode is required for action=alias"
+  [[ "$EXPECTED_CURRENT_MODE" == "off" ]] \
+    || fail "action=alias requires expected_current_mode=off (got '${EXPECTED_CURRENT_MODE}'); refuse auto-selection"
+
+  capture_live_snapshot
+  assert_exact_sha
+  pin_live_backend_image_for_transition
+  require_migrations_pending_zero_true "$SNAP_MIGRATIONS_ZERO" "action=alias"
+
+  if [[ "$SNAP_HEALTH_OK" != "true" ]]; then
+    fail "action=alias refused: backend_health_ok must be true before any env write"
+  fi
+  if [[ "$SNAP_MODE" != "off" ]]; then
+    fail "action=alias refused: live mode must be off before cutover (live='${SNAP_MODE}')"
+  fi
+  if [[ "$SNAP_MODE" != "$EXPECTED_CURRENT_MODE" ]]; then
+    fail "strict expected-current-mode transition failed: live='${SNAP_MODE}' expected_current_mode='${EXPECTED_CURRENT_MODE}'"
+  fi
+
+  # 1) Pre-write real password login (OR-column path while mode=off).
+  if prove_canary_password_login "pre_on"; then
+    pre_login_ok="true"
+  else
+    fail "action=alias refused: pre-ON password login failed (no env write performed)"
+  fi
+
+  # 2) T2a backfill + T2b readiness via admin JWT (no env write yet).
+  if ! run_alias_backfill; then
+    fail "action=alias refused: login-aliases backfill failed (no env write performed)"
+  fi
+  if ! run_alias_cutover_status; then
+    fail "action=alias refused: cutover-status not ready/canEnableCutover (no env write performed)"
+  fi
+
+  # 3) Explicit OFF rollback baseline (not stale on-disk) → write alias ON → recreate
+  #    → prove SHA/mode/health + post-ON login. fail_transition_restore always restores
+  #    that OFF baseline (never an arbitrary prior file).
+  establish_alias_off_rollback_baseline
+  # Arm before the persistent ON write. Any unhandled exit, SSH/HUP, cancellation,
+  # or signal in the ON window restores/recreates/proves the explicit OFF baseline.
+  arm_alias_exit_rollback_guard
+  write_lifecycle_override "true" "false" "false"
+  alias_on_applied="true"
+
+  if ! recreate_backend_only; then
+    fail_transition_restore "backend_health_not_true_after_restart"
+  fi
+  if [[ "$(resolve_deployed_sha)" != "$DEPLOY_SHA" ]]; then
+    fail_transition_restore "post_restart_sha_mismatch"
+  fi
+  if ! assert_exact_mode_alias; then
+    fail_transition_restore "post_restart_mode_not_alias"
+  fi
+  if prove_canary_password_login "post_on"; then
+    post_on_login_ok="true"
+  else
+    fail_transition_restore "post_on_password_login_failed"
+  fi
+
+  # 4) Success path: restore explicit OFF baseline, re-recreate, prove OFF + login.
+  # If rollback recreate fails, runtime OFF cannot be proven (OFF baseline on disk).
+  log "alias ON proven; restoring explicit OFF rollback baseline (success requires/proves OFF; canary must not leave alias enabled)"
+  restore_lifecycle_override
+  if ! recreate_backend_only; then
+    fail "action=alias: ON proven but rollback recreate failed — runtime OFF cannot be proven (explicit OFF baseline restored on disk; operator must inspect staging)"
+  fi
+  if [[ "$(resolve_deployed_sha)" != "$DEPLOY_SHA" ]]; then
+    fail "action=alias: rollback SHA mismatch after restore — runtime OFF not fully proven (operator must inspect staging)"
+  fi
+  if ! assert_exact_mode_off; then
+    fail "action=alias: rollback did not prove exact mode=off (operator must inspect staging)"
+  fi
+  if [[ "$(fetch_backend_health_ok)" != "true" ]]; then
+    fail "action=alias: rollback backend health not true — runtime OFF not fully proven (operator must inspect staging)"
+  fi
+  if prove_canary_password_login "post_rollback"; then
+    post_rollback_login_ok="true"
+  else
+    fail "action=alias: post-rollback password login failed after mode=off proof (operator must inspect credentials/stack)"
+  fi
+  rolled_back_to_off="true"
+  disarm_alias_exit_rollback_guard
+  cleanup_prev_backup
+
+  capture_live_snapshot
+  note="alias_cutover_canary_success_proved_off"
+  write_status_artifact \
+    "${SNAP_BUILD_SHA:-unknown}" \
+    "$SNAP_ALIAS" "$SNAP_PENDING" "$SNAP_DEPROV" "$SNAP_MODE" \
+    "$SNAP_ALIAS_READY" "$SNAP_CAN_ENABLE_ALIAS" \
+    "$SNAP_MIGRATIONS_ZERO" "$SNAP_HEALTH_OK" \
+    "alias" "true" "true" "$note"
+  {
+    echo "action=alias"
+    echo "mode=${SNAP_MODE}"
+    echo "build_sha=${SNAP_BUILD_SHA:-unknown}"
+    echo "transition_applied=true"
+    echo "from_mode=off"
+    echo "to_mode=off"
+    echo "alias_on_applied=${alias_on_applied}"
+    echo "pre_login_ok=${pre_login_ok}"
+    echo "post_on_login_ok=${post_on_login_ok}"
+    echo "post_rollback_login_ok=${post_rollback_login_ok}"
+    echo "rolled_back_to_off=${rolled_back_to_off}"
+    echo "backfill_ok=${BACKFILL_OK:-false}"
+    echo "backfill_inserted=${BACKFILL_INSERTED:-0}"
+    echo "backfill_collisions=${BACKFILL_COLLISIONS:-0}"
+    echo "backfill_skipped_empty=${BACKFILL_SKIPPED:-0}"
+    echo "cutover_ready=${CUTOVER_READY:-false}"
+    echo "cutover_can_enable=${CUTOVER_CAN_ENABLE:-false}"
+    echo "note=${note}"
+  } > "${OUTPUT_DIR}/summary.txt"
+  log "action=alias OK (transient ON proven; success proved OFF; backfill may persist)"
+}
+
 # --- main ------------------------------------------------------------------------------
 
 main() {
@@ -857,7 +1380,7 @@ main() {
     status) action_status ;;
     preflight) action_preflight ;;
     off) action_off ;;
-    alias) action_not_executable_on alias ;;
+    alias) action_alias ;;
     pending) action_not_executable_on pending ;;
     deprovision) action_not_executable_on deprovision ;;
     *) fail "invalid ACTION='${ACTION}' (status|preflight|off|alias|pending|deprovision)" ;;


### PR DESCRIPTION
## What
- add an executable staging-only `action=alias` lifecycle canary
- backfill login aliases, require zero collisions and cutover readiness
- prove designated canary-admin password login before ON, under transient alias-only ON, and after rollback OFF
- keep pending admission and deprovision non-executable
- document the secret-backed runbook and rollback contract

## Safety
- exact 40-char deployed SHA, zero pending migrations, healthy backend, and current mode `off` are mandatory
- only the staging backend is force-recreated; Postgres/Redis container IDs must remain unchanged
- raw credentials are never sent in argv, logs, or artifacts; they are transported as per-run chmod-600 files and cleaned by traps
- rollback baseline is an explicit compose-validated all-OFF file, never a stale on-disk override
- a remote `EXIT`/`HUP`/`INT`/`TERM` guard is armed before alias=ON and remains armed through OFF mode, health, SHA, and post-rollback login proof
- success always leaves and proves all lifecycle flags OFF; backfilled alias rows may persist

## Verification
- `node --test scripts/ops/dingtalk-lifecycle-staging-canary-contract.test.mjs` (73/73)
- `bash -n scripts/ops/dingtalk-lifecycle-staging-canary-remote.sh`
- workflow YAML parse
- functional SIGTERM harness proves restore -> backend recreate -> exact OFF/health proof before nonzero exit
- mutations pin collision rejection, exact password bytes, stale-override rejection, guard arm/disarm placement, and restore sequencing

## Operational boundary
Landing this PR does not dispatch staging and does not enable production. A real alias dispatch additionally requires repository secrets `LIFECYCLE_CANARY_LOGIN_IDENTIFIER` and `LIFECYCLE_CANARY_LOGIN_PASSWORD`; they must be configured out of band and never pasted into PR/chat.
