### PR TITLE
fix(ops): soak cadence — one pair per user per day (retire session packing AND the backdate ladder); diff-family pins

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -1465,6 +1465,7 @@ jobs:
             tests/integration/attendance-w7-2-compare-window-status.db.test.ts \
             tests/integration/attendance-w7-2-group-shadow-dualrun.db.test.ts \
             tests/integration/attendance-w7-4-read-side-labeling.db.test.ts \
+            tests/integration/attendance-soak-diff-families.db.test.ts \
             tests/integration/scratch-database-drain.db.test.ts \
             --reporter=dot
 

--- a/packages/core-backend/tests/integration/attendance-soak-diff-families.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-soak-diff-families.db.test.ts
@@ -9,12 +9,12 @@
  *  BOTH machines compute the same values and the next calc row is `equal`. Leg A pins the
  *  full lifecycle: v1 = late_minutes_mismatch (delta = the real late minutes), v2 = equal.
  *
- *  Family B — the PAIR-LADDER fixture contract: one check_in at the segment start
- *  (00:00:00 wall) + one check_out at the segment end (23:59:00 wall) on a BACKDATED work
- *  date produces `equal` on EVERY calc row and a legacy `normal` day — which is why the
- *  soak load generator's healthy diff surface is all-equal and any non-equal row is signal.
- *  (The generator's retired server-clock cadence packed pairs into one work date and
- *  flooded §4.2-critical review_required diffs; see the generator header.)
+ *  Family B — the SINGLE-DAILY-PAIR contract (the soak generator's 2/user/day cadence):
+ *  exactly one check_in + one check_out on a work date — here at the segment boundaries
+ *  (00:00:00 / 23:59:00 wall), the zero-anomaly ideal — produces `equal` on every calc row
+ *  and a legacy `normal` day. One pair per (user, work date) is the load shape whose
+ *  healthy diff surface is all-equal; extra same-day sessions are what flooded
+ *  §4.2-critical review_required diffs (soak-status 31962440160; see the generator header).
  *
  * Shared-DB discipline: every fixture id is a file-namespaced random UUID.
  */
@@ -69,7 +69,7 @@ function requestJson(
   })
 }
 
-describeDb('#4556 soak shadow-diff families — transient partial-day mismatch + pair-ladder all-equal (org2 shape)', () => {
+describeDb('#4556 soak shadow-diff families — transient partial-day mismatch + single-daily-pair all-equal (org2 shape)', () => {
   let server: MetaSheetServer | undefined
   let pool: Pool
   let baseUrl = ''
@@ -78,7 +78,7 @@ describeDb('#4556 soak shadow-diff families — transient partial-day mismatch +
 
   const org = randomUUID()
   const userA = randomUUID() // Family A — transient partial-day lifecycle
-  const userB = randomUUID() // Family B — pair-ladder all-equal contract
+  const userB = randomUUID() // Family B — single-daily-pair all-equal contract
   const shift = randomUUID()
   const group = randomUUID()
   const TZ = 'Asia/Shanghai'
@@ -229,7 +229,9 @@ describeDb('#4556 soak shadow-diff families — transient partial-day mismatch +
         Authorization: `Bearer ${await mintToken(userId)}`,
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify({ orgId: org, eventType, timezone: TZ, operationId: randomUUID(), occurredAt }),
+      // timezone deliberately OMITTED from the body — mirrors the soak generator (sent only
+      // when config-explicit); the org rule's own timezone governs work-date attribution.
+      body: JSON.stringify({ orgId: org, eventType, operationId: randomUUID(), occurredAt }),
     })
 
   const calcsFor = async (userId: string) =>
@@ -268,7 +270,7 @@ describeDb('#4556 soak shadow-diff families — transient partial-day mismatch +
     expect(rec.rows[0].late_minutes).toBe(90)
   })
 
-  it('Family B: a pair-ladder pair (00:00:00 in, 23:59:00 out, backdated) is equal on every calc row and a normal legacy day', async () => {
+  it('Family B: a single daily pair (00:00:00 in, 23:59:00 out) is equal on every calc row and a normal legacy day', async () => {
     // 2026-08-11T16:00:00Z == 2026-08-12 00:00:00 +08; 2026-08-12T15:59:00Z == 23:59:00 +08.
     const rIn = await punch(userB, 'check_in', '2026-08-11T16:00:00.000Z')
     const rOut = await punch(userB, 'check_out', '2026-08-12T15:59:00.000Z')

--- a/packages/core-backend/tests/integration/attendance-soak-diff-families.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-soak-diff-families.db.test.ts
@@ -1,0 +1,293 @@
+/**
+ * #4556 combined-soak shadow-diff FAMILY pins (real host, real DB) — the mechanical
+ * statement of what staging soak-status 31962440160 counted, built while dispositioning it:
+ *
+ *  Family A — `late_minutes_mismatch` is a TRANSIENT PARTIAL-DAY difference, not a
+ *  calculation divergence: legacy `computeMetrics` returns {status:'partial', lateMinutes:0}
+ *  while a day has only a check_in (plugins/plugin-attendance/index.cjs ~L11961), whereas
+ *  the W4 calculator reports the late minutes immediately; the moment the check_out lands,
+ *  BOTH machines compute the same values and the next calc row is `equal`. Leg A pins the
+ *  full lifecycle: v1 = late_minutes_mismatch (delta = the real late minutes), v2 = equal.
+ *
+ *  Family B — the PAIR-LADDER fixture contract: one check_in at the segment start
+ *  (00:00:00 wall) + one check_out at the segment end (23:59:00 wall) on a BACKDATED work
+ *  date produces `equal` on EVERY calc row and a legacy `normal` day — which is why the
+ *  soak load generator's healthy diff surface is all-equal and any non-equal row is signal.
+ *  (The generator's retired server-clock cadence packed pairs into one work date and
+ *  flooded §4.2-critical review_required diffs; see the generator header.)
+ *
+ * Shared-DB discipline: every fixture id is a file-namespaced random UUID.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import * as path from 'node:path'
+import net from 'net'
+import http from 'http'
+import { fileURLToPath } from 'node:url'
+import { randomUUID } from 'crypto'
+import { Pool } from 'pg'
+import { createRequire } from 'module'
+import type { MetaSheetServer } from '../../src/index'
+
+const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
+const describeDb = dbUrl ? describe : describe.skip
+const W4_ENV = 'ATTENDANCE_SHIFT_SEGMENT_CALCULATION_ENABLED'
+const W7_ENV = 'ATTENDANCE_W7_CONTEXT_SOURCE_ENABLED'
+const HERE = path.dirname(fileURLToPath(import.meta.url))
+const requireCjs = createRequire(import.meta.url)
+const { buildAttendanceGroupFixedScheduleProducerKey } = requireCjs(
+  '../../../../plugins/plugin-attendance/lib/attendance-group-fixed-schedule-producer-key.cjs',
+)
+
+type HttpResponse = { status: number; body?: any; raw: string }
+function requestJson(
+  url: string,
+  options: { method?: string; headers?: Record<string, string>; body?: string } = {},
+): Promise<HttpResponse> {
+  return new Promise((resolve, reject) => {
+    const target = new URL(url)
+    const req = http.request(
+      {
+        method: options.method || 'GET',
+        hostname: target.hostname,
+        port: target.port,
+        path: `${target.pathname}${target.search}`,
+        headers: options.headers,
+      },
+      (res) => {
+        let data = ''
+        res.on('data', (c) => { data += c })
+        res.on('end', () => {
+          let body: unknown
+          try { body = data ? JSON.parse(data) : undefined } catch { body = undefined }
+          resolve({ status: res.statusCode || 0, body, raw: data })
+        })
+      },
+    )
+    req.on('error', reject)
+    if (options.body) req.write(options.body)
+    req.end()
+  })
+}
+
+describeDb('#4556 soak shadow-diff families — transient partial-day mismatch + pair-ladder all-equal (org2 shape)', () => {
+  let server: MetaSheetServer | undefined
+  let pool: Pool
+  let baseUrl = ''
+  let priorW4: string | undefined
+  let priorW7: string | undefined
+
+  const org = randomUUID()
+  const userA = randomUUID() // Family A — transient partial-day lifecycle
+  const userB = randomUUID() // Family B — pair-ladder all-equal contract
+  const shift = randomUUID()
+  const group = randomUUID()
+  const TZ = 'Asia/Shanghai'
+
+  const mintToken = async (userId: string): Promise<string> => {
+    const res = await requestJson(
+      `${baseUrl}/api/auth/dev-token?userId=${encodeURIComponent(userId)}&roles=admin&perms=${encodeURIComponent('attendance:read,attendance:write,attendance:admin')}`,
+    )
+    return (res.body as { token?: string } | undefined)?.token ?? ''
+  }
+
+  async function insertActiveUser(userId: string): Promise<void> {
+    await pool.query(
+      `INSERT INTO users (id, email, username, name, password_hash, role, permissions, is_active, is_admin, created_at, updated_at)
+       VALUES ($1, $2, $1, 'soak diff-family fixture', 'x', 'user', '[]'::jsonb, true, false, now(), now())
+       ON CONFLICT (id) DO NOTHING`,
+      [userId, `${userId}@soak-diff-families.test`],
+    )
+    await pool.query(
+      `INSERT INTO user_orgs (user_id, org_id, is_active) VALUES ($1, $2, true) ON CONFLICT DO NOTHING`,
+      [userId, org],
+    )
+  }
+
+  beforeAll(async () => {
+    const canListen: boolean = await new Promise((resolve) => {
+      const s = net.createServer()
+      s.once('error', () => resolve(false))
+      s.listen(0, '127.0.0.1', () => s.close(() => resolve(true)))
+    })
+    if (!canListen || !dbUrl) throw new Error('suite needs loopback + DATABASE_URL')
+    priorW4 = process.env[W4_ENV]
+    priorW7 = process.env[W7_ENV]
+    process.env.DATABASE_URL = dbUrl
+    process.env.RBAC_BYPASS = 'true'
+    process.env.SKIP_PLUGINS = 'false'
+    process.env[W4_ENV] = org.toLowerCase()
+    delete process.env[W7_ENV]
+
+    const repoRoot = path.join(HERE, '../../../../')
+    const { MetaSheetServer: Server } = await import('../../src/index')
+    server = new Server({
+      port: 0,
+      host: '127.0.0.1',
+      pluginDirs: [path.join(repoRoot, 'plugins', 'plugin-attendance')],
+    })
+    await server.start()
+    const address = server.getAddress()
+    if (!address || typeof address === 'string') throw new Error('no TCP address')
+    baseUrl = `http://127.0.0.1:${address.port}`
+    pool = new Pool({ connectionString: dbUrl })
+
+    await insertActiveUser(userA)
+    await insertActiveUser(userB)
+    // W4 rollout: legacy -> shadow (the soak's org2 shape; NOT authoritative).
+    await pool.query(
+      `INSERT INTO attendance_calculation_rollout_state (org_id, state, engine_version, reason_code, actor_id, version, prior_state)
+       VALUES ($1, 'legacy', 'soak-diff-families', 'TEST_FIXTURE', 'soak-diff-actor', 1, NULL)`,
+      [org],
+    )
+    await pool.query(
+      `UPDATE attendance_calculation_rollout_state SET state = 'shadow', prior_state = 'legacy', version = 2 WHERE org_id = $1`,
+      [org],
+    )
+    // The soak seeder's exact shapes: full-day 00:00-23:59 Asia/Shanghai, grace 5/5,
+    // rounding 15, strict; group-produced published assignments for both users.
+    await pool.query(
+      `INSERT INTO attendance_shifts
+         (id, org_id, name, timezone, work_start_time, work_end_time, is_overnight, working_days,
+          late_grace_minutes, early_grace_minutes, rounding_minutes, flex_mode)
+       VALUES ($1, $2, $3, $4, '00:00', '23:59', false, '[0,1,2,3,4,5,6]'::jsonb, 5, 5, 15, 'strict')`,
+      [shift, org, `soak-diff-families ${shift}`, TZ],
+    )
+    await pool.query(
+      `INSERT INTO attendance_shift_segments
+         (id, org_id, shift_id, segment_index, start_time, end_time, start_day_offset, end_day_offset)
+       VALUES ($1, $2, $3, 0, '00:00', '23:59', 0, 0)`,
+      [randomUUID(), org, shift],
+    )
+    await pool.query(
+      `INSERT INTO attendance_groups (id, org_id, name, attendance_type, timezone)
+       VALUES ($1, $2, $3, 'fixed_shift', $4)`,
+      [group, org, `soak-diff-families group ${group}`, TZ],
+    )
+    await pool.query(
+      `INSERT INTO attendance_group_fixed_schedule_configs
+         (org_id, group_id, shift_id, start_date, end_date, revision, updated_by)
+       VALUES ($1, $2, $3, '2026-01-01', '2027-12-31', 1, 'soak-diff-families')`,
+      [org, group, shift],
+    )
+    const producerKey = buildAttendanceGroupFixedScheduleProducerKey({
+      groupId: group, shiftId: shift, startDate: '2026-01-01', endDate: '2027-12-31',
+    })
+    for (const userId of [userA, userB]) {
+      await pool.query(
+        `INSERT INTO attendance_group_members (org_id, group_id, user_id) VALUES ($1, $2, $3)`,
+        [org, group, userId],
+      )
+      await pool.query(
+        `INSERT INTO attendance_shift_assignments
+           (org_id, user_id, shift_id, start_date, end_date, is_active,
+            producer_type, producer_ref_id, producer_key, producer_run_id, publish_status)
+         VALUES ($1, $2, $3, '2026-01-01', '2027-12-31', true,
+                 'attendance_group_fixed_schedule', $4, $5, $6, 'published')`,
+        [org, userId, shift, group, producerKey, randomUUID()],
+      )
+      await pool.query(
+        `INSERT INTO attendance_calculation_group_memberships
+           (org_id, user_id, group_id, effective_from, effective_to,
+            assigned_by, assigned_reason, assigned_correlation_id)
+         VALUES ($1, $2, $3, '2026-01-01', NULL, 'soak-diff-families', 'seed', $4)`,
+        [org, userId, group, `soak-diff-families-${group}-${userId.slice(0, 8)}`],
+      )
+    }
+  }, 180_000)
+
+  afterAll(async () => {
+    for (const table of [
+      'attendance_record_segments',
+      'attendance_record_calculations',
+      'attendance_records',
+      'attendance_events',
+      'attendance_calculation_group_memberships',
+      'attendance_shift_assignments',
+      'attendance_group_fixed_schedule_configs',
+      'attendance_group_members',
+      'attendance_groups',
+      'attendance_shift_segments',
+      'attendance_shifts',
+      'user_orgs',
+    ]) {
+      await pool?.query(`DELETE FROM ${table} WHERE org_id = $1`, [org]).catch(() => undefined)
+    }
+    await pool?.query(`DELETE FROM attendance_calculation_rollout_state WHERE org_id = $1`, [org]).catch(() => undefined)
+    await pool?.query(`DELETE FROM users WHERE id = ANY($1::text[])`, [[userA, userB]]).catch(() => undefined)
+    await pool?.end()
+    await server?.stop?.()
+    if (priorW4 === undefined) delete process.env[W4_ENV]
+    else process.env[W4_ENV] = priorW4
+    if (priorW7 === undefined) delete process.env[W7_ENV]
+    else process.env[W7_ENV] = priorW7
+  }, 60_000)
+
+  const punch = async (userId: string, eventType: 'check_in' | 'check_out', occurredAt: string) =>
+    requestJson(`${baseUrl}/api/attendance/punch`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${await mintToken(userId)}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ orgId: org, eventType, timezone: TZ, operationId: randomUUID(), occurredAt }),
+    })
+
+  const calcsFor = async (userId: string) =>
+    (
+      await pool.query(
+        `SELECT c.version, c.outcome, c.shadow_diff_code, c.shadow_diff
+           FROM attendance_record_calculations c
+           JOIN attendance_records r ON r.id = c.attendance_record_id
+          WHERE r.org_id = $1 AND r.user_id = $2
+          ORDER BY c.version`,
+        [org, userId],
+      )
+    ).rows
+
+  it('Family A: an in-only day diffs ONLY as transient late_minutes_mismatch, and converges to equal when the pair completes', async () => {
+    // 2026-08-11T17:35:30Z == 01:35:30 +08 on 2026-08-12 — 95.5 wall minutes after the
+    // 00:00 segment start; grace 5 => both machines' converged late value is 90.
+    const rIn = await punch(userA, 'check_in', '2026-08-11T17:35:30.000Z')
+    expect(rIn.status).toBe(200)
+    const afterIn = await calcsFor(userA)
+    expect(afterIn.length).toBe(1)
+    expect(afterIn[0].shadow_diff_code).toBe('late_minutes_mismatch')
+    expect(afterIn[0].shadow_diff.changedFields).toEqual(['lateMinutes'])
+    expect(afterIn[0].shadow_diff.absoluteMinuteDelta).toBe(90)
+
+    const rOut = await punch(userA, 'check_out', '2026-08-11T17:36:30.000Z')
+    expect(rOut.status).toBe(200)
+    const afterOut = await calcsFor(userA)
+    expect(afterOut.length).toBe(2)
+    expect(afterOut[1].shadow_diff_code).toBe('equal')
+
+    const rec = await pool.query(
+      `SELECT status, late_minutes FROM attendance_records WHERE org_id = $1 AND user_id = $2`,
+      [org, userA],
+    )
+    expect(rec.rows[0].late_minutes).toBe(90)
+  })
+
+  it('Family B: a pair-ladder pair (00:00:00 in, 23:59:00 out, backdated) is equal on every calc row and a normal legacy day', async () => {
+    // 2026-08-11T16:00:00Z == 2026-08-12 00:00:00 +08; 2026-08-12T15:59:00Z == 23:59:00 +08.
+    const rIn = await punch(userB, 'check_in', '2026-08-11T16:00:00.000Z')
+    const rOut = await punch(userB, 'check_out', '2026-08-12T15:59:00.000Z')
+    expect(rIn.status).toBe(200)
+    expect(rOut.status).toBe(200)
+    const calcs = await calcsFor(userB)
+    expect(calcs.length).toBe(2)
+    for (const calc of calcs) {
+      expect(calc.outcome).toBe('completed')
+      expect(calc.shadow_diff_code).toBe('equal')
+    }
+    const rec = await pool.query(
+      `SELECT status, late_minutes, early_leave_minutes, work_date::text AS work_date
+         FROM attendance_records WHERE org_id = $1 AND user_id = $2`,
+      [org, userB],
+    )
+    expect(rec.rows[0].status).toBe('normal')
+    expect(rec.rows[0].late_minutes).toBe(0)
+    expect(rec.rows[0].early_leave_minutes).toBe(0)
+    expect(rec.rows[0].work_date).toBe('2026-08-12')
+  })
+})

--- a/packages/core-backend/tests/unit/source-files-hourcycle-parsing-guard.test.ts
+++ b/packages/core-backend/tests/unit/source-files-hourcycle-parsing-guard.test.ts
@@ -331,6 +331,15 @@ const KNOWN_SITES: KnownSite[] = [
     lineText: "const parts = new Intl.DateTimeFormat('en-CA', {",
     kind: 'display',
   },
+  {
+    // attendance-w4w7-soak-load-generator.mjs entry validation (#4932 gate round-2 P2-1) —
+    // dailyCapTimezone IANA-validity probe: construction-only inside try/catch (RangeError
+    // on an unknown zone), the formatter is discarded — never assigned, never `.format()`ed.
+    // Same idiom and classification as the loadConfig() timezone probe above. No hour option.
+    file: 'scripts/ops/attendance-w4w7-soak-load-generator.mjs',
+    lineText: "new Intl.DateTimeFormat('en-US', { timeZone: dailyCapTimezone })",
+    kind: 'display',
+  },
   // ---------------------------------------------------------------------------------
   // Sites found only once the domain/pattern widened to close the coverage gaps an
   // independent gate review identified: `.vue` files inside the existing domain
@@ -639,7 +648,7 @@ describe('repo guard: h24-midnight hourCycle/hour12 parsing hazard (issue #4922)
     expect(candidates.length).toBe(KNOWN_SITES.length)
     // 22 = the original 20 (#4927) + the 2 display-class sites in the combined-soak load
     // generator (#4556 soak, PR #4929): its tz-validity probe and its en-CA date-key idiom.
-    expect(KNOWN_SITES.length).toBe(22)
+    expect(KNOWN_SITES.length).toBe(23)
   })
 
   it('KNOWN_SITES covers exactly the real Intl.DateTimeFormat sites in the domain (set equality via coverageDiff — a new site reds this until classified)', () => {

--- a/packages/core-backend/tests/unit/source-files-hourcycle-parsing-guard.test.ts
+++ b/packages/core-backend/tests/unit/source-files-hourcycle-parsing-guard.test.ts
@@ -331,25 +331,6 @@ const KNOWN_SITES: KnownSite[] = [
     lineText: "const parts = new Intl.DateTimeFormat('en-CA', {",
     kind: 'display',
   },
-  {
-    // attendance-w4w7-soak-load-generator.mjs `zonedDateTimeToUtcIso()` (#4556 soak pair
-    // ladder) — formatToParts with hour/minute/second Number-consumed straight into
-    // Date.UTC(...): EXACTLY the h24-midnight hazard shape (this util constructs the
-    // 00:00:00 check_in instants). Carries explicit `hourCycle: 'h23'` AND the defensive
-    // 24->0 fold, mirroring the #4911 fix pair.
-    file: 'scripts/ops/attendance-w4w7-soak-load-generator.mjs',
-    lineText: "const fmt = new Intl.DateTimeFormat('en-CA', {",
-    kind: 'parsing',
-  },
-  {
-    // attendance-w4w7-soak-load-generator.mjs entry validation (#4556 soak pair ladder) —
-    // ladderTimezone IANA-validity probe: construction-only inside try/catch, formatter
-    // discarded; same idiom and classification as the loadConfig() probe above.
-    file: 'scripts/ops/attendance-w4w7-soak-load-generator.mjs',
-    lineText: "new Intl.DateTimeFormat('en-US', { timeZone: ladderTimezone })",
-    kind: 'display',
-  },
-
   // ---------------------------------------------------------------------------------
   // Sites found only once the domain/pattern widened to close the coverage gaps an
   // independent gate review identified: `.vue` files inside the existing domain
@@ -658,7 +639,7 @@ describe('repo guard: h24-midnight hourCycle/hour12 parsing hazard (issue #4922)
     expect(candidates.length).toBe(KNOWN_SITES.length)
     // 22 = the original 20 (#4927) + the 2 display-class sites in the combined-soak load
     // generator (#4556 soak, PR #4929): its tz-validity probe and its en-CA date-key idiom.
-    expect(KNOWN_SITES.length).toBe(24)
+    expect(KNOWN_SITES.length).toBe(22)
   })
 
   it('KNOWN_SITES covers exactly the real Intl.DateTimeFormat sites in the domain (set equality via coverageDiff — a new site reds this until classified)', () => {

--- a/packages/core-backend/tests/unit/source-files-hourcycle-parsing-guard.test.ts
+++ b/packages/core-backend/tests/unit/source-files-hourcycle-parsing-guard.test.ts
@@ -331,6 +331,24 @@ const KNOWN_SITES: KnownSite[] = [
     lineText: "const parts = new Intl.DateTimeFormat('en-CA', {",
     kind: 'display',
   },
+  {
+    // attendance-w4w7-soak-load-generator.mjs `zonedDateTimeToUtcIso()` (#4556 soak pair
+    // ladder) — formatToParts with hour/minute/second Number-consumed straight into
+    // Date.UTC(...): EXACTLY the h24-midnight hazard shape (this util constructs the
+    // 00:00:00 check_in instants). Carries explicit `hourCycle: 'h23'` AND the defensive
+    // 24->0 fold, mirroring the #4911 fix pair.
+    file: 'scripts/ops/attendance-w4w7-soak-load-generator.mjs',
+    lineText: "const fmt = new Intl.DateTimeFormat('en-CA', {",
+    kind: 'parsing',
+  },
+  {
+    // attendance-w4w7-soak-load-generator.mjs entry validation (#4556 soak pair ladder) —
+    // ladderTimezone IANA-validity probe: construction-only inside try/catch, formatter
+    // discarded; same idiom and classification as the loadConfig() probe above.
+    file: 'scripts/ops/attendance-w4w7-soak-load-generator.mjs',
+    lineText: "new Intl.DateTimeFormat('en-US', { timeZone: ladderTimezone })",
+    kind: 'display',
+  },
 
   // ---------------------------------------------------------------------------------
   // Sites found only once the domain/pattern widened to close the coverage gaps an
@@ -640,7 +658,7 @@ describe('repo guard: h24-midnight hourCycle/hour12 parsing hazard (issue #4922)
     expect(candidates.length).toBe(KNOWN_SITES.length)
     // 22 = the original 20 (#4927) + the 2 display-class sites in the combined-soak load
     // generator (#4556 soak, PR #4929): its tz-validity probe and its en-CA date-key idiom.
-    expect(KNOWN_SITES.length).toBe(22)
+    expect(KNOWN_SITES.length).toBe(24)
   })
 
   it('KNOWN_SITES covers exactly the real Intl.DateTimeFormat sites in the domain (set equality via coverageDiff — a new site reds this until classified)', () => {

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -779,6 +779,12 @@ export default defineConfig({
       // once both machines are on. Meaningless without real PostgreSQL.
       // Two-point wired: excluded here, whole-file run in plugin-tests.yml.
       'tests/integration/attendance-w7-1b-cutover-e2e.db.test.ts',
+      // #4556 combined-soak shadow-diff FAMILY pins (transient partial-day
+      // late_minutes_mismatch lifecycle + the pair-ladder all-equal contract).
+      // Boots a real MetaSheetServer and drives the real punch route against a
+      // W4-shadow org — meaningless without real PostgreSQL.
+      // Two-point wired: excluded here, whole-file run in plugin-tests.yml.
+      'tests/integration/attendance-soak-diff-families.db.test.ts',
       // #4556 W7-1b: OD-W7-10(a)'s four-cell matrix at the recompute route.
       // Seeds prior COMPLETED calculations with specific `context_snapshot.selector`
       // values against real CHECK constraints and deferred triggers, walks the

--- a/plugins/plugin-integration-core/lib/sealed-export/vectors/s6a-package-provenance-pins.json
+++ b/plugins/plugin-integration-core/lib/sealed-export/vectors/s6a-package-provenance-pins.json
@@ -86,6 +86,6 @@
     "s6aAcceptancePs51Test": "835c7c6ce943d82e0378a40a27c7fd1e8b79b526faa8ca4c8066e4231a4bfb0f",
     "s6aProductRuntimeTest": "de978adafa8b89772cefa921c2051f434bf346bf5c2978bef3424ee70f51ba3f",
     "multitableOnpremPackageBuild": "ae477a24375a7269e5710a3481905c9b74255c03fd802841a16849aca48ee33a",
-    "pluginTestsWorkflow": "36822156529083e518b92c192fb448efe031603f670bdde42a7750c6fd9e0639"
+    "pluginTestsWorkflow": "b221401aa6d2125ab4488c28462560e6fe984c0c90cdeca064457c3a195ac760"
   }
 }

--- a/scripts/ops/attendance-staging-window-runner-remote.sh
+++ b/scripts/ops/attendance-staging-window-runner-remote.sh
@@ -2068,7 +2068,8 @@ action_soak_run() {
   # entry's dailyCapTimezone (all soak orgs share one); override only for a deliberate
   # halt-retry with soak_opts allow_same_day_rerun=true (documented critical-shape risk).
   local batch_tz batch_day last_batch_day
-  batch_tz="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["entries"][0].get("dailyCapTimezone", "UTC"))' "$config_path")"
+  batch_tz="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["entries"][0]["dailyCapTimezone"])' "$config_path" 2>/dev/null)" \
+    || fail "config at ${config_path} carries no dailyCapTimezone — it predates the org-day cap contract and would silently revert the 2/day cap and the same-day guard to UTC days; re-run action=soak-seed first"
   batch_day="$(TZ="$batch_tz" date +%Y-%m-%d)"
   local batch_marker="${SOAK_PERSIST_DIR}/soak-run-last-batch-day"
   if [[ -f "$batch_marker" ]]; then

--- a/scripts/ops/attendance-staging-window-runner-remote.sh
+++ b/scripts/ops/attendance-staging-window-runner-remote.sh
@@ -2057,6 +2057,26 @@ action_soak_run() {
   done
   IFS="$IFS_SAVE"
 
+  # Pair-ladder anchors (identity of each run's backdated work-date window). The generator's
+  # retired always-server-clock cadence packed every pair into ONE work date, which collided
+  # with the W4 calculator's ambiguity semantics (duplicate_check_in / ambiguous_segment_match
+  # -> review_required, a §4.2 CRITICAL diff class): soak-status 31962440160 counted 50+80
+  # critical rows from cadence alone, so that fixture could NEVER meet the ratified
+  # zero-critical criterion. The ladder gives each (user, work_date) exactly ONE in/out pair:
+  # anchor = day before the family's earliest already-punched work_date (DB is the cursor —
+  # no host state file), or yesterday in the org's group timezone on a fresh family.
+  soak_resolve_pg
+  local ladder_specs="" cfg_org anchor tzv
+  while IFS= read -r cfg_org; do
+    [[ -n "$cfg_org" ]] || continue
+    tzv="$(soak_psql_ta "SELECT g.timezone FROM attendance_groups g WHERE g.org_id = '${cfg_org}' AND g.name LIKE 'w4w7-soak%' LIMIT 1;")"
+    [[ -n "$tzv" ]] || fail "org ${cfg_org:0:8} has no w4w7-soak group — cannot derive the ladder timezone (run action=soak-seed first)"
+    anchor="$(soak_psql_ta "SELECT to_char(COALESCE((SELECT min(r.work_date) FROM attendance_records r WHERE r.org_id = '${cfg_org}' AND EXISTS (SELECT 1 FROM users u WHERE u.id = r.user_id AND u.username LIKE '${SOAK_USER_PREFIX}%')) - 1, (now() AT TIME ZONE '${tzv}')::date - 1), 'YYYY-MM-DD');")"
+    [[ "$anchor" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]] || fail "ladder anchor derivation returned '${anchor}' for org ${cfg_org:0:8} — refusing"
+    ladder_specs+="${cfg_org}=${anchor}=${tzv};"
+    log "soak-run: org ${cfg_org:0:8} pair-ladder anchor ${anchor} (tz ${tzv})"
+  done < <(python3 -c 'import json,sys; [print(e["orgId"]) for e in json.load(open(sys.argv[1]))["entries"]]' "$config_path")
+
   # Log every synthetic user in through the REAL login route; tokens go ONLY into a 0600
   # host temp config (deleted below) and are never echoed (per-user output is id + ok/fail).
   mkdir -p "$SOAK_PERSIST_DIR"
@@ -2069,11 +2089,17 @@ action_soak_run() {
   trap cleanup_soak_run EXIT
   local -a login_pipe_status
   set +e
-  SOAK_SYNTH_PASSWORD="$SOAK_SYNTH_PASSWORD" python3 - "$config_path" "$run_config_host" <<'PY' 2>&1 | tee "${OUTPUT_DIR}/soak-run-login.log"
+  SOAK_SYNTH_PASSWORD="$SOAK_SYNTH_PASSWORD" SOAK_LADDER_SPECS="$ladder_specs" python3 - "$config_path" "$run_config_host" <<'PY' 2>&1 | tee "${OUTPUT_DIR}/soak-run-login.log"
 import json, os, sys, urllib.request
 config_path, out_path = sys.argv[1], sys.argv[2]
 cfg = json.load(open(config_path))
 password = os.environ["SOAK_SYNTH_PASSWORD"]
+ladder = {}
+for spec in os.environ.get("SOAK_LADDER_SPECS", "").split(";"):
+    if not spec:
+        continue
+    org, anchor, tz = spec.split("=", 2)
+    ladder[org] = (anchor, tz)
 base = "http://127.0.0.1:8082"
 failures = 0
 for entry in cfg["entries"]:
@@ -2097,6 +2123,13 @@ for entry in cfg["entries"]:
             print(f"[soak-run] login FAILED: {user_id} ({getattr(err, 'code', type(err).__name__)})")
             failures += 1
     entry["tokenOrCreds"] = creds
+    if entry["orgId"] not in ladder:
+        print(f"[soak-run] ladder anchor MISSING for org {entry['orgId']}")
+        failures += 1
+    else:
+        anchor, tz = ladder[entry["orgId"]]
+        entry["ladderAnchorDate"] = anchor
+        entry["ladderTimezone"] = tz
 fd = os.open(out_path, os.O_WRONLY | os.O_TRUNC | os.O_CREAT, 0o600)
 with os.fdopen(fd, "w") as f:
     json.dump(cfg, f)

--- a/scripts/ops/attendance-staging-window-runner-remote.sh
+++ b/scripts/ops/attendance-staging-window-runner-remote.sh
@@ -1841,13 +1841,13 @@ SQL
   # `userIds` entries are the closed family USERNAMES — soak-run feeds each one to POST
   # /api/auth/login as `identifier` (resolved by username) and the returned token carries
   # the user's minted UUID id. They are generator-local login/attribution keys, not DB ids.
-  python3 - "$SOAK_HOST_CONFIG_FILE" "$SOAK_ORG1" "$SOAK_ORG2" "$SOAK_ORG3" "$users_per_org" "$SOAK_USER_PREFIX" <<'PY'
+  python3 - "$SOAK_HOST_CONFIG_FILE" "$SOAK_ORG1" "$SOAK_ORG2" "$SOAK_ORG3" "$users_per_org" "$SOAK_USER_PREFIX" "$tz1" "$tz2" "$tz3" <<'PY'
 import json, os, sys
-path, org1, org2, org3, count, prefix = sys.argv[1:7]
+path, org1, org2, org3, count, prefix, tz1, tz2, tz3 = sys.argv[1:10]
 count = int(count)
 postures = ["legacy_only", "w4_only_legacy_arm", "both_machines_group_arm"]
 entries = []
-for org, posture in zip([org1, org2, org3], postures):
+for org, posture, tz in zip([org1, org2, org3], postures, [tz1, tz2, tz3]):
     user_prefix = f"{prefix}{org[:8]}-u"
     entries.append({
         "orgId": org,
@@ -1855,6 +1855,9 @@ for org, posture in zip([org1, org2, org3], postures):
         "minCleanPunches": 20,
         "userIds": [f"{user_prefix}{i:02d}" for i in range(1, count + 1)],
         "tokenOrCreds": {},
+        # gate round-2 P2-1: the 2/day cap must count against the ORG'S calendar day, not
+        # the generator's UTC default. Bookkeeping-only; never sent in a punch body.
+        "dailyCapTimezone": tz,
     })
 cfg = {
     "baseUrl": "http://127.0.0.1:8900",
@@ -2058,6 +2061,27 @@ action_soak_run() {
   done
   IFS="$IFS_SAVE"
 
+  # SAME-DAY RE-DISPATCH GUARD (gate round-2 P2-1): the generator's daily cap is
+  # per-process, so a second soak-run inside the same org-calendar day would land a second
+  # pair on the SAME work date — exactly the duplicate-session shape that floods
+  # §4.2-critical review_required diffs. The org day is derived from the FIRST config
+  # entry's dailyCapTimezone (all soak orgs share one); override only for a deliberate
+  # halt-retry with soak_opts allow_same_day_rerun=true (documented critical-shape risk).
+  local batch_tz batch_day last_batch_day
+  batch_tz="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["entries"][0].get("dailyCapTimezone", "UTC"))' "$config_path")"
+  batch_day="$(TZ="$batch_tz" date +%Y-%m-%d)"
+  local batch_marker="${SOAK_PERSIST_DIR}/soak-run-last-batch-day"
+  if [[ -f "$batch_marker" ]]; then
+    last_batch_day="$(cat "$batch_marker")"
+    if [[ "$last_batch_day" == "$batch_day" && "$(soak_opt allow_same_day_rerun false)" != "true" ]]; then
+      fail "a soak-run batch already ran (or started) on ${batch_day} (${batch_tz}) — a second same-day batch lands duplicate sessions on the same work date (§4.2-critical review_required). Wait for the next org-calendar day, or pass soak_opts allow_same_day_rerun=true for a deliberate retry (accepting that risk for already-punched users)"
+    fi
+  fi
+  # Written BEFORE the generator runs: even a PARTIAL batch punched some users, so a bare
+  # same-day retry would duplicate exactly those — burning the day on any attempt is the
+  # fail-closed choice; the override above is the deliberate escape hatch.
+  printf '%s\n' "$batch_day" > "$batch_marker"
+
   # Log every synthetic user in through the REAL login route; tokens go ONLY into a 0600
   # host temp config (deleted below) and are never echoed (per-user output is id + ok/fail).
   mkdir -p "$SOAK_PERSIST_DIR"
@@ -2162,11 +2186,24 @@ PY
     echo "http_level_clean=${total_clean}"
     echo "attempts=${total_attempts}"
     echo "note=haltedReason is LOAD-BEARING: targets_met (this batch met its targets) and daily_capacity_exhausted (every user completed its one daily pair; cumulative criteria accrue across days) are the clean outcomes; the HTTP tally upper-bounds (never equals) the DB-level clean-punch count — soak-status Q1-Q4 are the authoritative counts"
-    echo "result=$([[ "$halted" == "max_consecutive_incidents" ]] && echo FAIL || echo ok)"
+    # gate round-2 P2-3: exactly the two clean halts print ok; incidents FAIL the job; every
+    # other halt (stall, duration, safety cap) prints WARN — recorded, non-alert, but never
+    # dressed up as a clean batch.
+    case "$halted" in
+      targets_met|daily_capacity_exhausted) echo "result=ok" ;;
+      max_consecutive_incidents) echo "result=FAIL" ;;
+      *) echo "result=WARN" ;;
+    esac
   } > "${OUTPUT_DIR}/summary.txt"
   if [[ "$halted" == "max_consecutive_incidents" ]]; then
     fail "generator halted on consecutive non-clean responses (haltedReason=max_consecutive_incidents) — alert-class outcome, see soak-run.log + soak-run-summary.json"
   fi
+  case "$halted" in
+    targets_met|daily_capacity_exhausted) ;;
+    *)
+      log "soak-run WARN: haltedReason=${halted} is neither clean outcome — see summary.txt (a same-day retry needs soak_opts allow_same_day_rerun=true and accepts the duplicate-session risk for already-punched users)"
+      ;;
+  esac
   log "soak-run done: haltedReason=${halted} http_clean=${total_clean}/${punch_target} (DB-level counts come from action=soak-status, never from this tally)"
 }
 

--- a/scripts/ops/attendance-staging-window-runner-remote.sh
+++ b/scripts/ops/attendance-staging-window-runner-remote.sh
@@ -2002,14 +2002,15 @@ action_soak_flags() {
 action_soak_run() {
   soak_validate_opts
   local punch_target config_path
-  # Default 200 = the generator's own ruled C1 target (§2A.3), NOT the 240/day capacity:
-  # dailyCounts increments on every ATTEMPT while stopConditionsMet needs totalClean>=target,
-  # so setting the target AT capacity leaves zero headroom and a single documented first-punch
-  # PUNCH_TOO_SOON collision makes targets_met unreachable (the run then idles to the stall
-  # timeout). 200 against a 240 one-day capacity leaves 40 clean slots of headroom.
-  punch_target="$(soak_opt punch_target 200)"
-  [[ "$punch_target" =~ ^[1-9][0-9]{0,3}$ ]] \
-    || fail "punch_target must be 1..9999, got '${punch_target}'"
+  # Default `auto` = this run's ONE-DAY BATCH: with the 2/user/day cap (one in/out pair per
+  # user per wall-clock day — same-day session packing floods §4.2-critical review_required
+  # diffs, soak-status 31962440160, and backdating is rejected by the route's global-latest
+  # ordering, #4932 gate P1-1), a soak-run invocation is one daily batch. The runbook's
+  # CUMULATIVE §2A.3 criteria (200 total / 20 per org / 50 per arm) are judged from
+  # soak-status DB counts across days, never from one run's tally.
+  punch_target="$(soak_opt punch_target auto)"
+  [[ "$punch_target" == "auto" || "$punch_target" =~ ^[1-9][0-9]{0,3}$ ]] \
+    || fail "punch_target must be 1..9999 or 'auto' (one-day batch), got '${punch_target}'"
   config_path="$(soak_opt config "$SOAK_HOST_CONFIG_FILE")"
   [[ -f "$config_path" ]] || fail "soak config not found at ${config_path} — action=soak-seed writes it (or pass soak_opts config=<host-path>)"
   # Order enforcement: the flags must be LIVE on the serving backend before load.
@@ -2030,21 +2031,21 @@ action_soak_run() {
   orgs_csv="$(python3 -c 'import json,sys; print(",".join(e["orgId"] for e in json.load(open(sys.argv[1]))["entries"]))' "$config_path")" \
     || fail "could not parse soak config ${config_path}"
   both_csv="$(python3 -c 'import json,sys; print(",".join(e["orgId"] for e in json.load(open(sys.argv[1]))["entries"] if e["posture"] == "both_machines_group_arm"))' "$config_path")"
-  # DAY-CAPACITY CEILING (P3-2/P3-3): a single soak-run invocation is one bounded pass inside
-  # the 40-minute job. The generator's per-user daily cap (8 punches/user/day) means the most
-  # CLEAN punches one invocation can produce is total_users * 8; a target above that can never
-  # reach targets_met and would only idle to the stall timeout. That ceiling is also what keeps
-  # the run inside the job window (at the >=60s per-user spacing + <=1 req/s ceiling, one day's
-  # capacity for a default 30-user config is ~8 min of active load, not the old 2000-cap ~67 min).
+  # DAY-CAPACITY (P3-2/P3-3, revised for the 2/user/day pair cadence): one soak-run
+  # invocation is one daily batch — the most CLEAN punches it can produce is total_users * 2
+  # (one in/out pair per user per wall-clock day). punch_target=auto resolves to exactly that
+  # batch; an explicit target above it can never reach targets_met and would only idle to the
+  # stall timeout. Well inside the 40-minute job at <=1 req/s + >=60s per-user spacing.
   total_users="$(python3 -c 'import json,sys; print(sum(len(e["userIds"]) for e in json.load(open(sys.argv[1]))["entries"]))' "$config_path")"
   [[ "$total_users" =~ ^[1-9][0-9]*$ ]] || fail "could not derive the synthetic user count from ${config_path}"
-  day_capacity=$(( total_users * 8 ))
-  # Past ~60 users the GLOBAL <=1 req/sec ceiling binds instead of the per-user spacing, so a
-  # large-config capacity (e.g. 99x3x8=2376) would overrun the 40-minute job. 1800 = 30 min of
-  # active load at 1/s, leaving margin for logins/docker cp/artifact scp inside the timeout.
+  day_capacity=$(( total_users * 2 ))
+  # Past ~30x3 users the GLOBAL <=1 req/sec ceiling binds instead of the per-user spacing;
+  # 1800 = 30 min of active load at 1/s, leaving job-window margin for logins/docker cp/scp.
   (( day_capacity > 1800 )) && day_capacity=1800
+  [[ "$punch_target" == "auto" ]] && punch_target="$day_capacity"
   [[ "$punch_target" -le "$day_capacity" ]] \
-    || fail "punch_target=${punch_target} exceeds this config's one-day clean-punch capacity (${total_users} users x 8/user/day = ${day_capacity}); a larger target can never reach targets_met in one invocation and would only idle to the stall timeout. Lower punch_target, raise users_per_org at seed time, or run multiple soak-run invocations across days"
+    || fail "punch_target=${punch_target} exceeds this config's one-day clean-punch capacity (${total_users} users x 2/user/day = ${day_capacity}); the pair cadence makes cumulative criteria a multi-day affair — raise users_per_org at seed time or run daily batches"
+
   local IFS_SAVE="$IFS"
   IFS=','
   for org in $orgs_csv; do
@@ -2056,26 +2057,6 @@ action_soak_run() {
       || fail "both-machines config org ${org} is NOT in the live W7 allowlist ('${live_w7}')"
   done
   IFS="$IFS_SAVE"
-
-  # Pair-ladder anchors (identity of each run's backdated work-date window). The generator's
-  # retired always-server-clock cadence packed every pair into ONE work date, which collided
-  # with the W4 calculator's ambiguity semantics (duplicate_check_in / ambiguous_segment_match
-  # -> review_required, a §4.2 CRITICAL diff class): soak-status 31962440160 counted 50+80
-  # critical rows from cadence alone, so that fixture could NEVER meet the ratified
-  # zero-critical criterion. The ladder gives each (user, work_date) exactly ONE in/out pair:
-  # anchor = day before the family's earliest already-punched work_date (DB is the cursor —
-  # no host state file), or yesterday in the org's group timezone on a fresh family.
-  soak_resolve_pg
-  local ladder_specs="" cfg_org anchor tzv
-  while IFS= read -r cfg_org; do
-    [[ -n "$cfg_org" ]] || continue
-    tzv="$(soak_psql_ta "SELECT g.timezone FROM attendance_groups g WHERE g.org_id = '${cfg_org}' AND g.name LIKE 'w4w7-soak%' LIMIT 1;")"
-    [[ -n "$tzv" ]] || fail "org ${cfg_org:0:8} has no w4w7-soak group — cannot derive the ladder timezone (run action=soak-seed first)"
-    anchor="$(soak_psql_ta "SELECT to_char(COALESCE((SELECT min(r.work_date) FROM attendance_records r WHERE r.org_id = '${cfg_org}' AND EXISTS (SELECT 1 FROM users u WHERE u.id = r.user_id AND u.username LIKE '${SOAK_USER_PREFIX}%')) - 1, (now() AT TIME ZONE '${tzv}')::date - 1), 'YYYY-MM-DD');")"
-    [[ "$anchor" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]] || fail "ladder anchor derivation returned '${anchor}' for org ${cfg_org:0:8} — refusing"
-    ladder_specs+="${cfg_org}=${anchor}=${tzv};"
-    log "soak-run: org ${cfg_org:0:8} pair-ladder anchor ${anchor} (tz ${tzv})"
-  done < <(python3 -c 'import json,sys; [print(e["orgId"]) for e in json.load(open(sys.argv[1]))["entries"]]' "$config_path")
 
   # Log every synthetic user in through the REAL login route; tokens go ONLY into a 0600
   # host temp config (deleted below) and are never echoed (per-user output is id + ok/fail).
@@ -2089,17 +2070,11 @@ action_soak_run() {
   trap cleanup_soak_run EXIT
   local -a login_pipe_status
   set +e
-  SOAK_SYNTH_PASSWORD="$SOAK_SYNTH_PASSWORD" SOAK_LADDER_SPECS="$ladder_specs" python3 - "$config_path" "$run_config_host" <<'PY' 2>&1 | tee "${OUTPUT_DIR}/soak-run-login.log"
+  SOAK_SYNTH_PASSWORD="$SOAK_SYNTH_PASSWORD" python3 - "$config_path" "$run_config_host" <<'PY' 2>&1 | tee "${OUTPUT_DIR}/soak-run-login.log"
 import json, os, sys, urllib.request
 config_path, out_path = sys.argv[1], sys.argv[2]
 cfg = json.load(open(config_path))
 password = os.environ["SOAK_SYNTH_PASSWORD"]
-ladder = {}
-for spec in os.environ.get("SOAK_LADDER_SPECS", "").split(";"):
-    if not spec:
-        continue
-    org, anchor, tz = spec.split("=", 2)
-    ladder[org] = (anchor, tz)
 base = "http://127.0.0.1:8082"
 failures = 0
 for entry in cfg["entries"]:
@@ -2123,13 +2098,6 @@ for entry in cfg["entries"]:
             print(f"[soak-run] login FAILED: {user_id} ({getattr(err, 'code', type(err).__name__)})")
             failures += 1
     entry["tokenOrCreds"] = creds
-    if entry["orgId"] not in ladder:
-        print(f"[soak-run] ladder anchor MISSING for org {entry['orgId']}")
-        failures += 1
-    else:
-        anchor, tz = ladder[entry["orgId"]]
-        entry["ladderAnchorDate"] = anchor
-        entry["ladderTimezone"] = tz
 fd = os.open(out_path, os.O_WRONLY | os.O_TRUNC | os.O_CREAT, 0o600)
 with os.fdopen(fd, "w") as f:
     json.dump(cfg, f)
@@ -2156,7 +2124,7 @@ PY
     --base-url "$IN_CONTAINER_BASE_URL" \
     --target-total "$punch_target" \
     --rate-limit-per-sec 1 \
-    --punches-per-user-per-day 8 \
+    --punches-per-user-per-day 2 \
     --stall-timeout-minutes 15 \
     --tally-interval 10 \
     --output "${CONTAINER_RUNNER_DIR}/soak-run-summary.json" \
@@ -2193,7 +2161,7 @@ PY
     echo "halted_reason=${halted}"
     echo "http_level_clean=${total_clean}"
     echo "attempts=${total_attempts}"
-    echo "note=haltedReason is LOAD-BEARING: only targets_met means this invocation reached its targets; the HTTP tally upper-bounds (never equals) the DB-level clean-punch count — soak-status Q1-Q4 are the authoritative counts"
+    echo "note=haltedReason is LOAD-BEARING: targets_met (this batch met its targets) and daily_capacity_exhausted (every user completed its one daily pair; cumulative criteria accrue across days) are the clean outcomes; the HTTP tally upper-bounds (never equals) the DB-level clean-punch count — soak-status Q1-Q4 are the authoritative counts"
     echo "result=$([[ "$halted" == "max_consecutive_incidents" ]] && echo FAIL || echo ok)"
   } > "${OUTPUT_DIR}/summary.txt"
   if [[ "$halted" == "max_consecutive_incidents" ]]; then

--- a/scripts/ops/attendance-w4c2-ci-wiring.test.mjs
+++ b/scripts/ops/attendance-w4c2-ci-wiring.test.mjs
@@ -2202,6 +2202,7 @@ const EXPECTED_ATTENDANCE_SUITES = Object.freeze([
   'tests/integration/attendance-shift-segments-migration.db.test.ts',
   'tests/integration/attendance-shift-segments-writer-matrix.db.test.ts',
   'tests/integration/attendance-shift-swap.test.ts',
+  'tests/integration/attendance-soak-diff-families.db.test.ts',
   'tests/integration/attendance-unscheduled-reminder.test.ts',
   'tests/integration/attendance-w4c0-concurrency-gates-e3.db.test.ts',
   'tests/integration/attendance-w4c0-db-gates-e1.db.test.ts',

--- a/scripts/ops/attendance-w4w7-soak-config.template.json
+++ b/scripts/ops/attendance-w4w7-soak-config.template.json
@@ -9,22 +9,38 @@
       "orgId": "<org1-lowercase-uuid legacy-only>",
       "posture": "legacy_only",
       "minCleanPunches": 20,
-      "userIds": ["synth-w4w7-<org1first8>-u01", "synth-w4w7-<org1first8>-u02"],
-      "tokenOrCreds": {}
+      "userIds": [
+        "synth-w4w7-<org1first8>-u01",
+        "synth-w4w7-<org1first8>-u02"
+      ],
+      "tokenOrCreds": {},
+      "ladderAnchorDate": "<injected-by-soak-run YYYY-MM-DD strictly before today>",
+      "ladderTimezone": "<injected-by-soak-run org group IANA timezone>"
     },
     {
       "orgId": "<org2-lowercase-uuid w4-only>",
       "posture": "w4_only_legacy_arm",
       "minCleanPunches": 20,
-      "userIds": ["synth-w4w7-<org2first8>-u01", "synth-w4w7-<org2first8>-u02"],
-      "tokenOrCreds": {}
+      "userIds": [
+        "synth-w4w7-<org2first8>-u01",
+        "synth-w4w7-<org2first8>-u02"
+      ],
+      "tokenOrCreds": {},
+      "ladderAnchorDate": "<injected-by-soak-run YYYY-MM-DD strictly before today>",
+      "ladderTimezone": "<injected-by-soak-run org group IANA timezone>"
     },
     {
       "orgId": "<org3-lowercase-uuid both-machines>",
       "posture": "both_machines_group_arm",
       "minCleanPunches": 20,
-      "userIds": ["synth-w4w7-<org3first8>-u01", "synth-w4w7-<org3first8>-u02"],
-      "tokenOrCreds": {}
+      "userIds": [
+        "synth-w4w7-<org3first8>-u01",
+        "synth-w4w7-<org3first8>-u02"
+      ],
+      "tokenOrCreds": {},
+      "ladderAnchorDate": "<injected-by-soak-run YYYY-MM-DD strictly before today>",
+      "ladderTimezone": "<injected-by-soak-run org group IANA timezone>"
     }
-  ]
+  ],
+  "$ladder_note": "PAIR LADDER: action=soak-run injects ladderAnchorDate (YYYY-MM-DD, strictly before today) and ladderTimezone (the org group's IANA timezone) into every entry from the DB (anchor = day before the family's earliest punched work_date). The generator fails closed without them — the retired always-server-clock cadence packed every pair into one work date, flooding §4.2-critical review_required diffs (soak-status 31962440160). Pair j for a user targets anchor-j: check_in 00:00:00, check_out 23:59:00 wall time; a healthy run's whole shadow-diff surface is 'equal'."
 }

--- a/scripts/ops/attendance-w4w7-soak-config.template.json
+++ b/scripts/ops/attendance-w4w7-soak-config.template.json
@@ -13,7 +13,8 @@
         "synth-w4w7-<org1first8>-u01",
         "synth-w4w7-<org1first8>-u02"
       ],
-      "tokenOrCreds": {}
+      "tokenOrCreds": {},
+      "dailyCapTimezone": "<org group IANA timezone, written by action=soak-seed — REQUIRED: the 2/day cap and the same-day guard count against the ORG calendar day>"
     },
     {
       "orgId": "<org2-lowercase-uuid w4-only>",
@@ -23,7 +24,8 @@
         "synth-w4w7-<org2first8>-u01",
         "synth-w4w7-<org2first8>-u02"
       ],
-      "tokenOrCreds": {}
+      "tokenOrCreds": {},
+      "dailyCapTimezone": "<org group IANA timezone, written by action=soak-seed — REQUIRED: the 2/day cap and the same-day guard count against the ORG calendar day>"
     },
     {
       "orgId": "<org3-lowercase-uuid both-machines>",
@@ -33,7 +35,8 @@
         "synth-w4w7-<org3first8>-u01",
         "synth-w4w7-<org3first8>-u02"
       ],
-      "tokenOrCreds": {}
+      "tokenOrCreds": {},
+      "dailyCapTimezone": "<org group IANA timezone, written by action=soak-seed — REQUIRED: the 2/day cap and the same-day guard count against the ORG calendar day>"
     }
   ],
   "$cadence_note": "CADENCE: the generator default is 2 punches/user/wall-day = exactly ONE check_in/check_out pair per user per day (server clock; occurredAt never sent). Same-day session packing (the old 8/day row) floods §4.2-critical review_required diffs (soak-status 31962440160), and backdated acceleration is rejected by the route's global-latest punch ordering (#4932 gate P1-1) — the honest accelerator is users_per_org at seed time; the runbook's cumulative count criteria accrue across daily soak-run batches (DB-side soak-status judgments)."

--- a/scripts/ops/attendance-w4w7-soak-config.template.json
+++ b/scripts/ops/attendance-w4w7-soak-config.template.json
@@ -13,9 +13,7 @@
         "synth-w4w7-<org1first8>-u01",
         "synth-w4w7-<org1first8>-u02"
       ],
-      "tokenOrCreds": {},
-      "ladderAnchorDate": "<injected-by-soak-run YYYY-MM-DD strictly before today>",
-      "ladderTimezone": "<injected-by-soak-run org group IANA timezone>"
+      "tokenOrCreds": {}
     },
     {
       "orgId": "<org2-lowercase-uuid w4-only>",
@@ -25,9 +23,7 @@
         "synth-w4w7-<org2first8>-u01",
         "synth-w4w7-<org2first8>-u02"
       ],
-      "tokenOrCreds": {},
-      "ladderAnchorDate": "<injected-by-soak-run YYYY-MM-DD strictly before today>",
-      "ladderTimezone": "<injected-by-soak-run org group IANA timezone>"
+      "tokenOrCreds": {}
     },
     {
       "orgId": "<org3-lowercase-uuid both-machines>",
@@ -37,10 +33,8 @@
         "synth-w4w7-<org3first8>-u01",
         "synth-w4w7-<org3first8>-u02"
       ],
-      "tokenOrCreds": {},
-      "ladderAnchorDate": "<injected-by-soak-run YYYY-MM-DD strictly before today>",
-      "ladderTimezone": "<injected-by-soak-run org group IANA timezone>"
+      "tokenOrCreds": {}
     }
   ],
-  "$ladder_note": "PAIR LADDER: action=soak-run injects ladderAnchorDate (YYYY-MM-DD, strictly before today) and ladderTimezone (the org group's IANA timezone) into every entry from the DB (anchor = day before the family's earliest punched work_date). The generator fails closed without them — the retired always-server-clock cadence packed every pair into one work date, flooding §4.2-critical review_required diffs (soak-status 31962440160). Pair j for a user targets anchor-j: check_in 00:00:00, check_out 23:59:00 wall time; a healthy run's whole shadow-diff surface is 'equal'."
+  "$cadence_note": "CADENCE: the generator default is 2 punches/user/wall-day = exactly ONE check_in/check_out pair per user per day (server clock; occurredAt never sent). Same-day session packing (the old 8/day row) floods §4.2-critical review_required diffs (soak-status 31962440160), and backdated acceleration is rejected by the route's global-latest punch ordering (#4932 gate P1-1) — the honest accelerator is users_per_org at seed time; the runbook's cumulative count criteria accrue across daily soak-run batches (DB-side soak-status judgments)."
 }

--- a/scripts/ops/attendance-w4w7-soak-load-generator.mjs
+++ b/scripts/ops/attendance-w4w7-soak-load-generator.mjs
@@ -533,22 +533,25 @@ async function loadConfig(opts) {
       }
     }
 
-    // #4932 gate round-2 P2-1: the one-pair-per-WORK-DATE invariant is only as good as the
-    // day boundary the cap counts against. config.timezone defaults to UTC while the soak
-    // orgs' work dates are org-timezone days, so the cap must key on the ORG'S day: soak-seed
-    // writes dailyCapTimezone per entry (the org group's IANA timezone). Bookkeeping-only —
-    // NEVER sent in a punch body (that would override the org rule timezone server-side).
-    let dailyCapTimezone = null
-    if (rawEntry.dailyCapTimezone !== undefined) {
-      if (typeof rawEntry.dailyCapTimezone !== 'string' || !rawEntry.dailyCapTimezone.trim()) {
-        throw new ConfigError(`${where}.dailyCapTimezone must be a non-empty IANA timezone string when present.`)
-      }
-      dailyCapTimezone = rawEntry.dailyCapTimezone.trim()
-      try {
-        new Intl.DateTimeFormat('en-US', { timeZone: dailyCapTimezone })
-      } catch {
-        throw new ConfigError(`${where}.dailyCapTimezone ${JSON.stringify(dailyCapTimezone)} is not a recognized IANA timezone.`)
-      }
+    // #4932 gate round-2 P2-1 / round-3 P2-R3-1: the one-pair-per-WORK-DATE invariant is
+    // only as good as the day boundary the cap counts against, and an OPTIONAL field would
+    // let any stale config silently revert to the UTC default (the exact silent-revert
+    // class the retired ladder fields were made required against). REQUIRED, fail-closed:
+    // soak-seed writes dailyCapTimezone per entry (the org group's IANA timezone);
+    // bookkeeping-only — NEVER sent in a punch body (that would override the org rule
+    // timezone server-side).
+    if (typeof rawEntry.dailyCapTimezone !== 'string' || !rawEntry.dailyCapTimezone.trim()) {
+      throw new ConfigError(
+        `${where}.dailyCapTimezone is required — the 2/day pair cap must count against the org's `
+        + 'calendar day, and a config without it (any seeding older than this contract) would '
+        + 'silently revert the cap to UTC days. Re-run action=soak-seed to rewrite the config.'
+      )
+    }
+    const dailyCapTimezone = rawEntry.dailyCapTimezone.trim()
+    try {
+      new Intl.DateTimeFormat('en-US', { timeZone: dailyCapTimezone })
+    } catch {
+      throw new ConfigError(`${where}.dailyCapTimezone ${JSON.stringify(dailyCapTimezone)} is not a recognized IANA timezone.`)
     }
 
     const minCleanPunches = Number.isFinite(rawEntry.minCleanPunches) && rawEntry.minCleanPunches > 0
@@ -796,8 +799,11 @@ function nextEventType(userState) {
 }
 
 function capTimezoneFor(entry, config) {
-  // Per-entry org-day boundary; config.timezone (default UTC) only as a fallback.
-  return entry.dailyCapTimezone || config.timezone
+  // Per-entry org-day boundary — REQUIRED at config load, so no fallback exists here (a
+  // fallback would be the silent-revert channel the round-3 gate flagged). `config` stays
+  // in the signature so every call site routes through one auditable resolver.
+  void config
+  return entry.dailyCapTimezone
 }
 
 function userEligible(userState, opts, nowMs, timezone) {

--- a/scripts/ops/attendance-w4w7-soak-load-generator.mjs
+++ b/scripts/ops/attendance-w4w7-soak-load-generator.mjs
@@ -325,7 +325,10 @@ function buildOptions(argv) {
     // Default 8, per the runbook's ruled parameter row (§2A.7 recommended row, in effect per
     // §2A.9's default+veto record): 10 users/org x 3 orgs x 8 punches/user/day = 240/day, which
     // clears the ruled count criteria (N>=200 total, >=20/org, >=50/arm) inside one soak day.
-    // 8/user/day = check_in/check_out pairs across 4 sessions — still a real usage shape.
+    // Under the PAIR LADDER this caps punches per WALL-CLOCK day (rate hygiene): the 8 punches
+    // land as 4 in/out pairs on 4 DISTINCT backdated work dates, one pair per date — never as
+    // 4 same-date sessions (the retired cadence's shape, which floods §4.2-critical
+    // review_required diffs; see the entry validation).
     punchesPerUserPerDay: readNumberOpt(args, 'punches-per-user-per-day', 'SOAK_PUNCHES_PER_USER_PER_DAY', 8),
     targetTotal: readNumberOpt(args, 'target-total', 'SOAK_TARGET_TOTAL', 200), // §2A.3 C1
     targetPerOrg: readNumberOpt(args, 'target-per-org', 'SOAK_TARGET_PER_ORG', 20), // §2A.3 C2
@@ -343,6 +346,9 @@ function buildOptions(argv) {
       path.join(SCRIPT_DIR, `soak-load-generator-summary-${nowStampForFilename()}.json`)
     ),
     maxAttemptsSafetyMultiplier: readNumberOpt(args, 'max-attempts-multiplier', 'SOAK_MAX_ATTEMPTS_MULTIPLIER', 5),
+    // Pair-ladder depth ceiling: bounds how many distinct backdated work dates one run may
+    // descend below each entry's anchor (see the entry validation for why the ladder exists).
+    ladderMaxDepthDays: readNumberOpt(args, 'ladder-max-depth-days', 'SOAK_LADDER_MAX_DEPTH_DAYS', 60),
   }
 
   if (opts.rateLimitPerSec <= 0 || opts.rateLimitPerSec > 1) {
@@ -357,6 +363,9 @@ function buildOptions(argv) {
   if (opts.targetPerOrg <= 0) throw new ConfigError('--target-per-org must be > 0')
   if (opts.punchesPerUserPerDay <= 0) throw new ConfigError('--punches-per-user-per-day must be > 0')
   if (opts.minSecondsBetweenPunchesPerUser < 0) throw new ConfigError('--min-seconds-between-punches-per-user must be >= 0')
+  if (!Number.isInteger(opts.ladderMaxDepthDays) || opts.ladderMaxDepthDays <= 0 || opts.ladderMaxDepthDays > 366) {
+    throw new ConfigError('--ladder-max-depth-days must be an integer in [1, 366]')
+  }
 
   return opts
 }
@@ -391,10 +400,17 @@ Common options (env var fallback in parentheses):
   --output <path>                     Final JSON summary path. (SOAK_OUTPUT_FILE)
   --help                              This message.
 
-Note: occurredAt is never sent — every punch uses the server's own clock. Backdating is not
-implemented in this draft (a bounded, config-supplied offset would be needed to avoid the
-route's own FUTURE_PUNCH_NOT_ALLOWED / WORK_DATE_ATTRIBUTION_AMBIGUOUS guards; left as a named
-gap rather than shipped half-working).
+  --ladder-max-depth-days <n>         Pair-ladder depth ceiling per entry. Default 60. (SOAK_LADDER_MAX_DEPTH_DAYS)
+
+Note: every punch sends an explicit BACKDATED occurredAt (the PAIR LADDER): pair j for a user
+targets work date ladderAnchorDate - j, check_in at 00:00:00 and check_out at 23:59:00 wall
+time in ladderTimezone — one pair per (user, work date), which is why a healthy run's whole
+shadow-diff surface is 'equal'. The retired always-server-clock cadence packed every pair
+into ONE work date; the W4 calculator flags that as duplicate/ambiguous (review_required — a
+§4.2 CRITICAL diff class), so that fixture could never meet the ratified zero-critical
+criterion (soak-status 31962440160). Only PAST dates are ever sent (validated at config
+load), so the route's future-punch guard is never approached; anchors are injected per entry
+by action=soak-run from the DB (day before the family's earliest punched work date).
 
 This script defaults to DRY RUN. See the file header "SAFETY / NO-DESTRUCTIVE-OPS DISCIPLINE"
 for the three conditions required to send real traffic, and 【OWNER】 markers throughout.
@@ -526,6 +542,36 @@ async function loadConfig(opts) {
       }
     }
 
+    // PAIR-LADDER contract (both fields REQUIRED — the retired always-server-clock cadence
+    // is not selectable): each (user, work_date) gets exactly one check_in/check_out pair,
+    // pair j targeting ladderAnchorDate - j. Injected per entry by the runner's soak-run
+    // (anchor = day before the family's earliest punched work_date, from the DB); a config
+    // without them fails closed here rather than silently reverting to the retired cadence.
+    if (typeof rawEntry.ladderAnchorDate !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(rawEntry.ladderAnchorDate)) {
+      throw new ConfigError(
+        `${where}.ladderAnchorDate must be a YYYY-MM-DD date — the retired server-clock cadence `
+        + 'packs every pair into one work date and floods §4.2-critical review_required diffs '
+        + '(soak-status 31962440160); action=soak-run injects the anchor from the DB.'
+      )
+    }
+    if (typeof rawEntry.ladderTimezone !== 'string' || !rawEntry.ladderTimezone.trim()) {
+      throw new ConfigError(`${where}.ladderTimezone must name the org's group IANA timezone (soak-run injects it).`)
+    }
+    const ladderTimezone = rawEntry.ladderTimezone.trim()
+    try {
+      new Intl.DateTimeFormat('en-US', { timeZone: ladderTimezone })
+    } catch {
+      throw new ConfigError(`${where}.ladderTimezone ${JSON.stringify(ladderTimezone)} is not a recognized IANA timezone.`)
+    }
+    const todayInLadderTz = workDateInTimezone(new Date(), ladderTimezone)
+    if (rawEntry.ladderAnchorDate >= todayInLadderTz) {
+      throw new ConfigError(
+        `${where}.ladderAnchorDate ${rawEntry.ladderAnchorDate} is not strictly before today (${todayInLadderTz} `
+        + `in ${ladderTimezone}) — only PAST work dates are punched (future/today would race the server clock `
+        + "and the route's future-punch guard)."
+      )
+    }
+
     const minCleanPunches = Number.isFinite(rawEntry.minCleanPunches) && rawEntry.minCleanPunches > 0
       ? rawEntry.minCleanPunches
       : opts.targetPerOrg
@@ -554,6 +600,8 @@ async function loadConfig(opts) {
       minCleanPunches,
       userIds,
       tokenOrCreds,
+      ladderAnchorDate: rawEntry.ladderAnchorDate,
+      ladderTimezone,
     }
   })
 
@@ -625,6 +673,44 @@ function workDateInTimezone(date, timezone) {
   return `${map.year}-${map.month}-${map.day}`
 }
 
+/** date-only arithmetic on YYYY-MM-DD strings (UTC-anchored — no zone involved). */
+function minusDaysDateOnly(dateStr, days) {
+  const base = new Date(`${dateStr}T00:00:00Z`)
+  base.setUTCDate(base.getUTCDate() - days)
+  return base.toISOString().slice(0, 10)
+}
+
+/**
+ * The UTC instant of wall time `HH:MM:SS` on `YYYY-MM-DD` in `timezone`, as an ISO string.
+ * Two-pass offset derivation with `hourCycle: 'h23'` + a defensive 24->0 fold — the
+ * repo-wide h24-midnight lesson (#4922): older ICU resolves `hour12: false` to the h24
+ * cycle, formats midnight as hour '24', and a naive Date.UTC(...) then overflows a day
+ * forward, which for THIS tool would land every 00:00 check_in on the wrong work date.
+ * Exact for fixed-offset zones (the soak's Asia/Shanghai); a DST-fold wall time would
+ * resolve to one of its two instants, which is fine for fixture purposes.
+ */
+function zonedDateTimeToUtcIso(dateStr, timeStr, timezone) {
+  const fmt = new Intl.DateTimeFormat('en-CA', {
+    timeZone: timezone, hourCycle: 'h23',
+    year: 'numeric', month: '2-digit', day: '2-digit',
+    hour: '2-digit', minute: '2-digit', second: '2-digit',
+  })
+  const wallAsUtc = Date.parse(`${dateStr}T${timeStr}.000Z`)
+  const partsAt = (ms) => {
+    const map = Object.fromEntries(fmt.formatToParts(new Date(ms)).map((p) => [p.type, p.value]))
+    let hour = Number(map.hour)
+    if (hour === 24) hour = 0
+    return Date.UTC(Number(map.year), Number(map.month) - 1, Number(map.day), hour, Number(map.minute), Number(map.second))
+  }
+  // First pass: the zone's UTC offset observed at `wallAsUtc`; second pass re-derives the
+  // offset AT the candidate instant (handles offset transitions near the target wall time).
+  let offset = partsAt(wallAsUtc) - wallAsUtc
+  let candidate = wallAsUtc - offset
+  offset = partsAt(candidate) - candidate
+  candidate = wallAsUtc - offset
+  return new Date(candidate).toISOString()
+}
+
 // -----------------------------------------------------------------------------------------
 // HTTP punch call
 // -----------------------------------------------------------------------------------------
@@ -670,14 +756,21 @@ function classifyResponse(status, bodyText) {
   }
 }
 
-async function sendPunchWithRetry({ baseUrl, entry, userId, token, eventType, operationId, opts, throttle }) {
+async function sendPunchWithRetry({ baseUrl, entry, userId, token, eventType, operationId, occurredAt, opts, throttle }) {
   const body = {
     eventType,
     operationId, // idempotency key — same value reused across the retries below
     source: opts.sourceTagResolved,
     // meta intentionally omitted (null) — see "meta IS NOT AN INERT BAG" in the file header.
     orgId: entry.orgId, // always explicit — never rely on the token's own org claim (getOrgId precedence)
-    // occurredAt intentionally omitted — server clock always (no backdate support in this draft).
+    // PAIR-LADDER (retired-cadence replacement): an explicit BACKDATED business instant.
+    // The retired always-server-clock cadence packed every pair into one work date, which
+    // the W4 calculator flags as duplicate/ambiguous (review_required — a §4.2 CRITICAL
+    // class), so that fixture could never meet the ratified zero-critical criterion
+    // (soak-status 31962440160: 50+80 critical rows from cadence alone). Each pair now
+    // targets its own past work date; only PAST dates are ever sent (validated at config
+    // load), so the route's future-punch guard is never approached.
+    occurredAt,
   }
   if (opts.timezoneToSend) {
     // Only sent when the config file explicitly declared a timezone — see the file header's
@@ -751,7 +844,8 @@ function buildUserPool(config) {
         token: entry.tokenOrCreds[userId],
         lastPunchAt: 0,
         lastEventType: null, // null => first punch is check_in
-        dailyCounts: new Map(), // workDate(tz) -> count
+        dailyCounts: new Map(), // workDate(tz) -> count (WALL-CLOCK day — rate hygiene, not ladder targeting)
+        pairCursor: 0, // pair j targets entry.ladderAnchorDate - j; advances on a CLEAN check_out
       })
     }
   }
@@ -769,6 +863,9 @@ function userEligible(userState, opts, nowMs, timezone) {
   const today = workDateInTimezone(new Date(nowMs), timezone)
   const countToday = userState.dailyCounts.get(today) || 0
   if (countToday >= opts.punchesPerUserPerDay) return false
+  // Ladder depth bound: never descend more than ladderMaxDepthDays behind the anchor —
+  // a runaway (or mis-targeted) run must stall out rather than backfill months of records.
+  if (userState.pairCursor >= opts.ladderMaxDepthDays) return false
   return true
 }
 
@@ -888,6 +985,17 @@ function assessFeasibility(config, opts) {
   }))
   const slowestOrgDays = Math.max(totalDaysNeeded, ...perOrgDays.map((o) => o.daysNeeded))
 
+  // Ladder-depth reachability: each user contributes at most 2 punches per backdated work
+  // date, so the depth ceiling bounds this run's total capacity outright.
+  const ladderCapacity = totalUsers * opts.ladderMaxDepthDays * 2
+  if (opts.targetTotal > ladderCapacity) {
+    throw new ConfigError(
+      `targetTotal=${opts.targetTotal} exceeds the pair-ladder capacity ${ladderCapacity} `
+      + `(${totalUsers} users x ladderMaxDepthDays=${opts.ladderMaxDepthDays} x 2 punches/date) — `
+      + 'raise --ladder-max-depth-days, add users, or lower the target.'
+    )
+  }
+
   const lines = [
     `[feasibility] ${totalUsers} total users x ${opts.punchesPerUserPerDay}/day = `
     + `${totalDailyCapacity} punches/day best-case capacity`,
@@ -966,6 +1074,16 @@ async function runScheduler({ config, opts, willExecute }) {
 
     const eventType = nextEventType(picked)
     const operationId = randomUUID()
+    // Pair j targets work date anchor - j. check_in lands exactly ON the segment start
+    // (00:00:00 wall) and check_out at the segment end (23:59:00 wall): with the seeded
+    // full-day shift both machines compute zero late/early minutes, so a healthy run's
+    // whole diff surface is 'equal' — any non-equal row is signal, never fixture noise.
+    const ladderDate = minusDaysDateOnly(picked.entry.ladderAnchorDate, picked.pairCursor)
+    const occurredAt = zonedDateTimeToUtcIso(
+      ladderDate,
+      eventType === 'check_in' ? '00:00:00' : '23:59:00',
+      picked.entry.ladderTimezone,
+    )
 
     let result
     if (willExecute) {
@@ -979,6 +1097,7 @@ async function runScheduler({ config, opts, willExecute }) {
         token: picked.token,
         eventType,
         operationId,
+        occurredAt,
         opts,
         throttle,
       })
@@ -999,6 +1118,10 @@ async function runScheduler({ config, opts, willExecute }) {
 
     if (result.category === 'clean') {
       consecutiveIncidents = 0
+      // A CLEAN check_out completes this user's pair for `ladderDate`; the next pair
+      // descends one day. A failed check_out leaves the cursor put, so the SAME date is
+      // retried (a permanently half-punched date would surface as its own diff signal).
+      if (eventType === 'check_out') picked.pairCursor += 1
     } else {
       consecutiveIncidents++
       incidentLog.push({

--- a/scripts/ops/attendance-w4w7-soak-load-generator.mjs
+++ b/scripts/ops/attendance-w4w7-soak-load-generator.mjs
@@ -322,14 +322,16 @@ function buildOptions(argv) {
     confirmToken: readOpt(args, 'confirm', 'SOAK_CONFIRM', ''),
     confirmOrgIds: readOpt(args, 'confirm-org-ids', 'SOAK_CONFIRM_ORG_IDS', ''),
     rateLimitPerSec: readNumberOpt(args, 'rate-limit-per-sec', 'SOAK_RATE_LIMIT_PER_SEC', 1),
-    // Default 8, per the runbook's ruled parameter row (§2A.7 recommended row, in effect per
-    // §2A.9's default+veto record): 10 users/org x 3 orgs x 8 punches/user/day = 240/day, which
-    // clears the ruled count criteria (N>=200 total, >=20/org, >=50/arm) inside one soak day.
-    // Under the PAIR LADDER this caps punches per WALL-CLOCK day (rate hygiene): the 8 punches
-    // land as 4 in/out pairs on 4 DISTINCT backdated work dates, one pair per date — never as
-    // 4 same-date sessions (the retired cadence's shape, which floods §4.2-critical
-    // review_required diffs; see the entry validation).
-    punchesPerUserPerDay: readNumberOpt(args, 'punches-per-user-per-day', 'SOAK_PUNCHES_PER_USER_PER_DAY', 8),
+    // Default 2 = ONE check_in/check_out pair per user per wall-clock day. This REVISES the
+    // §2A.7 recommended row's 8/day (a documented, owner-vetoable deviation per §2A.9): the
+    // soak itself proved 8/day structurally violates the ratified zero-critical criterion —
+    // 4 same-day sessions on one full-day segment are flagged duplicate/ambiguous by the W4
+    // calculator (review_required, a §4.2 CRITICAL class; soak-status 31962440160 counted
+    // 50+80 critical rows from cadence alone). Backdated multi-date acceleration was built
+    // and retired unmerged (#4932 gate P1-1: enforcePunchConstraints' global-latest ordering
+    // 429s every backdated check_out). The honest accelerator is users_per_org at seed time,
+    // never same-day session packing.
+    punchesPerUserPerDay: readNumberOpt(args, 'punches-per-user-per-day', 'SOAK_PUNCHES_PER_USER_PER_DAY', 2),
     targetTotal: readNumberOpt(args, 'target-total', 'SOAK_TARGET_TOTAL', 200), // §2A.3 C1
     targetPerOrg: readNumberOpt(args, 'target-per-org', 'SOAK_TARGET_PER_ORG', 20), // §2A.3 C2
     targetPerArm: readNumberOpt(args, 'target-per-arm', 'SOAK_TARGET_PER_ARM', 50), // §2A.3 C4
@@ -346,9 +348,6 @@ function buildOptions(argv) {
       path.join(SCRIPT_DIR, `soak-load-generator-summary-${nowStampForFilename()}.json`)
     ),
     maxAttemptsSafetyMultiplier: readNumberOpt(args, 'max-attempts-multiplier', 'SOAK_MAX_ATTEMPTS_MULTIPLIER', 5),
-    // Pair-ladder depth ceiling: bounds how many distinct backdated work dates one run may
-    // descend below each entry's anchor (see the entry validation for why the ladder exists).
-    ladderMaxDepthDays: readNumberOpt(args, 'ladder-max-depth-days', 'SOAK_LADDER_MAX_DEPTH_DAYS', 60),
   }
 
   if (opts.rateLimitPerSec <= 0 || opts.rateLimitPerSec > 1) {
@@ -363,10 +362,6 @@ function buildOptions(argv) {
   if (opts.targetPerOrg <= 0) throw new ConfigError('--target-per-org must be > 0')
   if (opts.punchesPerUserPerDay <= 0) throw new ConfigError('--punches-per-user-per-day must be > 0')
   if (opts.minSecondsBetweenPunchesPerUser < 0) throw new ConfigError('--min-seconds-between-punches-per-user must be >= 0')
-  if (!Number.isInteger(opts.ladderMaxDepthDays) || opts.ladderMaxDepthDays <= 0 || opts.ladderMaxDepthDays > 366) {
-    throw new ConfigError('--ladder-max-depth-days must be an integer in [1, 366]')
-  }
-
   return opts
 }
 
@@ -400,17 +395,13 @@ Common options (env var fallback in parentheses):
   --output <path>                     Final JSON summary path. (SOAK_OUTPUT_FILE)
   --help                              This message.
 
-  --ladder-max-depth-days <n>         Pair-ladder depth ceiling per entry. Default 60. (SOAK_LADDER_MAX_DEPTH_DAYS)
-
-Note: every punch sends an explicit BACKDATED occurredAt (the PAIR LADDER): pair j for a user
-targets work date ladderAnchorDate - j, check_in at 00:00:00 and check_out at 23:59:00 wall
-time in ladderTimezone — one pair per (user, work date), which is why a healthy run's whole
-shadow-diff surface is 'equal'. The retired always-server-clock cadence packed every pair
-into ONE work date; the W4 calculator flags that as duplicate/ambiguous (review_required — a
-§4.2 CRITICAL diff class), so that fixture could never meet the ratified zero-critical
-criterion (soak-status 31962440160). Only PAST dates are ever sent (validated at config
-load), so the route's future-punch guard is never approached; anchors are injected per entry
-by action=soak-run from the DB (day before the family's earliest punched work date).
+Note: occurredAt is never sent — every punch uses the server's own clock, and the default
+daily cap of 2 gives each user exactly ONE in/out pair per wall-clock day. Same-day session
+packing (the old 8/day row) floods §4.2-critical review_required diffs (soak-status
+31962440160), and backdating was built and retired unmerged (#4932 gate P1-1:
+enforcePunchConstraints' global-latest ordering 429s every backdated check_out). Reaching
+the runbook's cumulative count criteria is therefore a MULTI-DAY affair by design; the
+honest accelerator is users_per_org at seed time.
 
 This script defaults to DRY RUN. See the file header "SAFETY / NO-DESTRUCTIVE-OPS DISCIPLINE"
 for the three conditions required to send real traffic, and 【OWNER】 markers throughout.
@@ -542,36 +533,6 @@ async function loadConfig(opts) {
       }
     }
 
-    // PAIR-LADDER contract (both fields REQUIRED — the retired always-server-clock cadence
-    // is not selectable): each (user, work_date) gets exactly one check_in/check_out pair,
-    // pair j targeting ladderAnchorDate - j. Injected per entry by the runner's soak-run
-    // (anchor = day before the family's earliest punched work_date, from the DB); a config
-    // without them fails closed here rather than silently reverting to the retired cadence.
-    if (typeof rawEntry.ladderAnchorDate !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(rawEntry.ladderAnchorDate)) {
-      throw new ConfigError(
-        `${where}.ladderAnchorDate must be a YYYY-MM-DD date — the retired server-clock cadence `
-        + 'packs every pair into one work date and floods §4.2-critical review_required diffs '
-        + '(soak-status 31962440160); action=soak-run injects the anchor from the DB.'
-      )
-    }
-    if (typeof rawEntry.ladderTimezone !== 'string' || !rawEntry.ladderTimezone.trim()) {
-      throw new ConfigError(`${where}.ladderTimezone must name the org's group IANA timezone (soak-run injects it).`)
-    }
-    const ladderTimezone = rawEntry.ladderTimezone.trim()
-    try {
-      new Intl.DateTimeFormat('en-US', { timeZone: ladderTimezone })
-    } catch {
-      throw new ConfigError(`${where}.ladderTimezone ${JSON.stringify(ladderTimezone)} is not a recognized IANA timezone.`)
-    }
-    const todayInLadderTz = workDateInTimezone(new Date(), ladderTimezone)
-    if (rawEntry.ladderAnchorDate >= todayInLadderTz) {
-      throw new ConfigError(
-        `${where}.ladderAnchorDate ${rawEntry.ladderAnchorDate} is not strictly before today (${todayInLadderTz} `
-        + `in ${ladderTimezone}) — only PAST work dates are punched (future/today would race the server clock `
-        + "and the route's future-punch guard)."
-      )
-    }
-
     const minCleanPunches = Number.isFinite(rawEntry.minCleanPunches) && rawEntry.minCleanPunches > 0
       ? rawEntry.minCleanPunches
       : opts.targetPerOrg
@@ -600,8 +561,6 @@ async function loadConfig(opts) {
       minCleanPunches,
       userIds,
       tokenOrCreds,
-      ladderAnchorDate: rawEntry.ladderAnchorDate,
-      ladderTimezone,
     }
   })
 
@@ -673,44 +632,6 @@ function workDateInTimezone(date, timezone) {
   return `${map.year}-${map.month}-${map.day}`
 }
 
-/** date-only arithmetic on YYYY-MM-DD strings (UTC-anchored — no zone involved). */
-function minusDaysDateOnly(dateStr, days) {
-  const base = new Date(`${dateStr}T00:00:00Z`)
-  base.setUTCDate(base.getUTCDate() - days)
-  return base.toISOString().slice(0, 10)
-}
-
-/**
- * The UTC instant of wall time `HH:MM:SS` on `YYYY-MM-DD` in `timezone`, as an ISO string.
- * Two-pass offset derivation with `hourCycle: 'h23'` + a defensive 24->0 fold — the
- * repo-wide h24-midnight lesson (#4922): older ICU resolves `hour12: false` to the h24
- * cycle, formats midnight as hour '24', and a naive Date.UTC(...) then overflows a day
- * forward, which for THIS tool would land every 00:00 check_in on the wrong work date.
- * Exact for fixed-offset zones (the soak's Asia/Shanghai); a DST-fold wall time would
- * resolve to one of its two instants, which is fine for fixture purposes.
- */
-function zonedDateTimeToUtcIso(dateStr, timeStr, timezone) {
-  const fmt = new Intl.DateTimeFormat('en-CA', {
-    timeZone: timezone, hourCycle: 'h23',
-    year: 'numeric', month: '2-digit', day: '2-digit',
-    hour: '2-digit', minute: '2-digit', second: '2-digit',
-  })
-  const wallAsUtc = Date.parse(`${dateStr}T${timeStr}.000Z`)
-  const partsAt = (ms) => {
-    const map = Object.fromEntries(fmt.formatToParts(new Date(ms)).map((p) => [p.type, p.value]))
-    let hour = Number(map.hour)
-    if (hour === 24) hour = 0
-    return Date.UTC(Number(map.year), Number(map.month) - 1, Number(map.day), hour, Number(map.minute), Number(map.second))
-  }
-  // First pass: the zone's UTC offset observed at `wallAsUtc`; second pass re-derives the
-  // offset AT the candidate instant (handles offset transitions near the target wall time).
-  let offset = partsAt(wallAsUtc) - wallAsUtc
-  let candidate = wallAsUtc - offset
-  offset = partsAt(candidate) - candidate
-  candidate = wallAsUtc - offset
-  return new Date(candidate).toISOString()
-}
-
 // -----------------------------------------------------------------------------------------
 // HTTP punch call
 // -----------------------------------------------------------------------------------------
@@ -756,21 +677,20 @@ function classifyResponse(status, bodyText) {
   }
 }
 
-async function sendPunchWithRetry({ baseUrl, entry, userId, token, eventType, operationId, occurredAt, opts, throttle }) {
+async function sendPunchWithRetry({ baseUrl, entry, userId, token, eventType, operationId, opts, throttle }) {
   const body = {
     eventType,
     operationId, // idempotency key — same value reused across the retries below
     source: opts.sourceTagResolved,
     // meta intentionally omitted (null) — see "meta IS NOT AN INERT BAG" in the file header.
     orgId: entry.orgId, // always explicit — never rely on the token's own org claim (getOrgId precedence)
-    // PAIR-LADDER (retired-cadence replacement): an explicit BACKDATED business instant.
-    // The retired always-server-clock cadence packed every pair into one work date, which
-    // the W4 calculator flags as duplicate/ambiguous (review_required — a §4.2 CRITICAL
-    // class), so that fixture could never meet the ratified zero-critical criterion
-    // (soak-status 31962440160: 50+80 critical rows from cadence alone). Each pair now
-    // targets its own past work date; only PAST dates are ever sent (validated at config
-    // load), so the route's future-punch guard is never approached.
-    occurredAt,
+    // occurredAt intentionally omitted — server clock always. Backdating was BUILT and then
+    // RETIRED unmerged: enforcePunchConstraints compares each punch against the user's
+    // GLOBALLY LATEST event (ORDER BY occurred_at DESC LIMIT 1, index.cjs ~22465), so any
+    // check_out below an already-recorded later same-type event 429s (PUNCH_TOO_SOON) —
+    // the #4932 gate reproduced a descending backdate ladder jamming on exactly that from
+    // rung 1 onward. Same-day pacing is governed by punchesPerUserPerDay (default 2 = one
+    // in/out pair per user per wall-day) instead.
   }
   if (opts.timezoneToSend) {
     // Only sent when the config file explicitly declared a timezone — see the file header's
@@ -844,8 +764,7 @@ function buildUserPool(config) {
         token: entry.tokenOrCreds[userId],
         lastPunchAt: 0,
         lastEventType: null, // null => first punch is check_in
-        dailyCounts: new Map(), // workDate(tz) -> count (WALL-CLOCK day — rate hygiene, not ladder targeting)
-        pairCursor: 0, // pair j targets entry.ladderAnchorDate - j; advances on a CLEAN check_out
+        dailyCounts: new Map(), // workDate(tz) -> count
       })
     }
   }
@@ -863,9 +782,6 @@ function userEligible(userState, opts, nowMs, timezone) {
   const today = workDateInTimezone(new Date(nowMs), timezone)
   const countToday = userState.dailyCounts.get(today) || 0
   if (countToday >= opts.punchesPerUserPerDay) return false
-  // Ladder depth bound: never descend more than ladderMaxDepthDays behind the anchor —
-  // a runaway (or mis-targeted) run must stall out rather than backfill months of records.
-  if (userState.pairCursor >= opts.ladderMaxDepthDays) return false
   return true
 }
 
@@ -985,17 +901,6 @@ function assessFeasibility(config, opts) {
   }))
   const slowestOrgDays = Math.max(totalDaysNeeded, ...perOrgDays.map((o) => o.daysNeeded))
 
-  // Ladder-depth reachability: each user contributes at most 2 punches per backdated work
-  // date, so the depth ceiling bounds this run's total capacity outright.
-  const ladderCapacity = totalUsers * opts.ladderMaxDepthDays * 2
-  if (opts.targetTotal > ladderCapacity) {
-    throw new ConfigError(
-      `targetTotal=${opts.targetTotal} exceeds the pair-ladder capacity ${ladderCapacity} `
-      + `(${totalUsers} users x ladderMaxDepthDays=${opts.ladderMaxDepthDays} x 2 punches/date) — `
-      + 'raise --ladder-max-depth-days, add users, or lower the target.'
-    )
-  }
-
   const lines = [
     `[feasibility] ${totalUsers} total users x ${opts.punchesPerUserPerDay}/day = `
     + `${totalDailyCapacity} punches/day best-case capacity`,
@@ -1063,27 +968,25 @@ async function runScheduler({ config, opts, willExecute }) {
       break
     }
     if (!picked) {
-      // Nobody eligible right now (daily caps or per-user spacing cooldown, or — see
-      // assessFeasibility — a legitimate wait for the next calendar day to reset daily caps).
-      // Bounded by the stall-timeout check above, which does NOT false-fire on this: it only
-      // fires after opts.stallTimeoutMinutes of ZERO attempts, deliberately set longer than
-      // one calendar-day daily-cap reset.
+      // DAILY-BATCH clean halt: when every user is either day-capped or belongs to an org
+      // whose targets are already met, nothing more can happen until the next wall-clock
+      // day — end THIS invocation cleanly instead of idling to the stall timeout. The
+      // runbook's cumulative count criteria accrue across daily batches (DB-side
+      // soak-status judgments), so this is a success outcome, not a shortfall.
+      const todayKey = workDateInTimezone(new Date(), config.timezone)
+      const allCapped = pool.every((u) =>
+        !orgNeedsMorePunches(tally, u.entry, opts)
+        || (u.dailyCounts.get(todayKey) || 0) >= opts.punchesPerUserPerDay)
+      if (allCapped) { haltedReason = 'daily_capacity_exhausted'; break }
+      // Otherwise somebody is only cooldown-ineligible (per-user spacing) — wait briefly.
+      // Bounded by the stall-timeout check above (fires only after stallTimeoutMinutes of
+      // ZERO attempts).
       await sleep(1000)
       continue
     }
 
     const eventType = nextEventType(picked)
     const operationId = randomUUID()
-    // Pair j targets work date anchor - j. check_in lands exactly ON the segment start
-    // (00:00:00 wall) and check_out at the segment end (23:59:00 wall): with the seeded
-    // full-day shift both machines compute zero late/early minutes, so a healthy run's
-    // whole diff surface is 'equal' — any non-equal row is signal, never fixture noise.
-    const ladderDate = minusDaysDateOnly(picked.entry.ladderAnchorDate, picked.pairCursor)
-    const occurredAt = zonedDateTimeToUtcIso(
-      ladderDate,
-      eventType === 'check_in' ? '00:00:00' : '23:59:00',
-      picked.entry.ladderTimezone,
-    )
 
     let result
     if (willExecute) {
@@ -1097,7 +1000,6 @@ async function runScheduler({ config, opts, willExecute }) {
         token: picked.token,
         eventType,
         operationId,
-        occurredAt,
         opts,
         throttle,
       })
@@ -1118,10 +1020,6 @@ async function runScheduler({ config, opts, willExecute }) {
 
     if (result.category === 'clean') {
       consecutiveIncidents = 0
-      // A CLEAN check_out completes this user's pair for `ladderDate`; the next pair
-      // descends one day. A failed check_out leaves the cursor put, so the SAME date is
-      // retried (a permanently half-punched date would surface as its own diff signal).
-      if (eventType === 'check_out') picked.pairCursor += 1
     } else {
       consecutiveIncidents++
       incidentLog.push({

--- a/scripts/ops/attendance-w4w7-soak-load-generator.mjs
+++ b/scripts/ops/attendance-w4w7-soak-load-generator.mjs
@@ -533,6 +533,24 @@ async function loadConfig(opts) {
       }
     }
 
+    // #4932 gate round-2 P2-1: the one-pair-per-WORK-DATE invariant is only as good as the
+    // day boundary the cap counts against. config.timezone defaults to UTC while the soak
+    // orgs' work dates are org-timezone days, so the cap must key on the ORG'S day: soak-seed
+    // writes dailyCapTimezone per entry (the org group's IANA timezone). Bookkeeping-only —
+    // NEVER sent in a punch body (that would override the org rule timezone server-side).
+    let dailyCapTimezone = null
+    if (rawEntry.dailyCapTimezone !== undefined) {
+      if (typeof rawEntry.dailyCapTimezone !== 'string' || !rawEntry.dailyCapTimezone.trim()) {
+        throw new ConfigError(`${where}.dailyCapTimezone must be a non-empty IANA timezone string when present.`)
+      }
+      dailyCapTimezone = rawEntry.dailyCapTimezone.trim()
+      try {
+        new Intl.DateTimeFormat('en-US', { timeZone: dailyCapTimezone })
+      } catch {
+        throw new ConfigError(`${where}.dailyCapTimezone ${JSON.stringify(dailyCapTimezone)} is not a recognized IANA timezone.`)
+      }
+    }
+
     const minCleanPunches = Number.isFinite(rawEntry.minCleanPunches) && rawEntry.minCleanPunches > 0
       ? rawEntry.minCleanPunches
       : opts.targetPerOrg
@@ -561,6 +579,7 @@ async function loadConfig(opts) {
       minCleanPunches,
       userIds,
       tokenOrCreds,
+      dailyCapTimezone,
     }
   })
 
@@ -776,6 +795,11 @@ function nextEventType(userState) {
   return 'check_in'
 }
 
+function capTimezoneFor(entry, config) {
+  // Per-entry org-day boundary; config.timezone (default UTC) only as a fallback.
+  return entry.dailyCapTimezone || config.timezone
+}
+
 function userEligible(userState, opts, nowMs, timezone) {
   const sinceLast = (nowMs - userState.lastPunchAt) / 1000
   if (userState.lastPunchAt !== 0 && sinceLast < opts.minSecondsBetweenPunchesPerUser) return false
@@ -962,7 +986,7 @@ async function runScheduler({ config, opts, willExecute }) {
       const idx = (cursor + i) % pool.length
       const candidate = pool[idx]
       if (!orgNeedsMorePunches(tally, candidate.entry, opts)) continue
-      if (!userEligible(candidate, opts, Date.now(), config.timezone)) continue
+      if (!userEligible(candidate, opts, Date.now(), capTimezoneFor(candidate.entry, config))) continue
       picked = candidate
       cursor = idx + 1
       break
@@ -973,10 +997,9 @@ async function runScheduler({ config, opts, willExecute }) {
       // day — end THIS invocation cleanly instead of idling to the stall timeout. The
       // runbook's cumulative count criteria accrue across daily batches (DB-side
       // soak-status judgments), so this is a success outcome, not a shortfall.
-      const todayKey = workDateInTimezone(new Date(), config.timezone)
       const allCapped = pool.every((u) =>
         !orgNeedsMorePunches(tally, u.entry, opts)
-        || (u.dailyCounts.get(todayKey) || 0) >= opts.punchesPerUserPerDay)
+        || (u.dailyCounts.get(workDateInTimezone(new Date(), capTimezoneFor(u.entry, config))) || 0) >= opts.punchesPerUserPerDay)
       if (allCapped) { haltedReason = 'daily_capacity_exhausted'; break }
       // Otherwise somebody is only cooldown-ineligible (per-user spacing) — wait briefly.
       // Bounded by the stall-timeout check above (fires only after stallTimeoutMinutes of
@@ -1032,7 +1055,7 @@ async function runScheduler({ config, opts, willExecute }) {
       })
     }
 
-    const today = workDateInTimezone(new Date(), config.timezone)
+    const today = workDateInTimezone(new Date(), capTimezoneFor(picked.entry, config))
     picked.dailyCounts.set(today, (picked.dailyCounts.get(today) || 0) + 1)
 
     sinceLastPrint++

--- a/scripts/ops/attendance-window-runner-pipeline.test.mjs
+++ b/scripts/ops/attendance-window-runner-pipeline.test.mjs
@@ -963,6 +963,15 @@ function assertSoakContract({ remote, workflow }) {
     'soak-run must track the last batch day host-side',
   )
   assert.ok(
+    slices.run.includes('carries no dailyCapTimezone'),
+    'soak-run must refuse a config without dailyCapTimezone (stale-config silent revert)',
+  )
+  assert.doesNotMatch(
+    slices.run,
+    /\.get\("dailyCapTimezone"/,
+    'the runner batch-day derivation must have no UTC default',
+  )
+  assert.ok(
     slices.run.includes('allow_same_day_rerun'),
     'the same-day guard must have exactly the explicit override, never a silent bypass',
   )
@@ -1442,6 +1451,17 @@ function assertGeneratorCadenceContract(generator) {
   assert.ok(
     generator.includes('function capTimezoneFor(entry, config)'),
     'the per-entry cap-timezone resolver must exist',
+  )
+  // Round-3 P2-R3-1: REQUIRED, fail-closed — an optional field lets any stale config
+  // silently revert the cap (and the runner guard) to UTC days.
+  assert.ok(
+    generator.includes('.dailyCapTimezone is required'),
+    'dailyCapTimezone must be REQUIRED — a stale config must refuse, never silently revert to UTC days',
+  )
+  assert.doesNotMatch(
+    generator,
+    /entry\.dailyCapTimezone \|\|/,
+    'the cap-timezone resolver must have no fallback (a fallback is the silent-revert channel)',
   )
   assert.equal(
     (generator.match(/capTimezoneFor\((?:candidate|picked|u)\.entry, config\)/g) || []).length,

--- a/scripts/ops/attendance-window-runner-pipeline.test.mjs
+++ b/scripts/ops/attendance-window-runner-pipeline.test.mjs
@@ -927,14 +927,30 @@ function assertSoakContract({ remote, workflow }) {
     slices.run.includes('is NOT in the live W7 allowlist'),
     'soak-run must fail closed when a both-machines config org is outside the live W7 allowlist',
   )
-  // P3-2/P3-3: a single soak-run is capped at one dayʼs clean-punch capacity so targets_met
-  // stays reachable and the run fits the job timeout.
+  // P3-2/P3-3 (revised for the pair cadence): a single soak-run is one DAILY BATCH capped
+  // at total_users x 2, so targets_met/daily_capacity_exhausted stay reachable inside the
+  // job timeout. The 2/user/day cap is LOAD-BEARING: same-day session packing (the old
+  // 8/day row) floods §4.2-critical review_required diffs (soak-status 31962440160), and
+  // backdated acceleration is rejected by the routeʼs global-latest punch ordering
+  // (#4932 gate P1-1) — the honest accelerator is users_per_org at seed time.
   assert.ok(
     slices.run.includes("one-day clean-punch capacity"),
-    'soak-run must cap punch_target at the configʼs one-day capacity (total_users x 8)',
+    'soak-run must cap punch_target at the configʼs one-day capacity (total_users x 2)',
+  )
+  assert.ok(
+    slices.run.includes('day_capacity=$(( total_users * 2 ))'),
+    'the one-day capacity must be total_users x 2 (one in/out pair per user per wall-day)',
   )
   assert.ok(slices.run.includes('--rate-limit-per-sec 1'), 'soak-run must pin the ruled <=1 req/sec global ceiling')
-  assert.ok(slices.run.includes('--punches-per-user-per-day 8'), 'soak-run must pin the ruled 8 punches/user/day quota')
+  assert.ok(
+    slices.run.includes('--punches-per-user-per-day 2'),
+    'soak-run must pin the 2 punches/user/day pair cadence (8/day floods critical review_required diffs)',
+  )
+  assert.doesNotMatch(
+    slices.run,
+    /--punches-per-user-per-day 8/,
+    'the retired 8/day session-packing quota must not come back',
+  )
   assert.ok(
     slices.run.includes('--confirm I_UNDERSTAND_THIS_DRIVES_SYNTHETIC_STAGING_TRAFFIC_ONLY'),
     'soak-run must carry the generatorʼs exact execute confirmation token',
@@ -1348,108 +1364,62 @@ test('P2-1: a newline-injection payload in soak_opts is REJECTED by workflow val
   assert.match(r.stderr, /single-line/, 'rejection must name the single-line rule')
 })
 
-test('soak pair-ladder: runner derives per-org anchors from the DB and injects them; generator fails closed without them and sends explicit backdated occurredAt', () => {
-  const remote = readFileSync(REMOTE_SH, 'utf8')
-  const generator = readFileSync(GENERATOR, 'utf8')
-  // Runner: anchor = day before the family's earliest punched work_date, family reached via
-  // the username join (NEVER a user_id prefix — the retired TEXT-id shape), fallback =
-  // yesterday in the org group's timezone; both injected into the run config copy.
+/**
+ * Generator cadence contract — ONE assertion body shared by the source test AND its
+ * mutation legs (#4932 gate P2-2: legs that re-check a pin by hand instead of calling the
+ * pinned assertion are tautologies — deleting the pin left both legs green).
+ */
+function assertGeneratorCadenceContract(generator) {
   assert.ok(
-    remote.includes("SELECT to_char(COALESCE((SELECT min(r.work_date) FROM attendance_records r WHERE r.org_id = '${cfg_org}' AND EXISTS (SELECT 1 FROM users u WHERE u.id = r.user_id AND u.username LIKE '${SOAK_USER_PREFIX}%')) - 1, (now() AT TIME ZONE '${tzv}')::date - 1), 'YYYY-MM-DD');"),
-    'soak-run must derive each orgʼs ladder anchor from the familyʼs earliest punched work_date via the username join',
-  )
-  assert.ok(
-    remote.includes('entry["ladderAnchorDate"] = anchor') && remote.includes('entry["ladderTimezone"] = tz'),
-    'soak-run must inject ladderAnchorDate/ladderTimezone into every run-config entry',
+    generator.includes("'SOAK_PUNCHES_PER_USER_PER_DAY', 2)"),
+    'the generator default must be 2 punches/user/day — one in/out pair per user per wall-day (8/day session packing floods §4.2-critical review_required diffs, soak-status 31962440160)',
   )
   assert.ok(
-    remote.includes('[soak-run] ladder anchor MISSING for org'),
-    'a config org without a derived anchor must fail the injection step, never run anchorless',
-  )
-  // Generator: both fields REQUIRED (fail-closed — the retired cadence is not selectable),
-  // anchor strictly before today, explicit occurredAt in the punch body, pair advance only
-  // on a CLEAN check_out, depth ceiling, and the h23 zoned construction (h24-midnight class).
-  assert.ok(
-    generator.includes('.ladderAnchorDate must be a YYYY-MM-DD date'),
-    'generator must refuse an entry without ladderAnchorDate',
+    generator.includes("haltedReason = 'daily_capacity_exhausted'"),
+    'the scheduler must end a daily batch cleanly when every user is day-capped or org-satisfied, never idle to the stall timeout',
   )
   assert.ok(
-    generator.includes('is not strictly before today'),
-    'generator must refuse an anchor that is today or future (server-clock race / future-punch guard)',
+    generator.includes('// occurredAt intentionally omitted — server clock always.'),
+    'punches must use the server clock — backdating is rejected by enforcePunchConstraintsʼ global-latest ordering (#4932 gate P1-1)',
   )
-  assert.match(
-    generator,
-    /const occurredAt = zonedDateTimeToUtcIso\(\n\s*ladderDate,\n\s*eventType === 'check_in' \? '00:00:00' : '23:59:00',/,
-    'check_in must land on the segment start and check_out on the segment end (zero-anomaly pairs — diff surface collapses to equal)',
-  )
-  assert.match(
-    generator,
-    /if \(eventType === 'check_out'\) picked\.pairCursor \+= 1/,
-    'the ladder must descend only on a CLEAN check_out',
-  )
-  assert.ok(
-    generator.includes('if (userState.pairCursor >= opts.ladderMaxDepthDays) return false'),
-    'the ladder depth ceiling must gate eligibility',
-  )
-  assert.match(
-    generator,
-    /hourCycle: 'h23',\n\s*year: 'numeric', month: '2-digit', day: '2-digit',\n\s*hour: '2-digit'/,
-    'the zoned instant construction must use hourCycle h23 (h24-midnight class)',
-  )
-  assert.ok(
-    generator.includes('if (hour === 24) hour = 0'),
-    'the zoned instant construction must carry the defensive 24->0 fold',
-  )
-  assert.match(generator, /body\.timezone = opts\.timezoneToSend/, 'sanity: timezone-body logic must survive the ladder edit')
-  const template = JSON.parse(readFileSync(join(HERE, 'attendance-w4w7-soak-config.template.json'), 'utf8'))
-  for (const entry of template.entries) {
-    assert.ok(typeof entry.ladderAnchorDate === 'string' && entry.ladderAnchorDate.includes('injected-by-soak-run'),
-      'template entries must document the injected ladderAnchorDate')
-    assert.ok(typeof entry.ladderTimezone === 'string' && entry.ladderTimezone.includes('injected-by-soak-run'),
-      'template entries must document the injected ladderTimezone')
-  }
-})
-
-test('EXECUTABLE (ladder): zonedDateTimeToUtcIso resolves wall times exactly — fixed-offset, UTC, and a DST-transition day', () => {
-  // Executes the REAL function text extracted from the shipped file (not a copy that could
-  // drift): the first draft of this util had a second-pass formula bug (subtracting from
-  // wallAsUtc instead of the candidate) that returned wall time UNADJUSTED for every
-  // non-UTC zone — this leg is the positive control that caught it.
-  const generator = readFileSync(GENERATOR, 'utf8')
-  const fnMatch = generator.match(/function zonedDateTimeToUtcIso[\s\S]*?\n\}/)
-  assert.ok(fnMatch, 'zonedDateTimeToUtcIso must exist in the generator')
-  // eslint-disable-next-line no-new-func
-  const zonedDateTimeToUtcIso = new Function(`${fnMatch[0]}; return zonedDateTimeToUtcIso`)()
-  assert.equal(zonedDateTimeToUtcIso('2026-08-12', '00:00:00', 'Asia/Shanghai'), '2026-08-11T16:00:00.000Z')
-  assert.equal(zonedDateTimeToUtcIso('2026-08-12', '23:59:00', 'Asia/Shanghai'), '2026-08-12T15:59:00.000Z')
-  assert.equal(zonedDateTimeToUtcIso('2026-08-12', '00:00:00', 'UTC'), '2026-08-12T00:00:00.000Z')
-  assert.equal(zonedDateTimeToUtcIso('2026-11-01', '00:00:00', 'America/New_York'), '2026-11-01T04:00:00.000Z')
-})
-
-test('MUTATION (ladder): dropping the anchor injection from soak-run turns the soak contract red', () => {
-  const original = readFileSync(REMOTE_SH, 'utf8')
-  const line = '        entry["ladderAnchorDate"] = anchor\n'
-  assert.ok(original.includes(line), 'mutation anchor must hit the injection line')
-  const mutated = original.replace(line, '')
-  assert.notEqual(mutated, original, 'mutation must change the file')
-  // The pin lives in the pair-ladder source-contract test above, not assertSoakContract —
-  // replay its check directly against the mutated text.
-  assert.ok(
-    !(mutated.includes('entry["ladderAnchorDate"] = anchor') && mutated.includes('entry["ladderTimezone"] = tz')),
-    'the injection pin must detect the dropped line',
-  )
-})
-
-test('MUTATION (ladder): reverting the generator to server-clock punches turns the pair-ladder pins red', () => {
-  const generator = readFileSync(GENERATOR, 'utf8')
-  const anchorLine = "const occurredAt = zonedDateTimeToUtcIso("
-  assert.ok(generator.includes(anchorLine), 'mutation anchor must hit the occurredAt construction')
-  const mutated = generator.replace(anchorLine, 'const occurredAt = undefined; void zonedDateTimeToUtcIso; const _unused = (')
-  assert.notEqual(mutated, generator, 'mutation must change the file')
   assert.doesNotMatch(
-    mutated,
-    /const occurredAt = zonedDateTimeToUtcIso\(\n\s*ladderDate,\n\s*eventType === 'check_in' \? '00:00:00' : '23:59:00',/,
-    'the occurredAt pin must detect the reverted construction',
+    generator,
+    /body\.occurredAt|occurredAt,\s*\n\s*\}/,
+    'the punch body must not carry occurredAt (the retired backdate ladder)',
+  )
+}
+
+test('soak generator: pair-cadence contract (2/day default, daily-batch clean halt, server clock only)', () => {
+  assertGeneratorCadenceContract(readFileSync(GENERATOR, 'utf8'))
+})
+
+test('MUTATION (cadence): restoring the 8/day default turns the cadence contract red', () => {
+  const original = readFileSync(GENERATOR, 'utf8')
+  const anchor = "'SOAK_PUNCHES_PER_USER_PER_DAY', 2)"
+  assert.ok(original.includes(anchor), 'mutation anchor must hit the daily-cap default')
+  const mutated = original.replace(anchor, "'SOAK_PUNCHES_PER_USER_PER_DAY', 8)")
+  assert.notEqual(mutated, original, 'mutation must change the file')
+  assert.throws(() => assertGeneratorCadenceContract(mutated), /2 punches\/user\/day/)
+})
+
+test('MUTATION (cadence): deleting the daily-batch clean halt turns the cadence contract red', () => {
+  const original = readFileSync(GENERATOR, 'utf8')
+  const anchor = "haltedReason = 'daily_capacity_exhausted'"
+  assert.ok(original.includes(anchor), 'mutation anchor must hit the clean-halt assignment')
+  const mutated = original.replace(anchor, "void 0")
+  assert.notEqual(mutated, original, 'mutation must change the file')
+  assert.throws(() => assertGeneratorCadenceContract(mutated), /daily batch cleanly/)
+})
+
+test('MUTATION (cadence): reverting the runner to the 8/day invocation turns the soak contract red', () => {
+  const original = readFileSync(REMOTE_SH, 'utf8')
+  const anchor = '--punches-per-user-per-day 2'
+  assert.ok(original.includes(anchor), 'mutation anchor must hit the runner invocation flag')
+  const mutated = original.replace(anchor, '--punches-per-user-per-day 8')
+  assert.notEqual(mutated, original, 'mutation must change the file')
+  assert.throws(
+    () => assertSoakContract({ remote: mutated, workflow: readFileSync(WORKFLOW, 'utf8') }),
+    /pair cadence|8\/day session-packing/,
   )
 })
 
@@ -1464,11 +1434,9 @@ test('soak generator: committed tool keeps its reviewed guard rails (rate ceilin
     /rateLimitPerSec <= 0 \|\| opts\.rateLimitPerSec > 1/,
     'the (0,1] global rate ceiling guard must survive promotion',
   )
-  assert.match(
-    generator,
-    /'SOAK_PUNCHES_PER_USER_PER_DAY', 8\)/,
-    'the ruled default of 8 punches/user/day (§2A.7/§2A.9 row) must be the default',
-  )
+  // The §2A.7 rowʼs 8/day default was REVISED to 2/day (a documented, owner-vetoable §2A.9
+  // deviation): the soak itself proved 8/day floods §4.2-critical review_required diffs
+  // (soak-status 31962440160). The 2/day pin lives in assertGeneratorCadenceContract above.
   assert.ok(generator.includes('UPPER-BOUNDS'), 'the HTTP-tally-upper-bounds-DB-count semantics note must survive')
   assert.ok(generator.includes("execute: readBoolOpt(args, 'execute', 'SOAK_EXECUTE', false)"), 'dry-run must stay the default')
   assert.doesNotMatch(generator, /dev-token\?/, 'the generator must never call the test-only dev-token endpoint')

--- a/scripts/ops/attendance-window-runner-pipeline.test.mjs
+++ b/scripts/ops/attendance-window-runner-pipeline.test.mjs
@@ -1348,6 +1348,111 @@ test('P2-1: a newline-injection payload in soak_opts is REJECTED by workflow val
   assert.match(r.stderr, /single-line/, 'rejection must name the single-line rule')
 })
 
+test('soak pair-ladder: runner derives per-org anchors from the DB and injects them; generator fails closed without them and sends explicit backdated occurredAt', () => {
+  const remote = readFileSync(REMOTE_SH, 'utf8')
+  const generator = readFileSync(GENERATOR, 'utf8')
+  // Runner: anchor = day before the family's earliest punched work_date, family reached via
+  // the username join (NEVER a user_id prefix — the retired TEXT-id shape), fallback =
+  // yesterday in the org group's timezone; both injected into the run config copy.
+  assert.ok(
+    remote.includes("SELECT to_char(COALESCE((SELECT min(r.work_date) FROM attendance_records r WHERE r.org_id = '${cfg_org}' AND EXISTS (SELECT 1 FROM users u WHERE u.id = r.user_id AND u.username LIKE '${SOAK_USER_PREFIX}%')) - 1, (now() AT TIME ZONE '${tzv}')::date - 1), 'YYYY-MM-DD');"),
+    'soak-run must derive each orgʼs ladder anchor from the familyʼs earliest punched work_date via the username join',
+  )
+  assert.ok(
+    remote.includes('entry["ladderAnchorDate"] = anchor') && remote.includes('entry["ladderTimezone"] = tz'),
+    'soak-run must inject ladderAnchorDate/ladderTimezone into every run-config entry',
+  )
+  assert.ok(
+    remote.includes('[soak-run] ladder anchor MISSING for org'),
+    'a config org without a derived anchor must fail the injection step, never run anchorless',
+  )
+  // Generator: both fields REQUIRED (fail-closed — the retired cadence is not selectable),
+  // anchor strictly before today, explicit occurredAt in the punch body, pair advance only
+  // on a CLEAN check_out, depth ceiling, and the h23 zoned construction (h24-midnight class).
+  assert.ok(
+    generator.includes('.ladderAnchorDate must be a YYYY-MM-DD date'),
+    'generator must refuse an entry without ladderAnchorDate',
+  )
+  assert.ok(
+    generator.includes('is not strictly before today'),
+    'generator must refuse an anchor that is today or future (server-clock race / future-punch guard)',
+  )
+  assert.match(
+    generator,
+    /const occurredAt = zonedDateTimeToUtcIso\(\n\s*ladderDate,\n\s*eventType === 'check_in' \? '00:00:00' : '23:59:00',/,
+    'check_in must land on the segment start and check_out on the segment end (zero-anomaly pairs — diff surface collapses to equal)',
+  )
+  assert.match(
+    generator,
+    /if \(eventType === 'check_out'\) picked\.pairCursor \+= 1/,
+    'the ladder must descend only on a CLEAN check_out',
+  )
+  assert.ok(
+    generator.includes('if (userState.pairCursor >= opts.ladderMaxDepthDays) return false'),
+    'the ladder depth ceiling must gate eligibility',
+  )
+  assert.match(
+    generator,
+    /hourCycle: 'h23',\n\s*year: 'numeric', month: '2-digit', day: '2-digit',\n\s*hour: '2-digit'/,
+    'the zoned instant construction must use hourCycle h23 (h24-midnight class)',
+  )
+  assert.ok(
+    generator.includes('if (hour === 24) hour = 0'),
+    'the zoned instant construction must carry the defensive 24->0 fold',
+  )
+  assert.match(generator, /body\.timezone = opts\.timezoneToSend/, 'sanity: timezone-body logic must survive the ladder edit')
+  const template = JSON.parse(readFileSync(join(HERE, 'attendance-w4w7-soak-config.template.json'), 'utf8'))
+  for (const entry of template.entries) {
+    assert.ok(typeof entry.ladderAnchorDate === 'string' && entry.ladderAnchorDate.includes('injected-by-soak-run'),
+      'template entries must document the injected ladderAnchorDate')
+    assert.ok(typeof entry.ladderTimezone === 'string' && entry.ladderTimezone.includes('injected-by-soak-run'),
+      'template entries must document the injected ladderTimezone')
+  }
+})
+
+test('EXECUTABLE (ladder): zonedDateTimeToUtcIso resolves wall times exactly — fixed-offset, UTC, and a DST-transition day', () => {
+  // Executes the REAL function text extracted from the shipped file (not a copy that could
+  // drift): the first draft of this util had a second-pass formula bug (subtracting from
+  // wallAsUtc instead of the candidate) that returned wall time UNADJUSTED for every
+  // non-UTC zone — this leg is the positive control that caught it.
+  const generator = readFileSync(GENERATOR, 'utf8')
+  const fnMatch = generator.match(/function zonedDateTimeToUtcIso[\s\S]*?\n\}/)
+  assert.ok(fnMatch, 'zonedDateTimeToUtcIso must exist in the generator')
+  // eslint-disable-next-line no-new-func
+  const zonedDateTimeToUtcIso = new Function(`${fnMatch[0]}; return zonedDateTimeToUtcIso`)()
+  assert.equal(zonedDateTimeToUtcIso('2026-08-12', '00:00:00', 'Asia/Shanghai'), '2026-08-11T16:00:00.000Z')
+  assert.equal(zonedDateTimeToUtcIso('2026-08-12', '23:59:00', 'Asia/Shanghai'), '2026-08-12T15:59:00.000Z')
+  assert.equal(zonedDateTimeToUtcIso('2026-08-12', '00:00:00', 'UTC'), '2026-08-12T00:00:00.000Z')
+  assert.equal(zonedDateTimeToUtcIso('2026-11-01', '00:00:00', 'America/New_York'), '2026-11-01T04:00:00.000Z')
+})
+
+test('MUTATION (ladder): dropping the anchor injection from soak-run turns the soak contract red', () => {
+  const original = readFileSync(REMOTE_SH, 'utf8')
+  const line = '        entry["ladderAnchorDate"] = anchor\n'
+  assert.ok(original.includes(line), 'mutation anchor must hit the injection line')
+  const mutated = original.replace(line, '')
+  assert.notEqual(mutated, original, 'mutation must change the file')
+  // The pin lives in the pair-ladder source-contract test above, not assertSoakContract —
+  // replay its check directly against the mutated text.
+  assert.ok(
+    !(mutated.includes('entry["ladderAnchorDate"] = anchor') && mutated.includes('entry["ladderTimezone"] = tz')),
+    'the injection pin must detect the dropped line',
+  )
+})
+
+test('MUTATION (ladder): reverting the generator to server-clock punches turns the pair-ladder pins red', () => {
+  const generator = readFileSync(GENERATOR, 'utf8')
+  const anchorLine = "const occurredAt = zonedDateTimeToUtcIso("
+  assert.ok(generator.includes(anchorLine), 'mutation anchor must hit the occurredAt construction')
+  const mutated = generator.replace(anchorLine, 'const occurredAt = undefined; void zonedDateTimeToUtcIso; const _unused = (')
+  assert.notEqual(mutated, generator, 'mutation must change the file')
+  assert.doesNotMatch(
+    mutated,
+    /const occurredAt = zonedDateTimeToUtcIso\(\n\s*ladderDate,\n\s*eventType === 'check_in' \? '00:00:00' : '23:59:00',/,
+    'the occurredAt pin must detect the reverted construction',
+  )
+})
+
 test('soak generator: committed tool keeps its reviewed guard rails (rate ceiling, dry-run default, ruled daily quota, upper-bound count semantics)', () => {
   const generator = readFileSync(GENERATOR, 'utf8')
   assert.ok(

--- a/scripts/ops/attendance-window-runner-pipeline.test.mjs
+++ b/scripts/ops/attendance-window-runner-pipeline.test.mjs
@@ -951,6 +951,42 @@ function assertSoakContract({ remote, workflow }) {
     /--punches-per-user-per-day 8/,
     'the retired 8/day session-packing quota must not come back',
   )
+  // Gate round-2 P2-1: the generatorʼs daily cap is per-process, so the runner must refuse
+  // a second batch inside the same org-calendar day (marker written BEFORE the generator
+  // runs — a partial batch already punched some users) with an explicit override only.
+  assert.ok(
+    slices.seed.includes('"dailyCapTimezone": tz,'),
+    'soak-seed must write each entryʼs org cap timezone into the config',
+  )
+  assert.ok(
+    slices.run.includes('soak-run-last-batch-day'),
+    'soak-run must track the last batch day host-side',
+  )
+  assert.ok(
+    slices.run.includes('allow_same_day_rerun'),
+    'the same-day guard must have exactly the explicit override, never a silent bypass',
+  )
+  const guardIdx = slices.run.indexOf('a soak-run batch already ran')
+  const markerWriteIdx = slices.run.indexOf('> "$batch_marker"')
+  const generatorRunIdx = slices.run.indexOf('--punches-per-user-per-day 2')
+  assert.ok(guardIdx !== -1 && markerWriteIdx !== -1, 'the same-day guard and marker write must exist')
+  assert.ok(
+    guardIdx < markerWriteIdx && markerWriteIdx < generatorRunIdx,
+    'the guard must run before the marker write, and the marker must be written BEFORE the generator runs',
+  )
+  // Gate round-2 P2-3: exactly the two clean halts print ok; incidents FAIL; all others WARN.
+  assert.ok(
+    slices.run.includes('targets_met|daily_capacity_exhausted) echo "result=ok"'),
+    'only the two clean halt reasons may print result=ok',
+  )
+  assert.ok(
+    slices.run.includes('max_consecutive_incidents) echo "result=FAIL"'),
+    'the incident halt must print result=FAIL',
+  )
+  assert.ok(
+    slices.run.includes('*) echo "result=WARN"'),
+    'every other halt reason (stall, duration, safety cap) must print result=WARN, never ok',
+  )
   assert.ok(
     slices.run.includes('--confirm I_UNDERSTAND_THIS_DRIVES_SYNTHETIC_STAGING_TRAFFIC_ONLY'),
     'soak-run must carry the generatorʼs exact execute confirmation token',
@@ -1378,14 +1414,39 @@ function assertGeneratorCadenceContract(generator) {
     generator.includes("haltedReason = 'daily_capacity_exhausted'"),
     'the scheduler must end a daily batch cleanly when every user is day-capped or org-satisfied, never idle to the stall timeout',
   )
-  assert.ok(
-    generator.includes('// occurredAt intentionally omitted — server clock always.'),
-    'punches must use the server clock — backdating is rejected by enforcePunchConstraintsʼ global-latest ordering (#4932 gate P1-1)',
+  // Server-clock pin bound to the CODE, not a comment (#4932 gate round-2 P2-2: the earlier
+  // comment-string pin stayed green when occurredAt was re-introduced mid-object): extract
+  // the actual `const body = {...}` construction, STRIP comment lines, and assert the
+  // remaining code never mentions occurredAt in any spelling.
+  const bodyStart = generator.indexOf('const body = {')
+  assert.ok(bodyStart !== -1, 'the punch body construction must exist')
+  const bodyEnd = generator.indexOf('\n  }', bodyStart)
+  assert.ok(bodyEnd > bodyStart, 'the punch body construction must close')
+  const bodyCode = generator
+    .slice(bodyStart, bodyEnd)
+    .split('\n')
+    .filter((line) => !line.trim().startsWith('//'))
+    .join('\n')
+  assert.doesNotMatch(
+    bodyCode,
+    /occurredAt/,
+    'the punch body CODE must not carry occurredAt in any form — server clock only (backdating is rejected by enforcePunchConstraintsʼ global-latest ordering, #4932 gate P1-1)',
   )
   assert.doesNotMatch(
     generator,
-    /body\.occurredAt|occurredAt,\s*\n\s*\}/,
-    'the punch body must not carry occurredAt (the retired backdate ladder)',
+    /body\.occurredAt/,
+    'no post-construction assignment may sneak occurredAt into the punch body',
+  )
+  // P2-1: the 2/day cap must count against the ORGʼS calendar day (per-entry
+  // dailyCapTimezone), and every daily-count site must resolve it via the one helper.
+  assert.ok(
+    generator.includes('function capTimezoneFor(entry, config)'),
+    'the per-entry cap-timezone resolver must exist',
+  )
+  assert.equal(
+    (generator.match(/capTimezoneFor\((?:candidate|picked|u)\.entry, config\)/g) || []).length,
+    3,
+    'all three daily-count sites (eligibility scan, all-capped halt, count increment) must key the day on the entryʼs cap timezone',
   )
 }
 
@@ -1411,6 +1472,26 @@ test('MUTATION (cadence): deleting the daily-batch clean halt turns the cadence 
   assert.throws(() => assertGeneratorCadenceContract(mutated), /daily batch cleanly/)
 })
 
+test('MUTATION (cadence): re-introducing occurredAt into the punch body mid-object turns the cadence contract red', () => {
+  const original = readFileSync(GENERATOR, 'utf8')
+  // The exact green-while-mutated shape the round-2 gate demonstrated: occurredAt inserted
+  // MID-object, comment left in place.
+  const anchor = 'operationId, // idempotency key — same value reused across the retries below'
+  assert.ok(original.includes(anchor), 'mutation anchor must hit the body construction')
+  const mutated = original.replace(anchor, `${anchor}\n    occurredAt: new Date().toISOString(),`)
+  assert.notEqual(mutated, original, 'mutation must change the file')
+  assert.throws(() => assertGeneratorCadenceContract(mutated), /server clock only/)
+})
+
+test('MUTATION (cadence): re-keying a daily-count site off the entry cap timezone turns the cadence contract red', () => {
+  const original = readFileSync(GENERATOR, 'utf8')
+  const anchor = 'capTimezoneFor(picked.entry, config)'
+  assert.ok(original.includes(anchor), 'mutation anchor must hit the count-increment site')
+  const mutated = original.replace(anchor, 'config.timezone')
+  assert.notEqual(mutated, original, 'mutation must change the file')
+  assert.throws(() => assertGeneratorCadenceContract(mutated), /cap timezone/)
+})
+
 test('MUTATION (cadence): reverting the runner to the 8/day invocation turns the soak contract red', () => {
   const original = readFileSync(REMOTE_SH, 'utf8')
   const anchor = '--punches-per-user-per-day 2'
@@ -1420,6 +1501,30 @@ test('MUTATION (cadence): reverting the runner to the 8/day invocation turns the
   assert.throws(
     () => assertSoakContract({ remote: mutated, workflow: readFileSync(WORKFLOW, 'utf8') }),
     /pair cadence|8\/day session-packing/,
+  )
+})
+
+test('MUTATION (same-day guard): removing the batch-day refusal turns the soak contract red', () => {
+  const original = readFileSync(REMOTE_SH, 'utf8')
+  const anchor = 'a soak-run batch already ran'
+  assert.ok(original.includes(anchor), 'mutation anchor must hit the same-day refusal')
+  const mutated = original.replace(anchor, 'a prior batch note:')
+  assert.notEqual(mutated, original, 'mutation must change the file')
+  assert.throws(
+    () => assertSoakContract({ remote: mutated, workflow: readFileSync(WORKFLOW, 'utf8') }),
+    /guard must run before the marker write|same-day guard/,
+  )
+})
+
+test('MUTATION (halt classes): letting a stall halt print result=ok turns the soak contract red', () => {
+  const original = readFileSync(REMOTE_SH, 'utf8')
+  const anchor = '*) echo "result=WARN"'
+  assert.ok(original.includes(anchor), 'mutation anchor must hit the WARN default case')
+  const mutated = original.replace(anchor, '*) echo "result=ok"')
+  assert.notEqual(mutated, original, 'mutation must change the file')
+  assert.throws(
+    () => assertSoakContract({ remote: mutated, workflow: readFileSync(WORKFLOW, 'utf8') }),
+    /result=WARN, never ok/,
   )
 })
 


### PR DESCRIPTION
## Round 2 (post-gate pivot) — head `5dc975bb85`

Round-1 gate: **REQUEST_CHANGES 2 P1 / 2 P2** — both P1s reproduced live: `enforcePunchConstraints` orders by the user's **globally latest** event, so every backdated `check_out` under an already-recorded later same-type event 429s (the descending ladder jams from rung 1, P1-1), and the cross-run anchor had no floor (P1-2). Backdating is unworkable as a class here → **ladder retired unmerged**.

### The honest fix
- **Generator cadence: 2 punches/user/wall-day** (one in/out pair; server clock; `occurredAt` never sent). This revises the §2A.7 8/day row as a documented, owner-vetoable §2A.9 deviation — the soak itself proved 8/day session packing floods §4.2-critical `review_required` diffs (soak-status 31962440160: the ENTIRE critical mass was cadence-made).
- **New `haltedReason=daily_capacity_exhausted`**: a soak-run invocation is one daily batch and ends cleanly when every user completed its pair; the runbook's cumulative criteria (200/20/50) accrue across daily batches, judged from soak-status DB counts.
- **Runner**: `punch_target` default `auto` = one-day batch (total_users × 2); capacity guard revised; ladder plumbing removed.
- **Acceleration** = `users_per_org` at seed time (30/org ⇒ ~2 daily batches to every cumulative criterion), never cadence.
- **P2-2 root fix**: cadence pins live in ONE shared assertion; every mutation leg calls it (no hand-replayed tautologies). **P2-1**: db suite reframed to the single-daily-pair contract, punch body drops `timezone`.
- Diff-family disposition unchanged: `late_minutes_mismatch` = transient partial-day (repro: v1 delta=90 → v2 equal → legacy 90); `attendance-soak-diff-families.db.test.ts` pins both families end-to-end (two-point wired, family 107).

Local: pipeline 57/57 · census 58/58 · wiring 255/255 · hourcycle 16/16 (22 sites) · diff-families 2/2 (real PG).

🤖 Generated with [Claude Code](https://claude.com/claude-code)