### PR TITLE
feat(approval): K4 — continuous_dept_heads assignee kind (Lock-1 §K4)

### DIFF
--- a/.github/workflows/approval-realdb-acceptance.yml
+++ b/.github/workflows/approval-realdb-acceptance.yml
@@ -1,9 +1,13 @@
 name: Approval real-DB acceptance (Lock-1 assignee kinds)
 
-# EVIDENCE LANE for the Lock-1 §K2 `requester_choice` real-DB acceptance suite
-# (tests/integration/approval-requester-choice.db.test.ts — G-8/G-9/G-17/G-18 with their
-# positive controls). Ephemeral first-party PostgreSQL container; no customer source, no
-# deployment, no flag change.
+# EVIDENCE LANE for the Lock-1 assignee-kind real-DB acceptance suites — currently:
+#   - approval-realdb-k2: §K2 `requester_choice`
+#     (tests/integration/approval-requester-choice.db.test.ts — G-8/G-9/G-17/G-18)
+#   - approval-realdb-k4: §K4 `continuous_dept_heads`
+#     (tests/integration/approval-dept-head-chain.db.test.ts — G-1/G-2/G-13,
+#      continue-past-empty-level over real SQL, freeze-purity/temporal)
+# Ephemeral first-party PostgreSQL container per job; no customer source, no deployment, no
+# flag change.
 #
 # WHY A STANDALONE FILE, not a plugin-tests.yml allowlist entry (PR #4952 gate, P2-1):
 # plugin-tests.yml is an s6a sha256-pinned provenance input
@@ -11,13 +15,16 @@ name: Approval real-DB acceptance (Lock-1 assignee kinds)
 # s6a re-pin and a merge-serialisation race. sealed-export-s6a-authority-row-lock.yml
 # documents choosing a separate workflow file for exactly this rationale and is the
 # in-repo precedent this file is modeled on. plugin-tests.yml is left byte-identical.
+# New assignee-kind real-DB suites are added HERE as sibling jobs rather than new files, so
+# each K-slice's evidence lane is independently load-bearing (a guard mutation in one kind's
+# create-path wiring reds only its own job) without growing the s6a-pinned surface.
 #
-# TWO-POINT WIRING (the other half): the suite is excluded from the no-DB default vitest
-# config (packages/core-backend/vitest.config.ts) in the SAME commit that adds this file,
-# so the required `test (18.x/20.x)` job no longer collect-and-skip-greens it. This
-# workflow is where the suite actually EXECUTES, with EXPECT_DB=1 arming the suite's
-# top-level anti-skip-green sentinel: a run in this lane with a missing/broken
-# DATABASE_URL goes RED instead of silently reporting 13 skipped tests.
+# TWO-POINT WIRING (the other half): each suite is excluded from the no-DB default vitest
+# config (packages/core-backend/vitest.config.ts) in the SAME commit that adds it, so the
+# required `test (18.x/20.x)` job no longer collect-and-skip-greens it. This workflow is
+# where each suite actually EXECUTES, with EXPECT_DB=1 arming its top-level anti-skip-green
+# sentinel (K2) / DATABASE_URL sentinel (K4): a run in this lane with a missing/broken
+# DATABASE_URL goes RED instead of silently reporting the whole suite as skipped.
 
 on:
   workflow_dispatch:
@@ -28,11 +35,13 @@ on:
     # keeps it off unrelated PRs.
     paths:
       - 'packages/core-backend/tests/integration/approval-requester-choice.db.test.ts'
+      - 'packages/core-backend/tests/integration/approval-dept-head-chain.db.test.ts'
       - 'packages/core-backend/tests/helpers/approval-schema-bootstrap.ts'
       - 'packages/core-backend/src/services/ApprovalProductService.ts'
       - 'packages/core-backend/src/services/ApprovalAssigneeResolver.ts'
       - 'packages/core-backend/src/services/ApprovalGraphExecutor.ts'
       - 'packages/core-backend/src/services/approval-directory.ts'
+      - 'packages/core-backend/src/services/ApprovalDirectoryOrg.ts'
       - 'packages/core-backend/src/routes/approvals.ts'
       - 'packages/core-backend/src/types/approval-product.ts'
       - '.github/workflows/approval-realdb-acceptance.yml'
@@ -40,11 +49,13 @@ on:
     branches: [main]
     paths:
       - 'packages/core-backend/tests/integration/approval-requester-choice.db.test.ts'
+      - 'packages/core-backend/tests/integration/approval-dept-head-chain.db.test.ts'
       - 'packages/core-backend/tests/helpers/approval-schema-bootstrap.ts'
       - 'packages/core-backend/src/services/ApprovalProductService.ts'
       - 'packages/core-backend/src/services/ApprovalAssigneeResolver.ts'
       - 'packages/core-backend/src/services/ApprovalGraphExecutor.ts'
       - 'packages/core-backend/src/services/approval-directory.ts'
+      - 'packages/core-backend/src/services/ApprovalDirectoryOrg.ts'
       - 'packages/core-backend/src/routes/approvals.ts'
       - 'packages/core-backend/src/types/approval-product.ts'
       - '.github/workflows/approval-realdb-acceptance.yml'
@@ -126,6 +137,84 @@ jobs:
             echo "lock=approval-lock1-enterprise-assignees-20260817 §K2"
             echo "gates=G-8,G-9,G-17,G-18 (+G-1/G-2 authoring, G-19 temporal arm)"
             echo "sentinelArmed=EXPECT_DB=1"
+            echo "customerSourceAccess=NOT_INVOLVED"
+            echo "flagChanged=false"
+            echo "externalWrite=false"
+          } | tee -a "$GITHUB_STEP_SUMMARY"
+
+  approval-realdb-k4:
+    name: approval-realdb-k4
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: metasheet_approval_realdb
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d metasheet_approval_realdb"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 20
+    env:
+      DATABASE_URL: postgresql://postgres:postgres@127.0.0.1:5432/metasheet_approval_realdb
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js 20.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.16.1
+          run_install: false
+
+      - name: Use empty npmrc for pnpm
+        run: |
+          echo "" > /tmp/empty-npmrc
+          echo "NPM_CONFIG_USERCONFIG=/tmp/empty-npmrc" >> "$GITHUB_ENV"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run DB migrations
+        env:
+          # Same per-PR-gate exclusion list as plugin-tests.yml's "Run DB migrations" step
+          # (see the T8 note there and packages/core-backend/MIGRATION_EXCLUDE_TRACKING.md
+          # for the per-item detail) — this lane provisions the identical schema the
+          # approval real-DB steps run against.
+          MIGRATION_EXCLUDE: 008_plugin_infrastructure.sql,048_create_event_bus_tables.sql,049_create_bpmn_workflow_tables.sql,042a_core_model_views.sql,20250924140000_create_gantt_tables.ts,20250925_create_view_tables.sql
+        run: pnpm --filter @metasheet/core-backend db:migrate
+
+      - name: Run Lock-1 §K4 continuous_dept_heads real-DB acceptance (whole file)
+        # WHOLE FILE, --reporter=verbose: a name filter matching zero tests would exit
+        # green and hide regressions; verbose prints every collected test so an empty
+        # collection shows in the log instead of reading as green. The sentinel here is
+        # the file's own top-level `sentinel: DATABASE_URL is set` test — it is INSIDE
+        # describeIfDatabase (unlike K2's dedicated top-level EXPECT_DB sentinel), which is
+        # sufficient in THIS lane because DATABASE_URL is unconditionally set above — there
+        # is no no-DB variant of this specific job to distinguish from.
+        run: >-
+          pnpm --filter @metasheet/core-backend exec vitest
+          --config vitest.integration.config.ts run
+          tests/integration/approval-dept-head-chain.db.test.ts
+          --reporter=verbose
+
+      - name: Values-free evidence (this job)
+        run: |
+          {
+            echo "evidenceKind=CONTROLLED_SYNTHETIC_FUNCTIONAL"
+            echo "suite=approval-dept-head-chain.db.test.ts"
+            echo "lock=approval-lock1-enterprise-assignees-20260817 §K4"
+            echo "gates=G-1,G-2,G-13 (continue-past-empty-level over real SQL, freeze-purity/temporal)"
             echo "customerSourceAccess=NOT_INVOLVED"
             echo "flagChanged=false"
             echo "externalWrite=false"

--- a/apps/web/src/approvals/approvalCapabilityRegistry.ts
+++ b/apps/web/src/approvals/approvalCapabilityRegistry.ts
@@ -34,6 +34,10 @@ export const APPROVAL_ASSIGNEE_SOURCE_LABELS: Record<ApprovalAssigneeSourceKind,
   // Lock-1 §K2 (RATIFIED 2026-08-17) — admitted in the SAME slice that lands the scope
   // validation + submit-time chooser end to end (registry table row: 提交人自选 / approval).
   requester_choice: '提交人自选',
+  // Lock-1 §K4 (RATIFIED 2026-08-17) — admitted in the SAME slice that lands the
+  // deptHeadChainIds snapshot + resolver arm end to end (registry table row:
+  // 连续多级部门负责人 / approval).
+  continuous_dept_heads: '连续多级部门负责人',
 }
 
 /** Display order matches parent §10.3's listed order. Kept as an explicit array (rather than
@@ -50,6 +54,8 @@ const SHIPPED_ASSIGNEE_SOURCE_KIND_ORDER: readonly ApprovalAssigneeSourceKind[] 
   'manager_at_level',
   // Lock-1 §K2: ratified kinds append after the original eight-member §10.3 order.
   'requester_choice',
+  // Lock-1 §K4: appended after K2.
+  'continuous_dept_heads',
 ]
 
 export interface ApprovalAssigneeSourceCapability {

--- a/apps/web/src/approvals/approvalNodeEdit.ts
+++ b/apps/web/src/approvals/approvalNodeEdit.ts
@@ -173,6 +173,10 @@ function isAssigneeSourceValid(source: ApprovalAssigneeSource, topLevelUserField
       return Number.isInteger(source.levels) && source.levels >= 1
     case 'manager_at_level':
       return Number.isInteger(source.level) && source.level >= 1
+    // Lock-1 §K4 PREVIEW: same shape/cap posture as continuous_managers (backend
+    // normalizeApprovalAssigneeSources stays the arbiter on the ceiling).
+    case 'continuous_dept_heads':
+      return Number.isInteger(source.levels) && source.levels >= 1
     case 'requester_choice':
       // Lock-1 §K2 PREVIEW (backend normalizeApprovalAssigneeSources stays the arbiter):
       // mode + scope discriminator, and a members/role scope needs ≥1 configured id.

--- a/apps/web/src/approvals/assigneeSource.ts
+++ b/apps/web/src/approvals/assigneeSource.ts
@@ -26,6 +26,7 @@ export function assigneeSourceSummary(source: ApprovalAssigneeSource): string {
     case 'dept_head': return '部门主管'
     case 'continuous_managers': return `连续多级上级（${source.levels} 级）`
     case 'manager_at_level': return `指定层级上级（第 ${source.level} 级）`
+    case 'continuous_dept_heads': return `连续多级部门负责人（${source.levels} 级）`
     // Lock-1 §K2: pre-choice placeholder — the approver is unknowable until the requester
     // chooses at submit time, so the flow/route preview says exactly that.
     case 'requester_choice': return '提交人自选（提交时选择）'

--- a/apps/web/src/approvals/components/ApprovalGraphNodeConfigEditor.vue
+++ b/apps/web/src/approvals/components/ApprovalGraphNodeConfigEditor.vue
@@ -508,8 +508,8 @@
         </el-select>
       </el-form-item>
       <el-form-item
-        v-else-if="approvalSourceKind(node.key) === 'manager_at_level' || approvalSourceKind(node.key) === 'continuous_managers'"
-        :label="approvalSourceKind(node.key) === 'manager_at_level' ? '指定上级层级' : '上级层级数'"
+        v-else-if="approvalSourceKind(node.key) === 'manager_at_level' || approvalSourceKind(node.key) === 'continuous_managers' || approvalSourceKind(node.key) === 'continuous_dept_heads'"
+        :label="approvalSourceKind(node.key) === 'manager_at_level' ? '指定上级层级' : approvalSourceKind(node.key) === 'continuous_dept_heads' ? '部门负责人层级数' : '上级层级数'"
       >
         <el-input-number
           :model-value="approvalSourceLevel(node.key)"

--- a/apps/web/src/approvals/parallelEdit.ts
+++ b/apps/web/src/approvals/parallelEdit.ts
@@ -159,6 +159,8 @@ function dynamicAssigneeSourceFingerprint(source: ApprovalAssigneeSource): strin
       return `continuous_managers:${source.levels}`
     case 'manager_at_level':
       return `manager_at_level:${source.level}`
+    case 'continuous_dept_heads':
+      return `continuous_dept_heads:${source.levels}`
     case 'form_field_user':
       return `form_field_user:${source.fieldId.trim()}`
     case 'static_user':

--- a/apps/web/src/approvals/templateAuthoring.ts
+++ b/apps/web/src/approvals/templateAuthoring.ts
@@ -491,6 +491,10 @@ function stepDraftFromApprovalNode(
   } else if (source?.kind === 'manager_at_level') {
     sourceKind = 'manager_at_level'
     level = source.level
+  } else if (source?.kind === 'continuous_dept_heads') {
+    // Lock-1 §K4: same shape as continuous_managers — reuses the shared `levels` field.
+    sourceKind = 'continuous_dept_heads'
+    levels = source.levels
   } else if (source?.kind === 'requester_choice') {
     // Lock-1 §K2: hydrate mode + scope; a members/role scope's id list rides the shared
     // idsText chip carrier (sourceFromStep re-shapes it back per scope type).
@@ -648,6 +652,8 @@ const BACKEND_ASSIGNEE_SOURCE_KEYS_BY_KIND: Record<string, string[]> = {
   dept_head: ['kind'],
   continuous_managers: ['kind', 'levels'],
   manager_at_level: ['kind', 'level'],
+  // Lock-1 §K4: same flat 2-level shape as continuous_managers.
+  continuous_dept_heads: ['kind', 'levels'],
   form_field_user: ['kind', 'fieldId'],
   // Lock-1 §K2: `scope` is the ONE nested object in the source union (see
   // requesterChoiceSourceHasBackendDrop below for its per-type key check — the flat 2-level
@@ -844,7 +850,7 @@ export function unsupportedTemplateAuthoringReason(template: ApprovalTemplateDet
     if (sources !== undefined) {
       if (!Array.isArray(sources) || sources.length !== 1) return true
       const source = sources[0] as ApprovalAssigneeSource
-      if (!['static_user', 'static_role', 'requester', 'form_field_user', 'direct_manager', 'dept_head', 'continuous_managers', 'manager_at_level', 'requester_choice'].includes(source?.kind)) return true
+      if (!['static_user', 'static_role', 'requester', 'form_field_user', 'direct_manager', 'dept_head', 'continuous_managers', 'manager_at_level', 'requester_choice', 'continuous_dept_heads'].includes(source?.kind)) return true
       // Lock-1 §K2: a malformed requester_choice shape must fail-closed to read-only here too —
       // hydrate would otherwise re-derive a default mode/scope and silently flatten it on save.
       if (source?.kind === 'requester_choice' && requesterChoiceSourceHasBackendDrop(source as unknown as Record<string, unknown>)) return true
@@ -1032,6 +1038,10 @@ export function sourceFromStep(step: ApprovalStepDraft): ApprovalAssigneeSource 
   }
   if (step.sourceKind === 'manager_at_level') {
     return { kind: 'manager_at_level', level: step.level }
+  }
+  if (step.sourceKind === 'continuous_dept_heads') {
+    // Lock-1 §K4: reuses the shared `levels` field (same shape as continuous_managers).
+    return { kind: 'continuous_dept_heads', levels: step.levels }
   }
   if (step.sourceKind === 'requester_choice') {
     // Lock-1 §K2: re-shape the shared idsText carrier into the per-scope id list.

--- a/apps/web/src/types/approval.ts
+++ b/apps/web/src/types/approval.ts
@@ -18,7 +18,7 @@ export const APPROVAL_ROLE_CONFIGURE_SENTINEL = '__APPROVAL_ROLE_PLACEHOLDER__'
 // `APPROVAL_NODE_TYPES` admission set.
 export type ApprovalNodeType = 'start' | 'approval' | 'cc' | 'condition' | 'parallel' | 'end' | 'handler'
 export type ApprovalAssigneeType = 'user' | 'role'
-export type ApprovalAssigneeSourceKind = 'static_user' | 'static_role' | 'requester' | 'form_field_user' | 'direct_manager' | 'dept_head' | 'continuous_managers' | 'manager_at_level' | 'requester_choice'
+export type ApprovalAssigneeSourceKind = 'static_user' | 'static_role' | 'requester' | 'form_field_user' | 'direct_manager' | 'dept_head' | 'continuous_managers' | 'manager_at_level' | 'requester_choice' | 'continuous_dept_heads'
 export type ApprovalMode = 'single' | 'all' | 'any'
 export type ParallelJoinMode = 'all' | 'any'
 export type EmptyAssigneePolicy = 'error' | 'auto-approve'
@@ -148,6 +148,14 @@ export type ApprovalAssigneeSource =
         | { type: 'members'; userIds: string[] }
         | { type: 'role'; roleIds: string[] }
     }
+  /**
+   * Lock-1 §K4 — 连续多级部门负责人. Byte-mirrors the backend union member: levels 1..`levels`
+   * (level 1 = the requester's own department head), resolved from the baked `deptHeadChainIds`
+   * snapshot — a DIFFERENT pointer from `continuous_managers` (leader_in_dept vs the department
+   * parent tree). No authoring shape beyond `levels`; the picker is a plain level-count input,
+   * same as `continuous_managers`.
+   */
+  | { kind: 'continuous_dept_heads'; levels: number }
 
 export type RequesterChoiceAssigneeSource = Extract<ApprovalAssigneeSource, { kind: 'requester_choice' }>
 

--- a/apps/web/src/views/approval/TemplateAuthoringView.vue
+++ b/apps/web/src/views/approval/TemplateAuthoringView.vue
@@ -537,6 +537,7 @@
                 <el-option label="指定层级上级" value="manager_at_level" />
                 <el-option label="表单用户字段" value="form_field_user" />
                 <el-option label="提交人自选" value="requester_choice" />
+                <el-option label="连续多级部门负责人" value="continuous_dept_heads" />
               </el-select>
             </el-form-item>
             <el-form-item v-if="step.sourceKind === 'continuous_managers'" label="上级层级数">
@@ -550,6 +551,18 @@
                 :step="1"
                 :disabled="readOnly"
                 data-testid="approval-step-levels"
+              />
+            </el-form-item>
+            <!-- Lock-1 §K4 (连续多级部门负责人) linear authoring: reuses the shared `levels`
+                 field, same cap posture as continuous_managers. -->
+            <el-form-item v-if="step.sourceKind === 'continuous_dept_heads'" label="部门负责人层级数">
+              <el-input-number
+                v-model="step.levels"
+                :min="1"
+                :max="10"
+                :step="1"
+                :disabled="readOnly"
+                data-testid="approval-step-dept-head-levels"
               />
             </el-form-item>
             <el-form-item v-if="step.sourceKind === 'manager_at_level'" label="指定上级层级">
@@ -1846,7 +1859,9 @@ function defaultApprovalSourceForKind(kind: ApprovalAssigneeSourceKind): Approva
           : kind === 'manager_at_level' ? { kind, level: 1 }
             // Lock-1 §K2: single choice over the whole company is the widest, always-valid start.
             : kind === 'requester_choice' ? { kind, mode: 'single', scope: { type: 'company' } }
-              : { kind: kind as 'requester' | 'direct_manager' | 'dept_head' }
+              // Lock-1 §K4: same default shape as continuous_managers.
+              : kind === 'continuous_dept_heads' ? { kind, levels: 1 }
+                : { kind: kind as 'requester' | 'direct_manager' | 'dept_head' }
 }
 function setApprovalSourceKind(nodeKey: string, kind: ApprovalAssigneeSourceKind): void {
   const current = approvalNodeFirstSource(nodeKey)
@@ -2457,12 +2472,15 @@ function approvalSourceLevel(nodeKey: string): number {
   const source = approvalNodeFirstSource(nodeKey)
   if (source?.kind === 'manager_at_level') return source.level
   if (source?.kind === 'continuous_managers') return source.levels
+  // Lock-1 §K4: same shared-field shape as continuous_managers.
+  if (source?.kind === 'continuous_dept_heads') return source.levels
   return 1
 }
 function setApprovalSourceLevel(nodeKey: string, value: number): void {
   const kind = approvalSourceKind(nodeKey)
   if (kind === 'manager_at_level') setApprovalNodeSource(nodeKey, { kind, level: value })
   else if (kind === 'continuous_managers') setApprovalNodeSource(nodeKey, { kind, levels: value })
+  else if (kind === 'continuous_dept_heads') setApprovalNodeSource(nodeKey, { kind, levels: value })
 }
 
 const userFields = computed(() => draft.value.fields.filter((field) => field.type === 'user' && field.id.trim()))

--- a/apps/web/tests/approval-assignee-source.test.ts
+++ b/apps/web/tests/approval-assignee-source.test.ts
@@ -42,6 +42,10 @@ describe('assigneeSourceSummary (single source)', () => {
     expect(assigneeSourceSummary({ kind: 'manager_at_level', level: 2 })).toBe('指定层级上级（第 2 级）')
   })
 
+  it('continuous_dept_heads: includes the level count (Lock-1 §K4)', () => {
+    expect(assigneeSourceSummary({ kind: 'continuous_dept_heads', levels: 3 })).toBe('连续多级部门负责人（3 级）')
+  })
+
   it('requester_choice: fixed pre-choice placeholder (提交时选择), no config values leaked (Lock-1 §K2)', () => {
     expect(
       assigneeSourceSummary({ kind: 'requester_choice', mode: 'single', scope: { type: 'company' } }),

--- a/apps/web/tests/approval-template-authoring-approval-node-edit.test.ts
+++ b/apps/web/tests/approval-template-authoring-approval-node-edit.test.ts
@@ -229,6 +229,17 @@ describe('validateApprovalNodeEdits (preview mirrors the backend assignee rule)'
       a: { nodeKey: 'a', assigneeSources: [{ kind: 'requester_choice', mode: 'both', scope: { type: 'company' } } as never] },
     })[0]).toMatch(/requester_choice/)
   })
+  it('Lock-1 §K4: continuous_dept_heads — a positive integer levels passes; 0/non-integer is flagged (isAssigneeSourceValid mirror site)', () => {
+    expect(validateApprovalNodeEdits({
+      a: { nodeKey: 'a', assigneeSources: [{ kind: 'continuous_dept_heads', levels: 3 }] },
+    })).toEqual([])
+    expect(validateApprovalNodeEdits({
+      a: { nodeKey: 'a', assigneeSources: [{ kind: 'continuous_dept_heads', levels: 0 }] },
+    })[0]).toMatch(/continuous_dept_heads/)
+    expect(validateApprovalNodeEdits({
+      a: { nodeKey: 'a', assigneeSources: [{ kind: 'continuous_dept_heads', levels: 1.5 }] },
+    })[0]).toMatch(/continuous_dept_heads/)
+  })
 })
 
 describe('G-5 fail-closed — complex approval-node config must stay within the BACKEND allowlist', () => {
@@ -316,5 +327,17 @@ describe('G-5 fail-closed — complex approval-node config must stay within the 
       fieldPermissions: [{ fieldId: 'amount', access: 'hidden' }],
     })
     expect(unsupportedTemplateAuthoringReason(buildTemplate(graph))).toBeNull()
+  })
+
+  // Lock-1 §K4 — BACKEND_ASSIGNEE_SOURCE_KEYS_BY_KIND mirror site: continuous_dept_heads must be
+  // ALLOWED (present in the allowlist) on the complex path, and an extra key on it must still be
+  // caught (the allowlist is per-kind exact, not a blanket pass-through).
+  it('K4: continuous_dept_heads is allowed on the complex path (registered in BACKEND_ASSIGNEE_SOURCE_KEYS_BY_KIND)', () => {
+    const graph = complexWith({ assigneeSources: [{ kind: 'continuous_dept_heads', levels: 3 }] })
+    expect(unsupportedTemplateAuthoringReason(buildTemplate(graph))).toBeNull()
+  })
+  it('K4: a continuous_dept_heads source with an unknown extra key forces read-only', () => {
+    const graph = complexWith({ assigneeSources: [{ kind: 'continuous_dept_heads', levels: 3, futureFlag: true }] })
+    expect(unsupportedTemplateAuthoringReason(buildTemplate(graph))).not.toBeNull()
   })
 })

--- a/apps/web/tests/approval-template-authoring-canvas-inspector.spec.ts
+++ b/apps/web/tests/approval-template-authoring-canvas-inspector.spec.ts
@@ -977,7 +977,7 @@ describe('Canvas V2 Slice A — canvas inspector', () => {
   // "iterate the exported table" mechanical assertion, not per-kind spot checks), so any single
   // label reverting to pre-D1 wording (or drifting to anything else) reds here regardless of
   // whether it happens to be one of the two kinds the D1/D2 test exercises.
-  it('D1 (P2-2): all nine assignee-source labels equal the ratified map by exact object equality', () => {
+  it('D1 (P2-2): all ten assignee-source labels equal the ratified map by exact object equality', () => {
     const RATIFIED_APPROVAL_ASSIGNEE_SOURCE_LABELS: Record<string, string> = {
       static_user: '指定成员',
       static_role: '指定角色',
@@ -990,11 +990,14 @@ describe('Canvas V2 Slice A — canvas inspector', () => {
       // Lock-1 §K2 (RATIFIED 2026-08-17) — the 提交人自选 registry row, admitted in the SAME
       // slice that lands scope validation + the submit-time chooser (Lock-1 §2.3 table).
       requester_choice: '提交人自选',
+      // Lock-1 §K4 (RATIFIED 2026-08-17) — the 连续多级部门负责人 registry row, admitted in the
+      // SAME slice that lands the deptHeadChainIds snapshot + resolver arm (Lock-1 §2.3 table).
+      continuous_dept_heads: '连续多级部门负责人',
     }
     expect(APPROVAL_ASSIGNEE_SOURCE_LABELS).toEqual(RATIFIED_APPROVAL_ASSIGNEE_SOURCE_LABELS)
-    // Also pin the count so a stray 10th entry (which would still satisfy `toEqual` on the keys
+    // Also pin the count so a stray 11th entry (which would still satisfy `toEqual` on the keys
     // above via structural superset checks in some matcher semantics) cannot slip through unnoticed.
-    expect(Object.keys(APPROVAL_ASSIGNEE_SOURCE_LABELS)).toHaveLength(9)
+    expect(Object.keys(APPROVAL_ASSIGNEE_SOURCE_LABELS)).toHaveLength(10)
   })
 
   it('A-7: no scrim/overlay-mask element with the inspector mounted and visible', async () => {
@@ -1403,7 +1406,9 @@ describe('Lock-0 P1-A — registry-driven tab membership + roster (direct mount)
               : kind === 'form_field_user' ? { kind, fieldId: '' }
                 : kind === 'continuous_managers' ? { kind, levels: 1 }
                   : kind === 'manager_at_level' ? { kind, level: 1 }
-                    : { kind }
+                    // Lock-1 §K4: same default shape as continuous_managers.
+                    : kind === 'continuous_dept_heads' ? { kind, levels: 1 }
+                      : { kind }
         edit.assigneeSources = [next, ...edit.assigneeSources.slice(1)]
       },
       syncApprovalNodeOptions: () => {},
@@ -1431,6 +1436,7 @@ describe('Lock-0 P1-A — registry-driven tab membership + roster (direct mount)
         if (!source) return
         if (source.kind === 'manager_at_level') source.level = value
         else if (source.kind === 'continuous_managers') source.levels = value
+        else if (source.kind === 'continuous_dept_heads') source.levels = value
       },
       approvalSourceIsPlaceholder: () => false,
       approvalNodeMode: () => 'single',
@@ -1623,10 +1629,11 @@ describe('Lock-0 P1-A — registry-driven tab membership + roster (direct mount)
     unmount()
   })
 
-  it('A-3: roster equals the nine-member ApprovalAssigneeSourceKind union by exact set equality, not count or subset', () => {
+  it('A-3: roster equals the ten-member ApprovalAssigneeSourceKind union by exact set equality, not count or subset', () => {
     // Lock-1 §2.3: the exact-set gate grows from eight to eight-plus-ratified-K-kinds in the
-    // SAME commit that lands each kind — K2 `requester_choice` is the first admitted row.
-    const CANONICAL_NINE = [
+    // SAME commit that lands each kind — K2 `requester_choice`, K4 `continuous_dept_heads`.
+    const CANONICAL_TEN = [
+      'continuous_dept_heads',
       'continuous_managers',
       'dept_head',
       'direct_manager',
@@ -1640,7 +1647,7 @@ describe('Lock-0 P1-A — registry-driven tab membership + roster (direct mount)
     const roster = [...assigneeSourceRoster(DEFAULT_APPROVAL_CAPABILITY_REGISTRY, 'approval')]
       .map((opt) => opt.kind)
       .sort()
-    expect(roster).toEqual(CANONICAL_NINE)
+    expect(roster).toEqual(CANONICAL_TEN)
 
     const node = makeApprovalNode('approval_x')
     const { container: c, unmount } = mountDirectInspector({
@@ -1653,7 +1660,26 @@ describe('Lock-0 P1-A — registry-driven tab membership + roster (direct mount)
     )
       .map((el) => el.getAttribute('data-testid')?.replace('approval-node-source-kind-', ''))
       .sort()
-    expect(rendered).toEqual(CANONICAL_NINE)
+    expect(rendered).toEqual(CANONICAL_TEN)
+    unmount()
+  })
+
+  // Lock-1 §K4 — continuous_dept_heads authoring sub-form (canvas/graph inspector surface,
+  // ApprovalGraphNodeConfigEditor.vue — distinct from the linear TemplateAuthoringView.vue steps
+  // editor covered in approvalTemplateAuthoring.spec.ts): registry-admitted, renders EDITABLE with
+  // the shared level-count input, no unknown-kind hint.
+  it('K4: continuous_dept_heads renders EDITABLE with the level-count input (registry-admitted)', () => {
+    const node = makeApprovalNode('approval_dh')
+    const { container: c, unmount } = mountDirectInspector({
+      node,
+      registry: DEFAULT_APPROVAL_CAPABILITY_REGISTRY,
+      api: createStubConfigApi({ approval_dh: { assigneeSources: [{ kind: 'continuous_dept_heads', levels: 2 }] } }),
+    })
+    const roster = c.querySelector('[data-testid="approval-node-source-kind-continuous_dept_heads"]') as HTMLInputElement
+    expect(roster).not.toBeNull()
+    expect(roster.checked).toBe(true)
+    expect(c.querySelector('[data-testid="approval-node-source-level"]')).not.toBeNull()
+    expect(c.querySelector('[data-testid="approval-node-source-kind-unknown"]')).toBeNull()
     unmount()
   })
 

--- a/apps/web/tests/approval-template-authoring-parallel-edit.test.ts
+++ b/apps/web/tests/approval-template-authoring-parallel-edit.test.ts
@@ -398,6 +398,16 @@ describe('parallelDynamicAssigneeConflicts — publish preflight (F2)', () => {
     )).toHaveLength(1)
   })
 
+  it('Lock-1 §K4: flags identical continuous_dept_heads levels — the fingerprint mirror is in lockstep with the backend', () => {
+    expect(parallelDynamicAssigneeConflicts(
+      withBranchSources([{ kind: 'continuous_dept_heads', levels: 2 }], [{ kind: 'continuous_dept_heads', levels: 2 }]),
+    )).toHaveLength(1)
+    // Positive control: DIFFERENT levels are NOT flagged (parameterized, not kind-blanket).
+    expect(parallelDynamicAssigneeConflicts(
+      withBranchSources([{ kind: 'continuous_dept_heads', levels: 1 }], [{ kind: 'continuous_dept_heads', levels: 3 }]),
+    )).toEqual([])
+  })
+
   it('Lock-1 §K2 / G-17: requester_choice × requester_choice is NOT flagged (null fingerprint DELIBERATE — same-person collision is the runtime 409 guard\'s job)', () => {
     // Two requester_choice sources on parallel branches are NOT provably identical — the
     // requester may pick different people per branch — so the publish preflight must not block
@@ -421,6 +431,11 @@ describe('parallelDynamicAssigneeConflicts — publish preflight (F2)', () => {
     )).toEqual([])
     expect(parallelDynamicAssigneeConflicts(
       withBranchSources([{ kind: 'continuous_managers', levels: 1 }], [{ kind: 'continuous_managers', levels: 3 }]),
+    )).toEqual([])
+    // Lock-1 §K4: continuous_managers and continuous_dept_heads are DIFFERENT kinds (a different
+    // pointer, per §K4) — same `levels` value must not collide even though the shapes are alike.
+    expect(parallelDynamicAssigneeConflicts(
+      withBranchSources([{ kind: 'continuous_managers', levels: 2 }], [{ kind: 'continuous_dept_heads', levels: 2 }]),
     )).toEqual([])
   })
 

--- a/apps/web/tests/approvalTemplateAuthoring.spec.ts
+++ b/apps/web/tests/approvalTemplateAuthoring.spec.ts
@@ -571,6 +571,26 @@ describe('approval template authoring helpers', () => {
     expect(rehydrated.steps[0].levels).toBe(3)
   })
 
+  it('Lock-1 §K4: round-trips a continuous_dept_heads source incl. levels (save emits {kind, levels}; levels survives the real wire) — the linear editor accepted-kind list mirror site', () => {
+    const draft = createEmptyTemplateDraft()
+    draft.key = 'dh'
+    draft.name = '连续多级部门负责人审批'
+    draft.steps[0].sourceKind = 'continuous_dept_heads'
+    draft.steps[0].levels = 2
+
+    const payload = buildCreateTemplatePayload(draft)
+    expect((payload.approvalGraph.nodes[1]?.config as any).assigneeSources).toEqual([{ kind: 'continuous_dept_heads', levels: 2 }])
+
+    // wire-vs-fixture trap: assert `levels` survives the real serialize→parse, not a hand-built chip.
+    const rehydrated = draftFromTemplate(buildTemplate({ approvalGraph: payload.approvalGraph }))
+    expect(rehydrated.steps[0].sourceKind).toBe('continuous_dept_heads')
+    expect(rehydrated.steps[0].levels).toBe(2)
+    // And the rebuilt graph is byte-identical to the first emit (no hydrate flatten).
+    expect(buildCreateTemplatePayload(rehydrated).approvalGraph.nodes[1]?.config).toEqual(
+      payload.approvalGraph.nodes[1]?.config,
+    )
+  })
+
   it('round-trips a manager_at_level source incl. level (save emits {kind, level}; level survives the real wire)', () => {
     const draft = createEmptyTemplateDraft()
     draft.key = 'mal'
@@ -1725,6 +1745,20 @@ describe('TemplateAuthoringView', () => {
     expect((container!.querySelector('[data-testid="approval-template-save-button"]') as HTMLButtonElement).disabled).toBe(false) // editable
     expect((container!.querySelector('[data-testid="approval-step-source-kind"]') as HTMLSelectElement).value).toBe('continuous_managers') // hydrated back
     expect(container!.querySelector('[data-testid="approval-step-levels"]')).not.toBeNull() // the levels input renders for this kind
+  })
+
+  it('Lock-1 §K4: continuous_dept_heads reads back editable: a saved continuous_dept_heads template is NOT fail-closed (sourceKind + levels input hydrated, registry-admitted)', async () => {
+    routeParams = { id: 'tpl_dh' }
+    getTemplateSpy.mockResolvedValue(buildTemplate({
+      approvalGraph: buildComboGraph({ assigneeSources: [{ kind: 'continuous_dept_heads', levels: 2 }], approvalMode: 'all', emptyAssigneePolicy: 'error' }),
+    }))
+    await mountView()
+    await flushUi()
+
+    expect(container!.querySelector('[data-testid="approval-template-unsupported-alert"]')).toBeNull() // in the allowlist → not fail-closed
+    expect((container!.querySelector('[data-testid="approval-template-save-button"]') as HTMLButtonElement).disabled).toBe(false) // editable
+    expect((container!.querySelector('[data-testid="approval-step-source-kind"]') as HTMLSelectElement).value).toBe('continuous_dept_heads') // hydrated back
+    expect((container!.querySelector('[data-testid="approval-step-dept-head-levels"]') as HTMLInputElement)).not.toBeNull() // the levels input renders for this kind
   })
 
   it('updates an existing supported template without replacing it through create', async () => {

--- a/packages/core-backend/src/services/ApprovalAssigneeResolver.ts
+++ b/packages/core-backend/src/services/ApprovalAssigneeResolver.ts
@@ -251,6 +251,29 @@ export function resolveApprovalAssignees(
         })
         break
       }
+      case 'continuous_dept_heads': {
+        // Lock-1 §K4: resolve to the requester's DEPARTMENT-HEAD chain (levels 1..source.levels),
+        // frozen in the snapshot at create — a DIFFERENT pointer from continuous_managers'
+        // managerChainIds (the leader_in_dept LEADER pointer). This walks the department PARENT
+        // tree reading dept_manager_userid_list at each level
+        // (ApprovalDirectoryOrg.resolveDeptHeadChain), which — unlike managerChainIds — CONTINUES
+        // past a level whose head is unresolved (the ratified continue-past-empty-level posture,
+        // ratified Lock-1 §K4 / confirmed BINDING by Lock-2), since the chain-build's next hop is
+        // the department's own parent pointer, never a resolved manager. No live directory
+        // re-query happens HERE either way: this arm is a pure slice over the frozen chain,
+        // mirroring continuous_managers exactly (same self-exclusion, same dedup-via-pushResolved,
+        // same emptyAssigneePolicy fallthrough on an empty result).
+        const requesterId = normalizeId(options.requesterSnapshot?.id)
+        const rawChain = options.requesterSnapshot?.deptHeadChainIds
+        const chain = Array.isArray(rawChain) ? rawChain : []
+        chain.slice(0, source.levels).forEach((entry) => {
+          const headId = normalizeId(entry)
+          if (headId && headId !== requesterId) {
+            pushResolved('user', headId, source, sourceIndex)
+          }
+        })
+        break
+      }
       default:
         throw new ServiceError(
           `Approval node ${options.nodeKey} has an unsupported assignee source`,

--- a/packages/core-backend/src/services/ApprovalDirectoryOrg.ts
+++ b/packages/core-backend/src/services/ApprovalDirectoryOrg.ts
@@ -70,6 +70,24 @@ export interface ApprovalRequesterOrgRelations {
    * `manager_at_level` (picks the single id at `level - 1`). Omitted when empty.
    */
   managerChainIds?: string[]
+  /**
+   * Lock-1 §K4 — ordered local user ids of the requester's DEPARTMENT-HEAD chain, level 1 first
+   * (the requester's own department head). A DIFFERENT pointer from `managerChainIds`: that chain
+   * walks the `leader_in_dept` LEADER pointer (`resolveManagerChain` below); this one walks the
+   * DEPARTMENT PARENT tree (`directory_departments.external_parent_department_id`), reading
+   * `dept_manager_userid_list` at each level (`resolveDeptHeadChain` below). The two coincide only
+   * where every department's leader is also its listed manager. Only populated when the caller
+   * opts in via `includeDeptHeadChain` (i.e. a published graph uses `continuous_dept_heads`).
+   * Cycle-guarded (visited set of external DEPARTMENT ids) + capped at `MAX_MANAGER_CHAIN_LEVELS`.
+   * RATIFIED continue-past-empty-level posture (Lock-1 §K4): a level whose manager list is empty
+   * or resolves to no linked local user contributes nothing to the chain, but the walk CONTINUES
+   * to that department's parent — the next hop is the department's OWN parent pointer, independent
+   * of whether a head resolves at this level. This is the one place this chain's termination
+   * differs from `managerChainIds`, whose next hop IS the resolved leader (so it DOES stop when
+   * none is found). Read by `continuous_dept_heads` (slices it to its own `levels`). Omitted when
+   * empty.
+   */
+  deptHeadChainIds?: string[]
 }
 
 /** Default cap on how far up the org tree the bake-time walk climbs when unconfigured. */
@@ -203,6 +221,11 @@ export async function resolveApprovalRequesterOrgRelations(
   query: QueryFn,
   options: {
     includeManagerChain?: boolean
+    /** Lock-1 §K4 — walk the department-head chain (`deptHeadChainIds`) into the result. Opt-in
+     *  like `includeManagerChain`: gated on the published graph using `continuous_dept_heads`
+     *  (`runtimeGraphUsesDeptHeadChain`), so the extra per-hop queries stay off every other
+     *  approval. */
+    includeDeptHeadChain?: boolean
     maxLevels?: number
     orgId?: string
     /**
@@ -502,6 +525,23 @@ export async function resolveApprovalRequesterOrgRelations(
     if (chain.length > 0) relations.managerChainIds = chain
   }
 
+  // 5) Department-head chain (Lock-1 §K4, opt-in): walk the department PARENT tree up from the
+  //    requester's primary department, reading dept_manager_userid_list at each level. Only runs
+  //    when the caller opts in — i.e. a published graph uses continuous_dept_heads — so the extra
+  //    per-hop queries are NOT added to every approval. requesterDeptId may be null (requester has
+  //    no primary department); resolveDeptHeadChain handles that as an immediate empty chain.
+  if (options.includeDeptHeadChain) {
+    const deptHeadChain = await resolveDeptHeadChain(
+      integrationId,
+      requesterDeptId,
+      requester.external_user_id,
+      userId,
+      clampChainLevels(options.maxLevels),
+      query,
+    )
+    if (deptHeadChain.length > 0) relations.deptHeadChainIds = deptHeadChain
+  }
+
   return relations
 }
 
@@ -609,6 +649,103 @@ async function resolveManagerChain(
 
     currentExternalId = hop.externalUserId
     currentDeptExternalId = hop.primaryDeptExternalId
+  }
+
+  return chain
+}
+
+interface DeptHop {
+  raw: unknown
+  parentExternalId: string | null
+}
+
+/**
+ * One hop: the department identified by `(integrationId, deptExternalId)`, returning its `raw`
+ * payload (source of `dept_manager_userid_list` for THIS level) and its parent's external id (to
+ * continue the walk). Returns `undefined` when the department itself cannot be found — top of the
+ * REACHABLE tree, covering both a genuine root department (no `external_parent_department_id`)
+ * and a dangling/missing parent reference from a partially-synced org.
+ */
+async function fetchDeptHop(
+  integrationId: string,
+  deptExternalId: string,
+  query: QueryFn,
+): Promise<DeptHop | undefined> {
+  const rows = await query<{ raw: unknown; external_parent_department_id: string | null }>(
+    `SELECT raw                          AS raw,
+            external_parent_department_id AS external_parent_department_id
+       FROM directory_departments
+      WHERE integration_id = $1::uuid
+        AND external_department_id = $2
+      LIMIT 1`,
+    [integrationId, deptExternalId],
+  )
+  const row = rows.rows[0]
+  if (!row) return undefined
+  return { raw: row.raw, parentExternalId: normalizeExternalId(row.external_parent_department_id) }
+}
+
+/**
+ * Lock-1 §K4 — walk the department PARENT tree up from the requester's primary department,
+ * collecting each level's head. A DIFFERENT pointer from `resolveManagerChain` above: that walk
+ * follows the `leader_in_dept` LEADER pointer (the next hop IS the resolved leader's own primary
+ * department); this walk follows `directory_departments.external_parent_department_id` — a
+ * property of the DEPARTMENT itself, independent of whether any head resolves at this level.
+ *
+ * "Primary" head selection is byte-identical to the shipped single-level `dept_head` (step 3
+ * above): the FIRST external id in `dept_manager_userid_list` order — excluding the requester's
+ * own EXTERNAL id — that resolves to a LINKED local user. The inner loop breaks on that first
+ * resolution exactly like the single-level computation; a SEPARATE local-id self-exclusion then
+ * decides whether the resolved head enters the CHAIN (mirroring how `managerChainIds` differs
+ * from `managerId` — see that field's doc comment).
+ *
+ * RATIFIED continue-past-empty-level posture (confirmed BINDING by Lock-2): a level whose manager
+ * list is empty, OR whose ids all resolve to no linked local user, contributes NOTHING to the
+ * chain — but the walk CONTINUES to that department's parent regardless, because the next hop
+ * (`hop.parentExternalId`) is read from THIS department's own row, never from a resolved manager.
+ * This is the exact way K4 differs from `resolveManagerChain`, whose next hop DOES depend on a
+ * resolved leader and therefore DOES stop when none is found.
+ *
+ * Termination is bounded three ways, mirroring `resolveManagerChain`:
+ *   - a visited-set of external DEPARTMENT ids stops cycles (dept A's parent is dept B, B's is A);
+ *   - a hop whose department cannot be found at all stops the walk (top of the reachable tree);
+ *   - at most `maxLevels` hops are taken.
+ * Self-exclusion is on the requester's LOCAL id (an alt-account of the requester listed as a
+ * manager of some ancestor department must not enter the chain — same rationale as
+ * `resolveManagerChain`'s local-id exclusion); duplicates are collapsed.
+ */
+async function resolveDeptHeadChain(
+  integrationId: string,
+  requesterDeptExternalId: string | null,
+  requesterExternalId: string,
+  requesterLocalId: string,
+  maxLevels: number,
+  query: QueryFn,
+): Promise<string[]> {
+  const chain: string[] = []
+  const visited = new Set<string>()
+  let currentDeptExternalId = requesterDeptExternalId
+
+  for (let level = 0; level < maxLevels; level += 1) {
+    if (!currentDeptExternalId || visited.has(currentDeptExternalId)) break
+    visited.add(currentDeptExternalId)
+
+    const hop = await fetchDeptHop(integrationId, currentDeptExternalId, query)
+    if (!hop) break
+
+    // Continue-past-empty-level: resolve THIS level's head without letting the outcome gate the
+    // next hop (set below, from `hop.parentExternalId`).
+    const managerExternalIds = parseDeptManagerExternalIds(asRecord(hop.raw))
+      .filter((external) => external !== requesterExternalId)
+    for (const external of managerExternalIds) {
+      const localId = await resolveLinkedLocalUserIdByExternal(integrationId, external, query)
+      if (localId) {
+        if (localId !== requesterLocalId && !chain.includes(localId)) chain.push(localId)
+        break
+      }
+    }
+
+    currentDeptExternalId = hop.parentExternalId
   }
 
   return chain

--- a/packages/core-backend/src/services/ApprovalProductService.ts
+++ b/packages/core-backend/src/services/ApprovalProductService.ts
@@ -638,6 +638,16 @@ function normalizeApprovalAssigneeSources(
         }
         return { kind: 'manager_at_level', level }
       }
+      case 'continuous_dept_heads': {
+        // Lock-1 §K4: `levels` validated byte-identically to `continuous_managers` — an
+        // out-of-range / non-integer / missing `levels` is rejected, never silently
+        // defaulted (enum-strictness).
+        const levels = source.levels
+        if (typeof levels !== 'number' || !Number.isInteger(levels) || levels < 1 || levels > MAX_MANAGER_CHAIN_LEVELS) {
+          failValidation(context, `${sourcePath}.levels must be an integer between 1 and ${MAX_MANAGER_CHAIN_LEVELS}`)
+        }
+        return { kind: 'continuous_dept_heads', levels }
+      }
       case 'form_field_user':
         if (!isNonEmptyString(source.fieldId)) {
           failValidation(context, `${sourcePath}.fieldId is required`)
@@ -1538,6 +1548,8 @@ function dynamicAssigneeSourceFingerprint(source: ApprovalAssigneeSource): strin
       return `continuous_managers:${source.levels}`
     case 'manager_at_level':
       return `manager_at_level:${source.level}`
+    case 'continuous_dept_heads':
+      return `continuous_dept_heads:${source.levels}`
     case 'form_field_user':
       return `form_field_user:${source.fieldId}`
     case 'static_user':
@@ -3127,6 +3139,26 @@ export function runtimeGraphUsesManagerChain(runtimeGraph: RuntimeGraph): boolea
 }
 
 /**
+ * Lock-1 §K4: true when any approval node's assignee sources include `continuous_dept_heads`.
+ * Used at create time to decide whether to walk the (more expensive) department-head chain into
+ * the requester snapshot — a SEPARATE opt-in gate from `runtimeGraphUsesManagerChain` above,
+ * because `continuous_dept_heads` bakes a DIFFERENT snapshot field (`deptHeadChainIds`, a
+ * different walk over a different pointer — see the union member's doc comment) via a DIFFERENT
+ * option (`includeDeptHeadChain`), so an unrelated template never pays for either walk. `kind` is
+ * read structurally so this works before the kind is added to the typed union (same posture as
+ * `runtimeGraphUsesManagerChain`).
+ */
+export function runtimeGraphUsesDeptHeadChain(runtimeGraph: RuntimeGraph): boolean {
+  return runtimeGraph.nodes.some((node) => {
+    if (node.type !== 'approval') return false
+    const config: unknown = node.config
+    const sources = isRecord(config) ? config.assigneeSources : undefined
+    if (!Array.isArray(sources)) return false
+    return sources.some((source) => isRecord(source) && source.kind === 'continuous_dept_heads')
+  })
+}
+
+/**
  * B5-b owner P1: does the graph use ANY org-derived assignee source? All four kinds resolve from
  * `orgRelations` — so when the org read FAILED (transient) or the routing POLICY is misconfigured,
  * an empty `orgRelations` is not "requester has no manager", it is "we could not find out". Letting
@@ -3135,6 +3167,13 @@ export function runtimeGraphUsesManagerChain(runtimeGraph: RuntimeGraph): boolea
  * on this detector fail-closes instead: 422 for the persistent policy config error, 503 for the
  * transient read failure — with NO instance and NO assignment created. Genuine data absence (the
  * read SUCCEEDED, the requester simply has no manager) still follows `emptyAssigneePolicy`.
+ *
+ * Lock-1 §2.1 EXTENSION (K4): `continuous_dept_heads` is EXTENDED into this detector alongside the
+ * four shipped org-derived kinds. Leaving it unextended would reproduce exactly the B5-b fail-open
+ * this guard closed: an org read failure plus `emptyAssigneePolicy: 'auto-approve'` would silently
+ * auto-approve instead of fail-closing at create. (K5-b `dept_head_at_level` is NOT added here —
+ * it is not implemented in this slice; §2.3 admits its registry row only once K4 has landed, and
+ * this detector must not claim a kind that does not exist yet.)
  */
 export function runtimeGraphUsesOrgAssigneeSource(runtimeGraph: RuntimeGraph): boolean {
   return runtimeGraph.nodes.some((node) => {
@@ -3153,7 +3192,8 @@ export function runtimeGraphUsesOrgAssigneeSource(runtimeGraph: RuntimeGraph): b
         (source.kind === 'direct_manager' ||
           source.kind === 'dept_head' ||
           source.kind === 'continuous_managers' ||
-          source.kind === 'manager_at_level'),
+          source.kind === 'manager_at_level' ||
+          source.kind === 'continuous_dept_heads'),
     )
   })
 }
@@ -5217,6 +5257,9 @@ export class ApprovalProductService {
       ? { userId: options.requesterOverride.userId, userName: options.requesterOverride.userName || options.requesterOverride.userId }
       : { userId: actor.userId, userName: actor.userName, email: actor.email, department: actor.department, roles: actor.roles, permissions: actor.permissions }
     const needsManagerChain = runtimeGraphUsesManagerChain(runtimeGraph)
+    // Lock-1 §K4 — separate opt-in gate for the department-head chain (a different snapshot field,
+    // a different walk, a different ApprovalDirectoryOrg option); see runtimeGraphUsesDeptHeadChain.
+    const needsDeptHeadChain = runtimeGraphUsesDeptHeadChain(runtimeGraph)
     let orgRelations: ApprovalRequesterOrgRelations = {}
     let orgReadFailed = false
     // B5-b: a routing-POLICY config error (policy points at a missing/inactive integration, or the
@@ -5229,6 +5272,7 @@ export class ApprovalProductService {
     try {
       orgRelations = await resolveApprovalRequesterOrgRelations(effectiveRequester.userId, pool.query.bind(pool), {
         includeManagerChain: needsManagerChain,
+        includeDeptHeadChain: needsDeptHeadChain,
       })
     } catch (error) {
       orgReadFailed = true
@@ -5406,6 +5450,8 @@ export class ApprovalProductService {
       ...(orgRelations.managerId ? { managerId: orgRelations.managerId } : {}),
       ...(orgRelations.deptHeadId ? { deptHeadId: orgRelations.deptHeadId } : {}),
       ...(orgRelations.managerChainIds ? { managerChainIds: orgRelations.managerChainIds } : {}),
+      // Lock-1 §K4: freeze the department-head chain baked above (opt-in, needsDeptHeadChain).
+      ...(orgRelations.deptHeadChainIds ? { deptHeadChainIds: orgRelations.deptHeadChainIds } : {}),
       ...(Object.keys(delegationMap).length > 0 ? { delegations: delegationMap } : {}),
       // Lock-1 §K2: freeze the validated submit-time choices (node key → chosen local user
       // ids). The resolver reads ONLY this map — immutable across return/admin-jump/timeout.

--- a/packages/core-backend/src/types/approval-product.ts
+++ b/packages/core-backend/src/types/approval-product.ts
@@ -16,7 +16,7 @@ export type ApprovalProductPermission = typeof APPROVAL_PRODUCT_PERMISSIONS[numb
 // admission set in ApprovalProductService.ts) or the type is unpublishable.
 export type ApprovalNodeType = 'start' | 'approval' | 'cc' | 'condition' | 'parallel' | 'end' | 'handler'
 export type ApprovalAssigneeType = 'user' | 'role'
-export type ApprovalAssigneeSourceKind = 'static_user' | 'static_role' | 'requester' | 'form_field_user' | 'direct_manager' | 'dept_head' | 'continuous_managers' | 'manager_at_level' | 'requester_choice'
+export type ApprovalAssigneeSourceKind = 'static_user' | 'static_role' | 'requester' | 'form_field_user' | 'direct_manager' | 'dept_head' | 'continuous_managers' | 'manager_at_level' | 'requester_choice' | 'continuous_dept_heads'
 export type ApprovalMode = 'single' | 'all' | 'any' | 'threshold'
 
 /**
@@ -243,6 +243,22 @@ export type ApprovalAssigneeSource =
         | { type: 'members'; userIds: string[] }
         | { type: 'role'; roleIds: string[] }
     }
+  /**
+   * Lock-1 §K4 — 连续多级部门负责人 (continuous department heads), levels 1..`levels` (level 1 =
+   * the requester's own department head), resolved from the baked `deptHeadChainIds` snapshot.
+   * A DIFFERENT pointer from `continuous_managers`/`managerChainIds`: that chain walks the
+   * `leader_in_dept` LEADER pointer (`ApprovalDirectoryOrg.resolveManagerChain`); this one walks
+   * the DEPARTMENT PARENT tree (`directory_departments.external_parent_department_id`), reading
+   * `dept_manager_userid_list` at each level (`ApprovalDirectoryOrg.resolveDeptHeadChain`). The
+   * two chains coincide only where every department's leader is also its listed manager.
+   * RATIFIED continue-past-empty-level posture: a level whose manager list is empty or resolves
+   * to no linked local user contributes NOTHING to the chain, but the walk CONTINUES to that
+   * department's parent (the next hop is the department's OWN parent pointer, independent of
+   * whether a head resolves at this level) — unlike `managerChainIds`, whose next hop IS the
+   * resolved leader and so DOES stop when none is found. `levels` is validated
+   * `[1, MAX_MANAGER_CHAIN_LEVELS]` at normalize time, byte-identically to `continuous_managers`.
+   */
+  | { kind: 'continuous_dept_heads'; levels: number }
 
 export type RequesterChoiceAssigneeSource = Extract<ApprovalAssigneeSource, { kind: 'requester_choice' }>
 
@@ -428,6 +444,19 @@ export interface ApprovalRequesterSnapshot {
    * snapshots omit it.
    */
   managerChainIds?: string[]
+  /**
+   * Lock-1 §K4 — ordered local user ids of the requester's DEPARTMENT-HEAD chain, level 1 first
+   * (the requester's own department head). A DIFFERENT pointer from `managerChainIds` — see the
+   * `continuous_dept_heads` union member doc comment for the leader-pointer vs parent-tree
+   * distinction. Frozen at create time only when the published graph uses `continuous_dept_heads`
+   * (gated by `runtimeGraphUsesDeptHeadChain`, so it is not baked for every approval).
+   * Cycle-guarded (visited set of external DEPARTMENT ids) + capped at MAX_MANAGER_CHAIN_LEVELS;
+   * self-excluded on the requester's LOCAL id; absent when unresolvable or unused. A level whose
+   * head is unresolved contributes nothing but does NOT truncate the walk (ratified
+   * continue-past-empty-level posture). Read by `continuous_dept_heads` (slices it to its own
+   * `levels`). Purely additive; existing snapshots omit it.
+   */
+  deptHeadChainIds?: string[]
   /**
    * Delegation (委托) substitution map (delegator localUserId -> delegatee localUserId),
    * frozen at create time from the active `approval_delegations` scoped to this template

--- a/packages/core-backend/tests/integration/approval-dept-head-chain.db.test.ts
+++ b/packages/core-backend/tests/integration/approval-dept-head-chain.db.test.ts
@@ -1,0 +1,473 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import net from 'net'
+import { MetaSheetServer } from '../../src/index'
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { query } from '../../src/db/pg'
+import { ensureApprovalSchemaReady, grantApprovalWriteForIntegrationActor } from '../helpers/approval-schema-bootstrap'
+
+/**
+ * Lock-1 §K4 `continuous_dept_heads` (连续多级部门负责人) — REAL-DB end-to-end acceptance
+ * (docs/development/approval-lock1-enterprise-assignees-20260817.md §K4; gates G-1/G-2/G-3/
+ * G-13/G-18; harness mirrors approval-requester-choice.db.test.ts, org fixture mirrors
+ * approval-manager-chain.db.test.ts extended with a THREE-level department PARENT tree).
+ *
+ * Org fixture (one integration, `dh-<TS>`):
+ *   DEPT_TOP (root; manager list = [HEAD3])
+ *     <- DEPT_MID (manager list EMPTY — the continue-past-empty-level level)
+ *          <- DEPT_BOT (REQ's primary dept; manager list = [HEAD1]; ALSO flags a DIFFERENT
+ *                       account LEADER_BOT leader_in_dept, for the G-13 pointer-distinctness arm)
+ *   DEPT_AGREE (separate, one level; the SAME account AGREE is both dept_manager_userid_list[0]
+ *               AND leader_in_dept-flagged — the G-13 "pointers coincide" arm)
+ *
+ * Proves:
+ *  G-1      levels validated byte-identically to continuous_managers: out-of-range / non-integer /
+ *           missing 400s; a valid shape saves in the same fixture (positive control);
+ *  G-2      a contract-unimplemented kind is rejected at authoring, never persisted;
+ *  G-3/core the real department-parent-tree walk executes real SQL end-to-end: DEPT_MID's EMPTY
+ *           manager list contributes NOTHING but the walk CONTINUES to DEPT_TOP (ratified Lock-1
+ *           §K4 continue-past-empty-level posture) — dispatch resolves EXACTLY [HEAD1, HEAD3],
+ *           each with metadata.resolvedFrom.kind='continuous_dept_heads';
+ *  G-13     in DEPT_BOT, leader_in_dept (LEADER_BOT) and dept_manager_userid_list (HEAD1) name
+ *           DIFFERENT people: continuous_managers and continuous_dept_heads resolve DIFFERENT
+ *           people for the SAME requester (arm 1 — discriminates the pointer, not the label); in
+ *           DEPT_AGREE they name the SAME person (AGREE): both kinds resolve the SAME person for a
+ *           second requester (arm 2 — the test is not vacuously always-different);
+ *  freeze   a directory mutation (DEPT_BOT's manager list swapped) AFTER create does not change an
+ *  purity   in-flight assignment (frozen snapshot) but DOES change a NEWLY created approval — the
+ *           freeze is temporal, not a dead/cached read (mirrors K2's G-19 temporal positive control);
+ *  G-18     the levels-validation 400 body carries the node key/source index, never a person id.
+ *
+ * G-20 (org-read fail-closed extension to continuous_dept_heads) lives in the existing parametrized
+ * fixture `approval-routing-policy-failclose.api.test.ts` (KINDS now includes
+ * 'continuous_dept_heads') — not duplicated here.
+ */
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const TS = Date.now()
+const REQ = `dh-req-${TS}`
+const REQ_AGREE = `dh-reqagree-${TS}`
+const APPROVER = `dh-appr-${TS}`
+const U_HEAD1 = `dh-head1-${TS}`
+const U_HEAD1B = `dh-head1b-${TS}` // post-mutation replacement head (freeze-purity temporal arm)
+const U_HEAD3 = `dh-head3-${TS}`
+const U_LEADER_BOT = `dh-leaderbot-${TS}` // leader_in_dept of DEPT_BOT, DIFFERENT from HEAD1 (G-13 arm 1)
+const U_AGREE = `dh-agree-${TS}` // both leader_in_dept AND dept_manager_userid_list of DEPT_AGREE (G-13 arm 2)
+
+// Deterministic external ids, hoisted to module scope so both `beforeAll` (fixture insert) and
+// individual `it()` blocks (the freeze-purity mutation) can reference the SAME values.
+const EXT_TOP = `dtop-${TS}`
+const EXT_MID = `dmid-${TS}`
+const EXT_BOT = `dbot-${TS}`
+const EXT_HEAD1 = `ehead1-${TS}`
+const EXT_HEAD1B = `ehead1b-${TS}`
+const EXT_HEAD3 = `ehead3-${TS}`
+const EXT_LEADER_BOT = `eleaderbot-${TS}`
+const EXT_REQ = `ereq-${TS}`
+const EXT_AGREE_DEPT = `dagree-${TS}`
+const EXT_AGREE_USER = `eagree-${TS}`
+const EXT_REQ_AGREE = `ereqagree-${TS}`
+
+async function canListen(): Promise<boolean> {
+  return await new Promise((r) => {
+    const s = net.createServer()
+    s.once('error', () => r(false))
+    s.listen(0, '127.0.0.1', () => s.close(() => r(true)))
+  })
+}
+async function tok(base: string, userId: string): Promise<string> {
+  await grantApprovalWriteForIntegrationActor(userId)
+  const res = await fetch(`${base}/api/auth/dev-token?userId=${encodeURIComponent(userId)}&roles=admin&perms=${encodeURIComponent('*:*')}`)
+  return ((await res.json()) as { token: string }).token
+}
+async function req(base: string, path: string, token: string, opts: { method?: string; body?: unknown } = {}): Promise<Response> {
+  return fetch(`${base}${path}`, {
+    method: opts.method || 'GET',
+    headers: { Authorization: `Bearer ${token}`, ...(opts.body !== undefined ? { 'Content-Type': 'application/json' } : {}) },
+    ...(opts.body !== undefined ? { body: JSON.stringify(opts.body) } : {}),
+  })
+}
+
+const FORM_SCHEMA = { fields: [{ id: 'reason', type: 'text', label: 'r', required: true }] }
+
+// gate (static APPROVER) -> heads (continuous_dept_heads) -> end.
+function headsGraph(levels: number, emptyAssigneePolicy: 'error' | 'auto-approve' = 'error') {
+  return {
+    nodes: [
+      { key: 'start', type: 'start', name: 's', config: {} },
+      { key: 'gate', type: 'approval', name: 'gate', config: { assigneeSources: [{ kind: 'static_user', userIds: [APPROVER] }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+      { key: 'heads', type: 'approval', name: 'heads', config: { assigneeSources: [{ kind: 'continuous_dept_heads', levels }], approvalMode: 'all', emptyAssigneePolicy } },
+      { key: 'end', type: 'end', name: 'e', config: {} },
+    ],
+    edges: [
+      { key: 's2g', source: 'start', target: 'gate' },
+      { key: 'g2h', source: 'gate', target: 'heads' },
+      { key: 'h2e', source: 'heads', target: 'end' },
+    ],
+  }
+}
+
+// single-node graph (no gate) directly resolving one kind at levels=1, for the G-13 comparison.
+function singleLevelGraph(kind: 'continuous_managers' | 'continuous_dept_heads') {
+  return {
+    nodes: [
+      { key: 'start', type: 'start', name: 's', config: {} },
+      { key: 'lvl1', type: 'approval', name: 'l', config: { assigneeSources: [{ kind, levels: 1 }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+      { key: 'end', type: 'end', name: 'e', config: {} },
+    ],
+    edges: [
+      { key: 's2l', source: 'start', target: 'lvl1' },
+      { key: 'l2e', source: 'lvl1', target: 'end' },
+    ],
+  }
+}
+
+type ErrorBody = { code?: string; error?: { code?: string; message?: string; details?: Record<string, unknown> } }
+function errorCode(body: ErrorBody): string | undefined {
+  return body.code ?? body.error?.code
+}
+
+describeIfDatabase('Lock-1 §K4 continuous_dept_heads — real-DB create/freeze/dispatch acceptance', () => {
+  let server: MetaSheetServer | undefined
+  let base = ''
+  let reqTok = ''
+  let reqAgreeTok = ''
+  let apprTok = ''
+  let head1Tok = ''
+  let head1bTok = ''
+  let head3Tok = ''
+  let integrationId = ''
+  let deptBotId = ''
+
+  async function createTemplate(key: string, graph: unknown): Promise<string> {
+    const created = await req(base, '/api/approval-templates', reqTok, {
+      method: 'POST',
+      body: { key, name: key, formSchema: FORM_SCHEMA, approvalGraph: graph },
+    })
+    expect(created.status, await created.clone().text()).toBe(201)
+    return ((await created.json()) as { id: string }).id
+  }
+  async function publishTemplate(tid: string): Promise<Response> {
+    return req(base, `/api/approval-templates/${tid}/publish`, reqTok, { method: 'POST', body: { policy: { allowRevoke: true } } })
+  }
+  async function createPublished(key: string, graph: unknown): Promise<string> {
+    const tid = await createTemplate(key, graph)
+    const published = await publishTemplate(tid)
+    expect(published.status, await published.clone().text()).toBe(200)
+    return tid
+  }
+  async function instanceCount(tid: string): Promise<number> {
+    const pool = poolManager.get()
+    const rows = await pool.query(`SELECT COUNT(*)::int AS n FROM approval_instances WHERE template_id = $1`, [tid])
+    return (rows.rows[0] as { n: number }).n
+  }
+  async function activeAssignees(iid: string, nodeKey: string): Promise<Array<{ assignee_id: string; metadata: Record<string, unknown> | null }>> {
+    const pool = poolManager.get()
+    const rows = await pool.query(
+      `SELECT assignee_id, metadata FROM approval_assignments WHERE instance_id = $1 AND node_key = $2 AND is_active = TRUE ORDER BY assignee_id`,
+      [iid, nodeKey],
+    )
+    return rows.rows as Array<{ assignee_id: string; metadata: Record<string, unknown> | null }>
+  }
+  async function createAsReq(tid: string, requesterTok = reqTok): Promise<{ status: number; iid?: string; text: string }> {
+    const started = await req(base, '/api/approvals', requesterTok, { method: 'POST', body: { templateId: tid, formData: { reason: 'r' } } })
+    const text = await started.clone().text()
+    if (started.status >= 300) return { status: started.status, text }
+    return { status: started.status, iid: ((await started.json()) as { id: string }).id, text }
+  }
+
+  beforeAll(async () => {
+    expect(await canListen()).toBe(true)
+    await ensureApprovalSchemaReady()
+
+    for (const u of [REQ, REQ_AGREE, APPROVER, U_HEAD1, U_HEAD1B, U_HEAD3, U_LEADER_BOT, U_AGREE]) {
+      await query(`INSERT INTO users (id, email, password_hash) VALUES ($1, $2, 'x') ON CONFLICT (id) DO NOTHING`, [u, `${u}@example.test`])
+    }
+
+    const integ = await query<{ id: string }>(
+      `INSERT INTO directory_integrations (name, corp_id) VALUES ($1, $2) RETURNING id`,
+      [`dh-${TS}`, `dh-corp-${TS}`],
+    )
+    integrationId = integ.rows[0].id
+
+    // ── DEPT_TOP <- DEPT_MID(empty) <- DEPT_BOT(REQ's primary) ──────────────────────────────
+    const extTop = EXT_TOP
+    const extMid = EXT_MID
+    const extBot = EXT_BOT
+    const extHead1 = EXT_HEAD1
+    const extHead3 = EXT_HEAD3
+    const extLeaderBot = EXT_LEADER_BOT
+    const extReq = EXT_REQ
+
+    await query(
+      `INSERT INTO directory_departments (integration_id, external_department_id, external_parent_department_id, name, is_active, raw)
+       VALUES ($1, $2, NULL, 'Top', true, $3::jsonb)`,
+      [integrationId, extTop, JSON.stringify({ dept_manager_userid_list: [extHead3] })],
+    )
+    // DEPT_MID: EMPTY manager list — the continue-past-empty-level proof point.
+    await query(
+      `INSERT INTO directory_departments (integration_id, external_department_id, external_parent_department_id, name, is_active, raw)
+       VALUES ($1, $2, $3, 'Mid', true, $4::jsonb)`,
+      [integrationId, extMid, extTop, JSON.stringify({ dept_manager_userid_list: [] })],
+    )
+    const deptBot = await query<{ id: string }>(
+      `INSERT INTO directory_departments (integration_id, external_department_id, external_parent_department_id, name, is_active, raw)
+       VALUES ($1, $2, $3, 'Bot', true, $4::jsonb) RETURNING id`,
+      [integrationId, extBot, extMid, JSON.stringify({ dept_manager_userid_list: [extHead1] })],
+    )
+    deptBotId = deptBot.rows[0].id
+
+    const accReq = await query<{ id: string }>(
+      `INSERT INTO directory_accounts (integration_id, external_user_id, external_key, name, raw)
+       VALUES ($1, $2, $3, 'Req', '{}'::jsonb) RETURNING id`,
+      [integrationId, extReq, `k-req-${TS}`],
+    )
+    const accHead1 = await query<{ id: string }>(
+      `INSERT INTO directory_accounts (integration_id, external_user_id, external_key, name, raw)
+       VALUES ($1, $2, $3, 'Head1', '{}'::jsonb) RETURNING id`,
+      [integrationId, extHead1, `k-head1-${TS}`],
+    )
+    const accHead3 = await query<{ id: string }>(
+      `INSERT INTO directory_accounts (integration_id, external_user_id, external_key, name, raw)
+       VALUES ($1, $2, $3, 'Head3', '{}'::jsonb) RETURNING id`,
+      [integrationId, extHead3, `k-head3-${TS}`],
+    )
+    // LEADER_BOT: member of DEPT_BOT, flagged leader_in_dept for it — DIFFERENT person from HEAD1
+    // (G-13 arm 1: the two pointers must disagree here).
+    const accLeaderBot = await query<{ id: string }>(
+      `INSERT INTO directory_accounts (integration_id, external_user_id, external_key, name, raw)
+       VALUES ($1, $2, $3, 'LeaderBot', $4::jsonb) RETURNING id`,
+      [integrationId, extLeaderBot, `k-leaderbot-${TS}`, JSON.stringify({ leader_in_dept: [{ dept_id: extBot, leader: true }] })],
+    )
+
+    await query(
+      `INSERT INTO directory_account_links (directory_account_id, local_user_id, link_status, match_strategy)
+       VALUES ($1, $2, 'linked', 'manual'), ($3, $4, 'linked', 'manual'), ($5, $6, 'linked', 'manual'), ($7, $8, 'linked', 'manual')`,
+      [accReq.rows[0].id, REQ, accHead1.rows[0].id, U_HEAD1, accHead3.rows[0].id, U_HEAD3, accLeaderBot.rows[0].id, U_LEADER_BOT],
+    )
+    await query(
+      `INSERT INTO directory_account_departments (directory_account_id, directory_department_id, is_primary)
+       VALUES ($1, $2, true), ($3, $2, false)`,
+      [accReq.rows[0].id, deptBotId, accLeaderBot.rows[0].id],
+    )
+
+    // ── DEPT_AGREE: the SAME account is both leader_in_dept AND dept_manager_userid_list[0]
+    //    (G-13 arm 2 — the two pointers COINCIDE here) ────────────────────────────────────────
+    const extAgreeDept = EXT_AGREE_DEPT
+    const extAgreeUser = EXT_AGREE_USER
+    const extReqAgree = EXT_REQ_AGREE
+    const deptAgree = await query<{ id: string }>(
+      `INSERT INTO directory_departments (integration_id, external_department_id, external_parent_department_id, name, is_active, raw)
+       VALUES ($1, $2, NULL, 'Agree', true, $3::jsonb) RETURNING id`,
+      [integrationId, extAgreeDept, JSON.stringify({ dept_manager_userid_list: [extAgreeUser] })],
+    )
+    const accReqAgree = await query<{ id: string }>(
+      `INSERT INTO directory_accounts (integration_id, external_user_id, external_key, name, raw)
+       VALUES ($1, $2, $3, 'ReqAgree', '{}'::jsonb) RETURNING id`,
+      [integrationId, extReqAgree, `k-reqagree-${TS}`],
+    )
+    const accAgree = await query<{ id: string }>(
+      `INSERT INTO directory_accounts (integration_id, external_user_id, external_key, name, raw)
+       VALUES ($1, $2, $3, 'Agree', $4::jsonb) RETURNING id`,
+      [integrationId, extAgreeUser, `k-agree-${TS}`, JSON.stringify({ leader_in_dept: [{ dept_id: extAgreeDept, leader: true }] })],
+    )
+    await query(
+      `INSERT INTO directory_account_links (directory_account_id, local_user_id, link_status, match_strategy)
+       VALUES ($1, $2, 'linked', 'manual'), ($3, $4, 'linked', 'manual')`,
+      [accReqAgree.rows[0].id, REQ_AGREE, accAgree.rows[0].id, U_AGREE],
+    )
+    await query(
+      `INSERT INTO directory_account_departments (directory_account_id, directory_department_id, is_primary)
+       VALUES ($1, $2, true), ($3, $2, false)`,
+      [accReqAgree.rows[0].id, deptAgree.rows[0].id, accAgree.rows[0].id],
+    )
+
+    server = new MetaSheetServer({ port: 0, host: '127.0.0.1', pluginDirs: [] })
+    await server.start()
+    base = `http://127.0.0.1:${server.getAddress()!.port}`
+    reqTok = await tok(base, REQ)
+    reqAgreeTok = await tok(base, REQ_AGREE)
+    apprTok = await tok(base, APPROVER)
+    head1Tok = await tok(base, U_HEAD1)
+    head1bTok = await tok(base, U_HEAD1B)
+    head3Tok = await tok(base, U_HEAD3)
+  })
+
+  afterAll(async () => {
+    try {
+      const pool = poolManager.get()
+      const tids = (await pool.query(`SELECT id FROM approval_templates WHERE key LIKE $1`, [`dh-${TS}-%`])).rows.map((r) => r.id as string)
+      if (tids.length > 0) {
+        const iids = (await pool.query(`SELECT id FROM approval_instances WHERE template_id = ANY($1::uuid[])`, [tids])).rows.map((r) => r.id as string)
+        if (iids.length > 0) {
+          await pool.query(`DELETE FROM approval_records WHERE instance_id = ANY($1)`, [iids])
+          await pool.query(`DELETE FROM approval_assignments WHERE instance_id = ANY($1)`, [iids])
+          await pool.query(`DELETE FROM approval_instances WHERE id = ANY($1)`, [iids])
+        }
+        await pool.query(`DELETE FROM approval_published_definitions WHERE template_id = ANY($1::uuid[])`, [tids])
+        await pool.query(`DELETE FROM approval_templates WHERE id = ANY($1::uuid[])`, [tids])
+      }
+      if (integrationId) {
+        await query(`DELETE FROM directory_accounts WHERE integration_id = $1`, [integrationId])
+        await query(`DELETE FROM directory_departments WHERE integration_id = $1`, [integrationId])
+        await query(`DELETE FROM directory_integrations WHERE id = $1`, [integrationId])
+      }
+      await query(`DELETE FROM users WHERE id = ANY($1::varchar[])`, [[REQ, REQ_AGREE, APPROVER, U_HEAD1, U_HEAD1B, U_HEAD3, U_LEADER_BOT, U_AGREE]])
+    } catch {
+      /* best effort */
+    }
+    if (server) await server.stop()
+  })
+
+  it('sentinel: DATABASE_URL is set (DB-backed lane must not silently skip)', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  // ── G-1 — authoring choke: levels validated byte-identically to continuous_managers ─────────
+  it('G-1: continuous_dept_heads saves with a valid levels; out-of-range / non-integer / missing each 400 (G-18: node key present, no person id)', async () => {
+    // Positive control FIRST: a valid shape saves.
+    const okTid = await createTemplate(`dh-${TS}-g1-ok`, headsGraph(3))
+    expect(okTid).toBeTruthy()
+
+    const badLevels: unknown[] = [0, -1, 1.5, 11, 'two', null, undefined]
+    for (const levels of badLevels) {
+      const graph = headsGraph(3) as { nodes: Array<{ config: { assigneeSources?: unknown[] } }> }
+      const source: Record<string, unknown> = { kind: 'continuous_dept_heads' }
+      if (levels !== undefined) source.levels = levels
+      graph.nodes[2].config.assigneeSources = [source]
+      const res = await req(base, '/api/approval-templates', reqTok, {
+        method: 'POST',
+        body: { key: `dh-${TS}-g1-bad`, name: 'bad', formSchema: FORM_SCHEMA, approvalGraph: graph },
+      })
+      expect(res.status, JSON.stringify(levels)).toBe(400)
+      const raw = await res.clone().text()
+      // G-18: values-free — the message carries the structural source-index location
+      // (`assigneeSources[0].levels`, a template-authored path — permitted by §2.6) and never a
+      // person id (trivially true here since none was ever supplied for a shape-rejection).
+      expect(raw).toContain('assigneeSources[0].levels')
+    }
+  })
+
+  // ── G-2 — not-yet-implemented is not inert ───────────────────────────────────────────────────
+  it('G-2: a contract-unimplemented kind (dept_head_at_level / K5-b, not landed in this slice) is rejected at authoring, never persisted', async () => {
+    const graph = headsGraph(3) as { nodes: Array<{ config: { assigneeSources?: unknown[] } }> }
+    graph.nodes[2].config.assigneeSources = [{ kind: 'dept_head_at_level', level: 1 }]
+    const key = `dh-${TS}-g2-unimplemented`
+    const res = await req(base, '/api/approval-templates', reqTok, {
+      method: 'POST',
+      body: { key, name: key, formSchema: FORM_SCHEMA, approvalGraph: graph },
+    })
+    expect(res.status).toBe(400)
+    const rows = await query(`SELECT id FROM approval_templates WHERE key = $1`, [key])
+    expect(rows.rows).toHaveLength(0)
+    // Positive control: continuous_dept_heads (this slice's implemented kind) persists — G-1 above.
+  })
+
+  // ── Core: real 3-level department-parent-tree walk, continue-past-empty over REAL SQL ────────
+  it('core: dispatch resolves EXACTLY [HEAD1, HEAD3] — DEPT_MID (empty list) contributes nothing but the walk CONTINUES to DEPT_TOP (ratified continue-past-empty-level posture)', async () => {
+    const tid = await createPublished(`dh-${TS}-core`, headsGraph(3))
+    const started = await createAsReq(tid)
+    expect(started.status, started.text).toBe(201)
+    const iid = started.iid!
+
+    const gateApprove = await req(base, `/api/approvals/${iid}/actions`, apprTok, { method: 'POST', body: { action: 'approve' } })
+    expect(gateApprove.status, await gateApprove.clone().text()).toBeLessThan(300)
+
+    const assignees = await activeAssignees(iid, 'heads')
+    expect(assignees.map((a) => a.assignee_id).sort()).toEqual([U_HEAD1, U_HEAD3].sort())
+    for (const a of assignees) {
+      const resolvedFrom = (a.metadata as { resolvedFrom?: { kind?: string } } | null)?.resolvedFrom
+      expect(resolvedFrom?.kind).toBe('continuous_dept_heads')
+    }
+
+    // Finish the instance so it does not linger PENDING for the afterAll cleanup ordering.
+    await req(base, `/api/approvals/${iid}/actions`, head1Tok, { method: 'POST', body: { action: 'approve' } })
+    await req(base, `/api/approvals/${iid}/actions`, head3Tok, { method: 'POST', body: { action: 'approve' } })
+  })
+
+  // ── G-13 — chain distinctness: the pointer, not the label ────────────────────────────────────
+  it('G-13 arm 1 (DISAGREE): in DEPT_BOT, leader_in_dept (LEADER_BOT) and dept_manager_userid_list (HEAD1) name DIFFERENT people — continuous_managers and continuous_dept_heads resolve DIFFERENT people for the SAME requester', async () => {
+    const cmTid = await createPublished(`dh-${TS}-g13-disagree-cm`, singleLevelGraph('continuous_managers'))
+    const cmRes = await createAsReq(cmTid)
+    expect(cmRes.status, cmRes.text).toBe(201)
+    const cmAssignees = await activeAssignees(cmRes.iid!, 'lvl1')
+
+    const dhTid = await createPublished(`dh-${TS}-g13-disagree-dh`, singleLevelGraph('continuous_dept_heads'))
+    const dhRes = await createAsReq(dhTid)
+    expect(dhRes.status, dhRes.text).toBe(201)
+    const dhAssignees = await activeAssignees(dhRes.iid!, 'lvl1')
+
+    expect(cmAssignees.map((a) => a.assignee_id)).toEqual([U_LEADER_BOT])
+    expect(dhAssignees.map((a) => a.assignee_id)).toEqual([U_HEAD1])
+    expect(cmAssignees.map((a) => a.assignee_id)).not.toEqual(dhAssignees.map((a) => a.assignee_id))
+  })
+
+  it('G-13 arm 2 (AGREE, positive control): in DEPT_AGREE, both pointers name the SAME person — continuous_managers and continuous_dept_heads resolve the SAME person (the test discriminates the pointer, not a blanket always-different assumption)', async () => {
+    const cmTid = await createPublished(`dh-${TS}-g13-agree-cm`, singleLevelGraph('continuous_managers'))
+    const cmRes = await createAsReq(cmTid, reqAgreeTok)
+    expect(cmRes.status, cmRes.text).toBe(201)
+    const cmAssignees = await activeAssignees(cmRes.iid!, 'lvl1')
+
+    const dhTid = await createPublished(`dh-${TS}-g13-agree-dh`, singleLevelGraph('continuous_dept_heads'))
+    const dhRes = await createAsReq(dhTid, reqAgreeTok)
+    expect(dhRes.status, dhRes.text).toBe(201)
+    const dhAssignees = await activeAssignees(dhRes.iid!, 'lvl1')
+
+    expect(cmAssignees.map((a) => a.assignee_id)).toEqual([U_AGREE])
+    expect(dhAssignees.map((a) => a.assignee_id)).toEqual([U_AGREE])
+  })
+
+  // ── Freeze purity: dispatch does not re-read the directory; the read IS per-create (temporal) ─
+  it('freeze purity: a directory mutation AFTER create does not change the in-flight (frozen) assignee, but DOES change a NEWLY created approval — temporal, not a dead read', async () => {
+    const tid = await createPublished(`dh-${TS}-freeze`, headsGraph(3))
+    const started = await createAsReq(tid)
+    expect(started.status, started.text).toBe(201)
+    const iid = started.iid!
+
+    // Mutate DEPT_BOT's manager list AFTER create: HEAD1 -> HEAD1B.
+    const accHead1b = await query<{ id: string }>(
+      `INSERT INTO directory_accounts (integration_id, external_user_id, external_key, name, raw)
+       VALUES ($1, $2, $3, 'Head1B', '{}'::jsonb) RETURNING id`,
+      [integrationId, EXT_HEAD1B, `k-head1b-${TS}`],
+    )
+    await query(
+      `INSERT INTO directory_account_links (directory_account_id, local_user_id, link_status, match_strategy)
+       VALUES ($1, $2, 'linked', 'manual')`,
+      [accHead1b.rows[0].id, U_HEAD1B],
+    )
+    try {
+      await query(
+        `UPDATE directory_departments SET raw = jsonb_set(COALESCE(raw, '{}'::jsonb), '{dept_manager_userid_list}', $2::jsonb) WHERE id = $1`,
+        [deptBotId, JSON.stringify([EXT_HEAD1B])],
+      )
+
+      // Dispatch the ALREADY-CREATED instance: the frozen snapshot must still resolve HEAD1, not
+      // HEAD1B — no live directory re-read at dispatch.
+      const gateApprove = await req(base, `/api/approvals/${iid}/actions`, apprTok, { method: 'POST', body: { action: 'approve' } })
+      expect(gateApprove.status, await gateApprove.clone().text()).toBeLessThan(300)
+      const inFlight = await activeAssignees(iid, 'heads')
+      expect(inFlight.map((a) => a.assignee_id).sort()).toEqual([U_HEAD1, U_HEAD3].sort())
+      expect(inFlight.map((a) => a.assignee_id)).not.toContain(U_HEAD1B)
+
+      // Positive control (temporal, not dead-cache): a NEW create AFTER the mutation DOES pick up
+      // HEAD1B — the scope read re-executes per create rather than being cached at module load.
+      const newTid = await createPublished(`dh-${TS}-freeze-new`, headsGraph(3))
+      const newStarted = await createAsReq(newTid)
+      expect(newStarted.status, newStarted.text).toBe(201)
+      const newGateApprove = await req(base, `/api/approvals/${newStarted.iid}/actions`, apprTok, { method: 'POST', body: { action: 'approve' } })
+      expect(newGateApprove.status, await newGateApprove.clone().text()).toBeLessThan(300)
+      const newAssignees = await activeAssignees(newStarted.iid!, 'heads')
+      expect(newAssignees.map((a) => a.assignee_id).sort()).toEqual([U_HEAD1B, U_HEAD3].sort())
+
+      // Clean up both in-flight instances so they do not linger PENDING.
+      await req(base, `/api/approvals/${iid}/actions`, head1Tok, { method: 'POST', body: { action: 'approve' } })
+      await req(base, `/api/approvals/${iid}/actions`, head3Tok, { method: 'POST', body: { action: 'approve' } })
+      await req(base, `/api/approvals/${newStarted.iid}/actions`, head1bTok, { method: 'POST', body: { action: 'approve' } })
+      await req(base, `/api/approvals/${newStarted.iid}/actions`, head3Tok, { method: 'POST', body: { action: 'approve' } })
+    } finally {
+      // Restore DEPT_BOT's manager list for any later test in this file relying on HEAD1.
+      await query(
+        `UPDATE directory_departments SET raw = jsonb_set(COALESCE(raw, '{}'::jsonb), '{dept_manager_userid_list}', $2::jsonb) WHERE id = $1`,
+        [deptBotId, JSON.stringify([EXT_HEAD1])],
+      )
+    }
+  })
+})

--- a/packages/core-backend/tests/integration/approval-routing-policy-failclose.api.test.ts
+++ b/packages/core-backend/tests/integration/approval-routing-policy-failclose.api.test.ts
@@ -23,7 +23,9 @@ import { grantApprovalWriteForIntegrationActor } from '../helpers/approval-schem
  * resolved empty; under `emptyAssigneePolicy: 'auto-approve'` the instance was AUTO-APPROVED —
  * a broken policy became a FAIL-OPEN that silently approves approvals.
  *
- * Proof, for EACH of the four org assignee sources (all with the dangerous auto-approve policy):
+ * Proof, for EACH of the org assignee sources (direct_manager / dept_head / continuous_managers /
+ * manager_at_level, plus Lock-1 §K4's continuous_dept_heads — all with the dangerous auto-approve
+ * policy):
  *   A. BROKEN POLICY (canonical target disabled) → create rejected **422
  *      APPROVAL_ROUTING_POLICY_MISCONFIGURED**, and — the load-bearing half — **ZERO
  *      approval_instances and ZERO approval_assignments** exist for the template.
@@ -76,10 +78,16 @@ async function req(base: string, path: string, token: string, opts: { method?: s
   })
 }
 
-type OrgSourceKind = 'direct_manager' | 'dept_head' | 'continuous_managers' | 'manager_at_level'
+type OrgSourceKind = 'direct_manager' | 'dept_head' | 'continuous_managers' | 'manager_at_level' | 'continuous_dept_heads'
 function graph(kind: OrgSourceKind) {
   const source =
-    kind === 'continuous_managers' ? { kind, levels: 2 } : kind === 'manager_at_level' ? { kind, level: 1 } : { kind }
+    kind === 'continuous_managers' ? { kind, levels: 2 }
+      : kind === 'manager_at_level' ? { kind, level: 1 }
+        // Lock-1 §K4: extends the detector's org-derived set alongside the four shipped kinds
+        // (runtimeGraphUsesOrgAssigneeSource, ApprovalProductService.ts) — this fixture proves the
+        // extension is load-bearing, not merely declared.
+        : kind === 'continuous_dept_heads' ? { kind, levels: 2 }
+          : { kind }
   return {
     nodes: [
       { key: 'start', type: 'start', name: 's', config: {} },
@@ -278,9 +286,9 @@ describeIfDatabase('B5-b owner P1 — routing-policy fail-close at approval crea
     expect(asg.rows[0].n).toBe(0)
   }
 
-  const KINDS: OrgSourceKind[] = ['direct_manager', 'dept_head', 'continuous_managers', 'manager_at_level']
+  const KINDS: OrgSourceKind[] = ['direct_manager', 'dept_head', 'continuous_managers', 'manager_at_level', 'continuous_dept_heads']
 
-  it('A. BROKEN policy → 422 APPROVAL_ROUTING_POLICY_MISCONFIGURED for ALL FOUR org sources, zero instances, zero assignments', async () => {
+  it('A. BROKEN policy → 422 APPROVAL_ROUTING_POLICY_MISCONFIGURED for ALL FIVE org sources (Lock-1 §K4 extends the set), zero instances, zero assignments', async () => {
     await setPolicy('default', dtIntId)
     await query(`UPDATE directory_integrations SET status = 'disabled' WHERE id = $1`, [dtIntId])
     try {
@@ -298,7 +306,7 @@ describeIfDatabase('B5-b owner P1 — routing-policy fail-close at approval crea
     }
   })
 
-  it('B. TRANSIENT org-read failure → 503 APPROVAL_REQUESTER_ORG_UNRESOLVED for all four sources, zero instances, zero assignments', async () => {
+  it('B. TRANSIENT org-read failure → 503 APPROVAL_REQUESTER_ORG_UNRESOLVED for all five sources (Lock-1 §K4 extends the set), zero instances, zero assignments', async () => {
     // healthy policy in place; arm the scoped Pool.query spy only for the create calls
     // (non-policy Error shape — not a config error). Publish stays on the healthy path.
     await setPolicy('default', localIntId)

--- a/packages/core-backend/tests/unit/approval-dept-head-chain.test.ts
+++ b/packages/core-backend/tests/unit/approval-dept-head-chain.test.ts
@@ -174,7 +174,14 @@ describe('dept-head chain walk (resolveApprovalRequesterOrgRelations + includeDe
     expect(rel.deptHeadChainIds).toEqual(['u-h1', 'u-h2'])
   })
 
-  it('excludes the requester themselves on LOCAL id — the level is consumed (walk continues) but nothing is pushed', async () => {
+  it('excludes the requester themselves via the EXTERNAL-id filter (pre-resolution) — the level is consumed (walk continues) but nothing is pushed', async () => {
+    // Correction (P2 fix round, 20260817): this test's earlier title claimed to cover the
+    // LOCAL-id guard (the `localId !== requesterLocalId` conjunct in `resolveDeptHeadChain`),
+    // but its fixture uses `e-r` — the requester's own EXTERNAL id — which is removed by the
+    // pre-resolution `.filter((external) => external !== requesterExternalId)` BEFORE the
+    // local-id check ever runs. It genuinely proves the external-id filter and the
+    // continue-past-empty posture; it does NOT exercise the local-id guard. See the next test
+    // for that.
     const hopped: string[] = []
     const query = makeDeptOrgQuery({
       ...BASE,
@@ -185,6 +192,35 @@ describe('dept-head chain walk (resolveApprovalRequesterOrgRelations + includeDe
       // NOTE: e-r is the requester's OWN external id, filtered out by the per-level exclusion
       // before resolution is even attempted (byte-identical to the single-level dept_head rule).
       localByExternalId: { 'e-h2': 'u-h2' },
+      onDeptHop: (deptId) => hopped.push(deptId),
+    })
+    const rel = await resolveApprovalRequesterOrgRelations('u-r', query, { includeDeptHeadChain: true })
+    expect(rel.deptHeadChainIds).toEqual(['u-h2'])
+    expect(hopped).toEqual(['d1', 'd2'])
+  })
+
+  it('excludes the requester\'s OWN local id when reached via a DIFFERENT (alt-account) external id — the `localId !== requesterLocalId` guard, not the external-id filter above', async () => {
+    // Reachability (multi-account org, e.g. DingTalk): the requester has TWO directory accounts
+    // linked to the SAME local user — their normal external id (`e-r`, excluded above by the
+    // filter) and an alt-account external id (`e-r-alt`) that is unrelated to `e-r` but resolves
+    // to the SAME local user. `e-r-alt` is listed FIRST in an ancestor dept's manager list, ahead
+    // of the department's real (different-person) head `e-h1`. The inner loop resolves `e-r-alt`
+    // to a local id on its first iteration and `break`s immediately — `e-h1` is never even
+    // queried — so the `localId !== requesterLocalId` self-exclusion is the ONLY thing standing
+    // between the requester's own alt-account local id and the chain. Mutating away that conjunct
+    // makes this level push `u-r` (the requester) instead of contributing nothing, and the walk
+    // still continues to d2 either way — proving the guard, not merely the continue-past-empty
+    // posture.
+    const hopped: string[] = []
+    const query = makeDeptOrgQuery({
+      ...BASE,
+      departments: {
+        d1: { managerExternalIds: ['e-r-alt', 'e-h1'], parentExternalId: 'd2' },
+        d2: { managerExternalIds: ['e-h2'], parentExternalId: null },
+      },
+      // e-r-alt is a DIFFERENT external id from the requester's own (e-r) — it survives the
+      // pre-resolution external-id filter — but resolves to the SAME local user as the requester.
+      localByExternalId: { 'e-r-alt': BASE.requesterLocalId, 'e-h1': 'u-h1', 'e-h2': 'u-h2' },
       onDeptHop: (deptId) => hopped.push(deptId),
     })
     const rel = await resolveApprovalRequesterOrgRelations('u-r', query, { includeDeptHeadChain: true })

--- a/packages/core-backend/tests/unit/approval-dept-head-chain.test.ts
+++ b/packages/core-backend/tests/unit/approval-dept-head-chain.test.ts
@@ -1,0 +1,282 @@
+import { describe, expect, it } from 'vitest'
+import { resolveApprovalRequesterOrgRelations } from '../../src/services/ApprovalDirectoryOrg'
+import { runtimeGraphUsesDeptHeadChain, runtimeGraphUsesOrgAssigneeSource } from '../../src/services/ApprovalProductService'
+import type { RuntimeGraph } from '../../src/types/approval-product'
+
+/**
+ * Lock-1 §K4 `continuous_dept_heads` — department-head chain walk unit test. Drives
+ * `resolveDeptHeadChain` through the public `resolveApprovalRequesterOrgRelations` seam
+ * (`includeDeptHeadChain`) against an in-memory org graph (no DB). The fake models the org as
+ * departments keyed by external id, each with its own `dept_manager_userid_list` and
+ * `external_parent_department_id` — a DIFFERENT pointer from the shipped
+ * `resolveManagerChain`/`leader_in_dept` walk that `approval-manager-chain.test.ts` covers.
+ *
+ * The load-bearing proof here is the RATIFIED continue-past-empty-level posture (Lock-1 §K4,
+ * confirmed BINDING by Lock-2): a level whose manager list is empty, or whose ids all resolve to
+ * no linked local user, contributes NOTHING to the chain but does NOT terminate the walk — the
+ * next hop is read from the department's OWN parent pointer, never from a resolved manager. Both
+ * causes are covered separately, each with an `onDeptHop` trace proving the level BEYOND the empty
+ * one really was queried (not just present in the expected array by coincidence).
+ */
+
+interface DeptModel {
+  managerExternalIds: string[]
+  parentExternalId: string | null
+}
+
+interface DeptOrgModel {
+  integrationId: string
+  requesterLocalId: string
+  requesterExternalId: string
+  requesterDeptExternalId: string | null
+  departments: Record<string, DeptModel>
+  localByExternalId: Record<string, string | null>
+  onDeptHop?: (deptExternalId: string) => void
+}
+
+function makeDeptOrgQuery(org: DeptOrgModel) {
+  return async <Row>(text: string, params?: unknown[]): Promise<{ rows: Row[] }> => {
+    // 0) B5-b routing-policy probe — empty rows = no policy = legacy fixture path.
+    if (text.includes('FROM directory_account_links l') && text.includes('org_directory_routing_policy')) {
+      return { rows: [] }
+    }
+    // 1) requester lookup by local user id.
+    if (text.includes('FROM directory_account_links l') && text.includes('LEFT JOIN directory_account_departments')) {
+      if (String(params?.[0]) !== org.requesterLocalId) return { rows: [] }
+      return {
+        rows: [{
+          integration_id: org.integrationId,
+          account_id: `acc-${org.requesterExternalId}`,
+          external_user_id: org.requesterExternalId,
+          raw: {},
+          primary_external_department_id: org.requesterDeptExternalId,
+          primary_department_raw: {},
+        }] as Row[],
+      }
+    }
+    // 1b) B3 normalized-manager gate — empty here, so direct-manager resolution (unrelated to
+    //     this chain) falls through to the legacy leader_in_dept scan (branch 3, also empty).
+    if (text.includes('ad.is_manager = true')) return { rows: [] }
+    // 2) K4 department-hop query — recognized by `external_parent_department_id`, a projection
+    //    ONLY this query selects (distinct from `findDeptLeaderHop`'s `primary_dept_external_id`).
+    if (text.includes('FROM directory_departments') && text.includes('external_parent_department_id')) {
+      const deptId = String(params?.[1])
+      org.onDeptHop?.(deptId)
+      const dept = org.departments[deptId]
+      if (!dept) return { rows: [] }
+      return {
+        rows: [{
+          raw: { dept_manager_userid_list: dept.managerExternalIds },
+          external_parent_department_id: dept.parentExternalId,
+        }] as Row[],
+      }
+    }
+    // 3) legacy single-hop direct-manager scan — empty (unrelated to this chain).
+    if (text.includes('JOIN directory_account_departments ad') && text.includes('d.external_department_id = $2')) {
+      return { rows: [] }
+    }
+    // 4) local user id BY ACCOUNT id — empty (unrelated to this chain; the direct-manager path).
+    if (text.includes('FROM directory_account_links') && text.includes('WHERE directory_account_id = $1::uuid')) {
+      return { rows: [{ local_user_id: null }] as Row[] }
+    }
+    // 5) local user id BY EXTERNAL id — the "primary head" resolution both the single-level
+    //    dept_head computation and resolveDeptHeadChain use.
+    if (text.includes('JOIN directory_account_links l') && text.includes('a.external_user_id = $2')) {
+      const external = String(params?.[1])
+      const localId = org.localByExternalId[external] ?? null
+      return { rows: (localId !== null ? [{ local_user_id: localId }] : []) as Row[] }
+    }
+    throw new Error(`unexpected query: ${text.slice(0, 80)}`)
+  }
+}
+
+const BASE = {
+  integrationId: 'int-1',
+  requesterLocalId: 'u-r',
+  requesterExternalId: 'e-r',
+  requesterDeptExternalId: 'd1',
+}
+
+describe('dept-head chain walk (resolveApprovalRequesterOrgRelations + includeDeptHeadChain)', () => {
+  it('walks multiple levels in order, stopping at the top of the tree (positive control: every level resolvable)', async () => {
+    const query = makeDeptOrgQuery({
+      ...BASE,
+      departments: {
+        d1: { managerExternalIds: ['e-h1'], parentExternalId: 'd2' },
+        d2: { managerExternalIds: ['e-h2'], parentExternalId: 'd3' },
+        d3: { managerExternalIds: ['e-h3'], parentExternalId: null },
+      },
+      localByExternalId: { 'e-h1': 'u-h1', 'e-h2': 'u-h2', 'e-h3': 'u-h3' },
+    })
+    const rel = await resolveApprovalRequesterOrgRelations('u-r', query, { includeDeptHeadChain: true })
+    expect(rel.deptHeadChainIds).toEqual(['u-h1', 'u-h2', 'u-h3'])
+  })
+
+  it('CONTINUES past a level whose manager list is EMPTY (ratified Lock-1 §K4 posture) — the level beyond it is proven queried, not merely present', async () => {
+    const hopped: string[] = []
+    const query = makeDeptOrgQuery({
+      ...BASE,
+      departments: {
+        d1: { managerExternalIds: ['e-h1'], parentExternalId: 'd2' },
+        d2: { managerExternalIds: [], parentExternalId: 'd3' }, // EMPTY list — contributes nothing
+        d3: { managerExternalIds: ['e-h3'], parentExternalId: null },
+      },
+      localByExternalId: { 'e-h1': 'u-h1', 'e-h3': 'u-h3' },
+      onDeptHop: (deptId) => hopped.push(deptId),
+    })
+    const rel = await resolveApprovalRequesterOrgRelations('u-r', query, { includeDeptHeadChain: true })
+    expect(rel.deptHeadChainIds).toEqual(['u-h1', 'u-h3']) // d2 contributes nothing but does not truncate
+    expect(hopped).toEqual(['d1', 'd2', 'd3']) // d3 WAS queried — the walk actually continued past d2
+  })
+
+  it('CONTINUES past a level whose manager list resolves to NO LINKED user (the other empty-level cause)', async () => {
+    const hopped: string[] = []
+    const query = makeDeptOrgQuery({
+      ...BASE,
+      departments: {
+        d1: { managerExternalIds: ['e-h1'], parentExternalId: 'd2' },
+        d2: { managerExternalIds: ['e-unlinked'], parentExternalId: 'd3' }, // present but UNLINKED
+        d3: { managerExternalIds: ['e-h3'], parentExternalId: null },
+      },
+      localByExternalId: { 'e-h1': 'u-h1', 'e-h3': 'u-h3' }, // e-unlinked deliberately absent
+      onDeptHop: (deptId) => hopped.push(deptId),
+    })
+    const rel = await resolveApprovalRequesterOrgRelations('u-r', query, { includeDeptHeadChain: true })
+    expect(rel.deptHeadChainIds).toEqual(['u-h1', 'u-h3'])
+    expect(hopped).toEqual(['d1', 'd2', 'd3'])
+  })
+
+  it('stops on a department-parent cycle (visited-set guard) without looping', async () => {
+    const query = makeDeptOrgQuery({
+      ...BASE,
+      departments: {
+        d1: { managerExternalIds: ['e-h1'], parentExternalId: 'd2' },
+        d2: { managerExternalIds: ['e-h2'], parentExternalId: 'd1' }, // points back to d1
+      },
+      localByExternalId: { 'e-h1': 'u-h1', 'e-h2': 'u-h2' },
+    })
+    const rel = await resolveApprovalRequesterOrgRelations('u-r', query, { includeDeptHeadChain: true })
+    expect(rel.deptHeadChainIds).toEqual(['u-h1', 'u-h2'])
+  })
+
+  it('caps the walk at the requested maxLevels', async () => {
+    const query = makeDeptOrgQuery({
+      ...BASE,
+      departments: {
+        d1: { managerExternalIds: ['e-h1'], parentExternalId: 'd2' },
+        d2: { managerExternalIds: ['e-h2'], parentExternalId: 'd3' },
+        d3: { managerExternalIds: ['e-h3'], parentExternalId: 'd4' },
+        d4: { managerExternalIds: ['e-h4'], parentExternalId: null },
+      },
+      localByExternalId: { 'e-h1': 'u-h1', 'e-h2': 'u-h2', 'e-h3': 'u-h3', 'e-h4': 'u-h4' },
+    })
+    const rel = await resolveApprovalRequesterOrgRelations('u-r', query, { includeDeptHeadChain: true, maxLevels: 2 })
+    expect(rel.deptHeadChainIds).toEqual(['u-h1', 'u-h2'])
+  })
+
+  it('excludes the requester themselves on LOCAL id — the level is consumed (walk continues) but nothing is pushed', async () => {
+    const hopped: string[] = []
+    const query = makeDeptOrgQuery({
+      ...BASE,
+      departments: {
+        d1: { managerExternalIds: ['e-r'], parentExternalId: 'd2' }, // requester listed as their own dept's head
+        d2: { managerExternalIds: ['e-h2'], parentExternalId: null },
+      },
+      // NOTE: e-r is the requester's OWN external id, filtered out by the per-level exclusion
+      // before resolution is even attempted (byte-identical to the single-level dept_head rule).
+      localByExternalId: { 'e-h2': 'u-h2' },
+      onDeptHop: (deptId) => hopped.push(deptId),
+    })
+    const rel = await resolveApprovalRequesterOrgRelations('u-r', query, { includeDeptHeadChain: true })
+    expect(rel.deptHeadChainIds).toEqual(['u-h2'])
+    expect(hopped).toEqual(['d1', 'd2'])
+  })
+
+  it('requester with no primary department resolves an empty chain without querying', async () => {
+    const hopped: string[] = []
+    const query = makeDeptOrgQuery({
+      ...BASE,
+      requesterDeptExternalId: null,
+      departments: {},
+      localByExternalId: {},
+      onDeptHop: (deptId) => hopped.push(deptId),
+    })
+    const rel = await resolveApprovalRequesterOrgRelations('u-r', query, { includeDeptHeadChain: true })
+    expect(rel.deptHeadChainIds).toBeUndefined()
+    expect(hopped).toEqual([])
+  })
+
+  it('does NOT walk the chain when includeDeptHeadChain is not set (gating — same opt-in posture as includeManagerChain)', async () => {
+    let hopped = false
+    const query = makeDeptOrgQuery({
+      ...BASE,
+      departments: { d1: { managerExternalIds: ['e-h1'], parentExternalId: null } },
+      localByExternalId: { 'e-h1': 'u-h1' },
+      onDeptHop: () => { hopped = true },
+    })
+    const rel = await resolveApprovalRequesterOrgRelations('u-r', query)
+    expect(rel.deptHeadChainIds).toBeUndefined()
+    expect(hopped).toBe(false)
+  })
+
+  it('is a SEPARATE opt-in from includeManagerChain — requesting only the manager chain does not walk the dept-head chain', async () => {
+    let hopped = false
+    const query = makeDeptOrgQuery({
+      ...BASE,
+      departments: { d1: { managerExternalIds: ['e-h1'], parentExternalId: null } },
+      localByExternalId: { 'e-h1': 'u-h1' },
+      onDeptHop: () => { hopped = true },
+    })
+    const rel = await resolveApprovalRequesterOrgRelations('u-r', query, { includeManagerChain: true })
+    expect(rel.deptHeadChainIds).toBeUndefined()
+    expect(hopped).toBe(false)
+  })
+})
+
+describe('runtimeGraphUsesDeptHeadChain (K4 conditional-bake scanner)', () => {
+  const graph = (sources: unknown): RuntimeGraph =>
+    ({ nodes: [{ key: 'n1', type: 'approval', config: { assigneeSources: sources } }] }) as unknown as RuntimeGraph
+
+  it('detects a continuous_dept_heads source on an approval node', () => {
+    expect(runtimeGraphUsesDeptHeadChain(graph([{ kind: 'continuous_dept_heads', levels: 3 }]))).toBe(true)
+  })
+
+  it('detects continuous_dept_heads mixed with non-chain sources', () => {
+    expect(runtimeGraphUsesDeptHeadChain(graph([{ kind: 'requester' }, { kind: 'continuous_dept_heads', levels: 1 }]))).toBe(true)
+  })
+
+  it('returns false for continuous_managers / manager_at_level — a SEPARATE gate from runtimeGraphUsesManagerChain, not a relabeling', () => {
+    expect(runtimeGraphUsesDeptHeadChain(graph([{ kind: 'continuous_managers', levels: 2 }]))).toBe(false)
+    expect(runtimeGraphUsesDeptHeadChain(graph([{ kind: 'manager_at_level', level: 1 }]))).toBe(false)
+  })
+
+  it('returns false when only other source kinds are present, and for non-approval / sourceless nodes', () => {
+    expect(runtimeGraphUsesDeptHeadChain(graph([{ kind: 'direct_manager' }, { kind: 'static_user', userIds: ['x'] }]))).toBe(false)
+    expect(runtimeGraphUsesDeptHeadChain({ nodes: [{ key: 'c', type: 'condition', config: {} }] } as unknown as RuntimeGraph)).toBe(false)
+    expect(runtimeGraphUsesDeptHeadChain({ nodes: [] } as unknown as RuntimeGraph)).toBe(false)
+  })
+})
+
+// G-20: the org-read fail-closed detector (§2.1) MUST be extended to continuous_dept_heads — this
+// is the mechanical proof the extension is load-bearing (mutate by deleting the union member from
+// ApprovalProductService.ts's runtimeGraphUsesOrgAssigneeSource and this test reds).
+describe('runtimeGraphUsesOrgAssigneeSource — K4 extension (Lock-1 §2.1, G-20 detector)', () => {
+  const graph = (sources: unknown): RuntimeGraph =>
+    ({ nodes: [{ key: 'n1', type: 'approval', config: { assigneeSources: sources } }] }) as unknown as RuntimeGraph
+
+  it('treats continuous_dept_heads as an org-derived source (extends the B5-b fail-closed guard)', () => {
+    expect(runtimeGraphUsesOrgAssigneeSource(graph([{ kind: 'continuous_dept_heads', levels: 2 }]))).toBe(true)
+  })
+
+  it('still detects the four shipped org-derived kinds (no narrowing regression)', () => {
+    expect(runtimeGraphUsesOrgAssigneeSource(graph([{ kind: 'direct_manager' }]))).toBe(true)
+    expect(runtimeGraphUsesOrgAssigneeSource(graph([{ kind: 'dept_head' }]))).toBe(true)
+    expect(runtimeGraphUsesOrgAssigneeSource(graph([{ kind: 'continuous_managers', levels: 2 }]))).toBe(true)
+    expect(runtimeGraphUsesOrgAssigneeSource(graph([{ kind: 'manager_at_level', level: 1 }]))).toBe(true)
+  })
+
+  it('does not flag a graph with no org-derived source at all (positive control — the detector is source-selected)', () => {
+    expect(runtimeGraphUsesOrgAssigneeSource(graph([{ kind: 'static_user', userIds: ['x'] }]))).toBe(false)
+    expect(runtimeGraphUsesOrgAssigneeSource(graph([{ kind: 'requester_choice', mode: 'single', scope: { type: 'company' } }]))).toBe(false)
+  })
+})

--- a/packages/core-backend/tests/unit/approval-product-service.test.ts
+++ b/packages/core-backend/tests/unit/approval-product-service.test.ts
@@ -4519,10 +4519,12 @@ describe('ApprovalProductService', () => {
     )
 
     // Scanner saw manager_at_level -> createApproval asked the resolver for the chain.
+    // Lock-1 §K4 added a SEPARATE opt-in (includeDeptHeadChain) to this SAME options object —
+    // false here since the graph carries no continuous_dept_heads source.
     expect(orgRelationsState.resolveApprovalRequesterOrgRelations).toHaveBeenCalledWith(
       'requester-1',
       expect.anything(),
-      { includeManagerChain: true },
+      { includeManagerChain: true, includeDeptHeadChain: false },
     )
 
     // And the chain is baked into the PERSISTED requester snapshot (INSERT param $5 / index 4),

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -303,6 +303,13 @@ export default defineConfig({
       // rationale as the K2 lane immediately above — plugin-tests.yml is an s6a sha256-pinned
       // provenance input, deliberately not extended). Two-point wiring, same commit.
       'tests/integration/approval-template-policy-carrier.db.test.ts',
+      // Lock-1 §K4 continuous_dept_heads real-DB acceptance (G-1/G-2/G-13, continue-past-empty,
+      // freeze purity). DATABASE_URL-gated; excluded here so the no-DB default job cannot
+      // collect-and-skip-green it, and carried by the SAME dedicated
+      // .github/workflows/approval-realdb-acceptance.yml workflow (sibling job
+      // approval-realdb-k4) — plugin-tests.yml stays byte-identical (s6a pin). Two-point wiring —
+      // both points land in the SAME commit.
+      'tests/integration/approval-dept-head-chain.db.test.ts',
       'tests/integration/approval-delegation-seam.db.test.ts',
       'tests/integration/approval-delegation-api.db.test.ts',
       'tests/integration/approval-detail-subform.db.test.ts',


### PR DESCRIPTION
## Summary

Full-stack slice of the RATIFIED Lock-1 §K4 `continuous_dept_heads` (连续多级部门负责人), following the exact pattern the just-merged K2 `requester_choice` (#4952) established.

**Semantics (per Lock-1 §K4):** resolves the chain of department heads walking UP the org tree from the requester's department, **continuing past a level whose manager is empty/unresolved** — the ratified continue-past-empty-level posture, confirmed BINDING by Lock-2. This is a DIFFERENT pointer from the shipped `continuous_managers`: that walks the `leader_in_dept` LEADER pointer; K4 walks the department PARENT tree (`directory_departments.external_parent_department_id`), reading `dept_manager_userid_list` at each level. All resolution is a pure function over the frozen create-time snapshot — no live directory reads at dispatch.

## What landed

**Backend**
- Types: `ApprovalAssigneeSourceKind` + source union member `{kind:'continuous_dept_heads'; levels:number}`; requester snapshot gains the frozen opt-in `deptHeadChainIds` field.
- `ApprovalDirectoryOrg.resolveDeptHeadChain` — new walk, gated by a separate `includeDeptHeadChain` option (mirrors `includeManagerChain`'s opt-in posture, so unrelated approvals pay nothing).
- `normalizeApprovalAssigneeSources`: `levels` validated byte-identically to `continuous_managers` (`[1, MAX_MANAGER_CHAIN_LEVELS]`).
- Create path: new `runtimeGraphUsesDeptHeadChain` detector; `runtimeGraphUsesOrgAssigneeSource` **extended** to include `continuous_dept_heads` (Lock-1 §2.1 mandatory extension — closes the same B5-b fail-open class an org-read failure now fails create 422/503 before any insert, even under `emptyAssigneePolicy:'auto-approve'`, instead of silently auto-approving).
- Resolver: pure arm slicing the frozen `deptHeadChainIds`, mirroring `continuous_managers` exactly.
- Fingerprint: `continuous_dept_heads:<levels>` on both mirrors (backend + `parallelEdit.ts`), lockstep-enforced by the existing `_exhaustive: never` guard on both sides.

**Frontend** — the five §2.5 mirror sites (backend type union; FE type union `apps/web/src/types/approval.ts`; `BACKEND_ASSIGNEE_SOURCE_KEYS_BY_KIND`; linear editor's accepted-kind list; `assigneeSourceSummary`) + capability registry row (exact-set spec grows 9→10) + `ApprovalGraphNodeConfigEditor.vue` sub-form (reuses the shared level-count input, same shape as `continuous_managers`/`manager_at_level`) + the linear step editor (`TemplateAuthoringView.vue`, reusing `step.levels` — no new draft field needed).

## Tests

- **Real-DB** `approval-dept-head-chain.db.test.ts`: G-1 (levels validation), G-2 (not-yet-implemented kind rejected), G-13 chain distinctness **both arms** (disagree in `DEPT_BOT` where `leader_in_dept` and `dept_manager_userid_list` name different people; agree in `DEPT_AGREE` where they coincide — proving the test discriminates the pointer, not the label), continue-past-empty-level proven over **real SQL** against a 3-level department-parent tree, and a freeze-purity/temporal mutation arm (a directory mutation after create does not change the in-flight assignment but DOES change a newly-created one).
- G-20 (org-read fail-closed) is satisfied by **extending** the existing parametrized `approval-routing-policy-failclose.api.test.ts` fixture (its `KINDS` array now includes `continuous_dept_heads`) rather than duplicating it — proves both the 422 (misconfigured policy) and 503 (transient failure) legs, zero rows, for all five org-derived kinds now.
- **Unit** `approval-dept-head-chain.test.ts`: `resolveDeptHeadChain` against an in-memory org fake, proving continue-past-empty for **both** causes (empty manager list; manager list resolving to no linked user) with `onDeptHop` traces proving the level beyond the empty one really was queried. Mutation-verified: reverting the continue-past-empty logic reds exactly the three tests that assert it (and the matching real-DB tests); deleting `continuous_dept_heads` from `runtimeGraphUsesOrgAssigneeSource` reds exactly its own test. All mutation probes used cp-backup + sha256 byte-identical restore.
- **Fix round (P2-1, gate MD `/tmp/K4-gate-20260817.md`)**: the unit arm titled "excludes the requester themselves on LOCAL id" was renamed to name the external-id filter it actually exercises (its `['e-r']` fixture is removed by the pre-resolution `external !== requesterExternalId` filter before the local-id conjunct runs), and a new arm was added using an alt-account external id that survives that filter but resolves to the requester's own local id. Mutation-verified: deleting `localId !== requesterLocalId` reds exactly the new arm (`['u-r','u-h2']` vs `['u-h2']`) and none of the other 16; restored cp-backup + sha256 byte-identical.
- **FE**: extended (not new) existing spec files — no CI-token wiring required. Exact-set registry mutation-verified: dropping the kind's label from `APPROVAL_ASSIGNEE_SOURCE_LABELS` reds the D1 exact-object-equality test (and fails the TypeScript exhaustive `Record` at compile time). (Correction: an earlier revision of this line claimed the label-drop reds three registry tests — it reds exactly D1; the A-3 roster and K4 sub-form mount are covered by their own mutations, not the label drop. Contract remains enforced by TS exhaustiveness + D1.)
- **Two-point wiring**: `vitest.config.ts` excludes the new `.db.test.ts` from the no-DB default job; `.github/workflows/approval-realdb-acceptance.yml` gains a sibling `approval-realdb-k4` job (`plugin-tests.yml` stays byte-identical — s6a sha256-pinned provenance input) and both `paths:` blocks gain the new test file plus `ApprovalDirectoryOrg.ts` (also missing from K2's own filter — added here too).

**Verification**: backend `tsc --noEmit` clean; `vue-tsc -b` clean (Node 20); full `apps/web/scripts/run-required-web-tests.sh` green (365 files / 4493 tests, Node 20); full backend `vitest run` green modulo pre-existing, unrelated nested-worktree `REPO_ROOT_AMBIGUOUS` collection failures (confirmed pre-existing by reproducing on the already-merged K2 file under the same environment) and one unrelated flaky rate-limit timing test.

## Deferred (per Lock-1, not this slice)

- **OD-L1-5(a)**: the "stop when a resolved person belongs to a nominated user group" endpoint termination is explicitly staged to a K1-dependent follow-up (K1 `user_group` doesn't exist yet) — level-count-only ships here, per the ratified recommendation.
- **K5-b `dept_head_at_level`**: intentionally NOT added to the union/registry/detector in this PR. Lock-1 §2.3 admits its registry row only once K4 has landed; §2.1's "extend to K4 and K5-b" is read as K4-only for this slice, K5-b is a separate follow-up.

Master lock invariants M1–M11 respected (M4 fail-closed registry, M7 no inert UI controls, M8 honesty, M11 values-free evidence language). No flag change, no migration, no deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
