### PR TITLE
feat(approval): K2 — requester_choice assignee kind (Lock-1 §K2)

### DIFF
--- a/.github/workflows/approval-realdb-acceptance.yml
+++ b/.github/workflows/approval-realdb-acceptance.yml
@@ -1,0 +1,132 @@
+name: Approval real-DB acceptance (Lock-1 assignee kinds)
+
+# EVIDENCE LANE for the Lock-1 §K2 `requester_choice` real-DB acceptance suite
+# (tests/integration/approval-requester-choice.db.test.ts — G-8/G-9/G-17/G-18 with their
+# positive controls). Ephemeral first-party PostgreSQL container; no customer source, no
+# deployment, no flag change.
+#
+# WHY A STANDALONE FILE, not a plugin-tests.yml allowlist entry (PR #4952 gate, P2-1):
+# plugin-tests.yml is an s6a sha256-pinned provenance input
+# (sealed-export-package-provenance.cjs PINNED_EVIDENCE_FILES), so every edit forces an
+# s6a re-pin and a merge-serialisation race. sealed-export-s6a-authority-row-lock.yml
+# documents choosing a separate workflow file for exactly this rationale and is the
+# in-repo precedent this file is modeled on. plugin-tests.yml is left byte-identical.
+#
+# TWO-POINT WIRING (the other half): the suite is excluded from the no-DB default vitest
+# config (packages/core-backend/vitest.config.ts) in the SAME commit that adds this file,
+# so the required `test (18.x/20.x)` job no longer collect-and-skip-greens it. This
+# workflow is where the suite actually EXECUTES, with EXPECT_DB=1 arming the suite's
+# top-level anti-skip-green sentinel: a run in this lane with a missing/broken
+# DATABASE_URL goes RED instead of silently reporting 13 skipped tests.
+
+on:
+  workflow_dispatch:
+  pull_request:
+    # No `branches:` filter, mirroring the s6a precedent: a brand-new workflow cannot be
+    # workflow_dispatch-ed until it has run once via a trigger it responds to, and a
+    # stacked-base PR would silently skip a branch-filtered trigger. The `paths` filter
+    # keeps it off unrelated PRs.
+    paths:
+      - 'packages/core-backend/tests/integration/approval-requester-choice.db.test.ts'
+      - 'packages/core-backend/tests/helpers/approval-schema-bootstrap.ts'
+      - 'packages/core-backend/src/services/ApprovalProductService.ts'
+      - 'packages/core-backend/src/services/ApprovalAssigneeResolver.ts'
+      - 'packages/core-backend/src/services/ApprovalGraphExecutor.ts'
+      - 'packages/core-backend/src/services/approval-directory.ts'
+      - 'packages/core-backend/src/routes/approvals.ts'
+      - 'packages/core-backend/src/types/approval-product.ts'
+      - '.github/workflows/approval-realdb-acceptance.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'packages/core-backend/tests/integration/approval-requester-choice.db.test.ts'
+      - 'packages/core-backend/tests/helpers/approval-schema-bootstrap.ts'
+      - 'packages/core-backend/src/services/ApprovalProductService.ts'
+      - 'packages/core-backend/src/services/ApprovalAssigneeResolver.ts'
+      - 'packages/core-backend/src/services/ApprovalGraphExecutor.ts'
+      - 'packages/core-backend/src/services/approval-directory.ts'
+      - 'packages/core-backend/src/routes/approvals.ts'
+      - 'packages/core-backend/src/types/approval-product.ts'
+      - '.github/workflows/approval-realdb-acceptance.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  approval-realdb-k2:
+    name: approval-realdb-k2
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: metasheet_approval_realdb
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d metasheet_approval_realdb"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 20
+    env:
+      DATABASE_URL: postgresql://postgres:postgres@127.0.0.1:5432/metasheet_approval_realdb
+      # Arms the suite's top-level sentinel: in THIS lane a missing DATABASE_URL is a
+      # red run, never a silent 13-tests-skipped green.
+      EXPECT_DB: '1'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js 20.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.16.1
+          run_install: false
+
+      - name: Use empty npmrc for pnpm
+        run: |
+          echo "" > /tmp/empty-npmrc
+          echo "NPM_CONFIG_USERCONFIG=/tmp/empty-npmrc" >> "$GITHUB_ENV"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run DB migrations
+        env:
+          # Same per-PR-gate exclusion list as plugin-tests.yml's "Run DB migrations" step
+          # (see the T8 note there and packages/core-backend/MIGRATION_EXCLUDE_TRACKING.md
+          # for the per-item detail) — this lane provisions the identical schema the
+          # approval real-DB steps run against.
+          MIGRATION_EXCLUDE: 008_plugin_infrastructure.sql,048_create_event_bus_tables.sql,049_create_bpmn_workflow_tables.sql,042a_core_model_views.sql,20250924140000_create_gantt_tables.ts,20250925_create_view_tables.sql
+        run: pnpm --filter @metasheet/core-backend db:migrate
+
+      - name: Run Lock-1 §K2 requester_choice real-DB acceptance (whole file)
+        # WHOLE FILE, --reporter=verbose: a name filter matching zero tests would exit
+        # green and hide regressions; verbose prints every collected test so an empty
+        # collection shows in the log instead of reading as green.
+        run: >-
+          pnpm --filter @metasheet/core-backend exec vitest
+          --config vitest.integration.config.ts run
+          tests/integration/approval-requester-choice.db.test.ts
+          --reporter=verbose
+
+      - name: Values-free evidence (this job)
+        run: |
+          {
+            echo "evidenceKind=CONTROLLED_SYNTHETIC_FUNCTIONAL"
+            echo "suite=approval-requester-choice.db.test.ts"
+            echo "lock=approval-lock1-enterprise-assignees-20260817 §K2"
+            echo "gates=G-8,G-9,G-17,G-18 (+G-1/G-2 authoring, G-19 temporal arm)"
+            echo "sentinelArmed=EXPECT_DB=1"
+            echo "customerSourceAccess=NOT_INVOLVED"
+            echo "flagChanged=false"
+            echo "externalWrite=false"
+          } | tee -a "$GITHUB_STEP_SUMMARY"

--- a/apps/web/src/approvals/api.ts
+++ b/apps/web/src/approvals/api.ts
@@ -1263,15 +1263,29 @@ export interface ApprovalDirectoryUser {
   email: string
 }
 
+/**
+ * Lock-1 §K2 — optional scope narrowing for the submit-time requester-choice chooser. Both
+ * filters AND onto the base active-user search server-side (`userIds` = the members scope's
+ * configured list; `roleIds` = plain user_roles membership for the role scope). Candidate
+ * convenience only — createApproval re-validates the actual submitted choice fail-closed.
+ */
+export interface ApprovalDirectoryUserSearchScope {
+  userIds?: string[]
+  roleIds?: string[]
+}
+
 export async function searchApprovalDirectoryUsers(
   q: string,
   limit = 20,
+  scope: ApprovalDirectoryUserSearchScope = {},
 ): Promise<ApprovalDirectoryUser[]> {
   try {
     const params = new URLSearchParams()
     const normalized = q.trim()
     if (normalized) params.set('q', normalized)
     params.set('limit', String(limit))
+    if (scope.userIds && scope.userIds.length > 0) params.set('userIds', scope.userIds.join(','))
+    if (scope.roleIds && scope.roleIds.length > 0) params.set('roleIds', scope.roleIds.join(','))
     const response = await apiFetch(`/api/approvals/directory/users?${params.toString()}`)
     if (!response.ok) return []
     const payload = await response.json().catch(() => null) as { users?: unknown } | null

--- a/apps/web/src/approvals/approvalCapabilityRegistry.ts
+++ b/apps/web/src/approvals/approvalCapabilityRegistry.ts
@@ -30,6 +30,9 @@ export const APPROVAL_ASSIGNEE_SOURCE_LABELS: Record<ApprovalAssigneeSourceKind,
   dept_head: '部门负责人',
   continuous_managers: '连续多级上级',
   manager_at_level: '指定层级上级',
+  // Lock-1 §K2 (RATIFIED 2026-08-17) — admitted in the SAME slice that lands the scope
+  // validation + submit-time chooser end to end (registry table row: 提交人自选 / approval).
+  requester_choice: '提交人自选',
 }
 
 /** Display order matches parent §10.3's listed order. Kept as an explicit array (rather than
@@ -44,6 +47,8 @@ const SHIPPED_ASSIGNEE_SOURCE_KIND_ORDER: readonly ApprovalAssigneeSourceKind[] 
   'dept_head',
   'continuous_managers',
   'manager_at_level',
+  // Lock-1 §K2: ratified kinds append after the original eight-member §10.3 order.
+  'requester_choice',
 ]
 
 export interface ApprovalAssigneeSourceCapability {

--- a/apps/web/src/approvals/approvalNodeEdit.ts
+++ b/apps/web/src/approvals/approvalNodeEdit.ts
@@ -126,6 +126,14 @@ function isAssigneeSourceValid(source: ApprovalAssigneeSource, topLevelUserField
       return Number.isInteger(source.levels) && source.levels >= 1
     case 'manager_at_level':
       return Number.isInteger(source.level) && source.level >= 1
+    case 'requester_choice':
+      // Lock-1 §K2 PREVIEW (backend normalizeApprovalAssigneeSources stays the arbiter):
+      // mode + scope discriminator, and a members/role scope needs ≥1 configured id.
+      if (source.mode !== 'single' && source.mode !== 'multi') return false
+      if (source.scope.type === 'company') return true
+      if (source.scope.type === 'members') return source.scope.userIds.some((id) => id.trim().length > 0)
+      if (source.scope.type === 'role') return source.scope.roleIds.some((id) => id.trim().length > 0)
+      return false
     case 'requester':
     case 'direct_manager':
     case 'dept_head':

--- a/apps/web/src/approvals/assigneeSource.ts
+++ b/apps/web/src/approvals/assigneeSource.ts
@@ -26,7 +26,14 @@ export function assigneeSourceSummary(source: ApprovalAssigneeSource): string {
     case 'dept_head': return '部门主管'
     case 'continuous_managers': return `连续多级上级（${source.levels} 级）`
     case 'manager_at_level': return `指定层级上级（第 ${source.level} 级）`
-    default: return JSON.stringify(source)
+    // Lock-1 §K2: pre-choice placeholder — the approver is unknowable until the requester
+    // chooses at submit time, so the flow/route preview says exactly that.
+    case 'requester_choice': return '提交人自选（提交时选择）'
+    // Lock-1 §2.5 item 5: values-free fallback. The previous `JSON.stringify(source)` default
+    // leaked raw config (including raw IDs) into an ordinary-user surface for any kind this
+    // switch does not know — a defect, not a precedent, per the ratified lock. An unknown kind
+    // gets a generic label and nothing else.
+    default: return '（未知审批人来源）'
   }
 }
 

--- a/apps/web/src/approvals/components/ApprovalGraphNodeConfigEditor.vue
+++ b/apps/web/src/approvals/components/ApprovalGraphNodeConfigEditor.vue
@@ -464,6 +464,101 @@
           @update:model-value="(value: number) => setApprovalSourceLevel(node.key, value ?? 1)"
         />
       </el-form-item>
+      <!-- Lock-1 §K2 (提交人自选) authoring sub-form: mode radio (单选/多选) + scope select
+           (全公司/指定成员/指定角色) with TYPED pickers only (D0 §10.2 — no raw-ID input).
+           The submit-time chooser itself lives in ApprovalNewView; this only authors the
+           mode + scope the server validates the requester's choice against. -->
+      <template v-else-if="approvalSourceKind(node.key) === 'requester_choice'">
+        <el-form-item label="选择方式">
+          <div
+            class="approval-node-source-roster"
+            role="radiogroup"
+            aria-label="选择方式"
+            data-testid="approval-node-requester-choice-mode"
+          >
+            <label class="approval-node-source-roster-option">
+              <input
+                type="radio"
+                :name="`approval-node-requester-choice-mode-${node.key}`"
+                :checked="requesterChoiceMode(node.key) === 'single'"
+                :disabled="readOnly"
+                data-testid="approval-node-requester-choice-mode-single"
+                @change="() => setRequesterChoiceMode(node.key, 'single')"
+              />
+              <span>单选（提交时选一人）</span>
+            </label>
+            <label class="approval-node-source-roster-option">
+              <input
+                type="radio"
+                :name="`approval-node-requester-choice-mode-${node.key}`"
+                :checked="requesterChoiceMode(node.key) === 'multi'"
+                :disabled="readOnly"
+                data-testid="approval-node-requester-choice-mode-multi"
+                @change="() => setRequesterChoiceMode(node.key, 'multi')"
+              />
+              <span>多选（提交时可选多人）</span>
+            </label>
+          </div>
+        </el-form-item>
+        <el-form-item label="可选范围">
+          <el-select
+            :model-value="requesterChoiceScopeType(node.key)"
+            size="small"
+            :disabled="readOnly"
+            class="ms-w-240"
+            data-testid="approval-node-requester-choice-scope"
+            @update:model-value="(type: 'company' | 'members' | 'role') => setRequesterChoiceScopeType(node.key, type)"
+          >
+            <el-option label="全公司（任意成员）" value="company" />
+            <el-option label="指定成员" value="members" />
+            <el-option label="指定角色的成员" value="role" />
+          </el-select>
+        </el-form-item>
+        <el-form-item v-if="requesterChoiceScopeType(node.key) === 'members'" label="可选成员">
+          <el-select
+            :model-value="requesterChoiceScopeIds(node.key)"
+            multiple
+            filterable
+            remote
+            :remote-method="onUserSearch"
+            :loading="directoryUsersLoading"
+            size="small"
+            :disabled="readOnly"
+            class="ms-w-360"
+            placeholder="搜索用户名 / 邮箱"
+            data-testid="approval-node-requester-choice-user-picker"
+            @update:model-value="(ids: string[] | string) => setRequesterChoiceScopeIds(node.key, ids)"
+            @visible-change="(visible: boolean) => visible && onUserSearch('')"
+          >
+            <el-option
+              v-for="user in directoryUsers"
+              :key="user.id"
+              :label="formatUserLabel(user)"
+              :value="user.id"
+            />
+          </el-select>
+        </el-form-item>
+        <el-form-item v-else-if="requesterChoiceScopeType(node.key) === 'role'" label="可选角色">
+          <el-select
+            :model-value="requesterChoiceScopeIds(node.key)"
+            multiple
+            filterable
+            size="small"
+            :disabled="readOnly"
+            class="ms-w-360"
+            placeholder="选择角色"
+            data-testid="approval-node-requester-choice-role-picker"
+            @update:model-value="(ids: string[] | string) => setRequesterChoiceScopeIds(node.key, ids)"
+          >
+            <el-option
+              v-for="role in directoryRoles"
+              :key="role.id"
+              :label="formatRoleLabel(role)"
+              :value="role.id"
+            />
+          </el-select>
+        </el-form-item>
+      </template>
       <!-- G-5 sentinel hint: a starter preset's placeholder role surfaces HERE, in the editor,
            so the admin replaces it before publish (rather than hitting the publish-time 400). -->
       <el-alert
@@ -596,6 +691,7 @@ import type {
   EmptyAssigneePolicy,
   NodeFieldAccess,
   ParallelNodeConfig,
+  RequesterChoiceAssigneeSource,
 } from '../../types/approval'
 import {
   APPROVAL_NODE_CONFIG_EDITOR_KEY,
@@ -724,6 +820,58 @@ const isKnownAssigneeSourceKind = computed(() =>
   isRegisteredAssigneeSourceKind(registry.value, props.node.type, approvalSourceKind(props.node.key)),
 )
 
+// ── Lock-1 §K2 requester_choice sub-form ────────────────────────────────────────────────────
+// Reads/writes the PRIMARY source of the SHARED approvalNodeEditFor edit model directly (the
+// same live model the roster's kind switch mutates), so no new context-api surface is needed
+// and both presentations (canvas inspector tabs / flat structured list) stay one source.
+function requesterChoiceSourceFor(nodeKey: string): RequesterChoiceAssigneeSource | null {
+  const source = approvalNodeEditFor(nodeKey)?.assigneeSources[0]
+  return source?.kind === 'requester_choice' ? source : null
+}
+function replaceRequesterChoiceSource(nodeKey: string, next: RequesterChoiceAssigneeSource): void {
+  const edit = approvalNodeEditFor(nodeKey)
+  if (!edit) return
+  edit.assigneeSources = [next, ...edit.assigneeSources.slice(1)]
+}
+function requesterChoiceMode(nodeKey: string): 'single' | 'multi' {
+  return requesterChoiceSourceFor(nodeKey)?.mode ?? 'single'
+}
+function setRequesterChoiceMode(nodeKey: string, mode: 'single' | 'multi'): void {
+  const source = requesterChoiceSourceFor(nodeKey)
+  if (!source || source.mode === mode) return
+  replaceRequesterChoiceSource(nodeKey, { ...source, mode })
+}
+function requesterChoiceScopeType(nodeKey: string): 'company' | 'members' | 'role' {
+  return requesterChoiceSourceFor(nodeKey)?.scope.type ?? 'company'
+}
+function setRequesterChoiceScopeType(nodeKey: string, type: 'company' | 'members' | 'role'): void {
+  const source = requesterChoiceSourceFor(nodeKey)
+  if (!source || source.scope.type === type) return
+  // A scope switch starts with an EMPTY id list deliberately: userIds and roleIds are different
+  // id domains, so carrying one list into the other scope would author wrong config.
+  const scope: RequesterChoiceAssigneeSource['scope'] =
+    type === 'members' ? { type: 'members', userIds: [] }
+      : type === 'role' ? { type: 'role', roleIds: [] }
+        : { type: 'company' }
+  replaceRequesterChoiceSource(nodeKey, { ...source, scope })
+}
+function requesterChoiceScopeIds(nodeKey: string): string[] {
+  const source = requesterChoiceSourceFor(nodeKey)
+  if (source?.scope.type === 'members') return source.scope.userIds
+  if (source?.scope.type === 'role') return source.scope.roleIds
+  return []
+}
+function setRequesterChoiceScopeIds(nodeKey: string, ids: string[] | string): void {
+  const source = requesterChoiceSourceFor(nodeKey)
+  if (!source) return
+  const list = Array.isArray(ids) ? ids : ids ? [ids] : []
+  if (source.scope.type === 'members') {
+    replaceRequesterChoiceSource(nodeKey, { ...source, scope: { type: 'members', userIds: list } })
+  } else if (source.scope.type === 'role') {
+    replaceRequesterChoiceSource(nodeKey, { ...source, scope: { type: 'role', roleIds: list } })
+  }
+}
+
 /** D2: configured summary echo. Reads the LIVE edit model (not `node.config`, which is the stale
  *  pre-edit snapshot in list mode — `TemplateAuthoringView.vue`'s `graphPreviewNodes` is sourced
  *  from `draft.preservedGraph`, not the live effective graph) so it stays correct in both
@@ -758,6 +906,16 @@ const configuredSourceSummaryLine = computed(() => {
   }
   if (source.kind === 'manager_at_level') {
     return `已配置：${label}（第 ${source.level} 级）`
+  }
+  if (source.kind === 'requester_choice') {
+    // §K2 echo — mode + scope, count-only (same no-raw-id rule as static_user/static_role).
+    const mode = source.mode === 'multi' ? '多选' : '单选'
+    const scope = source.scope.type === 'members'
+      ? `指定成员${source.scope.userIds.length ? `（${source.scope.userIds.length} 人）` : '（未选择）'}`
+      : source.scope.type === 'role'
+        ? `指定角色${source.scope.roleIds.length ? `（${source.scope.roleIds.length} 个）` : '（未选择）'}`
+        : '全公司'
+    return `已配置：${label}（${mode} · ${scope}）`
   }
   return `已配置：${label}`
 })

--- a/apps/web/src/approvals/parallelEdit.ts
+++ b/apps/web/src/approvals/parallelEdit.ts
@@ -164,6 +164,13 @@ function dynamicAssigneeSourceFingerprint(source: ApprovalAssigneeSource): strin
     case 'static_user':
     case 'static_role':
       return null
+    case 'requester_choice':
+      // Lock-1 §K2: `null` DELIBERATELY (backend mirror — keep in lockstep). Two
+      // requester_choice sources on parallel branches are NOT provably identical: the requester
+      // may pick different people per branch, so a same-person collision is the RUNTIME 409
+      // guard's job (`APPROVAL_ASSIGNEE_PARALLEL_DYNAMIC_CONFLICT`), which sees the actual
+      // chosen ids. Authoring/publish cannot, and must not block the shape.
+      return null
     default: {
       const _exhaustive: never = source
       return _exhaustive

--- a/apps/web/src/approvals/templateAuthoring.ts
+++ b/apps/web/src/approvals/templateAuthoring.ts
@@ -143,6 +143,13 @@ export interface ApprovalStepDraft {
   // Single 1-based management level the `manager_at_level` source resolves;
   // meaningful only when `sourceKind === 'manager_at_level'`. Same backend cap as `levels`.
   level: number
+  // Lock-1 §K2 (提交人自选) — meaningful only when `sourceKind === 'requester_choice'`.
+  // `single` = the requester picks exactly one approver at submit; `multi` = one or more.
+  requesterChoiceMode: 'single' | 'multi'
+  // §K2 scope discriminator. `company` = any active user; `members` / `role` narrow the
+  // chooser to a configured list, carried in the SAME `idsText` chip carrier the static
+  // pickers use (userIds for members, roleIds for role) — sourceFromStep re-shapes it.
+  requesterChoiceScopeType: 'company' | 'members' | 'role'
   approvalMode: ApprovalMode
   emptyAssigneePolicy: EmptyAssigneePolicy
   // Self-approver authoring: the editable toggle (merge the requester in as an
@@ -280,6 +287,8 @@ export function createEmptyStepDraft(index = 1): ApprovalStepDraft {
     fieldId: '',
     levels: 2,
     level: 1,
+    requesterChoiceMode: 'single',
+    requesterChoiceScopeType: 'company',
     approvalMode: 'single',
     emptyAssigneePolicy: 'error',
     mergeWithRequester: false,
@@ -445,6 +454,8 @@ function stepDraftFromApprovalNode(
   let fieldId = ''
   let levels = 2
   let level = 1
+  let requesterChoiceMode: 'single' | 'multi' = 'single'
+  let requesterChoiceScopeType: 'company' | 'members' | 'role' = 'company'
   if (source?.kind === 'static_user') {
     sourceKind = 'static_user'
     idsText = formatIds(source.userIds)
@@ -466,6 +477,14 @@ function stepDraftFromApprovalNode(
   } else if (source?.kind === 'manager_at_level') {
     sourceKind = 'manager_at_level'
     level = source.level
+  } else if (source?.kind === 'requester_choice') {
+    // Lock-1 §K2: hydrate mode + scope; a members/role scope's id list rides the shared
+    // idsText chip carrier (sourceFromStep re-shapes it back per scope type).
+    sourceKind = 'requester_choice'
+    requesterChoiceMode = source.mode
+    requesterChoiceScopeType = source.scope.type
+    if (source.scope.type === 'members') idsText = formatIds(source.scope.userIds)
+    else if (source.scope.type === 'role') idsText = formatIds(source.scope.roleIds)
   } else if (legacyType === 'user') {
     sourceKind = 'static_user'
     idsText = formatIds(legacyIds)
@@ -496,6 +515,8 @@ function stepDraftFromApprovalNode(
     fieldId,
     levels,
     level,
+    requesterChoiceMode,
+    requesterChoiceScopeType,
     approvalMode: config.approvalMode === 'all' || config.approvalMode === 'any' ? config.approvalMode : 'single',
     emptyAssigneePolicy: config.emptyAssigneePolicy === 'auto-approve' ? 'auto-approve' : 'error',
     mergeWithRequester,
@@ -599,7 +620,9 @@ const BACKEND_PRESERVED_COMPLEX_APPROVAL_CONFIG_KEYS = [
 //   - assigneeSources[] per kind (ApprovalProductService.ts:408-453)
 //   - autoApprovalPolicy (:371-376) — 4 fields
 //   - fieldPermissions[] (:786-799) — { fieldId, access }
-// All three bottom out in primitives / string-arrays (no deeper objects), so this 2-level check is complete.
+// autoApprovalPolicy / fieldPermissions bottom out in primitives / string-arrays; assigneeSources
+// does too EXCEPT the Lock-1 §K2 `requester_choice` source, whose `scope` is a nested object —
+// `requesterChoiceSourceHasBackendDrop` below carries that third level, so the check stays complete.
 const BACKEND_ASSIGNEE_SOURCE_KEYS_BY_KIND: Record<string, string[]> = {
   static_user: ['kind', 'userIds'],
   static_role: ['kind', 'roleIds'],
@@ -609,6 +632,30 @@ const BACKEND_ASSIGNEE_SOURCE_KEYS_BY_KIND: Record<string, string[]> = {
   continuous_managers: ['kind', 'levels'],
   manager_at_level: ['kind', 'level'],
   form_field_user: ['kind', 'fieldId'],
+  // Lock-1 §K2: `scope` is the ONE nested object in the source union (see
+  // requesterChoiceSourceHasBackendDrop below for its per-type key check — the flat 2-level
+  // allowlist alone cannot see inside it).
+  requester_choice: ['kind', 'mode', 'scope'],
+}
+
+// Lock-1 §K2 — the requester_choice `scope` shapes the backend accepts (normalize REJECTS any
+// other key/type rather than dropping it, but the FE posture is the same either way: a shape the
+// backend won't re-emit verbatim must force read-only, never silently flatten on save).
+const BACKEND_REQUESTER_CHOICE_SCOPE_KEYS_BY_TYPE: Record<string, string[]> = {
+  company: ['type'],
+  members: ['type', 'userIds'],
+  role: ['type', 'roleIds'],
+}
+
+function requesterChoiceSourceHasBackendDrop(source: Record<string, unknown>): boolean {
+  if (source.mode !== 'single' && source.mode !== 'multi') return true
+  const scope = source.scope
+  if (!isPlainRecord(scope)) return true
+  const allowedScopeKeys = BACKEND_REQUESTER_CHOICE_SCOPE_KEYS_BY_TYPE[scope.type as string]
+  if (!allowedScopeKeys || hasKeyOutside(scope, allowedScopeKeys)) return true
+  if (scope.type === 'members' && !Array.isArray(scope.userIds)) return true
+  if (scope.type === 'role' && !Array.isArray(scope.roleIds)) return true
+  return false
 }
 const BACKEND_AUTO_APPROVAL_POLICY_KEYS = ['mergeWithRequester', 'mergeAdjacentApprover', 'dedupeHistoricalApprover', 'actorMode']
 const BACKEND_FIELD_PERMISSION_KEYS = ['fieldId', 'access']
@@ -647,6 +694,8 @@ function complexApprovalConfigHasBackendDrop(config: Record<string, unknown>): b
       if (!isPlainRecord(source)) return true
       const allowed = BACKEND_ASSIGNEE_SOURCE_KEYS_BY_KIND[source.kind as string]
       if (!allowed || hasKeyOutside(source, allowed)) return true
+      // Lock-1 §K2: the nested `scope` object needs its own per-type key/shape check.
+      if (source.kind === 'requester_choice' && requesterChoiceSourceHasBackendDrop(source)) return true
     }
   }
   if (hasKeyOutside(config.autoApprovalPolicy, BACKEND_AUTO_APPROVAL_POLICY_KEYS)) return true
@@ -772,7 +821,10 @@ export function unsupportedTemplateAuthoringReason(template: ApprovalTemplateDet
     if (sources !== undefined) {
       if (!Array.isArray(sources) || sources.length !== 1) return true
       const source = sources[0] as ApprovalAssigneeSource
-      if (!['static_user', 'static_role', 'requester', 'form_field_user', 'direct_manager', 'dept_head', 'continuous_managers', 'manager_at_level'].includes(source?.kind)) return true
+      if (!['static_user', 'static_role', 'requester', 'form_field_user', 'direct_manager', 'dept_head', 'continuous_managers', 'manager_at_level', 'requester_choice'].includes(source?.kind)) return true
+      // Lock-1 §K2: a malformed requester_choice shape must fail-closed to read-only here too —
+      // hydrate would otherwise re-derive a default mode/scope and silently flatten it on save.
+      if (source?.kind === 'requester_choice' && requesterChoiceSourceHasBackendDrop(source as unknown as Record<string, unknown>)) return true
     }
     // T1-4: `buildStepConfig` re-emits only { fieldId, access } per entry (the backend allowlist),
     // so a linear node carrying an ARRAY-shaped fieldPermissions with an extra key or non-object
@@ -952,6 +1004,16 @@ export function sourceFromStep(step: ApprovalStepDraft): ApprovalAssigneeSource 
   }
   if (step.sourceKind === 'manager_at_level') {
     return { kind: 'manager_at_level', level: step.level }
+  }
+  if (step.sourceKind === 'requester_choice') {
+    // Lock-1 §K2: re-shape the shared idsText carrier into the per-scope id list.
+    const scope =
+      step.requesterChoiceScopeType === 'members'
+        ? { type: 'members' as const, userIds: parseIdsText(step.idsText) }
+        : step.requesterChoiceScopeType === 'role'
+          ? { type: 'role' as const, roleIds: parseIdsText(step.idsText) }
+          : { type: 'company' as const }
+    return { kind: 'requester_choice', mode: step.requesterChoiceMode, scope }
   }
   return { kind: 'requester' }
 }
@@ -1247,6 +1309,15 @@ export function validateTemplateApprovalFlow(draft: TemplateAuthoringDraft): str
     }
     if (step.sourceKind === 'form_field_user' && !userFieldIds.has(step.fieldId.trim())) {
       errors.push(`${label} 的表单用户字段无效`)
+    }
+    // Lock-1 §K2 PREVIEW (backend normalize is the final arbiter): a members/role scope needs
+    // at least one configured id — the backend rejects an empty scope list the same way.
+    if (
+      step.sourceKind === 'requester_choice'
+      && (step.requesterChoiceScopeType === 'members' || step.requesterChoiceScopeType === 'role')
+      && parseIdsText(step.idsText).length === 0
+    ) {
+      errors.push(`${label} 的提交人自选范围需要选择成员/角色`)
     }
   })
   return errors

--- a/apps/web/src/types/approval.ts
+++ b/apps/web/src/types/approval.ts
@@ -15,7 +15,7 @@ export const APPROVAL_ROLE_CONFIGURE_SENTINEL = '__APPROVAL_ROLE_PLACEHOLDER__'
 
 export type ApprovalNodeType = 'start' | 'approval' | 'cc' | 'condition' | 'parallel' | 'end'
 export type ApprovalAssigneeType = 'user' | 'role'
-export type ApprovalAssigneeSourceKind = 'static_user' | 'static_role' | 'requester' | 'form_field_user' | 'direct_manager' | 'dept_head' | 'continuous_managers' | 'manager_at_level'
+export type ApprovalAssigneeSourceKind = 'static_user' | 'static_role' | 'requester' | 'form_field_user' | 'direct_manager' | 'dept_head' | 'continuous_managers' | 'manager_at_level' | 'requester_choice'
 export type ApprovalMode = 'single' | 'all' | 'any'
 export type ParallelJoinMode = 'all' | 'any'
 export type EmptyAssigneePolicy = 'error' | 'auto-approve'
@@ -102,6 +102,21 @@ export type ApprovalAssigneeSource =
   | { kind: 'dept_head' }
   | { kind: 'continuous_managers'; levels: number }
   | { kind: 'manager_at_level'; level: number }
+  /**
+   * Lock-1 §K2 — 提交人自选. Byte-mirrors the backend union member: the requester picks the
+   * approver(s) at SUBMIT time (chooser in ApprovalNewView); choices travel in the create
+   * payload keyed by node key, are scope-validated server-side, and freeze at create.
+   */
+  | {
+      kind: 'requester_choice'
+      mode: 'single' | 'multi'
+      scope:
+        | { type: 'company' }
+        | { type: 'members'; userIds: string[] }
+        | { type: 'role'; roleIds: string[] }
+    }
+
+export type RequesterChoiceAssigneeSource = Extract<ApprovalAssigneeSource, { kind: 'requester_choice' }>
 
 export interface ConditionNodeConfig {
   branches: ConditionBranch[]
@@ -281,6 +296,12 @@ export interface UnifiedApprovalHistoryDTO {
 export interface CreateApprovalRequest {
   templateId: string
   formData: Record<string, unknown>
+  /**
+   * Lock-1 §K2 — submit-time approver choices, keyed by the published requester_choice
+   * node's key. Required per node when the route carries a requester_choice source (the
+   * server 422s values-free on a missing entry); validated + frozen server-side at create.
+   */
+  requesterChoices?: Record<string, string[]>
 }
 
 export interface ApprovalActionRequest {

--- a/apps/web/src/views/approval/ApprovalNewView.vue
+++ b/apps/web/src/views/approval/ApprovalNewView.vue
@@ -139,6 +139,54 @@
           </div>
         </el-card>
 
+        <!-- Lock-1 §K2 (提交人自选): submit-time approver chooser. Rendered only when the
+             loaded template's graph carries a requester_choice node; REQUIRED — handleSubmit
+             blocks until every such node has a mode-satisfying choice. The picker is
+             scope-filtered server-side (members/role scope → userIds/roleIds params on the
+             participant directory search); createApproval re-validates the submitted choice
+             fail-closed either way. -->
+        <el-card
+          v-if="requesterChoiceNodes.length > 0"
+          class="approval-new__requester-choice"
+          shadow="never"
+          data-testid="approval-requester-choice"
+        >
+          <template #header>
+            <span class="approval-new__flow-preview-header">选择审批人</span>
+          </template>
+          <el-form label-position="top">
+            <el-form-item
+              v-for="chooser in requesterChoiceNodes"
+              :key="chooser.nodeKey"
+              :label="`${chooser.nodeName}（${chooser.mode === 'multi' ? '可选多人' : '选一人'} · ${chooserScopeLabel(chooser)}）`"
+              required
+              data-testid="approval-requester-choice-item"
+            >
+              <el-select
+                :model-value="chooser.mode === 'multi' ? (requesterChoices[chooser.nodeKey] ?? []) : (requesterChoices[chooser.nodeKey]?.[0] ?? undefined)"
+                :multiple="chooser.mode === 'multi'"
+                filterable
+                remote
+                clearable
+                :remote-method="(q: string) => searchChoiceCandidates(chooser, q)"
+                :loading="choiceSearchLoading[chooser.nodeKey] === true"
+                class="ms-w-100pct"
+                placeholder="搜索并选择审批人"
+                :data-testid="`approval-requester-choice-picker-${chooser.nodeKey}`"
+                @update:model-value="(value: string[] | string | null) => setRequesterChoice(chooser, value)"
+                @visible-change="(visible: boolean) => visible && searchChoiceCandidates(chooser, '')"
+              >
+                <el-option
+                  v-for="option in choiceOptions[chooser.nodeKey] ?? []"
+                  :key="option.id"
+                  :label="choiceOptionLabel(option)"
+                  :value="option.id"
+                />
+              </el-select>
+            </el-form-item>
+          </el-form>
+        </el-card>
+
         <el-divider content-position="left">填写表单</el-divider>
 
         <el-form
@@ -509,7 +557,12 @@ import type { FormInstance, FormRules } from 'element-plus'
 import PageShell from '../../components/layout/PageShell.vue'
 import PageHeader from '../../components/layout/PageHeader.vue'
 import StatusTag from '../../components/status/StatusTag.vue'
-import type { FormField, FormSchema } from '../../types/approval'
+import type {
+  ApprovalAssigneeSource,
+  FormField,
+  FormSchema,
+  RequesterChoiceAssigneeSource,
+} from '../../types/approval'
 import { useApprovalStore } from '../../approvals/store'
 import { useApprovalTemplateStore } from '../../approvals/templateStore'
 import { useApprovalPermissions } from '../../approvals/permissions'
@@ -529,7 +582,12 @@ import {
   validateDetailRows,
 } from '../../approvals/detailField'
 import { summarizeApprovalFlow, type ApprovalFlowStep } from '../../approvals/graphSummary'
-import { previewApprovalRoute, type ApprovalRoutePreview } from '../../approvals/api'
+import {
+  previewApprovalRoute,
+  searchApprovalDirectoryUsers,
+  type ApprovalDirectoryUser,
+  type ApprovalRoutePreview,
+} from '../../approvals/api'
 import { routePreviewAssigneeSummary } from '../../approvals/routePreviewSummary'
 import { createRoutePreviewController } from '../../approvals/routePreviewController'
 import { getApproval } from '../../approvals/api'
@@ -771,6 +829,104 @@ const flowPreviewSteps = computed<ApprovalFlowStep[]>(() => {
   return summarizeApprovalFlow(graph, template.value?.formSchema ?? null)
 })
 
+// ---------------------------------------------------------------------------
+// Lock-1 §K2 (提交人自选) — submit-time approver chooser state.
+// ---------------------------------------------------------------------------
+interface RequesterChoiceChooser {
+  nodeKey: string
+  nodeName: string
+  mode: 'single' | 'multi'
+  scope: RequesterChoiceAssigneeSource['scope']
+}
+
+// One chooser row per approval node whose sources include a requester_choice entry (the FIRST
+// such source drives the UI; the server validates the submitted choice against EVERY
+// requester_choice source on the node, so the UI can never under-constrain the create).
+const requesterChoiceNodes = computed<RequesterChoiceChooser[]>(() => {
+  const graph = template.value?.approvalGraph
+  if (!graph) return []
+  const choosers: RequesterChoiceChooser[] = []
+  for (const node of graph.nodes) {
+    if (node.type !== 'approval') continue
+    const sources = (node.config as { assigneeSources?: ApprovalAssigneeSource[] }).assigneeSources
+    if (!Array.isArray(sources)) continue
+    const source = sources.find(
+      (entry): entry is RequesterChoiceAssigneeSource => !!entry && entry.kind === 'requester_choice',
+    )
+    if (source) {
+      choosers.push({
+        nodeKey: node.key,
+        nodeName: (node.name && node.name.trim()) || node.key,
+        mode: source.mode,
+        scope: source.scope,
+      })
+    }
+  }
+  return choosers
+})
+
+const requesterChoices = reactive<Record<string, string[]>>({})
+const choiceOptions = reactive<Record<string, ApprovalDirectoryUser[]>>({})
+const choiceSearchLoading = reactive<Record<string, boolean>>({})
+
+function chooserScopeLabel(chooser: RequesterChoiceChooser): string {
+  if (chooser.scope.type === 'members') return '限指定成员'
+  if (chooser.scope.type === 'role') return '限指定角色的成员'
+  return '全公司可选'
+}
+
+function choiceOptionLabel(option: ApprovalDirectoryUser): string {
+  const primary = option.name?.trim() || option.id
+  const email = option.email?.trim()
+  return email ? `${primary} · ${email}` : primary
+}
+
+async function searchChoiceCandidates(chooser: RequesterChoiceChooser, q: string): Promise<void> {
+  choiceSearchLoading[chooser.nodeKey] = true
+  try {
+    // Scope-filtered SERVER-SIDE so a members/role-scoped candidate outside the current search
+    // page still surfaces, and out-of-scope users never appear as pickable at all.
+    const scope = chooser.scope.type === 'members'
+      ? { userIds: chooser.scope.userIds }
+      : chooser.scope.type === 'role'
+        ? { roleIds: chooser.scope.roleIds }
+        : {}
+    choiceOptions[chooser.nodeKey] = await searchApprovalDirectoryUsers(q, 20, scope)
+  } finally {
+    choiceSearchLoading[chooser.nodeKey] = false
+  }
+}
+
+function setRequesterChoice(chooser: RequesterChoiceChooser, value: string[] | string | null): void {
+  const ids = Array.isArray(value)
+    ? value.filter((entry): entry is string => typeof entry === 'string' && entry.length > 0)
+    : typeof value === 'string' && value.length > 0
+      ? [value]
+      : []
+  if (ids.length === 0) delete requesterChoices[chooser.nodeKey]
+  else requesterChoices[chooser.nodeKey] = ids
+  // A changed choice invalidates a previously resolved route preview (stale names must not stick).
+  routePreviewController.invalidate()
+}
+
+/** First chooser whose selection does not satisfy its mode cardinality; null when all chosen. */
+function missingRequesterChoiceNode(): RequesterChoiceChooser | null {
+  for (const chooser of requesterChoiceNodes.value) {
+    const ids = requesterChoices[chooser.nodeKey] ?? []
+    if (chooser.mode === 'single' ? ids.length !== 1 : ids.length === 0) return chooser
+  }
+  return null
+}
+
+function buildRequesterChoicesPayload(): Record<string, string[]> {
+  const payload: Record<string, string[]> = {}
+  for (const chooser of requesterChoiceNodes.value) {
+    const ids = requesterChoices[chooser.nodeKey]
+    if (ids && ids.length > 0) payload[chooser.nodeKey] = [...ids]
+  }
+  return payload
+}
+
 // RP-2 (B3-05): live route preview state. Compute-at-click; any form edit invalidates the resolved
 // path (stale resolution must never keep rendering as if it matched the current values). The
 // generation race-guard lives in createRoutePreviewController so it is unit-testable.
@@ -786,7 +942,14 @@ const routePreviewController = createRoutePreviewController(previewApprovalRoute
 
 async function loadRoutePreview() {
   if (!template.value) return
-  await routePreviewController.run({ templateId: template.value.id, formData: { ...formData } })
+  // §K2: choices made so far ride along so the preview resolves the chosen names; pre-choice
+  // the server previews the requester_choice node honestly (placeholder / unresolved).
+  const choices = buildRequesterChoicesPayload()
+  await routePreviewController.run({
+    templateId: template.value.id,
+    formData: { ...formData },
+    ...(Object.keys(choices).length > 0 ? { requesterChoices: choices } : {}),
+  })
 }
 
 watch(formData, () => routePreviewController.invalidate(), { deep: true })
@@ -1020,11 +1183,20 @@ async function handleSubmit() {
     }
   }
 
+  // Lock-1 §K2: block submit until every requester_choice node carries a mode-satisfying
+  // choice — the server would 422 values-free anyway; this surfaces the actionable message.
+  const missingChoice = missingRequesterChoiceNode()
+  if (missingChoice) {
+    ElMessage.warning(`请为「${missingChoice.nodeName}」选择审批人`)
+    return
+  }
+
   const templateId = route.params.templateId as string
   try {
     const result = await approvalStore.submitApproval({
       templateId,
       formData: buildSubmitFormData(),
+      ...(requesterChoiceNodes.value.length > 0 ? { requesterChoices: buildRequesterChoicesPayload() } : {}),
     })
     ElMessage.success('审批已提交')
     // G-B2-14: a successful submit consumes the draft.
@@ -1176,6 +1348,11 @@ watch([visibleFieldIds, template], () => {
    deliberately NOT the authoring canvas's node-graph styling — this is a compact glance, not an
    editing surface. */
 .approval-new__flow-preview {
+  margin-bottom: 8px;
+}
+
+/* Lock-1 §K2: submit-time approver chooser card. */
+.approval-new__requester-choice {
   margin-bottom: 8px;
 }
 

--- a/apps/web/src/views/approval/TemplateAuthoringView.vue
+++ b/apps/web/src/views/approval/TemplateAuthoringView.vue
@@ -520,6 +520,7 @@
                 <el-option label="连续多级上级" value="continuous_managers" />
                 <el-option label="指定层级上级" value="manager_at_level" />
                 <el-option label="表单用户字段" value="form_field_user" />
+                <el-option label="提交人自选" value="requester_choice" />
               </el-select>
             </el-form-item>
             <el-form-item v-if="step.sourceKind === 'continuous_managers'" label="上级层级数">
@@ -594,6 +595,75 @@
                   :key="field.id"
                   :label="fieldDisplayLabel(field)"
                   :value="field.id"
+                />
+              </el-select>
+            </el-form-item>
+            <!-- Lock-1 §K2 (提交人自选) linear authoring: mode + scope with typed pickers only
+                 (the scope id list rides the shared idsText chip carrier via stepIds/setStepIds). -->
+            <el-form-item v-if="step.sourceKind === 'requester_choice'" label="选择方式">
+              <el-select v-model="step.requesterChoiceMode" :disabled="readOnly" class="ms-w-100pct" data-testid="approval-step-requester-choice-mode">
+                <el-option label="单选（提交时选一人）" value="single" />
+                <el-option label="多选（提交时可选多人）" value="multi" />
+              </el-select>
+            </el-form-item>
+            <el-form-item v-if="step.sourceKind === 'requester_choice'" label="可选范围">
+              <el-select
+                :model-value="step.requesterChoiceScopeType"
+                :disabled="readOnly"
+                class="ms-w-100pct"
+                data-testid="approval-step-requester-choice-scope"
+                @update:model-value="(type: 'company' | 'members' | 'role') => setStepRequesterChoiceScopeType(step, type)"
+              >
+                <el-option label="全公司（任意成员）" value="company" />
+                <el-option label="指定成员" value="members" />
+                <el-option label="指定角色的成员" value="role" />
+              </el-select>
+            </el-form-item>
+            <el-form-item
+              v-if="step.sourceKind === 'requester_choice' && step.requesterChoiceScopeType === 'members'"
+              label="可选成员"
+            >
+              <el-select
+                :model-value="stepIds(step)"
+                multiple
+                filterable
+                remote
+                :remote-method="onUserSearch"
+                :loading="directory.usersLoading.value"
+                :disabled="readOnly"
+                class="ms-w-100pct"
+                placeholder="搜索用户名 / 邮箱"
+                data-testid="approval-step-requester-choice-user-picker"
+                @update:model-value="(ids: string[]) => setStepIds(step, ids)"
+                @visible-change="(visible: boolean) => visible && onUserSearch('')"
+              >
+                <el-option
+                  v-for="user in directory.users.value"
+                  :key="user.id"
+                  :label="directoryUserDisplayLabel(user)"
+                  :value="user.id"
+                />
+              </el-select>
+            </el-form-item>
+            <el-form-item
+              v-if="step.sourceKind === 'requester_choice' && step.requesterChoiceScopeType === 'role'"
+              label="可选角色"
+            >
+              <el-select
+                :model-value="stepIds(step)"
+                multiple
+                filterable
+                :disabled="readOnly"
+                class="ms-w-100pct"
+                placeholder="选择角色"
+                data-testid="approval-step-requester-choice-role-picker"
+                @update:model-value="(ids: string[]) => setStepIds(step, ids)"
+              >
+                <el-option
+                  v-for="role in directory.roles.value"
+                  :key="role.id"
+                  :label="directoryRoleDisplayLabel(role)"
+                  :value="role.id"
                 />
               </el-select>
             </el-form-item>
@@ -1724,7 +1794,9 @@ function defaultApprovalSourceForKind(kind: ApprovalAssigneeSourceKind): Approva
       : kind === 'form_field_user' ? { kind, fieldId: '' }
         : kind === 'continuous_managers' ? { kind, levels: 1 }
           : kind === 'manager_at_level' ? { kind, level: 1 }
-            : { kind }
+            // Lock-1 §K2: single choice over the whole company is the widest, always-valid start.
+            : kind === 'requester_choice' ? { kind, mode: 'single', scope: { type: 'company' } }
+              : { kind: kind as 'requester' | 'direct_manager' | 'dept_head' }
 }
 function setApprovalSourceKind(nodeKey: string, kind: ApprovalAssigneeSourceKind): void {
   const current = approvalNodeFirstSource(nodeKey)
@@ -2369,6 +2441,14 @@ function setStepIds(step: ApprovalStepDraft, ids: string[]): void {
   step.idsText = ids.join(', ')
 }
 
+// Lock-1 §K2: a scope-type switch clears the shared idsText carrier deliberately — userIds and
+// roleIds are different id domains, so carrying one list into the other would author wrong config.
+function setStepRequesterChoiceScopeType(step: ApprovalStepDraft, type: 'company' | 'members' | 'role'): void {
+  if (step.requesterChoiceScopeType === type) return
+  step.requesterChoiceScopeType = type
+  step.idsText = ''
+}
+
 async function onUserSearch(query: string): Promise<void> {
   await directory.searchUsers(query)
   // Keep already-selected ids visible as chips even if the new search page omits them —
@@ -2395,6 +2475,13 @@ function syncStepOptions(step: ApprovalStepDraft): void {
     for (const id of parseIdsText(step.idsText)) directory.ensureUserOptionVisible(id)
   } else if (step.sourceKind === 'static_role') {
     for (const id of parseIdsText(step.idsText)) directory.ensureRoleOptionVisible(id)
+  } else if (step.sourceKind === 'requester_choice') {
+    // §K2: the scope id list rides idsText — keep its chips visible per scope type.
+    if (step.requesterChoiceScopeType === 'members') {
+      for (const id of parseIdsText(step.idsText)) directory.ensureUserOptionVisible(id)
+    } else if (step.requesterChoiceScopeType === 'role') {
+      for (const id of parseIdsText(step.idsText)) directory.ensureRoleOptionVisible(id)
+    }
   }
 }
 
@@ -2410,6 +2497,16 @@ function syncApprovalNodeOptions(nodeKey: string): void {
     for (const id of approvalSourceIds(nodeKey)) directory.ensureUserOptionVisible(id)
   } else if (kind === 'static_role') {
     for (const id of approvalSourceIds(nodeKey)) directory.ensureRoleOptionVisible(id)
+  } else if (kind === 'requester_choice') {
+    // §K2: keep the configured scope list's chips visible in the sub-form pickers.
+    const source = approvalNodeEditFor(nodeKey)?.assigneeSources[0]
+    if (source?.kind === 'requester_choice') {
+      if (source.scope.type === 'members') {
+        for (const id of source.scope.userIds) directory.ensureUserOptionVisible(id)
+      } else if (source.scope.type === 'role') {
+        for (const id of source.scope.roleIds) directory.ensureRoleOptionVisible(id)
+      }
+    }
   }
 }
 

--- a/apps/web/tests/approval-assignee-source.test.ts
+++ b/apps/web/tests/approval-assignee-source.test.ts
@@ -42,9 +42,34 @@ describe('assigneeSourceSummary (single source)', () => {
     expect(assigneeSourceSummary({ kind: 'manager_at_level', level: 2 })).toBe('指定层级上级（第 2 级）')
   })
 
-  it('falls back to a JSON dump for an unrecognized kind (defensive default)', () => {
-    const unknown = { kind: 'unknown_kind' } as unknown as ApprovalAssigneeSource
-    expect(assigneeSourceSummary(unknown)).toBe(JSON.stringify(unknown))
+  it('requester_choice: fixed pre-choice placeholder (提交时选择), no config values leaked (Lock-1 §K2)', () => {
+    expect(
+      assigneeSourceSummary({ kind: 'requester_choice', mode: 'single', scope: { type: 'company' } }),
+    ).toBe('提交人自选（提交时选择）')
+    // Same label regardless of mode/scope config — the approver is unknowable pre-choice, and
+    // the scope's configured ids must never leak into this ordinary-user surface.
+    const membersScoped = assigneeSourceSummary({
+      kind: 'requester_choice',
+      mode: 'multi',
+      scope: { type: 'members', userIds: ['secret_user_1'] },
+    })
+    expect(membersScoped).toBe('提交人自选（提交时选择）')
+    expect(membersScoped).not.toContain('secret_user_1')
+  })
+
+  // Lock-1 §2.5 item 5: the old `JSON.stringify(source)` default leaked raw config (raw IDs
+  // included) into an ordinary-user surface — a defect, not a precedent. The default is now a
+  // VALUES-FREE fixed label. G-16's "no JSON.stringify fallback reaches any surface" half.
+  it('unknown kind falls back to a values-free label — never a JSON dump of the source (Lock-1 §2.5)', () => {
+    const unknown = { kind: 'unknown_kind', secretIds: ['u_secret'] } as unknown as ApprovalAssigneeSource
+    const summary = assigneeSourceSummary(unknown)
+    expect(summary).toBe('（未知审批人来源）')
+    expect(summary).not.toContain('unknown_kind')
+    expect(summary).not.toContain('u_secret')
+    expect(summary).not.toBe(JSON.stringify(unknown))
+    // Positive control: a KNOWN kind still renders its typed summary (the fallback is
+    // unknown-selected, not a blanket label).
+    expect(assigneeSourceSummary({ kind: 'direct_manager' })).toBe('直属上级')
   })
 })
 

--- a/apps/web/tests/approval-template-authoring-approval-node-edit.test.ts
+++ b/apps/web/tests/approval-template-authoring-approval-node-edit.test.ts
@@ -212,6 +212,23 @@ describe('validateApprovalNodeEdits (preview mirrors the backend assignee rule)'
     draft.approvalNodeEdits!.approval_1.assigneeSources = []
     expect(validateTemplateDraft(draft).some((e) => /审批人来源/.test(e))).toBe(true)
   })
+  it('Lock-1 §K2: requester_choice — company/role-with-ids pass; empty members/role list and bad mode are flagged', () => {
+    expect(validateApprovalNodeEdits({
+      a: { nodeKey: 'a', assigneeSources: [{ kind: 'requester_choice', mode: 'single', scope: { type: 'company' } }] },
+    })).toEqual([])
+    expect(validateApprovalNodeEdits({
+      a: { nodeKey: 'a', assigneeSources: [{ kind: 'requester_choice', mode: 'multi', scope: { type: 'role', roleIds: ['r1'] } }] },
+    })).toEqual([])
+    expect(validateApprovalNodeEdits({
+      a: { nodeKey: 'a', assigneeSources: [{ kind: 'requester_choice', mode: 'multi', scope: { type: 'members', userIds: [] } }] },
+    })[0]).toMatch(/requester_choice/)
+    expect(validateApprovalNodeEdits({
+      a: { nodeKey: 'a', assigneeSources: [{ kind: 'requester_choice', mode: 'multi', scope: { type: 'role', roleIds: ['  '] } }] },
+    })[0]).toMatch(/requester_choice/)
+    expect(validateApprovalNodeEdits({
+      a: { nodeKey: 'a', assigneeSources: [{ kind: 'requester_choice', mode: 'both', scope: { type: 'company' } } as never] },
+    })[0]).toMatch(/requester_choice/)
+  })
 })
 
 describe('G-5 fail-closed — complex approval-node config must stay within the BACKEND allowlist', () => {
@@ -244,6 +261,33 @@ describe('G-5 fail-closed — complex approval-node config must stay within the 
   it('allows a complex approval node with only backend-preserved keys', () => {
     const graph = complexWith({ assigneeSources: [{ kind: 'direct_manager' }], approvalMode: 'single', emptyAssigneePolicy: 'error', autoApprovalPolicy: { mergeWithRequester: true } })
     expect(unsupportedTemplateAuthoringReason(buildTemplate(graph))).toBeNull()
+  })
+
+  // Lock-1 §K2: requester_choice is the FIRST source with a nested object (`scope`), so its
+  // allowlist check needs a third level — the flat 2-level allowlist alone cannot see inside it.
+  it('K2: a well-formed requester_choice source is allowed on the complex path (every scope type)', () => {
+    for (const scope of [
+      { type: 'company' },
+      { type: 'members', userIds: ['u1'] },
+      { type: 'role', roleIds: ['r1'] },
+    ]) {
+      const graph = complexWith({ assigneeSources: [{ kind: 'requester_choice', mode: 'single', scope }] })
+      expect(unsupportedTemplateAuthoringReason(buildTemplate(graph))).toBeNull()
+    }
+  })
+  it('K2: a malformed requester_choice (extra scope key / unknown scope type / bad mode) forces read-only', () => {
+    const extraScopeKey = complexWith({
+      assigneeSources: [{ kind: 'requester_choice', mode: 'single', scope: { type: 'members', userIds: ['u1'], futureFlag: true } }],
+    })
+    expect(unsupportedTemplateAuthoringReason(buildTemplate(extraScopeKey))).not.toBeNull()
+    const unknownScopeType = complexWith({
+      assigneeSources: [{ kind: 'requester_choice', mode: 'single', scope: { type: 'dept' } }],
+    })
+    expect(unsupportedTemplateAuthoringReason(buildTemplate(unknownScopeType))).not.toBeNull()
+    const badMode = complexWith({
+      assigneeSources: [{ kind: 'requester_choice', mode: 'both', scope: { type: 'company' } }],
+    })
+    expect(unsupportedTemplateAuthoringReason(buildTemplate(badMode))).not.toBeNull()
   })
 
   // NESTED unknown keys: the backend rebuilds assigneeSources[] / autoApprovalPolicy / fieldPermissions[]

--- a/apps/web/tests/approval-template-authoring-canvas-inspector.spec.ts
+++ b/apps/web/tests/approval-template-authoring-canvas-inspector.spec.ts
@@ -8,7 +8,7 @@ import { readFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { createApp, defineComponent, h, nextTick, provide, ref, type App as VueApp } from 'vue'
+import { createApp, defineComponent, h, nextTick, provide, reactive, ref, type App as VueApp } from 'vue'
 import TemplateAuthoringView from '../src/views/approval/TemplateAuthoringView.vue'
 import type { ApprovalNode, ApprovalTemplateDetailDTO } from '../src/types/approval'
 // Lock-0 P1-A (docs/development/approval-lock0-d0-interaction-delta-20260817.md) — direct-mount
@@ -977,7 +977,7 @@ describe('Canvas V2 Slice A — canvas inspector', () => {
   // "iterate the exported table" mechanical assertion, not per-kind spot checks), so any single
   // label reverting to pre-D1 wording (or drifting to anything else) reds here regardless of
   // whether it happens to be one of the two kinds the D1/D2 test exercises.
-  it('D1 (P2-2): all eight assignee-source labels equal the ratified §10.3 map by exact object equality', () => {
+  it('D1 (P2-2): all nine assignee-source labels equal the ratified map by exact object equality', () => {
     const RATIFIED_APPROVAL_ASSIGNEE_SOURCE_LABELS: Record<string, string> = {
       static_user: '指定成员',
       static_role: '指定角色',
@@ -987,11 +987,14 @@ describe('Canvas V2 Slice A — canvas inspector', () => {
       dept_head: '部门负责人',
       continuous_managers: '连续多级上级',
       manager_at_level: '指定层级上级',
+      // Lock-1 §K2 (RATIFIED 2026-08-17) — the 提交人自选 registry row, admitted in the SAME
+      // slice that lands scope validation + the submit-time chooser (Lock-1 §2.3 table).
+      requester_choice: '提交人自选',
     }
     expect(APPROVAL_ASSIGNEE_SOURCE_LABELS).toEqual(RATIFIED_APPROVAL_ASSIGNEE_SOURCE_LABELS)
-    // Also pin the count so a stray 9th entry (which would still satisfy `toEqual` on the 8 keys
+    // Also pin the count so a stray 10th entry (which would still satisfy `toEqual` on the keys
     // above via structural superset checks in some matcher semantics) cannot slip through unnoticed.
-    expect(Object.keys(APPROVAL_ASSIGNEE_SOURCE_LABELS)).toHaveLength(8)
+    expect(Object.keys(APPROVAL_ASSIGNEE_SOURCE_LABELS)).toHaveLength(9)
   })
 
   it('A-7: no scrim/overlay-mask element with the inspector mounted and visible', async () => {
@@ -1349,7 +1352,9 @@ describe('Lock-0 P1-A — registry-driven tab membership + roster (direct mount)
   function createStubConfigApi(
     seed: Record<string, { assigneeSources: Array<Record<string, unknown>>; fieldPermissions?: Array<{ fieldId: string; access: string }> }>,
   ): ApprovalNodeConfigEditorApi {
-    const edits: Record<string, { nodeKey: string; assigneeSources: Array<Record<string, unknown>>; fieldPermissions: Array<{ fieldId: string; access: string }> }> = {}
+    // Reactive so a sub-form edit (e.g. the K2 requester_choice scope switch) re-renders the
+    // mounted component the same way the production draft model does.
+    const edits: Record<string, { nodeKey: string; assigneeSources: Array<Record<string, unknown>>; fieldPermissions: Array<{ fieldId: string; access: string }> }> = reactive({})
     for (const [key, value] of Object.entries(seed)) {
       edits[key] = {
         nodeKey: key,
@@ -1618,21 +1623,24 @@ describe('Lock-0 P1-A — registry-driven tab membership + roster (direct mount)
     unmount()
   })
 
-  it('A-3: roster equals the eight-member ApprovalAssigneeSourceKind union by exact set equality, not count or subset', () => {
-    const CANONICAL_EIGHT = [
+  it('A-3: roster equals the nine-member ApprovalAssigneeSourceKind union by exact set equality, not count or subset', () => {
+    // Lock-1 §2.3: the exact-set gate grows from eight to eight-plus-ratified-K-kinds in the
+    // SAME commit that lands each kind — K2 `requester_choice` is the first admitted row.
+    const CANONICAL_NINE = [
       'continuous_managers',
       'dept_head',
       'direct_manager',
       'form_field_user',
       'manager_at_level',
       'requester',
+      'requester_choice',
       'static_role',
       'static_user',
     ]
     const roster = [...assigneeSourceRoster(DEFAULT_APPROVAL_CAPABILITY_REGISTRY, 'approval')]
       .map((opt) => opt.kind)
       .sort()
-    expect(roster).toEqual(CANONICAL_EIGHT)
+    expect(roster).toEqual(CANONICAL_NINE)
 
     const node = makeApprovalNode('approval_x')
     const { container: c, unmount } = mountDirectInspector({
@@ -1645,7 +1653,7 @@ describe('Lock-0 P1-A — registry-driven tab membership + roster (direct mount)
     )
       .map((el) => el.getAttribute('data-testid')?.replace('approval-node-source-kind-', ''))
       .sort()
-    expect(rendered).toEqual(CANONICAL_EIGHT)
+    expect(rendered).toEqual(CANONICAL_NINE)
     unmount()
   })
 
@@ -1739,5 +1747,110 @@ describe('Lock-0 P1-A — registry-driven tab membership + roster (direct mount)
     expect(container!.querySelector('[data-testid="approval-template-unsupported-alert"]')).not.toBeNull()
     const saveButton = container!.querySelector('[data-testid="approval-template-save-button"]') as HTMLButtonElement | null
     if (saveButton) expect(saveButton.disabled).toBe(true)
+  })
+
+  // ── Lock-1 §K2 — requester_choice authoring sub-form + G-16 positive arm ─────────────────────
+  it('K2 (G-16 positive arm): requester_choice renders EDITABLE with its typed summary — mode radio + scope select, no unknown-kind hint', () => {
+    const api = createStubConfigApi({
+      approval_rc: { assigneeSources: [{ kind: 'requester_choice', mode: 'single', scope: { type: 'company' } }] },
+    })
+    const { container: c, unmount } = mountDirectInspector({
+      node: makeApprovalNode('approval_rc'),
+      registry: DEFAULT_APPROVAL_CAPABILITY_REGISTRY,
+      api,
+    })
+    // Registry-known (the row landed in the SAME slice): roster radio checked + enabled, no A-4 hint.
+    const rosterRadio = c.querySelector('[data-testid="approval-node-source-kind-requester_choice"]') as HTMLInputElement
+    expect(rosterRadio).not.toBeNull()
+    expect(rosterRadio.checked).toBe(true)
+    expect(rosterRadio.disabled).toBe(false)
+    expect(c.querySelector('[data-testid="approval-node-source-kind-unknown"]')).toBeNull()
+    // D2 typed summary echo — mode + scope, count-only wording (no raw ids anywhere).
+    expect(
+      c.querySelector('[data-testid="approval-node-source-configured-summary"]')?.textContent,
+    ).toBe('已配置：提交人自选（单选 · 全公司）')
+    // Sub-form: mode radios reflect the model; company scope renders NO id picker at all.
+    const single = c.querySelector('[data-testid="approval-node-requester-choice-mode-single"]') as HTMLInputElement
+    const multi = c.querySelector('[data-testid="approval-node-requester-choice-mode-multi"]') as HTMLInputElement
+    expect(single.checked).toBe(true)
+    expect(multi.checked).toBe(false)
+    expect(c.querySelector('[data-testid="approval-node-requester-choice-scope"]')).not.toBeNull()
+    expect(c.querySelector('[data-testid="approval-node-requester-choice-user-picker"]')).toBeNull()
+    expect(c.querySelector('[data-testid="approval-node-requester-choice-role-picker"]')).toBeNull()
+    unmount()
+  })
+
+  it('K2: mode radio + scope select write the SHARED edit model; members/role scopes swap in their typed pickers (no raw-ID input)', async () => {
+    const api = createStubConfigApi({
+      approval_rc: { assigneeSources: [{ kind: 'requester_choice', mode: 'single', scope: { type: 'company' } }] },
+    })
+    // The typed pickers list directory options only — no free-text id entry exists anywhere in
+    // the sub-form (D0 §10.2).
+    ;(api as { directoryUsers: Array<{ id: string; name?: string; email?: string }> }).directoryUsers = [
+      { id: 'u_alpha', name: 'Alpha', email: 'a@x.test' },
+    ]
+    ;(api as { directoryRoles: Array<{ id: string; name?: string }> }).directoryRoles = [
+      { id: 'role_fin', name: '财务' },
+    ]
+    const { container: c, unmount } = mountDirectInspector({
+      node: makeApprovalNode('approval_rc'),
+      registry: DEFAULT_APPROVAL_CAPABILITY_REGISTRY,
+      api,
+    })
+
+    // mode single → multi via the native radio.
+    const multi = c.querySelector('[data-testid="approval-node-requester-choice-mode-multi"]') as HTMLInputElement
+    multi.checked = true
+    multi.dispatchEvent(new Event('change'))
+    expect(api.approvalNodeEditFor('approval_rc')?.assigneeSources[0]).toEqual({
+      kind: 'requester_choice',
+      mode: 'multi',
+      scope: { type: 'company' },
+    })
+
+    // scope company → members: the typed USER picker appears, and the switch starts from an
+    // EMPTY id list (userIds/roleIds are different id domains — never carried across).
+    const scopeSelect = c.querySelector('[data-testid="approval-node-requester-choice-scope"]') as HTMLSelectElement
+    scopeSelect.value = 'members'
+    scopeSelect.dispatchEvent(new Event('change'))
+    await flushUi()
+    expect(api.approvalNodeEditFor('approval_rc')?.assigneeSources[0]).toEqual({
+      kind: 'requester_choice',
+      mode: 'multi',
+      scope: { type: 'members', userIds: [] },
+    })
+    const userPicker = c.querySelector('[data-testid="approval-node-requester-choice-user-picker"]') as HTMLSelectElement
+    expect(userPicker).not.toBeNull()
+    expect(c.querySelector('[data-testid="approval-node-requester-choice-role-picker"]')).toBeNull()
+
+    // Picking a member writes scope.userIds into the SAME shared edit model.
+    userPicker.value = 'u_alpha'
+    userPicker.dispatchEvent(new Event('change'))
+    expect(api.approvalNodeEditFor('approval_rc')?.assigneeSources[0]).toEqual({
+      kind: 'requester_choice',
+      mode: 'multi',
+      scope: { type: 'members', userIds: ['u_alpha'] },
+    })
+
+    // scope members → role: ROLE picker replaces the user picker, id list resets again.
+    scopeSelect.value = 'role'
+    scopeSelect.dispatchEvent(new Event('change'))
+    await flushUi()
+    expect(api.approvalNodeEditFor('approval_rc')?.assigneeSources[0]).toEqual({
+      kind: 'requester_choice',
+      mode: 'multi',
+      scope: { type: 'role', roleIds: [] },
+    })
+    expect(c.querySelector('[data-testid="approval-node-requester-choice-user-picker"]')).toBeNull()
+    const rolePicker = c.querySelector('[data-testid="approval-node-requester-choice-role-picker"]') as HTMLSelectElement
+    expect(rolePicker).not.toBeNull()
+    rolePicker.value = 'role_fin'
+    rolePicker.dispatchEvent(new Event('change'))
+    expect(api.approvalNodeEditFor('approval_rc')?.assigneeSources[0]).toEqual({
+      kind: 'requester_choice',
+      mode: 'multi',
+      scope: { type: 'role', roleIds: ['role_fin'] },
+    })
+    unmount()
   })
 })

--- a/apps/web/tests/approval-template-authoring-parallel-edit.test.ts
+++ b/apps/web/tests/approval-template-authoring-parallel-edit.test.ts
@@ -398,6 +398,17 @@ describe('parallelDynamicAssigneeConflicts — publish preflight (F2)', () => {
     )).toHaveLength(1)
   })
 
+  it('Lock-1 §K2 / G-17: requester_choice × requester_choice is NOT flagged (null fingerprint DELIBERATE — same-person collision is the runtime 409 guard\'s job)', () => {
+    // Two requester_choice sources on parallel branches are NOT provably identical — the
+    // requester may pick different people per branch — so the publish preflight must not block
+    // the shape, even for byte-identical configs. Mirrors the backend null fingerprint.
+    const rc: ApprovalAssigneeSource = { kind: 'requester_choice', mode: 'single', scope: { type: 'company' } }
+    expect(parallelDynamicAssigneeConflicts(withBranchSources([rc], [{ ...rc }]))).toEqual([])
+    // Positive control (the assertion is kind-selected, not a dead walk): the SAME fixture with
+    // a provably-identical dynamic source on both branches IS flagged.
+    expect(parallelDynamicAssigneeConflicts(withBranchSources([{ kind: 'requester' }], [{ kind: 'requester' }]))).toHaveLength(1)
+  })
+
   it('does NOT flag different dynamic kinds or different parameters (negative control — no false positives)', () => {
     expect(parallelDynamicAssigneeConflicts(
       withBranchSources([{ kind: 'requester' }], [{ kind: 'direct_manager' }]),

--- a/apps/web/tests/approvalNewView.spec.ts
+++ b/apps/web/tests/approvalNewView.spec.ts
@@ -1374,3 +1374,188 @@ describe('ApprovalNewView — record-link labels are per-field (same recordId, d
     expect(displaysAfter[0]!.value).not.toContain(RECORD_LINK_LABEL_A)
   })
 })
+
+// ---------------------------------------------------------------------------
+// Lock-1 §K2 — submit-time requester-choice chooser (提交人自选)
+// ---------------------------------------------------------------------------
+describe('ApprovalNewView — Lock-1 §K2 requester_choice submit-time chooser', () => {
+  let app: VueApp<Element> | null = null
+  let container: HTMLDivElement | null = null
+
+  const RC_GRAPH: ApprovalGraph = {
+    nodes: [
+      { key: 'start', type: 'start', name: '发起', config: {} },
+      {
+        key: 'approval_1',
+        type: 'approval',
+        name: '自选审批人',
+        config: {
+          assigneeSources: [
+            { kind: 'requester_choice', mode: 'single', scope: { type: 'role', roleIds: ['role_fin'] } },
+          ],
+          approvalMode: 'single',
+          emptyAssigneePolicy: 'error',
+        },
+      },
+      { key: 'end', type: 'end', name: '结束', config: {} },
+    ],
+    edges: [
+      { key: 'e1', source: 'start', target: 'approval_1' },
+      { key: 'e2', source: 'approval_1', target: 'end' },
+    ],
+  }
+
+  // Interactive el-select stub (this suite only): forwards modelValue, emits update:modelValue
+  // on change, and emits visible-change on focus so the view's scope-filtered remote search
+  // actually runs — the shared render-only ElSelect stub above cannot drive either path.
+  const InteractiveElSelect = defineComponent({
+    name: 'ElSelect',
+    props: {
+      modelValue: [String, Array],
+      multiple: Boolean,
+      loading: Boolean,
+      disabled: Boolean,
+      placeholder: String,
+      filterable: Boolean,
+      remote: Boolean,
+      clearable: Boolean,
+    },
+    emits: ['update:modelValue', 'change', 'visible-change'],
+    render() {
+      return h('select', {
+        'data-el-select': 'true',
+        value: Array.isArray(this.modelValue) ? undefined : this.modelValue ?? '',
+        onFocus: () => this.$emit('visible-change', true),
+        onChange: (event: Event) => {
+          const value = (event.target as HTMLSelectElement).value
+          this.$emit('update:modelValue', this.multiple ? [value] : value)
+          this.$emit('change', value)
+        },
+      }, this.$slots.default?.())
+    },
+  })
+
+  beforeEach(() => {
+    routeQuery = {}
+    mockActiveTemplate.value = mockPublishedTemplate({
+      id: 'tpl_numfields',
+      formSchema: {
+        fields: [{ id: 'reason', type: 'text', label: '事由', required: true, defaultValue: '出差' } as FormField],
+      },
+      approvalGraph: RC_GRAPH,
+    })
+    submitApprovalSpy.mockReset()
+    submitApprovalSpy.mockResolvedValue(mockPendingApproval({ id: 'apv_rc_1' }))
+    searchApprovalDirectoryUsersSpy.mockReset()
+    searchApprovalDirectoryUsersSpy.mockResolvedValue([{ id: 'u_alpha', name: 'Alpha', email: 'a@x.test' }])
+    messageWarningSpy.mockClear()
+    pushSpy.mockClear()
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    if (app) app.unmount()
+    if (container) container.remove()
+    app = null
+    container = null
+    vi.clearAllMocks()
+  })
+
+  async function mountView() {
+    const { default: ApprovalNewView } = await import('../src/views/approval/ApprovalNewView.vue')
+    const Host = defineComponent({ setup: () => () => h(ApprovalNewView as any) })
+    app = createApp(Host)
+    app.component('ElAlert', ElAlert)
+    app.component('ElButton', ElButton)
+    app.component('ElCard', ElCard)
+    app.component('ElDatePicker', ElDatePicker)
+    app.component('ElDivider', ElDivider)
+    app.component('ElEmpty', ElEmpty)
+    app.component('ElForm', ElForm)
+    app.component('ElFormItem', ElFormItem)
+    app.component('ElIcon', ElIcon)
+    app.component('ElInput', ElInput)
+    app.component('ElInputNumber', ElInputNumber)
+    app.component('ElOption', ElOption)
+    app.component('ElSelect', InteractiveElSelect)
+    app.component('ElTable', ElTable)
+    app.component('ElTableColumn', ElTableColumn)
+    app.component('ElTag', ElTag)
+    app.component('ElUpload', ElUpload)
+    app.directive('loading', stubDirective)
+    app.mount(container!)
+    await flushUi()
+  }
+
+  function submitButton(): HTMLButtonElement {
+    const btn = Array.from(container!.querySelectorAll('button')).find((b) => b.textContent?.includes('提交审批'))
+    expect(btn).toBeTruthy()
+    return btn as HTMLButtonElement
+  }
+
+  function chooserPicker(): HTMLSelectElement {
+    const picker = container!.querySelector('[data-testid="approval-requester-choice-picker-approval_1"]')
+    expect(picker).not.toBeNull()
+    return picker as HTMLSelectElement
+  }
+
+  it('renders the chooser card for a requester_choice route; the static flow preview shows the pre-choice placeholder', async () => {
+    await mountView()
+    expect(container!.querySelector('[data-testid="approval-requester-choice"]')).not.toBeNull()
+    const item = container!.querySelector('[data-testid="approval-requester-choice-item"]')
+    expect(item?.textContent).toContain('自选审批人')
+    expect(item?.textContent).toContain('选一人')
+    expect(item?.textContent).toContain('限指定角色的成员')
+    // B2-07 static preview: honest placeholder — no fabricated approver, no raw config ids.
+    const flowPreview = container!.querySelector('[data-testid="approval-flow-preview"]')
+    expect(flowPreview?.textContent).toContain('提交人自选（提交时选择）')
+    expect(flowPreview?.textContent).not.toContain('role_fin')
+  })
+
+  it('does NOT render the chooser when the route has no requester_choice node (chooser is graph-selected, not blanket)', async () => {
+    mockActiveTemplate.value = mockPublishedTemplate({
+      id: 'tpl_numfields',
+      formSchema: {
+        fields: [{ id: 'reason', type: 'text', label: '事由', required: true, defaultValue: '出差' } as FormField],
+      },
+    })
+    await mountView()
+    expect(container!.querySelector('[data-testid="approval-requester-choice"]')).toBeNull()
+  })
+
+  it('opening the picker runs a scope-filtered directory search (role scope → roleIds param)', async () => {
+    await mountView()
+    chooserPicker().dispatchEvent(new Event('focus'))
+    await flushUi()
+    expect(searchApprovalDirectoryUsersSpy).toHaveBeenCalledWith('', 20, { roleIds: ['role_fin'] })
+  })
+
+  it('blocks submit until a mode-satisfying choice is made, then sends requesterChoices keyed by node key', async () => {
+    await mountView()
+
+    // No choice yet → submit is blocked with an actionable message and NOTHING is sent.
+    submitButton().click()
+    await flushUi()
+    expect(messageWarningSpy).toHaveBeenCalledWith('请为「自选审批人」选择审批人')
+    expect(submitApprovalSpy).not.toHaveBeenCalled()
+
+    // Choose via the scope-filtered picker (single mode → exactly one).
+    const picker = chooserPicker()
+    picker.dispatchEvent(new Event('focus'))
+    await flushUi()
+    picker.value = 'u_alpha'
+    picker.dispatchEvent(new Event('change'))
+    await flushUi()
+
+    submitButton().click()
+    await flushUi()
+    expect(submitApprovalSpy).toHaveBeenCalledTimes(1)
+    expect(submitApprovalSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        templateId: 'tpl_numfields',
+        requesterChoices: { approval_1: ['u_alpha'] },
+      }),
+    )
+  })
+})

--- a/apps/web/tests/approvalTemplateAuthoring.spec.ts
+++ b/apps/web/tests/approvalTemplateAuthoring.spec.ts
@@ -587,6 +587,50 @@ describe('approval template authoring helpers', () => {
     expect(rehydrated.steps[0].level).toBe(2)
   })
 
+  it('Lock-1 §K2: round-trips a requester_choice source incl. mode + role scope (idsText is the scope-id carrier)', () => {
+    const draft = createEmptyTemplateDraft()
+    draft.key = 'rc'
+    draft.name = '提交人自选审批'
+    draft.steps[0].sourceKind = 'requester_choice'
+    draft.steps[0].requesterChoiceMode = 'multi'
+    draft.steps[0].requesterChoiceScopeType = 'role'
+    draft.steps[0].idsText = 'role_fin, role_legal'
+
+    const payload = buildCreateTemplatePayload(draft)
+    expect((payload.approvalGraph.nodes[1]?.config as any).assigneeSources).toEqual([
+      { kind: 'requester_choice', mode: 'multi', scope: { type: 'role', roleIds: ['role_fin', 'role_legal'] } },
+    ])
+
+    // wire-vs-fixture trap: mode/scope survive the real serialize→parse, not a hand-built chip.
+    const rehydrated = draftFromTemplate(buildTemplate({ approvalGraph: payload.approvalGraph }))
+    expect(rehydrated.steps[0].sourceKind).toBe('requester_choice')
+    expect(rehydrated.steps[0].requesterChoiceMode).toBe('multi')
+    expect(rehydrated.steps[0].requesterChoiceScopeType).toBe('role')
+    expect(rehydrated.steps[0].idsText).toBe('role_fin, role_legal')
+    // And the rebuilt graph is byte-identical to the first emit (no hydrate flatten).
+    expect(buildCreateTemplatePayload(rehydrated).approvalGraph.nodes[1]?.config).toEqual(
+      payload.approvalGraph.nodes[1]?.config,
+    )
+  })
+
+  it('Lock-1 §K2: round-trips a members-scope requester_choice (single mode, userIds carrier)', () => {
+    const draft = createEmptyTemplateDraft()
+    draft.key = 'rc2'
+    draft.name = '提交人自选成员'
+    draft.steps[0].sourceKind = 'requester_choice'
+    draft.steps[0].requesterChoiceMode = 'single'
+    draft.steps[0].requesterChoiceScopeType = 'members'
+    draft.steps[0].idsText = 'u_alpha'
+
+    const payload = buildCreateTemplatePayload(draft)
+    expect((payload.approvalGraph.nodes[1]?.config as any).assigneeSources).toEqual([
+      { kind: 'requester_choice', mode: 'single', scope: { type: 'members', userIds: ['u_alpha'] } },
+    ])
+    const rehydrated = draftFromTemplate(buildTemplate({ approvalGraph: payload.approvalGraph }))
+    expect(rehydrated.steps[0].requesterChoiceScopeType).toBe('members')
+    expect(rehydrated.steps[0].idsText).toBe('u_alpha')
+  })
+
   // Lane E — self-approver authoring (autoApprovalPolicy.mergeWithRequester).
   function buildAutoApprovalTemplate(
     policy: AutoApprovalPolicy,

--- a/packages/core-backend/src/routes/approvals.ts
+++ b/packages/core-backend/src/routes/approvals.ts
@@ -116,6 +116,16 @@ function normalizeApprovalText(value: unknown): string | null {
   return normalized.length > 0 ? normalized : null
 }
 
+// Lock-1 §K2: explicit-whitelist extraction of the submit-time requester choices (node key →
+// chosen local user ids). Only the outer type is gated here; the authoritative shape / scope /
+// cardinality validation is `validateAndFreezeRequesterChoices` in the service (values-free 422
+// before any insert). A non-object value is treated as absent so the service's own
+// "required choice missing" rejection fires instead of a generic parse error.
+function extractRequesterChoices(value: unknown): Record<string, string[]> | undefined {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined
+  return value as Record<string, string[]>
+}
+
 function resolveApprovalActorId(req: Request): string | null {
   const candidate = req.user?.id ?? req.user?.userId ?? req.user?.sub
   if (typeof candidate !== 'string') return null
@@ -532,8 +542,9 @@ export function approvalsRouter(options?: ApprovalRouterOptions): Router {
         })
       }
 
+      const sampleRequesterChoices = extractRequesterChoices(req.body?.sampleRequesterChoices)
       const preview = await productService.previewTemplateRoute(
-        { templateId, formData: sampleFormData },
+        { templateId, formData: sampleFormData, ...(sampleRequesterChoices !== undefined ? { requesterChoices: sampleRequesterChoices } : {}) },
         {
           userId: actorId,
           userName: resolveApprovalActorName(req, actorId),
@@ -789,7 +800,20 @@ export function approvalsRouter(options?: ApprovalRouterOptions): Router {
     try {
       const q = String(req.query.q || '').trim()
       const limit = Number.parseInt(String(req.query.limit ?? '20'), 10)
-      const users = await searchDirectoryUsers(q, Number.isFinite(limit) ? limit : 20)
+      // Lock-1 §K2 — optional scope narrowing for the submit-time requester-choice picker:
+      // comma-separated id lists, capped so a hostile query cannot smuggle an unbounded array.
+      // Candidate convenience only — createApproval re-validates the actual choice server-side.
+      const parseScopeIds = (value: unknown): string[] | undefined => {
+        if (typeof value !== 'string' || value.trim().length === 0) return undefined
+        const ids = value.split(',').map((entry) => entry.trim()).filter((entry) => entry.length > 0)
+        return ids.length > 0 ? ids.slice(0, 200) : undefined
+      }
+      const scopeUserIds = parseScopeIds(req.query.userIds)
+      const scopeRoleIds = parseScopeIds(req.query.roleIds)
+      const users = await searchDirectoryUsers(q, Number.isFinite(limit) ? limit : 20, {
+        ...(scopeUserIds ? { userIds: scopeUserIds } : {}),
+        ...(scopeRoleIds ? { roleIds: scopeRoleIds } : {}),
+      })
       res.json({ users })
     } catch (error) {
       handleApprovalsError(res, error, 'APPROVAL_PARTICIPANT_DIRECTORY_FAILED', 'Failed to search directory users')
@@ -1034,8 +1058,9 @@ export function approvalsRouter(options?: ApprovalRouterOptions): Router {
         })
       }
 
+      const requesterChoices = extractRequesterChoices(req.body?.requesterChoices)
       const preview = await productService.previewApprovalRoute(
-        { templateId, formData },
+        { templateId, formData, ...(requesterChoices !== undefined ? { requesterChoices } : {}) },
         {
           userId,
           userName: resolveApprovalActorName(req, userId),
@@ -1086,8 +1111,9 @@ export function approvalsRouter(options?: ApprovalRouterOptions): Router {
         })
       }
 
+      const requesterChoices = extractRequesterChoices(req.body?.requesterChoices)
       const approval = await productService.createApproval(
-        { templateId, formData },
+        { templateId, formData, ...(requesterChoices !== undefined ? { requesterChoices } : {}) },
         {
           userId,
           userName: resolveApprovalActorName(req, userId),

--- a/packages/core-backend/src/services/ApprovalAssigneeResolver.ts
+++ b/packages/core-backend/src/services/ApprovalAssigneeResolver.ts
@@ -229,6 +229,28 @@ export function resolveApprovalAssignees(
         if (assigneeId) pushResolved('user', assigneeId, source, sourceIndex)
         break
       }
+      case 'requester_choice': {
+        // Lock-1 §K2: resolve to the requester's SUBMIT-TIME choice, read ONLY from the frozen
+        // snapshot map (node key → chosen local user ids). The choices were scope-validated at
+        // create (fail-closed 422 before any insert), so no live directory/role read happens
+        // here — the resolver stays pure, and a re-entered node (return / admin-jump /
+        // timeout-jump) re-resolves the SAME list regardless of any directory or role change
+        // after create. Changing an in-flight seat is `transfer` (a shipped action), never a
+        // re-choice. A missing/empty entry resolves EMPTY and falls to the node's
+        // emptyAssigneePolicy — unreachable via createApproval (which 422s on a missing
+        // choice); it covers only a made-then-unusable choice or a choices-free preview walk.
+        // NO self-exclusion (deliberate, unlike direct_manager/dept_head): the requester may
+        // legitimately be inside the configured scope; self-approval semantics stay owned by
+        // autoApprovalPolicy.mergeWithRequester.
+        const rawMap = options.requesterSnapshot?.requesterChoices
+        const rawList = isRecord(rawMap) ? rawMap[options.nodeKey] : undefined
+        const chosen = Array.isArray(rawList) ? rawList : []
+        chosen.forEach((entry) => {
+          const chosenId = normalizeId(entry)
+          if (chosenId) pushResolved('user', chosenId, source, sourceIndex)
+        })
+        break
+      }
       default:
         throw new ServiceError(
           `Approval node ${options.nodeKey} has an unsupported assignee source`,

--- a/packages/core-backend/src/services/ApprovalProductService.ts
+++ b/packages/core-backend/src/services/ApprovalProductService.ts
@@ -32,6 +32,7 @@ import type {
   NodeTimeoutConfig,
   NodeTimeoutEffect,
   PublishApprovalTemplateRequest,
+  RequesterChoiceAssigneeSource,
   RestoreApprovalTemplateVersionRequest,
   RuntimeGraph,
   RuntimePolicy,
@@ -639,6 +640,52 @@ function normalizeApprovalAssigneeSources(
           kind: 'form_field_user',
           fieldId: source.fieldId.trim(),
         }
+      case 'requester_choice': {
+        // Lock-1 §K2 + G-1: exact-shape validation — mode enum, scope discriminated by type,
+        // and (stricter than the shipped kinds, per the Lock-1 G-1 gate for NEW kinds) unknown
+        // extra keys on the source or its scope are REJECTED, never silently dropped.
+        const sourceKeys = Object.keys(source)
+        if (sourceKeys.some((key) => !['kind', 'mode', 'scope'].includes(key))) {
+          failValidation(context, `${sourcePath} carries unknown keys for requester_choice`)
+        }
+        const mode = source.mode
+        if (mode !== 'single' && mode !== 'multi') {
+          failValidation(context, `${sourcePath}.mode must be single or multi`)
+        }
+        const scope = source.scope
+        if (!isRecord(scope) || !isNonEmptyString(scope.type)) {
+          failValidation(context, `${sourcePath}.scope.type is required`)
+        }
+        switch (scope.type) {
+          case 'company':
+            if (Object.keys(scope).some((key) => key !== 'type')) {
+              failValidation(context, `${sourcePath}.scope carries unknown keys for the company scope`)
+            }
+            return { kind: 'requester_choice', mode, scope: { type: 'company' } }
+          case 'members':
+            if (Object.keys(scope).some((key) => !['type', 'userIds'].includes(key))) {
+              failValidation(context, `${sourcePath}.scope carries unknown keys for the members scope`)
+            }
+            return {
+              kind: 'requester_choice',
+              mode,
+              scope: { type: 'members', userIds: normalizeStringArray(scope.userIds, context, `${sourcePath}.scope.userIds`) },
+            }
+          case 'role':
+            if (Object.keys(scope).some((key) => !['type', 'roleIds'].includes(key))) {
+              failValidation(context, `${sourcePath}.scope carries unknown keys for the role scope`)
+            }
+            return {
+              kind: 'requester_choice',
+              mode,
+              scope: { type: 'role', roleIds: normalizeStringArray(scope.roleIds, context, `${sourcePath}.scope.roleIds`) },
+            }
+          default:
+            // `return` of the never-returning failValidation makes the exhaustiveness explicit
+            // for both TS and eslint's no-fallthrough (every scope branch returns or throws).
+            return failValidation(context, `${sourcePath}.scope.type must be company, members, or role`)
+        }
+      }
       default:
         failValidation(context, `${sourcePath}.kind is invalid`)
     }
@@ -1441,6 +1488,15 @@ function dynamicAssigneeSourceFingerprint(source: ApprovalAssigneeSource): strin
     case 'static_user':
     case 'static_role':
       // Statics are owned by collectBranchAssignees' duplicate check, not this gate.
+      return null
+    case 'requester_choice':
+      // Lock-1 §K2: `null` DELIBERATELY, not an oversight — the `_exhaustive` guard below forces
+      // this entry to exist, and this is the recorded decision. Two `requester_choice` sources on
+      // parallel branches are NOT provably identical: the requester may pick different people per
+      // branch, so per this gate's own rule (only provably-identical sources are publish-blocked)
+      // the same-person collision belongs to the RUNTIME
+      // `APPROVAL_ASSIGNEE_PARALLEL_DYNAMIC_CONFLICT` 409 guard
+      // (`assertNoActiveAssignmentConflicts`), which sees the actual chosen ids. Publish cannot.
       return null
     default: {
       const _exhaustive: never = source
@@ -2934,6 +2990,30 @@ export function runtimeGraphUsesOrgAssigneeSource(runtimeGraph: RuntimeGraph): b
           source.kind === 'manager_at_level'),
     )
   })
+}
+
+/**
+ * Lock-1 §K2: every `requester_choice` source in the published runtime graph, grouped by the
+ * carrying approval node's key. Drives the create-time choice validation + snapshot freeze —
+ * OPT-IN like `includeManagerChain`: an empty map means the create path does no K2 work at all.
+ */
+export function collectRuntimeGraphRequesterChoiceSources(
+  runtimeGraph: RuntimeGraph,
+): Map<string, RequesterChoiceAssigneeSource[]> {
+  const byNodeKey = new Map<string, RequesterChoiceAssigneeSource[]>()
+  for (const node of runtimeGraph.nodes) {
+    if (node.type !== 'approval') continue
+    const config: unknown = node.config
+    const sources = isRecord(config) ? config.assigneeSources : undefined
+    if (!Array.isArray(sources)) continue
+    for (const source of sources) {
+      if (!isRecord(source) || source.kind !== 'requester_choice') continue
+      const existing = byNodeKey.get(node.key)
+      if (existing) existing.push(source as unknown as RequesterChoiceAssigneeSource)
+      else byNodeKey.set(node.key, [source as unknown as RequesterChoiceAssigneeSource])
+    }
+  }
+  return byNodeKey
 }
 
 /**
@@ -4611,6 +4691,163 @@ export class ApprovalProductService {
   }
 
   /**
+   * Lock-1 §K2 — validate the submit-time requester choices against every published
+   * `requester_choice` node's configured scope, and return the FROZEN map (node key → chosen
+   * local user ids) the requester snapshot carries. Every rejection is a values-free 422
+   * (node keys and template-authored config only — never the chosen person ids) raised BEFORE
+   * any instance/assignment insert; a failed scope read is a retryable 503 (fail-closed,
+   * mirroring APPROVAL_REQUESTER_ORG_UNRESOLVED — an unverifiable choice must never freeze).
+   *
+   * Scope semantics (§K2, verbatim): `company` accepts any ACTIVE local user; `members`
+   * accepts only ids in the configured list (still active-checked — company is the widest
+   * scope and members/role only narrow it); `role` accepts only ids holding a configured
+   * role at create time, read FRESH from `user_roles`. That role read deliberately does NOT
+   * reuse `resolveApprovalRequesterRoleIds`: that helper INNER-JOINs `roles` on
+   * `approval_usable = true`, a curation flag governing the `requester.role` ROUTING
+   * predicate — importing it here would silently fail every choice scoped to a non-curated
+   * role. K2's role scope is plain role membership.
+   */
+  private async validateAndFreezeRequesterChoices(
+    payload: Record<string, string[]> | undefined,
+    sourcesByNode: Map<string, RequesterChoiceAssigneeSource[]>,
+    requireComplete: boolean,
+  ): Promise<Record<string, string[]>> {
+    if (!pool) throw new Error('Database not available')
+    // Payload shape: a plain record of node key → non-empty-string arrays. Anything else is a
+    // values-free 422 (the offending VALUE is never echoed — only the node key).
+    const normalized = new Map<string, string[]>()
+    if (payload !== undefined) {
+      if (!isRecord(payload)) {
+        throw new ServiceError('requesterChoices must be an object of node key to user-id arrays', 422, 'APPROVAL_REQUESTER_CHOICE_INVALID')
+      }
+      for (const [rawNodeKey, rawList] of Object.entries(payload)) {
+        const nodeKey = rawNodeKey.trim()
+        if (!sourcesByNode.has(nodeKey)) {
+          // An entry for a node the published route does not resolve by requester choice cannot
+          // be validated against any scope — fail-closed, never silently dropped.
+          throw new ServiceError(
+            `requesterChoices references a node that has no requester_choice source`,
+            422,
+            'APPROVAL_REQUESTER_CHOICE_UNKNOWN_NODE',
+            { nodeKey },
+          )
+        }
+        if (!Array.isArray(rawList) || rawList.some((entry) => typeof entry !== 'string' || entry.trim().length === 0)) {
+          throw new ServiceError(
+            `requesterChoices entries must be non-empty string arrays`,
+            422,
+            'APPROVAL_REQUESTER_CHOICE_INVALID',
+            { nodeKey },
+          )
+        }
+        // Trim + order-preserving dedupe; cardinality applies to the deduped list.
+        const ids: string[] = []
+        const seen = new Set<string>()
+        for (const entry of rawList) {
+          const id = entry.trim()
+          if (!seen.has(id)) {
+            seen.add(id)
+            ids.push(id)
+          }
+        }
+        normalized.set(nodeKey, ids)
+      }
+    }
+
+    const frozen: Record<string, string[]> = {}
+    // Batched activity check across every node's choices (company baseline for ALL scopes).
+    const allChosenIds = new Set<string>()
+    for (const ids of normalized.values()) for (const id of ids) allChosenIds.add(id)
+    let activeIds = new Set<string>()
+    if (allChosenIds.size > 0) {
+      try {
+        const activeResult = await pool.query<{ id: string }>(
+          `SELECT id FROM users WHERE id = ANY($1::varchar[]) AND is_active = TRUE`,
+          [[...allChosenIds]],
+        )
+        activeIds = new Set(activeResult.rows.map((row) => row.id))
+      } catch (error) {
+        metricsLogger.warn(
+          `Failed to resolve requester-choice candidates: ${error instanceof Error ? error.message : 'unknown error'}`,
+        )
+        throw new ServiceError(
+          'Could not verify the chosen approvers for this approval template. Please retry.',
+          503,
+          'APPROVAL_REQUESTER_CHOICE_UNRESOLVED',
+        )
+      }
+    }
+
+    for (const [nodeKey, sources] of sourcesByNode) {
+      const ids = normalized.get(nodeKey)
+      if (!ids || ids.length === 0) {
+        if (requireComplete) {
+          // §K2: the requester was REQUIRED to choose and did not — a create-time 422, never an
+          // empty resolution (only a made-then-unusable choice reaches emptyAssigneePolicy).
+          throw new ServiceError(
+            `A requester choice is required for this approval node`,
+            422,
+            'APPROVAL_REQUESTER_CHOICE_REQUIRED',
+            { nodeKey },
+          )
+        }
+        continue // read-only preview without choices: the node walks as EMPTY_ASSIGNEES, honestly.
+      }
+      for (const source of sources) {
+        // Mode cardinality — values-free 422 BEFORE any insert.
+        if ((source.mode === 'single' && ids.length !== 1) || (source.mode === 'multi' && ids.length === 0)) {
+          throw new ServiceError(
+            source.mode === 'single'
+              ? `This approval node requires exactly one chosen approver`
+              : `This approval node requires at least one chosen approver`,
+            422,
+            'APPROVAL_REQUESTER_CHOICE_CARDINALITY',
+            { nodeKey, mode: source.mode },
+          )
+        }
+        const outOfScope = (scopeType: RequesterChoiceAssigneeSource['scope']['type']): never => {
+          throw new ServiceError(
+            `A chosen approver is outside the scope configured for this approval node`,
+            422,
+            'APPROVAL_REQUESTER_CHOICE_OUT_OF_SCOPE',
+            { nodeKey, scopeType },
+          )
+        }
+        // Baseline for every scope: each chosen id is an ACTIVE local user.
+        if (ids.some((id) => !activeIds.has(id))) outOfScope(source.scope.type)
+        if (source.scope.type === 'members') {
+          const allowed = new Set(source.scope.userIds.map((id) => id.trim()))
+          if (ids.some((id) => !allowed.has(id))) outOfScope('members')
+        } else if (source.scope.type === 'role') {
+          // FRESH plain `user_roles` membership — see the method doc for why this must NOT go
+          // through resolveApprovalRequesterRoleIds (approval_usable is routing-predicate
+          // curation, not approver selection).
+          let holders: Set<string>
+          try {
+            const holderResult = await pool.query<{ user_id: string }>(
+              `SELECT DISTINCT user_id FROM user_roles WHERE user_id = ANY($1::varchar[]) AND role_id = ANY($2::varchar[])`,
+              [ids, source.scope.roleIds],
+            )
+            holders = new Set(holderResult.rows.map((row) => row.user_id))
+          } catch (error) {
+            metricsLogger.warn(
+              `Failed to resolve requester-choice role membership: ${error instanceof Error ? error.message : 'unknown error'}`,
+            )
+            throw new ServiceError(
+              'Could not verify the chosen approvers for this approval template. Please retry.',
+              503,
+              'APPROVAL_REQUESTER_CHOICE_UNRESOLVED',
+            )
+          }
+          if (ids.some((id) => !holders.has(id))) outOfScope('role')
+        }
+      }
+      frozen[nodeKey] = ids
+    }
+    return frozen
+  }
+
+  /**
    * RP-1 (route-preview lock, RATIFIED — RP-0): the SINGLE assembly shared by createApproval and
    * the read-only route preview. Everything from template-bundle load through executor
    * construction lives here so preview can NEVER drift from create (the same normalization,
@@ -4618,10 +4855,17 @@ export class ApprovalProductService {
    * Persistence never happens here; the caller decides whether to write (create) or walk (preview).
    */
   private async assembleCreationContext(
-    request: { templateId: string; formData: Record<string, unknown> },
+    request: { templateId: string; formData: Record<string, unknown>; requesterChoices?: Record<string, string[]> },
     actor: CreateApprovalActor,
     options: {
       whitelistFormDataToSchema?: boolean
+      // Lock-1 §K2: the READ-ONLY previews (B3-05/B3-06) may walk a `requester_choice` route
+      // WITHOUT the submit-time choices — the affected node then previews honestly as
+      // EMPTY_ASSIGNEES instead of 422-blocking the preview. The CREATE path (default) keeps
+      // the fail-closed contract: a published requester_choice node with no entry in the
+      // payload is a values-free 422 BEFORE any insert. Choices that ARE supplied are
+      // scope/cardinality-validated identically on every path (preview cannot drift).
+      requesterChoicePresence?: 'require' | 'optional'
       // RP-3 (B3-06 authoring 试运行): source the runtime graph from the LATEST (possibly draft)
       // version, compiled on the fly with the SAME buildRuntimeGraph the publish path uses (no
       // parallel impl) — lets an author dry-run un-published edits. Default 'active' = the
@@ -4920,6 +5164,21 @@ export class ApprovalProductService {
       )
     }
 
+    // Lock-1 §K2 (requester_choice) — validate the submitter's choices against each published
+    // node's configured scope and freeze them. Placed HERE, with the org/role wedge guards
+    // above and BEFORE any instance/assignment insert (mirroring the B5-b fail-closed
+    // placement): every rejection is a values-free 422 with zero rows persisted. OPT-IN — a
+    // graph without a requester_choice source (and a payload without choices) does no work.
+    const requesterChoiceSourcesByNode = collectRuntimeGraphRequesterChoiceSources(runtimeGraph)
+    let frozenRequesterChoices: Record<string, string[]> | undefined
+    if (requesterChoiceSourcesByNode.size > 0 || request.requesterChoices !== undefined) {
+      frozenRequesterChoices = await this.validateAndFreezeRequesterChoices(
+        request.requesterChoices,
+        requesterChoiceSourcesByNode,
+        options.requesterChoicePresence !== 'optional',
+      )
+    }
+
     // Delegation (委托) — freeze the active delegator->delegatee map (scoped to this
     // template + the create instant) into the snapshot BEFORE the executor resolves the
     // initial state, so the resolver's pushResolved substitution reads a frozen set and an
@@ -4956,6 +5215,11 @@ export class ApprovalProductService {
       ...(orgRelations.deptHeadId ? { deptHeadId: orgRelations.deptHeadId } : {}),
       ...(orgRelations.managerChainIds ? { managerChainIds: orgRelations.managerChainIds } : {}),
       ...(Object.keys(delegationMap).length > 0 ? { delegations: delegationMap } : {}),
+      // Lock-1 §K2: freeze the validated submit-time choices (node key → chosen local user
+      // ids). The resolver reads ONLY this map — immutable across return/admin-jump/timeout.
+      ...(frozenRequesterChoices && Object.keys(frozenRequesterChoices).length > 0
+        ? { requesterChoices: frozenRequesterChoices }
+        : {}),
     }
     const executor = new ApprovalGraphExecutor(runtimeGraph, normalizedFormData, {
       assignmentResolver: buildApprovalAssignmentResolver({
@@ -4992,12 +5256,15 @@ export class ApprovalProductService {
    * admin variant threads its sampleRequester through the same method under its own guard.
    */
   async previewApprovalRoute(
-    request: { templateId: string; formData: Record<string, unknown> },
+    request: { templateId: string; formData: Record<string, unknown>; requesterChoices?: Record<string, string[]> },
     actor: CreateApprovalActor,
   ): Promise<ApprovalRoutePreviewResult> {
     // B3-05: the requester IS the session actor; publish gate applies (active runtime graph).
+    // §K2: choices are OPTIONAL on the read-only preview (a not-yet-chosen requester_choice
+    // node previews as EMPTY_ASSIGNEES); supplied choices are validated + resolved to names.
     const { runtimeGraph, executor } = await this.assembleCreationContext(request, actor, {
       whitelistFormDataToSchema: true,
+      requesterChoicePresence: 'optional',
     })
     return this.walkPreviewRoute(runtimeGraph, executor)
   }
@@ -5011,7 +5278,7 @@ export class ApprovalProductService {
    * (owner order ③). `actor` still authorizes template visibility inside assembleCreationContext.
    */
   async previewTemplateRoute(
-    request: { templateId: string; formData: Record<string, unknown> },
+    request: { templateId: string; formData: Record<string, unknown>; requesterChoices?: Record<string, string[]> },
     actor: CreateApprovalActor,
     options: {
       // Identity only — see assembleCreationContext.requesterOverride: the sample requester's org
@@ -5022,6 +5289,7 @@ export class ApprovalProductService {
     const { runtimeGraph, executor } = await this.assembleCreationContext(request, actor, {
       whitelistFormDataToSchema: true,
       previewSource: 'draft',
+      requesterChoicePresence: 'optional',
       ...(options.sampleRequester ? { requesterOverride: options.sampleRequester } : {}),
     })
     return this.walkPreviewRoute(runtimeGraph, executor)

--- a/packages/core-backend/src/services/approval-directory.ts
+++ b/packages/core-backend/src/services/approval-directory.ts
@@ -30,24 +30,55 @@ function clampLimit(limit: number): number {
   return Math.min(Math.max(Math.trunc(limit), 1), MAX_LIMIT)
 }
 
+/**
+ * Lock-1 §K2 — optional scope narrowing for the submit-time requester-choice picker. Both
+ * constraints AND onto the base active-user search: `userIds` restricts candidates to an
+ * explicit id list (the `members` scope, template-authored config); `roleIds` restricts to
+ * users holding at least one of the roles via PLAIN `user_roles` membership (the `role`
+ * scope) — deliberately NOT joined on `roles.approval_usable`, which curates the
+ * `requester.role` ROUTING predicate, not approver selection (§K1 honesty note). The picker
+ * is candidate convenience only; `validateAndFreezeRequesterChoices` re-validates the actual
+ * submitted choice server-side at create.
+ */
+export interface DirectoryUserSearchScope {
+  userIds?: string[]
+  roleIds?: string[]
+}
+
 /** Search active users by id/name/email/username. Returns id/name/email only. */
-export async function searchDirectoryUsers(q: string, limit: number): Promise<DirectoryUserOption[]> {
+export async function searchDirectoryUsers(
+  q: string,
+  limit: number,
+  scope: DirectoryUserSearchScope = {},
+): Promise<DirectoryUserOption[]> {
   const safeLimit = clampLimit(limit)
   const term = q ? `%${q}%` : null
-  const where = term
-    ? `WHERE is_active = TRUE AND (COALESCE(email, '') ILIKE $1 OR COALESCE(username, '') ILIKE $1 OR name ILIKE $1 OR id ILIKE $1)`
-    : `WHERE is_active = TRUE`
+  const params: unknown[] = []
+  const conditions: string[] = ['is_active = TRUE']
+  if (term) {
+    params.push(term)
+    const p = `$${params.length}`
+    conditions.push(`(COALESCE(email, '') ILIKE ${p} OR COALESCE(username, '') ILIKE ${p} OR name ILIKE ${p} OR id ILIKE ${p})`)
+  }
+  const scopeUserIds = (scope.userIds ?? []).map((id) => id.trim()).filter((id) => id.length > 0)
+  if (scopeUserIds.length > 0) {
+    params.push(scopeUserIds)
+    conditions.push(`id = ANY($${params.length}::varchar[])`)
+  }
+  const scopeRoleIds = (scope.roleIds ?? []).map((id) => id.trim()).filter((id) => id.length > 0)
+  if (scopeRoleIds.length > 0) {
+    params.push(scopeRoleIds)
+    conditions.push(`EXISTS (SELECT 1 FROM user_roles ur WHERE ur.user_id = users.id AND ur.role_id = ANY($${params.length}::varchar[]))`)
+  }
+  params.push(safeLimit)
   const sql = `
     SELECT id, name, COALESCE(email, '') AS email
     FROM users
-    ${where}
+    WHERE ${conditions.join(' AND ')}
     ORDER BY name ASC
-    LIMIT ${term ? '$2' : '$1'}
+    LIMIT $${params.length}
   `
-  const result = await query<{ id: string; name: string; email: string }>(
-    sql,
-    term ? [term, safeLimit] : [safeLimit],
-  )
+  const result = await query<{ id: string; name: string; email: string }>(sql, params)
   return result.rows.map((row) => ({ id: row.id, name: row.name ?? '', email: row.email ?? '' }))
 }
 

--- a/packages/core-backend/src/types/approval-product.ts
+++ b/packages/core-backend/src/types/approval-product.ts
@@ -12,7 +12,7 @@ export type ApprovalProductPermission = typeof APPROVAL_PRODUCT_PERMISSIONS[numb
 
 export type ApprovalNodeType = 'start' | 'approval' | 'cc' | 'condition' | 'parallel' | 'end'
 export type ApprovalAssigneeType = 'user' | 'role'
-export type ApprovalAssigneeSourceKind = 'static_user' | 'static_role' | 'requester' | 'form_field_user' | 'direct_manager' | 'dept_head' | 'continuous_managers' | 'manager_at_level'
+export type ApprovalAssigneeSourceKind = 'static_user' | 'static_role' | 'requester' | 'form_field_user' | 'direct_manager' | 'dept_head' | 'continuous_managers' | 'manager_at_level' | 'requester_choice'
 export type ApprovalMode = 'single' | 'all' | 'any' | 'threshold'
 export type ParallelJoinMode = 'all' | 'any'
 export type EmptyAssigneePolicy = 'error' | 'auto-approve'
@@ -168,6 +168,30 @@ export type ApprovalAssigneeSource =
    * `[1, MAX_MANAGER_CHAIN_LEVELS]` at normalize time.
    */
   | { kind: 'manager_at_level'; level: number }
+  /**
+   * Lock-1 §K2 — 提交人自选 (requester choice). The REQUESTER picks the approver(s) at SUBMIT
+   * time: the chosen local user ids travel in the create payload
+   * (`CreateApprovalRequest.requesterChoices`, keyed by node key), are validated server-side
+   * against THIS configured `scope` at create (fail-closed 422 BEFORE any insert), and are
+   * frozen into `ApprovalRequesterSnapshot.requesterChoices`. The resolver reads ONLY that
+   * frozen map — never a live directory/role read — so return/admin-jump/timeout re-entry
+   * re-resolves the SAME list; changing an in-flight seat is `transfer`, not a re-choice.
+   * `mode: 'single'` requires exactly one chosen id; `'multi'` requires at least one.
+   * Scope semantics at create: `company` = any active local user; `members` = only ids in the
+   * configured list; `role` = only ids holding a configured role in a FRESH `user_roles` read
+   * (plain role membership — deliberately NOT the `approval_usable`-curated
+   * `resolveApprovalRequesterRoleIds`, which serves the `requester.role` ROUTING predicate).
+   */
+  | {
+      kind: 'requester_choice'
+      mode: 'single' | 'multi'
+      scope:
+        | { type: 'company' }
+        | { type: 'members'; userIds: string[] }
+        | { type: 'role'; roleIds: string[] }
+    }
+
+export type RequesterChoiceAssigneeSource = Extract<ApprovalAssigneeSource, { kind: 'requester_choice' }>
 
 export interface ApprovalAssigneeResolutionMetadata {
   /**
@@ -359,6 +383,16 @@ export interface ApprovalRequesterSnapshot {
    * delegation applies; purely additive.
    */
   delegations?: Record<string, string>
+  /**
+   * Lock-1 §K2 (requester_choice) — the requester's submit-time approver choices, FROZEN at
+   * create: node key → chosen local user ids, validated against each `requester_choice`
+   * source's configured scope BEFORE any insert. OPT-IN: present only when the published
+   * runtime graph carries a `requester_choice` source (unrelated approvals pay nothing).
+   * The resolver reads ONLY this map (no live read at dispatch/return/admin-jump/timeout),
+   * so a re-entered node re-resolves the SAME list; a directory/role change after create
+   * never alters it — the sanctioned in-flight mutation is `transfer`.
+   */
+  requesterChoices?: Record<string, string[]>
   [key: string]: unknown
 }
 
@@ -431,6 +465,15 @@ export interface UnifiedApprovalHistoryDTO {
 export interface CreateApprovalRequest {
   templateId: string
   formData: Record<string, unknown>
+  /**
+   * Lock-1 §K2 (requester_choice) — submit-time approver choices, keyed by the published
+   * `requester_choice` node's key. REQUIRED (per node) when the published route carries a
+   * `requester_choice` source: a missing/empty entry is a values-free 422 at create, never an
+   * empty resolution. Validated server-side against the node's configured scope + mode
+   * cardinality BEFORE any instance/assignment insert, then frozen into the requester
+   * snapshot (`requesterChoices`) that the resolver reads.
+   */
+  requesterChoices?: Record<string, string[]>
 }
 
 export interface ApprovalActionRequest {

--- a/packages/core-backend/tests/integration/approval-requester-choice.db.test.ts
+++ b/packages/core-backend/tests/integration/approval-requester-choice.db.test.ts
@@ -1,0 +1,512 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import net from 'net'
+import { MetaSheetServer } from '../../src/index'
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { ensureApprovalSchemaReady, grantApprovalWriteForIntegrationActor } from '../helpers/approval-schema-bootstrap'
+
+/**
+ * Lock-1 §K2 `requester_choice` (提交人自选) — REAL-DB end-to-end acceptance
+ * (docs/development/approval-lock1-enterprise-assignees-20260817.md §K2, gates G-1/G-2/G-8/G-9/
+ * G-17/G-18; harness mirrors approval-requester-role.db.test.ts).
+ *
+ * Proves:
+ *  G-1/G-2  the authoring choke accepts requester_choice ONLY in its exact shape and rejects a
+ *           contract-unimplemented kind outright (never persisted, never inert);
+ *  G-8      out-of-scope / cardinality / missing choices are values-free 422 at create with ZERO
+ *           rows persisted; an in-scope choice creates and the assignment carries
+ *           metadata.resolvedFrom.kind='requester_choice' — including the CURATION-INDEPENDENCE
+ *           discriminator: the role scope validates against PLAIN user_roles membership, so a
+ *           choice scoped to a role with approval_usable=FALSE still validates (a broken
+ *           implementation importing resolveApprovalRequesterRoleIds would 422 here);
+ *  G-9      a role change AFTER create does not alter the frozen choice — dispatch resolves the
+ *           chosen user, a return re-entry re-resolves the SAME list — while `transfer` (the
+ *           sanctioned mutation) DOES change the seat;
+ *  G-17     the null fingerprint is deliberate: requester_choice on both parallel branches
+ *           publishes (arm 1, with a `requester`×`requester` publish-400 positive control) and the
+ *           same-person collision is caught by the RUNTIME 409 (arm 2, with a
+ *           different-person create succeeding as the positive control);
+ *  G-18     the 422 bodies carry the node key (template-authored) and NEVER the chosen person id.
+ */
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const TS = Date.now()
+const REQ = `rchoice-req-${TS}`
+const APPROVER = `rchoice-appr-${TS}`
+const CHOSEN = `rchoice-chosen-${TS}` // holds ROLE (approval_usable=FALSE — the curation trap)
+const NON_HOLDER = `rchoice-nonholder-${TS}` // active user with NO user_roles row
+const M1 = `rchoice-m1-${TS}`
+const M2 = `rchoice-m2-${TS}`
+const OTHER = `rchoice-other-${TS}` // active; outside every members list; transfer target
+const INACTIVE = `rchoice-inactive-${TS}` // users.is_active = FALSE
+const ROLE = `rchoice-role-${TS}` // seeded with approval_usable = FALSE, deliberately
+
+async function canListen(): Promise<boolean> {
+  return await new Promise((r) => {
+    const s = net.createServer()
+    s.once('error', () => r(false))
+    s.listen(0, '127.0.0.1', () => s.close(() => r(true)))
+  })
+}
+async function tok(base: string, userId: string): Promise<string> {
+  await grantApprovalWriteForIntegrationActor(userId)
+  const res = await fetch(`${base}/api/auth/dev-token?userId=${encodeURIComponent(userId)}&roles=admin&perms=${encodeURIComponent('*:*')}`)
+  return ((await res.json()) as { token: string }).token
+}
+async function req(base: string, path: string, token: string, opts: { method?: string; body?: unknown } = {}): Promise<Response> {
+  return fetch(`${base}${path}`, {
+    method: opts.method || 'GET',
+    headers: { Authorization: `Bearer ${token}`, ...(opts.body !== undefined ? { 'Content-Type': 'application/json' } : {}) },
+    ...(opts.body !== undefined ? { body: JSON.stringify(opts.body) } : {}),
+  })
+}
+
+const FORM_SCHEMA = { fields: [{ id: 'reason', type: 'text', label: 'r', required: true }] }
+
+// Linear: static gate first, then a SINGLE-mode ROLE-scoped requester_choice node — used by the
+// role-scope validation, freeze/immutability (G-9) and transfer tests.
+const ROLE_SCOPE_GRAPH = {
+  nodes: [
+    { key: 'start', type: 'start', name: 's', config: {} },
+    { key: 'approval_1', type: 'approval', name: 'gate', config: { assigneeSources: [{ kind: 'static_user', userIds: [APPROVER] }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+    { key: 'approval_rc', type: 'approval', name: 'chosen', config: { assigneeSources: [{ kind: 'requester_choice', mode: 'single', scope: { type: 'role', roleIds: [ROLE] } }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+    { key: 'end', type: 'end', name: 'e', config: {} },
+  ],
+  edges: [
+    { key: 's2a1', source: 'start', target: 'approval_1' },
+    { key: 'a12rc', source: 'approval_1', target: 'approval_rc' },
+    { key: 'rc2e', source: 'approval_rc', target: 'end' },
+  ],
+}
+
+// MULTI-mode MEMBERS-scoped requester_choice as the first (and only) approval node.
+const MEMBERS_SCOPE_GRAPH = {
+  nodes: [
+    { key: 'start', type: 'start', name: 's', config: {} },
+    { key: 'approval_rc', type: 'approval', name: 'chosen', config: { assigneeSources: [{ kind: 'requester_choice', mode: 'multi', scope: { type: 'members', userIds: [M1, M2] } }], approvalMode: 'all', emptyAssigneePolicy: 'error' } },
+    { key: 'end', type: 'end', name: 'e', config: {} },
+  ],
+  edges: [
+    { key: 's2rc', source: 'start', target: 'approval_rc' },
+    { key: 'rc2e', source: 'approval_rc', target: 'end' },
+  ],
+}
+
+// SINGLE-mode COMPANY-scoped requester_choice (any ACTIVE local user).
+const COMPANY_SCOPE_GRAPH = {
+  nodes: [
+    { key: 'start', type: 'start', name: 's', config: {} },
+    { key: 'approval_rc', type: 'approval', name: 'chosen', config: { assigneeSources: [{ kind: 'requester_choice', mode: 'single', scope: { type: 'company' } }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+    { key: 'end', type: 'end', name: 'e', config: {} },
+  ],
+  edges: [
+    { key: 's2rc', source: 'start', target: 'approval_rc' },
+    { key: 'rc2e', source: 'approval_rc', target: 'end' },
+  ],
+}
+
+// Parallel fork whose BOTH branches are company-scoped requester_choice nodes (G-17).
+function parallelChoiceGraph(branchSource: (branch: 'a' | 'b') => Record<string, unknown>) {
+  return {
+    nodes: [
+      { key: 'start', type: 'start', name: 's', config: {} },
+      { key: 'fork', type: 'parallel', name: 'fork', config: { branches: ['e-fork-a', 'e-fork-b'], joinMode: 'all', joinNodeKey: 'join' } },
+      { key: 'branch_a', type: 'approval', name: 'A', config: { assigneeSources: [branchSource('a')], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+      { key: 'branch_b', type: 'approval', name: 'B', config: { assigneeSources: [branchSource('b')], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+      { key: 'join', type: 'approval', name: 'join', config: { assigneeSources: [{ kind: 'static_user', userIds: [APPROVER] }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+      { key: 'end', type: 'end', name: 'e', config: {} },
+    ],
+    edges: [
+      { key: 'e-start-fork', source: 'start', target: 'fork' },
+      { key: 'e-fork-a', source: 'fork', target: 'branch_a' },
+      { key: 'e-fork-b', source: 'fork', target: 'branch_b' },
+      { key: 'e-a-join', source: 'branch_a', target: 'join' },
+      { key: 'e-b-join', source: 'branch_b', target: 'join' },
+      { key: 'e-join-end', source: 'join', target: 'end' },
+    ],
+  }
+}
+
+type ErrorBody = { code?: string; error?: { code?: string; message?: string; details?: Record<string, unknown> } }
+function errorCode(body: ErrorBody): string | undefined {
+  return body.code ?? body.error?.code
+}
+
+describeIfDatabase('Lock-1 §K2 requester_choice — real-DB create/freeze/dispatch acceptance', () => {
+  let server: MetaSheetServer | undefined
+  let base = ''
+  let reqTok = ''
+  let apprTok = ''
+  let chosenTok = ''
+
+  async function createTemplate(key: string, graph: unknown): Promise<string> {
+    const created = await req(base, '/api/approval-templates', reqTok, {
+      method: 'POST',
+      body: { key, name: key, formSchema: FORM_SCHEMA, approvalGraph: graph },
+    })
+    expect(created.status, await created.clone().text()).toBe(201)
+    return ((await created.json()) as { id: string }).id
+  }
+  async function publishTemplate(tid: string): Promise<Response> {
+    return req(base, `/api/approval-templates/${tid}/publish`, reqTok, { method: 'POST', body: { policy: { allowRevoke: true } } })
+  }
+  async function createPublished(key: string, graph: unknown): Promise<string> {
+    const tid = await createTemplate(key, graph)
+    const published = await publishTemplate(tid)
+    expect(published.status, await published.clone().text()).toBe(200)
+    return tid
+  }
+  async function instanceCount(tid: string): Promise<number> {
+    const pool = poolManager.get()
+    const rows = await pool.query(`SELECT COUNT(*)::int AS n FROM approval_instances WHERE template_id = $1`, [tid])
+    return (rows.rows[0] as { n: number }).n
+  }
+  async function activeAssignees(iid: string): Promise<Array<{ assignee_id: string; node_key: string | null; metadata: Record<string, unknown> | null }>> {
+    const pool = poolManager.get()
+    const rows = await pool.query(
+      `SELECT assignee_id, node_key, metadata FROM approval_assignments WHERE instance_id = $1 AND is_active = TRUE ORDER BY assignee_id`,
+      [iid],
+    )
+    return rows.rows as Array<{ assignee_id: string; node_key: string | null; metadata: Record<string, unknown> | null }>
+  }
+
+  beforeAll(async () => {
+    expect(await canListen()).toBe(true)
+    await ensureApprovalSchemaReady()
+    const pool = poolManager.get()
+    // RBAC table guards (defensive — present via migrations in a full CI lane; matches the real schema).
+    await pool.query(`CREATE TABLE IF NOT EXISTS user_roles (user_id varchar(255) NOT NULL, role_id varchar(255) NOT NULL, created_at timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL)`)
+    await pool.query(`CREATE TABLE IF NOT EXISTS roles (id text PRIMARY KEY, name text NOT NULL, created_at timestamptz DEFAULT now() NOT NULL, updated_at timestamptz DEFAULT now() NOT NULL)`)
+    await pool.query(`ALTER TABLE roles ADD COLUMN IF NOT EXISTS approval_usable boolean NOT NULL DEFAULT false`)
+    await pool.query(`ALTER TABLE users ADD COLUMN IF NOT EXISTS is_active boolean NOT NULL DEFAULT true`)
+    // CURATION-INDEPENDENCE TRAP (§K2 verbatim): the choice-scope role is approval_usable=FALSE.
+    // K2's role scope is PLAIN membership; only the requester.role ROUTING predicate is curated.
+    await pool.query(`INSERT INTO roles (id, name, approval_usable) VALUES ($1, $2, false) ON CONFLICT (id) DO UPDATE SET approval_usable = false`, [ROLE, ROLE])
+    for (const userId of [REQ, APPROVER, CHOSEN, NON_HOLDER, M1, M2, OTHER]) {
+      await pool.query(`INSERT INTO users (id, email, password_hash, is_active) VALUES ($1, $2, 'x', TRUE) ON CONFLICT (id) DO NOTHING`, [userId, `${userId}@x.test`])
+    }
+    await pool.query(`INSERT INTO users (id, email, password_hash, is_active) VALUES ($1, $2, 'x', FALSE) ON CONFLICT (id) DO NOTHING`, [INACTIVE, `${INACTIVE}@x.test`])
+    await pool.query(`INSERT INTO user_roles (user_id, role_id) VALUES ($1, $2) ON CONFLICT DO NOTHING`, [CHOSEN, ROLE])
+    server = new MetaSheetServer({ port: 0, host: '127.0.0.1', pluginDirs: [] })
+    await server.start()
+    base = `http://127.0.0.1:${server.getAddress()!.port}`
+    reqTok = await tok(base, REQ)
+    apprTok = await tok(base, APPROVER)
+    chosenTok = await tok(base, CHOSEN)
+  })
+
+  afterAll(async () => {
+    try {
+      const pool = poolManager.get()
+      const tids = (await pool.query(`SELECT id FROM approval_templates WHERE key LIKE $1`, [`rchoice-${TS}-%`])).rows.map((r) => r.id as string)
+      if (tids.length > 0) {
+        const iids = (await pool.query(`SELECT id FROM approval_instances WHERE template_id = ANY($1::uuid[])`, [tids])).rows.map((r) => r.id as string)
+        if (iids.length > 0) {
+          await pool.query(`DELETE FROM approval_records WHERE instance_id = ANY($1)`, [iids])
+          await pool.query(`DELETE FROM approval_assignments WHERE instance_id = ANY($1)`, [iids])
+          await pool.query(`DELETE FROM approval_instances WHERE id = ANY($1)`, [iids])
+        }
+        await pool.query(`DELETE FROM approval_published_definitions WHERE template_id = ANY($1::uuid[])`, [tids])
+        await pool.query(`DELETE FROM approval_templates WHERE id = ANY($1::uuid[])`, [tids])
+      }
+      await pool.query(`DELETE FROM user_roles WHERE user_id = ANY($1::varchar[])`, [[CHOSEN]])
+      await pool.query(`DELETE FROM users WHERE id = ANY($1::varchar[])`, [[REQ, APPROVER, CHOSEN, NON_HOLDER, M1, M2, OTHER, INACTIVE]])
+      await pool.query(`DELETE FROM roles WHERE id = ANY($1::text[])`, [[ROLE]])
+    } catch {
+      /* best effort */
+    }
+    if (server) await server.stop()
+  })
+
+  it('sentinel: DATABASE_URL is set (DB-backed lane must not silently skip)', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  // ── G-1 / G-2 — authoring choke: exact shape only; unimplemented kinds fail closed ─────────
+  it('G-1: requester_choice saves in its exact shape; bad mode / unknown scope type / extra scope key each 400', async () => {
+    // Positive control FIRST: the exact shape saves (the rejection below is shape-selected).
+    await createTemplate(`rchoice-${TS}-g1-ok`, ROLE_SCOPE_GRAPH)
+
+    const badShapes: Array<Record<string, unknown>> = [
+      { kind: 'requester_choice', mode: 'both', scope: { type: 'company' } },
+      { kind: 'requester_choice', mode: 'single', scope: { type: 'dept' } },
+      { kind: 'requester_choice', mode: 'single', scope: { type: 'company', extra: true } },
+      { kind: 'requester_choice', mode: 'single', scope: { type: 'members', userIds: [] } },
+      { kind: 'requester_choice', mode: 'single', scope: { type: 'role' } },
+      { kind: 'requester_choice', mode: 'single', scope: { type: 'company' }, futureFlag: 1 },
+    ]
+    for (const source of badShapes) {
+      const graph = JSON.parse(JSON.stringify(COMPANY_SCOPE_GRAPH)) as typeof COMPANY_SCOPE_GRAPH
+      ;(graph.nodes[1].config as { assigneeSources: unknown[] }).assigneeSources = [source]
+      const res = await req(base, '/api/approval-templates', reqTok, {
+        method: 'POST',
+        body: { key: `rchoice-${TS}-g1-bad`, name: 'bad', formSchema: FORM_SCHEMA, approvalGraph: graph },
+      })
+      expect(res.status, JSON.stringify(source)).toBe(400)
+    }
+  })
+
+  it('G-2: a contract-unimplemented kind (user_group) is rejected at authoring and never persisted', async () => {
+    const graph = JSON.parse(JSON.stringify(COMPANY_SCOPE_GRAPH)) as typeof COMPANY_SCOPE_GRAPH
+    ;(graph.nodes[1].config as { assigneeSources: unknown[] }).assigneeSources = [{ kind: 'user_group', groupIds: ['g1'] }]
+    const key = `rchoice-${TS}-g2-usergroup`
+    const res = await req(base, '/api/approval-templates', reqTok, {
+      method: 'POST',
+      body: { key, name: key, formSchema: FORM_SCHEMA, approvalGraph: graph },
+    })
+    expect(res.status).toBe(400)
+    const pool = poolManager.get()
+    const rows = await pool.query(`SELECT id FROM approval_templates WHERE key = $1`, [key])
+    expect(rows.rows).toHaveLength(0)
+    // Positive control: the implemented kind persisted in the same fixture family (G-1 above).
+  })
+
+  // ── G-8 — create-path scope validation: values-free 422, zero rows ─────────────────────────
+  it('G-8: a published requester_choice node with NO entry in the payload is a create-time 422 (REQUIRED), zero rows', async () => {
+    const tid = await createPublished(`rchoice-${TS}-g8-required`, MEMBERS_SCOPE_GRAPH)
+    const res = await req(base, '/api/approvals', reqTok, { method: 'POST', body: { templateId: tid, formData: { reason: 'r' } } })
+    expect(res.status, await res.clone().text()).toBe(422)
+    const body = (await res.json()) as ErrorBody
+    expect(errorCode(body)).toBe('APPROVAL_REQUESTER_CHOICE_REQUIRED')
+    expect(body.error?.details?.nodeKey).toBe('approval_rc')
+    expect(await instanceCount(tid)).toBe(0)
+
+    // Positive control in the SAME fixture: an in-scope choice creates successfully, the frozen
+    // map lands in the snapshot, and the assignment is attributed to requester_choice.
+    const ok = await req(base, '/api/approvals', reqTok, {
+      method: 'POST',
+      body: { templateId: tid, formData: { reason: 'r' }, requesterChoices: { approval_rc: [M1] } },
+    })
+    expect(ok.status, await ok.clone().text()).toBe(201)
+    const iid = ((await ok.json()) as { id: string }).id
+    const pool = poolManager.get()
+    const snap = (await pool.query<{ requester_snapshot: { requesterChoices?: Record<string, string[]> } }>(
+      `SELECT requester_snapshot FROM approval_instances WHERE id = $1`,
+      [iid],
+    )).rows[0]
+    expect(snap.requester_snapshot.requesterChoices).toEqual({ approval_rc: [M1] })
+    const assignments = await activeAssignees(iid)
+    expect(assignments.map((a) => a.assignee_id)).toEqual([M1])
+    const resolvedFrom = (assignments[0].metadata as { resolvedFrom?: { kind?: string } } | null)?.resolvedFrom
+    expect(resolvedFrom?.kind).toBe('requester_choice')
+  })
+
+  it('G-8/G-18: an out-of-list members choice is a VALUES-FREE 422 (node key present, chosen id absent), zero rows', async () => {
+    const tid = await createPublished(`rchoice-${TS}-g8-members`, MEMBERS_SCOPE_GRAPH)
+    const res = await req(base, '/api/approvals', reqTok, {
+      method: 'POST',
+      body: { templateId: tid, formData: { reason: 'r' }, requesterChoices: { approval_rc: [OTHER] } },
+    })
+    expect(res.status).toBe(422)
+    const raw = await res.clone().text()
+    const body = (await res.json()) as ErrorBody
+    expect(errorCode(body)).toBe('APPROVAL_REQUESTER_CHOICE_OUT_OF_SCOPE')
+    // G-18 both arms: values-free (no chosen person id anywhere in the body) AND the SAME path
+    // carries the node key + scope type — the check is not passing on an empty payload.
+    expect(raw).not.toContain(OTHER)
+    expect(body.error?.details?.nodeKey).toBe('approval_rc')
+    expect(body.error?.details?.scopeType).toBe('members')
+    expect(await instanceCount(tid)).toBe(0)
+  })
+
+  it('G-8: single-mode cardinality — two chosen ids 422 (CARDINALITY) with zero rows; multi-mode accepts two', async () => {
+    const singleTid = await createPublished(`rchoice-${TS}-g8-card-single`, COMPANY_SCOPE_GRAPH)
+    const res = await req(base, '/api/approvals', reqTok, {
+      method: 'POST',
+      body: { templateId: singleTid, formData: { reason: 'r' }, requesterChoices: { approval_rc: [M1, M2] } },
+    })
+    expect(res.status).toBe(422)
+    const body = (await res.json()) as ErrorBody
+    expect(errorCode(body)).toBe('APPROVAL_REQUESTER_CHOICE_CARDINALITY')
+    expect(body.error?.details?.mode).toBe('single')
+    expect(await instanceCount(singleTid)).toBe(0)
+
+    // Positive control: the SAME two ids are accepted by a MULTI-mode node — the rejection is
+    // mode-selected, not blanket.
+    const multiTid = await createPublished(`rchoice-${TS}-g8-card-multi`, MEMBERS_SCOPE_GRAPH)
+    const ok = await req(base, '/api/approvals', reqTok, {
+      method: 'POST',
+      body: { templateId: multiTid, formData: { reason: 'r' }, requesterChoices: { approval_rc: [M1, M2] } },
+    })
+    expect(ok.status, await ok.clone().text()).toBe(201)
+    const iid = ((await ok.json()) as { id: string }).id
+    expect((await activeAssignees(iid)).map((a) => a.assignee_id).sort()).toEqual([M1, M2].sort())
+  })
+
+  it('G-8: an entry for a node with NO requester_choice source is 422 (UNKNOWN_NODE), zero rows', async () => {
+    const tid = await createPublished(`rchoice-${TS}-g8-unknownnode`, MEMBERS_SCOPE_GRAPH)
+    const res = await req(base, '/api/approvals', reqTok, {
+      method: 'POST',
+      body: { templateId: tid, formData: { reason: 'r' }, requesterChoices: { approval_rc: [M1], start: [M2] } },
+    })
+    expect(res.status).toBe(422)
+    expect(errorCode((await res.json()) as ErrorBody)).toBe('APPROVAL_REQUESTER_CHOICE_UNKNOWN_NODE')
+    expect(await instanceCount(tid)).toBe(0)
+  })
+
+  it('G-8: company scope accepts any ACTIVE user and rejects an INACTIVE one (OUT_OF_SCOPE, zero rows)', async () => {
+    const tid = await createPublished(`rchoice-${TS}-g8-company`, COMPANY_SCOPE_GRAPH)
+    const bad = await req(base, '/api/approvals', reqTok, {
+      method: 'POST',
+      body: { templateId: tid, formData: { reason: 'r' }, requesterChoices: { approval_rc: [INACTIVE] } },
+    })
+    expect(bad.status).toBe(422)
+    expect(errorCode((await bad.json()) as ErrorBody)).toBe('APPROVAL_REQUESTER_CHOICE_OUT_OF_SCOPE')
+    expect(await instanceCount(tid)).toBe(0)
+
+    // Positive: an arbitrary ACTIVE user (no role, no members list) is in scope for `company`.
+    const ok = await req(base, '/api/approvals', reqTok, {
+      method: 'POST',
+      body: { templateId: tid, formData: { reason: 'r' }, requesterChoices: { approval_rc: [NON_HOLDER] } },
+    })
+    expect(ok.status, await ok.clone().text()).toBe(201)
+  })
+
+  it('G-8 role scope: PLAIN user_roles membership — validates against an approval_usable=FALSE role (curation-independence) and rejects a non-holder', async () => {
+    const tid = await createPublished(`rchoice-${TS}-g8-role`, ROLE_SCOPE_GRAPH)
+    // THE §K2 DISCRIMINATOR: ROLE is seeded approval_usable=FALSE. A (wrong) implementation
+    // reusing resolveApprovalRequesterRoleIds would resolve zero holders and 422 here.
+    const ok = await req(base, '/api/approvals', reqTok, {
+      method: 'POST',
+      body: { templateId: tid, formData: { reason: 'r' }, requesterChoices: { approval_rc: [CHOSEN] } },
+    })
+    expect(ok.status, await ok.clone().text()).toBe(201)
+
+    // Non-holder of the configured role: OUT_OF_SCOPE, values-free, zero NEW rows.
+    const before = await instanceCount(tid)
+    const bad = await req(base, '/api/approvals', reqTok, {
+      method: 'POST',
+      body: { templateId: tid, formData: { reason: 'r' }, requesterChoices: { approval_rc: [NON_HOLDER] } },
+    })
+    expect(bad.status).toBe(422)
+    const raw = await bad.clone().text()
+    expect(errorCode((await bad.json()) as ErrorBody)).toBe('APPROVAL_REQUESTER_CHOICE_OUT_OF_SCOPE')
+    expect(raw).not.toContain(NON_HOLDER)
+    expect(await instanceCount(tid)).toBe(before)
+  })
+
+  // ── G-9 — freeze-at-create: role change never re-routes; return re-resolves the SAME list;
+  //          transfer is the ONE sanctioned in-flight mutation ────────────────────────────────
+  it('G-9: role removed AFTER create → dispatch still assigns the frozen choice; return re-entry re-resolves the SAME list; transfer DOES move the seat', async () => {
+    const tid = await createPublished(`rchoice-${TS}-g9`, ROLE_SCOPE_GRAPH)
+    const started = await req(base, '/api/approvals', reqTok, {
+      method: 'POST',
+      body: { templateId: tid, formData: { reason: 'r' }, requesterChoices: { approval_rc: [CHOSEN] } },
+    })
+    expect(started.status, await started.clone().text()).toBe(201)
+    const iid = ((await started.json()) as { id: string }).id
+
+    // Directory/role change AFTER create: CHOSEN loses the scoped role entirely.
+    const pool = poolManager.get()
+    await pool.query(`DELETE FROM user_roles WHERE user_id = $1 AND role_id = $2`, [CHOSEN, ROLE])
+    try {
+      // Dispatch to the requester_choice node — resolves from the FROZEN map, not live user_roles.
+      const approved = await req(base, `/api/approvals/${iid}/actions`, apprTok, { method: 'POST', body: { action: 'approve' } })
+      expect(approved.status, await approved.clone().text()).toBeLessThan(300)
+      let active = await activeAssignees(iid)
+      expect(active.map((a) => a.assignee_id)).toEqual([CHOSEN])
+      expect(active[0].node_key).toBe('approval_rc')
+
+      // Return to the gate node, then re-approve: the RE-ENTERED node re-resolves the SAME
+      // frozen list (immutability across return — no re-read, no re-choice, no re-validation).
+      const returned = await req(base, `/api/approvals/${iid}/actions`, chosenTok, {
+        method: 'POST',
+        body: { action: 'return', targetNodeKey: 'approval_1' },
+      })
+      expect(returned.status, await returned.clone().text()).toBeLessThan(300)
+      const reApproved = await req(base, `/api/approvals/${iid}/actions`, apprTok, { method: 'POST', body: { action: 'approve' } })
+      expect(reApproved.status, await reApproved.clone().text()).toBeLessThan(300)
+      active = await activeAssignees(iid)
+      expect(active.map((a) => a.assignee_id)).toEqual([CHOSEN])
+      expect(active[0].node_key).toBe('approval_rc')
+
+      // Positive control (the sanctioned mutation): transfer moves the seat to OTHER.
+      const transferred = await req(base, `/api/approvals/${iid}/actions`, chosenTok, {
+        method: 'POST',
+        body: { action: 'transfer', targetUserId: OTHER },
+      })
+      expect(transferred.status, await transferred.clone().text()).toBeLessThan(300)
+      active = await activeAssignees(iid)
+      expect(active.map((a) => a.assignee_id)).toEqual([OTHER])
+      expect(active.map((a) => a.assignee_id)).not.toContain(CHOSEN)
+    } finally {
+      // Restore for any later test relying on CHOSEN's membership.
+      await pool.query(`INSERT INTO user_roles (user_id, role_id) VALUES ($1, $2) ON CONFLICT DO NOTHING`, [CHOSEN, ROLE])
+    }
+  })
+
+  // ── G-17 — null fingerprint deliberate: publish passes, runtime 409 owns the collision ──────
+  it('G-17 arm 1: requester_choice on BOTH parallel branches publishes; identical `requester` sources are publish-blocked (positive control)', async () => {
+    const rcTid = await createTemplate(
+      `rchoice-${TS}-g17-publish`,
+      parallelChoiceGraph(() => ({ kind: 'requester_choice', mode: 'single', scope: { type: 'company' } })),
+    )
+    const published = await publishTemplate(rcTid)
+    expect(published.status, await published.clone().text()).toBe(200)
+
+    // Positive control: the SAME topology with a provably-identical dynamic source on both
+    // branches is publish-blocked with the SAME code the runtime guard raises.
+    const dupTid = await createTemplate(
+      `rchoice-${TS}-g17-dup`,
+      parallelChoiceGraph(() => ({ kind: 'requester' })),
+    )
+    const blocked = await publishTemplate(dupTid)
+    expect(blocked.status, await blocked.clone().text()).toBe(400)
+    expect(errorCode((await blocked.json()) as ErrorBody)).toBe('APPROVAL_ASSIGNEE_PARALLEL_DYNAMIC_CONFLICT')
+  })
+
+  it('G-17 arm 2: choosing the SAME person for both branches hits the runtime 409 (zero rows); different persons create fine', async () => {
+    const tid = await createPublished(
+      `rchoice-${TS}-g17-runtime`,
+      parallelChoiceGraph(() => ({ kind: 'requester_choice', mode: 'single', scope: { type: 'company' } })),
+    )
+    const conflicted = await req(base, '/api/approvals', reqTok, {
+      method: 'POST',
+      body: { templateId: tid, formData: { reason: 'r' }, requesterChoices: { branch_a: [M1], branch_b: [M1] } },
+    })
+    expect(conflicted.status, await conflicted.clone().text()).toBe(409)
+    expect(errorCode((await conflicted.json()) as ErrorBody)).toBe('APPROVAL_ASSIGNEE_PARALLEL_DYNAMIC_CONFLICT')
+    expect(await instanceCount(tid)).toBe(0)
+
+    // Positive control: DIFFERENT chosen persons fan out into two active branch assignments.
+    const ok = await req(base, '/api/approvals', reqTok, {
+      method: 'POST',
+      body: { templateId: tid, formData: { reason: 'r' }, requesterChoices: { branch_a: [M1], branch_b: [M2] } },
+    })
+    expect(ok.status, await ok.clone().text()).toBe(201)
+    const iid = ((await ok.json()) as { id: string }).id
+    const active = await activeAssignees(iid)
+    expect(active.map((a) => a.assignee_id).sort()).toEqual([M1, M2].sort())
+  })
+
+  // ── Route preview honesty (B3-05 substrate; §K2 optional-presence) ─────────────────────────
+  it('route preview: choices are OPTIONAL pre-choice (honest truncation, NOT a 422) and resolve the chosen user post-choice', async () => {
+    const tid = await createPublished(`rchoice-${TS}-preview`, MEMBERS_SCOPE_GRAPH)
+    // Pre-choice: the preview must NOT 422 (choices are optional on the read-only walk). With
+    // emptyAssigneePolicy 'error' on the first node, the walk's honest floor is an EMPTY
+    // TRUNCATED route (walkPreviewRoute catches the empty-resolution throw) — never a
+    // fabricated approver and never a create-style rejection.
+    const bare = await req(base, '/api/approvals/preview', reqTok, {
+      method: 'POST',
+      body: { templateId: tid, formData: { reason: 'r' } },
+    })
+    expect(bare.status, await bare.clone().text()).toBe(200)
+    const bareBody = (await bare.json()) as { route: Array<{ nodeKey: string }>; truncated?: boolean }
+    expect(bareBody.route).toEqual([])
+    expect(bareBody.truncated).toBe(true)
+
+    const chosen = await req(base, '/api/approvals/preview', reqTok, {
+      method: 'POST',
+      body: { templateId: tid, formData: { reason: 'r' }, requesterChoices: { approval_rc: [M1] } },
+    })
+    expect(chosen.status, await chosen.clone().text()).toBe(200)
+    const chosenBody = (await chosen.json()) as { route: Array<{ nodeKey: string; resolveError?: string; assignees: Array<{ id: string }> }> }
+    const chosenNode = chosenBody.route.find((n) => n.nodeKey === 'approval_rc')
+    expect(chosenNode?.resolveError).toBeUndefined()
+    expect(chosenNode?.assignees.map((a) => a.id)).toEqual([M1])
+    // Preview is validated on the SAME substrate: an out-of-scope preview choice 422s too.
+    const invalid = await req(base, '/api/approvals/preview', reqTok, {
+      method: 'POST',
+      body: { templateId: tid, formData: { reason: 'r' }, requesterChoices: { approval_rc: [OTHER] } },
+    })
+    expect(invalid.status).toBe(422)
+  })
+})

--- a/packages/core-backend/tests/integration/approval-requester-choice.db.test.ts
+++ b/packages/core-backend/tests/integration/approval-requester-choice.db.test.ts
@@ -130,6 +130,17 @@ function errorCode(body: ErrorBody): string | undefined {
   return body.code ?? body.error?.code
 }
 
+// ── Anti-skip-green sentinel (PR #4952 gate P2-2) ────────────────────────────────────────────
+// TOP-LEVEL, deliberately OUTSIDE describeIfDatabase: a sentinel inside the gated describe is
+// structurally inert — it skips exactly when it should fire. The dedicated
+// .github/workflows/approval-realdb-acceptance.yml lane sets EXPECT_DB=1: there, a
+// missing/broken DATABASE_URL REDS the run instead of reporting the whole suite as silently
+// skipped-green. Ordinary no-DB collection (EXPECT_DB unset) skips this test cleanly.
+const itIfExpectDb = process.env.EXPECT_DB === '1' ? it : it.skip
+itIfExpectDb('sentinel: EXPECT_DB lane must have DATABASE_URL (a DB-expected run must never skip-green)', () => {
+  expect(process.env.DATABASE_URL).toBeTruthy()
+})
+
 describeIfDatabase('Lock-1 §K2 requester_choice — real-DB create/freeze/dispatch acceptance', () => {
   let server: MetaSheetServer | undefined
   let base = ''
@@ -214,10 +225,6 @@ describeIfDatabase('Lock-1 §K2 requester_choice — real-DB create/freeze/dispa
       /* best effort */
     }
     if (server) await server.stop()
-  })
-
-  it('sentinel: DATABASE_URL is set (DB-backed lane must not silently skip)', () => {
-    expect(process.env.DATABASE_URL).toBeTruthy()
   })
 
   // ── G-1 / G-2 — authoring choke: exact shape only; unimplemented kinds fail closed ─────────
@@ -417,6 +424,19 @@ describeIfDatabase('Lock-1 §K2 requester_choice — real-DB create/freeze/dispa
       active = await activeAssignees(iid)
       expect(active.map((a) => a.assignee_id)).toEqual([CHOSEN])
       expect(active[0].node_key).toBe('approval_rc')
+
+      // G-19 temporal positive control (PR #4952 gate P3-5): the SAME role removal DOES reject a
+      // NEW create — the freeze is temporal (the scope read re-executes per create), never a
+      // dead/startup-cached read. Discriminates against a holders set cached across creates,
+      // which would pass both the in-flight assertions above and the static non-holder negative.
+      const beforeTemporal = await instanceCount(tid)
+      const temporalCreate = await req(base, '/api/approvals', reqTok, {
+        method: 'POST',
+        body: { templateId: tid, formData: { reason: 'r' }, requesterChoices: { approval_rc: [CHOSEN] } },
+      })
+      expect(temporalCreate.status, await temporalCreate.clone().text()).toBe(422)
+      expect(errorCode((await temporalCreate.json()) as ErrorBody)).toBe('APPROVAL_REQUESTER_CHOICE_OUT_OF_SCOPE')
+      expect(await instanceCount(tid)).toBe(beforeTemporal)
 
       // Positive control (the sanctioned mutation): transfer moves the seat to OTHER.
       const transferred = await req(base, `/api/approvals/${iid}/actions`, chosenTok, {

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -282,6 +282,13 @@ export default defineConfig({
       'tests/integration/approval-requester-department.db.test.ts',
       'tests/integration/approval-requester-title.db.test.ts',
       'tests/integration/approval-requester-role.db.test.ts',
+      // Lock-1 §K2 requester_choice real-DB acceptance (G-8/G-9/G-17/G-18). DATABASE_URL-gated;
+      // excluded here so the no-DB default job cannot collect-and-skip-green it, and carried by
+      // the DEDICATED .github/workflows/approval-realdb-acceptance.yml workflow (standalone per
+      // the sealed-export-s6a-authority-row-lock.yml precedent — plugin-tests.yml is an s6a
+      // sha256-pinned provenance input, so it is deliberately not extended). Two-point wiring —
+      // both points land in the SAME commit, per the PR #4952 adversarial gate (P2-1).
+      'tests/integration/approval-requester-choice.db.test.ts',
       'tests/integration/approval-delegation-seam.db.test.ts',
       'tests/integration/approval-delegation-api.db.test.ts',
       'tests/integration/approval-detail-subform.db.test.ts',


### PR DESCRIPTION
Implements **K2 — `requester_choice` (提交人自选)** from the RATIFIED `docs/development/approval-lock1-enterprise-assignees-20260817.md` §K2, under the §2 cross-cutting invariants and gates G-1/G-2/G-8/G-9/G-16/G-17/G-18 (Lock-0 L0-2 registry contract; master §P2 exit).

## Backend

- **Contract** (`types/approval-product.ts`): `ApprovalAssigneeSourceKind` + union member `{ kind: 'requester_choice'; mode: 'single'|'multi'; scope: {type:'company'}|{type:'members';userIds}|{type:'role';roleIds} }`; `ApprovalRequesterSnapshot.requesterChoices?: Record<string,string[]>` (frozen map, node key → chosen local user ids, OPT-IN); `CreateApprovalRequest.requesterChoices`.
- **Authoring choke** (`normalizeApprovalAssigneeSources`): exact-shape arm — mode enum, per-scope key allowlists, unknown extra keys on the source **and** its scope rejected (G-1; stricter than the shipped kinds, per the Lock-1 gate for new kinds).
- **Create path** (`assembleCreationContext` → new `validateAndFreezeRequesterChoices`, placed with the B5-b org wedge guards, BEFORE any insert): missing choice for a published `requester_choice` node → values-free 422 `APPROVAL_REQUESTER_CHOICE_REQUIRED`; mode cardinality → 422 `…_CARDINALITY`; out-of-scope → 422 `…_OUT_OF_SCOPE`; entry for a non-choice node → 422 `…_UNKNOWN_NODE`; failed scope read → 503 `…_UNRESOLVED` (fail-closed). Scope semantics per §K2: `company` = any **active** local user; `members` = configured list (active-checked — company is the widest scope, members/role only narrow it); `role` = **fresh plain `user_roles` membership**, deliberately NOT `resolveApprovalRequesterRoleIds` (its `approval_usable` INNER JOIN curates the `requester.role` ROUTING predicate, not approver selection). Validated choices freeze into `requester_snapshot.requesterChoices`.
- **Resolver** (`ApprovalAssigneeResolver`): pure `requester_choice` arm reading ONLY the frozen map — immutable across return / admin-jump / timeout re-entry (the sanctioned in-flight mutation is `transfer`); no self-exclusion (deliberate — self-approval stays owned by `autoApprovalPolicy.mergeWithRequester`); missing entry resolves empty → `emptyAssigneePolicy` (unreachable via create, which 422s first).
- **Fingerprint `null` DELIBERATE** with the §K2 rationale in a code comment beside the `_exhaustive` entry, on BOTH mirrors (`dynamicAssigneeSourceFingerprint` backend + `parallelEdit.ts` FE): parallel same-person collision is the runtime `APPROVAL_ASSIGNEE_PARALLEL_DYNAMIC_CONFLICT` 409's job (`assertNoActiveAssignmentConflicts` fires for requester_choice-resolved assignments because they carry `metadata.resolvedFrom` — G-17 second arm proven end to end).
- **Routes**: `requesterChoices` explicitly whitelisted on `POST /api/approvals`, `POST /api/approvals/preview`, and the B3-06 dry-run (`sampleRequesterChoices`). Choices are OPTIONAL on the read-only previews (`requesterChoicePresence: 'optional'`) — a choices-free preview walks honestly (empty/truncated), a supplied choice is validated on the SAME substrate as create. Participant directory search gains capped `userIds`/`roleIds` scope-narrowing params (plain `user_roles` EXISTS — not `approval_usable`-joined) for the chooser picker.

## Frontend (five §2.5 mirror sites + registry row + chooser)

1. FE type union + source union mirror (`types/approval.ts`).
2. `BACKEND_ASSIGNEE_SOURCE_KEYS_BY_KIND` + a new **third-level** scope-shape check (`requesterChoiceSourceHasBackendDrop`) — `scope` is the first nested object in the source union, so the flat 2-level allowlist alone could not see inside it; malformed shapes force read-only (both complex and linear paths).
3. Linear editor accepted-kind list + full linear-step authoring (`ApprovalStepDraft.requesterChoiceMode/ScopeType`, hydrate/`sourceFromStep` round-trip, mode/scope selects + typed user/role pickers riding the shared `idsText` chip carrier) — no hydrate flatten.
4. `assigneeSourceSummary`: explicit case `提交人自选（提交时选择）` **and** the `default: JSON.stringify(source)` raw-config leak replaced with a values-free fallback label (§2.5 item 5 — the leak is a defect, not a precedent).
5. Capability registry row `requester_choice / 提交人自选` admitted in the SAME commit; the L0-2 exact-set spec grows 8 → 9 in this commit (Lock-1 §2.3).
- **Authoring sub-form** (`ApprovalGraphNodeConfigEditor`): mode radio (单选/多选) + scope select (全公司/指定成员/指定角色) with typed pickers only (D0 §10.2 — no raw-ID input); scope switch starts from an empty id list (userIds/roleIds are different id domains); configured-summary echo (mode + scope, count-only).
- **Submit-time chooser** (`ApprovalNewView`): when the loaded route carries a `requester_choice` node, a required chooser card renders per node — scope-filtered server-side member picker (single/multi per mode), submit blocked until every node has a mode-satisfying choice, choices sent in the create payload keyed by node key. Route preview: static B2-07 preview shows the 提交人自选（提交时选择） placeholder pre-choice; the live B3-05 preview threads the choices post-choice and resolves the chosen names; any choice change invalidates a stale preview.

## Tests

**Real-DB integration** — `packages/core-backend/tests/integration/approval-requester-choice.db.test.ts` (13 tests, all green against a fresh migrated PostgreSQL):
- G-1 exact shape (+6 bad-shape 400s, valid-shape positive control), G-2 unimplemented-kind (`user_group`) rejected & never persisted;
- G-8 REQUIRED / OUT_OF_SCOPE (members, company-inactive, role-non-holder) / CARDINALITY / UNKNOWN_NODE — each 422 with **zero rows**, plus in-scope creates with `metadata.resolvedFrom.kind='requester_choice'` and the frozen snapshot map asserted from the row; **the §K2 curation-independence discriminator**: the scoped role is seeded `approval_usable=FALSE` and the choice still validates (an implementation reusing `resolveApprovalRequesterRoleIds` reds here);
- G-9 role deleted AFTER create → dispatch assigns the frozen choice; `return` re-entry re-resolves the SAME list; `transfer` DOES move the seat (positive control);
- G-17 arm 1 (publish passes for requester_choice×requester_choice; `requester`×`requester` publish-400 positive control) + arm 2 (same-person create → runtime 409, zero rows; different persons → both branch assignments active);
- G-18 values-free (raw 422 body carries the node key + scopeType, never the chosen person id);
- preview honesty (choices optional pre-choice, resolved post-choice, out-of-scope preview choice 422s on the same substrate).

**FE mounted specs** (all in files already wired in BOTH `run-required-web-tests.sh` and `approval-web-guard.yml` — no list edits needed):
- `approval-template-authoring-canvas-inspector.spec.ts`: A-3 exact-set 8→9 + D1 label pin 8→9 (registry row, same commit), K2 authoring sub-form (mode/scope/typed pickers write the shared edit model), G-16 positive arm (requester_choice renders EDITABLE with typed summary; existing A-4 unknown-kind read-only arm unchanged);
- `approvalNewView.spec.ts`: chooser renders per requester_choice node (and NOT for choice-free routes), scope-filtered search params, submit blocked until chosen, `requesterChoices` keyed by node key in the payload, flow-preview placeholder with no raw config ids;
- `approval-template-authoring-parallel-edit.test.ts`: G-17 FE mirror (null fingerprint not flagged; identical `requester` pair flagged as positive control);
- `approval-template-authoring-approval-node-edit.test.ts`: validation preview + third-level scope allowlist (well-formed passes / extra scope key / unknown scope type / bad mode force read-only);
- `approvalTemplateAuthoring.spec.ts`: linear round-trips (role + members scopes) incl. byte-identical re-emit;
- `approval-assignee-source.test.ts`: explicit placeholder case + values-free unknown-kind fallback (no `JSON.stringify` leak; known-kind positive control).

## Real-DB suite wiring (corrected after the adversarial gate)

The suite is now **two-point wired, both points in one commit** (gate P2-1):

1. **Excluded** from the no-DB default `vitest.config.ts` (alongside its three named siblings), so the required `test (18.x/20.x)` job no longer collect-and-skip-greens its tests;
2. **Executed** by a NEW standalone workflow `.github/workflows/approval-realdb-acceptance.yml` (job `approval-realdb-k2`), modeled on the `sealed-export-s6a-authority-row-lock.yml` precedent: PG 16 service container, `db:migrate` with the plugin-tests exclusion list, whole-file `vitest.integration.config.ts` run with `DATABASE_URL` + `EXPECT_DB=1`; path-filtered `pull_request` + `push:main` + `workflow_dispatch`. `plugin-tests.yml` stays byte-identical (it is an s6a sha256-pinned provenance input — the documented reason a separate file is the right shape).

**Correction of this PR's originally stated reason** (upheld in effect, refuted in reason by the gate): there is no `ci.yml` — `test (18.x/20.x)` lives inside `plugin-tests.yml` — and a `plugin-tests.yml` entry was never the only execution path; standalone real-DB workflows have in-repo precedent. The original head shipped the suite collect-and-skip-green in a required check with an inert in-describe sentinel; both are fixed on this head (sentinel now top-level, armed by `EXPECT_DB=1`, proven to red on a missing DATABASE_URL).

## Verification

- `tsc --noEmit` (core-backend) clean; `vue-tsc --noEmit` (apps/web) clean; changed backend files eslint-clean (0 errors).
- New real-DB suite: **13/13** against a fresh `db:migrate`-provisioned PostgreSQL (CI exclusion list reproduced).
- Full required web lane (`run-required-web-tests.sh`): see PR checks; all K2-touched suites green locally.
- **Three self-mutations, each restored byte-identical (verified with `cmp`):**
  1. bypass `validateAndFreezeRequesterChoices`'s required/cardinality/scope validation → exactly the **G-8 family red** (6 tests: REQUIRED, members OUT_OF_SCOPE/G-18, cardinality, company-inactive, role-scope, preview-invalid arm), G-9/G-17 stay green — validation-selected;
  2. dispatch drops the frozen `requesterChoices` before resolution (simulating a live-re-read resolver) → **exactly G-9 red, all 12 others green** — the frozen-map read at dispatch is what G-9 guards;
  3. drop the `requester_choice` registry roster row → **A-3 exact-set red + K2 G-16 positive arm red** (2 tests), rest green.

## Lock-1 clauses not fully satisfied (reported, not improvised)

- **Live route-preview pre-choice placeholder**: the B3-05 server walk previews a choices-free `requester_choice` node as an honest empty/truncated route (its first-node `emptyAssigneePolicy:'error'` resolution throws are caught by the shipped per-node fault-tolerance floor); the 提交人自选（提交时选择） placeholder is carried by the static B2-07 flow preview, and the live preview resolves real names once choices are made. No fabricated approver is ever shown.

## Adversarial gate (2026-08-17) and hardening round

Refute-first gate on head `06d7f1d875`: **APPROVE-with-hardening — 0 P1, 2 P2 (both evidence-lane), 5 P3, 4 NIT**; freeze-at-create purity held structurally (resolver has no DB handle in scope at all; graph + snapshot instance-pinned); 9/9 reviewer mutation probes RED, each on the intended guard. This head lands the hardening:

- **P2-1** — atomic two-point wiring (vitest exclude + the standalone `approval-realdb-k2` workflow, one commit). CI evidence: the workflow triggered on this PR and executed **13/13** (sentinel included).
- **P2-2** — the anti-skip-green sentinel hoisted out of `describeIfDatabase` to a top-level `EXPECT_DB=1`-armed test. Proven: armed + no DATABASE_URL → RED (1 failed / 12 skipped); armed + DB → 13/13.
- **P3-5** — G-19 temporal positive control added to the G-9 arm: the same post-create role removal DOES reject a NEW create (422 `OUT_OF_SCOPE`, zero new rows) — the scope read re-executes per create, never cached.

## Known follow-ups (from the gate — deliberately NOT in this PR, no closing keywords)

- **P3-1** — the participant picker's `roleIds`/`userIds` scope params are client-supplied under the broad `approvals:read|write|act` guard, letting any approval user ask "which users hold role R" (role partition of an already-fully-visible user set; the choice itself is NOT bypassable — create re-validates). Harden by deriving the scope server-side from `templateId` + `nodeKey` against the published node's authored config.
- **P3-2** — the submit-time chooser derives from the DRAFT template graph while create validates the PUBLISHED runtime graph; an edited-but-unpublished template can leave a requester facing a 422 `_REQUIRED` with no chooser to satisfy it (fail-closed both directions, no security impact). Fix: source choosers from the published projection.
- **P3-3** — unnamed sixth §2.5 mirror site: `linearStepSpine.ts`'s `isStepSourceResolvable`-style switch defaults `requester_choice` to "resolvable" (badge-only optimism; save + publish both still blocked). Add the explicit case; the next kind will hit this again.
- **P3-4** — `mode: 'multi'` has NO upper bound on chosen id count while every comparable path is capped (levels, visibility ids, explicitIds@200, picker@200, search@50); a company-scope multi create can mint one assignment per active user. **Needs an owner cap decision** (e.g. `MAX_REQUESTER_CHOICE_IDS`, values-free 422).
- **NIT-1** — `requesterChoiceSourceHasBackendDrop`'s allowlist lookup should `Array.isArray`-guard against prototype-inherited keys (`scope.type: 'constructor'` currently throws instead of returning read-only; unreachable via API; same pre-existing pattern in the kind-level allowlist).
- **NIT-2** — dead `multi && ids.length === 0` cardinality arm (the required/empty branch above already owns it).
- **NIT-3** — the picker's two silent ceilings (route slices scope ids at 200, query LIMIT clamps at 50) deserve a comment, and >200 a 400 rather than truncation.
- **NIT-4** — `assigneeSourceSummary`'s values-free `default` is no longer compiler-exhaustive (unlike `parallelEdit.ts`'s `_exhaustive: never`); consider `assertNever` + the values-free label to get both.

Per Lock-1's non-effects: no flag change, no migration, no tenant UAT, no deployment; merge is the owner's call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
