### PR TITLE
fix(dingtalk): support explicit lifecycle sentinel

### DIFF
--- a/.github/workflows/dingtalk-lifecycle-staging-canary.yml
+++ b/.github/workflows/dingtalk-lifecycle-staging-canary.yml
@@ -260,10 +260,14 @@ jobs:
           # STAGING_OWNER_ADMIN_PASSWORD is demoted and written to a chmod-600 file for
           # human-bootstrap only. LIFECYCLE_CANARY_DIRECTORY_ACCOUNT_ID is demoted for
           # pending|deprovision only (path transferred; value never printed).
+          # LIFECYCLE_CANARY_SENTINEL_DIRECTORY_ACCOUNT_ID is demoted only for the
+          # deprovision APPLY confirmation. Restore/recovery must remain operable
+          # without this extra preflight input.
           LIFECYCLE_CANARY_LOGIN_IDENTIFIER: ${{ secrets.LIFECYCLE_CANARY_LOGIN_IDENTIFIER }}
           LIFECYCLE_CANARY_LOGIN_PASSWORD: ${{ secrets.LIFECYCLE_CANARY_LOGIN_PASSWORD }}
           STAGING_OWNER_ADMIN_PASSWORD: ${{ inputs.action == 'human-bootstrap' && secrets.STAGING_OWNER_ADMIN_PASSWORD || '' }}
           LIFECYCLE_CANARY_DIRECTORY_ACCOUNT_ID: ${{ (inputs.action == 'pending' || inputs.action == 'deprovision') && secrets.LIFECYCLE_CANARY_DIRECTORY_ACCOUNT_ID || '' }}
+          LIFECYCLE_CANARY_SENTINEL_DIRECTORY_ACCOUNT_ID: ${{ inputs.action == 'deprovision' && inputs.bootstrap_confirmation == 'DINGTALK_SOURCE_DISABLED_DEDICATED_EXCLUSIVE_CONFIRMED' && secrets.LIFECYCLE_CANARY_SENTINEL_DIRECTORY_ACCOUNT_ID || '' }}
         run: |
           set -euo pipefail
           # --- SECRET DEMOTE (builtins only; no external child before unset) -------------
@@ -276,8 +280,14 @@ jobs:
           _CANARY_PASS="${LIFECYCLE_CANARY_LOGIN_PASSWORD-}"
           _STAGING_OWNER_PASS="${STAGING_OWNER_ADMIN_PASSWORD-}"
           _CANARY_SUBJECT="${LIFECYCLE_CANARY_DIRECTORY_ACCOUNT_ID-}"
-          unset LIFECYCLE_CANARY_LOGIN_IDENTIFIER LIFECYCLE_CANARY_LOGIN_PASSWORD STAGING_OWNER_ADMIN_PASSWORD LIFECYCLE_CANARY_DIRECTORY_ACCOUNT_ID
+          _CANARY_SENTINEL="${LIFECYCLE_CANARY_SENTINEL_DIRECTORY_ACCOUNT_ID-}"
+          unset LIFECYCLE_CANARY_LOGIN_IDENTIFIER LIFECYCLE_CANARY_LOGIN_PASSWORD STAGING_OWNER_ADMIN_PASSWORD LIFECYCLE_CANARY_DIRECTORY_ACCOUNT_ID LIFECYCLE_CANARY_SENTINEL_DIRECTORY_ACCOUNT_ID
           # --- end secret demote; external commands allowed after this point ------------
+
+          sentinel_apply=0
+          if [[ "$ACTION" == "deprovision" && "$BOOTSTRAP_CONFIRMATION" == "DINGTALK_SOURCE_DISABLED_DEDICATED_EXCLUSIVE_CONFIRMED" ]]; then
+            sentinel_apply=1
+          fi
 
           ssh_opts="-o StrictHostKeyChecking=yes -o UserKnownHostsFile=$HOME/.ssh/known_hosts -o IdentitiesOnly=yes -i $HOME/.ssh/deploy_key"
           DEPLOY_PATH="${DEPLOY_PATH:-metasheet2}"
@@ -336,28 +346,36 @@ jobs:
           # Alias/pending/deprovision/human-bootstrap mint admin JWT on remote after
           # successful canary pre-login. pending|deprovision also materialize
           # directory-account.id (subject UUID path only; never printed).
+          # deprovision apply also materializes sentinel-directory-account.id
+          # (explicit previously-synced sentinel UUID path only; never printed).
           remote_secrets_dir=""
           canary_ident_export=""
           canary_pass_export=""
           staging_owner_pass_export=""
           canary_subject_export=""
+          canary_sentinel_export=""
           if [[ "$ACTION" == "alias" || "$ACTION" == "bootstrap" || "$ACTION" == "human-bootstrap" || "$ACTION" == "pending" || "$ACTION" == "deprovision" ]]; then
             # Install trap BEFORE any secret materialization (mktemp/write/chmod).
             trap cleanup_canary_ephemeral_paths EXIT INT TERM
             # Presence via non-exported shell vars only (env already unset above).
             if [[ -z "${_CANARY_IDENT}" || -z "${_CANARY_PASS}" ]]; then
               echo "${ACTION} requires LIFECYCLE_CANARY_LOGIN_IDENTIFIER/PASSWORD (checked in Run remote action only); never ATTENDANCE_ADMIN_JWT" >&2
-              unset _CANARY_IDENT _CANARY_PASS _STAGING_OWNER_PASS _CANARY_SUBJECT
+              unset _CANARY_IDENT _CANARY_PASS _STAGING_OWNER_PASS _CANARY_SUBJECT _CANARY_SENTINEL
               exit 2
             fi
             if [[ "$ACTION" == "human-bootstrap" && -z "${_STAGING_OWNER_PASS}" ]]; then
               echo "human-bootstrap requires STAGING_OWNER_ADMIN_PASSWORD (checked in Run remote action only); never log secret" >&2
-              unset _CANARY_IDENT _CANARY_PASS _STAGING_OWNER_PASS _CANARY_SUBJECT
+              unset _CANARY_IDENT _CANARY_PASS _STAGING_OWNER_PASS _CANARY_SUBJECT _CANARY_SENTINEL
               exit 2
             fi
             if [[ ( "$ACTION" == "pending" || "$ACTION" == "deprovision" ) && -z "${_CANARY_SUBJECT}" ]]; then
               echo "${ACTION} requires LIFECYCLE_CANARY_DIRECTORY_ACCOUNT_ID (explicit subject; no auto-selection; checked in Run remote action only); never log secret" >&2
-              unset _CANARY_IDENT _CANARY_PASS _STAGING_OWNER_PASS _CANARY_SUBJECT
+              unset _CANARY_IDENT _CANARY_PASS _STAGING_OWNER_PASS _CANARY_SUBJECT _CANARY_SENTINEL
+              exit 2
+            fi
+            if [[ "$sentinel_apply" == "1" && -z "${_CANARY_SENTINEL}" ]]; then
+              echo "deprovision apply requires LIFECYCLE_CANARY_SENTINEL_DIRECTORY_ACCOUNT_ID (explicit sentinel; no auto-selection; checked in Run remote action only); never log secret" >&2
+              unset _CANARY_IDENT _CANARY_PASS _STAGING_OWNER_PASS _CANARY_SUBJECT _CANARY_SENTINEL
               exit 2
             fi
             secrets_dir="$(mktemp -d "${RUNNER_TEMP}/lifecycle-canary-secrets.XXXXXX")"
@@ -398,6 +416,16 @@ jobs:
             else
               unset _CANARY_SUBJECT
             fi
+            if [[ "$sentinel_apply" == "1" ]]; then
+              printf '%s' "${_CANARY_SENTINEL}" > "${secrets_dir}/sentinel-directory-account.id"
+              unset _CANARY_SENTINEL
+              chmod 600 "${secrets_dir}/sentinel-directory-account.id"
+              [[ -s "${secrets_dir}/sentinel-directory-account.id" ]] \
+                || { echo "secret file empty after materialize: sentinel-directory-account.id" >&2; exit 2; }
+              scp_files+=("${secrets_dir}/sentinel-directory-account.id")
+            else
+              unset _CANARY_SENTINEL
+            fi
             remote_secrets_dir="${RUNNER_DIR}/.canary-secrets"
             CLEAN_REMOTE_SECRETS_DIR="${remote_secrets_dir}"
             # Remote copy only after local materialize succeeded under trap coverage.
@@ -410,6 +438,11 @@ jobs:
               ssh $ssh_opts "$DEPLOY_USER@$DEPLOY_HOST" \
                 "bash -o pipefail -c 'set -euo pipefail; chmod 600 ${remote_secrets_dir}/login.identifier ${remote_secrets_dir}/login.password ${remote_secrets_dir}/staging-owner-admin.password'"
               staging_owner_pass_export="export STAGING_OWNER_ADMIN_PASSWORD_FILE='${remote_secrets_dir}/staging-owner-admin.password'"
+            elif [[ "$sentinel_apply" == "1" ]]; then
+              ssh $ssh_opts "$DEPLOY_USER@$DEPLOY_HOST" \
+                "bash -o pipefail -c 'set -euo pipefail; chmod 600 ${remote_secrets_dir}/login.identifier ${remote_secrets_dir}/login.password ${remote_secrets_dir}/directory-account.id ${remote_secrets_dir}/sentinel-directory-account.id'"
+              canary_subject_export="export CANARY_DIRECTORY_ACCOUNT_ID_FILE='${remote_secrets_dir}/directory-account.id'"
+              canary_sentinel_export="export CANARY_SENTINEL_DIRECTORY_ACCOUNT_ID_FILE='${remote_secrets_dir}/sentinel-directory-account.id'"
             elif [[ "$ACTION" == "pending" || "$ACTION" == "deprovision" ]]; then
               ssh $ssh_opts "$DEPLOY_USER@$DEPLOY_HOST" \
                 "bash -o pipefail -c 'set -euo pipefail; chmod 600 ${remote_secrets_dir}/login.identifier ${remote_secrets_dir}/login.password ${remote_secrets_dir}/directory-account.id'"
@@ -422,7 +455,7 @@ jobs:
             canary_pass_export="export CANARY_LOGIN_PASSWORD_FILE='${remote_secrets_dir}/login.password'"
           else
             # Non-secret actions: drop any unused shell copies; clean per-run dirs on exit.
-            unset _CANARY_IDENT _CANARY_PASS _STAGING_OWNER_PASS _CANARY_SUBJECT
+            unset _CANARY_IDENT _CANARY_PASS _STAGING_OWNER_PASS _CANARY_SUBJECT _CANARY_SENTINEL
             trap cleanup_canary_ephemeral_paths EXIT INT TERM
           fi
 
@@ -440,6 +473,7 @@ jobs:
           ${canary_pass_export}
           ${staging_owner_pass_export}
           ${canary_subject_export}
+          ${canary_sentinel_export}
           rm -rf '${remote_output_dir}'
           mkdir -p '${remote_output_dir}'
           set +e
@@ -498,12 +532,12 @@ jobs:
             echo "OFF is emergency env-gate rollback only — not OR-column design reintroduction."
             echo "Bootstrap creates/repairs fixed lifecycle-canary@staging.invalid admin only (no lifecycle env write)."
             echo "Human-bootstrap creates/repairs fixed username staging-owner-admin human platform admin only (no lifecycle env write; password file transport)."
-            echo "Bootstrap/human-bootstrap/alias/pending/deprovision require LIFECYCLE_CANARY_LOGIN_IDENTIFIER/PASSWORD (file transport); human-bootstrap also requires STAGING_OWNER_ADMIN_PASSWORD; pending/deprovision also require LIFECYCLE_CANARY_DIRECTORY_ACCOUNT_ID (explicit subject; never printed)."
+            echo "Bootstrap/human-bootstrap/alias/pending/deprovision require LIFECYCLE_CANARY_LOGIN_IDENTIFIER/PASSWORD (file transport); human-bootstrap also requires STAGING_OWNER_ADMIN_PASSWORD; pending/deprovision also require LIFECYCLE_CANARY_DIRECTORY_ACCOUNT_ID (explicit subject; never printed); deprovision APPLY also requires LIFECYCLE_CANARY_SENTINEL_DIRECTORY_ACCOUNT_ID (explicit sentinel; never printed)."
             echo "Pending default phase is admit-only; OAuth checkpoints are NOT_EXECUTED; optional PENDING_SSO_ACTIVATE (browser OAuth still NOT_EXECUTED)."
             echo "Deprovision apply uses DINGTALK_SOURCE_DISABLED_DEDICATED_EXCLUSIVE_CONFIRMED (flags OFF, access remains disabled). Restore uses DINGTALK_SOURCE_REACTIVATED_CONFIRMED (rehire + access restore; flags stay OFF)."
             echo "Empty-fetch abort recovery uses DINGTALK_EMPTY_FETCH_ABORT_SOURCE_RE_ADDED_CONFIRMED (flags stay OFF; never writes lifecycle env; clears run_bound journal only after directory reactivated + access graph unchanged proofs)."
             echo "Sync-failure-before-deprovision recovery uses DINGTALK_SYNC_FAILURE_BEFORE_DEPROVISION_SOURCE_RE_ADDED_CONFIRMED (flags stay OFF; never writes lifecycle env; clears run_bound journal only after zero ledger + exact failed-run identity + access graph unchanged proofs)."
-            echo "Deprovision refuses shared integrations: exactly one total directory account, manual scheduling, admission automation OFF, and member-group projection OFF are required."
+            echo "Deprovision apply refuses shared integrations: exactly two total directory accounts (owned target + explicit sentinel), distinct UUIDs, manual scheduling, admission automation OFF, and member-group projection OFF are required. Sentinel stays active/unlinked so provider fetch remains nonempty while the target is deprovisioned."
             echo "Deprovision reserves and journals the exact sync run UUID before env/HTTP; lost responses recover only through that run and its exact event/effects."
             echo "Empty-fetch abort recovery binds only the exact journal run_bound completed empty_directory_fetch abort with zero ledger; wrong phase/run/abort reason, any ledger, source still missing, access drift, sync failure, or any lifecycle flag ON leaves the journal intact."
             echo "Sync-failure-before-deprovision recovery binds journal run_bound deprovision_applied=false + zero ledger; run API proves failed + exact observed constraint idx_directory_accounts_provider_corp_external_key; zero ledger + intact graph prove no mutation; wrong phase/run/status/error class, sibling indexes, any ledger, source still missing, access drift, sync failure, or any lifecycle flag ON leaves the journal intact. Never claims end-to-end restore."

--- a/scripts/ops/dingtalk-lifecycle-staging-canary-contract.test.mjs
+++ b/scripts/ops/dingtalk-lifecycle-staging-canary-contract.test.mjs
@@ -387,6 +387,7 @@ test('workflow bootstrap/human-bootstrap/alias/pending/deprovision secret transp
   assert.doesNotMatch(yaml, /export LIFECYCLE_CANARY_LOGIN_PASSWORD=/)
   assert.doesNotMatch(yaml, /export STAGING_OWNER_ADMIN_PASSWORD=/)
   assert.doesNotMatch(yaml, /export LIFECYCLE_CANARY_DIRECTORY_ACCOUNT_ID=/)
+  assert.doesNotMatch(yaml, /export LIFECYCLE_CANARY_SENTINEL_DIRECTORY_ACCOUNT_ID=/)
   assert.doesNotMatch(yaml, /export CANARY_LOGIN_PASSWORD='/)
   // bootstrap/human-bootstrap/alias/pending/deprovision share the canary secret transport gate.
   assert.match(
@@ -404,6 +405,7 @@ test('workflow Validate inputs does not receive canary login secrets (no child i
   assert.equal(validate.env.LIFECYCLE_CANARY_LOGIN_IDENTIFIER, undefined)
   assert.equal(validate.env.LIFECYCLE_CANARY_LOGIN_PASSWORD, undefined)
   assert.equal(validate.env.STAGING_OWNER_ADMIN_PASSWORD, undefined)
+  assert.equal(validate.env.LIFECYCLE_CANARY_SENTINEL_DIRECTORY_ACCOUNT_ID, undefined)
   // No secret presence checks in this step (they launch after bash -n otherwise).
   assert.doesNotMatch(validate.run, /ATTENDANCE_ADMIN_JWT/)
   assert.doesNotMatch(validate.run, /LIFECYCLE_CANARY_LOGIN_IDENTIFIER/)
@@ -473,6 +475,7 @@ test('workflow materializes secrets inside Run remote action under EXIT trap (no
       '_CANARY_PASS="${LIFECYCLE_CANARY_LOGIN_PASSWORD-}"',
       '_STAGING_OWNER_PASS="${STAGING_OWNER_ADMIN_PASSWORD-}"',
       '_CANARY_SUBJECT="${LIFECYCLE_CANARY_DIRECTORY_ACCOUNT_ID-}"',
+      '_CANARY_SENTINEL="${LIFECYCLE_CANARY_SENTINEL_DIRECTORY_ACCOUNT_ID-}"',
     ],
     'only demote assignments (builtins) before secret env unset — no external commands; no JWT',
   )
@@ -537,8 +540,46 @@ test('workflow materializes secrets inside Run remote action under EXIT trap (no
   // Local+remote secret cleanup; never echo secret values.
   assert.match(runBody, /rm -rf "\$\{CLEAN_LOCAL_SECRETS_DIR\}"/)
   assert.match(runBody, /rm -rf '\$\{remote_secrets_dir\}'|rm -rf \$\{remote_rm\}/)
-  assert.doesNotMatch(runBody, /echo\s+[\"']?\$\{?(_CANARY_PASS|_STAGING_OWNER_PASS|STAGING_OWNER_ADMIN_PASSWORD)/)
+  assert.doesNotMatch(runBody, /echo\s+[\"']?\$\{?(_CANARY_PASS|_STAGING_OWNER_PASS|_CANARY_SENTINEL|STAGING_OWNER_ADMIN_PASSWORD)/)
   assert.doesNotMatch(runBody, /cat\s+[\"']?\$\{?secrets_dir\}.*password/)
+})
+
+test('workflow requires the explicit sentinel only for deprovision apply', () => {
+  const doc = loadYaml(read(WORKFLOW))
+  const remote = doc.jobs.run.steps.find((s) => s.name === 'Run remote action')
+  assert.ok(remote?.env && remote?.run)
+  assert.match(
+    String(remote.env.LIFECYCLE_CANARY_SENTINEL_DIRECTORY_ACCOUNT_ID),
+    /inputs\.action == 'deprovision'.*inputs\.bootstrap_confirmation == 'DINGTALK_SOURCE_DISABLED_DEDICATED_EXCLUSIVE_CONFIRMED'.*secrets\.LIFECYCLE_CANARY_SENTINEL_DIRECTORY_ACCOUNT_ID/,
+  )
+  assert.match(remote.run, /sentinel_apply=0/)
+  assert.match(
+    remote.run,
+    /\"\$ACTION\" == \"deprovision\" && \"\$BOOTSTRAP_CONFIRMATION\" == \"DINGTALK_SOURCE_DISABLED_DEDICATED_EXCLUSIVE_CONFIRMED\"/,
+  )
+  assert.match(remote.run, /if \[\[ \"\$sentinel_apply\" == \"1\" && -z \"\$\{_CANARY_SENTINEL\}\" \]\]/)
+  assert.match(remote.run, /export CANARY_SENTINEL_DIRECTORY_ACCOUNT_ID_FILE=/)
+  assert.doesNotMatch(remote.run, /export LIFECYCLE_CANARY_SENTINEL_DIRECTORY_ACCOUNT_ID=/)
+})
+
+test('deprovision restore and recovery paths never depend on the apply-only sentinel', () => {
+  const source = read(REMOTE_SH)
+  const restoreAndRecovery = [
+    actionDeprovisionRestoreBody(source),
+    actionDeprovisionEmptyFetchAbortRecoveryBody(source),
+    actionDeprovisionSyncFailureBeforeDeprovisionRecoveryBody(source),
+  ]
+  for (const body of restoreAndRecovery) {
+    assert.doesNotMatch(body, /CANARY_SENTINEL_DIRECTORY_ACCOUNT_ID_FILE/)
+    assert.doesNotMatch(body, /require_canary_sentinel_directory_account_id_file/)
+    assert.doesNotMatch(body, /prove_dedicated_subject_deprovision_precondition/)
+  }
+
+  const mutatedRestore = restoreAndRecovery[0].replace(
+    'require_canary_directory_account_id_file "deprovision"',
+    'require_canary_directory_account_id_file "deprovision"\n  require_canary_sentinel_directory_account_id_file',
+  )
+  assert.throws(() => assert.doesNotMatch(mutatedRestore, /require_canary_sentinel_directory_account_id_file/))
 })
 
 test('workflow cleanup never deletes persistent .metasheet2 overrides', () => {
@@ -4669,7 +4710,7 @@ test('workflow pending/deprovision phase confirmations and honest claims', () =>
   assert.match(yaml, /empty-fetch abort recovery|EMPTY_FETCH_ABORT/)
   assert.match(yaml, /sync-failure-before-deprovision recovery|SYNC_FAILURE_BEFORE_DEPROVISION/)
   assert.doesNotMatch(yaml, /docs may still say NOT EXECUTABLE|follow-up to refresh docs/i)
-  assert.match(yaml, /exactly one total directory account/)
+  assert.match(yaml, /exactly two total directory accounts \(owned target \+ explicit sentinel\)/)
   assert.match(yaml, /reserves and journals the exact sync run UUID before env\/HTTP/)
   assert.match(yaml, /Never claims end-to-end restore|never claims end-to-end restore/)
 })
@@ -5800,7 +5841,7 @@ test('MUTATION: deleting the pre-POST resolved probe makes the resume golden red
   })
 })
 
-test('R5: dedicated subject precondition requires one-account manual integration and exact effects', () => {
+test('R5: dedicated subject precondition requires exact target+sentinel integration and exact effects', () => {
   const source = read(REMOTE_SH)
   assert.match(source, /prove_dedicated_subject_deprovision_precondition/)
   const start = source.indexOf('prove_dedicated_subject_deprovision_precondition()')
@@ -5810,10 +5851,19 @@ test('R5: dedicated subject precondition requires one-account manual integration
   assert.match(body, /policy_not_mark_inactive/)
   assert.match(body, /integration_not_manual_only/)
   assert.match(body, /integration_automation_not_disabled/)
-  assert.match(body, /integration_not_single_account/)
+  assert.match(body, /integration_not_exact_target_and_sentinel/)
   assert.match(body, /count\(\*\)::int AS n/)
   assert.match(body, /count\(\*\) FILTER \(WHERE id = \$2\)::int AS target_n/)
+  assert.match(body, /count\(\*\) FILTER \(WHERE id = \$3\)::int AS sentinel_n/)
+  assert.match(body, /Number\(radius\.rows\[0\]\?\.n\) !== 2/)
   assert.match(body, /WHERE integration_id = \$1/)
+  assert.match(body, /target_sentinel_ids_not_distinct/)
+  assert.match(body, /sentinel_provider_not_dingtalk/)
+  assert.match(body, /sentinel_not_same_integration_corp/)
+  assert.match(body, /!sentinelCorp \|\| !targetCorp \|\| sentinelCorp !== targetCorp/)
+  assert.match(body, /sentinel_not_active/)
+  assert.match(body, /sentinel_name_not_owned/)
+  assert.match(body, /sentinel_must_be_unlinked/)
   assert.match(body, /not_globally_clear/)
   assert.match(body, /dingtalk_grant_not_enabled/)
   assert.match(body, /target_org_membership_not_active/)
@@ -5823,13 +5873,22 @@ test('R5: dedicated subject precondition requires one-account manual integration
   assert.match(body, /user_id = \$1 AND org_id = \$2/)
 })
 
-test('MUTATION: dropping the one-account integration radius guard turns red', () => {
+test('MUTATION: dropping the exact target+sentinel integration radius guard turns red', () => {
   const source = read(REMOTE_SH)
   const start = source.indexOf('prove_dedicated_subject_deprovision_precondition()')
   const end = source.indexOf('\nvalidate_mode_name()', start)
   const body = source.slice(start, end)
-  const mutated = body.replace('Number(radius.rows[0]?.n) !== 1', 'false')
-  assert.throws(() => assert.match(mutated, /Number\(radius\.rows\[0\]\?\.n\) !== 1/))
+  const mutated = body.replace('Number(radius.rows[0]?.n) !== 2', 'false')
+  assert.throws(() => assert.match(mutated, /Number\(radius\.rows\[0\]\?\.n\) !== 2/))
+})
+
+test('MUTATION: accepting a linked sentinel turns the sentinel contract red', () => {
+  const source = read(REMOTE_SH)
+  const start = source.indexOf('prove_dedicated_subject_deprovision_precondition()')
+  const end = source.indexOf('\nvalidate_mode_name()', start)
+  const body = source.slice(start, end)
+  const mutated = body.replace('if (s.has_linked_user === true)', 'if (false)')
+  assert.throws(() => assert.match(mutated, /if \(s\.has_linked_user === true\)/))
 })
 
 test('MUTATION: dropping dedicated precondition before env write turns red', () => {
@@ -6227,6 +6286,7 @@ test('workflow exports only safe remote env keys (no raw secret values)', () => 
   assert.match(yaml, /export CANARY_LOGIN_PASSWORD_FILE=/)
   assert.match(yaml, /export STAGING_OWNER_ADMIN_PASSWORD_FILE=/)
   assert.match(yaml, /export CANARY_DIRECTORY_ACCOUNT_ID_FILE=/)
+  assert.match(yaml, /export CANARY_SENTINEL_DIRECTORY_ACCOUNT_ID_FILE=/)
 })
 
 // --- human-bootstrap: fixed separate human platform admin -----------------------------

--- a/scripts/ops/dingtalk-lifecycle-staging-canary-remote.sh
+++ b/scripts/ops/dingtalk-lifecycle-staging-canary-remote.sh
@@ -58,12 +58,16 @@
 #                No auto-selection of directory accounts.
 #   deprovision — TRANSIENT secret-backed sync→deprovision canary on the SAME
 #                explicit owned subject. Never mutates a real/auto-selected
-#                account. Requires subject file + confirmation that the DingTalk
-#                source employee was disabled externally. Temporarily enables
-#                only DIRECTORY_DEPROVISION_ENABLED, runs real integration sync,
+#                account. Apply requires subject + explicit pre-synced sentinel
+#                files and confirmation that the DingTalk source employee was
+#                disabled externally. The dedicated integration must contain
+#                exactly target + active unlinked sentinel, keeping provider
+#                fetch nonempty. Temporarily enables only
+#                DIRECTORY_DEPROVISION_ENABLED, runs real integration sync,
 #                verifies ledger/effects/generation/access denial, then
-#                restore/prove OFF. Full source rehire/reactivate restore is an
-#                EXTERNAL phase (fail-closed note; not claimed by this action).
+#                restore/prove OFF. Restore/recovery do not require the sentinel
+#                file. Full source rehire/reactivate restore is an EXTERNAL phase
+#                (fail-closed note; not claimed by this action).
 #                EMPTY_FETCH_ABORT_RECOVERY (confirmation=
 #                DINGTALK_EMPTY_FETCH_ABORT_SOURCE_RE_ADDED_CONFIRMED): staging-only
 #                fail-closed recovery when the journal is stranded at phase=run_bound
@@ -125,11 +129,13 @@ RUN_STAMP="${RUN_STAMP:?RUN_STAMP is required (workflow run id marker)}"
 # separate STAGING_OWNER_ADMIN_PASSWORD_FILE for the human admin password only.
 # pending/deprovision require CANARY_DIRECTORY_ACCOUNT_ID_FILE (explicit owned
 # directory account UUID path only — never auto-selected, never printed).
+# Deprovision apply additionally requires an explicit pre-synced sentinel UUID.
 CANARY_ADMIN_JWT_FILE="${CANARY_ADMIN_JWT_FILE:-}"
 CANARY_LOGIN_IDENTIFIER_FILE="${CANARY_LOGIN_IDENTIFIER_FILE:-}"
 CANARY_LOGIN_PASSWORD_FILE="${CANARY_LOGIN_PASSWORD_FILE:-}"
 STAGING_OWNER_ADMIN_PASSWORD_FILE="${STAGING_OWNER_ADMIN_PASSWORD_FILE:-}"
 CANARY_DIRECTORY_ACCOUNT_ID_FILE="${CANARY_DIRECTORY_ACCOUNT_ID_FILE:-}"
+CANARY_SENTINEL_DIRECTORY_ACCOUNT_ID_FILE="${CANARY_SENTINEL_DIRECTORY_ACCOUNT_ID_FILE:-}"
 
 # Fixed dedicated lifecycle canary admin ownership markers (values-free constants).
 # Create/repair ONLY this (email, id) pair. Any email/id collision that does not
@@ -149,6 +155,7 @@ HUMAN_OWNER_NAME="Staging Owner Admin"
 # local admit identifier (not printed in artifacts). No auto-selection.
 SUBJECT_OWNER_NAME="Lifecycle Canary Employee"
 SUBJECT_OWNER_USERNAME="lifecycle-canary-employee"
+SENTINEL_OWNER_NAME="Lifecycle Canary Employee 2"
 DEPROVISION_SOURCE_CONFIRMATION="DINGTALK_SOURCE_DISABLED_DEDICATED_EXCLUSIVE_CONFIRMED"
 DEPROVISION_RESTORE_CONFIRMATION="DINGTALK_SOURCE_REACTIVATED_CONFIRMED"
 # Staging-only recovery for a completed empty_directory_fetch safe abort stranded at
@@ -555,6 +562,30 @@ PY
     fail "action=${context} refused: directory account subject file invalid (${shape#*|}); values never logged"
   fi
   log "${context} directory account subject file present (path only; values never logged; no auto-selection)"
+}
+
+require_canary_sentinel_directory_account_id_file() {
+  local path="${CANARY_SENTINEL_DIRECTORY_ACCOUNT_ID_FILE:-}"
+  [[ -n "$path" ]] || fail "action=deprovision apply requires CANARY_SENTINEL_DIRECTORY_ACCOUNT_ID_FILE (chmod-600 secret file path); no auto-selection"
+  [[ -f "$path" ]] || fail "action=deprovision apply secret file missing for CANARY_SENTINEL_DIRECTORY_ACCOUNT_ID_FILE"
+  [[ -s "$path" ]] || fail "action=deprovision apply secret file empty for CANARY_SENTINEL_DIRECTORY_ACCOUNT_ID_FILE"
+  local shape
+  shape="$(python3 - "$path" <<'PY'
+import pathlib, re, sys
+try:
+    raw = pathlib.Path(sys.argv[1]).read_bytes().decode("utf-8").strip()
+except Exception:
+    print("false|secret_file_read_failed")
+    raise SystemExit(0)
+if not re.fullmatch(r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}", raw):
+    print("false|sentinel_not_uuid")
+    raise SystemExit(0)
+print("true|ok")
+PY
+  )"
+  [[ "${shape%%|*}" == "true" ]] \
+    || fail "action=deprovision apply refused: sentinel file invalid (${shape#*|}); values never logged"
+  log "deprovision apply sentinel file present (path only; values never logged; no auto-selection)"
 }
 
 # Identifier secret file (app trim) must equal the fixed ownership email marker.
@@ -4495,8 +4526,8 @@ function emit(ok, note, userActive, memCount, grantState) {
 # exact integration (dingtalk active) org, linked account/user, target-org membership
 # active, user active, no other active+linked siblings, DingTalk grant enabled,
 # policy=mark_inactive. Additionally requires a scheduler/admission/group-disabled
-# integration containing exactly this one directory account (active or inactive rows
-# count), so a post-preview scope change cannot strand collateral users outside the
+# integration containing exactly the target and one explicit active, unlinked sentinel
+# across active/inactive rows, so provider fetch remains nonempty without widening the
 # one-subject journal. Expected effects: membership_changed+grant_changed+user_changed.
 # other-org membership is ignored for candidacy (org-scoped membership only).
 prove_dedicated_subject_deprovision_precondition() {
@@ -4508,18 +4539,24 @@ prove_dedicated_subject_deprovision_precondition() {
     || { PRECOND_NOTE="integration_id_file_missing"; return 1; }
   [[ -n "${CANARY_DIRECTORY_ACCOUNT_ID_FILE:-}" && -s "${CANARY_DIRECTORY_ACCOUNT_ID_FILE}" ]] \
     || { PRECOND_NOTE="directory_account_id_file_missing"; return 1; }
+  [[ -n "${CANARY_SENTINEL_DIRECTORY_ACCOUNT_ID_FILE:-}" && -s "${CANARY_SENTINEL_DIRECTORY_ACCOUNT_ID_FILE}" ]] \
+    || { PRECOND_NOTE="sentinel_directory_account_id_file_missing"; return 1; }
   local payload_json result
   payload_json="$(
     python3 - \
       "$CANARY_SUBJECT_LOCAL_USER_ID_FILE" \
       "$CANARY_SUBJECT_INTEGRATION_ID_FILE" \
-      "$CANARY_DIRECTORY_ACCOUNT_ID_FILE" <<'PY'
+      "$CANARY_DIRECTORY_ACCOUNT_ID_FILE" \
+      "$CANARY_SENTINEL_DIRECTORY_ACCOUNT_ID_FILE" \
+      "$SENTINEL_OWNER_NAME" <<'PY'
 import json, pathlib, sys
-u, i, a = sys.argv[1:4]
+u, i, a, s, sentinel_name = sys.argv[1:6]
 print(json.dumps({
     "user_id": pathlib.Path(u).read_bytes().decode("utf-8").strip(),
     "integration_id": pathlib.Path(i).read_bytes().decode("utf-8").strip(),
     "directory_account_id": pathlib.Path(a).read_bytes().decode("utf-8").strip(),
+    "sentinel_directory_account_id": pathlib.Path(s).read_bytes().decode("utf-8").strip(),
+    "sentinel_owner_name": sentinel_name,
 }, separators=(",", ":")))
 PY
   )" || { PRECOND_NOTE="precond_payload_failed"; return 1; }
@@ -4544,9 +4581,19 @@ function emit(ok, note) {
   const userId = String(p.user_id || "").trim();
   const integrationId = String(p.integration_id || "").trim();
   const accountId = String(p.directory_account_id || "").trim();
+  const sentinelId = String(p.sentinel_directory_account_id || "").trim();
+  const sentinelOwnerName = String(p.sentinel_owner_name || "");
   const uuid = /^[0-9a-fA-F-]{36}$/;
-  if (!uuid.test(userId) || !uuid.test(integrationId) || !uuid.test(accountId)) {
+  if (!uuid.test(userId) || !uuid.test(integrationId) || !uuid.test(accountId) || !uuid.test(sentinelId)) {
     emit("false", "precond_ids_invalid");
+    return;
+  }
+  if (accountId.toLowerCase() === sentinelId.toLowerCase()) {
+    emit("false", "target_sentinel_ids_not_distinct");
+    return;
+  }
+  if (!sentinelOwnerName) {
+    emit("false", "sentinel_owner_name_missing");
     return;
   }
   const url = process.env.DATABASE_URL;
@@ -4594,18 +4641,57 @@ function emit(ok, note) {
       emit("false", "integration_automation_not_disabled");
       return;
     }
-    // A destructive canary is never allowed on a shared real-employee integration.
-    // Count ALL rows, not only active rows: a stale/inactive sibling can be revived or
-    // rewritten by the provider walk and would escape the one-subject recovery journal.
+    // Closed set across ALL rows: owned target + explicit sentinel only. A stale or
+    // inactive third row could be revived by the provider walk outside this journal.
     const radius = await c.query(
       `SELECT count(*)::int AS n,
-              count(*) FILTER (WHERE id = $2)::int AS target_n
+              count(*) FILTER (WHERE id = $2)::int AS target_n,
+              count(*) FILTER (WHERE id = $3)::int AS sentinel_n
          FROM directory_accounts
         WHERE integration_id = $1`,
-      [integrationId, accountId]
+      [integrationId, accountId, sentinelId]
     );
-    if (Number(radius.rows[0]?.n) !== 1 || Number(radius.rows[0]?.target_n) !== 1) {
-      emit("false", "integration_not_single_account");
+    if (Number(radius.rows[0]?.n) !== 2
+        || Number(radius.rows[0]?.target_n) !== 1
+        || Number(radius.rows[0]?.sentinel_n) !== 1) {
+      emit("false", "integration_not_exact_target_and_sentinel");
+      return;
+    }
+    const sentinel = await c.query(
+      `SELECT s.provider, s.corp_id, s.name, s.is_active, s.integration_id,
+              t.corp_id AS target_corp_id,
+              EXISTS (
+                SELECT 1 FROM directory_account_links l
+                 WHERE l.directory_account_id = s.id
+                   AND l.link_status = '\''linked'\''
+              ) AS has_linked_user
+         FROM directory_accounts s
+         JOIN directory_accounts t ON t.id = $2
+        WHERE s.id = $1`,
+      [sentinelId, accountId]
+    );
+    const s = sentinel.rows[0];
+    if (!s || String(s.provider || "").toLowerCase() !== "dingtalk") {
+      emit("false", "sentinel_provider_not_dingtalk");
+      return;
+    }
+    const sentinelCorp = String(s.corp_id || "").trim();
+    const targetCorp = String(s.target_corp_id || "").trim();
+    if (String(s.integration_id || "").toLowerCase() !== integrationId.toLowerCase()
+        || !sentinelCorp || !targetCorp || sentinelCorp !== targetCorp) {
+      emit("false", "sentinel_not_same_integration_corp");
+      return;
+    }
+    if (s.is_active !== true) {
+      emit("false", "sentinel_not_active");
+      return;
+    }
+    if (String(s.name || "") !== sentinelOwnerName) {
+      emit("false", "sentinel_name_not_owned");
+      return;
+    }
+    if (s.has_linked_user === true) {
+      emit("false", "sentinel_must_be_unlinked");
       return;
     }
     // Exact linked account/user for this integration.
@@ -4678,7 +4764,7 @@ function emit(ok, note) {
   PRECOND_OK="${result%%|*}"
   PRECOND_NOTE="${result#*|}"
   if [[ "$PRECOND_OK" == "true" ]]; then
-    log "dedicated subject precondition OK (single-account manual integration+planner mark_inactive+global_clear+grant_enabled; expected effects membership+grant+user; ids never logged)"
+    log "dedicated subject precondition OK (exact target+active unlinked sentinel, manual integration, planner mark_inactive, global_clear, grant_enabled; expected effects membership+grant+user; ids never logged)"
     return 0
   fi
   log "dedicated subject precondition refused: note=${PRECOND_NOTE}"
@@ -5926,6 +6012,7 @@ action_deprovision_apply() {
   require_canary_secret_files "deprovision"
   assert_canary_identifier_matches_owner "deprovision"
   require_canary_directory_account_id_file "deprovision"
+  require_canary_sentinel_directory_account_id_file
   [[ -n "$EXPECTED_CURRENT_MODE" ]] || fail "expected_current_mode is required for action=deprovision"
   [[ "$EXPECTED_CURRENT_MODE" == "off" ]] \
     || fail "action=deprovision requires expected_current_mode=off (got '${EXPECTED_CURRENT_MODE}'); refuse auto-selection"
@@ -6126,6 +6213,9 @@ action_deprovision_apply() {
     echo "admin_jwt_minted=${admin_jwt_minted}"
     echo "subject_owned=true"
     echo "subject_auto_selected=false"
+    echo "sentinel_owned=true"
+    echo "sentinel_auto_selected=false"
+    echo "integration_exact_target_and_sentinel=true"
     echo "source_disable_confirmation=true"
     echo "preview_subject_gate_ok=true"
     echo "preview_would_deactivate=${PREVIEW_WOULD_DEACTIVATE:-0}"


### PR DESCRIPTION
## What changed

- Add an apply-only `LIFECYCLE_CANARY_SENTINEL_DIRECTORY_ACCOUNT_ID` secret path to the DingTalk lifecycle staging canary.
- Replace the obsolete single-account preflight with an exact target + active unlinked sentinel closed set across all directory rows.
- Keep restore, empty-fetch recovery, and sync-failure recovery independent of the sentinel input.
- Pin distinct ids, DingTalk provider, same non-empty corp/integration, fixed sentinel name, and exactly one linked target deactivation.

## Why

The staging canary sentinel was synced before the destructive deprovision exercise. The previous operator gate required exactly one historical directory row, so the safe next step is to explicitly recognize the sentinel instead of deleting database evidence or bypassing the gate.

## Validation

- `bash -n scripts/ops/dingtalk-lifecycle-staging-canary-remote.sh`
- `node --test scripts/ops/dingtalk-lifecycle-staging-canary-contract.test.mjs` (213/213)
- `shellcheck -x scripts/ops/dingtalk-lifecycle-staging-canary-remote.sh`
- Independent Kimi adversarial review: 0 P1/P2; its restore/recovery test-gap P3 was fixed with a load-bearing mutation.

## Operational boundary

- No production directory-sync code changes.
- No lifecycle flag is enabled by this PR.
- Do not set the new secret or execute deprovision until this PR is reviewed, merged, deployed, and staging exact-SHA is confirmed.