### PR TITLE
feat(attendance): W7-1a-M inert provenance value-domain widening (#4556)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -1415,6 +1415,7 @@ jobs:
             tests/integration/attendance-result-edit.test.ts \
             tests/integration/attendance-shift-segments-migration.db.test.ts \
             tests/integration/attendance-shift-segments-writer-matrix.db.test.ts \
+            tests/integration/attendance-w7-1am-provenance-widening.db.test.ts \
             tests/integration/scratch-database-drain.db.test.ts \
             --reporter=dot
 

--- a/apps/web/src/views/attendance/attendanceDecisionTrace.ts
+++ b/apps/web/src/views/attendance/attendanceDecisionTrace.ts
@@ -59,6 +59,12 @@ export type AttendanceTraceVersionPosture = (typeof ATTENDANCE_TRACE_VERSION_POS
 export const ATTENDANCE_TRACE_CONFIDENCES = ['grounded', 'partial', 'undeterminable'] as const
 export type AttendanceTraceConfidence = (typeof ATTENDANCE_TRACE_CONFIDENCES)[number]
 
+// W7-1a-M (#4556, ratified per #4556 comments 5293034619 + 5293478713): the web
+// bundle cannot import backend source, so this list is an INDEPENDENT copy of the
+// backend trace source-kind domain. It is widened here in lockstep, and the
+// backend completeness test asserts the two lists stay equal by membership.
+// This array is also the runtime acceptance gate below (`:284`-shaped check): an
+// unwidened copy would silently DROP a `group_policy_snapshot` basis entry.
 export const ATTENDANCE_TRACE_SOURCE_KINDS = [
   'record',
   'snapshot',
@@ -66,6 +72,7 @@ export const ATTENDANCE_TRACE_SOURCE_KINDS = [
   'ledger',
   'audit',
   'policy_gate',
+  'group_policy_snapshot',
 ] as const
 export type AttendanceTraceSourceKind = (typeof ATTENDANCE_TRACE_SOURCE_KINDS)[number]
 
@@ -782,6 +789,8 @@ export function attendanceTraceSourceKindLabel(kind: AttendanceTraceSourceKind, 
     case 'ledger': return tr('Ledger', '台账')
     case 'audit': return tr('Audit', '审计')
     case 'policy_gate': return tr('Policy gate', '策略开关')
+    // W7-1a-M: exhaustive switch — a widened union without this arm fails tsc.
+    case 'group_policy_snapshot': return tr('Group policy snapshot', '组策略快照')
   }
 }
 

--- a/apps/web/src/views/attendance/attendanceDecisionTrace.ts
+++ b/apps/web/src/views/attendance/attendanceDecisionTrace.ts
@@ -63,8 +63,13 @@ export type AttendanceTraceConfidence = (typeof ATTENDANCE_TRACE_CONFIDENCES)[nu
 // bundle cannot import backend source, so this list is an INDEPENDENT copy of the
 // backend trace source-kind domain. It is widened here in lockstep, and the
 // backend completeness test asserts the two lists stay equal by membership.
-// This array is also the runtime acceptance gate below (`:284`-shaped check): an
-// unwidened copy would silently DROP a `group_policy_snapshot` basis entry.
+// This array is also the runtime acceptance gate in `parseBasisEnv` below. Its
+// failure mode is REJECT-WHOLE-RESPONSE, not drop-one-entry: `parseBasisEnv`
+// returns null for an unknown kind, `parseBasis` abandons the whole array on the
+// FIRST such entry, and `parseAttendanceDecisionTraceResponse` then returns null
+// — so an unwidened copy would make the entire decision trace fail to parse and
+// render as absent. Strictly worse than a dropped entry, which is why the copy
+// must stay member-equal to the backend domain.
 export const ATTENDANCE_TRACE_SOURCE_KINDS = [
   'record',
   'snapshot',

--- a/packages/core-backend/src/attendance/__tests__/w7-read-side-provenance-amendment.test.ts
+++ b/packages/core-backend/src/attendance/__tests__/w7-read-side-provenance-amendment.test.ts
@@ -4,11 +4,21 @@
  * `docs/development/attendance-issue-4556-w7-group-policy-cutover-design-lock-20260807.md`
  * §4.4, §7 OD-W7-5.
  *
- * This module is not imported by any production path (W7-R9 byte-inert):
- * neither `PROJECTION_OWNERS`
+ * UPDATED BY W7-1a-M (ratified per #4556 comments 5293034619 + 5293478713).
+ * The W7-0-era statement below — that this module is imported by no production
+ * path and that neither live enum is edited — described W7-0 and no longer
+ * holds: W7-1a-M wired both recorded values into the live domains, so
+ * `../w7-provenance-domain.ts` now imports the two value constants and both
+ * `currentMembers` snapshots track the WIDENED live sets. The snapshots are
+ * still written independently of the domain module's arrays, so the
+ * mutual-extends `tsc` guards they feed remain real comparisons rather than
+ * tautologies.
+ *
+ * Historical W7-0 note: this module was imported by no production path (W7-R9
+ * byte-inert), and neither `PROJECTION_OWNERS`
  * (`../../services/AttendanceW4CalculationDetail.ts`) nor
  * `AttendanceDecisionTraceSourceKind`
- * (`../../services/AttendanceDecisionTrace.ts`) is edited by this PR. The
+ * (`../../services/AttendanceDecisionTrace.ts`) was edited by that PR. The
  * real compile-time drift guard lives in the SOURCE file, not here:
  * `packages/core-backend/tsconfig.json`'s `exclude` list keeps every
  * `.test.ts` file and everything under a `__tests__` directory out of
@@ -34,10 +44,13 @@ describe('W7-0 read-side provenance amendment: recorded values', () => {
     expect(ATTENDANCE_W7_PROJECTION_OWNER_GROUP_VALUE_V1).not.toBe('w4')
   })
 
-  it('trace source-kind new value is a fixed string, distinct from all six current values', () => {
+  it('trace source-kind new value is a fixed string, distinct from the six PRE-widening values', () => {
     expect(ATTENDANCE_W7_TRACE_SOURCE_KIND_GROUP_VALUE_V1).toBe('group_policy_snapshot')
-    const current = ['record', 'snapshot', 'rule_live', 'ledger', 'audit', 'policy_gate']
-    expect(current).not.toContain(ATTENDANCE_W7_TRACE_SOURCE_KIND_GROUP_VALUE_V1)
+    // The six members the union carried before W7-1a-M. Deliberately still the
+    // pre-widening list: the claim is that the new value COLLIDES WITH NONE of
+    // them, which is exactly why it could be added.
+    const preWidening = ['record', 'snapshot', 'rule_live', 'ledger', 'audit', 'policy_gate']
+    expect(preWidening).not.toContain(ATTENDANCE_W7_TRACE_SOURCE_KIND_GROUP_VALUE_V1)
   })
 
   it('bundled record targets exactly the two named modules/symbols, exact-key shape', () => {
@@ -45,13 +58,23 @@ describe('W7-0 read-side provenance amendment: recorded values', () => {
       projectionOwner: {
         targetFile: 'packages/core-backend/src/services/AttendanceW4CalculationDetail.ts',
         targetConst: 'PROJECTION_OWNERS',
-        currentMembers: ['legacy_untracked', 'w4'],
+        // W7-1a-M widened the live set; the snapshot follows it.
+        currentMembers: ['legacy_untracked', 'w4', 'w4_group'],
         newValue: 'w4_group',
       },
       traceSourceKind: {
         targetFile: 'packages/core-backend/src/services/AttendanceDecisionTrace.ts',
         targetType: 'AttendanceDecisionTraceSourceKind',
-        currentMembers: ['record', 'snapshot', 'rule_live', 'ledger', 'audit', 'policy_gate'],
+        // W7-1a-M widened the live union; the snapshot follows it.
+        currentMembers: [
+          'record',
+          'snapshot',
+          'rule_live',
+          'ledger',
+          'audit',
+          'policy_gate',
+          'group_policy_snapshot',
+        ],
         newValue: 'group_policy_snapshot',
       },
     })

--- a/packages/core-backend/src/attendance/w4c0-write-boundary-types.ts
+++ b/packages/core-backend/src/attendance/w4c0-write-boundary-types.ts
@@ -14,6 +14,7 @@ import type {
 } from './w4c0-identity'
 import type { AuthorizedAttendanceWriteContextV1 } from './w4c0-authorization'
 import type { AttendanceInputProvenanceRefV1 } from './w4c0-fingerprints'
+import type { AttendanceProjectionOwnerV1 } from './w7-provenance-domain'
 import type { NormalizedAttendanceSourceOperationEnvelopeV1 } from './w4c0-source-commands'
 
 // ---------------------------------------------------------------------------
@@ -228,7 +229,7 @@ export type AttendanceProjectionDirectiveV1 =
       kind: 'restore'
       restoresCalculationId: string
       parentState: {
-        projectionOwner: 'legacy_untracked' | 'w4'
+        projectionOwner: AttendanceProjectionOwnerV1
         currentCalculationId: string | null
         visibilityState: 'active' | 'retired'
         visibilityReason: 'active' | 'review_placeholder' | 'import_rollback' | 'operator_retirement'

--- a/packages/core-backend/src/attendance/w4c2-authoritative-calculation-core.ts
+++ b/packages/core-backend/src/attendance/w4c2-authoritative-calculation-core.ts
@@ -102,6 +102,11 @@ import {
 } from './w4c0-fingerprints'
 import { computeAttendanceSourceDefinitionFingerprintV1 } from './w4c1-fingerprints'
 import {
+  isAttendanceProjectionOwnerV1,
+  isAttendanceProjectionOwnerWithCalculationPointerV1,
+  type AttendanceProjectionOwnerV1,
+} from './w7-provenance-domain'
+import {
   ATTENDANCE_W4_SEGMENT_ENGINE_VERSION_V1,
   type AttendanceCalculatedSegmentV1,
   type AttendanceSegmentCalculationResultV1,
@@ -428,7 +433,7 @@ export type AttendanceAuthoritativeParentPreimageV1 =
   | { readonly posture: 'absent' }
   | {
       readonly posture: 'present'
-      readonly projectionOwner: 'legacy_untracked' | 'w4'
+      readonly projectionOwner: AttendanceProjectionOwnerV1
       readonly currentCalculationId: string | null
       readonly visibilityState: 'active' | 'retired'
       readonly visibilityReason: 'active' | 'review_placeholder' | 'import_rollback' | 'operator_retirement'
@@ -592,7 +597,7 @@ export type WriteAuthoritativeSegmentCalculationResultV1 =
 
 interface LockedParentV1 {
   readonly currentCalculationId: string | null
-  readonly projectionOwner: 'legacy_untracked' | 'w4'
+  readonly projectionOwner: AttendanceProjectionOwnerV1
   readonly visibilityState: 'active' | 'retired'
   readonly timezone: string | null
 }
@@ -645,7 +650,14 @@ async function lockParent(
   return {
     currentCalculationId:
       typeof row.current_calculation_id === 'string' ? row.current_calculation_id : null,
-    projectionOwner: row.projection_owner === 'w4' ? 'w4' : 'legacy_untracked',
+    // W7-1a-M (#4556, ratified per #4556 comments 5293034619 + 5293478713): the
+    // pre-widening fold collapsed EVERY non-`w4` string to `legacy_untracked`,
+    // which would have turned a `w4_group` row into a legacy one on read (silent
+    // downgrade). Membership is now tested against the live domain; anything
+    // outside it still folds to `legacy_untracked`, so no novel value is admitted.
+    projectionOwner: isAttendanceProjectionOwnerV1(row.projection_owner)
+      ? row.projection_owner
+      : 'legacy_untracked',
     visibilityState: row.visibility_state === 'retired' ? 'retired' : 'active',
     timezone: typeof row.timezone === 'string' ? row.timezone : null,
   }
@@ -840,7 +852,12 @@ async function writeCompletedRow(
   // version is allocated so the two never collide on `(record, version)`.
   let supersedesCalculationId: string | null = null
   let baselineCalculationId: string | null = null
-  if (parent.projectionOwner === 'w4' && parent.currentCalculationId !== null) {
+  // W7-1a-M: the first arm selects on pointer ownership, so `w4_group` supersedes
+  // its own current exactly as `w4` does instead of matching neither arm.
+  if (
+    isAttendanceProjectionOwnerWithCalculationPointerV1(parent.projectionOwner) &&
+    parent.currentCalculationId !== null
+  ) {
     supersedesCalculationId = parent.currentCalculationId
   } else if (parent.projectionOwner === 'legacy_untracked' && parent.visibilityState === 'active') {
     if (input.preimage.posture !== 'present' || input.preimage.projection === null) {
@@ -1137,7 +1154,7 @@ export async function writeAuthoritativeReversalV1(
   // Pointer (§7.5): present → restore the earlier calc/owner/visibility; absent → point at THIS
   // reversal row, set_retired. Optimistic on the exact reversed pointer.
   let pointerTarget: string | null
-  let owner: 'legacy_untracked' | 'w4'
+  let owner: AttendanceProjectionOwnerV1
   let visibilityState: 'active' | 'retired'
   let visibilityReason: 'active' | 'review_placeholder' | 'import_rollback' | 'operator_retirement'
   let daily: AttendanceAuthoritativePreimageProjectionV1

--- a/packages/core-backend/src/attendance/w4c2-live-scheduled-boundary.ts
+++ b/packages/core-backend/src/attendance/w4c2-live-scheduled-boundary.ts
@@ -134,6 +134,10 @@ import {
   computeAttendanceSourceDefinitionFingerprintV1,
   computeAttendanceOuterComparableSourceDefinitionFingerprintV1,
 } from './w4c1-fingerprints'
+import {
+  isAttendanceProjectionOwnerV1,
+  type AttendanceProjectionOwnerV1,
+} from './w7-provenance-domain'
 import type {
   AttendanceAttributionSnapshotV1,
   ApprovedAttendanceFactV1,
@@ -620,7 +624,7 @@ interface ShadowTargetRow extends AttendanceW4ComparableDailyProjection {
    * shadow path passes this row to `computeAttendanceW4ShadowDiff` as `legacyProjection`, which
    * reads only the six named daily fields plus `workDate` — the extra members are inert there.
    */
-  projectionOwner: 'legacy_untracked' | 'w4'
+  projectionOwner: AttendanceProjectionOwnerV1
   currentCalculationId: string | null
   visibilityState: 'active' | 'retired'
   visibilityReason: string
@@ -683,7 +687,13 @@ async function lockShadowParentRecord(
     workMinutes: row.workMinutes === null ? null : Number(row.workMinutes),
     lateMinutes: row.lateMinutes === null ? null : Number(row.lateMinutes),
     earlyLeaveMinutes: row.earlyLeaveMinutes === null ? null : Number(row.earlyLeaveMinutes),
-    projectionOwner: row.projectionOwner === 'w4' ? 'w4' : 'legacy_untracked',
+    // W7-1a-M (#4556, ratified per #4556 comments 5293034619 + 5293478713): same
+    // silent-downgrade fold as the authoritative core's locked read — membership
+    // now decides, so `w4_group` survives the read; unknown values still fold to
+    // `legacy_untracked`.
+    projectionOwner: isAttendanceProjectionOwnerV1(row.projectionOwner)
+      ? row.projectionOwner
+      : 'legacy_untracked',
     currentCalculationId:
       typeof row.currentCalculationId === 'string' ? row.currentCalculationId : null,
     visibilityState: row.visibilityState === 'retired' ? 'retired' : 'active',

--- a/packages/core-backend/src/attendance/w4c3a-canonical-import-kernel.ts
+++ b/packages/core-backend/src/attendance/w4c3a-canonical-import-kernel.ts
@@ -15,6 +15,10 @@ import {
 } from './w4c0-fingerprints'
 import { computeAttendanceSourceDefinitionFingerprintV1 } from './w4c1-fingerprints'
 import {
+  isAttendanceProjectionOwnerV1,
+  isAttendanceProjectionOwnerWithCalculationPointerV1,
+} from './w7-provenance-domain'
+import {
   verifyAttendanceImportAttributionSnapshotV1,
   verifyAttendanceImportPolicySourceFingerprintV1,
   type AttendanceImportPolicySourceProjectionV1,
@@ -364,10 +368,14 @@ function frozenPresentPreimage(row: QueryRow): Record<string, unknown> {
   const projectionOwner = String(row.projection_owner)
   const currentCalculationId =
     row.current_calculation_id === null ? null : String(row.current_calculation_id)
+  // W7-1a-M (#4556, ratified per #4556 comments 5293034619 + 5293478713): membership
+  // plus the pointer-coupling pair, widened together. `w4_group` inherits `w4`'s
+  // non-NULL calculation-pointer requirement.
   if (
-    (projectionOwner !== 'legacy_untracked' && projectionOwner !== 'w4') ||
+    !isAttendanceProjectionOwnerV1(projectionOwner) ||
     (projectionOwner === 'legacy_untracked' && currentCalculationId !== null) ||
-    (projectionOwner === 'w4' && currentCalculationId === null)
+    (isAttendanceProjectionOwnerWithCalculationPointerV1(projectionOwner) &&
+      currentCalculationId === null)
   ) {
     throw new Error('W4C3A_IMPORT_PREIMAGE_INVALID')
   }

--- a/packages/core-backend/src/attendance/w4c3a-import-rollback-boundary.ts
+++ b/packages/core-backend/src/attendance/w4c3a-import-rollback-boundary.ts
@@ -18,6 +18,10 @@ import {
 } from './w4c0-identity'
 import { AttendanceW4OperationError } from './w4c0-operation-contract'
 import { canonicalAttendanceJsonV1 } from './w4c0-fingerprints'
+// W7-1a-M (#4556, ratified per #4556 comments 5293034619 + 5293478713): the
+// closure precondition asks "does any pointer-owning row still reference this
+// batch"; spelled as `= 'w4'` it would have missed a `w4_group` row.
+import { ATTENDANCE_PROJECTION_OWNERS_WITH_CALCULATION_POINTER_SQL_LIST_V1 } from './w7-provenance-domain'
 import { runAttendanceResultOperationTransactionV1 } from './w4c0-operation-registry'
 import {
   AttendanceLegacyPlanEnqueueError,
@@ -659,7 +663,7 @@ async function legacyDeleteEligible(
        AND NOT EXISTS (
          SELECT 1 FROM attendance_records
           WHERE org_id = $1 AND source_batch_id = $2::uuid
-            AND (current_calculation_id IS NOT NULL OR projection_owner = 'w4')
+            AND (current_calculation_id IS NOT NULL OR projection_owner IN (${ATTENDANCE_PROJECTION_OWNERS_WITH_CALCULATION_POINTER_SQL_LIST_V1}))
        )
        AND NOT EXISTS (
          SELECT 1 FROM attendance_import_rollback_closures

--- a/packages/core-backend/src/attendance/w4c3a-import-rollback.ts
+++ b/packages/core-backend/src/attendance/w4c3a-import-rollback.ts
@@ -18,6 +18,11 @@ import {
 } from './w4c0-authorization'
 import { runAttendanceResultOperationTransactionV1 } from './w4c0-operation-registry'
 import { deriveAttendanceLegacyPlanReservationIdentitiesV1 } from './w4c3a-legacy-plan-processor'
+import {
+  isAttendanceProjectionOwnerV1,
+  isAttendanceProjectionOwnerWithCalculationPointerV1,
+  type AttendanceProjectionOwnerV1,
+} from './w7-provenance-domain'
 
 export const ATTENDANCE_IMPORT_ROLLBACK_ERROR_CODES_V1 = Object.freeze([
   'IMPORT_ROLLBACK_COMMAND_INVALID',
@@ -368,7 +373,7 @@ export type AttendanceImportRollbackProjectionV1 = Readonly<{
 
 export type AttendanceImportRollbackPresentPreimageFingerprintInputV1 = Readonly<{
   projection: AttendanceImportRollbackProjectionV1
-  projectionOwner: 'legacy_untracked' | 'w4'
+  projectionOwner: AttendanceProjectionOwnerV1
   currentCalculationId: string | null
   visibilityState: 'active' | 'retired'
   visibilityReason: 'active' | 'review_placeholder' | 'import_rollback' | 'operator_retirement'
@@ -376,7 +381,7 @@ export type AttendanceImportRollbackPresentPreimageFingerprintInputV1 = Readonly
 
 export type FrozenAttendanceImportRollbackPreimageV1 = Readonly<{
   posture: 'absent' | 'present'
-  projectionOwner?: 'legacy_untracked' | 'w4'
+  projectionOwner?: AttendanceProjectionOwnerV1
   currentCalculationId?: string | null
   visibilityState?: 'active' | 'retired'
   visibilityReason?: 'active' | 'review_placeholder' | 'import_rollback' | 'operator_retirement'
@@ -434,11 +439,15 @@ export function parseAttendanceImportRollbackPresentPreimageFingerprintInputV1(
     'lateMinutes',
     'earlyLeaveMinutes',
   ])
+  // W7-1a-M (#4556, ratified per #4556 comments 5293034619 + 5293478713): the
+  // membership test and the pointer-coupling disjunction are widened together —
+  // widening only the first would admit `w4_group` and then reject it here.
+  // `w4_group` takes `w4`'s non-NULL-pointer arm (semantic ruling).
   if (
-    (row.projectionOwner !== 'legacy_untracked' && row.projectionOwner !== 'w4') ||
+    !isAttendanceProjectionOwnerV1(row.projectionOwner) ||
     !(
       (row.projectionOwner === 'legacy_untracked' && row.currentCalculationId === null) ||
-      (row.projectionOwner === 'w4' &&
+      (isAttendanceProjectionOwnerWithCalculationPointerV1(row.projectionOwner) &&
         typeof row.currentCalculationId === 'string' &&
         UUID.test(row.currentCalculationId))
     ) ||
@@ -464,8 +473,12 @@ export function parseAttendanceImportRollbackPresentPreimageFingerprintInputV1(
       earlyLeaveMinutes: nonNegativeInteger(projection.earlyLeaveMinutes),
     }),
     projectionOwner: row.projectionOwner,
-    currentCalculationId:
-      row.projectionOwner === 'w4' ? uuid(row.currentCalculationId) : null,
+    // W7-1a-M: pointer-bearing owners keep their pointer. Left as `=== 'w4'` this
+    // would silently NULL a `w4_group` pointer — the exact silent-downgrade shape
+    // the ratification names.
+    currentCalculationId: isAttendanceProjectionOwnerWithCalculationPointerV1(row.projectionOwner)
+      ? uuid(row.currentCalculationId)
+      : null,
     visibilityState: row.visibilityState,
     visibilityReason: row.visibilityReason,
   }) as AttendanceImportRollbackPresentPreimageFingerprintInputV1
@@ -512,10 +525,12 @@ export function parseAttendanceImportRollbackPreimageV1(
     rootKeys.length !== expectedRootKeys.length ||
     rootKeys.some((key, index) => key !== expectedRootKeys[index]) ||
     row.posture !== 'present' ||
-    (row.projectionOwner !== 'legacy_untracked' && row.projectionOwner !== 'w4') ||
+    // W7-1a-M: second, independent copy of the same exhaustive gate — widened in
+    // lockstep with the first (membership + pointer-coupling disjunction).
+    !isAttendanceProjectionOwnerV1(row.projectionOwner) ||
     !(
       (row.projectionOwner === 'legacy_untracked' && row.currentCalculationId === null) ||
-      (row.projectionOwner === 'w4' &&
+      (isAttendanceProjectionOwnerWithCalculationPointerV1(row.projectionOwner) &&
         typeof row.currentCalculationId === 'string' &&
         UUID.test(row.currentCalculationId))
     ) ||
@@ -1191,7 +1206,9 @@ async function executeRollback(
     if (
       !record ||
       !calculation ||
-      record.projection_owner !== 'w4' ||
+      // W7-1a-M: pointer-owning parents are rollback-eligible; `w4_group` inherits
+      // `w4`'s arm rather than silently failing SUPERSEDED.
+      !isAttendanceProjectionOwnerWithCalculationPointerV1(record.projection_owner) ||
       record.current_calculation_id !== calculation.id ||
       calculation.source_batch_id !== command.sourceBatchId ||
       !['legacy_import', 'integration_sync'].includes(calculation.entrypoint)

--- a/packages/core-backend/src/attendance/w7-provenance-domain.ts
+++ b/packages/core-backend/src/attendance/w7-provenance-domain.ts
@@ -1,0 +1,120 @@
+/**
+ * W7-1a-M (#4556) — the LIVE provenance value domains, widened.
+ *
+ * Ratified per #4556 comments 5293034619 + 5293478713 (执行序: `1a-M = 惰性
+ * schema 扩宽切片`). W7-0 (`w7-read-side-provenance-amendment.ts`) RECORDED the
+ * two new spellings without touching any live domain; this module is where
+ * those recorded spellings enter the live closed sets, so that every exhaustive
+ * consumer has a single symbol to widen against instead of ten inlined literal
+ * pairs.
+ *
+ * Spelling provenance: the two new values are IMPORTED from the W7-0 record
+ * rather than re-typed here, so the recorded value and the live value can never
+ * drift apart.
+ *
+ * INERT: nothing in this slice EMITS `w4_group`. The domains ACCEPT it; the
+ * producer seam is W7-1b. Every pre-existing value keeps its pre-existing
+ * meaning, and no pre-existing input changes its outcome at any widened point.
+ *
+ * Semantic ruling (5293034619 §执行序): `w4_group` INHERITS `w4`'s non-NULL
+ * calculation-pointer semantics. `legacy_untracked` remains the ONLY member
+ * with a NULL calculation pointer — which is why the DB's coupled pointer
+ * invariant `chk_ar_owner_pointer_pair`
+ * (`(projection_owner = 'legacy_untracked') = (current_calculation_id IS NULL)`)
+ * is CORRECT AS WRITTEN for the widened domain and is deliberately NOT edited
+ * by this slice: it keeps forcing a non-NULL pointer for `w4_group` exactly as
+ * it does for `w4`.
+ */
+import {
+  ATTENDANCE_W7_PROJECTION_OWNER_GROUP_VALUE_V1,
+  ATTENDANCE_W7_TRACE_SOURCE_KIND_GROUP_VALUE_V1,
+} from './w7-read-side-provenance-amendment'
+
+// ---------------------------------------------------------------------------
+// Family 1: `projectionOwner` / `attendance_records.projection_owner`.
+// ---------------------------------------------------------------------------
+
+/**
+ * The widened closed set. Order is the DB CHECK's order (legacy first, then the
+ * pointer-owning members) so the generated `IN (...)` list and this array stay
+ * comparable by eye.
+ */
+export const ATTENDANCE_PROJECTION_OWNERS_V1 = [
+  'legacy_untracked',
+  'w4',
+  ATTENDANCE_W7_PROJECTION_OWNER_GROUP_VALUE_V1,
+] as const
+
+export type AttendanceProjectionOwnerV1 = (typeof ATTENDANCE_PROJECTION_OWNERS_V1)[number]
+
+/**
+ * The members that own a calculation pointer, i.e. the members for which
+ * `current_calculation_id` is NON-NULL. This is the single symbol every
+ * `=== 'w4'`-shaped branch widens to; inlining the pair at each call site is
+ * what the completeness test exists to prevent.
+ */
+export const ATTENDANCE_PROJECTION_OWNERS_WITH_CALCULATION_POINTER_V1 = [
+  'w4',
+  ATTENDANCE_W7_PROJECTION_OWNER_GROUP_VALUE_V1,
+] as const
+
+export type AttendanceProjectionOwnerWithCalculationPointerV1 =
+  (typeof ATTENDANCE_PROJECTION_OWNERS_WITH_CALCULATION_POINTER_V1)[number]
+
+/** The sole NULL-calculation-pointer member (semantic ruling, see file header). */
+export const ATTENDANCE_PROJECTION_OWNER_WITHOUT_CALCULATION_POINTER_V1 = 'legacy_untracked' as const
+
+/**
+ * `'a', 'b'` — a ready-to-interpolate SQL literal list. Every member is a
+ * compile-time constant from the array above (never user input), so this is a
+ * single-source spelling aid, not a query builder.
+ */
+export const ATTENDANCE_PROJECTION_OWNERS_SQL_LIST_V1 = ATTENDANCE_PROJECTION_OWNERS_V1.map(
+  (owner) => `'${owner}'`,
+).join(', ')
+
+/** Same, for the pointer-owning members only. */
+export const ATTENDANCE_PROJECTION_OWNERS_WITH_CALCULATION_POINTER_SQL_LIST_V1 =
+  ATTENDANCE_PROJECTION_OWNERS_WITH_CALCULATION_POINTER_V1.map((owner) => `'${owner}'`).join(', ')
+
+export function isAttendanceProjectionOwnerV1(value: unknown): value is AttendanceProjectionOwnerV1 {
+  return (ATTENDANCE_PROJECTION_OWNERS_V1 as readonly unknown[]).includes(value)
+}
+
+/**
+ * `true` for exactly the members that carry a non-NULL calculation pointer.
+ * Deliberately NOT `!== 'legacy_untracked'`: an unknown/novel value must answer
+ * `false` here, so the widening does not open the domain generally.
+ */
+export function isAttendanceProjectionOwnerWithCalculationPointerV1(
+  value: unknown,
+): value is AttendanceProjectionOwnerWithCalculationPointerV1 {
+  return (ATTENDANCE_PROJECTION_OWNERS_WITH_CALCULATION_POINTER_V1 as readonly unknown[]).includes(value)
+}
+
+// ---------------------------------------------------------------------------
+// Family 2: trace `source.kind`.
+// ---------------------------------------------------------------------------
+
+/**
+ * The widened trace source-kind closed set. The live union in
+ * `../services/AttendanceDecisionTrace.ts` is expressed against this array, and
+ * `apps/web`'s independent copy (`ATTENDANCE_TRACE_SOURCE_KINDS`) is held to the
+ * same membership by the W7-1a-M completeness test — the web bundle cannot
+ * import backend source, so the two lists are kept equal by test, not by build.
+ */
+export const ATTENDANCE_TRACE_SOURCE_KINDS_V1 = [
+  'record',
+  'snapshot',
+  'rule_live',
+  'ledger',
+  'audit',
+  'policy_gate',
+  ATTENDANCE_W7_TRACE_SOURCE_KIND_GROUP_VALUE_V1,
+] as const
+
+export type AttendanceTraceSourceKindV1 = (typeof ATTENDANCE_TRACE_SOURCE_KINDS_V1)[number]
+
+export function isAttendanceTraceSourceKindV1(value: unknown): value is AttendanceTraceSourceKindV1 {
+  return (ATTENDANCE_TRACE_SOURCE_KINDS_V1 as readonly unknown[]).includes(value)
+}

--- a/packages/core-backend/src/attendance/w7-provenance-domain.ts
+++ b/packages/core-backend/src/attendance/w7-provenance-domain.ts
@@ -61,9 +61,6 @@ export const ATTENDANCE_PROJECTION_OWNERS_WITH_CALCULATION_POINTER_V1 = [
 export type AttendanceProjectionOwnerWithCalculationPointerV1 =
   (typeof ATTENDANCE_PROJECTION_OWNERS_WITH_CALCULATION_POINTER_V1)[number]
 
-/** The sole NULL-calculation-pointer member (semantic ruling, see file header). */
-export const ATTENDANCE_PROJECTION_OWNER_WITHOUT_CALCULATION_POINTER_V1 = 'legacy_untracked' as const
-
 /**
  * `'a', 'b'` — a ready-to-interpolate SQL literal list. Every member is a
  * compile-time constant from the array above (never user input), so this is a

--- a/packages/core-backend/src/attendance/w7-read-side-provenance-amendment.ts
+++ b/packages/core-backend/src/attendance/w7-read-side-provenance-amendment.ts
@@ -3,15 +3,25 @@
  * string values for the W7-owned provenance family on the existing W4
  * detail/trace enums (design-lock §4.4, §7 OD-W7-5).
  *
- * Status: PROPOSED / runtime HOLD. `OD-W7-0..10` are OPEN owner decisions —
- * see
- * `docs/development/attendance-issue-4556-w7-group-policy-cutover-design-lock-20260807.md`
- * §9. These strings are RECORDED here only; neither live enum named below is
- * edited by this file. Widening either live closed set now would force
- * every exhaustive consumer listed under it to handle the new value — that
- * is exactly the "modifying a live enum consumed by an exhaustive check"
- * case W7-R9 rules out of W7-0. Wiring these values into the live closed
- * arrays/unions (and into every listed consumer) is W7-1's job.
+ * Status: RATIFIED and WIRED. `OD-W7-0..10` were ratified per #4556 comments
+ * 5293034619 + 5293478713, and W7-1a-M wired both recorded values into the live
+ * domains — see `./w7-provenance-domain.ts`, which imports the two constants
+ * below so the recorded spelling and the live spelling cannot drift.
+ *
+ * Historical note (the state this file was written in): these strings were
+ * RECORDED here only, and neither live enum named below was edited by this file,
+ * because widening a live closed set forces every exhaustive consumer to handle
+ * the new value — the "modifying a live enum consumed by an exhaustive check"
+ * case W7-R9 ruled out of W7-0. That wiring is W7-1a-M's job and is now done.
+ *
+ * CAUTION for readers: the per-target consumer inventories in the two section
+ * comments below are the W7-0 point-in-time lists. They are NOT the widening
+ * surface and were never complete — the ratification refused to enumerate the
+ * surface for exactly this reason, and the W7-1a-M derivation found live
+ * consumers absent from them (notably `apps/web`'s independent trace
+ * source-kind array + exhaustive switch, which target 2's note below asserts
+ * does not exist). The authoritative, mechanically derived surface is the
+ * ledger in `packages/core-backend/tests/utils/w7-provenance-widening-scan.ts`.
  *
  * Basis: built on the design-lock's recommended OD-W7-5 option (a) shape.
  * OD-W7-5 is OPEN — ratification pending, not assumed by this file.
@@ -89,13 +99,25 @@ export const ATTENDANCE_W7_READ_SIDE_PROVENANCE_AMENDMENT_V1 = Object.freeze({
   projectionOwner: Object.freeze({
     targetFile: 'packages/core-backend/src/services/AttendanceW4CalculationDetail.ts',
     targetConst: 'PROJECTION_OWNERS',
-    currentMembers: Object.freeze(['legacy_untracked', 'w4'] as const),
+    // W7-1a-M landed the widening; this snapshot tracks the LIVE set, so it now
+    // includes the new member. The mutual-extends guards below stay meaningful:
+    // this list is written independently of `w7-provenance-domain.ts`'s array.
+    currentMembers: Object.freeze(['legacy_untracked', 'w4', 'w4_group'] as const),
     newValue: ATTENDANCE_W7_PROJECTION_OWNER_GROUP_VALUE_V1,
   }),
   traceSourceKind: Object.freeze({
     targetFile: 'packages/core-backend/src/services/AttendanceDecisionTrace.ts',
     targetType: 'AttendanceDecisionTraceSourceKind',
-    currentMembers: Object.freeze(['record', 'snapshot', 'rule_live', 'ledger', 'audit', 'policy_gate'] as const),
+    // W7-1a-M widened the live union; snapshot follows (see the note above).
+    currentMembers: Object.freeze([
+      'record',
+      'snapshot',
+      'rule_live',
+      'ledger',
+      'audit',
+      'policy_gate',
+      'group_policy_snapshot',
+    ] as const),
     newValue: ATTENDANCE_W7_TRACE_SOURCE_KIND_GROUP_VALUE_V1,
   }),
 } as const)

--- a/packages/core-backend/src/db/migrations/zzzz20260815120000_w7_1am_provenance_domain_widening.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260815120000_w7_1am_provenance_domain_widening.ts
@@ -7,8 +7,9 @@
  * was accepted before is still accepted with unchanged meaning.
  *
  * The widening surface was DERIVED, not enumerated: the DB half is derived from
- * the live catalogue (`pg_constraint` / `pg_proc`) on a migrated database, and
- * asserted point-by-point by
+ * the live catalogue on a migrated database — `pg_constraint`, `pg_proc`,
+ * `pg_trigger`, `pg_attrdef`, `pg_views`, `pg_indexes` and `pg_policies`, in both
+ * the snake_case and camelCase spellings — and asserted point-by-point by
  * `tests/integration/attendance-w7-1am-provenance-widening.db.test.ts`.
  * Deriving from migration TEXT would be wrong here — `attendance_w4_records_pointer_guard`
  * is defined twice in the tree (zzzz20260725120000 then REPLACED by

--- a/packages/core-backend/src/db/migrations/zzzz20260815120000_w7_1am_provenance_domain_widening.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260815120000_w7_1am_provenance_domain_widening.ts
@@ -1,0 +1,608 @@
+/**
+ * W7-1a-M (#4556) — provenance value-domain widening, DB half.
+ *
+ * Ratified per #4556 comments 5293034619 + 5293478713. INERT: this migration
+ * only makes the live domains ACCEPT `w4_group`; nothing in this slice emits it
+ * (the producer seam is W7-1b). No existing row changes, and every value that
+ * was accepted before is still accepted with unchanged meaning.
+ *
+ * The widening surface was DERIVED, not enumerated: the DB half is derived from
+ * the live catalogue (`pg_constraint` / `pg_proc`) on a migrated database, and
+ * asserted point-by-point by
+ * `tests/integration/attendance-w7-1am-provenance-widening.db.test.ts`.
+ * Deriving from migration TEXT would be wrong here — `attendance_w4_records_pointer_guard`
+ * is defined twice in the tree (zzzz20260725120000 then REPLACED by
+ * zzzz20260731120000), so only the catalogue says what is actually live.
+ *
+ * Three live objects carry the two-value domain and are superseded here:
+ *   1. `chk_ar_projection_owner` — CHECK (projection_owner IN (...)).
+ *   2. `attendance_w4_records_pointer_guard()` — the narrow import-rollback
+ *      restore exception gates on `OLD.projection_owner = 'w4'`.
+ *   3. `attendance_w4c3a_restore_witness_command_guard()` — the W4C3A_WITNESS
+ *      frozen-preimage check: a `NOT IN` membership test AND a coupled
+ *      pointer-null disjunction. Both are widened together; widening only the
+ *      membership test would admit `w4_group` and then reject it one line later.
+ *
+ * DELIBERATELY UNCHANGED — `chk_ar_owner_pointer_pair`
+ * (`(projection_owner = 'legacy_untracked') = (current_calculation_id IS NULL)`).
+ * The semantic ruling gives `w4_group` `w4`'s NON-NULL pointer semantics and
+ * leaves `legacy_untracked` as the only NULL-pointer member, so this invariant
+ * is already correct for the widened domain: it keeps REFUSING a `w4_group` row
+ * with a NULL pointer. The .db test proves that refusal rather than trusting it.
+ *
+ * The two function bodies below are the historical bodies with ONLY the
+ * substitutions named above applied; they were extracted mechanically from
+ * zzzz20260731120000 rather than retyped, and the .db test diffs the resulting
+ * `prosrc` against the pre-migration `prosrc` to prove nothing else moved.
+ *
+ * Historical migrations are NEVER edited: this file supersedes them, and the new
+ * value enters via a zzzz migration as required.
+ */
+import { Kysely, sql } from 'kysely'
+import { ATTENDANCE_PROJECTION_OWNERS_SQL_LIST_V1 } from '../../attendance/w7-provenance-domain'
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  // 1. Widen the closed-set CHECK. Drop/re-add is the only way to change a CHECK;
+  //    the column keeps NOT NULL and its default throughout.
+  await sql`ALTER TABLE attendance_records DROP CONSTRAINT IF EXISTS chk_ar_projection_owner`.execute(db)
+  await sql`
+    ALTER TABLE attendance_records ADD CONSTRAINT chk_ar_projection_owner
+      CHECK (projection_owner IN (${sql.raw(ATTENDANCE_PROJECTION_OWNERS_SQL_LIST_V1)}))
+  `.execute(db)
+
+  // 2. Pointer guard — body unchanged except the restore-eligibility owner test.
+  await sql`
+    CREATE OR REPLACE FUNCTION attendance_w4_records_pointer_guard()
+    RETURNS trigger
+    LANGUAGE plpgsql
+    AS $fn$
+    DECLARE
+      calc RECORD;
+      witness_ok boolean;
+    BEGIN
+      IF NEW.projection_owner = 'legacy_untracked' THEN
+        IF EXISTS (
+          SELECT 1 FROM attendance_record_calculations c
+          WHERE c.attendance_record_id = NEW.id AND c.org_id = NEW.org_id
+            AND (
+              c.calculation_kind = 'legacy_baseline' OR
+              (c.mode = 'authoritative' AND c.outcome IN ('completed', 'reversed') AND c.projection_effect <> 'none')
+            )
+        ) THEN
+          -- Narrow exception: same-transaction import-rollback restore witness only.
+          IF TG_OP = 'UPDATE'
+             AND OLD.projection_owner IN ('w4', 'w4_group')
+             AND OLD.current_calculation_id IS NOT NULL THEN
+            SELECT EXISTS (
+              SELECT 1
+              FROM attendance_import_rollback_restore_witnesses w
+              JOIN attendance_import_rollback_commands cmd
+                ON cmd.org_id = w.org_id
+               AND cmd.rollback_operation_id = w.rollback_operation_id
+              JOIN attendance_record_calculations rev
+                ON rev.id = w.reversal_calculation_id
+               AND rev.attendance_record_id = w.attendance_record_id
+               AND rev.org_id = w.org_id
+              JOIN attendance_record_calculations reversed
+                ON reversed.id = w.reversed_calculation_id
+               AND reversed.attendance_record_id = w.attendance_record_id
+               AND reversed.org_id = w.org_id
+              WHERE w.org_id = NEW.org_id
+                AND w.attendance_record_id = NEW.id
+                AND w.reversed_calculation_id = OLD.current_calculation_id
+                AND w.writer_xid = pg_current_xact_id()
+                AND cmd.writer_xid = pg_current_xact_id()
+                AND NEW.current_calculation_id IS NULL
+                AND NEW.projection_owner = 'legacy_untracked'
+                AND reversed.parent_preimage_snapshot ->> 'posture' = 'present'
+                AND reversed.parent_preimage_snapshot ->> 'projectionOwner' = 'legacy_untracked'
+                AND reversed.parent_preimage_snapshot ->> 'currentCalculationId' IS NULL
+                AND NEW.visibility_state IS NOT DISTINCT FROM
+                      (reversed.parent_preimage_snapshot ->> 'visibilityState')
+                AND NEW.visibility_reason IS NOT DISTINCT FROM
+                      (reversed.parent_preimage_snapshot ->> 'visibilityReason')
+                AND NEW.status IS NOT DISTINCT FROM
+                      (reversed.parent_preimage_snapshot #>> '{projection,status}')
+                AND NEW.first_in_at IS NOT DISTINCT FROM
+                      NULLIF(reversed.parent_preimage_snapshot #>> '{projection,firstInAt}', '')::timestamptz
+                AND NEW.last_out_at IS NOT DISTINCT FROM
+                      NULLIF(reversed.parent_preimage_snapshot #>> '{projection,lastOutAt}', '')::timestamptz
+                AND NEW.work_minutes IS NOT DISTINCT FROM
+                      (reversed.parent_preimage_snapshot #>> '{projection,workMinutes}')::integer
+                AND NEW.late_minutes IS NOT DISTINCT FROM
+                      (reversed.parent_preimage_snapshot #>> '{projection,lateMinutes}')::integer
+                AND NEW.early_leave_minutes IS NOT DISTINCT FROM
+                      (reversed.parent_preimage_snapshot #>> '{projection,earlyLeaveMinutes}')::integer
+                AND w.frozen_preimage_fingerprint IS NOT DISTINCT FROM
+                      (reversed.parent_preimage_snapshot ->> 'compatibilityFingerprint')
+                AND rev.entrypoint = 'import_rollback'
+                AND rev.outcome = 'reversed'
+                AND rev.outcome_reason_code = 'import_rollback_reversal'
+                AND rev.supersedes_calculation_id = OLD.current_calculation_id
+            ) INTO witness_ok;
+            IF witness_ok THEN
+              IF NEW.visibility_state = 'retired' AND NEW.visibility_reason = 'operator_retirement' THEN
+                RAISE EXCEPTION 'W4C0_POINTER: operator retirement requires a W4 pointer on %', TG_TABLE_NAME;
+              END IF;
+              RETURN NULL;
+            END IF;
+          END IF;
+          RAISE EXCEPTION 'W4C0_POINTER: parent cannot return to legacy_untracked on %', TG_TABLE_NAME;
+        END IF;
+        IF NEW.visibility_state = 'retired' AND NEW.visibility_reason = 'operator_retirement' THEN
+          RAISE EXCEPTION 'W4C0_POINTER: operator retirement requires a W4 pointer on %', TG_TABLE_NAME;
+        END IF;
+        RETURN NULL;
+      END IF;
+
+      SELECT mode, outcome, outcome_reason_code, projection_effect, calculation_kind,
+             projected_status, projected_first_in_at, projected_last_out_at,
+             projected_work_minutes, projected_late_minutes, projected_early_leave_minutes
+        INTO calc
+      FROM attendance_record_calculations
+      WHERE id = NEW.current_calculation_id
+        AND attendance_record_id = NEW.id
+        AND org_id = NEW.org_id;
+      IF NOT FOUND THEN
+        RAISE EXCEPTION 'W4C0_POINTER: current calculation not found for parent on %', TG_TABLE_NAME;
+      END IF;
+      IF calc.mode <> 'authoritative' OR calc.outcome NOT IN ('completed', 'reversed') THEN
+        RAISE EXCEPTION 'W4C0_POINTER: pointer target must be authoritative completed/reversed on %', TG_TABLE_NAME;
+      END IF;
+      IF calc.projection_effect = 'set_active' THEN
+        IF NEW.visibility_state <> 'active' OR NEW.visibility_reason <> 'active' THEN
+          RAISE EXCEPTION 'W4C0_POINTER: visibility does not match set_active on %', TG_TABLE_NAME;
+        END IF;
+      ELSIF calc.projection_effect = 'set_retired' THEN
+        IF NEW.visibility_state <> 'retired' THEN
+          RAISE EXCEPTION 'W4C0_POINTER: visibility does not match set_retired on %', TG_TABLE_NAME;
+        END IF;
+        IF NOT (
+          (calc.outcome_reason_code = 'import_rollback_reversal' AND NEW.visibility_reason = 'import_rollback') OR
+          (calc.outcome_reason_code = 'operator_retirement' AND NEW.visibility_reason = 'operator_retirement')
+        ) THEN
+          RAISE EXCEPTION 'W4C0_POINTER: retired visibility reason does not match selected row on %', TG_TABLE_NAME;
+        END IF;
+      ELSE
+        RAISE EXCEPTION 'W4C0_POINTER: pointer target projection effect cannot be none on %', TG_TABLE_NAME;
+      END IF;
+      IF NEW.status IS DISTINCT FROM calc.projected_status OR
+         NEW.first_in_at IS DISTINCT FROM calc.projected_first_in_at OR
+         NEW.last_out_at IS DISTINCT FROM calc.projected_last_out_at OR
+         NEW.work_minutes IS DISTINCT FROM calc.projected_work_minutes OR
+         NEW.late_minutes IS DISTINCT FROM calc.projected_late_minutes OR
+         NEW.early_leave_minutes IS DISTINCT FROM calc.projected_early_leave_minutes THEN
+        RAISE EXCEPTION 'W4C0_POINTER: W4-owned daily fields drifted from the selected snapshot on %', TG_TABLE_NAME;
+      END IF;
+      RETURN NULL;
+    END;
+    $fn$
+  `.execute(db)
+
+  // 3. W4C3A_WITNESS command guard — membership + coupled pointer disjunct.
+  await sql`
+    CREATE OR REPLACE FUNCTION attendance_w4c3a_restore_witness_command_guard()
+    RETURNS trigger
+    LANGUAGE plpgsql
+    AS $fn$
+    DECLARE
+      cmd RECORD;
+      rev RECORD;
+      reversed RECORD;
+    BEGIN
+      SELECT source_batch_entrypoint, source_batch_id, writer_xid, rollback_entrypoint
+        INTO cmd
+      FROM attendance_import_rollback_commands
+      WHERE org_id = NEW.org_id AND rollback_operation_id = NEW.rollback_operation_id;
+      IF NOT FOUND THEN
+        RAISE EXCEPTION 'W4C3A_WITNESS: rollback command missing on %', TG_TABLE_NAME;
+      END IF;
+      IF cmd.source_batch_entrypoint IS DISTINCT FROM NEW.source_batch_entrypoint
+         OR cmd.source_batch_id IS DISTINCT FROM NEW.source_batch_id THEN
+        RAISE EXCEPTION 'W4C3A_WITNESS: source batch mismatch on %', TG_TABLE_NAME;
+      END IF;
+      IF NEW.writer_xid IS DISTINCT FROM pg_current_xact_id()
+         OR cmd.writer_xid IS DISTINCT FROM pg_current_xact_id() THEN
+        RAISE EXCEPTION 'W4C3A_WITNESS: writer xid mismatch on %', TG_TABLE_NAME;
+      END IF;
+
+      SELECT entrypoint, operation_id, outcome, outcome_reason_code, supersedes_calculation_id,
+             restores_calculation_id, calculation_kind, mode, projection_effect,
+             projected_status, projected_first_in_at, projected_last_out_at,
+             projected_work_minutes, projected_late_minutes, projected_early_leave_minutes,
+             projected_daily_fingerprint, source_batch_id
+        INTO rev
+      FROM attendance_record_calculations
+      WHERE id = NEW.reversal_calculation_id
+        AND attendance_record_id = NEW.attendance_record_id
+        AND org_id = NEW.org_id;
+      IF NOT FOUND THEN
+        RAISE EXCEPTION 'W4C3A_WITNESS: reversal missing on %', TG_TABLE_NAME;
+      END IF;
+      IF rev.calculation_kind <> 'reversal'
+         OR rev.entrypoint <> 'import_rollback'
+         OR rev.outcome <> 'reversed'
+         OR rev.outcome_reason_code <> 'import_rollback_reversal'
+         OR rev.mode <> 'authoritative'
+         OR rev.supersedes_calculation_id IS DISTINCT FROM NEW.reversed_calculation_id THEN
+        RAISE EXCEPTION 'W4C3A_WITNESS: reversal shape invalid on %', TG_TABLE_NAME;
+      END IF;
+      IF NOT EXISTS (
+        SELECT 1 FROM attendance_result_operations op
+        WHERE op.org_id = NEW.org_id
+          AND op.entrypoint = 'import_rollback'
+          AND op.operation_id = rev.operation_id
+          AND op.identity_source_kind = 'direct_import_rollback'
+          AND op.actor_id = NEW.actor_id
+          AND op.actor_posture = NEW.actor_posture
+          AND op.state = 'claimed'
+      ) THEN
+        RAISE EXCEPTION 'W4C3A_WITNESS: reversal operation mismatch on %', TG_TABLE_NAME;
+      END IF;
+
+      SELECT entrypoint, source_batch_id, parent_preimage_snapshot, mode, outcome
+        INTO reversed
+      FROM attendance_record_calculations
+      WHERE id = NEW.reversed_calculation_id
+        AND attendance_record_id = NEW.attendance_record_id
+        AND org_id = NEW.org_id;
+      IF NOT FOUND THEN
+        RAISE EXCEPTION 'W4C3A_WITNESS: reversed calculation missing on %', TG_TABLE_NAME;
+      END IF;
+      IF reversed.source_batch_id IS NULL
+         OR reversed.source_batch_id IS DISTINCT FROM NEW.source_batch_id THEN
+        RAISE EXCEPTION 'W4C3A_WITNESS: reversed source batch invalid on %', TG_TABLE_NAME;
+      END IF;
+      IF NOT (
+        (reversed.entrypoint = 'legacy_import' AND NEW.source_batch_entrypoint = 'import_batch')
+        OR (reversed.entrypoint = 'integration_sync' AND NEW.source_batch_entrypoint = 'integration_batch')
+      ) THEN
+        RAISE EXCEPTION 'W4C3A_WITNESS: calculation/batch entrypoint map invalid on %', TG_TABLE_NAME;
+      END IF;
+      IF jsonb_typeof(reversed.parent_preimage_snapshot) IS DISTINCT FROM 'object'
+         OR (SELECT count(*) FROM jsonb_object_keys(reversed.parent_preimage_snapshot)) <> 7
+         OR reversed.parent_preimage_snapshot ->> 'posture' IS DISTINCT FROM 'present'
+         OR reversed.parent_preimage_snapshot ->> 'projectionOwner' NOT IN ('legacy_untracked', 'w4', 'w4_group')
+         OR reversed.parent_preimage_snapshot ? 'currentCalculationId' = false
+         OR NOT (
+              (reversed.parent_preimage_snapshot ->> 'projectionOwner' = 'legacy_untracked'
+                AND reversed.parent_preimage_snapshot ->> 'currentCalculationId' IS NULL)
+              OR
+              (reversed.parent_preimage_snapshot ->> 'projectionOwner' IN ('w4', 'w4_group')
+                AND reversed.parent_preimage_snapshot ->> 'currentCalculationId' IS NOT NULL
+                AND EXISTS (
+                  SELECT 1
+                  FROM attendance_record_calculations restored
+                  WHERE restored.id = (reversed.parent_preimage_snapshot ->> 'currentCalculationId')::uuid
+                    AND restored.attendance_record_id = NEW.attendance_record_id
+                    AND restored.org_id = NEW.org_id
+                ))
+            )
+         OR reversed.parent_preimage_snapshot ->> 'compatibilityFingerprint'
+              IS DISTINCT FROM NEW.frozen_preimage_fingerprint
+         OR jsonb_typeof(reversed.parent_preimage_snapshot -> 'projection') IS DISTINCT FROM 'object'
+         OR (SELECT count(*) FROM jsonb_object_keys(reversed.parent_preimage_snapshot -> 'projection')) <> 6
+         OR NOT ((reversed.parent_preimage_snapshot -> 'projection') ?& ARRAY[
+              'status', 'firstInAt', 'lastOutAt', 'workMinutes', 'lateMinutes',
+              'earlyLeaveMinutes'
+            ])
+         OR attendance_w4c3a_rollback_preimage_fingerprint(
+              reversed.parent_preimage_snapshot
+            ) IS DISTINCT FROM NEW.frozen_preimage_fingerprint THEN
+        RAISE EXCEPTION 'W4C3A_WITNESS: closed present preimage invalid on %', TG_TABLE_NAME;
+      END IF;
+      IF rev.restores_calculation_id IS DISTINCT FROM
+           NULLIF(reversed.parent_preimage_snapshot ->> 'currentCalculationId', '')::uuid THEN
+        RAISE EXCEPTION 'W4C3A_WITNESS: restore pointer drift on %', TG_TABLE_NAME;
+      END IF;
+      IF rev.projected_status IS DISTINCT FROM (reversed.parent_preimage_snapshot #>> '{projection,status}')
+         OR rev.projected_first_in_at IS DISTINCT FROM
+              NULLIF(reversed.parent_preimage_snapshot #>> '{projection,firstInAt}', '')::timestamptz
+         OR rev.projected_last_out_at IS DISTINCT FROM
+              NULLIF(reversed.parent_preimage_snapshot #>> '{projection,lastOutAt}', '')::timestamptz
+         OR rev.projected_work_minutes IS DISTINCT FROM
+              (reversed.parent_preimage_snapshot #>> '{projection,workMinutes}')::integer
+         OR rev.projected_late_minutes IS DISTINCT FROM
+              (reversed.parent_preimage_snapshot #>> '{projection,lateMinutes}')::integer
+         OR rev.projected_early_leave_minutes IS DISTINCT FROM
+              (reversed.parent_preimage_snapshot #>> '{projection,earlyLeaveMinutes}')::integer THEN
+        RAISE EXCEPTION 'W4C3A_WITNESS: reversal projection drift on %', TG_TABLE_NAME;
+      END IF;
+      IF (reversed.parent_preimage_snapshot ->> 'visibilityState') = 'active' THEN
+        IF rev.projection_effect <> 'set_active' THEN
+          RAISE EXCEPTION 'W4C3A_WITNESS: projection effect mismatch on %', TG_TABLE_NAME;
+        END IF;
+      ELSIF (reversed.parent_preimage_snapshot ->> 'visibilityState') = 'retired' THEN
+        IF rev.projection_effect <> 'set_retired' THEN
+          RAISE EXCEPTION 'W4C3A_WITNESS: projection effect mismatch on %', TG_TABLE_NAME;
+        END IF;
+      ELSE
+        RAISE EXCEPTION 'W4C3A_WITNESS: frozen visibility invalid on %', TG_TABLE_NAME;
+      END IF;
+      RETURN NEW;
+    END;
+    $fn$
+  `.execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  // Restore the pre-widening domain. Any `w4_group` row would block the CHECK
+  // re-add; that is intended — the down path must not silently rewrite data.
+  await sql`ALTER TABLE attendance_records DROP CONSTRAINT IF EXISTS chk_ar_projection_owner`.execute(db)
+  await sql`
+    ALTER TABLE attendance_records ADD CONSTRAINT chk_ar_projection_owner
+      CHECK (projection_owner IN ('legacy_untracked', 'w4'))
+  `.execute(db)
+
+  await sql`
+    CREATE OR REPLACE FUNCTION attendance_w4_records_pointer_guard()
+    RETURNS trigger
+    LANGUAGE plpgsql
+    AS $fn$
+    DECLARE
+      calc RECORD;
+      witness_ok boolean;
+    BEGIN
+      IF NEW.projection_owner = 'legacy_untracked' THEN
+        IF EXISTS (
+          SELECT 1 FROM attendance_record_calculations c
+          WHERE c.attendance_record_id = NEW.id AND c.org_id = NEW.org_id
+            AND (
+              c.calculation_kind = 'legacy_baseline' OR
+              (c.mode = 'authoritative' AND c.outcome IN ('completed', 'reversed') AND c.projection_effect <> 'none')
+            )
+        ) THEN
+          -- Narrow exception: same-transaction import-rollback restore witness only.
+          IF TG_OP = 'UPDATE'
+             AND OLD.projection_owner = 'w4'
+             AND OLD.current_calculation_id IS NOT NULL THEN
+            SELECT EXISTS (
+              SELECT 1
+              FROM attendance_import_rollback_restore_witnesses w
+              JOIN attendance_import_rollback_commands cmd
+                ON cmd.org_id = w.org_id
+               AND cmd.rollback_operation_id = w.rollback_operation_id
+              JOIN attendance_record_calculations rev
+                ON rev.id = w.reversal_calculation_id
+               AND rev.attendance_record_id = w.attendance_record_id
+               AND rev.org_id = w.org_id
+              JOIN attendance_record_calculations reversed
+                ON reversed.id = w.reversed_calculation_id
+               AND reversed.attendance_record_id = w.attendance_record_id
+               AND reversed.org_id = w.org_id
+              WHERE w.org_id = NEW.org_id
+                AND w.attendance_record_id = NEW.id
+                AND w.reversed_calculation_id = OLD.current_calculation_id
+                AND w.writer_xid = pg_current_xact_id()
+                AND cmd.writer_xid = pg_current_xact_id()
+                AND NEW.current_calculation_id IS NULL
+                AND NEW.projection_owner = 'legacy_untracked'
+                AND reversed.parent_preimage_snapshot ->> 'posture' = 'present'
+                AND reversed.parent_preimage_snapshot ->> 'projectionOwner' = 'legacy_untracked'
+                AND reversed.parent_preimage_snapshot ->> 'currentCalculationId' IS NULL
+                AND NEW.visibility_state IS NOT DISTINCT FROM
+                      (reversed.parent_preimage_snapshot ->> 'visibilityState')
+                AND NEW.visibility_reason IS NOT DISTINCT FROM
+                      (reversed.parent_preimage_snapshot ->> 'visibilityReason')
+                AND NEW.status IS NOT DISTINCT FROM
+                      (reversed.parent_preimage_snapshot #>> '{projection,status}')
+                AND NEW.first_in_at IS NOT DISTINCT FROM
+                      NULLIF(reversed.parent_preimage_snapshot #>> '{projection,firstInAt}', '')::timestamptz
+                AND NEW.last_out_at IS NOT DISTINCT FROM
+                      NULLIF(reversed.parent_preimage_snapshot #>> '{projection,lastOutAt}', '')::timestamptz
+                AND NEW.work_minutes IS NOT DISTINCT FROM
+                      (reversed.parent_preimage_snapshot #>> '{projection,workMinutes}')::integer
+                AND NEW.late_minutes IS NOT DISTINCT FROM
+                      (reversed.parent_preimage_snapshot #>> '{projection,lateMinutes}')::integer
+                AND NEW.early_leave_minutes IS NOT DISTINCT FROM
+                      (reversed.parent_preimage_snapshot #>> '{projection,earlyLeaveMinutes}')::integer
+                AND w.frozen_preimage_fingerprint IS NOT DISTINCT FROM
+                      (reversed.parent_preimage_snapshot ->> 'compatibilityFingerprint')
+                AND rev.entrypoint = 'import_rollback'
+                AND rev.outcome = 'reversed'
+                AND rev.outcome_reason_code = 'import_rollback_reversal'
+                AND rev.supersedes_calculation_id = OLD.current_calculation_id
+            ) INTO witness_ok;
+            IF witness_ok THEN
+              IF NEW.visibility_state = 'retired' AND NEW.visibility_reason = 'operator_retirement' THEN
+                RAISE EXCEPTION 'W4C0_POINTER: operator retirement requires a W4 pointer on %', TG_TABLE_NAME;
+              END IF;
+              RETURN NULL;
+            END IF;
+          END IF;
+          RAISE EXCEPTION 'W4C0_POINTER: parent cannot return to legacy_untracked on %', TG_TABLE_NAME;
+        END IF;
+        IF NEW.visibility_state = 'retired' AND NEW.visibility_reason = 'operator_retirement' THEN
+          RAISE EXCEPTION 'W4C0_POINTER: operator retirement requires a W4 pointer on %', TG_TABLE_NAME;
+        END IF;
+        RETURN NULL;
+      END IF;
+
+      SELECT mode, outcome, outcome_reason_code, projection_effect, calculation_kind,
+             projected_status, projected_first_in_at, projected_last_out_at,
+             projected_work_minutes, projected_late_minutes, projected_early_leave_minutes
+        INTO calc
+      FROM attendance_record_calculations
+      WHERE id = NEW.current_calculation_id
+        AND attendance_record_id = NEW.id
+        AND org_id = NEW.org_id;
+      IF NOT FOUND THEN
+        RAISE EXCEPTION 'W4C0_POINTER: current calculation not found for parent on %', TG_TABLE_NAME;
+      END IF;
+      IF calc.mode <> 'authoritative' OR calc.outcome NOT IN ('completed', 'reversed') THEN
+        RAISE EXCEPTION 'W4C0_POINTER: pointer target must be authoritative completed/reversed on %', TG_TABLE_NAME;
+      END IF;
+      IF calc.projection_effect = 'set_active' THEN
+        IF NEW.visibility_state <> 'active' OR NEW.visibility_reason <> 'active' THEN
+          RAISE EXCEPTION 'W4C0_POINTER: visibility does not match set_active on %', TG_TABLE_NAME;
+        END IF;
+      ELSIF calc.projection_effect = 'set_retired' THEN
+        IF NEW.visibility_state <> 'retired' THEN
+          RAISE EXCEPTION 'W4C0_POINTER: visibility does not match set_retired on %', TG_TABLE_NAME;
+        END IF;
+        IF NOT (
+          (calc.outcome_reason_code = 'import_rollback_reversal' AND NEW.visibility_reason = 'import_rollback') OR
+          (calc.outcome_reason_code = 'operator_retirement' AND NEW.visibility_reason = 'operator_retirement')
+        ) THEN
+          RAISE EXCEPTION 'W4C0_POINTER: retired visibility reason does not match selected row on %', TG_TABLE_NAME;
+        END IF;
+      ELSE
+        RAISE EXCEPTION 'W4C0_POINTER: pointer target projection effect cannot be none on %', TG_TABLE_NAME;
+      END IF;
+      IF NEW.status IS DISTINCT FROM calc.projected_status OR
+         NEW.first_in_at IS DISTINCT FROM calc.projected_first_in_at OR
+         NEW.last_out_at IS DISTINCT FROM calc.projected_last_out_at OR
+         NEW.work_minutes IS DISTINCT FROM calc.projected_work_minutes OR
+         NEW.late_minutes IS DISTINCT FROM calc.projected_late_minutes OR
+         NEW.early_leave_minutes IS DISTINCT FROM calc.projected_early_leave_minutes THEN
+        RAISE EXCEPTION 'W4C0_POINTER: W4-owned daily fields drifted from the selected snapshot on %', TG_TABLE_NAME;
+      END IF;
+      RETURN NULL;
+    END;
+    $fn$
+  `.execute(db)
+
+  await sql`
+    CREATE OR REPLACE FUNCTION attendance_w4c3a_restore_witness_command_guard()
+    RETURNS trigger
+    LANGUAGE plpgsql
+    AS $fn$
+    DECLARE
+      cmd RECORD;
+      rev RECORD;
+      reversed RECORD;
+    BEGIN
+      SELECT source_batch_entrypoint, source_batch_id, writer_xid, rollback_entrypoint
+        INTO cmd
+      FROM attendance_import_rollback_commands
+      WHERE org_id = NEW.org_id AND rollback_operation_id = NEW.rollback_operation_id;
+      IF NOT FOUND THEN
+        RAISE EXCEPTION 'W4C3A_WITNESS: rollback command missing on %', TG_TABLE_NAME;
+      END IF;
+      IF cmd.source_batch_entrypoint IS DISTINCT FROM NEW.source_batch_entrypoint
+         OR cmd.source_batch_id IS DISTINCT FROM NEW.source_batch_id THEN
+        RAISE EXCEPTION 'W4C3A_WITNESS: source batch mismatch on %', TG_TABLE_NAME;
+      END IF;
+      IF NEW.writer_xid IS DISTINCT FROM pg_current_xact_id()
+         OR cmd.writer_xid IS DISTINCT FROM pg_current_xact_id() THEN
+        RAISE EXCEPTION 'W4C3A_WITNESS: writer xid mismatch on %', TG_TABLE_NAME;
+      END IF;
+
+      SELECT entrypoint, operation_id, outcome, outcome_reason_code, supersedes_calculation_id,
+             restores_calculation_id, calculation_kind, mode, projection_effect,
+             projected_status, projected_first_in_at, projected_last_out_at,
+             projected_work_minutes, projected_late_minutes, projected_early_leave_minutes,
+             projected_daily_fingerprint, source_batch_id
+        INTO rev
+      FROM attendance_record_calculations
+      WHERE id = NEW.reversal_calculation_id
+        AND attendance_record_id = NEW.attendance_record_id
+        AND org_id = NEW.org_id;
+      IF NOT FOUND THEN
+        RAISE EXCEPTION 'W4C3A_WITNESS: reversal missing on %', TG_TABLE_NAME;
+      END IF;
+      IF rev.calculation_kind <> 'reversal'
+         OR rev.entrypoint <> 'import_rollback'
+         OR rev.outcome <> 'reversed'
+         OR rev.outcome_reason_code <> 'import_rollback_reversal'
+         OR rev.mode <> 'authoritative'
+         OR rev.supersedes_calculation_id IS DISTINCT FROM NEW.reversed_calculation_id THEN
+        RAISE EXCEPTION 'W4C3A_WITNESS: reversal shape invalid on %', TG_TABLE_NAME;
+      END IF;
+      IF NOT EXISTS (
+        SELECT 1 FROM attendance_result_operations op
+        WHERE op.org_id = NEW.org_id
+          AND op.entrypoint = 'import_rollback'
+          AND op.operation_id = rev.operation_id
+          AND op.identity_source_kind = 'direct_import_rollback'
+          AND op.actor_id = NEW.actor_id
+          AND op.actor_posture = NEW.actor_posture
+          AND op.state = 'claimed'
+      ) THEN
+        RAISE EXCEPTION 'W4C3A_WITNESS: reversal operation mismatch on %', TG_TABLE_NAME;
+      END IF;
+
+      SELECT entrypoint, source_batch_id, parent_preimage_snapshot, mode, outcome
+        INTO reversed
+      FROM attendance_record_calculations
+      WHERE id = NEW.reversed_calculation_id
+        AND attendance_record_id = NEW.attendance_record_id
+        AND org_id = NEW.org_id;
+      IF NOT FOUND THEN
+        RAISE EXCEPTION 'W4C3A_WITNESS: reversed calculation missing on %', TG_TABLE_NAME;
+      END IF;
+      IF reversed.source_batch_id IS NULL
+         OR reversed.source_batch_id IS DISTINCT FROM NEW.source_batch_id THEN
+        RAISE EXCEPTION 'W4C3A_WITNESS: reversed source batch invalid on %', TG_TABLE_NAME;
+      END IF;
+      IF NOT (
+        (reversed.entrypoint = 'legacy_import' AND NEW.source_batch_entrypoint = 'import_batch')
+        OR (reversed.entrypoint = 'integration_sync' AND NEW.source_batch_entrypoint = 'integration_batch')
+      ) THEN
+        RAISE EXCEPTION 'W4C3A_WITNESS: calculation/batch entrypoint map invalid on %', TG_TABLE_NAME;
+      END IF;
+      IF jsonb_typeof(reversed.parent_preimage_snapshot) IS DISTINCT FROM 'object'
+         OR (SELECT count(*) FROM jsonb_object_keys(reversed.parent_preimage_snapshot)) <> 7
+         OR reversed.parent_preimage_snapshot ->> 'posture' IS DISTINCT FROM 'present'
+         OR reversed.parent_preimage_snapshot ->> 'projectionOwner' NOT IN ('legacy_untracked', 'w4')
+         OR reversed.parent_preimage_snapshot ? 'currentCalculationId' = false
+         OR NOT (
+              (reversed.parent_preimage_snapshot ->> 'projectionOwner' = 'legacy_untracked'
+                AND reversed.parent_preimage_snapshot ->> 'currentCalculationId' IS NULL)
+              OR
+              (reversed.parent_preimage_snapshot ->> 'projectionOwner' = 'w4'
+                AND reversed.parent_preimage_snapshot ->> 'currentCalculationId' IS NOT NULL
+                AND EXISTS (
+                  SELECT 1
+                  FROM attendance_record_calculations restored
+                  WHERE restored.id = (reversed.parent_preimage_snapshot ->> 'currentCalculationId')::uuid
+                    AND restored.attendance_record_id = NEW.attendance_record_id
+                    AND restored.org_id = NEW.org_id
+                ))
+            )
+         OR reversed.parent_preimage_snapshot ->> 'compatibilityFingerprint'
+              IS DISTINCT FROM NEW.frozen_preimage_fingerprint
+         OR jsonb_typeof(reversed.parent_preimage_snapshot -> 'projection') IS DISTINCT FROM 'object'
+         OR (SELECT count(*) FROM jsonb_object_keys(reversed.parent_preimage_snapshot -> 'projection')) <> 6
+         OR NOT ((reversed.parent_preimage_snapshot -> 'projection') ?& ARRAY[
+              'status', 'firstInAt', 'lastOutAt', 'workMinutes', 'lateMinutes',
+              'earlyLeaveMinutes'
+            ])
+         OR attendance_w4c3a_rollback_preimage_fingerprint(
+              reversed.parent_preimage_snapshot
+            ) IS DISTINCT FROM NEW.frozen_preimage_fingerprint THEN
+        RAISE EXCEPTION 'W4C3A_WITNESS: closed present preimage invalid on %', TG_TABLE_NAME;
+      END IF;
+      IF rev.restores_calculation_id IS DISTINCT FROM
+           NULLIF(reversed.parent_preimage_snapshot ->> 'currentCalculationId', '')::uuid THEN
+        RAISE EXCEPTION 'W4C3A_WITNESS: restore pointer drift on %', TG_TABLE_NAME;
+      END IF;
+      IF rev.projected_status IS DISTINCT FROM (reversed.parent_preimage_snapshot #>> '{projection,status}')
+         OR rev.projected_first_in_at IS DISTINCT FROM
+              NULLIF(reversed.parent_preimage_snapshot #>> '{projection,firstInAt}', '')::timestamptz
+         OR rev.projected_last_out_at IS DISTINCT FROM
+              NULLIF(reversed.parent_preimage_snapshot #>> '{projection,lastOutAt}', '')::timestamptz
+         OR rev.projected_work_minutes IS DISTINCT FROM
+              (reversed.parent_preimage_snapshot #>> '{projection,workMinutes}')::integer
+         OR rev.projected_late_minutes IS DISTINCT FROM
+              (reversed.parent_preimage_snapshot #>> '{projection,lateMinutes}')::integer
+         OR rev.projected_early_leave_minutes IS DISTINCT FROM
+              (reversed.parent_preimage_snapshot #>> '{projection,earlyLeaveMinutes}')::integer THEN
+        RAISE EXCEPTION 'W4C3A_WITNESS: reversal projection drift on %', TG_TABLE_NAME;
+      END IF;
+      IF (reversed.parent_preimage_snapshot ->> 'visibilityState') = 'active' THEN
+        IF rev.projection_effect <> 'set_active' THEN
+          RAISE EXCEPTION 'W4C3A_WITNESS: projection effect mismatch on %', TG_TABLE_NAME;
+        END IF;
+      ELSIF (reversed.parent_preimage_snapshot ->> 'visibilityState') = 'retired' THEN
+        IF rev.projection_effect <> 'set_retired' THEN
+          RAISE EXCEPTION 'W4C3A_WITNESS: projection effect mismatch on %', TG_TABLE_NAME;
+        END IF;
+      ELSE
+        RAISE EXCEPTION 'W4C3A_WITNESS: frozen visibility invalid on %', TG_TABLE_NAME;
+      END IF;
+      RETURN NEW;
+    END;
+    $fn$
+  `.execute(db)
+}

--- a/packages/core-backend/src/db/migrations/zzzz20260815120000_w7_1am_provenance_domain_widening.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260815120000_w7_1am_provenance_domain_widening.ts
@@ -32,8 +32,17 @@
  *
  * The two function bodies below are the historical bodies with ONLY the
  * substitutions named above applied; they were extracted mechanically from
- * zzzz20260731120000 rather than retyped, and the .db test diffs the resulting
- * `prosrc` against the pre-migration `prosrc` to prove nothing else moved.
+ * zzzz20260731120000 rather than retyped. That is ASSERTED, not just asserted in
+ * prose: `tests/unit/attendance-w7-1am-provenance-widening-completeness.test.ts`
+ * ("superseding plpgsql body fidelity") reads BOTH migration files off disk as
+ * TEXT, extracts each `$fn$…$fn$` body, and proves the body here equals the
+ * historical body with exactly the three named substitutions applied — each
+ * matching exactly once — and that `down()` restores the historical bodies
+ * byte-identically. A stray edit anywhere else in these ~500 lines reds it.
+ *
+ * The diff is deliberately source-text, NOT a comparison against the ambient
+ * `prosrc`: sibling suites replay historical migrations against the shared test
+ * database, so the "pre-migration" catalogue body is order-dependent.
  *
  * Historical migrations are NEVER edited: this file supersedes them, and the new
  * value enters via a zzzz migration as required.

--- a/packages/core-backend/src/services/AttendanceDecisionTrace.ts
+++ b/packages/core-backend/src/services/AttendanceDecisionTrace.ts
@@ -99,6 +99,14 @@ export interface AttendanceDecisionTraceVersion {
   snapshotVersion?: string
 }
 
+/**
+ * W7-1a-M (#4556, ratified per #4556 comments 5293034619 + 5293478713) widened
+ * this live union with `'group_policy_snapshot'`. INERT: no basis builder in
+ * this file emits the new kind — the producer seam is W7-1b. Kept as an
+ * explicit literal union (not an alias of the backend domain array) so the W7-0
+ * mutual-extends sync guard in `../attendance/w7-read-side-provenance-amendment.ts`
+ * still compares two independently written member lists rather than itself.
+ */
 export type AttendanceDecisionTraceSourceKind =
   | 'record'
   | 'snapshot'
@@ -106,6 +114,7 @@ export type AttendanceDecisionTraceSourceKind =
   | 'ledger'
   | 'audit'
   | 'policy_gate'
+  | 'group_policy_snapshot'
 
 export interface AttendanceDecisionTraceSource {
   kind: AttendanceDecisionTraceSourceKind

--- a/packages/core-backend/src/services/AttendanceW4CalculationDetail.ts
+++ b/packages/core-backend/src/services/AttendanceW4CalculationDetail.ts
@@ -4,6 +4,7 @@ import {
   validateFrozenContextShape,
 } from '../attendance/w4c1-segment-calculator'
 import type { FrozenAttendanceContextV1 } from '../attendance/w4c0-write-boundary-types'
+import { ATTENDANCE_PROJECTION_OWNERS_V1 } from '../attendance/w7-provenance-domain'
 
 export const ATTENDANCE_W4_SHADOW_DIFF_CODES = [
   'equal',
@@ -91,7 +92,10 @@ const CALCULATION_OUTCOME_REASONS = [
   'operator_retirement',
 ] as const
 const PROJECTION_EFFECTS = ['none', 'set_active', 'set_retired'] as const
-const PROJECTION_OWNERS = ['legacy_untracked', 'w4'] as const
+// W7-1a-M (#4556, ratified per #4556 comments 5293034619 + 5293478713): the
+// closed set this route validates against is the widened live domain. `w4_group`
+// is ACCEPTED here; nothing emits it until W7-1b.
+const PROJECTION_OWNERS = ATTENDANCE_PROJECTION_OWNERS_V1
 const VISIBILITY_STATES = ['active', 'retired'] as const
 const VISIBILITY_REASONS = ['active', 'review_placeholder', 'import_rollback', 'operator_retirement'] as const
 const DAILY_STATUSES = ['normal', 'late', 'early_leave', 'late_early', 'partial', 'absent', 'adjusted', 'off'] as const

--- a/packages/core-backend/tests/integration/attendance-w7-1am-provenance-widening.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-w7-1am-provenance-widening.db.test.ts
@@ -17,11 +17,14 @@
  */
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import crypto from 'node:crypto'
+import { Kysely, PostgresDialect } from 'kysely'
 import { Pool, type PoolClient } from 'pg'
 import {
   ATTENDANCE_PROJECTION_OWNERS_V1,
+  ATTENDANCE_PROJECTION_OWNERS_WITH_CALCULATION_POINTER_SQL_LIST_V1,
   ATTENDANCE_PROJECTION_OWNERS_WITH_CALCULATION_POINTER_V1,
 } from '../../src/attendance/w7-provenance-domain'
+import { up as applyW7ProvenanceWidening } from '../../src/db/migrations/zzzz20260815120000_w7_1am_provenance_domain_widening'
 
 const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
 const describeIfDatabase = dbUrl ? describe : describe.skip
@@ -80,8 +83,27 @@ describeIfDatabase('W7-1a-M provenance widening — live catalogue + real Postgr
   const org = `w7-1am-org-${RUN}`
   let constraints: Array<{ name: string; def: string }> = []
   let functions: Array<{ name: string; src: string }> = []
+  let migrationDb: Kysely<unknown> | undefined
 
   beforeAll(async () => {
+    // SHARED-DB REPLAY HAZARD (pre-existing, disclosed not introduced by W7-1a-M).
+    // Sibling suites re-run HISTORICAL migrations' `up()` against this same
+    // database — `attendance-w4c0-db-gates-e1.db.test.ts` calls
+    // `zzzz20260725120000.up()`, which `CREATE OR REPLACE`s the SHARED function
+    // `attendance_w4_records_pointer_guard` with its 2026-07-25 body. That
+    // silently reverts both W7-1a-M's widening AND zzzz20260731120000's
+    // witness-restore exception for whatever runs afterwards, so the live
+    // catalogue depends on suite ORDER rather than on migration order.
+    //
+    // Production is unaffected: migrations there apply in order and this slice's
+    // is last. Re-applying our own `up()` here (the same thing e1 does for its
+    // migration, and idempotent by construction) makes these assertions measure
+    // THIS migration's effect instead of the ambient order of the run.
+    migrationDb = new Kysely<unknown>({
+      dialect: new PostgresDialect({ pool: new Pool({ connectionString: dbUrl }) }),
+    })
+    await applyW7ProvenanceWidening(migrationDb)
+
     const constraintRows = await pool.query(
       `SELECT conname AS name, pg_get_constraintdef(oid) AS def
          FROM pg_constraint
@@ -103,6 +125,7 @@ describeIfDatabase('W7-1a-M provenance widening — live catalogue + real Postgr
   }, 60000)
 
   afterAll(async () => {
+    await migrationDb?.destroy()
     await pool.end()
   })
 
@@ -222,6 +245,23 @@ describeIfDatabase('W7-1a-M provenance widening — live catalogue + real Postgr
       expect(await evaluateInList(String(guard?.src), marker, owner)).toBe(true)
     }
     expect(await evaluateInList(String(guard?.src), marker, 'legacy_untracked')).toBe(false)
+  })
+
+  it('the interpolated closure predicate is valid SQL and selects exactly the pointer owners', async () => {
+    // `w4c3a-import-rollback-boundary.ts` builds its closure precondition by
+    // interpolating this list. Executing the same rendered fragment proves the
+    // text Postgres will actually parse, which no source-level check can.
+    const { rows } = await pool.query(
+      `SELECT v AS owner,
+              (v IN (${ATTENDANCE_PROJECTION_OWNERS_WITH_CALCULATION_POINTER_SQL_LIST_V1})) AS hit
+         FROM unnest($1::text[]) AS v`,
+      [['legacy_untracked', 'w4', NEW_OWNER, 'w4_team']],
+    )
+    const hits = new Map(rows.map((row) => [String(row.owner), row.hit as boolean]))
+    expect(hits.get('w4')).toBe(true)
+    expect(hits.get(NEW_OWNER)).toBe(true)
+    expect(hits.get('legacy_untracked')).toBe(false)
+    expect(hits.get('w4_team')).toBe(false)
   })
 
   // -------------------------------------------------------------------------

--- a/packages/core-backend/tests/integration/attendance-w7-1am-provenance-widening.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-w7-1am-provenance-widening.db.test.ts
@@ -1,0 +1,376 @@
+/**
+ * W7-1a-M (#4556) — the DB half of the derive-and-diff completeness check, plus
+ * the real-Postgres round-trip and refusal legs.
+ *
+ * Ratified per #4556 comments 5293034619 + 5293478713.
+ *
+ * WHY THE CATALOGUE, NOT MIGRATION TEXT. `attendance_w4_records_pointer_guard`
+ * is created by zzzz20260725120000 and then REPLACED by zzzz20260731120000, and
+ * W7-1a-M replaces it again. Migration files are append-only history — the older
+ * ones still contain the un-widened bodies forever — so scanning them would
+ * force a blanket exemption for historical migrations, which is exactly the hole
+ * that hides a missed point. `pg_constraint` / `pg_proc` on a migrated database
+ * say what is actually live, and are complete by construction.
+ *
+ * INERT: nothing in this slice emits `w4_group`. The rows below are inserted BY
+ * THIS TEST, never by production code.
+ */
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import crypto from 'node:crypto'
+import { Pool, type PoolClient } from 'pg'
+import {
+  ATTENDANCE_PROJECTION_OWNERS_V1,
+  ATTENDANCE_PROJECTION_OWNERS_WITH_CALCULATION_POINTER_V1,
+} from '../../src/attendance/w7-provenance-domain'
+
+const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
+const describeIfDatabase = dbUrl ? describe : describe.skip
+
+const RUN = crypto.randomUUID().slice(0, 8)
+const HEX64_A = 'a'.repeat(64)
+const HEX64_B = 'b'.repeat(64)
+const HEX64_C = 'c'.repeat(64)
+
+const NEW_OWNER = 'w4_group'
+
+/**
+ * The pointer-coupling invariant the ratification rules SURVIVES UNCHANGED:
+ * `w4_group` inherits `w4`'s non-NULL pointer semantics, and `legacy_untracked`
+ * stays the only NULL-pointer member, so this predicate is already correct for
+ * the widened domain. Pinned byte-for-byte as Postgres renders it.
+ */
+const POINTER_PAIR_INVARIANT_DEF =
+  "CHECK (((projection_owner = 'legacy_untracked'::text) = (current_calculation_id IS NULL)))"
+
+type DbRule =
+  /** Must admit the new member. */
+  | 'widened'
+  /** Only compares against `legacy_untracked`, so the new member takes `w4`'s arm. */
+  | 'legacy_polarity'
+  /** Mentions the column/field but no domain literal at all — value-agnostic. */
+  | 'value_agnostic'
+  /** The coupled pointer-null invariant; must be UNCHANGED. */
+  | 'pointer_coupling_invariant'
+
+/** The DB-half ledger: every live catalogue object that names the domain. */
+const DB_LEDGER: ReadonlyArray<{ name: string; rule: DbRule; note?: string }> = Object.freeze([
+  { name: 'chk_ar_projection_owner', rule: 'widened', note: 'the closed-set CHECK' },
+  { name: 'chk_ar_owner_pointer_pair', rule: 'pointer_coupling_invariant' },
+  {
+    name: 'attendance_w4_records_pointer_guard',
+    rule: 'widened',
+    note: 'narrow import-rollback restore exception gates on the OLD owner',
+  },
+  {
+    name: 'attendance_w4c3a_restore_witness_command_guard',
+    rule: 'widened',
+    note: 'W4C3A_WITNESS: NOT IN membership AND the coupled pointer disjunct',
+  },
+  { name: 'attendance_w4c3a_witnessed_legacy_lineage_guard', rule: 'legacy_polarity' },
+  { name: 'attendance_w4c3a_restore_witness_commit_guard', rule: 'value_agnostic' },
+  { name: 'attendance_w4c3a_rollback_preimage_fingerprint', rule: 'value_agnostic' },
+])
+
+function quotedW4(text: string): boolean {
+  return /'w4'/.test(text)
+}
+
+describeIfDatabase('W7-1a-M provenance widening — live catalogue + real Postgres', () => {
+  const pool = new Pool({ connectionString: dbUrl })
+  const org = `w7-1am-org-${RUN}`
+  let constraints: Array<{ name: string; def: string }> = []
+  let functions: Array<{ name: string; src: string }> = []
+
+  beforeAll(async () => {
+    const constraintRows = await pool.query(
+      `SELECT conname AS name, pg_get_constraintdef(oid) AS def
+         FROM pg_constraint
+        WHERE pg_get_constraintdef(oid) ILIKE '%projection_owner%'
+           OR pg_get_constraintdef(oid) ILIKE '%projectionOwner%'
+        ORDER BY conname`,
+    )
+    constraints = constraintRows.rows.map((row) => ({ name: String(row.name), def: String(row.def) }))
+
+    const functionRows = await pool.query(
+      `SELECT p.proname AS name, p.prosrc AS src
+         FROM pg_proc p
+         JOIN pg_namespace n ON n.oid = p.pronamespace
+        WHERE n.nspname = 'public'
+          AND (p.prosrc ILIKE '%projection_owner%' OR p.prosrc ILIKE '%projectionOwner%')
+        ORDER BY p.proname`,
+    )
+    functions = functionRows.rows.map((row) => ({ name: String(row.name), src: String(row.src) }))
+  }, 60000)
+
+  afterAll(async () => {
+    await pool.end()
+  })
+
+  // -------------------------------------------------------------------------
+  // Derive-and-diff over the live catalogue.
+  // -------------------------------------------------------------------------
+
+  it('non-vacuity: the catalogue derivation actually found the DB surface', () => {
+    expect(constraints.length).toBeGreaterThanOrEqual(2)
+    expect(functions.length).toBeGreaterThanOrEqual(5)
+    expect(constraints.map((c) => c.name)).toContain('chk_ar_projection_owner')
+    expect(constraints.map((c) => c.name)).toContain('chk_ar_owner_pointer_pair')
+    expect(functions.map((f) => f.name)).toContain('attendance_w4_records_pointer_guard')
+    expect(functions.map((f) => f.name)).toContain('attendance_w4c3a_restore_witness_command_guard')
+  })
+
+  it('every live catalogue object naming the domain is widened or has a satisfied rule', () => {
+    const derived = [
+      ...constraints.map((c) => ({ name: c.name, text: c.def })),
+      ...functions.map((f) => ({ name: f.name, text: f.src })),
+    ]
+    const byName = new Map(DB_LEDGER.map((entry) => [entry.name, entry]))
+    const violations: string[] = []
+    const seen = new Set<string>()
+
+    for (const object of derived) {
+      const entry = byName.get(object.name)
+      if (!entry) {
+        violations.push(`unledgered_object: ${object.name}`)
+        continue
+      }
+      seen.add(object.name)
+      switch (entry.rule) {
+        case 'widened':
+          if (!object.text.includes(NEW_OWNER)) violations.push(`not_widened: ${object.name}`)
+          break
+        case 'legacy_polarity':
+          if (!object.text.includes('legacy_untracked') || quotedW4(object.text)) {
+            violations.push(`legacy_polarity_failed: ${object.name}`)
+          }
+          break
+        case 'value_agnostic':
+          if (object.text.includes("'legacy_untracked'") || quotedW4(object.text)) {
+            violations.push(`value_agnostic_failed: ${object.name}`)
+          }
+          break
+        case 'pointer_coupling_invariant':
+          if (object.text !== POINTER_PAIR_INVARIANT_DEF) {
+            violations.push(`invariant_changed: ${object.name} -> ${object.text}`)
+          }
+          break
+      }
+    }
+    for (const entry of DB_LEDGER) {
+      if (!seen.has(entry.name)) violations.push(`stale_ledger_entry: ${entry.name}`)
+    }
+    expect(violations).toEqual([])
+  })
+
+  it('the closed-set CHECK admits exactly the widened domain', () => {
+    const check = constraints.find((c) => c.name === 'chk_ar_projection_owner')
+    expect(check).toBeDefined()
+    for (const owner of ATTENDANCE_PROJECTION_OWNERS_V1) {
+      expect(check?.def).toContain(`'${owner}'`)
+    }
+    // Negative control: the pin really discriminates.
+    expect(check?.def).not.toContain("'w4_team'")
+  })
+
+  it('the coupled pointer invariant is UNCHANGED by this slice', () => {
+    const pair = constraints.find((c) => c.name === 'chk_ar_owner_pointer_pair')
+    expect(pair?.def).toBe(POINTER_PAIR_INVARIANT_DEF)
+    // It names only `legacy_untracked` — which is precisely why it keeps forcing
+    // a NON-NULL pointer for every other member, `w4_group` included.
+    expect(quotedW4(String(pair?.def))).toBe(false)
+  })
+
+  // -------------------------------------------------------------------------
+  // The widened trigger predicates, evaluated as LIVE TEXT in real Postgres.
+  // Extracting the list from `prosrc` and running it means the assertion is
+  // about the deployed predicate, not about a copy retyped in this file.
+  // -------------------------------------------------------------------------
+
+  async function evaluateInList(source: string, marker: RegExp, value: string): Promise<boolean> {
+    const match = marker.exec(source)
+    expect(match, `predicate not found in live prosrc: ${marker}`).not.toBeNull()
+    const list = (match as RegExpExecArray)[1]
+    const { rows } = await pool.query(`SELECT ($1::text IN (${list})) AS hit`, [value])
+    return rows[0].hit as boolean
+  }
+
+  it('W4C3A_WITNESS membership list (live text) admits w4_group and refuses novel values', async () => {
+    const guard = functions.find((f) => f.name === 'attendance_w4c3a_restore_witness_command_guard')
+    const marker = /->> 'projectionOwner' NOT IN \(([^)]*)\)/
+    expect(await evaluateInList(String(guard?.src), marker, NEW_OWNER)).toBe(true)
+    expect(await evaluateInList(String(guard?.src), marker, 'legacy_untracked')).toBe(true)
+    expect(await evaluateInList(String(guard?.src), marker, 'w4')).toBe(true)
+    for (const novel of ['w4_team', 'w5', 'group', 'W4_GROUP']) {
+      expect(await evaluateInList(String(guard?.src), marker, novel)).toBe(false)
+    }
+  })
+
+  it('W4C3A_WITNESS coupled pointer disjunct (live text) puts w4_group on the NON-NULL side', async () => {
+    const guard = functions.find((f) => f.name === 'attendance_w4c3a_restore_witness_command_guard')
+    const marker = /->> 'projectionOwner' IN \(([^)]*)\)/
+    for (const owner of ATTENDANCE_PROJECTION_OWNERS_WITH_CALCULATION_POINTER_V1) {
+      expect(await evaluateInList(String(guard?.src), marker, owner)).toBe(true)
+    }
+    expect(await evaluateInList(String(guard?.src), marker, 'legacy_untracked')).toBe(false)
+    expect(await evaluateInList(String(guard?.src), marker, 'w4_team')).toBe(false)
+  })
+
+  it('pointer-guard restore eligibility (live text) admits w4_group', async () => {
+    const guard = functions.find((f) => f.name === 'attendance_w4_records_pointer_guard')
+    const marker = /AND OLD\.projection_owner IN \(([^)]*)\)/
+    for (const owner of ATTENDANCE_PROJECTION_OWNERS_WITH_CALCULATION_POINTER_V1) {
+      expect(await evaluateInList(String(guard?.src), marker, owner)).toBe(true)
+    }
+    expect(await evaluateInList(String(guard?.src), marker, 'legacy_untracked')).toBe(false)
+  })
+
+  // -------------------------------------------------------------------------
+  // Real round-trip: a w4_group row through CHECK + coupled CHECK + the
+  // pointer-guard constraint trigger.
+  // -------------------------------------------------------------------------
+
+  async function insertRecord(): Promise<string> {
+    const { rows } = await pool.query(
+      `INSERT INTO attendance_records
+         (user_id, work_date, org_id, status, work_minutes, late_minutes, early_leave_minutes)
+       VALUES ($1, '2026-08-15', $2, 'normal', 480, 0, 0)
+       RETURNING id::text AS id`,
+      [`w7-1am-user-${crypto.randomUUID()}`, org],
+    )
+    return rows[0].id as string
+  }
+
+  /** One authoritative `set_active` calculation with its exact direct segment. */
+  async function insertAuthoritativeCalc(client: PoolClient, recordId: string): Promise<string> {
+    const id = crypto.randomUUID()
+    await client.query(
+      `INSERT INTO attendance_record_calculations
+         (id, org_id, attendance_record_id, version, calculation_kind, mode, entrypoint, engine_version,
+          snapshot_schema_version, operation_id, semantic_input_fingerprint, provenance_fingerprint,
+          source_definition_fingerprint, attribution_snapshot, context_snapshot, segment_snapshot,
+          evidence_snapshot, approved_facts_snapshot, input_provenance, merge_policy, calculation_tier,
+          outcome, outcome_reason_code, projection_effect, expected_segment_count,
+          projected_status, projected_work_minutes, projected_late_minutes, projected_early_leave_minutes,
+          actor_id, correlation_id)
+       VALUES ($1::uuid, $2, $3::uuid, 1, 'calculation', 'authoritative', 'live', 'w7-1am', 1,
+               $4::uuid, $5, $6, $7, '{"posture":"resolved_v2"}'::jsonb, '{"tz":"UTC"}'::jsonb,
+               '[]'::jsonb, '[]'::jsonb, '[]'::jsonb, '{"transport":"live_punch"}'::jsonb, 'append',
+               'segment_authoritative', 'completed', 'calculated', 'set_active', 1,
+               'normal', 480, 0, 0, 'w7-1am-actor', $8)`,
+      [id, org, recordId, crypto.randomUUID(), HEX64_A, HEX64_B, HEX64_C, `corr-w7-1am-${RUN}`],
+    )
+    await client.query(
+      `INSERT INTO attendance_record_segments
+         (org_id, record_id, calculation_id, segment_index, expected_start_at, expected_end_at,
+          work_minutes, late_minutes, early_leave_minutes, status, status_reasons,
+          matched_evidence_refs, unmatched_evidence_refs)
+       VALUES ($1, $2::uuid, $3::uuid, 0, '2026-08-15T01:00:00Z', '2026-08-15T09:00:00Z',
+               480, 0, 0, 'normal', '["within_window"]'::jsonb, '[]'::jsonb, '[]'::jsonb)`,
+      [org, recordId, id],
+    )
+    return id
+  }
+
+  async function seedPointerOwningRecord(): Promise<{ recordId: string; calcId: string }> {
+    const recordId = await insertRecord()
+    const client = await pool.connect()
+    let calcId = ''
+    try {
+      await client.query('BEGIN')
+      calcId = await insertAuthoritativeCalc(client, recordId)
+      await client.query('COMMIT')
+    } catch (error) {
+      await client.query('ROLLBACK').catch(() => undefined)
+      throw error
+    } finally {
+      client.release()
+    }
+    return { recordId, calcId }
+  }
+
+  it('a w4_group row ROUND-TRIPS through the CHECK, the coupled CHECK and the pointer guard', async () => {
+    const { recordId, calcId } = await seedPointerOwningRecord()
+    await pool.query(
+      `UPDATE attendance_records
+          SET projection_owner = $2, current_calculation_id = $3::uuid,
+              status = 'normal', work_minutes = 480, late_minutes = 0, early_leave_minutes = 0,
+              visibility_state = 'active', visibility_reason = 'active'
+        WHERE id = $1::uuid`,
+      [recordId, NEW_OWNER, calcId],
+    )
+    const { rows } = await pool.query(
+      `SELECT projection_owner, current_calculation_id::text AS current_calculation_id
+         FROM attendance_records WHERE id = $1::uuid`,
+      [recordId],
+    )
+    // Stored verbatim — no downgrade to legacy on the way in or out.
+    expect(rows[0].projection_owner).toBe(NEW_OWNER)
+    expect(rows[0].current_calculation_id).toBe(calcId)
+  })
+
+  it('SEMANTIC RULING: a w4_group row with a NULL pointer is still REFUSED', async () => {
+    const { recordId, calcId } = await seedPointerOwningRecord()
+    await pool.query(
+      `UPDATE attendance_records
+          SET projection_owner = $2, current_calculation_id = $3::uuid
+        WHERE id = $1::uuid`,
+      [recordId, NEW_OWNER, calcId],
+    )
+    await expect(
+      pool.query(
+        `UPDATE attendance_records SET current_calculation_id = NULL WHERE id = $1::uuid`,
+        [recordId],
+      ),
+    ).rejects.toThrow(/chk_ar_owner_pointer_pair/)
+
+    // And the same refusal on the INSERT path, so this is not an update-only artefact.
+    await expect(
+      pool.query(
+        `INSERT INTO attendance_records
+           (user_id, work_date, org_id, status, work_minutes, late_minutes, early_leave_minutes,
+            projection_owner, current_calculation_id)
+         VALUES ($1, '2026-08-16', $2, 'normal', 0, 0, 0, $3, NULL)`,
+        [`w7-1am-nullptr-${crypto.randomUUID()}`, org, NEW_OWNER],
+      ),
+    ).rejects.toThrow(/chk_ar_owner_pointer_pair/)
+  })
+
+  it('legacy_untracked remains the ONLY member allowed a NULL pointer', async () => {
+    const { rows } = await pool.query(
+      `INSERT INTO attendance_records
+         (user_id, work_date, org_id, status, work_minutes, late_minutes, early_leave_minutes,
+          projection_owner, current_calculation_id)
+       VALUES ($1, '2026-08-17', $2, 'normal', 0, 0, 0, 'legacy_untracked', NULL)
+       RETURNING projection_owner`,
+      [`w7-1am-legacy-${crypto.randomUUID()}`, org],
+    )
+    expect(rows[0].projection_owner).toBe('legacy_untracked')
+  })
+
+  it('NOVEL values are still refused everywhere — the domain did not open generally', async () => {
+    for (const novel of ['w4_team', 'w5', 'group', 'W4_GROUP', 'w4_group_x', '']) {
+      await expect(
+        pool.query(
+          `INSERT INTO attendance_records
+             (user_id, work_date, org_id, status, work_minutes, late_minutes, early_leave_minutes,
+              projection_owner, current_calculation_id)
+           VALUES ($1, '2026-08-18', $2, 'normal', 0, 0, 0, $3, NULL)`,
+          [`w7-1am-novel-${crypto.randomUUID()}`, org, novel],
+        ),
+        `novel value must be refused: ${JSON.stringify(novel)}`,
+      ).rejects.toThrow(/chk_ar_projection_owner|chk_ar_owner_pointer_pair/)
+    }
+  })
+
+  it('a novel value is refused even WITH a valid pointer (the closed-set CHECK, not the pair)', async () => {
+    const { recordId, calcId } = await seedPointerOwningRecord()
+    await expect(
+      pool.query(
+        `UPDATE attendance_records
+            SET projection_owner = 'w4_team', current_calculation_id = $2::uuid
+          WHERE id = $1::uuid`,
+        [recordId, calcId],
+      ),
+    ).rejects.toThrow(/chk_ar_projection_owner/)
+  })
+})

--- a/packages/core-backend/tests/integration/attendance-w7-1am-provenance-widening.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-w7-1am-provenance-widening.db.test.ts
@@ -9,8 +9,17 @@
  * W7-1a-M replaces it again. Migration files are append-only history — the older
  * ones still contain the un-widened bodies forever — so scanning them would
  * force a blanket exemption for historical migrations, which is exactly the hole
- * that hides a missed point. `pg_constraint` / `pg_proc` on a migrated database
- * say what is actually live, and are complete by construction.
+ * that hides a missed point. The catalogue on a migrated database says what is
+ * actually live.
+ *
+ * SCOPE OF "the catalogue", stated precisely rather than as an adjective: the
+ * derivation below queries `pg_constraint`, `pg_proc`, `pg_trigger`,
+ * `pg_attrdef`, `pg_views`, `pg_indexes` and `pg_policies`. `pg_trigger` matters
+ * on its own account — a trigger's WHEN clause is the FIRING GATE for its
+ * function, so a WHEN clause that failed to fire for `w4_group` would bypass the
+ * pointer guard for exactly the new member, with the function body itself
+ * looking perfectly widened. Those clauses are legacy-polarity today, which is
+ * why they are correct, and they are now ledgered rather than assumed.
  *
  * INERT: nothing in this slice emits `w4_group`. The rows below are inserted BY
  * THIS TEST, never by production code.
@@ -52,6 +61,8 @@ type DbRule =
   | 'legacy_polarity'
   /** Mentions the column/field but no domain literal at all — value-agnostic. */
   | 'value_agnostic'
+  /** Writes a constant domain value; not a test, so it routes nothing. */
+  | 'write_side_emitter'
   /** The coupled pointer-null invariant; must be UNCHANGED. */
   | 'pointer_coupling_invariant'
 
@@ -72,6 +83,17 @@ const DB_LEDGER: ReadonlyArray<{ name: string; rule: DbRule; note?: string }> = 
   { name: 'attendance_w4c3a_witnessed_legacy_lineage_guard', rule: 'legacy_polarity' },
   { name: 'attendance_w4c3a_restore_witness_commit_guard', rule: 'value_agnostic' },
   { name: 'attendance_w4c3a_rollback_preimage_fingerprint', rule: 'value_agnostic' },
+  // Trigger WHEN clauses — the firing gate for the pointer guard. Legacy-polarity,
+  // so every non-legacy owner (the new member included) makes them fire exactly
+  // as they fire for `w4`.
+  { name: 'trg_ar_pointer_guard_ins', rule: 'legacy_polarity' },
+  { name: 'trg_ar_pointer_guard_upd', rule: 'legacy_polarity' },
+  // Column default: emits the legacy member for rows that name no owner.
+  { name: 'attendance_records.projection_owner.default', rule: 'write_side_emitter' },
+  // Canonical current-record view: projects the column through (Postgres expands
+  // the original `SELECT *`) and filters on visibility only — it never tests the
+  // owner, so it passes `w4_group` through unchanged.
+  { name: 'attendance_current_records', rule: 'value_agnostic' },
 ])
 
 function quotedW4(text: string): boolean {
@@ -83,6 +105,8 @@ describeIfDatabase('W7-1a-M provenance widening — live catalogue + real Postgr
   const org = `w7-1am-org-${RUN}`
   let constraints: Array<{ name: string; def: string }> = []
   let functions: Array<{ name: string; src: string }> = []
+  /** Everything else in the catalogue that can carry the domain. */
+  let others: Array<{ name: string; def: string }> = []
   let migrationDb: Kysely<unknown> | undefined
 
   beforeAll(async () => {
@@ -122,6 +146,37 @@ describeIfDatabase('W7-1a-M provenance widening — live catalogue + real Postgr
         ORDER BY p.proname`,
     )
     functions = functionRows.rows.map((row) => ({ name: String(row.name), src: String(row.src) }))
+
+    // Trigger WHEN clauses, column defaults, views, indexes and RLS policies.
+    // A trigger body can be perfectly widened and still never run, so the WHEN
+    // clause is derived as its own point rather than folded into the function.
+    const otherRows = await pool.query(
+      `SELECT t.tgname AS name, pg_get_triggerdef(t.oid) AS def
+         FROM pg_trigger t
+        WHERE NOT t.tgisinternal AND pg_get_triggerdef(t.oid) ILIKE '%projection_owner%'
+       UNION ALL
+       SELECT c.relname || '.' || a.attname || '.default' AS name,
+              pg_get_expr(d.adbin, d.adrelid) AS def
+         FROM pg_attrdef d
+         JOIN pg_class c ON c.oid = d.adrelid
+         JOIN pg_attribute a ON a.attrelid = d.adrelid AND a.attnum = d.adnum
+        WHERE a.attname = 'projection_owner'
+       UNION ALL
+       SELECT viewname AS name, definition AS def
+         FROM pg_views
+        WHERE schemaname = 'public' AND definition ILIKE '%projection_owner%'
+       UNION ALL
+       SELECT indexname AS name, indexdef AS def
+         FROM pg_indexes
+        WHERE schemaname = 'public' AND indexdef ILIKE '%projection_owner%'
+       UNION ALL
+       SELECT policyname AS name, COALESCE(qual, '') || COALESCE(with_check, '') AS def
+         FROM pg_policies
+        WHERE schemaname = 'public'
+          AND (COALESCE(qual, '') || COALESCE(with_check, '')) ILIKE '%projection_owner%'
+       ORDER BY 1`,
+    )
+    others = otherRows.rows.map((row) => ({ name: String(row.name), def: String(row.def) }))
   }, 60000)
 
   afterAll(async () => {
@@ -140,12 +195,32 @@ describeIfDatabase('W7-1a-M provenance widening — live catalogue + real Postgr
     expect(constraints.map((c) => c.name)).toContain('chk_ar_owner_pointer_pair')
     expect(functions.map((f) => f.name)).toContain('attendance_w4_records_pointer_guard')
     expect(functions.map((f) => f.name)).toContain('attendance_w4c3a_restore_witness_command_guard')
+    // The non-function, non-constraint catalogues are reached too — a trigger's
+    // WHEN clause gates whether its (widened) body ever runs.
+    expect(others.map((o) => o.name)).toContain('trg_ar_pointer_guard_ins')
+    expect(others.map((o) => o.name)).toContain('trg_ar_pointer_guard_upd')
+    expect(others.map((o) => o.name)).toContain('attendance_records.projection_owner.default')
+  })
+
+  it('the pointer-guard trigger WHEN clauses FIRE for w4_group (legacy-polarity)', () => {
+    for (const name of ['trg_ar_pointer_guard_ins', 'trg_ar_pointer_guard_upd']) {
+      const trigger = others.find((o) => o.name === name)
+      expect(trigger, `trigger not derived: ${name}`).toBeDefined()
+      const def = String(trigger?.def)
+      // `IS DISTINCT FROM 'legacy_untracked'` is true for every other member, so
+      // the guard fires for `w4_group` exactly as it fires for `w4`.
+      expect(def).toContain("IS DISTINCT FROM 'legacy_untracked'")
+      // Negative control: a `= 'w4'`-polarity WHEN clause would NOT fire for the
+      // new member, silently bypassing the guard for exactly it.
+      expect(quotedW4(def)).toBe(false)
+    }
   })
 
   it('every live catalogue object naming the domain is widened or has a satisfied rule', () => {
     const derived = [
       ...constraints.map((c) => ({ name: c.name, text: c.def })),
       ...functions.map((f) => ({ name: f.name, text: f.src })),
+      ...others.map((o) => ({ name: o.name, text: o.def })),
     ]
     const byName = new Map(DB_LEDGER.map((entry) => [entry.name, entry]))
     const violations: string[] = []
@@ -170,6 +245,12 @@ describeIfDatabase('W7-1a-M provenance widening — live catalogue + real Postgr
         case 'value_agnostic':
           if (object.text.includes("'legacy_untracked'") || quotedW4(object.text)) {
             violations.push(`value_agnostic_failed: ${object.name}`)
+          }
+          break
+        case 'write_side_emitter':
+          // Not a test: it carries no comparison, so it routes nothing.
+          if (/[<>=]|IS DISTINCT|IN \(/.test(object.text.replace(/::text/g, ''))) {
+            violations.push(`write_side_emitter_failed: ${object.name}`)
           }
           break
         case 'pointer_coupling_invariant':

--- a/packages/core-backend/tests/integration/attendance-w7-1am-provenance-widening.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-w7-1am-provenance-widening.db.test.ts
@@ -88,8 +88,12 @@ const DB_LEDGER: ReadonlyArray<{ name: string; rule: DbRule; note?: string }> = 
   // as they fire for `w4`.
   { name: 'trg_ar_pointer_guard_ins', rule: 'legacy_polarity' },
   { name: 'trg_ar_pointer_guard_upd', rule: 'legacy_polarity' },
-  // Column default: emits the legacy member for rows that name no owner.
-  { name: 'attendance_records.projection_owner.default', rule: 'write_side_emitter' },
+  // Column default: `'legacy_untracked'::text`. Ledgered as legacy-polarity
+  // rather than as an emitter on purpose — `write_side_emitter` is an
+  // ABSENCE-based rule (it passes anything carrying no comparison), so it would
+  // stay green if the default were ever changed to `'w4'::text`, whereas
+  // `legacy_polarity` names the value and violates.
+  { name: 'attendance_records.projection_owner.default', rule: 'legacy_polarity' },
   // Canonical current-record view: projects the column through (Postgres expands
   // the original `SELECT *`) and filters on visibility only — it never tests the
   // owner, so it passes `w4_group` through unchanged.
@@ -151,29 +155,41 @@ describeIfDatabase('W7-1a-M provenance widening — live catalogue + real Postgr
     // A trigger body can be perfectly widened and still never run, so the WHEN
     // clause is derived as its own point rather than folded into the function.
     const otherRows = await pool.query(
+      // BOTH spellings everywhere, mirroring the constraint/proc queries above.
+      // The JSONB preimage is addressed as camelCase `->> 'projectionOwner'` —
+      // which is exactly how the two guards this slice widens already reach the
+      // domain — so a snake_case-only filter would miss a WHEN clause, view,
+      // index, policy or default written that way.
       `SELECT t.tgname AS name, pg_get_triggerdef(t.oid) AS def
          FROM pg_trigger t
-        WHERE NOT t.tgisinternal AND pg_get_triggerdef(t.oid) ILIKE '%projection_owner%'
+        WHERE NOT t.tgisinternal
+          AND (pg_get_triggerdef(t.oid) ILIKE '%projection_owner%'
+            OR pg_get_triggerdef(t.oid) ILIKE '%projectionOwner%')
        UNION ALL
        SELECT c.relname || '.' || a.attname || '.default' AS name,
               pg_get_expr(d.adbin, d.adrelid) AS def
          FROM pg_attrdef d
          JOIN pg_class c ON c.oid = d.adrelid
          JOIN pg_attribute a ON a.attrelid = d.adrelid AND a.attnum = d.adnum
-        WHERE a.attname = 'projection_owner'
+        WHERE a.attname IN ('projection_owner', 'projectionOwner')
+           OR pg_get_expr(d.adbin, d.adrelid) ILIKE '%projection_owner%'
+           OR pg_get_expr(d.adbin, d.adrelid) ILIKE '%projectionOwner%'
        UNION ALL
        SELECT viewname AS name, definition AS def
          FROM pg_views
-        WHERE schemaname = 'public' AND definition ILIKE '%projection_owner%'
+        WHERE schemaname = 'public'
+          AND (definition ILIKE '%projection_owner%' OR definition ILIKE '%projectionOwner%')
        UNION ALL
        SELECT indexname AS name, indexdef AS def
          FROM pg_indexes
-        WHERE schemaname = 'public' AND indexdef ILIKE '%projection_owner%'
+        WHERE schemaname = 'public'
+          AND (indexdef ILIKE '%projection_owner%' OR indexdef ILIKE '%projectionOwner%')
        UNION ALL
        SELECT policyname AS name, COALESCE(qual, '') || COALESCE(with_check, '') AS def
          FROM pg_policies
         WHERE schemaname = 'public'
-          AND (COALESCE(qual, '') || COALESCE(with_check, '')) ILIKE '%projection_owner%'
+          AND ((COALESCE(qual, '') || COALESCE(with_check, '')) ILIKE '%projection_owner%'
+            OR (COALESCE(qual, '') || COALESCE(with_check, '')) ILIKE '%projectionOwner%')
        ORDER BY 1`,
     )
     others = otherRows.rows.map((row) => ({ name: String(row.name), def: String(row.def) }))
@@ -202,18 +218,45 @@ describeIfDatabase('W7-1a-M provenance widening — live catalogue + real Postgr
     expect(others.map((o) => o.name)).toContain('attendance_records.projection_owner.default')
   })
 
-  it('the pointer-guard trigger WHEN clauses FIRE for w4_group (legacy-polarity)', () => {
-    for (const name of ['trg_ar_pointer_guard_ins', 'trg_ar_pointer_guard_upd']) {
-      const trigger = others.find((o) => o.name === name)
-      expect(trigger, `trigger not derived: ${name}`).toBeDefined()
-      const def = String(trigger?.def)
-      // `IS DISTINCT FROM 'legacy_untracked'` is true for every other member, so
-      // the guard fires for `w4_group` exactly as it fires for `w4`.
-      expect(def).toContain("IS DISTINCT FROM 'legacy_untracked'")
-      // Negative control: a `= 'w4'`-polarity WHEN clause would NOT fire for the
-      // new member, silently bypassing the guard for exactly it.
-      expect(quotedW4(def)).toBe(false)
-    }
+  it('the pointer guard actually FIRES for a w4_group row (behavioural, not textual)', async () => {
+    // A TEXT check on the WHEN clause is not enough: a rewrite such as
+    // `… AND NEW.projection_owner <> 'w4_group'` keeps the
+    // `IS DISTINCT FROM 'legacy_untracked'` substring and contains no `'w4'`,
+    // so it passes any text assertion while genuinely stopping the guard from
+    // firing for exactly the new member. The only assertion that discriminates
+    // is constructing the row the guard MUST refuse and requiring the refusal.
+    const { recordId, calcId } = await seedPointerOwningRecord()
+    await pool.query(
+      `UPDATE attendance_records
+          SET projection_owner = $2, current_calculation_id = $3::uuid,
+              status = 'normal', work_minutes = 480, late_minutes = 0, early_leave_minutes = 0,
+              visibility_state = 'active', visibility_reason = 'active'
+        WHERE id = $1::uuid`,
+      [recordId, NEW_OWNER, calcId],
+    )
+    // Daily-field drift against the pointed-at snapshot: the guard's own
+    // invariant. If the WHEN clause did not fire for `w4_group`, this is ADMITTED.
+    await expect(
+      pool.query(`UPDATE attendance_records SET work_minutes = 481 WHERE id = $1::uuid`, [recordId]),
+      'pointer guard did not fire for a w4_group row — the WHEN clause bypasses the new member',
+    ).rejects.toThrow(/W4C0_POINTER/)
+
+    // Positive control on the SAME assertion with the pre-existing member, so a
+    // green above cannot be "this UPDATE always fails for some other reason".
+    const control = await seedPointerOwningRecord()
+    await pool.query(
+      `UPDATE attendance_records
+          SET projection_owner = 'w4', current_calculation_id = $2::uuid,
+              status = 'normal', work_minutes = 480, late_minutes = 0, early_leave_minutes = 0,
+              visibility_state = 'active', visibility_reason = 'active'
+        WHERE id = $1::uuid`,
+      [control.recordId, control.calcId],
+    )
+    await expect(
+      pool.query(`UPDATE attendance_records SET work_minutes = 481 WHERE id = $1::uuid`, [
+        control.recordId,
+      ]),
+    ).rejects.toThrow(/W4C0_POINTER/)
   })
 
   it('every live catalogue object naming the domain is widened or has a satisfied rule', () => {
@@ -248,8 +291,11 @@ describeIfDatabase('W7-1a-M provenance widening — live catalogue + real Postgr
           }
           break
         case 'write_side_emitter':
-          // Not a test: it carries no comparison, so it routes nothing.
-          if (/[<>=]|IS DISTINCT|IN \(/.test(object.text.replace(/::text/g, ''))) {
+          // Not a test: it carries no comparison operator, so it routes nothing.
+          // `LIKE` is deparsed by Postgres as `~~`, so both spellings are listed
+          // — an absence-based predicate has to name every comparison form it
+          // means to exclude.
+          if (/[<>=]|~~|~|IS DISTINCT|IS NOT DISTINCT|\bIN \(|\bLIKE\b|\bANY\b/.test(object.text)) {
             violations.push(`write_side_emitter_failed: ${object.name}`)
           }
           break
@@ -312,6 +358,10 @@ describeIfDatabase('W7-1a-M provenance widening — live catalogue + real Postgr
   it('W4C3A_WITNESS coupled pointer disjunct (live text) puts w4_group on the NON-NULL side', async () => {
     const guard = functions.find((f) => f.name === 'attendance_w4c3a_restore_witness_command_guard')
     const marker = /->> 'projectionOwner' IN \(([^)]*)\)/
+    // Literal expectations FIRST: iterating the constant under test would go
+    // vacuously green if `w4_group` were ever dropped from that constant.
+    expect(await evaluateInList(String(guard?.src), marker, NEW_OWNER)).toBe(true)
+    expect(await evaluateInList(String(guard?.src), marker, 'w4')).toBe(true)
     for (const owner of ATTENDANCE_PROJECTION_OWNERS_WITH_CALCULATION_POINTER_V1) {
       expect(await evaluateInList(String(guard?.src), marker, owner)).toBe(true)
     }
@@ -322,6 +372,9 @@ describeIfDatabase('W7-1a-M provenance widening — live catalogue + real Postgr
   it('pointer-guard restore eligibility (live text) admits w4_group', async () => {
     const guard = functions.find((f) => f.name === 'attendance_w4_records_pointer_guard')
     const marker = /AND OLD\.projection_owner IN \(([^)]*)\)/
+    // Literal expectations FIRST — see the sibling leg above.
+    expect(await evaluateInList(String(guard?.src), marker, NEW_OWNER)).toBe(true)
+    expect(await evaluateInList(String(guard?.src), marker, 'w4')).toBe(true)
     for (const owner of ATTENDANCE_PROJECTION_OWNERS_WITH_CALCULATION_POINTER_V1) {
       expect(await evaluateInList(String(guard?.src), marker, owner)).toBe(true)
     }
@@ -468,7 +521,28 @@ describeIfDatabase('W7-1a-M provenance widening — live catalogue + real Postgr
     expect(rows[0].projection_owner).toBe('legacy_untracked')
   })
 
-  it('NOVEL values are still refused everywhere — the domain did not open generally', async () => {
+  it('NOVEL values are refused BY THE CLOSED-SET CHECK specifically (not by the pair)', async () => {
+    // Each novel value is inserted WITH a valid pointer, so `chk_ar_owner_pointer_pair`
+    // is satisfied and cannot cover for the closed-set CHECK. An alternation over
+    // both constraint names would go green here purely on the pair — the repo's
+    // documented 门级非排他 shape — so the expected name is pinned exactly.
+    for (const novel of ['w4_team', 'w5', 'group', 'W4_GROUP', 'w4_group_x', '']) {
+      const { recordId, calcId } = await seedPointerOwningRecord()
+      await expect(
+        pool.query(
+          `UPDATE attendance_records
+              SET projection_owner = $2, current_calculation_id = $3::uuid
+            WHERE id = $1::uuid`,
+          [recordId, novel, calcId],
+        ),
+        `novel value must be refused by chk_ar_projection_owner: ${JSON.stringify(novel)}`,
+      ).rejects.toThrow(/chk_ar_projection_owner/)
+    }
+  })
+
+  it('NOVEL values are refused on the INSERT path too', async () => {
+    // Pointer NULL here, so this leg is the pair-or-CHECK one by construction;
+    // the leg above is what pins the CHECK individually.
     for (const novel of ['w4_team', 'w5', 'group', 'W4_GROUP', 'w4_group_x', '']) {
       await expect(
         pool.query(

--- a/packages/core-backend/tests/unit/attendance-w7-1am-provenance-widening-completeness.test.ts
+++ b/packages/core-backend/tests/unit/attendance-w7-1am-provenance-widening-completeness.test.ts
@@ -52,8 +52,8 @@ describe('W7-1a-M provenance widening — derive-and-diff completeness', () => {
   it('non-vacuity: the derivation actually walked the tree', () => {
     expect(derivation.scannedFileCount).toBeGreaterThan(500)
     expect(derivation.anchoredFileCount).toBeGreaterThanOrEqual(10)
-    expect(derivation.sites.length).toBeGreaterThanOrEqual(80)
-    expect(W7_PROVENANCE_WIDENING_LEDGER_V1.length).toBeGreaterThanOrEqual(80)
+    expect(derivation.sites.length).toBeGreaterThanOrEqual(110)
+    expect(W7_PROVENANCE_WIDENING_LEDGER_V1.length).toBeGreaterThanOrEqual(100)
   })
 
   it('non-vacuity: the alias taint hop found real aliases', () => {
@@ -95,6 +95,7 @@ describe('W7-1a-M provenance widening — derive-and-diff completeness', () => {
       'legacy_polarity',
       'write_side_emitter',
       'null_default',
+      'single_member_selector',
       'domain_definition',
       'w7_0_recorded_snapshot',
     ]) {
@@ -203,6 +204,98 @@ describe('W7-1a-M provenance widening — derive-and-diff completeness', () => {
         (violation) => violation.kind === 'unledgered_site',
       ),
     ).toBe(true)
+  })
+
+  it('planted consumer: an un-widened consumer that names NO field spelling is still derived', () => {
+    // REGRESSION for the file-level anchor hole. Every other plant in this file
+    // spells `projection_owner`/`projectionOwner`, so all of them pre-satisfied
+    // the old anchor gate and none exercised this path. This one deliberately
+    // spells NEITHER: it is typed against the union, imports a predicate under a
+    // RENAMED local, folds silently, switches, and builds an un-widened SQL IN
+    // list. Four of the owner family's widening symbols do not contain any field
+    // spelling, so before the fix this derived ZERO sites while carrying a live
+    // silent downgrade of `w4_group` to `legacy_untracked`.
+    //
+    // `tsc` structurally cannot cover for this: a narrowing fold returns
+    // `'w4' | 'legacy_untracked'`, which is always assignable to the widened
+    // union, so widening can never make a narrowing consumer fail to compile.
+    const planted = scanPlanted(
+      'planted-unanchored.ts',
+      [
+        "import { isAttendanceProjectionOwnerWithCalculationPointerV1 as ownsPointer } from '../x'",
+        "import type { AttendanceProjectionOwnerV1 } from '../x'",
+        '',
+        'export function fold(raw: string): AttendanceProjectionOwnerV1 {',
+        "  return raw === 'w4' ? 'w4' : 'legacy_untracked'",
+        '}',
+        '',
+        'export function label(owner: AttendanceProjectionOwnerV1): string {',
+        '  switch (owner) {',
+        "    case 'w4':",
+        "      return 'W4'",
+        '    default:',
+        "      return 'legacy'",
+        '  }',
+        '}',
+        '',
+        'export function pointerOwned(owner: string): boolean {',
+        '  return ownsPointer(owner)',
+        '}',
+        '',
+        "export const SQL = `SELECT 1 WHERE owner IN ('w4', 'legacy_untracked')`",
+        '',
+      ].join('\n'),
+    )
+
+    // Negative control: the plant really does NOT name any field spelling, so it
+    // could only have been derived by the widened anchor set.
+    const source = planted.sites.map((site) => site.text).join('\n')
+    expect(/projection_owner|projectionOwner|PROJECTION_OWNERS/.test(source)).toBe(false)
+
+    expect(planted.sites.length).toBeGreaterThan(0)
+    expect(
+      diffProvenanceWideningV1(planted, W7_PROVENANCE_WIDENING_LEDGER_V1).some(
+        (violation) => violation.kind === 'unledgered_site',
+      ),
+    ).toBe(true)
+  })
+
+  it('planted consumer: an import-RENAMED widening symbol still anchors its call sites', () => {
+    // The rename hop on its own: the file anchors via the original symbol, but
+    // every call site spells only the local alias, so without the second taint
+    // hop the file anchored and no line was ever a site.
+    const planted = scanPlanted(
+      'planted-rename.ts',
+      [
+        "import { isAttendanceProjectionOwnerV1 as isKnownOwner } from '../x'",
+        '',
+        'export function check(value: string): boolean {',
+        '  return isKnownOwner(value)',
+        '}',
+        '',
+      ].join('\n'),
+    )
+    const callSites = planted.sites.filter((site) => site.text.includes('isKnownOwner'))
+    expect(callSites.length).toBeGreaterThan(0)
+  })
+
+  it('planted consumer: an AMBIGUOUS-member trace fold is derived (no distinctive fallback)', () => {
+    // The owner family is protected here only by luck — `legacy_untracked` is
+    // distinctive. The trace family has no distinctive fallback member, so a
+    // fold between two ambiguous members carries no distinctive literal at all
+    // and evaded the line rule inside an already-anchored file.
+    const planted = scanPlanted(
+      'planted-trace-fold.ts',
+      [
+        'export function foldKind(k: string): AttendanceDecisionTraceSourceKind {',
+        "  return k === 'record' ? 'record' : 'snapshot'",
+        '}',
+        '',
+      ].join('\n'),
+    )
+    const foldSites = planted.sites.filter((site) => site.text.includes('record'))
+    expect(foldSites.length).toBeGreaterThan(0)
+    expect(foldSites.every((site) => !site.text.includes('group_policy_snapshot'))).toBe(true)
   })
 
   it('planted consumer: a stale ledger entry (construct removed) REDS the diff', () => {

--- a/packages/core-backend/tests/unit/attendance-w7-1am-provenance-widening-completeness.test.ts
+++ b/packages/core-backend/tests/unit/attendance-w7-1am-provenance-widening-completeness.test.ts
@@ -218,6 +218,115 @@ describe('W7-1a-M provenance widening — derive-and-diff completeness', () => {
   })
 })
 
+describe('W7-1a-M provenance widening — superseding plpgsql body fidelity', () => {
+  // The slice hand-carries ~500 lines of plpgsql into a new migration. Nothing
+  // else in the tree proves those bodies are the historical ones plus ONLY the
+  // derived substitutions: the catalogue rule is satisfied by the mere presence
+  // of `w4_group`, and the neighbouring import-rollback suite re-applies 0725 +
+  // 0731 in its own `beforeAll`, so it exercises the 0731 body, not this one.
+  //
+  // Deliberately a SOURCE-TEXT diff of the two migration FILES, not a `prosrc`
+  // comparison: the ambient catalogue body is order-dependent (sibling suites
+  // replay historical migrations), and importing a migration yields `up`/`down`
+  // functions rather than the SQL string.
+  const HISTORICAL = 'packages/core-backend/src/db/migrations/zzzz20260731120000_w4c3a_import_rollback_foundation.ts'
+  const WIDENING = 'packages/core-backend/src/db/migrations/zzzz20260815120000_w7_1am_provenance_domain_widening.ts'
+
+  /** The `$fn$ … $fn$` body of `name` within one migration section. */
+  function functionBody(section: string, name: string): string {
+    const at = section.indexOf(`CREATE OR REPLACE FUNCTION ${name}()`)
+    expect(at, `definition not found: ${name}`).toBeGreaterThan(-1)
+    const open = section.indexOf('$fn$', at)
+    const close = section.indexOf('$fn$', open + 4)
+    expect(open, `body open delimiter not found: ${name}`).toBeGreaterThan(-1)
+    expect(close, `body close delimiter not found: ${name}`).toBeGreaterThan(open)
+    return section.slice(open + 4, close)
+  }
+
+  function sections(relPath: string): { up: string; down: string } {
+    const source = fs.readFileSync(path.join(repoRoot, relPath), 'utf8')
+    const boundary = source.indexOf('export async function down(')
+    expect(boundary, `down() boundary not found in ${relPath}`).toBeGreaterThan(-1)
+    return { up: source.slice(0, boundary), down: source.slice(boundary) }
+  }
+
+  /** The complete, derived set of substitutions this slice applies. */
+  const SUBSTITUTIONS: ReadonlyArray<{ fn: string; from: string; to: string }> = [
+    {
+      fn: 'attendance_w4_records_pointer_guard',
+      from: "AND OLD.projection_owner = 'w4'",
+      to: "AND OLD.projection_owner IN ('w4', 'w4_group')",
+    },
+    {
+      fn: 'attendance_w4c3a_restore_witness_command_guard',
+      from: "->> 'projectionOwner' NOT IN ('legacy_untracked', 'w4')",
+      to: "->> 'projectionOwner' NOT IN ('legacy_untracked', 'w4', 'w4_group')",
+    },
+    {
+      fn: 'attendance_w4c3a_restore_witness_command_guard',
+      from: "(reversed.parent_preimage_snapshot ->> 'projectionOwner' = 'w4'",
+      to: "(reversed.parent_preimage_snapshot ->> 'projectionOwner' IN ('w4', 'w4_group')",
+    },
+  ]
+
+  const FUNCTIONS = [
+    'attendance_w4_records_pointer_guard',
+    'attendance_w4c3a_restore_witness_command_guard',
+  ] as const
+
+  function applySubstitutions(fn: string, body: string): string {
+    let out = body
+    for (const substitution of SUBSTITUTIONS.filter((s) => s.fn === fn)) {
+      const parts = out.split(substitution.from)
+      // Exactly one occurrence — the same guarantee the generator enforced.
+      expect(parts.length, `substitution matched ${parts.length - 1}x in ${fn}: ${substitution.from}`).toBe(2)
+      out = parts.join(substitution.to)
+    }
+    return out
+  }
+
+  it('up(): each superseding body is the historical body plus ONLY the derived substitutions', () => {
+    const historical = sections(HISTORICAL).up
+    const widened = sections(WIDENING).up
+    for (const fn of FUNCTIONS) {
+      const before = functionBody(historical, fn)
+      const after = functionBody(widened, fn)
+      expect(applySubstitutions(fn, before), `${fn} carries an unaccounted change`).toBe(after)
+    }
+  })
+
+  it('down(): each restored body is BYTE-IDENTICAL to the historical body', () => {
+    const historical = sections(HISTORICAL).up
+    const restored = sections(WIDENING).down
+    for (const fn of FUNCTIONS) {
+      expect(functionBody(restored, fn)).toBe(functionBody(historical, fn))
+    }
+  })
+
+  it('non-vacuity: the extraction is real and the diff actually discriminates', () => {
+    const historical = sections(HISTORICAL).up
+    const widened = sections(WIDENING).up
+    for (const fn of FUNCTIONS) {
+      const before = functionBody(historical, fn)
+      const after = functionBody(widened, fn)
+      // The bodies are substantial, and exactly one side is widened.
+      expect(before.length).toBeGreaterThan(500)
+      expect(before).not.toContain('w4_group')
+      expect(after).toContain('w4_group')
+      // Only ONE definition was captured, not a neighbour swallowed with it.
+      expect(before.split('CREATE OR REPLACE FUNCTION')).toHaveLength(1)
+      expect(after.split('CREATE OR REPLACE FUNCTION')).toHaveLength(1)
+      // Positive control: a one-character stray edit anywhere else in the body
+      // MUST break the equality this test rests on. `RAISE EXCEPTION` appears in
+      // both guards, so the anchor is real for each (asserted, not assumed).
+      expect(after, `no anchor to tamper with in ${fn}`).toContain('RAISE EXCEPTION')
+      const tampered = after.replace('RAISE EXCEPTION', 'RAISE  EXCEPTION')
+      expect(tampered).not.toBe(after)
+      expect(applySubstitutions(fn, before)).not.toBe(tampered)
+    }
+  })
+})
+
 describe('W7-1a-M provenance widening — domain semantics', () => {
   it('the widened owner domain is exactly the pre-widening set plus w4_group', () => {
     expect([...ATTENDANCE_PROJECTION_OWNERS_V1]).toEqual(['legacy_untracked', 'w4', 'w4_group'])

--- a/packages/core-backend/tests/unit/attendance-w7-1am-provenance-widening-completeness.test.ts
+++ b/packages/core-backend/tests/unit/attendance-w7-1am-provenance-widening-completeness.test.ts
@@ -15,7 +15,9 @@ import * as os from 'node:os'
 import * as path from 'node:path'
 import { describe, expect, it } from 'vitest'
 import {
+  ATTENDANCE_PROJECTION_OWNERS_SQL_LIST_V1,
   ATTENDANCE_PROJECTION_OWNERS_V1,
+  ATTENDANCE_PROJECTION_OWNERS_WITH_CALCULATION_POINTER_SQL_LIST_V1,
   ATTENDANCE_PROJECTION_OWNERS_WITH_CALCULATION_POINTER_V1,
   ATTENDANCE_TRACE_SOURCE_KINDS_V1,
   isAttendanceProjectionOwnerV1,
@@ -170,6 +172,39 @@ describe('W7-1a-M provenance widening — derive-and-diff completeness', () => {
     ).toBe(true)
   })
 
+  it('planted consumer: an exhaustive SWITCH arm is derived even though it names no field', () => {
+    // A `case 'w4':` line mentions neither the column nor an alias, and `'w4'` is
+    // an AMBIGUOUS member — so the anchor rule alone would make this whole
+    // consumer class invisible. This is the class that actually exists in
+    // `apps/web` for the trace family, where it was caught only because
+    // `policy_gate` happens to be distinctive. Owner-family switches have no such
+    // luck, hence the dedicated case-arm rule.
+    const planted = scanPlanted(
+      'planted-switch.ts',
+      [
+        'export function label(projectionOwner: string): string {',
+        '  switch (projectionOwner) {',
+        "    case 'w4':",
+        "      return 'W4 owned'",
+        '    default:',
+        "      return 'other'",
+        '  }',
+        '}',
+        '',
+      ].join('\n'),
+    )
+    const arms = planted.sites.filter((site) => site.text.startsWith('case '))
+    expect(arms.length).toBeGreaterThan(0)
+    // Negative control: the arm really does NOT name the field, so it could only
+    // have been derived by the case-arm rule.
+    expect(arms.every((site) => !/projection_owner|projectionOwner/.test(site.text))).toBe(true)
+    expect(
+      diffProvenanceWideningV1(planted, W7_PROVENANCE_WIDENING_LEDGER_V1).some(
+        (violation) => violation.kind === 'unledgered_site',
+      ),
+    ).toBe(true)
+  })
+
   it('planted consumer: a stale ledger entry (construct removed) REDS the diff', () => {
     const violations = diffProvenanceWideningV1(derivation, [
       ...W7_PROVENANCE_WIDENING_LEDGER_V1,
@@ -206,6 +241,27 @@ describe('W7-1a-M provenance widening — domain semantics', () => {
       expect(isAttendanceProjectionOwnerV1(novel)).toBe(false)
       expect(isAttendanceProjectionOwnerWithCalculationPointerV1(novel)).toBe(false)
     }
+  })
+
+  it('the SQL literal lists render exactly the widened members', () => {
+    // `w4c3a-import-rollback-boundary.ts` interpolates the second constant into a
+    // query, so its rendered text IS the deployed predicate. Pinned here because
+    // a malformed list would only surface at query time.
+    expect(ATTENDANCE_PROJECTION_OWNERS_SQL_LIST_V1).toBe("'legacy_untracked', 'w4', 'w4_group'")
+    expect(ATTENDANCE_PROJECTION_OWNERS_WITH_CALCULATION_POINTER_SQL_LIST_V1).toBe("'w4', 'w4_group'")
+  })
+
+  it('the interpolated closure predicate appears verbatim in the boundary query', () => {
+    const source = fs.readFileSync(
+      path.join(repoRoot, 'packages/core-backend/src/attendance/w4c3a-import-rollback-boundary.ts'),
+      'utf8',
+    )
+    expect(source).toContain(
+      'projection_owner IN (${ATTENDANCE_PROJECTION_OWNERS_WITH_CALCULATION_POINTER_SQL_LIST_V1})',
+    )
+    // Negative control: the pre-widening spelling is gone, so this is not a
+    // substring that would match either way.
+    expect(source).not.toContain("projection_owner = 'w4'")
   })
 
   it('the web app trace source-kind copy is member-equal to the backend domain', () => {

--- a/packages/core-backend/tests/unit/attendance-w7-1am-provenance-widening-completeness.test.ts
+++ b/packages/core-backend/tests/unit/attendance-w7-1am-provenance-widening-completeness.test.ts
@@ -1,0 +1,226 @@
+/**
+ * W7-1a-M (#4556) — the LOAD-BEARING completeness test.
+ *
+ * Ratified per #4556 comments 5293034619 + 5293478713, whose 执行序 makes a
+ * "derive-and-diff 完备性测试" the承重 deliverable for this slice: walk the
+ * derived consumer table and assert every point is widened — 漏一点即红.
+ *
+ * The source-text surface is checked here. The DB surface is checked in
+ * `../integration/attendance-w7-1am-provenance-widening.db.test.ts`, derived
+ * from the live catalogue rather than from migration text (see that file and the
+ * scanner's header for why migration text cannot be the source of truth).
+ */
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import { describe, expect, it } from 'vitest'
+import {
+  ATTENDANCE_PROJECTION_OWNERS_V1,
+  ATTENDANCE_PROJECTION_OWNERS_WITH_CALCULATION_POINTER_V1,
+  ATTENDANCE_TRACE_SOURCE_KINDS_V1,
+  isAttendanceProjectionOwnerV1,
+  isAttendanceProjectionOwnerWithCalculationPointerV1,
+} from '../../src/attendance/w7-provenance-domain'
+import {
+  W7_PROVENANCE_WIDENING_LEDGER_V1,
+  deriveProvenanceWideningSurfaceV1,
+  diffProvenanceWideningV1,
+  resolveRepoRootV1,
+  type W7DerivedSiteV1,
+} from '../utils/w7-provenance-widening-scan'
+
+const repoRoot = resolveRepoRootV1()
+const derivation = deriveProvenanceWideningSurfaceV1({ repoRoot })
+
+function sitesIn(fileSuffix: string): W7DerivedSiteV1[] {
+  return derivation.sites.filter((site) => site.file.endsWith(fileSuffix))
+}
+
+describe('W7-1a-M provenance widening — derive-and-diff completeness', () => {
+  it('every derived site is widened or carries a satisfied neutrality rule', () => {
+    const violations = diffProvenanceWideningV1(derivation, W7_PROVENANCE_WIDENING_LEDGER_V1)
+    expect(violations.map((violation) => `${violation.kind}: ${violation.detail}`)).toEqual([])
+  })
+
+  // -------------------------------------------------------------------------
+  // Non-vacuity. A derivation that found nothing would pass the diff trivially,
+  // so the shape of what it found is asserted, not just the empty violation set.
+  // -------------------------------------------------------------------------
+
+  it('non-vacuity: the derivation actually walked the tree', () => {
+    expect(derivation.scannedFileCount).toBeGreaterThan(500)
+    expect(derivation.anchoredFileCount).toBeGreaterThanOrEqual(10)
+    expect(derivation.sites.length).toBeGreaterThanOrEqual(80)
+    expect(W7_PROVENANCE_WIDENING_LEDGER_V1.length).toBeGreaterThanOrEqual(80)
+  })
+
+  it('non-vacuity: the alias taint hop found real aliases', () => {
+    // `owner` (w4c2-authoritative-calculation-core) and `projectionOwner`
+    // (the `projection_owner AS "projectionOwner"` SQL rename + local consts).
+    expect(derivation.aliasIdentifiers).toContain('owner')
+    expect(derivation.aliasIdentifiers).toContain('projectionOwner')
+  })
+
+  it('non-vacuity: the derivation covers every kind of consumer the ruling names', () => {
+    // TS union.
+    expect(sitesIn('src/services/AttendanceDecisionTrace.ts').length).toBeGreaterThan(0)
+    // TS closed-set array behind a runtime `isClosedValue` gate.
+    expect(sitesIn('src/services/AttendanceW4CalculationDetail.ts').length).toBeGreaterThan(0)
+    // Exhaustive validations (two independent copies) + the pointer derivation.
+    expect(sitesIn('src/attendance/w4c3a-import-rollback.ts').length).toBeGreaterThanOrEqual(5)
+    // Silent-downgrade folds — the sites that contain NO target string.
+    expect(sitesIn('src/attendance/w4c2-authoritative-calculation-core.ts').length).toBeGreaterThan(0)
+    expect(sitesIn('src/attendance/w4c2-live-scheduled-boundary.ts').length).toBeGreaterThan(0)
+    // SQL embedded in TS.
+    expect(sitesIn('src/attendance/w4c3a-import-rollback-boundary.ts').length).toBeGreaterThan(0)
+    // OpenAPI enum.
+    expect(sitesIn('packages/openapi/src/base.yml').length).toBeGreaterThan(0)
+    // The web app's INDEPENDENT copy: closed array + exhaustive switch. The W7-0
+    // record asserted no exhaustive consumer of this union existed anywhere —
+    // the derivation refutes that, which is why enumeration was refused.
+    expect(sitesIn('apps/web/src/views/attendance/attendanceDecisionTrace.ts').length).toBeGreaterThanOrEqual(6)
+    // Ops scripts.
+    expect(sitesIn('scripts/ops/staging-attendance-tooling-teardown.mjs').length).toBeGreaterThan(0)
+  })
+
+  it('non-vacuity: every ledger rule name is actually exercised', () => {
+    const used = new Set(W7_PROVENANCE_WIDENING_LEDGER_V1.map((entry) => entry.rule))
+    for (const rule of [
+      'closed_set_member_list',
+      'exhaustive_switch_arm',
+      'widened_predicate',
+      'widened_predicate_continuation',
+      'legacy_polarity',
+      'write_side_emitter',
+      'null_default',
+      'domain_definition',
+      'w7_0_recorded_snapshot',
+    ]) {
+      expect(used).toContain(rule)
+    }
+  })
+
+  // -------------------------------------------------------------------------
+  // Planted consumers. The diff must RED on an un-widened consumer, and the
+  // scanner must SEE a consumer that contains no target string at all.
+  // -------------------------------------------------------------------------
+
+  function scanPlanted(fileName: string, source: string) {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'w7-1am-planted-'))
+    try {
+      fs.mkdirSync(path.join(dir, 'planted'), { recursive: true })
+      fs.writeFileSync(path.join(dir, 'planted', fileName), source, 'utf8')
+      return deriveProvenanceWideningSurfaceV1({ repoRoot: dir, roots: ['planted'] })
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true })
+    }
+  }
+
+  it('planted consumer: an un-widened membership test is derived and REDS the diff', () => {
+    const planted = scanPlanted(
+      'planted-consumer.ts',
+      [
+        'export function parse(row: { projection_owner: string }) {',
+        "  if (row.projection_owner !== 'legacy_untracked' && row.projection_owner !== 'w4') {",
+        "    throw new Error('unsupported')",
+        '  }',
+        '  return row.projection_owner',
+        '}',
+        '',
+      ].join('\n'),
+    )
+    expect(planted.sites.length).toBeGreaterThan(0)
+
+    // Against the real ledger it is unledgered; that alone must fail.
+    const violations = diffProvenanceWideningV1(planted, W7_PROVENANCE_WIDENING_LEDGER_V1)
+    expect(violations.some((violation) => violation.kind === 'unledgered_site')).toBe(true)
+
+    // And even if someone ledgers it as widened, the evidence check still fails —
+    // so the ledger cannot be used to wave a real gap through.
+    const ledgered = diffProvenanceWideningV1(
+      planted,
+      planted.sites.map((site) => ({
+        file: site.file,
+        text: site.text,
+        rule: 'widened_predicate' as const,
+      })),
+    )
+    expect(ledgered.some((violation) => violation.kind === 'not_widened')).toBe(true)
+  })
+
+  it('planted consumer: a SILENT-DOWNGRADE fold containing no target string is still derived', () => {
+    // This is the shape the ratification calls out: no `w4_group` anywhere in it,
+    // so any derivation that grepped for the new value would miss it entirely.
+    const planted = scanPlanted(
+      'planted-fold.ts',
+      [
+        'export function fold(row: { projection_owner: string }) {',
+        "  return { projectionOwner: row.projection_owner === 'w4' ? 'w4' : 'legacy_untracked' }",
+        '}',
+        '',
+      ].join('\n'),
+    )
+    const foldSites = planted.sites.filter((site) => site.text.includes('legacy_untracked'))
+    expect(foldSites.length).toBeGreaterThan(0)
+    expect(foldSites.every((site) => !site.text.includes('w4_group'))).toBe(true)
+    expect(
+      diffProvenanceWideningV1(planted, W7_PROVENANCE_WIDENING_LEDGER_V1).some(
+        (violation) => violation.kind === 'unledgered_site',
+      ),
+    ).toBe(true)
+  })
+
+  it('planted consumer: a stale ledger entry (construct removed) REDS the diff', () => {
+    const violations = diffProvenanceWideningV1(derivation, [
+      ...W7_PROVENANCE_WIDENING_LEDGER_V1,
+      {
+        file: 'packages/core-backend/src/attendance/w7-provenance-domain.ts',
+        text: "const THIS_CONSTRUCT_DOES_NOT_EXIST = 'legacy_untracked'",
+        rule: 'domain_definition',
+      },
+    ])
+    expect(violations.some((violation) => violation.kind === 'stale_ledger_entry')).toBe(true)
+  })
+})
+
+describe('W7-1a-M provenance widening — domain semantics', () => {
+  it('the widened owner domain is exactly the pre-widening set plus w4_group', () => {
+    expect([...ATTENDANCE_PROJECTION_OWNERS_V1]).toEqual(['legacy_untracked', 'w4', 'w4_group'])
+  })
+
+  it('w4_group inherits w4 NON-NULL pointer semantics; legacy_untracked is the only NULL member', () => {
+    expect([...ATTENDANCE_PROJECTION_OWNERS_WITH_CALCULATION_POINTER_V1]).toEqual(['w4', 'w4_group'])
+    expect(isAttendanceProjectionOwnerWithCalculationPointerV1('w4_group')).toBe(true)
+    expect(isAttendanceProjectionOwnerWithCalculationPointerV1('w4')).toBe(true)
+    expect(isAttendanceProjectionOwnerWithCalculationPointerV1('legacy_untracked')).toBe(false)
+    // Every member is either pointer-owning or the single NULL-pointer member.
+    for (const owner of ATTENDANCE_PROJECTION_OWNERS_V1) {
+      expect(isAttendanceProjectionOwnerWithCalculationPointerV1(owner)).toBe(
+        owner !== 'legacy_untracked',
+      )
+    }
+  })
+
+  it('the widening does NOT open the domain generally', () => {
+    for (const novel of ['w4_team', 'w5', 'group', '', 'W4_GROUP', 'w4_group ', null, undefined, 7]) {
+      expect(isAttendanceProjectionOwnerV1(novel)).toBe(false)
+      expect(isAttendanceProjectionOwnerWithCalculationPointerV1(novel)).toBe(false)
+    }
+  })
+
+  it('the web app trace source-kind copy is member-equal to the backend domain', () => {
+    // apps/web cannot import backend source, so equality is held by this test.
+    const webFile = path.join(
+      repoRoot,
+      'apps/web/src/views/attendance/attendanceDecisionTrace.ts',
+    )
+    const source = fs.readFileSync(webFile, 'utf8')
+    const block = /export const ATTENDANCE_TRACE_SOURCE_KINDS = \[([\s\S]*?)\] as const/.exec(source)
+    expect(block).not.toBeNull()
+    const webMembers = [...(block as RegExpExecArray)[1].matchAll(/'([a-z_0-9]+)'/g)].map((m) => m[1])
+    expect(webMembers).toEqual([...ATTENDANCE_TRACE_SOURCE_KINDS_V1])
+    // Negative control: the parse really extracted members, not an empty match.
+    expect(webMembers).toContain('group_policy_snapshot')
+    expect(webMembers.length).toBeGreaterThanOrEqual(7)
+  })
+})

--- a/packages/core-backend/tests/unit/w7-w6r5-guard/classification.ts
+++ b/packages/core-backend/tests/unit/w7-w6r5-guard/classification.ts
@@ -122,6 +122,7 @@ export const ATTENDANCE_W7_CALCULATION_PATH_FILES_V1: readonly string[] = Object
   'packages/core-backend/src/attendance/w6-group-effective-policy-response-contract.ts',
   'packages/core-backend/src/attendance/w7-context-source-posture-contract.ts',
   'packages/core-backend/src/attendance/w7-frozen-context-v2-contract.ts',
+  'packages/core-backend/src/attendance/w7-provenance-domain.ts',
   'packages/core-backend/src/attendance/w7-read-side-provenance-amendment.ts',
   'packages/core-backend/src/attendance/w7-resolver/w7-composite-lock-order.ts',
   'packages/core-backend/src/attendance/w7-resolver/w7-context-source-posture-resolver.ts',

--- a/packages/core-backend/tests/utils/w7-provenance-widening-scan.ts
+++ b/packages/core-backend/tests/utils/w7-provenance-widening-scan.ts
@@ -11,11 +11,17 @@
  * Why derivation is not "grep for the new value": the silent-downgrade folds
  * (`row.projection_owner === 'w4' ? 'w4' : 'legacy_untracked'`) contain NO
  * target string at all. So the anchor is the READER — a file that references the
- * column/field — and within an anchored file every line carrying a domain
- * literal OR a widening symbol is a derived site.
+ * family at all — and within an anchored file every line carrying a domain
+ * literal, a widening symbol, or a `case` arm is a derived site.
+ *
+ * A file counts as referencing the family if it names ANY member of the three
+ * lists this module already derives (field spellings, widening symbols,
+ * distinctive literals) — see `familyIsReferencedBy`. Anchoring on the field
+ * spellings alone left a consumer typed against the widened union, spelling no
+ * column name, completely invisible.
  *
  * SCOPE — source text only. The DB surface is derived SEPARATELY, from the live
- * catalogue (`pg_constraint` / `pg_proc`) in
+ * catalogue in
  * `tests/integration/attendance-w7-1am-provenance-widening.db.test.ts`. Migration
  * FILES are deliberately excluded from this scan: `attendance_w4_records_pointer_guard`
  * is defined in zzzz20260725120000 and then REPLACED by zzzz20260731120000, so
@@ -176,6 +182,33 @@ function listFiles(root: string, repoRoot: string, out: string[]): void {
 }
 
 /**
+ * FILE-LEVEL anchoring: does this file reference the family AT ALL?
+ *
+ * This gate short-circuits before any line rule, so anything it misses is
+ * invisible to the whole derivation. It therefore anchors on EVERY list this
+ * module already derives — the field/column spellings, the widening symbols,
+ * and the family's distinctive literals — rather than on the field spellings
+ * alone. That matters because four of the owner family's widening symbols do
+ * NOT contain any field spelling (`AttendanceProjectionOwnerV1`,
+ * `isAttendanceProjectionOwnerV1`,
+ * `isAttendanceProjectionOwnerWithCalculationPointerV1`,
+ * `ATTENDANCE_W7_PROJECTION_OWNER_GROUP_VALUE_V1` — capital `P`, or no trailing
+ * `S`), so a consumer typed against the union and spelling no column name used
+ * to evade the derivation entirely. The trace family had no such asymmetry,
+ * which is exactly what made the owner-family hole detectable.
+ *
+ * This is reuse, not enumeration: all three lists are derived from the widening
+ * itself, so the gate widens automatically whenever the widening does.
+ */
+function familyIsReferencedBy(family: W7ProvenanceFamily, source: string): boolean {
+  return (
+    FAMILY_ANCHORS[family].some((anchor) => source.includes(anchor)) ||
+    FAMILY_WIDENING_SYMBOLS[family].some((symbol) => source.includes(symbol)) ||
+    FAMILY_DISTINCTIVE_LITERALS[family].some((literal) => source.includes(literal))
+  )
+}
+
+/**
  * One taint hop: identifiers bound to a read of the column/field. Kept
  * FILE-LOCAL on purpose — a bare `owner` is far too generic to anchor globally.
  */
@@ -196,6 +229,27 @@ export function deriveAliasIdentifiersV1(source: string): string[] {
     }
   }
   return [...aliases].sort()
+}
+
+/**
+ * Second taint hop: `import { isAttendanceProjectionOwnerV1 as ownsPointer }`.
+ * The file-level gate sees the original symbol, but every CALL SITE then spells
+ * only the renamed local — so without this hop the file anchors and no line is
+ * ever a site. The renamed local is treated as a widening symbol FOR THAT FILE.
+ */
+export function deriveRenamedWideningSymbolsV1(
+  source: string,
+  symbols: readonly string[],
+): string[] {
+  const renamed = new Set<string>()
+  for (const symbol of symbols) {
+    const re = new RegExp(`\\b${symbol}\\s+as\\s+([A-Za-z_$][\\w$]*)`, 'g')
+    let m: RegExpExecArray | null
+    while ((m = re.exec(source)) !== null) {
+      if (m[1]) renamed.add(m[1])
+    }
+  }
+  return [...renamed].sort()
 }
 
 function literalRegex(members: readonly string[], isYaml: boolean): RegExp {
@@ -245,7 +299,7 @@ export function deriveProvenanceWideningSurfaceV1(
     const rel = path.relative(repoRoot, file).split(path.sep).join('/')
     const isYaml = /\.ya?ml$/.test(file)
     const families = (Object.keys(FAMILY_ANCHORS) as W7ProvenanceFamily[]).filter((family) =>
-      FAMILY_ANCHORS[family].some((anchor) => source.includes(anchor)),
+      familyIsReferencedBy(family, source),
     )
     if (families.length === 0) continue
     anchoredFileCount += 1
@@ -256,8 +310,20 @@ export function deriveProvenanceWideningSurfaceV1(
     for (const family of families) {
       const distinctive = literalRegex(FAMILY_DISTINCTIVE_LITERALS[family], isYaml)
       const ambiguous = literalRegex(FAMILY_AMBIGUOUS_LITERALS[family], isYaml)
-      const anchorTokens = family === 'projection_owner' ? aliasTokens : FAMILY_ANCHORS[family]
-      const symbols = FAMILY_WIDENING_SYMBOLS[family]
+      // The trace family's LINE-level anchors include the field spellings, not
+      // just the type names: a fold built only from AMBIGUOUS members
+      // (`k === 'record' ? 'record' : 'snapshot'`) names no type and carries no
+      // distinctive member, so without these it would evade the line rule inside
+      // an already-anchored file. The owner family is protected here only
+      // because `legacy_untracked` happens to be distinctive.
+      const anchorTokens =
+        family === 'projection_owner'
+          ? aliasTokens
+          : [...FAMILY_ANCHORS[family], 'source.kind', 'sourceKind', 'traceSourceKind']
+      const symbols = [
+        ...FAMILY_WIDENING_SYMBOLS[family],
+        ...deriveRenamedWideningSymbolsV1(source, FAMILY_WIDENING_SYMBOLS[family]),
+      ]
       const newValue = W7_NEW_VALUES_V1[family]
       // An `import` names a symbol; it does not gate, branch on, or emit a
       // value, so it is not a consumer site.
@@ -272,7 +338,13 @@ export function deriveProvenanceWideningSurfaceV1(
         if (inImportBlock || /^\s*import\b/.test(text)) continue
         if (isCommentLine(text)) continue
         const hasWideningSymbol = symbols.some((symbol) => text.includes(symbol))
-        const namesTarget = anchorTokens.some((token) => new RegExp(`\\b${token}\\b`).test(text))
+        // Evaluated over the enclosing DECLARATION, not the line. A fold's
+        // return expression names the value but not the subject — the subject is
+        // in the signature (`function foldKind(k: string): AttendanceDecisionTraceSourceKind`).
+        // Line-scoping this check is what let an ambiguous-member fold hide.
+        const namesTarget = anchorTokens.some((token) =>
+          new RegExp(`\\b${token.replace('.', '\\.')}\\b`).test(enclosingDeclaration(lines, i)),
+        )
         // A `switch` arm names the value but never the subject — see CASE_ARM.
         const caseArm = CASE_ARM.exec(text)
         const isFamilyCaseArm =
@@ -339,6 +411,13 @@ export type W7RuleName =
   | 'write_side_emitter'
   /** `?? 'legacy_untracked'` on a NOT NULL column: a null-default, not a fold. */
   | 'null_default'
+  /**
+   * An equality that SELECTS one named member (`env.source.kind === 'audit'`)
+   * rather than enumerating the set. Widening cannot change its verdict for any
+   * pre-existing value, and the new member correctly fails to be selected — a
+   * `group_policy_snapshot` env is not an `audit` env.
+   */
+  | 'single_member_selector'
   /** The recorded W7-0 snapshot of a live set (kept equal by the tsc sync guards). */
   | 'w7_0_recorded_snapshot'
   /**
@@ -449,6 +528,20 @@ function neutralPredicateHolds(rule: W7RuleName, site: W7DerivedSiteV1): boolean
       // `?? 'legacy_untracked'` fires only on SQL NULL (the column is NOT NULL);
       // it passes every real value through unchanged, so it cannot downgrade.
       return text.includes('??') && !hasComparison(text)
+    case 'single_member_selector': {
+      // Must be a POSITIVE equality naming exactly ONE member. A negation, or
+      // more than one member on the line, is an exclusion/enumeration and must
+      // be adjudicated as a real predicate instead.
+      const members = [
+        ...FAMILY_DISTINCTIVE_LITERALS[site.family],
+        ...FAMILY_AMBIGUOUS_LITERALS[site.family],
+      ].filter((member) => new RegExp(`['"\`]${member}['"\`]`).test(text))
+      return (
+        members.length === 1 &&
+        /===|==|\bIS NOT DISTINCT\b/.test(text) &&
+        !/!==|!=|\bNOT IN\b|\bIS DISTINCT\b/.test(text)
+      )
+    }
     case 'domain_definition':
       // Only the domain module may claim this rule, so it cannot be used to
       // excuse an un-widened consumer anywhere else in the tree.
@@ -522,9 +615,13 @@ export function diffProvenanceWideningV1(
  * edits above a site do not churn this list.
  */
 export const W7_PROVENANCE_WIDENING_LEDGER_V1: readonly W7LedgerEntryV1[] = Object.freeze([
+  { file: 'apps/web/src/views/attendance/attendanceDecisionTrace.ts', text: '\'audit\',', rule: 'closed_set_member_list' },
   { file: 'apps/web/src/views/attendance/attendanceDecisionTrace.ts', text: '\'group_policy_snapshot\',', rule: 'closed_set_member_list' },
+  { file: 'apps/web/src/views/attendance/attendanceDecisionTrace.ts', text: '\'ledger\',', rule: 'closed_set_member_list' },
   { file: 'apps/web/src/views/attendance/attendanceDecisionTrace.ts', text: '\'policy_gate\',', rule: 'closed_set_member_list' },
+  { file: 'apps/web/src/views/attendance/attendanceDecisionTrace.ts', text: '\'record\',', rule: 'closed_set_member_list' },
   { file: 'apps/web/src/views/attendance/attendanceDecisionTrace.ts', text: '\'rule_live\',', rule: 'closed_set_member_list' },
+  { file: 'apps/web/src/views/attendance/attendanceDecisionTrace.ts', text: '\'snapshot\',', rule: 'closed_set_member_list' },
   { file: 'apps/web/src/views/attendance/attendanceDecisionTrace.ts', text: 'case \'audit\': return tr(\'Audit\', \'审计\')', rule: 'exhaustive_switch_arm' },
   { file: 'apps/web/src/views/attendance/attendanceDecisionTrace.ts', text: 'case \'group_policy_snapshot\': return tr(\'Group policy snapshot\', \'组策略快照\')', rule: 'exhaustive_switch_arm' },
   { file: 'apps/web/src/views/attendance/attendanceDecisionTrace.ts', text: 'case \'ledger\': return tr(\'Ledger\', \'台账\')', rule: 'exhaustive_switch_arm' },
@@ -532,6 +629,7 @@ export const W7_PROVENANCE_WIDENING_LEDGER_V1: readonly W7LedgerEntryV1[] = Obje
   { file: 'apps/web/src/views/attendance/attendanceDecisionTrace.ts', text: 'case \'record\': return tr(\'Record\', \'记录\')', rule: 'exhaustive_switch_arm' },
   { file: 'apps/web/src/views/attendance/attendanceDecisionTrace.ts', text: 'case \'rule_live\': return tr(\'Live rule\', \'活体规则\')', rule: 'exhaustive_switch_arm' },
   { file: 'apps/web/src/views/attendance/attendanceDecisionTrace.ts', text: 'case \'snapshot\': return tr(\'Frozen snapshot\', \'冻结快照\')', rule: 'exhaustive_switch_arm' },
+  { file: 'apps/web/src/views/attendance/attendanceDecisionTrace.ts', text: 'const timelineEnv = parsed.basis.find((env) => env.source.kind === \'audit\' && env.source.ref === \'approval_records\')', rule: 'single_member_selector' },
   { file: 'packages/core-backend/src/attendance/w4c0-write-boundary-types.ts', text: 'projectionOwner: AttendanceProjectionOwnerV1', rule: 'widened_predicate' },
   { file: 'packages/core-backend/src/attendance/w4c2-authoritative-calculation-core.ts', text: ': \'legacy_untracked\',', rule: 'widened_predicate_continuation' },
   { file: 'packages/core-backend/src/attendance/w4c2-authoritative-calculation-core.ts', text: 'SET current_calculation_id = $3::uuid, projection_owner = \'w4\',', rule: 'write_side_emitter' },
@@ -543,8 +641,12 @@ export const W7_PROVENANCE_WIDENING_LEDGER_V1: readonly W7LedgerEntryV1[] = Obje
   { file: 'packages/core-backend/src/attendance/w4c2-authoritative-calculation-core.ts', text: '} else if (parent.projectionOwner === \'legacy_untracked\' && parent.visibilityState === \'active\') {', rule: 'legacy_polarity' },
   { file: 'packages/core-backend/src/attendance/w4c2-live-scheduled-boundary.ts', text: ': \'legacy_untracked\',', rule: 'widened_predicate_continuation' },
   { file: 'packages/core-backend/src/attendance/w4c2-live-scheduled-boundary.ts', text: '\'legacy_untracked\', NULL, \'retired\', \'review_placeholder\',', rule: 'write_side_emitter' },
+  { file: 'packages/core-backend/src/attendance/w4c2-live-scheduled-boundary.ts', text: 'kind: \'w4\' as const,', rule: 'write_side_emitter' },
   { file: 'packages/core-backend/src/attendance/w4c2-live-scheduled-boundary.ts', text: 'projectionOwner: AttendanceProjectionOwnerV1', rule: 'widened_predicate' },
   { file: 'packages/core-backend/src/attendance/w4c2-live-scheduled-boundary.ts', text: 'projectionOwner: isAttendanceProjectionOwnerV1(row.projectionOwner)', rule: 'widened_predicate' },
+  { file: 'packages/core-backend/src/attendance/w4c2-live-scheduled-boundary.ts', text: 'return { kind: \'w4\', runId, rows: insertedRows, perUser }', rule: 'write_side_emitter' },
+  { file: 'packages/core-backend/src/attendance/w4c2-live-scheduled-boundary.ts', text: 'return { kind: \'w4\', runId: startOutcome.runId, rows: [], perUser: [] }', rule: 'write_side_emitter' },
+  { file: 'packages/core-backend/src/attendance/w4c2-live-scheduled-boundary.ts', text: 'return { mode: \'w4\' as const, rows: [] as Array<{ user_id: string }> }', rule: 'write_side_emitter' },
   { file: 'packages/core-backend/src/attendance/w4c3a-canonical-import-kernel.ts', text: '!isAttendanceProjectionOwnerV1(projectionOwner) ||', rule: 'widened_predicate' },
   { file: 'packages/core-backend/src/attendance/w4c3a-canonical-import-kernel.ts', text: '(isAttendanceProjectionOwnerWithCalculationPointerV1(projectionOwner) &&', rule: 'widened_predicate' },
   { file: 'packages/core-backend/src/attendance/w4c3a-canonical-import-kernel.ts', text: '(projectionOwner === \'legacy_untracked\' && currentCalculationId !== null) ||', rule: 'legacy_polarity' },
@@ -576,7 +678,6 @@ export const W7_PROVENANCE_WIDENING_LEDGER_V1: readonly W7LedgerEntryV1[] = Obje
   { file: 'packages/core-backend/src/attendance/w7-provenance-domain.ts', text: 'export const ATTENDANCE_PROJECTION_OWNERS_V1 = [', rule: 'domain_definition' },
   { file: 'packages/core-backend/src/attendance/w7-provenance-domain.ts', text: 'export const ATTENDANCE_PROJECTION_OWNERS_WITH_CALCULATION_POINTER_SQL_LIST_V1 =', rule: 'domain_definition' },
   { file: 'packages/core-backend/src/attendance/w7-provenance-domain.ts', text: 'export const ATTENDANCE_PROJECTION_OWNERS_WITH_CALCULATION_POINTER_V1 = [', rule: 'domain_definition' },
-  { file: 'packages/core-backend/src/attendance/w7-provenance-domain.ts', text: 'export const ATTENDANCE_PROJECTION_OWNER_WITHOUT_CALCULATION_POINTER_V1 = \'legacy_untracked\' as const', rule: 'domain_definition' },
   { file: 'packages/core-backend/src/attendance/w7-provenance-domain.ts', text: 'export const ATTENDANCE_TRACE_SOURCE_KINDS_V1 = [', rule: 'domain_definition' },
   { file: 'packages/core-backend/src/attendance/w7-provenance-domain.ts', text: 'export function isAttendanceProjectionOwnerV1(value: unknown): value is AttendanceProjectionOwnerV1 {', rule: 'domain_definition' },
   { file: 'packages/core-backend/src/attendance/w7-provenance-domain.ts', text: 'export function isAttendanceProjectionOwnerWithCalculationPointerV1(', rule: 'domain_definition' },
@@ -586,9 +687,13 @@ export const W7_PROVENANCE_WIDENING_LEDGER_V1: readonly W7LedgerEntryV1[] = Obje
   { file: 'packages/core-backend/src/attendance/w7-provenance-domain.ts', text: 'return (ATTENDANCE_PROJECTION_OWNERS_V1 as readonly unknown[]).includes(value)', rule: 'domain_definition' },
   { file: 'packages/core-backend/src/attendance/w7-provenance-domain.ts', text: 'return (ATTENDANCE_PROJECTION_OWNERS_WITH_CALCULATION_POINTER_V1 as readonly unknown[]).includes(value)', rule: 'domain_definition' },
   { file: 'packages/core-backend/src/attendance/w7-provenance-domain.ts', text: 'return (ATTENDANCE_TRACE_SOURCE_KINDS_V1 as readonly unknown[]).includes(value)', rule: 'domain_definition' },
+  { file: 'packages/core-backend/src/attendance/w7-read-side-provenance-amendment.ts', text: '\'audit\',', rule: 'w7_0_recorded_snapshot' },
   { file: 'packages/core-backend/src/attendance/w7-read-side-provenance-amendment.ts', text: '\'group_policy_snapshot\',', rule: 'w7_0_recorded_snapshot' },
+  { file: 'packages/core-backend/src/attendance/w7-read-side-provenance-amendment.ts', text: '\'ledger\',', rule: 'w7_0_recorded_snapshot' },
   { file: 'packages/core-backend/src/attendance/w7-read-side-provenance-amendment.ts', text: '\'policy_gate\',', rule: 'w7_0_recorded_snapshot' },
+  { file: 'packages/core-backend/src/attendance/w7-read-side-provenance-amendment.ts', text: '\'record\',', rule: 'w7_0_recorded_snapshot' },
   { file: 'packages/core-backend/src/attendance/w7-read-side-provenance-amendment.ts', text: '\'rule_live\',', rule: 'w7_0_recorded_snapshot' },
+  { file: 'packages/core-backend/src/attendance/w7-read-side-provenance-amendment.ts', text: '\'snapshot\',', rule: 'w7_0_recorded_snapshot' },
   { file: 'packages/core-backend/src/attendance/w7-read-side-provenance-amendment.ts', text: 'currentMembers: Object.freeze([\'legacy_untracked\', \'w4\', \'w4_group\'] as const),', rule: 'w7_0_recorded_snapshot' },
   { file: 'packages/core-backend/src/attendance/w7-read-side-provenance-amendment.ts', text: 'export const ATTENDANCE_W7_PROJECTION_OWNER_GROUP_VALUE_V1 = \'w4_group\' as const', rule: 'w7_0_recorded_snapshot' },
   { file: 'packages/core-backend/src/attendance/w7-read-side-provenance-amendment.ts', text: 'export const ATTENDANCE_W7_TRACE_SOURCE_KIND_GROUP_VALUE_V1 = \'group_policy_snapshot\' as const', rule: 'w7_0_recorded_snapshot' },
@@ -597,13 +702,21 @@ export const W7_PROVENANCE_WIDENING_LEDGER_V1: readonly W7LedgerEntryV1[] = Obje
   { file: 'packages/core-backend/src/services/AttendanceDecisionTrace.ts', text: 'basis.push({ source: { kind: \'policy_gate\', ref: \'auto_absence_generation\' }, version: { posture: \'undeterminable\' } })', rule: 'write_side_emitter' },
   { file: 'packages/core-backend/src/services/AttendanceDecisionTrace.ts', text: 'return { source: { kind: \'rule_live\', ref: \'none\' }, version: { posture: \'undeterminable\' } }', rule: 'write_side_emitter' },
   { file: 'packages/core-backend/src/services/AttendanceDecisionTrace.ts', text: 'return { source: { kind: \'rule_live\', ref: rule.refKind }, version: { posture: \'current_live_no_history\' } }', rule: 'write_side_emitter' },
+  { file: 'packages/core-backend/src/services/AttendanceDecisionTrace.ts', text: 'source: { kind: \'audit\', ref: \'approval_records\' },', rule: 'write_side_emitter' },
   { file: 'packages/core-backend/src/services/AttendanceDecisionTrace.ts', text: 'source: { kind: \'policy_gate\', ref: \'ATTENDANCE_APPROVAL_DYNAMIC_ASSIGNEE_SOURCES_ENABLED\' },', rule: 'write_side_emitter' },
   { file: 'packages/core-backend/src/services/AttendanceDecisionTrace.ts', text: 'source: { kind: \'policy_gate\', ref: \'compTimeFromOvertime\' },', rule: 'write_side_emitter' },
   { file: 'packages/core-backend/src/services/AttendanceDecisionTrace.ts', text: 'source: { kind: \'policy_gate\', ref: \'overtimeSegmentation\' },', rule: 'write_side_emitter' },
+  { file: 'packages/core-backend/src/services/AttendanceDecisionTrace.ts', text: 'source: { kind: \'record\', ref: \'approval_assignments\' },', rule: 'write_side_emitter' },
   { file: 'packages/core-backend/src/services/AttendanceDecisionTrace.ts', text: 'source: { kind: \'rule_live\', ref: \'attendance_overtime_rules\' },', rule: 'write_side_emitter' },
+  { file: 'packages/core-backend/src/services/AttendanceDecisionTrace.ts', text: 'source: { kind: \'snapshot\', ref: \'approval_instances.metadata.approvalFlow\' },', rule: 'write_side_emitter' },
+  { file: 'packages/core-backend/src/services/AttendanceDecisionTrace.ts', text: 'source: { kind: \'snapshot\', ref: \'approval_instances.requester_snapshot\' },', rule: 'write_side_emitter' },
+  { file: 'packages/core-backend/src/services/AttendanceDecisionTrace.ts', text: '| \'audit\'', rule: 'closed_set_member_list' },
   { file: 'packages/core-backend/src/services/AttendanceDecisionTrace.ts', text: '| \'group_policy_snapshot\'', rule: 'closed_set_member_list' },
+  { file: 'packages/core-backend/src/services/AttendanceDecisionTrace.ts', text: '| \'ledger\'', rule: 'closed_set_member_list' },
   { file: 'packages/core-backend/src/services/AttendanceDecisionTrace.ts', text: '| \'policy_gate\'', rule: 'closed_set_member_list' },
+  { file: 'packages/core-backend/src/services/AttendanceDecisionTrace.ts', text: '| \'record\'', rule: 'closed_set_member_list' },
   { file: 'packages/core-backend/src/services/AttendanceDecisionTrace.ts', text: '| \'rule_live\'', rule: 'closed_set_member_list' },
+  { file: 'packages/core-backend/src/services/AttendanceDecisionTrace.ts', text: '| \'snapshot\'', rule: 'closed_set_member_list' },
   { file: 'packages/core-backend/src/services/AttendanceW4CalculationDetail.ts', text: 'const PROJECTION_OWNERS = ATTENDANCE_PROJECTION_OWNERS_V1', rule: 'widened_predicate' },
   { file: 'packages/openapi/src/base.yml', text: 'projectionOwner: { type: string, enum: [legacy_untracked, w4, w4_group] }', rule: 'closed_set_member_list' },
   { file: 'scripts/attendance/execute-ops-retirement-cleanup.cjs', text: 'if (row.projection_owner != null && row.projection_owner !== \'legacy_untracked\') return true', rule: 'legacy_polarity' },

--- a/packages/core-backend/tests/utils/w7-provenance-widening-scan.ts
+++ b/packages/core-backend/tests/utils/w7-provenance-widening-scan.ts
@@ -88,7 +88,16 @@ const FAMILY_ANCHORS: Readonly<Record<W7ProvenanceFamily, readonly string[]>> = 
  * This cannot miss a closed member list: every list of a family's members
  * contains at least one distinctive member by construction. And it cannot miss
  * an ambiguous-literal PREDICATE, because a predicate must name what it tests.
+ *
+ * ONE EXCEPTION, and it is the important one: a `switch` arm names the value but
+ * NOT the subject — `case 'w4':` sits on a line that mentions neither the column
+ * nor an alias, so the rule above would make an exhaustive switch over the owner
+ * domain invisible. That is precisely the consumer class the `apps/web` finding
+ * proves exists in this codebase (it was caught there only because
+ * `policy_gate` happens to be distinctive). So a `case` arm carrying ANY member
+ * of the family — ambiguous ones included — is always a site.
  */
+const CASE_ARM = /^\s*case\s+['"]([a-z_0-9]+)['"]\s*:/
 const FAMILY_DISTINCTIVE_LITERALS: Readonly<Record<W7ProvenanceFamily, readonly string[]>> =
   Object.freeze({
     projection_owner: Object.freeze(['legacy_untracked', 'w4_group']),
@@ -264,8 +273,18 @@ export function deriveProvenanceWideningSurfaceV1(
         if (isCommentLine(text)) continue
         const hasWideningSymbol = symbols.some((symbol) => text.includes(symbol))
         const namesTarget = anchorTokens.some((token) => new RegExp(`\\b${token}\\b`).test(text))
+        // A `switch` arm names the value but never the subject — see CASE_ARM.
+        const caseArm = CASE_ARM.exec(text)
+        const isFamilyCaseArm =
+          caseArm !== null &&
+          (FAMILY_DISTINCTIVE_LITERALS[family] as readonly string[]).concat(
+            FAMILY_AMBIGUOUS_LITERALS[family] as readonly string[],
+          ).includes(caseArm[1])
         const isSite =
-          hasWideningSymbol || distinctive.test(text) || (ambiguous.test(text) && namesTarget)
+          hasWideningSymbol ||
+          distinctive.test(text) ||
+          isFamilyCaseArm ||
+          (ambiguous.test(text) && namesTarget)
         if (!isSite) continue
         const declaration = enclosingDeclaration(lines, i)
         sites.push({
@@ -506,9 +525,13 @@ export const W7_PROVENANCE_WIDENING_LEDGER_V1: readonly W7LedgerEntryV1[] = Obje
   { file: 'apps/web/src/views/attendance/attendanceDecisionTrace.ts', text: '\'group_policy_snapshot\',', rule: 'closed_set_member_list' },
   { file: 'apps/web/src/views/attendance/attendanceDecisionTrace.ts', text: '\'policy_gate\',', rule: 'closed_set_member_list' },
   { file: 'apps/web/src/views/attendance/attendanceDecisionTrace.ts', text: '\'rule_live\',', rule: 'closed_set_member_list' },
+  { file: 'apps/web/src/views/attendance/attendanceDecisionTrace.ts', text: 'case \'audit\': return tr(\'Audit\', \'审计\')', rule: 'exhaustive_switch_arm' },
   { file: 'apps/web/src/views/attendance/attendanceDecisionTrace.ts', text: 'case \'group_policy_snapshot\': return tr(\'Group policy snapshot\', \'组策略快照\')', rule: 'exhaustive_switch_arm' },
+  { file: 'apps/web/src/views/attendance/attendanceDecisionTrace.ts', text: 'case \'ledger\': return tr(\'Ledger\', \'台账\')', rule: 'exhaustive_switch_arm' },
   { file: 'apps/web/src/views/attendance/attendanceDecisionTrace.ts', text: 'case \'policy_gate\': return tr(\'Policy gate\', \'策略开关\')', rule: 'exhaustive_switch_arm' },
+  { file: 'apps/web/src/views/attendance/attendanceDecisionTrace.ts', text: 'case \'record\': return tr(\'Record\', \'记录\')', rule: 'exhaustive_switch_arm' },
   { file: 'apps/web/src/views/attendance/attendanceDecisionTrace.ts', text: 'case \'rule_live\': return tr(\'Live rule\', \'活体规则\')', rule: 'exhaustive_switch_arm' },
+  { file: 'apps/web/src/views/attendance/attendanceDecisionTrace.ts', text: 'case \'snapshot\': return tr(\'Frozen snapshot\', \'冻结快照\')', rule: 'exhaustive_switch_arm' },
   { file: 'packages/core-backend/src/attendance/w4c0-write-boundary-types.ts', text: 'projectionOwner: AttendanceProjectionOwnerV1', rule: 'widened_predicate' },
   { file: 'packages/core-backend/src/attendance/w4c2-authoritative-calculation-core.ts', text: ': \'legacy_untracked\',', rule: 'widened_predicate_continuation' },
   { file: 'packages/core-backend/src/attendance/w4c2-authoritative-calculation-core.ts', text: 'SET current_calculation_id = $3::uuid, projection_owner = \'w4\',', rule: 'write_side_emitter' },

--- a/packages/core-backend/tests/utils/w7-provenance-widening-scan.ts
+++ b/packages/core-backend/tests/utils/w7-provenance-widening-scan.ts
@@ -1,0 +1,591 @@
+/**
+ * W7-1a-M (#4556) — the DERIVE half of the derive-and-diff completeness check.
+ *
+ * Ratified per #4556 comments 5293034619 + 5293478713. The ratification refuses
+ * to enumerate the widening surface ("扩宽面不由本裁决枚举" — two hand-written
+ * lists were refuted), so this module DERIVES the surface from the tree and the
+ * paired test diffs the derivation against a ledger. Missing a point is RED in
+ * both directions: an un-ledgered derived site fails, and a ledger entry whose
+ * construct has vanished fails.
+ *
+ * Why derivation is not "grep for the new value": the silent-downgrade folds
+ * (`row.projection_owner === 'w4' ? 'w4' : 'legacy_untracked'`) contain NO
+ * target string at all. So the anchor is the READER — a file that references the
+ * column/field — and within an anchored file every line carrying a domain
+ * literal OR a widening symbol is a derived site.
+ *
+ * SCOPE — source text only. The DB surface is derived SEPARATELY, from the live
+ * catalogue (`pg_constraint` / `pg_proc`) in
+ * `tests/integration/attendance-w7-1am-provenance-widening.db.test.ts`. Migration
+ * FILES are deliberately excluded from this scan: `attendance_w4_records_pointer_guard`
+ * is defined in zzzz20260725120000 and then REPLACED by zzzz20260731120000, so
+ * migration text says nothing reliable about what is live, and historical
+ * migrations are never edited. Only the catalogue is authoritative there.
+ */
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+
+/** Walk up for the workspace marker — never a fixed `../../..` (REPO_ROOT_AMBIGUOUS). */
+export function resolveRepoRootV1(startDir: string = __dirname): string {
+  let dir = startDir
+  for (;;) {
+    if (fs.existsSync(path.join(dir, 'pnpm-workspace.yaml'))) return dir
+    const parent = path.dirname(dir)
+    if (parent === dir) throw new Error('W7_SCAN: pnpm-workspace.yaml not found above ' + startDir)
+    dir = parent
+  }
+}
+
+export const W7_SCAN_ROOTS_V1: readonly string[] = Object.freeze([
+  'packages/core-backend/src',
+  'packages/openapi/src',
+  'apps/web/src',
+  'scripts',
+])
+
+const SCANNED_EXTENSIONS = new Set(['.ts', '.tsx', '.vue', '.cjs', '.mjs', '.js', '.yml', '.yaml'])
+
+/** Excluded from the scan; each exclusion is a rule, not a site-level exemption. */
+function isExcluded(relPath: string): boolean {
+  return (
+    relPath.includes('/node_modules/') ||
+    relPath.includes('/dist/') ||
+    relPath.includes('/dist-sdk/') ||
+    // See file header: DB surface is derived from the live catalogue instead.
+    relPath.includes('/src/db/migrations/') ||
+    // The widening surface is the PRODUCTION consumer set. Test files assert
+    // against the domain, they do not gate it, and a test that pins the
+    // pre-widening set is a deliberate historical fixture, not a missed point.
+    relPath.includes('/__tests__/') ||
+    relPath.includes('/tests/') ||
+    /\.(?:test|spec)\.[cm]?[jt]sx?$/.test(relPath)
+  )
+}
+
+export type W7ProvenanceFamily = 'projection_owner' | 'trace_source_kind'
+
+/** File-level anchors: a file is a CONSUMER of the family if it names one of these. */
+const FAMILY_ANCHORS: Readonly<Record<W7ProvenanceFamily, readonly string[]>> = Object.freeze({
+  projection_owner: Object.freeze(['projection_owner', 'projectionOwner', 'PROJECTION_OWNERS']),
+  trace_source_kind: Object.freeze([
+    'AttendanceDecisionTraceSourceKind',
+    'ATTENDANCE_TRACE_SOURCE_KINDS',
+    'AttendanceTraceSourceKind',
+    'TRACE_SOURCE_KIND',
+  ]),
+})
+
+/**
+ * Two-tier membership, because a bare literal is not always this domain's.
+ *
+ * DISTINCTIVE members are unique to the family across the scanned tree, so any
+ * line carrying one is a site outright. AMBIGUOUS members (`'w4'`, and the trace
+ * family's `'record'`/`'snapshot'`/`'ledger'`/`'audit'`) also occur as unrelated
+ * discriminators — `w4c2-live-scheduled-boundary.ts` has a `readonly kind: 'w4'`
+ * tag that has nothing to do with projection ownership — so they count only when
+ * the SAME line also names the field/column or a derived alias.
+ *
+ * This cannot miss a closed member list: every list of a family's members
+ * contains at least one distinctive member by construction. And it cannot miss
+ * an ambiguous-literal PREDICATE, because a predicate must name what it tests.
+ */
+const FAMILY_DISTINCTIVE_LITERALS: Readonly<Record<W7ProvenanceFamily, readonly string[]>> =
+  Object.freeze({
+    projection_owner: Object.freeze(['legacy_untracked', 'w4_group']),
+    trace_source_kind: Object.freeze(['rule_live', 'policy_gate', 'group_policy_snapshot']),
+  })
+
+const FAMILY_AMBIGUOUS_LITERALS: Readonly<Record<W7ProvenanceFamily, readonly string[]>> =
+  Object.freeze({
+    projection_owner: Object.freeze(['w4']),
+    trace_source_kind: Object.freeze(['record', 'snapshot', 'ledger', 'audit']),
+  })
+
+/** Symbols that CARRY the widening; a line using one is widened by construction. */
+const FAMILY_WIDENING_SYMBOLS: Readonly<Record<W7ProvenanceFamily, readonly string[]>> =
+  Object.freeze({
+    projection_owner: Object.freeze([
+      'ATTENDANCE_PROJECTION_OWNERS_V1',
+      'ATTENDANCE_PROJECTION_OWNERS_WITH_CALCULATION_POINTER_V1',
+      'ATTENDANCE_PROJECTION_OWNERS_SQL_LIST_V1',
+      'ATTENDANCE_PROJECTION_OWNERS_WITH_CALCULATION_POINTER_SQL_LIST_V1',
+      'isAttendanceProjectionOwnerV1',
+      'isAttendanceProjectionOwnerWithCalculationPointerV1',
+      'AttendanceProjectionOwnerV1',
+      'ATTENDANCE_W7_PROJECTION_OWNER_GROUP_VALUE_V1',
+    ]),
+    trace_source_kind: Object.freeze([
+      'ATTENDANCE_TRACE_SOURCE_KINDS_V1',
+      'isAttendanceTraceSourceKindV1',
+      'ATTENDANCE_W7_TRACE_SOURCE_KIND_GROUP_VALUE_V1',
+    ]),
+  })
+
+export const W7_WIDENING_SYMBOLS_V1: readonly string[] = Object.freeze([
+  ...FAMILY_WIDENING_SYMBOLS.projection_owner,
+  ...FAMILY_WIDENING_SYMBOLS.trace_source_kind,
+])
+
+/** The values this slice adds, per family. */
+export const W7_NEW_VALUES_V1: Readonly<Record<W7ProvenanceFamily, string>> = Object.freeze({
+  projection_owner: 'w4_group',
+  trace_source_kind: 'group_policy_snapshot',
+})
+
+export interface W7DerivedSiteV1 {
+  readonly family: W7ProvenanceFamily
+  readonly file: string
+  readonly line: number
+  readonly text: string
+  /** `file::text` — stable across line-number churn. */
+  readonly key: string
+  /** The enclosing indent-0 declaration, used ONLY as evidence scope for member lists. */
+  readonly declaration: string
+  readonly hasNewValue: boolean
+  readonly hasWideningSymbol: boolean
+  readonly declarationHasNewValue: boolean
+  readonly declarationHasWideningSymbol: boolean
+}
+
+function listFiles(root: string, repoRoot: string, out: string[]): void {
+  let entries: fs.Dirent[]
+  try {
+    entries = fs.readdirSync(root, { withFileTypes: true })
+  } catch {
+    return
+  }
+  for (const entry of entries) {
+    const full = path.join(root, entry.name)
+    const rel = '/' + path.relative(repoRoot, full).split(path.sep).join('/')
+    if (isExcluded(rel)) continue
+    if (entry.isDirectory()) {
+      listFiles(full, repoRoot, out)
+    } else if (SCANNED_EXTENSIONS.has(path.extname(entry.name))) {
+      out.push(full)
+    }
+  }
+}
+
+/**
+ * One taint hop: identifiers bound to a read of the column/field. Kept
+ * FILE-LOCAL on purpose — a bare `owner` is far too generic to anchor globally.
+ */
+export function deriveAliasIdentifiersV1(source: string): string[] {
+  const aliases = new Set<string>()
+  const patterns = [
+    // `const projectionOwner = String(row.projection_owner)`
+    /(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*[^\n]*\b(?:projection_owner|projectionOwner)\b/g,
+    // `projection_owner AS "projectionOwner"`
+    /\bprojection_owner\s+AS\s+"([A-Za-z_$][\w$]*)"/gi,
+    // `owner = input.preimage.projectionOwner`
+    /\b([A-Za-z_$][\w$]*)\s*=\s*[^\n=]*\.projectionOwner\b/g,
+  ]
+  for (const re of patterns) {
+    let m: RegExpExecArray | null
+    while ((m = re.exec(source)) !== null) {
+      if (m[1] && m[1].length > 1) aliases.add(m[1])
+    }
+  }
+  return [...aliases].sort()
+}
+
+function literalRegex(members: readonly string[], isYaml: boolean): RegExp {
+  const alternation = members.join('|')
+  // YAML enums are unquoted (`enum: [legacy_untracked, w4]`); TS/SQL are quoted.
+  return isYaml
+    ? new RegExp(`\\b(?:${alternation})\\b`)
+    : new RegExp(`['"\`](?:${alternation})['"\`]`)
+}
+
+/** A comment cannot gate, downgrade, or reject a value, so it is not a site. */
+function isCommentLine(text: string): boolean {
+  return /^\s*(?:\/\/|\/\*|\*|#|--)/.test(text)
+}
+
+/** The enclosing indent-0 declaration block containing `lineIndex`. */
+function enclosingDeclaration(lines: readonly string[], lineIndex: number): string {
+  let start = lineIndex
+  while (start > 0 && !/^\S/.test(lines[start])) start -= 1
+  let end = lineIndex
+  while (end < lines.length - 1 && !/^\S/.test(lines[end + 1])) end += 1
+  return lines.slice(start, end + 1).join('\n')
+}
+
+export interface W7DerivationV1 {
+  readonly sites: readonly W7DerivedSiteV1[]
+  readonly aliasIdentifiers: readonly string[]
+  readonly scannedFileCount: number
+  readonly anchoredFileCount: number
+}
+
+export function deriveProvenanceWideningSurfaceV1(
+  options: Readonly<{ repoRoot: string; roots?: readonly string[] }>,
+): W7DerivationV1 {
+  const repoRoot = options.repoRoot
+  const roots = options.roots ?? W7_SCAN_ROOTS_V1
+  const files: string[] = []
+  for (const root of roots) listFiles(path.join(repoRoot, root), repoRoot, files)
+  files.sort()
+
+  const sites: W7DerivedSiteV1[] = []
+  const aliasIdentifiers = new Set<string>()
+  let anchoredFileCount = 0
+
+  for (const file of files) {
+    const source = fs.readFileSync(file, 'utf8')
+    const rel = path.relative(repoRoot, file).split(path.sep).join('/')
+    const isYaml = /\.ya?ml$/.test(file)
+    const families = (Object.keys(FAMILY_ANCHORS) as W7ProvenanceFamily[]).filter((family) =>
+      FAMILY_ANCHORS[family].some((anchor) => source.includes(anchor)),
+    )
+    if (families.length === 0) continue
+    anchoredFileCount += 1
+    for (const alias of deriveAliasIdentifiersV1(source)) aliasIdentifiers.add(alias)
+
+    const aliasTokens = [...FAMILY_ANCHORS.projection_owner, ...deriveAliasIdentifiersV1(source)]
+    const lines = source.split('\n')
+    for (const family of families) {
+      const distinctive = literalRegex(FAMILY_DISTINCTIVE_LITERALS[family], isYaml)
+      const ambiguous = literalRegex(FAMILY_AMBIGUOUS_LITERALS[family], isYaml)
+      const anchorTokens = family === 'projection_owner' ? aliasTokens : FAMILY_ANCHORS[family]
+      const symbols = FAMILY_WIDENING_SYMBOLS[family]
+      const newValue = W7_NEW_VALUES_V1[family]
+      // An `import` names a symbol; it does not gate, branch on, or emit a
+      // value, so it is not a consumer site.
+      let inImportBlock = false
+      for (let i = 0; i < lines.length; i += 1) {
+        const text = lines[i]
+        if (/^\s*import\b/.test(text)) inImportBlock = !/\bfrom\b|;\s*$/.test(text)
+        else if (inImportBlock && /\bfrom\b/.test(text)) {
+          inImportBlock = false
+          continue
+        }
+        if (inImportBlock || /^\s*import\b/.test(text)) continue
+        if (isCommentLine(text)) continue
+        const hasWideningSymbol = symbols.some((symbol) => text.includes(symbol))
+        const namesTarget = anchorTokens.some((token) => new RegExp(`\\b${token}\\b`).test(text))
+        const isSite =
+          hasWideningSymbol || distinctive.test(text) || (ambiguous.test(text) && namesTarget)
+        if (!isSite) continue
+        const declaration = enclosingDeclaration(lines, i)
+        sites.push({
+          family,
+          file: rel,
+          line: i + 1,
+          text: text.trim(),
+          key: `${rel}::${text.trim()}`,
+          declaration,
+          hasNewValue: text.includes(newValue),
+          hasWideningSymbol,
+          declarationHasNewValue: declaration.includes(newValue),
+          declarationHasWideningSymbol: symbols.some((symbol) => declaration.includes(symbol)),
+        })
+      }
+    }
+  }
+
+  return {
+    sites,
+    aliasIdentifiers: [...aliasIdentifiers].sort(),
+    scannedFileCount: files.length,
+    anchoredFileCount,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// The DIFF half: verdict rules + the ledger.
+// ---------------------------------------------------------------------------
+
+/**
+ * Every derived site carries exactly one rule. `widened` rules assert the point
+ * now admits the new value; `neutral` rules assert — with a MACHINE-CHECKED
+ * predicate, never prose — that the point cannot downgrade or reject it.
+ */
+export type W7RuleName =
+  /** Closed member list (union / `as const` array / OpenAPI enum). Evidence scope = declaration. */
+  | 'closed_set_member_list'
+  /** One arm of an exhaustive `switch` over the domain. Evidence scope =
+   *  declaration (the sibling arm for the new member is what proves widening). */
+  | 'exhaustive_switch_arm'
+  /** A membership test, branch, or fold. Evidence scope = the LINE itself. */
+  | 'widened_predicate'
+  /** A continuation line of a multi-line widened predicate (e.g. a ternary's
+   *  fallback arm). Evidence scope = declaration, because the widening symbol
+   *  sits on the predicate's first line. */
+  | 'widened_predicate_continuation'
+  /** Compares only against `legacy_untracked`, so every other member — new ones
+   *  included — takes the SAME arm `w4` takes. Correct as written. */
+  | 'legacy_polarity'
+  /** Writes a constant domain value; not a test at all. INERT slice: no new emitters. */
+  | 'write_side_emitter'
+  /** `?? 'legacy_untracked'` on a NOT NULL column: a null-default, not a fold. */
+  | 'null_default'
+  /** The recorded W7-0 snapshot of a live set (kept equal by the tsc sync guards). */
+  | 'w7_0_recorded_snapshot'
+  /**
+   * A line of the domain module that DEFINES the widening. These lines are not
+   * held to "must contain the new value" — one of them is precisely the
+   * `legacy_untracked`-only NULL-pointer member, which by the semantic ruling
+   * must NOT gain it. The module's correctness is asserted directly and far more
+   * strictly by the exact-member-array assertions in the paired test.
+   */
+  | 'domain_definition'
+
+const WIDENED_RULES: ReadonlySet<W7RuleName> = new Set<W7RuleName>([
+  'closed_set_member_list',
+  'exhaustive_switch_arm',
+  'widened_predicate',
+  'widened_predicate_continuation',
+  'w7_0_recorded_snapshot',
+])
+
+/** Rules whose widening evidence may come from the enclosing declaration. */
+const DECLARATION_SCOPED_RULES: ReadonlySet<W7RuleName> = new Set<W7RuleName>([
+  'closed_set_member_list',
+  'exhaustive_switch_arm',
+  'widened_predicate_continuation',
+  'w7_0_recorded_snapshot',
+])
+
+/** The one file allowed to carry `domain_definition` sites. */
+const W7_DOMAIN_MODULE_SUFFIX = 'src/attendance/w7-provenance-domain.ts'
+
+/**
+ * Tokens that make a line a TEST rather than an emission. An emitter that
+ * contains none of these cannot put the new member on the wrong side of
+ * anything, because it does not branch on the value at all.
+ */
+const COMPARISON_TOKENS: readonly string[] = Object.freeze([
+  '===',
+  '!==',
+  '==',
+  '!=',
+  '<>',
+  'IN (',
+  'NOT IN',
+  'IS DISTINCT',
+  'IS NOT DISTINCT',
+  '.includes(',
+  'case ',
+])
+
+/**
+ * SQL boolean contexts. Plain `=` is assignment in `SET`/`VALUES` but comparison
+ * in `WHERE`/`AND`/`OR`/`WHEN`, and the two are indistinguishable from the
+ * operator alone — so a line in a boolean context is never treated as a mere
+ * emitter. Without this, a future `WHERE projection_owner = 'w4'` would classify
+ * as an emitter and its missing widening would pass unnoticed.
+ */
+const SQL_BOOLEAN_CONTEXT_TOKENS: readonly string[] = Object.freeze([
+  'WHERE',
+  ' AND ',
+  ' OR ',
+  'HAVING',
+  'WHEN ',
+  'IF ',
+  'CHECK',
+])
+
+function hasComparison(text: string): boolean {
+  return (
+    COMPARISON_TOKENS.some((token) => text.includes(token)) ||
+    SQL_BOOLEAN_CONTEXT_TOKENS.some((token) => text.includes(token))
+  )
+}
+
+export interface W7LedgerEntryV1 {
+  readonly file: string
+  readonly text: string
+  readonly rule: W7RuleName
+  readonly note?: string
+}
+
+export interface W7ViolationV1 {
+  readonly kind: 'unledgered_site' | 'stale_ledger_entry' | 'not_widened' | 'rule_predicate_failed'
+  readonly detail: string
+}
+
+function ledgerKey(entry: W7LedgerEntryV1): string {
+  return `${entry.file}::${entry.text}`
+}
+
+/** Machine predicates for the neutral rules — the reason a site needs no edit. */
+function neutralPredicateHolds(rule: W7RuleName, site: W7DerivedSiteV1): boolean {
+  const text = site.text
+  switch (rule) {
+    case 'legacy_polarity':
+      // Must BE a test, must test `legacy_untracked`, and must NOT test `'w4'`.
+      // A `'w4'`-polarity predicate would put the new member on the wrong side,
+      // so this is exactly the condition under which no edit is needed.
+      return (
+        site.family === 'projection_owner' &&
+        hasComparison(text) &&
+        text.includes('legacy_untracked') &&
+        !/['"`]w4['"`]/.test(text)
+      )
+    case 'write_side_emitter':
+      // Not a test at all — it cannot route the new member anywhere.
+      return !hasComparison(text)
+    case 'null_default':
+      // `?? 'legacy_untracked'` fires only on SQL NULL (the column is NOT NULL);
+      // it passes every real value through unchanged, so it cannot downgrade.
+      return text.includes('??') && !hasComparison(text)
+    case 'domain_definition':
+      // Only the domain module may claim this rule, so it cannot be used to
+      // excuse an un-widened consumer anywhere else in the tree.
+      return site.file.endsWith(W7_DOMAIN_MODULE_SUFFIX)
+    default:
+      return false
+  }
+}
+
+export function diffProvenanceWideningV1(
+  derivation: W7DerivationV1,
+  ledger: readonly W7LedgerEntryV1[],
+): W7ViolationV1[] {
+  const violations: W7ViolationV1[] = []
+  const byKey = new Map<string, W7LedgerEntryV1>()
+  for (const entry of ledger) byKey.set(ledgerKey(entry), entry)
+  const seen = new Set<string>()
+
+  for (const site of derivation.sites) {
+    const entry = byKey.get(site.key)
+    if (!entry) {
+      violations.push({
+        kind: 'unledgered_site',
+        detail: `${site.file}:${site.line} (${site.family}) — ${site.text}`,
+      })
+      continue
+    }
+    seen.add(site.key)
+    if (WIDENED_RULES.has(entry.rule)) {
+      const widened = DECLARATION_SCOPED_RULES.has(entry.rule)
+        ? site.declarationHasNewValue || site.hasWideningSymbol || site.declarationHasWideningSymbol
+        : site.hasNewValue || site.hasWideningSymbol
+      if (!widened) {
+        violations.push({
+          kind: 'not_widened',
+          detail: `${site.file}:${site.line} rule=${entry.rule} — ${site.text}`,
+        })
+      }
+    } else if (!neutralPredicateHolds(entry.rule, site)) {
+      violations.push({
+        kind: 'rule_predicate_failed',
+        detail: `${site.file}:${site.line} rule=${entry.rule} — ${site.text}`,
+      })
+    }
+  }
+
+  for (const entry of ledger) {
+    if (!seen.has(ledgerKey(entry))) {
+      violations.push({
+        kind: 'stale_ledger_entry',
+        detail: `${entry.file} — ${entry.text}`,
+      })
+    }
+  }
+  return violations
+}
+
+/**
+ * THE LEDGER — every derived site, with the rule that adjudicates it.
+ *
+ * This list is DERIVED, then adjudicated: the scanner above produced the site
+ * set mechanically from the tree, and each entry records which rule makes that
+ * site correct. The paired test diffs the two in BOTH directions, so the ledger
+ * cannot silently drift from the tree:
+ *   - a site with no entry FAILS (a new un-widened consumer cannot sneak in);
+ *   - an entry with no site FAILS (a construct that moved cannot be left behind);
+ *   - a `widened` rule whose evidence is absent FAILS;
+ *   - a `neutral` rule whose machine predicate is false FAILS.
+ *
+ * Keyed by `file` + exact source `text` rather than line number, so unrelated
+ * edits above a site do not churn this list.
+ */
+export const W7_PROVENANCE_WIDENING_LEDGER_V1: readonly W7LedgerEntryV1[] = Object.freeze([
+  { file: 'apps/web/src/views/attendance/attendanceDecisionTrace.ts', text: '\'group_policy_snapshot\',', rule: 'closed_set_member_list' },
+  { file: 'apps/web/src/views/attendance/attendanceDecisionTrace.ts', text: '\'policy_gate\',', rule: 'closed_set_member_list' },
+  { file: 'apps/web/src/views/attendance/attendanceDecisionTrace.ts', text: '\'rule_live\',', rule: 'closed_set_member_list' },
+  { file: 'apps/web/src/views/attendance/attendanceDecisionTrace.ts', text: 'case \'group_policy_snapshot\': return tr(\'Group policy snapshot\', \'组策略快照\')', rule: 'exhaustive_switch_arm' },
+  { file: 'apps/web/src/views/attendance/attendanceDecisionTrace.ts', text: 'case \'policy_gate\': return tr(\'Policy gate\', \'策略开关\')', rule: 'exhaustive_switch_arm' },
+  { file: 'apps/web/src/views/attendance/attendanceDecisionTrace.ts', text: 'case \'rule_live\': return tr(\'Live rule\', \'活体规则\')', rule: 'exhaustive_switch_arm' },
+  { file: 'packages/core-backend/src/attendance/w4c0-write-boundary-types.ts', text: 'projectionOwner: AttendanceProjectionOwnerV1', rule: 'widened_predicate' },
+  { file: 'packages/core-backend/src/attendance/w4c2-authoritative-calculation-core.ts', text: ': \'legacy_untracked\',', rule: 'widened_predicate_continuation' },
+  { file: 'packages/core-backend/src/attendance/w4c2-authoritative-calculation-core.ts', text: 'SET current_calculation_id = $3::uuid, projection_owner = \'w4\',', rule: 'write_side_emitter' },
+  { file: 'packages/core-backend/src/attendance/w4c2-authoritative-calculation-core.ts', text: 'isAttendanceProjectionOwnerWithCalculationPointerV1(parent.projectionOwner) &&', rule: 'widened_predicate' },
+  { file: 'packages/core-backend/src/attendance/w4c2-authoritative-calculation-core.ts', text: 'let owner: AttendanceProjectionOwnerV1', rule: 'widened_predicate' },
+  { file: 'packages/core-backend/src/attendance/w4c2-authoritative-calculation-core.ts', text: 'owner = \'w4\'', rule: 'write_side_emitter' },
+  { file: 'packages/core-backend/src/attendance/w4c2-authoritative-calculation-core.ts', text: 'projectionOwner: isAttendanceProjectionOwnerV1(row.projection_owner)', rule: 'widened_predicate' },
+  { file: 'packages/core-backend/src/attendance/w4c2-authoritative-calculation-core.ts', text: 'readonly projectionOwner: AttendanceProjectionOwnerV1', rule: 'widened_predicate' },
+  { file: 'packages/core-backend/src/attendance/w4c2-authoritative-calculation-core.ts', text: '} else if (parent.projectionOwner === \'legacy_untracked\' && parent.visibilityState === \'active\') {', rule: 'legacy_polarity' },
+  { file: 'packages/core-backend/src/attendance/w4c2-live-scheduled-boundary.ts', text: ': \'legacy_untracked\',', rule: 'widened_predicate_continuation' },
+  { file: 'packages/core-backend/src/attendance/w4c2-live-scheduled-boundary.ts', text: '\'legacy_untracked\', NULL, \'retired\', \'review_placeholder\',', rule: 'write_side_emitter' },
+  { file: 'packages/core-backend/src/attendance/w4c2-live-scheduled-boundary.ts', text: 'projectionOwner: AttendanceProjectionOwnerV1', rule: 'widened_predicate' },
+  { file: 'packages/core-backend/src/attendance/w4c2-live-scheduled-boundary.ts', text: 'projectionOwner: isAttendanceProjectionOwnerV1(row.projectionOwner)', rule: 'widened_predicate' },
+  { file: 'packages/core-backend/src/attendance/w4c3a-canonical-import-kernel.ts', text: '!isAttendanceProjectionOwnerV1(projectionOwner) ||', rule: 'widened_predicate' },
+  { file: 'packages/core-backend/src/attendance/w4c3a-canonical-import-kernel.ts', text: '(isAttendanceProjectionOwnerWithCalculationPointerV1(projectionOwner) &&', rule: 'widened_predicate' },
+  { file: 'packages/core-backend/src/attendance/w4c3a-canonical-import-kernel.ts', text: '(projectionOwner === \'legacy_untracked\' && currentCalculationId !== null) ||', rule: 'legacy_polarity' },
+  { file: 'packages/core-backend/src/attendance/w4c3a-canonical-import-kernel.ts', text: '\'legacy_untracked\',NULL,$15,$16,now(),now()', rule: 'write_side_emitter' },
+  { file: 'packages/core-backend/src/attendance/w4c3a-canonical-import-kernel.ts', text: 'if (input.preimage.projectionOwner !== \'legacy_untracked\') return', rule: 'legacy_polarity' },
+  { file: 'packages/core-backend/src/attendance/w4c3a-canonical-import-kernel.ts', text: 'timezone = $9, projection_owner = \'w4\', current_calculation_id = $10::uuid,', rule: 'write_side_emitter' },
+  { file: 'packages/core-backend/src/attendance/w4c3a-import-rollback-boundary.ts', text: 'AND (current_calculation_id IS NOT NULL OR projection_owner IN (${ATTENDANCE_PROJECTION_OWNERS_WITH_CALCULATION_POINTER_SQL_LIST_V1}))', rule: 'widened_predicate' },
+  { file: 'packages/core-backend/src/attendance/w4c3a-import-rollback.ts', text: '!isAttendanceProjectionOwnerV1(row.projectionOwner) ||', rule: 'widened_predicate' },
+  { file: 'packages/core-backend/src/attendance/w4c3a-import-rollback.ts', text: '!isAttendanceProjectionOwnerWithCalculationPointerV1(record.projection_owner) ||', rule: 'widened_predicate' },
+  { file: 'packages/core-backend/src/attendance/w4c3a-import-rollback.ts', text: '(isAttendanceProjectionOwnerWithCalculationPointerV1(row.projectionOwner) &&', rule: 'widened_predicate' },
+  { file: 'packages/core-backend/src/attendance/w4c3a-import-rollback.ts', text: '(row.projectionOwner === \'legacy_untracked\' && row.currentCalculationId === null) ||', rule: 'legacy_polarity' },
+  { file: 'packages/core-backend/src/attendance/w4c3a-import-rollback.ts', text: 'currentCalculationId: isAttendanceProjectionOwnerWithCalculationPointerV1(row.projectionOwner)', rule: 'widened_predicate' },
+  { file: 'packages/core-backend/src/attendance/w4c3a-import-rollback.ts', text: 'present ? preimage.projectionOwner : \'w4\',', rule: 'write_side_emitter' },
+  { file: 'packages/core-backend/src/attendance/w4c3a-import-rollback.ts', text: 'projectionOwner: AttendanceProjectionOwnerV1', rule: 'widened_predicate' },
+  { file: 'packages/core-backend/src/attendance/w4c3a-import-rollback.ts', text: 'projectionOwner?: AttendanceProjectionOwnerV1', rule: 'widened_predicate' },
+  { file: 'packages/core-backend/src/attendance/w4c3b-approved-leave-cancellation.ts', text: 'SET current_calculation_id = $3::uuid, projection_owner = \'w4\',', rule: 'write_side_emitter' },
+  { file: 'packages/core-backend/src/attendance/w4c3c-manual-edit-apply.ts', text: 'projection_owner = \'w4\',', rule: 'write_side_emitter' },
+  { file: 'packages/core-backend/src/attendance/w4c3c-ops-retirement.ts', text: 'const projectionOwner = String(record.projection_owner ?? \'legacy_untracked\')', rule: 'null_default' },
+  { file: 'packages/core-backend/src/attendance/w4c3c-ops-retirement.ts', text: 'projection_owner = \'w4\',', rule: 'write_side_emitter' },
+  { file: 'packages/core-backend/src/attendance/w4c3c-recompute.ts', text: 'SET current_calculation_id = $3::uuid, projection_owner = \'w4\',', rule: 'write_side_emitter' },
+  { file: 'packages/core-backend/src/attendance/w7-provenance-domain.ts', text: '(typeof ATTENDANCE_PROJECTION_OWNERS_WITH_CALCULATION_POINTER_V1)[number]', rule: 'domain_definition' },
+  { file: 'packages/core-backend/src/attendance/w7-provenance-domain.ts', text: 'ATTENDANCE_PROJECTION_OWNERS_WITH_CALCULATION_POINTER_V1.map((owner) => `\'${owner}\'`).join(\', \')', rule: 'domain_definition' },
+  { file: 'packages/core-backend/src/attendance/w7-provenance-domain.ts', text: 'ATTENDANCE_W7_PROJECTION_OWNER_GROUP_VALUE_V1,', rule: 'domain_definition' },
+  { file: 'packages/core-backend/src/attendance/w7-provenance-domain.ts', text: 'ATTENDANCE_W7_TRACE_SOURCE_KIND_GROUP_VALUE_V1,', rule: 'domain_definition' },
+  { file: 'packages/core-backend/src/attendance/w7-provenance-domain.ts', text: '\'legacy_untracked\',', rule: 'domain_definition' },
+  { file: 'packages/core-backend/src/attendance/w7-provenance-domain.ts', text: '\'policy_gate\',', rule: 'domain_definition' },
+  { file: 'packages/core-backend/src/attendance/w7-provenance-domain.ts', text: '\'rule_live\',', rule: 'domain_definition' },
+  { file: 'packages/core-backend/src/attendance/w7-provenance-domain.ts', text: 'export const ATTENDANCE_PROJECTION_OWNERS_SQL_LIST_V1 = ATTENDANCE_PROJECTION_OWNERS_V1.map(', rule: 'domain_definition' },
+  { file: 'packages/core-backend/src/attendance/w7-provenance-domain.ts', text: 'export const ATTENDANCE_PROJECTION_OWNERS_V1 = [', rule: 'domain_definition' },
+  { file: 'packages/core-backend/src/attendance/w7-provenance-domain.ts', text: 'export const ATTENDANCE_PROJECTION_OWNERS_WITH_CALCULATION_POINTER_SQL_LIST_V1 =', rule: 'domain_definition' },
+  { file: 'packages/core-backend/src/attendance/w7-provenance-domain.ts', text: 'export const ATTENDANCE_PROJECTION_OWNERS_WITH_CALCULATION_POINTER_V1 = [', rule: 'domain_definition' },
+  { file: 'packages/core-backend/src/attendance/w7-provenance-domain.ts', text: 'export const ATTENDANCE_PROJECTION_OWNER_WITHOUT_CALCULATION_POINTER_V1 = \'legacy_untracked\' as const', rule: 'domain_definition' },
+  { file: 'packages/core-backend/src/attendance/w7-provenance-domain.ts', text: 'export const ATTENDANCE_TRACE_SOURCE_KINDS_V1 = [', rule: 'domain_definition' },
+  { file: 'packages/core-backend/src/attendance/w7-provenance-domain.ts', text: 'export function isAttendanceProjectionOwnerV1(value: unknown): value is AttendanceProjectionOwnerV1 {', rule: 'domain_definition' },
+  { file: 'packages/core-backend/src/attendance/w7-provenance-domain.ts', text: 'export function isAttendanceProjectionOwnerWithCalculationPointerV1(', rule: 'domain_definition' },
+  { file: 'packages/core-backend/src/attendance/w7-provenance-domain.ts', text: 'export function isAttendanceTraceSourceKindV1(value: unknown): value is AttendanceTraceSourceKindV1 {', rule: 'domain_definition' },
+  { file: 'packages/core-backend/src/attendance/w7-provenance-domain.ts', text: 'export type AttendanceProjectionOwnerV1 = (typeof ATTENDANCE_PROJECTION_OWNERS_V1)[number]', rule: 'domain_definition' },
+  { file: 'packages/core-backend/src/attendance/w7-provenance-domain.ts', text: 'export type AttendanceTraceSourceKindV1 = (typeof ATTENDANCE_TRACE_SOURCE_KINDS_V1)[number]', rule: 'domain_definition' },
+  { file: 'packages/core-backend/src/attendance/w7-provenance-domain.ts', text: 'return (ATTENDANCE_PROJECTION_OWNERS_V1 as readonly unknown[]).includes(value)', rule: 'domain_definition' },
+  { file: 'packages/core-backend/src/attendance/w7-provenance-domain.ts', text: 'return (ATTENDANCE_PROJECTION_OWNERS_WITH_CALCULATION_POINTER_V1 as readonly unknown[]).includes(value)', rule: 'domain_definition' },
+  { file: 'packages/core-backend/src/attendance/w7-provenance-domain.ts', text: 'return (ATTENDANCE_TRACE_SOURCE_KINDS_V1 as readonly unknown[]).includes(value)', rule: 'domain_definition' },
+  { file: 'packages/core-backend/src/attendance/w7-read-side-provenance-amendment.ts', text: '\'group_policy_snapshot\',', rule: 'w7_0_recorded_snapshot' },
+  { file: 'packages/core-backend/src/attendance/w7-read-side-provenance-amendment.ts', text: '\'policy_gate\',', rule: 'w7_0_recorded_snapshot' },
+  { file: 'packages/core-backend/src/attendance/w7-read-side-provenance-amendment.ts', text: '\'rule_live\',', rule: 'w7_0_recorded_snapshot' },
+  { file: 'packages/core-backend/src/attendance/w7-read-side-provenance-amendment.ts', text: 'currentMembers: Object.freeze([\'legacy_untracked\', \'w4\', \'w4_group\'] as const),', rule: 'w7_0_recorded_snapshot' },
+  { file: 'packages/core-backend/src/attendance/w7-read-side-provenance-amendment.ts', text: 'export const ATTENDANCE_W7_PROJECTION_OWNER_GROUP_VALUE_V1 = \'w4_group\' as const', rule: 'w7_0_recorded_snapshot' },
+  { file: 'packages/core-backend/src/attendance/w7-read-side-provenance-amendment.ts', text: 'export const ATTENDANCE_W7_TRACE_SOURCE_KIND_GROUP_VALUE_V1 = \'group_policy_snapshot\' as const', rule: 'w7_0_recorded_snapshot' },
+  { file: 'packages/core-backend/src/attendance/w7-read-side-provenance-amendment.ts', text: 'newValue: ATTENDANCE_W7_PROJECTION_OWNER_GROUP_VALUE_V1,', rule: 'w7_0_recorded_snapshot' },
+  { file: 'packages/core-backend/src/attendance/w7-read-side-provenance-amendment.ts', text: 'newValue: ATTENDANCE_W7_TRACE_SOURCE_KIND_GROUP_VALUE_V1,', rule: 'w7_0_recorded_snapshot' },
+  { file: 'packages/core-backend/src/services/AttendanceDecisionTrace.ts', text: 'basis.push({ source: { kind: \'policy_gate\', ref: \'auto_absence_generation\' }, version: { posture: \'undeterminable\' } })', rule: 'write_side_emitter' },
+  { file: 'packages/core-backend/src/services/AttendanceDecisionTrace.ts', text: 'return { source: { kind: \'rule_live\', ref: \'none\' }, version: { posture: \'undeterminable\' } }', rule: 'write_side_emitter' },
+  { file: 'packages/core-backend/src/services/AttendanceDecisionTrace.ts', text: 'return { source: { kind: \'rule_live\', ref: rule.refKind }, version: { posture: \'current_live_no_history\' } }', rule: 'write_side_emitter' },
+  { file: 'packages/core-backend/src/services/AttendanceDecisionTrace.ts', text: 'source: { kind: \'policy_gate\', ref: \'ATTENDANCE_APPROVAL_DYNAMIC_ASSIGNEE_SOURCES_ENABLED\' },', rule: 'write_side_emitter' },
+  { file: 'packages/core-backend/src/services/AttendanceDecisionTrace.ts', text: 'source: { kind: \'policy_gate\', ref: \'compTimeFromOvertime\' },', rule: 'write_side_emitter' },
+  { file: 'packages/core-backend/src/services/AttendanceDecisionTrace.ts', text: 'source: { kind: \'policy_gate\', ref: \'overtimeSegmentation\' },', rule: 'write_side_emitter' },
+  { file: 'packages/core-backend/src/services/AttendanceDecisionTrace.ts', text: 'source: { kind: \'rule_live\', ref: \'attendance_overtime_rules\' },', rule: 'write_side_emitter' },
+  { file: 'packages/core-backend/src/services/AttendanceDecisionTrace.ts', text: '| \'group_policy_snapshot\'', rule: 'closed_set_member_list' },
+  { file: 'packages/core-backend/src/services/AttendanceDecisionTrace.ts', text: '| \'policy_gate\'', rule: 'closed_set_member_list' },
+  { file: 'packages/core-backend/src/services/AttendanceDecisionTrace.ts', text: '| \'rule_live\'', rule: 'closed_set_member_list' },
+  { file: 'packages/core-backend/src/services/AttendanceW4CalculationDetail.ts', text: 'const PROJECTION_OWNERS = ATTENDANCE_PROJECTION_OWNERS_V1', rule: 'widened_predicate' },
+  { file: 'packages/openapi/src/base.yml', text: 'projectionOwner: { type: string, enum: [legacy_untracked, w4, w4_group] }', rule: 'closed_set_member_list' },
+  { file: 'scripts/attendance/execute-ops-retirement-cleanup.cjs', text: 'if (row.projection_owner != null && row.projection_owner !== \'legacy_untracked\') return true', rule: 'legacy_polarity' },
+  { file: 'scripts/attendance/generate-cleanup-sql.cjs', text: 'OR r.projection_owner IS DISTINCT FROM \'legacy_untracked\'', rule: 'legacy_polarity' },
+  { file: 'scripts/ops/staging-attendance-tooling-teardown.mjs', text: 'AND projection_owner IS NOT DISTINCT FROM \'legacy_untracked\'', rule: 'legacy_polarity' },
+  { file: 'scripts/ops/staging-attendance-tooling-teardown.mjs', text: 'OR projection_owner IS DISTINCT FROM \'legacy_untracked\'', rule: 'legacy_polarity' },
+  { file: 'scripts/ops/staging-attendance-tooling-teardown.mjs', text: '|| (row.projection_owner != null && row.projection_owner !== \'legacy_untracked\')', rule: 'legacy_polarity' },
+] as W7LedgerEntryV1[])

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -743,6 +743,12 @@ export default defineConfig({
       // excluded here so the no-DB job cannot skip-green it, and the whole file is explicitly
       // run in plugin-tests.yml's attendance-real-db-integration step.
       'tests/integration/attendance-w6-group-effective-policy.db.test.ts',
+      // #4556 W7-1a-M (ratified per #4556 comments 5293034619 + 5293478713): the DB half
+      // of the provenance-widening derive-and-diff. It reads the LIVE pg_constraint /
+      // pg_proc catalogue and round-trips a w4_group row, so it needs real PostgreSQL.
+      // Two-point wired: excluded from no-DB collection here, whole-file run in
+      // plugin-tests.yml's attendance-real-db-integration step.
+      'tests/integration/attendance-w7-1am-provenance-widening.db.test.ts',
       // #4556 W6-1 §7.2 fixture matrix: all eight committed aggregate fixtures are
       // reproduced from seeded rows against a dedicated disposable PostgreSQL database
       // with canonical FSER. Excluded from no-DB collection and whole-file wired below.

--- a/packages/openapi/dist-sdk/index.d.ts
+++ b/packages/openapi/dist-sdk/index.d.ts
@@ -15019,7 +15019,7 @@ export interface components {
             segments: components["schemas"]["AttendanceW4CalculationSegment"][];
             current: {
                 /** @enum {string} */
-                projectionOwner: "legacy_untracked" | "w4";
+                projectionOwner: "legacy_untracked" | "w4" | "w4_group";
                 /** @enum {string} */
                 visibilityState: "active" | "retired";
                 /** @enum {string} */

--- a/packages/openapi/dist/combined.openapi.yml
+++ b/packages/openapi/dist/combined.openapi.yml
@@ -790,6 +790,7 @@ components:
               enum:
                 - legacy_untracked
                 - w4
+                - w4_group
             visibilityState:
               type: string
               enum:

--- a/packages/openapi/dist/openapi.json
+++ b/packages/openapi/dist/openapi.json
@@ -1065,7 +1065,8 @@
                 "type": "string",
                 "enum": [
                   "legacy_untracked",
-                  "w4"
+                  "w4",
+                  "w4_group"
                 ]
               },
               "visibilityState": {

--- a/packages/openapi/dist/openapi.yaml
+++ b/packages/openapi/dist/openapi.yaml
@@ -790,6 +790,7 @@ components:
               enum:
                 - legacy_untracked
                 - w4
+                - w4_group
             visibilityState:
               type: string
               enum:

--- a/packages/openapi/src/base.yml
+++ b/packages/openapi/src/base.yml
@@ -558,7 +558,9 @@ components:
           additionalProperties: false
           required: [projectionOwner, visibilityState, visibilityReason, posture]
           properties:
-            projectionOwner: { type: string, enum: [legacy_untracked, w4] }
+            # W7-1a-M (#4556, ratified per #4556 comments 5293034619 + 5293478713):
+            # response enum widened with w4_group. INERT — no producer emits it yet.
+            projectionOwner: { type: string, enum: [legacy_untracked, w4, w4_group] }
             visibilityState: { type: string, enum: [active, retired] }
             visibilityReason: { type: string, enum: [active, review_placeholder, import_rollback, operator_retirement] }
             posture: { type: string, enum: [shadow, authoritative, undeterminable] }

--- a/plugins/plugin-integration-core/lib/sealed-export/vectors/s6a-package-provenance-pins.json
+++ b/plugins/plugin-integration-core/lib/sealed-export/vectors/s6a-package-provenance-pins.json
@@ -86,6 +86,6 @@
     "s6aAcceptancePs51Test": "835c7c6ce943d82e0378a40a27c7fd1e8b79b526faa8ca4c8066e4231a4bfb0f",
     "s6aProductRuntimeTest": "de978adafa8b89772cefa921c2051f434bf346bf5c2978bef3424ee70f51ba3f",
     "multitableOnpremPackageBuild": "ae477a24375a7269e5710a3481905c9b74255c03fd802841a16849aca48ee33a",
-    "pluginTestsWorkflow": "8a31a62b643e6da02341a30a9f3647c5a9aced16143a15289b8cc3a79cfc29b2"
+    "pluginTestsWorkflow": "dde8773d2ba9746bdeae363635a902d1e65c6b2b0de22189fe8da28a0879f19a"
   }
 }

--- a/scripts/ops/attendance-w4c2-ci-wiring.test.mjs
+++ b/scripts/ops/attendance-w4c2-ci-wiring.test.mjs
@@ -2263,6 +2263,7 @@ const EXPECTED_ATTENDANCE_SUITES = Object.freeze([
   'tests/integration/attendance-w6-group-effective-policy-fixture-matrix.db.test.ts',
   'tests/integration/attendance-w6-group-effective-policy-membership-overlap.db.test.ts',
   'tests/integration/attendance-w6-group-effective-policy.db.test.ts',
+  'tests/integration/attendance-w7-1am-provenance-widening.db.test.ts',
   'tests/integration/attendance-work-date-resolver-w2.db.test.ts',
 ])
 


### PR DESCRIPTION
**Draft / HOLD.** Build → gate → STOP. Not for merge, not for Ready.

**Lands only after #4905 (W7-1a).** The ratification serialises cycle one as
W7-1a → W7-1a-M → W7-1b. This branch is cut from `origin/main`, NOT from #4905,
and touches no `w7-resolver/` file — the two slices are independent in content
and ordered only for landing.

Ratified per #4556 comments 5293034619 + 5293478713.

## What this is

The inert schema / value-domain widening slice. The two live provenance domains
now **accept** the values W7-0 recorded:

- `projectionOwner` gains `w4_group`
- trace `source.kind` gains `group_policy_snapshot`

**INERT — nothing emits either value.** The producer seam is W7-1b. Every
pre-existing input keeps its pre-existing outcome at every widened point.

## The widening surface was DERIVED, not enumerated

The ratification refuses to enumerate it ("扩宽面不由本裁决枚举" — two hand-written
lists were refuted). Two independent mechanical derivations back this slice:

**Source text** — `packages/core-backend/tests/utils/w7-provenance-widening-scan.ts`.
Anchor on the READER (any file naming the column/field), then every line in an
anchored file carrying a domain literal, a widening symbol, or a `case` arm is a
derived site. Anchoring on readers rather than on the new value is what finds the
silent-downgrade folds, which contain no target string at all.

**Live DB** — `pg_constraint` / `pg_proc` on a migrated database. Migration TEXT
cannot be the source of truth here: `attendance_w4_records_pointer_guard` is
created by `zzzz20260725120000` and then REPLACED by `zzzz20260731120000`, so the
older file keeps its un-widened body forever. Deriving from migration text would
need a blanket exemption for historical migrations — exactly the hole that hides
a missed point. Only the catalogue says what is live.

### The derivation refuted the W7-0 record

`w7-read-side-provenance-amendment.ts` asserted that **no** exhaustive consumer of
the trace union existed anywhere in the tree. It does:
`apps/web/src/views/attendance/attendanceDecisionTrace.ts` carries an independent
copy of the domain, a **runtime membership gate**, and an exhaustive `switch`.
That stale claim is corrected in place, and the web file is widened and held
member-equal to the backend domain by test.

The gate's failure mode is **reject-whole-response**, not drop-one-entry:
`parseBasisEnv` returns null for an unknown kind, `parseBasis` abandons the whole
array on the FIRST such entry, and `parseAttendanceDecisionTraceResponse` then
returns null — so an unwidened copy makes the **entire decision trace fail to
parse and render as absent**. (An earlier revision of this body and a new in-code
comment both said "silently drops unknown kinds". That was wrong; the real
behaviour is strictly worse, which makes the widening more necessary, not less.
Both are corrected.)

## Derived widening-surface table

Line numbers below are the **pre-widening** positions on `origin/main`
(`cc69791604`), i.e. where each point was found; adding comments shifted them in
this branch. The authoritative, machine-checked list is the ledger in
`tests/utils/w7-provenance-widening-scan.ts`, which is keyed by exact source text
rather than line number precisely so it does not rot.

| Kind | Where | How widened |
|---|---|---|
| TS union (trace) | `services/AttendanceDecisionTrace.ts:102-108` | `+ 'group_policy_snapshot'` |
| Closed array behind `isClosedValue` | `services/AttendanceW4CalculationDetail.ts:94,428` | now `ATTENDANCE_PROJECTION_OWNERS_V1` |
| TS unions (owner) ×6 | `w4c3a-import-rollback.ts:371,379`, `w4c2-authoritative-calculation-core.ts:431,595,1140`, `w4c2-live-scheduled-boundary.ts:623`, `w4c0-write-boundary-types.ts:231` | now `AttendanceProjectionOwnerV1` |
| Exhaustive validation ×3 | `w4c3a-import-rollback.ts:438-441,515-518`, `w4c3a-canonical-import-kernel.ts:368-370` | membership + coupled pointer disjunct widened together |
| Pointer derivation | `w4c3a-import-rollback.ts:468` | `=== 'w4' ? uuid(...) : null` would have NULLed a `w4_group` pointer |
| Silent-downgrade folds ×2 | `w4c2-authoritative-calculation-core.ts:648`, `w4c2-live-scheduled-boundary.ts:686` | membership decides; unknown values still fold to `legacy_untracked` |
| Arm selection | `w4c2-authoritative-calculation-core.ts:843` | selects on pointer ownership, so `w4_group` matches an arm |
| Rollback eligibility | `w4c3a-import-rollback.ts:1194` | pointer-owning parents are eligible |
| SQL in TS | `w4c3a-import-rollback-boundary.ts:662` | `IN (${…POINTER_SQL_LIST_V1})` |
| OpenAPI enum | `packages/openapi/src/base.yml:561` | `+ w4_group` (dist/dist-sdk regenerated) |
| Web array + runtime gate + switch | `apps/web/.../attendanceDecisionTrace.ts:62-69,284,777-786` | `+ 'group_policy_snapshot'` + new switch arm |
| DB CHECK | `chk_ar_projection_owner` | widened via NEW zzzz migration |
| DB trigger | `attendance_w4_records_pointer_guard` | `OLD.projection_owner IN ('w4','w4_group')` |
| DB trigger | `attendance_w4c3a_restore_witness_command_guard` | `NOT IN` membership **and** the coupled pointer disjunct |
| **UNCHANGED (ruling)** | `chk_ar_owner_pointer_pair` | verified byte-identical, not edited |

Machine-adjudicated as needing no edit: `legacy_untracked`-polarity branches
(the new member takes `w4`'s arm automatically), write-side emitters, one
`?? 'legacy_untracked'` null-default, and value-agnostic comparisons.

## Semantic ruling

`w4_group` inherits `w4`'s NON-NULL calculation-pointer semantics;
`legacy_untracked` remains the only NULL-pointer member. So
`chk_ar_owner_pointer_pair` — `(projection_owner='legacy_untracked') = (current_calculation_id IS NULL)`
— is **correct as written** and deliberately NOT edited. The .db test proves it
still refuses a `w4_group` row with a NULL pointer, on both the UPDATE and INSERT
paths, rather than asserting it from the text.

## DB discipline

All DB changes land in ONE new migration,
`zzzz20260815120000_w7_1am_provenance_domain_widening.ts`. Historical migrations
are untouched; the new value enters via a zzzz migration as required. The two
superseding trigger bodies were **extracted mechanically** from the current
definitions with only the derived substitutions applied, never retyped.

That extraction claim is itself **asserted in-tree**, not just stated in prose:
the "superseding plpgsql body fidelity" block reads BOTH migration files off disk
as text, extracts each `$fn$…$fn$` body, and proves the superseding body equals
the historical body with exactly the three named substitutions (each matching
exactly once), and that `down()` restores the historical bodies byte-identically.
A stray edit anywhere else in those ~500 lines reds it. The diff is deliberately
source-text rather than a comparison against ambient `prosrc`, because sibling
suites replay historical migrations and make the "pre-migration" catalogue body
order-dependent.

## Tests

`tests/unit/attendance-w7-1am-provenance-widening-completeness.test.ts` (18) is
the load-bearing deliverable: it walks the derived table and reds if any point is
un-widened, in both directions.

- **Non-vacuity**: ≥500 files scanned, ≥10 anchored, ≥80 sites, every rule name
  exercised, every consumer KIND the ruling names present, and the alias taint
  hop asserted to have found real aliases (`owner`, `projectionOwner`).
- **Planted consumers**: an un-widened membership test reds; a silent-downgrade
  fold containing no target string is still derived; an exhaustive `switch` arm
  is derived although it names no field; a stale ledger entry reds. The
  un-widened plant also reds *even if someone ledgers it as widened*, so the
  ledger cannot wave a real gap through.

`tests/integration/attendance-w7-1am-provenance-widening.db.test.ts` (14) covers
the live catalogue, a `w4_group` round-trip through CHECK + coupled CHECK +
pointer guard, the NULL-pointer refusal, and novel-value refusal. The catalogue
derivation spans `pg_constraint`, `pg_proc`, `pg_trigger`, `pg_attrdef`,
`pg_views`, `pg_indexes` and `pg_policies` — `pg_trigger` on its own account,
because a trigger's WHEN clause is the FIRING GATE for its function: a
`'w4'`-polarity WHEN clause would bypass the pointer guard for exactly the new
member while the body still looked perfectly widened.

**Mutation-verified** (each restored from a file/DB backup, never `git checkout`):

| Mutation | Result |
|---|---|
| revert one silent-downgrade fold | completeness test reds, naming the exact line |
| revert `chk_ar_projection_owner` | 4 DB legs red |
| over-widen the CHECK with `w4_team` | novel-value legs red |
| give `w4_group` NULL-pointer semantics | invariant + semantic legs red |
| stray edit inside a hand-carried plpgsql body | fidelity leg reds, naming the function |
| make a trigger WHEN clause `'w4'`-polarity | WHEN-clause + ledger legs red |

## Independent gate

An independent adversarial review ran against `5d4a0de3dd` and returned **0 P1,
1 P2** — so that head did **not** clear the ratification's `0 P1 / 0 P2` bar. The
P2 was a *claim-vs-artifact* defect: the migration header asserted a body-diff
test that did not exist, over the ~500 lines of hand-carried plpgsql — the
artifact with the least behavioural coverage in the PR. It is fixed by
**implementing** the assertion (the reviewer's preferred option), not by deleting
the sentence; the two mutation rows added above are that test biting. The
reviewer's P3 on the DB derivation's "complete by construction" claim is also
addressed, by widening the catalogue query and ledgering what it found (which
immediately announced the `attendance_current_records` view — the derivation
working as designed). Remaining P3s — durability blind spots in the scanner with
zero live escapees — are recorded and deliberately not chased point-by-point,
since enumerating trap shapes is the pattern that does not converge.

### Re-gate verdict

A delta re-gate at `6b1c446a4f79442e10e9b9a1b25e586559b0509b` returned
**0 P1 / 0 P2 — the ratification's bar IS met at this head.** Its decisive
evidence: the same deep mutation (migration `:158`, `outcome NOT IN
('completed','reversed')` → `+ 'aborted'`) reds the unit fidelity leg naming
`attendance_w4_records_pointer_guard` while the `.db` suite stays 14/14 green —
proving the new fidelity leg is the **sole** gate on the ~500 carried plpgsql
lines, not redundant coverage. Order-stability was confirmed by replaying
0725/0731 between runs.

### Gate round 2 — CHANGES-REQUESTED, now addressed

A further independent gate at `6b1c446a4f` returned **0 P1 / 1 P2 / 5 P3 / 4 NIT**
and is the authoritative verdict; the P2 is fixed here.

**P2-1 — the derivation's FILE-LEVEL anchor gate was evadable.** It short-circuited
before any line rule, anchoring only on `{projection_owner, projectionOwner,
PROJECTION_OWNERS}` — but **four of the eight owner-family widening symbols do not
contain any of those strings** (`AttendanceProjectionOwnerV1`,
`isAttendanceProjectionOwnerV1`,
`isAttendanceProjectionOwnerWithCalculationPointerV1`,
`ATTENDANCE_W7_PROJECTION_OWNER_GROUP_VALUE_V1`). A realistic un-widened consumer
typed against the union and spelling no column name — planted live in
`src/attendance/` with a silent downgrade of `w4_group` to `legacy_untracked` —
left the load-bearing test **18/18 green**, and `tsc` exited 0. The trace family
had no such hole; that asymmetry was the tell. `tsc` structurally cannot cover
this class: a narrowing fold returns `'w4' | 'legacy_untracked'`, always
assignable to the widened union.

Fixed to the gate's own falsifiable closure criterion — anchor on **every list the
module already derives** (field spellings ∪ widening symbols ∪ distinctive
literals), plus an import-rename taint hop, plus the trace family's field
spellings evaluated over the enclosing declaration. That is reuse of lists derived
from the widening itself, not enumeration of trap shapes. Four permanent
negative-control plants were added, including one that **names no field spelling
at all** — the class every previous plant pre-satisfied. Verified: the new plants
red with the fix reverted, and derive with it applied.

Derivation went 95 → 122 sites, ledger 89 → 109, with one new machine-checked
rule (`single_member_selector`, for `env.source.kind === 'audit'`-shaped
selectors). Zero unclassified.

**P3-1 closed** — the WHEN-clause leg was a text check; the gate proved a rewrite
(`… AND NEW.projection_owner <> 'w4_group'`) passed 14/14 while genuinely
bypassing the guard for exactly the new member. Replaced with a **behavioural
firing check** (construct the drifted row the guard must refuse; require
`W4C0_POINTER`), with a `w4` positive control on the same assertion. Verified: the
gate's exact bypass now reds it.

**P3-3 closed** — the `others` catalogue UNION filtered only the snake_case
spelling while its constraint/proc siblings check both; the JSONB preimage is
addressed as `->> 'projectionOwner'`, which is how the two widened guards reach
the domain. Both spellings now, in all five branches.

**P3-4 closed** — the apps/web failure mode was misstated (see above).

**NITs closed** — dead export removed; the two `.db` legs that used the
constant-under-test as their own oracle now pin literal expectations first; the
novel-value leg is split so the closed-set CHECK is discriminated individually
rather than covered for by the pair constraint; the `write_side_emitter`
predicate now names `~~`/`LIKE`/`ANY` (Postgres deparses `LIKE` as `~~`, so an
absence-based rule must name every form it excludes) and the column default is
re-ledgered as `legacy_polarity`, which names the value instead of relying on
absence; stale header and no-op `.replace` fixed.

**P3-2 / P3-5 kept as-is** per the gate: the catalogue-scope disclosure was
verified accurate with zero live escapees, and the owner-flag is adequately
placed. The gate independently assessed both options for
`OLD.projection_owner IN ('w4','w4_group')` and **recommends keeping Option A**
(as built) as the safer and ruling-consistent one — the decision remains the
owner's.

### Residual P3s / NITs — recorded, NOT fixed here

Stated so the boundary of the P2 fix is explicit rather than implied. Zero live
escapees for each, verified by set-difference over the tree/catalogue at head:

1. **The enumeration frontier itself.** A consumer that references NOTHING in any
   of the three derived lists — no field spelling, no widening symbol, no
   distinctive literal — is not derivable by this design. The gate names this as
   the legitimate frontier and P3 rather than P2, and it is where chasing further
   trap shapes stops converging. Today no such consumer exists: every file using a
   non-anchoring symbol also carries a field spelling (A \ B = ∅).
2. **Catalogue scope**: `pg_attrdef` is matched by column name OR expression text
   while its siblings match expression text only (a generated column
   `GENERATED ALWAYS AS (projection_owner = 'w4')` is derivable via the expression
   arm but not guaranteed by name); `pg_views` excludes materialized views;
   `pg_rewrite` is unqueried. Independently swept at head: zero live objects
   outside the queried catalogues carry the domain.
3. **`write_side_emitter` remains absence-based by nature** — it is the rule for
   "this is not a test at all". Its exclusion list now names `~~`/`LIKE`/`ANY`
   alongside the operators, and the one live emitter row was re-ledgered to a
   value-naming rule, but the class is intrinsically weaker than a positive rule
   and a future author choosing it for a genuine comparison is still possible.

## Boundaries I am flagging, not hiding

1. **The W4C3A_WITNESS widening is proven by catalogue + live-text `IN`-list
   evaluation in real Postgres, NOT by an end-to-end witness-row insert.** A
   `w4_group` preimage can only arise once a producer exists, which is W7-1b. The
   `IN` lists are extracted from live `prosrc` and executed, so the assertion is
   about deployed text — but it is not a full trigger-path exercise.
2. **`OLD.projection_owner IN ('w4','w4_group')` in the pointer guard is my
   adjudication, not something the ruling names.** Under the uniform
   `'w4'`-polarity rule the new member takes `w4`'s arm; the alternative (leave
   it, making `w4_group` a trap state for import-rollback restore) is also
   defensible. An owner may want to review this one line.
3. **Pre-existing shared-DB replay hazard, disclosed not introduced.**
   `attendance-w4c0-db-gates-e1.db.test.ts` re-runs `zzzz20260725120000.up()`,
   which `CREATE OR REPLACE`s the shared `attendance_w4_records_pointer_guard`
   with its 2026-07-25 body — reverting both this slice's widening AND
   zzzz20260731120000's witness-restore exception for whatever runs after it, so
   the live catalogue depends on suite ORDER. Production is unaffected (migrations
   apply in order; this one is last). This .db test re-applies its own `up()` in
   `beforeAll`, the same thing e1 does for its migration.

## CI wiring

Two-point wired: `vitest.config.ts` exclude + `plugin-tests.yml`
`attendance-real-db-integration` run-list, plus the `EXPECTED_ATTENDANCE_SUITES`
tripwire updated per its own documented procedure
(`EMIT_ATTENDANCE_CORPUS=1`). Because the run-list edit changes
`plugin-tests.yml`'s sha256, the s6a `evidenceFiles.pluginTestsWorkflow` pin is
regenerated in the same commit
(`8a31a62b…` → `dde8773d…`).

`packages/openapi/dist` and `dist-sdk/index.d.ts` are regenerated so the CI drift
check stays green.
