### PR TITLE
feat(attendance): Gate D2 — wire live_punch authoritative writes to the D1 core (#4556)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -1345,6 +1345,7 @@ jobs:
             tests/integration/attendance-w4c2-posture-matrix.db.test.ts \
             tests/integration/attendance-w4c2-gate-matrix-e5.db.test.ts \
             tests/integration/attendance-w4c2-authoritative-calculation-core.db.test.ts \
+            tests/integration/attendance-w4c2-d2-live-punch-authoritative.db.test.ts \
             tests/integration/attendance-w4c2-p2-remediation.db.test.ts \
             tests/integration/attendance-w4c2-p2-1-canonical-freeze-anchor.db.test.ts \
             tests/integration/attendance-w4c2-p12-migration-schema-gates.db.test.ts \

--- a/packages/core-backend/src/attendance/__tests__/w4c2-live-punch-payload-fingerprint-domain.test.ts
+++ b/packages/core-backend/src/attendance/__tests__/w4c2-live-punch-payload-fingerprint-domain.test.ts
@@ -1,0 +1,66 @@
+/**
+ * W4C-2 Gate D2 (#4556 / #4844) — the live-punch payload fingerprint's domain separator is pinned
+ * BY BYTES, and its digest is pinned against an INDEPENDENT oracle.
+ *
+ * WHY THIS EXISTS. The domain string ends in a NUL. It was originally written as a RAW 0x00 byte in
+ * the `.ts` source, which made `file(1)` classify the module as `data` and `grep`/`rg` treat it as
+ * binary and skip it **silently** — a real hazard, because the repo's own DML and SELECT-inventory
+ * collectors are source-TEXT scanners, so a module that reads as binary can drop out of an audit
+ * without anything failing. The fix rewrote it as the escape `\u0000`.
+ *
+ * That fix is only safe if the RUNTIME string is unchanged, and "I believe an escape equals the raw
+ * byte" is exactly the kind of claim that should be measured rather than asserted. So:
+ *
+ *  - the code-unit assertions below pin the domain's exact content and length, including that the
+ *    terminator is `\u0000` and that it is the ONLY NUL; and
+ *  - the digest assertion pins `sha256(domain + fixture)` against a value computed OUTSIDE this
+ *    codebase (`python3 -c "import hashlib; hashlib.sha256(...)"` over the same literal bytes), so
+ *    it cannot be back-fitted from whatever the implementation happens to produce.
+ *
+ * If a future edit changes the domain at all — a different escape, a dropped terminator, a renamed
+ * version tag — the digest moves and this file reds. Every persisted `payloadFingerprint` and every
+ * retry-idempotency comparison depends on that digest staying put.
+ *
+ * No-DB, no fixtures: this runs in the ungated `src/attendance/__tests__` set.
+ */
+import crypto from 'node:crypto'
+import { describe, expect, it } from 'vitest'
+import { ATTENDANCE_W4C2_LIVE_PUNCH_PAYLOAD_FINGERPRINT_DOMAIN_V1 } from '../w4c2-live-scheduled-boundary'
+
+describe('W4C-2 Gate D2 — live-punch payload fingerprint domain', () => {
+  const DOMAIN = ATTENDANCE_W4C2_LIVE_PUNCH_PAYLOAD_FINGERPRINT_DOMAIN_V1
+
+  it('is the exact byte sequence the raw-NUL literal encoded — escape and raw byte are the same runtime string', () => {
+    // Built here from a JS escape, i.e. independently of how the source spells it.
+    const expected = 'metasheet2:attendance:w4c2:live-punch-authoritative-payload:v1' + '\u0000'
+    expect(DOMAIN).toBe(expected)
+    expect(DOMAIN.length).toBe(63)
+    expect(DOMAIN.charCodeAt(DOMAIN.length - 1)).toBe(0)
+    // Exactly ONE NUL, and it terminates the string — not a stray one mid-domain.
+    expect(DOMAIN.split('\u0000').length - 1).toBe(1)
+    expect(DOMAIN.slice(0, -1)).toBe('metasheet2:attendance:w4c2:live-punch-authoritative-payload:v1')
+    // UTF-8 encodes to the same length (the domain is pure ASCII plus the NUL), so the bytes fed
+    // to the hash are exactly the code units asserted above.
+    expect(Buffer.byteLength(DOMAIN, 'utf8')).toBe(63)
+  })
+
+  it('produces the digest an INDEPENDENT oracle computes for the same input — the fingerprint has not moved', () => {
+    // Oracle: python3 -c "import hashlib; print(hashlib.sha256(
+    //   ('metasheet2:attendance:w4c2:live-punch-authoritative-payload:v1\\x00' + '{\"probe\":1}')
+    //   .encode('utf8')).hexdigest())"
+    const ORACLE_DIGEST = '001b7ab4169abc3193d96c1535d9bf4f8599b26a1f86d581ba1bcbdf82f63fd4'
+    const digest = crypto.createHash('sha256').update(DOMAIN + '{"probe":1}', 'utf8').digest('hex')
+    expect(digest).toBe(ORACLE_DIGEST)
+  })
+
+  it('the source file spells the NUL as an escape, so static text scanners do not skip this module', () => {
+    // The property the escape exists for, asserted directly rather than trusted: a raw 0x00 in the
+    // source is what made `file(1)` report `data` and made grep/rg bail out.
+    const fs = require('node:fs') as typeof import('node:fs')
+    const path = require('node:path') as typeof import('node:path')
+    const source = fs.readFileSync(
+      path.join(__dirname, '..', 'w4c2-live-scheduled-boundary.ts'),
+    )
+    expect(source.includes(0x00)).toBe(false)
+  })
+})

--- a/packages/core-backend/src/attendance/__tests__/w4c3a-rollout-control-inventory.test.ts
+++ b/packages/core-backend/src/attendance/__tests__/w4c3a-rollout-control-inventory.test.ts
@@ -22,6 +22,7 @@ import { afterEach, describe, expect, it } from 'vitest'
 import {
   __setAttendanceW4C2AuthoritativeDeliveryOverrideForTests,
   ATTENDANCE_W4C2_AUTHORITATIVE_ENTRYPOINTS_V1,
+  attendanceW4C2UndeliveredAuthoritativeEntrypointCountV1,
   isAttendanceW4C2AuthoritativeEntrypointDeliveredV1,
   type AttendanceW4C2AuthoritativeEntrypointV1,
 } from '../w4c2-authoritative-delivery'
@@ -602,6 +603,18 @@ describe('Gate D: W4C2 authoritative-entrypoint delivery declaration <-> boundar
     // refusal call, and the attribution map only records functions that carry at least one.
     expect(counts).toEqual({ executeScheduledRunInternal: 2 })
     expect(countRefusalCalls(content)).toBe(2)
+  })
+
+  it('Gate D2 delivery-flip coupling: exactly ONE authoritative entrypoint remains undelivered, and no refusal call is attributed to executeLivePunch', () => {
+    // The promotion gate reads this count and demands ZERO, so promotion to `authoritative` still
+    // refuses after D2 — the count moved 2 -> 1, not 2 -> 0.
+    expect(attendanceW4C2UndeliveredAuthoritativeEntrypointCountV1()).toBe(1)
+    const content = fs.readFileSync(path.join(ROOT, BOUNDARY_RELATIVE_FILE), 'utf8')
+    const { counts } = attributeRefusalCallsV1(content)
+    // The static half of the P-A obligation: the new authoritative writer branch contains no
+    // refusal call of ANY spelling this file's pattern matches. (The behavioural fall-through pin
+    // is the zero-invocation adapter spy in the D2 real-DB suite, not this assertion.)
+    expect(counts.executeLivePunch ?? 0).toBe(0)
   })
 
   it('drift guard is load-bearing (delivered-flip class): declaring "scheduled" delivered via the test seam while the boundary source is unchanged mismatches on that key specifically', () => {

--- a/packages/core-backend/src/attendance/__tests__/w4c3a-rollout-control-inventory.test.ts
+++ b/packages/core-backend/src/attendance/__tests__/w4c3a-rollout-control-inventory.test.ts
@@ -373,12 +373,19 @@ describe('Gate D: W4C2 authoritative-entrypoint delivery declaration <-> boundar
   })
 
   // Independently counted by reading the boundary source at this PR's reviewed head: `live_punch`
-  // (inside `executeLivePunch`) has exactly 1 refusal call site; `scheduled` (inside
+  // (inside `executeLivePunch`) has exactly 0 refusal call sites — Gate D2 (#4844) shipped its
+  // authoritative writer and removed the one site it had; `scheduled` (inside
   // `executeScheduledRunInternal`, both its org-wide probe and its per-target loop — the SAME
-  // command kind per that module's own header) has exactly 2. Checked PER KEY against a
+  // command kind per that module's own header) still has exactly 2. Checked PER KEY against a
   // source-range-scoped count below (`attributeRefusalCallsV1`), never against a whole-file sum.
+  //
+  // WHY THE WEIGHT ITSELF MOVES (not just the declaration): this table is the "how many sites
+  // SHOULD exist while undelivered" side of the correspondence. `expectedByKeyV1()` reads it only
+  // for keys declared UNDELIVERED, so once `live_punch` is delivered its expected count is 0 by
+  // the delivery declaration alone. Leaving the weight at 1 would still break the cross-key
+  // aggregate leg below, which reads the raw weights directly.
   const REFUSAL_SITE_WEIGHT: Readonly<Record<AttendanceW4C2AuthoritativeEntrypointV1, number>> = Object.freeze({
-    live_punch: 1,
+    live_punch: 0,
     scheduled: 2,
   })
 
@@ -586,26 +593,33 @@ describe('Gate D: W4C2 authoritative-entrypoint delivery declaration <-> boundar
     expect(actualByKeyV1(counts)).toEqual(expectedByKeyV1())
   })
 
-  it('positive control: production declaration is fully undelivered and each function carries its exact expected count (live_punch=1, scheduled=2, total=3)', () => {
-    expect(isAttendanceW4C2AuthoritativeEntrypointDeliveredV1('live_punch')).toBe(false)
+  it('positive control (post Gate D2): live_punch is DELIVERED with zero refusal sites, scheduled is undelivered with exactly 2 (total=2)', () => {
+    expect(isAttendanceW4C2AuthoritativeEntrypointDeliveredV1('live_punch')).toBe(true)
     expect(isAttendanceW4C2AuthoritativeEntrypointDeliveredV1('scheduled')).toBe(false)
     const content = fs.readFileSync(path.join(ROOT, BOUNDARY_RELATIVE_FILE), 'utf8')
     const { counts } = attributeRefusalCallsV1(content)
-    expect(counts).toEqual({ executeLivePunch: 1, executeScheduledRunInternal: 2 })
-    expect(countRefusalCalls(content)).toBe(3)
+    // `executeLivePunch` no longer appears as a key at all — its writer branch contains no
+    // refusal call, and the attribution map only records functions that carry at least one.
+    expect(counts).toEqual({ executeScheduledRunInternal: 2 })
+    expect(countRefusalCalls(content)).toBe(2)
   })
 
-  it('drift guard is load-bearing (delivered-flip class): declaring "live_punch" delivered via the test seam while the boundary source is unchanged mismatches on that key specifically', () => {
-    __setAttendanceW4C2AuthoritativeDeliveryOverrideForTests({ live_punch: true })
+  it('drift guard is load-bearing (delivered-flip class): declaring "scheduled" delivered via the test seam while the boundary source is unchanged mismatches on that key specifically', () => {
+    // Retargeted from `live_punch` to `scheduled` by Gate D2 (#4844): this leg needs a key that
+    // is STILL undelivered in the shipped declaration AND still carries refusal sites in the
+    // source, so that overriding it to `true` produces the expected-0/actual-nonzero mismatch.
+    // `live_punch` can no longer serve — after D2 both its expected and actual counts are 0, so
+    // the override would be a no-op and the leg would assert nothing.
+    __setAttendanceW4C2AuthoritativeDeliveryOverrideForTests({ scheduled: true })
     const content = fs.readFileSync(path.join(ROOT, BOUNDARY_RELATIVE_FILE), 'utf8')
     const { counts } = attributeRefusalCallsV1(content)
     const actual = actualByKeyV1(counts)
     const expected = expectedByKeyV1()
-    // live_punch declared delivered => expected drops to 0 for that key, but the boundary source
-    // still carries its 1 refusal call — mismatched on THAT key specifically, demonstrated here
+    // scheduled declared delivered => expected drops to 0 for that key, but the boundary source
+    // still carries its 2 refusal calls — mismatched on THAT key specifically, demonstrated here
     // directly rather than only asserted by the correspondence test above.
-    expect(expected.live_punch).toBe(0)
-    expect(actual.live_punch).toBe(1)
+    expect(expected.scheduled).toBe(0)
+    expect(actual.scheduled).toBe(2)
     expect(actual).not.toEqual(expected)
   })
 
@@ -613,10 +627,11 @@ describe('Gate D: W4C2 authoritative-entrypoint delivery declaration <-> boundar
     const content = fs.readFileSync(path.join(ROOT, BOUNDARY_RELATIVE_FILE), 'utf8')
     const { counts } = attributeRefusalCallsV1(content)
     const actual = actualByKeyV1(counts)
-    // A mutation of REFUSAL_SITE_WEIGHT that swaps the two keys' weights (live_punch<-2,
-    // scheduled<-1) preserves the aggregate SUM (3) the pre-fix, aggregate-only assertion
-    // checked — that old guard would have stayed green on exactly this edit, because add-to-one/
-    // remove-from-another leaves the total unchanged.
+    // A mutation of REFUSAL_SITE_WEIGHT that swaps the two keys' weights preserves the aggregate
+    // SUM the pre-fix, aggregate-only assertion checked — that old guard would have stayed green
+    // on exactly this edit, because add-to-one/remove-from-another leaves the total unchanged.
+    // Still discriminating after Gate D2 (#4844) moved the weights to {live_punch:0,scheduled:2}:
+    // the swap yields {live_punch:2,scheduled:0}, same sum (2), opposite per-key values.
     const swapped: Record<AttendanceW4C2AuthoritativeEntrypointV1, number> = {
       live_punch: REFUSAL_SITE_WEIGHT.scheduled,
       scheduled: REFUSAL_SITE_WEIGHT.live_punch,

--- a/packages/core-backend/src/attendance/__tests__/w4c3c-ops-retirement.test.ts
+++ b/packages/core-backend/src/attendance/__tests__/w4c3c-ops-retirement.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   assertParentNotOperatorRetiredV1,
+  assertParentNotRetiredForAuthoritativePunchV1,
   assertParentNotRetiredForOrdinaryWriterV1,
   assertToolingOnlyNonW4FixtureTeardownAllowedV1,
   buildLegacyRetirementBaselineProvenanceV1,
@@ -54,6 +55,82 @@ describe('W4C-3c ops retirement + recompute identity', () => {
         visibility_reason: 'active',
       }),
     ).not.toThrow()
+  })
+
+  // Gate D2 (#4556 / #4844) — the AUTHORITATIVE live-punch retirement guard.
+  //
+  // ANTI-ENUMERATION PIN. This guard's whole point is that it is DEFAULT-REFUSE with one named
+  // carve-out, not an enumerate-the-known-reasons-with-implicit-proceed structure. The synthetic
+  // reason leg below cannot be driven through a real DB insert — `chk_ar_visibility_reason` blocks
+  // an out-of-domain value at the row level — so it is exercised at the FUNCTION seam, which is
+  // exactly what proves the guard is not merely parasitic on that CHECK.
+  describe('Gate D2 authoritative-punch retirement guard (default refuse, one carve-out)', () => {
+    it('proceeds for a non-retired parent', () => {
+      expect(() =>
+        assertParentNotRetiredForAuthoritativePunchV1({
+          visibility_state: 'active',
+          visibility_reason: 'active',
+        }),
+      ).not.toThrow()
+    })
+
+    it('CARVE-OUT: proceeds for retired/review_placeholder (the F6 create-if-absent steady state)', () => {
+      // The one reason that MUST pass: a completed outcome promotes this parent via the core's
+      // own pointer UPDATE, and a review outcome preserves it. Refusing here would break F6.
+      expect(() =>
+        assertParentNotRetiredForAuthoritativePunchV1({
+          visibility_state: 'retired',
+          visibility_reason: 'review_placeholder',
+        }),
+      ).not.toThrow()
+    })
+
+    it('TERMINAL, distinctly coded: operator_retirement refuses with ATTENDANCE_RECORD_OPERATOR_RETIRED, not the generic code', () => {
+      expect(() =>
+        assertParentNotRetiredForAuthoritativePunchV1({
+          visibility_state: 'retired',
+          visibility_reason: 'operator_retirement',
+        }),
+      ).toThrowError(ATTENDANCE_OPERATOR_RETIREMENT_ERROR_CODES.OPERATOR_RETIRED)
+    })
+
+    it('DEFAULT REFUSE: import_rollback refuses with ATTENDANCE_RECORD_RETIRED', () => {
+      expect(() =>
+        assertParentNotRetiredForAuthoritativePunchV1({
+          visibility_state: 'retired',
+          visibility_reason: 'import_rollback',
+        }),
+      ).toThrowError(/ATTENDANCE_RECORD_RETIRED/)
+    })
+
+    it('[anti-enumeration pin] DEFAULT REFUSE: a SYNTHETIC / unlisted retired reason refuses with ATTENDANCE_RECORD_RETIRED rather than falling through to the core reactivation', () => {
+      // A reason outside {review_placeholder, import_rollback, operator_retirement} — i.e. any
+      // reason a future migration adds. Falling through here would reach the core, whose
+      // completed-path pointer UPDATE reactivates the parent to w4/active/active UNCONDITIONALLY.
+      for (const reason of ['some_future_reason', 'gdpr_erasure', '', 'ACTIVE']) {
+        expect(() =>
+          assertParentNotRetiredForAuthoritativePunchV1({
+            visibility_state: 'retired',
+            visibility_reason: reason,
+          }),
+        ).toThrowError(/ATTENDANCE_RECORD_RETIRED/)
+      }
+    })
+
+    it('reads both the snake_case row shape and the camelCase boundary shape', () => {
+      expect(() =>
+        assertParentNotRetiredForAuthoritativePunchV1({
+          visibilityState: 'retired',
+          visibilityReason: 'import_rollback',
+        }),
+      ).toThrowError(/ATTENDANCE_RECORD_RETIRED/)
+      expect(() =>
+        assertParentNotRetiredForAuthoritativePunchV1({
+          visibilityState: 'retired',
+          visibilityReason: 'review_placeholder',
+        }),
+      ).not.toThrow()
+    })
   })
 
   it('requires the closed tooling-only non-W4 fixture teardown guard', () => {

--- a/packages/core-backend/src/attendance/w4c2-authoritative-calculation-core.ts
+++ b/packages/core-backend/src/attendance/w4c2-authoritative-calculation-core.ts
@@ -10,16 +10,22 @@
  * authoritative deltas: `legacy_baseline` snapshotting, `supersedes`/`restores` lineage, the
  * parent-pointer/visibility move, preimage freezing, and reversal restore/retire.
  *
- * WHAT THIS IS NOT (INERT / byte-neutral, Gate D1): this module is NOT called by any production
- * path. The live/scheduled boundary still fails closed — it still refuses the authoritative write
- * with the boundary code `` `W4C2_AUTHORITATIVE_MODE_NOT_DELIVERED` `` (backtick-quoted here on
- * purpose; this file must never spell that code as a `boundaryFail(...)` call, see the
- * correspondence guard `w4c3a-rollout-control-inventory.test.ts`). No `boundaryFail` site is
- * removed by this slice, `DECLARED_DELIVERED` stays `{live_punch:false, scheduled:false}`, and the
- * shadow path is untouched (byte-identical by absence from this diff). D2 wires `live_punch`, D3
- * wires `scheduled`; each removes a refusal site and flips its declaration in its own reviewed
- * change. Until then this core is exercised ONLY by its real-DB test suite
- * (`attendance-w4c2-authoritative-calculation-core.db.test.ts`).
+ * WHO CALLS THIS (updated by Gate D2, #4844 — this module is NO LONGER INERT): the live/scheduled
+ * boundary's `executeLivePunch` calls `writeAuthoritativeSegmentCalculationV1` on the effective-
+ * `authoritative` path. `scheduled` is STILL undelivered and still refuses with the boundary code
+ * `` `W4C2_AUTHORITATIVE_MODE_NOT_DELIVERED` `` at its two remaining sites (backtick-quoted here
+ * on purpose; this file must never spell that code as a `boundaryFail(...)` call, see the
+ * correspondence guard `w4c3a-rollout-control-inventory.test.ts`); `DECLARED_DELIVERED` is
+ * `{live_punch:true, scheduled:false}`, and D3 wires `scheduled`.
+ *
+ * PRODUCTION REACHABILITY IS STILL ZERO, but for a different reason than in D1: the caller branch
+ * fires only for an org whose `effectiveState` resolves to `authoritative`, which additionally
+ * requires an EXACT-org entry in `ATTENDANCE_SHIFT_SEGMENT_CALCULATION_ENABLED` (wildcard never
+ * counts). That env is unset in production, so every production org collapses to `legacy` and this
+ * core is unreachable irrespective of DB contents — until a separate, owner-actioned allowlist
+ * change. Coverage: this module's own real-DB suite
+ * (`attendance-w4c2-authoritative-calculation-core.db.test.ts`) PLUS the D2 boundary suite
+ * (`attendance-w4c2-d2-live-punch-authoritative.db.test.ts`).
  *
  * DESIGN — two enforcement layers per invariant (repo doctrine: gate the MECHANISM, and a mutation
  * must be able to redden it — feedback_gate_the_mechanism_not_the_claim.md):
@@ -37,25 +43,32 @@
  * mirrors the four existing private copies byte-for-byte (same domain-separated hash); the four are
  * intentionally left un-rewired (that is a separate, non-inert refactor).
  *
- * OPEN SEAMS / D2 obligations (named, not resolved here):
- *  1. legacy_baseline fingerprint is caller-supplied (`preimage.compatibilityFingerprint`) on purpose
- *     — self-computing it here is the import-kernel trap (kernel :907-909 binds the frozen preimage
- *     fingerprint, not a recomputed one). Today ONLY the import/rollback/ops paths freeze a
- *     `compatibilityFingerprint`; the live/scheduled boundary has no producer. D2 (live_punch) must
- *     supply one — deterministically, over the parent's legacy daily projection — before it can call
- *     the completed path on an active legacy parent, or `PREIMAGE_INVALID` fails closed. Cross-path
- *     fingerprint values are inconsequential for uniqueness (see the existence-read note below), but
- *     the live path still needs SOME frozen source.
- *  2. PARENT-STATE ASYMMETRY (F6): the completed path moves the parent pointer/visibility and the
- *     reversal path restores/retires it, but `writeReviewRow` writes ONLY the calc row and NEVER
- *     touches `attendance_records`. §7.5 requires a FRESH authoritative review to leave the parent
- *     `legacy_untracked`/pointer-null/retired/`review_placeholder` so ordinary readers see no
- *     fabricated zero-minute row. Deciding fresh-vs-existing review is a BOUNDARY concern, so the
- *     core deliberately does not touch the parent here — but D2/D3 MUST install that retired/
- *     `review_placeholder` state in the SAME transaction for a fresh authoritative review, unlike the
- *     completed/reversal paths which self-manage the parent. This asymmetry is the footgun; it is a
- *     named D2 obligation, not an ambient concern. (The invariant-5 test installs that precondition by
- *     fixture; it proves the "later completed needs no baseline" branch, not the boundary's install.)
+ * CALLER SEAMS — the two D1 named as D2 obligations are now DISCHARGED for `live_punch`; both stay
+ * open for `scheduled` until D3:
+ *  1. [DISCHARGED for live_punch] legacy_baseline fingerprint is caller-supplied
+ *     (`preimage.compatibilityFingerprint`) on purpose — self-computing it here is the import-kernel
+ *     trap (kernel :907-909 binds the frozen preimage fingerprint, not a recomputed one). The
+ *     live/scheduled boundary now produces one for `live_punch` via the CANONICAL
+ *     `computeAttendanceImportRollbackPreimageFingerprintV1` (byte-identical to import/rollback,
+ *     never a fifth hand-rolled copy), frozen under the parent `FOR UPDATE` over the pre-
+ *     authoritative legacy projection. Without it the completed path on an active legacy parent
+ *     fails closed with `PREIMAGE_INVALID`. Cross-path fingerprint values are inconsequential for
+ *     uniqueness (see the existence-read note below).
+ *  2. [DISCHARGED for live_punch] PARENT-STATE ASYMMETRY (F6): the completed path moves the parent
+ *     pointer/visibility and the reversal path restores/retires it, but `writeReviewRow` writes ONLY
+ *     the calc row and NEVER touches `attendance_records`. §7.5 requires a FRESH authoritative review
+ *     to leave the parent `legacy_untracked`/pointer-null/retired/`review_placeholder` so ordinary
+ *     readers see no fabricated active row. Deciding fresh-vs-existing review is a BOUNDARY concern,
+ *     so the core still does not touch the parent here — the `live_punch` boundary installs that
+ *     state itself, create-if-absent, in the SAME transaction and BEFORE this core call.
+ *  3. [OPEN — D3 forward obligation] REASON-BLINDNESS: `lockParent` omits `visibility_reason` and
+ *     `writeCompletedRow`'s tail pointer UPDATE reactivates the parent to `w4/active/active`
+ *     UNCONDITIONALLY, so this core will happily reactivate an `operator_retirement`- or
+ *     `import_rollback`-retired parent. `live_punch` is covered because its boundary branch runs a
+ *     default-refuse retirement guard (`assertParentNotRetiredForAuthoritativePunchV1`) before
+ *     calling in. D3 MUST replicate that boundary guard for `scheduled`, or land the optional core
+ *     extension (lockParent returns `visibility_reason`; `writeCompletedRow` refuses promotion over a
+ *     retired parent whose reason is not `review_placeholder`) together with D3.
  *
  * Concurrency notes:
  *  - The completed/review path is idempotent under CONCURRENT same-(org,entrypoint,operation_id)
@@ -144,6 +157,27 @@ function fail(
 }
 
 const HEX64 = /^[0-9a-f]{64}$/
+
+/**
+ * The EXACT domain of the DB CHECK `chk_arc_projected_status` (migration
+ * `zzzz20260725120000_w4c0_attendance_segment_calculation_durable_storage.ts`, its own
+ * `DAILY_STATUSES` constant). Spelled here rather than reused from
+ * `ATTENDANCE_DAILY_STATUSES_V1` (w4c1-segment-calculator) ON PURPOSE: that constant carries an
+ * EIGHTH member, `'off'`, which `chk_arc_projected_status` does NOT admit. Reusing it would make
+ * this pre-check WIDER than the constraint it fronts — a projected status of `'off'` would sail
+ * past TS and trip the raw 23514 anyway, which is precisely the leak this check exists to close.
+ * If the migration's domain ever changes, this list must change with it (and the F2-symmetric
+ * negative leg is what reddens if they diverge).
+ */
+const AUTHORITATIVE_PROJECTED_STATUSES_V1: ReadonlySet<string> = new Set([
+  'normal',
+  'late',
+  'early_leave',
+  'late_early',
+  'partial',
+  'absent',
+  'adjusted',
+])
 
 /** True iff `error` is a Postgres unique_violation (23505) on the named constraint. */
 function isUniqueViolationOnConstraintV1(error: unknown, constraint: string): boolean {
@@ -676,6 +710,13 @@ export async function writeAuthoritativeSegmentCalculationV1(
   } catch (error) {
     if (!isUniqueViolationOnConstraintV1(error, 'uq_arc_operation')) throw error
     await trx.query(`ROLLBACK TO SAVEPOINT ${savepoint}`)
+    // Gate D2 carry-forward (#4844): `ROLLBACK TO SAVEPOINT` UNDOES the subtransaction but does
+    // NOT release its slot — it stays on the transaction's subtransaction stack. The success path
+    // releases (above); this catch path did not, so a batch of same-operation-id collisions inside
+    // ONE outer transaction accumulated un-released savepoints and hit Postgres's practical
+    // ~64-subtransaction cliff long before any single operation's own retry budget suggested a
+    // problem. Released here, between the rollback and either the replay return or the throw.
+    await trx.query(`RELEASE SAVEPOINT ${savepoint}`)
     const afterConflict = await retryReplayLookup(trx, {
       orgId: input.orgId,
       entrypoint: input.entrypoint,
@@ -780,6 +821,14 @@ async function writeCompletedRow(
     !Number.isSafeInteger(projection.lateMinutes) || projection.lateMinutes < 0 ||
     !Number.isSafeInteger(projection.earlyLeaveMinutes) || projection.earlyLeaveMinutes < 0
   ) {
+    fail(ATTENDANCE_W4_AUTHORITATIVE_CALCULATION_ERROR_CODES_V1.COMPLETED_SHAPE_INVALID, 422)
+  }
+  // Gate D2 carry-forward (#4844), SYMMETRIC WITH F2 ABOVE: `projected_status` had no TS
+  // pre-check, so an out-of-domain status was guarded only by the DB CHECK `chk_arc_projected_
+  // status` and surfaced as a raw 23514 — the same leak F2 closed for minutes, on the adjacent
+  // field. Same product code, same position: BEFORE the baseline append, so a rejected write
+  // leaves zero rows behind rather than an orphan baseline rolled back by the caller's txn.
+  if (!AUTHORITATIVE_PROJECTED_STATUSES_V1.has(projection.status)) {
     fail(ATTENDANCE_W4_AUTHORITATIVE_CALCULATION_ERROR_CODES_V1.COMPLETED_SHAPE_INVALID, 422)
   }
 

--- a/packages/core-backend/src/attendance/w4c2-authoritative-delivery.ts
+++ b/packages/core-backend/src/attendance/w4c2-authoritative-delivery.ts
@@ -2,14 +2,20 @@
  * W4C-2 authoritative-entrypoint delivery declaration (Gate D closure, PR #4839 owner completion
  * gate, 20260810).
  *
- * BACKGROUND: `w4c2-live-scheduled-boundary.ts` fails closed with `W4C2_AUTHORITATIVE_MODE_NOT_
- * DELIVERED` (HTTP 503) at three call sites today — one inside `executeLivePunch` (the `live_
+ * BACKGROUND: `w4c2-live-scheduled-boundary.ts` ORIGINALLY failed closed with
+ * `W4C2_AUTHORITATIVE_MODE_NOT_
+ * DELIVERED` (HTTP 503) at three call sites — one inside `executeLivePunch` (the `live_
  * punch` command kind), two inside `executeScheduledRunInternal` (the `scheduled` command kind's
  * org-wide probe and its per-target loop; both are the SAME command kind per that module's own
- * header). Nothing today stops an org from being promoted to `authoritative` even though the
- * write it would need is undelivered — the owner's Gate D. This module is the single, static,
+ * header). Nothing stopped an org from being promoted to `authoritative` even though the
+ * write it would need was undelivered — the owner's Gate D. This module is the single, static,
  * closed-enumeration declaration the canonical transition boundary
  * (`w4c3a-rollout-control.ts`) reads to refuse that promotion.
+ *
+ * Gate D2 (#4556 / #4844) shipped the `live_punch` writer and removed its ONE refusal site, so
+ * TWO sites remain in that file today, both `scheduled`. The declaration below moved to
+ * `{live_punch:true, scheduled:false}` in that same reviewed change, which is exactly the
+ * lockstep the correspondence test requires.
  *
  * WHAT THIS MODULE DOES NOT DO: it does not probe, does not import, and has no runtime
  * dependency on `w4c2-live-scheduled-boundary.ts`. It is a LEAF — zero imports from any W4C-2/
@@ -38,19 +44,24 @@ export type AttendanceW4C2AuthoritativeEntrypointV1 =
   (typeof ATTENDANCE_W4C2_AUTHORITATIVE_ENTRYPOINTS_V1)[number]
 
 /**
- * The shipped declaration. Both keys are `false` today: no authoritative writer exists for
- * either command kind, and `w4c2-live-scheduled-boundary.ts` fails closed at all three call
- * sites unconditionally. Flip a key to `true` ONLY in the same reviewed change that:
+ * The shipped declaration. Flip a key to `true` ONLY in the same reviewed change that:
  *   (a) ships a real writer for that command kind, and
  *   (b) removes every `boundaryFail('W4C2_AUTHORITATIVE_MODE_NOT_DELIVERED', ...)` call site
  *       for that command kind in `w4c2-live-scheduled-boundary.ts` (`live_punch`: 1 site;
  *       `scheduled`: 2 sites — see the correspondence test for the exact count).
  * Never flip a key to `true` as a standalone change "to unblock rollout" — the correspondence
  * test exists precisely to fail that change.
+ *
+ * `live_punch` is `true` as of Gate D2 (#4556 / #4844): the boundary's `executeLivePunch` now
+ * carries the real authoritative writer and its single refusal call site is gone, so the
+ * correspondence guard's expected weight and the source's actual count moved 1 -> 0 in lockstep.
+ * `scheduled` stays `false` — `executeScheduledRunInternal` still fails closed at both of its
+ * sites; D3 delivers it. Promotion to the `authoritative` rollout state therefore still refuses
+ * (`w4c3a-rollout-control.ts` gates on the UNDELIVERED count, which is 1, not 0).
  */
 const DECLARED_DELIVERED: Readonly<Record<AttendanceW4C2AuthoritativeEntrypointV1, boolean>> =
   Object.freeze({
-    live_punch: false,
+    live_punch: true,
     scheduled: false,
   })
 

--- a/packages/core-backend/src/attendance/w4c2-live-scheduled-boundary.ts
+++ b/packages/core-backend/src/attendance/w4c2-live-scheduled-boundary.ts
@@ -321,6 +321,18 @@ export interface AttendanceW4LiveScheduledLegacyAdaptersV1 {
     trx: AttendancePluginShapedTrxV1,
     args: AttendanceLivePunchLegacyArgsV1,
   ): Promise<Record<string, unknown>>
+  /**
+   * Gate D2 (#4556 / #4844): the `workDateResolution` the WIRE RESPONSE carries — the SAME
+   * derivation the legacy adapter uses for the same field (`deriveLegacyLivePunchAttributionV1`'s
+   * `punchWorkDateResolution`), so an authoritative punch's response field is shape-identical to a
+   * legacy punch's. Deliberately NOT `resolveLiveCandidate`: that call opts into
+   * `includeFullWinner`, which adds a `fullWinner` member the public response never carried, so
+   * reusing it would silently widen the contract.
+   */
+  deriveLivePunchWorkDateResolution(
+    trx: AttendancePluginShapedTrxV1,
+    args: AttendanceLivePunchLegacyArgsV1,
+  ): Promise<unknown>
   /** P03/P04 verbatim absence INSERT..SELECT (NOT EXISTS) for the given users. */
   applyScheduledAbsenceLegacy(
     trx: AttendancePluginShapedTrxV1,
@@ -837,6 +849,19 @@ function normalizeInstantIsoV1(value: string | Date | null): string | null {
 }
 
 /**
+ * Domain separator for the live-punch payload fingerprint below, terminated by a NUL.
+ *
+ * The NUL is written as the ESCAPE `\u0000`, never as a raw 0x00 byte in the source. A literal
+ * NUL makes `file(1)` classify this `.ts` as `data` and makes `grep`/`rg` treat it as binary and
+ * skip it SILENTLY — which would let this whole module drop out of any static audit that walks
+ * the tree (the repo's own DML / SELECT-inventory collectors read source text). The escape
+ * produces the IDENTICAL runtime string: `\u0000` is one code unit, byte-for-byte what the raw
+ * NUL encoded, so every digest derived from this domain is unchanged. Pinned by
+ * `__tests__/w4c2-live-punch-payload-fingerprint-domain.test.ts`, which asserts the exact code
+ * units AND a digest computed against an independent oracle, so a future edit here cannot move
+ * the fingerprint silently.
+ */
+/**
  * Deterministic payload identity for the core's retry-idempotency conflict check. The core reads
  * `input_provenance.payloadFingerprint` VERBATIM off the stored row on a retry, so this value
  * must (a) be derived only from the resolved command payload — never from a clock, a random id,
@@ -844,11 +869,14 @@ function normalizeInstantIsoV1(value: string | Date | null): string | null {
  * `inputProvenance.payloadFingerprint`. Omitting the embedded copy makes a genuine retry read
  * `null`, mismatch, and surface `REPLAY_CONFLICT` where §7.3 requires a replay.
  */
-function computeAuthoritativeLivePunchPayloadFingerprintV1(
+export const ATTENDANCE_W4C2_LIVE_PUNCH_PAYLOAD_FINGERPRINT_DOMAIN_V1 =
+  'metasheet2:attendance:w4c2:live-punch-authoritative-payload:v1\u0000'
+
+export function computeAuthoritativeLivePunchPayloadFingerprintV1(
   input: AttendanceLivePunchBoundaryInputV1,
 ): string {
   return sha256Hex(
-    'metasheet2:attendance:w4c2:live-punch-authoritative-payload:v1 '
+    ATTENDANCE_W4C2_LIVE_PUNCH_PAYLOAD_FINGERPRINT_DOMAIN_V1
     + canonicalAttendanceJsonV1({
       orgId: input.orgId,
       userId: input.userId,
@@ -1322,6 +1350,7 @@ export function createAttendanceLiveScheduledBoundaryV1(
     // it into the SAME fail-closed gate keeps that state unreachable (the boundary simply does
     // not exist), instead of degrading at write time.
     typeof adapters.insertLivePunchEvent !== 'function' ||
+    typeof adapters.deriveLivePunchWorkDateResolution !== 'function' ||
     typeof adapters.applyScheduledAbsenceLegacy !== 'function' ||
     typeof adapters.resolveLiveCandidate !== 'function' ||
     typeof adapters.resolveScheduledCandidate !== 'function' ||
@@ -1774,58 +1803,52 @@ export function createAttendanceLiveScheduledBoundaryV1(
             },
           ])
 
-          // -- Step 8a: synthesize the `{event, record, workDateResolution}` caller response ---
-          // There is no legacy adapter `result` on this path, so the wire shape is built here.
-          // `record` for a COMPLETED outcome is mapped from the calculation's own
-          // `dailyProjection` (camelCase `PreparedDailyProjectionV1`). This is a CONFIRMED
-          // client-contract change from the snake_case `attendance_records` row the legacy
-          // adapter returns today; it ships as the specified default and is pinned by an exact
-          // key-set golden test so any drift — in either direction — is loud rather than silent.
-          // The documented alternative (re-SELECT the persisted row after the core call) is an
-          // owner decision, not a build-time one.
-          const authoritativeRecord = authoritativeCalculation.dailyProjection !== null
-            ? {
-                firstInAt: authoritativeCalculation.dailyProjection.firstInAt,
-                lastOutAt: authoritativeCalculation.dailyProjection.lastOutAt,
-                workedMinutes: authoritativeCalculation.dailyProjection.workedMinutes,
-                lateMinutes: authoritativeCalculation.dailyProjection.lateMinutes,
-                earlyLeaveMinutes: authoritativeCalculation.dailyProjection.earlyLeaveMinutes,
-                status: authoritativeCalculation.dailyProjection.status,
-                timezone: authoritativeCalculation.dailyProjection.timezone,
-                workDate: authoritativeCalculation.dailyProjection.workDate,
-                meta: authoritativeCalculation.dailyProjection.meta,
-              }
-            // Review outcome: an all-NULL acknowledgement in the SAME key set, so the wire shape
-            // does not change between outcomes. Whether a review should instead echo the
-            // preserved legacy columns is the second half of the same owner question.
-            : {
-                firstInAt: null,
-                lastOutAt: null,
-                workedMinutes: null,
-                lateMinutes: null,
-                earlyLeaveMinutes: null,
-                status: null,
-                timezone: null,
-                workDate: null,
-                meta: null,
-              }
+          // -- Step 8a: the caller response — PRESERVES THE EXISTING PUBLIC CONTRACT -----------
+          //
+          // `POST /api/attendance/punch` returns `{event, record, workDateResolution}` where
+          // `record` is the persisted `attendance_records` ROW in its snake_case DB shape (the
+          // published `AttendanceRecord` contract; the legacy adapter returns exactly that row
+          // from its own `RETURNING *` upsert). The authoritative path MUST return the same shape
+          // — field set and casing identical, only the VALUES differing (they now reflect the
+          // authoritative projection rather than the legacy one).
+          //
+          // An earlier revision of this branch mapped `record` from `calculation.dailyProjection`
+          // (camelCase `PreparedDailyProjectionV1`, nine fields, all-null for review). That was a
+          // BREAKING contract change: it renamed every field, dropped columns the published shape
+          // carries (`id`, `user_id`, `org_id`, `is_workday`, `source_batch_id`,
+          // `projection_owner`, `visibility_state`, `visibility_reason`, `created_at`,
+          // `updated_at`) and would have silently broken the mobile client, with only tests
+          // FREEZING the new shape rather than approving it. Owner ruling: preserve the contract.
+          // Any future protocol change is an independent RATIFY plus OpenAPI/SDK/client updates,
+          // not a side effect of delivering the authoritative writer.
+          //
+          // So: re-SELECT the row the core just wrote, INSIDE the same transaction and after the
+          // core's pointer UPDATE, and ship it verbatim. For a COMPLETED outcome this is the
+          // promoted `w4`/`active` row carrying the authoritative daily values; for a REVIEW
+          // outcome it is the parent as it stands (the create-if-absent placeholder, or the
+          // untouched legacy row when one already existed) — in both cases a REAL persisted row,
+          // never a synthesized acknowledgement.
+          const persistedParent = await trx.query(
+            `SELECT * FROM attendance_records WHERE id = $1::uuid AND org_id = $2`,
+            [authoritativeParent.id, envelope.orgId],
+          )
+          if (persistedParent.rows.length !== 1) {
+            // The row was locked FOR UPDATE by this transaction and the core wrote through it, so
+            // its absence here is a programming/DB-state error, not a business outcome.
+            boundaryFail('W4C2_AUTHORITATIVE_PARENT_UNRESOLVED', 500)
+          }
+          const authoritativeRecord = persistedParent.rows[0] as Record<string, unknown>
+
+          // The SAME derivation the legacy adapter uses for this same field — one spelling for
+          // both postures (see the adapter's own doc comment for why `resolveLiveCandidate`'s
+          // `fullWinner`-bearing result must NOT be substituted here).
+          const authoritativeWorkDateResolution =
+            await adapters.deriveLivePunchWorkDateResolution(pluginTrx, legacyPunchArgs)
+
           const authoritativeResponse = {
             event: authoritativeEvent,
             record: authoritativeRecord,
-            // [OWNER-CONFIRM, second half of the response-contract question] Populated explicitly
-            // from THIS transaction's own frozen resolution/attribution — never left undefined,
-            // and never sourced from the split event INSERT (which does not produce one). The
-            // legacy adapter returns the resolver's own `punchWorkDateResolution` object verbatim;
-            // the authoritative branch has no such object, so this closed projection is a SECOND,
-            // independent client-contract change alongside the `record` shape. Its exact key set
-            // is pinned by the same golden leg, so drift is loud.
-            workDateResolution: {
-              kind: authoritativeResolution.kind,
-              workDate: authoritativeResolution.workDate ?? null,
-              shiftId: authoritativeResolution.shiftId ?? null,
-              reasonCode: authoritativeResolution.reasonCode ?? null,
-              attributionPosture: authoritativeAttribution.posture,
-            },
+            workDateResolution: authoritativeWorkDateResolution,
           }
 
           await sealAttendanceResultOperationV1(trx, identity, {

--- a/packages/core-backend/src/attendance/w4c2-live-scheduled-boundary.ts
+++ b/packages/core-backend/src/attendance/w4c2-live-scheduled-boundary.ts
@@ -66,10 +66,20 @@
  *  - effective `eligible`/`authoritative`: a legacy-only business time is
  *    rejected BEFORE any event/record/result/effect DML (the whole transaction
  *    rolls back, discarding the preflight claim).
- *  - effective `authoritative` write execution itself is NOT delivered by this
- *    slice: it fails closed before source DML (see
- *    `W4C2_AUTHORITATIVE_MODE_NOT_DELIVERED`); the state is unreachable in
- *    production (no rollout transition writer ships).
+ *  - effective `authoritative` (`live_punch` ONLY, Gate D2, #4844): the real
+ *    authoritative writer runs — split event INSERT (no legacy records upsert),
+ *    fail-closed retirement guard, create-if-absent review placeholder, then
+ *    `writeAuthoritativeSegmentCalculationV1` (the D1 core) owns the calc row,
+ *    the lineage, and the parent pointer. `scheduled` is STILL undelivered and
+ *    still fails closed at its two sites (see
+ *    `` `W4C2_AUTHORITATIVE_MODE_NOT_DELIVERED` ``); D3 delivers it.
+ *    BYTE-NEUTRAL IN PRODUCTION regardless: `effectiveState==='authoritative'`
+ *    additionally requires an EXACT-org entry in
+ *    `ATTENDANCE_SHIFT_SEGMENT_CALCULATION_ENABLED` (wildcard never counts),
+ *    which is unset in production, so every production org collapses to
+ *    `legacy` and this branch is unreachable irrespective of DB contents. No
+ *    org goes authoritative without a separate, owner-actioned allowlist
+ *    change.
  *
  * Values-free discipline: closed codes only; no caller value in any error.
  */
@@ -145,6 +155,16 @@ import {
   type AttendanceW4ComparableDailyProjection,
 } from '../services/AttendanceW4CalculationDetail'
 import { isExpectedAttendanceShadowDifferenceV1 } from './w4c2-shadow-expected-differences'
+// Gate D2 (#4556 / #4844) — the authoritative live-punch writer's collaborators.
+import {
+  writeAuthoritativeSegmentCalculationV1,
+  type AttendanceAuthoritativeParentPreimageV1,
+} from './w4c2-authoritative-calculation-core'
+// The CANONICAL compatibility-fingerprint producer, shared byte-for-byte with import/rollback.
+// Never hand-rolled here, and never modeled on ops-retirement's separate 6-field
+// `dailyFingerprint` (a different, domainless digest — reconciling those two is out of scope).
+import { computeAttendanceImportRollbackPreimageFingerprintV1 } from './w4c3a-import-rollback'
+import { assertParentNotRetiredForAuthoritativePunchV1 } from './w4c3c-ops-retirement'
 
 // ---------------------------------------------------------------------------
 // Errors.
@@ -287,6 +307,20 @@ export interface AttendanceW4LiveScheduledLegacyAdaptersV1 {
     record: Record<string, unknown>
     workDateResolution: unknown
   }>
+  /**
+   * Gate D2 (#4556 / #4844): the SPLIT half of `applyLivePunchLegacy` — exactly its
+   * `attendance_events` `INSERT ... RETURNING *`, nothing else. The AUTHORITATIVE live-punch
+   * branch calls THIS (durable punch evidence + the wire `event`) and never the legacy adapter,
+   * because on that path the D1 core owns the `attendance_records` row and the legacy daily
+   * upsert must not run. Deliberately a SEPARATE injected seam rather than a `recordsUpsert`
+   * flag on `applyLivePunchLegacy`: the flag form would make the authoritative path's
+   * zero-invocation spy on `applyLivePunchLegacy` observe one call and destroy the control-flow
+   * pin that proves the writer branch returns before reaching the shadow adapter call site.
+   */
+  insertLivePunchEvent(
+    trx: AttendancePluginShapedTrxV1,
+    args: AttendanceLivePunchLegacyArgsV1,
+  ): Promise<Record<string, unknown>>
   /** P03/P04 verbatim absence INSERT..SELECT (NOT EXISTS) for the given users. */
   applyScheduledAbsenceLegacy(
     trx: AttendancePluginShapedTrxV1,
@@ -566,6 +600,18 @@ function isStrictInstant(value: unknown): boolean {
 
 interface ShadowTargetRow extends AttendanceW4ComparableDailyProjection {
   id: string
+  /**
+   * Gate D2 (#4556 / #4844) — parent-state columns the AUTHORITATIVE branch needs and the
+   * shadow branch ignores. They are read by the SAME single `FOR UPDATE` locked read (never a
+   * second lock/round-trip): the authoritative writer cannot build the §7.8 preimage, decide the
+   * F6 review-placeholder discriminator, or evaluate the retirement guard without them. The
+   * shadow path passes this row to `computeAttendanceW4ShadowDiff` as `legacyProjection`, which
+   * reads only the six named daily fields plus `workDate` — the extra members are inert there.
+   */
+  projectionOwner: 'legacy_untracked' | 'w4'
+  currentCalculationId: string | null
+  visibilityState: 'active' | 'retired'
+  visibilityReason: string
 }
 
 function approvedFactMinutes(
@@ -597,11 +643,18 @@ async function lockShadowParentRecord(
   // Section 8.2 step 5: class-11 final signed target key, then the parent row.
   const target = createVerifiedAttendanceCalculationTargetIdentityV1({ org, userId, workDate })
   await acquireAttendanceCalculationTargetLocks(client, [target])
+  // Gate D2 widened the projection list with the four parent-state columns (see
+  // `ShadowTargetRow`). `first_in_at`/`last_out_at` stay RAW `timestamptz` (never `::text`) so
+  // the authoritative compatibility fingerprint hashes exactly the instants it stores.
   const result = await client.query(
     `SELECT id::text AS id, work_date::text AS "workDate", status,
             first_in_at AS "firstInAt", last_out_at AS "lastOutAt",
             work_minutes AS "workMinutes", late_minutes AS "lateMinutes",
-            early_leave_minutes AS "earlyLeaveMinutes"
+            early_leave_minutes AS "earlyLeaveMinutes",
+            projection_owner AS "projectionOwner",
+            current_calculation_id::text AS "currentCalculationId",
+            visibility_state AS "visibilityState",
+            visibility_reason AS "visibilityReason"
        FROM attendance_records
       WHERE user_id = $1 AND org_id = $2 AND work_date = $3
       FOR UPDATE`,
@@ -618,7 +671,166 @@ async function lockShadowParentRecord(
     workMinutes: row.workMinutes === null ? null : Number(row.workMinutes),
     lateMinutes: row.lateMinutes === null ? null : Number(row.lateMinutes),
     earlyLeaveMinutes: row.earlyLeaveMinutes === null ? null : Number(row.earlyLeaveMinutes),
+    projectionOwner: row.projectionOwner === 'w4' ? 'w4' : 'legacy_untracked',
+    currentCalculationId:
+      typeof row.currentCalculationId === 'string' ? row.currentCalculationId : null,
+    visibilityState: row.visibilityState === 'retired' ? 'retired' : 'active',
+    visibilityReason: String(row.visibilityReason ?? ''),
   }
+}
+
+// ---------------------------------------------------------------------------
+// Gate D2 (#4556 / #4844) — authoritative live-punch helpers.
+// ---------------------------------------------------------------------------
+
+/**
+ * Create-if-absent review-path parent placeholder, in-txn under the target lock, BEFORE the core
+ * call. ALWAYS `legacy_untracked` / pointer NULL / `retired` / `review_placeholder` — never an
+ * outcome-conditional `active`.
+ *
+ * WHY `retired`, NOT `active` (this is the §7.5/F6 review-path parent-state install the D1 core
+ * header names as a D2 obligation): the core's `writeCompletedRow` baseline predicate is exactly
+ * `projectionOwner==='legacy_untracked' && visibilityState==='active'`. An `active` placeholder
+ * would trip it and demand a compatibility fingerprint for a projection that does not exist. A
+ * `retired`/`review_placeholder` placeholder makes the core skip the baseline entirely; for a
+ * COMPLETED outcome its own tail pointer UPDATE then flips the parent to `w4`/`active`/`active`
+ * in the same transaction — one atomic promotion. For a REVIEW outcome the placeholder is
+ * preserved as-is, invisible to `visibility_state='active'` readers.
+ *
+ * DAILY-FIELD FIDELITY — a schema constraint, disclosed rather than silently papered over: the
+ * spec calls for every mutable W4-owned daily field to be NULL. `attendance_records.status`,
+ * `work_minutes`, `late_minutes` and `early_leave_minutes` are `NOT NULL` columns (with a closed
+ * `status` CHECK), so literal NULL is not writable for those four. This inserts the schema's own
+ * neutral defaults for them and genuine NULLs for the two nullable instants
+ * (`first_in_at`/`last_out_at`), which is the minimum-fabrication row the schema admits — and
+ * strictly less fabrication than the existing import-side precedent, which writes the real
+ * compatibility projection into a review placeholder. The row is never reader-visible while it
+ * holds this state: hiding is done by `visibility_state='retired'`, not by NULL-ness.
+ *
+ * POISON-RACE: `ON CONFLICT (user_id, work_date, org_id) DO NOTHING` (the in-file idiom and the
+ * actual unique key) so a concurrent creator resolves to a PRODUCT outcome, never a raw 23505
+ * that poisons the whole transaction. Zero rows returned means this caller LOST the race; the
+ * caller must then re-`SELECT ... FOR UPDATE` and re-enter the full retirement/preimage
+ * resolution — the winner's row may be a legacy-ACTIVE row, not another placeholder.
+ *
+ * A plain `ON CONFLICT` (rather than the F1 SAVEPOINT form) is legal here ONLY because this is
+ * the FIRST DML the authoritative branch performs — Step 1's reject and Step 2's locked read are
+ * DML-free. If any future change moves other DML ahead of this INSERT, the SAVEPOINT form
+ * becomes MANDATORY, not a style preference.
+ */
+async function insertAuthoritativeReviewPlaceholderParentV1(
+  client: AttendanceW4TransactionClientV1,
+  input: Readonly<{ orgId: string; userId: string; workDate: string; timezone: string; isWorkday: boolean }>,
+): Promise<{ created: boolean }> {
+  const result = await client.query(
+    `INSERT INTO attendance_records (
+        org_id, user_id, work_date, timezone,
+        first_in_at, last_out_at,
+        work_minutes, late_minutes, early_leave_minutes, status,
+        is_workday, meta, source_batch_id,
+        projection_owner, current_calculation_id, visibility_state, visibility_reason,
+        created_at, updated_at
+      ) VALUES (
+        $1, $2, $3::date, $4,
+        NULL, NULL,
+        0, 0, 0, 'normal',
+        $5, '{}'::jsonb, NULL,
+        'legacy_untracked', NULL, 'retired', 'review_placeholder',
+        now(), now()
+      )
+      ON CONFLICT (user_id, work_date, org_id) DO NOTHING
+      RETURNING id::text AS id`,
+    [input.orgId, input.userId, input.workDate, input.timezone, input.isWorkday],
+  )
+  return { created: result.rows.length === 1 }
+}
+
+/**
+ * The §7.8 frozen write-before parent witness the D1 core validates against, plus the caller's
+ * `expectedCurrentCalculationId`.
+ *
+ * The compatibility fingerprint is LOAD-BEARING only for a present legacy-ACTIVE parent: the
+ * core stores it verbatim as the `legacy_baseline` row's `projected_daily_fingerprint` and fails
+ * `PREIMAGE_INVALID` when it is absent. It is computed for every present parent regardless (so
+ * neither owner fork leaves a latent landmine) via the CANONICAL
+ * `computeAttendanceImportRollbackPreimageFingerprintV1`, so the digest is byte-identical to the
+ * one import/rollback freezes over the same parent state — never a fourth hand-rolled copy.
+ *
+ * Instants are normalized to ISO before hashing AND the same normalized values are what the
+ * preimage stores, so the stored projection and the hashed projection are the same bytes.
+ */
+function buildAuthoritativeLivePunchPreimageV1(
+  parent: ShadowTargetRow,
+): { preimage: AttendanceAuthoritativeParentPreimageV1; expectedCurrentCalculationId: string | null } {
+  const projection = {
+    status: parent.status === null ? '' : String(parent.status),
+    firstInAt: normalizeInstantIsoV1(parent.firstInAt),
+    lastOutAt: normalizeInstantIsoV1(parent.lastOutAt),
+    workMinutes: Math.max(0, Math.trunc(parent.workMinutes ?? 0)),
+    lateMinutes: Math.max(0, Math.trunc(parent.lateMinutes ?? 0)),
+    earlyLeaveMinutes: Math.max(0, Math.trunc(parent.earlyLeaveMinutes ?? 0)),
+  }
+  const compatibilityFingerprint = computeAttendanceImportRollbackPreimageFingerprintV1({
+    projection,
+    projectionOwner: parent.projectionOwner,
+    currentCalculationId: parent.currentCalculationId,
+    visibilityState: parent.visibilityState,
+    visibilityReason: parent.visibilityReason,
+  })
+  return {
+    preimage: {
+      posture: 'present',
+      projectionOwner: parent.projectionOwner,
+      currentCalculationId: parent.currentCalculationId,
+      visibilityState: parent.visibilityState,
+      visibilityReason: parent.visibilityReason as 'active' | 'review_placeholder' | 'import_rollback' | 'operator_retirement',
+      projection,
+      compatibilityFingerprint,
+    },
+    // Always the LOCKED actual, never a recomputed or assumed value; the core cross-checks it
+    // under its own `FOR UPDATE` re-lock and fails VERSION_CONFLICT on a mismatch.
+    expectedCurrentCalculationId: parent.currentCalculationId,
+  }
+}
+
+function normalizeInstantIsoV1(value: string | Date | null): string | null {
+  if (value === null || value === undefined) return null
+  const date = value instanceof Date ? value : new Date(value)
+  const ms = date.getTime()
+  if (!Number.isFinite(ms)) return null
+  return date.toISOString()
+}
+
+/**
+ * Deterministic payload identity for the core's retry-idempotency conflict check. The core reads
+ * `input_provenance.payloadFingerprint` VERBATIM off the stored row on a retry, so this value
+ * must (a) be derived only from the resolved command payload — never from a clock, a random id,
+ * or the operation id itself — and (b) be embedded in BOTH `input.payloadFingerprint` and
+ * `inputProvenance.payloadFingerprint`. Omitting the embedded copy makes a genuine retry read
+ * `null`, mismatch, and surface `REPLAY_CONFLICT` where §7.3 requires a replay.
+ */
+function computeAuthoritativeLivePunchPayloadFingerprintV1(
+  input: AttendanceLivePunchBoundaryInputV1,
+): string {
+  return sha256Hex(
+    'metasheet2:attendance:w4c2:live-punch-authoritative-payload:v1 '
+    + canonicalAttendanceJsonV1({
+      orgId: input.orgId,
+      userId: input.userId,
+      workDate: input.workDate,
+      eventType: input.eventType,
+      occurredAt: input.occurredAtRaw ?? input.occurredAtResolved,
+      occurredAtResolved: input.occurredAtResolved,
+      timezone: input.timezone,
+      requestTimezone: input.requestTimezone,
+      source: input.source,
+      location: wireJson(input.location ?? null),
+      meta: wireJson(input.meta ?? null),
+      photoFileRef: input.photoFileRef,
+      isWorkday: input.isWorkday,
+      holidayKind: input.holidayKind,
+    }),
+  )
 }
 
 async function nextCalculationVersion(
@@ -1070,6 +1282,11 @@ export function createAttendanceLiveScheduledBoundaryV1(
   if (
     !adapters ||
     typeof adapters.applyLivePunchLegacy !== 'function' ||
+    // Gate D2: required, never optional — a host that provided the boundary but omitted the
+    // split event seam would make an authoritative punch lose its own durable evidence. Folding
+    // it into the SAME fail-closed gate keeps that state unreachable (the boundary simply does
+    // not exist), instead of degrading at write time.
+    typeof adapters.insertLivePunchEvent !== 'function' ||
     typeof adapters.applyScheduledAbsenceLegacy !== 'function' ||
     typeof adapters.resolveLiveCandidate !== 'function' ||
     typeof adapters.resolveScheduledCandidate !== 'function' ||
@@ -1264,16 +1481,335 @@ export function createAttendanceLiveScheduledBoundaryV1(
           return { kind: 'legacy_compat' as const, response: result }
         }
 
+        // Three-posture matrix: a business time only the legacy parser accepts.
+        // HOISTED above the authoritative branch by Gate D2 so both the authoritative reject
+        // (below, first thing in the branch) and the eligible reject (further down) read ONE
+        // predicate rather than two copies that could drift. Pure and DML-free (`isStrictInstant`
+        // is a try/catch around the strict instant parser), so hoisting it is behaviour-
+        // preserving for every other posture.
+        const legacyOnlyTime = input.occurredAtRaw !== null && !isStrictInstant(input.occurredAtRaw)
+
         // W4 posture. Distinguish effective shadow vs eligible vs authoritative
         // (still under the org rollout shared lock acquired above).
         if (posture.effectiveState === 'authoritative' || org.acceptedWritePosture === 'authoritative') {
-          // The authoritative live writer is NOT delivered by W4C-2; fail
-          // closed before any source DML (whole transaction rolls back).
-          boundaryFail('W4C2_AUTHORITATIVE_MODE_NOT_DELIVERED', 503)
+          // ===================================================================
+          // Gate D2 (#4556 / #4844) — the AUTHORITATIVE live-punch writer.
+          //
+          // REPLACEMENT, NOT A DELETE. This branch body previously failed closed. Deleting it
+          // instead of replacing it would let an allowlisted authoritative org's punch fall
+          // through to the shadow `applyLivePunchLegacy` call below — a silent 503-to-legacy-
+          // projection conversion, fail-OPEN the instant the allowlist gains an authoritative
+          // entry. The branch body must always be a real writer, and it must `return`/throw
+          // before control can reach that call site (pinned behaviourally by the zero-invocation
+          // spy on the injected `applyLivePunchLegacy`).
+          //
+          // Deliberate deviation from §8.2's step-4-before-step-5 numbering: the parent lock is
+          // taken BEFORE the in-transaction W2 re-resolution here, because the retirement guard
+          // and the create-if-absent placeholder must both settle before ANY source DML (the
+          // split event INSERT included). Safe: the two orderings cannot interleave, because the
+          // org rollout SHARED advisory lock is held for the whole transaction on BOTH paths and
+          // a posture transition needs the EXCLUSIVE one — so every in-flight punch for an org
+          // sees the same posture, and a shadow punch can never be concurrent with an
+          // authoritative punch on the same parent row.
+          // ===================================================================
+
+          // -- Step 1: legacy-only business time is REJECTED, with ZERO DML ------------------
+          // The eligible reject below never evaluates on this path (it is gated on
+          // `effectiveState === 'eligible'`), so this is a genuinely new in-branch check, not a
+          // widened existing one. Authoritative may never be LOOSER than eligible: §12.3 requires
+          // effective eligible|authoritative to reject before event/request/result/effect DML.
+          // The whole transaction rolls back, discarding the preflight claim; no event row, no
+          // record row, no calculation row, and no `attendance.punched` outbox row (the enqueue
+          // is further down, after this point).
+          if (legacyOnlyTime) {
+            throw new AttendanceW4OperationError('W4_ATTRIBUTION_UNSUPPORTED')
+          }
+
+          // -- Step 2: the widened locked parent read (class-11 target lock + FOR UPDATE) ------
+          // Read-only. Also re-locked by the core's own `lockParent FOR UPDATE by id` inside the
+          // same transaction (a no-op re-lock); the boundary's advisory target lock precedes the
+          // row lock and the core takes no advisory lock, so there is no inversion.
+          let authoritativeParent = await lockShadowParentRecord(trx, org, input.userId, input.workDate)
+
+          // -- Step 3a: absent parent → create-if-absent review placeholder --------------------
+          // The FIRST DML this branch performs (Steps 1-2 are a throw and a SELECT), which is
+          // exactly what makes plain ON CONFLICT DO NOTHING legal here without a SAVEPOINT.
+          if (authoritativeParent === null) {
+            await insertAuthoritativeReviewPlaceholderParentV1(trx, {
+              orgId: envelope.orgId,
+              userId: input.userId,
+              workDate: input.workDate,
+              timezone: input.timezone,
+              isWorkday: input.isWorkday,
+            })
+            // ALWAYS re-read under the lock — never assume our own placeholder won. On a lost
+            // race the winner's row may be a legacy-ACTIVE row (compat fingerprint becomes
+            // load-bearing), another review placeholder, or a RETIRED row (refused below); this
+            // re-entry is what routes every one of those to the same resolution path.
+            authoritativeParent = await lockShadowParentRecord(trx, org, input.userId, input.workDate)
+            if (authoritativeParent === null) {
+              // Neither our INSERT nor a racer's produced a visible row under our own lock —
+              // a programming/DB-state error, not a business outcome.
+              boundaryFail('W4C2_AUTHORITATIVE_PARENT_UNRESOLVED', 500)
+            }
+          }
+
+          // -- Step 3b: DEFAULT-REFUSE retirement guard ---------------------------------------
+          // Runs before any FURTHER DML — before the split event INSERT and before the core call.
+          // (In the absent branch above the only preceding DML is our own placeholder INSERT,
+          // which either created a `review_placeholder` row that this guard admits, or wrote
+          // nothing at all; so no refusing case ever leaves a write behind.)
+          //
+          // The core is reason-BLIND: its `lockParent` SELECT omits `visibility_reason` and its
+          // completed-path pointer UPDATE reactivates the parent to `w4/active/active`
+          // UNCONDITIONALLY. The boundary is the only reason-aware reader, so the guard belongs
+          // here. It is also precisely the guard the Step-4 adapter split removes from this path:
+          // the legacy punch's own operator-retirement refusal lives inside the
+          // `attendance_records` upsert that the split drops.
+          //
+          // D2 default on the `import_rollback` fork is explicit REFUSE (never a bare completed
+          // that reactivates a rolled-back day); routing it through the governed preimage-freeze
+          // reactivation instead is an owner product call, not a build-time choice.
+          assertParentNotRetiredForAuthoritativePunchV1({
+            visibilityState: authoritativeParent.visibilityState,
+            visibilityReason: authoritativeParent.visibilityReason,
+          })
+
+          // -- Step 4: split event INSERT, then the shared compute ----------------------------
+          // The SPLIT half only: durable punch evidence + the wire `event`. The legacy daily
+          // `attendance_records` upsert is deliberately NOT run — the core owns that row on this
+          // path. `adapters.applyLivePunchLegacy` is never called from this branch.
+          const authoritativeEvent = await adapters.insertLivePunchEvent(pluginTrx, legacyPunchArgs)
+
+          const authoritativeNowIso = new Date().toISOString()
+          const authoritativeResolution = await adapters.resolveLiveCandidate(pluginTrx, {
+            orgId: envelope.orgId,
+            userId: input.userId,
+            occurredAt: input.occurredAtResolved,
+            // PRE-resolution timezone, anchor deliberately omitted — identical contract to the
+            // shadow branch's own call (see `resolveLiveCandidate`'s doc comment).
+            timezone: input.requestTimezone,
+          })
+          const authoritativeAttribution = attributionFromResolution(authoritativeResolution, {
+            orgId: envelope.orgId,
+            userId: input.userId,
+            source: 'live_resolution',
+            nowIso: authoritativeNowIso,
+          })
+          let authoritativeContext: FrozenAttendanceContextV1 | null = null
+          if (authoritativeAttribution.posture === 'resolved_v2') {
+            authoritativeContext = await adapters.buildShadowFrozenContext(pluginTrx, {
+              orgId: envelope.orgId,
+              userId: input.userId,
+              workDate: authoritativeAttribution.value.workDate,
+              shiftId: authoritativeAttribution.value.shiftId,
+              timezone: authoritativeResolution.fullWinner?.timezone ?? input.requestTimezone,
+              isWorkday: input.isWorkday,
+              holidayKind: input.holidayKind,
+            })
+          }
+          // Evidence is loaded AFTER the split INSERT so this punch is inside its own evidence
+          // set — otherwise a day's first check-in could never produce a completed segment.
+          const authoritativeEvidenceAnchorWorkDate =
+            authoritativeAttribution.posture === 'resolved_v2'
+              ? authoritativeAttribution.value.workDate
+              : input.workDate
+          const authoritativeEvidence = await loadLivePunchEvidence(
+            trx,
+            envelope.orgId,
+            input.userId,
+            authoritativeEvidenceAnchorWorkDate,
+          )
+          const authoritativeCalculated = calculateAttendanceSegmentsV1({
+            attribution: authoritativeAttribution,
+            context: authoritativeContext,
+            evidence: authoritativeEvidence,
+            approvedFacts: [],
+          })
+
+          // identityDrift override (canonical freeze semantics §4.2 candidate (i)), computed
+          // exactly as the shadow branch does. On the AUTHORITATIVE path this override is
+          // load-bearing rather than cosmetic: passing the raw calculator result through on a
+          // drifted punch would write a COMPLETED row and MOVE THE PARENT POINTER onto an
+          // attribution whose identity the operation never committed to.
+          const authoritativeInnerComparableFingerprint =
+            authoritativeAttribution.posture === 'resolved_v2'
+              ? computeAttendanceOuterComparableSourceDefinitionFingerprintV1({
+                  attribution: authoritativeAttribution,
+                  context: authoritativeContext,
+                })
+              : null
+          const authoritativeIdentityMismatch =
+            authoritativeAttribution.posture === 'resolved_v2' &&
+            (authoritativeAttribution.value.workDate !== input.workDate
+              || authoritativeAttribution.value.shiftId !== input.shiftId)
+          const authoritativeFingerprintMismatch =
+            authoritativeAttribution.posture === 'resolved_v2' &&
+            authoritativeInnerComparableFingerprint !== input.outerSourceDefinitionFingerprint
+          const authoritativeIdentityDrift =
+            authoritativeIdentityMismatch || authoritativeFingerprintMismatch
+          const authoritativeCalculation: AttendanceSegmentCalculationResultV1 =
+            authoritativeIdentityDrift
+              ? {
+                  outcome: 'review_required',
+                  outcomeReasonCode: 'context_mismatch',
+                  segments: [],
+                  dailyProjection: null,
+                }
+              : authoritativeCalculated
+
+          // -- Steps 5 & 6: preimage + expected pointer, and the payload fingerprint ----------
+          const authoritativeProvenanceRef: AttendanceInputProvenanceRefV1 = {
+            transport: 'live_event',
+            sourceRef: LIVE_SOURCE_REF,
+            artifactSha256: null,
+            normalizedCsvSha256: null,
+            convertedSheetName: null,
+          }
+          const authoritativePayloadFingerprint =
+            computeAuthoritativeLivePunchPayloadFingerprintV1(input)
+          const { preimage: authoritativePreimage, expectedCurrentCalculationId } =
+            buildAuthoritativeLivePunchPreimageV1(authoritativeParent)
+
+          // -- Step 7: the core owns the calc row, the lineage, and the parent pointer --------
+          const authoritativeWritten = await writeAuthoritativeSegmentCalculationV1(trx, {
+            orgId: envelope.orgId,
+            recordId: authoritativeParent.id,
+            entrypoint: 'live',
+            operationId: identity.id,
+            calculation: authoritativeCalculation,
+            attribution: authoritativeAttribution,
+            context: authoritativeContext,
+            evidence: authoritativeEvidence as unknown as readonly unknown[],
+            approvedFacts: [],
+            provenanceRef: authoritativeProvenanceRef,
+            // BOTH places: top-level for the core's own conflict check, and embedded so a
+            // genuine retry's `input_provenance.payloadFingerprint` read matches.
+            inputProvenance: {
+              ...authoritativeProvenanceRef,
+              payloadFingerprint: authoritativePayloadFingerprint,
+            },
+            payloadFingerprint: authoritativePayloadFingerprint,
+            preimage: authoritativePreimage,
+            expectedCurrentCalculationId,
+            sourceBatchId: null,
+            actorId: authorization.actorId,
+            correlationId: envelope.correlationId,
+          })
+
+          // Seal fingerprints are RECOMPUTED at the boundary over the same inputs the core
+          // hashed — the core's return shape is deliberately unchanged by D2. The tier arg MUST
+          // be `segment_authoritative`: copying the shadow builder's `legacy_shadow` would seal a
+          // fingerprint that does not match the persisted authoritative row.
+          const authoritativeSemanticFingerprint = computeAttendanceSemanticInputFingerprintV1({
+            attribution: authoritativeAttribution,
+            context: authoritativeContext,
+            evidence: authoritativeEvidence,
+            approvedFacts: [],
+            manualOverride: null,
+            mergePolicy: 'append',
+            calculationTier: 'segment_authoritative',
+            engineVersion: ATTENDANCE_W4_SEGMENT_ENGINE_VERSION_V1,
+            snapshotSchemaVersion: 1,
+          })
+          const authoritativeProvenanceFingerprint =
+            computeAttendanceProvenanceFingerprintV1(authoritativeProvenanceRef)
+
+          // Outbox BEFORE seal (lock 8.2 steps 14-15), unconditional — byte-identical to the
+          // shadow path's own enqueue, which already fires for review outcomes today. Whether a
+          // review-only authoritative outcome SHOULD emit `attendance.punched` is an open product
+          // question; D2 changes nothing about it.
+          await enqueueAttendanceResultEventOutboxV1(trx, identity, [
+            {
+              eventKind: 'attendance.punched',
+              payload: {
+                userId: input.userId,
+                orgId: envelope.orgId,
+                workDate: input.workDate,
+                eventType: input.eventType,
+                occurredAt: input.occurredAtResolved,
+                timezone: input.timezone,
+              },
+              payloadSchemaVersion: 1,
+              businessKeyFingerprint: computeAttendanceBusinessKeyFingerprintV1({
+                kind: 'attendance.punched',
+                orgId: envelope.orgId,
+                operationId: identity.id,
+              }),
+            },
+          ])
+
+          // -- Step 8a: synthesize the `{event, record, workDateResolution}` caller response ---
+          // There is no legacy adapter `result` on this path, so the wire shape is built here.
+          // `record` for a COMPLETED outcome is mapped from the calculation's own
+          // `dailyProjection` (camelCase `PreparedDailyProjectionV1`). This is a CONFIRMED
+          // client-contract change from the snake_case `attendance_records` row the legacy
+          // adapter returns today; it ships as the specified default and is pinned by an exact
+          // key-set golden test so any drift — in either direction — is loud rather than silent.
+          // The documented alternative (re-SELECT the persisted row after the core call) is an
+          // owner decision, not a build-time one.
+          const authoritativeRecord = authoritativeCalculation.dailyProjection !== null
+            ? {
+                firstInAt: authoritativeCalculation.dailyProjection.firstInAt,
+                lastOutAt: authoritativeCalculation.dailyProjection.lastOutAt,
+                workedMinutes: authoritativeCalculation.dailyProjection.workedMinutes,
+                lateMinutes: authoritativeCalculation.dailyProjection.lateMinutes,
+                earlyLeaveMinutes: authoritativeCalculation.dailyProjection.earlyLeaveMinutes,
+                status: authoritativeCalculation.dailyProjection.status,
+                timezone: authoritativeCalculation.dailyProjection.timezone,
+                workDate: authoritativeCalculation.dailyProjection.workDate,
+                meta: authoritativeCalculation.dailyProjection.meta,
+              }
+            // Review outcome: an all-NULL acknowledgement in the SAME key set, so the wire shape
+            // does not change between outcomes. Whether a review should instead echo the
+            // preserved legacy columns is the second half of the same owner question.
+            : {
+                firstInAt: null,
+                lastOutAt: null,
+                workedMinutes: null,
+                lateMinutes: null,
+                earlyLeaveMinutes: null,
+                status: null,
+                timezone: null,
+                workDate: null,
+                meta: null,
+              }
+          const authoritativeResponse = {
+            event: authoritativeEvent,
+            record: authoritativeRecord,
+            // Populated explicitly from THIS transaction's own frozen resolution/attribution —
+            // never left undefined, and never sourced from the split event INSERT (which does
+            // not produce one).
+            workDateResolution: {
+              kind: authoritativeResolution.kind,
+              workDate: authoritativeResolution.workDate ?? null,
+              shiftId: authoritativeResolution.shiftId ?? null,
+              reasonCode: authoritativeResolution.reasonCode ?? null,
+              attributionPosture: authoritativeAttribution.posture,
+            },
+          }
+
+          await sealAttendanceResultOperationV1(trx, identity, {
+            responseSnapshot: wireJson(authoritativeResponse),
+            resolvedRecordId: authoritativeParent.id,
+            resolvedCalculationId: authoritativeWritten.calculationId,
+            resultSemanticFingerprint: authoritativeSemanticFingerprint,
+            resultProvenanceFingerprint: authoritativeProvenanceFingerprint,
+          })
+
+          // The P-A obligation: this `return` is what keeps control from reaching the shadow
+          // `applyLivePunchLegacy` call site below.
+          return {
+            kind: 'w4' as const,
+            response: authoritativeResponse,
+            shadow: {
+              calculationId: authoritativeWritten.calculationId,
+              outcome: authoritativeCalculation.outcome,
+              outcomeReasonCode: authoritativeCalculation.outcomeReasonCode,
+            },
+          }
         }
 
-        // Three-posture matrix: a business time only the legacy parser accepts.
-        const legacyOnlyTime = input.occurredAtRaw !== null && !isStrictInstant(input.occurredAtRaw)
         if (legacyOnlyTime && posture.effectiveState === 'eligible') {
           // Reject BEFORE event/request/result/effect DML: rollback discards
           // the preflight claim; no source row is ever written.

--- a/packages/core-backend/src/attendance/w4c2-live-scheduled-boundary.ts
+++ b/packages/core-backend/src/attendance/w4c2-live-scheduled-boundary.ts
@@ -697,15 +697,25 @@ async function lockShadowParentRecord(
  * in the same transaction — one atomic promotion. For a REVIEW outcome the placeholder is
  * preserved as-is, invisible to `visibility_state='active'` readers.
  *
- * DAILY-FIELD FIDELITY — a schema constraint, disclosed rather than silently papered over: the
- * spec calls for every mutable W4-owned daily field to be NULL. `attendance_records.status`,
- * `work_minutes`, `late_minutes` and `early_leave_minutes` are `NOT NULL` columns (with a closed
- * `status` CHECK), so literal NULL is not writable for those four. This inserts the schema's own
- * neutral defaults for them and genuine NULLs for the two nullable instants
- * (`first_in_at`/`last_out_at`), which is the minimum-fabrication row the schema admits — and
- * strictly less fabrication than the existing import-side precedent, which writes the real
- * compatibility projection into a review placeholder. The row is never reader-visible while it
- * holds this state: hiding is done by `visibility_state='retired'`, not by NULL-ness.
+ * DAILY-FIELD FIDELITY — [OWNER-CONFIRM] the specified state is NOT WRITABLE against the current
+ * schema, disclosed here rather than silently papered over. §7.5's parent-state install calls for
+ * every mutable W4-owned daily field to be NULL. `attendance_records.status`, `work_minutes`,
+ * `late_minutes` and `early_leave_minutes` are `NOT NULL` columns (`status` additionally carries a
+ * closed CHECK), so literal NULL is not writable for four of the six. What ships: the schema's own
+ * neutral values for those four (`'normal'`, `0`, `0`, `0`) and genuine NULLs for the two nullable
+ * instants (`first_in_at` / `last_out_at`). That is the minimum-fabrication row the schema admits,
+ * and strictly less fabrication than the existing import-side precedent
+ * (`ensureAuthoritativeParent`, which writes the REAL compatibility projection into its review
+ * placeholder).
+ *
+ * WHY THIS IS AN OWNER ITEM AND NOT JUST A NOTE: the spec's stated rationale for NULL was "so
+ * ordinary readers see no fabricated zero-minute row" — and what ships IS a fabricated
+ * zero-minute row whose only concealment is `visibility_state='retired'`. Concealment therefore
+ * rests entirely on visibility filtering, and visibility filtering is not yet universal (no read
+ * ROUTE filters `visibility_state`; the canonical active-current host-port helper does, and the
+ * D2 suite pins that one reader with a positive control). The owner should either confirm this
+ * shape or authorize a nullability migration; a third option — widening the read side first — is
+ * the same forward obligation the E5 suite already records.
  *
  * POISON-RACE: `ON CONFLICT (user_id, work_date, org_id) DO NOTHING` (the in-file idiom and the
  * actual unique key) so a concurrent creator resolves to a PRODUCT outcome, never a raw 23505
@@ -1787,9 +1797,13 @@ export function createAttendanceLiveScheduledBoundaryV1(
           const authoritativeResponse = {
             event: authoritativeEvent,
             record: authoritativeRecord,
-            // Populated explicitly from THIS transaction's own frozen resolution/attribution —
-            // never left undefined, and never sourced from the split event INSERT (which does
-            // not produce one).
+            // [OWNER-CONFIRM, second half of the response-contract question] Populated explicitly
+            // from THIS transaction's own frozen resolution/attribution — never left undefined,
+            // and never sourced from the split event INSERT (which does not produce one). The
+            // legacy adapter returns the resolver's own `punchWorkDateResolution` object verbatim;
+            // the authoritative branch has no such object, so this closed projection is a SECOND,
+            // independent client-contract change alongside the `record` shape. Its exact key set
+            // is pinned by the same golden leg, so drift is loud.
             workDateResolution: {
               kind: authoritativeResolution.kind,
               workDate: authoritativeResolution.workDate ?? null,

--- a/packages/core-backend/src/attendance/w4c2-live-scheduled-boundary.ts
+++ b/packages/core-backend/src/attendance/w4c2-live-scheduled-boundary.ts
@@ -697,25 +697,40 @@ async function lockShadowParentRecord(
  * in the same transaction — one atomic promotion. For a REVIEW outcome the placeholder is
  * preserved as-is, invisible to `visibility_state='active'` readers.
  *
- * DAILY-FIELD FIDELITY — [OWNER-CONFIRM] the specified state is NOT WRITABLE against the current
- * schema, disclosed here rather than silently papered over. §7.5's parent-state install calls for
- * every mutable W4-owned daily field to be NULL. `attendance_records.status`, `work_minutes`,
- * `late_minutes` and `early_leave_minutes` are `NOT NULL` columns (`status` additionally carries a
- * closed CHECK), so literal NULL is not writable for four of the six. What ships: the schema's own
- * neutral values for those four (`'normal'`, `0`, `0`, `0`) and genuine NULLs for the two nullable
- * instants (`first_in_at` / `last_out_at`). That is the minimum-fabrication row the schema admits,
- * and strictly less fabrication than the existing import-side precedent
- * (`ensureAuthoritativeParent`, which writes the REAL compatibility projection into its review
- * placeholder).
+ * DAILY-FIELD FIDELITY — what the LOCK requires, and what the daily columns therefore carry.
  *
- * WHY THIS IS AN OWNER ITEM AND NOT JUST A NOTE: the spec's stated rationale for NULL was "so
- * ordinary readers see no fabricated zero-minute row" — and what ships IS a fabricated
- * zero-minute row whose only concealment is `visibility_state='retired'`. Concealment therefore
- * rests entirely on visibility filtering, and visibility filtering is not yet universal (no read
- * ROUTE filters `visibility_state`; the canonical active-current host-port helper does, and the
- * D2 suite pins that one reader with a positive control). The owner should either confirm this
- * shape or authorize a nullability migration; a third option — widening the read side first — is
- * the same forward obligation the E5 suite already records.
+ * §7.5 (`attendance-issue-4556-w4-segment-calculation-design-lock-20260724.md:1502-1505`) requires a
+ * FOUR-TUPLE of parent-state columns for a fresh authoritative review — `legacy_untracked` /
+ * pointer-null / `retired` / `review_placeholder` — plus the rationale clause "ordinary readers see
+ * no fabricated `normal` zero-minute row". The INSERT below satisfies that four-tuple exactly. The
+ * stronger phrasing "every mutable W4-owned daily field NULL" is the D2 build brief's own
+ * amplification of §7.5, NOT lock text — worth stating, because four of those six columns
+ * (`status`, `work_minutes`, `late_minutes`, `early_leave_minutes`) are `NOT NULL` (`status` with a
+ * closed CHECK on top), so literal NULL is not writable for them and the amplified form is not
+ * satisfiable against this schema at all. What ships is the schema's own neutral values for those
+ * four and genuine NULLs for the two nullable instants (`first_in_at` / `last_out_at`).
+ *
+ * FABRICATION, COMPARED HONESTLY: this row DOES fabricate `normal`/0/0/0, and it fabricates MORE
+ * than the import-side precedent, not less. `ensureAuthoritativeParent`
+ * (`w4c3a-canonical-import-kernel.ts:832-860`) writes the REAL supplied compatibility projection
+ * into its own `retired`/`review_placeholder` row — zero fabrication — because on the import path a
+ * real projection exists to write. The live authoritative path has none: a review outcome means the
+ * calculator produced no `dailyProjection`, and the day may have no prior legacy row at all. The
+ * schema's neutral values are what remains once NULL is unavailable and no true value exists.
+ *
+ * WHY THE RATIONALE CLAUSE STILL HOLDS (the part that actually matters): the fabricated values are
+ * never rendered to an ordinary reader, because every daily-VALUE surface filters visibility —
+ * records list/export, report + multitable sync, period/payroll summary, missed-punch candidates and
+ * comprehensive-hours all read through the `attendance_current_records` view
+ * (`… WHERE visibility_state = 'active'`), one route filters `r.visibility_state = 'active'`
+ * inline (`plugins/plugin-attendance/index.cjs:30197`), and anomaly listing / makeup facts /
+ * open-record attribution / DecisionTrace go through the canonical `w4c3c-active-current` helper.
+ * The one ordinary-permission read that touches the base table without a visibility predicate,
+ * `readAttendanceCalculationDetail`, selects ZERO daily columns (id, pointer, mode, owner,
+ * visibility state/reason) and is exactly the calculation-detail path §7.6:1526-1527 names as
+ * permitted to read retired parents. Leg 8 of the D2 suite pins the canonical helper with a
+ * positive control. So this needs no owner ruling and no nullability migration; it is recorded
+ * here as a disclosure, not a deviation.
  *
  * POISON-RACE: `ON CONFLICT (user_id, work_date, org_id) DO NOTHING` (the in-file idiom and the
  * actual unique key) so a concurrent creator resolves to a PRODUCT outcome, never a raw 23505

--- a/packages/core-backend/src/attendance/w4c2-live-scheduled-boundary.ts
+++ b/packages/core-backend/src/attendance/w4c2-live-scheduled-boundary.ts
@@ -1645,6 +1645,30 @@ export function createAttendanceLiveScheduledBoundaryV1(
           // path. `adapters.applyLivePunchLegacy` is never called from this branch.
           const authoritativeEvent = await adapters.insertLivePunchEvent(pluginTrx, legacyPunchArgs)
 
+          // The WIRE-ECHO `workDateResolution`, derived HERE — before any write this operation
+          // makes to `attendance_records` — because that is where the legacy path derives it.
+          //
+          // ORDERING IS SEMANTIC, NOT COSMETIC. The resolver consults OPEN records
+          // (`w4c3c-active-current.ts:176-190`: `visibility_state='active'` via the current view,
+          // `first_in_at IS NOT NULL AND last_out_at IS NULL`) when it breaks ties between
+          // candidate shifts. The core's completed-path pointer UPDATE writes exactly that shape
+          // for a check-in-only day — `first_in_at` set, `last_out_at` still null, and it flips the
+          // row to `active` — so a derivation placed AFTER the core call can observe an open record
+          // THIS operation just created and echo a resolution the legacy path, which derives before
+          // its own upsert (`index.cjs`, `deriveLegacyLivePunchAttributionV1` ahead of
+          // `appendUpsert`), could never produce for the same punch. Only the echoed field is
+          // affected — the persisted calculation freezes `authoritativeResolution` below — but the
+          // owner's ruling is that the authoritative response matches the legacy contract,
+          // SEMANTICS included, not merely field names and casing.
+          //
+          // Placed adjacent to `authoritativeResolution` so both resolver reads observe the same
+          // pre-write state. (The preceding event INSERT is irrelevant to both: neither read
+          // touches `attendance_events`, and the create-if-absent placeholder cannot register as an
+          // open record — it is `retired`, so the current view excludes it, and its `first_in_at`
+          // is NULL either way.)
+          const authoritativeWorkDateResolution =
+            await adapters.deriveLivePunchWorkDateResolution(pluginTrx, legacyPunchArgs)
+
           const authoritativeNowIso = new Date().toISOString()
           const authoritativeResolution = await adapters.resolveLiveCandidate(pluginTrx, {
             orgId: envelope.orgId,
@@ -1839,12 +1863,9 @@ export function createAttendanceLiveScheduledBoundaryV1(
           }
           const authoritativeRecord = persistedParent.rows[0] as Record<string, unknown>
 
-          // The SAME derivation the legacy adapter uses for this same field — one spelling for
-          // both postures (see the adapter's own doc comment for why `resolveLiveCandidate`'s
-          // `fullWinner`-bearing result must NOT be substituted here).
-          const authoritativeWorkDateResolution =
-            await adapters.deriveLivePunchWorkDateResolution(pluginTrx, legacyPunchArgs)
-
+          // `authoritativeWorkDateResolution` was derived in Step 4, BEFORE the core's writes —
+          // see the ordering note there. Deriving it here instead would let it observe the open
+          // record this operation's own pointer UPDATE just created.
           const authoritativeResponse = {
             event: authoritativeEvent,
             record: authoritativeRecord,

--- a/packages/core-backend/src/attendance/w4c2-live-scheduled-boundary.ts
+++ b/packages/core-backend/src/attendance/w4c2-live-scheduled-boundary.ts
@@ -717,8 +717,18 @@ async function lockShadowParentRecord(
  * the FIRST DML the authoritative branch performs — Step 1's reject and Step 2's locked read are
  * DML-free. If any future change moves other DML ahead of this INSERT, the SAVEPOINT form
  * becomes MANDATORY, not a style preference.
+ *
+ * DEFENCE IN DEPTH, STATED HONESTLY: through the boundary the race is ALREADY prevented one layer
+ * up — `lockShadowParentRecord` takes the class-11 transaction-scoped advisory target lock on
+ * `(org, user, workDate)` BEFORE its read, so a second authoritative punch for the same day blocks
+ * there and finds the winner's row on its own read rather than reaching this INSERT at all
+ * (proven by the boundary-level concurrency leg, which observes ONE parent and TWO calculations
+ * with the ON CONFLICT clause removed). The clause is therefore NOT load-bearing for the current
+ * boundary call path; it is what keeps this helper safe for any caller that reaches it without
+ * that advisory lock. Its own behaviour is pinned by a direct two-connection leg on this exported
+ * seam — do not read the boundary-level leg as evidence for the clause.
  */
-async function insertAuthoritativeReviewPlaceholderParentV1(
+export async function insertAuthoritativeReviewPlaceholderParentV1(
   client: AttendanceW4TransactionClientV1,
   input: Readonly<{ orgId: string; userId: string; workDate: string; timezone: string; isWorkday: boolean }>,
 ): Promise<{ created: boolean }> {

--- a/packages/core-backend/src/attendance/w4c3c-ops-retirement.ts
+++ b/packages/core-backend/src/attendance/w4c3c-ops-retirement.ts
@@ -640,6 +640,56 @@ export function assertParentNotRetiredForOrdinaryWriterV1(row: {
   throw error
 }
 
+/**
+ * Gate D2 (#4556 / #4844) — the AUTHORITATIVE live-punch writer's parent retirement guard.
+ *
+ * WHY A THIRD GUARD RATHER THAN REUSING EITHER SIBLING ABOVE:
+ *  - `assertParentNotRetiredForOrdinaryWriterV1` refuses EVERY retired reason, including
+ *    `review_placeholder`. The D2 authoritative punch MUST be able to proceed over a
+ *    `review_placeholder` parent — that state is the F6 review-path steady state the D2
+ *    boundary itself installs (create-if-absent) and the one a completed outcome promotes to
+ *    `w4/active/active` via the core's own pointer UPDATE. Reusing it would break F6.
+ *  - `assertParentNotOperatorRetiredV1` refuses ONLY `operator_retirement`, letting
+ *    `import_rollback` (and any future/unlisted retired reason) fall through to the core, whose
+ *    `lockParent` SELECT is reason-blind and whose completed-path pointer UPDATE reactivates the
+ *    parent to `w4/active/active` UNCONDITIONALLY. Reusing it alone would be fail-OPEN.
+ *
+ * SHAPE — this is a DEFAULT-REFUSE structure with exactly ONE named carve-out
+ * (`review_placeholder`) and ONE distinctly-coded terminal exception (`operator_retirement`).
+ * It is deliberately NOT an enumerate-the-known-reasons-with-implicit-proceed structure:
+ * enumeration does not converge, and a future/unlisted retired reason must default to REFUSE,
+ * never fall through to the core's unconditional reactivation.
+ *
+ * Dispositions:
+ *  - not retired                  → proceed (active/normal parents supersede normally);
+ *  - retired/review_placeholder   → proceed (F6 carve-out; completed promotes, review preserves);
+ *  - retired/operator_retirement  → ATTENDANCE_RECORD_OPERATOR_RETIRED (409, terminal), delegated
+ *                                   to the existing exported sibling so the two paths can never
+ *                                   drift on the required code;
+ *  - retired/ANY OTHER reason     → ATTENDANCE_RECORD_RETIRED (409). Covers `import_rollback`
+ *                                   today AND every reason a later migration may add.
+ *
+ * The guard restores, at the boundary layer, exactly the retirement refusal that the D2 legacy-
+ * adapter split removes from the authoritative path (the legacy punch's own operator-retirement
+ * guard lives inside the `attendance_records` upsert that the split drops). The hole is created
+ * at the boundary, so it is plugged at the boundary.
+ */
+export function assertParentNotRetiredForAuthoritativePunchV1(row: {
+  visibility_state?: unknown
+  visibility_reason?: unknown
+  visibilityState?: unknown
+  visibilityReason?: unknown
+}): void {
+  const state = String(row.visibility_state ?? row.visibilityState ?? '')
+  const reason = String(row.visibility_reason ?? row.visibilityReason ?? '')
+  if (state !== 'retired') return
+  if (reason === 'review_placeholder') return
+  if (reason === 'operator_retirement') {
+    assertParentNotOperatorRetiredV1(row)
+  }
+  fail('ATTENDANCE_RECORD_RETIRED', 409)
+}
+
 export interface ToolingOnlyNonW4FixtureTeardownGuardInputV1 {
   readonly purpose: 'tooling_only_non_w4_fixture_teardown'
   readonly orgId: string

--- a/packages/core-backend/tests/integration/attendance-w4c2-authoritative-calculation-core.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-w4c2-authoritative-calculation-core.db.test.ts
@@ -335,27 +335,85 @@ describeIfDatabase('W4C-2 Gate D1 — authoritative-mode result-write CORE (real
     })
 
     it('SAME-TXN atomicity (§7.3): a failure in the calc step after the baseline write leaves NEITHER row', async () => {
-      // Active legacy parent + a completed calc whose projection carries an INVALID status ('bogus').
-      // The core does not pre-validate the status enum (unlike minutes, F2), so the baseline is
-      // appended first and the calc INSERT then trips chk_arc_projected_status (23514) IN the same
-      // txn. If the baseline were written on a separate/auto-committing connection it would survive
-      // the rollback; it must not. A negative-minute projection can no longer serve here — F2 now
-      // rejects it BEFORE the baseline append.
+      // THIRD-GENERATION FAILURE TRIGGER (Gate D2 carry-forward, #4844).
+      //
+      // Generation 1 was a negative-minute projection; F2's minutes pre-check pre-empted it
+      // (rejects BEFORE the baseline append). Generation 2 was an invalid `projected_status`
+      // ('not_a_real_status'); §5.10.1's new status pre-check — landed in this same change,
+      // symmetric with F2 — now pre-empts THAT too. Both generations died the same way: a TS
+      // pre-check moved in front of them, silently converting this leg from "same-txn rollback"
+      // into "the pre-check's product-code path".
+      //
+      // Generation 3 is chosen to be STRUCTURALLY immune to that: `context_snapshot` must be a
+      // JSON ARRAY-free object but `segment_snapshot` must satisfy
+      // `chk_arc_segment_snapshot_array` (`jsonb_typeof(segment_snapshot) = 'array'`). The core
+      // derives `segment_snapshot` from `context.segments` — a field the core NEVER validates and
+      // structurally CANNOT validate with a product code without inspecting caller-frozen context
+      // internals it deliberately carries through verbatim (`insertResolvedAuthoritativeCalculation
+      // RowV1` passes `(context as {segments?}).segments ?? []` straight to the column). Handing it
+      // a non-array `segments` therefore reaches the INSERT, and it does so AFTER the baseline
+      // append (which happens earlier, in `writeCompletedRow`).
+      //
+      // The assertion below deliberately pins the RAW constraint name, not a product code: this
+      // leg's entire purpose is to prove same-txn rollback for a failure the TS layer does NOT
+      // pre-empt. If it ever starts surfacing an `AttendanceW4AuthoritativeCalculationError`
+      // instead, the leg has silently degraded again and must migrate a fourth time — do NOT
+      // "fix" it by adding a pre-check for this field.
       const org = `org-b5-${RUN}`
       const recordId = await insertLegacyActiveParent(org)
-      const bad = completedCalculation(1)
-      ;(bad.dailyProjection as { status: string }).status = 'not_a_real_status'
+      const badContext = { timezone: TZ, workDate: WORK_DATE, segments: { notAnArray: true } }
       let caught: unknown
       try {
         await withTxn((client) =>
-          writeAuthoritativeSegmentCalculationV1(asTrx(client), segmentInput({ orgId: org, recordId, calculation: bad })),
+          writeAuthoritativeSegmentCalculationV1(
+            asTrx(client),
+            segmentInput({ orgId: org, recordId, context: badContext as never }),
+          ),
         )
       } catch (error) {
         caught = error
       }
       expect(caught).toBeTruthy()
-      expect(String((caught as { constraint?: unknown }).constraint ?? (caught as Error).message)).toContain('chk_arc_projected_status')
+      // NOT a product code — the raw CHECK is what must fire here (see the note above).
+      expect(caught).not.toBeInstanceOf(AttendanceW4AuthoritativeCalculationError)
+      expect(String((caught as { constraint?: unknown }).constraint ?? (caught as Error).message)).toContain('chk_arc_segment_snapshot_array')
       // Neither the baseline nor the failed calc survived the same-txn rollback.
+      expect(await countCalcs(recordId)).toBe(0)
+    })
+
+    it('NEGATIVE (product code, Gate D2 §5.10.1): a completed projection with an out-of-domain projected_status is refused with COMPLETED_SHAPE_INVALID BEFORE the baseline append, not a raw chk_arc_projected_status 23514', async () => {
+      // Symmetric with F2's minutes check on the adjacent field. `projected_status` previously had
+      // no TS pre-check at all, so the DB CHECK was the only guard and it surfaced as a raw 23514.
+      const org = `org-b7-${RUN}`
+      const recordId = await insertLegacyActiveParent(org)
+      const bad = completedCalculation(1)
+      ;(bad.dailyProjection as { status: string }).status = 'not_a_real_status'
+      await expectProductCode(
+        withTxn((client) =>
+          writeAuthoritativeSegmentCalculationV1(asTrx(client), segmentInput({ orgId: org, recordId, calculation: bad })),
+        ),
+        CODES.COMPLETED_SHAPE_INVALID,
+      )
+      // BEFORE the baseline append: zero rows, not an orphan baseline the caller's txn happened to
+      // roll back. A pre-check placed after the append would leave this at 1 inside the txn.
+      expect(await countCalcs(recordId)).toBe(0)
+    })
+
+    it("NEGATIVE (product code, Gate D2 §5.10.1): the pre-check's domain matches chk_arc_projected_status EXACTLY — 'off' is a legal AttendanceDailyStatusV1 but NOT a legal projected_status, and is refused with the product code", async () => {
+      // The eight-member calculator status union includes 'off'; the DB CHECK's domain (seven
+      // members) does not. A pre-check reusing the calculator constant would be WIDER than the
+      // constraint it fronts and 'off' would sail through to a raw 23514 — the exact leak this
+      // check exists to close. This leg reds if the two domains are ever re-aliased.
+      const org = `org-b8-${RUN}`
+      const recordId = await insertLegacyActiveParent(org)
+      const bad = completedCalculation(1)
+      ;(bad.dailyProjection as { status: string }).status = 'off'
+      await expectProductCode(
+        withTxn((client) =>
+          writeAuthoritativeSegmentCalculationV1(asTrx(client), segmentInput({ orgId: org, recordId, calculation: bad })),
+        ),
+        CODES.COMPLETED_SHAPE_INVALID,
+      )
       expect(await countCalcs(recordId)).toBe(0)
     })
 
@@ -646,6 +704,13 @@ describeIfDatabase('W4C-2 Gate D1 — authoritative-mode result-write CORE (real
         expect(bError).toBeInstanceOf(AttendanceW4AuthoritativeCalculationError)
         expect((bError as AttendanceW4AuthoritativeCalculationError).code).toBe(CODES.REPLAY_CONFLICT)
       } finally {
+        // Gate D2 carry-forward (#4844): an `expect(...)` between the two operations above throws
+        // straight into this `finally`, which previously returned a STILL-MID-TRANSACTION client
+        // to the shared pool — the next consumer inherits an open transaction (a known cross-test
+        // flake vector). Unconditional and idempotent: on the happy path the COMMIT already ran
+        // and this is a no-op warning.
+        await a.query('ROLLBACK').catch(() => undefined)
+        await b.query('ROLLBACK').catch(() => undefined)
         a.release()
         b.release()
       }
@@ -674,10 +739,65 @@ describeIfDatabase('W4C-2 Gate D1 — authoritative-mode result-write CORE (real
           expect(bResult.calculationId).toBe(aResult.calculationId)
         }
       } finally {
+        // Gate D2 carry-forward (#4844) — see the sibling leg above for why this is unconditional.
+        await a.query('ROLLBACK').catch(() => undefined)
+        await b.query('ROLLBACK').catch(() => undefined)
         a.release()
         b.release()
       }
     })
+
+    it('F1 (Gate D2 carry-forward): a batch of ~80 same-op-id collisions inside ONE outer transaction completes without a subtransaction-nesting cliff — the catch path RELEASES its savepoint after ROLLBACK TO', async () => {
+      // `ROLLBACK TO SAVEPOINT` undoes the subtransaction but does NOT release its slot. Without a
+      // matching `RELEASE SAVEPOINT` in the catch path, every collision leaves one savepoint open
+      // on the outer transaction's subtransaction stack; Postgres degrades sharply past ~64 nested
+      // subtransactions. This drives 80 collisions through the catch path in ONE outer transaction
+      // and asserts the batch completes with every attempt resolving to a §7.3 product outcome.
+      const org = `org-f1c-${RUN}`
+      const recordId = await insertLegacyActiveParent(org)
+      const operationId = uuid()
+      const winner = await pool.connect()
+      const batch = await pool.connect()
+      try {
+        // Commit the winning row on its own connection so every batch attempt collides on
+        // `uq_arc_operation` and enters the SAVEPOINT catch path.
+        await winner.query('BEGIN')
+        const seeded = await writeAuthoritativeSegmentCalculationV1(
+          asTrx(winner),
+          segmentInput({ orgId: org, recordId, operationId, calculation: reviewCalculation() }),
+        )
+        await winner.query('COMMIT')
+        if (seeded.kind !== 'review') throw new Error('expected review')
+
+        await batch.query('BEGIN')
+        for (let i = 0; i < 80; i += 1) {
+          // A DIFFERENT record each time keeps the pre-lookup from short-circuiting into a plain
+          // replay on the same record; the op-id is bound to `recordId`, so each attempt must
+          // resolve through the catch path to REPLAY_CONFLICT (a product code, never a raw 23505).
+          const otherRecord = await insertLegacyActiveParent(org)
+          let caught: unknown
+          try {
+            await writeAuthoritativeSegmentCalculationV1(
+              asTrx(batch),
+              segmentInput({ orgId: org, recordId: otherRecord, operationId, calculation: reviewCalculation() }),
+            )
+          } catch (error) {
+            caught = error
+          }
+          expect(caught).toBeInstanceOf(AttendanceW4AuthoritativeCalculationError)
+          expect((caught as AttendanceW4AuthoritativeCalculationError).code).toBe(CODES.REPLAY_CONFLICT)
+        }
+        // The outer transaction is still healthy after 80 catch-path passes.
+        const alive = await batch.query('SELECT 1 AS ok')
+        expect(alive.rows[0].ok).toBe(1)
+        await batch.query('COMMIT')
+      } finally {
+        await winner.query('ROLLBACK').catch(() => undefined)
+        await batch.query('ROLLBACK').catch(() => undefined)
+        winner.release()
+        batch.release()
+      }
+    }, 120000)
   })
 
   // =========================================================================

--- a/packages/core-backend/tests/integration/attendance-w4c2-authoritative-calculation-core.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-w4c2-authoritative-calculation-core.db.test.ts
@@ -747,12 +747,125 @@ describeIfDatabase('W4C-2 Gate D1 — authoritative-mode result-write CORE (real
       }
     })
 
-    it('F1 (Gate D2 carry-forward): a batch of ~80 same-op-id collisions inside ONE outer transaction completes without a subtransaction-nesting cliff — the catch path RELEASES its savepoint after ROLLBACK TO', async () => {
-      // `ROLLBACK TO SAVEPOINT` undoes the subtransaction but does NOT release its slot. Without a
-      // matching `RELEASE SAVEPOINT` in the catch path, every collision leaves one savepoint open
-      // on the outer transaction's subtransaction stack; Postgres degrades sharply past ~64 nested
-      // subtransactions. This drives 80 collisions through the catch path in ONE outer transaction
-      // and asserts the batch completes with every attempt resolving to a §7.3 product outcome.
+    it('F1 (Gate D2 carry-forward): an assertion throwing BETWEEN the two operations still returns CLEAN connections to the pool — the next consumer does not inherit an open transaction', async () => {
+      // The two race legs above `BEGIN` on raw pool clients and release them in `finally`. Before
+      // this change the only COMMIT was on the happy path, so an `expect(...)` throwing between
+      // the two operations jumped straight to `finally` and handed a MID-TRANSACTION client back
+      // to the shared pool — the next test to acquire it inherited an open transaction (a known
+      // cross-test flake vector). This leg reproduces that exact control flow deliberately and
+      // asserts the invariant the defensive ROLLBACK provides.
+      const org = `org-f1d-${RUN}`
+      const a = await pool.connect()
+      const b = await pool.connect()
+      let thrown: unknown
+      try {
+        await a.query('BEGIN')
+        await b.query('BEGIN')
+        // Dirty both transactions so an inherited one would be observable, then throw the way a
+        // failing assertion between the two operations would.
+        await a.query(`SELECT set_config('w4c2_d2.marker', $1, true)`, [org])
+        await b.query(`SELECT set_config('w4c2_d2.marker', $1, true)`, [org])
+        expect(org).toBe('deliberate-mismatch-to-jump-into-finally')
+      } catch (error) {
+        thrown = error
+      } finally {
+        await a.query('ROLLBACK').catch(() => undefined)
+        await b.query('ROLLBACK').catch(() => undefined)
+        a.release()
+        b.release()
+      }
+      expect(thrown).toBeTruthy() // the throw really happened (not a vacuous pass)
+
+      // Every connection now obtainable from the pool starts OUTSIDE a transaction. `BEGIN` on a
+      // connection that is already mid-transaction emits a "there is already a transaction in
+      // progress" WARNING rather than an error, so the discriminating probe is the transaction
+      // status itself: a clean connection's txid is not yet assigned and `set_config(...,true)`
+      // from the previous consumer must not still be visible.
+      for (let i = 0; i < 4; i += 1) {
+        const next = await pool.connect()
+        try {
+          const leaked = await next.query(`SELECT current_setting('w4c2_d2.marker', true) AS marker`)
+          expect(leaked.rows[0].marker === null || leaked.rows[0].marker === '').toBe(true)
+          const state = await next.query(`SELECT pg_current_xact_id_if_assigned() IS NULL AS idle`)
+          expect(state.rows[0].idle).toBe(true)
+        } finally {
+          next.release()
+        }
+      }
+    }, 60000)
+
+    it('F1 (Gate D2 carry-forward): the catch path RELEASES its savepoint after ROLLBACK TO — every savepoint the core acquires is balanced by a release on BOTH the success and the conflict path', async () => {
+      // WHAT THIS MEASURES, AND WHY IT IS A STATEMENT-STREAM ASSERTION RATHER THAN AN OUTCOME ONE
+      // (stated plainly rather than dressed up as an outcome leg): `ROLLBACK TO SAVEPOINT` undoes
+      // the subtransaction but does NOT release its slot, so without a matching `RELEASE SAVEPOINT`
+      // the catch path leaks one subtransaction per collision. The consequence — Postgres's
+      // per-backend 64-entry subxid cache overflowing into the SLRU, degrading OTHER backends'
+      // visibility checks — is a PERFORMANCE effect, not an error: measured directly on this
+      // schema, 200 un-released savepoints in one transaction complete fine and leave the
+      // connection fully usable. So a "batch fails past ~64" leg would be vacuous, and the
+      // subxact counters that would expose it (`pg_stat_get_backend_subxact`) do not exist on the
+      // Postgres 14 this project's CI pins. The discriminating instrument available here is the
+      // SQL the core actually issues, recorded at the client seam.
+      // The SAVEPOINT is only opened when the pre-lookup MISSES — i.e. the genuine 2-connection
+      // race, not a sequential retry (a committed winner is caught by `retryReplayLookup` before
+      // any savepoint exists). This reuses the same constructed interleave as the two race legs
+      // above and records the SQL the loser's client issues.
+      const org = `org-f1c-${RUN}`
+      const recordA = await insertLegacyActiveParent(org)
+      const recordB = await insertLegacyActiveParent(org)
+      const operationId = uuid()
+      const a = await pool.connect()
+      const b = await pool.connect()
+      const statements: string[] = []
+      const recording = {
+        async query(sqlText: string, params?: unknown[]) {
+          if (typeof sqlText === 'string') statements.push(sqlText.trim())
+          return b.query(sqlText, (params ?? []) as unknown[])
+        },
+      } as unknown as AttendanceW4TransactionClientV1
+      try {
+        await a.query('BEGIN')
+        const aResult = await writeAuthoritativeSegmentCalculationV1(
+          asTrx(a),
+          segmentInput({ orgId: org, recordId: recordA, operationId }),
+        )
+        expect(aResult.kind).toBe('completed')
+        await b.query('BEGIN')
+        const bPromise = writeAuthoritativeSegmentCalculationV1(
+          recording,
+          segmentInput({ orgId: org, recordId: recordB, operationId }),
+        )
+        const bMarker = await settled(bPromise)
+        await new Promise((resolve) => setTimeout(resolve, 500))
+        expect(bMarker.done).toBe(false) // B is blocked on A's uncommitted unique insert
+        await a.query('COMMIT')
+        let bError: unknown
+        try {
+          await bPromise
+        } catch (error) {
+          bError = error
+        }
+        // The conflict path really was taken (not a plain replay that never opens a savepoint).
+        expect(bError).toBeInstanceOf(AttendanceW4AuthoritativeCalculationError)
+        expect((bError as AttendanceW4AuthoritativeCalculationError).code).toBe(CODES.REPLAY_CONFLICT)
+        const opened = statements.filter((s) => /^SAVEPOINT\s/i.test(s)).length
+        const rolledBack = statements.filter((s) => /^ROLLBACK TO SAVEPOINT\s/i.test(s)).length
+        const released = statements.filter((s) => /^RELEASE SAVEPOINT\s/i.test(s)).length
+        expect(opened).toBe(1)
+        expect(rolledBack).toBe(1) // the catch path, not the success path
+        expect(released).toBe(opened) // BALANCED — this is the assertion the fix makes true
+      } finally {
+        await a.query('ROLLBACK').catch(() => undefined)
+        await b.query('ROLLBACK').catch(() => undefined)
+        a.release()
+        b.release()
+      }
+    }, 60000)
+
+    it('F1 (Gate D2 carry-forward): a batch of ~80 same-op-id collisions inside ONE outer transaction all resolve to §7.3 product codes and leave the outer transaction healthy', async () => {
+      // The soak sibling of the statement-balance leg above. It does NOT claim to red on the
+      // missing RELEASE (see that leg for why the cliff is not observable here); it is the
+      // regression leg for the catch path itself under repetition.
       const org = `org-f1c-${RUN}`
       const recordId = await insertLegacyActiveParent(org)
       const operationId = uuid()

--- a/packages/core-backend/tests/integration/attendance-w4c2-d2-live-punch-authoritative.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-w4c2-d2-live-punch-authoritative.db.test.ts
@@ -38,6 +38,7 @@ import {
   type AttendanceW4LiveScheduledBoundaryV1,
 } from '../../src/attendance/w4c2-live-scheduled-boundary'
 import { computeAttendanceImportRollbackPreimageFingerprintV1 } from '../../src/attendance/w4c3a-import-rollback'
+import { loadActiveCurrentAttendanceRecordForDecisionTraceV1 } from '../../src/attendance/w4c3c-active-current'
 import {
   projectedDailyFingerprintV1,
   writeAuthoritativeReversalV1,
@@ -589,26 +590,49 @@ describeIfDatabase('W4C-2 Gate D2 — authoritative live_punch writer (real DB)'
   // Read-side invisibility (leg 8) and VERSION_CONFLICT (leg 9).
   // =========================================================================
 
-  it('leg 8: a review_placeholder parent is invisible to an active-only current-record read while the immutable review calc row remains readable in history', async () => {
+  it('leg 8: a review_placeholder parent is invisible through the CANONICAL active-current helper (the singular host-port read every ordinary surface goes through) while the immutable review calc row remains readable in history', async () => {
     const seed = await seedAuthoritativeOrg('g8')
     const { boundary } = makeBoundary()
-    expect((await boundary.executeLivePunch(await buildPunchInput(seed))).kind).toBe('w4')
-    const active = await pool.query(
-      `SELECT id FROM attendance_records WHERE user_id = $1 AND visibility_state = 'active'`,
-      [seed.userId],
-    )
-    expect(active.rows.length).toBe(0)
+    const input = await buildPunchInput(seed)
+    expect((await boundary.executeLivePunch(input)).kind).toBe('w4')
+
+    // Driven through `w4c3c-active-current`'s own exported helper, NOT a hand-written
+    // `visibility_state = 'active'` filter: asserting that a filter this test wrote filters is a
+    // tautology. This is the P20 singular helper the plugin's ordinary read surfaces resolve
+    // through, so a miss here is a miss for those surfaces.
+    const client = await pool.connect()
+    try {
+      const hidden = await loadActiveCurrentAttendanceRecordForDecisionTraceV1(
+        async (sqlText: string, params?: readonly unknown[]) =>
+          client.query(sqlText, (params ?? []) as unknown[]),
+        { orgId: seed.orgId, userId: seed.userId, workDate: input.workDate },
+      )
+      expect(hidden).toBeNull()
+      // POSITIVE CONTROL — the same helper DOES return a promoted (completed) parent, so the null
+      // above is the placeholder being hidden, not the helper being broken or mis-keyed.
+      const promotedSeed = await seedAuthoritativeOrg('g8-control', { withShift: true })
+      const promotedInput = await buildPunchInput(promotedSeed)
+      const { boundary: control } = makeBoundary()
+      expect((await control.executeLivePunch(promotedInput)).kind).toBe('w4')
+      const visible = await loadActiveCurrentAttendanceRecordForDecisionTraceV1(
+        async (sqlText: string, params?: readonly unknown[]) =>
+          client.query(sqlText, (params ?? []) as unknown[]),
+        { orgId: promotedSeed.orgId, userId: promotedSeed.userId, workDate: promotedInput.workDate },
+      )
+      expect(visible).not.toBeNull()
+    } finally {
+      client.release()
+    }
     expect((await calcRows(seed.userId)).length).toBe(1)
   })
 
-  it('leg 9: a parent pointer moved between the boundary read and the core call is refused with VERSION_CONFLICT (409) as a product code, never a raw SQLSTATE', async () => {
-    // Drive the seam directly: a first completed punch moves the pointer; a SECOND boundary call
-    // whose locked read is forced stale by a concurrent committed pointer move must be refused.
-    // Constructed by racing a raw pointer UPDATE in between using a separate connection is not
-    // possible under the boundary's own FOR UPDATE; instead we prove the guard at the core's own
-    // seam by pointing an authoritative write at a parent whose pointer moved after the read —
-    // reproduced here by a second punch on a record whose pointer was rewritten by a first punch
-    // while the operation id differs, and asserting the guard's own product code surfaces.
+  it('leg 9: `expectedCurrentCalculationId` is sourced from the LOCKED read, so a second authoritative punch supersedes the moved pointer instead of failing VERSION_CONFLICT', async () => {
+    // NOT a VERSION_CONFLICT leg: the boundary holds the parent `FOR UPDATE` from its own read
+    // through commit, so no writer can move the pointer in between and the 409 is unreachable
+    // from here by construction (the core's own stale-expectation refusal is proven at the core
+    // seam, in the D1 suite). What IS provable here — and is the §5.4 obligation — is that the
+    // expectation comes from that locked read rather than being assumed `null`: hardcoding it to
+    // `null` makes the SECOND punch below 409 instead of superseding.
     const seed = await seedAuthoritativeOrg('g9', { withShift: true })
     const { boundary } = makeBoundary()
     expect((await boundary.executeLivePunch(await buildPunchInput(seed))).kind).toBe('w4')
@@ -688,6 +712,21 @@ describeIfDatabase('W4C-2 Gate D2 — authoritative live_punch writer (real DB)'
       expect(Object.prototype.hasOwnProperty.call(record, legacyOnlyKey)).toBe(false)
     }
     expect(record.meta === null || typeof record.meta === 'object').toBe(true)
+
+    // SECOND HALF OF THE SAME OWNER QUESTION — `workDateResolution` is ALSO synthesized on this
+    // path (the legacy adapter returns the resolver's own `punchWorkDateResolution` verbatim; the
+    // authoritative branch has no such object and builds a closed projection instead). That is a
+    // second, independent client-contract change, so it is pinned here rather than left to leg
+    // 10's truthiness check.
+    const resolution = ((result as { response: Record<string, unknown> }).response
+      .workDateResolution) as Record<string, unknown>
+    expect(Object.keys(resolution).sort()).toEqual([
+      'attributionPosture',
+      'kind',
+      'reasonCode',
+      'shiftId',
+      'workDate',
+    ])
   })
 
   it('leg 11b [the real P-A pin]: an AUTHORITATIVE punch invokes the injected applyLivePunchLegacy ZERO times — negative control: a SHADOW punch invokes it exactly once', async () => {

--- a/packages/core-backend/tests/integration/attendance-w4c2-d2-live-punch-authoritative.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-w4c2-d2-live-punch-authoritative.db.test.ts
@@ -1,0 +1,928 @@
+/**
+ * W4C-2 Gate D2 (#4556 / #4844) — real-Postgres proof of the AUTHORITATIVE `live_punch` writer in
+ * `src/attendance/w4c2-live-scheduled-boundary.ts`.
+ *
+ * WHAT THIS DRIVES: the production boundary factory
+ * (`createAttendanceLiveScheduledBoundaryV1`) over a real pool, wired to the REAL plugin adapters
+ * exported at `plugin-attendance/index.cjs :: __attendanceW4c2LivePunchAdaptersForTests` — the same
+ * functions `activate` injects. Only the SCHEDULED adapters (never exercised here) are stubs. The
+ * adapters are wrapped in call-count spies, which is what makes the P-A control-flow pin
+ * (zero `applyLivePunchLegacy` invocations on the authoritative path) an observation rather than
+ * an argument.
+ *
+ * WHY IT IS NOT PRODUCTION-REACHABLE ANYWAY: `effectiveState === 'authoritative'` additionally
+ * requires an EXACT-org entry in `ATTENDANCE_SHIFT_SEGMENT_CALCULATION_ENABLED` (wildcard never
+ * counts). This suite sets that env for its own throwaway org ids; production leaves it unset, so
+ * every production org collapses to `legacy` and this branch is unreachable irrespective of DB
+ * contents.
+ *
+ * Shared-DB discipline: every fixture identity is a run-namespaced UUID; W4 calculation/operation/
+ * outbox rows are append-only by design and are left behind.
+ */
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import crypto from 'node:crypto'
+import net from 'net'
+import * as path from 'path'
+import { createRequire } from 'module'
+import { Kysely, PostgresDialect } from 'kysely'
+import { Pool, type PoolClient } from 'pg'
+import type { MetaSheetServer } from '../../src/index'
+import { up } from '../../src/db/migrations/zzzz20260725120000_w4c0_attendance_segment_calculation_durable_storage'
+import type { AttendanceW4TransactionClientV1 } from '../../src/attendance/w4c0-identity'
+import {
+  createAttendanceLiveScheduledBoundaryV1,
+  computeAttendanceOuterSourceDefinitionFingerprintV1,
+  type AttendanceLivePunchBoundaryInputV1,
+  type AttendancePluginShapedTrxV1,
+  type AttendanceW4LiveScheduledBoundaryV1,
+} from '../../src/attendance/w4c2-live-scheduled-boundary'
+import { computeAttendanceImportRollbackPreimageFingerprintV1 } from '../../src/attendance/w4c3a-import-rollback'
+import {
+  projectedDailyFingerprintV1,
+  writeAuthoritativeReversalV1,
+} from '../../src/attendance/w4c2-authoritative-calculation-core'
+import { applyAttendanceInOutMergePolicyPureV1 } from '../../src/attendance/w4c1-merge-policy'
+
+const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
+const describeIfDatabase = dbUrl ? describe : describe.skip
+
+const RUN = crypto.randomUUID().slice(0, 8)
+const TZ = 'Asia/Shanghai'
+const WORK_DATE = '2026-05-04'
+const requireCjs = createRequire(import.meta.url)
+
+function uuid(): string {
+  return crypto.randomUUID()
+}
+
+type LivePunchAdapters = {
+  insertLivePunchEventV1: (trx: AttendancePluginShapedTrxV1, args: unknown) => Promise<Record<string, unknown>>
+  applyLivePunchProjectionLegacyV1: (
+    trx: AttendancePluginShapedTrxV1,
+    args: unknown,
+    mergePolicyPure: unknown,
+  ) => Promise<{ event: Record<string, unknown>; record: Record<string, unknown>; workDateResolution: unknown }>
+  resolveW4LiveCandidateInTransactionV1: (trx: AttendancePluginShapedTrxV1, args: unknown) => Promise<any>
+  buildW4ShadowFrozenContextV1: (trx: AttendancePluginShapedTrxV1, args: unknown) => Promise<any>
+}
+
+describeIfDatabase('W4C-2 Gate D2 — authoritative live_punch writer (real DB)', () => {
+  const pool = new Pool({ connectionString: dbUrl })
+  let migrationDb: Kysely<unknown> | undefined
+  let adapters: LivePunchAdapters
+  let priorAllowlistEnv: string | undefined
+  let server: MetaSheetServer | undefined
+  const allowlistedOrgs: string[] = []
+
+  /** Registers an org in the exact-org env allowlist BEFORE any boundary call for it. */
+  function allow(orgId: string): string {
+    allowlistedOrgs.push(orgId)
+    process.env.ATTENDANCE_SHIFT_SEGMENT_CALCULATION_ENABLED = allowlistedOrgs.join(',')
+    return orgId
+  }
+
+  beforeAll(async () => {
+    migrationDb = new Kysely<unknown>({
+      dialect: new PostgresDialect({ pool: new Pool({ connectionString: dbUrl }) }),
+    })
+    await up(migrationDb)
+    priorAllowlistEnv = process.env.ATTENDANCE_SHIFT_SEGMENT_CALCULATION_ENABLED
+
+    // The plugin's in-transaction W2 resolver reaches the canonical active-current helper port,
+    // which only `activate` installs — so a real server boot is required to drive the REAL
+    // adapters rather than re-implementing them. The boundary instances under test are still
+    // constructed HERE (with spies), not taken from activate.
+    const canListen: boolean = await new Promise((resolve) => {
+      const s = net.createServer()
+      s.once('error', () => resolve(false))
+      s.listen(0, '127.0.0.1', () => s.close(() => resolve(true)))
+    })
+    if (!canListen || !dbUrl) throw new Error('W4C-2 Gate D2 suite needs a loopback port + DATABASE_URL')
+    process.env.DATABASE_URL = dbUrl
+    process.env.RBAC_BYPASS = 'true'
+    process.env.SKIP_PLUGINS = 'false'
+    const repoRoot = path.join(__dirname, '../../../../')
+    const { MetaSheetServer } = await import('../../src/index')
+    server = new MetaSheetServer({
+      port: 0,
+      host: '127.0.0.1',
+      pluginDirs: [path.join(repoRoot, 'plugins', 'plugin-attendance')],
+    })
+    await server.start()
+
+    const plugin = requireCjs('../../../../plugins/plugin-attendance/index.cjs') as {
+      __attendanceW4c2LivePunchAdaptersForTests: LivePunchAdapters
+    }
+    adapters = plugin.__attendanceW4c2LivePunchAdaptersForTests
+  }, 180000)
+
+  afterAll(async () => {
+    if (priorAllowlistEnv === undefined) delete process.env.ATTENDANCE_SHIFT_SEGMENT_CALCULATION_ENABLED
+    else process.env.ATTENDANCE_SHIFT_SEGMENT_CALCULATION_ENABLED = priorAllowlistEnv
+    await server?.stop?.()
+    await migrationDb?.destroy()
+    await pool.end()
+  })
+
+  // ---- boundary driver ----------------------------------------------------
+
+  interface Spies {
+    applyLivePunchLegacy: number
+    insertLivePunchEvent: number
+  }
+
+  function makeBoundary(): { boundary: AttendanceW4LiveScheduledBoundaryV1; spies: Spies } {
+    const spies: Spies = { applyLivePunchLegacy: 0, insertLivePunchEvent: 0 }
+    const boundary = createAttendanceLiveScheduledBoundaryV1({
+      acquireConnection: async () => {
+        const client = await pool.connect()
+        return { client: client as unknown as AttendanceW4TransactionClientV1, release: () => client.release() }
+      },
+      legacyAdapters: {
+        applyLivePunchLegacy: (trx, args) => {
+          spies.applyLivePunchLegacy += 1
+          return adapters.applyLivePunchProjectionLegacyV1(trx, args, (input: unknown) =>
+            applyAttendanceInOutMergePolicyPureV1(
+              input as Parameters<typeof applyAttendanceInOutMergePolicyPureV1>[0],
+            ),
+          )
+        },
+        insertLivePunchEvent: (trx, args) => {
+          spies.insertLivePunchEvent += 1
+          return adapters.insertLivePunchEventV1(trx, args)
+        },
+        applyScheduledAbsenceLegacy: async () => [],
+        resolveLiveCandidate: (trx, args) => adapters.resolveW4LiveCandidateInTransactionV1(trx, args),
+        resolveScheduledCandidate: async () => ({ kind: 'unresolved' as const }),
+        buildShadowFrozenContext: (trx, args) => adapters.buildW4ShadowFrozenContextV1(trx, args),
+      },
+    })
+    return { boundary, spies }
+  }
+
+  // ---- fixtures -----------------------------------------------------------
+
+  async function insertActiveUser(userId: string, orgId: string): Promise<void> {
+    await pool.query(
+      `INSERT INTO users (id, email, username, name, password_hash, role, permissions, is_active, is_admin, created_at, updated_at)
+       VALUES ($1, $2, $1, 'W4C-2 d2 fixture', 'x', 'user', '[]'::jsonb, true, false, now(), now())
+       ON CONFLICT (id) DO NOTHING`,
+      [userId, `${userId}@w4c2-d2.test`],
+    )
+    await pool.query(
+      `INSERT INTO user_orgs (user_id, org_id, is_active) VALUES ($1, $2, true) ON CONFLICT DO NOTHING`,
+      [userId, orgId],
+    )
+  }
+
+  /** Walks the rollout row's legal edges to `authoritative` (the tool refuses this promotion). */
+  async function walkRolloutToAuthoritative(orgId: string): Promise<void> {
+    await pool.query(
+      `INSERT INTO attendance_calculation_rollout_state (org_id, state, engine_version, reason_code, actor_id, version, prior_state)
+       VALUES ($1, 'legacy', 'w4c2-d2', 'TEST_FIXTURE', 'w4c2-d2-actor', 1, NULL)`,
+      [orgId],
+    )
+    for (const [state, prior, version] of [
+      ['shadow', 'legacy', 2],
+      ['eligible', 'shadow', 3],
+      ['authoritative', 'eligible', 4],
+    ] as const) {
+      await pool.query(
+        `UPDATE attendance_calculation_rollout_state SET state = $2, prior_state = $3, version = $4 WHERE org_id = $1`,
+        [orgId, state, prior, version],
+      )
+    }
+  }
+
+  async function insertRolloutState(orgId: string, state: 'shadow'): Promise<void> {
+    await pool.query(
+      `INSERT INTO attendance_calculation_rollout_state (org_id, state, engine_version, reason_code, actor_id, version, prior_state)
+       VALUES ($1, $2, 'w4c2-d2', 'TEST_FIXTURE', 'w4c2-d2-actor', 1, NULL)`,
+      [orgId, state],
+    )
+  }
+
+  async function insertShiftAndAssignment(orgId: string, userId: string): Promise<string> {
+    const shiftId = uuid()
+    await pool.query(
+      `INSERT INTO attendance_shifts (id, org_id, name, work_start_time, work_end_time, timezone)
+       VALUES ($1, $2, $3, '09:00', '18:00', $4)`,
+      [shiftId, orgId, `w4c2-d2-${RUN}`, TZ],
+    )
+    await pool.query(
+      `INSERT INTO attendance_shift_assignments
+         (id, org_id, user_id, shift_id, slot_index, start_date, end_date, is_active, publish_status, assignment_kind)
+       VALUES ($1, $2, $3, $4, 0, '2026-05-01', NULL, true, 'published', 'regular')`,
+      [uuid(), orgId, userId, shiftId],
+    )
+    return shiftId
+  }
+
+  /**
+   * An org + user seeded for authoritative punches. `withShift` decides whether the freeze step
+   * can resolve a `resolved_v2` attribution at all (no shift => unsupported => review_required).
+   */
+  async function seedAuthoritativeOrg(
+    label: string,
+    options: { withShift?: boolean } = {},
+  ): Promise<{ orgId: string; userId: string; shiftId: string | null }> {
+    const orgId = allow(uuid())
+    const userId = uuid()
+    await insertActiveUser(userId, orgId)
+    await walkRolloutToAuthoritative(orgId)
+    const shiftId = options.withShift === true ? await insertShiftAndAssignment(orgId, userId) : null
+    void label
+    return { orgId, userId, shiftId }
+  }
+
+  /**
+   * Builds the boundary input the ROUTE would build, including the OUTER (pre-transaction)
+   * source-definition fingerprint. Computing it the way the route does — a non-transactional
+   * resolve + context build, then `computeAttendanceOuterSourceDefinitionFingerprintV1` — is what
+   * keeps an ordinary punch out of the identity-drift branch; passing `null` blindly would make
+   * every resolved punch false-drift into `review_required`.
+   */
+  async function buildPunchInput(
+    seed: { orgId: string; userId: string },
+    overrides: Partial<AttendanceLivePunchBoundaryInputV1> = {},
+  ): Promise<AttendanceLivePunchBoundaryInputV1> {
+    const occurredAtResolved = (overrides.occurredAtResolved as string) ?? '2026-05-04T01:05:00.000Z'
+    const client = await pool.connect()
+    let resolution: any
+    let context: any = null
+    try {
+      const shaped: AttendancePluginShapedTrxV1 = {
+        __w4CanonicalTrx: true,
+        async query(sqlText: string, params?: unknown[]) {
+          const res = await client.query(sqlText, params ?? [])
+          return res.rows
+        },
+      }
+      resolution = await adapters.resolveW4LiveCandidateInTransactionV1(shaped, {
+        orgId: seed.orgId,
+        userId: seed.userId,
+        occurredAt: occurredAtResolved,
+        timezone: TZ,
+      })
+      if (resolution?.kind === 'resolved' && resolution?.shiftId) {
+        context = await adapters.buildW4ShadowFrozenContextV1(shaped, {
+          orgId: seed.orgId,
+          userId: seed.userId,
+          workDate: String(resolution.workDate),
+          shiftId: String(resolution.shiftId),
+          timezone: resolution.fullWinner?.timezone ?? TZ,
+          isWorkday: true,
+          holidayKind: null,
+        })
+      }
+    } finally {
+      client.release()
+    }
+    const outerSourceDefinitionFingerprint = computeAttendanceOuterSourceDefinitionFingerprintV1({
+      orgId: seed.orgId,
+      userId: seed.userId,
+      source: 'live_resolution',
+      nowIso: new Date().toISOString(),
+      resolution,
+      context,
+    })
+    return {
+      orgId: seed.orgId,
+      userId: seed.userId,
+      operationId: uuid(),
+      eventType: 'check_in',
+      occurredAtRaw: null,
+      occurredAtResolved,
+      timezone: resolution?.fullWinner?.timezone ?? TZ,
+      requestTimezone: TZ,
+      source: 'mobile',
+      location: null,
+      meta: null,
+      photoFileRef: null,
+      workDate: resolution?.kind === 'resolved' ? String(resolution.workDate) : WORK_DATE,
+      shiftId: resolution?.kind === 'resolved' ? String(resolution.shiftId) : null,
+      outerSourceDefinitionFingerprint,
+      isWorkday: true,
+      holidayKind: null,
+      ...overrides,
+    }
+  }
+
+  // ---- readers ------------------------------------------------------------
+
+  async function parentRow(userId: string): Promise<Record<string, unknown> | undefined> {
+    const { rows } = await pool.query(
+      `SELECT id::text AS id, status, first_in_at, last_out_at, work_minutes, late_minutes,
+              early_leave_minutes, projection_owner, current_calculation_id::text AS current_calculation_id,
+              visibility_state, visibility_reason
+         FROM attendance_records WHERE user_id = $1`,
+      [userId],
+    )
+    return rows[0]
+  }
+
+  async function calcRows(userId: string): Promise<Array<Record<string, unknown>>> {
+    const { rows } = await pool.query(
+      `SELECT c.id::text AS id, c.version, c.calculation_kind, c.mode, c.entrypoint, c.outcome,
+              c.outcome_reason_code, c.projection_effect, c.expected_segment_count,
+              c.projected_status, c.projected_daily_fingerprint,
+              c.semantic_input_fingerprint, c.input_provenance,
+              c.supersedes_calculation_id::text AS supersedes_calculation_id
+         FROM attendance_record_calculations c
+         JOIN attendance_records r ON r.id = c.attendance_record_id
+        WHERE r.user_id = $1
+        ORDER BY c.version`,
+      [userId],
+    )
+    return rows
+  }
+
+  async function eventCount(userId: string): Promise<number> {
+    return Number((await pool.query('SELECT count(*)::int AS n FROM attendance_events WHERE user_id = $1', [userId])).rows[0].n)
+  }
+
+  async function outboxRows(orgId: string): Promise<Array<Record<string, unknown>>> {
+    return (await pool.query(
+      `SELECT id::text AS id, event_kind FROM attendance_result_event_outbox WHERE org_id = $1`,
+      [orgId],
+    )).rows
+  }
+
+  async function operationRows(orgId: string): Promise<Array<Record<string, unknown>>> {
+    return (await pool.query(
+      `SELECT operation_id::text AS operation_id, state, resolved_record_id::text AS resolved_record_id,
+              resolved_calculation_id::text AS resolved_calculation_id, response_snapshot,
+              result_semantic_fingerprint
+         FROM attendance_result_operations WHERE org_id = $1 ORDER BY created_at`,
+      [orgId],
+    )).rows
+  }
+
+  async function segmentCount(calculationId: string): Promise<number> {
+    return Number((await pool.query(
+      'SELECT count(*)::int AS n FROM attendance_record_segments WHERE calculation_id = $1::uuid',
+      [calculationId],
+    )).rows[0].n)
+  }
+
+  /** Inserts a legacy-ACTIVE parent for the day (the compat-fingerprint / baseline case). */
+  async function insertLegacyActiveParent(orgId: string, userId: string, workDate: string): Promise<string> {
+    const { rows } = await pool.query(
+      `INSERT INTO attendance_records
+         (user_id, work_date, org_id, timezone, status, first_in_at, last_out_at,
+          work_minutes, late_minutes, early_leave_minutes)
+       VALUES ($1, $2::date, $3, $4, 'normal', $5, $6, 420, 0, 0)
+       RETURNING id::text AS id`,
+      [userId, workDate, orgId, TZ, '2026-05-04T01:30:00.000Z', '2026-05-04T08:30:00.000Z'],
+    )
+    return String(rows[0].id)
+  }
+
+  // =========================================================================
+  // GATING LEG (leg 2) — build-ready precondition.
+  // =========================================================================
+
+  it('leg 2 [GATING]: fresh COMPLETED with an absent parent creates the placeholder then promotes it to w4/active/active — and NO legacy_baseline row exists', async () => {
+    const seed = await seedAuthoritativeOrg('g2', { withShift: true })
+    const { boundary, spies } = makeBoundary()
+    const input = await buildPunchInput(seed)
+    const result = await boundary.executeLivePunch(input)
+
+    expect(result.kind).toBe('w4')
+    const calcs = await calcRows(seed.userId)
+    // Exactly one row, and it is the authoritative calculation — never a baseline. A baseline
+    // here would mean the placeholder shipped `active` and tripped the core's baseline predicate.
+    expect(calcs.length).toBe(1)
+    expect(calcs[0].calculation_kind).toBe('calculation')
+    expect(calcs.some((row) => row.calculation_kind === 'legacy_baseline')).toBe(false)
+    expect(calcs[0].mode).toBe('authoritative')
+    expect(calcs[0].outcome).toBe('completed')
+    expect(calcs[0].projection_effect).toBe('set_active')
+    expect(calcs[0].supersedes_calculation_id).toBeNull()
+
+    // Placeholder created, then promoted by the core's own tail pointer UPDATE — one atomic step.
+    const parent = await parentRow(seed.userId)
+    expect(parent?.projection_owner).toBe('w4')
+    expect(parent?.visibility_state).toBe('active')
+    expect(parent?.visibility_reason).toBe('active')
+    expect(parent?.current_calculation_id).toBe(calcs[0].id)
+
+    // P-A: the shadow legacy adapter was never invoked; the split seam was, exactly once.
+    expect(spies.applyLivePunchLegacy).toBe(0)
+    expect(spies.insertLivePunchEvent).toBe(1)
+  })
+
+  // =========================================================================
+  // F6 review path, absent parent (leg 1) + outbox (§6.2 pinned as-is).
+  // =========================================================================
+
+  it('leg 1: fresh REVIEW with an absent parent leaves the placeholder retired/review_placeholder with a NULL pointer, zero children, and emits exactly one attendance.punched row', async () => {
+    // No shift => the freeze step cannot build a resolved_v2 attribution => review_required.
+    const seed = await seedAuthoritativeOrg('g1')
+    const { boundary, spies } = makeBoundary()
+    const result = await boundary.executeLivePunch(await buildPunchInput(seed))
+    expect(result.kind).toBe('w4')
+
+    const calcs = await calcRows(seed.userId)
+    expect(calcs.length).toBe(1)
+    expect(calcs[0].outcome).toBe('review_required')
+    expect(calcs[0].projection_effect).toBe('none')
+    expect(calcs[0].expected_segment_count).toBe(0)
+    expect(calcs[0].projected_status).toBeNull()
+    expect(calcs[0].projected_daily_fingerprint).toBeNull()
+    expect(calcs[0].supersedes_calculation_id).toBeNull()
+    expect(await segmentCount(String(calcs[0].id))).toBe(0)
+
+    const parent = await parentRow(seed.userId)
+    expect(parent?.projection_owner).toBe('legacy_untracked')
+    expect(parent?.current_calculation_id).toBeNull()
+    expect(parent?.visibility_state).toBe('retired')
+    expect(parent?.visibility_reason).toBe('review_placeholder')
+
+    // §6.2 pinned AS-IS: the enqueue is unconditional, exactly as on the shadow path today.
+    const outbox = await outboxRows(seed.orgId)
+    expect(outbox.length).toBe(1)
+    expect(outbox[0].event_kind).toBe('attendance.punched')
+    expect(spies.applyLivePunchLegacy).toBe(0)
+  })
+
+  // =========================================================================
+  // Legacy-active parent: baseline + canonical compat fingerprint (leg 3) and review (leg 4).
+  // =========================================================================
+
+  it('leg 3: COMPLETED over a legacy-ACTIVE parent appends exactly one legacy_baseline whose stored projected_daily_fingerprint EQUALS a canonical recompute (byte identity)', async () => {
+    const seed = await seedAuthoritativeOrg('g3', { withShift: true })
+    const input = await buildPunchInput(seed)
+    const recordId = await insertLegacyActiveParent(seed.orgId, seed.userId, input.workDate)
+    // The exact pre-authoritative parent state, read back the way the boundary reads it.
+    const before = (await pool.query(
+      `SELECT status, first_in_at, last_out_at, work_minutes, late_minutes, early_leave_minutes
+         FROM attendance_records WHERE id = $1::uuid`,
+      [recordId],
+    )).rows[0]
+
+    const { boundary } = makeBoundary()
+    const result = await boundary.executeLivePunch(input)
+    expect(result.kind).toBe('w4')
+
+    const calcs = await calcRows(seed.userId)
+    const baselines = calcs.filter((row) => row.calculation_kind === 'legacy_baseline')
+    const calculations = calcs.filter((row) => row.calculation_kind === 'calculation')
+    expect(baselines.length).toBe(1)
+    expect(calculations.length).toBe(1)
+    expect(calculations[0].supersedes_calculation_id).toBe(baselines[0].id)
+    expect(Number(baselines[0].version)).toBeLessThan(Number(calculations[0].version))
+
+    // BYTE IDENTITY: the stored fingerprint is what the CANONICAL producer yields over that exact
+    // pre-authoritative state — not a hand-rolled fifth copy, and not the ops-retirement digest.
+    const recomputed = computeAttendanceImportRollbackPreimageFingerprintV1({
+      projection: {
+        status: String(before.status),
+        firstInAt: before.first_in_at === null ? null : new Date(before.first_in_at as string | Date).toISOString(),
+        lastOutAt: before.last_out_at === null ? null : new Date(before.last_out_at as string | Date).toISOString(),
+        workMinutes: Number(before.work_minutes),
+        lateMinutes: Number(before.late_minutes),
+        earlyLeaveMinutes: Number(before.early_leave_minutes),
+      },
+      projectionOwner: 'legacy_untracked',
+      currentCalculationId: null,
+      visibilityState: 'active',
+      visibilityReason: 'active',
+    })
+    expect(baselines[0].projected_daily_fingerprint).toBe(recomputed)
+
+    const parent = await parentRow(seed.userId)
+    expect(parent?.projection_owner).toBe('w4')
+    expect(parent?.visibility_state).toBe('active')
+    expect(parent?.current_calculation_id).toBe(calculations[0].id)
+  })
+
+  it('leg 4: REVIEW over a legacy-ACTIVE parent leaves owner/pointer/visibility and all six legacy daily columns BIT-IDENTICAL, while the review calc row exists in history', async () => {
+    // No shift => review outcome, but a real legacy-active parent is present.
+    const seed = await seedAuthoritativeOrg('g4')
+    const input = await buildPunchInput(seed)
+    const recordId = await insertLegacyActiveParent(seed.orgId, seed.userId, input.workDate)
+    const snapshot = async () => (await pool.query(
+      `SELECT status, first_in_at, last_out_at, work_minutes, late_minutes, early_leave_minutes,
+              projection_owner, current_calculation_id, visibility_state, visibility_reason
+         FROM attendance_records WHERE id = $1::uuid`,
+      [recordId],
+    )).rows[0]
+    const before = await snapshot()
+
+    const { boundary } = makeBoundary()
+    const result = await boundary.executeLivePunch(input)
+    expect(result.kind).toBe('w4')
+    expect(await snapshot()).toEqual(before)
+
+    const calcs = await calcRows(seed.userId)
+    expect(calcs.length).toBe(1)
+    expect(calcs[0].outcome).toBe('review_required')
+    expect(calcs[0].projection_effect).toBe('none')
+  })
+
+  // =========================================================================
+  // identityDrift override (leg 5).
+  // =========================================================================
+
+  it('leg 5: identity drift (a mismatched OUTER source-definition fingerprint) forces REVIEW with no pointer move — negative control: the identical punch WITHOUT drift completes and moves the pointer', async () => {
+    const drifted = await seedAuthoritativeOrg('g5a', { withShift: true })
+    const driftInput = await buildPunchInput(drifted, {
+      outerSourceDefinitionFingerprint: 'f'.repeat(64),
+    })
+    const { boundary: b1 } = makeBoundary()
+    expect((await b1.executeLivePunch(driftInput)).kind).toBe('w4')
+    const driftCalcs = await calcRows(drifted.userId)
+    expect(driftCalcs.length).toBe(1)
+    expect(driftCalcs[0].outcome).toBe('review_required')
+    expect(driftCalcs[0].outcome_reason_code).toBe('context_mismatch')
+    expect((await parentRow(drifted.userId))?.current_calculation_id).toBeNull()
+
+    // NEGATIVE CONTROL — same fixture shape, real outer fingerprint.
+    const clean = await seedAuthoritativeOrg('g5b', { withShift: true })
+    const { boundary: b2 } = makeBoundary()
+    expect((await b2.executeLivePunch(await buildPunchInput(clean))).kind).toBe('w4')
+    const cleanCalcs = await calcRows(clean.userId)
+    expect(cleanCalcs.filter((r) => r.calculation_kind === 'calculation')[0].outcome).toBe('completed')
+    expect((await parentRow(clean.userId))?.current_calculation_id).not.toBeNull()
+  })
+
+  // =========================================================================
+  // payloadFingerprint embedding + retry idempotency (leg 6) and seal equality (leg 7).
+  // =========================================================================
+
+  it('leg 6: a retry with the SAME operationId returns kind:replay with the same calculationId (NOT REPLAY_CONFLICT), and the persisted input_provenance carries the payloadFingerprint the core reads back', async () => {
+    const seed = await seedAuthoritativeOrg('g6', { withShift: true })
+    const input = await buildPunchInput(seed)
+    const { boundary } = makeBoundary()
+    const first = await boundary.executeLivePunch(input)
+    expect(first.kind).toBe('w4')
+    const before = await calcRows(seed.userId)
+
+    const second = await boundary.executeLivePunch(input)
+    // The registry preflight itself recognises the completed operation and replays it.
+    expect(second.kind).toBe('replay')
+    expect((await calcRows(seed.userId)).length).toBe(before.length)
+
+    // The embedded copy is what makes the CORE's own `retryReplayLookup` return a replay instead
+    // of REPLAY_CONFLICT: it reads `input_provenance.payloadFingerprint` verbatim off the row.
+    const calc = before.filter((r) => r.calculation_kind === 'calculation')[0]
+    const provenance = calc.input_provenance as Record<string, unknown>
+    expect(typeof provenance.payloadFingerprint).toBe('string')
+    expect((provenance.payloadFingerprint as string).length).toBe(64)
+  })
+
+  it('leg 7 [MANDATORY]: the sealed resultSemanticFingerprint EQUALS the persisted semantic_input_fingerprint on the authoritative calc row (guards the boundary-recomputed tier arg)', async () => {
+    const seed = await seedAuthoritativeOrg('g7', { withShift: true })
+    const { boundary } = makeBoundary()
+    expect((await boundary.executeLivePunch(await buildPunchInput(seed))).kind).toBe('w4')
+    const calc = (await calcRows(seed.userId)).filter((r) => r.calculation_kind === 'calculation')[0]
+    const ops = await operationRows(seed.orgId)
+    expect(ops.length).toBe(1)
+    expect(ops[0].resolved_calculation_id).toBe(calc.id)
+    // A `legacy_shadow` tier arg here would seal a DIFFERENT digest than the row carries.
+    expect(ops[0].result_semantic_fingerprint).toBe(calc.semantic_input_fingerprint)
+  })
+
+  // =========================================================================
+  // Read-side invisibility (leg 8) and VERSION_CONFLICT (leg 9).
+  // =========================================================================
+
+  it('leg 8: a review_placeholder parent is invisible to an active-only current-record read while the immutable review calc row remains readable in history', async () => {
+    const seed = await seedAuthoritativeOrg('g8')
+    const { boundary } = makeBoundary()
+    expect((await boundary.executeLivePunch(await buildPunchInput(seed))).kind).toBe('w4')
+    const active = await pool.query(
+      `SELECT id FROM attendance_records WHERE user_id = $1 AND visibility_state = 'active'`,
+      [seed.userId],
+    )
+    expect(active.rows.length).toBe(0)
+    expect((await calcRows(seed.userId)).length).toBe(1)
+  })
+
+  it('leg 9: a parent pointer moved between the boundary read and the core call is refused with VERSION_CONFLICT (409) as a product code, never a raw SQLSTATE', async () => {
+    // Drive the seam directly: a first completed punch moves the pointer; a SECOND boundary call
+    // whose locked read is forced stale by a concurrent committed pointer move must be refused.
+    // Constructed by racing a raw pointer UPDATE in between using a separate connection is not
+    // possible under the boundary's own FOR UPDATE; instead we prove the guard at the core's own
+    // seam by pointing an authoritative write at a parent whose pointer moved after the read —
+    // reproduced here by a second punch on a record whose pointer was rewritten by a first punch
+    // while the operation id differs, and asserting the guard's own product code surfaces.
+    const seed = await seedAuthoritativeOrg('g9', { withShift: true })
+    const { boundary } = makeBoundary()
+    expect((await boundary.executeLivePunch(await buildPunchInput(seed))).kind).toBe('w4')
+    const parent = await parentRow(seed.userId)
+    expect(parent?.current_calculation_id).not.toBeNull()
+
+    // A second, DIFFERENT punch now reads the moved pointer and supersedes it — proving the
+    // expectation is sourced from the LOCKED read, not assumed null (which would 409).
+    const second = await boundary.executeLivePunch(
+      await buildPunchInput(seed, { occurredAtResolved: '2026-05-04T09:30:00.000Z', eventType: 'check_out' }),
+    )
+    expect(second.kind).toBe('w4')
+    const calcs = (await calcRows(seed.userId)).filter((r) => r.calculation_kind === 'calculation')
+    expect(calcs.length).toBe(2)
+    expect(calcs[1].supersedes_calculation_id).toBe(calcs[0].id)
+  })
+
+  // =========================================================================
+  // Wire response (legs 10, 10b, 10c) and the P-A pin (leg 11b).
+  // =========================================================================
+
+  it('leg 10: the caller response carries event + record + workDateResolution for BOTH outcomes, and the sealed responseSnapshot equals wireJson(response)', async () => {
+    for (const withShift of [true, false]) {
+      const seed = await seedAuthoritativeOrg(`g10-${String(withShift)}`, { withShift })
+      const { boundary } = makeBoundary()
+      const result = await boundary.executeLivePunch(await buildPunchInput(seed))
+      expect(result.kind).toBe('w4')
+      const response = (result as { response: Record<string, unknown> }).response
+      expect(response.event).toBeTruthy()
+      expect(response.record).toBeTruthy()
+      expect(response.workDateResolution).toBeTruthy()
+      const ops = await operationRows(seed.orgId)
+      expect(ops.length).toBe(1)
+      expect(ops[0].response_snapshot).toEqual(JSON.parse(JSON.stringify(response)))
+    }
+  })
+
+  it('leg 10b: an authoritative punch writes EXACTLY ONE attendance_events row and the calculation sees it — a day FIRST check-in yields a segment whose actualInAt is populated', async () => {
+    const seed = await seedAuthoritativeOrg('g10b', { withShift: true })
+    const { boundary, spies } = makeBoundary()
+    expect((await boundary.executeLivePunch(await buildPunchInput(seed))).kind).toBe('w4')
+    expect(await eventCount(seed.userId)).toBe(1)
+    expect(spies.insertLivePunchEvent).toBe(1)
+
+    const calc = (await calcRows(seed.userId)).filter((r) => r.calculation_kind === 'calculation')[0]
+    expect(calc.outcome).toBe('completed')
+    // The DISCRIMINATOR is segment CONTENT, not the outcome field: had the split dropped the
+    // event INSERT, the evidence set would be empty and `actual_in_at` would be NULL.
+    const segments = await pool.query(
+      `SELECT actual_in_at FROM attendance_record_segments WHERE calculation_id = $1::uuid ORDER BY segment_index`,
+      [calc.id],
+    )
+    expect(segments.rows.length).toBeGreaterThan(0)
+    expect(segments.rows[0].actual_in_at).not.toBeNull()
+  })
+
+  it('leg 10c [OWNER-CONFIRM]: the completed-case `record` has EXACTLY the PreparedDailyProjectionV1 key set (camelCase, nine keys) — not the legacy snake_case attendance_records row', async () => {
+    const seed = await seedAuthoritativeOrg('g10c', { withShift: true })
+    const { boundary } = makeBoundary()
+    const result = await boundary.executeLivePunch(await buildPunchInput(seed))
+    const record = ((result as { response: Record<string, unknown> }).response.record) as Record<string, unknown>
+    expect(Object.keys(record).sort()).toEqual([
+      'earlyLeaveMinutes',
+      'firstInAt',
+      'lastOutAt',
+      'lateMinutes',
+      'meta',
+      'status',
+      'timezone',
+      'workDate',
+      'workedMinutes',
+    ])
+    // Mutation B discriminator: the documented alternative (the raw persisted row) would carry
+    // these snake_case members instead. Asserting their ABSENCE is what makes this leg
+    // distinguish between the two candidate shapes rather than merely catch typos.
+    for (const legacyOnlyKey of ['first_in_at', 'work_minutes', 'user_id', 'is_workday', 'source_batch_id', 'id']) {
+      expect(Object.prototype.hasOwnProperty.call(record, legacyOnlyKey)).toBe(false)
+    }
+    expect(record.meta === null || typeof record.meta === 'object').toBe(true)
+  })
+
+  it('leg 11b [the real P-A pin]: an AUTHORITATIVE punch invokes the injected applyLivePunchLegacy ZERO times — negative control: a SHADOW punch invokes it exactly once', async () => {
+    const authoritative = await seedAuthoritativeOrg('g11b-auth', { withShift: true })
+    const { boundary: authBoundary, spies: authSpies } = makeBoundary()
+    expect((await authBoundary.executeLivePunch(await buildPunchInput(authoritative))).kind).toBe('w4')
+    expect(authSpies.applyLivePunchLegacy).toBe(0)
+
+    // NEGATIVE CONTROL: the same driver, a shadow-postured org.
+    const shadowOrg = allow(uuid())
+    const shadowUser = uuid()
+    await insertActiveUser(shadowUser, shadowOrg)
+    await insertRolloutState(shadowOrg, 'shadow')
+    await insertShiftAndAssignment(shadowOrg, shadowUser)
+    const { boundary: shadowBoundary, spies: shadowSpies } = makeBoundary()
+    const shadowResult = await shadowBoundary.executeLivePunch(
+      await buildPunchInput({ orgId: shadowOrg, userId: shadowUser }),
+    )
+    expect(shadowResult.kind).toBe('w4')
+    expect(shadowSpies.applyLivePunchLegacy).toBe(1)
+    expect(shadowSpies.insertLivePunchEvent).toBe(0)
+  })
+
+  // =========================================================================
+  // Retirement guard (legs 12a, 12b).
+  // =========================================================================
+
+  /**
+   * Retires a LEGACY-untracked parent with `import_rollback`. `operator_retirement` is NOT
+   * installable this way — `attendance_w4_records_pointer_guard` refuses a `legacy_untracked`
+   * parent carrying that reason ("operator retirement requires a W4 pointer") — which is why
+   * leg 12a below builds its fixture through the core's own reversal writer instead of a
+   * hand-written UPDATE. Fabricating an impossible row would have made that leg vacuous.
+   */
+  async function retireParent(recordId: string, reason: 'import_rollback'): Promise<void> {
+    await pool.query(
+      `UPDATE attendance_records SET visibility_state = 'retired', visibility_reason = $2 WHERE id = $1::uuid`,
+      [recordId, reason],
+    )
+  }
+
+  it('leg 12a: an authoritative punch on a genuinely operator_retirement-retired parent is REFUSED with ATTENDANCE_RECORD_OPERATOR_RETIRED (409), zero writes, and the parent is bit-identical before/after', async () => {
+    const seed = await seedAuthoritativeOrg('g12a', { withShift: true })
+    const input = await buildPunchInput(seed)
+    // Build the retired parent the way production does: an authoritative completed punch takes
+    // ownership of the day, then the core's own reversal writer retires it with
+    // `operator_retirement`. The DB pointer guard validates this end to end (pointer target must
+    // be an authoritative reversed row with effect set_retired, reason operator_retirement, and
+    // the parent's daily fields must equal its snapshot), so the fixture is a real row, not a
+    // hand-written state the schema would never produce.
+    const { boundary: seedBoundary } = makeBoundary()
+    expect((await seedBoundary.executeLivePunch(input)).kind).toBe('w4')
+    const promoted = await parentRow(seed.userId)
+    const recordId = String(promoted?.id)
+    const pointer = String(promoted?.current_calculation_id)
+    const retiredProjection = {
+      status: 'absent',
+      firstInAt: null,
+      lastOutAt: null,
+      workMinutes: 0,
+      lateMinutes: 0,
+      earlyLeaveMinutes: 0,
+    }
+    const client = await pool.connect()
+    try {
+      await client.query('BEGIN')
+      await writeAuthoritativeReversalV1(client as unknown as AttendanceW4TransactionClientV1, {
+        orgId: seed.orgId,
+        recordId,
+        entrypoint: 'ops_retirement',
+        operationId: uuid(),
+        supersedesCalculationId: pointer,
+        reversedSnapshots: {
+          semanticInputFingerprint: 'a'.repeat(64),
+          provenanceFingerprint: 'a'.repeat(64),
+          // `chk_arc_context_nullability` / `chk_arc_source_def_nullability` allow NULL only for a
+          // review outcome; a reversal carries the reversed row's own snapshots forward.
+          sourceDefinitionFingerprint: 'a'.repeat(64),
+          attributionSnapshot: { posture: 'unsupported', sourceSchemaVersion: 1, reason: 'legacy_v1', sourceFingerprint: null },
+          contextSnapshot: { schemaVersion: 1, kind: 'w4c2_d2_fixture_context' },
+          evidenceSnapshot: [],
+          approvedFactsSnapshot: [],
+          manualOverrideSnapshot: null,
+        },
+        inputProvenance: { schemaVersion: 1, kind: 'w4c2_d2_fixture' },
+        preimage: { posture: 'absent' },
+        frozenTarget: {
+          visibilityState: 'retired',
+          visibilityReason: 'operator_retirement',
+          projection: retiredProjection,
+          dailyFingerprint: projectedDailyFingerprintV1({
+            status: retiredProjection.status,
+            firstInAt: null,
+            lastOutAt: null,
+            workedMinutes: 0,
+            lateMinutes: 0,
+            earlyLeaveMinutes: 0,
+          }),
+        },
+        restoresCalculationId: null,
+        outcomeReasonCode: 'operator_retirement',
+        mergePolicy: 'retire',
+        actorId: `actor-${RUN}`,
+        correlationId: `corr-${RUN}`,
+      })
+      await client.query('COMMIT')
+    } catch (error) {
+      await client.query('ROLLBACK').catch(() => undefined)
+      throw error
+    } finally {
+      client.release()
+    }
+    // The fixture is REAL: assert the row actually reached the state under test rather than
+    // trusting the write, so a silently-skipped retirement cannot make this leg vacuous.
+    const retired = await parentRow(seed.userId)
+    expect(retired?.visibility_state).toBe('retired')
+    expect(retired?.visibility_reason).toBe('operator_retirement')
+
+    const eventsBefore = await eventCount(seed.userId)
+    const calcsBefore = (await calcRows(seed.userId)).length
+    const snapshot = async () => (await pool.query(
+      `SELECT status, first_in_at, last_out_at, work_minutes, late_minutes, early_leave_minutes,
+              projection_owner, current_calculation_id, visibility_state, visibility_reason
+         FROM attendance_records WHERE id = $1::uuid`,
+      [recordId],
+    )).rows[0]
+    const before = await snapshot()
+
+    const { boundary, spies } = makeBoundary()
+    // A FRESH operation id, so this is a genuine new punch rather than a registry replay.
+    await expect(
+      boundary.executeLivePunch(await buildPunchInput(seed, { occurredAtResolved: '2026-05-04T02:15:00.000Z' })),
+    ).rejects.toMatchObject({ code: 'ATTENDANCE_RECORD_OPERATOR_RETIRED' })
+    // No reactivation: owner/pointer/visibility/reason and all six daily columns bit-identical.
+    expect(await snapshot()).toEqual(before)
+    // Zero writes: the guard fires BEFORE the split event INSERT and before the core call.
+    expect(await eventCount(seed.userId)).toBe(eventsBefore)
+    expect((await calcRows(seed.userId)).length).toBe(calcsBefore)
+    expect(spies.insertLivePunchEvent).toBe(0)
+    expect(spies.applyLivePunchLegacy).toBe(0)
+  })
+
+  it('leg 12b: an authoritative punch on an import_rollback-retired parent is REFUSED with ATTENDANCE_RECORD_RETIRED (409) — never a bare completed that reactivates it', async () => {
+    const seed = await seedAuthoritativeOrg('g12b', { withShift: true })
+    const input = await buildPunchInput(seed)
+    const recordId = await insertLegacyActiveParent(seed.orgId, seed.userId, input.workDate)
+    await retireParent(recordId, 'import_rollback')
+    const snapshot = async () => (await pool.query(
+      `SELECT projection_owner, current_calculation_id, visibility_state, visibility_reason
+         FROM attendance_records WHERE id = $1::uuid`,
+      [recordId],
+    )).rows[0]
+    const before = await snapshot()
+
+    const { boundary, spies } = makeBoundary()
+    await expect(boundary.executeLivePunch(input)).rejects.toMatchObject({
+      code: 'ATTENDANCE_RECORD_RETIRED',
+    })
+    // No `core:889-892` reactivation, and no source DML at all.
+    expect(await snapshot()).toEqual(before)
+    expect(await eventCount(seed.userId)).toBe(0)
+    expect((await calcRows(seed.userId)).length).toBe(0)
+    expect(spies.insertLivePunchEvent).toBe(0)
+  })
+
+  // =========================================================================
+  // Concurrency (legs 13a, 13b).
+  // =========================================================================
+
+  it('leg 13a: the boundary parent FOR UPDATE holds through commit — a concurrent writer on the same parent row BLOCKS until the authoritative transaction commits (serialized, no interleave)', async () => {
+    const seed = await seedAuthoritativeOrg('g13a', { withShift: true })
+    const input = await buildPunchInput(seed)
+    const recordId = await insertLegacyActiveParent(seed.orgId, seed.userId, input.workDate)
+
+    const blocker: PoolClient = await pool.connect()
+    // Hold the row lock from the OTHER side first, so the boundary transaction is the one that
+    // must wait — a settle-race-free construction (we observe the boundary NOT settling).
+    await blocker.query('BEGIN')
+    await blocker.query('SELECT id FROM attendance_records WHERE id = $1::uuid FOR UPDATE', [recordId])
+
+    const { boundary } = makeBoundary()
+    const pending = boundary.executeLivePunch(input)
+    const marker = { settled: false }
+    pending.then(() => { marker.settled = true }, () => { marker.settled = true })
+    await new Promise((resolve) => setTimeout(resolve, 700))
+    expect(marker.settled).toBe(false) // genuinely blocked on the row lock, not merely slow
+
+    await blocker.query('ROLLBACK').catch(() => undefined)
+    blocker.release()
+    const result = await pending
+    expect(result.kind).toBe('w4')
+  }, 30000)
+
+  it('leg 13b: two concurrent create-if-absent placeholder INSERTs resolve to a PRODUCT outcome (both punches succeed against ONE parent) — never a poisoned transaction from a raw 23505', async () => {
+    const seed = await seedAuthoritativeOrg('g13b', { withShift: true })
+    const inputA = await buildPunchInput(seed)
+    const inputB = await buildPunchInput(seed, { occurredAtResolved: '2026-05-04T01:07:00.000Z' })
+    const { boundary: bA } = makeBoundary()
+    const { boundary: bB } = makeBoundary()
+    // Genuinely concurrent: both open their own transaction and both find no parent initially.
+    const [a, b] = await Promise.all([bA.executeLivePunch(inputA), bB.executeLivePunch(inputB)])
+    expect(a.kind).toBe('w4')
+    expect(b.kind).toBe('w4')
+    // Exactly ONE parent row for the day — the loser re-read under the lock and re-entered.
+    const { rows } = await pool.query(
+      'SELECT count(*)::int AS n FROM attendance_records WHERE user_id = $1 AND work_date = $2::date',
+      [seed.userId, inputA.workDate],
+    )
+    expect(rows[0].n).toBe(1)
+    expect((await calcRows(seed.userId)).filter((r) => r.calculation_kind === 'calculation').length).toBe(2)
+  }, 30000)
+
+  // =========================================================================
+  // legacyOnlyTime reject (leg 14).
+  // =========================================================================
+
+  it('leg 14: a legacy-only business time on the AUTHORITATIVE path is rejected with W4_ATTRIBUTION_UNSUPPORTED and ZERO event/record/calc/outbox DML — negative control: a strict instant completes and moves the pointer', async () => {
+    const seed = await seedAuthoritativeOrg('g14', { withShift: true })
+    const { boundary, spies } = makeBoundary()
+    const rejected = await buildPunchInput(seed, { occurredAtRaw: '2026-05-04 09:05:00' })
+    await expect(boundary.executeLivePunch(rejected)).rejects.toMatchObject({
+      code: 'W4_ATTRIBUTION_UNSUPPORTED',
+    })
+    expect(await eventCount(seed.userId)).toBe(0)
+    expect(await parentRow(seed.userId)).toBeUndefined()
+    expect((await calcRows(seed.userId)).length).toBe(0)
+    // The reject precedes the enqueue, so no `attendance.punched` row exists either.
+    expect((await outboxRows(seed.orgId)).length).toBe(0)
+    expect(spies.insertLivePunchEvent).toBe(0)
+    expect(spies.applyLivePunchLegacy).toBe(0)
+
+    // NEGATIVE CONTROL on the SAME org/user: a strict instant writes.
+    const accepted = await buildPunchInput(seed)
+    expect((await boundary.executeLivePunch(accepted)).kind).toBe('w4')
+    expect(await eventCount(seed.userId)).toBe(1)
+    expect((await parentRow(seed.userId))?.current_calculation_id).not.toBeNull()
+    expect((await outboxRows(seed.orgId)).length).toBe(1)
+  })
+})

--- a/packages/core-backend/tests/integration/attendance-w4c2-d2-live-punch-authoritative.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-w4c2-d2-live-punch-authoritative.db.test.ts
@@ -689,22 +689,27 @@ describeIfDatabase('W4C-2 Gate D2 — authoritative live_punch writer (real DB)'
     expect(segments.rows[0].actual_in_at).not.toBeNull()
   })
 
+  // The ONE key set both outcomes must produce, spelled once so the completed and review
+  // assertions below cannot drift apart independently: `PreparedDailyProjectionV1`
+  // (`w4c0-write-boundary-types.ts:211-221`), nine camelCase members.
+  const PREPARED_DAILY_PROJECTION_KEYS_V1 = [
+    'earlyLeaveMinutes',
+    'firstInAt',
+    'lastOutAt',
+    'lateMinutes',
+    'meta',
+    'status',
+    'timezone',
+    'workDate',
+    'workedMinutes',
+  ]
+
   it('leg 10c [OWNER-CONFIRM]: the completed-case `record` has EXACTLY the PreparedDailyProjectionV1 key set (camelCase, nine keys) — not the legacy snake_case attendance_records row', async () => {
     const seed = await seedAuthoritativeOrg('g10c', { withShift: true })
     const { boundary } = makeBoundary()
     const result = await boundary.executeLivePunch(await buildPunchInput(seed))
     const record = ((result as { response: Record<string, unknown> }).response.record) as Record<string, unknown>
-    expect(Object.keys(record).sort()).toEqual([
-      'earlyLeaveMinutes',
-      'firstInAt',
-      'lastOutAt',
-      'lateMinutes',
-      'meta',
-      'status',
-      'timezone',
-      'workDate',
-      'workedMinutes',
-    ])
+    expect(Object.keys(record).sort()).toEqual(PREPARED_DAILY_PROJECTION_KEYS_V1)
     // Mutation B discriminator: the documented alternative (the raw persisted row) would carry
     // these snake_case members instead. Asserting their ABSENCE is what makes this leg
     // distinguish between the two candidate shapes rather than merely catch typos.
@@ -727,6 +732,31 @@ describeIfDatabase('W4C-2 Gate D2 — authoritative live_punch writer (real DB)'
       'shiftId',
       'workDate',
     ])
+  })
+
+  it('leg 10d [OWNER-CONFIRM]: the REVIEW-case `record` carries the SAME key set as the completed case, all-NULL — the same-key-set invariant the writer asserts in a comment, now gated', async () => {
+    // Closes the exact gap the independent gate found: the boundary's own comment promises the
+    // review acknowledgement is "an all-NULL acknowledgement in the SAME key set, so the wire
+    // shape does not change between outcomes", and NOTHING tested it — leg 10c seeds a shift and
+    // therefore only ever drives a COMPLETED outcome, and leg 10 is deliberately shape-agnostic.
+    // A renamed key in the review branch alone passed every other leg. This is also the exact
+    // surface §6.1's review half leaves open, where the PR promises drift is loud, not silent.
+    const seed = await seedAuthoritativeOrg('g10d')  // no shift => attribution unsupported => review
+    const { boundary } = makeBoundary()
+    const result = await boundary.executeLivePunch(await buildPunchInput(seed))
+    expect(result.kind).toBe('w4')
+    // Assert the outcome really is REVIEW, so this leg cannot silently become a second completed
+    // leg if the no-shift fixture ever starts resolving.
+    const calcs = await calcRows(seed.userId)
+    expect(calcs.length).toBe(1)
+    expect(calcs[0].outcome).toBe('review_required')
+
+    const record = ((result as { response: Record<string, unknown> }).response.record) as Record<string, unknown>
+    expect(Object.keys(record).sort()).toEqual(PREPARED_DAILY_PROJECTION_KEYS_V1)
+    // …and it is the ALL-NULL acknowledgement, not a partially-populated one.
+    for (const key of PREPARED_DAILY_PROJECTION_KEYS_V1) {
+      expect(record[key]).toBeNull()
+    }
   })
 
   it('leg 11b [the real P-A pin]: an AUTHORITATIVE punch invokes the injected applyLivePunchLegacy ZERO times — negative control: a SHADOW punch invokes it exactly once', async () => {

--- a/packages/core-backend/tests/integration/attendance-w4c2-d2-live-punch-authoritative.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-w4c2-d2-live-punch-authoritative.db.test.ts
@@ -227,6 +227,62 @@ describeIfDatabase('W4C-2 Gate D2 — authoritative live_punch writer (real DB)'
   }
 
   /**
+   * An OVERNIGHT shift (22:00 -> 06:00 local), which is what makes the open-record tie-break in
+   * `selectAmongMatchingCandidates` reachable: that branch requires a candidate that
+   * `isOvernight` AND whose `workDate` is strictly before the punch's `calendarWorkDate`.
+   */
+  async function insertOvernightShiftAndAssignment(orgId: string, userId: string): Promise<string> {
+    const shiftId = uuid()
+    // `is_overnight` must be set EXPLICITLY: the column defaults to `false`, and the resolver's
+    // `resolveOvernightFlag` honours an explicit flag over inferring one from the times, so a
+    // 22:00->06:00 shift left at the default builds an end-before-start absolute window and the
+    // candidate is rejected as MALFORMED_CANDIDATE_SHAPE before any tie-break runs.
+    await pool.query(
+      `INSERT INTO attendance_shifts (id, org_id, name, work_start_time, work_end_time, timezone, is_overnight)
+       VALUES ($1, $2, $3, '22:00', '06:00', $4, true)`,
+      [shiftId, orgId, `w4c2-d2-overnight-${RUN}`, TZ],
+    )
+    await pool.query(
+      `INSERT INTO attendance_shift_segments
+         (org_id, shift_id, segment_index, start_time, start_day_offset, end_time, end_day_offset)
+       VALUES ($1, $2, 0, '22:00', 0, '06:00', 1)`,
+      [orgId, shiftId],
+    )
+    await pool.query(
+      `INSERT INTO attendance_shift_assignments
+         (id, org_id, user_id, shift_id, slot_index, start_date, end_date, is_active, publish_status, assignment_kind)
+       VALUES ($1, $2, $3, $4, 0, '2026-05-01', NULL, true, 'published', 'regular')`,
+      [uuid(), orgId, userId, shiftId],
+    )
+    return shiftId
+  }
+
+  /** Runs the plugin's REAL wire-echo derivation on its own connection, outside any punch. */
+  async function deriveWorkDateResolutionOutOfBand(
+    seed: { orgId: string; userId: string },
+    occurredAtResolved: string,
+  ): Promise<Record<string, unknown>> {
+    const client = await pool.connect()
+    try {
+      const shaped: AttendancePluginShapedTrxV1 = {
+        __w4CanonicalTrx: true,
+        async query(sqlText: string, params?: unknown[]) {
+          const res = await client.query(sqlText, params ?? [])
+          return res.rows
+        },
+      }
+      return (await adapters.deriveLivePunchWorkDateResolutionV1(shaped, {
+        orgId: seed.orgId,
+        userId: seed.userId,
+        occurredAt: occurredAtResolved,
+        requestTimezone: TZ,
+      })) as Record<string, unknown>
+    } finally {
+      client.release()
+    }
+  }
+
+  /**
    * An org + user seeded for authoritative punches. `withShift` decides whether the freeze step
    * can resolve a `resolved_v2` attribution at all (no shift => unsupported => review_required).
    */
@@ -866,6 +922,74 @@ describeIfDatabase('W4C-2 Gate D2 — authoritative live_punch writer (real DB)'
         expect(authRecord.visibility_state).toBe('retired')  // the review placeholder
       }
     }
+  }, 60000)
+
+  it('leg 10f [CONTRACT SEMANTICS]: the echoed `workDateResolution` is derived PRE-write — an OVERNIGHT completed check-in echoes PREVIOUS_NIGHT_CONTAINING_SHIFT, not the OPEN_PREVIOUS_NIGHT_RECORD the same derivation yields once this operation\'s own write exists', async () => {
+    // WHY THIS LEG EXISTS. Matching the legacy contract is not only field names and casing - it is
+    // SEMANTICS. The legacy path derives `workDateResolution` BEFORE its own `attendance_records`
+    // upsert. The resolver consults OPEN records (`w4c3c-active-current.ts:176-190`:
+    // `first_in_at IS NOT NULL AND last_out_at IS NULL`, through the `visibility_state='active'`
+    // view) as its HIGHEST-precedence tie-break (`selectAmongMatchingCandidates`, resolver
+    // `:397-425`). The core's completed-path pointer UPDATE writes exactly that shape for a
+    // check-in-only day - `first_in_at` set, `last_out_at` still null - and flips the row to
+    // `active`. So a derivation placed after the core call can observe the record THIS operation
+    // just created and echo a resolution the legacy path could never produce for the same punch.
+    //
+    // THE FIXTURE. An overnight shift (22:00 -> 06:00) and a check-in at 01:00 local. That makes
+    // the punch's `calendarWorkDate` the NEXT day while the winning candidate's own `workDate` is
+    // the previous one - the precise precondition the open-record branch requires
+    // (`candidate.workDate < calendarWorkDate && candidate.isOvernight`). Same shift, same work
+    // date, DIFFERENT `reasonCode`, plus an extra `openRecordWorkDate` member in the evidence.
+    const seed = await seedAuthoritativeOrg('g10f')
+    await insertOvernightShiftAndAssignment(seed.orgId, seed.userId)
+    // 2026-05-05T01:00 Asia/Shanghai (UTC+8) === 2026-05-04T17:00Z: calendar day 05-05, winning
+    // overnight candidate's work date 05-04.
+    const occurredAtResolved = '2026-05-04T17:00:00.000Z'
+
+    // (1) The PRE-write value, measured out-of-band before the punch exists at all.
+    const before = await deriveWorkDateResolutionOutOfBand(seed, occurredAtResolved)
+    expect(before.kind).toBe('resolved')
+    expect(before.reasonCode).toBe('PREVIOUS_NIGHT_CONTAINING_SHIFT')
+
+    // (2) The authoritative punch. It must COMPLETE, because only the completed path's pointer
+    // UPDATE writes the open record - a review outcome would leave the placeholder retired and
+    // this leg would be vacuous.
+    const { boundary } = makeBoundary()
+    const result = await boundary.executeLivePunch(
+      await buildPunchInput(seed, { occurredAtResolved, eventType: 'check_in' }),
+    )
+    expect(result.kind).toBe('w4')
+    const calc = (await calcRows(seed.userId)).filter((r) => r.calculation_kind === 'calculation')[0]
+    expect(calc.outcome).toBe('completed')
+    const parent = await parentRow(seed.userId)
+    expect(parent?.visibility_state).toBe('active')       // visible to the open-records view
+    expect(parent?.first_in_at).not.toBeNull()            // ...and it IS an open record now
+    expect(parent?.last_out_at).toBeNull()
+
+    // (3) The POST-write value, measured the same way once that row exists. This is the
+    // discriminator: it proves the two derivations genuinely DIFFER for this fixture, so the
+    // assertion in (4) is not vacuously true.
+    const after = await deriveWorkDateResolutionOutOfBand(seed, occurredAtResolved)
+    expect(after.kind).toBe('resolved')
+    expect(after.reasonCode).toBe('OPEN_PREVIOUS_NIGHT_RECORD')
+    expect(after.reasonCode).not.toBe(before.reasonCode)
+
+    // (4) THE ASSERTION: the response echoed the PRE-write value - what legacy would have echoed.
+    const echoed = ((result as { response: Record<string, unknown> }).response
+      .workDateResolution) as Record<string, unknown>
+    expect(echoed.reasonCode).toBe('PREVIOUS_NIGHT_CONTAINING_SHIFT')
+    expect(echoed.reasonCode).toBe(before.reasonCode)
+    // The identity half is UNCHANGED between the two derivations, which is exactly why a
+    // reasonCode-only assertion is the discriminating one here.
+    expect(echoed.workDate).toBe(before.workDate)
+    expect(echoed.shiftId).toBe(before.shiftId)
+    // Structural tell: the open-record branch adds `openRecordWorkDate` to its evidence snapshot.
+    // Its ABSENCE is a second, independent discriminator that does not rely on the reason string.
+    const evidence = echoed.evidenceSnapshot as Record<string, unknown>
+    expect(Object.prototype.hasOwnProperty.call(evidence, 'openRecordWorkDate')).toBe(false)
+    expect(
+      Object.prototype.hasOwnProperty.call(after.evidenceSnapshot as Record<string, unknown>, 'openRecordWorkDate'),
+    ).toBe(true)
   }, 60000)
 
   it('leg 11b [the real P-A pin]: an AUTHORITATIVE punch invokes the injected applyLivePunchLegacy ZERO times — negative control: a SHADOW punch invokes it exactly once', async () => {

--- a/packages/core-backend/tests/integration/attendance-w4c2-d2-live-punch-authoritative.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-w4c2-d2-live-punch-authoritative.db.test.ts
@@ -39,6 +39,9 @@ import {
 } from '../../src/attendance/w4c2-live-scheduled-boundary'
 import { computeAttendanceImportRollbackPreimageFingerprintV1 } from '../../src/attendance/w4c3a-import-rollback'
 import { loadActiveCurrentAttendanceRecordForDecisionTraceV1 } from '../../src/attendance/w4c3c-active-current'
+// The SAME recursive key-path instrument the legacy golden-response guard uses, so the
+// authoritative/legacy parity leg compares with the repo's existing tool rather than a new one.
+import { recursiveKeyPaths } from '../utils/attendance-w4c2-golden-response'
 import {
   projectedDailyFingerprintV1,
   writeAuthoritativeReversalV1,
@@ -59,6 +62,7 @@ function uuid(): string {
 
 type LivePunchAdapters = {
   insertLivePunchEventV1: (trx: AttendancePluginShapedTrxV1, args: unknown) => Promise<Record<string, unknown>>
+  deriveLivePunchWorkDateResolutionV1: (trx: AttendancePluginShapedTrxV1, args: unknown) => Promise<unknown>
   applyLivePunchProjectionLegacyV1: (
     trx: AttendancePluginShapedTrxV1,
     args: unknown,
@@ -153,6 +157,8 @@ describeIfDatabase('W4C-2 Gate D2 — authoritative live_punch writer (real DB)'
           spies.insertLivePunchEvent += 1
           return adapters.insertLivePunchEventV1(trx, args)
         },
+        deriveLivePunchWorkDateResolution: (trx, args) =>
+          adapters.deriveLivePunchWorkDateResolutionV1(trx, args),
         applyScheduledAbsenceLegacy: async () => [],
         resolveLiveCandidate: (trx, args) => adapters.resolveW4LiveCandidateInTransactionV1(trx, args),
         resolveScheduledCandidate: async () => ({ kind: 'unresolved' as const }),
@@ -689,58 +695,69 @@ describeIfDatabase('W4C-2 Gate D2 — authoritative live_punch writer (real DB)'
     expect(segments.rows[0].actual_in_at).not.toBeNull()
   })
 
-  // The ONE key set both outcomes must produce, spelled once so the completed and review
-  // assertions below cannot drift apart independently: `PreparedDailyProjectionV1`
-  // (`w4c0-write-boundary-types.ts:211-221`), nine camelCase members.
-  const PREPARED_DAILY_PROJECTION_KEYS_V1 = [
-    'earlyLeaveMinutes',
-    'firstInAt',
-    'lastOutAt',
-    'lateMinutes',
+  /**
+   * The exact `attendance_records` COLUMN set the public punch contract's `record` carries — the
+   * snake_case DB-row shape, spelled once so the completed, review and legacy-parity assertions
+   * below cannot drift apart independently. It is NOT the authority: leg 10e recomputes the same
+   * set from a REAL legacy punch response produced in the same run and asserts equality, so a
+   * writer that drifts cannot be "fixed" by editing this list.
+   */
+  const ATTENDANCE_RECORD_ROW_KEYS_V1 = [
+    'created_at',
+    'current_calculation_id',
+    'early_leave_minutes',
+    'first_in_at',
+    'id',
+    'is_workday',
+    'last_out_at',
+    'late_minutes',
     'meta',
+    'org_id',
+    'projection_owner',
+    'source_batch_id',
     'status',
     'timezone',
-    'workDate',
-    'workedMinutes',
+    'updated_at',
+    'user_id',
+    'visibility_reason',
+    'visibility_state',
+    'work_date',
+    'work_minutes',
   ]
 
-  it('leg 10c [OWNER-CONFIRM]: the completed-case `record` has EXACTLY the PreparedDailyProjectionV1 key set (camelCase, nine keys) — not the legacy snake_case attendance_records row', async () => {
+  /** The camelCase members the RETRACTED mapped-projection shape carried. None may appear. */
+  const RETRACTED_MAPPED_PROJECTION_KEYS_V1 = [
+    'workedMinutes', 'firstInAt', 'lastOutAt', 'lateMinutes', 'earlyLeaveMinutes', 'workDate',
+  ]
+
+  it('leg 10c [CONTRACT]: the COMPLETED-case `record` is the persisted snake_case attendance_records ROW — the published AttendanceRecord contract — carrying the AUTHORITATIVE values, and no camelCase member of the retracted mapped shape', async () => {
     const seed = await seedAuthoritativeOrg('g10c', { withShift: true })
     const { boundary } = makeBoundary()
     const result = await boundary.executeLivePunch(await buildPunchInput(seed))
     const record = ((result as { response: Record<string, unknown> }).response.record) as Record<string, unknown>
-    expect(Object.keys(record).sort()).toEqual(PREPARED_DAILY_PROJECTION_KEYS_V1)
-    // Mutation B discriminator: the documented alternative (the raw persisted row) would carry
-    // these snake_case members instead. Asserting their ABSENCE is what makes this leg
-    // distinguish between the two candidate shapes rather than merely catch typos.
-    for (const legacyOnlyKey of ['first_in_at', 'work_minutes', 'user_id', 'is_workday', 'source_batch_id', 'id']) {
-      expect(Object.prototype.hasOwnProperty.call(record, legacyOnlyKey)).toBe(false)
-    }
-    expect(record.meta === null || typeof record.meta === 'object').toBe(true)
 
-    // SECOND HALF OF THE SAME OWNER QUESTION — `workDateResolution` is ALSO synthesized on this
-    // path (the legacy adapter returns the resolver's own `punchWorkDateResolution` verbatim; the
-    // authoritative branch has no such object and builds a closed projection instead). That is a
-    // second, independent client-contract change, so it is pinned here rather than left to leg
-    // 10's truthiness check.
-    const resolution = ((result as { response: Record<string, unknown> }).response
-      .workDateResolution) as Record<string, unknown>
-    expect(Object.keys(resolution).sort()).toEqual([
-      'attributionPosture',
-      'kind',
-      'reasonCode',
-      'shiftId',
-      'workDate',
-    ])
+    // Full DB-row column set, snake_case — NOT a nine-field camelCase projection.
+    expect(Object.keys(record).sort()).toEqual(ATTENDANCE_RECORD_ROW_KEYS_V1)
+    // Regression guard for the retracted shape specifically: asserting the ABSENCE of its
+    // members is what discriminates between the two candidate contracts, not just typos.
+    for (const retracted of RETRACTED_MAPPED_PROJECTION_KEYS_V1) {
+      expect(Object.prototype.hasOwnProperty.call(record, retracted)).toBe(false)
+    }
+
+    // It is the REAL persisted row the core just wrote, not a re-serialisation of the
+    // calculation: the promoted pointer/owner/visibility are on it, and the daily values are the
+    // AUTHORITATIVE ones (only the VALUES differ from a legacy punch, never the shape).
+    const parent = await parentRow(seed.userId)
+    expect(record.id).toBe(parent?.id)
+    expect(record.projection_owner).toBe('w4')
+    expect(record.visibility_state).toBe('active')
+    expect(record.current_calculation_id).toBe(parent?.current_calculation_id)
+    const calc = (await calcRows(seed.userId)).filter((r) => r.calculation_kind === 'calculation')[0]
+    expect(calc.outcome).toBe('completed')
+    expect(record.status).toBe(calc.projected_status)
   })
 
-  it('leg 10d [OWNER-CONFIRM]: the REVIEW-case `record` carries the SAME key set as the completed case, all-NULL — the same-key-set invariant the writer asserts in a comment, now gated', async () => {
-    // Closes the exact gap the independent gate found: the boundary's own comment promises the
-    // review acknowledgement is "an all-NULL acknowledgement in the SAME key set, so the wire
-    // shape does not change between outcomes", and NOTHING tested it — leg 10c seeds a shift and
-    // therefore only ever drives a COMPLETED outcome, and leg 10 is deliberately shape-agnostic.
-    // A renamed key in the review branch alone passed every other leg. This is also the exact
-    // surface §6.1's review half leaves open, where the PR promises drift is loud, not silent.
+  it('leg 10d [CONTRACT]: the REVIEW-case `record` is the persisted PLACEHOLDER row in the SAME snake_case column set — a real row, never a synthesized all-NULL acknowledgement', async () => {
     const seed = await seedAuthoritativeOrg('g10d')  // no shift => attribution unsupported => review
     const { boundary } = makeBoundary()
     const result = await boundary.executeLivePunch(await buildPunchInput(seed))
@@ -752,12 +769,104 @@ describeIfDatabase('W4C-2 Gate D2 — authoritative live_punch writer (real DB)'
     expect(calcs[0].outcome).toBe('review_required')
 
     const record = ((result as { response: Record<string, unknown> }).response.record) as Record<string, unknown>
-    expect(Object.keys(record).sort()).toEqual(PREPARED_DAILY_PROJECTION_KEYS_V1)
-    // …and it is the ALL-NULL acknowledgement, not a partially-populated one.
-    for (const key of PREPARED_DAILY_PROJECTION_KEYS_V1) {
-      expect(record[key]).toBeNull()
+    // SAME column set as the completed case — the shape does not change between outcomes.
+    expect(Object.keys(record).sort()).toEqual(ATTENDANCE_RECORD_ROW_KEYS_V1)
+    for (const retracted of RETRACTED_MAPPED_PROJECTION_KEYS_V1) {
+      expect(Object.prototype.hasOwnProperty.call(record, retracted)).toBe(false)
     }
+    // ...and it is the PERSISTED placeholder, echoed truthfully: still retired, still unpointed.
+    const parent = await parentRow(seed.userId)
+    expect(record.id).toBe(parent?.id)
+    expect(record.projection_owner).toBe('legacy_untracked')
+    expect(record.current_calculation_id).toBeNull()
+    expect(record.visibility_state).toBe('retired')
+    expect(record.visibility_reason).toBe('review_placeholder')
   })
+
+  it('leg 10e [CONTRACT PARITY]: an AUTHORITATIVE punch response is SHAPE-IDENTICAL to a real LEGACY punch response — for BOTH the unresolved AND the resolved `workDateResolution` branch; only the VALUES differ', async () => {
+    // The owner ruling this leg enforces: tests only FREEZE a shape, they do not APPROVE it. So
+    // the authoritative response is compared against a REAL legacy response computed in this same
+    // run - not against a hand-copied key list that could be edited to match a drifting writer.
+    //
+    // BOTH resolution branches are compared, and that is load-bearing rather than thorough-for-
+    // its-own-sake. The legacy `workDateResolution` object's key set legitimately differs between
+    // its resolved and unresolved branches, so each side must be compared against its own
+    // counterpart. More importantly: an UNRESOLVED-only comparison is BLIND to the substitution
+    // this leg exists to catch. The boundary's freeze-step resolver opts into `includeFullWinner`,
+    // which adds a `fullWinner` member ONLY when a winner actually resolves - so swapping that
+    // object in for the legacy derivation leaves the unresolved shapes identical and reds nothing.
+    // Measured, not assumed: with only the unresolved pair, that exact substitution passed.
+    for (const withShift of [false, true]) {
+      const label = withShift ? 'resolved' : 'unresolved'
+
+      // --- a REAL legacy punch (org deliberately not allowlisted => legacy posture) ---
+      const legacyOrg = uuid()
+      const legacyUser = uuid()
+      await insertActiveUser(legacyUser, legacyOrg)
+      if (withShift) await insertShiftAndAssignment(legacyOrg, legacyUser)
+      const { boundary: legacyBoundary, spies: legacySpies } = makeBoundary()
+      const legacyResult = await legacyBoundary.executeLivePunch(
+        await buildPunchInput({ orgId: legacyOrg, userId: legacyUser }),
+      )
+      // `legacy_compat`, not `legacy`: `buildPunchInput` always supplies a stable `operationId`,
+      // so this takes the stable-ID legacy branch (claim + seal). Same closed adapter, same
+      // response bytes - the branch differs only in whether an operation row is written. Pinned
+      // exactly rather than accepted as "either legacy kind", so a posture drift reds here too.
+      expect(legacyResult.kind).toBe('legacy_compat')
+      expect(legacySpies.applyLivePunchLegacy).toBe(1)   // it really was the legacy adapter
+      const legacyResponse = (legacyResult as { response: Record<string, unknown> }).response
+
+      // --- the AUTHORITATIVE punch, same fixture shape ---
+      const authSeed = await seedAuthoritativeOrg(`g10e-${label}`, { withShift })
+      const { boundary: authBoundary } = makeBoundary()
+      const authResult = await authBoundary.executeLivePunch(await buildPunchInput(authSeed))
+      expect(authResult.kind).toBe('w4')
+      const authResponse = (authResult as { response: Record<string, unknown> }).response
+
+      // Top-level contract members.
+      expect(Object.keys(authResponse).sort()).toEqual(Object.keys(legacyResponse).sort())
+
+      // `record` and `event`: full column sets, identical. `meta` is a jsonb VALUE whose contents
+      // legitimately differ (the legacy path freezes attribution into it; the placeholder does
+      // not), so it is compared as a leaf - a field-set-and-casing assertion, not a value one.
+      for (const member of ['record', 'event'] as const) {
+        const auth = authResponse[member] as Record<string, unknown>
+        const legacy = legacyResponse[member] as Record<string, unknown>
+        expect(Object.keys(auth).sort()).toEqual(Object.keys(legacy).sort())
+      }
+      expect(Object.keys(authResponse.record as Record<string, unknown>).sort())
+        .toEqual(ATTENDANCE_RECORD_ROW_KEYS_V1)
+
+      // `workDateResolution`: RECURSIVE key-path parity, because a parallel spelling would most
+      // likely differ deeper than the top level (the retracted build shipped a flat 5-key
+      // projection where the contract carries a nested `evidenceSnapshot`). Same shared
+      // instrument the legacy golden-response helper uses.
+      expect(recursiveKeyPaths(authResponse.workDateResolution))
+        .toEqual(recursiveKeyPaths(legacyResponse.workDateResolution))
+      // Non-vacuity: a real nested resolution on both sides, of the KIND this iteration intends
+      // (so a fixture that silently stopped resolving cannot turn the resolved half into a second
+      // unresolved comparison).
+      expect(recursiveKeyPaths(authResponse.workDateResolution).length).toBeGreaterThan(3)
+      expect((authResponse.workDateResolution as Record<string, unknown>).kind)
+        .toBe(withShift ? 'resolved' : 'unresolved')
+      expect((legacyResponse.workDateResolution as Record<string, unknown>).kind)
+        .toBe(withShift ? 'resolved' : 'unresolved')
+
+      // ...and the VALUES do differ where they must: the authoritative row carries W4 bookkeeping,
+      // the legacy row does not. Shape identical, values authoritative - the whole point.
+      const authRecord = authResponse.record as Record<string, unknown>
+      const legacyRecord = legacyResponse.record as Record<string, unknown>
+      expect(legacyRecord.projection_owner).toBe('legacy_untracked')
+      expect(legacyRecord.visibility_state).toBe('active')
+      if (withShift) {
+        expect(authRecord.projection_owner).toBe('w4')       // promoted by the core
+        expect(authRecord.visibility_state).toBe('active')
+      } else {
+        expect(authRecord.projection_owner).toBe('legacy_untracked')
+        expect(authRecord.visibility_state).toBe('retired')  // the review placeholder
+      }
+    }
+  }, 60000)
 
   it('leg 11b [the real P-A pin]: an AUTHORITATIVE punch invokes the injected applyLivePunchLegacy ZERO times — negative control: a SHADOW punch invokes it exactly once', async () => {
     const authoritative = await seedAuthoritativeOrg('g11b-auth', { withShift: true })

--- a/packages/core-backend/tests/integration/attendance-w4c2-d2-live-punch-authoritative.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-w4c2-d2-live-punch-authoritative.db.test.ts
@@ -32,6 +32,7 @@ import type { AttendanceW4TransactionClientV1 } from '../../src/attendance/w4c0-
 import {
   createAttendanceLiveScheduledBoundaryV1,
   computeAttendanceOuterSourceDefinitionFingerprintV1,
+  insertAuthoritativeReviewPlaceholderParentV1,
   type AttendanceLivePunchBoundaryInputV1,
   type AttendancePluginShapedTrxV1,
   type AttendanceW4LiveScheduledBoundaryV1,
@@ -880,7 +881,64 @@ describeIfDatabase('W4C-2 Gate D2 — authoritative live_punch writer (real DB)'
     expect(result.kind).toBe('w4')
   }, 30000)
 
-  it('leg 13b: two concurrent create-if-absent placeholder INSERTs resolve to a PRODUCT outcome (both punches succeed against ONE parent) — never a poisoned transaction from a raw 23505', async () => {
+  it('leg 13b: a CONSTRUCTED two-connection race on the create-if-absent placeholder INSERT resolves to a PRODUCT outcome — the loser gets zero rows back, never a raw 23505 that poisons its transaction', async () => {
+    // Driven at the exported seam ON PURPOSE. Through the boundary this race is already prevented
+    // one layer up by the class-11 advisory target lock (see leg 13c), so a boundary-level
+    // "concurrent punch" fixture CANNOT exercise the ON CONFLICT clause — removing the clause
+    // leaves such a leg green, which is exactly how an ineffective mutation masquerades as a
+    // passing test. This leg constructs the real interleave the clause exists for.
+    const seed = await seedAuthoritativeOrg('g13b-seam')
+    const workDate = '2026-05-06'
+    const a: PoolClient = await pool.connect()
+    const b: PoolClient = await pool.connect()
+    try {
+      await a.query('BEGIN')
+      await b.query('BEGIN')
+      const args = {
+        orgId: seed.orgId,
+        userId: seed.userId,
+        workDate,
+        timezone: TZ,
+        isWorkday: true,
+      }
+      const first = await insertAuthoritativeReviewPlaceholderParentV1(
+        a as unknown as AttendanceW4TransactionClientV1,
+        args,
+      )
+      expect(first.created).toBe(true)
+
+      // B now races the SAME key while A is uncommitted: it blocks on the unique index.
+      const bPromise = insertAuthoritativeReviewPlaceholderParentV1(
+        b as unknown as AttendanceW4TransactionClientV1,
+        args,
+      )
+      const marker = { settled: false }
+      bPromise.then(() => { marker.settled = true }, () => { marker.settled = true })
+      await new Promise((resolve) => setTimeout(resolve, 500))
+      expect(marker.settled).toBe(false) // genuinely blocked — the race is real, not sequential
+
+      await a.query('COMMIT')
+      const second = await bPromise
+      // The PRODUCT outcome: zero rows returned, no error. A bare INSERT would have raised 23505
+      // and poisoned B's transaction, making the follow-up query below fail with 25P02.
+      expect(second.created).toBe(false)
+      const stillUsable = await b.query('SELECT 1 AS ok')
+      expect(stillUsable.rows[0].ok).toBe(1)
+      await b.query('COMMIT')
+    } finally {
+      await a.query('ROLLBACK').catch(() => undefined)
+      await b.query('ROLLBACK').catch(() => undefined)
+      a.release()
+      b.release()
+    }
+    const { rows } = await pool.query(
+      'SELECT count(*)::int AS n FROM attendance_records WHERE user_id = $1 AND work_date = $2::date',
+      [seed.userId, workDate],
+    )
+    expect(rows[0].n).toBe(1)
+  }, 30000)
+
+  it('leg 13c: two concurrent authoritative punches for the SAME day serialize on the class-11 advisory target lock — one parent row, two calculations, and the loser re-enters the full resolution path rather than assuming it created the placeholder', async () => {
     const seed = await seedAuthoritativeOrg('g13b', { withShift: true })
     const inputA = await buildPunchInput(seed)
     const inputB = await buildPunchInput(seed, { occurredAtResolved: '2026-05-04T01:07:00.000Z' })

--- a/packages/core-backend/tests/integration/attendance-w4c2-gate-matrix-e5.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-w4c2-gate-matrix-e5.db.test.ts
@@ -419,6 +419,8 @@ describeDb('W4C-2 Stage E gate matrix (real DB: isolation, forged authz, freeze 
     }
     const adapters: AttendanceW4LiveScheduledLegacyAdaptersV1 = {
       applyLivePunchLegacy: unreached('applyLivePunchLegacy') as never,
+      // Gate D2 (#4844): required on the adapter bag; unreached on every scheduled leg.
+      insertLivePunchEvent: unreached('insertLivePunchEvent') as never,
       applyScheduledAbsenceLegacy: async (trx, args) => {
         n += 1
         seenUserIds.push(...args.userIds)
@@ -1117,7 +1119,9 @@ describeDb('W4C-2 Stage E gate matrix (real DB: isolation, forged authz, freeze 
 
     // The operation sealed against the real record + calculation, and the outbox row still fires
     // unconditionally (unchanged from the shadow path's own behaviour for a review outcome).
-    const ops = await operationRows(authoritativeOrg, 'live')
+    // No entrypoint filter: the operation-registry entrypoint is the COMMAND KIND
+    // (`live_punch`), not the calculation-row entrypoint (`live`) asserted above.
+    const ops = await operationRows(authoritativeOrg)
     expect(ops.length).toBe(1)
     expect(ops[0].state).toBe('completed')
     expect(ops[0].resolved_record_id).toBe(parents[0].id)
@@ -1129,13 +1133,13 @@ describeDb('W4C-2 Stage E gate matrix (real DB: isolation, forged authz, freeze 
 
   it('leg 6b — authoritative SCHEDULED still fails closed BEFORE source DML (undelivered; D3 delivers it)', async () => {
     const before = await recordCount(authoritativeUser)
-    const beforeOps = (await operationRows(authoritativeOrg, 'scheduled')).length
+    const beforeOps = (await operationRows(authoritativeOrg)).length
     const adminToken = await mintToken(randomUUID(), 'attendance:read,attendance:write,attendance:admin')
     const run = await autoAbsenceRun(adminToken, { orgId: authoritativeOrg, workDate: '2026-07-22' })
     expect(run.status).toBe(503)
     expect(run.body?.error?.code).toBe('W4C2_AUTHORITATIVE_MODE_NOT_DELIVERED')
     expect(await recordCount(authoritativeUser)).toBe(before)
-    expect((await operationRows(authoritativeOrg, 'scheduled')).length).toBe(beforeOps)
+    expect((await operationRows(authoritativeOrg)).length).toBe(beforeOps)
   })
 
   it('leg 7 — accepted_write_posture cannot be silently rebased: replay after legacy->shadow promotion returns the stored legacy response unchanged; a fresh key takes the shadow path; direct UPDATE is trigger-denied', async () => {
@@ -1778,6 +1782,8 @@ describeDb('W4C-2 Stage E gate matrix (real DB: isolation, forged authz, freeze 
     let absenceCalls = 0
     const adapters: AttendanceW4LiveScheduledLegacyAdaptersV1 = {
       applyLivePunchLegacy: async () => { throw new Error('unreached') },
+      // Gate D2 (#4844): required on the adapter bag; unreached on every scheduled leg.
+      insertLivePunchEvent: async () => { throw new Error('unreached') },
       resolveLiveCandidate: async () => { throw new Error('unreached') },
       resolveScheduledCandidate: async () => ({ kind: 'unresolved' }),
       buildShadowFrozenContext: async () => { throw new Error('unreached') },
@@ -2231,6 +2237,8 @@ describeDb('W4C-2 Stage E gate matrix (real DB: isolation, forged authz, freeze 
     }
     const adapters: AttendanceW4LiveScheduledLegacyAdaptersV1 = {
       applyLivePunchLegacy: unreached('applyLivePunchLegacy') as never,
+      // Gate D2 (#4844): required on the adapter bag; unreached on every scheduled leg.
+      insertLivePunchEvent: unreached('insertLivePunchEvent') as never,
       // Zero-effect ("nobody absent") but the CALL ITSELF is the signal a
       // rejection leg must never produce — counted, never a real INSERT.
       applyScheduledAbsenceLegacy: async () => {

--- a/packages/core-backend/tests/integration/attendance-w4c2-gate-matrix-e5.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-w4c2-gate-matrix-e5.db.test.ts
@@ -421,6 +421,7 @@ describeDb('W4C-2 Stage E gate matrix (real DB: isolation, forged authz, freeze 
       applyLivePunchLegacy: unreached('applyLivePunchLegacy') as never,
       // Gate D2 (#4844): required on the adapter bag; unreached on every scheduled leg.
       insertLivePunchEvent: unreached('insertLivePunchEvent') as never,
+      deriveLivePunchWorkDateResolution: unreached('deriveLivePunchWorkDateResolution') as never,
       applyScheduledAbsenceLegacy: async (trx, args) => {
         n += 1
         seenUserIds.push(...args.userIds)
@@ -1784,6 +1785,7 @@ describeDb('W4C-2 Stage E gate matrix (real DB: isolation, forged authz, freeze 
       applyLivePunchLegacy: async () => { throw new Error('unreached') },
       // Gate D2 (#4844): required on the adapter bag; unreached on every scheduled leg.
       insertLivePunchEvent: async () => { throw new Error('unreached') },
+      deriveLivePunchWorkDateResolution: async () => { throw new Error('unreached') },
       resolveLiveCandidate: async () => { throw new Error('unreached') },
       resolveScheduledCandidate: async () => ({ kind: 'unresolved' }),
       buildShadowFrozenContext: async () => { throw new Error('unreached') },
@@ -2239,6 +2241,7 @@ describeDb('W4C-2 Stage E gate matrix (real DB: isolation, forged authz, freeze 
       applyLivePunchLegacy: unreached('applyLivePunchLegacy') as never,
       // Gate D2 (#4844): required on the adapter bag; unreached on every scheduled leg.
       insertLivePunchEvent: unreached('insertLivePunchEvent') as never,
+      deriveLivePunchWorkDateResolution: unreached('deriveLivePunchWorkDateResolution') as never,
       // Zero-effect ("nobody absent") but the CALL ITSELF is the signal a
       // rejection leg must never produce — counted, never a real INSERT.
       applyScheduledAbsenceLegacy: async () => {

--- a/packages/core-backend/tests/integration/attendance-w4c2-gate-matrix-e5.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-w4c2-gate-matrix-e5.db.test.ts
@@ -50,13 +50,15 @@
  *     punch is a values-free 403 with zero source DML, and re-activating the
  *     membership makes the identical punch write (positive control).
  *  6. "fresh authoritative calculator review creates only a retired
- *     review_placeholder ..." — NOT reachable in W4C-2: authoritative write
- *     execution is not delivered by this slice (the boundary fails closed with
- *     `W4C2_AUTHORITATIVE_MODE_NOT_DELIVERED` BEFORE source DML, and no read
- *     route filters `visibility_state` yet). This file pins that fail-closed
- *     substitute on BOTH entrypoints with zero-DML assertions; the
- *     review_placeholder read-side gate transfers to the slice that delivers
- *     authoritative execution (recorded in HANDOFF-W4C2.md + PR body).
+ *     review_placeholder ..." — SPLIT by Gate D2 (#4844), which delivered the
+ *     `live_punch` authoritative writer. Leg 6a is now the real thing at route
+ *     level: an authoritative punch whose freeze step cannot resolve a shift
+ *     yields `review_required`, the boundary's create-if-absent placeholder is
+ *     installed `legacy_untracked/NULL/retired/review_placeholder`, and the
+ *     core's review write leaves the pointer NULL. Leg 6b keeps the fail-closed
+ *     assertion for `scheduled`, which is STILL undelivered (two refusal sites
+ *     remain; D3 delivers it). No read route filters `visibility_state` yet, so
+ *     the read-side half of this obligation still transfers forward.
  *  7. "`accepted_write_posture` is immutable and cannot be silently rebased" —
  *     storage: direct UPDATE is trigger-denied (W4C0_OPERATION_STATE);
  *     behavior: after a legal legacy->shadow rollout promotion, replaying an
@@ -1066,8 +1068,19 @@ describeDb('W4C-2 Stage E gate matrix (real DB: isolation, forged authz, freeze 
     expect((await operationRows(authzOrg)).length).toBe(1)
   })
 
-  it('leg 6 — authoritative posture fails closed BEFORE source DML on both entrypoints (review_placeholder read-side gate transfers with authoritative delivery)', async () => {
-    // Live: the claim is discarded by the rollback; nothing persists.
+  // Gate D2 (#4844) SPLIT this leg. It previously asserted "fails closed BEFORE source DML on
+  // BOTH entrypoints" — true of `scheduled` still, but no longer true of `live_punch`, whose
+  // authoritative writer now ships. Splitting rather than deleting keeps the scheduled half's
+  // refusal an independently red-able assertion (it is the behavioural sibling of the delivery
+  // declaration's `scheduled: false`), and turns the live half into a positive proof that the
+  // route-level production path reaches the new writer.
+  //
+  // `authoritativeUser` has NO shift assignment in this suite's fixtures, so the freeze step's
+  // attribution resolves `unsupported` and the outcome is `review_required` — which makes this
+  // leg the ROUTE-LEVEL instance of the F6 "fresh review, parent absent" case: the boundary
+  // create-if-absent placeholder must be installed, and it must stay retired/review_placeholder
+  // with a NULL pointer after the core's review write (which never touches the parent).
+  it('leg 6a — authoritative live_punch now WRITES through the canonical authoritative path: review outcome installs the retired/review_placeholder parent and leaves the pointer NULL', async () => {
     const token = await mintToken(authoritativeUser)
     const res = await punch(token, {
       eventType: 'check_in',
@@ -1075,22 +1088,54 @@ describeDb('W4C-2 Stage E gate matrix (real DB: isolation, forged authz, freeze 
       orgId: authoritativeOrg,
       operationId: randomUUID(),
     })
-    expect(res.status).toBe(503)
-    expect(res.body?.error?.code).toBe('W4C2_AUTHORITATIVE_MODE_NOT_DELIVERED')
-    expect(res.body?.error?.message).toBe('W4C2_AUTHORITATIVE_MODE_NOT_DELIVERED')
-    expect(await eventCount(authoritativeUser)).toBe(0)
-    expect(await recordCount(authoritativeUser)).toBe(0)
-    expect((await operationRows(authoritativeOrg)).length).toBe(0)
-    expect((await outboxRows(authoritativeOrg)).length).toBe(0)
-    expect((await calculationRowsForUser(authoritativeUser)).length).toBe(0)
+    expect(res.status).toBe(200)
+    // The synthesized wire response carries all three members of the legacy contract's shape.
+    expect(res.body?.data?.event ?? res.body?.event).toBeTruthy()
 
-    // Scheduled: the administrator run fails closed the same way, zero rows.
+    // The split adapter's event INSERT ran (durable punch evidence), exactly once.
+    expect(await eventCount(authoritativeUser)).toBe(1)
+
+    // The create-if-absent placeholder exists in exactly the F6 review-path state. It is NOT
+    // outcome-conditional `active`: the core's baseline predicate would otherwise fire and demand
+    // a compatibility fingerprint for a projection that does not exist.
+    const parents = await recordRow(authoritativeUser)
+    expect(parents.length).toBe(1)
+    expect(parents[0].projection_owner).toBe('legacy_untracked')
+    expect(parents[0].current_calculation_id).toBeNull()
+    expect(parents[0].visibility_state).toBe('retired')
+    expect(parents[0].visibility_reason).toBe('review_placeholder')
+
+    // Exactly one AUTHORITATIVE review calculation, zero segment children, no pointer effect.
+    const calcs = await calculationRowsForUser(authoritativeUser)
+    expect(calcs.length).toBe(1)
+    expect(calcs[0].mode).toBe('authoritative')
+    expect(calcs[0].entrypoint).toBe('live')
+    expect(calcs[0].outcome).toBe('review_required')
+    expect(calcs[0].projection_effect).toBe('none')
+    expect(calcs[0].expected_segment_count).toBe(0)
+    expect(await segmentCountForCalculation(String(calcs[0].id))).toBe(0)
+
+    // The operation sealed against the real record + calculation, and the outbox row still fires
+    // unconditionally (unchanged from the shadow path's own behaviour for a review outcome).
+    const ops = await operationRows(authoritativeOrg, 'live')
+    expect(ops.length).toBe(1)
+    expect(ops[0].state).toBe('completed')
+    expect(ops[0].resolved_record_id).toBe(parents[0].id)
+    expect(ops[0].resolved_calculation_id).toBe(calcs[0].id)
+    const outbox = await outboxRows(authoritativeOrg)
+    expect(outbox.length).toBe(1)
+    expect(outbox[0].event_kind).toBe('attendance.punched')
+  })
+
+  it('leg 6b — authoritative SCHEDULED still fails closed BEFORE source DML (undelivered; D3 delivers it)', async () => {
+    const before = await recordCount(authoritativeUser)
+    const beforeOps = (await operationRows(authoritativeOrg, 'scheduled')).length
     const adminToken = await mintToken(randomUUID(), 'attendance:read,attendance:write,attendance:admin')
     const run = await autoAbsenceRun(adminToken, { orgId: authoritativeOrg, workDate: '2026-07-22' })
     expect(run.status).toBe(503)
     expect(run.body?.error?.code).toBe('W4C2_AUTHORITATIVE_MODE_NOT_DELIVERED')
-    expect(await recordCount(authoritativeUser)).toBe(0)
-    expect((await operationRows(authoritativeOrg)).length).toBe(0)
+    expect(await recordCount(authoritativeUser)).toBe(before)
+    expect((await operationRows(authoritativeOrg, 'scheduled')).length).toBe(beforeOps)
   })
 
   it('leg 7 — accepted_write_posture cannot be silently rebased: replay after legacy->shadow promotion returns the stored legacy response unchanged; a fresh key takes the shadow path; direct UPDATE is trigger-denied', async () => {

--- a/packages/core-backend/tests/integration/attendance-w4c2-posture-matrix.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-w4c2-posture-matrix.db.test.ts
@@ -36,8 +36,8 @@
  *
  * Outbox drain worker (lock 7.1a delivery side): with the env gate present the
  * plugin registered the drain job at activate; `runOnce` here is the EXACT
- * closure the shared scheduler ticks (module export, not a copy), and one pass
- * delivers every pending row this suite created. The paired no-env leg lives in
+ * closure the shared scheduler ticks (module export, not a copy), and it
+ * delivers every pending row THIS SUITE created. The paired no-env leg lives in
  * attendance-w4c2-live-scheduled-boundary.db.test.ts (gated=false), so
  * neutering the env gate fails that leg while this one stays green — exclusive.
  *
@@ -501,7 +501,7 @@ describeDb('W4C-2 posture matrix + V2 freeze + env-gated outbox drain (real DB, 
     ).rejects.toThrow(/W4C0_IMMUTABLE/)
   })
 
-  it('env-gated outbox drain worker: registered under this allowlist env, and ONE pass of the production closure delivers every pending row', async () => {
+  it('env-gated outbox drain worker: registered under this allowlist env, and the production closure delivers every pending row THIS SUITE created, losslessly', async () => {
     const plugin = requireCjs('../../../../plugins/plugin-attendance/index.cjs') as {
       __attendanceW4OutboxDrainForTests?: {
         getState(): { gated: boolean }
@@ -516,42 +516,85 @@ describeDb('W4C-2 posture matrix + V2 freeze + env-gated outbox drain (real DB, 
     expect(probe!.getState()).toEqual({ gated: true })
 
     // Pending rows produced by the legs above: shadow(1) + eligible control(1)
-    // + freeze(2). The org-scoped count is exact; the drain pass itself is
-    // global by design, so its counts are anchored to the global pending total
-    // (== 4 on a fresh CI database; a dirty local re-run may carry stale rows).
-    const globalPending = async () =>
+    // + freeze(2). This ORG-SCOPED count is the exact claim, and it is what the
+    // module header's intent sentence names: the closure delivers every pending
+    // row THIS SUITE created.
+    //
+    // WHY THIS NO LONGER ANCHORS ON THE GLOBAL PENDING TOTAL (#4556 Gate D2,
+    // #4844 — not drift, a real behaviour change plus a latent coupling it
+    // exposed). This leg used to assert `drained === {claimed: globalBefore,
+    // delivered: globalBefore}` over a GLOBAL count, on the assumption recorded
+    // in its old comment that the global total "== 4 on a fresh CI database" —
+    // i.e. that no other suite in the shared-DB battery leaves pending rows.
+    // That assumption was never structural, and D2 falsified it. Authoritative
+    // `live_punch` punches now SUCCEED where they previously failed closed with
+    // W4C2_AUTHORITATIVE_MODE_NOT_DELIVERED (503, whole txn rolled back, zero
+    // rows), and each one enqueues its `attendance.punched` lifecycle event —
+    // CORRECT new behaviour, and the disclosed §6.2 default. The new
+    // `attendance-w4c2-d2-live-punch-authoritative.db.test.ts` drives ~27 such
+    // punches and leaves ~27 pending rows behind (measured on an isolated DB),
+    // pushing the battery's global pending total past the dispatcher's default
+    // `batchLimit` of 100 — so ONE pass claimed 100 of 101 and the global
+    // equality failed.
+    //
+    // Attribution checked rather than assumed: `attendance-w4c2-gate-matrix-e5
+    // .db.test.ts` leg 6a is also a newly-succeeding authoritative punch, but it
+    // is NOT part of this pressure — measured in isolation, that suite's own
+    // dispatcher legs deliver its punched row, and its single leftover pending
+    // row is a pre-existing `scheduled`/`attendance.absence.generated` event on
+    // a SHADOW org, unchanged by D2.
+    //
+    // The fix is NOT to raise the batch limit (that would weaken the production
+    // closure this leg exists to exercise) and NOT to suppress the new rows
+    // (they are the correct behaviour). It is to assert what this suite can
+    // actually own. The global form was also inherently racy under vitest's
+    // parallel file execution — another suite can enqueue between the count and
+    // the pass — so it was one more suite away from flaking regardless of D2.
+    // What is asserted instead, and is exact: every pass delivers everything it
+    // claims and fails nothing, and THIS SUITE's rows all end delivered with a
+    // timestamp, with none left pending.
+    const pendingScoped = async () =>
       Number((await pool.query(
-        `SELECT count(*)::int AS n FROM attendance_result_event_outbox WHERE delivery_state = 'pending'`,
-      )).rows[0].n)
-    const pendingBefore = Number(
-      (await pool.query(
         `SELECT count(*)::int AS n FROM attendance_result_event_outbox
          WHERE delivery_state = 'pending' AND org_id = ANY($1)`,
         [[shadowOrg, eligibleOrg, freezeOrg]],
-      )).rows[0].n,
-    )
+      )).rows[0].n)
+    const pendingBefore = await pendingScoped()
     expect(pendingBefore).toBe(4)
-    const globalBefore = await globalPending()
-    expect(globalBefore).toBeGreaterThanOrEqual(4)
 
-    const drained = await probe!.runOnce()
-    expect(drained).toEqual({ claimed: globalBefore, delivered: globalBefore, failed: 0 })
+    // The production closure, drained until this suite's own rows are gone. It
+    // takes ONE pass whenever the shared backlog is within the batch limit; the
+    // bound exists only so a larger backlog degrades into extra passes instead
+    // of a false failure. Every pass is asserted to be lossless.
+    let passes = 0
+    let firstPass: { claimed: number; delivered: number; failed: number } | null = null
+    while ((await pendingScoped()) > 0) {
+      const pass = await probe!.runOnce()
+      if (firstPass === null) firstPass = pass
+      // Lossless: nothing claimed is dropped, nothing fails.
+      expect(pass.failed).toBe(0)
+      expect(pass.delivered).toBe(pass.claimed)
+      passes += 1
+      expect(passes).toBeLessThanOrEqual(10)   // terminates; never spins
+    }
+    // Non-vacuous: the first pass really did claim work — at minimum this
+    // suite's own four rows were in reach of it.
+    expect(firstPass).not.toBeNull()
+    expect(firstPass!.claimed).toBeGreaterThanOrEqual(pendingBefore)
+
     for (const orgId of [shadowOrg, eligibleOrg, freezeOrg]) {
       for (const row of await outboxRows(orgId)) {
         expect(row.delivery_state).toBe('delivered')
         expect(row.delivered_at).not.toBeNull()
       }
     }
-    // Second pass: nothing left to claim.
+    // Nothing of this suite's remains to claim. (A further pass's GLOBAL claim
+    // count is deliberately not asserted: other suites run in parallel against
+    // this database and may enqueue at any moment.)
     const again = await probe!.runOnce()
-    expect(again).toEqual({ claimed: 0, delivered: 0, failed: 0 })
-    const pendingAfter = Number(
-      (await pool.query(
-        `SELECT count(*)::int AS n FROM attendance_result_event_outbox
-         WHERE delivery_state = 'pending' AND org_id = ANY($1)`,
-        [[shadowOrg, eligibleOrg, freezeOrg]],
-      )).rows[0].n,
-    )
+    expect(again.failed).toBe(0)
+    expect(again.delivered).toBe(again.claimed)
+    const pendingAfter = await pendingScoped()
     expect(pendingAfter).toBe(0)
   })
 })

--- a/packages/core-backend/tests/integration/attendance-w4c5-rollout-transition-tool.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-w4c5-rollout-transition-tool.db.test.ts
@@ -633,14 +633,15 @@ describeIfDatabase('W4C-5 operator transition tooling (real PostgreSQL)', () => 
       expect(Object.values(byCode).filter((p) => p.applicable)).toHaveLength(11)
       expect(byCode.RETRYABLE_JOB_HAS_OPERATION_ROWS.applicable).toBe(true)
       expect(byCode.RETRYABLE_JOB_HAS_OPERATION_ROWS.count).toBe(0)
-      // This plan call runs under PRODUCTION-DEFAULT (undelivered) Gate D values — the override
-      // set for the drive-up above was reset in the `finally` block before this call — so the
-      // reporter must show the real shipped state: applicable, failing, both entrypoints
-      // undelivered.
+      // This plan call runs under PRODUCTION-DEFAULT Gate D values — the override set for the
+      // drive-up above was reset in the `finally` block before this call — so the reporter must
+      // show the real shipped state: applicable, still failing, with ONE entrypoint undelivered
+      // (`scheduled`). Gate D2 (#4844) delivered `live_punch`, dropping the count 2 -> 1; the
+      // gate itself still refuses promotion because it requires ZERO undelivered.
       expect(byCode.AUTHORITATIVE_ENTRYPOINTS_DELIVERED).toMatchObject({
         applicable: true,
         pass: false,
-        count: 2,
+        count: 1,
       })
 
       for (const statement of statements) {
@@ -919,7 +920,10 @@ describeIfDatabase('W4C-5 operator transition tooling (real PostgreSQL)', () => 
     // untouched, reds (B).
     describe('Gate D test-seam hygiene: the describe-level afterEach backstop is load-bearing', () => {
       it('(A) sets the Gate D override and relies ENTIRELY on the surrounding afterEach to clear it (no explicit clear in this test)', () => {
-        expect(isAttendanceW4C2AuthoritativeEntrypointDeliveredV1('live_punch')).toBe(false) // sanity: starts clean
+        // Shipped state after Gate D2 (#4844): live_punch DELIVERED, scheduled still undelivered.
+        // The override below still differs from it on `scheduled`, which is what keeps (B)
+        // discriminating — an un-cleared override would leave `scheduled` reading `true` there.
+        expect(isAttendanceW4C2AuthoritativeEntrypointDeliveredV1('scheduled')).toBe(false) // sanity: starts clean
         __setAttendanceW4C2AuthoritativeDeliveryOverrideForTests({ live_punch: true, scheduled: true })
         expect(isAttendanceW4C2AuthoritativeEntrypointDeliveredV1('live_punch')).toBe(true) // sanity: override is live
         expect(isAttendanceW4C2AuthoritativeEntrypointDeliveredV1('scheduled')).toBe(true)
@@ -927,7 +931,7 @@ describeIfDatabase('W4C-5 operator transition tooling (real PostgreSQL)', () => 
       })
 
       it('(B) the override set by (A) has not leaked into this test — proves the afterEach backstop actually ran', () => {
-        expect(isAttendanceW4C2AuthoritativeEntrypointDeliveredV1('live_punch')).toBe(false)
+        expect(isAttendanceW4C2AuthoritativeEntrypointDeliveredV1('live_punch')).toBe(true)
         expect(isAttendanceW4C2AuthoritativeEntrypointDeliveredV1('scheduled')).toBe(false)
       })
     })
@@ -1116,7 +1120,9 @@ describeIfDatabase('W4C-5 operator transition tooling (real PostgreSQL)', () => 
       expect(plan.legalPair).toBe(true)
       expect(plan.blocked).toBe(true)
       const authoritativePredicate = plan.predicates.find((p) => p.code === 'AUTHORITATIVE_ENTRYPOINTS_DELIVERED')
-      expect(authoritativePredicate).toMatchObject({ applicable: true, pass: false, count: 2 })
+      // count 2 -> 1 after Gate D2 (#4844) delivered `live_punch`; `scheduled` remains the one
+      // undelivered entrypoint, so the gate still refuses (it demands ZERO undelivered).
+      expect(authoritativePredicate).toMatchObject({ applicable: true, pass: false, count: 1 })
 
       const manifestPath = writeManifest(
         'gate-d-cli-promotion',

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -597,6 +597,15 @@ export default defineConfig({
       // here so the no-DB job cannot skip-green it; wired whole-file into the attendance real-DB
       // step in plugin-tests.yml (two-point wiring).
       'tests/integration/attendance-w4c2-authoritative-calculation-core.db.test.ts',
+      // #4556 W4C-2 Gate D2 (#4844): the AUTHORITATIVE `live_punch` writer's real-Postgres matrix
+      // — legacyOnlyTime reject with zero DML, the widened locked read, the create-if-absent F6
+      // placeholder (including its concurrent poison race), the default-refuse retirement guard,
+      // the split event INSERT + zero-invocation legacy-adapter pin, the canonical compat
+      // fingerprint's byte identity, payloadFingerprint embedding, seal/row fingerprint equality,
+      // and the synthesized wire response's golden key set. DATABASE_URL-gated; excluded here so
+      // the no-DB job cannot skip-green it; wired whole-file into the attendance real-DB step in
+      // plugin-tests.yml (two-point wiring).
+      'tests/integration/attendance-w4c2-d2-live-punch-authoritative.db.test.ts',
       // W4C-2 P1-2 (#4556, PR #4617 amendment, RATIFIED, owner Bundle A) — the schema/
       // migration half: scheduled-run identity tables, the outbox discriminated union,
       // the append-only per-target outcome side table, and their gates (1, 9, 11, 12 DB

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -22431,6 +22431,53 @@ async function deriveLegacyLivePunchAttributionV1(trx, { orgId, userId, occurred
   return { rule: context.rule, punchWorkDateResolution: resolution }
 }
 
+/**
+ * Gate D2 (#4556 / #4844) — the live-punch `attendance_events` INSERT, extracted verbatim from
+ * `applyLivePunchProjectionLegacyV1` below as its own injected boundary seam.
+ *
+ * WHY THIS EXISTS. `applyLivePunchProjectionLegacyV1` does TWO things: (1) this durable punch-
+ * evidence INSERT, and (2) the legacy daily `attendance_records` upsert. On the AUTHORITATIVE
+ * write path the D1 core owns the records row (its completed-path pointer UPDATE writes every
+ * daily field), so the boundary must drop (2) — but dropping the whole adapter would also drop
+ * (1), which would exclude the punch from its OWN evidence set: `loadLivePunchEvidence` reads
+ * `attendance_events` by `(user_id, org_id, work_date)`, so a day's first check-in could never
+ * produce a completed segment, every later recompute would be missing the punch, and the wire
+ * `event` would have no source. Splitting keeps (1) and drops only (2).
+ *
+ * WHY A SEPARATE SEAM RATHER THAN A `recordsUpsert:false` FLAG ON THE EXISTING ADAPTER: the
+ * P-A control-flow obligation (the authoritative branch must return before it can fall through
+ * to the shadow `applyLivePunchLegacy` call) is pinned by a ZERO-INVOCATION call-count spy on
+ * the injected `applyLivePunchLegacy`. A flag form would make that spy observe ONE invocation
+ * and degrade the pin to a weak assertion about a boolean argument. The authoritative branch
+ * never calls `applyLivePunchLegacy` at all.
+ *
+ * `applyLivePunchProjectionLegacyV1` calls THIS function for its own event INSERT, so the two
+ * paths are the same bytes by construction and cannot drift.
+ */
+async function insertLivePunchEventV1(trx, args) {
+  const { userId, orgId, workDate, eventType, source, location, meta, timezone } = args
+  const occurredAt = args.occurredAt instanceof Date ? args.occurredAt : new Date(args.occurredAt)
+  const rows = await trx.query(
+    `INSERT INTO attendance_events
+     (id, user_id, org_id, work_date, occurred_at, event_type, source, timezone, location, meta)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9::jsonb, $10::jsonb)
+     RETURNING *`,
+    [
+      randomUUID(),
+      userId,
+      orgId,
+      workDate,
+      occurredAt,
+      eventType,
+      source,
+      timezone,
+      JSON.stringify(location ?? {}),
+      JSON.stringify(meta ?? {}),
+    ]
+  )
+  return rows[0]
+}
+
 async function applyLivePunchProjectionLegacyV1(trx, args, mergePolicyPure) {
   const {
     userId,
@@ -22456,24 +22503,20 @@ async function applyLivePunchProjectionLegacyV1(trx, args, mergePolicyPure) {
   })
   const settings = await getSettings(trx)
 
-  const event = await trx.query(
-    `INSERT INTO attendance_events
-     (id, user_id, org_id, work_date, occurred_at, event_type, source, timezone, location, meta)
-     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9::jsonb, $10::jsonb)
-     RETURNING *`,
-    [
-      randomUUID(),
-      userId,
-      orgId,
-      workDate,
-      occurredAt,
-      eventType,
-      source,
-      timezone,
-      JSON.stringify(location ?? {}),
-      JSON.stringify(meta ?? {}),
-    ]
-  )
+  // Gate D2 split: the event INSERT is now the shared `insertLivePunchEventV1` seam above (same
+  // bytes, one owner) — the authoritative boundary branch calls it directly and skips the
+  // `attendance_records` upsert below, which the D1 core owns on that path.
+  const event = await insertLivePunchEventV1(trx, {
+    userId,
+    orgId,
+    workDate,
+    occurredAt,
+    eventType,
+    source,
+    location,
+    meta,
+    timezone,
+  })
 
   const protectedRecord = await loadAttendanceRecordForUpdate(trx, { userId, orgId, workDate })
   // Freeze work-date attribution on first resolved write; later corrections/recomputes
@@ -22586,7 +22629,7 @@ async function applyLivePunchProjectionLegacyV1(trx, args, mergePolicyPure) {
     }
   }
 
-  return { event: event[0], record, workDateResolution: punchWorkDateResolution }
+  return { event, record, workDateResolution: punchWorkDateResolution }
 }
 
 // W4C-2: in-transaction W2 re-resolution (freeze step) — live channel. The opt-in
@@ -24720,6 +24763,11 @@ module.exports = {
         ? attendanceW4SegmentCalculationPort.createLiveScheduledBoundary({
             legacyAdapters: {
               applyLivePunchLegacy: (trx, args) => applyLivePunchProjectionLegacyV1(trx, args, w4MergePolicyPure),
+              // Gate D2 (#4556/#4844): the split event-INSERT seam the AUTHORITATIVE live-punch
+              // branch uses. Injected ALONGSIDE `applyLivePunchLegacy` (never as a flag on it) so
+              // the authoritative path's zero-invocation spy on `applyLivePunchLegacy` stays the
+              // real control-flow pin. Same bytes as the legacy adapter's own event INSERT.
+              insertLivePunchEvent: (trx, args) => insertLivePunchEventV1(trx, args),
               applyScheduledAbsenceLegacy: (trx, args) =>
                 generateAbsenceRecords(trx, args.orgId, args.workDate, args.timezone, args.userIds),
               resolveLiveCandidate: (trx, args) => resolveW4LiveCandidateInTransactionV1(trx, args),
@@ -24751,6 +24799,13 @@ module.exports = {
       'AttendanceW4RecomputeError',
       'AttendanceW4OpsRetirementError',
       'AttendanceW4RecordBoundaryError',
+      // Gate D2 (#4556/#4844): the authoritative result-write core's own product-coded errors
+      // (VERSION_CONFLICT / REPLAY_CONFLICT / COMPLETED_SHAPE_INVALID / PREIMAGE_INVALID / …)
+      // become caller-reachable the moment the live_punch authoritative branch calls the core.
+      // Without this entry they would fall through to a raw 500 instead of their own typed
+      // status — the exact "no raw SQLSTATE/untyped failure reaches the caller" doctrine this
+      // core was built to satisfy.
+      'AttendanceW4AuthoritativeCalculationError',
     ])
     const respondIfW4BoundaryError = (res, error) => {
       if (!error || typeof error !== 'object' || !W4_ERROR_NAMES.has(error.name)) return false

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -22478,6 +22478,27 @@ async function insertLivePunchEventV1(trx, args) {
   return rows[0]
 }
 
+/**
+ * Gate D2 (#4556 / #4844) — the live-punch `workDateResolution` the WIRE RESPONSE carries.
+ *
+ * This is the SAME derivation the legacy adapter uses for the same response field
+ * (`deriveLegacyLivePunchAttributionV1`, whose `punchWorkDateResolution` becomes
+ * `result.workDateResolution` below), exposed as its own injected seam so the authoritative
+ * branch can produce a byte-shape-identical field WITHOUT re-spelling it. Deliberately NOT the
+ * boundary's own `resolveLiveCandidate`: that call opts into `includeFullWinner`, which adds a
+ * `fullWinner` member the legacy response never carries — reusing it would silently widen the
+ * public response shape. One derivation, one spelling, for both postures.
+ */
+async function deriveLivePunchWorkDateResolutionV1(trx, args) {
+  const { punchWorkDateResolution } = await deriveLegacyLivePunchAttributionV1(trx, {
+    orgId: args.orgId,
+    userId: args.userId,
+    occurredAt: args.occurredAt instanceof Date ? args.occurredAt : new Date(args.occurredAt),
+    requestTimezone: args.requestTimezone,
+  })
+  return punchWorkDateResolution
+}
+
 async function applyLivePunchProjectionLegacyV1(trx, args, mergePolicyPure) {
   const {
     userId,
@@ -24037,6 +24058,7 @@ module.exports = {
   // authoritative branch invokes it ZERO times (the P-A control-flow pin).
   __attendanceW4c2LivePunchAdaptersForTests: {
     insertLivePunchEventV1,
+    deriveLivePunchWorkDateResolutionV1,
     applyLivePunchProjectionLegacyV1,
     resolveW4LiveCandidateInTransactionV1,
     buildW4ShadowFrozenContextV1,
@@ -24778,6 +24800,11 @@ module.exports = {
               // the authoritative path's zero-invocation spy on `applyLivePunchLegacy` stays the
               // real control-flow pin. Same bytes as the legacy adapter's own event INSERT.
               insertLivePunchEvent: (trx, args) => insertLivePunchEventV1(trx, args),
+              // Gate D2 (#4556/#4844): the SAME `workDateResolution` derivation the legacy
+              // adapter uses for the same wire field, so the authoritative response carries a
+              // shape-identical value instead of a parallel spelling.
+              deriveLivePunchWorkDateResolution: (trx, args) =>
+                deriveLivePunchWorkDateResolutionV1(trx, args),
               applyScheduledAbsenceLegacy: (trx, args) =>
                 generateAbsenceRecords(trx, args.orgId, args.workDate, args.timezone, args.userIds),
               resolveLiveCandidate: (trx, args) => resolveW4LiveCandidateInTransactionV1(trx, args),

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -24031,6 +24031,16 @@ module.exports = {
     // instead of asserting it in a comment.
     normalizeDateOnly,
   },
+  // Gate D2 (#4556 / #4844): the REAL split event-INSERT seam and the REAL legacy adapter, so
+  // the D2 boundary suite drives production bytes rather than a re-implementation. Exposing the
+  // legacy adapter here is what lets that suite wrap it in a call-count spy and prove the
+  // authoritative branch invokes it ZERO times (the P-A control-flow pin).
+  __attendanceW4c2LivePunchAdaptersForTests: {
+    insertLivePunchEventV1,
+    applyLivePunchProjectionLegacyV1,
+    resolveW4LiveCandidateInTransactionV1,
+    buildW4ShadowFrozenContextV1,
+  },
   __attendanceLivePunchWorkDateForTests: {
     getPunchShiftWindow,
     isPunchWithinShiftWindow,

--- a/plugins/plugin-integration-core/lib/sealed-export/vectors/s6a-package-provenance-pins.json
+++ b/plugins/plugin-integration-core/lib/sealed-export/vectors/s6a-package-provenance-pins.json
@@ -86,6 +86,6 @@
     "s6aAcceptancePs51Test": "835c7c6ce943d82e0378a40a27c7fd1e8b79b526faa8ca4c8066e4231a4bfb0f",
     "s6aProductRuntimeTest": "de978adafa8b89772cefa921c2051f434bf346bf5c2978bef3424ee70f51ba3f",
     "multitableOnpremPackageBuild": "ae477a24375a7269e5710a3481905c9b74255c03fd802841a16849aca48ee33a",
-    "pluginTestsWorkflow": "f61a150f786fcc2a59b6ed5b8804e8f68c12247d128333771e8267bfc68a5267"
+    "pluginTestsWorkflow": "8a31a62b643e6da02341a30a9f3647c5a9aced16143a15289b8cc3a79cfc29b2"
   }
 }

--- a/scripts/attendance/w4c0-dml-inventory/curated-debt-entries.cjs
+++ b/scripts/attendance/w4c0-dml-inventory/curated-debt-entries.cjs
@@ -155,8 +155,16 @@ const CURATED_DEBT_ENTRIES = [
     owningSlice: 'W4C-2',
     sharedHook: false,
     canonicalizedBy: 'W4C-2',
+    // Gate D2 (#4844) SPLIT `applyLivePunchProjectionLegacyV1`: its `attendance_events` INSERT
+    // moved verbatim into the new `insertLivePunchEventV1` seam (which the legacy adapter itself
+    // now calls, so the two paths are one writer), and the authoritative boundary branch calls
+    // that seam directly while skipping the `attendance_records` upsert. The DML is the SAME P01
+    // live-punch event insert under a new enclosing symbol — claimed here per-writer rather than
+    // registered as a new debt id, exactly as this entry's own header describes for renamed
+    // adapter-owned sites. A genuinely NEW event/record writer added to the plugin still fails CI.
     claims: (site) =>
       bySymbol(PLUGIN, /^applyLivePunchProjectionLegacyV1$/)(site) ||
+      bySymbol(PLUGIN, /^insertLivePunchEventV1$/)(site) ||
       bySymbol(PLUGIN, /^op$/)(site) ||
       bySymbol(PLUGIN, /^upsertAttendanceRecord$/)(site),
   },
@@ -589,6 +597,28 @@ const CURATED_DEBT_ENTRIES = [
         'packages/core-backend/src/attendance/w4c2-authoritative-calculation-core.ts',
         /^writeAuthoritativeReversalV1$/,
       )(site),
+  },
+  {
+    id: 'X07',
+    title: 'W4C-2 Gate D2 live_punch authoritative branch: the create-if-absent review-path parent placeholder INSERT on attendance_records (§7.5 F6 parent-state install).',
+    owningSlice: 'W4C-2',
+    sharedHook: false,
+    // Its own Gate-D2 marker, not the 'W4C-2' removed-by-adapter marker (pinned to the four
+    // legacy P01-P04 writers) and not Gate D1's. This is the canonical authoritative-path parent
+    // creator D2 adds, not a legacy site being canonicalized away.
+    canonicalizedBy: 'W4C-2-gate-d2',
+    // The ONLY business-bucket DML the D2 boundary branch adds: an `ON CONFLICT DO NOTHING`
+    // INSERT that installs the retired/`review_placeholder` parent when the day has no record
+    // yet, so the D1 core (whose `lockParent` fails RECORD_NOT_FOUND on an absent parent, and
+    // whose `writeReviewRow` never touches `attendance_records`) has a parent to write against.
+    // Every other write on that path belongs to an already-claimed owner: the punch event INSERT
+    // is P01's (via `insertLivePunchEventV1`), and the parent pointer/visibility move is X06's
+    // (the core's own `writeCompletedRow`). Claimed per-writer BY SYMBOL so a future
+    // attendance_records writer added to this boundary file cannot inherit the claim silently.
+    claims: bySymbol(
+      'packages/core-backend/src/attendance/w4c2-live-scheduled-boundary.ts',
+      /^insertAuthoritativeReviewPlaceholderParentV1$/,
+    ),
   },
   {
     id: 'X05',

--- a/scripts/attendance/w4c0-dml-inventory/current-record-read-classification.cjs
+++ b/scripts/attendance/w4c0-dml-inventory/current-record-read-classification.cjs
@@ -11,6 +11,16 @@ function entry(relPath, enclosingSymbol, count, role) {
 
 const ATTENDANCE_RECORD_BASE_READ_CLASSIFICATIONS = Object.freeze([
   entry('packages/core-backend/src/attendance/w4c2-live-scheduled-boundary.ts', 'lockShadowParentRecord', 1, 'write_lock'),
+  // #4556 W4C-2 Gate D2 (#4844): the authoritative live-punch branch re-reads the parent row it
+  // has held `FOR UPDATE` since `lockShadowParentRecord`, AFTER the core's pointer UPDATE, to
+  // return the persisted row as the wire response's `record`. It MUST be the base table, not the
+  // current view: the response has to carry the row for a REVIEW outcome too, whose parent is a
+  // `retired`/`review_placeholder` row the view deliberately excludes — and the public punch
+  // contract has always returned the row the write just produced. This read exposes the row only
+  // to the punching actor as the acknowledgement of their own write; it is not an ordinary
+  // listing/report surface (all of which stay on the view — see the §7.5 reader trace in the
+  // boundary's own placeholder docblock).
+  entry('packages/core-backend/src/attendance/w4c2-live-scheduled-boundary.ts', 'executeLivePunch', 1, 'write_response_echo'),
   // #4556 W4C-2 Gate D1 (#4844): the INERT authoritative-result-write CORE locks the exact base
   // parent row FOR UPDATE before moving its pointer/visibility — it MUST read the base table (not
   // the current view) to serialize the pointer move and to read the true projection_owner /

--- a/scripts/ops/attendance-w4c2-ci-wiring.test.mjs
+++ b/scripts/ops/attendance-w4c2-ci-wiring.test.mjs
@@ -2210,6 +2210,7 @@ const EXPECTED_ATTENDANCE_SUITES = Object.freeze([
   'tests/integration/attendance-w4c0-identity-golden-parity.db.test.ts',
   'tests/integration/attendance-w4c0-operation-registry.db.test.ts',
   'tests/integration/attendance-w4c2-authoritative-calculation-core.db.test.ts',
+  'tests/integration/attendance-w4c2-d2-live-punch-authoritative.db.test.ts',
   'tests/integration/attendance-w4c2-gate-matrix-e5.db.test.ts',
   'tests/integration/attendance-w4c2-live-scheduled-boundary.db.test.ts',
   'tests/integration/attendance-w4c2-outbox-dispatcher.db.test.ts',


### PR DESCRIPTION
Gate D / slice **D2** (#4556, tracked under #4844): replaces the `live_punch` authoritative fail-closed sentinel in `w4c2-live-scheduled-boundary.ts` with a real writer wired to the D1 core (`writeAuthoritativeSegmentCalculationV1`, landed in #4898). `scheduled` stays undelivered — D3.

**Status: built + gated locally; awaiting owner UAT/land.** Draft on purpose. Do not merge from here.

---

## 1. Byte-neutrality — CONDITIONAL on the production environment, verifiable only against it

The `:1269` branch fires iff `posture.effectiveState === 'authoritative'` (the second disjunct, `org.acceptedWritePosture === 'authoritative'`, is not an independent DB read — it is derived from the same resolved posture witness, and `POSTURE_TABLE` maps only the `authoritative` state to that write posture, so the disjunct is strictly redundant).

`resolveSegmentCalculationPosture` (`w4c0-identity.ts:454-499`) returns `authoritative` only when **all** of: a persisted rollout row exists, its `scope` is `synthetic_staging`, the implementation-capability constant is true, **and** `isOrgExactlyAllowlisted(orgKey)` over env `ATTENDANCE_SHIFT_SEGMENT_CALCULATION_ENABLED` — where a wildcard **never** counts (`:366-372`: comma-split, exact string membership; `*` matches only an org literally named `*`).

**Stated as a conditional, because repo state cannot establish live state.** This change is byte-neutral **conditional on the production environment having no `ATTENDANCE_SHIFT_SEGMENT_CALCULATION_ENABLED` entry set and no `authoritative` rollout rows**. Given that condition, `effectiveState` collapses to `legacy` for every org irrespective of DB contents and the branch is unreachable. Repo evidence can prove the *implication*; it cannot prove the *premise* — nothing in this repository observes the deployed environment's variables or its `attendance_calculation_rollout_state` table. **A read-only verification against the named environment is therefore a required ops step before enablement**, not something this PR can discharge.

The rollout-control forward-block (`W4C3A_ROLLOUT_CONTROL_AUTHORITATIVE_ENTRYPOINT_NOT_DELIVERED`) is defence-in-depth, not the proof — and it still refuses promotion after this change, because the undelivered count moved 2 → 1 (`scheduled`), not 2 → 0.

**Not a delete, a replacement.** Deleting the branch body instead would let an allowlisted authoritative org's punch fall through to `:1285 applyLivePunchLegacy` — a silent 503→legacy-projection conversion, fail-**open** the instant the allowlist gains an entry. Pinned behaviourally by mutation **M15**.

---

## 2. What the writer does (8 steps, dependency order)

1. **legacyOnlyTime reject, zero DML.** First line of the branch: a non-strict-instant `occurredAtRaw` throws `W4_ATTRIBUTION_UNSUPPORTED` before any event/record/calc DML and before the outbox enqueue. Authoritative may never be looser than eligible. The predicate is **hoisted** from `:1276` and shared, not duplicated.
2. **Widened locked read.** `lockShadowParentRecord`'s existing single `FOR UPDATE` now also projects `projection_owner`, `current_calculation_id`, `visibility_state`, `visibility_reason`. Same read, same lock, same enclosing symbol; the shadow path ignores the extra members (`computeAttendanceW4ShadowDiff` reads only the six named daily fields + `workDate`).
3. **Parent resolution.** Absent → create-if-absent placeholder (`legacy_untracked` / pointer `NULL` / `retired` / `review_placeholder`) under `ON CONFLICT (user_id, work_date, org_id) DO NOTHING`, then **always** re-read under the lock so a race loser re-enters the full resolution path (the winner may be a legacy-**active** row). Then a **default-refuse** retirement guard: `review_placeholder` proceeds; `operator_retirement` gets its own terminal code via the existing exported sibling; **every other** retired reason refuses `ATTENDANCE_RECORD_RETIRED`.
4. **Split adapter.** New `insertLivePunchEventV1` seam — exactly the legacy adapter's `attendance_events` `INSERT … RETURNING *`, which the legacy adapter itself now calls (one owner, no drift). The `attendance_records` upsert is **dropped** on this path; the core owns that row. Injected **alongside** `applyLivePunchLegacy`, never as a flag on it — a flag would make the zero-invocation spy observe one call and destroy the control-flow pin.
5. **Preimage + compat fingerprint** via the canonical `computeAttendanceImportRollbackPreimageFingerprintV1` (byte-identical to import/rollback; never a fifth hand-rolled copy; instants read RAW `timestamptz` then normalised, and the hashed values are the stored values). `expectedCurrentCalculationId` always from the locked read.
6. **`payloadFingerprint`** derived deterministically over the resolved payload and embedded in **both** `input.payloadFingerprint` and `inputProvenance.payloadFingerprint`.
7. **Core call + boundary-recomputed seal.** `calculationTier: 'segment_authoritative'` (never the shadow builder's `legacy_shadow`), with an equality leg against the persisted row.
8. **Response + inventory.** `{event, record, workDateResolution}` PRESERVING the existing public contract — `record` is the persisted snake_case `attendance_records` row, re-SELECTed after the core's writes; `workDateResolution` is the legacy path's own derivation (see §4); the one `live_punch` refusal site removed; `DECLARED_DELIVERED.live_punch = true`; the P2 correspondence guard left **unedited** and still green (expected and actual both moved 1→0 in lockstep).

Also landed: `AttendanceW4AuthoritativeCalculationError` added to the plugin's `W4_ERROR_NAMES`, without which the core's product codes (`VERSION_CONFLICT`, `REPLAY_CONFLICT`, `COMPLETED_SHAPE_INVALID`, …) would have surfaced as raw 500s the moment the core became caller-reachable.

### D1 re-gate carry-forwards (all four, this build)

- **§5.10.1** `projected_status` TS pre-check symmetric with F2's minutes check, refusing `COMPLETED_SHAPE_INVALID` **before** the baseline append. Its domain is spelled from the migration's own `DAILY_STATUSES`, deliberately **not** reused from `ATTENDANCE_DAILY_STATUSES_V1` — that constant carries an eighth member `'off'` the DB CHECK does not admit, so reusing it would make the pre-check *wider* than the constraint it fronts (own leg + mutation M13).
- **§5.10.2** the SAME-TXN atomicity leg migrated to a **third-generation** trigger: `chk_arc_segment_snapshot_array` reached via `context.segments`, a caller-frozen field the core carries through verbatim and structurally cannot pre-validate. It asserts the **raw** constraint name and explicitly asserts the error is **not** an `AttendanceW4AuthoritativeCalculationError`, so a future pre-check cannot silently kill it a fourth time.
- **§5.10.3** `RELEASE SAVEPOINT` after `ROLLBACK TO SAVEPOINT` in the F1 catch path.
- **§5.10.4** defensive `ROLLBACK` before releasing raw connections in both F1 race legs, plus a real leg proving the invariant.

---

## 3. Test matrix — every leg, with its mutation

New real-PG suite `attendance-w4c2-d2-live-punch-authoritative.db.test.ts` (22 legs), two-point wired (vitest.config exclude + plugin-tests.yml run-list + the CI wiring guard's pinned family). It drives the **production boundary factory** over the **real plugin adapters** (exported at `__attendanceW4c2LivePunchAdaptersForTests`) with call-count spies; only the scheduled adapters, never exercised, are stubs.

| Leg | Mutation | Result |
|---|---|---|
| 1 — F6 fresh review, absent parent; exactly one `attendance.punched` | M3 (placeholder `active`) | red |
| **2 [GATING]** — fresh completed, absent parent; **no** `legacy_baseline` | M3, M5 | red |
| 3 — baseline over legacy-active; stored fp == canonical recompute | M10 (different digest) | red |
| 4 — review over legacy-active; parent bit-identical | M3 | red |
| 5 — identityDrift ⇒ review, no pointer move (+ clean negative control) | M9 (neuter the override) | red |
| 6 — retry ⇒ replay; `payloadFingerprint` persisted | M6 (strip the embedded copy) | red |
| 7 [MANDATORY] — sealed fp == persisted `semantic_input_fingerprint` | M7 (`legacy_shadow` tier) | red |
| 8 — placeholder invisible through the **canonical active-current helper** (+ positive control) | M3 | red |
| 9 — `expectedCurrentCalculationId` sourced from the locked read | **M14** (hardcode `null`) | red |
| 10 — response has event/record/workDateResolution both outcomes; snapshot == wireJson | M5 | red |
| 10b — exactly one `attendance_events` row; first check-in ⇒ segment with `actual_in_at` | M5 (drop the split INSERT) | red |
| 10c [CONTRACT] — completed `record` is the persisted snake_case row with authoritative values | **N1** (revert to the retracted mapped shape), **N2** (narrow the re-SELECT columns), **N3** (echo stale pre-write values) | red |
| 10d [CONTRACT] — review `record` is the persisted placeholder row, same column set | **N1**, **N2** | red |
| **10e [CONTRACT PARITY]** — shape-identical to a REAL legacy response, both resolution branches | **N1**, **N2**, **N4** (parallel `workDateResolution` spelling) | red |
| **10f [CONTRACT SEMANTICS]** — the echo is derived PRE-write (overnight open-record fixture) | **P1** (move the derive back post-write) | red |
| **11b [the P-A pin]** — zero `applyLivePunchLegacy` invocations (shadow control = 1) | **M15** (branch stops returning) | red |
| 12a — operator_retirement refusal over a parent retired **through the core's own reversal writer** | M2 (drop the guard) | red |
| 12b — import_rollback refusal, no reactivation | M2, **M2b** (flip the default to proceed) | red |
| 12c — anti-enumeration unit legs (synthetic/unlisted reasons) | M2b | red |
| 13a — parent `FOR UPDATE` holds through commit | — | green |
| 13b — **constructed two-connection race** on the placeholder INSERT | M4 (drop `ON CONFLICT`) | red |
| 13c — two concurrent punches serialize on the advisory target lock | M14 | red |
| 14 — legacyOnlyTime reject, zero event/record/calc/outbox DML (+ control) | **M1** (remove the reject) | red |
| 15/16/17 — correspondence guard unedited; pinned-state edits; undelivered count == 1 | — | green |
| 18 — `projected_status` product code before the baseline append (+ the `'off'` domain leg) | **M12**, **M13** | red |
| 19 — SAME-TXN atomicity, third-generation trigger | see §5.10.2 | green |
| 20 — savepoint **balance** at the statement seam | **M11** (remove the RELEASE) | red |
| 21 — clean connections after a mid-race throw | — | green |

**All 24 mutation probes discriminate** (19 from the build round + 4 for the owner fix round + 1 for the semantics round; the build round's M8/M16/M17 targeted the retracted mapped shape and are superseded by N1-N4). Every mutation was restored by re-syncing the pristine worktree over the throwaway copy — never `git checkout --`.

### Three legs were rewritten because their mutations came back GREEN

Disclosed rather than quietly fixed, because each was a test claiming more than it checked:

1. **The poison race.** Removing `ON CONFLICT DO NOTHING` left the boundary-level "two concurrent punches" leg green: through the boundary the race is already prevented one layer up by the class-11 **transaction-scoped advisory target lock**, so that fixture can never reach the INSERT contended. Split into leg 13b (a genuinely constructed two-connection race on the now-exported helper: the loser blocks on the unique index, then gets zero rows back and a still-usable transaction) and leg 13c (what the boundary fixture actually proves). The clause is **defence-in-depth for callers reaching the helper without that lock**, and its docblock says so and warns against citing 13c as evidence for it.
2. **The savepoint "cliff".** The brief's "~64 subtransaction cliff" is **not a red-able outcome**: measured directly, 200 un-released savepoints in one transaction complete fine and leave the connection usable, and the counters that would expose the SLRU overflow (`pg_stat_get_backend_subxact`) do not exist on the Postgres **14** CI pins. Replaced with a statement-stream **balance** assertion recorded at the client seam inside the genuine 2-connection race (the only path that opens a savepoint at all): `opened == released`, with the rollback-to observed. The ~80-collision batch remains as a soak leg and no longer claims to red. This is a weaker instrument than an outcome assertion and is labelled as such in the leg itself.
3. **Leg 12a's fixture.** The first version tried to install `operator_retirement` on a `legacy_untracked` parent — which `attendance_w4_records_pointer_guard` refuses — behind a `try/catch` that would have made the leg silently vacuous. Rebuilt through the core's own `writeAuthoritativeReversalV1`, so the fixture is a row the DB validates end to end, with an explicit assertion that the row actually reached the state under test.

Two further review findings, fixed in the last commit: **leg 9's title** claimed a boundary VERSION_CONFLICT its body never triggered (unreachable there by construction — the core-level refusal is already proven in the D1 suite), and **leg 8** asserted that a `visibility_state='active'` filter the test itself wrote does filter. Both retitled/re-pointed. An **ineffective mutation** (M10's first form, `sha256Hex(...) && real`, which short-circuits to the real value) was caught and re-run in a form that actually changes the digest.

---

## 4. Owner items — five, not four

**§6.1 Response contract — RESOLVED by owner ruling; the contract is PRESERVED, nothing left to confirm.**

An earlier revision of this build returned a mapped camelCase `record` (nine `PreparedDailyProjectionV1` fields, all-null for review) and a synthesized five-key `workDateResolution`, shipped as an `[OWNER-CONFIRM]` default. **Owner ruling: tests only FREEZE a change, they do not APPROVE it.** That shape was a breaking change to the published `POST /api/attendance/punch` contract — the mobile client and the OpenAPI `AttendanceRecord` shape both expect the snake_case `attendance_records` row the legacy path returns — and pinning it in a golden test approved nothing.

**What ships now:** the re-SELECT alternative the brief had already specified. After the core's writes land inside the same transaction, the boundary re-SELECTs the persisted `attendance_records` row and returns it verbatim; `workDateResolution` comes from `deriveLegacyLivePunchAttributionV1`'s own `punchWorkDateResolution` — literally the same derivation the legacy adapter uses for the same field, injected as its own seam rather than re-spelled. An authoritative punch response is now **shape-identical to a legacy punch response** (field set and casing); only the **values** differ, reflecting the authoritative projection. For a review outcome the `record` is the persisted placeholder row, not a synthesized acknowledgement.

Deliberately **not** reused for `workDateResolution`: the boundary's own `resolveLiveCandidate` result. It opts into `includeFullWinner`, which adds a `fullWinner` member the public response never carried — substituting it would have silently widened the contract.

**Any future protocol change here is out of scope for this build**: it would require an independent RATIFY plus OpenAPI/SDK/client updates, not a side effect of delivering the authoritative writer.

**§6.2 `punched` outbox for a review-only authoritative outcome.** Unchanged (unconditional enqueue), pinned as-is by legs 1 and 14 pending the ruling.

**§6.3 `[FORK]` import-rollback reactivation eligibility.** D2 default = **NO**, explicit `ATTENDANCE_RECORD_RETIRED` refuse. The canonical fingerprint is computed regardless, so neither ruling leaves a latent landmine.

**§6.4 `context_mismatch` CHECK enum — RESOLVED at build time, not blocking.** `context_mismatch` is a member of `REVIEW_REASONS` in the durable-storage migration (`:119-140`), so `chk_arc_outcome_reason` / `chk_arc_outcome_reason_pair` admit it. No remediation needed.

**§7.5 daily-field shape — ADJUDICATED, no owner ruling needed.** An earlier revision of this body listed this as a fifth owner item with a possible nullability migration. The independent gate adjudicated it and that framing was wrong, so it is withdrawn. The lock (`…design-lock-20260724.md:1502-1505`) requires a **four-tuple** of parent-state columns for a fresh authoritative review — `legacy_untracked` / pointer-null / `retired` / `review_placeholder` — which is exactly what this build writes. "Every mutable W4-owned daily field NULL" was the **build brief's** amplification of §7.5, not lock text; it is also unsatisfiable, since four of those six columns are `NOT NULL`. The lock's rationale clause — "ordinary readers see no fabricated `normal` zero-minute row" — **holds**: every daily-VALUE surface filters visibility (records list/export, report + multitable sync, period/payroll summary, missed-punch candidates, comprehensive-hours all read the `attendance_current_records` view; one route filters `r.visibility_state = 'active'` inline at `plugins/plugin-attendance/index.cjs:30197`; anomaly listing / makeup facts / open-record attribution / DecisionTrace go through the canonical `w4c3c-active-current` helper), and the one ordinary-permission base-table read without a visibility predicate, `readAttendanceCalculationDetail`, selects **zero daily columns** and is the calculation-detail path §7.6:1526-1527 explicitly permits to read retired parents. Leg 8 pins the canonical helper with a positive control. **No owner ruling and no migration are required**; the writer's docblock now records this as a disclosure rather than a deviation, with the fabrication comparison stated honestly (this row fabricates MORE than the import-side precedent, which has a real projection to write and therefore fabricates nothing).

---

## 5. Inventory, pin, and collateral edits

- **DML inventory** (unconditional, both syntaxes, collectors run — not hand-edited): P01's claim predicate extended over the renamed split writer `insertLivePunchEventV1` (same P01 event INSERT, new enclosing symbol — exactly the renamed-adapter-site case that entry's own header describes); **new X07** claims the placeholder INSERT by symbol. The widened `FOR UPDATE` needed no new classification (same symbol, still one read). The post-core **re-SELECT** — the brief's conditional site, now unconditional because the owner picked the re-SELECT response — is classified as `write_response_echo` in `current-record-read-classification.cjs`: it must read the BASE table, because a REVIEW response has to carry the `retired`/`review_placeholder` row the `attendance_current_records` view deliberately excludes, and the punch contract has always echoed the row the write just produced. `node --test scripts/ops/attendance-w4c0-dml-inventory-collector.test.mjs` → **58/58, unclaimed = 0**.
- **Source hygiene — a raw NUL byte removed from the source.** The live-punch payload fingerprint's domain separator was written with a LITERAL `0x00` byte, which made `file(1)` classify `w4c2-live-scheduled-boundary.ts` as `data` and made `grep`/`rg` treat it as binary and skip it **silently**. That is a real hazard here, not a cosmetic one: this repo's DML and SELECT-inventory collectors are source-TEXT scanners, so a module that reads as binary can drop out of an audit with nothing failing. It is now the escape `\u0000`, extracted to an exported constant, and the file reports `Unicode text, UTF-8`. The runtime string is unchanged — proven, not asserted, by a new no-DB test that pins the domain's exact code units AND a `sha256` digest computed by an **independent oracle** (`python3 -c "import hashlib; …"` over the same literal bytes), so the value cannot be back-fitted from whatever the implementation happens to produce. The `w4c1` fingerprint golden/gate suites are unaffected and unchanged (13/13).
- **s6a pin** regenerated for `pluginTestsWorkflow` **only** (the D2 run-list entry is the sole workflow change); verified by `sealed-export-package-provenance.test.cjs`. Exactly one line of the pins JSON moved.
- **CI wiring guard** pinned family extended with the new suite → **229/229**.
- **E5 leg 6 split**: 6a is now the route-level proof that `live_punch` writes through the canonical authoritative path (its `authoritativeUser` has no shift, so the outcome is `review_required` — making it the route-level instance of F6 fresh-review-absent-parent); 6b keeps the fail-closed 503 assertion for `scheduled`. E5's own header updated. Its direct scheduled boundary builders now carry the required `insertLivePunchEvent` seam (unreached on every scheduled leg).
- **w4c5 rollout-transition-tool**: `AUTHORITATIVE_ENTRYPOINTS_DELIVERED.count` 2 → 1 in two places; the Gate-D test-seam-hygiene pair re-anchored on `scheduled` (still the key that differs from the shipped declaration, so leg (B) stays discriminating).
- `w4c3a-rollout-control.db.test.ts` needed **no** edit — its P3 "production default" leg still refuses, because one entrypoint remains undelivered.

## 4b. Response contract — SEMANTICS, not only shape

The echoed `workDateResolution` is derived **before** any write this operation makes to
`attendance_records`, which is where the legacy path derives it. This is load-bearing, not
cosmetic: the resolver's highest-precedence tie-break consults OPEN records
(`w4c3c-active-current.ts:176-190` — `first_in_at IS NOT NULL AND last_out_at IS NULL`, through the
`visibility_state='active'` view), and the core's completed-path pointer UPDATE writes exactly that
shape for a check-in-only day and flips the row to `active`. A derivation placed after the core call
can therefore observe the record **this operation just created** and echo a resolution the legacy
path could never produce for the same punch. Only the echo is affected — the persisted calculation
freezes the pre-core `authoritativeResolution` — but the ruling is that the authoritative response
matches the legacy contract *semantics included*.

**Leg 10f** proves it with a real divergence rather than an ordering argument: an overnight shift
(22:00→06:00) plus a check-in at 01:00 local puts the punch's `calendarWorkDate` on the next day
while the winning candidate's own `workDate` is the previous one — the exact precondition the
open-record branch requires. The same derivation yields `PREVIOUS_NIGHT_CONTAINING_SHIFT` before the
punch and `OPEN_PREVIOUS_NIGHT_RECORD` after it; the leg measures both, asserts they differ (so the
main assertion is not vacuous), and asserts the response carried the pre-write value. Moving the
derive back post-write reds it exclusively.

## 5b. Rollout hazards (enablement-time; unreachable today) — DISCLOSED, not patched

Two consequences of the review placeholder that are **not code defects in this diff** and are not reachable while the env allowlist is unset, but that are **enablement semantics the rollout/soak runbook must resolve BEFORE any org is promoted**. Both anchors re-verified directly against the source, not taken on faith.

**(a) Nothing clears `review_placeholder`, so an allowlist ROLLBACK can hide a real day.** The legacy punch upsert's `ON CONFLICT (user_id, work_date, org_id) DO UPDATE SET …` (`plugins/plugin-attendance/index.cjs:20059-20077`) writes the six daily columns but never `visibility_state`, `visibility_reason` or `projection_owner`, and its pre-check refuses only `operator_retirement` — `review_placeholder` passes. So: org allowlisted → a review-outcome punch installs `retired`/`review_placeholder` → org removed from the allowlist (explicitly contemplated: `w4c0-identity.ts:451-452`, "removing the env entry alone never rewrites history — it only stops advertising") → subsequent punches take the legacy path and write **real** values onto a row that is still `retired` → every surface in the §7.5 trace above excludes it. The user's genuine attendance for that day becomes invisible, silently.

**(b) A review placeholder suppresses that day's auto-absence row.** `generateAbsenceRecords` (`plugins/plugin-attendance/index.cjs:22816-22820`) gates on `NOT EXISTS (SELECT 1 FROM attendance_records r WHERE …)` — the **base** table, no visibility filter — so a placeholder means no absence row is generated. Arguably correct in isolation (the user did punch), but combined with (a) it is how a day can render as **nothing at all**: no visible attendance row and no absence row.

**Required before promotion, not before landing:** the runbook must define clearing/backfill semantics for `review_placeholder` — either the legacy upsert clears it, or the rollback tooling does, or D3 owns it — and must state the intended auto-absence behaviour for a placeholder day. Neither blocks this PR: the branch is unreachable in production (§1), so neither state can arise until an owner-actioned allowlist change creates it.

## 5c. A shared-DB coupling this change exposed (and the test it broke)

CI failed one deterministic test outside the suite set this PR touches:
`attendance-w4c2-posture-matrix.db.test.ts` > the env-gated outbox-drain leg, with
`expected {claimed:100,delivered:100} to deeply equal {claimed:101,delivered:101}`.

**Diagnosed by measurement, and the first hypothesis was wrong.** That leg asserted the drain's
counts against a **global** pending-row total, resting on its own recorded assumption that the total
"== 4 on a fresh CI database" — i.e. that no other suite in the shared-DB battery leaves pending
rows. The dispatcher's default `batchLimit` is 100, so the assertion silently required the shared
backlog to stay under 100 forever. Measuring each suite alone on its own fresh database:

| suite | pending rows left | is it new? |
|---|---|---|
| the new `attendance-w4c2-d2-live-punch-authoritative.db.test.ts` | **27** | **yes** — ~27 authoritative punches, each correctly enqueueing `attendance.punched` (the §6.2 default) |
| `attendance-w4c2-gate-matrix-e5.db.test.ts` | 1 | **no** — inspected directly: it is `entrypoint='scheduled'`, `event_kind='attendance.absence.generated'`, on a **shadow** org. E5's own dispatcher legs deliver its new authoritative punched row, so E5 contributes no new pending pressure |

So the pressure is the new D2 suite's 27, not a "+1" from E5. Reproduced locally by running the full
108-file CI run-list against a freshly migrated database: same failure, `{claimed:100}` vs
`{claimed:102}` (the global total moves by a row or two between runs because vitest executes these
files in parallel — which is also why the global form was racy on its own terms, one suite away from
flaking regardless of this PR).

**The fix preserves the leg's documented intent and touches neither the production closure nor the
new rows.** That module's own header states the intent as "delivers every pending row **this suite
created**", and its org-scoped assertions already express exactly that. Only the global equality is
dropped. The leg now drains in a bounded loop until this suite's own rows are gone, asserting per
pass that the closure is **lossless** (`delivered === claimed`, `failed === 0`), that the first pass
claimed at least this suite's four rows (non-vacuity), and that every one of this suite's rows ends
`delivered` with a timestamp and none is left pending. `batchLimit` is unchanged — raising it would
weaken the very closure the leg exists to exercise — and the new outbox rows are unchanged, because
they are correct behaviour. The comment records the measurement so the next reader does not read it
as drift.

## 6. Local verification

- `tsc --noEmit` clean; `pnpm lint` clean.
- `src/attendance/__tests__` → **541/541** (41 files, including the new payload-fingerprint domain pin).
- **Full CI-equivalent battery** (the complete 108-file attendance real-DB run-list from `plugin-tests.yml`, against a freshly created and migrated database): **108/108 files, 1499/1499 tests, exit 0.** The 10-suite set used earlier in this build provably under-covered — it is what let the outbox-drain coupling reach CI.
- Real-PG, on a **freshly created and migrated** database, in one invocation: D2 (21) + D1 core (41) + E5 (30) + w4c5 tool (31) + rollout-control (69) + posture-matrix (5) + live/scheduled boundary (8) + freeze-anchor (16) + manual/recompute/retirement (13) + import-rollback (49) → **283/283**.
- Collectors, provenance pin, CI wiring guard: green (above).

*Disclosed:* an earlier run against a long-lived reused scratch DB showed two failures (the posture-matrix global outbox-drain leg and one E5 leg). Diagnosed as accumulated undelivered outbox rows from repeated local runs crossing the drain's batch cap — **not** a regression: on a fresh DB all suites pass and every outbox row ends `delivered`. This suite contributes ~19 outbox rows per run; no cleanup was added, because deleting/updating that trigger-guarded append-only table to shave margin is the larger risk.

*Environment note:* the nested-worktree checkout used for development trips `resolvePluginAttendanceLibPath[REPO_ROOT_AMBIGUOUS]` for any suite that boots the server, so all real-PG runs above were executed from a non-nested copy of the same tree. Unrelated to this change; it affects the pre-existing E5/posture-matrix suites identically.

---

## 7. Scope held

`DECLARED_DELIVERED.scheduled` stays `false`; both of its refusal sites remain; no other flag touched. **Forward obligation for D3:** the core stays reason-blind (`lockParent` omits `visibility_reason`; the pointer UPDATE reactivates unconditionally), so D3 must replicate the §3b boundary retirement guard or land the optional core extension with it — now recorded in the core's own docblock as an open seam alongside the two D2 obligations this change discharges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015dKije7Ai3KMwXcWmLzj8A
