### PR TITLE
docs(approval): stamp wave-3 residual closeout and palette-focus canaries

### DIFF
--- a/.github/workflows/approval-web-guard.yml
+++ b/.github/workflows/approval-web-guard.yml
@@ -110,6 +110,7 @@ on:
       - 'apps/web/tests/approval-version-dual-canvas.test.ts'
       - 'apps/web/tests/approval-flow-canvas-a11y.test.ts'
       - 'apps/web/tests/approval-canvas-inspector-a11y.test.ts'
+      - 'apps/web/tests/approval-form-palette-focus.test.ts'
       - 'apps/web/src/approvals/approvalFormAuthoringHistory.ts'
       - 'apps/web/src/approvals/approvalVersionDualCanvas.ts'
       - 'apps/web/src/approvals/approvalVersionReadSummary.ts'
@@ -303,6 +304,7 @@ on:
       - 'apps/web/tests/approval-version-dual-canvas.test.ts'
       - 'apps/web/tests/approval-flow-canvas-a11y.test.ts'
       - 'apps/web/tests/approval-canvas-inspector-a11y.test.ts'
+      - 'apps/web/tests/approval-form-palette-focus.test.ts'
       - 'apps/web/src/approvals/approvalFormAuthoringHistory.ts'
       - 'apps/web/src/approvals/approvalVersionDualCanvas.ts'
       - 'apps/web/src/approvals/approvalVersionReadSummary.ts'
@@ -470,6 +472,7 @@ jobs:
             approval-version-dual-canvas \
             approval-flow-canvas-a11y \
             approval-canvas-inspector-a11y \
+            approval-form-palette-focus \
             --reporter=dot
 
       - name: Run FWB mapping authoring contract

--- a/apps/web/scripts/run-required-web-tests.sh
+++ b/apps/web/scripts/run-required-web-tests.sh
@@ -139,7 +139,7 @@
 # any existing token).
 set -euo pipefail
 cd "$(dirname "$0")/.."
-# Always-on Canvas V2 + residual PLAN 6fa2fbf6 / wave-3 canaries (files landed on main via #4815–#4819).
+# Always-on Canvas V2 + residual PLAN 6fa2fbf6 / wave-3 canaries (files landed on main via #4815–#4826).
 npx vitest run \
   approval-canvas-commands \
   approval-form-commands \
@@ -150,6 +150,7 @@ npx vitest run \
   approval-version-dual-canvas \
   approval-flow-canvas-a11y \
   approval-canvas-inspector-a11y \
+  approval-form-palette-focus \
   --reporter=dot
 npx vitest run featureFlagsApprovalAttachments --reporter=dot
 npx vitest run approval-fwb-mapping-config approval-fwb-mapping-editor --reporter=dot

--- a/docs/development/approval-canvas-residual-parallel-closeout-verification-20260815.md
+++ b/docs/development/approval-canvas-residual-parallel-closeout-verification-20260815.md
@@ -1,0 +1,119 @@
+# Approval Canvas Residual Parallel — As-built Closeout (2026-08-15)
+
+**Status:** ENGINEERING CLOSEOUT ONLY — residual product PRs are on main; ledgers stamped DONE; palette-focus canary wired  
+**Integration head:** `origin/main` `348eccde90825591ed6af0b6e503d152fe3cc672`  
+`feat(attendance): Gate D3 — wire scheduled authoritative writes to the D1 core (#4556) (#4903)`  
+Residual vitest + `SKIP_TESTS=1` smoke were re-run on this closeout branch after rebase onto that head.  
+**This closeout:** ledger honesty + always-on canary wiring for every residual test that already exists on that head. No residual product behavior was re-implemented.
+
+## 0. Non-claims
+
+| Claim | Status |
+|---|---|
+| Residual product PRs merged on main | **YES** — `#4815` `#4816` `#4817` `#4818` `#4819` `#4823` `#4824` `#4825` `#4826` (and engineering land `#4806`) |
+| Wave-3 design ledger left OPEN | **NO** — stamped DONE with those PR numbers |
+| Real-tenant UAT | **NOT CLAIMED** |
+| Staged / production flag ON | **NOT CLAIMED** |
+| Product FINAL | **NOT CLAIMED** |
+| Owner G0 ratify (`PROPOSED` → `RATIFIED`) | **NOT CLAIMED** — lock Status lines unchanged |
+
+## 1. Residual PRs on the integration head
+
+From `{SCRATCH}/residual-prs.log` (`git log --oneline -F --grep='(#NNNN)'` on `348eccde90`):
+
+| PR | SHA | Subject |
+|---|---|---|
+| #4806 | `323d7e1afe` | Canvas V2 final-eligibility engineering |
+| #4815 | `a06ce31928` | form session undo/redo |
+| #4816 | `52796b726e` | dual-canvas version compare |
+| #4817 | `f814e6c61b` | residual G5-C canaries + owner UAT smoke harness |
+| #4818 | `5c3146acbc` | flow-canvas edge-insert a11y |
+| #4819 | `60659ddc3b` | inspector topology a11y |
+| #4823 | `2f86b92207` | wave-3 always-on residual canaries and smoke |
+| #4824 | `99c49475bb` | edge-insert menu item a11y |
+| #4825 | `5e1efd3e31` | form palette focus-return |
+| #4826 | `88d5cb14ce` | G5-C residual structural pins |
+
+Design ledgers:
+
+- `docs/development/approval-canvas-residual-parallel-design-20260808.md` — DONE (wave-1) `#4815`–`#4817`; canary list includes `approval-form-palette-focus` (`#4825`); follow-on wave-3 DONE `#4823`–`#4826`
+- `docs/development/approval-canvas-residual-parallel-wave2-design-20260808.md` — DONE `#4818`–`#4819`; follow-on wave-3 DONE `#4823`–`#4826`
+- `docs/development/approval-canvas-residual-parallel-wave3-design-20260808.md` — **DONE (wave-3)** `#4823` `#4824` `#4825` `#4826` (no OPEN rows)
+
+## 2. Always-on canary wiring (including palette-focus)
+
+`{SCRATCH}/canary-wiring.log` records that all six residual suites are required here:
+
+| Surface | Tokens present |
+|---|---|
+| `.github/workflows/approval-web-guard.yml` (path filters ×2 + canary vitest) | `approval-form-authoring-history`, `approval-version-dual-canvas`, `approval-flow-canvas-a11y`, `approval-canvas-inspector-a11y`, `approval-form-palette-focus`, `approval-g5c-authoring-scenarios` |
+| `apps/web/scripts/run-required-web-tests.sh` | same six (always-on block; no env flag) |
+| `scripts/ops/approval-canvas-owner-uat-smoke.sh` | `require_file` for the six test files (and form/dual-canvas modules); focused vitest list includes palette-focus |
+
+Absence of `approval-form-palette-focus` on those three surfaces was the leftover honesty/wiring gap after `#4823`–`#4826`.
+
+## 3. Residual vitest (real files on the integration-head worktree)
+
+Command (from `apps/web`, `--watch=false`):
+
+```bash
+pnpm exec vitest run --watch=false \
+  tests/approval-form-authoring-history.test.ts \
+  tests/approval-version-dual-canvas.test.ts \
+  tests/approval-flow-canvas-a11y.test.ts \
+  tests/approval-canvas-inspector-a11y.test.ts \
+  tests/approval-form-palette-focus.test.ts \
+  tests/approval-g5c-authoring-scenarios.test.ts \
+  --reporter=verbose
+```
+
+Capture: `{SCRATCH}/residual-vitest.log`
+
+| Result | Count |
+|---|---:|
+| Test files | **6 passed** |
+| Tests | **42 passed** |
+
+All six listed files ran. These are the shipped tests on this head, not copies.
+
+## 4. Owner smoke (values-free)
+
+```bash
+SKIP_TESTS=1 scripts/ops/approval-canvas-owner-uat-smoke.sh
+```
+
+Capture: `{SCRATCH}/owner-smoke.log`
+
+- Exit 0 / `approval-canvas-owner-uat-smoke: PASS`
+- Requires residual test files including `approval-form-palette-focus.test.ts` and `approval-g5c-authoring-scenarios.test.ts`
+- Does not set or recommend flipping `approvalCanvasV2`, FWB, or attachments flags
+- Does not claim product FINAL
+
+## 5. Flag defaults and lock ratify (unchanged)
+
+Capture: `{SCRATCH}/flags-default-off.log`
+
+| Gate | Default |
+|---|---|
+| `apps/web/src/stores/featureFlags.ts` `featureDefaults` | `approvalCanvasV2: false`, `approvalFwbWriteback: false`, `approvalAttachments: false` |
+| `isApprovalCanvasV2Enabled` | `APPROVAL_CANVAS_V2_ENABLED === 'true'` only |
+| `isFwbWritebackEnabled` | `APPROVAL_FWB_WRITEBACK_ENABLED === 'true'` only |
+| `isApprovalAttachmentsEnabled` | `APPROVAL_ATTACHMENTS_ENABLED === 'true'` only |
+| Canvas V2 interaction lock | **Status: PROPOSED** (unchanged) |
+| Canvas V2 development plan | **Status: PROPOSED** (unchanged) |
+
+## 6. Scratch evidence paths
+
+Implementer scratch dir (goal `{SCRATCH}`):
+
+`/var/folders/yh/vsjnc3z117zg5_rxcjdml1k00000gn/T/grok-goal-2cfbd188afc9/implementer`
+
+| File | What it proves |
+|---|---|
+| `residual-prs.log` | residual PR SHAs on `0261b33c61` |
+| `canary-wiring.log` | always-on / `require_file` lines including palette-focus |
+| `residual-vitest.log` | 6 files / 42 passed |
+| `owner-smoke.log` | `SKIP_TESTS=1` exit 0, files required, no flag flip |
+| `flags-default-off.log` | canvas / FWB / attachments default OFF; locks still PROPOSED |
+
+Owner-only remainder (out of this closeout): G0 ratify, real-tenant UAT, staged flag enablement, product FINAL.

--- a/docs/development/approval-canvas-residual-parallel-design-20260808.md
+++ b/docs/development/approval-canvas-residual-parallel-design-20260808.md
@@ -60,15 +60,17 @@ Agents may implement, test, push, open draft PRs, arm auto-merge when green. Mus
 - Existing Canvas V2 canaries remain required always-on:
   `approval-canvas-commands`, `approval-form-commands`, `approval-authoring-history`,
   `approval-g5c-authoring-scenarios`, `approval-version-read-summary`.
-- Residual canaries (promoted always-on in wave-3 after files landed):
+- Residual canaries (promoted always-on in wave-3 after files landed; palette-focus added in residual closeout):
   - `approval-form-authoring-history` (#4815)
   - `approval-version-dual-canvas` (#4816)
   - `approval-flow-canvas-a11y` (#4818)
   - `approval-canvas-inspector-a11y` (#4819)
+  - `approval-form-palette-focus` (#4825)
 - Owner smoke: `SKIP_TESTS=1 scripts/ops/approval-canvas-owner-uat-smoke.sh` for values-free checks;
   omit `SKIP_TESTS` to also run focused history + G5-C + residual vitest when `pnpm` is available.
 
 ## Follow-on
 
 - Wave-2 a11y polish: see `approval-canvas-residual-parallel-wave2-design-20260808.md` (DONE #4818–#4819).
-- Wave-3 canaries/smoke + remaining polish: see `approval-canvas-residual-parallel-wave3-design-20260808.md` (`6fa2fbf6-w3`).
+- Wave-3 canaries/smoke + remaining polish: see `approval-canvas-residual-parallel-wave3-design-20260808.md` (DONE #4823–#4826).
+- Residual as-built closeout (no UAT / flag ON / product FINAL): `approval-canvas-residual-parallel-closeout-verification-20260815.md`.

--- a/docs/development/approval-canvas-residual-parallel-wave2-design-20260808.md
+++ b/docs/development/approval-canvas-residual-parallel-wave2-design-20260808.md
@@ -45,4 +45,4 @@ Level 0: PR4 || PR5   (and continue babysit wave-1 #4815||#4816||#4817)
 
 ## Follow-on
 
-Wave-3 (`6fa2fbf6-w3`): promote residual canaries always-on + smoke honesty + additional polish lanes — see `approval-canvas-residual-parallel-wave3-design-20260808.md`.
+Wave-3 (`6fa2fbf6-w3`): promote residual canaries always-on + smoke honesty + additional polish lanes — see `approval-canvas-residual-parallel-wave3-design-20260808.md` (DONE #4823–#4826).

--- a/docs/development/approval-canvas-residual-parallel-wave3-design-20260808.md
+++ b/docs/development/approval-canvas-residual-parallel-wave3-design-20260808.md
@@ -1,8 +1,9 @@
 # Approval Canvas Residual Parallel — Wave 3 (2026-08-08)
 
-**Status:** AUTHORITATIVE FOR WAVE-3 PARALLEL EXECUTION  
+**Status:** DONE (wave-3)  
 **PLAN_ID:** `6fa2fbf6-w3`  
 **Base:** `origin/main` after wave-1 (#4815–#4817) + wave-2 (#4818–#4819)  
+**Merged:** #4823 (PR6 canaries/smoke), #4824 (PR7 edge-insert menu a11y), #4825 (PR8 form palette focus), #4826 (PR9 G5-C residual pins)  
 **Flags:** default OFF. No product FINAL. No G0 ratify flip.
 
 ## Goal
@@ -25,25 +26,25 @@ Four independent residual polish lanes with **no shared hot file**:
 
 ## PR Plan
 
-### PR 6: Promote residual canaries + smoke honesty — OPEN
+### PR 6: Promote residual canaries + smoke honesty — DONE (#4823)
 
 - **Description:** Residual test files now exist on main. Promote form-history + dual-canvas from optional `test -f` to always-on canaries; add flow-canvas-a11y + inspector-a11y canaries. Update owner smoke to verify residual modules present. Stamp wave-1/2 design ledgers DONE with PR numbers.
 - **Files/components affected:** `.github/workflows/approval-web-guard.yml`, `apps/web/scripts/run-required-web-tests.sh`, `scripts/ops/approval-canvas-owner-uat-smoke.sh`, residual design MDs (wave1/2/3)  
 - **Dependencies:** None  
 
-### PR 7: Edge-insert menu item a11y — OPEN
+### PR 7: Edge-insert menu item a11y — DONE (#4824)
 
 - **Description:** Menu buttons for insert approval/condition/parallel get business-language `aria-label` (no edge keys). Fit-to-view control gets aria-label if missing. Expand `approval-flow-canvas-a11y.test.ts` structural pins. No graph semantics.
 - **Files/components affected:** `apps/web/src/approvals/components/ApprovalFlowCanvas.vue`, `apps/web/tests/approval-flow-canvas-a11y.test.ts`  
 - **Dependencies:** None  
 
-### PR 8: Form palette focus return after add — OPEN
+### PR 8: Form palette focus return after add — DONE (#4825)
 
 - **Description:** After `addFieldOfType` / structural add, focus the new field row (or set selection) so keyboard/screen-reader authors land on the created field. Optional `aria-live` polite announcement. Wire through existing form history. Tests structural or focused mounted pin for focus/selection.
 - **Files/components affected:** `apps/web/src/views/approval/TemplateAuthoringView.vue`, optional `apps/web/tests/approval-form-palette-focus.test.ts`  
 - **Dependencies:** None  
 
-### PR 9: G5-C residual structural pins — OPEN
+### PR 9: G5-C residual structural pins — DONE (#4826)
 
 - **Description:** Extend G5-C suite (source-scan style) to pin: form undo/redo testids, dual-canvas testids/module import, edge-insert + inspector a11y labels. No product code.
 - **Files/components affected:** `apps/web/tests/approval-g5c-authoring-scenarios.test.ts`  
@@ -58,3 +59,7 @@ Level 0 parallel: PR6 || PR7 || PR8 || PR9
 ## Autonomy
 
 Agents implement, test, push, open PRs, arm squash auto-merge. Must not flip flags or claim product FINAL.
+
+## Closeout
+
+As-built residual closeout (no UAT / flag ON / product FINAL): `docs/development/approval-canvas-residual-parallel-closeout-verification-20260815.md`

--- a/scripts/ops/approval-canvas-owner-uat-smoke.sh
+++ b/scripts/ops/approval-canvas-owner-uat-smoke.sh
@@ -119,6 +119,8 @@ require_file "apps/web/tests/approval-form-authoring-history.test.ts"
 require_file "apps/web/tests/approval-version-dual-canvas.test.ts"
 require_file "apps/web/tests/approval-flow-canvas-a11y.test.ts"
 require_file "apps/web/tests/approval-canvas-inspector-a11y.test.ts"
+require_file "apps/web/tests/approval-form-palette-focus.test.ts"
+require_file "apps/web/tests/approval-g5c-authoring-scenarios.test.ts"
 
 # ---------------------------------------------------------------------------
 # 5) Optional focused vitest. Skippable via SKIP_TESTS=1.
@@ -137,6 +139,7 @@ else
       tests/approval-version-dual-canvas.test.ts \
       tests/approval-flow-canvas-a11y.test.ts \
       tests/approval-canvas-inspector-a11y.test.ts \
+      tests/approval-form-palette-focus.test.ts \
       --reporter=dot; then
       ok "focused vitest (history + g5c + residual) passed"
     else


### PR DESCRIPTION
## Why

Wave-3 residual product work (`#4823`–`#4826`) is already on `main`, but the wave-3 design ledger still said OPEN and `approval-form-palette-focus` was missing from the always-on canary / owner-smoke `require_file` lists.

This is ledger honesty + canary wiring only. It does **not** re-implement residual product behavior, flip flag defaults, ratify G0, run real-tenant UAT, or claim product FINAL.

## What changed

- Stamp residual design ledgers DONE with merged PR numbers (`#4815`–`#4819`, `#4823`–`#4826`). Wave-3 is no longer OPEN.
- Add `approval-form-palette-focus` to:
  - `.github/workflows/approval-web-guard.yml` (path filters + canary vitest)
  - `apps/web/scripts/run-required-web-tests.sh`
  - `scripts/ops/approval-canvas-owner-uat-smoke.sh` (`require_file` + focused vitest list)
- Also `require_file` `approval-g5c-authoring-scenarios.test.ts` in owner smoke.
- Add as-built closeout: `docs/development/approval-canvas-residual-parallel-closeout-verification-20260815.md`

## How to verify

```bash
# residual suites (real files)
pnpm --filter @metasheet/web exec vitest run --watch=false \
  tests/approval-form-authoring-history.test.ts \
  tests/approval-version-dual-canvas.test.ts \
  tests/approval-flow-canvas-a11y.test.ts \
  tests/approval-canvas-inspector-a11y.test.ts \
  tests/approval-form-palette-focus.test.ts \
  tests/approval-g5c-authoring-scenarios.test.ts

# values-free owner smoke (must require palette-focus; must not flip flags)
SKIP_TESTS=1 scripts/ops/approval-canvas-owner-uat-smoke.sh
```

Captured on this head: 6 files / 42 passed; smoke PASS.

## Non-claims

No real-tenant UAT. No staged flag ON. No product FINAL. Canvas V2 / FWB / attachments defaults stay OFF. Design-lock Status lines stay PROPOSED.