### PR TITLE
fix(attendance): #4556 Gate A Option B — retire plugin env-gate, port is one source of truth

### DIFF
--- a/packages/core-backend/tests/integration/attendance-plugin.test.ts
+++ b/packages/core-backend/tests/integration/attendance-plugin.test.ts
@@ -150,6 +150,15 @@ function createPluginDbForTest(pool: Pool) {
           const result = await client.query(sql, params as any[])
           return result.rows
         },
+        // #4556 Gate A / Option B: mirror the production plugin-context db adapter
+        // (`context.api.database.transaction` attaches `__rawClient: client`, src/index.ts).
+        // In-process writers that resolve the canonical segment-calculation posture port on
+        // their write trx (e.g. the auto-shift auto-write job) require this raw pg client seam;
+        // without it the port fails closed with `W4C3B_TRANSACTION_CLIENT_REQUIRED`. This fixture
+        // stood in for the production db before those writers were cut over to the port, so it
+        // never modelled `__rawClient`; add it so the mock stays faithful to the contract every
+        // production caller (`context.api.database`) already satisfies.
+        __rawClient: client,
       }
       try {
         await client.query('BEGIN')

--- a/packages/core-backend/tests/integration/attendance-shift-segments-writer-matrix.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-shift-segments-writer-matrix.db.test.ts
@@ -1645,6 +1645,96 @@ describeDb('W3 shift-segments writer matrix (real DB, route-level)', () => {
     expect(await countRows('attendance_shift_assignments', orgId)).toBe(0)
   })
 
+  /**
+   * #4556 Gate A / owner P1 — ROLLOUT-LOCK ORDER COUNTEREXAMPLE (deterministic, two real
+   * connections, real approval route).
+   *
+   * The hazard: the rollout TRANSITION path takes the rollout advisory lock EXCLUSIVE first and
+   * only then `SELECT ... FROM attendance_requests ... FOR UPDATE` (w4c3a-rollout-control.ts —
+   * exclusive at the top of the control transaction, request scan at `:948`). If the APPROVAL
+   * transaction were to take the request row lock FIRST and reach for the rollout SHARED lock
+   * only later (e.g. inside finalization, which is where this cutover wired a posture call),
+   * the two form a textbook wait cycle:
+   *     approval  holds request row   + waits rollout-shared
+   *     transition holds rollout-excl + waits request row
+   * PostgreSQL's detector fires and one side dies with SQLSTATE 40P01.
+   *
+   * This test pins the SAFE order by construction, against the production HTTP approval chain:
+   *   1. conn B opens a transaction and takes the rollout advisory lock EXCLUSIVE for the org
+   *      (same key builder the production code uses — not a hand-rolled key).
+   *   2. conn A fires the real approval route. It must block on the rollout SHARED lock
+   *      **before** it has taken any `attendance_requests` row lock.
+   *   3. conn B then takes `FOR UPDATE` on that very request row. This SUCCEEDS only because A
+   *      holds no row lock — it is the discriminating observation.
+   *   4. conn B commits (releasing exclusive); A then proceeds and completes.
+   *
+   * Load-bearing: hoisting the approval's posture resolution back BELOW the request row lock
+   * makes step 3 block on A while A waits on B ⇒ genuine deadlock, and the run dies with
+   * `40P01`. Verified by executing exactly that mutation.
+   */
+  it('P1: approval acquires the rollout lock BEFORE any request row lock (no deadlock vs a concurrent transition)', async () => {
+    const { buildAttendanceCalculationRolloutAdvisoryKey } = await import('../../src/attendance/w4c0-identity')
+    const orgId = randomUUID() // canonical rollout org key, so the port really takes the lock
+    const actorId = `${orgId}-admin`
+    await seedActiveIdentity(actorId, orgId)
+    const token = await mintToken(actorId, orgId)
+    const shiftId = (await createShiftViaApi(token, orgId, { name: 'Lock order', workStartTime: '09:00', workEndTime: '18:00' })).body.data.id as string
+    await seedDispatchFlow(token, orgId)
+    const scheduleGroupId = await seedScheduleGroup(orgId)
+
+    const create = await postJson('/api/attendance/schedule-dispatch-requests', token, orgId, {
+      userId: `${orgId}-worker`,
+      targetScheduleGroupId: scheduleGroupId,
+      targetShiftId: shiftId,
+      startDate: '2049-08-01',
+      endDate: '2049-08-01',
+    })
+    expect(create.status, create.raw).toBe(201)
+    const requestId = create.body.data.request.id as string
+
+    const advisoryKey = buildAttendanceCalculationRolloutAdvisoryKey(orgId as never).toString()
+    const connB = await pool.connect()
+    let approval: Promise<HttpResponse> | undefined
+    try {
+      // (1) transition-order connection: rollout EXCLUSIVE first.
+      await connB.query('BEGIN')
+      await connB.query('SELECT pg_advisory_xact_lock($1::bigint)', [advisoryKey])
+
+      // (2) approval, real route. Blocks on the rollout SHARED lock.
+      approval = postJson(`/api/attendance/requests/${requestId}/approve`, token, orgId, { comment: 'go' })
+      // Give the approval time to reach (and block on) the rollout lock.
+      await new Promise((resolve) => setTimeout(resolve, 1500))
+
+      // (3) THE DISCRIMINATOR: the transition-order connection now takes the same request row.
+      // With the safe ordering the approval is parked on the advisory lock holding no row lock,
+      // so this returns promptly. With the inverted ordering this blocks on the approval while
+      // the approval waits on us -> 40P01.
+      await connB.query('SET LOCAL lock_timeout = \'20s\'')
+      const locked = await connB.query(
+        'SELECT id FROM attendance_requests WHERE id = $1::uuid FOR UPDATE',
+        [requestId],
+      )
+      expect(locked.rows).toHaveLength(1)
+
+      // (4) release the exclusive lock; the approval may now proceed.
+      await connB.query('COMMIT')
+    } catch (error) {
+      await connB.query('ROLLBACK').catch(() => undefined)
+      // Surface a deadlock explicitly rather than as an opaque failure.
+      const code = (error as { code?: string })?.code
+      throw new Error(`transition-order connection failed${code ? ` (SQLSTATE ${code})` : ''}: ${String(error)}`)
+    } finally {
+      connB.release()
+    }
+
+    const approveRes = await approval!
+    // The approval must NOT have died of a deadlock. Its own outcome may legitimately be a
+    // typed refusal, but never a 40P01-driven 500.
+    expect(approveRes.raw).not.toContain('40P01')
+    expect(approveRes.raw).not.toContain('deadlock')
+    expect([200, 201, 422]).toContain(approveRes.status)
+  })
+
   it('matrix: automatic matching apply returns typed 422 with zero writes', async () => {
     const orgId = org('matrix-automatch')
     const token = await mintToken(`${orgId}-admin`, orgId)

--- a/packages/core-backend/tests/integration/attendance-shift-segments-writer-matrix.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-shift-segments-writer-matrix.db.test.ts
@@ -126,14 +126,21 @@ describeDb('W3 shift-segments writer matrix (real DB, route-level)', () => {
     return `w3wm-${tag}-${randomUUID().slice(0, 8)}`
   }
 
-  async function enableShadowPosture(orgId: string): Promise<void> {
-    process.env.ATTENDANCE_SHIFT_SEGMENT_CALCULATION_ENABLED = orgId
+  // Persist a `shadow` rollout-state row for an org (no env mutation). Factored out of
+  // enableShadowPosture so the Gate A lock-in describe can seed rows for orgs it reaches only
+  // via the wildcard — reusing the SAME INSERT text, so no new DML statement is introduced.
+  async function insertShadowRolloutRow(orgId: string): Promise<void> {
     await pool.query(
       `INSERT INTO attendance_calculation_rollout_state
          (org_id, state, engine_version, reason_code, actor_id, version, prior_state)
        VALUES ($1, 'shadow', 'w4c3b-p12-test', 'TEST_FIXTURE', 'w4c3b-p12-test', 1, NULL)`,
       [orgId],
     )
+  }
+
+  async function enableShadowPosture(orgId: string): Promise<void> {
+    process.env.ATTENDANCE_SHIFT_SEGMENT_CALCULATION_ENABLED = orgId
+    await insertShadowRolloutRow(orgId)
   }
 
   async function mintToken(userId: string, tenantId?: string): Promise<string> {
@@ -1993,5 +2000,78 @@ describeDb('W3 shift-segments writer matrix (real DB, route-level)', () => {
       clientD2.release()
       clientW2.release()
     }
+  })
+
+  /**
+   * #4556 Gate A / Option B lock-in (real-PG, route-level, production writer chain).
+   *
+   * After the cutover the ONLY authorization for a multi-segment shift reference is the core
+   * canonical posture port (exact-org allowlist, wildcard REFUSED, persisted rollout row). One
+   * env value holds org A EXACTLY plus the wildcard `*`. Three orgs, one production writer route
+   * (`POST /api/attendance/assignments` -> the `assignment_create` reference guard):
+   *   - org A: exact env entry + a persisted `shadow` row => the guard admits the multi-segment
+   *     reference and the writer chain persists a row (200/201, non-vacuous);
+   *   - org B: no env entry and no row => typed 422 + zero writes (fail-closed baseline);
+   *   - org W: a persisted `shadow` row but reachable only via the wildcard `*` => STILL 422 +
+   *     zero writes — the wildcard is INERT, which is the security property this gate locks in.
+   *
+   * Mutation-provable against the private `isOrgExactlyAllowlisted` body (execution point
+   * `resolveSegmentCalculationPosture` consults, NOT the re-export wrapper):
+   *   - re-admit `*` (add `if (entries.includes('*')) return true`) => org W leg flips 422->201;
+   *     org A stays 201, org B stays 422 (still no row);
+   *   - force it to always return false => org A leg flips 201->422; org B and org W stay 422.
+   * Org B is the fail-closed baseline; it is NOT separately mutation-proven, because a no-row org
+   * resolves `legacy` regardless of the allowlist (POSTURE_TABLE has no non-legacy row for it).
+   */
+  describe('Gate A lock-in: exact-org allows, wildcard is inert', () => {
+    const orgA = randomUUID()
+    const orgB = randomUUID()
+    const orgW = randomUUID()
+    let tokenA = ''
+    let tokenB = ''
+    let tokenW = ''
+
+    beforeAll(async () => {
+      // Org A exact + wildcard. randomUUID() is already the canonical lower-case org key, so the
+      // env entry, the persisted row's org_id, and the request org header are byte-identical.
+      process.env.ATTENDANCE_SHIFT_SEGMENT_CALCULATION_ENABLED = `${orgA},*`
+      await insertShadowRolloutRow(orgA)
+      await insertShadowRolloutRow(orgW)
+      tokenA = await mintToken(`${orgA}-admin`, orgA)
+      tokenB = await mintToken(`${orgB}-admin`, orgB)
+      tokenW = await mintToken(`${orgW}-admin`, orgW)
+    })
+
+    // Author a multi-segment shift (preview-only, always allowed) then drive the production
+    // active-assignment writer, whose reference guard resolves the port on its own write trx.
+    async function attemptMultiSegmentAssignment(token: string, orgId: string): Promise<HttpResponse> {
+      const shiftId = await createMultiShift(token, orgId, 'Gate A lock-in split')
+      return postJson('/api/attendance/assignments', token, orgId, {
+        userId: `${orgId}-worker`,
+        shiftId,
+        startDate: '2049-07-01',
+      })
+    }
+
+    it('org A (exact env entry + persisted shadow row) admits the multi-segment reference and persists a row', async () => {
+      const res = await attemptMultiSegmentAssignment(tokenA, orgA)
+      expect(res.status, res.raw).toBe(201)
+      // Non-vacuous: the production writer chain ran to completion, not merely past the guard.
+      expect(await countRows('attendance_shift_assignments', orgA)).toBe(1)
+    })
+
+    it('org B (no env entry, no rollout row) fails closed with the typed 422 and zero writes', async () => {
+      const res = await attemptMultiSegmentAssignment(tokenB, orgB)
+      expect(res.status, res.raw).toBe(422)
+      expect(codeOf(res)).toBe(GUARD_CODE)
+      expect(await countRows('attendance_shift_assignments', orgB)).toBe(0)
+    })
+
+    it('org W (persisted shadow row, reachable only via the wildcard) STILL fails closed — wildcard inert', async () => {
+      const res = await attemptMultiSegmentAssignment(tokenW, orgW)
+      expect(res.status, res.raw).toBe(422)
+      expect(codeOf(res)).toBe(GUARD_CODE)
+      expect(await countRows('attendance_shift_assignments', orgW)).toBe(0)
+    })
   })
 })

--- a/packages/core-backend/tests/integration/attendance-shift-segments-writer-matrix.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-shift-segments-writer-matrix.db.test.ts
@@ -73,6 +73,12 @@ function requestJson(url: string, options: { method?: string; headers?: Record<s
 }
 
 const codeOf = (r: HttpResponse) => r.body?.error?.code
+// The typed 422's message embeds the `producer` of the guard that refused
+// ("... so <producer> cannot use a multi-segment shift", attendance-shift-service.cjs).
+// That makes the producer an observable ATTRIBUTION channel on the HTTP response: it
+// identifies WHICH reference guard fail-closed, not merely that some guard did. Used by
+// the P2-1 leg below to hold one specific writer site load-bearing on its own.
+const messageOf = (r: HttpResponse) => String(r.body?.error?.message ?? '')
 
 describeDb('W3 shift-segments writer matrix (real DB, route-level)', () => {
   let server: MetaSheetServerType | undefined
@@ -1579,6 +1585,63 @@ describeDb('W3 shift-segments writer matrix (real DB, route-level)', () => {
     expect(state.rows[0].status).toBe('pending')
     expect(state.rows[0].publish_status).toBe('pending')
     expect(state.rows[0].finalized_at).toBeNull()
+    expect(await countRows('attendance_shift_assignments', orgId)).toBe(0)
+  })
+
+  /**
+   * #4556 Gate A / P2-1 — hold the `schedule_dispatch_final_approval` posture wiring
+   * (`index.cjs`, the `referenceSegments:` argument of its `assertShiftReferenceAllowed`
+   * call) load-bearing ON ITS OWN.
+   *
+   * Why the leg above cannot do it: forcing THAT ONE site fail-open (`referenceSegments: true`)
+   * leaves it green, because a SECOND fail-closed door downstream —
+   * `assertWorkContextSegmentCalculationAllowed` (hardcoded `referenceSegments: false`, one of
+   * this cutover's disclosed residual-R4 pinned-closed read paths) — refuses the same request
+   * and produces an identical `422` + identical error code. Classic 多道 fail-closed 门互相掩护:
+   * status and code are dominated, so neither can discriminate.
+   *
+   * What still discriminates, without opening the R4 door: WHICH producer refused. The typed
+   * 422's message names the refusing guard's `producer`. Correct behaviour ⇒ the dispatch
+   * final-approval guard refuses FIRST and the message names `schedule_dispatch_final_approval`.
+   * With that one site forced fail-open, the request survives it and is refused later by the
+   * calculation read path instead, whose message names `attendance calculation` — so this leg
+   * REDS while status/code stay 422/GUARD_CODE. Verified by executing exactly that mutation.
+   *
+   * Residual (disclosed in the PR body): this is an attribution-level proof, not a status-flip
+   * proof. A 200-vs-422 behavioural flip at this site remains impossible while the R4 door is
+   * pinned closed; closing P2-1 fully is therefore a BLOCKING precondition on the R4 slice,
+   * which is exactly what makes this site live.
+   */
+  it('P2-1: schedule-dispatch final approval 422 is attributed to ITS OWN guard, not to the covering R4 door', async () => {
+    const orgId = org('p21-dispatch-final-attribution')
+    const actorId = `${orgId}-admin`
+    await seedActiveIdentity(actorId, orgId)
+    const token = await mintToken(actorId, orgId)
+    const shiftId = (await createShiftViaApi(token, orgId, { name: 'Day', workStartTime: '09:00', workEndTime: '18:00' })).body.data.id as string
+    await seedDispatchFlow(token, orgId)
+    const scheduleGroupId = await seedScheduleGroup(orgId)
+
+    const create = await postJson('/api/attendance/schedule-dispatch-requests', token, orgId, {
+      userId: `${orgId}-worker`,
+      targetScheduleGroupId: scheduleGroupId,
+      targetShiftId: shiftId,
+      startDate: '2049-06-10',
+      endDate: '2049-06-10',
+    })
+    expect(create.status, create.raw).toBe(201)
+    const requestId = create.body.data.request.id as string
+
+    await injectSecondSegment(orgId, shiftId)
+    const approve = await postJson(`/api/attendance/requests/${requestId}/approve`, token, orgId, { comment: 'go' })
+    expect(approve.status, approve.raw).toBe(422)
+    expect(codeOf(approve)).toBe(GUARD_CODE)
+
+    // The load-bearing assertions: the refusal is attributed to the dispatch final-approval
+    // writer's own guard. If that site stops consuming the resolved posture, the refusal
+    // migrates to the calculation read path and both assertions fail.
+    expect(messageOf(approve), approve.raw).toContain('schedule_dispatch_final_approval')
+    expect(messageOf(approve), approve.raw).not.toContain('attendance calculation')
+
     expect(await countRows('attendance_shift_assignments', orgId)).toBe(0)
   })
 

--- a/packages/core-backend/tests/unit/attendance-shift-segments-service.test.ts
+++ b/packages/core-backend/tests/unit/attendance-shift-segments-service.test.ts
@@ -5,8 +5,11 @@
  * - first-to-last arithmetic must never replace the per-segment sum
  *   (plannedMinutes leg below fails if breaks are counted);
  * - removing one segment from the sum changes plannedMinutes;
- * - dropping the org scope from the capability flag check flips org isolation;
- * - accepting more than one midnight crossing / overlapping segments must fail.
+ * - the capability projection stays values-safe (no org id leaks into the DTO);
+ * - accepting more than one midnight crossing / overlapping segments must fail;
+ * - #4556 Gate A / Option B: the shift service reads NO environment value for reference
+ *   authorization — a multi-segment reference is fail-closed unless the caller passes the
+ *   canonical posture (`referenceSegments: true`) resolved from the core port.
  */
 import { randomUUID } from 'node:crypto'
 import { afterEach, describe, expect, it } from 'vitest'
@@ -316,13 +319,22 @@ describe('capability projection and org-scoped flag', () => {
     expect(JSON.stringify(capabilities)).not.toContain('org-a')
   })
 
-  it('does not let an env value claim W4 capability before the calculator exists', () => {
+  it('never consults the environment for authorization (the plugin env-gate is retired)', () => {
+    // #4556 Gate A / Option B: the plugin's own `isSegmentCalculationEnabled` env predicate
+    // (which wrongly accepted the '*' wildcard) has been deleted. The one source of truth for
+    // reference-writer authorization is now the core posture port, which callers resolve and
+    // pass as an explicit boolean. This unit proves the shift service reads NO environment value
+    // for that decision: a multi-segment reference with no explicit posture stays fail-closed
+    // regardless of the env, including the former wildcard-accept value.
     process.env[FLAG] = ' org-a , org-b '
-    expect(service.isSegmentCalculationEnabled('org-a')).toBe(false)
-    expect(service.isSegmentCalculationEnabled('org-b')).toBe(false)
-    expect(service.isSegmentCalculationEnabled('org-c')).toBe(false)
+    expect(() => service.assertSegmentCalculationAllowed({
+      orgId: 'org-a', shiftId: 'shift-x', segmentCount: 2, producer: 'attendance calculation',
+    })).toThrow(expect.objectContaining({ status: 422, code: ERR.MULTI_SEGMENT_CALCULATION_DISABLED }))
     process.env[FLAG] = '*'
-    expect(service.isSegmentCalculationEnabled('org-c')).toBe(false)
+    expect(() => service.assertSegmentCalculationAllowed({
+      orgId: 'org-c', shiftId: 'shift-x', segmentCount: 2, producer: 'attendance calculation',
+    })).toThrow(expect.objectContaining({ status: 422, code: ERR.MULTI_SEGMENT_CALCULATION_DISABLED }))
+    // The values-safe capability projection is pinned closed regardless of env, too.
     expect(service.buildShiftCapabilities('org-c').segmentCalculation).toMatchObject({
       enabled: false,
       authoritativeResults: false,

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -8352,11 +8352,18 @@ function getAttendanceGroupFixedScheduleEffectivenessService() {
 function assertWorkContextSegmentCalculationAllowed(orgId, workContext) {
   if (!workContext || workContext.source === 'rule') return
   const shift = workContext.rule
+  // #4556 Gate A / Option B: this synchronous calculation read path has no write trx / port in
+  // hand, so it is pinned to the closed legacy posture (`referenceSegments: false`). That is
+  // byte-identical to the retired env-gate's production behaviour (the plugin master gate was
+  // OFF, so a multi-segment work context always failed closed here). Residual R4+: once an org
+  // is turned on via Gate C its reference writers will be admitted while this read path still
+  // fails closed on a multi-segment shift, until it is re-sourced from the port in a later slice.
   getAttendanceShiftService().assertSegmentCalculationAllowed({
     orgId,
     shiftId: shift?.id,
     segmentCount: shift?.segmentCount,
     producer: 'attendance calculation',
+    referenceSegments: false,
   })
 }
 
@@ -11099,6 +11106,7 @@ async function applyAttendanceGroupFixedSchedule(db, input) {
     orgId: effectiveInput.orgId,
     shiftId: effectiveInput.shiftId,
     producer: 'fixed_schedule_apply',
+    referenceSegments: await resolveReferenceSegmentsPostureForWrite(db, effectiveInput.orgId),
   })
   const result = await buildAttendanceGroupFixedSchedulePlan(db, effectiveInput, { lockTargets: true })
   if (!result.ok) return result
@@ -11158,6 +11166,7 @@ async function rebuildAttendanceGroupFixedSchedule(db, input) {
     orgId: effectiveInput.orgId,
     shiftId: effectiveInput.shiftId,
     producer: 'fixed_schedule_rebuild',
+    referenceSegments: await resolveReferenceSegmentsPostureForWrite(db, effectiveInput.orgId),
   })
   const result = await buildAttendanceGroupFixedSchedulePlan(db, effectiveInput, {
     lockTargets: true,
@@ -14045,6 +14054,22 @@ let attendanceW4ActiveCurrentPort = null
 let w4RecordOperationBoundary = null
 let attendanceW4SegmentCalculationPortRef = null
 
+// #4556 Gate A / Option B cutover: the ONE seam every reference-producing writer consults to
+// learn whether an org's canonical posture admits a multi-segment shift reference. Resolves
+// the core posture port on the CALLER's write transaction (exact-org allowlist, wildcard
+// REFUSED, persisted rollout row required) and returns a strict boolean. An absent port is the
+// closed legacy posture (`referenceSegments: false`), so every writer stays fail-closed exactly
+// as before this cutover. The resolved boolean is passed explicitly to the shift-service guard;
+// the plugin no longer reads any environment predicate for reference-writer authorization, so
+// there is one source of truth. Mirrors the schedule-publication writer's established pattern.
+async function resolveReferenceSegmentsPostureForWrite(trx, orgId) {
+  const port = attendanceW4SegmentCalculationPortRef
+  const posture = port && typeof port.resolveOrgSegmentCalculationPosture === 'function'
+    ? await port.resolveOrgSegmentCalculationPosture(trx, orgId)
+    : { effectiveState: 'legacy', referenceSegments: false }
+  return posture.referenceSegments === true
+}
+
 function requireAttendanceActiveCurrentPort() {
   if (!attendanceW4ActiveCurrentPort) {
     throw new HttpError(
@@ -16361,6 +16386,10 @@ async function applyAutoShiftMatchingItems(db, {
   return db.transaction(async (trx) => {
     const applied = []
     const skipped = []
+    // #4556 Gate A / Option B: resolve the org's canonical posture ONCE for the whole apply
+    // (org is constant across items), hoisted above the per-item loop; every matched
+    // candidate's reference guard consumes this explicit boolean.
+    const autoMatchReferenceSegments = await resolveReferenceSegmentsPostureForWrite(trx, orgId)
     for (const item of items) {
       await acquireAttendanceScheduleAssignmentLock(trx, orgId, item.userId)
       const producerKey = buildAutoShiftMatchProducerKey(item.userId, item.workDate)
@@ -16434,6 +16463,7 @@ async function applyAutoShiftMatchingItems(db, {
         orgId,
         shiftId: item.candidateShiftId,
         producer: 'auto_shift_matching',
+        referenceSegments: autoMatchReferenceSegments,
       })
 
       const assignmentRows = await trx.query(
@@ -31527,6 +31557,7 @@ module.exports = {
         orgId,
         shiftRefs: [requesterSource.shiftId, counterpartySource.shiftId],
         producer: 'shift_swap_final_approval',
+        referenceSegments: await resolveReferenceSegmentsPostureForWrite(client, orgId),
       })
 
       const settings = await getSettings(client)
@@ -31888,6 +31919,7 @@ module.exports = {
         orgId,
         shiftId: detail.target_shift_id,
         producer: 'schedule_dispatch_final_approval',
+        referenceSegments: await resolveReferenceSegmentsPostureForWrite(client, orgId),
       })
 
       await assertScheduleDispatchScopeAllowed(client, orgId, actorAccess, buildScheduleDispatchSchedulerScopeTarget({
@@ -33187,6 +33219,7 @@ module.exports = {
         orgId: route.orgId,
         shiftId: input.targetShiftId,
         producer: 'schedule_dispatch_create',
+        referenceSegments: await resolveReferenceSegmentsPostureForWrite(trx, route.orgId),
       })
       await assertScheduleDispatchScopeAllowed(trx, route.orgId, {
         userId: route.actorId,
@@ -33460,6 +33493,7 @@ module.exports = {
         orgId: route.orgId,
         shiftRefs: [lockedRequesterSource.shiftId, lockedCounterpartySource.shiftId],
         producer: 'shift_swap_create',
+        referenceSegments: await resolveReferenceSegmentsPostureForWrite(trx, route.orgId),
       })
       if (lockedRequesterSource.userId !== route.actorId && !(await canAccessOtherUsers(route.actorId))) {
         throw new HttpError(403, 'FORBIDDEN', 'No access to create a shift-swap request for this requester')
@@ -38434,6 +38468,7 @@ module.exports = {
               orgId,
               shiftRefs: payload.shiftSequence,
               producer: 'rotation_rule_create',
+              referenceSegments: await resolveReferenceSegmentsPostureForWrite(trx, orgId),
             })
             return trx.query(
               `INSERT INTO attendance_rotation_rules
@@ -38527,6 +38562,7 @@ module.exports = {
               orgId,
               shiftRefs: payload.shiftSequence,
               producer: 'rotation_rule_update',
+              referenceSegments: await resolveReferenceSegmentsPostureForWrite(trx, orgId),
             })
             return trx.query(
               `UPDATE attendance_rotation_rules
@@ -38786,6 +38822,7 @@ module.exports = {
               orgId,
               shiftRefs: ruleRows[0]?.shift_sequence,
               producer: 'rotation_assignment_write',
+              referenceSegments: await resolveReferenceSegmentsPostureForWrite(trx, orgId),
             })
             const conflict = await findAttendanceScheduleAssignmentConflict(trx, {
               kind: 'rotation',
@@ -38929,6 +38966,7 @@ module.exports = {
               orgId,
               shiftRefs: ruleRows[0]?.shift_sequence,
               producer: 'rotation_assignment_write',
+              referenceSegments: await resolveReferenceSegmentsPostureForWrite(trx, orgId),
             })
             const conflict = await findAttendanceScheduleAssignmentConflict(trx, {
               kind: 'rotation',
@@ -39121,6 +39159,7 @@ module.exports = {
               orgId,
               shiftRefs: ruleRows[0]?.shift_sequence,
               producer: 'rotation_assignment_write',
+              referenceSegments: await resolveReferenceSegmentsPostureForWrite(trx, orgId),
             })
             const conflict = await findAttendanceScheduleAssignmentConflict(trx, {
               kind: 'rotation',
@@ -39272,6 +39311,7 @@ module.exports = {
               orgId,
               shiftRefs: ruleRows[0]?.shift_sequence,
               producer: 'rotation_assignment_write',
+              referenceSegments: await resolveReferenceSegmentsPostureForWrite(trx, orgId),
             })
             const conflict = await findAttendanceScheduleAssignmentConflict(trx, {
               kind: 'rotation',
@@ -46558,6 +46598,7 @@ module.exports = {
               orgId,
               shiftId: payload.shiftId,
               producer: 'draft_assignment_create',
+              referenceSegments: await resolveReferenceSegmentsPostureForWrite(trx, orgId),
             })
             const replacementValidation = await validateTemporaryShiftReplacement(trx, { orgId, payload, temporary })
             if (!replacementValidation.ok) return { temporaryError: replacementValidation.error }
@@ -46745,6 +46786,7 @@ module.exports = {
               orgId,
               shiftId: payload.shiftId,
               producer: 'draft_assignment_update',
+              referenceSegments: await resolveReferenceSegmentsPostureForWrite(trx, orgId),
             })
             const conflict = await findAttendanceScheduleAssignmentConflict(trx, {
               kind: 'shift',
@@ -46958,6 +47000,7 @@ module.exports = {
               orgId,
               shiftId: payload.shiftId,
               producer: 'assignment_create',
+              referenceSegments: await resolveReferenceSegmentsPostureForWrite(trx, orgId),
             })
             const conflict = await findAttendanceScheduleAssignmentConflict(trx, {
               kind: 'shift',
@@ -47137,6 +47180,7 @@ module.exports = {
               orgId,
               shiftId: payload.shiftId,
               producer: 'assignment_update',
+              referenceSegments: await resolveReferenceSegmentsPostureForWrite(trx, orgId),
             })
             const conflict = await findAttendanceScheduleAssignmentConflict(trx, {
               kind: 'shift',

--- a/plugins/plugin-attendance/lib/attendance-shift-service.cjs
+++ b/plugins/plugin-attendance/lib/attendance-shift-service.cjs
@@ -54,9 +54,19 @@ const SEGMENT_MIN = 1
 const SEGMENT_MAX = 3
 const MINUTES_PER_DAY = 1440
 const SEGMENT_CALCULATION_FLAG_ENV = 'ATTENDANCE_SHIFT_SEGMENT_CALCULATION_ENABLED'
-// W3 has no authoritative segment calculator. An environment value alone must never
-// make reference writers accept multi-segment shifts or advertise authoritative
-// results. W4 must flip this only in the same reviewed change that adds the calculator.
+// #4556 Gate A / Option B cutover: this constant is NO LONGER a reference-writer gate.
+// The plugin's own env-reading predicate (`isSegmentCalculationEnabled`) has been retired
+// so there is ONE source of truth for reference-writer authorization — the core canonical
+// posture port (`resolveOrgSegmentCalculationPosture`, exact-org allowlist, wildcard-refused,
+// persisted rollout row). Every reference writer now resolves the port on its write trx and
+// passes an explicit boolean; nothing here reads the environment for authorization.
+//
+// The constant survives ONLY as an injected, values-safe DIAGNOSTIC of whether the W4
+// AUTHORITATIVE CALCULATOR itself has shipped (it has not — this stays `false`). Its sole
+// consumer is the W6 group effective-policy aggregate via `attendance-admin.ts`, where it is
+// the second conjunct of `calculationPosture === 'authoritative' && segmentCalculationImplemented`
+// — i.e. even an org the port resolves `authoritative` must not be shown 'effective' results
+// until the calculator exists. Flipping it belongs to the reviewed change that lands W4C-1.
 const SEGMENT_CALCULATION_IMPLEMENTED = false
 const SHIFT_REFERENCE_DELETED_LABEL = 'Deleted or unavailable shift'
 
@@ -487,27 +497,19 @@ function createAttendanceShiftService(deps) {
   }
 
   /**
-   * Org-scoped authoritative-calculation flag. The env var holds a comma-separated
-   * list of opted-in org ids ('*' = all); unset/empty means OFF for every org.
-   * W3 ships it OFF everywhere; enabling it is a separately authorized rollout step.
-   */
-  function isSegmentCalculationEnabled(orgId) {
-    if (!SEGMENT_CALCULATION_IMPLEMENTED) return false
-    const raw = typeof process.env[SEGMENT_CALCULATION_FLAG_ENV] === 'string'
-      ? process.env[SEGMENT_CALCULATION_FLAG_ENV]
-      : ''
-    const entries = raw.split(',').map((entry) => entry.trim()).filter(Boolean)
-    if (entries.length === 0) return false
-    if (entries.includes('*')) return true
-    return entries.includes(String(orgId ?? DEFAULT_ORG_ID))
-  }
-
-  /**
    * Values-safe capability projection: state and labels only, no secrets and no
    * member/user values. Shows authoritative segment calculation disabled by default.
+   *
+   * #4556 Gate A / Option B: this projection is a pure DTO with no write trx / port in
+   * hand, so it is pinned to the closed legacy posture (`enabled: false`) rather than
+   * re-deriving posture from the environment. That is byte-identical to the retired
+   * env-gate's production behaviour (the plugin master gate was OFF, so this was always
+   * `false`). The authoritative reference-writer decision is made by the port, not here;
+   * a shadow/authoritative org's capability hint stays 'preview_only' until the read DTO
+   * is re-sourced from the port in a later slice (tracked residual R4).
    */
   function buildShiftCapabilities(orgId) {
-    const enabled = isSegmentCalculationEnabled(orgId)
+    const enabled = false
     return {
       segmentCalculation: {
         enabled,
@@ -762,7 +764,13 @@ function createAttendanceShiftService(deps) {
       if (mode === 'segments') {
         segments = validateShiftSegments(patch.segments)
         const currentCount = currentSegmentCount === 0 ? 1 : currentSegmentCount
-        if (segments.length > 1 && currentCount <= 1 && !isSegmentCalculationEnabled(orgId)) {
+        // #4556 Gate A / Option B: the service holds a write trx but no port, so the
+        // 1->multi conversion guard is pinned to the closed legacy posture (block whenever
+        // durable references exist). Byte-identical to the retired env-gate's production
+        // behaviour (master gate OFF => the env term was always true). Residual R4: a
+        // Gate-C-enabled shadow org still cannot convert here until this guard is re-sourced
+        // from the port in a later slice.
+        if (segments.length > 1 && currentCount <= 1) {
           const blockers = await findShiftDeleteBlockers(trx, { orgId, shiftId, shiftName: existing.name })
           if (blockers.length > 0) {
             throw new HttpError(
@@ -1072,9 +1080,15 @@ function createAttendanceShiftService(deps) {
     await assertLockedShiftReferenceAllowed(trx, { orgId, shiftId, producer, referenceSegments })
   }
 
+  // #4556 Gate A / Option B: a PURE function of the explicit `referenceSegments` boolean.
+  // `true` (the org's canonical posture, resolved by the port on the caller's write trx —
+  // exact-org allowlisted, wildcard-refused, persisted rollout row) admits any segment count.
+  // Anything else (`false`, or a caller that failed to resolve the port) is fail-closed: a
+  // multi-segment / unverifiable shift throws the typed 422. There is no environment read and
+  // no `=== undefined => isSegmentCalculationEnabled` fallback anymore — the plugin's second
+  // gating mechanism is retired, leaving the port as the one source of truth.
   function assertSegmentCalculationAllowed({ orgId, shiftId, segmentCount, producer, referenceSegments }) {
     if (referenceSegments === true) return
-    if (referenceSegments === undefined && isSegmentCalculationEnabled(orgId)) return
     const normalizedCount = Number(segmentCount)
     if (segmentCount == null || !Number.isInteger(normalizedCount) || normalizedCount < 0) {
       throw new HttpError(
@@ -1181,7 +1195,6 @@ function createAttendanceShiftService(deps) {
     mapFlexPolicyFromRow,
     deriveEnvelopeFromSegments,
     synthesizeSegmentsFromEnvelope,
-    isSegmentCalculationEnabled,
     buildShiftCapabilities,
     mapShiftWithSegments,
     loadSegmentsByShiftId,


### PR DESCRIPTION
## #4556 Gate A — Option B cutover (retire the plugin env-gate; the core posture port is the one source of truth)

**Status: DRAFT — build → gate → STOP.** Not marked ready; not to be merged here. Landing is gated on the owner decisions listed at the bottom. Flags all OFF; production byte-neutral.

Rebased onto `origin/main@f6793357f5` (W7-0 #4897, Gate E #4896, Gate D1 #4898 already landed). Clean rebase — no conflicts; **no `s6a-package-provenance-pins.json` conflict** because this branch touches no workflow file.

### What this does (Option B)

Before this change there were **two** independent gating mechanisms for whether a reference writer may accept a multi-segment shift: the core canonical posture port (`resolveOrgSegmentCalculationPosture` → `resolveSegmentCalculationPosture`, exact-org allowlist, wildcard **refused**, persisted rollout row) — already the sole gate across the W4C pipeline and the one migrated plugin route (schedule publication) — and the plugin's own env-reading predicate `isSegmentCalculationEnabled`. This retires the second mechanism so the port is the single source of truth.

> **Framing correction (independent gate, P3-1) — read this before weighing urgency.** An earlier draft of this body said the retired predicate "wrongly accepted the `*` wildcard," implying this PR closes a live authorization hole. **It does not.** That wildcard branch was **unreachable dead code at base**: `SEGMENT_CALCULATION_IMPLEMENTED` is a hardcoded `const false` whose check is the *first statement* of `isSegmentCalculationEnabled`, so the function returned `false` for every input — proven behaviourally at base (`"*"`, `"orgA,*"`, `" * "`, `"orgA"`, `""` all ⇒ `false`). The `referenceSegments === undefined ⇒ env-gate` fallback was therefore **already fail-closed**; retiring it is a *simplification*, not a hole closure. Two consequences: (1) byte-neutrality of the pinned-closed paths is **structural** (a hardcoded constant), which is a *stronger* guarantee than the deployment-config framing this body used before; (2) the real security content of this PR is the **opposite direction** — it is the **first** change that lets 17 plugin writer sites *admit* a multi-segment reference at all, previously structurally impossible. That widening is gated **solely** by the canonical port (exact-org + persisted rollout row), and is byte-neutral today **only** because no rollout row exists anywhere in production. Weigh the owner decisions as "widening now gated solely by the port," not "wildcard hole closed."

**Wired (~16 reference-writer guard sites)** — each now resolves the posture on its own write trx via `resolveReferenceSegmentsPostureForWrite(trx, orgId)` and passes an explicit `referenceSegments` boolean; port-absent ⇒ `{legacy, referenceSegments:false}` ⇒ fail-closed:

- `fixed_schedule_apply`, `fixed_schedule_rebuild`
- `auto_shift_matching` (via `assertShiftReferenceAllowed`; posture resolved **once**, hoisted above the per-item loop since org is constant)
- `shift_swap_create`, `shift_swap_final_approval`
- `schedule_dispatch_create`, `schedule_dispatch_final_approval`
- `rotation_rule_create`, `rotation_rule_update`, `rotation_assignment_write` (×4 sites)
- `draft_assignment_create`, `draft_assignment_update`, `assignment_create`, `assignment_update`

**Deletions**
- `isSegmentCalculationEnabled` env-gate function **incl. the `if (entries.includes('*')) return true` wildcard-accept branch**, and its export.
- The `referenceSegments === undefined ⇒ isSegmentCalculationEnabled(orgId)` fallback in `assertSegmentCalculationAllowed` — now a **pure function** of the explicit boolean.
- The `&& !isSegmentCalculationEnabled(orgId)` term in the `updateShift` 1→multi conversion guard (pinned to closed legacy).
- `buildShiftCapabilities` re-sourced from env to `enabled: false` (values-safe DTO, no trx/port in hand → pinned closed).

**Pinned-closed read paths (residual R4, disclosed):** `assertWorkContextSegmentCalculationAllowed`, `buildShiftCapabilities`, and the `updateShift` conversion guard have no write-trx/port in hand, so they are pinned to `referenceSegments:false` / `enabled:false`. Byte-identical to the retired env-gate's behaviour, and for a **structural** reason (`SEGMENT_CALCULATION_IMPLEMENTED` is a hardcoded `const false` short-circuiting that predicate's first statement) — not because of any deployment-config setting. Once an org is turned on via Gate C, its reference **writers** are admitted while these **read/hint** paths still fail closed until re-sourced from the port in a later slice.

**Kept: `SEGMENT_CALCULATION_IMPLEMENTED = false` (owner note, not deleted).** The brief called for deleting it, but W6 (which landed after the brief) introduced a real consumer: `attendance-admin.ts:144` passes it to the W6 group effective-policy aggregate as the second conjunct of `calculationPosture === 'authoritative' && segmentCalculationImplemented` (`w6-group-effective-policy-aggregate.ts:413/475`). It is no longer a reference-writer gate — it survives only as a values-safe diagnostic of whether the W4 authoritative calculator has shipped (it has not). Deleting it would weaken the W6 closure invariant. **Owner: confirm keep-as-diagnostic vs. relocate.**

### Byte-neutral (R2)
**Conditional claim — repo evidence cannot establish live-environment state.** No migration seeds a rollout row and no flag is flipped **in this repo**, so byte-neutrality holds **conditional on** the production database containing **zero** `attendance_calculation_rollout_state` rows (any non-`legacy` row with `scope='synthetic_staging'`) **and** `ATTENDANCE_SHIFT_SEGMENT_CALCULATION_ENABLED` containing no exact org-id entry for a live org. Under those two conditions every production org resolves `legacy` ⇒ all reference writers stay fail-closed exactly as today. I cannot verify live state from the repository and make **no** claim of live-prod verification: a **read-only check against the named environment** (`SELECT count(*) FROM attendance_calculation_rollout_state;` plus the env value) is a **required ops step before enablement**. Turning an org ON is the separate owner-authorized Gate C act of writing a shadow/authoritative row. Verified: DML-inventory collector byte-neutral (58/58, zero open-debt).

**Scope of "byte-neutral" (independent gate, P3-4 — a disclosed runtime-footprint change, not a defect).** Byte-neutral is precise for **authorization outcomes and DML**; it is **not** true of per-write DB work. For any org whose id parses as a canonical UUID, `resolveOrgSegmentCalculationPosture` now performs, inside each write trx, a `pg_advisory_xact_lock_shared` plus `SELECT state, scope FROM attendance_calculation_rollout_state` — on **16 production writer paths that previously touched neither**, including hot ones (`assignment_create`, `assignment_update`, the four `rotation_assignment_write` sites). An advisory lock plus a SELECT is **not DML**, so the 58/58 collector pass does not cover it. Operational consequence for Gate C sequencing: the shared rollout advisory lock is now taken briefly by **16 writer families instead of 1** — shared-vs-shared never conflicts, but an **exclusive** holder (the Gate C transition in `w4c3a-rollout-control.ts`) now blocks 16 writer families rather than one.

---

### Regression diagnosed and fixed (this PR's added commit)

The prior commit's full run surfaced **2 failures in `attendance-plugin.test.ts`**, both on the auto-shift **auto-write JOB** path (`runAttendanceAutoShiftAutoWriteOnce`): `status: 'partial'`, `appliedCount: 0`, `errorCount: <items>`.

**Root cause (empirically confirmed, not inferred).** I reproduced on a **clean, fully-migrated** DB (ruling out the tempting "stale test DB" explanation) and read the stored error: every failing item recorded `error_message = W4C3B_TRANSACTION_CLIENT_REQUIRED`. That error comes from the port when the transaction it is handed carries neither `__rawClient` nor `__w4CanonicalTrx` (`src/index.ts:2178`). The auto-write **job** is the *only* reference writer invoked **in-process** in the suite (every other wired writer is driven through an HTTP route). The route path uses the real plugin db (`context.api.database`, whose `.transaction` attaches `__rawClient: client`, `src/index.ts:540`) and **passed**. The job path, in tests only, is invoked through the test-local `createPluginDbForTest` fixture, whose `trx` exposed only `query` and **omitted `__rawClient`** — so once this cutover hoisted the port call into `applyAutoShiftMatchingItems`, the fixture's incompleteness surfaced as a hard failure.

**No production regression.** Every production caller of that writer passes `context.api.database` (`const db = context.api.database`, index.cjs:24416; the scheduler job registration passes the same), which supplies `__rawClient`. The framing is: *the cutover exposed an incomplete test fixture — it corrected, not a stale DB and not a production behaviour change.*

**Fix (mock, not code).** Per "mock is not the contract," `createPluginDbForTest` now attaches `__rawClient: client`, mirroring the production adapter. I did **not** add a `catch`/fallback-to-legacy in `resolveReferenceSegmentsPostureForWrite` — the port throwing on a non-canonical trx is intentional fail-closed for a programming error and a fallback would convert a loud error into a silent posture assumption.

**Base-vs-HEAD proof (same clean DB, full file each):** at the true merge base `f6793357f5` both auto-write tests are **green**; at HEAD they failed with `W4C3B…`; at HEAD **+ the mock fix** the full file is **163/163**.

### `__rawClient` fragility — named residual (disclosure, non-blocking)
The `__rawClient` seam is now **load-bearing at ~16 previously-independent writer sites**. A future writer that opens its transaction through some other db wrapper (bare `query`, no `__rawClient`) would fail closed with a runtime 500 rather than being rejected statically. Production is safe today because every caller uses `context.api.database`; but this is enforced only by runtime failure on an exercised path. Scope of what I verified for the other in-process callers: the wired sites are all reference writers, and every non-route caller in `attendance-plugin.test.ts` goes through `createPluginDbForTest` (now fixed); its other consumers (report-digest, report-sync, annual-leave accrual) touch **no** wired site — proven by the 163/163 full-file run, where only the two auto-write tests failed pre-fix. `attendance-shift-swap` and `attendance-schedule-dispatch` drive their writers via HTTP routes (real plugin db) — but note (independent gate, P2-1) that **routed is not the same as covered**: being driven through a real route says the `__rawClient` plumbing is exercised, *not* that the site's resolved boolean is actually consumed. See the P2-1 section below for the one site where that distinction was load-bearing. I did not exhaustively audit every unit fixture in the wider suite.

Related, disclosed: `resolveReferenceSegmentsPostureForWrite` returns `posture.referenceSegments === true`, so a malformed/undefined posture yields `false` (fail-closed) — correct direction, no fail-open surface.

---

### Lock-in gate (real-PG, route-level, production writer chain)
`attendance-shift-segments-writer-matrix.db.test.ts` → one env `ATTENDANCE_SHIFT_SEGMENT_CALCULATION_ENABLED="<orgA>,*"`, three orgs, one production route (`POST /api/attendance/assignments` → `assignment_create`):
- **org A** (exact env entry + persisted shadow row) ⇒ **201**, reference admitted, row persisted (non-vacuous: `countRows == 1`).
- **org B** (no entry, no row) ⇒ **422** `ATTENDANCE_SHIFT_MULTI_SEGMENT_CALCULATION_DISABLED`, zero writes.
- **org W** (persisted shadow row, reachable only via `*`) ⇒ **422**, zero writes — **wildcard inert**.

**Mutation proofs — actually executed (not just documented), restored via `cp` between runs, file-change verified each time:**
- Re-admit `*` in `isOrgExactlyAllowlisted` ⇒ **exactly org W flips 422→201** (leaks); org A/B unchanged. ✔
- Force `isOrgExactlyAllowlisted` to `return false` ⇒ **exactly org A flips 201→422**; org B/W unchanged. ✔

org B is the fail-closed baseline (a no-row org resolves `legacy` regardless of the allowlist), so it is intentionally not separately mutated. Head-scoped: the mutated predicate `isOrgExactlyAllowlisted` and its resolver `resolveSegmentCalculationPosture` (`w4c0-identity.ts`) are **byte-identical** at the true merge base `f6793357f5` and at head (`git diff f6793357f5 HEAD -- w4c0-identity.ts` is empty), and main touched neither the plugin writers nor the writer-matrix file, so the proofs bind to the rebased head. The **DB-07 `'*'` fixture** is kept: after the wildcard-forbid it is the load-bearing positive control that makes the file's docstring true by construction. Stale unit test `attendance-shift-segments-service.test.ts` updated to the new semantics (service reads **no** env for authorization; multi-segment without an explicit posture stays fail-closed even under the former wildcard value).

### P2-1 closed at attribution level — `schedule_dispatch_final_approval` is now load-bearing on its own

The independent gate found this site's posture wiring was an **untested guard**: forcing it alone fail-open (`referenceSegments: true`) left writer-matrix 36/36 **and** schedule-dispatch 17/17 green, while the same probe at every other producer family reddens 11/36. Cause: a second fail-closed door downstream — `assertWorkContextSegmentCalculationAllowed` (hardcoded `false`, one of this PR's own disclosed R4 pinned-closed read paths) — refuses the same request with an **identical status and error code**, dominating both. Textbook 多道 fail-closed 门互相掩护.

**New leg (added here):** `P2-1: schedule-dispatch final approval 422 is attributed to ITS OWN guard, not to the covering R4 door` (writer-matrix, real PG, route-level). What still discriminates without opening the R4 door is **which producer refused** — the typed 422's message names the refusing guard's `producer`.

| Run | Result |
|---|---|
| Clean (head) | **37/37 green** — refusal message names `schedule_dispatch_final_approval` |
| Mutation: fail-open at `:31922` only | **exactly the new leg reds** (1 failed / 36 passed); message became `...so **attendance calculation** cannot use a multi-segment shift` — the refusal demonstrably migrated to the R4 covering door |
| **Null control**: semantically-inert comment-only edit at the same line | **37/37 green** — so the red above is genuine behavioural signal, not an artifact of editing `index.cjs` |

The null control matters: the gate showed `attendance-plugin.test.ts` is **oracle-blind** to *any* `index.cjs` edit (a comment-only change reddened the same 2 tests as a real mutation). Writer-matrix is **not** oracle-blind — verified above — so this proof holds. Mutations applied only in a disposable clone and restored via `cp` (md5-verified back to the original).

**Residual, stated precisely — P2-1 is narrowed, not retired.** This is an **attribution-level** proof, not a status-flip proof. A 200-vs-422 behavioural flip at this site remains impossible while the R4 door stays pinned closed. **Closing P2-1 fully is therefore a BLOCKING precondition on the residual-R4 slice** — R4's removal is exactly what makes this site live. Recorded here and in the test's own docstring so it cannot be lost.

### Local verification (head `b842b0c9c3`, real local PG)
- `attendance-plugin.test.ts` — **163/163**
- `attendance-shift-segments-writer-matrix.db.test.ts` — **38/38** (3-org lock-in gate + P2-1 attribution leg + the new P1 lock-order counterexample)
- `attendance-shift-segments-service.test.ts` (unit) — **35/35**
- `tsc --noEmit` — clean · provenance pin test — OK · DML-inventory collector — **58/58** (byte-neutral)
- `attendance-schedule-dispatch.test.ts` — **17/17**. `attendance-shift-swap.test.ts` — 2 date off-by-one failures that are **pre-existing** (identical at the true merge base `f6793357f5`; a non-UTC local-timezone date-only artifact, unrelated to this change).

### P3-2 (allowlist case-asymmetry) — NOT changed here; escalated, one instruction conflicts with another

The gate's P3-2 notes that env allowlist entries are trimmed but **not** case-folded while `orgKey` is lower-cased, so an **uppercase** UUID in the env silently denies. It is **fail-closed** (an operator footgun, not a hole) and **pre-existing** (file byte-identical base→head).

I did **not** fix it, because the hardening instructions are self-contradictory on this point: the only place to fix it is `isOrgExactlyAllowlisted` in `packages/core-backend/src/attendance/w4c0-identity.ts:366-372` (repo-wide, the sole allowlist parse on this path), and the same instruction set says **do not touch `w4c0-identity.ts`**. Rather than pick a winner silently, the itemized cost of applying it:

- **Patch:** `raw.split(',').map((entry) => entry.trim())` → `.map((entry) => entry.trim().toLowerCase())`, plus a one-line test (uppercase env entry matches lower-case `orgKey`).
- **It is an allowlist WIDENING** — today uppercase denies, after the fix it admits. In a PR whose security content is "17 writer sites may now admit, gated solely by the port," widening the port's own admission predicate deserves its own review rather than a drive-by.
- **It invalidates a gate-verified claim:** `w4c0-identity.ts` byte-identical base→head (✅ in the gate's overclaim table) — the citation this body uses to head-scope the M3/M4 mutation proofs. Applying it requires **re-running M3 and M4** and rewriting that citation.

Owner/coordinator call. Deferring costs nothing today (fail-closed); applying it costs the re-proof above.

### P1 (owner) — rollout-lock ORDER: mechanism confirmed real, head already ordered safely, now permanently pinned

**The hazard is real and I reproduced it.** The rollout TRANSITION path takes the rollout advisory lock **exclusive** first, then `SELECT ... FROM attendance_requests ... FOR UPDATE` (`w4c3a-rollout-control.ts` — exclusive at the top of the control transaction, request scan `:948`). If an approval transaction took the request row lock **first** and reached for rollout-**shared** only later (e.g. inside finalization, where this cutover wired a posture call), the wait cycle is: approval holds request row + waits shared; transition holds exclusive + waits request row.

**New counterexample** (real PG, two real connections, production HTTP approval route) — `P1: approval acquires the rollout lock BEFORE any request row lock`:

| Run | Result |
|---|---|
| Head (`4ad736f8b2` ordering) | **PASS** — approval parks on the advisory lock holding **no** row lock; the transition-order connection takes `FOR UPDATE` on that row promptly; both complete |
| Mutation: remove the two **early** shared acquisitions so finalization's port call is the first one | **`SQLSTATE 40P01 deadlock detected`** — the owner's exact wait cycle |

So the mechanism is genuine, and the mutation is the owner's described pre-fix ordering. Restored via `cp`, md5-verified on both files.

**Why no hoist was needed at head — three independent pre-acquisitions.** Every wired site that runs inside a transaction holding `attendance_requests`/`approval_instances` does so under the W4C-3b request-operation boundary, which takes rollout-shared **before** the adapter's `execute`: boundary `w4c3b-request-operation-boundary.ts:426` (null-operationId path), operation-registry preflight `w4c0-operation-registry.ts:597`, and the decision adapter's own `prepare` (`index.cjs:34717`, which loads the request row **without** `FOR UPDATE` at `:34708` and only then resolves the port). `execute`'s first row lock is `index.cjs:36523`, strictly later. The org key is derived identically in `prepare` (`:34716`), `resolveRequestLegacyAuthorization` (`:34367`) and `executeRequestDecisionInTransaction` (`:36568`), so the non-canonical early-return in the port (`src/index.ts:2184-2190`) cannot cause one call to skip the lock and a later one to take it.

**CLASS SURVEY — lock-order census, all 17 posture-consumption sites.** Transition-path lock set under rollout-exclusive: `attendance_requests`, `approval_instances`, `attendance_records`, `attendance_record_calculations`, `attendance_import_{jobs,batches,items}`, `attendance_result_operation{s,_batches}`, `attendance_calculation_rollout_state`.

| Sites | Locks held when the port is called | Intersects transition set? | Verdict |
|---|---|---|---|
| `:16392` auto-shift matching | none — port call is the **first** statement of its `db.transaction` (hoisted above `acquireAttendanceScheduleAssignmentLock` `:16394`) | No | safe by construction |
| `:11109`, `:11169` fixed-schedule apply/rebuild | none inside their txn before the port | No | safe by construction |
| `:38471`, `:38565`, `:38825`, `:38969`, `:39162`, `:39314` rotation rule/assignment ×6 | none from the transition set | No | safe by construction |
| `:46601`, `:46789`, `:47003`, `:47183` draft/active assignment ×4 | none from the transition set (assignment advisory + `attendance_shifts` FOR SHARE only) | No | safe by construction |
| `:31560` swap final approval, `:31922` dispatch final approval | **`attendance_requests` FOR UPDATE (`:36523`) + `approval_instances` FOR UPDATE (`:36544`)**, held by the caller | **YES** | safe **only** by pre-acquisition (above) — the two sites where the hazard is live; pinned by the new counterexample |
| `:33222` dispatch create, `:33496` swap create | run under the same boundary (adapter `execute`); shared pre-acquired identically | YES (same boundary) | safe by pre-acquisition |

**Sites requiring a hoist: 0.** Sites where the inversion would be live absent pre-acquisition: **4** (the boundary-hosted request paths). The remaining 13 cannot invert — they never touch a transition-locked table before resolving the port. The census used each transaction's actual opening rather than a fixed window, because a fixed-width scan silently misses **caller-held** locks — which is exactly the case for those 4 nested sites.

**Residual (owner call, not fixed here):** finalization still *re-resolves* the posture (`:31560`/`:31922`) although the shared lock is already held by the enclosing boundary. That is redundant per-approval DB work (see the P3-4 runtime-footprint note), not a correctness or ordering defect. Threading the pre-resolved boolean down would touch the exact call the P2-1 attribution leg pins, so I left it for a reviewed change rather than folding it into a fix round.

### Owner decisions before ready/merge
1. Option B (this) vs Option A. 2. Whether a global kill-switch is retained (if yes: a single read inside `resolveSegmentCalculationPosture`, never a second plugin gate). 3. `SEGMENT_CALCULATION_IMPLEMENTED` keep-as-W6-diagnostic vs relocate. 4. The `__rawClient`-load-bearing residual above. Gate C/D/E remain separate owner-gated changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


