### PR TITLE
docs(approval): record G0 RATIFY and O3 DEFER for Canvas D0

### DIFF
--- a/docs/development/approval-canvas-data-closure-final-eligibility-development-20260808.md
+++ b/docs/development/approval-canvas-data-closure-final-eligibility-development-20260808.md
@@ -6,8 +6,8 @@
 **Pre-merge product tip (examples):** `0bfaeddeb180f25a05ea83563d43769cb4f4369b` (and later heads on the PR)  
 **Authoritative land SHA:** `323d7e1afef407f68c8ff2a6bfa940f175300f59`  
 **Authority:**  
-- `docs/development/approval-canvas-v2-development-plan-20260720.md` (D0–D11 + G gates; status remains PROPOSED for G0 owner ratify)  
-- `docs/development/approval-canvas-v2-interaction-design-lock-20260721.md` (D0 interaction contract; still PROPOSED until G0)  
+- `docs/development/approval-canvas-v2-development-plan-20260720.md` (D0–D11 + G gates; G0 recorded 2026-08-15, O3 DEFER, UAT/flags still owner-controlled)  
+- `docs/development/approval-canvas-v2-interaction-design-lock-20260721.md` (D0 interaction contract; **G0 RATIFIED 2026-08-15**)  
 - `docs/development/approval-automation-canvas-completion-*-20260722.md` (prior compose stack on main)
 
 This document records the **engineering closeout** that closes remaining G5-C product-path gaps on the dormant Canvas V2 surface and re-asserts G5-R data-closure invariants. It does **not** enable production flags or claim real-tenant UAT.
@@ -43,17 +43,17 @@ Data-closure (already on main from the 20260722 stack) remains:
 ### Explicit non-changes
 
 - No production / staging flag flipped ON.  
-- No Vue Flow / ELK adoption (O3 remains open; bespoke layout retained).  
+- No Vue Flow / ELK adoption (O3 DEFER 2026-08-15; bespoke layout retained).  
 - No number FWB unlock.  
 - No optional D7 runtimes (handler nodes, within-node ordered approvers, new assignee sources, readonly enforcement).  
 - No free-form edge rewiring / large-graph virtualization / native mobile bottom sheet.  
-- G0 owner ratification of D0 is **not** claimed — lock/plan status text left PROPOSED; implementation follows the written lock as the contract for this goal.
+- G0 owner ratification of D0 is recorded separately (2026-08-15 RATIFY / O3 DEFER). This 2026-08-08 development MD still does **not** enable flags or claim real-tenant UAT.
 
 ## 3. Mapping to D0–D11 / G gates
 
 | Gate / item | Engineering status after this delivery |
 |---|---|
-| D0 interaction lock | Written contract implemented for history, canvas-first default under flag, retained list alternative; **G0 owner ratify still open** |
+| D0 interaction lock | Written contract implemented for history, canvas-first default under flag, retained list alternative; **G0 RATIFIED 2026-08-15** |
 | D1 hygiene | Unchanged / still holds (no JSON / raw-id ordinary path) |
 | D2-a/b/c | Command algebra + session history **mounted**; empty-branch / invalid-move fail closed |
 | D3 Vue Flow/ELK | **Not** started (O3 open); bespoke layout + session commands |
@@ -72,7 +72,7 @@ Data-closure (already on main from the 20260722 stack) remains:
 2. ~~Form palette~~ — **closed**: field-type palette (`approval-field-palette`) without ID entry.  
 3. Version dual-canvas full product shell still not claimed; TemplateDetailView now surfaces `buildApprovalVersionReadSummary` lines + overlay tallies.  
 4. Canvas shells extracted (`ApprovalFlowCanvas` / `ApprovalCanvasNodeInspector`).  
-5. G0 / O3 owner decisions still open (D3 Vue Flow not started).  
+5. G0 RATIFIED 2026-08-15; O3 DEFER (D3 Vue Flow not started).  
 6. Real-tenant UAT and staged flag ON not executed.
 
 These residuals do **not** block the engineering claim “G5-C product-path algebra + mounted undo/history + canvas-first under flag + G5-R invariants hold.” They **do** block an honest **product FINAL** label until owner gates close.

--- a/docs/development/approval-canvas-data-closure-final-eligibility-verification-20260808.md
+++ b/docs/development/approval-canvas-data-closure-final-eligibility-verification-20260808.md
@@ -1,6 +1,6 @@
 # Approval Canvas + Data Closure — Final Eligibility Verification (2026-08-08)
 
-**Status:** ENGINEERING-READY FOR PRODUCT FINAL (owner UAT + staged flag ON **not** done)  
+**Status:** ENGINEERING-READY FOR PRODUCT FINAL (G0 RATIFIED 2026-08-15; owner UAT + staged flag ON **not** done)  
 **Landed:** https://github.com/zensgit/metasheet2/pull/4806 → `main` squash `323d7e1afe` (2026-08-08T04:20:48Z)  
 **Authoritative land SHA:** `323d7e1afef407f68c8ff2a6bfa940f175300f59`  
 **Pre-merge branch family:** `claude/approval-canvas-final-engineering-20260808`  
@@ -139,11 +139,11 @@ No product-code change in this delivery flips a default to ON.
 | Engineering stack complete for G5-C product-path + mounted undo/history + canvas-first under flag | **YES** |
 | G5-R number fail-closed + flag defaults + attachment flag-OFF still hold on this head | **YES** |
 | Documentation with SHAs + command evidence | **YES** |
-| **Product FINAL** (real-tenant UAT + staged flag ON + G0 ratify) | **NO** |
+| **Product FINAL** (real-tenant UAT + staged flag ON + G0 ratify) | **NO** — G0 is done; UAT and staged flags are not |
 
 **Authoritative status string:**
 
-> **ENGINEERING-READY FOR PRODUCT FINAL; NOT PRODUCT FINAL — owner UAT and staged flag enablement remain open.**
+> **ENGINEERING-READY FOR PRODUCT FINAL; G0 RATIFIED 2026-08-15; NOT PRODUCT FINAL — owner UAT and staged flag enablement remain open.**
 
 ## 6. Owner-only remaining gates
 
@@ -151,7 +151,7 @@ Executable owner packet (checklists + flag stages + sign-off template):
 
 → **`docs/development/approval-canvas-data-closure-owner-handoff-20260808.md`**
 
-1. G0 ratify of `approval-canvas-v2-interaction-design-lock-20260721.md` (and O3 layout engine choice if renderer migration is desired).  
-2. Real-tenant UAT: form authoring, linear/condition/parallel publish+execute, route preview, FWB create/update, attachments, version restore.  
-3. Staged enablement: durable → Class A → Class B → FWB → attachments / Canvas V2, with observation windows.  
+1. G0 ratify of `approval-canvas-v2-interaction-design-lock-20260721.md` — **done 2026-08-15 (RATIFY; O3 DEFER)**. See `approval-canvas-g0-ratify-20260815.md`.  
+2. Real-tenant UAT: form authoring, linear/condition/parallel publish+execute, route preview. FWB create/update and attachments stay **deferred** this round.  
+3. Staged enablement: Canvas-only staging first; FWB and attachments later, with observation windows.  
 4. Optional residual product polish (not blocking ENGINEERING-READY): form palette drag affordances; full editor-embedded dual-canvas version UX (beyond TemplateDetailView summary). Edge `+` / no canvas node clusters / form palette / shell extract already landed in #4806.

--- a/docs/development/approval-canvas-data-closure-owner-handoff-20260808.md
+++ b/docs/development/approval-canvas-data-closure-owner-handoff-20260808.md
@@ -1,12 +1,13 @@
 # Approval Canvas + Data Closure — Owner Handoff (G0 / UAT / staged flags)
 
-**Status:** OWNER ACTION REQUIRED — engineering closed on main; product FINAL blocked here  
+**Status:** G0 RATIFIED 2026-08-15 — real-tenant UAT and staged enablement remain open; product FINAL blocked here  
+**G0 record:** `docs/development/approval-canvas-g0-ratify-20260815.md`  
 **Date:** 2026-08-08  
 **Product code land:** https://github.com/zensgit/metasheet2/pull/4806 → `main` `323d7e1afe`  
 **Docs land stamp:** https://github.com/zensgit/metasheet2/pull/4811 → `main` `bea44e12d5`  
-**Authority locks (still PROPOSED until G0):**  
-- `docs/development/approval-canvas-v2-interaction-design-lock-20260721.md`  
-- `docs/development/approval-canvas-v2-development-plan-20260720.md`  
+**Authority locks:**  
+- `docs/development/approval-canvas-v2-interaction-design-lock-20260721.md` (**G0 RATIFIED 2026-08-15**)  
+- `docs/development/approval-canvas-v2-development-plan-20260720.md` (G0 recorded; O3 DEFER; UAT/flags still owner-controlled)  
 **Engineering companions:**  
 - `docs/development/approval-canvas-data-closure-final-eligibility-development-20260808.md`  
 - `docs/development/approval-canvas-data-closure-final-eligibility-verification-20260808.md`  
@@ -20,10 +21,10 @@
 |---|---|
 | Engineering stack for Canvas V2 authoring path + G5-R engineering invariants | **YES — on main** |
 | Product FINAL | **NO** |
-| G0 ratify of D0 | **NO — owner only** |
-| Real-tenant UAT | **NO — owner only** |
+| G0 ratify of D0 | **YES — 2026-08-15 RATIFY** (see `approval-canvas-g0-ratify-20260815.md`) |
+| Real-tenant UAT | **NO — still owner / tenant** |
 | Any production / staging flag ON by default | **NO** (`approvalCanvasV2`, FWB, attachments all default OFF) |
-| D3 Vue Flow / ELK renderer | **NO — blocked on O3** |
+| D3 Vue Flow / ELK renderer | **NO — O3 DEFER** |
 | Number FWB unlock / optional D7 runtimes | **NO** |
 
 Agents must **not** flip env flags or rewrite lock status from PROPOSED → RATIFIED without an explicit owner decision recorded below.
@@ -65,15 +66,15 @@ Copy this block into the PR/issue comment or lock header when decided:
 
 ```text
 G0 decision for approval-canvas-v2-interaction-design-lock-20260721.md
-Date:
-Owner:
-Decision: RATIFY | REJECT | RATIFY-WITH-DELTAS
-If RATIFY-WITH-DELTAS, list deltas:
-O3 layout engine (optional, independent): KEEP_BESPOKE | ADOPT_VUE_FLOW_ELK | DEFER
-Notes:
+Date: 2026-08-15
+Owner: zensgit
+Decision: RATIFY
+If RATIFY-WITH-DELTAS, list deltas: (none)
+O3 layout engine (optional, independent): DEFER
+Notes: Staging Canvas-only UAT (S1–S12) and staged flag enablement remain open. FWB/attachments stay OFF. No product FINAL.
 ```
 
-On **RATIFY**, owner (or designated doc maintainer) may flip the D0 lock **Status** line from `PROPOSED` to `RATIFIED` and cite this decision. Agents must not do that unilaterally.
+Recorded in `docs/development/approval-canvas-g0-ratify-20260815.md`. D0 lock Status is **RATIFIED**. Agents must still not flip runtime flags or claim product FINAL without a later owner decision.
 
 ### 2.2 G0 checklist (plan §7 + lock §19) — engineering evidence vs owner judgment
 
@@ -170,13 +171,13 @@ Do **not** enable everything at once. Canvas ON does **not** transitively enable
 
 ```text
 Product FINAL gate — Approval Canvas + Data Closure
-Land SHA: 323d7e1afe (or later main tip: ________)
-G0: RATIFY | REJECT | WITH-DELTAS  (date/owner)
-UAT G5-C: PASS | FAIL  (S1–S12 evidence link/notes)
-UAT G5-R: PASS | FAIL | DEFERRED (R1–R3)
-Staged flags: Canvas __ / FWB __ / Attachments __
-Residual accepted: dual-canvas full shell? O3 DEFER? list fallback keep?
-Product FINAL authorized: YES | NO
+Land SHA: 323d7e1afe (later main tip at G0 record: 9b693a11d9)
+G0: RATIFY  2026-08-15 / zensgit
+UAT G5-C: NOT RUN  (no managed staging tenant on the recording machine)
+UAT G5-R: DEFERRED (R1–R3 — not this round)
+Staged flags: Canvas not applied / FWB OFF / Attachments OFF
+Residual accepted: O3 DEFER; list fallback keep; dual-canvas full shell not required for this G0
+Product FINAL authorized: NO
 ```
 
 Only when **G0 + real-tenant UAT + staged enablement** are all owner-complete may docs claim **product FINAL**.
@@ -196,8 +197,8 @@ Only when **G0 + real-tenant UAT + staged enablement** are all owner-complete ma
 
 ## 7. Suggested owner order of operations
 
-1. **G0** on D0 lock (and optional O3) using §2.  
-2. Staging **Canvas-only** UAT using §3.2.  
-3. Stage flags per §4 (Canvas before FWB before attachments).  
-4. Sign product FINAL with §5.  
+1. **G0** on D0 lock (and optional O3) using §2. **Done 2026-08-15 (RATIFY, O3 DEFER).**  
+2. Staging **Canvas-only** UAT using §3.2. **Still open.**  
+3. Stage flags per §4 (Canvas before FWB before attachments). **Not started.**  
+4. Sign product FINAL with §5. **Not authorized.**  
 5. Open residual polish PRs only if UAT produces concrete gaps.

--- a/docs/development/approval-canvas-g0-ratify-20260815.md
+++ b/docs/development/approval-canvas-g0-ratify-20260815.md
@@ -1,0 +1,51 @@
+# Approval Canvas D0 — G0 Ratify Record (2026-08-15)
+
+**Decision:** RATIFY  
+**O3 layout engine:** DEFER (keep the shipped bespoke renderer; Vue Flow / ELK not authorized)  
+**Owner:** zensgit, via explicit instruction to execute the recorded recommendation  
+**Date:** 2026-08-15  
+**Integration head at record:** `origin/main` `9b693a11d9bb09f4cb5225223d01d7bc554b9805` (`#4912` closeout on main)
+
+This record is the G0 packet from `docs/development/approval-canvas-data-closure-owner-handoff-20260808.md` §2. It authorizes the D0 interaction contract. It does **not** enable runtime flags, run real-tenant UAT, or authorize product FINAL.
+
+## 1. Decision block (handoff §2.1)
+
+```text
+G0 decision for approval-canvas-v2-interaction-design-lock-20260721.md
+Date: 2026-08-15
+Owner: zensgit
+Decision: RATIFY
+If RATIFY-WITH-DELTAS, list deltas: (none)
+O3 layout engine (optional, independent): DEFER
+Notes: Execute the recommended owner packet. Staging Canvas-only UAT (S1–S12) remains a separate gate. FWB and attachments stay default OFF this round. Do not claim product FINAL.
+```
+
+## 2. What this ratify does and does not do
+
+| Action | Status |
+|---|---|
+| Flip D0 lock Status `PROPOSED` → `RATIFIED` | **YES** — this record |
+| O3 Vue Flow / ELK | **DEFER** — current bespoke canvas stays |
+| Real-tenant UAT (handoff §3.2 S1–S12) | **NOT DONE** — no tenant credentials; `docker/app.staging.env` absent on the recording machine |
+| Staged Canvas ON (handoff §4 stage 2+) | **NOT APPLIED** — no staging env file; repo/production defaults untouched; remote example host not mutated |
+| FWB / attachments enablement | **NOT THIS ROUND** |
+| Repo / production flag defaults | **UNCHANGED, OFF** |
+| Product FINAL | **NO** |
+
+## 3. Staging preflight (values-free)
+
+- Repo defaults on this head: `approvalCanvasV2: false`, `approvalFwbWriteback: false`, `approvalAttachments: false`.
+- Managed staging env `docker/app.staging.env` is **not present** (only `docker/app.staging.env.example`).
+- Example `PUBLIC_APP_URL` from that example file (`http://23.254.236.11:8082`) answered `/api/health` **ok** with build `12f1f8c466` (2026-08-12). That is **not** current `main` `9b693a11d9`, and this record did **not** set `APPROVAL_CANVAS_V2_ENABLED` there or log in.
+- Local `:8899` / `:8900` were not running. Starting a personal stack is not a real-tenant UAT substitute.
+
+S1–S12 therefore stay **NOT RUN**. FWB/attachments stay **DEFERRED**.
+
+## 4. Remaining owner gates (unchanged)
+
+1. Non-prod tenant on a build that includes `323d7e1afe` or later; Canvas-only `APPROVAL_CANVAS_V2_ENABLED=true` in **that** environment.  
+2. Handoff §3.2 S1–S12 + §3.4 fail-closed.  
+3. Only after that: canary / default-ON for Canvas, then separate FWB and attachments ladders.  
+4. Sign product FINAL with handoff §5 only when G0 + UAT + staged enablement are all complete.
+
+G0 is now complete. UAT and staged enablement are not.

--- a/docs/development/approval-canvas-remaining-engineering-design-20260808.md
+++ b/docs/development/approval-canvas-remaining-engineering-design-20260808.md
@@ -3,7 +3,7 @@
 **Status:** ENGINEERING CLOSED ON MAIN (owner product FINAL gates remain)  
 **Tracking PR:** https://github.com/zensgit/metasheet2/pull/4806 (**MERGED** squash `323d7e1afe`, 2026-08-08T04:20:48Z)  
 **Landed head family:** `claude/approval-canvas-final-engineering-20260808` → `main`  
-**Authority locks:** D0 interaction lock (written contract; G0 owner ratify still open), canvas V2 plan D-items, final-eligibility MDs  
+**Authority locks:** D0 interaction lock (**G0 RATIFIED 2026-08-15**; O3 DEFER), canvas V2 plan D-items, final-eligibility MDs  
 **Flags:** remain default OFF. No production enablement. No real-tenant UAT in this plan.
 
 ## Goal
@@ -43,7 +43,7 @@ Engineering stack for this line is **landed on main** via #4806. Further agent w
 | CI: approval-web-guard / web-tests green | **GREEN then MERGED** | squash `323d7e1afe` after required checks (incl. plugin `test` 18.x/20.x) |
 | Version dual-canvas shell (full D8-b) | **PARTIAL→UI wired** | pure summary + TemplateDetailView read summary lines/overlay tallies; full dual-canvas product shell not claimed |
 | Extract `ApprovalFlowCanvas` / inspector modules | **DONE on main** | `ApprovalFlowCanvas.vue` + `ApprovalCanvasNodeInspector.vue`; draft/history remain in parent |
-| D3 Vue Flow/ELK | **BLOCKED (O3)** | do not start |
+| D3 Vue Flow/ELK | **BLOCKED (O3 DEFER 2026-08-15)** | do not start |
 
 ## PR Plan (execute-plan ready)
 

--- a/docs/development/approval-canvas-residual-parallel-closeout-verification-20260815.md
+++ b/docs/development/approval-canvas-residual-parallel-closeout-verification-20260815.md
@@ -116,4 +116,6 @@ Implementer scratch dir (goal `{SCRATCH}`):
 | `owner-smoke.log` | `SKIP_TESTS=1` exit 0, files required, no flag flip |
 | `flags-default-off.log` | canvas / FWB / attachments default OFF; locks still PROPOSED |
 
-Owner-only remainder (out of this closeout): G0 ratify, real-tenant UAT, staged flag enablement, product FINAL.
+Owner-only remainder at this residual closeout: G0 ratify, real-tenant UAT, staged flag enablement, product FINAL.
+
+Follow-on 2026-08-15: G0 was owner-RATIFIED (O3 DEFER) in `docs/development/approval-canvas-g0-ratify-20260815.md`. This residual closeout still does not claim real-tenant UAT, staged flag ON, or product FINAL.

--- a/docs/development/approval-canvas-v2-development-plan-20260720.md
+++ b/docs/development/approval-canvas-v2-development-plan-20260720.md
@@ -1,6 +1,6 @@
 # Approval Canvas V2 Development Plan (2026-07-20)
 
-**Status:** PROPOSED - owner ratification required before D3 canvas foundation work starts
+**Status:** G0 RATIFIED 2026-08-15 (D0 lock). O3 DEFER — bespoke canvas retained; Vue Flow / ELK not authorized. Runtime flags and real-tenant UAT remain owner-controlled; not product FINAL.
 **Baseline:** `origin/main@a98996ee2e0269b22801a6b87d2b8d5b5f076025`
 **Scope:** approval form authoring, approval-flow canvas, template versions, form/decision-value writeback, and attachment integration
 **Flags:** Canvas V2 defaults OFF until G5-C plus owner UAT; FWB and attachments retain separate default-OFF gates
@@ -622,6 +622,7 @@ flags or production rollout.
       if the accessible-authoring equivalence gate passes.
 - [ ] O3 - Choose Vue Flow plus lazy-loaded ELK, accepting its measured bundle/license cost; otherwise amend
       the plan to authorize and verify a Dagre post-layout ordering/rerouting layer. No silent fallback.
+      **Owner 2026-08-15: DEFER** — do not start Vue Flow / ELK; keep the shipped bespoke renderer.
 - [ ] O3-p - Authorize D3-p as a pre-G0 compatibility repair for already-shipped timeout/threshold semantics.
       This does not ratify D0, start D3, or enable a flag.
 - [ ] O4 - Dragging is semantic placement; arbitrary persisted positions are out of scope.
@@ -671,5 +672,7 @@ The initial commit `2338eb928` received two read-only independent reviews before
   regression ownership. Manager/dept/level assignee sources are not attendance-only; they are present in the
   core approval types and product service and now have D7-c1 parity ownership.
 
-Subagent findings are inputs, not proof. This revision was reconciled against the repository by Codex; the plan
-remains PROPOSED until the owner checks section 13.
+Subagent findings are inputs, not proof. This revision was reconciled against the repository by Codex.
+G0 of the D0 lock was owner-RATIFIED 2026-08-15 (`docs/development/approval-canvas-g0-ratify-20260815.md`).
+O3 is DEFER (do not start Vue Flow / ELK). Section 13 items other than that O3 deferral, plus UAT and
+flag enablement, remain owner-controlled.

--- a/docs/development/approval-canvas-v2-interaction-design-lock-20260721.md
+++ b/docs/development/approval-canvas-v2-interaction-design-lock-20260721.md
@@ -1,6 +1,8 @@
 # Approval Canvas V2 Interaction Design Lock (D0, 2026-07-21)
 
-**Status:** PROPOSED — owner ratification required (G0) before D3-D6 (D6-f1 excepted) and D6-f2 start
+**Status:** RATIFIED 2026-08-15 (G0, owner zensgit). O3: DEFER (bespoke renderer retained; Vue Flow / ELK not authorized). Runtime flags stay default OFF. This ratify does not enable Canvas / FWB / attachments, does not record real-tenant UAT, and does not claim product FINAL.  
+**G0 record:** `docs/development/approval-canvas-g0-ratify-20260815.md`  
+**History:** was PROPOSED — owner ratification required (G0) before D3-D6 (D6-f1 excepted) and D6-f2 start.
 **Plan item:** D0 of `docs/development/approval-canvas-v2-development-plan-20260720.md` ("the plan")
 **Review baseline:** `3ade0d685bbad1605cf71803b228f9aac27d0842`
 **Phase-1 implementation checkpoint:** `eb107032d` (command/preview/backend guards only; no D3+ authorization)
@@ -9,9 +11,9 @@
 authoring surface — flow canvas, inspector, form builder, version lifecycle, route preview, states,
 accessibility, and acceptance evidence. It decides how people interact; it does not change what the graph means.
 
-This lock authorizes **development direction only**. Runtime flags, merge, UAT, and production enablement
-remain owner-gated exactly as the plan states (§4.3, §9 Human merge authority, §13). Nothing here turns
-anything on.
+This lock is the ratified interaction contract (G0, 2026-08-15). Runtime flags, UAT, and production
+enablement remain owner-gated exactly as the plan states (§4.3, §9 Human merge authority, §13). Nothing
+here turns anything on.
 
 ---
 
@@ -531,9 +533,8 @@ exists only after `committed`.
 
 ## 18. Owner gates preserved
 
-- G0 (this lock) → ratification required before D3/D6-f2 (plan §12: D3–D6 and D6-f2 BLOCKED on D0).
-  D3-p is the sole exception and still requires its own owner O3-p authorization; it closes an existing
-  frontend round-trip defect only and confers no renderer or Canvas enablement authority.
+- G0 (this lock) → **RATIFIED 2026-08-15**. O3 is **DEFER**, so D3 Vue Flow / ELK remains unauthorized.
+  D3-p stays a compatibility-only exception and confers no renderer or Canvas enablement authority.
 - Merge authority: every implementation PR requires named human owner/reviewer approval on exact-head
   evidence; subagent/Codex verdicts are recommendations only (plan §9).
 - `approvalCanvasV2` stays default-OFF; canary only after G5-C; default ON only after owner UAT (G6-C,


### PR DESCRIPTION
## Why

Owner authorized the recorded recommendation: **G0 RATIFY**, **O3 DEFER**, staging Canvas-only UAT later, FWB/attachments not this round.

## What changed

- New G0 record: `docs/development/approval-canvas-g0-ratify-20260815.md`
- D0 lock Status: `PROPOSED` → **RATIFIED 2026-08-15**
- Plan / handoff / eligibility MDs updated to match
- O3 recorded as **DEFER** (bespoke renderer stays; Vue Flow / ELK not started)

## What did not change

- Repo defaults stay OFF (`approvalCanvasV2`, FWB, attachments)
- No staging env was mutated
- Real-tenant S1–S12 **not run** (`docker/app.staging.env` missing; no tenant credentials)
- **Product FINAL is not authorized**

## How to verify

Read the G0 record and confirm lock Status is RATIFIED while `featureFlags.ts` still has `approvalCanvasV2: false`.