### PR TITLE
fix(ops): stage lifecycle bootstrap secret frames

### DIFF
--- a/scripts/ops/dingtalk-lifecycle-staging-canary-contract.test.mjs
+++ b/scripts/ops/dingtalk-lifecycle-staging-canary-contract.test.mjs
@@ -29,6 +29,7 @@ import {
   existsSync,
   mkdtempSync,
   readFileSync,
+  readdirSync,
   writeFileSync,
   rmSync,
 } from 'node:fs'
@@ -1972,8 +1973,8 @@ ON
 
 /** Extract the embedded non-secret bootstrap Node program (NODE heredoc). */
 function bootstrapNodeSource(source = read(REMOTE_SH)) {
-  const start = source.indexOf("cat >\"$node_tmp\" <<'NODE'")
-  assert.notEqual(start, -1, 'bootstrap node_tmp NODE heredoc must exist')
+  const start = source.indexOf("cat >\"$BOOTSTRAP_NODE_TMP\" <<'NODE'")
+  assert.notEqual(start, -1, 'bootstrap BOOTSTRAP_NODE_TMP NODE heredoc must exist')
   const bodyStart = source.indexOf('\n', start) + 1
   const end = source.indexOf('\nNODE\n', bodyStart)
   assert.notEqual(end, -1, 'NODE terminator missing')
@@ -2132,7 +2133,7 @@ test('bootstrap create and repair upsert user_session_revocations like session-r
   assert.equal(createFailed, true)
 })
 
-test('bootstrap streams secrets over docker exec stdin; never docker cp container secret files', () => {
+test('bootstrap frames secrets before docker exec; never nests heredoc pipeline or copies container files', () => {
   const source = read(REMOTE_SH)
   const start = source.indexOf('bootstrap_lifecycle_canary_admin()')
   const end = source.indexOf('\n# Admin API via JWT file', start)
@@ -2141,10 +2142,26 @@ test('bootstrap streams secrets over docker exec stdin; never docker cp containe
   assert.match(body, /readFrame|readUInt32BE/)
   assert.match(body, /docker exec -i/)
   assert.match(body, /no container secret files/i)
+  assert.match(body, /bootstrap\.frames\.XXXXXX/)
+  assert.match(body, /chmod 600 "\$BOOTSTRAP_FRAMED_TMP"/)
+  assert.match(body, />"\$BOOTSTRAP_FRAMED_TMP" <<'PY'/)
+  assert.match(body, /<"\$BOOTSTRAP_FRAMED_TMP"\)"/)
+  assert.match(body, /cleanup_bootstrap_tmps/)
+  assert.match(body, /arm_bootstrap_tmp_cleanup_guard/)
+  assert.match(source, /trap cleanup_bootstrap_tmps EXIT/)
+  assert.match(source, /trap 'exit 143' TERM/)
+  assert.match(body, /cleanup_bootstrap_tmps\s+disarm_bootstrap_tmp_cleanup_guard/)
+  assert.ok(
+    body.indexOf('>"$BOOTSTRAP_FRAMED_TMP" <<\'PY\'') < body.indexOf('docker exec -i'),
+    'secret framing must complete before docker exec command substitution',
+  )
+  assert.doesNotMatch(body, /<<'PY'\s*\|\s*docker exec/)
   assert.doesNotMatch(body, /docker cp/)
   // Host may mktemp a non-secret node source; must never docker-cp login secret files.
   assert.doesNotMatch(body, /docker cp[^\n]*login\.(identifier|password)/)
   assert.doesNotMatch(body, /BACKEND_CONTAINER:[^\n]*login\.(identifier|password)/)
+  assert.match(body, /secret framing input read failed/)
+  assert.doesNotMatch(body, /struct\.pack\(">I", 0\) \+ struct\.pack\(">I", 0\)/)
   assert.match(body, /CANARY_BOOTSTRAP_MIN_PASSWORD_LEN=12|password_too_short/)
   assert.match(body, /password\.length < minLen|password_too_short/)
   // JWT revocation watermark is authoritative; user_sessions is an additional belt.
@@ -2154,6 +2171,83 @@ test('bootstrap streams secrets over docker exec stdin; never docker cp containe
   assert.match(body, /user_sessions/)
   assert.match(body, /revoked_at/)
   assert.match(body, /lifecycle_canary_bootstrap_password_repair/)
+})
+
+test('FUNCTIONAL: bootstrap producer completes before docker and preserves exact framed password bytes', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'lifecycle-bootstrap-frames-'))
+  const ident = join(dir, 'login.identifier')
+  const password = join(dir, 'login.password')
+  writeFileSync(ident, 'lifecycle-canary@staging.invalid\n', { mode: 0o600 })
+  writeFileSync(password, Buffer.from('Exact\r\nPassword-12345', 'utf8'), { mode: 0o600 })
+  const harness = `
+set -euo pipefail
+export LIFECYCLE_CANARY_SOURCE_ONLY=true
+source "$1"
+CANARY_LOGIN_IDENTIFIER_FILE="$2"
+CANARY_LOGIN_PASSWORD_FILE="$3"
+docker() {
+  [[ "$1" == "exec" && "$2" == "-i" ]] || return 91
+  python3 -c 'import pathlib,sys; data=sys.stdin.buffer.read(); n1=int.from_bytes(data[:4],"big"); v1=data[4:4+n1]; p=4+n1; n2=int.from_bytes(data[p:p+4],"big"); v2=data[p+4:p+4+n2]; assert p+4+n2 == len(data); assert v1 == pathlib.Path(sys.argv[1]).read_bytes().strip(); assert v2 == pathlib.Path(sys.argv[2]).read_bytes(); print("true|created", end="")' "$CANARY_LOGIN_IDENTIFIER_FILE" "$CANARY_LOGIN_PASSWORD_FILE"
+}
+bootstrap_lifecycle_canary_admin
+`
+  try {
+    const result = spawnSync('bash', ['-c', harness, 'bash', REMOTE_SH, ident, password], {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        ACTION: 'bootstrap',
+        OUTPUT_DIR: dir,
+        RUN_STAMP: 'contract-bootstrap-frames',
+      },
+    })
+    assert.equal(result.status, 0, result.stderr || result.stdout)
+    assert.match(result.stdout, /bootstrap transaction OK outcome=created/)
+    assert.deepEqual(readdirSync(dir).sort(), ['login.identifier', 'login.password'])
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('FUNCTIONAL: bootstrap removes framed secrets on docker failure and SIGTERM', () => {
+  for (const [mode, dockerBody, expectedStatus] of [
+    ['failure', 'return 92', 1],
+    ['sigterm', 'kill -TERM $$; sleep 1', 143],
+  ]) {
+    const dir = mkdtempSync(join(tmpdir(), `lifecycle-bootstrap-${mode}-`))
+    const ident = join(dir, 'login.identifier')
+    const password = join(dir, 'login.password')
+    writeFileSync(ident, 'lifecycle-canary@staging.invalid', { mode: 0o600 })
+    writeFileSync(password, Buffer.from('ExactFailurePassword-12345', 'utf8'), { mode: 0o600 })
+    const harness = `
+set -euo pipefail
+export LIFECYCLE_CANARY_SOURCE_ONLY=true
+source "$1"
+CANARY_LOGIN_IDENTIFIER_FILE="$2"
+CANARY_LOGIN_PASSWORD_FILE="$3"
+docker() { ${dockerBody}; }
+bootstrap_lifecycle_canary_admin
+`
+    try {
+      const result = spawnSync('bash', ['-c', harness, 'bash', REMOTE_SH, ident, password], {
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          ACTION: 'bootstrap',
+          OUTPUT_DIR: dir,
+          RUN_STAMP: `contract-bootstrap-${mode}`,
+        },
+      })
+      assert.equal(result.status, expectedStatus, `${mode}: ${result.stderr}${result.stdout}`)
+      assert.deepEqual(
+        readdirSync(dir).sort(),
+        ['login.identifier', 'login.password'],
+        `${mode}: framed temp must be removed`,
+      )
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  }
 })
 
 test('bootstrap requires exact SHA, OFF, health, migrations zero; never writes lifecycle env', () => {

--- a/scripts/ops/dingtalk-lifecycle-staging-canary-remote.sh
+++ b/scripts/ops/dingtalk-lifecycle-staging-canary-remote.sh
@@ -560,6 +560,31 @@ mint_canary_admin_jwt_from_password_login() {
 
 # Strong minimum password length for the fixed canary admin (matches on-prem bootstrap floor).
 CANARY_BOOTSTRAP_MIN_PASSWORD_LEN=12
+BOOTSTRAP_NODE_TMP=""
+BOOTSTRAP_FRAMED_TMP=""
+
+cleanup_bootstrap_tmps() {
+  if [[ -n "${BOOTSTRAP_NODE_TMP:-}" && -f "${BOOTSTRAP_NODE_TMP}" ]]; then
+    rm -f "${BOOTSTRAP_NODE_TMP}"
+  fi
+  if [[ -n "${BOOTSTRAP_FRAMED_TMP:-}" && -f "${BOOTSTRAP_FRAMED_TMP}" ]]; then
+    rm -f "${BOOTSTRAP_FRAMED_TMP}"
+  fi
+  BOOTSTRAP_NODE_TMP=""
+  BOOTSTRAP_FRAMED_TMP=""
+}
+
+arm_bootstrap_tmp_cleanup_guard() {
+  trap cleanup_bootstrap_tmps EXIT
+  trap 'exit 129' HUP
+  trap 'exit 130' INT
+  trap 'exit 143' TERM
+  trap 'exit 141' PIPE
+}
+
+disarm_bootstrap_tmp_cleanup_guard() {
+  trap - EXIT HUP INT TERM PIPE
+}
 
 # Transactional create/repair of the FIXED owned lifecycle canary admin only.
 # Collision fail-closed: any users row matching email OR id that does not match
@@ -572,22 +597,18 @@ CANARY_BOOTSTRAP_MIN_PASSWORD_LEN=12
 # Node program is non-secret host temp source base64'd into env (not secret files).
 # stdout reason enums only via result lines.
 bootstrap_lifecycle_canary_admin() {
-  local result note node_tmp node_b64
+  local result note node_b64
   BOOTSTRAP_OUTCOME="unset"
-  node_tmp=""
+  BOOTSTRAP_NODE_TMP=""
+  BOOTSTRAP_FRAMED_TMP=""
 
-  cleanup_bootstrap_node_tmp() {
-    if [[ -n "${node_tmp:-}" && -f "${node_tmp}" ]]; then
-      rm -f "${node_tmp}"
-    fi
-    node_tmp=""
-  }
+  arm_bootstrap_tmp_cleanup_guard
 
   # Non-secret node program on host only (never contains credentials).
   # permissions column omitted (054 TEXT[] default / later jsonb default both work).
   # Repair revokes sessions when schema supports it (user_session_revocations and/or user_sessions).
-  node_tmp="$(mktemp "${TMPDIR:-/tmp}/lifecycle-canary-bootstrap-node.XXXXXX")"
-  cat >"$node_tmp" <<'NODE'
+  BOOTSTRAP_NODE_TMP="$(mktemp "${TMPDIR:-/tmp}/lifecycle-canary-bootstrap-node.XXXXXX")"
+  cat >"$BOOTSTRAP_NODE_TMP" <<'NODE'
 const { Client } = require("pg");
 
 function fail(code) {
@@ -798,21 +819,17 @@ function readFrame() {
 NODE
 
   # shellcheck disable=SC2064
-  trap cleanup_bootstrap_node_tmp RETURN
+  node_b64="$(base64 <"$BOOTSTRAP_NODE_TMP" | tr -d '\n')"
+  cleanup_bootstrap_tmps
 
-  node_b64="$(base64 <"$node_tmp" | tr -d '\n')"
-  cleanup_bootstrap_node_tmp
-
-  # Host: exact-byte secret files → framed stdin only. No secret values in argv/export.
-  # Also enforce password minimum length on host (values-free) before streaming.
-  if ! result="$(
-    python3 - "$CANARY_LOGIN_IDENTIFIER_FILE" "$CANARY_LOGIN_PASSWORD_FILE" "$CANARY_BOOTSTRAP_MIN_PASSWORD_LEN" <<'PY' | docker exec -i \
-      -e "CANARY_BOOTSTRAP_OWNER_ID=${CANARY_OWNER_USER_ID}" \
-      -e "CANARY_BOOTSTRAP_OWNER_EMAIL=${CANARY_OWNER_EMAIL}" \
-      -e "CANARY_BOOTSTRAP_MIN_PASSWORD_LEN=${CANARY_BOOTSTRAP_MIN_PASSWORD_LEN}" \
-      -e "CANARY_BOOTSTRAP_NODE_B64=${node_b64}" \
-      "$BACKEND_CONTAINER" \
-      node -e 'eval(Buffer.from(process.env.CANARY_BOOTSTRAP_NODE_B64||"","base64").toString("utf8"))'
+  # Build framed stdin before entering command substitution. Some staging-host bash
+  # versions misparse a heredoc feeding a pipeline nested inside $(...), even though
+  # bash -n accepts it. The framed file stays in the per-run chmod-700 secret dir,
+  # is chmod-600, and is removed by this function's exit/signal guard plus the
+  # workflow's independent remote-directory EXIT cleanup.
+  BOOTSTRAP_FRAMED_TMP="$(mktemp "$(dirname "$CANARY_LOGIN_PASSWORD_FILE")/bootstrap.frames.XXXXXX")"
+  chmod 600 "$BOOTSTRAP_FRAMED_TMP"
+  if ! python3 - "$CANARY_LOGIN_IDENTIFIER_FILE" "$CANARY_LOGIN_PASSWORD_FILE" "$CANARY_BOOTSTRAP_MIN_PASSWORD_LEN" >"$BOOTSTRAP_FRAMED_TMP" <<'PY'
 import pathlib
 import struct
 import sys
@@ -827,9 +844,8 @@ try:
     # Exact password bytes — no transform.
     password = pathlib.Path(pass_path).read_bytes()
 except Exception:
-    # Empty frames → container reports secret_stdin / empty_credentials path.
-    sys.stdout.buffer.write(struct.pack(">I", 0) + struct.pack(">I", 0))
-    raise SystemExit(0)
+    sys.stderr.write("secret framing input read failed\n")
+    raise SystemExit(2)
 # Host-side strong minimum: decode for length check only (UTF-8), still stream exact bytes.
 try:
     password_text = password.decode("utf-8")
@@ -842,9 +858,22 @@ sys.stdout.buffer.write(struct.pack(">I", len(identifier)) + identifier)
 sys.stdout.buffer.write(struct.pack(">I", len(password)) + password)
 sys.stdout.buffer.flush()
 PY
-  )"; then
+  then
+    fail "action=bootstrap: secret framing failed"
+  fi
+
+  if ! result="$(docker exec -i \
+    -e "CANARY_BOOTSTRAP_OWNER_ID=${CANARY_OWNER_USER_ID}" \
+    -e "CANARY_BOOTSTRAP_OWNER_EMAIL=${CANARY_OWNER_EMAIL}" \
+    -e "CANARY_BOOTSTRAP_MIN_PASSWORD_LEN=${CANARY_BOOTSTRAP_MIN_PASSWORD_LEN}" \
+    -e "CANARY_BOOTSTRAP_NODE_B64=${node_b64}" \
+    "$BACKEND_CONTAINER" \
+    node -e 'eval(Buffer.from(process.env.CANARY_BOOTSTRAP_NODE_B64||"","base64").toString("utf8"))' \
+    <"$BOOTSTRAP_FRAMED_TMP")"; then
     fail "action=bootstrap: container bootstrap transaction runner failed"
   fi
+  cleanup_bootstrap_tmps
+  disarm_bootstrap_tmp_cleanup_guard
 
   # Collapse multi-line docker/node noise to the last values-free status line.
   result="$(printf '%s\n' "$result" | tail -n1 | tr -d '\r')"


### PR DESCRIPTION
## Summary

- replace the staging bootstrap heredoc pipeline nested inside command substitution with chmod-600 framed temp input
- keep cleanup paths in script-level guard state so EXIT and signal traps remove both secret temp files
- add load-bearing success, Docker-failure, and SIGTERM cleanup contract tests

## Incident boundary

Staging run 31476237851 failed before any DB mutation because the remote shell misparsed the nested heredoc pipeline. Post-failure status run 31476302621 succeeded and re-proved all lifecycle flags OFF. This PR does not enable any flag and does not touch production.

## Verification

- `bash -n scripts/ops/dingtalk-lifecycle-staging-canary-remote.sh`
- `node --test scripts/ops/dingtalk-lifecycle-staging-canary-contract.test.mjs` (85/85)
- independent Grok review at `18fcb91c9123778a36f42384b4ea5f8546eab0e7`: ACCEPT, 0 P1 / 0 P2

After exact-head CI and merge, the bootstrap canary will be retried before the alias canary. Secrets remain file-framed and are never printed.