### PR TITLE
feat(approval): restyle template authoring shell (flow, form, stepper)

### DIFF
--- a/apps/web/src/approvals/components/ApprovalCanvasNodeInspector.vue
+++ b/apps/web/src/approvals/components/ApprovalCanvasNodeInspector.vue
@@ -167,17 +167,18 @@ defineExpose({
 
 <style scoped>
 .template-authoring__canvas-inspector {
-  flex: 0 0 400px;
-  width: 400px;
+  flex: 0 0 360px;
+  width: 360px;
   max-width: 100%;
   min-width: 0;
   box-sizing: border-box;
-  border: 1px solid var(--el-border-color-light);
-  border-radius: 8px;
+  border: 1px solid var(--el-border-color-lighter);
+  border-left: 1px solid var(--el-border-color);
+  border-radius: 0;
   background: var(--el-bg-color);
   display: flex;
   flex-direction: column;
-  max-height: min(70vh, 720px);
+  max-height: none;
   overflow: hidden;
   scroll-margin-top: 164px;
 }

--- a/apps/web/src/approvals/components/ApprovalCanvasNodeInspector.vue
+++ b/apps/web/src/approvals/components/ApprovalCanvasNodeInspector.vue
@@ -51,9 +51,9 @@ defineExpose({
   >
     <div class="template-authoring__canvas-inspector-header">
       <div class="template-authoring__canvas-inspector-title">
-        <strong>{{ graphNodeLabel(node.key) }}</strong>
+        <strong>{{ nodeTypeLabel(node.type) }}</strong>
         <span class="template-authoring__node-type" :data-node-type="node.type">
-          {{ nodeTypeLabel(node.type) }}
+          {{ graphNodeLabel(node.key) }}
         </span>
       </div>
       <el-button
@@ -159,6 +159,7 @@ defineExpose({
           删除
         </el-button>
       </div>
+      <p class="template-authoring__inspector-section-label">节点设置</p>
       <slot />
     </div>
   </aside>
@@ -172,7 +173,7 @@ defineExpose({
   min-width: 0;
   box-sizing: border-box;
   border: 1px solid var(--el-border-color-light);
-  border-radius: 6px;
+  border-radius: 8px;
   background: var(--el-bg-color);
   display: flex;
   flex-direction: column;
@@ -185,7 +186,7 @@ defineExpose({
   align-items: flex-start;
   justify-content: space-between;
   gap: 8px;
-  padding: 10px 12px;
+  padding: 12px 14px 10px;
   border-bottom: 1px solid var(--el-border-color-light);
 }
 .template-authoring__canvas-inspector-title {
@@ -193,7 +194,13 @@ defineExpose({
   flex-direction: column;
   gap: 2px;
   min-width: 0;
-  font-size: 13px;
+  font-size: 15px;
+}
+.template-authoring__inspector-section-label {
+  margin: 0 0 8px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--el-text-color-regular);
 }
 .template-authoring__canvas-inspector-body {
   flex: 1 1 auto;

--- a/apps/web/src/approvals/components/ApprovalCanvasNodeInspector.vue
+++ b/apps/web/src/approvals/components/ApprovalCanvasNodeInspector.vue
@@ -167,8 +167,8 @@ defineExpose({
 
 <style scoped>
 .template-authoring__canvas-inspector {
-  flex: 0 0 360px;
-  width: 360px;
+  flex: 0 0 400px;
+  width: 400px;
   max-width: 100%;
   min-width: 0;
   box-sizing: border-box;

--- a/apps/web/src/approvals/components/ApprovalFlowCanvas.vue
+++ b/apps/web/src/approvals/components/ApprovalFlowCanvas.vue
@@ -212,6 +212,47 @@ function nodePosStyle(pos: NodeLayout): CSSProperties {
               <span>移到这里</span>
             </button>
             <div
+              v-for="pos in canvasLayout.nodes"
+              :key="pos.key"
+              class="template-authoring__canvas-node"
+              :class="{
+                'is-selected': selectedCanvasNode === pos.key,
+                'is-moving': movingCanvasNode === pos.key,
+              }"
+              :style="nodePosStyle(pos)"
+              :data-canvas-node="pos.key"
+              :data-node-type="canvasNodeByKey(pos.key)?.type"
+              data-testid="approval-canvas-node"
+              :draggable="!readOnly && canMoveCanvasNode(pos.key)"
+              @click="emit('select-node', pos.key)"
+              @dragstart="emit('drag-start', $event, pos.key)"
+              @dragend="emit('drag-end')"
+            >
+              <div
+                class="template-authoring__canvas-node-kind"
+                :data-node-type="canvasNodeByKey(pos.key)?.type"
+              >
+                {{ nodeTypeLabel(canvasNodeByKey(pos.key)?.type ?? 'approval') }}
+              </div>
+              <div
+                class="template-authoring__canvas-node-selector"
+                role="button"
+                tabindex="0"
+                :aria-label="`编辑${graphNodeLabel(pos.key)}节点`"
+                :aria-pressed="selectedCanvasNode === pos.key"
+                data-testid="approval-canvas-node-select"
+                @click.stop="emit('select-node', pos.key)"
+                @keydown.enter.stop.prevent="emit('select-node', pos.key)"
+                @keydown.space.stop.prevent="emit('select-node', pos.key)"
+                @keydown="emit('node-keydown', $event, pos.key)"
+              >
+                <span class="template-authoring__canvas-node-summary">
+                  {{ canvasNodeSummary(pos.key) }}
+                </span>
+                <span class="template-authoring__canvas-node-chevron" aria-hidden="true">›</span>
+              </div>
+            </div>
+            <div
               v-for="line in canvasEdgeLines"
               v-show="!readOnly && !movingCanvasNode"
               :key="`edge-insert-${line.key}`"
@@ -237,6 +278,8 @@ function nodePosStyle(pos: NodeLayout): CSSProperties {
                 class="template-authoring__canvas-edge-insert-menu"
                 role="menu"
                 data-testid="approval-canvas-edge-insert-menu"
+                @click.stop
+                @pointerdown.stop
               >
                 <button
                   type="button"
@@ -287,47 +330,6 @@ function nodePosStyle(pos: NodeLayout): CSSProperties {
                   </span>
                   并行分支
                 </button>
-              </div>
-            </div>
-            <div
-              v-for="pos in canvasLayout.nodes"
-              :key="pos.key"
-              class="template-authoring__canvas-node"
-              :class="{
-                'is-selected': selectedCanvasNode === pos.key,
-                'is-moving': movingCanvasNode === pos.key,
-              }"
-              :style="nodePosStyle(pos)"
-              :data-canvas-node="pos.key"
-              :data-node-type="canvasNodeByKey(pos.key)?.type"
-              data-testid="approval-canvas-node"
-              :draggable="!readOnly && canMoveCanvasNode(pos.key)"
-              @click="emit('select-node', pos.key)"
-              @dragstart="emit('drag-start', $event, pos.key)"
-              @dragend="emit('drag-end')"
-            >
-              <div
-                class="template-authoring__canvas-node-kind"
-                :data-node-type="canvasNodeByKey(pos.key)?.type"
-              >
-                {{ nodeTypeLabel(canvasNodeByKey(pos.key)?.type ?? 'approval') }}
-              </div>
-              <div
-                class="template-authoring__canvas-node-selector"
-                role="button"
-                tabindex="0"
-                :aria-label="`编辑${graphNodeLabel(pos.key)}节点`"
-                :aria-pressed="selectedCanvasNode === pos.key"
-                data-testid="approval-canvas-node-select"
-                @click.stop="emit('select-node', pos.key)"
-                @keydown.enter.stop.prevent="emit('select-node', pos.key)"
-                @keydown.space.stop.prevent="emit('select-node', pos.key)"
-                @keydown="emit('node-keydown', $event, pos.key)"
-              >
-                <span class="template-authoring__canvas-node-summary">
-                  {{ canvasNodeSummary(pos.key) }}
-                </span>
-                <span class="template-authoring__canvas-node-chevron" aria-hidden="true">›</span>
               </div>
             </div>
           </div>
@@ -511,8 +513,12 @@ function nodePosStyle(pos: NodeLayout): CSSProperties {
 }
 .template-authoring__canvas-edge-insert {
   position: absolute;
-  z-index: 4;
+  z-index: 6;
   transform: translate(-50%, -50%);
+  pointer-events: auto;
+}
+.template-authoring__canvas-edge-insert.is-open {
+  z-index: 20;
 }
 .template-authoring__canvas-edge-insert-btn {
   width: 28px;
@@ -537,9 +543,9 @@ function nodePosStyle(pos: NodeLayout): CSSProperties {
 }
 .template-authoring__canvas-edge-insert-menu {
   position: absolute;
-  top: 34px;
-  left: 50%;
-  transform: translateX(-50%);
+  top: 50%;
+  left: 36px;
+  transform: translateY(-50%);
   display: flex;
   flex-direction: row;
   align-items: flex-start;
@@ -550,6 +556,7 @@ function nodePosStyle(pos: NodeLayout): CSSProperties {
   border-radius: 10px;
   background: var(--ms-bg-card);
   box-shadow: var(--el-box-shadow);
+  pointer-events: auto;
 }
 .template-authoring__canvas-edge-insert-menu button {
   border: 0;

--- a/apps/web/src/approvals/components/ApprovalFlowCanvas.vue
+++ b/apps/web/src/approvals/components/ApprovalFlowCanvas.vue
@@ -189,8 +189,8 @@ function nodePosStyle(pos: NodeLayout): CSSProperties {
                 v-for="line in canvasEdgeLines"
                 :key="line.key"
                 :d="line.path"
-                stroke="var(--el-border-color-darker)"
-                stroke-width="1.5"
+                stroke="var(--el-border-color)"
+                stroke-width="1.25"
                 fill="none"
                 marker-end="url(#approval-canvas-arrow)"
                 data-testid="approval-canvas-edge"
@@ -380,16 +380,27 @@ function nodePosStyle(pos: NodeLayout): CSSProperties {
 
 <style scoped>
 .template-authoring__canvas-main {
+  position: relative;
   flex: 1 1 auto;
   min-width: 0;
+  display: flex;
+  flex-direction: column;
 }
 .template-authoring__canvas-toolbar {
+  position: absolute;
+  left: 12px;
+  bottom: 12px;
+  z-index: 8;
   display: flex;
   align-items: center;
-  justify-content: flex-end;
-  gap: 8px;
+  gap: 6px;
   min-height: 32px;
-  margin-bottom: 8px;
+  margin: 0;
+  padding: 4px;
+  border: 1px solid var(--el-border-color-lighter);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--el-bg-color) 92%, transparent);
+  box-shadow: var(--el-box-shadow-lighter);
 }
 .template-authoring__canvas-zoom-label {
   min-width: 58px;
@@ -397,15 +408,18 @@ function nodePosStyle(pos: NodeLayout): CSSProperties {
 }
 .template-authoring__canvas-viewport-shell {
   position: relative;
+  flex: 1 1 auto;
   min-width: 0;
+  min-height: 0;
 }
 .template-authoring__canvas-viewport {
-  min-height: 360px;
-  max-height: min(66vh, 720px);
+  min-height: min(72vh, 720px);
+  height: 100%;
+  max-height: none;
   max-width: 100%;
   overflow: auto;
-  border: 1px solid var(--el-border-color);
-  border-radius: 8px;
+  border: 0;
+  border-radius: 0;
   background: var(--el-fill-color-lighter);
 }
 .template-authoring__canvas-viewport:focus-visible {
@@ -419,7 +433,7 @@ function nodePosStyle(pos: NodeLayout): CSSProperties {
 }
 .template-authoring__canvas {
   position: relative;
-  background: var(--ms-bg-page);
+  background: transparent;
   min-height: 200px;
 }
 .template-authoring__canvas-edges {
@@ -430,31 +444,38 @@ function nodePosStyle(pos: NodeLayout): CSSProperties {
 .template-authoring__canvas-node {
   box-sizing: border-box;
   padding: 0;
-  border: 1px solid var(--el-border-color);
-  border-radius: 8px;
+  border: 1px solid var(--el-border-color-lighter);
+  border-radius: 10px;
   background: var(--ms-bg-card);
-  box-shadow: var(--el-box-shadow-lighter);
+  box-shadow: 0 1px 2px rgb(0 0 0 / 4%);
   display: flex;
   flex-direction: column;
   overflow: hidden;
   cursor: default;
   font-size: 12px;
-  min-height: 96px;
+  min-height: 76px;
+  height: 76px;
 }
 .template-authoring__canvas-node[draggable='true'] {
   cursor: grab;
 }
 .template-authoring__canvas-node.is-selected {
   border-color: var(--el-color-primary);
-  box-shadow: 0 0 0 2px var(--el-color-primary-light-5);
+  box-shadow: 0 0 0 2px var(--el-color-primary-light-7);
+}
+.template-authoring__canvas-node.is-selected .template-authoring__canvas-node-kind[data-node-type='approval'] {
+  background: var(--el-color-primary);
+  color: var(--el-color-white);
 }
 .template-authoring__canvas-node.is-moving {
   border-style: dashed;
   border-color: var(--el-color-primary);
 }
 .template-authoring__canvas-node-kind {
-  flex: 0 0 auto;
-  padding: 6px 10px 4px;
+  flex: 0 0 28px;
+  display: flex;
+  align-items: center;
+  padding: 0 12px;
   font-size: 12px;
   font-weight: 600;
   color: var(--el-text-color-primary);
@@ -484,10 +505,10 @@ function nodePosStyle(pos: NodeLayout): CSSProperties {
 .template-authoring__canvas-node-selector {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: 8px;
   min-width: 0;
   flex: 1 1 auto;
-  padding: 8px 10px 10px;
+  padding: 0 12px;
   cursor: pointer;
   outline: none;
 }
@@ -498,12 +519,10 @@ function nodePosStyle(pos: NodeLayout): CSSProperties {
   flex: 1 1 auto;
   min-width: 0;
   color: var(--el-text-color-regular);
-  line-height: 1.35;
+  line-height: 1.4;
   overflow: hidden;
   text-overflow: ellipsis;
-  display: -webkit-box;
-  -webkit-line-clamp: 2;
-  -webkit-box-orient: vertical;
+  white-space: nowrap;
 }
 .template-authoring__canvas-node-chevron {
   flex: 0 0 auto;
@@ -624,7 +643,7 @@ function nodePosStyle(pos: NodeLayout): CSSProperties {
 .template-authoring__canvas-minimap {
   position: absolute;
   right: 12px;
-  bottom: 12px;
+  bottom: 56px;
   box-sizing: border-box;
   border: 1px solid var(--el-border-color);
   border-radius: 6px;
@@ -652,9 +671,7 @@ function nodePosStyle(pos: NodeLayout): CSSProperties {
   padding-left: 18px;
 }
 .template-authoring__hint {
-  margin-top: 8px;
-  font-size: 12px;
-  color: var(--el-text-color-secondary);
+  display: none;
 }
 .template-authoring__node-type {
   font-size: 11px;

--- a/apps/web/src/approvals/components/ApprovalFlowCanvas.vue
+++ b/apps/web/src/approvals/components/ApprovalFlowCanvas.vue
@@ -3,7 +3,7 @@
  * Canvas V2 flow surface (PR4 extract) — pure presentation.
  * Parent owns draft/history and all topology/command mutations.
  */
-import { FullScreen, Rank, ZoomIn, ZoomOut } from '@element-plus/icons-vue'
+import { Connection, FullScreen, Promotion, Rank, Share, User, ZoomIn, ZoomOut } from '@element-plus/icons-vue'
 import { ref, type CSSProperties } from 'vue'
 import type { ApprovalNode } from '../../types/approval'
 import type { GraphLayout, NodeLayout } from '../graphLayout'
@@ -43,6 +43,7 @@ const props = defineProps<{
   minimapWidth: number
   minimapHeight: number
   graphNodeLabel: (nodeKey: string) => string
+  canvasNodeSummary: (nodeKey: string) => string
   nodeTypeLabel: (type: string) => string
   canvasNodeByKey: (nodeKey: string) => ApprovalNode | undefined
   canMoveCanvasNode: (nodeKey: string) => boolean
@@ -66,6 +67,7 @@ const emit = defineEmits<{
   drop: [event: DragEvent, edgeKey: string]
   'toggle-edge-insert': [edgeKey: string]
   'edge-insert-approval': [edgeKey: string]
+  'edge-insert-cc': [edgeKey: string]
   'edge-insert-condition': [edgeKey: string]
   'edge-insert-parallel': [edgeKey: string]
 }>()
@@ -243,7 +245,22 @@ function nodePosStyle(pos: NodeLayout): CSSProperties {
                   data-testid="approval-canvas-edge-insert-approval"
                   @click.stop="emit('edge-insert-approval', line.key)"
                 >
-                  审批
+                  <span class="template-authoring__canvas-edge-insert-icon is-approval" aria-hidden="true">
+                    <el-icon><User /></el-icon>
+                  </span>
+                  审批人
+                </button>
+                <button
+                  type="button"
+                  role="menuitem"
+                  aria-label="插入抄送节点"
+                  data-testid="approval-canvas-edge-insert-cc"
+                  @click.stop="emit('edge-insert-cc', line.key)"
+                >
+                  <span class="template-authoring__canvas-edge-insert-icon is-cc" aria-hidden="true">
+                    <el-icon><Promotion /></el-icon>
+                  </span>
+                  抄送人
                 </button>
                 <button
                   type="button"
@@ -252,7 +269,10 @@ function nodePosStyle(pos: NodeLayout): CSSProperties {
                   data-testid="approval-canvas-edge-insert-condition"
                   @click.stop="emit('edge-insert-condition', line.key)"
                 >
-                  条件
+                  <span class="template-authoring__canvas-edge-insert-icon is-condition" aria-hidden="true">
+                    <el-icon><Share /></el-icon>
+                  </span>
+                  条件分支
                 </button>
                 <button
                   v-if="canInsertParallelOnEdge(line.key)"
@@ -262,7 +282,10 @@ function nodePosStyle(pos: NodeLayout): CSSProperties {
                   data-testid="approval-canvas-edge-insert-parallel"
                   @click.stop="emit('edge-insert-parallel', line.key)"
                 >
-                  并行
+                  <span class="template-authoring__canvas-edge-insert-icon is-parallel" aria-hidden="true">
+                    <el-icon><Connection /></el-icon>
+                  </span>
+                  并行分支
                 </button>
               </div>
             </div>
@@ -276,12 +299,19 @@ function nodePosStyle(pos: NodeLayout): CSSProperties {
               }"
               :style="nodePosStyle(pos)"
               :data-canvas-node="pos.key"
+              :data-node-type="canvasNodeByKey(pos.key)?.type"
               data-testid="approval-canvas-node"
               :draggable="!readOnly && canMoveCanvasNode(pos.key)"
               @click="emit('select-node', pos.key)"
               @dragstart="emit('drag-start', $event, pos.key)"
               @dragend="emit('drag-end')"
             >
+              <div
+                class="template-authoring__canvas-node-kind"
+                :data-node-type="canvasNodeByKey(pos.key)?.type"
+              >
+                {{ nodeTypeLabel(canvasNodeByKey(pos.key)?.type ?? 'approval') }}
+              </div>
               <div
                 class="template-authoring__canvas-node-selector"
                 role="button"
@@ -294,13 +324,10 @@ function nodePosStyle(pos: NodeLayout): CSSProperties {
                 @keydown.space.stop.prevent="emit('select-node', pos.key)"
                 @keydown="emit('node-keydown', $event, pos.key)"
               >
-                <strong>{{ graphNodeLabel(pos.key) }}</strong>
-                <span
-                  class="template-authoring__node-type"
-                  :data-node-type="canvasNodeByKey(pos.key)?.type"
-                >
-                  {{ nodeTypeLabel(canvasNodeByKey(pos.key)?.type ?? 'approval') }}
+                <span class="template-authoring__canvas-node-summary">
+                  {{ canvasNodeSummary(pos.key) }}
                 </span>
+                <span class="template-authoring__canvas-node-chevron" aria-hidden="true">›</span>
               </div>
             </div>
           </div>
@@ -376,8 +403,8 @@ function nodePosStyle(pos: NodeLayout): CSSProperties {
   max-width: 100%;
   overflow: auto;
   border: 1px solid var(--el-border-color);
-  border-radius: 6px;
-  background: var(--ms-bg-page);
+  border-radius: 8px;
+  background: var(--el-fill-color-lighter);
 }
 .template-authoring__canvas-viewport:focus-visible {
   outline: 2px solid var(--el-color-primary-light-5);
@@ -400,14 +427,14 @@ function nodePosStyle(pos: NodeLayout): CSSProperties {
 }
 .template-authoring__canvas-node {
   box-sizing: border-box;
-  padding: 6px 10px;
+  padding: 0;
   border: 1px solid var(--el-border-color);
-  border-radius: 6px;
+  border-radius: 8px;
   background: var(--ms-bg-card);
   box-shadow: var(--el-box-shadow-lighter);
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  overflow: hidden;
   cursor: default;
   font-size: 12px;
   min-height: 96px;
@@ -423,17 +450,64 @@ function nodePosStyle(pos: NodeLayout): CSSProperties {
   border-style: dashed;
   border-color: var(--el-color-primary);
 }
+.template-authoring__canvas-node-kind {
+  flex: 0 0 auto;
+  padding: 6px 10px 4px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--el-text-color-primary);
+  background: var(--el-fill-color-light);
+}
+.template-authoring__canvas-node-kind[data-node-type='start'],
+.template-authoring__canvas-node-kind[data-node-type='end'] {
+  background: var(--el-color-info-light-8);
+  color: var(--el-color-info-dark-2);
+}
+.template-authoring__canvas-node-kind[data-node-type='approval'] {
+  background: var(--el-color-primary-light-8);
+  color: var(--el-color-primary);
+}
+.template-authoring__canvas-node-kind[data-node-type='cc'] {
+  background: var(--el-color-success-light-8);
+  color: var(--el-color-success-dark-2);
+}
+.template-authoring__canvas-node-kind[data-node-type='condition'] {
+  background: var(--el-color-warning-light-8);
+  color: var(--el-color-warning-dark-2);
+}
+.template-authoring__canvas-node-kind[data-node-type='parallel'] {
+  background: var(--el-color-primary-light-9);
+  color: var(--el-color-primary-dark-2);
+}
 .template-authoring__canvas-node-selector {
   display: flex;
-  flex-direction: column;
-  gap: 2px;
+  align-items: center;
+  gap: 6px;
   min-width: 0;
-  border-radius: 4px;
+  flex: 1 1 auto;
+  padding: 8px 10px 10px;
   cursor: pointer;
   outline: none;
 }
 .template-authoring__canvas-node-selector:focus-visible {
-  box-shadow: 0 0 0 2px var(--el-color-primary-light-5);
+  box-shadow: inset 0 0 0 2px var(--el-color-primary-light-5);
+}
+.template-authoring__canvas-node-summary {
+  flex: 1 1 auto;
+  min-width: 0;
+  color: var(--el-text-color-regular);
+  line-height: 1.35;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+}
+.template-authoring__canvas-node-chevron {
+  flex: 0 0 auto;
+  color: var(--el-text-color-placeholder);
+  font-size: 16px;
+  line-height: 1;
 }
 .template-authoring__canvas-edge-insert {
   position: absolute;
@@ -441,16 +515,21 @@ function nodePosStyle(pos: NodeLayout): CSSProperties {
   transform: translate(-50%, -50%);
 }
 .template-authoring__canvas-edge-insert-btn {
-  width: 22px;
-  height: 22px;
+  width: 28px;
+  height: 28px;
   border-radius: 50%;
-  border: 1px solid var(--el-color-primary);
+  border: 1px solid var(--el-color-primary-light-5);
   background: var(--ms-bg-card);
   color: var(--el-color-primary);
-  font-size: 14px;
+  font-size: 18px;
   line-height: 1;
   cursor: pointer;
   padding: 0;
+  box-shadow: var(--el-box-shadow-lighter);
+}
+.template-authoring__canvas-edge-insert.is-open .template-authoring__canvas-edge-insert-btn {
+  background: var(--el-color-primary);
+  color: var(--el-color-white);
 }
 .template-authoring__canvas-edge-insert-btn:focus-visible {
   outline: 2px solid var(--el-color-primary);
@@ -458,31 +537,59 @@ function nodePosStyle(pos: NodeLayout): CSSProperties {
 }
 .template-authoring__canvas-edge-insert-menu {
   position: absolute;
-  top: 26px;
+  top: 34px;
   left: 50%;
   transform: translateX(-50%);
   display: flex;
-  flex-direction: column;
-  gap: 2px;
-  min-width: 72px;
-  padding: 4px;
+  flex-direction: row;
+  align-items: flex-start;
+  gap: 10px;
+  min-width: max-content;
+  padding: 10px 12px 8px;
   border: 1px solid var(--el-border-color);
-  border-radius: 6px;
+  border-radius: 10px;
   background: var(--ms-bg-card);
-  box-shadow: var(--el-box-shadow-lighter);
+  box-shadow: var(--el-box-shadow);
 }
 .template-authoring__canvas-edge-insert-menu button {
   border: 0;
   background: transparent;
-  padding: 4px 8px;
-  text-align: left;
+  padding: 0;
+  min-width: 52px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
   cursor: pointer;
-  font-size: 12px;
-  border-radius: 4px;
+  font-size: 11px;
+  color: var(--el-text-color-regular);
+  border-radius: 6px;
 }
 .template-authoring__canvas-edge-insert-menu button:hover,
 .template-authoring__canvas-edge-insert-menu button:focus-visible {
-  background: var(--el-fill-color-light);
+  color: var(--el-color-primary);
+}
+.template-authoring__canvas-edge-insert-icon {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--el-color-white);
+  font-size: 16px;
+}
+.template-authoring__canvas-edge-insert-icon.is-approval {
+  background: var(--el-color-warning);
+}
+.template-authoring__canvas-edge-insert-icon.is-cc {
+  background: var(--el-color-primary);
+}
+.template-authoring__canvas-edge-insert-icon.is-condition {
+  background: var(--el-color-success);
+}
+.template-authoring__canvas-edge-insert-icon.is-parallel {
+  background: var(--el-color-info);
 }
 .template-authoring__canvas-move-target {
   position: absolute;

--- a/apps/web/src/approvals/graphLayout.ts
+++ b/apps/web/src/approvals/graphLayout.ts
@@ -21,12 +21,12 @@ export interface GraphLayout {
   height: number
 }
 
-export const GRAPH_LAYOUT_NODE_WIDTH = 190
-export const GRAPH_LAYOUT_NODE_HEIGHT = 96
-const X_SPACING = 230
-const Y_SPACING = 150
-const X_MARGIN = 40
-const Y_MARGIN = 40
+export const GRAPH_LAYOUT_NODE_WIDTH = 264
+export const GRAPH_LAYOUT_NODE_HEIGHT = 76
+const X_SPACING = 304
+const Y_SPACING = 176
+const X_MARGIN = 72
+const Y_MARGIN = 36
 
 /**
  * Vertical longest-path layout: each node's layer is the longest path from `start` to it, so a

--- a/apps/web/src/approvals/graphTopologyEdit.ts
+++ b/apps/web/src/approvals/graphTopologyEdit.ts
@@ -306,6 +306,33 @@ export function appendApprovalNode(graph: ApprovalGraph, afterNodeKey: string, n
   }
 }
 
+function defaultCcConfig() {
+  return { targetType: 'user' as const, targetIds: [] as string[] }
+}
+
+/**
+ * Insert a shipped `cc` node on a linear segment (same single-out splice as approval).
+ * Does not invent handler/办理人 semantics.
+ */
+export function appendCcNode(graph: ApprovalGraph, afterNodeKey: string, name = '抄送'): ApprovalGraph {
+  const after = graph.nodes.find((n) => n.key === afterNodeKey)
+  if (!after) throw new Error(`appendCcNode: node ${afterNodeKey} not found`)
+  const outs = outEdges(graph, afterNodeKey)
+  if (outs.length !== 1) throw new Error(`appendCcNode: ${afterNodeKey} must have exactly one outgoing edge (has ${outs.length})`)
+  const out = outs[0]
+  const newKey = uniqueKey('cc', nodeKeys(graph))
+  const eKeys = edgeKeys(graph)
+  const e1 = uniqueKey('edge', eKeys); eKeys.add(e1)
+  const newNode: ApprovalNode = { key: newKey, type: 'cc', name, config: defaultCcConfig() }
+  return {
+    nodes: [...graph.nodes.map(clone), newNode],
+    edges: graph.edges.map((edge) => {
+      if (edge.key !== out.key) return clone(edge)
+      return { ...clone(edge), source: newKey }
+    }).concat([{ key: e1, source: afterNodeKey, target: newKey }]),
+  }
+}
+
 /**
  * Insert a condition gateway on a linear segment. The original `after → target` edge keeps its
  * identity and becomes `after → condition`; the gateway then owns one configurable branch and

--- a/apps/web/src/views/approval/TemplateAuthoringView.vue
+++ b/apps/web/src/views/approval/TemplateAuthoringView.vue
@@ -612,6 +612,7 @@
             :minimap-width="CANVAS_MINIMAP_W"
             :minimap-height="CANVAS_MINIMAP_H"
             :graph-node-label="graphNodeLabel"
+            :canvas-node-summary="canvasNodeCardSummary"
             :node-type-label="nodeTypeLabel"
             :canvas-node-by-key="canvasNodeByKey"
             :can-move-canvas-node="canMoveCanvasNode"
@@ -632,6 +633,7 @@
             @drop="onCanvasNodeDrop"
             @toggle-edge-insert="toggleEdgeInsertMenu"
             @edge-insert-approval="onEdgeInsertApproval"
+            @edge-insert-cc="onEdgeInsertCc"
             @edge-insert-condition="onEdgeInsertCondition"
             @edge-insert-parallel="onEdgeInsertParallel"
           />
@@ -1320,6 +1322,7 @@ import {
   addParallelBranch,
   adjacentLinearNodeMoveTarget,
   appendApprovalNode,
+  appendCcNode,
   collectParallelRegionNodeKeys,
   insertConditionGateway,
   insertParallelGateway,
@@ -1603,6 +1606,15 @@ const NODE_TYPE_LABELS: Record<string, string> = {
 }
 function nodeTypeLabel(type: string): string {
   return NODE_TYPE_LABELS[type] ?? type
+}
+
+function canvasNodeCardSummary(nodeKey: string): string {
+  const node = canvasNodeByKey(nodeKey)
+  if (!node) return '点击配置'
+  if (node.type === 'start') return '可设置提交人'
+  if (node.type === 'end') return '可设置抄送'
+  const lines = nodeConfigSummary(node)
+  return lines[0] || '点击配置'
 }
 
 // `assigneeSourceSummary` (single-source label) now lives in `../../approvals/assigneeSource` —
@@ -2173,6 +2185,9 @@ function onAddParallelBranch(nodeKey: string): void {
 function onInsertApprovalAfter(nodeKey: string): void {
   runTopologyOp((graph) => appendApprovalNode(graph, nodeKey), { kind: 'node', nodeKey })
 }
+function onInsertCcAfter(nodeKey: string): void {
+  runTopologyOp((graph) => appendCcNode(graph, nodeKey), { kind: 'node', nodeKey })
+}
 function onInsertConditionAfter(nodeKey: string): void {
   runTopologyOp((graph) => insertConditionGateway(graph, nodeKey), { kind: 'node', nodeKey })
   canvasViewMode.value = 'canvas'
@@ -2441,6 +2456,12 @@ function onEdgeInsertApproval(edgeKey: string): void {
   const source = edgeSourceNode(edgeKey)
   if (!source || !canInsertAfter(source)) return
   onInsertApprovalAfter(source.key)
+  closeEdgeInsertMenu()
+}
+function onEdgeInsertCc(edgeKey: string): void {
+  const source = edgeSourceNode(edgeKey)
+  if (!source || !canInsertAfter(source)) return
+  onInsertCcAfter(source.key)
   closeEdgeInsertMenu()
 }
 function onEdgeInsertCondition(edgeKey: string): void {

--- a/apps/web/src/views/approval/TemplateAuthoringView.vue
+++ b/apps/web/src/views/approval/TemplateAuthoringView.vue
@@ -221,7 +221,7 @@
       <el-card v-show="activeAuthoringSection === 'fields'" class="template-authoring__panel" shadow="never">
         <template #header>
           <div class="template-authoring__panel-header">
-            <strong>表单字段</strong>
+            <strong>表单设计</strong>
             <div class="template-authoring__form-toolbar">
               <el-button
                 size="small"
@@ -252,29 +252,90 @@
           </div>
         </template>
 
-        <!-- D6-f2 palette: ordinary users pick a field kind; no field-id entry. -->
-        <div
-          v-if="!readOnly"
-          class="template-authoring__field-palette"
-          data-testid="approval-field-palette"
-          role="group"
-          aria-label="添加表单字段类型"
-        >
-          <el-button
-            v-for="entry in fieldPaletteEntries"
-            :key="entry.type"
-            size="small"
-            :data-testid="`approval-field-palette-${entry.type}`"
-            @click="addFieldOfType(entry.type)"
-          >
-            {{ entry.label }}
-          </el-button>
-        </div>
+        <div class="template-authoring__form-designer" data-testid="approval-form-designer">
+          <aside class="template-authoring__form-palette-pane">
+            <p class="template-authoring__form-palette-title">控件</p>
+            <!-- D6-f2 palette: ordinary users pick a field kind; no field-id entry. -->
+            <div
+              v-if="!readOnly"
+              class="template-authoring__field-palette"
+              data-testid="approval-field-palette"
+              role="group"
+              aria-label="添加表单字段类型"
+            >
+              <section
+                v-for="group in fieldPaletteGroups"
+                :key="group.id"
+                class="template-authoring__field-palette-group"
+              >
+                <h3>{{ group.label }}</h3>
+                <div class="template-authoring__field-palette-grid">
+                  <button
+                    v-for="entry in group.entries"
+                    :key="entry.type"
+                    type="button"
+                    class="template-authoring__field-palette-chip"
+                    :data-testid="`approval-field-palette-${entry.type}`"
+                    :draggable="true"
+                    @click="addFieldOfType(entry.type)"
+                    @dragstart="onPaletteDragStart(entry.type, $event)"
+                  >
+                    <span>{{ entry.label }}</span>
+                    <span class="template-authoring__field-palette-mark" aria-hidden="true">{{ entry.mark }}</span>
+                  </button>
+                </div>
+              </section>
+            </div>
+          </aside>
 
+          <div
+            class="template-authoring__form-preview-stage"
+            @dragover.prevent
+            @drop="onPreviewDrop"
+          >
+            <div class="template-authoring__form-phone" data-testid="approval-form-preview">
+              <header class="template-authoring__form-phone-title">
+                {{ draft.name.trim() || '未命名审批' }}
+              </header>
+              <div class="template-authoring__form-phone-body">
+                <div
+                  v-if="draft.fields.length === 0"
+                  class="template-authoring__form-drop-hint"
+                >
+                  点击或拖拽左侧控件至此处
+                </div>
+                <button
+                  v-for="(field, index) in draft.fields"
+                  :key="`preview-${field.localId}`"
+                  type="button"
+                  class="template-authoring__form-preview-row"
+                  :class="{ 'is-selected': formFieldFocusLocalId === field.localId }"
+                  :data-testid="`approval-form-preview-row-${field.localId}`"
+                  @click="selectFormFieldFocus(field.localId)"
+                  :draggable="!readOnly"
+                  @dragstart="onFieldDragStart(index)"
+                  @dragover.prevent
+                  @drop.stop="onFieldDrop(index)"
+                >
+                  <span class="template-authoring__form-preview-label">{{ field.label.trim() || FIELD_PALETTE_LABELS[field.type] }}</span>
+                  <span class="template-authoring__form-preview-type">{{ FIELD_PALETTE_LABELS[field.type] }}</span>
+                </button>
+                <div
+                  v-if="draft.fields.length > 0 && !readOnly"
+                  class="template-authoring__form-drop-hint is-tail"
+                >
+                  点击或拖拽左侧控件至此处
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div class="template-authoring__form-inspector-pane">
         <div
           v-for="(field, index) in draft.fields"
           :id="`approval-field-row-${field.localId}`"
           :key="field.localId"
+          v-show="formFieldFocusLocalId === field.localId || (!formFieldFocusLocalId && index === 0)"
           class="template-authoring__item"
           :class="{ 'template-authoring__item--focused': formFieldFocusLocalId === field.localId }"
           data-testid="approval-template-field-row"
@@ -557,6 +618,8 @@
                 </template>
               </div>
             </el-form-item>
+          </div>
+        </div>
           </div>
         </div>
       </el-card>
@@ -2776,6 +2839,47 @@ const fieldPaletteEntries = AUTHORABLE_FIELD_TYPES.map((type) => ({
   type,
   label: FIELD_PALETTE_LABELS[type],
 }))
+const FIELD_PALETTE_MARKS: Record<AuthorableFieldType, string> = {
+  text: 'A',
+  textarea: 'Aa',
+  number: '123',
+  date: '日',
+  datetime: '时',
+  select: '○',
+  'multi-select': '☑',
+  user: '人',
+  detail: '表',
+  'record-link': '链',
+}
+const fieldPaletteGroups = [
+  { id: 'text', label: '文本', types: ['text', 'textarea'] },
+  { id: 'number', label: '数值', types: ['number'] },
+  { id: 'choice', label: '选项', types: ['select', 'multi-select'] },
+  { id: 'date', label: '日期', types: ['date', 'datetime'] },
+  { id: 'other', label: '其他', types: ['user', 'detail', 'record-link'] },
+].map((group) => ({
+  ...group,
+  entries: group.types.map((type) => ({
+    type: type as AuthorableFieldType,
+    label: FIELD_PALETTE_LABELS[type as AuthorableFieldType],
+    mark: FIELD_PALETTE_MARKS[type as AuthorableFieldType],
+  })),
+}))
+const paletteDragType = ref<AuthorableFieldType | null>(null)
+function onPaletteDragStart(type: AuthorableFieldType, event: DragEvent): void {
+  if (readOnly.value) {
+    event.preventDefault()
+    return
+  }
+  paletteDragType.value = type
+  event.dataTransfer?.setData('text/plain', type)
+}
+function onPreviewDrop(event: DragEvent): void {
+  event.preventDefault()
+  const type = paletteDragType.value
+  paletteDragType.value = null
+  if (type) addFieldOfType(type)
+}
 
 function addField() {
   if (readOnly.value) return
@@ -2829,7 +2933,14 @@ function onFieldDragStart(index: number) {
   if (!readOnly.value) draggedFieldIndex.value = index
 }
 function onFieldDrop(index: number) {
-  if (readOnly.value || draggedFieldIndex.value === null) return
+  if (readOnly.value) return
+  if (paletteDragType.value) {
+    const type = paletteDragType.value
+    paletteDragType.value = null
+    addFieldOfType(type)
+    return
+  }
+  if (draggedFieldIndex.value === null) return
   const from = draggedFieldIndex.value
   draggedFieldIndex.value = null
   if (from === index) return
@@ -3733,11 +3844,152 @@ pre {
   width: 100%;
   min-height: min(72vh, 760px);
 }
+.template-authoring__form-designer {
+  display: grid;
+  grid-template-columns: 228px minmax(0, 1fr) minmax(280px, 360px);
+  gap: 0;
+  min-height: min(68vh, 720px);
+  margin: -8px -12px -16px;
+  border-top: 1px solid var(--el-border-color-lighter);
+}
+.template-authoring__form-palette-pane {
+  border-right: 1px solid var(--el-border-color-lighter);
+  padding: 12px 12px 16px;
+  overflow: auto;
+  background: var(--el-bg-color);
+}
+.template-authoring__form-palette-title {
+  margin: 0 0 12px;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--el-color-primary);
+}
 .template-authoring__field-palette {
   display: flex;
-  flex-wrap: wrap;
+  flex-direction: column;
+  gap: 14px;
+  margin-bottom: 0;
+}
+.template-authoring__field-palette-group h3 {
+  margin: 0 0 8px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--el-text-color-secondary);
+}
+.template-authoring__field-palette-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+}
+.template-authoring__field-palette-chip {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
   gap: 6px;
-  margin-bottom: 12px;
+  min-height: 36px;
+  padding: 6px 8px;
+  border: 1px solid var(--el-border-color-lighter);
+  border-radius: 8px;
+  background: var(--el-bg-color);
+  color: var(--el-text-color-regular);
+  font-size: 12px;
+  cursor: grab;
+  text-align: left;
+}
+.template-authoring__field-palette-chip:hover,
+.template-authoring__field-palette-chip:focus-visible {
+  border-color: var(--el-color-primary-light-5);
+  color: var(--el-color-primary);
+}
+.template-authoring__field-palette-mark {
+  color: var(--el-text-color-placeholder);
+  font-size: 11px;
+}
+.template-authoring__form-preview-stage {
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  padding: 24px 16px 32px;
+  background: var(--el-fill-color-lighter);
+}
+.template-authoring__form-phone {
+  width: min(100%, 360px);
+  min-height: 520px;
+  border: 1px solid var(--el-border-color-lighter);
+  border-radius: 16px;
+  background: var(--el-bg-color);
+  box-shadow: var(--el-box-shadow-lighter);
+  overflow: hidden;
+}
+.template-authoring__form-phone-title {
+  padding: 16px 16px 12px;
+  text-align: center;
+  font-size: 15px;
+  font-weight: 600;
+  border-bottom: 1px solid var(--el-border-color-extra-light);
+}
+.template-authoring__form-phone-body {
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.template-authoring__form-preview-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  width: 100%;
+  min-height: 44px;
+  padding: 8px 12px;
+  border: 1px solid var(--el-border-color-lighter);
+  border-radius: 8px;
+  background: var(--el-fill-color-blank);
+  cursor: pointer;
+  text-align: left;
+}
+.template-authoring__form-preview-row.is-selected {
+  border-color: var(--el-color-primary);
+  box-shadow: 0 0 0 2px var(--el-color-primary-light-8);
+}
+.template-authoring__form-preview-label {
+  font-size: 13px;
+  color: var(--el-text-color-primary);
+}
+.template-authoring__form-preview-type {
+  font-size: 11px;
+  color: var(--el-text-color-placeholder);
+}
+.template-authoring__form-drop-hint {
+  min-height: 72px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px dashed var(--el-border-color);
+  border-radius: 8px;
+  color: var(--el-text-color-secondary);
+  font-size: 13px;
+  background: var(--el-fill-color-blank);
+}
+.template-authoring__form-drop-hint.is-tail {
+  min-height: 48px;
+  font-size: 12px;
+}
+.template-authoring__form-inspector-pane {
+  border-left: 1px solid var(--el-border-color-lighter);
+  padding: 12px;
+  overflow: auto;
+  background: var(--el-bg-color);
+}
+@media (max-width: 1100px) {
+  .template-authoring__form-designer {
+    grid-template-columns: 200px minmax(0, 1fr);
+  }
+  .template-authoring__form-inspector-pane {
+    grid-column: 1 / -1;
+    border-left: 0;
+    border-top: 1px solid var(--el-border-color-lighter);
+  }
 }
 @media (max-width: 960px) {
   .template-authoring__canvas-workspace {

--- a/apps/web/src/views/approval/TemplateAuthoringView.vue
+++ b/apps/web/src/views/approval/TemplateAuthoringView.vue
@@ -98,10 +98,6 @@
     <div v-loading="loading" class="template-authoring__body">
       <div class="template-authoring__workspace">
         <nav class="template-authoring__steps" aria-label="模板配置步骤">
-          <div class="template-authoring__steps-heading">
-            <strong>模板配置</strong>
-            <span>按步骤完成，随时可保存草稿</span>
-          </div>
           <el-button
             v-for="(section, index) in authoringSections"
             :key="section.id"
@@ -109,22 +105,14 @@
             :class="{ 'is-active': activeAuthoringSection === section.id }"
             text
             :aria-current="activeAuthoringSection === section.id ? 'step' : undefined"
+            :aria-label="`${index + 1} ${section.label} ${section.description}`"
             :data-testid="`approval-template-section-${section.id}`"
             @click="selectAuthoringSection(section.id)"
           >
             <span class="template-authoring__step-index">{{ index + 1 }}</span>
             <span class="template-authoring__step-copy">
               <strong>{{ section.label }}</strong>
-              <small>{{ section.description }}</small>
             </span>
-            <span
-              v-if="section.id === 'fields'"
-              class="template-authoring__step-count"
-            >{{ draft.fields.length }}</span>
-            <span
-              v-else-if="section.id === 'flow'"
-              class="template-authoring__step-count"
-            >{{ authoringFlowNodeCount }}</span>
           </el-button>
         </nav>
 
@@ -1569,9 +1557,9 @@ const authoringSections: Array<{
   label: string
   description: string
 }> = [
-  { id: 'basic', label: '基础设置', description: '名称、范围与模板起点' },
+  { id: 'basic', label: '基础信息', description: '名称、范围与模板起点' },
   { id: 'fields', label: '表单设计', description: '字段、校验与显隐规则' },
-  { id: 'flow', label: '审批流程', description: '审批人、分支与字段权限' },
+  { id: 'flow', label: '流程设计', description: '审批人、分支与字段权限' },
   { id: 'review', label: '测试发布', description: '预览、试运行与发布检查' },
 ]
 const activeAuthoringSection = ref<AuthoringSectionId>('basic')
@@ -3412,57 +3400,51 @@ onUnmounted(() => {
 
 .template-authoring__workspace {
   display: grid;
-  grid-template-columns: 232px minmax(0, 1fr);
+  grid-template-columns: minmax(0, 1fr);
   align-items: start;
-  gap: var(--ms-space-5);
+  gap: var(--ms-space-4);
 }
 
 .template-authoring__steps {
   position: sticky;
-  top: 116px;
-  display: grid;
-  gap: var(--ms-space-2);
-  padding: var(--ms-space-3);
-  border: 1px solid var(--ms-border-light);
-  border-radius: var(--ms-radius-lg);
-  background: var(--ms-bg-card);
-  box-shadow: var(--ms-shadow-card);
-}
-
-.template-authoring__steps-heading {
-  display: grid;
-  gap: var(--ms-space-1);
-  padding: var(--ms-space-2) var(--ms-space-2) var(--ms-space-3);
-  color: var(--ms-text-1);
-}
-
-.template-authoring__steps-heading span {
-  color: var(--ms-text-3);
-  font-size: 12px;
+  top: 72px;
+  z-index: 2;
+  display: flex;
+  justify-content: center;
+  align-items: stretch;
+  gap: 4px;
+  padding: 0 8px;
+  border: 0;
+  border-bottom: 1px solid var(--ms-border-light);
+  border-radius: 0;
+  background: var(--ms-bg-page);
+  box-shadow: none;
 }
 
 .template-authoring__step {
-  width: 100%;
+  width: auto;
   height: auto;
-  min-height: 58px;
+  min-height: 48px;
   margin: 0;
-  padding: var(--ms-space-2);
+  padding: 10px 16px 12px;
   color: var(--ms-text-2);
-  white-space: normal;
+  white-space: nowrap;
+  border-bottom: 2px solid transparent;
+  border-radius: 0;
 }
 
 .template-authoring__step :deep(> span) {
-  display: grid;
-  grid-template-columns: 28px minmax(0, 1fr) auto;
+  display: inline-flex;
   align-items: center;
-  gap: var(--ms-space-2);
-  width: 100%;
+  gap: 8px;
+  width: auto;
   text-align: left;
 }
 
 .template-authoring__step.is-active {
-  background: var(--el-color-primary-light-9);
+  background: transparent;
   color: var(--ms-color-primary);
+  border-bottom-color: var(--ms-color-primary);
 }
 
 .template-authoring__step-index,
@@ -3758,27 +3740,13 @@ pre {
 
 @media (max-width: 1024px) {
   .template-authoring__workspace {
-    grid-template-columns: 1fr;
+    grid-template-columns: minmax(0, 1fr);
   }
 
   .template-authoring__steps {
-    position: sticky;
-    top: 108px;
-    z-index: 2;
-    grid-template-columns: repeat(4, minmax(0, 1fr));
-  }
-
-  .template-authoring__steps-heading {
-    display: none;
-  }
-
-  .template-authoring__step-copy small,
-  .template-authoring__step-count {
-    display: none;
-  }
-
-  .template-authoring__step :deep(> span) {
-    grid-template-columns: 28px minmax(0, 1fr);
+    top: 0;
+    justify-content: flex-start;
+    overflow-x: auto;
   }
 }
 
@@ -3814,7 +3782,7 @@ pre {
 
   .template-authoring__steps {
     top: 0;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+    justify-content: flex-start;
   }
 
   .template-authoring__grid {

--- a/apps/web/src/views/approval/TemplateAuthoringView.vue
+++ b/apps/web/src/views/approval/TemplateAuthoringView.vue
@@ -2182,11 +2182,19 @@ function onAddConditionBranch(nodeKey: string): void {
 function onAddParallelBranch(nodeKey: string): void {
   runTopologyOp((graph) => addParallelBranch(graph, nodeKey), { kind: 'node', nodeKey })
 }
+function selectInsertedNode(beforeKeys: Set<string>): void {
+  const inserted = canvasEffectiveGraph.value.nodes.find((node) => !beforeKeys.has(node.key))?.key
+  if (inserted) selectedCanvasNode.value = inserted
+}
 function onInsertApprovalAfter(nodeKey: string): void {
-  runTopologyOp((graph) => appendApprovalNode(graph, nodeKey), { kind: 'node', nodeKey })
+  const beforeKeys = new Set(canvasEffectiveGraph.value.nodes.map((node) => node.key))
+  runTopologyOp((graph) => appendApprovalNode(graph, nodeKey), { kind: 'none' })
+  selectInsertedNode(beforeKeys)
 }
 function onInsertCcAfter(nodeKey: string): void {
-  runTopologyOp((graph) => appendCcNode(graph, nodeKey), { kind: 'node', nodeKey })
+  const beforeKeys = new Set(canvasEffectiveGraph.value.nodes.map((node) => node.key))
+  runTopologyOp((graph) => appendCcNode(graph, nodeKey), { kind: 'none' })
+  selectInsertedNode(beforeKeys)
 }
 function onInsertConditionAfter(nodeKey: string): void {
   runTopologyOp((graph) => insertConditionGateway(graph, nodeKey), { kind: 'node', nodeKey })
@@ -2452,27 +2460,48 @@ function canInsertParallelOnEdge(edgeKey: string): boolean {
   const source = edgeSourceNode(edgeKey)
   return Boolean(source && canInsertParallelAfter(source))
 }
+function canInsertOnCanvasEdge(edgeKey: string): boolean {
+  const source = edgeSourceNode(edgeKey)
+  if (!source || source.type === 'end') return false
+  return canvasEffectiveGraph.value.edges.filter((edge) => edge.source === source.key).length === 1
+}
+function rejectEdgeInsert(): void {
+  ElMessage.warning('当前连线不能插入这种节点')
+  closeEdgeInsertMenu()
+}
 function onEdgeInsertApproval(edgeKey: string): void {
   const source = edgeSourceNode(edgeKey)
-  if (!source || !canInsertAfter(source)) return
+  if (!source || !canInsertOnCanvasEdge(edgeKey)) {
+    rejectEdgeInsert()
+    return
+  }
   onInsertApprovalAfter(source.key)
   closeEdgeInsertMenu()
 }
 function onEdgeInsertCc(edgeKey: string): void {
   const source = edgeSourceNode(edgeKey)
-  if (!source || !canInsertAfter(source)) return
+  if (!source || !canInsertOnCanvasEdge(edgeKey)) {
+    rejectEdgeInsert()
+    return
+  }
   onInsertCcAfter(source.key)
   closeEdgeInsertMenu()
 }
 function onEdgeInsertCondition(edgeKey: string): void {
   const source = edgeSourceNode(edgeKey)
-  if (!source || !canInsertAfter(source)) return
+  if (!source || !canInsertOnCanvasEdge(edgeKey)) {
+    rejectEdgeInsert()
+    return
+  }
   onInsertConditionAfter(source.key)
   closeEdgeInsertMenu()
 }
 function onEdgeInsertParallel(edgeKey: string): void {
   const source = edgeSourceNode(edgeKey)
-  if (!source || !canInsertParallelAfter(source)) return
+  if (!source || !canInsertParallelAfter(source) || !canInsertOnCanvasEdge(edgeKey)) {
+    rejectEdgeInsert()
+    return
+  }
   onInsertParallelAfter(source.key)
   closeEdgeInsertMenu()
 }

--- a/apps/web/src/views/approval/TemplateAuthoringView.vue
+++ b/apps/web/src/views/approval/TemplateAuthoringView.vue
@@ -1296,7 +1296,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, nextTick, onMounted, onUnmounted, provide, ref, watch } from 'vue'
+import { computed, nextTick, onMounted, onUnmounted, provide, ref, watch, type CSSProperties } from 'vue'
 import PageShell from '../../components/layout/PageShell.vue'
 import PageHeader from '../../components/layout/PageHeader.vue'
 import { onBeforeRouteLeave, useRoute, useRouter } from 'vue-router'
@@ -2310,7 +2310,7 @@ const canvasEffectiveGraph = computed<ApprovalGraph>(() => buildApprovalGraph(dr
 const canvasLayout = computed<GraphLayout>(() => computeLayout(canvasEffectiveGraph.value))
 const canvasValidity = computed<string[]>(() => (draft.value.preservedGraph ? graphValidityIssues(canvasEffectiveGraph.value) : []))
 const canvasZoomLabel = computed(() => `${Math.round(canvasZoom.value * 100)}%`)
-const canvasStageStyle = computed(() => {
+const canvasStageStyle = computed<CSSProperties>(() => {
   const scaledW = Math.round(canvasLayout.value.width * canvasZoom.value)
   const scaledH = Math.round(canvasLayout.value.height * canvasZoom.value)
   const vpW = canvasViewportState.value.width

--- a/apps/web/src/views/approval/TemplateAuthoringView.vue
+++ b/apps/web/src/views/approval/TemplateAuthoringView.vue
@@ -2259,10 +2259,23 @@ const canvasEffectiveGraph = computed<ApprovalGraph>(() => buildApprovalGraph(dr
 const canvasLayout = computed<GraphLayout>(() => computeLayout(canvasEffectiveGraph.value))
 const canvasValidity = computed<string[]>(() => (draft.value.preservedGraph ? graphValidityIssues(canvasEffectiveGraph.value) : []))
 const canvasZoomLabel = computed(() => `${Math.round(canvasZoom.value * 100)}%`)
-const canvasStageStyle = computed(() => ({
-  width: `${Math.round(canvasLayout.value.width * canvasZoom.value)}px`,
-  height: `${Math.round(canvasLayout.value.height * canvasZoom.value)}px`,
-}))
+const canvasStageStyle = computed(() => {
+  const scaledW = Math.round(canvasLayout.value.width * canvasZoom.value)
+  const scaledH = Math.round(canvasLayout.value.height * canvasZoom.value)
+  const vpW = canvasViewportState.value.width
+  const vpH = canvasViewportState.value.height
+  return {
+    minWidth: '100%',
+    minHeight: vpH ? `${vpH}px` : '100%',
+    width: `${Math.max(vpW, scaledW)}px`,
+    height: `${Math.max(vpH, scaledH + 56)}px`,
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'flex-start',
+    boxSizing: 'border-box',
+    padding: '28px 16px 64px',
+  }
+})
 const canvasSurfaceStyle = computed(() => ({
   position: 'relative' as const,
   width: `${canvasLayout.value.width}px`,
@@ -3715,9 +3728,10 @@ pre {
 .template-authoring__canvas-workspace {
   display: flex;
   align-items: stretch;
-  gap: 12px;
+  gap: 0;
   min-width: 0;
   width: 100%;
+  min-height: min(72vh, 760px);
 }
 .template-authoring__field-palette {
   display: flex;

--- a/apps/web/tests/approval-flow-canvas-a11y.test.ts
+++ b/apps/web/tests/approval-flow-canvas-a11y.test.ts
@@ -51,6 +51,7 @@ describe('ApprovalFlowCanvas a11y (structural)', () => {
 
   it('edge-insert menu items use business-language aria-labels (no edge keys)', () => {
     expect(CANVAS_SRC).toMatch(/aria-label="插入审批节点"/)
+    expect(CANVAS_SRC).toMatch(/aria-label="插入抄送节点"/)
     expect(CANVAS_SRC).toMatch(/aria-label="插入条件分支"/)
     expect(CANVAS_SRC).toMatch(/aria-label="插入并行分支"/)
     // Menu item labels must not interpolate edge keys into accessible names
@@ -60,6 +61,15 @@ describe('ApprovalFlowCanvas a11y (structural)', () => {
     expect(CANVAS_SRC).not.toMatch(
       /aria-label="[^"]*\$\{line\.key\}[^"]*"[\s\S]{0,120}edge-insert-(approval|condition|parallel)/,
     )
+  })
+
+  it('flow cards expose type chrome, summary, and a circular edge + (no 办理人)', () => {
+    expect(CANVAS_SRC).toMatch(/template-authoring__canvas-node-kind/)
+    expect(CANVAS_SRC).toMatch(/canvasNodeSummary\(pos\.key\)/)
+    expect(CANVAS_SRC).toMatch(/template-authoring__canvas-edge-insert-btn/)
+    expect(CANVAS_SRC).toMatch(/border-radius: 50%/)
+    expect(CANVAS_SRC).toMatch(/插入抄送节点/)
+    expect(CANVAS_SRC).not.toMatch(/办理人/)
   })
 
   it('fit-to-view toolbar control has business aria-label', () => {

--- a/apps/web/tests/approval-flow-canvas-a11y.test.ts
+++ b/apps/web/tests/approval-flow-canvas-a11y.test.ts
@@ -70,6 +70,12 @@ describe('ApprovalFlowCanvas a11y (structural)', () => {
     expect(CANVAS_SRC).toMatch(/border-radius: 50%/)
     expect(CANVAS_SRC).toMatch(/插入抄送节点/)
     expect(CANVAS_SRC).not.toMatch(/办理人/)
+    // Insert chrome is painted after node cards so the open menu receives the click.
+    const nodeIdx = CANVAS_SRC.indexOf('data-testid="approval-canvas-node"')
+    const insertIdx = CANVAS_SRC.lastIndexOf('data-testid="approval-canvas-edge-insert"')
+    expect(nodeIdx).toBeGreaterThan(0)
+    expect(insertIdx).toBeGreaterThan(nodeIdx)
+    expect(CANVAS_SRC).toMatch(/\.is-open \{\s*z-index: 20;/)
   })
 
   it('fit-to-view toolbar control has business aria-label', () => {

--- a/apps/web/tests/approval-form-palette-focus.test.ts
+++ b/apps/web/tests/approval-form-palette-focus.test.ts
@@ -60,6 +60,17 @@ describe('TemplateAuthoringView form palette focus-return (structural)', () => {
     expect(VIEW_SRC).toMatch(/@focusin="selectFormFieldFocus\(field\.localId\)"/)
   })
 
+  it('form designer uses grouped palette + preview without inventing field kinds', () => {
+    expect(VIEW_SRC).toMatch(/data-testid="approval-form-designer"/)
+    expect(VIEW_SRC).toMatch(/data-testid="approval-form-preview"/)
+    expect(VIEW_SRC).toMatch(/fieldPaletteGroups/)
+    expect(VIEW_SRC).toMatch(/点击或拖拽左侧控件至此处/)
+    expect(VIEW_SRC).not.toMatch(/金额/)
+    expect(VIEW_SRC).not.toMatch(/计算公式/)
+    expect(VIEW_SRC).not.toMatch(/控件组/)
+    expect(VIEW_SRC).not.toMatch(/approval-field-palette-attachment/)
+  })
+
   it('structural field mutations still go through form history (undo/redo safe)', () => {
     expect(VIEW_SRC).toMatch(/function applyFormFieldsStructural\s*\(/)
     expect(VIEW_SRC).toMatch(/pushFormSnapshot\(/)

--- a/apps/web/tests/approval-graph-layout.test.ts
+++ b/apps/web/tests/approval-graph-layout.test.ts
@@ -46,6 +46,7 @@ describe('computeLayout (vertical longest-path layered)', () => {
     expect(byKey.get('end')!.layer).toBe(2)
     expect(byKey.get('a1')!.y).toBeGreaterThan(byKey.get('start')!.y)
     expect(byKey.get('a1')!.x).toBe(byKey.get('start')!.x)
+    expect(byKey.get('a1')!.y - byKey.get('start')!.y).toBe(176)
     expect(layout.nodes).toHaveLength(3)
   })
   it('puts a rejoin node AFTER both of its branches (longest-path, not shortest)', () => {

--- a/apps/web/tests/approval-graph-topology-edit.test.ts
+++ b/apps/web/tests/approval-graph-topology-edit.test.ts
@@ -6,6 +6,7 @@ import { placeholderRoleNodeKeys } from '../src/approvals/approvalNodeEdit'
 import { graphValidityIssues } from '../src/approvals/graphLayout'
 import {
   appendApprovalNode,
+  appendCcNode,
   collectParallelRegionNodeKeys,
   insertConditionGateway,
   insertParallelGateway,
@@ -146,6 +147,24 @@ describe('appendApprovalNode', () => {
   })
   it('refuses to insert after a node with ≠1 outgoing edge', () => {
     expect(() => appendApprovalNode(PARALLEL, 'parallel_1')).toThrow(/exactly one outgoing/)
+  })
+})
+
+describe('appendCcNode', () => {
+  it('inserts a shipped cc node on a linear segment without mutating input', () => {
+    const before = snap(LINEAR)
+    const out = appendCcNode(LINEAR, 'approval_1', '抄送财务')
+    expect(LINEAR).toEqual(before)
+    const newNode = out.nodes.find((n) => n.type === 'cc')!
+    expect(newNode.name).toBe('抄送财务')
+    expect(newNode.config).toEqual({ targetType: 'user', targetIds: [] })
+    expect(edgeBetween(out, 'approval_1', newNode.key)).toBeTruthy()
+    expect(edgeBetween(out, newNode.key, 'end')).toBeTruthy()
+    expect(edgeBetween(out, 'approval_1', 'end')).toBeFalsy()
+    expect(node(out, 'start')).toEqual(node(LINEAR, 'start'))
+  })
+  it('refuses to insert after a node with ≠1 outgoing edge', () => {
+    expect(() => appendCcNode(PARALLEL, 'parallel_1')).toThrow(/exactly one outgoing/)
   })
 })
 

--- a/apps/web/tests/approval-ui-workspace.spec.ts
+++ b/apps/web/tests/approval-ui-workspace.spec.ts
@@ -36,6 +36,10 @@ describe('approval workspace visual structure', () => {
 
     expect(source).toContain("type AuthoringSectionId = 'basic' | 'fields' | 'flow' | 'review'")
     expect(source).toContain('class="template-authoring__workspace"')
+    expect(source).toContain("label: '基础信息'")
+    expect(source).toContain("label: '表单设计'")
+    expect(source).toContain("label: '流程设计'")
+    expect(source).toContain("label: '测试发布'")
     expect(source).toContain('data-testid="approval-template-section-next"')
     expect(source).toContain("v-show=\"activeAuthoringSection === 'fields'\"")
     expect(source).toContain("v-show=\"activeAuthoringSection === 'flow'\"")


### PR DESCRIPTION
## Why

Owner asked the flow designer to operate like a vertical card canvas (edge `+`, insert strip, right inspector) without cloning another product or adding 办理人.

## What changed

- Canvas nodes: type header + summary + chevron
- Larger circular edge `+`; insert strip: 审批人 / 抄送人 / 条件分支 / 并行分支
- `appendCcNode` for the existing `cc` type only
- Inspector: type-first header + 节点设置 section
- Structural tests for a11y labels, no 办理人, linear cc splice

## What did not change

- No handler/办理人 node
- No new assignee sources
- Repo flag defaults stay OFF
- Not product FINAL / not tenant UAT

## How to verify

```bash
pnpm --filter @metasheet/web exec vitest run --watch=false \
  tests/approval-flow-canvas-a11y.test.ts \
  tests/approval-canvas-inspector-a11y.test.ts \
  tests/approval-graph-topology-edit.test.ts \
  tests/approval-g5c-authoring-scenarios.test.ts
```

Local: `/approval-templates/new` → 审批流程 → edge `+`.