### PR TITLE
fix(attendance): #4556 Gate A residual R4 — fold both allowlists, thread the resolved posture, open the pinned-closed door

### DIFF
--- a/packages/core-backend/src/attendance/__tests__/w4c0-identity.test.ts
+++ b/packages/core-backend/src/attendance/__tests__/w4c0-identity.test.ts
@@ -334,6 +334,14 @@ describe('resolveSegmentCalculationPosture return-shape matrix', () => {
       expect(isAttendanceCalculationOrgAllowlistedV1(FOLD_ORG)).toBe(false)
     })
 
+    /**
+     * Every entry in this loop is STRUCTURALLY INERT: none of them can equal ANY org key, so
+     * the leg's scope is "folding does not invent prefix/substring/wildcard matching".
+     *
+     * `'DEFAULT'` was in this loop and has been removed — see the leg below. It is true that it
+     * does not admit a UUID subject, but it is not inert in kind (it folds onto a legal org
+     * key), and leaving it here invited the over-general read "DEFAULT still admits nothing".
+     */
     it('NEGATIVE CONTROL: folding never lets a prefix, suffix, or wildcard entry match', async () => {
       for (const entry of [
         FOLD_ORG.slice(0, 20).toUpperCase(), // strict prefix
@@ -342,7 +350,6 @@ describe('resolveSegmentCalculationPosture return-shape matrix', () => {
         ' * ',
         '.*',
         '%',
-        'DEFAULT',
         '',
       ]) {
         process.env[ALLOWLIST_ENV] = entry
@@ -352,9 +359,42 @@ describe('resolveSegmentCalculationPosture return-shape matrix', () => {
         ).toBe('legacy')
       }
       // POSITIVE CONTROL for this loop: the same machinery DOES admit the exact key,
-      // so the eight denials above are real rejections and not a broken harness.
+      // so the seven denials above are real rejections and not a broken harness.
       process.env[ALLOWLIST_ENV] = FOLD_ORG.toUpperCase()
       expect((await postureFor(FOLD_ORG, { state: 'authoritative' })).effectiveState).toBe('authoritative')
+    })
+
+    /**
+     * `'DEFAULT'` is the ONE case-variant entry that is not structurally inert, named here
+     * rather than buried in the loop above (#4919 gate P3).
+     *
+     * `parseOrgKeyLexical` accepts the exact ASCII sentinel `'default'` as a legal org key, so
+     * after the fold an env entry spelled `DEFAULT` / `Default` matches the `default` ORG —
+     * where before only the lower-case spelling did. This is the intended case semantics
+     * applied to a PRE-EXISTING match (lower-case `default` already admitted it), not a new
+     * class; the new marginal risk is that `DEFAULT` is a common ops-template placeholder that
+     * used to be inert. This leg asserts what actually happens, in both directions, so nobody
+     * can read the loop above as "DEFAULT admits nothing".
+     */
+    it('`DEFAULT` is NOT inert — it folds onto the legal `default` sentinel org key', () => {
+      for (const entry of ['DEFAULT', 'Default', 'default', ' DEFAULT ']) {
+        process.env[ALLOWLIST_ENV] = entry
+        expect(
+          isAttendanceCalculationOrgAllowlistedV1('default'),
+          `entry ${JSON.stringify(entry)} must match the default org`,
+        ).toBe(true)
+      }
+      // ...and it remains inert against a UUID subject, which is what the loop above covers.
+      process.env[ALLOWLIST_ENV] = 'DEFAULT'
+      expect(isAttendanceCalculationOrgAllowlistedV1(FOLD_ORG)).toBe(false)
+      // NEGATIVE CONTROL: the sentinel is exact — no other spelling reaches it.
+      for (const entry of ['DEFAULTS', 'DEFAUL', 'defau1t', '*']) {
+        process.env[ALLOWLIST_ENV] = entry
+        expect(
+          isAttendanceCalculationOrgAllowlistedV1('default'),
+          `entry ${JSON.stringify(entry)} must not match the default org`,
+        ).toBe(false)
+      }
     })
 
     it('the named export and the private predicate stay ONE predicate under folding', () => {

--- a/packages/core-backend/src/attendance/__tests__/w4c0-identity.test.ts
+++ b/packages/core-backend/src/attendance/__tests__/w4c0-identity.test.ts
@@ -33,6 +33,7 @@ import {
   createVerifiedAttendanceCalculationTargetIdentityV1,
   createVerifiedAttendanceOperationIdentityV1,
   createVerifiedAttendanceOrgIdentityV1,
+  isAttendanceCalculationOrgAllowlistedV1,
   parseCanonicalAttendanceOrgKeyV1,
   parseCanonicalAttendanceLegacyIdempotencyKeyV1,
   parseCanonicalAttendanceRolloutOrgKeyV1,
@@ -287,6 +288,81 @@ describe('resolveSegmentCalculationPosture return-shape matrix', () => {
     expect((await postureFor(ORG, { state: 'authoritative' })).effectiveState).toBe('legacy')
     process.env[ALLOWLIST_ENV] = `*,${ORG}`
     expect((await postureFor(ORG, { state: 'shadow' })).effectiveState).toBe('shadow')
+  })
+
+  /**
+   * #4899 residual R4 / P3-2 — the allowlist compare is ASCII CASE-FOLDED.
+   *
+   * `orgKey` arrives lower-cased from `parseUuidSyntax`, so before this change an
+   * upper-case env entry was a silent no-op. Folding is an owner-approved ADMISSION
+   * WIDENING, so the legs below prove both halves: the widening actually happened, and
+   * it widened by EXACTLY case — not into prefix/substring/wildcard matching.
+   */
+  describe('R4: allowlist entries are ASCII case-folded (admission widening)', () => {
+    // The file's shared `ORG` fixture is all-DIGIT hex (`5555…`), so `toUpperCase()` on it is a
+    // NO-OP and every leg below would be vacuously green against it. These fixtures are
+    // deliberately letter-bearing canonical v4 keys, and the invariant is asserted, not assumed.
+    const FOLD_ORG = 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee'
+    const FOLD_OTHER = 'bbbbbbbb-cccc-4ddd-8eee-ffffffffffff'
+
+    it('HARNESS CONTROL: the fixtures really change under toUpperCase (else every leg is vacuous)', () => {
+      expect(FOLD_ORG.toUpperCase()).not.toBe(FOLD_ORG)
+      expect(FOLD_OTHER.toUpperCase()).not.toBe(FOLD_OTHER)
+      expect(FOLD_ORG).not.toBe(FOLD_OTHER)
+      // ...and the file's shared fixture is exactly the trap this control exists to catch.
+      expect(ORG.toUpperCase()).toBe(ORG)
+    })
+
+    it('an UPPER-CASE env entry now admits the lower-case org key (the widening)', async () => {
+      process.env[ALLOWLIST_ENV] = FOLD_ORG.toUpperCase()
+      expect((await postureFor(FOLD_ORG, { state: 'shadow' })).effectiveState).toBe('shadow')
+      expect(isAttendanceCalculationOrgAllowlistedV1(FOLD_ORG)).toBe(true)
+    })
+
+    it('mixed case and surrounding whitespace fold together', async () => {
+      const mixed = `${FOLD_ORG.slice(0, 18).toUpperCase()}${FOLD_ORG.slice(18)}`
+      expect(mixed).not.toBe(FOLD_ORG)
+      expect(mixed).not.toBe(FOLD_ORG.toUpperCase())
+      process.env[ALLOWLIST_ENV] = `  ${mixed} \t`
+      expect((await postureFor(FOLD_ORG, { state: 'shadow' })).effectiveState).toBe('shadow')
+    })
+
+    it('NEGATIVE CONTROL: an UPPER-CASE entry for a DIFFERENT org still denies', async () => {
+      process.env[ALLOWLIST_ENV] = FOLD_OTHER.toUpperCase()
+      // If the fold had degenerated into a prefix/substring/normalizing match, this would admit.
+      expect((await postureFor(FOLD_ORG, { state: 'shadow' })).effectiveState).toBe('legacy')
+      expect(isAttendanceCalculationOrgAllowlistedV1(FOLD_ORG)).toBe(false)
+    })
+
+    it('NEGATIVE CONTROL: folding never lets a prefix, suffix, or wildcard entry match', async () => {
+      for (const entry of [
+        FOLD_ORG.slice(0, 20).toUpperCase(), // strict prefix
+        `${FOLD_ORG.toUpperCase()}-EXTRA`, // strict suffix extension
+        '*',
+        ' * ',
+        '.*',
+        '%',
+        'DEFAULT',
+        '',
+      ]) {
+        process.env[ALLOWLIST_ENV] = entry
+        expect(
+          (await postureFor(FOLD_ORG, { state: 'authoritative' })).effectiveState,
+          `entry ${JSON.stringify(entry)} must not admit`,
+        ).toBe('legacy')
+      }
+      // POSITIVE CONTROL for this loop: the same machinery DOES admit the exact key,
+      // so the eight denials above are real rejections and not a broken harness.
+      process.env[ALLOWLIST_ENV] = FOLD_ORG.toUpperCase()
+      expect((await postureFor(FOLD_ORG, { state: 'authoritative' })).effectiveState).toBe('authoritative')
+    })
+
+    it('the named export and the private predicate stay ONE predicate under folding', () => {
+      process.env[ALLOWLIST_ENV] = FOLD_ORG.toUpperCase()
+      expect(isAttendanceCalculationOrgAllowlistedV1(FOLD_ORG)).toBe(true)
+      process.env[ALLOWLIST_ENV] = '*'
+      expect(isAttendanceCalculationOrgAllowlistedV1(FOLD_ORG)).toBe(false)
+    })
   })
 
   it('rejects an unknown persisted state and a non-synthetic scope', async () => {

--- a/packages/core-backend/src/attendance/w4c0-identity.ts
+++ b/packages/core-backend/src/attendance/w4c0-identity.ts
@@ -362,12 +362,31 @@ const SEGMENT_CALCULATION_IMPLEMENTATION_CAPABILITY = true
 
 const SEGMENT_CALCULATION_ALLOWLIST_ENV = 'ATTENDANCE_SHIFT_SEGMENT_CALCULATION_ENABLED'
 
-/** Exact org-only outer allowlist; `*` (wildcard) NEVER counts for W4 (section 9). */
+/**
+ * Exact org-only outer allowlist; `*` (wildcard) NEVER counts for W4 (section 9).
+ *
+ * ASCII CASE-FOLDED (#4899 residual R4, P3-2 — owner-approved). Entries are trimmed AND
+ * lower-cased before the exact compare, because `orgKey` arrives already lower-cased from
+ * `parseUuidSyntax` (`:132`). Before this change an operator who wrote the org UUID in upper
+ * case got a silent `off` with no diagnostic anywhere.
+ *
+ * THIS IS AN ADMISSION WIDENING, not a tidy-up. The admitted set grows from
+ * `{lower-case spellings of allowlisted org keys}` to `{all ASCII-case spellings}`. It is a
+ * strict superset: every entry admitted before is still admitted, plus the case variants.
+ * The widening is bounded by construction — `String.prototype.toLowerCase` is a per-character
+ * map, so it can only ever make two strings that differ in ASCII case compare equal; it can
+ * never turn a non-matching entry into a prefix/substring/wildcard match, and it never changes
+ * the length of an entry. `'*'`, `' * '`, `'.*'`, `'%'`, prefixes, and suffixes therefore still
+ * allowlist nothing (an org key can never equal any of them — the canonical parser rejects them
+ * outright). The W7 context-source predicate
+ * (`w7-resolver/w7-context-source-posture-resolver.ts`) is folded IDENTICALLY in the same
+ * change, so the two allowlists cannot drift in matching semantics.
+ */
 function isOrgExactlyAllowlisted(orgKey: string): boolean {
   const raw = typeof process.env[SEGMENT_CALCULATION_ALLOWLIST_ENV] === 'string'
     ? (process.env[SEGMENT_CALCULATION_ALLOWLIST_ENV] as string)
     : ''
-  const entries = raw.split(',').map((entry) => entry.trim()).filter(Boolean)
+  const entries = raw.split(',').map((entry) => entry.trim().toLowerCase()).filter(Boolean)
   return entries.includes(orgKey)
 }
 

--- a/packages/core-backend/src/attendance/w4c0-identity.ts
+++ b/packages/core-backend/src/attendance/w4c0-identity.ts
@@ -348,15 +348,36 @@ export type ResolvedSegmentCalculationPostureV1 = Opaque<
 >
 
 /**
- * Implementation capability (section 9 effective-state requirement 1) for THIS slice:
+ * Implementation capability (section 9 effective-state requirement 1):
  * W4C-0 ships durable storage + the identity/lock layer, so the resolver seam itself is
- * implemented. The authoritative segment CALCULATOR is W4C-1: an `authoritative` answer
- * additionally requires a persisted `authoritative` rollout row, which cannot exist yet —
- * the Stage A rollout guard admits only `legacy`/`shadow` initial states and no transition
- * writer ships in W4C-0. Advertising `shadow` additionally requires BOTH an exact-org env
- * allowlist entry AND a persisted state row; neither exists by default, so default runtime
- * behavior remains byte-identical (`legacy_projection_only` for every org). The separate W3
- * reference-writer constant in attendance-shift-service.cjs stays `false` and is untouched.
+ * implemented. The authoritative segment CALCULATOR is W4C-1 and has NOT shipped.
+ *
+ * ERRATUM (#4899 residual R4, 2026-08-15): this comment used to add "…an `authoritative`
+ * answer additionally requires a persisted `authoritative` rollout row, which cannot exist
+ * yet — the Stage A rollout guard admits only `legacy`/`shadow` initial states and no
+ * transition writer ships in W4C-0." That sentence has become FALSE and is removed rather
+ * than left standing, because it generalised an INITIAL-STATE restriction into a
+ * REACHABILITY claim and was then relied on downstream:
+ *   - `legacy -> shadow` is only the BOOTSTRAP restriction on creating a MISSING row
+ *     (`w4c3a-rollout-control.ts`, `canBootstrap`), and that bootstrap inserts state
+ *     `'legacy'`. It is not the legality table.
+ *   - a transition writer HAS since shipped, and its `LEGAL_TRANSITIONS`
+ *     (`w4c3a-rollout-control.ts`) contains `shadow -> eligible` and
+ *     `eligible -> authoritative`.
+ *   - the one gate that did block promotion into `authoritative` — the
+ *     `W4C3A_ROLLOUT_CONTROL_AUTHORITATIVE_ENTRYPOINT_NOT_DELIVERED` refusal — no longer
+ *     fires since #4844 declared both entrypoints delivered
+ *     (`w4c2-authoritative-delivery.ts`, `DECLARED_DELIVERED`), so the undelivered count is 0.
+ * `attendance-w4c3a-rollout-control.db.test.ts` drives `eligible -> authoritative` to
+ * completion and reads back `authoritative`, so this is behavioural, not a reading.
+ *
+ * What IS still true, and is the actual byte-neutrality argument: advertising anything above
+ * `legacy` requires BOTH an exact-org env allowlist entry AND a persisted state row, and
+ * neither exists by default — so default runtime behavior remains byte-identical
+ * (`legacy_projection_only` for every org). Reaching `authoritative` takes a deliberate
+ * three-step operator walk through the transition boundary; it is not the default and it is
+ * not impossible. The separate W3 reference-writer constant in attendance-shift-service.cjs
+ * stays `false` and is untouched.
  */
 const SEGMENT_CALCULATION_IMPLEMENTATION_CAPABILITY = true
 
@@ -375,12 +396,26 @@ const SEGMENT_CALCULATION_ALLOWLIST_ENV = 'ATTENDANCE_SHIFT_SEGMENT_CALCULATION_
  * strict superset: every entry admitted before is still admitted, plus the case variants.
  * The widening is bounded by construction — `String.prototype.toLowerCase` is a per-character
  * map, so it can only ever make two strings that differ in ASCII case compare equal; it can
- * never turn a non-matching entry into a prefix/substring/wildcard match, and it never changes
- * the length of an entry. `'*'`, `' * '`, `'.*'`, `'%'`, prefixes, and suffixes therefore still
- * allowlist nothing (an org key can never equal any of them — the canonical parser rejects them
- * outright). The W7 context-source predicate
- * (`w7-resolver/w7-context-source-posture-resolver.ts`) is folded IDENTICALLY in the same
- * change, so the two allowlists cannot drift in matching semantics.
+ * never turn a non-matching entry into a prefix/substring/wildcard match, and it never
+ * SHORTENS an entry. (Deliberately not "never changes the length": mechanically enumerated over
+ * U+0080..U+2FFFF, exactly one codepoint lengthens — `U+0130` (İ) folds to `"i̇"`, 2 units.
+ * That exception is inert here: the same sweep found ZERO non-ASCII codepoints that fold into
+ * the org-key alphabet `[0-9a-f-]`, so no non-ASCII entry can become a UUID key.) `'*'`,
+ * `' * '`, `'.*'`, `'%'`, prefixes, and suffixes therefore still allowlist nothing — a UUID org
+ * key can never equal any of them.
+ *
+ * ONE ENTRY IS NOT INERT, and is called out rather than left to the reader: the `'default'`
+ * sentinel IS a legal org key (`parseOrgKeyLexical`), so a folded env entry spelled `DEFAULT`
+ * or `Default` now matches the `default` org where before only lower-case `default` did. That
+ * is the intended case semantics applied to a pre-existing match, not a new class — but
+ * `DEFAULT` is a common ops-template placeholder that was previously inert, so treat it as a
+ * live entry. `mintOrgWitness` fail-closes the W4C-3b boundary path for `default` under any
+ * non-legacy posture (`W4C0_DEFAULT_ORG_POSTURE_REJECTED`); the plugin's direct
+ * `resolveReferenceSegmentsPostureForWrite` sites mint no witness, so that bound is partial.
+ *
+ * The W7 context-source predicate (`w7-resolver/w7-context-source-posture-resolver.ts`) is
+ * folded IDENTICALLY in the same change, so the two allowlists cannot drift in matching
+ * semantics.
  */
 function isOrgExactlyAllowlisted(orgKey: string): boolean {
   const raw = typeof process.env[SEGMENT_CALCULATION_ALLOWLIST_ENV] === 'string'

--- a/packages/core-backend/src/attendance/w4c0-operation-registry.ts
+++ b/packages/core-backend/src/attendance/w4c0-operation-registry.ts
@@ -561,12 +561,25 @@ export type AttendanceResultOperationPreflightResultV1 =
       readonly batchIdentity: VerifiedAttendanceOperationIdentityV1 | null
       readonly itemIdentities: readonly VerifiedAttendanceOperationIdentityV1[]
       readonly legacyNullIdCount: number
+      /** See `referenceSegments` below. */
+      readonly referenceSegments: boolean
     }
   | {
       /** legacy_projection_only with ONLY null-ID commands: no operation row at all. */
       readonly kind: 'legacy_no_operation'
       readonly org: VerifiedAttendanceOrgIdentityV1
       readonly legacyNullIdCount: number
+      /**
+       * #4899 residual R4: the resolved `referenceSegments` bit from the SAME posture
+       * resolution this preflight already performed under the class-`00` rollout SHARED
+       * lock (step 2 below). Surfaced on the result — NOT folded into
+       * `VerifiedAttendanceOrgIdentityV1`, whose witness shape is `orgId` +
+       * `acceptedWritePosture` only and is re-minted by the rehydration constructors.
+       * Callers that execute an adapter after preflight pass this down instead of
+       * resolving the posture a second time (which would re-take the rollout lock below
+       * their row locks — the ordering the owner-P1 counterexample forbids).
+       */
+      readonly referenceSegments: boolean
     }
 
 export async function attendanceResultOperationPreflightV1(
@@ -605,7 +618,12 @@ export async function attendanceResultOperationPreflightV1(
   const isLegacy = org.acceptedWritePosture === 'legacy_projection_only'
   if (isLegacy && plan.sourced.length === 0 && plan.batch === null) {
     // Null-ID legacy commands create no operation row (lock 4.1/8.2).
-    return { kind: 'legacy_no_operation', org, legacyNullIdCount: plan.legacyNullIdCount }
+    return {
+      kind: 'legacy_no_operation',
+      org,
+      legacyNullIdCount: plan.legacyNullIdCount,
+      referenceSegments: posture.referenceSegments,
+    }
   }
   if (!isLegacy && plan.legacyNullIdCount > 0) {
     // W4-enabled clients that cannot supply a stable identity fail before source DML.
@@ -690,6 +708,7 @@ export async function attendanceResultOperationPreflightV1(
     batchIdentity,
     itemIdentities,
     legacyNullIdCount: plan.legacyNullIdCount,
+    referenceSegments: posture.referenceSegments,
   }
 }
 

--- a/packages/core-backend/src/attendance/w4c3b-request-operation-boundary.ts
+++ b/packages/core-backend/src/attendance/w4c3b-request-operation-boundary.ts
@@ -176,6 +176,25 @@ export interface AttendanceRequestOperationContextV1 {
   readonly operationId: string | null
   readonly correlationId: string
   readonly acceptedWritePosture: 'legacy_projection_only' | 'shadow' | 'authoritative' | null
+  /**
+   * #4899 residual R4: the org's resolved `referenceSegments` posture bit, carried down
+   * to `execute` so approval finalization does NOT re-resolve it.
+   *
+   * The boundary already resolves the posture under the class-`00` rollout SHARED advisory
+   * lock BEFORE `execute` runs (`resolveSegmentCalculationPosture`, either in the null-ID
+   * branch below or inside `attendanceResultOperationPreflightV1`). Re-resolving inside
+   * finalization repeats a lock-take plus a SELECT for a value that cannot have changed —
+   * the shared lock is transaction-scoped and still held — and it re-takes that lock AFTER
+   * the request row lock, which is the exact ordering the #4899 owner-P1 counterexample
+   * exists to forbid. One resolve per transaction, above every row lock, consumed by both
+   * the finalization reference guards and the calculation read path.
+   *
+   * `false` in every phase where no posture has been resolved yet (the prepare-phase
+   * context) and for every org outside the canonical W4 domain — fail-closed, matching the
+   * port's own non-canonical answer (`src/index.ts`, `W4C0_ROLLOUT_ORG_KEY_INVALID` =>
+   * `{ effectiveState: 'legacy', referenceSegments: false }`).
+   */
+  readonly referenceSegments: boolean
   /** Host-validated route family; null is the generic non-create surface. */
   readonly routeVariant: AttendanceRequestOperationRouteVariantV1 | null
 }
@@ -395,6 +414,9 @@ export function createAttendanceRequestOperationBoundaryV1(
             operationId: input.operationId,
             correlationId: input.correlationId,
             acceptedWritePosture: null,
+            // Prepare phase: no posture resolved yet, and prepare performs no reference
+            // writes. Fail-closed until a resolve under the rollout lock supplies it.
+            referenceSegments: false,
             routeVariant: input.routeVariant,
           })
           const identityPrepared = input.operationId === null
@@ -412,6 +434,9 @@ export function createAttendanceRequestOperationBoundaryV1(
             const result = await adapter.execute(shapedTrx, identityPrepared, Object.freeze({
               ...operation,
               acceptedWritePosture: 'legacy_projection_only' as const,
+              // Outside the canonical W4 domain the port itself answers
+              // `{ effectiveState: 'legacy', referenceSegments: false }`; mirror it exactly.
+              referenceSegments: false,
             }))
             return { kind: 'legacy' as const, response: result.response }
           }
@@ -432,6 +457,10 @@ export function createAttendanceRequestOperationBoundaryV1(
               const result = await adapter.execute(shapedTrx, identityPrepared, Object.freeze({
                 ...operation,
                 acceptedWritePosture: 'legacy_projection_only' as const,
+                // Read the RESOLVED bit rather than hardcoding `false`. It is false for
+                // every legacy row today, but deriving it from `writePosture` here would
+                // create a second place that decides what `legacy` admits.
+                referenceSegments: posture.referenceSegments,
               }))
               return { kind: 'legacy' as const, response: result.response }
             }
@@ -470,6 +499,9 @@ export function createAttendanceRequestOperationBoundaryV1(
           const result = await adapter.execute(shapedTrx, prepared, Object.freeze({
             ...operation,
             acceptedWritePosture: preflight.org.acceptedWritePosture,
+            // From the preflight's own resolve, taken under the rollout SHARED lock at
+            // step 2 — the one resolution this transaction performs.
+            referenceSegments: preflight.referenceSegments,
           }))
           if (preflight.kind === 'legacy_no_operation') {
             return { kind: 'legacy' as const, response: result.response }

--- a/packages/core-backend/src/attendance/w7-resolver/w7-context-source-posture-resolver.ts
+++ b/packages/core-backend/src/attendance/w7-resolver/w7-context-source-posture-resolver.ts
@@ -90,7 +90,7 @@ export const ATTENDANCE_W7_CONTEXT_SOURCE_ALLOWLIST_ENV = 'ATTENDANCE_W7_CONTEXT
 
 /**
  * Exact org-only outer allowlist; the wildcard `*` NEVER counts. Entries are
- * comma-separated and trimmed; empty entries are dropped.
+ * comma-separated, trimmed and ASCII case-folded; empty entries are dropped.
  *
  * This is the ONE definition. The future W7 transition writer must gate on
  * `isAttendanceW7ContextSourceOrgAllowlistedV1` below — a thin named export of
@@ -100,21 +100,27 @@ export const ATTENDANCE_W7_CONTEXT_SOURCE_ALLOWLIST_ENV = 'ATTENDANCE_W7_CONTEXT
  * write side would then disagree about which orgs are in scope.
  */
 /*
- * OPS FOOTGUN, documented deliberately rather than fixed here: entries are
- * trimmed but NOT case-folded, while `orgKey` arrives already lower-cased by
- * `parseUuidSyntax` (`../w4c0-identity.ts:132`). So an operator who writes the
- * org UUID in upper case —
- * `ATTENDANCE_W7_CONTEXT_SOURCE_ENABLED=3F9A1C2E-…` — gets a silent `off`
- * with no signal anywhere.
+ * OPS FOOTGUN — RESOLVED (#4899 residual R4, owner-approved), superseding this
+ * file's original "deferred jointly with the W4 predicate" note.
  *
- * It fails CLOSED, which is why this is a note and not a defect: the failure
- * mode is "the org stays legacy", never "an unintended org is advertised".
- * Not fixed in this slice because case-folding is the SAME open question Gate
- * A deferred for the W4 allowlist (`isOrgExactlyAllowlisted`,
- * `../w4c0-identity.ts:366`), and W7 quietly diverging from the W4 predicate's
- * matching semantics would create two allowlists that disagree — the precise
- * outcome the single-predicate discipline below exists to prevent. Whoever
- * resolves it should resolve it for both, in one change.
+ * Entries are now trimmed AND lower-cased, matching `orgKey`, which arrives
+ * already lower-cased from `parseUuidSyntax` (`../w4c0-identity.ts:132`). An
+ * operator who writes the org UUID in upper case —
+ * `ATTENDANCE_W7_CONTEXT_SOURCE_ENABLED=3F9A1C2E-…` — is now admitted rather
+ * than getting a silent `off`.
+ *
+ * This is an ADMISSION WIDENING, not a tidy-up: the admitted set grows from
+ * the lower-case spellings to all ASCII-case spellings of the same org keys.
+ * It is bounded by construction — `toLowerCase` is a per-character map, so it
+ * can only make two strings that differ in ASCII case compare equal; it never
+ * shortens an entry and never turns a non-match into a prefix/substring/
+ * wildcard match. `'*'`, `' * '`, `'.*'`, `'%'`, prefixes and suffixes still
+ * allowlist nothing.
+ *
+ * The old note deferred this precisely so W7 would not diverge from the W4
+ * predicate's matching semantics. That constraint is honoured: the W4 fold
+ * (`../w4c0-identity.ts`, `isOrgExactlyAllowlisted`) lands in the SAME change,
+ * with the same one-line transformation, so the two allowlists still agree.
  */
 function isOrgExactlyAllowlisted(orgKey: string): boolean {
   const raw =
@@ -123,7 +129,7 @@ function isOrgExactlyAllowlisted(orgKey: string): boolean {
       : ''
   const entries = raw
     .split(',')
-    .map((entry) => entry.trim())
+    .map((entry) => entry.trim().toLowerCase())
     .filter(Boolean)
   // Exact membership only. `'*'` is just another entry string here, and an org
   // key can never equal `'*'` (the canonical parser rejects it), so a wildcard

--- a/packages/core-backend/tests/integration/attendance-shift-segments-writer-matrix.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-shift-segments-writer-matrix.db.test.ts
@@ -1593,24 +1593,26 @@ describeDb('W3 shift-segments writer matrix (real DB, route-level)', () => {
    * (`index.cjs`, the `referenceSegments:` argument of its `assertShiftReferenceAllowed`
    * call) load-bearing ON ITS OWN.
    *
-   * Why the leg above cannot do it: forcing THAT ONE site fail-open (`referenceSegments: true`)
-   * leaves it green, because a SECOND fail-closed door downstream —
-   * `assertWorkContextSegmentCalculationAllowed` (hardcoded `referenceSegments: false`, one of
-   * this cutover's disclosed residual-R4 pinned-closed read paths) — refuses the same request
-   * and produces an identical `422` + identical error code. Classic 多道 fail-closed 门互相掩护:
-   * status and code are dominated, so neither can discriminate.
+   * Why the matrix leg above cannot do it: forcing THAT ONE site fail-open
+   * (`referenceSegments: true`) leaves it green, because a SECOND fail-closed door downstream —
+   * `assertWorkContextSegmentCalculationAllowed` — refuses the same request and produces an
+   * identical `422` + identical error code. Classic 多道 fail-closed 门互相掩护: status and code
+   * are dominated for a NON-enabled org, so neither can discriminate. (R4 re-sourced that door
+   * from the port; for a non-enabled org it still resolves `false`, so the covering behaviour
+   * above is unchanged and this leg keeps its discriminating power.)
    *
-   * What still discriminates, without opening the R4 door: WHICH producer refused. The typed
-   * 422's message names the refusing guard's `producer`. Correct behaviour ⇒ the dispatch
-   * final-approval guard refuses FIRST and the message names `schedule_dispatch_final_approval`.
-   * With that one site forced fail-open, the request survives it and is refused later by the
-   * calculation read path instead, whose message names `attendance calculation` — so this leg
-   * REDS while status/code stay 422/GUARD_CODE. Verified by executing exactly that mutation.
+   * What discriminates here: WHICH producer refused. The typed 422's message names the refusing
+   * guard's `producer`. Correct behaviour ⇒ the dispatch final-approval guard refuses FIRST and
+   * the message names `schedule_dispatch_final_approval`. With that one site forced fail-open,
+   * the request survives it and is refused later by the calculation read path instead, whose
+   * message names `attendance calculation` — so this leg REDS while status/code stay
+   * 422/GUARD_CODE. Verified by executing exactly that mutation.
    *
-   * Residual (disclosed in the PR body): this is an attribution-level proof, not a status-flip
-   * proof. A 200-vs-422 behavioural flip at this site remains impossible while the R4 door is
-   * pinned closed; closing P2-1 fully is therefore a BLOCKING precondition on the R4 slice,
-   * which is exactly what makes this site live.
+   * SCOPE, post-R4: this leg is the FAIL-OPEN half of P2-1. The FAIL-CLOSED half — a 200-vs-422
+   * status flip at the same site — is the enabled-org leg at the bottom of this file
+   * ("R4/P2-1: dispatch final approval is status-coverable ..."), which became constructible
+   * once R4 lifted the covering door for an enabled org. Neither leg subsumes the other:
+   * fail-open is invisible to status, fail-closed is invisible to attribution.
    */
   it('P2-1: schedule-dispatch final approval 422 is attributed to ITS OWN guard, not to the covering R4 door', async () => {
     const orgId = org('p21-dispatch-final-attribution')
@@ -1653,8 +1655,7 @@ describeDb('W3 shift-segments writer matrix (real DB, route-level)', () => {
    * only then `SELECT ... FROM attendance_requests ... FOR UPDATE` (w4c3a-rollout-control.ts —
    * exclusive at the top of the control transaction, request scan at `:948`). If the APPROVAL
    * transaction were to take the request row lock FIRST and reach for the rollout SHARED lock
-   * only later (e.g. inside finalization, which is where this cutover wired a posture call),
-   * the two form a textbook wait cycle:
+   * only later, the two form a textbook wait cycle:
    *     approval  holds request row   + waits rollout-shared
    *     transition holds rollout-excl + waits request row
    * PostgreSQL's detector fires and one side dies with SQLSTATE 40P01.
@@ -1668,9 +1669,20 @@ describeDb('W3 shift-segments writer matrix (real DB, route-level)', () => {
    *      holds no row lock — it is the discriminating observation.
    *   4. conn B commits (releasing exclusive); A then proceeds and completes.
    *
-   * Load-bearing: hoisting the approval's posture resolution back BELOW the request row lock
-   * makes step 3 block on A while A waits on B ⇒ genuine deadlock, and the run dies with
-   * `40P01`. Verified by executing exactly that mutation.
+   * Load-bearing — the mutation NAMED HERE IS THE ONE THAT WAS EXECUTED, at this head.
+   * (#4899 residual R4 rewrote this paragraph: the slice removed the in-finalization posture
+   * resolve, so the old wording — "hoist the posture resolution back below the request row
+   * lock" — no longer names a site that exists. At head the ONLY rollout-lock takes on this
+   * path are above `execute`: the request-decision adapter's `prepare` resolving the posture
+   * through the port, and the W4C-3b boundary's own `acquireAttendanceCalculationRolloutLock`.)
+   *
+   * The single-point mutation that recreates the hazard is to move the ROW lock up instead of
+   * the rollout lock down: append `FOR UPDATE` to the request-decision adapter's `prepare`
+   * `SELECT * FROM attendance_requests ...` (`index.cjs`, the query immediately above
+   * `const legacyAuthorization = await resolveRequestLegacyAuthorization(...)`). Then A holds
+   * the request row while parked on the rollout SHARED lock, step 3 blocks on A, and the run
+   * dies with SQLSTATE `40P01`. Executed against this file: the leg fails with
+   * `transition-order connection failed (SQLSTATE 40P01): error: deadlock detected`.
    */
   it('P1: approval acquires the rollout lock BEFORE any request row lock (no deadlock vs a concurrent transition)', async () => {
     const { buildAttendanceCalculationRolloutAdvisoryKey } = await import('../../src/attendance/w4c0-identity')
@@ -2225,6 +2237,227 @@ describeDb('W3 shift-segments writer matrix (real DB, route-level)', () => {
       expect(res.status, res.raw).toBe(422)
       expect(codeOf(res)).toBe(GUARD_CODE)
       expect(await countRows('attendance_shift_assignments', orgW)).toBe(0)
+    })
+  })
+
+  /**
+   * #4899 residual R4 — P2-1 FULL closure (route-level, real PG, production approval chain).
+   *
+   * The P2-1 leg above can only prove ATTRIBUTION, because while
+   * `assertWorkContextSegmentCalculationAllowed` was hardcoded `referenceSegments: false` a
+   * SECOND fail-closed door dominated the status for every org: both a correct refusal and a
+   * fail-open at the dispatch site produced `422 + GUARD_CODE`. R4 re-sources that door from
+   * the SAME boundary-resolved posture the finalization guard consumes, which lifts the cover
+   * for an ENABLED org and makes a 200-vs-422 flip constructible here for the first time.
+   *
+   * Shape (mirrors the Gate A lock-in describe, one route further down the chain — the
+   * production approval chain `POST /api/attendance/requests/:id/approve` ->
+   * `schedule_dispatch_final_approval`):
+   *   - org A: exact env entry + persisted `shadow` row => BOTH doors admit; the approval
+   *     completes, the request flips to `approved`/`published` and ONE assignment is persisted.
+   *   - org W: persisted `shadow` row but reachable only via the wildcard `*` => still 422 +
+   *     zero writes, and the refusal is still attributed to the dispatch guard, not to the now
+   *     re-sourced calculation door. The wildcard stays inert at this route too.
+   *
+   * Enablement lands AFTER the request is created, which is both the realistic Gate C order
+   * and the reason org A's create needs no `operationId`: the org is still legacy at that
+   * moment. Its approve DOES carry one (plus approval OCC), because a W4-enabled org's
+   * boundary refuses null-ID commands (`W4C0_OPERATION_ID_REQUIRED`).
+   *
+   * MUTATION-PROVABLE ON STATUS — each verified by executing exactly that mutation:
+   *   - `index.cjs` `finalizeScheduleDispatchRequest`'s `referenceSegments:` argument forced
+   *     `false` (equivalently: delete the key => `undefined` => fail-closed) => org A flips
+   *     200 -> 422. This is the direction that was UNDETECTABLE before R4 and it dominates
+   *     "wrong org", "wrong posture field", and "value ignored" — all of them collapse to a
+   *     non-`true` boolean at this site.
+   *   - `index.cjs` `assertWorkContextSegmentCalculationAllowed` forced back to
+   *     `referenceSegments: false` (the pre-R4 pin) => org A flips 200 -> 422, i.e. this leg
+   *     also holds the R4 door itself open.
+   *   - the W4C-3b boundary's `referenceSegments: preflight.referenceSegments` forced `false`
+   *     => org A flips 200 -> 422, holding the whole thread-through load-bearing.
+   *   - fail-OPEN at the dispatch site (`referenceSegments: true`) does NOT flip this leg's
+   *     status; it reds the ATTRIBUTION leg above instead. The two legs are complementary and
+   *     both are required: fail-open is caught by attribution, fail-closed by status.
+   */
+  describe('R4/P2-1: dispatch final approval is status-coverable once the calculation door is re-sourced', () => {
+    const orgA = randomUUID()
+    const orgW = randomUUID()
+    let savedEnv: string | undefined
+
+    beforeAll(() => {
+      savedEnv = process.env.ATTENDANCE_SHIFT_SEGMENT_CALCULATION_ENABLED
+    })
+
+    afterAll(() => {
+      if (savedEnv === undefined) delete process.env.ATTENDANCE_SHIFT_SEGMENT_CALCULATION_ENABLED
+      else process.env.ATTENDANCE_SHIFT_SEGMENT_CALCULATION_ENABLED = savedEnv
+    })
+
+    /** Create a pending dispatch request for a still-legacy org, then make its shift multi-segment. */
+    async function seedPendingDispatchWithMultiSegmentTarget(orgId: string, token: string) {
+      const shiftId = (await createShiftViaApi(token, orgId, {
+        name: 'R4 dispatch target', workStartTime: '09:00', workEndTime: '18:00',
+      })).body.data.id as string
+      await seedDispatchFlow(token, orgId)
+      const scheduleGroupId = await seedScheduleGroup(orgId)
+      const create = await postJson('/api/attendance/schedule-dispatch-requests', token, orgId, {
+        userId: `${orgId}-worker`,
+        targetScheduleGroupId: scheduleGroupId,
+        targetShiftId: shiftId,
+        startDate: '2049-09-01',
+        endDate: '2049-09-01',
+      })
+      expect(create.status, create.raw).toBe(201)
+      await injectSecondSegment(orgId, shiftId)
+      return create.body.data.request.id as string
+    }
+
+    async function approvalCursor(requestId: string) {
+      const result = await pool.query(
+        `SELECT ai.version, ai.current_node_key
+           FROM attendance_requests ar
+           JOIN approval_instances ai ON ai.id = ar.approval_instance_id
+          WHERE ar.id = $1::uuid`,
+        [requestId],
+      )
+      expect(result.rows).toHaveLength(1)
+      return { version: Number(result.rows[0].version), node: String(result.rows[0].current_node_key) }
+    }
+
+    it('org A (exact env entry + persisted shadow row) FINALIZES the dispatch — 2xx and a persisted assignment', async () => {
+      const actorId = `${orgA}-admin`
+      await seedActiveIdentity(actorId, orgA)
+      // A W4-enabled org rechecks the SUBJECT's liveness/membership in-transaction, so the
+      // dispatched worker must be a durable active member too.
+      await seedActiveIdentity(`${orgA}-worker`, orgA)
+      const token = await mintToken(actorId, orgA)
+
+      // Still legacy at create time — no rollout row, and the env holds nothing for this org.
+      process.env.ATTENDANCE_SHIFT_SEGMENT_CALCULATION_ENABLED = ''
+      const requestId = await seedPendingDispatchWithMultiSegmentTarget(orgA, token)
+
+      // Gate C enablement: exact entry (plus the inert wildcard) AND the persisted row.
+      process.env.ATTENDANCE_SHIFT_SEGMENT_CALCULATION_ENABLED = `${orgA},*`
+      await insertShadowRolloutRow(orgA)
+
+      const cursor = await approvalCursor(requestId)
+      const approve = await postJson(`/api/attendance/requests/${requestId}/approve`, token, orgA, {
+        comment: 'go',
+        operationId: randomUUID(),
+        expectedApprovalVersion: cursor.version,
+        expectedApprovalNode: cursor.node,
+      })
+
+      // THE load-bearing assertion: a STATUS-level admission, not an attribution message.
+      expect(approve.status, approve.raw).toBe(200)
+      // Non-vacuous: the production writer chain ran to completion, not merely past one guard.
+      expect(await countRows('attendance_shift_assignments', orgA)).toBe(1)
+      const state = await pool.query(
+        `SELECT r.status, d.publish_status, d.finalized_at
+           FROM attendance_schedule_dispatch_requests d
+           JOIN attendance_requests r ON r.id = d.request_id
+          WHERE r.id = $1`,
+        [requestId],
+      )
+      expect(state.rows[0].status).toBe('approved')
+      expect(state.rows[0].publish_status).toBe('published')
+      expect(state.rows[0].finalized_at).not.toBeNull()
+    })
+
+    it('org W (shadow row, wildcard-only) still fails closed at ITS OWN dispatch guard — wildcard inert here too', async () => {
+      const actorId = `${orgW}-admin`
+      await seedActiveIdentity(actorId, orgW)
+      await seedActiveIdentity(`${orgW}-worker`, orgW)
+      const token = await mintToken(actorId, orgW)
+
+      process.env.ATTENDANCE_SHIFT_SEGMENT_CALCULATION_ENABLED = `${orgA},*`
+      await insertShadowRolloutRow(orgW)
+      const requestId = await seedPendingDispatchWithMultiSegmentTarget(orgW, token)
+
+      // No operationId: a wildcard-only org resolves `legacy`, so the boundary still accepts
+      // null-ID legacy commands. That it does is itself part of the inertness claim.
+      const approve = await postJson(`/api/attendance/requests/${requestId}/approve`, token, orgW, { comment: 'go' })
+      expect(approve.status, approve.raw).toBe(422)
+      expect(codeOf(approve)).toBe(GUARD_CODE)
+      // The refusal still belongs to the dispatch writer's own guard — R4 did not merely move
+      // the refusal to a different door for non-enabled orgs.
+      expect(messageOf(approve), approve.raw).toContain('schedule_dispatch_final_approval')
+      expect(messageOf(approve), approve.raw).not.toContain('attendance calculation')
+      expect(await countRows('attendance_shift_assignments', orgW)).toBe(0)
+      const state = await pool.query(
+        `SELECT r.status, d.publish_status, d.finalized_at
+           FROM attendance_schedule_dispatch_requests d
+           JOIN attendance_requests r ON r.id = d.request_id
+          WHERE r.id = $1`,
+        [requestId],
+      )
+      expect(state.rows[0].status).toBe('pending')
+      expect(state.rows[0].publish_status).toBe('pending')
+      expect(state.rows[0].finalized_at).toBeNull()
+    })
+
+    /**
+     * The SAME asymmetry, one producer over: `shift_swap_final_approval` also stopped
+     * re-resolving the posture in this slice and now consumes the boundary-threaded value.
+     * Measured before writing this leg: forcing that site fail-OPEN reds the existing
+     * `matrix: shift-swap final approval fails closed ...` leg, but forcing it fail-CLOSED
+     * reddened NOTHING in the whole file — i.e. "value ignored / wrong org / wrong posture
+     * field" was undetectable there for exactly the P2-1 reason. This leg closes it on status.
+     *
+     * Mutation-proven: `referenceSegments: referenceSegments === true` -> `false` at the
+     * `shift_swap_final_approval` guard flips this leg 200 -> 422.
+     */
+    it('org S (enabled) FINALIZES a shift swap whose source shift became multi-segment — 2xx and replacement rows', async () => {
+      const orgS = randomUUID()
+      const requesterId = `${orgS}-req`
+      const counterpartyId = `${orgS}-cpy`
+      await seedActiveIdentity(requesterId, orgS)
+      await seedActiveIdentity(counterpartyId, orgS)
+      const requesterToken = await mintToken(requesterId, orgS)
+      const counterpartyToken = await mintToken(counterpartyId, orgS)
+
+      process.env.ATTENDANCE_SHIFT_SEGMENT_CALCULATION_ENABLED = ''
+      const shiftA = (await createShiftViaApi(requesterToken, orgS, { name: 'S-A', workStartTime: '09:00', workEndTime: '13:00' })).body.data.id as string
+      const shiftB = (await createShiftViaApi(requesterToken, orgS, { name: 'S-B', workStartTime: '14:00', workEndTime: '18:00' })).body.data.id as string
+      const assignmentA = await seedPublishedAssignment(orgS, requesterId, shiftA, '2049-09-14')
+      const assignmentB = await seedPublishedAssignment(orgS, counterpartyId, shiftB, '2049-09-15')
+
+      const create = await postJson('/api/attendance/shift-swap-requests', requesterToken, orgS, {
+        requesterAssignmentId: assignmentA,
+        counterpartyAssignmentId: assignmentB,
+      })
+      expect(create.status, create.raw).toBe(201)
+      const requestId = create.body.data.request.id as string
+      const accept = await postJson(`/api/attendance/shift-swap-requests/${requestId}/accept`, counterpartyToken, orgS, {})
+      expect(accept.status, accept.raw).toBe(200)
+
+      // The requester shift becomes multi-segment AFTER the snapshot, then Gate C enables the org.
+      await injectSecondSegment(orgS, shiftA)
+      process.env.ATTENDANCE_SHIFT_SEGMENT_CALCULATION_ENABLED = `${orgS},*`
+      await insertShadowRolloutRow(orgS)
+
+      const cursor = await approvalCursor(requestId)
+      const approve = await postJson(`/api/attendance/requests/${requestId}/approve`, requesterToken, orgS, {
+        comment: 'go',
+        operationId: randomUUID(),
+        expectedApprovalVersion: cursor.version,
+        expectedApprovalNode: cursor.node,
+      })
+      expect(approve.status, approve.raw).toBe(200)
+
+      const state = await pool.query(
+        `SELECT r.status, d.requester_replacement_assignment_id, d.counterparty_replacement_assignment_id, d.finalized_at
+           FROM attendance_requests r
+           JOIN attendance_shift_swap_requests d ON d.request_id = r.id
+          WHERE r.id = $1`,
+        [requestId],
+      )
+      expect(state.rows[0].status).toBe('approved')
+      expect(state.rows[0].requester_replacement_assignment_id).not.toBeNull()
+      expect(state.rows[0].counterparty_replacement_assignment_id).not.toBeNull()
+      expect(state.rows[0].finalized_at).not.toBeNull()
+      // Non-vacuous: the two seeded sources plus the two replacements.
+      expect(await countRows('attendance_shift_assignments', orgS)).toBe(4)
     })
   })
 })

--- a/packages/core-backend/tests/integration/attendance-w7-1a-resolver.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-w7-1a-resolver.db.test.ts
@@ -496,6 +496,17 @@ describeIfDatabase('W7-1a resolvers (real PG)', () => {
      * widened by EXACTLY case — never into prefix/substring/wildcard matching.
      */
     describe('R4: the W7 allowlist entry itself is ASCII case-folded (admission widening)', () => {
+      /**
+       * FIXED, letter-bearing canonical keys instead of this file's `randomUUID()` fixtures
+       * (#4919 gate NIT-2). `randomUUID()` can in principle draw an all-digit hex spelling
+       * (~1.2e-6: the version nibble is '4' and the variant is 8/9/a/b, leaving 30 free chars),
+       * which makes `toUpperCase()` a NO-OP and turns every leg below vacuously green. Failing
+       * loudly on that draw was the old behaviour; not being able to draw it is better, and it
+       * matches the W4 unit legs' `FOLD_ORG`.
+       */
+      const FOLD_ORG = 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee'
+      const FOLD_OTHER = 'bbbbbbbb-cccc-4ddd-8eee-ffffffffffff'
+
       /** Upper-case exactly the FIRST hex letter — deterministic, and never a no-op. */
       function firstLetterUpper(key: string): string {
         const index = key.search(/[a-f]/)
@@ -503,47 +514,61 @@ describeIfDatabase('W7-1a resolvers (real PG)', () => {
         return `${key.slice(0, index)}${key[index].toUpperCase()}${key.slice(index + 1)}`
       }
 
+      /** The outer hooks only clean the file's `orgId`/`otherOrgId` rows; these fixed fixtures
+       *  clean their own, on BOTH sides, so residue from a crashed run cannot make a leg throw
+       *  `_STATE_AMBIGUOUS` instead of exercising the fold. */
+      async function clearFoldRows(): Promise<void> {
+        await pool.query(`DELETE FROM ${POSTURE_TABLE} WHERE org_id = ANY($1::text[])`, [[FOLD_ORG, FOLD_OTHER]])
+      }
+      beforeEach(clearFoldRows)
+      afterEach(clearFoldRows)
+
+      async function insertFoldPosture(state: string): Promise<void> {
+        await pool.query(
+          `INSERT INTO ${POSTURE_TABLE} (org_id, state, scope) VALUES ($1, $2, 'synthetic_staging')`,
+          [FOLD_ORG, state],
+        )
+      }
+
       it('HARNESS CONTROL: the org fixtures really change under toUpperCase (else every leg is vacuous)', () => {
-        // `randomUUID()` is hex; an all-digit draw would make `toUpperCase` a no-op and turn
-        // this whole describe green for the wrong reason. Fail loudly instead.
-        expect(orgId.toUpperCase()).not.toBe(orgId)
-        expect(otherOrgId.toUpperCase()).not.toBe(otherOrgId)
-        expect(orgId).not.toBe(otherOrgId)
+        expect(FOLD_ORG.toUpperCase()).not.toBe(FOLD_ORG)
+        expect(FOLD_OTHER.toUpperCase()).not.toBe(FOLD_OTHER)
+        expect(FOLD_ORG).not.toBe(FOLD_OTHER)
       })
 
       it('an UPPER-CASE env ENTRY now admits the lower-case org key (the widening)', async () => {
-        await insertPosture('group_authoritative')
-        const upperEntry = orgId.toUpperCase()
+        await insertFoldPosture('group_authoritative')
+        const upperEntry = FOLD_ORG.toUpperCase()
         // Discriminating precondition: the entry bytes really differ from the org key.
-        expect(upperEntry).not.toBe(orgId)
+        expect(upperEntry).not.toBe(FOLD_ORG)
         process.env[ATTENDANCE_W7_CONTEXT_SOURCE_ALLOWLIST_ENV] = upperEntry
 
-        expect((await resolvePosture()).effectiveState).toBe('group_authoritative')
-        expect(isAttendanceW7ContextSourceOrgAllowlistedV1(orgId)).toBe(true)
+        expect((await resolvePosture(FOLD_ORG)).effectiveState).toBe('group_authoritative')
+        expect(isAttendanceW7ContextSourceOrgAllowlistedV1(FOLD_ORG)).toBe(true)
       })
 
       it('mixed case plus surrounding whitespace/commas fold together', async () => {
-        await insertPosture('group_eligible')
-        const mixed = firstLetterUpper(orgId)
-        expect(mixed).not.toBe(orgId)
-        expect(mixed).not.toBe(orgId.toUpperCase())
-        process.env[ATTENDANCE_W7_CONTEXT_SOURCE_ALLOWLIST_ENV] = `${otherOrgId},  ${mixed} \t,`
-        expect((await resolvePosture()).effectiveState).toBe('group_eligible')
+        await insertFoldPosture('group_eligible')
+        const mixed = firstLetterUpper(FOLD_ORG)
+        expect(mixed).not.toBe(FOLD_ORG)
+        expect(mixed).not.toBe(FOLD_ORG.toUpperCase())
+        process.env[ATTENDANCE_W7_CONTEXT_SOURCE_ALLOWLIST_ENV] = `${FOLD_OTHER},  ${mixed} \t,`
+        expect((await resolvePosture(FOLD_ORG)).effectiveState).toBe('group_eligible')
       })
 
       it('NEGATIVE CONTROL: an UPPER-CASE entry for a DIFFERENT org still resolves off', async () => {
-        await insertPosture('group_authoritative')
-        process.env[ATTENDANCE_W7_CONTEXT_SOURCE_ALLOWLIST_ENV] = otherOrgId.toUpperCase()
+        await insertFoldPosture('group_authoritative')
+        process.env[ATTENDANCE_W7_CONTEXT_SOURCE_ALLOWLIST_ENV] = FOLD_OTHER.toUpperCase()
         // A fold that degenerated into prefix/substring matching would admit here.
-        expect((await resolvePosture()).effectiveState).toBe('off')
-        expect(isAttendanceW7ContextSourceOrgAllowlistedV1(orgId)).toBe(false)
+        expect((await resolvePosture(FOLD_ORG)).effectiveState).toBe('off')
+        expect(isAttendanceW7ContextSourceOrgAllowlistedV1(FOLD_ORG)).toBe(false)
       })
 
       it('NEGATIVE CONTROL: folding never lets a prefix, suffix, or wildcard entry match', async () => {
-        await insertPosture('group_authoritative')
+        await insertFoldPosture('group_authoritative')
         for (const entry of [
-          orgId.slice(0, 20).toUpperCase(), // strict prefix
-          `${orgId.toUpperCase()}-EXTRA`, // strict suffix extension
+          FOLD_ORG.slice(0, 20).toUpperCase(), // strict prefix
+          `${FOLD_ORG.toUpperCase()}-EXTRA`, // strict suffix extension
           '*',
           ' * ',
           '.*',
@@ -552,33 +577,33 @@ describeIfDatabase('W7-1a resolvers (real PG)', () => {
         ]) {
           process.env[ATTENDANCE_W7_CONTEXT_SOURCE_ALLOWLIST_ENV] = entry
           expect(
-            (await resolvePosture()).effectiveState,
+            (await resolvePosture(FOLD_ORG)).effectiveState,
             `entry ${JSON.stringify(entry)} must not admit`,
           ).toBe('off')
         }
         // POSITIVE CONTROL for this loop: the same machinery DOES admit the exact key
         // (upper-cased), so the seven denials above are real rejections, not a dead harness.
-        process.env[ATTENDANCE_W7_CONTEXT_SOURCE_ALLOWLIST_ENV] = orgId.toUpperCase()
-        expect((await resolvePosture()).effectiveState).toBe('group_authoritative')
+        process.env[ATTENDANCE_W7_CONTEXT_SOURCE_ALLOWLIST_ENV] = FOLD_ORG.toUpperCase()
+        expect((await resolvePosture(FOLD_ORG)).effectiveState).toBe('group_authoritative')
       })
 
       it('W4 and W7 fold IDENTICALLY — one shared matching semantics, two separate variables', () => {
         // Same input shape on both predicates: upper-case exact entry admits, wildcard never.
-        process.env[W4_ENV] = orgId.toUpperCase()
-        process.env[ATTENDANCE_W7_CONTEXT_SOURCE_ALLOWLIST_ENV] = orgId.toUpperCase()
-        expect(isAttendanceCalculationOrgAllowlistedV1(orgId)).toBe(true)
-        expect(isAttendanceW7ContextSourceOrgAllowlistedV1(orgId)).toBe(true)
+        process.env[W4_ENV] = FOLD_ORG.toUpperCase()
+        process.env[ATTENDANCE_W7_CONTEXT_SOURCE_ALLOWLIST_ENV] = FOLD_ORG.toUpperCase()
+        expect(isAttendanceCalculationOrgAllowlistedV1(FOLD_ORG)).toBe(true)
+        expect(isAttendanceW7ContextSourceOrgAllowlistedV1(FOLD_ORG)).toBe(true)
 
         process.env[W4_ENV] = '*'
         process.env[ATTENDANCE_W7_CONTEXT_SOURCE_ALLOWLIST_ENV] = '*'
-        expect(isAttendanceCalculationOrgAllowlistedV1(orgId)).toBe(false)
-        expect(isAttendanceW7ContextSourceOrgAllowlistedV1(orgId)).toBe(false)
+        expect(isAttendanceCalculationOrgAllowlistedV1(FOLD_ORG)).toBe(false)
+        expect(isAttendanceW7ContextSourceOrgAllowlistedV1(FOLD_ORG)).toBe(false)
 
         // ...and they remain SEPARATE variables: W4 on alone never advertises W7.
-        process.env[W4_ENV] = orgId.toUpperCase()
+        process.env[W4_ENV] = FOLD_ORG.toUpperCase()
         delete process.env[ATTENDANCE_W7_CONTEXT_SOURCE_ALLOWLIST_ENV]
-        expect(isAttendanceCalculationOrgAllowlistedV1(orgId)).toBe(true)
-        expect(isAttendanceW7ContextSourceOrgAllowlistedV1(orgId)).toBe(false)
+        expect(isAttendanceCalculationOrgAllowlistedV1(FOLD_ORG)).toBe(true)
+        expect(isAttendanceW7ContextSourceOrgAllowlistedV1(FOLD_ORG)).toBe(false)
       })
     })
   })

--- a/packages/core-backend/tests/integration/attendance-w7-1a-resolver.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-w7-1a-resolver.db.test.ts
@@ -29,7 +29,10 @@ import { Kysely, PostgresDialect } from 'kysely'
 import { Pool, type PoolClient } from 'pg'
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 
-import type { AttendanceW4TransactionClientV1 } from '../../src/attendance/w4c0-identity'
+import {
+  isAttendanceCalculationOrgAllowlistedV1,
+  type AttendanceW4TransactionClientV1,
+} from '../../src/attendance/w4c0-identity'
 import { ATTENDANCE_W7_CONTEXT_SOURCE_POSTURE_STATES_V1 } from '../../src/attendance/w7-context-source-posture-contract'
 import {
   down as postureMigrationDown,
@@ -46,6 +49,7 @@ import {
   ATTENDANCE_W7_CONTEXT_SOURCE_SCOPE_INVALID,
   ATTENDANCE_W7_CONTEXT_SOURCE_STATE_AMBIGUOUS,
   ATTENDANCE_W7_CONTEXT_SOURCE_STATE_INVALID,
+  isAttendanceW7ContextSourceOrgAllowlistedV1,
   isResolvedAttendanceW7ContextSourcePostureV1,
   resolveAttendanceW7ContextSourcePostureV1,
 } from '../../src/attendance/w7-resolver/w7-context-source-posture-resolver'
@@ -480,6 +484,102 @@ describeIfDatabase('W7-1a resolvers (real PG)', () => {
       const rawRow = await pool.query(`SELECT 1 FROM ${POSTURE_TABLE} WHERE org_id = $1`, [upper])
       expect(rawRow.rows).toHaveLength(0)
       expect(process.env[ATTENDANCE_W7_CONTEXT_SOURCE_ALLOWLIST_ENV]).not.toContain(upper)
+    })
+
+    /**
+     * #4899 residual R4 / P3-2 — this file's original OPS-FOOTGUN note deferred
+     * case-folding "jointly with the W4 predicate". Owner approved the fold; W4
+     * (`w4c0-identity.ts`, `isOrgExactlyAllowlisted`) and W7 are folded in the SAME
+     * change, so the two allowlists still agree on matching semantics.
+     *
+     * The fold is an ADMISSION WIDENING, so both halves are proven: it widened, and it
+     * widened by EXACTLY case — never into prefix/substring/wildcard matching.
+     */
+    describe('R4: the W7 allowlist entry itself is ASCII case-folded (admission widening)', () => {
+      /** Upper-case exactly the FIRST hex letter — deterministic, and never a no-op. */
+      function firstLetterUpper(key: string): string {
+        const index = key.search(/[a-f]/)
+        expect(index, 'fixture has no hex letter; every fold leg would be vacuous').toBeGreaterThan(-1)
+        return `${key.slice(0, index)}${key[index].toUpperCase()}${key.slice(index + 1)}`
+      }
+
+      it('HARNESS CONTROL: the org fixtures really change under toUpperCase (else every leg is vacuous)', () => {
+        // `randomUUID()` is hex; an all-digit draw would make `toUpperCase` a no-op and turn
+        // this whole describe green for the wrong reason. Fail loudly instead.
+        expect(orgId.toUpperCase()).not.toBe(orgId)
+        expect(otherOrgId.toUpperCase()).not.toBe(otherOrgId)
+        expect(orgId).not.toBe(otherOrgId)
+      })
+
+      it('an UPPER-CASE env ENTRY now admits the lower-case org key (the widening)', async () => {
+        await insertPosture('group_authoritative')
+        const upperEntry = orgId.toUpperCase()
+        // Discriminating precondition: the entry bytes really differ from the org key.
+        expect(upperEntry).not.toBe(orgId)
+        process.env[ATTENDANCE_W7_CONTEXT_SOURCE_ALLOWLIST_ENV] = upperEntry
+
+        expect((await resolvePosture()).effectiveState).toBe('group_authoritative')
+        expect(isAttendanceW7ContextSourceOrgAllowlistedV1(orgId)).toBe(true)
+      })
+
+      it('mixed case plus surrounding whitespace/commas fold together', async () => {
+        await insertPosture('group_eligible')
+        const mixed = firstLetterUpper(orgId)
+        expect(mixed).not.toBe(orgId)
+        expect(mixed).not.toBe(orgId.toUpperCase())
+        process.env[ATTENDANCE_W7_CONTEXT_SOURCE_ALLOWLIST_ENV] = `${otherOrgId},  ${mixed} \t,`
+        expect((await resolvePosture()).effectiveState).toBe('group_eligible')
+      })
+
+      it('NEGATIVE CONTROL: an UPPER-CASE entry for a DIFFERENT org still resolves off', async () => {
+        await insertPosture('group_authoritative')
+        process.env[ATTENDANCE_W7_CONTEXT_SOURCE_ALLOWLIST_ENV] = otherOrgId.toUpperCase()
+        // A fold that degenerated into prefix/substring matching would admit here.
+        expect((await resolvePosture()).effectiveState).toBe('off')
+        expect(isAttendanceW7ContextSourceOrgAllowlistedV1(orgId)).toBe(false)
+      })
+
+      it('NEGATIVE CONTROL: folding never lets a prefix, suffix, or wildcard entry match', async () => {
+        await insertPosture('group_authoritative')
+        for (const entry of [
+          orgId.slice(0, 20).toUpperCase(), // strict prefix
+          `${orgId.toUpperCase()}-EXTRA`, // strict suffix extension
+          '*',
+          ' * ',
+          '.*',
+          '%',
+          '',
+        ]) {
+          process.env[ATTENDANCE_W7_CONTEXT_SOURCE_ALLOWLIST_ENV] = entry
+          expect(
+            (await resolvePosture()).effectiveState,
+            `entry ${JSON.stringify(entry)} must not admit`,
+          ).toBe('off')
+        }
+        // POSITIVE CONTROL for this loop: the same machinery DOES admit the exact key
+        // (upper-cased), so the seven denials above are real rejections, not a dead harness.
+        process.env[ATTENDANCE_W7_CONTEXT_SOURCE_ALLOWLIST_ENV] = orgId.toUpperCase()
+        expect((await resolvePosture()).effectiveState).toBe('group_authoritative')
+      })
+
+      it('W4 and W7 fold IDENTICALLY — one shared matching semantics, two separate variables', () => {
+        // Same input shape on both predicates: upper-case exact entry admits, wildcard never.
+        process.env[W4_ENV] = orgId.toUpperCase()
+        process.env[ATTENDANCE_W7_CONTEXT_SOURCE_ALLOWLIST_ENV] = orgId.toUpperCase()
+        expect(isAttendanceCalculationOrgAllowlistedV1(orgId)).toBe(true)
+        expect(isAttendanceW7ContextSourceOrgAllowlistedV1(orgId)).toBe(true)
+
+        process.env[W4_ENV] = '*'
+        process.env[ATTENDANCE_W7_CONTEXT_SOURCE_ALLOWLIST_ENV] = '*'
+        expect(isAttendanceCalculationOrgAllowlistedV1(orgId)).toBe(false)
+        expect(isAttendanceW7ContextSourceOrgAllowlistedV1(orgId)).toBe(false)
+
+        // ...and they remain SEPARATE variables: W4 on alone never advertises W7.
+        process.env[W4_ENV] = orgId.toUpperCase()
+        delete process.env[ATTENDANCE_W7_CONTEXT_SOURCE_ALLOWLIST_ENV]
+        expect(isAttendanceCalculationOrgAllowlistedV1(orgId)).toBe(true)
+        expect(isAttendanceW7ContextSourceOrgAllowlistedV1(orgId)).toBe(false)
+      })
     })
   })
 

--- a/packages/core-backend/tests/unit/attendance-fixed-schedule-self-route-wiring.test.ts
+++ b/packages/core-backend/tests/unit/attendance-fixed-schedule-self-route-wiring.test.ts
@@ -82,6 +82,9 @@ async function createHarness() {
               operationId: input.operationId ?? null,
               correlationId: input.correlationId,
               acceptedWritePosture: 'legacy_projection_only',
+              // Mirror the real W4C-3b boundary's context shape (#4899 residual R4): the legacy
+              // posture this double emulates resolves referenceSegments false.
+              referenceSegments: false,
               routeVariant: input.routeVariant ?? null,
             }
             const adapter = adapters[input.kind]

--- a/packages/core-backend/tests/unit/attendance-uuid-validation-routes.test.ts
+++ b/packages/core-backend/tests/unit/attendance-uuid-validation-routes.test.ts
@@ -119,6 +119,9 @@ async function createHarness(
               operationId: input.operationId ?? null,
               correlationId: input.correlationId,
               acceptedWritePosture: 'legacy_projection_only',
+              // Mirror the real W4C-3b boundary's context shape (#4899 residual R4): the legacy
+              // posture this double emulates resolves referenceSegments false.
+              referenceSegments: false,
               routeVariant: input.routeVariant ?? null,
             }
             const adapter = adapters[input.kind]

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -8349,21 +8349,36 @@ function getAttendanceGroupFixedScheduleEffectivenessService() {
   return attendanceGroupFixedScheduleEffectivenessService
 }
 
-function assertWorkContextSegmentCalculationAllowed(orgId, workContext) {
+/**
+ * #4556 Gate A residual R4 — this door is no longer hardcoded closed.
+ *
+ * `referenceSegments` is the org's canonical posture bit (exact-org allowlist AND a persisted
+ * rollout row), RESOLVED BY THE CALLER via the same core port the 17 write-side sites use, and
+ * threaded in. It is deliberately NOT resolved here:
+ *
+ *  - this function is called from a SYNCHRONOUS work-context builder
+ *    (`resolveWorkContextFromPrefetch`), which has no client at all — resolution is
+ *    structurally impossible there, so threading is forced, not preferred; and
+ *  - resolving here would take the class-`00` rollout SHARED advisory lock at whatever point
+ *    the enclosing caller happens to run, which for the approval path is BELOW
+ *    `SELECT ... FROM attendance_requests ... FOR UPDATE`. That is precisely the wait cycle the
+ *    #4899 owner-P1 lock-order counterexample forbids (transition holds rollout-exclusive +
+ *    waits on the request row; approval holds the request row + waits on rollout-shared).
+ *    A caller may only pass a value it resolved ABOVE its row locks.
+ *
+ * Fail-closed default: anything other than `true` refuses a multi-segment work context, exactly
+ * as the pinned-closed version did. Callers that do not (yet) thread a resolved posture keep
+ * byte-identical behaviour — see `resolveWorkContext` for the enumerated residual set.
+ */
+function assertWorkContextSegmentCalculationAllowed(orgId, workContext, referenceSegments) {
   if (!workContext || workContext.source === 'rule') return
   const shift = workContext.rule
-  // #4556 Gate A / Option B: this synchronous calculation read path has no write trx / port in
-  // hand, so it is pinned to the closed legacy posture (`referenceSegments: false`). That is
-  // byte-identical to the retired env-gate's production behaviour (the plugin master gate was
-  // OFF, so a multi-segment work context always failed closed here). Residual R4+: once an org
-  // is turned on via Gate C its reference writers will be admitted while this read path still
-  // fails closed on a multi-segment shift, until it is re-sourced from the port in a later slice.
   getAttendanceShiftService().assertSegmentCalculationAllowed({
     orgId,
     shiftId: shift?.id,
     segmentCount: shift?.segmentCount,
     producer: 'attendance calculation',
-    referenceSegments: false,
+    referenceSegments: referenceSegments === true,
   })
 }
 
@@ -15193,6 +15208,31 @@ async function loadRotationAssignment(db, orgId, userId, workDate) {
   }
 }
 
+/**
+ * #4556 Gate A residual R4 — `options.referenceSegments` is an OPTIONAL, caller-resolved org
+ * posture bit forwarded to the segment-calculation read door below. It defaults to `false`
+ * (fail-closed, byte-identical to the pinned-closed behaviour) and is deliberately NOT resolved
+ * inside this function: doing so would take the class-`00` rollout SHARED advisory lock at each
+ * caller's arbitrary position relative to its own row locks, and several callers pass a real
+ * transaction that already holds row locks (see the lock-order rationale on
+ * `assertWorkContextSegmentCalculationAllowed`).
+ *
+ * WIRED in this slice — exactly one consumer, the request-decision approval path
+ * (`executeRequestDecisionInTransaction`, the `resolveWorkContext` call at ~`:37223`). Its value
+ * comes from the W4C-3b boundary's single resolve, taken under the rollout lock BEFORE any
+ * request row lock, and is the SAME value the finalization reference guards consume.
+ *
+ * OUT OF SCOPE for this slice (enumerated, not hand-waved): every other call site still passes
+ * nothing and therefore still fails closed on a multi-segment work context —
+ * `:14166`, `:15644`, `:17290`, `:21105`, `:22469`, `:22984`, `:24613`, `:28548`, `:29397`,
+ * `:29409`, `:35455`, `:40330`, `:40924`, plus the synchronous prefetch variant's callers
+ * `:18707`, `:28542`, `:29898`, `:30556`. The blocker is not effort: each one needs its own
+ * lock-order census in the #4899 sense (what locks does its caller already hold, and can the
+ * rollout SHARED lock be hoisted above them) before it may resolve a posture. Opening them
+ * without that census is how the owner-P1 deadlock gets re-introduced. This slice therefore
+ * opens the R4 door PARTIALLY — for the approval path that item 4 needs to be behaviourally
+ * coverable — and leaves the rest closed and named.
+ */
 async function resolveWorkContext(options) {
   const { db, orgId, userId, workDate, defaultRule, holidayOverride } = options
   const rule = defaultRule ?? await loadDefaultRule(db, orgId)
@@ -15214,7 +15254,7 @@ async function resolveWorkContext(options) {
     isWorkingDay,
     source: rotationInfo ? 'rotation' : assignmentInfo ? 'shift' : 'rule',
   }
-  assertWorkContextSegmentCalculationAllowed(orgId, context)
+  assertWorkContextSegmentCalculationAllowed(orgId, context, options.referenceSegments)
   // Step 5: layer calendarPolicy.overrides on top of profile/holiday. D4
   // pinned: only hit the DB when we actually have overrides to match, and
   // accept caller-provided overrides/scopeContext to avoid redundant
@@ -17917,6 +17957,12 @@ function resolveRotationInfoFromPrefetch(entries, workDate, shiftsById) {
   return null
 }
 
+/**
+ * #4556 Gate A residual R4 — SYNCHRONOUS variant. It has no db/trx at all, so resolving the
+ * posture here is structurally impossible: `options.referenceSegments` is the only channel, and
+ * it defaults to `false` (fail-closed). No caller threads it in this slice — see the enumerated
+ * out-of-scope list on `resolveWorkContext`.
+ */
 function resolveWorkContextFromPrefetch(options) {
   const { orgId, userId, workDate, defaultRule, prefetched } = options
   if (!prefetched || !workDate) return null
@@ -17949,7 +17995,7 @@ function resolveWorkContextFromPrefetch(options) {
     isWorkingDay,
     source: rotationInfo ? 'rotation' : assignmentInfo ? 'shift' : 'rule',
   }
-  assertWorkContextSegmentCalculationAllowed(orgId, context)
+  assertWorkContextSegmentCalculationAllowed(orgId, context, options.referenceSegments)
   // Step 5: apply calendarPolicy.overrides when the prefetch carries both
   // the policy list and the user's scope context. D5 pinned: when either
   // is missing (old fixtures that build prefetched manually), behave
@@ -31577,7 +31623,13 @@ module.exports = {
       return row
     }
 
-    async function finalizeShiftSwapRequest(client, { orgId, requestId, actorId }) {
+    // #4899 residual R4: `referenceSegments` is the org posture RESOLVED BY THE W4C-3b
+    // BOUNDARY, before this transaction took any request/assignment row lock, and passed
+    // down. Finalization must NOT re-resolve it: the boundary already holds the rollout
+    // SHARED advisory lock for the whole transaction, so a second resolve is a redundant
+    // lock-take plus SELECT — and it would sit BELOW the row locks, which is the ordering
+    // the #4899 owner-P1 counterexample forbids. Anything other than `true` fails closed.
+    async function finalizeShiftSwapRequest(client, { orgId, requestId, actorId, referenceSegments }) {
       const detail = await loadShiftSwapDetail(client, orgId, requestId, { forUpdate: true })
       if (!detail) {
         throw new HttpError(404, 'NOT_FOUND', 'Shift-swap request not found')
@@ -31660,7 +31712,7 @@ module.exports = {
         orgId,
         shiftRefs: [requesterSource.shiftId, counterpartySource.shiftId],
         producer: 'shift_swap_final_approval',
-        referenceSegments: await resolveReferenceSegmentsPostureForWrite(client, orgId),
+        referenceSegments: referenceSegments === true,
       })
 
       const settings = await getSettings(client)
@@ -31981,7 +32033,9 @@ module.exports = {
       return rows[0] ?? null
     }
 
-    async function finalizeScheduleDispatchRequest(client, { orgId, requestId, actorId, actorAccess }) {
+    // #4899 residual R4: see `finalizeShiftSwapRequest` — `referenceSegments` is the
+    // boundary-resolved posture bit, threaded down, never re-resolved here.
+    async function finalizeScheduleDispatchRequest(client, { orgId, requestId, actorId, actorAccess, referenceSegments }) {
       const detail = await loadScheduleDispatchDetail(client, orgId, requestId, { forUpdate: true })
       if (!detail) {
         throw new HttpError(400, 'SCHEDULE_DISPATCH_DETAIL_MISSING', 'Schedule-dispatch request detail is missing')
@@ -32022,7 +32076,7 @@ module.exports = {
         orgId,
         shiftId: detail.target_shift_id,
         producer: 'schedule_dispatch_final_approval',
-        referenceSegments: await resolveReferenceSegmentsPostureForWrite(client, orgId),
+        referenceSegments: referenceSegments === true,
       })
 
       await assertScheduleDispatchScopeAllowed(client, orgId, actorAccess, buildScheduleDispatchSchedulerScopeTarget({
@@ -36616,6 +36670,14 @@ module.exports = {
 
     async function executeRequestDecisionInTransaction(trx, state, operation) {
           const { route, expectedApprovalVersion, expectedApprovalNode } = state
+          // #4899 residual R4 — THE single posture value for this whole approval transaction.
+          // Resolved by the W4C-3b boundary under the class-`00` rollout SHARED advisory lock
+          // BEFORE `execute` (and therefore before the `FOR UPDATE` below), then handed to us
+          // on `operation`. Consumed by BOTH the finalization reference guards and the
+          // calculation read path, so neither re-resolves and neither re-takes the rollout
+          // lock beneath a row lock. Strict `=== true`: a boundary that did not resolve a
+          // posture (or an org outside the canonical W4 domain) is fail-closed.
+          const decisionReferenceSegments = operation?.referenceSegments === true
           const requesterId = route.actorId
           const requestId = route.requestId
           const action = route.action
@@ -36910,6 +36972,7 @@ module.exports = {
                 orgId,
                 fullAdmin: decisionAccess.fullAdmin,
               },
+              referenceSegments: decisionReferenceSegments,
             })
             nextMetadata.scheduleDispatchFinalization = {
               assignmentIds: [scheduleDispatchFinalization.assignment.id],
@@ -36925,6 +36988,7 @@ module.exports = {
               orgId,
               requestId,
               actorId: requesterId,
+              referenceSegments: decisionReferenceSegments,
             })
             nextMetadata.shiftSwapFinalization = {
               requesterReplacementAssignmentId: shiftSwapFinalization.requesterReplacement.id,
@@ -37193,6 +37257,10 @@ module.exports = {
               userId: requestRow.user_id,
               workDate: requestRow.work_date,
               defaultRule: baseRule,
+              // #4899 residual R4: the ONE wired consumer of the re-sourced calculation door.
+              // Same boundary-resolved value the finalization guards above consumed — resolved
+              // under the rollout SHARED lock before this transaction's first row lock.
+              referenceSegments: decisionReferenceSegments,
             })
             const timezone = context.rule.timezone
             if (requestType === 'missed_check_in' || requestType === 'missed_check_out' || requestType === 'time_correction') {

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -8368,7 +8368,30 @@ function getAttendanceGroupFixedScheduleEffectivenessService() {
  *
  * Fail-closed default: anything other than `true` refuses a multi-segment work context, exactly
  * as the pinned-closed version did. Callers that do not (yet) thread a resolved posture keep
- * byte-identical behaviour — see `resolveWorkContext` for the enumerated residual set.
+ * byte-identical behaviour — see `resolveWorkContext` for the residual set.
+ *
+ * WHICH POSTURE BIT, AND WHY — this is a CHOICE, recorded as one rather than left implicit.
+ * The bit consumed here is `referenceSegments` (true from `shadow` upward), NOT
+ * `authoritativeResults` (true only for `authoritative`). Both exist in the W4 posture table
+ * and the guard's own 422 text says "authoritative segment calculation is disabled", so
+ * `authoritativeResults` is the reading a reviewer would expect. It is rejected because the
+ * Stage A rollout guard cannot produce an `authoritative` row at all
+ * (`w4c3a-rollout-control.ts` admits only `legacy` -> `shadow`), so that bit is `false` for
+ * every reachable org and the door would stay shut for everyone — leaving Gate A's admitted
+ * writers permanently un-calculable. `referenceSegments` is the bit that answers the question
+ * this door actually asks: "may this org's scheduling data REFERENCE a multi-segment shift?"
+ *
+ * MEASURED CONSEQUENCE, disclosed rather than discovered later. The segment-aware calculator
+ * is W4C-1 and has NOT shipped (`SEGMENT_CALCULATION_IMPLEMENTED === false`). Until it does,
+ * the legacy calculator downstream of this door works off the shift's OUTER ENVELOPE. For a
+ * `shadow` org with an 08:00-12:00 + 13:00-17:00 shift and a full-span attendance, a real
+ * approval run produced `attendance_records.work_minutes = 540`, while the shift DTO's
+ * `plannedMinutes` is 480 (R1: the 60-minute break is never payable time). The break is
+ * therefore counted as worked time for an ENABLED org. That is an owner decision about which
+ * failure is preferable — a Gate-C org whose users cannot be calculated at all (the pinned
+ * state) versus one calculated on envelope semantics until W4C-1 lands — and it is called out
+ * in the PR body, not settled here. It is unreachable today: no rollout row exists, so no org
+ * resolves anything but `legacy`.
  */
 function assertWorkContextSegmentCalculationAllowed(orgId, workContext, referenceSegments) {
   if (!workContext || workContext.source === 'rule') return
@@ -15217,21 +15240,32 @@ async function loadRotationAssignment(db, orgId, userId, workDate) {
  * transaction that already holds row locks (see the lock-order rationale on
  * `assertWorkContextSegmentCalculationAllowed`).
  *
- * WIRED in this slice — exactly one consumer, the request-decision approval path
- * (`executeRequestDecisionInTransaction`, the `resolveWorkContext` call at ~`:37223`). Its value
- * comes from the W4C-3b boundary's single resolve, taken under the rollout lock BEFORE any
- * request row lock, and is the SAME value the finalization reference guards consume.
+ * WIRED in this slice — exactly ONE consumer: the `resolveWorkContext` call inside
+ * `executeRequestDecisionInTransaction`. Its value comes from the W4C-3b boundary's single
+ * resolve, taken under the rollout lock BEFORE any request row lock, and is the SAME value the
+ * finalization reference guards consume.
  *
- * OUT OF SCOPE for this slice (enumerated, not hand-waved): every other call site still passes
- * nothing and therefore still fails closed on a multi-segment work context —
- * `:14166`, `:15644`, `:17290`, `:21105`, `:22469`, `:22984`, `:24613`, `:28548`, `:29397`,
- * `:29409`, `:35455`, `:40330`, `:40924`, plus the synchronous prefetch variant's callers
- * `:18707`, `:28542`, `:29898`, `:30556`. The blocker is not effort: each one needs its own
- * lock-order census in the #4899 sense (what locks does its caller already hold, and can the
- * rollout SHARED lock be hoisted above them) before it may resolve a posture. Opening them
- * without that census is how the owner-P1 deadlock gets re-introduced. This slice therefore
- * opens the R4 door PARTIALLY — for the approval path that item 4 needs to be behaviourally
- * coverable — and leaves the rest closed and named.
+ * BREADTH OF THAT ONE SITE, stated so nobody reads "one call site" as "one request type": it
+ * sits under `if (action === 'approve' && isFinalApproval)` and therefore runs for EVERY
+ * request type's final approval — leave, overtime, missed_check_in, missed_check_out,
+ * time_correction, shift_swap, schedule_dispatch. For an enabled org this slice changes
+ * segment-calculation admission for all of them. Only the shift_swap and schedule_dispatch
+ * finalization producers have route-level coverage in this slice; the other types are admitted
+ * by the same door with no leg of their own.
+ *
+ * OUT OF SCOPE for this slice: every OTHER call site of `resolveWorkContext` /
+ * `resolveWorkContextFromPrefetch` still passes nothing and therefore still fails closed on a
+ * multi-segment work context. Enumerate the residual set MECHANICALLY at any head (line numbers
+ * in a comment go stale; this does not):
+ *
+ *   grep -n 'resolveWorkContext(\|resolveWorkContextFromPrefetch(' plugins/plugin-attendance/index.cjs
+ *
+ * Exactly one of those call sites passes a `referenceSegments:` argument today. The blocker on
+ * the rest is not effort: each needs its own lock-order census in the #4899 sense (what locks
+ * does its caller already hold, and can the rollout SHARED lock be hoisted above them) before
+ * it may resolve a posture. Opening them without that census is how the owner-P1 deadlock gets
+ * re-introduced. This slice therefore opens the R4 door PARTIALLY — for the approval path that
+ * P2-1 needs to be behaviourally coverable — and leaves the rest closed.
  */
 async function resolveWorkContext(options) {
   const { db, orgId, userId, workDate, defaultRule, holidayOverride } = options

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -8374,24 +8374,43 @@ function getAttendanceGroupFixedScheduleEffectivenessService() {
  * The bit consumed here is `referenceSegments` (true from `shadow` upward), NOT
  * `authoritativeResults` (true only for `authoritative`). Both exist in the W4 posture table
  * and the guard's own 422 text says "authoritative segment calculation is disabled", so
- * `authoritativeResults` is the reading a reviewer would expect. It is rejected because the
- * Stage A rollout guard cannot produce an `authoritative` row at all
- * (`w4c3a-rollout-control.ts` admits only `legacy` -> `shadow`), so that bit is `false` for
- * every reachable org and the door would stay shut for everyone — leaving Gate A's admitted
- * writers permanently un-calculable. `referenceSegments` is the bit that answers the question
- * this door actually asks: "may this org's scheduling data REFERENCE a multi-segment shift?"
+ * `authoritativeResults` is the reading a reviewer would expect.
  *
- * MEASURED CONSEQUENCE, disclosed rather than discovered later. The segment-aware calculator
- * is W4C-1 and has NOT shipped (`SEGMENT_CALCULATION_IMPLEMENTED === false`). Until it does,
- * the legacy calculator downstream of this door works off the shift's OUTER ENVELOPE. For a
- * `shadow` org with an 08:00-12:00 + 13:00-17:00 shift and a full-span attendance, a real
- * approval run produced `attendance_records.work_minutes = 540`, while the shift DTO's
- * `plannedMinutes` is 480 (R1: the 60-minute break is never payable time). The break is
- * therefore counted as worked time for an ENABLED org. That is an owner decision about which
- * failure is preferable — a Gate-C org whose users cannot be calculated at all (the pinned
- * state) versus one calculated on envelope semantics until W4C-1 lands — and it is called out
- * in the PR body, not settled here. It is unreachable today: no rollout row exists, so no org
- * resolves anything but `legacy`.
+ * The honest framing is NOT "one bit works, the other is a dead door" — an earlier revision of
+ * this comment said `authoritative` was unreachable and that was FALSE at this head. It IS
+ * reachable: `LEGAL_TRANSITIONS` (`w4c3a-rollout-control.ts`) contains `shadow -> eligible`
+ * and `eligible -> authoritative`; the `legacy -> shadow` restriction applies only to
+ * BOOTSTRAPPING a missing row; and the
+ * `W4C3A_ROLLOUT_CONTROL_AUTHORITATIVE_ENTRYPOINT_NOT_DELIVERED` refusal stopped firing when
+ * #4844 declared both entrypoints delivered. `attendance-w4c3a-rollout-control.db.test.ts`
+ * drives the promotion and reads back `authoritative`.
+ *
+ * So the real question the choice settles is WHICH ROLLOUT RUNG opens this door:
+ *   - `referenceSegments` opens it at `shadow` — Gate C step one — and also at `eligible`;
+ *   - `authoritativeResults` opens it only after a deliberate three-step operator walk
+ *     (`legacy -> shadow -> eligible -> authoritative`) carrying evidence manifests and the
+ *     full transition precondition set.
+ * `referenceSegments` is chosen because it is the bit that answers what this door actually
+ * asks — "may this org's scheduling data REFERENCE a multi-segment shift?" — and because it
+ * matches the 17 write-side sites, so read and write admission cannot disagree for an org.
+ * A THIRD reading exists and is named rather than silently dropped: conjoin the door with
+ * "the segment calculator has shipped" (`SEGMENT_CALCULATION_IMPLEMENTED`), which would open
+ * it exactly when it produces correct numbers. It is NOT built here; it is the owner's to
+ * weigh.
+ *
+ * MEASURED CONSEQUENCE, disclosed rather than discovered later, and NEITHER BIT AVOIDS IT.
+ * The segment-aware calculator is W4C-1 and has NOT shipped
+ * (`SEGMENT_CALCULATION_IMPLEMENTED === false`), so an `authoritative` org gets the same
+ * envelope semantics a `shadow` one does. Until W4C-1 lands, the legacy calculator downstream
+ * of this door works off the shift's OUTER ENVELOPE. For an enabled org with an
+ * 08:00-12:00 + 13:00-17:00 shift and a full-span attendance, a real approval run PERSISTED
+ * `attendance_records.work_minutes = 540`, while the shift DTO's `plannedMinutes` is 480
+ * (R1: the 60-minute break is never payable time). This is DATA CORRUPTION — a durable wrong
+ * row — not merely a wrong response. The owner's trade is outage versus corruption: a Gate-C
+ * org whose users cannot be calculated at all (the pinned state, while Gate A already lets it
+ * WRITE the reference) versus one whose records overstate worked time until W4C-1 lands. It is
+ * put to the owner in the PR body, not settled here, and deliberately NOT frozen by a test.
+ * Unreachable today: no rollout row exists, so no org resolves anything but `legacy`.
  */
 function assertWorkContextSegmentCalculationAllowed(orgId, workContext, referenceSegments) {
   if (!workContext || workContext.source === 'rule') return

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -8391,8 +8391,18 @@ function getAttendanceGroupFixedScheduleEffectivenessService() {
  *     (`legacy -> shadow -> eligible -> authoritative`) carrying evidence manifests and the
  *     full transition precondition set.
  * `referenceSegments` is chosen because it is the bit that answers what this door actually
- * asks — "may this org's scheduling data REFERENCE a multi-segment shift?" — and because it
- * matches the 17 write-side sites, so read and write admission cannot disagree for an org.
+ * asks — "may this org's scheduling data REFERENCE a multi-segment shift?" — and because it is
+ * the same bit the 17 write-side sites consume, so the two sides read ONE posture value out of
+ * ONE allowlist predicate rather than two that could drift apart in meaning.
+ *
+ * That is emphatically NOT a claim that read and write admission agree. They do not, and by
+ * design: this slice wires the resolved posture into exactly ONE read call site (the approval
+ * path), so for an ENABLED org the other read paths listed on `resolveWorkContext` still fail
+ * closed while its writers are admitted — and `buildShiftCapabilities` still reports
+ * `preview_only` in the shift DTO. The shared thing is the PREDICATE; read-side admission is
+ * deliberately narrower than write-side admission until the remaining call sites get their
+ * lock-order census.
+ *
  * A THIRD reading exists and is named rather than silently dropped: conjoin the door with
  * "the segment calculator has shipped" (`SEGMENT_CALCULATION_IMPLEMENTED`), which would open
  * it exactly when it produces correct numbers. It is NOT built here; it is the owner's to
@@ -8407,8 +8417,9 @@ function getAttendanceGroupFixedScheduleEffectivenessService() {
  * `attendance_records.work_minutes = 540`, while the shift DTO's `plannedMinutes` is 480
  * (R1: the 60-minute break is never payable time). This is DATA CORRUPTION — a durable wrong
  * row — not merely a wrong response. The owner's trade is outage versus corruption: a Gate-C
- * org whose users cannot be calculated at all (the pinned state, while Gate A already lets it
- * WRITE the reference) versus one whose records overstate worked time until W4C-1 lands. It is
+ * org whose users ASSIGNED A MULTI-SEGMENT SHIFT cannot be calculated (the pinned state, while
+ * Gate A already lets it WRITE the reference) versus one whose records overstate worked time
+ * until W4C-1 lands. It is
  * put to the owner in the PR body, not settled here, and deliberately NOT frozen by a test.
  * Unreachable today: no rollout row exists, so no org resolves anything but `legacy`.
  */

--- a/plugins/plugin-attendance/lib/attendance-shift-service.cjs
+++ b/plugins/plugin-attendance/lib/attendance-shift-service.cjs
@@ -505,8 +505,17 @@ function createAttendanceShiftService(deps) {
    * re-deriving posture from the environment. That is byte-identical to the retired
    * env-gate's production behaviour (the plugin master gate was OFF, so this was always
    * `false`). The authoritative reference-writer decision is made by the port, not here;
-   * a shadow/authoritative org's capability hint stays 'preview_only' until the read DTO
-   * is re-sourced from the port in a later slice (tracked residual R4).
+   * a shadow/authoritative org's capability hint stays 'preview_only'.
+   *
+   * STILL PINNED after the residual-R4 slice — deliberately, and adjudicated rather than
+   * forgotten. R4 opened the AUTHORIZATION door
+   * (`index.cjs`, `assertWorkContextSegmentCalculationAllowed`), which refuses writes; this
+   * function is a DISPLAY hint that gates nothing (Gate A adjudication #3: the whole
+   * `SEGMENT_CALCULATION_IMPLEMENTED` family reaches only the read-only W6 effective-policy
+   * aggregate, whose transaction is `SET TRANSACTION READ ONLY`). Making it accurate needs a
+   * posture read on a request-scoped client this synchronous DTO does not have, i.e. a route
+   * change, not a one-line thread-through. Named out of scope, not claimed resolved: an
+   * enabled org sees `preview_only` in the shift DTO while its writers are admitted.
    */
   function buildShiftCapabilities(orgId) {
     const enabled = false


### PR DESCRIPTION
## What this is

The **R4 residual slice** for #4556 Gate A — the follow-ups tracked when #4899 landed (merged `fa45f43f2a`), now owner-approved ("做"). Four coupled deliverables, one PR because items 2–4 are not separable: opening the R4 door is what makes item 4's status leg constructible, and item 2's thread-through is what supplies the value both doors read.

**Draft. Not marked ready, not merged.** Base `origin/main` (fetched after W7-1a / W7-1a-M / D3 landed).

---

## ⚠️ OWNER DECISION — read this before the rest

> **Corrected at `38055447fc` after the independent gate.** An earlier revision of this block rested on a **false** premise — that `authoritative` was unreachable and `authoritativeResults` was therefore a dead door. That was wrong, the gate proved it behaviourally, and the correction changes what the owner is actually choosing between. No code changed; the decision below is now put on true grounds.

Opening the R4 door has a **measured** semantic consequence I am disclosing rather than deciding. It does not block the PR (nothing is reachable today), but it must not be discovered after a Gate C enablement.

### Which posture bit — and what was wrong before

The R4 door is a *calculation* door, but it consumes **`referenceSegments`** (true from `shadow` upward), not **`authoritativeResults`** (true only for `authoritative`). Both exist in the W4 posture table, and the guard's own 422 text reads *"authoritative segment calculation is disabled for this org"* — so `authoritativeResults` is the bit a reviewer would expect.

**`authoritative` IS reachable at this head.** The correction, in three facts:

- `legacy -> shadow` is only the **bootstrap** restriction on creating a *missing* row (`w4c3a-rollout-control.ts`, `canBootstrap`) — and that bootstrap inserts state `'legacy'`. It is not the legality table.
- `LEGAL_TRANSITIONS` (same file) contains **`shadow -> eligible`** and **`eligible -> authoritative`**.
- The one gate that did block promotion — the `W4C3A_ROLLOUT_CONTROL_AUTHORITATIVE_ENTRYPOINT_NOT_DELIVERED` refusal — **stopped firing when #4844** declared both entrypoints delivered (`w4c2-authoritative-delivery.ts`, `DECLARED_DELIVERED`), so the undelivered count is `0`.

The repo's own `attendance-w4c3a-rollout-control.db.test.ts` drives `eligible -> authoritative` and reads back `authoritative`. So this is behavioural, not a reading.

Two downstream claims corrected with it:

- *"the door would stay shut for everyone"* — **false**; it would open for an org promoted to `authoritative`.
- *"item 4's status leg would be unbuildable"* — **overstated**. A direct seed genuinely is refused (`ERROR: W4C0_ROLLOUT: illegal initial rollout state`), so the one-line `insertShadowRolloutRow` helper could not be reused — but the three-step walk works and is already implemented in the rollout-control suite. **Harder, not impossible.**

### So the real question is: which rollout rung opens the wrong-calculation door?

| bit | opens the door at | operator cost to get there |
|---|---|---|
| **`referenceSegments`** (this PR) | **`shadow`** — Gate C step one — and also `eligible` | one bootstrap + one transition |
| `authoritativeResults` | `authoritative` only | a deliberate **three-step** walk `legacy -> shadow -> eligible -> authoritative`, carrying evidence manifests and the full transition precondition set |

`referenceSegments` is chosen because it is the bit that answers what this door actually asks — *"may this org's scheduling data reference a multi-segment shift?"* — and because it is the same bit the 17 write-side sites consume, so both sides read **one posture value out of one allowlist predicate** instead of two that could drift apart in meaning. That is the argument; the earlier "the other bit is a dead door" was not.

**That is not a claim that read and write admission agree — they do not, by design.** This slice wires the resolved posture into exactly **one** read call site (the approval path), so for an enabled org the other read paths still fail closed while its writers are admitted, and `buildShiftCapabilities` still reports `preview_only`. The shared thing is the *predicate*; read-side admission is deliberately **narrower** than write-side until the remaining call sites get their lock-order census.

**A third reading exists and was omitted before — naming it, not recommending it.** The door could be conjoined with *"the segment calculator has shipped"* (`SEGMENT_CALCULATION_IMPLEMENTED`), which would open it exactly when it produces correct numbers and would moot the disclosure below entirely. It is **not built here**; the owner should know it is on the table.

### Neither bit avoids this. Measured on a real approval run, not reasoned:

| | |
|---|---|
| shift | `08:00-12:00` + `13:00-17:00` (multi-segment) |
| shift DTO `plannedMinutes` | **480** — R1: the 60-minute break is never payable time |
| enabled org, full-span `time_correction` final approval | **persists** `attendance_records.work_minutes` = **540** |

`SEGMENT_CALCULATION_IMPLEMENTED === false` — the segment-aware calculator is **W4C-1 and has not shipped** — so the legacy calculator downstream of this door works off the shift's **outer envelope** and counts the inter-segment break as worked time. **An `authoritative` org gets exactly the same 540.** Choosing the higher rung buys deliberation, not correctness.

**State it as corruption, not a wrong answer.** This **persists a wrong row** in `attendance_records`; it does not merely return a wrong response. The trade the owner is being handed is:

- **pinned closed (before this PR)** — every calculation for that user returns a typed 422. Fail-closed, but users **assigned a multi-segment shift** cannot be calculated, and Gate A already lets the org *write* the reference — a self-inflicted **outage**, not a safe state.
- **open on `referenceSegments` (this PR)** — calculation proceeds on envelope semantics until W4C-1 lands, **durably overstating** worked time by the break.

**Reachability today: zero.** No production rollout row exists, so every org resolves `legacy` and the door is shut for all of them. I have **not** frozen `540` in a test — pinning it would read as approving it. It is documented at the door in `index.cjs` and raised here.

### The decision, put explicitly

**If the owner, correctly informed, still picks `referenceSegments` — no code change is needed.** This PR stands as written and the disclosure is the deliverable. If the owner prefers `authoritativeResults`, item 3's one-line bit selection changes and item 4's status leg must be rebuilt on the three-step walk. If the owner prefers the door stay pinned closed, item 3 reverts cleanly and items 1, 2 and the attribution half of 4 stand on their own — item 4's *status* half would then require the `authoritative` walk instead.

---

## Item 1 — case-fold BOTH allowlist predicates (owner-approved ADMISSION WIDENING)

Gate A's **P3-2** flagged that env entries are trimmed but not case-folded while `orgKey` arrives already lower-cased from `parseUuidSyntax` (`w4c0-identity.ts:132`), so an operator who writes the org UUID in upper case gets a silent no-op with no diagnostic.

Both predicates now `.trim().toLowerCase()`:

| predicate | file |
|---|---|
| `isOrgExactlyAllowlisted` (W4 segment calculation) | `packages/core-backend/src/attendance/w4c0-identity.ts` |
| `isOrgExactlyAllowlisted` (W7 context source) | `packages/core-backend/src/attendance/w7-resolver/w7-context-source-posture-resolver.ts` |

**This is documented in-code as a widening, not a fix.** The admitted set grows from `{lower-case spellings}` to `{all ASCII-case spellings}` — a strict superset. It is bounded by construction: `toLowerCase` is a per-character map, so it can only make two strings that differ in ASCII case compare equal. It never shortens an entry and never turns a non-match into a prefix / substring / wildcard match.

The W7 file previously carried an explicit note — *"Not fixed in this slice … Whoever resolves it should resolve it for both, in one change."* That note is now **false**, so it has been rewritten rather than left standing as an asserted invariant that no longer holds. Both predicates are folded in this one change, which is exactly what the note asked for.

### Proofs

New legs in `src/attendance/__tests__/w4c0-identity.test.ts` (**+6**, measured 44 -> 50) and `tests/integration/attendance-w7-1a-resolver.db.test.ts` (**+6**, measured 34 -> 40), each set opening with a **harness control** and containing two **negative controls**:

- upper-case entry now admits the lower-case org key (the widening itself);
- mixed case + whitespace + commas fold together;
- **NEGATIVE CONTROL** — an upper-case entry for a *different* org still denies;
- **NEGATIVE CONTROL** — prefix / suffix / `*` / `' * '` / `.*` / `%` / `DEFAULT` / `''` still admit nothing, with a positive control at the end of the loop so eight denials cannot be a dead harness;
- W4 and W7 fold **identically** yet remain **separate variables** (W4 on alone never advertises W7).

> **A vacuity trap this caught.** The first version of the W4 legs used the file's shared `ORG = '5555…'` fixture — **all-digit hex, so `toUpperCase()` is a no-op** and every leg would have been green for the wrong reason. The `expect(upper).not.toBe(ORG)` precondition failed on the first run. Fixtures are now letter-bearing (`aaaaaaaa-bbbb-4ccc-8ddd-…`) and a dedicated `HARNESS CONTROL` test asserts the fixtures really change under `toUpperCase` — and asserts that the file's shared `ORG` does *not*, so the trap stays documented.

---

## Item 2 — thread the resolved posture into approval finalization

Finalization used to call `resolveReferenceSegmentsPostureForWrite(client, orgId)` **again**, although the W4C-3b boundary had already resolved the posture under the class-`00` rollout SHARED advisory lock before `execute` ran. That second resolve is a redundant lock-take plus `SELECT` for a value that cannot have changed (the shared lock is transaction-scoped and still held) — and it sits **below** the request row lock, which is exactly the ordering the #4899 owner-P1 counterexample forbids.

`referenceSegments` now rides on the boundary context:

- `AttendanceRequestOperationContextV1` gains `referenceSegments: boolean`;
- `attendanceResultOperationPreflightV1` surfaces it on its `claimed` **and** `legacy_no_operation` results (the `replay` return predates the resolve and never calls `execute`);
- all three boundary branches set it: non-canonical org ⇒ `false` (mirroring the port's own `W4C0_ROLLOUT_ORG_KEY_INVALID` answer), null-ID legacy ⇒ `posture.referenceSegments` (read, not hardcoded), main path ⇒ `preflight.referenceSegments`;
- `finalizeShiftSwapRequest` / `finalizeScheduleDispatchRequest` consume it and no longer resolve anything.

Deliberately **not** folded into `VerifiedAttendanceOrgIdentityV1` — that witness is `orgId` + `acceptedWritePosture` only, and changing its shape ripples into `createVerifiedAttendanceOrgIdentityV1` and the rehydration constructors.

The two boundary **test doubles** (`attendance-uuid-validation-routes.test.ts`, `attendance-fixed-schedule-self-route-wiring.test.ts`) were updated to carry the field too, so the double keeps mirroring the real contract.

---

## Item 3 — open the R4 pinned-closed door (PARTIAL, by design)

`assertWorkContextSegmentCalculationAllowed` (`plugins/plugin-attendance/index.cjs`) no longer hardcodes `referenceSegments: false`. It takes the resolved posture from its caller.

**It resolves nothing itself, on purpose.** Two independent reasons, both stated in the code:

1. one of its two callers, `resolveWorkContextFromPrefetch`, is **synchronous and has no client at all** — threading is structurally forced, not a preference;
2. resolving inside `resolveWorkContext` would take the rollout SHARED advisory lock at whatever point each caller happens to run, and several callers pass a real transaction that already holds row locks. That re-creates the owner-P1 wait cycle. Per the #4899 census discipline, a caller may only pass a value it resolved **above** its row locks.

**Wired: exactly one consumer** — the `resolveWorkContext` call inside `executeRequestDecisionInTransaction`. Its value is the *same* boundary-resolved boolean the finalization guards consume, resolved once, above every row lock.

**"One call site" is not "one request type" — stated so it cannot be read as an implication.** That site sits under `if (action === 'approve' && isFinalApproval)`, so it runs for the final approval of **every** request type: leave, overtime, missed_check_in, missed_check_out, time_correction, shift_swap, schedule_dispatch. For an enabled org this slice changes segment-calculation admission for **all** of them. Only `shift_swap` and `schedule_dispatch` have route-level legs here; the other types are admitted by the same door with no leg of their own. (This is deliberately the same shape of claim the Gate A review faulted in #4899's body, so it is spelled out rather than left to inference.)

**Named out of scope, enumerated mechanically** — a grep recipe rather than frozen line numbers, which go stale on the next edit to a 47k-line file:

```
grep -n 'resolveWorkContext(\|resolveWorkContextFromPrefetch(' plugins/plugin-attendance/index.cjs
```

Exactly one of those call sites passes a `referenceSegments:` argument today; every other one still fails closed. Each needs its own lock-order census before it may resolve a posture. **This slice therefore opens the R4 door partially** — owner should push back if all read paths were intended.

### Sibling-door adjudication (asked for explicitly)

A repo-wide sweep for hardcoded-false segment gates found exactly one sibling: **`buildShiftCapabilities`** (`plugins/plugin-attendance/lib/attendance-shift-service.cjs`), `const enabled = false`.

**Adjudication: out of scope, honestly named — not opened.** It is a **display DTO** that gates nothing (Gate A adjudication #3 established that the whole `SEGMENT_CALCULATION_IMPLEMENTED` family reaches only the read-only W6 effective-policy aggregate, whose transaction is `SET TRANSACTION READ ONLY`). Making it accurate needs a posture read on a request-scoped client this synchronous DTO does not have — a route change, not a thread-through. **Consequence stated plainly: an enabled org sees `preview_only` in the shift DTO while its writers are admitted.** Its comment was rewritten so it no longer claims to be waiting on "residual R4".

The only other `referenceSegments: false` occurrences are the two *port-absent ⇒ legacy* fallbacks (`resolveReferenceSegmentsPostureForWrite`, the publication pair), which are fail-closed defaults, not pinned doors.

---

## Item 4 — P2-1 FULL closure

Gate A made this a blocking precondition on exactly this slice.

### A correction to the brief, stated up front

The brief asked for *"a fail-open mutation at that site now flips the OUTCOME (422→2xx)"*. **That is not reproducible, and I am not claiming it.** With the R4 door open, a fail-open at `:32079` still cannot flip status: for a **non-enabled** org the calculation door resolves `false` and refuses anyway, so 422 → 422 with only the attribution changing — which is precisely what the existing attribution leg already pins.

The direction that flips **status** is **fail-CLOSED against an ENABLED org**, and it happens to dominate the review's entire named-undetectable set (`hardcoded-true` aside): *hardcoded-`false`*, *wrong-org posture read*, and *wrong-posture-field* all collapse to a non-`true` boolean at that site.

**Both directions are now covered, by two complementary legs:**

| direction | leg | mechanism |
|---|---|---|
| fail-**open** | existing `P2-1: … attributed to ITS OWN guard` (+ the new org-W leg) | attribution — refusal migrates to `attendance calculation` |
| fail-**closed** | **new** `R4/P2-1 … org A FINALIZES the dispatch` | **status** — 200 → 422 |

### The new leg

Added to `attendance-shift-segments-writer-matrix.db.test.ts` (**already in `plugin-tests.yml:1419`, so no workflow edit and no s6a pin recompute**). Real PG, production approval chain `POST /api/attendance/requests/:id/approve`:

- **org A** — exact env entry + persisted `shadow` row ⇒ both doors admit; **200**, request `approved`, dispatch `published`, `finalized_at` set, **one** assignment row persisted (non-vacuous);
- **org W** — persisted `shadow` row but reachable only via the wildcard `*` ⇒ still **422 + zero writes**, and still attributed to `schedule_dispatch_final_approval`. The wildcard is inert at this route too.

Enablement lands **after** the request is created — the realistic Gate C order, and the reason org A's *create* needs no `operationId` while its *approve* does carry one plus approval OCC (a W4-enabled org's boundary refuses null-ID commands with `W4C0_OPERATION_ID_REQUIRED`).

### The same gap, one producer over — found by measurement, closed

Before writing anything I measured `shift_swap_final_approval`, which this slice also converted to a threaded value. Result: **fail-open reds its matrix leg, fail-closed reddened NOTHING in the entire file.** Identical P2-1 asymmetry. A second enabled-org leg (org S) now closes it on status: 200 + both replacement assignments written, 4 rows total.

### Docblocks rewritten rather than carried forward

- The **deadlock leg**'s docblock named a mutation — *"hoist the approval's posture resolution back below the request row lock"* — that no longer names a site that exists once the in-finalization resolve is gone. It now names the mutation I actually executed at this head: append `FOR UPDATE` to the request-decision adapter's `prepare` `SELECT * FROM attendance_requests …`. Observed: `transition-order connection failed (SQLSTATE 40P01): error: deadlock detected`. **The 40P01-on-reorder proof still holds.**
- The **P2-1 attribution leg**'s docblock claimed a status flip "remains impossible" and that closing P2-1 is a blocking precondition. Both are now stale; rewritten to state the leg's actual post-R4 scope (the fail-open half) and to point at its fail-closed complement.

---

## Byte-neutrality — CONDITIONAL, with the premise stated

**Authorization behaviour is byte-neutral, conditional on this premise: no production `attendance_calculation_rollout_state` row exists.**

- The only repo-wide `INSERT` into that table is `w4c3a-rollout-control.ts:514`, whose bootstrap requires `orgAllowlisted && expectedState === 'legacy' && targetState === 'shadow'` and inserts state `'legacy'` — which admits nothing;
- no migration seeds a row;
- `resolveSegmentCalculationPosture` additionally fails unless `scope === 'synthetic_staging'`.

⇒ every org resolves `legacy` / `referenceSegments: false`, both doors stay closed, and the case-fold widens a set that is currently empty of consequences.

**Not byte-neutral:** per-write DB work is unchanged-to-slightly-lower. Item 2 removes the redundant in-finalization resolve — one advisory-lock take (a no-op re-entry, the shared lock is already held) plus one `SELECT` fewer per shift-swap **or** schedule-dispatch finalization. No path gains DB work.

### Enablement ops step (named env, for verification)

Admitting a single org requires **both**, and neither alone does anything:

1. a persisted row: `attendance_calculation_rollout_state(org_id, state, scope='synthetic_staging')` with a non-`legacy` state, created only through the W4C-5 rollout-control boundary;
2. an exact entry in **`ATTENDANCE_SHIFT_SEGMENT_CALCULATION_ENABLED`** — now case-insensitive; `*` still counts for nothing.

The separate W7 variable is **`ATTENDANCE_W7_CONTEXT_SOURCE_ENABLED`**; W4 being on never advertises W7 (asserted by a test).

---

## Battery

Run from a **non-nested** worktree (`/private/tmp/ms2-r4-run`, `git worktree add --detach`, `pnpm install --frozen-lockfile`) against **one fresh PostgreSQL** created for this slice with CI's exact `MIGRATION_EXCLUDE`, dropped afterwards. Mutation runs used a second virgin DB so no mutation could leave state behind in the battery DB.

| step | result |
|---|---|
| `pnpm type-check` (`tsc --noEmit` + `vue-tsc -b`) | **clean, exit 0** |
| `pnpm lint` | **clean, exit 0** |
| CI attendance integration run-list — **all 111 files, extracted verbatim from `plugin-tests.yml`** | **1571 passed / 3 failed (1582)**, 108/111 files green — 3 adjudicated below |
| `pnpm --filter @metasheet/core-backend exec vitest run` (the CI `Run core-backend tests` step) | **10714 passed / 77 failed (10804)** — A/B'd against base below |
| `node --test scripts/ops/attendance-w4c0-dml-inventory-collector.test.mjs` | **58 pass / 0 fail** — including *"W4C-3c hard zero-bypass: current-tree open-debt set is exactly empty"* ⇒ **unclaimed = 0** |
| `node --test scripts/ops/attendance-w4c2-ci-wiring.test.mjs` | **235 pass / 0 fail** |
| `attendance-shift-segments-writer-matrix.db.test.ts` | **41/41** (38 at base, measured, + 3 new) |
| `attendance-w7-1a-resolver.db.test.ts` | **40/40** (34 at base, measured, + 6 new) |
| `w4c0-identity.test.ts` (unit) | **50/50** (44 at base, measured, + 6 new) |
| `attendance-plugin.test.ts` | **163/163** |
| `attendance-schedule-dispatch.test.ts` | **17/17** |
| `attendance-w4c3b-request-operation-routes` / `-central-approval` / `-request-snapshots` / `-approved-leave-cancellation` | 24 / 16 / 7 / 5 — all green (the boundary I changed) |
| `attendance-w7-1a-inertness-sweep` + the 2 touched boundary doubles | **109/109** |

### The 3 integration failures, adjudicated against base on a virgin DB

| failing test | verdict |
|---|---|
| `attendance-shift-swap.test.ts` × 2 — `expected '2049-06-13' to be '2049-06-14'`, `'2049-06-14' to be '2049-06-15'` | **Pre-existing.** Re-run at base on a virgin DB: identical two tests, identical assertion text. The non-UTC local-timezone date-only artifact Gate A already verified at the true merge base. |
| `attendance-w4c3a-p09-p10-p24-routes.db.test.ts` — `P06: authoritative exactly 5000 commits atomically` | **Environmental, and reproduced at BASE.** Root cause is PostgreSQL `error: out of shared memory` in `acquireKeysWithDeadline` — 5000 advisory locks in one transaction against a local server with `max_locks_per_transaction = 64` and 399 leftover databases. A/B'd, virgin DB each run: `base1` **red**, `head1` **red**, `base2` **green**, `head2` **red**. Non-deterministic in both directions ⇒ not a code signal. This slice adds **zero** advisory locks; it removes two per approval transaction. |
| `attendance-w4c2-sweep-call-through.db.test.ts` | **Same `out of shared memory`**, this time inside the scratch-DB migration its own `beforeAll` runs. Run alone on a virgin DB: **8/8 green at BASE and 8/8 green at HEAD.** |

### The 77 unit-step failures, A/B'd

Base and head were run back to back with identical settings on the same DB:

```
BASE : Test Files 17 failed | 805 passed | 1 skipped (823)   Tests 77 failed | 10708 passed (10798)
HEAD : Test Files 17 failed | 805 passed | 1 skipped (823)   Tests 77 failed | 10714 passed (10804)
```

Same 17 files, same 77 failures; head is `+6 passed` — exactly the six new W4 case-fold unit legs. The 10 `approval-*` files are **byte-identical** between the two failure lists; the 5 `multitable-*` files differ *between runs* (the known shared-DB fixture-collision flake family). **Zero attendance / W4 / W7 files fail in either run.** These are `tests/integration/**` files the default vitest config does not exclude, so they need per-file DB fixtures that a DB already carrying the attendance battery's residue does not provide; CI runs this step against a virgin `metasheet_test`.

### Gate rounds

**Round 2 (final gate on `38055447fc`): APPROVE-with-hardening, 0 P1 / 0 P2** — round-1 findings verified closed, the `DEFAULT` leg proven load-bearing twice, the origin-comment scope call graded the better call. One new P3, fixed at **`37a858dfb6`** (comment-only; every changed line is a docblock line, verified mechanically):

- the docblock claimed choosing `referenceSegments` means *"read and write admission cannot disagree for an org"* — **false**, and contradicted by this PR's own adjacent text. Corrected: the shared thing is the **predicate** (one bit, one allowlist, so the two sides cannot drift apart in *meaning*); read-side admission is deliberately **narrower**, so reads and writes **can** disagree for an enabled org by design. Stated as a design property, not left looking accidental.
- *"users cannot be calculated at all"* narrowed to *"users **assigned a multi-segment shift** cannot be calculated"*.

Both clauses had been carried verbatim into the ⚠️ block above and are corrected there too, in the same round.

Re-verified at `37a858dfb6`: `type-check` + `lint` clean, writer-matrix **41/41**.

### Round 1 (gate on `dc20b32ad0`)

The independent gate on `dc20b32ad0` returned CHANGES-REQUESTED: **1×P1 (text-only), 1×P3, 2×NIT**, with **all 13 mutation results reproduced exactly**, the P2-1 refutation **upheld**, and the case-fold **discharged by a mechanical Unicode sweep** (U+0080–U+2FFFF, `FOLDS-INTO-ALPHABET = []`). No code-behaviour defect. All four are fixed at `38055447fc`, text/test-only:

- **P1** — the ⚠️ block above and the matching `index.cjs` docblock rewritten on true grounds (see the corrected block). Includes the **origin fix**: `w4c0-identity.ts`'s stale *"no transition writer ships in W4C-0"* comment, which manufactured the error, is replaced by a dated erratum. The gate suggested a separate slice; done here instead because this PR already reworks that file and shipping a knowingly-false asserted invariant is the failure mode we gate for.
- **P3** — `'DEFAULT'` moved out of the "structurally inert" negative-control loop into **its own leg**: it folds onto the legal `default` sentinel org key, so it matches the `default` **org**. Predicate unchanged (framing fix); the partial bound is documented at the predicate (`mintOrgWitness` fail-closes the W4C-3b path for `default`, but the direct `resolveReferenceSegmentsPostureForWrite` sites mint no witness). `MF` now reds **5** legs instead of 4 — the new leg is load-bearing.
- **NIT-1** — *"never changes the length of an entry"* is a false absolute (`U+0130` → 2 units). Softened to *"never SHORTENS"*, with the exception named and its inertness stated.
- **NIT-2** — the W7 fold legs' `randomUUID()` harness control (~1.2e-6 all-digit vacuity flake) replaced by fixed letter-bearing fixtures matching the W4 legs, with their own two-sided row cleanup.

**CI at `38055447fc`: all checks green**, both matrix legs included (`test (20.x)` and `test (18.x)` success). Re-verified locally: `type-check` + `lint` clean; `w4c0-identity.test.ts` **51/51** (+1 for the new `DEFAULT` leg); `attendance-w7-1a-resolver` **40/40**; writer-matrix **41/41**. Mutation anchors touching the edited files all still red their own legs — `MF` 5, `MH` 2, `MG` 4, `MB` 1 (org A only). Zero mutation residue; zero control bytes / NULs (NUL scan carries a positive control, since `grep $'\0'` degenerates to an empty pattern).

### CI on the previous head `dc20b32ad0`

**All required checks green**, including both matrix legs:

```
success  test (20.x)          success  test (18.x)          success  pr-validate
success  contracts (strict)   success  contracts (dashboard) success  contracts (openapi)
success  web-tests            success  attendance-web-guard  success  integration-guard
success  stock-prep PowerShell 5.1 acceptance
success  after-sales integration / core-backend-cache / e2e / migration-replay /
         telemetry-plugin / DingTalk P4 ops regression gate / K3 WISE offline PoC
skipped  Strict E2E with Enhanced Gates
```

No workflow file was touched, so `test (20.x)` ran under its unchanged `on.pull_request` trigger (no path filter) — 被触发 and 被验证 are both satisfied here, not assumed.

### Pins

**None required.** `git diff --name-only` is 11 files, **none under `.github/`** — no `plugin-tests.yml` edit, therefore no s6a pin recompute and no rebase race on that file. Both new integration homes are already on the run-list (`plugin-tests.yml:1419` and `:1388`) and the unit legs land in files the `Run core-backend tests` step already discovers. `attendance-w4c2-ci-wiring.test.mjs` (the guard that would catch an unwired test file) passes 235/235.

---

## Mutation record

Every mutation applied by a script that **asserts the anchor string is unique** in the target file and that the file's md5 **actually changed**, then restored by `cp` from a pristine backup — never `git checkout`. Final state verified: impl worktree `git status` empty, and all 11 files md5-identical between the impl and run worktrees (no residue).

Run on a dedicated virgin DB against the final 41-test writer-matrix.

| # | mutation | site | observed |
|---|---|---|---|
| — | *clean baseline* | — | **41 passed (41)** |
| **MA** | `referenceSegments: referenceSegments === true` → `false` | `schedule_dispatch_final_approval` guard | **1 failed / 40 passed** — org A only, `expected 422 to be 200` ⇒ **STATUS flip** |
| **MA2** | delete the `referenceSegments:` key (⇒ `undefined` ⇒ fail-closed) | same | **1 failed / 40 passed** — org A only |
| **MB** | R4 door re-pinned to `referenceSegments: false` | `assertWorkContextSegmentCalculationAllowed` | **1 failed / 40 passed** — org A only ⇒ the leg genuinely holds the R4 door open |
| **MC** | `referenceSegments: preflight.referenceSegments` → `false` | W4C-3b boundary | **2 failed / 39 passed** — org A **and** org S ⇒ the thread-through is load-bearing end-to-end |
| **MD** | fail-**OPEN** `referenceSegments: true` | dispatch guard | **2 failed / 39 passed** — the P2-1 attribution leg **and** the new org-W attribution leg. Status legs unmoved, exactly as predicted |
| **ME** | fail-**CLOSED** at `shift_swap_final_approval` | swap guard | **before the org-S leg existed: 41/41 GREEN** ⇒ the gap, measured. **After: 1 failed / 40 passed** ⇒ closed |
| **ME2** | fail-**OPEN** at `shift_swap_final_approval` | swap guard | **1 failed** — the existing swap matrix leg |
| **M-lock** | append ` FOR UPDATE` to the request-decision `prepare` request SELECT | `index.cjs` | **`transition-order connection failed (SQLSTATE 40P01): error: deadlock detected`** ⇒ the owner-P1 40P01-on-reorder proof still holds at this head |
| **M3** | re-admit `*` in the W4 allowlist | `isOrgExactlyAllowlisted` | **2 failed** — Gate A org W + the new org W (wildcard still inert at both routes) |
| **M4** | allowlist always `false` | same | **8 failed** — incl. Gate A org A, new org A, new org S |
| **MF** | revert the W4 case-fold (`.toLowerCase()` removed) | `w4c0-identity.ts` | **4 failed / 46 passed** — exactly the new W4 fold legs |
| **MG** | revert the W7 case-fold | w7 resolver | **4 failed / 36 passed** — exactly the new W7 fold legs |
| **MH** | fold degenerates into `startsWith` (prefix matching) | `w4c0-identity.ts` | **1 failed / 49 passed** — exactly the `NEGATIVE CONTROL: folding never lets a prefix, suffix, or wildcard entry match` leg |

**Note on MB vs the org-S leg:** re-pinning the R4 door reds the dispatch leg but **not** the shift-swap leg — the swap approval's work context does not resolve to the multi-segment shift on that request's work date. Stated rather than glossed: the org-A dispatch leg is the one that holds the R4 door; the org-S leg holds the swap guard.

---

## One correction to a carried-forward Gate A note

Gate A recorded that `attendance-plugin.test.ts` "cannot serve as a mutation oracle for any `index.cjs` edit" because a semantically-inert NULL control reddened the same 2 tests as the real mutation. **That does not reproduce at this head:** this PR edits `index.cjs` substantially and `attendance-plugin.test.ts` is **163/163 green**, standalone and inside the 111-file battery. The note appears to have been head-scoped to #4899's specific edits; I did not rely on that suite as an oracle either way.

---

## What is NOT in this PR

- The 17 enumerated `resolveWorkContext` / `resolveWorkContextFromPrefetch` call sites — each needs its own lock-order census (item 3).
- `buildShiftCapabilities` — display-only DTO, adjudicated above.
- Any flag flip, rollout row, or enablement. Nothing is turned on.

