### PR TITLE
ops(dingtalk): configure MetaSheetCanary OAuth on staging

### DIFF
--- a/.github/workflows/dingtalk-oauth-staging-config-contract.yml
+++ b/.github/workflows/dingtalk-oauth-staging-config-contract.yml
@@ -1,0 +1,29 @@
+name: DingTalk OAuth Staging Config Contract
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/dingtalk-oauth-staging-config.yml'
+      - '.github/workflows/dingtalk-oauth-staging-config-contract.yml'
+      - 'scripts/ops/dingtalk-oauth-staging-config-contract.test.mjs'
+      - 'scripts/ops/dingtalk-oauth-staging-config-remote.sh'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  contract:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Verify runner YAML parser
+        run: python3 -c 'import yaml'
+      - name: Run OAuth staging configuration contract
+        run: node --test scripts/ops/dingtalk-oauth-staging-config-contract.test.mjs

--- a/.github/workflows/dingtalk-oauth-staging-config.yml
+++ b/.github/workflows/dingtalk-oauth-staging-config.yml
@@ -1,0 +1,187 @@
+name: DingTalk OAuth Staging Config
+
+run-name: "DingTalk OAuth staging: ${{ inputs.action }}"
+
+on:
+  workflow_dispatch:
+    inputs:
+      action:
+        description: 'status (read-only) | prepare (configure MetaSheetCanary OAuth)'
+        required: true
+        type: choice
+        options: [status, prepare]
+        default: status
+      deploy_sha:
+        description: 'Exact 40-character staging deploy SHA; required for prepare'
+        required: false
+        default: ''
+      expected_current_mode:
+        description: 'Must be off for prepare'
+        required: false
+        default: 'off'
+      confirmation:
+        description: 'prepare requires CONFIGURE_METASHEETCANARY_OAUTH'
+        required: false
+        default: ''
+
+concurrency:
+  group: attendance-staging-window-runner
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate workflow contract
+        env:
+          ACTION: ${{ inputs.action }}
+          DEPLOY_SHA: ${{ inputs.deploy_sha }}
+          EXPECTED_CURRENT_MODE: ${{ inputs.expected_current_mode }}
+          CONFIRMATION: ${{ inputs.confirmation }}
+        run: |
+          set -euo pipefail
+          [[ "$ACTION" == status || "$ACTION" == prepare ]]
+          [[ -z "$DEPLOY_SHA" || "$DEPLOY_SHA" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$EXPECTED_CURRENT_MODE" == off ]]
+          [[ -z "$CONFIRMATION" || "$CONFIRMATION" == CONFIGURE_METASHEETCANARY_OAUTH ]]
+          if [[ "$ACTION" == prepare ]]; then
+            [[ "$DEPLOY_SHA" =~ ^[0-9a-f]{40}$ ]]
+            [[ "$CONFIRMATION" == CONFIGURE_METASHEETCANARY_OAUTH ]]
+          fi
+          bash -n scripts/ops/dingtalk-oauth-staging-config-remote.sh
+          node --test scripts/ops/dingtalk-oauth-staging-config-contract.test.mjs
+
+      - name: Prepare pinned SSH transport
+        env:
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+          DEPLOY_SSH_KEY_B64: ${{ secrets.DEPLOY_SSH_KEY_B64 }}
+          DEPLOY_KNOWN_HOSTS: ${{ secrets.DEPLOY_KNOWN_HOSTS }}
+        run: |
+          set -euo pipefail
+          mkdir -p ~/.ssh
+          printf '%s' "$DEPLOY_SSH_KEY_B64" | base64 -d > ~/.ssh/deploy_key
+          decoded="$(printf '%s' "$DEPLOY_KNOWN_HOSTS" | base64 -d 2>/dev/null || true)"
+          if printf '%s' "$decoded" | grep -Eq 'ssh-ed25519|ssh-rsa|ecdsa-sha2'; then
+            printf '%s\n' "$decoded" > ~/.ssh/known_hosts
+          else
+            printf '%s\n' "$DEPLOY_KNOWN_HOSTS" > ~/.ssh/known_hosts
+          fi
+          grep -Eq 'ssh-ed25519|ssh-rsa|ecdsa-sha2' ~/.ssh/known_hosts
+          chmod 600 ~/.ssh/deploy_key ~/.ssh/known_hosts
+
+      - name: Run remote action
+        id: remote
+        continue-on-error: true
+        env:
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+          DEPLOY_PATH: ${{ secrets.DEPLOY_PATH }}
+          STAGING_DEPLOY_PATH: ${{ vars.STAGING_DEPLOY_PATH || 'metasheet2-dingtalk-staging' }}
+          ACTION: ${{ inputs.action }}
+          DEPLOY_SHA: ${{ inputs.deploy_sha }}
+          EXPECTED_CURRENT_MODE: ${{ inputs.expected_current_mode }}
+          CONFIRMATION: ${{ inputs.confirmation }}
+          OAUTH_CLIENT_ID: ${{ inputs.action == 'prepare' && secrets.STAGING_DINGTALK_OAUTH_CLIENT_ID || '' }}
+          OAUTH_CLIENT_SECRET: ${{ inputs.action == 'prepare' && secrets.STAGING_DINGTALK_OAUTH_CLIENT_SECRET || '' }}
+        run: |
+          set -euo pipefail
+          _CLIENT_ID="${OAUTH_CLIENT_ID-}"
+          _CLIENT_SECRET="${OAUTH_CLIENT_SECRET-}"
+          unset OAUTH_CLIENT_ID OAUTH_CLIENT_SECRET
+          ssh_opts="-o BatchMode=yes -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes -o UserKnownHostsFile=$HOME/.ssh/known_hosts -o GlobalKnownHostsFile=/dev/null -i $HOME/.ssh/deploy_key"
+          for pair in "DEPLOY_PATH=${DEPLOY_PATH:-metasheet2}" "STAGING_DEPLOY_PATH=$STAGING_DEPLOY_PATH"; do
+            [[ "${pair#*=}" =~ ^[A-Za-z0-9._/~-]+$ ]] || exit 2
+          done
+          [[ "$ACTION" == status || "$ACTION" == prepare ]]
+          [[ -z "$DEPLOY_SHA" || "$DEPLOY_SHA" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$EXPECTED_CURRENT_MODE" == off ]]
+          [[ -z "$CONFIRMATION" || "$CONFIRMATION" == CONFIGURE_METASHEETCANARY_OAUTH ]]
+          runner_dir="/tmp/dingtalk-oauth-config-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          output_dir="/tmp/dingtalk-oauth-config-out-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          artifact_name="dingtalk-oauth-staging-config-${ACTION}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          echo "artifact_name=$artifact_name" >> "$GITHUB_OUTPUT"
+          mkdir -p output/dingtalk-oauth
+          cleanup() {
+            set +e
+            rm -rf "${local_secret_dir:-}"
+            ssh $ssh_opts "$DEPLOY_USER@$DEPLOY_HOST" "rm -rf '$runner_dir' '$output_dir'" >/dev/null 2>&1
+          }
+          trap cleanup EXIT
+          trap 'exit 129' HUP
+          trap 'exit 130' INT
+          trap 'exit 143' TERM
+          tar -czf - scripts/ops/dingtalk-oauth-staging-config-remote.sh \
+            | ssh $ssh_opts "$DEPLOY_USER@$DEPLOY_HOST" "mkdir -p '$runner_dir' && tar -xzf - -C '$runner_dir' --strip-components=2"
+
+          secret_exports=""
+          if [[ "$ACTION" == prepare ]]; then
+            [[ -n "$_CLIENT_ID" && -n "$_CLIENT_SECRET" ]] || { echo 'OAuth secrets are required' >&2; exit 2; }
+            local_secret_dir="$(mktemp -d "${RUNNER_TEMP}/dingtalk-oauth.XXXXXX")"; chmod 700 "$local_secret_dir"; umask 077
+            printf '%s' "$_CLIENT_ID" > "$local_secret_dir/client.id"
+            printf '%s' "$_CLIENT_SECRET" > "$local_secret_dir/client.secret"
+            unset _CLIENT_ID _CLIENT_SECRET
+            chmod 600 "$local_secret_dir/client.id" "$local_secret_dir/client.secret"
+            remote_secret_dir="$runner_dir/.secrets"
+            ssh $ssh_opts "$DEPLOY_USER@$DEPLOY_HOST" "mkdir -p '$remote_secret_dir' && chmod 700 '$remote_secret_dir'"
+            scp $ssh_opts "$local_secret_dir/client.id" "$local_secret_dir/client.secret" "$DEPLOY_USER@$DEPLOY_HOST:$remote_secret_dir/"
+            ssh $ssh_opts "$DEPLOY_USER@$DEPLOY_HOST" "chmod 600 '$remote_secret_dir/client.id' '$remote_secret_dir/client.secret'"
+            secret_exports="export OAUTH_CLIENT_ID_FILE='$remote_secret_dir/client.id'; export OAUTH_CLIENT_SECRET_FILE='$remote_secret_dir/client.secret';"
+          else
+            unset _CLIENT_ID _CLIENT_SECRET
+          fi
+
+          remote_script="set -euo pipefail
+          export ACTION='$ACTION' DEPLOY_SHA='$DEPLOY_SHA' EXPECTED_CURRENT_MODE='$EXPECTED_CURRENT_MODE'
+          export CONFIRMATION='$CONFIRMATION' STAGING_DEPLOY_PATH='$STAGING_DEPLOY_PATH' DEPLOY_PATH='${DEPLOY_PATH:-metasheet2}'
+          export OUTPUT_DIR='$output_dir' RUN_STAMP='gh${GITHUB_RUN_ID}a${GITHUB_RUN_ATTEMPT}'
+          $secret_exports
+          rm -rf '$output_dir'; mkdir -p '$output_dir'
+          bash '$runner_dir/dingtalk-oauth-staging-config-remote.sh'"
+          escaped="$(printf '%s' "$remote_script" | sed "s/'/'\\\\''/g")"
+          set +e
+          ssh $ssh_opts "$DEPLOY_USER@$DEPLOY_HOST" "bash -o pipefail -c '$escaped'" 2>&1 | tee output/dingtalk-oauth/ssh.log
+          rc=${PIPESTATUS[0]}
+          scp $ssh_opts -r "$DEPLOY_USER@$DEPLOY_HOST:$output_dir/." output/dingtalk-oauth/ >> output/dingtalk-oauth/ssh.log 2>&1
+          scp_rc=$?
+          set -e
+          if [[ "$ACTION" == prepare && -f "$local_secret_dir/client.secret" ]]; then
+            # Scan the complete artifact payload against the real secret bytes.
+            # Only file paths enter argv; neither the secret nor its digest is logged.
+            python3 - "$local_secret_dir/client.secret" output/dingtalk-oauth <<'PY'
+          import pathlib, shutil, sys
+          secret = pathlib.Path(sys.argv[1]).read_bytes()
+          if not secret:
+              raise SystemExit("empty secret scan input")
+          root = pathlib.Path(sys.argv[2])
+          for path in root.rglob("*"):
+              if path.is_file() and secret in path.read_bytes():
+                  shutil.rmtree(root)
+                  raise SystemExit(f"secret bytes found in artifact file: {path.name}")
+          PY
+          fi
+          [[ "$rc" != 0 || "$scp_rc" == 0 ]] || rc="$scp_rc"
+          echo "remote_rc=$rc" >> "$GITHUB_OUTPUT"
+
+      - name: Upload values-free evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.remote.outputs.artifact_name || format('dingtalk-oauth-staging-config-{0}-{1}', inputs.action, github.run_id) }}
+          path: output/dingtalk-oauth
+          if-no-files-found: warn
+          retention-days: 14
+
+      - name: Fail on remote error
+        if: always()
+        env:
+          REMOTE_RC: ${{ steps.remote.outputs.remote_rc }}
+        run: |
+          set -euo pipefail
+          [[ "$REMOTE_RC" =~ ^[0-9]+$ && "$REMOTE_RC" == 0 ]] || exit "${REMOTE_RC:-1}"

--- a/scripts/ops/dingtalk-oauth-staging-config-contract.test.mjs
+++ b/scripts/ops/dingtalk-oauth-staging-config-contract.test.mjs
@@ -1,0 +1,96 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { test } from 'node:test'
+
+const workflow = readFileSync(new URL('../../.github/workflows/dingtalk-oauth-staging-config.yml', import.meta.url), 'utf8')
+const remote = readFileSync(new URL('./dingtalk-oauth-staging-config-remote.sh', import.meta.url), 'utf8')
+const contractWorkflow = readFileSync(new URL('../../.github/workflows/dingtalk-oauth-staging-config-contract.yml', import.meta.url), 'utf8')
+
+test('workflow is manual, staging-serialized, pinned-SSH, and fail-honest', () => {
+  assert.match(workflow, /workflow_dispatch:/)
+  assert.match(workflow, /group: attendance-staging-window-runner/)
+  assert.match(workflow, /permissions:\n  contents: read/)
+  assert.match(workflow, /StrictHostKeyChecking=yes/)
+  assert.match(workflow, /UserKnownHostsFile=/)
+  assert.match(workflow, /GlobalKnownHostsFile=\/dev\/null/)
+  assert.match(workflow, /continue-on-error: true/)
+  assert.match(workflow, /Fail on remote error/)
+})
+
+test('contract has a path-scoped pull-request workflow on Node 20', () => {
+  assert.match(contractWorkflow, /pull_request:/)
+  assert.match(contractWorkflow, /node-version: '20'/)
+  assert.match(contractWorkflow, /node --test scripts\/ops\/dingtalk-oauth-staging-config-contract\.test\.mjs/)
+  for (const file of [
+    '.github/workflows/dingtalk-oauth-staging-config.yml',
+    '.github/workflows/dingtalk-oauth-staging-config-contract.yml',
+    'scripts/ops/dingtalk-oauth-staging-config-contract.test.mjs',
+    'scripts/ops/dingtalk-oauth-staging-config-remote.sh',
+  ]) {
+    assert.match(contractWorkflow, new RegExp(file.replaceAll('.', '\\.')))
+  }
+})
+
+test('prepare requires exact head, explicit OFF posture, and exact confirmation', () => {
+  assert.match(remote, /\^\[0-9a-f\]\{40\}\$/)
+  assert.match(remote, /EXPECTED_CURRENT_MODE.*== off/)
+  assert.match(remote, /CONFIGURE_METASHEETCANARY_OAUTH/)
+  assert.match(remote, /lifecycle_all_off/)
+  assert.match(workflow, /\[\[ -z "\$DEPLOY_SHA" \|\| "\$DEPLOY_SHA" =~ \^\[0-9a-f\]\{40\}\$ \]\]/)
+  assert.match(workflow, /\[\[ "\$EXPECTED_CURRENT_MODE" == off \]\]/)
+  assert.match(workflow, /\[\[ -z "\$CONFIRMATION" \|\| "\$CONFIRMATION" == CONFIGURE_METASHEETCANARY_OAUTH \]\]/)
+})
+
+test('dedicated app and public callback are pinned', () => {
+  assert.match(remote, /dingn9htcox9lc12rxmc/)
+  assert.match(remote, /dingd1f07b3ff4c8042cbc961a6cb783455b/)
+  assert.match(remote, /https:\/\/metasheet-staging\.ddns\.net/)
+  assert.match(remote, /\/login\/dingtalk\/callback/)
+})
+
+test('credential transport is file-only and artifacts are values-free', () => {
+  assert.match(workflow, /unset OAUTH_CLIENT_ID OAUTH_CLIENT_SECRET/)
+  assert.match(workflow, /chmod 600.*client\.id.*client\.secret/)
+  assert.match(workflow, /secret in path\.read_bytes\(\)/)
+  assert.match(workflow, /shutil\.rmtree\(root\)/)
+  assert.match(remote, /OAUTH_CLIENT_ID_FILE/)
+  assert.match(remote, /OAUTH_CLIENT_SECRET_FILE/)
+  assert.doesNotMatch(remote, /echo[^\n]*\$\{?OAUTH_CLIENT_SECRET/)
+  assert.match(remote, /client_secret_present=/)
+  assert.match(remote, /container_secret_matches_file DINGTALK_CLIENT_SECRET/)
+  assert.match(remote, /live_value="\$\(container_value "\$key"\)"/)
+  assert.match(remote, /printf '%s' "\$live_value" \| sha256sum/)
+  assert.doesNotMatch(remote, /container_value "\$key" \| sha256sum/)
+})
+
+test('write is compose-validated, atomic, backend-only, and rollback-capable', () => {
+  assert.match(remote, /compose_with_env "\$candidate" config/)
+  assert.match(remote, /atomic_install_env/)
+  assert.match(remote, /--no-deps --force-recreate backend/)
+  assert.match(remote, /restoring previous env/)
+  assert.match(remote, /pg_before.*pg_after/s)
+  assert.match(remote, /redis_before.*redis_after/s)
+  assert.match(remote, /web_before.*web_after/s)
+  assert.doesNotMatch(remote, /\[\[ -w "\$target_dir" \]\]/)
+})
+
+test('transport input closed sets reject shell metacharacters', () => {
+  const sha = (value) => value === '' || /^[0-9a-f]{40}$/.test(value)
+  const mode = (value) => value === 'off'
+  const confirmation = (value) => value === '' || value === 'CONFIGURE_METASHEETCANARY_OAUTH'
+  for (const attack of ["x'; id; '", '$(id)', '`id`', 'off\nwhoami']) {
+    assert.equal(sha(attack), false)
+    assert.equal(mode(attack), false)
+    assert.equal(confirmation(attack), false)
+  }
+})
+
+test('all lifecycle gates are forced false in the candidate env', () => {
+  for (const key of [
+    'AUTH_LOGIN_USE_ALIASES',
+    'DIRECTORY_PENDING_ACTIVATION_ENABLED',
+    'DIRECTORY_DEPROVISION_ENABLED',
+  ]) {
+    assert.match(remote, new RegExp(`"${key}": "false"`))
+  }
+})

--- a/scripts/ops/dingtalk-oauth-staging-config-remote.sh
+++ b/scripts/ops/dingtalk-oauth-staging-config-remote.sh
@@ -1,0 +1,306 @@
+#!/usr/bin/env bash
+# Staging-only OAuth configuration for the dedicated MetaSheetCanary DingTalk app.
+set -euo pipefail
+
+log() { echo "[dingtalk-oauth-config] $*"; }
+fail() { echo "[dingtalk-oauth-config][error] $*" >&2; exit 1; }
+
+ACTION="${ACTION:?ACTION is required (status|prepare)}"
+DEPLOY_SHA="${DEPLOY_SHA:-}"
+EXPECTED_CURRENT_MODE="${EXPECTED_CURRENT_MODE:-}"
+CONFIRMATION="${CONFIRMATION:-}"
+OUTPUT_DIR="${OUTPUT_DIR:?OUTPUT_DIR is required}"
+RUN_STAMP="${RUN_STAMP:?RUN_STAMP is required}"
+STAGING_DEPLOY_PATH="${STAGING_DEPLOY_PATH:-metasheet2-dingtalk-staging}"
+DEPLOY_PATH="${DEPLOY_PATH:-metasheet2}"
+OAUTH_CLIENT_ID_FILE="${OAUTH_CLIENT_ID_FILE:-}"
+OAUTH_CLIENT_SECRET_FILE="${OAUTH_CLIENT_SECRET_FILE:-}"
+
+EXPECTED_CLIENT_ID="dingn9htcox9lc12rxmc"
+EXPECTED_CORP_ID="dingd1f07b3ff4c8042cbc961a6cb783455b"
+EXPECTED_APP_URL="https://metasheet-staging.ddns.net"
+EXPECTED_REDIRECT_URI="${EXPECTED_APP_URL}/login/dingtalk/callback"
+PREPARE_CONFIRMATION="CONFIGURE_METASHEETCANARY_OAUTH"
+
+BACKEND_CONTAINER="metasheet-staging-backend"
+WEB_CONTAINER="metasheet-staging-web"
+POSTGRES_CONTAINER="metasheet-staging-postgres"
+REDIS_CONTAINER="metasheet-staging-redis"
+HEALTH_URL="http://127.0.0.1:18900/health"
+FLAG_ALIAS="AUTH_LOGIN_USE_ALIASES"
+FLAG_PENDING="DIRECTORY_PENDING_ACTIVATION_ENABLED"
+FLAG_DEPROVISION="DIRECTORY_DEPROVISION_ENABLED"
+
+resolve_home_path() {
+  case "$1" in
+    /*) printf '%s' "$1" ;;
+    ~/*) printf '%s' "${HOME}/${1#\~/}" ;;
+    *) printf '%s' "${HOME}/$1" ;;
+  esac
+}
+
+STAGING_DIR="$(resolve_home_path "$STAGING_DEPLOY_PATH")"
+PROD_REPO_DIR="$(resolve_home_path "$DEPLOY_PATH")"
+STAGING_ENV_FILE="${STAGING_DIR}/docker/app.staging.env"
+LEGACY_COMPOSE_FILE="${STAGING_DIR}/docker-compose.app.staging.yml"
+ATTENDANCE_DIR="${HOME}/.metasheet2/window-runner"
+PERSISTENT_COMPOSE_FILE="${ATTENDANCE_DIR}/docker-compose.app.staging.yml"
+ATTENDANCE_OVERRIDE_FILE="${ATTENDANCE_DIR}/docker-compose.window-runner.override.yml"
+LIFECYCLE_OVERRIDE_FILE="${HOME}/.metasheet2/lifecycle-canary/docker-compose.lifecycle-canary.override.yml"
+PERSIST_DIR="${HOME}/.metasheet2/dingtalk-oauth-config"
+STAGING_COMPOSE_FILE="$LEGACY_COMPOSE_FILE"
+[[ -f "$PERSISTENT_COMPOSE_FILE" ]] && STAGING_COMPOSE_FILE="$PERSISTENT_COMPOSE_FILE"
+
+cleanup_files=()
+cleanup() {
+  local path
+  for path in "${cleanup_files[@]:-}"; do rm -f "$path"; done
+}
+trap cleanup EXIT
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+assert_staging_only() {
+  [[ -d "$STAGING_DIR" && -f "$STAGING_COMPOSE_FILE" && -f "$STAGING_ENV_FILE" ]] \
+    || fail "staging stack/env is missing; refusing to guess"
+  [[ "$STAGING_DIR" != "$PROD_REPO_DIR" ]] || fail "staging path equals production path"
+  grep -q "container_name: ${BACKEND_CONTAINER}" "$STAGING_COMPOSE_FILE" \
+    || fail "staging backend container is not declared"
+  grep -q "container_name: ${WEB_CONTAINER}" "$STAGING_COMPOSE_FILE" \
+    || fail "staging web container is not declared"
+  grep -q "container_name: ${POSTGRES_CONTAINER}" "$STAGING_COMPOSE_FILE" \
+    || fail "staging postgres container is not declared"
+  grep -q "container_name: ${REDIS_CONTAINER}" "$STAGING_COMPOSE_FILE" \
+    || fail "staging redis container is not declared"
+}
+
+is_true() {
+  case "$(printf '%s' "${1:-}" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')" in
+    true|1|yes|on) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+container_value() {
+  docker exec "$BACKEND_CONTAINER" sh -c 'printenv "$1" 2>/dev/null || true' sh "$1" 2>/dev/null || true
+}
+
+value_matches() {
+  [[ "$(container_value "$1")" == "$2" ]] && printf true || printf false
+}
+
+secret_present() {
+  [[ -n "$(container_value "$1")" ]] && printf true || printf false
+}
+
+container_secret_matches_file() {
+  local key="$1" expected_file="$2" live_value live_digest expected_digest
+  # Command substitution removes printenv's trailing newline. Hash the exact env
+  # value bytes, matching the newline-free chmod-600 secret file.
+  live_value="$(container_value "$key")"
+  live_digest="$(printf '%s' "$live_value" | sha256sum | awk '{print $1}')"
+  expected_digest="$(sha256sum "$expected_file" | awk '{print $1}')"
+  [[ -n "$live_value" && "$live_digest" == "$expected_digest" ]]
+}
+
+lifecycle_all_off() {
+  local key value
+  for key in "$FLAG_ALIAS" "$FLAG_PENDING" "$FLAG_DEPROVISION"; do
+    value="$(container_value "$key")"
+    if is_true "$value"; then printf false; return; fi
+  done
+  printf true
+}
+
+backend_health() {
+  local body
+  body="$(curl -fsS --max-time 10 "$HEALTH_URL" 2>/dev/null || true)"
+  printf '%s' "$body" | python3 -c 'import json,sys
+try:
+ d=json.load(sys.stdin); print("true" if d.get("ok") is True or d.get("status")=="ok" else "false")
+except Exception: print("false")'
+}
+
+health_commit() {
+  curl -fsS --max-time 10 "http://127.0.0.1:8082/api/health" 2>/dev/null \
+    | python3 -c 'import json,sys
+try: print(json.load(sys.stdin).get("build",{}).get("commit",""))
+except Exception: print("")' || true
+}
+
+deployed_sha() {
+  local image image_sha="" http_sha
+  image="$(docker inspect -f '{{.Config.Image}}' "$BACKEND_CONTAINER" 2>/dev/null || true)"
+  [[ "$image" =~ :([0-9a-f]{40})$ ]] && image_sha="${BASH_REMATCH[1]}"
+  http_sha="$(health_commit)"
+  if [[ "$image_sha" =~ ^[0-9a-f]{40}$ && "$http_sha" == "$image_sha" ]]; then
+    printf '%s' "$image_sha"
+  elif [[ -n "$image_sha" && -n "$http_sha" ]]; then
+    printf conflict
+  else
+    printf unknown
+  fi
+}
+
+write_status() {
+  local reason="$1" live_sha sha_match=false
+  live_sha="$(deployed_sha)"
+  [[ -n "$DEPLOY_SHA" && "$live_sha" == "$DEPLOY_SHA" ]] && sha_match=true
+  {
+    echo "schema=dingtalk-oauth-staging-config-v1"
+    echo "action=${ACTION}"
+    echo "reason=${reason}"
+    echo "deployed_sha=${live_sha}"
+    echo "deployed_sha_match=${sha_match}"
+    echo "backend_health=$(backend_health)"
+    echo "lifecycle_flags_all_off=$(lifecycle_all_off)"
+    echo "client_id_matches=$(value_matches DINGTALK_CLIENT_ID "$EXPECTED_CLIENT_ID")"
+    echo "client_secret_present=$(secret_present DINGTALK_CLIENT_SECRET)"
+    echo "corp_id_matches=$(value_matches DINGTALK_CORP_ID "$EXPECTED_CORP_ID")"
+    echo "redirect_uri_matches=$(value_matches DINGTALK_REDIRECT_URI "$EXPECTED_REDIRECT_URI")"
+    echo "public_app_url_matches=$(value_matches PUBLIC_APP_URL "$EXPECTED_APP_URL")"
+    echo "cors_origin_matches=$(value_matches CORS_ORIGIN "$EXPECTED_APP_URL")"
+  } > "${OUTPUT_DIR}/status.txt"
+  cp "${OUTPUT_DIR}/status.txt" "${OUTPUT_DIR}/summary.txt"
+}
+
+resolve_image_pin() {
+  local image
+  image="$(docker inspect -f '{{.Config.Image}}' "$BACKEND_CONTAINER" 2>/dev/null || true)"
+  [[ "$image" =~ ^ghcr\.io/([A-Za-z0-9._-]+)/metasheet2-backend:([0-9a-f]{40})$ ]] \
+    || fail "backend image is not pinned to a full SHA"
+  printf '%s %s' "${BASH_REMATCH[1]}" "${BASH_REMATCH[2]}"
+}
+
+compose_with_env() {
+  local env_file="$1"; shift
+  local owner tag pin
+  pin="$(resolve_image_pin)"; read -r owner tag <<< "$pin"
+  local -a files=(-f "$STAGING_COMPOSE_FILE")
+  [[ -f "$ATTENDANCE_OVERRIDE_FILE" ]] && files+=(-f "$ATTENDANCE_OVERRIDE_FILE")
+  [[ -f "$LIFECYCLE_OVERRIDE_FILE" ]] && files+=(-f "$LIFECYCLE_OVERRIDE_FILE")
+  (cd "$STAGING_DIR" && IMAGE_OWNER="$owner" IMAGE_TAG="$tag" APP_ENV_FILE="$env_file" \
+    docker compose --project-directory "$STAGING_DIR" --env-file "$env_file" "${files[@]}" "$@")
+}
+
+atomic_install_env() {
+  local candidate="$1" target_dir target_name uid gid image tmp_name
+  target_dir="$(dirname "$STAGING_ENV_FILE")"; target_name="$(basename "$STAGING_ENV_FILE")"
+  uid="$(stat -c '%u' "$STAGING_ENV_FILE")"; gid="$(stat -c '%g' "$STAGING_ENV_FILE")"
+  image="$(docker inspect -f '{{.Config.Image}}' "$BACKEND_CONTAINER")"
+  tmp_name=".${target_name}.oauth-${RUN_STAMP}.tmp"
+  timeout 30s docker run --rm --pull never --network none --entrypoint /bin/sh \
+    --mount "type=bind,src=${candidate},dst=/candidate,readonly" \
+    --mount "type=bind,src=${target_dir},dst=/target" \
+    -e TARGET_NAME="$target_name" -e TMP_NAME="$tmp_name" -e TARGET_UID="$uid" -e TARGET_GID="$gid" \
+    "$image" -c 'set -eu; umask 077; trap '\''rm -f "/target/${TMP_NAME}"'\'' EXIT; cp /candidate "/target/${TMP_NAME}"; chown "${TARGET_UID}:${TARGET_GID}" "/target/${TMP_NAME}"; chmod 600 "/target/${TMP_NAME}"; mv -f "/target/${TMP_NAME}" "/target/${TARGET_NAME}"; trap - EXIT' >/dev/null \
+    || fail "atomic env install failed; previous env retained"
+  rm -f "$candidate"
+}
+
+build_candidate() {
+  local destination="$1"
+  python3 - "$STAGING_ENV_FILE" "$destination" "$OAUTH_CLIENT_ID_FILE" "$OAUTH_CLIENT_SECRET_FILE" <<'PY'
+import os, sys
+src, dst, cid_path, secret_path = sys.argv[1:]
+def read(path):
+    with open(path, encoding="utf-8") as fh:
+        value=fh.read().rstrip("\r\n")
+    if not value or any(ord(c)<32 for c in value): raise SystemExit("invalid secret file")
+    return value
+updates={
+ "DINGTALK_CLIENT_ID": read(cid_path), "DINGTALK_CLIENT_SECRET": read(secret_path),
+ "DINGTALK_CORP_ID": "dingd1f07b3ff4c8042cbc961a6cb783455b",
+ "DINGTALK_REDIRECT_URI": "https://metasheet-staging.ddns.net/login/dingtalk/callback",
+ "PUBLIC_APP_URL": "https://metasheet-staging.ddns.net", "CORS_ORIGIN": "https://metasheet-staging.ddns.net",
+ "AUTH_LOGIN_USE_ALIASES": "false", "DIRECTORY_PENDING_ACTIVATION_ENABLED": "false",
+ "DIRECTORY_DEPROVISION_ENABLED": "false",
+}
+lines=open(src, encoding="utf-8", errors="replace").read().splitlines(); out=[]; seen=set()
+for line in lines:
+    key=line.split("=",1)[0].strip() if "=" in line and not line.lstrip().startswith("#") else ""
+    if key in updates: out.append(f"{key}={updates[key]}"); seen.add(key)
+    else: out.append(line)
+for key,value in updates.items():
+    if key not in seen: out.append(f"{key}={value}")
+with open(dst,"w",encoding="utf-8") as fh: fh.write("\n".join(out)+"\n")
+os.chmod(dst,0o600)
+PY
+}
+
+restart_backend() {
+  local pg_before redis_before web_before pg_after redis_after web_after i
+  pg_before="$(docker inspect -f '{{.Id}}' "$POSTGRES_CONTAINER")"
+  redis_before="$(docker inspect -f '{{.Id}}' "$REDIS_CONTAINER")"
+  web_before="$(docker inspect -f '{{.Id}}' "$WEB_CONTAINER")"
+  compose_with_env "$STAGING_ENV_FILE" up -d --no-deps --force-recreate backend \
+    > "${OUTPUT_DIR}/compose-up-backend.log" 2>&1 || return 1
+  pg_after="$(docker inspect -f '{{.Id}}' "$POSTGRES_CONTAINER" 2>/dev/null || true)"
+  redis_after="$(docker inspect -f '{{.Id}}' "$REDIS_CONTAINER" 2>/dev/null || true)"
+  web_after="$(docker inspect -f '{{.Id}}' "$WEB_CONTAINER" 2>/dev/null || true)"
+  [[ "$pg_before" == "$pg_after" && "$redis_before" == "$redis_after" && "$web_before" == "$web_after" ]] || return 1
+  for ((i=1; i<=30; i+=1)); do
+    [[ "$(backend_health)" == true ]] && return 0
+    sleep 2
+  done
+  return 1
+}
+
+require_secret_file() {
+  [[ -f "$1" && ! -L "$1" && -s "$1" ]] || fail "$2 secret file is missing"
+  [[ "$(stat -c '%a' "$1")" == 600 ]] || fail "$2 secret file must have mode 600"
+}
+
+action_prepare() {
+  [[ "$DEPLOY_SHA" =~ ^[0-9a-f]{40}$ ]] || fail "prepare requires a full deploy SHA"
+  [[ "$EXPECTED_CURRENT_MODE" == off ]] || fail "prepare requires expected_current_mode=off"
+  [[ "$CONFIRMATION" == "$PREPARE_CONFIRMATION" ]] || fail "prepare confirmation mismatch"
+  [[ "$(deployed_sha)" == "$DEPLOY_SHA" ]] || fail "deployed SHA does not match"
+  [[ "$(lifecycle_all_off)" == true ]] || fail "all lifecycle flags must be OFF"
+  [[ "$(backend_health)" == true ]] || fail "backend is not healthy"
+  require_secret_file "$OAUTH_CLIENT_ID_FILE" client_id
+  require_secret_file "$OAUTH_CLIENT_SECRET_FILE" client_secret
+  [[ "$(<"$OAUTH_CLIENT_ID_FILE")" == "$EXPECTED_CLIENT_ID" ]] || fail "client_id is not MetaSheetCanary"
+
+  mkdir -p "$PERSIST_DIR"; chmod 700 "$PERSIST_DIR"
+  local candidate backup
+  candidate="$(mktemp "${PERSIST_DIR}/.app.staging.env.XXXXXX")"; cleanup_files+=("$candidate")
+  backup="${PERSIST_DIR}/app.staging.env.backup-${RUN_STAMP}"
+  build_candidate "$candidate"
+  compose_with_env "$candidate" config >/dev/null 2>&1 || fail "candidate env failed compose validation"
+  cp -p "$STAGING_ENV_FILE" "$backup"; chmod 600 "$backup"
+  atomic_install_env "$candidate"
+
+  if ! restart_backend \
+    || [[ "$(deployed_sha)" != "$DEPLOY_SHA" ]] \
+    || [[ "$(lifecycle_all_off)" != true ]] \
+    || [[ "$(backend_health)" != true ]] \
+    || [[ "$(value_matches DINGTALK_CLIENT_ID "$EXPECTED_CLIENT_ID")" != true ]] \
+    || ! container_secret_matches_file DINGTALK_CLIENT_SECRET "$OAUTH_CLIENT_SECRET_FILE" \
+    || [[ "$(value_matches DINGTALK_CORP_ID "$EXPECTED_CORP_ID")" != true ]] \
+    || [[ "$(value_matches DINGTALK_REDIRECT_URI "$EXPECTED_REDIRECT_URI")" != true ]] \
+    || [[ "$(value_matches PUBLIC_APP_URL "$EXPECTED_APP_URL")" != true ]] \
+    || [[ "$(value_matches CORS_ORIGIN "$EXPECTED_APP_URL")" != true ]]; then
+    log "post-write verification failed; restoring previous env"
+    local rollback
+    rollback="$(mktemp "${PERSIST_DIR}/.rollback.XXXXXX")"; cleanup_files+=("$rollback")
+    cp "$backup" "$rollback"; chmod 600 "$rollback"; atomic_install_env "$rollback"
+    if restart_backend; then
+      write_status rollback_restored
+      fail "prepare failed; previous env and healthy backend were restored"
+    fi
+    write_status rollback_backend_unhealthy
+    fail "prepare failed; previous env was restored on disk but backend health was not recovered"
+  fi
+  write_status configured
+  log "MetaSheetCanary OAuth configured; lifecycle flags remain OFF"
+}
+
+mkdir -p "$OUTPUT_DIR"
+assert_staging_only
+case "$ACTION" in
+  status) write_status ok ;;
+  prepare) action_prepare ;;
+  *) fail "invalid action: ${ACTION}" ;;
+esac


### PR DESCRIPTION
## What changed

- add a manual staging-only `status|prepare` OAuth configuration workflow
- pin the dedicated MetaSheetCanary AppKey, corp ID, HTTPS callback, public URL, and CORS origin
- transport the OAuth secret through chmod-600 files and scan all evidence for the real secret bytes before upload
- atomically replace `docker/app.staging.env`, restart backend only, verify exact deployed SHA and unchanged web/Postgres/Redis containers, and roll back on failure
- force `AUTH_LOGIN_USE_ALIASES`, `DIRECTORY_PENDING_ACTIVATION_ENABLED`, and `DIRECTORY_DEPROVISION_ENABLED` to remain false
- wire the contract into the required Node 20 test lane

## Safety posture

- draft and unarmed; this PR does not dispatch `prepare`
- `prepare` requires exact SHA, live all-OFF posture, healthy backend, and exact confirmation `CONFIGURE_METASHEETCANARY_OAUTH`
- target is fixed to `https://metasheet-staging.ddns.net/login/dingtalk/callback`
- GitHub secrets contain the MetaSheetCanary client ID/secret; no secret value is committed or printed

## Verification

- `bash -n scripts/ops/dingtalk-oauth-staging-config-remote.sh`
- `node --test scripts/ops/dingtalk-oauth-staging-config-contract.test.mjs` (8/8)
- DingTalk adjacent required contracts together (62/62)
- Kimi read-only adversarial review; all reported P2 findings fixed, including input injection, cross-filesystem atomicity, web-container guard, artifact leak scan, and printenv newline digest mismatch
