### PR TITLE
fix(integration): stop exact-two apply after first save failure

### DIFF
--- a/docs/development/integration-k3wise-exact-two-saveonly-fast-track-20260813.md
+++ b/docs/development/integration-k3wise-exact-two-saveonly-fast-track-20260813.md
@@ -65,6 +65,8 @@ Apply 在任何目标写入前失败。
 
 Apply 在任何 `insertRows` Save 之前，会对全部 add 行再用同一严格 lookup 做一次整批预检：任一行已存在、键歧义、lookup 抛错或返回畸形结构，整批拒绝且 Save 次数为零。这不是原子 K3 insert-only。K3 Save 仍是 upsert；planner lookup 与预检 / Save 之间仍有 TOCTOU 窗口。真实实体执行在 owner 接受、或 K3 提供 create-only 之前仍未授权。
 
+精确两行策略还采用更严格的运行时停止条件：若第一条 Save 抛错，Apply 立即停止，不再尝试第二条 Save，回执只记录已尝试行的 values-free 失败计数。该行为仅适用于 `k3-test-only-exact-two-add-v1`；其他 C6 批次继续保持既有的逐行错误隔离语义。
+
 ## 页面交互
 
 工作台只展示状态、计数和固定策略信息，不展示 token、行值、目标 payload 或私密 lookup 配置。受控策略启用时：
@@ -98,4 +100,4 @@ realK3Calls=0
 entityServerMutations=0
 ```
 
-负控覆盖：非 K3 目标、未知策略字段、非两行、出现 update、重复 `FNumber`、普通写入用户设置/清空私密策略、策略在 token 后漂移、泛化 `K3_WISE_READ_BUSINESS_ERROR` 在受控策略下不得当缺席、planner lookup 之后目标变为已存在/歧义/lookup 失败则整批零 Save、无 tenant 的 `role:admin` 与跨 tenant carrier 在 Apply/私密策略变更上失败关闭，以及浏览器不渲染私密证据字段。
+负控覆盖：非 K3 目标、未知策略字段、非两行、出现 update、重复 `FNumber`、普通写入用户设置/清空私密策略、策略在 token 后漂移、泛化 `K3_WISE_READ_BUSINESS_ERROR` 在受控策略下不得当缺席、planner lookup 之后目标变为已存在/歧义/lookup 失败则整批零 Save、精确两行策略首条 Save 失败后不调用第二条 Save、普通 C6 策略仍隔离失败并继续干净兄弟行、无 tenant 的 `role:admin` 与跨 tenant carrier 在 Apply/私密策略变更上失败关闭，以及浏览器不渲染私密证据字段。

--- a/plugins/plugin-integration-core/__tests__/external-write-dry-run.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/external-write-dry-run.test.cjs
@@ -928,6 +928,40 @@ async function testK3ExactTwoAcceptancePolicyAllowsOnlyExactAddPlan() {
   assert.equal(calls.lookupByKey.length, 6, 'apply preflights both add rows after the planner lookups')
 }
 
+async function testK3ExactTwoAcceptanceStopsAfterFirstSaveFailure() {
+  const deadLetters = []
+  const { input, calls } = k3ExactTwoAcceptanceInput({
+    insertRows: () => {
+      throw new Error('K3 Save failed with private row values')
+    },
+  })
+  const dryRun = await dryRunExternalWrite(input)
+  const apply = await applyExternalWrite({
+    ...input,
+    dryRunToken: dryRun.dryRunToken,
+    applyUser: 'user_read',
+    runId: 'run_k3_exact_two_first_save_failure',
+    deadLetterStore: {
+      async createDeadLetter(entry) {
+        deadLetters.push(entry)
+        return { ...entry, id: `dl_${deadLetters.length}` }
+      },
+    },
+  })
+
+  assert.equal(apply.status, 'failed')
+  assert.equal(apply.counts.written, 0)
+  assert.equal(apply.counts.add, 0)
+  assert.equal(apply.counts.failed, 1)
+  assert.equal(calls.insertRows.length, 1, 'strict exact-two stops without attempting the sibling Save')
+  assert.equal(calls.updateRows.length, 0)
+  assert.deepEqual(apply.deadLetters, { attempted: 1, persisted: 1 })
+  const evidence = JSON.stringify(apply) + JSON.stringify(deadLetters)
+  for (const privateValue of ['P-001', 'P-002', 'Widget', 'Gadget']) {
+    assert.equal(evidence.includes(privateValue), false, `strict failure evidence stays values-free (${privateValue})`)
+  }
+}
+
 async function testK3ExactTwoAcceptancePolicyRejectsDuplicateMaterialKeysBeforeApply() {
   const { input, calls } = k3ExactTwoAcceptanceInput({
     sourceRows: [
@@ -1227,6 +1261,7 @@ async function main() {
   await testWriteSourceSeamGeneralizesLifecycleOffSqlProfile()
   await testWriteSourceSeamIsolatesRowFailureValuesFree()
   await testK3ExactTwoAcceptancePolicyAllowsOnlyExactAddPlan()
+  await testK3ExactTwoAcceptanceStopsAfterFirstSaveFailure()
   await testK3ExactTwoAcceptancePolicyRejectsDuplicateMaterialKeysBeforeApply()
   await testK3ExactTwoAcceptancePolicyBlocksUpdateOrWrongCardinality()
   await testK3ExactTwoAcceptancePolicyIsClosedAndRevisionBound()

--- a/plugins/plugin-integration-core/lib/external-write-dry-run.cjs
+++ b/plugins/plugin-integration-core/lib/external-write-dry-run.cjs
@@ -1055,6 +1055,7 @@ async function applyExternalWrite(input = {}) {
   const rowErrors = []
   const provenanceEvents = []
   const runId = optionalString(input.runId) || syntheticRunId(plan.pipeline, plan.revision)
+  const stopOnFirstWriteFailure = isStrictAddOnlyAcceptance(plan.acceptancePolicy)
   let writeOrdinal = 0
   for (const row of plan.planRows) {
     if (row.decision === 'skip') {
@@ -1133,6 +1134,11 @@ async function applyExternalWrite(input = {}) {
         eventType: 'target_write_failed',
         attrs: { decision: row.decision, errorCode },
       }))
+      // The exact-two K3 acceptance window is a supervised, rollback-bound exception.
+      // Once one Save fails, attempting its sibling would enlarge the partial-write set
+      // and violate the operation's fail-closed cleanup contract. Other C6 profiles retain
+      // their established row-isolation semantics and continue processing clean siblings.
+      if (stopOnFirstWriteFailure) break
     }
   }
   const status = applyStatus(counts)


### PR DESCRIPTION
## Outcome

The K3 `k3-test-only-exact-two-add-v1` acceptance path now stops immediately when the first Save fails, so it cannot enlarge a partial-write set by attempting the sibling Save.

## Scope

- strict exact-two K3 policy only;
- generic C6 row-isolation behavior remains unchanged;
- failure receipt remains values-free;
- Development & Verification boundary updated;
- no entity server mutation, deployment, or real K3 call performed.

## Verification

- `node plugins/plugin-integration-core/__tests__/external-write-dry-run.test.cjs` — PASS
- `node plugins/plugin-integration-core/__tests__/k3-wise-c6-write-profile.test.cjs` — 48/48 PASS
- `node plugins/plugin-integration-core/__tests__/http-routes.test.cjs` — PASS
- `git diff --check` — PASS

Related: #4861

`independentHumanReviewClaimed=NO`