### PR TITLE
feat(ops): bootstrap staging lifecycle canary admin

### DIFF
--- a/.github/workflows/dingtalk-lifecycle-staging-canary.yml
+++ b/.github/workflows/dingtalk-lifecycle-staging-canary.yml
@@ -5,16 +5,23 @@ run-name: "DingTalk Lifecycle Staging Canary: ${{ inputs.action }}${{ inputs.act
 # Staging-only MINIMAL SAFE operator lane for DingTalk lifecycle env gates.
 # One dispatch = ONE action. All lifecycle flags remain OFF by default.
 #
-# EXECUTABLE: status | preflight | off | alias
-#   off   = emergency env-gate clear of the three lifecycle flags only (with
-#           previous-override restore on restart/health/mode failure).
-#   alias = TRANSIENT secret-backed alias cutover canary. Success requires/proves
-#           OFF; failure restores the OFF override before failing. Runtime OFF
-#           cannot be proven if rollback recreate itself fails. Requires full
-#           deploy SHA, expected_current_mode=off, secrets.ATTENDANCE_ADMIN_JWT
-#           + secrets.LIFECYCLE_CANARY_LOGIN_IDENTIFIER
-#           + secrets.LIFECYCLE_CANARY_LOGIN_PASSWORD (materialized as chmod-600
-#           files; never shell-interpolated into remote argv/logs).
+# EXECUTABLE: status | preflight | off | bootstrap | alias
+#   off       = emergency env-gate clear of the three lifecycle flags only (with
+#               previous-override restore on restart/health/mode failure).
+#   bootstrap = staging-only create/repair of the FIXED dedicated lifecycle
+#               canary platform admin (lifecycle-canary@staging.invalid + fixed
+#               UUID). Requires full deploy SHA, expected_current_mode=off, exact
+#               mode off, health true, migrations zero. Idempotent for the owned
+#               row; collision fail-closed. Proves real password login. Never
+#               writes lifecycle env flags. Secrets: IDENTIFIER + PASSWORD only.
+#   alias     = TRANSIENT secret-backed alias cutover canary. Success requires/
+#               proves OFF; failure restores the OFF override before failing.
+#               Runtime OFF cannot be proven if rollback recreate itself fails.
+#               Requires full deploy SHA, expected_current_mode=off, and
+#               secrets.LIFECYCLE_CANARY_LOGIN_IDENTIFIER
+#               + secrets.LIFECYCLE_CANARY_LOGIN_PASSWORD only (chmod-600 file
+#               transport). Short-lived admin JWT is minted from the canary
+#               password login after pre-login — never secrets.ATTENDANCE_ADMIN_JWT.
 #
 # NOT EXECUTABLE: pending | deprovision
 #   Fail-closed preflight-only. Env flip alone is not a canary — there is no
@@ -32,11 +39,11 @@ on:
   workflow_dispatch:
     inputs:
       action:
-        description: 'status/preflight/off/alias = executable; pending/deprovision = NOT EXECUTABLE (fail-closed preflight-only)'
+        description: 'status/preflight/off/bootstrap/alias = executable; pending/deprovision = NOT EXECUTABLE (fail-closed preflight-only)'
         required: true
         type: choice
         # Quote 'off' — YAML 1.1 bare off becomes boolean false.
-        options: [status, preflight, 'off', alias, pending, deprovision]
+        options: [status, preflight, 'off', bootstrap, alias, pending, deprovision]
         default: status
       target_mode:
         description: 'preflight only: target mode to assess (off|alias|pending|deprovision). pending/deprovision assess readiness only — never apply.'
@@ -45,13 +52,18 @@ on:
         options: ['off', alias, pending, deprovision]
         default: 'off'
       expected_current_mode:
-        description: 'Required for action=off (live mode before clear) and action=alias (must be off). Optional for preflight.'
+        description: 'Required for action=off (live mode before clear) and action=bootstrap|alias (must be off). Optional for preflight.'
         required: false
         type: string
         default: ''
       deploy_sha:
-        description: 'FULL 40-char lowercase commit SHA currently deployed on staging. Required for action=off and action=alias; optional exact-match for preflight.'
+        description: 'FULL 40-char lowercase commit SHA currently deployed on staging. Required for action=off, bootstrap, and alias; optional exact-match for preflight.'
         required: false
+        default: ''
+      bootstrap_confirmation:
+        description: 'For action=bootstrap only, enter CREATE_STAGING_CANARY_ADMIN. Ignored by other actions.'
+        required: false
+        type: string
         default: ''
 
 # Share the attendance staging runner concurrency group so compose override races
@@ -77,12 +89,13 @@ jobs:
           TARGET_MODE: ${{ inputs.target_mode }}
           EXPECTED_CURRENT_MODE: ${{ inputs.expected_current_mode }}
           DEPLOY_SHA: ${{ inputs.deploy_sha }}
-          # Intentionally NO alias login secrets here — presence is checked only in
+          BOOTSTRAP_CONFIRMATION: ${{ inputs.bootstrap_confirmation }}
+          # Intentionally NO canary login secrets here — presence is checked only in
           # Run remote action after demoting env → non-exported shell vars + unset
           # (bash -n and other children must not inherit raw secret env).
         run: |
           set -euo pipefail
-          case "$ACTION" in status|preflight|off|alias|pending|deprovision) ;; *)
+          case "$ACTION" in status|preflight|off|bootstrap|alias|pending|deprovision) ;; *)
             echo "invalid action: $ACTION" >&2; exit 2
           ;; esac
 
@@ -108,17 +121,23 @@ jobs:
             fi
           fi
 
-          # action=alias: structural inputs only here. Secret presence is checked in
-          # Run remote action (success requires/proves OFF; failure restores OFF override first).
-          if [[ "$ACTION" == "alias" ]]; then
+          # action=bootstrap|alias: structural inputs only here. Secret presence is
+          # checked in Run remote action. bootstrap never writes lifecycle env flags.
+          # alias success requires/proves OFF; failure restores OFF override first.
+          if [[ "$ACTION" == "bootstrap" || "$ACTION" == "alias" ]]; then
             if [[ "$EXPECTED_CURRENT_MODE" != "off" ]]; then
-              echo "expected_current_mode must be exactly 'off' for action=alias (no auto-selection)" >&2
+              echo "expected_current_mode must be exactly 'off' for action=${ACTION} (no auto-selection)" >&2
               exit 2
             fi
             if [[ ! "$DEPLOY_SHA" =~ ^[0-9a-f]{40}$ ]]; then
-              echo "deploy_sha must be the FULL 40-char lowercase commit SHA for action=alias, got: '$DEPLOY_SHA'" >&2
+              echo "deploy_sha must be the FULL 40-char lowercase commit SHA for action=${ACTION}, got: '$DEPLOY_SHA'" >&2
               exit 2
             fi
+          fi
+
+          if [[ "$ACTION" == "bootstrap" && "$BOOTSTRAP_CONFIRMATION" != "CREATE_STAGING_CANARY_ADMIN" ]]; then
+            echo "bootstrap_confirmation must be exactly CREATE_STAGING_CANARY_ADMIN for action=bootstrap" >&2
+            exit 2
           fi
 
           if [[ -n "$DEPLOY_SHA" && ! "$DEPLOY_SHA" =~ ^[0-9a-f]{40}$ ]]; then
@@ -173,9 +192,10 @@ jobs:
           EXPECTED_CURRENT_MODE: ${{ inputs.expected_current_mode }}
           DEPLOY_SHA: ${{ inputs.deploy_sha }}
           RUNNER_DIR: ${{ steps.sync.outputs.runner_dir }}
-          # Alias secrets are materialized INSIDE this step under EXIT trap — never
-          # via a prior step secrets_dir output (cross-step leak / cancel gap).
-          ATTENDANCE_ADMIN_JWT: ${{ secrets.ATTENDANCE_ADMIN_JWT }}
+          # bootstrap/alias login secrets are materialized INSIDE this step under EXIT
+          # trap — never via a prior step secrets_dir output (cross-step leak / cancel).
+          # ATTENDANCE_ADMIN_JWT is intentionally NOT consumed; alias mints a short-lived
+          # admin JWT from the canary password login on the remote host.
           LIFECYCLE_CANARY_LOGIN_IDENTIFIER: ${{ secrets.LIFECYCLE_CANARY_LOGIN_IDENTIFIER }}
           LIFECYCLE_CANARY_LOGIN_PASSWORD: ${{ secrets.LIFECYCLE_CANARY_LOGIN_PASSWORD }}
         run: |
@@ -185,10 +205,10 @@ jobs:
           # shell variables, then unset the exported names so mktemp/ssh/scp/bash -n
           # children never inherit raw secret env. Presence checks + printf use the
           # shell vars only; those are unset immediately after materialize writes.
-          _CANARY_JWT="${ATTENDANCE_ADMIN_JWT-}"
+          # Never demote/export ATTENDANCE_ADMIN_JWT (alias mints JWT from password login).
           _CANARY_IDENT="${LIFECYCLE_CANARY_LOGIN_IDENTIFIER-}"
           _CANARY_PASS="${LIFECYCLE_CANARY_LOGIN_PASSWORD-}"
-          unset ATTENDANCE_ADMIN_JWT LIFECYCLE_CANARY_LOGIN_IDENTIFIER LIFECYCLE_CANARY_LOGIN_PASSWORD
+          unset LIFECYCLE_CANARY_LOGIN_IDENTIFIER LIFECYCLE_CANARY_LOGIN_PASSWORD
           # --- end secret demote; external commands allowed after this point ------------
 
           ssh_opts="-o StrictHostKeyChecking=yes -o UserKnownHostsFile=$HOME/.ssh/known_hosts -o IdentitiesOnly=yes -i $HOME/.ssh/deploy_key"
@@ -241,20 +261,21 @@ jobs:
             set -e
           }
 
-          # For alias: materialize chmod-600 secret files LOCALLY under EXIT trap, then
-          # scp path-only into the per-run remote directory. Never pass secrets_dir
-          # across steps (cancel/failure gap). Password written with printf '%s' (exact bytes).
+          # For bootstrap|alias: materialize chmod-600 identifier/password LOCALLY under
+          # EXIT trap, then scp path-only into the per-run remote directory. Never pass
+          # secrets_dir across steps. Never materialize ATTENDANCE_ADMIN_JWT.
+          # Password written with printf '%s' (exact bytes). Alias mints admin JWT on remote
+          # after successful pre-login into the same per-run secrets dir.
           remote_secrets_dir=""
-          canary_jwt_export=""
           canary_ident_export=""
           canary_pass_export=""
-          if [[ "$ACTION" == "alias" ]]; then
+          if [[ "$ACTION" == "alias" || "$ACTION" == "bootstrap" ]]; then
             # Install trap BEFORE any secret materialization (mktemp/write/chmod).
             trap cleanup_canary_ephemeral_paths EXIT INT TERM
             # Presence via non-exported shell vars only (env already unset above).
-            if [[ -z "${_CANARY_JWT}" || -z "${_CANARY_IDENT}" || -z "${_CANARY_PASS}" ]]; then
-              echo "alias requires ATTENDANCE_ADMIN_JWT + LIFECYCLE_CANARY_LOGIN_IDENTIFIER/PASSWORD (checked in Run remote action only)" >&2
-              unset _CANARY_JWT _CANARY_IDENT _CANARY_PASS
+            if [[ -z "${_CANARY_IDENT}" || -z "${_CANARY_PASS}" ]]; then
+              echo "${ACTION} requires LIFECYCLE_CANARY_LOGIN_IDENTIFIER/PASSWORD (checked in Run remote action only); never ATTENDANCE_ADMIN_JWT" >&2
+              unset _CANARY_IDENT _CANARY_PASS
               exit 2
             fi
             secrets_dir="$(mktemp -d "${RUNNER_TEMP}/lifecycle-canary-secrets.XXXXXX")"
@@ -263,13 +284,12 @@ jobs:
             chmod 700 "$secrets_dir"
             umask 077
             # Exact secret bytes from non-exported shell vars — printf '%s' preserves payload.
-            printf '%s' "${_CANARY_JWT}" > "${secrets_dir}/admin.jwt"
             printf '%s' "${_CANARY_IDENT}" > "${secrets_dir}/login.identifier"
             printf '%s' "${_CANARY_PASS}" > "${secrets_dir}/login.password"
             # Drop shell-held secret values as soon as files are written.
-            unset _CANARY_JWT _CANARY_IDENT _CANARY_PASS
-            chmod 600 "${secrets_dir}/admin.jwt" "${secrets_dir}/login.identifier" "${secrets_dir}/login.password"
-            for f in admin.jwt login.identifier login.password; do
+            unset _CANARY_IDENT _CANARY_PASS
+            chmod 600 "${secrets_dir}/login.identifier" "${secrets_dir}/login.password"
+            for f in login.identifier login.password; do
               [[ -s "${secrets_dir}/${f}" ]] || { echo "secret file empty after materialize: ${f}" >&2; exit 2; }
             done
             remote_secrets_dir="${RUNNER_DIR}/.canary-secrets"
@@ -278,18 +298,16 @@ jobs:
             ssh $ssh_opts "$DEPLOY_USER@$DEPLOY_HOST" \
               "bash -o pipefail -c 'set -euo pipefail; mkdir -p ${remote_secrets_dir}; chmod 700 ${remote_secrets_dir}'"
             scp $ssh_opts \
-              "${secrets_dir}/admin.jwt" \
               "${secrets_dir}/login.identifier" \
               "${secrets_dir}/login.password" \
               "$DEPLOY_USER@$DEPLOY_HOST:${remote_secrets_dir}/"
             ssh $ssh_opts "$DEPLOY_USER@$DEPLOY_HOST" \
-              "bash -o pipefail -c 'set -euo pipefail; chmod 600 ${remote_secrets_dir}/admin.jwt ${remote_secrets_dir}/login.identifier ${remote_secrets_dir}/login.password'"
-            canary_jwt_export="export CANARY_ADMIN_JWT_FILE='${remote_secrets_dir}/admin.jwt'"
+              "bash -o pipefail -c 'set -euo pipefail; chmod 600 ${remote_secrets_dir}/login.identifier ${remote_secrets_dir}/login.password'"
             canary_ident_export="export CANARY_LOGIN_IDENTIFIER_FILE='${remote_secrets_dir}/login.identifier'"
             canary_pass_export="export CANARY_LOGIN_PASSWORD_FILE='${remote_secrets_dir}/login.password'"
           else
-            # Non-alias: drop any unused shell copies; clean per-run runner/output on exit.
-            unset _CANARY_JWT _CANARY_IDENT _CANARY_PASS
+            # Non-secret actions: drop any unused shell copies; clean per-run dirs on exit.
+            unset _CANARY_IDENT _CANARY_PASS
             trap cleanup_canary_ephemeral_paths EXIT INT TERM
           fi
 
@@ -302,7 +320,6 @@ jobs:
           export DEPLOY_PATH='${DEPLOY_PATH}'
           export OUTPUT_DIR='${remote_output_dir}'
           export RUN_STAMP='gh${GITHUB_RUN_ID}a${GITHUB_RUN_ATTEMPT}'
-          ${canary_jwt_export}
           ${canary_ident_export}
           ${canary_pass_export}
           rm -rf '${remote_output_dir}'
@@ -358,10 +375,11 @@ jobs:
             echo "- Remote rc: \`${REMOTE_RC:-missing}\`"
             echo "- Artifact: \`${ARTIFACT_NAME:-missing}\`"
             echo ""
-            echo "**Executable:** status / preflight / off / alias (alias success requires/proves OFF; failure restores OFF override before failing)."
+            echo "**Executable:** status / preflight / off / bootstrap / alias (alias success requires/proves OFF; failure restores OFF override before failing)."
             echo "**NOT EXECUTABLE:** pending / deprovision (no real canary verifier)."
             echo "OFF is emergency env-gate rollback only — not OR-column design reintroduction."
-            echo "Alias canary requires ATTENDANCE_ADMIN_JWT + LIFECYCLE_CANARY_LOGIN_IDENTIFIER/PASSWORD secrets (file transport)."
+            echo "Bootstrap creates/repairs fixed lifecycle-canary@staging.invalid admin only (no lifecycle env write)."
+            echo "Bootstrap/alias require LIFECYCLE_CANARY_LOGIN_IDENTIFIER/PASSWORD only (file transport); alias mints short-lived admin JWT from password login — never ATTENDANCE_ADMIN_JWT."
             echo "Runtime OFF cannot be proven if alias rollback recreate itself fails (override restored on disk)."
             if [[ -f output/lifecycle-canary/summary.txt ]]; then
               echo ""

--- a/docs/development/dingtalk-lifecycle-canary-separate-go-20260724.md
+++ b/docs/development/dingtalk-lifecycle-canary-separate-go-20260724.md
@@ -1,7 +1,7 @@
 # DingTalk lifecycle canary — separate ops GO (not auto-enabled)
 
 **Date:** 2026-07-24
-**Updated:** 2026-08-11 (alias lane made executable as a **transient** secret-backed cutover; success requires/proves OFF; failure restores the OFF override before failing; pending/deprovision remain **NOT EXECUTABLE**; no successful ON canary run claimed here)
+**Updated:** 2026-08-11 (bootstrap fixed canary admin + alias JWT mint from password login; bootstrap stdin secret transport / no container secret files / permissions-column omit / session revoke on repair / post-bootstrap OFF+health+SHA reassert; alias remains a **transient** secret-backed cutover; success requires/proves OFF; failure restores the OFF override before failing; pending/deprovision remain **NOT EXECUTABLE**; no successful ON canary run claimed here)
 **Related locks:**
 - `dingtalk-directory-admission-activation-lifecycle-design-20260723.md` Rev 4.2
 - `dingtalk-deprovision-reactivation-and-evidence-chain-design-20260723.md` Rev 4.2
@@ -12,9 +12,10 @@
 | Flag / action | Default after code land | Executable in this lane? |
 |---------------|-------------------------|--------------------------|
 | `DIRECTORY_PENDING_ACTIVATION_ENABLED` ON | **OFF** | **NOT EXECUTABLE** — no admit→activate verifier |
-| `AUTH_LOGIN_USE_ALIASES` ON (T2b cutover) | **OFF** | **Executable only as a transient canary** (`action=alias`). Success requires/proves OFF in the same run; failure restores the OFF override before failing. Runtime OFF cannot be proven if rollback recreate itself fails (override restored on disk). Requires secret-backed password login + admin JWT. |
+| `AUTH_LOGIN_USE_ALIASES` ON (T2b cutover) | **OFF** | **Executable only as a transient canary** (`action=alias`). Success requires/proves OFF in the same run; failure restores the OFF override before failing. Runtime OFF cannot be proven if rollback recreate itself fails (override restored on disk). Requires secret-backed password login; short-lived admin JWT is minted from that login (never `secrets.ATTENDANCE_ADMIN_JWT`). |
 | `DIRECTORY_DEPROVISION_ENABLED` ON | **OFF** | **NOT EXECUTABLE** — no sync→deprovision verifier |
 | Env-gate clear (`action=off`) | n/a | Executable emergency only (after migrations true + exact SHA) |
+| Dedicated canary admin (`action=bootstrap`) | n/a | Executable staging-only create/repair of the **fixed** owned row only (no lifecycle env write) |
 
 Presence of canary subject/integration/owner tokens is **not** a real canary and is **not** accepted as an ON enabler. There is **no** auto-selection of login identities, **no** password reset path, and **no** production fallback.
 
@@ -31,6 +32,7 @@ Presence of canary subject/integration/owner tokens is **not** a real canary and
 | `status` | yes | values-free snapshot; multi-on fail-closed after report |
 | `preflight` | yes | readiness only; `migrations_pending_zero` must be exactly `true` (unknown fails) |
 | `off` | yes | emergency clear of the three env gates; previous-override restore on failure; health true after restart required |
+| `bootstrap` | yes (manual) | staging-only create/repair of fixed canary admin; see below; **no lifecycle env write** |
 | `alias` | yes (transient) | secret-backed cutover canary; see sequence below; success requires/proves OFF |
 | `pending` / `deprovision` | **NOT EXECUTABLE** | fail-closed preflight-only; `transition_applied=false` always |
 
@@ -40,23 +42,60 @@ Shared concurrency with `attendance-staging-window-runner`. Status artifacts sta
 
 `action=off` is an **emergency operational rollback of the env gate only**. Design lock Rev 4.2 §4.2 / §4.4 forbids reintroducing OR-column fallback on `users.email` / `username` / `mobile` as a long-term design after T2b. OFF is not canary completion and is not product permission to restore pre-T2b OR login.
 
+### `action=bootstrap` — fixed dedicated lifecycle canary admin
+
+**Purpose:** create or repair **only** the dedicated staging canary platform admin used by alias login. Does **not** enable lifecycle flags and does **not** touch an arbitrary existing admin.
+
+**Fixed ownership markers (both required):**
+
+- email: `lifecycle-canary@staging.invalid`
+- user id: `6c1fe000-ca0a-4000-8000-1ec0c1e00001` (fixed valid UUID)
+
+Any `users` row matching the email **or** the id that does **not** match **both** markers fails closed (`collision_not_owned` / `collision_multiple_rows`). No email/role scan of other admins.
+
+**Required inputs / secrets:**
+
+- `deploy_sha` — full 40-char lowercase staging deploy SHA
+- `expected_current_mode=off` (strict)
+- `bootstrap_confirmation=CREATE_STAGING_CANARY_ADMIN` (explicit privileged-operation confirmation)
+- `secrets.LIFECYCLE_CANARY_LOGIN_IDENTIFIER` — must decode+trim to exact `lifecycle-canary@staging.invalid`
+- `secrets.LIFECYCLE_CANARY_LOGIN_PASSWORD` — exact password bytes for that account (no CR/LF strip)
+
+**Gates before mutation:** exact deployed SHA (image tag + health commit agree), live mode `off`, backend health true, `migrations_pending_zero=true`.
+
+**Hard safety for bootstrap credentials + row mutation:**
+
+| Rule | Behavior |
+|------|----------|
+| Secret transport | Host streams exact identifier/password bytes over `docker exec` **stdin** (uint32be length frames). **No `docker cp`**, no persistent secret files under `/tmp` (or elsewhere) inside the backend container. |
+| Non-secret markers only | Container node receives fixed owner email/id + min password length via env only — never secret values in argv/export/logs. |
+| Password floor | Exact stored password length must be **≥ 12** (`password_too_short` fail-closed). |
+| `users.permissions` | Column **omitted** on insert/repair (054 `TEXT[]` default and later jsonb defaults both work; never `'[]'::jsonb`). |
+| Collision | Email **or** id match that is not **both** markers → fail closed; never mutates an arbitrary admin. |
+| Create/repair sessions | **Required primary guard** (same transaction, same shape as `session-revocation.ts` `revokeUserSessions`): upsert `user_session_revocations` (`user_id, revoked_after, updated_at, updated_by, reason` with `ON CONFLICT DO UPDATE` of the watermark). Its absence rolls back the mutation. Create also advances it because a previously deleted fixed row may have left orphaned stateless tokens. JWT verification uses `revoked_after` — updating `user_sessions` alone is **not** sufficient. Optional additional belt on repair: revoke live `user_sessions` rows when that table exists. Reasons: `lifecycle_canary_bootstrap_password_create|repair`. Before the new login proof, cross the next JWT `iat` second so the new token is newer than the watermark. |
+| Post-proof posture | After password login proof: re-capture and require mode still `off`, health true, migrations still zero, exact SHA unchanged. |
+| Env flags | **Never** writes lifecycle override / never enables alias/pending/deprovision. |
+
+**Transaction shape:** `BEGIN` → `SELECT … FOR UPDATE` on id/email → insert or repair owned row as active activated platform admin (`role=admin`, `is_admin=true`, `is_active=true`, `activation_status=activated`, `local_password_set=true`, `must_change_password=false`, `user_roles` admin + needed permissions) → optional session revoke on repair → `COMMIT`. Then prove real `POST /api/auth/login` and reassert OFF/health/SHA. Artifacts report outcome enums only (`created` / `repaired`); never credentials, tokens, or PII. `transition_applied=false` and `lifecycle_env_write=false`.
+
 ### `action=alias` — transient secret-backed cutover canary
 
-**Required inputs / secrets (no auto-selection):**
+**Required inputs / secrets (no auto-selection; no `ATTENDANCE_ADMIN_JWT`):**
 
 - `deploy_sha` — full 40-char lowercase staging deploy SHA
 - `expected_current_mode=off` (strict; refuse other values)
-- `secrets.ATTENDANCE_ADMIN_JWT` — platform-admin JWT for `POST /api/admin/login-aliases/backfill` and `GET /api/admin/login-aliases/cutover-status`
-- `secrets.LIFECYCLE_CANARY_LOGIN_IDENTIFIER` — real staging login identifier (email/username/mobile already claimed or claimable)
+- `secrets.LIFECYCLE_CANARY_LOGIN_IDENTIFIER` — exact fixed canary email (after trim)
 - `secrets.LIFECYCLE_CANARY_LOGIN_PASSWORD` — real password for that identifier (read exactly as stored; no CR/LF strip)
 
-**Secret transport:** only the **Run remote action** step receives the three alias secrets as step env. Its first lines (builtins only) copy them into **non-exported** shell variables and **unset** the exported names so no external child (`mktemp`, `ssh`, `scp`, `bash`) inherits raw secret env. Then it installs an `EXIT`/`INT`/`TERM` cleanup trap **before** `mktemp`, writes JWT/identifier/password as local `chmod 600` files via `printf '%s'` from the shell variables (exact password bytes), **unsets the shell variables immediately after the writes**, then remote `mkdir`/`scp` path-only into the per-run remote directory, exports **file paths only** (`CANARY_*_FILE`) to the remote script, and deletes local temp + per-run remote secrets/runner paths on every exit path. The **Validate inputs** step does **not** receive or check those secrets (so `bash -n` cannot inherit them). Secrets are **not** materialized in a prior step or passed via a `secrets_dir` output. Values must not appear in shell argv, process listings via exported env, logs, or artifacts. Persistent `~/.metasheet2` overrides are never deleted by this cleanup.
+**Admin JWT derivation:** after successful pre-ON password login, the remote script writes the short-lived login token to a **chmod 600** per-run remote secret file (`admin.jwt` beside the password file) and uses that path for `POST /api/admin/login-aliases/backfill` and `GET /api/admin/login-aliases/cutover-status`. The lane **never** consumes or overwrites repo-global `secrets.ATTENDANCE_ADMIN_JWT`.
+
+**Secret transport:** only the **Run remote action** step receives identifier/password as step env. Its first lines (builtins only) copy them into **non-exported** shell variables and **unset** the exported names so no external child (`mktemp`, `ssh`, `scp`, `bash`) inherits raw secret env. Then it installs an `EXIT`/`INT`/`TERM` cleanup trap **before** `mktemp`, writes identifier/password as local `chmod 600` files via `printf '%s'` from the shell variables (exact password bytes), **unsets the shell variables immediately after the writes**, then remote `mkdir`/`scp` path-only into the per-run remote directory, exports **file paths only** (`CANARY_LOGIN_*_FILE`) to the remote script, and deletes local temp + per-run remote secrets/runner paths on every exit path. The **Validate inputs** step does **not** receive or check those secrets (so `bash -n` cannot inherit them). Secrets are **not** materialized in a prior step or passed via a `secrets_dir` output. Values must not appear in shell argv, process listings via exported env, logs, or artifacts. Persistent `~/.metasheet2` overrides are never deleted by this cleanup. Same transport is shared with `action=bootstrap`.
 
 **Remote sequence (fail closed; any post-write failure restores OFF override before failing):**
 
 1. Prove exact SHA (image tag + health commit agree), backend health true, `migrations_pending_zero=true`, live mode `off`.
-2. Real `POST /api/auth/login` with secret identifier/password (**pre-ON**).
-3. Authenticated `POST /api/admin/login-aliases/backfill` (admin JWT) — require success; **exact nonnegative integer counts** with **`collisions==0`** (nonzero collisions refuse env write; alias-only would lock collided users out).
+2. Real `POST /api/auth/login` with secret identifier/password (**pre-ON**) and mint short-lived admin JWT file from that response.
+3. Authenticated `POST /api/admin/login-aliases/backfill` (minted JWT file) — require success; **exact nonnegative integer counts** with **`collisions==0`** (nonzero collisions refuse env write; alias-only would lock collided users out).
 4. Authenticated `GET /api/admin/login-aliases/cutover-status` — require `ready=true` and `canEnableCutover=true`.
 5. Establish a **compose-validated explicit OFF** rollback baseline on disk (all three flags false) and snapshot it — **never** restore an arbitrary prior on-disk file (a stale unapplied `alias=true` override would re-enable alias after recreate). Arm the remote `EXIT`/`HUP`/`INT`/`TERM`/`PIPE` rollback guard **before** the persistent ON write; it remains armed until runtime OFF and the post-rollback login are proven. Emergency recovery logs to the remote per-run output file rather than the possibly broken SSH stream. Then write `AUTH_LOGIN_USE_ALIASES=true` with pending/deprovision false; recreate **backend only** (Postgres/Redis container IDs unchanged).
 6. Prove exact SHA, mode `alias`, health true, and real password login (**post-ON**).
@@ -64,7 +103,7 @@ Shared concurrency with `attendance-staging-window-runner`. Status artifacts sta
 
 Backfill alias rows **may persist** after the run. Artifacts report only booleans / counts / reason enums / SHA — never credentials, identifiers, tokens, or PII.
 
-**Repo state note:** `ATTENDANCE_ADMIN_JWT` may already exist; `LIFECYCLE_CANARY_LOGIN_IDENTIFIER` / `LIFECYCLE_CANARY_LOGIN_PASSWORD` are new secrets that must be configured before a real alias dispatch. Landing this code does **not** configure those secrets and does **not** claim a successful canary execution.
+**Repo state note:** `LIFECYCLE_CANARY_LOGIN_IDENTIFIER` / `LIFECYCLE_CANARY_LOGIN_PASSWORD` must be configured before a real bootstrap or alias dispatch. This lane does **not** use `ATTENDANCE_ADMIN_JWT`. Landing this code does **not** configure those secrets and does **not** claim a successful canary execution.
 
 ## Current staging baseline (ON canary NOT EXECUTED)
 
@@ -89,11 +128,12 @@ those ON actions stay **NOT EXECUTABLE**. Alias now has a verifier path in this 
 ## Future canary sequence (when secrets + ops GO exist)
 
 1. Staging: deploy exact SHA; image and health provenance agree; migrations pending=0 via backup/clone-rehearsal.
-2. Configure `LIFECYCLE_CANARY_LOGIN_IDENTIFIER` / `LIFECYCLE_CANARY_LOGIN_PASSWORD` (plus existing `ATTENDANCE_ADMIN_JWT`).
-3. Dispatch `action=alias` with full `deploy_sha` and `expected_current_mode=off` — transient ON proof + OFF success proof (or OFF override restore on failure).
-4. Real admit→activate on explicit ids → only then pending ON (still not this lane today).
-5. Real deprovision proof → only then deprovision ON.
-6. Production = separate GO.
+2. Configure `LIFECYCLE_CANARY_LOGIN_IDENTIFIER` / `LIFECYCLE_CANARY_LOGIN_PASSWORD` for the fixed `lifecycle-canary@staging.invalid` identity.
+3. Dispatch `action=bootstrap` with full `deploy_sha`, `expected_current_mode=off`, and `bootstrap_confirmation=CREATE_STAGING_CANARY_ADMIN` — create/repair fixed owned admin (stdin secret stream, session revoke on repair) + password login proof + OFF/health/migrations/SHA reassert (no env write).
+4. Dispatch `action=alias` with full `deploy_sha` and `expected_current_mode=off` — mint JWT from canary password login, transient ON proof + OFF success proof (or OFF override restore on failure).
+5. Real admit→activate on explicit ids → only then pending ON (still not this lane today).
+6. Real deprovision proof → only then deprovision ON.
+7. Production = separate GO.
 
 ## Owner note
 

--- a/scripts/ops/dingtalk-lifecycle-staging-canary-contract.test.mjs
+++ b/scripts/ops/dingtalk-lifecycle-staging-canary-contract.test.mjs
@@ -2,17 +2,20 @@
 // dingtalk-lifecycle-staging-canary-contract.test.mjs
 //
 // Durable synthetic contract for the MINIMAL SAFE staging lifecycle lane:
-//   EXECUTABLE: status | preflight | off | alias
+//   EXECUTABLE: status | preflight | off | bootstrap | alias
 //   NOT EXECUTABLE: pending | deprovision (fail-closed preflight-only)
 //
 // Alias is a TRANSIENT secret-backed cutover canary: success requires/proves OFF;
 // failure restores the OFF override before failing. Runtime OFF cannot be proven
-// if rollback recreate itself fails.
+// if rollback recreate itself fails. Admin JWT is minted from canary password
+// login (never secrets.ATTENDANCE_ADMIN_JWT).
+// Bootstrap creates/repairs the fixed owned canary admin only (collision
+// fail-closed; no lifecycle env write).
 // Load-bearing mutations for owner P1/P2 gaps:
-//   * migrations_pending_zero unknown must fail preflight/off/alias (never success)
+//   * migrations_pending_zero unknown must fail preflight/off/alias/bootstrap
 //   * pending/deprovision never apply (transition_applied=false; NOT EXECUTABLE)
-//   * alias requires pre-login, backfill, readiness, post-ON login, rollback,
-//     post-rollback login, exact SHA, migrations, and secret-file transport
+//   * alias requires pre-login(+JWT mint), backfill, readiness, post-ON login,
+//     rollback, post-rollback login, exact SHA, migrations, secret-file transport
 //   * recreate requires health true after restart
 //   * previous-override restore on transition failure
 //   * multi-on: status/preflight fail closed; off still clears via classify_mode
@@ -115,6 +118,14 @@ function actionOffBody(source) {
   return source.slice(start, end)
 }
 
+function actionBootstrapBody(source) {
+  const start = source.indexOf('action_bootstrap()')
+  assert.notEqual(start, -1, 'action_bootstrap() must exist')
+  const end = source.indexOf('\naction_off()', start)
+  assert.notEqual(end, -1, 'action_off after action_bootstrap')
+  return source.slice(start, end)
+}
+
 // --- parse / presence -----------------------------------------------------------------
 
 test('remote script and workflow files exist', () => {
@@ -145,9 +156,17 @@ test('PR contract workflow executes this exact suite without changing the sealed
 
 // --- workflow shape -------------------------------------------------------------------
 
-test('workflow action choices include status/preflight/off/alias and non-executable ON names', () => {
+test('workflow action choices include status/preflight/off/bootstrap/alias and non-executable ON names', () => {
   const options = workflowOn(loadYaml(read(WORKFLOW))).workflow_dispatch.inputs.action.options
-  assert.deepEqual(options, ['status', 'preflight', 'off', 'alias', 'pending', 'deprovision'])
+  assert.deepEqual(options, [
+    'status',
+    'preflight',
+    'off',
+    'bootstrap',
+    'alias',
+    'pending',
+    'deprovision',
+  ])
   assert.ok(options.every((o) => typeof o === 'string'), 'quote off so YAML 1.1 keeps string')
 })
 
@@ -181,13 +200,17 @@ test('SSH transport requires a pinned known_hosts secret', () => {
   assert.doesNotMatch(yaml, /StrictHostKeyChecking=no/)
 })
 
-test('workflow requires deploy_sha + expected_current for off and alias; pending/deprovision NOT EXECUTABLE', () => {
+test('workflow requires deploy_sha + expected_current for off/bootstrap/alias; pending/deprovision NOT EXECUTABLE', () => {
   const yaml = read(WORKFLOW)
   assert.match(yaml, /expected_current_mode is required for action=off/)
-  assert.match(yaml, /expected_current_mode must be exactly 'off' for action=alias/)
-  assert.match(yaml, /deploy_sha must be the FULL 40-char lowercase commit SHA for action=alias/)
+  assert.match(yaml, /expected_current_mode must be exactly 'off' for action=\$\{ACTION\}/)
+  assert.match(yaml, /deploy_sha must be the FULL 40-char lowercase commit SHA for action=\$\{ACTION\}/)
+  assert.match(yaml, /ACTION" == "bootstrap" \|\| "\$ACTION" == "alias"/)
   // Secret presence is checked only in Run remote action (not Validate inputs).
-  assert.match(yaml, /alias requires ATTENDANCE_ADMIN_JWT \+ LIFECYCLE_CANARY_LOGIN_IDENTIFIER\/PASSWORD \(checked in Run remote action only\)/)
+  assert.match(
+    yaml,
+    /requires LIFECYCLE_CANARY_LOGIN_IDENTIFIER\/PASSWORD \(checked in Run remote action only\); never ATTENDANCE_ADMIN_JWT/,
+  )
   assert.match(yaml, /NOT EXECUTABLE/)
   // Must not require canary subject/integration for a pretend ON transition.
   assert.doesNotMatch(yaml, /canary_subject_id:/)
@@ -200,29 +223,44 @@ test('workflow requires deploy_sha + expected_current for off and alias; pending
   assert.doesNotMatch(yaml, /always OFF after/i)
 })
 
-test('workflow alias secret transport uses chmod-600 files + scp, not secret values in remote argv', () => {
+test('workflow requires an explicit privileged bootstrap confirmation phrase', () => {
+  const yaml = read(WORKFLOW)
+  const doc = loadYaml(yaml)
+  assert.ok(workflowOn(doc).workflow_dispatch.inputs.bootstrap_confirmation)
+  const validate = doc.jobs.run.steps.find((s) => s.name === 'Validate inputs and embedded scripts')
+  assert.equal(validate.env.BOOTSTRAP_CONFIRMATION, '${{ inputs.bootstrap_confirmation }}')
+  assert.match(validate.run, /ACTION" == "bootstrap"/)
+  assert.match(validate.run, /BOOTSTRAP_CONFIRMATION" != "CREATE_STAGING_CANARY_ADMIN"/)
+})
+
+test('workflow bootstrap/alias secret transport uses chmod-600 files + scp; never ATTENDANCE_ADMIN_JWT', () => {
   const yaml = read(WORKFLOW)
   assert.match(yaml, /chmod 600/)
   assert.match(yaml, /LIFECYCLE_CANARY_LOGIN_IDENTIFIER/)
   assert.match(yaml, /LIFECYCLE_CANARY_LOGIN_PASSWORD/)
-  assert.match(yaml, /ATTENDANCE_ADMIN_JWT/)
-  assert.match(yaml, /CANARY_ADMIN_JWT_FILE=/)
   assert.match(yaml, /CANARY_LOGIN_IDENTIFIER_FILE=/)
   assert.match(yaml, /CANARY_LOGIN_PASSWORD_FILE=/)
   assert.match(yaml, /\.canary-secrets/)
   assert.match(yaml, /scp \$ssh_opts/)
   // printf uses non-exported shell vars after env demote (not raw env names).
   assert.match(yaml, /printf '%s' "\$\{_CANARY_PASS\}"/)
-  assert.match(yaml, /printf '%s' "\$\{_CANARY_JWT\}"/)
   assert.match(yaml, /printf '%s' "\$\{_CANARY_IDENT\}"/)
+  // Must not materialize or demote ATTENDANCE_ADMIN_JWT (alias mints JWT from login).
+  // Prose may mention the forbidden secret; forbid GHA secret injection only.
+  assert.doesNotMatch(yaml, /_CANARY_JWT=/)
+  assert.doesNotMatch(yaml, /printf '%s' "\$\{_CANARY_JWT\}"/)
+  assert.doesNotMatch(yaml, /\$\{\{\s*secrets\.ATTENDANCE_ADMIN_JWT/)
+  assert.doesNotMatch(yaml, /export CANARY_ADMIN_JWT_FILE=/)
   // Must not export raw secret values into the remote script env.
   assert.doesNotMatch(yaml, /export ATTENDANCE_ADMIN_JWT=/)
   assert.doesNotMatch(yaml, /export LIFECYCLE_CANARY_LOGIN_IDENTIFIER=/)
   assert.doesNotMatch(yaml, /export LIFECYCLE_CANARY_LOGIN_PASSWORD=/)
   assert.doesNotMatch(yaml, /export CANARY_LOGIN_PASSWORD='/)
+  // bootstrap shares the same secret transport gate as alias.
+  assert.match(yaml, /ACTION" == "alias" \|\| "\$ACTION" == "bootstrap"/)
 })
 
-test('workflow Validate inputs does not receive alias secrets (no child inheritance gap)', () => {
+test('workflow Validate inputs does not receive canary login secrets (no child inheritance gap)', () => {
   const yaml = read(WORKFLOW)
   const doc = loadYaml(yaml)
   const validate = doc.jobs.run.steps.find((s) => s.name === 'Validate inputs and embedded scripts')
@@ -235,8 +273,9 @@ test('workflow Validate inputs does not receive alias secrets (no child inherita
   assert.doesNotMatch(validate.run, /LIFECYCLE_CANARY_LOGIN_IDENTIFIER/)
   assert.doesNotMatch(validate.run, /LIFECYCLE_CANARY_LOGIN_PASSWORD/)
   assert.match(validate.run, /bash -n scripts\/ops\/dingtalk-lifecycle-staging-canary-remote\.sh/)
-  // Structural alias checks remain; secret presence does not.
-  assert.match(validate.run, /expected_current_mode must be exactly 'off' for action=alias/)
+  // Structural bootstrap/alias checks remain; secret presence does not.
+  assert.match(validate.run, /expected_current_mode must be exactly 'off' for action=\$\{ACTION\}/)
+  assert.match(validate.run, /bootstrap\|alias/)
 })
 
 test('workflow materializes secrets inside Run remote action under EXIT trap (no separate secrets step)', () => {
@@ -273,7 +312,7 @@ test('workflow materializes secrets inside Run remote action under EXIT trap (no
       if (t === 'set -euo pipefail') sawSet = true
       continue
     }
-    if (t.startsWith('unset ATTENDANCE_ADMIN_JWT LIFECYCLE_CANARY_LOGIN_IDENTIFIER LIFECYCLE_CANARY_LOGIN_PASSWORD')) {
+    if (t.startsWith('unset LIFECYCLE_CANARY_LOGIN_IDENTIFIER LIFECYCLE_CANARY_LOGIN_PASSWORD')) {
       sawEnvUnset = true
       break
     }
@@ -285,23 +324,22 @@ test('workflow materializes secrets inside Run remote action under EXIT trap (no
   assert.deepEqual(
     demoteCode,
     [
-      '_CANARY_JWT="${ATTENDANCE_ADMIN_JWT-}"',
       '_CANARY_IDENT="${LIFECYCLE_CANARY_LOGIN_IDENTIFIER-}"',
       '_CANARY_PASS="${LIFECYCLE_CANARY_LOGIN_PASSWORD-}"',
     ],
-    'only demote assignments (builtins) before secret env unset — no external commands',
+    'only demote assignments (builtins) before secret env unset — no external commands; no JWT',
   )
 
   // Order after demote: trap → mktemp → printf from shell vars → unset shell vars → remote scp.
   const trapIdx = runBody.indexOf('trap cleanup_canary_ephemeral_paths EXIT INT TERM')
   const envUnsetIdx = runBody.indexOf(
-    'unset ATTENDANCE_ADMIN_JWT LIFECYCLE_CANARY_LOGIN_IDENTIFIER LIFECYCLE_CANARY_LOGIN_PASSWORD',
+    'unset LIFECYCLE_CANARY_LOGIN_IDENTIFIER LIFECYCLE_CANARY_LOGIN_PASSWORD',
   )
   const mktempIdx = runBody.indexOf('mktemp -d')
   const printfPassIdx = runBody.indexOf("printf '%s' \"${_CANARY_PASS}\"")
   // Post-write shell-var wipe (must follow password printf; fail-path unset is earlier).
   const unsetShellIdx = runBody.indexOf(
-    'unset _CANARY_JWT _CANARY_IDENT _CANARY_PASS',
+    'unset _CANARY_IDENT _CANARY_PASS',
     printfPassIdx,
   )
   const localCleanAssignIdx = runBody.indexOf('CLEAN_LOCAL_SECRETS_DIR="${secrets_dir}"')
@@ -320,9 +358,9 @@ test('workflow materializes secrets inside Run remote action under EXIT trap (no
   assert.match(remoteStep.run, /trap cleanup_canary_ephemeral_paths EXIT INT TERM/)
   assert.match(remoteStep.run, /mktemp -d/)
   assert.match(remoteStep.run, /printf '%s' "\$\{_CANARY_PASS\}"/)
-  assert.match(remoteStep.run, /unset ATTENDANCE_ADMIN_JWT LIFECYCLE_CANARY_LOGIN_IDENTIFIER LIFECYCLE_CANARY_LOGIN_PASSWORD/)
+  assert.match(remoteStep.run, /unset LIFECYCLE_CANARY_LOGIN_IDENTIFIER LIFECYCLE_CANARY_LOGIN_PASSWORD/)
   assert.ok(remoteStep.env, 'Run remote action must declare env')
-  assert.ok(remoteStep.env.ATTENDANCE_ADMIN_JWT, 'JWT secret on Run remote action only')
+  assert.equal(remoteStep.env.ATTENDANCE_ADMIN_JWT, undefined, 'never inject ATTENDANCE_ADMIN_JWT')
   assert.ok(remoteStep.env.LIFECYCLE_CANARY_LOGIN_IDENTIFIER, 'identifier secret on Run remote action only')
   assert.ok(remoteStep.env.LIFECYCLE_CANARY_LOGIN_PASSWORD, 'password secret on Run remote action only')
   assert.equal(remoteStep.env.SECRETS_DIR, undefined, 'no secrets_dir cross-step handoff')
@@ -334,6 +372,9 @@ test('workflow materializes secrets inside Run remote action under EXIT trap (no
   assert.match(runBody, /OUTPUT_COLLECTED=1/)
   // Explicit: secrets_dir must not be a step output handoff.
   assert.doesNotMatch(runBody, /secrets_dir=.*GITHUB_OUTPUT/)
+  // bootstrap|alias share materialize gate; no admin.jwt from GHA secrets.
+  assert.match(runBody, /ACTION" == "alias" \|\| "\$ACTION" == "bootstrap"/)
+  assert.doesNotMatch(runBody, /admin\.jwt/)
 })
 
 test('workflow cleanup never deletes persistent .metasheet2 overrides', () => {
@@ -618,8 +659,9 @@ test('production function: require_migrations_pending_zero_true accepts only tru
 
 // --- P1: pending/deprovision NOT EXECUTABLE; alias is executable ----------------------
 
-test('P1 pending/deprovision route to action_not_executable_on; alias routes to action_alias', () => {
+test('P1 pending/deprovision route to action_not_executable_on; alias routes to action_alias; bootstrap routes to action_bootstrap', () => {
   const source = read(REMOTE_SH)
+  assert.match(source, /bootstrap\) action_bootstrap/)
   assert.match(source, /alias\) action_alias/)
   assert.match(source, /pending\) action_not_executable_on pending/)
   assert.match(source, /deprovision\) action_not_executable_on deprovision/)
@@ -628,7 +670,7 @@ test('P1 pending/deprovision route to action_not_executable_on; alias routes to 
   assert.match(source, /transition_applied=false/)
   // Must not call write_lifecycle_override from the not-executable path with true flags.
   const start = source.indexOf('action_not_executable_on()')
-  const end = source.indexOf('\naction_off()', start)
+  const end = source.indexOf('\naction_bootstrap()', start)
   assert.notEqual(start, -1)
   assert.notEqual(end, -1)
   const body = source.slice(start, end)
@@ -646,17 +688,22 @@ test('P1 pending/deprovision route to action_not_executable_on; alias routes to 
   )
 })
 
-test('P1 action=off and action=alias write lifecycle override; pending/deprovision do not', () => {
+test('P1 action=off and action=alias write lifecycle override; bootstrap/pending/deprovision do not', () => {
   const source = read(REMOTE_SH)
   assert.match(source, /off\) action_off/)
+  assert.match(source, /bootstrap\) action_bootstrap/)
   assert.match(source, /alias\) action_alias/)
   assert.match(source, /action_off\(\)/)
+  assert.match(source, /action_bootstrap\(\)/)
   assert.match(source, /action_alias\(\)/)
   assert.match(source, /write_lifecycle_override "false" "false" "false"/)
   assert.match(source, /write_lifecycle_override "true" "false" "false"/)
+  const bootstrapBody = actionBootstrapBody(source)
+  assert.doesNotMatch(bootstrapBody, /write_lifecycle_override/)
+  assert.doesNotMatch(bootstrapBody, /recreate_backend_only/)
   const notExec = source.slice(
     source.indexOf('action_not_executable_on()'),
-    source.indexOf('\naction_off()'),
+    source.indexOf('\naction_bootstrap()'),
   )
   assert.doesNotMatch(notExec, /write_lifecycle_override/)
 })
@@ -904,7 +951,8 @@ test('alias summary reports only booleans/counts/reason enums/SHA (no secret fie
 
 test('alias requires secret files, expected_current_mode=off, exact SHA, migrations, health', () => {
   const body = actionAliasBody(read(REMOTE_SH))
-  assert.match(body, /require_canary_secret_files/)
+  assert.match(body, /require_canary_secret_files "alias"/)
+  assert.match(body, /assert_canary_identifier_matches_owner "alias"/)
   assert.match(body, /require_sha/)
   assert.match(body, /assert_exact_sha/)
   assert.match(body, /require_migrations_pending_zero_true/)
@@ -916,24 +964,27 @@ test('alias requires secret files, expected_current_mode=off, exact SHA, migrati
   assert.doesNotMatch(body, /resetPassword|reset_password|password-reset/)
   assert.doesNotMatch(body, /container_name: metasheet-backend/)
   assert.doesNotMatch(body, /metasheet-backend:latest/)
+  // Alias never consumes repo-global ATTENDANCE_ADMIN_JWT.
+  assert.match(body, /never secrets\.ATTENDANCE_ADMIN_JWT|Never.*ATTENDANCE_ADMIN_JWT/i)
 })
 
-test('alias proves pre-login before any env write; backfill and readiness before write', () => {
+test('alias proves pre-login JWT mint before any env write; backfill and readiness before write', () => {
   const body = actionAliasBody(read(REMOTE_SH))
-  const preLogin = body.indexOf('prove_canary_password_login "pre_on"')
+  const mint = body.indexOf('mint_canary_admin_jwt_from_password_login "pre_on"')
   const backfill = body.indexOf('run_alias_backfill')
   const cutover = body.indexOf('run_alias_cutover_status')
   const baseline = body.indexOf('establish_alias_off_rollback_baseline')
   const write = body.indexOf('write_lifecycle_override "true" "false" "false"')
-  assert.ok(preLogin > 0, 'pre_on login required')
-  assert.ok(backfill > preLogin, 'backfill after pre-login')
+  assert.ok(mint > 0, 'pre_on login+JWT mint required')
+  assert.ok(backfill > mint, 'backfill after pre-login JWT mint')
   assert.ok(cutover > backfill, 'cutover-status after backfill')
   assert.ok(baseline > cutover, 'explicit OFF baseline after readiness')
   assert.ok(write > baseline, 'ON write after OFF baseline')
   assert.doesNotMatch(body, /backup_lifecycle_override/)
-  assert.match(body, /pre-ON password login failed \(no env write performed\)/)
+  assert.match(body, /pre-ON password login \/ JWT mint failed \(no env write performed\)/)
   assert.match(body, /login-aliases backfill failed \(no env write performed\)/)
   assert.match(body, /cutover-status not ready\/canEnableCutover \(no env write performed\)/)
+  assert.match(body, /admin JWT file missing after mint/)
 })
 
 test('alias post-ON path requires recreate, exact SHA, mode alias, post-ON login; failures restore first', () => {
@@ -972,6 +1023,7 @@ test('alias secret helpers never interpolate secret values into shell argv or lo
   const source = read(REMOTE_SH)
   assert.match(source, /require_canary_secret_files\(\)/)
   assert.match(source, /prove_canary_password_login\(\)/)
+  assert.match(source, /mint_canary_admin_jwt_from_password_login\(\)/)
   assert.match(source, /admin_api_request\(\)/)
   assert.match(source, /CANARY_ADMIN_JWT_FILE/)
   assert.match(source, /CANARY_LOGIN_IDENTIFIER_FILE/)
@@ -991,12 +1043,22 @@ test('alias secret helpers never interpolate secret values into shell argv or lo
     /^\s*password = pathlib\.Path\(pass_path\)\.read_bytes\(\)\.decode\("utf-8"\)\.strip\(\)\s*$/m,
   )
   assert.match(source, /pathlib\.Path\(jwt_path\)\.read_text/)
+  // Minted JWT is written via pathlib write_bytes, never echoed.
+  assert.match(source, /out\.write_bytes\(token\.encode\("utf-8"\)\)/)
+  assert.match(source, /os\.chmod\(out, 0o600\)/)
   // Never curl -d with expanded password env or echo secret file contents.
   assert.doesNotMatch(source, /curl[^\n]*\$\{?CANARY_LOGIN_PASSWORD\}?/)
   assert.doesNotMatch(source, /curl[^\n]*\$\{?ATTENDANCE_ADMIN_JWT\}?/)
   assert.doesNotMatch(source, /echo\s+[\"']?\$\{?(CANARY_LOGIN_PASSWORD|ATTENDANCE_ADMIN_JWT|CANARY_ADMIN_JWT)/)
   assert.doesNotMatch(source, /cat\s+\"?\$\{?CANARY_LOGIN_PASSWORD_FILE/)
   assert.match(source, /values never logged/)
+  // require_canary_secret_files must not require JWT file from secrets.
+  const reqStart = source.indexOf('require_canary_secret_files()')
+  const reqEnd = source.indexOf('\nassert_canary_identifier_matches_owner()', reqStart)
+  const reqBody = source.slice(reqStart, reqEnd)
+  assert.match(reqBody, /CANARY_LOGIN_IDENTIFIER_FILE/)
+  assert.match(reqBody, /CANARY_LOGIN_PASSWORD_FILE/)
+  assert.doesNotMatch(reqBody, /CANARY_ADMIN_JWT_FILE/)
 })
 
 test('alias admin calls target backfill and cutover-status endpoints', () => {
@@ -1008,13 +1070,16 @@ test('alias admin calls target backfill and cutover-status endpoints', () => {
 })
 
 // Load-bearing MUTATION tests: removing any required gate turns the suite red.
-test('MUTATION: removing pre-ON login requirement turns alias contract red', () => {
+test('MUTATION: removing pre-ON login/JWT mint requirement turns alias contract red', () => {
   const original = read(REMOTE_SH)
-  const mutated = original.replace('prove_canary_password_login "pre_on"', 'true # pre_on removed')
+  const mutated = original.replace(
+    'mint_canary_admin_jwt_from_password_login "pre_on"',
+    'true # pre_on mint removed',
+  )
   const body = actionAliasBody(mutated)
   let failed = false
   try {
-    assert.match(body, /prove_canary_password_login "pre_on"/)
+    assert.match(body, /mint_canary_admin_jwt_from_password_login "pre_on"/)
   } catch {
     failed = true
   }
@@ -1154,14 +1219,14 @@ test('MUTATION: removing secret-file requirement turns alias contract red', () =
   assert.equal(failed, true)
 })
 
-test('production function: require_canary_secret_files rejects missing paths', () => {
+test('production function: require_canary_secret_files rejects missing login paths (JWT not required)', () => {
   const result = spawnSync(
     'bash',
     [
       '-o',
       'pipefail',
       '-c',
-      'source "$1"; CANARY_ADMIN_JWT_FILE=; CANARY_LOGIN_IDENTIFIER_FILE=; CANARY_LOGIN_PASSWORD_FILE=; require_canary_secret_files',
+      'source "$1"; CANARY_ADMIN_JWT_FILE=; CANARY_LOGIN_IDENTIFIER_FILE=; CANARY_LOGIN_PASSWORD_FILE=; require_canary_secret_files alias',
       'bash',
       REMOTE_SH,
     ],
@@ -1177,7 +1242,8 @@ test('production function: require_canary_secret_files rejects missing paths', (
     },
   )
   assert.notEqual(result.status, 0)
-  assert.match(result.stderr, /CANARY_ADMIN_JWT_FILE|secret file/)
+  assert.match(result.stderr, /CANARY_LOGIN_IDENTIFIER_FILE|CANARY_LOGIN_PASSWORD_FILE|secret file/)
+  assert.doesNotMatch(result.stderr, /CANARY_ADMIN_JWT_FILE/)
 })
 
 test('alias backfill requires exact nonnegative counts and collisions==0 before env write', () => {
@@ -1521,7 +1587,7 @@ with socketserver.TCPServer(("127.0.0.1", 0), Handler) as httpd:
   }
 })
 
-test('FUNCTIONAL harness: action_alias success call order pre-login→backfill→status→ON→OFF', () => {
+test('FUNCTIONAL harness: action_alias success call order pre-login+mint→backfill→status→ON→OFF', () => {
   const sha = 'c'.repeat(40)
   const result = spawnSync(
     'bash',
@@ -1534,6 +1600,7 @@ test('FUNCTIONAL harness: action_alias success call order pre-login→backfill�
        record() { CALL_LOG+=("\$1"); }
        require_sha() { record require_sha; }
        require_canary_secret_files() { record require_secrets; }
+       assert_canary_identifier_matches_owner() { record assert_owner_ident; }
        capture_live_snapshot() {
          record capture_live_snapshot
          SNAP_ALIAS=false; SNAP_PENDING=false; SNAP_DEPROV=false; SNAP_MODE=off
@@ -1543,6 +1610,12 @@ test('FUNCTIONAL harness: action_alias success call order pre-login→backfill�
        assert_exact_sha() { record assert_exact_sha; }
        pin_live_backend_image_for_transition() { record pin_image; }
        require_migrations_pending_zero_true() { record require_migrations; }
+       mint_canary_admin_jwt_from_password_login() {
+         record "mint:\$1"
+         CANARY_ADMIN_JWT_FILE="/tmp/lifecycle-canary-minted.jwt"
+         printf 'minted-token' > "\$CANARY_ADMIN_JWT_FILE"
+         return 0
+       }
        prove_canary_password_login() { record "login:\$1"; return 0; }
        run_alias_backfill() {
          record backfill
@@ -1599,7 +1672,8 @@ test('FUNCTIONAL harness: action_alias success call order pre-login→backfill�
     assert.ok(i >= 0, `missing call ${name} in ${lines.join(',')}`)
     return i
   }
-  assert.ok(idx('login:pre_on') < idx('backfill'))
+  assert.ok(idx('assert_owner_ident') < idx('mint:pre_on'))
+  assert.ok(idx('mint:pre_on') < idx('backfill'))
   assert.ok(idx('backfill') < idx('cutover_status'))
   assert.ok(idx('cutover_status') < idx('off_baseline'))
   assert.ok(idx('off_baseline') < idx('write:true:false:false'))
@@ -1718,6 +1792,7 @@ test('FUNCTIONAL harness: post-ON login failure invokes fail_transition_restore 
        record() { CALL_LOG+=("\$1"); }
        require_sha() { :; }
        require_canary_secret_files() { :; }
+       assert_canary_identifier_matches_owner() { :; }
        capture_live_snapshot() {
          SNAP_ALIAS=false; SNAP_PENDING=false; SNAP_DEPROV=false; SNAP_MODE=off
          SNAP_BUILD_SHA="$DEPLOY_SHA"; SNAP_ALIAS_READY=true; SNAP_CAN_ENABLE_ALIAS=true
@@ -1726,6 +1801,12 @@ test('FUNCTIONAL harness: post-ON login failure invokes fail_transition_restore 
        assert_exact_sha() { :; }
        pin_live_backend_image_for_transition() { :; }
        require_migrations_pending_zero_true() { :; }
+       mint_canary_admin_jwt_from_password_login() {
+         record "mint:\$1"
+         CANARY_ADMIN_JWT_FILE="/tmp/lifecycle-canary-minted-fail.jwt"
+         printf 'minted-token' > "\$CANARY_ADMIN_JWT_FILE"
+         return 0
+       }
        prove_canary_password_login() {
          record "login:\$1"
          if [[ "\$1" == "post_on" ]]; then return 1; fi
@@ -1887,9 +1968,445 @@ ON
   }
 })
 
+// --- bootstrap fixed canary admin -----------------------------------------------------
+
+/** Extract the embedded non-secret bootstrap Node program (NODE heredoc). */
+function bootstrapNodeSource(source = read(REMOTE_SH)) {
+  const start = source.indexOf("cat >\"$node_tmp\" <<'NODE'")
+  assert.notEqual(start, -1, 'bootstrap node_tmp NODE heredoc must exist')
+  const bodyStart = source.indexOf('\n', start) + 1
+  const end = source.indexOf('\nNODE\n', bodyStart)
+  assert.notEqual(end, -1, 'NODE terminator missing')
+  return source.slice(bodyStart, end)
+}
+
+/** SQL string payloads passed to c.query("...") inside the bootstrap node program. */
+function bootstrapSqlPayloads(nodeSrc) {
+  const payloads = []
+  const re = /c\.query\(\s*"((?:\\.|[^"\\])*)"/g
+  let m
+  while ((m = re.exec(nodeSrc)) !== null) {
+    payloads.push(m[1].replace(/\\"/g, '"').replace(/\\n/g, '\n'))
+  }
+  return payloads
+}
+
+test('bootstrap fixed ownership markers and collision fail-closed transaction shape', () => {
+  const source = read(REMOTE_SH)
+  assert.match(source, /CANARY_OWNER_EMAIL="lifecycle-canary@staging\.invalid"/)
+  assert.match(
+    source,
+    /CANARY_OWNER_USER_ID="6c1fe000-ca0a-4000-8000-1ec0c1e00001"/,
+  )
+  assert.match(source, /bootstrap_lifecycle_canary_admin\(\)/)
+  assert.match(source, /action_bootstrap\(\)/)
+  assert.match(source, /collision_not_owned/)
+  assert.match(source, /collision_multiple_rows/)
+  assert.match(source, /FOR UPDATE/)
+  assert.match(source, /BEGIN/)
+  assert.match(source, /COMMIT/)
+  assert.match(source, /ROLLBACK/)
+  assert.match(source, /local_password_set = TRUE/)
+  assert.match(source, /must_change_password = FALSE/)
+  assert.match(source, /activation_status = 'activated'/)
+  assert.match(source, /user_roles/)
+  assert.match(source, /role_id.*admin|VALUES \(\$1, 'admin'\)/)
+  // permissions omitted (054 TEXT[] vs jsonb drift) — never '[]'::jsonb cast.
+  assert.doesNotMatch(source, /'::jsonb/)
+  assert.match(source, /Omit permissions|omit permissions/i)
+  // Never mutates an arbitrary admin by email/role scan.
+  assert.doesNotMatch(source, /WHERE role = 'admin'[\s\S]{0,80}UPDATE users/)
+  assert.doesNotMatch(source, /WHERE is_admin = TRUE[\s\S]{0,80}UPDATE users/)
+})
+
+test('bootstrap SQL uses single-quoted PostgreSQL string literals (double-quote reversion is red)', () => {
+  const node = bootstrapNodeSource()
+  const sqls = bootstrapSqlPayloads(node)
+  assert.ok(sqls.length >= 5, `expected multiple c.query SQL strings, got ${sqls.length}`)
+  const joined = sqls.join('\n')
+
+  // Required single-quoted literals (PG string syntax).
+  assert.match(joined, /role = 'admin'/)
+  assert.match(joined, /activation_status = 'activated'/)
+  assert.match(joined, /table_schema = 'public'/)
+  assert.match(joined, /VALUES \(\$1, 'admin'\)/)
+  assert.match(joined, /VALUES \(\$1, \$2, \$3, \$4, 'admin'/)
+  assert.match(joined, /IN \('\*:\*', 'admin:users', 'admin:roles', 'admin:permissions'\)/)
+  assert.match(joined, /NULLIF\(trim\(name\), ''\)/)
+
+  // Forbidden: double-quoted SQL string literals (PG treats them as identifiers).
+  const forbidden = [
+    /role\s*=\s*"admin"/,
+    /activation_status\s*=\s*"activated"/,
+    /table_schema\s*=\s*"public"/,
+    /VALUES\s*\([^)]*"admin"/,
+    /IN\s*\(\s*"/,
+    /NULLIF\([^)]*,\s*""\)/,
+  ]
+  for (const re of forbidden) {
+    assert.doesNotMatch(joined, re)
+  }
+
+  // MUTATION: reintroducing double-quoted SQL literals must fail this contract.
+  const mutated = joined
+    .replaceAll("role = 'admin'", 'role = "admin"')
+    .replaceAll("activation_status = 'activated'", 'activation_status = "activated"')
+  let failed = false
+  try {
+    assert.doesNotMatch(mutated, /role\s*=\s*"admin"/)
+  } catch {
+    failed = true
+  }
+  assert.equal(failed, true, 'double-quoted role = "admin" must turn the contract red')
+})
+
+test('bootstrap create and repair upsert user_session_revocations like session-revocation.ts', () => {
+  const node = bootstrapNodeSource()
+  const removeRevocationUpsert = (source, reason) => {
+    const reasonArgs = `[ownerId, ownerId, "${reason}"]`
+    const reasonIdx = source.indexOf(reasonArgs)
+    assert.ok(reasonIdx > 0, `${reason} args must exist`)
+    const queryStart = source.lastIndexOf('await c.query(', reasonIdx)
+    const queryEnd = source.indexOf(');', reasonIdx)
+    assert.ok(queryStart > 0 && queryEnd > reasonIdx, `${reason} query bounds must exist`)
+    assert.match(
+      source.slice(queryStart, reasonIdx),
+      /INSERT INTO user_session_revocations/,
+      `${reason} must belong to the revocation upsert`,
+    )
+    return `${source.slice(0, queryStart)}/* revocation upsert removed */${source.slice(queryEnd + 2)}`
+  }
+  // Primary guard: same column list + ON CONFLICT watermark as revokeUserSessions().
+  assert.match(
+    node,
+    /INSERT INTO user_session_revocations \(user_id, revoked_after, updated_at, updated_by, reason\) VALUES \(\$1, NOW\(\), NOW\(\), \$2, \$3\) ON CONFLICT \(user_id\) DO UPDATE SET revoked_after = EXCLUDED\.revoked_after, updated_at = EXCLUDED\.updated_at, updated_by = EXCLUDED\.updated_by, reason = EXCLUDED\.reason/,
+  )
+  assert.match(node, /lifecycle_canary_bootstrap_password_repair/)
+  assert.match(node, /lifecycle_canary_bootstrap_password_create/)
+  assert.equal((node.match(/INSERT INTO user_session_revocations/g) || []).length, 2)
+  // Param shape: userId, updatedBy, reason — not reason-only / userId-as-reason confusion.
+  assert.match(
+    node,
+    /\[ownerId, ownerId, "lifecycle_canary_bootstrap_password_repair"\]/,
+  )
+  // Order: revocations upsert before optional user_sessions belt.
+  const revIdx = node.indexOf('INSERT INTO user_session_revocations')
+  const sessIdx = node.indexOf('UPDATE user_sessions SET revoked_at')
+  assert.ok(revIdx > 0, 'user_session_revocations upsert required')
+  assert.ok(sessIdx > revIdx, 'user_sessions belt must follow user_session_revocations primary guard')
+  assert.match(node, /Additional belt only|additional belt/i)
+  assert.doesNotMatch(node, /table_name = 'user_session_revocations'/)
+  assert.match(node, /absence must roll back the repair/i)
+
+  // MUTATION: dropping either branch's revocation upsert must redden its own contract.
+  const withoutRepairRev = removeRevocationUpsert(
+    node,
+    'lifecycle_canary_bootstrap_password_repair',
+  )
+  assert.match(withoutRepairRev, /lifecycle_canary_bootstrap_password_create/)
+  let repairFailed = false
+  try {
+    assert.match(
+      withoutRepairRev,
+      /\[ownerId, ownerId, "lifecycle_canary_bootstrap_password_repair"\]/,
+    )
+  } catch {
+    repairFailed = true
+  }
+  assert.equal(repairFailed, true)
+
+  const withoutCreateRev = removeRevocationUpsert(
+    node,
+    'lifecycle_canary_bootstrap_password_create',
+  )
+  assert.match(withoutCreateRev, /lifecycle_canary_bootstrap_password_repair/)
+  let createFailed = false
+  try {
+    assert.match(
+      withoutCreateRev,
+      /\[ownerId, ownerId, "lifecycle_canary_bootstrap_password_create"\]/,
+    )
+  } catch {
+    createFailed = true
+  }
+  assert.equal(createFailed, true)
+})
+
+test('bootstrap streams secrets over docker exec stdin; never docker cp container secret files', () => {
+  const source = read(REMOTE_SH)
+  const start = source.indexOf('bootstrap_lifecycle_canary_admin()')
+  const end = source.indexOf('\n# Admin API via JWT file', start)
+  const body = source.slice(start, end)
+  assert.match(body, /struct\.pack\(">I"/)
+  assert.match(body, /readFrame|readUInt32BE/)
+  assert.match(body, /docker exec -i/)
+  assert.match(body, /no container secret files/i)
+  assert.doesNotMatch(body, /docker cp/)
+  // Host may mktemp a non-secret node source; must never docker-cp login secret files.
+  assert.doesNotMatch(body, /docker cp[^\n]*login\.(identifier|password)/)
+  assert.doesNotMatch(body, /BACKEND_CONTAINER:[^\n]*login\.(identifier|password)/)
+  assert.match(body, /CANARY_BOOTSTRAP_MIN_PASSWORD_LEN=12|password_too_short/)
+  assert.match(body, /password\.length < minLen|password_too_short/)
+  // JWT revocation watermark is authoritative; user_sessions is an additional belt.
+  assert.match(body, /INSERT INTO user_session_revocations/)
+  assert.match(body, /revoked_after = EXCLUDED\.revoked_after/)
+  assert.match(body, /ON CONFLICT \(user_id\) DO UPDATE/)
+  assert.match(body, /user_sessions/)
+  assert.match(body, /revoked_at/)
+  assert.match(body, /lifecycle_canary_bootstrap_password_repair/)
+})
+
+test('bootstrap requires exact SHA, OFF, health, migrations zero; never writes lifecycle env', () => {
+  const body = actionBootstrapBody(read(REMOTE_SH))
+  assert.match(body, /require_sha/)
+  assert.match(body, /assert_exact_sha/)
+  assert.match(body, /require_migrations_pending_zero_true "\$SNAP_MIGRATIONS_ZERO" "action=bootstrap"/)
+  assert.match(body, /require_canary_secret_files "bootstrap"/)
+  assert.match(body, /assert_canary_identifier_matches_owner "bootstrap"/)
+  assert.match(body, /expected_current_mode=off/)
+  assert.match(body, /backend_health_ok must be true before account mutation/)
+  assert.match(body, /live mode must be off/)
+  assert.match(body, /bootstrap_lifecycle_canary_admin/)
+  assert.match(body, /sleep 1\.1/)
+  assert.match(body, /prove_canary_password_login "bootstrap"/)
+  // Post-bootstrap re-assert mode/health/SHA.
+  assert.match(body, /post-bootstrap live mode must remain off/)
+  assert.match(body, /post-bootstrap backend_health_ok must remain true/)
+  assert.match(body, /require_migrations_pending_zero_true "\$SNAP_MIGRATIONS_ZERO" "action=bootstrap post-check"/)
+  assert.match(body, /post-bootstrap SHA/)
+  assert.match(body, /post_bootstrap_mode_off=true/)
+  assert.match(body, /transition_applied=false/)
+  assert.match(body, /lifecycle_env_write=false/)
+  assert.doesNotMatch(body, /write_lifecycle_override/)
+  assert.doesNotMatch(body, /recreate_backend_only/)
+  assert.doesNotMatch(body, /AUTH_LOGIN_USE_ALIASES/)
+  assert.doesNotMatch(body, /pin_live_backend_image_for_transition/)
+})
+
+test('MUTATION: bootstrap enabling a lifecycle flag would fail no-env-write contract', () => {
+  const original = actionBootstrapBody(read(REMOTE_SH))
+  const mutated = `${original}\n  write_lifecycle_override "true" "false" "false"\n`
+  let failed = false
+  try {
+    assert.doesNotMatch(mutated, /write_lifecycle_override/)
+  } catch {
+    failed = true
+  }
+  assert.equal(failed, true)
+})
+
+test('alias JWT derivation mints from password login; never ATTENDANCE_ADMIN_JWT', () => {
+  const source = read(REMOTE_SH)
+  assert.match(source, /mint_canary_admin_jwt_from_password_login\(\)/)
+  assert.match(source, /admin\.jwt/)
+  assert.match(source, /never secrets\.ATTENDANCE_ADMIN_JWT|Never.*ATTENDANCE_ADMIN_JWT/i)
+  assert.match(source, /CANARY_ADMIN_JWT_FILE set from password login mint/)
+  const aliasBody = actionAliasBody(source)
+  assert.match(aliasBody, /mint_canary_admin_jwt_from_password_login "pre_on"/)
+  const mintIdx = aliasBody.indexOf('mint_canary_admin_jwt_from_password_login "pre_on"')
+  const backfillIdx = aliasBody.indexOf('run_alias_backfill')
+  assert.ok(mintIdx >= 0 && backfillIdx > mintIdx)
+  // Workflow must not inject secrets.ATTENDANCE_ADMIN_JWT; remote must not read that secret.
+  const yaml = read(WORKFLOW)
+  assert.doesNotMatch(yaml, /\$\{\{\s*secrets\.ATTENDANCE_ADMIN_JWT/)
+  assert.doesNotMatch(source, /\$\{\{\s*secrets\.ATTENDANCE_ADMIN_JWT/)
+  assert.doesNotMatch(source, /ATTENDANCE_ADMIN_JWT_FILE|printf.*ATTENDANCE_ADMIN_JWT/)
+})
+
+test('FUNCTIONAL harness: action_bootstrap order gates then create/repair then login then reassert; no env write', () => {
+  const sha = 'f'.repeat(40)
+  const result = spawnSync(
+    'bash',
+    [
+      '-o',
+      'pipefail',
+      '-c',
+      `source "$1"
+       CALL_LOG=()
+       record() { CALL_LOG+=("\$1"); }
+       require_sha() { record require_sha; }
+       require_canary_secret_files() { record require_secrets; }
+       assert_canary_identifier_matches_owner() { record assert_owner; }
+       capture_live_snapshot() {
+         record capture
+         SNAP_ALIAS=false; SNAP_PENDING=false; SNAP_DEPROV=false; SNAP_MODE=off
+         SNAP_BUILD_SHA="$DEPLOY_SHA"; SNAP_ALIAS_READY=true; SNAP_CAN_ENABLE_ALIAS=true
+         SNAP_MIGRATIONS_ZERO=true; SNAP_HEALTH_OK=true
+       }
+       assert_exact_sha() { record assert_sha; }
+       require_migrations_pending_zero_true() { record require_mig; }
+       bootstrap_lifecycle_canary_admin() { record bootstrap_txn; BOOTSTRAP_OUTCOME=created; return 0; }
+       prove_canary_password_login() { record "login:\$1"; return 0; }
+       write_lifecycle_override() { record "write:\$1:\$2:\$3"; }
+       write_status_artifact() { record write_status; }
+       OUTPUT_DIR="$2"
+       mkdir -p "$OUTPUT_DIR"
+       DEPLOY_SHA="$3"
+       EXPECTED_CURRENT_MODE=off
+       ACTION=bootstrap
+       action_bootstrap
+       printf '%s\\n' "\${CALL_LOG[@]}"`,
+      'bash',
+      REMOTE_SH,
+      '/tmp/lifecycle-canary-bootstrap-success',
+      sha,
+    ],
+    {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        ACTION: 'bootstrap',
+        OUTPUT_DIR: '/tmp/lifecycle-canary-bootstrap-success',
+        RUN_STAMP: 'contract',
+        LIFECYCLE_CANARY_SOURCE_ONLY: 'true',
+        DEPLOY_SHA: sha,
+        EXPECTED_CURRENT_MODE: 'off',
+      },
+    },
+  )
+  assert.equal(result.status, 0, result.stderr + result.stdout)
+  const lines = result.stdout.trim().split('\n')
+  const idx = (name) => {
+    const i = lines.indexOf(name)
+    assert.ok(i >= 0, `missing call ${name} in ${lines.join(',')}`)
+    return i
+  }
+  assert.ok(idx('require_sha') < idx('require_secrets'))
+  assert.ok(idx('require_secrets') < idx('assert_owner'))
+  assert.ok(idx('assert_sha') < idx('bootstrap_txn'))
+  assert.ok(idx('require_mig') < idx('bootstrap_txn'))
+  assert.ok(idx('bootstrap_txn') < idx('login:bootstrap'))
+  // Second capture + assert_exact_sha after login for post-bootstrap reassert.
+  const loginI = idx('login:bootstrap')
+  const secondCapture = lines.indexOf('capture', loginI + 1)
+  assert.ok(secondCapture > loginI, 'post-bootstrap recapture required')
+  const secondSha = lines.indexOf('assert_sha', loginI + 1)
+  assert.ok(secondSha > secondCapture, 'post-bootstrap SHA reassert after recapture')
+  assert.ok(!lines.some((l) => l.startsWith('write:')), 'bootstrap must not write lifecycle override')
+})
+
+test('FUNCTIONAL: mint_canary_admin_jwt_from_password_login writes chmod-600 JWT file from login', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'lifecycle-canary-mint-'))
+  /** @type {import('node:child_process').ChildProcess | null} */
+  let serverProc = null
+  /** @type {import('node:child_process').ChildProcess | null} */
+  let helperProc = null
+  const overallMs = 8000
+  try {
+    const identFile = join(dir, 'login.identifier')
+    const passFile = join(dir, 'login.password')
+    writeFileSync(identFile, 'lifecycle-canary@staging.invalid')
+    writeFileSync(passFile, 's3cret-canary-pass')
+    const jwtOut = join(dir, 'admin.jwt')
+
+    const serverPy = `
+import json
+import http.server
+import socketserver
+
+class Handler(http.server.BaseHTTPRequestHandler):
+    def do_POST(self):
+        n = int(self.headers.get("Content-Length", "0"))
+        self.rfile.read(n)
+        body = json.dumps({"success": True, "data": {"token": "minted-loopback-jwt"}}).encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+    def log_message(self, *_args):
+        return
+
+with socketserver.TCPServer(("127.0.0.1", 0), Handler) as httpd:
+    print(httpd.server_address[1], flush=True)
+    httpd.handle_request()
+`
+    serverProc = spawn('python3', ['-c', serverPy], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: process.env,
+    })
+    const serverDone = collectChild(serverProc, overallMs)
+    const port = await new Promise((resolve, reject) => {
+      let buf = ''
+      const timer = setTimeout(() => reject(new Error('loopback server port timeout')), 3000)
+      const onData = (chunk) => {
+        buf += chunk.toString('utf8')
+        const line = buf.trim().split(/\r?\n/).filter(Boolean).pop() || ''
+        if (/^\d+$/.test(line)) {
+          clearTimeout(timer)
+          serverProc.stdout.off('data', onData)
+          resolve(Number(line))
+        }
+      }
+      serverProc.stdout.on('data', onData)
+      serverProc.on('error', (err) => {
+        clearTimeout(timer)
+        reject(err)
+      })
+    })
+
+    helperProc = spawn(
+      'bash',
+      [
+        '-o',
+        'pipefail',
+        '-c',
+        `source "$1"
+         CANARY_LOGIN_IDENTIFIER_FILE="$2"
+         CANARY_LOGIN_PASSWORD_FILE="$3"
+         STAGING_API_BASE_URL="$4"
+         mint_canary_admin_jwt_from_password_login loopback_mint
+         printf 'PATH=%s\\n' "\$CANARY_ADMIN_JWT_FILE"
+         printf 'TOKEN='
+         cat "\$CANARY_ADMIN_JWT_FILE"
+         printf '\\n'
+         stat -f '%Lp' "\$CANARY_ADMIN_JWT_FILE" 2>/dev/null || stat -c '%a' "\$CANARY_ADMIN_JWT_FILE"`,
+        'bash',
+        REMOTE_SH,
+        identFile,
+        passFile,
+        `http://127.0.0.1:${port}`,
+      ],
+      {
+        env: {
+          ...process.env,
+          ACTION: 'status',
+          OUTPUT_DIR: '/tmp/lifecycle-canary-contract-source-only',
+          RUN_STAMP: 'contract',
+          LIFECYCLE_CANARY_SOURCE_ONLY: 'true',
+        },
+        stdio: ['ignore', 'pipe', 'pipe'],
+      },
+    )
+    const helperResult = await collectChild(helperProc, overallMs)
+    assert.equal(
+      helperResult.code,
+      0,
+      `helper failed: ${helperResult.stderr}${helperResult.stdout}`,
+    )
+    assert.match(helperResult.stdout, /PATH=.*admin\.jwt/)
+    assert.match(helperResult.stdout, /TOKEN=minted-loopback-jwt/)
+    assert.match(helperResult.stdout, /600/)
+    assert.ok(existsSync(jwtOut))
+    assert.equal(readFileSync(jwtOut, 'utf8'), 'minted-loopback-jwt')
+    await Promise.race([serverDone, new Promise((resolve) => setTimeout(resolve, 1000))])
+  } finally {
+    for (const proc of [helperProc, serverProc]) {
+      if (proc && !proc.killed && proc.exitCode === null) {
+        try {
+          proc.kill('SIGKILL')
+        } catch {
+          // ignore
+        }
+      }
+    }
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
 // --- docs / staging blockers ----------------------------------------------------------
 
-test('docs mark pending/deprovision NOT EXECUTABLE; alias is executable transient canary', () => {
+test('docs mark pending/deprovision NOT EXECUTABLE; alias is executable transient canary; bootstrap documented', () => {
   const closeout = read(CLOSEOUT_DOC)
   const go = read(CANARY_GO_DOC)
   // Closeout may still describe historical NOT EXECUTABLE for ON names; go-doc is authoritative.
@@ -1899,12 +2416,16 @@ test('docs mark pending/deprovision NOT EXECUTABLE; alias is executable transien
   assert.match(go, /deprovision/)
   assert.match(go, /EXECUTABLE/)
   assert.match(go, /alias/)
+  assert.match(go, /bootstrap/)
+  assert.match(go, /lifecycle-canary@staging\.invalid/)
   assert.match(go, /success requires\/proves OFF|Success requires\/proves OFF/i)
   assert.match(go, /failure restores the OFF override before failing/i)
   assert.match(go, /runtime OFF cannot be proven/i)
   assert.doesNotMatch(go, /ALWAYS returns to OFF|always returns to OFF|always restores OFF/i)
   assert.match(go, /LIFECYCLE_CANARY_LOGIN_IDENTIFIER|secret-backed/)
   assert.match(go, /collisions==0|collisions must be 0|collisions==0/i)
+  assert.match(go, /ATTENDANCE_ADMIN_JWT/)
+  assert.match(go, /never.*ATTENDANCE_ADMIN_JWT|not.*ATTENDANCE_ADMIN_JWT|mint.*password login/i)
   // No invented successful canary execution evidence.
   assert.doesNotMatch(go, /alias canary EXECUTED successfully|alias cutover canary PASSED on staging/i)
   assert.match(go, /NOT EXECUTED/)
@@ -1951,4 +2472,5 @@ test('workflow exports only safe remote env keys (no raw secret values)', () => 
   assert.doesNotMatch(yaml, /export OWNER_CONFIRM=/)
   assert.doesNotMatch(yaml, /export ATTENDANCE_ADMIN_JWT=/)
   assert.doesNotMatch(yaml, /export LIFECYCLE_CANARY_LOGIN_PASSWORD=/)
+  assert.doesNotMatch(yaml, /export CANARY_ADMIN_JWT_FILE=/)
 })

--- a/scripts/ops/dingtalk-lifecycle-staging-canary-remote.sh
+++ b/scripts/ops/dingtalk-lifecycle-staging-canary-remote.sh
@@ -10,16 +10,27 @@
 #   off        — emergency operational rollback of the THREE lifecycle env gates
 #                to OFF. Atomic previous-override backup + restore on
 #                restart/health/mode failure.
+#   bootstrap  — staging-only, manual create/repair of the FIXED dedicated
+#                lifecycle canary platform admin (email+UUID ownership markers).
+#                Requires full deploy SHA, expected_current_mode=off, exact mode
+#                off, health true, migrations_pending_zero true.
+#                Idempotent for the owned row; email/id collision not matching
+#                BOTH markers fails closed. Proves real password login.
+#                NEVER writes lifecycle env flags; never touches arbitrary admins.
+#                Requires login identifier/password secret files only (chmod 600).
 #   alias      — TRANSIENT secret-backed alias cutover canary.
 #                Success requires/proves OFF (post-rollback mode+login).
 #                Failure restores the OFF override before failing (post-write).
 #                Runtime OFF cannot be proven if rollback recreate itself fails
 #                (override restored on disk; operator must inspect).
-#                Requires full deploy SHA, expected_current_mode=off, admin JWT
-#                file + login identifier/password files (chmod 600).
-#                Sequence: pre-login → backfill (collisions==0) → cutover-status
-#                ready → write alias ON → recreate backend only → post-ON login
-#                → restore OFF → recreate → post-rollback login.
+#                Requires full deploy SHA, expected_current_mode=off, and login
+#                identifier/password files (chmod 600) only — NO repo-global
+#                ATTENDANCE_ADMIN_JWT. Short-lived admin JWT is minted from the
+#                canary password login into a chmod-600 per-run remote file after
+#                successful pre-login, then used for backfill/cutover-status.
+#                Sequence: pre-login (+mint JWT) → backfill (collisions==0) →
+#                cutover-status ready → write alias ON → recreate backend only →
+#                post-ON login → restore OFF → recreate → post-rollback login.
 #                Backfill rows may persist.
 #
 # NOT EXECUTABLE (fail-closed preflight-only; transition_applied always false):
@@ -31,10 +42,12 @@
 # HARD SAFETY RAILS:
 #   * Staging compose + metasheet-staging-* containers only; no prod fallback.
 #   * migrations_pending_zero must be exactly "true" for preflight_ok and for
-#     action=off / action=alias (unknown is a fail, never treated as success).
+#     action=off / action=alias / action=bootstrap (unknown is a fail, never
+#     treated as success).
 #   * action=off|alias: recreate backend only; prove postgres/redis IDs unchanged;
 #     require backend health true after restart; prove exact mode; restore
 #     previous override and re-recreate on any failure after the write.
+#   * action=bootstrap: no lifecycle env write; no backend recreate.
 #   * multi-on: status/preflight report and fail closed; action=off still clears
 #     the exact three flags (does not die in derive_mode before clear).
 #   * Artifacts never contain env values, credentials, subject ids, or PII —
@@ -47,7 +60,7 @@ set -euo pipefail
 log() { echo "[lifecycle-canary] $*"; }
 fail() { echo "[lifecycle-canary][error] $*" >&2; exit 1; }
 
-ACTION="${ACTION:?ACTION is required (status|preflight|off|alias|pending|deprovision)}"
+ACTION="${ACTION:?ACTION is required (status|preflight|off|bootstrap|alias|pending|deprovision)}"
 TARGET_MODE="${TARGET_MODE:-}"
 EXPECTED_CURRENT_MODE="${EXPECTED_CURRENT_MODE:-}"
 DEPLOY_SHA="${DEPLOY_SHA:-}"
@@ -56,11 +69,19 @@ DEPLOY_PATH="${DEPLOY_PATH:-metasheet2}"
 OUTPUT_DIR="${OUTPUT_DIR:?OUTPUT_DIR is required}"
 RUN_STAMP="${RUN_STAMP:?RUN_STAMP is required (workflow run id marker)}"
 
-# Secret-backed alias canary inputs: FILE PATHS only (values never exported).
-# Workflow materializes chmod-600 files into the per-run remote directory.
+# Secret-backed canary inputs: FILE PATHS only (values never exported).
+# Workflow materializes chmod-600 identifier/password into the per-run remote dir.
+# Alias mints CANARY_ADMIN_JWT_FILE after successful pre-login (never from
+# secrets.ATTENDANCE_ADMIN_JWT). Bootstrap does not consume a JWT file.
 CANARY_ADMIN_JWT_FILE="${CANARY_ADMIN_JWT_FILE:-}"
 CANARY_LOGIN_IDENTIFIER_FILE="${CANARY_LOGIN_IDENTIFIER_FILE:-}"
 CANARY_LOGIN_PASSWORD_FILE="${CANARY_LOGIN_PASSWORD_FILE:-}"
+
+# Fixed dedicated lifecycle canary admin ownership markers (values-free constants).
+# Create/repair ONLY this (email, id) pair. Any email/id collision that does not
+# match BOTH markers fails closed — never mutates an arbitrary existing admin.
+CANARY_OWNER_EMAIL="lifecycle-canary@staging.invalid"
+CANARY_OWNER_USER_ID="6c1fe000-ca0a-4000-8000-1ec0c1e00001"
 
 # Intentionally ignored: not a real verifier path. Kept empty so accidental
 # exports cannot be mistaken for canary completion evidence.
@@ -378,36 +399,75 @@ require_migrations_pending_zero_true() {
 }
 
 require_canary_secret_files() {
+  # Login identifier/password paths only — never JWT from secrets.ATTENDANCE_ADMIN_JWT.
   # Paths only — never read values into shell variables that get logged.
-  local f
+  local f context="${1:-alias}"
   for f in \
-    CANARY_ADMIN_JWT_FILE \
     CANARY_LOGIN_IDENTIFIER_FILE \
     CANARY_LOGIN_PASSWORD_FILE
   do
     local path="${!f:-}"
-    [[ -n "$path" ]] || fail "action=alias requires ${f} (chmod-600 secret file path); no auto-selection"
-    [[ -f "$path" ]] || fail "action=alias secret file missing for ${f}"
-    [[ -s "$path" ]] || fail "action=alias secret file empty for ${f}"
+    [[ -n "$path" ]] || fail "action=${context} requires ${f} (chmod-600 secret file path); no auto-selection"
+    [[ -f "$path" ]] || fail "action=${context} secret file missing for ${f}"
+    [[ -s "$path" ]] || fail "action=${context} secret file empty for ${f}"
   done
-  log "alias canary secret files present (paths only; values never logged)"
+  log "${context} canary login secret files present (paths only; values never logged)"
+}
+
+# Identifier secret file (app trim) must equal the fixed ownership email marker.
+# Values never logged; only ok / reason enums leave python.
+assert_canary_identifier_matches_owner() {
+  local context="$1"
+  local result ok note
+  result="$(
+    python3 - "$CANARY_LOGIN_IDENTIFIER_FILE" "$CANARY_OWNER_EMAIL" <<'PY'
+import pathlib
+import sys
+
+ident_path, expected = sys.argv[1], sys.argv[2]
+try:
+    identifier = pathlib.Path(ident_path).read_bytes().decode("utf-8").strip()
+except Exception:
+    print("false|secret_file_read_failed")
+    raise SystemExit(0)
+if not identifier:
+    print("false|empty_identifier")
+    raise SystemExit(0)
+if identifier != expected:
+    print("false|identifier_not_fixed_owner")
+    raise SystemExit(0)
+print("true|ok")
+PY
+  )"
+  ok="${result%%|*}"
+  note="${result#*|}"
+  if [[ "$ok" == "true" ]]; then
+    log "canary identifier matches fixed owner email (${context})"
+    return 0
+  fi
+  fail "action=${context} refused: login identifier must be exact fixed owner email (${note}); values never logged"
 }
 
 # Real password login via secret files. Values stay inside python; never argv/export/log.
 # Identifier may follow app trim semantics (strip ends). Password is read EXACTLY as
-# stored (no CR/LF strip, no transform). stdout: true|ok or false|<reason_enum>.
+# stored (no CR/LF strip, no transform).
+# Usage: prove_canary_password_login CONTEXT [jwt_out_file]
+# When jwt_out_file is set and login succeeds, write the short-lived token there
+# (chmod 600) for subsequent admin API calls. Never logs token contents.
 prove_canary_password_login() {
   local context="$1"
+  local jwt_out="${2:-}"
   local result ok note
   result="$(
-    python3 - "$CANARY_LOGIN_IDENTIFIER_FILE" "$CANARY_LOGIN_PASSWORD_FILE" "$STAGING_API_BASE_URL" <<'PY'
+    python3 - "$CANARY_LOGIN_IDENTIFIER_FILE" "$CANARY_LOGIN_PASSWORD_FILE" "$STAGING_API_BASE_URL" "$jwt_out" <<'PY'
 import json
+import os
 import pathlib
 import sys
 import urllib.error
 import urllib.request
 
-ident_path, pass_path, base = sys.argv[1], sys.argv[2], sys.argv[3]
+ident_path, pass_path, base, jwt_out = sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4]
 try:
     # read_bytes+decode avoids text-mode universal-newline translation.
     # App sanitizeLoginIdentifier trims ends; password must not be transformed.
@@ -450,17 +510,353 @@ ok = (
     and isinstance(token, str)
     and len(token) > 0
 )
-print("true|ok" if ok else f"false|http_{code}_login_rejected")
+if not ok:
+    print(f"false|http_{code}_login_rejected")
+    raise SystemExit(0)
+if jwt_out:
+    try:
+        out = pathlib.Path(jwt_out)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        # Exact token bytes; no trailing newline added.
+        out.write_bytes(token.encode("utf-8"))
+        os.chmod(out, 0o600)
+    except Exception:
+        print("false|jwt_write_failed")
+        raise SystemExit(0)
+print("true|ok")
 PY
   )"
   ok="${result%%|*}"
   note="${result#*|}"
   if [[ "$ok" == "true" ]]; then
-    log "password login OK (${context})"
+    if [[ -n "$jwt_out" ]]; then
+      log "password login OK (${context}); short-lived admin JWT written to secret file (path only)"
+    else
+      log "password login OK (${context})"
+    fi
     return 0
   fi
   log "password login FAILED (${context}): ${note}"
   return 1
+}
+
+# Mint short-lived admin JWT into a chmod-600 file beside the login password file.
+# Never consumes secrets.ATTENDANCE_ADMIN_JWT or any repo-global JWT secret.
+mint_canary_admin_jwt_from_password_login() {
+  local context="$1"
+  local jwt_path
+  [[ -n "${CANARY_LOGIN_PASSWORD_FILE:-}" ]] \
+    || fail "mint admin JWT requires CANARY_LOGIN_PASSWORD_FILE path"
+  jwt_path="$(dirname "$CANARY_LOGIN_PASSWORD_FILE")/admin.jwt"
+  if ! prove_canary_password_login "$context" "$jwt_path"; then
+    return 1
+  fi
+  [[ -f "$jwt_path" && -s "$jwt_path" ]] \
+    || fail "mint admin JWT: secret file missing/empty after login (${context})"
+  CANARY_ADMIN_JWT_FILE="$jwt_path"
+  log "CANARY_ADMIN_JWT_FILE set from password login mint (path only; never ATTENDANCE_ADMIN_JWT)"
+  return 0
+}
+
+# Strong minimum password length for the fixed canary admin (matches on-prem bootstrap floor).
+CANARY_BOOTSTRAP_MIN_PASSWORD_LEN=12
+
+# Transactional create/repair of the FIXED owned lifecycle canary admin only.
+# Collision fail-closed: any users row matching email OR id that does not match
+# BOTH ownership markers refuses mutation. Values never logged.
+#
+# Credential transport: host python reads chmod-600 secret files and streams exact
+# bytes over docker exec stdin (uint32be length frames). Container node receives
+# ONLY non-secret ownership markers via env. No docker cp of secrets, no persistent
+# container secret files — interrupt cannot leave identifier/password under /tmp.
+# Node program is non-secret host temp source base64'd into env (not secret files).
+# stdout reason enums only via result lines.
+bootstrap_lifecycle_canary_admin() {
+  local result note node_tmp node_b64
+  BOOTSTRAP_OUTCOME="unset"
+  node_tmp=""
+
+  cleanup_bootstrap_node_tmp() {
+    if [[ -n "${node_tmp:-}" && -f "${node_tmp}" ]]; then
+      rm -f "${node_tmp}"
+    fi
+    node_tmp=""
+  }
+
+  # Non-secret node program on host only (never contains credentials).
+  # permissions column omitted (054 TEXT[] default / later jsonb default both work).
+  # Repair revokes sessions when schema supports it (user_session_revocations and/or user_sessions).
+  node_tmp="$(mktemp "${TMPDIR:-/tmp}/lifecycle-canary-bootstrap-node.XXXXXX")"
+  cat >"$node_tmp" <<'NODE'
+const { Client } = require("pg");
+
+function fail(code) {
+  process.stdout.write("false|" + code);
+  process.exit(0);
+}
+
+function readExact(n) {
+  return new Promise(function (resolve, reject) {
+    if (n === 0) {
+      resolve(Buffer.alloc(0));
+      return;
+    }
+    var chunks = [];
+    var got = 0;
+    function onData(c) {
+      chunks.push(c);
+      got += c.length;
+      if (got >= n) {
+        process.stdin.pause();
+        process.stdin.off("data", onData);
+        process.stdin.off("error", onErr);
+        process.stdin.off("end", onEnd);
+        var buf = Buffer.concat(chunks);
+        if (buf.length > n) {
+          process.stdin.unshift(buf.subarray(n));
+        }
+        resolve(buf.subarray(0, n));
+      }
+    }
+    function onErr(e) { reject(e); }
+    function onEnd() { reject(new Error("short_stdin")); }
+    process.stdin.on("data", onData);
+    process.stdin.on("error", onErr);
+    process.stdin.on("end", onEnd);
+    process.stdin.resume();
+  });
+}
+
+function readFrame() {
+  return readExact(4).then(function (hdr) {
+    var len = hdr.readUInt32BE(0);
+    if (len > 1024 * 1024) throw new Error("frame_too_large");
+    return readExact(len);
+  });
+}
+
+(async function () {
+  var ownerId = String(process.env.CANARY_BOOTSTRAP_OWNER_ID || "");
+  var ownerEmail = String(process.env.CANARY_BOOTSTRAP_OWNER_EMAIL || "");
+  var minLen = Number(process.env.CANARY_BOOTSTRAP_MIN_PASSWORD_LEN || "12");
+  if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(ownerId)) {
+    fail("owner_id_not_uuid");
+    return;
+  }
+  if (!ownerEmail) {
+    fail("owner_email_missing");
+    return;
+  }
+  if (!Number.isInteger(minLen) || minLen < 12) {
+    fail("min_password_len_invalid");
+    return;
+  }
+
+  var identifier;
+  var password;
+  try {
+    var identBuf = await readFrame();
+    var passBuf = await readFrame();
+    identifier = identBuf.toString("utf8").trim();
+    // Password: exact UTF-8 decode of framed bytes (no CR/LF strip).
+    password = passBuf.toString("utf8");
+  } catch (e) {
+    fail("secret_stdin_read_failed");
+    return;
+  }
+  if (!identifier || password === "") {
+    fail("empty_credentials");
+    return;
+  }
+  if (identifier !== ownerEmail) {
+    fail("identifier_not_fixed_owner");
+    return;
+  }
+  if (password.length < minLen) {
+    fail("password_too_short");
+    return;
+  }
+
+  var bcrypt;
+  try {
+    bcrypt = require("bcryptjs");
+  } catch (e) {
+    fail("bcryptjs_unavailable");
+    return;
+  }
+  var roundsRaw = process.env.BCRYPT_SALT_ROUNDS || "12";
+  var rounds = Number(roundsRaw);
+  if (!Number.isInteger(rounds) || rounds < 12) {
+    fail("bcrypt_rounds_invalid");
+    return;
+  }
+  var passwordHash;
+  try {
+    passwordHash = bcrypt.hashSync(password, rounds);
+  } catch (e) {
+    fail("password_hash_failed");
+    return;
+  }
+
+  var url = process.env.DATABASE_URL;
+  if (!url) {
+    fail("database_url_missing");
+    return;
+  }
+  var c = new Client({ connectionString: url, connectionTimeoutMillis: 10000 });
+  try {
+    await c.connect();
+    await c.query("BEGIN");
+    // Lock any colliding ownership rows for the duration of the transaction.
+    var found = await c.query(
+      "SELECT id, email FROM users WHERE id = $1 OR lower(email) = lower($2) FOR UPDATE",
+      [ownerId, ownerEmail]
+    );
+    if (found.rows.length > 1) {
+      await c.query("ROLLBACK");
+      fail("collision_multiple_rows");
+      return;
+    }
+    if (found.rows.length === 1) {
+      var row = found.rows[0];
+      var emailOk =
+        typeof row.email === "string" && row.email.toLowerCase() === ownerEmail.toLowerCase();
+      var idOk = row.id === ownerId;
+      if (!emailOk || !idOk) {
+        await c.query("ROLLBACK");
+        fail("collision_not_owned");
+        return;
+      }
+      // Idempotent repair of the fixed owned row only.
+      // Omit permissions: leave existing value (avoids TEXT[] vs jsonb cast issues).
+      await c.query(
+        "UPDATE users SET password_hash = $1, name = COALESCE(NULLIF(trim(name), ''), $2), role = 'admin', is_admin = TRUE, is_active = TRUE, activation_status = 'activated', local_password_set = TRUE, must_change_password = FALSE, updated_at = NOW() WHERE id = $3 AND lower(email) = lower($4)",
+        [passwordHash, "Lifecycle Canary Admin", ownerId, ownerEmail]
+      );
+      // Password rotation PRIMARY guard (same shape as session-revocation.ts revokeUserSessions):
+      // upsert user_session_revocations.revoked_after — JWT verify uses this watermark.
+      // user_sessions row revoke is an additional belt only (not sufficient alone).
+      // Required when migrations_pending_zero=true; absence must roll back the repair.
+      await c.query(
+        "INSERT INTO user_session_revocations (user_id, revoked_after, updated_at, updated_by, reason) VALUES ($1, NOW(), NOW(), $2, $3) ON CONFLICT (user_id) DO UPDATE SET revoked_after = EXCLUDED.revoked_after, updated_at = EXCLUDED.updated_at, updated_by = EXCLUDED.updated_by, reason = EXCLUDED.reason",
+        [ownerId, ownerId, "lifecycle_canary_bootstrap_password_repair"]
+      );
+      // Additional belt only — not a substitute for user_session_revocations.
+      var sessTable = await c.query(
+        "SELECT 1 FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'user_sessions' LIMIT 1"
+      );
+      if (sessTable.rows.length > 0) {
+        await c.query(
+          "UPDATE user_sessions SET revoked_at = NOW(), revoked_by = $1, revoke_reason = $2, updated_at = NOW() WHERE user_id = $1 AND revoked_at IS NULL",
+          [ownerId, "lifecycle_canary_bootstrap_password_repair"]
+        );
+      }
+      await c.query(
+        "INSERT INTO user_roles (user_id, role_id) VALUES ($1, 'admin') ON CONFLICT (user_id, role_id) DO NOTHING",
+        [ownerId]
+      );
+      await c.query(
+        "INSERT INTO user_permissions (user_id, permission_code) SELECT $1, p.code FROM permissions p WHERE p.code IN ('*:*', 'admin:users', 'admin:roles', 'admin:permissions') ON CONFLICT (user_id, permission_code) DO NOTHING",
+        [ownerId]
+      );
+      await c.query("COMMIT");
+      process.stdout.write("true|repaired");
+      return;
+    }
+
+    // No collision: insert fixed owned row.
+    // Omit permissions so both TEXT[] default (054) and jsonb default work.
+    await c.query(
+      "INSERT INTO users (id, email, name, password_hash, role, is_admin, is_active, activation_status, local_password_set, must_change_password, created_at, updated_at) VALUES ($1, $2, $3, $4, 'admin', TRUE, TRUE, 'activated', TRUE, FALSE, NOW(), NOW())",
+      [ownerId, ownerEmail, "Lifecycle Canary Admin", passwordHash]
+    );
+    // A prior deleted canary row may have left orphaned stateless tokens because
+    // the revocation table has no users FK. Advance the watermark on create too.
+    await c.query(
+      "INSERT INTO user_session_revocations (user_id, revoked_after, updated_at, updated_by, reason) VALUES ($1, NOW(), NOW(), $2, $3) ON CONFLICT (user_id) DO UPDATE SET revoked_after = EXCLUDED.revoked_after, updated_at = EXCLUDED.updated_at, updated_by = EXCLUDED.updated_by, reason = EXCLUDED.reason",
+      [ownerId, ownerId, "lifecycle_canary_bootstrap_password_create"]
+    );
+    await c.query(
+      "INSERT INTO user_roles (user_id, role_id) VALUES ($1, 'admin') ON CONFLICT (user_id, role_id) DO NOTHING",
+      [ownerId]
+    );
+    await c.query(
+      "INSERT INTO user_permissions (user_id, permission_code) SELECT $1, p.code FROM permissions p WHERE p.code IN ('*:*', 'admin:users', 'admin:roles', 'admin:permissions') ON CONFLICT (user_id, permission_code) DO NOTHING",
+      [ownerId]
+    );
+    await c.query("COMMIT");
+    process.stdout.write("true|created");
+  } catch (err) {
+    try { await c.query("ROLLBACK"); } catch (e2) { /* ignore */ }
+    process.stdout.write("false|txn_failed");
+  } finally {
+    try { await c.end(); } catch (e3) { /* ignore */ }
+  }
+})().catch(function () {
+  process.stdout.write("false|txn_failed");
+});
+NODE
+
+  # shellcheck disable=SC2064
+  trap cleanup_bootstrap_node_tmp RETURN
+
+  node_b64="$(base64 <"$node_tmp" | tr -d '\n')"
+  cleanup_bootstrap_node_tmp
+
+  # Host: exact-byte secret files → framed stdin only. No secret values in argv/export.
+  # Also enforce password minimum length on host (values-free) before streaming.
+  if ! result="$(
+    python3 - "$CANARY_LOGIN_IDENTIFIER_FILE" "$CANARY_LOGIN_PASSWORD_FILE" "$CANARY_BOOTSTRAP_MIN_PASSWORD_LEN" <<'PY' | docker exec -i \
+      -e "CANARY_BOOTSTRAP_OWNER_ID=${CANARY_OWNER_USER_ID}" \
+      -e "CANARY_BOOTSTRAP_OWNER_EMAIL=${CANARY_OWNER_EMAIL}" \
+      -e "CANARY_BOOTSTRAP_MIN_PASSWORD_LEN=${CANARY_BOOTSTRAP_MIN_PASSWORD_LEN}" \
+      -e "CANARY_BOOTSTRAP_NODE_B64=${node_b64}" \
+      "$BACKEND_CONTAINER" \
+      node -e 'eval(Buffer.from(process.env.CANARY_BOOTSTRAP_NODE_B64||"","base64").toString("utf8"))'
+import pathlib
+import struct
+import sys
+
+ident_path, pass_path, min_len_s = sys.argv[1], sys.argv[2], sys.argv[3]
+try:
+    min_len = int(min_len_s)
+except Exception:
+    min_len = 12
+try:
+    identifier = pathlib.Path(ident_path).read_bytes().decode("utf-8").strip().encode("utf-8")
+    # Exact password bytes — no transform.
+    password = pathlib.Path(pass_path).read_bytes()
+except Exception:
+    # Empty frames → container reports secret_stdin / empty_credentials path.
+    sys.stdout.buffer.write(struct.pack(">I", 0) + struct.pack(">I", 0))
+    raise SystemExit(0)
+# Host-side strong minimum: decode for length check only (UTF-8), still stream exact bytes.
+try:
+    password_text = password.decode("utf-8")
+except Exception:
+    password_text = ""
+if len(password_text) < min_len:
+    # Still stream frames so container fails closed with password_too_short (same enum).
+    pass
+sys.stdout.buffer.write(struct.pack(">I", len(identifier)) + identifier)
+sys.stdout.buffer.write(struct.pack(">I", len(password)) + password)
+sys.stdout.buffer.flush()
+PY
+  )"; then
+    fail "action=bootstrap: container bootstrap transaction runner failed"
+  fi
+
+  # Collapse multi-line docker/node noise to the last values-free status line.
+  result="$(printf '%s\n' "$result" | tail -n1 | tr -d '\r')"
+  local ok="${result%%|*}"
+  note="${result#*|}"
+  BOOTSTRAP_OUTCOME="$note"
+  if [[ "$ok" != "true" ]]; then
+    log "bootstrap transaction refused: note=${note}"
+    return 1
+  fi
+  log "bootstrap transaction OK outcome=${note} (fixed owned row only; no container secret files; values never logged)"
+  return 0
 }
 
 # Admin API via JWT file. Prints values-free result lines; never logs token.
@@ -1180,7 +1576,88 @@ action_not_executable_on() {
     echo "transition_applied=false"
     echo "executable=false"
   } > "${OUTPUT_DIR}/summary.txt"
-  fail "action=${target} is NOT EXECUTABLE: no secret-backed real verifier for canary proof (admit-activate / sync-deprovision). Env flip alone is refused. Use status|preflight|off|alias only. transition_applied=false"
+  fail "action=${target} is NOT EXECUTABLE: no secret-backed real verifier for canary proof (admit-activate / sync-deprovision). Env flip alone is refused. Use status|preflight|off|bootstrap|alias only. transition_applied=false"
+}
+
+# Staging-only create/repair of the fixed dedicated lifecycle canary admin.
+# Never writes lifecycle env flags. Never mutates an arbitrary existing admin.
+# Idempotent for the (email, id) owned row; collision fail-closed otherwise.
+action_bootstrap() {
+  local note="bootstrap_canary_admin"
+  local login_ok="false"
+  BOOTSTRAP_OUTCOME="unset"
+
+  require_sha
+  require_canary_secret_files "bootstrap"
+  assert_canary_identifier_matches_owner "bootstrap"
+  [[ -n "$EXPECTED_CURRENT_MODE" ]] || fail "expected_current_mode is required for action=bootstrap"
+  [[ "$EXPECTED_CURRENT_MODE" == "off" ]] \
+    || fail "action=bootstrap requires expected_current_mode=off (got '${EXPECTED_CURRENT_MODE}'); refuse auto-selection"
+
+  capture_live_snapshot
+  assert_exact_sha
+  require_migrations_pending_zero_true "$SNAP_MIGRATIONS_ZERO" "action=bootstrap"
+
+  if [[ "$SNAP_HEALTH_OK" != "true" ]]; then
+    fail "action=bootstrap refused: backend_health_ok must be true before account mutation"
+  fi
+  if [[ "$SNAP_MODE" != "off" ]]; then
+    fail "action=bootstrap refused: live mode must be off (live='${SNAP_MODE}')"
+  fi
+  if [[ "$SNAP_MODE" != "$EXPECTED_CURRENT_MODE" ]]; then
+    fail "strict expected-current-mode transition failed: live='${SNAP_MODE}' expected_current_mode='${EXPECTED_CURRENT_MODE}'"
+  fi
+
+  # No lifecycle env write path exists below — collision/txn only touches fixed owned row.
+  if ! bootstrap_lifecycle_canary_admin; then
+    fail "action=bootstrap refused: fixed-owner create/repair failed (note=${BOOTSTRAP_OUTCOME:-unset}); no env write performed"
+  fi
+
+  # JWT iat is second-granularity while revoked_after is timestamptz. Both create
+  # and repair advance the watermark, so cross the next token second before proof.
+  sleep 1.1
+
+  if prove_canary_password_login "bootstrap"; then
+    login_ok="true"
+  else
+    fail "action=bootstrap refused: password login proof failed after create/repair (note=${BOOTSTRAP_OUTCOME:-unset})"
+  fi
+
+  # Re-prove stack posture after account mutation: mode still off, health true, SHA unchanged.
+  capture_live_snapshot
+  if [[ "$SNAP_MODE" != "off" ]]; then
+    fail "action=bootstrap refused: post-bootstrap live mode must remain off (live='${SNAP_MODE}'); no lifecycle env write expected"
+  fi
+  if [[ "$SNAP_HEALTH_OK" != "true" ]]; then
+    fail "action=bootstrap refused: post-bootstrap backend_health_ok must remain true"
+  fi
+  require_migrations_pending_zero_true "$SNAP_MIGRATIONS_ZERO" "action=bootstrap post-check"
+  if [[ "${SNAP_BUILD_SHA:-}" != "$DEPLOY_SHA" ]]; then
+    fail "action=bootstrap refused: post-bootstrap SHA '${SNAP_BUILD_SHA:-}' must match deploy_sha '${DEPLOY_SHA}'"
+  fi
+  assert_exact_sha
+
+  note="bootstrap_canary_admin_${BOOTSTRAP_OUTCOME}"
+  write_status_artifact \
+    "${SNAP_BUILD_SHA:-unknown}" \
+    "$SNAP_ALIAS" "$SNAP_PENDING" "$SNAP_DEPROV" "$SNAP_MODE" \
+    "$SNAP_ALIAS_READY" "$SNAP_CAN_ENABLE_ALIAS" \
+    "$SNAP_MIGRATIONS_ZERO" "$SNAP_HEALTH_OK" \
+    "" "" "false" "$note"
+  {
+    echo "action=bootstrap"
+    echo "mode=${SNAP_MODE}"
+    echo "build_sha=${SNAP_BUILD_SHA:-unknown}"
+    echo "transition_applied=false"
+    echo "bootstrap_outcome=${BOOTSTRAP_OUTCOME}"
+    echo "login_ok=${login_ok}"
+    echo "lifecycle_env_write=false"
+    echo "post_bootstrap_mode_off=true"
+    echo "post_bootstrap_health_ok=true"
+    echo "post_bootstrap_sha_match=true"
+    echo "note=${note}"
+  } > "${OUTPUT_DIR}/summary.txt"
+  log "action=bootstrap OK outcome=${BOOTSTRAP_OUTCOME} login_ok=${login_ok} (no lifecycle env write; mode/health/SHA reasserted)"
 }
 
 # Sole executable env write: clear the exact three lifecycle flags to false.
@@ -1245,16 +1722,20 @@ action_off() {
 # on-disk prior file). Persistent override is left explicitly OFF. Runtime OFF
 # cannot be proven if rollback recreate fails (OFF baseline restored on disk;
 # operator must inspect). Backfill rows may persist.
+# Admin JWT is minted from the canary password login into a chmod-600 per-run
+# remote file after successful pre-login — never secrets.ATTENDANCE_ADMIN_JWT.
 action_alias() {
   local pre_login_ok="false"
   local post_on_login_ok="false"
   local post_rollback_login_ok="false"
   local rolled_back_to_off="false"
   local alias_on_applied="false"
+  local admin_jwt_minted="false"
   local note="alias_cutover_canary"
 
   require_sha
-  require_canary_secret_files
+  require_canary_secret_files "alias"
+  assert_canary_identifier_matches_owner "alias"
   [[ -n "$EXPECTED_CURRENT_MODE" ]] || fail "expected_current_mode is required for action=alias"
   [[ "$EXPECTED_CURRENT_MODE" == "off" ]] \
     || fail "action=alias requires expected_current_mode=off (got '${EXPECTED_CURRENT_MODE}'); refuse auto-selection"
@@ -1274,14 +1755,19 @@ action_alias() {
     fail "strict expected-current-mode transition failed: live='${SNAP_MODE}' expected_current_mode='${EXPECTED_CURRENT_MODE}'"
   fi
 
-  # 1) Pre-write real password login (OR-column path while mode=off).
-  if prove_canary_password_login "pre_on"; then
+  # 1) Pre-write real password login (OR-column path while mode=off) AND mint
+  #    short-lived admin JWT into a chmod-600 per-run secret file for admin APIs.
+  #    Never read/overwrite secrets.ATTENDANCE_ADMIN_JWT.
+  if mint_canary_admin_jwt_from_password_login "pre_on"; then
     pre_login_ok="true"
+    admin_jwt_minted="true"
   else
-    fail "action=alias refused: pre-ON password login failed (no env write performed)"
+    fail "action=alias refused: pre-ON password login / JWT mint failed (no env write performed)"
   fi
+  [[ -n "${CANARY_ADMIN_JWT_FILE:-}" && -s "${CANARY_ADMIN_JWT_FILE}" ]] \
+    || fail "action=alias refused: admin JWT file missing after mint (no env write performed)"
 
-  # 2) T2a backfill + T2b readiness via admin JWT (no env write yet).
+  # 2) T2a backfill + T2b readiness via minted admin JWT file (no env write yet).
   if ! run_alias_backfill; then
     fail "action=alias refused: login-aliases backfill failed (no env write performed)"
   fi
@@ -1356,6 +1842,7 @@ action_alias() {
     echo "to_mode=off"
     echo "alias_on_applied=${alias_on_applied}"
     echo "pre_login_ok=${pre_login_ok}"
+    echo "admin_jwt_minted=${admin_jwt_minted}"
     echo "post_on_login_ok=${post_on_login_ok}"
     echo "post_rollback_login_ok=${post_rollback_login_ok}"
     echo "rolled_back_to_off=${rolled_back_to_off}"
@@ -1380,10 +1867,11 @@ main() {
     status) action_status ;;
     preflight) action_preflight ;;
     off) action_off ;;
+    bootstrap) action_bootstrap ;;
     alias) action_alias ;;
     pending) action_not_executable_on pending ;;
     deprovision) action_not_executable_on deprovision ;;
-    *) fail "invalid ACTION='${ACTION}' (status|preflight|off|alias|pending|deprovision)" ;;
+    *) fail "invalid ACTION='${ACTION}' (status|preflight|off|bootstrap|alias|pending|deprovision)" ;;
   esac
 }
 


### PR DESCRIPTION
## What

- add an explicit `bootstrap` action for the staging lifecycle canary workflow
- create or repair one fixed staging-only canary admin through a collision-safe transaction
- revoke prior stateless and persisted sessions on create or repair
- derive the alias-canary JWT from a real password login instead of the shared attendance JWT
- preserve and re-prove the all-flags-OFF baseline after bootstrap and alias rollback

## Safety boundary

- staging only; production is untouched
- bootstrap requires the exact confirmation phrase, deployed SHA, OFF mode, healthy backend, and zero pending migrations
- credentials travel through chmod-600 files and framed stdin; values are never emitted or stored in the container
- pending and deprovision remain non-executable; this PR does not enable any lifecycle flag

## Verification

- `node --test scripts/ops/dingtalk-lifecycle-staging-canary-contract.test.mjs` (83/83)
- `bash -n scripts/ops/dingtalk-lifecycle-staging-canary-remote.sh`
- real PostgreSQL goldens: create, repair and session revocation, ownership collision rejection, missing-revocation-table rollback
- independent Grok adversarial review: PASS, 0 P1/P2 after closing the orphan-token create path

Exact head before CI: `1667a63486c04c019e3cc89b6b3ff83186e08aaa`.
