### PR TITLE
fix(dingtalk): recover pre-deprovision sync failures

### DIFF
--- a/.github/workflows/dingtalk-lifecycle-staging-canary.yml
+++ b/.github/workflows/dingtalk-lifecycle-staging-canary.yml
@@ -55,6 +55,16 @@ run-name: "DingTalk Lifecycle Staging Canary: ${{ inputs.action }}${{ inputs.act
 #               zero ledger → prove intact access graph → flags-OFF sync after
 #               external source re-add → prove owned directory account active +
 #               access graph unchanged → clear journal only then.
+#               SYNC_FAILURE_BEFORE_DEPROVISION_RECOVERY:
+#               bootstrap_confirmation=DINGTALK_SYNC_FAILURE_BEFORE_DEPROVISION_SOURCE_RE_ADDED_CONFIRMED
+#               → flags stay OFF (never writes lifecycle env) → bind exact
+#               journal run_bound (deprovision_applied=false, zero ledger) → run API
+#               proves terminal failed + exact observed error class
+#               idx_directory_accounts_provider_corp_external_key → zero ledger +
+#               intact active access graph (no-mutation) → flags-OFF sync after
+#               external source re-add (deprovisionApplied=false) → source active +
+#               graph unchanged → final zero-ledger + exact run identity → clear
+#               journal only then. Never claims end-to-end restore.
 #
 # See:
 #   docs/development/dingtalk-lifecycle-canary-separate-go-20260724.md
@@ -89,7 +99,7 @@ on:
         required: false
         default: ''
       bootstrap_confirmation:
-        description: 'bootstrap=CREATE_STAGING_CANARY_ADMIN; human-bootstrap=CREATE_STAGING_HUMAN_ADMIN; pending optional PENDING_SSO_ACTIVATE; deprovision=DINGTALK_SOURCE_DISABLED_DEDICATED_EXCLUSIVE_CONFIRMED (apply) or DINGTALK_SOURCE_REACTIVATED_CONFIRMED (restore) or DINGTALK_EMPTY_FETCH_ABORT_SOURCE_RE_ADDED_CONFIRMED (empty-fetch abort recovery).'
+        description: 'bootstrap=CREATE_STAGING_CANARY_ADMIN; human-bootstrap=CREATE_STAGING_HUMAN_ADMIN; pending optional PENDING_SSO_ACTIVATE; deprovision=DINGTALK_SOURCE_DISABLED_DEDICATED_EXCLUSIVE_CONFIRMED (apply) or DINGTALK_SOURCE_REACTIVATED_CONFIRMED (restore) or DINGTALK_EMPTY_FETCH_ABORT_SOURCE_RE_ADDED_CONFIRMED (empty-fetch abort recovery) or DINGTALK_SYNC_FAILURE_BEFORE_DEPROVISION_SOURCE_RE_ADDED_CONFIRMED (sync-failure-before-deprovision recovery).'
         required: false
         type: string
         default: ''
@@ -176,9 +186,9 @@ jobs:
 
           if [[ "$ACTION" == "deprovision" ]]; then
             case "$BOOTSTRAP_CONFIRMATION" in
-              DINGTALK_SOURCE_DISABLED_DEDICATED_EXCLUSIVE_CONFIRMED|DINGTALK_SOURCE_REACTIVATED_CONFIRMED|DINGTALK_EMPTY_FETCH_ABORT_SOURCE_RE_ADDED_CONFIRMED) ;;
+              DINGTALK_SOURCE_DISABLED_DEDICATED_EXCLUSIVE_CONFIRMED|DINGTALK_SOURCE_REACTIVATED_CONFIRMED|DINGTALK_EMPTY_FETCH_ABORT_SOURCE_RE_ADDED_CONFIRMED|DINGTALK_SYNC_FAILURE_BEFORE_DEPROVISION_SOURCE_RE_ADDED_CONFIRMED) ;;
               *)
-                echo "bootstrap_confirmation must be DINGTALK_SOURCE_DISABLED_DEDICATED_EXCLUSIVE_CONFIRMED (apply), DINGTALK_SOURCE_REACTIVATED_CONFIRMED (restore), or DINGTALK_EMPTY_FETCH_ABORT_SOURCE_RE_ADDED_CONFIRMED (empty-fetch abort recovery) for action=deprovision" >&2
+                echo "bootstrap_confirmation must be DINGTALK_SOURCE_DISABLED_DEDICATED_EXCLUSIVE_CONFIRMED (apply), DINGTALK_SOURCE_REACTIVATED_CONFIRMED (restore), DINGTALK_EMPTY_FETCH_ABORT_SOURCE_RE_ADDED_CONFIRMED (empty-fetch abort recovery), or DINGTALK_SYNC_FAILURE_BEFORE_DEPROVISION_SOURCE_RE_ADDED_CONFIRMED (sync-failure-before-deprovision recovery) for action=deprovision" >&2
                 exit 2
               ;;
             esac
@@ -492,9 +502,11 @@ jobs:
             echo "Pending default phase is admit-only; OAuth checkpoints are NOT_EXECUTED; optional PENDING_SSO_ACTIVATE (browser OAuth still NOT_EXECUTED)."
             echo "Deprovision apply uses DINGTALK_SOURCE_DISABLED_DEDICATED_EXCLUSIVE_CONFIRMED (flags OFF, access remains disabled). Restore uses DINGTALK_SOURCE_REACTIVATED_CONFIRMED (rehire + access restore; flags stay OFF)."
             echo "Empty-fetch abort recovery uses DINGTALK_EMPTY_FETCH_ABORT_SOURCE_RE_ADDED_CONFIRMED (flags stay OFF; never writes lifecycle env; clears run_bound journal only after directory reactivated + access graph unchanged proofs)."
+            echo "Sync-failure-before-deprovision recovery uses DINGTALK_SYNC_FAILURE_BEFORE_DEPROVISION_SOURCE_RE_ADDED_CONFIRMED (flags stay OFF; never writes lifecycle env; clears run_bound journal only after zero ledger + exact failed-run identity + access graph unchanged proofs)."
             echo "Deprovision refuses shared integrations: exactly one total directory account, manual scheduling, admission automation OFF, and member-group projection OFF are required."
             echo "Deprovision reserves and journals the exact sync run UUID before env/HTTP; lost responses recover only through that run and its exact event/effects."
             echo "Empty-fetch abort recovery binds only the exact journal run_bound completed empty_directory_fetch abort with zero ledger; wrong phase/run/abort reason, any ledger, source still missing, access drift, sync failure, or any lifecycle flag ON leaves the journal intact."
+            echo "Sync-failure-before-deprovision recovery binds journal run_bound deprovision_applied=false + zero ledger; run API proves failed + exact observed constraint idx_directory_accounts_provider_corp_external_key; zero ledger + intact graph prove no mutation; wrong phase/run/status/error class, sibling indexes, any ledger, source still missing, access drift, sync failure, or any lifecycle flag ON leaves the journal intact. Never claims end-to-end restore."
             echo "Alias/pending/deprovision/human-bootstrap mint short-lived admin JWT from canary password login — never ATTENDANCE_ADMIN_JWT."
             echo "Runtime OFF cannot be proven if rollback recreate itself fails (override restored on disk)."
             if [[ -f output/lifecycle-canary/summary.txt ]]; then

--- a/scripts/ops/dingtalk-lifecycle-staging-canary-contract.test.mjs
+++ b/scripts/ops/dingtalk-lifecycle-staging-canary-contract.test.mjs
@@ -186,8 +186,20 @@ function actionDeprovisionRestoreBody(source) {
 function actionDeprovisionEmptyFetchAbortRecoveryBody(source) {
   const start = source.indexOf('action_deprovision_empty_fetch_abort_recovery()')
   assert.notEqual(start, -1, 'action_deprovision_empty_fetch_abort_recovery() must exist')
+  // Sync-failure-before-deprovision recovery follows empty_fetch; fall back to main.
+  let end = source.indexOf('\naction_deprovision_sync_failure_before_deprovision_recovery()', start)
+  if (end === -1) {
+    end = source.indexOf('\n# --- main', start)
+  }
+  assert.notEqual(end, -1, 'sync_failure recovery or main marker after empty_fetch_abort_recovery')
+  return source.slice(start, end)
+}
+
+function actionDeprovisionSyncFailureBeforeDeprovisionRecoveryBody(source) {
+  const start = source.indexOf('action_deprovision_sync_failure_before_deprovision_recovery()')
+  assert.notEqual(start, -1, 'action_deprovision_sync_failure_before_deprovision_recovery() must exist')
   const end = source.indexOf('\n# --- main', start)
-  assert.notEqual(end, -1, 'main marker after empty_fetch_abort_recovery')
+  assert.notEqual(end, -1, 'main marker after sync_failure_before_deprovision_recovery')
   return source.slice(start, end)
 }
 
@@ -2906,12 +2918,18 @@ test('deprovision apply phase: subject, source disable confirm, exact run ledger
     source,
     /DEPROVISION_EMPTY_FETCH_ABORT_RECOVERY_CONFIRMATION="DINGTALK_EMPTY_FETCH_ABORT_SOURCE_RE_ADDED_CONFIRMED"/,
   )
+  assert.match(
+    source,
+    /DEPROVISION_SYNC_FAILURE_BEFORE_DEPROVISION_RECOVERY_CONFIRMATION="DINGTALK_SYNC_FAILURE_BEFORE_DEPROVISION_SOURCE_RE_ADDED_CONFIRMED"/,
+  )
   assert.match(all, /DEPROVISION_SOURCE_CONFIRMATION|DINGTALK_SOURCE_DISABLED_DEDICATED_EXCLUSIVE_CONFIRMED/)
   assert.match(all, /DEPROVISION_RESTORE_CONFIRMATION|action_deprovision_restore/)
   assert.match(all, /DEPROVISION_EMPTY_FETCH_ABORT_RECOVERY_CONFIRMATION|action_deprovision_empty_fetch_abort_recovery/)
+  assert.match(all, /DEPROVISION_SYNC_FAILURE_BEFORE_DEPROVISION_RECOVERY_CONFIRMATION|action_deprovision_sync_failure_before_deprovision_recovery/)
   assert.match(all, /action_deprovision_apply/)
   assert.match(all, /action_deprovision_restore/)
   assert.match(all, /action_deprovision_empty_fetch_abort_recovery/)
+  assert.match(all, /action_deprovision_sync_failure_before_deprovision_recovery/)
   assert.match(body, /require_canary_directory_account_id_file "deprovision"/)
   assert.match(body, /run_deprovision_sync_preview_subject_gate/)
   assert.ok(
@@ -3631,12 +3649,785 @@ printf 'ok=%s note=%s\\n' "$SAFE_ABORT_LEDGER_OK" "$SAFE_ABORT_LEDGER_NOTE"
   rmSync(home, { recursive: true, force: true })
 })
 
+// --- sync_failure_before_deprovision recovery (run_bound, zero ledger) ---------------
+
+test('sync_failure_before_deprovision recovery: staging-only, never writes lifecycle env flags', () => {
+  const source = read(REMOTE_SH)
+  const body = actionDeprovisionSyncFailureBeforeDeprovisionRecoveryBody(source)
+  const all = actionDeprovisionBody(source)
+  assert.match(source, /DEPROVISION_SYNC_FAILURE_BEFORE_DEPROVISION_RECOVERY_CONFIRMATION/)
+  assert.match(source, /DINGTALK_SYNC_FAILURE_BEFORE_DEPROVISION_SOURCE_RE_ADDED_CONFIRMED/)
+  assert.match(all, /sync_failure_before_deprovision_recovery/)
+  assert.match(all, /action_deprovision_sync_failure_before_deprovision_recovery/)
+  assert.match(body, /lifecycle_env_write=false/)
+  assert.match(body, /transition_applied=false/)
+  assert.match(body, /end_to_end_restore_claimed=false/)
+  assert.doesNotMatch(body, /write_lifecycle_override/)
+  assert.doesNotMatch(body, /recreate_backend_only/)
+  assert.doesNotMatch(body, /establish_alias_off_rollback_baseline/)
+  assert.doesNotMatch(body, /arm_alias_exit_rollback_guard/)
+  // Must not enter rehire/ledger restore path or empty_fetch path.
+  assert.doesNotMatch(body, /run_deprovision_rehire_restore/)
+  assert.doesNotMatch(body, /run_or_resume_deprovision_rehire_restore/)
+  assert.doesNotMatch(body, /load_deprovision_apply_state/)
+  assert.doesNotMatch(body, /reconcile_run_journal_to_ledger_bound/)
+  assert.doesNotMatch(body, /load_run_bound_empty_fetch_abort_journal/)
+  assert.doesNotMatch(body, /prove_exact_run_empty_fetch_safe_abort/)
+})
+
+test('sync_failure_before_deprovision recovery binds exact failed run + observed class + zero ledger + intact graph', () => {
+  const source = read(REMOTE_SH)
+  const body = actionDeprovisionSyncFailureBeforeDeprovisionRecoveryBody(source)
+  assert.match(body, /load_run_bound_sync_failure_before_deprovision_journal/)
+  assert.match(body, /prove_exact_run_sync_failure_before_deprovision/)
+  assert.match(body, /prove_zero_deprovision_ledger_for_exact_run "sync_failure_before_deprovision_recovery_pre"/)
+  assert.match(body, /prove_zero_deprovision_ledger_for_exact_run "sync_failure_before_deprovision_recovery_final_pre_clear"/)
+  assert.match(body, /prove_intact_access_graph_no_ledger "sync_failure_before_deprovision_recovery_pre"/)
+  assert.match(body, /assert_subject_user_access_state "activated" "true" "sync_failure_before_deprovision_recovery_pre"/)
+  assert.match(body, /run_directory_sync_for_subject "sync_failure_before_deprovision_recovery" "false"/)
+  assert.match(body, /SYNC_DEPROVISION_APPLIED" != "false"/)
+  assert.match(body, /SUBJECT_ACTIVE" != "true"/)
+  assert.match(body, /prove_intact_access_graph_no_ledger "sync_failure_before_deprovision_recovery_post"/)
+  assert.match(body, /post_graph_snapshot" != "\$pre_graph_snapshot"/)
+  assert.match(body, /phase=sync_failure_before_deprovision_recovery/)
+  assert.match(body, /run_status_required=failed/)
+  assert.match(body, /journal_deprovision_applied_required=false/)
+  assert.match(body, /journal_phase_required=run_bound/)
+  assert.match(body, /error_class_required=duplicate_provider_corp_external_key/)
+  assert.match(body, /error_constraint_required=idx_directory_accounts_provider_corp_external_key/)
+  assert.match(body, /no_mutation_proven_by_zero_ledger_and_access_graph=true/)
+  assert.match(body, /journal left intact/)
+  assert.match(body, /zero_ledger_final_ok=/)
+  assert.match(body, /exact_run_final_ok=/)
+  assert.match(body, /sync_failure_before_deprovision_source_recovery_complete=true/)
+  assert.match(body, /canary_access_rollback_complete=false/)
+  assert.match(body, /end_to_end_restore_claimed=false/)
+  // Journal binds deprovision_applied=false; run proof does not claim absent stats alone prove it.
+  assert.match(body, /deprovision_applied=false is proven here|journal-bound/)
+  assert.match(body, /Does not alone prove deprovision_applied=false|journal binds deprovision_applied=false/)
+
+  // Helper contracts: failed status + exact single-constraint allowlist (no alternates/heuristics).
+  assert.match(source, /subject\.failed-sync-run-id/)
+  assert.match(source, /CANARY_FAILED_SYNC_RUN_ID_FILE/)
+  assert.match(source, /status != "failed"/)
+  assert.match(source, /deprovision_applied_true/)
+  assert.match(source, /error_class_not_allowlisted/)
+  assert.match(source, /duplicate_provider_corp_external_key/)
+  assert.match(source, /idx_directory_accounts_provider_corp_external_key/)
+  // Extract classify_error only — literals must live inside the function body.
+  const classifyStart = source.indexOf('def classify_error(msg):')
+  assert.notEqual(classifyStart, -1, 'classify_error must exist')
+  const classifyEnd = source.indexOf('\ntry:', classifyStart)
+  assert.notEqual(classifyEnd, -1)
+  const classifyBody = source.slice(classifyStart, classifyEnd)
+  // Load-bearing: exact observed constraint literal is inside classify_error itself.
+  assert.match(
+    classifyBody,
+    /exact_constraint = "idx_directory_accounts_provider_corp_external_key"/,
+  )
+  assert.match(classifyBody, /exact_signature =/)
+  assert.match(classifyBody, /duplicate key value violates unique constraint/)
+  assert.match(classifyBody, /exact_error_class = "duplicate_provider_corp_external_key"/)
+  assert.match(classifyBody, /if exact_signature not in m/)
+  assert.doesNotMatch(classifyBody, /idx_directory_accounts_provider_null_corp_external_key/)
+  assert.doesNotMatch(classifyBody, /idx_user_external_identities/)
+  // No bare provider_external_key alternate (corp index name is the only allowed index token).
+  assert.doesNotMatch(
+    classifyBody,
+    /idx_directory_accounts_provider_external_key"|provider_null_corp|provider_external_key"/,
+  )
+  assert.doesNotMatch(classifyBody, /if "provider" in m and "external_key"/)
+  assert.doesNotMatch(classifyBody, /if "provider" in m and "corp" in m/)
+  assert.match(source, /Absent\/null\/false stats do NOT alone prove deprovision_applied=false/)
+})
+
+test('sync_failure recovery clears journal only after final zero-ledger + exact run identity', () => {
+  const body = actionDeprovisionSyncFailureBeforeDeprovisionRecoveryBody(read(REMOTE_SH))
+  const preGraph = body.indexOf('prove_intact_access_graph_no_ledger "sync_failure_before_deprovision_recovery_pre"')
+  const preLedger = body.indexOf('prove_zero_deprovision_ledger_for_exact_run "sync_failure_before_deprovision_recovery_pre"')
+  const sync = body.indexOf('run_directory_sync_for_subject "sync_failure_before_deprovision_recovery" "false"')
+  const postActive = body.indexOf('SUBJECT_ACTIVE" != "true"')
+  const postGraph = body.indexOf('prove_intact_access_graph_no_ledger "sync_failure_before_deprovision_recovery_post"')
+  const drift = body.indexOf('post_graph_snapshot" != "$pre_graph_snapshot"')
+  const flagsOff = body.indexOf('lifecycle flags must remain OFF after recovery sync')
+  const finalLedger = body.indexOf(
+    'prove_zero_deprovision_ledger_for_exact_run "sync_failure_before_deprovision_recovery_final_pre_clear"',
+  )
+  const finalRun = body.lastIndexOf('prove_exact_run_sync_failure_before_deprovision')
+  const clear = body.indexOf('clear_deprovision_apply_state')
+  const summary = body.indexOf('phase=sync_failure_before_deprovision_recovery')
+  assert.ok(preLedger > 0 && preGraph > preLedger, 'pre zero-ledger before pre graph / sync')
+  assert.ok(sync > preGraph, 'pre graph before flags-OFF sync')
+  assert.ok(postActive > sync && postGraph > postActive, 'post account+graph after sync')
+  assert.ok(drift > postGraph && flagsOff > drift, 'drift+flags proofs after post graph')
+  assert.ok(finalLedger > flagsOff, 'final zero-ledger recheck after all post-sync proofs')
+  assert.ok(finalRun > finalLedger, 'final exact-run identity after final zero-ledger')
+  assert.ok(clear > finalRun, 'clear only after final exact-run identity recheck')
+  assert.ok(summary > clear, 'summary after clear')
+  assert.match(body, /FINAL proof gate: re-prove exact no-ledger AND exact failed-run identity AFTER/)
+  assert.match(body, /IMMEDIATELY before clear/)
+})
+
+test('MUTATION: sync_failure recovery moving clear before final proofs turns red', () => {
+  const body = actionDeprovisionSyncFailureBeforeDeprovisionRecoveryBody(read(REMOTE_SH))
+  const clear = body.indexOf('clear_deprovision_apply_state')
+  const finalLedger = body.indexOf(
+    'prove_zero_deprovision_ledger_for_exact_run "sync_failure_before_deprovision_recovery_final_pre_clear"',
+  )
+  assert.ok(clear > finalLedger, 'production clear must follow final zero-ledger recheck')
+  const mutated =
+    body.slice(0, body.indexOf('{') + 1) +
+    '\n  clear_deprovision_apply_state\n' +
+    body.slice(body.indexOf('{') + 1).replace('clear_deprovision_apply_state', 'true # cleared early')
+  let failed = false
+  try {
+    const mClear = mutated.indexOf('clear_deprovision_apply_state')
+    const mFinal = mutated.indexOf(
+      'prove_zero_deprovision_ledger_for_exact_run "sync_failure_before_deprovision_recovery_final_pre_clear"',
+    )
+    assert.ok(mClear > mFinal, 'clear only after final zero-ledger recheck')
+  } catch {
+    failed = true
+  }
+  assert.equal(failed, true)
+})
+
+test('MUTATION: sync_failure recovery writing lifecycle flags turns red', () => {
+  const body = actionDeprovisionSyncFailureBeforeDeprovisionRecoveryBody(read(REMOTE_SH))
+  const mutated = body.replace(
+    'lifecycle_env_write=false',
+    'lifecycle_env_write=true\n  write_lifecycle_override "false" "false" "true"',
+  )
+  let failed = false
+  try {
+    assert.doesNotMatch(mutated, /write_lifecycle_override/)
+    assert.match(mutated, /lifecycle_env_write=false/)
+  } catch {
+    failed = true
+  }
+  assert.equal(failed, true)
+})
+
+test('MUTATION: sync_failure recovery claiming end-to-end restore turns red', () => {
+  const body = actionDeprovisionSyncFailureBeforeDeprovisionRecoveryBody(read(REMOTE_SH))
+  const mutated = body.replaceAll('end_to_end_restore_claimed=false', 'end_to_end_restore_claimed=true')
+  let failed = false
+  try {
+    assert.match(mutated, /end_to_end_restore_claimed=false/)
+    assert.doesNotMatch(mutated, /end_to_end_restore_claimed=true/)
+  } catch {
+    failed = true
+  }
+  assert.equal(failed, true)
+})
+
+test('MUTATION: collapsing failed-run pin into recovery sync run pin turns red', () => {
+  const source = read(REMOTE_SH)
+  const loadStart = source.indexOf('load_run_bound_sync_failure_before_deprovision_journal()')
+  assert.notEqual(loadStart, -1)
+  const loadEnd = source.indexOf('\nprove_exact_run_sync_failure_before_deprovision()', loadStart)
+  assert.notEqual(loadEnd, -1)
+  const loadBody = source.slice(loadStart, loadEnd)
+  assert.match(loadBody, /subject\.failed-sync-run-id/)
+  assert.match(loadBody, /CANARY_FAILED_SYNC_RUN_ID_FILE=/)
+  // May mention recovery sync filename in comments, but must not assign that pin.
+  assert.doesNotMatch(loadBody, /CANARY_SUBJECT_SYNC_RUN_ID_FILE\s*=/)
+  assert.doesNotMatch(loadBody, /sec\s*\/\s*["']subject\.sync-run-id["']/)
+
+  const proveStart = source.indexOf('prove_exact_run_sync_failure_before_deprovision()')
+  const proveEnd = source.indexOf('\n# Prove zero deprovision ledger', proveStart)
+  const proveBody = source.slice(proveStart, proveEnd)
+  assert.match(proveBody, /CANARY_FAILED_SYNC_RUN_ID_FILE/)
+  assert.doesNotMatch(proveBody, /CANARY_SUBJECT_SYNC_RUN_ID_FILE/)
+  assert.doesNotMatch(proveBody, /CANARY_SAFE_ABORT_SYNC_RUN_ID_FILE/)
+
+  const zeroStart = source.indexOf('prove_zero_deprovision_ledger_for_exact_run()')
+  const zeroEnd = source.indexOf('\n# Access-graph intact proof WITHOUT effect ledger', zeroStart)
+  const zeroBody = source.slice(zeroStart, zeroEnd)
+  assert.match(zeroBody, /CANARY_FAILED_SYNC_RUN_ID_FILE/)
+  assert.match(zeroBody, /CANARY_SAFE_ABORT_SYNC_RUN_ID_FILE/)
+  assert.doesNotMatch(zeroBody, /CANARY_SUBJECT_SYNC_RUN_ID_FILE/)
+
+  // Mutation: force zero-ledger to use recovery sync pin — must turn red.
+  const mutated = zeroBody
+    .replaceAll('CANARY_FAILED_SYNC_RUN_ID_FILE', 'CANARY_SUBJECT_SYNC_RUN_ID_FILE')
+    .replaceAll('CANARY_SAFE_ABORT_SYNC_RUN_ID_FILE', 'CANARY_SUBJECT_SYNC_RUN_ID_FILE')
+  let failed = false
+  try {
+    assert.doesNotMatch(mutated, /CANARY_SUBJECT_SYNC_RUN_ID_FILE/)
+    assert.match(mutated, /CANARY_FAILED_SYNC_RUN_ID_FILE|CANARY_SAFE_ABORT_SYNC_RUN_ID_FILE/)
+  } catch {
+    failed = true
+  }
+  assert.equal(failed, true)
+
+  // Mutation on exact-run proof: bind recovery sync pin instead of failed pin — red.
+  const mutatedProve = proveBody.replaceAll(
+    'CANARY_FAILED_SYNC_RUN_ID_FILE',
+    'CANARY_SUBJECT_SYNC_RUN_ID_FILE',
+  )
+  failed = false
+  try {
+    assert.doesNotMatch(mutatedProve, /CANARY_SUBJECT_SYNC_RUN_ID_FILE/)
+    assert.match(mutatedProve, /CANARY_FAILED_SYNC_RUN_ID_FILE/)
+  } catch {
+    failed = true
+  }
+  assert.equal(failed, true)
+})
+
+test('empty_fetch recovery remains distinct from sync_failure recovery', () => {
+  const source = read(REMOTE_SH)
+  const emptyBody = actionDeprovisionEmptyFetchAbortRecoveryBody(source)
+  const failBody = actionDeprovisionSyncFailureBeforeDeprovisionRecoveryBody(source)
+  assert.match(emptyBody, /empty_directory_fetch/)
+  assert.match(emptyBody, /load_run_bound_empty_fetch_abort_journal/)
+  assert.doesNotMatch(emptyBody, /load_run_bound_sync_failure_before_deprovision_journal/)
+  assert.doesNotMatch(emptyBody, /prove_exact_run_sync_failure_before_deprovision/)
+  assert.match(failBody, /load_run_bound_sync_failure_before_deprovision_journal/)
+  assert.match(failBody, /prove_exact_run_sync_failure_before_deprovision/)
+  assert.doesNotMatch(failBody, /empty_directory_fetch/)
+  assert.doesNotMatch(failBody, /load_run_bound_empty_fetch_abort_journal/)
+  // Shared helpers only for zero-ledger / intact graph — not for journal load / run proof.
+  assert.match(emptyBody, /prove_zero_deprovision_ledger_for_exact_run/)
+  assert.match(failBody, /prove_zero_deprovision_ledger_for_exact_run/)
+  assert.match(emptyBody, /prove_intact_access_graph_no_ledger/)
+  assert.match(failBody, /prove_intact_access_graph_no_ledger/)
+})
+
+test('FUNCTIONAL: sync_failure journal load accepts run_bound applied=false and refuses applied=true', () => {
+  const home = mkdtempSync(join(tmpdir(), 'lifecycle-canary-sync-fail-ok-'))
+  const stateDir = join(home, '.metasheet2', 'lifecycle-canary', 'subject-state')
+  const { mkdirSync, chmodSync } = awaitImportFs()
+  mkdirSync(stateDir, { recursive: true })
+  const stateFile = join(stateDir, 'lifecycle-canary-employee.apply-state.json')
+  const sec = mkdtempSync(join(tmpdir(), 'lifecycle-canary-sync-fail-ok-sec-'))
+  const u = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+  const i = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
+  const a = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc'
+  const run = 'dddddddd-dddd-4ddd-8ddd-dddddddddddd'
+  const base = {
+    schema: 'lifecycle-canary-deprovision-apply-state-v4',
+    phase: 'run_bound',
+    subject_key: 'lifecycle-canary-employee',
+    local_user_id: u,
+    integration_id: i,
+    directory_account_id: a,
+    sync_run_id: run,
+    sync_users_deactivated: 0,
+    sync_accounts_deactivated: 0,
+    sync_deprovision_candidates: 0,
+    event_id: null,
+    effect_count: null,
+    effects: null,
+  }
+  writeFileSync(stateFile, JSON.stringify({ ...base, deprovision_applied: false }))
+  chmodSync(stateFile, 0o600)
+  writeFileSync(join(sec, 'subject.local-user-id'), u)
+  writeFileSync(join(sec, 'subject.integration-id'), i)
+  writeFileSync(join(sec, 'directory-account.id'), a)
+  for (const f of ['subject.local-user-id', 'subject.integration-id', 'directory-account.id']) {
+    chmodSync(join(sec, f), 0o600)
+  }
+
+  const harnessEnv = {
+    ...process.env,
+    ACTION: 'deprovision',
+    OUTPUT_DIR: home,
+    RUN_STAMP: 'contract-sync-fail-ok',
+    LIFECYCLE_CANARY_SOURCE_ONLY: 'true',
+  }
+  const okScript = `
+set -euo pipefail
+source "$1"
+export HOME="$2"
+CANARY_APPLY_STATE_DIR="$3"
+CANARY_APPLY_STATE_FILE="$4"
+CANARY_SUBJECT_LOCAL_USER_ID_FILE="$5/subject.local-user-id"
+CANARY_SUBJECT_INTEGRATION_ID_FILE="$5/subject.integration-id"
+CANARY_DIRECTORY_ACCOUNT_ID_FILE="$5/directory-account.id"
+SUBJECT_OWNER_USERNAME=lifecycle-canary-employee
+load_run_bound_sync_failure_before_deprovision_journal
+printf 'ok phase=%s run_file=%s\\n' "$JOURNAL_PHASE" "$([[ -s "\${CANARY_FAILED_SYNC_RUN_ID_FILE:-}" ]] && echo yes || echo no)"
+`
+  const ok = spawnSync(
+    'bash',
+    ['-o', 'pipefail', '-c', okScript, 'bash', REMOTE_SH, home, stateDir, stateFile, sec],
+    { encoding: 'utf8', env: harnessEnv },
+  )
+  assert.equal(ok.status, 0, ok.stderr + ok.stdout)
+  assert.match(ok.stdout, /ok phase=run_bound run_file=yes/)
+  assert.ok(existsSync(stateFile), 'eligible journal must remain until final clear')
+  assert.ok(existsSync(join(sec, 'subject.failed-sync-run-id')))
+  assert.equal(readFileSync(join(sec, 'subject.failed-sync-run-id'), 'utf8'), run)
+
+  writeFileSync(stateFile, JSON.stringify({ ...base, deprovision_applied: true }))
+  chmodSync(stateFile, 0o600)
+  const badScript = `
+set -euo pipefail
+source "$1"
+export HOME="$2"
+CANARY_APPLY_STATE_DIR="$3"
+CANARY_APPLY_STATE_FILE="$4"
+CANARY_SUBJECT_LOCAL_USER_ID_FILE="$5/subject.local-user-id"
+CANARY_SUBJECT_INTEGRATION_ID_FILE="$5/subject.integration-id"
+CANARY_DIRECTORY_ACCOUNT_ID_FILE="$5/directory-account.id"
+SUBJECT_OWNER_USERNAME=lifecycle-canary-employee
+set +e
+load_run_bound_sync_failure_before_deprovision_journal
+rc=$?
+set -e
+printf 'rc=%s exists=%s\\n' "$rc" "$([[ -f "$4" ]] && echo yes || echo no)"
+`
+  const bad = spawnSync(
+    'bash',
+    ['-o', 'pipefail', '-c', badScript, 'bash', REMOTE_SH, home, stateDir, stateFile, sec],
+    { encoding: 'utf8', env: harnessEnv },
+  )
+  assert.equal(bad.status, 0, bad.stderr + bad.stdout)
+  assert.match(bad.stdout, /rc=1 /)
+  assert.match(bad.stdout, /exists=yes/)
+  assert.equal(JSON.parse(readFileSync(stateFile, 'utf8')).deprovision_applied, true)
+  rmSync(home, { recursive: true, force: true })
+  rmSync(sec, { recursive: true, force: true })
+})
+
+test('FUNCTIONAL: sync_failure exact-run proof accepts exact observed English error class', async () => {
+  const home = mkdtempSync(join(tmpdir(), 'lifecycle-canary-sync-fail-run-'))
+  const sec = join(home, 'secrets')
+  const { mkdirSync, chmodSync } = awaitImportFs()
+  mkdirSync(sec, { recursive: true })
+  const jwt = join(sec, 'admin.jwt')
+  const integ = join(sec, 'subject.integration-id')
+  const runFile = join(sec, 'subject.failed-sync-run-id')
+  const integrationId = '11111111-2222-4333-8444-555555555555'
+  const runId = 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee'
+  writeFileSync(jwt, 'test-token')
+  writeFileSync(integ, integrationId)
+  writeFileSync(runFile, runId)
+  chmodSync(jwt, 0o600)
+  chmodSync(integ, 0o600)
+  chmodSync(runFile, 0o600)
+
+  // Observed live-journal English error (exact constraint only).
+  const observedError =
+    'duplicate key value violates unique constraint "idx_directory_accounts_provider_corp_external_key"'
+
+  const serverSource = `
+import json
+from http.server import BaseHTTPRequestHandler, HTTPServer
+RUN = ${JSON.stringify(runId)}
+ERR = ${JSON.stringify(observedError)}
+class H(BaseHTTPRequestHandler):
+    def log_message(self, *_): pass
+    def send_json(self, code, payload):
+        body = json.dumps(payload, separators=(",", ":")).encode()
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+    def do_GET(self):
+        if not self.path.endswith("/runs/" + RUN):
+            self.send_json(404, {"ok": False})
+            return
+        # Absent deprovisionApplied stats: run proof still accepts (journal binds applied=false).
+        self.send_json(200, {
+            "ok": True,
+            "data": {
+                "run": {
+                    "id": RUN,
+                    "status": "failed",
+                    "errorMessage": ERR,
+                    "stats": {},
+                }
+            },
+        })
+s = HTTPServer(("127.0.0.1", 0), H)
+print(s.server_port, flush=True)
+s.serve_forever()
+`
+  const server = spawn('python3', ['-u', '-c', serverSource], { stdio: ['ignore', 'pipe', 'pipe'] })
+  const port = await new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error('sync-fail run server did not start')), 5000)
+    server.once('exit', (code) => {
+      clearTimeout(timer)
+      reject(new Error(`sync-fail run server exited ${code}`))
+    })
+    server.stdout.once('data', (chunk) => {
+      clearTimeout(timer)
+      resolve(String(chunk).trim())
+    })
+  })
+  try {
+    const script = `
+set -euo pipefail
+source "$1"
+STAGING_API_BASE_URL="http://127.0.0.1:$2"
+CANARY_ADMIN_JWT_FILE="$3"
+CANARY_SUBJECT_INTEGRATION_ID_FILE="$4"
+CANARY_FAILED_SYNC_RUN_ID_FILE="$5"
+prove_exact_run_sync_failure_before_deprovision
+printf 'ok=%s note=%s class=%s\\n' "$FAILED_SYNC_RUN_OK" "$FAILED_SYNC_RUN_NOTE" "$FAILED_SYNC_ERROR_CLASS"
+`
+    const r = spawnSync(
+      'bash',
+      ['-o', 'pipefail', '-c', script, 'bash', REMOTE_SH, port, jwt, integ, runFile],
+      {
+        encoding: 'utf8',
+        timeout: 10000,
+        env: {
+          ...process.env,
+          ACTION: 'deprovision',
+          OUTPUT_DIR: home,
+          RUN_STAMP: 'contract-sync-fail-run',
+          LIFECYCLE_CANARY_SOURCE_ONLY: 'true',
+        },
+      },
+    )
+    assert.equal(r.status, 0, r.stderr + r.stdout)
+    assert.match(r.stdout, /ok=true note=ok class=duplicate_provider_corp_external_key/)
+    // Values-free: raw constraint detail / errorMessage must never appear in proof output.
+    assert.doesNotMatch(r.stdout, /duplicate key value violates|DETAIL:|secret|aaaaaaaa-bbbb/)
+  } finally {
+    server.kill('SIGTERM')
+    rmSync(home, { recursive: true, force: true })
+  }
+})
+
+test('FUNCTIONAL: sync_failure error-class allowlist refuses sibling/null/generic/23505-without-exact', async () => {
+  const home = mkdtempSync(join(tmpdir(), 'lifecycle-canary-sync-fail-allowlist-'))
+  const sec = join(home, 'secrets')
+  const { mkdirSync, chmodSync } = awaitImportFs()
+  mkdirSync(sec, { recursive: true })
+  const jwt = join(sec, 'admin.jwt')
+  const integ = join(sec, 'subject.integration-id')
+  const integrationId = '11111111-2222-4333-8444-555555555555'
+  writeFileSync(jwt, 'test-token')
+  writeFileSync(integ, integrationId)
+  chmodSync(jwt, 0o600)
+  chmodSync(integ, 0o600)
+
+  // Distinct run UUIDs → distinct error messages on one loopback server.
+  // Case labels are opaque (case-N): values-free asserts target raw message tokens only,
+  // never the case label (a label like null_corp_index would false-positive /null_corp/).
+  const cases = [
+    {
+      runId: 'aaaaaaaa-bbbb-4ccc-8ddd-111111111111',
+      name: 'case-1',
+      refuseTokens: [
+        /idx_user_external_identities_provider_corp_union/,
+        /duplicate key value violates unique constraint "idx_user_external_identities/,
+      ],
+      errorMessage:
+        'duplicate key value violates unique constraint "idx_user_external_identities_provider_corp_union"',
+    },
+    {
+      runId: 'aaaaaaaa-bbbb-4ccc-8ddd-222222222222',
+      name: 'case-2',
+      refuseTokens: [
+        /idx_directory_accounts_provider_null_corp_external_key/,
+        /duplicate key value violates unique constraint "idx_directory_accounts_provider_null_corp/,
+      ],
+      errorMessage:
+        'duplicate key value violates unique constraint "idx_directory_accounts_provider_null_corp_external_key"',
+    },
+    {
+      runId: 'aaaaaaaa-bbbb-4ccc-8ddd-333333333333',
+      name: 'case-3',
+      refuseTokens: [/duplicate key on provider and external_key for directory account/],
+      errorMessage: 'duplicate key on provider and external_key for directory account',
+    },
+    {
+      runId: 'aaaaaaaa-bbbb-4ccc-8ddd-444444444444',
+      name: 'case-4',
+      refuseTokens: [/23505 unique_violation detail=Key already exists/],
+      errorMessage: 'error: 23505 unique_violation detail=Key already exists',
+    },
+    {
+      runId: 'aaaaaaaa-bbbb-4ccc-8ddd-555555555555',
+      name: 'case-5',
+      refuseTokens: [
+        /idx_directory_accounts_provider_external_key"/,
+        /duplicate key value violates unique constraint "idx_directory_accounts_provider_external_key"/,
+      ],
+      errorMessage:
+        'duplicate key value violates unique constraint "idx_directory_accounts_provider_external_key"',
+    },
+    {
+      runId: 'aaaaaaaa-bbbb-4ccc-8ddd-666666666666',
+      name: 'case-6',
+      refuseTokens: [/idx_directory_accounts_provider_corp_external_key_v2/],
+      errorMessage:
+        'duplicate key value violates unique constraint "idx_directory_accounts_provider_corp_external_key_v2"',
+    },
+    {
+      runId: 'aaaaaaaa-bbbb-4ccc-8ddd-777777777777',
+      name: 'case-7',
+      refuseTokens: [/while idx_directory_accounts_provider_corp_external_key remains valid/],
+      errorMessage:
+        'duplicate key value violates unique constraint "some_other_constraint" while idx_directory_accounts_provider_corp_external_key remains valid',
+    },
+  ]
+
+  const byRun = Object.fromEntries(cases.map((c) => [c.runId, c.errorMessage]))
+  const serverSource = `
+import json
+from http.server import BaseHTTPRequestHandler, HTTPServer
+BY_RUN = ${JSON.stringify(byRun)}
+class H(BaseHTTPRequestHandler):
+    def log_message(self, *_): pass
+    def send_json(self, code, payload):
+        body = json.dumps(payload, separators=(",", ":")).encode()
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+    def do_GET(self):
+        run_id = self.path.rsplit("/", 1)[-1]
+        err = BY_RUN.get(run_id)
+        if err is None:
+            self.send_json(404, {"ok": False})
+            return
+        self.send_json(200, {
+            "ok": True,
+            "data": {
+                "run": {
+                    "id": run_id,
+                    "status": "failed",
+                    "errorMessage": err,
+                    "stats": {},
+                }
+            },
+        })
+s = HTTPServer(("127.0.0.1", 0), H)
+print(s.server_port, flush=True)
+s.serve_forever()
+`
+  const server = spawn('python3', ['-u', '-c', serverSource], { stdio: ['ignore', 'pipe', 'pipe'] })
+  const port = await new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error('sync-fail allowlist server did not start')), 5000)
+    server.once('exit', (code) => {
+      clearTimeout(timer)
+      reject(new Error(`sync-fail allowlist server exited ${code}`))
+    })
+    server.stdout.once('data', (chunk) => {
+      clearTimeout(timer)
+      resolve(String(chunk).trim())
+    })
+  })
+  try {
+    for (const c of cases) {
+      const runFile = join(sec, `subject.failed-sync-run-id.${c.name}`)
+      writeFileSync(runFile, c.runId)
+      chmodSync(runFile, 0o600)
+      const script = `
+set -euo pipefail
+source "$1"
+STAGING_API_BASE_URL="http://127.0.0.1:$2"
+CANARY_ADMIN_JWT_FILE="$3"
+CANARY_SUBJECT_INTEGRATION_ID_FILE="$4"
+CANARY_FAILED_SYNC_RUN_ID_FILE="$5"
+set +e
+prove_exact_run_sync_failure_before_deprovision
+rc=$?
+set -e
+printf 'case=%s rc=%s ok=%s note=%s class=%s\\n' "$6" "$rc" "$FAILED_SYNC_RUN_OK" "$FAILED_SYNC_RUN_NOTE" "$FAILED_SYNC_ERROR_CLASS"
+`
+      const r = spawnSync(
+        'bash',
+        ['-o', 'pipefail', '-c', script, 'bash', REMOTE_SH, port, jwt, integ, runFile, c.name],
+        {
+          encoding: 'utf8',
+          timeout: 10000,
+          env: {
+            ...process.env,
+            ACTION: 'deprovision',
+            OUTPUT_DIR: home,
+            RUN_STAMP: `contract-sync-fail-allowlist-${c.name}`,
+            LIFECYCLE_CANARY_SOURCE_ONLY: 'true',
+          },
+        },
+      )
+      assert.equal(r.status, 0, `${c.name}: ${r.stderr}\n${r.stdout}`)
+      assert.match(r.stdout, new RegExp(`case=${c.name} rc=1 `), c.name)
+      assert.match(r.stdout, /note=error_class_not_allowlisted/, c.name)
+      assert.doesNotMatch(r.stdout, /ok=true/, c.name)
+      // Values-free: stdout must not echo the raw sibling constraint / message tokens.
+      // Assert against those production-message tokens only — never against the case label.
+      for (const token of c.refuseTokens) {
+        assert.doesNotMatch(r.stdout, token, `${c.name} must not echo ${token}`)
+      }
+      assert.doesNotMatch(r.stdout, /DETAIL:/, c.name)
+    }
+  } finally {
+    server.kill('SIGTERM')
+    rmSync(home, { recursive: true, force: true })
+  }
+})
+
+test('FUNCTIONAL: sync_failure exact-run proof refuses completed empty_directory_fetch', async () => {
+  const home = mkdtempSync(join(tmpdir(), 'lifecycle-canary-sync-fail-refuse-empty-'))
+  const sec = join(home, 'secrets')
+  const { mkdirSync, chmodSync } = awaitImportFs()
+  mkdirSync(sec, { recursive: true })
+  const jwt = join(sec, 'admin.jwt')
+  const integ = join(sec, 'subject.integration-id')
+  const runFile = join(sec, 'subject.failed-sync-run-id')
+  const integrationId = '11111111-2222-4333-8444-555555555555'
+  const runId = 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee'
+  writeFileSync(jwt, 'test-token')
+  writeFileSync(integ, integrationId)
+  writeFileSync(runFile, runId)
+  for (const f of [jwt, integ, runFile]) chmodSync(f, 0o600)
+
+  const serverSource = `
+import json
+from http.server import BaseHTTPRequestHandler, HTTPServer
+RUN = ${JSON.stringify(runId)}
+class H(BaseHTTPRequestHandler):
+    def log_message(self, *_): pass
+    def send_json(self, code, payload):
+        body = json.dumps(payload, separators=(",", ":")).encode()
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+    def do_GET(self):
+        self.send_json(200, {
+            "ok": True,
+            "data": {
+                "run": {
+                    "id": RUN,
+                    "status": "completed",
+                    "stats": {
+                        "deprovisionApplied": False,
+                        "deprovisionAbortedReason": "empty_directory_fetch",
+                    },
+                }
+            },
+        })
+s = HTTPServer(("127.0.0.1", 0), H)
+print(s.server_port, flush=True)
+s.serve_forever()
+`
+  const server = spawn('python3', ['-u', '-c', serverSource], { stdio: ['ignore', 'pipe', 'pipe'] })
+  const port = await new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error('sync-fail refuse server did not start')), 5000)
+    server.once('exit', (code) => {
+      clearTimeout(timer)
+      reject(new Error(`sync-fail refuse server exited ${code}`))
+    })
+    server.stdout.once('data', (chunk) => {
+      clearTimeout(timer)
+      resolve(String(chunk).trim())
+    })
+  })
+  try {
+    const script = `
+set -euo pipefail
+source "$1"
+STAGING_API_BASE_URL="http://127.0.0.1:$2"
+CANARY_ADMIN_JWT_FILE="$3"
+CANARY_SUBJECT_INTEGRATION_ID_FILE="$4"
+CANARY_FAILED_SYNC_RUN_ID_FILE="$5"
+set +e
+prove_exact_run_sync_failure_before_deprovision
+rc=$?
+set -e
+printf 'rc=%s ok=%s note=%s\\n' "$rc" "$FAILED_SYNC_RUN_OK" "$FAILED_SYNC_RUN_NOTE"
+`
+    const r = spawnSync(
+      'bash',
+      ['-o', 'pipefail', '-c', script, 'bash', REMOTE_SH, port, jwt, integ, runFile],
+      {
+        encoding: 'utf8',
+        timeout: 10000,
+        env: {
+          ...process.env,
+          ACTION: 'deprovision',
+          OUTPUT_DIR: home,
+          RUN_STAMP: 'contract-sync-fail-refuse-empty',
+          LIFECYCLE_CANARY_SOURCE_ONLY: 'true',
+        },
+      },
+    )
+    assert.equal(r.status, 0, r.stderr + r.stdout)
+    assert.match(r.stdout, /rc=1 /)
+    assert.match(r.stdout, /note=run_not_failed/)
+  } finally {
+    server.kill('SIGTERM')
+    rmSync(home, { recursive: true, force: true })
+  }
+})
+
+test('FUNCTIONAL: zero-ledger proof keeps failed-run pin after a distinct recovery sync run exists', () => {
+  const home = mkdtempSync(join(tmpdir(), 'lifecycle-canary-sync-fail-run-pin-'))
+  const sec = join(home, 'secrets')
+  const { mkdirSync, chmodSync } = awaitImportFs()
+  mkdirSync(sec, { recursive: true })
+  const user = join(sec, 'subject.local-user-id')
+  const integ = join(sec, 'subject.integration-id')
+  const failedRun = join(sec, 'subject.failed-sync-run-id')
+  const recoveryRun = join(sec, 'subject.sync-run-id')
+  const acct = join(sec, 'directory-account.id')
+  const failedRunId = 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee'
+  writeFileSync(user, '99999999-8888-4777-8666-555555555555')
+  writeFileSync(integ, '11111111-2222-4333-8444-555555555555')
+  writeFileSync(failedRun, failedRunId)
+  writeFileSync(recoveryRun, 'bbbbbbbb-cccc-4ddd-8eee-ffffffffffff')
+  writeFileSync(acct, '12121212-3434-4656-8878-909090909090')
+  for (const f of [user, integ, failedRun, recoveryRun, acct]) chmodSync(f, 0o600)
+
+  const script = `
+set -euo pipefail
+source "$1"
+CANARY_SUBJECT_LOCAL_USER_ID_FILE="$2"
+CANARY_SUBJECT_INTEGRATION_ID_FILE="$3"
+CANARY_FAILED_SYNC_RUN_ID_FILE="$4"
+CANARY_SUBJECT_SYNC_RUN_ID_FILE="$5"
+CANARY_DIRECTORY_ACCOUNT_ID_FILE="$6"
+EXPECTED_FAILED_RUN_ID="$7"
+BACKEND_CONTAINER=metasheet-staging-backend
+docker() {
+  local payload
+  payload="$(cat)"
+  if [[ "$payload" == *"$EXPECTED_FAILED_RUN_ID"* ]]; then
+    printf 'true|ok|0|0'
+  else
+    printf 'false|wrong_run_pin|0|0'
+  fi
+}
+prove_zero_deprovision_ledger_for_exact_run "contract_distinct_failed_run_pin"
+printf 'ok=%s note=%s\\n' "$SAFE_ABORT_LEDGER_OK" "$SAFE_ABORT_LEDGER_NOTE"
+`
+  const r = spawnSync(
+    'bash',
+    ['-o', 'pipefail', '-c', script, 'bash', REMOTE_SH, user, integ, failedRun, recoveryRun, acct, failedRunId],
+    {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        ACTION: 'deprovision',
+        OUTPUT_DIR: home,
+        RUN_STAMP: 'contract-sync-fail-distinct-run-pin',
+        LIFECYCLE_CANARY_SOURCE_ONLY: 'true',
+      },
+    },
+  )
+  assert.equal(r.status, 0, r.stderr + r.stdout)
+  assert.match(r.stdout, /ok=true note=ok/)
+  rmSync(home, { recursive: true, force: true })
+})
+
 test('workflow validates empty-fetch abort recovery confirmation for action=deprovision', () => {
   const yaml = read(WORKFLOW)
   assert.match(yaml, /DINGTALK_EMPTY_FETCH_ABORT_SOURCE_RE_ADDED_CONFIRMED/)
   assert.match(
     yaml,
-    /DINGTALK_SOURCE_DISABLED_DEDICATED_EXCLUSIVE_CONFIRMED\|DINGTALK_SOURCE_REACTIVATED_CONFIRMED\|DINGTALK_EMPTY_FETCH_ABORT_SOURCE_RE_ADDED_CONFIRMED/,
+    /DINGTALK_SOURCE_DISABLED_DEDICATED_EXCLUSIVE_CONFIRMED\|DINGTALK_SOURCE_REACTIVATED_CONFIRMED\|DINGTALK_EMPTY_FETCH_ABORT_SOURCE_RE_ADDED_CONFIRMED\|DINGTALK_SYNC_FAILURE_BEFORE_DEPROVISION_SOURCE_RE_ADDED_CONFIRMED/,
   )
   // Secret paths for deprovision still cover recovery (same action).
   assert.match(
@@ -3871,13 +4662,16 @@ test('workflow pending/deprovision phase confirmations and honest claims', () =>
   assert.match(yaml, /DINGTALK_SOURCE_DISABLED_DEDICATED_EXCLUSIVE_CONFIRMED/)
   assert.match(yaml, /DINGTALK_SOURCE_REACTIVATED_CONFIRMED/)
   assert.match(yaml, /DINGTALK_EMPTY_FETCH_ABORT_SOURCE_RE_ADDED_CONFIRMED/)
+  assert.match(yaml, /DINGTALK_SYNC_FAILURE_BEFORE_DEPROVISION_SOURCE_RE_ADDED_CONFIRMED/)
   assert.match(yaml, /directory-account\.id/)
   assert.match(yaml, /NOT_EXECUTED/)
   assert.match(yaml, /restore phase|RESTORE/)
   assert.match(yaml, /empty-fetch abort recovery|EMPTY_FETCH_ABORT/)
+  assert.match(yaml, /sync-failure-before-deprovision recovery|SYNC_FAILURE_BEFORE_DEPROVISION/)
   assert.doesNotMatch(yaml, /docs may still say NOT EXECUTABLE|follow-up to refresh docs/i)
   assert.match(yaml, /exactly one total directory account/)
   assert.match(yaml, /reserves and journals the exact sync run UUID before env\/HTTP/)
+  assert.match(yaml, /Never claims end-to-end restore|never claims end-to-end restore/)
 })
 
 

--- a/scripts/ops/dingtalk-lifecycle-staging-canary-remote.sh
+++ b/scripts/ops/dingtalk-lifecycle-staging-canary-remote.sh
@@ -73,6 +73,17 @@
 #                pre-recovery intact access graph, external source re-add, flags-OFF
 #                sync, owned directory account active, and access graph unchanged —
 #                then and only then clears the journal.
+#                SYNC_FAILURE_BEFORE_DEPROVISION_RECOVERY (confirmation=
+#                DINGTALK_SYNC_FAILURE_BEFORE_DEPROVISION_SOURCE_RE_ADDED_CONFIRMED):
+#                staging-only fail-closed recovery when the journal is stranded at
+#                phase=run_bound after an exact terminal failed sync with zero ledger
+#                (e.g. ledger_verify_failed_sync_deprovision_not_applied after the
+#                observed idx_directory_accounts_provider_corp_external_key collision).
+#                Never writes lifecycle env. Journal binds deprovision_applied=false;
+#                run API proves status=failed + exact observed error class (values-free);
+#                zero ledger + intact active access graph prove no mutation. External
+#                source re-add, flags-OFF sync (deprovisionApplied=false), graph
+#                unchanged, final zero-ledger + exact run identity — then clears journal.
 #
 # HARD SAFETY RAILS:
 #   * Staging compose + metasheet-staging-* containers only; no prod fallback.
@@ -143,6 +154,10 @@ DEPROVISION_RESTORE_CONFIRMATION="DINGTALK_SOURCE_REACTIVATED_CONFIRMED"
 # Staging-only recovery for a completed empty_directory_fetch safe abort stranded at
 # phase=run_bound with no deprovision ledger. Never writes lifecycle env flags.
 DEPROVISION_EMPTY_FETCH_ABORT_RECOVERY_CONFIRMATION="DINGTALK_EMPTY_FETCH_ABORT_SOURCE_RE_ADDED_CONFIRMED"
+# Staging-only recovery for a terminal failed sync stranded at phase=run_bound with
+# journal deprovision_applied=false and zero ledger (exact observed constraint class).
+# Never writes lifecycle env flags.
+DEPROVISION_SYNC_FAILURE_BEFORE_DEPROVISION_RECOVERY_CONFIRMATION="DINGTALK_SYNC_FAILURE_BEFORE_DEPROVISION_SOURCE_RE_ADDED_CONFIRMED"
 PENDING_SSO_ACTIVATE_CONFIRMATION="PENDING_SSO_ACTIVATE"
 # Optional subject password file (path only). When present, deprovision may prove
 # pre-login then post-denial with the SAME proven credential. Never invent a wrong
@@ -3244,11 +3259,253 @@ PY
   return 1
 }
 
+# Load host journal for sync-failure-before-deprovision recovery only.
+# Accepts EXACTLY phase=run_bound with deprovision_applied=false and no ledger
+# binding (same journal shape as empty_fetch abort, different exact-run proof).
+# Pins the immutable failed run id separately from any later recovery sync run.
+# Leaves journal intact on any refuse (caller must not clear).
+load_run_bound_sync_failure_before_deprovision_journal() {
+  FAILED_SYNC_JOURNAL_OK="false"
+  FAILED_SYNC_JOURNAL_NOTE="unset"
+  [[ -f "$CANARY_APPLY_STATE_FILE" && -s "$CANARY_APPLY_STATE_FILE" ]] \
+    || { FAILED_SYNC_JOURNAL_NOTE="journal_missing"; return 1; }
+  [[ -n "${CANARY_SUBJECT_LOCAL_USER_ID_FILE:-}" && -s "${CANARY_SUBJECT_LOCAL_USER_ID_FILE}" ]] \
+    || { FAILED_SYNC_JOURNAL_NOTE="live_local_user_id_missing"; return 1; }
+  [[ -n "${CANARY_SUBJECT_INTEGRATION_ID_FILE:-}" && -s "${CANARY_SUBJECT_INTEGRATION_ID_FILE}" ]] \
+    || { FAILED_SYNC_JOURNAL_NOTE="live_integration_id_missing"; return 1; }
+  [[ -n "${CANARY_DIRECTORY_ACCOUNT_ID_FILE:-}" && -s "${CANARY_DIRECTORY_ACCOUNT_ID_FILE}" ]] \
+    || { FAILED_SYNC_JOURNAL_NOTE="live_directory_account_id_missing"; return 1; }
+  local sec_dir
+  sec_dir="$(_subject_secret_dir)"
+  if ! python3 - \
+    "$CANARY_APPLY_STATE_FILE" \
+    "$sec_dir" \
+    "$SUBJECT_OWNER_USERNAME" \
+    "$CANARY_SUBJECT_LOCAL_USER_ID_FILE" \
+    "$CANARY_SUBJECT_INTEGRATION_ID_FILE" \
+    "$CANARY_DIRECTORY_ACCOUNT_ID_FILE" <<'PY'
+import json, os, pathlib, re, sys
+(
+    state_path, sec_dir, subject_key,
+    live_user_path, live_integ_path, live_acct_path,
+) = sys.argv[1:7]
+uuid_re = re.compile(
+    r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+)
+try:
+    state = json.loads(pathlib.Path(state_path).read_bytes().decode("utf-8"))
+except Exception:
+    raise SystemExit(2)
+if not isinstance(state, dict) or state.get("schema") != "lifecycle-canary-deprovision-apply-state-v4":
+    raise SystemExit(3)
+if state.get("subject_key") != subject_key:
+    raise SystemExit(4)
+# Exact phase only — prepared must not skip to this recovery; ledger_bound uses restore.
+if state.get("phase") != "run_bound":
+    raise SystemExit(5)
+# Terminal failed-before-deprovision outcome: applied must be false (never true/null).
+if state.get("deprovision_applied") is not False:
+    raise SystemExit(6)
+# No ledger binding may exist for this recovery path.
+if state.get("event_id") not in (None, ""):
+    raise SystemExit(7)
+if state.get("effect_count") not in (None, 0):
+    raise SystemExit(8)
+effects = state.get("effects")
+if effects is not None and effects != []:
+    raise SystemExit(9)
+run_id = str(state.get("sync_run_id") or "").strip()
+local_user_id = str(state.get("local_user_id") or "").strip()
+integration_id = str(state.get("integration_id") or "").strip()
+directory_account_id = str(state.get("directory_account_id") or "").strip()
+for val in (run_id, local_user_id, integration_id, directory_account_id):
+    if not uuid_re.fullmatch(val):
+        raise SystemExit(10)
+live_user = pathlib.Path(live_user_path).read_bytes().decode("utf-8").strip()
+live_integ = pathlib.Path(live_integ_path).read_bytes().decode("utf-8").strip()
+live_acct = pathlib.Path(live_acct_path).read_bytes().decode("utf-8").strip()
+if live_user != local_user_id or live_integ != integration_id or live_acct != directory_account_id:
+    raise SystemExit(11)
+sec = pathlib.Path(sec_dir)
+sec.mkdir(parents=True, exist_ok=True)
+# Immutable failed-run pin must survive the recovery sync, which writes its own
+# fresh run id to subject.sync-run-id.
+failed_run_path = sec / "subject.failed-sync-run-id"
+failed_run_path.write_bytes(run_id.encode("utf-8"))
+os.chmod(failed_run_path, 0o600)
+(sec / "subject.local-user-id").write_bytes(local_user_id.encode("utf-8"))
+os.chmod(sec / "subject.local-user-id", 0o600)
+(sec / "subject.integration-id").write_bytes(integration_id.encode("utf-8"))
+os.chmod(sec / "subject.integration-id", 0o600)
+PY
+  then
+    FAILED_SYNC_JOURNAL_NOTE="journal_not_run_bound_failed_before_deprovision"
+    return 1
+  fi
+  CANARY_FAILED_SYNC_RUN_ID_FILE="${sec_dir}/subject.failed-sync-run-id"
+  CANARY_SUBJECT_LOCAL_USER_ID_FILE="${sec_dir}/subject.local-user-id"
+  CANARY_SUBJECT_INTEGRATION_ID_FILE="${sec_dir}/subject.integration-id"
+  JOURNAL_PHASE="run_bound"
+  FAILED_SYNC_JOURNAL_OK="true"
+  FAILED_SYNC_JOURNAL_NOTE="ok"
+  log "loaded recovery journal phase=run_bound for sync_failure_before_deprovision recovery (exact failed run bound; no ledger; ids never logged)"
+  return 0
+}
+
+# Prove the exact journaled sync run is terminal failed with the exact observed
+# error class (values-free). Binds ONLY CANARY_FAILED_SYNC_RUN_ID_FILE.
+# deprovision_applied=false is journal-bound (load_run_bound_*), not inferred from
+# absent/null run stats. Zero ledger + intact access graph prove no mutation.
+# Never latest-run guess. Never logs raw errorMessage / ids / secrets.
+prove_exact_run_sync_failure_before_deprovision() {
+  FAILED_SYNC_RUN_OK="false"
+  FAILED_SYNC_RUN_NOTE="unset"
+  FAILED_SYNC_ERROR_CLASS=""
+  [[ -n "${CANARY_ADMIN_JWT_FILE:-}" && -s "${CANARY_ADMIN_JWT_FILE}" ]] \
+    || { FAILED_SYNC_RUN_NOTE="admin_jwt_missing"; return 1; }
+  [[ -n "${CANARY_SUBJECT_INTEGRATION_ID_FILE:-}" && -s "${CANARY_SUBJECT_INTEGRATION_ID_FILE}" ]] \
+    || { FAILED_SYNC_RUN_NOTE="integration_id_file_missing"; return 1; }
+  [[ -n "${CANARY_FAILED_SYNC_RUN_ID_FILE:-}" && -s "${CANARY_FAILED_SYNC_RUN_ID_FILE}" ]] \
+    || { FAILED_SYNC_RUN_NOTE="sync_run_id_file_missing"; return 1; }
+  local result
+  result="$(
+    python3 - \
+      "$CANARY_ADMIN_JWT_FILE" \
+      "$STAGING_API_BASE_URL" \
+      "$CANARY_SUBJECT_INTEGRATION_ID_FILE" \
+      "$CANARY_FAILED_SYNC_RUN_ID_FILE" <<'PY'
+import json, pathlib, re, sys, urllib.error, urllib.parse, urllib.request
+
+jwt_path, base, integ_path, run_path = sys.argv[1:5]
+
+def emit(ok, note, err_class=""):
+    print(f"{ok}|{note}|{err_class}")
+    raise SystemExit(0)
+
+def classify_error(msg):
+    """Accept only exact observed constraint + a duplicate/unique-violation marker.
+
+    Rejects sibling identity indexes, null-corp index, generic provider/external_key
+    prose, and 23505 without the exact constraint name. Values-free: never returns msg.
+    """
+    # Literals live inside classify_error so contract extraction of this function
+    # remains load-bearing (constants outside the function are easy to miss).
+    exact_constraint = "idx_directory_accounts_provider_corp_external_key"
+    exact_signature = (
+        'duplicate key value violates unique constraint "'
+        + exact_constraint
+        + '"'
+    )
+    exact_error_class = "duplicate_provider_corp_external_key"
+    if type(msg) is not str:
+        return ""
+    m = msg.lower()
+    # Exact observed PostgreSQL signature required. A sibling index suffix or a
+    # diagnostic that merely mentions this constraint must not qualify.
+    if exact_signature not in m:
+        return ""
+    return exact_error_class
+
+try:
+    token = pathlib.Path(jwt_path).read_text(encoding="utf-8").strip()
+    integration_id = pathlib.Path(integ_path).read_bytes().decode("utf-8").strip()
+    run_id = pathlib.Path(run_path).read_bytes().decode("utf-8").strip()
+except Exception:
+    emit("false", "secret_file_read_failed")
+uuid_re = re.compile(
+    r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+)
+if not uuid_re.fullmatch(integration_id) or not uuid_re.fullmatch(run_id):
+    emit("false", "ids_invalid")
+url = (
+    base.rstrip("/")
+    + "/api/admin/directory/integrations/"
+    + urllib.parse.quote(integration_id, safe="")
+    + "/runs/"
+    + urllib.parse.quote(run_id, safe="")
+)
+req = urllib.request.Request(
+    url,
+    headers={"Authorization": f"Bearer {token}", "Accept": "application/json"},
+    method="GET",
+)
+try:
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        raw = resp.read().decode("utf-8", errors="replace")
+        code = int(resp.getcode())
+except urllib.error.HTTPError as e:
+    emit("false", f"run_http_{int(e.code)}")
+except Exception:
+    emit("false", "run_transport_failed")
+try:
+    payload = json.loads(raw) if raw else {}
+except Exception:
+    emit("false", "run_bad_json")
+if code != 200 or not isinstance(payload, dict) or payload.get("ok") is not True:
+    emit("false", f"run_http_{code}")
+data = payload.get("data") if isinstance(payload.get("data"), dict) else {}
+run = data.get("run") if isinstance(data.get("run"), dict) else None
+if run is None and isinstance(data.get("id"), str):
+    run = data
+if not isinstance(run, dict):
+    emit("false", "run_missing")
+if str(run.get("id") or "").strip() != run_id:
+    emit("false", "run_id_mismatch")
+status = str(run.get("status") or "").strip().lower()
+if status != "failed":
+    emit("false", "run_not_failed")
+# Fail closed only when stats explicitly claim deprovision already applied.
+# Absent/null/false stats do NOT alone prove deprovision_applied=false — that is
+# journal-bound; zero ledger + intact access graph are the no-mutation proofs.
+stats = run.get("stats") if isinstance(run.get("stats"), dict) else {}
+applied = stats.get("deprovisionApplied")
+if applied is True:
+    emit("false", "deprovision_applied_true")
+# Belt: if effect counters are present they must be zero (still not a substitute
+# for journal deprovision_applied=false or Postgres zero-ledger proof).
+for key in (
+    "deprovisionUsersDeactivatedCount",
+    "deprovisionGrantsDisabledCount",
+    "deprovisionMembershipDeactivationAttemptedCount",
+):
+    val = stats.get(key)
+    if val is None:
+        continue
+    if type(val) is not int or val != 0:
+        emit("false", "non_zero_user_or_grant_or_membership_effect_count")
+# Exact observed error class — values-free. Never print errorMessage.
+err_msg = run.get("errorMessage")
+if err_msg is None:
+    err_msg = run.get("error_message")
+err_class = classify_error(err_msg if isinstance(err_msg, str) else "")
+if not err_class:
+    emit("false", "error_class_not_allowlisted")
+emit("true", "ok", err_class)
+PY
+  )" || {
+    FAILED_SYNC_RUN_NOTE="python_failed"
+    return 1
+  }
+  FAILED_SYNC_RUN_OK="${result%%|*}"
+  local rest="${result#*|}"
+  FAILED_SYNC_RUN_NOTE="${rest%%|*}"
+  FAILED_SYNC_ERROR_CLASS="${rest#*|}"
+  if [[ "$FAILED_SYNC_RUN_OK" == "true" ]]; then
+    log "exact run sync_failure_before_deprovision proven (failed + exact observed error class=${FAILED_SYNC_ERROR_CLASS}; journal binds deprovision_applied=false; ids/raw error never logged)"
+    return 0
+  fi
+  log "exact run sync_failure_before_deprovision proof refused: note=${FAILED_SYNC_RUN_NOTE}"
+  return 1
+}
+
 # Prove zero deprovision ledger events/effects for the exact journaled run via
 # host docker/Postgres — never a paginated admin list / limit / latest inference.
 # Scope is exact equality on run_id::uuid + integration_id::uuid + local_user_id +
 # directory_account_id with NO status filter. Counts joined
 # directory_deprovision_effects for matched event(s). Both counts must be 0.
+# Immutable pin only: CANARY_FAILED_SYNC_RUN_ID_FILE (sync-failure recovery) or
+# CANARY_SAFE_ABORT_SYNC_RUN_ID_FILE (empty_fetch recovery). Never the recovery
+# sync's subject.sync-run-id pin.
 prove_zero_deprovision_ledger_for_exact_run() {
   local context="${1:-empty_fetch_abort_recovery}"
   SAFE_ABORT_LEDGER_OK="false"
@@ -3259,14 +3516,21 @@ prove_zero_deprovision_ledger_for_exact_run() {
     || { SAFE_ABORT_LEDGER_NOTE="local_user_id_file_missing"; return 1; }
   [[ -n "${CANARY_SUBJECT_INTEGRATION_ID_FILE:-}" && -s "${CANARY_SUBJECT_INTEGRATION_ID_FILE}" ]] \
     || { SAFE_ABORT_LEDGER_NOTE="integration_id_file_missing"; return 1; }
-  [[ -n "${CANARY_SAFE_ABORT_SYNC_RUN_ID_FILE:-}" && -s "${CANARY_SAFE_ABORT_SYNC_RUN_ID_FILE}" ]] \
-    || { SAFE_ABORT_LEDGER_NOTE="sync_run_id_file_missing"; return 1; }
+  local exact_run_pin=""
+  if [[ -n "${CANARY_FAILED_SYNC_RUN_ID_FILE:-}" && -s "${CANARY_FAILED_SYNC_RUN_ID_FILE}" ]]; then
+    exact_run_pin="$CANARY_FAILED_SYNC_RUN_ID_FILE"
+  elif [[ -n "${CANARY_SAFE_ABORT_SYNC_RUN_ID_FILE:-}" && -s "${CANARY_SAFE_ABORT_SYNC_RUN_ID_FILE}" ]]; then
+    exact_run_pin="$CANARY_SAFE_ABORT_SYNC_RUN_ID_FILE"
+  else
+    SAFE_ABORT_LEDGER_NOTE="sync_run_id_file_missing"
+    return 1
+  fi
   [[ -n "${CANARY_DIRECTORY_ACCOUNT_ID_FILE:-}" && -s "${CANARY_DIRECTORY_ACCOUNT_ID_FILE}" ]] \
     || { SAFE_ABORT_LEDGER_NOTE="directory_account_id_file_missing"; return 1; }
   local payload_json result
   payload_json="$(
     python3 - \
-      "$CANARY_SAFE_ABORT_SYNC_RUN_ID_FILE" \
+      "$exact_run_pin" \
       "$CANARY_SUBJECT_INTEGRATION_ID_FILE" \
       "$CANARY_SUBJECT_LOCAL_USER_ID_FILE" \
       "$CANARY_DIRECTORY_ACCOUNT_ID_FILE" <<'PY'
@@ -5605,16 +5869,27 @@ action_pending() {
 #   phase=run_bound after completed empty_directory_fetch abort with zero ledger.
 #   Clears journal only after proving directory account reactivated + access graph
 #   unchanged. Never writes lifecycle env flags.
+# Deprovision sync_failure_before_deprovision recovery
+# (confirmation=DINGTALK_SYNC_FAILURE_BEFORE_DEPROVISION_SOURCE_RE_ADDED_CONFIRMED):
+#   staging-only, flags stay OFF forever. Recovers a journal stranded at
+#   phase=run_bound (journal deprovision_applied=false, zero ledger) after terminal
+#   failed sync whose error class is the exact observed constraint
+#   idx_directory_accounts_provider_corp_external_key. Run API proves failed + class;
+#   zero ledger + intact graph prove no mutation. Clears journal only after those
+#   proofs + exact run identity recheck. Never writes lifecycle env; never claims
+#   end-to-end restore.
 action_deprovision() {
   local phase="apply"
   if [[ "${BOOTSTRAP_CONFIRMATION:-}" == "$DEPROVISION_RESTORE_CONFIRMATION" ]]; then
     phase="restore"
   elif [[ "${BOOTSTRAP_CONFIRMATION:-}" == "$DEPROVISION_EMPTY_FETCH_ABORT_RECOVERY_CONFIRMATION" ]]; then
     phase="empty_fetch_abort_recovery"
+  elif [[ "${BOOTSTRAP_CONFIRMATION:-}" == "$DEPROVISION_SYNC_FAILURE_BEFORE_DEPROVISION_RECOVERY_CONFIRMATION" ]]; then
+    phase="sync_failure_before_deprovision_recovery"
   elif [[ "${BOOTSTRAP_CONFIRMATION:-}" == "$DEPROVISION_SOURCE_CONFIRMATION" ]]; then
     phase="apply"
   else
-    fail "action=deprovision requires bootstrap_confirmation=${DEPROVISION_SOURCE_CONFIRMATION}|${DEPROVISION_RESTORE_CONFIRMATION}|${DEPROVISION_EMPTY_FETCH_ABORT_RECOVERY_CONFIRMATION}"
+    fail "action=deprovision requires bootstrap_confirmation=${DEPROVISION_SOURCE_CONFIRMATION}|${DEPROVISION_RESTORE_CONFIRMATION}|${DEPROVISION_EMPTY_FETCH_ABORT_RECOVERY_CONFIRMATION}|${DEPROVISION_SYNC_FAILURE_BEFORE_DEPROVISION_RECOVERY_CONFIRMATION}"
   fi
 
   if [[ "$phase" == "restore" ]]; then
@@ -5623,6 +5898,10 @@ action_deprovision() {
   fi
   if [[ "$phase" == "empty_fetch_abort_recovery" ]]; then
     action_deprovision_empty_fetch_abort_recovery
+    return $?
+  fi
+  if [[ "$phase" == "sync_failure_before_deprovision_recovery" ]]; then
+    action_deprovision_sync_failure_before_deprovision_recovery
     return $?
   fi
   action_deprovision_apply
@@ -6232,6 +6511,209 @@ action_deprovision_empty_fetch_abort_recovery() {
     echo "note=${note}"
   } > "${OUTPUT_DIR}/summary.txt"
   log "action=deprovision empty_fetch_abort_recovery OK (flags OFF; directory reactivated; access graph unchanged; journal cleared; no lifecycle env write)"
+}
+
+# Staging-only recovery for journal phase=run_bound after terminal failed sync with
+# journal deprovision_applied=false, zero ledger, and exact observed error class
+# idx_directory_accounts_provider_corp_external_key. Never writes lifecycle env.
+# Never calls rehire restore. Clears journal only after final post-sync proofs +
+# final zero-ledger recheck + exact failed-run identity recheck.
+action_deprovision_sync_failure_before_deprovision_recovery() {
+  local pre_login_ok="false"
+  local admin_jwt_minted="false"
+  local journal_ok="false"
+  local exact_run_ok="false"
+  local exact_run_final_ok="false"
+  local zero_ledger_ok="false"
+  local zero_ledger_final_ok="false"
+  local pre_graph_ok="false"
+  local source_active_after_sync="false"
+  local sync_ok="false"
+  local post_graph_ok="false"
+  local graph_unchanged_ok="false"
+  local flags_remain_off="false"
+  local journal_cleared="false"
+  local pre_graph_snapshot=""
+  local post_graph_snapshot=""
+  local note="sync_failure_before_deprovision_recovery_phase"
+
+  require_sha
+  require_canary_secret_files "deprovision"
+  assert_canary_identifier_matches_owner "deprovision"
+  require_canary_directory_account_id_file "deprovision"
+  [[ -n "$EXPECTED_CURRENT_MODE" ]] || fail "expected_current_mode is required for action=deprovision sync_failure_before_deprovision_recovery"
+  [[ "$EXPECTED_CURRENT_MODE" == "off" ]] \
+    || fail "action=deprovision sync_failure_before_deprovision_recovery requires expected_current_mode=off"
+
+  capture_live_snapshot
+  assert_exact_sha
+  require_migrations_pending_zero_true "$SNAP_MIGRATIONS_ZERO" "action=deprovision sync_failure_before_deprovision_recovery"
+
+  if [[ "$SNAP_HEALTH_OK" != "true" ]]; then
+    fail "action=deprovision sync_failure_before_deprovision_recovery refused: backend_health_ok must be true (journal left intact)"
+  fi
+  # Any lifecycle flag ON refuses recovery and leaves the journal intact.
+  if [[ "$SNAP_MODE" != "off" || "$SNAP_ALIAS" != "false" || "$SNAP_PENDING" != "false" || "$SNAP_DEPROV" != "false" ]]; then
+    fail "action=deprovision sync_failure_before_deprovision_recovery refused: all lifecycle flags must be OFF (live mode='${SNAP_MODE}'); journal left intact"
+  fi
+
+  if mint_canary_admin_jwt_from_password_login "sync_failure_before_deprovision_recovery_pre"; then
+    pre_login_ok="true"
+    admin_jwt_minted="true"
+  else
+    fail "action=deprovision sync_failure_before_deprovision_recovery refused: canary login / JWT mint failed (journal left intact)"
+  fi
+
+  if ! load_canary_directory_subject "sync_failure_before_deprovision_recovery_pre"; then
+    fail "action=deprovision sync_failure_before_deprovision_recovery refused: subject load failed (note=${SUBJECT_NOTE:-unset}); journal left intact; no auto-selection"
+  fi
+  if [[ "$SUBJECT_LOCAL_USERNAME_OK" != "true" || "$SUBJECT_LOCAL_NAME_OK" != "true" ]]; then
+    fail "action=deprovision sync_failure_before_deprovision_recovery refused: subject is not owned canary employee; journal left intact; no auto-selection"
+  fi
+  if [[ "$SUBJECT_HAS_LOCAL_USER" != "true" || -z "${CANARY_SUBJECT_LOCAL_USER_ID_FILE:-}" || ! -s "${CANARY_SUBJECT_LOCAL_USER_ID_FILE}" ]]; then
+    fail "action=deprovision sync_failure_before_deprovision_recovery refused: owned local user required; journal left intact"
+  fi
+
+  # Journal-bound proof: phase=run_bound, deprovision_applied=false, no ledger fields.
+  # Immutable pin → CANARY_FAILED_SYNC_RUN_ID_FILE (survives recovery sync run id).
+  # deprovision_applied=false is proven here — not by absent run stats.
+  if ! load_run_bound_sync_failure_before_deprovision_journal; then
+    fail "action=deprovision sync_failure_before_deprovision_recovery refused: journal not eligible run_bound failed-before-deprovision (note=${FAILED_SYNC_JOURNAL_NOTE:-unset}); journal left intact"
+  fi
+  journal_ok="true"
+
+  # Run API proof: status=failed + exact observed error class only (values-free).
+  # Does not alone prove deprovision_applied=false (that is journal-bound above).
+  if ! prove_exact_run_sync_failure_before_deprovision; then
+    fail "action=deprovision sync_failure_before_deprovision_recovery refused: exact run not failed with observed error class (note=${FAILED_SYNC_RUN_NOTE:-unset}); journal left intact"
+  fi
+  exact_run_ok="true"
+
+  # No-mutation proof: zero user/membership/grant ledger for that exact failed run
+  # only (exact SQL; no list/limit). Complements journal deprovision_applied=false.
+  if ! prove_zero_deprovision_ledger_for_exact_run "sync_failure_before_deprovision_recovery_pre"; then
+    fail "action=deprovision sync_failure_before_deprovision_recovery refused: ledger not empty for exact run (note=${SAFE_ABORT_LEDGER_NOTE:-unset}); journal left intact"
+  fi
+  zero_ledger_ok="true"
+
+  # No-mutation proof: access graph still activated + active membership + enabled grant.
+  if ! assert_subject_user_access_state "activated" "true" "sync_failure_before_deprovision_recovery_pre"; then
+    fail "action=deprovision sync_failure_before_deprovision_recovery refused: pre-recovery access not activated+active (note=${ACCESS_NOTE:-unset}); journal left intact"
+  fi
+  if ! prove_intact_access_graph_no_ledger "sync_failure_before_deprovision_recovery_pre"; then
+    fail "action=deprovision sync_failure_before_deprovision_recovery refused: pre-recovery access graph not intact (note=${INTACT_GRAPH_NOTE:-unset}); journal left intact"
+  fi
+  pre_graph_ok="true"
+  pre_graph_snapshot="${INTACT_GRAPH_SNAPSHOT}"
+
+  # External source re-add is operator-confirmed via bootstrap_confirmation.
+  # Flags stay OFF: sync under require_deprov_applied=false only.
+  if ! run_directory_sync_for_subject "sync_failure_before_deprovision_recovery" "false"; then
+    fail "action=deprovision sync_failure_before_deprovision_recovery refused: flags-OFF sync failed (note=${SYNC_NOTE:-unset}); journal left intact"
+  fi
+  if [[ "$SYNC_DEPROVISION_APPLIED" != "false" ]]; then
+    fail "action=deprovision sync_failure_before_deprovision_recovery refused: flags-OFF sync did not prove deprovisionApplied=false; journal left intact"
+  fi
+  sync_ok="true"
+
+  if ! load_canary_directory_subject "sync_failure_before_deprovision_recovery_post_sync"; then
+    fail "action=deprovision sync_failure_before_deprovision_recovery refused: subject reload failed (note=${SUBJECT_NOTE:-unset}); journal left intact"
+  fi
+  if [[ "$SUBJECT_ACTIVE" != "true" ]]; then
+    fail "action=deprovision sync_failure_before_deprovision_recovery refused: owned directory account not active after sync (external re-add gate); journal left intact"
+  fi
+  source_active_after_sync="true"
+
+  if ! assert_subject_user_access_state "activated" "true" "sync_failure_before_deprovision_recovery_post"; then
+    fail "action=deprovision sync_failure_before_deprovision_recovery refused: post-sync access not activated+active (note=${ACCESS_NOTE:-unset}); journal left intact"
+  fi
+  if ! prove_intact_access_graph_no_ledger "sync_failure_before_deprovision_recovery_post"; then
+    fail "action=deprovision sync_failure_before_deprovision_recovery refused: post-sync access graph not intact (note=${INTACT_GRAPH_NOTE:-unset}); journal left intact"
+  fi
+  post_graph_ok="true"
+  post_graph_snapshot="${INTACT_GRAPH_SNAPSHOT}"
+  if [[ -z "$pre_graph_snapshot" || "$post_graph_snapshot" != "$pre_graph_snapshot" ]]; then
+    fail "action=deprovision sync_failure_before_deprovision_recovery refused: access graph drift after flags-OFF sync (pre!=post); journal left intact"
+  fi
+  graph_unchanged_ok="true"
+
+  capture_live_snapshot
+  if [[ "$SNAP_MODE" != "off" || "$SNAP_ALIAS" != "false" || "$SNAP_PENDING" != "false" || "$SNAP_DEPROV" != "false" ]]; then
+    fail "action=deprovision sync_failure_before_deprovision_recovery refused: lifecycle flags must remain OFF after recovery sync; journal left intact"
+  fi
+  flags_remain_off="true"
+  assert_exact_sha
+  require_migrations_pending_zero_true "$SNAP_MIGRATIONS_ZERO" "action=deprovision sync_failure_before_deprovision_recovery post-check"
+  if [[ "$SNAP_HEALTH_OK" != "true" ]]; then
+    fail "action=deprovision sync_failure_before_deprovision_recovery refused: backend_health_ok must remain true; journal left intact"
+  fi
+
+  # FINAL proof gate: re-prove exact no-ledger AND exact failed-run identity AFTER
+  # flags-OFF sync + graph/flag checks and IMMEDIATELY before clear.
+  # Load-bearing order — contract MUTATION removes this recheck / moves clear earlier and must turn red.
+  # Immutable pin is CANARY_FAILED_SYNC_RUN_ID_FILE, never the recovery subject.sync-run-id pin.
+  if ! prove_zero_deprovision_ledger_for_exact_run "sync_failure_before_deprovision_recovery_final_pre_clear"; then
+    fail "action=deprovision sync_failure_before_deprovision_recovery refused: final pre-clear zero-ledger recheck failed (note=${SAFE_ABORT_LEDGER_NOTE:-unset}); journal left intact"
+  fi
+  zero_ledger_final_ok="true"
+  if ! prove_exact_run_sync_failure_before_deprovision; then
+    fail "action=deprovision sync_failure_before_deprovision_recovery refused: final pre-clear exact failed-run identity recheck failed (note=${FAILED_SYNC_RUN_NOTE:-unset}); journal left intact"
+  fi
+  exact_run_final_ok="true"
+  clear_deprovision_apply_state
+  journal_cleared="true"
+
+  note="sync_failure_before_deprovision_recovery_source_restored_access_graph_unchanged_journal_cleared"
+  write_status_artifact \
+    "${SNAP_BUILD_SHA:-unknown}" \
+    "$SNAP_ALIAS" "$SNAP_PENDING" "$SNAP_DEPROV" "$SNAP_MODE" \
+    "$SNAP_ALIAS_READY" "$SNAP_CAN_ENABLE_ALIAS" \
+    "$SNAP_MIGRATIONS_ZERO" "$SNAP_HEALTH_OK" \
+    "deprovision" "true" "false" "$note"
+  {
+    echo "action=deprovision"
+    echo "phase=sync_failure_before_deprovision_recovery"
+    echo "mode=${SNAP_MODE}"
+    echo "build_sha=${SNAP_BUILD_SHA:-unknown}"
+    echo "transition_applied=false"
+    echo "lifecycle_env_write=false"
+    echo "pre_login_ok=${pre_login_ok}"
+    echo "admin_jwt_minted=${admin_jwt_minted}"
+    echo "subject_owned=true"
+    echo "subject_auto_selected=false"
+    echo "source_re_add_confirmation=true"
+    echo "journal_ok=${journal_ok}"
+    echo "journal_phase_required=run_bound"
+    echo "journal_deprovision_applied_required=false"
+    echo "exact_run_ok=${exact_run_ok}"
+    echo "exact_run_final_ok=${exact_run_final_ok}"
+    echo "run_status_required=failed"
+    echo "error_class_required=duplicate_provider_corp_external_key"
+    echo "error_constraint_required=idx_directory_accounts_provider_corp_external_key"
+    echo "error_class_observed=${FAILED_SYNC_ERROR_CLASS:-unknown}"
+    echo "zero_ledger_ok=${zero_ledger_ok}"
+    echo "zero_ledger_final_ok=${zero_ledger_final_ok}"
+    echo "zero_ledger_event_count=${SAFE_ABORT_LEDGER_EVENT_COUNT:-0}"
+    echo "zero_ledger_effect_count=${SAFE_ABORT_LEDGER_EFFECT_COUNT:-0}"
+    echo "pre_graph_ok=${pre_graph_ok}"
+    echo "sync_ok=${sync_ok}"
+    echo "source_active_after_sync=${source_active_after_sync}"
+    echo "post_graph_ok=${post_graph_ok}"
+    echo "graph_unchanged_ok=${graph_unchanged_ok}"
+    echo "access_graph_user_active=${INTACT_GRAPH_USER_ACTIVE:-unknown}"
+    echo "access_graph_membership_active_count=${INTACT_GRAPH_MEMBERSHIP_ACTIVE_COUNT:-0}"
+    echo "access_graph_grant_state=${INTACT_GRAPH_GRANT_STATE:-unknown}"
+    echo "flags_remain_off=${flags_remain_off}"
+    echo "journal_cleared=${journal_cleared}"
+    echo "server_side_access_graph_mutation_proven=false"
+    echo "access_graph_unchanged_proven=true"
+    echo "no_mutation_proven_by_zero_ledger_and_access_graph=true"
+    echo "sync_failure_before_deprovision_source_recovery_complete=true"
+    echo "canary_access_rollback_complete=false"
+    echo "end_to_end_restore_claimed=false"
+    echo "note=${note}"
+  } > "${OUTPUT_DIR}/summary.txt"
+  log "action=deprovision sync_failure_before_deprovision_recovery OK (flags OFF; source restored; access graph unchanged; journal cleared; no lifecycle env write; end_to_end_restore_claimed=false)"
 }
 
 # --- main ------------------------------------------------------------------------------


### PR DESCRIPTION
## What changed

- Add a staging-only recovery mode for a lifecycle canary journal stranded at `run_bound` when directory sync failed before deprovision.
- Bind the immutable failed sync run separately from the later flags-OFF recovery sync.
- Require the exact observed PostgreSQL duplicate-constraint signature, exact zero-ledger proof, intact access graph, source reactivation, unchanged graph, all lifecycle flags OFF, and final pre-clear rechecks.
- Keep the existing empty-fetch abort recovery distinct and unchanged.

## Why

The dedicated staging canary's second deprovision attempt failed before ledger creation because a temporary source user already existed under another integration. The apply journal correctly remained recoverable, but the workflow only knew how to close a completed `empty_directory_fetch` abort. This adds a narrow fail-closed recovery for the exact observed failure class without enabling any lifecycle flag or claiming an end-to-end restore.

## Safety boundary

- Staging only; never writes lifecycle env overrides.
- All three lifecycle flags must remain OFF before and after recovery.
- No rehire/restore API call.
- Wrong journal phase, run, status, error signature, any ledger row, source absence, graph drift, sync failure, or health/SHA/migration mismatch leaves the journal intact.
- Summary remains values-free and sets `end_to_end_restore_claimed=false`.

## Verification

- `bash -n scripts/ops/dingtalk-lifecycle-staging-canary-remote.sh`
- `node --test scripts/ops/dingtalk-lifecycle-staging-canary-contract.test.mjs` (`210/210`)
- Mutation: broadening the error classifier admits a sibling identity constraint and turns the functional refusal test red.
- Mutation: collapsing the failed-run pin into the recovery sync pin turns the exact zero-ledger function test red with `wrong_run_pin`.
- Independent adversarial review: APPROVE, zero P1/P2 after tightening the classifier to the full observed PostgreSQL signature and adding `_v2`/mention-only refusals.

## Not claimed

- This does not complete the destructive apply/rehire canary. A second dedicated DingTalk identity that is not present in another integration is still required to keep provider fetch non-empty while the owned subject is removed.
- No lifecycle flag is authorized to remain ON.
