### PR TITLE
feat(integration): add bounded SQL lookup projection

### DIFF
--- a/plugins/plugin-integration-core/__tests__/data-source-sql-readonly-source-adapter.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/data-source-sql-readonly-source-adapter.test.cjs
@@ -14,8 +14,26 @@ const {
   createDataSourceSqlReadonlySourceAdapter,
   createDataSourceSqlReadonlySourceAdapterFactory,
 } = require('../lib/adapters/data-source-sql-readonly-source-adapter.cjs')
+const { dryRunExternalWrite } = require('../lib/external-write-dry-run.cjs')
 
 const SYSTEM = { kind: ADAPTER_KIND, config: { dataSourceId: 'pg-1' } }
+const LOOKUP_SYSTEM = {
+  kind: ADAPTER_KIND,
+  config: {
+    dataSourceId: 'pg-1',
+    lookupProjection: {
+      baseObject: 'dbo.bom_detail',
+      lookupObject: 'dbo.part_library',
+      localKey: 'part_id',
+      foreignKey: 'OBJ_ID',
+      fields: {
+        FNumber: 'IdentityNo',
+        FName: 'IdentityName',
+      },
+      maxRows: 3,
+    },
+  },
+}
 const WATERMARK_CURSOR_PREFIX = 'dswm1:'
 
 function decodeWatermarkCursor(cursor) {
@@ -44,7 +62,7 @@ function fakeFacade(overrides = {}) {
     },
     async select(id, table, options, principal) {
       calls.select.push({ id, table, options, principal })
-      return overrides.select ? overrides.select(options) : { data: [{ id: 1 }], metadata: {} }
+      return overrides.select ? overrides.select(options, { id, table, principal }) : { data: [{ id: 1 }], metadata: {} }
     },
   }
   return { api, calls }
@@ -133,6 +151,398 @@ async function main() {
       'array filter rejected',
     )
     assert.equal(f.calls.select.length, 0, 'invalid filters fail before any facade read')
+  }
+
+  // 4d. A system-bound lookup projection enriches at most three base rows through exact, read-only
+  //     per-row lookups. The request supplies only the base object/filter/limit; table and field
+  //     identifiers come exclusively from the persisted system config.
+  {
+    const f = fakeFacade({
+      select: (options, call) => {
+        if (call.table === 'dbo.bom_detail') {
+          return {
+            data: [
+              { id: 1, part_id: 'part-1', status: 'ready' },
+              { id: 2, part_id: 'part-2', status: 'ready' },
+            ],
+            metadata: {},
+          }
+        }
+        assert.equal(call.table, 'dbo.part_library')
+        const key = options.where.OBJ_ID
+        return {
+          data: [{
+            IdentityNo: key === 'part-1' ? 'M-001' : 'M-002',
+            IdentityName: key === 'part-1' ? 'Material One' : 'Material Two',
+          }],
+          metadata: {},
+        }
+      },
+    })
+    const res = await adapterWith(f, 'owner-42', LOOKUP_SYSTEM).read({
+      object: 'dbo.bom_detail',
+      limit: 3,
+      filters: { status: 'ready' },
+    })
+    assert.deepEqual(res.records, [
+      { id: 1, part_id: 'part-1', status: 'ready', FNumber: 'M-001', FName: 'Material One' },
+      { id: 2, part_id: 'part-2', status: 'ready', FNumber: 'M-002', FName: 'Material Two' },
+    ])
+    assert.equal(res.done, true)
+    assert.equal(res.metadata.lookupProjectionApplied, true)
+    assert.equal(res.metadata.lookupProjectionRows, 2)
+    assert.equal(f.calls.select.length, 3, 'one base read plus one lookup per base row')
+    assert.deepEqual(f.calls.select[0], {
+      id: 'pg-1',
+      table: 'dbo.bom_detail',
+      options: { limit: 3, offset: 0, where: { status: 'ready' } },
+      principal: 'owner-42',
+    })
+    assert.deepEqual(f.calls.select[1].options, {
+      limit: 2,
+      offset: 0,
+      where: { OBJ_ID: 'part-1' },
+    })
+    assert.deepEqual(f.calls.select[2].options, {
+      limit: 2,
+      offset: 0,
+      where: { OBJ_ID: 'part-2' },
+    })
+  }
+
+  // 4e. Projection configuration is strict and fails at construction: no arbitrary SQL-shaped
+  //     object names, unknown fields, or a row bound above three can reach the facade.
+  {
+    for (const lookupProjection of [
+      { ...LOOKUP_SYSTEM.config.lookupProjection, lookupObject: 'dbo.parts;DROP_TABLE' },
+      { ...LOOKUP_SYSTEM.config.lookupProjection, localKey: '__proto__' },
+      { ...LOOKUP_SYSTEM.config.lookupProjection, foreignKey: 'constructor' },
+      { ...LOOKUP_SYSTEM.config.lookupProjection, arbitrarySql: 'SELECT 1' },
+      { ...LOOKUP_SYSTEM.config.lookupProjection, maxRows: 4 },
+      { ...LOOKUP_SYSTEM.config.lookupProjection, maxRows: '3' },
+      {
+        ...LOOKUP_SYSTEM.config.lookupProjection,
+        fields: { FNumber: 'IdentityNo', FName: 'IdentityName', extra: 'secret' },
+      },
+    ]) {
+      const f = fakeFacade()
+      assert.throws(
+        () => adapterWith(f, 'owner-42', {
+          kind: ADAPTER_KIND,
+          config: { dataSourceId: 'pg-1', lookupProjection },
+        }),
+        /lookupProjection/,
+      )
+      assert.equal(f.calls.select.length, 0)
+    }
+  }
+
+  // 4f. The projection is bound to one base object and its saved row cap. Mismatch, over-limit,
+  //     and watermark modes fail before source contact.
+  {
+    const f = fakeFacade()
+    const a = adapterWith(f, 'owner-42', LOOKUP_SYSTEM)
+    await assert.rejects(
+      () => a.read({ object: 'dbo.other_table', limit: 3 }),
+      /bound to a different source object/,
+    )
+    await assert.rejects(
+      () => a.read({ object: 'dbo.bom_detail', limit: 4 }),
+      /server-bound maximum/,
+    )
+    await assert.rejects(
+      () => a.read({
+        object: 'dbo.bom_detail',
+        limit: 3,
+        watermark: { id: 1 },
+        watermarkConfig: { type: 'monotonic_id', field: 'id' },
+      }),
+      /does not support watermark/,
+    )
+    assert.equal(f.calls.select.length, 0)
+  }
+
+  // 4g. A request cannot inject or override lookup identifiers, including through request.options.
+  //     Unknown request fields are normalized away; only the system-bound lookup is contacted.
+  {
+    const f = fakeFacade({
+      select: (options, call) => call.table === 'dbo.bom_detail'
+        ? { data: [{ id: 1, part_id: 'part-1' }], metadata: {} }
+        : { data: [{ IdentityNo: 'M-001', IdentityName: 'Material One' }], metadata: {} },
+    })
+    await adapterWith(f, 'owner-42', LOOKUP_SYSTEM).read({
+      object: 'dbo.bom_detail',
+      limit: 3,
+      lookupProjection: { lookupObject: 'dbo.request_injected' },
+      options: { lookupProjection: { lookupObject: 'dbo.options_injected' } },
+    })
+    assert.deepEqual(f.calls.select.map((call) => call.table), ['dbo.bom_detail', 'dbo.part_library'])
+  }
+
+  // 4h. Missing base keys and output alias collisions stop after the base read and before lookup.
+  {
+    for (const baseRow of [
+      { id: 1, part_id: '' },
+      { id: 1, part_id: true },
+      { id: 1, part_id: 'part-1', FNumber: 'collision' },
+    ]) {
+      const f = fakeFacade({ select: () => ({ data: [baseRow], metadata: {} }) })
+      await assert.rejects(
+        () => adapterWith(f, 'owner-42', LOOKUP_SYSTEM).read({ object: 'dbo.bom_detail', limit: 3 }),
+        /lookup projection/,
+      )
+      assert.equal(f.calls.select.length, 1, 'invalid base row must not trigger lookup')
+    }
+  }
+
+  // 4i. Zero/multiple lookup rows, invalid projected fields, and driver failures all fail closed.
+  //     Driver text and row values are not carried into the surfaced error.
+  {
+    const cases = [
+      { lookupResult: { data: [], metadata: {} }, expected: /exactly one row/ },
+      {
+        lookupResult: {
+          data: [
+            { IdentityNo: 'M-001', IdentityName: 'Material One' },
+            { IdentityNo: 'M-001-DUP', IdentityName: 'Material One Duplicate' },
+          ],
+          metadata: {},
+        },
+        expected: /exactly one row/,
+      },
+      {
+        lookupResult: { data: [{ IdentityNo: 'M-001', IdentityName: ' ' }], metadata: {} },
+        expected: /required field/,
+      },
+      {
+        lookupResult: { data: [{ IdentityNo: 1001, IdentityName: 'Material One' }], metadata: {} },
+        expected: /required field/,
+      },
+      {
+        lookupResult: { data: [{ IdentityNo: 'M-001', IdentityName: false }], metadata: {} },
+        expected: /required field/,
+      },
+      {
+        lookupResult: { data: [], error: new Error('SENSITIVE_DRIVER_TEXT') },
+        expected: /lookup projection read failed/,
+      },
+    ]
+    for (const testCase of cases) {
+      const f = fakeFacade({
+        select: (options, call) => call.table === 'dbo.bom_detail'
+          ? { data: [{ id: 1, part_id: 'SENSITIVE_KEY_VALUE' }], metadata: {} }
+          : testCase.lookupResult,
+      })
+      let observed
+      try {
+        await adapterWith(f, 'owner-42', LOOKUP_SYSTEM).read({ object: 'dbo.bom_detail', limit: 3 })
+      } catch (error) {
+        observed = error
+      }
+      assert.ok(observed, 'invalid lookup must throw')
+      assert.match(observed.message, testCase.expected)
+      const publicError = JSON.stringify({ message: observed.message, details: observed.details })
+      assert.ok(!publicError.includes('SENSITIVE_KEY_VALUE'))
+      assert.ok(!publicError.includes('SENSITIVE_DRIVER_TEXT'))
+    }
+  }
+
+  // 4j. Base-read driver errors are also coarse whenever projection mode is enabled.
+  {
+    const f = fakeFacade({
+      select: () => ({ data: [], error: new Error('SENSITIVE_FILTER_OR_DRIVER_TEXT') }),
+    })
+    let observed
+    try {
+      await adapterWith(f, 'owner-42', LOOKUP_SYSTEM).read({ object: 'dbo.bom_detail', limit: 3 })
+    } catch (error) {
+      observed = error
+    }
+    assert.match(observed.message, /lookup projection base read failed/)
+    assert.ok(!observed.message.includes('SENSITIVE_FILTER_OR_DRIVER_TEXT'))
+  }
+
+  // 4j.1. The bounded join must be one-to-one across the whole base page: duplicate local keys or
+  //        duplicate projected material codes are ambiguous even when each individual lookup
+  //        returns exactly one row.
+  {
+    const duplicateLocalFacade = fakeFacade({
+      select: (options, call) => call.table === 'dbo.bom_detail'
+        ? {
+            data: [
+              { id: 1, part_id: 'duplicate-part' },
+              { id: 2, part_id: 'duplicate-part' },
+            ],
+            metadata: {},
+          }
+        : { data: [{ IdentityNo: 'M-001', IdentityName: 'Material One' }], metadata: {} },
+    })
+    await assert.rejects(
+      () => adapterWith(duplicateLocalFacade, 'owner-42', LOOKUP_SYSTEM).read({
+        object: 'dbo.bom_detail',
+        limit: 3,
+      }),
+      /base keys must be unique/,
+    )
+    assert.equal(duplicateLocalFacade.calls.select.length, 2, 'duplicate second key stops before its lookup')
+
+    const duplicateCodeFacade = fakeFacade({
+      select: (options, call) => call.table === 'dbo.bom_detail'
+        ? {
+            data: [
+              { id: 1, part_id: 'part-1' },
+              { id: 2, part_id: 'part-2' },
+            ],
+            metadata: {},
+          }
+        : {
+            data: [{
+              IdentityNo: options.where.OBJ_ID === 'part-1'
+                ? 'Duplicate-Material-Code'
+                : ' duplicate-material-code ',
+              IdentityName: 'Material Name',
+            }],
+            metadata: {},
+          },
+    })
+    await assert.rejects(
+      () => adapterWith(duplicateCodeFacade, 'owner-42', LOOKUP_SYSTEM).read({
+        object: 'dbo.bom_detail',
+        limit: 3,
+      }),
+      /material codes must be unique/,
+    )
+    assert.equal(duplicateCodeFacade.calls.select.length, 3)
+  }
+
+  // 4j.2. The facade is also treated as untrusted for row-count enforcement. Returning more base
+  //        rows than requested fails before any per-row lookup.
+  {
+    const f = fakeFacade({
+      select: () => ({
+        data: [
+          { id: 1, part_id: 'part-1' },
+          { id: 2, part_id: 'part-2' },
+          { id: 3, part_id: 'part-3' },
+        ],
+        metadata: {},
+      }),
+    })
+    await assert.rejects(
+      () => adapterWith(f, 'owner-42', LOOKUP_SYSTEM).read({ object: 'dbo.bom_detail', limit: 2 }),
+      /exceeded the server-bound row limit/,
+    )
+    assert.equal(f.calls.select.length, 1)
+  }
+
+  // 4k. Real C6 dry-run composition: the persisted source system constructs this adapter, the
+  //     persisted equality filter selects two base rows, projection supplies FNumber/FName, and
+  //     planning reaches add=2 without invoking either target write method.
+  {
+    const sourceFacade = fakeFacade({
+      select: (options, call) => {
+        if (call.table === 'dbo.bom_detail') {
+          assert.deepEqual(options.where, { approvedSlice: 'fixture' })
+          return {
+            data: [
+              { id: 1, part_id: 'C6-PRIVATE-PART-1' },
+              { id: 2, part_id: 'C6-PRIVATE-PART-2' },
+            ],
+            metadata: {},
+          }
+        }
+        const suffix = options.where.OBJ_ID.endsWith('1') ? '1' : '2'
+        return {
+          data: [{ IdentityNo: `C6-PRIVATE-CODE-${suffix}`, IdentityName: `C6-PRIVATE-NAME-${suffix}` }],
+          metadata: {},
+        }
+      },
+    })
+    const sourceAdapter = adapterWith(sourceFacade, 'owner-42', LOOKUP_SYSTEM)
+    const targetCalls = { test: 0, lookup: 0, insert: 0, update: 0 }
+    const tokenRecords = new Map()
+    const result = await dryRunExternalWrite({
+      pipeline: {
+        id: 'pipe_lookup_projection_c6',
+        tenantId: 'tenant-test',
+        workspaceId: 'workspace-test',
+        sourceSystemId: 'source-lookup-projection',
+        sourceObject: 'dbo.bom_detail',
+        targetSystemId: 'target-c6',
+        targetObject: 'material',
+        createdBy: 'owner-42',
+        options: { source: { filters: { approvedSlice: 'fixture' } } },
+        fieldMappings: [
+          { sourceField: 'FNumber', targetField: 'externalId', validation: [{ type: 'required' }] },
+          { sourceField: 'FName', targetField: 'name', validation: [{ type: 'required' }] },
+        ],
+      },
+      sourceSystem: { id: 'source-lookup-projection', ...LOOKUP_SYSTEM },
+      targetSystem: {
+        id: 'target-c6',
+        kind: 'data-source:sql-write-gated',
+        config: {
+          dataSourceId: 'target-data-source',
+          object: 'dbo.material',
+          keyFields: ['externalId'],
+          writableFields: ['name'],
+        },
+      },
+      sourceAdapter,
+      dataSourceWrites: {
+        async test() {
+          targetCalls.test += 1
+          return {
+            success: true,
+            capabilityState: { readOnly: false, c6WriteTarget: true, genericQueryDisabled: true },
+          }
+        },
+        async lookupByKey() {
+          targetCalls.lookup += 1
+          return { data: [], metadata: {} }
+        },
+        async insertRows() {
+          targetCalls.insert += 1
+          throw new Error('dry-run must not insert')
+        },
+        async updateRows() {
+          targetCalls.update += 1
+          throw new Error('dry-run must not update')
+        },
+      },
+      tokenStore: {
+        async get(key) { return tokenRecords.get(key) || null },
+        async set(key, value) { tokenRecords.set(key, value) },
+      },
+      dryRunUser: 'reviewer-1',
+      dataSourceOwnerPrincipal: 'owner-42',
+      maxRows: 3,
+    })
+    assert.equal(result.status, 'ready')
+    assert.equal(result.canApply, true)
+    assert.deepEqual(result.counts, {
+      sourceRows: 2,
+      planned: 2,
+      add: 2,
+      update: 0,
+      skip: 0,
+      held: 0,
+      failed: 0,
+    })
+    assert.deepEqual(targetCalls, { test: 1, lookup: 2, insert: 0, update: 0 })
+    assert.equal(sourceFacade.calls.select.length, 3)
+    assert.equal(tokenRecords.size, 1)
+    const publicText = JSON.stringify(result)
+    for (const privateValue of [
+      'C6-PRIVATE-PART-1',
+      'C6-PRIVATE-PART-2',
+      'C6-PRIVATE-CODE-1',
+      'C6-PRIVATE-CODE-2',
+      'C6-PRIVATE-NAME-1',
+      'C6-PRIVATE-NAME-2',
+    ]) {
+      assert.equal(publicText.includes(privateValue), false, 'C6 dry-run result stays values-free')
+    }
   }
 
   // 5. Read-only-source guard now lives in the host facade and fires on EVERY read path: a facade

--- a/plugins/plugin-integration-core/__tests__/external-systems.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/external-systems.test.cjs
@@ -211,6 +211,82 @@ async function main() {
   assert.deepEqual(adapterConfigSystem.credentials, { apiKey: 'credential-secret' },
     'adapter credentials still decrypt through private path')
 
+  // --- 4b. SQL lookup-projection identifiers stay on the private adapter load only ---
+  const projectionDb = createMockDb()
+  const projectionRegistry = createExternalSystemRegistry({
+    db: projectionDb,
+    credentialStore,
+    idGenerator: () => 'sys_lookup_projection',
+  })
+  const lookupProjection = {
+    baseObject: 'dbo.bom_detail',
+    lookupObject: 'dbo.part_library',
+    localKey: 'part_id',
+    foreignKey: 'OBJ_ID',
+    fields: { FNumber: 'IdentityNo', FName: 'IdentityName' },
+    maxRows: 3,
+  }
+  const publicProjectionCreate = await projectionRegistry.upsertExternalSystem({
+    tenantId: 'tenant_1',
+    name: 'private-sql-lookup-projection',
+    kind: 'data-source:sql-readonly',
+    role: 'source',
+    config: { dataSourceId: 'sql-readonly-1', schema: 'dbo', lookupProjection },
+    status: 'active',
+  })
+  assert.equal(publicProjectionCreate.config.dataSourceId, 'sql-readonly-1')
+  assert.equal(publicProjectionCreate.config.schema, 'dbo')
+  assert.equal(publicProjectionCreate.config.lookupProjection, undefined,
+    'public create response omits the complete private lookup projection')
+  const publicProjectionGet = await projectionRegistry.getExternalSystem({
+    tenantId: 'tenant_1',
+    id: 'sys_lookup_projection',
+  })
+  assert.equal(publicProjectionGet.config.lookupProjection, undefined,
+    'public get omits private SQL object/column identifiers')
+  const publicProjectionList = await projectionRegistry.listExternalSystems({
+    tenantId: 'tenant_1',
+    kind: 'data-source:sql-readonly',
+  })
+  assert.equal(publicProjectionList[0].config.lookupProjection, undefined,
+    'public list omits private SQL object/column identifiers')
+  const adapterProjectionSystem = await projectionRegistry.getExternalSystemForAdapter({
+    tenantId: 'tenant_1',
+    id: 'sys_lookup_projection',
+  })
+  assert.deepEqual(adapterProjectionSystem.config.lookupProjection, lookupProjection,
+    'private adapter load retains the persisted lookup projection exactly')
+  await projectionRegistry.upsertExternalSystem({
+    tenantId: 'tenant_1',
+    id: 'sys_lookup_projection',
+    name: 'private-sql-lookup-projection-renamed',
+    kind: 'data-source:sql-readonly',
+    role: 'source',
+    config: { dataSourceId: 'sql-readonly-1', schema: 'dbo' },
+    status: 'active',
+  })
+  const preservedProjectionSystem = await projectionRegistry.getExternalSystemForAdapter({
+    tenantId: 'tenant_1',
+    id: 'sys_lookup_projection',
+  })
+  assert.deepEqual(preservedProjectionSystem.config.lookupProjection, lookupProjection,
+    'public config round-trip cannot accidentally erase the hidden projection')
+  await projectionRegistry.upsertExternalSystem({
+    tenantId: 'tenant_1',
+    id: 'sys_lookup_projection',
+    name: 'private-sql-lookup-projection-renamed',
+    kind: 'data-source:sql-readonly',
+    role: 'source',
+    config: { dataSourceId: 'sql-readonly-1', schema: 'dbo', lookupProjection: null },
+    status: 'active',
+  })
+  const clearedProjectionSystem = await projectionRegistry.getExternalSystemForAdapter({
+    tenantId: 'tenant_1',
+    id: 'sys_lookup_projection',
+  })
+  assert.equal(clearedProjectionSystem.config.lookupProjection, null,
+    'trusted-admin explicit null clears the private lookup projection')
+
   // --- 5. Credential clear writes NULL ----------------------------------
   const cleared = await registry.upsertExternalSystem({
     tenantId: 'tenant_1',

--- a/plugins/plugin-integration-core/lib/adapters/data-source-sql-readonly-source-adapter.cjs
+++ b/plugins/plugin-integration-core/lib/adapters/data-source-sql-readonly-source-adapter.cjs
@@ -22,6 +22,19 @@ const { getPath, isBlank } = require('../transform-engine.cjs')
 const ADAPTER_KIND = 'data-source:sql-readonly'
 const WATERMARK_CURSOR_PREFIX = 'dswm1:'
 const WATERMARK_TYPES = new Set(['updated_at', 'monotonic_id'])
+const LOOKUP_PROJECTION_MAX_ROWS = 3
+const LOOKUP_PROJECTION_CONFIG_KEYS = new Set([
+  'baseObject',
+  'lookupObject',
+  'localKey',
+  'foreignKey',
+  'fields',
+  'maxRows',
+])
+const LOOKUP_PROJECTION_FIELD_ALIASES = Object.freeze(['FNumber', 'FName'])
+const FORBIDDEN_PROPERTY_KEYS = new Set(['__proto__', 'prototype', 'constructor'])
+const SQL_IDENTIFIER_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/
+const SQL_OBJECT_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)?$/
 
 // `requiredString` / `optionalString` are kept local (contracts.cjs only exposes them under
 // `__internals`); mirrors the staging adapter's approach.
@@ -43,6 +56,192 @@ function optionalString(value) {
 
 function isPlainObject(value) {
   return Boolean(value && typeof value === 'object' && !Array.isArray(value))
+}
+
+function isStrictPlainObject(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false
+  const prototype = Object.getPrototypeOf(value)
+  return prototype === Object.prototype || prototype === null
+}
+
+function snapshotAllowedObject(value, field, allowedKeys) {
+  if (!isStrictPlainObject(value)) {
+    throw new AdapterValidationError(`${field} must be a plain object`, { field })
+  }
+  const descriptors = Object.getOwnPropertyDescriptors(value)
+  const keys = Reflect.ownKeys(descriptors)
+  const out = Object.create(null)
+  for (const key of keys) {
+    if (typeof key !== 'string' || !allowedKeys.has(key)) {
+      throw new AdapterValidationError(`${field} contains an unsupported field`, { field })
+    }
+    const descriptor = descriptors[key]
+    if (!descriptor || !Object.prototype.hasOwnProperty.call(descriptor, 'value')) {
+      throw new AdapterValidationError(`${field} fields must be data properties`, { field })
+    }
+    out[key] = descriptor.value
+  }
+  return out
+}
+
+function requiredSqlIdentifier(value, field, { qualified = false } = {}) {
+  const patternMatches = typeof value === 'string' && (qualified ? SQL_OBJECT_PATTERN : SQL_IDENTIFIER_PATTERN).test(value)
+  const containsForbiddenSegment = patternMatches && value.split('.').some((segment) => FORBIDDEN_PROPERTY_KEYS.has(segment))
+  if (!patternMatches || containsForbiddenSegment) {
+    throw new AdapterValidationError(`${field} must be a SQL identifier`, { field })
+  }
+  return value
+}
+
+function normalizeLookupProjection(value) {
+  if (value === undefined || value === null) return null
+  const config = snapshotAllowedObject(value, 'config.lookupProjection', LOOKUP_PROJECTION_CONFIG_KEYS)
+  const fields = snapshotAllowedObject(
+    config.fields,
+    'config.lookupProjection.fields',
+    new Set(LOOKUP_PROJECTION_FIELD_ALIASES),
+  )
+  if (!LOOKUP_PROJECTION_FIELD_ALIASES.every((alias) => Object.prototype.hasOwnProperty.call(fields, alias))) {
+    throw new AdapterValidationError('config.lookupProjection.fields must define the required projection aliases', {
+      field: 'config.lookupProjection.fields',
+    })
+  }
+
+  const maxRows = config.maxRows === undefined ? LOOKUP_PROJECTION_MAX_ROWS : config.maxRows
+  if (typeof maxRows !== 'number' || !Number.isInteger(maxRows) || maxRows <= 0 || maxRows > LOOKUP_PROJECTION_MAX_ROWS) {
+    throw new AdapterValidationError('config.lookupProjection.maxRows must be an integer from 1 to 3', {
+      field: 'config.lookupProjection.maxRows',
+    })
+  }
+
+  const normalized = {
+    baseObject: requiredSqlIdentifier(config.baseObject, 'config.lookupProjection.baseObject', { qualified: true }),
+    lookupObject: requiredSqlIdentifier(config.lookupObject, 'config.lookupProjection.lookupObject', { qualified: true }),
+    localKey: requiredSqlIdentifier(config.localKey, 'config.lookupProjection.localKey'),
+    foreignKey: requiredSqlIdentifier(config.foreignKey, 'config.lookupProjection.foreignKey'),
+    fields: Object.freeze(Object.fromEntries(LOOKUP_PROJECTION_FIELD_ALIASES.map((alias) => [
+      alias,
+      requiredSqlIdentifier(fields[alias], `config.lookupProjection.fields.${alias}`),
+    ]))),
+    maxRows,
+  }
+  if (normalized.baseObject === normalized.lookupObject) {
+    throw new AdapterValidationError('config.lookupProjection lookup object must differ from the base object', {
+      field: 'config.lookupProjection.lookupObject',
+    })
+  }
+  if (new Set(Object.values(normalized.fields)).size !== LOOKUP_PROJECTION_FIELD_ALIASES.length) {
+    throw new AdapterValidationError('config.lookupProjection source fields must be distinct', {
+      field: 'config.lookupProjection.fields',
+    })
+  }
+  if (LOOKUP_PROJECTION_FIELD_ALIASES.includes(normalized.localKey)) {
+    throw new AdapterValidationError('config.lookupProjection local key conflicts with a projection alias', {
+      field: 'config.lookupProjection.localKey',
+    })
+  }
+  return Object.freeze(normalized)
+}
+
+function isNonBlankLookupKey(value) {
+  if (typeof value === 'string') return value.trim() !== ''
+  return typeof value === 'number' && Number.isFinite(value)
+}
+
+function isNonBlankProjectionString(value) {
+  return typeof value === 'string' && value.trim() !== ''
+}
+
+function assertLookupProjectionReadRequest(projection, request) {
+  if (!projection) return
+  if (request.object !== projection.baseObject) {
+    throw new AdapterValidationError('lookup projection is bound to a different source object', {
+      field: 'object',
+    })
+  }
+  if (request.limit > projection.maxRows) {
+    throw new AdapterValidationError('lookup projection read limit exceeds the server-bound maximum', {
+      field: 'limit',
+    })
+  }
+  if (hasOwnKeys(request.watermark) || hasOwnKeys(request.watermarkConfig)) {
+    throw new AdapterValidationError('lookup projection does not support watermark reads', {
+      field: 'watermark',
+    })
+  }
+}
+
+function coarseLookupProjectionError(message, field = 'config.lookupProjection') {
+  return new AdapterValidationError(message, { field })
+}
+
+function projectionScalarIdentity(value) {
+  return JSON.stringify([typeof value, value])
+}
+
+async function applyLookupProjection({ api, dataSourceId, principal, projection, records }) {
+  const enriched = []
+  const seenLocalKeys = new Set()
+  const seenMaterialCodes = new Set()
+  for (const record of records) {
+    if (!isStrictPlainObject(record)) {
+      throw coarseLookupProjectionError('lookup projection base row is invalid')
+    }
+    for (const alias of LOOKUP_PROJECTION_FIELD_ALIASES) {
+      if (Object.prototype.hasOwnProperty.call(record, alias)) {
+        throw coarseLookupProjectionError('lookup projection output alias collides with the base row')
+      }
+    }
+    const localValue = record[projection.localKey]
+    if (!isNonBlankLookupKey(localValue)) {
+      throw coarseLookupProjectionError('lookup projection base key is missing or invalid')
+    }
+    const localIdentity = projectionScalarIdentity(localValue)
+    if (seenLocalKeys.has(localIdentity)) {
+      throw coarseLookupProjectionError('lookup projection base keys must be unique')
+    }
+    seenLocalKeys.add(localIdentity)
+
+    let result
+    try {
+      result = await api.select(
+        dataSourceId,
+        projection.lookupObject,
+        {
+          limit: 2,
+          offset: 0,
+          where: { [projection.foreignKey]: localValue },
+        },
+        principal,
+      )
+    } catch {
+      throw coarseLookupProjectionError('lookup projection read failed')
+    }
+    if (result && result.error) {
+      throw coarseLookupProjectionError('lookup projection read failed')
+    }
+    const lookupRows = Array.isArray(result && result.data) ? result.data : []
+    if (lookupRows.length !== 1 || !isStrictPlainObject(lookupRows[0])) {
+      throw coarseLookupProjectionError('lookup projection did not resolve exactly one row')
+    }
+
+    const lookupRow = lookupRows[0]
+    const projected = {}
+    for (const alias of LOOKUP_PROJECTION_FIELD_ALIASES) {
+      const value = lookupRow[projection.fields[alias]]
+      if (!isNonBlankProjectionString(value)) {
+        throw coarseLookupProjectionError('lookup projection required field is missing or invalid')
+      }
+      projected[alias] = value
+    }
+    const materialCodeIdentity = projected.FNumber.trim().toLocaleLowerCase('en-US')
+    if (seenMaterialCodes.has(materialCodeIdentity)) {
+      throw coarseLookupProjectionError('lookup projection material codes must be unique')
+    }
+    seenMaterialCodes.add(materialCodeIdentity)
+    enriched.push({ ...record, ...projected })
+  }
+  return enriched
 }
 
 function hasOwnKeys(value) {
@@ -334,6 +533,9 @@ function createDataSourceSqlReadonlySourceAdapter({ system, context, principal }
   // The integration row carries only the reference to the data source — NEVER its credentials.
   const dataSourceId = requiredString(config.dataSourceId, 'config.dataSourceId')
   const schema = optionalString(config.schema)
+  // Optional projection is system-config-bound. A read request cannot choose or override its
+  // lookup object, keys, projected fields, or row bound.
+  const lookupProjection = normalizeLookupProjection(config.lookupProjection)
 
   return {
     async testConnection() {
@@ -372,6 +574,7 @@ function createDataSourceSqlReadonlySourceAdapter({ system, context, principal }
 
     async read(input = {}) {
       const request = normalizeReadRequest(input)
+      assertLookupProjectionReadRequest(lookupProjection, request)
       const api = getDataSourcesApi(context)
       const watermarkPlan = buildWatermarkReadPlan(request)
       const offset = watermarkPlan ? null : parseOffsetCursor(request.cursor)
@@ -381,17 +584,30 @@ function createDataSourceSqlReadonlySourceAdapter({ system, context, principal }
       const effectiveWhere = combineWhereClauses(where, watermarkPlan && watermarkPlan.where)
       if (effectiveWhere) selectOptions.where = effectiveWhere
       if (watermarkPlan) selectOptions.orderBy = watermarkPlan.orderBy
-      const result = await api.select(
-        dataSourceId,
-        request.object,
-        selectOptions,
-        principal
-      )
+      let result
+      try {
+        result = await api.select(
+          dataSourceId,
+          request.object,
+          selectOptions,
+          principal
+        )
+      } catch (error) {
+        if (lookupProjection) throw coarseLookupProjectionError('lookup projection base read failed')
+        throw error
+      }
       if (result && result.error) {
+        if (lookupProjection) throw coarseLookupProjectionError('lookup projection base read failed')
         throw result.error instanceof Error ? result.error : new Error(String(result.error))
       }
       const rows = Array.isArray(result && result.data) ? result.data : []
-      const records = rows.map((row) => (isPlainObject(row) ? { ...row } : row))
+      if (lookupProjection && rows.length > request.limit) {
+        throw coarseLookupProjectionError('lookup projection base read exceeded the server-bound row limit')
+      }
+      const baseRecords = rows.map((row) => (isPlainObject(row) ? { ...row } : row))
+      const records = lookupProjection
+        ? await applyLookupProjection({ api, dataSourceId, principal, projection: lookupProjection, records: baseRecords })
+        : baseRecords
       const fullPage = records.length >= request.limit
       const nextCursor = watermarkPlan && fullPage
         ? buildNextWatermarkCursor({ mode: watermarkPlan.mode, config: watermarkPlan.config, records })
@@ -411,6 +627,10 @@ function createDataSourceSqlReadonlySourceAdapter({ system, context, principal }
             watermarkField: watermarkPlan.config.field,
           } : { offset }),
           count: records.length,
+          ...(lookupProjection ? {
+            lookupProjectionApplied: true,
+            lookupProjectionRows: records.length,
+          } : {}),
         },
       })
     },
@@ -441,6 +661,11 @@ const DATA_SOURCE_SQL_READONLY_ADAPTER_METADATA = {
       maxRowsPerPage: 10000,
       noRawSql: true,
       dryRunFriendly: true,
+      serverBoundLookupProjection: {
+        requestConfigurable: false,
+        maxRowsPerPage: LOOKUP_PROJECTION_MAX_ROWS,
+        exactLookupMatchRequired: true,
+      },
     },
     write: {
       supported: false,

--- a/plugins/plugin-integration-core/lib/external-systems.cjs
+++ b/plugins/plugin-integration-core/lib/external-systems.cjs
@@ -18,6 +18,8 @@ const INSTANCE_DIGEST_KEY = crypto.randomBytes(32)
 const { sanitizeIntegrationPayload } = require('./payload-redaction.cjs')
 
 const TABLE = 'integration_external_systems'
+const SQL_READONLY_SOURCE_KIND = 'data-source:sql-readonly'
+const PRIVATE_SQL_READONLY_CONFIG_KEYS = new Set(['lookupProjection'])
 const VALID_ROLES = new Set(['source', 'target', 'bidirectional'])
 const VALID_STATUSES = new Set(['active', 'inactive', 'error'])
 
@@ -114,6 +116,13 @@ function scopeWhere({ tenantId, workspaceId }) {
 
 function rowToPublicExternalSystem(row, credentialFingerprint = null) {
   if (!row) return null
+  const sanitizedConfig = sanitizeIntegrationPayload(row.config ?? {})
+  const publicConfig = sanitizedConfig && typeof sanitizedConfig === 'object' && !Array.isArray(sanitizedConfig)
+    ? { ...sanitizedConfig }
+    : {}
+  if (row.kind === SQL_READONLY_SOURCE_KIND) {
+    for (const key of PRIVATE_SQL_READONLY_CONFIG_KEYS) delete publicConfig[key]
+  }
   return {
     id: row.id,
     tenantId: row.tenant_id,
@@ -122,7 +131,10 @@ function rowToPublicExternalSystem(row, credentialFingerprint = null) {
     name: row.name,
     kind: row.kind,
     role: row.role,
-    config: sanitizeIntegrationPayload(row.config ?? {}),
+    // SQL lookup-projection object/column identifiers are trusted-admin configuration. They stay
+    // available only through getExternalSystemForAdapter(); public create/get/list responses omit
+    // the whole private subtree rather than redacting individual values or exposing its shape.
+    config: publicConfig,
     capabilities: row.capabilities ?? {},
     status: row.status,
     lastTestedAt: row.last_tested_at ?? null,
@@ -192,6 +204,19 @@ function isPlainObject(value) {
   if (value === null || typeof value !== 'object' || Array.isArray(value)) return false
   const prototype = Object.getPrototypeOf(value)
   return prototype === Object.prototype || prototype === null
+}
+
+function preservePrivateConfigOnPublicUpdate(kind, existingConfig, nextConfig) {
+  if (kind !== SQL_READONLY_SOURCE_KIND || !isPlainObject(existingConfig) || !isPlainObject(nextConfig)) {
+    return nextConfig
+  }
+  const merged = { ...nextConfig }
+  for (const key of PRIVATE_SQL_READONLY_CONFIG_KEYS) {
+    if (!Object.prototype.hasOwnProperty.call(nextConfig, key) && Object.prototype.hasOwnProperty.call(existingConfig, key)) {
+      merged[key] = existingConfig[key]
+    }
+  }
+  return merged
 }
 
 async function maybeEncryptCredentials(credentialStore, credentials) {
@@ -270,8 +295,11 @@ function createExternalSystemRegistry({ db, credentialStore, idGenerator = crypt
       // Preserve stored config/capabilities when the caller did not explicitly
       // provide them. A status-only or name-only update must not wipe stored
       // connection config (baseUrl, orgId, etc.) or capability flags.
-      // Explicit null/empty-object still replaces (caller opted in).
+      // Explicit null/empty-object still replaces public config. Private SQL lookup-projection
+      // keys are the exception: public reads omit them, so their absence on update means preserve;
+      // a trusted-admin caller clears one explicitly with `{ lookupProjection: null }`.
       if (input.config === undefined) updateRow.config = existing.config
+      else updateRow.config = preservePrivateConfigOnPublicUpdate(existing.kind, existing.config, updateRow.config)
       if (input.capabilities === undefined) updateRow.capabilities = existing.capabilities
       if (credentialsEncrypted !== undefined) {
         updateRow.credentials_encrypted = credentialsEncrypted


### PR DESCRIPTION
## Summary

Adds an optional, persisted, server-bound lookup projection to the existing `data-source:sql-readonly` source adapter. This provides a no-DDL repair path when a bounded base read needs two authoritative material fields from one related read-only object.

Related owner decision: zensgit/metasheet2#4437, [`APPROVE_DRAFT_PR_REVIEW_ONLY_V1`](https://github.com/zensgit/metasheet2/issues/4437#issuecomment-5275278799).

This PR is intentionally Draft. It does not authorize Ready, merge, package, deployment, entity configuration, or operation16.

## Root cause

The already-filtered source returns the detail relation, while the required material code/name contract belongs to a related read-only relation. Guessing two columns from the detail shape is unsafe. The separately approved DBA-view lane stopped before DDL because its approved client/wrapper/private-config prerequisites were not established.

## Changes

- Adds strict `system.config.lookupProjection` normalization with a closed key set and SQL-identifier validation.
- Binds the projection to one base object and a maximum of three rows; request input cannot choose or override lookup configuration.
- Performs one structured equality lookup per base row with `limit=2`; requires exactly one result.
- Requires unique base lookup keys, nonblank string material fields, and unique normalized material codes.
- Fails closed on mismatch, over-limit rows, alias collisions, missing/invalid fields, 0/many lookup rows, or driver errors.
- Keeps projection errors values-free; raw driver messages and row values are not surfaced.
- Omits the private projection subtree from public external-system create/get/list responses while preserving it on ordinary public config updates; explicit `null` clears it.
- Leaves existing adapter behavior unchanged when no lookup projection is configured.

## Validation

- `external-systems.test.cjs`: PASS
- `data-source-sql-readonly-source-adapter.test.cjs`: PASS
- `adapter-contracts.test.cjs`: PASS
- `external-write-dry-run.test.cjs`: PASS
- `test-chain-completeness.test.cjs`: PASS (161 suites wired)
- production adapter syntax check: PASS
- `git diff --check`: PASS
- C6 composition control: `ready`, `sourceRows=2`, `planned=2`, `add=2`, target write calls `0`
- mutation control removing material-code uniqueness: PASS_DISCRIMINATING

The broader local Windows run completed 146/161 suites. The other 15 failures are in untouched environment-sensitive suites (Windows path separators, unavailable `python3`, directory-sync behavior, and existing pinned-artifact checks). They are not treated as passing; required Linux CI is the authoritative full-chain gate.

## Safety posture

- dependency manifest change: NO
- migration change: NO
- database DDL/DML: 0
- entity-server mutation: NO
- external writes: 0
- entity dry-run: 0
- credentials or business values published: NO
- independentHumanReviewClaimed: NO
