### PR TITLE
docs(dingtalk): record staging lifecycle canary and recovery evidence

### DIFF
--- a/docs/development/dingtalk-lifecycle-canary-separate-go-20260724.md
+++ b/docs/development/dingtalk-lifecycle-canary-separate-go-20260724.md
@@ -1,7 +1,7 @@
 # DingTalk lifecycle canary — separate ops GO (not auto-enabled)
 
 **Date:** 2026-07-24
-**Updated:** 2026-08-12 (hardened-deploy alias run 31529335625 completed with required OFF rollback at exact SHA `24794811b1c800402006b30d6e4fa9df670e124e`; pending/deprovision have fail-closed transient operators but remain **NOT EXECUTED**; deprovision requires a dedicated one-account integration and pre-reserves its exact sync run UUID before env/HTTP)
+**Updated:** 2026-08-12 (alias and server-side pending canaries completed with required OFF rollback; two pre-ledger deprovision failure classes were safely recovered at exact SHA `51f23ec7255c3fb0d9abc21bfbe4c3bce8e1c48f`; destructive apply/restore remains **NOT EXECUTED** pending a second unique DingTalk sentinel)
 **Related locks:**
 - `dingtalk-directory-admission-activation-lifecycle-design-20260723.md` Rev 4.2
 - `dingtalk-deprovision-reactivation-and-evidence-chain-design-20260723.md` Rev 4.5
@@ -34,8 +34,8 @@ Presence of canary subject/integration/owner tokens is **not** a real canary and
 | `off` | yes | emergency clear of the three env gates; previous-override restore on failure; health true after restart required |
 | `bootstrap` | yes (manual) | staging-only create/repair of fixed canary admin; see below; **no lifecycle env write** |
 | `alias` | yes (transient) | secret-backed cutover canary; see sequence below; success requires/proves OFF |
-| `pending` | yes (transient, **NOT EXECUTED**) | explicit owned directory account only; pending admit or optional SSO activation; required OFF rollback; browser OAuth remains a human checkpoint |
-| `deprovision` | yes (two-phase, **NOT EXECUTED**) | dedicated one-account manual integration only; exact preview/planner radius; reserved run UUID + recovery journal; exact event/effects restore; required OFF rollback |
+| `pending` | yes (transient, **SERVER-SIDE PASS**) | explicit owned account admitted and activated through SSO intent; required OFF rollback passed; browser OAuth remains a human checkpoint |
+| `deprovision` | yes (two-phase, **ATTEMPTED / NOT COMPLETE**) | dedicated manual integration and recovery paths proven; pre-reserves the exact run UUID before env/HTTP; destructive event/effects apply + restore awaits a second unique DingTalk sentinel; required OFF rollback remains mandatory |
 
 Shared concurrency with `attendance-staging-window-runner`. Status artifacts stay values-free (booleans / counts / reason enums / SHA only).
 
@@ -108,7 +108,7 @@ Backfill alias rows **may persist** after the run. Artifacts report only boolean
 
 ## Current staging baseline (alias executed and rolled back)
 
-As of 2026-08-12 the alias cutover canary is complete and rolled back. Pending and deprovision remain **NOT EXECUTED**. Safe preparation and execution evidence:
+As of 2026-08-12 the alias and server-side pending canaries are complete and rolled back. Deprovision recovery is proven, but destructive apply/restore remains **NOT EXECUTED**. Safe preparation and execution evidence:
 
 1. Attendance staging runner [run 31407444155](https://github.com/zensgit/metasheet2/actions/runs/31407444155) completed backup + clone rehearsal + real apply: migration state `296 applied / 18 pending` -> `314 applied / 0 pending`; rehearsal isolation held and auth round-trip returned 200.
 2. [#4853](https://github.com/zensgit/metasheet2/pull/4853), merge commit `ddec28b12ebff97fae33af45553d77c149d816e1`, installs and validates the checked-out staging Compose file, pins Compose project-directory, and derives build metadata from the exact `IMAGE_TAG`.
@@ -121,15 +121,18 @@ As of 2026-08-12 the alias cutover canary is complete and rolled back. Pending a
 9. [#4873](https://github.com/zensgit/metasheet2/pull/4873), merge commit `24794811b1c800402006b30d6e4fa9df670e124e`, added caller-reserved sync-run ids, exact-run recovery, a staged recovery journal, and the dedicated one-account/exclusive-window deprovision gates.
 10. Attendance staging [deploy 31528635839](https://github.com/zensgit/metasheet2/actions/runs/31528635839) deployed exact SHA `24794811b1c800402006b30d6e4fa9df670e124e`; lifecycle [status 31528753683](https://github.com/zensgit/metasheet2/actions/runs/31528753683) and [OFF preflight 31528911914](https://github.com/zensgit/metasheet2/actions/runs/31528911914) proved healthy backend, zero pending migrations, exact mode `off`, and all three flags `false`.
 11. Hardened-deploy lifecycle [alias 31529335625](https://github.com/zensgit/metasheet2/actions/runs/31529335625) again proved password login before ON, during alias-only, and after rollback; zero collisions; exact deployed SHA; and terminal mode `off` with all three flags `false`. This is the current alias proof; run `31504979575` remains historical evidence for the older deploy.
+12. Pending [admit 31551343313](https://github.com/zensgit/metasheet2/actions/runs/31551343313) and [SSO activate-intent 31551426867](https://github.com/zensgit/metasheet2/actions/runs/31551426867) used the explicit owned subject and left all lifecycle flags OFF. Browser OAuth checkpoints remain `NOT_EXECUTED`.
+13. [#4875](https://github.com/zensgit/metasheet2/pull/4875) and recovery [31555162698](https://github.com/zensgit/metasheet2/actions/runs/31555162698) closed an exact empty-fetch abort with zero ledger and unchanged access graph.
+14. [#4877](https://github.com/zensgit/metasheet2/pull/4877), merge `51f23ec7255c3fb0d9abc21bfbe4c3bce8e1c48f`, and runs [31559288370](https://github.com/zensgit/metasheet2/actions/runs/31559288370), [31559371562](https://github.com/zensgit/metasheet2/actions/runs/31559371562), and [31559480395](https://github.com/zensgit/metasheet2/actions/runs/31559480395) prove exact staging deploy, exact sync-failure recovery, cleared journal, unchanged access graph, zero ledger, and terminal mode `off`.
 
 The former image-tag/health-commit provenance conflict is resolved. This establishes the safe OFF baseline and the transient alias staging canary; it does not authorize production alias traffic.
 
-The secret-backed pending and deprovision operators now exist, but neither pending admission nor
-deprovision has been run in staging. Execution still requires one explicitly owned source employee.
-Deprovision additionally refuses any integration
+The secret-backed operators now exist and pending admission/SSO activation have run against the
+explicit owned source employee. Deprovision additionally refuses any integration
 that is scheduled, auto-admitting, member-group projecting, or contains anything other than the
-single selected directory account (inactive rows count too). The current shared employee
-integration is therefore ineligible by construction.
+single selected directory account (inactive rows count too). The dedicated integration passed those
+gates, but a destructive cycle still requires a second unique employee as a temporary non-target
+sentinel; using an employee already present in another integration fails before ledger by design.
 
 Apply also requires the literal confirmation
 `DINGTALK_SOURCE_DISABLED_DEDICATED_EXCLUSIVE_CONFIRMED`: the source is disabled, the integration
@@ -155,10 +158,10 @@ The full values-free execution record is `dingtalk-staging-lifecycle-canary-and-
 2. **Complete:** configure the fixed alias-canary login secrets without exposing their values.
 3. **Complete:** create/repair the dedicated canary administrators and prove password login with all flags OFF.
 4. **Complete:** dispatch `action=alias`; prove transient ON login and required OFF rollback login.
-5. **NOT EXECUTED (operator ready):** real admit→activate on an explicitly owned DingTalk employee, then pending rollback.
-6. **NOT EXECUTED (operator ready, dedicated integration required):** real source departure and deprovision/restore proof on that same employee, then rollback.
+5. **Complete server-side; browser OAuth NOT EXECUTED:** real admit→SSO activate intent on the explicitly owned employee, with pending rollback to OFF.
+6. **NOT EXECUTED (operator ready, second unique sentinel required):** real source departure and deprovision/restore proof on that same employee, then rollback.
 7. Production remains a separate GO.
 
 ## Owner note
 
-Landing this lane does not authorize traffic. The alias staging canary succeeded and returned to OFF; pending and deprovision remain incomplete. Merging code and completing staging alias do not leave `AUTH_LOGIN_USE_ALIASES` enabled or authorize any production lifecycle flag.
+Landing this lane does not authorize traffic. Alias and server-side pending staging canaries succeeded and returned to OFF; browser OAuth and destructive deprovision remain incomplete. Merging code and completing staging canaries do not leave any lifecycle flag enabled or authorize production traffic.

--- a/docs/development/dingtalk-lifecycle-canary-separate-go-20260724.md
+++ b/docs/development/dingtalk-lifecycle-canary-separate-go-20260724.md
@@ -1,7 +1,7 @@
 # DingTalk lifecycle canary — separate ops GO (not auto-enabled)
 
 **Date:** 2026-07-24
-**Updated:** 2026-08-12 (alias run 31504979575 completed with required OFF rollback; pending/deprovision now have fail-closed transient operators but remain **NOT EXECUTED**; deprovision requires a dedicated one-account integration and pre-reserves its exact sync run UUID before env/HTTP)
+**Updated:** 2026-08-12 (hardened-deploy alias run 31529335625 completed with required OFF rollback at exact SHA `24794811b1c800402006b30d6e4fa9df670e124e`; pending/deprovision have fail-closed transient operators but remain **NOT EXECUTED**; deprovision requires a dedicated one-account integration and pre-reserves its exact sync run UUID before env/HTTP)
 **Related locks:**
 - `dingtalk-directory-admission-activation-lifecycle-design-20260723.md` Rev 4.2
 - `dingtalk-deprovision-reactivation-and-evidence-chain-design-20260723.md` Rev 4.5
@@ -108,7 +108,7 @@ Backfill alias rows **may persist** after the run. Artifacts report only boolean
 
 ## Current staging baseline (alias executed and rolled back)
 
-As of 2026-08-11 the alias cutover canary is complete and rolled back. Pending and deprovision remain **NOT EXECUTED**. Safe preparation and execution evidence:
+As of 2026-08-12 the alias cutover canary is complete and rolled back. Pending and deprovision remain **NOT EXECUTED**. Safe preparation and execution evidence:
 
 1. Attendance staging runner [run 31407444155](https://github.com/zensgit/metasheet2/actions/runs/31407444155) completed backup + clone rehearsal + real apply: migration state `296 applied / 18 pending` -> `314 applied / 0 pending`; rehearsal isolation held and auth round-trip returned 200.
 2. [#4853](https://github.com/zensgit/metasheet2/pull/4853), merge commit `ddec28b12ebff97fae33af45553d77c149d816e1`, installs and validates the checked-out staging Compose file, pins Compose project-directory, and derives build metadata from the exact `IMAGE_TAG`.
@@ -118,11 +118,15 @@ As of 2026-08-11 the alias cutover canary is complete and rolled back. Pending a
 6. The existing `DEPLOY_KNOWN_HOSTS` secret is the independently verified deploy-host identity. The lane uses `StrictHostKeyChecking=yes`; missing host identity blocks dispatch rather than producing forgeable evidence.
 7. Lifecycle [status 31504862038](https://github.com/zensgit/metasheet2/actions/runs/31504862038) re-proved the exact staging SHA, healthy backend, zero pending migrations, mode `off`, and all three flags `false`.
 8. Lifecycle [alias 31504979575](https://github.com/zensgit/metasheet2/actions/runs/31504979575) proved password login before ON, during alias-only, and after rollback; it reported zero collisions and finished in exact mode `off` with all three flags `false`.
+9. [#4873](https://github.com/zensgit/metasheet2/pull/4873), merge commit `24794811b1c800402006b30d6e4fa9df670e124e`, added caller-reserved sync-run ids, exact-run recovery, a staged recovery journal, and the dedicated one-account/exclusive-window deprovision gates.
+10. Attendance staging [deploy 31528635839](https://github.com/zensgit/metasheet2/actions/runs/31528635839) deployed exact SHA `24794811b1c800402006b30d6e4fa9df670e124e`; lifecycle [status 31528753683](https://github.com/zensgit/metasheet2/actions/runs/31528753683) and [OFF preflight 31528911914](https://github.com/zensgit/metasheet2/actions/runs/31528911914) proved healthy backend, zero pending migrations, exact mode `off`, and all three flags `false`.
+11. Hardened-deploy lifecycle [alias 31529335625](https://github.com/zensgit/metasheet2/actions/runs/31529335625) again proved password login before ON, during alias-only, and after rollback; zero collisions; exact deployed SHA; and terminal mode `off` with all three flags `false`. This is the current alias proof; run `31504979575` remains historical evidence for the older deploy.
 
 The former image-tag/health-commit provenance conflict is resolved. This establishes the safe OFF baseline and the transient alias staging canary; it does not authorize production alias traffic.
 
-The secret-backed operators now exist, but neither action has been run in staging. Execution still
-requires one explicitly owned source employee. Deprovision additionally refuses any integration
+The secret-backed pending and deprovision operators now exist, but neither pending admission nor
+deprovision has been run in staging. Execution still requires one explicitly owned source employee.
+Deprovision additionally refuses any integration
 that is scheduled, auto-admitting, member-group projecting, or contains anything other than the
 single selected directory account (inactive rows count too). The current shared employee
 integration is therefore ineligible by construction.

--- a/docs/development/dingtalk-lifecycle-six-step-closeout-execution-20260810.md
+++ b/docs/development/dingtalk-lifecycle-six-step-closeout-execution-20260810.md
@@ -3,7 +3,7 @@
 - Date: 2026-08-10
 - Updated: 2026-08-12
 - Status: **CODE + STAGING ALIAS CANARY COMPLETE / PENDING + DEPROVISION + EXTERNAL GATES NOT EXECUTED**
-- Baseline: `origin/main @ ddec28b12ebff97fae33af45553d77c149d816e1`
+- Baseline: `origin/main @ 24794811b1c800402006b30d6e4fa9df670e124e`
 - Scope: close the OPS-01 superseded creation-effect residue without enabling lifecycle traffic
 - Operator lane (staging only, default-off): `.github/workflows/dingtalk-lifecycle-staging-canary.yml` + `scripts/ops/dingtalk-lifecycle-staging-canary-remote.sh` — `status` and transient `alias -> off` executed; pending/deprovision not executed
 
@@ -105,6 +105,9 @@ The safe OFF baseline and transient alias canary are proven:
 6. The existing `DEPLOY_KNOWN_HOSTS` secret supplies the independently verified host key. SSH and SCP require `StrictHostKeyChecking=yes`; this evidence lane does not accept first-use trust.
 7. [Lifecycle status 31504862038](https://github.com/zensgit/metasheet2/actions/runs/31504862038) re-proved the exact staging SHA, healthy backend, zero pending migrations, mode `off`, and all three flags `false`.
 8. [Lifecycle alias 31504979575](https://github.com/zensgit/metasheet2/actions/runs/31504979575) proved real password login before ON, while alias-only was live, and after rollback. It reported zero collisions and finished in exact mode `off` with all three flags `false`.
+9. [#4873](https://github.com/zensgit/metasheet2/pull/4873), merge commit `24794811b1c800402006b30d6e4fa9df670e124e`, hardened deprovision execution with a caller-reserved exact run id, recovery journal, exact ledger binding, and dedicated one-account/exclusive-window gates.
+10. [Attendance staging deploy 31528635839](https://github.com/zensgit/metasheet2/actions/runs/31528635839), [lifecycle status 31528753683](https://github.com/zensgit/metasheet2/actions/runs/31528753683), and [OFF preflight 31528911914](https://github.com/zensgit/metasheet2/actions/runs/31528911914) jointly proved the exact hardened deploy, healthy backend, zero pending migrations, and all three lifecycle flags OFF.
+11. [Lifecycle alias 31529335625](https://github.com/zensgit/metasheet2/actions/runs/31529335625) re-ran the three password-login legs against the hardened deploy, reported zero collisions, and finished in exact mode `off`. This supersedes the older deploy as the current alias proof.
 
 The former image-tag/health-commit conflict is resolved. Alias production enablement remains a separate owner GO. Pending and deprovision operators are implemented but remain blocked by the absence of an explicitly owned real test subject and, for deprovision, a dedicated one-account integration. The existing shared employee integration is not eligible.
 
@@ -157,5 +160,6 @@ The code and safe staging OFF-preflight portions of this six-step closeout are c
 | Staging operator lane, #4851 | `0083621f5dd1fd6dbeb0a5b71815156804e20a3b` |
 | Per-lane scratch DB mitigation, #4852 | `f0745831fe5385ccacf8fe6d6e5fd51174c02117` |
 | Exact staging Compose/provenance sync, #4853 | `ddec28b12ebff97fae33af45553d77c149d816e1` |
+| Canary exact-run recovery and dedicated-integration hardening, #4873 | `24794811b1c800402006b30d6e4fa9df670e124e` |
 
 The staging alias canary is complete and rolled back. Pending/deprovision canaries, U1-U13/corp-anchor, named production decisions, and the real two-corp T2-Gate are deliberately **NOT EXECUTED**. Transfer T3-T5 remains frozen. Issue #4820 remains open for recurrence observation. None of those remaining gates is represented as PASS by this closeout.

--- a/docs/development/dingtalk-lifecycle-six-step-closeout-execution-20260810.md
+++ b/docs/development/dingtalk-lifecycle-six-step-closeout-execution-20260810.md
@@ -2,10 +2,10 @@
 
 - Date: 2026-08-10
 - Updated: 2026-08-12
-- Status: **CODE + STAGING ALIAS CANARY COMPLETE / PENDING + DEPROVISION + EXTERNAL GATES NOT EXECUTED**
-- Baseline: `origin/main @ 24794811b1c800402006b30d6e4fa9df670e124e`
+- Status: **CODE + ALIAS + SERVER-SIDE PENDING CANARIES COMPLETE / DEPROVISION DESTRUCTIVE APPLY-RESTORE + EXTERNAL GATES NOT EXECUTED**
+- Baseline: `origin/main @ 51f23ec7255c3fb0d9abc21bfbe4c3bce8e1c48f`
 - Scope: close the OPS-01 superseded creation-effect residue without enabling lifecycle traffic
-- Operator lane (staging only, default-off): `.github/workflows/dingtalk-lifecycle-staging-canary.yml` + `scripts/ops/dingtalk-lifecycle-staging-canary-remote.sh` — `status` and transient `alias -> off` executed; pending/deprovision not executed
+- Operator lane (staging only, default-off): `.github/workflows/dingtalk-lifecycle-staging-canary.yml` + `scripts/ops/dingtalk-lifecycle-staging-canary-remote.sh` — `status`, transient `alias -> off`, pending admit, SSO-activate intent, and two pre-ledger deprovision recoveries executed; destructive deprovision apply/restore not complete
 
 ## 1. OPS-01 explicit compensation
 
@@ -72,7 +72,9 @@ DIRECTORY_PENDING_ACTIVATION_ENABLED=false
 DIRECTORY_DEPROVISION_ENABLED=false
 ```
 
-Merge is not an enablement instruction. The staging alias canary was later executed and returned to OFF; pending admission and deprovision remain **NOT EXECUTED**. See `dingtalk-staging-lifecycle-canary-and-uat-execution-20260811.md`.
+Merge is not an enablement instruction. The staging alias and server-side pending canaries were
+executed and returned to OFF. Browser OAuth and destructive deprovision apply/restore remain
+**NOT EXECUTED**. See `dingtalk-staging-lifecycle-canary-and-uat-execution-20260811.md`.
 
 ### 3.1 Staging operator lane (what is actually executable)
 
@@ -88,8 +90,8 @@ Merge is not an enablement instruction. The staging alias canary was later execu
 | `preflight` | yes | readiness only; `migrations_pending_zero` must be **exactly `true`** (`unknown` fails — never treated as success) |
 | `off` | yes | **sole env write**: emergency clear of the three gates; previous-override backup + restore on restart/health/mode failure; backend health must be true after restart; exact mode `off` proven |
 | `alias` | yes (transient) | secret-backed password login before ON, during alias-only, and after required OFF rollback |
-| `pending` | yes (transient, **NOT EXECUTED**) | explicit owned directory-account subject; admit-only or optional SSO activation; success requires OFF rollback; unobserved browser OAuth stays `NOT_EXECUTED` |
-| `deprovision` | yes (two-phase, **NOT EXECUTED**) | explicit owned subject in a dedicated one-account manual integration; exact preview/planner radius; pre-request reserved run UUID; exact ledger/restore; success requires OFF rollback |
+| `pending` | yes (transient, **SERVER-SIDE PASS**) | explicit owned directory-account subject; admit + SSO activate intent executed; browser OAuth checkpoints remain `NOT_EXECUTED`; flags returned to OFF |
+| `deprovision` | yes (two-phase, **ATTEMPTED / NOT COMPLETE**) | empty-fetch and duplicate-sentinel failures stayed pre-ledger and were safely recovered; a second unique DingTalk sentinel is still required for destructive apply/restore |
 
 `action=off` is an **emergency operational rollback of the env gate only**. Design lock Rev 4.2 §4.2 / §4.4 permanently forbids reintroducing OR-column fallback on `users.email` / `username` / `mobile` as a long-term design after T2b. OFF is not “canary stage 1 complete.”
 
@@ -108,16 +110,19 @@ The safe OFF baseline and transient alias canary are proven:
 9. [#4873](https://github.com/zensgit/metasheet2/pull/4873), merge commit `24794811b1c800402006b30d6e4fa9df670e124e`, hardened deprovision execution with a caller-reserved exact run id, recovery journal, exact ledger binding, and dedicated one-account/exclusive-window gates.
 10. [Attendance staging deploy 31528635839](https://github.com/zensgit/metasheet2/actions/runs/31528635839), [lifecycle status 31528753683](https://github.com/zensgit/metasheet2/actions/runs/31528753683), and [OFF preflight 31528911914](https://github.com/zensgit/metasheet2/actions/runs/31528911914) jointly proved the exact hardened deploy, healthy backend, zero pending migrations, and all three lifecycle flags OFF.
 11. [Lifecycle alias 31529335625](https://github.com/zensgit/metasheet2/actions/runs/31529335625) re-ran the three password-login legs against the hardened deploy, reported zero collisions, and finished in exact mode `off`. This supersedes the older deploy as the current alias proof.
+12. [Pending admit 31551343313](https://github.com/zensgit/metasheet2/actions/runs/31551343313) used an explicit owned subject, proved pending state, and rolled back to OFF. [SSO activate-intent 31551426867](https://github.com/zensgit/metasheet2/actions/runs/31551426867) activated it with lifecycle flags OFF. Browser OAuth checkpoints remain `NOT_EXECUTED`.
+13. [#4875](https://github.com/zensgit/metasheet2/pull/4875) added exact empty-fetch recovery. [Run 31555162698](https://github.com/zensgit/metasheet2/actions/runs/31555162698) proved zero ledger, unchanged access graph, active source, flags OFF, and cleared the safe-abort journal.
+14. [#4877](https://github.com/zensgit/metasheet2/pull/4877), merge `51f23ec7255c3fb0d9abc21bfbe4c3bce8e1c48f`, added exact pre-deprovision sync-failure recovery. Staging [deploy 31559288370](https://github.com/zensgit/metasheet2/actions/runs/31559288370), recovery [31559371562](https://github.com/zensgit/metasheet2/actions/runs/31559371562), and read-only status [31559480395](https://github.com/zensgit/metasheet2/actions/runs/31559480395) prove the exact deployed SHA, zero ledger before and after recovery sync, unchanged access graph, cleared journal, zero pending migrations, and all lifecycle flags OFF. The recovery does not claim deprovision restore.
 
-The former image-tag/health-commit conflict is resolved. Alias production enablement remains a separate owner GO. Pending and deprovision operators are implemented but remain blocked by the absence of an explicitly owned real test subject and, for deprovision, a dedicated one-account integration. The existing shared employee integration is not eligible.
+The former image-tag/health-commit conflict is resolved. Alias and pending production enablement remain separate owner decisions. The dedicated canary application, subject, and manual integration now exist. Destructive deprovision still requires a second unique DingTalk sentinel so the provider fetch remains nonempty while the target is absent; an employee already present in another integration cannot be reused.
 
 ### 3.3 Canary stages
 
 | Stage | Result | Required real proof |
 |---|---|---|
 | 1 | alias-only **PASS, rolled back** | password-login success against aliases + required `off` proof without OR-column fallback |
-| 2 | pending admission **NOT EXECUTED** | transient admit→activate on an explicit canary subject (not a presence token), then prove OFF |
-| 3 | deprovision **NOT EXECUTED** | dedicated one-account integration; reserved exact run UUID; sync→ledger→restore on the same subject, then prove OFF |
+| 2 | pending admission **SERVER-SIDE PASS; browser OAuth NOT EXECUTED** | explicit subject admit + SSO activate intent completed, then OFF proved |
+| 3 | deprovision **ATTEMPTED / NOT COMPLETE** | two pre-ledger failure classes were safely recovered; destructive sync→ledger→restore still needs a second unique source sentinel |
 
 ## 4. Owner and ops acceptance
 
@@ -126,9 +131,9 @@ Real enterprise evidence is unavailable in this development lane. Therefore thes
 - U1-U13 interactive-card acceptance;
 - U11-a real callback corp-anchor;
 - named owners and final production switch decisions;
-- lifecycle pending/deprovision stages (alias staging canary passed and rolled back; production alias remains a separate decision);
+- pending browser OAuth and destructive deprovision/restore stages (alias and server-side pending staging canaries passed; production flags remain separate decisions);
 
-Staging `status` and alias `off -> alias -> off` are complete per §3.2. The alias run's success condition included runtime OFF and a post-rollback password login.
+Staging `status`, alias `off -> alias -> off`, pending admit, SSO activate intent, and pre-ledger recovery paths are complete per §3.2. The current terminal status independently proves runtime OFF.
 
 The interactive-card procedure of record remains `dingtalk-hardening-real-uat-evidence-pack-20260713.md`.
 
@@ -161,5 +166,7 @@ The code and safe staging OFF-preflight portions of this six-step closeout are c
 | Per-lane scratch DB mitigation, #4852 | `f0745831fe5385ccacf8fe6d6e5fd51174c02117` |
 | Exact staging Compose/provenance sync, #4853 | `ddec28b12ebff97fae33af45553d77c149d816e1` |
 | Canary exact-run recovery and dedicated-integration hardening, #4873 | `24794811b1c800402006b30d6e4fa9df670e124e` |
+| Empty-fetch recovery, #4875 | `979c619ebf0ca1dfadedff2dc9b8db69b4f6b74c` |
+| Pre-deprovision sync-failure recovery, #4877 | `51f23ec7255c3fb0d9abc21bfbe4c3bce8e1c48f` |
 
-The staging alias canary is complete and rolled back. Pending/deprovision canaries, U1-U13/corp-anchor, named production decisions, and the real two-corp T2-Gate are deliberately **NOT EXECUTED**. Transfer T3-T5 remains frozen. Issue #4820 remains open for recurrence observation. None of those remaining gates is represented as PASS by this closeout.
+The staging alias and server-side pending canaries are complete and rolled back. Browser OAuth checkpoints, destructive deprovision/restore, U1-U13/corp-anchor, named production decisions, and the real two-corp T2-Gate are deliberately **NOT EXECUTED**. Transfer T3-T5 remains frozen. Issue #4820 remains open for recurrence observation. None of those remaining gates is represented as PASS by this closeout.

--- a/docs/development/dingtalk-staging-lifecycle-canary-and-uat-execution-20260811.md
+++ b/docs/development/dingtalk-staging-lifecycle-canary-and-uat-execution-20260811.md
@@ -1,8 +1,8 @@
 # DingTalk staging lifecycle canary and UAT execution record (2026-08-11/12)
 
-- Status: **PARTIAL EXECUTION / ALIAS PASS + HISTORICAL DESIGNATED-ADMIN OAUTH LOGIN AND POST-DEPLOY BINDING RECHECK PASS / PENDING + DEPROVISION OPERATORS READY BUT NOT EXECUTED / U1-U13 NOT EXECUTED**
-- Repository evidence head: `24794811b1c800402006b30d6e4fa9df670e124e`
-- Lifecycle staging deploy SHA: `24794811b1c800402006b30d6e4fa9df670e124e`
+- Status: **PARTIAL EXECUTION / ALIAS PASS / PENDING ADMIT + SSO-ACTIVATE INTENT PASS WITH BROWSER OAUTH NOT EXECUTED / DEPROVISION APPLY NOT COMPLETE + TWO SAFE RECOVERIES PASS / U1-U13 NOT EXECUTED**
+- Repository evidence head: `51f23ec7255c3fb0d9abc21bfbe4c3bce8e1c48f`
+- Lifecycle staging deploy SHA: `51f23ec7255c3fb0d9abc21bfbe4c3bce8e1c48f`
 - Production-readiness inventory deploy SHA: `24794811b1c800402006b30d6e4fa9df670e124e`
 - Owner instruction: keep all lifecycle flags OFF after every canary; do not convert missing real-enterprise evidence into PASS.
 
@@ -17,7 +17,7 @@ Two independently configured deployment roots were observed and must not be conf
 
 | Evidence lane | Deployed SHA | Purpose |
 |---|---|---|
-| Lifecycle staging canary (`STAGING_DEPLOY_PATH`) | `24794811b1c800402006b30d6e4fa9df670e124e` | Exact lifecycle status and transient alias ON/OFF proof after canary-recovery hardening |
+| Lifecycle staging canary (`STAGING_DEPLOY_PATH`) | `51f23ec7255c3fb0d9abc21bfbe4c3bce8e1c48f` | Exact lifecycle status, retained-journal recovery, and terminal OFF proof |
 | Production-readiness inventory (`DEPLOY_PATH`) | `24794811b1c800402006b30d6e4fa9df670e124e` | Read-only DingTalk integration, account, Stream, and flag inventory |
 
 The matching code SHA is not used to infer shared runtime state between the two roots; each
@@ -128,13 +128,26 @@ completed at repository and deployed head
 zero pending migrations, `mode=off`, all three lifecycle flags `false`, and
 `transition_applied=false`. These supersede the earlier lifecycle-deploy terminal-state proof.
 
+After the dedicated canary application/integration exercises, [#4875](https://github.com/zensgit/metasheet2/pull/4875)
+landed empty-fetch journal recovery and [#4877](https://github.com/zensgit/metasheet2/pull/4877)
+landed exact pre-deprovision sync-failure recovery. Attendance staging deploy
+[31559288370](https://github.com/zensgit/metasheet2/actions/runs/31559288370) pinned backend and
+web to exact SHA `51f23ec7255c3fb0d9abc21bfbe4c3bce8e1c48f`, reported zero pending
+migrations, and preserved the non-lifecycle staging mode. Recovery run
+[31559371562](https://github.com/zensgit/metasheet2/actions/runs/31559371562) then cleared the retained
+journal only after exact failed-run, zero-ledger, source-active, and unchanged-access-graph proofs.
+Independent read-only status run
+[31559480395](https://github.com/zensgit/metasheet2/actions/runs/31559480395) is the current terminal
+proof: exact deployed SHA, healthy backend, zero pending migrations, mode `off`, all three lifecycle
+flags `false`, and `transition_applied=false`.
+
 ## 4. Canary sequence
 
 | Order | Stage | Result | Durable evidence / reason |
 |---|---|---|---|
 | 1 | alias-only | **PASS, rolled back** | Hardened-deploy run `31529335625`; transient ON was proven by real password login and success required a return to exact OFF |
-| 2 | pending admission | **NOT EXECUTED** | Operator exists, but no explicitly owned DingTalk source employee has been proven in the target integration; no existing employee may be auto-selected |
-| 3 | deprovision | **NOT EXECUTED** | Operator exists, but requires the same owned employee in a dedicated one-account integration plus a real source-side disable/removal |
+| 2 | pending admission | **PASS for admit + SSO activate intent, rolled back; browser OAuth NOT EXECUTED** | Runs `31551343313` and `31551426867` used an explicit owned subject, never auto-selected it, and left lifecycle flags OFF |
+| 3 | deprovision | **ATTEMPTED, NOT COMPLETE** | Empty-source and duplicate-sentinel attempts made no lifecycle mutation; both retained journals were recovered with zero ledger and unchanged access graph. A second unique DingTalk sentinel is still required for a real apply/restore cycle |
 
 ### 4.1 Alias result
 
@@ -164,31 +177,24 @@ zero pending migrations, and deployed SHA
 persist, but this execution inserted zero rows. The earlier successful run `31504979575` remains
 historical evidence against the older deploy; it is not used as proof for the hardened deploy.
 
-### 4.2 Pending admission gate
+### 4.2 Pending admission result
 
-A read-only account inspection found active unmatched directory accounts, but none was
-explicitly designated and owned as a staging test employee. Those accounts may represent real
-people. Therefore the operator did not admit, activate, rename, disable, or otherwise mutate
-them. Presence of an unmatched account is not consent to use it as a canary.
+A dedicated canary application, department, employee, and manual integration were created before
+execution. The workflow consumed only the explicit directory-account secret and did not auto-select
+an account.
 
-The real OAuth administrator is now conclusively corp- and union-matched to its directory account,
-but it is a privileged account in a shared integration and is not a substitute for the dedicated
-test employee required below.
+- [Run 31551343313](https://github.com/zensgit/metasheet2/actions/runs/31551343313) transiently enabled
+  pending admission, admitted the explicit subject, proved `pending_activation`, and rolled back to
+  exact mode `off`.
+- [Run 31551426867](https://github.com/zensgit/metasheet2/actions/runs/31551426867) used the production
+  `PENDING_SSO_ACTIVATE` intent to activate the same subject while lifecycle flags remained OFF.
 
-Required external input before execution:
+Both artifacts are values-free and report `subject_owned=true`, `subject_auto_selected=false`, and
+successful password-backed administrator login. They do **not** prove browser OAuth denial or
+post-activation browser OAuth success: both browser checkpoints remain `NOT_EXECUTED`. Pending
+production enablement therefore remains a separate NO-GO decision despite the server-side canary.
 
-1. create or designate one dedicated DingTalk staging employee owned by the test;
-2. record only a values-free selection proof in the execution artifact;
-3. run sync/admit with pending enabled in a rollback-armed window;
-4. prove pending cannot log in, then activate it and prove the intended login path;
-5. restore `DIRECTORY_PENDING_ACTIVATION_ENABLED=false` and re-prove mode OFF.
-
-The operator accepts only the explicit directory-account secret. Its default phase proves pending
-admission and OFF rollback. Optional `PENDING_SSO_ACTIVATE` uses the real SSO activation path, but
-browser OAuth remains `NOT_EXECUTED` unless a human completes and observes that callback; the
-script does not promote an unobserved browser step to PASS.
-
-### 4.3 Deprovision gate
+### 4.3 Deprovision attempts, recovery, and remaining gate
 
 The earlier read-only directory preview saw no removal candidate and reported zero
 would-deactivate accounts. A later browser inspection showed that the active integration is a
@@ -213,8 +219,33 @@ retries cannot start a second provider pull with the same UUID. Recovery binds o
 single event and exact membership/grant/user effect triple. Restore probes the exact event tuple,
 reverses it, verifies the exact effect set and access graph, and leaves all three flags OFF.
 An exact run that terminates without a matching ledger event leaves a fail-closed journal. It must
-be resolved through an owner-reviewed abandonment procedure; deleting the journal to force a new
-apply is prohibited.
+be resolved through a reason-specific, owner-reviewed recovery path; deleting the journal to force
+a new apply is prohibited.
+
+The dedicated integration and explicit target passed the ownership/exclusivity gates, but a real
+destructive apply/restore cycle is still incomplete:
+
+1. An attempt with only the target removed produced the provider's empty-directory safeguard. No
+   event/effect was written and no access-graph row changed. After the source was restored,
+   [run 31555162698](https://github.com/zensgit/metasheet2/actions/runs/31555162698) proved the exact
+   `empty_directory_fetch` abort, zero ledger, active source, unchanged user/membership/grant graph,
+   all flags OFF, and cleared that journal without claiming restore.
+2. A second attempt kept the source nonempty by using an employee already present in another
+   integration. The sync failed before deprovision on the global provider/corp/external-key unique
+   constraint. [Run 31555714636](https://github.com/zensgit/metasheet2/actions/runs/31555714636)
+   retained the `run_bound` journal and returned all flags to OFF. [#4877](https://github.com/zensgit/metasheet2/pull/4877),
+   merge `51f23ec7255c3fb0d9abc21bfbe4c3bce8e1c48f`, added an exact-signature recovery that refuses
+   sibling/generic uniqueness errors. [Run 31559371562](https://github.com/zensgit/metasheet2/actions/runs/31559371562)
+   proved that exact failed run, zero event/effect rows before and after recovery sync, active
+   source, unchanged access graph, flags OFF, and then cleared the journal. It explicitly reports
+   `end_to_end_restore_claimed=false`.
+
+The remaining external prerequisite is a **second dedicated DingTalk employee identity with a real,
+unique phone number that is absent from every other integration**. It is needed only as a temporary
+source sentinel so the provider fetch remains nonempty when the target departs. Reusing an existing
+employee or inventing a phone number is prohibited. After it exists, the controlled sequence is:
+target absent + sentinel present -> apply; target re-added -> restore; sentinel removed; terminal
+status OFF.
 
 ## 5. DingTalk directory readiness
 
@@ -238,8 +269,9 @@ completed successfully against deployed SHA
 | all lifecycle/Stream flags OFF | `true` |
 | log level | ready (`LOG_LEVEL` missing; runtime default is `info`) |
 
-This proves a usable directory baseline, not pending/deprovision canary completion and not
-interactive-card readiness.
+This historical inventory proves a usable directory baseline. The later server-side pending
+canary completed as recorded in Section 4.2; it does not prove browser OAuth or destructive
+deprovision completion, and it is not interactive-card readiness.
 
 ## 6. U1-U13 and real callback corp-anchor
 
@@ -277,8 +309,8 @@ into this document or chat.
 | Decision | Current verdict |
 |---|---|
 | production alias enable | **NO GO** until owner reviews staging evidence and separately authorizes production |
-| production pending enable | **NO GO**; staging pending canary not executed |
-| production deprovision enable | **NO GO**; staging pending and deprovision canaries not executed |
+| production pending enable | **NO GO**; server-side staging admit/activate passed, but browser OAuth checkpoints and owner GO remain incomplete |
+| production deprovision enable | **NO GO**; safe-abort/recovery paths passed, but destructive apply/restore has not completed |
 | interactive-card Stream enable | **NO GO**; U1-U13/U11-a not executed |
 | Transfer T3-T5 | **FROZEN**; real two-corp T2-Gate remains separate and unexecuted |
 
@@ -293,14 +325,16 @@ DINGTALK_INTERACTIVE_CARD_STREAM_ENABLED=false
 
 ## 8. Next executable actions
 
-1. Provision a dedicated staging DingTalk employee and a separate one-account manual integration;
-   authorize that subject for pending and deprovision canaries.
-2. Execute pending and prove rollback to OFF, then execute two-phase deprovision and prove restore
-   plus rollback to OFF.
+1. Provision a second dedicated DingTalk sentinel employee with a real unique phone number and add
+   it only to the dedicated canary department/integration.
+2. Execute the destructive deprovision apply/restore sequence, remove the sentinel, and prove exact
+   OFF again. Separately complete the pending browser OAuth checkpoints if production pending is to
+   be considered.
 3. Configure the staging Stream/template inputs, re-confirm the info/debug log level, execute U1-U13 and the
    real callback corp-anchor procedure.
 4. Record named owners and explicit production switch decisions. Any absent evidence remains
    `NOT EXECUTED`.
 
-Until those external actions occur, the lifecycle code line and alias staging canary are
-closed, but production enablement and real-enterprise acceptance are not.
+Until those external actions occur, the lifecycle code line, alias canary, pending server-side
+canary, and fail-closed deprovision recovery paths are closed. Destructive deprovision/restore,
+production enablement, and real-enterprise acceptance are not.

--- a/docs/development/dingtalk-staging-lifecycle-canary-and-uat-execution-20260811.md
+++ b/docs/development/dingtalk-staging-lifecycle-canary-and-uat-execution-20260811.md
@@ -1,14 +1,15 @@
-# DingTalk staging lifecycle canary and UAT execution record (2026-08-11)
+# DingTalk staging lifecycle canary and UAT execution record (2026-08-11/12)
 
-- Status: **PARTIAL EXECUTION / ALIAS + DESIGNATED ADMIN OAUTH LOGIN PASS / PENDING + DEPROVISION OPERATORS READY BUT NOT EXECUTED / U1-U13 NOT EXECUTED**
-- Repository evidence head: `0287b250b33fe4c7ea98b880360af74fc08a5ebf`
-- Lifecycle staging deploy SHA: `ddec28b12ebff97fae33af45553d77c149d816e1`
-- Production-readiness inventory deploy SHA: `e27c8dbabb798cd1d3c407f1601430fd151df5bc`
+- Status: **PARTIAL EXECUTION / ALIAS PASS + HISTORICAL DESIGNATED-ADMIN OAUTH LOGIN AND POST-DEPLOY BINDING RECHECK PASS / PENDING + DEPROVISION OPERATORS READY BUT NOT EXECUTED / U1-U13 NOT EXECUTED**
+- Repository evidence head: `24794811b1c800402006b30d6e4fa9df670e124e`
+- Lifecycle staging deploy SHA: `24794811b1c800402006b30d6e4fa9df670e124e`
+- Production-readiness inventory deploy SHA: `24794811b1c800402006b30d6e4fa9df670e124e`
 - Owner instruction: keep all lifecycle flags OFF after every canary; do not convert missing real-enterprise evidence into PASS.
 
 This is a values-free execution record. It contains counts, booleans, reason enums, SHAs,
-and GitHub Actions run ids only. It intentionally omits passwords, tokens, names, email
-addresses, phone numbers, DingTalk user ids, union ids, and corp-id values.
+GitHub Actions run ids, timestamps, and non-secret synthetic operator labels. It intentionally
+omits passwords, tokens, real names, login identifiers, email addresses, phone numbers, DingTalk
+user ids, union ids, and corp-id values.
 
 ## 1. Environment boundary
 
@@ -16,23 +17,27 @@ Two independently configured deployment roots were observed and must not be conf
 
 | Evidence lane | Deployed SHA | Purpose |
 |---|---|---|
-| Lifecycle staging canary (`STAGING_DEPLOY_PATH`) | `ddec28b12ebff97fae33af45553d77c149d816e1` | Exact lifecycle status and transient alias ON/OFF proof |
-| Production-readiness inventory (`DEPLOY_PATH`) | `e27c8dbabb798cd1d3c407f1601430fd151df5bc` | Read-only DingTalk integration, account, Stream, and flag inventory |
+| Lifecycle staging canary (`STAGING_DEPLOY_PATH`) | `24794811b1c800402006b30d6e4fa9df670e124e` | Exact lifecycle status and transient alias ON/OFF proof after canary-recovery hardening |
+| Production-readiness inventory (`DEPLOY_PATH`) | `24794811b1c800402006b30d6e4fa9df670e124e` | Read-only DingTalk integration, account, Stream, and flag inventory |
 
-Neither SHA is used as proof for the other environment. Production enablement remains a
+The matching code SHA is not used to infer shared runtime state between the two roots; each
+runtime fact below is tied to its own workflow run and artifact. Production enablement remains a
 separate owner/ops decision.
 
 ## 2. Canary administrator credential
 
-The fixed staging-only administrator `staging-owner-admin` was repaired/rotated through the
-real administrative API. The new value was not printed or committed. It is retained in the
-operator's macOS Keychain and in the GitHub Actions secret
-`STAGING_OWNER_ADMIN_PASSWORD`; GitHub secret metadata records an update at
-`2026-08-11T15:00:47Z`.
+Two staging-only administrator credentials have separate purposes and must not be conflated:
 
-The real login proof is not inferred from secret presence. Alias run
-[31504979575](https://github.com/zensgit/metasheet2/actions/runs/31504979575) proved all three
-password-login legs using the configured canary credential:
+- `staging-owner-admin` and `STAGING_OWNER_ADMIN_PASSWORD` belong to the human-admin
+  bootstrap/rotation path. The value was repaired/rotated through the real administrative API,
+  was not printed or committed, and is retained in the operator's macOS Keychain and GitHub
+  Actions secret storage. Secret metadata records an update at `2026-08-11T15:00:47Z`.
+- The alias operator uses the fixed lifecycle-canary administrator and the separate
+  `LIFECYCLE_CANARY_LOGIN_IDENTIFIER` / `LIFECYCLE_CANARY_LOGIN_PASSWORD` secrets.
+
+Alias login proof is not inferred from either secret's presence. Hardened-deploy alias run
+[31529335625](https://github.com/zensgit/metasheet2/actions/runs/31529335625) proved all three
+password-login legs using the lifecycle-canary credential:
 
 - before alias enable: `pre_login_ok=true`;
 - while alias-only was live: `post_on_login_ok=true`;
@@ -86,6 +91,15 @@ the same browser session subsequently loaded `/admin/users` successfully. This p
 real DingTalk login and effective platform-administrator authorization. It does not identify or
 authorize a destructive pending/deprovision canary subject.
 
+After the hardened staging deploy, the previously completed real OAuth binding/login was rechecked
+through the still-authenticated session and administrator views. The recorded last-login time
+remained `2026-08-11T16:40:37.205Z`; this recheck is not represented as a second callback. The OAuth
+identity's corp and union identifiers matched the single linked directory account's corp and union
+identifiers, the local account was active, the DingTalk grant was enabled, and the effective roles
+included platform administrator. This is an identifier-level binding proof; no display-name or
+account-nickname inference is used. The linked directory account belongs to the shared employee
+integration and therefore remains disqualified as a destructive canary subject.
+
 These access-graph changes did not write any lifecycle environment switch. The fresh OFF proof in
 Section 3 was taken after the changes.
 
@@ -106,25 +120,28 @@ completed successfully at repository head
 | `DIRECTORY_DEPROVISION_ENABLED` | `false` |
 | transition applied | `false` (read-only status action) |
 
-A second read-only status run
-[31513394261](https://github.com/zensgit/metasheet2/actions/runs/31513394261) completed after the
-designated administrator role/grant change at repository head
-`0287b250b33fe4c7ea98b880360af74fc08a5ebf`. Its downloaded artifact again reports the same
-staging build SHA, healthy backend, zero pending migrations, `mode=off`, all three lifecycle flags
-`false`, and `transition_applied=false`. This is the current terminal-state proof; the earlier run
-remains the pre-change baseline.
+A later hardened-deploy status run
+[31528753683](https://github.com/zensgit/metasheet2/actions/runs/31528753683) and exact-SHA OFF
+preflight run [31528911914](https://github.com/zensgit/metasheet2/actions/runs/31528911914)
+completed at repository and deployed head
+`24794811b1c800402006b30d6e4fa9df670e124e`. Their downloaded artifacts report a healthy backend,
+zero pending migrations, `mode=off`, all three lifecycle flags `false`, and
+`transition_applied=false`. These supersede the earlier lifecycle-deploy terminal-state proof.
 
 ## 4. Canary sequence
 
 | Order | Stage | Result | Durable evidence / reason |
 |---|---|---|---|
-| 1 | alias-only | **PASS, rolled back** | Run `31504979575`; transient ON was proven by real password login and success required a return to exact OFF |
+| 1 | alias-only | **PASS, rolled back** | Hardened-deploy run `31529335625`; transient ON was proven by real password login and success required a return to exact OFF |
 | 2 | pending admission | **NOT EXECUTED** | Operator exists, but no explicitly owned DingTalk source employee has been proven in the target integration; no existing employee may be auto-selected |
 | 3 | deprovision | **NOT EXECUTED** | Operator exists, but requires the same owned employee in a dedicated one-account integration plus a real source-side disable/removal |
 
 ### 4.1 Alias result
 
-The alias run reported:
+The hardened-deploy alias rerun
+[31529335625](https://github.com/zensgit/metasheet2/actions/runs/31529335625) reported the following
+values in its downloaded artifact. Identical numeric counters in an earlier run do not substitute
+for this run-bound evidence:
 
 ```text
 transition_applied=true
@@ -142,8 +159,10 @@ cutover_can_enable=true
 ```
 
 Its final artifact again reported mode `off`, all three flags `false`, healthy backend,
-zero pending migrations, and the same staging build SHA. Alias rows created by a backfill
-would be allowed to persist, but this execution inserted zero rows.
+zero pending migrations, and deployed SHA
+`24794811b1c800402006b30d6e4fa9df670e124e`. Alias rows created by a backfill would be allowed to
+persist, but this execution inserted zero rows. The earlier successful run `31504979575` remains
+historical evidence against the older deploy; it is not used as proof for the hardened deploy.
 
 ### 4.2 Pending admission gate
 
@@ -151,6 +170,10 @@ A read-only account inspection found active unmatched directory accounts, but no
 explicitly designated and owned as a staging test employee. Those accounts may represent real
 people. Therefore the operator did not admit, activate, rename, disable, or otherwise mutate
 them. Presence of an unmatched account is not consent to use it as a canary.
+
+The real OAuth administrator is now conclusively corp- and union-matched to its directory account,
+but it is a privileged account in a shared integration and is not a substitute for the dedicated
+test employee required below.
 
 Required external input before execution:
 
@@ -172,6 +195,10 @@ would-deactivate accounts. A later browser inspection showed that the active int
 shared employee integration, so it is explicitly disqualified from destructive canary use.
 Deprovision cannot be proven by editing the local database or by selecting a real employee.
 
+The only other visible staging integration has a different corp anchor, zero accounts, and a
+failed most-recent sync. It cannot be repurposed as the dedicated integration for the authenticated
+corp without a separately authorized reconfiguration and valid source credentials.
+
 After Section 4.2 succeeds, an authorized operator must create/use a separate active DingTalk
 integration that contains exactly the selected account (all active and inactive account rows
 count), has scheduler, admission automation, and member-group projection disabled, and uses
@@ -191,8 +218,9 @@ apply is prohibited.
 
 ## 5. DingTalk directory readiness
 
-[Production-readiness inventory run 31505420277](https://github.com/zensgit/metasheet2/actions/runs/31505420277)
-completed successfully and reported:
+[Production-readiness inventory run 31529929612](https://github.com/zensgit/metasheet2/actions/runs/31529929612)
+completed successfully against deployed SHA
+`24794811b1c800402006b30d6e4fa9df670e124e` and reported:
 
 | Signal | Result |
 |---|---|
@@ -205,8 +233,10 @@ completed successfully and reported:
 | directory UAT baseline ready | `true` |
 | app key / app secret / agent id readiness | `true` |
 | allowed-corp allowlist | `configured` |
+| password-capable alias administrators in this deployment root | `0` |
 | pending users | `0` |
 | all lifecycle/Stream flags OFF | `true` |
+| log level | ready (`LOG_LEVEL` missing; runtime default is `info`) |
 
 This proves a usable directory baseline, not pending/deprovision canary completion and not
 interactive-card readiness.
@@ -224,7 +254,7 @@ simulated.
 | P1 latest storage-health precondition | conditionally ready, recheck at UAT start | Latest observed `Attendance Remote Storage Health (Prod)` run [31453711071](https://github.com/zensgit/metasheet2/actions/runs/31453711071) was successful; the evidence pack requires a fresh check at the actual UAT start |
 | P2 exact target SHA | known per environment | See Section 1; do not mix the two deployment roots |
 | P3 real corp + two linked users | directory subset ready only | Corp anchor and two linked users exist, but Stream app/template configuration is absent |
-| P4 `LOG_LEVEL=info|debug` | **NOT PROVEN** | Inventory reported log-level reason `missing`; silence cannot be interpreted as callback-shape evidence |
+| P4 `LOG_LEVEL=info|debug` | **READY** | Inventory reported `log_level_ready=true`, reason `missing`; `core/logger.ts` defaults an unset/empty value to `info` |
 
 Runtime inventory details for the missing Stream prerequisites:
 
@@ -237,8 +267,8 @@ credentials_ready=false
 ```
 
 Required external action: configure the four staging Stream/template inputs through the
-approved secret/configuration channel, set `LOG_LEVEL=info` for the controlled UAT window,
-execute the canonical U1-U13 procedure with real human clicks, capture only values-free
+approved secret/configuration channel, re-confirm the ready log level at the controlled UAT
+window start, execute the canonical U1-U13 procedure with real human clicks, capture only values-free
 booleans/status enums, and turn the Stream flag back OFF after U13. Secrets must not be pasted
 into this document or chat.
 
@@ -263,15 +293,13 @@ DINGTALK_INTERACTIVE_CARD_STREAM_ENABLED=false
 
 ## 8. Next executable actions
 
-1. Complete the target-enterprise selection for the operator-controlled DingTalk account and
-   verify it appears in a read-only directory preview; otherwise provision it in the target corp.
-2. Provision a dedicated staging DingTalk employee and a separate one-account manual integration;
+1. Provision a dedicated staging DingTalk employee and a separate one-account manual integration;
    authorize that subject for pending and deprovision canaries.
-3. Execute pending and prove rollback to OFF, then execute two-phase deprovision and prove restore
+2. Execute pending and prove rollback to OFF, then execute two-phase deprovision and prove restore
    plus rollback to OFF.
-4. Configure the staging Stream/template inputs and `LOG_LEVEL=info`; execute U1-U13 and the
+3. Configure the staging Stream/template inputs, re-confirm the info/debug log level, execute U1-U13 and the
    real callback corp-anchor procedure.
-5. Record named owners and explicit production switch decisions. Any absent evidence remains
+4. Record named owners and explicit production switch decisions. Any absent evidence remains
    `NOT EXECUTED`.
 
 Until those external actions occur, the lifecycle code line and alias staging canary are


### PR DESCRIPTION
## Summary
- record alias and server-side pending canary PASS while browser OAuth remains NOT EXECUTED
- record two pre-ledger deprovision failure classes, exact recovery evidence, and terminal flags-OFF status
- preserve destructive apply/restore, U1-U13/corp-anchor, production switches, and Transfer T3-T5 as explicit external gates
- identify the remaining external prerequisite: a second dedicated DingTalk sentinel with a real unique phone

## Runtime evidence
- pending admit: run 31551343313
- SSO activate intent: run 31551426867
- empty-fetch recovery: run 31555162698
- exact sync-failure recovery: run 31559371562
- terminal read-only OFF status: run 31559480395
- staging deploy SHA: 51f23ec7255c3fb0d9abc21bfbe4c3bce8e1c48f

## Verification
- `node --test scripts/ops/dingtalk-lifecycle-staging-canary-contract.test.mjs` (210/210)
- `git diff --check`
- values-free scan: no password, token, identifier, phone, corp, or DingTalk identity value added

## Safety
Docs only. No secret, lifecycle flag, runtime, canary, or production enablement change.