### PR TITLE
fix(dingtalk): retire terminal approval card actions

### DIFF
--- a/docs/development/approval-dingtalk-interactive-card-slice-b-design-lock-20260709.md
+++ b/docs/development/approval-dingtalk-interactive-card-slice-b-design-lock-20260709.md
@@ -1,5 +1,13 @@
 # 审批钉钉互动卡 Slice B · DESIGN-LOCK — 2026-07-09
 
+> **UAT correction 2026-08-15:** a real terminal update changed `statusText` but left both action
+> buttons visible. B-4 therefore also owns the closed template parameter `actionsVisible`: sends
+> set it to `true`; only genuine terminal outcomes (`executed` / terminal `stale`) set it to
+> `false`. Retryable refusal copy does not alter it. The published template must bind both buttons'
+> visibility to this variable and default it to `true` for cards created before this sender change.
+> Publish that backward-compatible template revision before deploying the sender/update code;
+> code-only delivery is not U9 evidence.
+
 > Status: **RATIFIED THROUGH B-2**. B-1 is shipped; the B-2 implementation accompanies this revision.
 > It opens only because Slice A A-5 has PASS evidence in
 > `approval-dingtalk-one-tap-a5-verification-20260705.md` §4.1.

--- a/docs/development/approval-dingtalk-slice-b-uat-checklist-20260710.md
+++ b/docs/development/approval-dingtalk-slice-b-uat-checklist-20260710.md
@@ -87,7 +87,7 @@ DingTalk interactive-card callback corp anchor
 
 | # | 步骤 | 期望 | 结果 |
 |---|---|---|---|
-| U9 | U4 成功后卡面 | `已由 <A 的服务端本地显示名> 同意 · <时间>`（显示名非钉钉 payload 回显） | ⬜ |
+| U9 | U4 成功后卡面 | `已由 <A 的服务端本地显示名> 同意 · <时间>`（显示名非钉钉 payload 回显），且「同意」「驳回」操作区消失；模板须定义默认值为 `true` 的公共布尔变量 `actionsVisible`，两个按钮均以其为显示条件 | ⬜ |
 | U10 | 卡片更新 API 人为置失败（如临时错模板）后 A 同意 | **审批已提交不回滚**；日志 values-free 错误；再次点击经 stale summary 收敛出真实终态 | ⬜ |
 | U11 | 伪造/过期 outTrackId 的回调（技术注入） | 卡面中性文案，与 operator-未解析场景**字节等同**（无存在性 oracle） | ⬜ |
 | **U11-a** | **真实点击的企业来源（#4116 跨企业门实证）** | 一次**真实**的同意点击必须**通过**跨企业门（而不是被 `corp_mismatch` 拒掉）。这是 §0-a 的验收面：worker values-free 日志应显示门读到了企业锚点（header `eventCorpId` 或 body `corpId`）**且与台账 `integration_id` 所属企业一致**。**若真实点击被判 `corp_mismatch` ⇒ 说明真实帧根本不带任何 corp 字段 ⇒ 立刻停止 UAT、关 flag**（这正是 §0-a 预警的 dead-on-arrival）。 | ⬜ |

--- a/packages/core-backend/src/integrations/dingtalk/client.ts
+++ b/packages/core-backend/src/integrations/dingtalk/client.ts
@@ -743,6 +743,7 @@ export interface DingTalkWorkNotificationActionCardInput {
 }
 
 export const DINGTALK_INTERACTIVE_APPROVAL_CARD_CALLBACK_ROUTE_KEY = 'approval_card'
+export const DINGTALK_INTERACTIVE_APPROVAL_CARD_ACTIONS_VISIBLE_KEY = 'actionsVisible'
 
 export interface DingTalkInteractiveApprovalCardInput {
   /** Recipient DingTalk user id. B-2 uses one card per approver. */
@@ -887,6 +888,7 @@ export async function sendDingTalkInteractiveApprovalCard(
             requestNo,
             nodeName,
             statusText,
+            [DINGTALK_INTERACTIVE_APPROVAL_CARD_ACTIONS_VISIBLE_KEY]: 'true',
             approveText: '同意',
             rejectText: '驳回',
             rejectUrl,
@@ -923,9 +925,10 @@ export async function sendDingTalkInteractiveApprovalCard(
  *
  * Official card-instances update endpoint (`PUT /v1.0/card/instances`), addressed by the SAME
  * `outTrackId` the B-2 send used (= the ledger delivery id). The update is a PRESENTATION
- * follow-up only: it carries exactly one param — the terminal `statusText` — with
- * `updateCardDataByKey` so every other card param (title/requestNo/nodeName/buttons) stays as
- * sent. Values-free by construction (B-2 §5 fence): no form data can ride this call.
+ * follow-up only: it carries the terminal `statusText` and, for a true terminal outcome, flips the
+ * closed template boolean `actionsVisible` to false. The template owns presentation and must bind
+ * BOTH action buttons' visibility to that variable. Values-free by construction (B-2 §5 fence):
+ * no form data can ride this call.
  *
  * HTTP-200 business failures fail closed (`success !== true` throws), same discipline as
  * create-and-deliver above — callers must never treat an unacknowledged update as applied.
@@ -935,6 +938,8 @@ export interface DingTalkInteractiveApprovalCardUpdateInput {
   outTrackId: string
   /** Terminal status copy (values-free, built server-side by interactive-card-update.ts). */
   statusText: string
+  /** Omitted for retryable refusal copy; the update API may retire actions but never re-enable them. */
+  actionsVisible?: false
 }
 
 export async function updateDingTalkInteractiveApprovalCard(
@@ -945,6 +950,10 @@ export async function updateDingTalkInteractiveApprovalCard(
 ): Promise<{ requestId?: string; raw: Record<string, unknown> }> {
   const outTrackId = input.outTrackId.trim()
   const statusText = input.statusText.trim()
+  const cardParamMap: Record<string, string> = { statusText }
+  if (input.actionsVisible === false) {
+    cardParamMap[DINGTALK_INTERACTIVE_APPROVAL_CARD_ACTIONS_VISIBLE_KEY] = 'false'
+  }
 
   if (!accessToken.trim()) throw new Error('DingTalk access token is required')
   if (!outTrackId) throw new Error('DingTalk interactive-card outTrackId is required')
@@ -961,9 +970,7 @@ export async function updateDingTalkInteractiveApprovalCard(
       body: JSON.stringify({
         outTrackId,
         cardData: {
-          cardParamMap: {
-            statusText,
-          },
+          cardParamMap,
         },
         cardUpdateOptions: { updateCardDataByKey: true },
       }),

--- a/packages/core-backend/src/integrations/dingtalk/interactive-card-update.ts
+++ b/packages/core-backend/src/integrations/dingtalk/interactive-card-update.ts
@@ -43,8 +43,10 @@ export const DINGTALK_APPROVAL_CARD_SYSTEM_UNAVAILABLE_TEXT = '暂时无法处�
 export type DingTalkApprovalCardTerminalUpdate = {
   /** The ledger delivery id — identical to the card's outTrackId (B-2 anchor). */
   outTrackId: string
-  /** Terminal status copy; the ONLY card param a B-4 update may change. */
+  /** Terminal or retryable status copy. */
   statusText: string
+  /** False only when the approval/card state is genuinely terminal. */
+  actionsVisible?: false
 }
 
 export type DingTalkApprovalCardUpdateSender = (update: DingTalkApprovalCardTerminalUpdate) => Promise<void>
@@ -139,10 +141,15 @@ export function buildDingTalkApprovalCardTerminalUpdate(
       return {
         outTrackId: result.deliveryId,
         statusText: name ? `已由 ${name} 同意 · ${time}` : `已同意 · ${time}`,
+        actionsVisible: false,
       }
     }
     case 'stale':
-      return { outTrackId: result.deliveryId, statusText: staleStatusText(result.summary) }
+      return {
+        outTrackId: result.deliveryId,
+        statusText: staleStatusText(result.summary),
+        actionsVisible: false,
+      }
     case 'engine_rejected': {
       const permissionDenied = result.httpStatus === 403 || result.code === 'APPROVAL_ASSIGNMENT_REQUIRED'
       return {

--- a/packages/core-backend/tests/unit/dingtalk-interactive-card-callback.test.ts
+++ b/packages/core-backend/tests/unit/dingtalk-interactive-card-callback.test.ts
@@ -616,6 +616,7 @@ describe('B-4 hook: terminal card update at outcome production', () => {
     expect(sends[0].outTrackId).toBe(DELIVERY_ID)
     // Display name is the LOCAL users.name resolved fail-closed by the adapter (lock §B-4).
     expect(sends[0].statusText).toMatch(/^已由 Approver A 同意 · \d{4}\/\d{2}\/\d{2} \d{2}:\d{2}$/)
+    expect(sends[0].actionsVisible).toBe(false)
     expect(sends[0].statusText).not.toContain('大黑客')
     expect(sends[0].statusText).not.toContain('Payload Hacker')
     expect(sends[0].statusText).not.toContain('EvilNick')
@@ -654,6 +655,8 @@ describe('B-4 hook: terminal card update at outcome production', () => {
     expect(b.sends).toHaveLength(1)
     expect(a.sends[0].statusText).toBe(b.sends[0].statusText)
     expect(a.sends[0].outTrackId).toBe(DELIVERY_ID)
+    expect(a.sends[0].actionsVisible).toBeUndefined()
+    expect(b.sends[0].actionsVisible).toBeUndefined()
   })
 
   it('stale duplicate → sender receives the TRUE terminal state from the summary', async () => {
@@ -663,7 +666,11 @@ describe('B-4 hook: terminal card update at outcome production', () => {
     const { sends, sender } = recordingSender()
     const result = await executeDingTalkApprovalCardCallback({ ...h.deps, cardUpdateSender: sender } as never, wirePayload())
     expect(result.outcome).toBe('stale')
-    expect(sends).toEqual([{ outTrackId: DELIVERY_ID, statusText: '已同意 · 2026/07/10 14:30' }])
+    expect(sends).toEqual([{
+      outTrackId: DELIVERY_ID,
+      statusText: '已同意 · 2026/07/10 14:30',
+      actionsVisible: false,
+    }])
   })
 
   it('parse-level rejection and unsupported actions never touch the card updater (no-op rows)', async () => {

--- a/packages/core-backend/tests/unit/dingtalk-interactive-card-update.test.ts
+++ b/packages/core-backend/tests/unit/dingtalk-interactive-card-update.test.ts
@@ -83,6 +83,7 @@ describe('buildDingTalkApprovalCardTerminalUpdate (§B-4 mapping table)', () => 
     expect(update).toEqual({
       outTrackId: DELIVERY_ID,
       statusText: `已由 张审批 同意 · ${ACTED_AT_TEXT}`,
+      actionsVisible: false,
     })
   })
 
@@ -103,7 +104,11 @@ describe('buildDingTalkApprovalCardTerminalUpdate (§B-4 mapping table)', () => 
     const approved = buildDingTalkApprovalCardTerminalUpdate({
       outcome: 'stale', deliveryId: DELIVERY_ID, summary: canarySummary(),
     })
-    expect(approved).toEqual({ outTrackId: DELIVERY_ID, statusText: `已同意 · ${ACTED_AT_TEXT}` })
+    expect(approved).toEqual({
+      outTrackId: DELIVERY_ID,
+      statusText: `已同意 · ${ACTED_AT_TEXT}`,
+      actionsVisible: false,
+    })
 
     const rejected = buildDingTalkApprovalCardTerminalUpdate({
       outcome: 'stale',
@@ -111,6 +116,7 @@ describe('buildDingTalkApprovalCardTerminalUpdate (§B-4 mapping table)', () => 
       summary: canarySummary({ actedAction: 'reject' }, { status: 'rejected' }),
     })
     expect(rejected?.statusText).toBe(`已驳回 · ${ACTED_AT_TEXT}`)
+    expect(rejected?.actionsVisible).toBe(false)
   })
 
   it('stale on a non-acted card falls through to the instance terminal status', () => {
@@ -125,6 +131,7 @@ describe('buildDingTalkApprovalCardTerminalUpdate (§B-4 mapping table)', () => 
         summary: canarySummary({ cardState: 'superseded', actedAction: null, actedAt: null }, { status }),
       })
       expect(update?.statusText).toBe(text)
+      expect(update?.actionsVisible).toBe(false)
     }
   })
 
@@ -149,6 +156,9 @@ describe('buildDingTalkApprovalCardTerminalUpdate (§B-4 mapping table)', () => 
       summary: canarySummary({ cardState: 'sent', sendStatus: 'pending', actedAction: null, actedAt: null }, { status: 'pending' }),
     })
     expect(undelivered?.statusText).toBe('卡片已失效，请在网页端查看')
+    expect(expired?.actionsVisible).toBe(false)
+    expect(superseded?.actionsVisible).toBe(false)
+    expect(undelivered?.actionsVisible).toBe(false)
   })
 
   it('P3-H: delivery_not_found and EVERY operator_unresolved reason render BYTE-EQUAL neutral copy (no existence oracle)', () => {
@@ -156,6 +166,7 @@ describe('buildDingTalkApprovalCardTerminalUpdate (§B-4 mapping table)', () => 
       outcome: 'delivery_not_found', outTrackId: DELIVERY_ID,
     })
     expect(notFound).toEqual({ outTrackId: DELIVERY_ID, statusText: DINGTALK_APPROVAL_CARD_NEUTRAL_UNPROCESSABLE_TEXT })
+    expect(notFound?.actionsVisible).toBeUndefined()
 
     for (const reason of ['unlinked', 'inactive', 'ambiguous', 'integration_unpinned'] as const) {
       const unresolved = buildDingTalkApprovalCardTerminalUpdate({
@@ -163,6 +174,7 @@ describe('buildDingTalkApprovalCardTerminalUpdate (§B-4 mapping table)', () => 
       })
       // toBe on the exact same string: byte-equal, not merely similar.
       expect(unresolved?.statusText).toBe(notFound?.statusText)
+      expect(unresolved?.actionsVisible).toBeUndefined()
     }
     // …and the shared copy is the ratified unmapped-user row (lock §B-4).
     expect(DINGTALK_APPROVAL_CARD_NEUTRAL_UNPROCESSABLE_TEXT).toBe('请先在网页端绑定钉钉后再处理')
@@ -177,6 +189,8 @@ describe('buildDingTalkApprovalCardTerminalUpdate (§B-4 mapping table)', () => 
     })
     expect(secret?.statusText).toBe(DINGTALK_APPROVAL_CARD_SYSTEM_UNAVAILABLE_TEXT)
     expect(wrapper?.statusText).toBe(secret?.statusText)
+    expect(secret?.actionsVisible).toBeUndefined()
+    expect(wrapper?.actionsVisible).toBeUndefined()
   })
 
   it('non-recipient / permission denied → 当前账号无权处理该审批', () => {
@@ -184,6 +198,7 @@ describe('buildDingTalkApprovalCardTerminalUpdate (§B-4 mapping table)', () => 
       outcome: 'engine_rejected', deliveryId: DELIVERY_ID, code: 'APPROVAL_ASSIGNMENT_REQUIRED', httpStatus: 403, summary: canarySummary({}, { status: 'pending' }),
     })
     expect(forbidden?.statusText).toBe(DINGTALK_APPROVAL_CARD_NO_PERMISSION_TEXT)
+    expect(forbidden?.actionsVisible).toBeUndefined()
 
     // The engine's assignee gate code maps to the same copy even if the HTTP class drifts.
     const codeOnly = buildDingTalkApprovalCardTerminalUpdate({
@@ -197,6 +212,7 @@ describe('buildDingTalkApprovalCardTerminalUpdate (§B-4 mapping table)', () => 
       outcome: 'engine_rejected', deliveryId: DELIVERY_ID, code: 'VALIDATION_ERROR', httpStatus: 400, summary: canarySummary({}, { status: 'pending' }),
     })
     expect(update?.statusText).toBe('无法处理该审批（VALIDATION_ERROR）')
+    expect(update?.actionsVisible).toBeUndefined()
   })
 
   it('parse-level rejections and unsupported actions are a NO-OP (no card update built)', () => {
@@ -236,7 +252,11 @@ describe('applyDingTalkApprovalCardTerminalUpdate (presentation follow-up, never
       async (update) => { sends.push(update) },
     )
     expect(outcome).toEqual({ status: 'updated', outTrackId: DELIVERY_ID })
-    expect(sends).toEqual([{ outTrackId: DELIVERY_ID, statusText: `已由 张审批 同意 · ${ACTED_AT_TEXT}` }])
+    expect(sends).toEqual([{
+      outTrackId: DELIVERY_ID,
+      statusText: `已由 张审批 同意 · ${ACTED_AT_TEXT}`,
+      actionsVisible: false,
+    }])
   })
 
   it('NO ROLLBACK: a failing card update resolves to a typed failure — it never throws back into the action path', async () => {
@@ -294,7 +314,12 @@ describe('applyDingTalkApprovalCardTerminalUpdate (presentation follow-up, never
     expect((updateInit.headers as Record<string, string>)['x-acs-dingtalk-access-token']).toBe('app-tok')
     expect(JSON.parse(String(updateInit.body))).toMatchObject({
       outTrackId: DELIVERY_ID,
-      cardData: { cardParamMap: { statusText: `已由 张审批 同意 · ${ACTED_AT_TEXT}` } },
+      cardData: {
+        cardParamMap: {
+          statusText: `已由 张审批 同意 · ${ACTED_AT_TEXT}`,
+          actionsVisible: 'false',
+        },
+      },
     })
     __resetDingTalkAppAccessTokenCacheForTests()
   })

--- a/packages/core-backend/tests/unit/dingtalk-work-notification.test.ts
+++ b/packages/core-backend/tests/unit/dingtalk-work-notification.test.ts
@@ -161,6 +161,7 @@ describe('dingtalk work notification client', () => {
           requestNo: 'REQ-1',
           nodeName: '部门审批',
           statusText: '等待你处理',
+          actionsVisible: 'true',
           approveText: '同意',
           rejectText: '驳回',
           rejectUrl: 'https://ms.example.test/m/approval-decision?d=delivery-1&t=token',
@@ -223,7 +224,7 @@ describe('dingtalk work notification client', () => {
     )).rejects.toThrow('create-and-deliver rejected')
   })
 
-  it('B-4 sends the official card-instances update shape (statusText only, update-by-key)', async () => {
+  it('B-4 sends terminal status and retires the template action area by key', async () => {
     const fetchMock = vi.fn(async () => new Response(JSON.stringify({
       success: true,
       result: true,
@@ -235,6 +236,7 @@ describe('dingtalk work notification client', () => {
       {
         outTrackId: 'delivery-1',
         statusText: '已由 张审批 同意 · 2026/07/10 14:30',
+        actionsVisible: false,
       },
       { openApiBaseUrl: 'https://api.dingtalk.test/' },
     )
@@ -248,15 +250,36 @@ describe('dingtalk work notification client', () => {
       'Content-Type': 'application/json',
       'x-acs-dingtalk-access-token': 'app-access-token',
     })
-    // Values-free fence (B-2 §5 / B-4): the update carries statusText ONLY — no form values, no
-    // extra params can ride the terminal update.
+    // Values-free fence (B-2 §5 / B-4): only status and the closed action-visibility boolean ride
+    // the terminal update. The template binds both buttons to actionsVisible.
     expect(JSON.parse(String(init.body))).toEqual({
       outTrackId: 'delivery-1',
       cardData: {
         cardParamMap: {
           statusText: '已由 张审批 同意 · 2026/07/10 14:30',
+          actionsVisible: 'false',
         },
       },
+      cardUpdateOptions: { updateCardDataByKey: true },
+    })
+  })
+
+  it('B-4 retryable copy leaves the existing action visibility untouched', async () => {
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({ success: true }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await updateDingTalkInteractiveApprovalCard('token', {
+      outTrackId: 'delivery-1',
+      statusText: '当前账号无权处理该审批',
+    })
+
+    const [, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit]
+    expect(JSON.parse(String(init.body))).toEqual({
+      outTrackId: 'delivery-1',
+      cardData: { cardParamMap: { statusText: '当前账号无权处理该审批' } },
       cardUpdateOptions: { updateCardDataByKey: true },
     })
   })


### PR DESCRIPTION
## What changed

- send the closed `actionsVisible=true` card parameter on newly created approval cards
- set `actionsVisible=false` only for genuine terminal outcomes (`executed` and non-actionable `stale`)
- preserve current action visibility for neutral, permission, system-failure, and other retryable outcomes
- update the design lock and U9 checklist with the template-first deployment contract

## Why

Real staging Stream UAT proved that terminal `statusText` updates correctly, but both approval buttons remain visible. The backend previously updated only `statusText`; the DingTalk template therefore had no terminal visibility signal.

## Verification

- `pnpm exec vitest run tests/unit/dingtalk-work-notification.test.ts tests/unit/dingtalk-interactive-card-update.test.ts tests/unit/dingtalk-interactive-card-callback.test.ts --watch=false` (78/78)
- `pnpm exec tsc --noEmit`
- `git diff --check`
- mutation proof: removing send-side `true` or terminal `false` makes the named payload/mapping tests fail
- independent adversarial pass found no P1/P2; its P3 omission-assertion gap was added to the permanent tests

## Deployment and UAT gate

This PR alone is **not U9 PASS**. The already-published DingTalk template has now been updated in place to define public Boolean `actionsVisible` with default `true` and bind the shared approve/reject action container to it; the current Card Platform UI exposed no separate publish-version action. This template-side prerequisite is complete, but runtime UAT is not. Before deploying this code, re-verify that exact template configuration. Then deploy the exact merge SHA, create a fresh card, run a bounded Stream UAT, verify terminal status plus disappearance of both actions, and turn Stream OFF again.

The separate reject deep-link/mobile-page failure remains unresolved and is not claimed by this PR. Stream and all lifecycle switches remain OFF. Auto-merge is not armed.