### PR TITLE
fix(ops): rollback-protect no-deps on-prem package apply

### DIFF
--- a/plugins/plugin-integration-core/__tests__/sealed-export-package-provenance.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/sealed-export-package-provenance.test.cjs
@@ -333,6 +333,30 @@ async function evidenceRunnerMutationFails() {
   }
 }
 
+async function packageBuildNoDepsControlMutationFails() {
+  const root = await clonePinnedTree()
+  try {
+    const target = path.join(
+      root,
+      'scripts/ops/multitable-onprem-package-build.sh',
+    )
+    const original = fs.readFileSync(target, 'utf8')
+    const mutated = original.replace(
+      'install-deps:0^|1',
+      'install-deps:1^|1',
+    )
+    assert.equal(mutated.length, original.length)
+    assert.notEqual(mutated, original)
+    fs.writeFileSync(target, mutated)
+    expectReason(
+      () => verifySealedExportPackageProvenance({ repoRoot: root }),
+      'SEALED_EXPORT_INTERNAL_ERROR',
+    )
+  } finally {
+    await fsPromises.rm(root, { force: true, recursive: true })
+  }
+}
+
 async function isolatedDependencyMutationFails() {
   const root = await clonePinnedTree()
   try {
@@ -487,6 +511,7 @@ async function main() {
   await profileCertificationDependencyMutationFails()
   await canonicalJsonDependencyMutationFails()
   await evidenceRunnerMutationFails()
+  await packageBuildNoDepsControlMutationFails()
   await isolatedDependencyMutationFails()
   await isolatedLockfileMutationFails()
   await packageShellVerifierRejectsPinnedMutation()

--- a/plugins/plugin-integration-core/lib/sealed-export/vectors/s6a-package-provenance-pins.json
+++ b/plugins/plugin-integration-core/lib/sealed-export/vectors/s6a-package-provenance-pins.json
@@ -85,7 +85,7 @@
     "s6aRuntimeAuthorityRealDbTest": "609da9054db15ced3567417b31ae743f2c3be1656f5e3d0874a77c3a4cbd0375",
     "s6aAcceptancePs51Test": "835c7c6ce943d82e0378a40a27c7fd1e8b79b526faa8ca4c8066e4231a4bfb0f",
     "s6aProductRuntimeTest": "de978adafa8b89772cefa921c2051f434bf346bf5c2978bef3424ee70f51ba3f",
-    "multitableOnpremPackageBuild": "463c7d73c6c7f2d1b6cdf0820d7a06974a9c463dd5e98bbbaf1c996e1dc4ed99",
+    "multitableOnpremPackageBuild": "ae477a24375a7269e5710a3481905c9b74255c03fd802841a16849aca48ee33a",
     "pluginTestsWorkflow": "6e6653d6cdb102330da32cacd10f12fb842111a3e23675857474068421ea5faa"
   }
 }

--- a/scripts/ops/multitable-onprem-apply-package.ps1
+++ b/scripts/ops/multitable-onprem-apply-package.ps1
@@ -7,9 +7,11 @@ param(
   [string]$BaseUrl = 'http://127.0.0.1',
   [string]$CheckNginx = '1',
   [string]$RunHealthcheck = '1',
+  [ValidateSet('0', '1')]
   [string]$InstallDeps = '1',
   [string]$BuildWeb = '0',
   [string]$BuildBackend = '0',
+  [ValidateSet('0', '1')]
   [string]$RunMigrations = '1',
   [string]$RestartService = '1',
   [string]$StagingRoot = '',
@@ -21,6 +23,10 @@ param(
 
 $ErrorActionPreference = 'Stop'
 $SupportedPackagePnpmVersion = '9.15.9'
+
+if ($InstallDeps -eq '0' -and $RunMigrations -ne '0') {
+  throw 'PACKAGE_NO_DEPS_REQUIRES_NO_MIGRATIONS: InstallDeps=0 requires RunMigrations=0'
+}
 
 function Resolve-NormalizedPath {
   param(
@@ -1017,6 +1023,9 @@ $stagingBase = Resolve-StagingBase -Candidate $StagingRoot
 Write-Info "Staging base: $stagingBase"
 $extractRoot = New-ShortTempDirectory -Prefix 'mspa' -BaseRoot $stagingBase
 $rollbackRoot = $null
+$noDepsOverlayTransaction = $null
+$noDepsOverlayStarted = $false
+$preserveRollbackRoot = $false
 
 try {
   Write-Info "Package archive: $resolvedArchive"
@@ -1150,54 +1159,131 @@ try {
       Write-Info "Dependency activation succeeded but old node_modules cleanup needs manual follow-up: $($_.Exception.Message)"
     }
   } else {
-    Write-Info 'InstallDeps=0: dependency preflight and rollback transaction explicitly bypassed by operator'
-    foreach ($item in Get-ChildItem -LiteralPath $packageRoot -Force) {
-      Copy-Item -LiteralPath $item.FullName -Destination $resolvedRoot -Recurse -Force
+    Write-Info 'InstallDeps=0: preserving existing node_modules and applying a rollback-protected package overlay'
+    $rollbackRoot = New-ShortTempDirectory -Prefix 'mspb' -BaseRoot $stagingBase
+    $noDepsOverlayTransaction = New-PackageOverlayTransaction `
+      -PackageRoot $packageRoot `
+      -LiveRoot $resolvedRoot `
+      -BackupRoot $rollbackRoot
+    $noDepsOverlayStarted = $true
+    try {
+      Copy-PackageOverlay -Transaction $noDepsOverlayTransaction
+    }
+    catch {
+      $copyError = $_
+      try {
+        Restore-PackageOverlay -Transaction $noDepsOverlayTransaction
+        $noDepsOverlayStarted = $false
+      }
+      catch {
+        $preserveRollbackRoot = $true
+        throw "PACKAGE_NO_DEPS_ROLLBACK_FAILED after '$($copyError.Exception.Message)': package overlay rollback failed: $($_.Exception.Message)"
+      }
+      throw $copyError
     }
   }
 
-  Set-Location $resolvedRoot
+  try {
+    Set-Location $resolvedRoot
 
-  if ($RunMigrations -ne '0') {
-    $migratePath = Join-Path $resolvedRoot 'packages\core-backend\dist\src\db\migrate.js'
-    if (-not (Test-Path -LiteralPath $migratePath)) {
-      throw "Missing backend migration entrypoint: $migratePath"
+    if ($RunMigrations -ne '0') {
+      $migratePath = Join-Path $resolvedRoot 'packages\core-backend\dist\src\db\migrate.js'
+      if (-not (Test-Path -LiteralPath $migratePath)) {
+        throw "Missing backend migration entrypoint: $migratePath"
+      }
+      Invoke-CheckedCommand "Run database migrations ($migratePath)" {
+        node $migratePath
+      }
     }
-    Invoke-CheckedCommand "Run database migrations ($migratePath)" {
-      node $migratePath
+
+    if ($RestartService -ne '0') {
+      $startScript = Join-Path $resolvedRoot 'scripts\ops\attendance-onprem-start-pm2.ps1'
+      if (-not (Test-Path -LiteralPath $startScript)) {
+        throw "Missing PM2 startup helper: $startScript"
+      }
+
+      Write-Info 'Start or restart PM2 service'
+      & $startScript -RootDir $resolvedRoot
+      if ($LASTEXITCODE -ne 0) {
+        throw 'pm2 startup failed'
+      }
+    }
+
+    if ($RunHealthcheck -ne '0') {
+      $healthUrl = ($BaseUrl.TrimEnd('/')) + '/health'
+      $pluginsUrl = ($ApiBase.TrimEnd('/')) + '/plugins'
+      $healthcheckAttemptsValue = Convert-PositiveInt -Value $HealthcheckAttempts -Label 'HealthcheckAttempts'
+      $healthcheckDelayValue = Convert-PositiveInt -Value $HealthcheckDelaySec -Label 'HealthcheckDelaySec'
+      if (-not (Invoke-Healthcheck -Urls @($healthUrl, $pluginsUrl) -Attempts $healthcheckAttemptsValue -DelaySec $healthcheckDelayValue)) {
+        throw "Healthcheck failed for $healthUrl and $pluginsUrl"
+      }
     }
   }
+  catch {
+    $postApplyError = $_
+    if ($InstallDeps -eq '0' -and $noDepsOverlayStarted) {
+      $rollbackErrors = @()
+      Write-Info 'No-dependency apply failed after overlay; restoring pre-change package files'
+      try {
+        Restore-PackageOverlay -Transaction $noDepsOverlayTransaction
+        $noDepsOverlayStarted = $false
+      }
+      catch {
+        $preserveRollbackRoot = $true
+        $rollbackErrors += "package overlay rollback failed: $($_.Exception.Message)"
+      }
 
-  if ($RestartService -ne '0') {
-    $startScript = Join-Path $resolvedRoot 'scripts\ops\attendance-onprem-start-pm2.ps1'
-    if (-not (Test-Path -LiteralPath $startScript)) {
-      throw "Missing PM2 startup helper: $startScript"
-    }
+      if ($rollbackErrors.Count -eq 0 -and $RestartService -ne '0') {
+        try {
+          $restoredStartScript = Join-Path $resolvedRoot 'scripts\ops\attendance-onprem-start-pm2.ps1'
+          if (-not (Test-Path -LiteralPath $restoredStartScript)) {
+            throw "Missing restored PM2 startup helper: $restoredStartScript"
+          }
+          Write-Info 'Restart restored PM2 service after package rollback'
+          & $restoredStartScript -RootDir $resolvedRoot
+          if ($LASTEXITCODE -ne 0) {
+            throw 'restored pm2 startup failed'
+          }
+        }
+        catch {
+          $rollbackErrors += "restored service restart failed: $($_.Exception.Message)"
+        }
+      }
 
-    Write-Info 'Start or restart PM2 service'
-    & $startScript -RootDir $resolvedRoot
-    if ($LASTEXITCODE -ne 0) {
-      throw 'pm2 startup failed'
+      if ($rollbackErrors.Count -eq 0 -and $RunHealthcheck -ne '0') {
+        try {
+          $restoredHealthUrl = ($BaseUrl.TrimEnd('/')) + '/health'
+          $restoredPluginsUrl = ($ApiBase.TrimEnd('/')) + '/plugins'
+          $restoredHealthcheckAttempts = Convert-PositiveInt -Value $HealthcheckAttempts -Label 'HealthcheckAttempts'
+          $restoredHealthcheckDelay = Convert-PositiveInt -Value $HealthcheckDelaySec -Label 'HealthcheckDelaySec'
+          if (-not (Invoke-Healthcheck -Urls @($restoredHealthUrl, $restoredPluginsUrl) -Attempts $restoredHealthcheckAttempts -DelaySec $restoredHealthcheckDelay)) {
+            throw 'restored runtime healthcheck failed'
+          }
+        }
+        catch {
+          $rollbackErrors += "restored runtime healthcheck failed: $($_.Exception.Message)"
+        }
+      }
+
+      if ($rollbackErrors.Count -gt 0) {
+        throw "PACKAGE_NO_DEPS_ROLLBACK_FAILED after '$($postApplyError.Exception.Message)': $($rollbackErrors -join '; ')"
+      }
     }
+    throw $postApplyError
   }
 
-  if ($RunHealthcheck -ne '0') {
-    $healthUrl = ($BaseUrl.TrimEnd('/')) + '/health'
-    $pluginsUrl = ($ApiBase.TrimEnd('/')) + '/plugins'
-    $healthcheckAttemptsValue = Convert-PositiveInt -Value $HealthcheckAttempts -Label 'HealthcheckAttempts'
-    $healthcheckDelayValue = Convert-PositiveInt -Value $HealthcheckDelaySec -Label 'HealthcheckDelaySec'
-    if (-not (Invoke-Healthcheck -Urls @($healthUrl, $pluginsUrl) -Attempts $healthcheckAttemptsValue -DelaySec $healthcheckDelayValue)) {
-      throw "Healthcheck failed for $healthUrl and $pluginsUrl"
-    }
-  }
-
+  $noDepsOverlayStarted = $false
   Write-Info "Package deploy complete"
   Write-Info "Archive applied: $resolvedArchive"
   Write-Info "Root: $resolvedRoot"
 }
 finally {
   if ($null -ne $rollbackRoot -and (Test-Path -LiteralPath $rollbackRoot)) {
-    Remove-Item -LiteralPath $rollbackRoot -Recurse -Force -ErrorAction SilentlyContinue
+    if ($preserveRollbackRoot) {
+      Write-Info "Rollback backup preserved for manual recovery: $rollbackRoot"
+    } else {
+      Remove-Item -LiteralPath $rollbackRoot -Recurse -Force -ErrorAction SilentlyContinue
+    }
   }
   if (Test-Path -LiteralPath $extractRoot) {
     Remove-Item -LiteralPath $extractRoot -Recurse -Force -ErrorAction SilentlyContinue

--- a/scripts/ops/multitable-onprem-apply-package.ps1
+++ b/scripts/ops/multitable-onprem-apply-package.ps1
@@ -978,12 +978,19 @@ function Invoke-Healthcheck {
   }
 
   for ($attempt = 1; $attempt -le $Attempts; $attempt++) {
+    $allUrlsHealthy = $true
     foreach ($url in $Urls) {
       Write-Info "Healthcheck attempt ${attempt}/${Attempts}: $url"
       if (Invoke-HealthcheckOnce -Url $url) {
         Write-Info "Healthcheck OK ($url)"
-        return $true
+      } else {
+        Write-Info "Healthcheck failed ($url)"
+        $allUrlsHealthy = $false
       }
+    }
+
+    if ($allUrlsHealthy) {
+      return $true
     }
 
     if ($attempt -lt $Attempts -and $DelaySec -gt 0) {
@@ -1171,13 +1178,36 @@ try {
     }
     catch {
       $copyError = $_
+      $rollbackErrors = @()
       try {
         Restore-PackageOverlay -Transaction $noDepsOverlayTransaction
         $noDepsOverlayStarted = $false
       }
       catch {
         $preserveRollbackRoot = $true
-        throw "PACKAGE_NO_DEPS_ROLLBACK_FAILED after '$($copyError.Exception.Message)': package overlay rollback failed: $($_.Exception.Message)"
+        $rollbackErrors += "package overlay rollback failed: $($_.Exception.Message)"
+      }
+
+      if ($rollbackErrors.Count -eq 0 -and $RestartService -ne '0') {
+        try {
+          $restoredStartScript = Join-Path $resolvedRoot 'scripts\ops\attendance-onprem-start-pm2.ps1'
+          if (-not (Test-Path -LiteralPath $restoredStartScript)) {
+            throw "Missing restored PM2 startup helper: $restoredStartScript"
+          }
+          Write-Info 'Restart restored PM2 service after package copy rollback'
+          & $restoredStartScript -RootDir $resolvedRoot
+          if ($LASTEXITCODE -ne 0) {
+            throw 'restored pm2 startup failed'
+          }
+        }
+        catch {
+          $preserveRollbackRoot = $true
+          $rollbackErrors += "restored service restart failed: $($_.Exception.Message)"
+        }
+      }
+
+      if ($rollbackErrors.Count -gt 0) {
+        throw "PACKAGE_NO_DEPS_ROLLBACK_FAILED after '$($copyError.Exception.Message)': $($rollbackErrors -join '; ')"
       }
       throw $copyError
     }

--- a/scripts/ops/multitable-onprem-deploy-launcher.ps1
+++ b/scripts/ops/multitable-onprem-deploy-launcher.ps1
@@ -2,10 +2,18 @@ param(
   [Parameter(Mandatory = $true)]
   [string]$PackageArchive,
   [string]$RootDir = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path,
-  [string]$StagingRoot = ''
+  [string]$StagingRoot = '',
+  [ValidateSet('0', '1')]
+  [string]$InstallDeps = '1',
+  [ValidateSet('0', '1')]
+  [string]$RunMigrations = '1'
 )
 
 $ErrorActionPreference = 'Stop'
+
+if ($InstallDeps -eq '0' -and $RunMigrations -ne '0') {
+  throw 'PACKAGE_NO_DEPS_REQUIRES_NO_MIGRATIONS: InstallDeps=0 requires RunMigrations=0'
+}
 
 # multitable-onprem-deploy-launcher.ps1
 #
@@ -179,7 +187,12 @@ try {
   # complete" + health 200) reliably yields launcher exit 0 and a Last
   # Result of 0 in the outer scheduled task (#1526 follow-up).
   try {
-    & $stagedApply -RootDir $resolvedRoot -PackageArchive $resolvedArchive -StagingRoot $stagingBase
+    & $stagedApply `
+      -RootDir $resolvedRoot `
+      -PackageArchive $resolvedArchive `
+      -StagingRoot $stagingBase `
+      -InstallDeps $InstallDeps `
+      -RunMigrations $RunMigrations
     $launcherExit = 0
   }
   catch {

--- a/scripts/ops/multitable-onprem-package-build.sh
+++ b/scripts/ops/multitable-onprem-package-build.sh
@@ -355,16 +355,20 @@ function write_windows_first_hop_bootstrap_assets() {
 @echo off
 setlocal
 if "%~1"=="" (
-  echo Usage: ${PACKAGE_NAME}-deploy-bootstrap.bat ^<package.zip^|package.tgz^> [installed-root]
+  echo Usage: ${PACKAGE_NAME}-deploy-bootstrap.bat ^<package.zip^|package.tgz^> [installed-root] [install-deps:0^|1] [run-migrations:0^|1]
   exit /b 64
 )
 set "INSTALL_ROOT=%~2"
 if "%INSTALL_ROOT%"=="" set "INSTALL_ROOT=%cd%"
+set "INSTALL_DEPS=%~3"
+if "%INSTALL_DEPS%"=="" set "INSTALL_DEPS=1"
+set "RUN_MIGRATIONS=%~4"
+if "%RUN_MIGRATIONS%"=="" set "RUN_MIGRATIONS=1"
 REM First-hop bootstrap sidecar. Use this from a release download when the
 REM already-installed deploy.bat/launcher is too old to stage the new package
 REM under C:\ms-tmp. It intentionally bypasses the installed launcher and runs
 REM the fresh launcher sidecar next to this .bat file.
-powershell -NoProfile -ExecutionPolicy Bypass -File "%~dp0${PACKAGE_NAME}-deploy-bootstrap.ps1" -RootDir "%INSTALL_ROOT%" -PackageArchive "%~1"
+powershell -NoProfile -ExecutionPolicy Bypass -File "%~dp0${PACKAGE_NAME}-deploy-bootstrap.ps1" -RootDir "%INSTALL_ROOT%" -PackageArchive "%~1" -InstallDeps "%INSTALL_DEPS%" -RunMigrations "%RUN_MIGRATIONS%"
 set "APPLY_EXIT=%ERRORLEVEL%"
 echo [multitable-onprem-deploy-bootstrap] apply exit=%APPLY_EXIT%
 exit /b %APPLY_EXIT%
@@ -634,6 +638,11 @@ First-hop bootstrap sidecar:
   ${PACKAGE_NAME}-deploy-bootstrap.ps1 (or the .bat wrapper) next to the package
   archive and run it from the existing install root:
     powershell -NoProfile -ExecutionPolicy Bypass -File .\${PACKAGE_NAME}-deploy-bootstrap.ps1 -RootDir . -PackageArchive .\${PACKAGE_NAME}.zip
+  A no-dependency repair must explicitly disable migrations as the same atomic
+  mode; either of these forms preserves existing node_modules and uses the
+  rollback-protected package overlay:
+    powershell -NoProfile -ExecutionPolicy Bypass -File .\${PACKAGE_NAME}-deploy-bootstrap.ps1 -RootDir . -PackageArchive .\${PACKAGE_NAME}.zip -InstallDeps 0 -RunMigrations 0
+    .\${PACKAGE_NAME}-deploy-bootstrap.bat .\${PACKAGE_NAME}.zip . 0 0
   The sidecar uses the current launcher logic immediately, defaults staging to
   C:\ms-tmp on Windows, and invokes the staged package's fresh apply helper.
 

--- a/scripts/ops/multitable-onprem-package-no-node-modules.test.mjs
+++ b/scripts/ops/multitable-onprem-package-no-node-modules.test.mjs
@@ -328,6 +328,21 @@ test('on-prem package build emits first-hop Windows bootstrap sidecar assets', (
   )
   assert.match(
     buildScript,
+    /set "INSTALL_DEPS=%~3"[\s\S]*if "%INSTALL_DEPS%"=="" set "INSTALL_DEPS=1"/,
+    'the bootstrap wrapper should accept an explicit dependency-install control while preserving its default',
+  )
+  assert.match(
+    buildScript,
+    /set "RUN_MIGRATIONS=%~4"[\s\S]*if "%RUN_MIGRATIONS%"=="" set "RUN_MIGRATIONS=1"/,
+    'the bootstrap wrapper should accept an explicit migration control while preserving its default',
+  )
+  assert.match(
+    buildScript,
+    /-InstallDeps "%INSTALL_DEPS%" -RunMigrations "%RUN_MIGRATIONS%"/,
+    'the bootstrap wrapper should forward both controls to the fresh launcher sidecar',
+  )
+  assert.match(
+    buildScript,
     /write_sha_file "\$BOOTSTRAP_PS1_TMP_PATH"/,
     'the PowerShell sidecar should get a sha256 file',
   )

--- a/scripts/ops/onprem-windows-system-hardening.test.mjs
+++ b/scripts/ops/onprem-windows-system-hardening.test.mjs
@@ -12,6 +12,139 @@ function readScript(relativePath) {
   return fs.readFileSync(path.join(repoRoot, relativePath), 'utf8')
 }
 
+function writeFixtureFile(filePath, contents, mode) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true })
+  fs.writeFileSync(filePath, contents)
+  if (mode) fs.chmodSync(filePath, mode)
+}
+
+function createTarArchive(stageRoot, packageName, archivePath) {
+  const result = spawnSync('tar', ['-czf', archivePath, '-C', stageRoot, packageName], {
+    encoding: 'utf8',
+  })
+  assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`)
+}
+
+function createNoDepsApplyFixture(startMode) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ms2-no-deps-apply-'))
+  const stageRoot = path.join(root, 'stage')
+  const packageName = 'metasheet-no-deps-fixture'
+  const packageRoot = path.join(stageRoot, packageName)
+  const liveRoot = path.join(root, 'live')
+  const archivePath = path.join(root, `${packageName}.tgz`)
+  const fakeBin = path.join(root, 'bin')
+  const nodeCallMarker = path.join(root, 'node-called.marker')
+  const newStartMarker = path.join(root, 'new-start.marker')
+  const oldStartMarker = path.join(root, 'old-start.marker')
+
+  writeFixtureFile(path.join(packageRoot, 'pnpm-lock.yaml'), "lockfileVersion: '9.0'\n")
+  writeFixtureFile(path.join(packageRoot, 'PACKAGE-METADATA.json'), '{}')
+  writeFixtureFile(
+    path.join(packageRoot, 'scripts/ops/multitable-onprem-apply-package.ps1'),
+    '# package-root marker only',
+  )
+  writeFixtureFile(path.join(packageRoot, 'payload.txt'), 'new-payload')
+  writeFixtureFile(path.join(packageRoot, 'new-only.txt'), 'new-only-payload')
+  const newStartTail = startMode === 'throw' ? "throw 'NEW_START_FAILURE'" : '$global:LASTEXITCODE = 0'
+  writeFixtureFile(
+    path.join(packageRoot, 'scripts/ops/attendance-onprem-start-pm2.ps1'),
+    `Set-Content -LiteralPath $env:NEW_START_MARKER -Value 'called' -NoNewline\n${newStartTail}\n`,
+  )
+
+  writeFixtureFile(path.join(liveRoot, 'docker/app.env'), 'PORT=8900\n')
+  writeFixtureFile(path.join(liveRoot, 'payload.txt'), 'old-payload')
+  writeFixtureFile(path.join(liveRoot, 'node_modules/preserved.marker'), 'preserved')
+  writeFixtureFile(
+    path.join(liveRoot, 'scripts/ops/attendance-onprem-start-pm2.ps1'),
+    "Set-Content -LiteralPath $env:OLD_START_MARKER -Value 'called' -NoNewline\n$global:LASTEXITCODE = 0\n",
+  )
+  writeFixtureFile(
+    path.join(fakeBin, 'node'),
+    '#!/bin/sh\nprintf called > "$NODE_CALL_MARKER"\nexit 91\n',
+    0o755,
+  )
+  createTarArchive(stageRoot, packageName, archivePath)
+
+  return {
+    root,
+    liveRoot,
+    archivePath,
+    fakeBin,
+    nodeCallMarker,
+    newStartMarker,
+    oldStartMarker,
+  }
+}
+
+function runNoDepsApply(fixture, { runHealthcheck }) {
+  const applyHelper = path.join(repoRoot, 'scripts/ops/multitable-onprem-apply-package.ps1')
+  return spawnSync(
+    'pwsh',
+    [
+      '-NoProfile',
+      '-NonInteractive',
+      '-File',
+      applyHelper,
+      '-PackageArchive',
+      fixture.archivePath,
+      '-RootDir',
+      fixture.liveRoot,
+      '-StagingRoot',
+      path.join(fixture.root, 'runtime-stage'),
+      '-InstallDeps',
+      '0',
+      '-RunMigrations',
+      '0',
+      '-RestartService',
+      '1',
+      '-RunHealthcheck',
+      runHealthcheck ? '1' : '0',
+      '-CheckNginx',
+      '0',
+      '-BaseUrl',
+      'http://127.0.0.1:1',
+      '-ApiBase',
+      'http://127.0.0.1:1/api',
+      '-HealthcheckAttempts',
+      '1',
+      '-HealthcheckDelaySec',
+      '1',
+    ],
+    {
+      cwd: repoRoot,
+      env: {
+        ...process.env,
+        PATH: `${fixture.fakeBin}${path.delimiter}${process.env.PATH}`,
+        NODE_CALL_MARKER: fixture.nodeCallMarker,
+        NEW_START_MARKER: fixture.newStartMarker,
+        OLD_START_MARKER: fixture.oldStartMarker,
+      },
+      encoding: 'utf8',
+    },
+  )
+}
+
+function runNoDepsWithMigrations(applyHelper, fixture) {
+  return spawnSync(
+    'pwsh',
+    [
+      '-NoProfile',
+      '-NonInteractive',
+      '-File',
+      applyHelper,
+      '-PackageArchive',
+      fixture.archivePath,
+      '-RootDir',
+      fixture.liveRoot,
+      '-InstallDeps',
+      '0',
+      '-RunMigrations',
+      '1',
+    ],
+    { cwd: repoRoot, encoding: 'utf8' },
+  )
+}
+
 test('Windows apply helper bootstraps SYSTEM-safe tool PATH and resolves pnpm from common locations', () => {
   const script = readScript('scripts/ops/multitable-onprem-apply-package.ps1')
 
@@ -390,6 +523,126 @@ test('Windows deploy launcher resolves staged package root by package markers, n
     'the staged root must not be chosen by first child directory',
   )
 })
+
+test('Windows deploy launcher forwards explicit no-dependency and no-migration controls to the staged helper', () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'ms2-launcher-flags-'))
+  const packageName = 'metasheet-launcher-fixture'
+  const packageRoot = path.join(tempRoot, 'stage', packageName)
+  const archivePath = path.join(tempRoot, `${packageName}.tgz`)
+  const liveRoot = path.join(tempRoot, 'live')
+  const markerPath = path.join(tempRoot, 'forwarded.marker')
+
+  try {
+    writeFixtureFile(path.join(packageRoot, 'pnpm-lock.yaml'), "lockfileVersion: '9.0'\n")
+    writeFixtureFile(path.join(packageRoot, 'PACKAGE-METADATA.json'), '{}')
+    writeFixtureFile(
+      path.join(packageRoot, 'scripts/ops/multitable-onprem-apply-package.ps1'),
+      String.raw`param(
+  [string]$PackageArchive,
+  [string]$RootDir,
+  [string]$StagingRoot,
+  [string]$InstallDeps = 'UNSET',
+  [string]$RunMigrations = 'UNSET'
+)
+Set-Content -LiteralPath $env:FORWARDED_MARKER -Value ("{0}|{1}" -f $InstallDeps, $RunMigrations) -NoNewline
+`,
+    )
+    fs.mkdirSync(liveRoot, { recursive: true })
+    createTarArchive(path.join(tempRoot, 'stage'), packageName, archivePath)
+
+    const launcher = path.join(repoRoot, 'scripts/ops/multitable-onprem-deploy-launcher.ps1')
+    const result = spawnSync(
+      'pwsh',
+      [
+        '-NoProfile',
+        '-NonInteractive',
+        '-File',
+        launcher,
+        '-PackageArchive',
+        archivePath,
+        '-RootDir',
+        liveRoot,
+        '-StagingRoot',
+        path.join(tempRoot, 'runtime-stage'),
+        '-InstallDeps',
+        '0',
+        '-RunMigrations',
+        '0',
+      ],
+      {
+        cwd: repoRoot,
+        env: { ...process.env, FORWARDED_MARKER: markerPath },
+        encoding: 'utf8',
+      },
+    )
+
+    assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`)
+    assert.equal(fs.readFileSync(markerPath, 'utf8'), '0|0')
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true })
+  }
+})
+
+test('no-dependency mode rejects migrations before either launcher or apply helper can stage a package', () => {
+  const fixture = createNoDepsApplyFixture('success')
+  const launcher = path.join(repoRoot, 'scripts/ops/multitable-onprem-deploy-launcher.ps1')
+  const applyHelper = path.join(repoRoot, 'scripts/ops/multitable-onprem-apply-package.ps1')
+
+  try {
+    for (const script of [launcher, applyHelper]) {
+      const result = runNoDepsWithMigrations(script, fixture)
+      assert.notEqual(result.status, 0, `${path.basename(script)} must reject the unsafe flag combination`)
+      assert.match(
+        `${result.stdout}\n${result.stderr}`,
+        /PACKAGE_NO_DEPS_REQUIRES_NO_MIGRATIONS/,
+        `${path.basename(script)} must fail with the closed policy token`,
+      )
+    }
+    assert.equal(fs.readFileSync(path.join(fixture.liveRoot, 'payload.txt'), 'utf8'), 'old-payload')
+    assert.equal(fs.existsSync(fixture.newStartMarker), false, 'the package must not reach its restart boundary')
+  } finally {
+    fs.rmSync(fixture.root, { recursive: true, force: true })
+  }
+})
+
+test('InstallDeps=0 applies the package overlay while preserving existing node_modules', () => {
+  const fixture = createNoDepsApplyFixture('success')
+  try {
+    const result = runNoDepsApply(fixture, { runHealthcheck: false })
+
+    assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`)
+    assert.equal(fs.readFileSync(path.join(fixture.liveRoot, 'payload.txt'), 'utf8'), 'new-payload')
+    assert.equal(fs.readFileSync(path.join(fixture.liveRoot, 'new-only.txt'), 'utf8'), 'new-only-payload')
+    assert.equal(fs.readFileSync(path.join(fixture.liveRoot, 'node_modules/preserved.marker'), 'utf8'), 'preserved')
+    assert.equal(fs.existsSync(fixture.nodeCallMarker), false, 'RunMigrations=0 must never invoke node')
+    assert.equal(fs.existsSync(fixture.newStartMarker), true, 'the new runtime must be restarted')
+    assert.equal(fs.existsSync(fixture.oldStartMarker), false, 'the old runtime must not restart after a successful apply')
+  } finally {
+    fs.rmSync(fixture.root, { recursive: true, force: true })
+  }
+})
+
+for (const [name, startMode, runHealthcheck] of [
+  ['service restart failure', 'throw', false],
+  ['post-restart health failure', 'success', true],
+]) {
+  test(`InstallDeps=0 restores the previous live tree after ${name}`, () => {
+    const fixture = createNoDepsApplyFixture(startMode)
+    try {
+      const result = runNoDepsApply(fixture, { runHealthcheck })
+
+      assert.notEqual(result.status, 0, 'the injected failure must remain fail-closed')
+      assert.equal(fs.readFileSync(path.join(fixture.liveRoot, 'payload.txt'), 'utf8'), 'old-payload')
+      assert.equal(fs.existsSync(path.join(fixture.liveRoot, 'new-only.txt')), false)
+      assert.equal(fs.readFileSync(path.join(fixture.liveRoot, 'node_modules/preserved.marker'), 'utf8'), 'preserved')
+      assert.equal(fs.existsSync(fixture.nodeCallMarker), false, 'RunMigrations=0 must never invoke node')
+      assert.equal(fs.existsSync(fixture.newStartMarker), true, 'the injected new-runtime boundary must execute')
+      assert.equal(fs.existsSync(fixture.oldStartMarker), true, 'rollback must restart the restored runtime')
+    } finally {
+      fs.rmSync(fixture.root, { recursive: true, force: true })
+    }
+  })
+}
 
 test('PM2 startup helper initializes SYSTEM profile env before invoking PM2', () => {
   const script = readScript('scripts/ops/attendance-onprem-start-pm2.ps1')

--- a/scripts/ops/onprem-windows-system-hardening.test.mjs
+++ b/scripts/ops/onprem-windows-system-hardening.test.mjs
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict'
-import { spawnSync } from 'node:child_process'
+import { spawn, spawnSync } from 'node:child_process'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
@@ -34,8 +34,10 @@ function createNoDepsApplyFixture(startMode) {
   const archivePath = path.join(root, `${packageName}.tgz`)
   const fakeBin = path.join(root, 'bin')
   const nodeCallMarker = path.join(root, 'node-called.marker')
+  const pnpmCallMarker = path.join(root, 'pnpm-called.marker')
   const newStartMarker = path.join(root, 'new-start.marker')
   const oldStartMarker = path.join(root, 'old-start.marker')
+  const runtimeStage = path.join(root, 'runtime-stage')
 
   writeFixtureFile(path.join(packageRoot, 'pnpm-lock.yaml'), "lockfileVersion: '9.0'\n")
   writeFixtureFile(path.join(packageRoot, 'PACKAGE-METADATA.json'), '{}')
@@ -63,6 +65,11 @@ function createNoDepsApplyFixture(startMode) {
     '#!/bin/sh\nprintf called > "$NODE_CALL_MARKER"\nexit 91\n',
     0o755,
   )
+  writeFixtureFile(
+    path.join(fakeBin, 'pnpm'),
+    '#!/bin/sh\nprintf called > "$PNPM_CALL_MARKER"\nexit 92\n',
+    0o755,
+  )
   createTarArchive(stageRoot, packageName, archivePath)
 
   return {
@@ -71,12 +78,21 @@ function createNoDepsApplyFixture(startMode) {
     archivePath,
     fakeBin,
     nodeCallMarker,
+    pnpmCallMarker,
     newStartMarker,
     oldStartMarker,
+    runtimeStage,
   }
 }
 
-function runNoDepsApply(fixture, { runHealthcheck }) {
+function runNoDepsApply(
+  fixture,
+  {
+    runHealthcheck,
+    baseUrl = 'http://127.0.0.1:1',
+    apiBase = 'http://127.0.0.1:1/api',
+  },
+) {
   const applyHelper = path.join(repoRoot, 'scripts/ops/multitable-onprem-apply-package.ps1')
   return spawnSync(
     'pwsh',
@@ -90,7 +106,7 @@ function runNoDepsApply(fixture, { runHealthcheck }) {
       '-RootDir',
       fixture.liveRoot,
       '-StagingRoot',
-      path.join(fixture.root, 'runtime-stage'),
+      fixture.runtimeStage,
       '-InstallDeps',
       '0',
       '-RunMigrations',
@@ -102,9 +118,9 @@ function runNoDepsApply(fixture, { runHealthcheck }) {
       '-CheckNginx',
       '0',
       '-BaseUrl',
-      'http://127.0.0.1:1',
+      baseUrl,
       '-ApiBase',
-      'http://127.0.0.1:1/api',
+      apiBase,
       '-HealthcheckAttempts',
       '1',
       '-HealthcheckDelaySec',
@@ -116,12 +132,132 @@ function runNoDepsApply(fixture, { runHealthcheck }) {
         ...process.env,
         PATH: `${fixture.fakeBin}${path.delimiter}${process.env.PATH}`,
         NODE_CALL_MARKER: fixture.nodeCallMarker,
+        PNPM_CALL_MARKER: fixture.pnpmCallMarker,
         NEW_START_MARKER: fixture.newStartMarker,
         OLD_START_MARKER: fixture.oldStartMarker,
       },
       encoding: 'utf8',
     },
   )
+}
+
+function waitForFile(filePath, timeoutMs = 5_000) {
+  const deadline = Date.now() + timeoutMs
+  const sleeper = new Int32Array(new SharedArrayBuffer(4))
+  while (Date.now() < deadline) {
+    if (fs.existsSync(filePath)) return
+    Atomics.wait(sleeper, 0, 0, 25)
+  }
+  throw new Error(`timed out waiting for ${filePath}`)
+}
+
+function startAsymmetricHealthServer(fixture, passingPath) {
+  const readyPath = path.join(fixture.root, `health-${passingPath.replaceAll('/', '_')}.port`)
+  const serverScript = String.raw`
+const fs = require('node:fs')
+const http = require('node:http')
+const readyPath = process.argv[1]
+const oldStartMarker = process.argv[2]
+const passingPath = process.argv[3]
+const server = http.createServer((request, response) => {
+  const restoredRuntime = fs.existsSync(oldStartMarker)
+  const ok = restoredRuntime || request.url === passingPath
+  response.statusCode = ok ? 200 : 503
+  response.end(ok ? 'ok' : 'unavailable')
+})
+server.listen(0, '127.0.0.1', () => {
+  fs.writeFileSync(readyPath, String(server.address().port))
+})
+`
+  const child = spawn(process.execPath, ['-e', serverScript, readyPath, fixture.oldStartMarker, passingPath], {
+    stdio: 'ignore',
+  })
+  try {
+    waitForFile(readyPath)
+  } catch (error) {
+    child.kill()
+    throw error
+  }
+
+  const port = Number.parseInt(fs.readFileSync(readyPath, 'utf8'), 10)
+  assert.ok(Number.isInteger(port) && port > 0, 'health fixture must publish a valid port')
+  return {
+    baseUrl: `http://127.0.0.1:${port}`,
+    stop() {
+      child.kill()
+    },
+  }
+}
+
+function runNoDepsApplyWithCopyFailure(fixture, { failRestore = false } = {}) {
+  const applyHelper = path.join(repoRoot, 'scripts/ops/multitable-onprem-apply-package.ps1')
+  const wrapperPath = path.join(fixture.root, 'inject-overlay-copy-failure.ps1')
+  writeFixtureFile(
+    wrapperPath,
+    String.raw`$ErrorActionPreference = 'Stop'
+$script:existingDestinationCopied = $false
+$script:newDestinationCopied = $false
+$script:overlayFailureInjected = $false
+$script:restoreFailureInjected = $false
+
+function global:Copy-Item {
+  param(
+    [string]$LiteralPath,
+    [string]$Destination,
+    [switch]$Force
+  )
+
+  $destinationFull = [System.IO.Path]::GetFullPath($Destination)
+  $existingDestination = [System.IO.Path]::GetFullPath($env:INJECT_EXISTING_DESTINATION)
+  $newDestination = [System.IO.Path]::GetFullPath($env:INJECT_NEW_DESTINATION)
+
+  if ($script:overlayFailureInjected -and
+      -not $script:restoreFailureInjected -and
+      $env:INJECT_RESTORE_FAILURE -eq '1' -and
+      [System.StringComparer]::OrdinalIgnoreCase.Equals($destinationFull, $existingDestination)) {
+    $script:restoreFailureInjected = $true
+    throw 'INJECTED_OVERLAY_RESTORE_FAILURE'
+  }
+
+  Microsoft.PowerShell.Management\Copy-Item -LiteralPath $LiteralPath -Destination $Destination -Force:$Force
+
+  if (-not $script:overlayFailureInjected) {
+    if ([System.StringComparer]::OrdinalIgnoreCase.Equals($destinationFull, $existingDestination)) {
+      $script:existingDestinationCopied = $true
+    }
+    if ([System.StringComparer]::OrdinalIgnoreCase.Equals($destinationFull, $newDestination)) {
+      $script:newDestinationCopied = $true
+    }
+    if ($script:existingDestinationCopied -and $script:newDestinationCopied) {
+      $script:overlayFailureInjected = $true
+      throw 'INJECTED_MID_OVERLAY_COPY_FAILURE'
+    }
+  }
+}
+
+& $env:APPLY_HELPER -PackageArchive $env:PACKAGE_ARCHIVE -RootDir $env:LIVE_ROOT -StagingRoot $env:RUNTIME_STAGE -InstallDeps 0 -RunMigrations 0 -RestartService 1 -RunHealthcheck 0 -CheckNginx 0
+`,
+  )
+
+  return spawnSync('pwsh', ['-NoProfile', '-NonInteractive', '-File', wrapperPath], {
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      PATH: `${fixture.fakeBin}${path.delimiter}${process.env.PATH}`,
+      APPLY_HELPER: applyHelper,
+      PACKAGE_ARCHIVE: fixture.archivePath,
+      LIVE_ROOT: fixture.liveRoot,
+      RUNTIME_STAGE: fixture.runtimeStage,
+      INJECT_EXISTING_DESTINATION: path.join(fixture.liveRoot, 'payload.txt'),
+      INJECT_NEW_DESTINATION: path.join(fixture.liveRoot, 'new-only.txt'),
+      INJECT_RESTORE_FAILURE: failRestore ? '1' : '0',
+      NODE_CALL_MARKER: fixture.nodeCallMarker,
+      PNPM_CALL_MARKER: fixture.pnpmCallMarker,
+      NEW_START_MARKER: fixture.newStartMarker,
+      OLD_START_MARKER: fixture.oldStartMarker,
+    },
+    encoding: 'utf8',
+  })
 }
 
 function runNoDepsWithMigrations(applyHelper, fixture) {
@@ -447,8 +583,10 @@ test('Windows apply helper retries post-PM2 healthcheck during warmup and remain
   assert.match(script, /function Invoke-HealthcheckOnce/)
   assert.match(script, /function Invoke-Healthcheck/)
   assert.match(script, /for \(\$attempt = 1; \$attempt -le \$Attempts; \$attempt\+\+\)/)
+  assert.match(script, /\$allUrlsHealthy = \$true/)
   assert.match(script, /foreach \(\$url in \$Urls\)/)
   assert.match(script, /Invoke-HealthcheckOnce -Url \$url/)
+  assert.match(script, /if \(\$allUrlsHealthy\) \{\s+return \$true\s+\}/)
   assert.match(script, /Start-Sleep -Seconds \$DelaySec/)
   assert.match(script, /return \$false/)
   assert.match(script, /Convert-PositiveInt -Value \$HealthcheckAttempts -Label 'HealthcheckAttempts'/)
@@ -643,6 +781,81 @@ for (const [name, startMode, runHealthcheck] of [
     }
   })
 }
+
+for (const [name, passingPath] of [
+  ['base health succeeds but plugin health fails', '/health'],
+  ['base health fails but plugin health succeeds', '/api/plugins'],
+]) {
+  test(`InstallDeps=0 rolls back when ${name}`, () => {
+    const fixture = createNoDepsApplyFixture('success')
+    const server = startAsymmetricHealthServer(fixture, passingPath)
+    try {
+      const result = runNoDepsApply(fixture, {
+        runHealthcheck: true,
+        baseUrl: server.baseUrl,
+        apiBase: `${server.baseUrl}/api`,
+      })
+
+      assert.notEqual(result.status, 0, 'a partial health result must remain fail-closed')
+      assert.equal(fs.readFileSync(path.join(fixture.liveRoot, 'payload.txt'), 'utf8'), 'old-payload')
+      assert.equal(fs.existsSync(path.join(fixture.liveRoot, 'new-only.txt')), false)
+      assert.equal(fs.readFileSync(path.join(fixture.liveRoot, 'node_modules/preserved.marker'), 'utf8'), 'preserved')
+      assert.equal(fs.existsSync(fixture.nodeCallMarker), false, 'RunMigrations=0 must never invoke node')
+      assert.equal(fs.existsSync(fixture.pnpmCallMarker), false, 'InstallDeps=0 must never invoke pnpm')
+      assert.equal(fs.existsSync(fixture.newStartMarker), true, 'the new runtime must reach the health boundary')
+      assert.equal(fs.existsSync(fixture.oldStartMarker), true, 'rollback must restart the restored runtime')
+    } finally {
+      server.stop()
+      fs.rmSync(fixture.root, { recursive: true, force: true })
+    }
+  })
+}
+
+test('InstallDeps=0 restores and restarts the previous runtime after a deterministic mid-overlay copy failure', () => {
+  const fixture = createNoDepsApplyFixture('success')
+  try {
+    const result = runNoDepsApplyWithCopyFailure(fixture)
+    const output = `${result.stdout}\n${result.stderr}`
+
+    assert.notEqual(result.status, 0, 'the injected copy failure must remain fail-closed')
+    assert.match(output, /INJECTED_MID_OVERLAY_COPY_FAILURE/)
+    assert.equal(fs.readFileSync(path.join(fixture.liveRoot, 'payload.txt'), 'utf8'), 'old-payload')
+    assert.equal(fs.existsSync(path.join(fixture.liveRoot, 'new-only.txt')), false)
+    assert.equal(fs.readFileSync(path.join(fixture.liveRoot, 'node_modules/preserved.marker'), 'utf8'), 'preserved')
+    assert.equal(fs.existsSync(fixture.nodeCallMarker), false, 'RunMigrations=0 must never invoke node')
+    assert.equal(fs.existsSync(fixture.pnpmCallMarker), false, 'InstallDeps=0 must never invoke pnpm')
+    assert.equal(fs.existsSync(fixture.newStartMarker), false, 'copy failure must precede new-runtime restart')
+    assert.equal(fs.existsSync(fixture.oldStartMarker), true, 'copy rollback must restart the restored runtime')
+  } finally {
+    fs.rmSync(fixture.root, { recursive: true, force: true })
+  }
+})
+
+test('InstallDeps=0 preserves the rollback backup when overlay restoration fails', () => {
+  const fixture = createNoDepsApplyFixture('success')
+  try {
+    const result = runNoDepsApplyWithCopyFailure(fixture, { failRestore: true })
+    const output = `${result.stdout}\n${result.stderr}`
+
+    assert.notEqual(result.status, 0, 'the injected restore failure must remain fail-closed')
+    assert.match(output, /PACKAGE_NO_DEPS_ROLLBACK_FAILED/)
+    assert.match(output, /INJECTED_OVERLAY_RESTORE_FAILURE/)
+    assert.equal(fs.readFileSync(path.join(fixture.liveRoot, 'node_modules/preserved.marker'), 'utf8'), 'preserved')
+    assert.equal(fs.existsSync(fixture.nodeCallMarker), false, 'RunMigrations=0 must never invoke node')
+    assert.equal(fs.existsSync(fixture.pnpmCallMarker), false, 'InstallDeps=0 must never invoke pnpm')
+
+    const rollbackRoots = fs.readdirSync(fixture.runtimeStage)
+      .filter((entry) => entry.startsWith('mspb-'))
+    assert.equal(rollbackRoots.length, 1, 'failed restoration must preserve exactly one rollback root')
+    assert.equal(
+      fs.readFileSync(path.join(fixture.runtimeStage, rollbackRoots[0], 'files/payload.txt'), 'utf8'),
+      'old-payload',
+      'preserved rollback backup must retain the pre-change file',
+    )
+  } finally {
+    fs.rmSync(fixture.root, { recursive: true, force: true })
+  }
+})
 
 test('PM2 startup helper initializes SYSTEM profile env before invoking PM2', () => {
   const script = readScript('scripts/ops/attendance-onprem-start-pm2.ps1')


### PR DESCRIPTION
## Problem

#4861 independently confirmed that the frozen Windows first-hop launcher could not forward `InstallDeps=0` / `RunMigrations=0`, while the staged apply helper defaulted both controls to `1`. Direct invocation was not an acceptable workaround because the old no-dependency branch copied into the live root without a rollback transaction.

A later exact-head review also found two rollback gaps: health committed after any one configured URL passed, and deterministic mid-overlay copy-failure recovery had no load-bearing full-path proof.

## Changes

- expose and forward `InstallDeps` and `RunMigrations` through the PowerShell first-hop launcher
- expose the same controls through the release `.bat` wrapper while preserving the normal `1/1` defaults
- reject `InstallDeps=0, RunMigrations=1` before extraction or live-root mutation
- replace the no-dependency raw copy with a file overlay that preserves existing `node_modules` and holds backups through restart and health verification
- require every configured health URL to pass in the same attempt before committing the overlay
- on copy, restart, or health failure, restore overwritten files, remove newly added files, restart the restored service, and fail closed
- preserve the rollback backup when file restoration or restored-service restart fails
- document the coupled `0/0` invocation and add behavior plus package-contract tests

## Verification

- `node --test scripts/ops/onprem-windows-system-hardening.test.mjs scripts/ops/multitable-onprem-package-no-node-modules.test.mjs` (34/34)
- `node plugins/plugin-integration-core/__tests__/sealed-export-package-provenance.test.cjs`
- PowerShell parser: launcher and apply helper
- `bash -n scripts/ops/multitable-onprem-package-build.sh`
- stock-preparation acceptance: 57/57 behavior checks
- RC-A window: 38/38 contract and 41/41 behavior checks
- original mutations independently made RED: both launcher flag forwards, no-deps migration policy, post-failure restore, restored-service restart, and batch-wrapper migration forwarding
- review-fix mutations made RED at target assertions: any-one-URL health success, removed copy rollback restart, removed file restore, and removed backup preservation
- fresh exact-head CI remains the authority for the full required and SQL Server product-action matrix

## Authorization boundary

This is the bounded packaging remediation authorized in #4861. It does not authorize dependency installation, migrations, deployment, configuration changes, external connections, flag changes, or external writes. After merge, the next permitted action is to build and verify a new `publish=false` package from the exact merge SHA and freeze its manifest and hashes; entity-machine execution remains separately authorized.