### PR TITLE
test(core-backend): widen raw-NUL source guard to .vue/.ps1/.py (#4908)

### DIFF
--- a/packages/core-backend/tests/unit/source-files-no-raw-control-bytes.test.ts
+++ b/packages/core-backend/tests/unit/source-files-no-raw-control-bytes.test.ts
@@ -38,33 +38,52 @@
  * SCOPE — stated precisely, because an earlier draft of this paragraph
  * overclaimed it as "EVERY tracked source file … NO exclusions".
  *
- * What the NUL leg actually covers: every tracked file whose extension is one
- * of `.ts .tsx .js .cjs .mjs .sql .sh` — **4154** of the repository's 10954
- * tracked files at the time of writing, all clean, which is why the leg needs
- * no allowlist WITHIN that domain. The absence of exclusions is real; the
- * "every source file" part was not.
+ * What the NUL leg covers: every tracked file whose extension is in
+ * `SOURCE_EXTENSIONS` below — derive the live count yourself rather than
+ * trusting a number pasted into a comment (that is this paragraph's own
+ * lesson, twice over now):
  *
- * What sits OUTSIDE it, counted rather than hand-waved: **267 hand-authored
- * files** — 242 `.vue`, 22 `.ps1`, 3 `.py` — plus non-source tracked files
- * (docs, JSON, YAML, assets). A raw NUL in any of those would make that file
- * binary to git and grep exactly as it did here, and this guard would not see
- * it. The 7-extension domain is where THIS defect actually occurred (a string
- * literal in a `.ts` module) and it is what shipped; widening it to `.vue`
- * and the scripting extensions is a straightforward, deliberately deferred
- * FOLLOW-UP, because widening a guard's domain is a behaviour change and this
- * commit is text-only. Whoever widens it should re-measure first: the
- * no-exclusions property above is a measured fact about the CURRENT domain,
- * not a promise that a larger one is equally clean.
+ *   git ls-files | grep -cE '\.(ts|tsx|js|cjs|mjs|sql|sh|vue|ps1|py)$'
+ *
+ * WIDENING HISTORY. Landed as `.ts .tsx .js .cjs .mjs .sql .sh` (7
+ * extensions, 4154 of 10954 tracked files at the time). #4908 widened it to
+ * add `.vue .ps1 .py` (the three hand-authored extensions counted OUTSIDE
+ * the original domain when it was drafted — 242 + 22 + 3 = 267 files,
+ * exactly the "267 hand-authored files" figure #4908 cited, which is why
+ * `.yml/.yaml` and other tracked-but-not-hand-authored extensions were
+ * considered and left out: they are structured config consumed by a parser,
+ * not code with string-literal escape idiom, and the issue's own count
+ * already closed the hand-authored set at those three). #4908 RE-MEASURED
+ * the widened set before flipping the switch, per this docstring's own
+ * instruction to whoever widens it next: all 267 files (242 `.vue`, 22
+ * `.ps1`, 3 `.py`) were clean of both a raw NUL and every other C0 byte
+ * (`git ls-files -z --cached` piped through the same byte scan the tests
+ * below run) — a measured fact about that domain at that commit, not a
+ * promise that stays true forever. Do the same re-measurement before
+ * widening it again.
+ *
+ * What still sits OUTSIDE the (now 10-extension) domain: non-source tracked
+ * files — docs, JSON, YAML/config, assets. A raw NUL in any of those would
+ * make that file binary to git and grep exactly as it did here, and this
+ * guard would not see it; they are excluded because they are not
+ * hand-authored programming/scripting source in the sense this defect class
+ * requires, not because anyone checked them and found them clean.
  *
  * WHY NOT BAN ALL C0 CONTROL BYTES REPO-WIDE. Because `0x01` is a deliberate,
  * pre-existing in-repo delimiter in three files that this guard does not own
  * (`src/attendance/w4c1-segment-calculator.ts` and two plugin-integration
- * tests), plus one vendored minified bundle. Banning C0 repo-wide would
- * therefore need an exclusion list on day one. Instead the stricter
- * "no C0 at all" leg is scoped to the W7 slice's own directory, where the
- * escape convention is established and the set is genuinely empty — and where
- * a raw `U+001F` was very nearly shipped in the composite lock helper before
- * being caught by hand.
+ * tests), plus one vendored minified bundle (a different, non-`0x01` pair of
+ * C0 bytes, already binary-hostile on its own terms and out of this guard's
+ * remit either way). Banning C0 repo-wide would therefore need an exclusion
+ * list on day one. Instead the stricter "no C0 at all" leg is scoped to the
+ * W7 slice's own directory, where the escape convention is established and
+ * the set is genuinely empty — and where a raw `U+001F` was very nearly
+ * shipped in the composite lock helper before being caught by hand. #4908
+ * re-checked `0x01` specifically across the WIDENED domain (the new `.vue
+ * .ps1 .py` files included, not just the original 7 extensions): still
+ * exactly those same three pre-existing carriers, no new ones introduced by
+ * the widening. A test below keeps that an executable fact rather than a
+ * comment someone forgets to update.
  */
 import { execFileSync } from 'node:child_process'
 import fs from 'node:fs'
@@ -76,13 +95,38 @@ const REPO_ROOT = path.resolve(__dirname, '../../../../')
 
 /** Extensions where this defect class lands: hand-authored source. Binary
  *  assets (images, fonts, archives) legitimately contain NUL and are not
- *  source, so they are not in the domain at all. */
-const SOURCE_EXTENSIONS = new Set(['.ts', '.tsx', '.js', '.cjs', '.mjs', '.sql', '.sh'])
+ *  source, so they are not in the domain at all. Widened by #4908 to add
+ *  `.vue .ps1 .py` (re-measured clean first — see docstring above);
+ *  `.yml/.yaml` and other config extensions were considered and left out as
+ *  parser-consumed config rather than hand-authored source. */
+const SOURCE_EXTENSIONS = new Set([
+  '.ts',
+  '.tsx',
+  '.js',
+  '.cjs',
+  '.mjs',
+  '.sql',
+  '.sh',
+  '.vue',
+  '.ps1',
+  '.py',
+])
 
 /** Tab, LF and CR are the only control bytes a text source legitimately holds. */
 const ALLOWED_CONTROL_BYTES = new Set([0x09, 0x0a, 0x0d])
 
 const W7_SLICE_DIR = 'packages/core-backend/src/attendance/w7-resolver'
+
+/** The only files anywhere in the (now widened) domain allowed to carry a
+ *  deliberate `0x01` delimiter — see "WHY NOT BAN ALL C0 CONTROL BYTES
+ *  REPO-WIDE" above. A file added to this set is a design decision, not a
+ *  test fixture; anything else that starts carrying `0x01` is either an
+ *  accident or needs its own reviewed addition here. */
+const KNOWN_0X01_CARRIERS = new Set([
+  'packages/core-backend/src/attendance/w4c1-segment-calculator.ts',
+  'plugins/plugin-integration-core/__tests__/k3-df-t1-target-payload-preview.test.cjs',
+  'plugins/plugin-integration-core/__tests__/read-source-probe-runtime.test.cjs',
+])
 
 /** Domain DERIVED from git, never a hand-maintained list — a file nobody
  *  listed is exactly what this guard has to see. */
@@ -149,14 +193,33 @@ describe('repo guard: source files contain no raw NUL byte', () => {
     // over nothing — the same "empty read is not an absence" failure this
     // guard exists to prevent, one level up.
     const files = trackedSourceFiles()
-    expect(files.length).toBeGreaterThan(3000)
+    expect(files.length).toBeGreaterThan(4000)
     expect(files).toContain('packages/core-backend/src/attendance/w4c0-identity.ts')
     expect(files).toContain(`${W7_SLICE_DIR}/w7-group-effective-context-issuance.ts`)
     expect(files).toContain('plugins/plugin-attendance/index.cjs')
+    // #4908 widening — proves the filter genuinely reaches the three new
+    // extensions rather than just growing SOURCE_EXTENSIONS in the const
+    // without the domain function actually picking them up.
+    expect(files).toContain('apps/web/src/App.vue')
+    expect(files).toContain('apps/web/src/views/AttendanceView.vue')
+    expect(files).toContain('scripts/ops/attendance-onprem-deploy-run.ps1')
+    expect(files).toContain('scripts/ops/github-dingtalk-oauth-stability-summary.py')
   })
 
-  it('NO tracked .ts/.tsx/.js/.cjs/.mjs/.sql/.sh file contains a raw NUL byte (no exclusions within that domain)', () => {
+  it('NO tracked .ts/.tsx/.js/.cjs/.mjs/.sql/.sh/.vue/.ps1/.py file contains a raw NUL byte (no exclusions within that domain)', () => {
     expect(filesContainingRawNul(trackedSourceFiles())).toEqual([])
+  })
+
+  it('0x01 is confined to exactly the three known pre-existing delimiter carriers, across the WIDENED domain', () => {
+    // Turns the docstring's "re-verified, no new 0x01 carriers" claim into an
+    // executable fact instead of a comment someone forgets to update the next
+    // time the domain widens. Scoped to 0x01 only — the vendored minified
+    // bundle legitimately carries other C0 bytes and is out of this guard's
+    // remit either way (see docstring).
+    const carriers = filesContainingOtherControlBytes(trackedSourceFiles())
+      .filter((hit) => hit.byte === '0x01')
+      .map((hit) => hit.file)
+    expect(new Set(carriers)).toEqual(KNOWN_0X01_CARRIERS)
   })
 
   it('POSITIVE CONTROL: a planted raw NUL reds the leg', () => {
@@ -181,6 +244,29 @@ describe('repo guard: source files contain no raw NUL byte', () => {
         expect(filesContainingRawNul(files, decoyRoot)).not.toContain(
           'packages/core-backend/src/attendance/clean.ts',
         )
+      },
+    )
+  })
+
+  it('POSITIVE CONTROL (#4908 widening): a planted raw NUL in a .vue SFC reds the leg', () => {
+    // Proves the widened domain is actually exercised, not just declared: a
+    // NUL inside a Vue single-file component's script block, the format that
+    // made up 242 of the 267 files this ticket brought into scope.
+    const probe = 'apps/web/src/views/probe-with-nul.vue'
+    withDecoyTree(
+      {
+        [probe]: Buffer.from(
+          `<script setup lang="ts">\nconst label = 'x\u0000'\n</script>\n<template><div>{{ label }}</div></template>\n`,
+          'utf8',
+        ),
+        'apps/web/src/views/clean.vue':
+          "<script setup lang='ts'>\nconst label = 'x\\u0000'\n</script>\n<template><div>{{ label }}</div></template>\n",
+      },
+      (decoyRoot) => {
+        const files = [probe, 'apps/web/src/views/clean.vue']
+        expect(fs.readFileSync(path.join(decoyRoot, probe)).includes(0x00)).toBe(true)
+        expect(filesContainingRawNul(files, decoyRoot)).toEqual([probe])
+        expect(filesContainingRawNul(files, decoyRoot)).not.toContain('apps/web/src/views/clean.vue')
       },
     )
   })

--- a/packages/core-backend/tests/unit/source-files-no-raw-control-bytes.test.ts
+++ b/packages/core-backend/tests/unit/source-files-no-raw-control-bytes.test.ts
@@ -47,27 +47,40 @@
  *
  * WIDENING HISTORY. Landed as `.ts .tsx .js .cjs .mjs .sql .sh` (7
  * extensions, 4154 of 10954 tracked files at the time). #4908 widened it to
- * add `.vue .ps1 .py` (the three hand-authored extensions counted OUTSIDE
- * the original domain when it was drafted — 242 + 22 + 3 = 267 files,
- * exactly the "267 hand-authored files" figure #4908 cited, which is why
- * `.yml/.yaml` and other tracked-but-not-hand-authored extensions were
- * considered and left out: they are structured config consumed by a parser,
- * not code with string-literal escape idiom, and the issue's own count
- * already closed the hand-authored set at those three). #4908 RE-MEASURED
- * the widened set before flipping the switch, per this docstring's own
- * instruction to whoever widens it next: all 267 files (242 `.vue`, 22
- * `.ps1`, 3 `.py`) were clean of both a raw NUL and every other C0 byte
- * (`git ls-files -z --cached` piped through the same byte scan the tests
- * below run) — a measured fact about that domain at that commit, not a
- * promise that stays true forever. Do the same re-measurement before
- * widening it again.
+ * add `.vue .ps1 .py` — the three extensions the issue named, and counted
+ * OUTSIDE the original domain when it was drafted: 242 + 22 + 3 = 267 files,
+ * exactly the "267 hand-authored files" figure #4908 cited. #4908
+ * RE-MEASURED the widened set before flipping the switch, per this
+ * docstring's own instruction to whoever widens it next: all 267 files were
+ * clean of both a raw NUL and every other C0 byte (`git ls-files -z --cached`
+ * piped through the same byte scan the tests below run) — a measured fact
+ * about that domain at that commit, not a promise that stays true forever.
  *
- * What still sits OUTSIDE the (now 10-extension) domain: non-source tracked
- * files — docs, JSON, YAML/config, assets. A raw NUL in any of those would
- * make that file binary to git and grep exactly as it did here, and this
- * guard would not see it; they are excluded because they are not
- * hand-authored programming/scripting source in the sense this defect class
- * requires, not because anyone checked them and found them clean.
+ * #4908 also went looking for OTHER tracked extensions that might be the same
+ * class before writing this section, rather than asserting the three named
+ * ones were the only candidates — the earlier overclaim this paragraph
+ * already warns about, reincarnated one level up, is exactly the mistake of
+ * saying "nothing else qualifies" without having looked:
+ *   - `.yml`/`.yaml` (133 tracked): structured config consumed by a parser,
+ *     not code with this defect class's string-literal escape idiom. NOT
+ *     byte-scanned — excluded on category, same reasoning as docs/JSON.
+ *   - `.bat` (1 file, a Windows batch script — same class as `.sh`/`.ps1`)
+ *     and `.rhai` (1 file, a Rhai script): genuinely hand-authored scripting
+ *     source, same defect-class risk as what's already in the domain.
+ *     Byte-scanned clean (0 NUL, 0 other C0) but left OUT of #4908's
+ *     `SOURCE_EXTENSIONS` change because they weren't what the issue asked
+ *     for — a deliberate deferral, not an oversight; whoever widens next
+ *     should treat them as pending, not re-derive that they exist.
+ *   - `.css` (5 files) and `.html` (12 files): hand-authored but declarative
+ *     markup/stylesheet, not procedural source in this defect class's sense.
+ *     Byte-scanned clean (0 NUL, 0 other C0) anyway and adjudicated OUT on
+ *     category, same footing as `.yml`/`.yaml`.
+ *
+ * What still sits OUTSIDE the (now 10-extension) domain: everything above
+ * that was left out, plus non-source tracked files never considered
+ * candidates at all — docs, JSON, other assets. A raw NUL in any of those
+ * would make that file binary to git and grep exactly as it did here, and
+ * this guard would not see it.
  *
  * WHY NOT BAN ALL C0 CONTROL BYTES REPO-WIDE. Because `0x01` is a deliberate,
  * pre-existing in-repo delimiter in three files that this guard does not own
@@ -96,9 +109,10 @@ const REPO_ROOT = path.resolve(__dirname, '../../../../')
 /** Extensions where this defect class lands: hand-authored source. Binary
  *  assets (images, fonts, archives) legitimately contain NUL and are not
  *  source, so they are not in the domain at all. Widened by #4908 to add
- *  `.vue .ps1 .py` (re-measured clean first — see docstring above);
- *  `.yml/.yaml` and other config extensions were considered and left out as
- *  parser-consumed config rather than hand-authored source. */
+ *  `.vue .ps1 .py` — the three extensions the issue named (re-measured clean
+ *  first — see docstring above). `.bat`/`.rhai`/`.css`/`.html`/`.yml`/`.yaml`
+ *  were also considered (byte-scanned or category-excluded — see docstring);
+ *  none of them were folded into this change. */
 const SOURCE_EXTENSIONS = new Set([
   '.ts',
   '.tsx',


### PR DESCRIPTION
refs #4908

## What

Widens `packages/core-backend/tests/unit/source-files-no-raw-control-bytes.test.ts`'s
`SOURCE_EXTENSIONS` domain from the original 7 extensions
(`.ts .tsx .js .cjs .mjs .sql .sh`) to add the three hand-authored extensions
the issue named: `.vue .ps1 .py`.

## Re-measurement (done FIRST, per the guard's own docstring instruction)

Derivation command: `git ls-files -z --cached`, filtered by extension, scanned
byte-for-byte for a raw NUL (`0x00`) and every other C0 control byte except
tab/LF/CR (`0x09/0x0a/0x0d`).

**Widened into `SOURCE_EXTENSIONS`:**

| extension | tracked file count | raw-NUL dirty | other-C0 dirty |
|---|---:|---:|---:|
| `.vue` | 242 | 0 | 0 |
| `.ps1` | 22 | 0 | 0 |
| `.py` | 3 | 0 | 0 |
| **total (new domain)** | **267** | **0** | **0** |

267 = exactly the "267 hand-authored files" figure the issue cited (242+22+3).

**Other candidate extensions found, byte-scanned, and adjudicated** (per the
issue's own "and any other hand-authored extensions" clause — not folding an
unchecked "nothing else qualifies" into the docstring, which would just be a
fresh instance of the overclaim the docstring already warns against):

| extension | tracked file count | raw-NUL dirty | other-C0 dirty | verdict |
|---|---:|---:|---:|---|
| `.bat` | 1 | 0 | 0 | same class as `.sh`/`.ps1` (hand-authored script) — clean, but left OUT: deliberately deferred, not what the issue asked for |
| `.rhai` | 1 | 0 | 0 | same as above — deferred |
| `.css` | 5 | 0 | 0 | markup/stylesheet, not procedural source — adjudicated OUT on category |
| `.html` | 12 | 0 | 0 | same as above — adjudicated OUT on category |
| `.yml`/`.yaml` | 133 | not scanned | not scanned | structured config consumed by a parser, no string-literal escape idiom — excluded on category without byte-scanning, same reasoning as docs/JSON |

Everything scanned came back clean, so there was nothing to fix in this PR
beyond the widening itself — no separate escape-fix commit was needed. `.bat`
and `.rhai` are real candidates for a future widening (now named explicitly in
the docstring so nobody has to re-derive that they exist); this PR does not
add them because the issue named exactly three extensions.

## `0x01` scoping re-verified for the widened domain

The docstring's "WHY NOT BAN ALL C0 CONTROL BYTES REPO-WIDE" section
documents that `0x01` is a deliberate pre-existing delimiter in exactly three
files. Re-scanned across the WIDENED domain (old 7 extensions + the new
`.vue .ps1 .py`): still exactly the same three carriers, no new ones
introduced by `.vue`/`.ps1`/`.py`:

- `packages/core-backend/src/attendance/w4c1-segment-calculator.ts`
- `plugins/plugin-integration-core/__tests__/k3-df-t1-target-payload-preview.test.cjs`
- `plugins/plugin-integration-core/__tests__/read-source-probe-runtime.test.cjs`

Added `KNOWN_0X01_CARRIERS` + an executable test
(`0x01 is confined to exactly the three known pre-existing delimiter carriers,
across the WIDENED domain`) so this stays a mechanical fact instead of a
docstring claim someone forgets to update the next time the domain widens.

(The vendored minified bundle the docstring already mentions,
`packages/openapi/node_modules/.ignored/js-yaml/dist/js-yaml.min.js`, carries
two *different* non-`0x01` C0 bytes — pre-existing, already outside this
guard's remit, unaffected by the widening; the new test is scoped to `0x01`
only so it doesn't collide with that file.)

## Positive control

Kept the existing `.ts` positive control unchanged and added a second one for
the widened domain: a planted raw NUL inside a `.vue` SFC `<script>` block
(`apps/web/src/views/probe-with-nul.vue`, decoy tree only — never written into
the real repo tree), with an escaped `.vue` sibling proving the leg reads the
byte, not the text `\u0000`. `.vue` was chosen because it's 242 of the 267
files this ticket brought into scope.

## Docstring

Rewritten across two commits:
1. Record the widening history and state the derivation command
   (`git ls-files | grep -cE '\.(ts|tsx|js|cjs|mjs|sql|sh|vue|ps1|py)$'`)
   instead of a hardcoded count that will go stale again — the docstring's
   own prior lesson, now applied to itself.
2. A follow-up commit named `.bat`/`.rhai`/`.css`/`.html` explicitly instead
   of letting them sit silently inside a "non-source" catch-all phrase that
   nobody had actually checked against — same overclaim shape the docstring's
   own opening sentence already calls out, caught in review before merge.

The historical landed-domain count (4154/10954) is kept as a dated snapshot,
not restated as current.

## Testing

- `npx tsc --noEmit` in `packages/core-backend` — clean.
- `npx vitest run tests/unit/source-files-no-raw-control-bytes.test.ts` — 8/8
  passed (re-run clean after the docstring-only follow-up commit too).
- `npx vitest run tests/unit` (full unit suite, 504 files) — 487 files / 6975
  tests passed. 17 files / 5 tests fail with `REPO_ROOT_AMBIGUOUS`, a
  **pre-existing environment artifact** of this agent's worktree being nested
  inside the canonical checkout (two ancestor directories both contain
  `packages/core-backend/package.json`) — reproduced identically with this
  PR's changes stashed out, so unrelated to this diff. The CI `test (20.x)`/
  `test (18.x)` checks on this PR are the authoritative signal for "the full
  unit-guard set green," not that local run.
- Mutation self-check (commit first, mutate, re-run, restore via `cp` from a
  pre-mutation backup — no `git checkout --`), run against the first commit's
  logic (the follow-up commit only touched comments):
  - Reverted `SOURCE_EXTENSIONS` to the old 7 → the new containment
    assertions (`apps/web/src/App.vue` etc.) in the "domain is non-vacuous"
    test went red as expected.
  - Neutered `filesContainingRawNul` to always return `[]` → both positive
    control tests (the pre-existing `.ts` one and the new `.vue` one) went
    red as expected.
  - Dropped one entry from `KNOWN_0X01_CARRIERS` → the `0x01` confinement
    test went red as expected.
  - Restored to the exact committed state after each (`git status
    --porcelain` empty).

## Not in scope / staying open

This is a draft PR per the assigned discipline — no merge, no follow-on
slice. Owner review + merge decision as usual.
