### PR TITLE
feat(dingtalk): add values-free Stream callback observer

### DIFF
--- a/.github/workflows/dingtalk-interactive-card-stream-staging-uat.yml
+++ b/.github/workflows/dingtalk-interactive-card-stream-staging-uat.yml
@@ -6,8 +6,10 @@ run-name: "DingTalk Stream Staging UAT: ${{ inputs.action }}"
 # One dispatch = ONE action. Stream stays OFF except explicit action=on.
 # Lifecycle flags are NEVER written by this lane.
 #
-# EXECUTABLE: status | prepare | on | off | https-on | https-off
+# EXECUTABLE: status | observe | prepare | on | off | https-on | https-off
 #   status  = read-only values-free snapshot (booleans / counts / reason classes)
+#   observe = read-only callback/corp-anchor/card-update result classes from the
+#             current Stream-ON backend container; never emits raw logs or ids
 #   prepare = transport Stream credentials (chmod-600 files), derive exactly one
 #             active integration for live DINGTALK_CORP_ID with >=2 linked local users,
 #             atomically write the four credential/id env keys into
@@ -22,7 +24,7 @@ run-name: "DingTalk Stream Staging UAT: ${{ inputs.action }}"
 #               staging public/CORS/OAuth callback URLs, restart backend, verify
 #   https-off = restore the pre-HTTPS staging env and remove the TLS gateway
 #
-# Exact deployed FULL 40-char lowercase SHA required for every mutating action.
+# Exact deployed FULL 40-char lowercase SHA required for every non-status action.
 # Secrets (prepare only): STAGING_DINGTALK_INTERACTIVE_CARD_CLIENT_ID /
 #   _CLIENT_SECRET / _TEMPLATE_ID — demoted + file transport; never argv/env
 #   persistence beyond the materialize window. Integration id is derived on host.
@@ -36,14 +38,14 @@ on:
   workflow_dispatch:
     inputs:
       action:
-        description: 'status | prepare | on | off | https-on | https-off'
+        description: 'status | observe | prepare | on | off | https-on | https-off'
         required: true
         type: choice
         # Quote 'on'/'off' — YAML 1.1 bare on/off become booleans.
-        options: [status, prepare, 'on', 'off', https-on, https-off]
+        options: [status, observe, prepare, 'on', 'off', https-on, https-off]
         default: status
       deploy_sha:
-        description: 'FULL 40-char lowercase commit SHA currently deployed on staging. Required for mutating actions; optional for status.'
+        description: 'FULL 40-char lowercase commit SHA currently deployed on staging. Required for every non-status action; optional for status exact-match reporting.'
         required: false
         default: ''
 
@@ -73,11 +75,11 @@ jobs:
           # (bash -n and other children must not inherit raw secret env).
         run: |
           set -euo pipefail
-          case "$ACTION" in status|prepare|on|off|https-on|https-off) ;; *)
+          case "$ACTION" in status|observe|prepare|on|off|https-on|https-off) ;; *)
             echo "invalid action: $ACTION" >&2; exit 2
           ;; esac
 
-          # Every mutating action requires exact full SHA.
+          # Every non-status action requires exact full SHA.
           if [[ "$ACTION" != "status" ]]; then
             if [[ ! "$DEPLOY_SHA" =~ ^[0-9a-f]{40}$ ]]; then
               echo "deploy_sha must be the FULL 40-char lowercase commit SHA for action=${ACTION}, got: '$DEPLOY_SHA'" >&2
@@ -140,7 +142,7 @@ jobs:
           RUNNER_DIR: ${{ steps.sync.outputs.runner_dir }}
           # prepare secrets are materialized INSIDE this step under EXIT trap —
           # never via a prior step secrets_dir output (cross-step leak / cancel).
-          # status/on/off do not receive credential secrets.
+          # status/observe/on/off do not receive credential secrets.
           STAGING_DINGTALK_INTERACTIVE_CARD_CLIENT_ID: ${{ inputs.action == 'prepare' && secrets.STAGING_DINGTALK_INTERACTIVE_CARD_CLIENT_ID || '' }}
           STAGING_DINGTALK_INTERACTIVE_CARD_CLIENT_SECRET: ${{ inputs.action == 'prepare' && secrets.STAGING_DINGTALK_INTERACTIVE_CARD_CLIENT_SECRET || '' }}
           STAGING_DINGTALK_INTERACTIVE_CARD_TEMPLATE_ID: ${{ inputs.action == 'prepare' && secrets.STAGING_DINGTALK_INTERACTIVE_CARD_TEMPLATE_ID || '' }}

--- a/.github/workflows/dingtalk-interactive-card-stream-staging-uat.yml
+++ b/.github/workflows/dingtalk-interactive-card-stream-staging-uat.yml
@@ -172,6 +172,14 @@ jobs:
 
           ssh_opts="-o BatchMode=yes -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes -o UserKnownHostsFile=$HOME/.ssh/known_hosts -o GlobalKnownHostsFile=/dev/null -i $HOME/.ssh/deploy_key"
           DEPLOY_PATH="${DEPLOY_PATH:-metasheet2}"
+          case "$ACTION" in status|observe|prepare|on|off) ;; *)
+            echo "refusing invalid action in remote execution step" >&2
+            exit 2
+          ;; esac
+          if [[ "$ACTION" == "observe" && ! "$EXPECTED_DELIVERY_ID" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$ ]]; then
+            echo "refusing invalid expected_delivery_id in remote execution step" >&2
+            exit 2
+          fi
           for pair in "DEPLOY_PATH=$DEPLOY_PATH" "STAGING_DEPLOY_PATH=$STAGING_DEPLOY_PATH"; do
             value="${pair#*=}"
             if [[ ! "$value" =~ ^[A-Za-z0-9._/~-]+$ ]]; then

--- a/.github/workflows/dingtalk-interactive-card-stream-staging-uat.yml
+++ b/.github/workflows/dingtalk-interactive-card-stream-staging-uat.yml
@@ -97,8 +97,13 @@ jobs:
             exit 2
           fi
 
-          if [[ "$ACTION" == "observe" && ! "$EXPECTED_DELIVERY_ID" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$ ]]; then
-            echo "observe requires expected_delivery_id as a lowercase UUID" >&2
+          if [[ "$ACTION" == "observe" ]]; then
+            if [[ ! "$EXPECTED_DELIVERY_ID" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$ ]]; then
+              echo "observe requires expected_delivery_id as a lowercase UUID" >&2
+              exit 2
+            fi
+          elif [[ -n "$EXPECTED_DELIVERY_ID" ]]; then
+            echo "expected_delivery_id is accepted only for action=observe" >&2
             exit 2
           fi
 
@@ -172,12 +177,26 @@ jobs:
 
           ssh_opts="-o BatchMode=yes -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes -o UserKnownHostsFile=$HOME/.ssh/known_hosts -o GlobalKnownHostsFile=/dev/null -i $HOME/.ssh/deploy_key"
           DEPLOY_PATH="${DEPLOY_PATH:-metasheet2}"
-          case "$ACTION" in status|observe|prepare|on|off) ;; *)
+          case "$ACTION" in status|observe|prepare|on|off|https-on|https-off) ;; *)
             echo "refusing invalid action in remote execution step" >&2
             exit 2
           ;; esac
-          if [[ "$ACTION" == "observe" && ! "$EXPECTED_DELIVERY_ID" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$ ]]; then
-            echo "refusing invalid expected_delivery_id in remote execution step" >&2
+          if [[ "$ACTION" != "status" ]]; then
+            if [[ ! "$DEPLOY_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+              echo "refusing invalid deploy_sha in remote execution step" >&2
+              exit 2
+            fi
+          elif [[ -n "$DEPLOY_SHA" && ! "$DEPLOY_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "refusing invalid optional deploy_sha in remote execution step" >&2
+            exit 2
+          fi
+          if [[ "$ACTION" == "observe" ]]; then
+            if [[ ! "$EXPECTED_DELIVERY_ID" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$ ]]; then
+              echo "refusing invalid expected_delivery_id in remote execution step" >&2
+              exit 2
+            fi
+          elif [[ -n "$EXPECTED_DELIVERY_ID" ]]; then
+            echo "refusing expected_delivery_id outside action=observe" >&2
             exit 2
           fi
           for pair in "DEPLOY_PATH=$DEPLOY_PATH" "STAGING_DEPLOY_PATH=$STAGING_DEPLOY_PATH"; do
@@ -342,7 +361,7 @@ jobs:
             echo "- Remote rc: \`${REMOTE_RC:-missing}\`"
             echo "- Artifact: \`${ARTIFACT_NAME:-missing}\`"
             echo ""
-            echo "**Executable:** status / prepare / on / off / https-on / https-off."
+            echo "**Executable:** status / observe / prepare / on / off / https-on / https-off."
             echo "prepare forces Stream OFF after writing credentials + derived integration id."
             echo "on flips ONLY Stream flag true after prerequisite + LOG_LEVEL checks; proves worker_started only."
             echo "stream_connected is always unknown here (SDK connect resolves + retries forever; not log-proven)."

--- a/.github/workflows/dingtalk-interactive-card-stream-staging-uat.yml
+++ b/.github/workflows/dingtalk-interactive-card-stream-staging-uat.yml
@@ -48,6 +48,10 @@ on:
         description: 'FULL 40-char lowercase commit SHA currently deployed on staging. Required for every non-status action; optional for status exact-match reporting.'
         required: false
         default: ''
+      expected_delivery_id:
+        description: 'Lowercase delivery UUID required only for observe; used for matching and never emitted.'
+        required: false
+        default: ''
 
 # Share the attendance staging runner concurrency group so compose/env races
 # cannot interleave on the same staging stack.
@@ -70,6 +74,7 @@ jobs:
         env:
           ACTION: ${{ inputs.action }}
           DEPLOY_SHA: ${{ inputs.deploy_sha }}
+          EXPECTED_DELIVERY_ID: ${{ inputs.expected_delivery_id }}
           # Intentionally NO Stream secrets here — presence is checked only in
           # Run remote action after demoting env → non-exported shell vars + unset
           # (bash -n and other children must not inherit raw secret env).
@@ -89,6 +94,11 @@ jobs:
 
           if [[ -n "$DEPLOY_SHA" && ! "$DEPLOY_SHA" =~ ^[0-9a-f]{40}$ ]]; then
             echo "deploy_sha must be empty or the FULL 40-char lowercase commit SHA, got: '$DEPLOY_SHA'" >&2
+            exit 2
+          fi
+
+          if [[ "$ACTION" == "observe" && ! "$EXPECTED_DELIVERY_ID" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$ ]]; then
+            echo "observe requires expected_delivery_id as a lowercase UUID" >&2
             exit 2
           fi
 
@@ -139,6 +149,7 @@ jobs:
           STAGING_DEPLOY_PATH: ${{ vars.STAGING_DEPLOY_PATH || 'metasheet2-dingtalk-staging' }}
           ACTION: ${{ inputs.action }}
           DEPLOY_SHA: ${{ inputs.deploy_sha }}
+          EXPECTED_DELIVERY_ID: ${{ inputs.expected_delivery_id }}
           RUNNER_DIR: ${{ steps.sync.outputs.runner_dir }}
           # prepare secrets are materialized INSIDE this step under EXIT trap —
           # never via a prior step secrets_dir output (cross-step leak / cancel).
@@ -266,6 +277,7 @@ jobs:
           remote_script="set -euo pipefail
           export ACTION='${ACTION}'
           export DEPLOY_SHA='${DEPLOY_SHA}'
+          export EXPECTED_DELIVERY_ID='${EXPECTED_DELIVERY_ID}'
           export STAGING_DEPLOY_PATH='${STAGING_DEPLOY_PATH}'
           export DEPLOY_PATH='${DEPLOY_PATH}'
           export OUTPUT_DIR='${remote_output_dir}'

--- a/scripts/ops/dingtalk-interactive-card-stream-staging-uat-contract.test.mjs
+++ b/scripts/ops/dingtalk-interactive-card-stream-staging-uat-contract.test.mjs
@@ -2,11 +2,11 @@
 // dingtalk-interactive-card-stream-staging-uat-contract.test.mjs
 //
 // Durable synthetic contract for the MINIMAL controlled Stream staging UAT lane:
-//   EXECUTABLE: status | prepare | on | off | https-on | https-off
+//   EXECUTABLE: status | observe | prepare | on | off | https-on | https-off
 //
 // Load-bearing rails:
 //   * workflow wiring (dispatch choices, SSH, concurrency, no schedule)
-//   * exact-SHA gate for every mutating action
+//   * exact-SHA gate for every non-status action
 //   * secret demotion + chmod-600 file transport (prepare only)
 //   * prepare forces Stream OFF while writing four credential/id keys
 //   * on flips only Stream flag true after LOG_LEVEL + prerequisite checks
@@ -117,14 +117,14 @@ test('workflow YAML parses with repository-available parser', () => {
 
 // --- workflow wiring ------------------------------------------------------------------
 
-test('workflow action choices include reversible HTTPS gateway actions', () => {
+test('workflow action choices include observer and reversible HTTPS gateway actions', () => {
   const doc = loadYaml(read(WORKFLOW))
   const inputs = workflowOn(doc).workflow_dispatch.inputs
-  assert.deepEqual(inputs.action.options, ['status', 'prepare', 'on', 'off', 'https-on', 'https-off'])
+  assert.deepEqual(inputs.action.options, ['status', 'observe', 'prepare', 'on', 'off', 'https-on', 'https-off'])
   assert.equal(inputs.action.default, 'status')
   // Quote on/off so YAML 1.1 keeps strings (loadYaml may coerce bare on/off).
   const yaml = read(WORKFLOW)
-  assert.match(yaml, /options:\s*\[status,\s*prepare,\s*'on',\s*'off',\s*https-on,\s*https-off\]/)
+  assert.match(yaml, /options:\s*\[status,\s*observe,\s*prepare,\s*'on',\s*'off',\s*https-on,\s*https-off\]/)
   assert.ok(
     inputs.action.options.every((o) => typeof o === 'string'),
     'on/off must remain strings after parse',
@@ -196,7 +196,7 @@ test('contract suite is wired into the required Node 20 plugin-tests lane', () =
 
 // --- exact-SHA gate -------------------------------------------------------------------
 
-test('workflow exact-SHA gate requires full 40-char deploy_sha for every mutating action', () => {
+test('workflow exact-SHA gate requires full 40-char deploy_sha for every non-status action', () => {
   const yaml = read(WORKFLOW)
   const doc = loadYaml(yaml)
   const validate = doc.jobs.run.steps.find((s) => s.name === 'Validate inputs and embedded scripts')
@@ -214,22 +214,36 @@ test('workflow exact-SHA gate requires full 40-char deploy_sha for every mutatin
   )
 })
 
-test('remote script require_exact_deployed_sha used by every mutating action and not status', () => {
+test('remote script require_exact_deployed_sha used by every non-status action and not status', () => {
   const source = read(REMOTE_SH)
   assert.match(source, /require_exact_deployed_sha/)
   assert.match(source, /resolve_deployed_sha/)
+  const observe = actionBody(source, 'action_observe', ['action_prepare'])
   const prepare = actionBody(source, 'action_prepare', ['action_on'])
   const on = actionBody(source, 'action_on', ['action_off'])
   const off = actionBody(source, 'action_off', ['action_https_on'])
   const httpsOn = actionBody(source, 'action_https_on', ['action_https_off'])
   const httpsOff = actionBody(source, 'action_https_off')
-  const status = actionBody(source, 'action_status', ['action_prepare'])
+  const status = actionBody(source, 'action_status', ['action_observe'])
+  assert.match(observe, /require_exact_deployed_sha "observe"/)
   assert.match(prepare, /require_exact_deployed_sha/)
   assert.match(on, /require_exact_deployed_sha/)
   assert.match(off, /require_exact_deployed_sha/)
   assert.match(httpsOn, /require_exact_deployed_sha/)
   assert.match(httpsOff, /require_exact_deployed_sha/)
   assert.doesNotMatch(status, /require_exact_deployed_sha/)
+})
+
+test('observe is read-only and emits values-free callback classes without raw logs or ids', () => {
+  const source = read(REMOTE_SH)
+  const observe = actionBody(source, 'action_observe', ['action_prepare'])
+  assert.match(observe, /action=observe/)
+  assert.match(observe, /header_event_corp_id_present=/)
+  assert.match(observe, /body_corp_id_present=/)
+  assert.match(observe, /latest_callback_outcome=/)
+  assert.match(observe, /card_update_failed_count=/)
+  assert.doesNotMatch(observe, /cat "\$tmp"|echo "\$anchor_line"|deliveryId=/)
+  assert.doesNotMatch(observe, /atomic_(?:set|upsert)|recreate_backend_only|compose_staging_cmd up/)
 })
 
 // --- secret demotion ------------------------------------------------------------------
@@ -852,7 +866,7 @@ test('status artifacts emit only booleans/counts/reason classes/sha schema keys'
 
 test('status action is read-only: no env writes, no flag flips, no compose up', () => {
   const source = read(REMOTE_SH)
-  const status = actionBody(source, 'action_status', ['action_prepare'])
+  const status = actionBody(source, 'action_status', ['action_observe'])
   assert.match(status, /write_status_artifact/)
   assert.doesNotMatch(status, /atomic_upsert_env_keys_from_files/)
   assert.doesNotMatch(status, /atomic_set_stream_flag/)

--- a/scripts/ops/dingtalk-interactive-card-stream-staging-uat-contract.test.mjs
+++ b/scripts/ops/dingtalk-interactive-card-stream-staging-uat-contract.test.mjs
@@ -214,21 +214,88 @@ test('workflow exact-SHA gate requires full 40-char deploy_sha for every non-sta
   )
 })
 
-test('observe requires a lowercase expected delivery UUID and never emits it', () => {
+test('observe exclusively requires a lowercase expected delivery UUID and never emits it', () => {
   const yaml = read(WORKFLOW)
   const doc = loadYaml(yaml)
   const validate = doc.jobs.run.steps.find((s) => s.name === 'Validate inputs and embedded scripts')
   assert.equal(validate.env.EXPECTED_DELIVERY_ID, '${{ inputs.expected_delivery_id }}')
   assert.match(validate.run, /observe requires expected_delivery_id as a lowercase UUID/)
+  assert.match(validate.run, /expected_delivery_id is accepted only for action=observe/)
   assert.match(validate.run, /\[1-5\]\[0-9a-f\]\{3\}/)
   const remoteStep = doc.jobs.run.steps.find((s) => s.name === 'Run remote action')
   assert.equal(remoteStep.env.EXPECTED_DELIVERY_ID, '${{ inputs.expected_delivery_id }}')
   assert.match(remoteStep.run, /refusing invalid expected_delivery_id in remote execution step/)
-  assert.match(remoteStep.run, /case "\$ACTION" in status\|observe\|prepare\|on\|off/)
+  assert.match(remoteStep.run, /refusing expected_delivery_id outside action=observe/)
+  assert.match(remoteStep.run, /case "\$ACTION" in status\|observe\|prepare\|on\|off\|https-on\|https-off/)
+  assert.match(remoteStep.run, /refusing invalid deploy_sha in remote execution step/)
+  assert.match(remoteStep.run, /refusing invalid optional deploy_sha in remote execution step/)
   const source = read(REMOTE_SH)
   const observe = actionBody(source, 'action_observe', ['action_prepare'])
   assert.match(observe, /grep -F -c "\$EXPECTED_DELIVERY_ID"/)
   assert.doesNotMatch(observe, /echo .*EXPECTED_DELIVERY_ID/)
+})
+
+test('workflow and remote preflights reject cross-action delivery-id injection before SSH construction', () => {
+  const doc = loadYaml(read(WORKFLOW))
+  const steps = doc.jobs.run.steps
+  const validate = steps.find((s) => s.name === 'Validate inputs and embedded scripts')
+  const remoteStep = steps.find((s) => s.name === 'Run remote action')
+  const remotePreflightEnd = remoteStep.run.indexOf('for pair in')
+  assert.ok(remotePreflightEnd > 0, 'remote preflight must precede path validation and SSH construction')
+  const remotePreflight = `${remoteStep.run.slice(0, remotePreflightEnd)}\nexit 0\n`
+  const sha = 'a'.repeat(40)
+  const deliveryId = '12345678-1234-4123-8123-123456789abc'
+
+  const runValidate = (action, deploySha, expectedDeliveryId) => spawnSync(
+    'bash',
+    ['-c', validate.run],
+    {
+      cwd: REPO_ROOT,
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        ACTION: action,
+        DEPLOY_SHA: deploySha,
+        EXPECTED_DELIVERY_ID: expectedDeliveryId,
+      },
+    },
+  )
+  const runRemotePreflight = (action, deploySha, expectedDeliveryId) => spawnSync(
+    'bash',
+    ['-c', remotePreflight],
+    {
+      cwd: REPO_ROOT,
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        ACTION: action,
+        DEPLOY_SHA: deploySha,
+        EXPECTED_DELIVERY_ID: expectedDeliveryId,
+        STAGING_DINGTALK_INTERACTIVE_CARD_CLIENT_ID: '',
+        STAGING_DINGTALK_INTERACTIVE_CARD_CLIENT_SECRET: '',
+        STAGING_DINGTALK_INTERACTIVE_CARD_TEMPLATE_ID: '',
+      },
+    },
+  )
+
+  for (const action of ['status', 'observe', 'prepare', 'on', 'off', 'https-on', 'https-off']) {
+    const deploySha = action === 'status' ? '' : sha
+    const expectedDeliveryId = action === 'observe' ? deliveryId : ''
+    assert.equal(runValidate(action, deploySha, expectedDeliveryId).status, 0, `validate ${action}`)
+    assert.equal(runRemotePreflight(action, deploySha, expectedDeliveryId).status, 0, `remote ${action}`)
+  }
+
+  for (const unsafe of [deliveryId, "'; touch /tmp/stream-uat-injection; #"]) {
+    assert.equal(runValidate('status', '', unsafe).status, 2)
+    assert.equal(runRemotePreflight('status', '', unsafe).status, 2)
+  }
+  assert.equal(runValidate('observe', sha, '').status, 2)
+  assert.equal(runRemotePreflight('observe', sha, '').status, 2)
+  assert.equal(runValidate('observe', sha, "'; touch /tmp/stream-uat-injection; #").status, 2)
+  assert.equal(runRemotePreflight('observe', sha, "'; touch /tmp/stream-uat-injection; #").status, 2)
+  assert.equal(runValidate('status', "'; touch /tmp/stream-uat-injection; #", '').status, 2)
+  assert.equal(runRemotePreflight('status', "'; touch /tmp/stream-uat-injection; #", '').status, 2)
+  assert.equal(runRemotePreflight('https-on', 'not-a-sha', '').status, 2)
 })
 
 test('remote script require_exact_deployed_sha used by every non-status action and not status', () => {
@@ -255,6 +322,8 @@ test('observe is read-only and emits values-free callback classes without raw lo
   const source = read(REMOTE_SH)
   const observe = actionBody(source, 'action_observe', ['action_prepare'])
   assert.match(observe, /action=observe/)
+  assert.match(observe, /require_lifecycle_flags_off "observe"/)
+  assert.match(observe, /require_log_level_info_or_debug "observe"/)
   assert.match(observe, /header_event_corp_id_present=/)
   assert.match(observe, /body_corp_id_present=/)
   assert.match(observe, /latest_callback_outcome=/)
@@ -283,6 +352,74 @@ test('observe is read-only and emits values-free callback classes without raw lo
   assert.doesNotMatch(observe, /echo "callback_handler_error_count=/)
   assert.doesNotMatch(observe, /cat "\$tmp"|echo "\$anchor_line"|deliveryId=/)
   assert.doesNotMatch(observe, /atomic_(?:set|upsert)|recreate_backend_only|compose_staging_cmd up/)
+})
+
+test('observe dynamically scopes Winston log evidence to the expected delivery', () => {
+  const source = read(REMOTE_SH)
+  const observe = actionBody(source, 'action_observe', ['action_prepare'])
+  const dir = mkdtempSync(join(tmpdir(), 'stream-observer-'))
+  const output = join(dir, 'output')
+  const logs = join(dir, 'backend.log')
+  const harness = join(dir, 'harness.sh')
+  const expected = '12345678-1234-4123-8123-123456789abc'
+  const other = '87654321-4321-4123-8123-cba987654321'
+  try {
+    writeFileSync(
+      logs,
+      [
+        `info: DingTalk interactive-card callback corp anchor {"deliveryId":"${other}","headerEventCorpIdPresent":false,"bodyCorpIdPresent":true}`,
+        `info: DingTalk interactive-card callback handled (stale delivery=${other})`,
+        `info: DingTalk interactive-card callback corp anchor {"deliveryId":"${expected}","headerEventCorpIdPresent":true,"bodyCorpIdPresent":false}`,
+        `info: DingTalk interactive-card callback handled (operator_unresolved:missing_link delivery=${expected})`,
+        `info: DingTalk interactive-card callback handled (executed delivery=${expected})`,
+        'warn: DingTalk interactive-card callback failed (callback_handler_error)',
+        `warn: DingTalk approval-card terminal update failed (card_update_failed:Error) delivery=${expected}`,
+      ].join('\n') + '\n',
+    )
+    writeFileSync(
+      harness,
+      [
+        '#!/usr/bin/env bash',
+        'set -euo pipefail',
+        'log() { :; }',
+        'fail() { echo "$*" >&2; exit 1; }',
+        'assert_staging_only() { :; }',
+        'require_exact_deployed_sha() { :; }',
+        'require_lifecycle_flags_off() { :; }',
+        'require_log_level_info_or_debug() { :; }',
+        'register_ephemeral() { :; }',
+        'read_flag_from_container() { printf true; }',
+        'docker() { [[ "$1" == "logs" ]] || return 1; cat "$LOG_FIXTURE"; }',
+        'BACKEND_CONTAINER=metasheet-staging-backend',
+        'FLAG_STREAM=DINGTALK_INTERACTIVE_CARD_STREAM_ENABLED',
+        'mkdir -p "$STREAM_UAT_PERSIST_DIR" "$OUTPUT_DIR"',
+        observe,
+        'action_observe',
+      ].join('\n'),
+    )
+    const result = spawnSync('bash', [harness], {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        EXPECTED_DELIVERY_ID: expected,
+        LOG_FIXTURE: logs,
+        OUTPUT_DIR: output,
+        STREAM_UAT_PERSIST_DIR: dir,
+      },
+    })
+    assert.equal(result.status, 0, result.stderr)
+    const artifact = readFileSync(join(output, 'callback-observer.txt'), 'utf8')
+    assert.match(artifact, /callback_anchor_log_count=1/)
+    assert.match(artifact, /header_event_corp_id_present=true/)
+    assert.match(artifact, /body_corp_id_present=false/)
+    assert.match(artifact, /callback_handled_count=2/)
+    assert.match(artifact, /latest_callback_outcome=executed/)
+    assert.match(artifact, /window_callback_handler_error_count=1/)
+    assert.match(artifact, /card_update_failed_count=1/)
+    assert.doesNotMatch(artifact, new RegExp(`${expected}|${other}`))
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
 })
 
 // --- secret demotion ------------------------------------------------------------------

--- a/scripts/ops/dingtalk-interactive-card-stream-staging-uat-contract.test.mjs
+++ b/scripts/ops/dingtalk-interactive-card-stream-staging-uat-contract.test.mjs
@@ -214,6 +214,19 @@ test('workflow exact-SHA gate requires full 40-char deploy_sha for every non-sta
   )
 })
 
+test('observe requires a lowercase expected delivery UUID and never emits it', () => {
+  const yaml = read(WORKFLOW)
+  const doc = loadYaml(yaml)
+  const validate = doc.jobs.run.steps.find((s) => s.name === 'Validate inputs and embedded scripts')
+  assert.equal(validate.env.EXPECTED_DELIVERY_ID, '${{ inputs.expected_delivery_id }}')
+  assert.match(validate.run, /observe requires expected_delivery_id as a lowercase UUID/)
+  assert.match(validate.run, /\[1-5\]\[0-9a-f\]\{3\}/)
+  const source = read(REMOTE_SH)
+  const observe = actionBody(source, 'action_observe', ['action_prepare'])
+  assert.match(observe, /grep -F -c "\$EXPECTED_DELIVERY_ID"/)
+  assert.doesNotMatch(observe, /echo .*EXPECTED_DELIVERY_ID/)
+})
+
 test('remote script require_exact_deployed_sha used by every non-status action and not status', () => {
   const source = read(REMOTE_SH)
   assert.match(source, /require_exact_deployed_sha/)

--- a/scripts/ops/dingtalk-interactive-card-stream-staging-uat-contract.test.mjs
+++ b/scripts/ops/dingtalk-interactive-card-stream-staging-uat-contract.test.mjs
@@ -242,6 +242,20 @@ test('observe is read-only and emits values-free callback classes without raw lo
   assert.match(observe, /body_corp_id_present=/)
   assert.match(observe, /latest_callback_outcome=/)
   assert.match(observe, /card_update_failed_count=/)
+  for (const outcome of [
+    'executed',
+    'stale',
+    'rejected',
+    'ignored_unsupported_action',
+    'delivery_not_found',
+    'operator_unresolved',
+    'link_secret_unavailable',
+    'engine_rejected',
+    'wrapper_not_found',
+  ]) {
+    assert.match(observe, new RegExp(`handled_outcome="${outcome}"`))
+  }
+  assert.doesNotMatch(observe, /handled_outcome="(?:accepted|duplicate)"/)
   assert.doesNotMatch(observe, /cat "\$tmp"|echo "\$anchor_line"|deliveryId=/)
   assert.doesNotMatch(observe, /atomic_(?:set|upsert)|recreate_backend_only|compose_staging_cmd up/)
 })

--- a/scripts/ops/dingtalk-interactive-card-stream-staging-uat-contract.test.mjs
+++ b/scripts/ops/dingtalk-interactive-card-stream-staging-uat-contract.test.mjs
@@ -221,6 +221,10 @@ test('observe requires a lowercase expected delivery UUID and never emits it', (
   assert.equal(validate.env.EXPECTED_DELIVERY_ID, '${{ inputs.expected_delivery_id }}')
   assert.match(validate.run, /observe requires expected_delivery_id as a lowercase UUID/)
   assert.match(validate.run, /\[1-5\]\[0-9a-f\]\{3\}/)
+  const remoteStep = doc.jobs.run.steps.find((s) => s.name === 'Run remote action')
+  assert.equal(remoteStep.env.EXPECTED_DELIVERY_ID, '${{ inputs.expected_delivery_id }}')
+  assert.match(remoteStep.run, /refusing invalid expected_delivery_id in remote execution step/)
+  assert.match(remoteStep.run, /case "\$ACTION" in status\|observe\|prepare\|on\|off/)
   const source = read(REMOTE_SH)
   const observe = actionBody(source, 'action_observe', ['action_prepare'])
   assert.match(observe, /grep -F -c "\$EXPECTED_DELIVERY_ID"/)
@@ -254,13 +258,11 @@ test('observe is read-only and emits values-free callback classes without raw lo
   assert.match(observe, /header_event_corp_id_present=/)
   assert.match(observe, /body_corp_id_present=/)
   assert.match(observe, /latest_callback_outcome=/)
+  assert.match(observe, /window_callback_handler_error_count=/)
   assert.match(observe, /card_update_failed_count=/)
   for (const outcome of [
     'executed',
     'stale',
-    'rejected',
-    'ignored_unsupported_action',
-    'delivery_not_found',
     'operator_unresolved',
     'link_secret_unavailable',
     'engine_rejected',
@@ -268,7 +270,17 @@ test('observe is read-only and emits values-free callback classes without raw lo
   ]) {
     assert.match(observe, new RegExp(`handled_outcome="${outcome}"`))
   }
+  // These production outcome strings do not carry the delivery UUID and cannot
+  // be claimed as evidence for EXPECTED_DELIVERY_ID.
+  for (const unscopedOutcome of [
+    'rejected',
+    'ignored_unsupported_action',
+    'delivery_not_found',
+  ]) {
+    assert.doesNotMatch(observe, new RegExp(`handled_outcome="${unscopedOutcome}"`))
+  }
   assert.doesNotMatch(observe, /handled_outcome="(?:accepted|duplicate)"/)
+  assert.doesNotMatch(observe, /echo "callback_handler_error_count=/)
   assert.doesNotMatch(observe, /cat "\$tmp"|echo "\$anchor_line"|deliveryId=/)
   assert.doesNotMatch(observe, /atomic_(?:set|upsert)|recreate_backend_only|compose_staging_cmd up/)
 })

--- a/scripts/ops/dingtalk-interactive-card-stream-staging-uat-contract.test.mjs
+++ b/scripts/ops/dingtalk-interactive-card-stream-staging-uat-contract.test.mjs
@@ -330,6 +330,8 @@ test('observe is read-only and emits values-free callback classes without raw lo
   assert.match(observe, /window_callback_handler_error_count=/)
   assert.match(observe, /card_update_failed_count=/)
   for (const outcome of [
+    'ignored_unsupported_action',
+    'delivery_not_found',
     'executed',
     'stale',
     'operator_unresolved',
@@ -339,15 +341,9 @@ test('observe is read-only and emits values-free callback classes without raw lo
   ]) {
     assert.match(observe, new RegExp(`handled_outcome="${outcome}"`))
   }
-  // These production outcome strings do not carry the delivery UUID and cannot
-  // be claimed as evidence for EXPECTED_DELIVERY_ID.
-  for (const unscopedOutcome of [
-    'rejected',
-    'ignored_unsupported_action',
-    'delivery_not_found',
-  ]) {
-    assert.doesNotMatch(observe, new RegExp(`handled_outcome="${unscopedOutcome}"`))
-  }
+  // A parse-time rejection has no delivery id and cannot be claimed as scoped
+  // evidence for EXPECTED_DELIVERY_ID. The two out_track_id outcomes above do.
+  assert.doesNotMatch(observe, /handled_outcome="rejected"/)
   assert.doesNotMatch(observe, /handled_outcome="(?:accepted|duplicate)"/)
   assert.doesNotMatch(observe, /echo "callback_handler_error_count=/)
   assert.doesNotMatch(observe, /cat "\$tmp"|echo "\$anchor_line"|deliveryId=/)
@@ -417,6 +413,67 @@ test('observe dynamically scopes Winston log evidence to the expected delivery',
     assert.match(artifact, /window_callback_handler_error_count=1/)
     assert.match(artifact, /card_update_failed_count=1/)
     assert.doesNotMatch(artifact, new RegExp(`${expected}|${other}`))
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('observe precisely classifies scoped out_track_id terminal outcomes', () => {
+  const source = read(REMOTE_SH)
+  const observe = actionBody(source, 'action_observe', ['action_prepare'])
+  const dir = mkdtempSync(join(tmpdir(), 'stream-observer-out-track-'))
+  const output = join(dir, 'output')
+  const logs = join(dir, 'backend.log')
+  const harness = join(dir, 'harness.sh')
+  const expected = '12345678-1234-4123-8123-123456789abc'
+  try {
+    writeFileSync(
+      harness,
+      [
+        '#!/usr/bin/env bash',
+        'set -euo pipefail',
+        'log() { :; }',
+        'fail() { echo "$*" >&2; exit 1; }',
+        'assert_staging_only() { :; }',
+        'require_exact_deployed_sha() { :; }',
+        'require_lifecycle_flags_off() { :; }',
+        'require_log_level_info_or_debug() { :; }',
+        'register_ephemeral() { :; }',
+        'read_flag_from_container() { printf true; }',
+        'docker() { [[ "$1" == "logs" ]] || return 1; cat "$LOG_FIXTURE"; }',
+        'BACKEND_CONTAINER=metasheet-staging-backend',
+        'FLAG_STREAM=DINGTALK_INTERACTIVE_CARD_STREAM_ENABLED',
+        'mkdir -p "$STREAM_UAT_PERSIST_DIR" "$OUTPUT_DIR"',
+        observe,
+        'action_observe',
+      ].join('\n'),
+    )
+    for (const [line, expectedOutcome] of [
+      [
+        `info: DingTalk interactive-card callback handled (ignored_unsupported_action out_track_id=${expected})`,
+        'ignored_unsupported_action',
+      ],
+      [
+        `info: DingTalk interactive-card callback handled (delivery_not_found out_track_id=${expected})`,
+        'delivery_not_found',
+      ],
+    ]) {
+      writeFileSync(logs, `${line}\n`)
+      const result = spawnSync('bash', [harness], {
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          EXPECTED_DELIVERY_ID: expected,
+          LOG_FIXTURE: logs,
+          OUTPUT_DIR: output,
+          STREAM_UAT_PERSIST_DIR: dir,
+        },
+      })
+      assert.equal(result.status, 0, result.stderr)
+      const artifact = readFileSync(join(output, 'callback-observer.txt'), 'utf8')
+      assert.match(artifact, new RegExp(`latest_callback_outcome=${expectedOutcome}`))
+      assert.doesNotMatch(artifact, new RegExp(expected))
+    }
   } finally {
     rmSync(dir, { recursive: true, force: true })
   }

--- a/scripts/ops/dingtalk-interactive-card-stream-staging-uat-remote.sh
+++ b/scripts/ops/dingtalk-interactive-card-stream-staging-uat-remote.sh
@@ -1740,7 +1740,7 @@ action_observe() {
   [[ "$live_flag" == "true" ]] \
     || fail "action=observe requires live Stream ON (got stream_enabled=${live_flag})"
 
-  local tmp anchor_count handled_count handler_error_count update_failed_count
+  local tmp anchor_count handled_count window_handler_error_count update_failed_count
   local header_present="unknown" body_present="unknown" handled_outcome="unknown"
   tmp="$(mktemp "${STREAM_UAT_PERSIST_DIR}/.callback-observer.XXXXXX")"
   register_ephemeral "$tmp"
@@ -1750,7 +1750,10 @@ action_observe() {
 
   anchor_count="$(grep -F 'DingTalk interactive-card callback corp anchor' "$tmp" | grep -F -c "$EXPECTED_DELIVERY_ID" || true)"
   handled_count="$(grep -F 'DingTalk interactive-card callback handled (' "$tmp" | grep -F -c "$EXPECTED_DELIVERY_ID" || true)"
-  handler_error_count="$(grep -F -c 'DingTalk interactive-card callback failed (callback_handler_error)' "$tmp" || true)"
+  # The worker's catch log intentionally carries no delivery id. Keep it as a
+  # window-level diagnostic; it must never be presented as scoped evidence for
+  # EXPECTED_DELIVERY_ID.
+  window_handler_error_count="$(grep -F -c 'DingTalk interactive-card callback failed (callback_handler_error)' "$tmp" || true)"
   update_failed_count="$(grep -F 'DingTalk approval-card terminal update failed (card_update_failed:' "$tmp" | grep -F -c "$EXPECTED_DELIVERY_ID" || true)"
 
   if [[ "$anchor_count" -gt 0 ]]; then
@@ -1772,9 +1775,6 @@ action_observe() {
     case "$handled_line" in
       *'(executed delivery='*) handled_outcome="executed" ;;
       *'(stale delivery='*) handled_outcome="stale" ;;
-      *'(rejected:'*) handled_outcome="rejected" ;;
-      *'(ignored_unsupported_action out_track_id='*) handled_outcome="ignored_unsupported_action" ;;
-      *'(delivery_not_found out_track_id='*) handled_outcome="delivery_not_found" ;;
       *'(operator_unresolved:'*) handled_outcome="operator_unresolved" ;;
       *'(link_secret_unavailable delivery='*) handled_outcome="link_secret_unavailable" ;;
       *'(engine_rejected:'*) handled_outcome="engine_rejected" ;;
@@ -1794,7 +1794,7 @@ action_observe() {
     echo "body_corp_id_present=${body_present}"
     echo "callback_handled_count=${handled_count}"
     echo "latest_callback_outcome=${handled_outcome}"
-    echo "callback_handler_error_count=${handler_error_count}"
+    echo "window_callback_handler_error_count=${window_handler_error_count}"
     echo "card_update_failed_count=${update_failed_count}"
   } > "${OUTPUT_DIR}/callback-observer.txt"
   cp "${OUTPUT_DIR}/callback-observer.txt" "${OUTPUT_DIR}/summary.txt"

--- a/scripts/ops/dingtalk-interactive-card-stream-staging-uat-remote.sh
+++ b/scripts/ops/dingtalk-interactive-card-stream-staging-uat-remote.sh
@@ -814,6 +814,7 @@ classify_log_level() {
 }
 
 require_log_level_info_or_debug() {
+  local context="${1:-on}"
   classify_log_level
   if [[ "$LOG_LEVEL_READY" == "true" ]]; then
     case "$LOG_LEVEL_REASON" in
@@ -823,7 +824,7 @@ require_log_level_info_or_debug() {
         ;;
     esac
   fi
-  fail "action=on requires LOG_LEVEL info/debug (got ready=${LOG_LEVEL_READY} reason=${LOG_LEVEL_REASON})"
+  fail "action=${context} requires LOG_LEVEL info/debug (got ready=${LOG_LEVEL_READY} reason=${LOG_LEVEL_REASON})"
 }
 
 # --- lifecycle flags (read only; never written) --------------------------------------
@@ -1731,7 +1732,8 @@ action_status() {
 action_observe() {
   assert_staging_only
   require_exact_deployed_sha "observe"
-  require_log_level_info_or_debug
+  require_lifecycle_flags_off "observe"
+  require_log_level_info_or_debug "observe"
   [[ "$EXPECTED_DELIVERY_ID" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$ ]] \
     || fail "action=observe requires expected_delivery_id as a lowercase UUID"
 
@@ -1881,7 +1883,7 @@ action_on() {
   require_exact_deployed_sha "on"
   pin_live_backend_image_for_transition
   require_lifecycle_flags_off "on"
-  require_log_level_info_or_debug
+  require_log_level_info_or_debug "on"
   require_stream_prerequisites_for_on
   require_staging_env_file
 

--- a/scripts/ops/dingtalk-interactive-card-stream-staging-uat-remote.sh
+++ b/scripts/ops/dingtalk-interactive-card-stream-staging-uat-remote.sh
@@ -1775,6 +1775,8 @@ action_observe() {
     local handled_line
     handled_line="$(grep -F 'DingTalk interactive-card callback handled (' "$tmp" | grep -F "$EXPECTED_DELIVERY_ID" | tail -n 1)"
     case "$handled_line" in
+      *'(ignored_unsupported_action out_track_id='*) handled_outcome="ignored_unsupported_action" ;;
+      *'(delivery_not_found out_track_id='*) handled_outcome="delivery_not_found" ;;
       *'(executed delivery='*) handled_outcome="executed" ;;
       *'(stale delivery='*) handled_outcome="stale" ;;
       *'(operator_unresolved:'*) handled_outcome="operator_unresolved" ;;

--- a/scripts/ops/dingtalk-interactive-card-stream-staging-uat-remote.sh
+++ b/scripts/ops/dingtalk-interactive-card-stream-staging-uat-remote.sh
@@ -48,6 +48,7 @@ fail() { echo "[stream-uat][error] $*" >&2; exit 1; }
 
 ACTION="${ACTION:?ACTION is required (status|observe|prepare|on|off|https-on|https-off)}"
 DEPLOY_SHA="${DEPLOY_SHA:-}"
+EXPECTED_DELIVERY_ID="${EXPECTED_DELIVERY_ID:-}"
 STAGING_DEPLOY_PATH="${STAGING_DEPLOY_PATH:-metasheet2-dingtalk-staging}"
 DEPLOY_PATH="${DEPLOY_PATH:-metasheet2}"
 OUTPUT_DIR="${OUTPUT_DIR:?OUTPUT_DIR is required}"
@@ -1731,6 +1732,8 @@ action_observe() {
   assert_staging_only
   require_exact_deployed_sha "observe"
   require_log_level_info_or_debug
+  [[ "$EXPECTED_DELIVERY_ID" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$ ]] \
+    || fail "action=observe requires expected_delivery_id as a lowercase UUID"
 
   local live_flag
   live_flag="$(read_flag_from_container "$FLAG_STREAM" || echo unknown)"
@@ -1745,14 +1748,14 @@ action_observe() {
   docker logs "$BACKEND_CONTAINER" >"$tmp" 2>&1 \
     || fail "action=observe could not read current backend container logs"
 
-  anchor_count="$(grep -F -c 'DingTalk interactive-card callback corp anchor' "$tmp" || true)"
-  handled_count="$(grep -F -c 'DingTalk interactive-card callback handled (' "$tmp" || true)"
+  anchor_count="$(grep -F 'DingTalk interactive-card callback corp anchor' "$tmp" | grep -F -c "$EXPECTED_DELIVERY_ID" || true)"
+  handled_count="$(grep -F 'DingTalk interactive-card callback handled (' "$tmp" | grep -F -c "$EXPECTED_DELIVERY_ID" || true)"
   handler_error_count="$(grep -F -c 'DingTalk interactive-card callback failed (callback_handler_error)' "$tmp" || true)"
-  update_failed_count="$(grep -F -c 'DingTalk approval-card terminal update failed (card_update_failed:' "$tmp" || true)"
+  update_failed_count="$(grep -F 'DingTalk approval-card terminal update failed (card_update_failed:' "$tmp" | grep -F -c "$EXPECTED_DELIVERY_ID" || true)"
 
   if [[ "$anchor_count" -gt 0 ]]; then
     local anchor_line
-    anchor_line="$(grep -F 'DingTalk interactive-card callback corp anchor' "$tmp" | tail -n 1)"
+    anchor_line="$(grep -F 'DingTalk interactive-card callback corp anchor' "$tmp" | grep -F "$EXPECTED_DELIVERY_ID" | tail -n 1)"
     [[ "$anchor_line" == *'headerEventCorpIdPresent=true'* || "$anchor_line" == *'"headerEventCorpIdPresent":true'* ]] \
       && header_present="true"
     [[ "$anchor_line" == *'headerEventCorpIdPresent=false'* || "$anchor_line" == *'"headerEventCorpIdPresent":false'* ]] \
@@ -1765,7 +1768,7 @@ action_observe() {
 
   if [[ "$handled_count" -gt 0 ]]; then
     local handled_line
-    handled_line="$(grep -F 'DingTalk interactive-card callback handled (' "$tmp" | tail -n 1)"
+    handled_line="$(grep -F 'DingTalk interactive-card callback handled (' "$tmp" | grep -F "$EXPECTED_DELIVERY_ID" | tail -n 1)"
     case "$handled_line" in
       *'(executed delivery='*) handled_outcome="executed" ;;
       *'(stale delivery='*) handled_outcome="stale" ;;

--- a/scripts/ops/dingtalk-interactive-card-stream-staging-uat-remote.sh
+++ b/scripts/ops/dingtalk-interactive-card-stream-staging-uat-remote.sh
@@ -1767,11 +1767,15 @@ action_observe() {
     local handled_line
     handled_line="$(grep -F 'DingTalk interactive-card callback handled (' "$tmp" | tail -n 1)"
     case "$handled_line" in
-      *'(accepted)'*) handled_outcome="accepted" ;;
-      *'(duplicate)'*) handled_outcome="duplicate" ;;
-      *'(stale)'*) handled_outcome="stale" ;;
-      *'(operator_unresolved)'*) handled_outcome="operator_unresolved" ;;
-      *'(link_secret_unavailable)'*) handled_outcome="link_secret_unavailable" ;;
+      *'(executed delivery='*) handled_outcome="executed" ;;
+      *'(stale delivery='*) handled_outcome="stale" ;;
+      *'(rejected:'*) handled_outcome="rejected" ;;
+      *'(ignored_unsupported_action out_track_id='*) handled_outcome="ignored_unsupported_action" ;;
+      *'(delivery_not_found out_track_id='*) handled_outcome="delivery_not_found" ;;
+      *'(operator_unresolved:'*) handled_outcome="operator_unresolved" ;;
+      *'(link_secret_unavailable delivery='*) handled_outcome="link_secret_unavailable" ;;
+      *'(engine_rejected:'*) handled_outcome="engine_rejected" ;;
+      *'(wrapper_not_found delivery='*) handled_outcome="wrapper_not_found" ;;
       *) handled_outcome="other" ;;
     esac
   fi

--- a/scripts/ops/dingtalk-interactive-card-stream-staging-uat-remote.sh
+++ b/scripts/ops/dingtalk-interactive-card-stream-staging-uat-remote.sh
@@ -7,6 +7,8 @@
 #
 # EXECUTABLE:
 #   status  — read-only snapshot (booleans / counts / reason classes / SHA only)
+#   observe — read-only callback/corp-anchor/card-update result classes for one
+#             validated expected delivery UUID; never emits raw logs or ids
 #   prepare — transport Stream credentials via chmod-600 files, derive exactly
 #             one active integration for live DINGTALK_CORP_ID with >=2 active
 #             linked local users, atomically write the four credential/id env
@@ -34,7 +36,7 @@
 #   * Lifecycle flags (alias/pending/deprovision) are NEVER written by this lane.
 #   * Stream stays OFF except explicit action=on.
 #   * Secrets never appear in shell argv, exported env values, logs, or artifacts.
-#   * Every mutating action requires exact deployed 40-char lowercase SHA.
+#   * Every non-status action requires exact deployed 40-char lowercase SHA.
 #   * Artifacts: booleans / counts / reason enums / SHA only — no raw IDs/PII.
 #   * stream_connected is always unknown in this lane (no connect claim from logs).
 #   * U12/U13 remain human-gated (real callback / flag-off UAT); not automated.
@@ -44,7 +46,7 @@ set -euo pipefail
 log() { echo "[stream-uat] $*"; }
 fail() { echo "[stream-uat][error] $*" >&2; exit 1; }
 
-ACTION="${ACTION:?ACTION is required (status|prepare|on|off|https-on|https-off)}"
+ACTION="${ACTION:?ACTION is required (status|observe|prepare|on|off|https-on|https-off)}"
 DEPLOY_SHA="${DEPLOY_SHA:-}"
 STAGING_DEPLOY_PATH="${STAGING_DEPLOY_PATH:-metasheet2-dingtalk-staging}"
 DEPLOY_PATH="${DEPLOY_PATH:-metasheet2}"
@@ -1725,6 +1727,73 @@ action_status() {
   log "action=status complete (read-only)"
 }
 
+action_observe() {
+  assert_staging_only
+  require_exact_deployed_sha "observe"
+  require_log_level_info_or_debug
+
+  local live_flag
+  live_flag="$(read_flag_from_container "$FLAG_STREAM" || echo unknown)"
+  [[ "$live_flag" == "true" ]] \
+    || fail "action=observe requires live Stream ON (got stream_enabled=${live_flag})"
+
+  local tmp anchor_count handled_count handler_error_count update_failed_count
+  local header_present="unknown" body_present="unknown" handled_outcome="unknown"
+  tmp="$(mktemp "${STREAM_UAT_PERSIST_DIR}/.callback-observer.XXXXXX")"
+  register_ephemeral "$tmp"
+  chmod 600 "$tmp"
+  docker logs "$BACKEND_CONTAINER" >"$tmp" 2>&1 \
+    || fail "action=observe could not read current backend container logs"
+
+  anchor_count="$(grep -F -c 'DingTalk interactive-card callback corp anchor' "$tmp" || true)"
+  handled_count="$(grep -F -c 'DingTalk interactive-card callback handled (' "$tmp" || true)"
+  handler_error_count="$(grep -F -c 'DingTalk interactive-card callback failed (callback_handler_error)' "$tmp" || true)"
+  update_failed_count="$(grep -F -c 'DingTalk approval-card terminal update failed (card_update_failed:' "$tmp" || true)"
+
+  if [[ "$anchor_count" -gt 0 ]]; then
+    local anchor_line
+    anchor_line="$(grep -F 'DingTalk interactive-card callback corp anchor' "$tmp" | tail -n 1)"
+    [[ "$anchor_line" == *'headerEventCorpIdPresent=true'* || "$anchor_line" == *'"headerEventCorpIdPresent":true'* ]] \
+      && header_present="true"
+    [[ "$anchor_line" == *'headerEventCorpIdPresent=false'* || "$anchor_line" == *'"headerEventCorpIdPresent":false'* ]] \
+      && header_present="false"
+    [[ "$anchor_line" == *'bodyCorpIdPresent=true'* || "$anchor_line" == *'"bodyCorpIdPresent":true'* ]] \
+      && body_present="true"
+    [[ "$anchor_line" == *'bodyCorpIdPresent=false'* || "$anchor_line" == *'"bodyCorpIdPresent":false'* ]] \
+      && body_present="false"
+  fi
+
+  if [[ "$handled_count" -gt 0 ]]; then
+    local handled_line
+    handled_line="$(grep -F 'DingTalk interactive-card callback handled (' "$tmp" | tail -n 1)"
+    case "$handled_line" in
+      *'(accepted)'*) handled_outcome="accepted" ;;
+      *'(duplicate)'*) handled_outcome="duplicate" ;;
+      *'(stale)'*) handled_outcome="stale" ;;
+      *'(operator_unresolved)'*) handled_outcome="operator_unresolved" ;;
+      *'(link_secret_unavailable)'*) handled_outcome="link_secret_unavailable" ;;
+      *) handled_outcome="other" ;;
+    esac
+  fi
+
+  rm -f "$tmp"
+  {
+    echo "schema=dingtalk-interactive-card-stream-callback-observer-v1"
+    echo "action=observe"
+    echo "reason=ok"
+    echo "stream_enabled=true"
+    echo "callback_anchor_log_count=${anchor_count}"
+    echo "header_event_corp_id_present=${header_present}"
+    echo "body_corp_id_present=${body_present}"
+    echo "callback_handled_count=${handled_count}"
+    echo "latest_callback_outcome=${handled_outcome}"
+    echo "callback_handler_error_count=${handler_error_count}"
+    echo "card_update_failed_count=${update_failed_count}"
+  } > "${OUTPUT_DIR}/callback-observer.txt"
+  cp "${OUTPUT_DIR}/callback-observer.txt" "${OUTPUT_DIR}/summary.txt"
+  log "action=observe complete (values-free callback classes only)"
+}
+
 action_prepare() {
   assert_staging_only
   require_compose_v2
@@ -2002,12 +2071,13 @@ chmod 700 "$OUTPUT_DIR" 2>/dev/null || true
 
 case "$ACTION" in
   status) action_status ;;
+  observe) action_observe ;;
   prepare) action_prepare ;;
   on) action_on ;;
   off) action_off ;;
   https-on) action_https_on ;;
   https-off) action_https_off ;;
-  *) fail "invalid ACTION='${ACTION}' (expected status|prepare|on|off|https-on|https-off)" ;;
+  *) fail "invalid ACTION='${ACTION}' (expected status|observe|prepare|on|off|https-on|https-off)" ;;
 esac
 
 log "done action=${ACTION}"


### PR DESCRIPTION
## Summary

- stack the read-only Stream callback observer on the refreshed reversible HTTPS UAT lane (#4890)
- validate every action and optional input at both workflow and remote-execution preflights before SSH construction
- add a values-free observer scoped to one expected lowercase delivery UUID
- guard observe with exact deployed SHA, Stream ON, lifecycle flags OFF, and LOG_LEVEL info/debug

## Exact stack

- base PR: #4890, commit `a710d83796025564eab417fcbfb04a6923b0561e`
- reviewed head: `593327bebe5ca202929817100249c39f86862f3e`
- net observer diff: exactly 3 files, stable patch-id `0cf43c5e6205d91ab66ad52317d0cad53a038026`
- current stacked exact-head CI: all checks passed at the reviewed head
- this PR remains Draft and unarmed; full required CI must still be rerun after #4890 lands and this PR is retargeted to main

## Verification

- `node --test scripts/ops/dingtalk-interactive-card-stream-staging-uat-contract.test.mjs`: 46/46 pass
- `bash -n scripts/ops/dingtalk-interactive-card-stream-staging-uat-remote.sh`
- mutations individually red when removing: HTTPS actions from remote closure; non-observe delivery-id rejection; optional status SHA rejection; expected-delivery scoping
- dynamic harness executes the production `action_observe` body against realistic Winston-shaped logs and proves target-only counts with no UUID emission
- independent Kimi adversarial review: APPROVE, 0 P1/0 P2

## Safety boundary

- `observe` is read-only and never writes Stream or lifecycle flags
- this PR does not merge, deploy, enable Stream, send a card, or claim U1-U13/callback completion
- the next real Stream window remains separately owner-gated
