### PR TITLE
feat(dingtalk): add controlled Stream staging UAT lane

### DIFF
--- a/.github/workflows/dingtalk-interactive-card-stream-staging-uat.yml
+++ b/.github/workflows/dingtalk-interactive-card-stream-staging-uat.yml
@@ -1,0 +1,353 @@
+name: DingTalk Interactive Card Stream Staging UAT
+
+run-name: "DingTalk Stream Staging UAT: ${{ inputs.action }}"
+
+# Staging-only MINIMAL controlled ops lane for DingTalk interactive-card Stream UAT.
+# One dispatch = ONE action. Stream stays OFF except explicit action=on.
+# Lifecycle flags are NEVER written by this lane.
+#
+# EXECUTABLE: status | prepare | on | off
+#   status  = read-only values-free snapshot (booleans / counts / reason classes)
+#   prepare = transport Stream credentials (chmod-600 files), derive exactly one
+#             active corp-anchored DingTalk integration with >=2 linked local users,
+#             atomically write the four credential/id env keys into
+#             docker/app.staging.env while FORCING Stream flag false, validate,
+#             restart backend only if needed
+#   on      = recheck prerequisites + LOG_LEVEL info/debug, flip ONLY Stream flag
+#             true, restart backend, prove worker_started only (values-free).
+#             Does NOT prove SDK connected (connect resolves + retries forever);
+#             stream_connected stays unknown until real callback UAT.
+#   off     = fail-safe Stream flag false + backend restart + worker stop proof
+#
+# Exact deployed FULL 40-char lowercase SHA required for prepare/on/off.
+# Secrets (prepare only): STAGING_DINGTALK_INTERACTIVE_CARD_CLIENT_ID /
+#   _CLIENT_SECRET / _TEMPLATE_ID — demoted + file transport; never argv/env
+#   persistence beyond the materialize window. Integration id is derived on host.
+#
+# Does NOT implement human U1–U13 clicks. U12/U13 (connect/callback + flag-off
+# human proofs) remain human-gated after action=on; this lane never claims connected.
+#
+# STAGING ONLY + shared concurrency with attendance-staging-window-runner.
+
+on:
+  workflow_dispatch:
+    inputs:
+      action:
+        description: 'status (read-only) | prepare (creds + force Stream OFF) | on (Stream ON) | off (fail-safe Stream OFF)'
+        required: true
+        type: choice
+        # Quote 'on'/'off' — YAML 1.1 bare on/off become booleans.
+        options: [status, prepare, 'on', 'off']
+        default: status
+      deploy_sha:
+        description: 'FULL 40-char lowercase commit SHA currently deployed on staging. Required for prepare/on/off; optional for status exact-match reporting.'
+        required: false
+        default: ''
+
+# Share the attendance staging runner concurrency group so compose/env races
+# cannot interleave on the same staging stack.
+concurrency:
+  group: attendance-staging-window-runner
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate inputs and embedded scripts
+        env:
+          ACTION: ${{ inputs.action }}
+          DEPLOY_SHA: ${{ inputs.deploy_sha }}
+          # Intentionally NO Stream secrets here — presence is checked only in
+          # Run remote action after demoting env → non-exported shell vars + unset
+          # (bash -n and other children must not inherit raw secret env).
+        run: |
+          set -euo pipefail
+          case "$ACTION" in status|prepare|on|off) ;; *)
+            echo "invalid action: $ACTION" >&2; exit 2
+          ;; esac
+
+          # prepare/on/off require exact full SHA.
+          if [[ "$ACTION" == "prepare" || "$ACTION" == "on" || "$ACTION" == "off" ]]; then
+            if [[ ! "$DEPLOY_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+              echo "deploy_sha must be the FULL 40-char lowercase commit SHA for action=${ACTION}, got: '$DEPLOY_SHA'" >&2
+              exit 2
+            fi
+          fi
+
+          if [[ -n "$DEPLOY_SHA" && ! "$DEPLOY_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "deploy_sha must be empty or the FULL 40-char lowercase commit SHA, got: '$DEPLOY_SHA'" >&2
+            exit 2
+          fi
+
+          bash -n scripts/ops/dingtalk-interactive-card-stream-staging-uat-remote.sh
+          echo "inputs and embedded scripts OK"
+
+      - name: Run pipeline self-test (contract suite)
+        run: node --test scripts/ops/dingtalk-interactive-card-stream-staging-uat-contract.test.mjs
+
+      - name: Sync runner scripts to deploy host
+        id: sync
+        env:
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+          DEPLOY_SSH_KEY_B64: ${{ secrets.DEPLOY_SSH_KEY_B64 }}
+          DEPLOY_KNOWN_HOSTS: ${{ secrets.DEPLOY_KNOWN_HOSTS }}
+        run: |
+          set -euo pipefail
+          mkdir -p ~/.ssh
+          [[ -n "$DEPLOY_KNOWN_HOSTS" ]] || { echo "DEPLOY_KNOWN_HOSTS is required" >&2; exit 2; }
+          printf '%s' "$DEPLOY_SSH_KEY_B64" | base64 -d > ~/.ssh/deploy_key
+          decoded_known_hosts="$(printf '%s' "$DEPLOY_KNOWN_HOSTS" | base64 -d 2>/dev/null || true)"
+          if printf '%s' "$decoded_known_hosts" | grep -Eq 'ssh-ed25519|ssh-rsa|ecdsa-sha2|ssh-dss'; then
+            printf '%s\n' "$decoded_known_hosts" > ~/.ssh/known_hosts
+          else
+            printf '%s\n' "$DEPLOY_KNOWN_HOSTS" > ~/.ssh/known_hosts
+          fi
+          grep -Eq 'ssh-ed25519|ssh-rsa|ecdsa-sha2|ssh-dss' ~/.ssh/known_hosts \
+            || { echo "DEPLOY_KNOWN_HOSTS did not resolve to a recognizable key" >&2; exit 2; }
+          chmod 600 ~/.ssh/deploy_key ~/.ssh/known_hosts
+          runner_dir="/tmp/dingtalk-stream-uat-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          echo "runner_dir=$runner_dir" >> "$GITHUB_OUTPUT"
+          tar -czf - \
+            scripts/ops/dingtalk-interactive-card-stream-staging-uat-remote.sh \
+          | ssh -o BatchMode=yes -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes \
+              -o UserKnownHostsFile=~/.ssh/known_hosts -o GlobalKnownHostsFile=/dev/null \
+              -i ~/.ssh/deploy_key \
+              "$DEPLOY_USER@$DEPLOY_HOST" \
+              "bash -o pipefail -c 'set -euo pipefail; rm -rf ${runner_dir}; mkdir -p ${runner_dir}; tar -xzf - -C ${runner_dir} --strip-components=2'"
+
+      - name: Run remote action
+        id: remote
+        continue-on-error: true
+        env:
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+          DEPLOY_PATH: ${{ secrets.DEPLOY_PATH }}
+          STAGING_DEPLOY_PATH: ${{ vars.STAGING_DEPLOY_PATH || 'metasheet2-dingtalk-staging' }}
+          ACTION: ${{ inputs.action }}
+          DEPLOY_SHA: ${{ inputs.deploy_sha }}
+          RUNNER_DIR: ${{ steps.sync.outputs.runner_dir }}
+          # prepare secrets are materialized INSIDE this step under EXIT trap —
+          # never via a prior step secrets_dir output (cross-step leak / cancel).
+          # status/on/off do not receive credential secrets.
+          STAGING_DINGTALK_INTERACTIVE_CARD_CLIENT_ID: ${{ inputs.action == 'prepare' && secrets.STAGING_DINGTALK_INTERACTIVE_CARD_CLIENT_ID || '' }}
+          STAGING_DINGTALK_INTERACTIVE_CARD_CLIENT_SECRET: ${{ inputs.action == 'prepare' && secrets.STAGING_DINGTALK_INTERACTIVE_CARD_CLIENT_SECRET || '' }}
+          STAGING_DINGTALK_INTERACTIVE_CARD_TEMPLATE_ID: ${{ inputs.action == 'prepare' && secrets.STAGING_DINGTALK_INTERACTIVE_CARD_TEMPLATE_ID || '' }}
+        run: |
+          set -euo pipefail
+          # --- SECRET DEMOTE (builtins only; no external child before unset) -------------
+          # GHA injects secrets as exported env for this step. Copy into non-exported
+          # shell variables, then unset the exported names so mktemp/ssh/scp/bash -n
+          # children never inherit raw secret env. Presence checks + printf use the
+          # shell vars only; those are unset immediately after materialize writes.
+          _STREAM_CLIENT_ID="${STAGING_DINGTALK_INTERACTIVE_CARD_CLIENT_ID-}"
+          _STREAM_CLIENT_SECRET="${STAGING_DINGTALK_INTERACTIVE_CARD_CLIENT_SECRET-}"
+          _STREAM_TEMPLATE_ID="${STAGING_DINGTALK_INTERACTIVE_CARD_TEMPLATE_ID-}"
+          unset STAGING_DINGTALK_INTERACTIVE_CARD_CLIENT_ID STAGING_DINGTALK_INTERACTIVE_CARD_CLIENT_SECRET STAGING_DINGTALK_INTERACTIVE_CARD_TEMPLATE_ID
+          # --- end secret demote; external commands allowed after this point ------------
+
+          ssh_opts="-o BatchMode=yes -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes -o UserKnownHostsFile=$HOME/.ssh/known_hosts -o GlobalKnownHostsFile=/dev/null -i $HOME/.ssh/deploy_key"
+          DEPLOY_PATH="${DEPLOY_PATH:-metasheet2}"
+          for pair in "DEPLOY_PATH=$DEPLOY_PATH" "STAGING_DEPLOY_PATH=$STAGING_DEPLOY_PATH"; do
+            value="${pair#*=}"
+            if [[ ! "$value" =~ ^[A-Za-z0-9._/~-]+$ ]]; then
+              echo "refusing unsafe characters in ${pair%%=*}: '$value'" >&2
+              exit 2
+            fi
+          done
+          remote_output_dir="/tmp/dingtalk-stream-uat-out-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          artifact_name="dingtalk-interactive-card-stream-staging-uat-${ACTION}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          echo "artifact_name=$artifact_name" >> "$GITHUB_OUTPUT"
+          mkdir -p output/stream-uat
+
+          # Per-run cleanup targets only. NEVER touch persistent ~/.metasheet2 overrides.
+          CLEAN_LOCAL_SECRETS_DIR=""
+          CLEAN_REMOTE_SECRETS_DIR=""
+          CLEAN_REMOTE_RUNNER_DIR="${RUNNER_DIR}"
+          CLEAN_REMOTE_OUTPUT_DIR="${remote_output_dir}"
+          # OUTPUT_COLLECTED gates whether trap may remove remote_output_dir before scp.
+          OUTPUT_COLLECTED=0
+
+          cleanup_stream_uat_ephemeral_paths() {
+            # Wipe local secret temp dir + per-run remote dirs.
+            # Does not delete persistent stream-uat backups / lifecycle overrides.
+            set +e
+            if [[ -n "${CLEAN_LOCAL_SECRETS_DIR:-}" && -d "${CLEAN_LOCAL_SECRETS_DIR}" ]]; then
+              rm -rf "${CLEAN_LOCAL_SECRETS_DIR}"
+            fi
+            if [[ -n "${DEPLOY_USER:-}" && -n "${DEPLOY_HOST:-}" ]]; then
+              remote_rm=""
+              if [[ -n "${CLEAN_REMOTE_SECRETS_DIR:-}" ]]; then
+                remote_rm="${remote_rm} ${CLEAN_REMOTE_SECRETS_DIR}"
+              fi
+              if [[ -n "${CLEAN_REMOTE_RUNNER_DIR:-}" ]]; then
+                remote_rm="${remote_rm} ${CLEAN_REMOTE_RUNNER_DIR}"
+              fi
+              if [[ "${OUTPUT_COLLECTED}" == "1" && -n "${CLEAN_REMOTE_OUTPUT_DIR:-}" ]]; then
+                remote_rm="${remote_rm} ${CLEAN_REMOTE_OUTPUT_DIR}"
+              fi
+              if [[ -n "${remote_rm// /}" ]]; then
+                # shellcheck disable=SC2086
+                ssh $ssh_opts "$DEPLOY_USER@$DEPLOY_HOST" \
+                  "bash -o pipefail -c 'rm -rf ${remote_rm}'" >/dev/null 2>&1
+              fi
+            fi
+            set -e
+          }
+
+          exit_after_stream_uat_cleanup() {
+            local signal_rc="$1"
+            trap - EXIT HUP INT TERM
+            cleanup_stream_uat_ephemeral_paths
+            exit "$signal_rc"
+          }
+
+          trap cleanup_stream_uat_ephemeral_paths EXIT
+          trap 'exit_after_stream_uat_cleanup 129' HUP
+          trap 'exit_after_stream_uat_cleanup 130' INT
+          trap 'exit_after_stream_uat_cleanup 143' TERM
+
+          remote_secrets_dir=""
+          stream_client_id_export=""
+          stream_client_secret_export=""
+          stream_template_id_export=""
+          if [[ "$ACTION" == "prepare" ]]; then
+            # Traps are installed before any secret materialization (mktemp/write/chmod).
+            if [[ -z "${_STREAM_CLIENT_ID}" || -z "${_STREAM_CLIENT_SECRET}" || -z "${_STREAM_TEMPLATE_ID}" ]]; then
+              echo "prepare requires STAGING_DINGTALK_INTERACTIVE_CARD_CLIENT_ID/CLIENT_SECRET/TEMPLATE_ID (checked in Run remote action only); never log secret" >&2
+              unset _STREAM_CLIENT_ID _STREAM_CLIENT_SECRET _STREAM_TEMPLATE_ID
+              exit 2
+            fi
+            secrets_dir="$(mktemp -d "${RUNNER_TEMP}/stream-uat-secrets.XXXXXX")"
+            CLEAN_LOCAL_SECRETS_DIR="${secrets_dir}"
+            chmod 700 "$secrets_dir"
+            umask 077
+            # Exact secret bytes from non-exported shell vars — printf '%s' preserves payload.
+            printf '%s' "${_STREAM_CLIENT_ID}" > "${secrets_dir}/client.id"
+            printf '%s' "${_STREAM_CLIENT_SECRET}" > "${secrets_dir}/client.secret"
+            printf '%s' "${_STREAM_TEMPLATE_ID}" > "${secrets_dir}/template.id"
+            # Drop shell-held secret values as soon as files are written.
+            unset _STREAM_CLIENT_ID _STREAM_CLIENT_SECRET _STREAM_TEMPLATE_ID
+            chmod 600 "${secrets_dir}/client.id" "${secrets_dir}/client.secret" "${secrets_dir}/template.id"
+            for f in client.id client.secret template.id; do
+              [[ -s "${secrets_dir}/${f}" ]] || { echo "secret file empty after materialize: ${f}" >&2; exit 2; }
+            done
+            remote_secrets_dir="${RUNNER_DIR}/.stream-uat-secrets"
+            CLEAN_REMOTE_SECRETS_DIR="${remote_secrets_dir}"
+            ssh $ssh_opts "$DEPLOY_USER@$DEPLOY_HOST" \
+              "bash -o pipefail -c 'set -euo pipefail; mkdir -p ${remote_secrets_dir}; chmod 700 ${remote_secrets_dir}'"
+            scp $ssh_opts \
+              "${secrets_dir}/client.id" \
+              "${secrets_dir}/client.secret" \
+              "${secrets_dir}/template.id" \
+              "$DEPLOY_USER@$DEPLOY_HOST:${remote_secrets_dir}/"
+            ssh $ssh_opts "$DEPLOY_USER@$DEPLOY_HOST" \
+              "bash -o pipefail -c 'set -euo pipefail; chmod 600 ${remote_secrets_dir}/client.id ${remote_secrets_dir}/client.secret ${remote_secrets_dir}/template.id'"
+            stream_client_id_export="export STREAM_CLIENT_ID_FILE='${remote_secrets_dir}/client.id'"
+            stream_client_secret_export="export STREAM_CLIENT_SECRET_FILE='${remote_secrets_dir}/client.secret'"
+            stream_template_id_export="export STREAM_TEMPLATE_ID_FILE='${remote_secrets_dir}/template.id'"
+          else
+            unset _STREAM_CLIENT_ID _STREAM_CLIENT_SECRET _STREAM_TEMPLATE_ID
+          fi
+
+          remote_script="set -euo pipefail
+          export ACTION='${ACTION}'
+          export DEPLOY_SHA='${DEPLOY_SHA}'
+          export STAGING_DEPLOY_PATH='${STAGING_DEPLOY_PATH}'
+          export DEPLOY_PATH='${DEPLOY_PATH}'
+          export OUTPUT_DIR='${remote_output_dir}'
+          export RUN_STAMP='gh${GITHUB_RUN_ID}a${GITHUB_RUN_ATTEMPT}'
+          ${stream_client_id_export}
+          ${stream_client_secret_export}
+          ${stream_template_id_export}
+          rm -rf '${remote_output_dir}'
+          mkdir -p '${remote_output_dir}'
+          set +e
+          bash '${RUNNER_DIR}/dingtalk-interactive-card-stream-staging-uat-remote.sh'
+          remote_action_rc=\$?
+          set -e
+          # Best-effort in-script secret wipe; EXIT trap also removes secrets/runner.
+          if [[ -n '${remote_secrets_dir}' ]]; then rm -rf '${remote_secrets_dir}'; fi
+          exit \"\${remote_action_rc}\""
+          escaped_script="$(printf '%s' "$remote_script" | sed "s/'/'\\\\''/g")"
+
+          set +e
+          ssh $ssh_opts "$DEPLOY_USER@$DEPLOY_HOST" "bash -o pipefail -c '${escaped_script}'" 2>&1 \
+            | tee output/stream-uat/ssh.log
+          rc=${PIPESTATUS[0]}
+          scp $ssh_opts -r "$DEPLOY_USER@$DEPLOY_HOST:${remote_output_dir}/." output/stream-uat/ 2>&1 \
+            | tee -a output/stream-uat/ssh.log
+          scp_rc=${PIPESTATUS[0]}
+          # Mark collected so EXIT trap may remove remote_output_dir (per-run only).
+          OUTPUT_COLLECTED=1
+          # Explicit cleanup (also covered by trap). NEVER touch persistent overrides.
+          ssh $ssh_opts "$DEPLOY_USER@$DEPLOY_HOST" \
+            "bash -o pipefail -c 'rm -rf ${remote_output_dir} ${RUNNER_DIR}'" \
+            >> output/stream-uat/ssh.log 2>&1
+          set -e
+
+          if [[ "$rc" == "0" && "$scp_rc" != "0" ]]; then
+            rc="$scp_rc"
+          fi
+          echo "remote_rc=$rc" >> "$GITHUB_OUTPUT"
+          exit 0
+
+      - name: Write step summary
+        if: always()
+        env:
+          REMOTE_RC: ${{ steps.remote.outputs.remote_rc }}
+          ARTIFACT_NAME: ${{ steps.remote.outputs.artifact_name }}
+          ACTION: ${{ inputs.action }}
+          DEPLOY_SHA: ${{ inputs.deploy_sha }}
+        run: |
+          set -euo pipefail
+          {
+            echo "## DingTalk Interactive Card Stream Staging UAT"
+            echo ""
+            echo "- Action: \`${ACTION}\`"
+            echo "- Deploy SHA: \`${DEPLOY_SHA:-<none>}\`"
+            echo "- Remote rc: \`${REMOTE_RC:-missing}\`"
+            echo "- Artifact: \`${ARTIFACT_NAME:-missing}\`"
+            echo ""
+            echo "**Executable:** status / prepare / on / off."
+            echo "prepare forces Stream OFF after writing credentials + derived integration id."
+            echo "on flips ONLY Stream flag true after prerequisite + LOG_LEVEL checks; proves worker_started only."
+            echo "stream_connected is always unknown here (SDK connect resolves + retries forever; not log-proven)."
+            echo "off is fail-safe Stream OFF + worker stop proof."
+            echo "Lifecycle flags are never written by this lane."
+            echo "Does not implement human U1–U13 clicks; U12/U13 remain human-gated."
+            echo "Artifacts are values-free (booleans / counts / reason classes / SHA only)."
+            if [[ -f output/stream-uat/summary.txt ]]; then
+              echo ""
+              echo '```text'
+              cat output/stream-uat/summary.txt
+              echo '```'
+            fi
+            if [[ -f output/stream-uat/stream-uat-status.txt ]]; then
+              echo ""
+              echo "### Status (values-free)"
+              echo '```text'
+              cat output/stream-uat/stream-uat-status.txt
+              echo '```'
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.remote.outputs.artifact_name || format('dingtalk-interactive-card-stream-staging-uat-{0}-{1}-{2}', inputs.action, github.run_id, github.run_attempt) }}
+          retention-days: 30
+          path: output/stream-uat
+
+      - name: Fail on remote error
+        if: steps.remote.outputs.remote_rc != '0'
+        run: exit 1

--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -193,6 +193,7 @@ jobs:
         if: matrix.node-version == '20.x'
         run: |
           node --test scripts/ops/dingtalk-production-readiness-inventory-contract.test.mjs
+          node --test scripts/ops/dingtalk-interactive-card-stream-staging-uat-contract.test.mjs
           node --test scripts/ops/dingtalk-oauth-stability-workflow-contract.test.mjs
 
       # REVIEW NIT-2 (exact-head round): these two suites already ran in `k3wise-offline-poc`, but

--- a/plugins/plugin-integration-core/lib/sealed-export/vectors/s6a-package-provenance-pins.json
+++ b/plugins/plugin-integration-core/lib/sealed-export/vectors/s6a-package-provenance-pins.json
@@ -86,6 +86,6 @@
     "s6aAcceptancePs51Test": "835c7c6ce943d82e0378a40a27c7fd1e8b79b526faa8ca4c8066e4231a4bfb0f",
     "s6aProductRuntimeTest": "de978adafa8b89772cefa921c2051f434bf346bf5c2978bef3424ee70f51ba3f",
     "multitableOnpremPackageBuild": "ae477a24375a7269e5710a3481905c9b74255c03fd802841a16849aca48ee33a",
-    "pluginTestsWorkflow": "6e6653d6cdb102330da32cacd10f12fb842111a3e23675857474068421ea5faa"
+    "pluginTestsWorkflow": "22e0eaa828d6d257ed3130060ab144aa92d6fe9e2b57b74111bec1143555a282"
   }
 }

--- a/scripts/ops/dingtalk-interactive-card-stream-staging-uat-contract.test.mjs
+++ b/scripts/ops/dingtalk-interactive-card-stream-staging-uat-contract.test.mjs
@@ -1,0 +1,837 @@
+#!/usr/bin/env node
+// dingtalk-interactive-card-stream-staging-uat-contract.test.mjs
+//
+// Durable synthetic contract for the MINIMAL controlled Stream staging UAT lane:
+//   EXECUTABLE: status | prepare | on | off
+//
+// Load-bearing rails:
+//   * workflow wiring (dispatch choices, SSH, concurrency, no schedule)
+//   * exact-SHA gate for prepare/on/off
+//   * secret demotion + chmod-600 file transport (prepare only)
+//   * prepare forces Stream OFF while writing four credential/id keys
+//   * on flips only Stream flag true after LOG_LEVEL + prerequisite checks
+//   * off is fail-safe Stream OFF + worker stop proof
+//   * no echo of secrets / raw IDs / PII
+//   * status is read-only (no env writes, no flag flips)
+//   * lifecycle flags never written true by this lane
+//
+// No network, no secrets, no workflow execution.
+
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { createRequire } from 'node:module'
+import { fileURLToPath } from 'node:url'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const REPO_ROOT = join(HERE, '..', '..')
+const REMOTE_SH = join(HERE, 'dingtalk-interactive-card-stream-staging-uat-remote.sh')
+const WORKFLOW = join(
+  REPO_ROOT,
+  '.github',
+  'workflows',
+  'dingtalk-interactive-card-stream-staging-uat.yml',
+)
+const ATTENDANCE_WORKFLOW = join(
+  REPO_ROOT,
+  '.github',
+  'workflows',
+  'attendance-staging-window-runner.yml',
+)
+const LIFECYCLE_WORKFLOW = join(
+  REPO_ROOT,
+  '.github',
+  'workflows',
+  'dingtalk-lifecycle-staging-canary.yml',
+)
+const PLUGIN_TESTS_WORKFLOW = join(REPO_ROOT, '.github', 'workflows', 'plugin-tests.yml')
+
+function read(path) {
+  return readFileSync(path, 'utf8')
+}
+
+function loadYaml(text) {
+  const require = createRequire(import.meta.url)
+  const candidates = [
+    () => require('js-yaml'),
+    () => require(join(REPO_ROOT, 'node_modules/js-yaml')),
+    () => require(join(REPO_ROOT, 'packages/openapi/node_modules/js-yaml')),
+  ]
+  for (const load of candidates) {
+    try {
+      return load().load(text)
+    } catch {
+      // try next
+    }
+  }
+  const py = spawnSync(
+    'python3',
+    ['-c', 'import sys,yaml,json; print(json.dumps(yaml.safe_load(sys.stdin.read())))'],
+    { input: text, encoding: 'utf8' },
+  )
+  if (py.status !== 0) {
+    throw new Error(`YAML parse failed: ${py.stderr || py.stdout}`)
+  }
+  return JSON.parse(py.stdout)
+}
+
+/** GitHub Actions `on:` is boolean true under YAML 1.1. */
+function workflowOn(doc) {
+  return doc.on ?? doc.true ?? doc[true]
+}
+
+function actionBody(source, name, nextNames = []) {
+  const start = source.indexOf(`${name}()`)
+  assert.notEqual(start, -1, `${name}() must exist`)
+  let end = source.length
+  for (const next of nextNames) {
+    const idx = source.indexOf(`\n${next}()`, start + 1)
+    if (idx !== -1 && idx < end) end = idx
+  }
+  const mainIdx = source.indexOf('\n# --- main', start + 1)
+  if (mainIdx !== -1 && mainIdx < end) end = mainIdx
+  return source.slice(start, end)
+}
+
+// --- parse / presence -----------------------------------------------------------------
+
+test('remote script and workflow files exist', () => {
+  assert.ok(existsSync(REMOTE_SH))
+  assert.ok(existsSync(WORKFLOW))
+})
+
+test('embedded remote script parses (bash -n)', () => {
+  const result = spawnSync('bash', ['-n', REMOTE_SH], { encoding: 'utf8' })
+  assert.equal(result.status, 0, result.stderr)
+})
+
+test('workflow YAML parses with repository-available parser', () => {
+  const doc = loadYaml(read(WORKFLOW))
+  assert.equal(doc.name, 'DingTalk Interactive Card Stream Staging UAT')
+  assert.ok(workflowOn(doc)?.workflow_dispatch?.inputs?.action)
+  assert.ok(doc.jobs?.run)
+})
+
+// --- workflow wiring ------------------------------------------------------------------
+
+test('workflow action choices are status/prepare/on/off with status default', () => {
+  const doc = loadYaml(read(WORKFLOW))
+  const inputs = workflowOn(doc).workflow_dispatch.inputs
+  assert.deepEqual(inputs.action.options, ['status', 'prepare', 'on', 'off'])
+  assert.equal(inputs.action.default, 'status')
+  // Quote on/off so YAML 1.1 keeps strings (loadYaml may coerce bare on/off).
+  const yaml = read(WORKFLOW)
+  assert.match(yaml, /options:\s*\[status,\s*prepare,\s*'on',\s*'off'\]/)
+  assert.ok(
+    inputs.action.options.every((o) => typeof o === 'string'),
+    'on/off must remain strings after parse',
+  )
+})
+
+test('workflow is manual-only (no schedule/push/pull_request)', () => {
+  const yaml = read(WORKFLOW)
+  const doc = loadYaml(yaml)
+  const on = workflowOn(doc)
+  assert.ok(on.workflow_dispatch)
+  assert.equal(on.schedule, undefined)
+  assert.equal(on.push, undefined)
+  assert.equal(on.pull_request, undefined)
+  assert.doesNotMatch(yaml, /schedule:/)
+  assert.doesNotMatch(yaml, /cron:/)
+})
+
+test('workflow shares concurrency with attendance staging runner and lifecycle lane', () => {
+  const stream = loadYaml(read(WORKFLOW))
+  const attendance = loadYaml(read(ATTENDANCE_WORKFLOW))
+  const lifecycle = loadYaml(read(LIFECYCLE_WORKFLOW))
+  assert.equal(stream.concurrency.group, attendance.concurrency.group)
+  assert.equal(stream.concurrency.group, lifecycle.concurrency.group)
+  assert.equal(stream.concurrency.group, 'attendance-staging-window-runner')
+  assert.equal(stream.concurrency['cancel-in-progress'], false)
+})
+
+test('workflow remote commands use bash -o pipefail -c; SSH pins known_hosts', () => {
+  const yaml = read(WORKFLOW)
+  assert.ok((yaml.match(/bash -o pipefail -c/g) || []).length >= 2)
+  assert.doesNotMatch(yaml, /bash\s+-s\b/)
+  assert.match(yaml, /DEPLOY_KNOWN_HOSTS/)
+  assert.match(yaml, /StrictHostKeyChecking=yes/)
+  assert.match(yaml, /UserKnownHostsFile=/)
+  assert.match(yaml, /GlobalKnownHostsFile=\/dev\/null/)
+  assert.match(yaml, /BatchMode=yes/)
+  assert.match(yaml, /IdentitiesOnly=yes/)
+  assert.doesNotMatch(yaml, /StrictHostKeyChecking=no/)
+})
+
+test('workflow Validate inputs runs bash -n on remote script and self-test step exists', () => {
+  const doc = loadYaml(read(WORKFLOW))
+  const validate = doc.jobs.run.steps.find((s) => s.name === 'Validate inputs and embedded scripts')
+  assert.ok(validate?.run)
+  assert.match(validate.run, /bash -n scripts\/ops\/dingtalk-interactive-card-stream-staging-uat-remote\.sh/)
+  const selfTest = doc.jobs.run.steps.find((s) => s.name === 'Run pipeline self-test (contract suite)')
+  assert.ok(selfTest?.run)
+  assert.match(
+    selfTest.run,
+    /node --test scripts\/ops\/dingtalk-interactive-card-stream-staging-uat-contract\.test\.mjs/,
+  )
+})
+
+test('contract suite is wired into the required Node 20 plugin-tests lane', () => {
+  const doc = loadYaml(read(PLUGIN_TESTS_WORKFLOW))
+  const requiredJob = doc.jobs?.test
+  assert.ok(requiredJob, 'plugin-tests test job must exist')
+  const step = requiredJob.steps?.find(
+    (candidate) => candidate.id === 'dingtalk-production-readiness-inventory-contract',
+  )
+  assert.ok(step?.run, 'required DingTalk contract step must exist')
+  assert.equal(step.if, "matrix.node-version == '20.x'")
+  assert.match(
+    step.run,
+    /node --test scripts\/ops\/dingtalk-interactive-card-stream-staging-uat-contract\.test\.mjs/,
+  )
+})
+
+// --- exact-SHA gate -------------------------------------------------------------------
+
+test('workflow exact-SHA gate requires full 40-char deploy_sha for prepare/on/off', () => {
+  const yaml = read(WORKFLOW)
+  const doc = loadYaml(yaml)
+  const validate = doc.jobs.run.steps.find((s) => s.name === 'Validate inputs and embedded scripts')
+  assert.equal(validate.env.DEPLOY_SHA, '${{ inputs.deploy_sha }}')
+  assert.match(validate.run, /ACTION" == "prepare" \|\| "\$ACTION" == "on" \|\| "\$ACTION" == "off"/)
+  assert.match(
+    validate.run,
+    /deploy_sha must be the FULL 40-char lowercase commit SHA for action=\$\{ACTION\}/,
+  )
+  assert.match(validate.run, /\^\[0-9a-f\]\{40\}\$/)
+  // status may omit deploy_sha
+  assert.doesNotMatch(
+    validate.run,
+    /deploy_sha must be the FULL 40-char lowercase commit SHA for action=status/,
+  )
+})
+
+test('remote script require_exact_deployed_sha used by prepare/on/off and not status-only path', () => {
+  const source = read(REMOTE_SH)
+  assert.match(source, /require_exact_deployed_sha/)
+  assert.match(source, /resolve_deployed_sha/)
+  const prepare = actionBody(source, 'action_prepare', ['action_on'])
+  const on = actionBody(source, 'action_on', ['action_off'])
+  const off = actionBody(source, 'action_off')
+  const status = actionBody(source, 'action_status', ['action_prepare'])
+  assert.match(prepare, /require_exact_deployed_sha/)
+  assert.match(on, /require_exact_deployed_sha/)
+  assert.match(off, /require_exact_deployed_sha/)
+  assert.doesNotMatch(status, /require_exact_deployed_sha/)
+})
+
+// --- secret demotion ------------------------------------------------------------------
+
+test('workflow Validate inputs does not receive Stream credential secrets', () => {
+  const doc = loadYaml(read(WORKFLOW))
+  const validate = doc.jobs.run.steps.find((s) => s.name === 'Validate inputs and embedded scripts')
+  assert.ok(validate?.env)
+  assert.equal(validate.env.STAGING_DINGTALK_INTERACTIVE_CARD_CLIENT_ID, undefined)
+  assert.equal(validate.env.STAGING_DINGTALK_INTERACTIVE_CARD_CLIENT_SECRET, undefined)
+  assert.equal(validate.env.STAGING_DINGTALK_INTERACTIVE_CARD_TEMPLATE_ID, undefined)
+  assert.doesNotMatch(validate.run, /STAGING_DINGTALK_INTERACTIVE_CARD_CLIENT/)
+})
+
+test('workflow materializes prepare secrets inside Run remote action under EXIT trap with demotion', () => {
+  const yaml = read(WORKFLOW)
+  const doc = loadYaml(yaml)
+  const steps = doc.jobs.run.steps
+  for (const step of steps) {
+    const name = String(step.name || '')
+    assert.doesNotMatch(name, /^Materialize/i)
+  }
+  assert.doesNotMatch(yaml, /id:\s*secrets\b/)
+  assert.doesNotMatch(yaml, /steps\.secrets\.outputs/)
+
+  const remoteStep = steps.find((s) => s.name === 'Run remote action')
+  assert.ok(remoteStep?.run)
+  assert.ok(remoteStep.env)
+  assert.ok(remoteStep.env.STAGING_DINGTALK_INTERACTIVE_CARD_CLIENT_ID)
+  assert.ok(remoteStep.env.STAGING_DINGTALK_INTERACTIVE_CARD_CLIENT_SECRET)
+  assert.ok(remoteStep.env.STAGING_DINGTALK_INTERACTIVE_CARD_TEMPLATE_ID)
+  // Conditional injection: prepare only.
+  assert.match(
+    String(remoteStep.env.STAGING_DINGTALK_INTERACTIVE_CARD_CLIENT_ID),
+    /inputs\.action == 'prepare'/,
+  )
+
+  const runLines = String(remoteStep.run).split('\n')
+  let sawSet = false
+  let sawEnvUnset = false
+  const linesBetweenSetAndEnvUnset = []
+  for (const line of runLines) {
+    const t = line.trim()
+    if (!sawSet) {
+      if (t === 'set -euo pipefail') {
+        sawSet = true
+      }
+      continue
+    }
+    if (
+      t.startsWith(
+        'unset STAGING_DINGTALK_INTERACTIVE_CARD_CLIENT_ID STAGING_DINGTALK_INTERACTIVE_CARD_CLIENT_SECRET STAGING_DINGTALK_INTERACTIVE_CARD_TEMPLATE_ID',
+      )
+    ) {
+      sawEnvUnset = true
+      break
+    }
+    linesBetweenSetAndEnvUnset.push(t)
+  }
+  assert.equal(sawSet, true)
+  assert.equal(sawEnvUnset, true, 'must unset exported secret env names early')
+  const demoteCode = linesBetweenSetAndEnvUnset.filter((t) => t && !t.startsWith('#'))
+  assert.deepEqual(
+    demoteCode,
+    [
+      '_STREAM_CLIENT_ID="${STAGING_DINGTALK_INTERACTIVE_CARD_CLIENT_ID-}"',
+      '_STREAM_CLIENT_SECRET="${STAGING_DINGTALK_INTERACTIVE_CARD_CLIENT_SECRET-}"',
+      '_STREAM_TEMPLATE_ID="${STAGING_DINGTALK_INTERACTIVE_CARD_TEMPLATE_ID-}"',
+    ],
+    'only demote assignments (builtins) before secret env unset — no external commands',
+  )
+
+  assert.match(remoteStep.run, /trap cleanup_stream_uat_ephemeral_paths EXIT/)
+  assert.match(remoteStep.run, /trap 'exit_after_stream_uat_cleanup 129' HUP/)
+  assert.match(remoteStep.run, /trap 'exit_after_stream_uat_cleanup 130' INT/)
+  assert.match(remoteStep.run, /trap 'exit_after_stream_uat_cleanup 143' TERM/)
+  assert.match(
+    remoteStep.run,
+    /exit_after_stream_uat_cleanup\(\) \{[\s\S]*trap - EXIT HUP INT TERM[\s\S]*cleanup_stream_uat_ephemeral_paths[\s\S]*exit "\$signal_rc"/,
+  )
+  assert.match(remoteStep.run, /mktemp -d/)
+  assert.match(remoteStep.run, /chmod 600/)
+  assert.match(remoteStep.run, /printf '%s' "\$\{_STREAM_CLIENT_ID\}"/)
+  assert.match(remoteStep.run, /printf '%s' "\$\{_STREAM_CLIENT_SECRET\}"/)
+  assert.match(remoteStep.run, /printf '%s' "\$\{_STREAM_TEMPLATE_ID\}"/)
+  assert.match(remoteStep.run, /unset _STREAM_CLIENT_ID _STREAM_CLIENT_SECRET _STREAM_TEMPLATE_ID/)
+  assert.match(remoteStep.run, /STREAM_CLIENT_ID_FILE=/)
+  assert.match(remoteStep.run, /STREAM_CLIENT_SECRET_FILE=/)
+  assert.match(remoteStep.run, /STREAM_TEMPLATE_ID_FILE=/)
+  assert.match(remoteStep.run, /scp \$ssh_opts/)
+  // Never export raw secret values into remote script env.
+  assert.doesNotMatch(remoteStep.run, /export STAGING_DINGTALK_INTERACTIVE_CARD_CLIENT_ID=/)
+  assert.doesNotMatch(remoteStep.run, /export STAGING_DINGTALK_INTERACTIVE_CARD_CLIENT_SECRET=/)
+  assert.doesNotMatch(remoteStep.run, /export STAGING_DINGTALK_INTERACTIVE_CARD_TEMPLATE_ID=/)
+  assert.doesNotMatch(remoteStep.run, /export STREAM_CLIENT_ID=/)
+  assert.doesNotMatch(remoteStep.run, /export STREAM_CLIENT_SECRET=/)
+})
+
+// --- prepare forces off ---------------------------------------------------------------
+
+test('remote prepare forces Stream flag false and writes four credential/id env keys', () => {
+  const source = read(REMOTE_SH)
+  const prepare = actionBody(source, 'action_prepare', ['action_on'])
+  assert.match(prepare, /atomic_upsert_env_keys_from_files/)
+  assert.match(prepare, /@literal:false/)
+  assert.match(prepare, /DINGTALK_INTERACTIVE_CARD_CLIENT_ID|KEY_CLIENT_ID/)
+  assert.match(prepare, /KEY_CLIENT_SECRET|DINGTALK_INTERACTIVE_CARD_CLIENT_SECRET/)
+  assert.match(prepare, /KEY_TEMPLATE_ID|DINGTALK_INTERACTIVE_CARD_TEMPLATE_ID/)
+  assert.match(prepare, /KEY_STREAM_INTEGRATION_ID|DINGTALK_INTERACTIVE_CARD_STREAM_INTEGRATION_ID/)
+  assert.match(prepare, /FLAG_STREAM|DINGTALK_INTERACTIVE_CARD_STREAM_ENABLED/)
+  assert.match(prepare, /derive_exact_integration_id_file/)
+  assert.match(prepare, /prepare must leave stream flag false/)
+  assert.match(prepare, /backend_needs_restart_for_prepare|backend restart/)
+  // Must not set stream true in prepare.
+  assert.doesNotMatch(prepare, /atomic_set_stream_flag\s+"true"/)
+  assert.doesNotMatch(prepare, /@literal:true/)
+})
+
+test('prepare refuses a live Stream worker instead of relying on a fallible restart to stop it', () => {
+  const source = read(REMOTE_SH)
+  const prepare = actionBody(source, 'action_prepare', ['action_on'])
+  const readIdx = prepare.indexOf('read_flag_from_container "$FLAG_STREAM"')
+  const offGuardIdx = prepare.indexOf('[[ "$pre_flag" == "false" ]]')
+  const writeIdx = prepare.indexOf('atomic_upsert_env_keys_from_files')
+  assert.ok(readIdx >= 0, 'prepare must read the live Stream flag')
+  assert.ok(offGuardIdx > readIdx, 'prepare must require the live flag to be false')
+  assert.ok(writeIdx > offGuardIdx, 'the OFF precondition must run before any credential write')
+  assert.match(prepare, /run action=off first/)
+})
+
+test('remote prepare derives exactly one active corp-anchored integration with >=2 linked users', () => {
+  const source = read(REMOTE_SH)
+  assert.match(source, /exactly one active DingTalk integration with nonempty corp_id/)
+  assert.match(source, />=2 active linked local users/)
+  assert.match(source, /count\(DISTINCT u\.id\)/)
+  assert.match(source, /provider = 'dingtalk'/)
+  assert.match(source, /status = 'active'/)
+  assert.match(source, /corp_id IS NOT NULL/)
+  assert.match(source, /chmod 600 "\$id_tmp"/)
+  // Never log integration id value.
+  assert.doesNotMatch(source, /log ".*integration_id=\$/)
+  assert.doesNotMatch(source, /echo .*\$id_val/)
+})
+
+// --- on / off behavior ----------------------------------------------------------------
+
+test('remote on rechecks prerequisites, requires LOG_LEVEL info/debug, flips only Stream true', () => {
+  const source = read(REMOTE_SH)
+  const on = actionBody(source, 'action_on', ['action_off'])
+  assert.match(on, /require_log_level_info_or_debug/)
+  assert.match(on, /require_stream_prerequisites_for_on/)
+  assert.match(on, /require_lifecycle_flags_off/)
+  assert.match(on, /atomic_set_stream_flag\s+"true"/)
+  assert.match(on, /recreate_backend_only/)
+  assert.match(on, /wait_for_worker_started/)
+  // on proves worker_started only; never claims SDK connected from startup logs.
+  assert.match(on, /worker_started only/)
+  assert.match(on, /stream_connected=\$\{STREAM_CONNECTED_UNKNOWN\}|stream_connected=unknown/)
+  assert.match(on, /u12_u13_human_gated=true/)
+  assert.doesNotMatch(on, /stream_connected=true/)
+  assert.doesNotMatch(on, /worker connected|SDK connected|connection proven/i)
+  // Must not write lifecycle flags.
+  assert.doesNotMatch(on, /AUTH_LOGIN_USE_ALIASES=true/)
+  assert.doesNotMatch(on, /DIRECTORY_PENDING_ACTIVATION_ENABLED=true/)
+  assert.doesNotMatch(on, /DIRECTORY_DEPROVISION_ENABLED=true/)
+  // Must not rewrite credential keys on on path.
+  assert.doesNotMatch(on, /atomic_upsert_env_keys_from_files/)
+})
+
+test('action=on arms fatal-signal fail-safe Stream OFF rollback before atomic_set true (load-bearing)', () => {
+  // P1 mutation surface: post-write failures must not leave Stream ON.
+  // Arm BEFORE atomic_set true; disarm ONLY after all post-write checks + artifact.
+  // Signal trap must exit (not return/continue). Rollback: disk flag false + recreate.
+  const source = read(REMOTE_SH)
+  const on = actionBody(source, 'action_on', ['action_off'])
+
+  // Arm helpers exist and perform force-off + recreate.
+  assert.match(source, /arm_stream_on_fail_safe_rollback/)
+  assert.match(source, /disarm_stream_on_fail_safe_rollback/)
+  assert.match(source, /stream_on_fail_safe_rollback/)
+  assert.match(source, /STREAM_ON_ROLLBACK_ARMED/)
+
+  const rollbackStart = source.indexOf('stream_on_fail_safe_rollback()')
+  assert.notEqual(rollbackStart, -1)
+  const rollbackEnd = source.indexOf('\narm_stream_on_fail_safe_rollback()', rollbackStart)
+  assert.notEqual(rollbackEnd, -1)
+  const rollbackBody = source.slice(rollbackStart, rollbackEnd)
+  assert.match(rollbackBody, /atomic_set_stream_flag\s+"false"/)
+  assert.match(rollbackBody, /recreate_backend_only/)
+  assert.match(rollbackBody, /on_fail_safe_rollback=/)
+  assert.match(rollbackBody, /STREAM_ON_ROLLBACK_DONE/)
+
+  // Trap wiring includes SSH disconnect signals; forbid return-only cleanup_ephemeral.
+  assert.doesNotMatch(source, /^[ \t]*trap[ \t]+cleanup_ephemeral\b/m)
+  assert.doesNotMatch(source, /^[ \t]*trap[ \t]+['"]cleanup_ephemeral['"]/m)
+  assert.match(source, /trap 'on_script_trap EXIT' EXIT/)
+  assert.match(source, /trap 'on_script_trap HUP' HUP/)
+  assert.match(source, /trap 'on_script_trap INT' INT/)
+  assert.match(source, /trap 'on_script_trap TERM' TERM/)
+  assert.match(source, /on_script_trap PIPE' PIPE/)
+  const trapStart = source.indexOf('on_script_trap()')
+  assert.notEqual(trapStart, -1)
+  const trapEnd = source.indexOf("\ntrap 'on_script_trap EXIT'", trapStart)
+  assert.notEqual(trapEnd, -1)
+  const trapBody = source.slice(trapStart, trapEnd)
+  assert.match(trapBody, /stream_on_fail_safe_rollback/)
+  assert.match(trapBody, /cleanup_ephemeral/)
+  // $? must be captured BEFORE any other command (including local reason=...).
+  // Otherwise saved_rc becomes 0 and EXIT can turn a failed on action green.
+  assert.match(
+    trapBody,
+    /on_script_trap\(\)\s*\{\s*\n\s*local saved_rc=\$\?/,
+    'on_script_trap must capture $? as the first statement',
+  )
+  const savedRcIdx = trapBody.indexOf('local saved_rc=$?')
+  const reasonIdx = trapBody.indexOf('local reason=')
+  assert.ok(savedRcIdx >= 0 && reasonIdx > savedRcIdx, 'saved_rc=$? must precede local reason=')
+  // Fatal signals must exit so main cannot continue after connection loss.
+  assert.match(trapBody, /exit 129/)
+  assert.match(trapBody, /exit 130/)
+  assert.match(trapBody, /exit 141/)
+  assert.match(trapBody, /exit 143/)
+  assert.match(trapBody, /HUP\)/)
+  assert.match(trapBody, /INT\)/)
+  assert.match(trapBody, /PIPE\)/)
+  assert.match(trapBody, /TERM\)/)
+  // Load-bearing: after INT/TERM case labels, must exit (not bare return).
+  assert.match(trapBody, /INT\)[\s\S]{0,80}exit 130/)
+  assert.match(trapBody, /TERM\)[\s\S]{0,80}exit 143/)
+
+  // Load-bearing order inside action_on:
+  // arm → atomic_set true → post checks → artifact → disarm
+  // Search post-write needles AFTER the true write so comment mentions do not win.
+  const armIdx = on.indexOf('arm_stream_on_fail_safe_rollback')
+  const setTrueIdx = on.indexOf('atomic_set_stream_flag "true"')
+  assert.ok(armIdx >= 0, 'must arm fail-safe rollback')
+  assert.ok(setTrueIdx > armIdx, 'arm must precede atomic_set true')
+  const afterWrite = on.slice(setTrueIdx)
+  const recreateRel = afterWrite.indexOf('if ! recreate_backend_only')
+  const shaRel = afterWrite.indexOf('require_exact_deployed_sha "on-post-restart"')
+  const liveFlagRel = afterWrite.indexOf('live stream flag is not true')
+  const workerRel = afterWrite.indexOf('wait_for_worker_started')
+  const lifeRel = afterWrite.indexOf('require_lifecycle_flags_off "on-post"')
+  const artifactRel = afterWrite.indexOf('write_status_artifact "on_ok"')
+  const summaryRel = afterWrite.indexOf('on_fail_safe_rollback_disarmed=true')
+  const disarmRel = afterWrite.indexOf('disarm_stream_on_fail_safe_rollback')
+
+  assert.ok(recreateRel >= 0, 'recreate after write')
+  assert.ok(shaRel >= 0, 'post-restart SHA after write')
+  assert.ok(liveFlagRel >= 0, 'live flag check after write')
+  assert.ok(workerRel >= 0, 'worker_started after write')
+  assert.ok(lifeRel >= 0, 'lifecycle post after write')
+  assert.ok(artifactRel > workerRel && artifactRel > lifeRel, 'artifact after post checks')
+  assert.ok(summaryRel > artifactRel, 'summary lines after write_status_artifact')
+  assert.ok(disarmRel > summaryRel, 'disarm only after artifact + summary writes')
+  assert.ok(disarmRel > shaRel && disarmRel > workerRel && disarmRel > lifeRel)
+
+  // Manual restore-only path without arm is insufficient; arm is required.
+  assert.match(on, /fail-safe rollback armed|fail-safe rollback ARMED|arm_stream_on_fail_safe_rollback/)
+})
+
+test('action=on post-write rollback covers every later failure and signal (load-bearing mutation)', () => {
+  // Removing arm, moving disarm before checks, or reintroducing return-only INT/TERM trap
+  // must redden this test.
+  const source = read(REMOTE_SH)
+  const on = actionBody(source, 'action_on', ['action_off'])
+
+  // Every post-write check is inside the armed window (between arm and disarm).
+  const armIdx = on.indexOf('arm_stream_on_fail_safe_rollback')
+  const disarmIdx = on.indexOf('disarm_stream_on_fail_safe_rollback')
+  assert.ok(armIdx >= 0 && disarmIdx > armIdx)
+  const armedWindow = on.slice(armIdx, disarmIdx)
+  for (const needle of [
+    'atomic_set_stream_flag "true"',
+    'if ! recreate_backend_only',
+    'require_exact_deployed_sha "on-post-restart"',
+    'live stream flag is not true',
+    'wait_for_worker_started',
+    'require_lifecycle_flags_off "on-post"',
+    'write_status_artifact "on_ok"',
+  ]) {
+    assert.ok(
+      armedWindow.includes(needle),
+      `armed window must include post-write step: ${needle}`,
+    )
+  }
+
+  // Rollback body must force false + recreate and report result.
+  assert.match(source, /stream_on_fail_safe_rollback\(\)[\s\S]*?atomic_set_stream_flag\s+"false"[\s\S]*?recreate_backend_only/)
+  assert.match(source, /on_fail_safe_rollback=/)
+
+  // Signal handling: no cleanup_ephemeral-only trap action; INT/TERM exit.
+  assert.doesNotMatch(source, /^[ \t]*trap[ \t]+cleanup_ephemeral\b/m)
+  assert.match(source, /on_script_trap\(\)[\s\S]*?INT\)[\s\S]*?exit 130/)
+  assert.match(source, /on_script_trap\(\)[\s\S]*?TERM\)[\s\S]*?exit 143/)
+  // Trap invokes rollback then cleanup (order).
+  const trapBody = source.slice(
+    source.indexOf('on_script_trap()'),
+    source.indexOf("trap 'on_script_trap EXIT'"),
+  )
+  const rbIdx = trapBody.indexOf('stream_on_fail_safe_rollback')
+  const clIdx = trapBody.indexOf('cleanup_ephemeral')
+  assert.ok(rbIdx >= 0 && clIdx > rbIdx, 'trap must rollback then cleanup_ephemeral')
+})
+
+test('on_script_trap EXIT preserves nonzero status; stubbed rollback runs exactly once (dynamic)', () => {
+  // Dynamic proof of the $? ordering P1:
+  // Armed post-write failure → EXIT trap → rollback once → process exits nonzero.
+  // If saved_rc is captured after `local reason=...`, trap body success can exit 0.
+  const source = read(REMOTE_SH)
+  const trapStart = source.indexOf('on_script_trap()')
+  assert.notEqual(trapStart, -1)
+  const trapEnd = source.indexOf("\ntrap 'on_script_trap EXIT'", trapStart)
+  assert.notEqual(trapEnd, -1)
+  const trapFn = source.slice(trapStart, trapEnd).trim()
+  // Guard: extracted body still has the load-bearing first-statement capture.
+  assert.match(trapFn, /^on_script_trap\(\)\s*\{\s*local saved_rc=\$\?/m)
+
+  const dir = mkdtempSync(join(tmpdir(), 'stream-uat-trap-'))
+  const outFile = join(dir, 'rollback.count')
+  const scriptFile = join(dir, 'trap-probe.sh')
+  const script = `set -euo pipefail
+OUT="${outFile}"
+ROLLBACK_COUNT=0
+STREAM_ON_ROLLBACK_ARMED=true
+STREAM_ON_SUCCESS=false
+STREAM_ON_ROLLBACK_DONE=false
+TRAP_IN_PROGRESS=false
+
+stream_on_fail_safe_rollback() {
+  # Stub: count invocations only (no docker / env mutation).
+  ROLLBACK_COUNT=$((ROLLBACK_COUNT + 1))
+  printf 'rollback_count=%s\\n' "$ROLLBACK_COUNT" >> "$OUT"
+}
+
+cleanup_ephemeral() {
+  :
+}
+
+${trapFn}
+
+trap 'on_script_trap EXIT' EXIT
+
+# Simulate armed post-write failure (e.g. require_exact_deployed_sha / wait_for_worker_started).
+exit 17
+`
+  try {
+    writeFileSync(scriptFile, script, 'utf8')
+    const result = spawnSync('bash', [scriptFile], {
+      encoding: 'utf8',
+      env: { ...process.env },
+    })
+    assert.notEqual(
+      result.status,
+      0,
+      `armed EXIT trap must not turn failed on-action green; status=${result.status} stderr=${result.stderr}`,
+    )
+    assert.equal(
+      result.status,
+      17,
+      `EXIT trap must re-exit with original nonzero status 17, got ${result.status}`,
+    )
+    assert.ok(existsSync(outFile), 'stubbed rollback must write count file')
+    const countOut = readFileSync(outFile, 'utf8').trim()
+    assert.equal(
+      countOut,
+      'rollback_count=1',
+      `stubbed rollback must run exactly once, got: ${JSON.stringify(countOut)}`,
+    )
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('action=on live STREAM_INTEGRATION_ID equals uniquely-derived anchor via file_digest vs env_key_digest_in_container', () => {
+  // SPECIFICALLY NAMED load-bearing mutation test.
+  // Fails if the comparison lines are removed from require_stream_prerequisites_for_on.
+  // Presence + "DB has one eligible anchor" alone must NOT pass; live env id must equal
+  // the uniquely-derived anchor via digests (never print ID).
+  const source = read(REMOTE_SH)
+  const prereqStart = source.indexOf('require_stream_prerequisites_for_on()')
+  assert.notEqual(prereqStart, -1, 'require_stream_prerequisites_for_on must exist')
+  const prereqEnd = source.indexOf('\n# --- artifact writers', prereqStart)
+  assert.notEqual(prereqEnd, -1)
+  const prereq = source.slice(prereqStart, prereqEnd)
+
+  // After unique anchor probe: secure materialize.
+  assert.match(prereq, /derive_exact_integration_id_file\s+"on"/)
+  assert.match(prereq, /INTEGRATION_ID_FILE/)
+
+  // INLINE comparison lines (not only a helper call) — removal of these fails this test.
+  assert.match(
+    prereq,
+    /dig_want="\$\(file_digest "\$INTEGRATION_ID_FILE"\)"/,
+    'require_stream_prerequisites_for_on must call file_digest on INTEGRATION_ID_FILE',
+  )
+  assert.match(
+    prereq,
+    /dig_live="\$\(env_key_digest_in_container "\$KEY_STREAM_INTEGRATION_ID"\)"/,
+    'require_stream_prerequisites_for_on must call env_key_digest_in_container on KEY_STREAM_INTEGRATION_ID',
+  )
+  assert.match(
+    prereq,
+    /\[\[\s*"\$dig_live"\s*!=\s*"\$dig_want"\s*\]\]/,
+    'require_stream_prerequisites_for_on must compare dig_live != dig_want',
+  )
+  assert.match(
+    prereq,
+    /digest mismatch|does not match uniquely-derived eligible anchor/,
+    'require_stream_prerequisites_for_on must fail closed on digest mismatch',
+  )
+  assert.match(prereq, /stale\/wrong|refuse stale/)
+  assert.match(prereq, /values not printed|never print id/i)
+
+  // Order is load-bearing: derive/materialize before digest compare.
+  const deriveIdx = prereq.indexOf('derive_exact_integration_id_file "on"')
+  const fileDigIdx = prereq.indexOf('file_digest "$INTEGRATION_ID_FILE"')
+  const envDigIdx = prereq.indexOf('env_key_digest_in_container "$KEY_STREAM_INTEGRATION_ID"')
+  const neIdx = prereq.indexOf('"$dig_live" != "$dig_want"')
+  assert.ok(deriveIdx >= 0, 'derive_exact_integration_id_file "on" required')
+  assert.ok(fileDigIdx > deriveIdx, 'file_digest must follow derive')
+  assert.ok(envDigIdx > deriveIdx, 'env_key_digest_in_container must follow derive')
+  assert.ok(neIdx > fileDigIdx && neIdx > envDigIdx, 'dig_live != dig_want must follow both digests')
+
+  // Never print/log the raw id value in this function body.
+  assert.doesNotMatch(prereq, /echo "\$\{?id_val/)
+  assert.doesNotMatch(prereq, /log ".*\$\{?id_val/)
+  assert.doesNotMatch(prereq, /printenv\s+\$KEY_STREAM_INTEGRATION_ID|printenv\s+DINGTALK_INTERACTIVE_CARD_STREAM_INTEGRATION_ID/)
+
+  // action=on must call this prereq (not a weaker path).
+  const on = actionBody(source, 'action_on', ['action_off'])
+  assert.equal(
+    (on.match(/require_stream_prerequisites_for_on/g) || []).length,
+    2,
+    'on must check the loaded integration anchor before and after backend recreate',
+  )
+  const recreateIdx = on.indexOf('recreate_backend_only')
+  const firstGateIdx = on.indexOf('require_stream_prerequisites_for_on')
+  const secondGateIdx = on.indexOf('require_stream_prerequisites_for_on', firstGateIdx + 1)
+  assert.ok(firstGateIdx < recreateIdx)
+  assert.ok(secondGateIdx > recreateIdx)
+})
+
+test('remote off is fail-safe: forces Stream false, restarts, verifies worker stopped', () => {
+  const source = read(REMOTE_SH)
+  const off = actionBody(source, 'action_off')
+  assert.match(off, /atomic_set_stream_flag\s+"false"/)
+  assert.match(off, /recreate_backend_only/)
+  assert.match(off, /wait_for_worker_disabled/)
+  assert.match(off, /fail_safe_off|Fail-safe|fail-safe/)
+  assert.match(source, /WORKER_DISABLED_MSG|worker disabled/)
+  assert.doesNotMatch(off, /atomic_set_stream_flag\s+"true"/)
+})
+
+test('stream flag rewrite removes candidate files before either failure exit', () => {
+  const source = read(REMOTE_SH)
+  const body = actionBody(source, 'atomic_set_stream_flag', ['recreate_backend_only'])
+  assert.match(
+    body,
+    /if ! python3[\s\S]*rm -f "\$py_script" "\$tmp"[\s\S]*fail "stream flag rewrite failed/,
+  )
+  assert.match(
+    body,
+    /if ! compose_staging_cmd_with_env_file[\s\S]*rm -f "\$tmp"[\s\S]*fail "candidate stream-flag env failed/,
+  )
+})
+
+test('remote worker proofs use values-free log message classes only', () => {
+  const source = read(REMOTE_SH)
+  assert.match(source, /DingTalk interactive-card Stream worker started/)
+  assert.match(source, /DingTalk interactive-card Stream worker disabled/)
+  assert.match(source, /DingTalk interactive-card Stream worker failed to start/)
+  assert.match(source, /probe_worker_state_from_logs/)
+  // Must not dump full docker logs to stdout.
+  assert.doesNotMatch(source, /docker logs[^\n]*\| tee/)
+  assert.doesNotMatch(source, /cat "\$tmp"/)
+})
+
+test('lane never claims stream_connected from worker_started logs; U12/U13 human-gated', () => {
+  const source = read(REMOTE_SH)
+  const yaml = read(WORKFLOW)
+  // Explicit unknown constant + artifact key.
+  assert.match(source, /STREAM_CONNECTED_UNKNOWN="unknown"/)
+  assert.match(source, /stream_connected=\$\{STREAM_CONNECTED_UNKNOWN\}/)
+  assert.match(source, /stream_connected remains unknown|stream_connected=unknown always/i)
+  // Documents SDK connect() resolves + retries forever / not a connect proof.
+  assert.match(source, /connect\(\) resolves|retries forever|NOT that the SDK is connected|not a connect proof/i)
+  assert.match(source, /U12\/U13|u12_u13_human_gated/)
+  // Never assign stream_connected=true from this lane.
+  assert.doesNotMatch(source, /stream_connected=true/)
+  assert.doesNotMatch(source, /STREAM_CONNECTED_UNKNOWN="true"/)
+  assert.doesNotMatch(source, /stream_connected proven|connection proven|SDK connected proven/i)
+  assert.match(yaml, /worker_started only|stream_connected stays unknown|U12\/U13 remain human-gated/)
+  assert.doesNotMatch(yaml, /stream_connected=true|prove[sd]? connected|connection proven/i)
+})
+
+// --- no echo of secrets ---------------------------------------------------------------
+
+test('workflow and remote script never echo secrets or raw credential env values', () => {
+  const yaml = read(WORKFLOW)
+  const source = read(REMOTE_SH)
+  for (const body of [yaml, source]) {
+    // Forbid echoing shell variables that hold secret material (names in prose are OK).
+    assert.doesNotMatch(body, /echo\s+[\"']?\$\{?(_STREAM_CLIENT_ID|_STREAM_CLIENT_SECRET|_STREAM_TEMPLATE_ID)\b/)
+    assert.doesNotMatch(body, /echo\s+[\"']?\$\{?(STAGING_DINGTALK_INTERACTIVE_CARD_CLIENT_ID|STAGING_DINGTALK_INTERACTIVE_CARD_CLIENT_SECRET|STAGING_DINGTALK_INTERACTIVE_CARD_TEMPLATE_ID)\b/)
+    assert.doesNotMatch(body, /printenv\s+DINGTALK_INTERACTIVE_CARD_CLIENT_SECRET/)
+    assert.doesNotMatch(body, /printenv\s+DINGTALK_INTERACTIVE_CARD_CLIENT_ID/)
+    assert.doesNotMatch(body, /cat\s+[\"']?\$\{?STREAM_CLIENT_SECRET_FILE/)
+    assert.doesNotMatch(body, /cat\s+[\"']?\$\{?STREAM_CLIENT_ID_FILE/)
+  }
+  // Digest comparison only — sha256sum of values, never plaintext log.
+  assert.match(source, /sha256sum/)
+  assert.match(source, /env_key_digest_in_container|file_digest/)
+  // Integration id written to file only.
+  assert.match(source, /INTEGRATION_ID_FILE/)
+  assert.doesNotMatch(source, /echo "\$\{?id_val/)
+})
+
+test('status artifacts emit only booleans/counts/reason classes/sha schema keys', () => {
+  const source = read(REMOTE_SH)
+  assert.match(source, /schema=dingtalk-interactive-card-stream-staging-uat-status-v1/)
+  for (const key of [
+    'stream_enabled=',
+    'client_id_present=',
+    'client_secret_present=',
+    'template_id_present=',
+    'stream_integration_id_present=',
+    'active_corp_anchored_integration_count=',
+    'linked_local_users_for_anchor_count=',
+    'single_anchor_two_users_ready=',
+    'lifecycle_flags_all_off=',
+    'log_level_ready=',
+    'log_level_reason=',
+    'worker_state=',
+    'stream_connected=',
+    'backend_health=',
+    'deployed_sha=',
+    'deployed_sha_match=',
+  ]) {
+    assert.match(source, new RegExp(key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')))
+  }
+  // stream_connected is always the unknown constant (never log-inferred true).
+  assert.match(source, /echo "stream_connected=\$\{STREAM_CONNECTED_UNKNOWN\}"/)
+  // Must not emit secret-like keys into artifacts.
+  assert.doesNotMatch(source, /echo "client_id=/)
+  assert.doesNotMatch(source, /echo "client_secret=/)
+  assert.doesNotMatch(source, /echo "template_id=/)
+  assert.doesNotMatch(source, /echo "integration_id=/)
+  assert.doesNotMatch(source, /echo "corp_id=/)
+})
+
+// --- status read-only -----------------------------------------------------------------
+
+test('status action is read-only: no env writes, no flag flips, no compose up', () => {
+  const source = read(REMOTE_SH)
+  const status = actionBody(source, 'action_status', ['action_prepare'])
+  assert.match(status, /write_status_artifact/)
+  assert.doesNotMatch(status, /atomic_upsert_env_keys_from_files/)
+  assert.doesNotMatch(status, /atomic_set_stream_flag/)
+  assert.doesNotMatch(status, /recreate_backend_only/)
+  assert.doesNotMatch(status, /compose_staging_cmd up/)
+  assert.doesNotMatch(status, /mv -f/)
+  assert.doesNotMatch(status, />>\s*"\$STAGING_ENV_FILE"/)
+})
+
+// --- lifecycle isolation --------------------------------------------------------------
+
+test('lane never writes lifecycle flags true; only reads them for guard/status', () => {
+  const source = read(REMOTE_SH)
+  assert.match(source, /AUTH_LOGIN_USE_ALIASES/)
+  assert.match(source, /DIRECTORY_PENDING_ACTIVATION_ENABLED/)
+  assert.match(source, /DIRECTORY_DEPROVISION_ENABLED/)
+  assert.match(source, /require_lifecycle_flags_off|read_lifecycle_all_off/)
+  assert.doesNotMatch(source, /AUTH_LOGIN_USE_ALIASES=true/)
+  assert.doesNotMatch(source, /DIRECTORY_PENDING_ACTIVATION_ENABLED=true/)
+  assert.doesNotMatch(source, /DIRECTORY_DEPROVISION_ENABLED=true/)
+  // Stream true only via action=on path flag setter.
+  assert.match(source, /atomic_set_stream_flag\s+"true"/)
+})
+
+// --- staging rails --------------------------------------------------------------------
+
+test('remote script enforces staging-only containers and recreate backend-only safety', () => {
+  const source = read(REMOTE_SH)
+  assert.match(source, /assert_staging_only/)
+  assert.match(source, /metasheet-staging-backend/)
+  assert.match(source, /metasheet-staging-postgres/)
+  assert.match(source, /refusing production fallback|PROD-track/)
+  assert.match(source, /recreate_backend_only/)
+  assert.match(source, /--no-deps --force-recreate backend/)
+  assert.match(source, /postgres\/redis untouched/)
+  // Unified EXIT/INT/TERM trap cleans ephemerals (and on-armed Stream rollback).
+  assert.match(source, /trap 'on_script_trap EXIT' EXIT/)
+  assert.match(source, /trap 'on_script_trap HUP' HUP/)
+  assert.match(source, /trap 'on_script_trap INT' INT/)
+  assert.match(source, /trap 'on_script_trap TERM' TERM/)
+  assert.match(source, /on_script_trap PIPE' PIPE/)
+  assert.match(source, /cleanup_ephemeral/)
+  assert.match(source, /chmod 600/)
+  assert.match(source, /mktemp/)
+})
+
+test('workflow does not claim to implement human U1-U13 clicks; U12/U13 human-gated', () => {
+  const yaml = read(WORKFLOW)
+  assert.match(yaml, /Does NOT implement human U1/)
+  assert.match(yaml, /U12\/U13 remain human-gated/)
+  assert.doesNotMatch(yaml, /U1–U13 automated/)
+  assert.doesNotMatch(yaml, /U12\/U13 automated/)
+})

--- a/scripts/ops/dingtalk-interactive-card-stream-staging-uat-remote.sh
+++ b/scripts/ops/dingtalk-interactive-card-stream-staging-uat-remote.sh
@@ -1,0 +1,1412 @@
+#!/usr/bin/env bash
+# dingtalk-interactive-card-stream-staging-uat-remote.sh
+#
+# Remote (deploy-host) half of
+# .github/workflows/dingtalk-interactive-card-stream-staging-uat.yml.
+# Executes ONE action per invocation against the STAGING stack only.
+#
+# EXECUTABLE:
+#   status  — read-only snapshot (booleans / counts / reason classes / SHA only)
+#   prepare — transport Stream credentials via chmod-600 files, derive exactly
+#             one active DingTalk integration (nonempty corp_id + >=2 active
+#             linked local users), atomically write the four credential/id env
+#             keys into docker/app.staging.env while FORCING Stream flag false,
+#             validate, and restart backend only if needed
+#   on      — recheck prerequisites + LOG_LEVEL info/debug, flip ONLY Stream
+#             flag true, restart backend, prove worker_started only (values-free).
+#             EXIT/INT/TERM fail-safe is ARMED before Stream ON write; any
+#             post-write non-success forces disk flag false + backend recreate
+#             and reports rollback result. Disarm only after all on checks +
+#             artifact succeed. Signal traps must exit (not return/continue).
+#             Does NOT prove SDK connected: interactive-card-stream.ts status
+#             'active' / log "worker started" means the worker is running with
+#             SDK-owned connection lifecycle; connect() resolves and retries
+#             forever. stream_connected stays unknown until real callback UAT
+#             (human U12/U13).
+#   off     — fail-safe: flip Stream flag false, restart backend, prove worker
+#             stopped / not registered
+#
+# HARD SAFETY RAILS:
+#   * Staging compose + metasheet-staging-* containers only; no prod fallback.
+#   * Lifecycle flags (alias/pending/deprovision) are NEVER written by this lane.
+#   * Stream stays OFF except explicit action=on.
+#   * Secrets never appear in shell argv, exported env values, logs, or artifacts.
+#   * prepare/on/off require exact deployed 40-char lowercase SHA.
+#   * Artifacts: booleans / counts / reason enums / SHA only — no raw IDs/PII.
+#   * stream_connected is always unknown in this lane (no connect claim from logs).
+#   * U12/U13 remain human-gated (real callback / flag-off UAT); not automated.
+#   * Invoked as `bash -o pipefail -c '<script>'`.
+set -euo pipefail
+
+log() { echo "[stream-uat] $*"; }
+fail() { echo "[stream-uat][error] $*" >&2; exit 1; }
+
+ACTION="${ACTION:?ACTION is required (status|prepare|on|off)}"
+DEPLOY_SHA="${DEPLOY_SHA:-}"
+STAGING_DEPLOY_PATH="${STAGING_DEPLOY_PATH:-metasheet2-dingtalk-staging}"
+DEPLOY_PATH="${DEPLOY_PATH:-metasheet2}"
+OUTPUT_DIR="${OUTPUT_DIR:?OUTPUT_DIR is required}"
+RUN_STAMP="${RUN_STAMP:?RUN_STAMP is required (workflow run id marker)}"
+
+# Secret-backed prepare inputs: FILE PATHS only (values never exported/logged).
+STREAM_CLIENT_ID_FILE="${STREAM_CLIENT_ID_FILE:-}"
+STREAM_CLIENT_SECRET_FILE="${STREAM_CLIENT_SECRET_FILE:-}"
+STREAM_TEMPLATE_ID_FILE="${STREAM_TEMPLATE_ID_FILE:-}"
+
+BACKEND_CONTAINER="metasheet-staging-backend"
+WEB_CONTAINER="metasheet-staging-web"
+POSTGRES_CONTAINER="metasheet-staging-postgres"
+REDIS_CONTAINER="metasheet-staging-redis"
+STAGING_WEB_HEALTH_URL="http://127.0.0.1:8082/api/health"
+STAGING_BACKEND_HEALTH_URL="http://127.0.0.1:18900/health"
+
+FLAG_STREAM="DINGTALK_INTERACTIVE_CARD_STREAM_ENABLED"
+KEY_CLIENT_ID="DINGTALK_INTERACTIVE_CARD_CLIENT_ID"
+KEY_CLIENT_SECRET="DINGTALK_INTERACTIVE_CARD_CLIENT_SECRET"
+KEY_TEMPLATE_ID="DINGTALK_INTERACTIVE_CARD_TEMPLATE_ID"
+KEY_STREAM_INTEGRATION_ID="DINGTALK_INTERACTIVE_CARD_STREAM_INTEGRATION_ID"
+
+FLAG_ALIAS="AUTH_LOGIN_USE_ALIASES"
+FLAG_PENDING="DIRECTORY_PENDING_ACTIVATION_ENABLED"
+FLAG_DEPROVISION="DIRECTORY_DEPROVISION_ENABLED"
+
+# Ephemeral temp paths cleaned by trap (chmod 600 where secrets live).
+EPHEMERAL_PATHS=()
+INTEGRATION_ID_FILE=""
+PINNED_IMAGE_OWNER=""
+PINNED_IMAGE_TAG=""
+
+# action=on fail-safe: when armed, any non-success path (fail/EXIT/INT/TERM) forces
+# Stream flag false on disk + backend recreate. Disarm only after full on success.
+STREAM_ON_ROLLBACK_ARMED="false"
+STREAM_ON_SUCCESS="false"
+STREAM_ON_ROLLBACK_DONE="false"
+STREAM_ON_ROLLBACK_RESULT=""
+TRAP_IN_PROGRESS="false"
+
+cleanup_ephemeral() {
+  local p
+  set +e
+  for p in "${EPHEMERAL_PATHS[@]:-}"; do
+    [[ -n "$p" ]] || continue
+    if [[ -d "$p" ]]; then
+      rm -rf "$p"
+    else
+      rm -f "$p"
+    fi
+  done
+  set -e
+}
+
+stream_on_fail_safe_rollback() {
+  # Force disk Stream flag false + recreate backend. Values-free result only.
+  # Idempotent; never prints secrets. Safe under set +e (trap context).
+  if [[ "$STREAM_ON_ROLLBACK_ARMED" != "true" ]]; then
+    return 0
+  fi
+  if [[ "$STREAM_ON_SUCCESS" == "true" ]]; then
+    return 0
+  fi
+  if [[ "$STREAM_ON_ROLLBACK_DONE" == "true" ]]; then
+    return 0
+  fi
+  STREAM_ON_ROLLBACK_DONE="true"
+  set +e
+  log "action=on fail-safe rollback: forcing Stream flag false + backend recreate"
+  local flag_rc=1 recreate_rc=1
+  # Subshell so helper fail()/exit cannot re-enter this trap mid-rollback.
+  if ( atomic_set_stream_flag "false" ); then
+    flag_rc=0
+  fi
+  if ( recreate_backend_only ); then
+    recreate_rc=0
+  fi
+  if [[ "$flag_rc" == "0" && "$recreate_rc" == "0" ]]; then
+    STREAM_ON_ROLLBACK_RESULT="ok;flag_off_rc=0;recreate_rc=0"
+  else
+    STREAM_ON_ROLLBACK_RESULT="partial_or_failed;flag_off_rc=${flag_rc};recreate_rc=${recreate_rc}"
+  fi
+  if [[ -n "${OUTPUT_DIR:-}" && -d "${OUTPUT_DIR:-}" ]]; then
+    {
+      echo "on_fail_safe_rollback=${STREAM_ON_ROLLBACK_RESULT}"
+      echo "stream_enabled_target_after_rollback=false"
+    } >> "${OUTPUT_DIR}/summary.txt" 2>/dev/null
+  fi
+  log "action=on fail-safe rollback result: ${STREAM_ON_ROLLBACK_RESULT}"
+  set -e
+  return 0
+}
+
+arm_stream_on_fail_safe_rollback() {
+  # Must be called BEFORE atomic_set_stream_flag true.
+  STREAM_ON_ROLLBACK_ARMED="true"
+  STREAM_ON_SUCCESS="false"
+  STREAM_ON_ROLLBACK_DONE="false"
+  STREAM_ON_ROLLBACK_RESULT=""
+  log "action=on fail-safe rollback ARMED (EXIT/INT/TERM will force Stream OFF)"
+}
+
+disarm_stream_on_fail_safe_rollback() {
+  # Only after all on post-write checks + artifacts succeed.
+  STREAM_ON_SUCCESS="true"
+  STREAM_ON_ROLLBACK_ARMED="false"
+  log "action=on fail-safe rollback DISARMED (on checks + artifact succeeded)"
+}
+
+# Unified trap: optional on-rollback, then ephemeral cleanup.
+# Do NOT register cleanup_ephemeral alone on signal traps — a return-only signal
+# handler lets the main script continue after a fatal signal. Every trapped fatal
+# signal MUST exit after rollback.
+#
+# CRITICAL: capture $? as the FIRST statement. Any prior command (including
+# `local reason=...`) succeeds and clobbers $? to 0, which would make EXIT re-exit
+# skip and turn a failed action_on into a green exit after trap body.
+on_script_trap() {
+  local saved_rc=$? # FIRST statement only — never put any command above this line
+  local reason="${1:-EXIT}"
+
+  if [[ "$TRAP_IN_PROGRESS" == "true" ]]; then
+    # Nested re-entry (e.g. exit from within trap): signals still force-exit.
+    case "$reason" in
+      HUP) exit 129 ;;
+      INT) exit 130 ;;
+      PIPE) exit 141 ;;
+      TERM) exit 143 ;;
+      *) return 0 ;;
+    esac
+  fi
+  TRAP_IN_PROGRESS="true"
+
+  set +e
+  # Armed action=on window: force Stream OFF + recreate before process ends.
+  stream_on_fail_safe_rollback
+  cleanup_ephemeral
+  set -e
+
+  case "$reason" in
+    HUP)
+      exit 129
+      ;;
+    INT)
+      # Signal: must exit so action_on cannot continue after partial post-write work.
+      exit 130
+      ;;
+    TERM)
+      exit 143
+      ;;
+    PIPE)
+      exit 141
+      ;;
+    EXIT)
+      # Re-exit non-zero so fail() status is preserved after trap body.
+      # Without this, trap-last-command success can make the whole script exit 0.
+      if [[ "$saved_rc" -ne 0 ]]; then
+        exit "$saved_rc"
+      fi
+      ;;
+    *)
+      exit 1
+      ;;
+  esac
+}
+
+# Separate trap lines so fatal signals cannot share a return-only cleanup handler.
+trap 'on_script_trap EXIT' EXIT
+trap 'on_script_trap HUP' HUP
+trap 'on_script_trap INT' INT
+trap 'on_script_trap TERM' TERM
+# A dropped non-PTY SSH channel can kill a writer with SIGPIPE. Silence the broken
+# channel before rollback so logging cannot recursively raise PIPE.
+trap 'exec >/dev/null 2>&1; on_script_trap PIPE' PIPE
+
+register_ephemeral() {
+  local p="$1"
+  EPHEMERAL_PATHS+=("$p")
+}
+
+resolve_home_path() {
+  local raw="$1"
+  if [[ "$raw" == /* ]]; then
+    printf '%s' "$raw"
+  elif [[ "$raw" == "~/"* ]]; then
+    printf '%s' "${HOME}/${raw#"~/"}"
+  else
+    printf '%s' "${HOME}/${raw}"
+  fi
+}
+
+STAGING_DIR="$(resolve_home_path "$STAGING_DEPLOY_PATH")"
+PROD_REPO_DIR="$(resolve_home_path "$DEPLOY_PATH")"
+LEGACY_STAGING_COMPOSE_FILE="${STAGING_DIR}/docker-compose.app.staging.yml"
+
+ATTENDANCE_PERSIST_DIR="${HOME}/.metasheet2/window-runner"
+ATTENDANCE_OVERRIDE_FILE="${ATTENDANCE_PERSIST_DIR}/docker-compose.window-runner.override.yml"
+PERSISTENT_STAGING_COMPOSE_FILE="${ATTENDANCE_PERSIST_DIR}/docker-compose.app.staging.yml"
+STAGING_COMPOSE_FILE="$LEGACY_STAGING_COMPOSE_FILE"
+if [[ -f "$PERSISTENT_STAGING_COMPOSE_FILE" ]]; then
+  STAGING_COMPOSE_FILE="$PERSISTENT_STAGING_COMPOSE_FILE"
+fi
+
+LIFECYCLE_PERSIST_DIR="${HOME}/.metasheet2/lifecycle-canary"
+LIFECYCLE_OVERRIDE_FILE="${LIFECYCLE_PERSIST_DIR}/docker-compose.lifecycle-canary.override.yml"
+
+STAGING_ENV_FILE="${STAGING_DIR}/docker/app.staging.env"
+STREAM_UAT_PERSIST_DIR="${HOME}/.metasheet2/stream-uat"
+mkdir -p "$STREAM_UAT_PERSIST_DIR"
+chmod 700 "$STREAM_UAT_PERSIST_DIR" 2>/dev/null || true
+
+is_truthy() {
+  local v
+  v="$(printf '%s' "${1:-}" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')"
+  case "$v" in
+    true|1|yes|on) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+assert_staging_only() {
+  [[ -d "$STAGING_DIR" ]] || fail "staging stack directory missing: ${STAGING_DIR} (set STAGING_DEPLOY_PATH); refusing to guess"
+  [[ -f "$STAGING_COMPOSE_FILE" ]] || fail "staging compose file missing: ${STAGING_COMPOSE_FILE}; fail closed — this runner never falls back to another compose file"
+  grep -q "container_name: ${BACKEND_CONTAINER}" "$STAGING_COMPOSE_FILE" \
+    || fail "compose file does not define ${BACKEND_CONTAINER}; refusing (wrong file?)"
+  grep -q "container_name: ${WEB_CONTAINER}" "$STAGING_COMPOSE_FILE" \
+    || fail "compose file does not define ${WEB_CONTAINER}; refusing (wrong file?)"
+  grep -q "container_name: ${POSTGRES_CONTAINER}" "$STAGING_COMPOSE_FILE" \
+    || fail "compose file does not define ${POSTGRES_CONTAINER}; refusing (wrong file?)"
+  grep -q "container_name: ${REDIS_CONTAINER}" "$STAGING_COMPOSE_FILE" \
+    || fail "compose file does not define ${REDIS_CONTAINER}; refusing (wrong file?)"
+  if grep -qE 'container_name: metasheet-(backend|web|postgres|redis)[[:space:]]*$' "$STAGING_COMPOSE_FILE"; then
+    fail "compose file defines PROD-track container names; refusing"
+  fi
+  if [[ "$STAGING_DIR" == "$PROD_REPO_DIR" ]]; then
+    fail "staging stack dir equals the prod-track repo dir (${STAGING_DIR}); refusing"
+  fi
+  if [[ "$(basename "$STAGING_COMPOSE_FILE")" != "docker-compose.app.staging.yml" ]]; then
+    fail "compose basename is not docker-compose.app.staging.yml; refusing production fallback"
+  fi
+  log "staging-only guard OK: dir=${STAGING_DIR} compose=$(basename "$STAGING_COMPOSE_FILE")"
+}
+
+require_compose_v2() {
+  if docker compose version >/dev/null 2>&1; then
+    return 0
+  fi
+  fail "docker compose v2 plugin is required"
+}
+
+resolve_live_backend_image_pin() {
+  local live_image
+  live_image="$(docker inspect -f '{{.Config.Image}}' "$BACKEND_CONTAINER" 2>/dev/null || true)"
+  if [[ "$live_image" =~ ^ghcr\.io/([A-Za-z0-9._-]+)/metasheet2-backend:([0-9a-f]{40})$ ]]; then
+    printf '%s %s' "${BASH_REMATCH[1]}" "${BASH_REMATCH[2]}"
+    return 0
+  fi
+  return 1
+}
+
+compose_staging_cmd() {
+  local image_pin image_owner image_tag
+  local -a files=(-f "$STAGING_COMPOSE_FILE")
+  if [[ -f "$ATTENDANCE_OVERRIDE_FILE" ]]; then
+    files+=(-f "$ATTENDANCE_OVERRIDE_FILE")
+  fi
+  if [[ -f "$LIFECYCLE_OVERRIDE_FILE" ]]; then
+    files+=(-f "$LIFECYCLE_OVERRIDE_FILE")
+  fi
+  if [[ -n "$PINNED_IMAGE_OWNER" && -n "$PINNED_IMAGE_TAG" ]]; then
+    image_owner="$PINNED_IMAGE_OWNER"
+    image_tag="$PINNED_IMAGE_TAG"
+  else
+    if ! image_pin="$(resolve_live_backend_image_pin)"; then
+      echo "[stream-uat][error] running backend image is not an exact ghcr.io owner/metasheet2-backend:<40-sha> pin; refusing compose" >&2
+      return 1
+    fi
+    read -r image_owner image_tag <<< "$image_pin"
+  fi
+  (cd "$STAGING_DIR" && IMAGE_OWNER="$image_owner" IMAGE_TAG="$image_tag" APP_ENV_FILE="$STAGING_ENV_FILE" \
+    docker compose --project-directory "$STAGING_DIR" --env-file "$STAGING_ENV_FILE" "${files[@]}" "$@")
+}
+
+pin_live_backend_image_for_transition() {
+  local image_pin
+  if ! image_pin="$(resolve_live_backend_image_pin)"; then
+    fail "running backend image is not an exact ghcr.io owner/metasheet2-backend:<40-sha> pin; refusing transition"
+  fi
+  read -r PINNED_IMAGE_OWNER PINNED_IMAGE_TAG <<< "$image_pin"
+  [[ "$PINNED_IMAGE_TAG" == "$DEPLOY_SHA" ]] \
+    || fail "running backend image tag '${PINNED_IMAGE_TAG}' does not match deploy_sha '${DEPLOY_SHA}'"
+}
+
+require_sha() {
+  [[ "$DEPLOY_SHA" =~ ^[0-9a-f]{40}$ ]] \
+    || fail "deploy_sha must be the FULL 40-char lowercase commit SHA, got: '${DEPLOY_SHA}'"
+}
+
+fetch_health_commit() {
+  local body
+  if ! body="$(curl -fsS --max-time 10 "$STAGING_WEB_HEALTH_URL" 2>/dev/null)"; then
+    printf ''
+    return 0
+  fi
+  printf '%s' "$body" | python3 -c 'import json,sys
+try:
+    print(json.load(sys.stdin).get("build", {}).get("commit", ""))
+except Exception:
+    print("")'
+}
+
+fetch_backend_health_ok() {
+  local body
+  if ! body="$(curl -fsS --max-time 10 "$STAGING_BACKEND_HEALTH_URL" 2>/dev/null)"; then
+    printf 'false'
+    return 0
+  fi
+  printf '%s' "$body" | python3 -c 'import json,sys
+try:
+    d=json.load(sys.stdin)
+    print("true" if d.get("ok") is True or d.get("status")=="ok" else "false")
+except Exception:
+    print("false")'
+}
+
+resolve_deployed_sha() {
+  local live_image image_commit="" health_commit=""
+  live_image="$(docker inspect -f '{{.Config.Image}}' "$BACKEND_CONTAINER" 2>/dev/null || true)"
+  if [[ "$live_image" =~ :([0-9a-f]{40})$ ]]; then
+    image_commit="${BASH_REMATCH[1]}"
+  fi
+  health_commit="$(fetch_health_commit)"
+
+  # Exact proof requires both sources and agreement.
+  if [[ -n "$image_commit" && "$health_commit" =~ ^[0-9a-f]{40}$ ]]; then
+    if [[ "$image_commit" == "$health_commit" ]]; then
+      printf '%s' "$image_commit"
+    else
+      printf 'conflict'
+    fi
+    return 0
+  fi
+  printf 'unknown'
+}
+
+require_exact_deployed_sha() {
+  local live context="${1:-transition}"
+  require_sha
+  live="$(resolve_deployed_sha)"
+  [[ "$live" =~ ^[0-9a-f]{40}$ ]] \
+    || fail "${context}: could not resolve one exact deployed staging SHA (image tag / health commit)"
+  [[ "$live" == "$DEPLOY_SHA" ]] \
+    || fail "${context}: deployed SHA '${live}' does not match required exact deploy_sha '${DEPLOY_SHA}'"
+  log "exact deployed SHA OK: ${live}"
+}
+
+read_flag_from_container() {
+  local key="$1" val
+  if ! val="$(docker exec "$BACKEND_CONTAINER" sh -c '
+key="$1"
+if printenv "$key" >/dev/null 2>&1; then
+  exec printenv "$key"
+fi
+printf "__MISSING__"
+' sh "$key" 2>/dev/null)"; then
+    return 1
+  fi
+  if [[ "$val" == "__MISSING__" ]]; then
+    printf 'false'
+    return 0
+  fi
+  if is_truthy "$val"; then
+    printf 'true'
+  else
+    printf 'false'
+  fi
+}
+
+env_key_present_in_container() {
+  local key="$1" raw
+  if ! raw="$(docker exec "$BACKEND_CONTAINER" sh -c '
+key="$1"
+if printenv "$key" >/dev/null 2>&1; then
+  v=$(printenv "$key")
+  if [ -n "$(printf "%s" "$v" | tr -d "[:space:]")" ]; then
+    printf "yes"
+  else
+    printf "empty"
+  fi
+else
+  printf "missing"
+fi
+' sh "$key" 2>/dev/null)"; then
+    printf 'unknown'
+    return 0
+  fi
+  if [[ "$raw" == "yes" ]]; then
+    printf 'true'
+  else
+    printf 'false'
+  fi
+}
+
+env_key_digest_in_container() {
+  # sha256 of trimmed value, or MISSING/EMPTY — never prints the value.
+  local key="$1" dig
+  dig="$(docker exec "$BACKEND_CONTAINER" sh -c '
+key="$1"
+if ! printenv "$key" >/dev/null 2>&1; then
+  printf "MISSING"
+  exit 0
+fi
+v=$(printenv "$key")
+trimmed=$(printf "%s" "$v" | sed "s/^[[:space:]]*//;s/[[:space:]]*$//")
+if [ -z "$trimmed" ]; then
+  printf "EMPTY"
+  exit 0
+fi
+printf "%s" "$trimmed" | sha256sum | awk "{print \$1}"
+' sh "$key" 2>/dev/null || true)"
+  if [[ -z "$dig" ]]; then
+    printf 'UNKNOWN'
+  else
+    printf '%s' "$dig"
+  fi
+}
+
+file_digest() {
+  local path="$1"
+  [[ -f "$path" ]] || { printf 'MISSING'; return 0; }
+  # shellcheck disable=SC2002
+  local dig
+  dig="$(sed 's/^[[:space:]]*//;s/[[:space:]]*$//' "$path" | tr -d '\r' | sha256sum | awk '{print $1}')"
+  if [[ -z "$dig" ]]; then
+    printf 'EMPTY'
+  else
+    printf '%s' "$dig"
+  fi
+}
+
+read_env_file_value_digest() {
+  local key="$1" file="$2" py_script dig
+  [[ -f "$file" ]] || { printf 'MISSING'; return 0; }
+  py_script="$(mktemp "${STREAM_UAT_PERSIST_DIR}/.env-digest.XXXXXX")"
+  register_ephemeral "$py_script"
+  chmod 600 "$py_script"
+  cat >"$py_script" <<'PY'
+import hashlib, sys
+key, path = sys.argv[1], sys.argv[2]
+value = None
+with open(path, encoding="utf-8", errors="replace") as fh:
+    for raw in fh:
+        line = raw.rstrip("\n").rstrip("\r")
+        if not line or line.lstrip().startswith("#"):
+            continue
+        if "=" not in line:
+            continue
+        k, v = line.split("=", 1)
+        if k.strip() == key:
+            value = v.strip()
+            if len(value) >= 2 and ((value[0] == value[-1] == '"') or (value[0] == value[-1] == "'")):
+                value = value[1:-1]
+if value is None:
+    print("MISSING")
+elif not value.strip():
+    print("EMPTY")
+else:
+    print(hashlib.sha256(value.strip().encode("utf-8")).hexdigest())
+PY
+  dig="$(python3 "$py_script" "$key" "$file" 2>/dev/null || true)"
+  rm -f "$py_script"
+  if [[ -z "$dig" ]]; then
+    printf 'UNKNOWN'
+  else
+    printf '%s' "$dig"
+  fi
+}
+
+# --- LOG_LEVEL classification (values-free) ------------------------------------------
+classify_log_level() {
+  # Sets LOG_LEVEL_READY and LOG_LEVEL_REASON (info|debug|other|missing|unknown).
+  local raw
+  if ! raw="$(docker exec "$BACKEND_CONTAINER" sh -c 'printenv LOG_LEVEL 2>/dev/null || true' 2>/dev/null)"; then
+    LOG_LEVEL_READY="unknown"
+    LOG_LEVEL_REASON="unknown"
+    return 0
+  fi
+  local normalized
+  normalized="$(printf '%s' "$raw" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')"
+  if [[ -z "$normalized" ]]; then
+    # core/logger.ts defaults to info when unset/empty.
+    LOG_LEVEL_READY="true"
+    LOG_LEVEL_REASON="missing"
+    return 0
+  fi
+  case "$normalized" in
+    info)
+      LOG_LEVEL_READY="true"
+      LOG_LEVEL_REASON="info"
+      ;;
+    debug)
+      LOG_LEVEL_READY="true"
+      LOG_LEVEL_REASON="debug"
+      ;;
+    *)
+      LOG_LEVEL_READY="false"
+      LOG_LEVEL_REASON="other"
+      ;;
+  esac
+}
+
+require_log_level_info_or_debug() {
+  classify_log_level
+  if [[ "$LOG_LEVEL_READY" == "true" ]]; then
+    case "$LOG_LEVEL_REASON" in
+      info|debug|missing)
+        log "LOG_LEVEL ready (reason=${LOG_LEVEL_REASON})"
+        return 0
+        ;;
+    esac
+  fi
+  fail "action=on requires LOG_LEVEL info/debug (got ready=${LOG_LEVEL_READY} reason=${LOG_LEVEL_REASON})"
+}
+
+# --- lifecycle flags (read only; never written) --------------------------------------
+read_lifecycle_all_off() {
+  local a p d
+  a="$(read_flag_from_container "$FLAG_ALIAS")" || { printf 'unknown'; return 0; }
+  p="$(read_flag_from_container "$FLAG_PENDING")" || { printf 'unknown'; return 0; }
+  d="$(read_flag_from_container "$FLAG_DEPROVISION")" || { printf 'unknown'; return 0; }
+  if [[ "$a" == "false" && "$p" == "false" && "$d" == "false" ]]; then
+    printf 'true'
+  else
+    printf 'false'
+  fi
+}
+
+require_lifecycle_flags_off() {
+  local context="${1:-transition}" all_off
+  all_off="$(read_lifecycle_all_off)"
+  [[ "$all_off" == "true" ]] \
+    || fail "${context}: lifecycle flags must all be OFF (this lane never enables them); got lifecycle_flags_all_off=${all_off}"
+  log "lifecycle flags all OFF OK"
+}
+
+# --- directory anchor derivation (values-free counts; id only via secret file) --------
+run_directory_anchor_probe() {
+  # stdout JSON: {active_corp_anchored_count, linked_users, ready, integration_id?}
+  # integration_id is written ONLY when count==1 and linked>=2; callers must not log it.
+  # Script is staged via chmod-600 temp file to avoid nested shell/node quoting hazards.
+  local script_tmp out
+  script_tmp="$(mktemp "${STREAM_UAT_PERSIST_DIR}/.anchor-probe.XXXXXX")"
+  register_ephemeral "$script_tmp"
+  chmod 600 "$script_tmp"
+  cat >"$script_tmp" <<'NODE'
+const { Client } = require("pg");
+(async () => {
+  const unknown = {
+    active_corp_anchored_count: "unknown",
+    linked_users: "unknown",
+    ready: "unknown",
+    integration_id: "",
+  };
+  const emit = (o) => process.stdout.write(JSON.stringify(o));
+  const url = process.env.DATABASE_URL;
+  if (!url) { emit(unknown); return; }
+  const c = new Client({ connectionString: url, connectionTimeoutMillis: 8000 });
+  try {
+    await c.connect();
+    const placeholder = [
+      "replace-me","changeme","change-me","placeholder","todo","xxx","your-corp-id","example"
+    ];
+    const r = await c.query(
+      `SELECT i.id::text AS id,
+              count(DISTINCT u.id)::int AS linked_users
+         FROM directory_integrations i
+         LEFT JOIN directory_accounts a
+           ON a.integration_id = i.id
+          AND a.provider = 'dingtalk'
+          AND a.is_active = TRUE
+         LEFT JOIN directory_account_links l
+           ON l.directory_account_id = a.id
+          AND l.link_status = 'linked'
+          AND l.local_user_id IS NOT NULL
+          AND length(trim(l.local_user_id::text)) > 0
+         LEFT JOIN users u
+           ON u.id = l.local_user_id
+          AND u.is_active = TRUE
+          AND COALESCE(u.activation_status, 'activated') = 'activated'
+        WHERE i.provider = 'dingtalk'
+          AND i.status = 'active'
+          AND i.corp_id IS NOT NULL
+          AND length(trim(i.corp_id)) > 0
+          AND lower(trim(i.corp_id)) <> ALL($1::text[])
+        GROUP BY i.id
+        ORDER BY i.id`,
+      [placeholder],
+    );
+    const rows = r.rows || [];
+    if (rows.length === 0) {
+      emit({ active_corp_anchored_count: 0, linked_users: 0, ready: "false", integration_id: "" });
+      return;
+    }
+    if (rows.length !== 1) {
+      emit({
+        active_corp_anchored_count: rows.length,
+        linked_users: "unknown",
+        ready: "false",
+        integration_id: "",
+      });
+      return;
+    }
+    const linked = Number(rows[0].linked_users) || 0;
+    const ready = linked >= 2;
+    emit({
+      active_corp_anchored_count: 1,
+      linked_users: linked,
+      ready: ready ? "true" : "false",
+      integration_id: ready ? String(rows[0].id || "") : "",
+    });
+  } catch {
+    emit(unknown);
+  } finally {
+    try { await c.end(); } catch { /* ignore */ }
+  }
+})().catch(() => {
+  process.stdout.write(JSON.stringify({
+    active_corp_anchored_count: "unknown",
+    linked_users: "unknown",
+    ready: "unknown",
+    integration_id: "",
+  }));
+});
+NODE
+  out="$(docker exec -i "$BACKEND_CONTAINER" node <"$script_tmp" 2>/dev/null || true)"
+  rm -f "$script_tmp"
+  if [[ -z "$out" ]]; then
+    printf '%s' '{"active_corp_anchored_count":"unknown","linked_users":"unknown","ready":"unknown","integration_id":""}'
+  else
+    printf '%s' "$out"
+  fi
+}
+
+parse_probe_field() {
+  local json="$1" field="$2"
+  printf '%s' "$json" | python3 -c "import json,sys
+d=json.load(sys.stdin)
+v=d.get(sys.argv[1], '')
+print('' if v is None else v)
+" "$field"
+}
+
+derive_exact_integration_id_file() {
+  # Writes integration UUID to chmod-600 temp file when exactly one ready anchor exists.
+  # Never prints the id. Sets INTEGRATION_ID_FILE on success.
+  # context: prepare|on (values-free fail messages only).
+  local context="${1:-prepare}"
+  local probe count linked ready id_tmp id_val
+  probe="$(run_directory_anchor_probe)"
+  count="$(parse_probe_field "$probe" active_corp_anchored_count)"
+  linked="$(parse_probe_field "$probe" linked_users)"
+  ready="$(parse_probe_field "$probe" ready)"
+  id_val="$(parse_probe_field "$probe" integration_id)"
+
+  # Persist values-free counts for artifacts (never the id).
+  ANCHOR_COUNT="$count"
+  ANCHOR_LINKED_USERS="$linked"
+  ANCHOR_READY="$ready"
+
+  if [[ "$count" != "1" ]]; then
+    fail "action=${context} requires exactly one active DingTalk integration with nonempty corp_id (got active_corp_anchored_count=${count})"
+  fi
+  if [[ "$ready" != "true" || -z "$id_val" ]]; then
+    fail "action=${context} requires that single anchor to have >=2 active linked local users (linked_users=${linked} ready=${ready})"
+  fi
+  # UUID shape only — refuse garbage without printing value.
+  if [[ ! "$id_val" =~ ^[0-9a-fA-F-]{36}$ ]]; then
+    fail "action=${context} derived integration id failed shape check (values not printed)"
+  fi
+  id_tmp="$(mktemp "${STREAM_UAT_PERSIST_DIR}/.integration-id.XXXXXX")"
+  register_ephemeral "$id_tmp"
+  umask 077
+  printf '%s' "$id_val" > "$id_tmp"
+  chmod 600 "$id_tmp"
+  INTEGRATION_ID_FILE="$id_tmp"
+  # Drop shell copy immediately.
+  unset id_val
+  log "derived exactly one corp-anchored integration with linked_users=${linked} (id path only; never logged)"
+}
+
+require_live_stream_integration_id_matches_derived_anchor() {
+  # Load-bearing for action=on: live DINGTALK_INTERACTIVE_CARD_STREAM_INTEGRATION_ID
+  # must equal the uniquely-derived eligible anchor. Digest/file comparison only —
+  # never prints the integration id. Presence alone is insufficient (stale/wrong ID).
+  local context="${1:-on}" dig_live dig_want
+  [[ -n "${INTEGRATION_ID_FILE:-}" && -f "$INTEGRATION_ID_FILE" && -s "$INTEGRATION_ID_FILE" ]] \
+    || fail "action=${context} requires derived integration id file before live-id match (never print id)"
+  dig_want="$(file_digest "$INTEGRATION_ID_FILE")"
+  dig_live="$(env_key_digest_in_container "$KEY_STREAM_INTEGRATION_ID")"
+  if [[ "$dig_want" == "MISSING" || "$dig_want" == "EMPTY" || "$dig_want" == "UNKNOWN" ]]; then
+    fail "action=${context}: derived integration id digest unusable (class=${dig_want}; values not printed)"
+  fi
+  if [[ "$dig_live" == "MISSING" || "$dig_live" == "EMPTY" || "$dig_live" == "UNKNOWN" ]]; then
+    fail "action=${context}: live ${KEY_STREAM_INTEGRATION_ID} digest unusable (class=${dig_live}; values not printed)"
+  fi
+  if [[ "$dig_live" != "$dig_want" ]]; then
+    fail "action=${context}: live ${KEY_STREAM_INTEGRATION_ID} does not match uniquely-derived eligible anchor (digest mismatch; refuse stale/wrong id; values not printed)"
+  fi
+  log "live stream integration id matches uniquely-derived anchor (digest equal; values never logged)"
+}
+
+# --- env file atomic upsert (secret values from files only) ---------------------------
+require_staging_env_file() {
+  [[ -f "$STAGING_ENV_FILE" ]] || fail "staging env file missing: ${STAGING_ENV_FILE}"
+  [[ -w "$STAGING_ENV_FILE" ]] || fail "staging env file not writable: ${STAGING_ENV_FILE}"
+}
+
+atomic_upsert_env_keys_from_files() {
+  # Args: pairs of KEY FILE_OR_LITERAL where FILE is a path, or @literal:VALUE for non-secret flags.
+  # Stream flag is always written as false for prepare via @literal:false.
+  require_staging_env_file
+  local tmp py_script out_py
+  tmp="$(mktemp "${STREAM_UAT_PERSIST_DIR}/.app.staging.env.XXXXXX")"
+  register_ephemeral "$tmp"
+  chmod 600 "$tmp"
+  py_script="$(mktemp "${STREAM_UAT_PERSIST_DIR}/.upsert-env.XXXXXX")"
+  register_ephemeral "$py_script"
+  chmod 600 "$py_script"
+
+  cat >"$py_script" <<'PY'
+import os, sys
+
+src, dst = sys.argv[1], sys.argv[2]
+pairs = sys.argv[3:]
+if len(pairs) % 2 != 0:
+    raise SystemExit("atomic_upsert: KEY/FILE pairs required")
+
+updates = {}
+for i in range(0, len(pairs), 2):
+    key = pairs[i]
+    spec = pairs[i + 1]
+    if not key or "=" in key or any(c.isspace() for c in key):
+        raise SystemExit("invalid env key")
+    if spec.startswith("@literal:"):
+        updates[key] = spec[len("@literal:"):]
+    else:
+        if not os.path.isfile(spec):
+            raise SystemExit("missing secret file for key")
+        with open(spec, "rb") as fh:
+            raw = fh.read()
+        # Exact bytes, strip only trailing newline/CR commonly introduced by secret writers.
+        value = raw.decode("utf-8", errors="strict")
+        if value.endswith("\r\n"):
+            value = value[:-2]
+        elif value.endswith("\n") or value.endswith("\r"):
+            value = value[:-1]
+        if not value.strip():
+            raise SystemExit("empty secret file for key")
+        # Refuse control characters (never print value).
+        if any(ord(ch) < 32 and ch not in "\t" for ch in value) or "\x7f" in value:
+            raise SystemExit("control characters in secret file for key")
+        updates[key] = value
+
+with open(src, encoding="utf-8", errors="replace") as fh:
+    lines = fh.read().splitlines()
+
+seen = set()
+out = []
+for line in lines:
+    stripped = line.strip()
+    if not stripped or stripped.startswith("#") or "=" not in line:
+        out.append(line)
+        continue
+    k = line.split("=", 1)[0].strip()
+    if k in updates:
+        out.append(f"{k}={updates[k]}")
+        seen.add(k)
+    else:
+        out.append(line)
+
+for k, v in updates.items():
+    if k not in seen:
+        out.append(f"{k}={v}")
+
+# Atomic write via same-dir temp already provided as dst; caller mv's into place.
+with open(dst, "w", encoding="utf-8") as fh:
+    fh.write("\n".join(out))
+    fh.write("\n")
+os.chmod(dst, 0o600)
+print("ok")
+PY
+
+  out_py="$(python3 "$py_script" "$STAGING_ENV_FILE" "$tmp" "$@" 2>/dev/null)" \
+    || fail "atomic env upsert failed (values not printed)"
+  rm -f "$py_script"
+  [[ "$out_py" == "ok" ]] || fail "atomic env upsert did not confirm ok"
+
+  # Validate candidate via compose config before replace.
+  if ! compose_staging_cmd_with_env_file "$tmp" config >/dev/null 2>&1; then
+    fail "candidate staging env failed 'docker compose config' validation; left previous env intact"
+  fi
+
+  # Backup previous env (mode 600) then atomic replace.
+  local backup
+  backup="${STREAM_UAT_PERSIST_DIR}/app.staging.env.backup-${RUN_STAMP}"
+  cp -p "$STAGING_ENV_FILE" "$backup"
+  chmod 600 "$backup" 2>/dev/null || true
+  mv -f "$tmp" "$STAGING_ENV_FILE"
+  chmod 600 "$STAGING_ENV_FILE"
+  # $tmp path no longer exists after mv; trap rm -f is a no-op for the old path.
+  log "staging env keys updated atomically (backup=${backup}; values never logged)"
+}
+
+compose_staging_cmd_with_env_file() {
+  local env_file="$1"
+  shift
+  local image_pin image_owner image_tag
+  local -a files=(-f "$STAGING_COMPOSE_FILE")
+  if [[ -f "$ATTENDANCE_OVERRIDE_FILE" ]]; then
+    files+=(-f "$ATTENDANCE_OVERRIDE_FILE")
+  fi
+  if [[ -f "$LIFECYCLE_OVERRIDE_FILE" ]]; then
+    files+=(-f "$LIFECYCLE_OVERRIDE_FILE")
+  fi
+  if [[ -n "$PINNED_IMAGE_OWNER" && -n "$PINNED_IMAGE_TAG" ]]; then
+    image_owner="$PINNED_IMAGE_OWNER"
+    image_tag="$PINNED_IMAGE_TAG"
+  else
+    if ! image_pin="$(resolve_live_backend_image_pin)"; then
+      return 1
+    fi
+    read -r image_owner image_tag <<< "$image_pin"
+  fi
+  (cd "$STAGING_DIR" && IMAGE_OWNER="$image_owner" IMAGE_TAG="$image_tag" APP_ENV_FILE="$env_file" \
+    docker compose --project-directory "$STAGING_DIR" --env-file "$env_file" "${files[@]}" "$@")
+}
+
+atomic_set_stream_flag() {
+  local desired="$1"  # true|false
+  require_staging_env_file
+  local tmp
+  tmp="$(mktemp "${STREAM_UAT_PERSIST_DIR}/.app.staging.env.flag.XXXXXX")"
+  register_ephemeral "$tmp"
+  chmod 600 "$tmp"
+  local py_script
+  py_script="$(mktemp "${STREAM_UAT_PERSIST_DIR}/.set-stream-flag.XXXXXX")"
+  register_ephemeral "$py_script"
+  chmod 600 "$py_script"
+  cat >"$py_script" <<'PY'
+import os, sys
+src, dst, key, value = sys.argv[1:5]
+if value not in ("true", "false"):
+    raise SystemExit("stream flag must be true or false")
+with open(src, encoding="utf-8", errors="replace") as fh:
+    lines = fh.read().splitlines()
+seen = False
+out = []
+for line in lines:
+    stripped = line.strip()
+    if not stripped or stripped.startswith("#") or "=" not in line:
+        out.append(line)
+        continue
+    k = line.split("=", 1)[0].strip()
+    if k == key:
+        out.append(f"{key}={value}")
+        seen = True
+    else:
+        out.append(line)
+if not seen:
+    out.append(f"{key}={value}")
+with open(dst, "w", encoding="utf-8") as fh:
+    fh.write("\n".join(out) + "\n")
+os.chmod(dst, 0o600)
+PY
+  if ! python3 "$py_script" "$STAGING_ENV_FILE" "$tmp" "$FLAG_STREAM" "$desired"; then
+    rm -f "$py_script" "$tmp"
+    fail "stream flag rewrite failed (values not printed)"
+  fi
+  rm -f "$py_script"
+  if ! compose_staging_cmd_with_env_file "$tmp" config >/dev/null 2>&1; then
+    rm -f "$tmp"
+    fail "candidate stream-flag env failed compose config validation; left previous env intact"
+  fi
+  local backup
+  backup="${STREAM_UAT_PERSIST_DIR}/app.staging.env.flag-backup-${RUN_STAMP}"
+  cp -p "$STAGING_ENV_FILE" "$backup"
+  chmod 600 "$backup" 2>/dev/null || true
+  mv -f "$tmp" "$STAGING_ENV_FILE"
+  chmod 600 "$STAGING_ENV_FILE"
+  # $tmp path no longer exists after mv; trap rm -f is a no-op for the old path.
+  log "stream flag set to ${desired} atomically (value is enum only)"
+}
+
+# --- backend recreate -----------------------------------------------------------------
+recreate_backend_only() {
+  local pg_id_before redis_id_before pg_id_after redis_id_after
+  local i health
+
+  pg_id_before="$(docker inspect -f '{{.Id}}' "$POSTGRES_CONTAINER")" \
+    || { log "staging postgres container not found"; return 1; }
+  redis_id_before="$(docker inspect -f '{{.Id}}' "$REDIS_CONTAINER")" \
+    || { log "staging redis container not found"; return 1; }
+
+  if ! compose_staging_cmd up -d --no-deps --force-recreate backend 2>&1 \
+    | tee "${OUTPUT_DIR}/compose-up-backend.log"; then
+    log "compose up backend failed"
+    return 1
+  fi
+
+  pg_id_after="$(docker inspect -f '{{.Id}}' "$POSTGRES_CONTAINER" 2>/dev/null || true)"
+  redis_id_after="$(docker inspect -f '{{.Id}}' "$REDIS_CONTAINER" 2>/dev/null || true)"
+  if [[ "$pg_id_before" != "$pg_id_after" ]]; then
+    log "staging postgres container was recreated — hard constraint violated"
+    return 1
+  fi
+  if [[ "$redis_id_before" != "$redis_id_after" ]]; then
+    log "staging redis container was recreated — hard constraint violated"
+    return 1
+  fi
+  log "postgres/redis untouched (container ids unchanged)"
+
+  for ((i = 1; i <= 30; i += 1)); do
+    if docker inspect -f '{{.State.Running}}' "$BACKEND_CONTAINER" 2>/dev/null | grep -qx 'true'; then
+      health="$(fetch_backend_health_ok)"
+      if [[ "$health" == "true" ]]; then
+        log "backend health true after restart (attempt ${i}/30)"
+        return 0
+      fi
+    fi
+    log "waiting for backend health true (attempt ${i}/30)"
+    sleep 2
+  done
+  log "backend health not true after restart — refuse transition success"
+  return 1
+}
+
+backend_needs_restart_for_prepare() {
+  # Compare digests of the four keys + stream flag false in live container vs desired files.
+  local live_flag dig_live dig_want
+  live_flag="$(read_flag_from_container "$FLAG_STREAM" || echo unknown)"
+  if [[ "$live_flag" != "false" ]]; then
+    return 0
+  fi
+  dig_live="$(env_key_digest_in_container "$KEY_CLIENT_ID")"
+  dig_want="$(file_digest "$STREAM_CLIENT_ID_FILE")"
+  [[ "$dig_live" == "$dig_want" ]] || return 0
+  dig_live="$(env_key_digest_in_container "$KEY_CLIENT_SECRET")"
+  dig_want="$(file_digest "$STREAM_CLIENT_SECRET_FILE")"
+  [[ "$dig_live" == "$dig_want" ]] || return 0
+  dig_live="$(env_key_digest_in_container "$KEY_TEMPLATE_ID")"
+  dig_want="$(file_digest "$STREAM_TEMPLATE_ID_FILE")"
+  [[ "$dig_live" == "$dig_want" ]] || return 0
+  dig_live="$(env_key_digest_in_container "$KEY_STREAM_INTEGRATION_ID")"
+  dig_want="$(file_digest "$INTEGRATION_ID_FILE")"
+  [[ "$dig_live" == "$dig_want" ]] || return 0
+  return 1
+}
+
+# --- worker log proofs (values-free message classes only) -----------------------------
+# IMPORTANT (interactive-card-stream.ts): log "worker started" / status active means
+# the worker process path started with SDK-owned connection lifecycle — NOT that the
+# SDK is connected. connect() resolves even on total failure and retries forever.
+# This lane may prove worker_started only; stream_connected is always unknown here.
+# Real connectivity remains human U12/U13 (callback UAT), never inferred from logs.
+WORKER_STARTED_MSG="DingTalk interactive-card Stream worker started"
+WORKER_DISABLED_MSG="DingTalk interactive-card Stream worker disabled"
+WORKER_FAILED_MSG="DingTalk interactive-card Stream worker failed to start"
+WORKER_SHUTDOWN_MSG="DingTalk interactive-card Stream worker shut down"
+# Always unknown until real callback UAT (human-gated U12/U13). Never flip from logs.
+STREAM_CONNECTED_UNKNOWN="unknown"
+
+probe_worker_state_from_logs() {
+  # Returns: started|disabled|failed|unknown — based on recent backend logs.
+  # "started" = worker_started only (not connected). Never dumps raw logs; only classifies.
+  local logs started disabled failed shutdown
+  if ! docker inspect -f '{{.State.Running}}' "$BACKEND_CONTAINER" 2>/dev/null | grep -qx 'true'; then
+    printf 'unknown'
+    return 0
+  fi
+  # Capture into a temp file (mode 600) then classify; never cat to console.
+  local tmp
+  tmp="$(mktemp "${STREAM_UAT_PERSIST_DIR}/.worker-logs.XXXXXX")"
+  register_ephemeral "$tmp"
+  chmod 600 "$tmp"
+  docker logs --tail 400 "$BACKEND_CONTAINER" >"$tmp" 2>&1 || true
+  started=0 disabled=0 failed=0 shutdown=0
+  grep -F "$WORKER_STARTED_MSG" "$tmp" >/dev/null 2>&1 && started=1
+  grep -F "$WORKER_DISABLED_MSG" "$tmp" >/dev/null 2>&1 && disabled=1
+  grep -F "$WORKER_FAILED_MSG" "$tmp" >/dev/null 2>&1 && failed=1
+  grep -F "$WORKER_SHUTDOWN_MSG" "$tmp" >/dev/null 2>&1 && shutdown=1
+  rm -f "$tmp"
+  # Prefer most-recent semantic: if stream flag is false, disabled wins over older started.
+  local flag
+  flag="$(read_flag_from_container "$FLAG_STREAM" 2>/dev/null || echo unknown)"
+  if [[ "$flag" == "true" ]]; then
+    if [[ "$failed" == "1" && "$started" != "1" ]]; then
+      printf 'failed'
+      return 0
+    fi
+    if [[ "$started" == "1" ]]; then
+      printf 'started'
+      return 0
+    fi
+    printf 'unknown'
+    return 0
+  fi
+  if [[ "$flag" == "false" ]]; then
+    if [[ "$disabled" == "1" || "$shutdown" == "1" ]]; then
+      printf 'disabled'
+      return 0
+    fi
+    # Flag off and no started line in recent window after a restart is "disabled".
+    if [[ "$started" != "1" ]]; then
+      printf 'disabled'
+      return 0
+    fi
+    # Stale started line with flag false — still report disabled via env authority.
+    printf 'disabled'
+    return 0
+  fi
+  printf 'unknown'
+}
+
+wait_for_worker_started() {
+  # Proves worker_started log class only. Does NOT prove stream_connected.
+  local i state
+  for ((i = 1; i <= 30; i += 1)); do
+    state="$(probe_worker_state_from_logs)"
+    if [[ "$state" == "started" ]]; then
+      log "worker_started proven (state=started; stream_connected remains unknown) attempt ${i}/30"
+      return 0
+    fi
+    if [[ "$state" == "failed" ]]; then
+      fail "worker failed to start (state=failed); refusing action=on success"
+    fi
+    log "waiting for worker_started only (state=${state}; not a connect proof) attempt ${i}/30"
+    sleep 2
+  done
+  fail "worker_started not proven within timeout (last state=${state:-unknown}; never claims connected)"
+}
+
+wait_for_worker_disabled() {
+  local i state flag
+  for ((i = 1; i <= 30; i += 1)); do
+    flag="$(read_flag_from_container "$FLAG_STREAM" || echo unknown)"
+    state="$(probe_worker_state_from_logs)"
+    if [[ "$flag" == "false" && ( "$state" == "disabled" || "$state" == "unknown" ) ]]; then
+      # unknown + flag false after restart is acceptable only when started is absent.
+      if [[ "$state" == "disabled" ]]; then
+        log "worker stopped/not registered proven (state=disabled flag=false) attempt ${i}/30"
+        return 0
+      fi
+    fi
+    if [[ "$flag" == "false" && "$state" != "started" && "$state" != "failed" ]]; then
+      log "worker not registered (flag=false state=${state}) attempt ${i}/30"
+      return 0
+    fi
+    log "waiting for worker disabled (flag=${flag} state=${state}) attempt ${i}/30"
+    sleep 2
+  done
+  # Fail-safe off: if flag is false in container, accept with warning class in summary.
+  flag="$(read_flag_from_container "$FLAG_STREAM" || echo unknown)"
+  if [[ "$flag" == "false" ]]; then
+    log "worker flag proven false; log class inconclusive — fail-safe off accepts flag=false"
+    return 0
+  fi
+  fail "worker stop not proven (flag=${flag})"
+}
+
+# --- secret file requirements ---------------------------------------------------------
+require_prepare_secret_files() {
+  local f
+  for f in STREAM_CLIENT_ID_FILE STREAM_CLIENT_SECRET_FILE STREAM_TEMPLATE_ID_FILE; do
+    local path="${!f:-}"
+    [[ -n "$path" ]] || fail "action=prepare requires ${f} (chmod-600 secret file path); never argv/env values"
+    [[ -f "$path" ]] || fail "action=prepare secret file missing for ${f}"
+    [[ -s "$path" ]] || fail "action=prepare secret file empty for ${f}"
+  done
+  log "prepare secret files present (paths only; values never logged)"
+}
+
+require_stream_prerequisites_for_on() {
+  # Credentials present + unique eligible DB anchor + LIVE integration-id equality.
+  # Presence alone is insufficient: a stale/wrong STREAM_INTEGRATION_ID must fail.
+  # After unique-anchor probe, materialize ID to chmod-600 file and compare digests
+  # (file_digest vs env_key_digest_in_container). Never print the ID.
+  local cid csec tmpl integ dig_live dig_want
+  cid="$(env_key_present_in_container "$KEY_CLIENT_ID")"
+  csec="$(env_key_present_in_container "$KEY_CLIENT_SECRET")"
+  tmpl="$(env_key_present_in_container "$KEY_TEMPLATE_ID")"
+  integ="$(env_key_present_in_container "$KEY_STREAM_INTEGRATION_ID")"
+  [[ "$cid" == "true" ]] || fail "action=on requires ${KEY_CLIENT_ID} present in live backend"
+  [[ "$csec" == "true" ]] || fail "action=on requires ${KEY_CLIENT_SECRET} present in live backend"
+  [[ "$tmpl" == "true" ]] || fail "action=on requires ${KEY_TEMPLATE_ID} present in live backend"
+  [[ "$integ" == "true" ]] || fail "action=on requires ${KEY_STREAM_INTEGRATION_ID} present in live backend"
+
+  # Unique anchor probe → secure materialize of exact integration id (path only).
+  derive_exact_integration_id_file "on"
+  [[ -n "${INTEGRATION_ID_FILE:-}" && -f "$INTEGRATION_ID_FILE" && -s "$INTEGRATION_ID_FILE" ]] \
+    || fail "action=on: derived integration id file missing after unique anchor probe (never print id)"
+
+  # LOAD-BEARING live integration-id equality (digest/file only; never print ID).
+  dig_want="$(file_digest "$INTEGRATION_ID_FILE")"
+  dig_live="$(env_key_digest_in_container "$KEY_STREAM_INTEGRATION_ID")"
+  if [[ "$dig_want" == "MISSING" || "$dig_want" == "EMPTY" || "$dig_want" == "UNKNOWN" ]]; then
+    fail "action=on: derived integration id digest unusable (class=${dig_want}; values not printed)"
+  fi
+  if [[ "$dig_live" == "MISSING" || "$dig_live" == "EMPTY" || "$dig_live" == "UNKNOWN" ]]; then
+    fail "action=on: live ${KEY_STREAM_INTEGRATION_ID} digest unusable (class=${dig_live}; values not printed)"
+  fi
+  if [[ "$dig_live" != "$dig_want" ]]; then
+    fail "action=on: live ${KEY_STREAM_INTEGRATION_ID} does not match uniquely-derived eligible anchor (digest mismatch; refuse stale/wrong id; values not printed)"
+  fi
+  # Keep helper available for shared prepare paths / explicit re-check callers.
+  require_live_stream_integration_id_matches_derived_anchor "on"
+  log "stream prerequisites OK (credentials present; single anchor linked_users=${ANCHOR_LINKED_USERS}; live integration id digest matches derived anchor)"
+}
+
+# --- artifact writers -----------------------------------------------------------------
+write_status_artifact() {
+  local reason="${1:-ok}"
+  local live_sha stream_on cid csec tmpl integ lifecycle health worker
+  live_sha="$(resolve_deployed_sha)"
+  stream_on="$(read_flag_from_container "$FLAG_STREAM" 2>/dev/null || echo unknown)"
+  cid="$(env_key_present_in_container "$KEY_CLIENT_ID")"
+  csec="$(env_key_present_in_container "$KEY_CLIENT_SECRET")"
+  tmpl="$(env_key_present_in_container "$KEY_TEMPLATE_ID")"
+  integ="$(env_key_present_in_container "$KEY_STREAM_INTEGRATION_ID")"
+  lifecycle="$(read_lifecycle_all_off)"
+  health="$(fetch_backend_health_ok)"
+  worker="$(probe_worker_state_from_logs)"
+  classify_log_level
+
+  local probe count linked ready
+  probe="$(run_directory_anchor_probe)"
+  count="$(parse_probe_field "$probe" active_corp_anchored_count)"
+  linked="$(parse_probe_field "$probe" linked_users)"
+  ready="$(parse_probe_field "$probe" ready)"
+
+  local sha_match="unknown"
+  if [[ -n "$DEPLOY_SHA" ]]; then
+    if [[ "$live_sha" =~ ^[0-9a-f]{40}$ && "$live_sha" == "$DEPLOY_SHA" ]]; then
+      sha_match="true"
+    elif [[ "$live_sha" == "unknown" || "$live_sha" == "conflict" ]]; then
+      sha_match="unknown"
+    else
+      sha_match="false"
+    fi
+  fi
+
+  {
+    echo "schema=dingtalk-interactive-card-stream-staging-uat-status-v1"
+    echo "action=${ACTION}"
+    echo "reason=${reason}"
+    echo "deployed_sha=${live_sha}"
+    echo "deployed_sha_match=${sha_match}"
+    echo "backend_health=${health}"
+    echo "stream_enabled=${stream_on}"
+    echo "client_id_present=${cid}"
+    echo "client_secret_present=${csec}"
+    echo "template_id_present=${tmpl}"
+    echo "stream_integration_id_present=${integ}"
+    echo "active_corp_anchored_integration_count=${count}"
+    echo "linked_local_users_for_anchor_count=${linked}"
+    echo "single_anchor_two_users_ready=${ready}"
+    echo "lifecycle_flags_all_off=${lifecycle}"
+    echo "log_level_ready=${LOG_LEVEL_READY}"
+    echo "log_level_reason=${LOG_LEVEL_REASON}"
+    echo "worker_state=${worker}"
+    # Never claim connected from startup logs; human U12/U13 only.
+    echo "stream_connected=${STREAM_CONNECTED_UNKNOWN}"
+  } > "${OUTPUT_DIR}/stream-uat-status.txt"
+
+  {
+    echo "schema=dingtalk-interactive-card-stream-staging-uat-status-v1"
+    echo "action=${ACTION}"
+    echo "reason=${reason}"
+    echo "stream_enabled=${stream_on}"
+    echo "worker_state=${worker}"
+    echo "stream_connected=${STREAM_CONNECTED_UNKNOWN}"
+    echo "lifecycle_flags_all_off=${lifecycle}"
+    echo "single_anchor_two_users_ready=${ready}"
+    echo "backend_health=${health}"
+  } > "${OUTPUT_DIR}/summary.txt"
+
+  log "status artifact written (values-free; stream_connected=unknown always in this lane)"
+}
+
+# --- actions --------------------------------------------------------------------------
+action_status() {
+  assert_staging_only
+  write_status_artifact "ok"
+  log "action=status complete (read-only)"
+}
+
+action_prepare() {
+  assert_staging_only
+  require_compose_v2
+  require_exact_deployed_sha "prepare"
+  pin_live_backend_image_for_transition
+  require_lifecycle_flags_off "prepare"
+  require_prepare_secret_files
+  require_staging_env_file
+
+  # Configuration is allowed only after action=off has proved the live worker disabled.
+  # Writing a false flag is not enough to stop an already-running client if the following
+  # backend recreate fails, so prepare must never double as an implicit stop operation.
+  local pre_flag
+  pre_flag="$(read_flag_from_container "$FLAG_STREAM" || echo unknown)"
+  [[ "$pre_flag" == "false" ]] \
+    || fail "action=prepare requires live Stream OFF before credential changes (got stream_enabled=${pre_flag}); run action=off first"
+  log "prepare precondition proven: live Stream OFF"
+
+  derive_exact_integration_id_file
+
+  # Atomic write of four credential/id keys + forced Stream flag false.
+  atomic_upsert_env_keys_from_files \
+    "$KEY_CLIENT_ID" "$STREAM_CLIENT_ID_FILE" \
+    "$KEY_CLIENT_SECRET" "$STREAM_CLIENT_SECRET_FILE" \
+    "$KEY_TEMPLATE_ID" "$STREAM_TEMPLATE_ID_FILE" \
+    "$KEY_STREAM_INTEGRATION_ID" "$INTEGRATION_ID_FILE" \
+    "$FLAG_STREAM" "@literal:false"
+
+  # Post-write digests on disk (presence only for summary).
+  local disk_flag_dig
+  disk_flag_dig="$(read_env_file_value_digest "$FLAG_STREAM" "$STAGING_ENV_FILE")"
+  # false literal digest is stable; just require not MISSING/EMPTY
+  [[ "$disk_flag_dig" != "MISSING" && "$disk_flag_dig" != "EMPTY" ]] \
+    || fail "prepare failed to persist stream flag false"
+
+  local need_restart="false"
+  if backend_needs_restart_for_prepare; then
+    need_restart="true"
+  fi
+
+  if [[ "$need_restart" == "true" ]]; then
+    log "prepare: backend restart required (env mismatch or stream not false in live container)"
+    if ! recreate_backend_only; then
+      fail "prepare: backend restart/health failed after env write"
+    fi
+    require_exact_deployed_sha "prepare-post-restart"
+  else
+    log "prepare: backend restart skipped (live container already matches forced-off credentials)"
+  fi
+
+  # Prove stream is false live.
+  local post_flag
+  post_flag="$(read_flag_from_container "$FLAG_STREAM" || echo unknown)"
+  [[ "$post_flag" == "false" ]] || fail "prepare must leave stream flag false (got ${post_flag})"
+
+  # Prove credential presence without values.
+  [[ "$(env_key_present_in_container "$KEY_CLIENT_ID")" == "true" ]] || fail "prepare: client_id not present live"
+  [[ "$(env_key_present_in_container "$KEY_CLIENT_SECRET")" == "true" ]] || fail "prepare: client_secret not present live"
+  [[ "$(env_key_present_in_container "$KEY_TEMPLATE_ID")" == "true" ]] || fail "prepare: template_id not present live"
+  [[ "$(env_key_present_in_container "$KEY_STREAM_INTEGRATION_ID")" == "true" ]] || fail "prepare: stream_integration_id not present live"
+
+  write_status_artifact "prepare_ok"
+  {
+    echo "prepare_forced_stream_off=true"
+    echo "backend_restarted=${need_restart}"
+    echo "active_corp_anchored_integration_count=${ANCHOR_COUNT}"
+    echo "linked_local_users_for_anchor_count=${ANCHOR_LINKED_USERS}"
+  } >> "${OUTPUT_DIR}/summary.txt"
+  log "action=prepare complete (stream forced OFF)"
+}
+
+action_on() {
+  assert_staging_only
+  require_compose_v2
+  require_exact_deployed_sha "on"
+  pin_live_backend_image_for_transition
+  require_lifecycle_flags_off "on"
+  require_log_level_info_or_debug
+  require_stream_prerequisites_for_on
+  require_staging_env_file
+
+  # --- fail-safe window ----------------------------------------------------------
+  # Arm BEFORE Stream ON write. Covers every later failure path:
+  #   recreate_backend_only, post-restart exact SHA, live flag true,
+  #   wait_for_worker_started, lifecycle post, write_status_artifact/summary,
+  #   and INT/TERM signals (trap exits; does not return/continue).
+  # Disarm ONLY after all checks + artifact writes succeed.
+  arm_stream_on_fail_safe_rollback
+
+  # Flip ONLY the Stream flag true (credentials untouched).
+  atomic_set_stream_flag "true"
+
+  # Post-write checks: any failure → fail()/non-zero exit → EXIT trap rollback.
+  if ! recreate_backend_only; then
+    fail "action=on: backend restart/health failed after Stream ON (fail-safe rollback armed)"
+  fi
+  require_exact_deployed_sha "on-post-restart"
+
+  # Recreate loads docker/app.staging.env, which may have drifted from the
+  # pre-restart container. Re-run the complete gate against the new process.
+  require_stream_prerequisites_for_on
+
+  local live_flag
+  live_flag="$(read_flag_from_container "$FLAG_STREAM" || echo unknown)"
+  [[ "$live_flag" == "true" ]] || fail "action=on: live stream flag is not true (got ${live_flag}) (fail-safe rollback armed)"
+
+  # worker_started only — not stream_connected (SDK connect resolves + retries forever).
+  wait_for_worker_started
+
+  # Lifecycle still off.
+  require_lifecycle_flags_off "on-post"
+
+  write_status_artifact "on_ok"
+  {
+    echo "stream_enabled=true"
+    echo "worker_state=started"
+    echo "stream_connected=${STREAM_CONNECTED_UNKNOWN}"
+    echo "log_level_reason=${LOG_LEVEL_REASON}"
+    echo "u12_u13_human_gated=true"
+    echo "on_fail_safe_rollback_disarmed=true"
+  } >> "${OUTPUT_DIR}/summary.txt"
+
+  # All on checks + artifact writes succeeded — disarm so EXIT does not roll Stream OFF.
+  disarm_stream_on_fail_safe_rollback
+  log "action=on complete (stream ON; worker_started only; stream_connected=unknown; U12/U13 human-gated)"
+}
+
+action_off() {
+  # Fail-safe: always attempt to force stream false + restart, even if probes are messy.
+  assert_staging_only
+  require_compose_v2
+  require_exact_deployed_sha "off"
+  pin_live_backend_image_for_transition
+  require_staging_env_file
+
+  atomic_set_stream_flag "false"
+
+  if ! recreate_backend_only; then
+    fail "action=off: backend restart/health failed after forcing stream false (operator must inspect)"
+  fi
+  require_exact_deployed_sha "off-post-restart"
+
+  local live_flag
+  live_flag="$(read_flag_from_container "$FLAG_STREAM" || echo unknown)"
+  [[ "$live_flag" == "false" ]] || fail "action=off: live stream flag is not false (got ${live_flag})"
+
+  wait_for_worker_disabled
+
+  write_status_artifact "off_ok"
+  {
+    echo "stream_enabled=false"
+    echo "worker_state=$(probe_worker_state_from_logs)"
+    echo "stream_connected=${STREAM_CONNECTED_UNKNOWN}"
+    echo "fail_safe_off=true"
+  } >> "${OUTPUT_DIR}/summary.txt"
+  log "action=off complete (stream OFF; worker stopped/not registered; stream_connected still unknown)"
+}
+
+# --- main -----------------------------------------------------------------------------
+mkdir -p "$OUTPUT_DIR"
+chmod 700 "$OUTPUT_DIR" 2>/dev/null || true
+
+case "$ACTION" in
+  status) action_status ;;
+  prepare) action_prepare ;;
+  on) action_on ;;
+  off) action_off ;;
+  *) fail "invalid ACTION='${ACTION}' (expected status|prepare|on|off)" ;;
+esac
+
+log "done action=${ACTION}"


### PR DESCRIPTION
## What changed

- add a manual-only staging workflow with `status`, `prepare`, `on`, and `off` actions
- derive the single eligible corp-anchored DingTalk integration from the staging DB instead of accepting a caller-supplied id
- require exact deployed SHA for every mutating action
- keep lifecycle flags OFF and make `prepare` force Stream OFF
- arm fail-safe rollback before Stream ON; cover EXIT/HUP/INT/TERM/PIPE and revalidate disk-loaded config after backend recreate
- materialize credentials through chmod-600 files and emit values-free artifacts only
- wire the contract suite into the required Node 20 plugin-tests lane

## Safety boundary

- this PR does not enable any staging or production flag
- `worker_started` is not treated as `stream_connected`
- real card delivery, click, callback, and U12/U13 evidence remain human-gated
- no auto-merge is armed

## Verification

- `bash -n scripts/ops/dingtalk-interactive-card-stream-staging-uat-remote.sh`
- `node --test scripts/ops/dingtalk-interactive-card-stream-staging-uat-contract.test.mjs` (31/31)
- `git diff --check`
- independent Kimi adversarial delta review: APPROVE, 0 P1/P2
- fresh read-only staging inventory: [run 31594882437](https://github.com/zensgit/metasheet2/actions/runs/31594882437)
  - deployed SHA: `0bb96d6f316be1c0cec68eed235ff23a1d01ff72`
  - one active corp-anchored DingTalk integration
  - two active linked local users
  - lifecycle flags OFF
  - Stream flag OFF

## Post-merge sequence

1. dispatch `status`
2. dispatch `prepare` against the then-current exact deployed SHA
3. verify Stream remains OFF
4. with an owner present, dispatch `on`, perform real card/callback UAT, then dispatch `off`
