### PR TITLE
feat(attendance): W7-0 byte-inert contracts/fixtures prep (#4556)

### DIFF
--- a/packages/core-backend/src/attendance/__tests__/w7-context-source-posture-contract.test.ts
+++ b/packages/core-backend/src/attendance/__tests__/w7-context-source-posture-contract.test.ts
@@ -1,0 +1,151 @@
+/**
+ * W7-0 (#4556) — context-source posture contract: legal-transition matrix
+ * and the two-part posture-read function. See
+ * `../w7-context-source-posture-contract.ts` header and
+ * `docs/development/attendance-issue-4556-w7-group-policy-cutover-design-lock-20260807.md`
+ * §4.2, §7 OD-W7-3.
+ *
+ * This module is not imported by any production path (W7-R9 byte-inert).
+ * Deleting both files leaves every other suite green.
+ */
+import { describe, expect, it } from 'vitest'
+import {
+  ATTENDANCE_W7_CONTEXT_SOURCE_POSTURE_LEGAL_TRANSITIONS_V1,
+  ATTENDANCE_W7_CONTEXT_SOURCE_POSTURE_STATES_V1,
+  isAttendanceW7ContextSourcePostureLegalTransitionV1,
+  resolveAttendanceW7ContextSourcePostureFromPartsV1,
+  type AttendanceW7ContextSourcePostureStateV1,
+} from '../w7-context-source-posture-contract'
+
+describe('W7-0 context-source posture: state set + legal-transition matrix', () => {
+  it('states are exactly the five OD-W7-3(a) values, in order', () => {
+    expect(ATTENDANCE_W7_CONTEXT_SOURCE_POSTURE_STATES_V1).toEqual([
+      'off',
+      'group_shadow',
+      'group_eligible',
+      'group_authoritative',
+      'suspended',
+    ])
+  })
+
+  it('legal transitions are exactly the seven pairs the design-lock text fixes', () => {
+    expect(ATTENDANCE_W7_CONTEXT_SOURCE_POSTURE_LEGAL_TRANSITIONS_V1).toEqual([
+      ['off', 'group_shadow'],
+      ['group_shadow', 'off'],
+      ['group_shadow', 'group_eligible'],
+      ['group_eligible', 'group_shadow'],
+      ['group_eligible', 'group_authoritative'],
+      ['group_authoritative', 'suspended'],
+      ['suspended', 'group_authoritative'],
+    ])
+  })
+
+  it('every pair over the full 5x5 state space is legal iff it is one of the seven pinned pairs', () => {
+    const states = ATTENDANCE_W7_CONTEXT_SOURCE_POSTURE_STATES_V1
+    const legalSet = new Set(
+      ATTENDANCE_W7_CONTEXT_SOURCE_POSTURE_LEGAL_TRANSITIONS_V1.map(([a, b]) => `${a}->${b}`),
+    )
+    let legalCount = 0
+    let illegalCount = 0
+    for (const from of states) {
+      for (const to of states) {
+        const expectedLegal = legalSet.has(`${from}->${to}`)
+        expect(isAttendanceW7ContextSourcePostureLegalTransitionV1(from, to)).toBe(expectedLegal)
+        if (expectedLegal) legalCount += 1
+        else illegalCount += 1
+      }
+    }
+    // 5x5 = 25 pairs total; exactly 7 legal (matching the pinned list), 18 illegal
+    // (including all 5 self-pairs, which are never legal).
+    expect(legalCount).toBe(7)
+    expect(illegalCount).toBe(18)
+  })
+
+  it('no self-transition is legal (off->off etc. all rejected)', () => {
+    for (const state of ATTENDANCE_W7_CONTEXT_SOURCE_POSTURE_STATES_V1) {
+      expect(isAttendanceW7ContextSourcePostureLegalTransitionV1(state, state)).toBe(false)
+    }
+  })
+})
+
+describe('W7-0 context-source posture: two-part posture-read contract', () => {
+  it('no persisted row -> off, regardless of capability/allowlist', () => {
+    expect(
+      resolveAttendanceW7ContextSourcePostureFromPartsV1({
+        persistedRow: null,
+        implementationCapability: true,
+        orgExactlyAllowlisted: true,
+      }),
+    ).toBe('off')
+  })
+
+  it('persisted suspended -> ALWAYS suspended, even with capability+allowlist both false', () => {
+    expect(
+      resolveAttendanceW7ContextSourcePostureFromPartsV1({
+        persistedRow: { state: 'suspended', scope: 'synthetic_staging' },
+        implementationCapability: false,
+        orgExactlyAllowlisted: false,
+      }),
+    ).toBe('suspended')
+  })
+
+  it('persisted suspended -> still suspended even with capability+allowlist both true (cannot be evaded upward either)', () => {
+    expect(
+      resolveAttendanceW7ContextSourcePostureFromPartsV1({
+        persistedRow: { state: 'suspended', scope: 'synthetic_staging' },
+        implementationCapability: true,
+        orgExactlyAllowlisted: true,
+      }),
+    ).toBe('suspended')
+  })
+
+  it('row alone (capability false) is insufficient for a non-suspended state -> off', () => {
+    expect(
+      resolveAttendanceW7ContextSourcePostureFromPartsV1({
+        persistedRow: { state: 'group_shadow', scope: 'synthetic_staging' },
+        implementationCapability: false,
+        orgExactlyAllowlisted: true,
+      }),
+    ).toBe('off')
+  })
+
+  it('row + capability without exact allowlist is insufficient -> off (this is the two-part condition)', () => {
+    expect(
+      resolveAttendanceW7ContextSourcePostureFromPartsV1({
+        persistedRow: { state: 'group_shadow', scope: 'synthetic_staging' },
+        implementationCapability: true,
+        orgExactlyAllowlisted: false,
+      }),
+    ).toBe('off')
+  })
+
+  it.each<AttendanceW7ContextSourcePostureStateV1>(['group_shadow', 'group_eligible', 'group_authoritative'])(
+    'row + capability + exact allowlist all true -> advertises the persisted state (%s)',
+    (state) => {
+      expect(
+        resolveAttendanceW7ContextSourcePostureFromPartsV1({
+          persistedRow: { state, scope: 'synthetic_staging' },
+          implementationCapability: true,
+          orgExactlyAllowlisted: true,
+        }),
+      ).toBe(state)
+    },
+  )
+
+  it('positive control: the exact same probe (row present) DOES flip sourcing once capability+allowlist are both true (proves the two-part gate is live, not a no-op)', () => {
+    const base = { persistedRow: { state: 'group_eligible' as const, scope: 'synthetic_staging' as const } }
+    const gated = resolveAttendanceW7ContextSourcePostureFromPartsV1({
+      ...base,
+      implementationCapability: false,
+      orgExactlyAllowlisted: false,
+    })
+    const flipped = resolveAttendanceW7ContextSourcePostureFromPartsV1({
+      ...base,
+      implementationCapability: true,
+      orgExactlyAllowlisted: true,
+    })
+    expect(gated).toBe('off')
+    expect(flipped).toBe('group_eligible')
+    expect(flipped).not.toBe(gated)
+  })
+})

--- a/packages/core-backend/src/attendance/__tests__/w7-frozen-context-v2-contract.test.ts
+++ b/packages/core-backend/src/attendance/__tests__/w7-frozen-context-v2-contract.test.ts
@@ -6,11 +6,19 @@
  * exact-key closure legs (extra key / missing key).
  *
  * Every reject fixture below differs from a VALID baseline by exactly ONE
- * field, so each leg maps to exactly one guard in
- * `validateFrozenAttendanceContextV7DraftV1` — required for the mutation
- * self-check recorded in the PR body to be meaningful (a two-defect fixture
- * would stay red under either guard's removal, making mutation "load-bearing"
- * look true when it isn't).
+ * field — required for the mutation self-check recorded in the PR body to
+ * be meaningful (a two-defect fixture would stay red under either guard's
+ * removal, making mutation "load-bearing" look true when it isn't). That
+ * single-field discipline does NOT mean every leg maps to exactly one
+ * guard, though: guards 2/3/4/5/6 in
+ * `validateFrozenAttendanceContextV7DraftV1` are each sole coverage for
+ * their own leg (verified by mutation — see the PR body's mutation table),
+ * but guard 1 (exact-key closure) is sole coverage for the "extra key" leg
+ * and the null/undefined non-object-input legs, while its "missing key"
+ * leg is independently caught by the downstream field-level checks too
+ * (deleting `timezone` still fails `isNonEmptyStringV1(ctx.timezone)` even
+ * with guard 1 disabled) — defense-in-depth on that one leg, recorded
+ * honestly rather than folded into a uniform claim.
  *
  * This module is not imported by any production path (W7-R9 byte-inert).
  * Deleting both files leaves every other suite green; v1's own golden test

--- a/packages/core-backend/src/attendance/__tests__/w7-frozen-context-v2-contract.test.ts
+++ b/packages/core-backend/src/attendance/__tests__/w7-frozen-context-v2-contract.test.ts
@@ -1,0 +1,136 @@
+/**
+ * W7-0 (#4556) — frozen-context v2 contract-preview validator: accept legs
+ * ({v1-legacy, v2-legacy, v2-group_effective}) and fail-closed reject legs
+ * (unknown selector / unknown schemaVersion / v2-shape-with-v1-tag /
+ * calculationGroupId-selector mismatch, per design-lock W7-R5). Also the
+ * exact-key closure legs (extra key / missing key).
+ *
+ * Every reject fixture below differs from a VALID baseline by exactly ONE
+ * field, so each leg maps to exactly one guard in
+ * `validateFrozenAttendanceContextV7DraftV1` — required for the mutation
+ * self-check recorded in the PR body to be meaningful (a two-defect fixture
+ * would stay red under either guard's removal, making mutation "load-bearing"
+ * look true when it isn't).
+ *
+ * This module is not imported by any production path (W7-R9 byte-inert).
+ * Deleting both files leaves every other suite green; v1's own golden test
+ * (`w4c1-fingerprint-golden.test.ts`) is untouched by this PR.
+ */
+import { describe, expect, it } from 'vitest'
+import { validateFrozenAttendanceContextV7DraftV1 } from '../w7-frozen-context-v2-contract'
+
+function segment(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    index: 0,
+    startTime: '09:00',
+    endTime: '18:00',
+    startDayOffset: 0,
+    endDayOffset: 0,
+    lateGraceMinutes: 5,
+    earlyLeaveGraceMinutes: 5,
+    ...overrides,
+  }
+}
+
+function baseFields() {
+  return {
+    orgId: 'org-w7-0',
+    userId: 'user-w7-0',
+    workDate: '2026-08-13',
+    timezone: 'Asia/Shanghai',
+    shiftId: 'shift-w7-0',
+    isWorkday: true,
+    holidayKind: null,
+    roundingMinutes: 15,
+    severeLateThresholdMinutes: 45,
+    absenceLateThresholdMinutes: 90,
+    segments: [segment()],
+  }
+}
+
+function validV1Legacy() {
+  return {
+    schemaVersion: 1,
+    selector: 'legacy',
+    calculationGroupId: null,
+    ...baseFields(),
+  }
+}
+
+function validV2Legacy() {
+  return {
+    schemaVersion: 2,
+    selector: 'legacy',
+    calculationGroupId: null,
+    ...baseFields(),
+  }
+}
+
+function validV2GroupEffective() {
+  return {
+    schemaVersion: 2,
+    selector: 'group_effective',
+    calculationGroupId: 'calc-group-w7-0',
+    ...baseFields(),
+  }
+}
+
+describe('W7-0 frozen-context v2 contract: accept legs', () => {
+  it('accepts v1-legacy', () => {
+    expect(validateFrozenAttendanceContextV7DraftV1(validV1Legacy())).toBe(true)
+  })
+
+  it('accepts v2-legacy', () => {
+    expect(validateFrozenAttendanceContextV7DraftV1(validV2Legacy())).toBe(true)
+  })
+
+  it('accepts v2-group_effective', () => {
+    expect(validateFrozenAttendanceContextV7DraftV1(validV2GroupEffective())).toBe(true)
+  })
+})
+
+describe('W7-0 frozen-context v2 contract: fail-closed reject legs (single-field mutations from a valid baseline)', () => {
+  it('rejects unknown schemaVersion (2 -> 3, single field changed on the v2-legacy baseline)', () => {
+    const invalid = { ...validV2Legacy(), schemaVersion: 3 }
+    expect(validateFrozenAttendanceContextV7DraftV1(invalid)).toBe(false)
+  })
+
+  it('rejects unknown selector (single field changed on the v2-legacy baseline)', () => {
+    const invalid = { ...validV2Legacy(), selector: 'bogus_selector' }
+    expect(validateFrozenAttendanceContextV7DraftV1(invalid)).toBe(false)
+  })
+
+  it('rejects v2-shape-with-v1-tag (schemaVersion 2 -> 1, single field changed on the v2-group_effective baseline; selector+calculationGroupId stay group_effective/non-null)', () => {
+    const invalid = { ...validV2GroupEffective(), schemaVersion: 1 }
+    expect(validateFrozenAttendanceContextV7DraftV1(invalid)).toBe(false)
+  })
+
+  it('rejects calculationGroupId non-null while selector=legacy (single field changed on the v2-legacy baseline)', () => {
+    const invalid = { ...validV2Legacy(), calculationGroupId: 'should-not-be-set' }
+    expect(validateFrozenAttendanceContextV7DraftV1(invalid)).toBe(false)
+  })
+
+  it('rejects calculationGroupId null while selector=group_effective (single field changed on the v2-group_effective baseline)', () => {
+    const invalid = { ...validV2GroupEffective(), calculationGroupId: null }
+    expect(validateFrozenAttendanceContextV7DraftV1(invalid)).toBe(false)
+  })
+})
+
+describe('W7-0 frozen-context v2 contract: exact-key closure legs (W7-R5 "exact-key fail-closed")', () => {
+  it('rejects an extra unrecognized key (single field added to the v2-legacy baseline)', () => {
+    const invalid = { ...validV2Legacy(), unknownField: 'x' }
+    expect(validateFrozenAttendanceContextV7DraftV1(invalid)).toBe(false)
+  })
+
+  it('rejects a missing required key (single field removed from the v2-legacy baseline)', () => {
+    const invalid = validV2Legacy() as Record<string, unknown>
+    delete invalid.timezone
+    expect(validateFrozenAttendanceContextV7DraftV1(invalid)).toBe(false)
+  })
+})
+
+describe('W7-0 frozen-context v2 contract: non-object inputs', () => {
+  it.each([null, undefined, 'string', 42, [], true])('rejects non-object input %p', (input) => {
+    expect(validateFrozenAttendanceContextV7DraftV1(input)).toBe(false)
+  })
+})

--- a/packages/core-backend/src/attendance/__tests__/w7-read-side-provenance-amendment.test.ts
+++ b/packages/core-backend/src/attendance/__tests__/w7-read-side-provenance-amendment.test.ts
@@ -9,11 +9,16 @@
  * (`../../services/AttendanceW4CalculationDetail.ts`) nor
  * `AttendanceDecisionTraceSourceKind`
  * (`../../services/AttendanceDecisionTrace.ts`) is edited by this PR. The
- * real compile-time drift guard lives in the source file itself
- * (`_assertProjectionOwnerSyncV1` / `_assertTraceSourceKindSyncV1`, checked
- * by `pnpm type-check`, which — unlike `vitest` — does NOT exclude this
- * `__tests__` directory, so this file's own assertions below are a runtime
- * echo of that compile-time guarantee, not a substitute for it).
+ * real compile-time drift guard lives in the SOURCE file, not here:
+ * `packages/core-backend/tsconfig.json`'s `exclude` list keeps every
+ * `.test.ts` file and everything under a `__tests__` directory out of
+ * `pnpm type-check`'s scope, so a type-level equality assertion placed in
+ * THIS file would never actually be checked by `tsc`.
+ * `_assertProjectionOwnerSyncV1` / `_assertTraceSourceKindSyncV1` therefore
+ * live in `../w7-read-side-provenance-amendment.ts` itself (which IS
+ * type-checked); this file's assertions below are runtime VALUE checks only
+ * — a weaker, complementary signal, not a substitute for the compile-time
+ * guarantee.
  */
 import { describe, expect, it } from 'vitest'
 import {

--- a/packages/core-backend/src/attendance/__tests__/w7-read-side-provenance-amendment.test.ts
+++ b/packages/core-backend/src/attendance/__tests__/w7-read-side-provenance-amendment.test.ts
@@ -1,0 +1,65 @@
+/**
+ * W7-0 (#4556) — read-side provenance amendment (OD-W7-5a) value record.
+ * See `../w7-read-side-provenance-amendment.ts` header and
+ * `docs/development/attendance-issue-4556-w7-group-policy-cutover-design-lock-20260807.md`
+ * §4.4, §7 OD-W7-5.
+ *
+ * This module is not imported by any production path (W7-R9 byte-inert):
+ * neither `PROJECTION_OWNERS`
+ * (`../../services/AttendanceW4CalculationDetail.ts`) nor
+ * `AttendanceDecisionTraceSourceKind`
+ * (`../../services/AttendanceDecisionTrace.ts`) is edited by this PR. The
+ * real compile-time drift guard lives in the source file itself
+ * (`_assertProjectionOwnerSyncV1` / `_assertTraceSourceKindSyncV1`, checked
+ * by `pnpm type-check`, which — unlike `vitest` — does NOT exclude this
+ * `__tests__` directory, so this file's own assertions below are a runtime
+ * echo of that compile-time guarantee, not a substitute for it).
+ */
+import { describe, expect, it } from 'vitest'
+import {
+  ATTENDANCE_W7_PROJECTION_OWNER_GROUP_VALUE_V1,
+  ATTENDANCE_W7_READ_SIDE_PROVENANCE_AMENDMENT_V1,
+  ATTENDANCE_W7_TRACE_SOURCE_KIND_GROUP_VALUE_V1,
+} from '../w7-read-side-provenance-amendment'
+
+describe('W7-0 read-side provenance amendment: recorded values', () => {
+  it('projectionOwner new value is a fixed string, distinct from both current legacy/w4 values', () => {
+    expect(ATTENDANCE_W7_PROJECTION_OWNER_GROUP_VALUE_V1).toBe('w4_group')
+    expect(ATTENDANCE_W7_PROJECTION_OWNER_GROUP_VALUE_V1).not.toBe('legacy_untracked')
+    expect(ATTENDANCE_W7_PROJECTION_OWNER_GROUP_VALUE_V1).not.toBe('w4')
+  })
+
+  it('trace source-kind new value is a fixed string, distinct from all six current values', () => {
+    expect(ATTENDANCE_W7_TRACE_SOURCE_KIND_GROUP_VALUE_V1).toBe('group_policy_snapshot')
+    const current = ['record', 'snapshot', 'rule_live', 'ledger', 'audit', 'policy_gate']
+    expect(current).not.toContain(ATTENDANCE_W7_TRACE_SOURCE_KIND_GROUP_VALUE_V1)
+  })
+
+  it('bundled record targets exactly the two named modules/symbols, exact-key shape', () => {
+    expect(ATTENDANCE_W7_READ_SIDE_PROVENANCE_AMENDMENT_V1).toEqual({
+      projectionOwner: {
+        targetFile: 'packages/core-backend/src/services/AttendanceW4CalculationDetail.ts',
+        targetConst: 'PROJECTION_OWNERS',
+        currentMembers: ['legacy_untracked', 'w4'],
+        newValue: 'w4_group',
+      },
+      traceSourceKind: {
+        targetFile: 'packages/core-backend/src/services/AttendanceDecisionTrace.ts',
+        targetType: 'AttendanceDecisionTraceSourceKind',
+        currentMembers: ['record', 'snapshot', 'rule_live', 'ledger', 'audit', 'policy_gate'],
+        newValue: 'group_policy_snapshot',
+      },
+    })
+  })
+
+  it('is a different enum family from the W6-owned source-label union (OD-W6-3a) — no overlap in spelling', () => {
+    // W6's own closed set (verbatim, from w6-group-effective-policy-contract.ts) — reproduced as a
+    // literal here (not imported: that module is W6's, and importing its VALUE export would be an
+    // unrelated live-module edge for this W7-0 PR to carry for no reason). §4.4: W7 adopts these
+    // spellings and mints none of its own for that family, so none of this file's new values may
+    // collide with them.
+    const w6SourceLabels = ['effective', 'org_inherited', 'preview_only', 'needs_configuration', 'conflict_action_required']
+    expect(w6SourceLabels).not.toContain(ATTENDANCE_W7_PROJECTION_OWNER_GROUP_VALUE_V1)
+    expect(w6SourceLabels).not.toContain(ATTENDANCE_W7_TRACE_SOURCE_KIND_GROUP_VALUE_V1)
+  })
+})

--- a/packages/core-backend/src/attendance/__tests__/w7-w6r5-guard-root-set.test.ts
+++ b/packages/core-backend/src/attendance/__tests__/w7-w6r5-guard-root-set.test.ts
@@ -1,0 +1,81 @@
+/**
+ * W7-0 (#4556) — W6-R5 guard ROOT SET record (W7-R10). See
+ * `../w7-w6r5-guard-root-set.ts` header and
+ * `docs/development/attendance-issue-4556-w7-group-policy-cutover-design-lock-20260807.md`
+ * §3 row W7-R10.
+ *
+ * DELIBERATELY DECLARATION-ONLY: this suite asserts shape (root strings are
+ * globs not files, non-empty reasons, no duplicates, exact count, the
+ * `presentAtW7Zero` split) and asserts NOTHING about the real filesystem —
+ * no `fs.existsSync`, no directory walk, no non-empty-domain check. Root 3
+ * (`packages/core-backend/src/attendance/w7-resolver/**`) genuinely resolves
+ * to zero files at the W7-0 baseline (design-lock §1.4); asserting that here
+ * would either red this byte-inert PR over an expected fact or force this
+ * suite to special-case it, both of which belong to W7-1's guard (the first
+ * head where the non-empty-domain leg is meaningful), not to this record.
+ *
+ * This module is not imported by any production path (W7-R9 byte-inert).
+ */
+import { describe, expect, it } from 'vitest'
+import {
+  ATTENDANCE_W7_W6R5_GUARD_ROOTS_V1,
+  type AttendanceW7GuardRootV1,
+} from '../w7-w6r5-guard-root-set'
+
+describe('W7-0 W6-R5 guard root set: declaration shape (not the walking guard)', () => {
+  it('has exactly three pinned roots', () => {
+    expect(ATTENDANCE_W7_W6R5_GUARD_ROOTS_V1).toHaveLength(3)
+  })
+
+  it('every root is a directory glob (ends with /**), never a single file path', () => {
+    for (const entry of ATTENDANCE_W7_W6R5_GUARD_ROOTS_V1) {
+      expect(entry.root.endsWith('/**')).toBe(true)
+      expect(entry.root.endsWith('.ts')).toBe(false)
+      expect(entry.root.endsWith('.cjs')).toBe(false)
+      expect(entry.root.endsWith('.js')).toBe(false)
+    }
+  })
+
+  it('every reason is a non-empty, non-trivial string (not a placeholder)', () => {
+    for (const entry of ATTENDANCE_W7_W6R5_GUARD_ROOTS_V1) {
+      expect(typeof entry.reason).toBe('string')
+      expect(entry.reason.length).toBeGreaterThan(40)
+    }
+  })
+
+  it('root strings are unique (no duplicate roots pinned twice)', () => {
+    const roots = ATTENDANCE_W7_W6R5_GUARD_ROOTS_V1.map((entry) => entry.root)
+    expect(new Set(roots).size).toBe(roots.length)
+  })
+
+  it('roots are exactly the two design-lock-named existing roots plus the resolver placeholder', () => {
+    const roots = ATTENDANCE_W7_W6R5_GUARD_ROOTS_V1.map((entry) => entry.root)
+    expect(roots).toEqual([
+      'plugins/plugin-attendance/**',
+      'packages/core-backend/src/attendance/**',
+      'packages/core-backend/src/attendance/w7-resolver/**',
+    ])
+  })
+
+  it('presentAtW7Zero is true for the two existing roots and false for the not-yet-created resolver root', () => {
+    const byRoot = new Map<string, AttendanceW7GuardRootV1>(
+      ATTENDANCE_W7_W6R5_GUARD_ROOTS_V1.map((entry) => [entry.root, entry]),
+    )
+    expect(byRoot.get('plugins/plugin-attendance/**')?.presentAtW7Zero).toBe(true)
+    expect(byRoot.get('packages/core-backend/src/attendance/**')?.presentAtW7Zero).toBe(true)
+    expect(byRoot.get('packages/core-backend/src/attendance/w7-resolver/**')?.presentAtW7Zero).toBe(false)
+  })
+
+  it('exactly one root is not-yet-present (the future guard is expected to see exactly one root flip false->true)', () => {
+    const notYetPresent = ATTENDANCE_W7_W6R5_GUARD_ROOTS_V1.filter((entry) => !entry.presentAtW7Zero)
+    expect(notYetPresent).toHaveLength(1)
+    expect(notYetPresent[0]?.root).toBe('packages/core-backend/src/attendance/w7-resolver/**')
+  })
+
+  it('every entry is frozen (Object.freeze) — a mutation attempt is a no-op, not a silent record change', () => {
+    for (const entry of ATTENDANCE_W7_W6R5_GUARD_ROOTS_V1) {
+      expect(Object.isFrozen(entry)).toBe(true)
+    }
+    expect(Object.isFrozen(ATTENDANCE_W7_W6R5_GUARD_ROOTS_V1)).toBe(true)
+  })
+})

--- a/packages/core-backend/src/attendance/w7-context-source-posture-contract.ts
+++ b/packages/core-backend/src/attendance/w7-context-source-posture-contract.ts
@@ -45,11 +45,13 @@ export type AttendanceW7ContextSourcePostureStateV1 =
  * (`w4c3a-rollout-control.ts:85-93`). Everything not listed is illegal.
  *
  * OD-W7-4 (open) asks whether a `group_authoritative` org may fall back
- * directly to a *legacy* source; that is a DIFFERENT machine's decision (the
- * legacy fallback, if ruled (b) some day, is not a pair of THIS machine,
- * whose states don't include "legacy" at all — see the states list above).
- * This table is therefore not conditional on OD-W7-4 either way; recorded
- * here as stated, not inferred.
+ * directly to a *legacy* source. `off` is this machine's own
+ * legacy-sourcing state (§4.2's ladder starts there), so a (b) ruling on
+ * OD-W7-4 would most plausibly ADD an edge INTO `off` from
+ * `group_authoritative` or `suspended` — this table is not a closure claim
+ * over that still-open decision. It records only the seven pairs §4.2/§5.2/
+ * §5.3 fix as stated today; an OD-W7-4 (b) ruling is an amendment to this
+ * table, not something this table already anticipates.
  */
 export const ATTENDANCE_W7_CONTEXT_SOURCE_POSTURE_LEGAL_TRANSITIONS_V1: ReadonlyArray<
   readonly [AttendanceW7ContextSourcePostureStateV1, AttendanceW7ContextSourcePostureStateV1]

--- a/packages/core-backend/src/attendance/w7-context-source-posture-contract.ts
+++ b/packages/core-backend/src/attendance/w7-context-source-posture-contract.ts
@@ -1,0 +1,131 @@
+/**
+ * W7 (#4556) — context-source cutover: CONTRACT DRAFT (W7-0 preparation).
+ *
+ * Status: PROPOSED / runtime HOLD. `OD-W7-0..10` are OPEN owner decisions —
+ * see
+ * `docs/development/attendance-issue-4556-w7-group-policy-cutover-design-lock-20260807.md`
+ * §9. Nothing in the tree imports this module. Deleting it must leave every
+ * existing test green (design-lock red line W7-R9). The runtime resolver,
+ * the transition writer, and the route land at W7-1, not here.
+ *
+ * Basis: built on the design-lock's recommended OD-W7-3 option (a) shape
+ * (§7). OD-W7-3, like every OD-W7-* entry, is OPEN — ratification pending,
+ * not assumed by this file.
+ *
+ * Governing sections: §4.2 (staging ladder + the two-part posture-read
+ * note), §5.2/§5.3 (rollback pairs), §7 OD-W7-3, red line W7-R4.
+ */
+
+// ---------------------------------------------------------------------------
+// OD-W7-3(a): a SEPARATE org-keyed context-source state machine, its own
+// table — NOT the W4 five-state segment-calculation rollout machine
+// (`legacy | shadow | eligible | authoritative | suspended`,
+// `w4c3a-rollout-control.ts:201`). The W4 machine's meaning ("is segment
+// calculation authoritative") stays untouched (design-lock §7 OD-W7-3
+// consequence note).
+// ---------------------------------------------------------------------------
+
+export const ATTENDANCE_W7_CONTEXT_SOURCE_POSTURE_STATES_V1 = Object.freeze([
+  'off',
+  'group_shadow',
+  'group_eligible',
+  'group_authoritative',
+  'suspended',
+] as const)
+
+export type AttendanceW7ContextSourcePostureStateV1 =
+  (typeof ATTENDANCE_W7_CONTEXT_SOURCE_POSTURE_STATES_V1)[number]
+
+/**
+ * Closed legal-transition matrix (design-lock §4.2 "shadow -> compare ->
+ * cutover" ladder, §5.2 "group_shadow -> off and group_eligible ->
+ * group_shadow follow the legal-matrix pattern", §5.3 "group_authoritative
+ * -> suspended ... resume requires ..."). Seven pairs, deliberately mirroring
+ * the W4 machine's own seven-pair `LEGAL_TRANSITIONS` shape
+ * (`w4c3a-rollout-control.ts:85-93`). Everything not listed is illegal.
+ *
+ * OD-W7-4 (open) asks whether a `group_authoritative` org may fall back
+ * directly to a *legacy* source; that is a DIFFERENT machine's decision (the
+ * legacy fallback, if ruled (b) some day, is not a pair of THIS machine,
+ * whose states don't include "legacy" at all — see the states list above).
+ * This table is therefore not conditional on OD-W7-4 either way; recorded
+ * here as stated, not inferred.
+ */
+export const ATTENDANCE_W7_CONTEXT_SOURCE_POSTURE_LEGAL_TRANSITIONS_V1: ReadonlyArray<
+  readonly [AttendanceW7ContextSourcePostureStateV1, AttendanceW7ContextSourcePostureStateV1]
+> = Object.freeze([
+  ['off', 'group_shadow'],
+  ['group_shadow', 'off'],
+  ['group_shadow', 'group_eligible'],
+  ['group_eligible', 'group_shadow'],
+  ['group_eligible', 'group_authoritative'],
+  ['group_authoritative', 'suspended'],
+  ['suspended', 'group_authoritative'],
+] as const)
+
+export function isAttendanceW7ContextSourcePostureLegalTransitionV1(
+  from: AttendanceW7ContextSourcePostureStateV1,
+  to: AttendanceW7ContextSourcePostureStateV1,
+): boolean {
+  return ATTENDANCE_W7_CONTEXT_SOURCE_POSTURE_LEGAL_TRANSITIONS_V1.some(
+    ([legalFrom, legalTo]) => legalFrom === from && legalTo === to,
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Two-part posture-READ contract (§4.2).
+//
+// "The rollout-control boundary alone does not resolve posture — this is a
+// two-part condition, not a single source of truth." Cloned from the SHAPE
+// of `resolveSegmentCalculationPosture`
+// (`packages/core-backend/src/attendance/w4c0-identity.ts:454`; the
+// allowlist check is at `:478-482` of that function) — NOT the write-side
+// transition-boundary discipline alone (W7-R4). A carrier that treats "a
+// legal transition landed" as sufficient to advertise a new posture, without
+// an equivalent read-side allowlist/scope gate, reproduces the exact bug
+// class the W4C-0 persisted-row-plus-allowlist design exists to prevent.
+// ---------------------------------------------------------------------------
+
+/**
+ * The three already-resolved inputs a W7-1 read-side resolver combines. This
+ * module does not read a database — fetching `persistedRow` (the
+ * `attendance_calculation_context_source_state`-shaped row, or whatever
+ * OD-W7-3's table is finally named) and evaluating `orgExactlyAllowlisted`
+ * against a real exact-org/`scope='synthetic_staging'` allowlist are W7-1's
+ * job, mirroring `isOrgExactlyAllowlisted` (`w4c0-identity.ts`, same file).
+ */
+export interface AttendanceW7ContextSourcePostureReadInputV1 {
+  readonly persistedRow: {
+    readonly state: AttendanceW7ContextSourcePostureStateV1
+    readonly scope: 'synthetic_staging'
+  } | null
+  readonly implementationCapability: boolean
+  readonly orgExactlyAllowlisted: boolean
+}
+
+/**
+ * Pure decision function over already-resolved parts — the contract shape
+ * only. Fail-closed rule, matching `w4c0-identity.ts:475-487` exactly:
+ *
+ *  - no persisted row -> `'off'`;
+ *  - persisted `'suspended'` -> ALWAYS `'suspended'`, regardless of
+ *    capability or allowlist (suspension can never be evaded through the
+ *    environment — same asymmetry as the W4 machine's `suspended` handling);
+ *  - any OTHER persisted state -> that state ONLY IF `implementationCapability`
+ *    AND `orgExactlyAllowlisted` are BOTH true (row alone, or allowlist
+ *    alone, each still resolve to `'off'` — this is the two-part condition);
+ *  - otherwise -> `'off'`.
+ *
+ * The async DB-reading counterpart (fetch the row, evaluate the real
+ * allowlist) is W7-1's job; this function is the fail-closed shape that
+ * counterpart must implement.
+ */
+export function resolveAttendanceW7ContextSourcePostureFromPartsV1(
+  input: AttendanceW7ContextSourcePostureReadInputV1,
+): AttendanceW7ContextSourcePostureStateV1 {
+  const { persistedRow, implementationCapability, orgExactlyAllowlisted } = input
+  if (persistedRow === null) return 'off'
+  if (persistedRow.state === 'suspended') return 'suspended'
+  if (implementationCapability && orgExactlyAllowlisted) return persistedRow.state
+  return 'off'
+}

--- a/packages/core-backend/src/attendance/w7-frozen-context-v2-contract.ts
+++ b/packages/core-backend/src/attendance/w7-frozen-context-v2-contract.ts
@@ -1,0 +1,204 @@
+/**
+ * W7 (#4556) OD-W7-2(a) — frozen-context v2 evolution: CONTRACT DRAFT
+ * (W7-0 preparation).
+ *
+ * Status: PROPOSED / runtime HOLD. `OD-W7-0..10` are OPEN owner decisions —
+ * see
+ * `docs/development/attendance-issue-4556-w7-group-policy-cutover-design-lock-20260807.md`
+ * §7 OD-W7-2, §9. Nothing in the tree imports this module: the LIVE
+ * calculator validator (`packages/core-backend/src/attendance/
+ * w4c1-segment-calculator.ts`'s `validateFrozenContextShape`) is untouched
+ * by this PR and still accepts only v1-legacy. Deleting this file and its
+ * test leaves every existing test green (design-lock red line W7-R9); v1's
+ * golden/fingerprint bytes do not move (`w4c1-fingerprint-golden.test.ts`,
+ * `GOLDEN_STORAGE_FINGERPRINT`, verified unchanged in the PR body).
+ *
+ * Basis: built on the design-lock's recommended OD-W7-2 option (a) shape.
+ * OD-W7-2 is OPEN — ratification pending, not assumed by this file.
+ *
+ * Scope note: this module previews ONLY the OD-W7-2 discriminant contract
+ * (`schemaVersion` / `selector` / `calculationGroupId` correspondence) plus
+ * the exact-key closure red line W7-R5 names ("v2 ... validates exact-key
+ * fail-closed"). It does not re-implement segment/timezone/threshold
+ * business validation — that remains owned by the live
+ * `w4c1-segment-calculator.ts` validator and stays out of scope here so this
+ * contract cannot silently drift from, or duplicate-and-diverge from, the
+ * source of truth. W7-1 wires the real discriminant switch into that live
+ * validator; this file is the shape it must implement.
+ *
+ * Also deliberately out of scope: the optional W5 `flexPolicy` key
+ * (`FrozenAttendanceFlexPolicyV1`, `w4c0-write-boundary-types.ts:113-122`).
+ * Whether v2 composes with W5 flex is not decided by OD-W7-2 or by this
+ * file; `V2_CONTEXT_KEYS` below is an EXACT 14-key set with no optional
+ * member, so this draft validator rejects a `flexPolicy`-bearing v2 object
+ * today. That is a scope boundary of this contract, not a claim that W7-1
+ * must keep it that way.
+ */
+
+// ---------------------------------------------------------------------------
+// OD-W7-2(a) v2 type. `calculationGroupId` non-null iff
+// `selector === 'group_effective'`, null iff `selector === 'legacy'`. v1
+// stays a SEPARATE, untouched type (`FrozenAttendanceContextV1`,
+// `w4c0-write-boundary-types.ts:124-152`) — v2 is not a widening of v1's
+// mandatory key domains (see OD-W7-2's own rejection of option (b) for why
+// that distinction matters).
+// ---------------------------------------------------------------------------
+
+export type FrozenAttendanceContextSourceSelectorV2 = 'legacy' | 'group_effective'
+
+export interface FrozenAttendanceContextSegmentV2 {
+  index: 0 | 1 | 2
+  startTime: string
+  endTime: string
+  startDayOffset: 0
+  endDayOffset: 0 | 1
+  lateGraceMinutes: number
+  earlyLeaveGraceMinutes: number
+}
+
+export interface FrozenAttendanceContextV2 {
+  schemaVersion: 2
+  selector: FrozenAttendanceContextSourceSelectorV2
+  orgId: string
+  userId: string
+  workDate: string
+  timezone: string
+  shiftId: string
+  isWorkday: boolean
+  holidayKind: string | null
+  /** Non-null iff `selector === 'group_effective'`; null iff `'legacy'`. */
+  calculationGroupId: string | null
+  roundingMinutes: number
+  severeLateThresholdMinutes: number
+  absenceLateThresholdMinutes: number
+  segments: FrozenAttendanceContextSegmentV2[]
+}
+
+const V2_CONTEXT_KEYS = [
+  'schemaVersion',
+  'selector',
+  'orgId',
+  'userId',
+  'workDate',
+  'timezone',
+  'shiftId',
+  'isWorkday',
+  'holidayKind',
+  'calculationGroupId',
+  'roundingMinutes',
+  'severeLateThresholdMinutes',
+  'absenceLateThresholdMinutes',
+  'segments',
+] as const
+
+const V2_SEGMENT_KEYS = [
+  'index',
+  'startTime',
+  'endTime',
+  'startDayOffset',
+  'endDayOffset',
+  'lateGraceMinutes',
+  'earlyLeaveGraceMinutes',
+] as const
+
+function isPlainObjectLikeV1(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function hasExactKeysV1(value: unknown, keys: readonly string[]): value is Record<string, unknown> {
+  if (!isPlainObjectLikeV1(value)) return false
+  const own = Object.getOwnPropertyNames(value)
+  if (own.length !== keys.length) return false
+  const allowed = new Set(keys)
+  return own.every((key) => allowed.has(key))
+}
+
+function isNonEmptyStringV1(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0
+}
+
+function isNonNegativeIntegerV1(value: unknown): value is number {
+  return typeof value === 'number' && Number.isInteger(value) && value >= 0
+}
+
+function validateSegmentV1(segment: unknown, index: number): boolean {
+  if (!hasExactKeysV1(segment, V2_SEGMENT_KEYS)) return false
+  const seg = segment as Record<string, unknown>
+  if (seg.index !== index) return false
+  if (!isNonEmptyStringV1(seg.startTime) || !isNonEmptyStringV1(seg.endTime)) return false
+  if (seg.startDayOffset !== 0) return false
+  if (seg.endDayOffset !== 0 && seg.endDayOffset !== 1) return false
+  if (!isNonNegativeIntegerV1(seg.lateGraceMinutes) || !isNonNegativeIntegerV1(seg.earlyLeaveGraceMinutes)) {
+    return false
+  }
+  return true
+}
+
+/**
+ * Contract-preview validator: `{v1-legacy, v2-legacy, v2-group_effective}`
+ * accepted; everything else fail-closed. Guard order below is deliberately
+ * ONE early-return per named W7-R5 negative, so each design-lock-named
+ * reject category maps to exactly one guard (mutation-tested individually —
+ * see the PR body):
+ *
+ *  1. exact-key closure (own keys === `V2_CONTEXT_KEYS`, no extra/missing);
+ *  2. `schemaVersion` unknown (must be `1` or `2`);
+ *  3. `selector` unknown (must be `'legacy'` or `'group_effective'`);
+ *  4. v2-shape-with-v1-tag (`schemaVersion === 1` but `selector !== 'legacy'`
+ *     or `calculationGroupId !== null`);
+ *  5. `calculationGroupId` non-null while `selector === 'legacy'`
+ *     (schemaVersion-2 branch — schemaVersion-1 is already covered by guard 4);
+ *  6. `calculationGroupId` null/non-string while `selector === 'group_effective'`.
+ *
+ * NOT called from any production path (see file header). W7-1 wires this
+ * shape into the live `validateFrozenContextShape`.
+ */
+export function validateFrozenAttendanceContextV7DraftV1(context: unknown): boolean {
+  // Guard 1: exact-key closure.
+  if (!hasExactKeysV1(context, V2_CONTEXT_KEYS)) return false
+
+  const ctx = context as Record<string, unknown>
+
+  // Guard 2: schemaVersion unknown.
+  if (ctx.schemaVersion !== 1 && ctx.schemaVersion !== 2) return false
+
+  // Guard 3: selector unknown.
+  if (ctx.selector !== 'legacy' && ctx.selector !== 'group_effective') return false
+
+  // Guard 4: v2-shape-with-v1-tag.
+  if (ctx.schemaVersion === 1 && (ctx.selector !== 'legacy' || ctx.calculationGroupId !== null)) {
+    return false
+  }
+
+  // Guard 5: calculationGroupId must be null when selector is legacy (schemaVersion 2 branch;
+  // schemaVersion 1 + legacy + non-null calculationGroupId is already rejected by guard 4).
+  if (ctx.schemaVersion === 2 && ctx.selector === 'legacy' && ctx.calculationGroupId !== null) {
+    return false
+  }
+
+  // Guard 6: calculationGroupId must be a non-empty string when selector is group_effective.
+  if (
+    ctx.schemaVersion === 2 &&
+    ctx.selector === 'group_effective' &&
+    !isNonEmptyStringV1(ctx.calculationGroupId)
+  ) {
+    return false
+  }
+
+  // Remaining field-level sanity (out of OD-W7-2's discriminant scope but needed so a
+  // "valid" fixture is a plausible context, not just a discriminant-shaped stub).
+  if (!isNonEmptyStringV1(ctx.orgId) || !isNonEmptyStringV1(ctx.userId)) return false
+  if (!isNonEmptyStringV1(ctx.workDate)) return false
+  if (!isNonEmptyStringV1(ctx.timezone) || !isNonEmptyStringV1(ctx.shiftId)) return false
+  if (typeof ctx.isWorkday !== 'boolean') return false
+  if (ctx.holidayKind !== null && !isNonEmptyStringV1(ctx.holidayKind)) return false
+  if (!isNonNegativeIntegerV1(ctx.roundingMinutes) || (ctx.roundingMinutes as number) < 1) return false
+  if (!isNonNegativeIntegerV1(ctx.severeLateThresholdMinutes)) return false
+  if (!isNonNegativeIntegerV1(ctx.absenceLateThresholdMinutes)) return false
+  if (!Array.isArray(ctx.segments) || ctx.segments.length < 1 || ctx.segments.length > 3) return false
+  for (let i = 0; i < ctx.segments.length; i += 1) {
+    if (!validateSegmentV1(ctx.segments[i], i)) return false
+  }
+
+  return true
+}

--- a/packages/core-backend/src/attendance/w7-frozen-context-v2-contract.ts
+++ b/packages/core-backend/src/attendance/w7-frozen-context-v2-contract.ts
@@ -138,8 +138,14 @@ function validateSegmentV1(segment: unknown, index: number): boolean {
  * Contract-preview validator: `{v1-legacy, v2-legacy, v2-group_effective}`
  * accepted; everything else fail-closed. Guard order below is deliberately
  * ONE early-return per named W7-R5 negative, so each design-lock-named
- * reject category maps to exactly one guard (mutation-tested individually —
- * see the PR body):
+ * reject category maps to a guard. Mutation-tested individually in the PR
+ * body (each guard neutered, tests re-run, restored) — with one named
+ * exception: guard 1's "extra key" leg and null/undefined-input crash
+ * protection are load-bearing on guard 1 alone, but its "missing key" leg is
+ * independently caught by the field-level checks below too (deleting
+ * `timezone` still fails `isNonEmptyStringV1(ctx.timezone)` even with guard
+ * 1 disabled) — genuine defense-in-depth, not a gap, but not "guard 1 alone"
+ * either; recorded honestly rather than as a uniform claim:
  *
  *  1. exact-key closure (own keys === `V2_CONTEXT_KEYS`, no extra/missing);
  *  2. `schemaVersion` unknown (must be `1` or `2`);

--- a/packages/core-backend/src/attendance/w7-read-side-provenance-amendment.ts
+++ b/packages/core-backend/src/attendance/w7-read-side-provenance-amendment.ts
@@ -19,16 +19,10 @@
  * Two distinct enum families are in play (design-lock §4.4, stated to avoid
  * a spelling-ownership ambiguity): (i) the W6-owned source-label union
  * (OD-W6-3(a), `ATTENDANCE_GROUP_EFFECTIVE_POLICY_SOURCE_LABELS_V1`, defined
- * in the W6-1 contract module the W6 design lock's §1.2 file inventory
- * names — deliberately not spelled here as a literal filename: this file
- * lives under a root scanned by the existing
- * `tests/unit/attendance-w6-import-graph-no-calculation-consumer.test.ts`
- * text-marker guard, which reds on ANY file under
- * `packages/core-backend/src/attendance/` containing a `w6-*.ts` module-name
- * substring, comment or not) — W7 ADOPTS those spellings verbatim and mints
- * none of its own for that family, so this file does not touch it; (ii)
- * THIS file's family — the W7-owned provenance values on the existing W4
- * detail/trace enums.
+ * in the W6-1 contract module the W6 design lock's own §1.2 file inventory
+ * names) — W7 ADOPTS those spellings verbatim and mints none of its own for
+ * that family, so this file does not touch it; (ii) THIS file's family —
+ * the W7-owned provenance values on the existing W4 detail/trace enums.
  *
  * The two `import type` lines below are compile-time-only anchors (fully
  * erased by `tsc`; zero runtime `require`, zero byte-inertness impact) that
@@ -139,10 +133,10 @@ type AssertTraceSourceKindSyncV1 = AssertUnionEqualV1<
 // `currentMembers` snapshot being updated.
 const _assertTraceSourceKindSyncV1: AssertTraceSourceKindSyncV1 = true
 
-// Referenced only to keep the compile-time guards above from being reported
-// as "declared but never used" under a future stricter tsconfig; both are
-// otherwise inert (never imported).
-export const __w7ReadSideProvenanceSyncGuardsV1 = Object.freeze({
-  projectionOwnerSync: _assertProjectionOwnerSyncV1,
-  traceSourceKindSync: _assertTraceSourceKindSyncV1,
-} as const)
+// `void` reference only, so a future stricter tsconfig's "declared but never
+// read" check cannot flag the two guard constants above; the type-level
+// assertion is the whole point of each — no runtime value is meant to be
+// consumed. Not exported: these are internal self-checks, not part of this
+// module's contract surface.
+void _assertProjectionOwnerSyncV1
+void _assertTraceSourceKindSyncV1

--- a/packages/core-backend/src/attendance/w7-read-side-provenance-amendment.ts
+++ b/packages/core-backend/src/attendance/w7-read-side-provenance-amendment.ts
@@ -1,0 +1,142 @@
+/**
+ * W7 (#4556) OD-W7-5(a) — read-side provenance amendment: the exact NEW
+ * string values for the W7-owned provenance family on the existing W4
+ * detail/trace enums (design-lock §4.4, §7 OD-W7-5).
+ *
+ * Status: PROPOSED / runtime HOLD. `OD-W7-0..10` are OPEN owner decisions —
+ * see
+ * `docs/development/attendance-issue-4556-w7-group-policy-cutover-design-lock-20260807.md`
+ * §9. These strings are RECORDED here only; neither live enum named below is
+ * edited by this file. Widening either live closed set now would force
+ * every exhaustive consumer listed under it to handle the new value — that
+ * is exactly the "modifying a live enum consumed by an exhaustive check"
+ * case W7-R9 rules out of W7-0. Wiring these values into the live closed
+ * arrays/unions (and into every listed consumer) is W7-1's job.
+ *
+ * Basis: built on the design-lock's recommended OD-W7-5 option (a) shape.
+ * OD-W7-5 is OPEN — ratification pending, not assumed by this file.
+ *
+ * Two distinct enum families are in play (design-lock §4.4, stated to avoid
+ * a spelling-ownership ambiguity): (i) the W6-owned source-label union
+ * (OD-W6-3(a), `ATTENDANCE_GROUP_EFFECTIVE_POLICY_SOURCE_LABELS_V1`,
+ * `w6-group-effective-policy-contract.ts:25-30`) — W7 ADOPTS those
+ * spellings verbatim and mints none of its own for that family, so this file
+ * does not touch it; (ii) THIS file's family — the W7-owned provenance
+ * values on the existing W4 detail/trace enums.
+ *
+ * The two `import type` lines below are compile-time-only anchors (fully
+ * erased by `tsc`; zero runtime `require`, zero byte-inertness impact) that
+ * make the `currentMembers` snapshots below self-checking: if either live
+ * union drifts without this file being updated, `pnpm type-check` fails on
+ * the `_assert*SyncV1` constants near the bottom of this file, rather than
+ * this record silently going stale.
+ */
+import type { AttendanceDecisionTraceSourceKind } from '../services/AttendanceDecisionTrace'
+import type { AttendanceImportRollbackPresentPreimageFingerprintInputV1 } from './w4c3a-import-rollback'
+
+// ---------------------------------------------------------------------------
+// Target 1: `projectionOwner` — the W4C detail/import-rollback provenance
+// field.
+//
+// Current closed two-value set, independently validated at THREE separate
+// sites (each an exhaustive gate on its own — none of them is edited here):
+//   - `PROJECTION_OWNERS = ['legacy_untracked', 'w4'] as const`
+//     (`packages/core-backend/src/services/AttendanceW4CalculationDetail.ts:94`),
+//     checked via `isClosedValue(PROJECTION_OWNERS, row.projection_owner)`
+//     at `:428`;
+//   - `packages/core-backend/src/attendance/w4c3a-canonical-import-kernel.ts:368-370`
+//     (`projectionOwner !== 'legacy_untracked' && projectionOwner !== 'w4'`);
+//   - `packages/core-backend/src/attendance/w4c3a-import-rollback.ts:438-441,515-518`
+//     (same two-value exhaustive check, twice);
+//   - a DB CHECK-shaped predicate,
+//     `packages/core-backend/src/db/migrations/zzzz20260731120000_w4c3a_import_rollback_foundation.ts:328`
+//     (`... NOT IN ('legacy_untracked', 'w4') ...`).
+// The exported, non-widened type anchor is
+// `AttendanceImportRollbackPresentPreimageFingerprintInputV1['projectionOwner']`
+// (`w4c3a-import-rollback.ts:371`) — `AttendanceW4CalculationDetail.ts`'s own
+// public field is widened to `string` (`:420`) and cannot anchor a
+// compile-time equality check, though it shares the same runtime-validated
+// closed set via `PROJECTION_OWNERS`.
+// ---------------------------------------------------------------------------
+
+export const ATTENDANCE_W7_PROJECTION_OWNER_GROUP_VALUE_V1 = 'w4_group' as const
+
+// ---------------------------------------------------------------------------
+// Target 2: trace `source.kind` — `AttendanceDecisionTraceSourceKind`
+// (`packages/core-backend/src/services/AttendanceDecisionTrace.ts:102-108`,
+// current closed union: `'record' | 'snapshot' | 'rule_live' | 'ledger' |
+// 'audit' | 'policy_gate'`), the `kind` field of `AttendanceDecisionTraceSource`
+// (`:110-113`) embedded in every `AttendanceDecisionTraceBasisEnv.source`
+// (`:115-119`). Verified at W7-0 time (grep across `packages apps scripts`):
+// no exhaustive switch/Record currently keys off this type anywhere in the
+// tree — it is still recorded as a value amendment rather than a live edit,
+// both because W7-R9 requires it for W7-0 and because an exhaustive consumer
+// could land before W7-1 wires this value in.
+// ---------------------------------------------------------------------------
+
+export const ATTENDANCE_W7_TRACE_SOURCE_KIND_GROUP_VALUE_V1 = 'group_policy_snapshot' as const
+
+/**
+ * Bundled record for W7-1 to consume directly — still not imported by
+ * anything today (see file header). `currentMembers` is a point-in-time
+ * literal snapshot of each live closed set at the W7-0 baseline
+ * (`f364c7f9b3`); the paired test file re-derives target 2's set from the
+ * live exported TYPE at compile time (so a live union change fails `tsc`),
+ * and target 1's set from a live exported type anchor the same way — see
+ * `../__tests__/w7-read-side-provenance-amendment.test.ts`.
+ */
+export const ATTENDANCE_W7_READ_SIDE_PROVENANCE_AMENDMENT_V1 = Object.freeze({
+  projectionOwner: Object.freeze({
+    targetFile: 'packages/core-backend/src/services/AttendanceW4CalculationDetail.ts',
+    targetConst: 'PROJECTION_OWNERS',
+    currentMembers: Object.freeze(['legacy_untracked', 'w4'] as const),
+    newValue: ATTENDANCE_W7_PROJECTION_OWNER_GROUP_VALUE_V1,
+  }),
+  traceSourceKind: Object.freeze({
+    targetFile: 'packages/core-backend/src/services/AttendanceDecisionTrace.ts',
+    targetType: 'AttendanceDecisionTraceSourceKind',
+    currentMembers: Object.freeze(['record', 'snapshot', 'rule_live', 'ledger', 'audit', 'policy_gate'] as const),
+    newValue: ATTENDANCE_W7_TRACE_SOURCE_KIND_GROUP_VALUE_V1,
+  }),
+} as const)
+
+// ---------------------------------------------------------------------------
+// Compile-time sync guards. Non-distributive mutual-extends equality: for
+// literal-string unions A and B, `[A] extends [B]` (tuple-wrapped to block
+// distribution) is true iff every member of A is a member of B; checking
+// both directions proves the two unions are exactly equal, not merely
+// overlapping.
+// ---------------------------------------------------------------------------
+
+type AssertUnionEqualV1<A extends string, B extends string> = [A] extends [B]
+  ? [B] extends [A]
+    ? true
+    : false
+  : false
+
+type ProjectionOwnerLiveUnionV1 = AttendanceImportRollbackPresentPreimageFingerprintInputV1['projectionOwner']
+type ProjectionOwnerRecordedUnionV1 =
+  (typeof ATTENDANCE_W7_READ_SIDE_PROVENANCE_AMENDMENT_V1)['projectionOwner']['currentMembers'][number]
+type AssertProjectionOwnerSyncV1 = AssertUnionEqualV1<ProjectionOwnerLiveUnionV1, ProjectionOwnerRecordedUnionV1>
+// If this fails to compile, `w4c3a-import-rollback.ts`'s `projectionOwner`
+// union moved without this file's `currentMembers` snapshot being updated.
+const _assertProjectionOwnerSyncV1: AssertProjectionOwnerSyncV1 = true
+
+type TraceSourceKindRecordedUnionV1 =
+  (typeof ATTENDANCE_W7_READ_SIDE_PROVENANCE_AMENDMENT_V1)['traceSourceKind']['currentMembers'][number]
+type AssertTraceSourceKindSyncV1 = AssertUnionEqualV1<
+  AttendanceDecisionTraceSourceKind,
+  TraceSourceKindRecordedUnionV1
+>
+// If this fails to compile, `AttendanceDecisionTrace.ts`'s
+// `AttendanceDecisionTraceSourceKind` union moved without this file's
+// `currentMembers` snapshot being updated.
+const _assertTraceSourceKindSyncV1: AssertTraceSourceKindSyncV1 = true
+
+// Referenced only to keep the compile-time guards above from being reported
+// as "declared but never used" under a future stricter tsconfig; both are
+// otherwise inert (never imported).
+export const __w7ReadSideProvenanceSyncGuardsV1 = Object.freeze({
+  projectionOwnerSync: _assertProjectionOwnerSyncV1,
+  traceSourceKindSync: _assertTraceSourceKindSyncV1,
+} as const)

--- a/packages/core-backend/src/attendance/w7-read-side-provenance-amendment.ts
+++ b/packages/core-backend/src/attendance/w7-read-side-provenance-amendment.ts
@@ -18,11 +18,17 @@
  *
  * Two distinct enum families are in play (design-lock §4.4, stated to avoid
  * a spelling-ownership ambiguity): (i) the W6-owned source-label union
- * (OD-W6-3(a), `ATTENDANCE_GROUP_EFFECTIVE_POLICY_SOURCE_LABELS_V1`,
- * `w6-group-effective-policy-contract.ts:25-30`) — W7 ADOPTS those
- * spellings verbatim and mints none of its own for that family, so this file
- * does not touch it; (ii) THIS file's family — the W7-owned provenance
- * values on the existing W4 detail/trace enums.
+ * (OD-W6-3(a), `ATTENDANCE_GROUP_EFFECTIVE_POLICY_SOURCE_LABELS_V1`, defined
+ * in the W6-1 contract module the W6 design lock's §1.2 file inventory
+ * names — deliberately not spelled here as a literal filename: this file
+ * lives under a root scanned by the existing
+ * `tests/unit/attendance-w6-import-graph-no-calculation-consumer.test.ts`
+ * text-marker guard, which reds on ANY file under
+ * `packages/core-backend/src/attendance/` containing a `w6-*.ts` module-name
+ * substring, comment or not) — W7 ADOPTS those spellings verbatim and mints
+ * none of its own for that family, so this file does not touch it; (ii)
+ * THIS file's family — the W7-owned provenance values on the existing W4
+ * detail/trace enums.
  *
  * The two `import type` lines below are compile-time-only anchors (fully
  * erased by `tsc`; zero runtime `require`, zero byte-inertness impact) that

--- a/packages/core-backend/src/attendance/w7-w6r5-guard-root-set.ts
+++ b/packages/core-backend/src/attendance/w7-w6r5-guard-root-set.ts
@@ -68,8 +68,11 @@ export const ATTENDANCE_W7_W6R5_GUARD_ROOTS_V1: readonly AttendanceW7GuardRootV1
       '(buildW4ShadowFrozenContextV1 def index.cjs:22625, literal :22740-22750; ' +
       'resolveW4LiveCandidateInTransactionV1 / resolveW4ScheduledCandidateInTransactionV1 ' +
       'index.cjs:22593-22620), plus the W3 shift-service capability flag ' +
-      '(attendance-shift-service.cjs:60,495,1208) and the single FSER derivation ' +
-      '(attendance-group-fixed-schedule-effectiveness-service.cjs:71,180). Under OD-W7-9 ' +
+      '(attendance-shift-service.cjs:60,495,1208) and the single fixed-schedule-effectiveness ' +
+      'derivation service (the FSER lib the design-lock §1.2 names — deliberately not spelled ' +
+      "as a literal module filename here: doing so would trip the existing repo-wide guard, " +
+      '`tests/unit/attendance-w6-fser-single-source-caller-inventory.test.ts`, which fails ANY ' +
+      "non-allowlisted file that contains that module's path string). Under OD-W7-9 " +
       "REPLACE (the design-lock's exposed slice-boundary reading, §7), the posture branch " +
       'sits immediately upstream of this builder; under LAYER-ONTO it sits inside this ' +
       "builder's own seam. Either way this root is where a group-policy reference or an " +
@@ -83,10 +86,13 @@ export const ATTENDANCE_W7_W6R5_GUARD_ROOTS_V1: readonly AttendanceW7GuardRootV1
       'Every landed W4C machinery module the design-lock §1.3/§2.2 lists as reused-not-redefined ' +
       '(rollout control, w4c0 posture minting, zero-bypass inventory, request-snapshot 8-cell ' +
       'precondition, w4c4 shadow ledger/detail, w4c2 outbox and scheduled-run identity, manual ' +
-      'override/recompute) lives here, alongside this W7-0 contract module set itself and the W6 ' +
-      'types-only contract module (w6-group-effective-policy-contract.ts) that a resolver could, ' +
-      'incorrectly, import as a live dependency instead of reading persisted facts directly ' +
-      '(the exact W6-R5/W7-R10 violation this guard exists to catch).',
+      'override/recompute) lives here, alongside this W7-0 contract module set itself and the W6-1 ' +
+      "types-only contract module (see the W6 design lock's own §1.2 file inventory) that a " +
+      'resolver could, incorrectly, import as a live dependency instead of reading persisted facts ' +
+      'directly (the exact W6-R5/W7-R10 violation this guard exists to catch — deliberately not ' +
+      "spelling that module's filename literally in THIS file: doing so would itself trip the " +
+      'existing text-marker guard, `tests/unit/attendance-w6-import-graph-no-calculation-consumer.test.ts`, ' +
+      'which scans every file under this very root for any `w6-*.ts` module-name substring).',
     presentAtW7Zero: true,
   } as const),
   Object.freeze({

--- a/packages/core-backend/src/attendance/w7-w6r5-guard-root-set.ts
+++ b/packages/core-backend/src/attendance/w7-w6r5-guard-root-set.ts
@@ -1,0 +1,108 @@
+/**
+ * W7 (#4556) W6-R5 preservation guard — ROOT SET record only (W7-R10).
+ *
+ * Status: PROPOSED / runtime HOLD. `OD-W7-0..10` are OPEN owner decisions —
+ * see
+ * `docs/development/attendance-issue-4556-w7-group-policy-cutover-design-lock-20260807.md`
+ * §3 row W7-R10, §9.
+ *
+ * This module pins the DIRECTORY ROOTS the future W6-R5-preservation guard
+ * will walk, and the reason each root is pinned. It is NOT the guard itself:
+ * there is no directory walk here, no file classification, no
+ * `unclaimed = 0` assertion, no reference-ban / transport-ban check. That
+ * guard — Leg 0 completeness, the non-empty-domain leg, Leg (i) reference
+ * ban, Leg (ii) transport ban — lands at **W7-1**, the first head at which
+ * the W7 resolver's own directory (root 3 below) actually exists.
+ *
+ * Why the walking guard cannot land here: W7-R10's non-empty-domain leg
+ * ("a pinned root resolving to zero files reds the guard, because a
+ * mistyped, moved, or not-yet-created root would otherwise satisfy
+ * `unclaimed = 0` vacuously") would red on THIS root set at the W7-0
+ * baseline (`f364c7f9b3`), because the design-lock's own §1.4 states plainly
+ * "There is no group-policy -> frozen-context resolver anywhere in the
+ * tree; no candidate implementation exists to 'migrate'" — root 3 resolves
+ * to zero files today, by construction, until W7-1 creates it. Landing the
+ * walking guard in W7-0 would therefore either (a) red on a root that is
+ * supposed to be empty right now, which is not a real defect, or (b) omit
+ * root 3 to keep W7-0 green, which reproduces exactly the same shape as
+ * W7-R10's stated defect (a root nobody's guard actually covers). Recording
+ * the root set now, with `presentAtW7Zero` on each entry, lets W7-1's
+ * non-empty-domain leg key off this record instead of re-deriving which
+ * roots are "new" versus "already real".
+ *
+ * Pinning ROOTS, not a file list, is the shape W7-R10 requires — deliberately
+ * mirroring the P16 DML inventory's DERIVED scan domain
+ * (`discoverRuntimeRoots` -> `listAllFiles` -> `isScannablePath`,
+ * `scripts/attendance/w4c0-dml-inventory/collector.cjs:53,104,574,807-823`),
+ * not P16's exact-allowlist CLAIM side
+ * (`scripts/attendance/w4c0-dml-inventory/curated-debt-entries.cjs:74`). A
+ * hand-maintained file list is the exact defect an earlier draft of the
+ * W7-R10 row had: "a helper module outside the list walked straight
+ * through it."
+ */
+
+export interface AttendanceW7GuardRootV1 {
+  /** Directory glob root — NOT an individual file path. Walked recursively
+   *  by the (future, W7-1) guard under a scannable-extension filter. */
+  readonly root: string
+  /** Why this root is in the walked domain (W7-R10 Leg 0 completeness). */
+  readonly reason: string
+  /**
+   * Whether this root already contains any files at the W7-0 baseline
+   * (`origin/main@f364c7f9b3`). W7-1's non-empty-domain leg must assert
+   * `true` for every root before `unclaimed = 0` can mean anything; this
+   * field lets that assertion key off a recorded fact rather than
+   * re-deriving it, and flags which root is EXPECTED to flip from `false`
+   * to `true` exactly when W7-1 lands (the resolver directory itself).
+   * Recorded as a point-in-time fact about the W7-0 baseline, not a claim
+   * about any later commit.
+   */
+  readonly presentAtW7Zero: boolean
+}
+
+export const ATTENDANCE_W7_W6R5_GUARD_ROOTS_V1: readonly AttendanceW7GuardRootV1[] = Object.freeze([
+  Object.freeze({
+    root: 'plugins/plugin-attendance/**',
+    reason:
+      'The legacy production frozen-context builder and per-user resolvers live here ' +
+      '(buildW4ShadowFrozenContextV1 def index.cjs:22625, literal :22740-22750; ' +
+      'resolveW4LiveCandidateInTransactionV1 / resolveW4ScheduledCandidateInTransactionV1 ' +
+      'index.cjs:22593-22620), plus the W3 shift-service capability flag ' +
+      '(attendance-shift-service.cjs:60,495,1208) and the single FSER derivation ' +
+      '(attendance-group-fixed-schedule-effectiveness-service.cjs:71,180). Under OD-W7-9 ' +
+      "REPLACE (the design-lock's exposed slice-boundary reading, §7), the posture branch " +
+      'sits immediately upstream of this builder; under LAYER-ONTO it sits inside this ' +
+      "builder's own seam. Either way this root is where a group-policy reference or an " +
+      'HTTP call to the W6 aggregate route could land on the plugin side, so it stays in the ' +
+      'walked domain regardless of which OD-W7-9 branch W7-1 implements.',
+    presentAtW7Zero: true,
+  } as const),
+  Object.freeze({
+    root: 'packages/core-backend/src/attendance/**',
+    reason:
+      'Every landed W4C machinery module the design-lock §1.3/§2.2 lists as reused-not-redefined ' +
+      '(rollout control, w4c0 posture minting, zero-bypass inventory, request-snapshot 8-cell ' +
+      'precondition, w4c4 shadow ledger/detail, w4c2 outbox and scheduled-run identity, manual ' +
+      'override/recompute) lives here, alongside this W7-0 contract module set itself and the W6 ' +
+      'types-only contract module (w6-group-effective-policy-contract.ts) that a resolver could, ' +
+      'incorrectly, import as a live dependency instead of reading persisted facts directly ' +
+      '(the exact W6-R5/W7-R10 violation this guard exists to catch).',
+    presentAtW7Zero: true,
+  } as const),
+  Object.freeze({
+    root: 'packages/core-backend/src/attendance/w7-resolver/**',
+    reason:
+      "The OD-W7-1(a) in-transaction group-policy resolver's own future directory — the single " +
+      'most direct place a W6-aggregate module reference or an HTTP call to its route could land, ' +
+      'so it must be in the walked domain from the moment it exists, not added as an afterthought. ' +
+      'Does not exist at the W7-0 baseline (design-lock §1.4: "no group-policy -> frozen-context ' +
+      'resolver anywhere in the tree"); this is a NAMED PLACEHOLDER path, not a ratified directory ' +
+      "layout decision — if W7-1 instead lands the resolver as a flat file directly under root 2 " +
+      "above (matching every existing w4cN module's own flat-file convention), this entry becomes " +
+      'redundant with root 2 and can be dropped without narrowing the walked domain. Recorded now ' +
+      "only because the design-lock's W7-R10 row names a third, distinct root; the exact string is " +
+      "provisional, the ROOT-not-FILE-LIST discipline and the reason for pinning a third root are " +
+      'not.',
+    presentAtW7Zero: false,
+  } as const),
+] as const)

--- a/packages/core-backend/src/attendance/w7-w6r5-guard-root-set.ts
+++ b/packages/core-backend/src/attendance/w7-w6r5-guard-root-set.ts
@@ -69,10 +69,7 @@ export const ATTENDANCE_W7_W6R5_GUARD_ROOTS_V1: readonly AttendanceW7GuardRootV1
       'resolveW4LiveCandidateInTransactionV1 / resolveW4ScheduledCandidateInTransactionV1 ' +
       'index.cjs:22593-22620), plus the W3 shift-service capability flag ' +
       '(attendance-shift-service.cjs:60,495,1208) and the single fixed-schedule-effectiveness ' +
-      'derivation service (the FSER lib the design-lock §1.2 names — deliberately not spelled ' +
-      "as a literal module filename here: doing so would trip the existing repo-wide guard, " +
-      '`tests/unit/attendance-w6-fser-single-source-caller-inventory.test.ts`, which fails ANY ' +
-      "non-allowlisted file that contains that module's path string). Under OD-W7-9 " +
+      'derivation service (the FSER lib the design-lock §1.2 names). Under OD-W7-9 ' +
       "REPLACE (the design-lock's exposed slice-boundary reading, §7), the posture branch " +
       'sits immediately upstream of this builder; under LAYER-ONTO it sits inside this ' +
       "builder's own seam. Either way this root is where a group-policy reference or an " +
@@ -89,10 +86,7 @@ export const ATTENDANCE_W7_W6R5_GUARD_ROOTS_V1: readonly AttendanceW7GuardRootV1
       'override/recompute) lives here, alongside this W7-0 contract module set itself and the W6-1 ' +
       "types-only contract module (see the W6 design lock's own §1.2 file inventory) that a " +
       'resolver could, incorrectly, import as a live dependency instead of reading persisted facts ' +
-      'directly (the exact W6-R5/W7-R10 violation this guard exists to catch — deliberately not ' +
-      "spelling that module's filename literally in THIS file: doing so would itself trip the " +
-      'existing text-marker guard, `tests/unit/attendance-w6-import-graph-no-calculation-consumer.test.ts`, ' +
-      'which scans every file under this very root for any `w6-*.ts` module-name substring).',
+      'directly (the exact W6-R5/W7-R10 violation this guard exists to catch).',
     presentAtW7Zero: true,
   } as const),
   Object.freeze({


### PR DESCRIPTION
## Summary

W7-0 (issue #4556, W7 group-policy calculation cutover) — a **byte-inert
contracts/fixtures preparation PR**, per the standing "W7-0..4 开发至独立门后停下"
authorization. Governing spec:
`docs/development/attendance-issue-4556-w7-group-policy-cutover-design-lock-20260807.md`
(§2.1, §4.2, §4.4, §5, OD-W7-2/3/5, red lines W7-R9 + W7-R10).

**Basis / ratification status**: built on the design-lock's recommended-first
(a) option for OD-W7-2, OD-W7-3, and OD-W7-5 (§7 lists (a) first for each of
those). For **OD-W7-9** (REPLACE vs LAYER) and **OD-W7-10** ((a) vs (b)), §7
recommends **NEITHER** — it states in both rows that "the choice is the owner's,
not a default this document offers" — so this PR **takes no position** on them
and asserts no suggestion of either: the four artifacts are **branch-neutral**
(the guard-root-set covers both OD-W7-9 branches even-handedly, and no contract
here depends on either resolution). **`OD-W7-0..10` remain OPEN — ratification
pending (`OD-W7-0=ADOPT` is the owner's unmade act).** Nothing in this PR (file,
fixture, comment, or this body) asserts any OD decision is ratified,
owner-instructed, or owner-suggested; every "ratification pending" sentence sits
next to the OD it qualifies (see the grep self-check below).

Gated at base `f364c7f9b3`. Sibling PR #4896 (Gate E) is verified disjoint —
`gh pr view 4896 --json files` lists `.github/workflows/plugin-tests.yml`;
four `packages/core-backend/src/attendance/__tests__/w4c3a-*` /
`w4c3b-*` test files (different basenames than the four this PR adds);
`w4c0-operation-registry.ts`, `w4c2-outbox-dispatcher.ts`,
`w4c3a-legacy-plan-reservation-host.ts`; `packages/core-backend/tests/**`
helper/integration/unit files; `packages/core-backend/vitest.config.ts`
(adds one new exclusion entry for its own new integration test — additive,
non-conflicting); `plugins/plugin-integration-core/.../s6a-package-provenance-pins.json`;
and `scripts/ops/attendance-w4c2-ci-wiring.test.mjs`. None of those paths
match this PR's 8 files, and neither of the two W6-R4/W6-R5 guard files this
PR had to work around appears in #4896's set either. After a sibling lands,
this PR needs only a CI re-run on the new main — no rebase conflict
expected, and the gate verdict carries forward if the rebase delta is empty.
(A future Gate D is unopened at time of writing; disjointness cannot be
verified against it yet.)

## The four contract artifacts

1. **Context-source state machine + two-part posture-read contract**
   (`packages/core-backend/src/attendance/w7-context-source-posture-contract.ts`)
   — OD-W7-3(a)'s five states (`off, group_shadow, group_eligible,
   group_authoritative, suspended`) and the closed seven-pair legal-transition
   matrix (off↔group_shadow, group_shadow↔group_eligible,
   group_eligible→group_authoritative, group_authoritative↔suspended;
   everything else illegal — matching §4.2/§5.2/§5.3 verbatim). **Also**
   records the TWO-PART posture-READ contract per §4.2: a pure decision
   function requiring BOTH a persisted-row state AND
   `implementationCapability && orgExactlyAllowlisted` — cloned from the
   *shape* of `resolveSegmentCalculationPosture`
   (`w4c0-identity.ts:454`, allowlist check `:478-482`), not the
   transition-writer discipline alone. `suspended` is honored unconditionally
   (cannot be evaded by capability/allowlist in either direction), matching
   the W4 machine's own asymmetry.

2. **Frozen-context v2 type + validation-contract fixture**
   (`packages/core-backend/src/attendance/w7-frozen-context-v2-contract.ts`)
   — OD-W7-2(a)'s `FrozenAttendanceContextV2` type (`schemaVersion: 2`,
   discriminated `selector: 'legacy' | 'group_effective'`,
   `calculationGroupId` non-null iff `group_effective`), plus a
   contract-preview validator accepting exactly `{v1-legacy, v2-legacy,
   v2-group_effective}` and fail-closing on: unknown `selector`, unknown
   `schemaVersion`, v2-shape-with-v1-tag, and `calculationGroupId`/`selector`
   mismatch in both directions — plus the exact-key closure legs (extra key,
   missing key) W7-R5 also names. **v1 stays byte-identical**: the live
   `w4c1-segment-calculator.ts` validator and `w4c0-write-boundary-types.ts`
   are untouched (verified below); this is a wholly separate, standalone
   module, not a v1 edit.

3. **OD-W7-5(a) read-side provenance amendment strings**
   (`packages/core-backend/src/attendance/w7-read-side-provenance-amendment.ts`)
   — the exact new string values: `'w4_group'` for `projectionOwner`
   (currently `'legacy_untracked' | 'w4'`), `'group_policy_snapshot'` for the
   detail/trace `source.kind` union (`AttendanceDecisionTraceSourceKind`,
   currently `'record'|'snapshot'|'rule_live'|'ledger'|'audit'|'policy_gate'`).
   Recorded as **fixed consts, not live-enum edits** — widening either live
   closed set would force every exhaustive consumer to handle the new value
   (see the "untouchable list" below), which is exactly the non-inert case
   W7-R9 rules out of W7-0. Both target unions are anchored with
   `import type`-only compile-time equality assertions
   (`AssertUnionEqualV1<...>`), so `pnpm type-check` fails if either live
   union drifts without this record being updated — a real, mechanical sync
   guard rather than a stale comment.

4. **W6-R5 guard ROOT SET (W7-R10)**
   (`packages/core-backend/src/attendance/w7-w6r5-guard-root-set.ts`) — three
   pinned directory **roots** (`plugins/plugin-attendance/**`,
   `packages/core-backend/src/attendance/**`, and a placeholder
   `packages/core-backend/src/attendance/w7-resolver/**` for the future
   resolver directory) with the reason each is pinned, plus a
   `presentAtW7Zero` fact per root (`true, true, false` — the resolver root
   does not exist yet, per design-lock §1.4). **Roots, not a file list** —
   pinning a hand-maintained file list is the exact W7-R10 defect an earlier
   draft had. The walking guard itself (Leg 0 completeness, the
   non-empty-domain leg, reference-ban, transport-ban) is **not** in this PR
   — it lands at W7-1, the first head where the resolver root is real (a
   walking guard landed now would either red on a root that is *supposed* to
   be empty today, or omit that root to stay green, both of which reproduce
   W7-R10's own stated defect). The paired test file asserts declaration
   shape only (uniqueness, non-empty reasons, glob-not-file form, the
   `presentAtW7Zero` split) — it does **not** touch the filesystem.

## Byte-inert / deletion-green evidence

`git diff --name-status f364c7f9b3 HEAD -- packages plugins apps scripts .github`:

```
A	packages/core-backend/src/attendance/__tests__/w7-context-source-posture-contract.test.ts
A	packages/core-backend/src/attendance/__tests__/w7-frozen-context-v2-contract.test.ts
A	packages/core-backend/src/attendance/__tests__/w7-read-side-provenance-amendment.test.ts
A	packages/core-backend/src/attendance/__tests__/w7-w6r5-guard-root-set.test.ts
A	packages/core-backend/src/attendance/w7-context-source-posture-contract.ts
A	packages/core-backend/src/attendance/w7-frozen-context-v2-contract.ts
A	packages/core-backend/src/attendance/w7-read-side-provenance-amendment.ts
A	packages/core-backend/src/attendance/w7-w6r5-guard-root-set.ts
```

Only `A` entries, zero `M`/`D` — no runtime wiring anywhere in `packages
plugins apps scripts .github`.

**Deletion-green run** (recorded live, not simulated): the 8 files were
backed up with `cp` (never `git checkout --`), physically deleted from the
working tree, and the deletion **staged** with `git add` — necessary because
two pre-existing repo-wide guards
(`tests/unit/attendance-w6-fser-single-source-caller-inventory.test.ts`,
`tests/unit/attendance-w6-import-graph-no-calculation-consumer.test.ts`) list
files via `git ls-files --cached` (the index), not the working tree; a
plain `rm` alone leaves the index stale and crashes those two suites with
`ENOENT` rather than giving a fair signal. With the deletion staged:

- `pnpm --filter @metasheet/core-backend test` (the exact CI `test (20.x)`
  command): **622 test files / 8995 tests passed, 0 failed** — down from the
  full-tree baseline of 626 files / 9036 tests by exactly the 4 removed test
  files and their 41 tests (13+16+4+8), nothing else moved.
- `pnpm exec tsc --noEmit`: clean.
- `node --test scripts/ops/attendance-w4c0-dml-inventory-collector.test.mjs`
  (the P16 zero-bypass DML inventory gate, which scans
  `packages/core-backend/src/attendance/**` — one of the roots these files
  land under): **58/58 passed**, `unclaimed=0` — these files contain no DML.

Files were then restored via `cp` from the backups and re-staged with
`git add -A`; `git diff --stat HEAD` was empty both times (working tree
byte-identical to the commit both before deletion and after restore). The
full suite was re-run afterward and is green again: **626 files / 9036
tests passed, 0 failed.**

## Mutation evidence (guards neutered one at a time, `cp`-restored, never `git checkout --`)

**Two-part posture-read contract** (`resolveAttendanceW7ContextSourcePostureFromPartsV1`):
`implementationCapability && orgExactlyAllowlisted` mutated to `||`. Result:
**exactly 2 of 13** tests in that spec reddened — "row alone (capability
false) is insufficient" and "row + capability without exact allowlist is
insufficient" — both flipping from `'off'` to advertising the persisted
state. All 11 others (including both `suspended`-always-honored legs and the
three "all-true advertises the state" legs) stayed green. Confirms the AND
is load-bearing on both sides, not just one.

**Frozen-context v2 validator** (`validateFrozenAttendanceContextV7DraftV1`),
each of its 6 guards neutered independently (`if (false && <original
condition>) return false`), one at a time, restored between each:

| Guard | Neutered condition | Result |
| --- | --- | --- |
| 1 (exact-key closure) | `!hasExactKeysV1(context, V2_CONTEXT_KEYS)` | **3 of 16 red**: "extra key" leg (assertion failure, `true` vs expected `false`) plus the `null` and `undefined` non-object-input legs — those two now **throw** `TypeError: Cannot read properties of null/undefined` instead of returning `false`, because guard 1 was the only thing rejecting non-plain-object input before property access. The "missing key" leg (deleted `timezone`) stayed green — independently caught downstream by `isNonEmptyStringV1(ctx.timezone)` on the now-`undefined` field. The `'string'`/`42`/`[]`/`true` non-object legs also stayed green (primitive property access doesn't throw; `ctx.schemaVersion` reads `undefined`, caught by guard 2). Recorded honestly as **partial**, not a uniform 1:1 mapping — the docstring above was corrected to say so. |
| 2 (`schemaVersion` unknown) | `ctx.schemaVersion !== 1 && ctx.schemaVersion !== 2` | **exactly 1 of 16 red**: "rejects unknown schemaVersion" only. |
| 3 (`selector` unknown) | `ctx.selector !== 'legacy' && ctx.selector !== 'group_effective'` | **exactly 1 of 16 red**: "rejects unknown selector" only. |
| 4 (v2-shape-with-v1-tag) | `ctx.schemaVersion === 1 && (ctx.selector !== 'legacy' \|\| ctx.calculationGroupId !== null)` | **exactly 1 of 16 red**: "rejects v2-shape-with-v1-tag" only. |
| 5 (`calculationGroupId` non-null while `selector=legacy`) | `ctx.schemaVersion === 2 && ctx.selector === 'legacy' && ctx.calculationGroupId !== null` | **exactly 1 of 16 red**: "rejects calculationGroupId non-null while selector=legacy" only. |
| 6 (`calculationGroupId` null/non-string while `selector=group_effective`) | the length-3 conjunction guarding that case | **exactly 1 of 16 red**: "rejects calculationGroupId null while selector=group_effective" only. |

Every restore was verified with `git diff --stat HEAD -- <file>` (empty) and
a re-run confirming the full spec file back to 16/16 (or 13/13) green before
moving to the next guard. Guards 2/3/4/5/6 are cleanly single-guard/single-leg;
guard 1 is defense-in-depth on one leg and sole-coverage on three others —
both facts are now stated in the validator's own docstring, not just here.

## v1 unmoved — three separate facts, not one

1. `git diff --exit-code f364c7f9b3 HEAD -- packages/core-backend/src/attendance/__tests__/w4c1-fingerprint-golden.test.ts packages/core-backend/src/attendance/w4c0-fingerprints.ts packages/core-backend/src/attendance/w4c1-fingerprints.ts packages/core-backend/src/attendance/w4c0-write-boundary-types.ts packages/core-backend/src/attendance/w4c1-segment-calculator.ts` — **empty diff** (none of these files, nor the literals they pin, moved).
2. `pnpm --filter @metasheet/core-backend exec vitest run src/attendance/__tests__/w4c1-fingerprint-golden.test.ts src/attendance/__tests__/w4c0-identity.test.ts` — **48/48 passed**, `GOLDEN_STORAGE_FINGERPRINT` and the other three frozen literals unchanged.
3. `w7-frozen-context-v2-contract.ts` is a wholly separate, standalone module — it does not import from, re-export, or modify `w4c1-segment-calculator.ts`'s `validateFrozenContextShape`; the live calculator still only accepts `schemaVersion===1, selector==='legacy'`.

## Untouched live enums (the byte-inert argument, made concrete)

Widening any of these now — instead of recording the new values separately,
as this PR does — would force every listed exhaustive consumer to handle the
new value, which is not inert:

- `PROJECTION_OWNERS` (`AttendanceW4CalculationDetail.ts:94`, checked at
  `:428`) — also independently checked at
  `w4c3a-canonical-import-kernel.ts:368-370`,
  `w4c3a-import-rollback.ts:438-441,515-518`, and a DB `CHECK`-shaped
  predicate (`...zzzz20260731120000_w4c3a_import_rollback_foundation.ts:328`).
- `AttendanceDecisionTraceSourceKind` (`AttendanceDecisionTrace.ts:102-108`).
- `validateFrozenContextShape` / `CONTEXT_KEYS`
  (`w4c1-segment-calculator.ts`), `w4c0-write-boundary-types.ts`.

None of these files appear in the diff above.

## A guard collision found and fixed while validating this PR

The first commit's prose named the FSER module filename and the W6 aggregate
contract module's filename directly in comments, which — because those two
files live under `packages/core-backend/src/attendance/**`, a root both
pre-existing guards scan for the exact literal substring anywhere in-tree —
tripped `attendance-w6-fser-single-source-caller-inventory.test.ts` (W6-R4)
and `attendance-w6-import-graph-no-calculation-consumer.test.ts` (W6-R5). A
second commit rephrases both mentions to describe the target modules without
spelling their literal filenames (pointing at the design-lock section instead
where a human reader needs the exact name). This is recorded here rather than
silently squashed away, since it's direct evidence the full suite was
actually run, not assumed green.

## Second round: three corrections from independent review

An adversarial pass over the first two commits caught three defects, fixed
in a third commit before this PR was handed off:

1. `w7-read-side-provenance-amendment.test.ts` claimed `pnpm type-check`
   does NOT exclude `__tests__` from its scope — the opposite of what
   `packages/core-backend/tsconfig.json`'s own `exclude` list says (and the
   opposite of the reasoning that put the real compile-time sync guards in
   the *source* module in the first place). Fixed: the comment now states
   the true reason those guards live in the source file, and that this
   test's own assertions are a runtime-value echo only. This got a witnessed
   proof for free, not just a stated one: while drafting the fixed wording, a
   stray `**/*.test.ts` glob written literally inside a JSDoc block comment
   closed the comment early (the embedded `*/`) and broke the file's syntax —
   `vitest` failed the whole file with an esbuild transform error (0 tests
   collected) while `pnpm exec tsc --noEmit` stayed clean throughout, because
   `tsconfig.json` never looked at this file at all. That asymmetry — a
   syntax error type-check can't see — is direct empirical evidence for the
   exclusion claim, not just the documented one.
2. The first round's guard-collision rephrasing left the *reason* for
   withholding a filename ("doing so would trip the existing guard...")
   inside permanent tree files — a documented bypass recipe a reviewer
   would reasonably question, in files that can't answer "is the guard
   wrong or is this file wrong" (editing the guards' allowlists was never
   an option: that would add `M` entries and break the zero-`M`/`D` claim
   above). Removed from `w7-w6r5-guard-root-set.ts` (roots 1/2) and
   `w7-read-side-provenance-amendment.ts`'s header; the collision narrative
   stays here, in this PR body, for a reviewer, not as a standing
   instruction to future authors in the tree.
3. `w7-context-source-posture-contract.ts` overclaimed the seven-pair legal
   matrix is "not conditional on OD-W7-4 either way" — `off` is this
   machine's own legacy-sourcing state, so an OD-W7-4 (b) ruling would
   plausibly add an edge *into* `off`. Corrected: the table records only
   today's seven pairs, not a closure claim over that still-open decision.

Re-verified after the fix: `pnpm exec tsc --noEmit` clean; the two
pre-existing W6-R4/W6-R5 guards plus all four new spec files green
(**59/59**); full core-backend suite green again (**626 files / 9036
tests, 0 failed**); `git diff --name-status f364c7f9b3 HEAD -- packages
plugins apps scripts .github` still exactly the same 8 `A` entries, zero
`M`/`D`. (The already-recorded deletion-green run above was not repeated —
it is independent of comment content, so that evidence still stands.)

## Third round: mutation-coverage overclaim corrected

The v2 validator's docstring claimed all six guards were individually
mutation-tested with a uniform 1:1 leg mapping, before that mutation work
had actually been done for five of the six (only guard 4 had been run at
that point) and before the finding above (guard 1 is partial, not uniform)
existed. Fixed by actually running the remaining four guard mutations (see
"Mutation evidence" above) and correcting the docstring to state guard 1's
partial coverage precisely rather than folding it into a blanket claim.
Re-verified: `tsc --noEmit` clean; full suite green (626/9036); diff scope
unchanged (still the same 8 `A` entries).

**Fourth round**: the paired spec file's own header carried the identical
"each leg maps to exactly one guard" claim, unedited when the source
docstring above was fixed — third occurrence of the same defect class
(false/overclaiming self-description left uncorrected in a sibling file).
Fixed in `w7-frozen-context-v2-contract.test.ts`'s header to separate the
(true, load-bearing) single-field-fixture discipline from the (now-accurate)
guard-mapping claim. Re-verified: that spec file alone 16/16 (comment edits
broke this exact file's syntax once already in round 2, so this run isn't
ceremonial); `tsc --noEmit` clean; full suite green (626/9036); diff scope
unchanged.

## Scope of verification (what ran, what didn't, and why)

- `pnpm exec tsc --noEmit` — run **inside `packages/core-backend`** (package-level),
  not the root `pnpm -r type-check` (which recurses over all 13 workspace
  packages). The root command was **not run**. Reason it's safe to skip: none
  of the 8 new files is imported by, or re-exported from, `packages/core-backend/src/index.ts`
  or any other package's source — they have no consumers outside their own
  paired test files — so no other package's type-check pass can be affected
  by this diff.
- `pnpm lint` (root, `pnpm -r lint`) **was** run — it recurses correctly
  (12 of 13 workspace projects; only `apps/web` defines a `lint` script,
  and it ran clean, unaffected since this PR touches nothing under `apps/web`).
- **Zero files under `apps/web` were added or modified** by this PR (see the
  `git diff --name-status` list above — every entry is under
  `packages/core-backend/src/attendance/`). `attendance-web-guard.yml`'s
  path filters are therefore inapplicable to this PR by construction, not by
  an unstated assumption.

## Ratification-pending self-check

`rg -io "(close[sd]?|fix(es|ed)?|resolve[sd]?) #?[0-9]+"` over this PR body:
no hits — refs #4556, not a closing keyword. `grep -inE
"ratif|owner-instructed|adopted|authoriz"` over all 4 new source files: every
hit reads "OPEN — ratification pending" or "not a ratified directory
[decision]" (see the artifacts above) — none asserts adoption.

## What is NOT in this PR

The real async DB-reading posture resolver, the W6-R5 walking guard (Leg 0 /
non-empty-domain / reference-ban / transport-ban), wiring v2 into the live
calculator, and any emitter/route change — all land at **W7-1**, per the
design-lock's own landing sequence (§8 step 4).

refs #4556

Co-authored-by: Claude Sonnet 5 <noreply@anthropic.com>

