### PR TITLE
fix(stock-prep): pass default integration scope

### DIFF
--- a/apps/web/src/components/integration/stockPreparation/StockPreparationWorkspace.vue
+++ b/apps/web/src/components/integration/stockPreparation/StockPreparationWorkspace.vue
@@ -61,6 +61,7 @@
       <StockPreparationDashboardView
         v-if="activeKey === 'dashboard'"
         :project-id="selectedProjectId"
+        :scope="scope"
         @select-project="handleDashboardProjectSelect"
         @navigate-stage="handleNavigateStage"
       />
@@ -69,27 +70,33 @@
            (#4017 pattern). -->
       <StockPreparationProjectWorkspaceView
         v-else-if="activeKey === 'project-workspace'"
+        :scope="scope"
         @select-project="handleProjectSelect"
       />
       <StockPreparationSnapshotDiffView
         v-else-if="activeKey === 'bom-snapshot-diff'"
         :project-id="selectedProjectId"
+        :scope="scope"
       />
       <StockPreparationMappingConfirmView
         v-else-if="activeKey === 'material-mapping'"
         :project-id="selectedProjectId"
+        :scope="scope"
       />
       <StockPreparationUnitConfirmView
         v-else-if="activeKey === 'unit-conversion'"
         :project-id="selectedProjectId"
+        :scope="scope"
       />
       <StockPreparationPrepLineView
         v-else-if="activeKey === 'prep-line'"
         :project-id="selectedProjectId"
+        :scope="scope"
       />
       <StockPreparationExceptionQueueView
         v-else-if="activeKey === 'exception-queue'"
         :project-id="selectedProjectId"
+        :scope="scope"
       />
       <p v-else class="stock-prep__panel-pending" data-testid="stock-prep-panel-pending">
         {{ bi('该视图将在后续 wave 落地,当前为容器占位。', 'This view lands in a later wave; this is a container placeholder for now.') }}
@@ -111,6 +118,7 @@
 import { computed, ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useLocale } from '../../../composables/useLocale'
+import { getDefaultIntegrationScope } from '../../../services/integration/workbench'
 import PageShell from '../../layout/PageShell.vue'
 import PageHeader from '../../layout/PageHeader.vue'
 import StockPreparationDashboardView from './StockPreparationDashboardView.vue'
@@ -122,6 +130,7 @@ import StockPreparationPrepLineView from './StockPreparationPrepLineView.vue'
 import StockPreparationExceptionQueueView from './StockPreparationExceptionQueueView.vue'
 
 const { locale } = useLocale()
+const scope = getDefaultIntegrationScope()
 
 // Same synchronous locale pattern as the rest of the integration surface (IntegrationHelpView /
 // errorCodeLabels): read `locale.value` directly in the template.

--- a/apps/web/tests/StockPreparationWorkspace.spec.ts
+++ b/apps/web/tests/StockPreparationWorkspace.spec.ts
@@ -452,6 +452,9 @@ describe('StockPreparationWorkspace shell', () => {
   beforeEach(() => {
     h.locale = 'zh-CN'
     h.route = { path: '/stock-prep', fullPath: '/stock-prep', meta: {}, query: {} }
+    localStorage.removeItem('tenantId')
+    localStorage.removeItem('workspaceId')
+    h.apiFetch.mockReset()
     container = document.createElement('div')
     document.body.appendChild(container)
   })
@@ -461,6 +464,9 @@ describe('StockPreparationWorkspace shell', () => {
     if (container) container.remove()
     app = null
     container = null
+    localStorage.removeItem('tenantId')
+    localStorage.removeItem('workspaceId')
+    h.apiFetch.mockReset()
     vi.clearAllMocks()
   })
 
@@ -514,6 +520,25 @@ describe('StockPreparationWorkspace shell', () => {
     // to badge, so that line is skipped for it only (see StockPreparationViewTab.noEndpointBadge).
     expect(root.querySelector('[data-testid="stock-prep-panel-endpoint"]')).toBeNull()
     expect(root.querySelector('[data-testid="stock-prep-dashboard"]')).not.toBeNull()
+  })
+
+  it('passes the default integration scope to the dashboard readonly request', async () => {
+    localStorage.setItem('tenantId', 'tenant-from-integration-scope')
+    localStorage.setItem('workspaceId', 'workspace-from-integration-scope')
+    h.apiFetch.mockImplementation(async () => new Response(JSON.stringify({
+      ok: true,
+      data: { projectCount: 0, statusCounts: {}, projects: [] },
+    }), { status: 200 }))
+
+    await mountShell()
+    await waitForSelector(container!, '[data-testid="stock-prep-dashboard-empty"]')
+
+    const call = h.apiFetch.mock.calls.find(([value]) => String(value).includes('/stock-preparation/projects'))
+    expect(call).toBeDefined()
+    const [url, options] = call as [string, unknown]
+    expect(url).toContain('tenantId=tenant-from-integration-scope')
+    expect(url).toContain('workspaceId=workspace-from-integration-scope')
+    expect(options).toBeUndefined()
   })
 
   it('shows a concrete view panel as a readonly GET placeholder and switches on tab click', async () => {


### PR DESCRIPTION
## Summary

- pass the existing default integration scope to the stock-preparation dashboard and all six child views
- prevent tenantless platform-admin sessions from issuing unscoped stock-preparation reads that fail with `TENANT_REQUIRED`
- keep the surface read-only; no ERP/K3 write path is added or changed

## Evidence

- observed the deployed `/api/integration/stock-preparation/projects` request returning HTTP 400 on the 192.168.1.222 read-only workbench
- targeted test: `32 passed`
- added a regression assertion that both tenant and workspace scope reach the dashboard GET request

## Validation

```text
apps/web/tests/StockPreparationWorkspace.spec.ts: 32 passed
```

No entity-host dependency install, build, migration, dry-run, Apply, or K3 Save/Submit/Audit was performed.
