### PR TITLE
feat(attendance): W6-2 OpenAPI contract wiring (#4556)

### DIFF
--- a/packages/core-backend/src/attendance/w6-group-effective-policy-response-contract.ts
+++ b/packages/core-backend/src/attendance/w6-group-effective-policy-response-contract.ts
@@ -41,7 +41,17 @@ import {
 const FSER_POSITION_REASON_CODES = new Set(ATTENDANCE_GROUP_EFFECTIVE_POLICY_FSER_REASON_CODES_V1)
 const DOMAIN_POSITION_REASON_CODES = new Set(ATTENDANCE_GROUP_EFFECTIVE_POLICY_DOMAIN_REASON_CODES_V1)
 
-const CALCULATION_POSTURES: readonly AttendanceGroupEffectivePolicyCalculationPostureV1[] = Object.freeze([
+// W6-2 (#4556) §7.3: these five closed sets have no separate hand-maintained
+// array in the TS contract module (`w6-group-effective-policy-contract.ts`)
+// — only an inline literal-union TYPE there. This file's own array IS the
+// concrete TS-side value for each, so each is exported (pure visibility
+// change, no behaviour change) for
+// `tests/unit/attendance-w6-2-enum-parity.test.ts` to import directly rather
+// than hand-copy. The runtime-behaviour leg stays independently meaningful:
+// it probes the actual validator functions below, which is a different
+// property than "does this array literal match" (a stray extra branch in
+// the `if` checks that use these arrays would drift the two apart).
+export const CALCULATION_POSTURES: readonly AttendanceGroupEffectivePolicyCalculationPostureV1[] = Object.freeze([
   'legacy',
   'shadow',
   'eligible',
@@ -49,16 +59,16 @@ const CALCULATION_POSTURES: readonly AttendanceGroupEffectivePolicyCalculationPo
   'suspended',
 ])
 
-const GROUP_TYPES: readonly AttendanceGroupEffectivePolicyGroupTypeV1[] = Object.freeze([
+export const GROUP_TYPES: readonly AttendanceGroupEffectivePolicyGroupTypeV1[] = Object.freeze([
   'fixed_shift',
   'scheduled_shift',
   'free_time',
 ])
 
-const FSER_STATES = Object.freeze(['not_configured', 'pending_apply', 'effective', 'configuration_changed'])
+export const FSER_STATES = Object.freeze(['not_configured', 'pending_apply', 'effective', 'configuration_changed'])
 
-const FLEX_MODES = Object.freeze(['strict', 'flex_required_duration'])
-const RULE_SOURCES = Object.freeze(['org_default', 'group_rule_set'])
+export const FLEX_MODES = Object.freeze(['strict', 'flex_required_duration'])
+export const RULE_SOURCES = Object.freeze(['org_default', 'group_rule_set'])
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 /**
  * W6-R8: the #4711 closed step/surface table, re-declared here because the
@@ -78,7 +88,7 @@ export const SCHEDULE_ROUTE_SURFACES: Record<string, readonly string[] | null> =
   calendar: null,
   rules: ['rule-sets'],
 })
-const GROUP_STAGES = Object.freeze(['basics', 'people', 'schedule', 'policies'])
+export const GROUP_STAGES = Object.freeze(['basics', 'people', 'schedule', 'policies'])
 /**
  * The sourceRef `kind` set the validator gates payloads with — imported from
  * the contract module (also the source the exported TS `kind` type derives

--- a/packages/core-backend/tests/unit/attendance-w6-2-enum-parity.test.ts
+++ b/packages/core-backend/tests/unit/attendance-w6-2-enum-parity.test.ts
@@ -8,11 +8,12 @@
  *   second list)."
  *
  * §7.3 bullet 2 says EVERY published closed enum, not just a sample. The
- * promoted schema block declares 22 raw `enum:` stanzas. This file pins 20
- * of them, counted as 21 logical positions (`editorRef.kind`'s two
- * one-value oneOf-branch stanzas — `[group_stage]` and
- * `[group_context_route]` — are one logical two-value union, tested as one
- * case, not two): the original three (SourceLabel, Domain, ConflictCode),
+ * promoted schema block declares 22 raw `enum:` stanzas. This file pins 21
+ * of them (1 deliberate exclusion — the envelope `ok:[true]` structural
+ * success/failure discriminator, which has no value domain), expressed as 20
+ * logical cases (`editorRef.kind`'s two one-value oneOf-branch stanzas —
+ * `[group_stage]` and `[group_context_route]` — are one logical two-value
+ * union, tested as one case, not two): the original three (SourceLabel, Domain, ConflictCode),
  * SourceRef.kind, FSER state, FSER reasonCodes, editorRef
  * kind/stage/step/surface, calculationPosture, groupType,
  * `domains.schedule.strategy` (a SEPARATE runtime-checked position that

--- a/packages/core-backend/tests/unit/attendance-w6-2-enum-parity.test.ts
+++ b/packages/core-backend/tests/unit/attendance-w6-2-enum-parity.test.ts
@@ -7,14 +7,43 @@
  *   are proven equal by one mechanical comparison test (no hand-copied
  *   second list)."
  *
+ * §7.3 bullet 2 says EVERY published closed enum, not just a sample. This
+ * file covers the FULL closed-enum inventory of the promoted W6 group
+ * effective-policy contract: SourceLabel, Domain, ConflictCode (the
+ * original three), plus SourceRef.kind, FSER state, FSER reasonCodes,
+ * editorRef stage/step/surface, calculationPosture, groupType, flex mode,
+ * rules source, and conflicts[].label.
+ *
  * Three independent sources are read for real, never retyped by hand:
- *   1. OpenAPI — the promoted `packages/openapi/src/base.yml` (this file's
- *      own text is parsed at test time; nothing here is a copy of its
- *      values).
- *   2. TS contract — the frozen arrays exported by
- *      `w6-group-effective-policy-contract.ts`, imported directly.
+ *   1. OpenAPI — the promoted `packages/openapi/src/base.yml`. Read via
+ *      sequential key-narrowing over the raw text (core-backend has no
+ *      js-yaml dependency), never a fixed top-level-only window: several of
+ *      these enums are nested several levels deep, and some field NAMES
+ *      collide elsewhere in the same schema with a DIFFERENT enum (e.g.
+ *      `domains.rules.source` vs `domains.punchMethod.source`) — a window
+ *      that isn't scoped through every intermediate key could silently
+ *      extract the wrong sibling's enum and produce a false-passing test.
+ *      `narrow()` below always descends schema -> ... -> field, so a
+ *      same-named field elsewhere in the document is never in scope.
+ *   2. TS contract — either the frozen arrays exported by
+ *      `w6-group-effective-policy-contract.ts` (SourceLabel, Domain,
+ *      ConflictCode, SourceRef.kind, FSER reasonCodes — the last is itself
+ *      derived from the real FSER service's `REASON_ORDER` import, not
+ *      hand-copied), or — where that module only carries an inline literal
+ *      TYPE union with no reusable array (calculationPosture, groupType,
+ *      flex mode, rules source, FSER state, editorRef stage) — the
+ *      corresponding array in `w6-group-effective-policy-response-contract.ts`,
+ *      exported by this PR for direct import instead of being hand-copied
+ *      into this file. `editorRef.step`/`editorRef.surface` are derived
+ *      mechanically from the already-exported `SCHEDULE_ROUTE_SURFACES`
+ *      object (`Object.keys` / flattened `Object.values`), never retyped.
+ *      `conflicts[].label` has no array anywhere (a single-value literal
+ *      type, `'conflict_action_required'`, checked in the validator by
+ *      direct `!==`) — per the "no distinct array to compare against" case,
+ *      that one case is OpenAPI-vs-runtime only (2-way), documented as such
+ *      inline, not padded out with a fabricated third leg.
  *   3. Runtime service — NOT a second import of (2) under a different name.
- *      This probes the production response validator
+ *      Every case probes the production response validator
  *      (`validateAttendanceGroupEffectivePolicyResponseV1`, the exact
  *      function the aggregate service calls on every real response before
  *      returning it) with a pool of candidate values and records which ones
@@ -23,8 +52,8 @@
  *      this accepted set without changing either declared list, so this
  *      leg catches drift the first assertion alone would miss.
  *
- * If SourceLabel, Domain, or ConflictCode drifts in ANY ONE of the three
- * sources, at least one assertion below reds.
+ * If any of these enums drifts in ANY ONE of its sources, at least one
+ * assertion below reds.
  */
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
@@ -33,51 +62,71 @@ import { describe, expect, it } from 'vitest'
 import {
   ATTENDANCE_GROUP_EFFECTIVE_POLICY_CONFLICT_CODES_V1,
   ATTENDANCE_GROUP_EFFECTIVE_POLICY_DOMAINS_V1,
+  ATTENDANCE_GROUP_EFFECTIVE_POLICY_FSER_REASON_CODES_V1,
   ATTENDANCE_GROUP_EFFECTIVE_POLICY_SOURCE_LABELS_V1,
+  ATTENDANCE_GROUP_EFFECTIVE_POLICY_SOURCE_REF_KINDS_V1,
 } from '../../src/attendance/w6-group-effective-policy-contract'
-import { validateAttendanceGroupEffectivePolicyResponseV1 } from '../../src/attendance/w6-group-effective-policy-response-contract'
+import {
+  CALCULATION_POSTURES,
+  FLEX_MODES,
+  FSER_STATES,
+  GROUP_STAGES,
+  GROUP_TYPES,
+  RULE_SOURCES,
+  SCHEDULE_ROUTE_SURFACES,
+  validateAttendanceGroupEffectivePolicyResponseV1,
+} from '../../src/attendance/w6-group-effective-policy-response-contract'
 
 const BASE_YAML_PATH = join(__dirname, '../../../openapi/src/base.yml')
 const TEST_UUID = 'a4556006-ffff-4000-8000-000000000099'
 
 /**
- * Extracts the flat `enum:` list under a top-level `components.schemas.<name>`
- * key from the raw OpenAPI YAML text.
+ * Locates `<key>:` as a YAML mapping key anywhere inside `window`, at
+ * whatever indentation it happens to be, and returns the sub-slice of
+ * `window` from that key's own line up to (but not including) the next
+ * line whose indentation is less than or equal to the key line's own —
+ * i.e. exactly that key's nested block, nothing from a sibling or an
+ * ancestor's later sibling.
  *
- * This is a mechanical text extraction, not a hand-copied list: core-backend
- * has no js-yaml dependency (only packages/openapi does), so this mirrors
- * the same regex-over-raw-text technique the pre-existing
- * "OpenAPI draft — hand-kept THIRD face" test in
- * `attendance-w6-group-effective-policy-response-contract.test.ts` already
- * uses for `AttendanceGroupEffectivePolicySourceRef.kind`, extended to also
- * accept the multi-line `enum:\n  - a\n  - b` block form (used by
- * `AttendanceGroupEffectivePolicyConflictCode`). The window is bounded by
- * the next sibling 4-space-indented schema key so it cannot swallow a
- * neighbouring schema's enum.
+ * Used for progressive narrowing (`schema -> field -> nested field -> ...`)
+ * so a field name that repeats elsewhere in the document with a DIFFERENT
+ * enum (`source` under both `domains.rules` and `domains.punchMethod`)
+ * cannot be confused for the one under test: callers narrow through every
+ * intermediate key first, so the window handed to the final `enum:` search
+ * is already scoped tightly enough that no sibling's field of the same
+ * name is in it.
  */
-function extractOpenApiEnum(yamlText: string, schemaName: string): string[] {
-  const anchor = `\n    ${schemaName}:\n`
-  const anchorAt = yamlText.indexOf(anchor)
-  if (anchorAt === -1) {
-    throw new Error(`extractOpenApiEnum: schema anchor not found — ${schemaName}`)
+function narrow(window: string, key: string): string {
+  const re = new RegExp(`\\n( *)${key}:(?=[ \\t\\n]|$)`)
+  const m = re.exec(window)
+  if (!m) {
+    throw new Error(`narrow: key not found — ${key}`)
   }
-  const searchFrom = anchorAt + anchor.length
-  const nextSibling = /\n {4}[A-Za-z]/.exec(yamlText.slice(searchFrom))
-  const windowEnd = nextSibling ? searchFrom + nextSibling.index : yamlText.length
-  const window = yamlText.slice(anchorAt, windowEnd)
+  const indent = m[1].length
+  const rest = window.slice(m.index + 1)
+  const firstNewline = rest.indexOf('\n')
+  const tail = firstNewline === -1 ? '' : rest.slice(firstNewline + 1)
+  const siblingRe = new RegExp(`\\n {0,${indent}}\\S`)
+  const siblingMatch = siblingRe.exec(`\n${tail}`)
+  const tailEnd = siblingMatch ? siblingMatch.index : tail.length + 1
+  const end = (firstNewline === -1 ? rest.length : firstNewline + 1) + Math.max(tailEnd - 1, 0)
+  return rest.slice(0, end)
+}
 
+/** Extracts an `enum:` list (inline `[a, b]` or block `- a\n  - b` form)
+ * from an already-narrowed window. Throws rather than returning an empty
+ * array on a miss, so a broken extraction cannot silently pass as "the
+ * empty set equals the empty set". */
+function extractEnum(window: string): string[] {
   const inline = /^[ \t]*enum:[ \t]*\[([^\]]*)\][ \t]*$/m.exec(window)
   if (inline) {
     const values = inline[1]
       .split(',')
       .map((entry) => entry.trim())
       .filter((entry) => entry.length > 0)
-    if (values.length === 0) {
-      throw new Error(`extractOpenApiEnum: empty inline enum — ${schemaName}`)
-    }
+    if (values.length === 0) throw new Error('extractEnum: empty inline enum')
     return values
   }
-
   const block = /enum:[ \t]*\n((?:[ \t]*-[ \t]*\S+[ \t]*\n?)+)/.exec(window)
   if (block) {
     const values = block[1]
@@ -86,98 +135,154 @@ function extractOpenApiEnum(yamlText: string, schemaName: string): string[] {
       .filter((line) => line.startsWith('-'))
       .map((line) => line.slice(1).trim())
       .filter((value) => value.length > 0)
-    if (values.length === 0) {
-      throw new Error(`extractOpenApiEnum: empty block enum — ${schemaName}`)
-    }
+    if (values.length === 0) throw new Error('extractEnum: empty block enum')
     return values
   }
+  throw new Error(`extractEnum: no enum found in window:\n${window.slice(0, 300)}`)
+}
 
-  throw new Error(`extractOpenApiEnum: no enum found under schema — ${schemaName}`)
+/** Reads `components.schemas.<schemaName><.path...>.enum` from the real
+ * OpenAPI source text by sequential narrowing — `path` empty means the
+ * enum sits directly in the schema's own body (the three original W6-1
+ * enums); non-empty descends through nested `properties`/`allOf` keys by
+ * field name only (works because each path used in this file is unique
+ * within its own already-narrowed parent window — see `narrow()` above). */
+function getOpenApiEnum(yamlText: string, schemaName: string, path: readonly string[] = []): string[] {
+  let window = narrow(yamlText, schemaName)
+  for (const key of path) window = narrow(window, key)
+  return extractEnum(window)
 }
 
 /** A minimally-shaped, fully closed-shape valid response (matches the
  * "positive control" fixture already proven-valid in
  * `attendance-w6-group-effective-policy-response-contract.test.ts`, plus one
- * conflict entry so `conflicts[].domain` / `conflicts[].code` can be probed
- * without also constructing a membership-overlap or FSER scenario). */
-function buildBaseResponse(): {
-  ok: true
-  data: {
-    groupId: string
-    groupType: string
-    timezone: string
-    activeMemberCount: number
-    managerPosture: { ownerCount: number; subOwnerCount: number }
-    calculationPosture: string
-    domains: Record<string, Record<string, unknown>>
-    conflicts: Array<Record<string, unknown>>
-    evaluatedAt: string
-  }
-} {
+ * conflict entry so `conflicts[].domain` / `conflicts[].code` /
+ * `conflicts[].label` can be probed without also constructing a
+ * membership-overlap scenario). `groupType: 'free_time'` so
+ * `domains.schedule.fixedSchedule` stays `null` — FSER fields have their
+ * own carrier below. */
+function buildBaseResponse() {
   return {
     ok: true,
     data: {
       groupId: TEST_UUID,
-      groupType: 'free_time',
+      groupType: 'free_time' as string,
       timezone: 'UTC',
       activeMemberCount: 0,
       managerPosture: { ownerCount: 0, subOwnerCount: 0 },
-      calculationPosture: 'legacy',
+      calculationPosture: 'legacy' as string,
       domains: {
-        membership: { label: 'effective', reasonCodes: [], editorRef: { kind: 'group_stage', stage: 'people' } },
+        membership: {
+          label: 'effective',
+          reasonCodes: [] as string[],
+          editorRef: { kind: 'group_stage', stage: 'people' } as Record<string, unknown>,
+        },
         schedule: {
           label: 'effective',
           strategy: 'free_time',
-          reasonCodes: [],
-          sourceRefs: [],
-          fixedSchedule: null,
-          editorRef: { kind: 'group_context_route', step: 'schedule' },
+          reasonCodes: [] as string[],
+          sourceRefs: [] as Record<string, unknown>[],
+          fixedSchedule: null as unknown,
+          editorRef: { kind: 'group_context_route', step: 'schedule' } as Record<string, unknown>,
         },
         segments: {
           label: 'effective',
-          reasonCodes: [],
-          sourceRefs: [],
-          editorRef: { kind: 'group_context_route', step: 'schedule', surface: 'shifts' },
+          reasonCodes: [] as string[],
+          sourceRefs: [] as Record<string, unknown>[],
+          editorRef: { kind: 'group_context_route', step: 'schedule', surface: 'shifts' } as Record<string, unknown>,
         },
-        flex: { label: 'effective', reasonCodes: [], editorRef: { kind: 'group_context_route', step: 'schedule', surface: 'shifts' } },
+        flex: {
+          label: 'effective',
+          reasonCodes: [] as string[],
+          editorRef: { kind: 'group_context_route', step: 'schedule', surface: 'shifts' } as Record<string, unknown>,
+        } as Record<string, unknown>,
         rules: {
           label: 'org_inherited',
-          source: 'org_default',
-          sourceRefs: [],
-          reasonCodes: [],
-          editorRef: { kind: 'group_context_route', step: 'rules', surface: 'rule-sets' },
+          source: 'org_default' as string,
+          sourceRefs: [] as Record<string, unknown>[],
+          reasonCodes: [] as string[],
+          editorRef: { kind: 'group_context_route', step: 'rules', surface: 'rule-sets' } as Record<string, unknown>,
         },
-        punchMethod: { label: 'org_inherited', source: 'org_inherited', reasonCodes: [], editorRef: { kind: 'group_stage', stage: 'policies' } },
+        punchMethod: {
+          label: 'org_inherited',
+          source: 'org_inherited',
+          reasonCodes: [] as string[],
+          editorRef: { kind: 'group_stage', stage: 'policies' },
+        },
         requestPosture: {
           label: 'org_inherited',
           overtime: 'org_inherited',
           makeupPunch: 'org_inherited',
           outdoor: 'org_inherited',
-          reasonCodes: [],
+          reasonCodes: [] as string[],
           editorRef: { kind: 'group_stage', stage: 'policies' },
         },
-      },
+      } as Record<string, Record<string, unknown>>,
       conflicts: [
-        { code: 'TIMEZONE_MISSING', domain: 'basics', label: 'conflict_action_required', editorRef: { kind: 'group_stage', stage: 'basics' } },
-      ],
+        {
+          code: 'TIMEZONE_MISSING',
+          domain: 'basics',
+          label: 'conflict_action_required' as string,
+          editorRef: { kind: 'group_stage', stage: 'basics' },
+        },
+      ] as Array<Record<string, unknown>>,
       evaluatedAt: '2026-08-05T00:00:00.000Z',
     },
   }
 }
 
+/** A second carrier, `groupType: 'fixed_shift'` with a fully-populated
+ * `domains.schedule.fixedSchedule`, so FSER `state`/`reasonCodes` — which
+ * only exist on that embedded object — can be probed the same way. */
+function buildFixedShiftResponse() {
+  const response = buildBaseResponse()
+  response.data.groupType = 'fixed_shift'
+  response.data.domains.schedule.strategy = 'fixed_shift'
+  response.data.domains.schedule.fixedSchedule = {
+    state: 'effective',
+    reasonCodes: ['EFFECTIVE'],
+    desired: null,
+    coverage: { targetMembers: 0, matchingMembers: 0, missingMembers: 0, nonMemberTargets: 0, differentKeyRows: 0 },
+    drift: { unconfiguredManagedRows: 0, unpublishedManagedRows: 0, managedSets: [] },
+    evaluatedAt: '2026-08-05T00:00:00.000Z',
+  }
+  return response
+}
+
+type ResponseT = ReturnType<typeof buildBaseResponse>
+
+/** Every step's allowed surfaces, flattened and deduped — mechanically
+ * derived from the real exported table, not hand-copied. `calendar: null`
+ * contributes nothing (there is no surface valid there). */
+const SCHEDULE_ROUTE_SURFACES_UNION = [...new Set(Object.values(SCHEDULE_ROUTE_SURFACES).filter((v): v is readonly string[] => v !== null).flat())]
+
 describe('W6-2 enum parity: OpenAPI base.yml <-> TS contract <-> runtime validator behaviour', () => {
   const yamlText = readFileSync(BASE_YAML_PATH, 'utf8')
 
-  it('the probe carrier itself is valid (sanity control on the fixture, independent of the enums under test)', () => {
+  it('the free_time probe carrier itself is valid (sanity control on the fixture, independent of the enums under test)', () => {
     expect(validateAttendanceGroupEffectivePolicyResponseV1(buildBaseResponse())).toEqual({ ok: true })
   })
 
-  const CASES = [
+  it('the fixed_shift probe carrier itself is valid (sanity control for the FSER-scoped cases)', () => {
+    expect(validateAttendanceGroupEffectivePolicyResponseV1(buildFixedShiftResponse())).toEqual({ ok: true })
+  })
+
+  type Case = {
+    enumName: string
+    schemaName: string
+    path: readonly string[]
+    contractValues: readonly string[]
+    probe: (candidate: string) => ResponseT
+    twoWayOnly?: true
+  }
+
+  const CASES: readonly Case[] = [
     {
       enumName: 'SourceLabel',
       schemaName: 'AttendanceGroupEffectivePolicySourceLabel',
-      contractValues: ATTENDANCE_GROUP_EFFECTIVE_POLICY_SOURCE_LABELS_V1 as readonly string[],
-      probe: (candidate: string) => {
+      path: [],
+      contractValues: ATTENDANCE_GROUP_EFFECTIVE_POLICY_SOURCE_LABELS_V1,
+      probe: (candidate) => {
         const response = buildBaseResponse()
         response.data.domains.membership.label = candidate
         return response
@@ -186,8 +291,9 @@ describe('W6-2 enum parity: OpenAPI base.yml <-> TS contract <-> runtime validat
     {
       enumName: 'Domain',
       schemaName: 'AttendanceGroupEffectivePolicyDomain',
-      contractValues: ATTENDANCE_GROUP_EFFECTIVE_POLICY_DOMAINS_V1 as readonly string[],
-      probe: (candidate: string) => {
+      path: [],
+      contractValues: ATTENDANCE_GROUP_EFFECTIVE_POLICY_DOMAINS_V1,
+      probe: (candidate) => {
         const response = buildBaseResponse()
         response.data.conflicts[0].domain = candidate
         return response
@@ -196,18 +302,159 @@ describe('W6-2 enum parity: OpenAPI base.yml <-> TS contract <-> runtime validat
     {
       enumName: 'ConflictCode',
       schemaName: 'AttendanceGroupEffectivePolicyConflictCode',
-      contractValues: ATTENDANCE_GROUP_EFFECTIVE_POLICY_CONFLICT_CODES_V1 as readonly string[],
-      probe: (candidate: string) => {
+      path: [],
+      contractValues: ATTENDANCE_GROUP_EFFECTIVE_POLICY_CONFLICT_CODES_V1,
+      probe: (candidate) => {
         const response = buildBaseResponse()
         response.data.conflicts[0].code = candidate
         return response
       },
     },
+    {
+      enumName: 'SourceRef.kind',
+      schemaName: 'AttendanceGroupEffectivePolicySourceRef',
+      path: ['kind'],
+      contractValues: ATTENDANCE_GROUP_EFFECTIVE_POLICY_SOURCE_REF_KINDS_V1,
+      probe: (candidate) => {
+        const response = buildBaseResponse()
+        response.data.domains.schedule.sourceRefs = [{ kind: candidate, id: TEST_UUID }]
+        return response
+      },
+    },
+    {
+      enumName: 'FixedSchedule.state (FSER)',
+      schemaName: 'AttendanceGroupEffectivePolicyFixedSchedule',
+      path: ['state'],
+      contractValues: FSER_STATES,
+      probe: (candidate) => {
+        const response = buildFixedShiftResponse()
+        ;(response.data.domains.schedule.fixedSchedule as Record<string, unknown>).state = candidate
+        return response
+      },
+    },
+    {
+      enumName: 'FixedSchedule.reasonCodes (FSER, position-specific closure)',
+      schemaName: 'AttendanceGroupEffectivePolicyFixedSchedule',
+      path: ['reasonCodes'],
+      contractValues: ATTENDANCE_GROUP_EFFECTIVE_POLICY_FSER_REASON_CODES_V1,
+      probe: (candidate) => {
+        const response = buildFixedShiftResponse()
+        ;(response.data.domains.schedule.fixedSchedule as Record<string, unknown>).reasonCodes = [candidate]
+        return response
+      },
+    },
+    {
+      enumName: 'EditorRef.stage (group_stage branch)',
+      schemaName: 'AttendanceGroupEffectivePolicyEditorRef',
+      path: ['stage'],
+      contractValues: GROUP_STAGES,
+      probe: (candidate) => {
+        const response = buildBaseResponse()
+        response.data.domains.membership.editorRef = { kind: 'group_stage', stage: candidate }
+        return response
+      },
+    },
+    {
+      enumName: 'EditorRef.step (group_context_route branch)',
+      schemaName: 'AttendanceGroupEffectivePolicyEditorRef',
+      path: ['step'],
+      contractValues: Object.keys(SCHEDULE_ROUTE_SURFACES),
+      probe: (candidate) => {
+        const response = buildBaseResponse()
+        // No `surface` key: every valid step (schedule/calendar/rules)
+        // accepts an editorRef with no surface, so this isolates `step`
+        // without also depending on a surface choice.
+        response.data.domains.flex.editorRef = { kind: 'group_context_route', step: candidate }
+        return response
+      },
+    },
+    {
+      enumName: 'EditorRef.surface (union across all group_context_route steps)',
+      schemaName: 'AttendanceGroupEffectivePolicyEditorRef',
+      path: ['surface'],
+      contractValues: SCHEDULE_ROUTE_SURFACES_UNION,
+      probe: (candidate) => {
+        // Surface validity is step-scoped (schedule vs rules allow
+        // different surfaces; calendar allows none) but the OpenAPI schema
+        // declares one FLAT union across every step. This probe accepts
+        // the candidate if EITHER step admits it, matching that union
+        // framing rather than falsely requiring it to be valid everywhere.
+        const underSchedule = buildBaseResponse()
+        underSchedule.data.domains.flex.editorRef = { kind: 'group_context_route', step: 'schedule', surface: candidate }
+        if (validateAttendanceGroupEffectivePolicyResponseV1(underSchedule).ok) return underSchedule
+        const underRules = buildBaseResponse()
+        underRules.data.domains.flex.editorRef = { kind: 'group_context_route', step: 'rules', surface: candidate }
+        return underRules
+      },
+    },
+    {
+      enumName: 'calculationPosture',
+      schemaName: 'AttendanceGroupEffectivePolicyResponse',
+      path: ['calculationPosture'],
+      contractValues: CALCULATION_POSTURES,
+      probe: (candidate) => {
+        const response = buildBaseResponse()
+        response.data.calculationPosture = candidate
+        return response
+      },
+    },
+    {
+      enumName: 'groupType',
+      schemaName: 'AttendanceGroupEffectivePolicyResponse',
+      path: ['groupType'],
+      contractValues: GROUP_TYPES,
+      probe: (candidate) => {
+        const response = buildBaseResponse()
+        response.data.groupType = candidate
+        return response
+      },
+    },
+    {
+      enumName: 'domains.flex.mode',
+      schemaName: 'AttendanceGroupEffectivePolicyResponse',
+      path: ['domains', 'flex', 'mode'],
+      contractValues: FLEX_MODES,
+      probe: (candidate) => {
+        const response = buildBaseResponse()
+        ;(response.data.domains.flex as Record<string, unknown>).mode = candidate
+        return response
+      },
+    },
+    {
+      enumName: 'domains.rules.source',
+      schemaName: 'AttendanceGroupEffectivePolicyResponse',
+      path: ['domains', 'rules', 'source'],
+      contractValues: RULE_SOURCES,
+      probe: (candidate) => {
+        const response = buildBaseResponse()
+        response.data.domains.rules.source = candidate
+        return response
+      },
+    },
+    {
+      enumName: 'conflicts[].label',
+      schemaName: 'AttendanceGroupEffectivePolicyConflict',
+      path: ['label'],
+      // No array anywhere in TS for this one — `contract.ts` types it as the
+      // single-value literal `'conflict_action_required'`, and the
+      // validator checks it with a direct `!==`, not an `.includes()`
+      // against a declared set. There is no second, distinct place to
+      // import a value from without hand-typing a one-element array (which
+      // is exactly the "hand-copied literal" this file avoids elsewhere),
+      // so this case is OpenAPI-vs-runtime only — see `twoWayOnly` below.
+      contractValues: ['conflict_action_required'],
+      twoWayOnly: true,
+      probe: (candidate) => {
+        const response = buildBaseResponse()
+        response.data.conflicts[0].label = candidate
+        return response
+      },
+    },
   ] as const
 
-  for (const { enumName, schemaName, contractValues, probe } of CASES) {
-    describe(`${enumName} (OpenAPI schema components.schemas.${schemaName})`, () => {
-      const openapiValues = extractOpenApiEnum(yamlText, schemaName)
+  for (const { enumName, schemaName, path, contractValues, probe, twoWayOnly } of CASES) {
+    describe(`${enumName} (OpenAPI components.schemas.${schemaName}${path.length ? '.' + path.join('.') : ''})`, () => {
+      const openapiValues = getOpenApiEnum(yamlText, schemaName, path)
       const contractSet = [...contractValues].sort()
       const openapiSet = [...openapiValues].sort()
 
@@ -216,7 +463,7 @@ describe('W6-2 enum parity: OpenAPI base.yml <-> TS contract <-> runtime validat
         expect(contractSet.length).toBeGreaterThan(0)
       })
 
-      it('OpenAPI base.yml enum equals the TS contract frozen array', () => {
+      it('OpenAPI base.yml enum equals the TS contract set' + (twoWayOnly ? ' (2-way: no separate TS array exists for this literal-constant field)' : ''), () => {
         expect(openapiSet).toEqual(contractSet)
       })
 

--- a/packages/core-backend/tests/unit/attendance-w6-2-enum-parity.test.ts
+++ b/packages/core-backend/tests/unit/attendance-w6-2-enum-parity.test.ts
@@ -1,0 +1,242 @@
+/**
+ * W6-2 (#4556) — mechanical enum-parity gate.
+ *
+ * Governing document:
+ *   docs/development/attendance-issue-4556-w6-group-effective-policy-design-lock-20260805.md
+ *   §7.3: "enum values in OpenAPI, TS contract module, and runtime service
+ *   are proven equal by one mechanical comparison test (no hand-copied
+ *   second list)."
+ *
+ * Three independent sources are read for real, never retyped by hand:
+ *   1. OpenAPI — the promoted `packages/openapi/src/base.yml` (this file's
+ *      own text is parsed at test time; nothing here is a copy of its
+ *      values).
+ *   2. TS contract — the frozen arrays exported by
+ *      `w6-group-effective-policy-contract.ts`, imported directly.
+ *   3. Runtime service — NOT a second import of (2) under a different name.
+ *      This probes the production response validator
+ *      (`validateAttendanceGroupEffectivePolicyResponseV1`, the exact
+ *      function the aggregate service calls on every real response before
+ *      returning it) with a pool of candidate values and records which ones
+ *      it actually accepts. A validator whose logic silently diverges from
+ *      the constant it imports (e.g. a stray extra `||` branch) changes
+ *      this accepted set without changing either declared list, so this
+ *      leg catches drift the first assertion alone would miss.
+ *
+ * If SourceLabel, Domain, or ConflictCode drifts in ANY ONE of the three
+ * sources, at least one assertion below reds.
+ */
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+import {
+  ATTENDANCE_GROUP_EFFECTIVE_POLICY_CONFLICT_CODES_V1,
+  ATTENDANCE_GROUP_EFFECTIVE_POLICY_DOMAINS_V1,
+  ATTENDANCE_GROUP_EFFECTIVE_POLICY_SOURCE_LABELS_V1,
+} from '../../src/attendance/w6-group-effective-policy-contract'
+import { validateAttendanceGroupEffectivePolicyResponseV1 } from '../../src/attendance/w6-group-effective-policy-response-contract'
+
+const BASE_YAML_PATH = join(__dirname, '../../../openapi/src/base.yml')
+const TEST_UUID = 'a4556006-ffff-4000-8000-000000000099'
+
+/**
+ * Extracts the flat `enum:` list under a top-level `components.schemas.<name>`
+ * key from the raw OpenAPI YAML text.
+ *
+ * This is a mechanical text extraction, not a hand-copied list: core-backend
+ * has no js-yaml dependency (only packages/openapi does), so this mirrors
+ * the same regex-over-raw-text technique the pre-existing
+ * "OpenAPI draft — hand-kept THIRD face" test in
+ * `attendance-w6-group-effective-policy-response-contract.test.ts` already
+ * uses for `AttendanceGroupEffectivePolicySourceRef.kind`, extended to also
+ * accept the multi-line `enum:\n  - a\n  - b` block form (used by
+ * `AttendanceGroupEffectivePolicyConflictCode`). The window is bounded by
+ * the next sibling 4-space-indented schema key so it cannot swallow a
+ * neighbouring schema's enum.
+ */
+function extractOpenApiEnum(yamlText: string, schemaName: string): string[] {
+  const anchor = `\n    ${schemaName}:\n`
+  const anchorAt = yamlText.indexOf(anchor)
+  if (anchorAt === -1) {
+    throw new Error(`extractOpenApiEnum: schema anchor not found — ${schemaName}`)
+  }
+  const searchFrom = anchorAt + anchor.length
+  const nextSibling = /\n {4}[A-Za-z]/.exec(yamlText.slice(searchFrom))
+  const windowEnd = nextSibling ? searchFrom + nextSibling.index : yamlText.length
+  const window = yamlText.slice(anchorAt, windowEnd)
+
+  const inline = /^[ \t]*enum:[ \t]*\[([^\]]*)\][ \t]*$/m.exec(window)
+  if (inline) {
+    const values = inline[1]
+      .split(',')
+      .map((entry) => entry.trim())
+      .filter((entry) => entry.length > 0)
+    if (values.length === 0) {
+      throw new Error(`extractOpenApiEnum: empty inline enum — ${schemaName}`)
+    }
+    return values
+  }
+
+  const block = /enum:[ \t]*\n((?:[ \t]*-[ \t]*\S+[ \t]*\n?)+)/.exec(window)
+  if (block) {
+    const values = block[1]
+      .split('\n')
+      .map((line) => line.trim())
+      .filter((line) => line.startsWith('-'))
+      .map((line) => line.slice(1).trim())
+      .filter((value) => value.length > 0)
+    if (values.length === 0) {
+      throw new Error(`extractOpenApiEnum: empty block enum — ${schemaName}`)
+    }
+    return values
+  }
+
+  throw new Error(`extractOpenApiEnum: no enum found under schema — ${schemaName}`)
+}
+
+/** A minimally-shaped, fully closed-shape valid response (matches the
+ * "positive control" fixture already proven-valid in
+ * `attendance-w6-group-effective-policy-response-contract.test.ts`, plus one
+ * conflict entry so `conflicts[].domain` / `conflicts[].code` can be probed
+ * without also constructing a membership-overlap or FSER scenario). */
+function buildBaseResponse(): {
+  ok: true
+  data: {
+    groupId: string
+    groupType: string
+    timezone: string
+    activeMemberCount: number
+    managerPosture: { ownerCount: number; subOwnerCount: number }
+    calculationPosture: string
+    domains: Record<string, Record<string, unknown>>
+    conflicts: Array<Record<string, unknown>>
+    evaluatedAt: string
+  }
+} {
+  return {
+    ok: true,
+    data: {
+      groupId: TEST_UUID,
+      groupType: 'free_time',
+      timezone: 'UTC',
+      activeMemberCount: 0,
+      managerPosture: { ownerCount: 0, subOwnerCount: 0 },
+      calculationPosture: 'legacy',
+      domains: {
+        membership: { label: 'effective', reasonCodes: [], editorRef: { kind: 'group_stage', stage: 'people' } },
+        schedule: {
+          label: 'effective',
+          strategy: 'free_time',
+          reasonCodes: [],
+          sourceRefs: [],
+          fixedSchedule: null,
+          editorRef: { kind: 'group_context_route', step: 'schedule' },
+        },
+        segments: {
+          label: 'effective',
+          reasonCodes: [],
+          sourceRefs: [],
+          editorRef: { kind: 'group_context_route', step: 'schedule', surface: 'shifts' },
+        },
+        flex: { label: 'effective', reasonCodes: [], editorRef: { kind: 'group_context_route', step: 'schedule', surface: 'shifts' } },
+        rules: {
+          label: 'org_inherited',
+          source: 'org_default',
+          sourceRefs: [],
+          reasonCodes: [],
+          editorRef: { kind: 'group_context_route', step: 'rules', surface: 'rule-sets' },
+        },
+        punchMethod: { label: 'org_inherited', source: 'org_inherited', reasonCodes: [], editorRef: { kind: 'group_stage', stage: 'policies' } },
+        requestPosture: {
+          label: 'org_inherited',
+          overtime: 'org_inherited',
+          makeupPunch: 'org_inherited',
+          outdoor: 'org_inherited',
+          reasonCodes: [],
+          editorRef: { kind: 'group_stage', stage: 'policies' },
+        },
+      },
+      conflicts: [
+        { code: 'TIMEZONE_MISSING', domain: 'basics', label: 'conflict_action_required', editorRef: { kind: 'group_stage', stage: 'basics' } },
+      ],
+      evaluatedAt: '2026-08-05T00:00:00.000Z',
+    },
+  }
+}
+
+describe('W6-2 enum parity: OpenAPI base.yml <-> TS contract <-> runtime validator behaviour', () => {
+  const yamlText = readFileSync(BASE_YAML_PATH, 'utf8')
+
+  it('the probe carrier itself is valid (sanity control on the fixture, independent of the enums under test)', () => {
+    expect(validateAttendanceGroupEffectivePolicyResponseV1(buildBaseResponse())).toEqual({ ok: true })
+  })
+
+  const CASES = [
+    {
+      enumName: 'SourceLabel',
+      schemaName: 'AttendanceGroupEffectivePolicySourceLabel',
+      contractValues: ATTENDANCE_GROUP_EFFECTIVE_POLICY_SOURCE_LABELS_V1 as readonly string[],
+      probe: (candidate: string) => {
+        const response = buildBaseResponse()
+        response.data.domains.membership.label = candidate
+        return response
+      },
+    },
+    {
+      enumName: 'Domain',
+      schemaName: 'AttendanceGroupEffectivePolicyDomain',
+      contractValues: ATTENDANCE_GROUP_EFFECTIVE_POLICY_DOMAINS_V1 as readonly string[],
+      probe: (candidate: string) => {
+        const response = buildBaseResponse()
+        response.data.conflicts[0].domain = candidate
+        return response
+      },
+    },
+    {
+      enumName: 'ConflictCode',
+      schemaName: 'AttendanceGroupEffectivePolicyConflictCode',
+      contractValues: ATTENDANCE_GROUP_EFFECTIVE_POLICY_CONFLICT_CODES_V1 as readonly string[],
+      probe: (candidate: string) => {
+        const response = buildBaseResponse()
+        response.data.conflicts[0].code = candidate
+        return response
+      },
+    },
+  ] as const
+
+  for (const { enumName, schemaName, contractValues, probe } of CASES) {
+    describe(`${enumName} (OpenAPI schema components.schemas.${schemaName})`, () => {
+      const openapiValues = extractOpenApiEnum(yamlText, schemaName)
+      const contractSet = [...contractValues].sort()
+      const openapiSet = [...openapiValues].sort()
+
+      it('discovered a non-empty enum from both real sources (guards against a silently-empty extraction)', () => {
+        expect(openapiSet.length).toBeGreaterThan(0)
+        expect(contractSet.length).toBeGreaterThan(0)
+      })
+
+      it('OpenAPI base.yml enum equals the TS contract frozen array', () => {
+        expect(openapiSet).toEqual(contractSet)
+      })
+
+      it('the runtime validator accepts EXACTLY the contract set — not a superset, not a subset', () => {
+        // Probe pool: every declared value from both real sources (deduped)
+        // plus stable near-miss junk that must never validate — this keeps
+        // the "accepted equals contract" assertion from being satisfiable by
+        // a validator that just accepts everything.
+        const junk = [
+          '',
+          'not_a_real_enum_value__w62_probe',
+          schemaName.toUpperCase(),
+          `${contractSet[0]}_extra_suffix`,
+        ]
+        const pool = [...new Set([...contractSet, ...openapiSet, ...junk])]
+
+        const accepted = pool.filter((candidate) => validateAttendanceGroupEffectivePolicyResponseV1(probe(candidate)).ok).sort()
+
+        expect(accepted).toEqual(contractSet)
+      })
+    })
+  }
+})

--- a/packages/core-backend/tests/unit/attendance-w6-2-enum-parity.test.ts
+++ b/packages/core-backend/tests/unit/attendance-w6-2-enum-parity.test.ts
@@ -7,12 +7,30 @@
  *   are proven equal by one mechanical comparison test (no hand-copied
  *   second list)."
  *
- * §7.3 bullet 2 says EVERY published closed enum, not just a sample. This
- * file covers the FULL closed-enum inventory of the promoted W6 group
- * effective-policy contract: SourceLabel, Domain, ConflictCode (the
- * original three), plus SourceRef.kind, FSER state, FSER reasonCodes,
- * editorRef stage/step/surface, calculationPosture, groupType, flex mode,
- * rules source, and conflicts[].label.
+ * §7.3 bullet 2 says EVERY published closed enum, not just a sample. The
+ * promoted schema block declares 22 raw `enum:` stanzas. This file pins 20
+ * of them, counted as 21 logical positions (`editorRef.kind`'s two
+ * one-value oneOf-branch stanzas — `[group_stage]` and
+ * `[group_context_route]` — are one logical two-value union, tested as one
+ * case, not two): the original three (SourceLabel, Domain, ConflictCode),
+ * SourceRef.kind, FSER state, FSER reasonCodes, editorRef
+ * kind/stage/step/surface, calculationPosture, groupType,
+ * `domains.schedule.strategy` (a SEPARATE runtime-checked position that
+ * happens to share the same value domain as `groupType`, not an alias for
+ * it), flex mode, rules source, conflicts[].label, `domains.punchMethod.source`,
+ * and all three `domains.requestPosture.{overtime,makeupPunch,outdoor}`
+ * fields.
+ *
+ * The ONE deliberate exclusion: the envelope's `ok: { type: boolean, enum:
+ * [true] }`. Unlike every field above, this is not a business value domain
+ * with alternatives an org or a user could be in — it is the boolean
+ * success/failure discriminator of the JSON envelope itself (this schema
+ * only describes the success shape; failures are separate 400/403/404
+ * responses, not `ok: false` bodies), the same structural tag every other
+ * MetaSheet response envelope in this OpenAPI file uses. It has no
+ * "TS contract" or "runtime enum" analogue to compare against beyond the
+ * single `envelope.ok !== true` check, which is a type/shape guard, not an
+ * enum-drift-prone value set.
  *
  * Three independent sources are read for real, never retyped by hand:
  *   1. OpenAPI — the promoted `packages/openapi/src/base.yml`. Read via
@@ -20,11 +38,16 @@
  *      js-yaml dependency), never a fixed top-level-only window: several of
  *      these enums are nested several levels deep, and some field NAMES
  *      collide elsewhere in the same schema with a DIFFERENT enum (e.g.
- *      `domains.rules.source` vs `domains.punchMethod.source`) — a window
- *      that isn't scoped through every intermediate key could silently
- *      extract the wrong sibling's enum and produce a false-passing test.
- *      `narrow()` below always descends schema -> ... -> field, so a
- *      same-named field elsewhere in the document is never in scope.
+ *      `domains.rules.source` vs `domains.punchMethod.source`; `groupType`
+ *      vs `domains.schedule.strategy`) — a window that isn't scoped through
+ *      every intermediate key could silently extract the wrong sibling's
+ *      enum and produce a false-passing test. `narrow()` below always
+ *      descends schema -> ... -> field, so a same-named field elsewhere in
+ *      the document is never in scope. `editorRef.kind` additionally needs
+ *      `narrowAll()`: its two legal values are declared as two SEPARATE
+ *      single-value stanzas (one per `oneOf` branch), so reading only the
+ *      first occurrence would silently drop the second branch's value —
+ *      `getOpenApiEnumUnion()` collects every occurrence and unions them.
  *   2. TS contract — either the frozen arrays exported by
  *      `w6-group-effective-policy-contract.ts` (SourceLabel, Domain,
  *      ConflictCode, SourceRef.kind, FSER reasonCodes — the last is itself
@@ -34,14 +57,28 @@
  *      flex mode, rules source, FSER state, editorRef stage) — the
  *      corresponding array in `w6-group-effective-policy-response-contract.ts`,
  *      exported by this PR for direct import instead of being hand-copied
- *      into this file. `editorRef.step`/`editorRef.surface` are derived
- *      mechanically from the already-exported `SCHEDULE_ROUTE_SURFACES`
- *      object (`Object.keys` / flattened `Object.values`), never retyped.
- *      `conflicts[].label` has no array anywhere (a single-value literal
- *      type, `'conflict_action_required'`, checked in the validator by
- *      direct `!==`) — per the "no distinct array to compare against" case,
- *      that one case is OpenAPI-vs-runtime only (2-way), documented as such
- *      inline, not padded out with a fabricated third leg.
+ *      into this file. `domains.schedule.strategy` reuses the same
+ *      `GROUP_TYPES` array `groupType` does (both positions are validated
+ *      against the identical set in the real validator — see
+ *      `w6-group-effective-policy-response-contract.ts`), but is still its
+ *      OWN case here because it is a distinct OpenAPI/runtime POSITION: a
+ *      drift only in the `domains.schedule.strategy` YAML stanza, or only
+ *      in the runtime check at that specific call site, would not be caught
+ *      by the `groupType` case, which never touches that field.
+ *      `editorRef.step`/`editorRef.surface` are derived mechanically from
+ *      the already-exported `SCHEDULE_ROUTE_SURFACES` object (`Object.keys`
+ *      / flattened `Object.values`), never retyped. `conflicts[].label`,
+ *      `editorRef.kind`, `domains.punchMethod.source`, and the three
+ *      `domains.requestPosture.*` fields have no array anywhere — each is a
+ *      literal type (`conflicts[].label`/`punchMethod.source`/
+ *      `requestPosture.*` are single fixed strings; `editorRef.kind` is a
+ *      two-value discriminator with no reusable union array, only inline
+ *      `'group_stage' | 'group_context_route'` in the contract type),
+ *      checked in the validator by direct `===`/`!==`/`.includes()` against
+ *      a value with no declared-array counterpart. Per "no distinct array
+ *      to compare against", these six cases are OpenAPI-vs-runtime only
+ *      (2-way), documented as such inline, not padded out with a
+ *      fabricated third leg.
  *   3. Runtime service — NOT a second import of (2) under a different name.
  *      Every case probes the production response validator
  *      (`validateAttendanceGroupEffectivePolicyResponseV1`, the exact
@@ -113,12 +150,14 @@ function narrow(window: string, key: string): string {
   return rest.slice(0, end)
 }
 
-/** Extracts an `enum:` list (inline `[a, b]` or block `- a\n  - b` form)
- * from an already-narrowed window. Throws rather than returning an empty
- * array on a miss, so a broken extraction cannot silently pass as "the
- * empty set equals the empty set". */
+/** Extracts an `enum:` list (inline `[a, b]` form — either on its own line
+ * or embedded in a flow-style mapping like `{ type: string, enum: [a, b] }`,
+ * used by the single-value `requestPosture.*` fields — or block `- a\n  - b`
+ * form) from an already-narrowed window. Throws rather than returning an
+ * empty array on a miss, so a broken extraction cannot silently pass as
+ * "the empty set equals the empty set". */
 function extractEnum(window: string): string[] {
-  const inline = /^[ \t]*enum:[ \t]*\[([^\]]*)\][ \t]*$/m.exec(window)
+  const inline = /enum:[ \t]*\[([^\]]*)\]/.exec(window)
   if (inline) {
     const values = inline[1]
       .split(',')
@@ -151,6 +190,35 @@ function getOpenApiEnum(yamlText: string, schemaName: string, path: readonly str
   let window = narrow(yamlText, schemaName)
   for (const key of path) window = narrow(window, key)
   return extractEnum(window)
+}
+
+/** Like `narrow()`, but returns EVERY occurrence of `<key>:` in `window`
+ * (each one's own bounded sub-block), not just the first. Needed for
+ * `editorRef.kind`: its two legal values are declared as two separate
+ * single-value `enum:` stanzas, one per `oneOf` branch — a plain `narrow()`
+ * would silently see only the first and miss the second. */
+function narrowAll(window: string, key: string): string[] {
+  const results: string[] = []
+  let remaining = window
+  while (true) {
+    const re = new RegExp(`\\n( *)${key}:(?=[ \\t\\n]|$)`)
+    const m = re.exec(remaining)
+    if (!m) break
+    const sub = narrow(remaining, key)
+    results.push(sub)
+    remaining = remaining.slice(m.index + 1 + sub.length)
+  }
+  if (results.length === 0) throw new Error(`narrowAll: key not found — ${key}`)
+  return results
+}
+
+/** Unions the `enum:` values across every occurrence of `<key>` under a
+ * schema — the multi-occurrence counterpart of `getOpenApiEnum`, used only
+ * for `editorRef.kind`. */
+function getOpenApiEnumUnion(yamlText: string, schemaName: string, key: string): string[] {
+  const schemaWindow = narrow(yamlText, schemaName)
+  const occurrences = narrowAll(schemaWindow, key)
+  return [...new Set(occurrences.flatMap((w) => extractEnum(w)))]
 }
 
 /** A minimally-shaped, fully closed-shape valid response (matches the
@@ -274,6 +342,11 @@ describe('W6-2 enum parity: OpenAPI base.yml <-> TS contract <-> runtime validat
     contractValues: readonly string[]
     probe: (candidate: string) => ResponseT
     twoWayOnly?: true
+    /** Override for the OpenAPI extraction — only `editorRef.kind` needs
+     * this (union across two separate oneOf-branch stanzas via
+     * `getOpenApiEnumUnion`); every other case uses the default
+     * `getOpenApiEnum(yamlText, schemaName, path)` sequential narrow. */
+    getOpenApiValues?: (yamlText: string) => string[]
   }
 
   const CASES: readonly Case[] = [
@@ -410,6 +483,25 @@ describe('W6-2 enum parity: OpenAPI base.yml <-> TS contract <-> runtime validat
       },
     },
     {
+      // Same value domain and same TS array as `groupType` above, but a
+      // DISTINCT OpenAPI stanza (`domains.schedule.strategy`, not
+      // `data.groupType`) and a DISTINCT runtime call site
+      // (`GROUP_TYPES.includes(scheduleValue.strategy...)` vs
+      // `GROUP_TYPES.includes(d.groupType...)`). The `groupType` case never
+      // touches `strategy`, so a drift confined to this position alone
+      // (either the YAML stanza or this specific runtime check) would go
+      // unnoticed without a dedicated case — this is that case.
+      enumName: 'domains.schedule.strategy',
+      schemaName: 'AttendanceGroupEffectivePolicyResponse',
+      path: ['domains', 'schedule', 'strategy'],
+      contractValues: GROUP_TYPES,
+      probe: (candidate) => {
+        const response = buildBaseResponse()
+        response.data.domains.schedule.strategy = candidate
+        return response
+      },
+    },
+    {
       enumName: 'domains.flex.mode',
       schemaName: 'AttendanceGroupEffectivePolicyResponse',
       path: ['domains', 'flex', 'mode'],
@@ -450,11 +542,88 @@ describe('W6-2 enum parity: OpenAPI base.yml <-> TS contract <-> runtime validat
         return response
       },
     },
+    {
+      enumName: 'domains.punchMethod.source',
+      schemaName: 'AttendanceGroupEffectivePolicyResponse',
+      path: ['domains', 'punchMethod', 'source'],
+      // Single fixed value in v1 (OD-4556-9), checked in the validator by
+      // direct `!==` — no array anywhere to import, same shape as
+      // `conflicts[].label` above.
+      contractValues: ['org_inherited'],
+      twoWayOnly: true,
+      probe: (candidate) => {
+        const response = buildBaseResponse()
+        response.data.domains.punchMethod.source = candidate
+        return response
+      },
+    },
+    {
+      enumName: 'domains.requestPosture.overtime',
+      schemaName: 'AttendanceGroupEffectivePolicyResponse',
+      path: ['domains', 'requestPosture', 'overtime'],
+      contractValues: ['org_inherited'],
+      twoWayOnly: true,
+      probe: (candidate) => {
+        const response = buildBaseResponse()
+        response.data.domains.requestPosture.overtime = candidate
+        return response
+      },
+    },
+    {
+      enumName: 'domains.requestPosture.makeupPunch',
+      schemaName: 'AttendanceGroupEffectivePolicyResponse',
+      path: ['domains', 'requestPosture', 'makeupPunch'],
+      contractValues: ['org_inherited'],
+      twoWayOnly: true,
+      probe: (candidate) => {
+        const response = buildBaseResponse()
+        response.data.domains.requestPosture.makeupPunch = candidate
+        return response
+      },
+    },
+    {
+      enumName: 'domains.requestPosture.outdoor',
+      schemaName: 'AttendanceGroupEffectivePolicyResponse',
+      path: ['domains', 'requestPosture', 'outdoor'],
+      contractValues: ['org_inherited'],
+      twoWayOnly: true,
+      probe: (candidate) => {
+        const response = buildBaseResponse()
+        response.data.domains.requestPosture.outdoor = candidate
+        return response
+      },
+    },
+    {
+      // The discriminator of the EditorRef `oneOf` union. Declared as two
+      // SEPARATE single-value stanzas in OpenAPI (one per branch) — see
+      // `getOpenApiEnumUnion` — and checked in the parser by two literal
+      // `===` comparisons, with no reusable array on either side. Like
+      // `punchMethod.source`, this is genuinely pinnable with the same
+      // 2-way construction already used elsewhere in this file, so it is
+      // pinned rather than left out as "structural": unlike the envelope's
+      // `ok: [true]` (excluded — see the file header), `kind` is a real
+      // business discriminator (which downstream UI navigation shape
+      // applies), not a fixed protocol tag.
+      enumName: 'EditorRef.kind (discriminator, union of both oneOf branches)',
+      schemaName: 'AttendanceGroupEffectivePolicyEditorRef',
+      path: ['kind'],
+      contractValues: ['group_stage', 'group_context_route'],
+      twoWayOnly: true,
+      getOpenApiValues: (yamlText) => getOpenApiEnumUnion(yamlText, 'AttendanceGroupEffectivePolicyEditorRef', 'kind'),
+      probe: (candidate) => {
+        const asGroupStage = buildBaseResponse()
+        asGroupStage.data.domains.membership.editorRef = { kind: candidate, stage: 'people' }
+        if (validateAttendanceGroupEffectivePolicyResponseV1(asGroupStage).ok) return asGroupStage
+        const asContextRoute = buildBaseResponse()
+        asContextRoute.data.domains.membership.editorRef = { kind: candidate, step: 'schedule' }
+        return asContextRoute
+      },
+    },
   ] as const
 
-  for (const { enumName, schemaName, path, contractValues, probe, twoWayOnly } of CASES) {
+  for (const { enumName, schemaName, path, contractValues, probe, twoWayOnly, getOpenApiValues } of CASES) {
     describe(`${enumName} (OpenAPI components.schemas.${schemaName}${path.length ? '.' + path.join('.') : ''})`, () => {
-      const openapiValues = getOpenApiEnum(yamlText, schemaName, path)
+      const openapiValues = getOpenApiValues ? getOpenApiValues(yamlText) : getOpenApiEnum(yamlText, schemaName, path)
       const contractSet = [...contractValues].sort()
       const openapiSet = [...openapiValues].sort()
 

--- a/packages/openapi/dist-sdk/index.d.ts
+++ b/packages/openapi/dist-sdk/index.d.ts
@@ -6808,6 +6808,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/attendance/groups/{groupId}/effective-policy": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Group effective-policy aggregate (values-free, read-only)
+         * @description W6 aggregate read model (design lock section 4). GET-only; org identity comes from the authenticated principal; a delegated attendance admin must also hold active membership in the target org. Unknown, cross-org, and inaccessible groups share one values-free 404 shape. The response never contains member lists, user IDs, punch values, or secrets (red line W6-R2).
+         */
+        get: operations["getAttendanceGroupEffectivePolicy"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/audit-logs": {
         parameters: {
             query?: never;
@@ -16776,6 +16796,165 @@ export interface components {
             /** Format: date-time */
             updatedAt: string;
         };
+        /**
+         * @description Closed source/effect label union (parent lock 5.1; OD-W6-3).
+         * @enum {string}
+         */
+        AttendanceGroupEffectivePolicySourceLabel: "effective" | "org_inherited" | "preview_only" | "needs_configuration" | "conflict_action_required";
+        /**
+         * @description Closed policy-domain union (OD-W6-4).
+         * @enum {string}
+         */
+        AttendanceGroupEffectivePolicyDomain: "basics" | "membership" | "schedule" | "segments" | "flex" | "rules" | "punch_method" | "request_posture";
+        /**
+         * @description Closed v1 conflict inventory (OD-W6-4).
+         * @enum {string}
+         */
+        AttendanceGroupEffectivePolicyConflictCode: "CALCULATION_GROUP_MEMBERSHIP_OVERLAP" | "FIXED_SCHEDULE_CONFIGURATION_CHANGED" | "FIXED_SCHEDULE_PENDING_APPLY" | "FIXED_SCHEDULE_UNPUBLISHED_MANAGED_ROW" | "SCHEDULE_STRATEGY_INCOMPLETE" | "RULE_SOURCE_MISSING" | "TIMEZONE_MISSING";
+        /** @description Closed editor reference union (OD-W6-9). `group_context_route` reuses the #4711 closed route family; `group_stage` reuses the existing group-editor stage union. No caller-supplied section IDs (red line W6-R8). */
+        AttendanceGroupEffectivePolicyEditorRef: {
+            /** @enum {string} */
+            kind: "group_stage";
+            /** @enum {string} */
+            stage: "basics" | "people" | "schedule" | "policies";
+        } | {
+            /** @enum {string} */
+            kind: "group_context_route";
+            /** @enum {string} */
+            step: "schedule" | "calendar" | "rules";
+            /**
+             * @description Closed per-step table from the #4711 lock section 3.1: step=schedule allows shifts|assignments|advanced-scheduling; step=rules allows rule-sets; step=calendar allows none.
+             * @enum {string}
+             */
+            surface?: "shifts" | "assignments" | "advanced-scheduling" | "rule-sets";
+        };
+        AttendanceGroupEffectivePolicySourceRef: {
+            /**
+             * @description Closed configuration-source kinds (config IDs only, never user IDs).
+             * @enum {string}
+             */
+            kind: "shift" | "rule_set" | "fixed_schedule_config";
+            /** Format: uuid */
+            id: string;
+        };
+        /** @description Embedded verbatim from the existing FSER effectiveness service (single source, red line W6-R4). States, reason codes, coverage, and drift keys are the FSER lock's contract, unchanged; W6 adds no reason code and no second derivation. */
+        AttendanceGroupEffectivePolicyFixedSchedule: {
+            /** @enum {string} */
+            state: "not_configured" | "pending_apply" | "effective" | "configuration_changed";
+            reasonCodes: ("NO_DESIRED_CONFIG" | "NO_TARGET_MEMBERS" | "DIFFERENT_MANAGED_KEY_ACTIVE" | "TARGET_MEMBER_MISSING" | "NON_MEMBER_TARGET_ACTIVE" | "DUPLICATE_MATCHING_ASSIGNMENT" | "ASSIGNMENT_VALUE_MISMATCH" | "UNPUBLISHED_MANAGED_ROW" | "EFFECTIVE")[];
+            desired: {
+                /** Format: uuid */
+                shiftId: string;
+                /** Format: date */
+                startDate: string;
+                /** Format: date */
+                endDate: string | null;
+                revision: number;
+            } | null;
+            coverage: {
+                targetMembers: number;
+                matchingMembers: number;
+                missingMembers: number;
+                nonMemberTargets: number;
+                differentKeyRows: number;
+            };
+            drift: {
+                unconfiguredManagedRows: number;
+                unpublishedManagedRows: number;
+                /** @description Group-safe values only (FSER lock); never user IDs. */
+                managedSets: {
+                    /** Format: uuid */
+                    shiftId: string;
+                    /** Format: date */
+                    startDate: string;
+                    /** Format: date */
+                    endDate: string | null;
+                    producerKey: string;
+                    rowCount: number;
+                }[];
+            };
+            /** Format: date-time */
+            evaluatedAt: string;
+        };
+        AttendanceGroupEffectivePolicyDomainSummary: {
+            label: components["schemas"]["AttendanceGroupEffectivePolicySourceLabel"];
+            /** @description Values-free reason codes; de-duplicated, contract order. */
+            reasonCodes: string[];
+            sourceRefs?: components["schemas"]["AttendanceGroupEffectivePolicySourceRef"][];
+            editorRef: components["schemas"]["AttendanceGroupEffectivePolicyEditorRef"];
+        };
+        AttendanceGroupEffectivePolicyConflict: {
+            code: components["schemas"]["AttendanceGroupEffectivePolicyConflictCode"];
+            domain: components["schemas"]["AttendanceGroupEffectivePolicyDomain"];
+            /** @enum {string} */
+            label: "conflict_action_required";
+            /** @description Count only; never user IDs (red line W6-R2). */
+            affectedUserCount?: number;
+            editorRef: components["schemas"]["AttendanceGroupEffectivePolicyEditorRef"];
+        };
+        AttendanceGroupEffectivePolicyResponse: {
+            /** @enum {boolean} */
+            ok: true;
+            data: {
+                /** Format: uuid */
+                groupId: string;
+                /**
+                 * @description Existing CHECK-constrained group type union.
+                 * @enum {string}
+                 */
+                groupType: "fixed_shift" | "scheduled_shift" | "free_time";
+                /** @description IANA zone; null surfaces TIMEZONE_MISSING. */
+                timezone: string | null;
+                activeMemberCount: number;
+                managerPosture: {
+                    ownerCount: number;
+                    subOwnerCount: number;
+                };
+                /**
+                 * @description Read-only mirror of the org W4 rollout state.
+                 * @enum {string}
+                 */
+                calculationPosture: "legacy" | "shadow" | "eligible" | "authoritative" | "suspended";
+                domains: {
+                    membership: components["schemas"]["AttendanceGroupEffectivePolicyDomainSummary"];
+                    schedule: components["schemas"]["AttendanceGroupEffectivePolicyDomainSummary"] & {
+                        /** @enum {string} */
+                        strategy: "fixed_shift" | "scheduled_shift" | "free_time";
+                        fixedSchedule: components["schemas"]["AttendanceGroupEffectivePolicyFixedSchedule"] | null;
+                    };
+                    segments: components["schemas"]["AttendanceGroupEffectivePolicyDomainSummary"];
+                    flex: components["schemas"]["AttendanceGroupEffectivePolicyDomainSummary"] & {
+                        /**
+                         * @description W5 flex mode union (w5-flex-policy.ts), read-only.
+                         * @enum {string}
+                         */
+                        mode?: "strict" | "flex_required_duration";
+                    };
+                    rules: components["schemas"]["AttendanceGroupEffectivePolicyDomainSummary"] & {
+                        /** @enum {string} */
+                        source: "org_default" | "group_rule_set";
+                    };
+                    punchMethod: components["schemas"]["AttendanceGroupEffectivePolicyDomainSummary"] & {
+                        /**
+                         * @description OD-4556-9 keeps punch policy org-inherited in v1.
+                         * @enum {string}
+                         */
+                        source: "org_inherited";
+                    };
+                    requestPosture: components["schemas"]["AttendanceGroupEffectivePolicyDomainSummary"] & {
+                        /** @enum {string} */
+                        overtime: "org_inherited";
+                        /** @enum {string} */
+                        makeupPunch: "org_inherited";
+                        /** @enum {string} */
+                        outdoor: "org_inherited";
+                    };
+                };
+                conflicts: components["schemas"]["AttendanceGroupEffectivePolicyConflict"][];
+                /** Format: date-time */
+                evaluatedAt: string;
+            };
+        };
     };
     responses: {
         /** @description Unauthorized - Missing or invalid JWT token */
@@ -17831,6 +18010,49 @@ export interface operations {
             401: components["responses"]["Unauthorized"];
             403: components["responses"]["Forbidden"];
             404: components["responses"]["NotFound"];
+        };
+    };
+    getAttendanceGroupEffectivePolicy: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                groupId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Aggregate effective-policy read model */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AttendanceGroupEffectivePolicyResponse"];
+                };
+            };
+            /** @description Typed validation failure. Any label/state/posture override input is rejected before aggregate SQL (red line W6-R7); malformed groupId is rejected after the transaction-bound authorization reads but before aggregate SQL. Enum-strict: unknown enum values are rejected, never defaulted (red line W6-R6). */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Authenticated-but-unscoped principal or org-selector mismatch; issued before any aggregate SQL (red line W6-R3). */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Unknown, cross-org, or inaccessible group, including a delegated admin without active target-org membership; one shared values-free shape (red line W6-R3). */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
         };
     };
 }

--- a/packages/openapi/dist/combined.openapi.yml
+++ b/packages/openapi/dist/combined.openapi.yml
@@ -4959,6 +4959,448 @@ components:
         - approvalGraph
         - createdAt
         - updatedAt
+    AttendanceGroupEffectivePolicySourceLabel:
+      type: string
+      description: Closed source/effect label union (parent lock 5.1; OD-W6-3).
+      enum:
+        - effective
+        - org_inherited
+        - preview_only
+        - needs_configuration
+        - conflict_action_required
+    AttendanceGroupEffectivePolicyDomain:
+      type: string
+      description: Closed policy-domain union (OD-W6-4).
+      enum:
+        - basics
+        - membership
+        - schedule
+        - segments
+        - flex
+        - rules
+        - punch_method
+        - request_posture
+    AttendanceGroupEffectivePolicyConflictCode:
+      type: string
+      description: Closed v1 conflict inventory (OD-W6-4).
+      enum:
+        - CALCULATION_GROUP_MEMBERSHIP_OVERLAP
+        - FIXED_SCHEDULE_CONFIGURATION_CHANGED
+        - FIXED_SCHEDULE_PENDING_APPLY
+        - FIXED_SCHEDULE_UNPUBLISHED_MANAGED_ROW
+        - SCHEDULE_STRATEGY_INCOMPLETE
+        - RULE_SOURCE_MISSING
+        - TIMEZONE_MISSING
+    AttendanceGroupEffectivePolicyEditorRef:
+      description: >
+        Closed editor reference union (OD-W6-9). `group_context_route` reuses
+        the #4711 closed route family; `group_stage` reuses the existing
+        group-editor stage union. No caller-supplied section IDs (red line
+        W6-R8).
+      oneOf:
+        - type: object
+          additionalProperties: false
+          required:
+            - kind
+            - stage
+          properties:
+            kind:
+              type: string
+              enum:
+                - group_stage
+            stage:
+              type: string
+              enum:
+                - basics
+                - people
+                - schedule
+                - policies
+        - type: object
+          additionalProperties: false
+          required:
+            - kind
+            - step
+          properties:
+            kind:
+              type: string
+              enum:
+                - group_context_route
+            step:
+              type: string
+              enum:
+                - schedule
+                - calendar
+                - rules
+            surface:
+              type: string
+              description: >
+                Closed per-step table from the #4711 lock section 3.1:
+                step=schedule allows shifts|assignments|advanced-scheduling;
+                step=rules allows rule-sets; step=calendar allows none.
+              enum:
+                - shifts
+                - assignments
+                - advanced-scheduling
+                - rule-sets
+    AttendanceGroupEffectivePolicySourceRef:
+      type: object
+      additionalProperties: false
+      required:
+        - kind
+        - id
+      properties:
+        kind:
+          type: string
+          description: Closed configuration-source kinds (config IDs only, never user IDs).
+          enum:
+            - shift
+            - rule_set
+            - fixed_schedule_config
+        id:
+          type: string
+          format: uuid
+    AttendanceGroupEffectivePolicyFixedSchedule:
+      type: object
+      description: >
+        Embedded verbatim from the existing FSER effectiveness service (single
+        source, red line W6-R4). States, reason codes, coverage, and drift keys
+        are the FSER lock's contract, unchanged; W6 adds no reason code and no
+        second derivation.
+      additionalProperties: false
+      required:
+        - state
+        - reasonCodes
+        - desired
+        - coverage
+        - drift
+        - evaluatedAt
+      properties:
+        state:
+          type: string
+          enum:
+            - not_configured
+            - pending_apply
+            - effective
+            - configuration_changed
+        reasonCodes:
+          type: array
+          items:
+            type: string
+            enum:
+              - NO_DESIRED_CONFIG
+              - NO_TARGET_MEMBERS
+              - DIFFERENT_MANAGED_KEY_ACTIVE
+              - TARGET_MEMBER_MISSING
+              - NON_MEMBER_TARGET_ACTIVE
+              - DUPLICATE_MATCHING_ASSIGNMENT
+              - ASSIGNMENT_VALUE_MISMATCH
+              - UNPUBLISHED_MANAGED_ROW
+              - EFFECTIVE
+        desired:
+          nullable: true
+          type: object
+          additionalProperties: false
+          required:
+            - shiftId
+            - startDate
+            - endDate
+            - revision
+          properties:
+            shiftId:
+              type: string
+              format: uuid
+            startDate:
+              type: string
+              format: date
+            endDate:
+              type: string
+              format: date
+              nullable: true
+            revision:
+              type: integer
+              minimum: 1
+        coverage:
+          type: object
+          additionalProperties: false
+          required:
+            - targetMembers
+            - matchingMembers
+            - missingMembers
+            - nonMemberTargets
+            - differentKeyRows
+          properties:
+            targetMembers:
+              type: integer
+              minimum: 0
+            matchingMembers:
+              type: integer
+              minimum: 0
+            missingMembers:
+              type: integer
+              minimum: 0
+            nonMemberTargets:
+              type: integer
+              minimum: 0
+            differentKeyRows:
+              type: integer
+              minimum: 0
+        drift:
+          type: object
+          additionalProperties: false
+          required:
+            - unconfiguredManagedRows
+            - unpublishedManagedRows
+            - managedSets
+          properties:
+            unconfiguredManagedRows:
+              type: integer
+              minimum: 0
+            unpublishedManagedRows:
+              type: integer
+              minimum: 0
+            managedSets:
+              type: array
+              description: Group-safe values only (FSER lock); never user IDs.
+              items:
+                type: object
+                additionalProperties: false
+                required:
+                  - shiftId
+                  - startDate
+                  - endDate
+                  - producerKey
+                  - rowCount
+                properties:
+                  shiftId:
+                    type: string
+                    format: uuid
+                  startDate:
+                    type: string
+                    format: date
+                  endDate:
+                    type: string
+                    format: date
+                    nullable: true
+                  producerKey:
+                    type: string
+                  rowCount:
+                    type: integer
+                    minimum: 1
+        evaluatedAt:
+          type: string
+          format: date-time
+    AttendanceGroupEffectivePolicyDomainSummary:
+      type: object
+      required:
+        - label
+        - reasonCodes
+        - editorRef
+      properties:
+        label:
+          $ref: '#/components/schemas/AttendanceGroupEffectivePolicySourceLabel'
+        reasonCodes:
+          type: array
+          description: Values-free reason codes; de-duplicated, contract order.
+          items:
+            type: string
+        sourceRefs:
+          type: array
+          items:
+            $ref: '#/components/schemas/AttendanceGroupEffectivePolicySourceRef'
+        editorRef:
+          $ref: '#/components/schemas/AttendanceGroupEffectivePolicyEditorRef'
+    AttendanceGroupEffectivePolicyConflict:
+      type: object
+      additionalProperties: false
+      required:
+        - code
+        - domain
+        - label
+        - editorRef
+      properties:
+        code:
+          $ref: '#/components/schemas/AttendanceGroupEffectivePolicyConflictCode'
+        domain:
+          $ref: '#/components/schemas/AttendanceGroupEffectivePolicyDomain'
+        label:
+          type: string
+          enum:
+            - conflict_action_required
+        affectedUserCount:
+          type: integer
+          minimum: 0
+          description: Count only; never user IDs (red line W6-R2).
+        editorRef:
+          $ref: '#/components/schemas/AttendanceGroupEffectivePolicyEditorRef'
+    AttendanceGroupEffectivePolicyResponse:
+      type: object
+      additionalProperties: false
+      required:
+        - ok
+        - data
+      properties:
+        ok:
+          type: boolean
+          enum:
+            - true
+        data:
+          type: object
+          additionalProperties: false
+          required:
+            - groupId
+            - groupType
+            - timezone
+            - activeMemberCount
+            - managerPosture
+            - calculationPosture
+            - domains
+            - conflicts
+            - evaluatedAt
+          properties:
+            groupId:
+              type: string
+              format: uuid
+            groupType:
+              type: string
+              description: Existing CHECK-constrained group type union.
+              enum:
+                - fixed_shift
+                - scheduled_shift
+                - free_time
+            timezone:
+              type: string
+              nullable: true
+              description: IANA zone; null surfaces TIMEZONE_MISSING.
+            activeMemberCount:
+              type: integer
+              minimum: 0
+            managerPosture:
+              type: object
+              additionalProperties: false
+              required:
+                - ownerCount
+                - subOwnerCount
+              properties:
+                ownerCount:
+                  type: integer
+                  minimum: 0
+                subOwnerCount:
+                  type: integer
+                  minimum: 0
+            calculationPosture:
+              type: string
+              description: Read-only mirror of the org W4 rollout state.
+              enum:
+                - legacy
+                - shadow
+                - eligible
+                - authoritative
+                - suspended
+            domains:
+              type: object
+              additionalProperties: false
+              required:
+                - membership
+                - schedule
+                - segments
+                - flex
+                - rules
+                - punchMethod
+                - requestPosture
+              properties:
+                membership:
+                  $ref: >-
+                    #/components/schemas/AttendanceGroupEffectivePolicyDomainSummary
+                schedule:
+                  allOf:
+                    - $ref: >-
+                        #/components/schemas/AttendanceGroupEffectivePolicyDomainSummary
+                    - type: object
+                      required:
+                        - strategy
+                        - fixedSchedule
+                      properties:
+                        strategy:
+                          type: string
+                          enum:
+                            - fixed_shift
+                            - scheduled_shift
+                            - free_time
+                        fixedSchedule:
+                          nullable: true
+                          allOf:
+                            - $ref: >-
+                                #/components/schemas/AttendanceGroupEffectivePolicyFixedSchedule
+                segments:
+                  $ref: >-
+                    #/components/schemas/AttendanceGroupEffectivePolicyDomainSummary
+                flex:
+                  allOf:
+                    - $ref: >-
+                        #/components/schemas/AttendanceGroupEffectivePolicyDomainSummary
+                    - type: object
+                      properties:
+                        mode:
+                          type: string
+                          description: W5 flex mode union (w5-flex-policy.ts), read-only.
+                          enum:
+                            - strict
+                            - flex_required_duration
+                rules:
+                  allOf:
+                    - $ref: >-
+                        #/components/schemas/AttendanceGroupEffectivePolicyDomainSummary
+                    - type: object
+                      required:
+                        - source
+                      properties:
+                        source:
+                          type: string
+                          enum:
+                            - org_default
+                            - group_rule_set
+                punchMethod:
+                  allOf:
+                    - $ref: >-
+                        #/components/schemas/AttendanceGroupEffectivePolicyDomainSummary
+                    - type: object
+                      required:
+                        - source
+                      properties:
+                        source:
+                          type: string
+                          description: OD-4556-9 keeps punch policy org-inherited in v1.
+                          enum:
+                            - org_inherited
+                requestPosture:
+                  allOf:
+                    - $ref: >-
+                        #/components/schemas/AttendanceGroupEffectivePolicyDomainSummary
+                    - type: object
+                      required:
+                        - overtime
+                        - makeupPunch
+                        - outdoor
+                      properties:
+                        overtime:
+                          type: string
+                          enum:
+                            - org_inherited
+                        makeupPunch:
+                          type: string
+                          enum:
+                            - org_inherited
+                        outdoor:
+                          type: string
+                          enum:
+                            - org_inherited
+            conflicts:
+              type: array
+              items:
+                $ref: '#/components/schemas/AttendanceGroupEffectivePolicyConflict'
+            evaluatedAt:
+              type: string
+              format: date-time
   responses:
     Unauthorized:
       description: Unauthorized - Missing or invalid JWT token
@@ -13002,6 +13444,51 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '409':
           $ref: '#/components/responses/Conflict'
+  /api/attendance/groups/{groupId}/effective-policy:
+    get:
+      summary: Group effective-policy aggregate (values-free, read-only)
+      description: >
+        W6 aggregate read model (design lock section 4). GET-only; org identity
+        comes from the authenticated principal; a delegated attendance admin
+        must also hold active membership in the target org. Unknown, cross-org,
+        and inaccessible groups share one values-free 404 shape. The response
+        never contains member lists, user IDs, punch values, or secrets (red
+        line W6-R2).
+      operationId: getAttendanceGroupEffectivePolicy
+      tags:
+        - attendance
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: groupId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: Aggregate effective-policy read model
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AttendanceGroupEffectivePolicyResponse'
+        '400':
+          description: >
+            Typed validation failure. Any label/state/posture override input is
+            rejected before aggregate SQL (red line W6-R7); malformed groupId is
+            rejected after the transaction-bound authorization reads but before
+            aggregate SQL. Enum-strict: unknown enum values are rejected, never
+            defaulted (red line W6-R6).
+        '403':
+          description: >
+            Authenticated-but-unscoped principal or org-selector mismatch;
+            issued before any aggregate SQL (red line W6-R3).
+        '404':
+          description: >
+            Unknown, cross-org, or inaccessible group, including a delegated
+            admin without active target-org membership; one shared values-free
+            shape (red line W6-R3).
   /api/audit-logs:
     get:
       summary: Admin-only audit log query

--- a/packages/openapi/dist/openapi.json
+++ b/packages/openapi/dist/openapi.json
@@ -6730,6 +6730,602 @@
           "createdAt",
           "updatedAt"
         ]
+      },
+      "AttendanceGroupEffectivePolicySourceLabel": {
+        "type": "string",
+        "description": "Closed source/effect label union (parent lock 5.1; OD-W6-3).",
+        "enum": [
+          "effective",
+          "org_inherited",
+          "preview_only",
+          "needs_configuration",
+          "conflict_action_required"
+        ]
+      },
+      "AttendanceGroupEffectivePolicyDomain": {
+        "type": "string",
+        "description": "Closed policy-domain union (OD-W6-4).",
+        "enum": [
+          "basics",
+          "membership",
+          "schedule",
+          "segments",
+          "flex",
+          "rules",
+          "punch_method",
+          "request_posture"
+        ]
+      },
+      "AttendanceGroupEffectivePolicyConflictCode": {
+        "type": "string",
+        "description": "Closed v1 conflict inventory (OD-W6-4).",
+        "enum": [
+          "CALCULATION_GROUP_MEMBERSHIP_OVERLAP",
+          "FIXED_SCHEDULE_CONFIGURATION_CHANGED",
+          "FIXED_SCHEDULE_PENDING_APPLY",
+          "FIXED_SCHEDULE_UNPUBLISHED_MANAGED_ROW",
+          "SCHEDULE_STRATEGY_INCOMPLETE",
+          "RULE_SOURCE_MISSING",
+          "TIMEZONE_MISSING"
+        ]
+      },
+      "AttendanceGroupEffectivePolicyEditorRef": {
+        "description": "Closed editor reference union (OD-W6-9). `group_context_route` reuses the #4711 closed route family; `group_stage` reuses the existing group-editor stage union. No caller-supplied section IDs (red line W6-R8).\n",
+        "oneOf": [
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "kind",
+              "stage"
+            ],
+            "properties": {
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "group_stage"
+                ]
+              },
+              "stage": {
+                "type": "string",
+                "enum": [
+                  "basics",
+                  "people",
+                  "schedule",
+                  "policies"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "kind",
+              "step"
+            ],
+            "properties": {
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "group_context_route"
+                ]
+              },
+              "step": {
+                "type": "string",
+                "enum": [
+                  "schedule",
+                  "calendar",
+                  "rules"
+                ]
+              },
+              "surface": {
+                "type": "string",
+                "description": "Closed per-step table from the #4711 lock section 3.1: step=schedule allows shifts|assignments|advanced-scheduling; step=rules allows rule-sets; step=calendar allows none.\n",
+                "enum": [
+                  "shifts",
+                  "assignments",
+                  "advanced-scheduling",
+                  "rule-sets"
+                ]
+              }
+            }
+          }
+        ]
+      },
+      "AttendanceGroupEffectivePolicySourceRef": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "kind",
+          "id"
+        ],
+        "properties": {
+          "kind": {
+            "type": "string",
+            "description": "Closed configuration-source kinds (config IDs only, never user IDs).",
+            "enum": [
+              "shift",
+              "rule_set",
+              "fixed_schedule_config"
+            ]
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          }
+        }
+      },
+      "AttendanceGroupEffectivePolicyFixedSchedule": {
+        "type": "object",
+        "description": "Embedded verbatim from the existing FSER effectiveness service (single source, red line W6-R4). States, reason codes, coverage, and drift keys are the FSER lock's contract, unchanged; W6 adds no reason code and no second derivation.\n",
+        "additionalProperties": false,
+        "required": [
+          "state",
+          "reasonCodes",
+          "desired",
+          "coverage",
+          "drift",
+          "evaluatedAt"
+        ],
+        "properties": {
+          "state": {
+            "type": "string",
+            "enum": [
+              "not_configured",
+              "pending_apply",
+              "effective",
+              "configuration_changed"
+            ]
+          },
+          "reasonCodes": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "NO_DESIRED_CONFIG",
+                "NO_TARGET_MEMBERS",
+                "DIFFERENT_MANAGED_KEY_ACTIVE",
+                "TARGET_MEMBER_MISSING",
+                "NON_MEMBER_TARGET_ACTIVE",
+                "DUPLICATE_MATCHING_ASSIGNMENT",
+                "ASSIGNMENT_VALUE_MISMATCH",
+                "UNPUBLISHED_MANAGED_ROW",
+                "EFFECTIVE"
+              ]
+            }
+          },
+          "desired": {
+            "nullable": true,
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "shiftId",
+              "startDate",
+              "endDate",
+              "revision"
+            ],
+            "properties": {
+              "shiftId": {
+                "type": "string",
+                "format": "uuid"
+              },
+              "startDate": {
+                "type": "string",
+                "format": "date"
+              },
+              "endDate": {
+                "type": "string",
+                "format": "date",
+                "nullable": true
+              },
+              "revision": {
+                "type": "integer",
+                "minimum": 1
+              }
+            }
+          },
+          "coverage": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "targetMembers",
+              "matchingMembers",
+              "missingMembers",
+              "nonMemberTargets",
+              "differentKeyRows"
+            ],
+            "properties": {
+              "targetMembers": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "matchingMembers": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "missingMembers": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "nonMemberTargets": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "differentKeyRows": {
+                "type": "integer",
+                "minimum": 0
+              }
+            }
+          },
+          "drift": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "unconfiguredManagedRows",
+              "unpublishedManagedRows",
+              "managedSets"
+            ],
+            "properties": {
+              "unconfiguredManagedRows": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "unpublishedManagedRows": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "managedSets": {
+                "type": "array",
+                "description": "Group-safe values only (FSER lock); never user IDs.",
+                "items": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": [
+                    "shiftId",
+                    "startDate",
+                    "endDate",
+                    "producerKey",
+                    "rowCount"
+                  ],
+                  "properties": {
+                    "shiftId": {
+                      "type": "string",
+                      "format": "uuid"
+                    },
+                    "startDate": {
+                      "type": "string",
+                      "format": "date"
+                    },
+                    "endDate": {
+                      "type": "string",
+                      "format": "date",
+                      "nullable": true
+                    },
+                    "producerKey": {
+                      "type": "string"
+                    },
+                    "rowCount": {
+                      "type": "integer",
+                      "minimum": 1
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "evaluatedAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "AttendanceGroupEffectivePolicyDomainSummary": {
+        "type": "object",
+        "required": [
+          "label",
+          "reasonCodes",
+          "editorRef"
+        ],
+        "properties": {
+          "label": {
+            "$ref": "#/components/schemas/AttendanceGroupEffectivePolicySourceLabel"
+          },
+          "reasonCodes": {
+            "type": "array",
+            "description": "Values-free reason codes; de-duplicated, contract order.",
+            "items": {
+              "type": "string"
+            }
+          },
+          "sourceRefs": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AttendanceGroupEffectivePolicySourceRef"
+            }
+          },
+          "editorRef": {
+            "$ref": "#/components/schemas/AttendanceGroupEffectivePolicyEditorRef"
+          }
+        }
+      },
+      "AttendanceGroupEffectivePolicyConflict": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "code",
+          "domain",
+          "label",
+          "editorRef"
+        ],
+        "properties": {
+          "code": {
+            "$ref": "#/components/schemas/AttendanceGroupEffectivePolicyConflictCode"
+          },
+          "domain": {
+            "$ref": "#/components/schemas/AttendanceGroupEffectivePolicyDomain"
+          },
+          "label": {
+            "type": "string",
+            "enum": [
+              "conflict_action_required"
+            ]
+          },
+          "affectedUserCount": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Count only; never user IDs (red line W6-R2)."
+          },
+          "editorRef": {
+            "$ref": "#/components/schemas/AttendanceGroupEffectivePolicyEditorRef"
+          }
+        }
+      },
+      "AttendanceGroupEffectivePolicyResponse": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "ok",
+          "data"
+        ],
+        "properties": {
+          "ok": {
+            "type": "boolean",
+            "enum": [
+              true
+            ]
+          },
+          "data": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "groupId",
+              "groupType",
+              "timezone",
+              "activeMemberCount",
+              "managerPosture",
+              "calculationPosture",
+              "domains",
+              "conflicts",
+              "evaluatedAt"
+            ],
+            "properties": {
+              "groupId": {
+                "type": "string",
+                "format": "uuid"
+              },
+              "groupType": {
+                "type": "string",
+                "description": "Existing CHECK-constrained group type union.",
+                "enum": [
+                  "fixed_shift",
+                  "scheduled_shift",
+                  "free_time"
+                ]
+              },
+              "timezone": {
+                "type": "string",
+                "nullable": true,
+                "description": "IANA zone; null surfaces TIMEZONE_MISSING."
+              },
+              "activeMemberCount": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "managerPosture": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": [
+                  "ownerCount",
+                  "subOwnerCount"
+                ],
+                "properties": {
+                  "ownerCount": {
+                    "type": "integer",
+                    "minimum": 0
+                  },
+                  "subOwnerCount": {
+                    "type": "integer",
+                    "minimum": 0
+                  }
+                }
+              },
+              "calculationPosture": {
+                "type": "string",
+                "description": "Read-only mirror of the org W4 rollout state.",
+                "enum": [
+                  "legacy",
+                  "shadow",
+                  "eligible",
+                  "authoritative",
+                  "suspended"
+                ]
+              },
+              "domains": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": [
+                  "membership",
+                  "schedule",
+                  "segments",
+                  "flex",
+                  "rules",
+                  "punchMethod",
+                  "requestPosture"
+                ],
+                "properties": {
+                  "membership": {
+                    "$ref": "#/components/schemas/AttendanceGroupEffectivePolicyDomainSummary"
+                  },
+                  "schedule": {
+                    "allOf": [
+                      {
+                        "$ref": "#/components/schemas/AttendanceGroupEffectivePolicyDomainSummary"
+                      },
+                      {
+                        "type": "object",
+                        "required": [
+                          "strategy",
+                          "fixedSchedule"
+                        ],
+                        "properties": {
+                          "strategy": {
+                            "type": "string",
+                            "enum": [
+                              "fixed_shift",
+                              "scheduled_shift",
+                              "free_time"
+                            ]
+                          },
+                          "fixedSchedule": {
+                            "nullable": true,
+                            "allOf": [
+                              {
+                                "$ref": "#/components/schemas/AttendanceGroupEffectivePolicyFixedSchedule"
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    ]
+                  },
+                  "segments": {
+                    "$ref": "#/components/schemas/AttendanceGroupEffectivePolicyDomainSummary"
+                  },
+                  "flex": {
+                    "allOf": [
+                      {
+                        "$ref": "#/components/schemas/AttendanceGroupEffectivePolicyDomainSummary"
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "mode": {
+                            "type": "string",
+                            "description": "W5 flex mode union (w5-flex-policy.ts), read-only.",
+                            "enum": [
+                              "strict",
+                              "flex_required_duration"
+                            ]
+                          }
+                        }
+                      }
+                    ]
+                  },
+                  "rules": {
+                    "allOf": [
+                      {
+                        "$ref": "#/components/schemas/AttendanceGroupEffectivePolicyDomainSummary"
+                      },
+                      {
+                        "type": "object",
+                        "required": [
+                          "source"
+                        ],
+                        "properties": {
+                          "source": {
+                            "type": "string",
+                            "enum": [
+                              "org_default",
+                              "group_rule_set"
+                            ]
+                          }
+                        }
+                      }
+                    ]
+                  },
+                  "punchMethod": {
+                    "allOf": [
+                      {
+                        "$ref": "#/components/schemas/AttendanceGroupEffectivePolicyDomainSummary"
+                      },
+                      {
+                        "type": "object",
+                        "required": [
+                          "source"
+                        ],
+                        "properties": {
+                          "source": {
+                            "type": "string",
+                            "description": "OD-4556-9 keeps punch policy org-inherited in v1.",
+                            "enum": [
+                              "org_inherited"
+                            ]
+                          }
+                        }
+                      }
+                    ]
+                  },
+                  "requestPosture": {
+                    "allOf": [
+                      {
+                        "$ref": "#/components/schemas/AttendanceGroupEffectivePolicyDomainSummary"
+                      },
+                      {
+                        "type": "object",
+                        "required": [
+                          "overtime",
+                          "makeupPunch",
+                          "outdoor"
+                        ],
+                        "properties": {
+                          "overtime": {
+                            "type": "string",
+                            "enum": [
+                              "org_inherited"
+                            ]
+                          },
+                          "makeupPunch": {
+                            "type": "string",
+                            "enum": [
+                              "org_inherited"
+                            ]
+                          },
+                          "outdoor": {
+                            "type": "string",
+                            "enum": [
+                              "org_inherited"
+                            ]
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              "conflicts": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/AttendanceGroupEffectivePolicyConflict"
+                }
+              },
+              "evaluatedAt": {
+                "type": "string",
+                "format": "date-time"
+              }
+            }
+          }
+        }
       }
     },
     "responses": {
@@ -19240,6 +19836,53 @@
           },
           "409": {
             "$ref": "#/components/responses/Conflict"
+          }
+        }
+      }
+    },
+    "/api/attendance/groups/{groupId}/effective-policy": {
+      "get": {
+        "summary": "Group effective-policy aggregate (values-free, read-only)",
+        "description": "W6 aggregate read model (design lock section 4). GET-only; org identity comes from the authenticated principal; a delegated attendance admin must also hold active membership in the target org. Unknown, cross-org, and inaccessible groups share one values-free 404 shape. The response never contains member lists, user IDs, punch values, or secrets (red line W6-R2).\n",
+        "operationId": "getAttendanceGroupEffectivePolicy",
+        "tags": [
+          "attendance"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "groupId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Aggregate effective-policy read model",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AttendanceGroupEffectivePolicyResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Typed validation failure. Any label/state/posture override input is rejected before aggregate SQL (red line W6-R7); malformed groupId is rejected after the transaction-bound authorization reads but before aggregate SQL. Enum-strict: unknown enum values are rejected, never defaulted (red line W6-R6).\n"
+          },
+          "403": {
+            "description": "Authenticated-but-unscoped principal or org-selector mismatch; issued before any aggregate SQL (red line W6-R3).\n"
+          },
+          "404": {
+            "description": "Unknown, cross-org, or inaccessible group, including a delegated admin without active target-org membership; one shared values-free shape (red line W6-R3).\n"
           }
         }
       }

--- a/packages/openapi/dist/openapi.yaml
+++ b/packages/openapi/dist/openapi.yaml
@@ -4959,6 +4959,448 @@ components:
         - approvalGraph
         - createdAt
         - updatedAt
+    AttendanceGroupEffectivePolicySourceLabel:
+      type: string
+      description: Closed source/effect label union (parent lock 5.1; OD-W6-3).
+      enum:
+        - effective
+        - org_inherited
+        - preview_only
+        - needs_configuration
+        - conflict_action_required
+    AttendanceGroupEffectivePolicyDomain:
+      type: string
+      description: Closed policy-domain union (OD-W6-4).
+      enum:
+        - basics
+        - membership
+        - schedule
+        - segments
+        - flex
+        - rules
+        - punch_method
+        - request_posture
+    AttendanceGroupEffectivePolicyConflictCode:
+      type: string
+      description: Closed v1 conflict inventory (OD-W6-4).
+      enum:
+        - CALCULATION_GROUP_MEMBERSHIP_OVERLAP
+        - FIXED_SCHEDULE_CONFIGURATION_CHANGED
+        - FIXED_SCHEDULE_PENDING_APPLY
+        - FIXED_SCHEDULE_UNPUBLISHED_MANAGED_ROW
+        - SCHEDULE_STRATEGY_INCOMPLETE
+        - RULE_SOURCE_MISSING
+        - TIMEZONE_MISSING
+    AttendanceGroupEffectivePolicyEditorRef:
+      description: >
+        Closed editor reference union (OD-W6-9). `group_context_route` reuses
+        the #4711 closed route family; `group_stage` reuses the existing
+        group-editor stage union. No caller-supplied section IDs (red line
+        W6-R8).
+      oneOf:
+        - type: object
+          additionalProperties: false
+          required:
+            - kind
+            - stage
+          properties:
+            kind:
+              type: string
+              enum:
+                - group_stage
+            stage:
+              type: string
+              enum:
+                - basics
+                - people
+                - schedule
+                - policies
+        - type: object
+          additionalProperties: false
+          required:
+            - kind
+            - step
+          properties:
+            kind:
+              type: string
+              enum:
+                - group_context_route
+            step:
+              type: string
+              enum:
+                - schedule
+                - calendar
+                - rules
+            surface:
+              type: string
+              description: >
+                Closed per-step table from the #4711 lock section 3.1:
+                step=schedule allows shifts|assignments|advanced-scheduling;
+                step=rules allows rule-sets; step=calendar allows none.
+              enum:
+                - shifts
+                - assignments
+                - advanced-scheduling
+                - rule-sets
+    AttendanceGroupEffectivePolicySourceRef:
+      type: object
+      additionalProperties: false
+      required:
+        - kind
+        - id
+      properties:
+        kind:
+          type: string
+          description: Closed configuration-source kinds (config IDs only, never user IDs).
+          enum:
+            - shift
+            - rule_set
+            - fixed_schedule_config
+        id:
+          type: string
+          format: uuid
+    AttendanceGroupEffectivePolicyFixedSchedule:
+      type: object
+      description: >
+        Embedded verbatim from the existing FSER effectiveness service (single
+        source, red line W6-R4). States, reason codes, coverage, and drift keys
+        are the FSER lock's contract, unchanged; W6 adds no reason code and no
+        second derivation.
+      additionalProperties: false
+      required:
+        - state
+        - reasonCodes
+        - desired
+        - coverage
+        - drift
+        - evaluatedAt
+      properties:
+        state:
+          type: string
+          enum:
+            - not_configured
+            - pending_apply
+            - effective
+            - configuration_changed
+        reasonCodes:
+          type: array
+          items:
+            type: string
+            enum:
+              - NO_DESIRED_CONFIG
+              - NO_TARGET_MEMBERS
+              - DIFFERENT_MANAGED_KEY_ACTIVE
+              - TARGET_MEMBER_MISSING
+              - NON_MEMBER_TARGET_ACTIVE
+              - DUPLICATE_MATCHING_ASSIGNMENT
+              - ASSIGNMENT_VALUE_MISMATCH
+              - UNPUBLISHED_MANAGED_ROW
+              - EFFECTIVE
+        desired:
+          nullable: true
+          type: object
+          additionalProperties: false
+          required:
+            - shiftId
+            - startDate
+            - endDate
+            - revision
+          properties:
+            shiftId:
+              type: string
+              format: uuid
+            startDate:
+              type: string
+              format: date
+            endDate:
+              type: string
+              format: date
+              nullable: true
+            revision:
+              type: integer
+              minimum: 1
+        coverage:
+          type: object
+          additionalProperties: false
+          required:
+            - targetMembers
+            - matchingMembers
+            - missingMembers
+            - nonMemberTargets
+            - differentKeyRows
+          properties:
+            targetMembers:
+              type: integer
+              minimum: 0
+            matchingMembers:
+              type: integer
+              minimum: 0
+            missingMembers:
+              type: integer
+              minimum: 0
+            nonMemberTargets:
+              type: integer
+              minimum: 0
+            differentKeyRows:
+              type: integer
+              minimum: 0
+        drift:
+          type: object
+          additionalProperties: false
+          required:
+            - unconfiguredManagedRows
+            - unpublishedManagedRows
+            - managedSets
+          properties:
+            unconfiguredManagedRows:
+              type: integer
+              minimum: 0
+            unpublishedManagedRows:
+              type: integer
+              minimum: 0
+            managedSets:
+              type: array
+              description: Group-safe values only (FSER lock); never user IDs.
+              items:
+                type: object
+                additionalProperties: false
+                required:
+                  - shiftId
+                  - startDate
+                  - endDate
+                  - producerKey
+                  - rowCount
+                properties:
+                  shiftId:
+                    type: string
+                    format: uuid
+                  startDate:
+                    type: string
+                    format: date
+                  endDate:
+                    type: string
+                    format: date
+                    nullable: true
+                  producerKey:
+                    type: string
+                  rowCount:
+                    type: integer
+                    minimum: 1
+        evaluatedAt:
+          type: string
+          format: date-time
+    AttendanceGroupEffectivePolicyDomainSummary:
+      type: object
+      required:
+        - label
+        - reasonCodes
+        - editorRef
+      properties:
+        label:
+          $ref: '#/components/schemas/AttendanceGroupEffectivePolicySourceLabel'
+        reasonCodes:
+          type: array
+          description: Values-free reason codes; de-duplicated, contract order.
+          items:
+            type: string
+        sourceRefs:
+          type: array
+          items:
+            $ref: '#/components/schemas/AttendanceGroupEffectivePolicySourceRef'
+        editorRef:
+          $ref: '#/components/schemas/AttendanceGroupEffectivePolicyEditorRef'
+    AttendanceGroupEffectivePolicyConflict:
+      type: object
+      additionalProperties: false
+      required:
+        - code
+        - domain
+        - label
+        - editorRef
+      properties:
+        code:
+          $ref: '#/components/schemas/AttendanceGroupEffectivePolicyConflictCode'
+        domain:
+          $ref: '#/components/schemas/AttendanceGroupEffectivePolicyDomain'
+        label:
+          type: string
+          enum:
+            - conflict_action_required
+        affectedUserCount:
+          type: integer
+          minimum: 0
+          description: Count only; never user IDs (red line W6-R2).
+        editorRef:
+          $ref: '#/components/schemas/AttendanceGroupEffectivePolicyEditorRef'
+    AttendanceGroupEffectivePolicyResponse:
+      type: object
+      additionalProperties: false
+      required:
+        - ok
+        - data
+      properties:
+        ok:
+          type: boolean
+          enum:
+            - true
+        data:
+          type: object
+          additionalProperties: false
+          required:
+            - groupId
+            - groupType
+            - timezone
+            - activeMemberCount
+            - managerPosture
+            - calculationPosture
+            - domains
+            - conflicts
+            - evaluatedAt
+          properties:
+            groupId:
+              type: string
+              format: uuid
+            groupType:
+              type: string
+              description: Existing CHECK-constrained group type union.
+              enum:
+                - fixed_shift
+                - scheduled_shift
+                - free_time
+            timezone:
+              type: string
+              nullable: true
+              description: IANA zone; null surfaces TIMEZONE_MISSING.
+            activeMemberCount:
+              type: integer
+              minimum: 0
+            managerPosture:
+              type: object
+              additionalProperties: false
+              required:
+                - ownerCount
+                - subOwnerCount
+              properties:
+                ownerCount:
+                  type: integer
+                  minimum: 0
+                subOwnerCount:
+                  type: integer
+                  minimum: 0
+            calculationPosture:
+              type: string
+              description: Read-only mirror of the org W4 rollout state.
+              enum:
+                - legacy
+                - shadow
+                - eligible
+                - authoritative
+                - suspended
+            domains:
+              type: object
+              additionalProperties: false
+              required:
+                - membership
+                - schedule
+                - segments
+                - flex
+                - rules
+                - punchMethod
+                - requestPosture
+              properties:
+                membership:
+                  $ref: >-
+                    #/components/schemas/AttendanceGroupEffectivePolicyDomainSummary
+                schedule:
+                  allOf:
+                    - $ref: >-
+                        #/components/schemas/AttendanceGroupEffectivePolicyDomainSummary
+                    - type: object
+                      required:
+                        - strategy
+                        - fixedSchedule
+                      properties:
+                        strategy:
+                          type: string
+                          enum:
+                            - fixed_shift
+                            - scheduled_shift
+                            - free_time
+                        fixedSchedule:
+                          nullable: true
+                          allOf:
+                            - $ref: >-
+                                #/components/schemas/AttendanceGroupEffectivePolicyFixedSchedule
+                segments:
+                  $ref: >-
+                    #/components/schemas/AttendanceGroupEffectivePolicyDomainSummary
+                flex:
+                  allOf:
+                    - $ref: >-
+                        #/components/schemas/AttendanceGroupEffectivePolicyDomainSummary
+                    - type: object
+                      properties:
+                        mode:
+                          type: string
+                          description: W5 flex mode union (w5-flex-policy.ts), read-only.
+                          enum:
+                            - strict
+                            - flex_required_duration
+                rules:
+                  allOf:
+                    - $ref: >-
+                        #/components/schemas/AttendanceGroupEffectivePolicyDomainSummary
+                    - type: object
+                      required:
+                        - source
+                      properties:
+                        source:
+                          type: string
+                          enum:
+                            - org_default
+                            - group_rule_set
+                punchMethod:
+                  allOf:
+                    - $ref: >-
+                        #/components/schemas/AttendanceGroupEffectivePolicyDomainSummary
+                    - type: object
+                      required:
+                        - source
+                      properties:
+                        source:
+                          type: string
+                          description: OD-4556-9 keeps punch policy org-inherited in v1.
+                          enum:
+                            - org_inherited
+                requestPosture:
+                  allOf:
+                    - $ref: >-
+                        #/components/schemas/AttendanceGroupEffectivePolicyDomainSummary
+                    - type: object
+                      required:
+                        - overtime
+                        - makeupPunch
+                        - outdoor
+                      properties:
+                        overtime:
+                          type: string
+                          enum:
+                            - org_inherited
+                        makeupPunch:
+                          type: string
+                          enum:
+                            - org_inherited
+                        outdoor:
+                          type: string
+                          enum:
+                            - org_inherited
+            conflicts:
+              type: array
+              items:
+                $ref: '#/components/schemas/AttendanceGroupEffectivePolicyConflict'
+            evaluatedAt:
+              type: string
+              format: date-time
   responses:
     Unauthorized:
       description: Unauthorized - Missing or invalid JWT token
@@ -13002,6 +13444,51 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '409':
           $ref: '#/components/responses/Conflict'
+  /api/attendance/groups/{groupId}/effective-policy:
+    get:
+      summary: Group effective-policy aggregate (values-free, read-only)
+      description: >
+        W6 aggregate read model (design lock section 4). GET-only; org identity
+        comes from the authenticated principal; a delegated attendance admin
+        must also hold active membership in the target org. Unknown, cross-org,
+        and inaccessible groups share one values-free 404 shape. The response
+        never contains member lists, user IDs, punch values, or secrets (red
+        line W6-R2).
+      operationId: getAttendanceGroupEffectivePolicy
+      tags:
+        - attendance
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: groupId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: Aggregate effective-policy read model
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AttendanceGroupEffectivePolicyResponse'
+        '400':
+          description: >
+            Typed validation failure. Any label/state/posture override input is
+            rejected before aggregate SQL (red line W6-R7); malformed groupId is
+            rejected after the transaction-bound authorization reads but before
+            aggregate SQL. Enum-strict: unknown enum values are rejected, never
+            defaulted (red line W6-R6).
+        '403':
+          description: >
+            Authenticated-but-unscoped principal or org-selector mismatch;
+            issued before any aggregate SQL (red line W6-R3).
+        '404':
+          description: >
+            Unknown, cross-org, or inaccessible group, including a delegated
+            admin without active target-org membership; one shared values-free
+            shape (red line W6-R3).
   /api/audit-logs:
     get:
       summary: Admin-only audit log query

--- a/packages/openapi/drafts/attendance-w6-group-effective-policy.draft.yml
+++ b/packages/openapi/drafts/attendance-w6-group-effective-policy.draft.yml
@@ -1,26 +1,36 @@
 # =============================================================================
-# W6 (#4556) group effective-policy aggregate — CONTRACT DRAFT (PROPOSED)
+# W6 (#4556) group effective-policy aggregate — CONTRACT DRAFT (PROMOTED)
 #
-# Status: PROPOSED / runtime HOLD. This file is intentionally OUTSIDE
-# packages/openapi/src/paths/ so tools/build.ts does not merge it into
-# dist/. It declares the W6 read contract only; there is no implementation.
+# Status: PROMOTED (W6-2). The `paths` and `components` content below has
+# been copied verbatim into packages/openapi/src/paths/attendance.yml and
+# packages/openapi/src/base.yml per the wiring plan that used to live here,
+# and IS now part of the built dist/ and generated SDK. This file itself
+# stays OUTSIDE packages/openapi/src/paths/ (tools/build.ts still does not
+# read it) — it is kept only as the historical PROPOSED record and because
+# tests/unit/attendance-w6-group-effective-policy-response-contract.test.ts
+# still reads its `AttendanceGroupEffectivePolicySourceRef.kind` enum as an
+# independent third face. Do not hand-edit this file's `paths:`/`components:`
+# body independently of packages/openapi/src/paths/attendance.yml +
+# packages/openapi/src/base.yml — they must stay in lockstep; treat the
+# `src/` copies as canonical going forward.
 #
 # Governing document:
 #   docs/development/attendance-issue-4556-w6-group-effective-policy-design-lock-20260805.md
 #   (sections 4.1-4.4; decisions OD-W6-1..9 are RATIFIED in section 9;
-#   the delegated-non-member status correction in section 10 is PROPOSED)
+#   the delegated-non-member status correction in section 10 is RATIFIED;
+#   §7.3 is the W6-2 wiring gate this promotion satisfies)
 #
-# Wiring plan (W6-2, blocked on owner RATIFY): move the `paths` and
-# `components` content into src/paths/attendance.yml + src/base.yml, rebuild
-# dist, regenerate the SDK, and keep the required attendance OpenAPI contract
-# gate green. Until then this draft must stay out of the build; the W6-0
-# acceptance re-runs `pnpm --filter @metasheet/openapi build` and proves dist/
-# is byte-identical.
+# W6-2 mechanical promotion: the `paths` and `components` content below was
+# copied into src/paths/attendance.yml + src/base.yml, dist/ was rebuilt, the
+# SDK was regenerated, and the required attendance OpenAPI contract gate
+# (`git diff --exit-code -- packages/openapi/dist packages/openapi/dist-sdk/index.d.ts`
+# in plugin-tests.yml) now reflects the published path instead of asserting
+# it stays out.
 # =============================================================================
 x-metasheet-draft:
-  status: PROPOSED
+  status: PROMOTED
   wave: attendance-4556-w6
-  mergedIntoBuild: false
+  mergedIntoBuild: true
 
 paths:
   /api/attendance/groups/{groupId}/effective-policy:

--- a/packages/openapi/src/base.yml
+++ b/packages/openapi/src/base.yml
@@ -4266,6 +4266,314 @@ components:
         - approvalGraph
         - createdAt
         - updatedAt
+    # --- W6-2 (#4556) group effective-policy aggregate schemas ---
+    # Promoted from packages/openapi/drafts/attendance-w6-group-effective-policy.draft.yml
+    # per design-lock docs/development/attendance-issue-4556-w6-group-effective-policy-design-lock-20260805.md §7.3.
+    # Verbatim content; do not hand-edit independently of the draft's governing document.
+    AttendanceGroupEffectivePolicySourceLabel:
+      type: string
+      description: Closed source/effect label union (parent lock 5.1; OD-W6-3).
+      enum: [effective, org_inherited, preview_only, needs_configuration, conflict_action_required]
+
+    AttendanceGroupEffectivePolicyDomain:
+      type: string
+      description: Closed policy-domain union (OD-W6-4).
+      enum: [basics, membership, schedule, segments, flex, rules, punch_method, request_posture]
+
+    AttendanceGroupEffectivePolicyConflictCode:
+      type: string
+      description: Closed v1 conflict inventory (OD-W6-4).
+      enum:
+        - CALCULATION_GROUP_MEMBERSHIP_OVERLAP
+        - FIXED_SCHEDULE_CONFIGURATION_CHANGED
+        - FIXED_SCHEDULE_PENDING_APPLY
+        - FIXED_SCHEDULE_UNPUBLISHED_MANAGED_ROW
+        - SCHEDULE_STRATEGY_INCOMPLETE
+        - RULE_SOURCE_MISSING
+        - TIMEZONE_MISSING
+
+    AttendanceGroupEffectivePolicyEditorRef:
+      description: >
+        Closed editor reference union (OD-W6-9). `group_context_route` reuses
+        the #4711 closed route family; `group_stage` reuses the existing
+        group-editor stage union. No caller-supplied section IDs (red line
+        W6-R8).
+      oneOf:
+        - type: object
+          additionalProperties: false
+          required: [kind, stage]
+          properties:
+            kind:
+              type: string
+              enum: [group_stage]
+            stage:
+              type: string
+              enum: [basics, people, schedule, policies]
+        - type: object
+          additionalProperties: false
+          required: [kind, step]
+          properties:
+            kind:
+              type: string
+              enum: [group_context_route]
+            step:
+              type: string
+              enum: [schedule, calendar, rules]
+            surface:
+              type: string
+              description: >
+                Closed per-step table from the #4711 lock section 3.1:
+                step=schedule allows shifts|assignments|advanced-scheduling;
+                step=rules allows rule-sets; step=calendar allows none.
+              enum: [shifts, assignments, advanced-scheduling, rule-sets]
+
+    AttendanceGroupEffectivePolicySourceRef:
+      type: object
+      additionalProperties: false
+      required: [kind, id]
+      properties:
+        kind:
+          type: string
+          description: Closed configuration-source kinds (config IDs only, never user IDs).
+          # AUTHORITY: `ATTENDANCE_GROUP_EFFECTIVE_POLICY_SOURCE_REF_KINDS_V1` in
+          # `packages/core-backend/src/attendance/w6-group-effective-policy-contract.ts`.
+          # The runtime validator imports it and the exported TS `kind` union is derived
+          # from it. This YAML enum is a hand-kept third face; a unit test
+          # (`…-response-contract.test.ts`) parses this enum and asserts set-equality
+          # with that constant, so it reds if either side moves.
+          enum: [shift, rule_set, fixed_schedule_config]
+        id:
+          type: string
+          format: uuid
+
+    AttendanceGroupEffectivePolicyFixedSchedule:
+      type: object
+      description: >
+        Embedded verbatim from the existing FSER effectiveness service
+        (single source, red line W6-R4). States, reason codes, coverage, and
+        drift keys are the FSER lock's contract, unchanged; W6 adds no reason
+        code and no second derivation.
+      additionalProperties: false
+      required: [state, reasonCodes, desired, coverage, drift, evaluatedAt]
+      properties:
+        state:
+          type: string
+          enum: [not_configured, pending_apply, effective, configuration_changed]
+        reasonCodes:
+          type: array
+          items:
+            type: string
+            enum:
+              - NO_DESIRED_CONFIG
+              - NO_TARGET_MEMBERS
+              - DIFFERENT_MANAGED_KEY_ACTIVE
+              - TARGET_MEMBER_MISSING
+              - NON_MEMBER_TARGET_ACTIVE
+              - DUPLICATE_MATCHING_ASSIGNMENT
+              - ASSIGNMENT_VALUE_MISMATCH
+              - UNPUBLISHED_MANAGED_ROW
+              - EFFECTIVE
+        desired:
+          nullable: true
+          type: object
+          additionalProperties: false
+          required: [shiftId, startDate, endDate, revision]
+          properties:
+            shiftId: { type: string, format: uuid }
+            startDate: { type: string, format: date }
+            # Nullable by construction: the producer emits null for an
+            # open-ended managed row, and the underlying column is nullable.
+            endDate: { type: string, format: date, nullable: true }
+            revision: { type: integer, minimum: 1 }
+        coverage:
+          type: object
+          additionalProperties: false
+          required: [targetMembers, matchingMembers, missingMembers, nonMemberTargets, differentKeyRows]
+          properties:
+            targetMembers: { type: integer, minimum: 0 }
+            matchingMembers: { type: integer, minimum: 0 }
+            missingMembers: { type: integer, minimum: 0 }
+            nonMemberTargets: { type: integer, minimum: 0 }
+            differentKeyRows: { type: integer, minimum: 0 }
+        drift:
+          type: object
+          additionalProperties: false
+          required: [unconfiguredManagedRows, unpublishedManagedRows, managedSets]
+          properties:
+            unconfiguredManagedRows: { type: integer, minimum: 0 }
+            unpublishedManagedRows: { type: integer, minimum: 0 }
+            managedSets:
+              type: array
+              description: Group-safe values only (FSER lock); never user IDs.
+              items:
+                type: object
+                additionalProperties: false
+                required: [shiftId, startDate, endDate, producerKey, rowCount]
+                properties:
+                  shiftId: { type: string, format: uuid }
+                  startDate: { type: string, format: date }
+                  # Nullable for the same reason as `desired.endDate` above.
+                  endDate: { type: string, format: date, nullable: true }
+                  producerKey: { type: string }
+                  rowCount: { type: integer, minimum: 1 }
+        evaluatedAt:
+          type: string
+          format: date-time
+
+    AttendanceGroupEffectivePolicyDomainSummary:
+      type: object
+      # NOTE: no `additionalProperties: false` here on purpose — this base
+      # schema is extended via allOf by per-domain keys (strategy,
+      # fixedSchedule, mode, source, ...), and a strict validator would
+      # otherwise reject the composed objects. Exact-key enforcement for the
+      # composed domain objects is owned by the W6-1 exact-key deepEqual
+      # tests; W6-2 may instead inline closed per-domain schemas when wiring
+      # this draft into the build.
+      required: [label, reasonCodes, editorRef]
+      properties:
+        label:
+          $ref: '#/components/schemas/AttendanceGroupEffectivePolicySourceLabel'
+        reasonCodes:
+          type: array
+          description: Values-free reason codes; de-duplicated, contract order.
+          items: { type: string }
+        sourceRefs:
+          type: array
+          items:
+            $ref: '#/components/schemas/AttendanceGroupEffectivePolicySourceRef'
+        editorRef:
+          $ref: '#/components/schemas/AttendanceGroupEffectivePolicyEditorRef'
+
+    AttendanceGroupEffectivePolicyConflict:
+      type: object
+      additionalProperties: false
+      required: [code, domain, label, editorRef]
+      properties:
+        code:
+          $ref: '#/components/schemas/AttendanceGroupEffectivePolicyConflictCode'
+        domain:
+          $ref: '#/components/schemas/AttendanceGroupEffectivePolicyDomain'
+        label:
+          type: string
+          enum: [conflict_action_required]
+        affectedUserCount:
+          type: integer
+          minimum: 0
+          description: Count only; never user IDs (red line W6-R2).
+        editorRef:
+          $ref: '#/components/schemas/AttendanceGroupEffectivePolicyEditorRef'
+
+    AttendanceGroupEffectivePolicyResponse:
+      type: object
+      additionalProperties: false
+      required: [ok, data]
+      properties:
+        ok:
+          type: boolean
+          enum: [true]
+        data:
+          type: object
+          additionalProperties: false
+          required:
+            - groupId
+            - groupType
+            - timezone
+            - activeMemberCount
+            - managerPosture
+            - calculationPosture
+            - domains
+            - conflicts
+            - evaluatedAt
+          properties:
+            groupId: { type: string, format: uuid }
+            groupType:
+              type: string
+              description: Existing CHECK-constrained group type union.
+              enum: [fixed_shift, scheduled_shift, free_time]
+            timezone:
+              type: string
+              nullable: true
+              description: IANA zone; null surfaces TIMEZONE_MISSING.
+            activeMemberCount:
+              type: integer
+              minimum: 0
+            managerPosture:
+              type: object
+              additionalProperties: false
+              required: [ownerCount, subOwnerCount]
+              properties:
+                ownerCount: { type: integer, minimum: 0 }
+                subOwnerCount: { type: integer, minimum: 0 }
+            calculationPosture:
+              type: string
+              description: Read-only mirror of the org W4 rollout state.
+              enum: [legacy, shadow, eligible, authoritative, suspended]
+            domains:
+              type: object
+              additionalProperties: false
+              required: [membership, schedule, segments, flex, rules, punchMethod, requestPosture]
+              properties:
+                membership:
+                  $ref: '#/components/schemas/AttendanceGroupEffectivePolicyDomainSummary'
+                schedule:
+                  allOf:
+                    - $ref: '#/components/schemas/AttendanceGroupEffectivePolicyDomainSummary'
+                    - type: object
+                      required: [strategy, fixedSchedule]
+                      properties:
+                        strategy:
+                          type: string
+                          enum: [fixed_shift, scheduled_shift, free_time]
+                        fixedSchedule:
+                          nullable: true
+                          allOf:
+                            - $ref: '#/components/schemas/AttendanceGroupEffectivePolicyFixedSchedule'
+                segments:
+                  $ref: '#/components/schemas/AttendanceGroupEffectivePolicyDomainSummary'
+                flex:
+                  allOf:
+                    - $ref: '#/components/schemas/AttendanceGroupEffectivePolicyDomainSummary'
+                    - type: object
+                      properties:
+                        mode:
+                          type: string
+                          description: W5 flex mode union (w5-flex-policy.ts), read-only.
+                          enum: [strict, flex_required_duration]
+                rules:
+                  allOf:
+                    - $ref: '#/components/schemas/AttendanceGroupEffectivePolicyDomainSummary'
+                    - type: object
+                      required: [source]
+                      properties:
+                        source:
+                          type: string
+                          enum: [org_default, group_rule_set]
+                punchMethod:
+                  allOf:
+                    - $ref: '#/components/schemas/AttendanceGroupEffectivePolicyDomainSummary'
+                    - type: object
+                      required: [source]
+                      properties:
+                        source:
+                          type: string
+                          description: OD-4556-9 keeps punch policy org-inherited in v1.
+                          enum: [org_inherited]
+                requestPosture:
+                  allOf:
+                    - $ref: '#/components/schemas/AttendanceGroupEffectivePolicyDomainSummary'
+                    - type: object
+                      required: [overtime, makeupPunch, outdoor]
+                      properties:
+                        overtime: { type: string, enum: [org_inherited] }
+                        makeupPunch: { type: string, enum: [org_inherited] }
+                        outdoor: { type: string, enum: [org_inherited] }
+            conflicts:
+              type: array
+              items:
+                $ref: '#/components/schemas/AttendanceGroupEffectivePolicyConflict'
+            evaluatedAt:
+              type: string
+              format: date-time
   responses:
     Unauthorized:
       description: Unauthorized - Missing or invalid JWT token

--- a/packages/openapi/src/paths/attendance.yml
+++ b/packages/openapi/src/paths/attendance.yml
@@ -4617,3 +4617,52 @@ paths:
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
         '409': { $ref: '#/components/responses/Conflict' }
+
+  # --- W6-2 (#4556) group effective-policy aggregate ---
+  # Promoted from packages/openapi/drafts/attendance-w6-group-effective-policy.draft.yml
+  # per design-lock docs/development/attendance-issue-4556-w6-group-effective-policy-design-lock-20260805.md §7.3.
+  # Verbatim content; do not hand-edit independently of the draft's governing document.
+  /api/attendance/groups/{groupId}/effective-policy:
+    get:
+      summary: Group effective-policy aggregate (values-free, read-only)
+      description: >
+        W6 aggregate read model (design lock section 4). GET-only; org identity
+        comes from the authenticated principal; a delegated attendance admin
+        must also hold active membership in the target org. Unknown,
+        cross-org, and inaccessible groups share one values-free 404 shape.
+        The response never contains member lists, user IDs, punch values, or
+        secrets (red line W6-R2).
+      operationId: getAttendanceGroupEffectivePolicy
+      tags: [attendance]
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: groupId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: Aggregate effective-policy read model
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AttendanceGroupEffectivePolicyResponse'
+        '400':
+          description: >
+            Typed validation failure. Any label/state/posture override input
+            is rejected before aggregate SQL (red line W6-R7); malformed
+            groupId is rejected after the transaction-bound authorization
+            reads but before aggregate SQL. Enum-strict: unknown enum values
+            are rejected, never defaulted (red line W6-R6).
+        '403':
+          description: >
+            Authenticated-but-unscoped principal or org-selector mismatch;
+            issued before any aggregate SQL (red line W6-R3).
+        '404':
+          description: >
+            Unknown, cross-org, or inaccessible group, including a delegated
+            admin without active target-org membership; one shared values-free
+            shape (red line W6-R3).


### PR DESCRIPTION
## Scope

W6-2 contract wiring for issue #4556, per design-lock §7.3
(`docs/development/attendance-issue-4556-w6-group-effective-policy-design-lock-20260805.md`).
Mechanical promotion of the already-drafted, unpublished OpenAPI draft
(`packages/openapi/drafts/attendance-w6-group-effective-policy.draft.yml`)
into the published contract — **not a new API**. Built on fresh `main`
(`0aed2a85b2`, the W6-1 merge).

**Update history:**
- **Rev 2** folded in two hardening items from the independent gate on the
  first head (code APPROVE, 0 P1/0 P2 — promotion faithful, 404 preserved,
  dist a genuine rebuild, contract-only, enum-parity load-bearing incl. the
  runtime leg): extended the enum-parity mechanism from 3 to 14 enums, and
  corrected the test-count claims.
- **Rev 3 (this revision)** closes a residual overclaim the re-gate on Rev 2
  found (code again APPROVE, 0 P1/0 P2): "FULL/EVERY published closed enum"
  was still 14 of 22 raw `enum:` stanzas; 5 genuine value-domain positions
  drifted silently. Pins those 5, plus one more (`editorRef.kind`) found
  while auditing the full inventory to make the coverage claim actually
  true, and fixes a stale count in this body's prose.

**Authorization note (for the record, not a claim of merge authority):**
build-only work on this line requires its own owner act per design-lock §9
(W6-1's own ratification explicitly scoped itself to "the W6-1 backend
aggregate slice only" and listed W6-2 as a separate, un-granted act, as does
every relay comment on #4556 through 2026-08-13T06:30). This branch proceeds
on an in-session owner grant ("授权 W6-2") relayed by the coordinating
session; unlike every prior grant in this issue's history, that grant has
not yet been posted to #4556 as a durable comment. Recommend it be posted
there before the follow-up merge gate, consistent with this issue's own
practice for W6-0/W6-1/#4876. This PR itself is Draft and does not carry any
merge/Ready/flag/deploy authorization — that stays a separate owner act per
§9.

## Files changed

1. **`packages/openapi/src/paths/attendance.yml`** — appended the draft's
   `paths` block verbatim: `GET /api/attendance/groups/{groupId}/effective-policy`
   (values-free aggregate read model; delegated-non-member and unknown/cross-org
   groups share one **404** shape per #4876, not 403 — preserved verbatim).
2. **`packages/openapi/src/base.yml`** — appended the draft's
   `components.schemas` block verbatim (`AttendanceGroupEffectivePolicySourceLabel`,
   `...Domain`, `...ConflictCode`, `...EditorRef`, `...SourceRef`,
   `...FixedSchedule`, `...DomainSummary`, `...Conflict`, `...Response`).
3. **`packages/openapi/dist/{openapi.yaml,openapi.json,combined.openapi.yml}`**
   + **`packages/openapi/dist-sdk/index.d.ts`** — rebuilt via
   `pnpm --filter @metasheet/openapi build && validate && generate:sdk`, then
   committed so the required attendance OpenAPI contract gate
   (`git diff --exit-code -- packages/openapi/dist packages/openapi/dist-sdk/index.d.ts`
   in `plugin-tests.yml`) is byte-identical against a fresh rebuild.
4. **`packages/openapi/drafts/attendance-w6-group-effective-policy.draft.yml`**
   — header only, marked `status: PROMOTED` / `mergedIntoBuild: true`; the
   `paths:`/`components:` body is untouched so the existing test
   (`attendance-w6-group-effective-policy-response-contract.test.ts`, "the
   OpenAPI draft — the hand-kept THIRD face") that reads its `SourceRef.kind`
   enum verbatim keeps passing.
5. **`packages/core-backend/tests/unit/attendance-w6-2-enum-parity.test.ts`**
   (new) — the design-lock §7.3 enum-parity test, now covering 20 of the 22
   published closed-enum stanzas (see below).
6. **`packages/core-backend/src/attendance/w6-group-effective-policy-response-contract.ts`**
   — exports six previously-local closed-set constants
   (`CALCULATION_POSTURES`, `GROUP_TYPES`, `FSER_STATES`, `FLEX_MODES`,
   `RULE_SOURCES`, `GROUP_STAGES`) — pure visibility change, no behaviour
   change — so the enum-parity test can import them directly instead of
   hand-copying, for the enums whose only TS-side representation was an
   inline literal-union `type` in the contract module with no reusable
   array there.

## Dist-change note (W6-0 zero-behaviour property)

Before this PR, `pnpm --filter @metasheet/openapi build` reproduced `dist/`
byte-identical (the draft lived outside `src/paths/`, so `tools/build.ts`
never read it — this is what the W6-0 acceptance proved). **This PR is the
step that intentionally changes that**: `dist/` now contains the
effective-policy path/schemas, and the same CI gate that used to prove "the
draft stays OUT" now proves "the rebuilt dist/SDK matches what's committed,
including the new path" — a stronger, still-mechanical form of the same
gate, not a silent removal of it.

## Enum-parity test — coverage statement (accurate, not "FULL/EVERY")

`attendance-w6-2-enum-parity.test.ts` proves closed enums equal across
three **independently read** sources — no hand-copied second list.

**Coverage: 20 of 22 raw `enum:` stanzas in the promoted schema block,
counted as 20 of 21 logical enum positions** (`editorRef.kind`'s two
one-value oneOf-branch stanzas — `[group_stage]` and
`[group_context_route]` — are one logical two-value union, tested as one
case, not two, the same way `ConflictCode`'s 7-item block list is one case
not seven).

Pinned (20 cases): `SourceLabel`, `Domain`, `ConflictCode`, `SourceRef.kind`,
FSER `state`, FSER `reasonCodes`, `editorRef` `kind`/`stage`/`step`/`surface`,
`calculationPosture`, `groupType`, `domains.schedule.strategy` (a SEPARATE
position from `groupType` — same value domain, different OpenAPI stanza and
different runtime call site), flex `mode`, rules `source`,
`conflicts[].label`, `domains.punchMethod.source`, and all three
`domains.requestPosture.{overtime,makeupPunch,outdoor}` fields.

**The one deliberate exclusion:** the envelope's
`ok: { type: boolean, enum: [true] }`. Unlike every field above, this is
not a business value domain with real alternatives (an org's rule source,
a group's calculation posture, etc.) — it is the boolean success/failure
discriminator of the JSON response envelope itself (this schema describes
only the success shape; failures are separate 400/403/404 responses, not
`ok: false` bodies), the same structural tag every other MetaSheet response
envelope in this OpenAPI file uses. It has no TS-array or distinct-runtime-
enum-set analogue to compare against beyond the single
`envelope.ok !== true` type/shape guard, so pinning it would mean either
hand-typing a fabricated one-element array or comparing a boolean literal
against itself — not a real third or even second leg.

1. **OpenAPI** — sequential key-narrowing over `packages/openapi/src/base.yml`'s
   raw text (core-backend has no `js-yaml` dependency). Narrowing always
   descends `schema -> field -> nested field`, never a flat search over the
   whole file — several of these enums are nested several `allOf`/`oneOf`
   levels deep, and some field NAMES repeat elsewhere with a **different**
   enum (`domains.rules.source` vs `domains.punchMethod.source`; `groupType`
   vs `domains.schedule.strategy`) — a window not scoped through every
   intermediate key could silently grab the wrong sibling's enum and
   produce a false-passing test. `editorRef.kind` additionally needed a
   `narrowAll`/`getOpenApiEnumUnion` helper: reading only the first
   occurrence of `kind:` would silently drop the second oneOf branch's
   value. Also relaxed the inline-enum regex to match flow-style YAML
   (`{ type: string, enum: [org_inherited] }`, used by the
   `requestPosture.*` fields) — the original regex required `enum:` to
   start a line, which flow style doesn't.
2. **TS contract** — real imports throughout, never retyped:
   - `SourceLabel`/`Domain`/`ConflictCode`/`SourceRef.kind`/FSER
     `reasonCodes`: the frozen arrays already exported by
     `w6-group-effective-policy-contract.ts` (FSER `reasonCodes` is itself
     derived from the real FSER service's `REASON_ORDER` import).
   - `calculationPosture`/`groupType`/`domains.schedule.strategy`/flex
     `mode`/rules `source`/FSER `state`/editorRef `stage`: that module only
     carries an inline literal **type** union for these, no reusable array
     — so the corresponding array in
     `w6-group-effective-policy-response-contract.ts` is exported by this
     PR (file 6 above) instead of hand-copying it into the test.
     `domains.schedule.strategy` reuses the same `GROUP_TYPES` array
     `groupType` does (both are validated against the identical set in the
     real validator) but is its own case because it is a distinct
     OpenAPI/runtime POSITION — a drift confined to that one stanza or that
     one call site would not be caught by the `groupType` case.
   - editorRef `step`/`surface`: derived mechanically from the already
     exported `SCHEDULE_ROUTE_SURFACES` object (`Object.keys` /
     flattened-deduped `Object.values`), never retyped.
   - `conflicts[].label`, `editorRef.kind`, `domains.punchMethod.source`,
     and the three `domains.requestPosture.*` fields: no array anywhere —
     each is a fixed literal (single string, or for `kind` a two-value
     discriminator with no reusable union array), checked in the validator
     by direct `===`/`!==`/`.includes()`. Documented in the test as
     **2-way only** (OpenAPI vs runtime), per "don't fake a third leg" —
     there is no second, distinct place to import a value from without
     hand-typing a literal array. `editorRef.kind` was pinned this way even
     though the earlier gate didn't name it, because it's genuinely
     pinnable with the identical construction — "do not narrow by dropping
     a pinnable enum."
3. **Runtime service** — unchanged in kind throughout: every case probes
   `validateAttendanceGroupEffectivePolicyResponseV1` (the exact function
   the aggregate service calls on every real response before returning it)
   with a pool of candidate values and records what it actually accepts, so
   validator-logic drift that touches neither declared list is still
   caught.

**Local verification (commands + output, re-run after this revision):**

```
$ pnpm --filter @metasheet/openapi build && pnpm --filter @metasheet/openapi validate && pnpm --filter @metasheet/openapi generate:sdk
Built OpenAPI to dist with parts: [...]
OpenAPI security validation passed
✨ openapi-typescript 7.13.0 ... SDK packaged to dist-sdk

$ git diff --exit-code -- packages/openapi/dist packages/openapi/dist-sdk/index.d.ts
(exit 0 — byte-identical to a fresh rebuild of the committed source; dist
unchanged by this revision, as expected — only test/export-visibility files
touched)

$ node --test scripts/ops/attendance-w4c4-openapi-contract.test.mjs
✔ W4C-4 OpenAPI carries only the three new calculation-detail/diff paths
✔ W4C-4 calculation detail and diff schemas are closed and values-safe
✔ generated SDK contains every W4C-4 path and schema
tests 3 / pass 3 / fail 0

$ pnpm --filter @metasheet/core-backend exec vitest run tests/unit/attendance-w6-2-enum-parity.test.ts --reporter=dot
Test Files  1 passed (1)
     Tests  62 passed (62)          # 20 cases x 3 assertions + 2 fixture sanity checks

$ pnpm --filter @metasheet/core-backend exec vitest run \
    tests/unit/attendance-w6-2-enum-parity.test.ts \
    tests/unit/attendance-w6-fser-single-source-caller-inventory.test.ts \
    tests/unit/attendance-w6-group-effective-policy-aggregate.test.ts \
    tests/unit/attendance-w6-group-effective-policy-authorization.test.ts \
    tests/unit/attendance-w6-group-effective-policy-dml-sweep.test.ts \
    tests/unit/attendance-w6-group-effective-policy-response-contract.test.ts \
    tests/unit/attendance-w6-import-graph-no-calculation-consumer.test.ts \
    tests/unit/attendance-w6-producer-key-single-source.test.ts \
    tests/unit/attendance-w6-schedule-route-surface-parity.test.ts \
    --reporter=dot
Test Files  9 passed (9)
     Tests  334 passed (334)          # 272 pre-existing + 62 in this file. (Rev 2's body incorrectly
                                       # still said "282" in its prose after already reporting the
                                       # correct 316 in its verification block — both are now 334.)

$ pnpm --filter @metasheet/core-backend exec tsc --noEmit
(clean, zero diagnostics)
```

**dist-sdk note (unchanged from Rev 2):** no dist-sdk test-count claim is
made in this body. `packages/openapi/dist-sdk`'s own `test` script
(`pnpm --filter @metasheet/sdk test`) runs only `tests/client.test.ts`; none
of it is part of any CI workflow — the only CI reference to `dist-sdk` is
the `git diff --exit-code` line on `index.d.ts` (already covered above).

## Load-bearing mutation proof — all 20 pinned cases, both directions

Every mutation was applied via `Edit`, tested with a targeted
`vitest -t "<case>"` run, then restored from a `cp` file backup (never
`git checkout --`) before the next mutation — restoration verified via
`diff` against the backup after every step.

**Original 3 + first 11 (14 total, from Rev 2)** — re-verified green this
revision; proofs unchanged, see the Rev-2 commit for the original per-case
table.

**6 newly-covered positions (this revision), each proved in both
directions:**

| Position | OpenAPI mutation → red | Other-source mutation → red |
| --- | --- | --- |
| `domains.schedule.strategy` (3-way) | `base.yml` `strategy` enum (verified only 1 assertion reds, NOT the sibling `groupType` case — confirms correct scoping) | `response-contract.ts` `GROUP_TYPES` (verified reds BOTH `strategy` and `groupType` cases, since they share the array) |
| `domains.punchMethod.source` (2-way) | `base.yml` enum value | `response-contract.ts` literal `!== 'org_inherited'` check |
| `domains.requestPosture.overtime` (2-way) | `base.yml` enum value (verified only 1 assertion reds, not `makeupPunch`/`outdoor`) | shared runtime loop check (see next row) |
| `domains.requestPosture.makeupPunch` (2-way) | `base.yml` enum value (isolated) | shared runtime loop check (see next row) |
| `domains.requestPosture.outdoor` (2-way) | `base.yml` enum value (isolated) | shared runtime loop check (see next row) |
| *(shared)* `requestPosture.*` runtime leg | — | `response-contract.ts` `requestPostureValue[key] !== 'org_inherited'` — ONE mutation reds all three `requestPosture.*` cases simultaneously (verified: exactly 3 assertions failed), since all three share one loop-based check |
| `editorRef.kind` (2-way, union of both oneOf branches) | `base.yml` `group_stage` branch enum value (union mismatch detected — confirms `narrowAll` reads both occurrences, not just the mutated one) | `response-contract.ts` parser's `value.kind === 'group_stage'` literal check |

All directions reproduced the expected red; all were restored and the full
62-test suite is green again at HEAD (see verification block above).

## Out of scope / not done here

W6-3 UI, W6-4 verification, any merge, Ready transition, flag change,
staging, soak, production/customer data, or closure of issue #4556 — all
remain separate owner acts per design-lock §9. This PR stays Draft.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
