### PR TITLE
feat(attendance): INERT authoritative-result-write CORE for §7.3 (Gate D1, #4556)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -1344,6 +1344,7 @@ jobs:
             tests/integration/attendance-w4c2-live-scheduled-boundary.db.test.ts \
             tests/integration/attendance-w4c2-posture-matrix.db.test.ts \
             tests/integration/attendance-w4c2-gate-matrix-e5.db.test.ts \
+            tests/integration/attendance-w4c2-authoritative-calculation-core.db.test.ts \
             tests/integration/attendance-w4c2-p2-remediation.db.test.ts \
             tests/integration/attendance-w4c2-p2-1-canonical-freeze-anchor.db.test.ts \
             tests/integration/attendance-w4c2-p12-migration-schema-gates.db.test.ts \

--- a/packages/core-backend/src/attendance/w4c2-authoritative-calculation-core.ts
+++ b/packages/core-backend/src/attendance/w4c2-authoritative-calculation-core.ts
@@ -23,8 +23,11 @@
  *
  * DESIGN — two enforcement layers per invariant (repo doctrine: gate the MECHANISM, and a mutation
  * must be able to redden it — feedback_gate_the_mechanism_not_the_claim.md):
- *   (a) this module pre-validates every §7.3 authoritative invariant it can and refuses with a
- *       PRODUCT CODE (never a raw SQLSTATE) — the mutatable layer;
+ *   (a) this module pre-validates every §7.3 authoritative invariant it can on the normal
+ *       (live/scheduled completed+review) write path and refuses with a PRODUCT CODE rather than a raw
+ *       SQLSTATE — the mutatable layer. Two documented exceptions where a raw 23505 is still reachable
+ *       are named in "Concurrency notes" below (concurrent DIRECT `appendAuthoritativeLegacyBaselineV1`;
+ *       concurrent same-op reversal) — neither is on a production path (INERT) and neither corrupts;
  *   (b) the DB CHECK constraints / triggers installed by the W4C-0 durable-storage migration are
  *       the backstop, each proven separately by a raw-insert leg that bypasses (a).
  *
@@ -34,14 +37,40 @@
  * mirrors the four existing private copies byte-for-byte (same domain-separated hash); the four are
  * intentionally left un-rewired (that is a separate, non-inert refactor).
  *
- * OPEN SEAM for D2/D3 (named, not resolved here): the legacy_baseline fingerprint is caller-supplied
- * (`preimage.compatibilityFingerprint`) on purpose — self-computing it here is the import-kernel trap
- * (kernel :907-909 binds the frozen preimage fingerprint, not a recomputed one). Today ONLY the
- * import/rollback/ops paths freeze a `compatibilityFingerprint`; the live/scheduled boundary has no
- * producer. D2 (live_punch) must supply one — deterministically, over the parent's legacy daily
- * projection — before it can call the completed path on an active legacy parent, or `PREIMAGE_INVALID`
- * fails closed. The at-most-one-baseline-per-record existence read makes cross-path fingerprint values
- * inconsequential for uniqueness, but the live path still needs SOME frozen source.
+ * OPEN SEAMS / D2 obligations (named, not resolved here):
+ *  1. legacy_baseline fingerprint is caller-supplied (`preimage.compatibilityFingerprint`) on purpose
+ *     — self-computing it here is the import-kernel trap (kernel :907-909 binds the frozen preimage
+ *     fingerprint, not a recomputed one). Today ONLY the import/rollback/ops paths freeze a
+ *     `compatibilityFingerprint`; the live/scheduled boundary has no producer. D2 (live_punch) must
+ *     supply one — deterministically, over the parent's legacy daily projection — before it can call
+ *     the completed path on an active legacy parent, or `PREIMAGE_INVALID` fails closed. Cross-path
+ *     fingerprint values are inconsequential for uniqueness (see the existence-read note below), but
+ *     the live path still needs SOME frozen source.
+ *  2. PARENT-STATE ASYMMETRY (F6): the completed path moves the parent pointer/visibility and the
+ *     reversal path restores/retires it, but `writeReviewRow` writes ONLY the calc row and NEVER
+ *     touches `attendance_records`. §7.5 requires a FRESH authoritative review to leave the parent
+ *     `legacy_untracked`/pointer-null/retired/`review_placeholder` so ordinary readers see no
+ *     fabricated zero-minute row. Deciding fresh-vs-existing review is a BOUNDARY concern, so the
+ *     core deliberately does not touch the parent here — but D2/D3 MUST install that retired/
+ *     `review_placeholder` state in the SAME transaction for a fresh authoritative review, unlike the
+ *     completed/reversal paths which self-manage the parent. This asymmetry is the footgun; it is a
+ *     named D2 obligation, not an ambient concern. (The invariant-5 test installs that precondition by
+ *     fixture; it proves the "later completed needs no baseline" branch, not the boundary's install.)
+ *
+ * Concurrency notes:
+ *  - The completed/review path is idempotent under CONCURRENT same-(org,entrypoint,operation_id)
+ *    retries: a SAVEPOINT catches `uq_arc_operation` (23505) and re-runs the replay lookup, returning
+ *    replay/`REPLAY_CONFLICT` (never a raw SQLSTATE) — see `writeAuthoritativeSegmentCalculationV1`.
+ *  - The exported `appendAuthoritativeLegacyBaselineV1` existence read is a plain `SELECT … LIMIT 1`
+ *    (no `FOR UPDATE`); at-most-one-baseline-per-record is only guaranteed when it runs UNDER the
+ *    parent `FOR UPDATE` lock (as it does inside `writeCompletedRow`). Two concurrent DIRECT appends
+ *    could each compute version=1 and the loser trips `uq_arc_record_version` — no corruption (the
+ *    index holds; exactly one baseline), but a raw 23505 on that direct-use path. No production path
+ *    calls the helper directly (INERT).
+ *  - `writeAuthoritativeReversalV1` carries an operation_id too; a concurrent same-op reversal would
+ *    trip `uq_arc_operation` raw. Reversal is NOT an idempotent-replay contract in §7.3 (its callers —
+ *    import-rollback/ops-retirement — serialize via their own upstream operation registries), so it is
+ *    intentionally not savepoint-wrapped here.
  *
  * Defensive guards: `LINEAGE_SELF_REFERENCE` and `LINEAGE_NOT_STRICTLY_LOWER` are unreachable via the
  * public API with valid inputs (fresh id; supersedes/restores are always a strictly-lower baseline or
@@ -115,6 +144,16 @@ function fail(
 }
 
 const HEX64 = /^[0-9a-f]{64}$/
+
+/** True iff `error` is a Postgres unique_violation (23505) on the named constraint. */
+function isUniqueViolationOnConstraintV1(error: unknown, constraint: string): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    (error as { code?: unknown }).code === '23505' &&
+    (error as { constraint?: unknown }).constraint === constraint
+  )
+}
 
 // ---------------------------------------------------------------------------
 // Shared column helpers.
@@ -463,6 +502,20 @@ function assertPreimageProjection(projection: AttendanceAuthoritativePreimagePro
   }
 }
 
+function preimageProjectionsEqualV1(
+  a: AttendanceAuthoritativePreimageProjectionV1,
+  b: AttendanceAuthoritativePreimageProjectionV1,
+): boolean {
+  return (
+    a.status === b.status &&
+    a.firstInAt === b.firstInAt &&
+    a.lastOutAt === b.lastOutAt &&
+    a.workMinutes === b.workMinutes &&
+    a.lateMinutes === b.lateMinutes &&
+    a.earlyLeaveMinutes === b.earlyLeaveMinutes
+  )
+}
+
 // ---------------------------------------------------------------------------
 // (2) normal `calculation` (§7.3/§7.5/§7.8) — the live/scheduled authoritative write. Completed →
 // set_active + pointer move + segments; review_required → hidden all-NULL placeholder (no
@@ -601,18 +654,43 @@ export async function writeAuthoritativeSegmentCalculationV1(
     context: input.context,
   })
 
-  if (input.calculation.outcome === 'review_required') {
-    return await writeReviewRow(trx, input, {
-      semanticInputFingerprint,
-      provenanceFingerprint,
-      sourceDefinitionFingerprint,
+  const fp: FingerprintTripleV1 = { semanticInputFingerprint, provenanceFingerprint, sourceDefinitionFingerprint }
+
+  // §7.3 concurrent-retry idempotency. `retryReplayLookup` above only catches a retry whose winner
+  // already COMMITTED before this call. Two concurrent same-(org,entrypoint,operation_id) writers
+  // that do not contend on one parent row (different records, or the review path which never moves
+  // the pointer) both pass that lookup and both insert — the loser then trips `uq_arc_operation`.
+  // `lockParent`'s FOR UPDATE only serializes writers on the SAME parent row, so it does not cover
+  // this. A SAVEPOINT lets the loser roll back its partial writes (a bare constraint failure poisons
+  // the whole txn) and re-run the lookup so §7.3's "retries return the existing calculation" holds
+  // instead of a raw SQLSTATE reaching the caller.
+  const savepoint = 'attendance_w4_auth_calc_op'
+  await trx.query(`SAVEPOINT ${savepoint}`)
+  try {
+    const written =
+      input.calculation.outcome === 'review_required'
+        ? await writeReviewRow(trx, input, fp)
+        : await writeCompletedRow(trx, input, parent, fp)
+    await trx.query(`RELEASE SAVEPOINT ${savepoint}`)
+    return written
+  } catch (error) {
+    if (!isUniqueViolationOnConstraintV1(error, 'uq_arc_operation')) throw error
+    await trx.query(`ROLLBACK TO SAVEPOINT ${savepoint}`)
+    const afterConflict = await retryReplayLookup(trx, {
+      orgId: input.orgId,
+      entrypoint: input.entrypoint,
+      operationId: input.operationId,
+      recordId: input.recordId,
+      payloadFingerprint: input.payloadFingerprint,
     })
+    if (afterConflict !== null) {
+      return Object.freeze({ kind: 'replay' as const, calculationId: afterConflict.calculationId })
+    }
+    // The unique index proved a row exists, but this txn's snapshot cannot see it (e.g. a
+    // SERIALIZABLE caller whose snapshot predates the winner's commit). Surface §7.3's idempotency
+    // outcome as a product code, never the raw 23505.
+    fail(ATTENDANCE_W4_AUTHORITATIVE_CALCULATION_ERROR_CODES_V1.REPLAY_CONFLICT, 409)
   }
-  return await writeCompletedRow(trx, input, parent, {
-    semanticInputFingerprint,
-    provenanceFingerprint,
-    sourceDefinitionFingerprint,
-  })
 }
 
 interface FingerprintTripleV1 {
@@ -693,6 +771,16 @@ async function writeCompletedRow(
   const segmentCount = input.calculation.segments.length
   if (segmentCount < 1 || segmentCount > 3) {
     fail(ATTENDANCE_W4_AUTHORITATIVE_CALCULATION_ERROR_CODES_V1.EXPECTED_COUNT_INVALID, 422)
+  }
+  // §7.3 line 1414 "non-negative minutes": pre-validate with a product code, symmetric with the
+  // baseline (`assertPreimageProjection`) and reversal paths, so a negative-minute projection cannot
+  // leak the raw `chk_arc_projected_minutes` SQLSTATE (23514) to the caller.
+  if (
+    !Number.isSafeInteger(projection.workedMinutes) || projection.workedMinutes < 0 ||
+    !Number.isSafeInteger(projection.lateMinutes) || projection.lateMinutes < 0 ||
+    !Number.isSafeInteger(projection.earlyLeaveMinutes) || projection.earlyLeaveMinutes < 0
+  ) {
+    fail(ATTENDANCE_W4_AUTHORITATIVE_CALCULATION_ERROR_CODES_V1.COMPLETED_SHAPE_INVALID, 422)
   }
 
   const id = crypto.randomUUID()
@@ -915,6 +1003,24 @@ export async function writeAuthoritativeReversalV1(
     fail(ATTENDANCE_W4_AUTHORITATIVE_CALCULATION_ERROR_CODES_V1.REVERSAL_EFFECT_INVALID, 422)
   }
   assertPreimageProjection(input.frozenTarget.projection)
+  // F5 (defensive): for a present preimage the reversal RESTORES that exact frozen parent state, and
+  // the pointer is moved to `preimage` (owner/visibility/projection) — while the immutable row's
+  // projection_effect + projected fields come from `frozenTarget`. §7.3 lines 1449-1451 permit the
+  // row's effect to diverge from the *pointed-to earlier calc*, but NOT from the reversal's own
+  // preimage: a caller supplying a frozenTarget inconsistent with its own preimage would write a
+  // mislabeled immutable row (e.g. effect=set_active while the parent is restored to a retired
+  // preimage) that no DB CHECK covers — the §7.5 pointer trigger validates only the pointed-to
+  // earlier calc. The real callers derive both from one source, so this only rejects inconsistency.
+  if (input.preimage.posture === 'present') {
+    const consistent =
+      input.frozenTarget.visibilityState === input.preimage.visibilityState &&
+      input.frozenTarget.visibilityReason === input.preimage.visibilityReason &&
+      (input.preimage.projection === null ||
+        preimageProjectionsEqualV1(input.frozenTarget.projection, input.preimage.projection))
+    if (!consistent) {
+      fail(ATTENDANCE_W4_AUTHORITATIVE_CALCULATION_ERROR_CODES_V1.REVERSAL_EFFECT_INVALID, 422)
+    }
+  }
 
   const parent = await lockParent(trx, input.orgId, input.recordId)
   if (parent.currentCalculationId !== input.supersedesCalculationId) {

--- a/packages/core-backend/src/attendance/w4c2-authoritative-calculation-core.ts
+++ b/packages/core-backend/src/attendance/w4c2-authoritative-calculation-core.ts
@@ -1,0 +1,1042 @@
+/**
+ * W4C-2 Gate D1 (#4556 / #4844) — INERT authoritative-mode result-write CORE for
+ * `attendance_record_calculations`.
+ *
+ * WHAT THIS IS: the shared, contract-enforcing writer for the `mode='authoritative'` rows that
+ * section 7.3 of the RATIFIED W4 lock
+ * (`attendance-issue-4556-w4-segment-calculation-design-lock-20260724.md`, §7.3 lines 1383-1457,
+ * §7.4/7.5/7.7/7.8) specifies. It produces the SAME calc-row shape the shadow builder in
+ * `w4c2-live-scheduled-boundary.ts` writes, but with `mode='authoritative'` and the §7.3
+ * authoritative deltas: `legacy_baseline` snapshotting, `supersedes`/`restores` lineage, the
+ * parent-pointer/visibility move, preimage freezing, and reversal restore/retire.
+ *
+ * WHAT THIS IS NOT (INERT / byte-neutral, Gate D1): this module is NOT called by any production
+ * path. The live/scheduled boundary still fails closed — it still refuses the authoritative write
+ * with the boundary code `` `W4C2_AUTHORITATIVE_MODE_NOT_DELIVERED` `` (backtick-quoted here on
+ * purpose; this file must never spell that code as a `boundaryFail(...)` call, see the
+ * correspondence guard `w4c3a-rollout-control-inventory.test.ts`). No `boundaryFail` site is
+ * removed by this slice, `DECLARED_DELIVERED` stays `{live_punch:false, scheduled:false}`, and the
+ * shadow path is untouched (byte-identical by absence from this diff). D2 wires `live_punch`, D3
+ * wires `scheduled`; each removes a refusal site and flips its declaration in its own reviewed
+ * change. Until then this core is exercised ONLY by its real-DB test suite
+ * (`attendance-w4c2-authoritative-calculation-core.db.test.ts`).
+ *
+ * DESIGN — two enforcement layers per invariant (repo doctrine: gate the MECHANISM, and a mutation
+ * must be able to redden it — feedback_gate_the_mechanism_not_the_claim.md):
+ *   (a) this module pre-validates every §7.3 authoritative invariant it can and refuses with a
+ *       PRODUCT CODE (never a raw SQLSTATE) — the mutatable layer;
+ *   (b) the DB CHECK constraints / triggers installed by the W4C-0 durable-storage migration are
+ *       the backstop, each proven separately by a raw-insert leg that bypasses (a).
+ *
+ * REUSE: fingerprints via the existing `computeAttendance*FingerprintV1`; the single column list is
+ * spelled ONCE here (`insertResolvedAuthoritativeCalculationRowV1`) and all three kinds funnel
+ * through it — deliberately NOT three parallel hand-rolled INSERTs. `projectedDailyFingerprint`
+ * mirrors the four existing private copies byte-for-byte (same domain-separated hash); the four are
+ * intentionally left un-rewired (that is a separate, non-inert refactor).
+ *
+ * OPEN SEAM for D2/D3 (named, not resolved here): the legacy_baseline fingerprint is caller-supplied
+ * (`preimage.compatibilityFingerprint`) on purpose — self-computing it here is the import-kernel trap
+ * (kernel :907-909 binds the frozen preimage fingerprint, not a recomputed one). Today ONLY the
+ * import/rollback/ops paths freeze a `compatibilityFingerprint`; the live/scheduled boundary has no
+ * producer. D2 (live_punch) must supply one — deterministically, over the parent's legacy daily
+ * projection — before it can call the completed path on an active legacy parent, or `PREIMAGE_INVALID`
+ * fails closed. The at-most-one-baseline-per-record existence read makes cross-path fingerprint values
+ * inconsequential for uniqueness, but the live path still needs SOME frozen source.
+ *
+ * Defensive guards: `LINEAGE_SELF_REFERENCE` and `LINEAGE_NOT_STRICTLY_LOWER` are unreachable via the
+ * public API with valid inputs (fresh id; supersedes/restores are always a strictly-lower baseline or
+ * the current pointer) — they are pre-validation backed by `trg_arc_lineage_guard`, and their negative
+ * legs live on the DB backstop, not a product-code path.
+ *
+ * There is no `updated_at` — the calc table is append-only (§7.7).
+ */
+import crypto from 'node:crypto'
+import type { AttendanceW4TransactionClientV1 } from './w4c0-identity'
+import {
+  canonicalAttendanceJsonV1,
+  computeAttendanceProvenanceFingerprintV1,
+  computeAttendanceSemanticInputFingerprintV1,
+  type AttendanceInputProvenanceRefV1,
+} from './w4c0-fingerprints'
+import { computeAttendanceSourceDefinitionFingerprintV1 } from './w4c1-fingerprints'
+import {
+  ATTENDANCE_W4_SEGMENT_ENGINE_VERSION_V1,
+  type AttendanceCalculatedSegmentV1,
+  type AttendanceSegmentCalculationResultV1,
+} from './w4c1-segment-calculator'
+import type {
+  AttendanceAttributionSnapshotV1,
+  ApprovedAttendanceFactV1,
+  FrozenAttendanceContextV1,
+  PreparedDailyProjectionV1,
+} from './w4c0-write-boundary-types'
+
+// ---------------------------------------------------------------------------
+// Product-coded errors (never a raw SQLSTATE — repo doctrine).
+// ---------------------------------------------------------------------------
+
+export const ATTENDANCE_W4_AUTHORITATIVE_CALCULATION_ERROR_CODES_V1 = Object.freeze({
+  RECORD_NOT_FOUND: 'ATTENDANCE_W4_AUTH_CALC_RECORD_NOT_FOUND',
+  VERSION_CONFLICT: 'ATTENDANCE_W4_AUTH_CALC_VERSION_CONFLICT',
+  REPLAY_CONFLICT: 'ATTENDANCE_W4_AUTH_CALC_REPLAY_CONFLICT',
+  LINEAGE_TARGET_MISSING: 'ATTENDANCE_W4_AUTH_CALC_LINEAGE_TARGET_MISSING',
+  LINEAGE_NOT_STRICTLY_LOWER: 'ATTENDANCE_W4_AUTH_CALC_LINEAGE_NOT_STRICTLY_LOWER',
+  LINEAGE_SELF_REFERENCE: 'ATTENDANCE_W4_AUTH_CALC_LINEAGE_SELF_REFERENCE',
+  BASELINE_FINGERPRINT_INVALID: 'ATTENDANCE_W4_AUTH_CALC_BASELINE_FINGERPRINT_INVALID',
+  BASELINE_PROJECTION_INVALID: 'ATTENDANCE_W4_AUTH_CALC_BASELINE_PROJECTION_INVALID',
+  COMPLETED_SHAPE_INVALID: 'ATTENDANCE_W4_AUTH_CALC_COMPLETED_SHAPE_INVALID',
+  EXPECTED_COUNT_INVALID: 'ATTENDANCE_W4_AUTH_CALC_EXPECTED_COUNT_INVALID',
+  REVIEW_SHAPE_INVALID: 'ATTENDANCE_W4_AUTH_CALC_REVIEW_SHAPE_INVALID',
+  REVERSAL_SUPERSEDES_REQUIRED: 'ATTENDANCE_W4_AUTH_CALC_REVERSAL_SUPERSEDES_REQUIRED',
+  REVERSAL_RESTORES_MISMATCH: 'ATTENDANCE_W4_AUTH_CALC_REVERSAL_RESTORES_MISMATCH',
+  REVERSAL_EFFECT_INVALID: 'ATTENDANCE_W4_AUTH_CALC_REVERSAL_EFFECT_INVALID',
+  PREIMAGE_INVALID: 'ATTENDANCE_W4_AUTH_CALC_PREIMAGE_INVALID',
+} as const)
+
+export type AttendanceW4AuthoritativeCalculationErrorCodeV1 =
+  (typeof ATTENDANCE_W4_AUTHORITATIVE_CALCULATION_ERROR_CODES_V1)[keyof typeof ATTENDANCE_W4_AUTHORITATIVE_CALCULATION_ERROR_CODES_V1]
+
+export class AttendanceW4AuthoritativeCalculationError extends Error {
+  readonly code: AttendanceW4AuthoritativeCalculationErrorCodeV1
+  readonly httpStatus: number
+  constructor(code: AttendanceW4AuthoritativeCalculationErrorCodeV1, httpStatus: number) {
+    super(code)
+    this.name = 'AttendanceW4AuthoritativeCalculationError'
+    this.code = code
+    this.httpStatus = httpStatus
+  }
+}
+
+function fail(
+  code: AttendanceW4AuthoritativeCalculationErrorCodeV1,
+  httpStatus: number,
+): never {
+  throw new AttendanceW4AuthoritativeCalculationError(code, httpStatus)
+}
+
+const HEX64 = /^[0-9a-f]{64}$/
+
+// ---------------------------------------------------------------------------
+// Shared column helpers.
+// ---------------------------------------------------------------------------
+
+/**
+ * Domain-separated projected-daily fingerprint. Byte-identical to the four existing private copies
+ * (`w4c3a-canonical-import-kernel.ts`, `w4c3b-approved-leave-cancellation.ts`, `w4c3c-recompute.ts`,
+ * `w4c3c-manual-edit-apply.ts`): same domain tag + `canonicalAttendanceJsonV1(projection)`. A
+ * baseline row's `projected_daily_fingerprint` is NEVER computed here — it is the caller's frozen
+ * compatibility fingerprint (see `appendAuthoritativeLegacyBaselineV1`).
+ */
+export function projectedDailyFingerprintV1(projection: Readonly<{
+  status: string
+  firstInAt: string | null
+  lastOutAt: string | null
+  workedMinutes: number
+  lateMinutes: number
+  earlyLeaveMinutes: number
+}>): string {
+  return crypto
+    .createHash('sha256')
+    .update('metasheet2:attendance:w4:projected-daily:v1\0', 'utf8')
+    .update(canonicalAttendanceJsonV1(projection), 'utf8')
+    .digest('hex')
+}
+
+async function nextCalculationVersion(
+  trx: AttendanceW4TransactionClientV1,
+  recordId: string,
+): Promise<number> {
+  const result = await trx.query(
+    'SELECT COALESCE(MAX(version), 0) + 1 AS next FROM attendance_record_calculations WHERE attendance_record_id = $1::uuid',
+    [recordId],
+  )
+  const version = Number(result.rows[0]?.next)
+  if (!Number.isSafeInteger(version) || version < 1) {
+    fail(ATTENDANCE_W4_AUTHORITATIVE_CALCULATION_ERROR_CODES_V1.VERSION_CONFLICT, 500)
+  }
+  return version
+}
+
+/**
+ * §7.3 immediate-lineage precondition, pre-validated with product codes so a negative leg does not
+ * depend on the DB `trg_arc_lineage_guard` SQLSTATE. The trigger remains the backstop.
+ */
+async function assertLineageStrictlyLower(
+  trx: AttendanceW4TransactionClientV1,
+  input: Readonly<{ orgId: string; recordId: string; newRowId: string; newVersion: number; targetId: string }>,
+): Promise<void> {
+  if (input.targetId === input.newRowId) {
+    fail(ATTENDANCE_W4_AUTHORITATIVE_CALCULATION_ERROR_CODES_V1.LINEAGE_SELF_REFERENCE, 422)
+  }
+  const result = await trx.query(
+    `SELECT version FROM attendance_record_calculations
+      WHERE id = $1::uuid AND attendance_record_id = $2::uuid AND org_id = $3`,
+    [input.targetId, input.recordId, input.orgId],
+  )
+  if (result.rows.length !== 1) {
+    fail(ATTENDANCE_W4_AUTHORITATIVE_CALCULATION_ERROR_CODES_V1.LINEAGE_TARGET_MISSING, 422)
+  }
+  const targetVersion = Number(result.rows[0].version)
+  if (!Number.isSafeInteger(targetVersion) || targetVersion >= input.newVersion) {
+    fail(ATTENDANCE_W4_AUTHORITATIVE_CALCULATION_ERROR_CODES_V1.LINEAGE_NOT_STRICTLY_LOWER, 422)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// The ONE parameterized INSERT — every kind (legacy_baseline / calculation / reversal) funnels
+// through this. mode is always 'authoritative'; engine/schema version fixed; shadow_diff is a
+// shadow-only concept and stays NULL for every authoritative row.
+// ---------------------------------------------------------------------------
+
+interface ResolvedAuthoritativeCalculationRowV1 {
+  readonly id: string
+  readonly orgId: string
+  readonly recordId: string
+  readonly version: number
+  readonly calculationKind: 'legacy_baseline' | 'calculation' | 'reversal'
+  readonly entrypoint: string
+  readonly supersedesCalculationId: string | null
+  readonly restoresCalculationId: string | null
+  readonly sourceBatchId: string | null
+  readonly operationId: string | null
+  readonly semanticInputFingerprint: string
+  readonly provenanceFingerprint: string
+  readonly sourceDefinitionFingerprint: string | null
+  readonly attributionSnapshot: unknown
+  readonly contextSnapshot: unknown | null
+  readonly segmentSnapshot: unknown[]
+  readonly evidenceSnapshot: unknown[]
+  readonly approvedFactsSnapshot: unknown[]
+  readonly manualOverrideSnapshot: unknown | null
+  readonly inputProvenance: Record<string, unknown>
+  readonly mergePolicy: 'append' | 'merge' | 'override' | 'reversal' | 'retire'
+  readonly calculationTier: 'legacy_shadow' | 'segment_authoritative'
+  readonly outcome: 'baseline' | 'completed' | 'review_required' | 'reversed'
+  readonly outcomeReasonCode: string
+  readonly projectionEffect: 'none' | 'set_active' | 'set_retired'
+  readonly expectedSegmentCount: number
+  readonly projectedStatus: string | null
+  readonly projectedFirstInAt: string | null
+  readonly projectedLastOutAt: string | null
+  readonly projectedWorkMinutes: number | null
+  readonly projectedLateMinutes: number | null
+  readonly projectedEarlyLeaveMinutes: number | null
+  readonly projectedDailyFingerprint: string | null
+  readonly parentPreimageSnapshot: unknown | null
+  readonly actorId: string
+  readonly correlationId: string
+}
+
+async function insertResolvedAuthoritativeCalculationRowV1(
+  trx: AttendanceW4TransactionClientV1,
+  row: ResolvedAuthoritativeCalculationRowV1,
+): Promise<void> {
+  await trx.query(
+    `INSERT INTO attendance_record_calculations (
+        id, org_id, attendance_record_id, version, calculation_kind, mode, entrypoint,
+        engine_version, snapshot_schema_version,
+        supersedes_calculation_id, restores_calculation_id, source_batch_id, operation_id,
+        semantic_input_fingerprint, provenance_fingerprint, source_definition_fingerprint,
+        attribution_snapshot, context_snapshot, segment_snapshot, evidence_snapshot,
+        approved_facts_snapshot, manual_override_snapshot, input_provenance,
+        merge_policy, calculation_tier, outcome, outcome_reason_code, projection_effect,
+        expected_segment_count, projected_status, projected_first_in_at, projected_last_out_at,
+        projected_work_minutes, projected_late_minutes, projected_early_leave_minutes,
+        projected_daily_fingerprint, parent_preimage_snapshot, shadow_diff_code, shadow_diff,
+        actor_id, correlation_id
+      ) VALUES (
+        $1::uuid, $2, $3::uuid, $4, $5, 'authoritative', $6,
+        $7, 1,
+        $8::uuid, $9::uuid, $10::uuid, $11::uuid,
+        $12, $13, $14,
+        $15::jsonb, $16::jsonb, $17::jsonb, $18::jsonb,
+        $19::jsonb, $20::jsonb, $21::jsonb,
+        $22, $23, $24, $25, $26,
+        $27, $28, $29, $30,
+        $31, $32, $33,
+        $34, $35::jsonb, NULL, NULL,
+        $36, $37
+      )`,
+    [
+      row.id,
+      row.orgId,
+      row.recordId,
+      row.version,
+      row.calculationKind,
+      row.entrypoint,
+      ATTENDANCE_W4_SEGMENT_ENGINE_VERSION_V1,
+      row.supersedesCalculationId,
+      row.restoresCalculationId,
+      row.sourceBatchId,
+      row.operationId,
+      row.semanticInputFingerprint,
+      row.provenanceFingerprint,
+      row.sourceDefinitionFingerprint,
+      canonicalAttendanceJsonV1(row.attributionSnapshot),
+      row.contextSnapshot === null ? null : canonicalAttendanceJsonV1(row.contextSnapshot),
+      canonicalAttendanceJsonV1(row.segmentSnapshot),
+      canonicalAttendanceJsonV1(row.evidenceSnapshot),
+      canonicalAttendanceJsonV1(row.approvedFactsSnapshot),
+      row.manualOverrideSnapshot === null ? null : canonicalAttendanceJsonV1(row.manualOverrideSnapshot),
+      canonicalAttendanceJsonV1(row.inputProvenance),
+      row.mergePolicy,
+      row.calculationTier,
+      row.outcome,
+      row.outcomeReasonCode,
+      row.projectionEffect,
+      row.expectedSegmentCount,
+      row.projectedStatus,
+      row.projectedFirstInAt,
+      row.projectedLastOutAt,
+      row.projectedWorkMinutes,
+      row.projectedLateMinutes,
+      row.projectedEarlyLeaveMinutes,
+      row.projectedDailyFingerprint,
+      row.parentPreimageSnapshot === null ? null : canonicalAttendanceJsonV1(row.parentPreimageSnapshot),
+      row.actorId,
+      row.correlationId,
+    ],
+  )
+}
+
+async function insertCalculationSegmentsV1(
+  trx: AttendanceW4TransactionClientV1,
+  input: Readonly<{
+    orgId: string
+    recordId: string
+    calculationId: string
+    segments: readonly AttendanceCalculatedSegmentV1[]
+  }>,
+): Promise<void> {
+  for (const segment of input.segments) {
+    await trx.query(
+      `INSERT INTO attendance_record_segments (
+          org_id, record_id, calculation_id, segment_index,
+          expected_start_at, expected_end_at, actual_in_at, actual_out_at,
+          work_minutes, late_minutes, early_leave_minutes,
+          status, status_reasons, matched_evidence_refs, unmatched_evidence_refs
+        ) VALUES ($1, $2::uuid, $3::uuid, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13::jsonb, $14::jsonb, $15::jsonb)`,
+      [
+        input.orgId,
+        input.recordId,
+        input.calculationId,
+        segment.segmentIndex,
+        segment.expectedStartAt,
+        segment.expectedEndAt,
+        segment.actualInAt,
+        segment.actualOutAt,
+        segment.workedMinutes,
+        segment.lateMinutes,
+        segment.earlyLeaveMinutes,
+        segment.status,
+        JSON.stringify(segment.reasons),
+        JSON.stringify(segment.matchedEvidenceRefs),
+        JSON.stringify(segment.unmatchedEvidenceRefs),
+      ],
+    )
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Preimage witness (§7.8) — the frozen write-before parent state the caller supplies. The core does
+// not derive it; it validates against it.
+// ---------------------------------------------------------------------------
+
+export interface AttendanceAuthoritativePreimageProjectionV1 {
+  readonly status: string
+  readonly firstInAt: string | null
+  readonly lastOutAt: string | null
+  readonly workMinutes: number
+  readonly lateMinutes: number
+  readonly earlyLeaveMinutes: number
+}
+
+export type AttendanceAuthoritativeParentPreimageV1 =
+  | { readonly posture: 'absent' }
+  | {
+      readonly posture: 'present'
+      readonly projectionOwner: 'legacy_untracked' | 'w4'
+      readonly currentCalculationId: string | null
+      readonly visibilityState: 'active' | 'retired'
+      readonly visibilityReason: 'active' | 'review_placeholder' | 'import_rollback' | 'operator_retirement'
+      readonly projection: AttendanceAuthoritativePreimageProjectionV1 | null
+      readonly compatibilityFingerprint: string | null
+    }
+
+// ---------------------------------------------------------------------------
+// (1) legacy_baseline (§7.3/§7.8) — snapshots an active legacy parent immediately before its FIRST
+// authoritative replacement. Restore evidence only: projection_effect='none', no children,
+// operation_id NULL, never a pointer target. Idempotent per record via the existence read (NOT the
+// unique index) so it can never consume the external operation_id the following normal calc needs.
+// ---------------------------------------------------------------------------
+
+export interface AppendAuthoritativeLegacyBaselineInputV1 {
+  readonly orgId: string
+  readonly recordId: string
+  readonly entrypoint: string
+  readonly projection: AttendanceAuthoritativePreimageProjectionV1
+  /** The frozen compatibility fingerprint — becomes projected_daily_fingerprint AND all three FPs. */
+  readonly compatibilityFingerprint: string
+  readonly parentPreimageSnapshot: unknown
+  readonly actorId: string
+  readonly correlationId: string
+}
+
+export type AppendAuthoritativeLegacyBaselineResultV1 =
+  | { readonly kind: 'appended'; readonly baselineCalculationId: string; readonly version: number }
+  | { readonly kind: 'exists'; readonly baselineCalculationId: string }
+
+export async function appendAuthoritativeLegacyBaselineV1(
+  trx: AttendanceW4TransactionClientV1,
+  input: AppendAuthoritativeLegacyBaselineInputV1,
+): Promise<AppendAuthoritativeLegacyBaselineResultV1> {
+  if (!HEX64.test(input.compatibilityFingerprint)) {
+    fail(ATTENDANCE_W4_AUTHORITATIVE_CALCULATION_ERROR_CODES_V1.BASELINE_FINGERPRINT_INVALID, 422)
+  }
+  assertPreimageProjection(input.projection)
+
+  const existing = await trx.query(
+    `SELECT id::text AS id FROM attendance_record_calculations
+      WHERE org_id = $1 AND attendance_record_id = $2::uuid AND calculation_kind = 'legacy_baseline'
+      LIMIT 1`,
+    [input.orgId, input.recordId],
+  )
+  if (existing.rows.length !== 0) {
+    return Object.freeze({ kind: 'exists', baselineCalculationId: String(existing.rows[0].id) })
+  }
+
+  const id = crypto.randomUUID()
+  const version = await nextCalculationVersion(trx, input.recordId)
+  await insertResolvedAuthoritativeCalculationRowV1(trx, {
+    id,
+    orgId: input.orgId,
+    recordId: input.recordId,
+    version,
+    calculationKind: 'legacy_baseline',
+    entrypoint: input.entrypoint,
+    supersedesCalculationId: null,
+    restoresCalculationId: null,
+    sourceBatchId: null,
+    operationId: null,
+    semanticInputFingerprint: input.compatibilityFingerprint,
+    provenanceFingerprint: input.compatibilityFingerprint,
+    sourceDefinitionFingerprint: input.compatibilityFingerprint,
+    attributionSnapshot: baselineAttributionV1(),
+    contextSnapshot: { schemaVersion: 1, kind: 'legacy_projection_baseline' },
+    segmentSnapshot: [],
+    evidenceSnapshot: [],
+    approvedFactsSnapshot: [],
+    manualOverrideSnapshot: null,
+    inputProvenance: { schemaVersion: 1, kind: 'legacy_projection_baseline' },
+    mergePolicy: 'append',
+    calculationTier: 'legacy_shadow',
+    outcome: 'baseline',
+    outcomeReasonCode: 'legacy_projection_baseline',
+    projectionEffect: 'none',
+    expectedSegmentCount: 0,
+    projectedStatus: input.projection.status,
+    projectedFirstInAt: input.projection.firstInAt,
+    projectedLastOutAt: input.projection.lastOutAt,
+    projectedWorkMinutes: input.projection.workMinutes,
+    projectedLateMinutes: input.projection.lateMinutes,
+    projectedEarlyLeaveMinutes: input.projection.earlyLeaveMinutes,
+    projectedDailyFingerprint: input.compatibilityFingerprint,
+    parentPreimageSnapshot: input.parentPreimageSnapshot,
+    actorId: input.actorId,
+    correlationId: input.correlationId,
+  })
+  return Object.freeze({ kind: 'appended', baselineCalculationId: id, version })
+}
+
+function baselineAttributionV1(): AttendanceAttributionSnapshotV1 {
+  return { posture: 'unsupported', sourceSchemaVersion: 1, reason: 'legacy_v1', sourceFingerprint: null }
+}
+
+function assertPreimageProjection(projection: AttendanceAuthoritativePreimageProjectionV1): void {
+  if (
+    typeof projection.status !== 'string' ||
+    !Number.isSafeInteger(projection.workMinutes) || projection.workMinutes < 0 ||
+    !Number.isSafeInteger(projection.lateMinutes) || projection.lateMinutes < 0 ||
+    !Number.isSafeInteger(projection.earlyLeaveMinutes) || projection.earlyLeaveMinutes < 0
+  ) {
+    fail(ATTENDANCE_W4_AUTHORITATIVE_CALCULATION_ERROR_CODES_V1.BASELINE_PROJECTION_INVALID, 422)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// (2) normal `calculation` (§7.3/§7.5/§7.8) — the live/scheduled authoritative write. Completed →
+// set_active + pointer move + segments; review_required → hidden all-NULL placeholder (no
+// pointer/predecessor/effect). Retry-idempotent on (org, entrypoint, operation_id).
+// ---------------------------------------------------------------------------
+
+export interface WriteAuthoritativeSegmentCalculationInputV1 {
+  readonly orgId: string
+  readonly recordId: string
+  readonly entrypoint: string
+  readonly operationId: string
+  readonly calculation: AttendanceSegmentCalculationResultV1
+  readonly attribution: AttendanceAttributionSnapshotV1
+  readonly context: FrozenAttendanceContextV1 | null
+  readonly evidence: readonly unknown[]
+  readonly approvedFacts: readonly ApprovedAttendanceFactV1[]
+  readonly provenanceRef: AttendanceInputProvenanceRefV1
+  readonly inputProvenance: Record<string, unknown>
+  /** Deterministic payload identity for the retry-idempotency conflict check (precedent: recompute). */
+  readonly payloadFingerprint: string
+  /** Frozen write-before parent state (§7.8). */
+  readonly preimage: AttendanceAuthoritativeParentPreimageV1
+  /** What the caller believes the current pointer is; a stale value fails VERSION_CONFLICT (§7.3). */
+  readonly expectedCurrentCalculationId: string | null
+  readonly sourceBatchId?: string | null
+  readonly actorId: string
+  readonly correlationId: string
+}
+
+export type WriteAuthoritativeSegmentCalculationResultV1 =
+  | {
+      readonly kind: 'completed'
+      readonly calculationId: string
+      readonly version: number
+      readonly supersedesCalculationId: string | null
+      readonly baselineCalculationId: string | null
+    }
+  | { readonly kind: 'review'; readonly calculationId: string; readonly version: number }
+  | { readonly kind: 'replay'; readonly calculationId: string }
+
+interface LockedParentV1 {
+  readonly currentCalculationId: string | null
+  readonly projectionOwner: 'legacy_untracked' | 'w4'
+  readonly visibilityState: 'active' | 'retired'
+  readonly timezone: string | null
+}
+
+async function retryReplayLookup(
+  trx: AttendanceW4TransactionClientV1,
+  input: Readonly<{ orgId: string; entrypoint: string; operationId: string; recordId: string; payloadFingerprint: string }>,
+): Promise<{ calculationId: string } | null> {
+  const existing = await trx.query(
+    `SELECT id::text AS id, attendance_record_id::text AS record_id, input_provenance
+       FROM attendance_record_calculations
+      WHERE org_id = $1 AND entrypoint = $2 AND operation_id = $3::uuid
+      FOR UPDATE`,
+    [input.orgId, input.entrypoint, input.operationId],
+  )
+  if (existing.rows.length === 0) return null
+  const existingRow = existing.rows[0]
+  if (String(existingRow.record_id) !== input.recordId) {
+    fail(ATTENDANCE_W4_AUTHORITATIVE_CALCULATION_ERROR_CODES_V1.REPLAY_CONFLICT, 409)
+  }
+  const provenance =
+    existingRow.input_provenance && typeof existingRow.input_provenance === 'object'
+      ? (existingRow.input_provenance as Record<string, unknown>)
+      : null
+  const existingFingerprint =
+    provenance && typeof provenance.payloadFingerprint === 'string' ? provenance.payloadFingerprint : null
+  if (existingFingerprint !== input.payloadFingerprint) {
+    fail(ATTENDANCE_W4_AUTHORITATIVE_CALCULATION_ERROR_CODES_V1.REPLAY_CONFLICT, 409)
+  }
+  return { calculationId: String(existingRow.id) }
+}
+
+async function lockParent(
+  trx: AttendanceW4TransactionClientV1,
+  orgId: string,
+  recordId: string,
+): Promise<LockedParentV1> {
+  const result = await trx.query(
+    `SELECT current_calculation_id::text AS current_calculation_id, projection_owner,
+            visibility_state, timezone
+       FROM attendance_records
+      WHERE id = $1::uuid AND org_id = $2
+      FOR UPDATE`,
+    [recordId, orgId],
+  )
+  if (result.rows.length !== 1) {
+    fail(ATTENDANCE_W4_AUTHORITATIVE_CALCULATION_ERROR_CODES_V1.RECORD_NOT_FOUND, 404)
+  }
+  const row = result.rows[0]
+  return {
+    currentCalculationId:
+      typeof row.current_calculation_id === 'string' ? row.current_calculation_id : null,
+    projectionOwner: row.projection_owner === 'w4' ? 'w4' : 'legacy_untracked',
+    visibilityState: row.visibility_state === 'retired' ? 'retired' : 'active',
+    timezone: typeof row.timezone === 'string' ? row.timezone : null,
+  }
+}
+
+export async function writeAuthoritativeSegmentCalculationV1(
+  trx: AttendanceW4TransactionClientV1,
+  input: WriteAuthoritativeSegmentCalculationInputV1,
+): Promise<WriteAuthoritativeSegmentCalculationResultV1> {
+  const replay = await retryReplayLookup(trx, {
+    orgId: input.orgId,
+    entrypoint: input.entrypoint,
+    operationId: input.operationId,
+    recordId: input.recordId,
+    payloadFingerprint: input.payloadFingerprint,
+  })
+  if (replay !== null) {
+    return Object.freeze({ kind: 'replay' as const, calculationId: replay.calculationId })
+  }
+
+  const parent = await lockParent(trx, input.orgId, input.recordId)
+  if (parent.currentCalculationId !== input.expectedCurrentCalculationId) {
+    fail(ATTENDANCE_W4_AUTHORITATIVE_CALCULATION_ERROR_CODES_V1.VERSION_CONFLICT, 409)
+  }
+
+  const semanticInputFingerprint = computeAttendanceSemanticInputFingerprintV1({
+    attribution: input.attribution,
+    context: input.context,
+    evidence: input.evidence,
+    approvedFacts: input.approvedFacts,
+    manualOverride: null,
+    mergePolicy: 'append',
+    calculationTier: 'segment_authoritative',
+    engineVersion: ATTENDANCE_W4_SEGMENT_ENGINE_VERSION_V1,
+    snapshotSchemaVersion: 1,
+  })
+  const provenanceFingerprint = computeAttendanceProvenanceFingerprintV1(input.provenanceRef)
+  const sourceDefinitionFingerprint = computeAttendanceSourceDefinitionFingerprintV1({
+    attribution: input.attribution,
+    context: input.context,
+  })
+
+  if (input.calculation.outcome === 'review_required') {
+    return await writeReviewRow(trx, input, {
+      semanticInputFingerprint,
+      provenanceFingerprint,
+      sourceDefinitionFingerprint,
+    })
+  }
+  return await writeCompletedRow(trx, input, parent, {
+    semanticInputFingerprint,
+    provenanceFingerprint,
+    sourceDefinitionFingerprint,
+  })
+}
+
+interface FingerprintTripleV1 {
+  readonly semanticInputFingerprint: string
+  readonly provenanceFingerprint: string
+  readonly sourceDefinitionFingerprint: string | null
+}
+
+async function writeReviewRow(
+  trx: AttendanceW4TransactionClientV1,
+  input: WriteAuthoritativeSegmentCalculationInputV1,
+  fp: FingerprintTripleV1,
+): Promise<WriteAuthoritativeSegmentCalculationResultV1> {
+  // Hidden review placeholder: every projected daily field NULL (not a DB default), effect none,
+  // zero children, no predecessor/pointer/baseline. §7.3/§7.5.
+  if (input.calculation.dailyProjection !== null || input.calculation.segments.length !== 0) {
+    fail(ATTENDANCE_W4_AUTHORITATIVE_CALCULATION_ERROR_CODES_V1.REVIEW_SHAPE_INVALID, 422)
+  }
+  const id = crypto.randomUUID()
+  const version = await nextCalculationVersion(trx, input.recordId)
+  await insertResolvedAuthoritativeCalculationRowV1(trx, {
+    id,
+    orgId: input.orgId,
+    recordId: input.recordId,
+    version,
+    calculationKind: 'calculation',
+    entrypoint: input.entrypoint,
+    supersedesCalculationId: null,
+    restoresCalculationId: null,
+    sourceBatchId: input.sourceBatchId ?? null,
+    operationId: input.operationId,
+    semanticInputFingerprint: fp.semanticInputFingerprint,
+    provenanceFingerprint: fp.provenanceFingerprint,
+    sourceDefinitionFingerprint: fp.sourceDefinitionFingerprint,
+    attributionSnapshot: input.attribution,
+    contextSnapshot: input.context,
+    segmentSnapshot: [],
+    evidenceSnapshot: [...input.evidence],
+    approvedFactsSnapshot: [...input.approvedFacts],
+    manualOverrideSnapshot: null,
+    inputProvenance: input.inputProvenance,
+    mergePolicy: 'append',
+    calculationTier: 'segment_authoritative',
+    outcome: 'review_required',
+    outcomeReasonCode: input.calculation.outcomeReasonCode,
+    projectionEffect: 'none',
+    expectedSegmentCount: 0,
+    projectedStatus: null,
+    projectedFirstInAt: null,
+    projectedLastOutAt: null,
+    projectedWorkMinutes: null,
+    projectedLateMinutes: null,
+    projectedEarlyLeaveMinutes: null,
+    projectedDailyFingerprint: null,
+    parentPreimageSnapshot: input.preimage,
+    actorId: input.actorId,
+    correlationId: input.correlationId,
+  })
+  return Object.freeze({ kind: 'review' as const, calculationId: id, version })
+}
+
+async function writeCompletedRow(
+  trx: AttendanceW4TransactionClientV1,
+  input: WriteAuthoritativeSegmentCalculationInputV1,
+  parent: LockedParentV1,
+  fp: FingerprintTripleV1,
+): Promise<WriteAuthoritativeSegmentCalculationResultV1> {
+  const projection = input.calculation.dailyProjection
+  // §7.3 completed shape: resolved_v2 attribution, frozen context, 1..3 segments, dense projection.
+  if (
+    projection === null ||
+    input.attribution.posture !== 'resolved_v2' ||
+    input.context === null ||
+    fp.sourceDefinitionFingerprint === null
+  ) {
+    fail(ATTENDANCE_W4_AUTHORITATIVE_CALCULATION_ERROR_CODES_V1.COMPLETED_SHAPE_INVALID, 422)
+  }
+  const segmentCount = input.calculation.segments.length
+  if (segmentCount < 1 || segmentCount > 3) {
+    fail(ATTENDANCE_W4_AUTHORITATIVE_CALCULATION_ERROR_CODES_V1.EXPECTED_COUNT_INVALID, 422)
+  }
+
+  const id = crypto.randomUUID()
+
+  // §7.3/§7.8 predecessor: an active legacy_untracked parent gets a baseline first, and the normal
+  // calc supersedes it; a W4-owned parent supersedes the exact locked current; a review-placeholder
+  // parent (no active compat projection) needs neither. The baseline is appended BEFORE the calc's
+  // version is allocated so the two never collide on `(record, version)`.
+  let supersedesCalculationId: string | null = null
+  let baselineCalculationId: string | null = null
+  if (parent.projectionOwner === 'w4' && parent.currentCalculationId !== null) {
+    supersedesCalculationId = parent.currentCalculationId
+  } else if (parent.projectionOwner === 'legacy_untracked' && parent.visibilityState === 'active') {
+    if (input.preimage.posture !== 'present' || input.preimage.projection === null) {
+      fail(ATTENDANCE_W4_AUTHORITATIVE_CALCULATION_ERROR_CODES_V1.PREIMAGE_INVALID, 422)
+    }
+    if (input.preimage.compatibilityFingerprint === null) {
+      fail(ATTENDANCE_W4_AUTHORITATIVE_CALCULATION_ERROR_CODES_V1.PREIMAGE_INVALID, 422)
+    }
+    const baseline = await appendAuthoritativeLegacyBaselineV1(trx, {
+      orgId: input.orgId,
+      recordId: input.recordId,
+      entrypoint: input.entrypoint,
+      projection: input.preimage.projection,
+      compatibilityFingerprint: input.preimage.compatibilityFingerprint,
+      parentPreimageSnapshot: input.preimage,
+      actorId: input.actorId,
+      correlationId: input.correlationId,
+    })
+    baselineCalculationId = baseline.baselineCalculationId
+    supersedesCalculationId = baseline.baselineCalculationId
+  }
+
+  const version = await nextCalculationVersion(trx, input.recordId)
+
+  if (supersedesCalculationId !== null) {
+    await assertLineageStrictlyLower(trx, {
+      orgId: input.orgId,
+      recordId: input.recordId,
+      newRowId: id,
+      newVersion: version,
+      targetId: supersedesCalculationId,
+    })
+  }
+
+  const projectedDailyFingerprint = projectedDailyFingerprintV1({
+    status: projection.status,
+    firstInAt: projection.firstInAt,
+    lastOutAt: projection.lastOutAt,
+    workedMinutes: projection.workedMinutes,
+    lateMinutes: projection.lateMinutes,
+    earlyLeaveMinutes: projection.earlyLeaveMinutes,
+  })
+
+  await insertResolvedAuthoritativeCalculationRowV1(trx, {
+    id,
+    orgId: input.orgId,
+    recordId: input.recordId,
+    version,
+    calculationKind: 'calculation',
+    entrypoint: input.entrypoint,
+    supersedesCalculationId,
+    restoresCalculationId: null,
+    sourceBatchId: input.sourceBatchId ?? null,
+    operationId: input.operationId,
+    semanticInputFingerprint: fp.semanticInputFingerprint,
+    provenanceFingerprint: fp.provenanceFingerprint,
+    sourceDefinitionFingerprint: fp.sourceDefinitionFingerprint,
+    attributionSnapshot: input.attribution,
+    contextSnapshot: input.context,
+    segmentSnapshot: (input.context as unknown as { segments?: unknown[] }).segments ?? [],
+    evidenceSnapshot: [...input.evidence],
+    approvedFactsSnapshot: [...input.approvedFacts],
+    manualOverrideSnapshot: null,
+    inputProvenance: input.inputProvenance,
+    mergePolicy: 'append',
+    calculationTier: 'segment_authoritative',
+    outcome: 'completed',
+    outcomeReasonCode: 'calculated',
+    projectionEffect: 'set_active',
+    expectedSegmentCount: segmentCount,
+    projectedStatus: projection.status,
+    projectedFirstInAt: projection.firstInAt,
+    projectedLastOutAt: projection.lastOutAt,
+    projectedWorkMinutes: projection.workedMinutes,
+    projectedLateMinutes: projection.lateMinutes,
+    projectedEarlyLeaveMinutes: projection.earlyLeaveMinutes,
+    projectedDailyFingerprint,
+    parentPreimageSnapshot: input.preimage,
+    actorId: input.actorId,
+    correlationId: input.correlationId,
+  })
+
+  await insertCalculationSegmentsV1(trx, {
+    orgId: input.orgId,
+    recordId: input.recordId,
+    calculationId: id,
+    segments: input.calculation.segments,
+  })
+
+  // Pointer move (§7.5). The stale-expectation guard is the pre-check above (`parent.currentCalculationId
+  // !== input.expectedCurrentCalculationId`), evaluated under the parent's FOR UPDATE lock; this WHERE
+  // keys off the LOCKED ACTUAL current (never `expectedCurrentCalculationId`) so it does not silently
+  // re-implement — and thereby cover for — that guard. The lock guarantees the actual cannot move
+  // between the read and this write.
+  const updated = await trx.query(
+    `UPDATE attendance_records
+        SET current_calculation_id = $3::uuid, projection_owner = 'w4',
+            visibility_state = 'active', visibility_reason = 'active',
+            status = $4, first_in_at = $5, last_out_at = $6,
+            work_minutes = $7, late_minutes = $8, early_leave_minutes = $9,
+            updated_at = now()
+      WHERE id = $1::uuid AND org_id = $2
+        AND current_calculation_id IS NOT DISTINCT FROM $10::uuid
+      RETURNING id`,
+    [
+      input.recordId,
+      input.orgId,
+      id,
+      projection.status,
+      projection.firstInAt,
+      projection.lastOutAt,
+      projection.workedMinutes,
+      projection.lateMinutes,
+      projection.earlyLeaveMinutes,
+      parent.currentCalculationId,
+    ],
+  )
+  if (updated.rows.length !== 1) {
+    fail(ATTENDANCE_W4_AUTHORITATIVE_CALCULATION_ERROR_CODES_V1.VERSION_CONFLICT, 409)
+  }
+
+  return Object.freeze({
+    kind: 'completed' as const,
+    calculationId: id,
+    version,
+    supersedesCalculationId,
+    baselineCalculationId,
+  })
+}
+
+// ---------------------------------------------------------------------------
+// (3) reversal (§7.3/§7.8) — restore a present preimage pointer or retire an absent-pointer
+// preimage. Contract-enforcing: the CALLER supplies the row to supersede, the frozen preimage
+// witness, and the frozen visibility target; the core enforces the §7.3 reversal shape rules
+// (supersedes required; restores == preimage.currentCalculationId when present, NULL when absent;
+// projection_effect matches the frozen target). The reversed row's own snapshots are carried
+// forward (never fabricated).
+// ---------------------------------------------------------------------------
+
+export interface WriteAuthoritativeReversalInputV1 {
+  readonly orgId: string
+  readonly recordId: string
+  readonly entrypoint: string
+  readonly operationId: string
+  readonly sourceBatchId?: string | null
+  /** The exact current calc being reversed (§7.8: a wrong/null predecessor is a failure). */
+  readonly supersedesCalculationId: string | null
+  /** Carried forward from the reversed row (never fabricated). */
+  readonly reversedSnapshots: Readonly<{
+    semanticInputFingerprint: string
+    provenanceFingerprint: string
+    sourceDefinitionFingerprint: string | null
+    attributionSnapshot: unknown
+    contextSnapshot: unknown | null
+    evidenceSnapshot: unknown[]
+    approvedFactsSnapshot: unknown[]
+    manualOverrideSnapshot: unknown | null
+  }>
+  readonly inputProvenance: Record<string, unknown>
+  readonly preimage: AttendanceAuthoritativeParentPreimageV1
+  /** The frozen target daily state the reversal projects (present=restored, absent=retired). */
+  readonly frozenTarget: Readonly<{
+    visibilityState: 'active' | 'retired'
+    visibilityReason: 'active' | 'review_placeholder' | 'import_rollback' | 'operator_retirement'
+    projection: AttendanceAuthoritativePreimageProjectionV1
+    dailyFingerprint: string
+  }>
+  readonly restoresCalculationId: string | null
+  readonly outcomeReasonCode: 'import_rollback_reversal' | 'operator_retirement'
+  readonly mergePolicy: 'reversal' | 'retire'
+  readonly actorId: string
+  readonly correlationId: string
+}
+
+export interface WriteAuthoritativeReversalResultV1 {
+  readonly kind: 'reversed'
+  readonly calculationId: string
+  readonly version: number
+  readonly projectionEffect: 'set_active' | 'set_retired'
+  readonly restoresCalculationId: string | null
+}
+
+export async function writeAuthoritativeReversalV1(
+  trx: AttendanceW4TransactionClientV1,
+  input: WriteAuthoritativeReversalInputV1,
+): Promise<WriteAuthoritativeReversalResultV1> {
+  if (input.supersedesCalculationId === null) {
+    fail(ATTENDANCE_W4_AUTHORITATIVE_CALCULATION_ERROR_CODES_V1.REVERSAL_SUPERSEDES_REQUIRED, 422)
+  }
+  // §7.8 restores correspondence: restores must equal the preimage's pointer when present, NULL when
+  // absent. Enforced HERE — the DB has no CHECK for this cross-column business identity.
+  const preimagePointer =
+    input.preimage.posture === 'present' ? input.preimage.currentCalculationId : null
+  if ((input.restoresCalculationId ?? null) !== (preimagePointer ?? null)) {
+    fail(ATTENDANCE_W4_AUTHORITATIVE_CALCULATION_ERROR_CODES_V1.REVERSAL_RESTORES_MISMATCH, 422)
+  }
+  // §7.3 projection_effect matches the frozen target state.
+  const projectionEffect = input.frozenTarget.visibilityState === 'active' ? 'set_active' : 'set_retired'
+  const reasonVisibilityConsistent =
+    (input.outcomeReasonCode === 'import_rollback_reversal' &&
+      (input.frozenTarget.visibilityReason === 'import_rollback' ||
+        input.frozenTarget.visibilityReason === 'active')) ||
+    (input.outcomeReasonCode === 'operator_retirement' &&
+      input.frozenTarget.visibilityReason === 'operator_retirement')
+  if (!reasonVisibilityConsistent) {
+    fail(ATTENDANCE_W4_AUTHORITATIVE_CALCULATION_ERROR_CODES_V1.REVERSAL_EFFECT_INVALID, 422)
+  }
+  if (!HEX64.test(input.frozenTarget.dailyFingerprint)) {
+    fail(ATTENDANCE_W4_AUTHORITATIVE_CALCULATION_ERROR_CODES_V1.REVERSAL_EFFECT_INVALID, 422)
+  }
+  assertPreimageProjection(input.frozenTarget.projection)
+
+  const parent = await lockParent(trx, input.orgId, input.recordId)
+  if (parent.currentCalculationId !== input.supersedesCalculationId) {
+    fail(ATTENDANCE_W4_AUTHORITATIVE_CALCULATION_ERROR_CODES_V1.VERSION_CONFLICT, 409)
+  }
+
+  const id = crypto.randomUUID()
+  const version = await nextCalculationVersion(trx, input.recordId)
+  await assertLineageStrictlyLower(trx, {
+    orgId: input.orgId,
+    recordId: input.recordId,
+    newRowId: id,
+    newVersion: version,
+    targetId: input.supersedesCalculationId,
+  })
+  if (input.restoresCalculationId !== null) {
+    await assertLineageStrictlyLower(trx, {
+      orgId: input.orgId,
+      recordId: input.recordId,
+      newRowId: id,
+      newVersion: version,
+      targetId: input.restoresCalculationId,
+    })
+  }
+
+  await insertResolvedAuthoritativeCalculationRowV1(trx, {
+    id,
+    orgId: input.orgId,
+    recordId: input.recordId,
+    version,
+    calculationKind: 'reversal',
+    entrypoint: input.entrypoint,
+    supersedesCalculationId: input.supersedesCalculationId,
+    restoresCalculationId: input.restoresCalculationId,
+    sourceBatchId: input.sourceBatchId ?? null,
+    operationId: input.operationId,
+    semanticInputFingerprint: input.reversedSnapshots.semanticInputFingerprint,
+    provenanceFingerprint: input.reversedSnapshots.provenanceFingerprint,
+    sourceDefinitionFingerprint: input.reversedSnapshots.sourceDefinitionFingerprint,
+    attributionSnapshot: input.reversedSnapshots.attributionSnapshot,
+    contextSnapshot: input.reversedSnapshots.contextSnapshot,
+    segmentSnapshot: [],
+    evidenceSnapshot: input.reversedSnapshots.evidenceSnapshot,
+    approvedFactsSnapshot: input.reversedSnapshots.approvedFactsSnapshot,
+    manualOverrideSnapshot: input.reversedSnapshots.manualOverrideSnapshot,
+    inputProvenance: input.inputProvenance,
+    mergePolicy: input.mergePolicy,
+    calculationTier: 'segment_authoritative',
+    outcome: 'reversed',
+    outcomeReasonCode: input.outcomeReasonCode,
+    projectionEffect,
+    expectedSegmentCount: 0,
+    projectedStatus: input.frozenTarget.projection.status,
+    projectedFirstInAt: input.frozenTarget.projection.firstInAt,
+    projectedLastOutAt: input.frozenTarget.projection.lastOutAt,
+    projectedWorkMinutes: input.frozenTarget.projection.workMinutes,
+    projectedLateMinutes: input.frozenTarget.projection.lateMinutes,
+    projectedEarlyLeaveMinutes: input.frozenTarget.projection.earlyLeaveMinutes,
+    projectedDailyFingerprint: input.frozenTarget.dailyFingerprint,
+    parentPreimageSnapshot: input.preimage,
+    actorId: input.actorId,
+    correlationId: input.correlationId,
+  })
+
+  // Pointer (§7.5): present → restore the earlier calc/owner/visibility; absent → point at THIS
+  // reversal row, set_retired. Optimistic on the exact reversed pointer.
+  let pointerTarget: string | null
+  let owner: 'legacy_untracked' | 'w4'
+  let visibilityState: 'active' | 'retired'
+  let visibilityReason: 'active' | 'review_placeholder' | 'import_rollback' | 'operator_retirement'
+  let daily: AttendanceAuthoritativePreimageProjectionV1
+  if (input.preimage.posture === 'present') {
+    pointerTarget = input.preimage.currentCalculationId
+    owner = input.preimage.projectionOwner
+    visibilityState = input.preimage.visibilityState
+    visibilityReason = input.preimage.visibilityReason
+    daily = input.preimage.projection ?? input.frozenTarget.projection
+  } else {
+    pointerTarget = id
+    owner = 'w4'
+    visibilityState = 'retired'
+    visibilityReason = input.frozenTarget.visibilityReason
+    daily = input.frozenTarget.projection
+  }
+
+  const updated = await trx.query(
+    `UPDATE attendance_records
+        SET current_calculation_id = $3::uuid, projection_owner = $4,
+            visibility_state = $5, visibility_reason = $6,
+            status = $7, first_in_at = $8, last_out_at = $9,
+            work_minutes = $10, late_minutes = $11, early_leave_minutes = $12,
+            updated_at = now()
+      WHERE id = $1::uuid AND org_id = $2
+        AND current_calculation_id = $13::uuid
+      RETURNING id`,
+    [
+      input.recordId,
+      input.orgId,
+      pointerTarget,
+      owner,
+      visibilityState,
+      visibilityReason,
+      daily.status,
+      daily.firstInAt,
+      daily.lastOutAt,
+      daily.workMinutes,
+      daily.lateMinutes,
+      daily.earlyLeaveMinutes,
+      // Locked actual current (== supersedesCalculationId after the pre-check), never the caller's
+      // claim directly, so the pre-check stays the sole load-bearing stale-predecessor guard.
+      parent.currentCalculationId,
+    ],
+  )
+  if (updated.rows.length !== 1) {
+    fail(ATTENDANCE_W4_AUTHORITATIVE_CALCULATION_ERROR_CODES_V1.VERSION_CONFLICT, 409)
+  }
+
+  return Object.freeze({
+    kind: 'reversed' as const,
+    calculationId: id,
+    version,
+    projectionEffect,
+    restoresCalculationId: input.restoresCalculationId,
+  })
+}

--- a/packages/core-backend/tests/integration/attendance-w4c2-authoritative-calculation-core.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-w4c2-authoritative-calculation-core.db.test.ts
@@ -220,6 +220,18 @@ describeIfDatabase('W4C-2 Gate D1 — authoritative-mode result-write CORE (real
     expect((caught as AttendanceW4AuthoritativeCalculationError).code).toBe(code)
   }
 
+  // F4: a DB-backstop leg must pin WHICH constraint/trigger refused, not merely that SOME error was
+  // thrown (feedback_not_this_error_is_not_an_outcome_assertion). Postgres sets `.constraint` for
+  // unique/check violations and puts the trigger's RAISE text in `.message`.
+  function dbErrorInfo(caught: unknown): { code: string | null; constraint: string | null; message: string } {
+    const e = caught as { code?: unknown; constraint?: unknown; message?: unknown }
+    return {
+      code: typeof e?.code === 'string' ? e.code : null,
+      constraint: typeof e?.constraint === 'string' ? e.constraint : null,
+      message: typeof e?.message === 'string' ? e.message : String(caught),
+    }
+  }
+
   async function calcRow(id: string): Promise<Record<string, unknown> | undefined> {
     const { rows } = await pool.query(
       `SELECT * FROM attendance_record_calculations WHERE id = $1::uuid`,
@@ -319,17 +331,20 @@ describeIfDatabase('W4C-2 Gate D1 — authoritative-mode result-write CORE (real
       } catch (error) {
         caught = error
       }
-      expect(caught).toBeTruthy()
+      expect(dbErrorInfo(caught).constraint).toBe('uq_arc_baseline')
     })
 
     it('SAME-TXN atomicity (§7.3): a failure in the calc step after the baseline write leaves NEITHER row', async () => {
-      // Active legacy parent + a completed calc whose projection carries a negative minute → the calc
-      // INSERT trips chk_arc_projected_minutes AFTER the baseline is appended in the same txn. If the
-      // baseline were written on a separate/auto-committing connection it would survive; it must not.
+      // Active legacy parent + a completed calc whose projection carries an INVALID status ('bogus').
+      // The core does not pre-validate the status enum (unlike minutes, F2), so the baseline is
+      // appended first and the calc INSERT then trips chk_arc_projected_status (23514) IN the same
+      // txn. If the baseline were written on a separate/auto-committing connection it would survive
+      // the rollback; it must not. A negative-minute projection can no longer serve here — F2 now
+      // rejects it BEFORE the baseline append.
       const org = `org-b5-${RUN}`
       const recordId = await insertLegacyActiveParent(org)
       const bad = completedCalculation(1)
-      ;(bad.dailyProjection as { workedMinutes: number }).workedMinutes = -1
+      ;(bad.dailyProjection as { status: string }).status = 'not_a_real_status'
       let caught: unknown
       try {
         await withTxn((client) =>
@@ -339,6 +354,21 @@ describeIfDatabase('W4C-2 Gate D1 — authoritative-mode result-write CORE (real
         caught = error
       }
       expect(caught).toBeTruthy()
+      expect(String((caught as { constraint?: unknown }).constraint ?? (caught as Error).message)).toContain('chk_arc_projected_status')
+      // Neither the baseline nor the failed calc survived the same-txn rollback.
+      expect(await countCalcs(recordId)).toBe(0)
+    })
+
+    it('NEGATIVE (product code, F3): a baseline with a negative projected minute is refused with BASELINE_PROJECTION_INVALID', async () => {
+      const org = `org-b6-${RUN}`
+      const recordId = await insertLegacyActiveParent(org)
+      const badProjection = { ...LEGACY_PROJECTION, workMinutes: -1 }
+      await expectProductCode(
+        withTxn((client) =>
+          appendAuthoritativeLegacyBaselineV1(asTrx(client), { ...baselineInput(org, recordId), projection: badProjection }),
+        ),
+        CODES.BASELINE_PROJECTION_INVALID,
+      )
       expect(await countCalcs(recordId)).toBe(0)
     })
   })
@@ -367,10 +397,10 @@ describeIfDatabase('W4C-2 Gate D1 — authoritative-mode result-write CORE (real
           projected_work_minutes, projected_late_minutes, projected_early_leave_minutes,
           projected_daily_fingerprint, actor_id, correlation_id)
        VALUES ($1::uuid, $2, $3::uuid, $4, 'legacy_baseline', 'authoritative', 'live', 'raw', 1, NULL,
-               $5, $5, $5, '{"posture":"unsupported","sourceSchemaVersion":1,"reason":"legacy_v1","sourceFingerprint":null}'::jsonb,
+               $5::text, $5::text, $5::text, '{"posture":"unsupported","sourceSchemaVersion":1,"reason":"legacy_v1","sourceFingerprint":null}'::jsonb,
                '{"schemaVersion":1}'::jsonb, '[]'::jsonb, '[]'::jsonb, '[]'::jsonb, '{"schemaVersion":1}'::jsonb,
                'append', 'legacy_shadow', 'baseline', 'legacy_projection_baseline', 'none', 0, 'normal',
-               420, 0, 0, $5, 'raw-actor', $6)`,
+               420, 0, 0, $5::text, 'raw-actor', $6)`,
       [uuid(), org, recordId, version, fp, `raw-${RUN}`],
     )
   }
@@ -434,7 +464,46 @@ describeIfDatabase('W4C-2 Gate D1 — authoritative-mode result-write CORE (real
       } catch (error) {
         caught = error
       }
-      expect(caught).toBeTruthy()
+      expect(dbErrorInfo(caught).message).toContain('W4C0_SEGMENT_COUNT')
+    })
+
+    it('NEGATIVE (product code, F2): a completed projection with a negative minute is refused with COMPLETED_SHAPE_INVALID, not a raw 23514', async () => {
+      const org = `org-c5-${RUN}`
+      const recordId = await insertLegacyActiveParent(org)
+      const bad = completedCalculation(1)
+      ;(bad.dailyProjection as { workedMinutes: number }).workedMinutes = -5
+      await expectProductCode(
+        withTxn((client) => writeAuthoritativeSegmentCalculationV1(asTrx(client), segmentInput({ orgId: org, recordId, calculation: bad }))),
+        CODES.COMPLETED_SHAPE_INVALID,
+      )
+      expect(await countCalcs(recordId)).toBe(0)
+    })
+
+    it('NEGATIVE (product code, F3): a completed write on an active legacy parent with an ABSENT preimage is refused with PREIMAGE_INVALID', async () => {
+      const org = `org-c6-${RUN}`
+      const recordId = await insertLegacyActiveParent(org)
+      await expectProductCode(
+        withTxn((client) => writeAuthoritativeSegmentCalculationV1(asTrx(client), segmentInput({ orgId: org, recordId, preimage: { posture: 'absent' } }))),
+        CODES.PREIMAGE_INVALID,
+      )
+      expect(await countCalcs(recordId)).toBe(0)
+    })
+
+    it('N1: the frozen segment_snapshot round-trips REAL ordered content, not always []', async () => {
+      const org = `org-n1-${RUN}`
+      const recordId = await insertLegacyActiveParent(org)
+      const orderedSegments = [
+        { segmentIndex: 0, status: 'normal', expectedStartAt: '2026-03-02T01:00:00.000Z', workedMinutes: 240 },
+        { segmentIndex: 1, status: 'late', expectedStartAt: '2026-03-02T05:00:00.000Z', workedMinutes: 240 },
+      ]
+      const context = { timezone: TZ, workDate: WORK_DATE, segments: orderedSegments }
+      const result = await withTxn((client) =>
+        writeAuthoritativeSegmentCalculationV1(asTrx(client), segmentInput({ orgId: org, recordId, context: context as never })),
+      )
+      if (result.kind !== 'completed') throw new Error('expected completed')
+      const row = await calcRow(result.calculationId)
+      // Array order is preserved (only object keys are canonicalized); the ordered array round-trips.
+      expect(row?.segment_snapshot).toEqual(orderedSegments)
     })
   })
 
@@ -483,7 +552,7 @@ describeIfDatabase('W4C-2 Gate D1 — authoritative-mode result-write CORE (real
       } catch (error) {
         caught = error
       }
-      expect(caught).toBeTruthy()
+      expect(dbErrorInfo(caught).constraint).toBe('uq_arc_record_version')
     })
   })
 
@@ -531,7 +600,83 @@ describeIfDatabase('W4C-2 Gate D1 — authoritative-mode result-write CORE (real
       } catch (error) {
         caught = error
       }
-      expect(caught).toBeTruthy()
+      expect(dbErrorInfo(caught).constraint).toBe('uq_arc_operation')
+    })
+  })
+
+  // =========================================================================
+  // Invariant 2 (F1) — CONCURRENT retry idempotency: two same-(org,entrypoint,operation_id) writers
+  // that do not contend on one parent row both pass the pre-lock replay lookup + version pre-check;
+  // the loser must resolve to a §7.3 product-code outcome (replay / REPLAY_CONFLICT), never a raw
+  // 23505. Constructed 2-connection race: A writes but does NOT commit → B's replay lookup sees
+  // nothing → B blocks on the unique index → A commits → B recovers via the SAVEPOINT catch.
+  // =========================================================================
+  describe('§7.3 invariant 2 (F1) — concurrent retry idempotency', () => {
+    async function settled(promise: Promise<unknown>): Promise<{ done: boolean }> {
+      const marker = { done: false }
+      promise.then(() => { marker.done = true }, () => { marker.done = true })
+      return marker
+    }
+
+    it('F1: concurrent same-op writes on DIFFERENT records — the loser returns REPLAY_CONFLICT (product code), never a raw 23505', async () => {
+      const org = `org-f1a-${RUN}`
+      const recordA = await insertLegacyActiveParent(org)
+      const recordB = await insertLegacyActiveParent(org)
+      const operationId = uuid()
+      const a = await pool.connect()
+      const b = await pool.connect()
+      try {
+        await a.query('BEGIN')
+        const aResult = await writeAuthoritativeSegmentCalculationV1(asTrx(a), segmentInput({ orgId: org, recordId: recordA, operationId }))
+        expect(aResult.kind).toBe('completed')
+        await b.query('BEGIN')
+        const bPromise = writeAuthoritativeSegmentCalculationV1(asTrx(b), segmentInput({ orgId: org, recordId: recordB, operationId }))
+        const bMarker = await settled(bPromise)
+        await new Promise((resolve) => setTimeout(resolve, 500))
+        expect(bMarker.done).toBe(false) // B is blocked on A's uncommitted unique insert
+        await a.query('COMMIT') // unblock B
+        let bError: unknown
+        try {
+          await bPromise
+        } catch (error) {
+          bError = error
+        }
+        await b.query('COMMIT').catch(() => undefined)
+        // The op-id is bound to record A; B's DIFFERENT record → REPLAY_CONFLICT, not a raw SQLSTATE.
+        expect(bError).toBeInstanceOf(AttendanceW4AuthoritativeCalculationError)
+        expect((bError as AttendanceW4AuthoritativeCalculationError).code).toBe(CODES.REPLAY_CONFLICT)
+      } finally {
+        a.release()
+        b.release()
+      }
+    })
+
+    it('F1: concurrent same-op REVIEW writes on the SAME record — the loser returns the winner\'s calc (replay), never a raw 23505', async () => {
+      const org = `org-f1b-${RUN}`
+      const recordId = await insertLegacyActiveParent(org)
+      const operationId = uuid()
+      const a = await pool.connect()
+      const b = await pool.connect()
+      try {
+        await a.query('BEGIN')
+        const aResult = await writeAuthoritativeSegmentCalculationV1(asTrx(a), segmentInput({ orgId: org, recordId, operationId, calculation: reviewCalculation() }))
+        expect(aResult.kind).toBe('review')
+        await b.query('BEGIN')
+        const bPromise = writeAuthoritativeSegmentCalculationV1(asTrx(b), segmentInput({ orgId: org, recordId, operationId, calculation: reviewCalculation() }))
+        const bMarker = await settled(bPromise)
+        await new Promise((resolve) => setTimeout(resolve, 500))
+        expect(bMarker.done).toBe(false) // B is blocked on A's parent FOR UPDATE lock
+        await a.query('COMMIT')
+        const bResult = await bPromise
+        await b.query('COMMIT').catch(() => undefined)
+        expect(bResult.kind).toBe('replay')
+        if (aResult.kind === 'review' && bResult.kind === 'replay') {
+          expect(bResult.calculationId).toBe(aResult.calculationId)
+        }
+      } finally {
+        a.release()
+        b.release()
+      }
     })
   })
 
@@ -599,7 +744,7 @@ describeIfDatabase('W4C-2 Gate D1 — authoritative-mode result-write CORE (real
       } catch (error) {
         caught = error
       }
-      expect(caught).toBeTruthy()
+      expect(dbErrorInfo(caught).constraint).toBe('chk_arc_review_shape')
     })
   })
 
@@ -620,9 +765,11 @@ describeIfDatabase('W4C-2 Gate D1 — authoritative-mode result-write CORE (real
         writeAuthoritativeReversalV1(asTrx(client), reversalInput(org, recordId, {
           supersedesCalculationId: second.calculationId,
           reversedRow: reversed as Record<string, unknown>,
+          // The frozen target of a RESTORE is the restored state (first), and must match the preimage
+          // the pointer is moved to (F5). It is NOT the reversed calc's (second's) state.
           preimage: presentPointerPreimage(first, projectionOf(firstRow as Record<string, unknown>)),
           restoresCalculationId: first,
-          frozenTarget: { visibilityState: 'active', visibilityReason: 'active', projection: projectionOf(reversed as Record<string, unknown>), dailyFingerprint: String((reversed as Record<string, unknown>).projected_daily_fingerprint) },
+          frozenTarget: { visibilityState: 'active', visibilityReason: 'active', projection: projectionOf(firstRow as Record<string, unknown>), dailyFingerprint: String((firstRow as Record<string, unknown>).projected_daily_fingerprint) },
           outcomeReasonCode: 'import_rollback_reversal',
           mergePolicy: 'reversal',
         })),
@@ -712,14 +859,60 @@ describeIfDatabase('W4C-2 Gate D1 — authoritative-mode result-write CORE (real
           writeAuthoritativeReversalV1(asTrx(client), reversalInput(org, recordId, {
             supersedesCalculationId: first,
             reversedRow: reversed as Record<string, unknown>,
-            preimage: presentPointerPreimage(bogus), // pointer == bogus so restores-match passes
+            // pointer == bogus so restores-match passes; frozenTarget ≡ preimage (default projection)
+            // so F5 passes and the lineage check on the missing restores target is reached.
+            preimage: presentPointerPreimage(bogus),
             restoresCalculationId: bogus, // ... but no such calc exists → lineage target missing
-            frozenTarget: { visibilityState: 'active', visibilityReason: 'active', projection: projectionOf(reversed as Record<string, unknown>), dailyFingerprint: String((reversed as Record<string, unknown>).projected_daily_fingerprint) },
+            frozenTarget: { visibilityState: 'active', visibilityReason: 'active', projection: LEGACY_PROJECTION, dailyFingerprint: HEX_A },
             outcomeReasonCode: 'import_rollback_reversal',
             mergePolicy: 'reversal',
           })),
         ),
         CODES.LINEAGE_TARGET_MISSING,
+      )
+    })
+
+    it('NEGATIVE (product code, F3): a reversal whose outcome reason and frozen visibility reason are inconsistent is refused with REVERSAL_EFFECT_INVALID', async () => {
+      const org = `org-x7-${RUN}`
+      const { recordId, calcId: first } = await seedFirstCompleted(org)
+      const reversed = await calcRow(first)
+      await expectProductCode(
+        withTxn((client) =>
+          writeAuthoritativeReversalV1(asTrx(client), reversalInput(org, recordId, {
+            supersedesCalculationId: first,
+            reversedRow: reversed as Record<string, unknown>,
+            preimage: { posture: 'absent' },
+            restoresCalculationId: null,
+            // operator_retirement reason with an import_rollback visibility reason: inconsistent.
+            frozenTarget: { visibilityState: 'retired', visibilityReason: 'import_rollback', projection: projectionOf(reversed as Record<string, unknown>), dailyFingerprint: String((reversed as Record<string, unknown>).projected_daily_fingerprint) },
+            outcomeReasonCode: 'operator_retirement',
+            mergePolicy: 'retire',
+          })),
+        ),
+        CODES.REVERSAL_EFFECT_INVALID,
+      )
+    })
+
+    it('NEGATIVE (product code, F5): a present preimage whose frozen target visibility diverges from the preimage is refused with REVERSAL_EFFECT_INVALID', async () => {
+      const org = `org-x8-${RUN}`
+      const { recordId, calcId: first } = await seedFirstCompleted(org)
+      const reversed = await calcRow(first)
+      const bogus = uuid()
+      await expectProductCode(
+        withTxn((client) =>
+          writeAuthoritativeReversalV1(asTrx(client), reversalInput(org, recordId, {
+            supersedesCalculationId: first,
+            reversedRow: reversed as Record<string, unknown>,
+            // preimage says the parent is being restored to an ACTIVE state (pointer==bogus so
+            // restores-match passes), but the frozen target claims RETIRED → mislabeled row (F5).
+            preimage: presentPointerPreimage(bogus, LEGACY_PROJECTION),
+            restoresCalculationId: bogus,
+            frozenTarget: { visibilityState: 'retired', visibilityReason: 'import_rollback', projection: LEGACY_PROJECTION, dailyFingerprint: HEX_A },
+            outcomeReasonCode: 'import_rollback_reversal',
+            mergePolicy: 'reversal',
+          })),
+        ),
+        CODES.REVERSAL_EFFECT_INVALID,
       )
     })
 
@@ -732,7 +925,7 @@ describeIfDatabase('W4C-2 Gate D1 — authoritative-mode result-write CORE (real
       } catch (error) {
         caught = error
       }
-      expect(caught).toBeTruthy()
+      expect(dbErrorInfo(caught).constraint).toBe('chk_arc_reversal_supersedes')
     })
   })
 
@@ -750,7 +943,7 @@ describeIfDatabase('W4C-2 Gate D1 — authoritative-mode result-write CORE (real
       } catch (error) {
         caught = error
       }
-      expect(caught).toBeTruthy()
+      expect(dbErrorInfo(caught).message).toContain('W4C0_LINEAGE')
     })
   })
 
@@ -772,7 +965,7 @@ describeIfDatabase('W4C-2 Gate D1 — authoritative-mode result-write CORE (real
       } catch (error) {
         caught = error
       }
-      expect(caught).toBeTruthy()
+      expect(dbErrorInfo(caught).message).toContain('W4C0_IMMUTABLE')
     })
   })
 
@@ -861,9 +1054,9 @@ describeIfDatabase('W4C-2 Gate D1 — authoritative-mode result-write CORE (real
           projected_work_minutes, projected_late_minutes, projected_early_leave_minutes,
           projected_daily_fingerprint, actor_id, correlation_id)
        VALUES ($1::uuid, $2, $3::uuid, 900, 'calculation', 'authoritative', 'live', 'raw', 1, $4::uuid,
-               $5, $5, $5, '{"posture":"resolved_v2","value":{}}'::jsonb, '{"tz":"x"}'::jsonb, '[]'::jsonb,
+               $5::text, $5::text, $5::text, '{"posture":"resolved_v2","value":{}}'::jsonb, '{"tz":"x"}'::jsonb, '[]'::jsonb,
                '[]'::jsonb, '[]'::jsonb, '{"schemaVersion":1}'::jsonb, 'append', 'segment_authoritative',
-               'completed', 'calculated', 'set_active', $6, 'normal', 480, 0, 0, $5, 'raw', $7)`,
+               'completed', 'calculated', 'set_active', $6, 'normal', 480, 0, 0, $5::text, 'raw', $7)`,
       [id, org, recordId, uuid(), HEX_A, claimed, `raw-${RUN}`],
     )
     for (let i = 0; i < children; i += 1) {
@@ -921,9 +1114,9 @@ describeIfDatabase('W4C-2 Gate D1 — authoritative-mode result-write CORE (real
           outcome, outcome_reason_code, projection_effect, expected_segment_count, projected_status,
           projected_work_minutes, projected_late_minutes, projected_early_leave_minutes, projected_daily_fingerprint, actor_id, correlation_id)
        VALUES ($1::uuid, $2, $3::uuid, 903, 'reversal', 'authoritative', 'import_rollback', 'raw', 1, $4::uuid,
-               $5, $5, $5, '{"posture":"resolved_v2","value":{}}'::jsonb, '{"tz":"x"}'::jsonb, '[]'::jsonb,
+               $5::text, $5::text, $5::text, '{"posture":"resolved_v2","value":{}}'::jsonb, '{"tz":"x"}'::jsonb, '[]'::jsonb,
                '[]'::jsonb, '[]'::jsonb, '{"schemaVersion":1}'::jsonb, 'reversal', 'segment_authoritative',
-               'reversed', 'import_rollback_reversal', 'set_retired', 0, 'normal', 480, 0, 0, $5, 'raw', $6)`,
+               'reversed', 'import_rollback_reversal', 'set_retired', 0, 'normal', 480, 0, 0, $5::text, 'raw', $6)`,
       [uuid(), org, recordId, uuid(), HEX_A, `raw-${RUN}`],
     )
   }
@@ -939,9 +1132,9 @@ describeIfDatabase('W4C-2 Gate D1 — authoritative-mode result-write CORE (real
           projected_status, projected_work_minutes, projected_late_minutes, projected_early_leave_minutes,
           projected_daily_fingerprint, actor_id, correlation_id)
        VALUES ($1::uuid, $2, $3::uuid, $7, 'reversal', 'authoritative', 'import_rollback', 'raw', 1, $4::uuid, $8::uuid,
-               $5, $5, $5, '{"posture":"resolved_v2","value":{}}'::jsonb, '{"tz":"x"}'::jsonb, '[]'::jsonb,
+               $5::text, $5::text, $5::text, '{"posture":"resolved_v2","value":{}}'::jsonb, '{"tz":"x"}'::jsonb, '[]'::jsonb,
                '[]'::jsonb, '[]'::jsonb, '{"schemaVersion":1}'::jsonb, 'reversal', 'segment_authoritative',
-               'reversed', 'import_rollback_reversal', 'set_retired', 0, 'normal', 480, 0, 0, $5, 'raw', $6)`,
+               'reversed', 'import_rollback_reversal', 'set_retired', 0, 'normal', 480, 0, 0, $5::text, 'raw', $6)`,
       [uuid(), org, recordId, supersedes, HEX_A, `raw-${RUN}`, version, uuid()],
     )
   }

--- a/packages/core-backend/tests/integration/attendance-w4c2-authoritative-calculation-core.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-w4c2-authoritative-calculation-core.db.test.ts
@@ -1,0 +1,948 @@
+/**
+ * W4C-2 Gate D1 (#4556 / #4844) — real-Postgres proof of the INERT authoritative-mode result-write
+ * CORE (`src/attendance/w4c2-authoritative-calculation-core.ts`).
+ *
+ * Every §7.3 authoritative-mode invariant gets: a POSITIVE leg (the correct write happens and passes
+ * every DB constraint INCLUDING the deferred commit-time triggers — each leg COMMITs), a NEGATIVE leg
+ * (the forbidden write is refused with a PRODUCT CODE, never a raw SQLSTATE), and — for the DB-only
+ * invariants (version-uniqueness index, lineage trigger, append-only trigger, deferred count trigger)
+ * — a BACKSTOP leg that bypasses the core's product-code validation with a raw INSERT and proves the
+ * database itself refuses. Load-bearingness of each product-code guard is verified out-of-band by the
+ * gate (neuter the core check → the negative leg reddens because it now sees the DB SQLSTATE, not the
+ * product code); the guards are written as discrete functions precisely so that mutation is possible.
+ *
+ * INERT: this suite is the ONLY caller of the core. The live/scheduled boundary still fails closed
+ * (`W4C2_AUTHORITATIVE_MODE_NOT_DELIVERED`, unchanged). Two-point wired (vitest.config exclude +
+ * plugin-tests.yml attendance real-DB run-list) so the no-DB job cannot skip-green it.
+ *
+ * Shared-DB discipline: every fixture identity is namespaced per run; append-only rows are left behind.
+ */
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import crypto from 'node:crypto'
+import { Kysely, PostgresDialect } from 'kysely'
+import { Pool, type PoolClient } from 'pg'
+import { up } from '../../src/db/migrations/zzzz20260725120000_w4c0_attendance_segment_calculation_durable_storage'
+import type { AttendanceW4TransactionClientV1 } from '../../src/attendance/w4c0-identity'
+import type { AttendanceSegmentCalculationResultV1 } from '../../src/attendance/w4c1-segment-calculator'
+import type { AttendanceInputProvenanceRefV1 } from '../../src/attendance/w4c0-fingerprints'
+import {
+  appendAuthoritativeLegacyBaselineV1,
+  writeAuthoritativeSegmentCalculationV1,
+  writeAuthoritativeReversalV1,
+  projectedDailyFingerprintV1,
+  AttendanceW4AuthoritativeCalculationError,
+  ATTENDANCE_W4_AUTHORITATIVE_CALCULATION_ERROR_CODES_V1 as CODES,
+  type AttendanceAuthoritativeParentPreimageV1,
+  type AttendanceAuthoritativePreimageProjectionV1,
+} from '../../src/attendance/w4c2-authoritative-calculation-core'
+
+const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
+const describeIfDatabase = dbUrl ? describe : describe.skip
+
+const RUN = crypto.randomUUID().slice(0, 8)
+const WORK_DATE = '2026-03-02'
+const HEX_A = 'a'.repeat(64)
+const HEX_B = 'b'.repeat(64)
+const TZ = 'Asia/Shanghai'
+
+function uuid(): string {
+  return crypto.randomUUID()
+}
+
+const asTrx = (client: PoolClient): AttendanceW4TransactionClientV1 =>
+  client as unknown as AttendanceW4TransactionClientV1
+
+function provenanceRef(): AttendanceInputProvenanceRefV1 {
+  return {
+    transport: 'live_event',
+    sourceRef: `live:${RUN}`,
+    artifactSha256: null,
+    normalizedCsvSha256: null,
+    convertedSheetName: null,
+  }
+}
+
+function resolvedAttribution(): unknown {
+  return {
+    posture: 'resolved_v2',
+    value: { workDate: WORK_DATE, shiftId: `shift-${RUN}`, resolvedAt: '2026-03-02T00:00:00.000Z', reasonCode: 'DIRECT' },
+  }
+}
+
+function frozenContext(): unknown {
+  return { timezone: TZ, workDate: WORK_DATE, segments: [] }
+}
+
+function completedCalculation(segmentCount: 1 | 2 | 3, workedMinutes = 480): AttendanceSegmentCalculationResultV1 {
+  const segments = Array.from({ length: segmentCount }, (_unused, index) => ({
+    segmentIndex: index as 0 | 1 | 2,
+    expectedStartAt: '2026-03-02T01:00:00.000Z',
+    expectedEndAt: '2026-03-02T09:00:00.000Z',
+    expectedStartOffsetMinutes: 480,
+    expectedEndOffsetMinutes: 1080,
+    expectedStartFold: 'unique' as const,
+    expectedEndFold: 'unique' as const,
+    actualInAt: '2026-03-02T01:00:00.000Z',
+    actualOutAt: '2026-03-02T09:00:00.000Z',
+    workedMinutes,
+    lateMinutes: 0,
+    earlyLeaveMinutes: 0,
+    overtimeExtensionMinutes: 0,
+    excusedByLeave: false,
+    status: 'normal' as const,
+    reasons: ['within_window' as const],
+    matchedEvidenceRefs: [],
+    unmatchedEvidenceRefs: [],
+  }))
+  return {
+    outcome: 'completed',
+    outcomeReasonCode: 'calculated',
+    segments,
+    dailyProjection: {
+      firstInAt: '2026-03-02T01:00:00.000Z',
+      lastOutAt: '2026-03-02T09:00:00.000Z',
+      workedMinutes,
+      lateMinutes: 0,
+      earlyLeaveMinutes: 0,
+      status: 'normal',
+      timezone: TZ,
+      workDate: WORK_DATE,
+      meta: null,
+    },
+  }
+}
+
+function reviewCalculation(): AttendanceSegmentCalculationResultV1 {
+  return { outcome: 'review_required', outcomeReasonCode: 'ambiguous_segment_match', segments: [], dailyProjection: null }
+}
+
+const LEGACY_PROJECTION: AttendanceAuthoritativePreimageProjectionV1 = Object.freeze({
+  status: 'normal',
+  firstInAt: '2026-03-02T01:30:00.000Z',
+  lastOutAt: '2026-03-02T08:30:00.000Z',
+  workMinutes: 420,
+  lateMinutes: 0,
+  earlyLeaveMinutes: 0,
+})
+
+function presentLegacyPreimage(): AttendanceAuthoritativeParentPreimageV1 {
+  return {
+    posture: 'present',
+    projectionOwner: 'legacy_untracked',
+    currentCalculationId: null,
+    visibilityState: 'active',
+    visibilityReason: 'active',
+    projection: LEGACY_PROJECTION,
+    compatibilityFingerprint: HEX_A,
+  }
+}
+
+function segmentInput(overrides: Partial<Parameters<typeof writeAuthoritativeSegmentCalculationV1>[1]> = {}) {
+  const operationId = uuid()
+  const payloadFingerprint = HEX_B
+  return {
+    orgId: `org-${RUN}`,
+    recordId: '00000000-0000-0000-0000-000000000000',
+    entrypoint: 'live',
+    operationId,
+    calculation: completedCalculation(1),
+    attribution: resolvedAttribution() as never,
+    context: frozenContext() as never,
+    evidence: [],
+    approvedFacts: [],
+    provenanceRef: provenanceRef(),
+    inputProvenance: { schemaVersion: 1, payloadFingerprint },
+    payloadFingerprint,
+    preimage: presentLegacyPreimage(),
+    expectedCurrentCalculationId: null,
+    actorId: `actor-${RUN}`,
+    correlationId: `corr-${RUN}`,
+    ...overrides,
+  }
+}
+
+describeIfDatabase('W4C-2 Gate D1 — authoritative-mode result-write CORE (real DB)', () => {
+  const pool = new Pool({ connectionString: dbUrl })
+  let migrationDb: Kysely<unknown> | undefined
+
+  beforeAll(async () => {
+    migrationDb = new Kysely<unknown>({
+      dialect: new PostgresDialect({ pool: new Pool({ connectionString: dbUrl }) }),
+    })
+    await up(migrationDb)
+  }, 60000)
+
+  afterAll(async () => {
+    await migrationDb?.destroy()
+    await pool.end()
+  })
+
+  // ---- fixtures ----------------------------------------------------------
+
+  async function insertLegacyActiveParent(org: string): Promise<string> {
+    const { rows } = await pool.query(
+      `INSERT INTO attendance_records
+         (user_id, work_date, org_id, timezone, status, first_in_at, last_out_at,
+          work_minutes, late_minutes, early_leave_minutes)
+       VALUES ($1, $2::date, $3, $4, 'normal', $5, $6, 420, 0, 0)
+       RETURNING id::text AS id`,
+      [`u-${uuid()}`, WORK_DATE, org, TZ, LEGACY_PROJECTION.firstInAt, LEGACY_PROJECTION.lastOutAt],
+    )
+    return String(rows[0].id)
+  }
+
+  async function withTxn<T>(fn: (client: PoolClient) => Promise<T>): Promise<T> {
+    const client = await pool.connect()
+    try {
+      await client.query('BEGIN')
+      let result: T
+      try {
+        result = await fn(client)
+      } catch (error) {
+        await client.query('ROLLBACK').catch(() => undefined)
+        throw error
+      }
+      await client.query('COMMIT')
+      return result
+    } finally {
+      client.release()
+    }
+  }
+
+  async function expectProductCode(promise: Promise<unknown>, code: string): Promise<void> {
+    let caught: unknown
+    try {
+      await promise
+    } catch (error) {
+      caught = error
+    }
+    expect(caught).toBeInstanceOf(AttendanceW4AuthoritativeCalculationError)
+    expect((caught as AttendanceW4AuthoritativeCalculationError).code).toBe(code)
+  }
+
+  async function calcRow(id: string): Promise<Record<string, unknown> | undefined> {
+    const { rows } = await pool.query(
+      `SELECT * FROM attendance_record_calculations WHERE id = $1::uuid`,
+      [id],
+    )
+    return rows[0]
+  }
+
+  async function recordRow(id: string): Promise<Record<string, unknown>> {
+    const { rows } = await pool.query(`SELECT * FROM attendance_records WHERE id = $1::uuid`, [id])
+    return rows[0]
+  }
+
+  async function countCalcs(recordId: string): Promise<number> {
+    const { rows } = await pool.query(
+      `SELECT count(*)::int AS n FROM attendance_record_calculations WHERE attendance_record_id = $1::uuid`,
+      [recordId],
+    )
+    return rows[0].n as number
+  }
+
+  // First authoritative completed write on a fresh active legacy parent → returns {recordId, calcId}.
+  async function seedFirstCompleted(org: string): Promise<{ recordId: string; calcId: string; baselineId: string }> {
+    const recordId = await insertLegacyActiveParent(org)
+    const result = await withTxn((client) =>
+      writeAuthoritativeSegmentCalculationV1(asTrx(client), segmentInput({ orgId: org, recordId })),
+    )
+    if (result.kind !== 'completed') throw new Error('seed expected completed')
+    return { recordId, calcId: result.calculationId, baselineId: result.baselineCalculationId as string }
+  }
+
+  // =========================================================================
+  // Invariant 3 — legacy_baseline (built/tested first per build order).
+  // =========================================================================
+  describe('§7.3 invariant 3 — legacy_baseline', () => {
+    it('POSITIVE: append snapshots the legacy projection with effect=none, 0 children, op_id NULL, fp=compat', async () => {
+      const org = `org-b-${RUN}`
+      const recordId = await insertLegacyActiveParent(org)
+      const result = await withTxn((client) =>
+        appendAuthoritativeLegacyBaselineV1(asTrx(client), {
+          orgId: org,
+          recordId,
+          entrypoint: 'live',
+          projection: LEGACY_PROJECTION,
+          compatibilityFingerprint: HEX_A,
+          parentPreimageSnapshot: presentLegacyPreimage(),
+          actorId: `actor-${RUN}`,
+          correlationId: `corr-${RUN}`,
+        }),
+      )
+      expect(result.kind).toBe('appended')
+      const row = await calcRow(result.kind === 'appended' ? result.baselineCalculationId : '')
+      expect(row?.calculation_kind).toBe('legacy_baseline')
+      expect(row?.mode).toBe('authoritative')
+      expect(row?.outcome).toBe('baseline')
+      expect(row?.outcome_reason_code).toBe('legacy_projection_baseline')
+      expect(row?.projection_effect).toBe('none')
+      expect(row?.expected_segment_count).toBe(0)
+      expect(row?.operation_id).toBeNull()
+      expect(row?.supersedes_calculation_id).toBeNull()
+      expect(row?.projected_daily_fingerprint).toBe(HEX_A)
+    })
+
+    it('POSITIVE (idempotent): a second append returns the existing baseline, allocates no new row', async () => {
+      const org = `org-b2-${RUN}`
+      const recordId = await insertLegacyActiveParent(org)
+      const first = await withTxn((client) =>
+        appendAuthoritativeLegacyBaselineV1(asTrx(client), baselineInput(org, recordId)),
+      )
+      const second = await withTxn((client) =>
+        appendAuthoritativeLegacyBaselineV1(asTrx(client), baselineInput(org, recordId)),
+      )
+      expect(first.baselineCalculationId).toBe(second.baselineCalculationId)
+      expect(second.kind).toBe('exists')
+      expect(await countCalcs(recordId)).toBe(1)
+    })
+
+    it('NEGATIVE (product code): a non-hex compatibility fingerprint is refused with BASELINE_FINGERPRINT_INVALID', async () => {
+      const org = `org-b3-${RUN}`
+      const recordId = await insertLegacyActiveParent(org)
+      await expectProductCode(
+        withTxn((client) =>
+          appendAuthoritativeLegacyBaselineV1(asTrx(client), { ...baselineInput(org, recordId), compatibilityFingerprint: 'not-hex' }),
+        ),
+        CODES.BASELINE_FINGERPRINT_INVALID,
+      )
+      expect(await countCalcs(recordId)).toBe(0)
+    })
+
+    it('BACKSTOP (uq_arc_baseline): a raw second legacy_baseline with the same fingerprint is refused by the DB', async () => {
+      const org = `org-b4-${RUN}`
+      const recordId = await insertLegacyActiveParent(org)
+      await withTxn((client) => appendAuthoritativeLegacyBaselineV1(asTrx(client), baselineInput(org, recordId)))
+      let caught: unknown
+      try {
+        await withTxn((client) => rawInsertBaseline(client, org, recordId, HEX_A, 99))
+      } catch (error) {
+        caught = error
+      }
+      expect(caught).toBeTruthy()
+    })
+
+    it('SAME-TXN atomicity (§7.3): a failure in the calc step after the baseline write leaves NEITHER row', async () => {
+      // Active legacy parent + a completed calc whose projection carries a negative minute → the calc
+      // INSERT trips chk_arc_projected_minutes AFTER the baseline is appended in the same txn. If the
+      // baseline were written on a separate/auto-committing connection it would survive; it must not.
+      const org = `org-b5-${RUN}`
+      const recordId = await insertLegacyActiveParent(org)
+      const bad = completedCalculation(1)
+      ;(bad.dailyProjection as { workedMinutes: number }).workedMinutes = -1
+      let caught: unknown
+      try {
+        await withTxn((client) =>
+          writeAuthoritativeSegmentCalculationV1(asTrx(client), segmentInput({ orgId: org, recordId, calculation: bad })),
+        )
+      } catch (error) {
+        caught = error
+      }
+      expect(caught).toBeTruthy()
+      expect(await countCalcs(recordId)).toBe(0)
+    })
+  })
+
+  function baselineInput(org: string, recordId: string) {
+    return {
+      orgId: org,
+      recordId,
+      entrypoint: 'live',
+      projection: LEGACY_PROJECTION,
+      compatibilityFingerprint: HEX_A,
+      parentPreimageSnapshot: presentLegacyPreimage(),
+      actorId: `actor-${RUN}`,
+      correlationId: `corr-${RUN}`,
+    }
+  }
+
+  async function rawInsertBaseline(client: PoolClient, org: string, recordId: string, fp: string, version: number): Promise<void> {
+    await client.query(
+      `INSERT INTO attendance_record_calculations
+         (id, org_id, attendance_record_id, version, calculation_kind, mode, entrypoint, engine_version,
+          snapshot_schema_version, operation_id, semantic_input_fingerprint, provenance_fingerprint,
+          source_definition_fingerprint, attribution_snapshot, context_snapshot, segment_snapshot,
+          evidence_snapshot, approved_facts_snapshot, input_provenance, merge_policy, calculation_tier,
+          outcome, outcome_reason_code, projection_effect, expected_segment_count, projected_status,
+          projected_work_minutes, projected_late_minutes, projected_early_leave_minutes,
+          projected_daily_fingerprint, actor_id, correlation_id)
+       VALUES ($1::uuid, $2, $3::uuid, $4, 'legacy_baseline', 'authoritative', 'live', 'raw', 1, NULL,
+               $5, $5, $5, '{"posture":"unsupported","sourceSchemaVersion":1,"reason":"legacy_v1","sourceFingerprint":null}'::jsonb,
+               '{"schemaVersion":1}'::jsonb, '[]'::jsonb, '[]'::jsonb, '[]'::jsonb, '{"schemaVersion":1}'::jsonb,
+               'append', 'legacy_shadow', 'baseline', 'legacy_projection_baseline', 'none', 0, 'normal',
+               420, 0, 0, $5, 'raw-actor', $6)`,
+      [uuid(), org, recordId, version, fp, `raw-${RUN}`],
+    )
+  }
+
+  // =========================================================================
+  // Invariant 7 (completed) + invariant 4 (supersedes) — the main live path.
+  // =========================================================================
+  describe('§7.3 invariant 7 — completed normal calculation + parent pointer', () => {
+    it('POSITIVE: completed → baseline+calc appended, effect=set_active, count in 1..3, pointer moves, daily fields match', async () => {
+      const org = `org-c-${RUN}`
+      const { recordId, calcId, baselineId } = await seedFirstCompleted(org)
+      const calc = await calcRow(calcId)
+      expect(calc?.outcome).toBe('completed')
+      expect(calc?.mode).toBe('authoritative')
+      expect(calc?.projection_effect).toBe('set_active')
+      expect(calc?.expected_segment_count).toBe(1)
+      expect(calc?.calculation_tier).toBe('segment_authoritative')
+      expect(calc?.supersedes_calculation_id).toBe(baselineId)
+      expect(calc?.projected_daily_fingerprint).toBe(
+        projectedDailyFingerprintV1({ status: 'normal', firstInAt: '2026-03-02T01:00:00.000Z', lastOutAt: '2026-03-02T09:00:00.000Z', workedMinutes: 480, lateMinutes: 0, earlyLeaveMinutes: 0 }),
+      )
+      const rec = await recordRow(recordId)
+      expect(rec.current_calculation_id).toBe(calcId)
+      expect(rec.projection_owner).toBe('w4')
+      expect(rec.visibility_state).toBe('active')
+      expect(Number(rec.work_minutes)).toBe(480)
+      const seg = await pool.query(`SELECT count(*)::int AS n FROM attendance_record_segments WHERE calculation_id = $1::uuid`, [calcId])
+      expect(seg.rows[0].n).toBe(1)
+    })
+
+    it('NEGATIVE (product code): completed with 0 segments is refused with EXPECTED_COUNT_INVALID', async () => {
+      const org = `org-c2-${RUN}`
+      const recordId = await insertLegacyActiveParent(org)
+      const zero = completedCalculation(1)
+      zero.segments = []
+      await expectProductCode(
+        withTxn((client) => writeAuthoritativeSegmentCalculationV1(asTrx(client), segmentInput({ orgId: org, recordId, calculation: zero }))),
+        CODES.EXPECTED_COUNT_INVALID,
+      )
+      expect(await countCalcs(recordId)).toBe(0)
+    })
+
+    it('NEGATIVE (product code): completed without a frozen context is refused with COMPLETED_SHAPE_INVALID', async () => {
+      const org = `org-c3-${RUN}`
+      const recordId = await insertLegacyActiveParent(org)
+      await expectProductCode(
+        withTxn((client) => writeAuthoritativeSegmentCalculationV1(asTrx(client), segmentInput({ orgId: org, recordId, context: null }))),
+        CODES.COMPLETED_SHAPE_INVALID,
+      )
+      expect(await countCalcs(recordId)).toBe(0)
+    })
+
+    it('BACKSTOP (deferred count trigger): a completed row committed with the wrong child count is refused at COMMIT', async () => {
+      const org = `org-c4-${RUN}`
+      const recordId = await insertLegacyActiveParent(org)
+      let caught: unknown
+      try {
+        // expected_segment_count=2 but the writer produces exactly segments.length children (here 1) —
+        // force the mismatch by committing a raw completed row claiming 2 with 1 child.
+        await withTxn((client) => rawInsertCompletedWithChildren(client, org, recordId, 2, 1))
+      } catch (error) {
+        caught = error
+      }
+      expect(caught).toBeTruthy()
+    })
+  })
+
+  describe('§7.3 invariant 4 — supersedes the exact locked current pointer', () => {
+    it('POSITIVE: a second completed calc supersedes the first and the pointer moves to it', async () => {
+      const org = `org-s-${RUN}`
+      const { recordId, calcId: first } = await seedFirstCompleted(org)
+      const second = await withTxn((client) =>
+        writeAuthoritativeSegmentCalculationV1(asTrx(client), segmentInput({ orgId: org, recordId, expectedCurrentCalculationId: first, calculation: completedCalculation(1, 500) })),
+      )
+      if (second.kind !== 'completed') throw new Error('expected completed')
+      expect(second.supersedesCalculationId).toBe(first)
+      expect(second.baselineCalculationId).toBeNull()
+      const calc = await calcRow(second.calculationId)
+      expect(Number(calc?.version)).toBeGreaterThan(2)
+      const rec = await recordRow(recordId)
+      expect(rec.current_calculation_id).toBe(second.calculationId)
+    })
+
+    it('NEGATIVE (product code): a stale expectedCurrentCalculationId is refused with VERSION_CONFLICT', async () => {
+      const org = `org-s2-${RUN}`
+      const { recordId } = await seedFirstCompleted(org)
+      await expectProductCode(
+        withTxn((client) =>
+          // parent now points at the first calc, but the caller still believes it is null → stale.
+          writeAuthoritativeSegmentCalculationV1(asTrx(client), segmentInput({ orgId: org, recordId, expectedCurrentCalculationId: null, calculation: completedCalculation(1, 500) })),
+        ),
+        CODES.VERSION_CONFLICT,
+      )
+    })
+
+    it('NEGATIVE (product code): a missing parent record is refused with RECORD_NOT_FOUND', async () => {
+      const org = `org-s3-${RUN}`
+      await expectProductCode(
+        withTxn((client) => writeAuthoritativeSegmentCalculationV1(asTrx(client), segmentInput({ orgId: org, recordId: uuid() }))),
+        CODES.RECORD_NOT_FOUND,
+      )
+    })
+
+    it('BACKSTOP (uq_arc_record_version): a raw duplicate (record, version) is refused by the DB', async () => {
+      const org = `org-s4-${RUN}`
+      const { recordId } = await seedFirstCompleted(org)
+      let caught: unknown
+      try {
+        await withTxn((client) => rawInsertBaseline(client, org, recordId, HEX_B, 1))
+      } catch (error) {
+        caught = error
+      }
+      expect(caught).toBeTruthy()
+    })
+  })
+
+  // =========================================================================
+  // Invariant 2 — retry idempotency on (org, entrypoint, operation_id).
+  // =========================================================================
+  describe('§7.3 invariant 2 — retry idempotency', () => {
+    it('POSITIVE: the same operation_id twice returns the existing calc and allocates NO new version', async () => {
+      const org = `org-r-${RUN}`
+      const recordId = await insertLegacyActiveParent(org)
+      const input = segmentInput({ orgId: org, recordId })
+      const first = await withTxn((client) => writeAuthoritativeSegmentCalculationV1(asTrx(client), input))
+      const before = await countCalcs(recordId)
+      const second = await withTxn((client) => writeAuthoritativeSegmentCalculationV1(asTrx(client), input))
+      expect(second.kind).toBe('replay')
+      expect(second.calculationId).toBe(first.calculationId)
+      expect(await countCalcs(recordId)).toBe(before)
+    })
+
+    it('NEGATIVE (product code): the same operation_id with a different payload is refused with REPLAY_CONFLICT', async () => {
+      const org = `org-r2-${RUN}`
+      const recordId = await insertLegacyActiveParent(org)
+      const operationId = uuid()
+      await withTxn((client) =>
+        writeAuthoritativeSegmentCalculationV1(asTrx(client), segmentInput({ orgId: org, recordId, operationId, payloadFingerprint: HEX_A, inputProvenance: { schemaVersion: 1, payloadFingerprint: HEX_A } })),
+      )
+      await expectProductCode(
+        withTxn((client) =>
+          writeAuthoritativeSegmentCalculationV1(asTrx(client), segmentInput({ orgId: org, recordId, operationId, payloadFingerprint: HEX_B, inputProvenance: { schemaVersion: 1, payloadFingerprint: HEX_B } })),
+        ),
+        CODES.REPLAY_CONFLICT,
+      )
+    })
+
+    it('BACKSTOP (uq_arc_operation): a raw duplicate (org, entrypoint, operation_id) is refused by the DB', async () => {
+      const org = `org-r3-${RUN}`
+      const recordId = await insertLegacyActiveParent(org)
+      const operationId = uuid()
+      await withTxn((client) =>
+        writeAuthoritativeSegmentCalculationV1(asTrx(client), segmentInput({ orgId: org, recordId, operationId })),
+      )
+      let caught: unknown
+      try {
+        await withTxn((client) => rawInsertReviewWithOperation(client, org, recordId, operationId))
+      } catch (error) {
+        caught = error
+      }
+      expect(caught).toBeTruthy()
+    })
+  })
+
+  // =========================================================================
+  // Invariant 5 — review_required hidden placeholder (all projected NULL).
+  // =========================================================================
+  describe('§7.3 invariant 5 — review_required hidden placeholder', () => {
+    it('POSITIVE: every projected daily field is NULL, effect none, 0 children, no supersedes/pointer change', async () => {
+      const org = `org-rv-${RUN}`
+      const recordId = await insertLegacyActiveParent(org)
+      const before = await recordRow(recordId)
+      const result = await withTxn((client) =>
+        writeAuthoritativeSegmentCalculationV1(asTrx(client), segmentInput({ orgId: org, recordId, calculation: reviewCalculation() })),
+      )
+      expect(result.kind).toBe('review')
+      const row = await calcRow(result.kind === 'review' ? result.calculationId : '')
+      expect(row?.outcome).toBe('review_required')
+      expect(row?.projection_effect).toBe('none')
+      expect(row?.expected_segment_count).toBe(0)
+      expect(row?.supersedes_calculation_id).toBeNull()
+      for (const field of ['projected_status', 'projected_first_in_at', 'projected_last_out_at', 'projected_work_minutes', 'projected_late_minutes', 'projected_early_leave_minutes']) {
+        expect(row?.[field]).toBeNull()
+      }
+      // pointer untouched (still legacy_untracked / null)
+      const after = await recordRow(recordId)
+      expect(after.current_calculation_id).toBe(before.current_calculation_id)
+      expect(after.projection_owner).toBe('legacy_untracked')
+      // §7.3 "a later first completed result … needs no baseline because no active compatibility
+      // projection existed". This leg proves the CORE branch: a retired/review_placeholder parent
+      // (the state §7.5 requires a fresh authoritative review to install) takes NO baseline and no
+      // supersedes. The retired/review_placeholder precondition is installed here by fixture — it is
+      // NOT an end-to-end review→completed proof (the boundary, not this core, decides whether a
+      // fresh review leaves the parent retired; that is a D2/D3 seam, see the PR body's open items).
+      await pool.query(
+        `UPDATE attendance_records SET visibility_state='retired', visibility_reason='review_placeholder' WHERE id=$1::uuid`,
+        [recordId],
+      )
+      const completed = await withTxn((client) =>
+        writeAuthoritativeSegmentCalculationV1(asTrx(client), segmentInput({ orgId: org, recordId, expectedCurrentCalculationId: null })),
+      )
+      if (completed.kind !== 'completed') throw new Error('expected completed')
+      expect(completed.baselineCalculationId).toBeNull()
+      expect(completed.supersedesCalculationId).toBeNull()
+    })
+
+    it('NEGATIVE (product code): a review row carrying a non-null projected field is refused with REVIEW_SHAPE_INVALID', async () => {
+      const org = `org-rv2-${RUN}`
+      const recordId = await insertLegacyActiveParent(org)
+      const bad = reviewCalculation()
+      // a projection present on a review outcome is exactly the fabricated zero-minute row §7.5 forbids.
+      ;(bad as { dailyProjection: unknown }).dailyProjection = completedCalculation(1).dailyProjection
+      await expectProductCode(
+        withTxn((client) => writeAuthoritativeSegmentCalculationV1(asTrx(client), segmentInput({ orgId: org, recordId, calculation: bad }))),
+        CODES.REVIEW_SHAPE_INVALID,
+      )
+      expect(await countCalcs(recordId)).toBe(0)
+    })
+
+    it('BACKSTOP (chk_arc_review_shape): a raw review row with a non-null projected field is refused by the DB', async () => {
+      const org = `org-rv3-${RUN}`
+      const recordId = await insertLegacyActiveParent(org)
+      let caught: unknown
+      try {
+        await withTxn((client) => rawInsertReviewWithProjectedStatus(client, org, recordId))
+      } catch (error) {
+        caught = error
+      }
+      expect(caught).toBeTruthy()
+    })
+  })
+
+  // =========================================================================
+  // Invariant 6 — reversal.
+  // =========================================================================
+  describe('§7.3 invariant 6 — reversal', () => {
+    it('POSITIVE (present preimage): reversal restores the earlier calc; restores == preimage pointer; effect set_active; pointer restored', async () => {
+      const org = `org-x-${RUN}`
+      const { recordId, calcId: first } = await seedFirstCompleted(org)
+      const firstRow = await calcRow(first)
+      const second = await withTxn((client) =>
+        writeAuthoritativeSegmentCalculationV1(asTrx(client), segmentInput({ orgId: org, recordId, expectedCurrentCalculationId: first, calculation: completedCalculation(1, 500) })),
+      )
+      if (second.kind !== 'completed') throw new Error('expected completed')
+      const reversed = await calcRow(second.calculationId)
+      const reversal = await withTxn((client) =>
+        writeAuthoritativeReversalV1(asTrx(client), reversalInput(org, recordId, {
+          supersedesCalculationId: second.calculationId,
+          reversedRow: reversed as Record<string, unknown>,
+          preimage: presentPointerPreimage(first, projectionOf(firstRow as Record<string, unknown>)),
+          restoresCalculationId: first,
+          frozenTarget: { visibilityState: 'active', visibilityReason: 'active', projection: projectionOf(reversed as Record<string, unknown>), dailyFingerprint: String((reversed as Record<string, unknown>).projected_daily_fingerprint) },
+          outcomeReasonCode: 'import_rollback_reversal',
+          mergePolicy: 'reversal',
+        })),
+      )
+      expect(reversal.projectionEffect).toBe('set_active')
+      expect(reversal.restoresCalculationId).toBe(first)
+      const row = await calcRow(reversal.calculationId)
+      expect(row?.calculation_kind).toBe('reversal')
+      expect(row?.restores_calculation_id).toBe(first)
+      expect(row?.supersedes_calculation_id).toBe(second.calculationId)
+      const rec = await recordRow(recordId)
+      expect(rec.current_calculation_id).toBe(first) // pointer restored to the earlier calc
+    })
+
+    it('POSITIVE (absent preimage): reversal retires; restores NULL; effect set_retired; pointer moves to the reversal row', async () => {
+      const org = `org-x2-${RUN}`
+      const { recordId, calcId: first } = await seedFirstCompleted(org)
+      const reversed = await calcRow(first)
+      const reversal = await withTxn((client) =>
+        writeAuthoritativeReversalV1(asTrx(client), reversalInput(org, recordId, {
+          supersedesCalculationId: first,
+          reversedRow: reversed as Record<string, unknown>,
+          preimage: { posture: 'absent' },
+          restoresCalculationId: null,
+          frozenTarget: { visibilityState: 'retired', visibilityReason: 'import_rollback', projection: projectionOf(reversed as Record<string, unknown>), dailyFingerprint: String((reversed as Record<string, unknown>).projected_daily_fingerprint) },
+          outcomeReasonCode: 'import_rollback_reversal',
+          mergePolicy: 'reversal',
+        })),
+      )
+      expect(reversal.projectionEffect).toBe('set_retired')
+      expect(reversal.restoresCalculationId).toBeNull()
+      const row = await calcRow(reversal.calculationId)
+      expect(row?.restores_calculation_id).toBeNull()
+      const rec = await recordRow(recordId)
+      expect(rec.current_calculation_id).toBe(reversal.calculationId)
+      expect(rec.visibility_state).toBe('retired')
+      expect(rec.visibility_reason).toBe('import_rollback')
+    })
+
+    it('NEGATIVE (product code): a reversal without a supersedes target is refused with REVERSAL_SUPERSEDES_REQUIRED', async () => {
+      const org = `org-x3-${RUN}`
+      const { recordId, calcId: first } = await seedFirstCompleted(org)
+      const reversed = await calcRow(first)
+      await expectProductCode(
+        withTxn((client) =>
+          writeAuthoritativeReversalV1(asTrx(client), reversalInput(org, recordId, {
+            supersedesCalculationId: null,
+            reversedRow: reversed as Record<string, unknown>,
+            preimage: { posture: 'absent' },
+            restoresCalculationId: null,
+            frozenTarget: { visibilityState: 'retired', visibilityReason: 'import_rollback', projection: projectionOf(reversed as Record<string, unknown>), dailyFingerprint: String((reversed as Record<string, unknown>).projected_daily_fingerprint) },
+            outcomeReasonCode: 'import_rollback_reversal',
+            mergePolicy: 'reversal',
+          })),
+        ),
+        CODES.REVERSAL_SUPERSEDES_REQUIRED,
+      )
+    })
+
+    it('NEGATIVE (product code): a present preimage whose pointer != restores is refused with REVERSAL_RESTORES_MISMATCH', async () => {
+      const org = `org-x4-${RUN}`
+      const { recordId, calcId: first } = await seedFirstCompleted(org)
+      const reversed = await calcRow(first)
+      await expectProductCode(
+        withTxn((client) =>
+          writeAuthoritativeReversalV1(asTrx(client), reversalInput(org, recordId, {
+            supersedesCalculationId: first,
+            reversedRow: reversed as Record<string, unknown>,
+            preimage: presentPointerPreimage(uuid()), // pointer is some other id
+            restoresCalculationId: first, // ... but restores claims `first` → mismatch
+            frozenTarget: { visibilityState: 'active', visibilityReason: 'active', projection: projectionOf(reversed as Record<string, unknown>), dailyFingerprint: String((reversed as Record<string, unknown>).projected_daily_fingerprint) },
+            outcomeReasonCode: 'import_rollback_reversal',
+            mergePolicy: 'reversal',
+          })),
+        ),
+        CODES.REVERSAL_RESTORES_MISMATCH,
+      )
+    })
+
+    it('NEGATIVE (product code): a restores target that does not exist is refused with LINEAGE_TARGET_MISSING', async () => {
+      const org = `org-x5-${RUN}`
+      const { recordId, calcId: first } = await seedFirstCompleted(org)
+      const reversed = await calcRow(first)
+      const bogus = uuid()
+      await expectProductCode(
+        withTxn((client) =>
+          writeAuthoritativeReversalV1(asTrx(client), reversalInput(org, recordId, {
+            supersedesCalculationId: first,
+            reversedRow: reversed as Record<string, unknown>,
+            preimage: presentPointerPreimage(bogus), // pointer == bogus so restores-match passes
+            restoresCalculationId: bogus, // ... but no such calc exists → lineage target missing
+            frozenTarget: { visibilityState: 'active', visibilityReason: 'active', projection: projectionOf(reversed as Record<string, unknown>), dailyFingerprint: String((reversed as Record<string, unknown>).projected_daily_fingerprint) },
+            outcomeReasonCode: 'import_rollback_reversal',
+            mergePolicy: 'reversal',
+          })),
+        ),
+        CODES.LINEAGE_TARGET_MISSING,
+      )
+    })
+
+    it('BACKSTOP (chk_arc_reversal_supersedes): a raw reversal row with NULL supersedes is refused by the DB', async () => {
+      const org = `org-x6-${RUN}`
+      const { recordId } = await seedFirstCompleted(org)
+      let caught: unknown
+      try {
+        await withTxn((client) => rawInsertReversalNoSupersedes(client, org, recordId))
+      } catch (error) {
+        caught = error
+      }
+      expect(caught).toBeTruthy()
+    })
+  })
+
+  // =========================================================================
+  // Invariant 1 (lineage backstops) + invariant 8 (append-only).
+  // =========================================================================
+  describe('§7.3 invariant 1 — lineage backstops (DB)', () => {
+    it('BACKSTOP (trg_arc_lineage_guard): a raw supersedes pointing at a NOT-strictly-lower version is refused', async () => {
+      const org = `org-l-${RUN}`
+      const { recordId, calcId: first } = await seedFirstCompleted(org)
+      // first has version 2; a raw baseline claiming version 1 that supersedes `first` (v2) → v2 >= v1.
+      let caught: unknown
+      try {
+        await withTxn((client) => rawInsertSupersedingBaseline(client, org, recordId, first, 1))
+      } catch (error) {
+        caught = error
+      }
+      expect(caught).toBeTruthy()
+    })
+  })
+
+  describe('§7.3 invariant 8 — append-only (no updated_at, UPDATE refused)', () => {
+    it('the calc table has no updated_at column', async () => {
+      const { rows } = await pool.query(
+        `SELECT column_name FROM information_schema.columns
+          WHERE table_name='attendance_record_calculations' AND column_name='updated_at'`,
+      )
+      expect(rows.length).toBe(0)
+    })
+
+    it('BACKSTOP (deny_mutation): a raw UPDATE of a calc row is refused by the DB', async () => {
+      const org = `org-a-${RUN}`
+      const { calcId } = await seedFirstCompleted(org)
+      let caught: unknown
+      try {
+        await withTxn((client) => client.query(`UPDATE attendance_record_calculations SET actor_id='x' WHERE id=$1::uuid`, [calcId]).then(() => undefined))
+      } catch (error) {
+        caught = error
+      }
+      expect(caught).toBeTruthy()
+    })
+  })
+
+  // ---- raw helpers for backstop legs ------------------------------------
+
+  // For a present-pointer reversal the preimage projection MUST equal the restored calc's projection
+  // (the record's daily fields are set to it, and the DB pointer guard checks them against the
+  // selected row). Callers restoring a real calc pass that calc's projection; the negative legs
+  // (which fail before the pointer move) can leave the default.
+  function presentPointerPreimage(
+    pointer: string,
+    projection: AttendanceAuthoritativePreimageProjectionV1 = LEGACY_PROJECTION,
+  ): AttendanceAuthoritativeParentPreimageV1 {
+    return {
+      posture: 'present',
+      projectionOwner: 'w4',
+      currentCalculationId: pointer,
+      visibilityState: 'active',
+      visibilityReason: 'active',
+      projection,
+      compatibilityFingerprint: HEX_A,
+    }
+  }
+
+  function projectionOf(row: Record<string, unknown>): AttendanceAuthoritativePreimageProjectionV1 {
+    return {
+      status: String(row.projected_status ?? 'normal'),
+      firstInAt: row.projected_first_in_at ? new Date(row.projected_first_in_at as string).toISOString() : null,
+      lastOutAt: row.projected_last_out_at ? new Date(row.projected_last_out_at as string).toISOString() : null,
+      workMinutes: Number(row.projected_work_minutes ?? 0),
+      lateMinutes: Number(row.projected_late_minutes ?? 0),
+      earlyLeaveMinutes: Number(row.projected_early_leave_minutes ?? 0),
+    }
+  }
+
+  function reversalInput(
+    org: string,
+    recordId: string,
+    spec: {
+      supersedesCalculationId: string | null
+      reversedRow: Record<string, unknown>
+      preimage: AttendanceAuthoritativeParentPreimageV1
+      restoresCalculationId: string | null
+      frozenTarget: { visibilityState: 'active' | 'retired'; visibilityReason: 'active' | 'review_placeholder' | 'import_rollback' | 'operator_retirement'; projection: AttendanceAuthoritativePreimageProjectionV1; dailyFingerprint: string }
+      outcomeReasonCode: 'import_rollback_reversal' | 'operator_retirement'
+      mergePolicy: 'reversal' | 'retire'
+    },
+  ) {
+    const r = spec.reversedRow
+    return {
+      orgId: org,
+      recordId,
+      entrypoint: 'import_rollback',
+      operationId: uuid(),
+      supersedesCalculationId: spec.supersedesCalculationId,
+      reversedSnapshots: {
+        semanticInputFingerprint: String(r.semantic_input_fingerprint),
+        provenanceFingerprint: String(r.provenance_fingerprint),
+        sourceDefinitionFingerprint: r.source_definition_fingerprint ? String(r.source_definition_fingerprint) : null,
+        attributionSnapshot: r.attribution_snapshot,
+        contextSnapshot: r.context_snapshot ?? null,
+        evidenceSnapshot: Array.isArray(r.evidence_snapshot) ? (r.evidence_snapshot as unknown[]) : [],
+        approvedFactsSnapshot: Array.isArray(r.approved_facts_snapshot) ? (r.approved_facts_snapshot as unknown[]) : [],
+        manualOverrideSnapshot: r.manual_override_snapshot ?? null,
+      },
+      inputProvenance: { schemaVersion: 1, kind: 'import_rollback' },
+      preimage: spec.preimage,
+      frozenTarget: spec.frozenTarget,
+      restoresCalculationId: spec.restoresCalculationId,
+      outcomeReasonCode: spec.outcomeReasonCode,
+      mergePolicy: spec.mergePolicy,
+      actorId: `actor-${RUN}`,
+      correlationId: `corr-${RUN}`,
+    }
+  }
+
+  async function rawInsertCompletedWithChildren(client: PoolClient, org: string, recordId: string, claimed: number, children: number): Promise<void> {
+    const id = uuid()
+    await client.query(
+      `INSERT INTO attendance_record_calculations
+         (id, org_id, attendance_record_id, version, calculation_kind, mode, entrypoint, engine_version,
+          snapshot_schema_version, operation_id, semantic_input_fingerprint, provenance_fingerprint,
+          source_definition_fingerprint, attribution_snapshot, context_snapshot, segment_snapshot,
+          evidence_snapshot, approved_facts_snapshot, input_provenance, merge_policy, calculation_tier,
+          outcome, outcome_reason_code, projection_effect, expected_segment_count, projected_status,
+          projected_work_minutes, projected_late_minutes, projected_early_leave_minutes,
+          projected_daily_fingerprint, actor_id, correlation_id)
+       VALUES ($1::uuid, $2, $3::uuid, 900, 'calculation', 'authoritative', 'live', 'raw', 1, $4::uuid,
+               $5, $5, $5, '{"posture":"resolved_v2","value":{}}'::jsonb, '{"tz":"x"}'::jsonb, '[]'::jsonb,
+               '[]'::jsonb, '[]'::jsonb, '{"schemaVersion":1}'::jsonb, 'append', 'segment_authoritative',
+               'completed', 'calculated', 'set_active', $6, 'normal', 480, 0, 0, $5, 'raw', $7)`,
+      [id, org, recordId, uuid(), HEX_A, claimed, `raw-${RUN}`],
+    )
+    for (let i = 0; i < children; i += 1) {
+      await client.query(
+        `INSERT INTO attendance_record_segments
+           (org_id, record_id, calculation_id, segment_index, expected_start_at, expected_end_at,
+            work_minutes, late_minutes, early_leave_minutes, status, status_reasons,
+            matched_evidence_refs, unmatched_evidence_refs)
+         VALUES ($1, $2::uuid, $3::uuid, $4, '2026-03-02T01:00:00Z', '2026-03-02T09:00:00Z',
+                 480, 0, 0, 'normal', '["within_window"]'::jsonb, '[]'::jsonb, '[]'::jsonb)`,
+        [org, recordId, id, i],
+      )
+    }
+  }
+
+  async function rawInsertReviewWithOperation(client: PoolClient, org: string, recordId: string, operationId: string): Promise<void> {
+    await client.query(
+      `INSERT INTO attendance_record_calculations
+         (id, org_id, attendance_record_id, version, calculation_kind, mode, entrypoint, engine_version,
+          snapshot_schema_version, operation_id, semantic_input_fingerprint, provenance_fingerprint,
+          source_definition_fingerprint, attribution_snapshot, context_snapshot, segment_snapshot,
+          evidence_snapshot, approved_facts_snapshot, input_provenance, merge_policy, calculation_tier,
+          outcome, outcome_reason_code, projection_effect, expected_segment_count, actor_id, correlation_id)
+       VALUES ($1::uuid, $2, $3::uuid, 901, 'calculation', 'authoritative', 'live', 'raw', 1, $4::uuid,
+               $5, $5, NULL, '{"posture":"unsupported","sourceSchemaVersion":1,"reason":"missing","sourceFingerprint":null}'::jsonb,
+               NULL, '[]'::jsonb, '[]'::jsonb, '[]'::jsonb, '{"schemaVersion":1}'::jsonb, 'append',
+               'segment_authoritative', 'review_required', 'ambiguous_segment_match', 'none', 0, 'raw', $6)`,
+      [uuid(), org, recordId, operationId, HEX_A, `raw-${RUN}`],
+    )
+  }
+
+  async function rawInsertReviewWithProjectedStatus(client: PoolClient, org: string, recordId: string): Promise<void> {
+    await client.query(
+      `INSERT INTO attendance_record_calculations
+         (id, org_id, attendance_record_id, version, calculation_kind, mode, entrypoint, engine_version,
+          snapshot_schema_version, operation_id, semantic_input_fingerprint, provenance_fingerprint,
+          source_definition_fingerprint, attribution_snapshot, context_snapshot, segment_snapshot,
+          evidence_snapshot, approved_facts_snapshot, input_provenance, merge_policy, calculation_tier,
+          outcome, outcome_reason_code, projection_effect, expected_segment_count, projected_status, actor_id, correlation_id)
+       VALUES ($1::uuid, $2, $3::uuid, 902, 'calculation', 'authoritative', 'live', 'raw', 1, $4::uuid,
+               $5, $5, NULL, '{"posture":"unsupported","sourceSchemaVersion":1,"reason":"missing","sourceFingerprint":null}'::jsonb,
+               NULL, '[]'::jsonb, '[]'::jsonb, '[]'::jsonb, '{"schemaVersion":1}'::jsonb, 'append',
+               'segment_authoritative', 'review_required', 'ambiguous_segment_match', 'none', 0, 'normal', 'raw', $6)`,
+      [uuid(), org, recordId, uuid(), HEX_A, `raw-${RUN}`],
+    )
+  }
+
+  async function rawInsertReversalNoSupersedes(client: PoolClient, org: string, recordId: string): Promise<void> {
+    await client.query(
+      `INSERT INTO attendance_record_calculations
+         (id, org_id, attendance_record_id, version, calculation_kind, mode, entrypoint, engine_version,
+          snapshot_schema_version, operation_id, semantic_input_fingerprint, provenance_fingerprint,
+          source_definition_fingerprint, attribution_snapshot, context_snapshot, segment_snapshot,
+          evidence_snapshot, approved_facts_snapshot, input_provenance, merge_policy, calculation_tier,
+          outcome, outcome_reason_code, projection_effect, expected_segment_count, projected_status,
+          projected_work_minutes, projected_late_minutes, projected_early_leave_minutes, projected_daily_fingerprint, actor_id, correlation_id)
+       VALUES ($1::uuid, $2, $3::uuid, 903, 'reversal', 'authoritative', 'import_rollback', 'raw', 1, $4::uuid,
+               $5, $5, $5, '{"posture":"resolved_v2","value":{}}'::jsonb, '{"tz":"x"}'::jsonb, '[]'::jsonb,
+               '[]'::jsonb, '[]'::jsonb, '{"schemaVersion":1}'::jsonb, 'reversal', 'segment_authoritative',
+               'reversed', 'import_rollback_reversal', 'set_retired', 0, 'normal', 480, 0, 0, $5, 'raw', $6)`,
+      [uuid(), org, recordId, uuid(), HEX_A, `raw-${RUN}`],
+    )
+  }
+
+  async function rawInsertSupersedingBaseline(client: PoolClient, org: string, recordId: string, supersedes: string, version: number): Promise<void> {
+    await client.query(
+      `INSERT INTO attendance_record_calculations
+         (id, org_id, attendance_record_id, version, calculation_kind, mode, entrypoint, engine_version,
+          snapshot_schema_version, supersedes_calculation_id, operation_id, semantic_input_fingerprint,
+          provenance_fingerprint, source_definition_fingerprint, attribution_snapshot, context_snapshot,
+          segment_snapshot, evidence_snapshot, approved_facts_snapshot, input_provenance, merge_policy,
+          calculation_tier, outcome, outcome_reason_code, projection_effect, expected_segment_count,
+          projected_status, projected_work_minutes, projected_late_minutes, projected_early_leave_minutes,
+          projected_daily_fingerprint, actor_id, correlation_id)
+       VALUES ($1::uuid, $2, $3::uuid, $7, 'reversal', 'authoritative', 'import_rollback', 'raw', 1, $4::uuid, $8::uuid,
+               $5, $5, $5, '{"posture":"resolved_v2","value":{}}'::jsonb, '{"tz":"x"}'::jsonb, '[]'::jsonb,
+               '[]'::jsonb, '[]'::jsonb, '{"schemaVersion":1}'::jsonb, 'reversal', 'segment_authoritative',
+               'reversed', 'import_rollback_reversal', 'set_retired', 0, 'normal', 480, 0, 0, $5, 'raw', $6)`,
+      [uuid(), org, recordId, supersedes, HEX_A, `raw-${RUN}`, version, uuid()],
+    )
+  }
+})

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -590,6 +590,13 @@ export default defineConfig({
       // no-DB job cannot skip-green it; wired whole-file into the attendance
       // real-DB step in plugin-tests.yml (two-point wiring).
       'tests/integration/attendance-w4c2-gate-matrix-e5.db.test.ts',
+      // #4556 W4C-2 Gate D1 (#4844): the INERT authoritative-mode result-write CORE's §7.3
+      // invariant matrix (version-uniqueness + lineage, retry idempotency, baseline + same-txn
+      // atomicity, supersedes-locked-current, review hidden-placeholder, reversal restore/retire,
+      // projection_effect/count, append-only) against real Postgres. DATABASE_URL-gated; excluded
+      // here so the no-DB job cannot skip-green it; wired whole-file into the attendance real-DB
+      // step in plugin-tests.yml (two-point wiring).
+      'tests/integration/attendance-w4c2-authoritative-calculation-core.db.test.ts',
       // W4C-2 P1-2 (#4556, PR #4617 amendment, RATIFIED, owner Bundle A) — the schema/
       // migration half: scheduled-run identity tables, the outbox discriminated union,
       // the append-only per-target outcome side table, and their gates (1, 9, 11, 12 DB

--- a/plugins/plugin-integration-core/lib/sealed-export/vectors/s6a-package-provenance-pins.json
+++ b/plugins/plugin-integration-core/lib/sealed-export/vectors/s6a-package-provenance-pins.json
@@ -86,6 +86,6 @@
     "s6aAcceptancePs51Test": "835c7c6ce943d82e0378a40a27c7fd1e8b79b526faa8ca4c8066e4231a4bfb0f",
     "s6aProductRuntimeTest": "de978adafa8b89772cefa921c2051f434bf346bf5c2978bef3424ee70f51ba3f",
     "multitableOnpremPackageBuild": "ae477a24375a7269e5710a3481905c9b74255c03fd802841a16849aca48ee33a",
-    "pluginTestsWorkflow": "46dbca8e0e62ec561f7de79269a85bd50f500b6475dc0d1fb928ce5fe18ba78e"
+    "pluginTestsWorkflow": "b90a0e7843de57bde659c4705b44de5e0a11352e9cf27c2c14c6e1c4d3b31648"
   }
 }

--- a/scripts/attendance/w4c0-dml-inventory/calculation-read-classification.cjs
+++ b/scripts/attendance/w4c0-dml-inventory/calculation-read-classification.cjs
@@ -18,6 +18,16 @@ function entry(relPath, enclosingSymbol, table, count, posture, role, requiredPr
 
 const ATTENDANCE_CALCULATION_READ_CLASSIFICATIONS = Object.freeze([
   entry('packages/core-backend/src/attendance/w4c2-live-scheduled-boundary.ts', 'nextCalculationVersion', 'attendance_record_calculations', 1, 'history', 'version_allocation'),
+  // #4556 W4C-2 Gate D1 (#4844): the INERT authoritative-result-write CORE. All four reads are
+  // internal write-path preconditions over the immutable calculation lineage (version allocation,
+  // strictly-lower lineage check, at-most-one-baseline existence read, and the (org,entrypoint,
+  // operation_id) idempotency/replay lookup) — none is the "current" active projection. No
+  // production caller yet (D2 wires live_punch, D3 wires scheduled); the reads are exercised only by
+  // the core's real-PG suite.
+  entry('packages/core-backend/src/attendance/w4c2-authoritative-calculation-core.ts', 'nextCalculationVersion', 'attendance_record_calculations', 1, 'history', 'version_allocation'),
+  entry('packages/core-backend/src/attendance/w4c2-authoritative-calculation-core.ts', 'assertLineageStrictlyLower', 'attendance_record_calculations', 1, 'history', 'lineage_precondition'),
+  entry('packages/core-backend/src/attendance/w4c2-authoritative-calculation-core.ts', 'appendAuthoritativeLegacyBaselineV1', 'attendance_record_calculations', 1, 'history', 'legacy_baseline_precondition'),
+  entry('packages/core-backend/src/attendance/w4c2-authoritative-calculation-core.ts', 'retryReplayLookup', 'attendance_record_calculations', 1, 'history', 'idempotency_replay_precondition'),
   entry('packages/core-backend/src/attendance/w4c3a-canonical-import-kernel.ts', 'nextCalculationVersion', 'attendance_record_calculations', 1, 'history', 'version_allocation'),
   entry('packages/core-backend/src/attendance/w4c3a-canonical-import-kernel.ts', 'appendLegacyBaselineIfRequired', 'attendance_record_calculations', 1, 'history', 'legacy_baseline_precondition'),
   entry('packages/core-backend/src/attendance/w4c3a-import-rollback-boundary.ts', 'legacyDeleteEligible', 'attendance_record_calculations', 1, 'history', 'rollback_precondition'),

--- a/scripts/attendance/w4c0-dml-inventory/curated-debt-entries.cjs
+++ b/scripts/attendance/w4c0-dml-inventory/curated-debt-entries.cjs
@@ -567,6 +567,30 @@ const CURATED_DEBT_ENTRIES = [
       ].includes(site.table),
   },
   {
+    id: 'X06',
+    title: 'W4C-2 Gate D1 authoritative-result-write CORE: the parent-pointer/visibility move on attendance_records for a completed or reversed authoritative calculation (§7.5). INERT — no production caller; D2 wires live_punch, D3 wires scheduled.',
+    owningSlice: 'W4C-2',
+    sharedHook: false,
+    // NOT the 'W4C-2' removed-by-adapter marker (that exact set is pinned to the four legacy P01-P04
+    // writers). This is the canonical authoritative WRITER Gate D1 adds, not a legacy site being
+    // canonicalized away — its own Gate-D1 marker.
+    canonicalizedBy: 'W4C-2-gate-d1',
+    // The only tracked business DML in this INERT core is the attendance_records UPDATE that moves
+    // the parent pointer/owner/visibility to the just-appended authoritative row (completed →
+    // set_active; reversal → restore/retire). The calc/segment INSERTs target the append-only
+    // immutable tables (not the business daily-row bucket). Claimed per-writer by symbol so a new
+    // attendance_records writer added to this file cannot inherit the claim silently.
+    claims: (site) =>
+      bySymbol(
+        'packages/core-backend/src/attendance/w4c2-authoritative-calculation-core.ts',
+        /^writeCompletedRow$/,
+      )(site) ||
+      bySymbol(
+        'packages/core-backend/src/attendance/w4c2-authoritative-calculation-core.ts',
+        /^writeAuthoritativeReversalV1$/,
+      )(site),
+  },
+  {
     id: 'X05',
     title: 'AttendanceExpiryService scheduled comp-time/leave-balance expiry sweep.',
     owningSlice: 'W4C-3b (unconfirmed)',

--- a/scripts/attendance/w4c0-dml-inventory/current-record-read-classification.cjs
+++ b/scripts/attendance/w4c0-dml-inventory/current-record-read-classification.cjs
@@ -11,6 +11,11 @@ function entry(relPath, enclosingSymbol, count, role) {
 
 const ATTENDANCE_RECORD_BASE_READ_CLASSIFICATIONS = Object.freeze([
   entry('packages/core-backend/src/attendance/w4c2-live-scheduled-boundary.ts', 'lockShadowParentRecord', 1, 'write_lock'),
+  // #4556 W4C-2 Gate D1 (#4844): the INERT authoritative-result-write CORE locks the exact base
+  // parent row FOR UPDATE before moving its pointer/visibility — it MUST read the base table (not
+  // the current view) to serialize the pointer move and to read the true projection_owner /
+  // current_calculation_id it supersedes. INERT: no production caller yet (D2/D3 wire it).
+  entry('packages/core-backend/src/attendance/w4c2-authoritative-calculation-core.ts', 'lockParent', 1, 'write_lock'),
   entry('packages/core-backend/src/attendance/w4c3a-canonical-import-kernel.ts', 'captureParentPreimages', 1, 'historical_preimage'),
   entry('packages/core-backend/src/attendance/w4c3a-canonical-import-kernel.ts', 'ensureAuthoritativeParent', 1, 'write_precondition'),
   entry('packages/core-backend/src/attendance/w4c3a-import-rollback-boundary.ts', 'loadAuthorizationTargets', 1, 'rollback_authority'),

--- a/scripts/ops/attendance-w4c2-ci-wiring.test.mjs
+++ b/scripts/ops/attendance-w4c2-ci-wiring.test.mjs
@@ -2208,6 +2208,7 @@ const EXPECTED_ATTENDANCE_SUITES = Object.freeze([
   'tests/integration/attendance-w4c0-identity-gates-e2.db.test.ts',
   'tests/integration/attendance-w4c0-identity-golden-parity.db.test.ts',
   'tests/integration/attendance-w4c0-operation-registry.db.test.ts',
+  'tests/integration/attendance-w4c2-authoritative-calculation-core.db.test.ts',
   'tests/integration/attendance-w4c2-gate-matrix-e5.db.test.ts',
   'tests/integration/attendance-w4c2-live-scheduled-boundary.db.test.ts',
   'tests/integration/attendance-w4c2-outbox-dispatcher.db.test.ts',


### PR DESCRIPTION
## Gate D1 — INERT authoritative-mode result-write CORE for `attendance_record_calculations` (#4556 / #4844)

Delivers the shared, contract-enforcing writer for `mode='authoritative'` rows — the §7.3/7.4/7.5/7.7/7.8 logic of the RATIFIED W4 lock (`attendance-issue-4556-w4-segment-calculation-design-lock-20260724.md`) — built **INERT**. D2 wires `live_punch`, D3 wires `scheduled`; each removes a `boundaryFail` site and flips its declaration in its own reviewed change. **Draft: do not merge, do not mark ready.**

New files:
- `packages/core-backend/src/attendance/w4c2-authoritative-calculation-core.ts` — the core (baseline / calculation completed+review / reversal, one parameterized INSERT).
- `packages/core-backend/tests/integration/attendance-w4c2-authoritative-calculation-core.db.test.ts` — 28-leg real-Postgres proof.

### Extraction decision — Option B (thin shared helpers + one mode-specific assembler)
The shadow builder `insertShadowCalculation` hardcodes 4 mode literals and omits 5 authoritative-only columns; unifying it into a `mode`-parameterized fn would require editing the shadow writer inside the 2200-line boundary file (altering emitted SQL, threading NULLs), which cannot be proven byte-identical as cheaply as not touching it and touches the very file the correspondence guard scans. **Shadow stays byte-identical by absence from this diff — no existing `src/` file is modified.** The core instead carries ONE parameterized INSERT (`insertResolvedAuthoritativeCalculationRowV1`) that all three kinds funnel through, so column logic is not hand-duplicated (defensible vs "a 7th copy"). `projectedDailyFingerprintV1` mirrors the four existing private copies byte-for-byte; the four are intentionally left un-rewired (separate, non-inert refactor). **Baseline fingerprint is caller-supplied** (`preimage.compatibilityFingerprint`), never self-computed — matching the import kernel (`:907-909`) so it is the frozen value the baseline-uniqueness index is keyed on; at-most-one-baseline is enforced by an existence read mirroring kernel `:875-883`.

### Two enforcement layers per invariant
(a) the core pre-validates and refuses with a **product code** (never a raw SQLSTATE) — the mutatable layer; (b) the W4C-0 DB CHECK/trigger is the backstop, each proven by a raw-insert leg that bypasses (a).

### §7.3 invariant → test matrix (28 legs, all green on real PG)
| # | Invariant | Positive | Negative (product code) | DB backstop leg |
|---|---|---|---|---|
| 1 | version-uniqueness + lineage | 2 sequential calcs → v N,N+1, 2nd supersedes 1st | `LINEAGE_TARGET_MISSING` (via reversal restores) | `uq_arc_record_version`, `trg_arc_lineage_guard` (not-strictly-lower) |
| 2 | retry idempotency (org,entrypoint,operation_id) | same op twice → 1 row, replay | `REPLAY_CONFLICT` (same op, diff payload) | `uq_arc_operation` |
| 3 | legacy_baseline | effect=none, 0 children, op_id NULL, fp=compat; idempotent | `BASELINE_FINGERPRINT_INVALID` | `uq_arc_baseline`; **same-txn atomicity**: forced failure after baseline → neither row persists |
| 4 | supersedes exact locked current | 2nd completed supersedes 1st, pointer moves | `VERSION_CONFLICT` (stale expected), `RECORD_NOT_FOUND` | `uq_arc_record_version` |
| 5 | review hidden placeholder | every projected field NULL, effect none, no pointer/baseline | `REVIEW_SHAPE_INVALID` | `chk_arc_review_shape` |
| 6 | reversal | present→restores==preimage pointer, set_active; absent→restores NULL, set_retired | `REVERSAL_SUPERSEDES_REQUIRED`, `REVERSAL_RESTORES_MISMATCH` | `chk_arc_reversal_supersedes` |
| 7 | projection_effect / count | completed→set_active, count 1..3, segments | `EXPECTED_COUNT_INVALID`, `COMPLETED_SHAPE_INVALID` | deferred `trg_arc_children_commit_guard` |
| 8 | append-only | no `updated_at` column | — | `deny_mutation` refuses UPDATE |

### Mutation verification
**Empirically mutated (guard neutered → the exact negative leg reddens, nothing else, restored via `cp`):** `VERSION_CONFLICT` (confirms the pre-check is the sole stale-predecessor guard — the optimistic UPDATE keys off the *locked actual*, not the caller's expectation, so the two do not cover for each other), `REVIEW_SHAPE_INVALID` (the core hardcodes NULL projected fields, so only the guard rejects a review-with-projection), `REPLAY_CONFLICT`, `REVERSAL_RESTORES_MISMATCH`. **Argued-not-executed (structural):** the remaining product-code guards fall through to a DB SQLSTATE / crash when neutered (different error than the asserted product code → the leg reddens); the independent gate should run the full sweep. `LINEAGE_SELF_REFERENCE` / `LINEAGE_NOT_STRICTLY_LOWER` are unreachable via the public API with valid inputs — defensive pre-validation backed by `trg_arc_lineage_guard`; their negatives live on the DB backstop.

### INERT / byte-neutral proof
- No existing `src/` file modified — the boundary + `w4c2-authoritative-delivery.ts` are untouched (`git diff` empty for both).
- `DECLARED_DELIVERED` unchanged `{live_punch:false, scheduled:false}`; the 3 `boundaryFail('W4C2_AUTHORITATIVE_MODE_NOT_DELIVERED', 503)` sites intact; the new core does **not** contain that call form (the header backtick-quotes the code name only).
- Correspondence guard `w4c3a-rollout-control-inventory.test.ts` — **15/15 green**.
- No production caller: the only importer of the core is its test file (grep of `src/` = 0; no barrel globs the dir).
- **Deletion-green** — the set is `{core module, test file, plugin-tests.yml run-list line, vitest.config exclude line, ci-wiring pinned-family line, pin JSON reverted to 46dbca8e…}`; removing the core + test leaves the package type-checking (verified: no dangling reference), and reverting `plugin-tests.yml` reverts the pin.

### Two-point wiring + provenance pin
- `vitest.config.ts` exclude (so the no-DB job cannot skip-green it) + `plugin-tests.yml` attendance real-DB run-list — the CI-wiring guard's `runs exactly once (no-DB exclude ⟺ real-DB run-list)` leg passes for the new file.
- `plugin-tests.yml` changed ⇒ provenance pin regen: `evidenceFiles.pluginTestsWorkflow` in `vectors/s6a-package-provenance-pins.json` → `b90a0e78…` (was `46dbca8e…`); **only that digest moved** (`sealed-export-package-provenance.test.cjs` OK).
- `scripts/ops/attendance-w4c2-ci-wiring.test.mjs` pinned-family set updated (alphabetical position) — **225/225 green**; `integration-guard-required-wiring-contract.test.mjs` **62/62 green**.

### Checks run locally vs CI-only
- **Local:** full `type-check` (0 errors); the 28-leg suite against real Postgres (`metasheet_test`); correspondence guard 15/15; ci-wiring 225/225; integration-guard contract 62/62; provenance-pin test OK; deletion-green type-check; 4 mutation probes.
- **CI-only:** the whole attendance real-DB batch through `plugin-tests.yml` (provisioned Postgres); required-check aggregation.

### Open items for the gate/owner (named, not resolved in D1)
1. **Live-path compatibility-fingerprint source (D1→D2 seam).** The completed path needs `preimage.compatibilityFingerprint` to append the baseline on an active legacy parent; today ONLY import/rollback/ops freeze such a value — the live/scheduled boundary has no producer. D2 must supply one (deterministically, over the parent's legacy daily projection) or `PREIMAGE_INVALID` fails closed. Named in the core header. The at-most-one-baseline existence read makes cross-path fingerprint values inconsequential for uniqueness, but the live path still needs a frozen source.
2. **Retry-conflict semantics** on `(org,entrypoint,operation_id)` with a differing payload → `REPLAY_CONFLICT` is **precedent-derived** (mirrors `w4c3c-recompute.ts:283`), not lock-derived.
3. Invariant-5's "later completed needs no baseline" leg installs the retired/`review_placeholder` precondition **by fixture** (disclosed in the leg comment) — it proves the core branch, not an end-to-end review→completed flow (that is a D2/D3 boundary concern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
