### PR TITLE
feat(dingtalk): add reversible staging HTTPS gateway

### DIFF
--- a/.github/workflows/dingtalk-interactive-card-stream-staging-uat.yml
+++ b/.github/workflows/dingtalk-interactive-card-stream-staging-uat.yml
@@ -6,7 +6,7 @@ run-name: "DingTalk Stream Staging UAT: ${{ inputs.action }}"
 # One dispatch = ONE action. Stream stays OFF except explicit action=on.
 # Lifecycle flags are NEVER written by this lane.
 #
-# EXECUTABLE: status | prepare | on | off
+# EXECUTABLE: status | prepare | on | off | https-on | https-off
 #   status  = read-only values-free snapshot (booleans / counts / reason classes)
 #   prepare = transport Stream credentials (chmod-600 files), derive exactly one
 #             active integration for live DINGTALK_CORP_ID with >=2 linked local users,
@@ -18,8 +18,11 @@ run-name: "DingTalk Stream Staging UAT: ${{ inputs.action }}"
 #             Does NOT prove SDK connected (connect resolves + retries forever);
 #             stream_connected stays unknown until real callback UAT.
 #   off     = fail-safe Stream flag false + backend restart + worker stop proof
+#   https-on  = provision a pinned Caddy TLS gateway on 443, atomically switch
+#               staging public/CORS/OAuth callback URLs, restart backend, verify
+#   https-off = restore the pre-HTTPS staging env and remove the TLS gateway
 #
-# Exact deployed FULL 40-char lowercase SHA required for prepare/on/off.
+# Exact deployed FULL 40-char lowercase SHA required for every mutating action.
 # Secrets (prepare only): STAGING_DINGTALK_INTERACTIVE_CARD_CLIENT_ID /
 #   _CLIENT_SECRET / _TEMPLATE_ID — demoted + file transport; never argv/env
 #   persistence beyond the materialize window. Integration id is derived on host.
@@ -33,14 +36,14 @@ on:
   workflow_dispatch:
     inputs:
       action:
-        description: 'status (read-only) | prepare (creds + force Stream OFF) | on (Stream ON) | off (fail-safe Stream OFF)'
+        description: 'status | prepare | on | off | https-on | https-off'
         required: true
         type: choice
         # Quote 'on'/'off' — YAML 1.1 bare on/off become booleans.
-        options: [status, prepare, 'on', 'off']
+        options: [status, prepare, 'on', 'off', https-on, https-off]
         default: status
       deploy_sha:
-        description: 'FULL 40-char lowercase commit SHA currently deployed on staging. Required for prepare/on/off; optional for status exact-match reporting.'
+        description: 'FULL 40-char lowercase commit SHA currently deployed on staging. Required for mutating actions; optional for status.'
         required: false
         default: ''
 
@@ -70,12 +73,12 @@ jobs:
           # (bash -n and other children must not inherit raw secret env).
         run: |
           set -euo pipefail
-          case "$ACTION" in status|prepare|on|off) ;; *)
+          case "$ACTION" in status|prepare|on|off|https-on|https-off) ;; *)
             echo "invalid action: $ACTION" >&2; exit 2
           ;; esac
 
-          # prepare/on/off require exact full SHA.
-          if [[ "$ACTION" == "prepare" || "$ACTION" == "on" || "$ACTION" == "off" ]]; then
+          # Every mutating action requires exact full SHA.
+          if [[ "$ACTION" != "status" ]]; then
             if [[ ! "$DEPLOY_SHA" =~ ^[0-9a-f]{40}$ ]]; then
               echo "deploy_sha must be the FULL 40-char lowercase commit SHA for action=${ACTION}, got: '$DEPLOY_SHA'" >&2
               exit 2
@@ -317,11 +320,12 @@ jobs:
             echo "- Remote rc: \`${REMOTE_RC:-missing}\`"
             echo "- Artifact: \`${ARTIFACT_NAME:-missing}\`"
             echo ""
-            echo "**Executable:** status / prepare / on / off."
+            echo "**Executable:** status / prepare / on / off / https-on / https-off."
             echo "prepare forces Stream OFF after writing credentials + derived integration id."
             echo "on flips ONLY Stream flag true after prerequisite + LOG_LEVEL checks; proves worker_started only."
             echo "stream_connected is always unknown here (SDK connect resolves + retries forever; not log-proven)."
             echo "off is fail-safe Stream OFF + worker stop proof."
+            echo "https-on/off manage only the pinned staging TLS gateway and three public URL keys."
             echo "Lifecycle flags are never written by this lane."
             echo "Does not implement human U1–U13 clicks; U12/U13 remain human-gated."
             echo "Artifacts are values-free (booleans / counts / reason classes / SHA only)."

--- a/scripts/ops/dingtalk-interactive-card-stream-staging-uat-contract.test.mjs
+++ b/scripts/ops/dingtalk-interactive-card-stream-staging-uat-contract.test.mjs
@@ -2,11 +2,11 @@
 // dingtalk-interactive-card-stream-staging-uat-contract.test.mjs
 //
 // Durable synthetic contract for the MINIMAL controlled Stream staging UAT lane:
-//   EXECUTABLE: status | prepare | on | off
+//   EXECUTABLE: status | prepare | on | off | https-on | https-off
 //
 // Load-bearing rails:
 //   * workflow wiring (dispatch choices, SSH, concurrency, no schedule)
-//   * exact-SHA gate for prepare/on/off
+//   * exact-SHA gate for every mutating action
 //   * secret demotion + chmod-600 file transport (prepare only)
 //   * prepare forces Stream OFF while writing four credential/id keys
 //   * on flips only Stream flag true after LOG_LEVEL + prerequisite checks
@@ -117,14 +117,14 @@ test('workflow YAML parses with repository-available parser', () => {
 
 // --- workflow wiring ------------------------------------------------------------------
 
-test('workflow action choices are status/prepare/on/off with status default', () => {
+test('workflow action choices include reversible HTTPS gateway actions', () => {
   const doc = loadYaml(read(WORKFLOW))
   const inputs = workflowOn(doc).workflow_dispatch.inputs
-  assert.deepEqual(inputs.action.options, ['status', 'prepare', 'on', 'off'])
+  assert.deepEqual(inputs.action.options, ['status', 'prepare', 'on', 'off', 'https-on', 'https-off'])
   assert.equal(inputs.action.default, 'status')
   // Quote on/off so YAML 1.1 keeps strings (loadYaml may coerce bare on/off).
   const yaml = read(WORKFLOW)
-  assert.match(yaml, /options:\s*\[status,\s*prepare,\s*'on',\s*'off'\]/)
+  assert.match(yaml, /options:\s*\[status,\s*prepare,\s*'on',\s*'off',\s*https-on,\s*https-off\]/)
   assert.ok(
     inputs.action.options.every((o) => typeof o === 'string'),
     'on/off must remain strings after parse',
@@ -196,12 +196,12 @@ test('contract suite is wired into the required Node 20 plugin-tests lane', () =
 
 // --- exact-SHA gate -------------------------------------------------------------------
 
-test('workflow exact-SHA gate requires full 40-char deploy_sha for prepare/on/off', () => {
+test('workflow exact-SHA gate requires full 40-char deploy_sha for every mutating action', () => {
   const yaml = read(WORKFLOW)
   const doc = loadYaml(yaml)
   const validate = doc.jobs.run.steps.find((s) => s.name === 'Validate inputs and embedded scripts')
   assert.equal(validate.env.DEPLOY_SHA, '${{ inputs.deploy_sha }}')
-  assert.match(validate.run, /ACTION" == "prepare" \|\| "\$ACTION" == "on" \|\| "\$ACTION" == "off"/)
+  assert.match(validate.run, /"\$ACTION" != "status"/)
   assert.match(
     validate.run,
     /deploy_sha must be the FULL 40-char lowercase commit SHA for action=\$\{ACTION\}/,
@@ -214,17 +214,21 @@ test('workflow exact-SHA gate requires full 40-char deploy_sha for prepare/on/of
   )
 })
 
-test('remote script require_exact_deployed_sha used by prepare/on/off and not status-only path', () => {
+test('remote script require_exact_deployed_sha used by every mutating action and not status', () => {
   const source = read(REMOTE_SH)
   assert.match(source, /require_exact_deployed_sha/)
   assert.match(source, /resolve_deployed_sha/)
   const prepare = actionBody(source, 'action_prepare', ['action_on'])
   const on = actionBody(source, 'action_on', ['action_off'])
-  const off = actionBody(source, 'action_off')
+  const off = actionBody(source, 'action_off', ['action_https_on'])
+  const httpsOn = actionBody(source, 'action_https_on', ['action_https_off'])
+  const httpsOff = actionBody(source, 'action_https_off')
   const status = actionBody(source, 'action_status', ['action_prepare'])
   assert.match(prepare, /require_exact_deployed_sha/)
   assert.match(on, /require_exact_deployed_sha/)
   assert.match(off, /require_exact_deployed_sha/)
+  assert.match(httpsOn, /require_exact_deployed_sha/)
+  assert.match(httpsOff, /require_exact_deployed_sha/)
   assert.doesNotMatch(status, /require_exact_deployed_sha/)
 })
 
@@ -677,7 +681,7 @@ test('action=on live STREAM_INTEGRATION_ID equals uniquely-derived anchor via fi
 
 test('remote off is fail-safe: forces Stream false, restarts, verifies worker stopped', () => {
   const source = read(REMOTE_SH)
-  const off = actionBody(source, 'action_off')
+  const off = actionBody(source, 'action_off', ['action_https_on'])
   assert.match(off, /atomic_set_stream_flag\s+"false"/)
   assert.match(off, /recreate_backend_only/)
   assert.match(off, /wait_for_worker_disabled/)
@@ -795,7 +799,7 @@ test('workflow and remote script never echo secrets or raw credential env values
 
 test('status artifacts emit only booleans/counts/reason classes/sha schema keys', () => {
   const source = read(REMOTE_SH)
-  assert.match(source, /schema=dingtalk-interactive-card-stream-staging-uat-status-v2/)
+  assert.match(source, /schema=dingtalk-interactive-card-stream-staging-uat-status-v3/)
   for (const key of [
     'stream_enabled=',
     'client_id_present=',
@@ -816,6 +820,21 @@ test('status artifacts emit only booleans/counts/reason classes/sha schema keys'
     'backend_health=',
     'deployed_sha=',
     'deployed_sha_match=',
+    'https_port_80_listener=',
+    'https_port_443_listener=',
+    'https_port_80_docker_publishers=',
+    'https_port_443_docker_publishers=',
+    'https_sudo_noninteractive=',
+    'https_host_nginx_present=',
+    'https_host_caddy_present=',
+    'https_host_certbot_present=',
+    'https_gateway_container_running=',
+    'https_gateway_health=',
+    'https_gateway_image_match=',
+    'https_env_backup_present=',
+    'https_public_url_match=',
+    'https_cors_origin_match=',
+    'https_dingtalk_redirect_match=',
   ]) {
     assert.match(source, new RegExp(key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')))
   }
@@ -841,6 +860,164 @@ test('status action is read-only: no env writes, no flag flips, no compose up', 
   assert.doesNotMatch(status, /compose_staging_cmd up/)
   assert.doesNotMatch(status, /mv -f/)
   assert.doesNotMatch(status, />>\s*"\$STAGING_ENV_FILE"/)
+})
+
+test('status reports only bounded HTTPS gateway facts', () => {
+  const source = read(REMOTE_SH)
+  assert.match(source, /probe_https_gateway_status/)
+  assert.match(source, /docker ps --format '\{\{\.Names\}\}\|\{\{\.Ports\}\}'/)
+  assert.match(source, /sudo -n true/)
+  assert.match(source, /https_port_80_docker_publishers=/)
+  assert.match(source, /https_port_443_docker_publishers=/)
+  assert.doesNotMatch(source, /docker inspect.*Env/)
+})
+
+test('https-on is pinned, exact-SHA gated, TLS-ALPN only, and rollback-armed', () => {
+  const source = read(REMOTE_SH)
+  const httpsOn = actionBody(source, 'action_https_on', ['action_https_off'])
+  assert.match(source, /caddy:2\.10\.2-alpine@sha256:[0-9a-f]{64}/)
+  assert.match(source, /disable_http_challenge/)
+  assert.match(source, /auto_https disable_redirects/)
+  assert.match(source, /"\$HTTPS_GATEWAY_IMAGE" caddy validate --config \/etc\/caddy\/Caddyfile/)
+  assert.match(httpsOn, /require_exact_deployed_sha/)
+  assert.match(httpsOn, /require_lifecycle_flags_off/)
+  assert.match(httpsOn, /requires Stream OFF/)
+  assert.match(httpsOn, /probe_tcp_listener 443/)
+  assert.match(httpsOn, /getent ahostsv4 "\$HTTPS_GATEWAY_HOST"/)
+  assert.match(httpsOn, /resolved_ip.*HTTPS_GATEWAY_EXPECTED_IP/)
+  assert.match(httpsOn, /arm_https_on_fail_safe_rollback/)
+  assert.match(httpsOn, /atomic_upsert_env_keys_from_files/)
+  assert.match(httpsOn, /PUBLIC_APP_URL/)
+  assert.match(httpsOn, /CORS_ORIGIN/)
+  assert.match(httpsOn, /DINGTALK_REDIRECT_URI/)
+  assert.match(httpsOn, /recreate_backend_only/)
+  assert.match(httpsOn, /disarm_https_on_fail_safe_rollback/)
+  assert.ok(
+    httpsOn.indexOf('arm_https_on_fail_safe_rollback') < httpsOn.indexOf('docker run -d'),
+    'rollback must arm before gateway mutation',
+  )
+})
+
+test('HTTPS transitions never write the Stream flag', () => {
+  const source = read(REMOTE_SH)
+  const httpsOn = actionBody(source, 'action_https_on', ['action_https_off'])
+  const httpsOff = actionBody(source, 'action_https_off')
+  assert.doesNotMatch(httpsOn, /atomic_set_stream_flag/)
+  assert.doesNotMatch(httpsOff, /atomic_set_stream_flag/)
+})
+
+test('HTTPS success requires a certificate valid for at least 24 hours', () => {
+  const source = read(REMOTE_SH)
+  const wait = actionBody(source, 'wait_for_https_gateway', ['require_https_live_env_matches'])
+  assert.match(wait, /openssl s_client .* -servername "\$HTTPS_GATEWAY_HOST"/)
+  assert.match(wait, /openssl x509 -checkend 86400 -noout/)
+})
+
+test('https-on rollback detects a completed env write and preserves the gateway when env restore fails', () => {
+  const source = read(REMOTE_SH)
+  const rollback = actionBody(source, 'https_on_fail_safe_rollback', ['arm_https_on_fail_safe_rollback'])
+  assert.match(rollback, /https_env_file_matches_gateway[\s\S]*env_match_rc=\$\?/)
+  assert.match(rollback, /HTTPS_ENV_WRITTEN.*true.*\|\|.*env_match_rc.*0/)
+  assert.match(rollback, /env_match_rc.*2[\s\S]*env_was_switched="unknown"/)
+  assert.match(rollback, /env_rc.*0.*&&.*recreate_rc.*0/)
+  assert.match(rollback, /gateway_rc=2/)
+  assert.match(rollback, /skipped_env_not_restored/)
+  assert.match(
+    rollback,
+    /if \[\[ "\$env_was_switched" == "false" \|\| \( "\$env_rc" == "0" && "\$recreate_rc" == "0" \) \]\]; then\s+remove_https_gateway_if_present \|\| gateway_rc=1\s+else[\s\S]*?gateway_rc=2/,
+  )
+})
+
+test('HTTPS env-state detection is tri-state and fails closed on unknown reads', () => {
+  const source = read(REMOTE_SH)
+  const detector = actionBody(source, 'https_env_file_matches_gateway', ['remove_https_gateway_if_present'])
+  assert.match(detector, /STAGING_ENV_FILE.*\|\| return 2/)
+  assert.match(detector, /UNKNOWN[\s\S]*return 2/)
+  assert.doesNotMatch(detector, /UNKNOWN[\s\S]*return 1/)
+})
+
+test('HTTPS env restore changes only the three URL keys and preserves intervening env changes', () => {
+  const source = read(REMOTE_SH)
+  const restore = actionBody(source, 'restore_https_env_backup', ['https_env_file_matches_gateway'])
+  assert.match(restore, /target_keys = \("PUBLIC_APP_URL", "CORS_ORIGIN", "DINGTALK_REDIRECT_URI"\)/)
+  assert.match(restore, /read_lines\(current_path\)/)
+  assert.match(restore, /backup_values/)
+  assert.doesNotMatch(restore, /cp -p "\$HTTPS_ENV_BACKUP" "\$candidate"/)
+})
+
+test('HTTPS restore helper dynamically restores only URL keys and removes backup-missing keys', () => {
+  const source = read(REMOTE_SH)
+  const restore = actionBody(source, 'restore_https_env_backup', ['https_env_file_matches_gateway'])
+  const match = restore.match(/cat >"\$py_script" <<'PY'\n([\s\S]*?)\nPY/)
+  assert.ok(match, 'embedded targeted restore script must be extractable')
+
+  const dir = mkdtempSync(join(tmpdir(), 'https-env-restore-'))
+  const current = join(dir, 'current.env')
+  const backup = join(dir, 'backup.env')
+  const candidate = join(dir, 'candidate.env')
+  try {
+    writeFileSync(
+      current,
+      [
+        'PUBLIC_APP_URL=https://gateway.example',
+        'CORS_ORIGIN=https://gateway.example',
+        'DINGTALK_REDIRECT_URI=https://gateway.example/login/dingtalk/callback',
+        'DINGTALK_INTERACTIVE_CARD_STREAM_ENABLED=true',
+        'ROTATED_CREDENTIAL=new-marker',
+      ].join('\n') + '\n',
+    )
+    writeFileSync(
+      backup,
+      [
+        'PUBLIC_APP_URL=http://old.example',
+        'CORS_ORIGIN=http://old.example',
+        'DINGTALK_INTERACTIVE_CARD_STREAM_ENABLED=false',
+        'ROTATED_CREDENTIAL=old-marker',
+      ].join('\n') + '\n',
+    )
+    const result = spawnSync('python3', ['-c', match[1], current, backup, candidate], {
+      encoding: 'utf8',
+    })
+    assert.equal(result.status, 0, result.stderr)
+    const restored = read(candidate)
+    assert.match(restored, /^PUBLIC_APP_URL=http:\/\/old\.example$/m)
+    assert.match(restored, /^CORS_ORIGIN=http:\/\/old\.example$/m)
+    assert.doesNotMatch(restored, /^DINGTALK_REDIRECT_URI=/m)
+    assert.match(restored, /^DINGTALK_INTERACTIVE_CARD_STREAM_ENABLED=true$/m)
+    assert.match(restored, /^ROTATED_CREDENTIAL=new-marker$/m)
+    assert.doesNotMatch(restored, /old-marker/)
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('https-off verifies restored live env and fails closed until the gateway is absent', () => {
+  const source = read(REMOTE_SH)
+  const httpsOff = actionBody(source, 'action_https_off')
+  assert.match(httpsOff, /restore_https_env_backup/)
+  assert.match(httpsOff, /recreate_backend_only/)
+  assert.match(httpsOff, /require_https_live_env_matches_backup/)
+  assert.match(httpsOff, /require_lifecycle_flags_off/)
+  assert.match(httpsOff, /requires Stream OFF/)
+  assert.match(httpsOff, /remove_https_gateway_if_present \|\| fail/)
+  assert.match(httpsOff, /rm -f "\$HTTPS_ENV_BACKUP" \|\| fail/)
+  assert.doesNotMatch(httpsOff, /docker rm -f[\s\S]*\|\| true/)
+  assert.ok(
+    httpsOff.indexOf('restore_https_env_backup') < httpsOff.indexOf('remove_https_gateway_if_present'),
+    'env/backend restore must precede gateway removal',
+  )
+  assert.ok(
+    httpsOff.indexOf('remove_https_gateway_if_present') < httpsOff.indexOf('write_status_artifact'),
+    'status success must follow verified gateway removal',
+  )
+})
+
+test('gateway removal helper treats absence as success but verifies a present container is gone', () => {
+  const source = read(REMOTE_SH)
+  const remove = actionBody(source, 'remove_https_gateway_if_present', ['https_on_fail_safe_rollback'])
+  assert.match(remove, /if ! docker inspect/)
+  assert.match(remove, /docker rm -f .* \|\| return 1/)
+  assert.match(remove, /! docker inspect/)
 })
 
 // --- lifecycle isolation --------------------------------------------------------------

--- a/scripts/ops/dingtalk-interactive-card-stream-staging-uat-contract.test.mjs
+++ b/scripts/ops/dingtalk-interactive-card-stream-staging-uat-contract.test.mjs
@@ -939,10 +939,145 @@ test('HTTPS env-state detection is tri-state and fails closed on unknown reads',
 test('HTTPS env restore changes only the three URL keys and preserves intervening env changes', () => {
   const source = read(REMOTE_SH)
   const restore = actionBody(source, 'restore_https_env_backup', ['https_env_file_matches_gateway'])
+  assert.match(restore, /require_https_env_backup_integrity \|\| return 1/)
   assert.match(restore, /target_keys = \("PUBLIC_APP_URL", "CORS_ORIGIN", "DINGTALK_REDIRECT_URI"\)/)
   assert.match(restore, /read_lines\(current_path\)/)
   assert.match(restore, /backup_values/)
   assert.doesNotMatch(restore, /cp -p "\$HTTPS_ENV_BACKUP" "\$candidate"/)
+})
+
+test('HTTPS backup is checksum-sealed before gateway mutation and verified before restore', () => {
+  const source = read(REMOTE_SH)
+  const httpsOn = actionBody(source, 'action_https_on', ['action_https_off'])
+  const httpsOff = actionBody(source, 'action_https_off')
+  assert.match(httpsOn, /write_https_env_backup_checksum \|\| fail/)
+  assert.ok(
+    httpsOn.indexOf('write_https_env_backup_checksum') < httpsOn.indexOf('docker pull'),
+    'backup must be sealed before gateway mutation',
+  )
+  assert.match(httpsOff, /require_https_env_backup_integrity \|\| fail/)
+  assert.ok(
+    httpsOff.indexOf('require_https_env_backup_integrity') <
+      httpsOff.indexOf('restore_https_env_backup'),
+    'backup integrity must be verified before restore',
+  )
+  assert.match(httpsOff, /rm -f "\$HTTPS_ENV_BACKUP" "\$HTTPS_ENV_BACKUP_SHA256"/)
+})
+
+test('HTTPS backup checksum detects tampering without printing values', () => {
+  const source = read(REMOTE_SH)
+  const writeChecksum = actionBody(source, 'write_https_env_backup_checksum', [
+    'validate_legacy_https_env_backup',
+  ])
+  const validateLegacy = actionBody(source, 'validate_legacy_https_env_backup', [
+    'require_https_env_backup_integrity',
+  ])
+  const requireIntegrity = actionBody(source, 'require_https_env_backup_integrity', [
+    'restore_https_env_backup',
+  ])
+  const dir = mkdtempSync(join(tmpdir(), 'https-env-checksum-'))
+  const backup = join(dir, 'backup.env')
+  const checksum = join(dir, 'backup.env.sha256')
+  try {
+    writeFileSync(
+      backup,
+      [
+        'PUBLIC_APP_URL=http://old.example',
+        'CORS_ORIGIN=http://old.example',
+        'DINGTALK_REDIRECT_URI=http://old.example/login/dingtalk/callback',
+      ].join('\n') + '\n',
+    )
+    const harness = `
+set -euo pipefail
+HTTPS_ENV_BACKUP="$1"
+HTTPS_ENV_BACKUP_SHA256="$2"
+HTTPS_GATEWAY_ORIGIN="https://gateway.example"
+HTTPS_GATEWAY_CALLBACK="https://gateway.example/login/dingtalk/callback"
+HTTPS_ENV_BACKUP_LEGACY_SEALED=false
+RUN_STAMP=test
+register_ephemeral() { :; }
+${writeChecksum}
+${validateLegacy}
+${requireIntegrity}
+write_https_env_backup_checksum
+require_https_env_backup_integrity
+printf '\\n# tampered\\n' >>"$HTTPS_ENV_BACKUP"
+if require_https_env_backup_integrity; then
+  exit 19
+fi
+`
+    const result = spawnSync('bash', ['-c', harness, 'bash', backup, checksum], {
+      encoding: 'utf8',
+    })
+    assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`)
+    assert.equal(result.stdout, '')
+    assert.equal(result.stderr, '')
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('legacy HTTPS backup adoption accepts one coherent prior URL triplet and rejects ambiguity', () => {
+  const source = read(REMOTE_SH)
+  const validator = actionBody(source, 'validate_legacy_https_env_backup', [
+    'require_https_env_backup_integrity',
+  ])
+  const match = validator.match(/<<'PY'\n([\s\S]*?)\nPY/)
+  assert.ok(match, 'legacy backup validator must be extractable')
+  const dir = mkdtempSync(join(tmpdir(), 'https-legacy-backup-'))
+  const backup = join(dir, 'backup.env')
+  const run = () =>
+    spawnSync(
+      'python3',
+      [
+        '-c',
+        match[1],
+        backup,
+        'https://gateway.example',
+        'https://gateway.example/login/dingtalk/callback',
+      ],
+      { encoding: 'utf8' },
+    )
+  try {
+    writeFileSync(
+      backup,
+      [
+        'PUBLIC_APP_URL=http://old.example',
+        'CORS_ORIGIN=http://old.example',
+        'DINGTALK_REDIRECT_URI=http://old.example/login/dingtalk/callback',
+      ].join('\n') + '\n',
+    )
+    assert.equal(run().status, 0)
+
+    writeFileSync(
+      backup,
+      [
+        'PUBLIC_APP_URL=http://old.example',
+        'PUBLIC_APP_URL=http://other.example',
+        'CORS_ORIGIN=http://old.example',
+        'DINGTALK_REDIRECT_URI=http://old.example/login/dingtalk/callback',
+      ].join('\n') + '\n',
+    )
+    assert.notEqual(run().status, 0, 'duplicate URL keys must be rejected')
+
+    writeFileSync(
+      backup,
+      [
+        'PUBLIC_APP_URL=https://gateway.example',
+        'CORS_ORIGIN=https://gateway.example',
+        'DINGTALK_REDIRECT_URI=https://gateway.example/login/dingtalk/callback',
+      ].join('\n') + '\n',
+    )
+    assert.notEqual(run().status, 0, 'already-gateway snapshot must be rejected')
+
+    writeFileSync(
+      backup,
+      ['PUBLIC_APP_URL=http://old.example', 'CORS_ORIGIN=http://old.example'].join('\n') + '\n',
+    )
+    assert.notEqual(run().status, 0, 'truncated snapshot must be rejected')
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
 })
 
 test('HTTPS restore helper dynamically restores only URL keys and removes backup-missing keys', () => {
@@ -999,8 +1134,9 @@ test('https-off verifies restored live env and fails closed until the gateway is
   assert.match(httpsOff, /require_https_live_env_matches_backup/)
   assert.match(httpsOff, /require_lifecycle_flags_off/)
   assert.match(httpsOff, /requires Stream OFF/)
+  assert.match(httpsOff, /HTTPS env backup integrity check failed/)
   assert.match(httpsOff, /remove_https_gateway_if_present \|\| fail/)
-  assert.match(httpsOff, /rm -f "\$HTTPS_ENV_BACKUP" \|\| fail/)
+  assert.match(httpsOff, /rm -f "\$HTTPS_ENV_BACKUP" "\$HTTPS_ENV_BACKUP_SHA256"/)
   assert.doesNotMatch(httpsOff, /docker rm -f[\s\S]*\|\| true/)
   assert.ok(
     httpsOff.indexOf('restore_https_env_backup') < httpsOff.indexOf('remove_https_gateway_if_present'),

--- a/scripts/ops/dingtalk-interactive-card-stream-staging-uat-remote.sh
+++ b/scripts/ops/dingtalk-interactive-card-stream-staging-uat-remote.sh
@@ -167,8 +167,94 @@ disarm_stream_on_fail_safe_rollback() {
   log "action=on fail-safe rollback DISARMED (on checks + artifact succeeded)"
 }
 
+write_https_env_backup_checksum() {
+  [[ -f "$HTTPS_ENV_BACKUP" ]] || return 1
+  local digest candidate
+  digest="$(sha256sum "$HTTPS_ENV_BACKUP" 2>/dev/null | awk '{print $1}')"
+  [[ "$digest" =~ ^[0-9a-f]{64}$ ]] || return 1
+  candidate="${HTTPS_ENV_BACKUP_SHA256}.${RUN_STAMP}.tmp"
+  register_ephemeral "$candidate"
+  umask 077
+  printf '%s\n' "$digest" >"$candidate" || return 1
+  chmod 600 "$candidate"
+  mv -f "$candidate" "$HTTPS_ENV_BACKUP_SHA256"
+  chmod 600 "$HTTPS_ENV_BACKUP_SHA256"
+}
+
+validate_legacy_https_env_backup() {
+  # Compatibility for the one staging gateway created before checksum sealing
+  # existed. Accept only one coherent, non-gateway URL triplet; never print it.
+  [[ -f "$HTTPS_ENV_BACKUP" ]] || return 1
+  python3 - "$HTTPS_ENV_BACKUP" "$HTTPS_GATEWAY_ORIGIN" "$HTTPS_GATEWAY_CALLBACK" <<'PY'
+import sys
+from urllib.parse import urlsplit
+
+path, gateway_origin, gateway_callback = sys.argv[1:]
+keys = ("PUBLIC_APP_URL", "CORS_ORIGIN", "DINGTALK_REDIRECT_URI")
+values = {key: [] for key in keys}
+
+with open(path, encoding="utf-8", errors="strict") as fh:
+    for raw in fh:
+        line = raw.rstrip("\r\n")
+        if not line.strip() or line.lstrip().startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        key = key.strip()
+        if key in values:
+            value = value.strip()
+            if len(value) >= 2 and value[0] == value[-1] and value[0] in "\"'":
+                value = value[1:-1]
+            values[key].append(value.strip())
+
+if any(len(values[key]) != 1 for key in keys):
+    raise SystemExit(1)
+
+def parsed(value):
+    result = urlsplit(value)
+    if result.scheme not in ("http", "https") or not result.hostname:
+        raise SystemExit(1)
+    if result.username or result.password or result.fragment:
+        raise SystemExit(1)
+    return result
+
+public = parsed(values["PUBLIC_APP_URL"][0])
+cors = parsed(values["CORS_ORIGIN"][0])
+redirect = parsed(values["DINGTALK_REDIRECT_URI"][0])
+
+def origin(result):
+    return f"{result.scheme}://{result.netloc}".rstrip("/")
+
+if origin(public) != origin(cors) or origin(public) != origin(redirect):
+    raise SystemExit(1)
+if redirect.path.rstrip("/") != "/login/dingtalk/callback":
+    raise SystemExit(1)
+if values["PUBLIC_APP_URL"][0].rstrip("/") == gateway_origin.rstrip("/"):
+    raise SystemExit(1)
+if values["DINGTALK_REDIRECT_URI"][0].rstrip("/") == gateway_callback.rstrip("/"):
+    raise SystemExit(1)
+PY
+}
+
+require_https_env_backup_integrity() {
+  [[ -f "$HTTPS_ENV_BACKUP" ]] || return 1
+  if [[ ! -f "$HTTPS_ENV_BACKUP_SHA256" ]]; then
+    validate_legacy_https_env_backup || return 1
+    write_https_env_backup_checksum || return 1
+    HTTPS_ENV_BACKUP_LEGACY_SEALED="true"
+  fi
+
+  local expected actual line_count
+  line_count="$(wc -l <"$HTTPS_ENV_BACKUP_SHA256" | tr -d '[:space:]')"
+  [[ "$line_count" == "1" ]] || return 1
+  expected="$(tr -d '\r\n' <"$HTTPS_ENV_BACKUP_SHA256")"
+  [[ "$expected" =~ ^[0-9a-f]{64}$ ]] || return 1
+  actual="$(sha256sum "$HTTPS_ENV_BACKUP" 2>/dev/null | awk '{print $1}')"
+  [[ "$actual" =~ ^[0-9a-f]{64}$ && "$actual" == "$expected" ]]
+}
+
 restore_https_env_backup() {
   [[ -f "$HTTPS_ENV_BACKUP" ]] || return 1
+  require_https_env_backup_integrity || return 1
   local candidate py_script
   candidate="$(mktemp "${STREAM_UAT_PERSIST_DIR}/.https-restore.XXXXXX")"
   register_ephemeral "$candidate"
@@ -285,10 +371,10 @@ https_on_fail_safe_rollback() {
     gateway_rc=2
   fi
   if [[ "$env_was_switched" == "true" && "$env_rc" == "0" && "$recreate_rc" == "0" && "$gateway_rc" == "0" ]]; then
-    rm -f "$HTTPS_ENV_BACKUP" || env_rc=1
+    rm -f "$HTTPS_ENV_BACKUP" "$HTTPS_ENV_BACKUP_SHA256" || env_rc=1
   fi
   if [[ "$env_was_switched" == "false" && "$gateway_rc" == "0" && -f "$HTTPS_ENV_BACKUP" ]]; then
-    rm -f "$HTTPS_ENV_BACKUP" || env_rc=1
+    rm -f "$HTTPS_ENV_BACKUP" "$HTTPS_ENV_BACKUP_SHA256" || env_rc=1
   fi
   rm -f "${STREAM_UAT_PERSIST_DIR}/app.staging.env.backup-${RUN_STAMP}" >/dev/null 2>&1 || env_rc=1
   {
@@ -421,6 +507,8 @@ mkdir -p "$STREAM_UAT_PERSIST_DIR"
 chmod 700 "$STREAM_UAT_PERSIST_DIR" 2>/dev/null || true
 HTTPS_GATEWAY_PERSIST_DIR="${HOME}/.metasheet2/staging-https-gateway"
 HTTPS_ENV_BACKUP="${HTTPS_GATEWAY_PERSIST_DIR}/app.staging.env.before-https"
+HTTPS_ENV_BACKUP_SHA256="${HTTPS_ENV_BACKUP}.sha256"
+HTTPS_ENV_BACKUP_LEGACY_SEALED="false"
 
 is_truthy() {
   local v
@@ -1809,10 +1897,12 @@ action_https_on() {
   local live_stream
   live_stream="$(read_flag_from_container "$FLAG_STREAM" || echo unknown)"
   [[ "$live_stream" == "false" ]] || fail "action=https-on requires Stream OFF (got ${live_stream})"
-  if [[ -e "$HTTPS_ENV_BACKUP" ]] && docker inspect "$HTTPS_GATEWAY_CONTAINER" >/dev/null 2>&1; then
+  if [[ -e "$HTTPS_ENV_BACKUP" || -e "$HTTPS_ENV_BACKUP_SHA256" ]] \
+      && docker inspect "$HTTPS_GATEWAY_CONTAINER" >/dev/null 2>&1; then
     fail "managed HTTPS gateway is already active; use status or https-off"
   fi
-  if [[ -e "$HTTPS_ENV_BACKUP" ]] || docker inspect "$HTTPS_GATEWAY_CONTAINER" >/dev/null 2>&1; then
+  if [[ -e "$HTTPS_ENV_BACKUP" || -e "$HTTPS_ENV_BACKUP_SHA256" ]] \
+      || docker inspect "$HTTPS_GATEWAY_CONTAINER" >/dev/null 2>&1; then
     fail "incomplete/unmanaged HTTPS gateway state; inspect backup and pinned container identity before retry"
   fi
   [[ "$(probe_tcp_listener 443)" == "false" ]] || fail "port 443 is already occupied; refuse gateway install"
@@ -1827,10 +1917,11 @@ action_https_on() {
   web_network="$(resolve_staging_web_network)"
   mkdir -p "$HTTPS_GATEWAY_PERSIST_DIR"
   chmod 700 "$HTTPS_GATEWAY_PERSIST_DIR"
+  arm_https_on_fail_safe_rollback
   cp -p "$STAGING_ENV_FILE" "$HTTPS_ENV_BACKUP"
   chmod 600 "$HTTPS_ENV_BACKUP"
+  write_https_env_backup_checksum || fail "failed to seal pre-HTTPS env backup"
 
-  arm_https_on_fail_safe_rollback
   docker pull "$HTTPS_GATEWAY_IMAGE" >/dev/null
   write_https_caddyfile
   docker run -d \
@@ -1880,6 +1971,7 @@ action_https_off() {
   require_lifecycle_flags_off "https-off"
   require_staging_env_file
   [[ -f "$HTTPS_ENV_BACKUP" ]] || fail "HTTPS env backup missing; refuse ambiguous rollback"
+  require_https_env_backup_integrity || fail "HTTPS env backup integrity check failed; refuse ambiguous rollback"
   [[ "$(read_flag_from_container "$FLAG_STREAM" || echo unknown)" == "false" ]] \
     || fail "action=https-off requires Stream OFF; run action=off first"
 
@@ -1891,11 +1983,13 @@ action_https_off() {
   [[ "$(read_flag_from_container "$FLAG_STREAM" || echo unknown)" == "false" ]] \
     || fail "Stream flag changed during HTTPS rollback"
   remove_https_gateway_if_present || fail "HTTPS gateway removal failed or container still exists"
-  rm -f "$HTTPS_ENV_BACKUP" || fail "HTTPS rollback verified but backup cleanup failed"
+  rm -f "$HTTPS_ENV_BACKUP" "$HTTPS_ENV_BACKUP_SHA256" \
+    || fail "HTTPS rollback verified but backup cleanup failed"
   write_status_artifact "https_off_ok"
   {
     echo "https_gateway_enabled=false"
     echo "https_env_restored=true"
+    echo "https_legacy_backup_sealed=${HTTPS_ENV_BACKUP_LEGACY_SEALED}"
     echo "stream_enabled=false"
     echo "lifecycle_flags_all_off=true"
   } >> "${OUTPUT_DIR}/summary.txt"

--- a/scripts/ops/dingtalk-interactive-card-stream-staging-uat-remote.sh
+++ b/scripts/ops/dingtalk-interactive-card-stream-staging-uat-remote.sh
@@ -25,13 +25,16 @@
 #             (human U12/U13).
 #   off     — fail-safe: flip Stream flag false, restart backend, prove worker
 #             stopped / not registered
+#   https-on  — provision a pinned Caddy TLS gateway on 443, atomically switch
+#               staging public/CORS/OAuth callback URLs, restart, verify
+#   https-off — restore the pre-HTTPS env and remove the gateway
 #
 # HARD SAFETY RAILS:
 #   * Staging compose + metasheet-staging-* containers only; no prod fallback.
 #   * Lifecycle flags (alias/pending/deprovision) are NEVER written by this lane.
 #   * Stream stays OFF except explicit action=on.
 #   * Secrets never appear in shell argv, exported env values, logs, or artifacts.
-#   * prepare/on/off require exact deployed 40-char lowercase SHA.
+#   * Every mutating action requires exact deployed 40-char lowercase SHA.
 #   * Artifacts: booleans / counts / reason enums / SHA only — no raw IDs/PII.
 #   * stream_connected is always unknown in this lane (no connect claim from logs).
 #   * U12/U13 remain human-gated (real callback / flag-off UAT); not automated.
@@ -41,7 +44,7 @@ set -euo pipefail
 log() { echo "[stream-uat] $*"; }
 fail() { echo "[stream-uat][error] $*" >&2; exit 1; }
 
-ACTION="${ACTION:?ACTION is required (status|prepare|on|off)}"
+ACTION="${ACTION:?ACTION is required (status|prepare|on|off|https-on|https-off)}"
 DEPLOY_SHA="${DEPLOY_SHA:-}"
 STAGING_DEPLOY_PATH="${STAGING_DEPLOY_PATH:-metasheet2-dingtalk-staging}"
 DEPLOY_PATH="${DEPLOY_PATH:-metasheet2}"
@@ -70,6 +73,13 @@ FLAG_ALIAS="AUTH_LOGIN_USE_ALIASES"
 FLAG_PENDING="DIRECTORY_PENDING_ACTIVATION_ENABLED"
 FLAG_DEPROVISION="DIRECTORY_DEPROVISION_ENABLED"
 
+HTTPS_GATEWAY_HOST="metasheet-staging.ddns.net"
+HTTPS_GATEWAY_EXPECTED_IP="23.254.236.11"
+HTTPS_GATEWAY_ORIGIN="https://${HTTPS_GATEWAY_HOST}"
+HTTPS_GATEWAY_CALLBACK="${HTTPS_GATEWAY_ORIGIN}/login/dingtalk/callback"
+HTTPS_GATEWAY_CONTAINER="metasheet-staging-https-gateway"
+HTTPS_GATEWAY_IMAGE="caddy:2.10.2-alpine@sha256:4c6e91c6ed0e2fa03efd5b44747b625fec79bc9cd06ac5235a779726618e530d"
+
 # Ephemeral temp paths cleaned by trap (chmod 600 where secrets live).
 EPHEMERAL_PATHS=()
 INTEGRATION_ID_FILE=""
@@ -82,6 +92,10 @@ STREAM_ON_ROLLBACK_ARMED="false"
 STREAM_ON_SUCCESS="false"
 STREAM_ON_ROLLBACK_DONE="false"
 STREAM_ON_ROLLBACK_RESULT=""
+HTTPS_ON_ROLLBACK_ARMED="false"
+HTTPS_ON_SUCCESS="false"
+HTTPS_ON_ROLLBACK_DONE="false"
+HTTPS_ENV_WRITTEN="false"
 TRAP_IN_PROGRESS="false"
 
 cleanup_ephemeral() {
@@ -153,6 +167,155 @@ disarm_stream_on_fail_safe_rollback() {
   log "action=on fail-safe rollback DISARMED (on checks + artifact succeeded)"
 }
 
+restore_https_env_backup() {
+  [[ -f "$HTTPS_ENV_BACKUP" ]] || return 1
+  local candidate py_script
+  candidate="$(mktemp "${STREAM_UAT_PERSIST_DIR}/.https-restore.XXXXXX")"
+  register_ephemeral "$candidate"
+  py_script="$(mktemp "${STREAM_UAT_PERSIST_DIR}/.https-restore-script.XXXXXX")"
+  register_ephemeral "$py_script"
+  cat >"$py_script" <<'PY'
+import os, sys
+
+current_path, backup_path, candidate_path = sys.argv[1:]
+target_keys = ("PUBLIC_APP_URL", "CORS_ORIGIN", "DINGTALK_REDIRECT_URI")
+
+def read_lines(path):
+    with open(path, encoding="utf-8", errors="strict") as fh:
+        return fh.read().splitlines()
+
+def key_for(line):
+    stripped = line.strip()
+    if not stripped or stripped.startswith("#") or "=" not in line:
+        return None
+    return line.split("=", 1)[0].strip()
+
+backup_values = {key: None for key in target_keys}
+for line in read_lines(backup_path):
+    key = key_for(line)
+    if key in backup_values:
+        backup_values[key] = line.split("=", 1)[1]
+
+out = []
+emitted = set()
+for line in read_lines(current_path):
+    key = key_for(line)
+    if key not in backup_values:
+        out.append(line)
+        continue
+    if key not in emitted and backup_values[key] is not None:
+        out.append(f"{key}={backup_values[key]}")
+    emitted.add(key)
+
+for key in target_keys:
+    if key not in emitted and backup_values[key] is not None:
+        out.append(f"{key}={backup_values[key]}")
+
+with open(candidate_path, "w", encoding="utf-8") as fh:
+    fh.write("\n".join(out) + "\n")
+os.chmod(candidate_path, 0o600)
+PY
+  python3 "$py_script" "$STAGING_ENV_FILE" "$HTTPS_ENV_BACKUP" "$candidate" \
+    || { rm -f "$candidate" "$py_script"; return 1; }
+  chmod 600 "$candidate"
+  compose_staging_cmd_with_env_file "$candidate" config >/dev/null 2>&1 \
+    || { rm -f "$candidate" "$py_script"; return 1; }
+  if ! ( atomic_replace_staging_env "$candidate" ); then
+    rm -f "$candidate" "$py_script"
+    return 1
+  fi
+  rm -f "$candidate" "$py_script"
+}
+
+https_env_file_matches_gateway() {
+  local origin_digest callback_digest public_digest cors_digest redirect_digest
+  [[ -f "$STAGING_ENV_FILE" ]] || return 2
+  origin_digest="$(printf '%s' "$HTTPS_GATEWAY_ORIGIN" | sha256sum | awk '{print $1}')"
+  callback_digest="$(printf '%s' "$HTTPS_GATEWAY_CALLBACK" | sha256sum | awk '{print $1}')"
+  public_digest="$(read_env_file_value_digest PUBLIC_APP_URL "$STAGING_ENV_FILE")"
+  cors_digest="$(read_env_file_value_digest CORS_ORIGIN "$STAGING_ENV_FILE")"
+  redirect_digest="$(read_env_file_value_digest DINGTALK_REDIRECT_URI "$STAGING_ENV_FILE")"
+  if [[ "$public_digest" == "UNKNOWN" || "$cors_digest" == "UNKNOWN" || "$redirect_digest" == "UNKNOWN" ]]; then
+    return 2
+  fi
+  [[ "$public_digest" == "$origin_digest" \
+    && "$cors_digest" == "$origin_digest" \
+    && "$redirect_digest" == "$callback_digest" ]]
+}
+
+remove_https_gateway_if_present() {
+  if ! docker inspect "$HTTPS_GATEWAY_CONTAINER" >/dev/null 2>&1; then
+    return 0
+  fi
+  docker rm -f "$HTTPS_GATEWAY_CONTAINER" >/dev/null 2>&1 || return 1
+  ! docker inspect "$HTTPS_GATEWAY_CONTAINER" >/dev/null 2>&1
+}
+
+https_on_fail_safe_rollback() {
+  if [[ "$HTTPS_ON_ROLLBACK_ARMED" != "true" || "$HTTPS_ON_SUCCESS" == "true" || "$HTTPS_ON_ROLLBACK_DONE" == "true" ]]; then
+    return 0
+  fi
+  HTTPS_ON_ROLLBACK_DONE="true"
+  set +e
+  local env_rc=0 recreate_rc=0 gateway_rc=0 env_was_switched="false" env_match_rc=1
+  https_env_file_matches_gateway
+  env_match_rc=$?
+  if [[ "$HTTPS_ENV_WRITTEN" == "true" || "$env_match_rc" == "0" ]]; then
+    env_was_switched="true"
+    ( restore_https_env_backup ) || env_rc=1
+    if [[ "$env_rc" == "0" ]]; then
+      ( recreate_backend_only ) || recreate_rc=1
+    else
+      recreate_rc=1
+    fi
+  elif [[ "$env_match_rc" == "2" ]]; then
+    # Unknown is not evidence of "not switched". Preserve both recovery assets.
+    env_was_switched="unknown"
+    env_rc=1
+    recreate_rc=1
+  elif [[ -f "$HTTPS_ENV_BACKUP" ]]; then
+    # No env write occurred. Keep the snapshot until gateway removal succeeds,
+    # so a failed removal never strands an unmanaged container without evidence.
+    :
+  fi
+  if [[ "$env_was_switched" == "false" || ( "$env_rc" == "0" && "$recreate_rc" == "0" ) ]]; then
+    remove_https_gateway_if_present || gateway_rc=1
+  else
+    # Keep the still-required gateway online when env rollback failed.
+    gateway_rc=2
+  fi
+  if [[ "$env_was_switched" == "true" && "$env_rc" == "0" && "$recreate_rc" == "0" && "$gateway_rc" == "0" ]]; then
+    rm -f "$HTTPS_ENV_BACKUP" || env_rc=1
+  fi
+  if [[ "$env_was_switched" == "false" && "$gateway_rc" == "0" && -f "$HTTPS_ENV_BACKUP" ]]; then
+    rm -f "$HTTPS_ENV_BACKUP" || env_rc=1
+  fi
+  rm -f "${STREAM_UAT_PERSIST_DIR}/app.staging.env.backup-${RUN_STAMP}" >/dev/null 2>&1 || env_rc=1
+  {
+    echo "https_on_fail_safe_rollback=true"
+    echo "https_env_restore_ok=$([[ "$env_rc" == "0" ]] && echo true || echo false)"
+    echo "https_backend_restore_ok=$([[ "$recreate_rc" == "0" ]] && echo true || echo false)"
+    case "$gateway_rc" in
+      0) echo "https_gateway_remove_result=removed_or_absent" ;;
+      1) echo "https_gateway_remove_result=failed" ;;
+      2) echo "https_gateway_remove_result=skipped_env_not_restored" ;;
+    esac
+  } >> "${OUTPUT_DIR}/summary.txt" 2>/dev/null
+  set -e
+}
+
+arm_https_on_fail_safe_rollback() {
+  HTTPS_ON_ROLLBACK_ARMED="true"
+  HTTPS_ON_SUCCESS="false"
+  HTTPS_ON_ROLLBACK_DONE="false"
+  HTTPS_ENV_WRITTEN="false"
+}
+
+disarm_https_on_fail_safe_rollback() {
+  HTTPS_ON_SUCCESS="true"
+  HTTPS_ON_ROLLBACK_ARMED="false"
+}
+
 # Unified trap: optional on-rollback, then ephemeral cleanup.
 # Do NOT register cleanup_ephemeral alone on signal traps — a return-only signal
 # handler lets the main script continue after a fatal signal. Every trapped fatal
@@ -180,6 +343,8 @@ on_script_trap() {
   set +e
   # Armed action=on window: force Stream OFF + recreate before process ends.
   stream_on_fail_safe_rollback
+  # Armed action=https-on window: restore env + remove TLS gateway.
+  https_on_fail_safe_rollback
   cleanup_ephemeral
   set -e
 
@@ -254,6 +419,8 @@ STAGING_ENV_FILE="${STAGING_DIR}/docker/app.staging.env"
 STREAM_UAT_PERSIST_DIR="${HOME}/.metasheet2/stream-uat"
 mkdir -p "$STREAM_UAT_PERSIST_DIR"
 chmod 700 "$STREAM_UAT_PERSIST_DIR" 2>/dev/null || true
+HTTPS_GATEWAY_PERSIST_DIR="${HOME}/.metasheet2/staging-https-gateway"
+HTTPS_ENV_BACKUP="${HTTPS_GATEWAY_PERSIST_DIR}/app.staging.env.before-https"
 
 is_truthy() {
   local v
@@ -1229,6 +1396,147 @@ require_stream_prerequisites_for_on() {
 }
 
 # --- artifact writers -----------------------------------------------------------------
+probe_tcp_listener() {
+  local port="$1"
+  if command -v ss >/dev/null 2>&1; then
+    if ss -H -ltn "sport = :${port}" 2>/dev/null | grep -q .; then
+      printf 'true'
+    else
+      printf 'false'
+    fi
+    return 0
+  fi
+  printf 'unknown'
+}
+
+docker_publishers_for_port() {
+  local port="$1"
+  local publishers
+  publishers="$(docker ps --format '{{.Names}}|{{.Ports}}' 2>/dev/null \
+    | awk -F '|' -v needle=":${port}->" 'index($2, needle) { print $1 }' \
+    | sort -u \
+    | paste -sd, -)"
+  if [[ -z "$publishers" ]]; then
+    printf 'none'
+    return 0
+  fi
+  if [[ ! "$publishers" =~ ^[A-Za-z0-9_.-]+(,[A-Za-z0-9_.-]+)*$ ]]; then
+    printf 'unknown'
+    return 0
+  fi
+  printf '%s' "$publishers"
+}
+
+probe_https_gateway_status() {
+  HTTPS_PORT_80_LISTENER="$(probe_tcp_listener 80)"
+  HTTPS_PORT_443_LISTENER="$(probe_tcp_listener 443)"
+  HTTPS_PORT_80_DOCKER_PUBLISHERS="$(docker_publishers_for_port 80)"
+  HTTPS_PORT_443_DOCKER_PUBLISHERS="$(docker_publishers_for_port 443)"
+  if sudo -n true >/dev/null 2>&1; then
+    HTTPS_SUDO_NONINTERACTIVE="true"
+  else
+    HTTPS_SUDO_NONINTERACTIVE="false"
+  fi
+  if command -v nginx >/dev/null 2>&1; then HTTPS_HOST_NGINX_PRESENT="true"; else HTTPS_HOST_NGINX_PRESENT="false"; fi
+  if command -v caddy >/dev/null 2>&1; then HTTPS_HOST_CADDY_PRESENT="true"; else HTTPS_HOST_CADDY_PRESENT="false"; fi
+  if command -v certbot >/dev/null 2>&1; then HTTPS_HOST_CERTBOT_PRESENT="true"; else HTTPS_HOST_CERTBOT_PRESENT="false"; fi
+  if docker inspect -f '{{.State.Running}}' "$HTTPS_GATEWAY_CONTAINER" 2>/dev/null | grep -qx true; then
+    HTTPS_GATEWAY_CONTAINER_RUNNING="true"
+  else
+    HTTPS_GATEWAY_CONTAINER_RUNNING="false"
+  fi
+  if [[ "$(docker inspect -f '{{.Config.Image}}' "$HTTPS_GATEWAY_CONTAINER" 2>/dev/null || true)" == "$HTTPS_GATEWAY_IMAGE" ]]; then
+    HTTPS_GATEWAY_IMAGE_MATCH="true"
+  else
+    HTTPS_GATEWAY_IMAGE_MATCH="false"
+  fi
+  if [[ -f "$HTTPS_ENV_BACKUP" ]]; then HTTPS_ENV_BACKUP_PRESENT="true"; else HTTPS_ENV_BACKUP_PRESENT="false"; fi
+  if curl -fsS --max-time 5 --resolve "${HTTPS_GATEWAY_HOST}:443:127.0.0.1" \
+      "${HTTPS_GATEWAY_ORIGIN}/api/health" >/dev/null 2>&1; then
+    HTTPS_GATEWAY_HEALTH="true"
+  else
+    HTTPS_GATEWAY_HEALTH="false"
+  fi
+  local expected_origin_digest expected_callback_digest
+  expected_origin_digest="$(printf '%s' "$HTTPS_GATEWAY_ORIGIN" | sha256sum | awk '{print $1}')"
+  expected_callback_digest="$(printf '%s' "$HTTPS_GATEWAY_CALLBACK" | sha256sum | awk '{print $1}')"
+  if [[ "$(env_key_digest_in_container PUBLIC_APP_URL)" == "$expected_origin_digest" ]]; then HTTPS_PUBLIC_URL_MATCH="true"; else HTTPS_PUBLIC_URL_MATCH="false"; fi
+  if [[ "$(env_key_digest_in_container CORS_ORIGIN)" == "$expected_origin_digest" ]]; then HTTPS_CORS_ORIGIN_MATCH="true"; else HTTPS_CORS_ORIGIN_MATCH="false"; fi
+  if [[ "$(env_key_digest_in_container DINGTALK_REDIRECT_URI)" == "$expected_callback_digest" ]]; then HTTPS_DINGTALK_REDIRECT_MATCH="true"; else HTTPS_DINGTALK_REDIRECT_MATCH="false"; fi
+}
+
+resolve_staging_web_network() {
+  local networks
+  mapfile -t networks < <(docker inspect -f '{{range $name, $_ := .NetworkSettings.Networks}}{{println $name}}{{end}}' "$WEB_CONTAINER" 2>/dev/null | sed '/^[[:space:]]*$/d' | sort -u)
+  [[ "${#networks[@]}" -eq 1 ]] || fail "staging web must have exactly one Docker network for isolated HTTPS gateway (count=${#networks[@]})"
+  [[ "${networks[0]}" =~ ^[A-Za-z0-9_.-]+$ ]] || fail "staging web network name contains unsafe characters"
+  printf '%s' "${networks[0]}"
+}
+
+write_https_caddyfile() {
+  mkdir -p "$HTTPS_GATEWAY_PERSIST_DIR/data" "$HTTPS_GATEWAY_PERSIST_DIR/config"
+  chmod 700 "$HTTPS_GATEWAY_PERSIST_DIR" "$HTTPS_GATEWAY_PERSIST_DIR/data" "$HTTPS_GATEWAY_PERSIST_DIR/config"
+  local candidate="${HTTPS_GATEWAY_PERSIST_DIR}/.Caddyfile.${RUN_STAMP}.tmp"
+  register_ephemeral "$candidate"
+  cat >"$candidate" <<EOF
+{
+  auto_https disable_redirects
+}
+
+${HTTPS_GATEWAY_HOST} {
+  tls {
+    issuer acme {
+      disable_http_challenge
+    }
+  }
+  reverse_proxy ${WEB_CONTAINER}:80
+}
+EOF
+  chmod 600 "$candidate"
+  docker run --rm --pull never --network none \
+    -v "${candidate}:/etc/caddy/Caddyfile:ro" \
+    "$HTTPS_GATEWAY_IMAGE" caddy validate --config /etc/caddy/Caddyfile >/dev/null
+  mv -f "$candidate" "${HTTPS_GATEWAY_PERSIST_DIR}/Caddyfile"
+  chmod 600 "${HTTPS_GATEWAY_PERSIST_DIR}/Caddyfile"
+}
+
+wait_for_https_gateway() {
+  local i
+  for ((i = 1; i <= 45; i += 1)); do
+    if curl -fsS --max-time 5 --resolve "${HTTPS_GATEWAY_HOST}:443:127.0.0.1" \
+        "${HTTPS_GATEWAY_ORIGIN}/api/health" >/dev/null 2>&1; then
+      if echo | openssl s_client -connect 127.0.0.1:443 -servername "$HTTPS_GATEWAY_HOST" 2>/dev/null \
+          | openssl x509 -checkend 86400 -noout >/dev/null 2>&1; then
+        log "HTTPS gateway health and certificate valid (attempt ${i}/45)"
+        return 0
+      fi
+    fi
+    sleep 2
+  done
+  echo "https_gateway_failure_class=health_or_certificate_timeout" \
+    > "${OUTPUT_DIR}/https-gateway-failure.txt"
+  return 1
+}
+
+require_https_live_env_matches() {
+  local origin_digest callback_digest
+  origin_digest="$(printf '%s' "$HTTPS_GATEWAY_ORIGIN" | sha256sum | awk '{print $1}')"
+  callback_digest="$(printf '%s' "$HTTPS_GATEWAY_CALLBACK" | sha256sum | awk '{print $1}')"
+  [[ "$(env_key_digest_in_container PUBLIC_APP_URL)" == "$origin_digest" ]] || fail "live PUBLIC_APP_URL does not match HTTPS gateway"
+  [[ "$(env_key_digest_in_container CORS_ORIGIN)" == "$origin_digest" ]] || fail "live CORS_ORIGIN does not match HTTPS gateway"
+  [[ "$(env_key_digest_in_container DINGTALK_REDIRECT_URI)" == "$callback_digest" ]] || fail "live DINGTALK_REDIRECT_URI does not match HTTPS callback"
+}
+
+require_https_live_env_matches_backup() {
+  local key backup_digest live_digest
+  for key in PUBLIC_APP_URL CORS_ORIGIN DINGTALK_REDIRECT_URI; do
+    backup_digest="$(read_env_file_value_digest "$key" "$HTTPS_ENV_BACKUP")"
+    live_digest="$(env_key_digest_in_container "$key")"
+    [[ "$backup_digest" == "$live_digest" ]] \
+      || fail "live ${key} does not match the pre-HTTPS backup (digest mismatch; values not printed)"
+  done
+}
+
 write_status_artifact() {
   local reason="${1:-ok}"
   local live_sha stream_on cid csec tmpl integ lifecycle health worker
@@ -1251,6 +1559,7 @@ write_status_artifact() {
   eligible_count="$(parse_probe_field "$probe" eligible_anchor_count)"
   linked="$(parse_probe_field "$probe" linked_users)"
   ready="$(parse_probe_field "$probe" ready)"
+  probe_https_gateway_status
 
   local sha_match="unknown"
   if [[ -n "$DEPLOY_SHA" ]]; then
@@ -1264,7 +1573,7 @@ write_status_artifact() {
   fi
 
   {
-    echo "schema=dingtalk-interactive-card-stream-staging-uat-status-v2"
+    echo "schema=dingtalk-interactive-card-stream-staging-uat-status-v3"
     echo "action=${ACTION}"
     echo "reason=${reason}"
     echo "deployed_sha=${live_sha}"
@@ -1287,10 +1596,25 @@ write_status_artifact() {
     echo "worker_state=${worker}"
     # Never claim connected from startup logs; human U12/U13 only.
     echo "stream_connected=${STREAM_CONNECTED_UNKNOWN}"
+    echo "https_port_80_listener=${HTTPS_PORT_80_LISTENER}"
+    echo "https_port_443_listener=${HTTPS_PORT_443_LISTENER}"
+    echo "https_port_80_docker_publishers=${HTTPS_PORT_80_DOCKER_PUBLISHERS}"
+    echo "https_port_443_docker_publishers=${HTTPS_PORT_443_DOCKER_PUBLISHERS}"
+    echo "https_sudo_noninteractive=${HTTPS_SUDO_NONINTERACTIVE}"
+    echo "https_host_nginx_present=${HTTPS_HOST_NGINX_PRESENT}"
+    echo "https_host_caddy_present=${HTTPS_HOST_CADDY_PRESENT}"
+    echo "https_host_certbot_present=${HTTPS_HOST_CERTBOT_PRESENT}"
+    echo "https_gateway_container_running=${HTTPS_GATEWAY_CONTAINER_RUNNING}"
+    echo "https_gateway_health=${HTTPS_GATEWAY_HEALTH}"
+    echo "https_gateway_image_match=${HTTPS_GATEWAY_IMAGE_MATCH}"
+    echo "https_env_backup_present=${HTTPS_ENV_BACKUP_PRESENT}"
+    echo "https_public_url_match=${HTTPS_PUBLIC_URL_MATCH}"
+    echo "https_cors_origin_match=${HTTPS_CORS_ORIGIN_MATCH}"
+    echo "https_dingtalk_redirect_match=${HTTPS_DINGTALK_REDIRECT_MATCH}"
   } > "${OUTPUT_DIR}/stream-uat-status.txt"
 
   {
-    echo "schema=dingtalk-interactive-card-stream-staging-uat-status-v2"
+    echo "schema=dingtalk-interactive-card-stream-staging-uat-status-v3"
     echo "action=${ACTION}"
     echo "reason=${reason}"
     echo "stream_enabled=${stream_on}"
@@ -1474,6 +1798,110 @@ action_off() {
   log "action=off complete (stream OFF; worker stopped/not registered; stream_connected still unknown)"
 }
 
+action_https_on() {
+  assert_staging_only
+  require_compose_v2
+  require_exact_deployed_sha "https-on"
+  pin_live_backend_image_for_transition
+  require_lifecycle_flags_off "https-on"
+  require_staging_env_file
+
+  local live_stream
+  live_stream="$(read_flag_from_container "$FLAG_STREAM" || echo unknown)"
+  [[ "$live_stream" == "false" ]] || fail "action=https-on requires Stream OFF (got ${live_stream})"
+  if [[ -e "$HTTPS_ENV_BACKUP" ]] && docker inspect "$HTTPS_GATEWAY_CONTAINER" >/dev/null 2>&1; then
+    fail "managed HTTPS gateway is already active; use status or https-off"
+  fi
+  if [[ -e "$HTTPS_ENV_BACKUP" ]] || docker inspect "$HTTPS_GATEWAY_CONTAINER" >/dev/null 2>&1; then
+    fail "incomplete/unmanaged HTTPS gateway state; inspect backup and pinned container identity before retry"
+  fi
+  [[ "$(probe_tcp_listener 443)" == "false" ]] || fail "port 443 is already occupied; refuse gateway install"
+
+  local resolved_ip
+  resolved_ip="$(getent ahostsv4 "$HTTPS_GATEWAY_HOST" 2>/dev/null | awk 'NR == 1 { print $1 }')"
+  [[ "$resolved_ip" == "$HTTPS_GATEWAY_EXPECTED_IP" ]] || fail "HTTPS gateway DNS does not resolve to expected staging IP"
+  command -v curl >/dev/null 2>&1 || fail "curl is required for HTTPS verification"
+  command -v openssl >/dev/null 2>&1 || fail "openssl is required for certificate verification"
+
+  local web_network
+  web_network="$(resolve_staging_web_network)"
+  mkdir -p "$HTTPS_GATEWAY_PERSIST_DIR"
+  chmod 700 "$HTTPS_GATEWAY_PERSIST_DIR"
+  cp -p "$STAGING_ENV_FILE" "$HTTPS_ENV_BACKUP"
+  chmod 600 "$HTTPS_ENV_BACKUP"
+
+  arm_https_on_fail_safe_rollback
+  docker pull "$HTTPS_GATEWAY_IMAGE" >/dev/null
+  write_https_caddyfile
+  docker run -d \
+    --name "$HTTPS_GATEWAY_CONTAINER" \
+    --restart unless-stopped \
+    --network "$web_network" \
+    -p 443:443/tcp \
+    -p 443:443/udp \
+    -v "${HTTPS_GATEWAY_PERSIST_DIR}/Caddyfile:/etc/caddy/Caddyfile:ro" \
+    -v "${HTTPS_GATEWAY_PERSIST_DIR}/data:/data" \
+    -v "${HTTPS_GATEWAY_PERSIST_DIR}/config:/config" \
+    "$HTTPS_GATEWAY_IMAGE" >/dev/null
+
+  wait_for_https_gateway || fail "HTTPS gateway did not obtain a valid certificate/health response"
+
+  atomic_upsert_env_keys_from_files \
+    PUBLIC_APP_URL "@literal:${HTTPS_GATEWAY_ORIGIN}" \
+    CORS_ORIGIN "@literal:${HTTPS_GATEWAY_ORIGIN}" \
+    DINGTALK_REDIRECT_URI "@literal:${HTTPS_GATEWAY_CALLBACK}"
+  HTTPS_ENV_WRITTEN="true"
+  rm -f "${STREAM_UAT_PERSIST_DIR}/app.staging.env.backup-${RUN_STAMP}"
+
+  recreate_backend_only || fail "backend restart failed after HTTPS env switch"
+  require_exact_deployed_sha "https-on-post-restart"
+  require_https_live_env_matches
+  require_lifecycle_flags_off "https-on-post"
+  [[ "$(read_flag_from_container "$FLAG_STREAM" || echo unknown)" == "false" ]] || fail "Stream flag changed during HTTPS transition"
+  wait_for_https_gateway || fail "HTTPS gateway failed post-restart verification"
+
+  write_status_artifact "https_on_ok"
+  {
+    echo "https_gateway_enabled=true"
+    echo "https_certificate_valid=true"
+    echo "https_env_switched=true"
+    echo "stream_enabled=false"
+    echo "lifecycle_flags_all_off=true"
+  } >> "${OUTPUT_DIR}/summary.txt"
+  disarm_https_on_fail_safe_rollback
+  log "action=https-on complete (HTTPS ready; Stream/lifecycle flags remain OFF)"
+}
+
+action_https_off() {
+  assert_staging_only
+  require_compose_v2
+  require_exact_deployed_sha "https-off"
+  pin_live_backend_image_for_transition
+  require_lifecycle_flags_off "https-off"
+  require_staging_env_file
+  [[ -f "$HTTPS_ENV_BACKUP" ]] || fail "HTTPS env backup missing; refuse ambiguous rollback"
+  [[ "$(read_flag_from_container "$FLAG_STREAM" || echo unknown)" == "false" ]] \
+    || fail "action=https-off requires Stream OFF; run action=off first"
+
+  restore_https_env_backup || fail "failed to restore pre-HTTPS staging env"
+  recreate_backend_only || fail "backend restart failed after HTTPS env restore"
+  require_exact_deployed_sha "https-off-post-restart"
+  require_https_live_env_matches_backup
+  require_lifecycle_flags_off "https-off-post"
+  [[ "$(read_flag_from_container "$FLAG_STREAM" || echo unknown)" == "false" ]] \
+    || fail "Stream flag changed during HTTPS rollback"
+  remove_https_gateway_if_present || fail "HTTPS gateway removal failed or container still exists"
+  rm -f "$HTTPS_ENV_BACKUP" || fail "HTTPS rollback verified but backup cleanup failed"
+  write_status_artifact "https_off_ok"
+  {
+    echo "https_gateway_enabled=false"
+    echo "https_env_restored=true"
+    echo "stream_enabled=false"
+    echo "lifecycle_flags_all_off=true"
+  } >> "${OUTPUT_DIR}/summary.txt"
+  log "action=https-off complete (pre-HTTPS env restored; gateway removed)"
+}
+
 # --- main -----------------------------------------------------------------------------
 mkdir -p "$OUTPUT_DIR"
 chmod 700 "$OUTPUT_DIR" 2>/dev/null || true
@@ -1483,7 +1911,9 @@ case "$ACTION" in
   prepare) action_prepare ;;
   on) action_on ;;
   off) action_off ;;
-  *) fail "invalid ACTION='${ACTION}' (expected status|prepare|on|off)" ;;
+  https-on) action_https_on ;;
+  https-off) action_https_off ;;
+  *) fail "invalid ACTION='${ACTION}' (expected status|prepare|on|off|https-on|https-off)" ;;
 esac
 
 log "done action=${ACTION}"


### PR DESCRIPTION
## What

- extend the existing staging-only DingTalk Stream UAT lane with bounded HTTPS gateway status
- add exact-SHA-gated `https-on` / `https-off` actions
- provision the digest-pinned Caddy gateway for `metasheet-staging.ddns.net` on port 443 using TLS-ALPN only
- atomically switch and restore only `PUBLIC_APP_URL`, `CORS_ORIGIN`, and `DINGTALK_REDIRECT_URI`
- keep Stream and all lifecycle flags OFF throughout HTTPS transitions

## Why

The staging DingTalk OAuth callback needs a trusted HTTPS origin. The gateway is already live on staging, but its implementation and rollback contract must be durable on main before Stream UAT proceeds.

## Safety corrections in exact head

- rollback keeps the gateway online when env restore or backend recreate fails
- signal-window detection is tri-state; `UNKNOWN` preserves gateway and backups
- `https-off` fails unless the restored live env matches the pre-HTTPS URL values and the named gateway is verified absent
- restore patches only the three URL keys, preserving intervening Stream credentials and unrelated env changes
- gateway removal errors are never swallowed; success artifacts are written only after verified removal
- raw Caddy logs are not uploaded; failures emit a bounded reason class
- unknown or incomplete existing-container state is not auto-adopted

## Verification

- exact head: `a710d83796025564eab417fcbfb04a6923b0561e`
- rebuilt on main `eadd2dd88bf084bf20318fd4b4513c721654f4b9`
- net diff: exactly 3 files, stable patch-id `e96cc582a3c59038e9a0da6bc947fef9100734ca`
- prior HTTPS implementation patch-id preserved across refresh: `b15e6391ea6fad950945b73a27846065bc32631f`
- `bash -n scripts/ops/dingtalk-interactive-card-stream-staging-uat-remote.sh`
- `node --test scripts/ops/dingtalk-interactive-card-stream-staging-uat-contract.test.mjs` - 42/42 pass
- dynamic fixture executes the embedded targeted-restore Python and proves unrelated env changes survive
- mutations removing the port-443 guard, DNS expected-IP pin, or 24-hour certificate check each redden its named contract test
- mutation adding a Stream flag write to `https-on` reddens the transition-isolation test
- mutation making gateway removal unconditional reddens the rollback structure test
- independent Kimi adversarial review: APPROVE, 0 P1/P2 after the three P2 coverage gaps were closed
- exact-head GitHub checks: 14 success, 0 pending, 0 fail; merge state CLEAN

## Runtime evidence already obtained

- live gateway container uses the pinned `caddy:2.10.2-alpine` digest and the DDNS hostname
- staging OAuth is healthy and lifecycle flags remain OFF
- Stream remains OFF; no `prepare`, `on`, `https-on`, or `https-off` action was executed during this refresh

## Rollback

After this PR is merged and its exact merge SHA is deployed, dispatch `https-off` only with that exact deployed SHA. It restores only the three pre-HTTPS URL keys, recreates the backend, verifies live digests and OFF invariants, removes and verifies absence of the named gateway, then removes the secret-bearing backup.

## Current posture

Draft and unarmed. The live gateway remains in place; Stream prepare/on and all lifecycle switches remain owner-gated and were not changed.
