### PR TITLE
test(core-backend): drain W4C-3a scratch database

### DIFF
--- a/packages/core-backend/tests/integration/attendance-w4c3a-canonical-import-kernel.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-w4c3a-canonical-import-kernel.db.test.ts
@@ -30,6 +30,12 @@ import { up as addOffStatusUp } from '../../src/db/migrations/zzzz20260731120000
 // by the product. Applying the widening here is what makes the emission leg
 // below a test of the writer instead of a test of a stale schema.
 import { up as w7ProvenanceWideningUp } from '../../src/db/migrations/zzzz20260815120000_w7_1am_provenance_domain_widening'
+import {
+  attachOwnedPoolTerminationHandler,
+  dropScratchDatabase,
+  formatScratchDropFailure,
+  formatScratchDropOutcome,
+} from '../helpers/scratch-database'
 
 const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
 const describeIfDatabase = dbUrl ? describe : describe.skip
@@ -480,11 +486,45 @@ describeIfDatabase('W4C-3a canonical import kernel (real PostgreSQL)', () => {
   }, 90000)
 
   afterAll(async () => {
-    await db?.destroy()
-    await pool?.end()
-    await adminPool?.query(`DROP DATABASE IF EXISTS ${scratchName} WITH (FORCE)`).catch(() => undefined)
-    await adminPool?.end()
-  })
+    // #4820 recurrence: this suite owns both pools connected to the scratch database. Keep the
+    // exact administrator-termination handler scoped to teardown, then revoke new connections
+    // and drain before DROP instead of unconditionally killing idle clients with FORCE.
+    const teardownHandlers = [migrationPool, pool]
+      .filter((p): p is Pool => Boolean(p))
+      .map((p) => attachOwnedPoolTerminationHandler(p))
+    let closeError: unknown
+    let dropError: unknown
+    try {
+      try {
+        await db?.destroy()
+      } catch (error) {
+        closeError = error
+      }
+      try {
+        await pool?.end()
+      } catch (error) {
+        closeError ??= error
+      }
+      if (adminPool) {
+        try {
+          const outcome = await dropScratchDatabase(adminPool, scratchName)
+          console.log(formatScratchDropOutcome('w4c3a-canonical-import', outcome))
+        } catch (error) {
+          dropError = error
+          console.log(formatScratchDropFailure('w4c3a-canonical-import', error))
+        }
+      }
+    } finally {
+      try {
+        await adminPool?.end()
+      } catch (error) {
+        closeError ??= error
+      }
+      for (const handler of teardownHandlers) handler.detach()
+    }
+    if (closeError) throw closeError
+    if (dropError) throw dropError
+  }, 60000)
 
   async function execute(input: ReturnType<typeof fixture>): Promise<void> {
     const client = await pool.connect()

--- a/packages/core-backend/tests/integration/scratch-database-drain.db.test.ts
+++ b/packages/core-backend/tests/integration/scratch-database-drain.db.test.ts
@@ -472,6 +472,39 @@ describeIfDatabase('#4791 scratch-database teardown drain', () => {
         expect(src, file).toMatch(/if \(poolCaptureError\) throw poolCaptureError/)
       }
     })
+
+    it('source contract: W4C-3a canonical import drains both owned pools before dropping scratch DB', () => {
+      const dir = dirname(fileURLToPath(import.meta.url))
+      const src = readFileSync(join(dir, 'attendance-w4c3a-canonical-import-kernel.db.test.ts'), 'utf8')
+      const teardownAt = src.indexOf('// #4820 recurrence:')
+      const teardownEnd = src.indexOf('\n  }, 60000)', teardownAt)
+
+      expect(teardownAt).toBeGreaterThan(-1)
+      expect(teardownEnd).toBeGreaterThan(teardownAt)
+
+      const teardown = src.slice(teardownAt, teardownEnd)
+      const migrationCloseAt = teardown.indexOf('await db?.destroy()')
+      const poolCloseAt = teardown.indexOf('await pool?.end()')
+      const helperAt = teardown.indexOf('dropScratchDatabase(adminPool, scratchName)')
+      const adminCloseAt = teardown.indexOf('await adminPool?.end()')
+      const detachAt = teardown.indexOf('for (const handler of teardownHandlers) handler.detach()')
+      const closeRethrowAt = teardown.indexOf('if (closeError) throw closeError')
+      const dropRethrowAt = teardown.indexOf('if (dropError) throw dropError')
+
+      expect(teardown).toMatch(
+        /const teardownHandlers = \[migrationPool, pool\]\s*\.filter\([\s\S]*?\.map\(\(p\) => attachOwnedPoolTerminationHandler\(p\)\)/,
+      )
+      expect(migrationCloseAt).toBeGreaterThan(-1)
+      expect(poolCloseAt).toBeGreaterThan(migrationCloseAt)
+      expect(helperAt).toBeGreaterThan(poolCloseAt)
+      expect(teardown).toMatch(/formatScratchDropOutcome\('w4c3a-canonical-import'/)
+      expect(teardown).toMatch(/formatScratchDropFailure\('w4c3a-canonical-import'/)
+      expect(adminCloseAt).toBeGreaterThan(helperAt)
+      expect(detachAt).toBeGreaterThan(adminCloseAt)
+      expect(closeRethrowAt).toBeGreaterThan(detachAt)
+      expect(dropRethrowAt).toBeGreaterThan(closeRethrowAt)
+      expect(teardown).not.toMatch(/WITH\s*\(FORCE\)/i)
+    })
   })
 
   // ==============================================================================================


### PR DESCRIPTION
## Summary

- replace the W4C-3a canonical-import suite's unconditional `DROP DATABASE ... WITH (FORCE)` with the shared scratch-database drain helper
- close both scratch-owned pools before drop and keep the exact `57P01` teardown handler attached until the admin pool is closed
- add a source contract that pins the dual-pool close/drop/detach/rethrow ordering

## Why

Issue #4820 recurred on PR #4890 exact head `3a7b58aa2946658ba366291f0556f60a811300d6`: Node 20 completed all 116 files / 1622 tests, then emitted an unhandled PostgreSQL `57P01` for `ms2_w4c3a_kernel_*`. The W4C-3a suite still force-dropped its scratch database directly and did not use the drain helper introduced by #4852.

Failed run: https://github.com/zensgit/metasheet2/actions/runs/31932604155/job/95129603515

## Verification

- real PostgreSQL: 2 files, 25/25 tests pass
- teardown evidence: `scratchDrain=CLEAN suite=w4c3a-canonical-import ... residualBackends=0`
- `pnpm --filter @metasheet/core-backend exec tsc --noEmit`
- mutation: replacing `await db?.destroy()` makes the named W4C-3a source contract fail at `migrationCloseAt`; restoring it returns green
- independent Grok review: 0 bugs, 1 source-contract suggestion; the suggestion was absorbed by pinning the executable teardown sequence and narrowing the FORCE ban to that block

## Scope

- test infrastructure only; no product/runtime or staging configuration changes
- Draft and unarmed; this PR does not enable Stream or any lifecycle flag

Issue #4820 remains open until exact-head CI and merge verification complete.
