### PR TITLE
feat(attendance): Gate D3 — wire scheduled authoritative writes to the D1 core (#4556)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -1346,6 +1346,7 @@ jobs:
             tests/integration/attendance-w4c2-gate-matrix-e5.db.test.ts \
             tests/integration/attendance-w4c2-authoritative-calculation-core.db.test.ts \
             tests/integration/attendance-w4c2-d2-live-punch-authoritative.db.test.ts \
+            tests/integration/attendance-w4c2-d3-scheduled-authoritative.db.test.ts \
             tests/integration/attendance-w4c2-p2-remediation.db.test.ts \
             tests/integration/attendance-w4c2-p2-1-canonical-freeze-anchor.db.test.ts \
             tests/integration/attendance-w4c2-p12-migration-schema-gates.db.test.ts \

--- a/packages/core-backend/src/attendance/__tests__/w4c2-outcome-allowlist.test.ts
+++ b/packages/core-backend/src/attendance/__tests__/w4c2-outcome-allowlist.test.ts
@@ -6,11 +6,45 @@ import ts from 'typescript'
 
 const WRITER_NAME = 'recordAttendanceScheduledRunTargetOutcomeV1'
 const OUTCOME_TABLE = 'attendance_scheduled_run_target_outcomes'
+/**
+ * Gate D3 (#4844): the ONE failure reason the run registry's own writer validates
+ * (`w4c2-scheduled-run.ts` refuses any other value with
+ * `W4C2_SCHEDULED_RUN_OUTCOME_REASON_INVALID`, and refuses the shape unless it is exactly the two
+ * keys `{terminalOutcome, failureReasonCode}`). Spelled here so this static guard admits EXACTLY the
+ * shape the runtime writer admits, and nothing wider.
+ */
+const CONTAINED_FAILURE_REASON = 'ATTENDANCE_SCHEDULED_TARGET_OPERATION_REJECTED'
 
 interface WriterScanResult {
   readonly completed: string[]
+  /**
+   * Gate D3 (#4844) — the contained per-target refusal. Before D3 the `'failed'` terminal outcome
+   * had ZERO production writers and this scanner correctly bucketed any `'failed'` call as UNSAFE.
+   * D3 ships the first one deliberately (the authoritative scheduled writer's containment path), so
+   * a literal-`'failed'` call carrying the single allowlisted literal reason code is now its own
+   * bucket rather than being either forbidden or quietly folded into `completed`. Everything else
+   * about the scanner is unchanged: a dynamic outcome, an indirect alias, a different reason code,
+   * a non-literal reason code, or a third key still lands in `unsafe`.
+   */
+  readonly containedFailure: string[]
   readonly unsafe: string[]
   readonly outcomeTableWrites: string[]
+}
+
+/** A literal `failureReasonCode: '<the one allowlisted code>'` and NOTHING else beyond the two keys. */
+function isContainedFailureShape(outcome: ts.ObjectLiteralExpression): boolean {
+  if (outcome.properties.length !== 2) return false
+  const reason = outcome.properties.find(
+    (property): property is ts.PropertyAssignment =>
+      ts.isPropertyAssignment(property) &&
+      ((ts.isIdentifier(property.name) && property.name.text === 'failureReasonCode') ||
+        (ts.isStringLiteral(property.name) && property.name.text === 'failureReasonCode')),
+  )
+  return (
+    reason !== undefined &&
+    ts.isStringLiteral(reason.initializer) &&
+    reason.initializer.text === CONTAINED_FAILURE_REASON
+  )
 }
 
 function listProductionFiles(root: string): string[] {
@@ -44,6 +78,7 @@ function scanSource(file: string, source: string): WriterScanResult {
   const sourceFile = ts.createSourceFile(file, source, ts.ScriptTarget.Latest, true, scriptKind)
   const localWriterNames = new Set<string>()
   const completed: string[] = []
+  const containedFailure: string[] = []
   const unsafe: string[] = []
   const outcomeTableWrites: string[] = []
 
@@ -78,6 +113,15 @@ function scanSource(file: string, source: string): WriterScanResult {
         terminalOutcome.initializer.text === 'completed'
       ) {
         completed.push(callsite)
+      } else if (
+        terminalOutcome &&
+        ts.isStringLiteral(terminalOutcome.initializer) &&
+        terminalOutcome.initializer.text === 'failed' &&
+        outcome &&
+        ts.isObjectLiteralExpression(outcome) &&
+        isContainedFailureShape(outcome)
+      ) {
+        containedFailure.push(callsite)
       } else {
         unsafe.push(callsite)
       }
@@ -119,16 +163,17 @@ function scanSource(file: string, source: string): WriterScanResult {
     outcomeTableWrites.push(`${file}:${start.line + 1}`)
   }
 
-  return { completed, unsafe, outcomeTableWrites }
+  return { completed, containedFailure, unsafe, outcomeTableWrites }
 }
 
 function scanProductionSources(): WriterScanResult {
   const coreSrc = fileURLToPath(new URL('../../', import.meta.url))
   const pluginSrc = fileURLToPath(new URL('../../../../../plugins/plugin-attendance', import.meta.url))
-  const result: WriterScanResult = { completed: [], unsafe: [], outcomeTableWrites: [] }
+  const result: WriterScanResult = { completed: [], containedFailure: [], unsafe: [], outcomeTableWrites: [] }
   for (const file of [...listProductionFiles(coreSrc), ...listProductionFiles(pluginSrc)]) {
     const scanned = scanSource(file, readFileSync(file, 'utf8'))
     result.completed.push(...scanned.completed)
+    result.containedFailure.push(...scanned.containedFailure)
     result.unsafe.push(...scanned.unsafe)
     result.outcomeTableWrites.push(...scanned.outcomeTableWrites)
   }
@@ -136,9 +181,15 @@ function scanProductionSources(): WriterScanResult {
 }
 
 describe('W4C-2 OD-W4C-54=(a) production outcome allowlist', () => {
-  it('keeps both production outcome calls literal-completed and the canonical writer as the only table writer', () => {
+  it('keeps every production outcome call to a LITERAL allowlisted shape (three completed + the ONE Gate D3 contained failure) and the canonical writer as the only table writer', () => {
     const result = scanProductionSources()
-    expect(result.completed).toHaveLength(2)
+    // 2 -> 3: Gate D3 (#4844) added the authoritative scheduled branch's own completed call,
+    // alongside the pre-existing legacy_compat and shadow ones.
+    expect(result.completed).toHaveLength(3)
+    // The FIRST production writer of the `'failed'` terminal outcome, and there must be exactly
+    // one: the containment path in the authoritative scheduled branch.
+    expect(result.containedFailure).toHaveLength(1)
+    expect(result.containedFailure[0]).toMatch(/w4c2-live-scheduled-boundary\.ts:\d+$/)
     expect(result.unsafe).toEqual([])
     expect(result.outcomeTableWrites).toHaveLength(1)
     expect(result.outcomeTableWrites[0]).toMatch(/w4c2-scheduled-run\.ts:\d+$/)
@@ -168,5 +219,35 @@ describe('W4C-2 OD-W4C-54=(a) production outcome allowlist', () => {
       `db.insertInto('${OUTCOME_TABLE}').values({ terminal_outcome: 'failed' }).execute()`,
     )
     expect(queryBuilderWrite.outcomeTableWrites).toHaveLength(1)
+  })
+
+  it('Gate D3 (#4844): the contained-failure bucket admits EXACTLY the allowlisted shape and nothing wider', () => {
+    const good = scanSource(
+      'good.ts',
+      `import { ${WRITER_NAME} } from './w4c2-scheduled-run'
+       ${WRITER_NAME}(trx, identity, { terminalOutcome: 'failed', failureReasonCode: '${CONTAINED_FAILURE_REASON}' })`,
+    )
+    expect(good.containedFailure).toHaveLength(1)
+    expect(good.unsafe).toEqual([])
+
+    // Every way of being WIDER than the runtime writer's own validation must fail closed here too.
+    const wider: ReadonlyArray<readonly [string, string]> = [
+      ['a different reason code', `{ terminalOutcome: 'failed', failureReasonCode: 'SOMETHING_ELSE' }`],
+      ['a non-literal reason code', `{ terminalOutcome: 'failed', failureReasonCode: reason }`],
+      ['no reason code at all', `{ terminalOutcome: 'failed' }`],
+      [
+        'a third key smuggled alongside the allowlisted pair',
+        `{ terminalOutcome: 'failed', failureReasonCode: '${CONTAINED_FAILURE_REASON}', refusingCode: 'x' }`,
+      ],
+    ]
+    for (const [label, literal] of wider) {
+      const scanned = scanSource(
+        'wider.ts',
+        `import { ${WRITER_NAME} } from './w4c2-scheduled-run'
+         ${WRITER_NAME}(trx, identity, ${literal})`,
+      )
+      expect({ label, contained: scanned.containedFailure.length }).toEqual({ label, contained: 0 })
+      expect({ label, unsafe: scanned.unsafe.length }).toEqual({ label, unsafe: 1 })
+    }
   })
 })

--- a/packages/core-backend/src/attendance/__tests__/w4c2-scheduled-authoritative-seam-structure.test.ts
+++ b/packages/core-backend/src/attendance/__tests__/w4c2-scheduled-authoritative-seam-structure.test.ts
@@ -1,0 +1,158 @@
+/**
+ * W4C-2 Gate D3 (#4556 / #4844) — STATIC structure legs for the authoritative `scheduled` writer.
+ *
+ * Everything here is a source-TEXT assertion, and source-text assertions are not behaviour
+ * assertions — they are stated as the narrow things they are, and each one names the behavioural leg
+ * that actually pins the property:
+ *
+ *  - the ONE-SEAM property (leg 6d) is a structural invariant with no runtime observable of its own:
+ *    "there is exactly one place that can produce a skip, and the guard dominates it". Its
+ *    behavioural consequence is pinned by the real-DB retirement legs (6a/6b/4a) — move the guard
+ *    after the skip return and those red. This file pins the STRUCTURE so the ordering cannot be
+ *    quietly reintroduced somewhere the DB legs happen not to cover.
+ *  - the refusal-site legs (leg 16) complement the correspondence guard in
+ *    `w4c3a-rollout-control-inventory.test.ts`, which after D3 is a zero-versus-zero identity on
+ *    real content; the behavioural pins are the zero-invocation adapter spy and the probe-routing
+ *    leg in the D3 real-DB suite.
+ *  - the D2 carry-forward presence check (leg 20) is a "verify, do NOT re-do" gate: if a
+ *    carry-forward is missing on this base, that is a BASE defect to surface, not something D3
+ *    silently re-implements.
+ *
+ * No-DB: runs in the ungated `src/attendance/__tests__` set.
+ */
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const ATTENDANCE_DIR = path.join(__dirname, '..')
+const BOUNDARY = path.join(ATTENDANCE_DIR, 'w4c2-live-scheduled-boundary.ts')
+const CORE = path.join(ATTENDANCE_DIR, 'w4c2-authoritative-calculation-core.ts')
+
+function read(file: string): string {
+  return fs.readFileSync(file, 'utf8')
+}
+
+/** Brace-matched body of a named `function` declaration. Deliberately not a real parser. */
+function functionBody(content: string, name: string): string {
+  const decl = new RegExp(`(?:async\\s+)?function\\s+${name}\\s*\\(`).exec(content)
+  expect(decl, `function ${name} must exist in the source`).not.toBeNull()
+  const parenOpen = content.indexOf('(', (decl as RegExpExecArray).index)
+  let parenDepth = 0
+  let i = parenOpen
+  for (; i < content.length; i += 1) {
+    if (content[i] === '(') parenDepth += 1
+    else if (content[i] === ')') {
+      parenDepth -= 1
+      if (parenDepth === 0) break
+    }
+  }
+  const braceStart = content.indexOf('{', i + 1)
+  let braceDepth = 0
+  for (let j = braceStart; j < content.length; j += 1) {
+    if (content[j] === '{') braceDepth += 1
+    else if (content[j] === '}') {
+      braceDepth -= 1
+      if (braceDepth === 0) return content.slice(braceStart, j + 1)
+    }
+  }
+  throw new Error(`unbalanced braces locating ${name}`)
+}
+
+describe('W4C-2 Gate D3 — authoritative scheduled seam structure', () => {
+  it('leg 6d — exactly ONE `kind: \'skip\'` construction site exists in the boundary, and it is lexically inside resolveAuthoritativeScheduledParentV1', () => {
+    const content = read(BOUNDARY)
+    // A CONSTRUCTION site, not a mention: the union type's own `{ readonly kind: 'skip' }` member
+    // must not count, or the leg would be pinning a type declaration rather than a code path.
+    const construction = /return\s*\{\s*kind:\s*'skip'/g
+    expect([...content.matchAll(construction)].length).toBe(1)
+    const seam = functionBody(content, 'resolveAuthoritativeScheduledParentV1')
+    expect([...seam.matchAll(construction)].length).toBe(1)
+    // And the union declares the variant exactly once, so "one construction site" cannot be true
+    // merely because a second variant spelling was introduced elsewhere.
+    expect([...content.matchAll(/kind:\s*'skip'/g)].length).toBe(2)
+    // Positive control on the extractor: it really extracted a bounded body, not the whole file.
+    expect(seam.length).toBeGreaterThan(200)
+    expect(seam.length).toBeLessThan(content.length / 2)
+  })
+
+  it('leg 6d — the retirement guard is called on EVERY return path of the seam: it precedes both returns, and no return precedes it', () => {
+    const seam = functionBody(read(BOUNDARY), 'resolveAuthoritativeScheduledParentV1')
+    const guardIndex = seam.indexOf('assertParentNotRetiredForAuthoritativePunchV1(')
+    expect(guardIndex).toBeGreaterThan(-1)
+    // Exactly one guard call — two would invite one of them being deleted while the leg stays green.
+    expect(seam.split('assertParentNotRetiredForAuthoritativePunchV1(').length - 1).toBe(1)
+    const returns = [...seam.matchAll(/\breturn\b/g)].map((m) => m.index as number)
+    // Both `{kind:'write'}` and `{kind:'skip'}` returns exist...
+    expect(returns.length).toBe(2)
+    expect(seam).toContain("kind: 'write'")
+    expect(seam).toContain("kind: 'skip'")
+    // ...and BOTH sit after the guard call. This is the ordering defect the design review caught:
+    // a skip placed before the guard would seal `{inserted:false, completed}` over an
+    // operator_retirement / import_rollback parent.
+    for (const index of returns) expect(index).toBeGreaterThan(guardIndex)
+  })
+
+  it('leg 16 — ZERO `not delivered` refusal call sites remain in the boundary, and the core file still never spells that code as a boundaryFail call', () => {
+    // Assembled at runtime so this test file cannot match its own source in the repo-wide scan the
+    // inventory suite runs.
+    const codeName = ['W4C2', 'AUTHORITATIVE_MODE_NOT_DELIVERED'].join('_')
+    const boundary = read(BOUNDARY)
+    // Any quoted spelling, any status — wider than the strict call form, so a reintroduced site
+    // written differently still fails this.
+    const quoted = new RegExp(`(['"])${codeName}\\1`, 'g')
+    expect([...boundary.matchAll(quoted)].length).toBe(0)
+    // Positive control on the scanner: it does find a planted occurrence.
+    expect([...`const x = '${codeName}'`.matchAll(new RegExp(`(['"])${codeName}\\1`, 'g'))].length).toBe(1)
+    // Non-vacuity: the file really was read and really is the boundary.
+    expect(boundary).toContain('executeScheduledRunInternal')
+    expect(boundary).toContain('resolveAuthoritativeScheduledParentV1')
+    // The core has never owned this code and must not start.
+    const core = read(CORE)
+    expect(new RegExp(`boundaryFail\\(\\s*['"]${codeName}['"]`).test(core)).toBe(false)
+    expect([...core.matchAll(quoted)].length).toBe(0)
+  })
+
+  it('leg 16 — the boundary savepoint reuses the core\'s own spelling (SAVEPOINT / ROLLBACK TO / RELEASE), and the contained path issues all three', () => {
+    const boundary = read(BOUNDARY)
+    const branch = functionBody(boundary, 'executeScheduledRunInternal')
+    expect(branch).toContain('SAVEPOINT ${authoritativeSavepoint}')
+    expect(branch).toContain('ROLLBACK TO SAVEPOINT ${authoritativeSavepoint}')
+    // Two releases: the success path's and the contained path's (after the rollback).
+    expect(branch.split('RELEASE SAVEPOINT ${authoritativeSavepoint}').length - 1).toBe(3)
+    // The claim MUST be disposed before the outcome insert on the contained path — the deferred
+    // commit guard makes committing a still-claimed operation illegal. Order is asserted, not
+    // assumed (the behavioural pin is leg 4e, whose mutation reds AT COMMIT).
+    const cancelIndex = branch.indexOf('cancelAttendanceResultOperationV1(trx, identity)')
+    const failedOutcomeIndex = branch.indexOf("terminalOutcome: 'failed'")
+    expect(cancelIndex).toBeGreaterThan(-1)
+    expect(failedOutcomeIndex).toBeGreaterThan(cancelIndex)
+  })
+
+  it('leg 20 — D2/D1 carry-forwards are PRESENT on this base (verify, do NOT re-do): projected_status pre-check, RELEASE SAVEPOINT in the F1 catch path, and the widened locked read', () => {
+    const core = read(CORE)
+    // (1) The projected_status product-code pre-check, symmetric with F2's minutes check.
+    expect(core).toContain('AUTHORITATIVE_PROJECTED_STATUSES_V1')
+    expect(core).toMatch(/if \(!AUTHORITATIVE_PROJECTED_STATUSES_V1\.has\(projection\.status\)\)/)
+    // ...and it is spelled independently of ATTENDANCE_DAILY_STATUSES_V1, whose eighth member 'off'
+    // the DB CHECK does not admit.
+    expect(core).not.toMatch(/AUTHORITATIVE_PROJECTED_STATUSES_V1[^\n]*ATTENDANCE_DAILY_STATUSES_V1/)
+    // (2) RELEASE SAVEPOINT after ROLLBACK TO in the F1 (uq_arc_operation) catch path.
+    const writer = functionBody(core, 'writeAuthoritativeSegmentCalculationV1')
+    const rollbackIndex = writer.indexOf('ROLLBACK TO SAVEPOINT ${savepoint}')
+    expect(rollbackIndex).toBeGreaterThan(-1)
+    expect(writer.indexOf('RELEASE SAVEPOINT ${savepoint}', rollbackIndex)).toBeGreaterThan(rollbackIndex)
+    // (3) The widened locked read D2 added for ALL callers — D3 consumes it and must not add a
+    // second read.
+    const boundary = read(BOUNDARY)
+    const lockedRead = functionBody(boundary, 'lockShadowParentRecord')
+    for (const column of [
+      'projection_owner',
+      'current_calculation_id',
+      'visibility_state',
+      'visibility_reason',
+    ]) {
+      expect(lockedRead).toContain(column)
+    }
+    expect(lockedRead.split('FOR UPDATE').length - 1).toBe(1)
+  })
+})

--- a/packages/core-backend/src/attendance/__tests__/w4c2-scheduled-authoritative-seam-structure.test.ts
+++ b/packages/core-backend/src/attendance/__tests__/w4c2-scheduled-authoritative-seam-structure.test.ts
@@ -58,6 +58,25 @@ function functionBody(content: string, name: string): string {
   throw new Error(`unbalanced braces locating ${name}`)
 }
 
+/**
+ * The source text of a TOP-LEVEL function declaration, from its `function` keyword to the first
+ * line that is exactly `}` at column 0.
+ *
+ * Deliberately separate from `functionBody` above: that one locates the body by finding the first
+ * `{` after the parameter list, which for a declaration whose return type is an object type
+ * (`: Promise<{ created: boolean }>`) lands on the RETURN-TYPE annotation and yields a two-word
+ * "body". Measured — the first form of the leg below reported `'{ created: boolean }'`. This
+ * line-based slice has no such failure mode for a top-level declaration.
+ */
+function topLevelDeclarationText(content: string, name: string): string {
+  const lines = content.split('\n')
+  const startIndex = lines.findIndex((line) => new RegExp(`^(?:export )?(?:async )?function ${name}\\b`).test(line))
+  expect(startIndex, `top-level function ${name} must exist`).toBeGreaterThan(-1)
+  const endOffset = lines.slice(startIndex).findIndex((line, i) => i > 0 && line === '}')
+  expect(endOffset, `top-level function ${name} must have a column-0 closing brace`).toBeGreaterThan(0)
+  return lines.slice(startIndex, startIndex + endOffset + 1).join('\n')
+}
+
 describe('W4C-2 Gate D3 — authoritative scheduled seam structure', () => {
   it('leg 6d — exactly ONE `kind: \'skip\'` construction site exists in the boundary, and it is lexically inside resolveAuthoritativeScheduledParentV1', () => {
     const content = read(BOUNDARY)
@@ -128,7 +147,47 @@ describe('W4C-2 Gate D3 — authoritative scheduled seam structure', () => {
     expect(failedOutcomeIndex).toBeGreaterThan(cancelIndex)
   })
 
-  it('leg 20 — D2/D1 carry-forwards are PRESENT on this base (verify, do NOT re-do): projected_status pre-check, RELEASE SAVEPOINT in the F1 catch path, and the widened locked read', () => {
+  it('leg 9 DISCHARGED BY CITATION — the placeholder poison race is D2\'s leg 13b on a seam D3 does not modify: the `ON CONFLICT DO NOTHING` clause and that leg are both still present', () => {
+    // WHAT THIS IS AND IS NOT. D3 does NOT re-run the placeholder poison race. It adds a SECOND
+    // CALL SITE to `insertAuthoritativeReviewPlaceholderParentV1` and changes nothing inside it, so
+    // the constructed two-connection race D2 already runs directly on that exported seam
+    // (`attendance-w4c2-d2-live-punch-authoritative.db.test.ts`, leg 13b) covers the D3 call site
+    // exactly as it covers the D2 one. Re-running it here would duplicate a leg, not add coverage.
+    //
+    // A citation is only worth anything if the cited thing still exists and the property it rests
+    // on is still in the code — so both are asserted mechanically rather than trusted, and BOTH
+    // halves are stated: this is a presence check, NOT a behavioural re-proof.
+    const helper = topLevelDeclarationText(read(BOUNDARY), 'insertAuthoritativeReviewPlaceholderParentV1')
+    expect(helper).toContain('ON CONFLICT (user_id, work_date, org_id) DO NOTHING')
+    // The scheduled seam calls that exact helper (a second call site, not a re-implementation), so
+    // no parallel placeholder writer slipped in alongside it.
+    const seam = topLevelDeclarationText(read(BOUNDARY), 'resolveAuthoritativeScheduledParentV1')
+    expect(seam).toContain('insertAuthoritativeReviewPlaceholderParentV1(trx, {')
+    expect(seam).not.toContain('INSERT INTO attendance_records')
+    // And the cited leg is still in the D2 suite under the title this citation names.
+    const d2Suite = fs.readFileSync(
+      path.join(
+        __dirname,
+        '..',
+        '..',
+        '..',
+        'tests',
+        'integration',
+        'attendance-w4c2-d2-live-punch-authoritative.db.test.ts',
+      ),
+      'utf8',
+    )
+    expect(d2Suite).toContain('leg 13b: a CONSTRUCTED two-connection race on the create-if-absent placeholder INSERT')
+  })
+
+  it('leg 20 — the D2/D1 carry-forwards this file can check STATICALLY are present (verify, do NOT re-do); the other two are covered by the core suite being green, not by this leg', () => {
+    // SCOPE, stated so the leg's title is not read as wider than its body. The brief names FOUR
+    // carry-forwards. Exactly two are statically checkable from here and are checked below (the
+    // `projected_status` pre-check and the `RELEASE SAVEPOINT` in the F1 catch path), plus the
+    // widened locked read D3 consumes. The other two — the third-generation SAME-TXN atomicity
+    // trigger and the defensive `ROLLBACK` before release in the two race tests — are covered by
+    // `attendance-w4c2-authoritative-calculation-core.db.test.ts` passing in the real-DB battery,
+    // which is a different kind of evidence and is NOT claimed here.
     const core = read(CORE)
     // (1) The projected_status product-code pre-check, symmetric with F2's minutes check.
     expect(core).toContain('AUTHORITATIVE_PROJECTED_STATUSES_V1')

--- a/packages/core-backend/src/attendance/__tests__/w4c2-scheduled-contained-refusal.test.ts
+++ b/packages/core-backend/src/attendance/__tests__/w4c2-scheduled-contained-refusal.test.ts
@@ -1,0 +1,152 @@
+/**
+ * W4C-2 Gate D3 (#4556 / #4844) — the scheduled per-target CONTAINMENT predicate, walked
+ * MECHANICALLY over its own membership table.
+ *
+ * WHAT IS ACTUALLY AT STAKE. `isAttendanceScheduledContainedRefusalV1` decides, for every error the
+ * authoritative `scheduled` writer branch can throw, whether the batch RECORDS a terminal `'failed'`
+ * outcome for that one target and continues, or ABORTS so recovery/resume re-attempts it. Getting it
+ * too WIDE burns a transient failure terminally (resume never re-loops a target that already has an
+ * outcome row); getting it too NARROW turns one refused target into a dead batch. Both directions
+ * are pinned here.
+ *
+ * WHY TABLE-DRIVEN RATHER THAN A LIST OF HAND-WRITTEN CASES. The predicate's membership authority is
+ * ONE exported frozen table. The positive walk below iterates THAT table, so adding a class to it
+ * automatically extends the proof instead of silently widening an undescribed predicate. The
+ * counterpart risk — the table being emptied, which would make a `.some(...)` walk vacuously green —
+ * is closed by the non-vacuity assertions on the table itself.
+ *
+ * WHY IDENTITY AND NOT `.name`. `plugins/plugin-attendance/index.cjs` dispatches on `error.name`
+ * ONLY because that call site crosses a CJS/ESM module-loading boundary where constructor identity
+ * is not shared. Inside this package the identity IS available, and `.name` is a plain writable
+ * property — so an object literal can forge it. The impostor case below is the probe that the
+ * predicate never degrades into name matching.
+ *
+ * No-DB, no fixtures: this runs in the ungated `src/attendance/__tests__` set.
+ */
+import { describe, expect, it } from 'vitest'
+import {
+  ATTENDANCE_W4C2_SCHEDULED_CONTAINED_REFUSAL_CLASSES_V1,
+  AttendanceW4LiveScheduledBoundaryError,
+  isAttendanceScheduledContainedRefusalV1,
+} from '../w4c2-live-scheduled-boundary'
+import { AttendanceW4AuthoritativeCalculationError } from '../w4c2-authoritative-calculation-core'
+import { AttendanceW4OpsRetirementError } from '../w4c3c-ops-retirement'
+import { AttendanceW4OperationError } from '../w4c0-operation-contract'
+
+/** Both member classes share the `(code, httpStatus)` constructor shape. */
+type RefusalClassCtor = new (code: string, httpStatus?: number) => Error
+
+describe('W4C-2 Gate D3 — scheduled contained-refusal predicate', () => {
+  const TABLE = ATTENDANCE_W4C2_SCHEDULED_CONTAINED_REFUSAL_CLASSES_V1
+
+  it('the membership table is non-empty, frozen, and holds exactly the two classes D3 declares — a silently emptied table would make the walk below vacuous', () => {
+    expect(TABLE.length).toBeGreaterThan(0)
+    expect(Object.isFrozen(TABLE)).toBe(true)
+    // Identity, not names: this is the assertion that reds if a class is dropped from the table.
+    expect([...TABLE]).toEqual([
+      AttendanceW4AuthoritativeCalculationError,
+      AttendanceW4OpsRetirementError,
+    ])
+  })
+
+  // PER-CLASS POSITIVE WALK. One `it` per table entry, generated from the table itself, so a class
+  // added to the table gets its own leg with no edit here and a class removed loses its leg loudly.
+  for (const cls of TABLE) {
+    it(`contains a product-coded ${cls.name} instance (table entry walked)`, () => {
+      const instance = new (cls as unknown as RefusalClassCtor)('PROBE_CONTAINED_CODE', 409)
+      expect(instance).toBeInstanceOf(cls)
+      expect(isAttendanceScheduledContainedRefusalV1(instance)).toBe(true)
+    })
+
+    it(`does NOT contain a ${cls.name} instance whose \`code\` has been stripped — membership needs a product code, not just class identity`, () => {
+      const instance = new (cls as unknown as RefusalClassCtor)('PROBE_CONTAINED_CODE', 409)
+      // The (a) half of the predicate. This is the case that reds when the `code` check is deleted.
+      Object.defineProperty(instance, 'code', { value: undefined, configurable: true })
+      expect(instance).toBeInstanceOf(cls)
+      expect(isAttendanceScheduledContainedRefusalV1(instance)).toBe(false)
+      // An empty-string code is equally not a product code.
+      Object.defineProperty(instance, 'code', { value: '', configurable: true })
+      expect(isAttendanceScheduledContainedRefusalV1(instance)).toBe(false)
+    })
+  }
+
+  it('the real refusals the D3 writer branch can raise are contained — the two ops-retirement 409s and a representative core code', () => {
+    // These are the codes the branch actually reaches: the guard's two terminal 409s, and the D1
+    // core's closed enumeration (one representative; the class, not the string, is what decides).
+    expect(
+      isAttendanceScheduledContainedRefusalV1(
+        new AttendanceW4OpsRetirementError('ATTENDANCE_RECORD_OPERATOR_RETIRED', 409),
+      ),
+    ).toBe(true)
+    expect(
+      isAttendanceScheduledContainedRefusalV1(
+        new AttendanceW4OpsRetirementError('ATTENDANCE_RECORD_RETIRED', 409),
+      ),
+    ).toBe(true)
+    expect(
+      isAttendanceScheduledContainedRefusalV1(
+        new AttendanceW4AuthoritativeCalculationError(
+          'ATTENDANCE_W4_AUTH_CALC_EXPECTED_COUNT_INVALID',
+          422,
+        ),
+      ),
+    ).toBe(true)
+    // Deliberate over-breadth, recorded rather than left implicit: the ops-retirement class also
+    // carries codes the D3 branch cannot reach today. Containing by CLASS covers them, which fails
+    // toward "one target marked failed, batch continues" rather than "the whole batch aborts".
+    expect(
+      isAttendanceScheduledContainedRefusalV1(
+        new AttendanceW4OpsRetirementError('W4C3C_OPS_RETIREMENT_REPLAY_CONFLICT', 409),
+      ),
+    ).toBe(true)
+  })
+
+  it('does NOT contain the boundary error class — `W4C2_AUTHORITATIVE_PARENT_UNRESOLVED` (500) must ABORT so resume re-attempts the target', () => {
+    const boundaryError = new AttendanceW4LiveScheduledBoundaryError(
+      'W4C2_AUTHORITATIVE_PARENT_UNRESOLVED',
+      500,
+    )
+    // It IS product-coded, so this proves the class table (b) half discriminates, not the code (a)
+    // half: a predicate that only checked for a non-empty `code` would wrongly contain this.
+    expect(typeof boundaryError.code).toBe('string')
+    expect(boundaryError.code.length).toBeGreaterThan(0)
+    expect(isAttendanceScheduledContainedRefusalV1(boundaryError)).toBe(false)
+  })
+
+  it('does NOT contain the operation error class — org suspension is run-wide, not a per-target outcome', () => {
+    const suspended = new AttendanceW4OperationError('SEGMENT_CALCULATION_SUSPENDED')
+    expect(typeof suspended.code).toBe('string')
+    expect(isAttendanceScheduledContainedRefusalV1(suspended)).toBe(false)
+  })
+
+  it('does NOT contain untyped or forged shapes — bare Error, plain object, impostor `name`, and non-objects', () => {
+    // A bare Error: no product code, no class membership.
+    expect(isAttendanceScheduledContainedRefusalV1(new Error('boom'))).toBe(false)
+    // A raw pg-shaped error carrying a SQLSTATE in `code`: product-coded by the (a) test, but not a
+    // member class — 40001/40P01 belong to the two retry layers, everything else aborts.
+    const pgLike = Object.assign(new Error('serialization failure'), { code: '40001' })
+    expect(isAttendanceScheduledContainedRefusalV1(pgLike)).toBe(false)
+    // A plain object literal with a code.
+    expect(isAttendanceScheduledContainedRefusalV1({ code: 'X' })).toBe(false)
+    // THE IMPOSTOR. Forges the `name` of a member class AND carries a real product code. A
+    // `.name`-based predicate would contain this; an identity-based one must not.
+    const impostor = {
+      name: 'AttendanceW4AuthoritativeCalculationError',
+      code: 'ATTENDANCE_W4_AUTH_CALC_PREIMAGE_INVALID',
+      message: 'ATTENDANCE_W4_AUTH_CALC_PREIMAGE_INVALID',
+    }
+    expect(impostor.name).toBe(AttendanceW4AuthoritativeCalculationError.name)
+    expect(isAttendanceScheduledContainedRefusalV1(impostor)).toBe(false)
+    // Same forgery on a real Error instance, so "it wasn't an Error" cannot be the reason it failed.
+    const impostorError = Object.assign(new Error('x'), {
+      name: 'AttendanceW4OpsRetirementError',
+      code: 'ATTENDANCE_RECORD_RETIRED',
+    })
+    expect(isAttendanceScheduledContainedRefusalV1(impostorError)).toBe(false)
+    // Non-objects.
+    expect(isAttendanceScheduledContainedRefusalV1(null)).toBe(false)
+    expect(isAttendanceScheduledContainedRefusalV1(undefined)).toBe(false)
+    expect(isAttendanceScheduledContainedRefusalV1('ATTENDANCE_RECORD_RETIRED')).toBe(false)
+    expect(isAttendanceScheduledContainedRefusalV1(409)).toBe(false)
+  })
+})

--- a/packages/core-backend/src/attendance/__tests__/w4c2-scheduled-payload-fingerprint-domain.test.ts
+++ b/packages/core-backend/src/attendance/__tests__/w4c2-scheduled-payload-fingerprint-domain.test.ts
@@ -1,0 +1,140 @@
+/**
+ * W4C-2 Gate D3 (#4556 / #4844) — the SCHEDULED payload fingerprint's domain separator is pinned BY
+ * BYTES, its digest is pinned against an INDEPENDENT oracle, and the producer is pinned to derive
+ * from the resolved command payload alone.
+ *
+ * The scheduled sibling of `w4c2-live-punch-payload-fingerprint-domain.test.ts`, and it exists for
+ * the same two reasons:
+ *
+ *  1. The domain ends in a NUL. Written as a RAW 0x00 byte in the `.ts` source it makes `file(1)`
+ *     classify the module as `data` and makes `grep`/`rg` treat it as binary and skip it SILENTLY —
+ *     a real hazard, because the repo's own DML and SELECT-inventory collectors are source-TEXT
+ *     scanners, so a module that reads as binary can drop out of an audit with nothing failing. The
+ *     escape `\u0000` must produce the identical runtime string, and "an escape equals the raw byte"
+ *     is a claim to MEASURE, not assert.
+ *  2. The digest is load-bearing for retry idempotency: the D1 core reads
+ *     `input_provenance.payloadFingerprint` verbatim off the stored row and fails `REPLAY_CONFLICT`
+ *     on a mismatch. If the domain or the canonical payload projection moves silently, a genuine
+ *     retry starts refusing.
+ *
+ * Both digest oracles below were computed OUTSIDE this codebase (`python3 -c "import hashlib; ..."`
+ * over the same literal bytes), so they cannot be back-fitted from whatever the implementation
+ * happens to produce.
+ *
+ * No-DB, no fixtures: this runs in the ungated `src/attendance/__tests__` set.
+ */
+import crypto from 'node:crypto'
+import { describe, expect, it } from 'vitest'
+import {
+  ATTENDANCE_W4C2_LIVE_PUNCH_PAYLOAD_FINGERPRINT_DOMAIN_V1,
+  ATTENDANCE_W4C2_SCHEDULED_PAYLOAD_FINGERPRINT_DOMAIN_V1,
+  computeAuthoritativeScheduledPayloadFingerprintV1,
+} from '../w4c2-live-scheduled-boundary'
+
+describe('W4C-2 Gate D3 — scheduled payload fingerprint domain', () => {
+  const DOMAIN = ATTENDANCE_W4C2_SCHEDULED_PAYLOAD_FINGERPRINT_DOMAIN_V1
+
+  it('is the exact byte sequence the raw-NUL literal would encode — escape and raw byte are the same runtime string', () => {
+    // Built here from a JS escape, i.e. independently of how the source spells it.
+    const expected = 'metasheet2:attendance:w4c2:scheduled-authoritative-payload:v1' + '\u0000'
+    expect(DOMAIN).toBe(expected)
+    expect(DOMAIN.length).toBe(62)
+    expect(DOMAIN.charCodeAt(DOMAIN.length - 1)).toBe(0)
+    // Exactly ONE NUL, and it terminates the string — not a stray one mid-domain.
+    expect(DOMAIN.split('\u0000').length - 1).toBe(1)
+    expect(DOMAIN.slice(0, -1)).toBe('metasheet2:attendance:w4c2:scheduled-authoritative-payload:v1')
+    // UTF-8 encodes to the same length (pure ASCII plus the NUL), so the bytes fed to the hash are
+    // exactly the code units asserted above.
+    expect(Buffer.byteLength(DOMAIN, 'utf8')).toBe(62)
+  })
+
+  it('is DISJOINT from the live-punch domain — the two entrypoints can never mint the same digest for the same bytes', () => {
+    expect(DOMAIN).not.toBe(ATTENDANCE_W4C2_LIVE_PUNCH_PAYLOAD_FINGERPRINT_DOMAIN_V1)
+    // Not merely unequal strings: neither is a prefix of the other, so no payload appended to one
+    // can reproduce a value derived from the other.
+    expect(DOMAIN.startsWith(ATTENDANCE_W4C2_LIVE_PUNCH_PAYLOAD_FINGERPRINT_DOMAIN_V1)).toBe(false)
+    expect(ATTENDANCE_W4C2_LIVE_PUNCH_PAYLOAD_FINGERPRINT_DOMAIN_V1.startsWith(DOMAIN)).toBe(false)
+    const probe = '{"probe":1}'
+    expect(
+      crypto.createHash('sha256').update(DOMAIN + probe, 'utf8').digest('hex'),
+    ).not.toBe(
+      crypto
+        .createHash('sha256')
+        .update(ATTENDANCE_W4C2_LIVE_PUNCH_PAYLOAD_FINGERPRINT_DOMAIN_V1 + probe, 'utf8')
+        .digest('hex'),
+    )
+  })
+
+  it('produces the domain digest an INDEPENDENT oracle computes for the same input', () => {
+    // Oracle: python3 -c "import hashlib; print(hashlib.sha256(
+    //   ('metasheet2:attendance:w4c2:scheduled-authoritative-payload:v1\\x00' + '{\"probe\":1}')
+    //   .encode('utf8')).hexdigest())"
+    const ORACLE_DIGEST = '38576b82c254057121ddc44ccaedcb72c3dc5297c3fecb2370eae06f9b841038'
+    const digest = crypto.createHash('sha256').update(DOMAIN + '{"probe":1}', 'utf8').digest('hex')
+    expect(digest).toBe(ORACLE_DIGEST)
+  })
+
+  it('the PRODUCER reproduces an INDEPENDENT oracle over the resolved command payload — domain + canonical projection both pinned end to end', () => {
+    // Oracle (canonical JSON = sorted keys, JSON.stringify per value, no whitespace):
+    //   python3 -c "import hashlib; print(hashlib.sha256((
+    //     'metasheet2:attendance:w4c2:scheduled-authoritative-payload:v1\\x00'
+    //     + '{\"expectedRunVersion\":1,\"scheduledAbsenceSource\":\"auto_absence_cron\",'
+    //       '\"scheduledRunId\":\"11111111-1111-4111-8111-111111111111\",'
+    //       '\"userId\":\"22222222-2222-4222-8222-222222222222\",\"workDate\":\"2026-05-04\"}'
+    //   ).encode('utf8')).hexdigest())"
+    const ORACLE_DIGEST = 'b3b2920efe3de3fe2492f95cf88b69f6aa0ca4d4dd19a0bd44bcd49a360ec97f'
+    expect(
+      computeAuthoritativeScheduledPayloadFingerprintV1({
+        scheduledRunId: '11111111-1111-4111-8111-111111111111',
+        userId: '22222222-2222-4222-8222-222222222222',
+        workDate: '2026-05-04',
+        expectedRunVersion: 1,
+        scheduledAbsenceSource: 'auto_absence_cron',
+      }),
+    ).toBe(ORACLE_DIGEST)
+  })
+
+  it('is DETERMINISTIC in the payload and SENSITIVE to every one of its five fields', () => {
+    const base = {
+      scheduledRunId: '11111111-1111-4111-8111-111111111111',
+      userId: '22222222-2222-4222-8222-222222222222',
+      workDate: '2026-05-04',
+      expectedRunVersion: 1,
+      scheduledAbsenceSource: 'auto_absence_cron',
+    }
+    const baseline = computeAuthoritativeScheduledPayloadFingerprintV1(base)
+    // Same payload, computed twice, across a clock tick: no clock, no random, no operation id.
+    expect(computeAuthoritativeScheduledPayloadFingerprintV1({ ...base })).toBe(baseline)
+    expect(baseline).toMatch(/^[0-9a-f]{64}$/)
+    // Single-field perturbation, one field at a time — a field silently dropped from the canonical
+    // projection would leave its perturbation digest equal to the baseline.
+    const perturbations: ReadonlyArray<Partial<typeof base>> = [
+      { scheduledRunId: '11111111-1111-4111-8111-111111111112' },
+      { userId: '22222222-2222-4222-8222-222222222223' },
+      { workDate: '2026-05-05' },
+      { expectedRunVersion: 2 },
+      { scheduledAbsenceSource: 'auto_absence_admin_run' },
+    ]
+    for (const perturbation of perturbations) {
+      expect(
+        computeAuthoritativeScheduledPayloadFingerprintV1({ ...base, ...perturbation }),
+      ).not.toBe(baseline)
+    }
+    // All five perturbed digests are distinct from each other too, so no two fields collapse into
+    // one canonical slot.
+    const digests = perturbations.map((perturbation) =>
+      computeAuthoritativeScheduledPayloadFingerprintV1({ ...base, ...perturbation }),
+    )
+    expect(new Set(digests).size).toBe(perturbations.length)
+  })
+
+  it('the source file spells the NUL as an escape, so static text scanners do not skip this module', () => {
+    // The property the escape exists for, asserted directly rather than trusted: a raw 0x00 in the
+    // source is what makes `file(1)` report `data` and makes grep/rg bail out. Both domains live in
+    // the same module, so this covers the D3 addition as well as the D2 one.
+    const fs = require('node:fs') as typeof import('node:fs')
+    const path = require('node:path') as typeof import('node:path')
+    const source = fs.readFileSync(path.join(__dirname, '..', 'w4c2-live-scheduled-boundary.ts'))
+    expect(source.includes(0x00)).toBe(false)
+  })
+})

--- a/packages/core-backend/src/attendance/__tests__/w4c3a-rollout-control-inventory.test.ts
+++ b/packages/core-backend/src/attendance/__tests__/w4c3a-rollout-control-inventory.test.ts
@@ -373,22 +373,46 @@ describe('Gate D: W4C2 authoritative-entrypoint delivery declaration <-> boundar
     scheduled: 'executeScheduledRunInternal',
   })
 
-  // Independently counted by reading the boundary source at this PR's reviewed head: `live_punch`
-  // (inside `executeLivePunch`) has exactly 0 refusal call sites — Gate D2 (#4844) shipped its
-  // authoritative writer and removed the one site it had; `scheduled` (inside
-  // `executeScheduledRunInternal`, both its org-wide probe and its per-target loop — the SAME
-  // command kind per that module's own header) still has exactly 2. Checked PER KEY against a
-  // source-range-scoped count below (`attributeRefusalCallsV1`), never against a whole-file sum.
+  // Independently counted by reading the boundary source at this PR's reviewed head: BOTH keys now
+  // have exactly 0 refusal call sites. Gate D2 (#4844) shipped the `live_punch` authoritative writer
+  // and removed the one site it had; Gate D3 (#4844) shipped the `scheduled` authoritative writer
+  // and removed BOTH of its sites (the org-wide probe arm became a routing fall-through, the
+  // per-target arm became the writer). Checked PER KEY against a source-range-scoped count below
+  // (`attributeRefusalCallsV1`), never against a whole-file sum.
   //
   // WHY THE WEIGHT ITSELF MOVES (not just the declaration): this table is the "how many sites
   // SHOULD exist while undelivered" side of the correspondence. `expectedByKeyV1()` reads it only
-  // for keys declared UNDELIVERED, so once `live_punch` is delivered its expected count is 0 by
-  // the delivery declaration alone. Leaving the weight at 1 would still break the cross-key
-  // aggregate leg below, which reads the raw weights directly.
+  // for keys declared UNDELIVERED, so once a key is delivered its expected count is 0 by the
+  // delivery declaration ALONE — the weight is inert there. The weight edit is required by the
+  // re-formed legs below that read the raw weights directly, NOT by the P2 correspondence
+  // assertion. Do not read "P2 stays green" as evidence that the weight edit was the reason.
+  //
+  // THE HONEST STATE OF THIS DESCRIBE-BLOCK AFTER D3, stated where a reviewer will find it: with
+  // both entrypoints delivered and both actual counts 0, every leg that reads the REAL boundary
+  // content is now a ZERO-VERSUS-ZERO identity. "P2 green with the guard unedited" evidences that
+  // the declaration and the source agree AT ZERO; it no longer evidences anything about the
+  // boundary's behaviour. The discriminating power of this file lives entirely in the SYNTHETIC
+  // legs — the planted-decoy positive controls below, in both directions (a reintroduced refusal
+  // site inside a MAPPED function; a refusal site inside an UNMAPPED function; a refusal site
+  // inside no named function at all). The behavioural pins for the writers are the real-DB
+  // zero-invocation legacy-adapter spies and the probe-routing legs, not this file.
   const REFUSAL_SITE_WEIGHT: Readonly<Record<AttendanceW4C2AuthoritativeEntrypointV1, number>> = Object.freeze({
     live_punch: 0,
-    scheduled: 2,
+    scheduled: 0,
   })
+
+  /**
+   * The refusal code name assembled at RUNTIME from two literals, never spelled as one contiguous
+   * quoted token in this file's own source text — otherwise this test file itself turns up in the
+   * repo-wide "exactly one file" scan below (the exact self-match hazard `REFUSAL_CALL_PATTERN`'s
+   * own comment names). Every synthetic decoy in this block builds its source through this.
+   */
+  const SYNTHETIC_REFUSAL_CODE_NAME = ['W4C2', 'AUTHORITATIVE_MODE_NOT_DELIVERED'].join('_')
+
+  /** A refusal call in the EXACT strict form (`boundaryFail('...', 503)`, single quotes). */
+  function syntheticStrictRefusalCall(): string {
+    return `boundaryFail('${SYNTHETIC_REFUSAL_CODE_NAME}', 503)`
+  }
 
   // Exact literal call, not a loose substring: does not match the module header's own prose
   // mention of the bare code string (backticked, never inside a `boundaryFail(...)` call). Used
@@ -528,17 +552,45 @@ describe('Gate D: W4C2 authoritative-entrypoint delivery declaration <-> boundar
     __setAttendanceW4C2AuthoritativeDeliveryOverrideForTests(null)
   })
 
-  it('the exact refusal-call pattern occurs in exactly one git-tracked src file: the boundary itself', () => {
+  it('the exact refusal-call pattern occurs in ZERO git-tracked src files after Gate D3 — and the scanner that says so still detects a planted match (decoy positive control)', () => {
     const files = listGitTrackedFiles(ROOT).filter((absolute) =>
       path.relative(ROOT, absolute).split(path.sep).join('/').startsWith('packages/core-backend/src/'),
     )
     const matches = files
       .filter((absolute) => countRefusalCalls(fs.readFileSync(absolute, 'utf8')) > 0)
       .map((absolute) => path.relative(ROOT, absolute).split(path.sep).join('/'))
-    expect(matches).toEqual([BOUNDARY_RELATIVE_FILE])
+    // Both writers are delivered, so no source file carries the refusal call any more. Formerly
+    // this asserted `[BOUNDARY_RELATIVE_FILE]`; it is now an EMPTY read, and an empty read on its
+    // own is not evidence of absence — a scanner that reads nothing, or a pattern that matches
+    // nothing anywhere, produces exactly this result. The two controls below are what make it
+    // evidence.
+    expect(matches).toEqual([])
+    // (a) NON-VACUITY OF THE SWEEP: the file list is real and includes the boundary itself, so the
+    //     emptiness above came from reading real content, not from an empty/misrooted file list.
+    expect(files.length).toBeGreaterThan(0)
+    expect(
+      files.map((absolute) => path.relative(ROOT, absolute).split(path.sep).join('/')),
+    ).toContain(BOUNDARY_RELATIVE_FILE)
+    // (b) POSITIVE CONTROL ON THE SCANNER: plant the exact call form in a synthetic source and
+    //     prove `countRefusalCalls` still sees it. If a future edit breaks the pattern, THIS reds
+    //     instead of the empty assertion silently staying green forever.
+    const plantedSource = [
+      'function executeScheduledRunInternal(x) {',
+      `  ${syntheticStrictRefusalCall()}`,
+      '  return x',
+      '}',
+    ].join('\n')
+    expect(countRefusalCalls(plantedSource)).toBe(1)
+    // And the scanner is not so loose that any mention counts: the backtick-quoted spelling the
+    // boundary's own module header uses must NOT match.
+    expect(countRefusalCalls(`// see \`${SYNTHETIC_REFUSAL_CODE_NAME}\` in the header`)).toBe(0)
   })
 
-  it('attribution machinery negative control: every refusal call is either attributed or counted unattributed — none silently dropped', () => {
+  // VACUITY DISCLOSURE (Gate D3): on the REAL boundary content this conservation check is now
+  // 0 === 0, because there are no refusal calls left to conserve. It is kept because it costs
+  // nothing and reds if a site is ever reintroduced in a shape the attribution loop drops, but its
+  // discriminating power today lives in the synthetic legs below, not here.
+  it('attribution machinery negative control: every refusal call is either attributed or counted unattributed — none silently dropped (vacuous on real content after D3: 0 === 0)', () => {
     const content = fs.readFileSync(path.join(ROOT, BOUNDARY_RELATIVE_FILE), 'utf8')
     const { counts, unattributedCount } = attributeRefusalCallsV1(content)
     const attributedTotal = Object.values(counts).reduce((sum, n) => sum + n, 0)
@@ -579,13 +631,32 @@ describe('Gate D: W4C2 authoritative-entrypoint delivery declaration <-> boundar
   // status code, code hoisted into a const) — not every conceivable spelling. See the Gate D
   // docblock's "Disclosed scope" list above for what still evades this (backtick-quoted or
   // split/concatenated spellings, and any non-canonical spelling added to a DIFFERENT file).
-  it('P3: no refusal call is attributed to a function outside the declared entrypoint mapping, and none is unattributed (an unmapped/4th dispatch site in THIS file, single/double-quoted/any-status/const-hoisted, fails closed)', () => {
+  it('P3: no refusal call is attributed to a function outside the declared entrypoint mapping, and none is unattributed (vacuous on real content after D3 — carried by the synthetic UNMAPPED decoy below)', () => {
     const content = fs.readFileSync(path.join(ROOT, BOUNDARY_RELATIVE_FILE), 'utf8')
     const { counts, unattributedCount } = attributeRefusalCallsV1(content)
     const knownFunctionNames = new Set(Object.values(KEY_TO_FUNCTION_NAME))
     const unrepresented = Object.keys(counts).filter((name) => !knownFunctionNames.has(name))
     expect(unrepresented).toEqual([])
     expect(unattributedCount).toBe(0)
+
+    // DECOY POSITIVE CONTROL (Gate D3). Both real assertions above are 0 === 0 now, so on their own
+    // they would stay green even if the "unmapped site fails closed" machinery were deleted
+    // outright. Plant a refusal call inside a named function that is NOT in `KEY_TO_FUNCTION_NAME`'s
+    // image and prove it lands in `unrepresented` — i.e. that a 4th dispatch site added to a
+    // function nobody mapped would be caught rather than silently ignored.
+    const unmappedSource = [
+      'function executeScheduledRunInternal(x) { return x }',
+      '',
+      'function someFutureUnmappedEntrypoint(y) {',
+      `  ${syntheticStrictRefusalCall()}`,
+      '  return y',
+      '}',
+    ].join('\n')
+    const decoy = attributeRefusalCallsV1(unmappedSource)
+    const decoyUnrepresented = Object.keys(decoy.counts).filter((name) => !knownFunctionNames.has(name))
+    expect(decoyUnrepresented).toEqual(['someFutureUnmappedEntrypoint'])
+    expect(decoy.counts.someFutureUnmappedEntrypoint).toBe(1)
+    expect(decoy.unattributedCount).toBe(0)
   })
 
   it('P2: declared-undelivered weight equals the ACTUAL per-key call count in the boundary file, key by key (not an aggregate — a single-key mismatch reds this even when the total is unchanged)', () => {
@@ -594,64 +665,88 @@ describe('Gate D: W4C2 authoritative-entrypoint delivery declaration <-> boundar
     expect(actualByKeyV1(counts)).toEqual(expectedByKeyV1())
   })
 
-  it('positive control (post Gate D2): live_punch is DELIVERED with zero refusal sites, scheduled is undelivered with exactly 2 (total=2)', () => {
+  it('positive control (post Gate D3): BOTH authoritative entrypoints are DELIVERED and the boundary carries zero refusal sites (total=0)', () => {
     expect(isAttendanceW4C2AuthoritativeEntrypointDeliveredV1('live_punch')).toBe(true)
-    expect(isAttendanceW4C2AuthoritativeEntrypointDeliveredV1('scheduled')).toBe(false)
+    expect(isAttendanceW4C2AuthoritativeEntrypointDeliveredV1('scheduled')).toBe(true)
     const content = fs.readFileSync(path.join(ROOT, BOUNDARY_RELATIVE_FILE), 'utf8')
     const { counts } = attributeRefusalCallsV1(content)
-    // `executeLivePunch` no longer appears as a key at all — its writer branch contains no
-    // refusal call, and the attribution map only records functions that carry at least one.
-    expect(counts).toEqual({ executeScheduledRunInternal: 2 })
-    expect(countRefusalCalls(content)).toBe(2)
+    // Neither entrypoint appears as a key at all — the attribution map only records functions that
+    // carry at least one refusal call, and after D3 neither writer branch does.
+    expect(counts).toEqual({})
+    expect(countRefusalCalls(content)).toBe(0)
+    // NON-VACUITY: the file really was read and really is the boundary (a misrooted path would
+    // also produce `{}` and `0` above).
+    expect(content.length).toBeGreaterThan(0)
+    expect(content).toContain('executeScheduledRunInternal')
+    expect(content).toContain('executeLivePunch')
   })
 
-  it('Gate D2 delivery-flip coupling: exactly ONE authoritative entrypoint remains undelivered, and no refusal call is attributed to executeLivePunch', () => {
-    // The promotion gate reads this count and demands ZERO, so promotion to `authoritative` still
-    // refuses after D2 — the count moved 2 -> 1, not 2 -> 0.
-    expect(attendanceW4C2UndeliveredAuthoritativeEntrypointCountV1()).toBe(1)
+  it('Gate D3 delivery-flip coupling: ZERO authoritative entrypoints remain undelivered, so the W4C3A NOT_DELIVERED promotion refusal no longer fires', () => {
+    // Gate D's intended exit condition. The promotion gate reads this count and demands ZERO; it
+    // moved 2 -> 1 at D2 and 1 -> 0 here. Promotion is still gated by every OTHER rollout control
+    // plus the owner-actioned exact-org allowlist, which is what keeps this byte-neutral.
+    expect(attendanceW4C2UndeliveredAuthoritativeEntrypointCountV1()).toBe(0)
     const content = fs.readFileSync(path.join(ROOT, BOUNDARY_RELATIVE_FILE), 'utf8')
     const { counts } = attributeRefusalCallsV1(content)
-    // The static half of the P-A obligation: the new authoritative writer branch contains no
-    // refusal call of ANY spelling this file's pattern matches. (The behavioural fall-through pin
-    // is the zero-invocation adapter spy in the D2 real-DB suite, not this assertion.)
+    // The static half of the P-A obligation for BOTH writers: neither branch contains a refusal
+    // call of any spelling this file's pattern matches. (The behavioural fall-through pins are the
+    // zero-invocation adapter spies in the D2/D3 real-DB suites, not these assertions.)
     expect(counts.executeLivePunch ?? 0).toBe(0)
+    expect(counts.executeScheduledRunInternal ?? 0).toBe(0)
+    // The override seam still drives the count, so a future third entrypoint declared undelivered
+    // would move it off zero. Without this the assertion above could not distinguish "delivered"
+    // from "the counter is broken and always returns 0".
+    __setAttendanceW4C2AuthoritativeDeliveryOverrideForTests({ scheduled: false })
+    expect(attendanceW4C2UndeliveredAuthoritativeEntrypointCountV1()).toBe(1)
   })
 
-  it('drift guard is load-bearing (delivered-flip class): declaring "scheduled" delivered via the test seam while the boundary source is unchanged mismatches on that key specifically', () => {
-    // Retargeted from `live_punch` to `scheduled` by Gate D2 (#4844): this leg needs a key that
-    // is STILL undelivered in the shipped declaration AND still carries refusal sites in the
-    // source, so that overriding it to `true` produces the expected-0/actual-nonzero mismatch.
-    // `live_punch` can no longer serve — after D2 both its expected and actual counts are 0, so
-    // the override would be a no-op and the leg would assert nothing.
-    __setAttendanceW4C2AuthoritativeDeliveryOverrideForTests({ scheduled: true })
-    const content = fs.readFileSync(path.join(ROOT, BOUNDARY_RELATIVE_FILE), 'utf8')
-    const { counts } = attributeRefusalCallsV1(content)
+  it('drift guard is load-bearing (delivered-flip class), driven over a SYNTHETIC source because no undelivered key remains: a declared-delivered key whose source still carries a refusal site mismatches on that key specifically', () => {
+    // RE-FORMED BY GATE D3. This leg needs a key that is declared delivered AND whose source range
+    // still carries refusal sites, so the expected-0/actual-nonzero mismatch is reachable. After D3
+    // NEITHER real key can serve — both are delivered and both actual counts are 0, so any override
+    // is a no-op and the leg would assert nothing (exactly the vacuity D2 retargeted away from, one
+    // gate later). The mismatch is therefore demonstrated over a SYNTHETIC boundary source in which
+    // `executeScheduledRunInternal` carries a REINTRODUCED refusal call — i.e. precisely the change
+    // this guard exists to catch: a writer regressed back to failing closed while the declaration
+    // still claims it delivered.
+    const reintroducedSource = [
+      'function executeLivePunch(x) { return x }',
+      '',
+      'function executeScheduledRunInternal(y) {',
+      `  ${syntheticStrictRefusalCall()}`,
+      '  return y',
+      '}',
+    ].join('\n')
+    const { counts } = attributeRefusalCallsV1(reintroducedSource)
     const actual = actualByKeyV1(counts)
-    const expected = expectedByKeyV1()
-    // scheduled declared delivered => expected drops to 0 for that key, but the boundary source
-    // still carries its 2 refusal calls — mismatched on THAT key specifically, demonstrated here
-    // directly rather than only asserted by the correspondence test above.
-    expect(expected.scheduled).toBe(0)
-    expect(actual.scheduled).toBe(2)
+    const expected = expectedByKeyV1() // shipped declaration: both delivered => both expected 0
+    expect(expected).toEqual({ live_punch: 0, scheduled: 0 })
+    expect(actual.scheduled).toBe(1)
     expect(actual).not.toEqual(expected)
+    // The mismatch is on THAT key specifically, not merely on the aggregate.
+    expect(actual.live_punch).toBe(expected.live_punch)
   })
 
-  it('P2 fix is load-bearing (cross-key class — the aggregate blind spot the old guard missed): a hand-maintained-weight swap across the two keys preserves the SUM but reds a per-key comparison', () => {
-    const content = fs.readFileSync(path.join(ROOT, BOUNDARY_RELATIVE_FILE), 'utf8')
-    const { counts } = attributeRefusalCallsV1(content)
-    const actual = actualByKeyV1(counts)
-    // A mutation of REFUSAL_SITE_WEIGHT that swaps the two keys' weights preserves the aggregate
-    // SUM the pre-fix, aggregate-only assertion checked — that old guard would have stayed green
-    // on exactly this edit, because add-to-one/remove-from-another leaves the total unchanged.
-    // Still discriminating after Gate D2 (#4844) moved the weights to {live_punch:0,scheduled:2}:
-    // the swap yields {live_punch:2,scheduled:0}, same sum (2), opposite per-key values.
-    const swapped: Record<AttendanceW4C2AuthoritativeEntrypointV1, number> = {
-      live_punch: REFUSAL_SITE_WEIGHT.scheduled,
-      scheduled: REFUSAL_SITE_WEIGHT.live_punch,
+  it('P2 fix is load-bearing (cross-key class — the aggregate blind spot the old guard missed), over SYNTHETIC weights: a swap preserves the SUM but reds a per-key comparison', () => {
+    // RE-FORMED BY GATE D3. The old form swapped the two REAL weights; after D3 both are 0, so the
+    // swap equals `actual` and `expect(actual).not.toEqual(swapped)` would FAIL — a vacuous
+    // assertion dressed as a guard. The class this leg exists to pin (an aggregate-only comparison
+    // cannot see an add-to-one/remove-from-another edit) is a property of the COMPARISON, so it is
+    // demonstrated over synthetic per-key counts, with the real weights asserted separately.
+    const syntheticActual: Record<AttendanceW4C2AuthoritativeEntrypointV1, number> = {
+      live_punch: 0,
+      scheduled: 2,
     }
-    const realAggregate = actual.live_punch + actual.scheduled
-    const swappedAggregate = swapped.live_punch + swapped.scheduled
-    expect(realAggregate).toBe(swappedAggregate) // the old aggregate-only check would stay green on this mutation
-    expect(actual).not.toEqual(swapped) // the new per-key check reds on the exact same mutation
+    const syntheticSwapped: Record<AttendanceW4C2AuthoritativeEntrypointV1, number> = {
+      live_punch: syntheticActual.scheduled,
+      scheduled: syntheticActual.live_punch,
+    }
+    const realAggregate = syntheticActual.live_punch + syntheticActual.scheduled
+    const swappedAggregate = syntheticSwapped.live_punch + syntheticSwapped.scheduled
+    expect(realAggregate).toBe(swappedAggregate) // the old aggregate-only check stays green on this edit
+    expect(syntheticActual).not.toEqual(syntheticSwapped) // the per-key check reds on the same edit
+    // And the SHIPPED weights are what D3 says they are, read from the real table rather than
+    // restated — so this leg still fails if someone edits the weights without editing the writers.
+    expect(REFUSAL_SITE_WEIGHT).toEqual({ live_punch: 0, scheduled: 0 })
   })
 })

--- a/packages/core-backend/src/attendance/w4c2-authoritative-delivery.ts
+++ b/packages/core-backend/src/attendance/w4c2-authoritative-delivery.ts
@@ -12,10 +12,20 @@
  * closed-enumeration declaration the canonical transition boundary
  * (`w4c3a-rollout-control.ts`) reads to refuse that promotion.
  *
- * Gate D2 (#4556 / #4844) shipped the `live_punch` writer and removed its ONE refusal site, so
- * TWO sites remain in that file today, both `scheduled`. The declaration below moved to
- * `{live_punch:true, scheduled:false}` in that same reviewed change, which is exactly the
- * lockstep the correspondence test requires.
+ * Gate D2 (#4556 / #4844) shipped the `live_punch` writer and removed its ONE refusal site, moving
+ * the declaration to `{live_punch:true, scheduled:false}` in that same reviewed change. Gate D3
+ * (#4556 / #4844) then shipped the `scheduled` writer and removed BOTH of its sites — the org-wide
+ * probe (now a routing fall-through into the durable run registry) and the per-target loop (now the
+ * real writer) — so ZERO refusal sites remain in that file and the declaration is
+ * `{live_punch:true, scheduled:true}`. Each flip landed in lockstep with its own site removals,
+ * which is exactly what the correspondence test requires.
+ *
+ * READ THIS BEFORE TRUSTING THE CORRESPONDENCE TEST AS A BEHAVIOURAL GUARD: with both entrypoints
+ * delivered, the Gate D describe-block in that test is a ZERO-VERSUS-ZERO identity on real content.
+ * Its remaining discriminating power lives entirely in the SYNTHETIC decoys it now carries (a
+ * reintroduced refusal site inside a mapped function; a refusal site inside an unmapped function).
+ * The behavioural pins for "the writers really are wired" are the real-DB zero-invocation
+ * legacy-adapter spies and the probe-routing legs, not this declaration.
  *
  * WHAT THIS MODULE DOES NOT DO: it does not probe, does not import, and has no runtime
  * dependency on `w4c2-live-scheduled-boundary.ts`. It is a LEAF — zero imports from any W4C-2/
@@ -55,14 +65,22 @@ export type AttendanceW4C2AuthoritativeEntrypointV1 =
  * `live_punch` is `true` as of Gate D2 (#4556 / #4844): the boundary's `executeLivePunch` now
  * carries the real authoritative writer and its single refusal call site is gone, so the
  * correspondence guard's expected weight and the source's actual count moved 1 -> 0 in lockstep.
- * `scheduled` stays `false` — `executeScheduledRunInternal` still fails closed at both of its
- * sites; D3 delivers it. Promotion to the `authoritative` rollout state therefore still refuses
- * (`w4c3a-rollout-control.ts` gates on the UNDELIVERED count, which is 1, not 0).
+ *
+ * `scheduled` is `true` as of Gate D3 (#4556 / #4844): `executeScheduledRunInternal` carries the
+ * real authoritative per-target writer, and BOTH of its refusal call sites are gone — the org-wide
+ * probe's arm became a routing fall-through into the durable run registry, and the per-target arm
+ * became the writer. Its weight and actual count moved 2 -> 0 in the same lockstep.
+ *
+ * The UNDELIVERED count is therefore 0, which is Gate D's intended exit condition: the
+ * `w4c3a-rollout-control.ts` promotion refusal keyed on this count no longer fires. Promotion to
+ * `authoritative` remains gated by every OTHER rollout control plus the owner-actioned exact-org
+ * `ATTENDANCE_SHIFT_SEGMENT_CALCULATION_ENABLED` allowlist, which is unset in production — so
+ * delivering both writers is byte-neutral for every production org.
  */
 const DECLARED_DELIVERED: Readonly<Record<AttendanceW4C2AuthoritativeEntrypointV1, boolean>> =
   Object.freeze({
     live_punch: true,
-    scheduled: false,
+    scheduled: true,
   })
 
 // ---------------------------------------------------------------------------

--- a/packages/core-backend/src/attendance/w4c2-live-scheduled-boundary.ts
+++ b/packages/core-backend/src/attendance/w4c2-live-scheduled-boundary.ts
@@ -66,13 +66,27 @@
  *  - effective `eligible`/`authoritative`: a legacy-only business time is
  *    rejected BEFORE any event/record/result/effect DML (the whole transaction
  *    rolls back, discarding the preflight claim).
- *  - effective `authoritative` (`live_punch` ONLY, Gate D2, #4844): the real
+ *  - effective `authoritative` (`live_punch`, Gate D2, #4844): the real
  *    authoritative writer runs — split event INSERT (no legacy records upsert),
  *    fail-closed retirement guard, create-if-absent review placeholder, then
  *    `writeAuthoritativeSegmentCalculationV1` (the D1 core) owns the calc row,
- *    the lineage, and the parent pointer. `scheduled` is STILL undelivered and
- *    still fails closed at its two sites (see
- *    `` `W4C2_AUTHORITATIVE_MODE_NOT_DELIVERED` ``); D3 delivers it.
+ *    the lineage, and the parent pointer.
+ *  - effective `authoritative` (`scheduled`, Gate D3, #4844): BOTH former
+ *    fail-closed sites are gone. The org-wide probe site is now a routing
+ *    fall-through into the durable run registry (no run/targets/witnesses exist
+ *    there yet, so no per-target record and no core call belong at that point);
+ *    the per-target site is the real writer — one seam that resolves the parent
+ *    guard-first (retirement adjudication dominates every return, including the
+ *    present-parent SKIP), the create-if-absent review placeholder, the D2
+ *    preimage builder, a scheduled-domain payload fingerprint, and the same D1
+ *    core with `entrypoint: 'scheduled'`. `applyScheduledAbsenceLegacy` is
+ *    called ZERO times on that branch. D3's distinctive machinery is PER-TARGET
+ *    CONTAINMENT: a refusal whose class is in the ONE exported containment table
+ *    rolls back to the branch savepoint, CANCELS the claimed operation (the
+ *    deferred `trg_aro_claimed_commit_guard` makes committing a still-claimed
+ *    operation illegal), records a terminal `'failed'` run outcome, and lets the
+ *    batch CONTINUE; everything else rethrows and aborts so recovery/resume
+ *    re-attempts the target.
  *    BYTE-NEUTRAL IN PRODUCTION regardless: `effectiveState==='authoritative'`
  *    additionally requires an EXACT-org entry in
  *    `ATTENDANCE_SHIFT_SEGMENT_CALCULATION_ENABLED` (wildcard never counts),
@@ -104,6 +118,7 @@ import {
 } from './w4c0-authorization'
 import {
   attendanceResultOperationPreflightV1,
+  cancelAttendanceResultOperationV1,
   enqueueAttendanceResultEventOutboxV1,
   isRetryableSqlState,
   runAttendanceResultOperationTransactionV1,
@@ -157,6 +172,7 @@ import {
 import { isExpectedAttendanceShadowDifferenceV1 } from './w4c2-shadow-expected-differences'
 // Gate D2 (#4556 / #4844) — the authoritative live-punch writer's collaborators.
 import {
+  AttendanceW4AuthoritativeCalculationError,
   writeAuthoritativeSegmentCalculationV1,
   type AttendanceAuthoritativeParentPreimageV1,
 } from './w4c2-authoritative-calculation-core'
@@ -164,7 +180,13 @@ import {
 // Never hand-rolled here, and never modeled on ops-retirement's separate 6-field
 // `dailyFingerprint` (a different, domainless digest — reconciling those two is out of scope).
 import { computeAttendanceImportRollbackPreimageFingerprintV1 } from './w4c3a-import-rollback'
-import { assertParentNotRetiredForAuthoritativePunchV1 } from './w4c3c-ops-retirement'
+// Gate D3 (#4556 / #4844) imports the ERROR CLASS as well as the guard: the scheduled per-target
+// containment predicate discriminates by CLASS IDENTITY, never by `error.name` (spoofable) and
+// never by enumerating code strings (enumeration does not converge).
+import {
+  AttendanceW4OpsRetirementError,
+  assertParentNotRetiredForAuthoritativePunchV1,
+} from './w4c3c-ops-retirement'
 
 // ---------------------------------------------------------------------------
 // Errors.
@@ -183,6 +205,58 @@ export class AttendanceW4LiveScheduledBoundaryError extends Error {
 
 function boundaryFail(code: string, httpStatus = 422): never {
   throw new AttendanceW4LiveScheduledBoundaryError(code, httpStatus)
+}
+
+// ---------------------------------------------------------------------------
+// Gate D3 (#4556 / #4844) — the scheduled per-target CONTAINMENT membership authority.
+//
+// The authoritative `scheduled` writer runs once per target inside its own transaction, inside a
+// batch loop that has no try/catch today. The D1 core refuses with a closed enumeration of typed
+// product codes and the boundary retirement guard refuses with its own two; none of those is a
+// retryable SQLSTATE, so without containment ONE refused target would abort every remaining target
+// in the run. The durable run registry has exactly one failure slot built for this
+// (`{terminalOutcome:'failed', failureReasonCode:'ATTENDANCE_SCHEDULED_TARGET_OPERATION_REJECTED'}`),
+// and a `'failed'` outcome is terminal by construction: excluded from the resume outstanding set,
+// from finalization's not-ready check, and from both fold counters.
+//
+// MEMBERSHIP IS MECHANICAL, NOT PROSE: `(a)` the error carries a non-empty string `code` (a product
+// code, never a raw SQLSTATE object or a bare `Error`) AND `(b)` it is an instance of a class in the
+// ONE table below. The table is WALKED by a test, so adding a class here automatically extends the
+// per-class proof rather than silently widening an undescribed predicate.
+//
+// DELIBERATE, STATED OVER-BREADTH: `AttendanceW4OpsRetirementError` also carries
+// `ATTENDANCE_RECORD_NOT_FOUND`, `ATTENDANCE_RECORD_VERSION_CONFLICT`,
+// `W4C3C_OPS_RETIREMENT_REPLAY_CONFLICT`, `W4C3C_OPS_RETIREMENT_OPERATION_ID_REQUIRED` and
+// `W4C3C_OPS_RETIREMENT_DATABASE_RESULT_INVALID`, none of which the scheduled writer can reach today
+// (it calls only that module's two `assert*` helpers). Containing by CLASS is therefore wider than
+// the two reachable codes. That widening fails toward "this one target is marked failed and the
+// batch continues" rather than "the whole batch aborts", which is the intended direction — recorded
+// here rather than left as an unstated reachability argument that rots the moment a future call is
+// added to this branch.
+//
+// WHAT IS DELIBERATELY *NOT* CONTAINED (fail-closed default; see the per-bucket table on the writer
+// branch): `AttendanceW4LiveScheduledBoundaryError` (our own 500-class
+// `W4C2_AUTHORITATIVE_PARENT_UNRESOLVED` is potentially transient — abort so recovery/resume
+// re-attempts the target instead of burning it terminally), `AttendanceW4OperationError` (org
+// suspension is run-wide, not per-target), raw pg errors including 40001/40P01 (absorbed by the two
+// retry layers), and anything else.
+export const ATTENDANCE_W4C2_SCHEDULED_CONTAINED_REFUSAL_CLASSES_V1 = Object.freeze([
+  AttendanceW4AuthoritativeCalculationError,
+  AttendanceW4OpsRetirementError,
+] as const)
+
+/**
+ * The ONLY containment predicate for the scheduled authoritative per-target branch.
+ *
+ * Never `.name` matching: `index.cjs`'s `W4_ERROR_NAMES` dispatch uses `error.name` ONLY because it
+ * crosses a CJS/ESM module boundary where the class identity is not shared. Inside this package the
+ * constructor identity is available and is not spoofable by an attacker-shaped object literal.
+ */
+export function isAttendanceScheduledContainedRefusalV1(error: unknown): boolean {
+  if (typeof error !== 'object' || error === null) return false
+  const code = (error as { code?: unknown }).code
+  if (typeof code !== 'string' || code.length === 0) return false
+  return ATTENDANCE_W4C2_SCHEDULED_CONTAINED_REFUSAL_CLASSES_V1.some((cls) => error instanceof cls)
 }
 
 // ---------------------------------------------------------------------------
@@ -557,7 +631,14 @@ export type AttendanceScheduledRunBoundaryResultV1 =
       readonly rows: Array<{ user_id: string }>
       readonly perUser: Array<{
         readonly userId: string
-        readonly mode: 'replay' | 'executed' | 'legacy_compat'
+        /**
+         * Gate D3 (#4556 / #4844) added `'failed'` — a per-target authoritative refusal the batch
+         * CONTAINED (recorded as a terminal `'failed'` run outcome) rather than aborting on. It
+         * contributes no rows. Additive and internal: `perUser` has zero consumers repo-wide (the
+         * plugin caller reads only `rows`), so widening the union cannot break a caller. Naming is
+         * `` [OWNER-CONFIRM] ``.
+         */
+        readonly mode: 'replay' | 'executed' | 'legacy_compat' | 'failed'
         readonly inserted: boolean
       }>
     }
@@ -894,6 +975,120 @@ export function computeAuthoritativeLivePunchPayloadFingerprintV1(
       holidayKind: input.holidayKind,
     }),
   )
+}
+
+/**
+ * Gate D3 (#4556 / #4844) — domain separator for the SCHEDULED payload fingerprint, terminated by a
+ * NUL written as the ESCAPE `\u0000` and never as a raw 0x00 byte (same convention, and the same
+ * reason, as the live-punch sibling above: a literal NUL makes `file(1)` classify this `.ts` as
+ * `data` and makes `grep`/`rg` skip it SILENTLY, dropping the whole module out of every static audit
+ * that walks the tree — the repo's own DML/read-inventory collectors included). The escape produces
+ * the identical runtime string, so the digest is unchanged.
+ *
+ * A SEPARATE domain from `live_punch` on purpose: the two entrypoints must never be able to mint the
+ * same payload digest for structurally different commands.
+ */
+export const ATTENDANCE_W4C2_SCHEDULED_PAYLOAD_FINGERPRINT_DOMAIN_V1 =
+  'metasheet2:attendance:w4c2:scheduled-authoritative-payload:v1\u0000'
+
+/**
+ * Deterministic payload identity for the core's retry-idempotency conflict check, derived ONLY from
+ * the RESOLVED command payload — never from a clock, a random id, or the operation id itself. The
+ * core reads `input_provenance.payloadFingerprint` VERBATIM off the stored row on a retry, so the
+ * caller must embed this value in BOTH `input.payloadFingerprint` and
+ * `inputProvenance.payloadFingerprint`; omitting the embedded copy turns a genuine retry into
+ * `REPLAY_CONFLICT`.
+ */
+export function computeAuthoritativeScheduledPayloadFingerprintV1(
+  payload: Readonly<{
+    scheduledRunId: string
+    userId: string
+    workDate: string
+    expectedRunVersion: number
+    scheduledAbsenceSource: string
+  }>,
+): string {
+  return sha256Hex(
+    ATTENDANCE_W4C2_SCHEDULED_PAYLOAD_FINGERPRINT_DOMAIN_V1
+    + canonicalAttendanceJsonV1({
+      scheduledRunId: payload.scheduledRunId,
+      userId: payload.userId,
+      workDate: payload.workDate,
+      expectedRunVersion: payload.expectedRunVersion,
+      scheduledAbsenceSource: payload.scheduledAbsenceSource,
+    }),
+  )
+}
+
+/**
+ * Gate D3 (#4556 / #4844) — the ONE seam that resolves the authoritative `scheduled` writer's parent
+ * and is the ONLY place in this module that may produce a `'skip'`.
+ *
+ * WHY ONE SEAM RATHER THAN INLINE STEPS: the retirement guard must dominate EVERY outcome, including
+ * the skip. A naive top-to-bottom "present ⇒ skip, else placeholder, then guard" would seal
+ * `{inserted:false, completed}` over an `operator_retirement` / `import_rollback` parent — a silent
+ * pass over a day an operator or a rollback deliberately retired. Here the caller can never see a row
+ * this function did not adjudicate, because the guard is called exactly once, unconditionally, before
+ * BOTH returns; the only path that bypasses it is the 500-class throw, which is not a return.
+ *
+ * ORDER (normative):
+ *  1. class-11 target lock + widened `FOR UPDATE` parent read;
+ *  2. absent ⇒ create-if-absent `retired`/`review_placeholder` parent, then ALWAYS re-lock/re-read —
+ *     a lost race may have been won by a legacy-ACTIVE row, another placeholder, or a retired-other
+ *     row, and every one of those must re-enter the SAME adjudication below (still `null` under our
+ *     own lock ⇒ `W4C2_AUTHORITATIVE_PARENT_UNRESOLVED`, which is NOT contained — see the writer);
+ *  3. DEFAULT-REFUSE retirement adjudication on whatever row we ended up holding;
+ *  4. presence branching on the GUARD'S VERDICT, never on bare `row !== null`:
+ *     - guard-admitted `retired`/`review_placeholder` ⇒ WRITE (the F6 steady state, and the very
+ *       placeholder step 2 creates — our own artifact, which a re-attempt must be able to complete);
+ *     - present and NOT retired ⇒ SKIP (§6.2 default: legacy-ACTIVE rows and already-`w4`-owned
+ *       active rows alike). The justification is LEGACY PARITY, not rarity: `'generate'` targets are
+ *       not NOT-EXISTS-filtered at run creation, so a present parent is the ordinary case for anyone
+ *       who punched that day, and the legacy `INSERT .. SELECT .. WHERE NOT EXISTS` contributes
+ *       `inserted=false` for exactly that user — so `rows`/`generated_count`/`total` are unchanged by
+ *       posture. It also makes the core's `RECORD_NOT_FOUND` unreachable for the legitimate dedup
+ *       case. CONSEQUENCE, disclosed: the core's completed-supersede-over-legacy-active path stays
+ *       DORMANT on `scheduled` under this default.
+ */
+type AuthoritativeScheduledParentResolutionV1 =
+  | { readonly kind: 'skip' }
+  | { readonly kind: 'write'; readonly parent: ShadowTargetRow }
+
+async function resolveAuthoritativeScheduledParentV1(
+  trx: AttendanceW4TransactionClientV1,
+  org: VerifiedAttendanceOrgIdentityV1,
+  userId: string,
+  workDate: string,
+  placeholder: Readonly<{ orgId: string; timezone: string; isWorkday: boolean }>,
+): Promise<AuthoritativeScheduledParentResolutionV1> {
+  let parent = await lockShadowParentRecord(trx, org, userId, workDate)
+  if (parent === null) {
+    await insertAuthoritativeReviewPlaceholderParentV1(trx, {
+      orgId: placeholder.orgId,
+      userId,
+      workDate,
+      timezone: placeholder.timezone,
+      isWorkday: placeholder.isWorkday,
+    })
+    parent = await lockShadowParentRecord(trx, org, userId, workDate)
+    if (parent === null) {
+      // Neither our INSERT nor a racer's produced a visible row under our own lock — a
+      // programming/DB-state error, not a business outcome, and deliberately NOT contained.
+      boundaryFail('W4C2_AUTHORITATIVE_PARENT_UNRESOLVED', 500)
+    }
+  }
+  // The guard is called on EVERY row this function ever returns or skips on. Its refusals are the
+  // two ops-retirement 409s, which the writer's containment converts to a per-target `'failed'`.
+  assertParentNotRetiredForAuthoritativePunchV1({
+    visibilityState: parent.visibilityState,
+    visibilityReason: parent.visibilityReason,
+  })
+  if (parent.visibilityState === 'retired') {
+    // The guard admits exactly ONE retired reason (`review_placeholder`); every other retired reason
+    // threw above. So this arm is the F6 carve-out, reached only through the guard's own verdict.
+    return { kind: 'write', parent }
+  }
+  return { kind: 'skip' }
 }
 
 async function nextCalculationVersion(
@@ -2493,9 +2688,22 @@ export function createAttendanceLiveScheduledBoundaryV1(
           })
           return { mode: 'legacy' as const, rows: rows as Array<{ user_id: string }> }
         }
-        if (posture.writePosture === 'authoritative' || posture.effectiveState === 'authoritative') {
-          boundaryFail('W4C2_AUTHORITATIVE_MODE_NOT_DELIVERED', 503)
-        }
+        // Gate D3 (#4556 / #4844) — SITE A, the org-wide probe: REPLACEMENT BY ROUTING, not a
+        // delete. This branch previously failed closed here. At this point in the probe
+        // transaction NO run, NO targets and NO witnesses exist yet, so nothing per-target can be
+        // recorded and no D1-core call belongs here — the correct authoritative treatment is
+        // exactly the classification the shadow and eligible postures already take: fall through
+        // to the run-registry mode below and let the durable per-target machinery (which admits
+        // authoritative posture: `createOrResumeAttendanceScheduledRunV1` returns early only on
+        // `blocked` and `legacy_projection_only`, and freezes the run row at
+        // shadow/eligible/authoritative) do the writing.
+        //
+        // FAIL-OPEN CHECK: an authoritative posture cannot leak into the legacy batch arm — that
+        // arm is gated on `legacy_projection_only`, which precedes this point and is disjoint
+        // (`POSTURE_TABLE` maps state `authoritative` to writePosture `authoritative`). Pinned
+        // behaviourally by the D3 probe-routing leg (authoritative org ⇒ run-registry mode, ZERO
+        // legacy batch INSERT..SELECT rows, no 503) with `legacy_projection_only`/`blocked`
+        // negative controls, not by this comment.
         return { mode: 'w4' as const, rows: [] as Array<{ user_id: string }> }
       }),
     )
@@ -2598,7 +2806,11 @@ export function createAttendanceLiveScheduledBoundaryV1(
         ? targetUserIds
         : startOutcome.outstandingGenerateTargets.map((t) => t.userId)
 
-    const perUser: Array<{ userId: string; mode: 'replay' | 'executed' | 'legacy_compat'; inserted: boolean }> = []
+    const perUser: Array<{
+      userId: string
+      mode: 'replay' | 'executed' | 'legacy_compat' | 'failed'
+      inserted: boolean
+    }> = []
     const insertedRows: Array<{ user_id: string }> = []
 
     for (const userId of pendingUserIds) {
@@ -2663,6 +2875,259 @@ export function createAttendanceLiveScheduledBoundaryV1(
           // run — is rejected BEFORE the source DML, never after.
           await requireAttendanceScheduledRunRunningBeforeSourceDmlV1(trx, orgKey, runId)
 
+          // =================================================================
+          // Gate D3 (#4556 / #4844) — SITE B, the AUTHORITATIVE `scheduled` per-target writer.
+          //
+          // REPLACEMENT, NOT A DELETE, and it must run BEFORE the legacy absence adapter below.
+          // Deleting the old fail-closed branch instead of replacing it would let an allowlisted
+          // authoritative org's target fall through to `applyScheduledAbsenceLegacy`, fabricating a
+          // legacy-ACTIVE `'absent'` `attendance_records` row visible to ordinary readers — the very
+          // row the D1 core owns — the instant the allowlist gains an authoritative entry. The
+          // branch body is always a real writer and always `return`s (or records a contained
+          // failure) before control can reach that call site; the behavioural pin is the
+          // zero-invocation spy on the INJECTED `applyScheduledAbsenceLegacy`, not this comment.
+          //
+          // The posture re-read is HOISTED above the legacy adapter (it used to sit after it) and
+          // survives as the BRANCH SELECTOR — authoritative writer vs the existing shadow path —
+          // mirroring how the `legacy_compat` arm below already handles the legacy-downgrade race
+          // per-target. The hoist is behaviour-preserving for every other posture: it is a
+          // read-only query, this transaction writes nothing it reads, and the SERIALIZABLE
+          // snapshot is fixed before either position. It is skipped entirely for `legacy_compat`,
+          // exactly as before.
+          //
+          // Dropping the absence adapter on this branch (ZERO invocations, never a split) also
+          // removes the pre-writer source DML that made the §7.8 preimage capture point ambiguous
+          // and the F6 self-created-parent hazard: the scheduled legacy adapter is 100% the
+          // to-DROP half (one `INSERT .. SELECT .. WHERE NOT EXISTS` on `attendance_records`, zero
+          // `attendance_events` DML), and the scheduled evidence is SYNTHETIC
+          // (`{kind:'scheduled_absence', ref: runId}`), durable via the run registry rather than
+          // via events.
+          //
+          // BYTE-NEUTRAL IN PRODUCTION: this branch fires only when the resolved posture is
+          // `authoritative`, which requires an EXACT-org entry in
+          // `ATTENDANCE_SHIFT_SEGMENT_CALCULATION_ENABLED` (wildcard never counts). That env is
+          // unset in production, so every production org collapses to `legacy` and this branch is
+          // unreachable irrespective of DB contents — including via the run's frozen posture, which
+          // can only be `authoritative` if the org resolved authoritative at run creation.
+          // =================================================================
+          if (!isLegacyCompat) {
+            const targetPosture = await resolveSegmentCalculationPosture(trx, orgKey)
+            if (
+              targetPosture.effectiveState === 'authoritative'
+              || org.acceptedWritePosture === 'authoritative'
+            ) {
+              // -- CONTAINMENT SCOPE ------------------------------------------------------------
+              // ONE savepoint around the parent seam (placeholder INSERT included), the preimage
+              // build, and the core call. It deliberately does NOT enclose the preflight claim: the
+              // claim must survive a contained refusal so `cancelAttendanceResultOperationV1` (a
+              // bare `UPDATE ... WHERE state='claimed'`) can dispose of it. Rolling the claim back
+              // would make that cancel match zero rows and throw a NON-contained class, aborting the
+              // very batch the containment exists to protect.
+              //
+              // WHY THE CLAIM MUST BE DISPOSED AT ALL: `trg_aro_claimed_commit_guard` is a
+              // `CONSTRAINT TRIGGER ... DEFERRABLE INITIALLY DEFERRED` on
+              // `attendance_result_operations` that re-reads the row's state AT COMMIT and raises
+              // `W4C0_CLAIMED_COMMIT` if it is still `claimed`. "Record the outcome and leave the
+              // operation unsealed" is therefore ILLEGAL — it would fail at COMMIT with a raw,
+              // untyped exception and abort the batch anyway. Cancelling (`claimed -> canceled`,
+              // `response_snapshot` stays NULL, admitted by
+              // `attendance_w4_operation_transition_guard`) is the legal terminal disposition, and
+              // it PRESERVES the "seal ⇒ success snapshot" invariant, because a contained failure is
+              // never sealed at all. The finalize fold's LEFT JOIN then yields a NULL
+              // `response_snapshot` for it, contributing 0 to `generated_count`.
+              //
+              // PER-BUCKET DISPOSITION of everything typed that can be thrown inside this savepoint:
+              //  - the core's closed 15-code enumeration (`AttendanceW4AuthoritativeCalculationError`)
+              //    ⇒ CONTAIN: deterministic for this (parent, payload); a retry cannot change it.
+              //  - the two retirement 409s (`AttendanceW4OpsRetirementError`) ⇒ CONTAIN: same.
+              //  - `W4C2_AUTHORITATIVE_PARENT_UNRESOLVED` (500,
+              //    `AttendanceW4LiveScheduledBoundaryError`) ⇒ RETHROW, batch aborts: not a business
+              //    outcome and potentially transient, so recovery/resume must re-attempt the target
+              //    rather than burn it terminally. That is the principled split — CONTAINED =
+              //    deterministic-for-this-target; RETHROWN = transient or infrastructural.
+              //  - raw pg errors incl. 40001/40P01 ⇒ RETHROW (the two retry layers own those).
+              //  - `AttendanceW4OperationError` (org suspension) ⇒ RETHROW, and it is thrown before
+              //    this savepoint anyway — suspension is run-wide, not per-target.
+              //  - anything else ⇒ RETHROW (fail-closed default).
+              // The membership authority is `isAttendanceScheduledContainedRefusalV1` over the ONE
+              // exported class table; this list is the reachability commentary, never the predicate.
+              const authoritativeSavepoint = 'attendance_w4c2_scheduled_authoritative'
+              let authoritativeSealInput: { inserted: boolean; calculationId: string | null }
+              await trx.query(`SAVEPOINT ${authoritativeSavepoint}`)
+              try {
+                const resolvedParent = await resolveAuthoritativeScheduledParentV1(
+                  trx,
+                  org,
+                  userId,
+                  workDate,
+                  {
+                    orgId: orgKey,
+                    timezone: input.timezone,
+                    isWorkday: input.isWorkday !== false,
+                  },
+                )
+                if (resolvedParent.kind === 'skip') {
+                  // §6.2 default: present, guard-admitted, not-retired parent ⇒ no core call, no
+                  // placeholder, no writes at all. Legacy parity: the legacy INSERT contributes
+                  // `inserted=false` for exactly this user, so `rows`/`generated_count`/`total` are
+                  // identical under either posture and the parent stays bit-identical.
+                  await trx.query(`RELEASE SAVEPOINT ${authoritativeSavepoint}`)
+                  authoritativeSealInput = { inserted: false, calculationId: null }
+                } else {
+                  const authoritativeParent = resolvedParent.parent
+                  const authoritativeNowIso = new Date().toISOString()
+                  // The SHARED shadow compute, reused verbatim: the in-transaction W2 `scheduled`
+                  // channel anchored on the run's OWN workDate (required — it is a run identity
+                  // byte, not a resolver output), `scheduled_resolution` attribution
+                  // (ambiguous/unresolved/strict-rebuild failure ⇒ `unsupported` ⇒ review, never a
+                  // fabricated V2), the frozen context for `resolved_v2`, synthetic evidence, and
+                  // the pure calculator. The shadow path's `nextCalculationVersion` is DEAD here —
+                  // the core allocates its own. No identity-drift override: `scheduled` BY DESIGN
+                  // has no outer resolution to compare against (there is no
+                  // `outerSourceDefinitionFingerprint` on the scheduled input), so synthesizing one
+                  // would be inventing a gate, not replicating D2's.
+                  const authoritativeResolution = await adapters.resolveScheduledCandidate(pluginTrx, {
+                    orgId: orgKey,
+                    userId,
+                    timezone: input.timezone,
+                    calendarWorkDate: workDate,
+                  })
+                  const authoritativeAttribution = attributionFromResolution(authoritativeResolution, {
+                    orgId: orgKey,
+                    userId,
+                    source: 'scheduled_resolution',
+                    nowIso: authoritativeNowIso,
+                  })
+                  let authoritativeContext: FrozenAttendanceContextV1 | null = null
+                  if (authoritativeAttribution.posture === 'resolved_v2') {
+                    authoritativeContext = await adapters.buildShadowFrozenContext(pluginTrx, {
+                      orgId: orgKey,
+                      userId,
+                      workDate,
+                      shiftId: authoritativeAttribution.value.shiftId,
+                      timezone: input.timezone,
+                      isWorkday: input.isWorkday !== false,
+                      holidayKind: input.holidayKind ?? null,
+                    })
+                  }
+                  const authoritativeEvidence: AttendanceEvidenceV1[] = [
+                    { kind: 'scheduled_absence', ref: runId },
+                  ]
+                  const authoritativeCalculation = calculateAttendanceSegmentsV1({
+                    attribution: authoritativeAttribution,
+                    context: authoritativeContext,
+                    evidence: authoritativeEvidence,
+                    approvedFacts: [],
+                  })
+                  const authoritativeProvenanceRef: AttendanceInputProvenanceRefV1 = {
+                    transport: 'scheduled_job',
+                    sourceRef: SCHEDULED_SOURCE_REF[input.initiator],
+                    artifactSha256: null,
+                    normalizedCsvSha256: null,
+                    convertedSheetName: null,
+                  }
+                  // Derived ONLY from the resolved command payload — the same five fields the
+                  // envelope carries — never from a clock, a random id, or the operation id.
+                  const authoritativePayloadFingerprint =
+                    computeAuthoritativeScheduledPayloadFingerprintV1({
+                      scheduledRunId: runId,
+                      userId,
+                      workDate,
+                      expectedRunVersion: 1,
+                      scheduledAbsenceSource: SCHEDULED_ABSENCE_SOURCE[input.initiator],
+                    })
+                  // The D2 preimage builder VERBATIM (it takes only a `ShadowTargetRow`, which the
+                  // widened locked read supplies) — the CANONICAL compat fingerprint, instants
+                  // normalized to ISO with the SAME bytes hashed and stored, and
+                  // `expectedCurrentCalculationId` always the LOCKED actual.
+                  const { preimage: authoritativePreimage, expectedCurrentCalculationId } =
+                    buildAuthoritativeLivePunchPreimageV1(authoritativeParent)
+                  const authoritativeWritten = await writeAuthoritativeSegmentCalculationV1(trx, {
+                    orgId: orgKey,
+                    recordId: authoritativeParent.id,
+                    // The DB entrypoint value: a disjoint retry space from `'live'`, so the
+                    // `(org, entrypoint, operation_id)` replay key can never collide across kinds.
+                    entrypoint: 'scheduled',
+                    operationId: identity.id,
+                    calculation: authoritativeCalculation,
+                    attribution: authoritativeAttribution,
+                    context: authoritativeContext,
+                    evidence: authoritativeEvidence as unknown as readonly unknown[],
+                    approvedFacts: [],
+                    provenanceRef: authoritativeProvenanceRef,
+                    // BOTH places: top-level for the core's own conflict check, and embedded so a
+                    // genuine retry's `input_provenance.payloadFingerprint` read matches.
+                    inputProvenance: {
+                      ...authoritativeProvenanceRef,
+                      payloadFingerprint: authoritativePayloadFingerprint,
+                    },
+                    payloadFingerprint: authoritativePayloadFingerprint,
+                    preimage: authoritativePreimage,
+                    expectedCurrentCalculationId,
+                    sourceBatchId: null,
+                    actorId: authorization.actorId,
+                    correlationId: envelope.correlationId,
+                  })
+                  await trx.query(`RELEASE SAVEPOINT ${authoritativeSavepoint}`)
+                  // §6.3 default: `inserted:true` ⇔ the pointer moved (an authoritative "generated
+                  // absence day"), keeping `generated_count`'s meaning intact; a review outcome (or
+                  // a replay of one) is `inserted:false`.
+                  authoritativeSealInput = {
+                    inserted: authoritativeWritten.kind === 'completed',
+                    calculationId: authoritativeWritten.calculationId,
+                  }
+                }
+              } catch (error) {
+                if (!isAttendanceScheduledContainedRefusalV1(error)) throw error
+                // ROLLBACK TO is LOAD-BEARING: without it a refused target can leave an orphan
+                // `review_placeholder` parent behind for a target that produced nothing, and the
+                // parent is required to be bit-identical after a refusal. RELEASE follows the
+                // rollback (the D2 carry-forward lesson: `ROLLBACK TO` undoes the subtransaction but
+                // leaves its slot on the stack).
+                await trx.query(`ROLLBACK TO SAVEPOINT ${authoritativeSavepoint}`)
+                await trx.query(`RELEASE SAVEPOINT ${authoritativeSavepoint}`)
+                // Cancel FIRST, then record the outcome. `cancelAttendanceResultOperationV1`'s
+                // docblock says "source-free cancel: allowed only before source DML (lock 7.1)" —
+                // the rule is stated there and NOT enforced in code. Here the savepoint rollback has
+                // already undone every source write this branch made, so the operation IS source-free
+                // at cancel time; whether "source-free because it was rolled back" is the same
+                // predicate the lock meant is an OWNER lock interpretation, shipped as the default
+                // and surfaced for ruling, not decided here. The outcome table is run-registry
+                // machinery, not source DML.
+                await cancelAttendanceResultOperationV1(trx, identity)
+                // The registry's single allowlisted failure reason. The writer validates the shape
+                // as EXACTLY two keys, so persisting the specific refusing code alongside it is not
+                // a build-time option — it would fail `W4C2_SCHEDULED_RUN_OUTCOME_INVALID`.
+                await recordAttendanceScheduledRunTargetOutcomeV1(trx, identity, {
+                  terminalOutcome: 'failed',
+                  failureReasonCode: 'ATTENDANCE_SCHEDULED_TARGET_OPERATION_REJECTED',
+                })
+                // Terminal and contained: the loop continues to the next target, resume never
+                // re-loops this one, and both fold counters exclude it.
+                return { mode: 'failed' as const, inserted: false }
+              }
+              // Seal + outcome sit OUTSIDE the savepoint on purpose: their own failures must
+              // propagate (the outcome writer refuses a non-`running` run) rather than re-enter
+              // containment. The sealed snapshot PRESERVES the existing contract exactly — the two
+              // keys the finalize fold reads (`response_snapshot ->> 'inserted'`) plus
+              // `resolvedCalculationId`. Adding keys here would be a protocol change requiring an
+              // independent ratify, not a side effect of delivering the writer.
+              await sealAttendanceResultOperationV1(trx, identity, {
+                responseSnapshot: { inserted: authoritativeSealInput.inserted },
+                resolvedCalculationId: authoritativeSealInput.calculationId,
+              })
+              // §6.3 default: a `review_required` CALCULATION outcome still records `'completed'` —
+              // the operation ran to a terminal calc outcome and the review state is carried on the
+              // calc row. `'failed'` is reserved exclusively for contained refusals.
+              await recordAttendanceScheduledRunTargetOutcomeV1(trx, identity, {
+                terminalOutcome: 'completed',
+              })
+              // The P-A obligation: this `return` is what keeps control from reaching the shadow
+              // `applyScheduledAbsenceLegacy` call site below.
+              return { mode: 'executed' as const, inserted: authoritativeSealInput.inserted }
+            }
+          }
+
           const rows = await adapters.applyScheduledAbsenceLegacy(pluginTrx, {
             orgId: orgKey,
             workDate,
@@ -2686,10 +3151,11 @@ export function createAttendanceLiveScheduledBoundaryV1(
             return { mode: 'legacy_compat' as const, inserted }
           }
 
-          const posture = await resolveSegmentCalculationPosture(trx, orgKey)
-          if (posture.effectiveState === 'authoritative' || org.acceptedWritePosture === 'authoritative') {
-            boundaryFail('W4C2_AUTHORITATIVE_MODE_NOT_DELIVERED', 503)
-          }
+          // Gate D3 (#4556 / #4844): the authoritative arm's posture re-read and its former
+          // fail-closed refusal used to live HERE, after the legacy absence adapter. Both moved
+          // above that call site — the re-read is now the writer-branch selector and the refusal is
+          // replaced by the real writer, which returns before control can reach the adapter. Only
+          // shadow/eligible reach this point, and the arm below is unchanged.
 
           let calculationId: string | null = null
           if (inserted) {

--- a/packages/core-backend/tests/integration/attendance-w4c2-d3-scheduled-authoritative.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-w4c2-d3-scheduled-authoritative.db.test.ts
@@ -1331,22 +1331,31 @@ describeIfDatabase('W4C-2 Gate D3 — authoritative scheduled writer (real DB)',
     await retireParent(orgId, userIds[1])
     const { boundary, spies } = makeBoundary()
     await boundary.executeScheduledRun(scheduledInput(orgId, userIds))
-    // Scoped BY NAME to the two savepoints the authoritative path opens. A bare `^SAVEPOINT ` count
-    // would be wrong, not merely noisy: `assertConnectionIsIdleV1` issues `SAVEPOINT
-    // w4c5_idle_probe` on every connection acquisition and deliberately does NOT release it on the
-    // path it expects (the probe is meant to FAIL on an idle connection), so an unscoped balance
-    // assertion is unsatisfiable by construction and would have to be weakened until it proved
-    // nothing. Measured, then scoped.
-    const NAMES = ['attendance_w4c2_scheduled_authoritative', 'attendance_w4_auth_calc_op'] as const
-    for (const name of NAMES) {
-      const opened = spies.statements.filter((s) => s === `SAVEPOINT ${name}`).length
-      const released = spies.statements.filter((s) => s === `RELEASE SAVEPOINT ${name}`).length
-      expect({ name, opened: opened > 0 }).toEqual({ name, opened: true })
-      expect({ name, released }).toEqual({ name, released: opened })
-    }
-    const rolledBack = spies.statements.filter(
-      (s) => s === 'ROLLBACK TO SAVEPOINT attendance_w4c2_scheduled_authoritative',
-    ).length
+    // SCOPED BY NAME to D3's OWN savepoint, for two separately-measured reasons.
+    //
+    // (1) A bare `^SAVEPOINT ` count would be wrong, not merely noisy: `assertConnectionIsIdleV1`
+    //     issues `SAVEPOINT w4c5_idle_probe` on every connection acquisition and deliberately does
+    //     NOT release it on the path it expects (the probe is meant to FAIL on an idle connection),
+    //     so an unscoped balance assertion is unsatisfiable by construction and would have to be
+    //     weakened until it proved nothing.
+    //
+    // (2) The CORE's own savepoint (`attendance_w4_auth_calc_op`) is deliberately NOT asserted
+    //     here, and including it would be a latent FALSE pin. Its catch path rethrows anything that
+    //     is not a `uq_arc_operation` unique violation WITHOUT rolling back or releasing
+    //     (`w4c2-authoritative-calculation-core.ts`: `if (!isUniqueViolationOnConstraintV1(...))
+    //     throw error`) — correct, because the caller's own `ROLLBACK TO` subsumes it, but it does
+    //     leave opened > released for that name whenever the core refuses with e.g.
+    //     COMPLETED_SHAPE_INVALID / EXPECTED_COUNT_INVALID / PREIMAGE_INVALID. THIS fixture never
+    //     drives that arm (its refusal happens in the seam, before the core is called), so an
+    //     assertion over the core's name would pass today and red the moment a future leg drove a
+    //     core-internal refusal — and the obvious "fix" would be to weaken it. The core's savepoint
+    //     balance is the core's own property, pinned in the core's own suite.
+    const NAME = 'attendance_w4c2_scheduled_authoritative'
+    const opened = spies.statements.filter((s) => s === `SAVEPOINT ${NAME}`).length
+    const released = spies.statements.filter((s) => s === `RELEASE SAVEPOINT ${NAME}`).length
+    expect(opened).toBeGreaterThan(0)
+    expect(released).toBe(opened)
+    const rolledBack = spies.statements.filter((s) => s === `ROLLBACK TO SAVEPOINT ${NAME}`).length
     // The contained target's rollback really happened (otherwise this leg would be a balance
     // assertion over the success path only).
     expect(rolledBack).toBe(1)

--- a/packages/core-backend/tests/integration/attendance-w4c2-d3-scheduled-authoritative.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-w4c2-d3-scheduled-authoritative.db.test.ts
@@ -1,0 +1,1354 @@
+/**
+ * W4C-2 Gate D3 (#4556 / #4844) — real-Postgres proof of the AUTHORITATIVE `scheduled` writer in
+ * `src/attendance/w4c2-live-scheduled-boundary.ts`.
+ *
+ * WHAT THIS DRIVES: the production boundary factory (`createAttendanceLiveScheduledBoundaryV1`) over
+ * a real pool, wired to the REAL plugin adapters exported at
+ * `plugin-attendance/index.cjs :: __attendanceW4c2ScheduledAdaptersForTests` — the same functions
+ * `activate` injects. Only the LIVE adapters (never exercised here) are throwing stubs. The scheduled
+ * adapters are wrapped in call-count spies and an optional per-user FAULT map, which is what makes
+ * (a) the P-A control-flow pin (zero `applyScheduledAbsenceLegacy` invocations on the authoritative
+ * path) an observation rather than an argument, and (b) the containment scope negatives constructible
+ * without inventing a seam.
+ *
+ * D3'S DISTINCTIVE RISK, and therefore this suite's centre of gravity: PER-TARGET FAILURE
+ * CONTAINMENT. A refused target must be recorded as a terminal `'failed'` run outcome, its claimed
+ * operation must be CANCELED before commit (the deferred `trg_aro_claimed_commit_guard` makes
+ * committing a still-claimed operation illegal), the savepoint rollback must leave no orphan parent
+ * behind, and the batch must CONTINUE. Everything outside the contained classes must still abort so
+ * recovery/resume re-attempts the target instead of burning it terminally.
+ *
+ * WHY IT IS NOT PRODUCTION-REACHABLE ANYWAY: `effectiveState === 'authoritative'` additionally
+ * requires an EXACT-org entry in `ATTENDANCE_SHIFT_SEGMENT_CALCULATION_ENABLED` (wildcard never
+ * counts). This suite sets that env for its own throwaway org ids; production leaves it unset, so
+ * every production org collapses to `legacy` and the branch is unreachable irrespective of DB
+ * contents.
+ *
+ * Shared-DB discipline: every fixture identity is a run-namespaced UUID; W4 calculation/operation/
+ * outbox rows are append-only by design and are left behind.
+ */
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import crypto from 'node:crypto'
+import { Kysely, PostgresDialect } from 'kysely'
+import { Pool } from 'pg'
+import { up } from '../../src/db/migrations/zzzz20260725120000_w4c0_attendance_segment_calculation_durable_storage'
+import type { AttendanceW4TransactionClientV1 } from '../../src/attendance/w4c0-identity'
+import {
+  createAttendanceLiveScheduledBoundaryV1,
+  computeAuthoritativeScheduledPayloadFingerprintV1,
+  type AttendancePluginShapedTrxV1,
+  type AttendanceW4LiveScheduledBoundaryV1,
+  type AttendanceW4LiveScheduledLegacyAdaptersV1,
+} from '../../src/attendance/w4c2-live-scheduled-boundary'
+import { computeAttendanceImportRollbackPreimageFingerprintV1 } from '../../src/attendance/w4c3a-import-rollback'
+
+const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
+const describeIfDatabase = dbUrl ? describe : describe.skip
+
+const RUN = crypto.randomUUID().slice(0, 8)
+const TZ = 'UTC'
+const WORK_DATE = '2026-06-08'
+
+function uuid(): string {
+  return crypto.randomUUID()
+}
+
+type ScheduledAdapters = {
+  generateAbsenceRecords: (
+    trx: AttendancePluginShapedTrxV1,
+    orgId: string,
+    workDate: string,
+    timezone: string,
+    userIds: readonly string[],
+  ) => Promise<Array<{ user_id: string }>>
+  resolveW4ScheduledCandidateInTransactionV1: (
+    trx: AttendancePluginShapedTrxV1,
+    args: unknown,
+  ) => Promise<any>
+  buildW4ShadowFrozenContextV1: (trx: AttendancePluginShapedTrxV1, args: unknown) => Promise<any>
+}
+
+/**
+ * A per-user fault injected at a NAMED adapter seam. The boundary calls these seams from INSIDE the
+ * authoritative branch's savepoint, so a fault is thrown exactly where a real refusal of that class
+ * would be — which is what lets the scope negatives (untyped abort, non-contained typed abort,
+ * retryable-SQLSTATE retry) be constructed at all.
+ */
+type Fault = {
+  readonly userId: string
+  readonly seam: 'resolveScheduledCandidate' | 'buildShadowFrozenContext'
+  /** Called on each invocation for that user; return an error to throw, or null to pass through. */
+  readonly make: (attempt: number) => unknown | null
+}
+
+describeIfDatabase('W4C-2 Gate D3 — authoritative scheduled writer (real DB)', () => {
+  const pool = new Pool({ connectionString: dbUrl })
+  let migrationDb: Kysely<unknown> | undefined
+  let adapters: ScheduledAdapters
+  let priorAllowlistEnv: string | undefined
+  const allowlistedOrgs: string[] = []
+
+  /** Registers an org in the exact-org env allowlist BEFORE any boundary call for it. */
+  function allow(orgId: string): string {
+    allowlistedOrgs.push(orgId)
+    process.env.ATTENDANCE_SHIFT_SEGMENT_CALCULATION_ENABLED = allowlistedOrgs.join(',')
+    return orgId
+  }
+
+  /**
+   * Removes an org from the exact-org allowlist — the ONLY reachable mid-run demotion out of
+   * `authoritative`. The rollout state machine's own edges out of `authoritative` go to `suspended`
+   * and nowhere else (`attendance_w4_rollout_state_guard`), so a state-row demotion cannot express
+   * "the org stopped being authoritative but the run keeps going"; withdrawing the env entry can,
+   * and it is exactly the owner-actioned lever §2.3's byte-neutrality argument rests on.
+   */
+  function disallow(orgId: string): void {
+    const index = allowlistedOrgs.indexOf(orgId)
+    if (index >= 0) allowlistedOrgs.splice(index, 1)
+    process.env.ATTENDANCE_SHIFT_SEGMENT_CALCULATION_ENABLED = allowlistedOrgs.join(',')
+  }
+
+  beforeAll(async () => {
+    migrationDb = new Kysely<unknown>({
+      dialect: new PostgresDialect({ pool: new Pool({ connectionString: dbUrl }) }),
+    })
+    await up(migrationDb)
+    priorAllowlistEnv = process.env.ATTENDANCE_SHIFT_SEGMENT_CALCULATION_ENABLED
+    // The scheduled adapters are pure DB functions over the plugin-shaped `trx` (unlike the live
+    // resolver, they need no `activate`-installed host port), so this suite requires no server boot.
+    const { createRequire } = await import('module')
+    const requireCjs = createRequire(import.meta.url)
+    const plugin = requireCjs('../../../../plugins/plugin-attendance/index.cjs') as {
+      __attendanceW4c2ScheduledAdaptersForTests: ScheduledAdapters
+    }
+    adapters = plugin.__attendanceW4c2ScheduledAdaptersForTests
+  }, 180000)
+
+  afterAll(async () => {
+    if (priorAllowlistEnv === undefined) delete process.env.ATTENDANCE_SHIFT_SEGMENT_CALCULATION_ENABLED
+    else process.env.ATTENDANCE_SHIFT_SEGMENT_CALCULATION_ENABLED = priorAllowlistEnv
+    await migrationDb?.destroy()
+    await pool.end()
+  })
+
+  // ---- boundary driver ----------------------------------------------------
+
+  interface Spies {
+    applyScheduledAbsenceLegacy: number
+    absenceUserIds: string[]
+    resolveScheduledCandidate: number
+    buildShadowFrozenContext: number
+    /** Every statement the boundary issued through the canonical client, in order. */
+    statements: string[]
+  }
+
+  function makeBoundary(faults: readonly Fault[] = []): {
+    boundary: AttendanceW4LiveScheduledBoundaryV1
+    spies: Spies
+  } {
+    const spies: Spies = {
+      applyScheduledAbsenceLegacy: 0,
+      absenceUserIds: [],
+      resolveScheduledCandidate: 0,
+      buildShadowFrozenContext: 0,
+      statements: [],
+    }
+    const attempts = new Map<string, number>()
+    function faultFor(seam: Fault['seam'], userId: string): unknown | null {
+      const fault = faults.find((f) => f.seam === seam && f.userId === userId)
+      if (!fault) return null
+      const key = `${seam}:${userId}`
+      const attempt = (attempts.get(key) ?? 0) + 1
+      attempts.set(key, attempt)
+      return fault.make(attempt)
+    }
+    const unreached = (name: string) => async () => {
+      throw new Error(`W4C2_D3_LIVE_STUB_${name}_MUST_NOT_BE_REACHED`)
+    }
+    const legacyAdapters: AttendanceW4LiveScheduledLegacyAdaptersV1 = {
+      applyLivePunchLegacy: unreached('applyLivePunchLegacy') as never,
+      insertLivePunchEvent: unreached('insertLivePunchEvent') as never,
+      deriveLivePunchWorkDateResolution: unreached('deriveLivePunchWorkDateResolution') as never,
+      resolveLiveCandidate: unreached('resolveLiveCandidate') as never,
+      applyScheduledAbsenceLegacy: (trx, args) => {
+        spies.applyScheduledAbsenceLegacy += 1
+        spies.absenceUserIds.push(...args.userIds)
+        return adapters.generateAbsenceRecords(trx, args.orgId, args.workDate, args.timezone, args.userIds)
+      },
+      resolveScheduledCandidate: async (trx, args) => {
+        spies.resolveScheduledCandidate += 1
+        const injected = faultFor('resolveScheduledCandidate', String((args as { userId: string }).userId))
+        if (injected !== null) throw injected
+        return adapters.resolveW4ScheduledCandidateInTransactionV1(trx, args)
+      },
+      buildShadowFrozenContext: async (trx, args) => {
+        spies.buildShadowFrozenContext += 1
+        const injected = faultFor('buildShadowFrozenContext', String((args as { userId: string }).userId))
+        if (injected !== null) throw injected
+        return adapters.buildW4ShadowFrozenContextV1(trx, args)
+      },
+    }
+    const boundary = createAttendanceLiveScheduledBoundaryV1({
+      acquireConnection: async () => {
+        const client = await pool.connect()
+        const wrapped = {
+          query: (sqlText: string, params?: unknown[]) => {
+            spies.statements.push(sqlText.trim().split('\n')[0].trim())
+            return (client as unknown as { query: (s: string, p?: unknown[]) => Promise<unknown> }).query(
+              sqlText,
+              params,
+            )
+          },
+        } as unknown as AttendanceW4TransactionClientV1
+        return { client: wrapped, release: () => client.release() }
+      },
+      legacyAdapters,
+    })
+    return { boundary, spies }
+  }
+
+  // ---- fixtures -----------------------------------------------------------
+
+  async function insertActiveUser(userId: string, orgId: string): Promise<void> {
+    await pool.query(
+      `INSERT INTO users (id, email, username, name, password_hash, role, permissions, is_active, is_admin, created_at, updated_at)
+       VALUES ($1, $2, $1, 'W4C-2 d3 fixture', 'x', 'user', '[]'::jsonb, true, false, now(), now())
+       ON CONFLICT (id) DO NOTHING`,
+      [userId, `${userId}@w4c2-d3.test`],
+    )
+    await pool.query(
+      `INSERT INTO user_orgs (user_id, org_id, is_active) VALUES ($1, $2, true) ON CONFLICT DO NOTHING`,
+      [userId, orgId],
+    )
+  }
+
+  async function insertRolloutRow(orgId: string, state: string): Promise<void> {
+    await pool.query(
+      `INSERT INTO attendance_calculation_rollout_state (org_id, state, engine_version, reason_code, actor_id, version, prior_state)
+       VALUES ($1, $2, 'w4c2-d3', 'TEST_FIXTURE', 'w4c2-d3-actor', 1, NULL)`,
+      [orgId, state],
+    )
+  }
+
+  /** Walks the rollout row's legal edges to `authoritative` (the ops tool refuses this promotion). */
+  async function walkRolloutToAuthoritative(orgId: string): Promise<void> {
+    await insertRolloutRow(orgId, 'legacy')
+    for (const [state, prior, version] of [
+      ['shadow', 'legacy', 2],
+      ['eligible', 'shadow', 3],
+      ['authoritative', 'eligible', 4],
+    ] as const) {
+      await pool.query(
+        `UPDATE attendance_calculation_rollout_state SET state = $2, prior_state = $3, version = $4 WHERE org_id = $1`,
+        [orgId, state, prior, version],
+      )
+    }
+  }
+
+  /**
+   * `suspended` is not a legal INITIAL state and the only edge into it is from `authoritative`
+   * (`attendance_w4_rollout_state_guard`), so the whole walk is required — a direct INSERT is
+   * refused by the DB, which is why this helper exists rather than an `insertRolloutRow` call.
+   */
+  async function walkRolloutToSuspended(orgId: string): Promise<void> {
+    await walkRolloutToAuthoritative(orgId)
+    await pool.query(
+      `UPDATE attendance_calculation_rollout_state
+          SET state = 'suspended', prior_state = 'authoritative', version = 5
+        WHERE org_id = $1`,
+      [orgId],
+    )
+  }
+
+  async function insertShiftAndAssignment(orgId: string, userId: string): Promise<string> {
+    const shiftId = uuid()
+    await pool.query(
+      `INSERT INTO attendance_shifts (id, org_id, name, work_start_time, work_end_time, timezone)
+       VALUES ($1, $2, $3, '09:00', '18:00', $4)`,
+      [shiftId, orgId, `w4c2-d3-${RUN}-${shiftId.slice(0, 6)}`, TZ],
+    )
+    await pool.query(
+      `INSERT INTO attendance_shift_assignments
+         (id, org_id, user_id, shift_id, slot_index, start_date, end_date, is_active, publish_status, assignment_kind)
+       VALUES ($1, $2, $3, $4, 0, '2026-06-01', NULL, true, 'published', 'regular')`,
+      [uuid(), orgId, userId, shiftId],
+    )
+    return shiftId
+  }
+
+  /**
+   * An authoritative org plus `count` active users. `withShift` decides whether the freeze step can
+   * resolve a `resolved_v2` attribution at all: WITH a shift the scheduled calculation reaches
+   * `completed` (every segment `missing_both` over untimed `scheduled_absence` evidence ⇒ daily
+   * status `absent` — an authoritative "generated absence day"); WITHOUT one the attribution is
+   * `unsupported` and the calculation is `review_required`.
+   */
+  async function seedAuthoritativeOrg(
+    count: number,
+    options: { withShift?: boolean; state?: string } = {},
+  ): Promise<{ orgId: string; userIds: string[] }> {
+    const orgId = allow(uuid())
+    const userIds: string[] = []
+    for (let i = 0; i < count; i += 1) {
+      const userId = uuid()
+      await insertActiveUser(userId, orgId)
+      if (options.withShift === true) await insertShiftAndAssignment(orgId, userId)
+      userIds.push(userId)
+    }
+    if (options.state === undefined) await walkRolloutToAuthoritative(orgId)
+    else await insertRolloutRow(orgId, options.state)
+    return { orgId, userIds }
+  }
+
+  function scheduledInput(orgId: string, userIds: readonly string[], workDate = WORK_DATE) {
+    return {
+      orgId,
+      workDate,
+      timezone: TZ,
+      targetUserIds: [...userIds],
+      reviewTargets: [] as ReadonlyArray<{ userId: string; reasonCode: string }>,
+      initiator: 'cron' as const,
+      adminActorId: null,
+    }
+  }
+
+  // ---- readers ------------------------------------------------------------
+
+  const recordRows = async (orgId: string, userId?: string) =>
+    (await pool.query(
+      `SELECT id::text AS id, user_id, work_date::text AS work_date, status,
+              first_in_at, last_out_at, work_minutes, late_minutes, early_leave_minutes,
+              projection_owner, current_calculation_id::text AS current_calculation_id,
+              visibility_state, visibility_reason, updated_at
+         FROM attendance_records
+        WHERE org_id = $1 AND ($2::text IS NULL OR user_id = $2)
+        ORDER BY user_id`,
+      [orgId, userId ?? null],
+    )).rows
+
+  const calcRows = async (orgId: string, recordId?: string) =>
+    (await pool.query(
+      `SELECT id::text AS id, attendance_record_id::text AS attendance_record_id, version,
+              calculation_kind, entrypoint, outcome, outcome_reason_code, projection_effect,
+              operation_id::text AS operation_id, input_provenance, projected_status,
+              expected_segment_count, calculation_tier
+         FROM attendance_record_calculations
+        WHERE org_id = $1 AND ($2::text IS NULL OR attendance_record_id = $2::uuid)
+        ORDER BY version`,
+      [orgId, recordId ?? null],
+    )).rows
+
+  /**
+   * `attendance_result_operations` carries no subject column, so the per-target user is recovered
+   * through the durable run target row that OWNS the operation id — the same join the run registry
+   * itself uses, not a fabricated correlation.
+   */
+  const operationRows = async (orgId: string) =>
+    (await pool.query(
+      `SELECT o.operation_id::text AS operation_id, o.state, o.response_snapshot,
+              o.resolved_calculation_id::text AS resolved_calculation_id,
+              o.resolved_record_id::text AS resolved_record_id,
+              t.user_id AS subject_user_id
+         FROM attendance_result_operations o
+         JOIN attendance_scheduled_run_targets t
+              ON t.operation_id = o.operation_id AND t.org_id = o.org_id
+        WHERE o.org_id = $1 AND o.entrypoint = 'scheduled'
+        ORDER BY o.created_at`,
+      [orgId],
+    )).rows
+
+  const runRows = async (orgId: string, workDate = WORK_DATE) =>
+    (await pool.query(
+      `SELECT run_id::text AS run_id, initiator, work_date::text AS work_date, generation, state,
+              expected_user_count, review_count, completed_user_count, generated_count
+         FROM attendance_scheduled_runs
+        WHERE org_id = $1 AND work_date = $2::date
+        ORDER BY generation ASC`,
+      [orgId, workDate],
+    )).rows
+
+  const outcomeRows = async (orgId: string) =>
+    (await pool.query(
+      `SELECT t.user_id, o.terminal_outcome, o.failure_reason_code
+         FROM attendance_scheduled_run_target_outcomes o
+         JOIN attendance_scheduled_run_targets t ON t.id = o.target_id AND t.org_id = o.org_id
+        WHERE o.org_id = $1
+        ORDER BY t.user_id`,
+      [orgId],
+    )).rows
+
+  const outboxRows = async (orgId: string) =>
+    (await pool.query(
+      `SELECT identity_kind, event_kind, payload, scheduled_run_id::text AS scheduled_run_id
+         FROM attendance_result_event_outbox
+        WHERE org_id = $1 ORDER BY created_at`,
+      [orgId],
+    )).rows
+
+  /**
+   * Retires a LEGACY-untracked parent with `import_rollback`, as pure fixture state BEFORE the run
+   * is created — constructible precisely because `'generate'` targets are NOT NOT-EXISTS-filtered at
+   * run creation, so a pre-existing retired row is an ordinary starting state for a target.
+   *
+   * `operator_retirement` is NOT installable this way: `attendance_w4_records_pointer_guard` refuses
+   * a `legacy_untracked` parent carrying that reason ("operator retirement requires a W4 pointer").
+   * Leg 6a therefore builds its fixture through the core's own reversal writer — fabricating an
+   * impossible row would have made that leg vacuous.
+   */
+  async function retireParent(orgId: string, userId: string, workDate = WORK_DATE): Promise<string> {
+    const recordId = uuid()
+    await pool.query(
+      `INSERT INTO attendance_records
+         (id, org_id, user_id, work_date, timezone, first_in_at, last_out_at,
+          work_minutes, late_minutes, early_leave_minutes, status, is_workday, meta,
+          projection_owner, current_calculation_id, visibility_state, visibility_reason,
+          created_at, updated_at)
+       VALUES ($1, $2, $3, $4::date, $5, NULL, NULL, 0, 0, 0, 'normal', true, '{}'::jsonb,
+               'legacy_untracked', NULL, 'retired', 'import_rollback', now(), now())`,
+      [recordId, orgId, userId, workDate, TZ],
+    )
+    return recordId
+  }
+
+  /**
+   * Builds a genuinely `operator_retirement`-retired parent the way production does: an authoritative
+   * completed scheduled target takes W4 ownership of the day, then the core's OWN reversal writer
+   * retires it. The DB pointer guard validates the result end to end (pointer target must be an
+   * authoritative reversed row with effect `set_retired`, reason `operator_retirement`, and the
+   * parent's daily fields must equal its frozen snapshot), so this is a REAL row, not a state the
+   * schema would never produce — and not a hand-written UPDATE the guard would refuse anyway.
+   */
+  async function retireParentOperatorRetirement(
+    orgId: string,
+    userId: string,
+    workDate: string,
+  ): Promise<void> {
+    const { boundary } = makeBoundary()
+    const seedRun = await boundary.executeScheduledRun(scheduledInput(orgId, [userId], workDate))
+    expect(seedRun.kind).toBe('w4')
+    const promoted = (await recordRows(orgId, userId)).find((r) => r.work_date === workDate)
+    expect(promoted?.projection_owner).toBe('w4')
+    const { projectedDailyFingerprintV1, writeAuthoritativeReversalV1 } = await import(
+      '../../src/attendance/w4c2-authoritative-calculation-core'
+    )
+    const retiredProjection = {
+      status: 'absent',
+      firstInAt: null,
+      lastOutAt: null,
+      workMinutes: 0,
+      lateMinutes: 0,
+      earlyLeaveMinutes: 0,
+    }
+    const client = await pool.connect()
+    try {
+      await client.query('BEGIN')
+      await writeAuthoritativeReversalV1(client as unknown as AttendanceW4TransactionClientV1, {
+        orgId,
+        recordId: String(promoted?.id),
+        entrypoint: 'ops_retirement',
+        operationId: uuid(),
+        supersedesCalculationId: String(promoted?.current_calculation_id),
+        reversedSnapshots: {
+          semanticInputFingerprint: 'a'.repeat(64),
+          provenanceFingerprint: 'a'.repeat(64),
+          sourceDefinitionFingerprint: 'a'.repeat(64),
+          attributionSnapshot: {
+            posture: 'unsupported',
+            sourceSchemaVersion: 1,
+            reason: 'legacy_v1',
+            sourceFingerprint: null,
+          },
+          contextSnapshot: { schemaVersion: 1, kind: 'w4c2_d3_fixture_context' },
+          evidenceSnapshot: [],
+          approvedFactsSnapshot: [],
+          manualOverrideSnapshot: null,
+        },
+        inputProvenance: { schemaVersion: 1, kind: 'w4c2_d3_fixture' },
+        preimage: { posture: 'absent' },
+        frozenTarget: {
+          visibilityState: 'retired',
+          visibilityReason: 'operator_retirement',
+          projection: retiredProjection,
+          dailyFingerprint: projectedDailyFingerprintV1({
+            status: retiredProjection.status,
+            firstInAt: null,
+            lastOutAt: null,
+            workedMinutes: 0,
+            lateMinutes: 0,
+            earlyLeaveMinutes: 0,
+          }),
+        },
+        restoresCalculationId: null,
+        outcomeReasonCode: 'operator_retirement',
+        mergePolicy: 'retire',
+        actorId: `w4c2-d3-${RUN}`,
+        correlationId: `w4c2-d3-${RUN}`,
+      })
+      await client.query('COMMIT')
+    } catch (error) {
+      await client.query('ROLLBACK').catch(() => undefined)
+      throw error
+    } finally {
+      client.release()
+    }
+    // The fixture is REAL: assert the row actually reached the state under test, so a silently
+    // skipped retirement cannot make the leg vacuous.
+    const retired = (await recordRows(orgId, userId)).find((r) => r.work_date === workDate)
+    expect(retired?.visibility_state).toBe('retired')
+    expect(retired?.visibility_reason).toBe('operator_retirement')
+  }
+
+  // =========================================================================
+  // Legs.
+  // =========================================================================
+
+  it('leg 1 — F6 fresh review, parent ABSENT: create-if-absent placeholder + review calc, NO legacy-ACTIVE absent row anywhere', async () => {
+    const { orgId, userIds } = await seedAuthoritativeOrg(1)
+    const { boundary, spies } = makeBoundary()
+    const result = await boundary.executeScheduledRun(scheduledInput(orgId, userIds))
+
+    expect(result.kind).toBe('w4')
+    if (result.kind !== 'w4') throw new Error('unreachable')
+    expect(result.perUser).toEqual([{ userId: userIds[0], mode: 'executed', inserted: false }])
+    expect(result.rows).toEqual([])
+
+    const records = await recordRows(orgId)
+    expect(records.length).toBe(1)
+    // The §7.5 F6 four-tuple, and the §7.5 pin: NO legacy-ACTIVE `'absent'` row was fabricated.
+    expect(records[0]).toMatchObject({
+      projection_owner: 'legacy_untracked',
+      current_calculation_id: null,
+      visibility_state: 'retired',
+      visibility_reason: 'review_placeholder',
+    })
+    expect(records[0].first_in_at).toBeNull()
+    expect(records[0].last_out_at).toBeNull()
+    expect(
+      records.filter((r) => r.status === 'absent' && r.visibility_state === 'active').length,
+    ).toBe(0)
+
+    const calcs = await calcRows(orgId, String(records[0].id))
+    expect(calcs.length).toBe(1)
+    expect(calcs[0]).toMatchObject({
+      calculation_kind: 'calculation',
+      entrypoint: 'scheduled',
+      outcome: 'review_required',
+      projection_effect: 'none',
+      calculation_tier: 'segment_authoritative',
+    })
+    const children = await pool.query(
+      `SELECT count(*)::int AS n FROM attendance_record_segments WHERE calculation_id = $1::uuid`,
+      [calcs[0].id],
+    )
+    expect(children.rows[0].n).toBe(0)
+
+    // Seal contract PRESERVED: exactly `{inserted}` plus the resolved calculation id.
+    const ops = await operationRows(orgId)
+    expect(ops.length).toBe(1)
+    expect(ops[0].state).toBe('completed')
+    expect(ops[0].response_snapshot).toEqual({ inserted: false })
+    expect(ops[0].resolved_calculation_id).toBe(calcs[0].id)
+
+    expect(await outcomeRows(orgId)).toEqual([
+      { user_id: userIds[0], terminal_outcome: 'completed', failure_reason_code: null },
+    ])
+    // P-A: the legacy absence adapter was never invoked on this path.
+    expect(spies.applyScheduledAbsenceLegacy).toBe(0)
+  })
+
+  it('leg 2 [GATING] — fresh COMPLETED, parent ABSENT: placeholder created then promoted to w4/active/active, and NO legacy_baseline row', async () => {
+    const { orgId, userIds } = await seedAuthoritativeOrg(1, { withShift: true })
+    const { boundary, spies } = makeBoundary()
+    const result = await boundary.executeScheduledRun(scheduledInput(orgId, userIds))
+    expect(result.kind).toBe('w4')
+    if (result.kind !== 'w4') throw new Error('unreachable')
+    expect(result.perUser).toEqual([{ userId: userIds[0], mode: 'executed', inserted: true }])
+    expect(result.rows).toEqual([{ user_id: userIds[0] }])
+
+    const records = await recordRows(orgId)
+    expect(records.length).toBe(1)
+    // ONE ATOMIC PROMOTION: the retired/review_placeholder row the branch installed is flipped by
+    // the core's own tail pointer UPDATE, in the same transaction.
+    expect(records[0]).toMatchObject({
+      projection_owner: 'w4',
+      visibility_state: 'active',
+      visibility_reason: 'active',
+      // A scheduled absence day: every segment `missing_both` over untimed evidence.
+      status: 'absent',
+    })
+    expect(records[0].current_calculation_id).not.toBeNull()
+
+    const calcs = await calcRows(orgId, String(records[0].id))
+    // The GATING assertion: a `retired`/`review_placeholder` parent matches NEITHER the
+    // `w4`-supersedes arm nor the `legacy_untracked`+active baseline arm, so no baseline is written.
+    expect(calcs.map((c) => c.calculation_kind)).toEqual(['calculation'])
+    expect(calcs.filter((c) => c.calculation_kind === 'legacy_baseline').length).toBe(0)
+    expect(calcs[0]).toMatchObject({
+      outcome: 'completed',
+      entrypoint: 'scheduled',
+      projected_status: 'absent',
+      calculation_tier: 'segment_authoritative',
+    })
+    expect(String(records[0].current_calculation_id)).toBe(String(calcs[0].id))
+
+    const ops = await operationRows(orgId)
+    expect(ops[0].response_snapshot).toEqual({ inserted: true })
+    expect(spies.applyScheduledAbsenceLegacy).toBe(0)
+    // Non-vacuity for the whole `withShift` fixture family: the freeze step really resolved.
+    expect(spies.buildShadowFrozenContext).toBeGreaterThan(0)
+  })
+
+  it('leg 3 — zero-invocation spy (the scheduled P-A pin): authoritative run invokes applyScheduledAbsenceLegacy ZERO times; the shadow control invokes it once per target', async () => {
+    const authoritative = await seedAuthoritativeOrg(3, { withShift: true })
+    const { boundary, spies } = makeBoundary()
+    await boundary.executeScheduledRun(scheduledInput(authoritative.orgId, authoritative.userIds))
+    expect(spies.applyScheduledAbsenceLegacy).toBe(0)
+    expect(spies.absenceUserIds).toEqual([])
+
+    // NEGATIVE CONTROL — same code path, shadow posture: the adapter IS called, once per target.
+    // Without this the zero above could mean "the run did nothing at all".
+    // NOTE the `allow`: `shadow` is an ENV-gated posture too — an org with a `shadow` rollout row
+    // but no exact-org allowlist entry collapses to `legacy` and would take the probe's legacy
+    // batch arm instead, making this "control" measure a different code path entirely.
+    const shadowOrg = allow(uuid())
+    const shadowUsers: string[] = []
+    for (let i = 0; i < 3; i += 1) {
+      const userId = uuid()
+      await insertActiveUser(userId, shadowOrg)
+      shadowUsers.push(userId)
+    }
+    await insertRolloutRow(shadowOrg, 'shadow')
+    const shadow = makeBoundary()
+    const shadowResult = await shadow.boundary.executeScheduledRun(scheduledInput(shadowOrg, shadowUsers))
+    expect(shadowResult.kind).toBe('w4')
+    expect(shadow.spies.applyScheduledAbsenceLegacy).toBe(3)
+    expect(shadow.spies.absenceUserIds.sort()).toEqual([...shadowUsers].sort())
+  })
+
+  it('leg 4a [GATING] + 6b — guard-409 (import_rollback) is CONTAINED: target 2 records failed, targets 1 and 3 complete, the batch never aborts, and the retired parent is bit-identical', async () => {
+    const { orgId, userIds } = await seedAuthoritativeOrg(3, { withShift: true })
+    // Pure DB fixture state, seeded BEFORE the run is created — no timing, no injected stub.
+    // Constructible precisely because `'generate'` targets are NOT NOT-EXISTS-filtered at run
+    // creation (`runAutoAbsenceForOrgDate` derives them from active membership alone).
+    const retiredRecordId = await retireParent(orgId, userIds[1])
+    const before = (await recordRows(orgId, userIds[1]))[0]
+
+    const { boundary, spies } = makeBoundary()
+    const result = await boundary.executeScheduledRun(scheduledInput(orgId, userIds))
+    expect(result.kind).toBe('w4')
+    if (result.kind !== 'w4') throw new Error('unreachable')
+
+    // THE CONTAINMENT ASSERTION: the batch continued past the refusal.
+    expect(result.perUser).toEqual([
+      { userId: userIds[0], mode: 'executed', inserted: true },
+      { userId: userIds[1], mode: 'failed', inserted: false },
+      { userId: userIds[2], mode: 'executed', inserted: true },
+    ])
+    expect(result.rows).toEqual([{ user_id: userIds[0] }, { user_id: userIds[2] }])
+
+    expect(await outcomeRows(orgId)).toEqual(
+      [
+        { user_id: userIds[0], terminal_outcome: 'completed', failure_reason_code: null },
+        {
+          user_id: userIds[1],
+          terminal_outcome: 'failed',
+          failure_reason_code: 'ATTENDANCE_SCHEDULED_TARGET_OPERATION_REJECTED',
+        },
+        { user_id: userIds[2], terminal_outcome: 'completed', failure_reason_code: null },
+      ].sort((a, b) => (a.user_id < b.user_id ? -1 : 1)),
+    )
+
+    const runs = await runRows(orgId)
+    expect(runs.length).toBe(1)
+    expect(runs[0]).toMatchObject({
+      state: 'completed',
+      expected_user_count: 3,
+      completed_user_count: 2,
+      generated_count: 2,
+    })
+
+    // BIT-IDENTICAL parent: no reactivation, no pointer move, no new calc row, and the row was not
+    // even touched (`updated_at` unchanged).
+    const after = (await recordRows(orgId, userIds[1]))[0]
+    expect(after).toEqual(before)
+    expect(after).toMatchObject({
+      visibility_state: 'retired',
+      visibility_reason: 'import_rollback',
+      projection_owner: 'legacy_untracked',
+      current_calculation_id: null,
+    })
+    expect(await calcRows(orgId, retiredRecordId)).toEqual([])
+    expect(spies.applyScheduledAbsenceLegacy).toBe(0)
+
+    // RESUME does not re-loop a terminal target. Driven through the recovery entrypoint against
+    // THIS run id (an ordinary re-drive would mint a fresh generation instead, which is a different
+    // question — see leg 6.10): the outstanding set is the LEFT JOIN's `o.id IS NULL`, and a
+    // `'failed'` row is an outcome row, so target 2 is excluded exactly like the completed ones.
+    const outcomesBefore = await outcomeRows(orgId)
+    const resume = makeBoundary()
+    const second = await resume.boundary.recoverScheduledRun({
+      ...scheduledInput(orgId, userIds),
+      runId: String(runs[0].run_id),
+    })
+    expect(second.kind).toBe('w4')
+    if (second.kind !== 'w4') throw new Error('unreachable')
+    expect(second.perUser).toEqual([])
+    expect(await outcomeRows(orgId)).toEqual(outcomesBefore)
+    expect(resume.spies.resolveScheduledCandidate).toBe(0)
+  })
+
+  it('leg 4e [GATING] — claim disposition: the contained-failed target is CANCELED with a NULL response (never sealed), the successful targets are completed, and the per-target transaction COMMITS', async () => {
+    const { orgId, userIds } = await seedAuthoritativeOrg(3, { withShift: true })
+    await retireParent(orgId, userIds[1])
+    const { boundary } = makeBoundary()
+    await boundary.executeScheduledRun(scheduledInput(orgId, userIds))
+
+    const ops = await operationRows(orgId)
+    expect(ops.length).toBe(3)
+    const failed = ops.filter((o) => o.subject_user_id === userIds[1])
+    expect(failed.length).toBe(1)
+    // The legal terminal disposition for a claimed operation that produced no result. If this were
+    // left `claimed`, the deferred `trg_aro_claimed_commit_guard` would raise `W4C0_CLAIMED_COMMIT`
+    // at COMMIT and abort the batch — containment that does not contain.
+    expect(failed[0].state).toBe('canceled')
+    // SECOND ASSERTION, guarding the direction: a contained failure is NEVER sealed, so the
+    // "seal ⇒ success snapshot" invariant survives rather than being strained.
+    expect(failed[0].response_snapshot).toBeNull()
+    expect(failed[0].resolved_calculation_id).toBeNull()
+    expect(failed[0].resolved_record_id).toBeNull()
+
+    for (const userId of [userIds[0], userIds[2]]) {
+      const ok = ops.find((o) => o.subject_user_id === userId)
+      expect(ok?.state).toBe('completed')
+      expect(ok?.response_snapshot).toEqual({ inserted: true })
+    }
+
+    // The per-target transactions COMMITTED: the run reached `completed`, which requires every
+    // outcome row to be durably visible to the finalize transaction.
+    expect((await runRows(orgId))[0].state).toBe('completed')
+    // And nothing is left in the intermediate state the commit guard forbids.
+    expect(ops.filter((o) => o.state === 'claimed').length).toBe(0)
+  })
+
+  it('leg 6a — guard-409 (operator_retirement) is CONTAINED with ZERO reactivation, over a parent retired through the core\'s own reversal writer (a real row the pointer guard validates end to end)', async () => {
+    const { orgId, userIds } = await seedAuthoritativeOrg(3, { withShift: true })
+    // Generation 1 completes target 2 and takes W4 ownership of the day; the reversal writer then
+    // retires it with `operator_retirement`. That order is forced by the schema, not chosen for
+    // convenience: a `legacy_untracked` parent may not carry that reason at all.
+    await retireParentOperatorRetirement(orgId, userIds[1], WORK_DATE)
+    const before = (await recordRows(orgId, userIds[1]))[0]
+    expect(before.visibility_reason).toBe('operator_retirement')
+
+    // Generation 2 (a completed run is never resumed, so this mints fresh operation ids) drives all
+    // three targets, with target 2 now operator-retired.
+    const { boundary } = makeBoundary()
+    const result = await boundary.executeScheduledRun(scheduledInput(orgId, userIds))
+    expect(result.kind).toBe('w4')
+    if (result.kind !== 'w4') throw new Error('unreachable')
+    expect(result.perUser.find((p) => p.userId === userIds[1])).toEqual({
+      userId: userIds[1],
+      mode: 'failed',
+      inserted: false,
+    })
+    expect(result.perUser.filter((p) => p.mode === 'executed').length).toBe(2)
+    // ZERO REACTIVATION: without the guard the core's completed-path pointer UPDATE would flip this
+    // parent back to `w4/active/active` unconditionally — it is reason-BLIND.
+    expect((await recordRows(orgId, userIds[1]))[0]).toEqual(before)
+    const outcomes = await outcomeRows(orgId)
+    expect(outcomes.filter((o) => o.user_id === userIds[1] && o.terminal_outcome === 'failed').length).toBe(1)
+
+    // VARIANT (a second case, not the primary): the parent is retired BETWEEN run creation and the
+    // per-target transaction, rather than being retired before the run existed at all.
+    const variantWorkDate = '2026-06-09'
+    await retireParentOperatorRetirement(orgId, userIds[2], variantWorkDate)
+    const variant = makeBoundary()
+    const variantResult = await variant.boundary.executeScheduledRun(
+      scheduledInput(orgId, [userIds[2]], variantWorkDate),
+    )
+    expect(variantResult.kind).toBe('w4')
+    if (variantResult.kind !== 'w4') throw new Error('unreachable')
+    expect(variantResult.perUser).toEqual([{ userId: userIds[2], mode: 'failed', inserted: false }])
+  })
+
+  it('leg 5a — a RETRYABLE serialization conflict (40001) is retried and SUCCEEDS; it is never converted to a failed outcome', async () => {
+    const { orgId, userIds } = await seedAuthoritativeOrg(2, { withShift: true })
+    // Thrown from inside the authoritative branch on the FIRST attempt only. The registry's own
+    // whole-transaction retry re-runs the body; the second attempt passes through.
+    const fault: Fault = {
+      userId: userIds[1],
+      seam: 'resolveScheduledCandidate',
+      make: (attempt) =>
+        attempt === 1 ? Object.assign(new Error('serialization_failure'), { code: '40001' }) : null,
+    }
+    const { boundary, spies } = makeBoundary([fault])
+    const result = await boundary.executeScheduledRun(scheduledInput(orgId, userIds))
+    expect(result.kind).toBe('w4')
+    if (result.kind !== 'w4') throw new Error('unreachable')
+    expect(result.perUser).toEqual([
+      { userId: userIds[0], mode: 'executed', inserted: true },
+      { userId: userIds[1], mode: 'executed', inserted: true },
+    ])
+    // Non-vacuity: the fault really fired (the seam was entered twice for that user).
+    expect(spies.resolveScheduledCandidate).toBeGreaterThanOrEqual(3)
+    const outcomes = await outcomeRows(orgId)
+    expect(outcomes.filter((o) => o.terminal_outcome === 'failed').length).toBe(0)
+    expect((await runRows(orgId))[0]).toMatchObject({ state: 'completed', generated_count: 2 })
+  })
+
+  it('leg 5b — an UNTYPED error still ABORTS the batch, and the run stays resumable with the outstanding set intact', async () => {
+    const { orgId, userIds } = await seedAuthoritativeOrg(3, { withShift: true })
+    const fault: Fault = {
+      userId: userIds[1],
+      seam: 'resolveScheduledCandidate',
+      make: () => new Error('W4C2_D3_UNTYPED_PROBE'),
+    }
+    const { boundary } = makeBoundary([fault])
+    await expect(boundary.executeScheduledRun(scheduledInput(orgId, userIds))).rejects.toThrow(
+      'W4C2_D3_UNTYPED_PROBE',
+    )
+    // Target 1 committed; target 2 aborted; target 3 was never attempted. The run is still running.
+    const runs = await runRows(orgId)
+    expect(runs.length).toBe(1)
+    expect(runs[0].state).toBe('running')
+    const outcomes = await outcomeRows(orgId)
+    expect(outcomes.map((o) => o.user_id)).toEqual([userIds[0]])
+    expect(outcomes[0].terminal_outcome).toBe('completed')
+    // Nothing was burned terminally: the OUTSTANDING targets re-enter on a resume and complete.
+    const resume = makeBoundary()
+    const second = await resume.boundary.executeScheduledRun(scheduledInput(orgId, userIds))
+    expect(second.kind).toBe('w4')
+    if (second.kind !== 'w4') throw new Error('unreachable')
+    expect(second.perUser.map((p) => p.userId).sort()).toEqual([userIds[1], userIds[2]].sort())
+    expect(second.perUser.every((p) => p.mode === 'executed')).toBe(true)
+    expect((await runRows(orgId))[0]).toMatchObject({ state: 'completed', completed_user_count: 3 })
+  })
+
+  it('leg 5c — a NON-CONTAINED typed boundary error (the 500-class parent-unresolved family) ABORTS rather than becoming a failed outcome', async () => {
+    // CONSTRUCTION NOTE, stated honestly: the NATURAL raise site for
+    // `W4C2_AUTHORITATIVE_PARENT_UNRESOLVED` — our own placeholder INSERT and a racer's both leaving
+    // no visible row under our own lock — is not constructible through the boundary (the class-11
+    // advisory target lock prevents it one layer up). The error is therefore injected at an adapter
+    // seam INSIDE the savepoint, as the exact class and code the boundary raises. What this proves is
+    // the DISPOSITION (this class aborts, it is not contained), which is the property under test; it
+    // does not prove the raise site is reachable, and does not claim to.
+    const { AttendanceW4LiveScheduledBoundaryError } = await import(
+      '../../src/attendance/w4c2-live-scheduled-boundary'
+    )
+    const { orgId, userIds } = await seedAuthoritativeOrg(3, { withShift: true })
+    const fault: Fault = {
+      userId: userIds[1],
+      seam: 'resolveScheduledCandidate',
+      make: () => new AttendanceW4LiveScheduledBoundaryError('W4C2_AUTHORITATIVE_PARENT_UNRESOLVED', 500),
+    }
+    const { boundary } = makeBoundary([fault])
+    await expect(boundary.executeScheduledRun(scheduledInput(orgId, userIds))).rejects.toMatchObject({
+      code: 'W4C2_AUTHORITATIVE_PARENT_UNRESOLVED',
+    })
+    const outcomes = await outcomeRows(orgId)
+    // NOT a failed outcome — that is the whole point of the split.
+    expect(outcomes.filter((o) => o.terminal_outcome === 'failed').length).toBe(0)
+    expect(outcomes.map((o) => o.user_id)).toEqual([userIds[0]])
+    expect((await runRows(orgId))[0].state).toBe('running')
+  })
+
+  it('leg 8 — SKIP on a present, guard-admitted, not-retired parent: no core call, no placeholder, seal {inserted:false}, parent bit-identical', async () => {
+    const { orgId, userIds } = await seedAuthoritativeOrg(2, { withShift: true })
+    // The ORDINARY case, not a race: a user who punched that day already has a legacy-ACTIVE parent
+    // at run creation, because `'generate'` targets are not NOT-EXISTS-filtered there.
+    const presentRecordId = uuid()
+    await pool.query(
+      `INSERT INTO attendance_records
+         (id, org_id, user_id, work_date, timezone, first_in_at, last_out_at,
+          work_minutes, late_minutes, early_leave_minutes, status, is_workday, meta,
+          projection_owner, current_calculation_id, visibility_state, visibility_reason,
+          created_at, updated_at)
+       VALUES ($1, $2, $3, $4::date, $5, now(), NULL, 480, 0, 0, 'normal', true, '{}'::jsonb,
+               'legacy_untracked', NULL, 'active', 'active', now(), now())`,
+      [presentRecordId, orgId, userIds[1], WORK_DATE, TZ],
+    )
+    const before = (await recordRows(orgId, userIds[1]))[0]
+
+    const { boundary, spies } = makeBoundary()
+    const result = await boundary.executeScheduledRun(scheduledInput(orgId, userIds))
+    expect(result.kind).toBe('w4')
+    if (result.kind !== 'w4') throw new Error('unreachable')
+    expect(result.perUser).toEqual([
+      { userId: userIds[0], mode: 'executed', inserted: true },
+      // LEGACY PARITY: the legacy INSERT would have contributed `inserted=false` for exactly this
+      // user, so `rows` / `generated_count` are unchanged by posture.
+      { userId: userIds[1], mode: 'executed', inserted: false },
+    ])
+    expect(result.rows).toEqual([{ user_id: userIds[0] }])
+
+    // BIT-IDENTICAL: no supersede, no pointer move, no placeholder, and no calc row at all — the
+    // discriminator between SKIP and the supersede alternative.
+    expect((await recordRows(orgId, userIds[1]))[0]).toEqual(before)
+    expect(await calcRows(orgId, presentRecordId)).toEqual([])
+    // The core's RECORD_NOT_FOUND (404) is unreachable for the legitimate dedup case.
+    expect(await outcomeRows(orgId)).toEqual(
+      [
+        { user_id: userIds[0], terminal_outcome: 'completed', failure_reason_code: null },
+        { user_id: userIds[1], terminal_outcome: 'completed', failure_reason_code: null },
+      ].sort((a, b) => (a.user_id < b.user_id ? -1 : 1)),
+    )
+    const ops = await operationRows(orgId)
+    const skipped = ops.find((o) => o.subject_user_id === userIds[1])
+    expect(skipped?.state).toBe('completed')
+    expect(skipped?.response_snapshot).toEqual({ inserted: false })
+    expect(skipped?.resolved_calculation_id).toBeNull()
+    // A skip performs NO compute at all: the W2 resolver was entered once (for target 1 only).
+    expect(spies.resolveScheduledCandidate).toBe(1)
+    expect(spies.applyScheduledAbsenceLegacy).toBe(0)
+  })
+
+  it('leg 6.10 — SECOND GENERATION over a first-generation review placeholder: the guard ADMITS it and the re-attempt completes it (a deliberate, narrow divergence from legacy NOT-EXISTS parity)', async () => {
+    // Generation 1: no shift ⇒ review ⇒ the parent is left as our own retired/review_placeholder.
+    const { orgId, userIds } = await seedAuthoritativeOrg(1)
+    const first = makeBoundary()
+    await first.boundary.executeScheduledRun(scheduledInput(orgId, userIds))
+    const afterFirst = (await recordRows(orgId, userIds[0]))[0]
+    expect(afterFirst).toMatchObject({ visibility_state: 'retired', visibility_reason: 'review_placeholder' })
+
+    // Now give the user a shift so a re-attempt can actually resolve, and drive again. A completed
+    // run is never resumed, so this mints a FRESH generation with fresh operation ids.
+    await insertShiftAndAssignment(orgId, userIds[0])
+    const second = makeBoundary()
+    const result = await second.boundary.executeScheduledRun(scheduledInput(orgId, userIds))
+    expect(result.kind).toBe('w4')
+    if (result.kind !== 'w4') throw new Error('unreachable')
+    expect(result.perUser).toEqual([{ userId: userIds[0], mode: 'executed', inserted: true }])
+    // The placeholder is OUR artifact and the re-attempt completes it — legacy's `NOT EXISTS` would
+    // have skipped (a row exists). Recorded as the deliberate divergence it is.
+    const afterSecond = (await recordRows(orgId, userIds[0]))[0]
+    expect(afterSecond).toMatchObject({
+      id: afterFirst.id,
+      projection_owner: 'w4',
+      visibility_state: 'active',
+      visibility_reason: 'active',
+    })
+    const runs = await runRows(orgId)
+    expect(runs.map((r) => r.generation)).toEqual([1, 2])
+  })
+
+  it('leg 7a/7b — payloadFingerprint persists in input_provenance, and a re-drive of a completed target REPLAYS through the preflight with no second calc row', async () => {
+    const { orgId, userIds } = await seedAuthoritativeOrg(1, { withShift: true })
+    const { boundary } = makeBoundary()
+    await boundary.executeScheduledRun(scheduledInput(orgId, userIds))
+    const records = await recordRows(orgId, userIds[0])
+    const calcsAfterFirst = await calcRows(orgId, String(records[0].id))
+    expect(calcsAfterFirst.length).toBe(1)
+
+    // 7a — the persisted provenance carries the embedded copy the core reads VERBATIM on a retry.
+    const provenance = calcsAfterFirst[0].input_provenance as Record<string, unknown>
+    expect(typeof provenance.payloadFingerprint).toBe('string')
+    expect(provenance.payloadFingerprint).toMatch(/^[0-9a-f]{64}$/)
+    // Recomputed here from the resolved command payload alone — the run id is the only value the
+    // test has to read back, and it comes from the run row, not from the stored fingerprint.
+    const runId = (await runRows(orgId))[0].run_id
+    expect(provenance.payloadFingerprint).toBe(
+      computeAuthoritativeScheduledPayloadFingerprintV1({
+        scheduledRunId: String(runId),
+        userId: userIds[0],
+        workDate: WORK_DATE,
+        expectedRunVersion: 1,
+        scheduledAbsenceSource: 'cron_auto_absence',
+      }),
+    )
+    expect(provenance.transport).toBe('scheduled_job')
+
+    // 7b — a re-drive of the SAME (run, target) is served by the preflight replay: the completed run
+    // is not resumed, so this drives the recovery entrypoint against the same run id.
+    const replayBoundary = makeBoundary()
+    const replayed = await replayBoundary.boundary.recoverScheduledRun({
+      ...scheduledInput(orgId, userIds),
+      runId: String(runId),
+    })
+    expect(replayed.kind).toBe('w4')
+    if (replayed.kind !== 'w4') throw new Error('unreachable')
+    // The completed target is NOT re-looped (the outstanding set is empty), so no second core call.
+    expect(replayed.perUser).toEqual([])
+    expect((await calcRows(orgId, String(records[0].id))).length).toBe(1)
+  })
+
+  it('leg 10 — SITE A probe routing: an authoritative org reaches the run-registry mode with ZERO legacy batch rows and no 503; legacy_projection_only still takes the batch arm; suspended still suspends', async () => {
+    const authoritative = await seedAuthoritativeOrg(2, { withShift: true })
+    const { boundary, spies } = makeBoundary()
+    const result = await boundary.executeScheduledRun(
+      scheduledInput(authoritative.orgId, authoritative.userIds),
+    )
+    expect(result.kind).toBe('w4')
+    if (result.kind !== 'w4') throw new Error('unreachable')
+    expect(result.runId).not.toBeNull()
+    // The probe never ran the legacy batch INSERT..SELECT, and never refused.
+    expect(spies.applyScheduledAbsenceLegacy).toBe(0)
+
+    // NEGATIVE CONTROL 1 — `legacy_projection_only` (an org with no rollout row at all) still takes
+    // the probe's own legacy batch arm: ONE adapter call for the whole batch, `kind:'legacy'`.
+    const legacyOrg = uuid()
+    const legacyUsers = [uuid(), uuid()]
+    for (const userId of legacyUsers) await insertActiveUser(userId, legacyOrg)
+    await insertRolloutRow(legacyOrg, 'legacy')
+    const legacy = makeBoundary()
+    const legacyResult = await legacy.boundary.executeScheduledRun(scheduledInput(legacyOrg, legacyUsers))
+    expect(legacyResult.kind).toBe('legacy')
+    expect(legacy.spies.applyScheduledAbsenceLegacy).toBe(1)
+    expect(legacy.spies.absenceUserIds.sort()).toEqual([...legacyUsers].sort())
+
+    // NEGATIVE CONTROL 2 — `suspended` still suspends before any DML.
+    const suspendedOrg = allow(uuid())
+    const suspendedUser = uuid()
+    await insertActiveUser(suspendedUser, suspendedOrg)
+    await walkRolloutToSuspended(suspendedOrg)
+    const suspended = makeBoundary()
+    const suspendedResult = await suspended.boundary.executeScheduledRun(
+      scheduledInput(suspendedOrg, [suspendedUser]),
+    )
+    expect(suspendedResult.kind).toBe('suspended')
+    expect(suspended.spies.applyScheduledAbsenceLegacy).toBe(0)
+  })
+
+  it('leg 11 — outbox: ZERO per-target rows; finalize enqueues absence.generated with total = generatedCount; review_required fires iff the run\'s FROZEN review_count > 0', async () => {
+    // (a) A run whose only review-ness is a `'generate'` target with a review_required CALCULATION
+    //     outcome must NOT emit `attendance.work_date.review_required` — the finalize condition reads
+    //     the run row's frozen `review_count`, which counts `'review'`-KIND targets only. This is
+    //     today's shadow behaviour, unchanged by D3, disclosed rather than discovered later.
+    const calcReview = await seedAuthoritativeOrg(1)
+    const a = makeBoundary()
+    await a.boundary.executeScheduledRun(scheduledInput(calcReview.orgId, calcReview.userIds))
+    const aRows = await outboxRows(calcReview.orgId)
+    expect(aRows.every((r) => r.identity_kind === 'scheduled_run')).toBe(true)
+    expect(aRows.map((r) => r.event_kind)).toEqual(['attendance.absence.generated'])
+    expect((aRows[0].payload as { total: number }).total).toBe(0)
+
+    // (b) A run with a real `'review'`-KIND target DOES emit it, alongside the generated event whose
+    //     total equals the fold's generated_count (completed-and-inserted only).
+    const withReview = await seedAuthoritativeOrg(2, { withShift: true })
+    const reviewUser = uuid()
+    const b = makeBoundary()
+    await b.boundary.executeScheduledRun({
+      ...scheduledInput(withReview.orgId, withReview.userIds),
+      reviewTargets: [{ userId: reviewUser, reasonCode: 'WORK_DATE_ATTRIBUTION_AMBIGUOUS' }],
+    })
+    const bRows = await outboxRows(withReview.orgId)
+    expect(bRows.map((r) => r.event_kind).sort()).toEqual([
+      'attendance.absence.generated',
+      'attendance.work_date.review_required',
+    ])
+    const generated = bRows.find((r) => r.event_kind === 'attendance.absence.generated')
+    const run = (await runRows(withReview.orgId))[0]
+    expect((generated?.payload as { total: number }).total).toBe(Number(run.generated_count))
+    expect(Number(run.generated_count)).toBe(2)
+    // ZERO per-target rows on either run: every outbox row is run-scoped.
+    expect(bRows.every((r) => r.scheduled_run_id !== null)).toBe(true)
+    expect(bRows.length).toBe(2)
+  })
+
+  it('leg 12 — posture downgrade DURING the per-target loop: the per-target re-read is the branch SELECTOR, so the remaining targets take the legacy_compat path, no refusal appears anywhere, the run does not wedge, and it finalizes', async () => {
+    // WHERE THIS SCENARIO IS ACTUALLY REACHABLE, measured rather than assumed. A demotion BETWEEN
+    // boundary calls cannot produce a mixed run at all: `resumeAttendanceScheduledRunV1` refuses
+    // with `W4C2_SCHEDULED_RUN_RESUME_POSTURE_MISMATCH` when the run's FROZEN posture differs from
+    // the org's currently resolved one, so a demoted org can never resume its authoritative run
+    // (verified by construction — that is the error that came back). The reachable form is a
+    // demotion INSIDE one call's per-target loop, which the loop does not re-fence: only the
+    // per-target posture re-read sees it. That is exactly the §6.7 default under test.
+    const { orgId, userIds } = await seedAuthoritativeOrg(3, { withShift: true })
+    const demoteDuringTarget1: Fault = {
+      userId: userIds[0],
+      seam: 'resolveScheduledCandidate',
+      make: () => {
+        // Withdraw the exact-org allowlist entry while target 1 is mid-flight; target 1 finishes
+        // authoritatively (its own posture read already happened), targets 2 and 3 do not.
+        disallow(orgId)
+        return null
+      },
+    }
+    const { boundary, spies } = makeBoundary([demoteDuringTarget1])
+    // DISCLOSED, PRE-EXISTING, AND NOT D3's: the FINALIZE transaction fences on posture too
+    // (`W4C2_SCHEDULED_RUN_FINALIZATION_POSTURE_MISMATCH`), so a mid-run demotion surfaces there
+    // after every per-target transaction has already committed. D3 changes nothing about that; it is
+    // asserted rather than worked around so the leg cannot silently absorb a regression in it.
+    await expect(boundary.executeScheduledRun(scheduledInput(orgId, userIds))).rejects.toMatchObject({
+      code: 'W4C2_SCHEDULED_RUN_FINALIZATION_POSTURE_MISMATCH',
+    })
+
+    // MIXED RUN, read from committed state: each target is honest to the posture at its OWN write
+    // time — target 1 authoritative, targets 2 and 3 through the existing `legacy_compat` downgrade
+    // idiom — with NO refusal anywhere and no target left outstanding.
+    expect(spies.applyScheduledAbsenceLegacy).toBe(2)
+    expect(spies.absenceUserIds.sort()).toEqual([userIds[1], userIds[2]].sort())
+    const outcomes = await outcomeRows(orgId)
+    expect(outcomes.length).toBe(3)
+    expect(outcomes.every((o) => o.terminal_outcome === 'completed')).toBe(true)
+    expect((await recordRows(orgId, userIds[0]))[0].projection_owner).toBe('w4')
+    expect((await recordRows(orgId, userIds[1]))[0]).toMatchObject({
+      projection_owner: 'legacy_untracked',
+      status: 'absent',
+      visibility_state: 'active',
+    })
+
+    // NO WEDGE: restoring the posture lets the run finalize on the next drive, with zero targets
+    // re-looped (they all already carry terminal outcomes).
+    allow(orgId)
+    const finalizer = makeBoundary()
+    const finalized = await finalizer.boundary.recoverScheduledRun({
+      ...scheduledInput(orgId, userIds),
+      runId: String((await runRows(orgId))[0].run_id),
+    })
+    expect(finalized.kind).toBe('w4')
+    if (finalized.kind !== 'w4') throw new Error('unreachable')
+    expect(finalized.perUser).toEqual([])
+    const runs = await runRows(orgId)
+    expect(runs.length).toBe(1)
+    expect(runs[0]).toMatchObject({ state: 'completed', completed_user_count: 3, generated_count: 3 })
+  })
+
+  it('leg 13 — recovery/resume re-entry: only OUTSTANDING targets re-enter the authoritative writer; an already-completed target is SKIPPED, not replayed', async () => {
+    const { orgId, userIds } = await seedAuthoritativeOrg(3, { withShift: true })
+    const fault: Fault = {
+      userId: userIds[1],
+      seam: 'resolveScheduledCandidate',
+      make: () => new Error('W4C2_D3_KILL_AFTER_TARGET_1'),
+    }
+    const killed = makeBoundary([fault])
+    await expect(killed.boundary.executeScheduledRun(scheduledInput(orgId, userIds))).rejects.toThrow()
+    const runId = (await runRows(orgId))[0].run_id
+    const calcsAfterKill = await calcRows(orgId)
+    expect(calcsAfterKill.length).toBe(1)
+
+    const recovered = makeBoundary()
+    const result = await recovered.boundary.recoverScheduledRun({
+      ...scheduledInput(orgId, userIds),
+      runId: String(runId),
+    })
+    expect(result.kind).toBe('w4')
+    if (result.kind !== 'w4') throw new Error('unreachable')
+    // The completed target does NOT reappear — the outstanding set is the LEFT JOIN's `o.id IS NULL`.
+    expect(result.perUser.map((p) => p.userId).sort()).toEqual([userIds[1], userIds[2]].sort())
+    expect(calcsAfterKill.length + 2).toBe((await calcRows(orgId)).length)
+    expect((await runRows(orgId))[0]).toMatchObject({ state: 'completed', completed_user_count: 3 })
+  })
+
+  it('leg 14 — seal/outcome/fold coupling: every executed target has seal + outcome, a contained-failed target has an outcome and NO seal, and the fold recomputes from raw rows', async () => {
+    const { orgId, userIds } = await seedAuthoritativeOrg(3, { withShift: true })
+    await retireParent(orgId, userIds[2])
+    const { boundary } = makeBoundary()
+    await boundary.executeScheduledRun(scheduledInput(orgId, userIds))
+
+    const ops = await operationRows(orgId)
+    const outcomes = await outcomeRows(orgId)
+    expect(outcomes.length).toBe(3)
+    expect(ops.length).toBe(3)
+    for (const outcome of outcomes) {
+      const op = ops.find((o) => o.subject_user_id === outcome.user_id)
+      if (outcome.terminal_outcome === 'failed') {
+        expect(op?.state).toBe('canceled')
+        expect(op?.response_snapshot).toBeNull()
+      } else {
+        expect(op?.state).toBe('completed')
+        expect(op?.response_snapshot).not.toBeNull()
+      }
+    }
+
+    // Recompute the fold's two counters from raw rows and compare with the frozen run row.
+    const recomputed = await pool.query(
+      `SELECT count(*) FILTER (WHERE o.terminal_outcome = 'completed')::int AS completed,
+              count(*) FILTER (WHERE o.terminal_outcome = 'completed'
+                               AND op.response_snapshot ->> 'inserted' = 'true')::int AS generated
+         FROM attendance_scheduled_run_target_outcomes o
+         JOIN attendance_scheduled_run_targets t ON t.id = o.target_id AND t.org_id = o.org_id
+         LEFT JOIN attendance_result_operations op
+                ON op.operation_id = t.operation_id AND op.org_id = t.org_id
+        WHERE o.org_id = $1`,
+      [orgId],
+    )
+    const run = (await runRows(orgId))[0]
+    expect(Number(run.completed_user_count)).toBe(recomputed.rows[0].completed)
+    expect(Number(run.generated_count)).toBe(recomputed.rows[0].generated)
+    expect(Number(run.generated_count)).toBe(2)
+  })
+
+  it('leg 15 — compat-fingerprint byte identity: the preimage builder over a legacy-active-shaped locked row equals a canonical recompute (direct leg; the supersede path is dormant under the SKIP default)', async () => {
+    // Under the shipped §6.2 SKIP default the scheduled branch never reaches the core with a
+    // legacy-ACTIVE parent, so the compatibility fingerprint is dormant on this path. The producer
+    // is pinned DIRECTLY so the fork's other side has no latent landmine: the boundary hashes the
+    // SAME normalized bytes it stores, via the canonical import/rollback producer.
+    const firstInAt = new Date('2026-06-08T01:00:00.000Z')
+    const projection = {
+      status: 'normal',
+      firstInAt: firstInAt.toISOString(),
+      lastOutAt: null,
+      workMinutes: 480,
+      lateMinutes: 0,
+      earlyLeaveMinutes: 0,
+    }
+    const canonical = computeAttendanceImportRollbackPreimageFingerprintV1({
+      projection,
+      projectionOwner: 'legacy_untracked',
+      currentCalculationId: null,
+      visibilityState: 'active',
+      visibilityReason: 'active',
+    })
+    expect(canonical).toMatch(/^[0-9a-f]{64}$/)
+    // A raw `timestamptz` (Date) normalized to ISO produces the identical digest — the "hash what
+    // you store" property. A Date fed through unnormalized would not.
+    const viaDate = computeAttendanceImportRollbackPreimageFingerprintV1({
+      projection: { ...projection, firstInAt: new Date(firstInAt).toISOString() },
+      projectionOwner: 'legacy_untracked',
+      currentCalculationId: null,
+      visibilityState: 'active',
+      visibilityReason: 'active',
+    })
+    expect(viaDate).toBe(canonical)
+    // Discriminating: a different visibility reason moves the digest.
+    expect(
+      computeAttendanceImportRollbackPreimageFingerprintV1({
+        projection,
+        projectionOwner: 'legacy_untracked',
+        currentCalculationId: null,
+        visibilityState: 'retired',
+        visibilityReason: 'review_placeholder',
+      }),
+    ).not.toBe(canonical)
+  })
+
+  it('leg 4b — rollback completeness: a refusal forced AFTER the placeholder INSERT leaves NO attendance_records row behind, and the failed outcome does exist', async () => {
+    const { orgId, userIds } = await seedAuthoritativeOrg(3, { withShift: true })
+    // Target 2's parent is ABSENT, so the seam creates the placeholder INSIDE the savepoint; the
+    // core-class refusal is forced AFTER it, at the frozen-context seam. Injected as the exact class
+    // the D1 core raises, so the containment path taken is the real one.
+    const { AttendanceW4AuthoritativeCalculationError } = await import(
+      '../../src/attendance/w4c2-authoritative-calculation-core'
+    )
+    const fault: Fault = {
+      userId: userIds[1],
+      seam: 'buildShadowFrozenContext',
+      make: () =>
+        new AttendanceW4AuthoritativeCalculationError('ATTENDANCE_W4_AUTH_CALC_PREIMAGE_INVALID', 422),
+    }
+    const { boundary } = makeBoundary([fault])
+    const result = await boundary.executeScheduledRun(scheduledInput(orgId, userIds))
+    expect(result.kind).toBe('w4')
+    if (result.kind !== 'w4') throw new Error('unreachable')
+    expect(result.perUser.find((p) => p.userId === userIds[1])?.mode).toBe('failed')
+
+    // THE ASSERTION: the placeholder the seam inserted was rolled back with the savepoint. An
+    // orphan `review_placeholder` parent for a target that produced nothing is exactly what
+    // removing `ROLLBACK TO SAVEPOINT` leaves behind.
+    expect(await recordRows(orgId, userIds[1])).toEqual([])
+    const outcomes = await outcomeRows(orgId)
+    expect(outcomes.find((o) => o.user_id === userIds[1])).toEqual({
+      user_id: userIds[1],
+      terminal_outcome: 'failed',
+      failure_reason_code: 'ATTENDANCE_SCHEDULED_TARGET_OPERATION_REJECTED',
+    })
+    // And the batch continued.
+    expect(outcomes.filter((o) => o.terminal_outcome === 'completed').length).toBe(2)
+  })
+
+  it('leg 4c — CORE-error arm: a real AttendanceW4AuthoritativeCalculationError raised BY THE CORE ITSELF (REPLAY_CONFLICT via a decoy calc row) is contained, proving the containment is class-general and not guard-specific', async () => {
+    const { orgId, userIds } = await seedAuthoritativeOrg(3, { withShift: true })
+    // Two-phase fixture. Phase 1: drive target 1 only, so a durable run exists whose target 2 row
+    // carries a committed `operation_id` we can read.
+    const fault: Fault = {
+      userId: userIds[1],
+      seam: 'resolveScheduledCandidate',
+      make: (attempt) => (attempt === 1 ? new Error('W4C2_D3_PHASE_1_STOP') : null),
+    }
+    const phase1 = makeBoundary([fault])
+    await expect(phase1.boundary.executeScheduledRun(scheduledInput(orgId, userIds))).rejects.toThrow(
+      'W4C2_D3_PHASE_1_STOP',
+    )
+    const runId = String((await runRows(orgId))[0].run_id)
+    const target = await pool.query(
+      `SELECT operation_id::text AS operation_id FROM attendance_scheduled_run_targets
+        WHERE org_id = $1 AND run_id = $2::uuid AND user_id = $3 AND target_kind = 'generate'`,
+      [orgId, runId, userIds[1]],
+    )
+    expect(target.rows.length).toBe(1)
+    const operationId = String(target.rows[0].operation_id)
+
+    // Phase 2: plant a DECOY calculation row on a parent for target 2 keyed by
+    // (org, entrypoint='scheduled', operation_id) whose `input_provenance` lacks
+    // `payloadFingerprint`. The core's own `retryReplayLookup` finds it, the fingerprints mismatch,
+    // and it fails REPLAY_CONFLICT (409) BEFORE any write — a refusal the CORE raises, not the guard.
+    const decoyRecordId = uuid()
+    await pool.query(
+      `INSERT INTO attendance_records
+         (id, org_id, user_id, work_date, timezone, work_minutes, late_minutes, early_leave_minutes,
+          status, is_workday, meta, projection_owner, current_calculation_id, visibility_state,
+          visibility_reason, created_at, updated_at)
+       VALUES ($1, $2, $3, $4::date, $5, 0, 0, 0, 'normal', true, '{}'::jsonb,
+               'legacy_untracked', NULL, 'retired', 'review_placeholder', now(), now())`,
+      [decoyRecordId, orgId, userIds[1], WORK_DATE, TZ],
+    )
+    await pool.query(
+      `INSERT INTO attendance_record_calculations
+         (id, org_id, attendance_record_id, version, calculation_kind, mode, entrypoint,
+          engine_version, snapshot_schema_version, operation_id,
+          semantic_input_fingerprint, provenance_fingerprint, source_definition_fingerprint,
+          attribution_snapshot, context_snapshot, segment_snapshot, evidence_snapshot,
+          approved_facts_snapshot, manual_override_snapshot, input_provenance, merge_policy,
+          calculation_tier, outcome, outcome_reason_code, projection_effect, expected_segment_count,
+          actor_id, correlation_id, created_at)
+       VALUES ($1, $2, $3::uuid, 1, 'calculation', 'authoritative', 'scheduled',
+               'w4c2-d3-decoy', 1, $4::uuid,
+               $5, $5, NULL,
+               '{"posture":"unsupported","sourceSchemaVersion":null,"reason":"unresolved","sourceFingerprint":null}'::jsonb,
+               NULL, '[]'::jsonb, '[]'::jsonb, '[]'::jsonb, NULL,
+               '{"transport":"scheduled_job"}'::jsonb, 'append',
+               'segment_authoritative', 'review_required', 'input_schema_invalid', 'none', 0,
+               'w4c2-d3-actor', 'w4c2-d3-decoy', now())`,
+      [uuid(), orgId, decoyRecordId, operationId, 'a'.repeat(64)],
+    )
+
+    const phase2 = makeBoundary()
+    const result = await phase2.boundary.recoverScheduledRun({
+      ...scheduledInput(orgId, userIds),
+      runId,
+    })
+    expect(result.kind).toBe('w4')
+    if (result.kind !== 'w4') throw new Error('unreachable')
+    // Target 2 was refused BY THE CORE and contained; target 3 still completed.
+    expect(result.perUser.find((p) => p.userId === userIds[1])?.mode).toBe('failed')
+    expect(result.perUser.find((p) => p.userId === userIds[2])?.mode).toBe('executed')
+    const outcomes = await outcomeRows(orgId)
+    expect(outcomes.find((o) => o.user_id === userIds[1])).toMatchObject({
+      terminal_outcome: 'failed',
+      failure_reason_code: 'ATTENDANCE_SCHEDULED_TARGET_OPERATION_REJECTED',
+    })
+    // The decoy row is the ONLY calculation on that parent — the refused attempt wrote nothing.
+    expect((await calcRows(orgId, decoyRecordId)).length).toBe(1)
+    expect((await runRows(orgId))[0].state).toBe('completed')
+  })
+
+  it('leg 4d — savepoint BALANCE (a statement-stream assertion, NOT an outcome assertion): the branch opens exactly as many savepoints as it releases, with ROLLBACK TO observed on the contained path', async () => {
+    // STATED WEAKNESS, per the brief: this proves the RELEASE is issued, not that omitting it causes
+    // harm. D2 already measured that 200 un-released savepoints complete fine and that the counters
+    // which would expose an overflow do not exist on the Postgres 14 CI pins; and structurally each
+    // target runs in its OWN transaction with one savepoint, committed right after the outcome
+    // INSERT, so savepoints cannot stack across targets here at all.
+    const { orgId, userIds } = await seedAuthoritativeOrg(3, { withShift: true })
+    await retireParent(orgId, userIds[1])
+    const { boundary, spies } = makeBoundary()
+    await boundary.executeScheduledRun(scheduledInput(orgId, userIds))
+    // Scoped BY NAME to the two savepoints the authoritative path opens. A bare `^SAVEPOINT ` count
+    // would be wrong, not merely noisy: `assertConnectionIsIdleV1` issues `SAVEPOINT
+    // w4c5_idle_probe` on every connection acquisition and deliberately does NOT release it on the
+    // path it expects (the probe is meant to FAIL on an idle connection), so an unscoped balance
+    // assertion is unsatisfiable by construction and would have to be weakened until it proved
+    // nothing. Measured, then scoped.
+    const NAMES = ['attendance_w4c2_scheduled_authoritative', 'attendance_w4_auth_calc_op'] as const
+    for (const name of NAMES) {
+      const opened = spies.statements.filter((s) => s === `SAVEPOINT ${name}`).length
+      const released = spies.statements.filter((s) => s === `RELEASE SAVEPOINT ${name}`).length
+      expect({ name, opened: opened > 0 }).toEqual({ name, opened: true })
+      expect({ name, released }).toEqual({ name, released: opened })
+    }
+    const rolledBack = spies.statements.filter(
+      (s) => s === 'ROLLBACK TO SAVEPOINT attendance_w4c2_scheduled_authoritative',
+    ).length
+    // The contained target's rollback really happened (otherwise this leg would be a balance
+    // assertion over the success path only).
+    expect(rolledBack).toBe(1)
+  })
+})

--- a/packages/core-backend/tests/integration/attendance-w4c2-gate-matrix-e5.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-w4c2-gate-matrix-e5.db.test.ts
@@ -1132,15 +1132,39 @@ describeDb('W4C-2 Stage E gate matrix (real DB: isolation, forged authz, freeze 
     expect(outbox[0].event_kind).toBe('attendance.punched')
   })
 
-  it('leg 6b — authoritative SCHEDULED still fails closed BEFORE source DML (undelivered; D3 delivers it)', async () => {
+  it('leg 6b — authoritative SCHEDULED now WRITES through the canonical authoritative path (Gate D3, #4844): the fail-closed sentinel is gone, the durable run executes, and NO legacy-ACTIVE absent row is fabricated', async () => {
+    // RE-FORMED BY GATE D3. This leg asserted a 503 `not delivered` refusal, which was true only
+    // while the scheduled entrypoint was undelivered. D3 removed BOTH of that entrypoint's refusal
+    // sites, so the assertion is re-pointed at what the route does NOW — end to end through the
+    // real HTTP surface, which is the half this file owns (the writer's internals are the D3
+    // real-DB suite's).
+    //
+    // `schedAdminUser` is a REAL active `users` row (the P1-4 in-transaction actor recheck rejects
+    // anything else with 403). Using a random uuid here would produce a 403 that merely proves the
+    // recheck works, not that the writer is wired — measured, then fixed.
     const before = await recordCount(authoritativeUser)
-    const beforeOps = (await operationRows(authoritativeOrg)).length
-    const adminToken = await mintToken(randomUUID(), 'attendance:read,attendance:write,attendance:admin')
+    const adminToken = await mintToken(schedAdminUser, 'attendance:read,attendance:write,attendance:admin')
     const run = await autoAbsenceRun(adminToken, { orgId: authoritativeOrg, workDate: '2026-07-22' })
-    expect(run.status).toBe(503)
-    expect(run.body?.error?.code).toBe('W4C2_AUTHORITATIVE_MODE_NOT_DELIVERED')
-    expect(await recordCount(authoritativeUser)).toBe(before)
-    expect((await operationRows(authoritativeOrg)).length).toBe(beforeOps)
+    expect(run.status).toBe(200)
+    // The sentinel is GONE: no code, and nothing that looks like it, comes back.
+    expect(JSON.stringify(run.body ?? {})).not.toContain('AUTHORITATIVE_MODE_NOT_DELIVERED')
+    // A durable run row exists for that (org, workDate) — the run-registry routing Site A now
+    // performs instead of refusing.
+    const runs = await pool.query(
+      `SELECT state FROM attendance_scheduled_runs WHERE org_id = $1 AND work_date = '2026-07-22'::date`,
+      [authoritativeOrg],
+    )
+    expect(runs.rows.length).toBeGreaterThan(0)
+    // §7.5: whatever the per-target outcome was, the authoritative path never fabricates a
+    // legacy-ACTIVE `'absent'` row for an ordinary reader.
+    const fabricated = await pool.query(
+      `SELECT count(*)::int AS n FROM attendance_records
+        WHERE org_id = $1 AND work_date = '2026-07-22'::date
+          AND status = 'absent' AND visibility_state = 'active' AND projection_owner = 'legacy_untracked'`,
+      [authoritativeOrg],
+    )
+    expect(fabricated.rows[0].n).toBe(0)
+    void before
   })
 
   it('leg 7 — accepted_write_posture cannot be silently rebased: replay after legacy->shadow promotion returns the stored legacy response unchanged; a fresh key takes the shadow path; direct UPDATE is trigger-denied', async () => {

--- a/packages/core-backend/tests/integration/attendance-w4c3a-rollout-control.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-w4c3a-rollout-control.db.test.ts
@@ -40,6 +40,7 @@ import {
 } from '../../src/attendance/w4c3b-request-snapshots'
 import {
   __setAttendanceW4C2AuthoritativeDeliveryOverrideForTests,
+  attendanceW4C2UndeliveredAuthoritativeEntrypointCountV1,
   ATTENDANCE_W4C2_AUTHORITATIVE_ENTRYPOINTS_V1,
 } from '../../src/attendance/w4c2-authoritative-delivery'
 
@@ -2388,7 +2389,12 @@ describeIfDatabase('W4C-3a core-only rollout control (real PostgreSQL)', () => {
       it.each([
         ['P1', { live_punch: false, scheduled: true }],
         ['P2', { live_punch: true, scheduled: false }],
-        ['P3 (production default)', null],
+        // P3 ('production default', override `null`) was RETIRED by Gate D3 (#4844). It asserted
+        // that the SHIPPED declaration refuses, which was true only while an entrypoint was still
+        // undelivered. Both are delivered now, so the shipped default no longer refuses — that is
+        // Gate D's intended EXIT condition, not a regression. The exit condition has its own
+        // dedicated leg below (with the override control that keeps it non-vacuous); leaving P3
+        // here re-pinned as `null` would have been a test freezing a stale product state.
       ] as const)('%s: refuses with the values-free code and writes NOTHING when an entrypoint is undelivered', async (_label, override) => {
         const org = crypto.randomUUID()
         allow(org)
@@ -2441,7 +2447,7 @@ describeIfDatabase('W4C-3a core-only rollout control (real PostgreSQL)', () => {
       it.each([
         ['R1', { live_punch: false, scheduled: true }],
         ['R2', { live_punch: true, scheduled: false }],
-        ['R3 (production default)', null],
+        // R3 retired by Gate D3 (#4844) for the same reason as P3 above — see that comment.
       ] as const)('%s: refuses with the values-free code and writes NOTHING when an entrypoint is undelivered', async (_label, override) => {
         const org = crypto.randomUUID()
         allow(org)
@@ -2488,6 +2494,53 @@ describeIfDatabase('W4C-3a core-only rollout control (real PostgreSQL)', () => {
           client.release()
         }
       })
+    })
+
+    it('Gate D3 EXIT CONDITION (#4844): under the SHIPPED declaration — no override at all — the NOT_DELIVERED refusal no longer fires, and re-declaring either entrypoint undelivered brings it straight back', async () => {
+      // This replaces the retired P3/R3 "production default refuses" cases. Both entrypoints are
+      // delivered now, so the shipped default must NOT refuse — Gate D's whole purpose. Asserted
+      // with two controls so it can never degrade into "nothing happened":
+      //   (a) the undelivered COUNT the promotion gate reads is 0 under the shipped declaration;
+      //   (b) re-declaring EITHER key undelivered through the test seam restores the refusal, so a
+      //       silently-deleted gate would red here rather than pass as an "exit condition".
+      __setAttendanceW4C2AuthoritativeDeliveryOverrideForTests(null)
+      expect(attendanceW4C2UndeliveredAuthoritativeEntrypointCountV1()).toBe(0)
+      const shippedOrg = crypto.randomUUID()
+      allow(shippedOrg)
+      const client = await pool.connect()
+      try {
+        await advanceToEligible(client, shippedOrg)
+        // (a) the shipped default PROMOTES rather than refusing.
+        await transitionAttendanceCalculationRolloutV1(client as unknown as AttendanceW4TransactionClientV1, {
+          orgId: shippedOrg, actorId, correlationId: crypto.randomUUID(), engineVersion: 'w4c3a-control-test',
+          targetState: 'authoritative', expectedState: 'eligible', expectedVersion: 3,
+          evidenceManifestSha256: hex64(`${shippedOrg}-d3-exit`), evidenceReferences: baseRefs(`${shippedOrg}-d3-exit`),
+          reasonCode: 'rollout_transition',
+        })
+        await expect(pool.query(
+          'SELECT state FROM attendance_calculation_rollout_state WHERE org_id = $1',
+          [shippedOrg],
+        )).resolves.toMatchObject({ rows: [{ state: 'authoritative' }] })
+
+        // (b) NON-VACUITY: the gate is still wired. Declare `scheduled` undelivered and the very
+        // same call shape refuses again on a fresh org.
+        const controlOrg = crypto.randomUUID()
+        allow(controlOrg)
+        await advanceToEligible(client, controlOrg)
+        __setAttendanceW4C2AuthoritativeDeliveryOverrideForTests({ live_punch: true, scheduled: false })
+        expect(attendanceW4C2UndeliveredAuthoritativeEntrypointCountV1()).toBe(1)
+        await expect(
+          transitionAttendanceCalculationRolloutV1(client as unknown as AttendanceW4TransactionClientV1, {
+            orgId: controlOrg, actorId, correlationId: crypto.randomUUID(), engineVersion: 'w4c3a-control-test',
+            targetState: 'authoritative', expectedState: 'eligible', expectedVersion: 3,
+            evidenceManifestSha256: hex64(`${controlOrg}-d3-exit-ctl`), evidenceReferences: baseRefs(`${controlOrg}-d3-exit-ctl`),
+            reasonCode: 'rollout_transition',
+          }),
+        ).rejects.toMatchObject({ code: 'W4C3A_ROLLOUT_CONTROL_AUTHORITATIVE_ENTRYPOINT_NOT_DELIVERED' })
+      } finally {
+        __setAttendanceW4C2AuthoritativeDeliveryOverrideForTests(null)
+        client.release()
+      }
     })
 
     it('positive control (gate 4): with BOTH entrypoints delivered, promotion AND resume still succeed — "it refuses" and "it is broken" are distinguishable', async () => {

--- a/packages/core-backend/tests/integration/attendance-w4c5-rollout-transition-tool.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-w4c5-rollout-transition-tool.db.test.ts
@@ -635,13 +635,15 @@ describeIfDatabase('W4C-5 operator transition tooling (real PostgreSQL)', () => 
       expect(byCode.RETRYABLE_JOB_HAS_OPERATION_ROWS.count).toBe(0)
       // This plan call runs under PRODUCTION-DEFAULT Gate D values — the override set for the
       // drive-up above was reset in the `finally` block before this call — so the reporter must
-      // show the real shipped state: applicable, still failing, with ONE entrypoint undelivered
-      // (`scheduled`). Gate D2 (#4844) delivered `live_punch`, dropping the count 2 -> 1; the
-      // gate itself still refuses promotion because it requires ZERO undelivered.
+      // show the real shipped state. Gate D2 (#4844) delivered `live_punch` (count 2 -> 1) and
+      // Gate D3 (#4844) delivered `scheduled` (1 -> 0), so the predicate is now applicable AND
+      // PASSING with zero undelivered entrypoints. The predicate stays APPLICABLE — that is what
+      // keeps this assertion discriminating rather than degenerating into "the reporter dropped
+      // it": a reporter that stopped evaluating Gate D would show `applicable: false` and red here.
       expect(byCode.AUTHORITATIVE_ENTRYPOINTS_DELIVERED).toMatchObject({
         applicable: true,
-        pass: false,
-        count: 1,
+        pass: true,
+        count: 0,
       })
 
       for (const statement of statements) {
@@ -920,19 +922,25 @@ describeIfDatabase('W4C-5 operator transition tooling (real PostgreSQL)', () => 
     // untouched, reds (B).
     describe('Gate D test-seam hygiene: the describe-level afterEach backstop is load-bearing', () => {
       it('(A) sets the Gate D override and relies ENTIRELY on the surrounding afterEach to clear it (no explicit clear in this test)', () => {
-        // Shipped state after Gate D2 (#4844): live_punch DELIVERED, scheduled still undelivered.
-        // The override below still differs from it on `scheduled`, which is what keeps (B)
-        // discriminating — an un-cleared override would leave `scheduled` reading `true` there.
-        expect(isAttendanceW4C2AuthoritativeEntrypointDeliveredV1('scheduled')).toBe(false) // sanity: starts clean
-        __setAttendanceW4C2AuthoritativeDeliveryOverrideForTests({ live_punch: true, scheduled: true })
-        expect(isAttendanceW4C2AuthoritativeEntrypointDeliveredV1('live_punch')).toBe(true) // sanity: override is live
+        // RE-FORMED BY GATE D3 (#4844). The shipped declaration is now `{live_punch:true,
+        // scheduled:true}`, so the old `{live_punch:true, scheduled:true}` override became a NO-OP
+        // and (B) could no longer tell "the backstop ran" from "the override never did anything" —
+        // the pair would have stayed green with the afterEach deleted. The override must therefore
+        // differ from the shipped declaration; it is now the UNDELIVERED direction, which is
+        // guaranteed to differ for as long as any key is declared delivered at all.
+        expect(isAttendanceW4C2AuthoritativeEntrypointDeliveredV1('live_punch')).toBe(true) // sanity: starts clean
         expect(isAttendanceW4C2AuthoritativeEntrypointDeliveredV1('scheduled')).toBe(true)
+        __setAttendanceW4C2AuthoritativeDeliveryOverrideForTests({ live_punch: false, scheduled: false })
+        expect(isAttendanceW4C2AuthoritativeEntrypointDeliveredV1('live_punch')).toBe(false) // sanity: override is live
+        expect(isAttendanceW4C2AuthoritativeEntrypointDeliveredV1('scheduled')).toBe(false)
         // No clear here, deliberately — proving the afterEach above is what cleans this up.
       })
 
       it('(B) the override set by (A) has not leaked into this test — proves the afterEach backstop actually ran', () => {
+        // Both read `true` ONLY if the override was cleared: (A) left both keys overridden to
+        // `false`, which is the opposite of the shipped declaration on BOTH keys.
         expect(isAttendanceW4C2AuthoritativeEntrypointDeliveredV1('live_punch')).toBe(true)
-        expect(isAttendanceW4C2AuthoritativeEntrypointDeliveredV1('scheduled')).toBe(false)
+        expect(isAttendanceW4C2AuthoritativeEntrypointDeliveredV1('scheduled')).toBe(true)
       })
     })
   })
@@ -1082,7 +1090,7 @@ describeIfDatabase('W4C-5 operator transition tooling (real PostgreSQL)', () => 
       expect(await rolloutRow(orgId)).toBeNull()
     })
 
-    it('Gate D (owner completion gate, PR #4839, 20260810), driven through the actual CLI subprocess: a legal eligible -> authoritative promotion still refuses with AUTHORITATIVE_ENTRYPOINT_NOT_DELIVERED under production values — the test seam cannot cross the subprocess boundary, so this proves the CLI has no bypass and is display-only', async () => {
+    it('Gate D3 EXIT CONDITION (#4844), driven through the actual CLI subprocess: with BOTH entrypoints delivered a legal eligible -> authoritative promotion is no longer refused by Gate D — and the in-process test seam still cannot cross the subprocess boundary, so the CLI remains display-only with no bypass', async () => {
       const orgId = crypto.randomUUID()
       allow(orgId)
       const driveClient = await pool.connect()
@@ -1118,11 +1126,31 @@ describeIfDatabase('W4C-5 operator transition tooling (real PostgreSQL)', () => 
       const planResult = spawnCli(['plan', '--org', orgId, '--target', 'authoritative'])
       const plan = JSON.parse(planResult.stdout) as AttendanceRolloutTransitionPlanV1 & { planDigest: string }
       expect(plan.legalPair).toBe(true)
-      expect(plan.blocked).toBe(true)
+      expect(plan.blocked).toBe(false)
       const authoritativePredicate = plan.predicates.find((p) => p.code === 'AUTHORITATIVE_ENTRYPOINTS_DELIVERED')
-      // count 2 -> 1 after Gate D2 (#4844) delivered `live_punch`; `scheduled` remains the one
-      // undelivered entrypoint, so the gate still refuses (it demands ZERO undelivered).
-      expect(authoritativePredicate).toMatchObject({ applicable: true, pass: false, count: 1 })
+      // count 2 -> 1 after Gate D2 (#4844) delivered `live_punch`, and 1 -> 0 after Gate D3
+      // (#4844) delivered `scheduled`. The predicate stays APPLICABLE (it is keyed on
+      // `targetState === 'authoritative'`, not on the count), which is what keeps this assertion
+      // discriminating: a reporter that stopped evaluating Gate D would report `applicable:false`.
+      expect(authoritativePredicate).toMatchObject({ applicable: true, pass: true, count: 0 })
+
+      // THE PROPERTY THIS LEG STILL CARRIES, unchanged by the flip: the in-process delivery
+      // override is a module-level singleton in THIS process and cannot cross a subprocess
+      // boundary, so the CLI always reports the SHIPPED declaration. Declaring `scheduled`
+      // undelivered here must not move the subprocess's answer.
+      __setAttendanceW4C2AuthoritativeDeliveryOverrideForTests({ live_punch: true, scheduled: false })
+      try {
+        const seamPlan = JSON.parse(
+          spawnCli(['plan', '--org', orgId, '--target', 'authoritative']).stdout,
+        ) as AttendanceRolloutTransitionPlanV1
+        expect(seamPlan.predicates.find((p) => p.code === 'AUTHORITATIVE_ENTRYPOINTS_DELIVERED')).toMatchObject({
+          applicable: true,
+          pass: true,
+          count: 0,
+        })
+      } finally {
+        __setAttendanceW4C2AuthoritativeDeliveryOverrideForTests(null)
+      }
 
       const manifestPath = writeManifest(
         'gate-d-cli-promotion',
@@ -1150,10 +1178,12 @@ describeIfDatabase('W4C-5 operator transition tooling (real PostgreSQL)', () => 
         '--engine-version', 'w4c5-tool-test',
       ])
 
-      expect(applyResult.status).toBe(7)
-      expect(applyResult.stderr).toContain('W4C3A_ROLLOUT_CONTROL_AUTHORITATIVE_ENTRYPOINT_NOT_DELIVERED')
-      await expect(rolloutRow(orgId)).resolves.toEqual(before)
-      await expect(eventCount(orgId)).resolves.toBe(beforeEvents)
+      // Gate D's exit condition, end to end through the real CLI: the promotion now APPLIES.
+      expect(applyResult.status).toBe(0)
+      expect(applyResult.stderr).not.toContain('W4C3A_ROLLOUT_CONTROL_AUTHORITATIVE_ENTRYPOINT_NOT_DELIVERED')
+      await expect(rolloutRow(orgId)).resolves.toEqual({ state: 'authoritative', version: 4 })
+      await expect(eventCount(orgId)).resolves.toBe(beforeEvents + 1)
+      expect(before).toEqual({ state: 'eligible', version: 3 })
     })
 
     it('missing confirmation refuses with W4C5_TOOL_CONFIRMATION_REQUIRED before any DB access', async () => {

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -606,6 +606,15 @@ export default defineConfig({
       // the no-DB job cannot skip-green it; wired whole-file into the attendance real-DB step in
       // plugin-tests.yml (two-point wiring).
       'tests/integration/attendance-w4c2-d2-live-punch-authoritative.db.test.ts',
+      // #4556 W4C-2 Gate D3 (#4844): the AUTHORITATIVE `scheduled` writer's real-Postgres matrix —
+      // the F6 placeholder + review/completed outcomes, the zero-invocation legacy-absence-adapter
+      // pin, the guard-first parent seam (skip vs write vs contained 409), and above all D3's
+      // PER-TARGET CONTAINMENT: rollback-to-savepoint completeness, the claimed-operation cancel
+      // that makes the commit legal, the terminal `failed` outcome, the batch continuing past a
+      // refusal, and the scope negatives that must still abort. DATABASE_URL-gated; excluded here so
+      // the no-DB job cannot skip-green it; wired whole-file into the attendance real-DB step in
+      // plugin-tests.yml (two-point wiring).
+      'tests/integration/attendance-w4c2-d3-scheduled-authoritative.db.test.ts',
       // W4C-2 P1-2 (#4556, PR #4617 amendment, RATIFIED, owner Bundle A) — the schema/
       // migration half: scheduled-run identity tables, the outbox discriminated union,
       // the append-only per-target outcome side table, and their gates (1, 9, 11, 12 DB

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -24093,6 +24093,17 @@ module.exports = {
     resolveW4LiveCandidateInTransactionV1,
     buildW4ShadowFrozenContextV1,
   },
+  // Gate D3 (#4556 / #4844): the SCHEDULED half of the same seam set — the REAL absence
+  // INSERT..SELECT the boundary drops on the authoritative branch (so the D3 suite can wrap it in a
+  // call-count spy and prove ZERO invocations), plus the REAL in-transaction W2 scheduled resolver
+  // and frozen-context builder the authoritative branch reuses. Same rationale as the live bag: the
+  // suite drives production bytes rather than a re-implementation. `activate` injects exactly these
+  // three functions into `legacyAdapters` (see the boundary construction below).
+  __attendanceW4c2ScheduledAdaptersForTests: {
+    generateAbsenceRecords,
+    resolveW4ScheduledCandidateInTransactionV1,
+    buildW4ShadowFrozenContextV1,
+  },
   __attendanceLivePunchWorkDateForTests: {
     getPunchShiftWindow,
     isPunchWithinShiftWindow,

--- a/plugins/plugin-integration-core/lib/sealed-export/vectors/s6a-package-provenance-pins.json
+++ b/plugins/plugin-integration-core/lib/sealed-export/vectors/s6a-package-provenance-pins.json
@@ -86,6 +86,6 @@
     "s6aAcceptancePs51Test": "835c7c6ce943d82e0378a40a27c7fd1e8b79b526faa8ca4c8066e4231a4bfb0f",
     "s6aProductRuntimeTest": "de978adafa8b89772cefa921c2051f434bf346bf5c2978bef3424ee70f51ba3f",
     "multitableOnpremPackageBuild": "ae477a24375a7269e5710a3481905c9b74255c03fd802841a16849aca48ee33a",
-    "pluginTestsWorkflow": "8a31a62b643e6da02341a30a9f3647c5a9aced16143a15289b8cc3a79cfc29b2"
+    "pluginTestsWorkflow": "6db9404765ab64b63eb505886dc91851e15e20596f011e3cf1000aa68b6870d3"
   }
 }

--- a/scripts/attendance/w4c0-dml-inventory/curated-debt-entries.cjs
+++ b/scripts/attendance/w4c0-dml-inventory/curated-debt-entries.cjs
@@ -600,9 +600,24 @@ const CURATED_DEBT_ENTRIES = [
   },
   {
     id: 'X07',
-    title: 'W4C-2 Gate D2 live_punch authoritative branch: the create-if-absent review-path parent placeholder INSERT on attendance_records (§7.5 F6 parent-state install).',
+    title: 'W4C-2 Gate D2/D3 authoritative branches: the create-if-absent review-path parent placeholder INSERT on attendance_records (§7.5 F6 parent-state install).',
     owningSlice: 'W4C-2',
     sharedHook: false,
+    // Gate D3 (#4844) CLASSIFICATION NOTE — measured with the collectors, not reasoned:
+    //   * the scheduled authoritative branch's placeholder creation is a CALL to the same
+    //     `insertAuthoritativeReviewPlaceholderParentV1` helper this entry claims BY SYMBOL, so it
+    //     adds no new DML statement text and no new census site. The `bySymbol` claim is exactly
+    //     what makes a second call site inert here while still refusing a genuinely NEW
+    //     attendance_records writer added to the boundary file;
+    //   * the core call, the first production `recordAttendanceScheduledRunTargetOutcomeV1('failed')`
+    //     call and the `cancelAttendanceResultOperationV1` call are CALLS into already-claimed
+    //     writers (the D1 core / the run registry / the operation registry), not new DML;
+    //   * D3 REMOVES `applyScheduledAbsenceLegacy` from the authoritative arm — a classification
+    //     change rather than a new site: that adapter's own INSERT..SELECT stays claimed for the
+    //     legacy/shadow/legacy_compat paths that still call it;
+    //   * the branch's `SAVEPOINT` / `ROLLBACK TO SAVEPOINT` / `RELEASE SAVEPOINT` statements carry
+    //     no verb the DML scanner tracks.
+    // Collector output on the D3 head: unclaimed = 0, with no census hand-edit.
     // Its own Gate-D2 marker, not the 'W4C-2' removed-by-adapter marker (pinned to the four
     // legacy P01-P04 writers) and not Gate D1's. This is the canonical authoritative-path parent
     // creator D2 adds, not a legacy site being canonicalized away.

--- a/scripts/ops/attendance-w4c2-ci-wiring.test.mjs
+++ b/scripts/ops/attendance-w4c2-ci-wiring.test.mjs
@@ -2211,6 +2211,7 @@ const EXPECTED_ATTENDANCE_SUITES = Object.freeze([
   'tests/integration/attendance-w4c0-operation-registry.db.test.ts',
   'tests/integration/attendance-w4c2-authoritative-calculation-core.db.test.ts',
   'tests/integration/attendance-w4c2-d2-live-punch-authoritative.db.test.ts',
+  'tests/integration/attendance-w4c2-d3-scheduled-authoritative.db.test.ts',
   'tests/integration/attendance-w4c2-gate-matrix-e5.db.test.ts',
   'tests/integration/attendance-w4c2-live-scheduled-boundary.db.test.ts',
   'tests/integration/attendance-w4c2-outbox-dispatcher.db.test.ts',


### PR DESCRIPTION
Gate D slice **D3** (#4844 / #4556): wires the `scheduled` command kind's authoritative writes to the D1 core, removes **both** of its `W4C2_AUTHORITATIVE_MODE_NOT_DELIVERED` refusal sites, and flips `DECLARED_DELIVERED.scheduled` in the same reviewed change. **Built + gated locally; awaiting owner UAT/land.** Draft on purpose — the owner lands it.

## Byte-neutrality (the load-bearing production-impact proof)

Both former sites fired iff the resolved posture is `authoritative`, and `resolveSegmentCalculationPosture` returns `authoritative` only when `isOrgExactlyAllowlisted(orgKey)` holds over `ATTENDANCE_SHIFT_SEGMENT_CALCULATION_ENABLED` (wildcard never counts — Gate A exact-org doctrine). That env is unset in production ⇒ every production org collapses to `legacy` ⇒ **both replaced branches are unreachable irrespective of DB contents**. The run-frozen-posture wrinkle changes nothing: a run row can only freeze at `authoritative` if the org resolved authoritative at run creation, which needs the same allowlist entry. The rollout-control forward-block is defense-in-depth, not the proof.

## The two sites

**Site A — org-wide probe: replacement by ROUTING.** At that point no run, no targets and no witnesses exist, so nothing per-target can be recorded and no core call belongs there. The authoritative arm now falls through to the run-registry `{mode:'w4', rows:[]}` the shadow/eligible postures already take; the legacy batch arm stays unreachable for authoritative posture (it is gated on the disjoint `legacy_projection_only`, which precedes it).

**Site B — per-target loop: the real writer.** Installed *before* the legacy absence adapter and returning before it, so `applyScheduledAbsenceLegacy` is invoked **zero** times on that branch. The posture re-read is hoisted above the adapter and survives as the branch selector (read-only, same SERIALIZABLE snapshot, skipped entirely for `legacy_compat` exactly as before). The branch:

- resolves the parent through **one seam**, `resolveAuthoritativeScheduledParentV1`, the only place that can produce a `'skip'`, which calls the DEFAULT-REFUSE retirement guard **unconditionally before both returns**;
- creates the F6 `legacy_untracked` / NULL / `retired` / `review_placeholder` placeholder when the parent is absent, then always re-locks/re-reads so a race loser re-enters the same adjudication;
- builds the §7.8 preimage with D2's helper (canonical compat fingerprint; `expectedCurrentCalculationId` from the LOCKED read);
- mints a scheduled-domain `payloadFingerprint` (own NUL-**escaped** domain constant) embedded in **both** `payloadFingerprint` and `inputProvenance.payloadFingerprint`;
- calls `writeAuthoritativeSegmentCalculationV1` with `entrypoint: 'scheduled'`.

Dropping the absence adapter also removes the fabricated legacy-ACTIVE `'absent'` row, the pre-writer source DML that made the preimage capture point ambiguous, and the F6 self-created-parent hazard.

## D3's distinctive machinery: per-target containment

A refusal whose class is in the ONE exported table and which carries a product code → `ROLLBACK TO SAVEPOINT` → `RELEASE` → **cancel the claimed operation** → record a terminal `{failed, ATTENDANCE_SCHEDULED_TARGET_OPERATION_REJECTED}` outcome → commit → **the batch continues**. Everything else rethrows.

| Thrown inside the savepoint | Class | Disposition |
|---|---|---|
| the core's closed 15-code enumeration | `AttendanceW4AuthoritativeCalculationError` | **CONTAIN** — deterministic for this (parent, payload) |
| `ATTENDANCE_RECORD_OPERATOR_RETIRED` / `ATTENDANCE_RECORD_RETIRED` | `AttendanceW4OpsRetirementError` | **CONTAIN** — same |
| `W4C2_AUTHORITATIVE_PARENT_UNRESOLVED` (500) | `AttendanceW4LiveScheduledBoundaryError` | **RETHROW**, batch aborts — potentially transient, so resume must re-attempt rather than burn it terminally |
| raw pg errors incl. 40001/40P01 | pg `Error` | **RETHROW** (the two retry layers own those) |
| `SEGMENT_CALCULATION_SUSPENDED` | `AttendanceW4OperationError` | **RETHROW** — suspension is run-wide, and it is thrown before the savepoint anyway |
| anything else | — | **RETHROW** (fail-closed default) |

Membership is mechanical: `(a)` a non-empty string `code` **and** `(b)` `instanceof` a class in `ATTENDANCE_W4C2_SCHEDULED_CONTAINED_REFUSAL_CLASSES_V1`, which a test **walks** rather than restating. Never `.name` matching (`index.cjs` uses `.name` only because it crosses a module-loading boundary; inside this package the identity is available and `.name` is forgeable — there is an impostor leg). The class table is deliberately **wider** than the two reachable ops-retirement codes; that widening fails toward "one target failed, batch continues", stated in the code rather than left as a reachability argument that rots.

**Why the cancel is not optional.** `trg_aro_claimed_commit_guard` is a `CONSTRAINT TRIGGER … DEFERRABLE INITIALLY DEFERRED` that re-reads the operation's state at COMMIT and raises `W4C0_CLAIMED_COMMIT` if it is still `claimed`. "Record the outcome and leave it unsealed" is therefore **illegal** — it would fail at COMMIT with a raw untyped exception and abort the very batch containment exists to protect. Cancelling (`claimed → canceled`, `response_snapshot` stays NULL) is the legal disposition and it *preserves* the "seal ⇒ success snapshot" invariant, because a contained failure is never sealed at all. **Mutation run: deleting the cancel call reds AT COMMIT with `W4C0_CLAIMED_COMMIT: claimed operation row cannot commit`** — 7 legs red.

## Contracts preserved (§2.5)

The sealed per-target `responseSnapshot` stays `{inserted}` + `resolvedCalculationId` (the finalize fold reads `response_snapshot ->> 'inserted'`). Run-level outcomes, the finalize fold, and the two run-scoped outbox events are unchanged; **zero** per-target outbox rows. No new wire, snapshot, or event shape. `perUser` gains an additive `'failed'` mode — internal, zero consumers repo-wide.

## Test matrix

**21 real-PG legs** in `attendance-w4c2-d3-scheduled-authoritative.db.test.ts`, driven through the production boundary factory over the REAL plugin scheduled adapters (new `__attendanceW4c2ScheduledAdaptersForTests` bag) wrapped in call-count spies plus a per-user fault map. Gating legs 2 / 4a / 4b / 4e all green. Plus 3 no-DB suites (containment-predicate walk, scheduled fingerprint domain, seam structure) and the re-formed inventory guard.

**Leg 9 (placeholder poison race) is DISCHARGED BY CITATION, not run here — stated plainly because it is on the brief's own gating list.** D3 adds a *second call site* to `insertAuthoritativeReviewPlaceholderParentV1` and changes nothing inside it, so D2's leg 13b — a constructed two-connection race directly on that exported seam — already covers the D3 call site exactly as it covers the D2 one; re-running it would duplicate a leg, not add coverage. The citation is itself asserted rather than trusted (a dedicated seam-structure leg checks that the `ON CONFLICT (user_id, work_date, org_id) DO NOTHING` clause is still in the helper, that the scheduled seam *calls* the helper rather than carrying its own `INSERT INTO attendance_records`, and that D2's leg 13b still exists under the title cited), and that leg says in its own body that it is a **presence check, not a behavioural re-proof**.

**19 mutations run, every one effective** (`cp` backups, never `git checkout --`; each asserts anchor-hit + file-changed):

| Mutation | Reds |
|---|---|
| remove the per-target catch | 7 legs (batch aborts) |
| delete `ROLLBACK TO SAVEPOINT` | 4b (orphan `review_placeholder` survives) + 4d |
| **delete the claim cancel** | 7 legs, **at COMMIT**, `W4C0_CLAIMED_COMMIT` |
| remove the retirement guard | 5 legs (retired parent reactivated) |
| naive "present ⇒ skip" before the guard | 6 legs + both seam-structure legs |
| skip becomes write | leg 8 (skip-vs-supersede discriminator) |
| strip the embedded `payloadFingerprint` | leg 7a |
| **writer branch stops returning** | 20/21 (the P-A fail-open conversion §2.4 forbids) |
| restore Site A's refusal | 20/21 |
| predicate: drop the `code` check | both stripped-code unit legs |
| predicate: drop a table entry | its per-class leg + the table assertion |
| predicate: degrade to `.name` matching | the impostor leg |
| un-flip `DECLARED_DELIVERED` | 2 inventory legs |
| neuter `countRefusalCalls` | the empty-read leg's decoy positive control |
| drop unmapped attribution | the P3 unmapped decoy |
| blind `actualByKeyV1` | the re-formed drift guard (P2 correspondence stays green — the point of the degeneration note) |
| drift `REFUSAL_SITE_WEIGHT` | the re-formed cross-key leg |
| reintroduce Site B, plain spelling | seam-structure leg 16 **and** 4 inventory legs incl. P2 correspondence |
| drift the failure reason code | the OD-W4C-54 allowlist + 7 real-DB legs |

### Measured findings that changed a leg rather than being argued around

1. **`completed` IS reachable on the scheduled path** — nothing in the repo had driven a `resolved_v2` scheduled calculation before (the e5 harness stubs the resolver `unresolved`). Measured: untimed `scheduled_absence` evidence + a real frozen context ⇒ every segment `missing_both` ⇒ daily status `absent`, outcome `completed`. Leg 2 is built on that, not on an assumption.
2. **The "guard after skip" reorder is semantically inert** in the shipped structure, because the guard is unconditional. Measured green, then replaced with the defect in the shape it would actually take (skip decided on bare `row !== null`), which reds 6 legs.
3. **A cross-call posture demotion cannot produce a mixed run at all** — `resumeAttendanceScheduledRunV1` refuses `W4C2_SCHEDULED_RUN_RESUME_POSTURE_MISMATCH`. Leg 12 was rebuilt on the reachable form (demotion *inside* one call's loop) and additionally asserts the pre-existing `W4C2_SCHEDULED_RUN_FINALIZATION_POSTURE_MISMATCH`, which D3 does not change.
4. **An unscoped savepoint-balance assertion is unsatisfiable by construction** — `assertConnectionIsIdleV1` issues `SAVEPOINT w4c5_idle_probe` per connection and deliberately never releases it on the path it expects. Leg 4d is scoped by savepoint NAME, and labelled a statement-stream assertion rather than an outcome assertion (D2 already measured that 200 un-released savepoints complete fine on the PG14 CI pins). **Scoped again, to D3's name only, after a second read:** the CORE's savepoint is not universally balanced — its catch rethrows anything that is not a `uq_arc_operation` unique violation *without* rolling back or releasing, which is correct (the caller's `ROLLBACK TO` subsumes it) but leaves opened > released on a core-internal refusal. This fixture never drives that arm, so asserting over the core's name would have passed today and red on a future leg that did, with the obvious "fix" being to weaken it.
5. **`operator_retirement` is not installable by UPDATE** — `attendance_w4_records_pointer_guard` refuses it on a `legacy_untracked` parent. Leg 6a builds it through the core's own reversal writer, as D2 does.
6. **E5 leg 6b's random-uuid admin token now yields 403, not the writer** — the P1-4 actor-liveness recheck. Measured, then re-pointed at the file's real active admin row.

## Correspondence-ledger update, stated plainly

Once both entrypoints are delivered, the Gate D describe-block in `w4c3a-rollout-control-inventory.test.ts` is a **zero-versus-zero identity on real content**. "Leg 17 green with the guard unedited" evidences that the declaration and the source agree *at zero*; it no longer evidences anything about the boundary's behaviour. `REFUSAL_SITE_WEIGHT.scheduled: 2 → 0` is required by the re-formed legs that read the raw weights, **not** by the P2 correspondence assertion (`expectedByKeyV1()` returns `delivered ? 0 : weight`, so the weight is inert there) — do not read "P2 stays green" as evidence for the weight edit.

The suite's remaining discriminating power lives in synthetic decoys in both directions, each shipped with the mutation that reds it. Worth recording: the P2 correspondence leg is **not** inert — a plain-spelling reintroduction of a refusal site reds it along with three others. The behavioural pins remain the zero-invocation adapter spy and the probe-routing leg.

Per-block fate: `:531` re-formed to `toEqual([])` **plus** a scanner decoy and a sweep non-vacuity check · `:541` kept, vacuity stated in the title · `:552` kept verbatim · `:582` kept + unmapped decoy · **`:591` P2 correspondence green and UNEDITED** · `:597`/`:608` updated to fully-delivered · `:620` re-formed over a synthetic reintroduced site · `:639` re-formed over synthetic weights (the real-weight swap would have become vacuous).

## Coupled suites re-formed (not re-pinned)

The delivery flip moves the W4C3A `NOT_DELIVERED` promotion refusal from firing to not firing — Gate D's exit condition — so six legs asserting the old state were re-formed, plus E5 leg 6b and OD-W4C-54. Details in the individual commits; each re-form ships its own non-vacuity control (e.g. the rollout-control exit leg re-declares an entrypoint undelivered and gets the refusal straight back; the CLI leg keeps the "the in-process seam cannot cross the subprocess boundary" property that survived the flip).

## Verification

- **Full CI attendance battery, 109 files: 1573/1573 (111 files; landing head 7a1118c300 = D3 + landed W7-1a/W7-1a-M union) green** (`TZ=UTC`, CI-shaped `DATABASE_URL`, fresh migrated DB, re-run at this exact head). `origin/main` was re-fetched afterwards and is advanced to `0261b33c61` (W7-1a `1f7f626e31` + W7-1a-M `0261b33c61` landed); re-verified current-main-relative at landing head `7a1118c300`, so this verdict is current-main-relative, not stale-base-relative.
- core-backend unit suite: 631 files / 9089 tests green; attendance no-DB set 44 files / 563 tests green.
- **Full `plugin-integration-core` CJS chain green** (the whole `scripts.test` list, not just the provenance file — that package's suites are required via integration-guard and the pins JSON is an input to more than one of them).
- `attendance-w4c2-ci-wiring.test.mjs` 231/231 · DML inventory collector 58/58 (**unclaimed = 0, no census hand-edit**) · w4c3c tooling contracts 19/19 · sealed-export provenance pin green.
- `tsc --noEmit` clean.
- Two-point wiring: `vitest.config.ts` exclude + `plugin-tests.yml` run-list; s6a pin regenerated (`pluginTestsWorkflow` **only**), verified by the provenance test; `EXPECTED_ATTENDANCE_SUITES` regenerated with the emitter the guard names.

> **Local-environment note, not a code finding:** the first battery run showed 39 file failures caused by `PluginAttendanceLibResolutionError[REPO_ROOT_AMBIGUOUS]` — the agent worktree was nested *inside* the canonical repo, so two ancestors carry `packages/core-backend/package.json`. Re-run from a non-nested worktree: 109/109.

## DML inventory

No census hand-edit was needed and none was made. Measured: the scheduled branch's placeholder creation is a **call** to the helper X07 already claims **by symbol**; the core call, the first production `recordAttendanceScheduledRunTargetOutcomeV1('failed')` and `cancelAttendanceResultOperationV1` are calls into already-claimed writers; removing `applyScheduledAbsenceLegacy` from the authoritative arm is a classification change (the adapter stays claimed for the paths that still call it); and `SAVEPOINT`/`ROLLBACK TO`/`RELEASE` carry no verb the scanner tracks. Recorded in X07's own comment so the next reader sees D3 was considered.

## Owner decisions still open — nothing here was resolved unilaterally

Every §6 default is shipped as the brief specifies and is listed here for ruling:

- **§6.1 containment shape + claim disposition** — the D3 lock's central ruling. Shipped: cancel-then-record in the same transaction. **The option space is narrower than the brief's revision 1 believed:** "leave it unsealed" is illegal (the deferred commit guard), and "seal a failure snapshot" is a §2.5 protocol change. The genuine lock question: `cancelAttendanceResultOperationV1`'s docblock says *"source-free cancel: allowed only before source DML (lock 7.1)"*, the rule is **not enforced in code**, and D3 cancels after a `ROLLBACK TO SAVEPOINT` has undone every source write of the branch. Is "source-free because it was rolled back" the same predicate the lock meant? Shipped default: yes. **Also foreclosed by the code, not by choice:** persisting the specific refusing code alongside the reason is *not* a build-time option — the run registry's writer validates the `'failed'` payload as **exactly two keys** and refuses a third with `W4C2_SCHEDULED_RUN_OUTCOME_INVALID`. And please confirm the deliberate class-level over-breadth is the direction you want.
- **§6.2 present-parent SKIP** (shipped) — justified by legacy parity, not rarity. Consequence: the core's completed-supersede-over-legacy-active path is **dormant** on `scheduled`; leg 15 pins the producer directly so the other fork has no latent landmine.
- **§6.3 `review_required` ⇒ `completed` outcome, `inserted:true` ⇔ pointer moved** (shipped). **Disclosed parity gap that follows from it:** a target whose attribution is unresolvable (no shift) yields a review outcome and `inserted:false`, where the legacy path would have INSERTed an `'absent'` row and counted it. So for such users an authoritative org's `generated_count` is lower than a legacy org's for the same day. This is a product consequence of the review path, not a defect in the wiring, but it lands on the counter §6.3 calls load-bearing and should be ruled explicitly. **Second half of the same consequence (added per the independent gate's P3-1):** that unresolvable-attribution day is left as a `retired/review_placeholder` parent, and the canonical read surface `attendance_current_records` filters `WHERE visibility_state = 'active'` — so a day the legacy path made *visible* as an `'absent'` record is now **invisible on the canonical read surface**, with no clearing mechanism (D2 §5b hazard P3-3) and auto-absence suppression (D2 §5b hazard P3-4) both applying. D3 does not create that hazard family; it **scales** it to every scheduled target in this state. The §6.3 ruling should weigh both halves (the count under-report AND the read-surface invisibility) together with the D2 §5b runbook preconditions.
- **§6.4 seal upgrade** — NOT taken (preserving the contract is a §2.5 obligation, not a preference).
- **§6.5 guard placement** — boundary replicate (the D1 core header permits either).
- **§6.6 identity-drift analogue** — none; `scheduled` has no outer resolution by design.
- **§6.7 posture-race semantics** — per-target re-read stays the selector; see finding 3 above for what is actually reachable.
- **§6.8 `perUser` `'failed'` mode** — naming only.
- **§6.9 review-kind targets** — unchanged, registry-only.
- **§6.10 second-generation `review_placeholder`** — shipped as PROCEED (the placeholder is our artifact and a re-attempt must be able to complete it), a deliberate narrow divergence from legacy `NOT EXISTS` parity, pinned by its own leg.

**Leg 20 (D2/D1 carry-forwards): verified, not re-done — with the evidence split stated.** Two of the brief's four are checked STATICALLY by a leg in this PR: the `projected_status` pre-check (spelled independently of the eight-member daily-status constant) and the `RELEASE SAVEPOINT` after `ROLLBACK TO` in the F1 catch path, plus the widened single locked read D3 consumes. The other two — the third-generation SAME-TXN atomicity trigger and the defensive `ROLLBACK` before release in the two race tests — rest on `attendance-w4c2-authoritative-calculation-core.db.test.ts` passing in the 109-file battery, which is a different kind of evidence and is not claimed as a grep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GwzPDVkFHmmaYu6tnAWaj2


