### PR TITLE
fix(ops): per-org same-day batch guard + honest halt classification (Codex post-merge P1/P2)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -720,6 +720,15 @@ jobs:
             git fetch --no-tags origin e0defbe26d7f2e1747e74aa908ca710422812bf7
           node --test scripts/ops/attendance-w4c0-dml-inventory-collector.test.mjs
 
+      # #4556 combined-soak: the window-runner pipeline contract (guard/classifier
+      # executable legs + mutation legs). A node:test .test.mjs like the collector above —
+      # invisible to every workspace test chain, so it must be named explicitly here or it
+      # runs ONLY as the workflow_dispatch preflight and never gates a PR (the #4933 gate
+      # demonstrated two mutation escapes merging ungated exactly this way).
+      - name: Run attendance window-runner pipeline contract
+        run: |
+          node --test scripts/ops/attendance-window-runner-pipeline.test.mjs
+
       - name: Run linting
         if: matrix.node-version == '20.x'
         run: |

--- a/plugins/plugin-integration-core/lib/sealed-export/vectors/s6a-package-provenance-pins.json
+++ b/plugins/plugin-integration-core/lib/sealed-export/vectors/s6a-package-provenance-pins.json
@@ -86,6 +86,6 @@
     "s6aAcceptancePs51Test": "835c7c6ce943d82e0378a40a27c7fd1e8b79b526faa8ca4c8066e4231a4bfb0f",
     "s6aProductRuntimeTest": "de978adafa8b89772cefa921c2051f434bf346bf5c2978bef3424ee70f51ba3f",
     "multitableOnpremPackageBuild": "ae477a24375a7269e5710a3481905c9b74255c03fd802841a16849aca48ee33a",
-    "pluginTestsWorkflow": "b221401aa6d2125ab4488c28462560e6fe984c0c90cdeca064457c3a195ac760"
+    "pluginTestsWorkflow": "0daf855e090775118f104ce72426f50d8d8692dd4933a9eb20be077ad4462bff"
   }
 }

--- a/scripts/ops/attendance-staging-window-runner-remote.sh
+++ b/scripts/ops/attendance-staging-window-runner-remote.sh
@@ -2011,7 +2011,10 @@ soak_batch_guard_entries() {
 import json, sys
 cfg = json.load(open(sys.argv[1]))
 for e in cfg["entries"]:
-    org = e.get("orgId"); tz = e.get("dailyCapTimezone")
+    try:
+        org, tz = e["orgId"], e["dailyCapTimezone"]
+    except KeyError:
+        sys.stderr.write("entry missing orgId/dailyCapTimezone\n"); sys.exit(1)
     if not org or not tz:
         sys.stderr.write("entry missing orgId/dailyCapTimezone\n"); sys.exit(1)
     print(f"{org}\t{tz}")
@@ -2028,6 +2031,26 @@ soak_batch_guard_check() {
   local line org tz today rec_day entries
   entries="$(soak_batch_guard_entries "$config_path")" \
     || { echo "config at ${config_path} is missing orgId/dailyCapTimezone — it predates the org-day cap contract; re-run action=soak-seed first"; return 1; }
+  # LEGACY MARKER MIGRATION (#4933 gate P2-3): the pre-per-org guard wrote ONE global day
+  # to the singular path; silently ignoring it would re-open the same-day duplicate window
+  # for a marker written by the previous code. Migrate CONSERVATIVELY — the legacy day is
+  # attributed to EVERY org (it was derived from entries[0]'s timezone; over-refusing for up
+  # to one day is the fail-closed direction, and it self-heals at each org's next local day).
+  local legacy_marker="${marker%-days}-day"
+  if [[ "$legacy_marker" != "$marker" && -f "$legacy_marker" && ! -f "$marker" ]]; then
+    local legacy_day
+    legacy_day="$(head -1 "$legacy_marker" | tr -d '[:space:]')"
+    if [[ "$legacy_day" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+      while IFS=$'\t' read -r org tz; do
+        printf '%s=%s=%s\n' "$org" "$tz" "$legacy_day" >> "$marker"
+      done <<< "$entries"
+      rm -f "$legacy_marker"
+      echo "migrated legacy single-day batch marker (${legacy_day}) to the per-org set — the legacy day counts for EVERY org (conservative fail-closed)" >&2
+    else
+      echo "legacy batch marker at ${legacy_marker} holds unrecognized content '${legacy_day}' — refusing fail-closed; inspect and remove it manually if a batch is genuinely due"
+      return 1
+    fi
+  fi
   [[ -f "$marker" ]] || return 0
   while IFS= read -r line; do
     [[ -z "$line" ]] && continue

--- a/scripts/ops/attendance-staging-window-runner-remote.sh
+++ b/scripts/ops/attendance-staging-window-runner-remote.sh
@@ -2002,6 +2002,86 @@ action_soak_flags() {
   log "soak-flags OK: W4=${SOAK_ORG1_SHORT},${SOAK_ORG2_SHORT},${SOAK_ORG3_SHORT} W7=${SOAK_ORG3_SHORT} live on the backend"
 }
 
+# --- soak daily-batch guard + halt classification (testable units; #4932 follow-up) ------
+# soak_batch_guard_entries <config_path> — prints "orgId<TAB>dailyCapTimezone" per entry;
+# fails (non-zero) if any entry lacks either field (stale-config fail-closed, round-3
+# P2-R3-1 contract).
+soak_batch_guard_entries() {
+  python3 -c '
+import json, sys
+cfg = json.load(open(sys.argv[1]))
+for e in cfg["entries"]:
+    org = e.get("orgId"); tz = e.get("dailyCapTimezone")
+    if not org or not tz:
+        sys.stderr.write("entry missing orgId/dailyCapTimezone\n"); sys.exit(1)
+    print(f"{org}\t{tz}")
+' "$1"
+}
+
+# soak_batch_guard_check <config_path> <marker_path> <override(true|false)> — prints a
+# refusal message and returns 1 if ANY config org already ran a batch on its OWN current
+# local day (whole-batch refusal — Codex P1: per-org day boundaries diverge across the three
+# supported org timezones). Malformed or legacy marker content refuses fail-closed. Returns
+# 0 (silent) when the batch may proceed.
+soak_batch_guard_check() {
+  local config_path="$1" marker="$2" override="$3"
+  local line org tz today rec_day entries
+  entries="$(soak_batch_guard_entries "$config_path")" \
+    || { echo "config at ${config_path} is missing orgId/dailyCapTimezone — it predates the org-day cap contract; re-run action=soak-seed first"; return 1; }
+  [[ -f "$marker" ]] || return 0
+  while IFS= read -r line; do
+    [[ -z "$line" ]] && continue
+    if ! [[ "$line" =~ ^[0-9a-fA-F-]+=[A-Za-z0-9_/+-]+=[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+      echo "unrecognized batch-marker line '${line}' in ${marker} (legacy or corrupted format) — refusing fail-closed; inspect and remove the marker manually if a batch is genuinely due"
+      return 1
+    fi
+  done < "$marker"
+  while IFS=$'\t' read -r org tz; do
+    today="$(TZ="$tz" date +%Y-%m-%d)"
+    rec_day="$(grep -m1 "^${org}=" "$marker" | awk -F= '{print $3}')"
+    if [[ -n "$rec_day" && "$rec_day" == "$today" && "$override" != "true" ]]; then
+      echo "org ${org:0:8} already ran (or started) a batch on its local day ${today} (${tz}) — a second same-day batch lands duplicate sessions on the same work date (§4.2-critical review_required); the WHOLE batch is refused. Wait for every org's next local day, or pass soak_opts allow_same_day_rerun=true for a deliberate retry (accepting that risk for already-punched users)"
+      return 1
+    fi
+  done <<< "$entries"
+  return 0
+}
+
+# soak_batch_guard_stamp <config_path> <marker_path> — records ONE line per org:
+# "<orgId>=<tz>=<its-current-local-day>" (whole-file overwrite; only same-day lines matter).
+soak_batch_guard_stamp() {
+  local config_path="$1" marker="$2"
+  local org tz
+  : > "$marker"
+  while IFS=$'\t' read -r org tz; do
+    printf '%s=%s=%s\n' "$org" "$tz" "$(TZ="$tz" date +%Y-%m-%d)" >> "$marker"
+  done < <(soak_batch_guard_entries "$config_path")
+}
+
+# soak_run_classify <haltedReason> <total_clean> <total_attempts> <punch_target> — the ONE
+# halt classifier (Codex P2: daily_capacity_exhausted with scattered incidents must never
+# print ok — dailyCounts increments on EVERY attempt, so capacity exhaustion alone proves
+# nothing about cleanliness). ok ONLY for a clean halt with zero incidents and the target
+# reached; FAIL for the consecutive-incident halt; WARN for everything else, including
+# non-numeric tallies (fail-closed).
+soak_run_classify() {
+  local halted="$1" clean="$2" attempts="$3" target="$4"
+  if ! [[ "$clean" =~ ^[0-9]+$ && "$attempts" =~ ^[0-9]+$ && "$target" =~ ^[0-9]+$ ]]; then
+    echo "WARN"
+    return 0
+  fi
+  local incidents=$(( attempts - clean ))
+  case "$halted" in
+    max_consecutive_incidents) echo "FAIL" ;;
+    targets_met|daily_capacity_exhausted)
+      if (( incidents > 0 )); then echo "WARN"
+      elif (( clean < target )); then echo "WARN"
+      else echo "ok"; fi
+      ;;
+    *) echo "WARN" ;;
+  esac
+}
+
 action_soak_run() {
   soak_validate_opts
   local punch_target config_path
@@ -2061,31 +2141,28 @@ action_soak_run() {
   done
   IFS="$IFS_SAVE"
 
-  # SAME-DAY RE-DISPATCH GUARD (gate round-2 P2-1): the generator's daily cap is
-  # per-process, so a second soak-run inside the same org-calendar day would land a second
-  # pair on the SAME work date — exactly the duplicate-session shape that floods
-  # §4.2-critical review_required diffs. The org day is derived from the FIRST config
-  # entry's dailyCapTimezone (all soak orgs share one); override only for a deliberate
-  # halt-retry with soak_opts allow_same_day_rerun=true (documented critical-shape risk).
-  local batch_tz batch_day last_batch_day
-  batch_tz="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["entries"][0]["dailyCapTimezone"])' "$config_path" 2>/dev/null)" \
-    || fail "config at ${config_path} carries no dailyCapTimezone — it predates the org-day cap contract and would silently revert the 2/day cap and the same-day guard to UTC days; re-run action=soak-seed first"
-  batch_day="$(TZ="$batch_tz" date +%Y-%m-%d)"
-  local batch_marker="${SOAK_PERSIST_DIR}/soak-run-last-batch-day"
-  if [[ -f "$batch_marker" ]]; then
-    last_batch_day="$(cat "$batch_marker")"
-    if [[ "$last_batch_day" == "$batch_day" && "$(soak_opt allow_same_day_rerun false)" != "true" ]]; then
-      fail "a soak-run batch already ran (or started) on ${batch_day} (${batch_tz}) — a second same-day batch lands duplicate sessions on the same work date (§4.2-critical review_required). Wait for the next org-calendar day, or pass soak_opts allow_same_day_rerun=true for a deliberate retry (accepting that risk for already-punched users)"
-    fi
+  # SAME-DAY RE-DISPATCH GUARD (gate round-2 P2-1; Codex post-merge review P1): the
+  # generator's daily cap is per-process, so a second soak-run inside the same org-calendar
+  # day would land a second pair on the SAME work date — the duplicate-session shape that
+  # floods §4.2-critical review_required diffs. The seeder explicitly supports THREE
+  # independent org timezones, so the marker is a PER-ORG closed set ({orgId}={tz}={localDay}
+  # lines) and the batch is refused WHOLE if ANY org already ran on its own current local
+  # day — a first-entry-only derivation would admit a second batch the moment org1 crossed
+  # midnight while org2/org3 had not. Override only for a deliberate halt-retry with
+  # soak_opts allow_same_day_rerun=true (documented critical-shape risk).
+  mkdir -p "$SOAK_PERSIST_DIR"
+  local batch_marker="${SOAK_PERSIST_DIR}/soak-run-last-batch-days"
+  local guard_msg
+  if ! guard_msg="$(soak_batch_guard_check "$config_path" "$batch_marker" "$(soak_opt allow_same_day_rerun false)")"; then
+    fail "${guard_msg}"
   fi
-  # Written BEFORE the generator runs: even a PARTIAL batch punched some users, so a bare
-  # same-day retry would duplicate exactly those — burning the day on any attempt is the
-  # fail-closed choice; the override above is the deliberate escape hatch.
-  printf '%s\n' "$batch_day" > "$batch_marker"
+  # Stamped BEFORE the generator runs: even a PARTIAL batch punched some users, so a bare
+  # same-day retry would duplicate exactly those — burning each org's day on any attempt is
+  # the fail-closed choice; the override above is the deliberate escape hatch.
+  soak_batch_guard_stamp "$config_path" "$batch_marker"
 
   # Log every synthetic user in through the REAL login route; tokens go ONLY into a 0600
   # host temp config (deleted below) and are never echoed (per-user output is id + ok/fail).
-  mkdir -p "$SOAK_PERSIST_DIR"
   local run_config_host
   run_config_host="$(mktemp "${SOAK_PERSIST_DIR}/.soak-run-config.XXXXXX")"
   cleanup_soak_run() {
@@ -2186,25 +2263,24 @@ PY
     echo "halted_reason=${halted}"
     echo "http_level_clean=${total_clean}"
     echo "attempts=${total_attempts}"
-    echo "note=haltedReason is LOAD-BEARING: targets_met (this batch met its targets) and daily_capacity_exhausted (every user completed its one daily pair; cumulative criteria accrue across days) are the clean outcomes; the HTTP tally upper-bounds (never equals) the DB-level clean-punch count — soak-status Q1-Q4 are the authoritative counts"
-    # gate round-2 P2-3: exactly the two clean halts print ok; incidents FAIL the job; every
-    # other halt (stall, duration, safety cap) prints WARN — recorded, non-alert, but never
-    # dressed up as a clean batch.
-    case "$halted" in
-      targets_met|daily_capacity_exhausted) echo "result=ok" ;;
-      max_consecutive_incidents) echo "result=FAIL" ;;
-      *) echo "result=WARN" ;;
-    esac
+    echo "note=haltedReason is LOAD-BEARING: targets_met and daily_capacity_exhausted are clean outcomes ONLY with zero incidents and the target reached (Codex P2: capacity counts every ATTEMPT, so exhaustion alone proves nothing about cleanliness); the HTTP tally upper-bounds (never equals) the DB-level clean-punch count — soak-status Q1-Q4 are the authoritative counts"
+    if [[ "$total_clean" =~ ^[0-9]+$ && "$total_attempts" =~ ^[0-9]+$ ]]; then
+      echo "incidents=$(( total_attempts - total_clean ))"
+    else
+      echo "incidents=unknown"
+    fi
+    # gate round-2 P2-3 + Codex P2: ONE classifier decides — ok only for a clean halt with
+    # zero incidents and target reached; incidents-halt FAILs; everything else WARNs.
+    echo "result=$(soak_run_classify "$halted" "$total_clean" "$total_attempts" "$punch_target")"
   } > "${OUTPUT_DIR}/summary.txt"
   if [[ "$halted" == "max_consecutive_incidents" ]]; then
     fail "generator halted on consecutive non-clean responses (haltedReason=max_consecutive_incidents) — alert-class outcome, see soak-run.log + soak-run-summary.json"
   fi
-  case "$halted" in
-    targets_met|daily_capacity_exhausted) ;;
-    *)
-      log "soak-run WARN: haltedReason=${halted} is neither clean outcome — see summary.txt (a same-day retry needs soak_opts allow_same_day_rerun=true and accepts the duplicate-session risk for already-punched users)"
-      ;;
-  esac
+  local batch_result
+  batch_result="$(soak_run_classify "$halted" "$total_clean" "$total_attempts" "$punch_target")"
+  if [[ "$batch_result" != "ok" ]]; then
+    log "soak-run ${batch_result}: haltedReason=${halted} clean=${total_clean}/${punch_target} — see summary.txt (a same-day retry needs soak_opts allow_same_day_rerun=true and accepts the duplicate-session risk for already-punched users)"
+  fi
   log "soak-run done: haltedReason=${halted} http_clean=${total_clean}/${punch_target} (DB-level counts come from action=soak-status, never from this tally)"
 }
 

--- a/scripts/ops/attendance-window-runner-pipeline.test.mjs
+++ b/scripts/ops/attendance-window-runner-pipeline.test.mjs
@@ -20,7 +20,7 @@
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
 import { spawnSync } from 'node:child_process'
-import { mkdtempSync, readFileSync, existsSync } from 'node:fs'
+import { mkdtempSync, readFileSync, existsSync, writeFileSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -530,8 +530,10 @@ function extractSoakSlices(remote) {
     // The seed slice deliberately spans its helpers (SQL writer, per-org report, W4/W7
     // posture walks) through the end of action_soak_seed — they are one action's body.
     seed: sliceBetween(remote, 'soak_seed_write_org_sql() {', '\naction_soak_flags() {', 'soak-seed'),
-    flags: sliceBetween(remote, 'action_soak_flags() {', '\naction_soak_run() {', 'soak-flags'),
-    run: sliceBetween(remote, 'action_soak_run() {', '\nsoak_status_scalar() {', 'soak-run'),
+    flags: sliceBetween(remote, 'action_soak_flags() {', '\n# --- soak daily-batch guard', 'soak-flags'),
+    // The run slice deliberately spans the guard/classifier helper functions ahead of
+    // action_soak_run — they are that action's testable units.
+    run: sliceBetween(remote, '# --- soak daily-batch guard', '\nsoak_status_scalar() {', 'soak-run'),
     status: sliceBetween(remote, 'soak_status_scalar() {', '\n# --- main', 'soak-status'),
   }
 }
@@ -963,38 +965,66 @@ function assertSoakContract({ remote, workflow }) {
     'soak-run must track the last batch day host-side',
   )
   assert.ok(
-    slices.run.includes('carries no dailyCapTimezone'),
-    'soak-run must refuse a config without dailyCapTimezone (stale-config silent revert)',
+    slices.run.includes('is missing orgId/dailyCapTimezone'),
+    'the guard must refuse a config without orgId/dailyCapTimezone (stale-config silent revert)',
   )
   assert.doesNotMatch(
     slices.run,
-    /\.get\("dailyCapTimezone"/,
-    'the runner batch-day derivation must have no UTC default',
+    /\.get\("dailyCapTimezone", ?"/,
+    'the batch-day derivation must have no fallback default (a defaulted .get is the silent-revert channel)',
   )
   assert.ok(
     slices.run.includes('allow_same_day_rerun'),
     'the same-day guard must have exactly the explicit override, never a silent bypass',
   )
-  const guardIdx = slices.run.indexOf('a soak-run batch already ran')
-  const markerWriteIdx = slices.run.indexOf('> "$batch_marker"')
+  // Codex post-merge P1: the marker is a PER-ORG closed set and the batch refuses WHOLE if
+  // ANY org already ran on its own local day — a first-entry-only derivation would admit a
+  // second batch the moment org1 crossed midnight while org2/org3 had not.
+  assert.ok(
+    slices.run.includes('soak_batch_guard_check() {'),
+    'the per-org same-day guard function must exist',
+  )
+  assert.match(
+    slices.run,
+    /while IFS=\$'\\t' read -r org tz; do\n\s+today="\$\(TZ="\$tz" date \+%Y-%m-%d\)"/,
+    'the guard must derive TODAY per org from that orgʼs own timezone (never entries[0] alone)',
+  )
+  assert.doesNotMatch(
+    slices.run,
+    /entries"\]\[0\]\["dailyCapTimezone"\]/,
+    'no first-entry-only timezone derivation may remain in the batch guard path',
+  )
+  const guardIdx = slices.run.indexOf('soak_batch_guard_check "$config_path" "$batch_marker"')
+  const markerWriteIdx = slices.run.indexOf('soak_batch_guard_stamp "$config_path" "$batch_marker"')
   const generatorRunIdx = slices.run.indexOf('--punches-per-user-per-day 2')
-  assert.ok(guardIdx !== -1 && markerWriteIdx !== -1, 'the same-day guard and marker write must exist')
+  assert.ok(guardIdx !== -1 && markerWriteIdx !== -1, 'the same-day guard check and per-org stamp must exist')
   assert.ok(
     guardIdx < markerWriteIdx && markerWriteIdx < generatorRunIdx,
-    'the guard must run before the marker write, and the marker must be written BEFORE the generator runs',
+    'the guard must run before the stamp, and the stamp must land BEFORE the generator runs',
   )
-  // Gate round-2 P2-3: exactly the two clean halts print ok; incidents FAIL; all others WARN.
+  // Gate round-2 P2-3 + Codex post-merge P2: ONE classifier decides the batch result — ok
+  // requires a clean halt AND zero incidents AND target reached; capacity exhaustion alone
+  // proves nothing (dailyCounts increments on every ATTEMPT).
   assert.ok(
-    slices.run.includes('targets_met|daily_capacity_exhausted) echo "result=ok"'),
-    'only the two clean halt reasons may print result=ok',
+    slices.run.includes('soak_run_classify() {'),
+    'the halt classifier function must exist',
+  )
+  assert.match(
+    slices.run,
+    /targets_met\|daily_capacity_exhausted\)\n\s+if \(\( incidents > 0 \)\); then echo "WARN"/,
+    'a clean-halt batch with ANY incidents must classify WARN, never ok',
   )
   assert.ok(
-    slices.run.includes('max_consecutive_incidents) echo "result=FAIL"'),
-    'the incident halt must print result=FAIL',
+    slices.run.includes('max_consecutive_incidents) echo "FAIL"'),
+    'the incident halt must classify FAIL',
   )
   assert.ok(
-    slices.run.includes('*) echo "result=WARN"'),
-    'every other halt reason (stall, duration, safety cap) must print result=WARN, never ok',
+    slices.run.includes('*) echo "WARN"'),
+    'every other halt reason (stall, duration, safety cap) must classify WARN, never ok',
+  )
+  assert.ok(
+    slices.run.includes('echo "result=$(soak_run_classify "$halted" "$total_clean" "$total_attempts" "$punch_target")"'),
+    'the summary result line must come from the classifier, never an inline case',
   )
   assert.ok(
     slices.run.includes('--confirm I_UNDERSTAND_THIS_DRIVES_SYNTHETIC_STAGING_TRAFFIC_ONLY'),
@@ -1352,7 +1382,9 @@ test('MUTATION (P2-4): deleting the soak-run live-allowlist coverage loops turns
   const mutatedRun = slices.run
     .replace(w4Loop, 'DELETED_W4_COVERAGE_MESSAGE')
     .replace(w7Loop, 'DELETED_W7_COVERAGE_MESSAGE')
-  const mutated = original.replace(slices.run, mutatedRun)
+  // Replacement-FUNCTION form: the run slice now contains bash `$'` sequences, which
+  // String.replace treats as special replacement patterns and silently corrupts the file.
+  const mutated = original.replace(slices.run, () => mutatedRun)
   assert.notEqual(mutated, original, 'mutation must change the file')
   assert.throws(
     () => assertSoakContract({ remote: mutated, workflow: readFileSync(WORKFLOW, 'utf8') }),
@@ -1524,28 +1556,169 @@ test('MUTATION (cadence): reverting the runner to the 8/day invocation turns the
   )
 })
 
-test('MUTATION (same-day guard): removing the batch-day refusal turns the soak contract red', () => {
+test('MUTATION (same-day guard): removing the guard-check call turns the soak contract red', () => {
   const original = readFileSync(REMOTE_SH, 'utf8')
-  const anchor = 'a soak-run batch already ran'
-  assert.ok(original.includes(anchor), 'mutation anchor must hit the same-day refusal')
-  const mutated = original.replace(anchor, 'a prior batch note:')
+  const anchor = 'soak_batch_guard_check "$config_path" "$batch_marker"'
+  assert.ok(original.includes(anchor), 'mutation anchor must hit the guard-check call')
+  const mutated = original.replace(anchor, 'true # guard skipped')
   assert.notEqual(mutated, original, 'mutation must change the file')
   assert.throws(
     () => assertSoakContract({ remote: mutated, workflow: readFileSync(WORKFLOW, 'utf8') }),
-    /guard must run before the marker write|same-day guard/,
+    /guard check and per-org stamp must exist|guard must run before the stamp/,
   )
 })
 
-test('MUTATION (halt classes): letting a stall halt print result=ok turns the soak contract red', () => {
+test('MUTATION (same-day guard): reverting to a first-entry-only timezone derivation turns the soak contract red', () => {
   const original = readFileSync(REMOTE_SH, 'utf8')
-  const anchor = '*) echo "result=WARN"'
-  assert.ok(original.includes(anchor), 'mutation anchor must hit the WARN default case')
-  const mutated = original.replace(anchor, '*) echo "result=ok"')
+  // The Codex P1 shape: derive one global day from entries[0] instead of per-org days.
+  const anchor = '  while IFS=$\'\\t\' read -r org tz; do\n    today="$(TZ="$tz" date +%Y-%m-%d)"'
+  assert.ok(original.includes(anchor), 'mutation anchor must hit the per-org day loop')
+  const mutated = original.replace(
+    anchor,
+    () => '  tz="$(soak_batch_guard_entries "$config_path" | head -1 | cut -f2)"\n  today="$(TZ="$tz" date +%Y-%m-%d)"\n  while IFS=$\'\\t\' read -r org _ignored_tz; do',
+  )
   assert.notEqual(mutated, original, 'mutation must change the file')
   assert.throws(
     () => assertSoakContract({ remote: mutated, workflow: readFileSync(WORKFLOW, 'utf8') }),
-    /result=WARN, never ok/,
+    /orgʼs own timezone/,
   )
+})
+
+test('MUTATION (halt classes): letting an incident-bearing clean halt classify ok turns the soak contract red', () => {
+  const original = readFileSync(REMOTE_SH, 'utf8')
+  const anchor = 'if (( incidents > 0 )); then echo "WARN"'
+  assert.ok(original.includes(anchor), 'mutation anchor must hit the incidents branch')
+  const mutated = original.replace(anchor, 'if (( incidents > 999999 )); then echo "WARN"')
+  assert.notEqual(mutated, original, 'mutation must change the file')
+  assert.throws(
+    () => assertSoakContract({ remote: mutated, workflow: readFileSync(WORKFLOW, 'utf8') }),
+    /ANY incidents must classify WARN/,
+  )
+})
+
+test('MUTATION (halt classes): letting a stall halt classify ok turns the soak contract red', () => {
+  const original = readFileSync(REMOTE_SH, 'utf8')
+  const anchor = '*) echo "WARN"'
+  assert.ok(original.includes(anchor), 'mutation anchor must hit the WARN default case')
+  const mutated = original.replace(anchor, '*) echo "ok"')
+  assert.notEqual(mutated, original, 'mutation must change the file')
+  assert.throws(
+    () => assertSoakContract({ remote: mutated, workflow: readFileSync(WORKFLOW, 'utf8') }),
+    /classify WARN, never ok/,
+  )
+})
+
+/**
+ * EXECUTABLE legs — extract the REAL guard/classifier functions from the shipped runner and
+ * drive them with fixture configs/markers (the Codex P1 three-timezone cross-day
+ * counterexample, and the P2 interleaved clean/fail classification matrix). Extraction runs
+ * the shipped bytes, so a behavioural regression cannot hide behind an intact source pin.
+ */
+function extractRunnerFunctions(names) {
+  const remote = readFileSync(REMOTE_SH, 'utf8')
+  return names
+    .map((name) => {
+      const m = remote.match(new RegExp(`^${name}\\(\\) \\{[\\s\\S]*?\\n\\}`, 'm'))
+      assert.ok(m, `${name} must exist in the runner`)
+      return m[0]
+    })
+    .join('\n')
+}
+
+test('EXECUTABLE (Codex P1): the per-org guard refuses a cross-day second batch that a first-entry derivation would admit', () => {
+  const fns = extractRunnerFunctions(['soak_batch_guard_entries', 'soak_batch_guard_check', 'soak_batch_guard_stamp'])
+  // Kiritimati (UTC+14) and Pago Pago (UTC-11) are 25h apart: their local calendar days are
+  // NEVER both equal to their values one real day apart, so "org1 crossed midnight, org2
+  // has not" is constructible at ANY wall-clock moment: stamp all orgs, then rewind ONLY
+  // org1's line one day. A first-entry-only guard (keyed on org1) would see yesterday!=today
+  // and ADMIT the batch; the per-org guard must refuse on org2/org3.
+  const dir = mkdtempSync(join(tmpdir(), 'soak-guard-'))
+  try {
+    const cfg = join(dir, 'config.json')
+    const marker = join(dir, 'marker')
+    const script = join(dir, 'probe.sh')
+    writeFileSync(cfg, JSON.stringify({
+      entries: [
+        { orgId: 'aaaaaaaa-0000-0000-0000-000000000001', dailyCapTimezone: 'Pacific/Kiritimati' },
+        { orgId: 'bbbbbbbb-0000-0000-0000-000000000002', dailyCapTimezone: 'Pacific/Pago_Pago' },
+        { orgId: 'cccccccc-0000-0000-0000-000000000003', dailyCapTimezone: 'Asia/Shanghai' },
+      ],
+    }))
+    writeFileSync(script, `#!/bin/bash\nset -u\n${fns}\n"$@"\n`)
+    const run = (...args) => spawnSync('bash', [script, ...args], { encoding: 'utf8' })
+    // Fresh marker: stamp writes one line per org, each under its OWN timezone.
+    let r = run('soak_batch_guard_stamp', cfg, marker)
+    assert.equal(r.status, 0, `stamp must succeed: ${r.stderr}`)
+    const lines = readFileSync(marker, 'utf8').trim().split('\n')
+    assert.equal(lines.length, 3, 'stamp must write one line per org')
+    for (const line of lines) assert.match(line, /^[0-9a-f-]+=[A-Za-z0-9_/+-]+=\d{4}-\d{2}-\d{2}$/)
+    // Same-day re-dispatch: refused (any org matches its own local day).
+    r = run('soak_batch_guard_check', cfg, marker, 'false')
+    assert.equal(r.status, 1, 'a same-day second batch must be refused')
+    assert.match(r.stdout, /already ran \(or started\) a batch on its local day/)
+    // Cross-day counterexample: rewind ONLY org1's (first entry!) recorded day. A guard
+    // keyed on entries[0] alone sees a stale day and admits; the per-org guard still
+    // refuses because org2/org3 remain on their same local days.
+    const rewound = lines.map((line) => {
+      if (!line.startsWith('aaaaaaaa-')) return line
+      const [org, tz, day] = line.split('=')
+      const d = new Date(`${day}T00:00:00Z`)
+      d.setUTCDate(d.getUTCDate() - 1)
+      return `${org}=${tz}=${d.toISOString().slice(0, 10)}`
+    })
+    writeFileSync(marker, `${rewound.join('\n')}\n`)
+    r = run('soak_batch_guard_check', cfg, marker, 'false')
+    assert.equal(r.status, 1, 'org1 crossing midnight must NOT admit a batch while org2/org3 are still on their punched local day')
+    assert.match(r.stdout, /bbbbbbbb|cccccccc/, 'the refusal must come from a non-first org')
+    // All orgs rewound one day: the batch may proceed.
+    const allRewound = lines.map((line) => {
+      const [org, tz, day] = line.split('=')
+      const d = new Date(`${day}T00:00:00Z`)
+      d.setUTCDate(d.getUTCDate() - 1)
+      return `${org}=${tz}=${d.toISOString().slice(0, 10)}`
+    })
+    writeFileSync(marker, `${allRewound.join('\n')}\n`)
+    r = run('soak_batch_guard_check', cfg, marker, 'false')
+    assert.equal(r.status, 0, `all orgs on a fresh local day must be admitted: ${r.stdout}`)
+    // Override admits a same-day batch (deliberate escape hatch).
+    writeFileSync(marker, `${lines.join('\n')}\n`)
+    r = run('soak_batch_guard_check', cfg, marker, 'true')
+    assert.equal(r.status, 0, 'the explicit override must admit a same-day retry')
+    // Legacy/corrupted marker content refuses fail-closed.
+    writeFileSync(marker, '2026-08-17\n')
+    r = run('soak_batch_guard_check', cfg, marker, 'false')
+    assert.equal(r.status, 1, 'a legacy single-date marker must refuse fail-closed')
+    assert.match(r.stdout, /unrecognized batch-marker line/)
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('EXECUTABLE (Codex P2): the halt classifier never calls an incident-bearing or short batch ok', () => {
+  const fns = extractRunnerFunctions(['soak_run_classify'])
+  const dir = mkdtempSync(join(tmpdir(), 'soak-classify-'))
+  try {
+    const script = join(dir, 'probe.sh')
+    writeFileSync(script, `#!/bin/bash\nset -u\n${fns}\n"$@"\n`)
+    const classify = (...args) => {
+      const r = spawnSync('bash', [script, 'soak_run_classify', ...args], { encoding: 'utf8' })
+      assert.equal(r.status, 0, `classifier must not error: ${r.stderr}`)
+      return r.stdout.trim()
+    }
+    assert.equal(classify('targets_met', '180', '180', '180'), 'ok')
+    assert.equal(classify('daily_capacity_exhausted', '180', '180', '180'), 'ok')
+    // Interleaved clean/fail (scattered 429/500s, never 5 consecutive): capacity exhausts
+    // with a shortfall — MUST NOT be ok (the Codex P2 shape).
+    assert.equal(classify('daily_capacity_exhausted', '160', '180', '180'), 'WARN')
+    assert.equal(classify('targets_met', '180', '183', '180'), 'WARN')
+    assert.equal(classify('daily_capacity_exhausted', '160', '160', '180'), 'WARN')
+    assert.equal(classify('max_consecutive_incidents', '10', '15', '180'), 'FAIL')
+    assert.equal(classify('no_eligible_users_stall_timeout', '180', '180', '180'), 'WARN')
+    assert.equal(classify('duration_elapsed', '180', '180', '180'), 'WARN')
+    assert.equal(classify('targets_met', 'unknown', 'unknown', '180'), 'WARN')
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
 })
 
 test('soak generator: committed tool keeps its reviewed guard rails (rate ceiling, dry-run default, ruled daily quota, upper-bound count semantics)', () => {

--- a/scripts/ops/attendance-window-runner-pipeline.test.mjs
+++ b/scripts/ops/attendance-window-runner-pipeline.test.mjs
@@ -970,8 +970,8 @@ function assertSoakContract({ remote, workflow }) {
   )
   assert.doesNotMatch(
     slices.run,
-    /\.get\("dailyCapTimezone", ?"/,
-    'the batch-day derivation must have no fallback default (a defaulted .get is the silent-revert channel)',
+    /\.get\("dailyCapTimezone"/,
+    'no .get on dailyCapTimezone may exist in the run slice at all — subscript access is the by-construction fail-closed shape, and any .get re-introduction is the silent-revert channel (#4933 gate P2-1: an `or "UTC"` fallback slipped past the narrowed form)',
   )
   assert.ok(
     slices.run.includes('allow_same_day_rerun'),
@@ -1669,7 +1669,13 @@ test('EXECUTABLE (Codex P1): the per-org guard refuses a cross-day second batch 
     writeFileSync(marker, `${rewound.join('\n')}\n`)
     r = run('soak_batch_guard_check', cfg, marker, 'false')
     assert.equal(r.status, 1, 'org1 crossing midnight must NOT admit a batch while org2/org3 are still on their punched local day')
-    assert.match(r.stdout, /bbbbbbbb|cccccccc/, 'the refusal must come from a non-first org')
+    // org2 ONLY (#4933 gate P2-2): entries order makes org2 the first same-day match under
+    // correct code at EVERY wall-clock instant, while under a first-entry-only derivation
+    // org2 (Pago Pago, 25h from Kiritimati — never the same calendar day) can NEVER refuse;
+    // the old /bbbbbbbb|cccccccc/ disjunction let org3 (Shanghai, same date as Kiritimati
+    // 18h/day) mask that mutation 75% of the time.
+    assert.match(r.stdout, /bbbbbbbb/, 'the refusal must come from org2 (the 25h-offset org)')
+    assert.doesNotMatch(r.stdout, /cccccccc/, 'org3 must not be the refusing org while org2 precedes it in entry order')
     // All orgs rewound one day: the batch may proceed.
     const allRewound = lines.map((line) => {
       const [org, tz, day] = line.split('=')
@@ -1689,6 +1695,48 @@ test('EXECUTABLE (Codex P1): the per-org guard refuses a cross-day second batch 
     r = run('soak_batch_guard_check', cfg, marker, 'false')
     assert.equal(r.status, 1, 'a legacy single-date marker must refuse fail-closed')
     assert.match(r.stdout, /unrecognized batch-marker line/)
+    // BEHAVIOURAL stale-config refusal (#4933 gate P2-1: a text pin alone was neuterable —
+    // an `or "UTC"` fallback kept the pinned string while silently reverting): a config
+    // whose entry lacks dailyCapTimezone must refuse through the REAL function, whatever
+    // the source spelling.
+    const staleCfg = join(dir, 'stale-config.json')
+    writeFileSync(staleCfg, JSON.stringify({
+      entries: [
+        { orgId: 'aaaaaaaa-0000-0000-0000-000000000001', dailyCapTimezone: 'Asia/Shanghai' },
+        { orgId: 'bbbbbbbb-0000-0000-0000-000000000002' },
+      ],
+    }))
+    rmSync(marker, { force: true })
+    r = run('soak_batch_guard_check', staleCfg, marker, 'false')
+    assert.equal(r.status, 1, 'a config entry without dailyCapTimezone must refuse — never default to UTC days')
+    assert.match(r.stdout, /is missing orgId\/dailyCapTimezone/)
+    // LEGACY-PATH MIGRATION (#4933 gate P2-3: the marker was renamed -day -> -days; a
+    // pre-rename marker at the old path must be migrated conservatively, never silently
+    // ignored). The migrated day counts for EVERY org, so a same-day batch refuses...
+    const legacyMarker = join(dir, 'marker-day')
+    const migratedMarker = join(dir, 'marker-days')
+    const orgToday = (tz) => {
+      const r2 = spawnSync('bash', ['-c', `TZ=${tz} date +%Y-%m-%d`], { encoding: 'utf8' })
+      return r2.stdout.trim()
+    }
+    rmSync(migratedMarker, { force: true })
+    writeFileSync(legacyMarker, `${orgToday('Pacific/Pago_Pago')}\n`)
+    r = run('soak_batch_guard_check', cfg, migratedMarker, 'false')
+    assert.equal(r.status, 1, 'a legacy same-day marker must migrate AND refuse')
+    assert.ok(!existsSync(legacyMarker), 'the legacy marker must be consumed by migration')
+    assert.ok(existsSync(migratedMarker), 'migration must write the per-org marker')
+    assert.equal(
+      readFileSync(migratedMarker, 'utf8').trim().split('\n').length,
+      3,
+      'migration must attribute the legacy day to EVERY org (conservative fail-closed)',
+    )
+    // ...and unrecognized legacy content refuses without migrating.
+    rmSync(migratedMarker, { force: true })
+    writeFileSync(legacyMarker, 'not-a-date\n')
+    r = run('soak_batch_guard_check', cfg, migratedMarker, 'false')
+    assert.equal(r.status, 1, 'unrecognized legacy marker content must refuse fail-closed')
+    assert.match(r.stdout, /legacy batch marker .* holds unrecognized content/)
+    assert.ok(existsSync(legacyMarker), 'an unrecognized legacy marker must be left in place for inspection')
   } finally {
     rmSync(dir, { recursive: true, force: true })
   }


### PR DESCRIPTION
## Codex post-merge review of #4932 — both findings accepted and closed

**P1 — multi-timezone bypass of the same-day guard.** The seeder supports three independent org timezones, but the guard derived ONE global day from `entries[0].dailyCapTimezone`: org1 crossing its local midnight admitted a second batch while org2/org3 were still on their punched local day (generator dailyCounts are per-process), reproducing the duplicate-session §4.2-critical `review_required` shape. Latent for the current all-Asia/Shanghai config; real for the supported input domain — the correct question is 「错误配置会被拒绝吗」, and the answer was no.
→ The marker is now a **per-org closed set** (`{orgId}={tz}={localDay}` lines); `soak_batch_guard_check` refuses the **whole batch** if ANY org already ran on its own current local day; legacy/corrupted marker content refuses fail-closed; stamp still lands BEFORE the generator runs (also fixes a latent marker-write-before-mkdir ordering bug).

**P2 — `daily_capacity_exhausted` masked failed batches.** `dailyCounts` counts every ATTEMPT, so scattered (non-consecutive) 429/500s exhausted capacity with a clean shortfall while the wrapper printed `result=ok` — and the marker blocked a make-up run.
→ ONE classifier (`soak_run_classify`): **ok ⟺ clean halt ∧ zero incidents ∧ target reached**; incident halt FAILs; stall/duration/safety-cap/non-numeric WARN. Summary now records `incidents=`.

**Executable evidence (both units extracted from the shipped bytes and driven directly):**
- Codex's三时区跨日反例 as a permanent leg: Kiritimati (+14) / Pago Pago (−11) / Shanghai — rewinding ONLY org1's recorded day must still refuse on org2/org3 (a first-entry-only guard admits it); same-day refusal, all-rewound admission, override, and legacy-marker fail-closed all asserted.
- Interleaved clean/fail classification matrix (incl. `(daily_capacity_exhausted, 160/180) → WARN` — the exact masked shape).
- 4 mutation legs (guard-call removal, first-entry-derivation revert, incidents-branch neuter, WARN→ok flip), all routed through the shared contract assertions.
- Suite hazard fixed en route: large-hunk mutations switched to replacement-function form (the run slice now contains bash `$'` sequences, which `String.replace` treats as special replacement patterns and silently corrupts).

Pipeline **65/65** · census 58/58 · wiring 255/255. After merge: re-seed, then the first daily batch + soak-status run from the new SHA — measured DB clean deltas replace the previous conditional throughput prediction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)