### PR TITLE
fix(attendance): Gate E first batch — idle-connection precondition on caller-supplied txn owners (#4844)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -1367,6 +1367,7 @@ jobs:
             tests/integration/attendance-w4c3a-import-rollback.db.test.ts \
             tests/integration/attendance-w4c3a-rollout-control.db.test.ts \
             tests/integration/attendance-w4c5-rollout-transition-tool.db.test.ts \
+            tests/integration/attendance-gate-e-txn-ownership-batch1.db.test.ts \
             tests/integration/attendance-w4c3b-request-operation-routes.db.test.ts \
             tests/integration/attendance-w4c3b-approved-leave-cancellation.db.test.ts \
             tests/integration/attendance-w4c3b-request-snapshots.db.test.ts \

--- a/packages/core-backend/src/attendance/__tests__/w4c3a-legacy-plan-mutation-seams.test.ts
+++ b/packages/core-backend/src/attendance/__tests__/w4c3a-legacy-plan-mutation-seams.test.ts
@@ -176,6 +176,12 @@ describe('blueprint mutations — real production surfaces', () => {
         client: {
           query: async (sql: string, params?: unknown[]) => {
             queries.push([sql, ...(params ?? [])])
+            // This is a freshly-acquired (idle) connection — the SAME affirmative-proof
+            // contract the real driver gives `assertConnectionIsIdleV1`'s own
+            // `SAVEPOINT w4c5_idle_probe` (SQLSTATE 25P01, no active transaction).
+            if (sql === 'SAVEPOINT w4c5_idle_probe') {
+              throw Object.assign(new Error('no_active_sql_transaction'), { code: '25P01' })
+            }
             if (
               String(sql).includes('FROM attendance_import_jobs') &&
               String(sql).includes('id = $1') &&

--- a/packages/core-backend/src/attendance/__tests__/w4c3a-legacy-plan-reservation-host.test.ts
+++ b/packages/core-backend/src/attendance/__tests__/w4c3a-legacy-plan-reservation-host.test.ts
@@ -63,6 +63,12 @@ describe('W4C-3a P07 production reservation host', () => {
         client: {
           query: async (text: string) => {
             sql.push(text)
+            // This is a freshly-acquired (idle) connection — the SAME affirmative-proof
+            // contract the real driver gives `assertConnectionIsIdleV1`'s own
+            // `SAVEPOINT w4c5_idle_probe` (SQLSTATE 25P01, no active transaction).
+            if (text === 'SAVEPOINT w4c5_idle_probe') {
+              throw Object.assign(new Error('no_active_sql_transaction'), { code: '25P01' })
+            }
             if (text.includes('attendance_calculation_rollout_state')) {
               rolloutAttempts += 1
               if (rolloutAttempts === 1) {
@@ -169,6 +175,10 @@ describe('W4C-3a P07 production reservation host', () => {
     expect(released).toBe(1)
     expect(rolloutAttempts).toBe(2)
     expect(sql).toEqual([
+      // Gate E (#4844): the idle-precondition probe runs exactly ONCE, before the retry loop —
+      // never re-issued per attempt (the loop's own ROLLBACK already restores idle between
+      // attempts).
+      'SAVEPOINT w4c5_idle_probe',
       'BEGIN ISOLATION LEVEL SERIALIZABLE',
       "SELECT set_config('statement_timeout', $1, true)",
       "SELECT set_config('lock_timeout', $1, true)",

--- a/packages/core-backend/src/attendance/__tests__/w4c3a-sync-import-host.test.ts
+++ b/packages/core-backend/src/attendance/__tests__/w4c3a-sync-import-host.test.ts
@@ -193,6 +193,12 @@ describe('W4C-3a P06 sync import host (unit/static)', () => {
         client: {
           query: async (text: string) => {
             sql.push(text)
+            // This is a freshly-acquired (idle) connection — the SAME affirmative-proof
+            // contract the real driver gives `assertConnectionIsIdleV1`'s own
+            // `SAVEPOINT w4c5_idle_probe` (SQLSTATE 25P01, no active transaction).
+            if (text === 'SAVEPOINT w4c5_idle_probe') {
+              throw Object.assign(new Error('no_active_sql_transaction'), { code: '25P01' })
+            }
             if (text.includes('attendance_calculation_rollout_state')) {
               return {
                 rows: [{ state: 'authoritative', scope: 'synthetic_staging' }],
@@ -243,7 +249,10 @@ describe('W4C-3a P06 sync import host (unit/static)', () => {
       ),
     ).rejects.toThrow('ATTENDANCE_IMPORT_BATCH_LIMIT_EXCEEDED')
     expect(released).toBe(1)
-    expect(sql[0]).toContain('BEGIN ISOLATION LEVEL SERIALIZABLE')
+    // Gate E (#4844): the idle-precondition probe's own SAVEPOINT is genuinely the FIRST
+    // statement issued on the connection, before the wrapper's BEGIN.
+    expect(sql[0]).toBe('SAVEPOINT w4c5_idle_probe')
+    expect(sql[1]).toContain('BEGIN ISOLATION LEVEL SERIALIZABLE')
     expect(sql.join('\n')).not.toMatch(
       /INSERT INTO attendance_import_batches|INSERT INTO attendance_import_items|COPY |attendance_import_jobs|attendance_import_legacy_execution_plan/i,
     )
@@ -553,6 +562,12 @@ describe('W4C-3a P06 sync import host (unit/static)', () => {
           client: {
             query: async (text: string) => {
               sql.push(text)
+              // This is a freshly-acquired (idle) connection — the SAME affirmative-proof
+              // contract the real driver gives `assertConnectionIsIdleV1`'s own
+              // `SAVEPOINT w4c5_idle_probe` (SQLSTATE 25P01, no active transaction).
+              if (text === 'SAVEPOINT w4c5_idle_probe') {
+                throw Object.assign(new Error('no_active_sql_transaction'), { code: '25P01' })
+              }
               if (text.includes('attendance_calculation_rollout_state')) {
                 return {
                   rows: [{ state: 'authoritative', scope: 'synthetic_staging' }],
@@ -599,7 +614,10 @@ describe('W4C-3a P06 sync import host (unit/static)', () => {
           }),
         ),
       ).rejects.toThrow('ATTENDANCE_IMPORT_BATCH_LIMIT_EXCEEDED')
-      expect(sql[0]).toContain('BEGIN ISOLATION LEVEL SERIALIZABLE')
+      // Gate E (#4844): the idle-precondition probe's own SAVEPOINT is genuinely the FIRST
+      // statement issued on the connection, before the wrapper's BEGIN.
+      expect(sql[0]).toBe('SAVEPOINT w4c5_idle_probe')
+      expect(sql[1]).toContain('BEGIN ISOLATION LEVEL SERIALIZABLE')
       expect(sql.join('\n')).not.toMatch(
         /INSERT INTO attendance_import_(?:jobs|batches|items)|attendance_import_legacy_execution_plan|attendance_import_legacy_terminal/i,
       )

--- a/packages/core-backend/src/attendance/__tests__/w4c3b-request-operation-boundary.test.ts
+++ b/packages/core-backend/src/attendance/__tests__/w4c3b-request-operation-boundary.test.ts
@@ -25,6 +25,12 @@ function fakeClient(rolloutState: 'shadow' | 'suspended' | null): AttendanceW4Tr
     calls,
     async query(sqlText: string, params: unknown[] = []) {
       calls.push({ sqlText, params })
+      // This is a freshly-acquired (idle) connection — the SAME affirmative-proof contract the
+      // real driver gives `assertConnectionIsIdleV1`'s own `SAVEPOINT w4c5_idle_probe`
+      // (SQLSTATE 25P01, no active transaction).
+      if (sqlText === 'SAVEPOINT w4c5_idle_probe') {
+        throw Object.assign(new Error('no_active_sql_transaction'), { code: '25P01' })
+      }
       if (sqlText.includes('FROM users WHERE id = $1')) return { rows: [{ ok: 1 }] }
       if (sqlText.includes('FROM user_orgs WHERE user_id = $1')) return { rows: [{ ok: 1 }] }
       if (sqlText.startsWith('SELECT state, scope FROM attendance_calculation_rollout_state')) {

--- a/packages/core-backend/src/attendance/w4c0-operation-registry.ts
+++ b/packages/core-backend/src/attendance/w4c0-operation-registry.ts
@@ -39,6 +39,7 @@ import type {
 import {
   acquireAttendanceCalculationRolloutLock,
   acquireAttendanceResultOperationLocks,
+  assertConnectionIsIdleV1,
   createVerifiedAttendanceOperationIdentityV1,
   createVerifiedAttendanceOrgIdentityV1,
   deriveAttendanceOperationCandidateIdentityV1,
@@ -918,6 +919,16 @@ export async function runAttendanceResultOperationTransactionV1<T>(
   connection: AttendanceW4TransactionClientV1,
   body: (trx: AttendanceW4TransactionClientV1) => Promise<T>,
 ): Promise<T> {
+  // Gate E (#4844) first batch: `connection` is CALLER-supplied. PostgreSQL only WARNs on a
+  // nested `BEGIN` (never errors) — on a dirty caller connection this function's own `COMMIT`
+  // below would durably publish the caller's uncommitted writes, strictly worse than a merely
+  // wrong snapshot: this function actually commits. Proven idle exactly ONCE, BEFORE the retry
+  // loop (not inside it) — the loop's own `ROLLBACK` on a failed attempt already restores idle
+  // between attempts, so the precondition is "idle on entry", not "idle every iteration".
+  // Reuses the EXISTING exported probe (w4c0-identity.ts) rather than building a second one —
+  // see that function's own doc comment for the SAVEPOINT-probe proof and refusal code
+  // (`W4C0_CONNECTION_NOT_IDLE`, never a raw SQLSTATE).
+  await assertConnectionIsIdleV1(connection)
   let attempt = 0
   // W4_TRANSACTION_MAX_RETRIES retries => up to (1 + retries) attempts.
   for (;;) {

--- a/packages/core-backend/src/attendance/w4c2-outbox-dispatcher.ts
+++ b/packages/core-backend/src/attendance/w4c2-outbox-dispatcher.ts
@@ -33,6 +33,7 @@
  * caller's concern.
  */
 import type { AttendanceW4TransactionClientV1 } from './w4c0-identity'
+import { assertConnectionIsIdleV1 } from './w4c0-identity'
 
 export class AttendanceW4OutboxDispatchError extends Error {
   readonly code: string
@@ -101,6 +102,13 @@ export async function dispatchAttendanceResultEventOutboxV1(
   let delivered = 0
   let failed = 0
 
+  // Gate E (#4844) first batch: `connection` is caller-supplied, same class as the operation-
+  // registry transaction wrapper — a dirty caller connection would let this function's own
+  // unconditional COMMIT durably publish the caller's uncommitted writes (PostgreSQL only WARNs,
+  // never errors, on the nested BEGIN below). Reuses the EXISTING exported probe rather than
+  // building a second one — see its own doc comment (w4c0-identity.ts) for the SAVEPOINT-probe
+  // proof and refusal code (`W4C0_CONNECTION_NOT_IDLE`, never a raw SQLSTATE).
+  await assertConnectionIsIdleV1(connection)
   await connection.query('BEGIN', [])
   try {
     // Claim due pending rows; SKIP LOCKED partitions the set between

--- a/packages/core-backend/src/attendance/w4c3a-legacy-plan-reservation-host.ts
+++ b/packages/core-backend/src/attendance/w4c3a-legacy-plan-reservation-host.ts
@@ -127,10 +127,12 @@ export function createAttendanceLegacyPlanReservationHostV1(
     async reserveLegacyImportPlanV1(input) {
       validateHostInputBeforeConnection(input)
       const acquired = await deps.acquireConnection()
-      const trx = acquired.client
+      // Freshly-acquired, idle-on-entry connection — NOT a transaction handle yet (the wrapper
+      // below opens the transaction on it after `assertConnectionIsIdleV1` certifies idle).
+      const connection = acquired.client
       try {
-        return await runAttendanceResultOperationTransactionV1(trx, async () => {
-        const posture = await resolveSegmentCalculationPosture(trx, input.orgId)
+        return await runAttendanceResultOperationTransactionV1(connection, async () => {
+        const posture = await resolveSegmentCalculationPosture(connection, input.orgId)
         const org = createVerifiedAttendanceOrgIdentityV1({
           orgKey: input.orgId,
           posture,
@@ -221,7 +223,7 @@ export function createAttendanceLegacyPlanReservationHostV1(
             : []
 
         return reserveAttendanceLegacyImportPlanJobV1(
-          trx,
+          connection,
           authorization,
           {
             batchIdentity,

--- a/packages/core-backend/tests/helpers/attendance-txn-ownership-walk.ts
+++ b/packages/core-backend/tests/helpers/attendance-txn-ownership-walk.ts
@@ -1,0 +1,294 @@
+import * as ts from 'typescript'
+
+/**
+ * Gate E (#4844) — DB-free static-AST classifier for "who owns this transaction". #4844 says
+ * verbatim: "Enumerating known offenders converges no better here than it did the last two
+ * times — the guard has to walk the exported table." This module IS that walk: given a parsed
+ * `packages/core-backend/src/attendance/*.ts` file, it finds every EXPORTED function that opens
+ * a transaction (`BEGIN` / `START TRANSACTION`) on one of its OWN parameters typed
+ * `AttendanceW4TransactionClientV1` — i.e. a connection the CALLER supplied, not one this
+ * function acquired itself — and partitions each such site into exactly one of
+ * `{OWNS, JOINS, NESTED, UNKNOWN}`, fail-closed: a shape nobody reviewed lands in UNKNOWN.
+ *
+ * Modelled on the existing F1 assembly guard
+ * (`tests/helpers/attendance-w6-index-assembly-order.ts` + its test,
+ * `tests/unit/attendance-w6-group-effective-policy-authorization.test.ts`): the same TypeScript
+ * compiler AST-walk idiom (never text/regex over the raw file), the same "whitelist the ONE
+ * unconditional shape, don't blacklist conditional ancestor kinds" discipline (this module's
+ * `isTopLevelStatementOfFunctionBody`, modelled on that file's `classifyUnconditional`), and the
+ * same context key discipline: `enclosing-symbol + ancestor-KIND path`, never line/column (those
+ * drift on unrelated edits elsewhere in the file).
+ *
+ * Domain (narrower than F1's "every `this` use"): a `BEGIN`-site is OWNS iff the SAME exported
+ * function calls `assertConnectionIsIdleV1(<sameConnectionParam>)` as a genuinely UNCONDITIONAL
+ * top-level statement of its OWN body block — i.e. a direct statement of the function's body,
+ * not nested inside any `if`/loop/`try`/`switch`/logical-short-circuit — occurring textually
+ * BEFORE the `BEGIN` call (which MAY itself be arbitrarily nested, e.g. inside a retry loop's
+ * `try` block: only the PROOF must be unconditional, not the `BEGIN` it dominates). This exactly
+ * matches both converted first-batch sites ("once before the retry loop"; "before the bare
+ * `BEGIN`") and the pre-existing correct sibling
+ * (`planAttendanceCalculationRolloutTransitionV1` in w4c3a-rollout-control.ts).
+ *
+ * Scope boundaries (documented residuals, matching this repo's convention of NAMING what a
+ * static walker cannot decide rather than silently guessing):
+ *  - The BEGIN/idle-proof detector never crosses into a NESTED function-like boundary (arrow
+ *    function, function expression, method, accessor, constructor) — a `.query('BEGIN')` issued
+ *    inside a callback passed to `body` (the retry wrapper's own generic parameter) belongs to
+ *    the CALLER's closure, not to this function's own transaction-management responsibility, and
+ *    is correctly invisible here (it is that OTHER exported function's own site, if any).
+ *  - Connection-parameter identity is NAME-based (no `TypeChecker`/symbol resolution) — a local
+ *    alias (`const conn = connection`) or destructure would not be recognized as the same
+ *    identity. Verified empirically (grep) that no function in `src/attendance/*.ts` does this
+ *    today; a future one would surface as a NEW, unmatched `BEGIN` call with a differently-named
+ *    receiver, which this walker simply does not collect at all (not silently OWNS) — it is
+ *    invisible rather than misclassified, the same trade-off F1's own `argumentsReachIdentifier`
+ *    documents for its domain.
+ *  - `BEGIN`/`START TRANSACTION` detection only matches a `StringLiteral` or
+ *    `NoSubstitutionTemplateLiteral` first argument (`ts.isStringLiteralLike`) — a dynamically
+ *    interpolated query string (`TemplateExpression` with substitutions) is undecidable
+ *    statically and is not detected as a BEGIN site at all (same invisible-not-misclassified
+ *    trade-off). No site in this module's actual surface does this today.
+ */
+
+const CONNECTION_TYPE_NAME = 'AttendanceW4TransactionClientV1'
+const IDLE_PROOF_CALLEE_NAME = 'assertConnectionIsIdleV1'
+const BEGIN_STATEMENT_PATTERN = /^\s*(BEGIN\b|START\s+TRANSACTION\b)/i
+
+export type TxnOwnershipBucket = 'OWNS' | 'JOINS' | 'NESTED' | 'UNKNOWN'
+
+export interface TxnOwnershipAllowlistEntryV1 {
+  /** Basename of the file under `src/attendance/`, e.g. `'w4c3b-request-snapshots.ts'`. */
+  readonly file: string
+  /** The exported function's own name. */
+  readonly enclosingFunction: string
+  readonly bucket: 'JOINS' | 'NESTED'
+  /** Required, reviewed justification — never optional. A function that legitimately runs
+   *  inside the caller's already-open transaction (JOINS), or that opens its own NAMED,
+   *  released savepoint nested inside the caller's transaction (NESTED), belongs here with the
+   *  reviewer's reasoning, not silently inferred by the walker. */
+  readonly reason: string
+}
+
+/**
+ * Gate E (#4844) first-batch allowlist. EMPTY BY DESIGN: a full sweep of
+ * `packages/core-backend/src/attendance/*.ts` (the guard test's own discovery) finds exactly
+ * three `BEGIN`-on-caller-connection sites total, and all three are category-1 (OWNS) — the two
+ * converted this batch plus the one sibling (`planAttendanceCalculationRolloutTransitionV1`)
+ * that already did this correctly (W4C-5 NEW-B / PR #4839). Any FUTURE JOINS/NESTED site must be
+ * added here, reviewed, with a `reason` — it must never be inferred by the walker itself, and an
+ * un-added new BEGIN site lands in UNKNOWN and reds the guard, exactly as designed.
+ */
+export const TXN_OWNERSHIP_ALLOWLIST_V1: readonly TxnOwnershipAllowlistEntryV1[] = []
+
+export interface BeginSiteV1 {
+  /** `enclosing-function // ancestor-KIND-path // BEGIN // #occurrence-ordinal` — stable under
+   *  unrelated edits elsewhere in the same function; changes only if this SITE itself moves to a
+   *  different syntactic context. NEVER line/column. */
+  readonly key: string
+  readonly file: string
+  readonly enclosingFunction: string
+  readonly connParamName: string
+  /** The literal BEGIN statement text, e.g. `'BEGIN ISOLATION LEVEL SERIALIZABLE'`. */
+  readonly statementText: string
+  readonly bucket: TxnOwnershipBucket
+  readonly reason?: string
+  /** Diagnostic only — never asserted on by key/identity, only used to order/dedupe within one
+   *  file during collection. */
+  readonly start: number
+}
+
+function hasExportModifier(node: ts.Node): boolean {
+  if (!ts.canHaveModifiers(node)) return false
+  const mods = ts.getModifiers(node)
+  return !!mods?.some((m) => m.kind === ts.SyntaxKind.ExportKeyword)
+}
+
+/** Every top-level `export function` / `export async function` declaration in the file — the
+ *  "whole exported surface" this guard walks. Deliberately top-level-statements only: nothing in
+ *  this codebase's `src/attendance/*.ts` exports a function any other way (verified: zero
+ *  `export const x = (...) => ...` arrow exports across the directory), and a TypeScript
+ *  namespace/module-nested export is not a shape this directory uses either. */
+function exportedFunctionDeclarations(source: ts.SourceFile): ts.FunctionDeclaration[] {
+  const out: ts.FunctionDeclaration[] = []
+  for (const stmt of source.statements) {
+    if (ts.isFunctionDeclaration(stmt) && stmt.name && stmt.body && hasExportModifier(stmt)) {
+      out.push(stmt)
+    }
+  }
+  return out
+}
+
+/** Parameters of `fn` typed exactly `AttendanceW4TransactionClientV1` (a plain `TypeReference` by
+ *  name — no aliasing/renaming import exists anywhere in this directory today, verified by
+ *  grep). These are the "caller-supplied connection" identities this guard reasons about. */
+function connectionParams(fn: ts.FunctionDeclaration): ts.ParameterDeclaration[] {
+  return fn.parameters.filter((p) => {
+    const t = p.type
+    return !!t && ts.isTypeReferenceNode(t) && ts.isIdentifier(t.typeName) && t.typeName.text === CONNECTION_TYPE_NAME
+  })
+}
+
+function paramName(p: ts.ParameterDeclaration): string | null {
+  return ts.isIdentifier(p.name) ? p.name.text : null
+}
+
+/** A rebinding/closure boundary this walk does not cross — see the module docblock's first
+ *  residual note. */
+function isFunctionLikeBoundary(node: ts.Node): boolean {
+  return (
+    ts.isFunctionDeclaration(node) ||
+    ts.isFunctionExpression(node) ||
+    ts.isArrowFunction(node) ||
+    ts.isMethodDeclaration(node) ||
+    ts.isGetAccessorDeclaration(node) ||
+    ts.isSetAccessorDeclaration(node) ||
+    ts.isConstructorDeclaration(node)
+  )
+}
+
+interface RawCall {
+  readonly node: ts.CallExpression
+  readonly start: number
+}
+
+/** Every `CallExpression` in `fn`'s OWN scope (its body, recursing through control-flow
+ *  constructs but never into a nested function-like) matching `predicate`, in source order. */
+function collectOwnScopeCalls(
+  fn: ts.FunctionDeclaration,
+  predicate: (call: ts.CallExpression) => boolean,
+): RawCall[] {
+  const out: RawCall[] = []
+  const visit = (node: ts.Node, isRoot: boolean): void => {
+    if (!isRoot && isFunctionLikeBoundary(node)) return
+    if (ts.isCallExpression(node) && predicate(node)) {
+      out.push({ node, start: node.getStart() })
+    }
+    node.forEachChild((child) => visit(child, false))
+  }
+  if (fn.body) visit(fn.body, true)
+  out.sort((a, b) => a.start - b.start)
+  return out
+}
+
+/** `<connName>.query(<string-literal-like matching BEGIN|START TRANSACTION>, ...)` — the
+ *  transaction-opening statement shape this guard targets. Returns the literal statement text on
+ *  a match, `null` otherwise (including the "undecidable" cases named in the module docblock). */
+function matchBeginCall(call: ts.CallExpression, connName: string): string | null {
+  const callee = call.expression
+  if (!ts.isPropertyAccessExpression(callee)) return null
+  if (callee.name.text !== 'query') return null
+  if (!ts.isIdentifier(callee.expression) || callee.expression.text !== connName) return null
+  const arg0 = call.arguments[0]
+  if (!arg0 || !ts.isStringLiteralLike(arg0)) return null
+  return BEGIN_STATEMENT_PATTERN.test(arg0.text) ? arg0.text : null
+}
+
+/** `assertConnectionIsIdleV1(<connName>)` — bare identifier callee, bare identifier first
+ *  argument matching the SAME connection identity by name. */
+function isIdleProofCallOnConn(call: ts.CallExpression, connName: string): boolean {
+  const callee = call.expression
+  if (!ts.isIdentifier(callee) || callee.text !== IDLE_PROOF_CALLEE_NAME) return false
+  const arg0 = call.arguments[0]
+  return !!arg0 && ts.isIdentifier(arg0) && arg0.text === connName
+}
+
+/**
+ * WHITELIST (not blacklist) of the one unconditional shape, modelled directly on the F1 guard's
+ * `classifyUnconditional`: `node` (after unwrapping at most one enclosing `await`) must be the
+ * whole expression of a bare `ExpressionStatement` that is ITSELF a direct statement of `fn`'s
+ * own body `Block` — zero hops. A call inside an `if`/loop/`try`/`catch`/short-circuit does NOT
+ * qualify, even if it happens to run before the `BEGIN` on every path THIS version of the code
+ * takes — that requires case-by-case reasoning this guard deliberately declines to do; such a
+ * shape is exactly what the JOINS/NESTED allowlist (with a reviewed `reason`) exists for.
+ */
+function isTopLevelStatementOfFunctionBody(fn: ts.FunctionDeclaration, call: ts.CallExpression): boolean {
+  let expr: ts.Node = call
+  const parent: ts.Node | undefined = expr.parent
+  if (parent && ts.isAwaitExpression(parent) && parent.expression === expr) {
+    expr = parent
+  }
+  const stmt = expr.parent
+  if (!stmt || !ts.isExpressionStatement(stmt) || stmt.expression !== expr) return false
+  const body = stmt.parent
+  return !!body && ts.isBlock(body) && body === fn.body
+}
+
+/** Ancestor-KIND path from (excluding) `fn` down to (including) `node`, root-to-node order.
+ *  NEVER line/column — see the module docblock. Matches F1's `baseKeyOf` idiom exactly. */
+function ancestorKindPath(fn: ts.FunctionDeclaration, node: ts.Node): string {
+  const kinds: string[] = []
+  let current: ts.Node = node
+  while (current.parent && current.parent !== fn) {
+    current = current.parent
+    kinds.push(ts.SyntaxKind[current.kind])
+  }
+  kinds.reverse()
+  return kinds.join('>')
+}
+
+/**
+ * Walk the WHOLE exported surface of one already-parsed source file and partition every
+ * BEGIN-on-caller-connection site into `{OWNS, JOINS, NESTED, UNKNOWN}`. `fileLabel` is the
+ * basename used both for allowlist matching and for the returned sites' `file`/`key` fields — the
+ * caller (the guard test) owns filesystem access; this function is pure and DB-free.
+ */
+export function discoverBeginSitesV1(
+  source: ts.SourceFile,
+  fileLabel: string,
+  allowlist: readonly TxnOwnershipAllowlistEntryV1[] = TXN_OWNERSHIP_ALLOWLIST_V1,
+): BeginSiteV1[] {
+  const out: BeginSiteV1[] = []
+  const keyOrdinal = new Map<string, number>()
+
+  for (const fn of exportedFunctionDeclarations(source)) {
+    const fnName = fn.name!.text
+    for (const param of connectionParams(fn)) {
+      const connName = paramName(param)
+      if (!connName) continue
+
+      const beginCalls = collectOwnScopeCalls(fn, (c) => matchBeginCall(c, connName) !== null)
+      if (beginCalls.length === 0) continue
+
+      const dominatingIdleStarts = collectOwnScopeCalls(fn, (c) => isIdleProofCallOnConn(c, connName))
+        .filter((c) => isTopLevelStatementOfFunctionBody(fn, c.node))
+        .map((c) => c.start)
+
+      for (const { node: beginNode, start } of beginCalls) {
+        const statementText = matchBeginCall(beginNode, connName)!
+        const dominated = dominatingIdleStarts.some((idleStart) => idleStart < start)
+
+        const baseKey = `${fnName}//${ancestorKindPath(fn, beginNode)}//BEGIN`
+        const ordinal = keyOrdinal.get(baseKey) ?? 0
+        keyOrdinal.set(baseKey, ordinal + 1)
+        const key = `${baseKey}//#${ordinal}`
+
+        let bucket: TxnOwnershipBucket
+        let reason: string | undefined
+        if (dominated) {
+          bucket = 'OWNS'
+        } else {
+          const allow = allowlist.find((a) => a.file === fileLabel && a.enclosingFunction === fnName)
+          if (allow) {
+            bucket = allow.bucket
+            reason = allow.reason
+          } else {
+            bucket = 'UNKNOWN'
+          }
+        }
+
+        out.push({
+          key,
+          file: fileLabel,
+          enclosingFunction: fnName,
+          connParamName: connName,
+          statementText,
+          bucket,
+          reason,
+          start,
+        })
+      }
+    }
+  }
+
+  return out
+}

--- a/packages/core-backend/tests/helpers/attendance-txn-ownership-walk.ts
+++ b/packages/core-backend/tests/helpers/attendance-txn-ownership-walk.ts
@@ -292,3 +292,68 @@ export function discoverBeginSitesV1(
 
   return out
 }
+
+// ---------------------------------------------------------------------------
+// Independent, DELIBERATELY BROADER collector — the P2-c backstop.
+//
+// `discoverBeginSitesV1` only ever LOOKS at BEGIN calls on a receiver identifier that is the
+// NAME of a parameter whose declared type is exactly `AttendanceW4TransactionClientV1`
+// (`connectionParams`'s type-name gate). That gate is exactly right for CLASSIFYING a site's
+// ownership — but it means a `BEGIN` issued on a receiver typed something else (a raw `PoolClient`
+// parameter, an untyped parameter, a locally-narrowed alias) is not merely UNKNOWN, it is
+// INVISIBLE: `discoverBeginSitesV1` never produces a `BeginSiteV1` for it at all, so it cannot
+// even reach the UNKNOWN bucket the rest of this guard's fail-closed discipline relies on.
+//
+// This mirrors the exact defect class the F1 guard's own `independentThisStarts` exists to catch
+// (its doc comment: "so a pruning bug in the builder cannot hide behind a self-consistent-but-
+// incomplete `part.all`" — P2-c). The fix there was an INDEPENDENT, un-pruned reference walk the
+// test compares the classified set against, member-by-member. This is that walk for THIS domain:
+// every `<Identifier>.query(<string-literal-like matching BEGIN|START TRANSACTION>, ...)` call
+// inside ANY exported function's own scope — with NO type gate on the receiver at all — so a
+// differently-typed or untyped BEGIN site is found here even though `discoverBeginSitesV1` would
+// never see it. The guard test asserts the two walks' site COUNTS agree on the real tree; a
+// mismatch means `discoverBeginSitesV1`'s type gate just went blind to something this broader
+// walk still sees, and that mismatch is itself the failure — not merely "some future improvement".
+// ---------------------------------------------------------------------------
+
+export interface IndependentBeginCallSiteV1 {
+  readonly enclosingFunction: string
+  readonly receiverName: string
+  readonly statementText: string
+}
+
+/** Same BEGIN/START-TRANSACTION text match as `matchBeginCall`, but with NO receiver-identity or
+ *  receiver-TYPE constraint at all: any `<Identifier>.query(...)` qualifies. */
+function matchBeginCallAnyReceiver(call: ts.CallExpression): { receiverName: string; text: string } | null {
+  const callee = call.expression
+  if (!ts.isPropertyAccessExpression(callee)) return null
+  if (callee.name.text !== 'query') return null
+  if (!ts.isIdentifier(callee.expression)) return null
+  const arg0 = call.arguments[0]
+  if (!arg0 || !ts.isStringLiteralLike(arg0)) return null
+  if (!BEGIN_STATEMENT_PATTERN.test(arg0.text)) return null
+  return { receiverName: callee.expression.text, text: arg0.text }
+}
+
+/**
+ * Every `BEGIN`/`START TRANSACTION` `.query(...)` call inside ANY exported function's own scope
+ * (same closure-boundary pruning as the classifier — see `collectOwnScopeCalls`), with NO type
+ * gate on the receiver. Independent of `connectionParams`/`matchBeginCall` entirely: it re-derives
+ * "every exported function" itself rather than reusing a shared helper's OUTPUT, so a bug in
+ * `exportedFunctionDeclarations` cannot silently agree with itself on both sides of the
+ * comparison the guard test makes.
+ */
+export function independentDiscoverBeginCallSitesV1(source: ts.SourceFile): IndependentBeginCallSiteV1[] {
+  const out: IndependentBeginCallSiteV1[] = []
+  for (const stmt of source.statements) {
+    if (!ts.isFunctionDeclaration(stmt) || !stmt.name || !stmt.body || !hasExportModifier(stmt)) continue
+    const fn = stmt
+    const fnName = fn.name!.text
+    const calls = collectOwnScopeCalls(fn, (c) => matchBeginCallAnyReceiver(c) !== null)
+    for (const { node } of calls) {
+      const match = matchBeginCallAnyReceiver(node)!
+      out.push({ enclosingFunction: fnName, receiverName: match.receiverName, statementText: match.text })
+    }
+  }
+  return out
+}

--- a/packages/core-backend/tests/integration/attendance-gate-e-txn-ownership-batch1.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-gate-e-txn-ownership-batch1.db.test.ts
@@ -68,6 +68,39 @@ function wrap(client: Client): AttendanceW4TransactionClientV1 {
   }
 }
 
+/**
+ * §D4 state 4's "cleanup FAILURE" leg (distinct from the plain "cleanup happened" leg below):
+ * intercepts `assertConnectionIsIdleV1`'s own two teardown statements
+ * (`ROLLBACK TO SAVEPOINT w4c5_idle_probe` / `RELEASE SAVEPOINT w4c5_idle_probe`,
+ * w4c0-identity.ts ~L1393-1394) and REJECTS them WITHOUT ever sending them to the real
+ * connection — simulating a transient failure (dropped connection, statement timeout) on
+ * exactly those two statements, never on anything else (the probe's own `SAVEPOINT`, or any
+ * application query). Production wraps both teardown statements in `.catch(() => undefined)`,
+ * so the injected failure must be fully absorbed: the caller must still see the product code
+ * `W4C0_CONNECTION_NOT_IDLE`, never the injected error and never a raw SQLSTATE. Because the
+ * wrapper prevents the REAL teardown from ever running, the `w4c5_idle_probe` savepoint is
+ * still genuinely DEFINED on the connection afterward — the test proves the injection was
+ * real (not vacuous) by having the caller's own `RELEASE SAVEPOINT` SUCCEED at that point
+ * (contrast with the "cleanup happened" test, where the same statement FAILS 3B001) — and only
+ * THEN rolls back, which is what actually removes the leftover savepoint (`ROLLBACK` ends the
+ * whole transaction block, taking every savepoint defined within it, regardless of whether it
+ * was ever explicitly released).
+ */
+function wrapWithTeardownFailure(client: Client): AttendanceW4TransactionClientV1 {
+  return {
+    query: async (sqlText: string, params?: unknown[]) => {
+      if (
+        sqlText === 'ROLLBACK TO SAVEPOINT w4c5_idle_probe' ||
+        sqlText === 'RELEASE SAVEPOINT w4c5_idle_probe'
+      ) {
+        throw new Error('injected teardown failure (synthetic, never sent to the real connection)')
+      }
+      const result = await client.query(sqlText, params)
+      return { rows: (result.rows ?? []) as Array<Record<string, unknown>> }
+    },
+  }
+}
+
 describeDb('Gate E (#4844) batch 1 — transaction-ownership idle precondition (real DB, four-state)', () => {
   let pool: Pool
 
@@ -179,7 +212,7 @@ describeDb('Gate E (#4844) batch 1 — transaction-ownership idle precondition (
       }
     })
 
-    it('4. cleanup: on refusal the idle probe has already RELEASEd its own savepoint — a caller RELEASE afterward fails 3B001, and the connection is fully usable once the caller rolls back', async () => {
+    it('4a. cleanup succeeded: on refusal the idle probe has already RELEASEd its own savepoint — a caller RELEASE afterward fails 3B001, and the connection is fully usable once the caller rolls back', async () => {
       const client = await openClient()
       try {
         await client.query('BEGIN')
@@ -197,6 +230,29 @@ describeDb('Gate E (#4844) batch 1 — transaction-ownership idle precondition (
         // connection silently answering something else.
         await expect(client.query('SELECT 1')).rejects.toMatchObject({ code: '25P02' })
         await client.query('ROLLBACK')
+        await expect(client.query('SELECT 1 AS ok')).resolves.toMatchObject({ rows: [{ ok: 1 }] })
+      } finally {
+        await client.query('ROLLBACK').catch(() => undefined)
+        await client.end()
+      }
+    })
+
+    it("4b. cleanup FAILED (the probe's own teardown rejects): the caller still sees the product code, never the injected error or a raw SQLSTATE; the leftover savepoint (proven still defined, since teardown never ran) is removed once the caller rolls back its own txn, and the connection is usable again", async () => {
+      const client = await openClient()
+      try {
+        await client.query('BEGIN')
+        await client.query('SELECT 1')
+        await expect(
+          runAttendanceResultOperationTransactionV1(wrapWithTeardownFailure(client), async () => 'should-not-run'),
+        ).rejects.toMatchObject({ code: 'W4C0_CONNECTION_NOT_IDLE' }) // never the injected error
+        // Proves the injection was real, not vacuous: because `wrapWithTeardownFailure` prevented
+        // the REAL `ROLLBACK TO SAVEPOINT` / `RELEASE SAVEPOINT` from ever reaching PostgreSQL,
+        // `w4c5_idle_probe` is STILL genuinely defined — a caller-issued RELEASE now SUCCEEDS
+        // (the opposite of 4a's 3B001, where cleanup had genuinely already removed it).
+        await expect(client.query('RELEASE SAVEPOINT w4c5_idle_probe')).resolves.toBeDefined()
+        await client.query('ROLLBACK')
+        // `ROLLBACK` ends the whole transaction block, taking the leftover savepoint with it
+        // regardless of whether it was ever explicitly released — the connection is fully usable.
         await expect(client.query('SELECT 1 AS ok')).resolves.toMatchObject({ rows: [{ ok: 1 }] })
       } finally {
         await client.query('ROLLBACK').catch(() => undefined)
@@ -269,7 +325,7 @@ describeDb('Gate E (#4844) batch 1 — transaction-ownership idle precondition (
       }
     })
 
-    it('4. cleanup: on refusal the idle probe has already RELEASEd its own savepoint — a caller RELEASE afterward fails 3B001, and the connection is fully usable once the caller rolls back', async () => {
+    it('4a. cleanup succeeded: on refusal the idle probe has already RELEASEd its own savepoint — a caller RELEASE afterward fails 3B001, and the connection is fully usable once the caller rolls back', async () => {
       const client = await openClient()
       try {
         await client.query('BEGIN')
@@ -281,6 +337,25 @@ describeDb('Gate E (#4844) batch 1 — transaction-ownership idle precondition (
           code: '3B001',
         })
         await expect(client.query('SELECT 1')).rejects.toMatchObject({ code: '25P02' })
+        await client.query('ROLLBACK')
+        await expect(client.query('SELECT 1 AS ok')).resolves.toMatchObject({ rows: [{ ok: 1 }] })
+      } finally {
+        await client.query('ROLLBACK').catch(() => undefined)
+        await client.end()
+      }
+    })
+
+    it("4b. cleanup FAILED (the probe's own teardown rejects): the caller still sees the product code, never the injected error or a raw SQLSTATE; the leftover savepoint (proven still defined, since teardown never ran) is removed once the caller rolls back its own txn, and the connection is usable again", async () => {
+      const client = await openClient()
+      try {
+        await client.query('BEGIN')
+        await client.query('SELECT 1')
+        await expect(
+          dispatchAttendanceResultEventOutboxV1(wrapWithTeardownFailure(client), { emit: vi.fn() }),
+        ).rejects.toMatchObject({ code: 'W4C0_CONNECTION_NOT_IDLE' }) // never the injected error
+        // Proves the injection was real: the leftover savepoint is still genuinely defined, so a
+        // caller-issued RELEASE now SUCCEEDS (the opposite of 4a's 3B001).
+        await expect(client.query('RELEASE SAVEPOINT w4c5_idle_probe')).resolves.toBeDefined()
         await client.query('ROLLBACK')
         await expect(client.query('SELECT 1 AS ok')).resolves.toMatchObject({ rows: [{ ok: 1 }] })
       } finally {

--- a/packages/core-backend/tests/integration/attendance-gate-e-txn-ownership-batch1.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-gate-e-txn-ownership-batch1.db.test.ts
@@ -1,0 +1,292 @@
+/**
+ * Gate E (#4844) first batch — real-PostgreSQL four-state acceptance for the two converted
+ * category-1 sites (a multi-statement boundary that `BEGIN`s on a CALLER-supplied connection
+ * with no idle proof — on a dirty connection PostgreSQL only WARNs on the nested `BEGIN`, then
+ * the function's own `COMMIT`/`ROLLBACK` acts on the CALLER's transaction):
+ *
+ *  1. `runAttendanceResultOperationTransactionV1` (w4c0-operation-registry.ts) —
+ *     `BEGIN ISOLATION LEVEL SERIALIZABLE` then `COMMIT`, inside a bounded retry loop. On a dirty
+ *     caller connection the `COMMIT` durably publishes the caller's uncommitted writes.
+ *  2. `dispatchAttendanceResultEventOutboxV1` (w4c2-outbox-dispatcher.ts) — bare `BEGIN` then
+ *     `COMMIT`, same class, no isolation pin.
+ *
+ * Both now call the EXISTING exported `assertConnectionIsIdleV1` (w4c0-identity.ts) before their
+ * first `BEGIN` — no new probe was written. Four states per site, per the design lock (§D4):
+ *   1. an open, READ-ONLY caller txn -> refused `W4C0_CONNECTION_NOT_IDLE`; the caller's txn is
+ *      still open and usable afterward (neither committed nor rolled back by the callee).
+ *   2. an open txn with UNCOMMITTED writes -> refused; the caller's row stays invisible to a
+ *      SECOND connection while refused, visible only IN-TXN to the caller, and gone once the
+ *      caller rolls back — the DISCRIMINATING case: pre-fix, the wrapped function's own `COMMIT`
+ *      would durably publish that row regardless of what the caller intended.
+ *   3. an idle connection -> POSITIVE CONTROL: the function succeeds and does its real work
+ *      (without this, "it refuses" cannot be told apart from "it's broken").
+ *   4. cleanup -- the idle probe's own `SAVEPOINT w4c5_idle_probe` is fully RELEASEd on refusal,
+ *      not merely rolled back to (mirrors the P2-C proof in
+ *      attendance-w4c5-rollout-transition-tool.db.test.ts): a caller-issued
+ *      `RELEASE SAVEPOINT w4c5_idle_probe` afterward must fail 3B001 (does not exist), and the
+ *      connection is otherwise fully usable once the caller rolls back its own txn.
+ *
+ * Wiring: same shared `metasheet_test` DB as the sibling
+ * `attendance-w4c2-outbox-dispatcher.db.test.ts` (migrations already applied by the workflow's
+ * `db:migrate` step; `attendance_result_operations` / `attendance_result_event_outbox` exist).
+ * Additionally self-provisions ONE small, run-namespaced scratch table for the write-visibility
+ * probe, since `runAttendanceResultOperationTransactionV1` is schema-agnostic (any `body`
+ * callback) and the discriminating property (does this function's `COMMIT` durably publish an
+ * uncommitted caller write) does not depend on any attendance-specific table.
+ *
+ * DATABASE_URL-gated (`describeDb`); excluded in `vitest.config.ts` and wired whole-file into the
+ * attendance real-DB step in `plugin-tests.yml` (two-point wiring — see both files' comments at
+ * this test's own entry).
+ */
+import { randomUUID } from 'crypto'
+import { Client, Pool } from 'pg'
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
+import { runAttendanceResultOperationTransactionV1 } from '../../src/attendance/w4c0-operation-registry'
+import {
+  dispatchAttendanceResultEventOutboxV1,
+  type AttendanceOutboxDeliveryV1,
+} from '../../src/attendance/w4c2-outbox-dispatcher'
+import type { AttendanceW4TransactionClientV1 } from '../../src/attendance/w4c0-identity'
+
+const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
+const describeDb = dbUrl ? describe : describe.skip
+
+// File-level fixture-ID namespace (per this repo's shared-DB discipline): every identifier below
+// is derived from this ONE run tag, unique to this file's process invocation, so concurrently
+// running sibling `.db.test.ts` files against the same shared DB cannot collide with it.
+const RUN = `gateE1b1_${Date.now().toString(36)}${Math.floor(Math.random() * 1e6).toString(36)}`
+const PROBE_TABLE = `gate_e_batch1_probe_${RUN}`
+const ORG = `${RUN}_org`
+const FP = 'e'.repeat(64)
+
+function wrap(client: Client): AttendanceW4TransactionClientV1 {
+  return {
+    query: async (sqlText: string, params?: unknown[]) => {
+      const result = await client.query(sqlText, params)
+      return { rows: (result.rows ?? []) as Array<Record<string, unknown>> }
+    },
+  }
+}
+
+describeDb('Gate E (#4844) batch 1 — transaction-ownership idle precondition (real DB, four-state)', () => {
+  let pool: Pool
+
+  const openClient = async (): Promise<Client> => {
+    const client = new Client({ connectionString: dbUrl })
+    await client.connect()
+    return client
+  }
+
+  const probeRowCount = async (id: string): Promise<number> =>
+    Number(
+      (await pool.query(`SELECT count(*)::int AS n FROM ${PROBE_TABLE} WHERE id = $1`, [id])).rows[0].n,
+    )
+
+  const seedPendingOutboxRow = async (eventKind: string, payload: Record<string, unknown>): Promise<string> => {
+    const id = randomUUID()
+    const operationId = randomUUID()
+    // Same FK shape as the sibling `attendance-w4c2-outbox-dispatcher.db.test.ts`'s
+    // `seedPending`: W4C-2 amendment section 1.4's `fk_areo_operation` requires a real
+    // (org_id, entrypoint, operation_id) row before any outbox row can reference it.
+    await pool.query(
+      `INSERT INTO attendance_result_operations (
+          org_id, entrypoint, operation_id, identity_source_kind, source_ref, actor_id, actor_posture,
+          capability, subject_scope, command_fingerprint, accepted_write_posture, state, response_snapshot
+        ) VALUES ($1,'live_punch',$2,'direct_live_punch','ref:gate-e-batch1',$3,'self','punch','{}'::jsonb,$4,'shadow','completed','{}'::jsonb)`,
+      [ORG, operationId, `actor-${RUN}`, FP],
+    )
+    await pool.query(
+      `INSERT INTO attendance_result_event_outbox
+         (id, org_id, entrypoint, operation_id, identity_kind, event_kind, payload, payload_schema_version, business_key_fingerprint, delivery_state)
+       VALUES ($1, $2, 'live_punch', $3, 'operation', $4, $5::jsonb, 1, $6, 'pending')`,
+      [id, ORG, operationId, eventKind, JSON.stringify(payload), FP],
+    )
+    return id
+  }
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: dbUrl })
+    await pool.query(
+      `CREATE TABLE IF NOT EXISTS ${PROBE_TABLE} (id uuid PRIMARY KEY, tag text NOT NULL)`,
+    )
+  })
+
+  afterAll(async () => {
+    await pool.query(`DROP TABLE IF EXISTS ${PROBE_TABLE}`).catch(() => undefined)
+    await pool?.end().catch(() => undefined)
+  })
+
+  describe('site 1: runAttendanceResultOperationTransactionV1 (w4c0-operation-registry.ts)', () => {
+    it('1. refuses on an open READ-ONLY caller txn; the caller txn stays open and intact (can still SELECT and COMMIT its own txn)', async () => {
+      const client = await openClient()
+      const body = vi.fn(async () => 'should-not-run')
+      try {
+        await client.query('BEGIN')
+        await client.query('SELECT 1')
+        await expect(runAttendanceResultOperationTransactionV1(wrap(client), body)).rejects.toMatchObject({
+          code: 'W4C0_CONNECTION_NOT_IDLE',
+        })
+        expect(body).not.toHaveBeenCalled()
+        await expect(client.query('SELECT 1 AS still_alive')).resolves.toMatchObject({
+          rows: [{ still_alive: 1 }],
+        })
+        await expect(client.query('COMMIT')).resolves.toBeDefined()
+      } finally {
+        await client.query('ROLLBACK').catch(() => undefined)
+        await client.end()
+      }
+    })
+
+    it("2. refuses on an open txn with UNCOMMITTED writes — the caller's row stays invisible to a SECOND connection while refused, visible only IN-TXN to the caller, and gone once the caller rolls back (the DISCRIMINATING case: pre-fix, this function's own COMMIT would durably publish it)", async () => {
+      const client = await openClient()
+      const rowId = randomUUID()
+      const body = vi.fn(async () => 'should-not-run')
+      try {
+        await client.query('BEGIN')
+        await client.query(`INSERT INTO ${PROBE_TABLE} (id, tag) VALUES ($1, $2)`, [rowId, 'site1-uncommitted'])
+        await expect(runAttendanceResultOperationTransactionV1(wrap(client), body)).rejects.toMatchObject({
+          code: 'W4C0_CONNECTION_NOT_IDLE',
+        })
+        expect(body).not.toHaveBeenCalled()
+        // A SECOND connection must not see the row — it is still uncommitted.
+        expect(await probeRowCount(rowId)).toBe(0)
+        // The caller's OWN connection, still inside its own open txn, still sees it.
+        await expect(
+          client.query(`SELECT count(*)::int AS n FROM ${PROBE_TABLE} WHERE id = $1`, [rowId]),
+        ).resolves.toMatchObject({ rows: [{ n: 1 }] })
+        await client.query('ROLLBACK')
+        // After the caller rolls back its own txn, the row is gone everywhere.
+        expect(await probeRowCount(rowId)).toBe(0)
+      } finally {
+        await client.query('ROLLBACK').catch(() => undefined)
+        await client.end()
+      }
+    })
+
+    it("3. positive control: an idle connection succeeds and COMMITs the body's real work", async () => {
+      const client = await openClient()
+      const rowId = randomUUID()
+      try {
+        const result = await runAttendanceResultOperationTransactionV1(wrap(client), async (trx) => {
+          await trx.query(`INSERT INTO ${PROBE_TABLE} (id, tag) VALUES ($1, $2)`, [rowId, 'site1-idle-control'])
+          return 'ok'
+        })
+        expect(result).toBe('ok')
+        // Committed — visible from a second connection.
+        expect(await probeRowCount(rowId)).toBe(1)
+      } finally {
+        await client.end()
+      }
+    })
+
+    it('4. cleanup: on refusal the idle probe has already RELEASEd its own savepoint — a caller RELEASE afterward fails 3B001, and the connection is fully usable once the caller rolls back', async () => {
+      const client = await openClient()
+      try {
+        await client.query('BEGIN')
+        await client.query('SELECT 1')
+        await expect(
+          runAttendanceResultOperationTransactionV1(wrap(client), async () => 'should-not-run'),
+        ).rejects.toMatchObject({ code: 'W4C0_CONNECTION_NOT_IDLE' })
+        // The guard already RELEASEd `w4c5_idle_probe` — a second RELEASE must fail with 3B001
+        // (invalid_savepoint_specification), proving cleanup rather than merely documenting it.
+        await expect(client.query('RELEASE SAVEPOINT w4c5_idle_probe')).rejects.toMatchObject({
+          code: '3B001',
+        })
+        // That failed RELEASE poisons the rest of the (still-open) transaction until ROLLBACK —
+        // confirming this was a genuine SQL-level 3B001 on THIS connection, not a dropped/reset
+        // connection silently answering something else.
+        await expect(client.query('SELECT 1')).rejects.toMatchObject({ code: '25P02' })
+        await client.query('ROLLBACK')
+        await expect(client.query('SELECT 1 AS ok')).resolves.toMatchObject({ rows: [{ ok: 1 }] })
+      } finally {
+        await client.query('ROLLBACK').catch(() => undefined)
+        await client.end()
+      }
+    })
+  })
+
+  describe('site 2: dispatchAttendanceResultEventOutboxV1 (w4c2-outbox-dispatcher.ts)', () => {
+    it('1. refuses on an open READ-ONLY caller txn; the caller txn stays open and intact (can still SELECT and COMMIT its own txn)', async () => {
+      const client = await openClient()
+      const emit = vi.fn()
+      try {
+        await client.query('BEGIN')
+        await client.query('SELECT 1')
+        await expect(dispatchAttendanceResultEventOutboxV1(wrap(client), { emit })).rejects.toMatchObject({
+          code: 'W4C0_CONNECTION_NOT_IDLE',
+        })
+        expect(emit).not.toHaveBeenCalled()
+        await expect(client.query('SELECT 1 AS still_alive')).resolves.toMatchObject({
+          rows: [{ still_alive: 1 }],
+        })
+        await expect(client.query('COMMIT')).resolves.toBeDefined()
+      } finally {
+        await client.query('ROLLBACK').catch(() => undefined)
+        await client.end()
+      }
+    })
+
+    it("2. refuses on an open txn with UNCOMMITTED writes — the caller's row stays invisible to a SECOND connection while refused, visible only IN-TXN to the caller, and gone once the caller rolls back (the DISCRIMINATING case: pre-fix, this function's own COMMIT would durably publish it)", async () => {
+      const client = await openClient()
+      const rowId = randomUUID()
+      const emit = vi.fn()
+      try {
+        await client.query('BEGIN')
+        await client.query(`INSERT INTO ${PROBE_TABLE} (id, tag) VALUES ($1, $2)`, [rowId, 'site2-uncommitted'])
+        await expect(dispatchAttendanceResultEventOutboxV1(wrap(client), { emit })).rejects.toMatchObject({
+          code: 'W4C0_CONNECTION_NOT_IDLE',
+        })
+        expect(emit).not.toHaveBeenCalled()
+        expect(await probeRowCount(rowId)).toBe(0)
+        await expect(
+          client.query(`SELECT count(*)::int AS n FROM ${PROBE_TABLE} WHERE id = $1`, [rowId]),
+        ).resolves.toMatchObject({ rows: [{ n: 1 }] })
+        await client.query('ROLLBACK')
+        expect(await probeRowCount(rowId)).toBe(0)
+      } finally {
+        await client.query('ROLLBACK').catch(() => undefined)
+        await client.end()
+      }
+    })
+
+    it('3. positive control: an idle connection dispatches a real pending row', async () => {
+      const id = await seedPendingOutboxRow('attendance.punched', { probe: 'gate-e-batch1-idle', run: RUN })
+      const client = await openClient()
+      const emitted: AttendanceOutboxDeliveryV1[] = []
+      try {
+        const result = await dispatchAttendanceResultEventOutboxV1(wrap(client), {
+          emit: (delivery) => {
+            emitted.push(delivery)
+          },
+        })
+        expect(result.delivered).toBeGreaterThanOrEqual(1)
+        expect(emitted.some((e) => (e.payload as { run?: string })?.run === RUN)).toBe(true)
+        await expect(
+          pool.query('SELECT delivery_state FROM attendance_result_event_outbox WHERE id = $1', [id]),
+        ).resolves.toMatchObject({ rows: [{ delivery_state: 'delivered' }] })
+      } finally {
+        await client.end()
+      }
+    })
+
+    it('4. cleanup: on refusal the idle probe has already RELEASEd its own savepoint — a caller RELEASE afterward fails 3B001, and the connection is fully usable once the caller rolls back', async () => {
+      const client = await openClient()
+      try {
+        await client.query('BEGIN')
+        await client.query('SELECT 1')
+        await expect(
+          dispatchAttendanceResultEventOutboxV1(wrap(client), { emit: vi.fn() }),
+        ).rejects.toMatchObject({ code: 'W4C0_CONNECTION_NOT_IDLE' })
+        await expect(client.query('RELEASE SAVEPOINT w4c5_idle_probe')).rejects.toMatchObject({
+          code: '3B001',
+        })
+        await expect(client.query('SELECT 1')).rejects.toMatchObject({ code: '25P02' })
+        await client.query('ROLLBACK')
+        await expect(client.query('SELECT 1 AS ok')).resolves.toMatchObject({ rows: [{ ok: 1 }] })
+      } finally {
+        await client.query('ROLLBACK').catch(() => undefined)
+        await client.end()
+      }
+    })
+  })
+})

--- a/packages/core-backend/tests/unit/attendance-gate-e-txn-ownership-walk.test.ts
+++ b/packages/core-backend/tests/unit/attendance-gate-e-txn-ownership-walk.test.ts
@@ -1,0 +1,260 @@
+/**
+ * Gate E (#4844) first batch — the class-closing anti-regression guard.
+ *
+ * #4844's own scope statement, verbatim: "Enumerating known offenders converges no better here
+ * than it did the last two times — the guard has to walk the exported table." This file IS that
+ * walk: it parses every `.ts` file directly under `packages/core-backend/src/attendance/`,
+ * classifies every `BEGIN`/`START TRANSACTION` issued on a CALLER-supplied
+ * `AttendanceW4TransactionClientV1` parameter (`../helpers/attendance-txn-ownership-walk.ts`),
+ * and asserts the `UNKNOWN` bucket is EMPTY. A future new BEGIN-on-caller-connection site with no
+ * dominating `assertConnectionIsIdleV1` proof — and not explicitly reviewed onto the
+ * JOINS/NESTED allowlist — lands in UNKNOWN and reds this file, not by enumerating it here by
+ * name.
+ *
+ * DB-free: pure static AST analysis, no PostgreSQL required. Modelled on the F1 assembly guard
+ * (`tests/helpers/attendance-w6-index-assembly-order.ts` +
+ * `tests/unit/attendance-w6-group-effective-policy-authorization.test.ts`) — same ts-compiler
+ * walk idiom, same non-vacuity discipline (assert the walk actually found something, not just
+ * that it found nothing bad), same synthetic-fixture mutation probe (never mutates files on
+ * disk — the "delete the proof, watch UNKNOWN turn non-empty" claim is proven via an in-memory
+ * string-mutated copy of the REAL source text, per Gate E design lock §D3).
+ */
+import { readdirSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import * as ts from 'typescript'
+import { describe, expect, it } from 'vitest'
+import {
+  discoverBeginSitesV1,
+  TXN_OWNERSHIP_ALLOWLIST_V1,
+  type BeginSiteV1,
+} from '../helpers/attendance-txn-ownership-walk'
+
+const ATTENDANCE_SRC_DIR = join(__dirname, '..', '..', 'src', 'attendance')
+
+/** Non-recursive `*.ts` glob — matches the design lock's own scope statement ("the whole exported
+ *  surface of `packages/core-backend/src/attendance/*.ts`"), deliberately excluding the sibling
+ *  `__tests__/` subdirectory (test fixtures, not production exported surface). */
+function loadAttendanceFileNames(): string[] {
+  return readdirSync(ATTENDANCE_SRC_DIR, { withFileTypes: true })
+    .filter((entry) => entry.isFile() && entry.name.endsWith('.ts'))
+    .map((entry) => entry.name)
+    .sort()
+}
+
+function discoverAllBeginSites(): BeginSiteV1[] {
+  const out: BeginSiteV1[] = []
+  for (const file of loadAttendanceFileNames()) {
+    const path = join(ATTENDANCE_SRC_DIR, file)
+    const text = readFileSync(path, 'utf8')
+    const source = ts.createSourceFile(path, text, ts.ScriptTarget.ES2022, true)
+    out.push(...discoverBeginSitesV1(source, file))
+  }
+  return out
+}
+
+describe('Gate E (#4844) transaction-ownership guard — walk the exported table (DB-free, static AST)', () => {
+  describe('real packages/core-backend/src/attendance/*.ts', () => {
+    const fileNames = loadAttendanceFileNames()
+    const sites = discoverAllBeginSites()
+
+    it('non-vacuity: the directory scan itself is not empty (guards against a silently broken glob reading zero files and vacuously passing every assertion below)', () => {
+      // 51 files as of this batch; a loose lower bound so an unrelated future file addition does
+      // not itself red this line — the point is "not zero / not a handful", not an exact census.
+      expect(fileNames.length).toBeGreaterThan(40)
+      expect(fileNames).toContain('w4c0-operation-registry.ts')
+      expect(fileNames).toContain('w4c2-outbox-dispatcher.ts')
+    })
+
+    it('non-vacuity: the walk actually DISCOVERS the two converted category-1 sites, named — an AST walk that silently matches nothing must fail here first, before the UNKNOWN-empty assertion below could otherwise pass vacuously', () => {
+      const names = sites.map((s) => `${s.file}::${s.enclosingFunction}`)
+      expect(names).toEqual(
+        expect.arrayContaining([
+          'w4c0-operation-registry.ts::runAttendanceResultOperationTransactionV1',
+          'w4c2-outbox-dispatcher.ts::dispatchAttendanceResultEventOutboxV1',
+        ]),
+      )
+      expect(sites.length).toBeGreaterThanOrEqual(2)
+    })
+
+    it('the allowlist is EMPTY for this batch — a full sweep of the exported surface found zero legitimate JOINS/NESTED sites, so every discovered BEGIN site here must be OWNS', () => {
+      expect(TXN_OWNERSHIP_ALLOWLIST_V1).toEqual([])
+    })
+
+    it('UNKNOWN is EMPTY across the WHOLE exported surface — every BEGIN-on-caller-connection site is provably OWNS (or reviewed-allowlisted JOINS/NESTED, none of which exist today)', () => {
+      const unknown = sites.filter((s) => s.bucket === 'UNKNOWN')
+      expect(unknown).toEqual([])
+    })
+
+    it('exact named OWNS census: the two converted sites plus the pre-existing correctly-guarded sibling (`planAttendanceCalculationRolloutTransitionV1`, W4C-5 NEW-B) — a NEW BEGIN-on-caller-connection site anywhere in the exported surface changes this exact list and demands review, not a silent pass', () => {
+      expect(sites.map((s) => `${s.file}::${s.enclosingFunction}`).sort()).toEqual([
+        'w4c0-operation-registry.ts::runAttendanceResultOperationTransactionV1',
+        'w4c2-outbox-dispatcher.ts::dispatchAttendanceResultEventOutboxV1',
+        'w4c3a-rollout-control.ts::planAttendanceCalculationRolloutTransitionV1',
+      ])
+      for (const s of sites) {
+        expect(s.bucket).toBe('OWNS')
+        expect(s.reason).toBeUndefined()
+      }
+    })
+
+    it('every site key is enclosing-symbol + ancestor-KIND path (no line/column) and unique — the F1 context-key rule', () => {
+      const keys = sites.map((s) => s.key)
+      expect(new Set(keys).size).toBe(keys.length)
+      for (const key of keys) {
+        expect(key).not.toMatch(/:\d+:\d+/) // not a "line:col"-shaped fragment
+        expect(key.split('//').length).toBeGreaterThanOrEqual(3) // fn // ancestor-path // BEGIN // #n
+      }
+    })
+  })
+
+  describe('mutation probe (synthetic in-memory fixture, per design-lock §D3 — never mutates a file on disk): deleting the idle-proof call moves a converted site from OWNS to UNKNOWN', () => {
+    const probes: ReadonlyArray<{ file: string; enclosingFunction: string }> = [
+      { file: 'w4c0-operation-registry.ts', enclosingFunction: 'runAttendanceResultOperationTransactionV1' },
+      { file: 'w4c2-outbox-dispatcher.ts', enclosingFunction: 'dispatchAttendanceResultEventOutboxV1' },
+    ]
+
+    for (const { file, enclosingFunction } of probes) {
+      it(`${file}::${enclosingFunction}: removing "assertConnectionIsIdleV1(connection)" reds UNKNOWN for exactly this site, on a real-source-text-derived synthetic fixture`, () => {
+        const path = join(ATTENDANCE_SRC_DIR, file)
+        const text = readFileSync(path, 'utf8')
+        const needle = 'assertConnectionIsIdleV1(connection)'
+        // Guard against a silent no-op mutation if the real source's exact shape drifts —
+        // exactly one occurrence expected (the call itself; nothing else in either file
+        // mentions this literal substring).
+        expect(text.split(needle).length - 1).toBe(1)
+
+        // Replace the CALLEE, not the whole statement — keeps the mutated text syntactically
+        // valid (still `await <expr>(connection)`) while making the idle-proof predicate
+        // (which keys on the callee identifier `assertConnectionIsIdleV1`) stop matching. This
+        // is the AST-level equivalent of "the proof call is gone" without needing to reconstruct
+        // valid surrounding statement punctuation by hand.
+        const mutated = text.replace(needle, 'Promise.resolve(connection)')
+        expect(mutated).not.toEqual(text)
+        // The CALL is gone; the import declaration naming the same identifier legitimately
+        // remains (an unused import is not this guard's concern — the classifier keys on the
+        // CALLEE of a CallExpression, never on raw text containing the identifier).
+        expect(mutated.split(needle).length - 1).toBe(0)
+
+        const mutatedSource = ts.createSourceFile(path, mutated, ts.ScriptTarget.ES2022, true)
+        const mutatedSites = discoverBeginSitesV1(mutatedSource, file)
+        const target = mutatedSites.find((s) => s.enclosingFunction === enclosingFunction)
+
+        expect(target).toBeDefined()
+        expect(target!.bucket).toBe('UNKNOWN')
+        expect(target!.reason).toBeUndefined()
+
+        // Non-vacuity within the probe itself: the ORIGINAL (unmutated) source must classify
+        // this exact site as OWNS — otherwise "moves to UNKNOWN" would be trivially true of a
+        // site that was never OWNS in the first place.
+        const originalSource = ts.createSourceFile(path, text, ts.ScriptTarget.ES2022, true)
+        const originalSite = discoverBeginSitesV1(originalSource, file).find(
+          (s) => s.enclosingFunction === enclosingFunction,
+        )
+        expect(originalSite?.bucket).toBe('OWNS')
+      })
+    }
+  })
+
+  describe('classifier state-space coverage (inline synthetic fixtures — never index.ts / never src/attendance, so these are independent of the live tree)', () => {
+    const CONN_TYPE_DECL = 'interface AttendanceW4TransactionClientV1 { query(sqlText: string, params?: unknown[]): Promise<{ rows: unknown[] }> }\n'
+
+    const classify = (body: string, fnName = 'fixtureFn'): BeginSiteV1[] => {
+      const src = `${CONN_TYPE_DECL}export async function ${fnName}(connection: AttendanceW4TransactionClientV1): Promise<void> {\n${body}\n}\n`
+      const source = ts.createSourceFile('fixture.ts', src, ts.ScriptTarget.ES2022, true)
+      return discoverBeginSitesV1(source, 'fixture.ts', [])
+    }
+
+    it('OWNS: idle proof as a bare unconditional statement immediately before BEGIN', () => {
+      const sites = classify(
+        `  await assertConnectionIsIdleV1(connection)\n  await connection.query('BEGIN', [])\n`,
+      )
+      expect(sites).toHaveLength(1)
+      expect(sites[0].bucket).toBe('OWNS')
+    })
+
+    it('OWNS: idle proof before a loop that itself contains the BEGIN (the retry-loop shape, site 1)', () => {
+      const sites = classify(
+        `  await assertConnectionIsIdleV1(connection)\n  for (;;) {\n    try {\n      await connection.query('BEGIN ISOLATION LEVEL SERIALIZABLE', [])\n      break\n    } catch (e) {\n      break\n    }\n  }\n`,
+      )
+      expect(sites).toHaveLength(1)
+      expect(sites[0].bucket).toBe('OWNS')
+    })
+
+    it('UNKNOWN: no idle proof call anywhere', () => {
+      const sites = classify(`  await connection.query('BEGIN', [])\n`)
+      expect(sites).toHaveLength(1)
+      expect(sites[0].bucket).toBe('UNKNOWN')
+    })
+
+    it('UNKNOWN: idle proof present but nested inside an `if` — not an unconditional top-level statement, so it does not dominate', () => {
+      const sites = classify(
+        `  if (Math.random() > 0) {\n    await assertConnectionIsIdleV1(connection)\n  }\n  await connection.query('BEGIN', [])\n`,
+      )
+      expect(sites).toHaveLength(1)
+      expect(sites[0].bucket).toBe('UNKNOWN')
+    })
+
+    it('UNKNOWN: idle proof present but AFTER the BEGIN (wrong order)', () => {
+      const sites = classify(
+        `  await connection.query('BEGIN', [])\n  await assertConnectionIsIdleV1(connection)\n`,
+      )
+      expect(sites).toHaveLength(1)
+      expect(sites[0].bucket).toBe('UNKNOWN')
+    })
+
+    it('UNKNOWN: idle proof called on a DIFFERENT identifier than the one BEGIN uses (name-based identity, deliberately not symbol-resolved)', () => {
+      const src =
+        `${CONN_TYPE_DECL}export async function fixtureFn(connection: AttendanceW4TransactionClientV1, other: AttendanceW4TransactionClientV1): Promise<void> {\n` +
+        `  await assertConnectionIsIdleV1(other)\n  await connection.query('BEGIN', [])\n}\n`
+      const source = ts.createSourceFile('fixture.ts', src, ts.ScriptTarget.ES2022, true)
+      const sites = discoverBeginSitesV1(source, 'fixture.ts', [])
+      expect(sites).toHaveLength(1)
+      expect(sites[0].bucket).toBe('UNKNOWN')
+    })
+
+    it('invisible, not OWNS: a BEGIN issued inside a NESTED closure (a callback passed to another function) is not attributed to the enclosing exported function at all — zero sites, not a false OWNS/UNKNOWN', () => {
+      const sites = classify(
+        `  await assertConnectionIsIdleV1(connection)\n  await Promise.resolve().then(async () => {\n    await connection.query('BEGIN', [])\n  })\n`,
+      )
+      expect(sites).toEqual([])
+    })
+
+    it('not a BEGIN site at all: SAVEPOINT is out of scope for this batch (category-3, explicitly deferred by the design lock)', () => {
+      const sites = classify(`  await connection.query('SAVEPOINT some_savepoint', [])\n`)
+      expect(sites).toEqual([])
+    })
+
+    it('START TRANSACTION is treated as an alias for BEGIN', () => {
+      const sites = classify(`  await connection.query('START TRANSACTION', [])\n`)
+      expect(sites).toHaveLength(1)
+      expect(sites[0].bucket).toBe('UNKNOWN')
+    })
+
+    it('a non-exported function is not walked at all (the guard\'s domain is the EXPORTED surface only)', () => {
+      const src =
+        `${CONN_TYPE_DECL}async function notExported(connection: AttendanceW4TransactionClientV1): Promise<void> {\n` +
+        `  await connection.query('BEGIN', [])\n}\n`
+      const source = ts.createSourceFile('fixture.ts', src, ts.ScriptTarget.ES2022, true)
+      expect(discoverBeginSitesV1(source, 'fixture.ts', [])).toEqual([])
+    })
+
+    it('JOINS/NESTED: an allowlisted site with a reason is classified accordingly, not OWNS/UNKNOWN', () => {
+      const src = `${CONN_TYPE_DECL}export async function fixtureFn(connection: AttendanceW4TransactionClientV1): Promise<void> {\n  await connection.query('BEGIN', [])\n}\n`
+      const source = ts.createSourceFile('fixture.ts', src, ts.ScriptTarget.ES2022, true)
+      const sites = discoverBeginSitesV1(source, 'fixture.ts', [
+        { file: 'fixture.ts', enclosingFunction: 'fixtureFn', bucket: 'JOINS', reason: 'synthetic fixture, JOINS branch coverage' },
+      ])
+      expect(sites).toHaveLength(1)
+      expect(sites[0].bucket).toBe('JOINS')
+      expect(sites[0].reason).toBe('synthetic fixture, JOINS branch coverage')
+    })
+
+    it('key stability: an unrelated sibling statement inserted earlier in the same function does not change the BEGIN site\'s key', () => {
+      const before = classify(`  await assertConnectionIsIdleV1(connection)\n  await connection.query('BEGIN', [])\n`)
+      const after = classify(
+        `  const unrelated = 1 + 1\n  await assertConnectionIsIdleV1(connection)\n  await connection.query('BEGIN', [])\n`,
+      )
+      expect(after[0].key).toBe(before[0].key)
+    })
+  })
+})

--- a/packages/core-backend/tests/unit/attendance-gate-e-txn-ownership-walk.test.ts
+++ b/packages/core-backend/tests/unit/attendance-gate-e-txn-ownership-walk.test.ts
@@ -25,6 +25,7 @@ import * as ts from 'typescript'
 import { describe, expect, it } from 'vitest'
 import {
   discoverBeginSitesV1,
+  independentDiscoverBeginCallSitesV1,
   TXN_OWNERSHIP_ALLOWLIST_V1,
   type BeginSiteV1,
 } from '../helpers/attendance-txn-ownership-walk'
@@ -104,6 +105,45 @@ describe('Gate E (#4844) transaction-ownership guard — walk the exported table
         expect(key).not.toMatch(/:\d+:\d+/) // not a "line:col"-shaped fragment
         expect(key.split('//').length).toBeGreaterThanOrEqual(3) // fn // ancestor-path // BEGIN // #n
       }
+    })
+
+    it("P2-c backstop: the classifier's site COUNT agrees with an INDEPENDENT, type-agnostic collector — a BEGIN call the classifier's AttendanceW4TransactionClientV1 type-name gate cannot see would otherwise be INVISIBLE (not even UNKNOWN), the exact defect class the F1 guard's independentThisStarts exists to catch", () => {
+      let independentTotal = 0
+      for (const file of fileNames) {
+        const path = join(ATTENDANCE_SRC_DIR, file)
+        const source = ts.createSourceFile(path, readFileSync(path, 'utf8'), ts.ScriptTarget.ES2022, true)
+        independentTotal += independentDiscoverBeginCallSitesV1(source).length
+      }
+      // Reference-independent completeness (P2-c): if this ever drops below `sites.length`, the
+      // classifier is reporting MORE sites than even the broad, type-agnostic walk can find —
+      // impossible unless the classifier double-counts. If it ever RISES above `sites.length`,
+      // some BEGIN call the classifier's type gate did not recognize as a caller-connection
+      // parameter is invisible to the whole rest of this file's UNKNOWN-empty discipline.
+      expect(independentTotal).toBe(sites.length)
+    })
+  })
+
+  describe("P2-c backstop, load-bearing (synthetic fixture): a BEGIN call on a receiver typed something OTHER than AttendanceW4TransactionClientV1 is invisible to the narrow classifier but IS found by the independent collector — proving the count cross-check above is not vacuous", () => {
+    const OTHER_TYPE_DECL = 'interface SomeOtherPoolClient { query(sqlText: string, params?: unknown[]): Promise<{ rows: unknown[] }> }\n'
+
+    it('the classifier finds ZERO sites (the receiver is not AttendanceW4TransactionClientV1-typed) while the independent walker finds ONE — the mismatch this guard is built to catch', () => {
+      const src =
+        `${OTHER_TYPE_DECL}export async function fixtureFnOtherType(connection: SomeOtherPoolClient): Promise<void> {\n` +
+        `  await connection.query('BEGIN', [])\n}\n`
+      const source = ts.createSourceFile('fixture-other-type.ts', src, ts.ScriptTarget.ES2022, true)
+
+      const classified = discoverBeginSitesV1(source, 'fixture-other-type.ts', [])
+      const independent = independentDiscoverBeginCallSitesV1(source)
+
+      expect(classified).toEqual([]) // invisible to the narrow, type-gated classifier
+      expect(independent).toHaveLength(1) // found by the broad, type-agnostic walk
+      expect(independent[0]).toMatchObject({
+        enclosingFunction: 'fixtureFnOtherType',
+        receiverName: 'connection',
+      })
+      // This is exactly the count mismatch (0 !== 1) the real-tree cross-check above asserts
+      // does NOT happen today — if it ever did, that assertion reds.
+      expect(classified.length).not.toBe(independent.length)
     })
   })
 

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -680,6 +680,14 @@ export default defineConfig({
       'tests/integration/attendance-w4c3a-import-rollback.db.test.ts',
       'tests/integration/attendance-w4c3a-rollout-control.db.test.ts',
       'tests/integration/attendance-w4c5-rollout-transition-tool.db.test.ts',
+      // Gate E (#4844) first batch: real-Postgres four-state acceptance (open-read-only-refuse,
+      // open-with-uncommitted-writes discriminating case, idle positive control, savepoint
+      // cleanup) for the two converted category-1 sites
+      // (`runAttendanceResultOperationTransactionV1` / `dispatchAttendanceResultEventOutboxV1`).
+      // DATABASE_URL-gated (describeDb); excluded here so the no-DB job cannot skip-green it;
+      // wired whole-file into the attendance real-DB step in plugin-tests.yml (two-point
+      // wiring).
+      'tests/integration/attendance-gate-e-txn-ownership-batch1.db.test.ts',
       'tests/integration/attendance-w4c3b-request-operation-routes.db.test.ts',
       'tests/integration/attendance-w4c3b-approved-leave-cancellation.db.test.ts',
       // OBS-1 (2026-08-07): the two W4C-3b suites below landed in #4716 with NEITHER wiring

--- a/plugins/plugin-integration-core/lib/sealed-export/vectors/s6a-package-provenance-pins.json
+++ b/plugins/plugin-integration-core/lib/sealed-export/vectors/s6a-package-provenance-pins.json
@@ -86,6 +86,6 @@
     "s6aAcceptancePs51Test": "835c7c6ce943d82e0378a40a27c7fd1e8b79b526faa8ca4c8066e4231a4bfb0f",
     "s6aProductRuntimeTest": "de978adafa8b89772cefa921c2051f434bf346bf5c2978bef3424ee70f51ba3f",
     "multitableOnpremPackageBuild": "ae477a24375a7269e5710a3481905c9b74255c03fd802841a16849aca48ee33a",
-    "pluginTestsWorkflow": "46dbca8e0e62ec561f7de79269a85bd50f500b6475dc0d1fb928ce5fe18ba78e"
+    "pluginTestsWorkflow": "1c07bf3c6cfbaa3ac45160d0ed0a62c5a61ce2f95e60e7e4766aaaf324e2ae1f"
   }
 }

--- a/scripts/ops/attendance-w4c2-ci-wiring.test.mjs
+++ b/scripts/ops/attendance-w4c2-ci-wiring.test.mjs
@@ -2181,6 +2181,7 @@ const EXPECTED_ATTENDANCE_SUITES = Object.freeze([
   'tests/integration/attendance-decision-trace-w5-0.db.test.ts',
   'tests/integration/attendance-expiry-service.test.ts',
   'tests/integration/attendance-files-acl.test.ts',
+  'tests/integration/attendance-gate-e-txn-ownership-batch1.db.test.ts',
   'tests/integration/attendance-group-fixed-schedule-config-consume.db.test.ts',
   'tests/integration/attendance-group-fixed-schedule-config-migration.db.test.ts',
   'tests/integration/attendance-group-fixed-schedule-effectiveness.db.test.ts',


### PR DESCRIPTION
## Summary

First batch (2 of the 2 named category-1 sites) of #4844's transaction-ownership hardening:
multi-statement boundaries that `BEGIN` on a **caller-supplied** connection with no idle proof.
On a dirty caller connection PostgreSQL only WARNs on the nested `BEGIN` (never errors), so the
function's own `COMMIT`/`ROLLBACK` then acts on the **caller's** transaction. Both converted sites
are category-1 (the function owns and commits its own transaction):

1. `runAttendanceResultOperationTransactionV1` (`packages/core-backend/src/attendance/w4c0-operation-registry.ts`)
   — `BEGIN ISOLATION LEVEL SERIALIZABLE` then `COMMIT`, inside a bounded retry loop. On a dirty
   caller connection the `COMMIT` durably publishes the caller's uncommitted writes — strictly
   worse than a wrong snapshot, because this function actually commits.
2. `dispatchAttendanceResultEventOutboxV1` (`packages/core-backend/src/attendance/w4c2-outbox-dispatcher.ts`)
   — bare `BEGIN` then `COMMIT`, same class, no isolation pin.

This is a mechanical implementation of a locked design (build brief derived from #4844's own
scope statement); no design discretion was exercised here.

## What changed

### 1. Reused the existing idle probe — no new probe written
Both sites now call `await assertConnectionIsIdleV1(connection)` (already exported from
`w4c0-identity.ts`, generalized in PR #4839) exactly once, **before** their first `BEGIN`:
- Site 1: before the `for (;;)` retry loop (not inside it — the loop's own `ROLLBACK` already
  restores idle between attempts; the precondition is "idle on entry").
- Site 2: before the bare `BEGIN` (~L104 pre-change).

Production behaviour is byte-neutral for the idle common case (every current caller passes a
fresh pooled connection): the probe's `SAVEPOINT` raises `25P01` and returns immediately.

### 2. Class-closing guard: walk the exported table, not a hand list
#4844 says verbatim: *"Enumerating known offenders converges no better here than it did the last
two times — the guard has to walk the exported table."*

`packages/core-backend/tests/helpers/attendance-txn-ownership-walk.ts` is a DB-free static-AST
walker (TypeScript compiler API, modelled on the existing F1 assembly guard —
`tests/helpers/attendance-w6-index-assembly-order.ts` + its test) that:
- Walks **every exported function** across `packages/core-backend/src/attendance/*.ts` (51 files
  today — non-recursive, matching the design lock's own scope statement).
- Detects every `<connParam>.query('BEGIN'…)` / `START TRANSACTION` issued on a parameter typed
  `AttendanceW4TransactionClientV1` (a caller-supplied connection).
- Partitions each site into `OWNS` (a dominating, unconditional `assertConnectionIsIdleV1` call on
  the same connection identity precedes the `BEGIN`) / `JOINS` / `NESTED` (allowlisted, with a
  required reviewed `reason` — **empty for this batch**, verified by grep: exactly 3
  BEGIN-on-caller-connection sites exist in the whole exported surface today, all category-1) /
  `UNKNOWN` (fail-closed default).
- Keys every site by `enclosing-symbol + ancestor-KIND path` — never line/column (the F1 rule).
- **P2-c backstop**: the classification gate above (`AttendanceW4TransactionClientV1`-typed
  parameters only) is exactly right for classifying ownership, but means a BEGIN on a
  differently-typed or untyped receiver would be *invisible* to the classifier rather than
  UNKNOWN. A second, deliberately type-agnostic collector
  (`independentDiscoverBeginCallSitesV1`) finds every `<Identifier>.query('BEGIN'…)` call inside
  any exported function regardless of receiver type; the guard asserts its count on the real tree
  equals the classifier's site count (3 == 3), and a fixture proves the cross-check is load-bearing
  (a receiver typed something else: classifier finds 0, independent walker finds 1 — the exact
  mismatch the real-tree assertion is built to catch). Mirrors the F1 guard's own
  `independentThisStarts`, built for the identical reason ("so a pruning bug in the builder cannot
  hide").

`tests/unit/attendance-gate-e-txn-ownership-walk.test.ts` is the guard itself (22 tests):
- **UNKNOWN is EMPTY** across the whole exported surface (the load-bearing assertion).
- **Non-vacuity**: asserts the walk actually discovers the two converted sites by name, plus an
  exact named OWNS census (the two converted sites **and** the pre-existing correctly-guarded
  sibling `planAttendanceCalculationRolloutTransitionV1` in `w4c3a-rollout-control.ts`, W4C-5
  NEW-B / #4839 — the walk finds it too, for free, as a positive control that the classifier isn't
  just recognizing my own two edits).
- **P2-c backstop** (above): 2 tests.
- **Mutation probe** (per design lock §D3 — never mutates a file on disk): reads the real,
  post-fix source text of both site files, string-replaces the idle-proof call's callee only
  (`assertConnectionIsIdleV1(connection)` → `Promise.resolve(connection)`) in an in-memory copy,
  re-parses it, and asserts the site moves from `OWNS` to `UNKNOWN`. Also verified by hand against
  the **live tree** (not just the synthetic fixture): removed each site's idle-proof call for
  real, confirmed the guard test goes RED (`UNKNOWN` non-empty, named census fails), then restored
  via `cp` from a backup — never `git checkout`.
- 12 additional inline-fixture tests cover the classifier's state space: dominating-before-loop,
  no-proof, proof-nested-in-`if` (does not dominate), proof-after-`BEGIN`, proof-on-a-different
  identifier (name-based identity, deliberately not symbol-resolved), a BEGIN inside a nested
  closure (invisible, not misclassified), `SAVEPOINT` (out of scope, not a BEGIN site),
  `START TRANSACTION` aliasing, non-exported functions (not walked), the JOINS/NESTED allowlist
  path, and key stability under an unrelated sibling insertion.

### 3. Real-PostgreSQL four-state acceptance, per site
`packages/core-backend/tests/integration/attendance-gate-e-txn-ownership-batch1.db.test.ts`
(wiring copied from the sibling `attendance-w4c2-outbox-dispatcher.db.test.ts` / P2-C proof in
`attendance-w4c5-rollout-transition-tool.db.test.ts`), 10 tests (5 per site):

1. **Open, read-only caller txn** → refuses `W4C0_CONNECTION_NOT_IDLE`; caller's txn stays open
   and usable (can still `SELECT`/`COMMIT` its own txn — the callee neither committed nor rolled
   it back).
2. **Open txn with uncommitted writes** → refused; a **second** connection cannot see the row
   while refused; the caller's **own** connection still sees it in-txn; the row is gone once the
   caller rolls back. This is the **discriminating** case — pre-fix, the wrapped function's own
   `COMMIT` would durably publish that row regardless of the caller's intent.
3. **Idle connection** → positive control: the function succeeds and does its real work (site 1:
   the `body` callback's write commits; site 2: dispatches and delivers a real pending outbox
   row). Without this, "it refuses" can't be told apart from "it's broken".
4. **Cleanup, split into two legs**, both against the real driver:
   - **4a (succeeded)**: on refusal the idle probe has already `RELEASE`d its own savepoint — a
     caller-issued `RELEASE SAVEPOINT w4c5_idle_probe` afterward fails `3B001`
     (`invalid_savepoint_specification`), and the connection is fully usable once the caller rolls
     back its own txn (mirrors the existing P2-C proof pattern).
   - **4b (the probe's own teardown FAILS)**: a wrapped connection rejects exactly the two
     teardown statements (`ROLLBACK TO SAVEPOINT` / `RELEASE SAVEPOINT w4c5_idle_probe`,
     simulating a transient failure) without ever sending them to PostgreSQL. Asserts the caller
     still sees the product code `W4C0_CONNECTION_NOT_IDLE` — never the injected error, never a
     raw SQLSTATE (production wraps both teardown statements in `.catch(() => undefined)`). Proves
     the injection was real, not vacuous, by having the caller's own `RELEASE SAVEPOINT` **succeed**
     at that point (the savepoint is genuinely still defined, since the wrapper blocked the real
     teardown) — the opposite of 4a's `3B001` — then rolls back (which removes every savepoint in
     the transaction regardless of whether it was ever explicitly released) and confirms the
     connection is usable again.

Two-point wiring: added to `vitest.config.ts`'s `exclude` (so the no-DB job can't skip-green it)
and to `plugin-tests.yml`'s attendance real-DB step run-list (whole-file). **Third point found
during self-review**: `scripts/ops/attendance-w4c2-ci-wiring.test.mjs` derives the attendance
corpus from disk + wiring and cross-checks it against a frozen `EXPECTED_ATTENDANCE_SUITES`
literal (same discipline as this repo's s6a hash pin — deliberately pinned so growth/shrinkage is
announced, not silently absorbed). Updated that literal (via the guard's own
`EMIT_ATTENDANCE_CORPUS=1` regeneration path, not hand-typed) to include the new suite; reran the
guard (225/225) and the other 23 `scripts/ops/*ci-wiring.test.mjs` siblings together (345/345, 0
fail) to confirm no cross-guard regression.

### 4. Sealed-export provenance pin regeneration
`.github/workflows/plugin-tests.yml` is itself a pinned evidence file in the sealed-export S6-A
package-provenance set (id `pluginTestsWorkflow`, `evidenceFiles` in
`sealed-export-package-provenance.cjs`). The run-list addition legitimately changed that file's
bytes, so the frozen digest in `vectors/s6a-package-provenance-pins.json` no longer matched.
Regenerated via the module's own official `computePackageProvenancePinSet(repoRoot)` helper —
never hand-edited. Diff is exactly the one intended digest (`evidenceFiles.pluginTestsWorkflow`);
every other pinned module/migration/runtime-file/evidence-file digest is unchanged.
`node __tests__/sealed-export-package-provenance.test.cjs` passes; the full `test:sealed-export-s5`
(11 files) and `test:sealed-export-s6a` (11 files) chains both pass, 0 fail.

### 5. Repaired the four co-located `src/attendance/__tests__/` mocks broken by the new probe (P1, found by
independent review)
An independent adversarial gate (first truly independent review of this PR) found the required
DB-free `test` job actually RED — 9 failing tests across 4 pre-existing co-located unit-test files
that exercise the two converted wrapper functions through production adapters/hosts:
`w4c3a-legacy-plan-mutation-seams.test.ts`, `w4c3a-legacy-plan-reservation-host.test.ts`,
`w4c3a-sync-import-host.test.ts`, `w4c3b-request-operation-boundary.test.ts`. **Root cause: a
test-mock gap, not a production regression** — each file's fake pg client resolved *every*
`query()` call, including the new probe's `SAVEPOINT w4c5_idle_probe`, with `{ rows: [] }`
(success), which the probe reads as "an open transaction already existed" → refuses
`W4C0_CONNECTION_NOT_IDLE`. The gate's own counter-experiment (production code unchanged, one mock
patched) and causal-isolation probe (both site probes neutered → all 4 files 31/31 green on base
behavior) confirmed this precisely, plus a repo-wide caller trace and 207 real-DB caller tests
across the same production call paths, all green.

Fixed each fake client to reject `query('SAVEPOINT w4c5_idle_probe')` with `{ code: '25P01' }` —
the real idle connection's affirmative-proof path, the exact contract the DB test's `wrap()`
already relies on (letting the real driver answer it). Every affected test's mock models a
freshly-acquired, idle-on-entry connection, so this is faithful, not a workaround. Matched the
query string EXACTLY (no blanket SAVEPOINT rejection — the code may issue other named savepoints
elsewhere). Two files (`w4c3a-legacy-plan-reservation-host.test.ts`,
`w4c3a-sync-import-host.test.ts`) also assert the EXACT SQL statement sequence issued; updated
those expected sequences to include the probe's `SAVEPOINT w4c5_idle_probe` as the genuinely-first
statement (it now is), since it runs once before the wrapper's own `BEGIN`.

**Also fixes a NIT** from the same review: `w4c3a-legacy-plan-reservation-host.ts:130` named the
freshly-acquired (idle-on-entry) connection `trx`, implying a transaction handle it isn't yet.
Renamed to `connection` at all 4 use sites in that function's scope — pure rename, no behavior
change (confirmed: this is the *only* production-code line in this follow-up; every other change
in this commit is test-mock-only).

**Correction to this PR body's earlier claim:** an earlier revision of this section stated the
broken `tests/unit` files (a *different*, pre-existing failure set —
`REPO_ROOT_AMBIGUOUS`/environmental, unrelated to this PR) "neither import the two changed
production files." That statement is **true** for those `tests/unit/` files, but the independent
gate found a **separate** set — the 4 co-located `src/attendance/__tests__/` files above — that
DOES exercise the two converted wrapper functions (transitively, through production
adapters/hosts), and this PR's earlier local verification never ran that directory at all
(`npx vitest run tests/unit` was the only sweep executed; `src/attendance/__tests__/` — the
directory the required job actually checks — was missed entirely). That gap is now closed: see
the verification section below.

## Verification run locally (this session)

- `pnpm -w install` (workspace deps, none pre-installed in this worktree).
- `npx tsc --noEmit` in `packages/core-backend` — **clean** (this repo's `tsconfig.json` excludes
  `**/*.test.ts`/`**/__tests__/**`, so I additionally typechecked the 3 new/changed test/helper
  files end-to-end via a temporary `files`-based tsconfig extending the real one — **clean**,
  deleted before commit, not part of the diff).
- No lint script/config exists for `core-backend` in this repo (confirmed: no `eslint.config.*`
  anywhere, no `lint` script in `packages/core-backend/package.json`) — not applicable.
- DB-free guard: `npx vitest run tests/unit/attendance-gate-e-txn-ownership-walk.test.ts` —
  **22/22 passed**.
- Real-DB acceptance: a local Postgres happened to be reachable in this sandbox
  (`metasheet_test`, fully migrated — 317/317 applied) — ran
  `npx vitest --config vitest.integration.config.ts run tests/integration/attendance-gate-e-txn-ownership-batch1.db.test.ts`
  — **10/10 passed**. (In CI this runs as part of the `Run attendance integration tests` step in
  `plugin-tests.yml`, gated on `DATABASE_URL`; noting per the build brief's instruction that it
  "likely only runs in CI" — it happened to also be runnable here. `on.pull_request` in
  `plugin-tests.yml` carries no `paths:` filter — this job runs on every PR regardless.)
- CI wiring guards: `scripts/ops/attendance-w4c2-ci-wiring.test.mjs` **225/225**; all 24
  `scripts/ops/*ci-wiring.test.mjs` siblings together **345/345, 0 fail**.
- Regression check: reran the two pre-existing sibling suites
  (`attendance-w4c0-operation-registry.db.test.ts` 8/8,
  `attendance-w4c2-outbox-dispatcher.db.test.ts` 5/5) against the same local DB — unaffected.
- Mutation self-check on BOTH sites, on BOTH test layers, run TWICE — once right after the first
  commit, and once more against the CURRENT head (after the P2-c/4a-4b follow-up) for site 1, so
  the evidence isn't stale relative to what's actually being reviewed: removed
  `assertConnectionIsIdleV1(connection)` from the live source, confirmed (a) the DB-free guard
  goes 19/22 (the 3 that red are UNKNOWN-empty, the named census, and the mutation probe's own
  live-tree sanity check — the new P2-c count cross-check correctly stays green under this
  mutation, since the proof's absence changes the BUCKET, not the SITE COUNT, both walkers still
  find 3 sites either way), and (b) the real-DB suite goes 6/10 (site 1's tests 1, 2, 4a, 4b all
  red — 4b surfaces the SAME raw `25001` SQLSTATE as 1/2/4a, not a different mechanism: with the
  proof gone, `wrapWithTeardownFailure`'s interception is never reached at all because execution
  never gets past the dirty `BEGIN`; test 3, the idle positive control, correctly stays green) —
  then restored via `cp` from a pre-mutation backup (never `git checkout`) both times. Diffs and
  `git status` verified clean/byte-identical to the pre-mutation state after each restore.
- Broader `pnpm vitest run tests/unit` sweep: 17-18 pre-existing files fail with
  `REPO_ROOT_AMBIGUOUS` (a path-resolution artifact of this sandbox's nested worktree — two
  ancestors both contain `packages/core-backend/package.json`); one unrelated multitable guard
  intermittently fails on a missing decoy fixture file (present in one run, absent in another —
  looks like cross-session sandbox noise, not this diff). All pre-existing/environmental: none
  import the two changed production files or the Gate E test files (checked by name). I did not
  re-run the same sweep against an unmodified checkout to confirm identically (the harness
  restricts this agent to its own worktree), so treat that as name-based evidence, not an
  independently re-run control. **This sweep does NOT cover `src/attendance/__tests__/` — that
  directory is separate from `tests/unit/` and was missed by this PR's original local
  verification; see the required-suite run below, which is what actually caught (and now fixes)
  the P1.**
- **Required DB-free unit suite, the one the independent gate found RED:**
  `npx vitest run src/attendance/__tests__` — **490/490 passed** (was 481/490 before this fix, 9
  failures across the 4 files named in "What changed" §5). This is the exact DB-free set CI's
  required `test` job runs.

## Out of scope (named, not built, per the design lock)

- A full branded-type refactor making "joins caller" the type-level default across the package —
  large, invasive, its own design-lock + owner scope call. The walk-the-table guard added here
  **is** the acceptance-named enforcement for this batch; the type refactor is a later lane.
- Gate D and any further category-3 (savepoint) sites — out of scope for this batch; the guard
  deliberately does not match `SAVEPOINT` statements at all.

## Landing concern (not a build blocker)

#4844 itself records an unresolved **"Owner ruling requested on lane assignment"** — this PR does
not resolve or presuppose that ruling; it is a landing-sequencing concern for the owner, not
something this batch's mechanical implementation can or should decide.

## Test plan

- [x] `npx tsc --noEmit` (core-backend `src/`) — clean
- [x] Ad-hoc typecheck of the new/changed test/helper files — clean (the 4 fixed `__tests__` mocks
      show only pre-existing, unrelated errors under an ad-hoc CJS tsconfig — `import.meta`/module
      target and an unrelated shared-fixture type gap, both far from the edited lines; these files
      are excluded from the real `tsconfig.json` and run via `vitest`'s own transform, not `tsc`)
- [x] DB-free guard (`tests/unit/attendance-gate-e-txn-ownership-walk.test.ts`) — 22/22
- [x] Real-DB four-state (5-leg) acceptance (`tests/integration/attendance-gate-e-txn-ownership-batch1.db.test.ts`) — 10/10 (ran locally; CI-gated by `DATABASE_URL` in `plugin-tests.yml`)
- [x] CI wiring guards (`scripts/ops/*ci-wiring.test.mjs`, 24 files) — 345/345, 0 fail
- [x] Sealed-export provenance: `sealed-export-package-provenance.test.cjs` pass; `test:sealed-export-s5` (11 files) + `test:sealed-export-s6a` (11 files) — all pass
- [x] **Required suite `src/attendance/__tests__` — 490/490** (fixed from 481/490; this is the P1 the independent gate found)
- [x] Sibling regression suites unaffected — 13/13
- [x] Mutation self-check on both sites, both test layers — RED confirmed, restored via `cp`
- [ ] CI required checks (not yet observed — this PR is opened as **Draft**)

Draft — build-to-gate, no auto-merge, not marked ready. Refs #4844.
