### PR TITLE
docs(dingtalk): record staging lifecycle canary closeout

### DIFF
--- a/docs/development/dingtalk-lifecycle-canary-separate-go-20260724.md
+++ b/docs/development/dingtalk-lifecycle-canary-separate-go-20260724.md
@@ -1,7 +1,7 @@
 # DingTalk lifecycle canary — separate ops GO (not auto-enabled)
 
 **Date:** 2026-07-24
-**Updated:** 2026-08-12 (alias and server-side pending canaries completed with required OFF rollback; two pre-ledger deprovision failure classes were safely recovered at exact SHA `51f23ec7255c3fb0d9abc21bfbe4c3bce8e1c48f`; destructive apply/restore remains **NOT EXECUTED** pending a second unique DingTalk sentinel)
+**Updated:** 2026-08-12 (alias, server-side pending, and server-side deprovision apply/restore canaries completed with required terminal OFF proof at exact SHA `2bf058c2a4fd5abed76df347b3bfdb74dba148ee`; browser and production GO remain separate)
 **Related locks:**
 - `dingtalk-directory-admission-activation-lifecycle-design-20260723.md` Rev 4.2
 - `dingtalk-deprovision-reactivation-and-evidence-chain-design-20260723.md` Rev 4.5
@@ -13,7 +13,7 @@
 |---------------|-------------------------|--------------------------|
 | `DIRECTORY_PENDING_ACTIVATION_ENABLED` ON | **OFF** | **Executable only as a transient canary** on an explicit owned account. Default phase admits to pending and proves OFF rollback; optional SSO activation still records browser OAuth as `NOT_EXECUTED` until a human observes it. |
 | `AUTH_LOGIN_USE_ALIASES` ON (T2b cutover) | **OFF** | **Executable only as a transient canary** (`action=alias`). Success requires/proves OFF in the same run; failure restores the OFF override before failing. Runtime OFF cannot be proven if rollback recreate itself fails (override restored on disk). Requires secret-backed password login; short-lived admin JWT is minted from that login (never `secrets.ATTENDANCE_ADMIN_JWT`). |
-| `DIRECTORY_DEPROVISION_ENABLED` ON | **OFF** | **Executable only as a two-phase transient canary** on an explicit owned account in a dedicated one-account integration. Apply and restore are separate confirmed operations; every exit restores/proves the flags OFF or reports that runtime OFF is unproven. |
+| `DIRECTORY_DEPROVISION_ENABLED` ON | **OFF** | **Executable only as a two-phase transient canary** on an explicit owned account in a dedicated exact target-plus-sentinel integration. Apply and restore are separate confirmed operations; every exit restores/proves the flags OFF or reports that runtime OFF is unproven. |
 | Env-gate clear (`action=off`) | n/a | Executable emergency only (after migrations true + exact SHA) |
 | Dedicated canary admin (`action=bootstrap`) | n/a | Executable staging-only create/repair of the **fixed** owned row only (no lifecycle env write) |
 
@@ -35,7 +35,7 @@ Presence of canary subject/integration/owner tokens is **not** a real canary and
 | `bootstrap` | yes (manual) | staging-only create/repair of fixed canary admin; see below; **no lifecycle env write** |
 | `alias` | yes (transient) | secret-backed cutover canary; see sequence below; success requires/proves OFF |
 | `pending` | yes (transient, **SERVER-SIDE PASS**) | explicit owned account admitted and activated through SSO intent; required OFF rollback passed; browser OAuth remains a human checkpoint |
-| `deprovision` | yes (two-phase, **ATTEMPTED / NOT COMPLETE**) | dedicated manual integration and recovery paths proven; pre-reserves the exact run UUID before env/HTTP; destructive event/effects apply + restore awaits a second unique DingTalk sentinel; required OFF rollback remains mandatory |
+| `deprovision` | yes (two-phase, **SERVER-SIDE PASS**) | explicit target + sentinel apply wrote one event/three effects; restore reversed the exact set, restored the access graph, cleared the journal, and kept all lifecycle flags OFF; browser checkpoints remain separate |
 
 Shared concurrency with `attendance-staging-window-runner`. Status artifacts stay values-free (booleans / counts / reason enums / SHA only).
 
@@ -104,11 +104,11 @@ Any `users` row matching the email **or** the id that does **not** match **both*
 
 Backfill alias rows **may persist** after the run. Artifacts report only booleans / counts / reason enums / SHA — never credentials, identifiers, tokens, or PII.
 
-**Repo state note:** `LIFECYCLE_CANARY_LOGIN_IDENTIFIER` / `LIFECYCLE_CANARY_LOGIN_PASSWORD` must be configured before a real bootstrap or alias dispatch. This lane does **not** use `ATTENDANCE_ADMIN_JWT`. Landing this code does **not** configure those secrets and does **not** claim a successful canary execution.
+**Repo state note:** `LIFECYCLE_CANARY_LOGIN_IDENTIFIER` / `LIFECYCLE_CANARY_LOGIN_PASSWORD` must be configured before a real bootstrap or alias dispatch. This lane does **not** use `ATTENDANCE_ADMIN_JWT`. Code landing alone configures no secret and proves no runtime result; the successful staging executions are separately bound to the runs below.
 
-## Current staging baseline (alias executed and rolled back)
+## Current staging baseline (three server-side canaries executed and rolled back)
 
-As of 2026-08-12 the alias and server-side pending canaries are complete and rolled back. Deprovision recovery is proven, but destructive apply/restore remains **NOT EXECUTED**. Safe preparation and execution evidence:
+As of 2026-08-12 the alias, server-side pending, and server-side deprovision apply/restore canaries are complete with terminal OFF proof. Browser OAuth/login checkpoints and production enablement remain separate. Safe preparation and execution evidence:
 
 1. Attendance staging runner [run 31407444155](https://github.com/zensgit/metasheet2/actions/runs/31407444155) completed backup + clone rehearsal + real apply: migration state `296 applied / 18 pending` -> `314 applied / 0 pending`; rehearsal isolation held and auth round-trip returned 200.
 2. [#4853](https://github.com/zensgit/metasheet2/pull/4853), merge commit `ddec28b12ebff97fae33af45553d77c149d816e1`, installs and validates the checked-out staging Compose file, pins Compose project-directory, and derives build metadata from the exact `IMAGE_TAG`.
@@ -124,20 +124,26 @@ As of 2026-08-12 the alias and server-side pending canaries are complete and rol
 12. Pending [admit 31551343313](https://github.com/zensgit/metasheet2/actions/runs/31551343313) and [SSO activate-intent 31551426867](https://github.com/zensgit/metasheet2/actions/runs/31551426867) used the explicit owned subject and left all lifecycle flags OFF. Browser OAuth checkpoints remain `NOT_EXECUTED`.
 13. [#4875](https://github.com/zensgit/metasheet2/pull/4875) and recovery [31555162698](https://github.com/zensgit/metasheet2/actions/runs/31555162698) closed an exact empty-fetch abort with zero ledger and unchanged access graph.
 14. [#4877](https://github.com/zensgit/metasheet2/pull/4877), merge `51f23ec7255c3fb0d9abc21bfbe4c3bce8e1c48f`, and runs [31559288370](https://github.com/zensgit/metasheet2/actions/runs/31559288370), [31559371562](https://github.com/zensgit/metasheet2/actions/runs/31559371562), and [31559480395](https://github.com/zensgit/metasheet2/actions/runs/31559480395) prove exact staging deploy, exact sync-failure recovery, cleared journal, unchanged access graph, zero ledger, and terminal mode `off`.
+15. [#4879](https://github.com/zensgit/metasheet2/pull/4879), merge `2bf058c2a4fd5abed76df347b3bfdb74dba148ee`, added the explicit distinct sentinel gate. Staging [deploy 31573166502](https://github.com/zensgit/metasheet2/actions/runs/31573166502), [status 31573329397](https://github.com/zensgit/metasheet2/actions/runs/31573329397), and [preflight 31575076447](https://github.com/zensgit/metasheet2/actions/runs/31575076447) proved the exact deployed SHA, `314/0` migrations, health, and OFF baseline.
+16. [Apply 31575411459](https://github.com/zensgit/metasheet2/actions/runs/31575411459) proved the exact target-and-sentinel source shape, one deactivation candidate, one event, three effects, generation advance, disabled access graph, retained `ledger_bound` journal, and automatic flag rollback to OFF.
+17. [Restore 31575938536](https://github.com/zensgit/metasheet2/actions/runs/31575938536) proved source reactivation, exact three-effect reversal, fully resolved event, restored user/membership/grant graph, cleared journal, and flags remaining OFF. Its browser checkpoints remain `NOT_EXECUTED` and it does not claim browser end-to-end restore.
+18. The temporary sentinel was removed from the canary department after restore; the organization member count remained unchanged and the department returned to the target-only source shape.
+19. Terminal read-only [status 31576139497](https://github.com/zensgit/metasheet2/actions/runs/31576139497) reports exact SHA `2bf058c2a4fd5abed76df347b3bfdb74dba148ee`, healthy backend, zero pending migrations, mode `off`, all three lifecycle flags `false`, and `transition_applied=false`.
+20. Post-restore read-only [production-readiness inventory 31579935836](https://github.com/zensgit/metasheet2/actions/runs/31579935836) reports the same exact deployed SHA, one active corp-anchored DingTalk integration, two active linked local users, and all lifecycle/Stream flags OFF. It also re-confirms that the four Stream/template prerequisites remain absent, so U1-U13 and the real callback corp-anchor remain `NOT_EXECUTED` rather than inferred green.
 
-The former image-tag/health-commit provenance conflict is resolved. This establishes the safe OFF baseline and the transient alias staging canary; it does not authorize production alias traffic.
+The former image-tag/health-commit provenance conflict is resolved. This establishes the safe OFF baseline and the three server-side transient staging canaries; it does not authorize production lifecycle traffic.
 
-The secret-backed operators now exist and pending admission/SSO activation have run against the
-explicit owned source employee. Deprovision additionally refuses any integration
+The secret-backed operators now exist; pending admission/SSO activation and deprovision
+apply/restore have run against the explicit owned source employee. Deprovision refuses any integration
 that is scheduled, auto-admitting, member-group projecting, or contains anything other than the
-single selected directory account (inactive rows count too). The dedicated integration passed those
-gates, but a destructive cycle still requires a second unique employee as a temporary non-target
-sentinel; using an employee already present in another integration fails before ledger by design.
+explicit selected directory account plus the distinct active unlinked sentinel required for apply
+(inactive rows count too). The dedicated integration passed those gates; using an employee already
+present in another integration still fails before ledger by design.
 
 Apply also requires the literal confirmation
 `DINGTALK_SOURCE_DISABLED_DEDICATED_EXCLUSIVE_CONFIRMED`: the source is disabled, the integration
 is dedicated to the one canary account, and no other operator may sync or edit that integration
-until the apply window has returned all lifecycle flags to OFF. Preview plus the one-account
+until the apply window has returned all lifecycle flags to OFF. Preview plus the exact target-plus-sentinel
 precondition are strong fail-closed gates, but they are not an atomic scope lock; this explicit
 exclusive window is therefore a required operational hold, not an optional note.
 
@@ -159,9 +165,9 @@ The full values-free execution record is `dingtalk-staging-lifecycle-canary-and-
 3. **Complete:** create/repair the dedicated canary administrators and prove password login with all flags OFF.
 4. **Complete:** dispatch `action=alias`; prove transient ON login and required OFF rollback login.
 5. **Complete server-side; browser OAuth NOT EXECUTED:** real admit→SSO activate intent on the explicitly owned employee, with pending rollback to OFF.
-6. **NOT EXECUTED (operator ready, second unique sentinel required):** real source departure and deprovision/restore proof on that same employee, then rollback.
+6. **Complete server-side; browser checkpoints NOT EXECUTED:** real source departure, exact event/effect apply, source re-add, exact restore, sentinel removal, cleared journal, and terminal OFF proof.
 7. Production remains a separate GO.
 
 ## Owner note
 
-Landing this lane does not authorize traffic. Alias and server-side pending staging canaries succeeded and returned to OFF; browser OAuth and destructive deprovision remain incomplete. Merging code and completing staging canaries do not leave any lifecycle flag enabled or authorize production traffic.
+Landing this lane does not authorize traffic. Alias, server-side pending, and server-side deprovision canaries succeeded and returned to OFF. Browser checkpoints, U1-U13, real callback evidence, and production GO remain incomplete. Merging code and completing staging canaries do not leave any lifecycle flag enabled or authorize production traffic.

--- a/docs/development/dingtalk-staging-lifecycle-canary-and-uat-execution-20260811.md
+++ b/docs/development/dingtalk-staging-lifecycle-canary-and-uat-execution-20260811.md
@@ -1,8 +1,8 @@
 # DingTalk staging lifecycle canary and UAT execution record (2026-08-11/12)
 
-- Status: **PARTIAL EXECUTION / ALIAS PASS / PENDING ADMIT + SSO-ACTIVATE INTENT PASS WITH BROWSER OAUTH NOT EXECUTED / DEPROVISION APPLY NOT COMPLETE + TWO SAFE RECOVERIES PASS / U1-U13 NOT EXECUTED**
-- Repository evidence head: `51f23ec7255c3fb0d9abc21bfbe4c3bce8e1c48f`
-- Lifecycle staging deploy SHA: `51f23ec7255c3fb0d9abc21bfbe4c3bce8e1c48f`
+- Status: **STAGING SERVER-SIDE CANARIES COMPLETE / ALIAS PASS / PENDING ADMIT + SSO-ACTIVATE INTENT PASS WITH BROWSER OAUTH NOT EXECUTED / DEPROVISION APPLY + RESTORE PASS / U1-U13 NOT EXECUTED**
+- Repository evidence head: `2bf058c2a4fd5abed76df347b3bfdb74dba148ee`
+- Lifecycle staging deploy SHA: `2bf058c2a4fd5abed76df347b3bfdb74dba148ee`
 - Production-readiness inventory deploy SHA: `24794811b1c800402006b30d6e4fa9df670e124e`
 - Owner instruction: keep all lifecycle flags OFF after every canary; do not convert missing real-enterprise evidence into PASS.
 
@@ -17,8 +17,8 @@ Two independently configured deployment roots were observed and must not be conf
 
 | Evidence lane | Deployed SHA | Purpose |
 |---|---|---|
-| Lifecycle staging canary (`STAGING_DEPLOY_PATH`) | `51f23ec7255c3fb0d9abc21bfbe4c3bce8e1c48f` | Exact lifecycle status, retained-journal recovery, and terminal OFF proof |
-| Production-readiness inventory (`DEPLOY_PATH`) | `24794811b1c800402006b30d6e4fa9df670e124e` | Read-only DingTalk integration, account, Stream, and flag inventory |
+| Lifecycle staging canary (`STAGING_DEPLOY_PATH`) | `2bf058c2a4fd5abed76df347b3bfdb74dba148ee` | Exact lifecycle status, deprovision apply/restore, and terminal OFF proof |
+| Production-readiness inventory (`DEPLOY_PATH`) | `2bf058c2a4fd5abed76df347b3bfdb74dba148ee` | Read-only DingTalk integration, account, Stream, and flag inventory |
 
 The matching code SHA is not used to infer shared runtime state between the two roots; each
 runtime fact below is tied to its own workflow run and artifact. Production enablement remains a
@@ -137,9 +137,19 @@ migrations, and preserved the non-lifecycle staging mode. Recovery run
 [31559371562](https://github.com/zensgit/metasheet2/actions/runs/31559371562) then cleared the retained
 journal only after exact failed-run, zero-ledger, source-active, and unchanged-access-graph proofs.
 Independent read-only status run
-[31559480395](https://github.com/zensgit/metasheet2/actions/runs/31559480395) is the current terminal
-proof: exact deployed SHA, healthy backend, zero pending migrations, mode `off`, all three lifecycle
-flags `false`, and `transition_applied=false`.
+[31559480395](https://github.com/zensgit/metasheet2/actions/runs/31559480395) was the terminal proof for
+that recovery head: exact deployed SHA, healthy backend, zero pending migrations, mode `off`, all
+three lifecycle flags `false`, and `transition_applied=false`.
+
+[#4879](https://github.com/zensgit/metasheet2/pull/4879), merge
+`2bf058c2a4fd5abed76df347b3bfdb74dba148ee`, added the explicit second-sentinel contract. Staging
+deploy [31573166502](https://github.com/zensgit/metasheet2/actions/runs/31573166502) pinned backend
+and web to that exact SHA with `314/0` migrations. Read-only status
+[31573329397](https://github.com/zensgit/metasheet2/actions/runs/31573329397), deprovision preflight
+[31575076447](https://github.com/zensgit/metasheet2/actions/runs/31575076447), and terminal status
+[31576139497](https://github.com/zensgit/metasheet2/actions/runs/31576139497) each reported a healthy
+backend, zero pending migrations, mode `off`, all three lifecycle flags `false`, and
+`transition_applied=false`. The terminal status supersedes the earlier terminal-state proof.
 
 ## 4. Canary sequence
 
@@ -147,7 +157,7 @@ flags `false`, and `transition_applied=false`.
 |---|---|---|---|
 | 1 | alias-only | **PASS, rolled back** | Hardened-deploy run `31529335625`; transient ON was proven by real password login and success required a return to exact OFF |
 | 2 | pending admission | **PASS for admit + SSO activate intent, rolled back; browser OAuth NOT EXECUTED** | Runs `31551343313` and `31551426867` used an explicit owned subject, never auto-selected it, and left lifecycle flags OFF |
-| 3 | deprovision | **ATTEMPTED, NOT COMPLETE** | Empty-source and duplicate-sentinel attempts made no lifecycle mutation; both retained journals were recovered with zero ledger and unchanged access graph. A second unique DingTalk sentinel is still required for a real apply/restore cycle |
+| 3 | deprovision | **PASS server-side, restored and rolled back; browser login/OAuth checkpoints NOT EXECUTED** | Apply run `31575411459` wrote one event and three effects for the explicit target; restore run `31575938536` reversed the exact effect set, restored the access graph, cleared the journal, and kept all lifecycle flags OFF |
 
 ### 4.1 Alias result
 
@@ -194,7 +204,7 @@ successful password-backed administrator login. They do **not** prove browser OA
 post-activation browser OAuth success: both browser checkpoints remain `NOT_EXECUTED`. Pending
 production enablement therefore remains a separate NO-GO decision despite the server-side canary.
 
-### 4.3 Deprovision attempts, recovery, and remaining gate
+### 4.3 Deprovision attempts, recovery, and completed server-side cycle
 
 The earlier read-only directory preview saw no removal candidate and reported zero
 would-deactivate accounts. A later browser inspection showed that the active integration is a
@@ -206,12 +216,12 @@ failed most-recent sync. It cannot be repurposed as the dedicated integration fo
 corp without a separately authorized reconfiguration and valid source credentials.
 
 After Section 4.2 succeeds, an authorized operator must create/use a separate active DingTalk
-integration that contains exactly the selected account (all active and inactive account rows
-count), has scheduler, admission automation, and member-group projection disabled, and uses
-`mark_inactive`. Apply requires
+integration containing exactly the selected linked account plus one distinct active unlinked
+sentinel (all active and inactive account rows count), with scheduler, admission automation, and
+member-group projection disabled, using `mark_inactive`. Apply requires
 `DINGTALK_SOURCE_DISABLED_DEDICATED_EXCLUSIVE_CONFIRMED`, which attests that the source is disabled
 and no other operator will sync or edit this dedicated integration until the lifecycle flags are
-proven OFF. The preview and one-account checks are not an atomic scope lock, so this exclusive
+proven OFF. The preview and exact target-plus-sentinel checks are not an atomic scope lock, so this exclusive
 window is mandatory. The apply sequence then requires an exact one-subject preview and planner result,
 persists a random sync run UUID before env/HTTP, transiently enables only deprovision, and starts
 the async sync with that UUID. A lost 202 or runner crash retains the exact recovery journal;
@@ -222,8 +232,8 @@ An exact run that terminates without a matching ledger event leaves a fail-close
 be resolved through a reason-specific, owner-reviewed recovery path; deleting the journal to force
 a new apply is prohibited.
 
-The dedicated integration and explicit target passed the ownership/exclusivity gates, but a real
-destructive apply/restore cycle is still incomplete:
+The dedicated integration and explicit target passed the ownership/exclusivity gates. Two earlier
+pre-ledger attempts failed safely before the completed cycle:
 
 1. An attempt with only the target removed produced the provider's empty-directory safeguard. No
    event/effect was written and no access-graph row changed. After the source was restored,
@@ -240,18 +250,37 @@ destructive apply/restore cycle is still incomplete:
    source, unchanged access graph, flags OFF, and then cleared the journal. It explicitly reports
    `end_to_end_restore_claimed=false`.
 
-The remaining external prerequisite is a **second dedicated DingTalk employee identity with a real,
-unique phone number that is absent from every other integration**. It is needed only as a temporary
-source sentinel so the provider fetch remains nonempty when the target departs. Reusing an existing
-employee or inventing a phone number is prohibited. After it exists, the controlled sequence is:
-target absent + sentinel present -> apply; target re-added -> restore; sentinel removed; terminal
-status OFF.
+[#4879](https://github.com/zensgit/metasheet2/pull/4879) then added an explicit sentinel secret and
+enforced an exact two-account integration shape: the owned linked target plus one distinct active,
+unlinked sentinel. Three early apply dispatches
+([31574918042](https://github.com/zensgit/metasheet2/actions/runs/31574918042),
+[31575135399](https://github.com/zensgit/metasheet2/actions/runs/31575135399), and
+[31575274256](https://github.com/zensgit/metasheet2/actions/runs/31575274256)) rejected a malformed
+sentinel secret at the UUID-shape gate before lifecycle env or ledger mutation. The operator then
+corrected the secret through stdin without exposing its value.
+
+The controlled source sequence was observed in the DingTalk administrator UI without recording
+identifiers: organization membership remained five; the canary department changed from target plus
+sentinel, to sentinel only for apply, back to both for restore, and finally to the target only after
+the temporary sentinel was removed.
+
+[Apply run 31575411459](https://github.com/zensgit/metasheet2/actions/runs/31575411459) proved the
+exact target-and-sentinel gate, a one-target preview, one deactivated user/account, one ledger event,
+three effects, and a present generation. It then restored all flags to OFF while retaining the
+`ledger_bound` journal and disabled access graph for the explicit restore phase.
+
+[Restore run 31575938536](https://github.com/zensgit/metasheet2/actions/runs/31575938536) synchronized
+the re-added source with deprovision OFF, reversed exactly three effects, proved the event fully
+resolved, restored one active membership and the enabled grant, cleared the journal, and left all
+three lifecycle flags OFF. The artifact deliberately reports password-login and OAuth browser
+checkpoints as `NOT_EXECUTED` and `end_to_end_restore_claimed=false`; this is a real provider sync and
+server-side access-graph apply/restore proof, not a fabricated browser acceptance result.
 
 ## 5. DingTalk directory readiness
 
-[Production-readiness inventory run 31529929612](https://github.com/zensgit/metasheet2/actions/runs/31529929612)
-completed successfully against deployed SHA
-`24794811b1c800402006b30d6e4fa9df670e124e` and reported:
+[Production-readiness inventory run 31579935836](https://github.com/zensgit/metasheet2/actions/runs/31579935836)
+completed successfully after the lifecycle restore against deployed SHA
+`2bf058c2a4fd5abed76df347b3bfdb74dba148ee` and reported:
 
 | Signal | Result |
 |---|---|
@@ -269,9 +298,9 @@ completed successfully against deployed SHA
 | all lifecycle/Stream flags OFF | `true` |
 | log level | ready (`LOG_LEVEL` missing; runtime default is `info`) |
 
-This historical inventory proves a usable directory baseline. The later server-side pending
-canary completed as recorded in Section 4.2; it does not prove browser OAuth or destructive
-deprovision completion, and it is not interactive-card readiness.
+This fresh read-only inventory proves that the usable directory baseline and exact OFF state still
+held after the server-side pending and deprovision canaries recorded in Sections 4.2 and 4.3. It
+does not prove the omitted browser checkpoints and is not interactive-card readiness.
 
 ## 6. U1-U13 and real callback corp-anchor
 
@@ -310,9 +339,11 @@ into this document or chat.
 |---|---|
 | production alias enable | **NO GO** until owner reviews staging evidence and separately authorizes production |
 | production pending enable | **NO GO**; server-side staging admit/activate passed, but browser OAuth checkpoints and owner GO remain incomplete |
-| production deprovision enable | **NO GO**; safe-abort/recovery paths passed, but destructive apply/restore has not completed |
+| production deprovision enable | **NO GO**; staging server-side apply/restore passed, but production still requires a separate owner GO and the remaining real-enterprise/browser acceptance evidence |
 | interactive-card Stream enable | **NO GO**; U1-U13/U11-a not executed |
 | Transfer T3-T5 | **FROZEN**; real two-corp T2-Gate remains separate and unexecuted |
+| lifecycle production-enable owner | **NOT ASSIGNED**; do not infer an owner from repository or staging access |
+| interactive-card UAT owner | **NOT ASSIGNED**; assign before provisioning the missing Stream/template inputs |
 
 The safe terminal state for this execution is therefore:
 
@@ -325,16 +356,13 @@ DINGTALK_INTERACTIVE_CARD_STREAM_ENABLED=false
 
 ## 8. Next executable actions
 
-1. Provision a second dedicated DingTalk sentinel employee with a real unique phone number and add
-   it only to the dedicated canary department/integration.
-2. Execute the destructive deprovision apply/restore sequence, remove the sentinel, and prove exact
-   OFF again. Separately complete the pending browser OAuth checkpoints if production pending is to
-   be considered.
-3. Configure the staging Stream/template inputs, re-confirm the info/debug log level, execute U1-U13 and the
+1. Complete the pending/deprovision browser login/OAuth checkpoints if production lifecycle
+   enablement is to be considered; do not infer them from the server-side results.
+2. Configure the staging Stream/template inputs, re-confirm the info/debug log level, execute U1-U13 and the
    real callback corp-anchor procedure.
-4. Record named owners and explicit production switch decisions. Any absent evidence remains
+3. Record named owners and explicit production switch decisions. Any absent evidence remains
    `NOT EXECUTED`.
 
-Until those external actions occur, the lifecycle code line, alias canary, pending server-side
-canary, and fail-closed deprovision recovery paths are closed. Destructive deprovision/restore,
-production enablement, and real-enterprise acceptance are not.
+The lifecycle code line and all three server-side staging canaries are closed with terminal OFF
+proof. Browser acceptance, production enablement, U1-U13, the real callback corp-anchor, and the
+remaining real-enterprise acceptance are not complete.


### PR DESCRIPTION
## Summary

- record #4879 exact-SHA staging deploy and terminal OFF proof
- record real provider deprovision apply (1 event / 3 effects) and exact restore
- record sentinel source cleanup without exposing identifiers
- preserve browser OAuth, U1-U13, callback corp-anchor, and production GO as NOT EXECUTED / NO GO

## Verification

- apply: Actions run 31575411459
- restore: Actions run 31575938536
- terminal status: Actions run 31576139497
- post-restore production-readiness inventory: Actions run 31579935836
- `git diff --check`
- stale incomplete-status phrase scan: zero matches

Docs-only. No lifecycle flag, credential, identifier, or runtime code change. Auto-merge is not armed.
