### PR TITLE
feat(approval): F2 — exact insertion slots + typed drag codec + browser harness (delta §5 F2)

### DIFF
--- a/.github/workflows/approval-browser-verify.yml
+++ b/.github/workflows/approval-browser-verify.yml
@@ -1,0 +1,89 @@
+name: Approval Browser Verify
+
+# F2 real-browser verification lane for the approval Designer 2.0 form builder
+# (docs/development/approval-form-builder-parity-delta-design-20260811.md §5 F2,
+# §7.1 items 7-8). Boots Vite via the OWNED playwright.approval-verification
+# config (its own webServer on port 5175 — never a reused disappearing server),
+# renders the real ApprovalFormPalette + ApprovalFormBuilder through
+# apps/web/verification/approval-form-builder-harness.html, and asserts from
+# DOM/session evidence: exact start/middle/end insertion-slot placement via
+# real DataTransfer drags, cancelled-drag (Escape / drop-outside) no-ops,
+# strict typed-codec rejection of text/plain + malformed payloads (with a
+# positive control), the stale-anchor values-free no-op, and the read-only
+# transition. Screenshots upload as supporting artifacts.
+#
+# NOT a required check yet: per delta §7.1 item 8 the branch-protection
+# addition is an explicit OWNER step before the F4 merge; until that owner
+# action is visible, this lane's evidence is exact-head but not "required".
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'apps/web/src/approvals/components/ApprovalFormBuilder.vue'
+      - 'apps/web/src/approvals/components/ApprovalFormPalette.vue'
+      - 'apps/web/src/approvals/approvalFormDragPayload.ts'
+      - 'apps/web/src/approvals/approvalFormAuthoringAdapter.ts'
+      - 'apps/web/src/approvals/approvalFormIdentity.ts'
+      - 'apps/web/src/approvals/approvalFormCommands.ts'
+      - 'apps/web/src/approvals/approvalFormAuthoringHistory.ts'
+      - 'apps/web/verification/approval-form-builder-harness.html'
+      - 'apps/web/verification/approval-form-builder-harness.ts'
+      - 'apps/web/verification/approval-form-builder-parity.spec.ts'
+      - 'apps/web/playwright.approval-verification.config.ts'
+      - '.github/workflows/approval-browser-verify.yml'
+
+jobs:
+  browser-verify:
+    name: Approval browser verify (chromium)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js 20.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.16.1
+          run_install: false
+
+      - name: Use empty npmrc for pnpm
+        run: |
+          echo "" > /tmp/empty-npmrc
+          echo "NPM_CONFIG_USERCONFIG=/tmp/empty-npmrc" >> "$GITHUB_ENV"
+
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        shell: bash
+        run: echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
+
+      - name: Setup pnpm cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright chromium (+ system deps)
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Run approval browser verification (boots Vite, renders real components)
+        run: pnpm --filter @metasheet/web exec playwright test --config playwright.approval-verification.config.ts
+
+      - name: Upload verification screenshots
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: approval-browser-verify-screenshots
+          path: apps/web/verification-output/afb-*.png
+          if-no-files-found: warn

--- a/.github/workflows/approval-web-guard.yml
+++ b/.github/workflows/approval-web-guard.yml
@@ -135,6 +135,14 @@ on:
       - 'apps/web/src/approvals/approvalFormAuthoringAdapter.ts'
       - 'apps/web/tests/approval-form-identity.test.ts'
       - 'apps/web/tests/approval-form-authoring-adapter.test.ts'
+      # F2 (2026-08-17, delta §5 F2): typed drag codec + Designer 2.0 palette/builder components
+      # (standalone until the F4 mount) + their mounted specs.
+      - 'apps/web/src/approvals/approvalFormDragPayload.ts'
+      - 'apps/web/src/approvals/components/ApprovalFormPalette.vue'
+      - 'apps/web/src/approvals/components/ApprovalFormBuilder.vue'
+      - 'apps/web/tests/approval-form-drag-payload.test.ts'
+      - 'apps/web/tests/approval-form-palette-chips.spec.ts'
+      - 'apps/web/tests/approval-form-builder-slots.spec.ts'
       # G-B2-19: readable condition-branch summaries — conditionSummary.ts pure fn consumed by
       # authoring nodeConfigSummary + editor branch heads + the upcomingNodes/graphSummary chain.
       - 'apps/web/src/approvals/conditionSummary.ts'
@@ -339,6 +347,14 @@ on:
       - 'apps/web/src/approvals/approvalFormAuthoringAdapter.ts'
       - 'apps/web/tests/approval-form-identity.test.ts'
       - 'apps/web/tests/approval-form-authoring-adapter.test.ts'
+      # F2 (2026-08-17, delta §5 F2): typed drag codec + Designer 2.0 palette/builder components
+      # (standalone until the F4 mount) + their mounted specs (same set as the pull_request block).
+      - 'apps/web/src/approvals/approvalFormDragPayload.ts'
+      - 'apps/web/src/approvals/components/ApprovalFormPalette.vue'
+      - 'apps/web/src/approvals/components/ApprovalFormBuilder.vue'
+      - 'apps/web/tests/approval-form-drag-payload.test.ts'
+      - 'apps/web/tests/approval-form-palette-chips.spec.ts'
+      - 'apps/web/tests/approval-form-builder-slots.spec.ts'
       # G-B2-19: readable condition-branch summaries — conditionSummary.ts pure fn consumed by
       # authoring nodeConfigSummary + editor branch heads + the upcomingNodes/graphSummary chain.
       - 'apps/web/src/approvals/conditionSummary.ts'
@@ -496,6 +512,9 @@ jobs:
             approval-form-inline-editor-extract \
             approval-form-identity \
             approval-form-authoring-adapter \
+            approval-form-drag-payload \
+            approval-form-palette-chips \
+            approval-form-builder-slots \
             --reporter=dot
 
       - name: Run FWB mapping authoring contract

--- a/apps/web/playwright.approval-verification.config.ts
+++ b/apps/web/playwright.approval-verification.config.ts
@@ -1,0 +1,36 @@
+import { defineConfig, devices } from '@playwright/test'
+
+// F2 approval form-builder browser-verification lane (delta §5 F2 / §7.1
+// item 7: an OWNED real-Chromium harness with its own server — never a reused
+// disappearing server). Boots Vite, renders the real ApprovalFormPalette +
+// ApprovalFormBuilder via verification/approval-form-builder-harness.html, and
+// asserts exact-slot DataTransfer drags, cancelled-drag no-ops, strict codec
+// rejection, and the stale-anchor no-op.
+// Run: `pnpm --filter @metasheet/web exec playwright test
+//       --config playwright.approval-verification.config.ts` (cwd = apps/web).
+// Port 5175 keeps this lane's server disjoint from the multitable lane (5174).
+const PORT = 5175
+
+export default defineConfig({
+  testDir: './verification',
+  testMatch: '**/approval-form-builder-parity.spec.ts',
+  timeout: 60_000,
+  fullyParallel: false,
+  retries: process.env.CI ? 1 : 0,
+  reporter: [['list']],
+  outputDir: './verification-output/_pw-approval',
+  use: {
+    baseURL: `http://127.0.0.1:${PORT}`,
+    screenshot: 'off', // the spec takes explicit, named screenshots
+    trace: process.env.CI ? 'retain-on-failure' : 'off',
+  },
+  projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
+  webServer: {
+    command: `pnpm exec vite --port ${PORT} --strictPort`,
+    url: `http://127.0.0.1:${PORT}/verification/approval-form-builder-harness.html`,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  },
+})

--- a/apps/web/playwright.verification.config.ts
+++ b/apps/web/playwright.verification.config.ts
@@ -9,6 +9,10 @@ const PORT = 5174
 export default defineConfig({
   testDir: './verification',
   testMatch: '**/*.spec.ts',
+  // The approval form-builder spec runs in its OWN lane
+  // (playwright.approval-verification.config.ts / approval-browser-verify.yml)
+  // so an approval-harness failure cannot red the multitable lane.
+  testIgnore: '**/approval-form-builder-parity.spec.ts',
   timeout: 60_000,
   fullyParallel: false,
   retries: process.env.CI ? 1 : 0,

--- a/apps/web/scripts/run-required-web-tests.sh
+++ b/apps/web/scripts/run-required-web-tests.sh
@@ -152,6 +152,17 @@
 # legacy-helper freeze pins). Both bare basename tokens; each verified to match exactly one file
 # in isolation, and no existing token (approval-form-authoring-history is the closest neighbor)
 # is a substring of either or vice versa.
+#
+# F2 (2026-08-17, delta §5 F2): `approval-form-drag-payload` (typed drag codec: single app MIME,
+# strict decode, transient-session store), `approval-form-palette-chips` (mounted Designer 2.0
+# palette: shipped-shell grouping pin, click/drag/keyboard, read-only), and
+# `approval-form-builder-slots` (mounted builder: N+1 semantic slots, exact FB-D3 anchors,
+# codec negatives with positive controls, stale-anchor no-op, five-trigger transient clearing,
+# FB-D4 click/drag/keyboard equivalence, FB-D8 no-production-mount pin). All bare basename
+# tokens; each verified to match exactly one file. Deliberate non-collisions: `approval-form-draft`
+# is NOT a substring of `approval-form-drag-payload` (draft vs drag-), `approval-form-palette-focus`
+# does not match `approval-form-palette-chips`, and the playwright-only
+# `verification/approval-form-builder-parity.spec.ts` matches none of these tokens.
 set -euo pipefail
 cd "$(dirname "$0")/.."
 # Always-on Canvas V2 + residual PLAN 6fa2fbf6 / wave-3 canaries (files landed on main via #4815–#4826).
@@ -169,6 +180,9 @@ npx vitest run \
   approval-form-inline-editor-extract \
   approval-form-identity \
   approval-form-authoring-adapter \
+  approval-form-drag-payload \
+  approval-form-palette-chips \
+  approval-form-builder-slots \
   --reporter=dot
 npx vitest run featureFlagsApprovalAttachments --reporter=dot
 npx vitest run approval-fwb-mapping-config approval-fwb-mapping-editor --reporter=dot

--- a/apps/web/src/approvals/approvalFormDragPayload.ts
+++ b/apps/web/src/approvals/approvalFormDragPayload.ts
@@ -1,0 +1,198 @@
+import {
+  AUTHORABLE_FIELD_TYPES,
+  type AuthorableFieldType,
+} from './templateAuthoring'
+
+/**
+ * F2 typed drag codec — RATIFIED approval-form-builder-parity delta §3.1
+ * (approval-form-builder-parity-delta-design-20260811.md).
+ *
+ * Drag data is internal and type-limited. Contract:
+ * - ONE application-specific MIME type for both payload kinds. `text/plain`
+ *   (or any other type) is NEVER read back as a command — `read…` only calls
+ *   `getData` with `APPROVAL_FORM_DRAG_MIME`.
+ * - Decoding is a strict structured validator: unknown versions, kinds,
+ *   extra/missing properties, non-allowlisted field types, blank local ids,
+ *   non-JSON, and non-object JSON all decode to `null`, never to a command.
+ * - Payloads carry NO persistent field id, form value, user value, credential,
+ *   or label. The ephemeral `localId` of an existing field is the only
+ *   identifier allowed (§8: in-page field-move payload / non-visible DOM data
+ *   only — never ordinary-user copy, logs, or persistence).
+ * - Transient drag state lives in an `ApprovalFormDragSession` whose explicit
+ *   `clear()` the owning components wire to ALL of: successful/failed drop,
+ *   `dragend`, Escape, route change (component unmount), and the read-only
+ *   transition.
+ *
+ * This module is pure (no Vue, no Element Plus): components mirror the session
+ * into their own reactive state via `subscribe`.
+ */
+
+/** The single application-specific drag MIME type (palette AND field moves). */
+export const APPROVAL_FORM_DRAG_MIME = 'application/x-metasheet-approval-form'
+
+export type ApprovalFormDragPayload =
+  | { version: 1; kind: 'palette'; fieldType: AuthorableFieldType }
+  | { version: 1; kind: 'field'; localId: string }
+
+const AUTHORABLE_TYPE_SET: ReadonlySet<string> = new Set<string>(
+  AUTHORABLE_FIELD_TYPES,
+)
+
+export function encodeApprovalFormDragPayload(
+  payload: ApprovalFormDragPayload,
+): string {
+  return JSON.stringify(payload)
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    !Array.isArray(value) &&
+    Object.getPrototypeOf(value) === Object.prototype
+  )
+}
+
+/**
+ * Strict structured validator (§3.1): returns the typed payload only for an
+ * EXACT match — version 1, an allowlisted kind, the exact property set for
+ * that kind, and an allowlisted `fieldType` / non-blank `localId`. Anything
+ * else — foreign producers, truncated JSON, extra properties, unknown
+ * versions/kinds/types — is `null`, never a command.
+ */
+export function decodeApprovalFormDragPayload(
+  raw: string | null | undefined,
+): ApprovalFormDragPayload | null {
+  if (typeof raw !== 'string' || raw.length === 0) return null
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    return null
+  }
+  if (!isPlainRecord(parsed)) return null
+  if (parsed.version !== 1) return null
+  const keys = Object.keys(parsed).sort()
+  if (parsed.kind === 'palette') {
+    if (keys.join(',') !== 'fieldType,kind,version') return null
+    const fieldType = parsed.fieldType
+    if (typeof fieldType !== 'string' || !AUTHORABLE_TYPE_SET.has(fieldType)) {
+      return null
+    }
+    return {
+      version: 1,
+      kind: 'palette',
+      fieldType: fieldType as AuthorableFieldType,
+    }
+  }
+  if (parsed.kind === 'field') {
+    if (keys.join(',') !== 'kind,localId,version') return null
+    const localId = parsed.localId
+    if (typeof localId !== 'string' || localId.trim().length === 0) return null
+    return { version: 1, kind: 'field', localId }
+  }
+  return null
+}
+
+/**
+ * Write the payload under the application MIME type ONLY. Deliberately no
+ * `text/plain` mirror: a generic type must never round-trip into a command,
+ * and not writing it keeps foreign drop targets from receiving draft content.
+ */
+export function writeApprovalFormDragPayload(
+  dataTransfer: DataTransfer | null | undefined,
+  payload: ApprovalFormDragPayload,
+): void {
+  if (!dataTransfer) return
+  dataTransfer.setData(
+    APPROVAL_FORM_DRAG_MIME,
+    encodeApprovalFormDragPayload(payload),
+  )
+  try {
+    dataTransfer.effectAllowed = payload.kind === 'field' ? 'move' : 'copy'
+  } catch {
+    // Some environments expose a readonly effectAllowed; the payload is set.
+  }
+}
+
+/**
+ * Read a payload back from a drop. Reads ONLY `APPROVAL_FORM_DRAG_MIME`; a
+ * `text/plain` (or any other type) entry is never consulted, so a generic or
+ * foreign drag can never become a command (§3.1).
+ */
+export function readApprovalFormDragPayload(
+  dataTransfer: DataTransfer | null | undefined,
+): ApprovalFormDragPayload | null {
+  if (!dataTransfer) return null
+  let raw = ''
+  try {
+    raw = dataTransfer.getData(APPROVAL_FORM_DRAG_MIME)
+  } catch {
+    return null
+  }
+  return decodeApprovalFormDragPayload(raw)
+}
+
+/**
+ * `dragover`-time candidate check (§3.2): browsers do not expose trustworthy
+ * payload CONTENT until `drop`, but the TYPE list is visible, so slots may
+ * expand/highlight when the application MIME type is present. Full structured
+ * validation still runs at `drop` before any command.
+ */
+export function dataTransferSignalsApprovalFormDrag(
+  dataTransfer: DataTransfer | null | undefined,
+): boolean {
+  if (!dataTransfer) return false
+  try {
+    return Array.from(dataTransfer.types ?? []).includes(
+      APPROVAL_FORM_DRAG_MIME,
+    )
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Transient drag-state store (§3.1). Pure observable holder: `begin` on
+ * `dragstart`, `clear` on drop (success OR failure), `dragend`, Escape,
+ * route change/unmount, and the read-only transition. `clear` is idempotent;
+ * listeners fire only on actual transitions.
+ */
+export interface ApprovalFormDragSession {
+  /** The payload of the in-flight drag, or null when no drag is active. */
+  active(): ApprovalFormDragPayload | null
+  begin(payload: ApprovalFormDragPayload): void
+  clear(): void
+  /** Subscribe to transitions; returns an unsubscribe function. */
+  subscribe(
+    listener: (active: ApprovalFormDragPayload | null) => void,
+  ): () => void
+}
+
+export function createApprovalFormDragSession(): ApprovalFormDragSession {
+  let current: ApprovalFormDragPayload | null = null
+  const listeners = new Set<(active: ApprovalFormDragPayload | null) => void>()
+  function notify(): void {
+    listeners.forEach((listener) => listener(current))
+  }
+  return {
+    active() {
+      return current
+    },
+    begin(payload) {
+      current = payload
+      notify()
+    },
+    clear() {
+      if (current === null) return
+      current = null
+      notify()
+    },
+    subscribe(listener) {
+      listeners.add(listener)
+      return () => {
+        listeners.delete(listener)
+      }
+    },
+  }
+}

--- a/apps/web/src/approvals/components/ApprovalFormBuilder.vue
+++ b/apps/web/src/approvals/components/ApprovalFormBuilder.vue
@@ -1,0 +1,727 @@
+<template>
+  <div
+    class="approval-form-builder"
+    data-testid="approval-form-builder"
+    :data-drag-active="activeDrag ? 'true' : undefined"
+    @dragover="onCanvasDragOver"
+    @drop="onCanvasDrop"
+  >
+    <div class="approval-form-builder__list" role="list" aria-label="表单字段">
+      <template
+        v-for="(descriptor, index) in slotDescriptors"
+        :key="descriptor.key"
+      >
+        <div v-if="!readOnly" class="approval-form-builder__slot-region">
+          <button
+            type="button"
+            class="approval-form-builder__slot"
+            :class="{
+              'is-drag-active': activeDrag !== null,
+              'is-drop-target': dropTargetKey === descriptor.key,
+              'is-menu-open': insertMenuSlotKey === descriptor.key,
+            }"
+            :data-testid="`approval-form-builder-slot-${descriptor.key}`"
+            :data-slot-position="descriptor.position"
+            :aria-label="`在位置 ${descriptor.position + 1} 插入字段`"
+            :aria-expanded="insertMenuSlotKey === descriptor.key"
+            @click.stop="onSlotClick(descriptor)"
+            @dragenter="onSlotDragOver(descriptor, $event)"
+            @dragover="onSlotDragOver(descriptor, $event)"
+            @dragleave="onSlotDragLeave(descriptor)"
+            @drop.stop="onSlotDrop(descriptor, $event)"
+          >
+            <span class="approval-form-builder__slot-line" aria-hidden="true" />
+            <span class="approval-form-builder__slot-plus" aria-hidden="true">＋</span>
+          </button>
+          <div
+            v-if="insertMenuSlotKey === descriptor.key"
+            class="approval-form-builder__slot-menu"
+            role="menu"
+            aria-label="选择要插入的字段类型"
+            data-testid="approval-form-builder-slot-menu"
+          >
+            <button
+              v-for="option in insertTypeOptions"
+              :key="option.type"
+              type="button"
+              role="menuitem"
+              class="approval-form-builder__slot-menu-item"
+              :data-testid="`approval-form-builder-insert-${option.type}`"
+              @click.stop="onInsertMenuPick(descriptor, option.type)"
+            >
+              {{ option.label }}
+            </button>
+          </div>
+        </div>
+
+        <div
+          v-if="index < fields.length"
+          class="approval-form-builder__card"
+          :class="{ 'is-selected': selectedLocalId === fields[index].localId }"
+          role="listitem"
+          tabindex="-1"
+          data-testid="approval-form-builder-card"
+          :data-field-local-id="fields[index].localId"
+          :data-field-type="fields[index].type"
+          :data-selected="selectedLocalId === fields[index].localId ? 'true' : undefined"
+          :aria-current="selectedLocalId === fields[index].localId ? 'true' : undefined"
+          :aria-label="cardAccessibleName(fields[index], index)"
+          @click="selectField(fields[index].localId)"
+          @focusin="selectField(fields[index].localId)"
+        >
+          <div class="approval-form-builder__card-main">
+            <span
+              v-if="selectedLocalId === fields[index].localId"
+              class="approval-form-builder__card-selected-mark"
+              data-testid="approval-form-builder-card-selected-mark"
+            >
+              已选
+            </span>
+            <span class="approval-form-builder__card-label">
+              {{ fields[index].label.trim() || typeLabels[fields[index].type] }}
+            </span>
+            <span class="approval-form-builder__card-summary">
+              {{ cardSummary(fields[index]) }}
+            </span>
+          </div>
+          <div v-if="!readOnly" class="approval-form-builder__card-actions">
+            <button
+              type="button"
+              class="approval-form-builder__card-action"
+              :data-testid="`approval-form-builder-move-up-${fields[index].localId}`"
+              :disabled="index === 0"
+              aria-label="上移"
+              @click.stop="onMoveByOffset(fields[index].localId, -1)"
+            >
+              上移
+            </button>
+            <button
+              type="button"
+              class="approval-form-builder__card-action"
+              :data-testid="`approval-form-builder-move-down-${fields[index].localId}`"
+              :disabled="index === fields.length - 1"
+              aria-label="下移"
+              @click.stop="onMoveByOffset(fields[index].localId, 1)"
+            >
+              下移
+            </button>
+            <button
+              type="button"
+              class="approval-form-builder__card-handle"
+              :data-testid="`approval-form-builder-handle-${fields[index].localId}`"
+              :draggable="true"
+              aria-label="拖拽调整字段位置"
+              @click.stop
+              @dragstart="onHandleDragStart(fields[index], $event)"
+              @dragend="onHandleDragEnd"
+            >
+              ⠿
+            </button>
+          </div>
+        </div>
+      </template>
+    </div>
+    <p
+      class="approval-form-builder__status"
+      role="status"
+      aria-live="polite"
+      data-testid="approval-form-builder-status"
+    >
+      {{ statusMessage }}
+    </p>
+  </div>
+</template>
+
+<script lang="ts">
+/**
+ * Values-free feedback copy (§3.1/FB-D3/§8): typed refusals map to named
+ * business explanations that carry NO field values, labels, or ids. Exported
+ * for the specs to pin the exact copy.
+ */
+export const STALE_SLOT_RETRY_MESSAGE =
+  '插入位置已变化，本次操作未执行，请重试。'
+export const GENERIC_RETRY_MESSAGE = '操作未完成，请重试。'
+</script>
+
+<script setup lang="ts">
+/**
+ * F2 Designer 2.0 form canvas (delta §3.2/§3.3, FB-D1..D4, FB-D8) — the NEW
+ * builder, SEPARATE from the extracted flag-OFF `ApprovalFormInlineEditor`
+ * fallback. It has NO production mount in this slice: F4 performs the first
+ * mount in `TemplateAuthoringView.vue` behind the existing `approvalCanvasV2`
+ * flag. Until then it is fully exercisable standalone (mounted tests + the
+ * owned browser harness under `apps/web/verification/`).
+ *
+ * Contract highlights:
+ * - ONE command path (FB-D4): palette click (`appendField`), palette drag,
+ *   slot click/keyboard insertion, existing-field drag, and keyboard
+ *   上移/下移 ALL go through the injected `approvalFormAuthoringAdapter`. This
+ *   component never splices/filters the field array itself.
+ * - N+1 semantic insertion slots (FB-D3): each slot carries the
+ *   `FormInsertionAnchor` bound at render ({start} | {after,localId}); the
+ *   pure command re-resolves it against the CURRENT draft immediately before
+ *   mutation. A stale anchor is a values-free no-op with a retry message —
+ *   never an index fallback, never an append fallback.
+ * - Typed drag codec (§3.1): drops decode strictly via
+ *   `readApprovalFormDragPayload`; `text/plain`/foreign/malformed payloads are
+ *   never commands. `dragover` may only use MIME-type PRESENCE as the
+ *   candidate signal.
+ * - Transient drag state (§3.1) clears on: drop (success or failure, on-slot
+ *   or outside), dragend, Escape, route change (unmount), and the read-only
+ *   transition.
+ * - The move HANDLE initiates existing-field drag, not the whole card (§3.3).
+ * - Read-only mode renders no slots, handles, or move buttons.
+ */
+import {
+  computed,
+  nextTick,
+  onBeforeUnmount,
+  onMounted,
+  ref,
+  shallowRef,
+  watch,
+} from 'vue'
+import {
+  createFormAuthoringAdapter,
+  type FormAdapterResult,
+  type FormAuthoringAdapter,
+  type FormAuthoringSession,
+} from '../approvalFormAuthoringAdapter'
+import type { FormInsertionAnchor } from '../approvalFormCommands'
+import {
+  createApprovalFormDragSession,
+  dataTransferSignalsApprovalFormDrag,
+  readApprovalFormDragPayload,
+  writeApprovalFormDragPayload,
+  type ApprovalFormDragPayload,
+  type ApprovalFormDragSession,
+} from '../approvalFormDragPayload'
+import type {
+  AuthorableFieldType,
+  FieldAuthoringDraft,
+  TemplateAuthoringDraft,
+} from '../templateAuthoring'
+import {
+  APPROVAL_FORM_FIELD_TYPE_LABELS,
+  APPROVAL_FORM_PALETTE_GROUPS,
+} from './ApprovalFormPalette.vue'
+
+interface InsertionSlotDescriptor {
+  key: string
+  anchor: FormInsertionAnchor
+  position: number
+}
+
+const props = withDefaults(
+  defineProps<{
+    /** Hydrated draft seeding the session (once, at mount). */
+    draft: TemplateAuthoringDraft
+    readOnly?: boolean
+    /** Shared transient drag session (pass the same one to the palette). */
+    dragSession?: ApprovalFormDragSession
+    /** FB-D4/FB-D5 seam: the ONE production adapter; injectable in tests. */
+    adapter?: FormAuthoringAdapter
+  }>(),
+  { readOnly: false, dragSession: undefined, adapter: undefined },
+)
+
+const emit = defineEmits<{
+  (
+    e: 'draft-change',
+    draft: TemplateAuthoringDraft,
+    focusLocalId: string | null,
+  ): void
+}>()
+
+const adapter: FormAuthoringAdapter =
+  props.adapter ?? createFormAuthoringAdapter()
+const dragSession: ApprovalFormDragSession =
+  props.dragSession ?? createApprovalFormDragSession()
+
+const sessionRef = shallowRef<FormAuthoringSession>(
+  adapter.startSession(props.draft, props.draft.fields[0]?.localId ?? null),
+)
+const selectedLocalId = ref<string | null>(
+  props.draft.fields[0]?.localId ?? null,
+)
+const statusMessage = ref('')
+const activeDrag = shallowRef<ApprovalFormDragPayload | null>(
+  dragSession.active(),
+)
+const dropTargetKey = ref<string | null>(null)
+const insertMenuSlotKey = ref<string | null>(null)
+
+const typeLabels = APPROVAL_FORM_FIELD_TYPE_LABELS
+const insertTypeOptions = APPROVAL_FORM_PALETTE_GROUPS.flatMap(
+  (group) => group.entries,
+)
+
+const fields = computed(() => sessionRef.value.draft.fields)
+
+// FB-D3: N+1 slots for N fields, identified by current neighbors, never a
+// persisted index/pixel. The anchor is bound to the slot at RENDER; the
+// command re-resolves it at mutation time.
+const slotDescriptors = computed<InsertionSlotDescriptor[]>(() => {
+  const descriptors: InsertionSlotDescriptor[] = [
+    { key: 'start', anchor: { kind: 'start' }, position: 0 },
+  ]
+  sessionRef.value.draft.fields.forEach((field, index) => {
+    descriptors.push({
+      key: `after-${field.localId}`,
+      anchor: { kind: 'after', localId: field.localId },
+      position: index + 1,
+    })
+  })
+  return descriptors
+})
+
+function cardSummary(field: FieldAuthoringDraft): string {
+  const parts = [typeLabels[field.type], field.required ? '必填' : '选填']
+  if (field.type === 'detail') {
+    parts.push(`${field.detailColumns.length} 个子字段`)
+  }
+  return parts.join(' · ')
+}
+
+function cardAccessibleName(field: FieldAuthoringDraft, index: number): string {
+  const label = field.label.trim() || typeLabels[field.type]
+  return `${label}，${typeLabels[field.type]}字段，位置 ${index + 1}`
+}
+
+function selectField(localId: string): void {
+  selectedLocalId.value = localId
+}
+
+/**
+ * Commit one adapter result: success updates session/selection and (only for a
+ * value-changing edit) emits `draft-change`; rejection surfaces a VALUES-FREE
+ * retry message and leaves session, draft, and history untouched (FB-D4).
+ */
+function applyResult(result: FormAdapterResult): boolean {
+  if (!result.ok) {
+    statusMessage.value =
+      result.reason === 'target_not_found' || result.reason === 'field_not_found'
+        ? STALE_SLOT_RETRY_MESSAGE
+        : GENERIC_RETRY_MESSAGE
+    return false
+  }
+  sessionRef.value = result.session
+  selectedLocalId.value = result.focusLocalId
+  statusMessage.value = ''
+  if (result.changed) {
+    emit('draft-change', result.session.draft, result.focusLocalId)
+  }
+  if (result.focusLocalId) void focusCard(result.focusLocalId)
+  return true
+}
+
+async function focusCard(localId: string): Promise<void> {
+  await nextTick()
+  const card = document.querySelector<HTMLElement>(
+    `[data-testid="approval-form-builder"] [data-field-local-id="${localId}"]`,
+  )
+  card?.focus()
+}
+
+/** Palette click path: append (§3.1), same adapter as every other path. */
+function appendField(type: AuthorableFieldType): boolean {
+  if (props.readOnly) return false
+  return applyResult(adapter.addField(sessionRef.value, type))
+}
+
+/** Slot click/keyboard path: exact-anchor insert via the same adapter. */
+function insertFieldAt(
+  anchor: FormInsertionAnchor,
+  type: AuthorableFieldType,
+): boolean {
+  if (props.readOnly) return false
+  return applyResult(adapter.addField(sessionRef.value, type, anchor))
+}
+
+/**
+ * Adapter passthrough (reference-aware, last-field-forbidden). No F2 UI mounts
+ * it — the delete affordance arrives with the F3 inspector — but the command
+ * surface stays the ONE adapter path.
+ */
+function removeField(localId: string): boolean {
+  if (props.readOnly) return false
+  return applyResult(adapter.removeField(sessionRef.value, localId))
+}
+
+function onMoveByOffset(localId: string, offset: -1 | 1): void {
+  if (props.readOnly) return
+  applyResult(adapter.moveFieldByOffset(sessionRef.value, localId, offset))
+}
+
+// --- insertion slot interactions -------------------------------------------
+
+function onSlotClick(descriptor: InsertionSlotDescriptor): void {
+  if (props.readOnly) return
+  insertMenuSlotKey.value =
+    insertMenuSlotKey.value === descriptor.key ? null : descriptor.key
+}
+
+function onInsertMenuPick(
+  descriptor: InsertionSlotDescriptor,
+  type: AuthorableFieldType,
+): void {
+  insertMenuSlotKey.value = null
+  insertFieldAt(descriptor.anchor, type)
+}
+
+function isCandidateDrag(event: DragEvent): boolean {
+  return (
+    activeDrag.value !== null ||
+    dataTransferSignalsApprovalFormDrag(event.dataTransfer)
+  )
+}
+
+function onSlotDragOver(
+  descriptor: InsertionSlotDescriptor,
+  event: DragEvent,
+): void {
+  if (props.readOnly) return
+  if (!isCandidateDrag(event)) return
+  event.preventDefault()
+  if (event.dataTransfer) {
+    try {
+      event.dataTransfer.dropEffect =
+        activeDrag.value?.kind === 'field' ? 'move' : 'copy'
+    } catch {
+      // readonly dropEffect in exotic hosts; affordance only.
+    }
+  }
+  dropTargetKey.value = descriptor.key
+}
+
+function onSlotDragLeave(descriptor: InsertionSlotDescriptor): void {
+  if (dropTargetKey.value === descriptor.key) dropTargetKey.value = null
+}
+
+/**
+ * Drop on slot k: strict decode first (§3.1 — full structured validation at
+ * drop, before ANY command/draft/history mutation), then the slot's
+ * render-time SEMANTIC anchor goes to the adapter, which re-resolves it
+ * against the current draft (FB-D3). Transient drag state clears on both
+ * success and failure.
+ */
+function onSlotDrop(
+  descriptor: InsertionSlotDescriptor,
+  event: DragEvent,
+): void {
+  event.preventDefault()
+  const payload = readApprovalFormDragPayload(event.dataTransfer)
+  clearTransientDragState()
+  if (props.readOnly) return
+  if (!payload) return // foreign/malformed/generic payload: never a command
+  if (payload.kind === 'palette') {
+    applyResult(adapter.addField(sessionRef.value, payload.fieldType, descriptor.anchor))
+    return
+  }
+  moveFieldToAnchor(payload.localId, descriptor.anchor)
+}
+
+/**
+ * Existing-field drop: resolve the semantic anchor against the CURRENT draft
+ * and call the same canonical `moveField` the keyboard path uses (§3.3).
+ * Dropping a field on one of its own adjacent slots is a value-identical
+ * boundary no-op (zero history entries) by adapter construction.
+ */
+function moveFieldToAnchor(
+  movingLocalId: string,
+  anchor: FormInsertionAnchor,
+): void {
+  if (anchor.kind === 'start') {
+    const first = sessionRef.value.draft.fields[0]
+    if (!first) return
+    applyResult(
+      adapter.moveField(sessionRef.value, movingLocalId, first.localId, 'before'),
+    )
+    return
+  }
+  applyResult(
+    adapter.moveField(sessionRef.value, movingLocalId, anchor.localId, 'after'),
+  )
+}
+
+// --- existing-field drag (move handle, §3.3) --------------------------------
+
+function onHandleDragStart(field: FieldAuthoringDraft, event: DragEvent): void {
+  if (props.readOnly) {
+    event.preventDefault()
+    return
+  }
+  const payload = {
+    version: 1,
+    kind: 'field',
+    localId: field.localId,
+  } as const
+  writeApprovalFormDragPayload(event.dataTransfer, payload)
+  dragSession.begin(payload)
+  selectedLocalId.value = field.localId
+}
+
+function onHandleDragEnd(): void {
+  clearTransientDragState()
+}
+
+// --- canvas-level (outside-slot) drag handling ------------------------------
+
+function onCanvasDragOver(_event: DragEvent): void {
+  // Invalid regions are NOT drop targets (§3.2): no preventDefault here, so
+  // the browser refuses the drop outside a slot.
+}
+
+function onCanvasDrop(event: DragEvent): void {
+  // Dropping outside a slot is a no-op; it still clears transient state.
+  event.preventDefault()
+  clearTransientDragState()
+}
+
+// --- transient-state clearing (§3.1: all five triggers) ---------------------
+
+function clearTransientDragState(): void {
+  dragSession.clear()
+  dropTargetKey.value = null
+}
+
+function onWindowKeydown(event: KeyboardEvent): void {
+  if (event.key !== 'Escape') return
+  clearTransientDragState()
+  insertMenuSlotKey.value = null
+}
+
+const unsubscribe = dragSession.subscribe((active) => {
+  activeDrag.value = active
+  if (!active) dropTargetKey.value = null
+})
+
+watch(
+  () => props.readOnly,
+  (readOnly) => {
+    if (readOnly) {
+      clearTransientDragState()
+      insertMenuSlotKey.value = null
+    }
+  },
+)
+
+onMounted(() => {
+  window.addEventListener('keydown', onWindowKeydown)
+})
+
+onBeforeUnmount(() => {
+  window.removeEventListener('keydown', onWindowKeydown)
+  clearTransientDragState() // route change/unmount clears the shared session
+  unsubscribe()
+})
+
+defineExpose({
+  appendField,
+  insertFieldAt,
+  removeField,
+  getSession: () => sessionRef.value,
+  getDragSession: () => dragSession,
+})
+</script>
+
+<style scoped>
+.approval-form-builder {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-height: 240px;
+  padding: 16px;
+  background: var(--el-fill-color-lighter);
+  border-radius: 12px;
+}
+
+.approval-form-builder__list {
+  display: flex;
+  flex-direction: column;
+}
+
+.approval-form-builder__slot-region {
+  position: relative;
+}
+
+.approval-form-builder__slot {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  min-height: 40px;
+  padding: 4px 8px;
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+  color: var(--el-text-color-placeholder);
+}
+
+.approval-form-builder__slot-line {
+  flex: 1;
+  height: 2px;
+  border-radius: 1px;
+  background: var(--el-border-color-lighter);
+}
+
+.approval-form-builder__slot-plus {
+  font-size: 12px;
+  opacity: 0;
+}
+
+.approval-form-builder__slot:hover .approval-form-builder__slot-plus,
+.approval-form-builder__slot:focus-visible .approval-form-builder__slot-plus,
+.approval-form-builder__slot.is-drag-active .approval-form-builder__slot-plus,
+.approval-form-builder__slot.is-menu-open .approval-form-builder__slot-plus {
+  opacity: 1;
+}
+
+.approval-form-builder__slot:hover .approval-form-builder__slot-line,
+.approval-form-builder__slot:focus-visible .approval-form-builder__slot-line,
+.approval-form-builder__slot.is-drag-active .approval-form-builder__slot-line {
+  background: var(--el-color-primary-light-5);
+}
+
+.approval-form-builder__slot.is-drop-target .approval-form-builder__slot-line {
+  height: 4px;
+  background: var(--el-color-primary);
+}
+
+.approval-form-builder__slot.is-drop-target {
+  color: var(--el-color-primary);
+}
+
+.approval-form-builder__slot:focus-visible {
+  outline: 2px solid var(--el-color-primary);
+  outline-offset: 2px;
+}
+
+.approval-form-builder__slot-menu {
+  position: absolute;
+  z-index: 10;
+  top: 100%;
+  left: 8px;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(96px, 1fr));
+  gap: 4px;
+  padding: 8px;
+  border: 1px solid var(--el-border-color-lighter);
+  border-radius: 8px;
+  background: var(--el-bg-color);
+  box-shadow: var(--el-box-shadow-lighter);
+}
+
+.approval-form-builder__slot-menu-item {
+  min-height: 40px;
+  padding: 6px 10px;
+  border: 1px solid var(--el-border-color-lighter);
+  border-radius: 6px;
+  background: var(--el-bg-color);
+  color: var(--el-text-color-regular);
+  font-size: 12px;
+  cursor: pointer;
+  text-align: left;
+}
+
+.approval-form-builder__slot-menu-item:hover,
+.approval-form-builder__slot-menu-item:focus-visible {
+  border-color: var(--el-color-primary-light-5);
+  color: var(--el-color-primary);
+}
+
+.approval-form-builder__card {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  min-height: 56px;
+  padding: 10px 14px;
+  border: 1px solid var(--el-border-color-lighter);
+  border-radius: 10px;
+  background: var(--el-bg-color);
+  cursor: pointer;
+}
+
+.approval-form-builder__card.is-selected {
+  border-color: var(--el-color-primary);
+  box-shadow: 0 0 0 1px var(--el-color-primary-light-5);
+}
+
+.approval-form-builder__card:focus-visible {
+  outline: 2px solid var(--el-color-primary);
+  outline-offset: 2px;
+}
+
+.approval-form-builder__card-main {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.approval-form-builder__card-selected-mark {
+  flex: none;
+  padding: 1px 6px;
+  border: 1px solid var(--el-color-primary);
+  border-radius: 4px;
+  font-size: 11px;
+  color: var(--el-color-primary);
+}
+
+.approval-form-builder__card-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 13px;
+  color: var(--el-text-color-primary);
+}
+
+.approval-form-builder__card-summary {
+  flex: none;
+  font-size: 11px;
+  color: var(--el-text-color-placeholder);
+}
+
+.approval-form-builder__card-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.approval-form-builder__card-action,
+.approval-form-builder__card-handle {
+  min-height: 40px;
+  min-width: 40px;
+  padding: 4px 8px;
+  border: 1px solid var(--el-border-color-lighter);
+  border-radius: 6px;
+  background: var(--el-bg-color);
+  color: var(--el-text-color-regular);
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.approval-form-builder__card-action:disabled {
+  color: var(--el-text-color-placeholder);
+  cursor: not-allowed;
+}
+
+.approval-form-builder__card-handle {
+  cursor: grab;
+  touch-action: none;
+}
+
+.approval-form-builder__card-action:focus-visible,
+.approval-form-builder__card-handle:focus-visible {
+  outline: 2px solid var(--el-color-primary);
+  outline-offset: 2px;
+}
+
+.approval-form-builder__status {
+  min-height: 18px;
+  margin: 0;
+  font-size: 12px;
+  color: var(--el-color-danger);
+}
+</style>

--- a/apps/web/src/approvals/components/ApprovalFormPalette.vue
+++ b/apps/web/src/approvals/components/ApprovalFormPalette.vue
@@ -1,0 +1,249 @@
+<template>
+  <div class="approval-form-palette" data-testid="approval-form-palette">
+    <p class="approval-form-palette__title">控件</p>
+    <div
+      v-if="!readOnly"
+      class="approval-form-palette__groups"
+      role="group"
+      aria-label="添加表单字段类型"
+    >
+      <section
+        v-for="group in APPROVAL_FORM_PALETTE_GROUPS"
+        :key="group.id"
+        class="approval-form-palette__group"
+      >
+        <h3>{{ group.label }}</h3>
+        <div class="approval-form-palette__grid">
+          <button
+            v-for="entry in group.entries"
+            :key="entry.type"
+            type="button"
+            class="approval-form-palette__chip"
+            :data-testid="`approval-form-palette-chip-${entry.type}`"
+            :draggable="true"
+            :aria-label="`添加${entry.label}字段`"
+            @click="onChipClick(entry.type)"
+            @dragstart="onChipDragStart(entry.type, $event)"
+            @dragend="onChipDragEnd"
+          >
+            <span>{{ entry.label }}</span>
+            <span class="approval-form-palette__mark" aria-hidden="true">{{ entry.mark }}</span>
+          </button>
+        </div>
+      </section>
+    </div>
+    <p
+      v-else
+      class="approval-form-palette__readonly-note"
+      data-testid="approval-form-palette-readonly"
+    >
+      只读模式下不可添加字段
+    </p>
+  </div>
+</template>
+
+<script lang="ts">
+/**
+ * F2 palette display data — the same AuthorableFieldType grouping/labels/marks
+ * as the shipped #4917 shell (`TemplateAuthoringView.vue` fieldPaletteGroups),
+ * defined here so the Designer 2.0 palette/builder pair is standalone (FB-D8:
+ * separate from the extracted `ApprovalFormInlineEditor` fallback, which keeps
+ * receiving the parent's copies via props). Exported so `ApprovalFormBuilder`
+ * renders identical type labels on cards and insertion menus.
+ */
+import type { AuthorableFieldType } from '../templateAuthoring'
+
+export interface ApprovalFormPaletteEntry {
+  type: AuthorableFieldType
+  label: string
+  mark: string
+}
+
+export interface ApprovalFormPaletteGroup {
+  id: string
+  label: string
+  entries: ApprovalFormPaletteEntry[]
+}
+
+export const APPROVAL_FORM_FIELD_TYPE_LABELS: Record<
+  AuthorableFieldType,
+  string
+> = {
+  text: '文本',
+  textarea: '多行文本',
+  number: '数字',
+  date: '日期',
+  datetime: '日期时间',
+  select: '单选',
+  'multi-select': '多选',
+  user: '人员',
+  detail: '明细',
+  'record-link': '关联记录',
+}
+
+const FIELD_TYPE_MARKS: Record<AuthorableFieldType, string> = {
+  text: 'A',
+  textarea: 'Aa',
+  number: '123',
+  date: '日',
+  datetime: '时',
+  select: '○',
+  'multi-select': '☑',
+  user: '人',
+  detail: '表',
+  'record-link': '链',
+}
+
+export const APPROVAL_FORM_PALETTE_GROUPS: ApprovalFormPaletteGroup[] = [
+  { id: 'text', label: '文本', types: ['text', 'textarea'] },
+  { id: 'number', label: '数值', types: ['number'] },
+  { id: 'choice', label: '选项', types: ['select', 'multi-select'] },
+  { id: 'date', label: '日期', types: ['date', 'datetime'] },
+  { id: 'other', label: '其他', types: ['user', 'detail', 'record-link'] },
+].map(({ id, label, types }) => ({
+  id,
+  label,
+  entries: (types as AuthorableFieldType[]).map((type) => ({
+    type,
+    label: APPROVAL_FORM_FIELD_TYPE_LABELS[type],
+    mark: FIELD_TYPE_MARKS[type],
+  })),
+}))
+</script>
+
+<script setup lang="ts">
+/**
+ * F2 Designer 2.0 palette (delta §3.1, FB-D8) — standalone until the F4 mount
+ * behind `approvalCanvasV2`. NOT the flag-OFF fallback (that stays
+ * `ApprovalFormInlineEditor.vue`).
+ *
+ * - Click = append intent (`append-field`); the composing owner routes it to
+ *   the ONE `approvalFormAuthoringAdapter` (FB-D4). This component never
+ *   mutates a draft itself.
+ * - Dragstart writes the typed codec payload under the application MIME only
+ *   and begins the shared transient drag session; dragend, unmount (route
+ *   change), and the read-only transition clear it (§3.1).
+ * - Read-only mode renders no draggable chips (§3.1).
+ * - Chips are native buttons: keyboard activation (Enter/Space) is complete
+ *   without pointer drag (FB-D2).
+ */
+import { onBeforeUnmount, watch } from 'vue'
+import {
+  createApprovalFormDragSession,
+  writeApprovalFormDragPayload,
+  type ApprovalFormDragSession,
+} from '../approvalFormDragPayload'
+import type { AuthorableFieldType as AuthorableFieldTypeSetup } from '../templateAuthoring'
+
+const props = withDefaults(
+  defineProps<{
+    readOnly?: boolean
+    /** Shared transient drag session (pass the builder's; defaults local). */
+    dragSession?: ApprovalFormDragSession
+  }>(),
+  { readOnly: false, dragSession: undefined },
+)
+
+const emit = defineEmits<{
+  (e: 'append-field', type: AuthorableFieldTypeSetup): void
+}>()
+
+const session: ApprovalFormDragSession =
+  props.dragSession ?? createApprovalFormDragSession()
+
+function onChipClick(type: AuthorableFieldTypeSetup): void {
+  if (props.readOnly) return
+  emit('append-field', type)
+}
+
+function onChipDragStart(
+  type: AuthorableFieldTypeSetup,
+  event: DragEvent,
+): void {
+  if (props.readOnly) {
+    event.preventDefault()
+    return
+  }
+  const payload = { version: 1, kind: 'palette', fieldType: type } as const
+  writeApprovalFormDragPayload(event.dataTransfer, payload)
+  session.begin(payload)
+}
+
+function onChipDragEnd(): void {
+  session.clear()
+}
+
+// §3.1 transient-state clearing: read-only transition + route change/unmount.
+watch(
+  () => props.readOnly,
+  (readOnly) => {
+    if (readOnly) session.clear()
+  },
+)
+onBeforeUnmount(() => {
+  session.clear()
+})
+</script>
+
+<style scoped>
+.approval-form-palette {
+  padding: 12px 12px 16px;
+  overflow: auto;
+  background: var(--el-bg-color);
+}
+.approval-form-palette__title {
+  margin: 0 0 12px;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--el-color-primary);
+}
+.approval-form-palette__groups {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+.approval-form-palette__group h3 {
+  margin: 0 0 8px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--el-text-color-secondary);
+}
+.approval-form-palette__grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+}
+.approval-form-palette__chip {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 6px;
+  min-height: 40px;
+  padding: 6px 8px;
+  border: 1px solid var(--el-border-color-lighter);
+  border-radius: 8px;
+  background: var(--el-bg-color);
+  color: var(--el-text-color-regular);
+  font-size: 12px;
+  cursor: grab;
+  text-align: left;
+}
+.approval-form-palette__chip:hover,
+.approval-form-palette__chip:focus-visible {
+  border-color: var(--el-color-primary-light-5);
+  color: var(--el-color-primary);
+}
+.approval-form-palette__chip:focus-visible {
+  outline: 2px solid var(--el-color-primary);
+  outline-offset: 2px;
+}
+.approval-form-palette__mark {
+  color: var(--el-text-color-placeholder);
+  font-size: 11px;
+}
+.approval-form-palette__readonly-note {
+  margin: 0;
+  font-size: 12px;
+  color: var(--el-text-color-secondary);
+}
+</style>

--- a/apps/web/tests/approval-form-builder-slots.spec.ts
+++ b/apps/web/tests/approval-form-builder-slots.spec.ts
@@ -1,0 +1,744 @@
+/**
+ * F2 mounted builder spec (delta §3.1-§3.3, FB-D3/FB-D4/FB-D8, Gate F2) — the
+ * NEW Designer 2.0 `ApprovalFormBuilder.vue`: N+1 semantic insertion slots,
+ * strict drag-codec drops, stale-anchor no-ops, transient drag-state clearing
+ * on all five triggers, click/drag/keyboard convergence on the ONE adapter,
+ * and the no-production-mount pin (F4 mounts behind `approvalCanvasV2`).
+ * Mount pattern: repo-standard `createApp` + real DOM events (no test-utils).
+ */
+import { readFileSync, readdirSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { createApp, h, nextTick, reactive, ref, type App as VueApp } from 'vue'
+
+import ApprovalFormBuilder, {
+  GENERIC_RETRY_MESSAGE,
+  STALE_SLOT_RETRY_MESSAGE,
+} from '../src/approvals/components/ApprovalFormBuilder.vue'
+import {
+  createFormAuthoringAdapter,
+  type FormAuthoringAdapter,
+  type FormAuthoringSession,
+} from '../src/approvals/approvalFormAuthoringAdapter'
+import {
+  OPAQUE_IDENTITY_TOKEN_BYTES,
+  createOpaqueFormIdentityAllocator,
+  type IdentityRandomSource,
+} from '../src/approvals/approvalFormIdentity'
+import {
+  APPROVAL_FORM_DRAG_MIME,
+  createApprovalFormDragSession,
+  encodeApprovalFormDragPayload,
+  type ApprovalFormDragPayload,
+  type ApprovalFormDragSession,
+} from '../src/approvals/approvalFormDragPayload'
+import {
+  createEmptyFieldDraft,
+  createEmptyStepDraft,
+  createEmptyTemplateDraft,
+  type AuthorableFieldType,
+  type FieldAuthoringDraft,
+  type TemplateAuthoringDraft,
+} from '../src/approvals/templateAuthoring'
+
+// --- fixtures ---------------------------------------------------------------
+
+function field(
+  index: number,
+  overrides: Partial<FieldAuthoringDraft> = {},
+): FieldAuthoringDraft {
+  return {
+    ...createEmptyFieldDraft(index),
+    localId: `local_${index}`,
+    id: `field_${index}`,
+    label: `字段 ${index}`,
+    ...overrides,
+  }
+}
+
+function draftWith(fields: FieldAuthoringDraft[]): TemplateAuthoringDraft {
+  return {
+    ...createEmptyTemplateDraft(),
+    key: 'form_builder',
+    name: '表单构建器',
+    fields,
+    steps: [createEmptyStepDraft(1)],
+  }
+}
+
+/** Deterministic seam replaying scripted 8-byte blocks (F1 pattern). */
+function scriptedSource(blocks: number[][]): IdentityRandomSource {
+  let cursor = 0
+  return {
+    nextBytes(length: number): Uint8Array {
+      expect(length).toBe(OPAQUE_IDENTITY_TOKEN_BYTES)
+      const block = blocks[cursor % blocks.length]!
+      cursor += 1
+      return Uint8Array.from(block)
+    },
+  }
+}
+
+const BLOCK_A = [0x0a, 0x0a, 0x0a, 0x0a, 0x0a, 0x0a, 0x0a, 0x0a]
+const BLOCK_B = [0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b]
+
+/** Fresh adapter with the SAME deterministic identity script per call. */
+function deterministicAdapter(): FormAuthoringAdapter {
+  return createFormAuthoringAdapter({
+    identityAllocator: createOpaqueFormIdentityAllocator(
+      scriptedSource([BLOCK_A, BLOCK_B]),
+    ),
+  })
+}
+
+function makeDataTransfer(entries: Record<string, string> = {}) {
+  const store = new Map(Object.entries(entries))
+  return {
+    get types(): string[] {
+      return Array.from(store.keys())
+    },
+    setData(type: string, value: string): void {
+      store.set(type, String(value))
+    },
+    getData(type: string): string {
+      return store.get(type) ?? ''
+    },
+    effectAllowed: 'uninitialized',
+    dropEffect: 'none',
+  } as unknown as DataTransfer
+}
+
+function payloadTransfer(payload: ApprovalFormDragPayload): DataTransfer {
+  return makeDataTransfer({
+    [APPROVAL_FORM_DRAG_MIME]: encodeApprovalFormDragPayload(payload),
+  })
+}
+
+function dispatchDrag(
+  el: Element,
+  type: string,
+  dataTransfer: DataTransfer | null = null,
+): void {
+  const event = new Event(type, { bubbles: true, cancelable: true })
+  Object.defineProperty(event, 'dataTransfer', { value: dataTransfer })
+  el.dispatchEvent(event)
+}
+
+// --- mount harness ----------------------------------------------------------
+
+interface BuilderExposed {
+  appendField(type: AuthorableFieldType): boolean
+  insertFieldAt(anchor: unknown, type: AuthorableFieldType): boolean
+  removeField(localId: string): boolean
+  getSession(): FormAuthoringSession
+  getDragSession(): ApprovalFormDragSession
+}
+
+interface BuilderHarness {
+  root: HTMLElement
+  state: { readOnly: boolean }
+  draftChanges: [TemplateAuthoringDraft, string | null][]
+  vm: BuilderExposed
+  q(selector: string): HTMLElement
+  slot(key: string): HTMLElement
+  localOrder(): (string | null)[]
+  slotKeys(): (string | null)[]
+  dropOnSlot(key: string, dataTransfer: DataTransfer): Promise<void>
+  unmount(): void
+}
+
+const mounted: { app: VueApp<Element>; container: HTMLDivElement }[] = []
+
+async function mountBuilder(
+  fields: FieldAuthoringDraft[],
+  options: {
+    readOnly?: boolean
+    dragSession?: ApprovalFormDragSession
+    adapter?: FormAuthoringAdapter
+  } = {},
+): Promise<BuilderHarness> {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const state = reactive({ readOnly: options.readOnly ?? false })
+  const draft = draftWith(fields)
+  const draftChanges: [TemplateAuthoringDraft, string | null][] = []
+  const exposedRef = ref<BuilderExposed | null>(null)
+  const app = createApp({
+    setup() {
+      return () =>
+        h(ApprovalFormBuilder, {
+          draft,
+          readOnly: state.readOnly,
+          dragSession: options.dragSession,
+          adapter: options.adapter,
+          ref: exposedRef,
+          onDraftChange: (
+            next: TemplateAuthoringDraft,
+            focusLocalId: string | null,
+          ) => {
+            draftChanges.push([next, focusLocalId])
+          },
+        })
+    },
+  })
+  app.mount(container)
+  mounted.push({ app, container })
+  await nextTick()
+
+  function q(selector: string): HTMLElement {
+    const el = container.querySelector(selector)
+    if (!el) throw new Error(`selector not rendered: ${selector}`)
+    return el as HTMLElement
+  }
+
+  return {
+    root: container,
+    state,
+    draftChanges,
+    get vm() {
+      return exposedRef.value!
+    },
+    q,
+    slot(key: string) {
+      return q(`[data-testid="approval-form-builder-slot-${key}"]`)
+    },
+    localOrder() {
+      return Array.from(
+        container.querySelectorAll(
+          '[data-testid="approval-form-builder-card"]',
+        ),
+      ).map((card) => card.getAttribute('data-field-local-id'))
+    },
+    slotKeys() {
+      return Array.from(
+        container.querySelectorAll('.approval-form-builder__slot'),
+      ).map((slot) =>
+        (slot.getAttribute('data-testid') ?? '').replace(
+          'approval-form-builder-slot-',
+          '',
+        ),
+      )
+    },
+    async dropOnSlot(key: string, dataTransfer: DataTransfer) {
+      const slotEl = q(`[data-testid="approval-form-builder-slot-${key}"]`)
+      dispatchDrag(slotEl, 'dragover', dataTransfer)
+      dispatchDrag(slotEl, 'drop', dataTransfer)
+      await nextTick()
+    },
+    unmount() {
+      app.unmount()
+      container.remove()
+    },
+  }
+}
+
+afterEach(() => {
+  while (mounted.length > 0) {
+    const entry = mounted.pop()!
+    try {
+      entry.app.unmount()
+    } catch {
+      // already unmounted by the test
+    }
+    entry.container.remove()
+  }
+})
+
+// --- N+1 slots --------------------------------------------------------------
+
+describe('ApprovalFormBuilder — N+1 insertion slots (FB-D3, §3.2)', () => {
+  it('renders exactly N+1 semantic slots in order: start, then after each field', async () => {
+    const builder = await mountBuilder([field(1), field(2), field(3)])
+    expect(builder.localOrder()).toEqual(['local_1', 'local_2', 'local_3'])
+    expect(builder.slotKeys()).toEqual([
+      'start',
+      'after-local_1',
+      'after-local_2',
+      'after-local_3',
+    ])
+  })
+
+  it('slot count tracks the field count: N+2 slots after one insert', async () => {
+    const builder = await mountBuilder([field(1), field(2)])
+    expect(builder.slotKeys()).toHaveLength(3)
+    await builder.dropOnSlot(
+      'start',
+      payloadTransfer({ version: 1, kind: 'palette', fieldType: 'select' }),
+    )
+    expect(builder.slotKeys()).toHaveLength(4)
+  })
+
+  it('read-only mode renders NO slots, move buttons, or drag handles', async () => {
+    const builder = await mountBuilder([field(1), field(2)], {
+      readOnly: true,
+    })
+    expect(builder.slotKeys()).toHaveLength(0)
+    expect(builder.root.querySelector('[draggable="true"]')).toBeNull()
+    expect(
+      builder.root.querySelector(
+        '[data-testid^="approval-form-builder-move-up-"]',
+      ),
+    ).toBeNull()
+    // Cards still render for reading.
+    expect(builder.localOrder()).toEqual(['local_1', 'local_2'])
+  })
+})
+
+// --- anchor exactness -------------------------------------------------------
+
+describe('ApprovalFormBuilder — exact anchor placement (FB-D3)', () => {
+  it('drop on the START slot prepends atomically: exact order, ONE history entry', async () => {
+    const builder = await mountBuilder([field(1), field(2), field(3)])
+    await builder.dropOnSlot(
+      'start',
+      payloadTransfer({ version: 1, kind: 'palette', fieldType: 'select' }),
+    )
+    const order = builder.localOrder()
+    expect(order).toHaveLength(4)
+    expect(order.slice(1)).toEqual(['local_1', 'local_2', 'local_3'])
+    const cards = Array.from(
+      builder.root.querySelectorAll(
+        '[data-testid="approval-form-builder-card"]',
+      ),
+    )
+    expect(cards[0]!.getAttribute('data-field-type')).toBe('select')
+    // Atomic prepend: exactly ONE history entry (never add-then-move).
+    expect(builder.vm.getSession().history.undoStack).toHaveLength(1)
+    // New field selected (programmatic selected state, non-color-only marker).
+    expect(cards[0]!.getAttribute('data-selected')).toBe('true')
+    expect(
+      cards[0]!.querySelector(
+        '[data-testid="approval-form-builder-card-selected-mark"]',
+      ),
+    ).not.toBeNull()
+  })
+
+  it('drop on a MIDDLE slot inserts exactly after its anchor field', async () => {
+    const builder = await mountBuilder([field(1), field(2), field(3)])
+    await builder.dropOnSlot(
+      'after-local_1',
+      payloadTransfer({ version: 1, kind: 'palette', fieldType: 'user' }),
+    )
+    const order = builder.localOrder()
+    expect(order[0]).toBe('local_1')
+    expect(order.slice(2)).toEqual(['local_2', 'local_3'])
+    const cards = Array.from(
+      builder.root.querySelectorAll(
+        '[data-testid="approval-form-builder-card"]',
+      ),
+    )
+    expect(cards[1]!.getAttribute('data-field-type')).toBe('user')
+    expect(builder.vm.getSession().history.undoStack).toHaveLength(1)
+  })
+
+  it('drop on the END slot appends exactly', async () => {
+    const builder = await mountBuilder([field(1), field(2), field(3)])
+    await builder.dropOnSlot(
+      'after-local_3',
+      payloadTransfer({ version: 1, kind: 'palette', fieldType: 'date' }),
+    )
+    const order = builder.localOrder()
+    expect(order.slice(0, 3)).toEqual(['local_1', 'local_2', 'local_3'])
+    const cards = Array.from(
+      builder.root.querySelectorAll(
+        '[data-testid="approval-form-builder-card"]',
+      ),
+    )
+    expect(cards[3]!.getAttribute('data-field-type')).toBe('date')
+    expect(builder.vm.getSession().history.undoStack).toHaveLength(1)
+  })
+
+  it('existing-field payload drop moves by localId to the exact slot (§3.3)', async () => {
+    const builder = await mountBuilder([field(1), field(2), field(3)])
+    await builder.dropOnSlot(
+      'after-local_1',
+      payloadTransfer({ version: 1, kind: 'field', localId: 'local_3' }),
+    )
+    expect(builder.localOrder()).toEqual(['local_1', 'local_3', 'local_2'])
+    expect(builder.vm.getSession().history.undoStack).toHaveLength(1)
+  })
+
+  it('dropping a field on its own adjacent slot is a value-identical no-op: ZERO history entries', async () => {
+    const builder = await mountBuilder([field(1), field(2), field(3)])
+    // local_1 is already first: the start slot drop changes nothing.
+    await builder.dropOnSlot(
+      'start',
+      payloadTransfer({ version: 1, kind: 'field', localId: 'local_1' }),
+    )
+    expect(builder.localOrder()).toEqual(['local_1', 'local_2', 'local_3'])
+    expect(builder.vm.getSession().history.undoStack).toHaveLength(0)
+    expect(builder.draftChanges).toHaveLength(0)
+  })
+})
+
+// --- strict codec at the drop boundary --------------------------------------
+
+describe('ApprovalFormBuilder — strict decode negatives (codec §3.1)', () => {
+  it('a text/plain foreign payload is NEVER a command (with positive control)', async () => {
+    const builder = await mountBuilder([field(1), field(2)])
+    // Foreign payloads: a bare legacy type string, and a command-shaped JSON
+    // body — both under text/plain only.
+    for (const raw of [
+      'select',
+      JSON.stringify({ version: 1, kind: 'palette', fieldType: 'select' }),
+    ]) {
+      await builder.dropOnSlot('start', makeDataTransfer({ 'text/plain': raw }))
+      expect(builder.localOrder()).toEqual(['local_1', 'local_2'])
+      expect(builder.vm.getSession().history.undoStack).toHaveLength(0)
+    }
+    // Positive control: the SAME body under the application MIME mutates.
+    await builder.dropOnSlot(
+      'start',
+      payloadTransfer({ version: 1, kind: 'palette', fieldType: 'select' }),
+    )
+    expect(builder.localOrder()).toHaveLength(3)
+    expect(builder.vm.getSession().history.undoStack).toHaveLength(1)
+  })
+
+  it.each([
+    ['malformed JSON under the app MIME', { [APPROVAL_FORM_DRAG_MIME]: '{oops' }],
+    ['unknown version', { [APPROVAL_FORM_DRAG_MIME]: JSON.stringify({ version: 9, kind: 'palette', fieldType: 'text' }) }],
+    ['unknown kind', { [APPROVAL_FORM_DRAG_MIME]: JSON.stringify({ version: 1, kind: 'palette-field', fieldType: 'text' }) }],
+    ['extra property', { [APPROVAL_FORM_DRAG_MIME]: JSON.stringify({ version: 1, kind: 'palette', fieldType: 'text', index: 0 }) }],
+    ['disabled attachment type stays fail-closed', { [APPROVAL_FORM_DRAG_MIME]: JSON.stringify({ version: 1, kind: 'palette', fieldType: 'attachment' }) }],
+    ['blank localId', { [APPROVAL_FORM_DRAG_MIME]: JSON.stringify({ version: 1, kind: 'field', localId: ' ' }) }],
+    ['wrong MIME (application/json)', { 'application/json': JSON.stringify({ version: 1, kind: 'palette', fieldType: 'text' }) }],
+    ['empty dataTransfer', {}],
+  ])('%s → zero draft/history mutation', async (_name, entries) => {
+    const builder = await mountBuilder([field(1), field(2)])
+    await builder.dropOnSlot(
+      'start',
+      makeDataTransfer(entries as Record<string, string>),
+    )
+    expect(builder.localOrder()).toEqual(['local_1', 'local_2'])
+    expect(builder.vm.getSession().history.undoStack).toHaveLength(0)
+    expect(builder.draftChanges).toHaveLength(0)
+  })
+})
+
+// --- stale anchor -----------------------------------------------------------
+
+describe('ApprovalFormBuilder — stale anchor is a values-free no-op (FB-D3)', () => {
+  it('a drop whose render-time anchor field was removed re-resolves to a no-op with the retry message', async () => {
+    const builder = await mountBuilder([field(1), field(2), field(3)])
+    // Grab the slot DOM node bound to the anchor {after, local_2} BEFORE the
+    // draft changes.
+    const staleSlot = builder.slot('after-local_2')
+    // Remove the anchor field through the same adapter, then drop BEFORE the
+    // re-render lands (no nextTick) — the genuine staleness window.
+    expect(builder.vm.removeField('local_2')).toBe(true)
+    dispatchDrag(
+      staleSlot,
+      'drop',
+      payloadTransfer({ version: 1, kind: 'palette', fieldType: 'select' }),
+    )
+    await nextTick()
+    // No insert happened; only the remove is in history.
+    expect(
+      builder.vm.getSession().draft.fields.map((entry) => entry.localId),
+    ).toEqual(['local_1', 'local_3'])
+    expect(builder.vm.getSession().history.undoStack).toHaveLength(1)
+    // Values-free retry copy — exact pin; carries no labels/ids/values.
+    expect(
+      builder.q('[data-testid="approval-form-builder-status"]').textContent,
+    ).toBe(STALE_SLOT_RETRY_MESSAGE)
+    expect(STALE_SLOT_RETRY_MESSAGE).not.toMatch(/local_|field_|字段 \d/)
+    expect(GENERIC_RETRY_MESSAGE).not.toMatch(/local_|field_|字段 \d/)
+  })
+
+  it('a stale existing-field MOVE target is the same values-free no-op', async () => {
+    const builder = await mountBuilder([field(1), field(2), field(3)])
+    const staleSlot = builder.slot('after-local_2')
+    expect(builder.vm.removeField('local_2')).toBe(true)
+    dispatchDrag(
+      staleSlot,
+      'drop',
+      payloadTransfer({ version: 1, kind: 'field', localId: 'local_3' }),
+    )
+    await nextTick()
+    expect(
+      builder.vm.getSession().draft.fields.map((entry) => entry.localId),
+    ).toEqual(['local_1', 'local_3'])
+    expect(builder.vm.getSession().history.undoStack).toHaveLength(1)
+    expect(
+      builder.q('[data-testid="approval-form-builder-status"]').textContent,
+    ).toBe(STALE_SLOT_RETRY_MESSAGE)
+  })
+})
+
+// --- transient drag-state clearing (all five triggers) ----------------------
+
+describe('ApprovalFormBuilder — transient drag state clears on all five triggers (§3.1)', () => {
+  function startHandleDrag(builder: BuilderHarness, localId: string): void {
+    dispatchDrag(
+      builder.q(`[data-testid="approval-form-builder-handle-${localId}"]`),
+      'dragstart',
+      makeDataTransfer(),
+    )
+  }
+
+  it('trigger 1 — drop (successful AND failed) clears; drop outside a slot is a clearing no-op', async () => {
+    const dragSession = createApprovalFormDragSession()
+    const builder = await mountBuilder([field(1), field(2)], { dragSession })
+    startHandleDrag(builder, 'local_2')
+    expect(dragSession.active()).toEqual({
+      version: 1,
+      kind: 'field',
+      localId: 'local_2',
+    })
+    await builder.dropOnSlot(
+      'start',
+      payloadTransfer({ version: 1, kind: 'field', localId: 'local_2' }),
+    )
+    expect(dragSession.active()).toBeNull()
+
+    // Failed drop (foreign payload) clears too.
+    startHandleDrag(builder, 'local_1')
+    expect(dragSession.active()).not.toBeNull()
+    await builder.dropOnSlot('start', makeDataTransfer({ 'text/plain': 'x' }))
+    expect(dragSession.active()).toBeNull()
+
+    // Drop OUTSIDE any slot (canvas background) is a no-op that still clears.
+    startHandleDrag(builder, 'local_1')
+    expect(dragSession.active()).not.toBeNull()
+    const before = builder.vm.getSession()
+    dispatchDrag(
+      builder.q('[data-testid="approval-form-builder"]'),
+      'drop',
+      makeDataTransfer(),
+    )
+    await nextTick()
+    expect(dragSession.active()).toBeNull()
+    expect(builder.vm.getSession()).toBe(before)
+  })
+
+  it('trigger 2 — dragend on the move handle clears', async () => {
+    const dragSession = createApprovalFormDragSession()
+    const builder = await mountBuilder([field(1), field(2)], { dragSession })
+    startHandleDrag(builder, 'local_1')
+    expect(dragSession.active()).not.toBeNull()
+    dispatchDrag(
+      builder.q('[data-testid="approval-form-builder-handle-local_1"]'),
+      'dragend',
+    )
+    expect(dragSession.active()).toBeNull()
+  })
+
+  it('trigger 3 — Escape clears (and collapses the drop-target affordance)', async () => {
+    const dragSession = createApprovalFormDragSession()
+    const builder = await mountBuilder([field(1), field(2)], { dragSession })
+    startHandleDrag(builder, 'local_1')
+    const slotEl = builder.slot('after-local_2')
+    dispatchDrag(slotEl, 'dragover', makeDataTransfer())
+    await nextTick()
+    expect(slotEl.classList.contains('is-drop-target')).toBe(true)
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+    await nextTick()
+    expect(dragSession.active()).toBeNull()
+    expect(slotEl.classList.contains('is-drop-target')).toBe(false)
+    // The cancelled drag left zero draft/history mutation.
+    expect(builder.vm.getSession().history.undoStack).toHaveLength(0)
+  })
+
+  it('trigger 4 — unmount (route change) clears the SHARED session', async () => {
+    const dragSession = createApprovalFormDragSession()
+    const builder = await mountBuilder([field(1), field(2)], { dragSession })
+    startHandleDrag(builder, 'local_1')
+    expect(dragSession.active()).not.toBeNull()
+    builder.unmount()
+    expect(dragSession.active()).toBeNull()
+  })
+
+  it('trigger 5 — the read-only transition clears and removes drop targets', async () => {
+    const dragSession = createApprovalFormDragSession()
+    const builder = await mountBuilder([field(1), field(2)], { dragSession })
+    startHandleDrag(builder, 'local_1')
+    expect(dragSession.active()).not.toBeNull()
+    builder.state.readOnly = true
+    await nextTick()
+    expect(dragSession.active()).toBeNull()
+    expect(builder.slotKeys()).toHaveLength(0)
+  })
+})
+
+// --- click/drag/keyboard equivalence (FB-D4) --------------------------------
+
+describe('ApprovalFormBuilder — click, drag, and keyboard paths are IDENTICAL (FB-D4)', () => {
+  it('slot-menu click insert === palette drag to the same slot: same draft, same single history entry', async () => {
+    // Same deterministic identity script → byte-identical results.
+    const dragBuilder = await mountBuilder([field(1), field(2), field(3)], {
+      adapter: deterministicAdapter(),
+    })
+    await dragBuilder.dropOnSlot(
+      'after-local_1',
+      payloadTransfer({ version: 1, kind: 'palette', fieldType: 'select' }),
+    )
+
+    const clickBuilder = await mountBuilder([field(1), field(2), field(3)], {
+      adapter: deterministicAdapter(),
+    })
+    // Slot click opens the type menu; the menu item is a native BUTTON, so
+    // Enter/Space keyboard activation is the same click event path (FB-D2).
+    clickBuilder.slot('after-local_1').click()
+    await nextTick()
+    expect(
+      clickBuilder.slot('after-local_1').getAttribute('aria-expanded'),
+    ).toBe('true')
+    const menuItem = clickBuilder.q(
+      '[data-testid="approval-form-builder-insert-select"]',
+    )
+    expect(menuItem.tagName).toBe('BUTTON')
+    menuItem.click()
+    await nextTick()
+
+    const dragSession = dragBuilder.vm.getSession()
+    const clickSession = clickBuilder.vm.getSession()
+    expect(clickSession.draft.fields).toEqual(dragSession.draft.fields)
+    expect(dragSession.history.undoStack).toHaveLength(1)
+    expect(clickSession.history.undoStack).toHaveLength(1)
+    expect(clickSession.history.undoStack).toEqual(
+      dragSession.history.undoStack,
+    )
+    expect(clickSession.history.focusLocalId).toBe(
+      dragSession.history.focusLocalId,
+    )
+    expect(clickBuilder.localOrder()).toEqual(dragBuilder.localOrder())
+  })
+
+  it('palette click-to-append (appendField) === drag to the END slot', async () => {
+    const dragBuilder = await mountBuilder([field(1), field(2)], {
+      adapter: deterministicAdapter(),
+    })
+    await dragBuilder.dropOnSlot(
+      'after-local_2',
+      payloadTransfer({ version: 1, kind: 'palette', fieldType: 'date' }),
+    )
+
+    const clickBuilder = await mountBuilder([field(1), field(2)], {
+      adapter: deterministicAdapter(),
+    })
+    expect(clickBuilder.vm.appendField('date')).toBe(true)
+    await nextTick()
+
+    expect(clickBuilder.vm.getSession().draft.fields).toEqual(
+      dragBuilder.vm.getSession().draft.fields,
+    )
+    expect(clickBuilder.vm.getSession().history.undoStack).toEqual(
+      dragBuilder.vm.getSession().history.undoStack,
+    )
+    expect(clickBuilder.vm.getSession().history.undoStack).toHaveLength(1)
+  })
+
+  it('existing-field drag === keyboard 上移: same order, focus, and history snapshot (§3.3)', async () => {
+    const dragBuilder = await mountBuilder([field(1), field(2), field(3)])
+    await dragBuilder.dropOnSlot(
+      'start',
+      payloadTransfer({ version: 1, kind: 'field', localId: 'local_2' }),
+    )
+
+    const keyboardBuilder = await mountBuilder([field(1), field(2), field(3)])
+    keyboardBuilder
+      .q('[data-testid="approval-form-builder-move-up-local_2"]')
+      .click()
+    await nextTick()
+
+    expect(dragBuilder.localOrder()).toEqual([
+      'local_2',
+      'local_1',
+      'local_3',
+    ])
+    expect(keyboardBuilder.localOrder()).toEqual(dragBuilder.localOrder())
+    expect(keyboardBuilder.vm.getSession().history.undoStack).toEqual(
+      dragBuilder.vm.getSession().history.undoStack,
+    )
+    expect(keyboardBuilder.vm.getSession().history.undoStack).toHaveLength(1)
+    expect(keyboardBuilder.vm.getSession().history.focusLocalId).toBe(
+      dragBuilder.vm.getSession().history.focusLocalId,
+    )
+    // Selection retained on the moved field in both paths.
+    expect(
+      dragBuilder.root
+        .querySelector('[data-field-local-id="local_2"]')
+        ?.getAttribute('data-selected'),
+    ).toBe('true')
+    expect(
+      keyboardBuilder.root
+        .querySelector('[data-field-local-id="local_2"]')
+        ?.getAttribute('data-selected'),
+    ).toBe('true')
+  })
+
+  it('keyboard boundary moves are disabled buttons (zero-entry no-op posture)', async () => {
+    const builder = await mountBuilder([field(1), field(2)])
+    expect(
+      (
+        builder.q(
+          '[data-testid="approval-form-builder-move-up-local_1"]',
+        ) as HTMLButtonElement
+      ).disabled,
+    ).toBe(true)
+    expect(
+      (
+        builder.q(
+          '[data-testid="approval-form-builder-move-down-local_2"]',
+        ) as HTMLButtonElement
+      ).disabled,
+    ).toBe(true)
+    expect(builder.vm.getSession().history.undoStack).toHaveLength(0)
+  })
+})
+
+// --- draft-change emission --------------------------------------------------
+
+describe('ApprovalFormBuilder — draft-change emission (FB-D4)', () => {
+  it('emits exactly one draft-change per value-changing command, none for rejections', async () => {
+    const builder = await mountBuilder([field(1), field(2)])
+    await builder.dropOnSlot(
+      'start',
+      payloadTransfer({ version: 1, kind: 'palette', fieldType: 'text' }),
+    )
+    expect(builder.draftChanges).toHaveLength(1)
+    expect(builder.draftChanges[0]![0].fields).toHaveLength(3)
+    // Rejected drop (foreign payload): no additional emission.
+    await builder.dropOnSlot('start', makeDataTransfer({ 'text/plain': 'x' }))
+    expect(builder.draftChanges).toHaveLength(1)
+  })
+})
+
+// --- no-production-mount pin (FB-D8) ----------------------------------------
+
+describe('F2 no-mount pin — production views do not import the new builder (FB-D8)', () => {
+  function collectViewSources(dir: string, out: string[] = []): string[] {
+    for (const entry of readdirSync(dir)) {
+      const full = join(dir, entry)
+      if (statSync(full).isDirectory()) {
+        collectViewSources(full, out)
+      } else if (/\.(vue|ts)$/.test(entry)) {
+        out.push(full)
+      }
+    }
+    return out
+  }
+
+  it('no file under src/views references ApprovalFormBuilder or ApprovalFormPalette (positive control: the F0 fallback IS imported)', () => {
+    const viewsDir = join(__dirname, '..', 'src', 'views')
+    const sources = collectViewSources(viewsDir)
+    expect(sources.length).toBeGreaterThan(10)
+    const offenders: string[] = []
+    let inlineEditorSeen = false
+    for (const file of sources) {
+      const text = readFileSync(file, 'utf8')
+      if (
+        text.includes('ApprovalFormBuilder') ||
+        text.includes('ApprovalFormPalette')
+      ) {
+        offenders.push(file)
+      }
+      if (text.includes('ApprovalFormInlineEditor')) inlineEditorSeen = true
+    }
+    expect(offenders).toEqual([])
+    // Positive control: the scan DOES see component imports — the extracted
+    // F0 fallback is mounted by TemplateAuthoringView on this baseline.
+    expect(inlineEditorSeen).toBe(true)
+  })
+})

--- a/apps/web/tests/approval-form-drag-payload.test.ts
+++ b/apps/web/tests/approval-form-drag-payload.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  APPROVAL_FORM_DRAG_MIME,
+  createApprovalFormDragSession,
+  dataTransferSignalsApprovalFormDrag,
+  decodeApprovalFormDragPayload,
+  encodeApprovalFormDragPayload,
+  readApprovalFormDragPayload,
+  writeApprovalFormDragPayload,
+  type ApprovalFormDragPayload,
+} from '../src/approvals/approvalFormDragPayload'
+import { AUTHORABLE_FIELD_TYPES } from '../src/approvals/templateAuthoring'
+
+/** Minimal DataTransfer double (jsdom has no DataTransfer constructor). */
+function makeDataTransfer(entries: Record<string, string> = {}) {
+  const store = new Map(Object.entries(entries))
+  return {
+    get types(): string[] {
+      return Array.from(store.keys())
+    },
+    setData(type: string, value: string): void {
+      store.set(type, String(value))
+    },
+    getData(type: string): string {
+      return store.get(type) ?? ''
+    },
+    effectAllowed: 'uninitialized',
+    dropEffect: 'none',
+  } as unknown as DataTransfer
+}
+
+describe('approvalFormDragPayload codec (delta §3.1)', () => {
+  it('round-trips both payload kinds for EVERY authorable field type (positive control)', () => {
+    for (const fieldType of AUTHORABLE_FIELD_TYPES) {
+      const payload: ApprovalFormDragPayload = {
+        version: 1,
+        kind: 'palette',
+        fieldType,
+      }
+      expect(
+        decodeApprovalFormDragPayload(encodeApprovalFormDragPayload(payload)),
+      ).toEqual(payload)
+    }
+    const move: ApprovalFormDragPayload = {
+      version: 1,
+      kind: 'field',
+      localId: 'fldloc_ab12',
+    }
+    expect(
+      decodeApprovalFormDragPayload(encodeApprovalFormDragPayload(move)),
+    ).toEqual(move)
+  })
+
+  it.each([
+    ['empty string', ''],
+    ['not JSON', 'text'],
+    ['bare field type string (legacy text/plain shape)', 'select'],
+    ['JSON array', '[]'],
+    ['JSON null', 'null'],
+    ['JSON string', '"select"'],
+    ['unknown version', JSON.stringify({ version: 2, kind: 'palette', fieldType: 'text' })],
+    ['missing version', JSON.stringify({ kind: 'palette', fieldType: 'text' })],
+    ['string version', JSON.stringify({ version: '1', kind: 'palette', fieldType: 'text' })],
+    ['unknown kind', JSON.stringify({ version: 1, kind: 'palette-field', fieldType: 'text' })],
+    ['prompt-divergent existing-field kind', JSON.stringify({ version: 1, kind: 'existing-field', localId: 'x' })],
+    ['extra property on palette', JSON.stringify({ version: 1, kind: 'palette', fieldType: 'text', label: '秘密' })],
+    ['extra property on field', JSON.stringify({ version: 1, kind: 'field', localId: 'x', index: 3 })],
+    ['missing fieldType', JSON.stringify({ version: 1, kind: 'palette' })],
+    ['non-authorable fieldType (attachment stays fail-closed)', JSON.stringify({ version: 1, kind: 'palette', fieldType: 'attachment' })],
+    ['unknown fieldType', JSON.stringify({ version: 1, kind: 'palette', fieldType: 'wormhole' })],
+    ['non-string localId', JSON.stringify({ version: 1, kind: 'field', localId: 7 })],
+    ['blank localId', JSON.stringify({ version: 1, kind: 'field', localId: '   ' })],
+    ['palette keys under field kind', JSON.stringify({ version: 1, kind: 'field', fieldType: 'text' })],
+  ])('strict decode rejects %s as null, never a command', (_name, raw) => {
+    expect(decodeApprovalFormDragPayload(raw)).toBeNull()
+  })
+
+  it('rejects a __proto__-carrying body (own extra key under JSON.parse)', () => {
+    // JSON.parse uses CreateDataProperty, so `__proto__` in the text becomes
+    // an OWN enumerable key — the exact-key-set check must reject it.
+    expect(
+      decodeApprovalFormDragPayload(
+        '{"version":1,"kind":"field","localId":"x","__proto__":{}}',
+      ),
+    ).toBeNull()
+  })
+
+  it('write() stores under the application MIME ONLY — no text/plain mirror', () => {
+    const dataTransfer = makeDataTransfer()
+    writeApprovalFormDragPayload(dataTransfer, {
+      version: 1,
+      kind: 'palette',
+      fieldType: 'user',
+    })
+    expect(Array.from(dataTransfer.types)).toEqual([APPROVAL_FORM_DRAG_MIME])
+    expect(dataTransfer.getData('text/plain')).toBe('')
+    expect(
+      decodeApprovalFormDragPayload(
+        dataTransfer.getData(APPROVAL_FORM_DRAG_MIME),
+      ),
+    ).toEqual({ version: 1, kind: 'palette', fieldType: 'user' })
+  })
+
+  it('read() NEVER consults text/plain: a foreign generic payload is not a command', () => {
+    // Foreign drag carrying a perfectly command-shaped JSON body — but under
+    // the generic type. Must decode to null.
+    const foreign = makeDataTransfer({
+      'text/plain': JSON.stringify({
+        version: 1,
+        kind: 'palette',
+        fieldType: 'text',
+      }),
+    })
+    expect(readApprovalFormDragPayload(foreign)).toBeNull()
+    // Positive control: the SAME body under the application MIME decodes.
+    const internal = makeDataTransfer({
+      [APPROVAL_FORM_DRAG_MIME]: JSON.stringify({
+        version: 1,
+        kind: 'palette',
+        fieldType: 'text',
+      }),
+    })
+    expect(readApprovalFormDragPayload(internal)).toEqual({
+      version: 1,
+      kind: 'palette',
+      fieldType: 'text',
+    })
+  })
+
+  it('read() handles a null dataTransfer and a throwing getData as null', () => {
+    expect(readApprovalFormDragPayload(null)).toBeNull()
+    const throwing = {
+      getData() {
+        throw new Error('denied')
+      },
+      types: [] as string[],
+    } as unknown as DataTransfer
+    expect(readApprovalFormDragPayload(throwing)).toBeNull()
+  })
+
+  it('dragover candidate signal is MIME-type presence, not content', () => {
+    expect(
+      dataTransferSignalsApprovalFormDrag(
+        makeDataTransfer({ [APPROVAL_FORM_DRAG_MIME]: '' }),
+      ),
+    ).toBe(true)
+    expect(
+      dataTransferSignalsApprovalFormDrag(
+        makeDataTransfer({ 'text/plain': 'text' }),
+      ),
+    ).toBe(false)
+    expect(dataTransferSignalsApprovalFormDrag(null)).toBe(false)
+  })
+})
+
+describe('approvalFormDragSession transient store (delta §3.1)', () => {
+  it('begin/active/clear transitions notify subscribers; clear is idempotent', () => {
+    const session = createApprovalFormDragSession()
+    const seen: (ApprovalFormDragPayload | null)[] = []
+    const unsubscribe = session.subscribe((active) => seen.push(active))
+    expect(session.active()).toBeNull()
+
+    const payload: ApprovalFormDragPayload = {
+      version: 1,
+      kind: 'field',
+      localId: 'fldloc_1',
+    }
+    session.begin(payload)
+    expect(session.active()).toEqual(payload)
+    session.clear()
+    expect(session.active()).toBeNull()
+    // Idempotent: a second clear does not re-notify.
+    session.clear()
+    expect(seen).toEqual([payload, null])
+
+    unsubscribe()
+    session.begin(payload)
+    expect(seen).toHaveLength(2)
+  })
+
+  it('positive control: a listener registered while active fires on the clear transition', () => {
+    const session = createApprovalFormDragSession()
+    session.begin({ version: 1, kind: 'palette', fieldType: 'date' })
+    const listener = vi.fn()
+    session.subscribe(listener)
+    session.clear()
+    expect(listener).toHaveBeenCalledTimes(1)
+    expect(listener).toHaveBeenCalledWith(null)
+  })
+})

--- a/apps/web/tests/approval-form-palette-chips.spec.ts
+++ b/apps/web/tests/approval-form-palette-chips.spec.ts
@@ -1,0 +1,195 @@
+/**
+ * F2 mounted palette spec (delta §3.1, Gate F2) — the NEW Designer 2.0
+ * `ApprovalFormPalette.vue` (FB-D8: separate from the extracted flag-OFF
+ * `ApprovalFormInlineEditor` fallback; no production mount until F4).
+ * Mount pattern: repo-standard `createApp` + real DOM events (no test-utils).
+ */
+import { afterEach, describe, expect, it } from 'vitest'
+import { createApp, h, nextTick, reactive, type App as VueApp } from 'vue'
+
+import ApprovalFormPalette, {
+  APPROVAL_FORM_FIELD_TYPE_LABELS,
+  APPROVAL_FORM_PALETTE_GROUPS,
+} from '../src/approvals/components/ApprovalFormPalette.vue'
+import {
+  APPROVAL_FORM_DRAG_MIME,
+  createApprovalFormDragSession,
+  decodeApprovalFormDragPayload,
+  type ApprovalFormDragSession,
+} from '../src/approvals/approvalFormDragPayload'
+import {
+  AUTHORABLE_FIELD_TYPES,
+  type AuthorableFieldType,
+} from '../src/approvals/templateAuthoring'
+
+function makeDataTransfer(entries: Record<string, string> = {}) {
+  const store = new Map(Object.entries(entries))
+  return {
+    get types(): string[] {
+      return Array.from(store.keys())
+    },
+    setData(type: string, value: string): void {
+      store.set(type, String(value))
+    },
+    getData(type: string): string {
+      return store.get(type) ?? ''
+    },
+    effectAllowed: 'uninitialized',
+    dropEffect: 'none',
+  } as unknown as DataTransfer
+}
+
+function dispatchDrag(
+  el: Element,
+  type: string,
+  dataTransfer: DataTransfer | null = null,
+): void {
+  const event = new Event(type, { bubbles: true, cancelable: true })
+  Object.defineProperty(event, 'dataTransfer', { value: dataTransfer })
+  el.dispatchEvent(event)
+}
+
+let app: VueApp<Element> | null = null
+let container: HTMLDivElement | null = null
+
+interface PaletteHarness {
+  state: { readOnly: boolean }
+  appended: AuthorableFieldType[]
+  chip(type: string): HTMLButtonElement
+}
+
+async function mountPalette(
+  options: { readOnly?: boolean; dragSession?: ApprovalFormDragSession } = {},
+): Promise<PaletteHarness> {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  const state = reactive({ readOnly: options.readOnly ?? false })
+  const appended: AuthorableFieldType[] = []
+  app = createApp({
+    setup() {
+      return () =>
+        h(ApprovalFormPalette, {
+          readOnly: state.readOnly,
+          dragSession: options.dragSession,
+          onAppendField: (type: AuthorableFieldType) => {
+            appended.push(type)
+          },
+        })
+    },
+  })
+  app.mount(container)
+  await nextTick()
+  return {
+    state,
+    appended,
+    chip(type: string) {
+      const el = container!.querySelector(
+        `[data-testid="approval-form-palette-chip-${type}"]`,
+      )
+      if (!el) throw new Error(`chip ${type} not rendered`)
+      return el as HTMLButtonElement
+    },
+  }
+}
+
+afterEach(() => {
+  app?.unmount()
+  container?.remove()
+  app = null
+  container = null
+})
+
+describe('ApprovalFormPalette (F2)', () => {
+  it('pins the shipped-shell grouping: every authorable type once, same groups/labels', () => {
+    const groupedTypes = APPROVAL_FORM_PALETTE_GROUPS.flatMap((group) =>
+      group.entries.map((entry) => entry.type),
+    )
+    expect([...groupedTypes].sort()).toEqual([...AUTHORABLE_FIELD_TYPES].sort())
+    expect(groupedTypes).toHaveLength(new Set(groupedTypes).size)
+    // Same group ids/labels as the shipped #4917 shell in TemplateAuthoringView.
+    expect(
+      APPROVAL_FORM_PALETTE_GROUPS.map((group) => [group.id, group.label]),
+    ).toEqual([
+      ['text', '文本'],
+      ['number', '数值'],
+      ['choice', '选项'],
+      ['date', '日期'],
+      ['other', '其他'],
+    ])
+    expect(APPROVAL_FORM_FIELD_TYPE_LABELS.text).toBe('文本')
+    expect(APPROVAL_FORM_FIELD_TYPE_LABELS['record-link']).toBe('关联记录')
+  })
+
+  it('renders one keyboard-operable button chip per authorable type', async () => {
+    const palette = await mountPalette()
+    for (const type of AUTHORABLE_FIELD_TYPES) {
+      const chip = palette.chip(type)
+      // Native buttons: Enter/Space activation is complete without drag (FB-D2).
+      expect(chip.tagName).toBe('BUTTON')
+      expect(chip.getAttribute('draggable')).toBe('true')
+      expect(chip.textContent).toContain(APPROVAL_FORM_FIELD_TYPE_LABELS[type])
+    }
+  })
+
+  it('click emits ONE append-field intent per type — the palette never mutates a draft', async () => {
+    const palette = await mountPalette()
+    for (const type of AUTHORABLE_FIELD_TYPES) {
+      palette.chip(type).click()
+    }
+    expect(palette.appended).toEqual([...AUTHORABLE_FIELD_TYPES])
+  })
+
+  it('dragstart writes the typed codec payload for EVERY type and begins the shared session; dragend clears', async () => {
+    const dragSession = createApprovalFormDragSession()
+    const palette = await mountPalette({ dragSession })
+    for (const type of AUTHORABLE_FIELD_TYPES) {
+      const dataTransfer = makeDataTransfer()
+      const chip = palette.chip(type)
+      dispatchDrag(chip, 'dragstart', dataTransfer)
+      // Application MIME only — never a text/plain command mirror (§3.1).
+      expect(Array.from(dataTransfer.types)).toEqual([APPROVAL_FORM_DRAG_MIME])
+      expect(
+        decodeApprovalFormDragPayload(
+          dataTransfer.getData(APPROVAL_FORM_DRAG_MIME),
+        ),
+      ).toEqual({ version: 1, kind: 'palette', fieldType: type })
+      expect(dragSession.active()).toEqual({
+        version: 1,
+        kind: 'palette',
+        fieldType: type,
+      })
+      dispatchDrag(chip, 'dragend')
+      expect(dragSession.active()).toBeNull()
+    }
+  })
+
+  it('read-only mode renders NO chips (no draggable palette, §3.1) and the readOnly transition clears an in-flight drag', async () => {
+    const dragSession = createApprovalFormDragSession()
+    const palette = await mountPalette({ dragSession })
+    dispatchDrag(palette.chip('text'), 'dragstart', makeDataTransfer())
+    expect(dragSession.active()).not.toBeNull()
+
+    palette.state.readOnly = true
+    await nextTick()
+    expect(dragSession.active()).toBeNull()
+    expect(container!.querySelector('[draggable="true"]')).toBeNull()
+    expect(
+      container!.querySelector('[data-testid="approval-form-palette-chip-text"]'),
+    ).toBeNull()
+    expect(
+      container!.querySelector(
+        '[data-testid="approval-form-palette-readonly"]',
+      )?.textContent,
+    ).toContain('只读')
+  })
+
+  it('unmount (route change) clears the shared transient drag session', async () => {
+    const dragSession = createApprovalFormDragSession()
+    const palette = await mountPalette({ dragSession })
+    dispatchDrag(palette.chip('user'), 'dragstart', makeDataTransfer())
+    expect(dragSession.active()).not.toBeNull()
+    app!.unmount()
+    app = null
+    expect(dragSession.active()).toBeNull()
+  })
+})

--- a/apps/web/tests/ui-foundation-style-guard.spec.ts
+++ b/apps/web/tests/ui-foundation-style-guard.spec.ts
@@ -33,6 +33,10 @@ const TARGET_FILES = [
   // F0 (docs/development/approval-form-builder-parity-delta-design-20260811.md §5 F0): extracted
   // from the already-token-only TemplateAuthoringView.vue verbatim, so it starts clean too.
   'src/approvals/components/ApprovalFormInlineEditor.vue',
+  // F2 (same delta §5 F2 / §6 rules): the NEW Designer 2.0 palette + builder join the UF-6
+  // target set in their introducing slice, born token-only (var(--el-*) exclusively).
+  'src/approvals/components/ApprovalFormPalette.vue',
+  'src/approvals/components/ApprovalFormBuilder.vue',
   'src/views/AutomationExecutionsView.vue',
   'src/views/WorkflowHubView.vue',
   'src/views/WorkflowDesigner.vue',

--- a/apps/web/verification/approval-form-builder-harness.html
+++ b/apps/web/verification/approval-form-builder-harness.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<html>
+  <head><meta charset="utf-8" /><title>Approval form builder — browser verification harness (F2)</title></head>
+  <body style="margin:16px;font-family:system-ui">
+    <h3>Approval form builder — exact insertion slots + typed drag codec (F2)</h3>
+    <div id="app" style="display:grid;grid-template-columns:240px minmax(420px,1fr);gap:16px;max-width:960px"></div>
+    <script type="module" src="./approval-form-builder-harness.ts"></script>
+  </body>
+</html>

--- a/apps/web/verification/approval-form-builder-harness.ts
+++ b/apps/web/verification/approval-form-builder-harness.ts
@@ -1,0 +1,140 @@
+// Browser-verification harness for the F2 Designer 2.0 form builder (delta §5
+// F2 / §7.1 item 7 owned harness). Mounts the REAL ApprovalFormPalette +
+// ApprovalFormBuilder with one shared transient drag session (exactly the F4
+// composition shape) and publishes bounded, VALUES-FREE metrics for Playwright:
+// field types in order, slot/history counts, drag-state, and the status copy.
+// No persistent ids, labels, or draft values are exported.
+import { createApp, h, ref } from 'vue'
+import ApprovalFormBuilder, {
+  STALE_SLOT_RETRY_MESSAGE,
+} from '../src/approvals/components/ApprovalFormBuilder.vue'
+import ApprovalFormPalette from '../src/approvals/components/ApprovalFormPalette.vue'
+import {
+  APPROVAL_FORM_DRAG_MIME,
+  createApprovalFormDragSession,
+} from '../src/approvals/approvalFormDragPayload'
+import type { FormAuthoringSession } from '../src/approvals/approvalFormAuthoringAdapter'
+import {
+  createEmptyFieldDraft,
+  createEmptyStepDraft,
+  createEmptyTemplateDraft,
+  type AuthorableFieldType,
+  type FieldAuthoringDraft,
+  type TemplateAuthoringDraft,
+} from '../src/approvals/templateAuthoring'
+
+interface AfbState {
+  /** Field types in canvas order — from the SESSION (sync source of truth). */
+  order: string[]
+  /** Field types in canvas order — from the rendered DOM. */
+  domOrder: (string | null)[]
+  slotCount: number
+  historyDepth: number
+  statusText: string
+  activeDragKind: 'palette' | 'field' | null
+  readOnly: boolean
+}
+
+interface AfbHarnessApi {
+  ready: true
+  /** The application drag MIME — asserted against the spec's literal. */
+  mime: string
+  staleRetryMessage: string
+  state(): AfbState
+  /** Adapter-backed removal of the field at list index 1 (stale-anchor setup). */
+  removeSecondField(): boolean
+  setReadOnly(value: boolean): void
+}
+
+declare global {
+  interface Window {
+    __AFB__?: AfbHarnessApi
+  }
+}
+
+interface BuilderExposed {
+  appendField(type: AuthorableFieldType): boolean
+  removeField(localId: string): boolean
+  getSession(): FormAuthoringSession
+}
+
+function field(
+  index: number,
+  type: AuthorableFieldType,
+): FieldAuthoringDraft {
+  return {
+    ...createEmptyFieldDraft(index),
+    localId: `local_${index}`,
+    id: `field_${index}`,
+    type,
+    label: `字段 ${index}`,
+  }
+}
+
+const draft: TemplateAuthoringDraft = {
+  ...createEmptyTemplateDraft(),
+  key: 'afb_harness',
+  name: '表单构建器验证',
+  fields: [field(1, 'text'), field(2, 'number'), field(3, 'date')],
+  steps: [createEmptyStepDraft(1)],
+}
+
+const dragSession = createApprovalFormDragSession()
+const builderRef = ref<BuilderExposed | null>(null)
+const readOnly = ref(false)
+
+createApp({
+  setup() {
+    return () => [
+      h(ApprovalFormPalette, {
+        readOnly: readOnly.value,
+        dragSession,
+        onAppendField: (type: AuthorableFieldType) => {
+          builderRef.value?.appendField(type)
+        },
+      }),
+      h(ApprovalFormBuilder, {
+        draft,
+        readOnly: readOnly.value,
+        dragSession,
+        ref: builderRef,
+      }),
+    ]
+  },
+}).mount('#app')
+
+window.__AFB__ = {
+  ready: true,
+  mime: APPROVAL_FORM_DRAG_MIME,
+  staleRetryMessage: STALE_SLOT_RETRY_MESSAGE,
+  state(): AfbState {
+    const session = builderRef.value!.getSession()
+    return {
+      order: session.draft.fields.map((entry) => entry.type),
+      domOrder: Array.from(
+        document.querySelectorAll(
+          '[data-testid="approval-form-builder-card"]',
+        ),
+      ).map((card) => card.getAttribute('data-field-type')),
+      slotCount: document.querySelectorAll('.approval-form-builder__slot')
+        .length,
+      historyDepth: session.history.undoStack.length,
+      statusText:
+        document.querySelector(
+          '[data-testid="approval-form-builder-status"]',
+        )?.textContent ?? '',
+      activeDragKind: dragSession.active()?.kind ?? null,
+      readOnly: readOnly.value,
+    }
+  },
+  removeSecondField(): boolean {
+    const session = builderRef.value!.getSession()
+    const second = session.draft.fields[1]
+    if (!second) return false
+    return builderRef.value!.removeField(second.localId)
+  },
+  setReadOnly(value: boolean): void {
+    readOnly.value = value
+  },
+}
+window.dispatchEvent(new Event('afb-ready'))

--- a/apps/web/verification/approval-form-builder-parity.spec.ts
+++ b/apps/web/verification/approval-form-builder-parity.spec.ts
@@ -1,0 +1,326 @@
+// F2 real-browser verification (delta §5 F2, §7.1 item 7, §7.2 B2/B3/B5
+// subset): exact insertion-slot placement via REAL DataTransfer drags,
+// cancelled-drag no-ops (Escape + drop-outside), strict codec rejection of
+// foreign/malformed payloads, and the stale-anchor values-free no-op — all
+// asserted from DOM/session evidence, screenshots as supporting artifacts.
+// The full B1-B12 width matrix runs in F4 on the assembled head.
+import { test, expect, type Page } from '@playwright/test'
+import { mkdirSync } from 'node:fs'
+
+const OUT = 'verification-output'
+const HARNESS = '/verification/approval-form-builder-harness.html'
+// Pinned literal, asserted against the runtime module's exported constant so
+// codec drift cannot silently decouple this spec from production.
+const MIME = 'application/x-metasheet-approval-form'
+
+interface AfbState {
+  order: string[]
+  domOrder: (string | null)[]
+  slotCount: number
+  historyDepth: number
+  statusText: string
+  activeDragKind: 'palette' | 'field' | null
+  readOnly: boolean
+}
+
+async function state(page: Page): Promise<AfbState> {
+  return await page.evaluate(() => window.__AFB__!.state())
+}
+
+async function settled(page: Page): Promise<AfbState> {
+  // The session mutates synchronously; wait until the DOM re-render caught up.
+  await page.waitForFunction(() => {
+    const current = window.__AFB__!.state()
+    return (
+      current.domOrder.length === current.order.length &&
+      current.domOrder.every((entry, index) => entry === current.order[index])
+    )
+  })
+  return await state(page)
+}
+
+/** Real-DataTransfer drag from a palette chip onto slot `slotIndex`. */
+async function dragChipToSlot(
+  page: Page,
+  chipType: string,
+  slotIndex: number,
+): Promise<void> {
+  await page.evaluate(
+    ({ chipType, slotIndex }) => {
+      const chip = document.querySelector(
+        `[data-testid="approval-form-palette-chip-${chipType}"]`,
+      )!
+      const dataTransfer = new DataTransfer()
+      chip.dispatchEvent(
+        new DragEvent('dragstart', {
+          bubbles: true,
+          cancelable: true,
+          dataTransfer,
+        }),
+      )
+      const slot = document.querySelectorAll('.approval-form-builder__slot')[
+        slotIndex
+      ]!
+      slot.dispatchEvent(
+        new DragEvent('dragover', {
+          bubbles: true,
+          cancelable: true,
+          dataTransfer,
+        }),
+      )
+      slot.dispatchEvent(
+        new DragEvent('drop', {
+          bubbles: true,
+          cancelable: true,
+          dataTransfer,
+        }),
+      )
+      chip.dispatchEvent(
+        new DragEvent('dragend', {
+          bubbles: true,
+          cancelable: true,
+          dataTransfer,
+        }),
+      )
+    },
+    { chipType, slotIndex },
+  )
+}
+
+test.beforeEach(async ({ page }) => {
+  mkdirSync(OUT, { recursive: true })
+  await page.goto(HARNESS, { waitUntil: 'domcontentloaded' })
+  await page.waitForFunction(() => window.__AFB__?.ready === true)
+})
+
+test('harness pins: codec MIME and initial N+1 slot render', async ({
+  page,
+}) => {
+  const errs: string[] = []
+  page.on('console', (m) => {
+    if (m.type() === 'error') errs.push(`console: ${m.text()}`)
+  })
+  page.on('pageerror', (e) => errs.push(`pageerror: ${String(e)}`))
+
+  expect(await page.evaluate(() => window.__AFB__!.mime)).toBe(MIME)
+  const initial = await settled(page)
+  expect(initial.order).toEqual(['text', 'number', 'date'])
+  expect(initial.slotCount).toBe(4) // N+1
+  expect(initial.historyDepth).toBe(0)
+  expect(initial.statusText).toBe('')
+  await page.screenshot({ path: `${OUT}/afb-initial.png`, fullPage: true })
+  expect(errs, `console/page errors:\n${errs.join('\n')}`).toEqual([])
+})
+
+test('B2/B3 — real DataTransfer drags place at the EXACT start/middle/end slots', async ({
+  page,
+}) => {
+  // Start slot (index 0): prepend.
+  await dragChipToSlot(page, 'select', 0)
+  let current = await settled(page)
+  expect(current.order).toEqual(['select', 'text', 'number', 'date'])
+  expect(current.slotCount).toBe(5)
+  expect(current.historyDepth).toBe(1)
+  expect(current.activeDragKind).toBeNull() // drop + dragend cleared
+
+  // Middle slot (index 2 = after the 2nd field): exact between placement.
+  await dragChipToSlot(page, 'user', 2)
+  current = await settled(page)
+  expect(current.order).toEqual(['select', 'text', 'user', 'number', 'date'])
+  expect(current.historyDepth).toBe(2)
+
+  // End slot (last index): exact append.
+  await dragChipToSlot(page, 'textarea', current.slotCount - 1)
+  current = await settled(page)
+  expect(current.order).toEqual([
+    'select',
+    'text',
+    'user',
+    'number',
+    'date',
+    'textarea',
+  ])
+  expect(current.historyDepth).toBe(3)
+  await page.screenshot({ path: `${OUT}/afb-after-drags.png`, fullPage: true })
+})
+
+test('B5 — cancelled drag: Escape clears transient state with ZERO mutation', async ({
+  page,
+}) => {
+  await page.evaluate(() => {
+    const chip = document.querySelector(
+      '[data-testid="approval-form-palette-chip-date"]',
+    )!
+    chip.dispatchEvent(
+      new DragEvent('dragstart', {
+        bubbles: true,
+        cancelable: true,
+        dataTransfer: new DataTransfer(),
+      }),
+    )
+  })
+  expect((await state(page)).activeDragKind).toBe('palette')
+  await expect(
+    page.locator('[data-testid="approval-form-builder"]'),
+  ).toHaveAttribute('data-drag-active', 'true')
+
+  await page.keyboard.press('Escape')
+  await expect(
+    page.locator('[data-testid="approval-form-builder"]'),
+  ).not.toHaveAttribute('data-drag-active', 'true')
+  const after = await settled(page)
+  expect(after.activeDragKind).toBeNull()
+  expect(after.order).toEqual(['text', 'number', 'date'])
+  expect(after.historyDepth).toBe(0)
+})
+
+test('B5 — drop OUTSIDE any slot is a no-op that still clears drag state', async ({
+  page,
+}) => {
+  await page.evaluate(() => {
+    const chip = document.querySelector(
+      '[data-testid="approval-form-palette-chip-select"]',
+    )!
+    const dataTransfer = new DataTransfer()
+    chip.dispatchEvent(
+      new DragEvent('dragstart', {
+        bubbles: true,
+        cancelable: true,
+        dataTransfer,
+      }),
+    )
+    // Canvas background, not a slot.
+    document
+      .querySelector('[data-testid="approval-form-builder"]')!
+      .dispatchEvent(
+        new DragEvent('drop', {
+          bubbles: true,
+          cancelable: true,
+          dataTransfer,
+        }),
+      )
+  })
+  const after = await settled(page)
+  expect(after.activeDragKind).toBeNull()
+  expect(after.order).toEqual(['text', 'number', 'date'])
+  expect(after.historyDepth).toBe(0)
+})
+
+test('B5 — foreign/malformed payloads are rejected; positive control mutates', async ({
+  page,
+}) => {
+  await page.evaluate((mime) => {
+    const slot = document.querySelectorAll('.approval-form-builder__slot')[0]!
+    const drop = (dataTransfer: DataTransfer) =>
+      slot.dispatchEvent(
+        new DragEvent('drop', {
+          bubbles: true,
+          cancelable: true,
+          dataTransfer,
+        }),
+      )
+    // text/plain foreign payloads — bare type AND command-shaped JSON.
+    let dt = new DataTransfer()
+    dt.setData('text/plain', 'select')
+    drop(dt)
+    dt = new DataTransfer()
+    dt.setData(
+      'text/plain',
+      JSON.stringify({ version: 1, kind: 'palette', fieldType: 'select' }),
+    )
+    drop(dt)
+    // Malformed JSON under the application MIME.
+    dt = new DataTransfer()
+    dt.setData(mime, '{oops')
+    drop(dt)
+    // Unknown kind under the application MIME.
+    dt = new DataTransfer()
+    dt.setData(
+      mime,
+      JSON.stringify({ version: 1, kind: 'palette-field', fieldType: 'text' }),
+    )
+    drop(dt)
+  }, MIME)
+  let current = await settled(page)
+  expect(current.order).toEqual(['text', 'number', 'date'])
+  expect(current.historyDepth).toBe(0)
+
+  // Positive control: a well-formed payload under the app MIME on the SAME slot.
+  await page.evaluate((mime) => {
+    const slot = document.querySelectorAll('.approval-form-builder__slot')[0]!
+    const dataTransfer = new DataTransfer()
+    dataTransfer.setData(
+      mime,
+      JSON.stringify({ version: 1, kind: 'palette', fieldType: 'select' }),
+    )
+    slot.dispatchEvent(
+      new DragEvent('drop', { bubbles: true, cancelable: true, dataTransfer }),
+    )
+  }, MIME)
+  current = await settled(page)
+  expect(current.order).toEqual(['select', 'text', 'number', 'date'])
+  expect(current.historyDepth).toBe(1)
+})
+
+test('B5 — stale anchor: drop on a slot whose anchor field was just removed is a values-free no-op', async ({
+  page,
+}) => {
+  const removed = await page.evaluate((mime) => {
+    // Capture the slot bound to {after, <2nd field>} BEFORE the removal, then
+    // drop before the re-render lands — the genuine staleness window.
+    const staleSlot = document.querySelectorAll(
+      '.approval-form-builder__slot',
+    )[2]!
+    const ok = window.__AFB__!.removeSecondField()
+    const dataTransfer = new DataTransfer()
+    dataTransfer.setData(
+      mime,
+      JSON.stringify({ version: 1, kind: 'palette', fieldType: 'select' }),
+    )
+    staleSlot.dispatchEvent(
+      new DragEvent('drop', { bubbles: true, cancelable: true, dataTransfer }),
+    )
+    return ok
+  }, MIME)
+  expect(removed).toBe(true)
+  const after = await settled(page)
+  // Only the removal landed; the stale drop inserted nothing.
+  expect(after.order).toEqual(['text', 'date'])
+  expect(after.historyDepth).toBe(1)
+  const staleMessage = await page.evaluate(
+    () => window.__AFB__!.staleRetryMessage,
+  )
+  expect(after.statusText).toBe(staleMessage)
+  // Values-free: the copy names no field ids/labels/values.
+  expect(staleMessage).not.toMatch(/local_|field_|字段 \d/)
+  await page.screenshot({ path: `${OUT}/afb-stale-anchor.png`, fullPage: true })
+})
+
+test('B8 — read-only transition clears drag state and removes all drop targets', async ({
+  page,
+}) => {
+  await page.evaluate(() => {
+    const chip = document.querySelector(
+      '[data-testid="approval-form-palette-chip-text"]',
+    )!
+    chip.dispatchEvent(
+      new DragEvent('dragstart', {
+        bubbles: true,
+        cancelable: true,
+        dataTransfer: new DataTransfer(),
+      }),
+    )
+    window.__AFB__!.setReadOnly(true)
+  })
+  await page.waitForFunction(
+    () => window.__AFB__!.state().slotCount === 0,
+  )
+  const after = await state(page)
+  expect(after.activeDragKind).toBeNull()
+  expect(after.order).toEqual(['text', 'number', 'date'])
+  expect(
+    await page
+      .locator('[data-testid="approval-form-palette-chip-text"]')
+      .count(),
+  ).toBe(0)
+})


### PR DESCRIPTION
Implements slice **F2** of the RATIFIED approval form-builder parity delta (`docs/development/approval-form-builder-parity-delta-design-20260811.md` §5 F2, governed by FB-D1/D2/D3/D4/D8, §3.1-§3.3), on top of F0 (#4939) and F1 (#4942). Standalone until F4: **no production mount** — the FB-D8 no-mount pin test proves no `src/views` file imports the new builder/palette (positive control: the F0 `ApprovalFormInlineEditor` fallback IS imported).

## What lands

**Typed drag codec — `apps/web/src/approvals/approvalFormDragPayload.ts` (pure)**
- ONE application-specific MIME `application/x-metasheet-approval-form` for both payload kinds (delta §3.1: `{version:1, kind:'palette', fieldType}` | `{version:1, kind:'field', localId}`).
- Strict structured decode: unknown version/kind, extra/missing keys, non-allowlisted `fieldType` (incl. `attachment`, which stays fail-closed), blank `localId`, non-JSON → `null`, never a command. `readApprovalFormDragPayload` never consults `text/plain`.
- `ApprovalFormDragSession` transient store with explicit `clear()`; §3.1 clearing wired to all five triggers: drop (success AND failure, on-slot or outside), dragend, Escape, route change (unmount), read-only transition.

**`ApprovalFormPalette.vue` (NEW, Designer 2.0)** — grouped chips reusing the shipped #4917 shell's grouping/labels/marks (pinned by test); click emits the append intent, dragstart writes the codec payload + begins the shared session; chips are native buttons (keyboard-complete per FB-D2); read-only renders no draggable palette.

**`ApprovalFormBuilder.vue` (NEW center canvas, SEPARATE from the F0 fallback)**
- **N+1 explicit insertion slots** (start/between/end), each carrying its render-bound semantic anchor; the adapter/command re-resolves it against the CURRENT draft immediately before mutation (FB-D3). Stale anchor → values-free no-op with pinned retry copy `插入位置已变化，本次操作未执行，请重试。` — never an index or append fallback.
- Drop on slot k → adapter `addField(type, anchor)` for palette payloads / `moveField(localId, target, placement)` for existing-field payloads; visual drop-target affordance during candidate `dragover` (MIME presence only, content validated at drop).
- Slot click/Enter opens a type menu that runs the SAME add command at that slot; palette click-append, slot insert, drag, and 上移/下移 all converge on the ONE `approvalFormAuthoringAdapter` (FB-D4) — proven identical draft + identical single history entry via a deterministic identity seam.
- Move handle (not the whole card) initiates existing-field drag (§3.3); read-only renders no slots/handles/move buttons.

**Browser harness (owned, real Chromium)** — `apps/web/verification/approval-form-builder-harness.{html,ts}` + `approval-form-builder-parity.spec.ts` + `apps/web/playwright.approval-verification.config.ts` (own Vite webServer, port 5175, disjoint from the multitable lane; the multitable config now `testIgnore`s this spec so the lanes cannot red each other). Real-`DataTransfer` drags assert: exact start/middle/end placement, Escape + drop-outside cancelled-drag no-ops, foreign/malformed payload rejection with positive control, stale-anchor no-op, read-only transition.

**NEW workflow `.github/workflows/approval-browser-verify.yml`** — **non-required**. Per delta §7.1 item 8, adding it to branch protection is an **owner step** before the F4 merge; until that owner action is visible this lane's evidence is exact-head but not described as required.

**CI two-point wiring (same PR, master-lock M2/M3 rule)** — the three new spec tokens (`approval-form-drag-payload`, `approval-form-palette-chips`, `approval-form-builder-slots`) are added to `apps/web/scripts/run-required-web-tests.sh` AND `approval-web-guard.yml` (both path blocks + the canary run step). Each token verified to match exactly ONE file in isolation (deliberate non-collisions with `approval-form-draft` / `approval-form-palette-focus` documented in the script). The palette + builder join the UF-6 `ui-foundation-style-guard` TARGET_FILES (delta §6 rule). `plugin-tests.yml` untouched.

## Verification (this head)

- `pnpm --filter @metasheet/web exec vue-tsc --noEmit` — clean.
- Full `run-required-web-tests.sh` — green: 16 files / 197 tests (canary block incl. new specs), then 1/14, 2/21, 2/28, and 362 files / **4391 tests** final batch. New specs: 27 (codec) + 6 (palette) + 30 (builder) = **63 tests**.
- `pnpm --filter @metasheet/web build` — green.
- Approval browser lane run locally in real Chromium: **7/7 passed** (`playwright test --config playwright.approval-verification.config.ts`).
- `git diff --check` clean.

## Self-run discriminating mutations (each restored byte-identical via `cmp`)

| Mutation | Result |
|---|---|
| (i) slot drop ignores the anchor and appends | RED ×4: start-slot exactness, middle-slot exactness, stale-anchor, click/drag equivalence |
| (ii) codec falls back to `text/plain` | RED ×2: codec foreign-payload test + mounted builder foreign-payload test |
| (iii) Escape handler skips `clear()` | RED ×1: trigger-3 Escape clearing test |

## Divergences from the tasking prompt (delta doc wins)

1. **Payload kind names**: prompt suggested `palette-field`/`existing-field`; delta §3.1 specifies `kind:'palette'` / `kind:'field'` — the doc's shape is implemented (the prompt's variant is even pinned as a decode NEGATIVE).
2. **MIME name**: prompt example was `application/x-metasheet-form-palette`; since §3.1 mandates ONE application MIME covering palette AND existing-field payloads, the neutral `application/x-metasheet-approval-form` is used.
3. **UF-6 additions**: the prompt's DELIVER list omits them, but delta §5 F2 expected files + §6 require the palette/builder to join `ui-foundation-style-guard.spec.ts` in this slice — included.
4. **No `@vue/test-utils`**: the repo has no such dependency and delta §8 forbids new ones; mounted specs use the repo-standard `createApp` + real-DOM-event pattern (same as the F0 extraction spec).
5. **Route-change clearing** is implemented as unmount clearing (navigation unmounts the standalone builder/palette; F4 owns any additional view-level route hooks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
