### PR TITLE
feat(ops): bootstrap staging human admin safely

### DIFF
--- a/.github/workflows/dingtalk-lifecycle-staging-canary.yml
+++ b/.github/workflows/dingtalk-lifecycle-staging-canary.yml
@@ -5,7 +5,7 @@ run-name: "DingTalk Lifecycle Staging Canary: ${{ inputs.action }}${{ inputs.act
 # Staging-only MINIMAL SAFE operator lane for DingTalk lifecycle env gates.
 # One dispatch = ONE action. All lifecycle flags remain OFF by default.
 #
-# EXECUTABLE: status | preflight | off | bootstrap | alias
+# EXECUTABLE: status | preflight | off | bootstrap | human-bootstrap | alias
 #   off       = emergency env-gate clear of the three lifecycle flags only (with
 #               previous-override restore on restart/health/mode failure).
 #   bootstrap = staging-only create/repair of the FIXED dedicated lifecycle
@@ -14,6 +14,17 @@ run-name: "DingTalk Lifecycle Staging Canary: ${{ inputs.action }}${{ inputs.act
 #               mode off, health true, migrations zero. Idempotent for the owned
 #               row; collision fail-closed. Proves real password login. Never
 #               writes lifecycle env flags. Secrets: IDENTIFIER + PASSWORD only.
+#   human-bootstrap = staging-only create/repair of a SEPARATE fixed human
+#               platform admin (username staging-owner-admin, name Staging Owner
+#               Admin, no email/mobile). Requires full deploy SHA,
+#               expected_current_mode=off, confirmation CREATE_STAGING_HUMAN_ADMIN,
+#               exact mode off, health true, migrations zero. Authenticates admin
+#               API with the existing canary admin; human password only via
+#               secrets.STAGING_OWNER_ADMIN_PASSWORD → chmod-600 file path (never
+#               logged). Create or idempotent reset of the owned match only;
+#               required reset-password / access / login / revoke-sessions proofs.
+#               Never writes lifecycle env flags; no restart. Secrets: canary
+#               IDENTIFIER + PASSWORD + STAGING_OWNER_ADMIN_PASSWORD.
 #   alias     = TRANSIENT secret-backed alias cutover canary. Success requires/
 #               proves OFF; failure restores the OFF override before failing.
 #               Runtime OFF cannot be proven if rollback recreate itself fails.
@@ -39,11 +50,11 @@ on:
   workflow_dispatch:
     inputs:
       action:
-        description: 'status/preflight/off/bootstrap/alias = executable; pending/deprovision = NOT EXECUTABLE (fail-closed preflight-only)'
+        description: 'status/preflight/off/bootstrap/human-bootstrap/alias = executable; pending/deprovision = NOT EXECUTABLE (fail-closed preflight-only)'
         required: true
         type: choice
         # Quote 'off' — YAML 1.1 bare off becomes boolean false.
-        options: [status, preflight, 'off', bootstrap, alias, pending, deprovision]
+        options: [status, preflight, 'off', bootstrap, human-bootstrap, alias, pending, deprovision]
         default: status
       target_mode:
         description: 'preflight only: target mode to assess (off|alias|pending|deprovision). pending/deprovision assess readiness only — never apply.'
@@ -52,16 +63,16 @@ on:
         options: ['off', alias, pending, deprovision]
         default: 'off'
       expected_current_mode:
-        description: 'Required for action=off (live mode before clear) and action=bootstrap|alias (must be off). Optional for preflight.'
+        description: 'Required for action=off (live mode before clear) and action=bootstrap|human-bootstrap|alias (must be off). Optional for preflight.'
         required: false
         type: string
         default: ''
       deploy_sha:
-        description: 'FULL 40-char lowercase commit SHA currently deployed on staging. Required for action=off, bootstrap, and alias; optional exact-match for preflight.'
+        description: 'FULL 40-char lowercase commit SHA currently deployed on staging. Required for action=off, bootstrap, human-bootstrap, and alias; optional exact-match for preflight.'
         required: false
         default: ''
       bootstrap_confirmation:
-        description: 'For action=bootstrap only, enter CREATE_STAGING_CANARY_ADMIN. Ignored by other actions.'
+        description: 'For action=bootstrap enter CREATE_STAGING_CANARY_ADMIN; for action=human-bootstrap enter CREATE_STAGING_HUMAN_ADMIN. Ignored by other actions.'
         required: false
         type: string
         default: ''
@@ -95,7 +106,7 @@ jobs:
           # (bash -n and other children must not inherit raw secret env).
         run: |
           set -euo pipefail
-          case "$ACTION" in status|preflight|off|bootstrap|alias|pending|deprovision) ;; *)
+          case "$ACTION" in status|preflight|off|bootstrap|human-bootstrap|alias|pending|deprovision) ;; *)
             echo "invalid action: $ACTION" >&2; exit 2
           ;; esac
 
@@ -121,10 +132,11 @@ jobs:
             fi
           fi
 
-          # action=bootstrap|alias: structural inputs only here. Secret presence is
-          # checked in Run remote action. bootstrap never writes lifecycle env flags.
-          # alias success requires/proves OFF; failure restores OFF override first.
-          if [[ "$ACTION" == "bootstrap" || "$ACTION" == "alias" ]]; then
+          # action=bootstrap|human-bootstrap|alias: structural inputs only here. Secret
+          # presence is checked in Run remote action. bootstrap/human-bootstrap never
+          # write lifecycle env flags. alias success requires/proves OFF; failure
+          # restores OFF override first.
+          if [[ "$ACTION" == "bootstrap" || "$ACTION" == "human-bootstrap" || "$ACTION" == "alias" ]]; then
             if [[ "$EXPECTED_CURRENT_MODE" != "off" ]]; then
               echo "expected_current_mode must be exactly 'off' for action=${ACTION} (no auto-selection)" >&2
               exit 2
@@ -137,6 +149,11 @@ jobs:
 
           if [[ "$ACTION" == "bootstrap" && "$BOOTSTRAP_CONFIRMATION" != "CREATE_STAGING_CANARY_ADMIN" ]]; then
             echo "bootstrap_confirmation must be exactly CREATE_STAGING_CANARY_ADMIN for action=bootstrap" >&2
+            exit 2
+          fi
+
+          if [[ "$ACTION" == "human-bootstrap" && "$BOOTSTRAP_CONFIRMATION" != "CREATE_STAGING_HUMAN_ADMIN" ]]; then
+            echo "bootstrap_confirmation must be exactly CREATE_STAGING_HUMAN_ADMIN for action=human-bootstrap" >&2
             exit 2
           fi
 
@@ -191,13 +208,17 @@ jobs:
           TARGET_MODE: ${{ inputs.target_mode }}
           EXPECTED_CURRENT_MODE: ${{ inputs.expected_current_mode }}
           DEPLOY_SHA: ${{ inputs.deploy_sha }}
+          BOOTSTRAP_CONFIRMATION: ${{ inputs.bootstrap_confirmation }}
           RUNNER_DIR: ${{ steps.sync.outputs.runner_dir }}
-          # bootstrap/alias login secrets are materialized INSIDE this step under EXIT
-          # trap — never via a prior step secrets_dir output (cross-step leak / cancel).
-          # ATTENDANCE_ADMIN_JWT is intentionally NOT consumed; alias mints a short-lived
-          # admin JWT from the canary password login on the remote host.
+          # bootstrap/human-bootstrap/alias login secrets are materialized INSIDE this
+          # step under EXIT trap — never via a prior step secrets_dir output (cross-step
+          # leak / cancel). ATTENDANCE_ADMIN_JWT is intentionally NOT consumed; alias
+          # and human-bootstrap mint a short-lived admin JWT from the canary password
+          # login on the remote host. STAGING_OWNER_ADMIN_PASSWORD is demoted and
+          # written to a chmod-600 file for human-bootstrap only (path transferred).
           LIFECYCLE_CANARY_LOGIN_IDENTIFIER: ${{ secrets.LIFECYCLE_CANARY_LOGIN_IDENTIFIER }}
           LIFECYCLE_CANARY_LOGIN_PASSWORD: ${{ secrets.LIFECYCLE_CANARY_LOGIN_PASSWORD }}
+          STAGING_OWNER_ADMIN_PASSWORD: ${{ inputs.action == 'human-bootstrap' && secrets.STAGING_OWNER_ADMIN_PASSWORD || '' }}
         run: |
           set -euo pipefail
           # --- SECRET DEMOTE (builtins only; no external child before unset) -------------
@@ -208,7 +229,8 @@ jobs:
           # Never demote/export ATTENDANCE_ADMIN_JWT (alias mints JWT from password login).
           _CANARY_IDENT="${LIFECYCLE_CANARY_LOGIN_IDENTIFIER-}"
           _CANARY_PASS="${LIFECYCLE_CANARY_LOGIN_PASSWORD-}"
-          unset LIFECYCLE_CANARY_LOGIN_IDENTIFIER LIFECYCLE_CANARY_LOGIN_PASSWORD
+          _STAGING_OWNER_PASS="${STAGING_OWNER_ADMIN_PASSWORD-}"
+          unset LIFECYCLE_CANARY_LOGIN_IDENTIFIER LIFECYCLE_CANARY_LOGIN_PASSWORD STAGING_OWNER_ADMIN_PASSWORD
           # --- end secret demote; external commands allowed after this point ------------
 
           ssh_opts="-o StrictHostKeyChecking=yes -o UserKnownHostsFile=$HOME/.ssh/known_hosts -o IdentitiesOnly=yes -i $HOME/.ssh/deploy_key"
@@ -261,21 +283,28 @@ jobs:
             set -e
           }
 
-          # For bootstrap|alias: materialize chmod-600 identifier/password LOCALLY under
-          # EXIT trap, then scp path-only into the per-run remote directory. Never pass
-          # secrets_dir across steps. Never materialize ATTENDANCE_ADMIN_JWT.
-          # Password written with printf '%s' (exact bytes). Alias mints admin JWT on remote
-          # after successful pre-login into the same per-run secrets dir.
+          # For bootstrap|human-bootstrap|alias: materialize chmod-600 secrets LOCALLY
+          # under EXIT trap, then scp path-only into the per-run remote directory. Never
+          # pass secrets_dir across steps. Never materialize ATTENDANCE_ADMIN_JWT.
+          # Password written with printf '%s' (exact bytes). Alias/human-bootstrap mint
+          # admin JWT on remote after successful canary pre-login into the same per-run
+          # secrets dir. human-bootstrap also materializes staging-owner-admin.password.
           remote_secrets_dir=""
           canary_ident_export=""
           canary_pass_export=""
-          if [[ "$ACTION" == "alias" || "$ACTION" == "bootstrap" ]]; then
+          staging_owner_pass_export=""
+          if [[ "$ACTION" == "alias" || "$ACTION" == "bootstrap" || "$ACTION" == "human-bootstrap" ]]; then
             # Install trap BEFORE any secret materialization (mktemp/write/chmod).
             trap cleanup_canary_ephemeral_paths EXIT INT TERM
             # Presence via non-exported shell vars only (env already unset above).
             if [[ -z "${_CANARY_IDENT}" || -z "${_CANARY_PASS}" ]]; then
               echo "${ACTION} requires LIFECYCLE_CANARY_LOGIN_IDENTIFIER/PASSWORD (checked in Run remote action only); never ATTENDANCE_ADMIN_JWT" >&2
-              unset _CANARY_IDENT _CANARY_PASS
+              unset _CANARY_IDENT _CANARY_PASS _STAGING_OWNER_PASS
+              exit 2
+            fi
+            if [[ "$ACTION" == "human-bootstrap" && -z "${_STAGING_OWNER_PASS}" ]]; then
+              echo "human-bootstrap requires STAGING_OWNER_ADMIN_PASSWORD (checked in Run remote action only); never log secret" >&2
+              unset _CANARY_IDENT _CANARY_PASS _STAGING_OWNER_PASS
               exit 2
             fi
             secrets_dir="$(mktemp -d "${RUNNER_TEMP}/lifecycle-canary-secrets.XXXXXX")"
@@ -286,28 +315,47 @@ jobs:
             # Exact secret bytes from non-exported shell vars — printf '%s' preserves payload.
             printf '%s' "${_CANARY_IDENT}" > "${secrets_dir}/login.identifier"
             printf '%s' "${_CANARY_PASS}" > "${secrets_dir}/login.password"
-            # Drop shell-held secret values as soon as files are written.
+            # Drop shell-held canary secret values as soon as files are written.
             unset _CANARY_IDENT _CANARY_PASS
             chmod 600 "${secrets_dir}/login.identifier" "${secrets_dir}/login.password"
             for f in login.identifier login.password; do
               [[ -s "${secrets_dir}/${f}" ]] || { echo "secret file empty after materialize: ${f}" >&2; exit 2; }
             done
+            scp_files=(
+              "${secrets_dir}/login.identifier"
+              "${secrets_dir}/login.password"
+            )
+            if [[ "$ACTION" == "human-bootstrap" ]]; then
+              printf '%s' "${_STAGING_OWNER_PASS}" > "${secrets_dir}/staging-owner-admin.password"
+              unset _STAGING_OWNER_PASS
+              chmod 600 "${secrets_dir}/staging-owner-admin.password"
+              [[ -s "${secrets_dir}/staging-owner-admin.password" ]] \
+                || { echo "secret file empty after materialize: staging-owner-admin.password" >&2; exit 2; }
+              scp_files+=("${secrets_dir}/staging-owner-admin.password")
+            else
+              unset _STAGING_OWNER_PASS
+            fi
             remote_secrets_dir="${RUNNER_DIR}/.canary-secrets"
             CLEAN_REMOTE_SECRETS_DIR="${remote_secrets_dir}"
             # Remote copy only after local materialize succeeded under trap coverage.
             ssh $ssh_opts "$DEPLOY_USER@$DEPLOY_HOST" \
               "bash -o pipefail -c 'set -euo pipefail; mkdir -p ${remote_secrets_dir}; chmod 700 ${remote_secrets_dir}'"
             scp $ssh_opts \
-              "${secrets_dir}/login.identifier" \
-              "${secrets_dir}/login.password" \
+              "${scp_files[@]}" \
               "$DEPLOY_USER@$DEPLOY_HOST:${remote_secrets_dir}/"
-            ssh $ssh_opts "$DEPLOY_USER@$DEPLOY_HOST" \
-              "bash -o pipefail -c 'set -euo pipefail; chmod 600 ${remote_secrets_dir}/login.identifier ${remote_secrets_dir}/login.password'"
+            if [[ "$ACTION" == "human-bootstrap" ]]; then
+              ssh $ssh_opts "$DEPLOY_USER@$DEPLOY_HOST" \
+                "bash -o pipefail -c 'set -euo pipefail; chmod 600 ${remote_secrets_dir}/login.identifier ${remote_secrets_dir}/login.password ${remote_secrets_dir}/staging-owner-admin.password'"
+              staging_owner_pass_export="export STAGING_OWNER_ADMIN_PASSWORD_FILE='${remote_secrets_dir}/staging-owner-admin.password'"
+            else
+              ssh $ssh_opts "$DEPLOY_USER@$DEPLOY_HOST" \
+                "bash -o pipefail -c 'set -euo pipefail; chmod 600 ${remote_secrets_dir}/login.identifier ${remote_secrets_dir}/login.password'"
+            fi
             canary_ident_export="export CANARY_LOGIN_IDENTIFIER_FILE='${remote_secrets_dir}/login.identifier'"
             canary_pass_export="export CANARY_LOGIN_PASSWORD_FILE='${remote_secrets_dir}/login.password'"
           else
             # Non-secret actions: drop any unused shell copies; clean per-run dirs on exit.
-            unset _CANARY_IDENT _CANARY_PASS
+            unset _CANARY_IDENT _CANARY_PASS _STAGING_OWNER_PASS
             trap cleanup_canary_ephemeral_paths EXIT INT TERM
           fi
 
@@ -316,12 +364,14 @@ jobs:
           export TARGET_MODE='${TARGET_MODE}'
           export EXPECTED_CURRENT_MODE='${EXPECTED_CURRENT_MODE}'
           export DEPLOY_SHA='${DEPLOY_SHA}'
+          export BOOTSTRAP_CONFIRMATION='${BOOTSTRAP_CONFIRMATION}'
           export STAGING_DEPLOY_PATH='${STAGING_DEPLOY_PATH}'
           export DEPLOY_PATH='${DEPLOY_PATH}'
           export OUTPUT_DIR='${remote_output_dir}'
           export RUN_STAMP='gh${GITHUB_RUN_ID}a${GITHUB_RUN_ATTEMPT}'
           ${canary_ident_export}
           ${canary_pass_export}
+          ${staging_owner_pass_export}
           rm -rf '${remote_output_dir}'
           mkdir -p '${remote_output_dir}'
           set +e
@@ -375,11 +425,12 @@ jobs:
             echo "- Remote rc: \`${REMOTE_RC:-missing}\`"
             echo "- Artifact: \`${ARTIFACT_NAME:-missing}\`"
             echo ""
-            echo "**Executable:** status / preflight / off / bootstrap / alias (alias success requires/proves OFF; failure restores OFF override before failing)."
+            echo "**Executable:** status / preflight / off / bootstrap / human-bootstrap / alias (alias success requires/proves OFF; failure restores OFF override before failing)."
             echo "**NOT EXECUTABLE:** pending / deprovision (no real canary verifier)."
             echo "OFF is emergency env-gate rollback only — not OR-column design reintroduction."
             echo "Bootstrap creates/repairs fixed lifecycle-canary@staging.invalid admin only (no lifecycle env write)."
-            echo "Bootstrap/alias require LIFECYCLE_CANARY_LOGIN_IDENTIFIER/PASSWORD only (file transport); alias mints short-lived admin JWT from password login — never ATTENDANCE_ADMIN_JWT."
+            echo "Human-bootstrap creates/repairs fixed username staging-owner-admin human platform admin only (no lifecycle env write; password file transport)."
+            echo "Bootstrap/human-bootstrap/alias require LIFECYCLE_CANARY_LOGIN_IDENTIFIER/PASSWORD (file transport); human-bootstrap also requires STAGING_OWNER_ADMIN_PASSWORD file; alias/human-bootstrap mint short-lived admin JWT from canary password login — never ATTENDANCE_ADMIN_JWT."
             echo "Runtime OFF cannot be proven if alias rollback recreate itself fails (override restored on disk)."
             if [[ -f output/lifecycle-canary/summary.txt ]]; then
               echo ""

--- a/scripts/ops/dingtalk-lifecycle-staging-canary-contract.test.mjs
+++ b/scripts/ops/dingtalk-lifecycle-staging-canary-contract.test.mjs
@@ -2,7 +2,7 @@
 // dingtalk-lifecycle-staging-canary-contract.test.mjs
 //
 // Durable synthetic contract for the MINIMAL SAFE staging lifecycle lane:
-//   EXECUTABLE: status | preflight | off | bootstrap | alias
+//   EXECUTABLE: status | preflight | off | bootstrap | human-bootstrap | alias
 //   NOT EXECUTABLE: pending | deprovision (fail-closed preflight-only)
 //
 // Alias is a TRANSIENT secret-backed cutover canary: success requires/proves OFF;
@@ -11,8 +11,11 @@
 // login (never secrets.ATTENDANCE_ADMIN_JWT).
 // Bootstrap creates/repairs the fixed owned canary admin only (collision
 // fail-closed; no lifecycle env write).
+// Human-bootstrap creates/repairs a SEPARATE fixed human platform admin
+// (username staging-owner-admin) via canary-authenticated admin API + password
+// file; required reset-password/access/login/revoke; no lifecycle env write.
 // Load-bearing mutations for owner P1/P2 gaps:
-//   * migrations_pending_zero unknown must fail preflight/off/alias/bootstrap
+//   * migrations_pending_zero unknown must fail preflight/off/alias/bootstrap/human-bootstrap
 //   * pending/deprovision never apply (transition_applied=false; NOT EXECUTABLE)
 //   * alias requires pre-login(+JWT mint), backfill, readiness, post-ON login,
 //     rollback, post-rollback login, exact SHA, migrations, secret-file transport
@@ -106,8 +109,8 @@ function workflowOn(doc) {
 function actionAliasBody(source) {
   const start = source.indexOf('action_alias()')
   assert.notEqual(start, -1, 'action_alias() must exist')
-  const end = source.indexOf('\n# --- main', start)
-  assert.notEqual(end, -1, 'main marker after action_alias')
+  const end = source.indexOf('\naction_human_bootstrap()', start)
+  assert.notEqual(end, -1, 'action_human_bootstrap after action_alias')
   return source.slice(start, end)
 }
 
@@ -124,6 +127,22 @@ function actionBootstrapBody(source) {
   assert.notEqual(start, -1, 'action_bootstrap() must exist')
   const end = source.indexOf('\naction_off()', start)
   assert.notEqual(end, -1, 'action_off after action_bootstrap')
+  return source.slice(start, end)
+}
+
+function actionHumanBootstrapBody(source) {
+  const start = source.indexOf('action_human_bootstrap()')
+  assert.notEqual(start, -1, 'action_human_bootstrap() must exist')
+  const end = source.indexOf('\n# --- main', start)
+  assert.notEqual(end, -1, 'main marker after action_human_bootstrap')
+  return source.slice(start, end)
+}
+
+function bootstrapHumanPlatformAdminBody(source) {
+  const start = source.indexOf('bootstrap_human_platform_admin()')
+  assert.notEqual(start, -1, 'bootstrap_human_platform_admin() must exist')
+  const end = source.indexOf('\n# POST /api/admin/login-aliases/backfill', start)
+  assert.notEqual(end, -1, 'backfill marker after bootstrap_human_platform_admin')
   return source.slice(start, end)
 }
 
@@ -157,13 +176,14 @@ test('PR contract workflow executes this exact suite without changing the sealed
 
 // --- workflow shape -------------------------------------------------------------------
 
-test('workflow action choices include status/preflight/off/bootstrap/alias and non-executable ON names', () => {
+test('workflow action choices include status/preflight/off/bootstrap/human-bootstrap/alias and non-executable ON names', () => {
   const options = workflowOn(loadYaml(read(WORKFLOW))).workflow_dispatch.inputs.action.options
   assert.deepEqual(options, [
     'status',
     'preflight',
     'off',
     'bootstrap',
+    'human-bootstrap',
     'alias',
     'pending',
     'deprovision',
@@ -201,12 +221,15 @@ test('SSH transport requires a pinned known_hosts secret', () => {
   assert.doesNotMatch(yaml, /StrictHostKeyChecking=no/)
 })
 
-test('workflow requires deploy_sha + expected_current for off/bootstrap/alias; pending/deprovision NOT EXECUTABLE', () => {
+test('workflow requires deploy_sha + expected_current for off/bootstrap/human-bootstrap/alias; pending/deprovision NOT EXECUTABLE', () => {
   const yaml = read(WORKFLOW)
   assert.match(yaml, /expected_current_mode is required for action=off/)
   assert.match(yaml, /expected_current_mode must be exactly 'off' for action=\$\{ACTION\}/)
   assert.match(yaml, /deploy_sha must be the FULL 40-char lowercase commit SHA for action=\$\{ACTION\}/)
-  assert.match(yaml, /ACTION" == "bootstrap" \|\| "\$ACTION" == "alias"/)
+  assert.match(
+    yaml,
+    /ACTION" == "bootstrap" \|\| "\$ACTION" == "human-bootstrap" \|\| "\$ACTION" == "alias"/,
+  )
   // Secret presence is checked only in Run remote action (not Validate inputs).
   assert.match(
     yaml,
@@ -217,14 +240,14 @@ test('workflow requires deploy_sha + expected_current for off/bootstrap/alias; p
   assert.doesNotMatch(yaml, /canary_subject_id:/)
   assert.doesNotMatch(yaml, /canary_integration_id:/)
   assert.doesNotMatch(yaml, /owner_confirm:/)
-  // No password-reset API / admin reset path (prose saying "no password reset" is fine).
+  // Workflow must not embed admin password-reset HTTP paths (remote script may).
   assert.doesNotMatch(yaml, /resetPassword|reset_password|\/api\/.*password-reset/i)
   assert.doesNotMatch(yaml, /POST\s+\/api\/admin\/.*password/i)
   // No unconditional always-OFF claim in structural validation comments.
   assert.doesNotMatch(yaml, /always OFF after/i)
 })
 
-test('workflow requires an explicit privileged bootstrap confirmation phrase', () => {
+test('workflow requires explicit privileged confirmation phrases for bootstrap and human-bootstrap', () => {
   const yaml = read(WORKFLOW)
   const doc = loadYaml(yaml)
   assert.ok(workflowOn(doc).workflow_dispatch.inputs.bootstrap_confirmation)
@@ -232,20 +255,26 @@ test('workflow requires an explicit privileged bootstrap confirmation phrase', (
   assert.equal(validate.env.BOOTSTRAP_CONFIRMATION, '${{ inputs.bootstrap_confirmation }}')
   assert.match(validate.run, /ACTION" == "bootstrap"/)
   assert.match(validate.run, /BOOTSTRAP_CONFIRMATION" != "CREATE_STAGING_CANARY_ADMIN"/)
+  assert.match(validate.run, /ACTION" == "human-bootstrap"/)
+  assert.match(validate.run, /BOOTSTRAP_CONFIRMATION" != "CREATE_STAGING_HUMAN_ADMIN"/)
 })
 
-test('workflow bootstrap/alias secret transport uses chmod-600 files + scp; never ATTENDANCE_ADMIN_JWT', () => {
+test('workflow bootstrap/human-bootstrap/alias secret transport uses chmod-600 files + scp; never ATTENDANCE_ADMIN_JWT', () => {
   const yaml = read(WORKFLOW)
   assert.match(yaml, /chmod 600/)
   assert.match(yaml, /LIFECYCLE_CANARY_LOGIN_IDENTIFIER/)
   assert.match(yaml, /LIFECYCLE_CANARY_LOGIN_PASSWORD/)
+  assert.match(yaml, /STAGING_OWNER_ADMIN_PASSWORD/)
   assert.match(yaml, /CANARY_LOGIN_IDENTIFIER_FILE=/)
   assert.match(yaml, /CANARY_LOGIN_PASSWORD_FILE=/)
+  assert.match(yaml, /STAGING_OWNER_ADMIN_PASSWORD_FILE=/)
   assert.match(yaml, /\.canary-secrets/)
   assert.match(yaml, /scp \$ssh_opts/)
   // printf uses non-exported shell vars after env demote (not raw env names).
   assert.match(yaml, /printf '%s' "\$\{_CANARY_PASS\}"/)
   assert.match(yaml, /printf '%s' "\$\{_CANARY_IDENT\}"/)
+  assert.match(yaml, /printf '%s' "\$\{_STAGING_OWNER_PASS\}"/)
+  assert.match(yaml, /staging-owner-admin\.password/)
   // Must not materialize or demote ATTENDANCE_ADMIN_JWT (alias mints JWT from login).
   // Prose may mention the forbidden secret; forbid GHA secret injection only.
   assert.doesNotMatch(yaml, /_CANARY_JWT=/)
@@ -256,9 +285,13 @@ test('workflow bootstrap/alias secret transport uses chmod-600 files + scp; neve
   assert.doesNotMatch(yaml, /export ATTENDANCE_ADMIN_JWT=/)
   assert.doesNotMatch(yaml, /export LIFECYCLE_CANARY_LOGIN_IDENTIFIER=/)
   assert.doesNotMatch(yaml, /export LIFECYCLE_CANARY_LOGIN_PASSWORD=/)
+  assert.doesNotMatch(yaml, /export STAGING_OWNER_ADMIN_PASSWORD=/)
   assert.doesNotMatch(yaml, /export CANARY_LOGIN_PASSWORD='/)
-  // bootstrap shares the same secret transport gate as alias.
-  assert.match(yaml, /ACTION" == "alias" \|\| "\$ACTION" == "bootstrap"/)
+  // bootstrap/human-bootstrap share the canary secret transport gate as alias.
+  assert.match(
+    yaml,
+    /ACTION" == "alias" \|\| "\$ACTION" == "bootstrap" \|\| "\$ACTION" == "human-bootstrap"/,
+  )
 })
 
 test('workflow Validate inputs does not receive canary login secrets (no child inheritance gap)', () => {
@@ -269,14 +302,16 @@ test('workflow Validate inputs does not receive canary login secrets (no child i
   assert.equal(validate.env.ATTENDANCE_ADMIN_JWT, undefined)
   assert.equal(validate.env.LIFECYCLE_CANARY_LOGIN_IDENTIFIER, undefined)
   assert.equal(validate.env.LIFECYCLE_CANARY_LOGIN_PASSWORD, undefined)
+  assert.equal(validate.env.STAGING_OWNER_ADMIN_PASSWORD, undefined)
   // No secret presence checks in this step (they launch after bash -n otherwise).
   assert.doesNotMatch(validate.run, /ATTENDANCE_ADMIN_JWT/)
   assert.doesNotMatch(validate.run, /LIFECYCLE_CANARY_LOGIN_IDENTIFIER/)
   assert.doesNotMatch(validate.run, /LIFECYCLE_CANARY_LOGIN_PASSWORD/)
+  assert.doesNotMatch(validate.run, /STAGING_OWNER_ADMIN_PASSWORD/)
   assert.match(validate.run, /bash -n scripts\/ops\/dingtalk-lifecycle-staging-canary-remote\.sh/)
-  // Structural bootstrap/alias checks remain; secret presence does not.
+  // Structural bootstrap/human-bootstrap/alias checks remain; secret presence does not.
   assert.match(validate.run, /expected_current_mode must be exactly 'off' for action=\$\{ACTION\}/)
-  assert.match(validate.run, /bootstrap\|alias/)
+  assert.match(validate.run, /bootstrap\|human-bootstrap\|alias|bootstrap" \|\| "\$ACTION" == "human-bootstrap"/)
 })
 
 test('workflow materializes secrets inside Run remote action under EXIT trap (no separate secrets step)', () => {
@@ -313,7 +348,11 @@ test('workflow materializes secrets inside Run remote action under EXIT trap (no
       if (t === 'set -euo pipefail') sawSet = true
       continue
     }
-    if (t.startsWith('unset LIFECYCLE_CANARY_LOGIN_IDENTIFIER LIFECYCLE_CANARY_LOGIN_PASSWORD')) {
+    if (
+      t.startsWith(
+        'unset LIFECYCLE_CANARY_LOGIN_IDENTIFIER LIFECYCLE_CANARY_LOGIN_PASSWORD STAGING_OWNER_ADMIN_PASSWORD',
+      )
+    ) {
       sawEnvUnset = true
       break
     }
@@ -327,6 +366,7 @@ test('workflow materializes secrets inside Run remote action under EXIT trap (no
     [
       '_CANARY_IDENT="${LIFECYCLE_CANARY_LOGIN_IDENTIFIER-}"',
       '_CANARY_PASS="${LIFECYCLE_CANARY_LOGIN_PASSWORD-}"',
+      '_STAGING_OWNER_PASS="${STAGING_OWNER_ADMIN_PASSWORD-}"',
     ],
     'only demote assignments (builtins) before secret env unset — no external commands; no JWT',
   )
@@ -334,10 +374,11 @@ test('workflow materializes secrets inside Run remote action under EXIT trap (no
   // Order after demote: trap → mktemp → printf from shell vars → unset shell vars → remote scp.
   const trapIdx = runBody.indexOf('trap cleanup_canary_ephemeral_paths EXIT INT TERM')
   const envUnsetIdx = runBody.indexOf(
-    'unset LIFECYCLE_CANARY_LOGIN_IDENTIFIER LIFECYCLE_CANARY_LOGIN_PASSWORD',
+    'unset LIFECYCLE_CANARY_LOGIN_IDENTIFIER LIFECYCLE_CANARY_LOGIN_PASSWORD STAGING_OWNER_ADMIN_PASSWORD',
   )
   const mktempIdx = runBody.indexOf('mktemp -d')
   const printfPassIdx = runBody.indexOf("printf '%s' \"${_CANARY_PASS}\"")
+  const printfOwnerIdx = runBody.indexOf("printf '%s' \"${_STAGING_OWNER_PASS}\"")
   // Post-write shell-var wipe (must follow password printf; fail-path unset is earlier).
   const unsetShellIdx = runBody.indexOf(
     'unset _CANARY_IDENT _CANARY_PASS',
@@ -351,6 +392,8 @@ test('workflow materializes secrets inside Run remote action under EXIT trap (no
   assert.ok(localCleanAssignIdx > trapIdx && localCleanAssignIdx < remoteMkdirIdx, 'register local dir for trap before remote copy')
   assert.ok(printfPassIdx > trapIdx, 'password materialize after trap')
   assert.ok(printfPassIdx < remoteMkdirIdx, 'local password write before remote mkdir')
+  assert.ok(printfOwnerIdx > printfPassIdx, 'human password materialize after canary password')
+  assert.ok(printfOwnerIdx < remoteMkdirIdx, 'human password local write before remote mkdir')
   assert.ok(unsetShellIdx > printfPassIdx, 'unset shell secret vars immediately after printf writes')
   assert.ok(unsetShellIdx < remoteMkdirIdx, 'shell secret vars cleared before remote copy')
   assert.ok(remoteMkdirIdx > mktempIdx, 'remote secrets mkdir after local materialize')
@@ -359,11 +402,16 @@ test('workflow materializes secrets inside Run remote action under EXIT trap (no
   assert.match(remoteStep.run, /trap cleanup_canary_ephemeral_paths EXIT INT TERM/)
   assert.match(remoteStep.run, /mktemp -d/)
   assert.match(remoteStep.run, /printf '%s' "\$\{_CANARY_PASS\}"/)
-  assert.match(remoteStep.run, /unset LIFECYCLE_CANARY_LOGIN_IDENTIFIER LIFECYCLE_CANARY_LOGIN_PASSWORD/)
+  assert.match(remoteStep.run, /printf '%s' "\$\{_STAGING_OWNER_PASS\}"/)
+  assert.match(
+    remoteStep.run,
+    /unset LIFECYCLE_CANARY_LOGIN_IDENTIFIER LIFECYCLE_CANARY_LOGIN_PASSWORD STAGING_OWNER_ADMIN_PASSWORD/,
+  )
   assert.ok(remoteStep.env, 'Run remote action must declare env')
   assert.equal(remoteStep.env.ATTENDANCE_ADMIN_JWT, undefined, 'never inject ATTENDANCE_ADMIN_JWT')
   assert.ok(remoteStep.env.LIFECYCLE_CANARY_LOGIN_IDENTIFIER, 'identifier secret on Run remote action only')
   assert.ok(remoteStep.env.LIFECYCLE_CANARY_LOGIN_PASSWORD, 'password secret on Run remote action only')
+  assert.ok(remoteStep.env.STAGING_OWNER_ADMIN_PASSWORD, 'human password secret on Run remote action only')
   assert.equal(remoteStep.env.SECRETS_DIR, undefined, 'no secrets_dir cross-step handoff')
 
   assert.match(runBody, /CLEAN_REMOTE_SECRETS_DIR/)
@@ -373,9 +421,17 @@ test('workflow materializes secrets inside Run remote action under EXIT trap (no
   assert.match(runBody, /OUTPUT_COLLECTED=1/)
   // Explicit: secrets_dir must not be a step output handoff.
   assert.doesNotMatch(runBody, /secrets_dir=.*GITHUB_OUTPUT/)
-  // bootstrap|alias share materialize gate; no admin.jwt from GHA secrets.
-  assert.match(runBody, /ACTION" == "alias" \|\| "\$ACTION" == "bootstrap"/)
+  // bootstrap|human-bootstrap|alias share materialize gate; no admin.jwt from GHA secrets.
+  assert.match(
+    runBody,
+    /ACTION" == "alias" \|\| "\$ACTION" == "bootstrap" \|\| "\$ACTION" == "human-bootstrap"/,
+  )
   assert.doesNotMatch(runBody, /admin\.jwt/)
+  // Local+remote secret cleanup; never echo secret values.
+  assert.match(runBody, /rm -rf "\$\{CLEAN_LOCAL_SECRETS_DIR\}"/)
+  assert.match(runBody, /rm -rf '\$\{remote_secrets_dir\}'|rm -rf \$\{remote_rm\}/)
+  assert.doesNotMatch(runBody, /echo\s+[\"']?\$\{?(_CANARY_PASS|_STAGING_OWNER_PASS|STAGING_OWNER_ADMIN_PASSWORD)/)
+  assert.doesNotMatch(runBody, /cat\s+[\"']?\$\{?secrets_dir\}.*password/)
 })
 
 test('workflow cleanup never deletes persistent .metasheet2 overrides', () => {
@@ -660,9 +716,10 @@ test('production function: require_migrations_pending_zero_true accepts only tru
 
 // --- P1: pending/deprovision NOT EXECUTABLE; alias is executable ----------------------
 
-test('P1 pending/deprovision route to action_not_executable_on; alias routes to action_alias; bootstrap routes to action_bootstrap', () => {
+test('P1 pending/deprovision route to action_not_executable_on; alias routes to action_alias; bootstrap/human-bootstrap route', () => {
   const source = read(REMOTE_SH)
   assert.match(source, /bootstrap\) action_bootstrap/)
+  assert.match(source, /human-bootstrap\) action_human_bootstrap/)
   assert.match(source, /alias\) action_alias/)
   assert.match(source, /pending\) action_not_executable_on pending/)
   assert.match(source, /deprovision\) action_not_executable_on deprovision/)
@@ -689,19 +746,24 @@ test('P1 pending/deprovision route to action_not_executable_on; alias routes to 
   )
 })
 
-test('P1 action=off and action=alias write lifecycle override; bootstrap/pending/deprovision do not', () => {
+test('P1 action=off and action=alias write lifecycle override; bootstrap/human-bootstrap/pending/deprovision do not', () => {
   const source = read(REMOTE_SH)
   assert.match(source, /off\) action_off/)
   assert.match(source, /bootstrap\) action_bootstrap/)
+  assert.match(source, /human-bootstrap\) action_human_bootstrap/)
   assert.match(source, /alias\) action_alias/)
   assert.match(source, /action_off\(\)/)
   assert.match(source, /action_bootstrap\(\)/)
+  assert.match(source, /action_human_bootstrap\(\)/)
   assert.match(source, /action_alias\(\)/)
   assert.match(source, /write_lifecycle_override "false" "false" "false"/)
   assert.match(source, /write_lifecycle_override "true" "false" "false"/)
   const bootstrapBody = actionBootstrapBody(source)
   assert.doesNotMatch(bootstrapBody, /write_lifecycle_override/)
   assert.doesNotMatch(bootstrapBody, /recreate_backend_only/)
+  const humanBody = actionHumanBootstrapBody(source)
+  assert.doesNotMatch(humanBody, /write_lifecycle_override/)
+  assert.doesNotMatch(humanBody, /recreate_backend_only/)
   const notExec = source.slice(
     source.indexOf('action_not_executable_on()'),
     source.indexOf('\naction_bootstrap()'),
@@ -2555,6 +2617,7 @@ test('workflow exports only safe remote env keys (no raw secret values)', () => 
     'TARGET_MODE',
     'EXPECTED_CURRENT_MODE',
     'DEPLOY_SHA',
+    'BOOTSTRAP_CONFIRMATION',
     'STAGING_DEPLOY_PATH',
     'DEPLOY_PATH',
     'OUTPUT_DIR',
@@ -2566,5 +2629,762 @@ test('workflow exports only safe remote env keys (no raw secret values)', () => 
   assert.doesNotMatch(yaml, /export OWNER_CONFIRM=/)
   assert.doesNotMatch(yaml, /export ATTENDANCE_ADMIN_JWT=/)
   assert.doesNotMatch(yaml, /export LIFECYCLE_CANARY_LOGIN_PASSWORD=/)
+  assert.doesNotMatch(yaml, /export STAGING_OWNER_ADMIN_PASSWORD=/)
   assert.doesNotMatch(yaml, /export CANARY_ADMIN_JWT_FILE=/)
+  // Path-only exports for secret files are allowed.
+  assert.match(yaml, /export CANARY_LOGIN_IDENTIFIER_FILE=/)
+  assert.match(yaml, /export CANARY_LOGIN_PASSWORD_FILE=/)
+  assert.match(yaml, /export STAGING_OWNER_ADMIN_PASSWORD_FILE=/)
+})
+
+// --- human-bootstrap: fixed separate human platform admin -----------------------------
+
+test('human-bootstrap fixed identity markers and confirmation CREATE_STAGING_HUMAN_ADMIN', () => {
+  const source = read(REMOTE_SH)
+  const yaml = read(WORKFLOW)
+  assert.match(source, /HUMAN_OWNER_USERNAME="staging-owner-admin"/)
+  assert.match(source, /HUMAN_OWNER_NAME="Staging Owner Admin"/)
+  assert.match(source, /action_human_bootstrap\(\)/)
+  assert.match(source, /bootstrap_human_platform_admin\(\)/)
+  assert.match(source, /STAGING_OWNER_ADMIN_PASSWORD_FILE/)
+  assert.match(source, /BOOTSTRAP_CONFIRMATION=CREATE_STAGING_HUMAN_ADMIN/)
+  assert.match(yaml, /CREATE_STAGING_HUMAN_ADMIN/)
+  assert.match(yaml, /human-bootstrap/)
+  assert.match(yaml, /staging-owner-admin/)
+})
+
+test('human-bootstrap requires exact SHA, OFF, health, migrations zero; never writes lifecycle env or restarts', () => {
+  const body = actionHumanBootstrapBody(read(REMOTE_SH))
+  assert.match(body, /require_sha/)
+  assert.match(body, /assert_exact_sha/)
+  assert.match(body, /require_migrations_pending_zero_true "\$SNAP_MIGRATIONS_ZERO" "action=human-bootstrap"/)
+  assert.match(body, /require_canary_secret_files "human-bootstrap"/)
+  assert.match(body, /assert_canary_identifier_matches_owner "human-bootstrap"/)
+  assert.match(body, /require_staging_owner_admin_password_file "human-bootstrap"/)
+  assert.match(body, /BOOTSTRAP_CONFIRMATION=CREATE_STAGING_HUMAN_ADMIN/)
+  assert.match(body, /expected_current_mode=off/)
+  assert.match(body, /backend_health_ok must be true before account mutation/)
+  assert.match(body, /live mode must be off/)
+  assert.match(body, /mint_canary_admin_jwt_from_password_login "human-bootstrap"/)
+  assert.match(body, /bootstrap_human_platform_admin/)
+  assert.match(body, /post-human-bootstrap live mode must remain off/)
+  assert.match(body, /all lifecycle flags must remain OFF/)
+  assert.match(body, /post-human-bootstrap backend_health_ok must remain true/)
+  assert.match(body, /require_migrations_pending_zero_true "\$SNAP_MIGRATIONS_ZERO" "action=human-bootstrap post-check"/)
+  assert.match(body, /post-human-bootstrap SHA/)
+  assert.match(body, /post_human_bootstrap_mode_off=true/)
+  assert.match(body, /post_human_bootstrap_flags_off=true/)
+  assert.match(body, /post_human_bootstrap_migrations_zero=true/)
+  assert.match(body, /transition_applied=false/)
+  assert.match(body, /lifecycle_env_write=false/)
+  assert.match(body, /backend_recreate=false/)
+  assert.doesNotMatch(body, /write_lifecycle_override/)
+  assert.doesNotMatch(body, /recreate_backend_only/)
+  assert.doesNotMatch(body, /pin_live_backend_image_for_transition/)
+  // Values-free summary only (no password/token/PII fields).
+  assert.doesNotMatch(body, /password=/)
+  assert.doesNotMatch(body, /identifier=/)
+  assert.doesNotMatch(body, /Authorization/)
+  assert.doesNotMatch(body, /Bearer /)
+})
+
+test('human-bootstrap sequence: mint JWT then create/repair with required reset/access/login/revoke', () => {
+  const body = actionHumanBootstrapBody(read(REMOTE_SH))
+  const mint = body.indexOf('mint_canary_admin_jwt_from_password_login "human-bootstrap"')
+  const txn = body.indexOf('bootstrap_human_platform_admin')
+  const postCapture = body.indexOf('post-human-bootstrap live mode must remain off')
+  assert.ok(mint > 0, 'canary JWT mint required')
+  assert.ok(txn > mint, 'human mutation after canary JWT mint')
+  assert.ok(postCapture > txn, 'post-check after mutation')
+
+  const helper = bootstrapHumanPlatformAdminBody(read(REMOTE_SH))
+  // Create path via POST /api/admin/users without email/mobile.
+  assert.match(helper, /\/api\/admin\/users/)
+  assert.match(helper, /"username": owner_username/)
+  assert.match(helper, /"name": owner_name/)
+  assert.match(helper, /"role": "admin"/)
+  assert.match(helper, /"roleId": "admin"/)
+  const createBody = helper.match(/create_body = \{[\s\S]*?\n    \}/)?.[0] || ''
+  assert.ok(createBody, 'create_body must exist')
+  assert.doesNotMatch(createBody, /"password":/)
+  assert.match(helper, /no email\/mobile|Create path: username\+name\+admin only; no email\/mobile/i)
+  assert.doesNotMatch(helper, /"email":/)
+  assert.doesNotMatch(helper, /"mobile":/)
+  // Safe repair / collision fail-closed.
+  assert.match(helper, /collision_multiple_rows/)
+  assert.match(helper, /identity_name_mismatch/)
+  assert.match(helper, /require_admin_access\(user_id, token, "pre_reset"\)/)
+  assert.match(helper, /f"\{phase\}_access_not_admin"/)
+  assert.match(helper, /identity_contact_not_empty/)
+  assert.match(helper, /outcome = "repaired"/)
+  assert.match(helper, /outcome = "created"/)
+  // Required reset-password forces must_change_password.
+  assert.match(helper, /\/reset-password/)
+  assert.match(helper, /must_change_password|Required reset-password forces must_change_password/)
+  // GET access verifies admin role/isAdmin.
+  assert.match(helper, /\/access/)
+  assert.match(helper, /isAdmin/)
+  assert.match(helper, /access_not_admin/)
+  assert.match(helper, /access_inactive/)
+  assert.match(helper, /access_not_activated/)
+  // Real login verifies passwordChangeRequired + exact username.
+  assert.match(helper, /\/api\/auth\/login/)
+  assert.match(helper, /passwordChangeRequired/)
+  assert.match(helper, /login_password_change_required_missing/)
+  assert.match(helper, /login_username_mismatch/)
+  // Required revoke-sessions with canary JWT (not human token).
+  assert.match(helper, /\/revoke-sessions/)
+  assert.match(helper, /lifecycle_canary_human_bootstrap/)
+  assert.match(helper, /revoke_proof_missing/)
+  // Existing-account repair proves RBAC ownership before reset. Both paths prove it
+  // again after reset, then login and revoke the proof session.
+  const preAccessIdx = helper.indexOf('require_admin_access(user_id, token, "pre_reset")')
+  const resetIdx = helper.indexOf('f"/api/admin/users/{urllib.parse.quote(user_id, safe=\'\')}/reset-password"')
+  const postAccessIdx = helper.indexOf('require_admin_access(user_id, token, "post_reset")')
+  const loginIdx = helper.indexOf('base.rstrip("/") + "/api/auth/login"')
+  const revokeIdx = helper.indexOf('f"/api/admin/users/{urllib.parse.quote(user_id, safe=\'\')}/revoke-sessions"')
+  assert.ok(preAccessIdx > 0 && preAccessIdx < resetIdx, 'existing-account access proof before reset-password')
+  assert.ok(postAccessIdx > resetIdx, 'post-write access proof after reset-password')
+  assert.ok(loginIdx > postAccessIdx, 'login after post-write access proof')
+  assert.ok(revokeIdx > loginIdx, 'revoke-sessions after login proof')
+  // Secrets: password from file path only; never logged.
+  assert.match(helper, /STAGING_OWNER_ADMIN_PASSWORD_FILE|pass_path/)
+  assert.match(helper, /values never logged|never logged/i)
+  assert.doesNotMatch(helper, /print\(password\)|log\(password\)|echo .*password/i)
+  assert.doesNotMatch(helper, /sys\.stdout\.write\(password\)/)
+})
+
+test('human-bootstrap workflow wiring demotes STAGING_OWNER_ADMIN_PASSWORD and cleans local+remote files', () => {
+  const yaml = read(WORKFLOW)
+  const doc = loadYaml(yaml)
+  const remoteStep = doc.jobs.run.steps.find((s) => s.name === 'Run remote action')
+  assert.ok(remoteStep?.env?.STAGING_OWNER_ADMIN_PASSWORD)
+  assert.match(
+    String(remoteStep.env.STAGING_OWNER_ADMIN_PASSWORD),
+    /inputs\.action == 'human-bootstrap'.*secrets\.STAGING_OWNER_ADMIN_PASSWORD/,
+  )
+  assert.match(remoteStep.run, /_STAGING_OWNER_PASS="\$\{STAGING_OWNER_ADMIN_PASSWORD-\}"/)
+  assert.match(
+    remoteStep.run,
+    /unset LIFECYCLE_CANARY_LOGIN_IDENTIFIER LIFECYCLE_CANARY_LOGIN_PASSWORD STAGING_OWNER_ADMIN_PASSWORD/,
+  )
+  assert.match(remoteStep.run, /printf '%s' "\$\{_STAGING_OWNER_PASS\}"/)
+  assert.match(remoteStep.run, /staging-owner-admin\.password/)
+  assert.match(remoteStep.run, /chmod 600 .*staging-owner-admin\.password|chmod 600 "\$\{secrets_dir\}\/staging-owner-admin\.password"/)
+  assert.match(remoteStep.run, /export STAGING_OWNER_ADMIN_PASSWORD_FILE=/)
+  assert.match(remoteStep.run, /human-bootstrap requires STAGING_OWNER_ADMIN_PASSWORD/)
+  // Cleanup both local and remote secret dirs.
+  assert.match(remoteStep.run, /CLEAN_LOCAL_SECRETS_DIR/)
+  assert.match(remoteStep.run, /CLEAN_REMOTE_SECRETS_DIR/)
+  assert.match(remoteStep.run, /rm -rf "\$\{CLEAN_LOCAL_SECRETS_DIR\}"/)
+  assert.match(remoteStep.run, /rm -rf '\$\{remote_secrets_dir\}'|if \[\[ -n '\$\{remote_secrets_dir\}' \]\]; then rm -rf/)
+  // Never log secret.
+  assert.doesNotMatch(remoteStep.run, /echo .*_STAGING_OWNER_PASS/)
+  assert.doesNotMatch(remoteStep.run, /(?:echo|printf)[^\n]*\$\{?STAGING_OWNER_ADMIN_PASSWORD\}?/)
+  assert.doesNotMatch(yaml, /export STAGING_OWNER_ADMIN_PASSWORD=/)
+})
+
+test('human-bootstrap enforces the backend password policy before any account mutation', () => {
+  const helper = bootstrapHumanPlatformAdminBody(read(REMOTE_SH))
+  const policyEnd = helper.indexOf('# 1) Lookup by username query')
+  assert.ok(policyEnd > 0, 'password policy must precede the first API lookup')
+  const policy = helper.slice(0, policyEnd)
+  assert.match(policy, /password != password\.strip\(\)/)
+  assert.match(policy, /len\(password\) < 8/)
+  assert.match(policy, /len\(password\) > 128/)
+  assert.match(policy, /char\.islower\(\)/)
+  assert.match(policy, /char\.isupper\(\)/)
+  assert.match(policy, /char\.isdigit\(\)/)
+  for (const weak of ['password', '123456', 'qwerty', 'abc123', 'letmein', 'admin']) {
+    assert.match(policy, new RegExp(`"${weak}"`))
+  }
+})
+
+test('FUNCTIONAL harness: action_human_bootstrap order gates then mint then mutation then reassert; no env write', () => {
+  const sha = 'c'.repeat(40)
+  const result = spawnSync(
+    'bash',
+    [
+      '-o',
+      'pipefail',
+      '-c',
+      `source "$1"
+       CALL_LOG=()
+       record() { CALL_LOG+=("\$1"); }
+       require_sha() { record require_sha; }
+       require_canary_secret_files() { record require_secrets; }
+       assert_canary_identifier_matches_owner() { record assert_owner; }
+       require_staging_owner_admin_password_file() { record require_owner_pass; }
+       capture_live_snapshot() {
+         record capture
+         SNAP_ALIAS=false; SNAP_PENDING=false; SNAP_DEPROV=false; SNAP_MODE=off
+         SNAP_BUILD_SHA="$DEPLOY_SHA"; SNAP_ALIAS_READY=true; SNAP_CAN_ENABLE_ALIAS=true
+         SNAP_MIGRATIONS_ZERO=true; SNAP_HEALTH_OK=true
+       }
+       assert_exact_sha() { record assert_sha; }
+       require_migrations_pending_zero_true() { record require_mig; }
+       mint_canary_admin_jwt_from_password_login() {
+         record "mint:\$1"
+         CANARY_ADMIN_JWT_FILE=/tmp/lifecycle-human-bootstrap-jwt
+         printf 'jwt' > "\$CANARY_ADMIN_JWT_FILE"
+         return 0
+       }
+       bootstrap_human_platform_admin() { record human_txn; HUMAN_BOOTSTRAP_OUTCOME=created; return 0; }
+       write_lifecycle_override() { record "write:\$1:\$2:\$3"; }
+       recreate_backend_only() { record recreate; return 0; }
+       write_status_artifact() { record write_status; }
+       OUTPUT_DIR="$2"
+       mkdir -p "$OUTPUT_DIR"
+       DEPLOY_SHA="$3"
+       EXPECTED_CURRENT_MODE=off
+       BOOTSTRAP_CONFIRMATION=CREATE_STAGING_HUMAN_ADMIN
+       ACTION=human-bootstrap
+       action_human_bootstrap
+       printf '%s\\n' "\${CALL_LOG[@]}"`,
+      'bash',
+      REMOTE_SH,
+      '/tmp/lifecycle-canary-human-bootstrap-success',
+      sha,
+    ],
+    {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        ACTION: 'human-bootstrap',
+        OUTPUT_DIR: '/tmp/lifecycle-canary-human-bootstrap-success',
+        RUN_STAMP: 'contract',
+        LIFECYCLE_CANARY_SOURCE_ONLY: 'true',
+        DEPLOY_SHA: sha,
+        EXPECTED_CURRENT_MODE: 'off',
+        BOOTSTRAP_CONFIRMATION: 'CREATE_STAGING_HUMAN_ADMIN',
+      },
+    },
+  )
+  assert.equal(result.status, 0, result.stderr + result.stdout)
+  const lines = result.stdout.trim().split('\n')
+  const idx = (name) => {
+    const i = lines.indexOf(name)
+    assert.ok(i >= 0, `missing call ${name} in ${lines.join(',')}`)
+    return i
+  }
+  assert.ok(idx('require_sha') < idx('require_secrets'))
+  assert.ok(idx('require_secrets') < idx('assert_owner'))
+  assert.ok(idx('assert_owner') < idx('require_owner_pass'))
+  assert.ok(idx('require_mig') < idx('mint:human-bootstrap'))
+  assert.ok(idx('mint:human-bootstrap') < idx('human_txn'))
+  const humanI = idx('human_txn')
+  const secondCapture = lines.indexOf('capture', humanI + 1)
+  assert.ok(secondCapture > humanI, 'post-human-bootstrap recapture required')
+  const secondSha = lines.indexOf('assert_sha', humanI + 1)
+  assert.ok(secondSha > secondCapture, 'post-human-bootstrap SHA reassert after recapture')
+  assert.ok(!lines.some((l) => l.startsWith('write:')), 'human-bootstrap must not write lifecycle override')
+  assert.ok(!lines.includes('recreate'), 'human-bootstrap must not recreate backend')
+})
+
+test('FUNCTIONAL: bootstrap_human_platform_admin create path orders reset/access/login/revoke', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'lifecycle-human-bootstrap-create-'))
+  const jwtFile = join(dir, 'admin.jwt')
+  const passFile = join(dir, 'staging-owner-admin.password')
+  const callsFile = join(dir, 'calls.txt')
+  writeFileSync(jwtFile, 'canary-jwt-token', { mode: 0o600 })
+  writeFileSync(passFile, 'HumanPass9Xyz', { mode: 0o600 })
+  writeFileSync(callsFile, '', { mode: 0o600 })
+  const serverPy = `
+import json, http.server, socketserver, pathlib
+calls = pathlib.Path(${JSON.stringify(callsFile)})
+class H(http.server.BaseHTTPRequestHandler):
+    def _read(self):
+        n = int(self.headers.get('Content-Length', '0'))
+        return self.rfile.read(n) if n else b''
+    def _write(self, code, obj):
+        body = json.dumps(obj).encode('utf-8')
+        self.send_response(code)
+        self.send_header('Content-Type', 'application/json')
+        self.send_header('Content-Length', str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+    def do_GET(self):
+        calls.write_text(calls.read_text() + f'GET {self.path}\\n', encoding='utf-8')
+        auth = self.headers.get('Authorization', '')
+        assert auth == 'Bearer canary-jwt-token'
+        if self.path.startswith('/api/admin/users?') and 'staging-owner-admin' in self.path:
+            return self._write(200, {'ok': True, 'data': {'items': [], 'total': 0}})
+        if self.path.endswith('/access'):
+            return self._write(200, {
+                'ok': True,
+                'data': {
+                    'user': {
+                        'id': 'user-new',
+                        'username': 'staging-owner-admin',
+                        'name': 'Staging Owner Admin',
+                        'email': None,
+                        'mobile': None,
+                        'role': 'admin',
+                        'is_admin': True,
+                        'is_active': True,
+                        'activationStatus': 'activated',
+                    },
+                    'roles': ['admin'],
+                    'isAdmin': True,
+                },
+            })
+        self._write(404, {'ok': False})
+    def do_POST(self):
+        raw = self._read()
+        calls.write_text(calls.read_text() + f'POST {self.path}\\n', encoding='utf-8')
+        auth = self.headers.get('Authorization', '')
+        if self.path == '/api/auth/login':
+            body = json.loads(raw.decode('utf-8'))
+            assert body['identifier'] == 'staging-owner-admin'
+            assert body['password'] == 'HumanPass9Xyz'
+            return self._write(200, {
+                'success': True,
+                'data': {
+                    'token': 'human-session-jwt',
+                    'passwordChangeRequired': True,
+                    'user': {'username': 'staging-owner-admin', 'name': 'Staging Owner Admin'},
+                },
+            })
+        assert auth == 'Bearer canary-jwt-token'
+        if self.path == '/api/admin/users':
+            body = json.loads(raw.decode('utf-8'))
+            assert body.get('username') == 'staging-owner-admin'
+            assert body.get('name') == 'Staging Owner Admin'
+            assert body.get('role') == 'admin'
+            assert body.get('roleId') == 'admin'
+            assert 'password' not in body
+            assert 'email' not in body
+            assert 'mobile' not in body
+            return self._write(200, {
+                'ok': True,
+                'data': {
+                    'user': {
+                        'id': 'user-new',
+                        'username': 'staging-owner-admin',
+                        'name': 'Staging Owner Admin',
+                        'email': None,
+                        'mobile': None,
+                        'role': 'admin',
+                        'is_admin': True,
+                    },
+                },
+            })
+        if self.path.endswith('/reset-password'):
+            body = json.loads(raw.decode('utf-8'))
+            assert body.get('password') == 'HumanPass9Xyz'
+            return self._write(200, {'ok': True, 'data': {'userId': 'user-new'}})
+        if self.path.endswith('/revoke-sessions'):
+            return self._write(200, {
+                'ok': True,
+                'data': {'userId': 'user-new', 'revokedAfter': '2026-08-11T00:00:00.000Z'},
+            })
+        self._write(404, {'ok': False})
+    def log_message(self, *args):
+        return
+with socketserver.TCPServer(('127.0.0.1', 0), H) as httpd:
+    print(httpd.server_address[1], flush=True)
+    for _ in range(6):
+        httpd.handle_request()
+`
+  const serverProc = spawn('python3', ['-c', serverPy], {
+    stdio: ['ignore', 'pipe', 'pipe'],
+    env: process.env,
+  })
+  const serverDone = collectChild(serverProc, 10000)
+  try {
+    const port = await new Promise((resolve, reject) => {
+      let buf = ''
+      const timer = setTimeout(() => reject(new Error('port timeout')), 3000)
+      const onData = (chunk) => {
+        buf += chunk.toString('utf8')
+        const line = buf.trim().split(/\r?\n/).filter(Boolean).pop() || ''
+        if (/^\d+$/.test(line)) {
+          clearTimeout(timer)
+          serverProc.stdout.off('data', onData)
+          resolve(line)
+        }
+      }
+      serverProc.stdout.on('data', onData)
+    })
+    const result = spawnSync(
+      'bash',
+      [
+        '-o',
+        'pipefail',
+        '-c',
+        `source "$1"
+         CANARY_ADMIN_JWT_FILE="$2"
+         STAGING_OWNER_ADMIN_PASSWORD_FILE="$3"
+         STAGING_API_BASE_URL="http://127.0.0.1:$4"
+         bootstrap_human_platform_admin
+         printf 'OUTCOME=%s\\n' "$HUMAN_BOOTSTRAP_OUTCOME"`,
+        'bash',
+        REMOTE_SH,
+        jwtFile,
+        passFile,
+        port,
+      ],
+      {
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          ACTION: 'human-bootstrap',
+          OUTPUT_DIR: dir,
+          RUN_STAMP: 'contract-human-create',
+          LIFECYCLE_CANARY_SOURCE_ONLY: 'true',
+        },
+        timeout: 10000,
+      },
+    )
+    assert.equal(result.status, 0, result.stderr + result.stdout)
+    assert.match(result.stdout, /OUTCOME=created/)
+    assert.match(result.stdout, /human-bootstrap OK outcome=created/)
+    const calls = readFileSync(callsFile, 'utf8')
+    assert.match(calls, /GET \/api\/admin\/users\?/)
+    assert.match(calls, /POST \/api\/admin\/users\n/)
+    assert.match(calls, /POST \/api\/admin\/users\/user-new\/reset-password/)
+    assert.match(calls, /GET \/api\/admin\/users\/user-new\/access/)
+    assert.match(calls, /POST \/api\/auth\/login/)
+    assert.match(calls, /POST \/api\/admin\/users\/user-new\/revoke-sessions/)
+    const order = [
+      calls.indexOf('GET /api/admin/users?'),
+      calls.indexOf('POST /api/admin/users\n'),
+      calls.indexOf('POST /api/admin/users/user-new/reset-password'),
+      calls.indexOf('GET /api/admin/users/user-new/access'),
+      calls.indexOf('POST /api/auth/login'),
+      calls.indexOf('POST /api/admin/users/user-new/revoke-sessions'),
+    ]
+    for (let i = 1; i < order.length; i += 1) {
+      assert.ok(order[i] > order[i - 1], `call order broken at ${i}: ${calls}`)
+    }
+    await Promise.race([serverDone, new Promise((r) => setTimeout(r, 500))])
+  } finally {
+    if (!serverProc.killed && serverProc.exitCode === null) {
+      try {
+        serverProc.kill('SIGKILL')
+      } catch {
+        // ignore
+      }
+    }
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('FUNCTIONAL: bootstrap_human_platform_admin safe repair and collision rejection', async () => {
+  async function runScenario(items, expectOk, expectNote, options = {}) {
+    const {
+      accessAdmin = true,
+      accessActive = true,
+      accessActivationStatus = 'activated',
+      passwordChangeRequired = true,
+      resetCode = 200,
+      revokeCode = 200,
+      revokeProof = true,
+    } = options
+    const dir = mkdtempSync(join(tmpdir(), 'lifecycle-human-bootstrap-repair-'))
+    const jwtFile = join(dir, 'admin.jwt')
+    const passFile = join(dir, 'staging-owner-admin.password')
+    writeFileSync(jwtFile, 'canary-jwt-token', { mode: 0o600 })
+    writeFileSync(passFile, 'HumanPass9Xyz', { mode: 0o600 })
+    const serverPy = `
+import json, http.server, socketserver
+items = json.loads(${JSON.stringify(JSON.stringify(items))})
+access_admin = ${accessAdmin ? 'True' : 'False'}
+access_active = ${accessActive ? 'True' : 'False'}
+access_activation_status = ${JSON.stringify(accessActivationStatus)}
+password_change_required = ${passwordChangeRequired ? 'True' : 'False'}
+reset_code = ${Number(resetCode)}
+revoke_code = ${Number(revokeCode)}
+revoke_proof = ${revokeProof ? 'True' : 'False'}
+class H(http.server.BaseHTTPRequestHandler):
+    def _read(self):
+        n = int(self.headers.get('Content-Length', '0'))
+        return self.rfile.read(n) if n else b''
+    def _write(self, code, obj):
+        body = json.dumps(obj).encode('utf-8')
+        self.send_response(code)
+        self.send_header('Content-Type', 'application/json')
+        self.send_header('Content-Length', str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+    def do_GET(self):
+        if self.path.startswith('/api/admin/users?'):
+            return self._write(200, {'ok': True, 'data': {'items': items, 'total': len(items)}})
+        if '/access' in self.path:
+            u = items[0]
+            access_user = dict(u)
+            access_user['is_active'] = access_active
+            access_user['activationStatus'] = access_activation_status
+            return self._write(200, {
+                'ok': True,
+                'data': {
+                    'user': access_user,
+                    'roles': ['admin'] if access_admin else [],
+                    'isAdmin': access_admin,
+                },
+            })
+        self._write(404, {'ok': False})
+    def do_POST(self):
+        if self.path == '/api/auth/login':
+            return self._write(200, {
+                'success': True,
+                'data': {
+                    'token': 't',
+                    'passwordChangeRequired': password_change_required,
+                    'user': {'username': 'staging-owner-admin'},
+                },
+            })
+        if self.path.endswith('/reset-password'):
+            return self._write(reset_code, {'ok': reset_code == 200, 'data': {}})
+        if self.path.endswith('/revoke-sessions'):
+            data = {
+                'revokedAfter': '2026-08-11T00:00:00.000Z' if revoke_proof else None,
+            }
+            return self._write(revoke_code, {'ok': revoke_code == 200, 'data': data})
+        if self.path == '/api/admin/users':
+            return self._write(500, {'ok': False})
+        self._write(404, {'ok': False})
+    def log_message(self, *args):
+        return
+with socketserver.TCPServer(('127.0.0.1', 0), H) as httpd:
+    print(httpd.server_address[1], flush=True)
+    for _ in range(8):
+        httpd.handle_request()
+`
+    const serverProc = spawn('python3', ['-c', serverPy], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: process.env,
+    })
+    const serverDone = collectChild(serverProc, 10000)
+    try {
+      const port = await new Promise((resolve, reject) => {
+        let buf = ''
+        const timer = setTimeout(() => reject(new Error('port timeout')), 3000)
+        const onData = (chunk) => {
+          buf += chunk.toString('utf8')
+          const line = buf.trim().split(/\r?\n/).filter(Boolean).pop() || ''
+          if (/^\d+$/.test(line)) {
+            clearTimeout(timer)
+            serverProc.stdout.off('data', onData)
+            resolve(line)
+          }
+        }
+        serverProc.stdout.on('data', onData)
+      })
+      const result = spawnSync(
+        'bash',
+        [
+          '-o',
+          'pipefail',
+          '-c',
+          `source "$1"
+           CANARY_ADMIN_JWT_FILE="$2"
+           STAGING_OWNER_ADMIN_PASSWORD_FILE="$3"
+           STAGING_API_BASE_URL="http://127.0.0.1:$4"
+           if bootstrap_human_platform_admin; then
+             printf 'ok|%s' "$HUMAN_BOOTSTRAP_OUTCOME"
+           else
+             printf 'fail|%s' "$HUMAN_BOOTSTRAP_OUTCOME"
+           fi`,
+          'bash',
+          REMOTE_SH,
+          jwtFile,
+          passFile,
+          port,
+        ],
+        {
+          encoding: 'utf8',
+          env: {
+            ...process.env,
+            ACTION: 'human-bootstrap',
+            OUTPUT_DIR: dir,
+            RUN_STAMP: 'contract-human-repair',
+            LIFECYCLE_CANARY_SOURCE_ONLY: 'true',
+          },
+          timeout: 10000,
+        },
+      )
+      assert.equal(result.status, 0, result.stderr + result.stdout)
+      if (expectOk) {
+        assert.match(result.stdout, new RegExp(`(?:^|\\n)ok\\|${expectNote}`))
+      } else {
+        assert.match(result.stdout, new RegExp(`(?:^|\\n)fail\\|${expectNote}`))
+      }
+      await Promise.race([serverDone, new Promise((r) => setTimeout(r, 500))])
+    } finally {
+      if (!serverProc.killed && serverProc.exitCode === null) {
+        try {
+          serverProc.kill('SIGKILL')
+        } catch {
+          // ignore
+        }
+      }
+      rmSync(dir, { recursive: true, force: true })
+    }
+  }
+
+  await runScenario(
+    [
+      {
+        id: 'owned-1',
+        username: 'staging-owner-admin',
+        name: 'Staging Owner Admin',
+        email: null,
+        mobile: null,
+        role: 'admin',
+        is_admin: true,
+      },
+    ],
+    true,
+    'repaired',
+  )
+  await runScenario(
+    [
+      {
+        id: 'a',
+        username: 'staging-owner-admin',
+        name: 'Staging Owner Admin',
+        email: null,
+        mobile: null,
+        role: 'admin',
+        is_admin: true,
+      },
+      {
+        id: 'b',
+        username: 'staging-owner-admin',
+        name: 'Staging Owner Admin',
+        email: null,
+        mobile: null,
+        role: 'admin',
+        is_admin: true,
+      },
+    ],
+    false,
+    'collision_multiple_rows',
+  )
+  await runScenario(
+    [
+      {
+        id: 'x',
+        username: 'staging-owner-admin',
+        name: 'Wrong Name',
+        email: null,
+        mobile: null,
+        role: 'admin',
+        is_admin: true,
+      },
+    ],
+    false,
+    'identity_name_mismatch',
+  )
+  await runScenario(
+    [
+      {
+        id: 'y',
+        username: 'staging-owner-admin',
+        name: 'Staging Owner Admin',
+        email: null,
+        mobile: null,
+        role: 'user',
+        is_admin: false,
+      },
+    ],
+    false,
+    'pre_reset_access_not_admin',
+    { accessAdmin: false },
+  )
+  const ownedAdmin = [{
+    id: 'owned-proof',
+    username: 'staging-owner-admin',
+    name: 'Staging Owner Admin',
+    email: null,
+    mobile: null,
+    role: 'admin',
+    is_admin: true,
+  }]
+  await runScenario(ownedAdmin, false, 'reset_http_503', { resetCode: 503 })
+  await runScenario(ownedAdmin, false, 'pre_reset_access_inactive', {
+    accessActive: false,
+  })
+  await runScenario(ownedAdmin, false, 'pre_reset_access_not_activated', {
+    accessActivationStatus: 'pending_activation',
+  })
+  await runScenario(ownedAdmin, false, 'login_password_change_required_missing', {
+    passwordChangeRequired: false,
+  })
+  await runScenario(ownedAdmin, false, 'revoke_http_503', { revokeCode: 503 })
+  await runScenario(ownedAdmin, false, 'revoke_proof_missing', { revokeProof: false })
+})
+
+test('MUTATION: human-bootstrap create request carrying operator password turns contract red', () => {
+  const helper = bootstrapHumanPlatformAdminBody(read(REMOTE_SH))
+  const mutated = helper.replace(
+    '"roleId": "admin",',
+    '"roleId": "admin",\n        "password": password,',
+  )
+  const createBody = mutated.match(/create_body = \{[\s\S]*?\n    \}/)?.[0] || ''
+  assert.throws(() => assert.doesNotMatch(createBody, /"password":/))
+})
+
+test('MUTATION: human-bootstrap dropping reset-password turns contract red', () => {
+  const helper = bootstrapHumanPlatformAdminBody(read(REMOTE_SH))
+  const mutated = helper.replaceAll('/reset-password', '/no-reset')
+  let failed = false
+  try {
+    assert.match(mutated, /\/reset-password/)
+  } catch {
+    failed = true
+  }
+  assert.equal(failed, true)
+})
+
+test('MUTATION: human-bootstrap dropping login passwordChangeRequired check turns contract red', () => {
+  const helper = bootstrapHumanPlatformAdminBody(read(REMOTE_SH))
+  const mutated = helper.replaceAll('passwordChangeRequired', 'passwordChangeIgnored')
+  let failed = false
+  try {
+    assert.match(mutated, /passwordChangeRequired/)
+  } catch {
+    failed = true
+  }
+  assert.equal(failed, true)
+})
+
+test('MUTATION: human-bootstrap dropping revoke-sessions turns contract red', () => {
+  const helper = bootstrapHumanPlatformAdminBody(read(REMOTE_SH))
+  const mutated = helper.replaceAll('/revoke-sessions', '/no-revoke')
+  let failed = false
+  try {
+    assert.match(mutated, /\/revoke-sessions/)
+  } catch {
+    failed = true
+  }
+  assert.equal(failed, true)
+})
+
+test('MUTATION: human-bootstrap writing lifecycle override turns no-env-write contract red', () => {
+  const original = actionHumanBootstrapBody(read(REMOTE_SH))
+  const mutated = `${original}\n  write_lifecycle_override "true" "false" "false"\n`
+  let failed = false
+  try {
+    assert.doesNotMatch(mutated, /write_lifecycle_override/)
+  } catch {
+    failed = true
+  }
+  assert.equal(failed, true)
+})
+
+test('MUTATION: human-bootstrap skipping canary JWT mint turns contract red', () => {
+  const body = actionHumanBootstrapBody(read(REMOTE_SH))
+  const mutated = body.replace(
+    'mint_canary_admin_jwt_from_password_login "human-bootstrap"',
+    'true # mint removed',
+  )
+  let failed = false
+  try {
+    assert.match(mutated, /mint_canary_admin_jwt_from_password_login "human-bootstrap"/)
+  } catch {
+    failed = true
+  }
+  assert.equal(failed, true)
 })

--- a/scripts/ops/dingtalk-lifecycle-staging-canary-remote.sh
+++ b/scripts/ops/dingtalk-lifecycle-staging-canary-remote.sh
@@ -18,6 +18,21 @@
 #                BOTH markers fails closed. Proves real password login.
 #                NEVER writes lifecycle env flags; never touches arbitrary admins.
 #                Requires login identifier/password secret files only (chmod 600).
+#   human-bootstrap — staging-only create/repair of a SEPARATE fixed human
+#                platform administrator (username staging-owner-admin, name
+#                Staging Owner Admin, no email/mobile). Authenticates admin API
+#                with the existing fixed canary admin JWT (minted from canary
+#                password login). Human password arrives only as chmod-600
+#                STAGING_OWNER_ADMIN_PASSWORD_FILE (path only; never logged).
+#                Lookup exact-matches username; fail closed on multiple rows or
+#                identity/name/admin mismatch. Create via POST /api/admin/users
+#                (no email/mobile) or idempotent reset of the owned match only;
+#                then required POST reset-password (must_change_password), GET
+#                access (admin role/isAdmin), real POST login
+#                (passwordChangeRequired + exact username), then required
+#                revoke-sessions with canary JWT. Never writes lifecycle env;
+#                never restarts. Post-check: exact SHA, health, migrations-zero,
+#                all flags OFF. Artifacts are values-free booleans/enums only.
 #   alias      — TRANSIENT secret-backed alias cutover canary.
 #                Success requires/proves OFF (post-rollback mode+login).
 #                Failure restores the OFF override before failing (post-write).
@@ -42,12 +57,12 @@
 # HARD SAFETY RAILS:
 #   * Staging compose + metasheet-staging-* containers only; no prod fallback.
 #   * migrations_pending_zero must be exactly "true" for preflight_ok and for
-#     action=off / action=alias / action=bootstrap (unknown is a fail, never
-#     treated as success).
+#     action=off / action=alias / action=bootstrap / action=human-bootstrap
+#     (unknown is a fail, never treated as success).
 #   * action=off|alias: recreate backend only; prove postgres/redis IDs unchanged;
 #     require backend health true after restart; prove exact mode; restore
 #     previous override and re-recreate on any failure after the write.
-#   * action=bootstrap: no lifecycle env write; no backend recreate.
+#   * action=bootstrap|human-bootstrap: no lifecycle env write; no backend recreate.
 #   * multi-on: status/preflight report and fail closed; action=off still clears
 #     the exact three flags (does not die in derive_mode before clear).
 #   * Artifacts never contain env values, credentials, subject ids, or PII —
@@ -60,10 +75,11 @@ set -euo pipefail
 log() { echo "[lifecycle-canary] $*"; }
 fail() { echo "[lifecycle-canary][error] $*" >&2; exit 1; }
 
-ACTION="${ACTION:?ACTION is required (status|preflight|off|bootstrap|alias|pending|deprovision)}"
+ACTION="${ACTION:?ACTION is required (status|preflight|off|bootstrap|human-bootstrap|alias|pending|deprovision)}"
 TARGET_MODE="${TARGET_MODE:-}"
 EXPECTED_CURRENT_MODE="${EXPECTED_CURRENT_MODE:-}"
 DEPLOY_SHA="${DEPLOY_SHA:-}"
+BOOTSTRAP_CONFIRMATION="${BOOTSTRAP_CONFIRMATION:-}"
 STAGING_DEPLOY_PATH="${STAGING_DEPLOY_PATH:-metasheet2-dingtalk-staging}"
 DEPLOY_PATH="${DEPLOY_PATH:-metasheet2}"
 OUTPUT_DIR="${OUTPUT_DIR:?OUTPUT_DIR is required}"
@@ -73,15 +89,24 @@ RUN_STAMP="${RUN_STAMP:?RUN_STAMP is required (workflow run id marker)}"
 # Workflow materializes chmod-600 identifier/password into the per-run remote dir.
 # Alias mints CANARY_ADMIN_JWT_FILE after successful pre-login (never from
 # secrets.ATTENDANCE_ADMIN_JWT). Bootstrap does not consume a JWT file.
+# human-bootstrap mints JWT from canary login for admin API, and consumes a
+# separate STAGING_OWNER_ADMIN_PASSWORD_FILE for the human admin password only.
 CANARY_ADMIN_JWT_FILE="${CANARY_ADMIN_JWT_FILE:-}"
 CANARY_LOGIN_IDENTIFIER_FILE="${CANARY_LOGIN_IDENTIFIER_FILE:-}"
 CANARY_LOGIN_PASSWORD_FILE="${CANARY_LOGIN_PASSWORD_FILE:-}"
+STAGING_OWNER_ADMIN_PASSWORD_FILE="${STAGING_OWNER_ADMIN_PASSWORD_FILE:-}"
 
 # Fixed dedicated lifecycle canary admin ownership markers (values-free constants).
 # Create/repair ONLY this (email, id) pair. Any email/id collision that does not
 # match BOTH markers fails closed — never mutates an arbitrary existing admin.
 CANARY_OWNER_EMAIL="lifecycle-canary@staging.invalid"
 CANARY_OWNER_USER_ID="6c1fe000-ca0a-4000-8000-1ec0c1e00001"
+
+# Fixed SEPARATE human platform administrator identity (values-free constants).
+# Username ownership only (no email/mobile). Collision / identity mismatch fails
+# closed — never mutates an arbitrary existing admin.
+HUMAN_OWNER_USERNAME="staging-owner-admin"
+HUMAN_OWNER_NAME="Staging Owner Admin"
 
 # Intentionally ignored: not a real verifier path. Kept empty so accidental
 # exports cannot be mistaken for canary completion evidence.
@@ -387,7 +412,8 @@ probe_migration_pending_zero() {
 }
 
 require_migrations_pending_zero_true() {
-  # Load-bearing for every transition (action=off|alias) and for preflight_ok.
+  # Load-bearing for every transition (action=off|alias) and for
+  # action=bootstrap|human-bootstrap and for preflight_ok.
   local v="$1" context="$2"
   if [[ "$v" == "true" ]]; then
     return 0
@@ -412,6 +438,16 @@ require_canary_secret_files() {
     [[ -s "$path" ]] || fail "action=${context} secret file empty for ${f}"
   done
   log "${context} canary login secret files present (paths only; values never logged)"
+}
+
+require_staging_owner_admin_password_file() {
+  # Human admin password path only — never export or log the value.
+  local path="${STAGING_OWNER_ADMIN_PASSWORD_FILE:-}"
+  local context="${1:-human-bootstrap}"
+  [[ -n "$path" ]] || fail "action=${context} requires STAGING_OWNER_ADMIN_PASSWORD_FILE (chmod-600 secret file path); no auto-selection"
+  [[ -f "$path" ]] || fail "action=${context} secret file missing for STAGING_OWNER_ADMIN_PASSWORD_FILE"
+  [[ -s "$path" ]] || fail "action=${context} secret file empty for STAGING_OWNER_ADMIN_PASSWORD_FILE"
+  log "${context} staging owner admin password file present (path only; values never logged)"
 }
 
 # Identifier secret file (app trim) must equal the fixed ownership email marker.
@@ -932,6 +968,303 @@ except Exception as e:
     raise SystemExit(2)
 sys.stdout.write(f"{code}\n{body}")
 PY
+}
+
+# Staging-only create/repair of the FIXED separate human platform admin via admin API.
+# Auth: short-lived canary admin JWT file (minted from canary password login).
+# Human password: STAGING_OWNER_ADMIN_PASSWORD_FILE only (exact bytes into API; never logged).
+# Sequence (values-free reason enums only on stdout):
+#   list → exact username match → create OR safe repair gate → required reset-password
+#   → GET access (admin role/isAdmin) → real login (passwordChangeRequired + username)
+#   → required revoke-sessions (canary JWT).
+# Fail closed: multiple exact matches, identity/name/admin mismatch, missing proofs.
+# Sets HUMAN_BOOTSTRAP_OUTCOME to created|repaired|reason enum.
+bootstrap_human_platform_admin() {
+  local result ok note python_tmp
+  HUMAN_BOOTSTRAP_OUTCOME="unset"
+  [[ -n "${CANARY_ADMIN_JWT_FILE:-}" && -f "${CANARY_ADMIN_JWT_FILE}" && -s "${CANARY_ADMIN_JWT_FILE}" ]] \
+    || fail "action=human-bootstrap requires canary admin JWT file (minted from password login)"
+  [[ -n "${STAGING_OWNER_ADMIN_PASSWORD_FILE:-}" && -f "${STAGING_OWNER_ADMIN_PASSWORD_FILE}" && -s "${STAGING_OWNER_ADMIN_PASSWORD_FILE}" ]] \
+    || fail "action=human-bootstrap requires STAGING_OWNER_ADMIN_PASSWORD_FILE path"
+
+  # Keep the heredoc outside command substitution. Older deploy-host Bash versions
+  # parse Python parentheses inside a nested heredoc as shell syntax. The temporary
+  # source contains no credentials; only chmod-600 secret file paths are argv.
+  python_tmp="$(mktemp "${TMPDIR:-/tmp}/lifecycle-human-bootstrap.XXXXXX.py")"
+  chmod 600 "$python_tmp"
+  cat >"$python_tmp" <<'PY'
+import json
+import pathlib
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+
+jwt_path, pass_path, base, owner_username, owner_name = sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4], sys.argv[5]
+
+
+def emit(ok, note):
+    sys.stdout.write(("true" if ok else "false") + "|" + note)
+    raise SystemExit(0)
+
+
+def read_token():
+    try:
+        token = pathlib.Path(jwt_path).read_text(encoding="utf-8").strip()
+    except Exception:
+        emit(False, "admin_jwt_read_failed")
+    if not token:
+        emit(False, "admin_jwt_empty")
+    return token
+
+
+def read_password_bytes():
+    try:
+        # Exact bytes for transport; no transform/log.
+        return pathlib.Path(pass_path).read_bytes()
+    except Exception:
+        emit(False, "secret_file_read_failed")
+
+
+def password_text(raw: bytes) -> str:
+    try:
+        return raw.decode("utf-8")
+    except Exception:
+        emit(False, "password_not_utf8")
+
+
+def request(method, path, token, body_obj=None):
+    url = base.rstrip("/") + path
+    data = None
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/json",
+    }
+    if body_obj is not None:
+        data = json.dumps(body_obj).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+    elif method.upper() == "POST":
+        data = b"{}"
+        headers["Content-Type"] = "application/json"
+    req = urllib.request.Request(url, data=data, headers=headers, method=method.upper())
+    try:
+        with urllib.request.urlopen(req, timeout=60) as resp:
+            raw = resp.read().decode("utf-8", errors="replace")
+            code = int(resp.getcode())
+    except urllib.error.HTTPError as e:
+        raw = e.read().decode("utf-8", errors="replace")
+        code = int(e.code)
+    except Exception:
+        return None, None
+    try:
+        parsed = json.loads(raw) if raw else {}
+    except Exception:
+        parsed = None
+    return code, parsed
+
+
+def empty_contact(value):
+    if value is None:
+        return True
+    if isinstance(value, str) and value.strip() == "":
+        return True
+    return False
+
+
+def require_admin_access(user_id, token, phase):
+    quoted_id = urllib.parse.quote(user_id, safe="")
+    code, payload = request("GET", f"/api/admin/users/{quoted_id}/access", token)
+    if code is None:
+        emit(False, f"{phase}_access_transport_failed")
+    if code != 200 or not isinstance(payload, dict) or payload.get("ok") is not True:
+        emit(False, f"{phase}_access_http_{code if code is not None else 'na'}")
+    access = payload.get("data") if isinstance(payload.get("data"), dict) else {}
+    access_user = access.get("user") if isinstance(access.get("user"), dict) else {}
+    roles = access.get("roles") if isinstance(access.get("roles"), list) else []
+    if access.get("isAdmin") is not True or not any(str(role) == "admin" for role in roles):
+        emit(False, f"{phase}_access_not_admin")
+    username = access_user.get("username")
+    if not isinstance(username, str) or username.strip().lower() != owner_username.lower():
+        emit(False, f"{phase}_access_username_mismatch")
+    name = access_user.get("name")
+    if not isinstance(name, str) or name != owner_name:
+        emit(False, f"{phase}_access_name_mismatch")
+    if not empty_contact(access_user.get("email")) or not empty_contact(access_user.get("mobile")):
+        emit(False, f"{phase}_access_contact_not_empty")
+    if access_user.get("is_active") is not True:
+        emit(False, f"{phase}_access_inactive")
+    if access_user.get("activationStatus") != "activated":
+        emit(False, f"{phase}_access_not_activated")
+
+
+token = read_token()
+password_raw = read_password_bytes()
+password = password_text(password_raw)
+if password == "":
+    emit(False, "empty_password")
+if password != password.strip():
+    emit(False, "password_outer_whitespace")
+if len(password) < 8:
+    emit(False, "password_too_short")
+if len(password) > 128:
+    emit(False, "password_too_long")
+if not any(char.islower() for char in password):
+    emit(False, "password_missing_lowercase")
+if not any(char.isupper() for char in password):
+    emit(False, "password_missing_uppercase")
+if not any(char.isdigit() for char in password):
+    emit(False, "password_missing_digit")
+if any(pattern in password.lower() for pattern in ("password", "123456", "qwerty", "abc123", "letmein", "admin")):
+    emit(False, "password_weak_pattern")
+
+# 1) Lookup by username query; exact-match only (values never logged).
+q = urllib.parse.urlencode({"q": owner_username, "page": "1", "pageSize": "100"})
+code, payload = request("GET", f"/api/admin/users?{q}", token)
+if code is None:
+    emit(False, "list_transport_failed")
+if code != 200 or not isinstance(payload, dict) or payload.get("ok") is not True:
+    emit(False, f"list_http_{code if code is not None else 'na'}")
+data = payload.get("data") if isinstance(payload.get("data"), dict) else {}
+items = data.get("items") if isinstance(data.get("items"), list) else []
+exact = []
+for item in items:
+    if not isinstance(item, dict):
+        continue
+    uname = item.get("username")
+    if isinstance(uname, str) and uname.strip().lower() == owner_username.lower():
+        exact.append(item)
+if len(exact) > 1:
+    emit(False, "collision_multiple_rows")
+
+outcome = "unset"
+user_id = ""
+if len(exact) == 1:
+    row = exact[0]
+    user_id = str(row.get("id") or "").strip()
+    name = row.get("name")
+    if not user_id:
+        emit(False, "identity_missing_id")
+    if not isinstance(name, str) or name != owner_name:
+        emit(False, "identity_name_mismatch")
+    if not empty_contact(row.get("email")) or not empty_contact(row.get("mobile")):
+        emit(False, "identity_contact_not_empty")
+    # Ownership guard before any password mutation. Profile flags are not enough;
+    # verify the production RBAC surface used by ensurePlatformAdmin.
+    require_admin_access(user_id, token, "pre_reset")
+    outcome = "repaired"
+else:
+    # 2) Create with username/name/admin only; no email/mobile and without the
+    # operator password. The server-generated temporary
+    # password keeps must_change_password=true even if this process is interrupted
+    # before the required reset below. The generated value is never emitted.
+    create_body = {
+        "username": owner_username,
+        "name": owner_name,
+        "role": "admin",
+        "roleId": "admin",
+        "isActive": True,
+    }
+    code, payload = request("POST", "/api/admin/users", token, create_body)
+    if code is None:
+        emit(False, "create_transport_failed")
+    if code != 200 or not isinstance(payload, dict) or payload.get("ok") is not True:
+        emit(False, f"create_http_{code if code is not None else 'na'}")
+    created = payload.get("data") if isinstance(payload.get("data"), dict) else {}
+    created_user = created.get("user") if isinstance(created.get("user"), dict) else {}
+    user_id = str(created_user.get("id") or created.get("userId") or "").strip()
+    if not user_id:
+        emit(False, "create_missing_user_id")
+    created_username = created_user.get("username")
+    if not isinstance(created_username, str) or created_username.strip().lower() != owner_username.lower():
+        emit(False, "create_username_mismatch")
+    if not empty_contact(created_user.get("email")) or not empty_contact(created_user.get("mobile")):
+        emit(False, "create_contact_not_empty")
+    outcome = "created"
+
+# 3) Required reset-password forces must_change_password (create and repair).
+code, payload = request(
+    "POST",
+    f"/api/admin/users/{urllib.parse.quote(user_id, safe='')}/reset-password",
+    token,
+    {"password": password},
+)
+if code is None:
+    emit(False, "reset_transport_failed")
+if code != 200 or not isinstance(payload, dict) or payload.get("ok") is not True:
+    emit(False, f"reset_http_{code if code is not None else 'na'}")
+
+# 4) Post-write access proof catches create/role drift and protects the claimed result.
+require_admin_access(user_id, token, "post_reset")
+
+# 5) Real password login: passwordChangeRequired true + exact username.
+login_body = json.dumps({"identifier": owner_username, "password": password}).encode("utf-8")
+login_req = urllib.request.Request(
+    base.rstrip("/") + "/api/auth/login",
+    data=login_body,
+    headers={"Content-Type": "application/json", "Accept": "application/json"},
+    method="POST",
+)
+try:
+    with urllib.request.urlopen(login_req, timeout=20) as resp:
+        login_raw = resp.read().decode("utf-8", errors="replace")
+        login_code = int(resp.getcode())
+except urllib.error.HTTPError as e:
+    emit(False, f"login_http_{int(e.code)}")
+except Exception:
+    emit(False, "login_request_failed")
+try:
+    login_data = json.loads(login_raw)
+except Exception:
+    emit(False, f"login_http_{login_code}_bad_json")
+if login_code != 200 or not isinstance(login_data, dict) or login_data.get("success") is not True:
+    emit(False, f"login_http_{login_code}_rejected")
+login_payload = login_data.get("data") if isinstance(login_data.get("data"), dict) else {}
+if login_payload.get("passwordChangeRequired") is not True:
+    emit(False, "login_password_change_required_missing")
+login_user = login_payload.get("user") if isinstance(login_payload.get("user"), dict) else {}
+login_username = login_user.get("username")
+if not isinstance(login_username, str) or login_username.strip().lower() != owner_username.lower():
+    emit(False, "login_username_mismatch")
+
+# 6) Required revoke-sessions using canary JWT (clean up human login session).
+code, payload = request(
+    "POST",
+    f"/api/admin/users/{urllib.parse.quote(user_id, safe='')}/revoke-sessions",
+    token,
+    {"reason": "lifecycle_canary_human_bootstrap"},
+)
+if code is None:
+    emit(False, "revoke_transport_failed")
+if code != 200 or not isinstance(payload, dict) or payload.get("ok") is not True:
+    emit(False, f"revoke_http_{code if code is not None else 'na'}")
+revoke_data = payload.get("data") if isinstance(payload.get("data"), dict) else {}
+revoked_after = revoke_data.get("revokedAfter")
+if not isinstance(revoked_after, str) or not revoked_after.strip():
+    emit(False, "revoke_proof_missing")
+
+emit(True, outcome)
+PY
+  if ! result="$(python3 "$python_tmp" \
+    "$CANARY_ADMIN_JWT_FILE" \
+    "$STAGING_OWNER_ADMIN_PASSWORD_FILE" \
+    "$STAGING_API_BASE_URL" \
+    "$HUMAN_OWNER_USERNAME" \
+    "$HUMAN_OWNER_NAME")"; then
+    rm -f "$python_tmp"
+    HUMAN_BOOTSTRAP_OUTCOME="python_failed"
+    log "human-bootstrap refused: note=python_failed"
+    return 1
+  fi
+  rm -f "$python_tmp"
+  ok="${result%%|*}"
+  note="${result#*|}"
+  HUMAN_BOOTSTRAP_OUTCOME="$note"
+  if [[ "$ok" != "true" ]]; then
+    log "human-bootstrap refused: note=${note}"
+    return 1
+  fi
+  log "human-bootstrap OK outcome=${note} (fixed human admin only; values never logged)"
+  return 0
 }
 
 # POST /api/admin/login-aliases/backfill — success required; record counts only.
@@ -1605,7 +1938,7 @@ action_not_executable_on() {
     echo "transition_applied=false"
     echo "executable=false"
   } > "${OUTPUT_DIR}/summary.txt"
-  fail "action=${target} is NOT EXECUTABLE: no secret-backed real verifier for canary proof (admit-activate / sync-deprovision). Env flip alone is refused. Use status|preflight|off|bootstrap|alias only. transition_applied=false"
+  fail "action=${target} is NOT EXECUTABLE: no secret-backed real verifier for canary proof (admit-activate / sync-deprovision). Env flip alone is refused. Use status|preflight|off|bootstrap|human-bootstrap|alias only. transition_applied=false"
 }
 
 # Staging-only create/repair of the fixed dedicated lifecycle canary admin.
@@ -1886,6 +2219,96 @@ action_alias() {
   log "action=alias OK (transient ON proven; success proved OFF; backfill may persist)"
 }
 
+# Staging-only create/repair of the FIXED separate human platform administrator.
+# Authenticates admin API with the fixed lifecycle canary admin (password login → JWT).
+# Human password is STAGING_OWNER_ADMIN_PASSWORD_FILE only. Never writes lifecycle env;
+# never restarts. Collision / identity mismatch fail closed.
+action_human_bootstrap() {
+  local note="human_bootstrap_admin"
+  local human_ok="false"
+  HUMAN_BOOTSTRAP_OUTCOME="unset"
+
+  require_sha
+  require_canary_secret_files "human-bootstrap"
+  assert_canary_identifier_matches_owner "human-bootstrap"
+  require_staging_owner_admin_password_file "human-bootstrap"
+  [[ "$BOOTSTRAP_CONFIRMATION" == "CREATE_STAGING_HUMAN_ADMIN" ]] \
+    || fail "action=human-bootstrap requires BOOTSTRAP_CONFIRMATION=CREATE_STAGING_HUMAN_ADMIN"
+  [[ -n "$EXPECTED_CURRENT_MODE" ]] || fail "expected_current_mode is required for action=human-bootstrap"
+  [[ "$EXPECTED_CURRENT_MODE" == "off" ]] \
+    || fail "action=human-bootstrap requires expected_current_mode=off (got '${EXPECTED_CURRENT_MODE}'); refuse auto-selection"
+
+  capture_live_snapshot
+  assert_exact_sha
+  require_migrations_pending_zero_true "$SNAP_MIGRATIONS_ZERO" "action=human-bootstrap"
+
+  if [[ "$SNAP_HEALTH_OK" != "true" ]]; then
+    fail "action=human-bootstrap refused: backend_health_ok must be true before account mutation"
+  fi
+  if [[ "$SNAP_MODE" != "off" ]]; then
+    fail "action=human-bootstrap refused: live mode must be off (live='${SNAP_MODE}')"
+  fi
+  if [[ "$SNAP_MODE" != "$EXPECTED_CURRENT_MODE" ]]; then
+    fail "strict expected-current-mode transition failed: live='${SNAP_MODE}' expected_current_mode='${EXPECTED_CURRENT_MODE}'"
+  fi
+
+  # Mint short-lived canary admin JWT for admin API (never ATTENDANCE_ADMIN_JWT).
+  if ! mint_canary_admin_jwt_from_password_login "human-bootstrap"; then
+    fail "action=human-bootstrap refused: canary password login / JWT mint failed (no human mutation performed)"
+  fi
+  [[ -n "${CANARY_ADMIN_JWT_FILE:-}" && -s "${CANARY_ADMIN_JWT_FILE}" ]] \
+    || fail "action=human-bootstrap refused: admin JWT file missing after mint (no human mutation performed)"
+
+  # No lifecycle env write path exists below — create/repair only the fixed human identity.
+  if ! bootstrap_human_platform_admin; then
+    fail "action=human-bootstrap refused: fixed human create/repair failed (note=${HUMAN_BOOTSTRAP_OUTCOME:-unset}); no env write performed"
+  fi
+  human_ok="true"
+
+  # Re-prove stack posture after account mutation: mode still off, health true, SHA unchanged,
+  # migrations zero, all three lifecycle flags OFF. No restart expected.
+  capture_live_snapshot
+  if [[ "$SNAP_MODE" != "off" ]]; then
+    fail "action=human-bootstrap refused: post-human-bootstrap live mode must remain off (live='${SNAP_MODE}'); no lifecycle env write expected"
+  fi
+  if [[ "$SNAP_ALIAS" != "false" || "$SNAP_PENDING" != "false" || "$SNAP_DEPROV" != "false" ]]; then
+    fail "action=human-bootstrap refused: post-human-bootstrap all lifecycle flags must remain OFF"
+  fi
+  if [[ "$SNAP_HEALTH_OK" != "true" ]]; then
+    fail "action=human-bootstrap refused: post-human-bootstrap backend_health_ok must remain true"
+  fi
+  require_migrations_pending_zero_true "$SNAP_MIGRATIONS_ZERO" "action=human-bootstrap post-check"
+  if [[ "${SNAP_BUILD_SHA:-}" != "$DEPLOY_SHA" ]]; then
+    fail "action=human-bootstrap refused: post-human-bootstrap SHA '${SNAP_BUILD_SHA:-}' must match deploy_sha '${DEPLOY_SHA}'"
+  fi
+  assert_exact_sha
+
+  note="human_bootstrap_admin_${HUMAN_BOOTSTRAP_OUTCOME}"
+  write_status_artifact \
+    "${SNAP_BUILD_SHA:-unknown}" \
+    "$SNAP_ALIAS" "$SNAP_PENDING" "$SNAP_DEPROV" "$SNAP_MODE" \
+    "$SNAP_ALIAS_READY" "$SNAP_CAN_ENABLE_ALIAS" \
+    "$SNAP_MIGRATIONS_ZERO" "$SNAP_HEALTH_OK" \
+    "" "" "false" "$note"
+  {
+    echo "action=human-bootstrap"
+    echo "mode=${SNAP_MODE}"
+    echo "build_sha=${SNAP_BUILD_SHA:-unknown}"
+    echo "transition_applied=false"
+    echo "human_bootstrap_outcome=${HUMAN_BOOTSTRAP_OUTCOME}"
+    echo "human_bootstrap_ok=${human_ok}"
+    echo "lifecycle_env_write=false"
+    echo "backend_recreate=false"
+    echo "post_human_bootstrap_mode_off=true"
+    echo "post_human_bootstrap_flags_off=true"
+    echo "post_human_bootstrap_health_ok=true"
+    echo "post_human_bootstrap_migrations_zero=true"
+    echo "post_human_bootstrap_sha_match=true"
+    echo "note=${note}"
+  } > "${OUTPUT_DIR}/summary.txt"
+  log "action=human-bootstrap OK outcome=${HUMAN_BOOTSTRAP_OUTCOME} (no lifecycle env write; mode/health/SHA/migrations reasserted)"
+}
+
 # --- main ------------------------------------------------------------------------------
 
 main() {
@@ -1897,10 +2320,11 @@ main() {
     preflight) action_preflight ;;
     off) action_off ;;
     bootstrap) action_bootstrap ;;
+    human-bootstrap) action_human_bootstrap ;;
     alias) action_alias ;;
     pending) action_not_executable_on pending ;;
     deprovision) action_not_executable_on deprovision ;;
-    *) fail "invalid ACTION='${ACTION}' (status|preflight|off|bootstrap|alias|pending|deprovision)" ;;
+    *) fail "invalid ACTION='${ACTION}' (status|preflight|off|bootstrap|human-bootstrap|alias|pending|deprovision)" ;;
   esac
 }
 


### PR DESCRIPTION
## Summary

Adds a staging-only `human-bootstrap` action for the DingTalk lifecycle canary workflow. It creates or safely repairs one fixed human platform administrator:

- username: `staging-owner-admin`
- name: `Staging Owner Admin`
- no email or mobile
- platform admin
- forced password change on first login

The action authenticates through the existing lifecycle canary account, transports the operator password only through chmod-600 files, verifies the account through the production access and login APIs, revokes the proof session, and reasserts the exact deploy SHA, health, zero pending migrations, and all three lifecycle flags OFF.

## Safety boundaries

- Staging only; production paths are untouched.
- Never writes lifecycle env flags and never restarts the backend.
- Requires full deployed SHA, `expected_current_mode=off`, and `CREATE_STAGING_HUMAN_ADMIN` both in the workflow and remote helper.
- Create request does not carry the operator password; the backend-generated temporary credential preserves forced-change semantics if interrupted before reset.
- Existing rows are reset only after exact username/name/contact/admin/active/activated ownership checks.
- Password, JWT, email, and mobile values never enter artifacts or logs.
- Required revoke proof is a non-empty `revokedAfter` watermark.

## Verification

- `node --test scripts/ops/dingtalk-lifecycle-staging-canary-contract.test.mjs` — 99/99
- `bash -n scripts/ops/dingtalk-lifecycle-staging-canary-remote.sh`
- `git diff --check`
- Mutations: create request carrying the operator password, removing forced-change verification, removing reset/revoke, and bypassing remote confirmation each turn the contract red.
- Independent Grok 4.5 delta review: 0 P1/P2 remaining.

## Not included

- No lifecycle flag activation or canary transition.
- No staging account or secret mutation before this PR merges and exact deployed SHA/OFF posture are re-proven.
