### PR TITLE
[PROPOSED] docs(attendance): align W6 delegated access status (#4556)

### DIFF
--- a/docs/development/attendance-issue-4556-w6-group-effective-policy-design-lock-20260805.md
+++ b/docs/development/attendance-issue-4556-w6-group-effective-policy-design-lock-20260805.md
@@ -376,9 +376,11 @@ This correction is deliberately narrow:
 3. No runtime behavior changes here. W6-R3 and §4.1 already selected 404, and
    the W6-1 candidate is reviewed against that existing governing behavior.
 
-On 2026-08-12 the owner authorized this independent docs-only correction to
-merge as PROPOSED against exact baseline
-`979c619ebf0ca1dfadedff2dc9b8db69b4f6b74c`. After merge, the exact correction
+On 2026-08-12 the owner initially authorized this independent docs-only
+correction to merge as PROPOSED against exact baseline
+`979c619ebf0ca1dfadedff2dc9b8db69b4f6b74c`. After unrelated PR 4877 advanced
+`main`, the owner renewed the same narrow authorization against exact baseline
+`51f23ec7255c3fb0d9abc21bfbe4c3bce8e1c48f`. After merge, the exact correction
 SHA must be presented for a separate owner RATIFY. This authorization does not
 grant PR 4849 merge, W6-2/W6-3/W6-4, further runtime work, flags, deployment,
 staging, soak, production/customer data use, or closure of issue 4556.

--- a/docs/development/attendance-issue-4556-w6-group-effective-policy-design-lock-20260805.md
+++ b/docs/development/attendance-issue-4556-w6-group-effective-policy-design-lock-20260805.md
@@ -380,7 +380,9 @@ On 2026-08-12 the owner initially authorized this independent docs-only
 correction to merge as PROPOSED against exact baseline
 `979c619ebf0ca1dfadedff2dc9b8db69b4f6b74c`. After unrelated PR 4877 advanced
 `main`, the owner renewed the same narrow authorization against exact baseline
-`51f23ec7255c3fb0d9abc21bfbe4c3bce8e1c48f`. After merge, the exact correction
+`51f23ec7255c3fb0d9abc21bfbe4c3bce8e1c48f`. After unrelated PR 4874 advanced
+`main` again, the owner renewed it against exact baseline
+`525f47e78ba0815a1f3c0e49aac10035bcbd2d14`. After merge, the exact correction
 SHA must be presented for a separate owner RATIFY. This authorization does not
 grant PR 4849 merge, W6-2/W6-3/W6-4, further runtime work, flags, deployment,
 staging, soak, production/customer data use, or closure of issue 4556.

--- a/docs/development/attendance-issue-4556-w6-group-effective-policy-design-lock-20260805.md
+++ b/docs/development/attendance-issue-4556-w6-group-effective-policy-design-lock-20260805.md
@@ -1,7 +1,9 @@
 # Attendance Issue #4556 W6 Group Effective-Policy Read Aggregation Design Lock
 
 > Status: **RATIFIED** (W6-1 backend aggregate only) — see the ratification
-> record in §9. Every W6 slice beyond W6-1 remains **HOLD**.
+> record in §9. The narrow delegated-non-member status correction in §10 is
+> **PROPOSED** pending owner RATIFY of this correction's exact merged SHA.
+> Every W6 slice beyond W6-1 remains **HOLD**.
 >
 > Date: 2026-08-05 · Ratified: 2026-08-08
 >
@@ -270,7 +272,7 @@ winner selection stays W7 and stays fail-closed per parent R2.
 - service + route per §4; real-DB legs in the existing attendance integration
   gate file set, fixture IDs file-namespaced;
 - matrix: every §4.3 fixture shape reproduced from seeded rows with exact-key
-  deepEqual; two-org isolation; delegated-non-member 403; spoofed org
+  deepEqual; two-org isolation; delegated-non-member 404; spoofed org
   selectors 403 before aggregate SQL; unknown group 404 shape parity; invalid enum
   negatives for every enum field;
 - mutation legs, each individually red: drop the auth guard; add a second
@@ -347,3 +349,32 @@ slice only**, Draft/HOLD, stopping after a fresh exact-head gate. W6-2 contract
 wiring, W6-3 UI, W6-4 verification, any merge, staging, soak, flag change,
 deployment, and closure of issue 4556 each remain separate, un-granted owner
 acts — §8's landing sequence is unchanged by this record.
+
+## 10. PROPOSED correction — delegated non-member status (2026-08-12)
+
+**Status: PROPOSED.** This section cannot ratify itself. The owner must RATIFY
+the exact merged SHA of this correction before PR 4849 can use it as final-gate
+authority.
+
+The RATIFIED W6-R3 and §4.1 require missing and inaccessible groups to share
+one values-free 404 shape. The former §7.2 matrix line instead required a 403
+for a delegated attendance admin without active target-org membership. That
+line contradicted the governing rule and the same document's endpoint
+contract.
+
+This correction is deliberately narrow:
+
+1. §7.2 now requires the delegated-non-member leg to return the shared
+   values-free 404 shape. Spoofed org selectors remain 403 before aggregate
+   SQL.
+2. The unpublished OpenAPI draft moves delegated non-membership out of the 403
+   description and into the shared inaccessible-group 404 description.
+3. No runtime behavior changes here. W6-R3 and §4.1 already selected 404, and
+   the W6-1 candidate is reviewed against that existing governing behavior.
+
+On 2026-08-12 the owner authorized this independent docs-only correction to
+merge as PROPOSED against exact baseline
+`979c619ebf0ca1dfadedff2dc9b8db69b4f6b74c`. After merge, the exact correction
+SHA must be presented for a separate owner RATIFY. This authorization does not
+grant PR 4849 merge, W6-2/W6-3/W6-4, further runtime work, flags, deployment,
+staging, soak, production/customer data use, or closure of issue 4556.

--- a/docs/development/attendance-issue-4556-w6-group-effective-policy-design-lock-20260805.md
+++ b/docs/development/attendance-issue-4556-w6-group-effective-policy-design-lock-20260805.md
@@ -10,8 +10,10 @@
 > Pinned baseline: `origin/main@db74bd8667df1084797c97d872fe53ef845e3803`
 >
 > Ratified SHA: `2967da018ceea41b91098e14d4c15a57236eb5f8` (the merge commit of
-> PR 4771, which is where this document landed on `main`; its content has been
-> byte-identical on `main` since that commit)
+> PR 4771, which is where the original RATIFIED baseline landed on `main`; that
+> baseline remained byte-identical through `979c619ebf0ca1dfadedff2dc9b8db69b4f6b74c`.
+> The §10 correction is a later PROPOSED delta and does not rewrite that
+> historical ratification.)
 >
 > Scope: issue #4556, W6 only (锁 §9.7 group effective-policy workspace 的
 > read-only 聚合面)

--- a/docs/development/attendance-issue-4556-w6-group-effective-policy-design-lock-20260805.md
+++ b/docs/development/attendance-issue-4556-w6-group-effective-policy-design-lock-20260805.md
@@ -9,11 +9,13 @@
 >
 > Pinned baseline: `origin/main@db74bd8667df1084797c97d872fe53ef845e3803`
 >
-> Ratified SHA: `2967da018ceea41b91098e14d4c15a57236eb5f8` (the merge commit of
-> PR 4771, which is where the original RATIFIED baseline landed on `main`; that
-> baseline remained byte-identical through `979c619ebf0ca1dfadedff2dc9b8db69b4f6b74c`.
-> The §10 correction is a later PROPOSED delta and does not rewrite that
-> historical ratification.)
+> Ratified proposal SHA: `2967da018ceea41b91098e14d4c15a57236eb5f8`
+> (PR 4771, where the original PROPOSED design landed on `main`).
+>
+> Durable RATIFY-record merge: `ecf77d2433596bbdd8b67c312a37178dbc97f715`
+> (PR 4821). Its resulting lock blob remained byte-identical through
+> `979c619ebf0ca1dfadedff2dc9b8db69b4f6b74c`. The §10 correction is a later
+> PROPOSED delta and does not rewrite either historical record.
 >
 > Scope: issue #4556, W6 only (锁 §9.7 group effective-policy workspace 的
 > read-only 聚合面)

--- a/packages/openapi/drafts/attendance-w6-group-effective-policy.draft.yml
+++ b/packages/openapi/drafts/attendance-w6-group-effective-policy.draft.yml
@@ -7,7 +7,8 @@
 #
 # Governing document:
 #   docs/development/attendance-issue-4556-w6-group-effective-policy-design-lock-20260805.md
-#   (sections 4.1-4.4; decision points OD-W6-1..9 are OPEN)
+#   (sections 4.1-4.4; decisions OD-W6-1..9 are RATIFIED in section 9;
+#   the delegated-non-member status correction in section 10 is PROPOSED)
 #
 # Wiring plan (W6-2, blocked on owner RATIFY): move the `paths` and
 # `components` content into src/paths/attendance.yml + src/base.yml, rebuild
@@ -58,12 +59,12 @@ paths:
             defaulted (red line W6-R6).
         '403':
           description: >
-            Authenticated-but-unscoped principal, org-selector mismatch, or
-            delegated admin without active target-org membership; issued
-            before any aggregate SQL (red line W6-R3).
+            Authenticated-but-unscoped principal or org-selector mismatch;
+            issued before any aggregate SQL (red line W6-R3).
         '404':
           description: >
-            Unknown, cross-org, or inaccessible group; one shared values-free
+            Unknown, cross-org, or inaccessible group, including a delegated
+            admin without active target-org membership; one shared values-free
             shape (red line W6-R3).
 
 components:


### PR DESCRIPTION
## Status

PROPOSED docs-only correction. Runtime and PR #4849 remain HOLD. This PR has no ratification authority.

## What changed

- Correct W6 lock section 7.2 so delegated admins without active target-org membership receive the shared values-free 404 already required by RATIFIED W6-R3 and section 4.1.
- Keep spoofed org selectors and authenticated-but-unscoped requests at 403 before aggregate SQL.
- Align the unpublished OpenAPI draft with the same split.
- Record that the owner must RATIFY this PR exact merged SHA before PR #4849 may use the correction in its final gate.

## Why

The old section 7.2 matrix said delegated-non-member 403, contradicting the governing W6-R3 and section 4.1 404 contract. PR #4849 follows the governing 404 behavior; this correction removes the documentary contradiction without changing runtime behavior.

## Verification

- YAML parse: PASS.
- Contract assertions: old delegated-non-member 403 text absent; section 7.2 and draft 404 text aligned.
- pnpm --filter @metasheet/openapi build: PASS.
- pnpm --filter @metasheet/openapi validate: PASS.
- Generated OpenAPI dist hash before and after: byte-identical.
- Changed files: exactly the W6 lock and unpublished OpenAPI draft.

## Landing sequence

1. Review and merge this PR as PROPOSED.
2. Present the exact merged SHA for a separate owner RATIFY.
3. Only after RATIFY may #4849 catch up, recompute its workflow pin, and run fresh final gates.

No W6-2/3/4, additional runtime, flags, deployment, staging, soak, production/customer data, or issue #4556 closure is authorized.