### PR TITLE
fix(ops): soak-seed W4-walk label/artifact misattribution + soak-run backend-log slice (#4556 soak)

### DIFF
--- a/scripts/ops/attendance-staging-window-runner-remote.sh
+++ b/scripts/ops/attendance-staging-window-runner-remote.sh
@@ -1487,7 +1487,19 @@ soak_seed_report_org() {
 soak_w4_walk_to_shadow() {
   # Walk ONE org's W4 rollout posture legacy->shadow through the REAL Gate C CLI
   # (plan -> fresh manifest -> apply). Idempotent: an org already at/past shadow is skipped.
-  local org="$1" org8="${org:0:8}"
+  #
+  # TWO STATEMENTS, NOT ONE — load-bearing, proven by real dispatch 31953379181: bash
+  # expands EVERY word of a `local` simple command BEFORE the builtin performs any
+  # assignment, so in `local org="$1" org8="${org:0:8}"` the `${org:0:8}` reads the
+  # CALLER's `org` — which in action_soak_seed is the seeding loop's local, left at ORG3
+  # after the loop. In that dispatch the CLI target/DB reads (`$org`) were correct (both
+  # rollout rows landed), but org2's label, plan/apply/manifest artifact FILENAMES, and
+  # the manifest's syntheticOrgRef suffix (all `$org8`) said org3 — org2's walk evidence
+  # was overwritten and misattributed. Splitting the statements makes `${org:0:8}` expand
+  # AFTER the local `org` is assigned. Pinned by the pipeline test (source shape + an
+  # executable bash leg reproducing the expansion order + a rejoin mutation leg).
+  local org="$1"
+  local org8="${org:0:8}"
   local state
   state="$(soak_psql_ta "SELECT COALESCE((SELECT state FROM attendance_calculation_rollout_state WHERE org_id = '${org}'), 'absent');")"
   case "$state" in
@@ -2054,6 +2066,14 @@ PY
   [[ "${pipe_status[1]}" == "0" ]] || fail "tee failed writing soak-run.log (rc=${pipe_status[1]})"
   docker cp "${BACKEND_CONTAINER}:${CONTAINER_RUNNER_DIR}/soak-run-summary.json" \
     "${OUTPUT_DIR}/soak-run-summary.json" 2>/dev/null || true
+  # Filtered backend-log slice, ALWAYS captured (same filtered_pipe contract as
+  # action_smoke): dispatch 31953571638 produced five INTERNAL_ERROR punch 500s on the
+  # W4-shadow org with zero artifact-side server evidence — the HTTP body says only
+  # "Failed to punch attendance", so without this slice a server-side punch failure is
+  # undiagnosable from the run's own artifact.
+  filtered_pipe "${OUTPUT_DIR}/soak-run-backend-log-slice.log" \
+    'attendance|punch|calculation|shadow|segment|boundary|error|Error' \
+    -- docker logs --since 30m "$BACKEND_CONTAINER"
   cleanup_soak_run
   trap - EXIT
   [[ "$gen_rc" == "0" ]] || fail "soak load generator exited rc=${gen_rc} (see soak-run.log)"

--- a/scripts/ops/attendance-window-runner-pipeline.test.mjs
+++ b/scripts/ops/attendance-window-runner-pipeline.test.mjs
@@ -683,6 +683,30 @@ function assertSoakContract({ remote, workflow }) {
     'seed must refuse W7 targets beyond group_shadow (compare-window exit predicates need real soak evidence)',
   )
   assert.match(slices.seed, /suspended\)\s*\n\s*fail/, 'seed must fail closed on a suspended posture, never resume it')
+  // Per-org walk identity (real-dispatch 31953379181 defect): every word of a `local`
+  // simple command expands BEFORE the builtin assigns, so `local org="$1" org8="${org:0:8}"`
+  // derived org8 from the CALLER's `org` (the seeding loop's local, left at org3) — org2's
+  // walk ran against the right org but its label, artifact filenames, and the manifest's
+  // syntheticOrgRef suffix all said org3, and org2's plan/apply JSONs were overwritten.
+  // Pin the fixed two-statement shape and forbid the rejoined form.
+  assert.ok(
+    slices.seed.includes('  local org="$1"\n  local org8="${org:0:8}"'),
+    'the W4 walk must assign `org` and derive `org8` in TWO separate local statements (same-statement self-reference reads the CALLERʼs org — dispatch 31953379181)',
+  )
+  assert.doesNotMatch(
+    slices.seed,
+    // Statement-anchored (multiline): the fix's own explanatory COMMENT legitimately quotes
+    // the buggy spelling; only a real `local ...` statement at line start may not.
+    /^\s*local org="\$1" org8=/m,
+    'the W4 walk must never rejoin org/org8 into one local statement (org8 would expand against the callerʼs org)',
+  )
+  // ...and every CLI walk invocation must target the function-local loop arg, never a
+  // SOAK_ORG* literal reached past it.
+  assert.doesNotMatch(
+    slices.seed,
+    /--org "\$SOAK_ORG/,
+    'walk CLI invocations must use the function-local $org, never a SOAK_ORG* literal',
+  )
 
   // soak-flags: baseline-marker order gate BEFORE the override write; atomic
   // candidate->validate->rename via the SAME persistent override; backend-only recreate
@@ -796,6 +820,18 @@ function assertSoakContract({ remote, workflow }) {
   )
   assert.ok(slices.run.includes('cleanup_soak_run'), 'soak-run must delete the token-bearing temp config (trap cleanup)')
   assert.ok(slices.run.includes('max_consecutive_incidents'), 'soak-run must fail on the consecutive-incident halt (alert-class)')
+  // Dispatch 31953571638: five punch 500s with zero server-side evidence in the artifact —
+  // the backend-log slice (same filtered_pipe contract as action_smoke) is what makes a
+  // server-side punch failure diagnosable from the runʼs own artifact.
+  assert.ok(
+    slices.run.includes('soak-run-backend-log-slice.log'),
+    'soak-run must capture a filtered backend-log slice into the artifact',
+  )
+  assert.match(
+    slices.run,
+    /filtered_pipe "\$\{OUTPUT_DIR\}\/soak-run-backend-log-slice\.log"/,
+    'the backend-log slice must go through filtered_pipe (producer failure must fail the step; zero matches must not)',
+  )
   assert.ok(slices.run.includes('haltedReason is LOAD-BEARING'), 'soak-run must surface haltedReason semantics in its summary')
 
   // soak-status: the monitoring-pack Q-series labels must all be present, plus the W7-2
@@ -889,6 +925,44 @@ test('MUTATION: dropping the generator execute-confirmation from soak-run turns 
   assert.throws(
     () => assertSoakContract({ remote: mutated, workflow: readFileSync(WORKFLOW, 'utf8') }),
     /execute confirmation token/,
+  )
+})
+
+test('EXECUTABLE: bash expands a whole `local` statement before assigning — the org2-walk misattribution class (dispatch 31953379181) — and the split form fixes it', () => {
+  // Runs REAL bash (the same invocation shape as the workflow's remote command), not a
+  // paraphrase: the JOINED form must leak the callerʼs `org` into org8 (the defect — this
+  // half is the positive control proving the probe discriminates), and the SPLIT form the
+  // remote script now uses must derive org8 from the function argument.
+  const probe = [
+    'set -euo pipefail',
+    'joined() { local org="$1" org8="${org:0:8}"; echo "joined=$org8"; }',
+    'split() { local org="$1"; local org8="${org:0:8}"; echo "split=$org8"; }',
+    'caller() { local org="33333333-caller-org"; joined "22222222-arg-org"; split "22222222-arg-org"; }',
+    'caller',
+  ].join('\n')
+  const result = runPipefailBash(probe)
+  assert.equal(result.status, 0, `probe must run; stderr: ${result.stderr}`)
+  assert.match(
+    result.stdout,
+    /joined=33333333/,
+    'positive control: the joined form must expand org8 against the CALLERʼs org (the defect) — if this stops leaking, bash semantics changed and the pin should be re-examined',
+  )
+  assert.match(
+    result.stdout,
+    /split=22222222/,
+    'the split form (what the remote script uses) must derive org8 from the function argument',
+  )
+})
+
+test('MUTATION: rejoining the W4 walkʼs org/org8 into one local statement turns the soak contract red', () => {
+  const original = readFileSync(REMOTE_SH, 'utf8')
+  const fixed = '  local org="$1"\n  local org8="${org:0:8}"'
+  assert.ok(original.includes(fixed), 'mutation anchor must hit the fixed split shape')
+  const mutated = original.replace(fixed, '  local org="$1" org8="${org:0:8}"')
+  assert.notEqual(mutated, original, 'mutation must change the file')
+  assert.throws(
+    () => assertSoakContract({ remote: mutated, workflow: readFileSync(WORKFLOW, 'utf8') }),
+    /TWO separate local statements|never rejoin org\/org8/,
   )
 })
 


### PR DESCRIPTION
## What this fixes

First real soak dispatch (seed 31953379181 → run 31953571638 → status 31953784052) exposed one seed-script defect. Reproduced from the artifacts before fixing — and the evidence chain **corrects the initial reading**:

### The actual defect (evidence-side misattribution, not a skipped walk)

`soak-seed-posture.txt` shows `w4_3f62c6e4=transitioned_shadow` TWICE (correlations `af67e315…`, `27715216…`) and no `w4_853b767f` line; only one `w4-apply-3f62c6e4.json` exists. But the DB ground truth (soak-status "posture rows" section) shows **BOTH** rollout rows landed: org2 `853b767f…` = `shadow` v2 `prior legacy` AND org3 `3f62c6e4…` = `shadow` v2. **Org2's walk DID apply, against the right org, through the real Gate C boundary.**

Mechanism, empirically verified: bash expands **every word of a `local` simple command before the builtin performs any assignment**, so in `local org="$1" org8="${org:0:8}"` the `${org:0:8}` reads the **caller's** `org` — `action_soak_seed`'s seeding-loop local, left at **org3** after the loop. `$org` (CLI `--org`, all DB reads/writes, manifest `orgId`) was correct both times; `$org8` (log/posture labels, plan/apply/manifest **filenames**, the W4 manifest's `syntheticOrgRef` suffix) said org3 both times. Consequences: org2's walk evidence was overwritten by org3's and misattributed, and — disclosure — **org2's rollout event on staging carries an evidence manifest whose `syntheticOrgRef` names org3's prefix** (`synthetic-staging-org-3f62c6e4`); the transition itself and its `orgId` are correct, synthetic scope only, but the evidence-ledger blemish should be known to the owner.

**Fix:** split into two `local` statements (statement 2 expands after statement 1 assigns). Idiom sweep over the whole script: no other self-referencing multi-assignment `local` (the two others reference positional params only).

### Test legs (pipeline suite 41 → 43, all green)

- Source pin: the walk must declare `org` and derive `org8` in **two separate** `local` statements (statement-anchored — the fix's own comment legitimately quotes the buggy spelling); walk CLI invocations must never say `--org "$SOAK_ORG*"`.
- **Executable leg**: runs real bash under the workflow's invocation shape — the joined form must leak the caller's value into `org8` (positive control proving the probe discriminates; also re-detects if bash semantics ever change) and the split form must derive from the argument.
- Mutation leg: rejoining the two statements reds the contract.

### org1-vs-org2 divergence — mechanism, and a server-side finding

Seeded shapes are **byte-uniform** (seed report: all three orgs identically got 10 users/perms/user_orgs, 1 shift+segment, 1 group, 1 FSC, 10 members, 10 published group-produced assignments, 10 calc-group memberships — `legacy_only` skips **nothing**). The only difference at punch time is the posture row: org1 = W4-allowlisted + **no rollout row** (legacy arm) → **10/10 HTTP-clean**; org2 = W4-allowlisted + **`shadow` rollout row** → **5/5 punch 500s** (`INTERNAL_ERROR "Failed to punch attendance"`), with **zero** `attendance_records`/`attendance_record_calculations` rows (Q11/Q12 = 0 rows) — the failure precedes any persistence. org3 (also shadow + W7 `group_shadow`) was **never reached** (round-robin pool order; the halt fired inside org2's block).

**So the hazard is NOT "allowlisted + membership + no rollout row" — that exact combination (org1) punched clean. The candidate hazard is: W4-allowlisted org at `shadow` posture → every live punch 500s on the deployed image (`815bd1a844`).** That is the state every org enters on Soak-Day 1 of the ladder, so if it reproduces it is a **server-side finding warranting its own issue**, not a seed-script matter. Honest limits: root cause is not diagnosable from the run's own artifact (the HTTP body is generic and soak-run captured no server logs — fixed below), staging-env-specific causes are not excluded, and n=5 punches on one org. Recommended next: re-dispatch soak-seed (idempotent; also repairs org2's artifact record) + soak-run — the new backend-log slice will carry the stack for the 500 if it reproduces.

Also worth recording from this run: `[Q1] clean_punch_total = 0` despite org1's 10 HTTP-clean punches — legacy-arm punches write no result-operation/calculation rows, so the §2A.2 clean-punch counter counts **W4-postured orgs only**, by construction of the ruled predicate. Expected, not a defect; stated so the ledger reader does not chase it.

### Also in this PR

`soak-run` now always captures a **filtered backend-log slice** into the artifact (same `filtered_pipe` contract as `action_smoke` — producer failure fails the step, zero matches does not), so the next 500 is diagnosable from the run itself. Pinned by two new contract assertions.

## Verification (head of this PR)

- Pipeline self-test **43/43** (2 new tests + 5 new contract assertions; rejoin mutation red-proven).
- `bash -n` clean; DML census (CI-exact, pinned-ref fetch) **58/58**; control-byte scan clean; `plugin-tests.yml` untouched (`41d2eb71…`).
- **No server code changes** (diff = remote script + pipeline test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
