### PR TITLE
feat(dingtalk): harden staging lifecycle canary recovery

### DIFF
--- a/.github/workflows/dingtalk-lifecycle-staging-canary.yml
+++ b/.github/workflows/dingtalk-lifecycle-staging-canary.yml
@@ -5,7 +5,7 @@ run-name: "DingTalk Lifecycle Staging Canary: ${{ inputs.action }}${{ inputs.act
 # Staging-only MINIMAL SAFE operator lane for DingTalk lifecycle env gates.
 # One dispatch = ONE action. All lifecycle flags remain OFF by default.
 #
-# EXECUTABLE: status | preflight | off | bootstrap | human-bootstrap | alias
+# EXECUTABLE: status | preflight | off | bootstrap | human-bootstrap | alias | pending | deprovision
 #   off       = emergency env-gate clear of the three lifecycle flags only (with
 #               previous-override restore on restart/health/mode failure).
 #   bootstrap = staging-only create/repair of the FIXED dedicated lifecycle
@@ -33,11 +33,21 @@ run-name: "DingTalk Lifecycle Staging Canary: ${{ inputs.action }}${{ inputs.act
 #               + secrets.LIFECYCLE_CANARY_LOGIN_PASSWORD only (chmod-600 file
 #               transport). Short-lived admin JWT is minted from the canary
 #               password login after pre-login — never secrets.ATTENDANCE_ADMIN_JWT.
-#
-# NOT EXECUTABLE: pending | deprovision
-#   Fail-closed preflight-only. Env flip alone is not a canary — there is no
-#   secret-backed real verifier for admit→activate or sync→deprovision.
-#   transition_applied is always false for these actions.
+#   pending   = TRANSIENT secret-backed pending ADMIT canary on an EXPLICIT owned
+#               directory account subject (file transport; never printed).
+#               Default phase: admit only (pending flag ON → real admit → pending
+#               state proofs → flags OFF). OAuth negative/positive checkpoints are
+#               NOT_EXECUTED (manual). Optional confirmation PENDING_SSO_ACTIVATE
+#               runs SSO activate only (no env write); browser OAuth still
+#               NOT_EXECUTED. No auto-selection. No temp_password activate claim.
+#   deprovision = Two-phase canary on the SAME explicit subject.
+#               APPLY: bootstrap_confirmation=DINGTALK_SOURCE_DISABLED_DEDICATED_EXCLUSIVE_CONFIRMED
+#               → deprovision flag ON → real sync → ledger bound to exact run.id
+#               → access denial → flags OFF (access remains disabled; not
+#               end-to-end success).
+#               RESTORE: bootstrap_confirmation=DINGTALK_SOURCE_REACTIVATED_CONFIRMED
+#               → flags stay OFF → sync after external source re-enable → rehire
+#               restore for the applied event → prove resolved + access restored.
 #
 # See:
 #   docs/development/dingtalk-lifecycle-canary-separate-go-20260724.md
@@ -50,29 +60,29 @@ on:
   workflow_dispatch:
     inputs:
       action:
-        description: 'status/preflight/off/bootstrap/human-bootstrap/alias = executable; pending/deprovision = NOT EXECUTABLE (fail-closed preflight-only)'
+        description: 'status/preflight/off/bootstrap/human-bootstrap/alias/pending/deprovision = executable (pending/deprovision need explicit subject secret + rollback)'
         required: true
         type: choice
         # Quote 'off' — YAML 1.1 bare off becomes boolean false.
         options: [status, preflight, 'off', bootstrap, human-bootstrap, alias, pending, deprovision]
         default: status
       target_mode:
-        description: 'preflight only: target mode to assess (off|alias|pending|deprovision). pending/deprovision assess readiness only — never apply.'
+        description: 'preflight only: target mode to assess (off|alias|pending|deprovision). Stack readiness only — action=pending|deprovision still require subject secret.'
         required: false
         type: choice
         options: ['off', alias, pending, deprovision]
         default: 'off'
       expected_current_mode:
-        description: 'Required for action=off (live mode before clear) and action=bootstrap|human-bootstrap|alias (must be off). Optional for preflight.'
+        description: 'Required for action=off (live mode before clear) and action=bootstrap|human-bootstrap|alias|pending|deprovision (must be off). Optional for preflight.'
         required: false
         type: string
         default: ''
       deploy_sha:
-        description: 'FULL 40-char lowercase commit SHA currently deployed on staging. Required for action=off, bootstrap, human-bootstrap, and alias; optional exact-match for preflight.'
+        description: 'FULL 40-char lowercase commit SHA currently deployed on staging. Required for action=off, bootstrap, human-bootstrap, alias, pending, and deprovision; optional exact-match for preflight.'
         required: false
         default: ''
       bootstrap_confirmation:
-        description: 'For action=bootstrap enter CREATE_STAGING_CANARY_ADMIN; for action=human-bootstrap enter CREATE_STAGING_HUMAN_ADMIN. Ignored by other actions.'
+        description: 'bootstrap=CREATE_STAGING_CANARY_ADMIN; human-bootstrap=CREATE_STAGING_HUMAN_ADMIN; pending optional PENDING_SSO_ACTIVATE; deprovision=DINGTALK_SOURCE_DISABLED_DEDICATED_EXCLUSIVE_CONFIRMED (apply) or DINGTALK_SOURCE_REACTIVATED_CONFIRMED (restore).'
         required: false
         type: string
         default: ''
@@ -132,11 +142,11 @@ jobs:
             fi
           fi
 
-          # action=bootstrap|human-bootstrap|alias: structural inputs only here. Secret
-          # presence is checked in Run remote action. bootstrap/human-bootstrap never
-          # write lifecycle env flags. alias success requires/proves OFF; failure
-          # restores OFF override first.
-          if [[ "$ACTION" == "bootstrap" || "$ACTION" == "human-bootstrap" || "$ACTION" == "alias" ]]; then
+          # action=bootstrap|human-bootstrap|alias|pending|deprovision: structural inputs
+          # only here. Secret presence is checked in Run remote action.
+          # bootstrap/human-bootstrap never write lifecycle env flags.
+          # alias/pending/deprovision success requires/proves OFF; failure restores OFF.
+          if [[ "$ACTION" == "bootstrap" || "$ACTION" == "human-bootstrap" || "$ACTION" == "alias" || "$ACTION" == "pending" || "$ACTION" == "deprovision" ]]; then
             if [[ "$EXPECTED_CURRENT_MODE" != "off" ]]; then
               echo "expected_current_mode must be exactly 'off' for action=${ACTION} (no auto-selection)" >&2
               exit 2
@@ -157,14 +167,29 @@ jobs:
             exit 2
           fi
 
+          if [[ "$ACTION" == "deprovision" ]]; then
+            case "$BOOTSTRAP_CONFIRMATION" in
+              DINGTALK_SOURCE_DISABLED_DEDICATED_EXCLUSIVE_CONFIRMED|DINGTALK_SOURCE_REACTIVATED_CONFIRMED) ;;
+              *)
+                echo "bootstrap_confirmation must be DINGTALK_SOURCE_DISABLED_DEDICATED_EXCLUSIVE_CONFIRMED (apply) or DINGTALK_SOURCE_REACTIVATED_CONFIRMED (restore) for action=deprovision" >&2
+                exit 2
+              ;;
+            esac
+          fi
+
+          if [[ "$ACTION" == "pending" && -n "$BOOTSTRAP_CONFIRMATION" ]]; then
+            case "$BOOTSTRAP_CONFIRMATION" in
+              PENDING_ADMIT|PENDING_SSO_ACTIVATE) ;;
+              *)
+                echo "bootstrap_confirmation for action=pending must be empty, PENDING_ADMIT, or PENDING_SSO_ACTIVATE" >&2
+                exit 2
+              ;;
+            esac
+          fi
+
           if [[ -n "$DEPLOY_SHA" && ! "$DEPLOY_SHA" =~ ^[0-9a-f]{40}$ ]]; then
             echo "deploy_sha must be empty or the FULL 40-char lowercase commit SHA, got: '$DEPLOY_SHA'" >&2
             exit 2
-          fi
-
-          # Document that pending/deprovision are NOT EXECUTABLE (remote fails closed).
-          if [[ "$ACTION" == "pending" || "$ACTION" == "deprovision" ]]; then
-            echo "NOTE: action=$ACTION is NOT EXECUTABLE in this lane (no real verifier). Remote will fail-closed with transition_applied=false." >&2
           fi
 
           bash -n scripts/ops/dingtalk-lifecycle-staging-canary-remote.sh
@@ -210,15 +235,18 @@ jobs:
           DEPLOY_SHA: ${{ inputs.deploy_sha }}
           BOOTSTRAP_CONFIRMATION: ${{ inputs.bootstrap_confirmation }}
           RUNNER_DIR: ${{ steps.sync.outputs.runner_dir }}
-          # bootstrap/human-bootstrap/alias login secrets are materialized INSIDE this
-          # step under EXIT trap — never via a prior step secrets_dir output (cross-step
-          # leak / cancel). ATTENDANCE_ADMIN_JWT is intentionally NOT consumed; alias
-          # and human-bootstrap mint a short-lived admin JWT from the canary password
-          # login on the remote host. STAGING_OWNER_ADMIN_PASSWORD is demoted and
-          # written to a chmod-600 file for human-bootstrap only (path transferred).
+          # bootstrap/human-bootstrap/alias/pending/deprovision login secrets are
+          # materialized INSIDE this step under EXIT trap — never via a prior step
+          # secrets_dir output (cross-step leak / cancel). ATTENDANCE_ADMIN_JWT is
+          # intentionally NOT consumed; alias/pending/deprovision/human-bootstrap mint a
+          # short-lived admin JWT from the canary password login on the remote host.
+          # STAGING_OWNER_ADMIN_PASSWORD is demoted and written to a chmod-600 file for
+          # human-bootstrap only. LIFECYCLE_CANARY_DIRECTORY_ACCOUNT_ID is demoted for
+          # pending|deprovision only (path transferred; value never printed).
           LIFECYCLE_CANARY_LOGIN_IDENTIFIER: ${{ secrets.LIFECYCLE_CANARY_LOGIN_IDENTIFIER }}
           LIFECYCLE_CANARY_LOGIN_PASSWORD: ${{ secrets.LIFECYCLE_CANARY_LOGIN_PASSWORD }}
           STAGING_OWNER_ADMIN_PASSWORD: ${{ inputs.action == 'human-bootstrap' && secrets.STAGING_OWNER_ADMIN_PASSWORD || '' }}
+          LIFECYCLE_CANARY_DIRECTORY_ACCOUNT_ID: ${{ (inputs.action == 'pending' || inputs.action == 'deprovision') && secrets.LIFECYCLE_CANARY_DIRECTORY_ACCOUNT_ID || '' }}
         run: |
           set -euo pipefail
           # --- SECRET DEMOTE (builtins only; no external child before unset) -------------
@@ -230,7 +258,8 @@ jobs:
           _CANARY_IDENT="${LIFECYCLE_CANARY_LOGIN_IDENTIFIER-}"
           _CANARY_PASS="${LIFECYCLE_CANARY_LOGIN_PASSWORD-}"
           _STAGING_OWNER_PASS="${STAGING_OWNER_ADMIN_PASSWORD-}"
-          unset LIFECYCLE_CANARY_LOGIN_IDENTIFIER LIFECYCLE_CANARY_LOGIN_PASSWORD STAGING_OWNER_ADMIN_PASSWORD
+          _CANARY_SUBJECT="${LIFECYCLE_CANARY_DIRECTORY_ACCOUNT_ID-}"
+          unset LIFECYCLE_CANARY_LOGIN_IDENTIFIER LIFECYCLE_CANARY_LOGIN_PASSWORD STAGING_OWNER_ADMIN_PASSWORD LIFECYCLE_CANARY_DIRECTORY_ACCOUNT_ID
           # --- end secret demote; external commands allowed after this point ------------
 
           ssh_opts="-o StrictHostKeyChecking=yes -o UserKnownHostsFile=$HOME/.ssh/known_hosts -o IdentitiesOnly=yes -i $HOME/.ssh/deploy_key"
@@ -283,28 +312,35 @@ jobs:
             set -e
           }
 
-          # For bootstrap|human-bootstrap|alias: materialize chmod-600 secrets LOCALLY
-          # under EXIT trap, then scp path-only into the per-run remote directory. Never
-          # pass secrets_dir across steps. Never materialize ATTENDANCE_ADMIN_JWT.
-          # Password written with printf '%s' (exact bytes). Alias/human-bootstrap mint
-          # admin JWT on remote after successful canary pre-login into the same per-run
-          # secrets dir. human-bootstrap also materializes staging-owner-admin.password.
+          # For bootstrap|human-bootstrap|alias|pending|deprovision: materialize chmod-600
+          # secrets LOCALLY under EXIT trap, then scp path-only into the per-run remote
+          # directory. Never pass secrets_dir across steps. Never materialize
+          # ATTENDANCE_ADMIN_JWT. Password written with printf '%s' (exact bytes).
+          # Alias/pending/deprovision/human-bootstrap mint admin JWT on remote after
+          # successful canary pre-login. pending|deprovision also materialize
+          # directory-account.id (subject UUID path only; never printed).
           remote_secrets_dir=""
           canary_ident_export=""
           canary_pass_export=""
           staging_owner_pass_export=""
-          if [[ "$ACTION" == "alias" || "$ACTION" == "bootstrap" || "$ACTION" == "human-bootstrap" ]]; then
+          canary_subject_export=""
+          if [[ "$ACTION" == "alias" || "$ACTION" == "bootstrap" || "$ACTION" == "human-bootstrap" || "$ACTION" == "pending" || "$ACTION" == "deprovision" ]]; then
             # Install trap BEFORE any secret materialization (mktemp/write/chmod).
             trap cleanup_canary_ephemeral_paths EXIT INT TERM
             # Presence via non-exported shell vars only (env already unset above).
             if [[ -z "${_CANARY_IDENT}" || -z "${_CANARY_PASS}" ]]; then
               echo "${ACTION} requires LIFECYCLE_CANARY_LOGIN_IDENTIFIER/PASSWORD (checked in Run remote action only); never ATTENDANCE_ADMIN_JWT" >&2
-              unset _CANARY_IDENT _CANARY_PASS _STAGING_OWNER_PASS
+              unset _CANARY_IDENT _CANARY_PASS _STAGING_OWNER_PASS _CANARY_SUBJECT
               exit 2
             fi
             if [[ "$ACTION" == "human-bootstrap" && -z "${_STAGING_OWNER_PASS}" ]]; then
               echo "human-bootstrap requires STAGING_OWNER_ADMIN_PASSWORD (checked in Run remote action only); never log secret" >&2
-              unset _CANARY_IDENT _CANARY_PASS _STAGING_OWNER_PASS
+              unset _CANARY_IDENT _CANARY_PASS _STAGING_OWNER_PASS _CANARY_SUBJECT
+              exit 2
+            fi
+            if [[ ( "$ACTION" == "pending" || "$ACTION" == "deprovision" ) && -z "${_CANARY_SUBJECT}" ]]; then
+              echo "${ACTION} requires LIFECYCLE_CANARY_DIRECTORY_ACCOUNT_ID (explicit subject; no auto-selection; checked in Run remote action only); never log secret" >&2
+              unset _CANARY_IDENT _CANARY_PASS _STAGING_OWNER_PASS _CANARY_SUBJECT
               exit 2
             fi
             secrets_dir="$(mktemp -d "${RUNNER_TEMP}/lifecycle-canary-secrets.XXXXXX")"
@@ -335,6 +371,16 @@ jobs:
             else
               unset _STAGING_OWNER_PASS
             fi
+            if [[ "$ACTION" == "pending" || "$ACTION" == "deprovision" ]]; then
+              printf '%s' "${_CANARY_SUBJECT}" > "${secrets_dir}/directory-account.id"
+              unset _CANARY_SUBJECT
+              chmod 600 "${secrets_dir}/directory-account.id"
+              [[ -s "${secrets_dir}/directory-account.id" ]] \
+                || { echo "secret file empty after materialize: directory-account.id" >&2; exit 2; }
+              scp_files+=("${secrets_dir}/directory-account.id")
+            else
+              unset _CANARY_SUBJECT
+            fi
             remote_secrets_dir="${RUNNER_DIR}/.canary-secrets"
             CLEAN_REMOTE_SECRETS_DIR="${remote_secrets_dir}"
             # Remote copy only after local materialize succeeded under trap coverage.
@@ -347,6 +393,10 @@ jobs:
               ssh $ssh_opts "$DEPLOY_USER@$DEPLOY_HOST" \
                 "bash -o pipefail -c 'set -euo pipefail; chmod 600 ${remote_secrets_dir}/login.identifier ${remote_secrets_dir}/login.password ${remote_secrets_dir}/staging-owner-admin.password'"
               staging_owner_pass_export="export STAGING_OWNER_ADMIN_PASSWORD_FILE='${remote_secrets_dir}/staging-owner-admin.password'"
+            elif [[ "$ACTION" == "pending" || "$ACTION" == "deprovision" ]]; then
+              ssh $ssh_opts "$DEPLOY_USER@$DEPLOY_HOST" \
+                "bash -o pipefail -c 'set -euo pipefail; chmod 600 ${remote_secrets_dir}/login.identifier ${remote_secrets_dir}/login.password ${remote_secrets_dir}/directory-account.id'"
+              canary_subject_export="export CANARY_DIRECTORY_ACCOUNT_ID_FILE='${remote_secrets_dir}/directory-account.id'"
             else
               ssh $ssh_opts "$DEPLOY_USER@$DEPLOY_HOST" \
                 "bash -o pipefail -c 'set -euo pipefail; chmod 600 ${remote_secrets_dir}/login.identifier ${remote_secrets_dir}/login.password'"
@@ -355,7 +405,7 @@ jobs:
             canary_pass_export="export CANARY_LOGIN_PASSWORD_FILE='${remote_secrets_dir}/login.password'"
           else
             # Non-secret actions: drop any unused shell copies; clean per-run dirs on exit.
-            unset _CANARY_IDENT _CANARY_PASS _STAGING_OWNER_PASS
+            unset _CANARY_IDENT _CANARY_PASS _STAGING_OWNER_PASS _CANARY_SUBJECT
             trap cleanup_canary_ephemeral_paths EXIT INT TERM
           fi
 
@@ -372,6 +422,7 @@ jobs:
           ${canary_ident_export}
           ${canary_pass_export}
           ${staging_owner_pass_export}
+          ${canary_subject_export}
           rm -rf '${remote_output_dir}'
           mkdir -p '${remote_output_dir}'
           set +e
@@ -425,13 +476,18 @@ jobs:
             echo "- Remote rc: \`${REMOTE_RC:-missing}\`"
             echo "- Artifact: \`${ARTIFACT_NAME:-missing}\`"
             echo ""
-            echo "**Executable:** status / preflight / off / bootstrap / human-bootstrap / alias (alias success requires/proves OFF; failure restores OFF override before failing)."
-            echo "**NOT EXECUTABLE:** pending / deprovision (no real canary verifier)."
+            echo "**Executable:** status / preflight / off / bootstrap / human-bootstrap / alias / pending / deprovision."
+            echo "Alias/pending/deprovision success requires/proves OFF; failure restores OFF override before failing."
             echo "OFF is emergency env-gate rollback only — not OR-column design reintroduction."
             echo "Bootstrap creates/repairs fixed lifecycle-canary@staging.invalid admin only (no lifecycle env write)."
             echo "Human-bootstrap creates/repairs fixed username staging-owner-admin human platform admin only (no lifecycle env write; password file transport)."
-            echo "Bootstrap/human-bootstrap/alias require LIFECYCLE_CANARY_LOGIN_IDENTIFIER/PASSWORD (file transport); human-bootstrap also requires STAGING_OWNER_ADMIN_PASSWORD file; alias/human-bootstrap mint short-lived admin JWT from canary password login — never ATTENDANCE_ADMIN_JWT."
-            echo "Runtime OFF cannot be proven if alias rollback recreate itself fails (override restored on disk)."
+            echo "Bootstrap/human-bootstrap/alias/pending/deprovision require LIFECYCLE_CANARY_LOGIN_IDENTIFIER/PASSWORD (file transport); human-bootstrap also requires STAGING_OWNER_ADMIN_PASSWORD; pending/deprovision also require LIFECYCLE_CANARY_DIRECTORY_ACCOUNT_ID (explicit subject; never printed)."
+            echo "Pending default phase is admit-only; OAuth checkpoints are NOT_EXECUTED; optional PENDING_SSO_ACTIVATE (browser OAuth still NOT_EXECUTED)."
+            echo "Deprovision apply uses DINGTALK_SOURCE_DISABLED_DEDICATED_EXCLUSIVE_CONFIRMED (flags OFF, access remains disabled). Restore uses DINGTALK_SOURCE_REACTIVATED_CONFIRMED (rehire + access restore; flags stay OFF)."
+            echo "Deprovision refuses shared integrations: exactly one total directory account, manual scheduling, admission automation OFF, and member-group projection OFF are required."
+            echo "Deprovision reserves and journals the exact sync run UUID before env/HTTP; lost responses recover only through that run and its exact event/effects."
+            echo "Alias/pending/deprovision/human-bootstrap mint short-lived admin JWT from canary password login — never ATTENDANCE_ADMIN_JWT."
+            echo "Runtime OFF cannot be proven if rollback recreate itself fails (override restored on disk)."
             if [[ -f output/lifecycle-canary/summary.txt ]]; then
               echo ""
               echo '```text'

--- a/docs/development/dingtalk-lifecycle-canary-separate-go-20260724.md
+++ b/docs/development/dingtalk-lifecycle-canary-separate-go-20260724.md
@@ -1,7 +1,7 @@
 # DingTalk lifecycle canary — separate ops GO (not auto-enabled)
 
 **Date:** 2026-07-24
-**Updated:** 2026-08-11 (bootstrap fixed canary admin + alias JWT mint from password login; bootstrap stdin secret transport / no container secret files / permissions-column omit / session revoke on repair / post-bootstrap OFF+health+SHA reassert; alias remains a **transient** secret-backed cutover; success requires/proves OFF; failure restores the OFF override before failing; pending/deprovision remain **NOT EXECUTABLE**; no successful ON canary run claimed here)
+**Updated:** 2026-08-11 (bootstrap fixed canary admin + alias JWT mint from password login; bootstrap stdin secret transport / no container secret files / permissions-column omit / session revoke on repair / post-bootstrap OFF+health+SHA reassert; alias is a **transient** secret-backed cutover and run 31504979575 completed with required OFF rollback; pending/deprovision remain **NOT EXECUTABLE**)
 **Related locks:**
 - `dingtalk-directory-admission-activation-lifecycle-design-20260723.md` Rev 4.2
 - `dingtalk-deprovision-reactivation-and-evidence-chain-design-20260723.md` Rev 4.2
@@ -105,9 +105,9 @@ Backfill alias rows **may persist** after the run. Artifacts report only boolean
 
 **Repo state note:** `LIFECYCLE_CANARY_LOGIN_IDENTIFIER` / `LIFECYCLE_CANARY_LOGIN_PASSWORD` must be configured before a real bootstrap or alias dispatch. This lane does **not** use `ATTENDANCE_ADMIN_JWT`. Landing this code does **not** configure those secrets and does **not** claim a successful canary execution.
 
-## Current staging baseline (ON canary NOT EXECUTED)
+## Current staging baseline (alias executed and rolled back)
 
-As of 2026-08-11 this lane remains **NOT EXECUTED** for a completed alias cutover canary run (secrets for identifier/password may be absent; no invented success). Safe preparation evidence for the OFF baseline:
+As of 2026-08-11 the alias cutover canary is complete and rolled back. Pending and deprovision remain **NOT EXECUTED**. Safe preparation and execution evidence:
 
 1. Attendance staging runner [run 31407444155](https://github.com/zensgit/metasheet2/actions/runs/31407444155) completed backup + clone rehearsal + real apply: migration state `296 applied / 18 pending` -> `314 applied / 0 pending`; rehearsal isolation held and auth round-trip returned 200.
 2. [#4853](https://github.com/zensgit/metasheet2/pull/4853), merge commit `ddec28b12ebff97fae33af45553d77c149d816e1`, installs and validates the checked-out staging Compose file, pins Compose project-directory, and derives build metadata from the exact `IMAGE_TAG`.
@@ -115,26 +115,28 @@ As of 2026-08-11 this lane remains **NOT EXECUTED** for a completed alias cutove
 4. Lifecycle [status 31418997337](https://github.com/zensgit/metasheet2/actions/runs/31418997337) proved exact build SHA, healthy backend, zero pending migrations, `mode=off`, and all three flags `false`.
 5. Lifecycle [preflight 31419066036](https://github.com/zensgit/metasheet2/actions/runs/31419066036) proved `preflight_target_mode=off`, `preflight_ok=true`, and `transition_applied=false`. No env write occurred.
 6. The existing `DEPLOY_KNOWN_HOSTS` secret is the independently verified deploy-host identity. The lane uses `StrictHostKeyChecking=yes`; missing host identity blocks dispatch rather than producing forgeable evidence.
+7. Lifecycle [status 31504862038](https://github.com/zensgit/metasheet2/actions/runs/31504862038) re-proved the exact staging SHA, healthy backend, zero pending migrations, mode `off`, and all three flags `false`.
+8. Lifecycle [alias 31504979575](https://github.com/zensgit/metasheet2/actions/runs/31504979575) proved password login before ON, during alias-only, and after rollback; it reported zero collisions and finished in exact mode `off` with all three flags `false`.
 
-The former image-tag/health-commit provenance conflict is resolved. This establishes only the safe OFF baseline, not an executed alias canary.
+The former image-tag/health-commit provenance conflict is resolved. This establishes the safe OFF baseline and the transient alias staging canary; it does not authorize production alias traffic.
 
 Until a **secret-backed real verifier** exists for:
 
 - pending: real admit→activate on an explicit canary subject,
 - deprovision: real sync→deprovision on an explicit canary integration,
 
-those ON actions stay **NOT EXECUTABLE**. Alias now has a verifier path in this lane, but a successful run still requires configured secrets + operator dispatch and is **NOT EXECUTED** by this documentation alone.
+those ON actions stay **NOT EXECUTABLE**. The full values-free execution record is `dingtalk-staging-lifecycle-canary-and-uat-execution-20260811.md`.
 
-## Future canary sequence (when secrets + ops GO exist)
+## Canary sequence
 
-1. Staging: deploy exact SHA; image and health provenance agree; migrations pending=0 via backup/clone-rehearsal.
-2. Configure `LIFECYCLE_CANARY_LOGIN_IDENTIFIER` / `LIFECYCLE_CANARY_LOGIN_PASSWORD` for the fixed `lifecycle-canary@staging.invalid` identity.
-3. Dispatch `action=bootstrap` with full `deploy_sha`, `expected_current_mode=off`, and `bootstrap_confirmation=CREATE_STAGING_CANARY_ADMIN` — create/repair fixed owned admin (stdin secret stream, session revoke on repair) + password login proof + OFF/health/migrations/SHA reassert (no env write).
-4. Dispatch `action=alias` with full `deploy_sha` and `expected_current_mode=off` — mint JWT from canary password login, transient ON proof + OFF success proof (or OFF override restore on failure).
-5. Real admit→activate on explicit ids → only then pending ON (still not this lane today).
-6. Real deprovision proof → only then deprovision ON.
-7. Production = separate GO.
+1. **Complete:** staging exact-SHA deployment, migrations, backup/clone rehearsal, and health provenance.
+2. **Complete:** configure the fixed alias-canary login secrets without exposing their values.
+3. **Complete:** create/repair the dedicated canary administrators and prove password login with all flags OFF.
+4. **Complete:** dispatch `action=alias`; prove transient ON login and required OFF rollback login.
+5. **NOT EXECUTED:** real admit→activate on an explicitly owned DingTalk employee, then pending rollback.
+6. **NOT EXECUTED:** real source departure and deprovision/restore proof on that same employee, then rollback.
+7. Production remains a separate GO.
 
 ## Owner note
 
-Landing this lane ≠ authorizing traffic and ≠ completing canary. **Alias cutover canary NOT EXECUTED** until a real dispatch with secrets succeeds. Merging code does not leave `AUTH_LOGIN_USE_ALIASES` enabled and does not complete lifecycle canary.
+Landing this lane does not authorize traffic. The alias staging canary succeeded and returned to OFF; pending and deprovision remain incomplete. Merging code and completing staging alias do not leave `AUTH_LOGIN_USE_ALIASES` enabled or authorize any production lifecycle flag.

--- a/docs/development/dingtalk-lifecycle-canary-separate-go-20260724.md
+++ b/docs/development/dingtalk-lifecycle-canary-separate-go-20260724.md
@@ -1,19 +1,19 @@
 # DingTalk lifecycle canary — separate ops GO (not auto-enabled)
 
 **Date:** 2026-07-24
-**Updated:** 2026-08-11 (bootstrap fixed canary admin + alias JWT mint from password login; bootstrap stdin secret transport / no container secret files / permissions-column omit / session revoke on repair / post-bootstrap OFF+health+SHA reassert; alias is a **transient** secret-backed cutover and run 31504979575 completed with required OFF rollback; pending/deprovision remain **NOT EXECUTABLE**)
+**Updated:** 2026-08-12 (alias run 31504979575 completed with required OFF rollback; pending/deprovision now have fail-closed transient operators but remain **NOT EXECUTED**; deprovision requires a dedicated one-account integration and pre-reserves its exact sync run UUID before env/HTTP)
 **Related locks:**
 - `dingtalk-directory-admission-activation-lifecycle-design-20260723.md` Rev 4.2
-- `dingtalk-deprovision-reactivation-and-evidence-chain-design-20260723.md` Rev 4.2
+- `dingtalk-deprovision-reactivation-and-evidence-chain-design-20260723.md` Rev 4.5
 - Closeout execution: `dingtalk-lifecycle-six-step-closeout-execution-20260810.md`
 
 ## What is NOT enabled by merge
 
 | Flag / action | Default after code land | Executable in this lane? |
 |---------------|-------------------------|--------------------------|
-| `DIRECTORY_PENDING_ACTIVATION_ENABLED` ON | **OFF** | **NOT EXECUTABLE** — no admit→activate verifier |
+| `DIRECTORY_PENDING_ACTIVATION_ENABLED` ON | **OFF** | **Executable only as a transient canary** on an explicit owned account. Default phase admits to pending and proves OFF rollback; optional SSO activation still records browser OAuth as `NOT_EXECUTED` until a human observes it. |
 | `AUTH_LOGIN_USE_ALIASES` ON (T2b cutover) | **OFF** | **Executable only as a transient canary** (`action=alias`). Success requires/proves OFF in the same run; failure restores the OFF override before failing. Runtime OFF cannot be proven if rollback recreate itself fails (override restored on disk). Requires secret-backed password login; short-lived admin JWT is minted from that login (never `secrets.ATTENDANCE_ADMIN_JWT`). |
-| `DIRECTORY_DEPROVISION_ENABLED` ON | **OFF** | **NOT EXECUTABLE** — no sync→deprovision verifier |
+| `DIRECTORY_DEPROVISION_ENABLED` ON | **OFF** | **Executable only as a two-phase transient canary** on an explicit owned account in a dedicated one-account integration. Apply and restore are separate confirmed operations; every exit restores/proves the flags OFF or reports that runtime OFF is unproven. |
 | Env-gate clear (`action=off`) | n/a | Executable emergency only (after migrations true + exact SHA) |
 | Dedicated canary admin (`action=bootstrap`) | n/a | Executable staging-only create/repair of the **fixed** owned row only (no lifecycle env write) |
 
@@ -34,7 +34,8 @@ Presence of canary subject/integration/owner tokens is **not** a real canary and
 | `off` | yes | emergency clear of the three env gates; previous-override restore on failure; health true after restart required |
 | `bootstrap` | yes (manual) | staging-only create/repair of fixed canary admin; see below; **no lifecycle env write** |
 | `alias` | yes (transient) | secret-backed cutover canary; see sequence below; success requires/proves OFF |
-| `pending` / `deprovision` | **NOT EXECUTABLE** | fail-closed preflight-only; `transition_applied=false` always |
+| `pending` | yes (transient, **NOT EXECUTED**) | explicit owned directory account only; pending admit or optional SSO activation; required OFF rollback; browser OAuth remains a human checkpoint |
+| `deprovision` | yes (two-phase, **NOT EXECUTED**) | dedicated one-account manual integration only; exact preview/planner radius; reserved run UUID + recovery journal; exact event/effects restore; required OFF rollback |
 
 Shared concurrency with `attendance-staging-window-runner`. Status artifacts stay values-free (booleans / counts / reason enums / SHA only).
 
@@ -120,12 +121,29 @@ As of 2026-08-11 the alias cutover canary is complete and rolled back. Pending a
 
 The former image-tag/health-commit provenance conflict is resolved. This establishes the safe OFF baseline and the transient alias staging canary; it does not authorize production alias traffic.
 
-Until a **secret-backed real verifier** exists for:
+The secret-backed operators now exist, but neither action has been run in staging. Execution still
+requires one explicitly owned source employee. Deprovision additionally refuses any integration
+that is scheduled, auto-admitting, member-group projecting, or contains anything other than the
+single selected directory account (inactive rows count too). The current shared employee
+integration is therefore ineligible by construction.
 
-- pending: real admit→activate on an explicit canary subject,
-- deprovision: real sync→deprovision on an explicit canary integration,
+Apply also requires the literal confirmation
+`DINGTALK_SOURCE_DISABLED_DEDICATED_EXCLUSIVE_CONFIRMED`: the source is disabled, the integration
+is dedicated to the one canary account, and no other operator may sync or edit that integration
+until the apply window has returned all lifecycle flags to OFF. Preview plus the one-account
+precondition are strong fail-closed gates, but they are not an atomic scope lock; this explicit
+exclusive window is therefore a required operational hold, not an optional note.
 
-those ON actions stay **NOT EXECUTABLE**. The full values-free execution record is `dingtalk-staging-lifecycle-canary-and-uat-execution-20260811.md`.
+For deprovision apply, journal schema v4 persists the subject tuple and a random run UUID **before**
+the env write and HTTP request. The async API must claim that UUID; a repeated request returns the
+same run without a second provider pull. A lost 202 or runner crash is recovered only from that
+exact UUID, then the exact event/effect triple. Restore status is read by exact event/user/integration
+tuple rather than a recent-events page. No latest/sole-event inference is permitted.
+If the reserved run terminates without a matching ledger event, the journal intentionally blocks
+both overwrite and a guessed restore. That state requires an owner-reviewed abandonment procedure;
+operators must not delete the journal merely to retry.
+
+The full values-free execution record is `dingtalk-staging-lifecycle-canary-and-uat-execution-20260811.md`.
 
 ## Canary sequence
 
@@ -133,8 +151,8 @@ those ON actions stay **NOT EXECUTABLE**. The full values-free execution record 
 2. **Complete:** configure the fixed alias-canary login secrets without exposing their values.
 3. **Complete:** create/repair the dedicated canary administrators and prove password login with all flags OFF.
 4. **Complete:** dispatch `action=alias`; prove transient ON login and required OFF rollback login.
-5. **NOT EXECUTED:** real admit→activate on an explicitly owned DingTalk employee, then pending rollback.
-6. **NOT EXECUTED:** real source departure and deprovision/restore proof on that same employee, then rollback.
+5. **NOT EXECUTED (operator ready):** real admit→activate on an explicitly owned DingTalk employee, then pending rollback.
+6. **NOT EXECUTED (operator ready, dedicated integration required):** real source departure and deprovision/restore proof on that same employee, then rollback.
 7. Production remains a separate GO.
 
 ## Owner note

--- a/docs/development/dingtalk-lifecycle-six-step-closeout-execution-20260810.md
+++ b/docs/development/dingtalk-lifecycle-six-step-closeout-execution-20260810.md
@@ -2,10 +2,10 @@
 
 - Date: 2026-08-10
 - Updated: 2026-08-11
-- Status: **CODE + STAGING OFF-PREFLIGHT COMPLETE / ON CANARY AND EXTERNAL GATES NOT EXECUTED**
+- Status: **CODE + STAGING ALIAS CANARY COMPLETE / PENDING + DEPROVISION + EXTERNAL GATES NOT EXECUTED**
 - Baseline: `origin/main @ ddec28b12ebff97fae33af45553d77c149d816e1`
 - Scope: close the OPS-01 superseded creation-effect residue without enabling lifecycle traffic
-- Operator lane (staging only, default-off): `.github/workflows/dingtalk-lifecycle-staging-canary.yml` + `scripts/ops/dingtalk-lifecycle-staging-canary-remote.sh` — `status` and `preflight -> off` executed; no transition applied
+- Operator lane (staging only, default-off): `.github/workflows/dingtalk-lifecycle-staging-canary.yml` + `scripts/ops/dingtalk-lifecycle-staging-canary-remote.sh` — `status` and transient `alias -> off` executed; pending/deprovision not executed
 
 ## 1. OPS-01 explicit compensation
 
@@ -72,7 +72,7 @@ DIRECTORY_PENDING_ACTIVATION_ENABLED=false
 DIRECTORY_DEPROVISION_ENABLED=false
 ```
 
-Merge is not an enablement instruction. **Lifecycle canary is NOT EXECUTED** and must not be implied complete by this PR or by the operator lane landing.
+Merge is not an enablement instruction. The staging alias canary was later executed and returned to OFF; pending admission and deprovision remain **NOT EXECUTED**. See `dingtalk-staging-lifecycle-canary-and-uat-execution-20260811.md`.
 
 ### 3.1 Staging operator lane (what is actually executable)
 
@@ -87,13 +87,14 @@ Merge is not an enablement instruction. **Lifecycle canary is NOT EXECUTED** and
 | `status` | yes | values-free snapshot; multi-on reports then fail-closed |
 | `preflight` | yes | readiness only; `migrations_pending_zero` must be **exactly `true`** (`unknown` fails — never treated as success) |
 | `off` | yes | **sole env write**: emergency clear of the three gates; previous-override backup + restore on restart/health/mode failure; backend health must be true after restart; exact mode `off` proven |
-| `alias` / `pending` / `deprovision` | **NOT EXECUTABLE** | fail-closed preflight-only; `transition_applied=false` always. Env flip alone is not a canary — no secret-backed password-login / admit→activate / sync→deprovision verifier exists in this lane. Presence tokens are not ON enablers. |
+| `alias` | yes (transient) | secret-backed password login before ON, during alias-only, and after required OFF rollback |
+| `pending` / `deprovision` | **NOT EXECUTABLE** | fail-closed preflight-only; no admit→activate / sync→deprovision verifier exists in this lane. Presence tokens are not ON enablers. |
 
 `action=off` is an **emergency operational rollback of the env gate only**. Design lock Rev 4.2 §4.2 / §4.4 permanently forbids reintroducing OR-column fallback on `users.email` / `username` / `mobile` as a long-term design after T2b. OFF is not “canary stage 1 complete.”
 
-### 3.2 Staging preparation result (2026-08-11)
+### 3.2 Staging preparation and alias result (2026-08-11)
 
-Lifecycle ON canaries remain **NOT EXECUTED**. The safe OFF baseline is now proven:
+The safe OFF baseline and transient alias canary are proven:
 
 1. [Attendance staging runner 31407444155](https://github.com/zensgit/metasheet2/actions/runs/31407444155) completed host backup, clone rehearsal, isolation check, real migration, and auth round-trip. Migration state moved from `296 applied / 18 pending` to `314 applied / 0 pending`. The backup is retained on the deploy host; only its values-free metadata and SHA-256 entered the artifact.
 2. [#4853](https://github.com/zensgit/metasheet2/pull/4853), merge commit `ddec28b12ebff97fae33af45553d77c149d816e1`, made the staging runner install and validate the checked-out staging Compose file before deploy. It also pins Compose project-directory and exact `IMAGE_TAG` metadata. Exact-head CI passed 15/15.
@@ -101,16 +102,18 @@ Lifecycle ON canaries remain **NOT EXECUTED**. The safe OFF baseline is now prov
 4. [Lifecycle status 31418997337](https://github.com/zensgit/metasheet2/actions/runs/31418997337) reported `mode=off`, all three lifecycle flags `false`, exact build SHA, zero pending migrations, healthy backend, and `transition_applied=false`.
 5. [Lifecycle preflight 31419066036](https://github.com/zensgit/metasheet2/actions/runs/31419066036) reported `preflight_target_mode=off`, `preflight_ok=true`, all flags still OFF, and `transition_applied=false`.
 6. The existing `DEPLOY_KNOWN_HOSTS` secret supplies the independently verified host key. SSH and SCP require `StrictHostKeyChecking=yes`; this evidence lane does not accept first-use trust.
+7. [Lifecycle status 31504862038](https://github.com/zensgit/metasheet2/actions/runs/31504862038) re-proved the exact staging SHA, healthy backend, zero pending migrations, mode `off`, and all three flags `false`.
+8. [Lifecycle alias 31504979575](https://github.com/zensgit/metasheet2/actions/runs/31504979575) proved real password login before ON, while alias-only was live, and after rollback. It reported zero collisions and finished in exact mode `off` with all three flags `false`.
 
-The former image-tag/health-commit conflict is resolved. ON remains blocked by the absence of secret-backed real verifiers and owner GO. Future ON sequence (alias → pending → deprovision) is documentation-only and **NOT EXECUTABLE** here.
+The former image-tag/health-commit conflict is resolved. Alias production enablement remains a separate owner GO. Pending and deprovision remain blocked by the absence of explicit real test subjects and secret-backed real verifiers.
 
-### 3.3 Future stages (NOT EXECUTABLE in this lane today)
+### 3.3 Canary stages
 
-| Stage | Desired enable | Required real proof (missing today) |
+| Stage | Result | Required real proof |
 |---|---|---|
-| 1 | alias-only | password-login success against aliases + emergency `off` proof without OR-column fallback |
-| 2 | pending admission | admit→activate on an explicit canary subject (not a presence token) |
-| 3 | deprovision | sync→deprovision on an explicit canary integration; then `off` clears the writer |
+| 1 | alias-only **PASS, rolled back** | password-login success against aliases + required `off` proof without OR-column fallback |
+| 2 | pending admission **NOT EXECUTED** | admit→activate on an explicit canary subject (not a presence token) |
+| 3 | deprovision **NOT EXECUTED** | sync→deprovision on the same explicit canary subject; then `off` clears the writer |
 
 ## 4. Owner and ops acceptance
 
@@ -119,9 +122,9 @@ Real enterprise evidence is unavailable in this development lane. Therefore thes
 - U1-U13 interactive-card acceptance;
 - U11-a real callback corp-anchor;
 - named owners and final production switch decisions;
-- lifecycle canary ON stages (alias/pending/deprovision);
+- lifecycle pending/deprovision stages (alias staging canary passed and rolled back; production alias remains a separate decision);
 
-Staging `status` and `preflight -> off` are complete per §3.2. Emergency `action=off` was not needed because live mode was already exactly OFF; no env write was performed.
+Staging `status` and alias `off -> alias -> off` are complete per §3.2. The alias run's success condition included runtime OFF and a post-rollback password login.
 
 The interactive-card procedure of record remains `dingtalk-hardening-real-uat-evidence-pack-20260713.md`.
 
@@ -154,4 +157,4 @@ The code and safe staging OFF-preflight portions of this six-step closeout are c
 | Per-lane scratch DB mitigation, #4852 | `f0745831fe5385ccacf8fe6d6e5fd51174c02117` |
 | Exact staging Compose/provenance sync, #4853 | `ddec28b12ebff97fae33af45553d77c149d816e1` |
 
-Lifecycle ON canaries, U1-U13/corp-anchor, named owner decisions, and the real two-corp T2-Gate are deliberately **NOT EXECUTED**. Transfer T3-T5 remains frozen. Issue #4820 remains open for recurrence observation. None of those gates is represented as PASS by this closeout.
+The staging alias canary is complete and rolled back. Pending/deprovision canaries, U1-U13/corp-anchor, named production decisions, and the real two-corp T2-Gate are deliberately **NOT EXECUTED**. Transfer T3-T5 remains frozen. Issue #4820 remains open for recurrence observation. None of those remaining gates is represented as PASS by this closeout.

--- a/docs/development/dingtalk-lifecycle-six-step-closeout-execution-20260810.md
+++ b/docs/development/dingtalk-lifecycle-six-step-closeout-execution-20260810.md
@@ -1,7 +1,7 @@
 # DingTalk lifecycle six-step closeout execution
 
 - Date: 2026-08-10
-- Updated: 2026-08-11
+- Updated: 2026-08-12
 - Status: **CODE + STAGING ALIAS CANARY COMPLETE / PENDING + DEPROVISION + EXTERNAL GATES NOT EXECUTED**
 - Baseline: `origin/main @ ddec28b12ebff97fae33af45553d77c149d816e1`
 - Scope: close the OPS-01 superseded creation-effect residue without enabling lifecycle traffic
@@ -88,7 +88,8 @@ Merge is not an enablement instruction. The staging alias canary was later execu
 | `preflight` | yes | readiness only; `migrations_pending_zero` must be **exactly `true`** (`unknown` fails — never treated as success) |
 | `off` | yes | **sole env write**: emergency clear of the three gates; previous-override backup + restore on restart/health/mode failure; backend health must be true after restart; exact mode `off` proven |
 | `alias` | yes (transient) | secret-backed password login before ON, during alias-only, and after required OFF rollback |
-| `pending` / `deprovision` | **NOT EXECUTABLE** | fail-closed preflight-only; no admit→activate / sync→deprovision verifier exists in this lane. Presence tokens are not ON enablers. |
+| `pending` | yes (transient, **NOT EXECUTED**) | explicit owned directory-account subject; admit-only or optional SSO activation; success requires OFF rollback; unobserved browser OAuth stays `NOT_EXECUTED` |
+| `deprovision` | yes (two-phase, **NOT EXECUTED**) | explicit owned subject in a dedicated one-account manual integration; exact preview/planner radius; pre-request reserved run UUID; exact ledger/restore; success requires OFF rollback |
 
 `action=off` is an **emergency operational rollback of the env gate only**. Design lock Rev 4.2 §4.2 / §4.4 permanently forbids reintroducing OR-column fallback on `users.email` / `username` / `mobile` as a long-term design after T2b. OFF is not “canary stage 1 complete.”
 
@@ -105,15 +106,15 @@ The safe OFF baseline and transient alias canary are proven:
 7. [Lifecycle status 31504862038](https://github.com/zensgit/metasheet2/actions/runs/31504862038) re-proved the exact staging SHA, healthy backend, zero pending migrations, mode `off`, and all three flags `false`.
 8. [Lifecycle alias 31504979575](https://github.com/zensgit/metasheet2/actions/runs/31504979575) proved real password login before ON, while alias-only was live, and after rollback. It reported zero collisions and finished in exact mode `off` with all three flags `false`.
 
-The former image-tag/health-commit conflict is resolved. Alias production enablement remains a separate owner GO. Pending and deprovision remain blocked by the absence of explicit real test subjects and secret-backed real verifiers.
+The former image-tag/health-commit conflict is resolved. Alias production enablement remains a separate owner GO. Pending and deprovision operators are implemented but remain blocked by the absence of an explicitly owned real test subject and, for deprovision, a dedicated one-account integration. The existing shared employee integration is not eligible.
 
 ### 3.3 Canary stages
 
 | Stage | Result | Required real proof |
 |---|---|---|
 | 1 | alias-only **PASS, rolled back** | password-login success against aliases + required `off` proof without OR-column fallback |
-| 2 | pending admission **NOT EXECUTED** | admit→activate on an explicit canary subject (not a presence token) |
-| 3 | deprovision **NOT EXECUTED** | sync→deprovision on the same explicit canary subject; then `off` clears the writer |
+| 2 | pending admission **NOT EXECUTED** | transient admit→activate on an explicit canary subject (not a presence token), then prove OFF |
+| 3 | deprovision **NOT EXECUTED** | dedicated one-account integration; reserved exact run UUID; sync→ledger→restore on the same subject, then prove OFF |
 
 ## 4. Owner and ops acceptance
 

--- a/docs/development/dingtalk-staging-lifecycle-canary-and-uat-execution-20260811.md
+++ b/docs/development/dingtalk-staging-lifecycle-canary-and-uat-execution-20260811.md
@@ -1,0 +1,200 @@
+# DingTalk staging lifecycle canary and UAT execution record (2026-08-11)
+
+- Status: **PARTIAL EXECUTION / ALIAS CANARY PASS / PENDING + DEPROVISION + U1-U13 NOT EXECUTED**
+- Repository evidence head: `325917c0a484522ef9ce87b286d5d986d4e205b3`
+- Lifecycle staging deploy SHA: `ddec28b12ebff97fae33af45553d77c149d816e1`
+- Production-readiness inventory deploy SHA: `e27c8dbabb798cd1d3c407f1601430fd151df5bc`
+- Owner instruction: keep all lifecycle flags OFF after every canary; do not convert missing real-enterprise evidence into PASS.
+
+This is a values-free execution record. It contains counts, booleans, reason enums, SHAs,
+and GitHub Actions run ids only. It intentionally omits passwords, tokens, names, email
+addresses, phone numbers, DingTalk user ids, union ids, and corp-id values.
+
+## 1. Environment boundary
+
+Two independently configured deployment roots were observed and must not be conflated:
+
+| Evidence lane | Deployed SHA | Purpose |
+|---|---|---|
+| Lifecycle staging canary (`STAGING_DEPLOY_PATH`) | `ddec28b12ebff97fae33af45553d77c149d816e1` | Exact lifecycle status and transient alias ON/OFF proof |
+| Production-readiness inventory (`DEPLOY_PATH`) | `e27c8dbabb798cd1d3c407f1601430fd151df5bc` | Read-only DingTalk integration, account, Stream, and flag inventory |
+
+Neither SHA is used as proof for the other environment. Production enablement remains a
+separate owner/ops decision.
+
+## 2. Canary administrator credential
+
+The fixed staging-only administrator `staging-owner-admin` was repaired/rotated through the
+real administrative API. The new value was not printed or committed. It is retained in the
+operator's macOS Keychain and in the GitHub Actions secret
+`STAGING_OWNER_ADMIN_PASSWORD`; GitHub secret metadata records an update at
+`2026-08-11T15:00:47Z`.
+
+The real login proof is not inferred from secret presence. Alias run
+[31504979575](https://github.com/zensgit/metasheet2/actions/runs/31504979575) proved all three
+password-login legs using the configured canary credential:
+
+- before alias enable: `pre_login_ok=true`;
+- while alias-only was live: `post_on_login_ok=true`;
+- after rollback to OFF: `post_rollback_login_ok=true`.
+
+Password rotation and secret assignment do not authorize any lifecycle flag.
+
+## 3. Exact OFF baseline
+
+[Lifecycle status run 31504862038](https://github.com/zensgit/metasheet2/actions/runs/31504862038)
+completed successfully at repository head
+`325917c0a484522ef9ce87b286d5d986d4e205b3`. Its downloaded values-free artifact reports:
+
+| Check | Result |
+|---|---|
+| staging build SHA | `ddec28b12ebff97fae33af45553d77c149d816e1` |
+| backend health | `true` |
+| migrations pending zero | `true` |
+| mode | `off` |
+| `AUTH_LOGIN_USE_ALIASES` | `false` |
+| `DIRECTORY_PENDING_ACTIVATION_ENABLED` | `false` |
+| `DIRECTORY_DEPROVISION_ENABLED` | `false` |
+| transition applied | `false` (read-only status action) |
+
+## 4. Canary sequence
+
+| Order | Stage | Result | Durable evidence / reason |
+|---|---|---|---|
+| 1 | alias-only | **PASS, rolled back** | Run `31504979575`; transient ON was proven by real password login and success required a return to exact OFF |
+| 2 | pending admission | **NOT EXECUTED** | No explicitly owned DingTalk source employee exists for a destructive admit -> activate test; no existing employee may be auto-selected |
+| 3 | deprovision | **NOT EXECUTED** | Requires a real source-side disable/removal of the same dedicated canary employee after pending activation succeeds |
+
+### 4.1 Alias result
+
+The alias run reported:
+
+```text
+transition_applied=true
+alias_on_applied=true
+pre_login_ok=true
+post_on_login_ok=true
+post_rollback_login_ok=true
+rolled_back_to_off=true
+backfill_ok=true
+backfill_inserted=0
+backfill_collisions=0
+backfill_skipped_empty=20
+cutover_ready=true
+cutover_can_enable=true
+```
+
+Its final artifact again reported mode `off`, all three flags `false`, healthy backend,
+zero pending migrations, and the same staging build SHA. Alias rows created by a backfill
+would be allowed to persist, but this execution inserted zero rows.
+
+### 4.2 Pending admission gate
+
+A read-only account inspection found active unmatched directory accounts, but none was
+explicitly designated and owned as a staging test employee. Those accounts may represent real
+people. Therefore the operator did not admit, activate, rename, disable, or otherwise mutate
+them. Presence of an unmatched account is not consent to use it as a canary.
+
+Required external input before execution:
+
+1. create or designate one dedicated DingTalk staging employee owned by the test;
+2. record only a values-free selection proof in the execution artifact;
+3. run sync/admit with pending enabled in a rollback-armed window;
+4. prove pending cannot log in, then activate it and prove the intended login path;
+5. restore `DIRECTORY_PENDING_ACTIVATION_ENABLED=false` and re-prove mode OFF.
+
+### 4.3 Deprovision gate
+
+The read-only directory preview saw no removal candidate and reported zero would-deactivate
+accounts. Deprovision cannot be proven by editing the local database or by selecting a real
+employee. After Section 4.2 succeeds, an authorized operator must disable/remove that same
+dedicated employee at the DingTalk source, run sync with deprovision transiently enabled,
+verify the event/effect ledger and access denial, exercise restore as specified, and then
+return the flag to OFF.
+
+## 5. DingTalk directory readiness
+
+[Production-readiness inventory run 31505420277](https://github.com/zensgit/metasheet2/actions/runs/31505420277)
+completed successfully and reported:
+
+| Signal | Result |
+|---|---|
+| read-only probe | `true` |
+| active DingTalk integrations | `1` |
+| active corp-anchored integrations | `1` |
+| active directory accounts | `2` |
+| active linked local users | `2` |
+| at least two linked users ready | `true` |
+| directory UAT baseline ready | `true` |
+| app key / app secret / agent id readiness | `true` |
+| allowed-corp allowlist | `configured` |
+| pending users | `0` |
+| all lifecycle/Stream flags OFF | `true` |
+
+This proves a usable directory baseline, not pending/deprovision canary completion and not
+interactive-card readiness.
+
+## 6. U1-U13 and real callback corp-anchor
+
+The canonical procedure remains
+`docs/development/dingtalk-hardening-real-uat-evidence-pack-20260713.md`. No row below is
+simulated.
+
+| Gate | Result | Blocking evidence |
+|---|---|---|
+| U1-U13 (including U3-a and U11-b) | **NOT EXECUTED** | Stream client id, client secret, card template id, and integration id are all absent from the runtime inventory |
+| U11-a real callback corp-anchor | **NOT EXECUTED** | No real card can be sent/clicked without the Stream/template configuration; no callback frame was captured |
+| P1 latest storage-health precondition | conditionally ready, recheck at UAT start | Latest observed `Attendance Remote Storage Health (Prod)` run [31453711071](https://github.com/zensgit/metasheet2/actions/runs/31453711071) was successful; the evidence pack requires a fresh check at the actual UAT start |
+| P2 exact target SHA | known per environment | See Section 1; do not mix the two deployment roots |
+| P3 real corp + two linked users | directory subset ready only | Corp anchor and two linked users exist, but Stream app/template configuration is absent |
+| P4 `LOG_LEVEL=info|debug` | **NOT PROVEN** | Inventory reported log-level reason `missing`; silence cannot be interpreted as callback-shape evidence |
+
+Runtime inventory details for the missing Stream prerequisites:
+
+```text
+client_id_present=false
+client_secret_present=false
+template_id_present=false
+integration_id_present=false
+credentials_ready=false
+```
+
+Required external action: configure the four staging Stream/template inputs through the
+approved secret/configuration channel, set `LOG_LEVEL=info` for the controlled UAT window,
+execute the canonical U1-U13 procedure with real human clicks, capture only values-free
+booleans/status enums, and turn the Stream flag back OFF after U13. Secrets must not be pasted
+into this document or chat.
+
+## 7. Production and transfer gates
+
+| Decision | Current verdict |
+|---|---|
+| production alias enable | **NO GO** until owner reviews staging evidence and separately authorizes production |
+| production pending enable | **NO GO**; staging pending canary not executed |
+| production deprovision enable | **NO GO**; staging pending and deprovision canaries not executed |
+| interactive-card Stream enable | **NO GO**; U1-U13/U11-a not executed |
+| Transfer T3-T5 | **FROZEN**; real two-corp T2-Gate remains separate and unexecuted |
+
+The safe terminal state for this execution is therefore:
+
+```text
+AUTH_LOGIN_USE_ALIASES=false
+DIRECTORY_PENDING_ACTIVATION_ENABLED=false
+DIRECTORY_DEPROVISION_ENABLED=false
+DINGTALK_INTERACTIVE_CARD_STREAM_ENABLED=false
+```
+
+## 8. Next executable actions
+
+1. The owner completes the open DingTalk OAuth browser handoff; record success or the
+   values-free rejection reason. This is login evidence only, not U11-a.
+2. Provision one dedicated staging DingTalk employee and authorize its use for pending and
+   deprovision canaries.
+3. Execute pending, prove rollback to OFF, then execute deprovision and prove rollback to OFF.
+4. Configure the staging Stream/template inputs and `LOG_LEVEL=info`; execute U1-U13 and the
+   real callback corp-anchor procedure.
+5. Record named owners and explicit production switch decisions. Any absent evidence remains
+   `NOT EXECUTED`.
+
+Until those external actions occur, the lifecycle code line and alias staging canary are
+closed, but production enablement and real-enterprise acceptance are not.

--- a/docs/development/dingtalk-staging-lifecycle-canary-and-uat-execution-20260811.md
+++ b/docs/development/dingtalk-staging-lifecycle-canary-and-uat-execution-20260811.md
@@ -1,6 +1,6 @@
 # DingTalk staging lifecycle canary and UAT execution record (2026-08-11)
 
-- Status: **PARTIAL EXECUTION / ALIAS CANARY PASS / PENDING + DEPROVISION + U1-U13 NOT EXECUTED**
+- Status: **PARTIAL EXECUTION / ALIAS + OAUTH LOGIN PASS / PENDING + DEPROVISION + U1-U13 NOT EXECUTED**
 - Repository evidence head: `325917c0a484522ef9ce87b286d5d986d4e205b3`
 - Lifecycle staging deploy SHA: `ddec28b12ebff97fae33af45553d77c149d816e1`
 - Production-readiness inventory deploy SHA: `e27c8dbabb798cd1d3c407f1601430fd151df5bc`
@@ -39,6 +39,28 @@ password-login legs using the configured canary credential:
 - after rollback to OFF: `post_rollback_login_ok=true`.
 
 Password rotation and secret assignment do not authorize any lifecycle flag.
+
+### 2.1 Real DingTalk account binding and login
+
+The operator completed the DingTalk consent in an authenticated
+`staging-owner-admin` browser session. The callback returned to the settings page with the
+bound result, and a fresh status read showed all of the following simultaneously:
+
+```text
+dingtalk_available=true
+dingtalk_enabled=true
+dingtalk_identity_bound=true
+directory_managed=false
+```
+
+The browser then logged out of the password-authenticated session, returned to `/login`, and
+selected `Use DingTalk login`. Without entering the local password again, the real DingTalk
+OAuth callback completed and redirected to the authenticated `/attendance` page. The earlier
+fail-closed `unlinked_enabled_local_user` result therefore changed to a successful login only
+after the explicit binding operation.
+
+This is evidence for account binding and DingTalk OAuth login only. It is not evidence for the
+interactive-card Stream callback gate in Section 6.
 
 ## 3. Exact OFF baseline
 
@@ -186,14 +208,12 @@ DINGTALK_INTERACTIVE_CARD_STREAM_ENABLED=false
 
 ## 8. Next executable actions
 
-1. The owner completes the open DingTalk OAuth browser handoff; record success or the
-   values-free rejection reason. This is login evidence only, not U11-a.
-2. Provision one dedicated staging DingTalk employee and authorize its use for pending and
+1. Provision one dedicated staging DingTalk employee and authorize its use for pending and
    deprovision canaries.
-3. Execute pending, prove rollback to OFF, then execute deprovision and prove rollback to OFF.
-4. Configure the staging Stream/template inputs and `LOG_LEVEL=info`; execute U1-U13 and the
+2. Execute pending, prove rollback to OFF, then execute deprovision and prove rollback to OFF.
+3. Configure the staging Stream/template inputs and `LOG_LEVEL=info`; execute U1-U13 and the
    real callback corp-anchor procedure.
-5. Record named owners and explicit production switch decisions. Any absent evidence remains
+4. Record named owners and explicit production switch decisions. Any absent evidence remains
    `NOT EXECUTED`.
 
 Until those external actions occur, the lifecycle code line and alias staging canary are

--- a/docs/development/dingtalk-staging-lifecycle-canary-and-uat-execution-20260811.md
+++ b/docs/development/dingtalk-staging-lifecycle-canary-and-uat-execution-20260811.md
@@ -1,7 +1,7 @@
 # DingTalk staging lifecycle canary and UAT execution record (2026-08-11)
 
-- Status: **PARTIAL EXECUTION / ALIAS + OAUTH LOGIN PASS / PENDING + DEPROVISION + U1-U13 NOT EXECUTED**
-- Repository evidence head: `325917c0a484522ef9ce87b286d5d986d4e205b3`
+- Status: **PARTIAL EXECUTION / ALIAS + DESIGNATED ADMIN OAUTH LOGIN PASS / PENDING + DEPROVISION + U1-U13 NOT EXECUTED**
+- Repository evidence head: `0287b250b33fe4c7ea98b880360af74fc08a5ebf`
 - Lifecycle staging deploy SHA: `ddec28b12ebff97fae33af45553d77c149d816e1`
 - Production-readiness inventory deploy SHA: `e27c8dbabb798cd1d3c407f1601430fd151df5bc`
 - Owner instruction: keep all lifecycle flags OFF after every canary; do not convert missing real-enterprise evidence into PASS.
@@ -62,6 +62,33 @@ after the explicit binding operation.
 This is evidence for account binding and DingTalk OAuth login only. It is not evidence for the
 interactive-card Stream callback gate in Section 6.
 
+### 2.2 Designated DingTalk administrator login
+
+The operator selected the existing active directory account designated for this staging
+administrator check. A read-only inventory first proved that it was linked to one local user and
+had a complete DingTalk identity, but had no DingTalk login grant and did not have the platform
+administrator role. With explicit owner approval, the administrative API then performed exactly
+two auditable access-graph changes for that existing local user:
+
+```text
+platform_admin=true
+dingtalk_login_grant_enabled=true
+directory_linked=true
+identity_union_id_present=true
+identity_open_id_present=true
+```
+
+The OAuth chooser initially presented a different cached DingTalk account. That account was not
+authorized; the operator returned to the account chooser and completed consent with the designated
+administrator account. The backend recorded a fresh DingTalk login at
+`2026-08-11T16:40:37.205Z`, the callback redirected to the authenticated `/attendance` page, and
+the same browser session subsequently loaded `/admin/users` successfully. This proves both the
+real DingTalk login and effective platform-administrator authorization. It does not identify or
+authorize a destructive pending/deprovision canary subject.
+
+These access-graph changes did not write any lifecycle environment switch. The fresh OFF proof in
+Section 3 was taken after the changes.
+
 ## 3. Exact OFF baseline
 
 [Lifecycle status run 31504862038](https://github.com/zensgit/metasheet2/actions/runs/31504862038)
@@ -78,6 +105,14 @@ completed successfully at repository head
 | `DIRECTORY_PENDING_ACTIVATION_ENABLED` | `false` |
 | `DIRECTORY_DEPROVISION_ENABLED` | `false` |
 | transition applied | `false` (read-only status action) |
+
+A second read-only status run
+[31513394261](https://github.com/zensgit/metasheet2/actions/runs/31513394261) completed after the
+designated administrator role/grant change at repository head
+`0287b250b33fe4c7ea98b880360af74fc08a5ebf`. Its downloaded artifact again reports the same
+staging build SHA, healthy backend, zero pending migrations, `mode=off`, all three lifecycle flags
+`false`, and `transition_applied=false`. This is the current terminal-state proof; the earlier run
+remains the pre-change baseline.
 
 ## 4. Canary sequence
 

--- a/docs/development/dingtalk-staging-lifecycle-canary-and-uat-execution-20260811.md
+++ b/docs/development/dingtalk-staging-lifecycle-canary-and-uat-execution-20260811.md
@@ -1,6 +1,6 @@
 # DingTalk staging lifecycle canary and UAT execution record (2026-08-11)
 
-- Status: **PARTIAL EXECUTION / ALIAS + DESIGNATED ADMIN OAUTH LOGIN PASS / PENDING + DEPROVISION + U1-U13 NOT EXECUTED**
+- Status: **PARTIAL EXECUTION / ALIAS + DESIGNATED ADMIN OAUTH LOGIN PASS / PENDING + DEPROVISION OPERATORS READY BUT NOT EXECUTED / U1-U13 NOT EXECUTED**
 - Repository evidence head: `0287b250b33fe4c7ea98b880360af74fc08a5ebf`
 - Lifecycle staging deploy SHA: `ddec28b12ebff97fae33af45553d77c149d816e1`
 - Production-readiness inventory deploy SHA: `e27c8dbabb798cd1d3c407f1601430fd151df5bc`
@@ -119,8 +119,8 @@ remains the pre-change baseline.
 | Order | Stage | Result | Durable evidence / reason |
 |---|---|---|---|
 | 1 | alias-only | **PASS, rolled back** | Run `31504979575`; transient ON was proven by real password login and success required a return to exact OFF |
-| 2 | pending admission | **NOT EXECUTED** | No explicitly owned DingTalk source employee exists for a destructive admit -> activate test; no existing employee may be auto-selected |
-| 3 | deprovision | **NOT EXECUTED** | Requires a real source-side disable/removal of the same dedicated canary employee after pending activation succeeds |
+| 2 | pending admission | **NOT EXECUTED** | Operator exists, but no explicitly owned DingTalk source employee has been proven in the target integration; no existing employee may be auto-selected |
+| 3 | deprovision | **NOT EXECUTED** | Operator exists, but requires the same owned employee in a dedicated one-account integration plus a real source-side disable/removal |
 
 ### 4.1 Alias result
 
@@ -160,14 +160,34 @@ Required external input before execution:
 4. prove pending cannot log in, then activate it and prove the intended login path;
 5. restore `DIRECTORY_PENDING_ACTIVATION_ENABLED=false` and re-prove mode OFF.
 
+The operator accepts only the explicit directory-account secret. Its default phase proves pending
+admission and OFF rollback. Optional `PENDING_SSO_ACTIVATE` uses the real SSO activation path, but
+browser OAuth remains `NOT_EXECUTED` unless a human completes and observes that callback; the
+script does not promote an unobserved browser step to PASS.
+
 ### 4.3 Deprovision gate
 
-The read-only directory preview saw no removal candidate and reported zero would-deactivate
-accounts. Deprovision cannot be proven by editing the local database or by selecting a real
-employee. After Section 4.2 succeeds, an authorized operator must disable/remove that same
-dedicated employee at the DingTalk source, run sync with deprovision transiently enabled,
-verify the event/effect ledger and access denial, exercise restore as specified, and then
-return the flag to OFF.
+The earlier read-only directory preview saw no removal candidate and reported zero
+would-deactivate accounts. A later browser inspection showed that the active integration is a
+shared employee integration, so it is explicitly disqualified from destructive canary use.
+Deprovision cannot be proven by editing the local database or by selecting a real employee.
+
+After Section 4.2 succeeds, an authorized operator must create/use a separate active DingTalk
+integration that contains exactly the selected account (all active and inactive account rows
+count), has scheduler, admission automation, and member-group projection disabled, and uses
+`mark_inactive`. Apply requires
+`DINGTALK_SOURCE_DISABLED_DEDICATED_EXCLUSIVE_CONFIRMED`, which attests that the source is disabled
+and no other operator will sync or edit this dedicated integration until the lifecycle flags are
+proven OFF. The preview and one-account checks are not an atomic scope lock, so this exclusive
+window is mandatory. The apply sequence then requires an exact one-subject preview and planner result,
+persists a random sync run UUID before env/HTTP, transiently enables only deprovision, and starts
+the async sync with that UUID. A lost 202 or runner crash retains the exact recovery journal;
+retries cannot start a second provider pull with the same UUID. Recovery binds only that run's
+single event and exact membership/grant/user effect triple. Restore probes the exact event tuple,
+reverses it, verifies the exact effect set and access graph, and leaves all three flags OFF.
+An exact run that terminates without a matching ledger event leaves a fail-closed journal. It must
+be resolved through an owner-reviewed abandonment procedure; deleting the journal to force a new
+apply is prohibited.
 
 ## 5. DingTalk directory readiness
 
@@ -243,12 +263,15 @@ DINGTALK_INTERACTIVE_CARD_STREAM_ENABLED=false
 
 ## 8. Next executable actions
 
-1. Provision one dedicated staging DingTalk employee and authorize its use for pending and
-   deprovision canaries.
-2. Execute pending, prove rollback to OFF, then execute deprovision and prove rollback to OFF.
-3. Configure the staging Stream/template inputs and `LOG_LEVEL=info`; execute U1-U13 and the
+1. Complete the target-enterprise selection for the operator-controlled DingTalk account and
+   verify it appears in a read-only directory preview; otherwise provision it in the target corp.
+2. Provision a dedicated staging DingTalk employee and a separate one-account manual integration;
+   authorize that subject for pending and deprovision canaries.
+3. Execute pending and prove rollback to OFF, then execute two-phase deprovision and prove restore
+   plus rollback to OFF.
+4. Configure the staging Stream/template inputs and `LOG_LEVEL=info`; execute U1-U13 and the
    real callback corp-anchor procedure.
-4. Record named owners and explicit production switch decisions. Any absent evidence remains
+5. Record named owners and explicit production switch decisions. Any absent evidence remains
    `NOT EXECUTED`.
 
 Until those external actions occur, the lifecycle code line and alias staging canary are

--- a/packages/core-backend/src/directory/directory-sync.ts
+++ b/packages/core-backend/src/directory/directory-sync.ts
@@ -3554,6 +3554,22 @@ export class DirectorySyncInProgressError extends Error {
 }
 
 /**
+ * Async callers may reserve the run UUID before the request so a lost 202 response
+ * never loses correlation with a destructive sync. Reusing that UUID is an
+ * idempotent observation of the original run, not permission to execute it again.
+ */
+export class DirectorySyncRunReplayError extends Error {
+  readonly code = 'DIRECTORY_SYNC_RUN_REPLAY'
+  readonly runId: string
+
+  constructor(runId: string) {
+    super(`Directory sync run ${runId} already exists`)
+    this.name = 'DirectorySyncRunReplayError'
+    this.runId = runId
+  }
+}
+
+/**
  * Transfer MVP T2 (§12.2): an ACTIVE org transfer freezes its SOURCE integration's sync. The
  * dangerous write a mid-transfer sync performs is the unconditional absence sweep — a source
  * tenant being emptied/migrated looks exactly like "everyone left", and the sweep would mark the
@@ -3715,18 +3731,36 @@ async function claimDirectorySyncRun(
   integrationId: string,
   triggeredBy: string,
   triggerSource: 'manual' | 'scheduler',
+  requestedRunId?: string,
 ): Promise<{ rows: DirectoryRunRow[] }> {
   try {
     return await query<DirectoryRunRow>(
       `INSERT INTO directory_sync_runs (
-         integration_id, status, started_at, stats, meta, triggered_by, trigger_source, created_at, updated_at
+         id, integration_id, status, started_at, stats, meta, triggered_by, trigger_source, created_at, updated_at
        )
-       VALUES ($1, 'running', NOW(), '{}'::jsonb, '{}'::jsonb, $2, $3, NOW(), NOW())
+       VALUES (COALESCE($4::uuid, gen_random_uuid()), $1, 'running', NOW(), '{}'::jsonb, '{}'::jsonb, $2, $3, NOW(), NOW())
        RETURNING id, integration_id, status, started_at, finished_at, stats, error_message, triggered_by, trigger_source, created_at, updated_at`,
-      [integrationId, triggeredBy, triggerSource],
+      [integrationId, triggeredBy, triggerSource, requestedRunId ?? null],
     )
   } catch (error) {
     if (isUniqueViolation(error)) {
+      if (requestedRunId) {
+        const replay = await query<{ id: string }>(
+          `SELECT id
+             FROM directory_sync_runs
+            WHERE id = $1
+              AND integration_id = $2
+            LIMIT 1`,
+          [requestedRunId, integrationId],
+        )
+        if (replay.rows.length === 1) {
+          const activeRunId = await findActiveDirectorySyncRunId(integrationId)
+          if (activeRunId && activeRunId !== replay.rows[0].id) {
+            throw new DirectorySyncInProgressError(activeRunId)
+          }
+          throw new DirectorySyncRunReplayError(requestedRunId)
+        }
+      }
       throw new DirectorySyncInProgressError(await findActiveDirectorySyncRunId(integrationId))
     }
     throw error
@@ -3742,7 +3776,7 @@ export async function syncDirectoryIntegration(
    * caller that wants to answer 202 needs the runId, and only the runId, up front — it
    * cannot wait for a large-tenant walk to finish inside an HTTP request.
    */
-  hooks: { onRunStarted?: (runId: string) => void } = {},
+  hooks: { onRunStarted?: (runId: string) => void; requestedRunId?: string } = {},
 ): Promise<{
   integration: DirectoryIntegrationSummary
   run: DirectorySyncRunSummary
@@ -3774,7 +3808,12 @@ export async function syncDirectoryIntegration(
   // later apply would not protect it. Expired leases are reclaimed first so a crashed
   // run cannot wedge an integration forever.
   await reclaimStaleDirectorySyncRuns(integrationId)
-  const runResult = await claimDirectorySyncRun(integrationId, triggeredBy, triggerSource)
+  const runResult = await claimDirectorySyncRun(
+    integrationId,
+    triggeredBy,
+    triggerSource,
+    hooks.requestedRunId,
+  )
   const runId = runResult.rows[0].id
   // R5: wall-clock anchor for stats.durationMs. Measured app-side from the lease claim to
   // just before the completion UPDATE (stats is serialized inside the transaction), so it
@@ -4976,6 +5015,21 @@ export async function listDirectorySyncRuns(
     items: rowsResult.rows.map(summarizeRun),
     total: Number(totalResult.rows[0]?.total ?? 0),
   }
+}
+
+export async function getDirectorySyncRun(
+  integrationId: string,
+  runId: string,
+): Promise<DirectorySyncRunSummary | null> {
+  const result = await query<DirectoryRunRow>(
+    `SELECT id, integration_id, status, started_at, finished_at, stats, error_message, triggered_by, trigger_source, created_at, updated_at
+       FROM directory_sync_runs
+      WHERE integration_id = $1
+        AND id = $2
+      LIMIT 1`,
+    [integrationId, runId],
+  )
+  return result.rows[0] ? summarizeRun(result.rows[0]) : null
 }
 
 export async function listDirectorySyncAlerts(

--- a/packages/core-backend/src/routes/admin-directory.ts
+++ b/packages/core-backend/src/routes/admin-directory.ts
@@ -5,6 +5,7 @@ import { Logger } from '../core/logger'
 import {
   DirectorySyncFrozenByTransferError,
   DirectorySyncInProgressError,
+  DirectorySyncRunReplayError,
   DirectoryTenantChangeBlockedError,
   acknowledgeDirectorySyncAlert,
   admitDirectoryAccountUser,
@@ -14,6 +15,7 @@ import {
   bindDirectoryAccount,
   createDirectoryIntegration,
   getDirectorySyncScheduleSnapshot,
+  getDirectorySyncRun,
   getDirectoryAccountSummary,
   getDirectoryReviewItem,
   listDirectoryIntegrationAccounts,
@@ -533,9 +535,17 @@ export function adminDirectoryRouter(): Router {
     // where the pull outlives any sane request timeout) ask for 202 + runId and poll the
     // runs endpoint.
     if (req.body?.async === true) {
+      const requestedRunId = typeof req.body?.runId === 'string' ? req.body.runId.trim() : ''
+      if (requestedRunId && !UUID_SHAPE_RE.test(requestedRunId)) {
+        jsonError(res, 400, 'DIRECTORY_SYNC_RUN_ID_INVALID', 'runId must be a UUID')
+        return
+      }
       try {
         const runId = await new Promise<string>((resolve, reject) => {
-          syncDirectoryIntegration(req.params.integrationId, adminUserId, 'manual', { onRunStarted: resolve })
+          syncDirectoryIntegration(req.params.integrationId, adminUserId, 'manual', {
+            onRunStarted: resolve,
+            requestedRunId: requestedRunId || undefined,
+          })
             .then((result) => {
               logger.info(`Async directory sync finished for ${req.params.integrationId} (run ${result.run.id})`)
             })
@@ -551,6 +561,16 @@ export function adminDirectoryRouter(): Router {
         jsonOk(res, { accepted: true, runId, integrationId: req.params.integrationId })
         return
       } catch (error) {
+        if (error instanceof DirectorySyncRunReplayError) {
+          res.status(202)
+          jsonOk(res, {
+            accepted: true,
+            runId: error.runId,
+            integrationId: req.params.integrationId,
+            replayed: true,
+          })
+          return
+        }
         // DT-HARDEN-05: the lease conflict is thrown by the claim, BEFORE onRunStarted
         // ever fires, so it always lands in this catch — and it is the same benign
         // "already running" state as in the non-async branch below. Map it identically:
@@ -632,6 +652,26 @@ export function adminDirectoryRouter(): Router {
       })
     } catch (error) {
       jsonError(res, 500, 'DIRECTORY_RUNS_FAILED', readErrorMessage(error, 'Failed to load sync runs'))
+    }
+  })
+
+  router.get('/integrations/:integrationId/runs/:runId', async (req: Request, res: Response) => {
+    const adminUserId = await ensurePlatformAdmin(req, res)
+    if (!adminUserId) return
+    if (!UUID_SHAPE_RE.test(req.params.runId)) {
+      jsonError(res, 400, 'DIRECTORY_SYNC_RUN_ID_INVALID', 'runId must be a UUID')
+      return
+    }
+
+    try {
+      const run = await getDirectorySyncRun(req.params.integrationId, req.params.runId)
+      if (!run) {
+        jsonError(res, 404, 'DIRECTORY_RUN_NOT_FOUND', 'Directory sync run not found')
+        return
+      }
+      jsonOk(res, { run })
+    } catch (error) {
+      jsonError(res, 500, 'DIRECTORY_RUN_FAILED', readErrorMessage(error, 'Failed to load sync run'))
     }
   })
 

--- a/packages/core-backend/tests/integration/directory-sync-orchestration.db.test.ts
+++ b/packages/core-backend/tests/integration/directory-sync-orchestration.db.test.ts
@@ -1,4 +1,5 @@
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
+import { randomUUID } from 'node:crypto'
 
 // R1-L4 — the syncDirectoryIntegration ORCHESTRATION HARNESS.
 //
@@ -42,6 +43,8 @@ import { applyDirectoryDeprovisionCandidate } from '../../src/directory/deprovis
 import {
   createDirectoryIntegration,
   DirectorySyncInProgressError,
+  DirectorySyncRunReplayError,
+  getDirectorySyncRun,
   syncDirectoryIntegration,
 } from '../../src/directory/directory-sync'
 import {
@@ -211,6 +214,50 @@ async function pollUntil<T>(read: () => Promise<T>, done: (value: T) => boolean,
 describeIfDatabase('syncDirectoryIntegration orchestration harness (real DB)', () => {
   it('sentinel: DATABASE_URL is set (DB-backed lane must not silently skip)', () => {
     expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  it('claims a caller-reserved run UUID once and replays it without a second provider pull', async () => {
+    const integration = await createDirectoryIntegration({
+      name: `dso-reserved-${TS}`,
+      corpId: `dso-reserved-corp-${TS}`,
+      appKey: `dso-reserved-appkey-${TS}`,
+      appSecret: 'dso-secret',
+      admissionMode: 'manual_only',
+    })
+    const requestedRunId = randomUUID()
+    activeDirectory = { departments: [], usersByDept: {} }
+    const pullsBefore = clientMocks.fetchDingTalkAppAccessToken.mock.calls.length
+
+    try {
+      const first = await syncDirectoryIntegration(integration.id, 'system:dso-reserved', 'manual', {
+        requestedRunId,
+      })
+      expect(first.run.id).toBe(requestedRunId)
+      expect(first.run.status).toBe('completed')
+      const pullsAfterFirst = clientMocks.fetchDingTalkAppAccessToken.mock.calls.length
+      expect(pullsAfterFirst).toBeGreaterThan(pullsBefore)
+      expect(await getDirectorySyncRun(integration.id, requestedRunId)).toMatchObject({
+        id: requestedRunId,
+        integrationId: integration.id,
+        status: 'completed',
+      })
+      expect(await getDirectorySyncRun(randomUUID(), requestedRunId)).toBeNull()
+
+      const replay = await syncDirectoryIntegration(integration.id, 'system:dso-reserved', 'manual', {
+        requestedRunId,
+      }).catch((error) => error)
+      expect(replay).toBeInstanceOf(DirectorySyncRunReplayError)
+      expect((replay as DirectorySyncRunReplayError).runId).toBe(requestedRunId)
+      expect(clientMocks.fetchDingTalkAppAccessToken.mock.calls.length).toBe(pullsAfterFirst)
+
+      const rows = await query<{ id: string }>(
+        `SELECT id FROM directory_sync_runs WHERE id = $1 AND integration_id = $2`,
+        [requestedRunId, integration.id],
+      )
+      expect(rows.rows).toEqual([{ id: requestedRunId }])
+    } finally {
+      await cleanupIntegration(integration.id)
+    }
   })
 
   // -------------------------------------------------------------------------

--- a/packages/core-backend/tests/unit/admin-directory-routes.test.ts
+++ b/packages/core-backend/tests/unit/admin-directory-routes.test.ts
@@ -3,7 +3,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 // Resolves through the vi.mock factory below, which re-exports the REAL class —
 // so `new DirectorySyncInProgressError(...)` here is the same constructor the
 // route's `instanceof` discriminates against in production.
-import { DirectorySyncInProgressError } from '../../src/directory/directory-sync'
+import {
+  DirectorySyncInProgressError,
+  DirectorySyncRunReplayError,
+} from '../../src/directory/directory-sync'
 // NOT mocked below — this is the REAL class the admin-directory routes reuse for schedule_cron save-time
 // validation (roadmap §7.8), and the SAME class `directory-sync-scheduler.ts` uses to actually run the
 // job. Importing it directly here pins its actual acceptance semantics, independent of any route-level mock.
@@ -27,6 +30,7 @@ const directoryMocks = vi.hoisted(() => ({
   batchUnbindDirectoryAccounts: vi.fn(),
   bindDirectoryAccount: vi.fn(),
   createDirectoryIntegration: vi.fn(),
+  getDirectorySyncRun: vi.fn(),
   getDirectorySyncScheduleSnapshot: vi.fn(),
   getDirectoryAccountSummary: vi.fn(),
   getDirectoryReviewItem: vi.fn(),
@@ -86,6 +90,8 @@ vi.mock('../../src/directory/directory-sync', async (importOriginal) => ({
   // every error path that reaches the catch (including the async pre-run-row failure).
   DirectorySyncFrozenByTransferError: (await importOriginal<typeof import('../../src/directory/directory-sync')>())
     .DirectorySyncFrozenByTransferError,
+  DirectorySyncRunReplayError: (await importOriginal<typeof import('../../src/directory/directory-sync')>())
+    .DirectorySyncRunReplayError,
   acknowledgeDirectorySyncAlert: directoryMocks.acknowledgeDirectorySyncAlert,
   admitDirectoryAccountUser: directoryMocks.admitDirectoryAccountUser,
   batchAdmitDirectoryAccountUsers: directoryMocks.batchAdmitDirectoryAccountUsers,
@@ -93,6 +99,7 @@ vi.mock('../../src/directory/directory-sync', async (importOriginal) => ({
   batchUnbindDirectoryAccounts: directoryMocks.batchUnbindDirectoryAccounts,
   bindDirectoryAccount: directoryMocks.bindDirectoryAccount,
   createDirectoryIntegration: directoryMocks.createDirectoryIntegration,
+  getDirectorySyncRun: directoryMocks.getDirectorySyncRun,
   getDirectorySyncScheduleSnapshot: directoryMocks.getDirectorySyncScheduleSnapshot,
   getDirectoryAccountSummary: directoryMocks.getDirectoryAccountSummary,
   getDirectoryReviewItem: directoryMocks.getDirectoryReviewItem,
@@ -231,6 +238,7 @@ describe('adminDirectoryRouter', () => {
     directoryMocks.batchUnbindDirectoryAccounts.mockReset()
     directoryMocks.bindDirectoryAccount.mockReset()
     directoryMocks.createDirectoryIntegration.mockReset()
+    directoryMocks.getDirectorySyncRun.mockReset()
     directoryMocks.getDirectorySyncScheduleSnapshot.mockReset()
     directoryMocks.getDirectoryAccountSummary.mockReset()
     directoryMocks.getDirectoryReviewItem.mockReset()
@@ -1276,6 +1284,71 @@ describe('adminDirectoryRouter', () => {
     resolveSync({ run: { id: 'run-async-1' } })
   })
 
+  it('passes a caller-reserved UUID to the async claim and returns that exact run id', async () => {
+    const requestedRunId = '11111111-1111-4111-8111-111111111111'
+    let resolveSync: (value: unknown) => void = () => {}
+    directoryMocks.syncDirectoryIntegration.mockImplementation(
+      (_id: string, _actor: string, _source: string, hooks: {
+        onRunStarted?: (runId: string) => void
+        requestedRunId?: string
+      }) => {
+        expect(hooks.requestedRunId).toBe(requestedRunId)
+        hooks.onRunStarted?.(requestedRunId)
+        return new Promise((resolve) => { resolveSync = resolve })
+      },
+    )
+
+    const response = await invokeRoute('post', '/integrations/:integrationId/sync', {
+      params: { integrationId: 'dir-1' },
+      body: { async: true, runId: requestedRunId },
+      user: { id: 'admin-1', role: 'admin' },
+    })
+
+    expect(response.statusCode).toBe(202)
+    expect(response.body).toMatchObject({
+      ok: true,
+      data: { accepted: true, runId: requestedRunId, integrationId: 'dir-1' },
+    })
+    resolveSync({ run: { id: requestedRunId } })
+  })
+
+  it('rejects a malformed reserved run id before starting a sync', async () => {
+    const response = await invokeRoute('post', '/integrations/:integrationId/sync', {
+      params: { integrationId: 'dir-1' },
+      body: { async: true, runId: 'not-a-uuid' },
+      user: { id: 'admin-1', role: 'admin' },
+    })
+
+    expect(response.statusCode).toBe(400)
+    expect(response.body).toMatchObject({
+      ok: false,
+      error: { code: 'DIRECTORY_SYNC_RUN_ID_INVALID' },
+    })
+    expect(directoryMocks.syncDirectoryIntegration).not.toHaveBeenCalled()
+  })
+
+  it('returns the reserved run id on idempotent replay without starting another pull', async () => {
+    const requestedRunId = '22222222-2222-4222-8222-222222222222'
+    directoryMocks.syncDirectoryIntegration.mockRejectedValue(new DirectorySyncRunReplayError(requestedRunId))
+
+    const response = await invokeRoute('post', '/integrations/:integrationId/sync', {
+      params: { integrationId: 'dir-1' },
+      body: { async: true, runId: requestedRunId },
+      user: { id: 'admin-1', role: 'admin' },
+    })
+
+    expect(response.statusCode).toBe(202)
+    expect(response.body).toMatchObject({
+      ok: true,
+      data: {
+        accepted: true,
+        runId: requestedRunId,
+        integrationId: 'dir-1',
+        replayed: true,
+      },
+    })
+  })
+
   it('surfaces an error when an async sync fails before the run row exists', async () => {
     directoryMocks.syncDirectoryIntegration.mockRejectedValue(new Error('Directory integration not found'))
 
@@ -1321,6 +1394,55 @@ describe('adminDirectoryRouter', () => {
       ok: false,
       error: { code: 'DIRECTORY_SYNC_IN_PROGRESS', details: { activeRunId: 'run-live-2' } },
     })
+  })
+
+  it('loads one exact sync run without paginated-list inference', async () => {
+    const runId = '11111111-1111-4111-8111-111111111111'
+    directoryMocks.getDirectorySyncRun.mockResolvedValue({ id: runId, status: 'completed' })
+
+    const response = await invokeRoute('get', '/integrations/:integrationId/runs/:runId', {
+      params: { integrationId: 'dir-1', runId },
+      user: { id: 'admin-1', role: 'admin' },
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(directoryMocks.getDirectorySyncRun).toHaveBeenCalledWith('dir-1', runId)
+    expect(response.body).toMatchObject({ ok: true, data: { run: { id: runId, status: 'completed' } } })
+  })
+
+  it('rejects malformed exact sync run ids before querying', async () => {
+    const response = await invokeRoute('get', '/integrations/:integrationId/runs/:runId', {
+      params: { integrationId: 'dir-1', runId: 'not-a-uuid' },
+      user: { id: 'admin-1', role: 'admin' },
+    })
+
+    expect(response.statusCode).toBe(400)
+    expect(response.body).toMatchObject({ ok: false, error: { code: 'DIRECTORY_SYNC_RUN_ID_INVALID' } })
+    expect(directoryMocks.getDirectorySyncRun).not.toHaveBeenCalled()
+  })
+
+  it('requires platform admin for an exact sync run lookup', async () => {
+    const runId = '22222222-2222-4222-8222-222222222222'
+    const response = await invokeRoute('get', '/integrations/:integrationId/runs/:runId', {
+      params: { integrationId: 'dir-1', runId },
+      user: { id: 'not-admin' },
+    })
+
+    expect(response.statusCode).toBe(403)
+    expect(directoryMocks.getDirectorySyncRun).not.toHaveBeenCalled()
+  })
+
+  it('returns 404 when the exact sync run does not belong to the integration', async () => {
+    const runId = '22222222-2222-4222-8222-222222222222'
+    directoryMocks.getDirectorySyncRun.mockResolvedValue(null)
+
+    const response = await invokeRoute('get', '/integrations/:integrationId/runs/:runId', {
+      params: { integrationId: 'dir-1', runId },
+      user: { id: 'admin-1', role: 'admin' },
+    })
+
+    expect(response.statusCode).toBe(404)
+    expect(response.body).toMatchObject({ ok: false, error: { code: 'DIRECTORY_RUN_NOT_FOUND' } })
   })
 
   it('previews a sync without applying it', async () => {

--- a/packages/core-backend/tests/unit/directory-sync-run-lease.test.ts
+++ b/packages/core-backend/tests/unit/directory-sync-run-lease.test.ts
@@ -31,6 +31,7 @@ import {
   DIRECTORY_SYNC_LEASE_STALE_MINUTES,
   DirectorySyncInProgressError,
   DirectorySyncLeaseLostError,
+  DirectorySyncRunReplayError,
   previewDirectorySyncIntegration,
   reclaimStaleDirectorySyncRuns,
   syncDirectoryIntegration,
@@ -88,11 +89,12 @@ type LoggedCall = { text: string; params: unknown[] | undefined }
  * loop in the apply body is a no-op, which is exactly the point: these tests pin the
  * lease machinery, not the apply.
  */
-function installFullRunMocks(options: { completionRows?: Array<{ id: string }> } = {}) {
+function installFullRunMocks(options: { completionRows?: Array<{ id: string }>; runId?: string } = {}) {
   const bareCalls: LoggedCall[] = []
   const beats: LoggedCall[] = []
   const txCalls: LoggedCall[] = []
-  const completionRows = options.completionRows ?? [{ id: RUN_ID }]
+  const runId = options.runId ?? RUN_ID
+  const completionRows = options.completionRows ?? [{ id: runId }]
 
   pgMocks.query.mockImplementation(async (sql: unknown, params?: unknown[]) => {
     const text = String(sql)
@@ -101,9 +103,9 @@ function installFullRunMocks(options: { completionRows?: Array<{ id: string }> }
       beats.push({ text, params })
       return { rows: [] }
     }
-    if (text.includes('INSERT INTO directory_sync_runs')) return { rows: [runRow()] }
+    if (text.includes('INSERT INTO directory_sync_runs')) return { rows: [runRow({ id: runId })] }
     if (text.includes('FROM directory_integrations')) return { rows: [INTEGRATION_ROW] }
-    if (text.includes('FROM directory_sync_runs')) return { rows: [runRow({ status: 'completed' })] }
+    if (text.includes('FROM directory_sync_runs')) return { rows: [runRow({ id: runId, status: 'completed' })] }
     return { rows: [] }
   })
 
@@ -191,6 +193,69 @@ describe('DT-HARDEN-05 directory sync run lease', () => {
     expect(error).toBeInstanceOf(DirectorySyncInProgressError)
     expect((error as DirectorySyncInProgressError).activeRunId).toBe('run-active')
     expect((error as DirectorySyncInProgressError).statusCode).toBe(409)
+  })
+
+  it('claims the exact caller-reserved UUID before the provider pull', async () => {
+    const requestedRunId = '11111111-1111-4111-8111-111111111111'
+    const onRunStarted = vi.fn()
+    const { bareCalls } = installFullRunMocks({ runId: requestedRunId })
+
+    const result = await syncDirectoryIntegration('dir-1', 'admin-1', 'manual', {
+      requestedRunId,
+      onRunStarted,
+    })
+
+    const claim = bareCalls.find((call) => call.text.includes('INSERT INTO directory_sync_runs'))
+    expect(claim?.text).toContain('COALESCE($4::uuid, gen_random_uuid())')
+    expect(claim?.params).toEqual(['dir-1', 'admin-1', 'manual', requestedRunId])
+    expect(onRunStarted).toHaveBeenCalledOnce()
+    expect(onRunStarted).toHaveBeenCalledWith(requestedRunId)
+    expect(result.run.id).toBe(requestedRunId)
+  })
+
+  it('treats a repeated reserved UUID as observation and never pulls DingTalk twice', async () => {
+    const requestedRunId = '22222222-2222-4222-8222-222222222222'
+    pgMocks.query
+      .mockResolvedValueOnce({ rows: [INTEGRATION_ROW] })
+      .mockResolvedValueOnce({ rows: [{ reg: 'provider_org_transfers' }] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockRejectedValueOnce(uniqueViolation())
+      .mockResolvedValueOnce({ rows: [{ id: requestedRunId }] })
+      .mockResolvedValueOnce({ rows: [] })
+
+    const error = await syncDirectoryIntegration('dir-1', 'admin-1', 'manual', {
+      requestedRunId,
+    }).catch((caught) => caught)
+
+    expect(error).toBeInstanceOf(DirectorySyncRunReplayError)
+    expect((error as DirectorySyncRunReplayError).runId).toBe(requestedRunId)
+    expect(pgMocks.query.mock.calls[4]?.[1]).toEqual(['dir-1', 'admin-1', 'manual', requestedRunId])
+    expect(String(pgMocks.query.mock.calls[5]?.[0])).toContain('WHERE id = $1')
+    expect(pgMocks.query.mock.calls[5]?.[1]).toEqual([requestedRunId, 'dir-1'])
+    expect(String(pgMocks.query.mock.calls[6]?.[0])).toContain("status = 'running'")
+    expect(dingtalkMocks.fetchDingTalkAppAccessToken).not.toHaveBeenCalled()
+    expect(dingtalkMocks.listDingTalkDepartments).not.toHaveBeenCalled()
+  })
+
+  it('does not let replay of an old run hide a different live run', async () => {
+    const requestedRunId = '33333333-3333-4333-8333-333333333333'
+    pgMocks.query
+      .mockResolvedValueOnce({ rows: [INTEGRATION_ROW] })
+      .mockResolvedValueOnce({ rows: [{ reg: 'provider_org_transfers' }] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockRejectedValueOnce(uniqueViolation())
+      .mockResolvedValueOnce({ rows: [{ id: requestedRunId }] })
+      .mockResolvedValueOnce({ rows: [{ id: 'different-live-run' }] })
+
+    const error = await syncDirectoryIntegration('dir-1', 'admin-1', 'manual', {
+      requestedRunId,
+    }).catch((caught) => caught)
+
+    expect(error).toBeInstanceOf(DirectorySyncInProgressError)
+    expect((error as DirectorySyncInProgressError).activeRunId).toBe('different-live-run')
+    expect(dingtalkMocks.fetchDingTalkAppAccessToken).not.toHaveBeenCalled()
   })
 
   it('reclaims the lease before claiming it, so a crashed run cannot wedge an integration', async () => {

--- a/scripts/ops/dingtalk-lifecycle-staging-canary-contract.test.mjs
+++ b/scripts/ops/dingtalk-lifecycle-staging-canary-contract.test.mjs
@@ -2,21 +2,25 @@
 // dingtalk-lifecycle-staging-canary-contract.test.mjs
 //
 // Durable synthetic contract for the MINIMAL SAFE staging lifecycle lane:
-//   EXECUTABLE: status | preflight | off | bootstrap | human-bootstrap | alias
-//   NOT EXECUTABLE: pending | deprovision (fail-closed preflight-only)
+//   EXECUTABLE: status | preflight | off | bootstrap | human-bootstrap | alias |
+//               pending | deprovision
 //
-// Alias is a TRANSIENT secret-backed cutover canary: success requires/proves OFF;
-// failure restores the OFF override before failing. Runtime OFF cannot be proven
-// if rollback recreate itself fails. Admin JWT is minted from canary password
-// login (never secrets.ATTENDANCE_ADMIN_JWT).
+// Alias/pending/deprovision are TRANSIENT secret-backed canaries: success
+// requires/proves OFF; failure restores the OFF override before failing.
+// Runtime OFF cannot be proven if rollback recreate fails. Admin JWT is minted
+// from canary password login (never secrets.ATTENDANCE_ADMIN_JWT).
 // Bootstrap creates/repairs the fixed owned canary admin only (collision
 // fail-closed; no lifecycle env write).
 // Human-bootstrap creates/repairs a SEPARATE fixed human platform admin
 // (username staging-owner-admin) via canary-authenticated admin API + password
 // file; required reset-password/access/login/revoke; no lifecycle env write.
+// Pending: explicit directory-account subject file, pending-only flag, real
+// admit/activate, unconditional OFF rollback. Deprovision: same subject, external
+// source-disable confirmation, deprovision-only flag, real sync+ledger proofs,
+// OFF rollback; does not claim end-to-end source rehire restore.
 // Load-bearing mutations for owner P1/P2 gaps:
-//   * migrations_pending_zero unknown must fail preflight/off/alias/bootstrap/human-bootstrap
-//   * pending/deprovision never apply (transition_applied=false; NOT EXECUTABLE)
+//   * migrations_pending_zero unknown must fail preflight/off/alias/bootstrap/human-bootstrap/pending/deprovision
+//   * pending/deprovision require explicit subject (no auto-selection); omit subject refuses
 //   * alias requires pre-login(+JWT mint), backfill, readiness, post-ON login,
 //     rollback, post-rollback login, exact SHA, migrations, secret-file transport
 //   * recreate requires health true after restart
@@ -133,8 +137,75 @@ function actionBootstrapBody(source) {
 function actionHumanBootstrapBody(source) {
   const start = source.indexOf('action_human_bootstrap()')
   assert.notEqual(start, -1, 'action_human_bootstrap() must exist')
+  // pending/deprovision actions follow human-bootstrap; stop before them.
+  let end = source.indexOf('\naction_pending()', start)
+  if (end === -1) {
+    end = source.indexOf('\n# --- main', start)
+  }
+  assert.notEqual(end, -1, 'action_pending or main marker after action_human_bootstrap')
+  return source.slice(start, end)
+}
+
+function actionPendingBody(source) {
+  const start = source.indexOf('action_pending()')
+  assert.notEqual(start, -1, 'action_pending() must exist')
+  const end = source.indexOf('\naction_deprovision()', start)
+  assert.notEqual(end, -1, 'action_deprovision after action_pending')
+  return source.slice(start, end)
+}
+
+function actionDeprovisionBody(source) {
+  // Includes dispatcher + apply + restore (all before main).
+  const start = source.indexOf('action_deprovision()')
+  assert.notEqual(start, -1, 'action_deprovision() must exist')
   const end = source.indexOf('\n# --- main', start)
-  assert.notEqual(end, -1, 'main marker after action_human_bootstrap')
+  assert.notEqual(end, -1, 'main marker after action_deprovision')
+  return source.slice(start, end)
+}
+
+function actionDeprovisionApplyBody(source) {
+  const start = source.indexOf('action_deprovision_apply()')
+  assert.notEqual(start, -1, 'action_deprovision_apply() must exist')
+  const end = source.indexOf('\naction_deprovision_restore()', start)
+  assert.notEqual(end, -1, 'action_deprovision_restore after apply')
+  return source.slice(start, end)
+}
+
+function actionDeprovisionRestoreBody(source) {
+  const start = source.indexOf('action_deprovision_restore()')
+  assert.notEqual(start, -1, 'action_deprovision_restore() must exist')
+  const end = source.indexOf('\n# --- main', start)
+  assert.notEqual(end, -1, 'main marker after restore')
+  return source.slice(start, end)
+}
+
+function verifyDeprovisionLedgerBody(source) {
+  const start = source.indexOf('verify_deprovision_ledger_for_subject()')
+  assert.notEqual(start, -1, 'verify_deprovision_ledger_for_subject must exist')
+  let end = source.indexOf('\n# --- recovery journal state machine', start)
+  if (end === -1) {
+    end = source.indexOf('\npersist_deprovision_apply_state()', start)
+  }
+  if (end === -1) {
+    end = source.indexOf('\nrun_deprovision_rehire_restore()', start)
+  }
+  assert.notEqual(end, -1, 'journal/persist/rehire after ledger verify')
+  return source.slice(start, end)
+}
+
+function runDirectorySyncForSubjectBody(source) {
+  const start = source.indexOf('run_directory_sync_for_subject()')
+  assert.notEqual(start, -1, 'run_directory_sync_for_subject must exist')
+  const end = source.indexOf('\n# GET deprovision events for subject', start)
+  assert.notEqual(end, -1, 'ledger marker after run_directory_sync_for_subject')
+  return source.slice(start, end)
+}
+
+function runOrResumeRestoreBody(source) {
+  const start = source.indexOf('run_or_resume_deprovision_rehire_restore()')
+  assert.notEqual(start, -1, 'run_or_resume_deprovision_rehire_restore must exist')
+  const end = source.indexOf('\n# Authoritative access-graph proof', start)
+  assert.notEqual(end, -1, 'access graph marker after restore resume helper')
   return source.slice(start, end)
 }
 
@@ -176,7 +247,7 @@ test('PR contract workflow executes this exact suite without changing the sealed
 
 // --- workflow shape -------------------------------------------------------------------
 
-test('workflow action choices include status/preflight/off/bootstrap/human-bootstrap/alias and non-executable ON names', () => {
+test('workflow action choices include all explicit staging actions', () => {
   const options = workflowOn(loadYaml(read(WORKFLOW))).workflow_dispatch.inputs.action.options
   assert.deepEqual(options, [
     'status',
@@ -221,22 +292,23 @@ test('SSH transport requires a pinned known_hosts secret', () => {
   assert.doesNotMatch(yaml, /StrictHostKeyChecking=no/)
 })
 
-test('workflow requires deploy_sha + expected_current for off/bootstrap/human-bootstrap/alias; pending/deprovision NOT EXECUTABLE', () => {
+test('workflow requires deploy_sha + expected_current for off/bootstrap/human-bootstrap/alias/pending/deprovision', () => {
   const yaml = read(WORKFLOW)
   assert.match(yaml, /expected_current_mode is required for action=off/)
   assert.match(yaml, /expected_current_mode must be exactly 'off' for action=\$\{ACTION\}/)
   assert.match(yaml, /deploy_sha must be the FULL 40-char lowercase commit SHA for action=\$\{ACTION\}/)
   assert.match(
     yaml,
-    /ACTION" == "bootstrap" \|\| "\$ACTION" == "human-bootstrap" \|\| "\$ACTION" == "alias"/,
+    /ACTION" == "bootstrap" \|\| "\$ACTION" == "human-bootstrap" \|\| "\$ACTION" == "alias" \|\| "\$ACTION" == "pending" \|\| "\$ACTION" == "deprovision"/,
   )
   // Secret presence is checked only in Run remote action (not Validate inputs).
   assert.match(
     yaml,
     /requires LIFECYCLE_CANARY_LOGIN_IDENTIFIER\/PASSWORD \(checked in Run remote action only\); never ATTENDANCE_ADMIN_JWT/,
   )
-  assert.match(yaml, /NOT EXECUTABLE/)
-  // Must not require canary subject/integration for a pretend ON transition.
+  assert.match(yaml, /LIFECYCLE_CANARY_DIRECTORY_ACCOUNT_ID/)
+  assert.match(yaml, /DINGTALK_SOURCE_DISABLED_DEDICATED_EXCLUSIVE_CONFIRMED/)
+  // Must not use bare canary_subject_id workflow inputs (secret-file transport only).
   assert.doesNotMatch(yaml, /canary_subject_id:/)
   assert.doesNotMatch(yaml, /canary_integration_id:/)
   assert.doesNotMatch(yaml, /owner_confirm:/)
@@ -259,21 +331,25 @@ test('workflow requires explicit privileged confirmation phrases for bootstrap a
   assert.match(validate.run, /BOOTSTRAP_CONFIRMATION" != "CREATE_STAGING_HUMAN_ADMIN"/)
 })
 
-test('workflow bootstrap/human-bootstrap/alias secret transport uses chmod-600 files + scp; never ATTENDANCE_ADMIN_JWT', () => {
+test('workflow bootstrap/human-bootstrap/alias/pending/deprovision secret transport uses chmod-600 files + scp; never ATTENDANCE_ADMIN_JWT', () => {
   const yaml = read(WORKFLOW)
   assert.match(yaml, /chmod 600/)
   assert.match(yaml, /LIFECYCLE_CANARY_LOGIN_IDENTIFIER/)
   assert.match(yaml, /LIFECYCLE_CANARY_LOGIN_PASSWORD/)
   assert.match(yaml, /STAGING_OWNER_ADMIN_PASSWORD/)
+  assert.match(yaml, /LIFECYCLE_CANARY_DIRECTORY_ACCOUNT_ID/)
   assert.match(yaml, /CANARY_LOGIN_IDENTIFIER_FILE=/)
   assert.match(yaml, /CANARY_LOGIN_PASSWORD_FILE=/)
   assert.match(yaml, /STAGING_OWNER_ADMIN_PASSWORD_FILE=/)
+  assert.match(yaml, /CANARY_DIRECTORY_ACCOUNT_ID_FILE=/)
+  assert.match(yaml, /directory-account\.id/)
   assert.match(yaml, /\.canary-secrets/)
   assert.match(yaml, /scp \$ssh_opts/)
   // printf uses non-exported shell vars after env demote (not raw env names).
   assert.match(yaml, /printf '%s' "\$\{_CANARY_PASS\}"/)
   assert.match(yaml, /printf '%s' "\$\{_CANARY_IDENT\}"/)
   assert.match(yaml, /printf '%s' "\$\{_STAGING_OWNER_PASS\}"/)
+  assert.match(yaml, /printf '%s' "\$\{_CANARY_SUBJECT\}"/)
   assert.match(yaml, /staging-owner-admin\.password/)
   // Must not materialize or demote ATTENDANCE_ADMIN_JWT (alias mints JWT from login).
   // Prose may mention the forbidden secret; forbid GHA secret injection only.
@@ -286,11 +362,12 @@ test('workflow bootstrap/human-bootstrap/alias secret transport uses chmod-600 f
   assert.doesNotMatch(yaml, /export LIFECYCLE_CANARY_LOGIN_IDENTIFIER=/)
   assert.doesNotMatch(yaml, /export LIFECYCLE_CANARY_LOGIN_PASSWORD=/)
   assert.doesNotMatch(yaml, /export STAGING_OWNER_ADMIN_PASSWORD=/)
+  assert.doesNotMatch(yaml, /export LIFECYCLE_CANARY_DIRECTORY_ACCOUNT_ID=/)
   assert.doesNotMatch(yaml, /export CANARY_LOGIN_PASSWORD='/)
-  // bootstrap/human-bootstrap share the canary secret transport gate as alias.
+  // bootstrap/human-bootstrap/alias/pending/deprovision share the canary secret transport gate.
   assert.match(
     yaml,
-    /ACTION" == "alias" \|\| "\$ACTION" == "bootstrap" \|\| "\$ACTION" == "human-bootstrap"/,
+    /ACTION" == "alias" \|\| "\$ACTION" == "bootstrap" \|\| "\$ACTION" == "human-bootstrap" \|\| "\$ACTION" == "pending" \|\| "\$ACTION" == "deprovision"/,
   )
 })
 
@@ -309,9 +386,13 @@ test('workflow Validate inputs does not receive canary login secrets (no child i
   assert.doesNotMatch(validate.run, /LIFECYCLE_CANARY_LOGIN_PASSWORD/)
   assert.doesNotMatch(validate.run, /STAGING_OWNER_ADMIN_PASSWORD/)
   assert.match(validate.run, /bash -n scripts\/ops\/dingtalk-lifecycle-staging-canary-remote\.sh/)
-  // Structural bootstrap/human-bootstrap/alias checks remain; secret presence does not.
+  // Structural bootstrap/human-bootstrap/alias/pending/deprovision checks remain; secret presence does not.
   assert.match(validate.run, /expected_current_mode must be exactly 'off' for action=\$\{ACTION\}/)
-  assert.match(validate.run, /bootstrap\|human-bootstrap\|alias|bootstrap" \|\| "\$ACTION" == "human-bootstrap"/)
+  assert.match(
+    validate.run,
+    /bootstrap\|human-bootstrap\|alias\|pending\|deprovision|bootstrap" \|\| "\$ACTION" == "human-bootstrap"/,
+  )
+  assert.doesNotMatch(validate.run, /LIFECYCLE_CANARY_DIRECTORY_ACCOUNT_ID/)
 })
 
 test('workflow materializes secrets inside Run remote action under EXIT trap (no separate secrets step)', () => {
@@ -350,7 +431,7 @@ test('workflow materializes secrets inside Run remote action under EXIT trap (no
     }
     if (
       t.startsWith(
-        'unset LIFECYCLE_CANARY_LOGIN_IDENTIFIER LIFECYCLE_CANARY_LOGIN_PASSWORD STAGING_OWNER_ADMIN_PASSWORD',
+        'unset LIFECYCLE_CANARY_LOGIN_IDENTIFIER LIFECYCLE_CANARY_LOGIN_PASSWORD STAGING_OWNER_ADMIN_PASSWORD LIFECYCLE_CANARY_DIRECTORY_ACCOUNT_ID',
       )
     ) {
       sawEnvUnset = true
@@ -367,6 +448,7 @@ test('workflow materializes secrets inside Run remote action under EXIT trap (no
       '_CANARY_IDENT="${LIFECYCLE_CANARY_LOGIN_IDENTIFIER-}"',
       '_CANARY_PASS="${LIFECYCLE_CANARY_LOGIN_PASSWORD-}"',
       '_STAGING_OWNER_PASS="${STAGING_OWNER_ADMIN_PASSWORD-}"',
+      '_CANARY_SUBJECT="${LIFECYCLE_CANARY_DIRECTORY_ACCOUNT_ID-}"',
     ],
     'only demote assignments (builtins) before secret env unset — no external commands; no JWT',
   )
@@ -374,7 +456,7 @@ test('workflow materializes secrets inside Run remote action under EXIT trap (no
   // Order after demote: trap → mktemp → printf from shell vars → unset shell vars → remote scp.
   const trapIdx = runBody.indexOf('trap cleanup_canary_ephemeral_paths EXIT INT TERM')
   const envUnsetIdx = runBody.indexOf(
-    'unset LIFECYCLE_CANARY_LOGIN_IDENTIFIER LIFECYCLE_CANARY_LOGIN_PASSWORD STAGING_OWNER_ADMIN_PASSWORD',
+    'unset LIFECYCLE_CANARY_LOGIN_IDENTIFIER LIFECYCLE_CANARY_LOGIN_PASSWORD STAGING_OWNER_ADMIN_PASSWORD LIFECYCLE_CANARY_DIRECTORY_ACCOUNT_ID',
   )
   const mktempIdx = runBody.indexOf('mktemp -d')
   const printfPassIdx = runBody.indexOf("printf '%s' \"${_CANARY_PASS}\"")
@@ -405,13 +487,14 @@ test('workflow materializes secrets inside Run remote action under EXIT trap (no
   assert.match(remoteStep.run, /printf '%s' "\$\{_STAGING_OWNER_PASS\}"/)
   assert.match(
     remoteStep.run,
-    /unset LIFECYCLE_CANARY_LOGIN_IDENTIFIER LIFECYCLE_CANARY_LOGIN_PASSWORD STAGING_OWNER_ADMIN_PASSWORD/,
+    /unset LIFECYCLE_CANARY_LOGIN_IDENTIFIER LIFECYCLE_CANARY_LOGIN_PASSWORD STAGING_OWNER_ADMIN_PASSWORD LIFECYCLE_CANARY_DIRECTORY_ACCOUNT_ID/,
   )
   assert.ok(remoteStep.env, 'Run remote action must declare env')
   assert.equal(remoteStep.env.ATTENDANCE_ADMIN_JWT, undefined, 'never inject ATTENDANCE_ADMIN_JWT')
   assert.ok(remoteStep.env.LIFECYCLE_CANARY_LOGIN_IDENTIFIER, 'identifier secret on Run remote action only')
   assert.ok(remoteStep.env.LIFECYCLE_CANARY_LOGIN_PASSWORD, 'password secret on Run remote action only')
   assert.ok(remoteStep.env.STAGING_OWNER_ADMIN_PASSWORD, 'human password secret on Run remote action only')
+  assert.ok(remoteStep.env.LIFECYCLE_CANARY_DIRECTORY_ACCOUNT_ID, 'subject secret on Run remote action only')
   assert.equal(remoteStep.env.SECRETS_DIR, undefined, 'no secrets_dir cross-step handoff')
 
   assert.match(runBody, /CLEAN_REMOTE_SECRETS_DIR/)
@@ -421,10 +504,10 @@ test('workflow materializes secrets inside Run remote action under EXIT trap (no
   assert.match(runBody, /OUTPUT_COLLECTED=1/)
   // Explicit: secrets_dir must not be a step output handoff.
   assert.doesNotMatch(runBody, /secrets_dir=.*GITHUB_OUTPUT/)
-  // bootstrap|human-bootstrap|alias share materialize gate; no admin.jwt from GHA secrets.
+  // bootstrap|human-bootstrap|alias|pending|deprovision share materialize gate; no admin.jwt from GHA secrets.
   assert.match(
     runBody,
-    /ACTION" == "alias" \|\| "\$ACTION" == "bootstrap" \|\| "\$ACTION" == "human-bootstrap"/,
+    /ACTION" == "alias" \|\| "\$ACTION" == "bootstrap" \|\| "\$ACTION" == "human-bootstrap" \|\| "\$ACTION" == "pending" \|\| "\$ACTION" == "deprovision"/,
   )
   assert.doesNotMatch(runBody, /admin\.jwt/)
   // Local+remote secret cleanup; never echo secret values.
@@ -714,61 +797,49 @@ test('production function: require_migrations_pending_zero_true accepts only tru
   assert.match(run('unknown').stderr, /unknown/)
 })
 
-// --- P1: pending/deprovision NOT EXECUTABLE; alias is executable ----------------------
+// --- P1: pending/deprovision/alias are explicit transient operators ------------------
 
-test('P1 pending/deprovision route to action_not_executable_on; alias routes to action_alias; bootstrap/human-bootstrap route', () => {
+test('P1 pending/deprovision route to action_pending/action_deprovision; alias routes to action_alias; bootstrap/human-bootstrap route', () => {
   const source = read(REMOTE_SH)
   assert.match(source, /bootstrap\) action_bootstrap/)
   assert.match(source, /human-bootstrap\) action_human_bootstrap/)
   assert.match(source, /alias\) action_alias/)
-  assert.match(source, /pending\) action_not_executable_on pending/)
-  assert.match(source, /deprovision\) action_not_executable_on deprovision/)
-  assert.match(source, /NOT EXECUTABLE/)
-  assert.match(source, /not_executable_no_real_verifier/)
-  assert.match(source, /transition_applied=false/)
-  // Must not call write_lifecycle_override from the not-executable path with true flags.
-  const start = source.indexOf('action_not_executable_on()')
-  const end = source.indexOf('\naction_bootstrap()', start)
-  assert.notEqual(start, -1)
-  assert.notEqual(end, -1)
-  const body = source.slice(start, end)
-  assert.doesNotMatch(body, /write_lifecycle_override/)
-  assert.doesNotMatch(body, /recreate_backend_only/)
-  assert.match(body, /transition_applied.*false|false" "false"/)
+  assert.match(source, /pending\) action_pending/)
+  assert.match(source, /deprovision\) action_deprovision/)
+  assert.match(source, /action_pending\(\)/)
+  assert.match(source, /action_deprovision\(\)/)
+  assert.doesNotMatch(source, /action_not_executable_on/)
+  assert.doesNotMatch(source, /not_executable_no_real_verifier/)
   const preflightStart = source.indexOf('preflight_for_target()')
   const preflightEnd = source.indexOf('\naction_preflight()', preflightStart)
   const preflightBody = source.slice(preflightStart, preflightEnd)
-  // pending/deprovision still force not-executable; alias does not.
-  assert.match(preflightBody, /pending\|deprovision\)[\s\S]*not_executable_no_real_verifier/)
-  assert.doesNotMatch(
-    preflightBody,
-    /alias\)[\s\S]{0,400}not_executable_no_real_verifier/,
-  )
+  // Stack readiness only — no force not-executable for pending/deprovision.
+  assert.doesNotMatch(preflightBody, /not_executable_no_real_verifier/)
+  assert.match(preflightBody, /pending\|deprovision\)/)
 })
 
-test('P1 action=off and action=alias write lifecycle override; bootstrap/human-bootstrap/pending/deprovision do not', () => {
+test('P1 action=off/alias/pending/deprovision write lifecycle override; bootstrap/human-bootstrap do not', () => {
   const source = read(REMOTE_SH)
   assert.match(source, /off\) action_off/)
   assert.match(source, /bootstrap\) action_bootstrap/)
   assert.match(source, /human-bootstrap\) action_human_bootstrap/)
   assert.match(source, /alias\) action_alias/)
+  assert.match(source, /pending\) action_pending/)
+  assert.match(source, /deprovision\) action_deprovision/)
   assert.match(source, /action_off\(\)/)
   assert.match(source, /action_bootstrap\(\)/)
   assert.match(source, /action_human_bootstrap\(\)/)
   assert.match(source, /action_alias\(\)/)
   assert.match(source, /write_lifecycle_override "false" "false" "false"/)
   assert.match(source, /write_lifecycle_override "true" "false" "false"/)
+  assert.match(source, /write_lifecycle_override "false" "true" "false"/)
+  assert.match(source, /write_lifecycle_override "false" "false" "true"/)
   const bootstrapBody = actionBootstrapBody(source)
   assert.doesNotMatch(bootstrapBody, /write_lifecycle_override/)
   assert.doesNotMatch(bootstrapBody, /recreate_backend_only/)
   const humanBody = actionHumanBootstrapBody(source)
   assert.doesNotMatch(humanBody, /write_lifecycle_override/)
   assert.doesNotMatch(humanBody, /recreate_backend_only/)
-  const notExec = source.slice(
-    source.indexOf('action_not_executable_on()'),
-    source.indexOf('\naction_bootstrap()'),
-  )
-  assert.doesNotMatch(notExec, /write_lifecycle_override/)
 })
 
 test('MUTATION: routing alias back to not-executable would fail action_alias contract', () => {
@@ -786,13 +857,17 @@ test('MUTATION: routing alias back to not-executable would fail action_alias con
   assert.equal(failed, true)
 })
 
-test('workflow and remote do not export or require canary presence tokens as ON enablers', () => {
+test('workflow and remote do not export raw subject values; subject is path-only secret file', () => {
   const yaml = read(WORKFLOW)
   const source = read(REMOTE_SH)
-  assert.doesNotMatch(yaml, /CANARY_SUBJECT_ID/)
+  assert.doesNotMatch(yaml, /export CANARY_SUBJECT_ID=/)
+  assert.doesNotMatch(yaml, /export LIFECYCLE_CANARY_DIRECTORY_ACCOUNT_ID=/)
   assert.doesNotMatch(yaml, /OWNER_CONFIRM/)
   assert.doesNotMatch(source, /has_canary_inputs/)
-  assert.match(source, /NOT used/)
+  assert.match(source, /CANARY_DIRECTORY_ACCOUNT_ID_FILE/)
+  assert.match(source, /no auto-selection/)
+  // Path-only export is allowed; raw value export is not.
+  assert.match(yaml, /export CANARY_DIRECTORY_ACCOUNT_ID_FILE=/)
 })
 
 // --- P1: health true required after restart -------------------------------------------
@@ -2560,17 +2635,2025 @@ with socketserver.TCPServer(("127.0.0.1", 0), Handler) as httpd:
   }
 })
 
+
+// --- pending admit canary -------------------------------------------------------------
+
+test('pending admit-only: subject secret, expected off, SHA, migrations; no temp_password activate; OAuth NOT_EXECUTED', () => {
+  const body = actionPendingBody(read(REMOTE_SH))
+  assert.match(body, /require_canary_secret_files "pending"/)
+  assert.match(body, /require_canary_directory_account_id_file "pending"/)
+  assert.match(body, /require_sha/)
+  assert.match(body, /assert_exact_sha/)
+  assert.match(body, /require_migrations_pending_zero_true/)
+  assert.match(body, /expected_current_mode=off/)
+  assert.match(body, /write_lifecycle_override "false" "true" "false"/)
+  assert.match(body, /assert_exact_mode_pending/)
+  assert.match(body, /run_pending_admit/)
+  assert.match(body, /assert_subject_user_access_state "pending_activation" "false"/)
+  assert.match(body, /oauth_negative_checkpoint="NOT_EXECUTED"/)
+  assert.match(body, /oauth_positive_checkpoint="NOT_EXECUTED"/)
+  assert.match(body, /password_login_denied_checkpoint="NOT_EXECUTED"/)
+  assert.match(body, /password_login_denied_ok=false/)
+  assert.match(body, /activate_executed="false"|activate_executed=\$\{activate_executed\}/)
+  assert.match(body, /run_pending_sso_activate/)
+  assert.match(body, /PENDING_SSO_ACTIVATE/)
+  // No vacuous wrong-password denial; no temp_password activate path.
+  assert.doesNotMatch(body, /lifecycle-canary-login-must-fail/)
+  assert.doesNotMatch(body, /run_pending_activate\b/)
+  assert.doesNotMatch(body, /mode.: .temp_password|mode": "temp_password/)
+  assert.doesNotMatch(body, /prove_subject_login_denied "/)
+  assert.match(body, /restore_lifecycle_override/)
+  assert.match(body, /assert_exact_mode_off/)
+  assert.match(body, /rolled_back_to_off/)
+})
+
+test('pending SSO phase uses mode=sso and keeps OAuth checkpoints NOT_EXECUTED', () => {
+  const source = read(REMOTE_SH)
+  const body = actionPendingBody(source)
+  assert.match(body, /phase="sso_activate"|phase=sso_activate/)
+  assert.match(body, /run_pending_sso_activate/)
+  assert.match(body, /browser OAuth NOT_EXECUTED|oauth_positive_checkpoint="NOT_EXECUTED"/)
+  assert.match(body, /lifecycle_env_write=false/)
+  // SSO body lives in the helper (not only action_pending).
+  assert.match(source, /"mode": "sso"/)
+  assert.match(source, /enableDingTalkGrant.: True|enableDingTalkGrant": true/)
+})
+
+test('MUTATION: reintroducing wrong-password login denial as evidence turns contract red', () => {
+  const source = read(REMOTE_SH)
+  assert.doesNotMatch(source, /lifecycle-canary-login-must-fail/)
+  const mutated = source + '\nprove_subject_login_denied() { curl -d password=lifecycle-canary-login-must-fail; }\n'
+  let failed = false
+  try {
+    assert.doesNotMatch(mutated, /lifecycle-canary-login-must-fail/)
+  } catch {
+    failed = true
+  }
+  assert.equal(failed, true)
+})
+
+test('MUTATION: pending admit claiming password_login_denied_ok=true without proven password turns red', () => {
+  const body = actionPendingBody(read(REMOTE_SH))
+  // Admit phase summary must keep denied_ok false / NOT_EXECUTED.
+  assert.match(body, /password_login_denied_ok=false/)
+  const mutated = body.replaceAll('password_login_denied_ok=false', 'password_login_denied_ok=true')
+  let failed = false
+  try {
+    assert.match(mutated, /password_login_denied_ok=false/)
+  } catch {
+    failed = true
+  }
+  assert.equal(failed, true)
+})
+
+test('MUTATION: removing pending admit assertion turns contract red', () => {
+  const body = actionPendingBody(read(REMOTE_SH))
+  const mutated = body.replaceAll('run_pending_admit', 'true_admit_removed')
+  let failed = false
+  try {
+    assert.match(mutated, /run_pending_admit/)
+  } catch {
+    failed = true
+  }
+  assert.equal(failed, true)
+})
+
+test('MUTATION: removing pending OFF restore turns contract red', () => {
+  const body = actionPendingBody(read(REMOTE_SH))
+  const mutated = body.replace(
+    'restoring explicit OFF rollback baseline (success requires/proves OFF; canary must not leave pending enabled)',
+    'skip restore',
+  )
+  let failed = false
+  try {
+    assert.match(
+      mutated,
+      /restoring explicit OFF rollback baseline \(success requires\/proves OFF; canary must not leave pending enabled\)/,
+    )
+  } catch {
+    failed = true
+  }
+  assert.equal(failed, true)
+})
+
+test('production function: require_canary_directory_account_id_file rejects missing/empty/non-uuid', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'lifecycle-subject-'))
+  try {
+    function run(pathValue) {
+      return spawnSync(
+        'bash',
+        [
+          '-o',
+          'pipefail',
+          '-c',
+          'source "$1"; CANARY_DIRECTORY_ACCOUNT_ID_FILE="$2"; require_canary_directory_account_id_file pending',
+          'bash',
+          REMOTE_SH,
+          pathValue,
+        ],
+        {
+          encoding: 'utf8',
+          env: {
+            ...process.env,
+            ACTION: 'status',
+            OUTPUT_DIR: '/tmp/lifecycle-canary-contract-source-only',
+            RUN_STAMP: 'contract',
+            LIFECYCLE_CANARY_SOURCE_ONLY: 'true',
+          },
+        },
+      )
+    }
+    assert.notEqual(run('').status, 0)
+    assert.match(run('').stderr, /CANARY_DIRECTORY_ACCOUNT_ID_FILE|no auto-selection/)
+    const missing = join(dir, 'missing.id')
+    assert.notEqual(run(missing).status, 0)
+    const empty = join(dir, 'empty.id')
+    writeFileSync(empty, '', { mode: 0o600 })
+    assert.notEqual(run(empty).status, 0)
+    const bad = join(dir, 'bad.id')
+    writeFileSync(bad, 'not-a-uuid', { mode: 0o600 })
+    assert.notEqual(run(bad).status, 0)
+    assert.match(run(bad).stderr, /subject_not_uuid|invalid/)
+    const good = join(dir, 'good.id')
+    writeFileSync(good, '6c1fe000-ca0a-4000-8000-1ec0c1e00099', { mode: 0o600 })
+    assert.equal(run(good).status, 0, run(good).stderr)
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('FUNCTIONAL: subject omission refuses pending before any env write', () => {
+  const sha = 'f'.repeat(40)
+  const result = spawnSync(
+    'bash',
+    [
+      '-o',
+      'pipefail',
+      '-c',
+      `source "$1"
+       CALL_LOG=()
+       record() { CALL_LOG+=("\$1"); }
+       require_sha() { record require_sha; }
+       require_canary_secret_files() { :; }
+       assert_canary_identifier_matches_owner() { :; }
+       require_canary_directory_account_id_file() {
+         record require_subject
+         fail "action=pending requires CANARY_DIRECTORY_ACCOUNT_ID_FILE (chmod-600 secret file path); no auto-selection"
+       }
+       write_lifecycle_override() { record "write:\$1:\$2:\$3"; }
+       fail() { record "fail:\$*"; printf '%s\\n' "\${CALL_LOG[@]}"; exit 1; }
+       DEPLOY_SHA="$2"
+       EXPECTED_CURRENT_MODE=off
+       ACTION=pending
+       action_pending
+       printf '%s\\n' "\${CALL_LOG[@]}"`,
+      'bash',
+      REMOTE_SH,
+      sha,
+    ],
+    {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        ACTION: 'pending',
+        OUTPUT_DIR: '/tmp/lifecycle-canary-pending-omit',
+        RUN_STAMP: 'contract',
+        LIFECYCLE_CANARY_SOURCE_ONLY: 'true',
+        DEPLOY_SHA: sha,
+        EXPECTED_CURRENT_MODE: 'off',
+      },
+    },
+  )
+  assert.notEqual(result.status, 0)
+  const lines = result.stdout.trim().split('\n').filter(Boolean)
+  assert.ok(lines.includes('require_subject'), lines.join(','))
+  assert.ok(!lines.some((l) => l.startsWith('write:')), 'must not write lifecycle override without subject')
+})
+
+test('FUNCTIONAL: pending interrupt in ON window restores OFF before exit', () => {
+  const sha = '1'.repeat(40)
+  const dir = mkdtempSync(join(tmpdir(), 'lifecycle-pending-term-'))
+  const calls = join(dir, 'calls.log')
+  try {
+    const result = spawnSync(
+      'bash',
+      [
+        '-o',
+        'pipefail',
+        '-c',
+        `source "$1"
+         CALLS="$2"
+         record() { printf '%s\\n' "$1" >> "$CALLS"; }
+         restore_lifecycle_override() { record restore_off; return 0; }
+         recreate_backend_only() { record recreate_backend; return 0; }
+         resolve_deployed_sha() { record resolve_sha; printf '%s' "$DEPLOY_SHA"; }
+         assert_exact_mode_off() { record mode_off; return 0; }
+         fetch_backend_health_ok() { record health_ok; printf 'true'; }
+         cleanup_prev_backup() { record cleanup_backup; }
+         DEPLOY_SHA="$3"
+         ACTION=pending
+         arm_alias_exit_rollback_guard
+         record pending_on_written
+         kill -TERM $$
+         record after_signal`,
+        'bash',
+        REMOTE_SH,
+        calls,
+        sha,
+      ],
+      {
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          ACTION: 'pending',
+          OUTPUT_DIR: dir,
+          RUN_STAMP: 'contract-pending-term',
+          LIFECYCLE_CANARY_SOURCE_ONLY: 'true',
+        },
+      },
+    )
+    assert.equal(result.status, 143, result.stderr + result.stdout)
+    const lines = readFileSync(calls, 'utf8').trim().split('\n')
+    assert.ok(lines.indexOf('pending_on_written') < lines.indexOf('restore_off'))
+    assert.ok(lines.indexOf('restore_off') < lines.indexOf('recreate_backend'))
+    assert.ok(!lines.includes('after_signal'))
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+// --- deprovision apply / restore ------------------------------------------------------
+
+test('deprovision apply phase: subject, source disable confirm, exact run ledger, flags OFF, not end-to-end', () => {
+  const source = read(REMOTE_SH)
+  const body = actionDeprovisionApplyBody(source)
+  const all = actionDeprovisionBody(source)
+  assert.match(source, /DEPROVISION_SOURCE_CONFIRMATION="DINGTALK_SOURCE_DISABLED_DEDICATED_EXCLUSIVE_CONFIRMED"/)
+  assert.match(source, /DEPROVISION_RESTORE_CONFIRMATION="DINGTALK_SOURCE_REACTIVATED_CONFIRMED"/)
+  assert.match(all, /DEPROVISION_SOURCE_CONFIRMATION|DINGTALK_SOURCE_DISABLED_DEDICATED_EXCLUSIVE_CONFIRMED/)
+  assert.match(all, /DEPROVISION_RESTORE_CONFIRMATION|action_deprovision_restore/)
+  assert.match(all, /action_deprovision_apply/)
+  assert.match(all, /action_deprovision_restore/)
+  assert.match(body, /require_canary_directory_account_id_file "deprovision"/)
+  assert.match(body, /run_deprovision_sync_preview_subject_gate/)
+  assert.ok(
+    body.indexOf('run_deprovision_sync_preview_subject_gate')
+      < body.indexOf('write_lifecycle_override "false" "false" "true"'),
+    'preview gate must precede deprovision env write',
+  )
+  assert.match(body, /write_lifecycle_override "false" "false" "true"/)
+  assert.match(body, /run_directory_sync_for_subject "deprovision_apply" "true"/)
+  assert.match(body, /verify_deprovision_ledger_for_subject/)
+  assert.match(body, /ledger_run_match/)
+  assert.match(body, /source_still_active_after_sync_external_gate/)
+  assert.match(body, /access_restored=false/)
+  assert.match(body, /canary_access_rollback_complete=false/)
+  assert.match(body, /end_to_end_restore_claimed=false/)
+  assert.match(body, /restore_phase_required=true/)
+  assert.match(body, /prove_subject_login_denied_with_proven_password/)
+  assert.match(body, /login_denied_checkpoint="NOT_EXECUTED"|login_denied_checkpoint=\$\{login_denied_checkpoint\}/)
+  assert.match(body, /NOT_EXECUTED/)
+  // Vacuous wrong-password helper must not exist.
+  assert.doesNotMatch(body, /lifecycle-canary-login-must-fail/)
+  assert.doesNotMatch(body, /end_to_end_restore_claimed=true/)
+})
+
+test('deprovision restore phase: source reactivated confirm, rehire, resolved, access restored, flags OFF', () => {
+  const source = read(REMOTE_SH)
+  const body = actionDeprovisionRestoreBody(source)
+  assert.match(body, /run_directory_sync_for_subject "deprovision_restore"/)
+  assert.match(body, /run_or_resume_deprovision_rehire_restore/)
+  const resume = runOrResumeRestoreBody(source)
+  assert.match(resume, /run_deprovision_rehire_restore/)
+  assert.match(resume, /verify_deprovision_event_resolved/)
+  assert.match(body, /assert_subject_user_access_state "activated" "true"/)
+  assert.match(body, /flags_remain_off/)
+  assert.match(body, /canary_access_rollback_complete=true/)
+  assert.match(body, /server_side_access_graph_restore_proven=true/)
+  assert.match(body, /end_to_end_restore_claimed=false/)
+  assert.match(body, /lifecycle_env_write=false/)
+  assert.doesNotMatch(body, /write_lifecycle_override "false" "false" "true"/)
+  // Rehire mode is on the restore helper (not the action body).
+  assert.match(source, /"mode": "rehire"/)
+  assert.match(source, /run_deprovision_rehire_restore\(\)/)
+})
+
+test('deprovision ledger requires exact sync run.id equality (load-bearing)', () => {
+  const ledger = verifyDeprovisionLedgerBody(read(REMOTE_SH))
+  assert.match(ledger, /CANARY_SUBJECT_SYNC_RUN_ID_FILE/)
+  assert.match(ledger, /event_run_id_mismatch/)
+  assert.match(ledger, /expected_run_id/)
+  assert.match(ledger, /run_id == expected_run_id|rid == expected_run_id/)
+  assert.match(ledger, /SYNC_DEPROVISION_APPLIED/)
+  assert.match(ledger, /sync_deprovision_not_applied/)
+  // Must not pick newest event without run filter.
+  assert.doesNotMatch(ledger, /Pick newest event/)
+})
+
+test('MUTATION: dropping ledger run_id equality turns contract red', () => {
+  const ledger = verifyDeprovisionLedgerBody(read(REMOTE_SH))
+  // Remove the equality check lines.
+  const mutated = ledger
+    .replaceAll('event_run_id_mismatch', 'event_run_ignored')
+    .replaceAll('rid == expected_run_id', 'True')
+    .replaceAll('event_run != expected_run_id', 'False')
+  let failed = false
+  try {
+    assert.match(mutated, /event_run_id_mismatch/)
+  } catch {
+    failed = true
+  }
+  assert.equal(failed, true)
+})
+
+test('MUTATION: accepting any applied event without run match turns ledger contract red', () => {
+  const ledger = verifyDeprovisionLedgerBody(read(REMOTE_SH))
+  const mutated = ledger.replace(
+    'if rid == expected_run_id:\n        matched.append(item)',
+    'matched.append(item)  # run equality removed',
+  )
+  let failed = false
+  try {
+    assert.match(mutated, /if rid == expected_run_id:\s*\n\s*matched\.append\(item\)/)
+  } catch {
+    failed = true
+  }
+  assert.equal(failed, true)
+})
+
+test('MUTATION: deprovision apply claiming end-to-end restore turns contract red', () => {
+  const body = actionDeprovisionApplyBody(read(REMOTE_SH))
+  const mutated = body.replaceAll('end_to_end_restore_claimed=false', 'end_to_end_restore_claimed=true')
+  let failed = false
+  try {
+    assert.match(mutated, /end_to_end_restore_claimed=false/)
+  } catch {
+    failed = true
+  }
+  assert.equal(failed, true)
+})
+
+test('MUTATION: removing deprovision rehire restore from restore phase turns red', () => {
+  const body = actionDeprovisionRestoreBody(read(REMOTE_SH))
+  const mutated = body.replaceAll('run_deprovision_rehire_restore', 'true_restore_removed')
+  let failed = false
+  try {
+    assert.match(mutated, /run_deprovision_rehire_restore/)
+  } catch {
+    failed = true
+  }
+  assert.equal(failed, true)
+})
+
+test('MUTATION: setting login_denied_ok=true without proven password path turns red', () => {
+  const body = actionDeprovisionApplyBody(read(REMOTE_SH))
+  // When no proven password, login_denied_ok must stay false / NOT_EXECUTED.
+  assert.match(body, /login_denied_ok="false"/)
+  assert.match(body, /login_denied_checkpoint="NOT_EXECUTED"/)
+  const mutated = body.replace(
+    'login_denied_ok="false"\n    login_denied_checkpoint="NOT_EXECUTED"',
+    'login_denied_ok="true"\n    login_denied_checkpoint="NOT_EXECUTED"',
+  )
+  let failed = false
+  try {
+    assert.match(mutated, /login_denied_ok="false"\n\s*login_denied_checkpoint="NOT_EXECUTED"/)
+  } catch {
+    failed = true
+  }
+  assert.equal(failed, true)
+})
+
+test('FUNCTIONAL: deprovision refuses without source confirmation before env write', () => {
+  const sha = '2'.repeat(40)
+  const result = spawnSync(
+    'bash',
+    [
+      '-o',
+      'pipefail',
+      '-c',
+      `source "$1"
+       CALL_LOG=()
+       record() { CALL_LOG+=("\$1"); }
+       require_sha() { record require_sha; }
+       write_lifecycle_override() { record "write:\$1:\$2:\$3"; }
+       fail() { record "fail:\$*"; printf '%s\\n' "\${CALL_LOG[@]}"; exit 1; }
+       DEPLOY_SHA="$2"
+       EXPECTED_CURRENT_MODE=off
+       BOOTSTRAP_CONFIRMATION=WRONG
+       ACTION=deprovision
+       action_deprovision
+       printf '%s\\n' "\${CALL_LOG[@]}"`,
+      'bash',
+      REMOTE_SH,
+      sha,
+    ],
+    {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        ACTION: 'deprovision',
+        OUTPUT_DIR: '/tmp/lifecycle-canary-deprov-confirm',
+        RUN_STAMP: 'contract',
+        LIFECYCLE_CANARY_SOURCE_ONLY: 'true',
+        DEPLOY_SHA: sha,
+        EXPECTED_CURRENT_MODE: 'off',
+        BOOTSTRAP_CONFIRMATION: 'WRONG',
+      },
+    },
+  )
+  assert.notEqual(result.status, 0)
+  const lines = result.stdout.trim().split('\n').filter(Boolean)
+  assert.ok(lines.some((l) => l.includes('DINGTALK_SOURCE_DISABLED_DEDICATED_EXCLUSIVE_CONFIRMED') || l.includes('DINGTALK_SOURCE_REACTIVATED')))
+  assert.ok(!lines.some((l) => l.startsWith('write:')), 'must not write without confirmation')
+})
+
+test('FUNCTIONAL harness: pending admit failure after ON write restores OFF before terminate', () => {
+  const sha = '3'.repeat(40)
+  const result = spawnSync(
+    'bash',
+    [
+      '-o',
+      'pipefail',
+      '-c',
+      `source "$1"
+       CALL_LOG=()
+       record() { CALL_LOG+=("\$1"); }
+       require_sha() { :; }
+       require_canary_secret_files() { :; }
+       assert_canary_identifier_matches_owner() { :; }
+       require_canary_directory_account_id_file() { :; }
+       capture_live_snapshot() {
+         SNAP_ALIAS=false; SNAP_PENDING=false; SNAP_DEPROV=false; SNAP_MODE=off
+         SNAP_BUILD_SHA="$DEPLOY_SHA"; SNAP_ALIAS_READY=true; SNAP_CAN_ENABLE_ALIAS=true
+         SNAP_MIGRATIONS_ZERO=true; SNAP_HEALTH_OK=true
+       }
+       assert_exact_sha() { :; }
+       pin_live_backend_image_for_transition() { :; }
+       require_migrations_pending_zero_true() { :; }
+       mint_canary_admin_jwt_from_password_login() {
+         record "mint:\$1"
+         CANARY_ADMIN_JWT_FILE="/tmp/lifecycle-canary-pending-mint.jwt"
+         printf 'minted-token' > "\$CANARY_ADMIN_JWT_FILE"
+         return 0
+       }
+       load_canary_directory_subject() {
+         record "load:\$1"
+         SUBJECT_OK=true; SUBJECT_NOTE=ok; SUBJECT_PROVIDER_OK=true; SUBJECT_NAME_OK=true
+         SUBJECT_ACTIVE=true; SUBJECT_LINK_STATUS=unmatched; SUBJECT_HAS_LOCAL_USER=false
+         SUBJECT_LOCAL_USERNAME_OK=false; SUBJECT_LOCAL_NAME_OK=false
+         return 0
+       }
+       establish_alias_off_rollback_baseline() { record off_baseline; }
+       arm_alias_exit_rollback_guard() { record arm_exit_guard; }
+       disarm_alias_exit_rollback_guard() { record disarm_exit_guard; }
+       write_lifecycle_override() { record "write:\$1:\$2:\$3"; }
+       recreate_backend_only() { record recreate; return 0; }
+       resolve_deployed_sha() { printf '%s' "$DEPLOY_SHA"; }
+       assert_exact_mode_pending() { record mode_pending; return 0; }
+       run_pending_admit() { record admit; ADMIT_NOTE=forced_fail; return 1; }
+       restore_lifecycle_override() { record restore; }
+       cleanup_prev_backup() { record cleanup_backup; }
+       fail() { record "fail:\$*"; printf '%s\\n' "\${CALL_LOG[@]}"; exit 1; }
+       OUTPUT_DIR="$2"
+       mkdir -p "$OUTPUT_DIR"
+       DEPLOY_SHA="$3"
+       EXPECTED_CURRENT_MODE=off
+       ACTION=pending
+       BOOTSTRAP_CONFIRMATION=
+       action_pending
+       printf '%s\\n' "\${CALL_LOG[@]}"
+       exit 0`,
+      'bash',
+      REMOTE_SH,
+      '/tmp/lifecycle-canary-pending-fail',
+      sha,
+    ],
+    {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        ACTION: 'pending',
+        OUTPUT_DIR: '/tmp/lifecycle-canary-pending-fail',
+        RUN_STAMP: 'contract',
+        LIFECYCLE_CANARY_SOURCE_ONLY: 'true',
+        DEPLOY_SHA: sha,
+        EXPECTED_CURRENT_MODE: 'off',
+      },
+    },
+  )
+  assert.notEqual(result.status, 0)
+  const lines = result.stdout.trim().split('\n').filter(Boolean)
+  const writeIdx = lines.indexOf('write:false:true:false')
+  const admitIdx = lines.indexOf('admit')
+  const restoreIdx = lines.indexOf('restore')
+  const failIdx = lines.findIndex((l) => l.startsWith('fail:'))
+  assert.ok(writeIdx >= 0, lines.join(','))
+  assert.ok(admitIdx > writeIdx)
+  assert.ok(restoreIdx > admitIdx, 'fail_transition_restore must restore after admit failure')
+  assert.ok(failIdx > restoreIdx)
+})
+
+test('workflow pending/deprovision phase confirmations and honest claims', () => {
+  const yaml = read(WORKFLOW)
+  assert.match(yaml, /PENDING_SSO_ACTIVATE/)
+  assert.match(yaml, /DINGTALK_SOURCE_DISABLED_DEDICATED_EXCLUSIVE_CONFIRMED/)
+  assert.match(yaml, /DINGTALK_SOURCE_REACTIVATED_CONFIRMED/)
+  assert.match(yaml, /directory-account\.id/)
+  assert.match(yaml, /NOT_EXECUTED/)
+  assert.match(yaml, /restore phase|RESTORE/)
+  assert.doesNotMatch(yaml, /docs may still say NOT EXECUTABLE|follow-up to refresh docs/i)
+  assert.match(yaml, /exactly one total directory account/)
+  assert.match(yaml, /reserves and journals the exact sync run UUID before env\/HTTP/)
+})
+
+
+test('P1-D: login denial accepts only 401/403 auth errors; 5xx/transport fail', () => {
+  const source = read(REMOTE_SH)
+  const start = source.indexOf('prove_subject_login_denied_with_proven_password()')
+  assert.notEqual(start, -1)
+  const end = source.indexOf('\nrun_pending_sso_activate()', start)
+  const body = source.slice(start, end)
+  assert.match(body, /code not in \(401, 403\)/)
+  assert.match(body, /not_auth_denial/)
+  assert.match(body, /get\("success"\) is not False/)
+  assert.match(body, /CLOSED_LOGIN_ERRORS|Invalid account or password/)
+  assert.match(body, /auth_error_not_in_closed_set|auth_denied/)
+  assert.match(body, /bad_json/)
+  assert.doesNotMatch(body, /"invalid" in err_l|"password" in err_l|"unauthorized" in err_l/)
+  assert.doesNotMatch(body, /print\(f"true\|http_\{int\(e\.code\)\}_denied"\)/)
+})
+
+test('P1-E: SSO activate uses mode=sso and enableDingTalkGrant true; no temp_password', () => {
+  const source = read(REMOTE_SH)
+  assert.match(source, /"mode": "sso"/)
+  assert.match(source, /"enableDingTalkGrant": True/)
+  assert.match(source, /run_pending_sso_activate/)
+  assert.doesNotMatch(source, /"mode": "temp_password"/)
+  assert.match(source, /Pending admit: grant must stay false|enableDingTalkGrant": False/)
+  assert.match(source, /oauth_negative_checkpoint="NOT_EXECUTED"/)
+  assert.match(source, /oauth_positive_checkpoint="NOT_EXECUTED"/)
+})
+
+test('P1-F: deprovision sync/preview gate requires sole linked deactivation matching subject', () => {
+  const source = read(REMOTE_SH)
+  assert.match(source, /run_deprovision_sync_preview_subject_gate/)
+  assert.match(source, /\/sync\/preview/)
+  assert.match(source, /wouldDeactivateAccounts/)
+  assert.match(source, /wouldDeactivateLinkedAccounts/)
+  assert.match(source, /would_deactivate_not_exactly_one/)
+  assert.match(source, /would_deactivate_linked_not_exactly_one/)
+  assert.match(source, /sampled_deactivations_not_exactly_one/)
+  assert.match(source, /sampled_external_not_subject/)
+  assert.match(source, /subject\.external-user-id/)
+  const apply = actionDeprovisionApplyBody(source)
+  assert.ok(
+    apply.indexOf('run_deprovision_sync_preview_subject_gate')
+      < apply.indexOf('write_lifecycle_override "false" "false" "true"'),
+  )
+})
+
+test('P2-C: ledger counts only status exactly applied', () => {
+  const ledger = verifyDeprovisionLedgerBody(read(REMOTE_SH))
+  assert.match(ledger, /st != "applied"|st == "applied"/)
+  assert.match(ledger, /exactly "applied"|must be exactly|status must be exactly/)
+  assert.doesNotMatch(ledger, /in \("applied", "open"/)
+})
+
+test('FUNCTIONAL: preview gate refuses when wouldDeactivateAccounts is 2 (collateral)', () => {
+  const py = [
+    'preview={"wouldDeactivateAccounts":2,"wouldDeactivateLinkedAccounts":2,"sampledDeactivations":[{"externalUserId":"u1","linked":True},{"externalUserId":"u2","linked":True}]}',
+    'would=preview["wouldDeactivateAccounts"]',
+    'linked=preview["wouldDeactivateLinkedAccounts"]',
+    'print("false|would_deactivate_not_exactly_one|%s|%s"%(would,linked) if would!=1 else ("false|would_deactivate_linked_not_exactly_one|%s|%s"%(would,linked) if linked!=1 else "true|ok|1|1"))',
+  ].join('\n')
+  const result = spawnSync('python3', ['-c', py], { encoding: 'utf8' })
+  assert.equal(result.status, 0, result.stderr + result.stdout)
+  assert.match(result.stdout, /false\|would_deactivate_not_exactly_one/)
+})
+
+test('MUTATION: treating HTTP 500 as login denial turns contract red', () => {
+  const source = read(REMOTE_SH)
+  const start = source.indexOf('prove_subject_login_denied_with_proven_password()')
+  const end = source.indexOf('\nrun_pending_sso_activate()', start)
+  const body = source.slice(start, end)
+  const mutated = body.replace(
+    'if code not in (401, 403):',
+    'if code not in (401, 403, 500):  # mutation softens 500',
+  )
+  let failed = false
+  try {
+    assert.match(mutated, /if code not in \(401, 403\):/)
+  } catch {
+    failed = true
+  }
+  assert.equal(failed, true)
+})
+
+test('MUTATION: preview gate accepting wouldDeactivateAccounts!=1 turns red', () => {
+  const source = read(REMOTE_SH)
+  const start = source.indexOf('run_deprovision_sync_preview_subject_gate()')
+  const end = source.indexOf('\nrun_directory_sync_for_subject()', start)
+  const body = source.slice(start, end)
+  const mutated = body.replace('if would != 1:', 'if False:  # would check removed')
+  let failed = false
+  try {
+    assert.match(mutated, /if would != 1:/)
+  } catch {
+    failed = true
+  }
+  assert.equal(failed, true)
+})
+
+test('MUTATION: ledger counting empty status as applied turns red', () => {
+  const ledger = verifyDeprovisionLedgerBody(read(REMOTE_SH))
+  const mutated = ledger.replace(
+    'if type(st) is not str or st != "applied":',
+    'if False:  # empty/open accepted',
+  )
+  let failed = false
+  try {
+    assert.match(mutated, /type\(st\) is not str or st != "applied"/)
+  } catch {
+    failed = true
+  }
+  assert.equal(failed, true)
+})
+
+test('FUNCTIONAL: proven-password denial rejects HTTP 500', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'lifecycle-deny-5xx-'))
+  const passFile = join(dir, 'pass')
+  writeFileSync(passFile, 'ProvenPass-12345!', { mode: 0o600 })
+  const serverPy = `
+import json, http.server, socketserver
+class H(http.server.BaseHTTPRequestHandler):
+    def do_POST(self):
+        n = int(self.headers.get('Content-Length', '0'))
+        self.rfile.read(n)
+        self.send_response(500)
+        self.send_header('Content-Type', 'application/json')
+        body = json.dumps({"success": False, "error": "Internal server error"}).encode()
+        self.send_header('Content-Length', str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+    def log_message(self, *a):
+        return
+with socketserver.TCPServer(('127.0.0.1', 0), H) as httpd:
+    print(httpd.server_address[1], flush=True)
+    httpd.handle_request()
+`
+  /** @type {import('node:child_process').ChildProcess | null} */
+  let serverProc = null
+  try {
+    serverProc = spawn('python3', ['-c', serverPy], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: process.env,
+    })
+    const port = await new Promise((resolve, reject) => {
+      let buf = ''
+      const timer = setTimeout(() => reject(new Error('loopback port timeout')), 3000)
+      const onData = (chunk) => {
+        buf += chunk.toString('utf8')
+        const line = buf.trim().split(/\r?\n/).filter(Boolean).pop() || ''
+        if (/^\d+$/.test(line)) {
+          clearTimeout(timer)
+          serverProc.stdout.off('data', onData)
+          resolve(Number(line))
+        }
+      }
+      serverProc.stdout.on('data', onData)
+      serverProc.on('error', (err) => {
+        clearTimeout(timer)
+        reject(err)
+      })
+    })
+    const result = spawnSync(
+      'bash',
+      [
+        '-o',
+        'pipefail',
+        '-c',
+        'source "$1"; STAGING_API_BASE_URL="http://127.0.0.1:$2"; SUBJECT_OWNER_USERNAME=lifecycle-canary-employee; SUBJECT_PASSWORD_PROVEN_OK=true; CANARY_SUBJECT_TEMP_PASSWORD_FILE="$3"; if prove_subject_login_denied_with_proven_password loopback_5xx; then echo FAIL_ACCEPTED; exit 3; fi; echo "note=${LOGIN_DENIED_NOTE}"; exit 0',
+        'bash',
+        REMOTE_SH,
+        String(port),
+        passFile,
+      ],
+      {
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          ACTION: 'status',
+          OUTPUT_DIR: dir,
+          RUN_STAMP: 'contract',
+          LIFECYCLE_CANARY_SOURCE_ONLY: 'true',
+        },
+      },
+    )
+    assert.equal(result.status, 0, result.stderr + result.stdout)
+    assert.match(result.stdout, /note=http_500_not_auth_denial/)
+    assert.doesNotMatch(result.stdout, /FAIL_ACCEPTED/)
+  } finally {
+    if (serverProc && serverProc.exitCode === null) {
+      try {
+        serverProc.kill('SIGKILL')
+      } catch {
+        // ignore
+      }
+    }
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+
+// --- Round-3 fail-closed hardening ----------------------------------------------------
+
+test('R3: assert_subject_user_access_state requires JSON boolean is_active (missing/null/string fail)', () => {
+  const source = read(REMOTE_SH)
+  const start = source.indexOf('assert_subject_user_access_state()')
+  const end = source.indexOf('\nresolve_subject_password_file()', start)
+  const body = source.slice(start, end)
+  assert.match(body, /is_active_missing/)
+  assert.match(body, /is_active_not_boolean/)
+  assert.match(body, /type\(is_active\) is not bool/)
+  // Must not coerce missing/null/string to false.
+  assert.doesNotMatch(body, /active_s = "true" if is_active is True else "false"\nactivation = str/)
+  assert.doesNotMatch(body, /is_active is None:\n    is_active = data\.get/)
+})
+
+test('FUNCTIONAL: assert_subject_user_access_state rejects missing/null/string is_active', () => {
+  function runPayload(userObj) {
+    const py = `
+import json
+user = json.loads(${JSON.stringify(JSON.stringify(userObj))})
+if "is_active" in user:
+    is_active = user["is_active"]
+elif "isActive" in user:
+    is_active = user["isActive"]
+else:
+    print("false|is_active_missing")
+    raise SystemExit(0)
+if type(is_active) is not bool:
+    print("false|is_active_not_boolean")
+    raise SystemExit(0)
+print("true|ok|" + ("true" if is_active is True else "false"))
+`
+    return spawnSync('python3', ['-c', py], { encoding: 'utf8' })
+  }
+  for (const bad of [{}, { is_active: null }, { is_active: 'false' }, { isActive: 'false' }, { is_active: 0 }]) {
+    const r = runPayload(bad)
+    assert.equal(r.status, 0, r.stderr)
+    assert.match(r.stdout, /false\|is_active_(missing|not_boolean)/)
+  }
+  const ok = runPayload({ is_active: false, activationStatus: 'activated' })
+  assert.match(ok.stdout, /true\|ok\|false/)
+})
+
+test('MUTATION: coercing missing is_active to false turns access contract red', () => {
+  const source = read(REMOTE_SH)
+  const start = source.indexOf('assert_subject_user_access_state()')
+  const end = source.indexOf('\nresolve_subject_password_file()', start)
+  const body = source.slice(start, end)
+  const mutated = body.replace(
+    'emit("false", "is_active_missing")',
+    'is_active = False  # mutation: missing becomes false',
+  )
+  let failed = false
+  try {
+    assert.match(mutated, /is_active_missing/)
+  } catch {
+    failed = true
+  }
+  assert.equal(failed, true)
+})
+
+test('R3: login denial closed-set only Invalid account or password', () => {
+  const source = read(REMOTE_SH)
+  const start = source.indexOf('prove_subject_login_denied_with_proven_password()')
+  const end = source.indexOf('\nrun_pending_sso_activate()', start)
+  const body = source.slice(start, end)
+  assert.match(body, /CLOSED_LOGIN_ERRORS/)
+  assert.match(body, /Invalid account or password/)
+  assert.match(body, /auth_error_not_in_closed_set/)
+  assert.doesNotMatch(body, /"invalid" in err_l/)
+  assert.doesNotMatch(body, /"unauthorized" in err_l/)
+  assert.doesNotMatch(body, /"forbidden" in err_l/)
+})
+
+test('FUNCTIONAL: closed-set denial rejects CSRF-style 403 error text', () => {
+  const py = `
+CLOSED_LOGIN_ERRORS = frozenset({"Invalid account or password"})
+for code, err in [(403, "CSRF token missing"), (401, "Unauthorized"), (401, "Invalid account or password")]:
+    ok = err in CLOSED_LOGIN_ERRORS
+    print(f"{code}|{err}|{'true' if ok else 'false'}")
+`
+  const r = spawnSync('python3', ['-c', py], { encoding: 'utf8' })
+  assert.equal(r.status, 0, r.stderr)
+  assert.match(r.stdout, /403\|CSRF token missing\|false/)
+  assert.match(r.stdout, /401\|Unauthorized\|false/)
+  assert.match(r.stdout, /401\|Invalid account or password\|true/)
+})
+
+test('R3: apply persists exact run/event/effects; restore forbids discovery', () => {
+  const source = read(REMOTE_SH)
+  assert.match(source, /persist_deprovision_apply_state/)
+  assert.match(source, /load_deprovision_apply_state/)
+  assert.match(source, /clear_deprovision_apply_state/)
+  assert.match(source, /lifecycle-canary-deprovision-apply-state-v4/)
+  assert.match(source, /\.apply-state\.json/)
+  assert.doesNotMatch(source, /discover_applied_deprovision_event_for_subject/)
+  assert.match(source, /event_id_file_missing_no_discovery|no event auto-discovery|no_discovery/)
+  const apply = actionDeprovisionApplyBody(source)
+  assert.match(apply, /persist_deprovision_apply_state|journal_upgrade_ledger_bound/)
+  const restore = actionDeprovisionRestoreBody(source)
+  assert.match(restore, /load_deprovision_apply_state/)
+  assert.match(restore, /clear_deprovision_apply_state/)
+  assert.doesNotMatch(restore, /discover_applied/)
+})
+
+test('R3: restore requires fully_resolved and all effects reversed', () => {
+  const source = read(REMOTE_SH)
+  const start = source.indexOf('verify_deprovision_event_resolved()')
+  const end = source.indexOf('\nprove_access_graph_state()', start)
+  const body = source.slice(start, end)
+  assert.match(body, /fully_resolved/)
+  assert.match(body, /effect_not_reversed|status.*reversed/)
+  assert.match(body, /event_status_superseded|event_not_fully_resolved/)
+  assert.match(body, /effect_missing_after_restore/)
+  assert.match(body, /effects_empty_after_restore/)
+  // Must not treat "not in applied list" alone as success without fully_resolved.
+  assert.doesNotMatch(body, /emit\("true", "resolved"\)/)
+  assert.match(body, /fully_resolved_all_reversed/)
+})
+
+test('MUTATION: restore accepting event merely absent from applied turns red', () => {
+  const source = read(REMOTE_SH)
+  const start = source.indexOf('verify_deprovision_event_resolved()')
+  const end = source.indexOf('\nprove_access_graph_state()', start)
+  const body = source.slice(start, end)
+  const mutated = body.replaceAll('fully_resolved', 'applied_absent')
+  let failed = false
+  try {
+    assert.match(mutated, /fully_resolved/)
+  } catch {
+    failed = true
+  }
+  assert.equal(failed, true)
+})
+
+test('R3: access graph proof uses DB user/membership/grant not profile-only access API', () => {
+  const source = read(REMOTE_SH)
+  assert.match(source, /prove_access_graph_state/)
+  assert.match(source, /user_orgs/)
+  assert.match(source, /user_external_auth_grants/)
+  assert.match(source, /provider = \$2|provider = 'dingtalk'|provider = \$2/)
+  assert.match(source, /server_side_access_graph_restore_proven/)
+  const restore = actionDeprovisionRestoreBody(source)
+  assert.match(restore, /prove_access_graph_state "restored"/)
+  assert.match(restore, /server_side_access_graph_restore_proven=true/)
+  assert.match(restore, /end_to_end_restore_claimed=false/)
+  assert.doesNotMatch(restore, /end_to_end_restore_claimed=true/)
+  const apply = actionDeprovisionApplyBody(source)
+  assert.match(apply, /prove_access_graph_state "deprovisioned"/)
+})
+
+test('R3: post-sync radius requires candidate=1 and accountsDeactivated=1', () => {
+  const source = read(REMOTE_SH)
+  assert.match(source, /sync_candidate_radius_not_one/)
+  assert.match(source, /sync_accounts_deactivated_not_one/)
+  assert.match(source, /candidates != 1|candidates == 1/)
+  assert.match(source, /accounts != 1|accounts == 1/)
+  assert.match(source, /sync_radius_not_atomic_lock|not atomic/)
+  const apply = actionDeprovisionApplyBody(source)
+  assert.match(apply, /SYNC_DEPROVISION_CANDIDATES\}?" == "1"|SYNC_DEPROVISION_CANDIDATES" == "1"/)
+  assert.match(apply, /SYNC_ACCOUNTS_DEACTIVATED\}?" == "1"|SYNC_ACCOUNTS_DEACTIVATED" == "1"/)
+  assert.match(apply, /\$\{SYNC_DEPROVISION_CANDIDATES\}" == "1"/)
+  assert.match(apply, /\$\{SYNC_ACCOUNTS_DEACTIVATED\}" == "1"/)
+})
+
+test('MUTATION: dropping post-sync accountsDeactivated==1 check turns red', () => {
+  const apply = actionDeprovisionApplyBody(read(REMOTE_SH))
+  const mutated = apply.replaceAll('sync_accounts_deactivated_not_one', 'radius_ignored')
+  let failed = false
+  try {
+    assert.match(mutated, /sync_accounts_deactivated_not_one/)
+  } catch {
+    failed = true
+  }
+  assert.equal(failed, true)
+})
+
+test('MUTATION: claiming end_to_end_restore_claimed=true while OAuth NOT_EXECUTED turns red', () => {
+  const restore = actionDeprovisionRestoreBody(read(REMOTE_SH))
+  assert.match(restore, /oauth_positive_checkpoint="NOT_EXECUTED"|oauth_positive_checkpoint=NOT_EXECUTED/)
+  assert.match(restore, /end_to_end_restore_claimed=false/)
+  const mutated = restore.replaceAll('end_to_end_restore_claimed=false', 'end_to_end_restore_claimed=true')
+  let failed = false
+  try {
+    assert.match(mutated, /end_to_end_restore_claimed=false/)
+  } catch {
+    failed = true
+  }
+  assert.equal(failed, true)
+})
+
+// --- Round 4: org-scoped membership, effect-metadata graph, exact effect set, state bind ---
+
+function proveAccessGraphBody(source) {
+  const start = source.indexOf('prove_access_graph_state()')
+  assert.notEqual(start, -1, 'prove_access_graph_state must exist')
+  const end = source.indexOf('\nvalidate_mode_name()', start)
+  assert.notEqual(end, -1, 'validate_mode_name after prove_access_graph_state')
+  return source.slice(start, end)
+}
+
+function loadDeprovisionApplyStateBody(source) {
+  const start = source.indexOf('load_deprovision_apply_state()')
+  assert.notEqual(start, -1)
+  // R5: load is last journal helper before rehire restore.
+  let end = source.indexOf('\nrun_deprovision_rehire_restore()', start)
+  if (end === -1) {
+    end = source.indexOf('\n# POST rehire restore', start)
+  }
+  assert.notEqual(end, -1)
+  return source.slice(start, end)
+}
+
+function persistDeprovisionApplyStateBody(source) {
+  // R5: ledger_bound upgrade lives in journal_upgrade_ledger_bound; persist is a thin alias.
+  const start = source.indexOf('journal_upgrade_ledger_bound()')
+  assert.notEqual(start, -1)
+  const end = source.indexOf('\n// Compat name used by older comments', start)
+  assert.notEqual(end, -1)
+  return source.slice(start, end)
+}
+
+function journalStateMachineRegion(source) {
+  const start = source.indexOf('# --- recovery journal state machine')
+  assert.notEqual(start, -1)
+  const end = source.indexOf('# POST rehire restore for EXACT event id', start)
+  assert.notEqual(end, -1)
+  return source.slice(start, end)
+}
+
+function rehireRestoreBody(source) {
+  const start = source.indexOf('run_deprovision_rehire_restore()')
+  assert.notEqual(start, -1)
+  const end = source.indexOf('\nverify_deprovision_event_resolved()', start)
+  assert.notEqual(end, -1)
+  return source.slice(start, end)
+}
+
+function eventResolvedBody(source) {
+  const start = source.indexOf('verify_deprovision_event_resolved()')
+  assert.notEqual(start, -1)
+  const end = source.indexOf('\nprove_access_graph_state()', start)
+  assert.notEqual(end, -1)
+  return source.slice(start, end)
+}
+
+test('R4: membership graph is org-scoped via exact integration org_id (not all-orgs)', () => {
+  const body = proveAccessGraphBody(read(REMOTE_SH))
+  assert.match(body, /directory_integrations/)
+  assert.match(body, /provider = \$2/)
+  assert.match(body, /dingtalk/)
+  assert.match(body, /org_id/)
+  assert.match(body, /user_id = \$1 AND org_id = \$2 AND COALESCE\(is_active, TRUE\) = TRUE/)
+  // Must NOT count membership across all orgs without org_id filter.
+  assert.doesNotMatch(
+    body,
+    /FROM user_orgs WHERE user_id = \$1 AND COALESCE\(is_active, TRUE\) = TRUE(?![\s\S]*org_id)/,
+  )
+  // Active integration preferred/required.
+  assert.match(body, /integration_not_active|integStatus !== "active"/)
+  assert.match(body, /integration_org_not_unique/)
+})
+
+test('MUTATION: dropping org_id scope on membership turns red', () => {
+  const body = proveAccessGraphBody(read(REMOTE_SH))
+  const mutated = body.replaceAll(
+    'user_id = $1 AND org_id = $2 AND COALESCE(is_active, TRUE) = TRUE',
+    'user_id = $1 AND COALESCE(is_active, TRUE) = TRUE',
+  )
+  let failed = false
+  try {
+    assert.match(mutated, /user_id = \$1 AND org_id = \$2 AND COALESCE\(is_active, TRUE\) = TRUE/)
+  } catch {
+    failed = true
+  }
+  assert.equal(failed, true)
+})
+
+test('R4: graph proofs are effect-metadata driven (closed types + before/after/grant_row_created)', () => {
+  const source = read(REMOTE_SH)
+  const ledger = verifyDeprovisionLedgerBody(source)
+  assert.match(ledger, /membership_changed/)
+  assert.match(ledger, /grant_changed/)
+  assert.match(ledger, /user_changed/)
+  assert.match(ledger, /before_active/)
+  assert.match(ledger, /after_active/)
+  assert.match(ledger, /grant_row_created/)
+  assert.match(ledger, /CLOSED_EFFECT_TYPES/)
+  assert.match(ledger, /effect_id_duplicate/)
+  assert.match(ledger, /effect_type_not_closed_set/)
+  assert.match(ledger, /effect_type_set_not_exact_triple|user_changed_effect_missing/)
+  const graph = proveAccessGraphBody(source)
+  assert.match(graph, /membership_changed/)
+  assert.match(graph, /grant_changed/)
+  assert.match(graph, /user_changed/)
+  assert.match(graph, /after_active/)
+  assert.match(graph, /before_active/)
+  assert.match(graph, /grant_row_created/)
+  assert.match(graph, /grant_row_created_not_absent/)
+  assert.match(graph, /grant_enabled_not_before|grant_enabled_not_after/)
+  // No free-floating "always require user inactive / membership zero" without effects.
+  assert.doesNotMatch(graph, /if \(isActive !== false\) \{\s*emit\("false", "user_still_active"/)
+})
+
+test('FUNCTIONAL: other-org active membership must not green restore when target org inactive', () => {
+  // Pure predicate: target-org scoped active flag only.
+  const py = `
+mem_active_target = False  # target org inactive after "failed" restore
+mem_active_other = True    # other org still active
+expected_before = True     # membership_changed before_active
+ok = mem_active_target == expected_before
+print("restore_ok" if ok else "restore_fail")
+# deprovision: target inactive, other active → still pass
+mem_active_target_dep = False
+expected_after = False
+ok_dep = mem_active_target_dep == expected_after
+print("deprov_ok" if ok_dep else "deprov_fail")
+`
+  const r = spawnSync('python3', ['-c', py], { encoding: 'utf8' })
+  assert.equal(r.status, 0, r.stderr)
+  assert.match(r.stdout, /restore_fail/)
+  assert.match(r.stdout, /deprov_ok/)
+})
+
+test('R4: restore live effect id set must equal persisted exactly (no extra/missing/dup/non-reversed)', () => {
+  const body = eventResolvedBody(read(REMOTE_SH))
+  assert.match(body, /effect_extra_live/)
+  assert.match(body, /effect_missing_after_restore/)
+  assert.match(body, /effect_id_duplicate_live|expected_effect_id_duplicate/)
+  assert.match(body, /effect_not_reversed/)
+  assert.match(body, /len\(by_id\) != len\(expected_effects\)/)
+  assert.match(body, /live_id not in seen_exp/)
+})
+
+test('MUTATION: allowing extra live effects turns red', () => {
+  const body = eventResolvedBody(read(REMOTE_SH))
+  const mutated = body.replaceAll('effect_extra_live', 'extra_ignored')
+  let failed = false
+  try {
+    assert.match(mutated, /effect_extra_live/)
+  } catch {
+    failed = true
+  }
+  assert.equal(failed, true)
+})
+
+test('R4: restoredEffectCount must equal persisted effect_count exactly', () => {
+  const body = rehireRestoreBody(read(REMOTE_SH))
+  assert.match(body, /restore_effect_count_mismatch/)
+  assert.match(body, /count != expected/)
+  assert.match(body, /restoredEffectCount/)
+  assert.doesNotMatch(body, /count < 1:\s*\n\s*emit\("false", "restore_effect_count_invalid"\)\s*\nemit\("true"/)
+})
+
+test('MUTATION: restoredEffectCount only >0 turns red', () => {
+  const body = rehireRestoreBody(read(REMOTE_SH))
+  const mutated = body
+    .replaceAll('if count != expected:', 'if count < 1:')
+    .replaceAll('restore_effect_count_mismatch', 'restore_effect_count_invalid')
+  let failed = false
+  try {
+    assert.match(mutated, /restore_effect_count_mismatch/)
+    assert.match(mutated, /count != expected/)
+  } catch {
+    failed = true
+  }
+  assert.equal(failed, true)
+})
+
+test('R4: post-sync requires deprovisionUsersDeactivatedCount exact 1', () => {
+  const source = read(REMOTE_SH)
+  assert.match(source, /sync_users_deactivated_not_one/)
+  assert.match(source, /deprovisionUsersDeactivatedCount/)
+  const apply = actionDeprovisionApplyBody(source)
+  assert.match(apply, /\$\{SYNC_USERS_DEACTIVATED\}" == "1"/)
+  assert.match(apply, /sync_users_deactivated_not_one/)
+})
+
+test('MUTATION: dropping usersDeactivated==1 assertion turns red', () => {
+  const apply = actionDeprovisionApplyBody(read(REMOTE_SH))
+  const mutated = apply.replaceAll('sync_users_deactivated_not_one', 'users_ignored')
+  let failed = false
+  try {
+    assert.match(mutated, /sync_users_deactivated_not_one/)
+  } catch {
+    failed = true
+  }
+  assert.equal(failed, true)
+})
+
+test('R4: apply state binds local_user_id+integration_id+directory_account_id+subject_key+run/event/effects', () => {
+  const source = read(REMOTE_SH)
+  const region = journalStateMachineRegion(source)
+  assert.match(region, /local_user_id/)
+  assert.match(region, /integration_id/)
+  assert.match(region, /directory_account_id/)
+  assert.match(region, /subject_key/)
+  assert.match(region, /sync_run_id/)
+  assert.match(region, /event_id/)
+  assert.match(region, /effect_count/)
+  assert.match(region, /lifecycle-canary-deprovision-apply-state-v4/)
+  assert.match(region, /refuse overwrite|unrecovered recovery journal/)
+  const load = loadDeprovisionApplyStateBody(source)
+  assert.match(load, /live_user != local_user_id|SystemExit\(10\)/)
+  assert.match(load, /live_integ != integration_id|SystemExit\(11\)/)
+  assert.match(load, /live_acct != directory_account_id|SystemExit\(12\)/)
+  assert.match(load, /lifecycle-canary-deprovision-apply-state-v4/)
+  assert.match(load, /ledger_bound/)
+  const apply = actionDeprovisionApplyBody(source)
+  assert.match(apply, /refuse_existing_deprovision_apply_state/)
+  assert.match(apply, /journal_init_prepared/)
+  // refuse + prepared must run before env write
+  const refuseIdx = apply.indexOf('refuse_existing_deprovision_apply_state')
+  const preparedIdx = apply.indexOf('journal_init_prepared')
+  const writeIdx = apply.indexOf('write_lifecycle_override')
+  assert.ok(refuseIdx > 0 && preparedIdx > refuseIdx && writeIdx > preparedIdx, 'refuse+prepared before env write')
+  const restore = actionDeprovisionRestoreBody(source)
+  assert.match(restore, /clear_deprovision_apply_state/)
+  // clear only after successful path markers
+  const clearIdx = restore.indexOf('clear_deprovision_apply_state')
+  const graphIdx = restore.indexOf('prove_access_graph_state "restored"')
+  assert.ok(clearIdx > graphIdx, 'clear state only after successful restore proofs')
+})
+
+test('MUTATION: state bound only by username (no id rebind) turns red', () => {
+  const load = loadDeprovisionApplyStateBody(read(REMOTE_SH))
+  const mutated = load
+    .replaceAll('local_user_id', 'subject_only')
+    .replaceAll('integration_id', 'subject_only')
+    .replaceAll('directory_account_id', 'subject_only')
+  let failed = false
+  try {
+    assert.match(mutated, /local_user_id/)
+    assert.match(mutated, /integration_id/)
+    assert.match(mutated, /directory_account_id/)
+  } catch {
+    failed = true
+  }
+  assert.equal(failed, true)
+})
+
+test('MUTATION: apply overwriting existing unrecovered state turns red', () => {
+  const apply = actionDeprovisionApplyBody(read(REMOTE_SH))
+  const mutated = apply.replaceAll('refuse_existing_deprovision_apply_state', 'skip_state_refuse')
+  let failed = false
+  try {
+    assert.match(mutated, /refuse_existing_deprovision_apply_state/)
+  } catch {
+    failed = true
+  }
+  assert.equal(failed, true)
+})
+
+test('R4: graph DB failure/unknown fail closed; never log ids/PII', () => {
+  const source = read(REMOTE_SH)
+  const body = proveAccessGraphBody(source)
+  assert.match(body, /db_query_failed/)
+  assert.match(body, /database_url_missing/)
+  assert.match(body, /docker_exec_failed/)
+  // Values-free notes only — no echo of user/integration ids in log lines.
+  assert.doesNotMatch(body, /log ".*\$\{?userId/)
+  assert.doesNotMatch(body, /log ".*\$\{?integrationId/)
+  assert.doesNotMatch(body, /console\.log\(userId|console\.log\(integrationId/)
+  // Doc comment sits immediately above the function (outside body slice).
+  const header = source.slice(
+    source.lastIndexOf('# Authoritative access-graph', source.indexOf('prove_access_graph_state()')),
+    source.indexOf('prove_access_graph_state()'),
+  )
+  assert.match(header, /Never prints user\/ids\/PII|never prints/i)
+})
+test('FUNCTIONAL: effect metadata capture requires closed types and strict booleans', () => {
+  const py = `
+CLOSED = frozenset({"membership_changed", "grant_changed", "user_changed"})
+def check(fx):
+    if fx.get("type") not in CLOSED: return "type"
+    if type(fx.get("before_active")) is not bool: return "ba"
+    if type(fx.get("after_active")) is not bool: return "aa"
+    if type(fx.get("grant_row_created")) is not bool: return "grc"
+    return "ok"
+cases = [
+  {"type":"user_changed","before_active":True,"after_active":False,"grant_row_created":False},
+  {"type":"weird","before_active":True,"after_active":False,"grant_row_created":False},
+  {"type":"grant_changed","before_active":"x","after_active":False,"grant_row_created":False},
+]
+for c in cases:
+    print(check(c))
+`
+  const r = spawnSync('python3', ['-c', py], { encoding: 'utf8' })
+  assert.equal(r.status, 0, r.stderr)
+  const lines = r.stdout.trim().split('\n')
+  assert.deepEqual(lines, ['ok', 'type', 'ba'])
+})
+
+// --- Round 5: recovery journal, run-id-before-counts, precondition, keep-journal ---
+
+test('R5: prepared journal reserves run id before HTTP and radius judgments', () => {
+  const source = read(REMOTE_SH)
+  const journal = journalStateMachineRegion(source)
+  const start = source.indexOf('run_directory_sync_for_subject()')
+  const end = source.indexOf('\nverify_deprovision_ledger_for_subject()', start)
+  const body = source.slice(start, end)
+  const reserveIdx = journal.indexOf('uuid.uuid4()')
+  const journalWriteIdx = journal.indexOf('tmp.replace(pathlib.Path(out_path))')
+  const requestIdx = body.indexOf('urllib.request.Request')
+  const radiusIdx = body.indexOf('sync_candidate_radius_not_one')
+  assert.ok(reserveIdx > 0 && journalWriteIdx > reserveIdx, 'prepared journal must reserve and persist run id')
+  assert.ok(requestIdx > 0 && radiusIdx > requestIdx, 'reserved-id request must precede radius emit')
+  // Radius failures must still emit run_present=true.
+  assert.match(body, /sync_candidate_radius_not_one[\s\S]*"true"\)/)
+  assert.match(body, /SYNC_RUN_ID_PRESENT" == "true"/)
+  assert.match(body, /reserved_run_id/)
+  assert.match(body, /"runId": reserved_run_id/)
+})
+
+test('MUTATION: radius fail without run_present=true turns red', () => {
+  const source = read(REMOTE_SH)
+  const start = source.indexOf('run_directory_sync_for_subject()')
+  const end = source.indexOf('\nverify_deprovision_ledger_for_subject()', start)
+  const body = source.slice(start, end)
+  // Corrupt the radius emit to drop run_present true.
+  const mutated = body.replaceAll(
+    'emit("false", "sync_candidate_radius_not_one", applied_s, nonneg(users), nonneg(accounts), nonneg(candidates), "true")',
+    'emit("false", "sync_candidate_radius_not_one", applied_s, nonneg(users), nonneg(accounts), nonneg(candidates))',
+  )
+  let failed = false
+  try {
+    assert.match(
+      mutated,
+      /emit\("false", "sync_candidate_radius_not_one", applied_s, nonneg\(users\), nonneg\(accounts\), nonneg\(candidates\), "true"\)/,
+    )
+  } catch {
+    failed = true
+  }
+  assert.equal(failed, true)
+})
+
+test('R5: journal state machine prepared→run_bound→ledger_bound unidirectional', () => {
+  const region = journalStateMachineRegion(read(REMOTE_SH))
+  assert.match(region, /phase": "prepared"|phase.: .prepared/)
+  assert.match(region, /"phase": "run_bound"|phase = "run_bound"|state\["phase"\] = "run_bound"/)
+  assert.match(region, /"phase": "ledger_bound"|state\["phase"\] = "ledger_bound"/)
+  assert.match(region, /phase"\) not in \{"prepared", "run_bound"\}/)
+  assert.match(region, /phase"\) not in \{"prepared", "run_bound"\}/)
+  assert.match(region, /lifecycle-canary-deprovision-apply-state-v4/)
+  assert.match(region, /journal_init_prepared/)
+  assert.match(region, /journal_upgrade_run_bound/)
+  assert.match(region, /journal_upgrade_ledger_bound/)
+  assert.match(region, /reconcile_run_journal_to_ledger_bound/)
+  // Restore load only accepts ledger_bound after exact reserved-run reconcile.
+  const load = loadDeprovisionApplyStateBody(read(REMOTE_SH))
+  assert.match(load, /reconcile to ledger_bound|phase"\) != "ledger_bound"/)
+  assert.match(load, /reconcile_run_journal_to_ledger_bound|prepared.*run_bound/)
+  // Comments may mention "sole event" only as FORBIDDEN; must not implement discovery.
+  assert.doesNotMatch(load, /discover_applied|items\[0\]|matched\[0\].*without run/)
+  assert.match(load, /no sole-event guess|never "sole event"|no event auto-discovery/i)
+})
+
+test('R5: apply orders precondition→prepared→sync→run_bound→ledger→radius/graph', () => {
+  const apply = actionDeprovisionApplyBody(read(REMOTE_SH))
+  const pre = apply.indexOf('prove_dedicated_subject_deprovision_precondition')
+  const prepared = apply.indexOf('journal_init_prepared')
+  const write = apply.indexOf('write_lifecycle_override')
+  const sync = apply.indexOf('run_directory_sync_for_subject "deprovision_apply"')
+  const runBound = apply.indexOf('journal_upgrade_run_bound')
+  const ledger = apply.indexOf('verify_deprovision_ledger_for_subject')
+  const bound = apply.indexOf('persist_deprovision_apply_state')
+  const radius = apply.indexOf('sync_candidate_radius_not_one')
+  const graph = apply.indexOf('prove_access_graph_state "deprovisioned"')
+  assert.ok(pre > 0 && prepared > pre && write > prepared, 'precond+prepared before env write')
+  assert.ok(sync > write && runBound > sync && ledger > runBound && bound > ledger, 'run_bound then ledger then bound')
+  assert.ok(radius > bound && graph > radius, 'radius/graph only after ledger_bound')
+  assert.match(apply, /fail_deprovision_apply_keep_journal/)
+  assert.match(apply, /journal_clear_if_phase_prepared/)
+})
+
+test('R6: destructive apply sends its pre-reserved exact run before polling', () => {
+  const body = runDirectorySyncForSubjectBody(read(REMOTE_SH))
+  const reserveRead = body.indexOf('reserved_run_id = str(state.get("sync_run_id")')
+  const asyncRequest = body.indexOf('{"async": True, "runId": reserved_run_id}')
+  const bind = body.indexOf('state["phase"] = "run_bound"')
+  const poll = body.indexOf('while time.monotonic() < deadline')
+  assert.ok(reserveRead > 0 && asyncRequest > reserveRead, 'deprovision apply must send pre-reserved run id')
+  assert.ok(bind > asyncRequest && poll > bind, 'run existence must be journaled before polling')
+  assert.match(body, /status in \{"completed", "failed"\}/)
+  assert.match(body, /run_url = integration_base \+ "\/runs\/" \+ urllib\.parse\.quote\(run_id, safe=""\)/)
+  assert.match(body, /exact_run = poll_data\.get\("run"\)/)
+  assert.match(body, /str\(exact_run\.get\("id"\) or ""\)\.strip\(\) != run_id/)
+  assert.doesNotMatch(body, /pageSize|poll_data\.get\("items"\)/)
+})
+
+test('MUTATION: reverting destructive apply to synchronous start turns recovery contract red', () => {
+  const body = runDirectorySyncForSubjectBody(read(REMOTE_SH))
+  const mutated = body.replace('{"async": True, "runId": reserved_run_id}', '{"async": True}')
+  assert.throws(() => assert.match(mutated, /\{"async": True, "runId": reserved_run_id\}/))
+})
+
+test('R6: restore is resumable after the exact event already committed fully_resolved', () => {
+  const helper = runOrResumeRestoreBody(read(REMOTE_SH))
+  const verify = helper.indexOf('verify_deprovision_event_resolved')
+  const post = helper.indexOf('run_deprovision_rehire_restore')
+  assert.ok(verify > 0 && post > verify, 'exact-event resolved probe must precede restore POST')
+  assert.match(helper, /RESTORE_RESUMED_FULLY_RESOLVED="true"/)
+  assert.match(helper, /skipping duplicate POST/)
+  assert.match(helper, /event_not_fully_resolved/)
+})
+
+test('R6: restore status probes the exact event tuple, never a paginated recent list', () => {
+  const source = read(REMOTE_SH)
+  const start = source.indexOf('read_exact_deprovision_event_status()')
+  const end = source.indexOf('\n# After restore:', start)
+  const body = source.slice(start, end)
+  assert.match(body, /FROM directory_deprovision_events/)
+  assert.match(body, /WHERE id = \$1::uuid/)
+  assert.match(body, /local_user_id = \$2/)
+  assert.match(body, /integration_id = \$3/)
+  assert.doesNotMatch(body, /limit["']?:\s*["']?100/i)
+})
+
+test('MUTATION: removing exact event-id scope from restore status probe turns red', () => {
+  const source = read(REMOTE_SH)
+  const start = source.indexOf('read_exact_deprovision_event_status()')
+  const end = source.indexOf('\n# After restore:', start)
+  const body = source.slice(start, end)
+  const mutated = body.replace('WHERE id = $1::uuid', 'WHERE TRUE')
+  assert.throws(() => assert.match(mutated, /WHERE id = \$1::uuid/))
+})
+
+test('FUNCTIONAL: fully_resolved resume skips a duplicate non-idempotent restore POST', () => {
+  const home = mkdtempSync(join(tmpdir(), 'lifecycle-canary-restore-resume-'))
+  const calls = join(home, 'restore.calls')
+  const script = `
+set -euo pipefail
+source "$1"
+verify_deprovision_event_resolved() { RESOLVED_NOTE=fully_resolved_all_reversed; return 0; }
+run_deprovision_rehire_restore() { echo called >> "$2"; return 0; }
+LEDGER_EFFECT_COUNT=3
+run_or_resume_deprovision_rehire_restore
+printf '%s|%s|%s\n' "$RESTORE_RESUMED_FULLY_RESOLVED" "$RESTORE_OK" "$RESTORE_EFFECT_COUNT"
+test ! -e "$2"
+`
+  const r = spawnSync('bash', ['-o', 'pipefail', '-c', script, 'bash', REMOTE_SH, calls], {
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      ACTION: 'deprovision',
+      OUTPUT_DIR: home,
+      RUN_STAMP: 'contract-r6-restore-resume',
+      LIFECYCLE_CANARY_SOURCE_ONLY: 'true',
+    },
+  })
+  assert.equal(r.status, 0, r.stderr + r.stdout)
+  assert.match(r.stdout, /true\|true\|3/)
+  assert.equal(existsSync(calls), false)
+  rmSync(home, { recursive: true, force: true })
+})
+
+test('FUNCTIONAL: async destructive sync binds run before polling terminal stats', async () => {
+  const home = mkdtempSync(join(tmpdir(), 'lifecycle-canary-async-sync-'))
+  const sec = join(home, 'secrets')
+  const stateDir = join(home, 'state')
+  const { mkdirSync, chmodSync } = awaitImportFs()
+  mkdirSync(sec, { recursive: true })
+  mkdirSync(stateDir, { recursive: true })
+  const jwt = join(sec, 'admin.jwt')
+  const integ = join(sec, 'subject.integration-id')
+  const stateFile = join(stateDir, 'subject.apply-state.json')
+  const integrationId = '11111111-2222-3333-4444-555555555555'
+  const runId = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'
+  writeFileSync(jwt, 'test-token')
+  writeFileSync(integ, integrationId)
+  writeFileSync(stateFile, JSON.stringify({
+    schema: 'lifecycle-canary-deprovision-apply-state-v4',
+    phase: 'prepared',
+    subject_key: 'lifecycle-canary-employee',
+    local_user_id: '99999999-8888-7777-6666-555555555555',
+    integration_id: integrationId,
+    directory_account_id: '12121212-3434-5656-7878-909090909090',
+    sync_run_id: runId,
+    sync_users_deactivated: null,
+    sync_accounts_deactivated: null,
+    sync_deprovision_candidates: null,
+    deprovision_applied: null,
+    event_id: null,
+    effect_count: null,
+    effects: null,
+  }))
+  chmodSync(jwt, 0o600)
+  chmodSync(integ, 0o600)
+  chmodSync(stateFile, 0o600)
+
+  const serverSource = `
+import json
+from http.server import BaseHTTPRequestHandler, HTTPServer
+RUN = "${runId}"
+STATE = ${JSON.stringify(stateFile)}
+polls = 0
+class H(BaseHTTPRequestHandler):
+    def log_message(self, *_): pass
+    def send_json(self, code, payload):
+        body = json.dumps(payload, separators=(",", ":")).encode()
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+    def do_POST(self):
+        n = int(self.headers.get("Content-Length", "0"))
+        body = json.loads(self.rfile.read(n) or b"{}")
+        if body != {"async": True, "runId": RUN}:
+            self.send_json(400, {"ok": False})
+            return
+        self.send_json(202, {"ok": True, "data": {"accepted": True, "runId": RUN}})
+    def do_GET(self):
+        global polls
+        state = json.load(open(STATE))
+        if state.get("phase") != "run_bound" or state.get("sync_run_id") != RUN:
+            self.send_json(409, {"ok": False})
+            return
+        polls += 1
+        status = "running" if polls == 1 else "completed"
+        stats = {} if status == "running" else {
+            "deprovisionApplied": True,
+            "deprovisionUsersDeactivatedCount": 1,
+            "accountsDeactivatedCount": 1,
+            "deprovisionCandidateCount": 1,
+        }
+        self.send_json(200, {"ok": True, "data": {"run": {"id": RUN, "status": status, "stats": stats}}})
+s = HTTPServer(("127.0.0.1", 0), H)
+print(s.server_port, flush=True)
+s.serve_forever()
+`
+  const server = spawn('python3', ['-u', '-c', serverSource], {
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+  const port = await new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error('mock sync server did not start')), 5000)
+    server.once('exit', (code) => {
+      clearTimeout(timer)
+      reject(new Error(`mock sync server exited ${code}`))
+    })
+    server.stdout.once('data', (chunk) => {
+      clearTimeout(timer)
+      resolve(String(chunk).trim())
+    })
+  })
+  try {
+    const script = `
+set -euo pipefail
+source "$1"
+STAGING_API_BASE_URL="http://127.0.0.1:$2"
+CANARY_ADMIN_JWT_FILE="$3"
+CANARY_SUBJECT_INTEGRATION_ID_FILE="$4"
+CANARY_DIRECTORY_ACCOUNT_ID_FILE="$5/directory-account.id"
+CANARY_APPLY_STATE_FILE="$6"
+SUBJECT_OWNER_USERNAME=lifecycle-canary-employee
+printf '%s' 12121212-3434-5656-7878-909090909090 > "$CANARY_DIRECTORY_ACCOUNT_ID_FILE"
+run_directory_sync_for_subject deprovision_apply true
+journal_upgrade_run_bound
+python3 - "$6" <<'PY'
+import json,sys
+s=json.load(open(sys.argv[1]))
+print("|".join([s["phase"], s["sync_run_id"], str(s["sync_users_deactivated"]), str(s["deprovision_applied"]).lower()]))
+PY
+`
+    const r = spawnSync(
+      'bash',
+      ['-o', 'pipefail', '-c', script, 'bash', REMOTE_SH, port, jwt, integ, sec, stateFile],
+      {
+        encoding: 'utf8',
+        timeout: 15000,
+        env: {
+          ...process.env,
+          ACTION: 'deprovision',
+          OUTPUT_DIR: home,
+          RUN_STAMP: 'contract-r6-async-sync',
+          LIFECYCLE_CANARY_SOURCE_ONLY: 'true',
+        },
+      },
+    )
+    assert.equal(r.status, 0, r.stderr + r.stdout)
+    assert.match(r.stdout, new RegExp(`run_bound\\|${runId}\\|1\\|true`))
+    const state = JSON.parse(readFileSync(stateFile, 'utf8'))
+    assert.equal(state.phase, 'run_bound')
+    assert.equal(state.sync_run_id, runId)
+    assert.equal(state.sync_accounts_deactivated, 1)
+    assert.equal(state.sync_deprovision_candidates, 1)
+  } finally {
+    server.kill('SIGTERM')
+    rmSync(home, { recursive: true, force: true })
+  }
+})
+
+test('FUNCTIONAL: lost 202 keeps the pre-request reserved run journal recoverable', async () => {
+  const home = mkdtempSync(join(tmpdir(), 'lifecycle-canary-lost-202-'))
+  const sec = join(home, 'secrets')
+  const stateFile = join(home, 'subject.apply-state.json')
+  const record = join(home, 'request.json')
+  const { mkdirSync, chmodSync } = awaitImportFs()
+  mkdirSync(sec, { recursive: true })
+  const jwt = join(sec, 'admin.jwt')
+  const integ = join(sec, 'subject.integration-id')
+  const acct = join(sec, 'directory-account.id')
+  const runId = 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee'
+  const integrationId = '11111111-2222-4333-8444-555555555555'
+  writeFileSync(jwt, 'test-token')
+  writeFileSync(integ, integrationId)
+  writeFileSync(acct, '12121212-3434-4656-8878-909090909090')
+  writeFileSync(stateFile, JSON.stringify({
+    schema: 'lifecycle-canary-deprovision-apply-state-v4',
+    phase: 'prepared',
+    subject_key: 'lifecycle-canary-employee',
+    local_user_id: '99999999-8888-4777-8666-555555555555',
+    integration_id: integrationId,
+    directory_account_id: '12121212-3434-4656-8878-909090909090',
+    sync_run_id: runId,
+    sync_users_deactivated: null,
+    sync_accounts_deactivated: null,
+    sync_deprovision_candidates: null,
+    deprovision_applied: null,
+    event_id: null,
+    effect_count: null,
+    effects: null,
+  }))
+  chmodSync(jwt, 0o600)
+  chmodSync(integ, 0o600)
+  chmodSync(acct, 0o600)
+  chmodSync(stateFile, 0o600)
+
+  const serverSource = `
+import json, socket
+from http.server import BaseHTTPRequestHandler, HTTPServer
+RECORD = ${JSON.stringify(record)}
+class H(BaseHTTPRequestHandler):
+    def log_message(self, *_): pass
+    def do_POST(self):
+        n = int(self.headers.get("Content-Length", "0"))
+        body = json.loads(self.rfile.read(n) or b"{}")
+        open(RECORD, "w").write(json.dumps(body, separators=(",", ":")))
+        self.connection.shutdown(socket.SHUT_RDWR)
+        self.connection.close()
+s = HTTPServer(("127.0.0.1", 0), H)
+print(s.server_port, flush=True)
+s.serve_forever()
+`
+  const server = spawn('python3', ['-u', '-c', serverSource], { stdio: ['ignore', 'pipe', 'pipe'] })
+  const port = await new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error('lost-202 server did not start')), 5000)
+    server.once('exit', (code) => {
+      clearTimeout(timer)
+      reject(new Error(`lost-202 server exited ${code}`))
+    })
+    server.stdout.once('data', (chunk) => {
+      clearTimeout(timer)
+      resolve(String(chunk).trim())
+    })
+  })
+  try {
+    const script = `
+set -euo pipefail
+source "$1"
+STAGING_API_BASE_URL="http://127.0.0.1:$2"
+CANARY_ADMIN_JWT_FILE="$3"
+CANARY_SUBJECT_INTEGRATION_ID_FILE="$4"
+CANARY_DIRECTORY_ACCOUNT_ID_FILE="$5"
+CANARY_APPLY_STATE_FILE="$6"
+SUBJECT_OWNER_USERNAME=lifecycle-canary-employee
+set +e
+run_directory_sync_for_subject deprovision_apply true
+rc=$?
+set -e
+python3 - "$6" "$rc" <<'PY'
+import json,sys
+s=json.load(open(sys.argv[1]))
+print("|".join([str(sys.argv[2]), s["phase"], s["sync_run_id"]]))
+PY
+`
+    const r = spawnSync(
+      'bash',
+      ['-o', 'pipefail', '-c', script, 'bash', REMOTE_SH, port, jwt, integ, acct, stateFile],
+      {
+        encoding: 'utf8',
+        timeout: 10000,
+        env: {
+          ...process.env,
+          ACTION: 'deprovision',
+          OUTPUT_DIR: home,
+          RUN_STAMP: 'contract-r6-lost-202',
+          LIFECYCLE_CANARY_SOURCE_ONLY: 'true',
+        },
+      },
+    )
+    assert.equal(r.status, 0, r.stderr + r.stdout)
+    assert.match(r.stdout, new RegExp(`1\\|prepared\\|${runId}`))
+    assert.deepEqual(JSON.parse(readFileSync(record, 'utf8')), { async: true, runId })
+    const state = JSON.parse(readFileSync(stateFile, 'utf8'))
+    assert.equal(state.phase, 'prepared')
+    assert.equal(state.sync_run_id, runId)
+  } finally {
+    server.kill('SIGTERM')
+    rmSync(home, { recursive: true, force: true })
+  }
+})
+
+test('MUTATION: clearing prepared journal after a lost 202 turns red', () => {
+  const apply = actionDeprovisionApplyBody(read(REMOTE_SH))
+  const start = apply.indexOf('run_directory_sync_for_subject "deprovision_apply"')
+  const end = apply.indexOf('journal_upgrade_run_bound', start)
+  const responseLossWindow = apply.slice(start, end)
+  assert.match(responseLossWindow, /fail_deprovision_apply_keep_journal/)
+  assert.doesNotMatch(responseLossWindow, /journal_clear_if_phase_prepared/)
+  const mutated = responseLossWindow.replace(
+    'fail_deprovision_apply_keep_journal',
+    'journal_clear_if_phase_prepared',
+  )
+  assert.throws(() => assert.doesNotMatch(mutated, /journal_clear_if_phase_prepared/))
+})
+
+test('MUTATION: deleting the pre-POST resolved probe makes the resume golden red', () => {
+  const helper = runOrResumeRestoreBody(read(REMOTE_SH))
+  const mutated = helper.replace('if verify_deprovision_event_resolved; then', 'if false; then')
+  assert.throws(() => {
+    const verify = mutated.indexOf('if verify_deprovision_event_resolved; then')
+    const post = mutated.indexOf('run_deprovision_rehire_restore')
+    assert.ok(verify > 0 && post > verify)
+  })
+})
+
+test('R5: dedicated subject precondition requires one-account manual integration and exact effects', () => {
+  const source = read(REMOTE_SH)
+  assert.match(source, /prove_dedicated_subject_deprovision_precondition/)
+  const start = source.indexOf('prove_dedicated_subject_deprovision_precondition()')
+  const end = source.indexOf('\nvalidate_mode_name()', start)
+  const body = source.slice(start, end)
+  assert.match(body, /mark_inactive/)
+  assert.match(body, /policy_not_mark_inactive/)
+  assert.match(body, /integration_not_manual_only/)
+  assert.match(body, /integration_automation_not_disabled/)
+  assert.match(body, /integration_not_single_account/)
+  assert.match(body, /count\(\*\)::int AS n/)
+  assert.match(body, /count\(\*\) FILTER \(WHERE id = \$2\)::int AS target_n/)
+  assert.match(body, /WHERE integration_id = \$1/)
+  assert.match(body, /not_globally_clear/)
+  assert.match(body, /dingtalk_grant_not_enabled/)
+  assert.match(body, /target_org_membership_not_active/)
+  assert.match(body, /user_not_active/)
+  assert.match(body, /ok_expected_effects_membership_grant_user/)
+  // other-org membership must not be used as global membership scan without org scope
+  assert.match(body, /user_id = \$1 AND org_id = \$2/)
+})
+
+test('MUTATION: dropping the one-account integration radius guard turns red', () => {
+  const source = read(REMOTE_SH)
+  const start = source.indexOf('prove_dedicated_subject_deprovision_precondition()')
+  const end = source.indexOf('\nvalidate_mode_name()', start)
+  const body = source.slice(start, end)
+  const mutated = body.replace('Number(radius.rows[0]?.n) !== 1', 'false')
+  assert.throws(() => assert.match(mutated, /Number\(radius\.rows\[0\]\?\.n\) !== 1/))
+})
+
+test('MUTATION: dropping dedicated precondition before env write turns red', () => {
+  const apply = actionDeprovisionApplyBody(read(REMOTE_SH))
+  const mutated = apply.replaceAll('prove_dedicated_subject_deprovision_precondition', 'skip_precond')
+  let failed = false
+  try {
+    assert.match(mutated, /prove_dedicated_subject_deprovision_precondition/)
+  } catch {
+    failed = true
+  }
+  assert.equal(failed, true)
+})
+
+test('R5: radius/graph failure keeps journal and sets recovery_required', () => {
+  const source = read(REMOTE_SH)
+  assert.match(source, /fail_deprovision_apply_keep_journal/)
+  const start = source.indexOf('fail_deprovision_apply_keep_journal()')
+  const end = source.indexOf('\n# --- actions', start)
+  const body = source.slice(start, end > 0 ? end : start + 2500)
+  assert.match(body, /recovery_required=true/)
+  assert.match(body, /exact_run_persisted=/)
+  assert.match(body, /journal_retained=true/)
+  assert.match(body, /journal_phase=/)
+  assert.doesNotMatch(body, /rm -f "\$CANARY_APPLY_STATE_FILE"/)
+  assert.match(body, /restore_lifecycle_override/)
+  const apply = actionDeprovisionApplyBody(source)
+  assert.match(apply, /fail_deprovision_apply_keep_journal "sync_candidate_radius_not_one"/)
+  assert.match(apply, /fail_deprovision_apply_keep_journal "sync_users_deactivated_not_one"/)
+  assert.match(apply, /fail_deprovision_apply_keep_journal "access_graph_not_deprovisioned/)
+})
+
+test('MUTATION: radius failure clearing journal turns red', () => {
+  const source = read(REMOTE_SH)
+  const start = source.indexOf('fail_deprovision_apply_keep_journal()')
+  const end = source.indexOf('\naction_status()', start)
+  const body = source.slice(start, end > 0 ? end : start + 3000)
+  const mutated = body + '\nrm -f "$CANARY_APPLY_STATE_FILE"\n'
+  // Production body must not clear journal; inject proves the mutation detector.
+  assert.doesNotMatch(body, /rm -f "\$CANARY_APPLY_STATE_FILE"/)
+  assert.match(mutated, /rm -f "\$CANARY_APPLY_STATE_FILE"/)
+})
+
+test('R6: deprovision failure disarms rollback guard only after runtime OFF is proven', () => {
+  const source = read(REMOTE_SH)
+  const start = source.indexOf('fail_deprovision_apply_keep_journal()')
+  const end = source.indexOf('\n# --- actions', start)
+  const body = source.slice(start, end > 0 ? end : start + 3500)
+  const proof = body.indexOf('if assert_exact_mode_off')
+  const disarm = body.indexOf('disarm_alias_exit_rollback_guard')
+  const cleanup = body.indexOf('cleanup_prev_backup')
+  assert.ok(proof > 0 && disarm > proof && cleanup > disarm)
+  assert.match(body, /EXIT rollback guard remains armed for a final retry/)
+})
+
+test('FUNCTIONAL: an unproven first OFF restore gets one EXIT-guard retry before exit', () => {
+  const home = mkdtempSync(join(tmpdir(), 'lifecycle-canary-off-retry-'))
+  const outDir = mkdtempSync(join(tmpdir(), 'lifecycle-canary-off-retry-out-'))
+  const stateFile = join(home, 'subject.apply-state.json')
+  const attempts = join(home, 'attempts.log')
+  writeFileSync(stateFile, JSON.stringify({
+    schema: 'lifecycle-canary-deprovision-apply-state-v4',
+    phase: 'prepared',
+    subject_key: 'lifecycle-canary-employee',
+    sync_run_id: 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee',
+  }))
+
+  const script = `
+set -euo pipefail
+source "$1"
+OUTPUT_DIR="$2"
+CANARY_APPLY_STATE_FILE="$3"
+ATTEMPTS_FILE="$4"
+ACTION=deprovision
+DEPLOY_SHA=1111111111111111111111111111111111111111
+SUBJECT_OWNER_USERNAME=lifecycle-canary-employee
+RECREATE_ATTEMPTS=0
+restore_lifecycle_override() { echo restore >> "$ATTEMPTS_FILE"; }
+recreate_backend_only() { RECREATE_ATTEMPTS=$((RECREATE_ATTEMPTS + 1)); echo recreate >> "$ATTEMPTS_FILE"; return 0; }
+assert_exact_mode_off() { [[ "$RECREATE_ATTEMPTS" -ge 2 ]]; }
+resolve_deployed_sha() { echo "$DEPLOY_SHA"; }
+fetch_backend_health_ok() { echo true; }
+capture_live_snapshot() { SNAP_MODE=unknown; SNAP_BUILD_SHA="$DEPLOY_SHA"; }
+cleanup_prev_backup() { echo cleanup >> "$ATTEMPTS_FILE"; }
+fail() { echo fail >> "$ATTEMPTS_FILE"; exit 2; }
+arm_alias_exit_rollback_guard
+fail_deprovision_apply_keep_journal first_off_unproven
+`
+  const r = spawnSync(
+    'bash',
+    ['-o', 'pipefail', '-c', script, 'bash', REMOTE_SH, outDir, stateFile, attempts],
+    {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        ACTION: 'deprovision',
+        OUTPUT_DIR: outDir,
+        RUN_STAMP: 'contract-r6-off-retry',
+        LIFECYCLE_CANARY_SOURCE_ONLY: 'true',
+      },
+    },
+  )
+  assert.notEqual(r.status, 0)
+  const calls = readFileSync(attempts, 'utf8').trim().split('\n')
+  assert.equal(calls.filter((line) => line === 'restore').length, 2)
+  assert.equal(calls.filter((line) => line === 'recreate').length, 2)
+  assert.equal(calls.filter((line) => line === 'cleanup').length, 1)
+  assert.match(readFileSync(join(outDir, 'alias-emergency-rollback.log'), 'utf8'), /proved runtime OFF/)
+  assert.equal(JSON.parse(readFileSync(stateFile, 'utf8')).phase, 'prepared')
+  rmSync(home, { recursive: true, force: true })
+  rmSync(outDir, { recursive: true, force: true })
+})
+
+test('R5: ledger requires exact effect type triple membership+grant+user', () => {
+  const ledger = verifyDeprovisionLedgerBody(read(REMOTE_SH))
+  assert.match(ledger, /effect_type_set_not_exact_triple/)
+  assert.match(ledger, /grant_row_created_unexpected_for_canary/)
+  assert.match(ledger, /effect_before_after_not_active_to_inactive/)
+  assert.match(ledger, /len\(applied_effects\) != 3/)
+})
+
+test('FUNCTIONAL: journal prepared→run_bound→ledger_bound upgrades and refuses overwrite', () => {
+  const home = mkdtempSync(join(tmpdir(), 'lifecycle-canary-journal-'))
+  const stateDir = join(home, '.metasheet2', 'lifecycle-canary', 'subject-state')
+  const { mkdirSync, chmodSync } = awaitImportFs()
+  mkdirSync(stateDir, { recursive: true })
+  const stateFile = join(stateDir, 'lifecycle-canary-employee.apply-state.json')
+  const sec = mkdtempSync(join(tmpdir(), 'lifecycle-canary-sec-'))
+  const u = '11111111-1111-1111-1111-111111111111'
+  const i = '22222222-2222-2222-2222-222222222222'
+  const a = '33333333-3333-3333-3333-333333333333'
+  const run = '44444444-4444-4444-4444-444444444444'
+  const ev = '55555555-5555-5555-5555-555555555555'
+  const e1 = '66666666-6666-6666-6666-666666666666'
+  const e2 = '77777777-7777-7777-7777-777777777777'
+  const e3 = '88888888-8888-8888-8888-888888888888'
+  writeFileSync(join(sec, 'subject.local-user-id'), u)
+  writeFileSync(join(sec, 'subject.integration-id'), i)
+  writeFileSync(join(sec, 'directory-account.id'), a)
+  writeFileSync(join(sec, 'subject.sync-run-id'), run)
+  writeFileSync(join(sec, 'subject.deprovision-event-id'), ev)
+  const effects = {
+    effects: [
+      { id: e1, type: 'membership_changed', before_active: true, after_active: false, grant_row_created: false },
+      { id: e2, type: 'grant_changed', before_active: true, after_active: false, grant_row_created: false },
+      { id: e3, type: 'user_changed', before_active: true, after_active: false, grant_row_created: false },
+    ],
+    effect_count: 3,
+  }
+  writeFileSync(join(sec, 'subject.deprovision-effects.json'), JSON.stringify(effects))
+
+  const script = `
+set -euo pipefail
+source "$1"
+export HOME="$2"
+CANARY_APPLY_STATE_DIR="$3"
+CANARY_APPLY_STATE_FILE="$4"
+CANARY_SUBJECT_LOCAL_USER_ID_FILE="$5/subject.local-user-id"
+CANARY_SUBJECT_INTEGRATION_ID_FILE="$5/subject.integration-id"
+CANARY_DIRECTORY_ACCOUNT_ID_FILE="$5/directory-account.id"
+CANARY_SUBJECT_SYNC_RUN_ID_FILE="$5/subject.sync-run-id"
+CANARY_SUBJECT_DEPROVISION_EVENT_ID_FILE="$5/subject.deprovision-event-id"
+CANARY_SUBJECT_EFFECTS_FILE="$5/subject.deprovision-effects.json"
+SUBJECT_OWNER_USERNAME="lifecycle-canary-employee"
+SYNC_USERS_DEACTIVATED=1
+SYNC_ACCOUNTS_DEACTIVATED=1
+SYNC_DEPROVISION_CANDIDATES=1
+SYNC_DEPROVISION_APPLIED=true
+fail() { echo "FAIL:$*"; exit 9; }
+journal_init_prepared
+python3 -c "import json;print(json.load(open('$4'))['phase'])"
+journal_upgrade_run_bound
+python3 -c "import json;print(json.load(open('$4'))['phase'])"
+journal_upgrade_ledger_bound
+python3 -c "import json;s=json.load(open('$4'));print(s['phase']);print(s['effect_count'])"
+`
+  const harnessEnv = {
+    ...process.env,
+    ACTION: 'deprovision',
+    OUTPUT_DIR: home,
+    RUN_STAMP: 'contract-r5-journal',
+    LIFECYCLE_CANARY_SOURCE_ONLY: 'true',
+  }
+  const r = spawnSync(
+    'bash',
+    ['-o', 'pipefail', '-c', script, 'bash', REMOTE_SH, home, stateDir, stateFile, sec],
+    { encoding: 'utf8', env: harnessEnv },
+  )
+  assert.equal(r.status, 0, r.stderr + r.stdout)
+  assert.match(r.stdout, /prepared/)
+  assert.match(r.stdout, /run_bound/)
+  assert.match(r.stdout, /ledger_bound/)
+  assert.match(r.stdout, /3/)
+  assert.ok(existsSync(stateFile), 'journal must remain on disk')
+  const final = JSON.parse(readFileSync(stateFile, 'utf8'))
+  assert.equal(final.phase, 'ledger_bound')
+  assert.equal(final.schema, 'lifecycle-canary-deprovision-apply-state-v4')
+  assert.equal(final.effect_count, 3)
+  // Second prepared must refuse (file exists).
+  const r2 = spawnSync(
+    'bash',
+    [
+      '-o',
+      'pipefail',
+      '-c',
+      `source "$1"
+       export HOME="$2"
+       CANARY_APPLY_STATE_DIR="$3"
+       CANARY_APPLY_STATE_FILE="$4"
+       CANARY_SUBJECT_LOCAL_USER_ID_FILE="$5/subject.local-user-id"
+       CANARY_SUBJECT_INTEGRATION_ID_FILE="$5/subject.integration-id"
+       CANARY_DIRECTORY_ACCOUNT_ID_FILE="$5/directory-account.id"
+       SUBJECT_OWNER_USERNAME=lifecycle-canary-employee
+       fail() { echo REFUSED; exit 3; }
+       journal_init_prepared
+       echo UNEXPECTED_OK`,
+      'bash',
+      REMOTE_SH,
+      home,
+      stateDir,
+      stateFile,
+      sec,
+    ],
+    { encoding: 'utf8', env: harnessEnv },
+  )
+  assert.notEqual(r2.status, 0)
+  assert.match(r2.stdout, /REFUSED/)
+  assert.equal(JSON.parse(readFileSync(stateFile, 'utf8')).phase, 'ledger_bound')
+  rmSync(home, { recursive: true, force: true })
+  rmSync(sec, { recursive: true, force: true })
+})
+
+test('FUNCTIONAL: radius anomaly failure path retains host journal and reports recovery markers', () => {
+  const home = mkdtempSync(join(tmpdir(), 'lifecycle-canary-radius-'))
+  const stateDir = join(home, '.metasheet2', 'lifecycle-canary', 'subject-state')
+  const { mkdirSync, chmodSync } = awaitImportFs()
+  mkdirSync(stateDir, { recursive: true })
+  const stateFile = join(stateDir, 'lifecycle-canary-employee.apply-state.json')
+  const outDir = mkdtempSync(join(tmpdir(), 'lifecycle-canary-out-'))
+  const run = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
+  const u = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'
+  const i = 'cccccccc-cccc-cccc-cccc-cccccccccccc'
+  const a = 'dddddddd-dddd-dddd-dddd-dddddddddddd'
+  writeFileSync(
+    stateFile,
+    JSON.stringify({
+      schema: 'lifecycle-canary-deprovision-apply-state-v4',
+      phase: 'run_bound',
+      subject_key: 'lifecycle-canary-employee',
+      local_user_id: u,
+      integration_id: i,
+      directory_account_id: a,
+      sync_run_id: run,
+      sync_users_deactivated: 2,
+      sync_accounts_deactivated: 1,
+      sync_deprovision_candidates: 2,
+      deprovision_applied: true,
+      event_id: null,
+      effect_count: null,
+      effects: null,
+    }),
+  )
+  chmodSync(stateFile, 0o600)
+  const script = `
+set -euo pipefail
+source "$1"
+export HOME="$2"
+CANARY_APPLY_STATE_DIR="$3"
+CANARY_APPLY_STATE_FILE="$4"
+OUTPUT_DIR="$5"
+ACTION=deprovision
+SUBJECT_OWNER_USERNAME=lifecycle-canary-employee
+restore_lifecycle_override() { :; }
+recreate_backend_only() { return 0; }
+disarm_alias_exit_rollback_guard() { :; }
+cleanup_prev_backup() { :; }
+assert_exact_mode_off() { return 0; }
+capture_live_snapshot() { SNAP_MODE=off; SNAP_BUILD_SHA=deadbeef; }
+fail() { echo "FAIL:$*"; exit 2; }
+fail_deprovision_apply_keep_journal "sync_candidate_radius_not_one"
+`
+  const r = spawnSync(
+    'bash',
+    ['-o', 'pipefail', '-c', script, 'bash', REMOTE_SH, home, stateDir, stateFile, outDir],
+    {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        ACTION: 'deprovision',
+        OUTPUT_DIR: outDir,
+        RUN_STAMP: 'contract-r5-radius',
+        LIFECYCLE_CANARY_SOURCE_ONLY: 'true',
+      },
+    },
+  )
+  assert.notEqual(r.status, 0, r.stderr + r.stdout)
+  assert.ok(existsSync(stateFile), 'host journal must survive radius failure path')
+  const st = JSON.parse(readFileSync(stateFile, 'utf8'))
+  assert.equal(st.phase, 'run_bound')
+  assert.equal(st.sync_run_id, run)
+  assert.ok(existsSync(join(outDir, 'summary.txt')), `summary missing: ${r.stdout}\n${r.stderr}`)
+  const summary = readFileSync(join(outDir, 'summary.txt'), 'utf8')
+  assert.match(summary, /recovery_required=true/)
+  assert.match(summary, /exact_run_persisted=true/)
+  assert.match(summary, /journal_retained=true/)
+  assert.match(summary, /journal_phase=run_bound/)
+  assert.match(summary, /rolled_back_flags_off=true/)
+  assert.doesNotMatch(summary, /aaaaaaaa-aaaa/)
+  rmSync(home, { recursive: true, force: true })
+  rmSync(outDir, { recursive: true, force: true })
+})
+
+function awaitImportFs() {
+  // mkdirSync/chmodSync not in top-level imports — pull via createRequire for harness only.
+  const require = createRequire(import.meta.url)
+  return require('node:fs')
+}
+
 // --- docs / staging blockers ----------------------------------------------------------
 
-test('docs mark pending/deprovision NOT EXECUTABLE; alias is executable transient canary; bootstrap documented', () => {
+test('docs mark pending/deprovision executable but NOT EXECUTED; alias transient canary and bootstrap documented', () => {
   const closeout = read(CLOSEOUT_DOC)
   const go = read(CANARY_GO_DOC)
-  // Closeout may still describe historical NOT EXECUTABLE for ON names; go-doc is authoritative.
-  assert.match(closeout, /NOT EXECUTABLE/)
-  assert.match(go, /NOT EXECUTABLE/)
+  assert.doesNotMatch(closeout, /pending[^\n]*NOT EXECUTABLE|deprovision[^\n]*NOT EXECUTABLE/i)
+  assert.doesNotMatch(go, /pending[^\n]*NOT EXECUTABLE|deprovision[^\n]*NOT EXECUTABLE/i)
   assert.match(go, /pending/)
   assert.match(go, /deprovision/)
-  assert.match(go, /EXECUTABLE/)
+  assert.match(go, /Executable only as a transient canary/)
+  assert.match(go, /Executable only as a two-phase transient canary/)
+  assert.match(go, /NOT EXECUTED/)
+  assert.match(go, /dedicated one-account integration|single selected directory account/i)
+  assert.match(go, /pre-reserves|before.*env.*HTTP|before env\/HTTP/i)
   assert.match(go, /alias/)
   assert.match(go, /bootstrap/)
   assert.match(go, /lifecycle-canary@staging\.invalid/)
@@ -2582,9 +4665,8 @@ test('docs mark pending/deprovision NOT EXECUTABLE; alias is executable transien
   assert.match(go, /collisions==0|collisions must be 0|collisions==0/i)
   assert.match(go, /ATTENDANCE_ADMIN_JWT/)
   assert.match(go, /never.*ATTENDANCE_ADMIN_JWT|not.*ATTENDANCE_ADMIN_JWT|mint.*password login/i)
-  // No invented successful canary execution evidence.
-  assert.doesNotMatch(go, /alias canary EXECUTED successfully|alias cutover canary PASSED on staging/i)
-  assert.match(go, /NOT EXECUTED/)
+  // No invented successful pending/deprovision execution evidence.
+  assert.doesNotMatch(go, /pending admission[^\n]*\*\*(PASS|COMPLETE)|deprovision[^\n]*\*\*(PASS|COMPLETE)/i)
 })
 
 test('docs distinguish emergency off env-gate from OR-column fallback reintroduction', () => {
@@ -2625,16 +4707,18 @@ test('workflow exports only safe remote env keys (no raw secret values)', () => 
   ]) {
     assert.match(yaml, new RegExp(`export ${key}=`))
   }
-  assert.doesNotMatch(yaml, /export CANARY_SUBJECT/)
+  assert.doesNotMatch(yaml, /export CANARY_SUBJECT_ID=/)
   assert.doesNotMatch(yaml, /export OWNER_CONFIRM=/)
   assert.doesNotMatch(yaml, /export ATTENDANCE_ADMIN_JWT=/)
   assert.doesNotMatch(yaml, /export LIFECYCLE_CANARY_LOGIN_PASSWORD=/)
   assert.doesNotMatch(yaml, /export STAGING_OWNER_ADMIN_PASSWORD=/)
+  assert.doesNotMatch(yaml, /export LIFECYCLE_CANARY_DIRECTORY_ACCOUNT_ID=/)
   assert.doesNotMatch(yaml, /export CANARY_ADMIN_JWT_FILE=/)
   // Path-only exports for secret files are allowed.
   assert.match(yaml, /export CANARY_LOGIN_IDENTIFIER_FILE=/)
   assert.match(yaml, /export CANARY_LOGIN_PASSWORD_FILE=/)
   assert.match(yaml, /export STAGING_OWNER_ADMIN_PASSWORD_FILE=/)
+  assert.match(yaml, /export CANARY_DIRECTORY_ACCOUNT_ID_FILE=/)
 })
 
 // --- human-bootstrap: fixed separate human platform admin -----------------------------

--- a/scripts/ops/dingtalk-lifecycle-staging-canary-remote.sh
+++ b/scripts/ops/dingtalk-lifecycle-staging-canary-remote.sh
@@ -47,21 +47,33 @@
 #                cutover-status ready → write alias ON → recreate backend only →
 #                post-ON login → restore OFF → recreate → post-rollback login.
 #                Backfill rows may persist.
-#
-# NOT EXECUTABLE (fail-closed preflight-only; transition_applied always false):
-#   pending / deprovision
-#     Env flips alone are NOT a canary. There is no secret-backed real verifier
-#     for admit→activate or sync→deprovision. Presence tokens must not pretend
-#     to drive those paths.
+#   pending    — TRANSIENT secret-backed pending-admit canary on an EXPLICIT
+#                owned directory account subject (file path only; never printed).
+#                Requires full deploy SHA, expected_current_mode=off, health true,
+#                migrations zero, canary login secrets, and
+#                CANARY_DIRECTORY_ACCOUNT_ID_FILE. Temporarily enables only
+#                DIRECTORY_PENDING_ACTIVATION_ENABLED, real admin admit, pending
+#                state assertions, optional activate path, then unconditional
+#                rollback/recreate/prove OFF (success/failure/interrupt).
+#                No auto-selection of directory accounts.
+#   deprovision — TRANSIENT secret-backed sync→deprovision canary on the SAME
+#                explicit owned subject. Never mutates a real/auto-selected
+#                account. Requires subject file + confirmation that the DingTalk
+#                source employee was disabled externally. Temporarily enables
+#                only DIRECTORY_DEPROVISION_ENABLED, runs real integration sync,
+#                verifies ledger/effects/generation/access denial, then
+#                restore/prove OFF. Full source rehire/reactivate restore is an
+#                EXTERNAL phase (fail-closed note; not claimed by this action).
 #
 # HARD SAFETY RAILS:
 #   * Staging compose + metasheet-staging-* containers only; no prod fallback.
 #   * migrations_pending_zero must be exactly "true" for preflight_ok and for
-#     action=off / action=alias / action=bootstrap / action=human-bootstrap
-#     (unknown is a fail, never treated as success).
-#   * action=off|alias: recreate backend only; prove postgres/redis IDs unchanged;
-#     require backend health true after restart; prove exact mode; restore
-#     previous override and re-recreate on any failure after the write.
+#     action=off / action=alias / action=bootstrap / action=human-bootstrap /
+#     action=pending / action=deprovision (unknown is a fail, never success).
+#   * action=off|alias|pending|deprovision: recreate backend only; prove
+#     postgres/redis IDs unchanged; require backend health true after restart;
+#     prove exact mode; restore previous/OFF override and re-recreate on any
+#     failure after the write. EXIT/signal guard armed in ON window.
 #   * action=bootstrap|human-bootstrap: no lifecycle env write; no backend recreate.
 #   * multi-on: status/preflight report and fail closed; action=off still clears
 #     the exact three flags (does not die in derive_mode before clear).
@@ -87,14 +99,17 @@ RUN_STAMP="${RUN_STAMP:?RUN_STAMP is required (workflow run id marker)}"
 
 # Secret-backed canary inputs: FILE PATHS only (values never exported).
 # Workflow materializes chmod-600 identifier/password into the per-run remote dir.
-# Alias mints CANARY_ADMIN_JWT_FILE after successful pre-login (never from
-# secrets.ATTENDANCE_ADMIN_JWT). Bootstrap does not consume a JWT file.
+# Alias/pending/deprovision mint CANARY_ADMIN_JWT_FILE after successful pre-login
+# (never from secrets.ATTENDANCE_ADMIN_JWT). Bootstrap does not consume a JWT file.
 # human-bootstrap mints JWT from canary login for admin API, and consumes a
 # separate STAGING_OWNER_ADMIN_PASSWORD_FILE for the human admin password only.
+# pending/deprovision require CANARY_DIRECTORY_ACCOUNT_ID_FILE (explicit owned
+# directory account UUID path only — never auto-selected, never printed).
 CANARY_ADMIN_JWT_FILE="${CANARY_ADMIN_JWT_FILE:-}"
 CANARY_LOGIN_IDENTIFIER_FILE="${CANARY_LOGIN_IDENTIFIER_FILE:-}"
 CANARY_LOGIN_PASSWORD_FILE="${CANARY_LOGIN_PASSWORD_FILE:-}"
 STAGING_OWNER_ADMIN_PASSWORD_FILE="${STAGING_OWNER_ADMIN_PASSWORD_FILE:-}"
+CANARY_DIRECTORY_ACCOUNT_ID_FILE="${CANARY_DIRECTORY_ACCOUNT_ID_FILE:-}"
 
 # Fixed dedicated lifecycle canary admin ownership markers (values-free constants).
 # Create/repair ONLY this (email, id) pair. Any email/id collision that does not
@@ -108,9 +123,24 @@ CANARY_OWNER_USER_ID="6c1fe000-ca0a-4000-8000-1ec0c1e00001"
 HUMAN_OWNER_USERNAME="staging-owner-admin"
 HUMAN_OWNER_NAME="Staging Owner Admin"
 
-# Intentionally ignored: not a real verifier path. Kept empty so accidental
-# exports cannot be mistaken for canary completion evidence.
-# CANARY_SUBJECT_ID / CANARY_INTEGRATION_ID / OWNER_CONFIRM are NOT used.
+# Fixed dedicated DingTalk directory subject ownership markers (values-free).
+# pending/deprovision operate ONLY on the secret-backed account id whose live
+# directory account name matches SUBJECT_OWNER_NAME. Username is the stable
+# local admit identifier (not printed in artifacts). No auto-selection.
+SUBJECT_OWNER_NAME="Lifecycle Canary Employee"
+SUBJECT_OWNER_USERNAME="lifecycle-canary-employee"
+DEPROVISION_SOURCE_CONFIRMATION="DINGTALK_SOURCE_DISABLED_DEDICATED_EXCLUSIVE_CONFIRMED"
+DEPROVISION_RESTORE_CONFIRMATION="DINGTALK_SOURCE_REACTIVATED_CONFIRMED"
+PENDING_SSO_ACTIVATE_CONFIRMATION="PENDING_SSO_ACTIVATE"
+# Optional subject password file (path only). When present, deprovision may prove
+# pre-login then post-denial with the SAME proven credential. Never invent a wrong
+# password as denial evidence.
+CANARY_SUBJECT_PASSWORD_FILE="${CANARY_SUBJECT_PASSWORD_FILE:-}"
+CANARY_SUBJECT_SYNC_RUN_ID_FILE="${CANARY_SUBJECT_SYNC_RUN_ID_FILE:-}"
+CANARY_SUBJECT_DEPROVISION_EVENT_ID_FILE="${CANARY_SUBJECT_DEPROVISION_EVENT_ID_FILE:-}"
+
+# Legacy presence-token names are intentionally NOT env-driven enablers.
+# Subject identity is path-only via CANARY_DIRECTORY_ACCOUNT_ID_FILE.
 
 BACKEND_CONTAINER="metasheet-staging-backend"
 WEB_CONTAINER="metasheet-staging-web"
@@ -150,13 +180,31 @@ fi
 
 LIFECYCLE_PERSIST_DIR="${HOME}/.metasheet2/lifecycle-canary"
 LIFECYCLE_OVERRIDE_FILE="${LIFECYCLE_PERSIST_DIR}/docker-compose.lifecycle-canary.override.yml"
-# Previous-override backup used during action=off|alias for restore-on-failure
-# (alias success path also restores OFF to prove rollback; failure restores first).
+# Previous-override backup used during action=off|alias|pending|deprovision for
+# restore-on-failure (alias/pending/deprovision success paths also restore OFF).
 LIFECYCLE_PREV_BACKUP=""
 LIFECYCLE_PREV_STATE="absent" # absent | present
 PINNED_IMAGE_OWNER=""
 PINNED_IMAGE_TAG=""
 ALIAS_ROLLBACK_ARMED="false"
+# Subject-local ephemeral secret files written under the per-run secrets dir
+# (local user id / temp password). Never logged; cleaned with secrets dir.
+CANARY_SUBJECT_LOCAL_USER_ID_FILE=""
+CANARY_SUBJECT_TEMP_PASSWORD_FILE=""
+CANARY_SUBJECT_INTEGRATION_ID_FILE=""
+# Host-persisted recovery journal for cross-run restore (mode 600). Keyed by
+# fixed SUBJECT_OWNER_USERNAME. Schema v4 state machine (unidirectional):
+#   prepared → run_bound → ledger_bound → (clear after successful restore)
+# Binds subject_key + local_user_id + integration_id + directory_account_id;
+# prepared also reserves exact run UUID; run_bound adds terminal counts;
+# ledger_bound adds exact event/effects.
+# Survives per-run secret cleanup. Deleted only after successful restore.
+CANARY_APPLY_STATE_DIR="${HOME}/.metasheet2/lifecycle-canary/subject-state"
+CANARY_APPLY_STATE_FILE="${CANARY_APPLY_STATE_DIR}/${SUBJECT_OWNER_USERNAME}.apply-state.json"
+CANARY_SUBJECT_EFFECTS_FILE=""
+JOURNAL_PHASE="none"
+# Dedicated canary expected effect type set (planner mark_inactive + grant enabled + global clear).
+CANARY_EXPECTED_EFFECT_TYPES="grant_changed membership_changed user_changed"
 
 is_truthy() {
   local v
@@ -448,6 +496,38 @@ require_staging_owner_admin_password_file() {
   [[ -f "$path" ]] || fail "action=${context} secret file missing for STAGING_OWNER_ADMIN_PASSWORD_FILE"
   [[ -s "$path" ]] || fail "action=${context} secret file empty for STAGING_OWNER_ADMIN_PASSWORD_FILE"
   log "${context} staging owner admin password file present (path only; values never logged)"
+}
+
+require_canary_directory_account_id_file() {
+  # Explicit owned directory account subject path only — never auto-select.
+  local path="${CANARY_DIRECTORY_ACCOUNT_ID_FILE:-}"
+  local context="${1:-pending}"
+  [[ -n "$path" ]] || fail "action=${context} requires CANARY_DIRECTORY_ACCOUNT_ID_FILE (chmod-600 secret file path); no auto-selection"
+  [[ -f "$path" ]] || fail "action=${context} secret file missing for CANARY_DIRECTORY_ACCOUNT_ID_FILE"
+  [[ -s "$path" ]] || fail "action=${context} secret file empty for CANARY_DIRECTORY_ACCOUNT_ID_FILE"
+  # Shape-only check inside python; value never printed.
+  local shape
+  shape="$(
+    python3 - "$path" <<'PY'
+import pathlib, re, sys
+try:
+    raw = pathlib.Path(sys.argv[1]).read_bytes().decode("utf-8").strip()
+except Exception:
+    print("false|secret_file_read_failed")
+    raise SystemExit(0)
+if not raw:
+    print("false|empty_subject")
+    raise SystemExit(0)
+if not re.fullmatch(r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}", raw):
+    print("false|subject_not_uuid")
+    raise SystemExit(0)
+print("true|ok")
+PY
+  )"
+  if [[ "${shape%%|*}" != "true" ]]; then
+    fail "action=${context} refused: directory account subject file invalid (${shape#*|}); values never logged"
+  fi
+  log "${context} directory account subject file present (path only; values never logged; no auto-selection)"
 }
 
 # Identifier secret file (app trim) must equal the fixed ownership email marker.
@@ -925,17 +1005,19 @@ PY
 }
 
 # Admin API via JWT file. Prints values-free result lines; never logs token.
-# Usage: admin_api_request METHOD PATH
+# Usage: admin_api_request METHOD PATH [optional_json_body_file]
+# When body file is set, POST/PATCH send exact file bytes (never logged).
+# When body file empty and method is POST, send {}.
 # stdout on transport success: HTTP_CODE\nBODY
 admin_api_request() {
-  local method="$1" path="$2"
-  python3 - "$CANARY_ADMIN_JWT_FILE" "$STAGING_API_BASE_URL" "$method" "$path" <<'PY'
+  local method="$1" path="$2" body_file="${3:-}"
+  python3 - "$CANARY_ADMIN_JWT_FILE" "$STAGING_API_BASE_URL" "$method" "$path" "$body_file" <<'PY'
 import pathlib
 import sys
 import urllib.error
 import urllib.request
 
-jwt_path, base, method, path = sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4]
+jwt_path, base, method, path, body_file = sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4], sys.argv[5]
 try:
     token = pathlib.Path(jwt_path).read_text(encoding="utf-8").strip()
 except Exception:
@@ -945,19 +1027,30 @@ if not token:
     sys.stderr.write("admin jwt file empty\n")
     raise SystemExit(2)
 url = base.rstrip("/") + path
-data = b"{}" if method.upper() == "POST" else None
+method_u = method.upper()
+data = None
+headers = {
+    "Authorization": f"Bearer {token}",
+    "Accept": "application/json",
+}
+if body_file:
+    try:
+        data = pathlib.Path(body_file).read_bytes()
+    except Exception:
+        sys.stderr.write("admin api body file read failed\n")
+        raise SystemExit(2)
+    headers["Content-Type"] = "application/json"
+elif method_u == "POST":
+    data = b"{}"
+    headers["Content-Type"] = "application/json"
 req = urllib.request.Request(
     url,
     data=data,
-    headers={
-        "Authorization": f"Bearer {token}",
-        "Accept": "application/json",
-        "Content-Type": "application/json",
-    },
-    method=method.upper(),
+    headers=headers,
+    method=method_u,
 )
 try:
-    with urllib.request.urlopen(req, timeout=60) as resp:
+    with urllib.request.urlopen(req, timeout=120) as resp:
         body = resp.read().decode("utf-8", errors="replace")
         code = int(resp.getcode())
 except urllib.error.HTTPError as e:
@@ -1405,6 +1498,2419 @@ print(("true" if ready is True else "false") + "|" + ("true" if can is True else
   return 0
 }
 
+# --- pending / deprovision subject helpers (secret-file paths only) --------------------
+# All helpers emit values-free reason enums / booleans / counts. Subject ids, integration
+# ids, user ids, and temp passwords stay only in chmod-600 files under the per-run
+# secrets directory and are never logged or written to artifacts.
+
+_subject_secret_dir() {
+  local base="${CANARY_DIRECTORY_ACCOUNT_ID_FILE:-${CANARY_LOGIN_PASSWORD_FILE:-}}"
+  [[ -n "$base" ]] || fail "subject secret dir: no secret file base path"
+  dirname "$base"
+}
+
+# Load GET /api/admin/directory/accounts/:id for the explicit subject file.
+# Sets SUBJECT_* booleans/enums only; writes integration/local-user id files when present.
+# SUBJECT_NOTE is a reason enum on failure paths.
+load_canary_directory_subject() {
+  local context="${1:-pending}"
+  SUBJECT_OK="false"
+  SUBJECT_NOTE="unset"
+  SUBJECT_PROVIDER_OK="false"
+  SUBJECT_NAME_OK="false"
+  SUBJECT_ACTIVE="false"
+  SUBJECT_LINK_STATUS="unknown"
+  SUBJECT_HAS_LOCAL_USER="false"
+  SUBJECT_LOCAL_USERNAME_OK="false"
+  SUBJECT_LOCAL_NAME_OK="false"
+  CANARY_SUBJECT_INTEGRATION_ID_FILE=""
+  CANARY_SUBJECT_LOCAL_USER_ID_FILE=""
+
+  local sec_dir result
+  sec_dir="$(_subject_secret_dir)"
+  result="$(
+    python3 - \
+      "$CANARY_ADMIN_JWT_FILE" \
+      "$STAGING_API_BASE_URL" \
+      "$CANARY_DIRECTORY_ACCOUNT_ID_FILE" \
+      "$SUBJECT_OWNER_NAME" \
+      "$SUBJECT_OWNER_USERNAME" \
+      "$sec_dir" <<'PY'
+import json, os, pathlib, re, sys, urllib.error, urllib.parse, urllib.request
+
+jwt_path, base, acct_path, owner_name, owner_username, sec_dir = sys.argv[1:7]
+
+def emit(parts):
+    print("|".join(parts))
+    raise SystemExit(0)
+
+try:
+    token = pathlib.Path(jwt_path).read_text(encoding="utf-8").strip()
+    account_id = pathlib.Path(acct_path).read_bytes().decode("utf-8").strip()
+except Exception:
+    emit(["false", "secret_file_read_failed", "false", "false", "false", "unknown", "false", "false", "false"])
+if not token:
+    emit(["false", "admin_jwt_empty", "false", "false", "false", "unknown", "false", "false", "false"])
+if not re.fullmatch(r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}", account_id):
+    emit(["false", "subject_not_uuid", "false", "false", "false", "unknown", "false", "false", "false"])
+
+url = base.rstrip("/") + "/api/admin/directory/accounts/" + urllib.parse.quote(account_id, safe="")
+req = urllib.request.Request(url, headers={"Authorization": f"Bearer {token}", "Accept": "application/json"}, method="GET")
+try:
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        raw = resp.read().decode("utf-8", errors="replace")
+        code = int(resp.getcode())
+except urllib.error.HTTPError as e:
+    emit(["false", f"account_http_{int(e.code)}", "false", "false", "false", "unknown", "false", "false", "false"])
+except Exception:
+    emit(["false", "account_transport_failed", "false", "false", "false", "unknown", "false", "false", "false"])
+try:
+    payload = json.loads(raw) if raw else {}
+except Exception:
+    emit(["false", "account_bad_json", "false", "false", "false", "unknown", "false", "false", "false"])
+if code != 200 or not isinstance(payload, dict) or payload.get("ok") is not True:
+    emit(["false", f"account_http_{code}", "false", "false", "false", "unknown", "false", "false", "false"])
+data = payload.get("data") if isinstance(payload.get("data"), dict) else {}
+account = data.get("account") if isinstance(data.get("account"), dict) else {}
+if not account:
+    emit(["false", "account_missing", "false", "false", "false", "unknown", "false", "false", "false"])
+
+provider = str(account.get("provider") or "").strip().lower()
+name = account.get("name") if isinstance(account.get("name"), str) else ""
+is_active = account.get("isActive") is True
+link_status = str(account.get("linkStatus") or "unknown")
+integration_id = str(account.get("integrationId") or "").strip()
+external_user_id = str(account.get("externalUserId") or "").strip()
+local_user = account.get("localUser") if isinstance(account.get("localUser"), dict) else None
+local_id = str(local_user.get("id") or "").strip() if local_user else ""
+local_username = str(local_user.get("username") or "").strip() if local_user else ""
+local_name = str(local_user.get("name") or "") if local_user else ""
+
+provider_ok = "true" if provider == "dingtalk" else "false"
+name_ok = "true" if name == owner_name else "false"
+active = "true" if is_active else "false"
+has_local = "true" if local_id else "false"
+local_username_ok = "true" if local_username.lower() == owner_username.lower() else "false"
+local_name_ok = "true" if local_name == owner_name else "false"
+
+if name_ok != "true":
+    emit(["false", "subject_name_not_owned", provider_ok, name_ok, active, link_status, has_local, local_username_ok, local_name_ok])
+if provider_ok != "true":
+    emit(["false", "subject_provider_not_dingtalk", provider_ok, name_ok, active, link_status, has_local, local_username_ok, local_name_ok])
+if not re.fullmatch(r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}", integration_id):
+    emit(["false", "integration_id_missing", provider_ok, name_ok, active, link_status, has_local, local_username_ok, local_name_ok])
+if not external_user_id:
+    emit(["false", "external_user_id_missing", provider_ok, name_ok, active, link_status, has_local, local_username_ok, local_name_ok])
+
+sec = pathlib.Path(sec_dir)
+sec.mkdir(parents=True, exist_ok=True)
+integ_path = sec / "subject.integration-id"
+integ_path.write_bytes(integration_id.encode("utf-8"))
+os.chmod(integ_path, 0o600)
+# External user id for values-free subject match against sync/preview samples (never logged).
+ext_path = sec / "subject.external-user-id"
+ext_path.write_bytes(external_user_id.encode("utf-8"))
+os.chmod(ext_path, 0o600)
+local_path = ""
+if local_id:
+    if not re.fullmatch(r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}", local_id):
+        emit(["false", "local_user_id_invalid", provider_ok, name_ok, active, link_status, has_local, local_username_ok, local_name_ok])
+    lp = sec / "subject.local-user-id"
+    lp.write_bytes(local_id.encode("utf-8"))
+    os.chmod(lp, 0o600)
+    local_path = str(lp)
+
+# stdout: ok|note|provider_ok|name_ok|active|link|has_local|local_user_ok|local_name_ok|integ_file|local_file
+print("|".join([
+    "true", "ok", provider_ok, name_ok, active, link_status, has_local,
+    local_username_ok, local_name_ok, str(integ_path), local_path,
+]))
+PY
+  )" || {
+    SUBJECT_NOTE="python_failed"
+    log "load subject failed (python); values never logged"
+    return 1
+  }
+
+  local ok note rest
+  ok="${result%%|*}"
+  rest="${result#*|}"
+  note="${rest%%|*}"
+  rest="${rest#*|}"
+  SUBJECT_PROVIDER_OK="${rest%%|*}"
+  rest="${rest#*|}"
+  SUBJECT_NAME_OK="${rest%%|*}"
+  rest="${rest#*|}"
+  SUBJECT_ACTIVE="${rest%%|*}"
+  rest="${rest#*|}"
+  SUBJECT_LINK_STATUS="${rest%%|*}"
+  rest="${rest#*|}"
+  SUBJECT_HAS_LOCAL_USER="${rest%%|*}"
+  rest="${rest#*|}"
+  SUBJECT_LOCAL_USERNAME_OK="${rest%%|*}"
+  rest="${rest#*|}"
+  SUBJECT_LOCAL_NAME_OK="${rest%%|*}"
+  rest="${rest#*|}"
+  CANARY_SUBJECT_INTEGRATION_ID_FILE="${rest%%|*}"
+  CANARY_SUBJECT_LOCAL_USER_ID_FILE="${rest#*|}"
+  SUBJECT_NOTE="$note"
+  if [[ "$ok" != "true" ]]; then
+    SUBJECT_OK="false"
+    log "load subject refused (${context}): note=${note} link=${SUBJECT_LINK_STATUS} active=${SUBJECT_ACTIVE}"
+    return 1
+  fi
+  SUBJECT_OK="true"
+  log "subject loaded (${context}): owned name/provider ok; link=${SUBJECT_LINK_STATUS} active=${SUBJECT_ACTIVE} has_local=${SUBJECT_HAS_LOCAL_USER} (ids never logged)"
+  return 0
+}
+
+# POST /api/admin/directory/accounts/:id/admit-user under pending mode.
+# Body uses fixed owned username + owned name only (no email/mobile/password).
+# enableDingTalkGrant=false is intentional for pending_activation (server also forces
+# grant off while DIRECTORY_PENDING_ACTIVATION_ENABLED). DingTalk OAuth grant is
+# exercised only in PENDING_SSO_ACTIVATE (mode=sso + enableDingTalkGrant=true).
+# Writes local user id file on success. Sets ADMIT_OK / ADMIT_NOTE / ADMIT_ACTIVATION_STATUS.
+run_pending_admit() {
+  local sec_dir body_file result
+  ADMIT_OK="false"
+  ADMIT_NOTE="unset"
+  ADMIT_ACTIVATION_STATUS="unknown"
+  sec_dir="$(_subject_secret_dir)"
+  body_file="$(mktemp "${sec_dir}/admit.body.XXXXXX")"
+  chmod 600 "$body_file"
+  # Fixed owned markers only — no PII from directory account email/mobile.
+  python3 - "$body_file" "$SUBJECT_OWNER_NAME" "$SUBJECT_OWNER_USERNAME" <<'PY'
+import json, pathlib, sys
+path, name, username = sys.argv[1], sys.argv[2], sys.argv[3]
+pathlib.Path(path).write_bytes(json.dumps({
+    "name": name,
+    "username": username,
+    # Pending admit: grant must stay false until explicit SSO activate phase.
+    "enableDingTalkGrant": False,
+}).encode("utf-8"))
+PY
+  result="$(
+    python3 - \
+      "$CANARY_ADMIN_JWT_FILE" \
+      "$STAGING_API_BASE_URL" \
+      "$CANARY_DIRECTORY_ACCOUNT_ID_FILE" \
+      "$body_file" \
+      "$sec_dir" \
+      "$SUBJECT_OWNER_NAME" \
+      "$SUBJECT_OWNER_USERNAME" <<'PY'
+import json, os, pathlib, re, sys, urllib.error, urllib.parse, urllib.request
+
+jwt_path, base, acct_path, body_path, sec_dir, owner_name, owner_username = sys.argv[1:8]
+
+def emit(ok, note, activation="unknown"):
+    print(f"{ok}|{note}|{activation}")
+    raise SystemExit(0)
+
+try:
+    token = pathlib.Path(jwt_path).read_text(encoding="utf-8").strip()
+    account_id = pathlib.Path(acct_path).read_bytes().decode("utf-8").strip()
+    body = pathlib.Path(body_path).read_bytes()
+except Exception:
+    emit("false", "secret_file_read_failed")
+url = base.rstrip("/") + "/api/admin/directory/accounts/" + urllib.parse.quote(account_id, safe="") + "/admit-user"
+req = urllib.request.Request(
+    url,
+    data=body,
+    headers={
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+    },
+    method="POST",
+)
+try:
+    with urllib.request.urlopen(req, timeout=60) as resp:
+        raw = resp.read().decode("utf-8", errors="replace")
+        code = int(resp.getcode())
+except urllib.error.HTTPError as e:
+    emit("false", f"admit_http_{int(e.code)}")
+except Exception:
+    emit("false", "admit_transport_failed")
+try:
+    payload = json.loads(raw) if raw else {}
+except Exception:
+    emit("false", "admit_bad_json")
+if code != 200 or not isinstance(payload, dict) or payload.get("ok") is not True:
+    emit("false", f"admit_http_{code}")
+data = payload.get("data") if isinstance(payload.get("data"), dict) else {}
+user = data.get("user") if isinstance(data.get("user"), dict) else {}
+activation = str(data.get("activationStatus") or user.get("activationStatus") or "unknown")
+user_id = str(user.get("id") or "").strip()
+user_name = str(user.get("name") or "")
+user_username = str(user.get("username") or "").strip()
+if not re.fullmatch(r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}", user_id):
+    emit("false", "admit_missing_user_id", activation)
+if user_name != owner_name:
+    emit("false", "admit_name_mismatch", activation)
+if user_username.lower() != owner_username.lower():
+    emit("false", "admit_username_mismatch", activation)
+if activation != "pending_activation":
+    emit("false", "admit_not_pending_activation", activation)
+lp = pathlib.Path(sec_dir) / "subject.local-user-id"
+lp.write_bytes(user_id.encode("utf-8"))
+os.chmod(lp, 0o600)
+emit("true", "admitted", activation)
+PY
+  )" || {
+    rm -f "$body_file"
+    ADMIT_NOTE="python_failed"
+    return 1
+  }
+  rm -f "$body_file"
+  ADMIT_OK="${result%%|*}"
+  local rest="${result#*|}"
+  ADMIT_NOTE="${rest%%|*}"
+  ADMIT_ACTIVATION_STATUS="${rest#*|}"
+  if [[ "$ADMIT_OK" == "true" ]]; then
+    CANARY_SUBJECT_LOCAL_USER_ID_FILE="$(_subject_secret_dir)/subject.local-user-id"
+    log "pending admit OK activation=${ADMIT_ACTIVATION_STATUS} (ids never logged)"
+    return 0
+  fi
+  log "pending admit refused: note=${ADMIT_NOTE}"
+  return 1
+}
+
+# Assert local user activation/access state via GET /api/admin/users/:id/access.
+# Sets ACCESS_OK ACCESS_IS_ACTIVE ACCESS_ACTIVATION ACCESS_NOTE
+# Profile activation_status + is_active only (not membership/grant). is_active MUST be
+# JSON boolean exactly equal to expected; missing/null/string/unknown all fail closed.
+assert_subject_user_access_state() {
+  local expect_activation="$1" expect_active="$2" context="${3:-pending}"
+  ACCESS_OK="false"
+  ACCESS_IS_ACTIVE="unknown"
+  ACCESS_ACTIVATION="unknown"
+  ACCESS_NOTE="unset"
+  [[ -n "${CANARY_SUBJECT_LOCAL_USER_ID_FILE:-}" && -s "${CANARY_SUBJECT_LOCAL_USER_ID_FILE}" ]] \
+    || { ACCESS_NOTE="local_user_id_file_missing"; return 1; }
+  local result
+  result="$(
+    python3 - "$CANARY_ADMIN_JWT_FILE" "$STAGING_API_BASE_URL" "$CANARY_SUBJECT_LOCAL_USER_ID_FILE" \
+      "$expect_activation" "$expect_active" <<'PY'
+import json, pathlib, sys, urllib.error, urllib.parse, urllib.request
+
+jwt_path, base, user_path, exp_act, exp_active = sys.argv[1:6]
+
+def emit(ok, note, is_active="unknown", activation="unknown"):
+    print(f"{ok}|{note}|{is_active}|{activation}")
+    raise SystemExit(0)
+
+try:
+    token = pathlib.Path(jwt_path).read_text(encoding="utf-8").strip()
+    user_id = pathlib.Path(user_path).read_bytes().decode("utf-8").strip()
+except Exception:
+    emit("false", "secret_file_read_failed")
+url = base.rstrip("/") + "/api/admin/users/" + urllib.parse.quote(user_id, safe="") + "/access"
+req = urllib.request.Request(url, headers={"Authorization": f"Bearer {token}", "Accept": "application/json"}, method="GET")
+try:
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        raw = resp.read().decode("utf-8", errors="replace")
+        code = int(resp.getcode())
+except urllib.error.HTTPError as e:
+    emit("false", f"access_http_{int(e.code)}")
+except Exception:
+    emit("false", "access_transport_failed")
+try:
+    payload = json.loads(raw) if raw else {}
+except Exception:
+    emit("false", "access_bad_json")
+if code != 200 or not isinstance(payload, dict) or payload.get("ok") is not True:
+    emit("false", f"access_http_{code}")
+data = payload.get("data") if isinstance(payload.get("data"), dict) else {}
+user = data.get("user") if isinstance(data.get("user"), dict) else {}
+if not user:
+    emit("false", "access_user_missing")
+# Strict: is_active must be JSON boolean on user (prefer snake_case, else camelCase).
+# Missing / null / string / number / unknown MUST fail — never coerce.
+if "is_active" in user:
+    is_active = user["is_active"]
+elif "isActive" in user:
+    is_active = user["isActive"]
+else:
+    emit("false", "is_active_missing")
+if type(is_active) is not bool:
+    emit("false", "is_active_not_boolean", "unknown")
+active_s = "true" if is_active is True else "false"
+activation = user.get("activationStatus")
+if activation is None:
+    activation = user.get("activation_status")
+if type(activation) is not str or not activation.strip():
+    emit("false", "activation_missing_or_not_string", active_s, "unknown")
+activation = activation.strip()
+if activation != exp_act:
+    emit("false", "activation_mismatch", active_s, activation)
+if active_s != exp_active:
+    emit("false", "is_active_mismatch", active_s, activation)
+emit("true", "ok", active_s, activation)
+PY
+  )" || {
+    ACCESS_NOTE="python_failed"
+    return 1
+  }
+  ACCESS_OK="${result%%|*}"
+  local rest="${result#*|}"
+  ACCESS_NOTE="${rest%%|*}"
+  rest="${rest#*|}"
+  ACCESS_IS_ACTIVE="${rest%%|*}"
+  ACCESS_ACTIVATION="${rest#*|}"
+  if [[ "$ACCESS_OK" == "true" ]]; then
+    log "subject access state OK (${context}): activation=${ACCESS_ACTIVATION} is_active=${ACCESS_IS_ACTIVE}"
+    return 0
+  fi
+  log "subject access state refused (${context}): note=${ACCESS_NOTE} activation=${ACCESS_ACTIVATION} is_active=${ACCESS_IS_ACTIVE}"
+  return 1
+}
+
+# Resolve optional subject password path (path only). Prefer explicit
+# CANARY_SUBJECT_PASSWORD_FILE, else subject.temp-password under secret dir.
+resolve_subject_password_file() {
+  if [[ -n "${CANARY_SUBJECT_PASSWORD_FILE:-}" && -s "${CANARY_SUBJECT_PASSWORD_FILE}" ]]; then
+    printf '%s' "$CANARY_SUBJECT_PASSWORD_FILE"
+    return 0
+  fi
+  if [[ -n "${CANARY_SUBJECT_TEMP_PASSWORD_FILE:-}" && -s "${CANARY_SUBJECT_TEMP_PASSWORD_FILE}" ]]; then
+    printf '%s' "$CANARY_SUBJECT_TEMP_PASSWORD_FILE"
+    return 0
+  fi
+  local candidate
+  candidate="$(_subject_secret_dir)/subject.temp-password"
+  if [[ -s "$candidate" ]]; then
+    printf '%s' "$candidate"
+    return 0
+  fi
+  return 1
+}
+
+# Prove subject password login using SUBJECT_OWNER_USERNAME + password file.
+# Never uses a deliberately wrong password as evidence.
+prove_subject_password_login() {
+  local context="${1:-subject_login}"
+  local pass_file="${2:-}"
+  SUBJECT_LOGIN_OK="false"
+  SUBJECT_LOGIN_NOTE="unset"
+  if [[ -z "$pass_file" ]]; then
+    pass_file="$(resolve_subject_password_file 2>/dev/null || true)"
+  fi
+  [[ -n "$pass_file" && -s "$pass_file" ]] \
+    || { SUBJECT_LOGIN_NOTE="subject_password_file_missing"; return 1; }
+  local result
+  result="$(
+    python3 - "$STAGING_API_BASE_URL" "$SUBJECT_OWNER_USERNAME" "$pass_file" <<'PY'
+import json, pathlib, sys, urllib.error, urllib.request
+base, username, pass_path = sys.argv[1], sys.argv[2], sys.argv[3]
+try:
+    # Exact subject password bytes (not the canary-admin prove helper line).
+    password = pathlib.Path(pass_path).read_bytes().decode("utf-8", errors="strict")
+except Exception:
+    print("false|secret_file_read_failed")
+    raise SystemExit(0)
+if password == "":
+    print("false|empty_password")
+    raise SystemExit(0)
+body = json.dumps({"identifier": username, "password": password}).encode("utf-8")
+req = urllib.request.Request(
+    base.rstrip("/") + "/api/auth/login",
+    data=body,
+    headers={"Content-Type": "application/json", "Accept": "application/json"},
+    method="POST",
+)
+try:
+    with urllib.request.urlopen(req, timeout=20) as resp:
+        raw = resp.read().decode("utf-8", errors="replace")
+        code = int(resp.getcode())
+except urllib.error.HTTPError as e:
+    print(f"false|http_{int(e.code)}")
+    raise SystemExit(0)
+except Exception:
+    print("false|request_failed")
+    raise SystemExit(0)
+try:
+    data = json.loads(raw)
+except Exception:
+    print(f"false|http_{code}_bad_json")
+    raise SystemExit(0)
+token = ""
+if isinstance(data, dict) and isinstance(data.get("data"), dict):
+    token = data["data"].get("token") or ""
+ok = code == 200 and data.get("success") is True and isinstance(token, str) and len(token) > 0
+print("true|ok" if ok else f"false|http_{code}_login_rejected")
+PY
+  )" || {
+    SUBJECT_LOGIN_NOTE="python_failed"
+    return 1
+  }
+  SUBJECT_LOGIN_OK="${result%%|*}"
+  SUBJECT_LOGIN_NOTE="${result#*|}"
+  if [[ "$SUBJECT_LOGIN_OK" == "true" ]]; then
+    CANARY_SUBJECT_TEMP_PASSWORD_FILE="$pass_file"
+    log "subject password login OK (${context})"
+    return 0
+  fi
+  log "subject password login FAILED (${context}): ${SUBJECT_LOGIN_NOTE}"
+  return 1
+}
+
+# Denial proof ONLY with a credential that was just proven to work (same file).
+# Authoritative denial evidence: HTTP 401 or 403 + JSON success=false + auth error
+# string (e.g. Invalid account or password). Transport errors, 5xx, non-auth 4xx,
+# and bad JSON are FAIL — never treated as successful denial.
+prove_subject_login_denied_with_proven_password() {
+  local context="${1:-deprovision}"
+  local pass_file="${2:-${CANARY_SUBJECT_TEMP_PASSWORD_FILE:-}}"
+  LOGIN_DENIED_OK="false"
+  LOGIN_DENIED_NOTE="unset"
+  [[ -n "$pass_file" && -s "$pass_file" ]] \
+    || { LOGIN_DENIED_NOTE="proven_password_file_missing"; return 1; }
+  # Must not claim denial without a positive proof in this process earlier.
+  [[ "${SUBJECT_PASSWORD_PROVEN_OK:-false}" == "true" ]] \
+    || { LOGIN_DENIED_NOTE="password_not_proven_before_denial"; return 1; }
+  local result
+  result="$(
+    python3 - "$STAGING_API_BASE_URL" "$SUBJECT_OWNER_USERNAME" "$pass_file" <<'PY'
+import json, pathlib, sys, urllib.error, urllib.request
+base, username, pass_path = sys.argv[1], sys.argv[2], sys.argv[3]
+try:
+    password = pathlib.Path(pass_path).read_bytes().decode("utf-8", errors="strict")
+except Exception:
+    print("false|secret_file_read_failed")
+    raise SystemExit(0)
+if password == "":
+    print("false|empty_password")
+    raise SystemExit(0)
+body = json.dumps({"identifier": username, "password": password}).encode("utf-8")
+req = urllib.request.Request(
+    base.rstrip("/") + "/api/auth/login",
+    data=body,
+    headers={"Content-Type": "application/json", "Accept": "application/json"},
+    method="POST",
+)
+raw = ""
+code = 0
+try:
+    with urllib.request.urlopen(req, timeout=20) as resp:
+        raw = resp.read().decode("utf-8", errors="replace")
+        code = int(resp.getcode())
+except urllib.error.HTTPError as e:
+    code = int(e.code)
+    try:
+        raw = e.read().decode("utf-8", errors="replace")
+    except Exception:
+        print(f"false|http_{code}_body_unreadable")
+        raise SystemExit(0)
+except Exception:
+    print("false|request_failed")
+    raise SystemExit(0)
+# Only 401/403 may count as auth denial. 5xx/other 4xx fail closed.
+if code not in (401, 403):
+    if code == 200:
+        # Fall through to JSON parse — must not have a usable token.
+        pass
+    else:
+        print(f"false|http_{code}_not_auth_denial")
+        raise SystemExit(0)
+try:
+    data = json.loads(raw) if raw else None
+except Exception:
+    print(f"false|http_{code}_bad_json")
+    raise SystemExit(0)
+if not isinstance(data, dict):
+    print(f"false|http_{code}_bad_json")
+    raise SystemExit(0)
+token = ""
+if isinstance(data.get("data"), dict):
+    token = data["data"].get("token") or ""
+if code == 200 and data.get("success") is True and isinstance(token, str) and len(token) > 0:
+    print("false|login_unexpectedly_succeeded")
+    raise SystemExit(0)
+if code in (401, 403):
+    # Authoritative auth error body from production login route closed set only.
+    # CSRF/gateway/other 401/403 must not false-green.
+    if data.get("success") is not False:
+        print(f"false|http_{code}_missing_success_false")
+        raise SystemExit(0)
+    err = data.get("error")
+    if not isinstance(err, str):
+        print(f"false|http_{code}_missing_auth_error")
+        raise SystemExit(0)
+    # Closed set from packages/core-backend/src/routes/auth.ts login failures.
+    CLOSED_LOGIN_ERRORS = frozenset({
+        "Invalid account or password",
+    })
+    if err in CLOSED_LOGIN_ERRORS:
+        print(f"true|http_{code}_auth_denied")
+        raise SystemExit(0)
+    print(f"false|http_{code}_auth_error_not_in_closed_set")
+    raise SystemExit(0)
+print(f"false|http_{code}_not_auth_denial")
+PY
+  )" || {
+    LOGIN_DENIED_NOTE="python_failed"
+    return 1
+  }
+  LOGIN_DENIED_OK="${result%%|*}"
+  LOGIN_DENIED_NOTE="${result#*|}"
+  if [[ "$LOGIN_DENIED_OK" == "true" ]]; then
+    log "subject proven-password login denied OK (${context}): ${LOGIN_DENIED_NOTE}"
+    return 0
+  fi
+  log "subject proven-password login denial failed (${context}): ${LOGIN_DENIED_NOTE}"
+  return 1
+}
+
+# POST /api/admin/users/:id/activate with mode=sso + enableDingTalkGrant=true.
+# This is the DingTalk lifecycle activation path (grant/deny-row surface). Never
+# temp_password. Browser OAuth negative/positive remain human NOT_EXECUTED.
+run_pending_sso_activate() {
+  local sec_dir body_file result
+  ACTIVATE_OK="false"
+  ACTIVATE_NOTE="unset"
+  sec_dir="$(_subject_secret_dir)"
+  [[ -n "${CANARY_SUBJECT_LOCAL_USER_ID_FILE:-}" && -s "${CANARY_SUBJECT_LOCAL_USER_ID_FILE}" ]] \
+    || { ACTIVATE_NOTE="local_user_id_file_missing"; return 1; }
+  body_file="$(mktemp "${sec_dir}/activate.sso.body.XXXXXX")"
+  chmod 600 "$body_file"
+  python3 - "$body_file" <<'PY'
+import json, pathlib, sys
+pathlib.Path(sys.argv[1]).write_bytes(json.dumps({
+    "mode": "sso",
+    "enableDingTalkGrant": True,
+}).encode("utf-8"))
+PY
+  result="$(
+    python3 - \
+      "$CANARY_ADMIN_JWT_FILE" \
+      "$STAGING_API_BASE_URL" \
+      "$CANARY_SUBJECT_LOCAL_USER_ID_FILE" \
+      "$body_file" \
+      "$CANARY_DIRECTORY_ACCOUNT_ID_FILE" <<'PY'
+import json, pathlib, sys, urllib.error, urllib.parse, urllib.request
+
+jwt_path, base, user_path, body_path, acct_path = sys.argv[1:6]
+
+def emit(ok, note):
+    print(f"{ok}|{note}")
+    raise SystemExit(0)
+
+try:
+    token = pathlib.Path(jwt_path).read_text(encoding="utf-8").strip()
+    user_id = pathlib.Path(user_path).read_bytes().decode("utf-8").strip()
+    body = pathlib.Path(body_path).read_bytes()
+    account_id = pathlib.Path(acct_path).read_bytes().decode("utf-8").strip()
+except Exception:
+    emit("false", "secret_file_read_failed")
+try:
+    obj = json.loads(body.decode("utf-8"))
+except Exception:
+    emit("false", "activate_body_bad_json")
+obj["directoryAccountId"] = account_id
+body = json.dumps(obj).encode("utf-8")
+url = base.rstrip("/") + "/api/admin/users/" + urllib.parse.quote(user_id, safe="") + "/activate"
+req = urllib.request.Request(
+    url,
+    data=body,
+    headers={
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+    },
+    method="POST",
+)
+try:
+    with urllib.request.urlopen(req, timeout=60) as resp:
+        raw = resp.read().decode("utf-8", errors="replace")
+        code = int(resp.getcode())
+except urllib.error.HTTPError as e:
+    emit("false", f"activate_http_{int(e.code)}")
+except Exception:
+    emit("false", "activate_transport_failed")
+try:
+    payload = json.loads(raw) if raw else {}
+except Exception:
+    emit("false", "activate_bad_json")
+if code != 200 or not isinstance(payload, dict) or payload.get("ok") is not True:
+    emit("false", f"activate_http_{code}")
+data = payload.get("data") if isinstance(payload.get("data"), dict) else {}
+activation = str(data.get("activationStatus") or "")
+if activation != "activated":
+    emit("false", "activate_status_not_activated")
+emit("true", "sso_activated")
+PY
+  )" || {
+    rm -f "$body_file"
+    ACTIVATE_NOTE="python_failed"
+    return 1
+  }
+  rm -f "$body_file"
+  ACTIVATE_OK="${result%%|*}"
+  ACTIVATE_NOTE="${result#*|}"
+  if [[ "$ACTIVATE_OK" == "true" ]]; then
+    log "pending SSO activate OK (browser OAuth still NOT_EXECUTED; values never logged)"
+    return 0
+  fi
+  log "pending SSO activate refused: note=${ACTIVATE_NOTE}"
+  return 1
+}
+
+# POST /api/admin/directory/integrations/:id/sync/preview — collateral radius gate.
+# Must run while lifecycle flags are still OFF (no env write yet). Whole-integration
+# preview: require exactly one wouldDeactivateAccount, exactly one
+# wouldDeactivateLinkedAccount, and the sole sampled deactivation externalUserId
+# matches the explicit subject externalUserId (secret-file compare only).
+# Sets PREVIEW_OK PREVIEW_NOTE PREVIEW_WOULD_DEACTIVATE PREVIEW_WOULD_DEACTIVATE_LINKED
+run_deprovision_sync_preview_subject_gate() {
+  PREVIEW_OK="false"
+  PREVIEW_NOTE="unset"
+  PREVIEW_WOULD_DEACTIVATE="0"
+  PREVIEW_WOULD_DEACTIVATE_LINKED="0"
+  [[ -n "${CANARY_SUBJECT_INTEGRATION_ID_FILE:-}" && -s "${CANARY_SUBJECT_INTEGRATION_ID_FILE}" ]] \
+    || { PREVIEW_NOTE="integration_id_file_missing"; return 1; }
+  local ext_path
+  ext_path="$(_subject_secret_dir)/subject.external-user-id"
+  [[ -s "$ext_path" ]] || { PREVIEW_NOTE="external_user_id_file_missing"; return 1; }
+  local result
+  result="$(
+    python3 - \
+      "$CANARY_ADMIN_JWT_FILE" \
+      "$STAGING_API_BASE_URL" \
+      "$CANARY_SUBJECT_INTEGRATION_ID_FILE" \
+      "$ext_path" <<'PY'
+import json, pathlib, sys, urllib.error, urllib.parse, urllib.request
+
+jwt_path, base, integ_path, ext_path = sys.argv[1:5]
+
+def emit(ok, note, would="0", linked="0"):
+    print(f"{ok}|{note}|{would}|{linked}")
+    raise SystemExit(0)
+
+def nonneg_int(v, name):
+    if type(v) is not int or v < 0:
+        raise ValueError(name)
+    return v
+
+try:
+    token = pathlib.Path(jwt_path).read_text(encoding="utf-8").strip()
+    integration_id = pathlib.Path(integ_path).read_bytes().decode("utf-8").strip()
+    subject_external = pathlib.Path(ext_path).read_bytes().decode("utf-8").strip()
+except Exception:
+    emit("false", "secret_file_read_failed")
+if not subject_external:
+    emit("false", "subject_external_empty")
+url = (
+    base.rstrip("/")
+    + "/api/admin/directory/integrations/"
+    + urllib.parse.quote(integration_id, safe="")
+    + "/sync/preview"
+)
+req = urllib.request.Request(
+    url,
+    data=b"{}",
+    headers={
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+    },
+    method="POST",
+)
+try:
+    with urllib.request.urlopen(req, timeout=180) as resp:
+        raw = resp.read().decode("utf-8", errors="replace")
+        code = int(resp.getcode())
+except urllib.error.HTTPError as e:
+    emit("false", f"preview_http_{int(e.code)}")
+except Exception:
+    emit("false", "preview_transport_failed")
+try:
+    payload = json.loads(raw) if raw else {}
+except Exception:
+    emit("false", "preview_bad_json")
+if code != 200 or not isinstance(payload, dict) or payload.get("ok") is not True:
+    emit("false", f"preview_http_{code}")
+data = payload.get("data") if isinstance(payload.get("data"), dict) else {}
+preview = data.get("preview") if isinstance(data.get("preview"), dict) else data
+if not isinstance(preview, dict):
+    emit("false", "preview_missing")
+try:
+    would = nonneg_int(preview.get("wouldDeactivateAccounts"), "wouldDeactivateAccounts")
+    linked = nonneg_int(preview.get("wouldDeactivateLinkedAccounts"), "wouldDeactivateLinkedAccounts")
+except Exception:
+    emit("false", "preview_counts_malformed")
+if would != 1:
+    emit("false", "would_deactivate_not_exactly_one", str(would), str(linked))
+if linked != 1:
+    emit("false", "would_deactivate_linked_not_exactly_one", str(would), str(linked))
+samples = preview.get("sampledDeactivations")
+if not isinstance(samples, list) or len(samples) != 1:
+    emit("false", "sampled_deactivations_not_exactly_one", str(would), str(linked))
+sample = samples[0] if isinstance(samples[0], dict) else {}
+sample_ext = str(sample.get("externalUserId") or "").strip()
+if not sample_ext:
+    emit("false", "sampled_external_missing", str(would), str(linked))
+# Secret-file compare only — never print either id.
+if sample_ext != subject_external:
+    emit("false", "sampled_external_not_subject", str(would), str(linked))
+if sample.get("linked") is not True:
+    emit("false", "sampled_not_linked", str(would), str(linked))
+emit("true", "ok", "1", "1")
+PY
+  )" || {
+    PREVIEW_NOTE="python_failed"
+    return 1
+  }
+  PREVIEW_OK="${result%%|*}"
+  local rest="${result#*|}"
+  PREVIEW_NOTE="${rest%%|*}"
+  rest="${rest#*|}"
+  PREVIEW_WOULD_DEACTIVATE="${rest%%|*}"
+  PREVIEW_WOULD_DEACTIVATE_LINKED="${rest#*|}"
+  if [[ "$PREVIEW_OK" == "true" ]]; then
+    log "deprovision sync/preview subject gate OK would_deactivate=1 would_deactivate_linked=1 subject_match=true (ids never logged)"
+    return 0
+  fi
+  log "deprovision sync/preview subject gate refused: note=${PREVIEW_NOTE} would_deactivate=${PREVIEW_WOULD_DEACTIVATE} would_deactivate_linked=${PREVIEW_WOULD_DEACTIVATE_LINKED}"
+  return 1
+}
+
+# POST /api/admin/directory/integrations/:id/sync (sync body {}).
+# Captures exact synchronous run.id into a secret file (never printed).
+# For deprovision-apply context: requires deprovisionApplied === true.
+# Sets SYNC_OK SYNC_NOTE SYNC_DEPROVISION_APPLIED SYNC_USERS_DEACTIVATED
+# SYNC_ACCOUNTS_DEACTIVATED SYNC_DEPROVISION_CANDIDATES SYNC_RUN_ID_PRESENT
+run_directory_sync_for_subject() {
+  local context="${1:-deprovision}"
+  local require_deprov_applied="${2:-false}"
+  SYNC_OK="false"
+  SYNC_NOTE="unset"
+  SYNC_DEPROVISION_APPLIED="false"
+  SYNC_USERS_DEACTIVATED="0"
+  SYNC_ACCOUNTS_DEACTIVATED="0"
+  SYNC_DEPROVISION_CANDIDATES="0"
+  SYNC_RUN_ID_PRESENT="false"
+  CANARY_SUBJECT_SYNC_RUN_ID_FILE=""
+  [[ -n "${CANARY_SUBJECT_INTEGRATION_ID_FILE:-}" && -s "${CANARY_SUBJECT_INTEGRATION_ID_FILE}" ]] \
+    || { SYNC_NOTE="integration_id_file_missing"; return 1; }
+  local sec_dir result
+  sec_dir="$(_subject_secret_dir)"
+  result="$(
+    python3 - "$CANARY_ADMIN_JWT_FILE" "$STAGING_API_BASE_URL" "$CANARY_SUBJECT_INTEGRATION_ID_FILE" \
+      "$sec_dir" "$require_deprov_applied" "$CANARY_APPLY_STATE_FILE" "$SUBJECT_OWNER_USERNAME" <<'PY'
+import json, os, pathlib, re, sys, time, urllib.error, urllib.parse, urllib.request
+
+jwt_path, base, integ_path, sec_dir, require_applied, state_path, subject_key = sys.argv[1:8]
+
+def emit(ok, note, applied="false", users="0", accounts="0", candidates="0", run_present="false"):
+    print(f"{ok}|{note}|{applied}|{users}|{accounts}|{candidates}|{run_present}")
+    raise SystemExit(0)
+
+try:
+    token = pathlib.Path(jwt_path).read_text(encoding="utf-8").strip()
+    integration_id = pathlib.Path(integ_path).read_bytes().decode("utf-8").strip()
+except Exception:
+    emit("false", "secret_file_read_failed")
+integration_base = base.rstrip("/") + "/api/admin/directory/integrations/" + urllib.parse.quote(integration_id, safe="")
+url = integration_base + "/sync"
+async_apply = require_applied == "true"
+reserved_run_id = ""
+request_body = b"{}"
+if async_apply:
+    try:
+        state = json.loads(pathlib.Path(state_path).read_bytes().decode("utf-8"))
+    except Exception:
+        emit("false", "journal_prepared_state_invalid")
+    reserved_run_id = str(state.get("sync_run_id") or "").strip() if isinstance(state, dict) else ""
+    if (
+        not isinstance(state, dict)
+        or state.get("schema") != "lifecycle-canary-deprovision-apply-state-v4"
+        or state.get("phase") not in {"prepared", "run_bound"}
+        or state.get("subject_key") != subject_key
+        or not re.fullmatch(r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}", reserved_run_id)
+    ):
+        emit("false", "journal_prepared_state_invalid")
+    request_body = json.dumps(
+        {"async": True, "runId": reserved_run_id},
+        separators=(",", ":"),
+    ).encode("utf-8")
+req = urllib.request.Request(
+    url,
+    data=request_body,
+    headers={
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+    },
+    method="POST",
+)
+try:
+    with urllib.request.urlopen(req, timeout=180) as resp:
+        raw = resp.read().decode("utf-8", errors="replace")
+        code = int(resp.getcode())
+except urllib.error.HTTPError as e:
+    emit("false", f"sync_http_{int(e.code)}")
+except Exception:
+    emit("false", "sync_transport_failed")
+try:
+    payload = json.loads(raw) if raw else {}
+except Exception:
+    emit("false", "sync_bad_json")
+expected_code = 202 if async_apply else 200
+if code != expected_code or not isinstance(payload, dict) or payload.get("ok") is not True:
+    emit("false", f"sync_http_{code}")
+data = payload.get("data") if isinstance(payload.get("data"), dict) else {}
+run = data.get("run") if isinstance(data.get("run"), dict) else {}
+if not run and isinstance(data.get("id"), str):
+    run = data
+run_id = str(data.get("runId") if async_apply else (run.get("id") or data.get("runId") or "")).strip()
+if not re.fullmatch(r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}", run_id):
+    emit("false", "sync_run_id_missing")
+if async_apply and run_id != reserved_run_id:
+    emit("false", "sync_run_id_mismatch")
+# The run UUID was already persisted in phase=prepared before any env write or HTTP
+# request. Materialize the same value for exact-run polling and ledger verification.
+run_path = pathlib.Path(sec_dir) / "subject.sync-run-id"
+run_path.write_bytes(run_id.encode("utf-8"))
+os.chmod(run_path, 0o600)
+
+if async_apply:
+    # Record only that the reserved run now exists. This is deliberately not named
+    # Terminal status and deprovision outcome are still unknown here.
+    try:
+        state_file = pathlib.Path(state_path)
+        state = json.loads(state_file.read_bytes().decode("utf-8"))
+        if (
+            not isinstance(state, dict)
+            or state.get("schema") != "lifecycle-canary-deprovision-apply-state-v4"
+            or state.get("phase") not in {"prepared", "run_bound"}
+            or state.get("subject_key") != subject_key
+            or str(state.get("sync_run_id") or "").strip() != run_id
+        ):
+            emit("false", "journal_prepared_state_invalid", run_present="true")
+        state["phase"] = "run_bound"
+        state["sync_users_deactivated"] = None
+        state["sync_accounts_deactivated"] = None
+        state["sync_deprovision_candidates"] = None
+        state["deprovision_applied"] = None
+        tmp = pathlib.Path(state_path + ".tmp")
+        tmp.write_bytes(json.dumps(state, separators=(",", ":")).encode("utf-8"))
+        os.chmod(tmp, 0o600)
+        tmp.replace(state_file)
+        os.chmod(state_file, 0o600)
+    except SystemExit:
+        raise
+    except Exception:
+        emit("false", "journal_run_bind_failed", run_present="true")
+
+    # Poll the exact async run; never use latest/sole-run inference.
+    deadline = time.monotonic() + 180
+    terminal = None
+    while time.monotonic() < deadline:
+        run_url = integration_base + "/runs/" + urllib.parse.quote(run_id, safe="")
+        poll_req = urllib.request.Request(
+            run_url,
+            headers={"Authorization": f"Bearer {token}", "Accept": "application/json"},
+            method="GET",
+        )
+        try:
+            with urllib.request.urlopen(poll_req, timeout=30) as poll_resp:
+                poll_raw = poll_resp.read().decode("utf-8", errors="replace")
+                poll_code = int(poll_resp.getcode())
+        except urllib.error.HTTPError as e:
+            emit("false", f"sync_poll_http_{int(e.code)}", run_present="true")
+        except Exception:
+            emit("false", "sync_poll_transport_failed", run_present="true")
+        try:
+            poll_payload = json.loads(poll_raw) if poll_raw else {}
+        except Exception:
+            emit("false", "sync_poll_bad_json", run_present="true")
+        if poll_code != 200 or not isinstance(poll_payload, dict) or poll_payload.get("ok") is not True:
+            emit("false", f"sync_poll_http_{poll_code}", run_present="true")
+        poll_data = poll_payload.get("data") if isinstance(poll_payload.get("data"), dict) else {}
+        exact_run = poll_data.get("run") if isinstance(poll_data.get("run"), dict) else None
+        if exact_run is None or str(exact_run.get("id") or "").strip() != run_id:
+            emit("false", "sync_poll_run_mismatch", run_present="true")
+        status = str(exact_run.get("status") or "").strip().lower()
+        if status in {"completed", "failed"}:
+            terminal = exact_run
+            break
+        if status not in {"pending", "running"}:
+            emit("false", "sync_poll_status_invalid", run_present="true")
+        time.sleep(2)
+    if terminal is None:
+        emit("false", "sync_poll_timeout", run_present="true")
+    if str(terminal.get("status") or "").strip().lower() != "completed":
+        emit("false", "sync_run_failed", run_present="true")
+    run = terminal
+
+stats = run.get("stats") if isinstance(run.get("stats"), dict) else {}
+if not stats and isinstance(data.get("stats"), dict):
+    stats = data["stats"]
+applied = stats.get("deprovisionApplied")
+applied_s = "true" if applied is True else "false"
+users = stats.get("deprovisionUsersDeactivatedCount")
+accounts = stats.get("accountsDeactivatedCount")
+candidates = stats.get("deprovisionCandidateCount")
+
+def nonneg(v):
+    if type(v) is int and v >= 0:
+        return str(v)
+    return "0"
+
+if require_applied == "true" and applied is not True:
+    # run id already on disk; emit run_present=true so caller upgrades journal.
+    emit("false", "deprovision_not_applied_on_sync", applied_s, nonneg(users), nonneg(accounts), nonneg(candidates), "true")
+
+# Radius notes for apply: emit false WITH run_present=true so recovery journal can bind.
+# Callers must journal phase=run_bound before treating this as terminal.
+if require_applied == "true":
+    if type(candidates) is not int or candidates != 1:
+        emit("false", "sync_candidate_radius_not_one", applied_s, nonneg(users), nonneg(accounts), nonneg(candidates), "true")
+    if type(accounts) is not int or accounts != 1:
+        emit("false", "sync_accounts_deactivated_not_one", applied_s, nonneg(users), nonneg(accounts), nonneg(candidates), "true")
+    if type(users) is not int or users != 1:
+        emit("false", "sync_users_deactivated_not_one", applied_s, nonneg(users), nonneg(accounts), nonneg(candidates), "true")
+
+emit("true", "ok", applied_s, nonneg(users), nonneg(accounts), nonneg(candidates), "true")
+PY
+  )" || {
+    SYNC_NOTE="python_failed"
+    return 1
+  }
+  SYNC_OK="${result%%|*}"
+  local rest="${result#*|}"
+  SYNC_NOTE="${rest%%|*}"
+  rest="${rest#*|}"
+  SYNC_DEPROVISION_APPLIED="${rest%%|*}"
+  rest="${rest#*|}"
+  SYNC_USERS_DEACTIVATED="${rest%%|*}"
+  rest="${rest#*|}"
+  SYNC_ACCOUNTS_DEACTIVATED="${rest%%|*}"
+  rest="${rest#*|}"
+  SYNC_DEPROVISION_CANDIDATES="${rest%%|*}"
+  SYNC_RUN_ID_PRESENT="${rest#*|}"
+  # Run id file is recovery anchor even when radius counts fail.
+  if [[ "$SYNC_RUN_ID_PRESENT" == "true" ]]; then
+    CANARY_SUBJECT_SYNC_RUN_ID_FILE="${sec_dir}/subject.sync-run-id"
+  fi
+  if [[ "$SYNC_OK" == "true" ]]; then
+    log "directory sync OK (${context}): deprovision_applied=${SYNC_DEPROVISION_APPLIED} users_deactivated=${SYNC_USERS_DEACTIVATED} accounts_deactivated=${SYNC_ACCOUNTS_DEACTIVATED} candidates=${SYNC_DEPROVISION_CANDIDATES} run_id_present=${SYNC_RUN_ID_PRESENT}"
+    return 0
+  fi
+  if [[ "$SYNC_RUN_ID_PRESENT" == "true" ]]; then
+    log "directory sync radius/apply anomaly (${context}): note=${SYNC_NOTE} run_id_persisted=true (recovery journal required; ids never logged)"
+  else
+    log "directory sync refused (${context}): note=${SYNC_NOTE}"
+  fi
+  return 1
+}
+
+# GET deprovision events for subject; require applied event whose run_id equals the
+# exact synchronous sync run.id captured in CANARY_SUBJECT_SYNC_RUN_ID_FILE.
+# Also requires caller already observed deprovisionApplied=true from that sync.
+# Writes matching event id to secret file for restore phase.
+# Sets LEDGER_OK LEDGER_NOTE LEDGER_EVENT_COUNT LEDGER_EFFECT_COUNT LEDGER_GENERATION_PRESENT LEDGER_RUN_MATCH
+verify_deprovision_ledger_for_subject() {
+  LEDGER_OK="false"
+  LEDGER_NOTE="unset"
+  LEDGER_EVENT_COUNT="0"
+  LEDGER_EFFECT_COUNT="0"
+  LEDGER_GENERATION_PRESENT="false"
+  LEDGER_RUN_MATCH="false"
+  CANARY_SUBJECT_DEPROVISION_EVENT_ID_FILE=""
+  [[ -n "${CANARY_SUBJECT_LOCAL_USER_ID_FILE:-}" && -s "${CANARY_SUBJECT_LOCAL_USER_ID_FILE}" ]] \
+    || { LEDGER_NOTE="local_user_id_file_missing"; return 1; }
+  [[ -n "${CANARY_SUBJECT_INTEGRATION_ID_FILE:-}" && -s "${CANARY_SUBJECT_INTEGRATION_ID_FILE}" ]] \
+    || { LEDGER_NOTE="integration_id_file_missing"; return 1; }
+  [[ -n "${CANARY_SUBJECT_SYNC_RUN_ID_FILE:-}" && -s "${CANARY_SUBJECT_SYNC_RUN_ID_FILE}" ]] \
+    || { LEDGER_NOTE="sync_run_id_file_missing"; return 1; }
+  [[ "${SYNC_DEPROVISION_APPLIED:-false}" == "true" ]] \
+    || { LEDGER_NOTE="sync_deprovision_not_applied"; return 1; }
+  local sec_dir result
+  sec_dir="$(_subject_secret_dir)"
+  result="$(
+    python3 - \
+      "$CANARY_ADMIN_JWT_FILE" \
+      "$STAGING_API_BASE_URL" \
+      "$CANARY_SUBJECT_LOCAL_USER_ID_FILE" \
+      "$CANARY_SUBJECT_INTEGRATION_ID_FILE" \
+      "$CANARY_SUBJECT_SYNC_RUN_ID_FILE" \
+      "$sec_dir" <<'PY'
+import json, os, pathlib, re, sys, urllib.error, urllib.parse, urllib.request
+
+jwt_path, base, user_path, integ_path, run_path, sec_dir = sys.argv[1:7]
+
+def emit(ok, note, events="0", effects="0", gen="false", run_match="false"):
+    print(f"{ok}|{note}|{events}|{effects}|{gen}|{run_match}")
+    raise SystemExit(0)
+
+def get_json(token, url):
+    req = urllib.request.Request(url, headers={"Authorization": f"Bearer {token}", "Accept": "application/json"}, method="GET")
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            raw = resp.read().decode("utf-8", errors="replace")
+            code = int(resp.getcode())
+    except urllib.error.HTTPError as e:
+        return int(e.code), None
+    except Exception:
+        return None, None
+    try:
+        return code, json.loads(raw) if raw else {}
+    except Exception:
+        return code, None
+
+try:
+    token = pathlib.Path(jwt_path).read_text(encoding="utf-8").strip()
+    user_id = pathlib.Path(user_path).read_bytes().decode("utf-8").strip()
+    integration_id = pathlib.Path(integ_path).read_bytes().decode("utf-8").strip()
+    expected_run_id = pathlib.Path(run_path).read_bytes().decode("utf-8").strip()
+except Exception:
+    emit("false", "secret_file_read_failed")
+if not re.fullmatch(r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}", expected_run_id):
+    emit("false", "expected_run_id_invalid")
+
+q = urllib.parse.urlencode({"userId": user_id, "integrationId": integration_id, "status": "applied", "limit": "50"})
+code, payload = get_json(token, base.rstrip("/") + "/api/admin/directory/deprovision/events?" + q)
+if code is None:
+    emit("false", "events_transport_failed")
+if code != 200 or not isinstance(payload, dict) or payload.get("ok") is not True:
+    emit("false", f"events_http_{code if code is not None else 'na'}")
+data = payload.get("data") if isinstance(payload.get("data"), dict) else {}
+items = data.get("items") if isinstance(data.get("items"), list) else []
+if not items:
+    emit("false", "events_empty", "0", "0", "false", "false")
+
+# Load-bearing: select ONLY the event whose run_id equals the exact sync run.
+matched = []
+for item in items:
+    if not isinstance(item, dict):
+        continue
+    rid = str(item.get("run_id") or item.get("runId") or "").strip()
+    if rid == expected_run_id:
+        matched.append(item)
+if not matched:
+    emit("false", "event_run_id_mismatch", str(len(items)), "0", "false", "false")
+if len(matched) > 1:
+    emit("false", "event_run_id_ambiguous", str(len(matched)), "0", "false", "false")
+event = matched[0]
+event_id = str(event.get("id") or "").strip()
+gen = event.get("access_generation_at_apply")
+if gen is None:
+    gen = event.get("accessGenerationAtApply")
+gen_present = "true" if isinstance(gen, int) or (isinstance(gen, str) and gen.strip().isdigit()) else "false"
+if not event_id:
+    emit("false", "event_id_missing", "1", "0", gen_present, "true")
+# LOAD-BEARING equality: event.run_id must equal expected sync run.id
+event_run = str(event.get("run_id") or event.get("runId") or "").strip()
+if event_run != expected_run_id:
+    emit("false", "event_run_id_mismatch", "1", "0", gen_present, "false")
+
+code2, payload2 = get_json(token, base.rstrip("/") + "/api/admin/directory/deprovision/events/" + urllib.parse.quote(event_id, safe="") + "/effects")
+if code2 is None:
+    emit("false", "effects_transport_failed", "1", "0", gen_present, "true")
+if code2 != 200 or not isinstance(payload2, dict) or payload2.get("ok") is not True:
+    emit("false", f"effects_http_{code2 if code2 is not None else 'na'}", "1", "0", gen_present, "true")
+data2 = payload2.get("data") if isinstance(payload2.get("data"), dict) else {}
+effects = data2.get("items") if isinstance(data2.get("items"), list) else []
+# Closed set mirrors packages/core-backend deprovision-ledger/planner effect types.
+CLOSED_EFFECT_TYPES = frozenset({"membership_changed", "grant_changed", "user_changed"})
+applied_effects = []
+seen_ids = set()
+for fx in effects:
+    if not isinstance(fx, dict):
+        emit("false", "effect_not_object", "1", "0", gen_present, "true")
+    # status must be exactly "applied" — empty/open/other do not count.
+    st = fx.get("status")
+    if type(st) is not str or st != "applied":
+        emit("false", "effect_status_not_applied", "1", "0", gen_present, "true")
+    fx_id = str(fx.get("id") or "").strip()
+    fx_type = str(fx.get("effect_type") or fx.get("effectType") or "").strip()
+    if not fx_id or not fx_type:
+        emit("false", "effect_id_or_type_missing", "1", "0", gen_present, "true")
+    if fx_type not in CLOSED_EFFECT_TYPES:
+        emit("false", "effect_type_not_closed_set", "1", "0", gen_present, "true")
+    if fx_id in seen_ids:
+        emit("false", "effect_id_duplicate", "1", "0", gen_present, "true")
+    seen_ids.add(fx_id)
+    # Strict booleans from ledger — drive access-graph proofs later.
+    ba = fx.get("before_active")
+    if ba is None:
+        ba = fx.get("beforeActive")
+    aa = fx.get("after_active")
+    if aa is None:
+        aa = fx.get("afterActive")
+    if type(ba) is not bool or type(aa) is not bool:
+        emit("false", "effect_active_flags_not_boolean", "1", "0", gen_present, "true")
+    grc = fx.get("grant_row_created")
+    if grc is None:
+        grc = fx.get("grantRowCreated")
+    if grc is None:
+        grc = False
+    if type(grc) is not bool:
+        emit("false", "effect_grant_row_created_not_boolean", "1", "0", gen_present, "true")
+    if grc is True and fx_type != "grant_changed":
+        emit("false", "effect_grant_row_created_type_invalid", "1", "0", gen_present, "true")
+    if grc is True and (ba is not False or aa is not False):
+        emit("false", "effect_grant_row_created_flags_invalid", "1", "0", gen_present, "true")
+    applied_effects.append({
+        "id": fx_id,
+        "type": fx_type,
+        "before_active": ba,
+        "after_active": aa,
+        "grant_row_created": grc,
+    })
+if len(applied_effects) < 1:
+    emit("false", "effects_empty", "1", "0", gen_present, "true")
+# Dedicated canary: exact effect type set from planner (mark_inactive + grant enabled + global clear).
+type_list = [fx["type"] for fx in applied_effects]
+type_set = set(type_list)
+if type_set != CLOSED_EFFECT_TYPES or len(applied_effects) != 3 or len(type_list) != len(type_set):
+    emit("false", "effect_type_set_not_exact_triple", "1", str(len(applied_effects)), gen_present, "true")
+# Canary subject established via SSO+grant true → grant_changed flips enabled (not deny-row create).
+for fx in applied_effects:
+    if fx["type"] == "grant_changed" and fx["grant_row_created"] is True:
+        emit("false", "grant_row_created_unexpected_for_canary", "1", str(len(applied_effects)), gen_present, "true")
+    if fx["before_active"] is not True or fx["after_active"] is not False:
+        emit("false", "effect_before_after_not_active_to_inactive", "1", str(len(applied_effects)), gen_present, "true")
+if gen_present != "true":
+    emit("false", "generation_missing", "1", str(len(applied_effects)), gen_present, "true")
+
+ev_path = pathlib.Path(sec_dir) / "subject.deprovision-event-id"
+ev_path.write_bytes(event_id.encode("utf-8"))
+os.chmod(ev_path, 0o600)
+fx_path = pathlib.Path(sec_dir) / "subject.deprovision-effects.json"
+fx_path.write_bytes(json.dumps({"effects": applied_effects, "effect_count": len(applied_effects)}, separators=(",", ":")).encode("utf-8"))
+os.chmod(fx_path, 0o600)
+emit("true", "ok", "1", str(len(applied_effects)), gen_present, "true")
+PY
+  )" || {
+    LEDGER_NOTE="python_failed"
+    return 1
+  }
+  LEDGER_OK="${result%%|*}"
+  local rest="${result#*|}"
+  LEDGER_NOTE="${rest%%|*}"
+  rest="${rest#*|}"
+  LEDGER_EVENT_COUNT="${rest%%|*}"
+  rest="${rest#*|}"
+  LEDGER_EFFECT_COUNT="${rest%%|*}"
+  rest="${rest#*|}"
+  LEDGER_GENERATION_PRESENT="${rest%%|*}"
+  LEDGER_RUN_MATCH="${rest#*|}"
+  if [[ "$LEDGER_OK" == "true" ]]; then
+    CANARY_SUBJECT_DEPROVISION_EVENT_ID_FILE="${sec_dir}/subject.deprovision-event-id"
+    CANARY_SUBJECT_EFFECTS_FILE="${sec_dir}/subject.deprovision-effects.json"
+    log "deprovision ledger OK events=${LEDGER_EVENT_COUNT} effects=${LEDGER_EFFECT_COUNT} generation_present=${LEDGER_GENERATION_PRESENT} run_match=${LEDGER_RUN_MATCH}"
+    return 0
+  fi
+  log "deprovision ledger refused: note=${LEDGER_NOTE}"
+  return 1
+}
+
+# --- recovery journal state machine (v4): prepared → run_bound → ledger_bound ---
+# Host path under ~/.metasheet2 survives per-run secret cleanup. Never logs ids.
+# `prepared` already owns the caller-reserved run UUID before env write / HTTP.
+# Unidirectional upgrades only; restore accepts ledger_bound or reconciles
+# prepared/run_bound via that exact UUID — never a latest/sole-event guess.
+
+_journal_read_phase() {
+  JOURNAL_PHASE="none"
+  [[ -f "$CANARY_APPLY_STATE_FILE" && -s "$CANARY_APPLY_STATE_FILE" ]] || return 0
+  JOURNAL_PHASE="$(
+    python3 - "$CANARY_APPLY_STATE_FILE" <<'PY'
+import json, pathlib, sys
+try:
+    st = json.loads(pathlib.Path(sys.argv[1]).read_bytes().decode("utf-8"))
+except Exception:
+    print("invalid")
+    raise SystemExit(0)
+print(str(st.get("phase") or "invalid") if isinstance(st, dict) else "invalid")
+PY
+  )"
+}
+
+refuse_existing_deprovision_apply_state() {
+  if [[ -f "$CANARY_APPLY_STATE_FILE" && -s "$CANARY_APPLY_STATE_FILE" ]]; then
+    fail "action=deprovision apply refused: unrecovered recovery journal exists at host path (restore/reconcile first); no env write; refuse overwrite"
+  fi
+}
+
+# Create phase=prepared BEFORE env write, including a caller-reserved run UUID.
+journal_init_prepared() {
+  mkdir -p "$CANARY_APPLY_STATE_DIR"
+  chmod 700 "$CANARY_APPLY_STATE_DIR"
+  refuse_existing_deprovision_apply_state
+  [[ -n "${CANARY_SUBJECT_LOCAL_USER_ID_FILE:-}" && -s "${CANARY_SUBJECT_LOCAL_USER_ID_FILE}" ]] \
+    || fail "journal prepared: local user id file missing"
+  [[ -n "${CANARY_SUBJECT_INTEGRATION_ID_FILE:-}" && -s "${CANARY_SUBJECT_INTEGRATION_ID_FILE}" ]] \
+    || fail "journal prepared: integration id file missing"
+  [[ -n "${CANARY_DIRECTORY_ACCOUNT_ID_FILE:-}" && -s "${CANARY_DIRECTORY_ACCOUNT_ID_FILE}" ]] \
+    || fail "journal prepared: directory account id file missing"
+  local sec_dir
+  sec_dir="$(_subject_secret_dir)"
+  python3 - \
+    "$CANARY_APPLY_STATE_FILE" \
+    "$CANARY_SUBJECT_LOCAL_USER_ID_FILE" \
+    "$CANARY_SUBJECT_INTEGRATION_ID_FILE" \
+    "$CANARY_DIRECTORY_ACCOUNT_ID_FILE" \
+    "$SUBJECT_OWNER_USERNAME" \
+    "$sec_dir" <<'PY'
+import json, os, pathlib, re, sys, uuid
+out_path, user_path, integ_path, acct_path, subject_key, sec_dir = sys.argv[1:7]
+uuid_re = re.compile(
+    r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+)
+if pathlib.Path(out_path).is_file() and pathlib.Path(out_path).stat().st_size > 0:
+    raise SystemExit(9)
+local_user_id = pathlib.Path(user_path).read_bytes().decode("utf-8").strip()
+integration_id = pathlib.Path(integ_path).read_bytes().decode("utf-8").strip()
+directory_account_id = pathlib.Path(acct_path).read_bytes().decode("utf-8").strip()
+for val in (local_user_id, integration_id, directory_account_id):
+    if not uuid_re.fullmatch(val):
+        raise SystemExit(2)
+run_id = str(uuid.uuid4())
+payload = {
+    "schema": "lifecycle-canary-deprovision-apply-state-v4",
+    "phase": "prepared",
+    "subject_key": subject_key,
+    "local_user_id": local_user_id,
+    "integration_id": integration_id,
+    "directory_account_id": directory_account_id,
+    "sync_run_id": run_id,
+    "sync_users_deactivated": None,
+    "sync_accounts_deactivated": None,
+    "sync_deprovision_candidates": None,
+    "deprovision_applied": None,
+    "event_id": None,
+    "effect_count": None,
+    "effects": None,
+}
+tmp = pathlib.Path(out_path + ".tmp")
+tmp.write_bytes(json.dumps(payload, separators=(",", ":")).encode("utf-8"))
+os.chmod(tmp, 0o600)
+tmp.replace(pathlib.Path(out_path))
+os.chmod(out_path, 0o600)
+run_path = pathlib.Path(sec_dir) / "subject.sync-run-id"
+run_path.write_bytes(run_id.encode("utf-8"))
+os.chmod(run_path, 0o600)
+PY
+  CANARY_SUBJECT_SYNC_RUN_ID_FILE="${sec_dir}/subject.sync-run-id"
+  JOURNAL_PHASE="prepared"
+  log "recovery journal phase=prepared (subject + reserved run id bound before env/HTTP; ids never logged)"
+}
+
+# Finalize prepared/run_bound → run_bound after the exact async run reaches terminal.
+# The async starter may already have set run_bound with null outcome fields; this step
+# fills the exact terminal counts without claiming that the deprovision ledger is bound.
+journal_upgrade_run_bound() {
+  [[ -n "${CANARY_SUBJECT_SYNC_RUN_ID_FILE:-}" && -s "${CANARY_SUBJECT_SYNC_RUN_ID_FILE}" ]] \
+    || fail "journal run_bound refused: sync run id file missing"
+  python3 - \
+    "$CANARY_APPLY_STATE_FILE" \
+    "$CANARY_SUBJECT_SYNC_RUN_ID_FILE" \
+    "$SUBJECT_OWNER_USERNAME" \
+    "${SYNC_USERS_DEACTIVATED:-0}" \
+    "${SYNC_ACCOUNTS_DEACTIVATED:-0}" \
+    "${SYNC_DEPROVISION_CANDIDATES:-0}" \
+    "${SYNC_DEPROVISION_APPLIED:-false}" <<'PY'
+import json, os, pathlib, re, sys
+(
+    state_path, run_path, subject_key,
+    users_s, accounts_s, candidates_s, applied_s,
+) = sys.argv[1:8]
+uuid_re = re.compile(
+    r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+)
+try:
+    state = json.loads(pathlib.Path(state_path).read_bytes().decode("utf-8"))
+except Exception:
+    raise SystemExit(2)
+if not isinstance(state, dict) or state.get("schema") != "lifecycle-canary-deprovision-apply-state-v4":
+    raise SystemExit(3)
+if state.get("subject_key") != subject_key:
+    raise SystemExit(4)
+if state.get("phase") not in {"prepared", "run_bound"}:
+    # Strict monotonicity: prepared/run_bound may become run_bound; never overwrite ledger_bound.
+    raise SystemExit(5)
+run_id = pathlib.Path(run_path).read_bytes().decode("utf-8").strip()
+if not uuid_re.fullmatch(run_id):
+    raise SystemExit(6)
+if str(state.get("sync_run_id") or "").strip() != run_id:
+    raise SystemExit(7)
+def as_int(s):
+    try:
+        v = int(s)
+        return v if v >= 0 else None
+    except Exception:
+        return None
+state["phase"] = "run_bound"
+state["sync_users_deactivated"] = as_int(users_s)
+state["sync_accounts_deactivated"] = as_int(accounts_s)
+state["sync_deprovision_candidates"] = as_int(candidates_s)
+state["deprovision_applied"] = applied_s == "true"
+state["event_id"] = None
+state["effect_count"] = None
+state["effects"] = None
+tmp = pathlib.Path(state_path + ".tmp")
+tmp.write_bytes(json.dumps(state, separators=(",", ":")).encode("utf-8"))
+os.chmod(tmp, 0o600)
+tmp.replace(pathlib.Path(state_path))
+os.chmod(state_path, 0o600)
+PY
+  JOURNAL_PHASE="run_bound"
+  log "recovery journal phase=run_bound (exact async run + terminal outcome persisted; ledger/radius may still be abnormal; ids never logged)"
+}
+
+# Upgrade run_bound → ledger_bound with exact event + typed effects (atomic).
+journal_upgrade_ledger_bound() {
+  [[ -n "${CANARY_SUBJECT_DEPROVISION_EVENT_ID_FILE:-}" && -s "${CANARY_SUBJECT_DEPROVISION_EVENT_ID_FILE}" ]] \
+    || fail "journal ledger_bound refused: event id file missing"
+  [[ -n "${CANARY_SUBJECT_EFFECTS_FILE:-}" && -s "${CANARY_SUBJECT_EFFECTS_FILE}" ]] \
+    || fail "journal ledger_bound refused: effects file missing"
+  [[ -n "${CANARY_SUBJECT_SYNC_RUN_ID_FILE:-}" && -s "${CANARY_SUBJECT_SYNC_RUN_ID_FILE}" ]] \
+    || fail "journal ledger_bound refused: run id file missing"
+  python3 - \
+    "$CANARY_APPLY_STATE_FILE" \
+    "$CANARY_SUBJECT_SYNC_RUN_ID_FILE" \
+    "$CANARY_SUBJECT_DEPROVISION_EVENT_ID_FILE" \
+    "$CANARY_SUBJECT_EFFECTS_FILE" \
+    "$SUBJECT_OWNER_USERNAME" <<'PY'
+import json, os, pathlib, re, sys
+state_path, run_path, event_path, fx_path, subject_key = sys.argv[1:6]
+uuid_re = re.compile(
+    r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+)
+CLOSED = frozenset({"membership_changed", "grant_changed", "user_changed"})
+try:
+    state = json.loads(pathlib.Path(state_path).read_bytes().decode("utf-8"))
+except Exception:
+    raise SystemExit(2)
+if not isinstance(state, dict) or state.get("schema") != "lifecycle-canary-deprovision-apply-state-v4":
+    raise SystemExit(3)
+if state.get("subject_key") != subject_key:
+    raise SystemExit(4)
+if state.get("phase") not in {"prepared", "run_bound"}:
+    raise SystemExit(5)
+run_id = pathlib.Path(run_path).read_bytes().decode("utf-8").strip()
+event_id = pathlib.Path(event_path).read_bytes().decode("utf-8").strip()
+if not uuid_re.fullmatch(run_id) or not uuid_re.fullmatch(event_id):
+    raise SystemExit(6)
+if str(state.get("sync_run_id") or "").strip() != run_id:
+    raise SystemExit(7)
+fx = json.loads(pathlib.Path(fx_path).read_bytes().decode("utf-8"))
+effects = fx.get("effects") if isinstance(fx, dict) else None
+if not isinstance(effects, list) or len(effects) != 3:
+    raise SystemExit(8)
+seen = set()
+types = []
+for fx_item in effects:
+    if not isinstance(fx_item, dict):
+        raise SystemExit(9)
+    fid = str(fx_item.get("id") or "").strip()
+    ftype = str(fx_item.get("type") or "").strip()
+    if not uuid_re.fullmatch(fid) or ftype not in CLOSED:
+        raise SystemExit(10)
+    if fid in seen:
+        raise SystemExit(11)
+    seen.add(fid)
+    types.append(ftype)
+    if type(fx_item.get("before_active")) is not bool or type(fx_item.get("after_active")) is not bool:
+        raise SystemExit(12)
+    if type(fx_item.get("grant_row_created")) is not bool:
+        raise SystemExit(13)
+if set(types) != CLOSED or len(types) != 3:
+    raise SystemExit(14)
+state["phase"] = "ledger_bound"
+state["event_id"] = event_id
+state["effect_count"] = 3
+state["effects"] = effects
+tmp = pathlib.Path(state_path + ".tmp")
+tmp.write_bytes(json.dumps(state, separators=(",", ":")).encode("utf-8"))
+os.chmod(tmp, 0o600)
+tmp.replace(pathlib.Path(state_path))
+os.chmod(state_path, 0o600)
+PY
+  JOURNAL_PHASE="ledger_bound"
+  log "recovery journal phase=ledger_bound (exact event+effects bound; ids never logged)"
+}
+
+# Early-fail before any deprovision write: drop prepared-only journal so re-apply is possible.
+journal_clear_if_phase_prepared() {
+  _journal_read_phase
+  if [[ "$JOURNAL_PHASE" == "prepared" ]]; then
+    rm -f "$CANARY_APPLY_STATE_FILE"
+    JOURNAL_PHASE="none"
+    log "cleared prepared-only recovery journal (no sync run occurred)"
+  fi
+}
+
+clear_deprovision_apply_state() {
+  if [[ -f "$CANARY_APPLY_STATE_FILE" ]]; then
+    rm -f "$CANARY_APPLY_STATE_FILE"
+    JOURNAL_PHASE="none"
+    log "cleared recovery journal after successful restore"
+  fi
+}
+
+# Compat name used by older comments/tests: ledger_bound write path is journal_upgrade_ledger_bound.
+persist_deprovision_apply_state() {
+  journal_upgrade_ledger_bound
+}
+
+# Reconcile phase=prepared/run_bound → ledger_bound using ONLY the pre-request
+# reserved run id (no sole-event / latest-event discovery). Safe at restore entry
+# after a lost HTTP response or runner crash.
+reconcile_run_journal_to_ledger_bound() {
+  [[ -f "$CANARY_APPLY_STATE_FILE" && -s "$CANARY_APPLY_STATE_FILE" ]] \
+    || { LEDGER_NOTE="journal_missing"; return 1; }
+  local sec_dir
+  sec_dir="$(_subject_secret_dir)"
+  # Materialize run id from journal into secret file for ledger verify.
+  python3 - \
+    "$CANARY_APPLY_STATE_FILE" \
+    "$sec_dir" \
+    "$SUBJECT_OWNER_USERNAME" \
+    "$CANARY_SUBJECT_LOCAL_USER_ID_FILE" \
+    "$CANARY_SUBJECT_INTEGRATION_ID_FILE" \
+    "$CANARY_DIRECTORY_ACCOUNT_ID_FILE" <<'PY'
+import json, os, pathlib, re, sys
+(
+    state_path, sec_dir, subject_key,
+    live_user_path, live_integ_path, live_acct_path,
+) = sys.argv[1:7]
+uuid_re = re.compile(
+    r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+)
+state = json.loads(pathlib.Path(state_path).read_bytes().decode("utf-8"))
+if state.get("schema") != "lifecycle-canary-deprovision-apply-state-v4":
+    raise SystemExit(2)
+if state.get("subject_key") != subject_key:
+    raise SystemExit(3)
+if state.get("phase") not in {"prepared", "run_bound"}:
+    raise SystemExit(4)
+run_id = str(state.get("sync_run_id") or "").strip()
+local_user_id = str(state.get("local_user_id") or "").strip()
+integration_id = str(state.get("integration_id") or "").strip()
+directory_account_id = str(state.get("directory_account_id") or "").strip()
+for val in (run_id, local_user_id, integration_id, directory_account_id):
+    if not uuid_re.fullmatch(val):
+        raise SystemExit(5)
+live_user = pathlib.Path(live_user_path).read_bytes().decode("utf-8").strip()
+live_integ = pathlib.Path(live_integ_path).read_bytes().decode("utf-8").strip()
+live_acct = pathlib.Path(live_acct_path).read_bytes().decode("utf-8").strip()
+if live_user != local_user_id or live_integ != integration_id or live_acct != directory_account_id:
+    raise SystemExit(6)
+sec = pathlib.Path(sec_dir)
+sec.mkdir(parents=True, exist_ok=True)
+(sec / "subject.sync-run-id").write_bytes(run_id.encode("utf-8"))
+os.chmod(sec / "subject.sync-run-id", 0o600)
+# Ensure local/integ files match journal for ledger query.
+(sec / "subject.local-user-id").write_bytes(local_user_id.encode("utf-8"))
+os.chmod(sec / "subject.local-user-id", 0o600)
+(sec / "subject.integration-id").write_bytes(integration_id.encode("utf-8"))
+os.chmod(sec / "subject.integration-id", 0o600)
+PY
+  CANARY_SUBJECT_SYNC_RUN_ID_FILE="${sec_dir}/subject.sync-run-id"
+  CANARY_SUBJECT_LOCAL_USER_ID_FILE="${sec_dir}/subject.local-user-id"
+  CANARY_SUBJECT_INTEGRATION_ID_FILE="${sec_dir}/subject.integration-id"
+  SYNC_DEPROVISION_APPLIED="true"
+  if ! verify_deprovision_ledger_for_subject; then
+    log "reconcile prepared/run_bound→ledger_bound refused: ledger note=${LEDGER_NOTE:-unset} (exact reserved run only; no sole-event guess)"
+    return 1
+  fi
+  if ! journal_upgrade_ledger_bound; then
+    log "reconcile prepared/run_bound→ledger_bound refused: journal upgrade failed"
+    return 1
+  fi
+  log "reconcile prepared/run_bound→ledger_bound OK (exact reserved run bound; ids never logged)"
+  return 0
+}
+
+# Load host journal for restore. Accepts ledger_bound; prepared/run_bound first
+# reconcile only the pre-request reserved run UUID. Never auto-discovers events.
+load_deprovision_apply_state() {
+  [[ -f "$CANARY_APPLY_STATE_FILE" && -s "$CANARY_APPLY_STATE_FILE" ]] \
+    || fail "deprovision restore refused: recovery journal missing (run apply phase first); no event auto-discovery"
+  [[ -n "${CANARY_SUBJECT_LOCAL_USER_ID_FILE:-}" && -s "${CANARY_SUBJECT_LOCAL_USER_ID_FILE}" ]] \
+    || fail "deprovision restore refused: live local user id missing for state rebind"
+  [[ -n "${CANARY_SUBJECT_INTEGRATION_ID_FILE:-}" && -s "${CANARY_SUBJECT_INTEGRATION_ID_FILE}" ]] \
+    || fail "deprovision restore refused: live integration id missing for state rebind"
+  [[ -n "${CANARY_DIRECTORY_ACCOUNT_ID_FILE:-}" && -s "${CANARY_DIRECTORY_ACCOUNT_ID_FILE}" ]] \
+    || fail "deprovision restore refused: live directory account id missing for state rebind"
+  _journal_read_phase
+  if [[ "$JOURNAL_PHASE" == "prepared" || "$JOURNAL_PHASE" == "run_bound" ]]; then
+    log "recovery journal phase=${JOURNAL_PHASE}; attempting exact reserved-run reconcile to ledger_bound"
+    if ! reconcile_run_journal_to_ledger_bound; then
+      fail "deprovision restore refused: journal phase=${JOURNAL_PHASE} and exact-run ledger reconcile failed (note=${LEDGER_NOTE:-unset}); recovery_required=true; no latest/sole-event guess"
+    fi
+  fi
+  _journal_read_phase
+  if [[ "$JOURNAL_PHASE" != "ledger_bound" ]]; then
+    fail "deprovision restore refused: journal phase must reconcile to ledger_bound (got '${JOURNAL_PHASE}'); no auto-discovery"
+  fi
+  local sec_dir loaded_count
+  sec_dir="$(_subject_secret_dir)"
+  loaded_count="$(
+    python3 - \
+      "$CANARY_APPLY_STATE_FILE" \
+      "$sec_dir" \
+      "$SUBJECT_OWNER_USERNAME" \
+      "$CANARY_SUBJECT_LOCAL_USER_ID_FILE" \
+      "$CANARY_SUBJECT_INTEGRATION_ID_FILE" \
+      "$CANARY_DIRECTORY_ACCOUNT_ID_FILE" <<'PY'
+import json, os, pathlib, re, sys
+(
+    state_path, sec_dir, subject_key,
+    live_user_path, live_integ_path, live_acct_path,
+) = sys.argv[1:7]
+uuid_re = re.compile(
+    r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+)
+CLOSED = frozenset({"membership_changed", "grant_changed", "user_changed"})
+try:
+    state = json.loads(pathlib.Path(state_path).read_bytes().decode("utf-8"))
+except Exception:
+    raise SystemExit(2)
+if not isinstance(state, dict) or state.get("schema") != "lifecycle-canary-deprovision-apply-state-v4":
+    raise SystemExit(3)
+if state.get("subject_key") != subject_key:
+    raise SystemExit(4)
+if state.get("phase") != "ledger_bound":
+    raise SystemExit(15)
+run_id = str(state.get("sync_run_id") or "").strip()
+event_id = str(state.get("event_id") or "").strip()
+local_user_id = str(state.get("local_user_id") or "").strip()
+integration_id = str(state.get("integration_id") or "").strip()
+directory_account_id = str(state.get("directory_account_id") or "").strip()
+effects = state.get("effects")
+count = state.get("effect_count")
+for val in (run_id, event_id, local_user_id, integration_id, directory_account_id):
+    if not uuid_re.fullmatch(val):
+        raise SystemExit(5)
+if type(count) is not int or count != 3 or not isinstance(effects, list) or len(effects) != count:
+    raise SystemExit(6)
+live_user = pathlib.Path(live_user_path).read_bytes().decode("utf-8").strip()
+live_integ = pathlib.Path(live_integ_path).read_bytes().decode("utf-8").strip()
+live_acct = pathlib.Path(live_acct_path).read_bytes().decode("utf-8").strip()
+if live_user != local_user_id:
+    raise SystemExit(10)
+if live_integ != integration_id:
+    raise SystemExit(11)
+if live_acct != directory_account_id:
+    raise SystemExit(12)
+seen = set()
+types = []
+for fx in effects:
+    if not isinstance(fx, dict):
+        raise SystemExit(7)
+    fid = str(fx.get("id") or "").strip()
+    ftype = str(fx.get("type") or "").strip()
+    if not uuid_re.fullmatch(fid) or ftype not in CLOSED:
+        raise SystemExit(8)
+    if fid in seen:
+        raise SystemExit(9)
+    seen.add(fid)
+    types.append(ftype)
+    if type(fx.get("before_active")) is not bool or type(fx.get("after_active")) is not bool:
+        raise SystemExit(13)
+    if type(fx.get("grant_row_created")) is not bool:
+        raise SystemExit(14)
+if set(types) != CLOSED:
+    raise SystemExit(16)
+sec = pathlib.Path(sec_dir)
+sec.mkdir(parents=True, exist_ok=True)
+(sec / "subject.sync-run-id").write_bytes(run_id.encode("utf-8"))
+(sec / "subject.deprovision-event-id").write_bytes(event_id.encode("utf-8"))
+(sec / "subject.deprovision-effects.json").write_bytes(
+    json.dumps({"effects": effects, "effect_count": count}, separators=(",", ":")).encode("utf-8")
+)
+for name in ("subject.sync-run-id", "subject.deprovision-event-id", "subject.deprovision-effects.json"):
+    os.chmod(sec / name, 0o600)
+print(str(count))
+PY
+  )" || fail "deprovision restore refused: ledger_bound journal load failed (missing/drift); no event auto-discovery"
+  CANARY_SUBJECT_SYNC_RUN_ID_FILE="${sec_dir}/subject.sync-run-id"
+  CANARY_SUBJECT_DEPROVISION_EVENT_ID_FILE="${sec_dir}/subject.deprovision-event-id"
+  CANARY_SUBJECT_EFFECTS_FILE="${sec_dir}/subject.deprovision-effects.json"
+  LEDGER_EFFECT_COUNT="$loaded_count"
+  JOURNAL_PHASE="ledger_bound"
+  log "loaded recovery journal phase=ledger_bound (exact ids+run+event+effects re-verified; no auto-discovery)"
+}
+
+# POST rehire restore for EXACT event id from apply state only. No discovery.
+# restoredEffectCount must equal persisted effect_count exactly (not merely >0).
+run_deprovision_rehire_restore() {
+  RESTORE_OK="false"
+  RESTORE_NOTE="unset"
+  RESTORE_EFFECT_COUNT="0"
+  [[ -n "${CANARY_SUBJECT_DEPROVISION_EVENT_ID_FILE:-}" && -s "${CANARY_SUBJECT_DEPROVISION_EVENT_ID_FILE}" ]] \
+    || { RESTORE_NOTE="event_id_file_missing_no_discovery"; return 1; }
+  [[ -n "${CANARY_SUBJECT_EFFECTS_FILE:-}" && -s "${CANARY_SUBJECT_EFFECTS_FILE}" ]] \
+    || { RESTORE_NOTE="effects_file_missing"; return 1; }
+  local result
+  result="$(
+    python3 - \
+      "$CANARY_ADMIN_JWT_FILE" \
+      "$STAGING_API_BASE_URL" \
+      "$CANARY_SUBJECT_DEPROVISION_EVENT_ID_FILE" \
+      "$CANARY_SUBJECT_EFFECTS_FILE" <<'PY'
+import json, pathlib, sys, urllib.error, urllib.parse, urllib.request
+
+jwt_path, base, event_path, fx_path = sys.argv[1:5]
+
+def emit(ok, note, effects="0"):
+    print(f"{ok}|{note}|{effects}")
+    raise SystemExit(0)
+
+try:
+    token = pathlib.Path(jwt_path).read_text(encoding="utf-8").strip()
+    event_id = pathlib.Path(event_path).read_bytes().decode("utf-8").strip()
+    fx = json.loads(pathlib.Path(fx_path).read_bytes().decode("utf-8"))
+except Exception:
+    emit("false", "secret_file_read_failed")
+effects = fx.get("effects") if isinstance(fx, dict) else None
+expected = fx.get("effect_count") if isinstance(fx, dict) else None
+if not isinstance(effects, list) or len(effects) < 1:
+    emit("false", "expected_effects_invalid")
+if type(expected) is not int or expected != len(effects):
+    expected = len(effects)
+if expected < 1:
+    emit("false", "expected_effect_count_invalid")
+url = base.rstrip("/") + "/api/admin/directory/deprovision/events/" + urllib.parse.quote(event_id, safe="") + "/restore"
+body = json.dumps({"mode": "rehire"}).encode("utf-8")
+req = urllib.request.Request(
+    url,
+    data=body,
+    headers={
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+    },
+    method="POST",
+)
+try:
+    with urllib.request.urlopen(req, timeout=60) as resp:
+        raw = resp.read().decode("utf-8", errors="replace")
+        code = int(resp.getcode())
+except urllib.error.HTTPError as e:
+    emit("false", f"restore_http_{int(e.code)}")
+except Exception:
+    emit("false", "restore_transport_failed")
+try:
+    payload = json.loads(raw) if raw else {}
+except Exception:
+    emit("false", "restore_bad_json")
+if code != 200 or not isinstance(payload, dict) or payload.get("ok") is not True:
+    emit("false", f"restore_http_{code}")
+data = payload.get("data") if isinstance(payload.get("data"), dict) else {}
+count = data.get("restoredEffectCount")
+if type(count) is not int:
+    count = data.get("restored_effect_count")
+if type(count) is not int:
+    emit("false", "restore_effect_count_invalid")
+# Load-bearing: exact equality with persisted effect_count (not merely >0).
+if count != expected:
+    emit("false", "restore_effect_count_mismatch", str(count))
+emit("true", "restored", str(count))
+PY
+  )" || {
+    RESTORE_NOTE="python_failed"
+    return 1
+  }
+  RESTORE_OK="${result%%|*}"
+  local rest="${result#*|}"
+  RESTORE_NOTE="${rest%%|*}"
+  RESTORE_EFFECT_COUNT="${rest#*|}"
+  if [[ "$RESTORE_OK" == "true" ]]; then
+    log "deprovision rehire restore OK effects=${RESTORE_EFFECT_COUNT}"
+    return 0
+  fi
+  log "deprovision rehire restore refused: note=${RESTORE_NOTE}"
+  return 1
+}
+
+# Read the exact persisted event status from the authoritative table. A paginated
+# "latest 100" list is not an identity lookup and can miss an old committed restore,
+# causing a second non-idempotent POST.
+read_exact_deprovision_event_status() {
+  EXACT_EVENT_STATUS="unknown"
+  [[ -n "${CANARY_SUBJECT_DEPROVISION_EVENT_ID_FILE:-}" && -s "${CANARY_SUBJECT_DEPROVISION_EVENT_ID_FILE}" ]] \
+    || return 1
+  [[ -n "${CANARY_SUBJECT_LOCAL_USER_ID_FILE:-}" && -s "${CANARY_SUBJECT_LOCAL_USER_ID_FILE}" ]] \
+    || return 1
+  [[ -n "${CANARY_SUBJECT_INTEGRATION_ID_FILE:-}" && -s "${CANARY_SUBJECT_INTEGRATION_ID_FILE}" ]] \
+    || return 1
+  local payload result
+  payload="$(python3 - \
+    "$CANARY_SUBJECT_DEPROVISION_EVENT_ID_FILE" \
+    "$CANARY_SUBJECT_LOCAL_USER_ID_FILE" \
+    "$CANARY_SUBJECT_INTEGRATION_ID_FILE" <<'PY'
+import json, pathlib, sys
+event_path, user_path, integration_path = sys.argv[1:4]
+print(json.dumps({
+    "event_id": pathlib.Path(event_path).read_bytes().decode("utf-8").strip(),
+    "user_id": pathlib.Path(user_path).read_bytes().decode("utf-8").strip(),
+    "integration_id": pathlib.Path(integration_path).read_bytes().decode("utf-8").strip(),
+}, separators=(",", ":")))
+PY
+  )" || return 1
+  if ! result="$(printf '%s' "$payload" | docker exec -i "$BACKEND_CONTAINER" node -e '
+const { Client } = require("pg");
+function emit(status) { process.stdout.write(status); process.exit(0); }
+(async () => {
+  let p;
+  try {
+    const chunks = [];
+    for await (const c of process.stdin) chunks.push(c);
+    p = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+  } catch (e) { emit("invalid"); return; }
+  const uuid = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
+  if (!uuid.test(String(p.event_id || "")) || !String(p.user_id || "").trim()
+      || !String(p.integration_id || "").trim()) { emit("invalid"); return; }
+  if (!process.env.DATABASE_URL) { emit("db_error"); return; }
+  const c = new Client({ connectionString: process.env.DATABASE_URL, connectionTimeoutMillis: 10000 });
+  try {
+    await c.connect();
+    const r = await c.query(
+      `SELECT status
+         FROM directory_deprovision_events
+        WHERE id = $1::uuid
+          AND local_user_id = $2
+          AND integration_id = $3
+        LIMIT 2`,
+      [p.event_id, p.user_id, p.integration_id]
+    );
+    if (r.rows.length !== 1) { emit(r.rows.length === 0 ? "missing" : "ambiguous"); return; }
+    const status = String(r.rows[0].status || "").trim();
+    emit(["applied", "fully_resolved", "superseded"].includes(status) ? status : "invalid_status");
+  } catch (e) { emit("db_error"); }
+  finally { try { await c.end(); } catch (e2) {} }
+})().catch(() => emit("db_error"));
+')"; then
+    return 1
+  fi
+  EXACT_EVENT_STATUS="$(printf '%s\n' "$result" | tail -n1 | tr -d '\r')"
+  case "$EXACT_EVENT_STATUS" in
+    applied|fully_resolved|superseded) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# After restore: exact event must be fully_resolved; live effect id set must equal
+# persisted set exactly (length+ids); each type match and status exactly reversed.
+# extra / missing / duplicate / non-reversed all fail closed.
+verify_deprovision_event_resolved() {
+  RESOLVED_OK="false"
+  RESOLVED_NOTE="unset"
+  [[ -n "${CANARY_SUBJECT_DEPROVISION_EVENT_ID_FILE:-}" && -s "${CANARY_SUBJECT_DEPROVISION_EVENT_ID_FILE}" ]] \
+    || { RESOLVED_NOTE="event_id_file_missing"; return 1; }
+  [[ -n "${CANARY_SUBJECT_EFFECTS_FILE:-}" && -s "${CANARY_SUBJECT_EFFECTS_FILE}" ]] \
+    || { RESOLVED_NOTE="effects_file_missing"; return 1; }
+  [[ -n "${CANARY_SUBJECT_LOCAL_USER_ID_FILE:-}" && -s "${CANARY_SUBJECT_LOCAL_USER_ID_FILE}" ]] \
+    || { RESOLVED_NOTE="local_user_id_file_missing"; return 1; }
+  [[ -n "${CANARY_SUBJECT_INTEGRATION_ID_FILE:-}" && -s "${CANARY_SUBJECT_INTEGRATION_ID_FILE}" ]] \
+    || { RESOLVED_NOTE="integration_id_file_missing"; return 1; }
+  if ! read_exact_deprovision_event_status; then
+    RESOLVED_NOTE="event_status_probe_${EXACT_EVENT_STATUS:-unknown}"
+    return 1
+  fi
+  case "$EXACT_EVENT_STATUS" in
+    fully_resolved) ;;
+    superseded) RESOLVED_NOTE="event_status_superseded"; return 1 ;;
+    applied) RESOLVED_NOTE="event_not_fully_resolved"; return 1 ;;
+    *) RESOLVED_NOTE="event_status_${EXACT_EVENT_STATUS:-unknown}"; return 1 ;;
+  esac
+  local result
+  result="$(
+    python3 - \
+      "$CANARY_ADMIN_JWT_FILE" \
+      "$STAGING_API_BASE_URL" \
+      "$CANARY_SUBJECT_DEPROVISION_EVENT_ID_FILE" \
+      "$CANARY_SUBJECT_EFFECTS_FILE" \
+      "$CANARY_SUBJECT_LOCAL_USER_ID_FILE" \
+      "$CANARY_SUBJECT_INTEGRATION_ID_FILE" \
+      "$EXACT_EVENT_STATUS" <<'PY'
+import json, pathlib, sys, urllib.error, urllib.parse, urllib.request
+
+jwt_path, base, event_path, fx_path, user_path, integ_path, exact_status = sys.argv[1:8]
+
+def emit(ok, note):
+    print(f"{ok}|{note}")
+    raise SystemExit(0)
+
+def get_json(token, url):
+    req = urllib.request.Request(url, headers={"Authorization": f"Bearer {token}", "Accept": "application/json"}, method="GET")
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            raw = resp.read().decode("utf-8", errors="replace")
+            code = int(resp.getcode())
+    except urllib.error.HTTPError as e:
+        try:
+            body = e.read().decode("utf-8", errors="replace")
+        except Exception:
+            body = ""
+        return int(e.code), None
+    except Exception:
+        return None, None
+    try:
+        return code, json.loads(raw) if raw else {}
+    except Exception:
+        return code, None
+
+try:
+    token = pathlib.Path(jwt_path).read_text(encoding="utf-8").strip()
+    event_id = pathlib.Path(event_path).read_bytes().decode("utf-8").strip()
+    expected = json.loads(pathlib.Path(fx_path).read_bytes().decode("utf-8"))
+    user_id = pathlib.Path(user_path).read_bytes().decode("utf-8").strip()
+    integration_id = pathlib.Path(integ_path).read_bytes().decode("utf-8").strip()
+except Exception:
+    emit("false", "secret_file_read_failed")
+expected_effects = expected.get("effects") if isinstance(expected, dict) else None
+if not isinstance(expected_effects, list) or len(expected_effects) < 1:
+    emit("false", "expected_effects_invalid")
+expected_ids = []
+seen_exp = set()
+for exp in expected_effects:
+    if not isinstance(exp, dict):
+        emit("false", "expected_effects_invalid")
+    eid = str(exp.get("id") or "").strip()
+    etype = str(exp.get("type") or "").strip()
+    if not eid or not etype:
+        emit("false", "expected_effects_invalid")
+    if eid in seen_exp:
+        emit("false", "expected_effect_id_duplicate")
+    seen_exp.add(eid)
+    expected_ids.append(eid)
+
+if exact_status != "fully_resolved":
+    emit("false", f"event_status_{exact_status or 'missing'}")
+
+# Live effects: exact id-set equality with persisted (no extra/missing/duplicate).
+code2, payload2 = get_json(
+    token,
+    base.rstrip("/") + "/api/admin/directory/deprovision/events/"
+    + urllib.parse.quote(event_id, safe="") + "/effects",
+)
+if code2 != 200 or not isinstance(payload2, dict) or payload2.get("ok") is not True:
+    emit("false", f"effects_http_{code2 if code2 is not None else 'na'}")
+data2 = payload2.get("data") if isinstance(payload2.get("data"), dict) else {}
+effects = data2.get("items") if isinstance(data2.get("items"), list) else []
+if not effects:
+    emit("false", "effects_empty_after_restore")
+by_id = {}
+for fx in effects:
+    if not isinstance(fx, dict):
+        emit("false", "effect_not_object")
+    fx_id = str(fx.get("id") or "").strip()
+    if not fx_id:
+        emit("false", "effect_id_missing")
+    if fx_id in by_id:
+        emit("false", "effect_id_duplicate_live")
+    by_id[fx_id] = fx
+# Exact set equality: same length and same ids.
+if len(by_id) != len(expected_effects):
+    if len(by_id) > len(expected_effects):
+        emit("false", "effect_extra_live")
+    emit("false", "effect_missing_after_restore")
+for exp in expected_effects:
+    eid = str(exp.get("id") or "").strip()
+    etype = str(exp.get("type") or "").strip()
+    if eid not in by_id:
+        emit("false", "effect_missing_after_restore")
+    live = by_id[eid]
+    live_type = str(live.get("effect_type") or live.get("effectType") or "").strip()
+    if live_type != etype:
+        emit("false", "effect_type_mismatch")
+    live_st = live.get("status")
+    if type(live_st) is not str or live_st != "reversed":
+        emit("false", "effect_not_reversed")
+# Any live id not in expected is already caught by length+set equality above.
+for live_id in by_id:
+    if live_id not in seen_exp:
+        emit("false", "effect_extra_live")
+emit("true", "fully_resolved_all_reversed")
+PY
+  )" || {
+    RESOLVED_NOTE="python_failed"
+    return 1
+  }
+  RESOLVED_OK="${result%%|*}"
+  RESOLVED_NOTE="${result#*|}"
+  if [[ "$RESOLVED_OK" == "true" ]]; then
+    log "deprovision event fully_resolved + exact effect set reversed OK"
+    return 0
+  fi
+  log "deprovision event resolve check refused: note=${RESOLVED_NOTE}"
+  return 1
+}
+
+# Idempotent runner-side restore recovery. A previous restore request may have
+# committed while its response or the following verification was lost. Probe the
+# exact persisted event first: fully_resolved means resume verification without a
+# second non-idempotent POST; only the exact applied-state note may call restore.
+run_or_resume_deprovision_rehire_restore() {
+  RESTORE_RESUMED_FULLY_RESOLVED="false"
+  if verify_deprovision_event_resolved; then
+    RESTORE_RESUMED_FULLY_RESOLVED="true"
+    RESTORE_OK="true"
+    RESTORE_NOTE="already_fully_resolved"
+    RESTORE_EFFECT_COUNT="${LEDGER_EFFECT_COUNT:-0}"
+    log "deprovision restore resume: exact event already fully_resolved; skipping duplicate POST"
+    return 0
+  fi
+  if [[ "${RESOLVED_NOTE:-unset}" != "event_not_fully_resolved" ]]; then
+    RESTORE_NOTE="pre_restore_event_probe_${RESOLVED_NOTE:-unset}"
+    return 1
+  fi
+  if ! run_deprovision_rehire_restore; then
+    return 1
+  fi
+  if ! verify_deprovision_event_resolved; then
+    RESTORE_NOTE="post_restore_event_probe_${RESOLVED_NOTE:-unset}"
+    return 1
+  fi
+  return 0
+}
+
+# Authoritative access-graph proof via read-only SQL in staging backend (DATABASE_URL).
+# Never prints user/ids/PII. expect_mode: deprovisioned | restored.
+# Effect-metadata driven (membership_changed|grant_changed|user_changed):
+#   deprovisioned → current == after_active; restored → current == before_active.
+# Membership is org-scoped: resolve unique org_id from exact integration
+# (provider=dingtalk, status=active), then
+#   WHERE user_id=$1 AND org_id=$2 AND COALESCE(is_active,TRUE)=TRUE.
+# Without a corresponding effect, that leg is not required/claimed.
+# DB read failure / unknown → fail closed.
+prove_access_graph_state() {
+  local expect_mode="$1" context="${2:-deprovision}"
+  GRAPH_OK="false"
+  GRAPH_NOTE="unset"
+  GRAPH_USER_ACTIVE="unknown"
+  GRAPH_MEMBERSHIP_ACTIVE_COUNT="0"
+  GRAPH_GRANT_STATE="unknown"
+  [[ -n "${CANARY_SUBJECT_LOCAL_USER_ID_FILE:-}" && -s "${CANARY_SUBJECT_LOCAL_USER_ID_FILE}" ]] \
+    || { GRAPH_NOTE="local_user_id_file_missing"; return 1; }
+  [[ -n "${CANARY_SUBJECT_INTEGRATION_ID_FILE:-}" && -s "${CANARY_SUBJECT_INTEGRATION_ID_FILE}" ]] \
+    || { GRAPH_NOTE="integration_id_file_missing"; return 1; }
+  [[ -n "${CANARY_SUBJECT_EFFECTS_FILE:-}" && -s "${CANARY_SUBJECT_EFFECTS_FILE}" ]] \
+    || { GRAPH_NOTE="effects_file_missing"; return 1; }
+  local payload_json result
+  payload_json="$(
+    python3 - \
+      "$CANARY_SUBJECT_LOCAL_USER_ID_FILE" \
+      "$CANARY_SUBJECT_INTEGRATION_ID_FILE" \
+      "$CANARY_SUBJECT_EFFECTS_FILE" \
+      "$expect_mode" <<'PY'
+import json, pathlib, sys
+user_path, integ_path, fx_path, mode = sys.argv[1:5]
+user_id = pathlib.Path(user_path).read_bytes().decode("utf-8").strip()
+integration_id = pathlib.Path(integ_path).read_bytes().decode("utf-8").strip()
+fx = json.loads(pathlib.Path(fx_path).read_bytes().decode("utf-8"))
+effects = fx.get("effects") if isinstance(fx, dict) else None
+if not isinstance(effects, list) or len(effects) < 1:
+    raise SystemExit(2)
+print(json.dumps({
+    "user_id": user_id,
+    "integration_id": integration_id,
+    "mode": mode,
+    "effects": effects,
+}, separators=(",", ":")))
+PY
+  )" || { GRAPH_NOTE="graph_payload_build_failed"; return 1; }
+  if ! result="$(printf '%s' "$payload_json" | docker exec -i \
+    "$BACKEND_CONTAINER" \
+    node -e '
+const { Client } = require("pg");
+function emit(ok, note, userActive, memCount, grantState) {
+  process.stdout.write([ok, note, userActive, memCount, grantState].join("|"));
+  process.exit(0);
+}
+(async () => {
+  let payload;
+  try {
+    const chunks = [];
+    for await (const c of process.stdin) chunks.push(c);
+    payload = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+  } catch (e) {
+    emit("false", "graph_payload_invalid", "unknown", "0", "unknown");
+    return;
+  }
+  const mode = String(payload.mode || "");
+  const userId = String(payload.user_id || "").trim();
+  const integrationId = String(payload.integration_id || "").trim();
+  const effects = Array.isArray(payload.effects) ? payload.effects : null;
+  if (!/^[0-9a-fA-F-]{36}$/.test(userId) || !/^[0-9a-fA-F-]{36}$/.test(integrationId)) {
+    emit("false", "graph_ids_invalid", "unknown", "0", "unknown");
+    return;
+  }
+  if (!effects || effects.length < 1) {
+    emit("false", "graph_effects_invalid", "unknown", "0", "unknown");
+    return;
+  }
+  if (mode !== "deprovisioned" && mode !== "restored") {
+    emit("false", "expect_mode_invalid", "unknown", "0", "unknown");
+    return;
+  }
+  const CLOSED = new Set(["membership_changed", "grant_changed", "user_changed"]);
+  const seen = new Set();
+  for (const fx of effects) {
+    if (!fx || typeof fx !== "object") {
+      emit("false", "graph_effects_invalid", "unknown", "0", "unknown");
+      return;
+    }
+    const id = String(fx.id || "").trim();
+    const type = String(fx.type || "").trim();
+    if (!/^[0-9a-fA-F-]{36}$/.test(id) || !CLOSED.has(type)) {
+      emit("false", "graph_effect_type_invalid", "unknown", "0", "unknown");
+      return;
+    }
+    if (seen.has(id)) {
+      emit("false", "graph_effect_id_duplicate", "unknown", "0", "unknown");
+      return;
+    }
+    seen.add(id);
+    if (typeof fx.before_active !== "boolean" || typeof fx.after_active !== "boolean") {
+      emit("false", "graph_effect_flags_invalid", "unknown", "0", "unknown");
+      return;
+    }
+    if (typeof fx.grant_row_created !== "boolean") {
+      emit("false", "graph_effect_flags_invalid", "unknown", "0", "unknown");
+      return;
+    }
+  }
+  const url = process.env.DATABASE_URL;
+  if (!url) {
+    emit("false", "database_url_missing", "unknown", "0", "unknown");
+    return;
+  }
+  const c = new Client({ connectionString: url, connectionTimeoutMillis: 10000 });
+  try {
+    await c.connect();
+    // Exact integration → unique org (provider=dingtalk, prefer active).
+    const integ = await c.query(
+      "SELECT org_id, status FROM directory_integrations WHERE id = $1 AND provider = $2",
+      [integrationId, "dingtalk"]
+    );
+    if (integ.rows.length !== 1) {
+      emit("false", "integration_org_not_unique", "unknown", "0", "unknown");
+      return;
+    }
+    const orgId = String(integ.rows[0].org_id || "").trim();
+    const integStatus = String(integ.rows[0].status || "").trim().toLowerCase();
+    if (!orgId) {
+      emit("false", "integration_org_missing", "unknown", "0", "unknown");
+      return;
+    }
+    if (integStatus !== "active") {
+      emit("false", "integration_not_active", "unknown", "0", "unknown");
+      return;
+    }
+    const u = await c.query(
+      "SELECT is_active FROM users WHERE id = $1",
+      [userId]
+    );
+    if (u.rows.length !== 1) {
+      emit("false", "user_row_missing", "unknown", "0", "unknown");
+      return;
+    }
+    const isActive = u.rows[0].is_active;
+    if (typeof isActive !== "boolean") {
+      emit("false", "user_is_active_not_boolean", "unknown", "0", "unknown");
+      return;
+    }
+    // Org-scoped membership only — other-org active memberships must not green this.
+    const m = await c.query(
+      "SELECT count(*)::int AS n FROM user_orgs WHERE user_id = $1 AND org_id = $2 AND COALESCE(is_active, TRUE) = TRUE",
+      [userId, orgId]
+    );
+    const memN = Number(m.rows[0]?.n);
+    if (!Number.isInteger(memN) || memN < 0) {
+      emit("false", "membership_count_invalid", isActive ? "true" : "false", "0", "unknown");
+      return;
+    }
+    const memActive = memN > 0;
+    const g = await c.query(
+      "SELECT enabled FROM user_external_auth_grants WHERE local_user_id = $1 AND provider = $2 LIMIT 2",
+      [userId, "dingtalk"]
+    );
+    let grantState = "absent";
+    if (g.rows.length > 1) {
+      emit("false", "grant_ambiguous", isActive ? "true" : "false", String(memN), "unknown");
+      return;
+    }
+    if (g.rows.length === 1) {
+      if (typeof g.rows[0].enabled !== "boolean") {
+        emit("false", "grant_enabled_not_boolean", isActive ? "true" : "false", String(memN), "unknown");
+        return;
+      }
+      grantState = g.rows[0].enabled === true ? "enabled" : "disabled";
+    }
+    // Effect-driven proofs only — no free-floating leg requirements.
+    for (const fx of effects) {
+      const expected = mode === "deprovisioned" ? fx.after_active : fx.before_active;
+      if (fx.type === "user_changed") {
+        if (isActive !== expected) {
+          emit("false", mode === "deprovisioned" ? "user_active_not_after" : "user_active_not_before",
+            isActive ? "true" : "false", String(memN), grantState);
+          return;
+        }
+      } else if (fx.type === "membership_changed") {
+        if (memActive !== expected) {
+          emit("false", mode === "deprovisioned" ? "membership_active_not_after" : "membership_active_not_before",
+            isActive ? "true" : "false", String(memN), grantState);
+          return;
+        }
+      } else if (fx.type === "grant_changed") {
+        if (fx.grant_row_created === true) {
+          if (mode === "deprovisioned") {
+            // after: deny-row exists and is disabled
+            if (g.rows.length !== 1 || g.rows[0].enabled !== false) {
+              emit("false", "grant_row_created_not_after", isActive ? "true" : "false", String(memN), grantState);
+              return;
+            }
+          } else {
+            // restore of creation: row must be ABSENT
+            if (g.rows.length !== 0) {
+              emit("false", "grant_row_created_not_absent", isActive ? "true" : "false", String(memN), grantState);
+              return;
+            }
+          }
+        } else {
+          const enabled = g.rows.length === 1 && g.rows[0].enabled === true;
+          if (enabled !== expected) {
+            emit("false", mode === "deprovisioned" ? "grant_enabled_not_after" : "grant_enabled_not_before",
+              isActive ? "true" : "false", String(memN), grantState);
+            return;
+          }
+        }
+      } else {
+        emit("false", "graph_effect_type_invalid", "unknown", "0", "unknown");
+        return;
+      }
+    }
+    emit("true", "ok", isActive ? "true" : "false", String(memN), grantState);
+  } catch (e) {
+    emit("false", "db_query_failed", "unknown", "0", "unknown");
+  } finally {
+    try { await c.end(); } catch (e2) { /* ignore */ }
+  }
+})().catch(() => emit("false", "db_query_failed", "unknown", "0", "unknown"));
+')"; then
+    GRAPH_NOTE="docker_exec_failed"
+    return 1
+  fi
+  result="$(printf '%s\n' "$result" | tail -n1 | tr -d '\r')"
+  GRAPH_OK="${result%%|*}"
+  local rest="${result#*|}"
+  GRAPH_NOTE="${rest%%|*}"
+  rest="${rest#*|}"
+  GRAPH_USER_ACTIVE="${rest%%|*}"
+  rest="${rest#*|}"
+  GRAPH_MEMBERSHIP_ACTIVE_COUNT="${rest%%|*}"
+  GRAPH_GRANT_STATE="${rest#*|}"
+  if [[ "$GRAPH_OK" == "true" ]]; then
+    log "access graph OK (${context}): mode=${expect_mode} user_active=${GRAPH_USER_ACTIVE} membership_active_count=${GRAPH_MEMBERSHIP_ACTIVE_COUNT} grant=${GRAPH_GRANT_STATE}"
+    return 0
+  fi
+  log "access graph refused (${context}): note=${GRAPH_NOTE}"
+  return 1
+}
+
+# Read-only dedicated-subject precondition BEFORE any deprovision env write.
+# Mirrors production planner inputs for mark_inactive + globally clear + grant enabled:
+# exact integration (dingtalk active) org, linked account/user, target-org membership
+# active, user active, no other active+linked siblings, DingTalk grant enabled,
+# policy=mark_inactive. Additionally requires a scheduler/admission/group-disabled
+# integration containing exactly this one directory account (active or inactive rows
+# count), so a post-preview scope change cannot strand collateral users outside the
+# one-subject journal. Expected effects: membership_changed+grant_changed+user_changed.
+# other-org membership is ignored for candidacy (org-scoped membership only).
+prove_dedicated_subject_deprovision_precondition() {
+  PRECOND_OK="false"
+  PRECOND_NOTE="unset"
+  [[ -n "${CANARY_SUBJECT_LOCAL_USER_ID_FILE:-}" && -s "${CANARY_SUBJECT_LOCAL_USER_ID_FILE}" ]] \
+    || { PRECOND_NOTE="local_user_id_file_missing"; return 1; }
+  [[ -n "${CANARY_SUBJECT_INTEGRATION_ID_FILE:-}" && -s "${CANARY_SUBJECT_INTEGRATION_ID_FILE}" ]] \
+    || { PRECOND_NOTE="integration_id_file_missing"; return 1; }
+  [[ -n "${CANARY_DIRECTORY_ACCOUNT_ID_FILE:-}" && -s "${CANARY_DIRECTORY_ACCOUNT_ID_FILE}" ]] \
+    || { PRECOND_NOTE="directory_account_id_file_missing"; return 1; }
+  local payload_json result
+  payload_json="$(
+    python3 - \
+      "$CANARY_SUBJECT_LOCAL_USER_ID_FILE" \
+      "$CANARY_SUBJECT_INTEGRATION_ID_FILE" \
+      "$CANARY_DIRECTORY_ACCOUNT_ID_FILE" <<'PY'
+import json, pathlib, sys
+u, i, a = sys.argv[1:4]
+print(json.dumps({
+    "user_id": pathlib.Path(u).read_bytes().decode("utf-8").strip(),
+    "integration_id": pathlib.Path(i).read_bytes().decode("utf-8").strip(),
+    "directory_account_id": pathlib.Path(a).read_bytes().decode("utf-8").strip(),
+}, separators=(",", ":")))
+PY
+  )" || { PRECOND_NOTE="precond_payload_failed"; return 1; }
+  if ! result="$(printf '%s' "$payload_json" | docker exec -i \
+    "$BACKEND_CONTAINER" \
+    node -e '
+const { Client } = require("pg");
+function emit(ok, note) {
+  process.stdout.write(ok + "|" + note);
+  process.exit(0);
+}
+(async () => {
+  let p;
+  try {
+    const chunks = [];
+    for await (const c of process.stdin) chunks.push(c);
+    p = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+  } catch (e) {
+    emit("false", "precond_payload_invalid");
+    return;
+  }
+  const userId = String(p.user_id || "").trim();
+  const integrationId = String(p.integration_id || "").trim();
+  const accountId = String(p.directory_account_id || "").trim();
+  const uuid = /^[0-9a-fA-F-]{36}$/;
+  if (!uuid.test(userId) || !uuid.test(integrationId) || !uuid.test(accountId)) {
+    emit("false", "precond_ids_invalid");
+    return;
+  }
+  const url = process.env.DATABASE_URL;
+  if (!url) {
+    emit("false", "database_url_missing");
+    return;
+  }
+  const c = new Client({ connectionString: url, connectionTimeoutMillis: 10000 });
+  try {
+    await c.connect();
+    const integ = await c.query(
+      "SELECT org_id, status, default_deprovision_policy, sync_enabled, schedule_cron, config FROM directory_integrations WHERE id = $1 AND provider = $2",
+      [integrationId, "dingtalk"]
+    );
+    if (integ.rows.length !== 1) {
+      emit("false", "integration_not_unique");
+      return;
+    }
+    const orgId = String(integ.rows[0].org_id || "").trim();
+    const status = String(integ.rows[0].status || "").trim().toLowerCase();
+    const policy = String(integ.rows[0].default_deprovision_policy || "").trim();
+    if (!orgId) {
+      emit("false", "integration_org_missing");
+      return;
+    }
+    if (status !== "active") {
+      emit("false", "integration_not_active");
+      return;
+    }
+    if (policy !== "mark_inactive") {
+      emit("false", "policy_not_mark_inactive");
+      return;
+    }
+    if (integ.rows[0].sync_enabled !== false || String(integ.rows[0].schedule_cron || "").trim() !== "") {
+      emit("false", "integration_not_manual_only");
+      return;
+    }
+    let config = integ.rows[0].config;
+    if (typeof config === "string") {
+      try { config = JSON.parse(config); } catch (e) { config = null; }
+    }
+    if (!config || typeof config !== "object"
+        || String(config.admissionMode || "manual_only") !== "manual_only"
+        || String(config.memberGroupSyncMode || "disabled") !== "disabled") {
+      emit("false", "integration_automation_not_disabled");
+      return;
+    }
+    // A destructive canary is never allowed on a shared real-employee integration.
+    // Count ALL rows, not only active rows: a stale/inactive sibling can be revived or
+    // rewritten by the provider walk and would escape the one-subject recovery journal.
+    const radius = await c.query(
+      `SELECT count(*)::int AS n,
+              count(*) FILTER (WHERE id = $2)::int AS target_n
+         FROM directory_accounts
+        WHERE integration_id = $1`,
+      [integrationId, accountId]
+    );
+    if (Number(radius.rows[0]?.n) !== 1 || Number(radius.rows[0]?.target_n) !== 1) {
+      emit("false", "integration_not_single_account");
+      return;
+    }
+    // Exact linked account/user for this integration.
+    const link = await c.query(
+      `SELECT 1
+         FROM directory_account_links l
+         JOIN directory_accounts a ON a.id = l.directory_account_id
+        WHERE l.directory_account_id = $1
+          AND l.local_user_id = $2
+          AND l.link_status = '\''linked'\''
+          AND a.integration_id = $3
+          AND a.is_active = TRUE
+        LIMIT 1`,
+      [accountId, userId, integrationId]
+    );
+    if (link.rows.length !== 1) {
+      emit("false", "account_not_linked_active");
+      return;
+    }
+    const u = await c.query("SELECT is_active FROM users WHERE id = $1", [userId]);
+    if (u.rows.length !== 1 || u.rows[0].is_active !== true) {
+      emit("false", "user_not_active");
+      return;
+    }
+    // Target-org membership active (other-org membership does not satisfy this).
+    const mem = await c.query(
+      "SELECT count(*)::int AS n FROM user_orgs WHERE user_id = $1 AND org_id = $2 AND COALESCE(is_active, TRUE) = TRUE",
+      [userId, orgId]
+    );
+    if (Number(mem.rows[0]?.n) < 1) {
+      emit("false", "target_org_membership_not_active");
+      return;
+    }
+    // Global clear: no other active+linked sibling directory accounts.
+    const sib = await c.query(
+      `SELECT count(*)::int AS n
+         FROM directory_account_links l
+         JOIN directory_accounts a ON a.id = l.directory_account_id
+        WHERE l.local_user_id = $1
+          AND l.link_status = '\''linked'\''
+          AND a.is_active = TRUE
+          AND a.id <> $2`,
+      [userId, accountId]
+    );
+    if (Number(sib.rows[0]?.n) !== 0) {
+      emit("false", "not_globally_clear");
+      return;
+    }
+    const g = await c.query(
+      "SELECT enabled FROM user_external_auth_grants WHERE local_user_id = $1 AND provider = $2 LIMIT 2",
+      [userId, "dingtalk"]
+    );
+    if (g.rows.length !== 1 || g.rows[0].enabled !== true) {
+      emit("false", "dingtalk_grant_not_enabled");
+      return;
+    }
+    // Planner expectation locked for this dedicated canary.
+    emit("true", "ok_expected_effects_membership_grant_user");
+  } catch (e) {
+    emit("false", "db_query_failed");
+  } finally {
+    try { await c.end(); } catch (e2) { /* ignore */ }
+  }
+})().catch(() => emit("false", "db_query_failed"));
+')"; then
+    PRECOND_NOTE="docker_exec_failed"
+    return 1
+  fi
+  result="$(printf '%s\n' "$result" | tail -n1 | tr -d '\r')"
+  PRECOND_OK="${result%%|*}"
+  PRECOND_NOTE="${result#*|}"
+  if [[ "$PRECOND_OK" == "true" ]]; then
+    log "dedicated subject precondition OK (single-account manual integration+planner mark_inactive+global_clear+grant_enabled; expected effects membership+grant+user; ids never logged)"
+    return 0
+  fi
+  log "dedicated subject precondition refused: note=${PRECOND_NOTE}"
+  return 1
+}
+
 validate_mode_name() {
   local m="$1" label="$2"
   case "$m" in
@@ -1572,10 +4078,10 @@ write_lifecycle_override() {
     echo "# OFF is an emergency operational rollback of these env gates only —"
     echo "# it does NOT reintroduce OR-column login fallback as a long-term design"
     echo "# (design lock Rev 4.2 §4.2 / §4.4: after T2b cutover, Auth reads aliases only)."
-    echo "# action=alias may write AUTH_LOGIN_USE_ALIASES=true transiently; success"
+    echo "# action=alias|pending|deprovision may write one flag true transiently; success"
     echo "# requires/proves OFF; failure restores the compose-validated explicit OFF"
     echo "# rollback baseline (never a stale on-disk prior file). Runtime OFF cannot be"
-    echo "# proven if rollback recreate fails. pending/deprovision ON remain NOT EXECUTABLE."
+    echo "# proven if rollback recreate fails."
     echo "services:"
     echo "  backend:"
     echo "    environment:"
@@ -1659,6 +4165,28 @@ assert_exact_mode_alias() {
   return 1
 }
 
+assert_exact_mode_pending() {
+  local a p d m
+  read -r a p d m <<< "$(read_live_flags)"
+  if [[ "$a" == "false" && "$p" == "true" && "$d" == "false" && "$m" == "pending" ]]; then
+    log "exact mode proven after restart: pending (only DIRECTORY_PENDING_ACTIVATION_ENABLED true)"
+    return 0
+  fi
+  log "post-restart mode is '${m}' (alias=${a} pending=${p} deprovision=${d}), expected pending with only pending true"
+  return 1
+}
+
+assert_exact_mode_deprovision() {
+  local a p d m
+  read -r a p d m <<< "$(read_live_flags)"
+  if [[ "$a" == "false" && "$p" == "false" && "$d" == "true" && "$m" == "deprovision" ]]; then
+    log "exact mode proven after restart: deprovision (only DIRECTORY_DEPROVISION_ENABLED true)"
+    return 0
+  fi
+  log "post-restart mode is '${m}' (alias=${a} pending=${p} deprovision=${d}), expected deprovision with only deprovision true"
+  return 1
+}
+
 assert_exact_sha() {
   require_sha
   local live
@@ -1732,13 +4260,59 @@ fail_transition_restore() {
   restore_lifecycle_override
   # Best-effort recreate after restore so live env matches restored override.
   recreate_backend_only || log "restore recreate did not reach health true; operator must inspect staging"
-  if [[ "$ACTION" == "alias" ]]; then
+  if [[ "$ACTION" == "alias" || "$ACTION" == "pending" || "$ACTION" == "deprovision" ]]; then
     # This explicit failure path already attempted runtime restore. Avoid a
     # second EXIT-handler recreate after its backup is cleaned below.
     disarm_alias_exit_rollback_guard
   fi
   cleanup_prev_backup
   fail "action=${ACTION} failed: ${reason} (previous override restored)"
+}
+
+# Deprovision apply failure AFTER a real sync write: restore three flags OFF,
+# keep host recovery journal (never clear), emit values-free recovery markers.
+fail_deprovision_apply_keep_journal() {
+  local reason="$1"
+  _journal_read_phase
+  local phase="${JOURNAL_PHASE:-unknown}"
+  local exact_run="false"
+  if [[ -f "$CANARY_APPLY_STATE_FILE" && -s "$CANARY_APPLY_STATE_FILE" ]]; then
+    if [[ "$phase" == "prepared" || "$phase" == "run_bound" || "$phase" == "ledger_bound" ]]; then
+      exact_run="true"
+    fi
+  fi
+  log "deprovision apply failure (${reason}); restoring flags OFF; retaining recovery journal phase=${phase} exact_run_persisted=${exact_run} (ids never logged)"
+  restore_lifecycle_override
+  recreate_backend_only || log "restore recreate did not reach health true; operator must inspect staging"
+  # Prove OFF before disarming the EXIT guard. If the first restore/recreate did not
+  # converge, keep both the guard and its backup alive: `fail` below will trigger one
+  # final restore/recreate attempt instead of knowingly exiting with deprovision ON.
+  # The recovery journal is independent and remains retained either way.
+  local flags_off="false"
+  if assert_exact_mode_off 2>/dev/null; then
+    flags_off="true"
+    disarm_alias_exit_rollback_guard
+    cleanup_prev_backup
+  else
+    log "flags OFF not proven after keep-journal failure path; EXIT rollback guard remains armed for a final retry"
+  fi
+  capture_live_snapshot 2>/dev/null || true
+  {
+    echo "action=deprovision"
+    echo "phase=apply"
+    echo "mode=${SNAP_MODE:-unknown}"
+    echo "build_sha=${SNAP_BUILD_SHA:-unknown}"
+    echo "transition_applied=true"
+    echo "recovery_required=true"
+    echo "exact_run_persisted=${exact_run}"
+    echo "journal_retained=true"
+    echo "journal_phase=${phase}"
+    echo "rolled_back_flags_off=${flags_off}"
+    echo "apply_completed=false"
+    echo "end_to_end_restore_claimed=false"
+    echo "note=deprovision_apply_failed_recovery_journal_retained_${reason}"
+  } > "${OUTPUT_DIR}/summary.txt" 2>/dev/null || true
+  fail "action=deprovision apply failed: ${reason} (flags restore attempted; recovery journal retained phase=${phase}; recovery_required=true)"
 }
 
 # --- actions ---------------------------------------------------------------------------
@@ -1863,14 +4437,14 @@ preflight_for_target() {
       fi
       ;;
     pending|deprovision)
+      # Stack readiness only. action=pending|deprovision additionally require the
+      # explicit secret-backed directory account subject (no auto-selection) and
+      # real admin API proofs before any write.
       if [[ "$SNAP_MODE" != "off" && "$SNAP_MODE" != "$target" ]]; then
         PREFLIGHT_OK="false"
         PREFLIGHT_NOTE="other_lifecycle_flag_on"
         return 0
       fi
-      # ON is NOT EXECUTABLE (no admit/activate or sync/deprovision proof).
-      PREFLIGHT_OK="false"
-      PREFLIGHT_NOTE="not_executable_no_real_verifier"
       ;;
     multi-on)
       PREFLIGHT_OK="false"
@@ -1906,39 +4480,7 @@ action_preflight() {
   if [[ "$PREFLIGHT_OK" != "true" ]]; then
     fail "preflight failed: ${PREFLIGHT_NOTE}"
   fi
-  # pending/deprovision remain NOT EXECUTABLE ON even when stack looks ready.
-  if [[ "$target" == "pending" || "$target" == "deprovision" ]]; then
-    log "preflight assessed target=${target} note=${PREFLIGHT_NOTE} (ON transition NOT EXECUTABLE)"
-  else
-    log "preflight OK target=${target} note=${PREFLIGHT_NOTE}"
-  fi
-}
-
-# Fail-closed: pending/deprovision never apply. Preflight assessment only.
-action_not_executable_on() {
-  local target="$1"
-  capture_live_snapshot
-  preflight_for_target "$target"
-  # Force not-executable note even if stack would look "ready".
-  local note="not_executable_no_real_verifier"
-  if [[ "$PREFLIGHT_OK" != "true" ]]; then
-    note="${PREFLIGHT_NOTE};not_executable_no_real_verifier"
-  fi
-  write_status_artifact \
-    "${SNAP_BUILD_SHA:-unknown}" \
-    "$SNAP_ALIAS" "$SNAP_PENDING" "$SNAP_DEPROV" "$SNAP_MODE" \
-    "$SNAP_ALIAS_READY" "$SNAP_CAN_ENABLE_ALIAS" \
-    "$SNAP_MIGRATIONS_ZERO" "$SNAP_HEALTH_OK" \
-    "$target" "false" "false" "$note"
-  {
-    echo "action=${target}"
-    echo "mode=${SNAP_MODE}"
-    echo "preflight_ok=false"
-    echo "note=${note}"
-    echo "transition_applied=false"
-    echo "executable=false"
-  } > "${OUTPUT_DIR}/summary.txt"
-  fail "action=${target} is NOT EXECUTABLE: no secret-backed real verifier for canary proof (admit-activate / sync-deprovision). Env flip alone is refused. Use status|preflight|off|bootstrap|human-bootstrap|alias only. transition_applied=false"
+  log "preflight OK target=${target} note=${PREFLIGHT_NOTE}"
 }
 
 # Staging-only create/repair of the fixed dedicated lifecycle canary admin.
@@ -2309,6 +4851,680 @@ action_human_bootstrap() {
   log "action=human-bootstrap OK outcome=${HUMAN_BOOTSTRAP_OUTCOME} (no lifecycle env write; mode/health/SHA/migrations reasserted)"
 }
 
+# Transient secret-backed pending ADMIT canary (phase: admit-only by default).
+# Does NOT auto-activate via temp_password. DingTalk OAuth negative/positive
+# checkpoints are manual NOT_EXECUTED (never claimed true by a wrong-password probe).
+# Optional phase: BOOTSTRAP_CONFIRMATION=PENDING_SSO_ACTIVATE runs SSO activate only
+# (no lifecycle env write); browser OAuth still NOT_EXECUTED.
+# Success for admit phase requires/proves flags OFF. No auto-selection.
+action_pending() {
+  local pre_login_ok="false"
+  local admin_jwt_minted="false"
+  local pending_on_applied="false"
+  local admit_ok="false"
+  local pending_state_ok="false"
+  local rolled_back_to_off="false"
+  local sso_activate_ok="false"
+  local phase="admit"
+  local note="pending_admit_canary"
+  # Honest checkpoints — never true unless real evidence exists.
+  local oauth_negative_checkpoint="NOT_EXECUTED"
+  local oauth_positive_checkpoint="NOT_EXECUTED"
+  local password_login_denied_checkpoint="NOT_EXECUTED"
+  local activate_executed="false"
+
+  require_sha
+  require_canary_secret_files "pending"
+  assert_canary_identifier_matches_owner "pending"
+  require_canary_directory_account_id_file "pending"
+  [[ -n "$EXPECTED_CURRENT_MODE" ]] || fail "expected_current_mode is required for action=pending"
+  [[ "$EXPECTED_CURRENT_MODE" == "off" ]] \
+    || fail "action=pending requires expected_current_mode=off (got '${EXPECTED_CURRENT_MODE}'); refuse auto-selection"
+
+  if [[ -n "${BOOTSTRAP_CONFIRMATION:-}" && "$BOOTSTRAP_CONFIRMATION" != "$PENDING_SSO_ACTIVATE_CONFIRMATION" && "$BOOTSTRAP_CONFIRMATION" != "PENDING_ADMIT" ]]; then
+    fail "action=pending: bootstrap_confirmation must be empty|PENDING_ADMIT|PENDING_SSO_ACTIVATE (got confirmation set; values never log secrets)"
+  fi
+  if [[ "${BOOTSTRAP_CONFIRMATION:-}" == "$PENDING_SSO_ACTIVATE_CONFIRMATION" ]]; then
+    phase="sso_activate"
+  fi
+
+  capture_live_snapshot
+  assert_exact_sha
+  require_migrations_pending_zero_true "$SNAP_MIGRATIONS_ZERO" "action=pending"
+
+  if [[ "$SNAP_HEALTH_OK" != "true" ]]; then
+    fail "action=pending refused: backend_health_ok must be true before mutation"
+  fi
+  if [[ "$SNAP_MODE" != "off" ]]; then
+    fail "action=pending refused: live mode must be off (live='${SNAP_MODE}')"
+  fi
+
+  if mint_canary_admin_jwt_from_password_login "pending_pre"; then
+    pre_login_ok="true"
+    admin_jwt_minted="true"
+  else
+    fail "action=pending refused: canary password login / JWT mint failed (no mutation performed)"
+  fi
+  [[ -n "${CANARY_ADMIN_JWT_FILE:-}" && -s "${CANARY_ADMIN_JWT_FILE}" ]] \
+    || fail "action=pending refused: admin JWT file missing after mint"
+
+  if [[ "$phase" == "sso_activate" ]]; then
+    # --- SSO activate phase: no lifecycle env write; browser OAuth remains NOT_EXECUTED ---
+    if ! load_canary_directory_subject "pending_sso_pre"; then
+      fail "action=pending sso_activate refused: subject load failed (note=${SUBJECT_NOTE:-unset}); no auto-selection"
+    fi
+    if [[ "$SUBJECT_LINK_STATUS" != "linked" || "$SUBJECT_HAS_LOCAL_USER" != "true" \
+      || "$SUBJECT_LOCAL_USERNAME_OK" != "true" || "$SUBJECT_LOCAL_NAME_OK" != "true" ]]; then
+      fail "action=pending sso_activate refused: subject must be owned linked pending user; no auto-selection"
+    fi
+    if ! assert_subject_user_access_state "pending_activation" "false" "sso_pre"; then
+      fail "action=pending sso_activate refused: user must be pending_activation (note=${ACCESS_NOTE:-unset})"
+    fi
+    if ! run_pending_sso_activate; then
+      fail "action=pending sso_activate refused: ${ACTIVATE_NOTE:-unset}"
+    fi
+    sso_activate_ok="true"
+    activate_executed="true"
+    if ! assert_subject_user_access_state "activated" "true" "sso_post"; then
+      fail "action=pending sso_activate refused: post-activate access state failed (note=${ACCESS_NOTE:-unset})"
+    fi
+    # Browser DingTalk OAuth login is human-only; never claim true here.
+    oauth_negative_checkpoint="NOT_EXECUTED"
+    oauth_positive_checkpoint="NOT_EXECUTED"
+    password_login_denied_checkpoint="NOT_EXECUTED"
+    capture_live_snapshot
+    if [[ "$SNAP_MODE" != "off" || "$SNAP_ALIAS" != "false" || "$SNAP_PENDING" != "false" || "$SNAP_DEPROV" != "false" ]]; then
+      fail "action=pending sso_activate refused: lifecycle flags must remain OFF (no env write expected)"
+    fi
+    note="pending_sso_activate_flags_off_oauth_not_executed"
+    write_status_artifact \
+      "${SNAP_BUILD_SHA:-unknown}" \
+      "$SNAP_ALIAS" "$SNAP_PENDING" "$SNAP_DEPROV" "$SNAP_MODE" \
+      "$SNAP_ALIAS_READY" "$SNAP_CAN_ENABLE_ALIAS" \
+      "$SNAP_MIGRATIONS_ZERO" "$SNAP_HEALTH_OK" \
+      "pending" "true" "false" "$note"
+    {
+      echo "action=pending"
+      echo "phase=sso_activate"
+      echo "mode=${SNAP_MODE}"
+      echo "build_sha=${SNAP_BUILD_SHA:-unknown}"
+      echo "transition_applied=false"
+      echo "lifecycle_env_write=false"
+      echo "pre_login_ok=${pre_login_ok}"
+      echo "admin_jwt_minted=${admin_jwt_minted}"
+      echo "subject_owned=true"
+      echo "subject_auto_selected=false"
+      echo "sso_activate_ok=${sso_activate_ok}"
+      echo "activate_executed=${activate_executed}"
+      echo "oauth_negative_checkpoint=${oauth_negative_checkpoint}"
+      echo "oauth_positive_checkpoint=${oauth_positive_checkpoint}"
+      echo "password_login_denied_checkpoint=${password_login_denied_checkpoint}"
+      echo "password_login_denied_ok=false"
+      echo "note=${note}"
+    } > "${OUTPUT_DIR}/summary.txt"
+    log "action=pending SSO activate OK (flags OFF; browser OAuth NOT_EXECUTED)"
+    return 0
+  fi
+
+  # --- Admit phase: temporary pending-only flag, real admit, authoritative pending state ---
+  pin_live_backend_image_for_transition
+  if ! load_canary_directory_subject "pending_pre"; then
+    fail "action=pending refused: explicit subject load failed (note=${SUBJECT_NOTE:-unset}); no env write; no auto-selection"
+  fi
+  if [[ "$SUBJECT_ACTIVE" != "true" ]]; then
+    fail "action=pending refused: subject directory account must be active before admit (note=subject_inactive)"
+  fi
+  if [[ "$SUBJECT_LINK_STATUS" == "linked" ]]; then
+    if [[ "$SUBJECT_HAS_LOCAL_USER" != "true" || "$SUBJECT_LOCAL_USERNAME_OK" != "true" || "$SUBJECT_LOCAL_NAME_OK" != "true" ]]; then
+      fail "action=pending refused: linked subject is not the owned canary employee (collision_not_owned); no auto-selection"
+    fi
+  elif [[ "$SUBJECT_LINK_STATUS" != "unmatched" && "$SUBJECT_LINK_STATUS" != "pending" ]]; then
+    fail "action=pending refused: subject link_status='${SUBJECT_LINK_STATUS}' is not admit-eligible"
+  fi
+
+  establish_alias_off_rollback_baseline
+  arm_alias_exit_rollback_guard
+  write_lifecycle_override "false" "true" "false"
+  pending_on_applied="true"
+
+  if ! recreate_backend_only; then
+    fail_transition_restore "backend_health_not_true_after_restart"
+  fi
+  if [[ "$(resolve_deployed_sha)" != "$DEPLOY_SHA" ]]; then
+    fail_transition_restore "post_restart_sha_mismatch"
+  fi
+  if ! assert_exact_mode_pending; then
+    fail_transition_restore "post_restart_mode_not_pending"
+  fi
+
+  if ! load_canary_directory_subject "pending_on"; then
+    fail_transition_restore "subject_reload_failed_${SUBJECT_NOTE:-unset}"
+  fi
+
+  if [[ "$SUBJECT_LINK_STATUS" == "linked" && "$SUBJECT_HAS_LOCAL_USER" == "true" ]]; then
+    if ! assert_subject_user_access_state "pending_activation" "false" "pre_existing_pending"; then
+      if [[ "$ACCESS_ACTIVATION" == "activated" && "$ACCESS_IS_ACTIVE" == "true" ]]; then
+        fail_transition_restore "subject_already_activated_use_sso_or_deprovision"
+      fi
+      fail_transition_restore "pre_existing_pending_state_failed_${ACCESS_NOTE:-unset}"
+    fi
+    admit_ok="true"
+    ADMIT_NOTE="pre_existing_owned_pending"
+    ADMIT_ACTIVATION_STATUS="pending_activation"
+  else
+    if ! run_pending_admit; then
+      fail_transition_restore "admit_failed_${ADMIT_NOTE:-unset}"
+    fi
+    admit_ok="true"
+  fi
+
+  # Authoritative pending state via admin access API — not a wrong-password login probe.
+  if ! assert_subject_user_access_state "pending_activation" "false" "post_admit"; then
+    fail_transition_restore "pending_state_assert_failed_${ACCESS_NOTE:-unset}"
+  fi
+  pending_state_ok="true"
+  # Pending users have unusable passwords; OAuth blocked/allowed is human-only.
+  password_login_denied_checkpoint="NOT_EXECUTED"
+  oauth_negative_checkpoint="NOT_EXECUTED"
+  oauth_positive_checkpoint="NOT_EXECUTED"
+  activate_executed="false"
+
+  log "pending admit proven; restoring explicit OFF rollback baseline (success requires/proves OFF; canary must not leave pending enabled)"
+  restore_lifecycle_override
+  if ! recreate_backend_only; then
+    fail "action=pending: admit proven but rollback recreate failed — runtime OFF cannot be proven (explicit OFF baseline restored on disk; operator must inspect staging)"
+  fi
+  if [[ "$(resolve_deployed_sha)" != "$DEPLOY_SHA" ]]; then
+    fail "action=pending: rollback SHA mismatch after restore — runtime OFF not fully proven (operator must inspect staging)"
+  fi
+  if ! assert_exact_mode_off; then
+    fail "action=pending: rollback did not prove exact mode=off (operator must inspect staging)"
+  fi
+  if [[ "$(fetch_backend_health_ok)" != "true" ]]; then
+    fail "action=pending: rollback backend health not true — runtime OFF not fully proven (operator must inspect staging)"
+  fi
+  rolled_back_to_off="true"
+  disarm_alias_exit_rollback_guard
+  cleanup_prev_backup
+
+  capture_live_snapshot
+  note="pending_admit_proved_off_oauth_not_executed"
+  write_status_artifact \
+    "${SNAP_BUILD_SHA:-unknown}" \
+    "$SNAP_ALIAS" "$SNAP_PENDING" "$SNAP_DEPROV" "$SNAP_MODE" \
+    "$SNAP_ALIAS_READY" "$SNAP_CAN_ENABLE_ALIAS" \
+    "$SNAP_MIGRATIONS_ZERO" "$SNAP_HEALTH_OK" \
+    "pending" "true" "true" "$note"
+  {
+    echo "action=pending"
+    echo "phase=admit"
+    echo "mode=${SNAP_MODE}"
+    echo "build_sha=${SNAP_BUILD_SHA:-unknown}"
+    echo "transition_applied=true"
+    echo "from_mode=off"
+    echo "to_mode=off"
+    echo "pending_on_applied=${pending_on_applied}"
+    echo "pre_login_ok=${pre_login_ok}"
+    echo "admin_jwt_minted=${admin_jwt_minted}"
+    echo "subject_owned=true"
+    echo "subject_auto_selected=false"
+    echo "admit_ok=${admit_ok}"
+    echo "admit_note=${ADMIT_NOTE:-unset}"
+    echo "pending_state_ok=${pending_state_ok}"
+    echo "activate_executed=${activate_executed}"
+    echo "oauth_negative_checkpoint=${oauth_negative_checkpoint}"
+    echo "oauth_positive_checkpoint=${oauth_positive_checkpoint}"
+    echo "password_login_denied_checkpoint=${password_login_denied_checkpoint}"
+    echo "password_login_denied_ok=false"
+    echo "rolled_back_to_off=${rolled_back_to_off}"
+    echo "note=${note}"
+  } > "${OUTPUT_DIR}/summary.txt"
+  log "action=pending admit OK (transient pending ON proven; admit verified; flags OFF; OAuth/activate NOT_EXECUTED)"
+}
+
+# Deprovision apply phase
+# (confirmation=DINGTALK_SOURCE_DISABLED_DEDICATED_EXCLUSIVE_CONFIRMED):
+#   temporary deprovision-only flag → real sync → exact run.id ledger bind → access denial
+#   → flags OFF. Does NOT restore access. Not an end-to-end rollback canary.
+# Deprovision restore phase (confirmation=DINGTALK_SOURCE_REACTIVATED_CONFIRMED):
+#   flags stay OFF → sync after external source re-enable → rehire restore exact event
+#   → prove event/effects resolved + access restored.
+action_deprovision() {
+  local phase="apply"
+  if [[ "${BOOTSTRAP_CONFIRMATION:-}" == "$DEPROVISION_RESTORE_CONFIRMATION" ]]; then
+    phase="restore"
+  elif [[ "${BOOTSTRAP_CONFIRMATION:-}" == "$DEPROVISION_SOURCE_CONFIRMATION" ]]; then
+    phase="apply"
+  else
+    fail "action=deprovision requires bootstrap_confirmation=${DEPROVISION_SOURCE_CONFIRMATION}|${DEPROVISION_RESTORE_CONFIRMATION}"
+  fi
+
+  if [[ "$phase" == "restore" ]]; then
+    action_deprovision_restore
+    return $?
+  fi
+  action_deprovision_apply
+}
+
+action_deprovision_apply() {
+  local pre_login_ok="false"
+  local admin_jwt_minted="false"
+  local deprovision_on_applied="false"
+  local source_inactive_after_sync="false"
+  local sync_ok="false"
+  local ledger_ok="false"
+  local access_denied_ok="false"
+  local login_denied_ok="false"
+  local login_denied_checkpoint="NOT_EXECUTED"
+  local subject_password_pre_ok="false"
+  local rolled_back_flags_off="false"
+  local note="deprovision_apply_phase"
+  SUBJECT_PASSWORD_PROVEN_OK="false"
+
+  require_sha
+  require_canary_secret_files "deprovision"
+  assert_canary_identifier_matches_owner "deprovision"
+  require_canary_directory_account_id_file "deprovision"
+  [[ -n "$EXPECTED_CURRENT_MODE" ]] || fail "expected_current_mode is required for action=deprovision"
+  [[ "$EXPECTED_CURRENT_MODE" == "off" ]] \
+    || fail "action=deprovision requires expected_current_mode=off (got '${EXPECTED_CURRENT_MODE}'); refuse auto-selection"
+
+  capture_live_snapshot
+  assert_exact_sha
+  pin_live_backend_image_for_transition
+  require_migrations_pending_zero_true "$SNAP_MIGRATIONS_ZERO" "action=deprovision"
+
+  if [[ "$SNAP_HEALTH_OK" != "true" ]]; then
+    fail "action=deprovision apply refused: backend_health_ok must be true before any env write"
+  fi
+  if [[ "$SNAP_MODE" != "off" ]]; then
+    fail "action=deprovision apply refused: live mode must be off (live='${SNAP_MODE}')"
+  fi
+
+  if mint_canary_admin_jwt_from_password_login "deprovision_apply_pre"; then
+    pre_login_ok="true"
+    admin_jwt_minted="true"
+  else
+    fail "action=deprovision apply refused: canary login / JWT mint failed (no env write)"
+  fi
+
+  if ! load_canary_directory_subject "deprovision_apply_pre"; then
+    fail "action=deprovision apply refused: subject load failed (note=${SUBJECT_NOTE:-unset}); no auto-selection"
+  fi
+  if [[ "$SUBJECT_LINK_STATUS" != "linked" || "$SUBJECT_HAS_LOCAL_USER" != "true" ]]; then
+    fail "action=deprovision apply refused: subject must be linked owned local user; no auto-selection"
+  fi
+  if [[ "$SUBJECT_LOCAL_USERNAME_OK" != "true" || "$SUBJECT_LOCAL_NAME_OK" != "true" ]]; then
+    fail "action=deprovision apply refused: linked local user is not owned canary employee; no auto-selection"
+  fi
+  if [[ "$SUBJECT_ACTIVE" != "true" ]]; then
+    fail "action=deprovision apply refused: account already inactive — need this-run active→inactive transition"
+  fi
+  if ! assert_subject_user_access_state "activated" "true" "deprovision_apply_pre"; then
+    fail "action=deprovision apply refused: local user must be activated+active (note=${ACCESS_NOTE:-unset})"
+  fi
+
+  # Optional proven-password checkpoint (never wrong-password).
+  local pass_file=""
+  if pass_file="$(resolve_subject_password_file 2>/dev/null)"; then
+    if prove_subject_password_login "deprovision_pre" "$pass_file"; then
+      subject_password_pre_ok="true"
+      SUBJECT_PASSWORD_PROVEN_OK="true"
+    else
+      fail "action=deprovision apply refused: subject password file present but pre-deprovision login failed (note=${SUBJECT_LOGIN_NOTE:-unset})"
+    fi
+  else
+    login_denied_checkpoint="NOT_EXECUTED"
+    login_denied_ok="false"
+  fi
+
+  # Collateral radius: whole-integration sync/preview BEFORE any deprovision env write.
+  # Require sole would-deactivate (linked) sample matches explicit subject externalUserId.
+  if ! run_deprovision_sync_preview_subject_gate; then
+    fail "action=deprovision apply refused: sync/preview subject gate failed (note=${PREVIEW_NOTE:-unset}); no env write performed; no auto-selection"
+  fi
+
+  # Read-only planner precondition (exact triple effects) before env write.
+  if ! prove_dedicated_subject_deprovision_precondition; then
+    fail "action=deprovision apply refused: dedicated subject precondition failed (note=${PRECOND_NOTE:-unset}); no env write"
+  fi
+
+  # Fail closed: unrecovered prior journal must not be overwritten.
+  refuse_existing_deprovision_apply_state
+  # Create recovery journal phase=prepared BEFORE env write (ids only).
+  journal_init_prepared
+
+  establish_alias_off_rollback_baseline
+  arm_alias_exit_rollback_guard
+  write_lifecycle_override "false" "false" "true"
+  deprovision_on_applied="true"
+
+  if ! recreate_backend_only; then
+    journal_clear_if_phase_prepared
+    fail_transition_restore "backend_health_not_true_after_restart"
+  fi
+  if [[ "$(resolve_deployed_sha)" != "$DEPLOY_SHA" ]]; then
+    journal_clear_if_phase_prepared
+    fail_transition_restore "post_restart_sha_mismatch"
+  fi
+  if ! assert_exact_mode_deprovision; then
+    journal_clear_if_phase_prepared
+    fail_transition_restore "post_restart_mode_not_deprovision"
+  fi
+
+  # Sync may return radius anomaly; run id is still written first for recovery.
+  local sync_rc=0
+  run_directory_sync_for_subject "deprovision_apply" "true" || sync_rc=$?
+  if [[ "$SYNC_RUN_ID_PRESENT" != "true" || -z "${CANARY_SUBJECT_SYNC_RUN_ID_FILE:-}" || ! -s "${CANARY_SUBJECT_SYNC_RUN_ID_FILE}" ]]; then
+    # The reserved UUID was persisted before this POST. A transport failure may mean
+    # the server accepted and applied the run while the 202 was lost; deleting the
+    # prepared journal here would strand access changes with no recovery anchor.
+    fail_deprovision_apply_keep_journal "sync_start_or_response_failed_${SYNC_NOTE:-unset}"
+  fi
+  # ALWAYS upgrade journal to run_bound once the exact run reaches terminal
+  # (counts may be abnormal and ledger is not yet claimed).
+  if ! journal_upgrade_run_bound; then
+    fail_deprovision_apply_keep_journal "journal_upgrade_run_bound_failed"
+  fi
+
+  # Bind ledger (exact run → unique event + exact triple effects) BEFORE radius/graph gates.
+  if ! verify_deprovision_ledger_for_subject; then
+    # Keep phase=run_bound; restore flags; recovery_required (exact run persisted).
+    fail_deprovision_apply_keep_journal "ledger_verify_failed_${LEDGER_NOTE:-unset}"
+  fi
+  [[ "$LEDGER_RUN_MATCH" == "true" ]] \
+    || fail_deprovision_apply_keep_journal "ledger_run_id_not_matched"
+  # Atomic upgrade run_bound → ledger_bound (compat alias persist_deprovision_apply_state).
+  if ! persist_deprovision_apply_state; then
+    fail_deprovision_apply_keep_journal "journal_upgrade_ledger_bound_failed"
+  fi
+  ledger_ok="true"
+
+  # NOW post-sync TOCTOU radius: success requires exact 1/1/1. Failure keeps ledger_bound journal.
+  if [[ "$sync_rc" -ne 0 || "$SYNC_OK" != "true" ]]; then
+    fail_deprovision_apply_keep_journal "sync_radius_or_apply_anomaly_${SYNC_NOTE:-unset}"
+  fi
+  [[ "$SYNC_DEPROVISION_APPLIED" == "true" ]] \
+    || fail_deprovision_apply_keep_journal "deprovision_not_applied_on_sync"
+  [[ "${SYNC_DEPROVISION_CANDIDATES}" == "1" ]] \
+    || fail_deprovision_apply_keep_journal "sync_candidate_radius_not_one"
+  [[ "${SYNC_ACCOUNTS_DEACTIVATED}" == "1" ]] \
+    || fail_deprovision_apply_keep_journal "sync_accounts_deactivated_not_one"
+  [[ "${SYNC_USERS_DEACTIVATED}" == "1" ]] \
+    || fail_deprovision_apply_keep_journal "sync_users_deactivated_not_one"
+  sync_ok="true"
+
+  if ! load_canary_directory_subject "deprovision_post_sync"; then
+    fail_deprovision_apply_keep_journal "subject_reload_failed_${SUBJECT_NOTE:-unset}"
+  fi
+  if [[ "$SUBJECT_ACTIVE" != "false" ]]; then
+    fail_deprovision_apply_keep_journal "source_still_active_after_sync_external_gate"
+  fi
+  source_inactive_after_sync="true"
+
+  if ! assert_subject_user_access_state "activated" "false" "post_deprovision"; then
+    fail_deprovision_apply_keep_journal "access_not_denied_${ACCESS_NOTE:-unset}"
+  fi
+  access_denied_ok="true"
+
+  if ! prove_access_graph_state "deprovisioned" "post_deprovision"; then
+    fail_deprovision_apply_keep_journal "access_graph_not_deprovisioned_${GRAPH_NOTE:-unset}"
+  fi
+
+  if [[ "$SUBJECT_PASSWORD_PROVEN_OK" == "true" ]]; then
+    if ! prove_subject_login_denied_with_proven_password "deprovision_apply"; then
+      fail_deprovision_apply_keep_journal "login_not_denied_after_deprovision_${LOGIN_DENIED_NOTE:-unset}"
+    fi
+    login_denied_ok="true"
+    login_denied_checkpoint="proven_password_denied"
+  else
+    login_denied_ok="false"
+    login_denied_checkpoint="NOT_EXECUTED"
+  fi
+
+  # Flags OFF only — access remains disabled. Journal phase=ledger_bound retained for restore.
+  # NOTE: preview+sync radius checks are NOT an atomic scope lock; real deprovision
+  # may only target a dedicated isolated enterprise/integration — never a shared
+  # integration that holds real employees.
+  log "deprovision apply proven; restoring explicit OFF flags (access remains disabled; journal ledger_bound retained; restore phase required)"
+  restore_lifecycle_override
+  if ! recreate_backend_only; then
+    fail "action=deprovision apply: rollback recreate failed — runtime OFF cannot be proven (operator must inspect staging; journal retained)"
+  fi
+  if [[ "$(resolve_deployed_sha)" != "$DEPLOY_SHA" ]]; then
+    fail "action=deprovision apply: rollback SHA mismatch (operator must inspect staging; journal retained)"
+  fi
+  if ! assert_exact_mode_off; then
+    fail "action=deprovision apply: rollback did not prove exact mode=off (journal retained)"
+  fi
+  if [[ "$(fetch_backend_health_ok)" != "true" ]]; then
+    fail "action=deprovision apply: rollback backend health not true (journal retained)"
+  fi
+  rolled_back_flags_off="true"
+  disarm_alias_exit_rollback_guard
+  cleanup_prev_backup
+
+  capture_live_snapshot
+  note="deprovision_apply_flags_off_access_disabled_restore_phase_required"
+  write_status_artifact \
+    "${SNAP_BUILD_SHA:-unknown}" \
+    "$SNAP_ALIAS" "$SNAP_PENDING" "$SNAP_DEPROV" "$SNAP_MODE" \
+    "$SNAP_ALIAS_READY" "$SNAP_CAN_ENABLE_ALIAS" \
+    "$SNAP_MIGRATIONS_ZERO" "$SNAP_HEALTH_OK" \
+    "deprovision" "true" "true" "$note"
+  {
+    echo "action=deprovision"
+    echo "phase=apply"
+    echo "mode=${SNAP_MODE}"
+    echo "build_sha=${SNAP_BUILD_SHA:-unknown}"
+    echo "transition_applied=true"
+    echo "from_mode=off"
+    echo "to_mode=off"
+    echo "deprovision_on_applied=${deprovision_on_applied}"
+    echo "pre_login_ok=${pre_login_ok}"
+    echo "admin_jwt_minted=${admin_jwt_minted}"
+    echo "subject_owned=true"
+    echo "subject_auto_selected=false"
+    echo "source_disable_confirmation=true"
+    echo "preview_subject_gate_ok=true"
+    echo "preview_would_deactivate=${PREVIEW_WOULD_DEACTIVATE:-0}"
+    echo "preview_would_deactivate_linked=${PREVIEW_WOULD_DEACTIVATE_LINKED:-0}"
+    echo "preview_subject_match=true"
+    echo "sync_radius_not_atomic_lock=true"
+    echo "source_inactive_after_sync=${source_inactive_after_sync}"
+    echo "sync_ok=${sync_ok}"
+    echo "sync_deprovision_applied=${SYNC_DEPROVISION_APPLIED:-false}"
+    echo "sync_run_id_present=${SYNC_RUN_ID_PRESENT:-false}"
+    echo "sync_users_deactivated=${SYNC_USERS_DEACTIVATED:-0}"
+    echo "sync_accounts_deactivated=${SYNC_ACCOUNTS_DEACTIVATED:-0}"
+    echo "sync_deprovision_candidates=${SYNC_DEPROVISION_CANDIDATES:-0}"
+    echo "ledger_ok=${ledger_ok}"
+    echo "ledger_run_match=${LEDGER_RUN_MATCH:-false}"
+    echo "ledger_event_count=${LEDGER_EVENT_COUNT:-0}"
+    echo "ledger_effect_count=${LEDGER_EFFECT_COUNT:-0}"
+    echo "ledger_generation_present=${LEDGER_GENERATION_PRESENT:-false}"
+    echo "journal_phase=ledger_bound"
+    echo "journal_retained=true"
+    echo "exact_run_persisted=true"
+    echo "recovery_required=false"
+    echo "apply_completed=true"
+    echo "apply_state_persisted=true"
+    echo "access_denied_ok=${access_denied_ok}"
+    echo "access_graph_user_active=${GRAPH_USER_ACTIVE:-unknown}"
+    echo "access_graph_membership_active_count=${GRAPH_MEMBERSHIP_ACTIVE_COUNT:-0}"
+    echo "access_graph_grant_state=${GRAPH_GRANT_STATE:-unknown}"
+    echo "subject_password_pre_ok=${subject_password_pre_ok}"
+    echo "login_denied_checkpoint=${login_denied_checkpoint}"
+    echo "login_denied_ok=${login_denied_ok}"
+    echo "rolled_back_flags_off=${rolled_back_flags_off}"
+    echo "access_restored=false"
+    echo "canary_access_rollback_complete=false"
+    echo "server_side_access_graph_restore_proven=false"
+    echo "end_to_end_restore_claimed=false"
+    echo "restore_phase_required=true"
+    echo "note=${note}"
+  } > "${OUTPUT_DIR}/summary.txt"
+  log "action=deprovision apply OK (flags OFF; access disabled; journal ledger_bound retained; restore phase required)"
+}
+
+action_deprovision_restore() {
+  local pre_login_ok="false"
+  local admin_jwt_minted="false"
+  local source_active_after_sync="false"
+  local sync_ok="false"
+  local restore_ok="false"
+  local resolved_ok="false"
+  local access_restored_ok="false"
+  local graph_restored_ok="false"
+  local login_restored_ok="false"
+  local login_restored_checkpoint="NOT_EXECUTED"
+  local oauth_negative_checkpoint="NOT_EXECUTED"
+  local oauth_positive_checkpoint="NOT_EXECUTED"
+  local flags_remain_off="false"
+  local note="deprovision_restore_phase"
+  SUBJECT_PASSWORD_PROVEN_OK="false"
+
+  require_sha
+  require_canary_secret_files "deprovision"
+  assert_canary_identifier_matches_owner "deprovision"
+  require_canary_directory_account_id_file "deprovision"
+  [[ -n "$EXPECTED_CURRENT_MODE" ]] || fail "expected_current_mode is required for action=deprovision restore"
+  [[ "$EXPECTED_CURRENT_MODE" == "off" ]] \
+    || fail "action=deprovision restore requires expected_current_mode=off"
+
+  capture_live_snapshot
+  assert_exact_sha
+  require_migrations_pending_zero_true "$SNAP_MIGRATIONS_ZERO" "action=deprovision restore"
+
+  if [[ "$SNAP_HEALTH_OK" != "true" ]]; then
+    fail "action=deprovision restore refused: backend_health_ok must be true"
+  fi
+  if [[ "$SNAP_MODE" != "off" || "$SNAP_ALIAS" != "false" || "$SNAP_PENDING" != "false" || "$SNAP_DEPROV" != "false" ]]; then
+    fail "action=deprovision restore refused: all lifecycle flags must be OFF before restore (live mode='${SNAP_MODE}')"
+  fi
+
+  if mint_canary_admin_jwt_from_password_login "deprovision_restore_pre"; then
+    pre_login_ok="true"
+    admin_jwt_minted="true"
+  else
+    fail "action=deprovision restore refused: canary login / JWT mint failed"
+  fi
+
+  if ! load_canary_directory_subject "deprovision_restore_pre"; then
+    fail "action=deprovision restore refused: subject load failed (note=${SUBJECT_NOTE:-unset}); no auto-selection"
+  fi
+  if [[ "$SUBJECT_LOCAL_USERNAME_OK" != "true" || "$SUBJECT_LOCAL_NAME_OK" != "true" ]]; then
+    fail "action=deprovision restore refused: subject is not owned canary employee; no auto-selection"
+  fi
+
+  # Exact apply correlation from host persistent state — NEVER discover events by scan.
+  if ! load_deprovision_apply_state; then
+    fail "action=deprovision restore refused: apply state load failed (missing/drift); no event auto-discovery"
+  fi
+
+  # External source reactivated → sync so local account becomes active again (no deprovision flag).
+  if ! run_directory_sync_for_subject "deprovision_restore" "false"; then
+    fail "action=deprovision restore refused: sync failed (note=${SYNC_NOTE:-unset})"
+  fi
+  sync_ok="true"
+
+  if ! load_canary_directory_subject "deprovision_restore_post_sync"; then
+    fail "action=deprovision restore refused: subject reload failed (note=${SUBJECT_NOTE:-unset})"
+  fi
+  if [[ "$SUBJECT_ACTIVE" != "true" ]]; then
+    fail "action=deprovision restore refused: subject source not active after sync (external re-enable gate)"
+  fi
+  source_active_after_sync="true"
+
+  if ! run_or_resume_deprovision_rehire_restore; then
+    fail "action=deprovision restore refused: rehire restore/resume failed (note=${RESTORE_NOTE:-unset})"
+  fi
+  restore_ok="true"
+  resolved_ok="true"
+
+  if ! assert_subject_user_access_state "activated" "true" "post_restore"; then
+    fail "action=deprovision restore refused: profile access not restored (note=${ACCESS_NOTE:-unset})"
+  fi
+  access_restored_ok="true"
+
+  if ! prove_access_graph_state "restored" "post_restore"; then
+    fail "action=deprovision restore refused: access graph not restored (note=${GRAPH_NOTE:-unset})"
+  fi
+  graph_restored_ok="true"
+
+  local pass_file=""
+  if pass_file="$(resolve_subject_password_file 2>/dev/null)"; then
+    if prove_subject_password_login "deprovision_restore" "$pass_file"; then
+      login_restored_ok="true"
+      login_restored_checkpoint="proven_password_ok"
+    else
+      fail "action=deprovision restore refused: subject password login failed after restore (note=${SUBJECT_LOGIN_NOTE:-unset})"
+    fi
+  else
+    login_restored_ok="false"
+    login_restored_checkpoint="NOT_EXECUTED"
+  fi
+  # Human DingTalk OAuth positive/negative remain manual.
+  oauth_negative_checkpoint="NOT_EXECUTED"
+  oauth_positive_checkpoint="NOT_EXECUTED"
+
+  capture_live_snapshot
+  if [[ "$SNAP_MODE" != "off" || "$SNAP_ALIAS" != "false" || "$SNAP_PENDING" != "false" || "$SNAP_DEPROV" != "false" ]]; then
+    fail "action=deprovision restore refused: lifecycle flags must remain OFF after restore"
+  fi
+  flags_remain_off="true"
+  assert_exact_sha
+  require_migrations_pending_zero_true "$SNAP_MIGRATIONS_ZERO" "action=deprovision restore post-check"
+  if [[ "$SNAP_HEALTH_OK" != "true" ]]; then
+    fail "action=deprovision restore refused: backend_health_ok must remain true"
+  fi
+
+  clear_deprovision_apply_state
+
+  note="deprovision_restore_server_side_access_graph_proven_flags_off"
+  write_status_artifact \
+    "${SNAP_BUILD_SHA:-unknown}" \
+    "$SNAP_ALIAS" "$SNAP_PENDING" "$SNAP_DEPROV" "$SNAP_MODE" \
+    "$SNAP_ALIAS_READY" "$SNAP_CAN_ENABLE_ALIAS" \
+    "$SNAP_MIGRATIONS_ZERO" "$SNAP_HEALTH_OK" \
+    "deprovision" "true" "false" "$note"
+  {
+    echo "action=deprovision"
+    echo "phase=restore"
+    echo "mode=${SNAP_MODE}"
+    echo "build_sha=${SNAP_BUILD_SHA:-unknown}"
+    echo "transition_applied=false"
+    echo "lifecycle_env_write=false"
+    echo "pre_login_ok=${pre_login_ok}"
+    echo "admin_jwt_minted=${admin_jwt_minted}"
+    echo "subject_owned=true"
+    echo "subject_auto_selected=false"
+    echo "source_reactivate_confirmation=true"
+    echo "source_active_after_sync=${source_active_after_sync}"
+    echo "sync_ok=${sync_ok}"
+    echo "restore_ok=${restore_ok}"
+    echo "restore_resumed_fully_resolved=${RESTORE_RESUMED_FULLY_RESOLVED:-false}"
+    echo "restore_effect_count=${RESTORE_EFFECT_COUNT:-0}"
+    echo "event_fully_resolved_ok=${resolved_ok}"
+    echo "access_restored_ok=${access_restored_ok}"
+    echo "access_graph_restored_ok=${graph_restored_ok}"
+    echo "access_graph_user_active=${GRAPH_USER_ACTIVE:-unknown}"
+    echo "access_graph_membership_active_count=${GRAPH_MEMBERSHIP_ACTIVE_COUNT:-0}"
+    echo "access_graph_grant_state=${GRAPH_GRANT_STATE:-unknown}"
+    echo "login_restored_checkpoint=${login_restored_checkpoint}"
+    echo "login_restored_ok=${login_restored_ok}"
+    echo "oauth_negative_checkpoint=${oauth_negative_checkpoint}"
+    echo "oauth_positive_checkpoint=${oauth_positive_checkpoint}"
+    echo "flags_remain_off=${flags_remain_off}"
+    echo "server_side_access_graph_restore_proven=true"
+    echo "canary_access_rollback_complete=true"
+    # OAuth human checkpoints not executed → must not claim full end-to-end.
+    echo "end_to_end_restore_claimed=false"
+    echo "note=${note}"
+  } > "${OUTPUT_DIR}/summary.txt"
+  log "action=deprovision restore OK (server-side access graph proven; OAuth NOT_EXECUTED; end_to_end_restore_claimed=false; flags OFF)"
+}
+
 # --- main ------------------------------------------------------------------------------
 
 main() {
@@ -2322,8 +5538,8 @@ main() {
     bootstrap) action_bootstrap ;;
     human-bootstrap) action_human_bootstrap ;;
     alias) action_alias ;;
-    pending) action_not_executable_on pending ;;
-    deprovision) action_not_executable_on deprovision ;;
+    pending) action_pending ;;
+    deprovision) action_deprovision ;;
     *) fail "invalid ACTION='${ACTION}' (status|preflight|off|bootstrap|human-bootstrap|alias|pending|deprovision)" ;;
   esac
 }


### PR DESCRIPTION
## What changed

- preserve the existing values-free staging execution record and successful alias-only canary evidence
- add caller-reserved directory sync run UUIDs and idempotent replay so a lost HTTP 202 cannot lose the destructive run correlation or pull the provider twice
- add an exact platform-admin run lookup endpoint scoped by integration + run id
- harden the staging canary journal to `prepared -> run_bound -> ledger_bound`, including exact event/effect binding and fail-closed recovery
- require a dedicated manual, scheduler-disabled, single-account integration and explicit source-disabled/exclusive-operator confirmation before deprovision apply
- make failure rollback retry the OFF proof from the EXIT guard when the first proof fails
- record pending admission, deprovision, U1-U13, real callback corp-anchor, production switches, and Transfer T3-T5 as NOT EXECUTED where evidence is missing

## Existing staging evidence

- lifecycle status run 31513394261: exact deployed SHA, healthy backend, zero pending migrations, mode off, all three lifecycle flags false
- alias run 31504979575: real password login before ON, while alias-only was live, and after rollback; zero collisions; final mode off
- designated administrator OAuth login and platform-admin authorization were verified separately
- no pending or deprovision action is claimed executed by this PR

No secret value, token, name, email, phone number, DingTalk userid, unionId, or corp-id value is recorded.

## Safety boundary

- all three lifecycle flags remain OFF outside each bounded action
- deprovision may run only against a dedicated one-account integration while its DingTalk source is disabled and no concurrent operator or automation can mutate/sync it
- the preview/precondition is not an atomic scope lock; the exclusive staging window is therefore load-bearing
- a failed exact run with no ledger match keeps its recovery journal; manual journal deletion is forbidden and abandonment requires owner-reviewed evidence
- U1-U13 and real callback/corp-anchor remain NOT EXECUTED until their real secrets, template, integration, and human actions exist
- production enablement remains a separate owner/ops GO

## Verification at head 36eb9c4688

- `node --test scripts/ops/dingtalk-lifecycle-staging-canary-contract.test.mjs` — 179/179
- backend route + lease unit suites — 136/136
- real PostgreSQL directory orchestration suite — 17/17
- `pnpm --filter @metasheet/core-backend exec tsc --noEmit`
- `bash -n scripts/ops/dingtalk-lifecycle-staging-canary-remote.sh`
- `git diff --check`
- independent read-only adversarial delta review: APPROVE, no new P1/P2; the journal-recovery and exclusive-window residuals are explicitly hold-gated above

This PR remains intentionally draft and unarmed.

## Exact-head GitHub CI

Head `36eb9c4688`: all checks settled with zero failures, including `test (18.x)`, `test (20.x)`, `web-tests`, `e2e`, `migration-replay`, contract suites, and coverage. The PR remains draft and unarmed.