### PR TITLE
fix(dingtalk): recover empty-fetch canary journal

### DIFF
--- a/.github/workflows/dingtalk-lifecycle-staging-canary.yml
+++ b/.github/workflows/dingtalk-lifecycle-staging-canary.yml
@@ -40,7 +40,7 @@ run-name: "DingTalk Lifecycle Staging Canary: ${{ inputs.action }}${{ inputs.act
 #               NOT_EXECUTED (manual). Optional confirmation PENDING_SSO_ACTIVATE
 #               runs SSO activate only (no env write); browser OAuth still
 #               NOT_EXECUTED. No auto-selection. No temp_password activate claim.
-#   deprovision = Two-phase canary on the SAME explicit subject.
+#   deprovision = Multi-phase canary on the SAME explicit subject.
 #               APPLY: bootstrap_confirmation=DINGTALK_SOURCE_DISABLED_DEDICATED_EXCLUSIVE_CONFIRMED
 #               → deprovision flag ON → real sync → ledger bound to exact run.id
 #               → access denial → flags OFF (access remains disabled; not
@@ -48,6 +48,13 @@ run-name: "DingTalk Lifecycle Staging Canary: ${{ inputs.action }}${{ inputs.act
 #               RESTORE: bootstrap_confirmation=DINGTALK_SOURCE_REACTIVATED_CONFIRMED
 #               → flags stay OFF → sync after external source re-enable → rehire
 #               restore for the applied event → prove resolved + access restored.
+#               EMPTY_FETCH_ABORT_RECOVERY:
+#               bootstrap_confirmation=DINGTALK_EMPTY_FETCH_ABORT_SOURCE_RE_ADDED_CONFIRMED
+#               → flags stay OFF (never writes lifecycle env) → bind exact
+#               journal run_bound completed empty_directory_fetch abort with
+#               zero ledger → prove intact access graph → flags-OFF sync after
+#               external source re-add → prove owned directory account active +
+#               access graph unchanged → clear journal only then.
 #
 # See:
 #   docs/development/dingtalk-lifecycle-canary-separate-go-20260724.md
@@ -82,7 +89,7 @@ on:
         required: false
         default: ''
       bootstrap_confirmation:
-        description: 'bootstrap=CREATE_STAGING_CANARY_ADMIN; human-bootstrap=CREATE_STAGING_HUMAN_ADMIN; pending optional PENDING_SSO_ACTIVATE; deprovision=DINGTALK_SOURCE_DISABLED_DEDICATED_EXCLUSIVE_CONFIRMED (apply) or DINGTALK_SOURCE_REACTIVATED_CONFIRMED (restore).'
+        description: 'bootstrap=CREATE_STAGING_CANARY_ADMIN; human-bootstrap=CREATE_STAGING_HUMAN_ADMIN; pending optional PENDING_SSO_ACTIVATE; deprovision=DINGTALK_SOURCE_DISABLED_DEDICATED_EXCLUSIVE_CONFIRMED (apply) or DINGTALK_SOURCE_REACTIVATED_CONFIRMED (restore) or DINGTALK_EMPTY_FETCH_ABORT_SOURCE_RE_ADDED_CONFIRMED (empty-fetch abort recovery).'
         required: false
         type: string
         default: ''
@@ -169,9 +176,9 @@ jobs:
 
           if [[ "$ACTION" == "deprovision" ]]; then
             case "$BOOTSTRAP_CONFIRMATION" in
-              DINGTALK_SOURCE_DISABLED_DEDICATED_EXCLUSIVE_CONFIRMED|DINGTALK_SOURCE_REACTIVATED_CONFIRMED) ;;
+              DINGTALK_SOURCE_DISABLED_DEDICATED_EXCLUSIVE_CONFIRMED|DINGTALK_SOURCE_REACTIVATED_CONFIRMED|DINGTALK_EMPTY_FETCH_ABORT_SOURCE_RE_ADDED_CONFIRMED) ;;
               *)
-                echo "bootstrap_confirmation must be DINGTALK_SOURCE_DISABLED_DEDICATED_EXCLUSIVE_CONFIRMED (apply) or DINGTALK_SOURCE_REACTIVATED_CONFIRMED (restore) for action=deprovision" >&2
+                echo "bootstrap_confirmation must be DINGTALK_SOURCE_DISABLED_DEDICATED_EXCLUSIVE_CONFIRMED (apply), DINGTALK_SOURCE_REACTIVATED_CONFIRMED (restore), or DINGTALK_EMPTY_FETCH_ABORT_SOURCE_RE_ADDED_CONFIRMED (empty-fetch abort recovery) for action=deprovision" >&2
                 exit 2
               ;;
             esac
@@ -484,8 +491,10 @@ jobs:
             echo "Bootstrap/human-bootstrap/alias/pending/deprovision require LIFECYCLE_CANARY_LOGIN_IDENTIFIER/PASSWORD (file transport); human-bootstrap also requires STAGING_OWNER_ADMIN_PASSWORD; pending/deprovision also require LIFECYCLE_CANARY_DIRECTORY_ACCOUNT_ID (explicit subject; never printed)."
             echo "Pending default phase is admit-only; OAuth checkpoints are NOT_EXECUTED; optional PENDING_SSO_ACTIVATE (browser OAuth still NOT_EXECUTED)."
             echo "Deprovision apply uses DINGTALK_SOURCE_DISABLED_DEDICATED_EXCLUSIVE_CONFIRMED (flags OFF, access remains disabled). Restore uses DINGTALK_SOURCE_REACTIVATED_CONFIRMED (rehire + access restore; flags stay OFF)."
+            echo "Empty-fetch abort recovery uses DINGTALK_EMPTY_FETCH_ABORT_SOURCE_RE_ADDED_CONFIRMED (flags stay OFF; never writes lifecycle env; clears run_bound journal only after directory reactivated + access graph unchanged proofs)."
             echo "Deprovision refuses shared integrations: exactly one total directory account, manual scheduling, admission automation OFF, and member-group projection OFF are required."
             echo "Deprovision reserves and journals the exact sync run UUID before env/HTTP; lost responses recover only through that run and its exact event/effects."
+            echo "Empty-fetch abort recovery binds only the exact journal run_bound completed empty_directory_fetch abort with zero ledger; wrong phase/run/abort reason, any ledger, source still missing, access drift, sync failure, or any lifecycle flag ON leaves the journal intact."
             echo "Alias/pending/deprovision/human-bootstrap mint short-lived admin JWT from canary password login — never ATTENDANCE_ADMIN_JWT."
             echo "Runtime OFF cannot be proven if rollback recreate itself fails (override restored on disk)."
             if [[ -f output/lifecycle-canary/summary.txt ]]; then

--- a/scripts/ops/dingtalk-lifecycle-staging-canary-contract.test.mjs
+++ b/scripts/ops/dingtalk-lifecycle-staging-canary-contract.test.mjs
@@ -174,8 +174,20 @@ function actionDeprovisionApplyBody(source) {
 function actionDeprovisionRestoreBody(source) {
   const start = source.indexOf('action_deprovision_restore()')
   assert.notEqual(start, -1, 'action_deprovision_restore() must exist')
+  // Empty-fetch abort recovery follows restore; fall back to main for older snapshots.
+  let end = source.indexOf('\naction_deprovision_empty_fetch_abort_recovery()', start)
+  if (end === -1) {
+    end = source.indexOf('\n# --- main', start)
+  }
+  assert.notEqual(end, -1, 'empty_fetch_abort_recovery or main marker after restore')
+  return source.slice(start, end)
+}
+
+function actionDeprovisionEmptyFetchAbortRecoveryBody(source) {
+  const start = source.indexOf('action_deprovision_empty_fetch_abort_recovery()')
+  assert.notEqual(start, -1, 'action_deprovision_empty_fetch_abort_recovery() must exist')
   const end = source.indexOf('\n# --- main', start)
-  assert.notEqual(end, -1, 'main marker after restore')
+  assert.notEqual(end, -1, 'main marker after empty_fetch_abort_recovery')
   return source.slice(start, end)
 }
 
@@ -2890,10 +2902,16 @@ test('deprovision apply phase: subject, source disable confirm, exact run ledger
   const all = actionDeprovisionBody(source)
   assert.match(source, /DEPROVISION_SOURCE_CONFIRMATION="DINGTALK_SOURCE_DISABLED_DEDICATED_EXCLUSIVE_CONFIRMED"/)
   assert.match(source, /DEPROVISION_RESTORE_CONFIRMATION="DINGTALK_SOURCE_REACTIVATED_CONFIRMED"/)
+  assert.match(
+    source,
+    /DEPROVISION_EMPTY_FETCH_ABORT_RECOVERY_CONFIRMATION="DINGTALK_EMPTY_FETCH_ABORT_SOURCE_RE_ADDED_CONFIRMED"/,
+  )
   assert.match(all, /DEPROVISION_SOURCE_CONFIRMATION|DINGTALK_SOURCE_DISABLED_DEDICATED_EXCLUSIVE_CONFIRMED/)
   assert.match(all, /DEPROVISION_RESTORE_CONFIRMATION|action_deprovision_restore/)
+  assert.match(all, /DEPROVISION_EMPTY_FETCH_ABORT_RECOVERY_CONFIRMATION|action_deprovision_empty_fetch_abort_recovery/)
   assert.match(all, /action_deprovision_apply/)
   assert.match(all, /action_deprovision_restore/)
+  assert.match(all, /action_deprovision_empty_fetch_abort_recovery/)
   assert.match(body, /require_canary_directory_account_id_file "deprovision"/)
   assert.match(body, /run_deprovision_sync_preview_subject_gate/)
   assert.ok(
@@ -2936,6 +2954,700 @@ test('deprovision restore phase: source reactivated confirm, rehire, resolved, a
   // Rehire mode is on the restore helper (not the action body).
   assert.match(source, /"mode": "rehire"/)
   assert.match(source, /run_deprovision_rehire_restore\(\)/)
+})
+
+// --- empty_directory_fetch safe-abort recovery (run_bound, no ledger) -----------------
+
+test('empty_fetch abort recovery: staging-only, never writes lifecycle env flags', () => {
+  const source = read(REMOTE_SH)
+  const body = actionDeprovisionEmptyFetchAbortRecoveryBody(source)
+  const all = actionDeprovisionBody(source)
+  assert.match(source, /DEPROVISION_EMPTY_FETCH_ABORT_RECOVERY_CONFIRMATION/)
+  assert.match(source, /DINGTALK_EMPTY_FETCH_ABORT_SOURCE_RE_ADDED_CONFIRMED/)
+  assert.match(all, /empty_fetch_abort_recovery/)
+  assert.match(all, /action_deprovision_empty_fetch_abort_recovery/)
+  assert.match(body, /lifecycle_env_write=false/)
+  assert.match(body, /transition_applied=false/)
+  assert.doesNotMatch(body, /write_lifecycle_override/)
+  assert.doesNotMatch(body, /recreate_backend_only/)
+  assert.doesNotMatch(body, /establish_alias_off_rollback_baseline/)
+  assert.doesNotMatch(body, /arm_alias_exit_rollback_guard/)
+  // Must not enter rehire/ledger restore path.
+  assert.doesNotMatch(body, /run_deprovision_rehire_restore/)
+  assert.doesNotMatch(body, /run_or_resume_deprovision_rehire_restore/)
+  assert.doesNotMatch(body, /load_deprovision_apply_state/)
+  assert.doesNotMatch(body, /reconcile_run_journal_to_ledger_bound/)
+})
+
+test('flags-OFF directory sync requires explicit deprovisionApplied=false, not missing/null', () => {
+  const body = runDirectorySyncForSubjectBody(read(REMOTE_SH))
+  assert.match(body, /applied_s = "true" if applied is True else \("false" if applied is False else "unknown"\)/)
+  assert.match(body, /require_applied == "false" and applied is not False/)
+  assert.match(body, /deprovision_applied_not_false_on_sync/)
+})
+
+test('empty_fetch abort recovery binds exact journal run_bound + empty_directory_fetch + zero ledger + intact graph', () => {
+  const source = read(REMOTE_SH)
+  const body = actionDeprovisionEmptyFetchAbortRecoveryBody(source)
+  assert.match(body, /load_run_bound_empty_fetch_abort_journal/)
+  assert.match(body, /prove_exact_run_empty_fetch_safe_abort/)
+  assert.match(body, /prove_zero_deprovision_ledger_for_exact_run "empty_fetch_abort_recovery_pre"/)
+  assert.match(body, /prove_zero_deprovision_ledger_for_exact_run "empty_fetch_abort_recovery_final_pre_clear"/)
+  assert.match(body, /prove_intact_access_graph_no_ledger "empty_fetch_abort_recovery_pre"/)
+  assert.match(body, /assert_subject_user_access_state "activated" "true" "empty_fetch_abort_recovery_pre"/)
+  assert.match(body, /run_directory_sync_for_subject "empty_fetch_abort_recovery" "false"/)
+  assert.match(body, /SYNC_DEPROVISION_APPLIED" != "false"/)
+  assert.match(body, /SUBJECT_ACTIVE" != "true"/)
+  assert.match(body, /prove_intact_access_graph_no_ledger "empty_fetch_abort_recovery_post"/)
+  assert.match(body, /post_graph_snapshot" != "\$pre_graph_snapshot"/)
+  assert.match(body, /phase=empty_fetch_abort_recovery/)
+  assert.match(body, /aborted_reason_required=empty_directory_fetch/)
+  assert.match(body, /deprovision_applied_required=false/)
+  assert.match(body, /journal_phase_required=run_bound/)
+  assert.match(body, /journal left intact/)
+  assert.match(body, /zero_ledger_final_ok=/)
+  assert.match(body, /safe_abort_source_recovery_complete=true/)
+  assert.match(body, /canary_access_rollback_complete=false/)
+
+  // Helper contracts: phase/applied/abortedReason exactness.
+  assert.match(source, /state\.get\("phase"\) != "run_bound"/)
+  assert.match(source, /state\.get\("deprovision_applied"\) is not False/)
+  assert.match(source, /aborted\.strip\(\) != "empty_directory_fetch"/)
+  assert.match(source, /ledger_event_present_for_exact_run/)
+  assert.match(source, /grant_not_enabled/)
+  assert.match(source, /membership_not_active/)
+  assert.match(source, /user_not_activated/)
+})
+
+test('empty_fetch zero-ledger proof is exact SQL scope — rejects list/limit/latest inference', () => {
+  const source = read(REMOTE_SH)
+  const start = source.indexOf('prove_zero_deprovision_ledger_for_exact_run()')
+  assert.notEqual(start, -1)
+  const end = source.indexOf('\n# Access-graph intact proof WITHOUT effect ledger', start)
+  assert.notEqual(end, -1)
+  const body = source.slice(start, end)
+  // Exact Postgres four-key scope + effects join; no status filter.
+  assert.match(body, /FROM directory_deprovision_events e/)
+  assert.match(body, /LEFT JOIN directory_deprovision_effects fx/)
+  assert.match(body, /e\.run_id = \$1::uuid/)
+  assert.match(body, /e\.integration_id = \$2::uuid/)
+  assert.match(body, /e\.local_user_id = \$3/)
+  assert.match(body, /e\.directory_account_id = \$4::uuid/)
+  assert.match(body, /count\(DISTINCT e\.id\)::int AS event_count/)
+  assert.match(body, /count\(fx\.id\)::int AS effect_count/)
+  assert.match(body, /eventCount !== 0/)
+  assert.match(body, /effectCount !== 0/)
+  assert.doesNotMatch(body, /status\s*=\s*['"]applied['"]|status:\s*["']applied["']/)
+  // Must not use paginated admin list / limit / latest-run inference.
+  assert.doesNotMatch(body, /\/api\/admin\/directory\/deprovision\/events/)
+  assert.doesNotMatch(body, /limit["']?\s*[:=]\s*["']?50|limit=50/)
+  assert.doesNotMatch(body, /urlencode|urllib\.request/)
+  assert.doesNotMatch(body, /\bORDER BY\b|\border by\b/)
+  assert.doesNotMatch(body, /items\[0\]|latest_run|getLatest|order by created/i)
+  // Production comments may forbid "latest" in prose; that is intentional and allowed.
+  assert.match(body, /No limit\/order\/latest inference|no list\/limit/i)
+  assert.match(body, /docker exec -i/)
+  assert.match(body, /CANARY_DIRECTORY_ACCOUNT_ID_FILE/)
+  assert.match(body, /CANARY_SAFE_ABORT_SYNC_RUN_ID_FILE/)
+  assert.doesNotMatch(body, /CANARY_SUBJECT_SYNC_RUN_ID_FILE/)
+})
+
+test('MUTATION: safe-abort ledger proof may not fall back to the recovery sync run pin', () => {
+  const source = read(REMOTE_SH)
+  const start = source.indexOf('prove_zero_deprovision_ledger_for_exact_run()')
+  const end = source.indexOf('\n# Access-graph intact proof WITHOUT effect ledger', start)
+  const body = source.slice(start, end)
+  const mutated = body.replaceAll('CANARY_SAFE_ABORT_SYNC_RUN_ID_FILE', 'CANARY_SUBJECT_SYNC_RUN_ID_FILE')
+  assert.match(body, /CANARY_SAFE_ABORT_SYNC_RUN_ID_FILE/)
+  assert.doesNotMatch(body, /CANARY_SUBJECT_SYNC_RUN_ID_FILE/)
+  assert.match(mutated, /CANARY_SUBJECT_SYNC_RUN_ID_FILE/)
+})
+
+test('empty_fetch abort recovery clears journal only after final post-sync proofs and zero-ledger recheck', () => {
+  const body = actionDeprovisionEmptyFetchAbortRecoveryBody(read(REMOTE_SH))
+  const preGraph = body.indexOf('prove_intact_access_graph_no_ledger "empty_fetch_abort_recovery_pre"')
+  const preLedger = body.indexOf('prove_zero_deprovision_ledger_for_exact_run "empty_fetch_abort_recovery_pre"')
+  const sync = body.indexOf('run_directory_sync_for_subject "empty_fetch_abort_recovery" "false"')
+  const postActive = body.indexOf('SUBJECT_ACTIVE" != "true"')
+  const postGraph = body.indexOf('prove_intact_access_graph_no_ledger "empty_fetch_abort_recovery_post"')
+  const drift = body.indexOf('post_graph_snapshot" != "$pre_graph_snapshot"')
+  const flagsOff = body.indexOf('lifecycle flags must remain OFF after recovery sync')
+  const finalLedger = body.indexOf(
+    'prove_zero_deprovision_ledger_for_exact_run "empty_fetch_abort_recovery_final_pre_clear"',
+  )
+  const clear = body.indexOf('clear_deprovision_apply_state')
+  const summary = body.indexOf('phase=empty_fetch_abort_recovery')
+  assert.ok(preLedger > 0 && preGraph > preLedger, 'pre zero-ledger before pre graph / sync')
+  assert.ok(sync > preGraph, 'pre graph before flags-OFF sync')
+  assert.ok(postActive > sync && postGraph > postActive, 'post account+graph after sync')
+  assert.ok(drift > postGraph && flagsOff > drift, 'drift+flags proofs after post graph')
+  assert.ok(finalLedger > flagsOff, 'final zero-ledger recheck after all post-sync proofs')
+  assert.ok(clear > finalLedger, 'clear only after final zero-ledger recheck')
+  assert.ok(summary > clear, 'summary after clear')
+  // Explicit load-bearing markers for mutation detectors.
+  assert.match(body, /FINAL proof gate: re-prove exact no-ledger AFTER flags-OFF sync/)
+  assert.match(body, /IMMEDIATELY before clear/)
+})
+
+test('MUTATION: moving clear_deprovision_apply_state before final proofs turns red', () => {
+  const body = actionDeprovisionEmptyFetchAbortRecoveryBody(read(REMOTE_SH))
+  const clear = body.indexOf('clear_deprovision_apply_state')
+  const finalLedger = body.indexOf(
+    'prove_zero_deprovision_ledger_for_exact_run "empty_fetch_abort_recovery_final_pre_clear"',
+  )
+  assert.ok(clear > finalLedger, 'production clear must follow final zero-ledger recheck')
+  // Move clear to the top of the action body — must break the order contract.
+  const mutated =
+    body.slice(0, body.indexOf('{') + 1) +
+    '\n  clear_deprovision_apply_state\n' +
+    body.slice(body.indexOf('{') + 1).replace('clear_deprovision_apply_state', 'true # cleared early')
+  let failed = false
+  try {
+    const mClear = mutated.indexOf('clear_deprovision_apply_state')
+    const mFinal = mutated.indexOf(
+      'prove_zero_deprovision_ledger_for_exact_run "empty_fetch_abort_recovery_final_pre_clear"',
+    )
+    assert.ok(mClear > mFinal, 'clear only after final zero-ledger recheck')
+  } catch {
+    failed = true
+  }
+  assert.equal(failed, true)
+})
+
+test('MUTATION: removing final pre-clear zero-ledger recheck turns red', () => {
+  const body = actionDeprovisionEmptyFetchAbortRecoveryBody(read(REMOTE_SH))
+  assert.match(body, /empty_fetch_abort_recovery_final_pre_clear/)
+  const mutated = body.replace(
+    'prove_zero_deprovision_ledger_for_exact_run "empty_fetch_abort_recovery_final_pre_clear"',
+    'true # final zero-ledger recheck removed',
+  )
+  let failed = false
+  try {
+    const finalLedger = mutated.indexOf(
+      'prove_zero_deprovision_ledger_for_exact_run "empty_fetch_abort_recovery_final_pre_clear"',
+    )
+    const clear = mutated.indexOf('clear_deprovision_apply_state')
+    assert.ok(finalLedger > 0 && clear > finalLedger)
+    assert.match(mutated, /empty_fetch_abort_recovery_final_pre_clear/)
+  } catch {
+    failed = true
+  }
+  assert.equal(failed, true)
+})
+
+test('MUTATION: reintroducing paginated list limit=50 into zero-ledger proof turns red', () => {
+  const source = read(REMOTE_SH)
+  const start = source.indexOf('prove_zero_deprovision_ledger_for_exact_run()')
+  const end = source.indexOf('\n# Access-graph intact proof WITHOUT effect ledger', start)
+  const body = source.slice(start, end)
+  const mutated = body.replace(
+    'FROM directory_deprovision_events e',
+    'FROM directory_deprovision_events e /* limit=50 */',
+  ).replace(
+    'docker exec -i',
+    'curl -fsS "$STAGING_API_BASE_URL/api/admin/directory/deprovision/events?limit=50" # docker exec -i',
+  )
+  let failed = false
+  try {
+    assert.doesNotMatch(mutated, /limit["']?\s*[:=]\s*["']?50|limit=50/)
+    assert.doesNotMatch(mutated, /\/api\/admin\/directory\/deprovision\/events/)
+  } catch {
+    failed = true
+  }
+  assert.equal(failed, true)
+})
+
+test('clear_deprovision_apply_state log is context-neutral (not restore-only)', () => {
+  const source = read(REMOTE_SH)
+  const start = source.indexOf('clear_deprovision_apply_state()')
+  const end = source.indexOf('\n# Compat name used by older comments/tests', start)
+  const body = source.slice(start, end)
+  assert.match(body, /cleared recovery journal/)
+  assert.doesNotMatch(body, /successful restore/)
+})
+
+test('MUTATION: empty_fetch recovery writing lifecycle flags turns red', () => {
+  const body = actionDeprovisionEmptyFetchAbortRecoveryBody(read(REMOTE_SH))
+  const mutated = body.replace(
+    'lifecycle_env_write=false',
+    'lifecycle_env_write=true\n  write_lifecycle_override "false" "false" "true"',
+  )
+  let failed = false
+  try {
+    assert.doesNotMatch(mutated, /write_lifecycle_override/)
+    assert.match(mutated, /lifecycle_env_write=false/)
+  } catch {
+    failed = true
+  }
+  assert.equal(failed, true)
+})
+
+test('FUNCTIONAL: empty_fetch recovery refuses wrong journal phase and leaves journal intact', () => {
+  const home = mkdtempSync(join(tmpdir(), 'lifecycle-canary-empty-fetch-phase-'))
+  const stateDir = join(home, '.metasheet2', 'lifecycle-canary', 'subject-state')
+  const { mkdirSync, chmodSync } = awaitImportFs()
+  mkdirSync(stateDir, { recursive: true })
+  const stateFile = join(stateDir, 'lifecycle-canary-employee.apply-state.json')
+  const sec = mkdtempSync(join(tmpdir(), 'lifecycle-canary-empty-fetch-sec-'))
+  const u = '11111111-1111-4111-8111-111111111111'
+  const i = '22222222-2222-4222-8222-222222222222'
+  const a = '33333333-3333-4333-8333-333333333333'
+  const run = '44444444-4444-4444-8444-444444444444'
+  writeFileSync(
+    stateFile,
+    JSON.stringify({
+      schema: 'lifecycle-canary-deprovision-apply-state-v4',
+      phase: 'ledger_bound',
+      subject_key: 'lifecycle-canary-employee',
+      local_user_id: u,
+      integration_id: i,
+      directory_account_id: a,
+      sync_run_id: run,
+      sync_users_deactivated: 1,
+      sync_accounts_deactivated: 1,
+      sync_deprovision_candidates: 1,
+      deprovision_applied: true,
+      event_id: '55555555-5555-4555-8555-555555555555',
+      effect_count: 3,
+      effects: [],
+    }),
+  )
+  chmodSync(stateFile, 0o600)
+  writeFileSync(join(sec, 'subject.local-user-id'), u)
+  writeFileSync(join(sec, 'subject.integration-id'), i)
+  writeFileSync(join(sec, 'directory-account.id'), a)
+  chmodSync(join(sec, 'subject.local-user-id'), 0o600)
+  chmodSync(join(sec, 'subject.integration-id'), 0o600)
+  chmodSync(join(sec, 'directory-account.id'), 0o600)
+
+  const script = `
+set -euo pipefail
+source "$1"
+export HOME="$2"
+CANARY_APPLY_STATE_DIR="$3"
+CANARY_APPLY_STATE_FILE="$4"
+CANARY_SUBJECT_LOCAL_USER_ID_FILE="$5/subject.local-user-id"
+CANARY_SUBJECT_INTEGRATION_ID_FILE="$5/subject.integration-id"
+CANARY_DIRECTORY_ACCOUNT_ID_FILE="$5/directory-account.id"
+SUBJECT_OWNER_USERNAME=lifecycle-canary-employee
+set +e
+load_run_bound_empty_fetch_abort_journal
+rc=$?
+set -e
+printf 'rc=%s note=%s exists=%s\\n' "$rc" "\${SAFE_ABORT_JOURNAL_NOTE:-unset}" "$([[ -f "$4" ]] && echo yes || echo no)"
+`
+  const r = spawnSync(
+    'bash',
+    ['-o', 'pipefail', '-c', script, 'bash', REMOTE_SH, home, stateDir, stateFile, sec],
+    {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        ACTION: 'deprovision',
+        OUTPUT_DIR: home,
+        RUN_STAMP: 'contract-empty-fetch-phase',
+        LIFECYCLE_CANARY_SOURCE_ONLY: 'true',
+      },
+    },
+  )
+  assert.equal(r.status, 0, r.stderr + r.stdout)
+  assert.match(r.stdout, /rc=1 /)
+  assert.match(r.stdout, /exists=yes/)
+  assert.equal(JSON.parse(readFileSync(stateFile, 'utf8')).phase, 'ledger_bound')
+  rmSync(home, { recursive: true, force: true })
+  rmSync(sec, { recursive: true, force: true })
+})
+
+test('FUNCTIONAL: empty_fetch recovery accepts run_bound applied=false journal and refuses applied=true', () => {
+  const home = mkdtempSync(join(tmpdir(), 'lifecycle-canary-empty-fetch-ok-'))
+  const stateDir = join(home, '.metasheet2', 'lifecycle-canary', 'subject-state')
+  const { mkdirSync, chmodSync } = awaitImportFs()
+  mkdirSync(stateDir, { recursive: true })
+  const stateFile = join(stateDir, 'lifecycle-canary-employee.apply-state.json')
+  const sec = mkdtempSync(join(tmpdir(), 'lifecycle-canary-empty-fetch-ok-sec-'))
+  const u = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+  const i = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
+  const a = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc'
+  const run = 'dddddddd-dddd-4ddd-8ddd-dddddddddddd'
+  const base = {
+    schema: 'lifecycle-canary-deprovision-apply-state-v4',
+    phase: 'run_bound',
+    subject_key: 'lifecycle-canary-employee',
+    local_user_id: u,
+    integration_id: i,
+    directory_account_id: a,
+    sync_run_id: run,
+    sync_users_deactivated: 0,
+    sync_accounts_deactivated: 1,
+    sync_deprovision_candidates: 0,
+    event_id: null,
+    effect_count: null,
+    effects: null,
+  }
+  writeFileSync(stateFile, JSON.stringify({ ...base, deprovision_applied: false }))
+  chmodSync(stateFile, 0o600)
+  writeFileSync(join(sec, 'subject.local-user-id'), u)
+  writeFileSync(join(sec, 'subject.integration-id'), i)
+  writeFileSync(join(sec, 'directory-account.id'), a)
+  for (const f of ['subject.local-user-id', 'subject.integration-id', 'directory-account.id']) {
+    chmodSync(join(sec, f), 0o600)
+  }
+
+  const harnessEnv = {
+    ...process.env,
+    ACTION: 'deprovision',
+    OUTPUT_DIR: home,
+    RUN_STAMP: 'contract-empty-fetch-ok',
+    LIFECYCLE_CANARY_SOURCE_ONLY: 'true',
+  }
+  const okScript = `
+set -euo pipefail
+source "$1"
+export HOME="$2"
+CANARY_APPLY_STATE_DIR="$3"
+CANARY_APPLY_STATE_FILE="$4"
+CANARY_SUBJECT_LOCAL_USER_ID_FILE="$5/subject.local-user-id"
+CANARY_SUBJECT_INTEGRATION_ID_FILE="$5/subject.integration-id"
+CANARY_DIRECTORY_ACCOUNT_ID_FILE="$5/directory-account.id"
+SUBJECT_OWNER_USERNAME=lifecycle-canary-employee
+load_run_bound_empty_fetch_abort_journal
+printf 'ok phase=%s run_file=%s\\n' "$JOURNAL_PHASE" "$([[ -s "\${CANARY_SAFE_ABORT_SYNC_RUN_ID_FILE:-}" ]] && echo yes || echo no)"
+`
+  const ok = spawnSync(
+    'bash',
+    ['-o', 'pipefail', '-c', okScript, 'bash', REMOTE_SH, home, stateDir, stateFile, sec],
+    { encoding: 'utf8', env: harnessEnv },
+  )
+  assert.equal(ok.status, 0, ok.stderr + ok.stdout)
+  assert.match(ok.stdout, /ok phase=run_bound run_file=yes/)
+  assert.ok(existsSync(stateFile), 'eligible journal must remain until final clear')
+
+  writeFileSync(stateFile, JSON.stringify({ ...base, deprovision_applied: true }))
+  chmodSync(stateFile, 0o600)
+  const badScript = `
+set -euo pipefail
+source "$1"
+export HOME="$2"
+CANARY_APPLY_STATE_DIR="$3"
+CANARY_APPLY_STATE_FILE="$4"
+CANARY_SUBJECT_LOCAL_USER_ID_FILE="$5/subject.local-user-id"
+CANARY_SUBJECT_INTEGRATION_ID_FILE="$5/subject.integration-id"
+CANARY_DIRECTORY_ACCOUNT_ID_FILE="$5/directory-account.id"
+SUBJECT_OWNER_USERNAME=lifecycle-canary-employee
+set +e
+load_run_bound_empty_fetch_abort_journal
+rc=$?
+set -e
+printf 'rc=%s exists=%s\\n' "$rc" "$([[ -f "$4" ]] && echo yes || echo no)"
+`
+  const bad = spawnSync(
+    'bash',
+    ['-o', 'pipefail', '-c', badScript, 'bash', REMOTE_SH, home, stateDir, stateFile, sec],
+    { encoding: 'utf8', env: harnessEnv },
+  )
+  assert.equal(bad.status, 0, bad.stderr + bad.stdout)
+  assert.match(bad.stdout, /rc=1 /)
+  assert.match(bad.stdout, /exists=yes/)
+  assert.equal(JSON.parse(readFileSync(stateFile, 'utf8')).deprovision_applied, true)
+  rmSync(home, { recursive: true, force: true })
+  rmSync(sec, { recursive: true, force: true })
+})
+
+test('FUNCTIONAL: empty_fetch exact-run proof requires completed+applied=false+empty_directory_fetch', async () => {
+  const home = mkdtempSync(join(tmpdir(), 'lifecycle-canary-empty-fetch-run-'))
+  const sec = join(home, 'secrets')
+  const { mkdirSync, chmodSync } = awaitImportFs()
+  mkdirSync(sec, { recursive: true })
+  const jwt = join(sec, 'admin.jwt')
+  const integ = join(sec, 'subject.integration-id')
+  const runFile = join(sec, 'subject.sync-run-id')
+  const integrationId = '11111111-2222-4333-8444-555555555555'
+  const runId = 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee'
+  writeFileSync(jwt, 'test-token')
+  writeFileSync(integ, integrationId)
+  writeFileSync(runFile, runId)
+  chmodSync(jwt, 0o600)
+  chmodSync(integ, 0o600)
+  chmodSync(runFile, 0o600)
+
+  const serverSource = `
+import json
+from http.server import BaseHTTPRequestHandler, HTTPServer
+RUN = ${JSON.stringify(runId)}
+class H(BaseHTTPRequestHandler):
+    def log_message(self, *_): pass
+    def send_json(self, code, payload):
+        body = json.dumps(payload, separators=(",", ":")).encode()
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+    def do_GET(self):
+        if not self.path.endswith("/runs/" + RUN):
+            self.send_json(404, {"ok": False})
+            return
+        self.send_json(200, {
+            "ok": True,
+            "data": {
+                "run": {
+                    "id": RUN,
+                    "status": "completed",
+                    "stats": {
+                        "deprovisionApplied": False,
+                        "deprovisionAbortedReason": "empty_directory_fetch",
+                        "deprovisionUsersDeactivatedCount": 0,
+                        "deprovisionGrantsDisabledCount": 0,
+                        "deprovisionMembershipDeactivationAttemptedCount": 0,
+                        "accountsDeactivatedCount": 1,
+                    },
+                }
+            },
+        })
+s = HTTPServer(("127.0.0.1", 0), H)
+print(s.server_port, flush=True)
+s.serve_forever()
+`
+  const server = spawn('python3', ['-u', '-c', serverSource], { stdio: ['ignore', 'pipe', 'pipe'] })
+  const port = await new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error('empty-fetch run server did not start')), 5000)
+    server.once('exit', (code) => {
+      clearTimeout(timer)
+      reject(new Error(`empty-fetch run server exited ${code}`))
+    })
+    server.stdout.once('data', (chunk) => {
+      clearTimeout(timer)
+      resolve(String(chunk).trim())
+    })
+  })
+  try {
+    const script = `
+set -euo pipefail
+source "$1"
+STAGING_API_BASE_URL="http://127.0.0.1:$2"
+CANARY_ADMIN_JWT_FILE="$3"
+CANARY_SUBJECT_INTEGRATION_ID_FILE="$4"
+CANARY_SAFE_ABORT_SYNC_RUN_ID_FILE="$5"
+prove_exact_run_empty_fetch_safe_abort
+printf 'ok=%s note=%s\\n' "$SAFE_ABORT_RUN_OK" "$SAFE_ABORT_RUN_NOTE"
+`
+    const r = spawnSync(
+      'bash',
+      ['-o', 'pipefail', '-c', script, 'bash', REMOTE_SH, port, jwt, integ, runFile],
+      {
+        encoding: 'utf8',
+        timeout: 10000,
+        env: {
+          ...process.env,
+          ACTION: 'deprovision',
+          OUTPUT_DIR: home,
+          RUN_STAMP: 'contract-empty-fetch-run',
+          LIFECYCLE_CANARY_SOURCE_ONLY: 'true',
+        },
+      },
+    )
+    assert.equal(r.status, 0, r.stderr + r.stdout)
+    assert.match(r.stdout, /ok=true note=ok/)
+  } finally {
+    server.kill('SIGTERM')
+    rmSync(home, { recursive: true, force: true })
+  }
+})
+
+test('FUNCTIONAL: zero-ledger exact SQL proof fails closed when event_count>0 (no list API)', () => {
+  const home = mkdtempSync(join(tmpdir(), 'lifecycle-canary-empty-fetch-ledger-'))
+  const sec = join(home, 'secrets')
+  const { mkdirSync, chmodSync } = awaitImportFs()
+  mkdirSync(sec, { recursive: true })
+  const user = join(sec, 'subject.local-user-id')
+  const integ = join(sec, 'subject.integration-id')
+  const runFile = join(sec, 'subject.sync-run-id')
+  const acct = join(sec, 'directory-account.id')
+  const userId = '99999999-8888-4777-8666-555555555555'
+  const integrationId = '11111111-2222-4333-8444-555555555555'
+  const runId = 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee'
+  const accountId = '12121212-3434-4656-8878-909090909090'
+  writeFileSync(user, userId)
+  writeFileSync(integ, integrationId)
+  writeFileSync(runFile, runId)
+  writeFileSync(acct, accountId)
+  for (const f of [user, integ, runFile, acct]) chmodSync(f, 0o600)
+
+  // Mock docker exec path used by exact SQL helper: emit event_count=1 effect_count=2.
+  const script = `
+set -euo pipefail
+source "$1"
+CANARY_SUBJECT_LOCAL_USER_ID_FILE="$2"
+CANARY_SUBJECT_INTEGRATION_ID_FILE="$3"
+CANARY_SAFE_ABORT_SYNC_RUN_ID_FILE="$4"
+CANARY_DIRECTORY_ACCOUNT_ID_FILE="$5"
+BACKEND_CONTAINER=metasheet-staging-backend
+docker() {
+  if [[ "\$1" == "exec" ]]; then
+    # Consume payload stdin; never hit network/admin list.
+    cat >/dev/null
+    printf 'false|ledger_event_present_for_exact_run|1|2'
+    return 0
+  fi
+  return 125
+}
+set +e
+prove_zero_deprovision_ledger_for_exact_run "contract_event_present"
+rc=\$?
+set -e
+printf 'rc=%s note=%s events=%s effects=%s\\n' "\$rc" "\$SAFE_ABORT_LEDGER_NOTE" "\$SAFE_ABORT_LEDGER_EVENT_COUNT" "\$SAFE_ABORT_LEDGER_EFFECT_COUNT"
+`
+  const r = spawnSync(
+    'bash',
+    ['-o', 'pipefail', '-c', script, 'bash', REMOTE_SH, user, integ, runFile, acct],
+    {
+      encoding: 'utf8',
+      timeout: 10000,
+      env: {
+        ...process.env,
+        ACTION: 'deprovision',
+        OUTPUT_DIR: home,
+        RUN_STAMP: 'contract-empty-fetch-ledger',
+        LIFECYCLE_CANARY_SOURCE_ONLY: 'true',
+      },
+    },
+  )
+  assert.equal(r.status, 0, r.stderr + r.stdout)
+  assert.match(r.stdout, /rc=1 /)
+  assert.match(r.stdout, /ledger_event_present_for_exact_run/)
+  assert.match(r.stdout, /events=1 effects=2/)
+  rmSync(home, { recursive: true, force: true })
+})
+
+test('FUNCTIONAL: zero-ledger exact SQL proof accepts event_count=0 and effect_count=0', () => {
+  const home = mkdtempSync(join(tmpdir(), 'lifecycle-canary-empty-fetch-ledger-ok-'))
+  const sec = join(home, 'secrets')
+  const { mkdirSync, chmodSync } = awaitImportFs()
+  mkdirSync(sec, { recursive: true })
+  const user = join(sec, 'subject.local-user-id')
+  const integ = join(sec, 'subject.integration-id')
+  const runFile = join(sec, 'subject.sync-run-id')
+  const acct = join(sec, 'directory-account.id')
+  writeFileSync(user, '99999999-8888-4777-8666-555555555555')
+  writeFileSync(integ, '11111111-2222-4333-8444-555555555555')
+  writeFileSync(runFile, 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee')
+  writeFileSync(acct, '12121212-3434-4656-8878-909090909090')
+  for (const f of [user, integ, runFile, acct]) chmodSync(f, 0o600)
+
+  const script = `
+set -euo pipefail
+source "$1"
+CANARY_SUBJECT_LOCAL_USER_ID_FILE="$2"
+CANARY_SUBJECT_INTEGRATION_ID_FILE="$3"
+CANARY_SAFE_ABORT_SYNC_RUN_ID_FILE="$4"
+CANARY_DIRECTORY_ACCOUNT_ID_FILE="$5"
+BACKEND_CONTAINER=metasheet-staging-backend
+docker() {
+  if [[ "\$1" == "exec" ]]; then
+    cat >/dev/null
+    printf 'true|ok|0|0'
+    return 0
+  fi
+  return 125
+}
+prove_zero_deprovision_ledger_for_exact_run "contract_zero_ok"
+printf 'ok=%s note=%s events=%s effects=%s\\n' "\$SAFE_ABORT_LEDGER_OK" "\$SAFE_ABORT_LEDGER_NOTE" "\$SAFE_ABORT_LEDGER_EVENT_COUNT" "\$SAFE_ABORT_LEDGER_EFFECT_COUNT"
+`
+  const r = spawnSync(
+    'bash',
+    ['-o', 'pipefail', '-c', script, 'bash', REMOTE_SH, user, integ, runFile, acct],
+    {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        ACTION: 'deprovision',
+        OUTPUT_DIR: home,
+        RUN_STAMP: 'contract-empty-fetch-ledger-ok',
+        LIFECYCLE_CANARY_SOURCE_ONLY: 'true',
+      },
+    },
+  )
+  assert.equal(r.status, 0, r.stderr + r.stdout)
+  assert.match(r.stdout, /ok=true note=ok events=0 effects=0/)
+  rmSync(home, { recursive: true, force: true })
+})
+
+test('FUNCTIONAL: zero-ledger proof keeps the abort run pin after a distinct recovery sync run exists', () => {
+  const home = mkdtempSync(join(tmpdir(), 'lifecycle-canary-empty-fetch-run-pin-'))
+  const sec = join(home, 'secrets')
+  const { mkdirSync, chmodSync } = awaitImportFs()
+  mkdirSync(sec, { recursive: true })
+  const user = join(sec, 'subject.local-user-id')
+  const integ = join(sec, 'subject.integration-id')
+  const abortRun = join(sec, 'subject.safe-abort-sync-run-id')
+  const recoveryRun = join(sec, 'subject.sync-run-id')
+  const acct = join(sec, 'directory-account.id')
+  const abortRunId = 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee'
+  writeFileSync(user, '99999999-8888-4777-8666-555555555555')
+  writeFileSync(integ, '11111111-2222-4333-8444-555555555555')
+  writeFileSync(abortRun, abortRunId)
+  writeFileSync(recoveryRun, 'bbbbbbbb-cccc-4ddd-8eee-ffffffffffff')
+  writeFileSync(acct, '12121212-3434-4656-8878-909090909090')
+  for (const f of [user, integ, abortRun, recoveryRun, acct]) chmodSync(f, 0o600)
+
+  const script = `
+set -euo pipefail
+source "$1"
+CANARY_SUBJECT_LOCAL_USER_ID_FILE="$2"
+CANARY_SUBJECT_INTEGRATION_ID_FILE="$3"
+CANARY_SAFE_ABORT_SYNC_RUN_ID_FILE="$4"
+CANARY_SUBJECT_SYNC_RUN_ID_FILE="$5"
+CANARY_DIRECTORY_ACCOUNT_ID_FILE="$6"
+EXPECTED_ABORT_RUN_ID="$7"
+BACKEND_CONTAINER=metasheet-staging-backend
+docker() {
+  local payload
+  payload="$(cat)"
+  if [[ "$payload" == *"$EXPECTED_ABORT_RUN_ID"* ]]; then
+    printf 'true|ok|0|0'
+  else
+    printf 'false|wrong_run_pin|0|0'
+  fi
+}
+prove_zero_deprovision_ledger_for_exact_run "contract_distinct_run_pin"
+printf 'ok=%s note=%s\\n' "$SAFE_ABORT_LEDGER_OK" "$SAFE_ABORT_LEDGER_NOTE"
+`
+  const r = spawnSync(
+    'bash',
+    ['-o', 'pipefail', '-c', script, 'bash', REMOTE_SH, user, integ, abortRun, recoveryRun, acct, abortRunId],
+    {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        ACTION: 'deprovision',
+        OUTPUT_DIR: home,
+        RUN_STAMP: 'contract-empty-fetch-distinct-run-pin',
+        LIFECYCLE_CANARY_SOURCE_ONLY: 'true',
+      },
+    },
+  )
+  assert.equal(r.status, 0, r.stderr + r.stdout)
+  assert.match(r.stdout, /ok=true note=ok/)
+  rmSync(home, { recursive: true, force: true })
+})
+
+test('workflow validates empty-fetch abort recovery confirmation for action=deprovision', () => {
+  const yaml = read(WORKFLOW)
+  assert.match(yaml, /DINGTALK_EMPTY_FETCH_ABORT_SOURCE_RE_ADDED_CONFIRMED/)
+  assert.match(
+    yaml,
+    /DINGTALK_SOURCE_DISABLED_DEDICATED_EXCLUSIVE_CONFIRMED\|DINGTALK_SOURCE_REACTIVATED_CONFIRMED\|DINGTALK_EMPTY_FETCH_ABORT_SOURCE_RE_ADDED_CONFIRMED/,
+  )
+  // Secret paths for deprovision still cover recovery (same action).
+  assert.match(
+    yaml,
+    /\(inputs\.action == 'pending' \|\| inputs\.action == 'deprovision'\) && secrets\.LIFECYCLE_CANARY_DIRECTORY_ACCOUNT_ID/,
+  )
+  assert.match(yaml, /LIFECYCLE_CANARY_LOGIN_IDENTIFIER/)
+  assert.match(yaml, /LIFECYCLE_CANARY_LOGIN_PASSWORD/)
+  assert.match(yaml, /CANARY_DIRECTORY_ACCOUNT_ID_FILE=/)
+  assert.doesNotMatch(yaml, /export LIFECYCLE_CANARY_DIRECTORY_ACCOUNT_ID=/)
+  assert.doesNotMatch(yaml, /export LIFECYCLE_CANARY_LOGIN_PASSWORD=/)
 })
 
 test('deprovision ledger requires exact sync run.id equality (load-bearing)', () => {
@@ -3158,9 +3870,11 @@ test('workflow pending/deprovision phase confirmations and honest claims', () =>
   assert.match(yaml, /PENDING_SSO_ACTIVATE/)
   assert.match(yaml, /DINGTALK_SOURCE_DISABLED_DEDICATED_EXCLUSIVE_CONFIRMED/)
   assert.match(yaml, /DINGTALK_SOURCE_REACTIVATED_CONFIRMED/)
+  assert.match(yaml, /DINGTALK_EMPTY_FETCH_ABORT_SOURCE_RE_ADDED_CONFIRMED/)
   assert.match(yaml, /directory-account\.id/)
   assert.match(yaml, /NOT_EXECUTED/)
   assert.match(yaml, /restore phase|RESTORE/)
+  assert.match(yaml, /empty-fetch abort recovery|EMPTY_FETCH_ABORT/)
   assert.doesNotMatch(yaml, /docs may still say NOT EXECUTABLE|follow-up to refresh docs/i)
   assert.match(yaml, /exactly one total directory account/)
   assert.match(yaml, /reserves and journals the exact sync run UUID before env\/HTTP/)

--- a/scripts/ops/dingtalk-lifecycle-staging-canary-remote.sh
+++ b/scripts/ops/dingtalk-lifecycle-staging-canary-remote.sh
@@ -64,6 +64,15 @@
 #                verifies ledger/effects/generation/access denial, then
 #                restore/prove OFF. Full source rehire/reactivate restore is an
 #                EXTERNAL phase (fail-closed note; not claimed by this action).
+#                EMPTY_FETCH_ABORT_RECOVERY (confirmation=
+#                DINGTALK_EMPTY_FETCH_ABORT_SOURCE_RE_ADDED_CONFIRMED): staging-only
+#                fail-closed recovery when the journal is stranded at phase=run_bound
+#                after an exact completed sync aborted with empty_directory_fetch and
+#                produced no user/membership/grant ledger. Never writes lifecycle env
+#                flags. Requires exact journal run, abortedReason match, zero ledger,
+#                pre-recovery intact access graph, external source re-add, flags-OFF
+#                sync, owned directory account active, and access graph unchanged —
+#                then and only then clears the journal.
 #
 # HARD SAFETY RAILS:
 #   * Staging compose + metasheet-staging-* containers only; no prod fallback.
@@ -131,6 +140,9 @@ SUBJECT_OWNER_NAME="Lifecycle Canary Employee"
 SUBJECT_OWNER_USERNAME="lifecycle-canary-employee"
 DEPROVISION_SOURCE_CONFIRMATION="DINGTALK_SOURCE_DISABLED_DEDICATED_EXCLUSIVE_CONFIRMED"
 DEPROVISION_RESTORE_CONFIRMATION="DINGTALK_SOURCE_REACTIVATED_CONFIRMED"
+# Staging-only recovery for a completed empty_directory_fetch safe abort stranded at
+# phase=run_bound with no deprovision ledger. Never writes lifecycle env flags.
+DEPROVISION_EMPTY_FETCH_ABORT_RECOVERY_CONFIRMATION="DINGTALK_EMPTY_FETCH_ABORT_SOURCE_RE_ADDED_CONFIRMED"
 PENDING_SSO_ACTIVATE_CONFIRMATION="PENDING_SSO_ACTIVATE"
 # Optional subject password file (path only). When present, deprovision may prove
 # pre-login then post-denial with the SAME proven credential. Never invent a wrong
@@ -2447,7 +2459,7 @@ stats = run.get("stats") if isinstance(run.get("stats"), dict) else {}
 if not stats and isinstance(data.get("stats"), dict):
     stats = data["stats"]
 applied = stats.get("deprovisionApplied")
-applied_s = "true" if applied is True else "false"
+applied_s = "true" if applied is True else ("false" if applied is False else "unknown")
 users = stats.get("deprovisionUsersDeactivatedCount")
 accounts = stats.get("accountsDeactivatedCount")
 candidates = stats.get("deprovisionCandidateCount")
@@ -2460,6 +2472,8 @@ def nonneg(v):
 if require_applied == "true" and applied is not True:
     # run id already on disk; emit run_present=true so caller upgrades journal.
     emit("false", "deprovision_not_applied_on_sync", applied_s, nonneg(users), nonneg(accounts), nonneg(candidates), "true")
+if require_applied == "false" and applied is not False:
+    emit("false", "deprovision_applied_not_false_on_sync", applied_s, nonneg(users), nonneg(accounts), nonneg(candidates), "true")
 
 # Radius notes for apply: emit false WITH run_present=true so recovery journal can bind.
 # Callers must journal phase=run_bound before treating this as terminal.
@@ -2948,7 +2962,8 @@ clear_deprovision_apply_state() {
   if [[ -f "$CANARY_APPLY_STATE_FILE" ]]; then
     rm -f "$CANARY_APPLY_STATE_FILE"
     JOURNAL_PHASE="none"
-    log "cleared recovery journal after successful restore"
+    # Context-neutral: used by rehire restore and empty_fetch abort recovery.
+    log "cleared recovery journal"
   fi
 }
 
@@ -3024,6 +3039,501 @@ PY
   fi
   log "reconcile prepared/run_bound→ledger_bound OK (exact reserved run bound; ids never logged)"
   return 0
+}
+
+# Load host journal for empty_directory_fetch safe-abort recovery only.
+# Accepts EXACTLY phase=run_bound with deprovision_applied=false and no ledger
+# binding. Never upgrades to ledger_bound; never auto-discovers events/runs.
+# Leaves journal intact on any refuse (caller must not clear).
+load_run_bound_empty_fetch_abort_journal() {
+  SAFE_ABORT_JOURNAL_OK="false"
+  SAFE_ABORT_JOURNAL_NOTE="unset"
+  [[ -f "$CANARY_APPLY_STATE_FILE" && -s "$CANARY_APPLY_STATE_FILE" ]] \
+    || { SAFE_ABORT_JOURNAL_NOTE="journal_missing"; return 1; }
+  [[ -n "${CANARY_SUBJECT_LOCAL_USER_ID_FILE:-}" && -s "${CANARY_SUBJECT_LOCAL_USER_ID_FILE}" ]] \
+    || { SAFE_ABORT_JOURNAL_NOTE="live_local_user_id_missing"; return 1; }
+  [[ -n "${CANARY_SUBJECT_INTEGRATION_ID_FILE:-}" && -s "${CANARY_SUBJECT_INTEGRATION_ID_FILE}" ]] \
+    || { SAFE_ABORT_JOURNAL_NOTE="live_integration_id_missing"; return 1; }
+  [[ -n "${CANARY_DIRECTORY_ACCOUNT_ID_FILE:-}" && -s "${CANARY_DIRECTORY_ACCOUNT_ID_FILE}" ]] \
+    || { SAFE_ABORT_JOURNAL_NOTE="live_directory_account_id_missing"; return 1; }
+  local sec_dir
+  sec_dir="$(_subject_secret_dir)"
+  if ! python3 - \
+    "$CANARY_APPLY_STATE_FILE" \
+    "$sec_dir" \
+    "$SUBJECT_OWNER_USERNAME" \
+    "$CANARY_SUBJECT_LOCAL_USER_ID_FILE" \
+    "$CANARY_SUBJECT_INTEGRATION_ID_FILE" \
+    "$CANARY_DIRECTORY_ACCOUNT_ID_FILE" <<'PY'
+import json, os, pathlib, re, sys
+(
+    state_path, sec_dir, subject_key,
+    live_user_path, live_integ_path, live_acct_path,
+) = sys.argv[1:7]
+uuid_re = re.compile(
+    r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+)
+try:
+    state = json.loads(pathlib.Path(state_path).read_bytes().decode("utf-8"))
+except Exception:
+    raise SystemExit(2)
+if not isinstance(state, dict) or state.get("schema") != "lifecycle-canary-deprovision-apply-state-v4":
+    raise SystemExit(3)
+if state.get("subject_key") != subject_key:
+    raise SystemExit(4)
+# Exact phase only — prepared must not skip to this recovery; ledger_bound uses restore.
+if state.get("phase") != "run_bound":
+    raise SystemExit(5)
+# Terminal safe-abort outcome from journal_upgrade_run_bound: applied must be false.
+if state.get("deprovision_applied") is not False:
+    raise SystemExit(6)
+# No ledger binding may exist for this recovery path.
+if state.get("event_id") not in (None, ""):
+    raise SystemExit(7)
+if state.get("effect_count") not in (None, 0):
+    raise SystemExit(8)
+effects = state.get("effects")
+if effects is not None and effects != []:
+    raise SystemExit(9)
+run_id = str(state.get("sync_run_id") or "").strip()
+local_user_id = str(state.get("local_user_id") or "").strip()
+integration_id = str(state.get("integration_id") or "").strip()
+directory_account_id = str(state.get("directory_account_id") or "").strip()
+for val in (run_id, local_user_id, integration_id, directory_account_id):
+    if not uuid_re.fullmatch(val):
+        raise SystemExit(10)
+live_user = pathlib.Path(live_user_path).read_bytes().decode("utf-8").strip()
+live_integ = pathlib.Path(live_integ_path).read_bytes().decode("utf-8").strip()
+live_acct = pathlib.Path(live_acct_path).read_bytes().decode("utf-8").strip()
+if live_user != local_user_id or live_integ != integration_id or live_acct != directory_account_id:
+    raise SystemExit(11)
+sec = pathlib.Path(sec_dir)
+sec.mkdir(parents=True, exist_ok=True)
+abort_run_path = sec / "subject.safe-abort-sync-run-id"
+abort_run_path.write_bytes(run_id.encode("utf-8"))
+os.chmod(abort_run_path, 0o600)
+(sec / "subject.local-user-id").write_bytes(local_user_id.encode("utf-8"))
+os.chmod(sec / "subject.local-user-id", 0o600)
+(sec / "subject.integration-id").write_bytes(integration_id.encode("utf-8"))
+os.chmod(sec / "subject.integration-id", 0o600)
+PY
+  then
+    SAFE_ABORT_JOURNAL_NOTE="journal_not_run_bound_safe_abort"
+    return 1
+  fi
+  # This immutable pin must survive the recovery sync, which writes its own
+  # fresh run id to subject.sync-run-id.
+  CANARY_SAFE_ABORT_SYNC_RUN_ID_FILE="${sec_dir}/subject.safe-abort-sync-run-id"
+  CANARY_SUBJECT_LOCAL_USER_ID_FILE="${sec_dir}/subject.local-user-id"
+  CANARY_SUBJECT_INTEGRATION_ID_FILE="${sec_dir}/subject.integration-id"
+  JOURNAL_PHASE="run_bound"
+  SAFE_ABORT_JOURNAL_OK="true"
+  SAFE_ABORT_JOURNAL_NOTE="ok"
+  log "loaded recovery journal phase=run_bound for empty_fetch_abort recovery (exact run bound; no ledger; ids never logged)"
+  return 0
+}
+
+# Prove the exact journaled sync run is terminal completed with
+# deprovisionApplied=false and deprovisionAbortedReason=empty_directory_fetch.
+# Binds ONLY CANARY_SAFE_ABORT_SYNC_RUN_ID_FILE (journal run). Never latest-run guess.
+prove_exact_run_empty_fetch_safe_abort() {
+  SAFE_ABORT_RUN_OK="false"
+  SAFE_ABORT_RUN_NOTE="unset"
+  [[ -n "${CANARY_ADMIN_JWT_FILE:-}" && -s "${CANARY_ADMIN_JWT_FILE}" ]] \
+    || { SAFE_ABORT_RUN_NOTE="admin_jwt_missing"; return 1; }
+  [[ -n "${CANARY_SUBJECT_INTEGRATION_ID_FILE:-}" && -s "${CANARY_SUBJECT_INTEGRATION_ID_FILE}" ]] \
+    || { SAFE_ABORT_RUN_NOTE="integration_id_file_missing"; return 1; }
+  [[ -n "${CANARY_SAFE_ABORT_SYNC_RUN_ID_FILE:-}" && -s "${CANARY_SAFE_ABORT_SYNC_RUN_ID_FILE}" ]] \
+    || { SAFE_ABORT_RUN_NOTE="sync_run_id_file_missing"; return 1; }
+  local result
+  result="$(
+    python3 - \
+      "$CANARY_ADMIN_JWT_FILE" \
+      "$STAGING_API_BASE_URL" \
+      "$CANARY_SUBJECT_INTEGRATION_ID_FILE" \
+      "$CANARY_SAFE_ABORT_SYNC_RUN_ID_FILE" <<'PY'
+import json, pathlib, re, sys, urllib.error, urllib.parse, urllib.request
+
+jwt_path, base, integ_path, run_path = sys.argv[1:5]
+
+def emit(ok, note):
+    print(f"{ok}|{note}")
+    raise SystemExit(0)
+
+try:
+    token = pathlib.Path(jwt_path).read_text(encoding="utf-8").strip()
+    integration_id = pathlib.Path(integ_path).read_bytes().decode("utf-8").strip()
+    run_id = pathlib.Path(run_path).read_bytes().decode("utf-8").strip()
+except Exception:
+    emit("false", "secret_file_read_failed")
+uuid_re = re.compile(
+    r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+)
+if not uuid_re.fullmatch(integration_id) or not uuid_re.fullmatch(run_id):
+    emit("false", "ids_invalid")
+url = (
+    base.rstrip("/")
+    + "/api/admin/directory/integrations/"
+    + urllib.parse.quote(integration_id, safe="")
+    + "/runs/"
+    + urllib.parse.quote(run_id, safe="")
+)
+req = urllib.request.Request(
+    url,
+    headers={"Authorization": f"Bearer {token}", "Accept": "application/json"},
+    method="GET",
+)
+try:
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        raw = resp.read().decode("utf-8", errors="replace")
+        code = int(resp.getcode())
+except urllib.error.HTTPError as e:
+    emit("false", f"run_http_{int(e.code)}")
+except Exception:
+    emit("false", "run_transport_failed")
+try:
+    payload = json.loads(raw) if raw else {}
+except Exception:
+    emit("false", "run_bad_json")
+if code != 200 or not isinstance(payload, dict) or payload.get("ok") is not True:
+    emit("false", f"run_http_{code}")
+data = payload.get("data") if isinstance(payload.get("data"), dict) else {}
+run = data.get("run") if isinstance(data.get("run"), dict) else None
+if run is None and isinstance(data.get("id"), str):
+    run = data
+if not isinstance(run, dict):
+    emit("false", "run_missing")
+if str(run.get("id") or "").strip() != run_id:
+    emit("false", "run_id_mismatch")
+status = str(run.get("status") or "").strip().lower()
+if status != "completed":
+    emit("false", "run_not_completed")
+stats = run.get("stats") if isinstance(run.get("stats"), dict) else {}
+applied = stats.get("deprovisionApplied")
+if applied is not False:
+    emit("false", "deprovision_applied_not_false")
+aborted = stats.get("deprovisionAbortedReason")
+if aborted is None:
+    aborted = stats.get("deprovision_aborted_reason")
+if type(aborted) is not str or aborted.strip() != "empty_directory_fetch":
+    emit("false", "aborted_reason_not_empty_directory_fetch")
+# Belt: user/membership/grant deactivation counts must be zero when aborted.
+for key in (
+    "deprovisionUsersDeactivatedCount",
+    "deprovisionGrantsDisabledCount",
+    "deprovisionMembershipDeactivationAttemptedCount",
+):
+    val = stats.get(key)
+    if val is None:
+        continue
+    if type(val) is not int or val != 0:
+        emit("false", "non_zero_user_or_grant_or_membership_effect_count")
+emit("true", "ok")
+PY
+  )" || {
+    SAFE_ABORT_RUN_NOTE="python_failed"
+    return 1
+  }
+  SAFE_ABORT_RUN_OK="${result%%|*}"
+  SAFE_ABORT_RUN_NOTE="${result#*|}"
+  if [[ "$SAFE_ABORT_RUN_OK" == "true" ]]; then
+    log "exact run empty_directory_fetch safe abort proven (completed + applied=false + abortedReason match; ids never logged)"
+    return 0
+  fi
+  log "exact run empty_directory_fetch proof refused: note=${SAFE_ABORT_RUN_NOTE}"
+  return 1
+}
+
+# Prove zero deprovision ledger events/effects for the exact journaled run via
+# host docker/Postgres — never a paginated admin list / limit / latest inference.
+# Scope is exact equality on run_id::uuid + integration_id::uuid + local_user_id +
+# directory_account_id with NO status filter. Counts joined
+# directory_deprovision_effects for matched event(s). Both counts must be 0.
+prove_zero_deprovision_ledger_for_exact_run() {
+  local context="${1:-empty_fetch_abort_recovery}"
+  SAFE_ABORT_LEDGER_OK="false"
+  SAFE_ABORT_LEDGER_NOTE="unset"
+  SAFE_ABORT_LEDGER_EVENT_COUNT="0"
+  SAFE_ABORT_LEDGER_EFFECT_COUNT="0"
+  [[ -n "${CANARY_SUBJECT_LOCAL_USER_ID_FILE:-}" && -s "${CANARY_SUBJECT_LOCAL_USER_ID_FILE}" ]] \
+    || { SAFE_ABORT_LEDGER_NOTE="local_user_id_file_missing"; return 1; }
+  [[ -n "${CANARY_SUBJECT_INTEGRATION_ID_FILE:-}" && -s "${CANARY_SUBJECT_INTEGRATION_ID_FILE}" ]] \
+    || { SAFE_ABORT_LEDGER_NOTE="integration_id_file_missing"; return 1; }
+  [[ -n "${CANARY_SAFE_ABORT_SYNC_RUN_ID_FILE:-}" && -s "${CANARY_SAFE_ABORT_SYNC_RUN_ID_FILE}" ]] \
+    || { SAFE_ABORT_LEDGER_NOTE="sync_run_id_file_missing"; return 1; }
+  [[ -n "${CANARY_DIRECTORY_ACCOUNT_ID_FILE:-}" && -s "${CANARY_DIRECTORY_ACCOUNT_ID_FILE}" ]] \
+    || { SAFE_ABORT_LEDGER_NOTE="directory_account_id_file_missing"; return 1; }
+  local payload_json result
+  payload_json="$(
+    python3 - \
+      "$CANARY_SAFE_ABORT_SYNC_RUN_ID_FILE" \
+      "$CANARY_SUBJECT_INTEGRATION_ID_FILE" \
+      "$CANARY_SUBJECT_LOCAL_USER_ID_FILE" \
+      "$CANARY_DIRECTORY_ACCOUNT_ID_FILE" <<'PY'
+import json, pathlib, re, sys
+run_path, integ_path, user_path, acct_path = sys.argv[1:5]
+uuid_re = re.compile(
+    r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+)
+vals = []
+for path in (run_path, integ_path, user_path, acct_path):
+    try:
+        raw = pathlib.Path(path).read_bytes().decode("utf-8").strip()
+    except Exception:
+        raise SystemExit(2)
+    if not uuid_re.fullmatch(raw):
+        raise SystemExit(3)
+    vals.append(raw)
+print(json.dumps({
+    "run_id": vals[0],
+    "integration_id": vals[1],
+    "local_user_id": vals[2],
+    "directory_account_id": vals[3],
+}, separators=(",", ":")))
+PY
+  )" || { SAFE_ABORT_LEDGER_NOTE="ledger_payload_build_failed"; return 1; }
+  if ! result="$(printf '%s' "$payload_json" | docker exec -i \
+    "$BACKEND_CONTAINER" \
+    node -e '
+const { Client } = require("pg");
+function emit(ok, note, events, effects) {
+  process.stdout.write([ok, note, events, effects].join("|"));
+  process.exit(0);
+}
+(async () => {
+  let payload;
+  try {
+    const chunks = [];
+    for await (const c of process.stdin) chunks.push(c);
+    payload = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+  } catch (e) {
+    emit("false", "ledger_payload_invalid", "0", "0");
+    return;
+  }
+  const runId = String(payload.run_id || "").trim();
+  const integrationId = String(payload.integration_id || "").trim();
+  const localUserId = String(payload.local_user_id || "").trim();
+  const directoryAccountId = String(payload.directory_account_id || "").trim();
+  const uuid = /^[0-9a-fA-F-]{36}$/;
+  if (!uuid.test(runId) || !uuid.test(integrationId) || !uuid.test(localUserId) || !uuid.test(directoryAccountId)) {
+    emit("false", "ledger_ids_invalid", "0", "0");
+    return;
+  }
+  const url = process.env.DATABASE_URL;
+  if (!url) {
+    emit("false", "database_url_missing", "0", "0");
+    return;
+  }
+  const c = new Client({ connectionString: url, connectionTimeoutMillis: 10000 });
+  try {
+    await c.connect();
+    // Exact four-key scope. No status filter. No limit/order/latest inference.
+    // run_id::uuid + integration_id::uuid + local_user_id + directory_account_id.
+    const r = await c.query(
+      `SELECT
+         count(DISTINCT e.id)::int AS event_count,
+         count(fx.id)::int AS effect_count
+       FROM directory_deprovision_events e
+       LEFT JOIN directory_deprovision_effects fx
+         ON fx.event_id = e.id
+      WHERE e.run_id = $1::uuid
+        AND e.integration_id = $2::uuid
+        AND e.local_user_id = $3
+        AND e.directory_account_id = $4::uuid`,
+      [runId, integrationId, localUserId, directoryAccountId]
+    );
+    if (r.rows.length !== 1) {
+      emit("false", "ledger_count_row_missing", "0", "0");
+      return;
+    }
+    const eventCount = Number(r.rows[0].event_count);
+    const effectCount = Number(r.rows[0].effect_count);
+    if (!Number.isInteger(eventCount) || eventCount < 0 || !Number.isInteger(effectCount) || effectCount < 0) {
+      emit("false", "ledger_counts_invalid", "0", "0");
+      return;
+    }
+    if (eventCount !== 0) {
+      emit("false", "ledger_event_present_for_exact_run", String(eventCount), String(effectCount));
+      return;
+    }
+    if (effectCount !== 0) {
+      emit("false", "ledger_effect_present_for_exact_run", String(eventCount), String(effectCount));
+      return;
+    }
+    emit("true", "ok", "0", "0");
+  } catch (e) {
+    emit("false", "db_query_failed", "0", "0");
+  } finally {
+    try { await c.end(); } catch (e2) { /* ignore */ }
+  }
+})().catch(() => emit("false", "db_query_failed", "0", "0"));
+')"; then
+    SAFE_ABORT_LEDGER_NOTE="docker_exec_failed"
+    return 1
+  fi
+  result="$(printf '%s\n' "$result" | tail -n1 | tr -d '\r')"
+  SAFE_ABORT_LEDGER_OK="${result%%|*}"
+  local rest="${result#*|}"
+  SAFE_ABORT_LEDGER_NOTE="${rest%%|*}"
+  rest="${rest#*|}"
+  SAFE_ABORT_LEDGER_EVENT_COUNT="${rest%%|*}"
+  SAFE_ABORT_LEDGER_EFFECT_COUNT="${rest#*|}"
+  if [[ "$SAFE_ABORT_LEDGER_OK" == "true" ]]; then
+    log "zero deprovision ledger for exact run proven (${context}): events=0 effects=0 (exact SQL scope; ids never logged)"
+    return 0
+  fi
+  log "zero deprovision ledger proof refused (${context}): note=${SAFE_ABORT_LEDGER_NOTE} events=${SAFE_ABORT_LEDGER_EVENT_COUNT} effects=${SAFE_ABORT_LEDGER_EFFECT_COUNT}"
+  return 1
+}
+
+# Access-graph intact proof WITHOUT effect ledger (safe-abort path only).
+# Requires: user is_active=true, org-scoped active membership >=1, DingTalk grant enabled.
+# Sets INTACT_GRAPH_* for pre/post equality checks. Never prints ids.
+prove_intact_access_graph_no_ledger() {
+  local context="${1:-empty_fetch_abort_recovery}"
+  INTACT_GRAPH_OK="false"
+  INTACT_GRAPH_NOTE="unset"
+  INTACT_GRAPH_USER_ACTIVE="unknown"
+  INTACT_GRAPH_MEMBERSHIP_ACTIVE_COUNT="0"
+  INTACT_GRAPH_GRANT_STATE="unknown"
+  INTACT_GRAPH_SNAPSHOT=""
+  [[ -n "${CANARY_SUBJECT_LOCAL_USER_ID_FILE:-}" && -s "${CANARY_SUBJECT_LOCAL_USER_ID_FILE}" ]] \
+    || { INTACT_GRAPH_NOTE="local_user_id_file_missing"; return 1; }
+  [[ -n "${CANARY_SUBJECT_INTEGRATION_ID_FILE:-}" && -s "${CANARY_SUBJECT_INTEGRATION_ID_FILE}" ]] \
+    || { INTACT_GRAPH_NOTE="integration_id_file_missing"; return 1; }
+  local payload_json result
+  payload_json="$(
+    python3 - \
+      "$CANARY_SUBJECT_LOCAL_USER_ID_FILE" \
+      "$CANARY_SUBJECT_INTEGRATION_ID_FILE" <<'PY'
+import json, pathlib, sys
+u, i = sys.argv[1:3]
+print(json.dumps({
+    "user_id": pathlib.Path(u).read_bytes().decode("utf-8").strip(),
+    "integration_id": pathlib.Path(i).read_bytes().decode("utf-8").strip(),
+}, separators=(",", ":")))
+PY
+  )" || { INTACT_GRAPH_NOTE="graph_payload_build_failed"; return 1; }
+  if ! result="$(printf '%s' "$payload_json" | docker exec -i \
+    "$BACKEND_CONTAINER" \
+    node -e '
+const { Client } = require("pg");
+function emit(ok, note, userActive, memCount, grantState) {
+  process.stdout.write([ok, note, userActive, memCount, grantState].join("|"));
+  process.exit(0);
+}
+(async () => {
+  let payload;
+  try {
+    const chunks = [];
+    for await (const c of process.stdin) chunks.push(c);
+    payload = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+  } catch (e) {
+    emit("false", "graph_payload_invalid", "unknown", "0", "unknown");
+    return;
+  }
+  const userId = String(payload.user_id || "").trim();
+  const integrationId = String(payload.integration_id || "").trim();
+  if (!/^[0-9a-fA-F-]{36}$/.test(userId) || !/^[0-9a-fA-F-]{36}$/.test(integrationId)) {
+    emit("false", "graph_ids_invalid", "unknown", "0", "unknown");
+    return;
+  }
+  const url = process.env.DATABASE_URL;
+  if (!url) {
+    emit("false", "database_url_missing", "unknown", "0", "unknown");
+    return;
+  }
+  const c = new Client({ connectionString: url, connectionTimeoutMillis: 10000 });
+  try {
+    await c.connect();
+    const integ = await c.query(
+      "SELECT org_id, status FROM directory_integrations WHERE id = $1 AND provider = $2",
+      [integrationId, "dingtalk"]
+    );
+    if (integ.rows.length !== 1) {
+      emit("false", "integration_org_not_unique", "unknown", "0", "unknown");
+      return;
+    }
+    const orgId = String(integ.rows[0].org_id || "").trim();
+    const integStatus = String(integ.rows[0].status || "").trim().toLowerCase();
+    if (!orgId) {
+      emit("false", "integration_org_missing", "unknown", "0", "unknown");
+      return;
+    }
+    if (integStatus !== "active") {
+      emit("false", "integration_not_active", "unknown", "0", "unknown");
+      return;
+    }
+    const u = await c.query(
+      "SELECT is_active, activation_status FROM users WHERE id = $1",
+      [userId]
+    );
+    if (u.rows.length !== 1) {
+      emit("false", "user_row_missing", "unknown", "0", "unknown");
+      return;
+    }
+    const isActive = u.rows[0].is_active;
+    if (typeof isActive !== "boolean") {
+      emit("false", "user_is_active_not_boolean", "unknown", "0", "unknown");
+      return;
+    }
+    const activation = String(u.rows[0].activation_status || "").trim();
+    if (activation !== "activated") {
+      emit("false", "user_not_activated", isActive ? "true" : "false", "0", "unknown");
+      return;
+    }
+    if (isActive !== true) {
+      emit("false", "user_not_active", "false", "0", "unknown");
+      return;
+    }
+    const m = await c.query(
+      "SELECT count(*)::int AS n FROM user_orgs WHERE user_id = $1 AND org_id = $2 AND COALESCE(is_active, TRUE) = TRUE",
+      [userId, orgId]
+    );
+    const memN = Number(m.rows[0]?.n);
+    if (!Number.isInteger(memN) || memN < 1) {
+      emit("false", "membership_not_active", "true", String(Number.isInteger(memN) ? memN : 0), "unknown");
+      return;
+    }
+    const g = await c.query(
+      "SELECT enabled FROM user_external_auth_grants WHERE local_user_id = $1 AND provider = $2 LIMIT 2",
+      [userId, "dingtalk"]
+    );
+    if (g.rows.length !== 1) {
+      emit("false", g.rows.length === 0 ? "grant_absent" : "grant_ambiguous", "true", String(memN), "unknown");
+      return;
+    }
+    if (typeof g.rows[0].enabled !== "boolean" || g.rows[0].enabled !== true) {
+      emit("false", "grant_not_enabled", "true", String(memN), g.rows[0].enabled === false ? "disabled" : "unknown");
+      return;
+    }
+    emit("true", "ok", "true", String(memN), "enabled");
+  } catch (e) {
+    emit("false", "db_query_failed", "unknown", "0", "unknown");
+  } finally {
+    try { await c.end(); } catch (e2) { /* ignore */ }
+  }
+})().catch(() => emit("false", "db_query_failed", "unknown", "0", "unknown"));
+')"; then
+    INTACT_GRAPH_NOTE="docker_exec_failed"
+    return 1
+  fi
+  result="$(printf '%s\n' "$result" | tail -n1 | tr -d '\r')"
+  INTACT_GRAPH_OK="${result%%|*}"
+  local rest="${result#*|}"
+  INTACT_GRAPH_NOTE="${rest%%|*}"
+  rest="${rest#*|}"
+  INTACT_GRAPH_USER_ACTIVE="${rest%%|*}"
+  rest="${rest#*|}"
+  INTACT_GRAPH_MEMBERSHIP_ACTIVE_COUNT="${rest%%|*}"
+  INTACT_GRAPH_GRANT_STATE="${rest#*|}"
+  INTACT_GRAPH_SNAPSHOT="${INTACT_GRAPH_USER_ACTIVE}|${INTACT_GRAPH_MEMBERSHIP_ACTIVE_COUNT}|${INTACT_GRAPH_GRANT_STATE}"
+  if [[ "$INTACT_GRAPH_OK" == "true" ]]; then
+    log "intact access graph OK (${context}): user_active=${INTACT_GRAPH_USER_ACTIVE} membership_active_count=${INTACT_GRAPH_MEMBERSHIP_ACTIVE_COUNT} grant=${INTACT_GRAPH_GRANT_STATE}"
+    return 0
+  fi
+  log "intact access graph refused (${context}): note=${INTACT_GRAPH_NOTE}"
+  return 1
 }
 
 # Load host journal for restore. Accepts ledger_bound; prepared/run_bound first
@@ -5089,18 +5599,30 @@ action_pending() {
 # Deprovision restore phase (confirmation=DINGTALK_SOURCE_REACTIVATED_CONFIRMED):
 #   flags stay OFF → sync after external source re-enable → rehire restore exact event
 #   → prove event/effects resolved + access restored.
+# Deprovision empty_fetch_abort recovery
+# (confirmation=DINGTALK_EMPTY_FETCH_ABORT_SOURCE_RE_ADDED_CONFIRMED):
+#   staging-only, flags stay OFF forever. Recovers a journal stranded at
+#   phase=run_bound after completed empty_directory_fetch abort with zero ledger.
+#   Clears journal only after proving directory account reactivated + access graph
+#   unchanged. Never writes lifecycle env flags.
 action_deprovision() {
   local phase="apply"
   if [[ "${BOOTSTRAP_CONFIRMATION:-}" == "$DEPROVISION_RESTORE_CONFIRMATION" ]]; then
     phase="restore"
+  elif [[ "${BOOTSTRAP_CONFIRMATION:-}" == "$DEPROVISION_EMPTY_FETCH_ABORT_RECOVERY_CONFIRMATION" ]]; then
+    phase="empty_fetch_abort_recovery"
   elif [[ "${BOOTSTRAP_CONFIRMATION:-}" == "$DEPROVISION_SOURCE_CONFIRMATION" ]]; then
     phase="apply"
   else
-    fail "action=deprovision requires bootstrap_confirmation=${DEPROVISION_SOURCE_CONFIRMATION}|${DEPROVISION_RESTORE_CONFIRMATION}"
+    fail "action=deprovision requires bootstrap_confirmation=${DEPROVISION_SOURCE_CONFIRMATION}|${DEPROVISION_RESTORE_CONFIRMATION}|${DEPROVISION_EMPTY_FETCH_ABORT_RECOVERY_CONFIRMATION}"
   fi
 
   if [[ "$phase" == "restore" ]]; then
     action_deprovision_restore
+    return $?
+  fi
+  if [[ "$phase" == "empty_fetch_abort_recovery" ]]; then
+    action_deprovision_empty_fetch_abort_recovery
     return $?
   fi
   action_deprovision_apply
@@ -5523,6 +6045,193 @@ action_deprovision_restore() {
     echo "note=${note}"
   } > "${OUTPUT_DIR}/summary.txt"
   log "action=deprovision restore OK (server-side access graph proven; OAuth NOT_EXECUTED; end_to_end_restore_claimed=false; flags OFF)"
+}
+
+# Staging-only recovery for journal phase=run_bound after empty_directory_fetch safe abort.
+# Never writes lifecycle env flags. Never calls rehire restore. Clears journal only after
+# final post-sync proofs (directory account active + access graph unchanged + flags OFF).
+action_deprovision_empty_fetch_abort_recovery() {
+  local pre_login_ok="false"
+  local admin_jwt_minted="false"
+  local journal_ok="false"
+  local exact_run_ok="false"
+  local zero_ledger_ok="false"
+  local zero_ledger_final_ok="false"
+  local pre_graph_ok="false"
+  local source_active_after_sync="false"
+  local sync_ok="false"
+  local post_graph_ok="false"
+  local graph_unchanged_ok="false"
+  local flags_remain_off="false"
+  local journal_cleared="false"
+  local pre_graph_snapshot=""
+  local post_graph_snapshot=""
+  local note="empty_fetch_abort_recovery_phase"
+
+  require_sha
+  require_canary_secret_files "deprovision"
+  assert_canary_identifier_matches_owner "deprovision"
+  require_canary_directory_account_id_file "deprovision"
+  [[ -n "$EXPECTED_CURRENT_MODE" ]] || fail "expected_current_mode is required for action=deprovision empty_fetch_abort_recovery"
+  [[ "$EXPECTED_CURRENT_MODE" == "off" ]] \
+    || fail "action=deprovision empty_fetch_abort_recovery requires expected_current_mode=off"
+
+  capture_live_snapshot
+  assert_exact_sha
+  require_migrations_pending_zero_true "$SNAP_MIGRATIONS_ZERO" "action=deprovision empty_fetch_abort_recovery"
+
+  if [[ "$SNAP_HEALTH_OK" != "true" ]]; then
+    fail "action=deprovision empty_fetch_abort_recovery refused: backend_health_ok must be true (journal left intact)"
+  fi
+  # Any lifecycle flag ON refuses recovery and leaves the journal intact.
+  if [[ "$SNAP_MODE" != "off" || "$SNAP_ALIAS" != "false" || "$SNAP_PENDING" != "false" || "$SNAP_DEPROV" != "false" ]]; then
+    fail "action=deprovision empty_fetch_abort_recovery refused: all lifecycle flags must be OFF (live mode='${SNAP_MODE}'); journal left intact"
+  fi
+
+  if mint_canary_admin_jwt_from_password_login "empty_fetch_abort_recovery_pre"; then
+    pre_login_ok="true"
+    admin_jwt_minted="true"
+  else
+    fail "action=deprovision empty_fetch_abort_recovery refused: canary login / JWT mint failed (journal left intact)"
+  fi
+
+  if ! load_canary_directory_subject "empty_fetch_abort_recovery_pre"; then
+    fail "action=deprovision empty_fetch_abort_recovery refused: subject load failed (note=${SUBJECT_NOTE:-unset}); journal left intact; no auto-selection"
+  fi
+  if [[ "$SUBJECT_LOCAL_USERNAME_OK" != "true" || "$SUBJECT_LOCAL_NAME_OK" != "true" ]]; then
+    fail "action=deprovision empty_fetch_abort_recovery refused: subject is not owned canary employee; journal left intact; no auto-selection"
+  fi
+  if [[ "$SUBJECT_HAS_LOCAL_USER" != "true" || -z "${CANARY_SUBJECT_LOCAL_USER_ID_FILE:-}" || ! -s "${CANARY_SUBJECT_LOCAL_USER_ID_FILE}" ]]; then
+    fail "action=deprovision empty_fetch_abort_recovery refused: owned local user required; journal left intact"
+  fi
+
+  # Exact journal bind: phase=run_bound, deprovision_applied=false, no ledger fields.
+  if ! load_run_bound_empty_fetch_abort_journal; then
+    fail "action=deprovision empty_fetch_abort_recovery refused: journal not eligible run_bound safe abort (note=${SAFE_ABORT_JOURNAL_NOTE:-unset}); journal left intact"
+  fi
+  journal_ok="true"
+
+  # Exact terminal run: completed + applied=false + abortedReason=empty_directory_fetch.
+  if ! prove_exact_run_empty_fetch_safe_abort; then
+    fail "action=deprovision empty_fetch_abort_recovery refused: exact run not empty_directory_fetch safe abort (note=${SAFE_ABORT_RUN_NOTE:-unset}); journal left intact"
+  fi
+  exact_run_ok="true"
+
+  # Zero user/membership/grant ledger for that exact run only (exact SQL; no list/limit).
+  if ! prove_zero_deprovision_ledger_for_exact_run "empty_fetch_abort_recovery_pre"; then
+    fail "action=deprovision empty_fetch_abort_recovery refused: ledger not empty for exact run (note=${SAFE_ABORT_LEDGER_NOTE:-unset}); journal left intact"
+  fi
+  zero_ledger_ok="true"
+
+  # Pre-recovery access graph must still be activated + active membership + enabled grant.
+  if ! assert_subject_user_access_state "activated" "true" "empty_fetch_abort_recovery_pre"; then
+    fail "action=deprovision empty_fetch_abort_recovery refused: pre-recovery access not activated+active (note=${ACCESS_NOTE:-unset}); journal left intact"
+  fi
+  if ! prove_intact_access_graph_no_ledger "empty_fetch_abort_recovery_pre"; then
+    fail "action=deprovision empty_fetch_abort_recovery refused: pre-recovery access graph not intact (note=${INTACT_GRAPH_NOTE:-unset}); journal left intact"
+  fi
+  pre_graph_ok="true"
+  pre_graph_snapshot="${INTACT_GRAPH_SNAPSHOT}"
+
+  # External source re-add is operator-confirmed via bootstrap_confirmation.
+  # Flags stay OFF: sync under require_deprov_applied=false only.
+  if ! run_directory_sync_for_subject "empty_fetch_abort_recovery" "false"; then
+    fail "action=deprovision empty_fetch_abort_recovery refused: flags-OFF sync failed (note=${SYNC_NOTE:-unset}); journal left intact"
+  fi
+  if [[ "$SYNC_DEPROVISION_APPLIED" != "false" ]]; then
+    fail "action=deprovision empty_fetch_abort_recovery refused: flags-OFF sync did not prove deprovisionApplied=false; journal left intact"
+  fi
+  sync_ok="true"
+
+  if ! load_canary_directory_subject "empty_fetch_abort_recovery_post_sync"; then
+    fail "action=deprovision empty_fetch_abort_recovery refused: subject reload failed (note=${SUBJECT_NOTE:-unset}); journal left intact"
+  fi
+  if [[ "$SUBJECT_ACTIVE" != "true" ]]; then
+    fail "action=deprovision empty_fetch_abort_recovery refused: owned directory account not active after sync (external re-add gate); journal left intact"
+  fi
+  source_active_after_sync="true"
+
+  if ! assert_subject_user_access_state "activated" "true" "empty_fetch_abort_recovery_post"; then
+    fail "action=deprovision empty_fetch_abort_recovery refused: post-sync access not activated+active (note=${ACCESS_NOTE:-unset}); journal left intact"
+  fi
+  if ! prove_intact_access_graph_no_ledger "empty_fetch_abort_recovery_post"; then
+    fail "action=deprovision empty_fetch_abort_recovery refused: post-sync access graph not intact (note=${INTACT_GRAPH_NOTE:-unset}); journal left intact"
+  fi
+  post_graph_ok="true"
+  post_graph_snapshot="${INTACT_GRAPH_SNAPSHOT}"
+  if [[ -z "$pre_graph_snapshot" || "$post_graph_snapshot" != "$pre_graph_snapshot" ]]; then
+    fail "action=deprovision empty_fetch_abort_recovery refused: access graph drift after flags-OFF sync (pre!=post); journal left intact"
+  fi
+  graph_unchanged_ok="true"
+
+  capture_live_snapshot
+  if [[ "$SNAP_MODE" != "off" || "$SNAP_ALIAS" != "false" || "$SNAP_PENDING" != "false" || "$SNAP_DEPROV" != "false" ]]; then
+    fail "action=deprovision empty_fetch_abort_recovery refused: lifecycle flags must remain OFF after recovery sync; journal left intact"
+  fi
+  flags_remain_off="true"
+  assert_exact_sha
+  require_migrations_pending_zero_true "$SNAP_MIGRATIONS_ZERO" "action=deprovision empty_fetch_abort_recovery post-check"
+  if [[ "$SNAP_HEALTH_OK" != "true" ]]; then
+    fail "action=deprovision empty_fetch_abort_recovery refused: backend_health_ok must remain true; journal left intact"
+  fi
+
+  # FINAL proof gate: re-prove exact no-ledger AFTER flags-OFF sync + graph/flag checks
+  # and IMMEDIATELY before clear, so a concurrent/delayed exact event cannot appear
+  # between the first zero-ledger proof and journal clear.
+  # Load-bearing order — contract MUTATION removes this recheck / moves clear earlier and must turn red.
+  if ! prove_zero_deprovision_ledger_for_exact_run "empty_fetch_abort_recovery_final_pre_clear"; then
+    fail "action=deprovision empty_fetch_abort_recovery refused: final pre-clear zero-ledger recheck failed (note=${SAFE_ABORT_LEDGER_NOTE:-unset}); journal left intact"
+  fi
+  zero_ledger_final_ok="true"
+  clear_deprovision_apply_state
+  journal_cleared="true"
+
+  note="empty_fetch_abort_recovery_directory_reactivated_access_graph_unchanged_journal_cleared"
+  write_status_artifact \
+    "${SNAP_BUILD_SHA:-unknown}" \
+    "$SNAP_ALIAS" "$SNAP_PENDING" "$SNAP_DEPROV" "$SNAP_MODE" \
+    "$SNAP_ALIAS_READY" "$SNAP_CAN_ENABLE_ALIAS" \
+    "$SNAP_MIGRATIONS_ZERO" "$SNAP_HEALTH_OK" \
+    "deprovision" "true" "false" "$note"
+  {
+    echo "action=deprovision"
+    echo "phase=empty_fetch_abort_recovery"
+    echo "mode=${SNAP_MODE}"
+    echo "build_sha=${SNAP_BUILD_SHA:-unknown}"
+    echo "transition_applied=false"
+    echo "lifecycle_env_write=false"
+    echo "pre_login_ok=${pre_login_ok}"
+    echo "admin_jwt_minted=${admin_jwt_minted}"
+    echo "subject_owned=true"
+    echo "subject_auto_selected=false"
+    echo "source_re_add_confirmation=true"
+    echo "journal_ok=${journal_ok}"
+    echo "journal_phase_required=run_bound"
+    echo "exact_run_ok=${exact_run_ok}"
+    echo "aborted_reason_required=empty_directory_fetch"
+    echo "deprovision_applied_required=false"
+    echo "zero_ledger_ok=${zero_ledger_ok}"
+    echo "zero_ledger_final_ok=${zero_ledger_final_ok}"
+    echo "zero_ledger_event_count=${SAFE_ABORT_LEDGER_EVENT_COUNT:-0}"
+    echo "zero_ledger_effect_count=${SAFE_ABORT_LEDGER_EFFECT_COUNT:-0}"
+    echo "pre_graph_ok=${pre_graph_ok}"
+    echo "sync_ok=${sync_ok}"
+    echo "source_active_after_sync=${source_active_after_sync}"
+    echo "post_graph_ok=${post_graph_ok}"
+    echo "graph_unchanged_ok=${graph_unchanged_ok}"
+    echo "access_graph_user_active=${INTACT_GRAPH_USER_ACTIVE:-unknown}"
+    echo "access_graph_membership_active_count=${INTACT_GRAPH_MEMBERSHIP_ACTIVE_COUNT:-0}"
+    echo "access_graph_grant_state=${INTACT_GRAPH_GRANT_STATE:-unknown}"
+    echo "flags_remain_off=${flags_remain_off}"
+    echo "journal_cleared=${journal_cleared}"
+    echo "server_side_access_graph_mutation_proven=false"
+    echo "access_graph_unchanged_proven=true"
+    echo "safe_abort_source_recovery_complete=true"
+    echo "canary_access_rollback_complete=false"
+    echo "end_to_end_restore_claimed=false"
+    echo "note=${note}"
+  } > "${OUTPUT_DIR}/summary.txt"
+  log "action=deprovision empty_fetch_abort_recovery OK (flags OFF; directory reactivated; access graph unchanged; journal cleared; no lifecycle env write)"
 }
 
 # --- main ------------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add a staging-only recovery phase for a deprovision canary journal stranded at `run_bound` after an exact `empty_directory_fetch` safe abort
- keep all lifecycle flags OFF, reactivate the owned directory account with a flags-off sync, and clear the journal only after exact run/ledger/access proofs
- pin the aborted run independently from the recovery sync run so the final zero-ledger recheck cannot drift

## Safety
- no production directory/deprovision implementation changes
- no lifecycle env write in the recovery phase
- exact four-key Postgres ledger query: run + integration + local user + directory account
- wrong phase/run/abort reason, any event/effect, source still absent, access drift, sync anomaly, or any flag ON leaves the journal intact
- does not claim browser OAuth or full end-to-end restore

## Verification
- `bash -n scripts/ops/dingtalk-lifecycle-staging-canary-remote.sh`
- `node --test scripts/ops/dingtalk-lifecycle-staging-canary-contract.test.mjs` (197/197)
- mutation: reverting the helper to the recovery sync run pin makes both identity tests fail
- independent adversarial delta review: APPROVE, 0 P1/P2
