### PR TITLE
fix(integration): bind C6 SQL reads to persisted filters

### DIFF
--- a/plugins/plugin-integration-core/__tests__/external-write-dry-run.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/external-write-dry-run.test.cjs
@@ -76,6 +76,7 @@ function baseInput(overrides = {}) {
       targetSystemId: 'target_1',
       targetObject: 'target_items',
       createdBy: 'owner-7',
+      options: { source: { filters: { approvedSlice: 'fixture' } } },
       fieldMappings: [
         { sourceField: 'code', targetField: 'externalId', validation: [{ type: 'required' }] },
         { sourceField: 'name', targetField: 'name', validation: [{ type: 'required' }] },
@@ -165,6 +166,101 @@ async function testReadyDryRunIssuesTokenAndStaysValuesFree() {
   assert.equal(evidenceText.includes('Widget'), false, 'evidence must not include source names')
   assert.equal(evidenceText.includes(result.dryRunToken), false, 'evidence must not include the bearer dry-run token')
   assert.equal(result.evidence.dryRunTokenPresent, true)
+}
+
+async function testServerBoundSqlEqualityFiltersForwardAndDiscriminateCompleteness() {
+  const reads = []
+  const filterValue = 'PRIVATE-FILTER-SENTINEL'
+  const persistedFilters = {
+    zString: filterValue,
+    aNull: null,
+    mNumber: 7,
+    bBoolean: true,
+  }
+  const { input } = baseInput({
+    input: {
+      maxRows: 3,
+      pipeline: {
+        ...baseInput().input.pipeline,
+        options: { source: { filters: persistedFilters } },
+      },
+    },
+    sourceRead: (readInput) => {
+      reads.push(JSON.parse(JSON.stringify(readInput)))
+      if (!readInput.filters) {
+        return {
+          records: [
+            { code: 'P-001', name: 'Widget', status: 'new' },
+            { code: 'P-002', name: 'Gadget', status: 'old' },
+            { code: 'P-003', name: 'Third', status: 'new' },
+          ],
+          done: false,
+          nextCursor: '3',
+        }
+      }
+      return {
+        records: [
+          { code: 'P-001', name: 'Widget', status: 'new' },
+          { code: 'P-002', name: 'Gadget', status: 'old' },
+        ],
+        done: true,
+        nextCursor: null,
+      }
+    },
+  })
+  const result = await dryRunExternalWrite(input)
+  assert.equal(result.status, 'ready', 'persisted filter changes the unfiltered truncated RED plan to ready')
+  assert.deepEqual(reads, [{
+    object: 'items',
+    filters: { aNull: null, bBoolean: true, mNumber: 7, zString: filterValue },
+    limit: 3,
+    cursor: null,
+  }])
+  const publicText = JSON.stringify(result)
+  assert.equal(publicText.includes(filterValue), false, 'filter values never enter public result/evidence')
+  assert.equal(publicText.includes('zString'), false, 'filter keys never enter public result/evidence')
+}
+
+async function testMissingOrInvalidSqlFiltersFailBeforeSourceContactValuesFree() {
+  for (const [filters, expectedCode] of [
+    [undefined, 'C6_WRITE_SOURCE_FILTERS_REQUIRED'],
+    [{}, 'C6_WRITE_SOURCE_FILTERS_REQUIRED'],
+    [{ secretField: { $operator: 'PRIVATE-ERROR-SENTINEL' } }, 'C6_WRITE_SOURCE_FILTERS_INVALID'],
+  ]) {
+    let reads = 0
+    const { input, calls } = baseInput({
+      input: {
+        pipeline: {
+          ...baseInput().input.pipeline,
+          options: filters === undefined ? {} : { source: { filters } },
+        },
+      },
+      sourceRead: () => { reads += 1; return { records: [], done: true, nextCursor: null } },
+    })
+    await assert.rejects(
+      () => dryRunExternalWrite(input),
+      (error) => {
+        const text = JSON.stringify({ code: error.code, message: error.message, details: error.details })
+        return error && error.code === expectedCode
+          && !text.includes('secretField')
+          && !text.includes('PRIVATE-ERROR-SENTINEL')
+      },
+    )
+    assert.equal(reads, 0, 'invalid/missing persisted filter fails before source contact')
+    assert.equal(calls.test.length, 0, 'invalid/missing persisted filter also fails before target capability contact')
+  }
+}
+
+async function testStoredFilterChangeInvalidatesDryRunRevisionBeforeWrite() {
+  const { input, calls } = baseInput({ input: { dryRunUser: 'user_write' } })
+  const dryRun = await dryRunExternalWrite(input)
+  input.pipeline.options.source.filters.approvedSlice = 'changed-after-dry-run'
+  await assert.rejects(
+    () => applyExternalWrite({ ...input, dryRunToken: dryRun.dryRunToken, applyUser: 'user_write' }),
+    (error) => error && error.code === 'C6_WRITE_DRY_RUN_TOKEN_MISMATCH',
+  )
+  assert.equal(calls.insertRows.length, 0, 'stored filter revision mismatch fails before insert')
+  assert.equal(calls.updateRows.length, 0, 'stored filter revision mismatch fails before update')
 }
 
 async function testApplyConsumesTokenRecomputesAndWritesEligibleRows() {
@@ -806,6 +902,9 @@ async function testWriteSourceSeamIsolatesRowFailureValuesFree() {
 
 async function main() {
   await testReadyDryRunIssuesTokenAndStaysValuesFree()
+  await testServerBoundSqlEqualityFiltersForwardAndDiscriminateCompleteness()
+  await testMissingOrInvalidSqlFiltersFailBeforeSourceContactValuesFree()
+  await testStoredFilterChangeInvalidatesDryRunRevisionBeforeWrite()
   await testWriteSourceSeamGeneralizesLifecycleOffSqlProfile()
   await testWriteSourceSeamIsolatesRowFailureValuesFree()
   await testAmbiguousTargetKeyHoldsAndDoesNotIssueToken()

--- a/plugins/plugin-integration-core/__tests__/external-write-dry-run.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/external-write-dry-run.test.cjs
@@ -262,6 +262,52 @@ async function testMissingOrInvalidSqlFiltersFailBeforeSourceContactValuesFree()
   }
 }
 
+async function testSqlFilterDriverFailuresAreRedactedForDryRunAndApply() {
+  const filterKey = 'privateFilterColumn'
+  const filterValue = 'PRIVATE-FILTER-LITERAL'
+  const driverLeak = `invalid input for ${filterKey}: ${filterValue}`
+  let failRead = true
+  const { input } = baseInput({
+    input: {
+      dryRunUser: 'user_write',
+      pipeline: {
+        ...baseInput().input.pipeline,
+        options: { source: { filters: { [filterKey]: filterValue } } },
+      },
+    },
+    sourceRead: () => {
+      if (failRead) throw new Error(driverLeak)
+      return {
+        records: [
+          { code: 'P-001', name: 'Widget', status: 'new' },
+          { code: 'P-002', name: 'Gadget', status: 'old' },
+        ],
+        done: true,
+        nextCursor: null,
+      }
+    },
+  })
+  const assertRedacted = (error) => {
+    const text = JSON.stringify({ code: error.code, message: error.message, details: error.details })
+    return error && error.code === 'C6_WRITE_SOURCE_READ_FAILED'
+      && error.status === 502
+      && !text.includes(filterKey)
+      && !text.includes(filterValue)
+      && !text.includes(driverLeak)
+  }
+
+  await assert.rejects(() => dryRunExternalWrite(input), assertRedacted)
+
+  failRead = false
+  const dryRun = await dryRunExternalWrite(input)
+  failRead = true
+  await assert.rejects(
+    () => applyExternalWrite({ ...input, dryRunToken: dryRun.dryRunToken, applyUser: 'user_write' }),
+    assertRedacted,
+    'Apply recomputation uses the same values-free filtered-read failure boundary',
+  )
+}
+
 async function testStoredFilterChangeInvalidatesDryRunRevisionBeforeWrite() {
   const { input, calls } = baseInput({ input: { dryRunUser: 'user_write' } })
   const dryRun = await dryRunExternalWrite(input)
@@ -915,6 +961,7 @@ async function main() {
   await testReadyDryRunIssuesTokenAndStaysValuesFree()
   await testServerBoundSqlEqualityFiltersForwardAndDiscriminateCompleteness()
   await testMissingOrInvalidSqlFiltersFailBeforeSourceContactValuesFree()
+  await testSqlFilterDriverFailuresAreRedactedForDryRunAndApply()
   await testStoredFilterChangeInvalidatesDryRunRevisionBeforeWrite()
   await testWriteSourceSeamGeneralizesLifecycleOffSqlProfile()
   await testWriteSourceSeamIsolatesRowFailureValuesFree()

--- a/plugins/plugin-integration-core/__tests__/external-write-dry-run.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/external-write-dry-run.test.cjs
@@ -226,6 +226,9 @@ async function testMissingOrInvalidSqlFiltersFailBeforeSourceContactValuesFree()
     [undefined, 'C6_WRITE_SOURCE_FILTERS_REQUIRED'],
     [{}, 'C6_WRITE_SOURCE_FILTERS_REQUIRED'],
     [{ secretField: { $operator: 'PRIVATE-ERROR-SENTINEL' } }, 'C6_WRITE_SOURCE_FILTERS_INVALID'],
+    [{ 'invalid-key-PRIVATE': 'PRIVATE-KEY-SENTINEL' }, 'C6_WRITE_SOURCE_FILTERS_INVALID'],
+    [{ $or: 'PRIVATE-OPERATOR-SENTINEL' }, 'C6_WRITE_SOURCE_FILTERS_INVALID'],
+    [JSON.parse('{"__proto__":"PRIVATE-PROTO-SENTINEL"}'), 'C6_WRITE_SOURCE_FILTERS_INVALID'],
   ]) {
     let reads = 0
     const { input, calls } = baseInput({
@@ -242,8 +245,16 @@ async function testMissingOrInvalidSqlFiltersFailBeforeSourceContactValuesFree()
       (error) => {
         const text = JSON.stringify({ code: error.code, message: error.message, details: error.details })
         return error && error.code === expectedCode
-          && !text.includes('secretField')
-          && !text.includes('PRIVATE-ERROR-SENTINEL')
+          && [
+            'secretField',
+            'PRIVATE-ERROR-SENTINEL',
+            'invalid-key-PRIVATE',
+            'PRIVATE-KEY-SENTINEL',
+            '$or',
+            'PRIVATE-OPERATOR-SENTINEL',
+            '__proto__',
+            'PRIVATE-PROTO-SENTINEL',
+          ].every((sentinel) => !text.includes(sentinel))
       },
     )
     assert.equal(reads, 0, 'invalid/missing persisted filter fails before source contact')

--- a/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
@@ -1678,6 +1678,7 @@ async function testPipelineExternalWriteDryRunRoute() {
     targetSystemId: targetSystem.id,
     targetObject: 'public.target_items',
     createdBy: 'owner-7',
+    options: { source: { filters: { approvedSlice: 'PRIVATE-ROUTE-FILTER' } } },
     fieldMappings: [
       { sourceField: 'code', targetField: 'externalId' },
       { sourceField: 'name', targetField: 'name' },
@@ -1761,7 +1762,7 @@ async function testPipelineExternalWriteDryRunRoute() {
   assert.equal(res.body.data.counts.add, 1)
   assert.equal(res.body.data.evidence.dryRunTokenPresent, true)
   assert.equal(storage.map.size, 1, 'route persists the dry-run token through plugin storage')
-  assert.deepEqual(sourceReadCalls, [{ object: 'public.source_items', limit: 100, cursor: null }])
+  assert.deepEqual(sourceReadCalls, [{ object: 'public.source_items', filters: { approvedSlice: 'PRIVATE-ROUTE-FILTER' }, limit: 100, cursor: null }])
   assert.equal(findCalls(calls, 'getExternalSystemForAdapter').length, 1, 'only the source system uses adapter-ready credential loading')
   assert.equal(findCalls(calls, 'getExternalSystemForAdapter')[0][1].id, sourceSystem.id)
   assert.equal(findCalls(calls, 'getExternalSystem').length, 1, 'target system is loaded as config only')
@@ -1808,6 +1809,21 @@ async function testPipelineExternalWriteDryRunRoute() {
   assert.equal(res.statusCode, 400)
   assert.equal(res.body.error.code, 'C6_WRITE_DRY_RUN_REQUEST_INVALID')
   assert.equal(calls.length, callsBeforeClientInjection, 'client-supplied dry-run injection control is rejected before loading the pipeline')
+
+  const callsBeforeFilterSteering = calls.length
+  res = await invoke(routes, 'POST', '/api/integration/pipelines/:id/external-write/dry-run', {
+    user: READ_USER,
+    params: { id: pipeline.id },
+    body: {
+      tenantId: 'tenant_1',
+      workspaceId: 'workspace_1',
+      filters: { approvedSlice: 'REQUEST-STEERING-SENTINEL' },
+    },
+  })
+  assert.equal(res.statusCode, 400)
+  assert.equal(res.body.error.code, 'C6_WRITE_DRY_RUN_REQUEST_INVALID')
+  assert.equal(calls.length, callsBeforeFilterSteering, 'request-supplied filter steering is rejected before loading the pipeline')
+  assert.equal(JSON.stringify(res.body).includes('REQUEST-STEERING-SENTINEL'), false, 'rejected request values stay out of errors')
 }
 
 async function testPipelineExternalWriteApplyRoute() {
@@ -1849,6 +1865,7 @@ async function testPipelineExternalWriteApplyRoute() {
     targetSystemId: targetSystem.id,
     targetObject: 'public.target_items',
     createdBy: 'owner-7',
+    options: { source: { filters: { approvedSlice: 'fixture' } } },
     fieldMappings: [
       { sourceField: 'code', targetField: 'externalId' },
       { sourceField: 'name', targetField: 'name' },
@@ -2091,6 +2108,7 @@ async function testPipelineExternalWriteApplyTestFailureInjectionRoute() {
     targetSystemId: targetSystem.id,
     targetObject: 'public.target_items',
     createdBy: 'owner-7',
+    options: { source: { filters: { approvedSlice: 'fixture' } } },
     fieldMappings: [
       { sourceField: 'code', targetField: 'externalId' },
       { sourceField: 'name', targetField: 'name' },
@@ -2315,6 +2333,7 @@ async function testPipelineExternalWriteApplyPersistsDeadLetterAndProvenance() {
     targetSystemId: targetSystem.id,
     targetObject: 'public.target_items',
     createdBy: 'owner-7',
+    options: { source: { filters: { approvedSlice: 'fixture' } } },
     fieldMappings: [
       { sourceField: 'code', targetField: 'externalId' },
       { sourceField: 'name', targetField: 'name' },
@@ -2507,6 +2526,7 @@ async function testPipelineExternalWriteApplyDoesNotOverstateProvenancePersisten
     targetSystemId: targetSystem.id,
     targetObject: 'public.target_items',
     createdBy: 'owner-7',
+    options: { source: { filters: { approvedSlice: 'fixture' } } },
     fieldMappings: [
       { sourceField: 'code', targetField: 'externalId' },
       { sourceField: 'name', targetField: 'name' },
@@ -2621,6 +2641,7 @@ async function testPipelineExternalWriteDryRunPreflightFailsClosed() {
           targetSystemId: 'target_c6',
           targetObject: 'public.target_items',
           createdBy: 'owner-7',
+          options: { source: { filters: { approvedSlice: 'fixture' } } },
           fieldMappings: [],
           ...pipelineOverride,
         }
@@ -5655,6 +5676,7 @@ async function testPipelineExternalWriteMultitableRoute() {
     id: 'pipe_mt', tenantId: 'tenant_1', workspaceId: 'workspace_1', name: 'C6 multitable', status: 'active',
     sourceSystemId: sourceSystem.id, sourceObject: 'src_items',
     targetSystemId: targetSystem.id, targetObject: 'approved_materials', createdBy: 'owner-7',
+    options: { source: { filters: { approvedSlice: 'fixture' } } },
     fieldMappings: [
       { sourceField: 'c', targetField: 'code' },
       { sourceField: 'n', targetField: 'name' },

--- a/plugins/plugin-integration-core/__tests__/k3-wise-c6-write-profile.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/k3-wise-c6-write-profile.test.cjs
@@ -226,6 +226,7 @@ function pipelineFixture() {
     targetSystemId: 'k3-target-1',
     targetObject: 'material',
     createdBy: 'owner-7',
+    options: { source: { filters: { fixtureScope: 'approved' } } },
     fieldMappings: [
       { sourceField: 'code', targetField: 'FNumber', validation: [{ type: 'required' }] },
       { sourceField: 'name', targetField: 'FName', validation: [{ type: 'required' }] },

--- a/plugins/plugin-integration-core/__tests__/metasheet-multitable-target-adapter.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/metasheet-multitable-target-adapter.test.cjs
@@ -145,6 +145,7 @@ async function testMultitableWriteSourceRidesC6Lifecycle() {
       sourceSystemId: 'src', sourceObject: 'items',
       targetSystemId: multitableSystem.id, targetObject: 'approved_materials',
       createdBy: 'owner-1',
+      options: { source: { filters: { fixtureScope: 'approved' } } },
       fieldMappings: [
         { sourceField: 'code', targetField: 'code', validation: [{ type: 'required' }] },
         { sourceField: 'name', targetField: 'name' },
@@ -232,6 +233,7 @@ async function testMultitableAmbiguousKeyHolds() {
     pipeline: {
       id: 'pipe_dup', tenantId: 't1', workspaceId: 'w1', sourceSystemId: 'src', sourceObject: 'items',
       targetSystemId: system.id, targetObject: 'approved_materials', createdBy: 'owner-1',
+      options: { source: { filters: { fixtureScope: 'approved' } } },
       fieldMappings: [
         { sourceField: 'code', targetField: 'code', validation: [{ type: 'required' }] },
         { sourceField: 'name', targetField: 'name' },
@@ -271,6 +273,7 @@ async function testMultitableUnmappedFieldRoundTrips() {
     pipeline: {
       id: 'pipe_unmapped', tenantId: 't1', workspaceId: 'w1', sourceSystemId: 'src', sourceObject: 'items',
       targetSystemId: system.id, targetObject: 'approved_materials', createdBy: 'owner-1',
+      options: { source: { filters: { fixtureScope: 'approved' } } },
       fieldMappings: [
         { sourceField: 'code', targetField: 'code', validation: [{ type: 'required' }] },
         { sourceField: 'name', targetField: 'name' },

--- a/plugins/plugin-integration-core/lib/external-write-dry-run.cjs
+++ b/plugins/plugin-integration-core/lib/external-write-dry-run.cjs
@@ -473,7 +473,22 @@ async function readSourceRows({ sourceAdapter, object, maxRows, filters }) {
       cursor,
     }
     if (filters !== undefined) readRequest.filters = filters
-    const read = await sourceAdapter.read(readRequest)
+    let read
+    try {
+      read = await sourceAdapter.read(readRequest)
+    } catch (error) {
+      // SQL drivers commonly echo identifiers and rejected literal values in their errors.
+      // Persisted equality filters are private server-side configuration, so never let a
+      // filtered-read driver error escape into HTTP responses or Apply run evidence.
+      if (filters !== undefined) {
+        throw new ExternalWriteDryRunError(
+          502,
+          'C6_WRITE_SOURCE_READ_FAILED',
+          'persisted SQL read-only source read failed',
+        )
+      }
+      throw error
+    }
     const pageRecords = Array.isArray(read && read.records) ? read.records : []
     records.push(...pageRecords.slice(0, Math.max(0, maxRows - records.length)))
     if ((read && read.done === true) || !(read && read.nextCursor)) {

--- a/plugins/plugin-integration-core/lib/external-write-dry-run.cjs
+++ b/plugins/plugin-integration-core/lib/external-write-dry-run.cjs
@@ -379,6 +379,7 @@ function valuesEqual(left, right) {
 }
 
 const SQL_READONLY_SOURCE_KIND = 'data-source:sql-readonly'
+const SQL_EQUALITY_FILTER_IDENTIFIER_PATTERN = /^[A-Za-z0-9_]+(?:\.[A-Za-z0-9_]+)*$/
 
 // C6 never accepts source predicates from the request. For the SQL read-only source, the only
 // predicate surface is the already persisted pipeline options. Keep the accepted language equal
@@ -404,7 +405,9 @@ function normalizeServerBoundSqlEqualityFilters(pipeline, sourceSystem) {
   }
   const normalized = {}
   for (const [key, value] of entries.sort(([left], [right]) => left.localeCompare(right))) {
-    if (typeof key !== 'string' || key.trim() === '' || key !== key.trim()) {
+    if (typeof key !== 'string' ||
+        key === '__proto__' ||
+        !SQL_EQUALITY_FILTER_IDENTIFIER_PATTERN.test(key)) {
       throw new ExternalWriteDryRunError(422, 'C6_WRITE_SOURCE_FILTERS_INVALID', 'persisted SQL read-only source equality filters are invalid')
     }
     if (value !== null && !['string', 'number', 'boolean'].includes(typeof value)) {

--- a/plugins/plugin-integration-core/lib/external-write-dry-run.cjs
+++ b/plugins/plugin-integration-core/lib/external-write-dry-run.cjs
@@ -378,6 +378,46 @@ function valuesEqual(left, right) {
   return false
 }
 
+const SQL_READONLY_SOURCE_KIND = 'data-source:sql-readonly'
+
+// C6 never accepts source predicates from the request. For the SQL read-only source, the only
+// predicate surface is the already persisted pipeline options. Keep the accepted language equal
+// to the adapter's structured equality contract and normalize key order so dry-run/apply revisions
+// bind the same server-side decision without exposing keys or values in evidence/errors.
+function normalizeServerBoundSqlEqualityFilters(pipeline, sourceSystem) {
+  if (!sourceSystem || sourceSystem.kind !== SQL_READONLY_SOURCE_KIND) return undefined
+  const sourceOptions = pipeline && pipeline.options && pipeline.options.source
+  if (!isPlainObject(sourceOptions) || !isPlainObject(sourceOptions.filters)) {
+    throw new ExternalWriteDryRunError(
+      422,
+      'C6_WRITE_SOURCE_FILTERS_REQUIRED',
+      'persisted SQL read-only source equality filters are required',
+    )
+  }
+  const entries = Object.entries(sourceOptions.filters)
+  if (entries.length === 0) {
+    throw new ExternalWriteDryRunError(
+      422,
+      'C6_WRITE_SOURCE_FILTERS_REQUIRED',
+      'persisted SQL read-only source equality filters are required',
+    )
+  }
+  const normalized = {}
+  for (const [key, value] of entries.sort(([left], [right]) => left.localeCompare(right))) {
+    if (typeof key !== 'string' || key.trim() === '' || key !== key.trim()) {
+      throw new ExternalWriteDryRunError(422, 'C6_WRITE_SOURCE_FILTERS_INVALID', 'persisted SQL read-only source equality filters are invalid')
+    }
+    if (value !== null && !['string', 'number', 'boolean'].includes(typeof value)) {
+      throw new ExternalWriteDryRunError(422, 'C6_WRITE_SOURCE_FILTERS_INVALID', 'persisted SQL read-only source equality filters are invalid')
+    }
+    if (typeof value === 'number' && !Number.isFinite(value)) {
+      throw new ExternalWriteDryRunError(422, 'C6_WRITE_SOURCE_FILTERS_INVALID', 'persisted SQL read-only source equality filters are invalid')
+    }
+    normalized[key] = value
+  }
+  return normalized
+}
+
 function keyFromRecord(record, keyFields) {
   const key = {}
   const missing = []
@@ -417,18 +457,20 @@ function classifyExisting({ existingRows, targetRecord, writableFields }) {
   return allEqual ? 'skip' : 'update'
 }
 
-async function readSourceRows({ sourceAdapter, object, maxRows }) {
+async function readSourceRows({ sourceAdapter, object, maxRows, filters }) {
   const records = []
   let cursor = null
   let pagesRead = 0
   let complete = false
   while (records.length < maxRows && pagesRead < MAX_PAGES) {
     pagesRead += 1
-    const read = await sourceAdapter.read({
+    const readRequest = {
       object,
       limit: Math.min(DEFAULT_PAGE_SIZE, maxRows - records.length),
       cursor,
-    })
+    }
+    if (filters !== undefined) readRequest.filters = filters
+    const read = await sourceAdapter.read(readRequest)
     const pageRecords = Array.isArray(read && read.records) ? read.records : []
     records.push(...pageRecords.slice(0, Math.max(0, maxRows - records.length)))
     if ((read && read.done === true) || !(read && read.nextCursor)) {
@@ -456,6 +498,7 @@ function buildRevision(input) {
       systemId: input.pipeline.sourceSystemId,
       object: input.pipeline.sourceObject,
       kind: input.sourceKind,
+      filters: input.sourceFilters || null,
     },
     target: {
       systemId: input.pipeline.targetSystemId,
@@ -551,6 +594,7 @@ function validatePlannerInput(input = {}, phase = 'dry-run') {
 
 async function computeExternalWritePlan(input = {}) {
   const pipeline = validatePlannerInput(input, input.phase || 'dry-run')
+  const sourceFilters = normalizeServerBoundSqlEqualityFilters(pipeline, input.sourceSystem)
   const profile = resolveTargetWriteProfile(input)
   const targetConfig = normalizeTargetConfig(input.targetSystem, profile)
   const testFailureInjection = normalizeTestFailureInjectionConfig(input.testFailureInjection, {
@@ -574,6 +618,7 @@ async function computeExternalWritePlan(input = {}) {
     sourceAdapter: input.sourceAdapter,
     object: pipeline.sourceObject,
     maxRows,
+    filters: sourceFilters,
   })
   const counts = {
     sourceRows: sourceRead.records.length,
@@ -655,6 +700,7 @@ async function computeExternalWritePlan(input = {}) {
   const revision = buildRevision({
     pipeline,
     sourceKind: input.sourceSystem && input.sourceSystem.kind,
+    sourceFilters,
     targetConfig,
     targetCapabilityState,
     testFailureInjection,
@@ -670,6 +716,7 @@ async function computeExternalWritePlan(input = {}) {
     dataSourceWrites,
     targetCapabilityState,
     sourceKind: input.sourceSystem && input.sourceSystem.kind,
+    sourceFilters,
     sourceRead,
     counts,
     rowErrorTypes,
@@ -953,6 +1000,7 @@ module.exports = {
     consumeDryRunToken,
     normalizeTargetConfig,
     normalizeTestFailureInjectionConfig,
+    normalizeServerBoundSqlEqualityFilters,
     valuesEqual,
   },
 }

--- a/scripts/ops/fixtures/integration-k3wise/run-mock-poc-demo.mjs
+++ b/scripts/ops/fixtures/integration-k3wise/run-mock-poc-demo.mjs
@@ -319,6 +319,7 @@ async function main() {
         targetSystemId: chainTarget.id,
         targetObject: 'material',
         createdBy: 'demo-operator',
+        options: { source: { filters: { fixtureScope: 'approved' } } },
         fieldMappings: [
           { sourceField: 'code', targetField: 'FNumber', validation: [{ type: 'required' }] },
           { sourceField: 'name', targetField: 'FName', validation: [{ type: 'required' }] },


### PR DESCRIPTION
## Scope

Implements the bounded #4437 C6 server-bound SQL equality-filter package approved in the owner decision.

- Reads filters only from persisted `pipeline.options.source.filters`.
- Applies only to `data-source:sql-readonly` C6 source reads.
- Accepts only non-empty primitive equality values (`null`, string, finite number, boolean) through the existing structured adapter contract.
- Rejects missing/invalid filters before source or target contact with values-free errors.
- Rejects request-supplied filter steering through the existing C6 request allowlist.
- Binds normalized filters into the dry-run revision, so a stored-filter change invalidates Apply before any write.
- Leaves non-SQL source kinds unchanged.

No dependencies, migrations, deployment scripts, credentials, entity-server writes, Apply/run/replay, or business-row mutation are included.

## Evidence

- `twoRowEqualityFilterAvailable=YES` (private read-only feasibility; field names and values suppressed)
- `node --check plugins/plugin-integration-core/lib/external-write-dry-run.cjs`
- SQL read-only source adapter: pass
- pipeline runner: pass
- external-write dry-run: pass
- HTTP routes: pass
- K3 WISE C6 profile: 44/44 pass
- multitable C6 target: pass
- PLM/K3 route and E2E mocks: pass
- `git diff --check`: pass
- Full package `npm test` could not start locally because the Windows command line for the repository's monolithic test script exceeds the platform limit; no test in that command executed or failed.

Mutation control:

- `mutation=REMOVE_C6_FILTER_FORWARDING`
- `expected=FAIL`
- `observed=FAIL`
- `discriminator=ready_to_not_applyable_truncated`

## Merge gate

Keep Draft. Do not merge until the frozen exact head has all required checks successful, integration-guard demonstrably executes the changed C6 suites, and an independent non-author review reports zero P1/P2 findings. Package/deployment remains a separate owner-gated phase.

`independentHumanReviewClaimed=NO`