### PR TITLE
feat(approval): F1 — form command adapter, opaque identity allocator, reference provider (delta §5 F1)

### DIFF
--- a/.github/workflows/approval-web-guard.yml
+++ b/.github/workflows/approval-web-guard.yml
@@ -129,6 +129,12 @@ on:
       # of TemplateAuthoringView.vue) + its behavior-equivalence spec.
       - 'apps/web/src/approvals/components/ApprovalFormInlineEditor.vue'
       - 'apps/web/tests/approval-form-inline-editor-extract.spec.ts'
+      # F1 (2026-08-17, delta §5 F1): opaque identity allocator + production form-command adapter
+      # (FB-D3/D4/D5/D6) + their specs. approvalFormCommands.ts and its test are already listed above.
+      - 'apps/web/src/approvals/approvalFormIdentity.ts'
+      - 'apps/web/src/approvals/approvalFormAuthoringAdapter.ts'
+      - 'apps/web/tests/approval-form-identity.test.ts'
+      - 'apps/web/tests/approval-form-authoring-adapter.test.ts'
       # G-B2-19: readable condition-branch summaries — conditionSummary.ts pure fn consumed by
       # authoring nodeConfigSummary + editor branch heads + the upcomingNodes/graphSummary chain.
       - 'apps/web/src/approvals/conditionSummary.ts'
@@ -327,6 +333,12 @@ on:
       # of TemplateAuthoringView.vue) + its behavior-equivalence spec.
       - 'apps/web/src/approvals/components/ApprovalFormInlineEditor.vue'
       - 'apps/web/tests/approval-form-inline-editor-extract.spec.ts'
+      # F1 (2026-08-17, delta §5 F1): opaque identity allocator + production form-command adapter
+      # (FB-D3/D4/D5/D6) + their specs. approvalFormCommands.ts and its test are already listed above.
+      - 'apps/web/src/approvals/approvalFormIdentity.ts'
+      - 'apps/web/src/approvals/approvalFormAuthoringAdapter.ts'
+      - 'apps/web/tests/approval-form-identity.test.ts'
+      - 'apps/web/tests/approval-form-authoring-adapter.test.ts'
       # G-B2-19: readable condition-branch summaries — conditionSummary.ts pure fn consumed by
       # authoring nodeConfigSummary + editor branch heads + the upcomingNodes/graphSummary chain.
       - 'apps/web/src/approvals/conditionSummary.ts'
@@ -482,6 +494,8 @@ jobs:
             approval-canvas-inspector-a11y \
             approval-form-palette-focus \
             approval-form-inline-editor-extract \
+            approval-form-identity \
+            approval-form-authoring-adapter \
             --reporter=dot
 
       - name: Run FWB mapping authoring contract

--- a/apps/web/scripts/run-required-web-tests.sh
+++ b/apps/web/scripts/run-required-web-tests.sh
@@ -144,6 +144,14 @@
 # alongside the other approval-form-* canaries. Bare basename token; verified unique — no existing
 # `approval-form-*` token (approval-form-commands / approval-form-authoring-history /
 # approval-form-palette-focus / approval-form-draft) is a substring of it or vice versa.
+#
+# F1 (2026-08-17, delta §5 F1): `approval-form-identity` (opaque collision-resistant allocator,
+# FB-D5 OPAQUE_COLLISION_RESISTANT) + `approval-form-authoring-adapter` (the single production
+# command adapter over approvalFormCommands + form history: FB-D3 anchor re-resolution, FB-D4
+# one-history-entry semantics, FB-D5 collision retry, FB-D6 current-draft reference provider,
+# legacy-helper freeze pins). Both bare basename tokens; each verified to match exactly one file
+# in isolation, and no existing token (approval-form-authoring-history is the closest neighbor)
+# is a substring of either or vice versa.
 set -euo pipefail
 cd "$(dirname "$0")/.."
 # Always-on Canvas V2 + residual PLAN 6fa2fbf6 / wave-3 canaries (files landed on main via #4815–#4826).
@@ -159,6 +167,8 @@ npx vitest run \
   approval-canvas-inspector-a11y \
   approval-form-palette-focus \
   approval-form-inline-editor-extract \
+  approval-form-identity \
+  approval-form-authoring-adapter \
   --reporter=dot
 npx vitest run featureFlagsApprovalAttachments --reporter=dot
 npx vitest run approval-fwb-mapping-config approval-fwb-mapping-editor --reporter=dot

--- a/apps/web/src/approvals/approvalFormAuthoringAdapter.ts
+++ b/apps/web/src/approvals/approvalFormAuthoringAdapter.ts
@@ -1,0 +1,295 @@
+import {
+  addFormDetailColumn,
+  addFormField,
+  collectFormFieldDependencies,
+  moveFormField,
+  moveFormFieldByOffset,
+  removeFormField,
+  type FormCommandFailureReason,
+  type FormCommandResult,
+  type FormFieldDependency,
+  type FormInsertionAnchor,
+} from './approvalFormCommands'
+import {
+  canRedoFormHistory,
+  canUndoFormHistory,
+  createFormAuthoringHistory,
+  pushFormSnapshot,
+  redoFormHistory,
+  undoFormHistory,
+  type FormAuthoringHistory,
+} from './approvalFormAuthoringHistory'
+import {
+  createOpaqueFormIdentityAllocator,
+  type OpaqueFormIdentityAllocator,
+} from './approvalFormIdentity'
+import type {
+  AuthorableFieldType,
+  TemplateAuthoringDraft,
+} from './templateAuthoring'
+
+/**
+ * F1 production form-authoring adapter — the ONE typed command path of RATIFIED
+ * FB-D4 (approval-form-builder-parity-delta-design-20260811.md), consumed by
+ * the F2/F3 `ApprovalFormBuilder` behind `approvalCanvasV2`. The flag-OFF
+ * inline editor fallback does not route through this module (delta §5 F1:
+ * additive-only, no production mount until F4).
+ *
+ * Contract:
+ * - Every structural edit flows through `approvalFormCommands` + the form
+ *   authoring history. The UI must never splice/filter the production field
+ *   array directly for these actions.
+ * - A value-changing successful command produces EXACTLY ONE history entry and
+ *   one focus result; a value-identical boundary/no-op produces ZERO history
+ *   entries; a rejected command produces ZERO draft and ZERO history mutation.
+ * - Anchors (FB-D3) are re-resolved by the pure command against the CURRENT
+ *   draft immediately before mutation — this adapter never captures or
+ *   forwards an index. A stale anchor is a values-free no-op rejection.
+ * - Identity (FB-D5 `OPAQUE_COLLISION_RESISTANT`): new field/detail-column
+ *   identities come only from the injected opaque allocator. On
+ *   `field_identity_conflict` the adapter retries with a FRESH candidate up to
+ *   `maxIdentityAttempts`; exhaustion is the typed
+ *   `identity_allocation_exhausted` failure with zero mutation. This adapter
+ *   never calls the legacy length-derived `createEmptyFieldDraft` /
+ *   `createEmptyDetailColumnDraft` helpers.
+ * - References (FB-D6): the authoritative reference set is the current-draft
+ *   set from `collectFormFieldDependencies`, complete by construction;
+ *   `listFieldReferences` exposes it as the delete/retype reference provider.
+ * - Failure surface is values-free: results carry only typed reasons and
+ *   internal dependency kinds/locations — never form values, labels, or other
+ *   user content.
+ */
+
+/** Immutable session snapshot: the current draft plus its structural history. */
+export interface FormAuthoringSession {
+  readonly draft: TemplateAuthoringDraft
+  readonly history: FormAuthoringHistory
+}
+
+export type FormAdapterFailureReason =
+  | FormCommandFailureReason
+  /** Allocator retries exhausted without a collision-free candidate. */
+  | 'identity_allocation_exhausted'
+  /** Undo/redo requested on an empty stack. */
+  | 'history_empty'
+
+/**
+ * Values-free adapter result. On failure the session is returned UNCHANGED —
+ * callers keep using it; no partial draft or history mutation exists.
+ */
+export type FormAdapterResult =
+  | {
+      ok: true
+      session: FormAuthoringSession
+      focusLocalId: string | null
+      /** True when a history entry was created (value-changing edit). */
+      changed: boolean
+    }
+  | {
+      ok: false
+      reason: FormAdapterFailureReason
+      dependencies: readonly FormFieldDependency[]
+      session: FormAuthoringSession
+    }
+
+export interface FormAuthoringAdapterOptions {
+  /** Identity authority; injected deterministic in tests (FB-D5 seam). */
+  identityAllocator?: OpaqueFormIdentityAllocator
+  /** Collision-retry budget per logical add; each attempt is a fresh candidate. */
+  maxIdentityAttempts?: number
+}
+
+export const DEFAULT_IDENTITY_ALLOCATION_ATTEMPTS = 5
+
+export interface FormAuthoringAdapter {
+  /** Seed a session from a hydrated draft. Stacks start empty. */
+  startSession(
+    draft: TemplateAuthoringDraft,
+    focusLocalId?: string | null,
+  ): FormAuthoringSession
+  /** Palette click (no anchor = append) and exact-slot drop (FB-D3 anchor). */
+  addField(
+    session: FormAuthoringSession,
+    fieldType: AuthorableFieldType,
+    anchor?: FormInsertionAnchor,
+  ): FormAdapterResult
+  /** Append one column to an existing detail field with an opaque identity. */
+  addDetailColumn(
+    session: FormAuthoringSession,
+    fieldLocalId: string,
+  ): FormAdapterResult
+  /** Reference-aware delete; refuses last-field and referenced deletes. */
+  removeField(session: FormAuthoringSession, localId: string): FormAdapterResult
+  /** Semantic drag placement. */
+  moveField(
+    session: FormAuthoringSession,
+    movingLocalId: string,
+    targetLocalId: string,
+    placement: 'before' | 'after',
+  ): FormAdapterResult
+  /** Keyboard 上移/下移; boundary is a zero-entry no-op. */
+  moveFieldByOffset(
+    session: FormAuthoringSession,
+    localId: string,
+    offset: -1 | 1,
+  ): FormAdapterResult
+  /**
+   * FB-D6 reference provider: the complete-by-construction current-draft
+   * reference set for the field, for inspector business copy. Empty when the
+   * field does not exist.
+   */
+  listFieldReferences(
+    session: FormAuthoringSession,
+    localId: string,
+  ): readonly FormFieldDependency[]
+  undo(session: FormAuthoringSession): FormAdapterResult
+  redo(session: FormAuthoringSession): FormAdapterResult
+  canUndo(session: FormAuthoringSession): boolean
+  canRedo(session: FormAuthoringSession): boolean
+}
+
+function failure(
+  session: FormAuthoringSession,
+  reason: FormAdapterFailureReason,
+  dependencies: readonly FormFieldDependency[] = [],
+): FormAdapterResult {
+  return { ok: false, reason, dependencies, session }
+}
+
+/**
+ * Commit one successful command result: push at most ONE history snapshot
+ * (`pushFormSnapshot` returns the identical history for value-identical field
+ * lists, so boundary no-ops create zero entries by construction).
+ */
+function commit(
+  session: FormAuthoringSession,
+  result: FormCommandResult,
+): FormAdapterResult {
+  if (!result.ok) {
+    return failure(session, result.reason, result.dependencies)
+  }
+  const history = pushFormSnapshot(
+    session.history,
+    result.draft.fields,
+    result.focusLocalId,
+  )
+  const changed =
+    history.undoStack.length > session.history.undoStack.length
+  return {
+    ok: true,
+    session: { draft: result.draft, history },
+    focusLocalId: result.focusLocalId,
+    changed,
+  }
+}
+
+export function createFormAuthoringAdapter(
+  options: FormAuthoringAdapterOptions = {},
+): FormAuthoringAdapter {
+  const allocator =
+    options.identityAllocator ?? createOpaqueFormIdentityAllocator()
+  const maxAttempts = Math.max(
+    1,
+    options.maxIdentityAttempts ?? DEFAULT_IDENTITY_ALLOCATION_ATTEMPTS,
+  )
+
+  return {
+    startSession(draft, focusLocalId = null) {
+      return {
+        draft,
+        history: createFormAuthoringHistory(draft.fields, focusLocalId),
+      }
+    },
+
+    addField(session, fieldType, anchor) {
+      for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+        // FRESH candidate per attempt — a rejected candidate is never reused.
+        const identity = allocator.nextFieldIdentity(fieldType)
+        const result = addFormField(session.draft, fieldType, identity, anchor)
+        if (result.ok) return commit(session, result)
+        if (result.reason !== 'field_identity_conflict') {
+          return failure(session, result.reason, result.dependencies)
+        }
+      }
+      return failure(session, 'identity_allocation_exhausted')
+    },
+
+    addDetailColumn(session, fieldLocalId) {
+      for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+        const identity = allocator.nextDetailColumnIdentity()
+        const result = addFormDetailColumn(
+          session.draft,
+          fieldLocalId,
+          identity,
+        )
+        if (result.ok) return commit(session, result)
+        if (result.reason !== 'field_identity_conflict') {
+          return failure(session, result.reason, result.dependencies)
+        }
+      }
+      return failure(session, 'identity_allocation_exhausted')
+    },
+
+    removeField(session, localId) {
+      return commit(session, removeFormField(session.draft, localId))
+    },
+
+    moveField(session, movingLocalId, targetLocalId, placement) {
+      return commit(
+        session,
+        moveFormField(session.draft, movingLocalId, targetLocalId, placement),
+      )
+    },
+
+    moveFieldByOffset(session, localId, offset) {
+      return commit(
+        session,
+        moveFormFieldByOffset(session.draft, localId, offset),
+      )
+    },
+
+    listFieldReferences(session, localId) {
+      const field = session.draft.fields.find(
+        (candidate) => candidate.localId === localId,
+      )
+      if (!field) return []
+      return collectFormFieldDependencies(session.draft, field.id)
+    },
+
+    undo(session) {
+      const result = undoFormHistory(session.history)
+      if (!result.ok) return failure(session, 'history_empty')
+      return {
+        ok: true,
+        session: {
+          draft: { ...session.draft, fields: result.fields },
+          history: result.history,
+        },
+        focusLocalId: result.focusLocalId,
+        changed: true,
+      }
+    },
+
+    redo(session) {
+      const result = redoFormHistory(session.history)
+      if (!result.ok) return failure(session, 'history_empty')
+      return {
+        ok: true,
+        session: {
+          draft: { ...session.draft, fields: result.fields },
+          history: result.history,
+        },
+        focusLocalId: result.focusLocalId,
+        changed: true,
+      }
+    },
+
+    canUndo(session) {
+      return canUndoFormHistory(session.history)
+    },
+
+    canRedo(session) {
+      return canRedoFormHistory(session.history)
+    },
+  }
+}

--- a/apps/web/src/approvals/approvalFormAuthoringAdapter.ts
+++ b/apps/web/src/approvals/approvalFormAuthoringAdapter.ts
@@ -173,8 +173,15 @@ function commit(
     result.draft.fields,
     result.focusLocalId,
   )
-  const changed =
-    history.undoStack.length > session.history.undoStack.length
+  // Identity, not undo-stack length growth: once the stack saturates
+  // `FORM_AUTHORING_HISTORY_MAX_STACK`, `trimStack` drops the oldest entry on
+  // every further real push, so length stops growing even though a genuine
+  // value-changing edit landed. `pushFormSnapshot`'s three return paths all
+  // discriminate correctly on `fields` identity instead: a full no-op returns
+  // the SAME history object (same `fields` ref); a focus-only change spreads
+  // the existing history (same `fields` ref carried over); a real change
+  // always returns a freshly cloned `fields` array (new ref).
+  const changed = history.fields !== session.history.fields
   return {
     ok: true,
     session: { draft: result.draft, history },

--- a/apps/web/src/approvals/approvalFormCommands.ts
+++ b/apps/web/src/approvals/approvalFormCommands.ts
@@ -369,7 +369,7 @@ function collectPreservedGraphReferences(
   }
   if (!isRecord(value)) return
 
-  if (value.fieldId === fieldId) {
+  if (typeof value.fieldId === 'string' && value.fieldId.trim() === fieldId) {
     dependencies.push({ kind: 'preserved_graph_reference', location })
   }
   if (
@@ -437,7 +437,9 @@ export function collectFormFieldDependencies(
       })
     }
     if (
-      step.fieldPermissions.some((permission) => permission.fieldId === fieldId)
+      step.fieldPermissions.some(
+        (permission) => permission.fieldId.trim() === fieldId,
+      )
     ) {
       dependencies.push({
         kind: 'step_field_permission',
@@ -486,7 +488,9 @@ export function collectFormFieldDependencies(
   const mapping = draft.amountConsistencyCheck
   if (
     mapping &&
-    (mapping.totalFieldId === fieldId || mapping.detailFieldId === fieldId)
+    (mapping.totalFieldId.trim() === fieldId ||
+      mapping.detailFieldId.trim() === fieldId ||
+      mapping.amountColumnId.trim() === fieldId)
   ) {
     dependencies.push({
       kind: 'amount_consistency_mapping',

--- a/apps/web/src/approvals/approvalFormCommands.ts
+++ b/apps/web/src/approvals/approvalFormCommands.ts
@@ -6,9 +6,13 @@ import type {
 } from './templateAuthoring'
 
 /**
- * D6-f1 form command algebra. These commands use `localId` only as a view-model
- * selection key. It is never rendered as, or accepted from, ordinary-user input;
- * persisted field ids remain owned by the existing template-authoring serializer.
+ * D6-f1 form command algebra, amended by F1 of the RATIFIED
+ * approval-form-builder-parity delta (FB-D3 anchors, FB-D5
+ * `OPAQUE_COLLISION_RESISTANT` identity, FB-D6
+ * `CURRENT_DRAFT_REFERENCES_PLUS_VERSION_PINNED_EXTERNALS` delete boundary).
+ * These commands use `localId` only as a view-model selection key. It is never
+ * rendered as, or accepted from, ordinary-user input; persisted field ids
+ * remain owned by the existing template-authoring serializer.
  */
 
 export type FormCommandFailureReason =
@@ -16,10 +20,9 @@ export type FormCommandFailureReason =
   | 'target_not_found'
   | 'unsupported_field_type'
   | 'invalid_field_identity'
-  | 'identity_history_missing'
   | 'field_identity_conflict'
-  | 'reference_inventory_missing'
   | 'field_is_referenced'
+  | 'last_field_removal_forbidden'
 
 export type FormDependencyKind =
   | 'visibility_rule'
@@ -39,9 +42,17 @@ export interface FormFieldDependency {
 }
 
 /**
- * FWB mappings and future persisted integrations are not stored on the authoring
- * draft. A delete must receive a complete inventory from their owner rather than
- * assuming that no out-of-draft reference exists.
+ * Optional external-reference input for `collectFormFieldDependencies`, reserved
+ * for a FUTURE same-version external reference owner. It is NOT an FWB
+ * inventory: no template-keyed FWB reference inventory exists, and FWB mappings
+ * are deliberately not live references to this mutable draft — they are pinned
+ * to `sourceTemplateVersionId`, save/execute already require that pin to match
+ * the active template version, and publishing any new version makes old
+ * mappings stale and requires reconfirmation independently of which fields
+ * changed (RATIFIED FB-D6). The production delete path therefore takes no
+ * inventory; a future same-version external reference owner must add an
+ * authoritative provider plus backend validation before delete safety can
+ * widen — the UI must never fabricate such a provider.
  */
 export interface CompleteFormReferenceInventory {
   readonly complete: true
@@ -54,10 +65,16 @@ export interface FormExternalReference {
 }
 
 /**
- * An identity allocated by the authoring session's durable identity owner. It is
- * an internal command input, not a normal-user field-id API. The pure command
- * deliberately never derives persistent IDs from the current draft: a deleted
- * maximum suffix must not become a later field's identity.
+ * An identity allocated by the opaque collision-resistant allocator
+ * (`approvalFormIdentity.ts` — RATIFIED FB-D5 `OPAQUE_COLLISION_RESISTANT`).
+ * It is an internal command input, not a normal-user field-id API. The pure
+ * command deliberately never derives persistent IDs from the current draft: a
+ * deleted maximum suffix must not become a later field's identity. The opaque
+ * allocator is the sole collision authority — this command validates each
+ * candidate against the complete current draft, the adapter retries a
+ * collision with a fresh candidate, and cross-version non-reuse is provided by
+ * the allocator's opacity rather than an identity-history parameter or a
+ * server reservation API.
  *
  * Detail fields need an explicit first-column identity because column IDs are
  * also persisted and may not collide with any live field or column identity.
@@ -71,17 +88,23 @@ export interface FormFieldIdentity {
   }
 }
 
-/**
- * Complete reservation history for the template's published versions and current
- * draft. D6-f2's durable identity allocator must maintain this set as fields or
- * detail columns are introduced and retired. D6-f1 uses it as a fail-closed
- * command input now, so correctness is not left to an unverified caller policy.
- */
-export interface CompleteFormIdentityHistory {
-  readonly complete: true
-  readonly persistentIds: readonly string[]
-  readonly localIds: readonly string[]
+/** Opaque identity for one additional detail column (`addFormDetailColumn`). */
+export interface FormDetailColumnIdentity {
+  readonly persistentId: string
+  readonly localId: string
 }
+
+/**
+ * FB-D3 semantic insertion anchor: a slot is identified by its current
+ * neighbors, never by a persisted index or pixel coordinate. Anchors are
+ * re-resolved against the draft immediately before mutation; a stale `after`
+ * anchor (field removed since drag start) is a values-free rejection with zero
+ * draft mutation. `{ kind: 'start' }` prepends ATOMICALLY inside one
+ * `addFormField` call — it is never implemented as an add-then-move pair.
+ */
+export type FormInsertionAnchor =
+  | { kind: 'start' }
+  | { kind: 'after'; localId: string }
 
 export type FormCommandResult =
   | {
@@ -161,28 +184,16 @@ function isUsableIdentity(
   )
 }
 
-function isCompleteIdentityHistory(
-  history: CompleteFormIdentityHistory | undefined,
-): history is CompleteFormIdentityHistory {
-  return Boolean(
-    history &&
-      history.complete === true &&
-      Array.isArray(history.persistentIds) &&
-      Array.isArray(history.localIds) &&
-      history.persistentIds.every(nonBlank) &&
-      history.localIds.every(nonBlank),
-  )
-}
-
-function identityConflicts(
+/**
+ * Every identity token reserved by the COMPLETE current draft: field
+ * persistent/local ids plus every detail column's persistent/local ids. This is
+ * the FB-D5 collision domain — the opaque allocator (not an identity-history
+ * parameter) owns cross-version non-reuse.
+ */
+function reservedDraftIdentityTokens(
   draft: TemplateAuthoringDraft,
-  identity: FormFieldIdentity,
-  history: CompleteFormIdentityHistory,
-): boolean {
-  const reserved = new Set<string>([
-    ...history.persistentIds,
-    ...history.localIds,
-  ])
+): Set<string> {
+  const reserved = new Set<string>()
   draft.fields.forEach((field) => {
     reserved.add(field.id)
     reserved.add(field.localId)
@@ -191,40 +202,76 @@ function identityConflicts(
       reserved.add(column.localId)
     })
   })
-  const candidates = [
+  return reserved
+}
+
+/** True when candidates collide with each other or with the current draft. */
+function candidateTokensConflict(
+  draft: TemplateAuthoringDraft,
+  candidates: readonly string[],
+): boolean {
+  if (new Set(candidates).size !== candidates.length) {
+    return true
+  }
+  const reserved = reservedDraftIdentityTokens(draft)
+  return candidates.some((candidate) => reserved.has(candidate))
+}
+
+function identityConflicts(
+  draft: TemplateAuthoringDraft,
+  identity: FormFieldIdentity,
+): boolean {
+  return candidateTokensConflict(draft, [
     identity.persistentId,
     identity.localId,
     ...(identity.detailColumn
       ? [identity.detailColumn.persistentId, identity.detailColumn.localId]
       : []),
-  ]
-  if (new Set(candidates).size !== candidates.length) {
-    return true
-  }
-  return candidates.some((candidate) => reserved.has(candidate))
+  ])
 }
 
 /**
- * Add a supported top-level field at the selected location. The caller supplies
- * a durable identity, making this pure command deterministic for retries while
- * preventing the old max-suffix allocator from reusing deleted persistent IDs.
- * Its complete history is mandatory: without it a deleted identity cannot be
- * distinguished from one that was never allocated, so add fails closed.
+ * Add a supported top-level field at the anchor-selected slot. The caller
+ * supplies a durable OPAQUE identity (RATIFIED FB-D5
+ * `OPAQUE_COLLISION_RESISTANT`): the opaque allocator is the sole collision
+ * authority, this command validates each candidate against the complete
+ * current draft, and the production adapter retries a collision with a FRESH
+ * candidate. Supplying the identity keeps this pure command deterministic for
+ * replays while preventing the old max-suffix allocator from reusing deleted
+ * persistent IDs.
+ *
+ * Anchor semantics (FB-D3): the anchor is resolved against `draft` at call
+ * time — never a captured index. `{ kind: 'start' }` prepends ATOMICALLY in
+ * this one command (one splice, never an add-then-move pair); a stale
+ * `{ kind: 'after' }` anchor is a values-free `target_not_found` rejection
+ * with zero mutation. Omitting the anchor keeps the legacy append convenience
+ * used by palette click.
  */
 export function addFormField(
   draft: TemplateAuthoringDraft,
   fieldType: AuthorableFieldType,
   identity: FormFieldIdentity,
-  history: CompleteFormIdentityHistory,
-  afterLocalId?: string,
+  anchor?: FormInsertionAnchor,
 ): FormCommandResult {
   if (!AUTHORABLE_FIELD_TYPES.has(fieldType))
     return rejected('unsupported_field_type')
   if (!isUsableIdentity(fieldType, identity))
     return rejected('invalid_field_identity')
-  if (!isCompleteIdentityHistory(history))
-    return rejected('identity_history_missing')
-  if (identityConflicts(draft, identity, history))
+
+  let insertAt: number
+  if (!anchor) {
+    insertAt = draft.fields.length
+  } else if (anchor.kind === 'start') {
+    insertAt = 0
+  } else {
+    const index = draft.fields.findIndex(
+      (candidate) => candidate.localId === anchor.localId,
+    )
+    if (index === -1) return rejected('target_not_found')
+    insertAt = index + 1
+  }
+
+  if (identityConflicts(draft, identity))
     return rejected('field_identity_conflict')
 
   const field: FieldAuthoringDraft = {
@@ -244,20 +291,54 @@ export function addFormField(
     recordLinkSheetId: '',
   }
 
-  if (!afterLocalId) {
-    return successful(
-      { ...draft, fields: [...draft.fields, field] },
-      field.localId,
-    )
-  }
-
-  const index = draft.fields.findIndex(
-    (candidate) => candidate.localId === afterLocalId,
-  )
-  if (index === -1) return rejected('target_not_found')
   const fields = [...draft.fields]
-  fields.splice(index + 1, 0, field)
+  fields.splice(insertAt, 0, field)
   return successful({ ...draft, fields }, field.localId)
+}
+
+/**
+ * Append one additional column to an existing `detail` field with a supplied
+ * OPAQUE identity (FB-D5 — column ids are persisted and share one collision
+ * domain with every live field/column identity in the complete current draft).
+ * The generated `子字段 N` label is display copy only — it is never identity,
+ * and duplicate display labels after a deletion are legal and editable.
+ */
+export function addFormDetailColumn(
+  draft: TemplateAuthoringDraft,
+  fieldLocalId: string,
+  identity: FormDetailColumnIdentity,
+): FormCommandResult {
+  const index = draft.fields.findIndex(
+    (field) => field.localId === fieldLocalId,
+  )
+  if (index === -1) return rejected('field_not_found')
+  const owner = draft.fields[index]
+  if (owner.type !== 'detail') return rejected('unsupported_field_type')
+  if (
+    !identity ||
+    !nonBlank(identity.persistentId) ||
+    !nonBlank(identity.localId)
+  )
+    return rejected('invalid_field_identity')
+  if (
+    candidateTokensConflict(draft, [identity.persistentId, identity.localId])
+  )
+    return rejected('field_identity_conflict')
+
+  const column: DetailColumnDraft = {
+    localId: identity.localId,
+    id: identity.persistentId,
+    type: 'text',
+    label: `子字段 ${owner.detailColumns.length + 1}`,
+    required: false,
+    optionsText: '',
+  }
+  const fields = [...draft.fields]
+  fields[index] = {
+    ...owner,
+    detailColumns: [...owner.detailColumns, column],
+  }
+  return successful({ ...draft, fields }, owner.localId)
 }
 
 function formulaReferencesField(value: string, fieldId: string): boolean {
@@ -310,9 +391,15 @@ function collectPreservedGraphReferences(
 }
 
 /**
- * Enumerate every reference represented by the current authoring draft. The
- * inventory is deliberately conservative: an unrecognised graph `fieldId` or
- * formula token blocks delete rather than being rewritten to another field.
+ * Enumerate every reference represented by the current authoring draft —
+ * complete by construction over the draft (visibility, assignee sources, field
+ * permissions, condition rules/formulas, preserved graph, amount-consistency
+ * mapping). Per RATIFIED FB-D6 this current-draft set is the authoritative
+ * delete boundary; the optional `inventory` is only the seam for a FUTURE
+ * authoritative same-version external reference owner (see
+ * `CompleteFormReferenceInventory`). The walk is deliberately conservative: an
+ * unrecognised graph `fieldId` or formula token blocks delete rather than
+ * being rewritten to another field.
  */
 export function collectFormFieldDependencies(
   draft: TemplateAuthoringDraft,
@@ -418,28 +505,29 @@ export function collectFormFieldDependencies(
 }
 
 /**
- * Remove only an unreferenced field. The reference inventory is required because
- * writeback mappings are owned outside this draft; omission is a fail-closed
- * refusal, never an assumption that no mapping exists.
+ * Remove only a removable, unreferenced field. RATIFIED FB-D6
+ * (`CURRENT_DRAFT_REFERENCES_PLUS_VERSION_PINNED_EXTERNALS`): the authoritative
+ * reference set for delete is the complete-by-construction current-draft set
+ * from `collectFormFieldDependencies`; FWB stays version-pinned-external (see
+ * `CompleteFormReferenceInventory` for why no live FWB inventory exists), so
+ * the production delete signature takes no inventory parameter.
+ *
+ * Removing the final remaining field is rejected HERE with
+ * `last_field_removal_forbidden` BEFORE reference evaluation — the UI
+ * disable/early-return is a convenience only, never the integrity boundary.
  */
 export function removeFormField(
   draft: TemplateAuthoringDraft,
   localId: string,
-  inventory?: CompleteFormReferenceInventory,
 ): FormCommandResult {
   const index = draft.fields.findIndex((field) => field.localId === localId)
   if (index === -1) return rejected('field_not_found')
-  if (
-    !inventory ||
-    inventory.complete !== true ||
-    !Array.isArray(inventory.references)
-  ) {
-    return rejected('reference_inventory_missing')
+  if (draft.fields.length <= 1) {
+    return rejected('last_field_removal_forbidden')
   }
   const dependencies = collectFormFieldDependencies(
     draft,
     draft.fields[index].id,
-    inventory,
   )
   if (dependencies.length > 0)
     return rejected('field_is_referenced', dependencies)

--- a/apps/web/src/approvals/approvalFormIdentity.ts
+++ b/apps/web/src/approvals/approvalFormIdentity.ts
@@ -1,0 +1,112 @@
+import type {
+  FormDetailColumnIdentity,
+  FormFieldIdentity,
+} from './approvalFormCommands'
+import type { AuthorableFieldType } from './templateAuthoring'
+
+/**
+ * F1 opaque identity allocator — RATIFIED FB-D5 `OPAQUE_COLLISION_RESISTANT`
+ * (approval-form-builder-parity-delta-design-20260811.md §2/§10).
+ *
+ * This module is the SOLE identity authority for Designer 2.0 fields, detail
+ * columns, and their local selection ids. Contract:
+ *
+ * - Identities are opaque random tokens. They are NEVER derived from current
+ *   list length, maximum visible suffix, array index, timestamps, or any other
+ *   draft state — by construction: no allocator entry point accepts a draft.
+ * - Every call produces a FRESH candidate (new random bytes per token), so the
+ *   adapter's collision retry can never re-submit a rejected candidate.
+ * - Cross-version non-reuse is provided by opacity/entropy, not by a server
+ *   reservation API or an identity-history parameter: `addFormField` /
+ *   `addFormDetailColumn` validate each candidate against the complete current
+ *   draft, and `approvalFormAuthoringAdapter` retries a collision before any
+ *   mutation.
+ * - The random source is an injected seam (`IdentityRandomSource`) so tests can
+ *   be deterministic and can force collisions; production uses Web Crypto.
+ *
+ * The legacy `createEmptyFieldDraft(index)` / `createEmptyDetailColumnDraft(index)`
+ * helpers remain the flag-OFF inline-editor fallback and are NOT re-routed here
+ * (delta §5 F1 protected baseline). This module must never import them.
+ */
+
+/** Random-byte seam. Production: Web Crypto. Tests: injected deterministic source. */
+export interface IdentityRandomSource {
+  /** Return `length` uniformly random bytes. Each call must be independent. */
+  nextBytes(length: number): Uint8Array
+}
+
+/** Bytes of entropy per identity token (16 hex chars = 64 bits per token). */
+export const OPAQUE_IDENTITY_TOKEN_BYTES = 8
+
+/** Allocates opaque identities; see module doc for the FB-D5 contract. */
+export interface OpaqueFormIdentityAllocator {
+  /**
+   * Fresh opaque field identity. Includes a first detail-column identity
+   * exactly when `fieldType === 'detail'` (column ids are persisted too and
+   * share the same collision domain).
+   */
+  nextFieldIdentity(fieldType: AuthorableFieldType): FormFieldIdentity
+  /** Fresh opaque identity for one additional detail column. */
+  nextDetailColumnIdentity(): FormDetailColumnIdentity
+}
+
+/** Web Crypto random source with a non-crypto fallback for exotic test hosts. */
+export function defaultIdentityRandomSource(): IdentityRandomSource {
+  return {
+    nextBytes(length: number): Uint8Array {
+      const bytes = new Uint8Array(length)
+      const cryptoApi = (globalThis as { crypto?: Crypto }).crypto
+      if (cryptoApi && typeof cryptoApi.getRandomValues === 'function') {
+        cryptoApi.getRandomValues(bytes)
+        return bytes
+      }
+      for (let index = 0; index < length; index += 1) {
+        bytes[index] = Math.floor(Math.random() * 256)
+      }
+      return bytes
+    },
+  }
+}
+
+function hexToken(source: IdentityRandomSource): string {
+  const bytes = source.nextBytes(OPAQUE_IDENTITY_TOKEN_BYTES)
+  let token = ''
+  for (let index = 0; index < bytes.length; index += 1) {
+    token += bytes[index]!.toString(16).padStart(2, '0')
+  }
+  return token
+}
+
+/**
+ * Create the opaque allocator. Prefixes (`fld_`/`fldloc_`/`dcol_`/`dcolloc_`)
+ * are namespacing only — the random token is the identity; prefixes carry no
+ * ordering or count information. Distinct prefixes also keep opaque ids out of
+ * the legacy `field_N` / `col_N` / `field_<ts>_*` / `detailcol_<ts>_*` shapes,
+ * so the two allocation lineages cannot alias each other.
+ */
+export function createOpaqueFormIdentityAllocator(
+  source: IdentityRandomSource = defaultIdentityRandomSource(),
+): OpaqueFormIdentityAllocator {
+  return {
+    nextFieldIdentity(fieldType: AuthorableFieldType): FormFieldIdentity {
+      return {
+        persistentId: `fld_${hexToken(source)}`,
+        localId: `fldloc_${hexToken(source)}`,
+        ...(fieldType === 'detail'
+          ? {
+              detailColumn: {
+                persistentId: `dcol_${hexToken(source)}`,
+                localId: `dcolloc_${hexToken(source)}`,
+              },
+            }
+          : {}),
+      }
+    },
+    nextDetailColumnIdentity(): FormDetailColumnIdentity {
+      return {
+        persistentId: `dcol_${hexToken(source)}`,
+        localId: `dcolloc_${hexToken(source)}`,
+      }
+    },
+  }
+}

--- a/apps/web/tests/approval-form-authoring-adapter.test.ts
+++ b/apps/web/tests/approval-form-authoring-adapter.test.ts
@@ -1,0 +1,464 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import {
+  createFormAuthoringAdapter,
+  DEFAULT_IDENTITY_ALLOCATION_ATTEMPTS,
+  type FormAdapterResult,
+} from '../src/approvals/approvalFormAuthoringAdapter'
+import {
+  OPAQUE_IDENTITY_TOKEN_BYTES,
+  createOpaqueFormIdentityAllocator,
+  type IdentityRandomSource,
+} from '../src/approvals/approvalFormIdentity'
+import {
+  createEmptyDetailColumnDraft,
+  createEmptyFieldDraft,
+  createEmptyStepDraft,
+  createEmptyTemplateDraft,
+  type FieldAuthoringDraft,
+  type TemplateAuthoringDraft,
+} from '../src/approvals/templateAuthoring'
+
+function field(
+  index: number,
+  overrides: Partial<FieldAuthoringDraft> = {},
+): FieldAuthoringDraft {
+  return {
+    ...createEmptyFieldDraft(index),
+    localId: `local_${index}`,
+    id: `field_${index}`,
+    label: `字段 ${index}`,
+    ...overrides,
+  }
+}
+
+function draftWith(fields: FieldAuthoringDraft[]): TemplateAuthoringDraft {
+  return {
+    ...createEmptyTemplateDraft(),
+    key: 'form_adapter',
+    name: '表单适配器',
+    fields,
+    steps: [createEmptyStepDraft(1)],
+  }
+}
+
+function assertOk(
+  result: FormAdapterResult,
+): asserts result is Extract<FormAdapterResult, { ok: true }> {
+  expect(result.ok).toBe(true)
+  if (!result.ok) throw new Error(result.reason)
+}
+
+/** Seam that replays scripted 8-byte blocks in order (then wraps). */
+function scriptedSource(blocks: number[][]): IdentityRandomSource {
+  let cursor = 0
+  return {
+    nextBytes(length: number): Uint8Array {
+      expect(length).toBe(OPAQUE_IDENTITY_TOKEN_BYTES)
+      const block = blocks[cursor % blocks.length]!
+      cursor += 1
+      return Uint8Array.from(block)
+    },
+  }
+}
+
+const BLOCK_A = [0x0a, 0x0a, 0x0a, 0x0a, 0x0a, 0x0a, 0x0a, 0x0a]
+const BLOCK_B = [0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b]
+const BLOCK_C = [0x0c, 0x0c, 0x0c, 0x0c, 0x0c, 0x0c, 0x0c, 0x0c]
+const BLOCK_D = [0x0d, 0x0d, 0x0d, 0x0d, 0x0d, 0x0d, 0x0d, 0x0d]
+const HEX_A = '0a'.repeat(8)
+const HEX_B = '0b'.repeat(8)
+const HEX_C = '0c'.repeat(8)
+const HEX_D = '0d'.repeat(8)
+
+describe('approvalFormAuthoringAdapter - identity (FB-D5)', () => {
+  it('delete-middle-then-add mints a FRESH opaque id: no reuse of the retired id, no collision', () => {
+    const adapter = createFormAuthoringAdapter()
+    const session = adapter.startSession(
+      draftWith([field(1), field(2), field(3)]),
+    )
+    const removed = adapter.removeField(session, 'local_2')
+    assertOk(removed)
+    expect(removed.session.draft.fields.map((entry) => entry.id)).toEqual([
+      'field_1',
+      'field_3',
+    ])
+    // Positive control: the add succeeds after the middle delete.
+    const added = adapter.addField(removed.session, 'text')
+    assertOk(added)
+    const created = added.session.draft.fields.at(-1)!
+    // Never the retired id, never a live id — and provably from the opaque
+    // allocator (a length-derived `field_${length + 1}` mint cannot match).
+    expect(created.id).not.toBe('field_2')
+    expect(['field_1', 'field_2', 'field_3']).not.toContain(created.id)
+    expect(created.id).toMatch(/^fld_[0-9a-f]{16}$/)
+    expect(created.localId).toMatch(/^fldloc_[0-9a-f]{16}$/)
+    const ids = added.session.draft.fields.map((entry) => entry.id)
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+
+  it('retries a seam-forced collision with a FRESH candidate and succeeds', () => {
+    // First candidate (A/B) collides with a live field id; second (C/D) is free.
+    const source = scriptedSource([BLOCK_A, BLOCK_B, BLOCK_C, BLOCK_D])
+    const adapter = createFormAuthoringAdapter({
+      identityAllocator: createOpaqueFormIdentityAllocator(source),
+    })
+    const session = adapter.startSession(
+      draftWith([field(1, { id: `fld_${HEX_A}` })]),
+    )
+    const added = adapter.addField(session, 'text')
+    assertOk(added)
+    const created = added.session.draft.fields.at(-1)!
+    expect(created.id).toBe(`fld_${HEX_C}`)
+    expect(created.localId).toBe(`fldloc_${HEX_D}`)
+    expect(created.id).not.toBe(`fld_${HEX_A}`)
+    // Exactly ONE history entry despite the internal retry.
+    expect(added.session.history.undoStack).toHaveLength(1)
+    expect(added.changed).toBe(true)
+  })
+
+  it('exhausts the retry budget as a typed values-free failure with zero mutation', () => {
+    // Constant seam: every candidate collides with the live field id forever.
+    const source = scriptedSource([BLOCK_A])
+    const adapter = createFormAuthoringAdapter({
+      identityAllocator: createOpaqueFormIdentityAllocator(source),
+    })
+    const session = adapter.startSession(
+      draftWith([field(1, { id: `fld_${HEX_A}` })]),
+    )
+    const result = adapter.addField(session, 'text')
+    expect(result).toMatchObject({
+      ok: false,
+      reason: 'identity_allocation_exhausted',
+      dependencies: [],
+    })
+    if (!result.ok) {
+      // Session returned unchanged by identity — zero draft/history mutation.
+      expect(result.session).toBe(session)
+      // Values-free failure surface: typed members only.
+      expect(Object.keys(result).sort()).toEqual([
+        'dependencies',
+        'ok',
+        'reason',
+        'session',
+      ])
+    }
+    expect(session.history.undoStack).toHaveLength(0)
+    expect(session.draft.fields).toHaveLength(1)
+    expect(DEFAULT_IDENTITY_ALLOCATION_ATTEMPTS).toBeGreaterThan(1)
+  })
+
+  it('appends a detail column through the opaque allocator with one history entry', () => {
+    const adapter = createFormAuthoringAdapter()
+    const detailOwner = field(1, {
+      localId: 'detail_local',
+      id: 'detail_field',
+      type: 'detail',
+      detailColumns: [
+        {
+          localId: 'existing_column_local',
+          id: 'existing_column',
+          type: 'text',
+          label: '已有子字段',
+          required: false,
+          optionsText: '',
+        },
+      ],
+    })
+    const session = adapter.startSession(draftWith([detailOwner, field(2)]))
+    const added = adapter.addDetailColumn(session, 'detail_local')
+    assertOk(added)
+    const columns = added.session.draft.fields[0].detailColumns
+    expect(columns).toHaveLength(2)
+    expect(columns.at(-1)!.id).toMatch(/^dcol_[0-9a-f]{16}$/)
+    expect(columns.at(-1)!.localId).toMatch(/^dcolloc_[0-9a-f]{16}$/)
+    expect(added.session.history.undoStack).toHaveLength(1)
+    expect(added.focusLocalId).toBe('detail_local')
+    // Negative: a non-detail target is a typed refusal with zero entries.
+    const refused = adapter.addDetailColumn(added.session, 'local_2')
+    expect(refused).toMatchObject({ ok: false, reason: 'unsupported_field_type' })
+    if (!refused.ok) expect(refused.session).toBe(added.session)
+  })
+})
+
+describe('approvalFormAuthoringAdapter - anchors (FB-D3)', () => {
+  it('start anchor prepends exactly, atomically, as ONE history entry', () => {
+    const adapter = createFormAuthoringAdapter()
+    const session = adapter.startSession(draftWith([field(1), field(2)]))
+    const added = adapter.addField(session, 'text', { kind: 'start' })
+    assertOk(added)
+    expect(added.session.draft.fields).toHaveLength(3)
+    expect(added.session.draft.fields[0].id).toMatch(/^fld_[0-9a-f]{16}$/)
+    expect(added.session.draft.fields.slice(1).map((entry) => entry.id)).toEqual(
+      ['field_1', 'field_2'],
+    )
+    expect(added.session.draft.fields[0].localId).toBe(added.focusLocalId)
+    // ONE entry — a single undo returns to the pre-add list (no hidden
+    // add-then-move pair).
+    expect(added.session.history.undoStack).toHaveLength(1)
+    const undone = adapter.undo(added.session)
+    assertOk(undone)
+    expect(undone.session.draft.fields.map((entry) => entry.id)).toEqual([
+      'field_1',
+      'field_2',
+    ])
+  })
+
+  it('after anchor inserts at the exact slot', () => {
+    const adapter = createFormAuthoringAdapter()
+    const session = adapter.startSession(draftWith([field(1), field(2)]))
+    const added = adapter.addField(session, 'number', {
+      kind: 'after',
+      localId: 'local_1',
+    })
+    assertOk(added)
+    expect(added.session.draft.fields.map((entry) => entry.localId)).toEqual([
+      'local_1',
+      added.focusLocalId,
+      'local_2',
+    ])
+  })
+
+  it('re-resolves the anchor immediately before mutation: a stale anchor is a zero-entry no-op', () => {
+    const adapter = createFormAuthoringAdapter()
+    const session = adapter.startSession(
+      draftWith([field(1), field(2), field(3)]),
+    )
+    // Anchor captured at "drag start" while local_2 sits at index 1…
+    const anchor = { kind: 'after', localId: 'local_2' } as const
+    // …the anchored field is deleted before the drop lands.
+    const removed = adapter.removeField(session, 'local_2')
+    assertOk(removed)
+    const stale = adapter.addField(removed.session, 'text', anchor)
+    expect(stale).toMatchObject({
+      ok: false,
+      reason: 'target_not_found',
+      dependencies: [],
+    })
+    if (!stale.ok) expect(stale.session).toBe(removed.session)
+    // Zero draft and zero history mutation: a captured-index implementation
+    // would have inserted at the old index 2 instead.
+    expect(removed.session.draft.fields.map((entry) => entry.id)).toEqual([
+      'field_1',
+      'field_3',
+    ])
+    expect(removed.session.history.undoStack).toHaveLength(1)
+    // Positive control: the same anchor shape works when its neighbor lives.
+    const live = adapter.addField(removed.session, 'text', {
+      kind: 'after',
+      localId: 'local_3',
+    })
+    assertOk(live)
+    expect(live.session.draft.fields.map((entry) => entry.localId)).toEqual([
+      'local_1',
+      'local_3',
+      live.focusLocalId,
+    ])
+  })
+})
+
+describe('approvalFormAuthoringAdapter - history semantics (FB-D4)', () => {
+  it('a value-changing command creates exactly one entry with one focus result', () => {
+    const adapter = createFormAuthoringAdapter()
+    const session = adapter.startSession(draftWith([field(1), field(2)]))
+    const moved = adapter.moveField(session, 'local_2', 'local_1', 'before')
+    assertOk(moved)
+    expect(moved.changed).toBe(true)
+    expect(moved.focusLocalId).toBe('local_2')
+    expect(moved.session.history.undoStack).toHaveLength(1)
+    expect(moved.session.history.focusLocalId).toBe('local_2')
+  })
+
+  it('a value-identical boundary no-op creates zero entries', () => {
+    const adapter = createFormAuthoringAdapter()
+    const session = adapter.startSession(draftWith([field(1), field(2)]))
+    const noop = adapter.moveFieldByOffset(session, 'local_1', -1)
+    assertOk(noop)
+    expect(noop.changed).toBe(false)
+    expect(noop.session.history.undoStack).toHaveLength(0)
+    expect(noop.session.draft.fields.map((entry) => entry.id)).toEqual([
+      'field_1',
+      'field_2',
+    ])
+  })
+
+  it('a rejected command creates zero draft and zero history mutation', () => {
+    const adapter = createFormAuthoringAdapter()
+    const dependent = field(2, {
+      visibility: {
+        dependsOnFieldId: 'field_1',
+        operator: 'eq',
+        valueText: 'yes',
+      },
+    })
+    const session = adapter.startSession(draftWith([field(1), dependent]))
+    const refused = adapter.removeField(session, 'local_1')
+    expect(refused).toMatchObject({ ok: false, reason: 'field_is_referenced' })
+    if (!refused.ok) {
+      expect(refused.session).toBe(session)
+      expect(
+        refused.dependencies.map((entry) => entry.kind),
+      ).toContain('visibility_rule')
+      // Values-free: dependencies carry only internal kind/location members.
+      for (const dependency of refused.dependencies) {
+        expect(Object.keys(dependency).sort()).toEqual(['kind', 'location'])
+        expect(dependency.location).not.toContain('yes')
+      }
+    }
+    expect(session.history.undoStack).toHaveLength(0)
+  })
+
+  it('undo/redo restore list and focus as coherent snapshots', () => {
+    const adapter = createFormAuthoringAdapter()
+    const session = adapter.startSession(draftWith([field(1), field(2)]))
+    const added = adapter.addField(session, 'text', { kind: 'start' })
+    assertOk(added)
+    const moved = adapter.moveField(added.session, 'local_2', 'local_1', 'before')
+    assertOk(moved)
+    expect(adapter.canUndo(moved.session)).toBe(true)
+
+    const undoMove = adapter.undo(moved.session)
+    assertOk(undoMove)
+    expect(undoMove.session.draft.fields.map((entry) => entry.id)).toEqual(
+      added.session.draft.fields.map((entry) => entry.id),
+    )
+    const undoAdd = adapter.undo(undoMove.session)
+    assertOk(undoAdd)
+    expect(undoAdd.session.draft.fields.map((entry) => entry.id)).toEqual([
+      'field_1',
+      'field_2',
+    ])
+    const redone = adapter.redo(undoAdd.session)
+    assertOk(redone)
+    expect(redone.session.draft.fields.map((entry) => entry.id)).toEqual(
+      added.session.draft.fields.map((entry) => entry.id),
+    )
+    // Empty stacks fail closed with the typed history reason.
+    const emptyRedo = adapter.redo(moved.session)
+    expect(emptyRedo).toMatchObject({ ok: false, reason: 'history_empty' })
+    const freshSession = adapter.startSession(draftWith([field(1)]))
+    expect(adapter.undo(freshSession)).toMatchObject({
+      ok: false,
+      reason: 'history_empty',
+    })
+  })
+
+  it('undo preserves non-field draft properties (fields-scoped history)', () => {
+    const adapter = createFormAuthoringAdapter()
+    const draft = draftWith([field(1), field(2)])
+    const session = adapter.startSession(draft)
+    const moved = adapter.moveField(session, 'local_2', 'local_1', 'before')
+    assertOk(moved)
+    const undone = adapter.undo(moved.session)
+    assertOk(undone)
+    expect(undone.session.draft.key).toBe('form_adapter')
+    expect(undone.session.draft.steps).toBe(draft.steps)
+  })
+})
+
+describe('approvalFormAuthoringAdapter - guards and references (FB-D6)', () => {
+  it('refuses removing the final field through the command-level guard', () => {
+    const adapter = createFormAuthoringAdapter()
+    const session = adapter.startSession(draftWith([field(1)]))
+    const refused = adapter.removeField(session, 'local_1')
+    expect(refused).toMatchObject({
+      ok: false,
+      reason: 'last_field_removal_forbidden',
+    })
+    if (!refused.ok) expect(refused.session).toBe(session)
+    expect(session.history.undoStack).toHaveLength(0)
+  })
+
+  it('exposes the current-draft reference provider for inspector copy', () => {
+    const adapter = createFormAuthoringAdapter()
+    const dependent = field(2, {
+      visibility: {
+        dependsOnFieldId: 'field_1',
+        operator: 'eq',
+        valueText: 'yes',
+      },
+    })
+    const session = adapter.startSession(draftWith([field(1), dependent]))
+    const references = adapter.listFieldReferences(session, 'local_1')
+    expect(references.map((entry) => entry.kind)).toEqual(['visibility_rule'])
+    expect(adapter.listFieldReferences(session, 'local_2')).toEqual([])
+    expect(adapter.listFieldReferences(session, 'missing')).toEqual([])
+  })
+})
+
+describe('legacy length-derived helpers - frozen fallback baseline (delta §5 F1)', () => {
+  it('createEmptyFieldDraft output is pinned byte-for-byte (deterministic members)', () => {
+    const draft = createEmptyFieldDraft(3)
+    const { localId, ...rest } = draft
+    expect(rest).toEqual({
+      id: 'field_3',
+      type: 'text',
+      label: '字段 3',
+      required: false,
+      placeholder: '',
+      optionsText: '',
+      visibility: { dependsOnFieldId: '', operator: 'eq', valueText: '' },
+      detailColumns: [],
+      minRowsText: '',
+      maxRowsText: '',
+      recordLinkBaseId: '',
+      recordLinkSheetId: '',
+    })
+    expect(localId).toMatch(/^field_\d+_[0-9a-f]{1,6}$/)
+    // Default-arg pin: the historical `index = 1` default stays intact.
+    expect(createEmptyFieldDraft().id).toBe('field_1')
+  })
+
+  it('createEmptyDetailColumnDraft output is pinned byte-for-byte (deterministic members)', () => {
+    const column = createEmptyDetailColumnDraft(2)
+    const { localId, ...rest } = column
+    expect(rest).toEqual({
+      id: 'col_2',
+      type: 'text',
+      label: '子字段 2',
+      required: false,
+      optionsText: '',
+    })
+    expect(localId).toMatch(/^detailcol_\d+_\d+$/)
+    expect(createEmptyDetailColumnDraft().id).toBe('col_1')
+  })
+
+  it('the adapter and allocator never reference the legacy helpers while the inline fallback still does', () => {
+    const adapterSource = readFileSync(
+      join(__dirname, '../src/approvals/approvalFormAuthoringAdapter.ts'),
+      'utf8',
+    )
+    const identitySource = readFileSync(
+      join(__dirname, '../src/approvals/approvalFormIdentity.ts'),
+      'utf8',
+    )
+    // Positive controls: the right, non-empty modules were read.
+    expect(adapterSource).toContain('createFormAuthoringAdapter')
+    expect(identitySource).toContain('createOpaqueFormIdentityAllocator')
+    // Strip comments before scanning: doc prose may NAME the legacy helpers,
+    // but any real import or call survives comment-stripping and fails here.
+    const stripComments = (source: string): string =>
+      source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/[^\n]*/g, '')
+    for (const source of [adapterSource, identitySource]) {
+      const code = stripComments(source)
+      // Scan control: stripping must not have emptied the module body.
+      expect(code).toContain('export function')
+      expect(code).not.toMatch(/createEmptyFieldDraft/)
+      expect(code).not.toMatch(/createEmptyDetailColumnDraft/)
+    }
+    // The flag-OFF fallback (TemplateAuthoringView) keeps its legacy call
+    // sites untouched — F1 must not silently migrate them.
+    const viewSource = readFileSync(
+      join(__dirname, '../src/views/approval/TemplateAuthoringView.vue'),
+      'utf8',
+    )
+    expect(viewSource).toMatch(
+      /createEmptyFieldDraft\(draft\.value\.fields\.length \+ 1\)/,
+    )
+    expect(viewSource).toMatch(
+      /createEmptyDetailColumnDraft\(field\.detailColumns\.length \+ 1\)/,
+    )
+  })
+})

--- a/apps/web/tests/approval-form-authoring-adapter.test.ts
+++ b/apps/web/tests/approval-form-authoring-adapter.test.ts
@@ -181,6 +181,81 @@ describe('approvalFormAuthoringAdapter - identity (FB-D5)', () => {
     expect(refused).toMatchObject({ ok: false, reason: 'unsupported_field_type' })
     if (!refused.ok) expect(refused.session).toBe(added.session)
   })
+
+  it('detail column add retries a seam-forced collision with a FRESH candidate and succeeds (P2-3)', () => {
+    // Gate F1 names "field/detail collision retry"; this loop (addDetailColumn)
+    // is structurally identical to the field retry loop above but was
+    // previously unexercised — cutting its budget to 1 must turn this RED.
+    // First candidate (A/B) collides with the owner's live column id; second
+    // (C/D) is free.
+    const source = scriptedSource([BLOCK_A, BLOCK_B, BLOCK_C, BLOCK_D])
+    const adapter = createFormAuthoringAdapter({
+      identityAllocator: createOpaqueFormIdentityAllocator(source),
+    })
+    const detailOwner = field(1, {
+      localId: 'detail_local',
+      id: 'detail_field',
+      type: 'detail',
+      detailColumns: [
+        {
+          localId: 'existing_column_local',
+          id: `dcol_${HEX_A}`,
+          type: 'text',
+          label: '已有子字段',
+          required: false,
+          optionsText: '',
+        },
+      ],
+    })
+    const session = adapter.startSession(draftWith([detailOwner]))
+    const added = adapter.addDetailColumn(session, 'detail_local')
+    assertOk(added)
+    const columns = added.session.draft.fields[0].detailColumns
+    expect(columns.at(-1)!.id).toBe(`dcol_${HEX_C}`)
+    expect(columns.at(-1)!.localId).toBe(`dcolloc_${HEX_D}`)
+    expect(columns.at(-1)!.id).not.toBe(`dcol_${HEX_A}`)
+    // Exactly ONE history entry despite the internal retry.
+    expect(added.session.history.undoStack).toHaveLength(1)
+    expect(added.changed).toBe(true)
+  })
+
+  it('detail column add exhausts the retry budget as a typed values-free failure with zero mutation (P2-3)', () => {
+    // Constant seam: every candidate collides with the owner's live column id
+    // forever — proves the typed exhaustion path on the detail-column loop,
+    // not just the field loop.
+    const source = scriptedSource([BLOCK_A])
+    const adapter = createFormAuthoringAdapter({
+      identityAllocator: createOpaqueFormIdentityAllocator(source),
+    })
+    const detailOwner = field(1, {
+      localId: 'detail_local',
+      id: 'detail_field',
+      type: 'detail',
+      detailColumns: [
+        {
+          localId: 'existing_column_local',
+          id: `dcol_${HEX_A}`,
+          type: 'text',
+          label: '已有子字段',
+          required: false,
+          optionsText: '',
+        },
+      ],
+    })
+    const session = adapter.startSession(draftWith([detailOwner]))
+    const result = adapter.addDetailColumn(session, 'detail_local')
+    expect(result).toMatchObject({
+      ok: false,
+      reason: 'identity_allocation_exhausted',
+      dependencies: [],
+    })
+    if (!result.ok) {
+      // Session returned unchanged by identity — zero draft/history mutation.
+      expect(result.session).toBe(session)
+    }
+    expect(session.history.undoStack).toHaveLength(0)
+    expect(session.draft.fields[0].detailColumns).toHaveLength(1)
+  })
 })
 
 describe('approvalFormAuthoringAdapter - anchors (FB-D3)', () => {
@@ -343,6 +418,32 @@ describe('approvalFormAuthoringAdapter - history semantics (FB-D4)', () => {
       ok: false,
       reason: 'history_empty',
     })
+  })
+
+  it('changed stays true across the history-stack cap (P2-2: fields identity, not stack-length growth)', () => {
+    // FORM_AUTHORING_HISTORY_MAX_STACK = 100 (approvalFormAuthoringHistory.ts):
+    // once the undo stack saturates, `trimStack` drops the oldest entry on
+    // every further push, so `undoStack.length` stops growing even though
+    // each add below is a genuine value-changing edit. Reproduced on the
+    // pre-fix adapter: adds #101-105 reported `changed: false`. `changed` must
+    // track `history.fields` identity (fresh clone on real change; same
+    // reference on a full no-op or a focus-only change), not stack-length
+    // growth, so it stays `true` through and past the cap.
+    const adapter = createFormAuthoringAdapter()
+    let session = adapter.startSession(draftWith([field(1)]))
+    for (let i = 0; i < 105; i += 1) {
+      const before = session.draft.fields.length
+      const added = adapter.addField(session, 'text')
+      assertOk(added)
+      expect(added.changed).toBe(true)
+      expect(added.session.draft.fields.length).toBe(before + 1)
+      session = added.session
+    }
+    expect(session.draft.fields).toHaveLength(106)
+    // Confirms this test actually crosses the saturation boundary the flag
+    // got wrong: the stack itself is capped at 100 even though 105 real
+    // edits landed.
+    expect(session.history.undoStack.length).toBe(100)
   })
 
   it('undo preserves non-field draft properties (fields-scoped history)', () => {

--- a/apps/web/tests/approval-form-commands.test.ts
+++ b/apps/web/tests/approval-form-commands.test.ts
@@ -22,6 +22,7 @@ import {
   type FieldAuthoringDraft,
   type TemplateAuthoringDraft,
 } from '../src/approvals/templateAuthoring'
+import type { FormField } from '../src/types/approval'
 
 function field(
   index: number,
@@ -532,6 +533,23 @@ describe('approvalFormCommands - remove', () => {
         'external_reference',
       ]),
     )
+    // P2-1a: the kind SET alone cannot tell apart the two independent
+    // `condition_formula` producers (conditionEdits.branches[].formulaExpression
+    // at commands.ts:456, and the preserved-graph walk over `value.expression`
+    // at commands.ts:375-380, reached here via `draft.preservedGraph`) — either
+    // could be deleted and the kind set would still contain `condition_formula`.
+    // Asserting the LOCATION set makes each producer individually load-bearing:
+    // the two locations are distinct strings, so killing either producer alone
+    // drops one of them from this set.
+    const conditionFormulaLocations = dependencies
+      .filter((entry) => entry.kind === 'condition_formula')
+      .map((entry) => entry.location)
+    expect(new Set(conditionFormulaLocations)).toEqual(
+      new Set([
+        'conditionEdits.condition_1.branches.0.formula',
+        'preservedGraph.nodes[0].config.branches[0].formula',
+      ]),
+    )
     const refused = removeFormField(source, 'local_1')
     expect(refused).toMatchObject({
       ok: false,
@@ -545,6 +563,106 @@ describe('approvalFormCommands - remove', () => {
         refused.dependencies.every((entry) => entry.kind !== 'external_reference'),
       ).toBe(true)
     }
+  })
+
+  it('refuses delete when the only reference lives in a hydrated field.original (P2-1b)', () => {
+    // `fieldDraftFromField` (templateAuthoring.ts:425) sets `original: field`
+    // UNCONDITIONALLY on every hydrated authorable field, and `DetailColumnDraft`
+    // carries no visibility member of its own — so a detail SUB-FIELD's
+    // `visibilityRule` naming a top-level field is detectable ONLY through the
+    // `field.original` walk (commands.ts:420-427). This fixture's detail field
+    // has no typed visibility of its own; the sole reference to `field_1` lives
+    // inside `original.columns[0].visibilityRule.fieldId`.
+    const detailFieldOriginal: FormField = {
+      id: 'detail_field',
+      type: 'detail',
+      label: '明细',
+      columns: [
+        {
+          id: 'sub_column',
+          type: 'text',
+          label: '子字段',
+          visibilityRule: { fieldId: 'field_1', operator: 'eq' },
+        },
+      ],
+    }
+    const source = draftWith([
+      field(1),
+      field(2, {
+        id: 'detail_field',
+        type: 'detail',
+        original: detailFieldOriginal,
+      }),
+    ])
+    const dependencies = collectFormFieldDependencies(source, 'field_1')
+    expect(dependencies).toEqual([
+      {
+        kind: 'preserved_graph_reference',
+        location: 'fields.local_2.original.columns[0].visibilityRule',
+      },
+    ])
+    expect(removeFormField(source, 'local_1')).toMatchObject({
+      ok: false,
+      reason: 'field_is_referenced',
+    })
+  })
+
+  it('refuses delete when the field is referenced as the amount-consistency COLUMN id (P3-1)', () => {
+    // `AmountConsistencyMapping.amountColumnId` (types/approval.ts:189-193) is a
+    // persisted detail-column id; the walk previously checked only
+    // `totalFieldId`/`detailFieldId`, orphaning `amountColumnId` on delete.
+    const source = draftWith([field(1), field(2)])
+    source.amountConsistencyCheck = {
+      totalFieldId: 'unrelated_total',
+      detailFieldId: 'unrelated_detail',
+      amountColumnId: 'field_1',
+    }
+    const dependencies = collectFormFieldDependencies(source, 'field_1')
+    expect(dependencies).toEqual([
+      { kind: 'amount_consistency_mapping', location: 'amountConsistencyCheck' },
+    ])
+    expect(removeFormField(source, 'local_1')).toMatchObject({
+      ok: false,
+      reason: 'field_is_referenced',
+    })
+  })
+
+  it('trims whitespace-padded reference ids: permission.fieldId, mapping.totalFieldId, preserved-graph value.fieldId (P3-2)', () => {
+    const source = draftWith([field(1), field(2)])
+    source.steps[0] = {
+      ...source.steps[0],
+      fieldPermissions: [{ fieldId: ' field_1 ', access: 'hidden' }],
+    }
+    source.amountConsistencyCheck = {
+      totalFieldId: ' field_1 ',
+      detailFieldId: 'items',
+      amountColumnId: 'amount',
+    }
+    source.preservedGraph = {
+      nodes: [
+        {
+          key: 'condition_1',
+          type: 'condition',
+          config: {
+            branches: [
+              {
+                edgeKey: 'e1',
+                rules: [{ fieldId: ' field_1 ', operator: 'eq' }],
+              },
+            ],
+          },
+        },
+      ],
+      edges: [],
+    }
+    const dependencies = collectFormFieldDependencies(source, 'field_1')
+    expect(new Set(dependencies.map((entry) => entry.kind))).toEqual(
+      new Set([
+        'step_field_permission',
+        'amount_consistency_mapping',
+        'preserved_graph_reference',
+      ]),
+    )
   })
 })
 

--- a/apps/web/tests/approval-form-commands.test.ts
+++ b/apps/web/tests/approval-form-commands.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  addFormDetailColumn,
   addFormField,
   applyFormCommands,
   collectFormFieldDependencies,
@@ -8,7 +9,6 @@ import {
   moveFormFieldByOffset,
   removeFormField,
   type CompleteFormReferenceInventory,
-  type CompleteFormIdentityHistory,
   type FormCommandResult,
   type FormFieldIdentity,
 } from '../src/approvals/approvalFormCommands'
@@ -22,17 +22,6 @@ import {
   type FieldAuthoringDraft,
   type TemplateAuthoringDraft,
 } from '../src/approvals/templateAuthoring'
-
-const EMPTY_INVENTORY: CompleteFormReferenceInventory = {
-  complete: true,
-  references: [],
-}
-
-const EMPTY_IDENTITY_HISTORY: CompleteFormIdentityHistory = {
-  complete: true,
-  persistentIds: [],
-  localIds: [],
-}
 
 function field(
   index: number,
@@ -85,18 +74,8 @@ describe('approvalFormCommands - add', () => {
     (type) => {
       const source = draftWith([field(1)])
       const fieldIdentity = identity(2, type === 'detail')
-      const first = addFormField(
-        source,
-        type,
-        fieldIdentity,
-        EMPTY_IDENTITY_HISTORY,
-      )
-      const replay = addFormField(
-        source,
-        type,
-        fieldIdentity,
-        EMPTY_IDENTITY_HISTORY,
-      )
+      const first = addFormField(source, type, fieldIdentity)
+      const replay = addFormField(source, type, fieldIdentity)
       assertOk(first)
       assertOk(replay)
 
@@ -120,13 +99,12 @@ describe('approvalFormCommands - add', () => {
     },
   )
 
-  it('inserts after the selected internal field key without accepting a persisted id input', () => {
+  it('inserts after the anchored internal field key without accepting a persisted id input', () => {
     const result = addFormField(
       draftWith([field(1), field(2)]),
       'number',
       identity(3),
-      EMPTY_IDENTITY_HISTORY,
-      'local_1',
+      { kind: 'after', localId: 'local_1' },
     )
     assertOk(result)
     expect(result.draft.fields.map((entry) => entry.id)).toEqual([
@@ -137,50 +115,64 @@ describe('approvalFormCommands - add', () => {
     expect(result.focusLocalId).toBe('new_local_3')
   })
 
-  it('fails closed for unsupported kinds, missing identities/history, and missing insertion targets', () => {
+  it('prepends atomically at the start anchor as ONE command (FB-D3, never add-then-move)', () => {
+    const source = draftWith([field(1), field(2)])
+    const result = addFormField(source, 'text', identity(3), { kind: 'start' })
+    assertOk(result)
+    expect(result.draft.fields.map((entry) => entry.id)).toEqual([
+      'new_field_3',
+      'field_1',
+      'field_2',
+    ])
+    expect(result.focusLocalId).toBe('new_local_3')
+    // Source draft untouched: the prepend is a single immutable command result.
+    expect(source.fields.map((entry) => entry.id)).toEqual([
+      'field_1',
+      'field_2',
+    ])
+  })
+
+  it('re-resolves an after anchor against the current draft: a stale anchor is a no-op rejection', () => {
+    const source = draftWith([field(1), field(2), field(3)])
+    // Anchor captured while local_2 exists (e.g. at drag start)…
+    const anchor = { kind: 'after', localId: 'local_2' } as const
+    // Positive control first: the anchor works while its neighbor is live.
+    const live = addFormField(source, 'text', identity(9), anchor)
+    assertOk(live)
+    expect(live.draft.fields.map((entry) => entry.id)).toEqual([
+      'field_1',
+      'field_2',
+      'new_field_9',
+      'field_3',
+    ])
+    // …then the neighbor is removed before the drop lands.
+    const removed = removeFormField(source, 'local_2')
+    assertOk(removed)
+    const stale = addFormField(removed.draft, 'text', identity(9), anchor)
+    expect(stale).toMatchObject({ ok: false, reason: 'target_not_found' })
+    // Zero mutation: the draft the stale drop targeted is unchanged.
+    expect(removed.draft.fields.map((entry) => entry.id)).toEqual([
+      'field_1',
+      'field_3',
+    ])
+  })
+
+  it('fails closed for unsupported kinds, missing identities, and missing insertion targets', () => {
     expect(
-      addFormField(
-        draftWith([field(1)]),
-        'attachment' as never,
-        identity(2),
-        EMPTY_IDENTITY_HISTORY,
-      ),
+      addFormField(draftWith([field(1)]), 'attachment' as never, identity(2)),
     ).toMatchObject({ ok: false, reason: 'unsupported_field_type' })
     expect(
-      addFormField(
-        draftWith([field(1)]),
-        'text',
-        undefined as never,
-        EMPTY_IDENTITY_HISTORY,
-      ),
+      addFormField(draftWith([field(1)]), 'text', undefined as never),
     ).toMatchObject({ ok: false, reason: 'invalid_field_identity' })
     expect(
-      addFormField(
-        draftWith([field(1)]),
-        'text',
-        identity(2),
-        undefined as never,
-      ),
-    ).toMatchObject({ ok: false, reason: 'identity_history_missing' })
-    expect(
       addFormField(draftWith([field(1)]), 'text', identity(2), {
-        complete: false,
-        persistentIds: [],
-        localIds: [],
-      } as never),
-    ).toMatchObject({ ok: false, reason: 'identity_history_missing' })
-    expect(
-      addFormField(
-        draftWith([field(1)]),
-        'text',
-        identity(2),
-        EMPTY_IDENTITY_HISTORY,
-        'missing',
-      ),
+        kind: 'after',
+        localId: 'missing',
+      }),
     ).toMatchObject({ ok: false, reason: 'target_not_found' })
   })
 
-  it('rejects blank and field/detail-column identity collisions before it changes the draft', () => {
+  it('rejects blank and field/detail-column identity collisions against the complete current draft', () => {
     const source = draftWith([
       field(1, {
         localId: 'existing_local',
@@ -199,161 +191,171 @@ describe('approvalFormCommands - add', () => {
       }),
     ])
     expect(
-      addFormField(
-        source,
-        'text',
-        { persistentId: ' ', localId: 'new_local' },
-        EMPTY_IDENTITY_HISTORY,
-      ),
+      addFormField(source, 'text', {
+        persistentId: ' ',
+        localId: 'new_local',
+      }),
     ).toMatchObject({
       ok: false,
       reason: 'invalid_field_identity',
     })
     expect(
-      addFormField(
-        source,
-        'text',
-        {
-          persistentId: 'new_field',
-          localId: ' ',
-        },
-        EMPTY_IDENTITY_HISTORY,
-      ),
+      addFormField(source, 'text', {
+        persistentId: 'new_field',
+        localId: ' ',
+      }),
     ).toMatchObject({ ok: false, reason: 'invalid_field_identity' })
     expect(
-      addFormField(
-        source,
-        'text',
-        {
-          persistentId: 'existing_field',
-          localId: 'new_local',
-        },
-        EMPTY_IDENTITY_HISTORY,
-      ),
+      addFormField(source, 'text', {
+        persistentId: 'existing_field',
+        localId: 'new_local',
+      }),
     ).toMatchObject({ ok: false, reason: 'field_identity_conflict' })
     expect(
-      addFormField(
-        source,
-        'text',
-        {
-          persistentId: 'same_internal_token',
-          localId: 'same_internal_token',
-        },
-        EMPTY_IDENTITY_HISTORY,
-      ),
+      addFormField(source, 'text', {
+        persistentId: 'same_internal_token',
+        localId: 'same_internal_token',
+      }),
     ).toMatchObject({ ok: false, reason: 'field_identity_conflict' })
     expect(
-      addFormField(
-        source,
-        'text',
-        {
+      addFormField(source, 'text', {
+        persistentId: 'existing_column',
+        localId: 'new_local',
+      }),
+    ).toMatchObject({
+      ok: false,
+      reason: 'field_identity_conflict',
+    })
+    expect(
+      addFormField(source, 'text', {
+        persistentId: 'new_field',
+        localId: 'existing_column_local',
+      }),
+    ).toMatchObject({
+      ok: false,
+      reason: 'field_identity_conflict',
+    })
+    expect(
+      addFormField(source, 'detail', {
+        persistentId: 'new_detail',
+        localId: 'new_detail_local',
+        detailColumn: {
+          persistentId: 'new_column',
+          localId: 'existing_local',
+        },
+      }),
+    ).toMatchObject({ ok: false, reason: 'field_identity_conflict' })
+    expect(
+      addFormField(source, 'detail', {
+        persistentId: 'new_detail',
+        localId: 'new_detail_local',
+        detailColumn: {
           persistentId: 'existing_column',
-          localId: 'new_local',
+          localId: 'new_column_local',
         },
-        EMPTY_IDENTITY_HISTORY,
-      ),
-    ).toMatchObject({
-      ok: false,
-      reason: 'field_identity_conflict',
-    })
-    expect(
-      addFormField(
-        source,
-        'text',
-        {
-          persistentId: 'new_field',
-          localId: 'existing_column_local',
-        },
-        EMPTY_IDENTITY_HISTORY,
-      ),
-    ).toMatchObject({
-      ok: false,
-      reason: 'field_identity_conflict',
-    })
-    expect(
-      addFormField(
-        source,
-        'detail',
-        {
-          persistentId: 'new_detail',
-          localId: 'new_detail_local',
-          detailColumn: {
-            persistentId: 'new_column',
-            localId: 'existing_local',
-          },
-        },
-        EMPTY_IDENTITY_HISTORY,
-      ),
+      }),
     ).toMatchObject({ ok: false, reason: 'field_identity_conflict' })
     expect(
-      addFormField(
-        source,
-        'detail',
-        {
-          persistentId: 'new_detail',
-          localId: 'new_detail_local',
-          detailColumn: {
-            persistentId: 'existing_column',
-            localId: 'new_column_local',
-          },
+      addFormField(source, 'detail', {
+        persistentId: 'new_detail',
+        localId: 'new_detail_local',
+        detailColumn: {
+          persistentId: 'new_detail_local',
+          localId: 'new_column_local',
         },
-        EMPTY_IDENTITY_HISTORY,
-      ),
-    ).toMatchObject({ ok: false, reason: 'field_identity_conflict' })
-    expect(
-      addFormField(
-        source,
-        'detail',
-        {
-          persistentId: 'new_detail',
-          localId: 'new_detail_local',
-          detailColumn: {
-            persistentId: 'new_detail_local',
-            localId: 'new_column_local',
-          },
-        },
-        EMPTY_IDENTITY_HISTORY,
-      ),
+      }),
     ).toMatchObject({ ok: false, reason: 'field_identity_conflict' })
     expect(source.fields).toHaveLength(1)
   })
+})
 
-  it('rejects a retired identity after delete while a fresh identity remains a positive control', () => {
-    const source = draftWith([
-      field(1, { id: 'retired_field', localId: 'retired_local' }),
-    ])
-    const deleted = removeFormField(source, 'retired_local', EMPTY_INVENTORY)
-    assertOk(deleted)
-    const history: CompleteFormIdentityHistory = {
-      complete: true,
-      persistentIds: ['retired_field'],
-      localIds: ['retired_local'],
-    }
-    expect(
-      addFormField(
-        deleted.draft,
-        'text',
+describe('approvalFormCommands - detail column add', () => {
+  const detailOwner = () =>
+    field(1, {
+      localId: 'detail_local',
+      id: 'detail_field',
+      type: 'detail',
+      detailColumns: [
         {
-          persistentId: 'retired_field',
-          localId: 'new_local_after_delete',
+          localId: 'existing_column_local',
+          id: 'existing_column',
+          type: 'text',
+          label: '已有子字段',
+          required: false,
+          optionsText: '',
         },
-        history,
-      ),
-    ).toMatchObject({ ok: false, reason: 'field_identity_conflict' })
-    const added = addFormField(
-      deleted.draft,
-      'text',
-      {
-        persistentId: 'fresh_field_after_delete',
-        localId: 'fresh_local_after_delete',
-      },
-      history,
-    )
-    assertOk(added)
-    expect(added.draft.fields.map((entry) => entry.id)).toEqual([
-      'fresh_field_after_delete',
+      ],
+    })
+
+  it('appends a column with the supplied opaque identity and leaves the source draft untouched', () => {
+    const source = draftWith([detailOwner(), field(2)])
+    const result = addFormDetailColumn(source, 'detail_local', {
+      persistentId: 'dcol_new',
+      localId: 'dcolloc_new',
+    })
+    assertOk(result)
+    expect(result.focusLocalId).toBe('detail_local')
+    const owner = result.draft.fields[0]
+    expect(owner.detailColumns.map((column) => column.id)).toEqual([
+      'existing_column',
+      'dcol_new',
     ])
-    expect(added.draft.fields[0].id).not.toBe('retired_field')
+    expect(owner.detailColumns.at(-1)).toMatchObject({
+      localId: 'dcolloc_new',
+      type: 'text',
+      required: false,
+      optionsText: '',
+    })
+    expect(source.fields[0].detailColumns).toHaveLength(1)
+  })
+
+  it('fails closed for missing owners, non-detail targets, blank identities, and draft collisions', () => {
+    const source = draftWith([detailOwner(), field(2)])
+    expect(
+      addFormDetailColumn(source, 'missing', {
+        persistentId: 'dcol_new',
+        localId: 'dcolloc_new',
+      }),
+    ).toMatchObject({ ok: false, reason: 'field_not_found' })
+    expect(
+      addFormDetailColumn(source, 'local_2', {
+        persistentId: 'dcol_new',
+        localId: 'dcolloc_new',
+      }),
+    ).toMatchObject({ ok: false, reason: 'unsupported_field_type' })
+    expect(
+      addFormDetailColumn(source, 'detail_local', {
+        persistentId: ' ',
+        localId: 'dcolloc_new',
+      }),
+    ).toMatchObject({ ok: false, reason: 'invalid_field_identity' })
+    expect(
+      addFormDetailColumn(source, 'detail_local', {
+        persistentId: 'dcol_new',
+        localId: ' ',
+      }),
+    ).toMatchObject({ ok: false, reason: 'invalid_field_identity' })
+    // Collision domain is the COMPLETE draft: existing column id, an existing
+    // top-level FIELD id, and internal duplicates all reject.
+    expect(
+      addFormDetailColumn(source, 'detail_local', {
+        persistentId: 'existing_column',
+        localId: 'dcolloc_new',
+      }),
+    ).toMatchObject({ ok: false, reason: 'field_identity_conflict' })
+    expect(
+      addFormDetailColumn(source, 'detail_local', {
+        persistentId: 'field_2',
+        localId: 'dcolloc_new',
+      }),
+    ).toMatchObject({ ok: false, reason: 'field_identity_conflict' })
+    expect(
+      addFormDetailColumn(source, 'detail_local', {
+        persistentId: 'same_internal_token',
+        localId: 'same_internal_token',
+      }),
+    ).toMatchObject({ ok: false, reason: 'field_identity_conflict' })
+    expect(source.fields[0].detailColumns).toHaveLength(1)
   })
 })
 
@@ -403,17 +405,9 @@ describe('approvalFormCommands - reorder', () => {
 })
 
 describe('approvalFormCommands - remove', () => {
-  it('refuses delete until the out-of-draft reference inventory is explicitly complete', () => {
-    const result = removeFormField(draftWith([field(1)]), 'local_1')
-    expect(result).toMatchObject({
-      ok: false,
-      reason: 'reference_inventory_missing',
-    })
-  })
-
-  it('removes an unreferenced field immutably once the inventory is complete', () => {
+  it('removes an unreferenced field immutably using the current-draft reference set (FB-D6)', () => {
     const source = draftWith([field(1), field(2)])
-    const result = removeFormField(source, 'local_1', EMPTY_INVENTORY)
+    const result = removeFormField(source, 'local_1')
     assertOk(result)
     expect(result.draft.fields.map((entry) => entry.id)).toEqual(['field_2'])
     expect(result.focusLocalId).toBe('local_2')
@@ -421,6 +415,34 @@ describe('approvalFormCommands - remove', () => {
       'field_1',
       'field_2',
     ])
+  })
+
+  it('refuses to remove the final remaining field at the command level, BEFORE reference evaluation', () => {
+    const solo = draftWith([field(1)])
+    // A missing field is still field_not_found, not the last-field refusal.
+    expect(removeFormField(solo, 'missing')).toMatchObject({
+      ok: false,
+      reason: 'field_not_found',
+    })
+    expect(removeFormField(solo, 'local_1')).toMatchObject({
+      ok: false,
+      reason: 'last_field_removal_forbidden',
+    })
+    // Ordering proof: a REFERENCED single field still reports the last-field
+    // refusal (with no dependency list) — the guard sits before the walk.
+    const referencedSolo = draftWith([field(1)])
+    referencedSolo.steps[0] = {
+      ...referencedSolo.steps[0],
+      fieldPermissions: [{ fieldId: 'field_1', access: 'hidden' }],
+    }
+    expect(removeFormField(referencedSolo, 'local_1')).toMatchObject({
+      ok: false,
+      reason: 'last_field_removal_forbidden',
+      dependencies: [],
+    })
+    // Positive control: the same unreferenced field is removable once a second
+    // field exists.
+    assertOk(removeFormField(draftWith([field(1), field(2)]), 'local_1'))
   })
 
   it('rejects visibility, assignee, permission, condition, formula, graph, amount and external references', () => {
@@ -485,9 +507,12 @@ describe('approvalFormCommands - remove', () => {
       amountColumnId: 'amount',
     }
 
+    // The optional inventory remains the collector's seam for a FUTURE
+    // authoritative same-version external owner (FB-D6) — production delete
+    // itself takes no inventory.
     const inventory: CompleteFormReferenceInventory = {
       complete: true,
-      references: [{ fieldId: 'field_1', location: 'fwb.mappings.0' }],
+      references: [{ fieldId: 'field_1', location: 'future.external.0' }],
     }
     const dependencies = collectFormFieldDependencies(
       source,
@@ -507,10 +532,19 @@ describe('approvalFormCommands - remove', () => {
         'external_reference',
       ]),
     )
-    expect(removeFormField(source, 'local_1', inventory)).toMatchObject({
+    const refused = removeFormField(source, 'local_1')
+    expect(refused).toMatchObject({
       ok: false,
       reason: 'field_is_referenced',
     })
+    if (!refused.ok) {
+      // Production delete evaluates the CURRENT-DRAFT reference set — the six
+      // in-draft kinds are all named; no inventory-fed kind is fabricated.
+      expect(refused.dependencies.length).toBeGreaterThan(0)
+      expect(
+        refused.dependencies.every((entry) => entry.kind !== 'external_reference'),
+      ).toBe(true)
+    }
   })
 })
 

--- a/apps/web/tests/approval-form-identity.test.ts
+++ b/apps/web/tests/approval-form-identity.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  OPAQUE_IDENTITY_TOKEN_BYTES,
+  createOpaqueFormIdentityAllocator,
+  defaultIdentityRandomSource,
+  type IdentityRandomSource,
+} from '../src/approvals/approvalFormIdentity'
+
+/** Deterministic seam: replays scripted byte blocks and counts draws. */
+function scriptedSource(blocks: number[][]): IdentityRandomSource & {
+  draws: number
+} {
+  let cursor = 0
+  const source = {
+    draws: 0,
+    nextBytes(length: number): Uint8Array {
+      expect(length).toBe(OPAQUE_IDENTITY_TOKEN_BYTES)
+      const block = blocks[cursor % blocks.length]!
+      cursor += 1
+      source.draws += 1
+      return Uint8Array.from(block)
+    },
+  }
+  return source
+}
+
+function countingSource(): IdentityRandomSource & { draws: number } {
+  const source = {
+    draws: 0,
+    nextBytes(length: number): Uint8Array {
+      const bytes = new Uint8Array(length)
+      // Encode the draw ordinal into the block so every token is distinct
+      // and provably a function of the seam, not of any outside state.
+      bytes[0] = (source.draws >> 8) & 0xff
+      bytes[1] = source.draws & 0xff
+      source.draws += 1
+      return bytes
+    },
+  }
+  return source
+}
+
+describe('approvalFormIdentity - opaque collision-resistant allocator (FB-D5)', () => {
+  it('derives identities from the injected opaque randomness, never from list length or suffix counters', () => {
+    // Named discriminating pin: a length-/suffix-derived allocator ignores the
+    // injected seam, so these EXACT ids can only come from the seam bytes.
+    const source = scriptedSource([
+      [0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07],
+      [0xff, 0xee, 0xdd, 0xcc, 0xbb, 0xaa, 0x99, 0x88],
+    ])
+    const allocator = createOpaqueFormIdentityAllocator(source)
+    const identity = allocator.nextFieldIdentity('text')
+    expect(identity).toEqual({
+      persistentId: 'fld_0001020304050607',
+      localId: 'fldloc_ffeeddccbbaa9988',
+    })
+    expect(identity.detailColumn).toBeUndefined()
+    expect(source.draws).toBe(2)
+  })
+
+  it('mints a detail field identity with a first-column identity from four independent draws', () => {
+    const source = countingSource()
+    const allocator = createOpaqueFormIdentityAllocator(source)
+    const identity = allocator.nextFieldIdentity('detail')
+    expect(identity.persistentId).toMatch(/^fld_[0-9a-f]{16}$/)
+    expect(identity.localId).toMatch(/^fldloc_[0-9a-f]{16}$/)
+    expect(identity.detailColumn?.persistentId).toMatch(/^dcol_[0-9a-f]{16}$/)
+    expect(identity.detailColumn?.localId).toMatch(/^dcolloc_[0-9a-f]{16}$/)
+    expect(source.draws).toBe(4)
+    // All four tokens are pairwise distinct.
+    const tokens = [
+      identity.persistentId,
+      identity.localId,
+      identity.detailColumn!.persistentId,
+      identity.detailColumn!.localId,
+    ].map((value) => value.slice(value.indexOf('_') + 1))
+    expect(new Set(tokens).size).toBe(4)
+  })
+
+  it('produces a FRESH candidate on every call (retry never re-submits a rejected candidate)', () => {
+    const source = countingSource()
+    const allocator = createOpaqueFormIdentityAllocator(source)
+    const first = allocator.nextFieldIdentity('text')
+    const second = allocator.nextFieldIdentity('text')
+    expect(second.persistentId).not.toBe(first.persistentId)
+    expect(second.localId).not.toBe(first.localId)
+    const columnA = allocator.nextDetailColumnIdentity()
+    const columnB = allocator.nextDetailColumnIdentity()
+    expect(columnB.persistentId).not.toBe(columnA.persistentId)
+    expect(columnB.localId).not.toBe(columnA.localId)
+  })
+
+  it('default source mints unique well-formed identities at session scale', () => {
+    const allocator = createOpaqueFormIdentityAllocator()
+    const seen = new Set<string>()
+    for (let index = 0; index < 500; index += 1) {
+      const identity = allocator.nextFieldIdentity('text')
+      expect(identity.persistentId).toMatch(/^fld_[0-9a-f]{16}$/)
+      expect(identity.localId).toMatch(/^fldloc_[0-9a-f]{16}$/)
+      seen.add(identity.persistentId)
+      seen.add(identity.localId)
+    }
+    expect(seen.size).toBe(1000)
+  })
+
+  it('opaque prefixes never alias the legacy length-derived shapes', () => {
+    const allocator = createOpaqueFormIdentityAllocator()
+    const identity = allocator.nextFieldIdentity('detail')
+    const column = allocator.nextDetailColumnIdentity()
+    for (const value of [
+      identity.persistentId,
+      identity.localId,
+      identity.detailColumn!.persistentId,
+      identity.detailColumn!.localId,
+      column.persistentId,
+      column.localId,
+    ]) {
+      // Legacy shapes: field_N / col_N (persisted) and field_<ts>_* /
+      // detailcol_<ts>_* (local). The opaque lineage must not collide.
+      expect(value).not.toMatch(/^field_/)
+      expect(value).not.toMatch(/^col_/)
+      expect(value).not.toMatch(/^detailcol_/)
+    }
+  })
+
+  it('default random source returns independent blocks of the requested length', () => {
+    const source = defaultIdentityRandomSource()
+    const first = source.nextBytes(OPAQUE_IDENTITY_TOKEN_BYTES)
+    const second = source.nextBytes(OPAQUE_IDENTITY_TOKEN_BYTES)
+    expect(first).toHaveLength(OPAQUE_IDENTITY_TOKEN_BYTES)
+    expect(second).toHaveLength(OPAQUE_IDENTITY_TOKEN_BYTES)
+    // 2^-64 false-failure probability: two independent 8-byte draws colliding.
+    expect(Array.from(first)).not.toEqual(Array.from(second))
+  })
+})

--- a/apps/web/tests/approval-g5c-authoring-scenarios.test.ts
+++ b/apps/web/tests/approval-g5c-authoring-scenarios.test.ts
@@ -10,7 +10,6 @@ import {
   addFormField,
   applyFormCommands,
   moveFormFieldByOffset,
-  type CompleteFormIdentityHistory,
   type FormFieldIdentity,
 } from '../src/approvals/approvalFormCommands'
 import {
@@ -41,10 +40,6 @@ import type { ApprovalGraph, ApprovalTemplateDetailDTO } from '../src/types/appr
 
 const VIEW_PATH = join(__dirname, '../src/views/approval/TemplateAuthoringView.vue')
 
-function completeHistory(ids: string[]): CompleteFormIdentityHistory {
-  return { complete: true, persistentIds: ids, localIds: ids.map((id) => `local-${id}`) }
-}
-
 function identityFor(type: AuthorableFieldType, n: number): FormFieldIdentity {
   const base = {
     persistentId: `f_${type}_${n}`,
@@ -67,12 +62,12 @@ describe('G5-C S1 form authoring (real form commands)', () => {
     let draft = createEmptyTemplateDraft()
     // Start from empty field list for a clean matrix.
     draft = { ...draft, fields: [] }
-    // Identity history is complete but empty: allocator-owned ids must not pre-exist.
-    const emptyHistory = completeHistory([])
 
     for (const [index, type] of AUTHORABLE_FIELD_TYPES.entries()) {
       const identity = identityFor(type, index)
-      const added = addFormField(draft, type, identity, emptyHistory)
+      // FB-D5 RATIFIED: identity is opaque-allocator-owned; the command checks
+      // candidates against the complete current draft (no history parameter).
+      const added = addFormField(draft, type, identity)
       expect(added.ok, `add ${type}`).toBe(true)
       if (!added.ok) return
       draft = added.draft


### PR DESCRIPTION
Implements slice **F1** of the RATIFIED approval form-builder parity delta
(`docs/development/approval-form-builder-parity-delta-design-20260811.md` §5 F1, on
`origin/codex/approval-form-builder-parity-lock-20260811`; ratified 2026-08-17 under master P0-A,
`approval-parity-master-design-lock-20260817.md`). Pure substrate only — **no production mount, no drag
UI** (first production use of this path is the F4 feature-ON mount behind `approvalCanvasV2`); the
flag-OFF inline editor fallback is untouched. All approval flags remain OFF.

## Contract decisions (cited to the ratified enums)

- **FB-D5 = `OPAQUE_COLLISION_RESISTANT`** (delta §10): new `approvalFormIdentity.ts` is the sole
  identity authority — opaque random tokens (`fld_`/`fldloc_`/`dcol_`/`dcolloc_` + 64-bit hex), an
  injected deterministic `IdentityRandomSource` seam, a FRESH candidate per call/retry, and **no draft
  input by construction** (never length/suffix/index-derived). Accordingly `CompleteFormIdentityHistory`
  and the mandatory history parameter are **removed from the production `addFormField` signature**
  (`identity_history_missing` removed as unreachable): the command validates each candidate against the
  complete current draft (fields + detail columns, persistent + local ids), and the adapter retries a
  collision up to a budget, failing typed (`identity_allocation_exhausted`) with zero mutation.
  Cross-version non-reuse is provided by allocator opacity, not a server reservation API (delta FB-D5).
- **FB-D6 = `CURRENT_DRAFT_REFERENCES_PLUS_VERSION_PINNED_EXTERNALS`** (delta §10):
  `CompleteFormReferenceInventory` is **removed from the production `removeFormField` signature**
  (`reference_inventory_missing` removed as unreachable); the authoritative delete boundary is the
  complete-by-construction current-draft set from `collectFormFieldDependencies` (six kinds). FWB stays
  version-pinned-external — the misleading inventory comment is amended to record the
  `sourceTemplateVersionId` pin truth, and the type survives only as the collector's seam for a FUTURE
  authoritative same-version external owner (the UI must never fabricate one).
  `last_field_removal_forbidden` now lives **inside `removeFormField`, before reference evaluation**;
  the UI disable stays a convenience, not the integrity boundary.
- **FB-D3**: `FormInsertionAnchor` (`{kind:'start'} | {kind:'after';localId}`) added to `addFormField`.
  `start` prepends **atomically in one command / one history entry** (never add-then-move); anchors are
  re-resolved against the current draft immediately before mutation; a stale anchor is a values-free
  `target_not_found` no-op with zero draft/history mutation. Omitted anchor keeps the legacy append
  convenience (palette click).
- **FB-D4**: new `approvalFormAuthoringAdapter.ts` is the ONE typed command path over
  `approvalFormCommands` + `approvalFormAuthoringHistory`: value-changing success = exactly one history
  entry + one focus result; value-identical boundary/no-op = zero entries; rejection = zero draft and
  zero history mutation (failure returns the session unchanged, values-free surface). Includes the
  FB-D6 reference provider (`listFieldReferences`) and the new `addFormDetailColumn` command
  (opaque column identity; `子字段 N` label is display copy only, never identity).
- **Protected baseline (delta §5 F1)**: `createEmptyFieldDraft` / `createEmptyDetailColumnDraft` are
  byte-unchanged (output pins in the adapter spec), their fallback call sites in
  `TemplateAuthoringView.vue` are untouched (source pin), and a comment-stripped source scan proves the
  adapter/allocator never import or call them (with positive scan controls).

## Tests (all green locally; exact counts)

Focused set (9 files, **240 tests** — updated after the gate fix round below, +6 over the original 234):

| Spec | Tests |
|---|---|
| `approval-form-identity.test.ts` (new) | 6 |
| `approval-form-authoring-adapter.test.ts` (new) | 20 |
| `approval-form-commands.test.ts` (extended) | 26 |
| `approval-g5c-authoring-scenarios.test.ts` (signature-amended) | 15 |
| `approval-form-authoring-history.test.ts` | 7 |
| `approval-form-inline-editor-extract.spec.ts` | 10 |
| `approval-form-palette-focus.test.ts` | 6 |
| `approvalTemplateAuthoring.spec.ts` | 65 |
| `ui-foundation-style-guard.spec.ts` | 85 |

Also: `pnpm --filter @metasheet/web exec vue-tsc --noEmit` clean (exit 0, zero diagnostics); full
`bash apps/web/scripts/run-required-web-tests.sh` (CI-identical invocation, `set -euo pipefail`) exited 0
with the final always-on block at **362 files / 4387 tests** — all vitest invocations green, and the
block containing both new spec files reproduces at **134 tests** (128 baseline + 6 from the fix round).

## Mutation log (self-run, restored, `git status` clean of residue)

1. **Allocator reverted to length/counter-derived** (ignore injected seam) →
   `approval-form-identity.test.ts` "derives identities from the injected opaque randomness" RED
   (+ delete-middle-add adapter test RED). Restored → green.
2. **Anchor re-resolution neutered** (stale `after` anchor falls back to a captured position instead of
   re-resolving) → adapter "stale anchor is a zero-entry no-op" RED + command stale-anchor test RED.
   Restored → green.
3. **`last_field_removal_forbidden` guard removed** from `removeFormField` → command-level and
   adapter-level last-field tests RED. Restored → green.

Each negative has its positive control in-suite (successful add/remove/move with the missing
prerequisite supplied). See the **Gate fix round** section below for four additional mutation probes
run against the guards this PR previously left untested.

## Gate F1 checklist (delta §5)

- [x] explicit start/middle/end insertion (anchor tests, command + adapter)
- [x] duplicate/nonblank identity negatives (blank/duplicate/cross-domain collisions incl. detail columns)
- [x] field/detail collision retry (seam-forced collision → fresh candidate → success; exhaustion typed
      for **both** the field loop and the detail-column loop — the latter closed in the gate fix round)
- [x] last-field refusal at command level (ordering proof: referenced single field still reports it)
- [x] current-draft referenced-delete refusal with named dependency kinds (all nine kinds now
      individually load-bearing — see gate fix round)
- [x] move by `localId`; drag/keyboard same algebra; replay/no-op controls
- [x] undo/redo coherent snapshots; empty stacks fail closed
- [x] `FormCommandFailureReason` includes `last_field_removal_forbidden`; neutralizing the command-level
      guard fails its dedicated test while the UI convenience guard remains
- [x] source pins: adapter/allocator never call the legacy length-derived helpers; helper outputs pinned;
      fallback call sites untouched
- [x] no production mount, no drag UI (no production import of the adapter; inline editor unchanged)
- [x] CI wiring in the SAME PR: `run-required-web-tests.sh` tokens (`approval-form-identity`,
      `approval-form-authoring-adapter`, each isolation-verified to match exactly 1 file) +
      `approval-web-guard.yml` path filters in BOTH `pull_request` and `push` and the canary run list.
      `plugin-tests.yml` untouched. **Correction from an earlier revision of this body**: the
      merge-blocking required check for these two new spec files is **`web-tests`** (via
      `run-required-web-tests.sh`, `.github/workflows/web-tests.yml`, no path filter, required on
      `main`). `approval-web-guard` is a **path-filtered canary, not a required context**
      (`gh api repos/zensgit/metasheet2/branches/main/protection --jq
      '.required_status_checks.contexts'`) — its wiring is real but does not itself block merge. This
      was previously described as "CI two-point collection" in a way that could be read as "two
      required gates"; it is one required gate (`web-tests`) plus one non-required canary.

## Gate fix round (independent adversarial review, 2026-08-17)

An independent adversarial gate (`/tmp/pr4942-review-claude-20260817.md`) returned
**REQUEST-CHANGES** on the head reviewed as `c9f7ce3bfd` — 0 P1, 4 P2, 3 P3. Nothing was a live
production defect (F1 has no mount), but two Gate F1 checkboxes above were not true as stated: three
FB-D6 delete-refusal producers and the FB-D5 detail-column retry loop could be neutered with the
entire suite green, and `changed` was wrong past the history-stack cap. This section records
findings → fixes → my own re-verification.

**Findings → fixes:**

1. **P2-2 (real defect, new code)** — `approvalFormAuthoringAdapter.ts` `commit()` derived `changed`
   from undo-stack **length growth**. Past `FORM_AUTHORING_HISTORY_MAX_STACK = 100`, `trimStack` drops
   the oldest entry on every further real push, so length stops growing and value-changing edits
   #101+ reported `changed: false` (reproduced by the gate: adds #101–#105). Fixed to
   `changed = history.fields !== session.history.fields`, checked against all three
   `pushFormSnapshot` return paths (full no-op → same object; focus-only → same `fields` ref carried
   over; real change → freshly cloned array). Added a regression test that crosses the cap with 105
   successive adds, asserting `changed: true` and draft-length growth on every one.
2. **P2-1a** — the all-kinds delete-refusal fixture in `approval-form-commands.test.ts` fed BOTH
   independent `condition_formula` producers (`conditionEdits.branches[].formulaExpression` and the
   preserved-graph walk) and asserted only a kind SET, so either producer alone was undetectable.
   Added a LOCATION-set assertion isolating the two producers' distinct location strings
   (`conditionEdits.condition_1.branches.0.formula` vs
   `preservedGraph.nodes[0].config.branches[0].formula`).
3. **P2-1b (zero-coverage guard)** — the `field.original` reference walk (the sole detector for a
   detail sub-field's `visibilityRule` naming a top-level field, since `DetailColumnDraft` carries no
   visibility member of its own) had no fixture in either suite. Added one: the only reference lives
   in `original.columns[0].visibilityRule.fieldId`; delete refuses.
4. **P2-3** — the detail-column collision-retry/exhaustion loop (structurally identical to the field
   loop) was unexercised. Added two adapter tests using the same injected-seam pattern as the existing
   field-retry tests: forced first-candidate collision → fresh candidate succeeds with exactly one
   history entry; constant-collision seam → typed `identity_allocation_exhausted` with zero mutation.
5. **P3-1** — `AmountConsistencyMapping.amountColumnId` (a persisted detail-column id) was missing
   from the reference walk (only `totalFieldId`/`detailFieldId` were checked). Added it to the walk
   plus a fixture proving a field referenced as the amount COLUMN id refuses delete.
6. **P3-2** — added `.trim()` to the three untrimmed comparisons the gate named
   (`permission.fieldId`, `mapping.totalFieldId`/`detailFieldId`/`amountColumnId`, preserved-graph
   `value.fieldId`), matching the visibility/step/condition arms that already trimmed. One micro-test
   with whitespace-padded ids across all three arms.
7. **PR body** — corrected the CI-reality wording (see checklist item above).

**Verification:**

- `pnpm exec vue-tsc --noEmit`: exit 0, zero diagnostics (captured directly, not through a pipe).
- Focused 5-file set: **74/74 passed** (68 baseline + 6 new). Full 9-file focused set from the table
  above: **240/240 passed**.
- `bash apps/web/scripts/run-required-web-tests.sh` (CI-identical): exit 0; the block containing both
  edited spec files went from 128 → **134 tests**, all green; final always-on block still
  **362 files / 4387 tests**.
- Four mutation probes from the gate report, self-run against the fixed code (each: `cp` backup before
  mutating, `git diff --numstat`/`diff` confirms the exact line changed, restored by `cp`, `cmp`
  byte-identical after):

  | # | Mutation | Result before this fix round | Result after |
  |---|---|---|---|
  | 1 | Kill `conditionEdits` `condition_formula` producer (commands.ts:456) | 68 GREEN | **RED** — `approval-form-commands.test.ts` "rejects visibility, assignee, permission, condition, formula, graph, amount and external references" (location-set assertion) |
  | 2 | Kill the graph/`original` formula producer (commands.ts:375-380) | 68 GREEN | **RED** — same test, same assertion (other location) |
  | 3 | Kill the whole `field.original` walk (commands.ts:420-427) | no fixture existed | **RED** — new P2-1b test "refuses delete when the only reference lives in a hydrated field.original" |
  | 4 | Cut the detail-column retry budget to 1 (adapter.ts, `addDetailColumn` loop only) | 68 GREEN | **RED** — new P2-3 test "detail column add retries a seam-forced collision with a FRESH candidate and succeeds" |

- `git status --porcelain` after all mutation restores: only the 4 intended files touched
  (`approvalFormCommands.ts`, `approvalFormAuthoringAdapter.ts`, and their two test files) — no probe
  residue.

Not relitigated: the ratified FB-D5/FB-D6 enums (`OPAQUE_COLLISION_RESISTANT` /
`CURRENT_DRAFT_REFERENCES_PLUS_VERSION_PINNED_EXTERNALS`), and the three deferred items the gate
placed before F3 rather than this PR (P3-3 structural caller-supplied-identity bar, owned by F4's
import/call-site proof) — P3-1 and P3-2 are now closed here rather than deferred, ahead of schedule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
