### PR TITLE
feat(approval): P1-A0 — basic-info step-nav issue count from typed issues

### DIFF
--- a/apps/web/src/approvals/templateAuthoring.ts
+++ b/apps/web/src/approvals/templateAuthoring.ts
@@ -1259,13 +1259,22 @@ export type RecordLinkCatalogValidationContext = {
 // P1-A0 (master §4 UI-0 "live validation count"; Lock-0 L0-3 typed-issue-record delta) — typed
 // issue shape for the authoring validators. `target` reuses L0-3's exact `{ kind, key }` contract
 // (`approval-lock0-d0-interaction-delta-20260817.md` L0-3) so a later slice adopting the header
-// count can consume this same record instead of migrating a second shape; `severity` is a
-// SUPERSET addition L0-3 does not define (kept because every basic-info check below is currently
-// a hard "must fix" — see `validateTemplateBasicInfo`). This is the typed sibling of the existing
-// `string[]` validators, not a replacement: `validationErrors` (the save-blocking surface) and
-// `publishChecklist` (the publish pre-flight, `TemplateAuthoringView.vue`) both keep consuming the
-// plain-string validators below UNCHANGED. Only the NEW basic-info step-nav issue badge derives
-// its count from this typed shape (`AuthoringValidationIssue[].length`, never hand-counted).
+// count can consume this same record instead of migrating a second shape.
+//
+// `severity` is a SUPERSET field L0-3 does not define. Every basic-info check today is a hard
+// "must fix", so `severity` is currently ALWAYS `'error'` — it is declared for the future header
+// count (which may eventually need to distinguish a soft warning) but has exactly one live value
+// right now; do not read its presence as evidence a warning tier already exists.
+//
+// This is a typed SIBLING of the existing `string[]` validators, not a replacement — but not fully
+// independent of them either: `validateTemplateFormFields` below now COMPOSES
+// `validateTemplateBasicInfo`'s `.message`s for its first five entries (previously inlined). Both
+// `validationErrors` (the save-blocking surface) and `publishChecklist` (the publish pre-flight,
+// `TemplateAuthoringView.vue`) therefore transitively call through this new function, but their
+// composition, values, and rendered strings are byte-identical to before this extraction (pinned
+// by the regression tests below) — "sibling, not replacement" describes the OUTPUT contract, not
+// the call graph. Only the NEW basic-info step-nav issue badge derives its displayed count from
+// the typed shape directly (`AuthoringValidationIssue[].length`, never hand-counted).
 export type AuthoringValidationSeverity = 'error' | 'warning'
 
 export interface AuthoringValidationIssueTarget {

--- a/apps/web/src/approvals/templateAuthoring.ts
+++ b/apps/web/src/approvals/templateAuthoring.ts
@@ -1256,21 +1256,102 @@ export type RecordLinkCatalogValidationContext = {
   sheets: ReadonlyArray<{ id: string; baseId?: string | null }>
 }
 
+// P1-A0 (master §4 UI-0 "live validation count"; Lock-0 L0-3 typed-issue-record delta) — typed
+// issue shape for the authoring validators. `target` reuses L0-3's exact `{ kind, key }` contract
+// (`approval-lock0-d0-interaction-delta-20260817.md` L0-3) so a later slice adopting the header
+// count can consume this same record instead of migrating a second shape; `severity` is a
+// SUPERSET addition L0-3 does not define (kept because every basic-info check below is currently
+// a hard "must fix" — see `validateTemplateBasicInfo`). This is the typed sibling of the existing
+// `string[]` validators, not a replacement: `validationErrors` (the save-blocking surface) and
+// `publishChecklist` (the publish pre-flight, `TemplateAuthoringView.vue`) both keep consuming the
+// plain-string validators below UNCHANGED. Only the NEW basic-info step-nav issue badge derives
+// its count from this typed shape (`AuthoringValidationIssue[].length`, never hand-counted).
+export type AuthoringValidationSeverity = 'error' | 'warning'
+
+export interface AuthoringValidationIssueTarget {
+  kind: 'node' | 'field' | 'section'
+  key: string
+}
+
+export interface AuthoringValidationIssue {
+  /** Stable rule identifier (was informally "field" — renamed to avoid colliding with the
+   * `target.kind === 'field'` case, since a basic-info issue like `visibility` targets the whole
+   * 基础信息 section, not a `FieldAuthoringDraft`). */
+  code: string
+  message: string
+  severity: AuthoringValidationSeverity
+  target?: AuthoringValidationIssueTarget
+}
+
+/**
+ * Typed basic-info issues — the SAME five checks `validateTemplateFormFields` has always run
+ * first (`unsupportedReason` / key / name / visibility scope / SLA hours), extracted verbatim so
+ * the 基础信息 step-nav badge can derive its count from a typed array instead of a hand-maintained
+ * counter. `validateTemplateFormFields` below calls this and flattens `.message` into its existing
+ * `string[]`, in the SAME order, so the combined validation set, order, and exact copy are
+ * unchanged from before this extraction — this function adds a typed VIEW onto existing rules, it
+ * does not add, remove, or reword any of them.
+ *
+ * `unsupportedReason` (an attachment-field/unknown-node structural block, not something an author
+ * fixes by editing 基础信息 text) is included deliberately: `firstInvalidAuthoringSection` already
+ * routes a validate() failure carrying it to the `'basic'` step (this file, `hasBasicSettingsError`
+ * in `TemplateAuthoringView.vue`), so counting it here mirrors an existing attribution rather than
+ * inventing a new one — it does not introduce a second, disagreeing classification.
+ */
+export function validateTemplateBasicInfo(
+  draft: TemplateAuthoringDraft,
+  unsupportedReason?: string | null,
+): AuthoringValidationIssue[] {
+  const issues: AuthoringValidationIssue[] = []
+  if (unsupportedReason) {
+    issues.push({
+      code: 'unsupported',
+      message: unsupportedReason,
+      severity: 'error',
+      target: { kind: 'section', key: 'basic' },
+    })
+  }
+  if (!draft.key.trim()) {
+    issues.push({
+      code: 'key',
+      message: '模板 Key 必填',
+      severity: 'error',
+      target: { kind: 'field', key: 'key' },
+    })
+  }
+  if (!draft.name.trim()) {
+    issues.push({
+      code: 'name',
+      message: '模板名称必填',
+      severity: 'error',
+      target: { kind: 'field', key: 'name' },
+    })
+  }
+  if (draft.visibilityType !== 'all' && parseIdsText(draft.visibilityIdsText).length === 0) {
+    issues.push({
+      code: 'visibility',
+      message: '非全员可见范围至少需要一个 id',
+      severity: 'error',
+      target: { kind: 'field', key: 'visibilityIdsText' },
+    })
+  }
+  if (Number.isNaN(buildSlaHours(draft))) {
+    issues.push({
+      code: 'slaHours',
+      message: 'SLA 必须是正整数小时或留空',
+      severity: 'error',
+      target: { kind: 'field', key: 'slaHoursText' },
+    })
+  }
+  return issues
+}
+
 export function validateTemplateFormFields(
   draft: TemplateAuthoringDraft,
   unsupportedReason?: string | null,
   recordLinkCatalog?: RecordLinkCatalogValidationContext | null,
 ): string[] {
-  const errors: string[] = []
-  if (unsupportedReason) errors.push(unsupportedReason)
-  if (!draft.key.trim()) errors.push('模板 Key 必填')
-  if (!draft.name.trim()) errors.push('模板名称必填')
-  if (draft.visibilityType !== 'all' && parseIdsText(draft.visibilityIdsText).length === 0) {
-    errors.push('非全员可见范围至少需要一个 id')
-  }
-  if (Number.isNaN(buildSlaHours(draft))) {
-    errors.push('SLA 必须是正整数小时或留空')
-  }
+  const errors: string[] = validateTemplateBasicInfo(draft, unsupportedReason).map((issue) => issue.message)
   const fields = draft.fields.map((field) => field.id.trim()).filter(Boolean)
   if (fields.length !== draft.fields.length) errors.push('字段 id 必填')
   if (new Set(fields).size !== fields.length) errors.push('字段 id 不能重复')

--- a/apps/web/src/views/approval/TemplateAuthoringView.vue
+++ b/apps/web/src/views/approval/TemplateAuthoringView.vue
@@ -119,13 +119,24 @@
             :class="{ 'is-active': activeAuthoringSection === section.id }"
             text
             :aria-current="activeAuthoringSection === section.id ? 'step' : undefined"
-            :aria-label="`${index + 1} ${section.label} ${section.description}`"
+            :aria-label="`${index + 1} ${section.label} ${section.description}${section.id === 'basic' && basicInfoIssueCount > 0 ? `，${basicInfoIssueCount} 项不完善` : ''}`"
             :data-testid="`approval-template-section-${section.id}`"
             @click="selectAuthoringSection(section.id)"
           >
             <span class="template-authoring__step-index">{{ index + 1 }}</span>
             <span class="template-authoring__step-copy">
               <strong>{{ section.label }}</strong>
+            </span>
+            <!-- P1-A0: typed-issue-derived count, basic-info step only (see `basicInfoIssueCount`
+                 above — NOT the parent-lock header count, which stays undelivered debt).
+                 Reuses the pre-existing `.template-authoring__step-count` pill style, which had
+                 no template usage before this slice. -->
+            <span
+              v-if="section.id === 'basic' && basicInfoIssueCount > 0"
+              class="template-authoring__step-count"
+              data-testid="approval-template-section-basic-issue-count"
+            >
+              {{ basicInfoIssueCount }} 项不完善
             </span>
           </el-button>
         </nav>
@@ -184,10 +195,20 @@
             <el-input v-model="draft.name" :disabled="readOnly" data-testid="approval-template-name" />
           </el-form-item>
           <el-form-item label="分类">
-            <el-input v-model="draft.category" :disabled="readOnly" placeholder="如 请假 / 采购 / 报销" />
+            <el-input
+              v-model="draft.category"
+              :disabled="readOnly"
+              placeholder="如 请假 / 采购 / 报销"
+              data-testid="approval-template-category"
+            />
           </el-form-item>
           <el-form-item label="SLA 小时">
-            <el-input v-model="draft.slaHoursText" :disabled="readOnly" placeholder="留空表示不启用" />
+            <el-input
+              v-model="draft.slaHoursText"
+              :disabled="readOnly"
+              placeholder="留空表示不启用"
+              data-testid="approval-template-sla-hours"
+            />
           </el-form-item>
           <el-form-item label="描述" class="template-authoring__wide">
             <el-input
@@ -195,11 +216,17 @@
               :disabled="readOnly"
               type="textarea"
               :rows="3"
+              data-testid="approval-template-description"
             />
           </el-form-item>
           <el-form-item label="可见范围">
             <div class="template-authoring__inline">
-              <el-select v-model="draft.visibilityType" :disabled="readOnly" class="ms-w-140">
+              <el-select
+                v-model="draft.visibilityType"
+                :disabled="readOnly"
+                class="ms-w-140"
+                data-testid="approval-template-visibility-type"
+              >
                 <el-option label="全员" value="all" />
                 <el-option label="部门" value="dept" />
                 <el-option label="角色" value="role" />
@@ -209,11 +236,16 @@
                 v-model="draft.visibilityIdsText"
                 :disabled="readOnly || draft.visibilityType === 'all'"
                 placeholder="逗号分隔，按所选范围填写"
+                data-testid="approval-template-visibility-ids"
               />
             </div>
           </el-form-item>
           <el-form-item label="发布策略">
-            <el-checkbox v-model="draft.allowRevoke" :disabled="readOnly">
+            <el-checkbox
+              v-model="draft.allowRevoke"
+              :disabled="readOnly"
+              data-testid="approval-template-allow-revoke"
+            >
               允许发起人撤回
             </el-checkbox>
           </el-form-item>
@@ -1111,6 +1143,8 @@ import {
   unsupportedTemplateAuthoringReason,
   validateTemplateFormFields,
   validateTemplateApprovalFlow,
+  validateTemplateBasicInfo,
+  type AuthoringValidationIssue,
   placeholderRoleNodeKeys,
   approvalFormulaInsertOptions,
   parallelDynamicAssigneeConflicts,
@@ -1373,6 +1407,16 @@ const authoringFlowNodeCount = computed(() => (
 const authoringSectionIndex = computed(() => (
   authoringSections.findIndex(section => section.id === activeAuthoringSection.value)
 ))
+
+// P1-A0 (master §4 UI-0 "live validation count"; Lock-0 L0-3 typed-issue-record delta, scoped to
+// the 基础信息 step only — the parent-lock header count over the FULL publishChecklist stays
+// undelivered L0-5-adjacent debt, tracked separately, and is NOT what this badge claims to be).
+// Typed source of truth; the step-nav badge below reads `.length` off this array — it never
+// hand-counts or hardcodes a number.
+const basicInfoIssues = computed<AuthoringValidationIssue[]>(() => (
+  validateTemplateBasicInfo(draft.value, unsupportedReason.value)
+))
+const basicInfoIssueCount = computed<number>(() => basicInfoIssues.value.length)
 
 function scrollAuthoringTarget(target: HTMLElement | null, focus = false) {
   if (!target) return

--- a/apps/web/tests/approvalTemplateAuthoring.spec.ts
+++ b/apps/web/tests/approvalTemplateAuthoring.spec.ts
@@ -13,6 +13,8 @@ import {
   graphReadOnlyReason,
   unsupportedTemplateAuthoringReason,
   validateTemplateDraft,
+  validateTemplateFormFields,
+  validateTemplateBasicInfo,
 } from '../src/approvals/templateAuthoring'
 
 const pushSpy = vi.fn().mockResolvedValue(undefined)
@@ -321,6 +323,98 @@ function setInput(testId: string, value: string) {
   input.dispatchEvent(new Event('input'))
 }
 
+// P1-A0 — typed basic-info issue model (master §4 UI-0; Lock-0 L0-3 typed-issue-record delta,
+// basic-info-step scope only). `validateTemplateBasicInfo` is a NEW typed extraction of the SAME
+// five checks `validateTemplateFormFields` has always run first; these pin (a) the typed shape and
+// derivable count, and (b) that the extraction did not change the combined string-validator output
+// — order, text, and set all byte-identical to before this slice.
+describe('validateTemplateBasicInfo (P1-A0 typed issue model)', () => {
+  it('positive control: a fully valid basic-info draft yields zero typed issues', () => {
+    const draft = createEmptyTemplateDraft()
+    draft.key = 'travel'
+    draft.name = '出差审批'
+
+    const issues = validateTemplateBasicInfo(draft, null)
+
+    expect(issues).toEqual([])
+  })
+
+  it('returns one typed {code, message, severity, target} issue per missing required field, in the SAME order as the string validator', () => {
+    const draft = createEmptyTemplateDraft()
+    // key/name left blank on purpose; visibilityType defaults to 'all' (no id requirement);
+    // slaHoursText defaults to '' (unset, not invalid) — only key/name should fire here.
+
+    const issues = validateTemplateBasicInfo(draft, null)
+
+    expect(issues).toEqual([
+      { code: 'key', message: '模板 Key 必填', severity: 'error', target: { kind: 'field', key: 'key' } },
+      { code: 'name', message: '模板名称必填', severity: 'error', target: { kind: 'field', key: 'name' } },
+    ])
+  })
+
+  it('every basic-info issue is severity "error" (no invented "warning" issue widens the validated set)', () => {
+    const draft = createEmptyTemplateDraft()
+    draft.slaHoursText = 'abc'
+
+    const issues = validateTemplateBasicInfo(draft, 'unsupported-x')
+
+    expect(issues.length).toBeGreaterThan(0)
+    expect(issues.every((issue) => issue.severity === 'error')).toBe(true)
+  })
+
+  it('attributes unsupportedReason to the basic-info section (mirrors the existing firstInvalidAuthoringSection routing, not a new classification)', () => {
+    const draft = createEmptyTemplateDraft()
+    draft.key = 'travel'
+    draft.name = '出差审批'
+
+    const issues = validateTemplateBasicInfo(draft, '该模板包含当前 MVP 不支持编辑的结构')
+
+    expect(issues).toEqual([{
+      code: 'unsupported',
+      message: '该模板包含当前 MVP 不支持编辑的结构',
+      severity: 'error',
+      target: { kind: 'section', key: 'basic' },
+    }])
+  })
+
+  it('typed issue count derivation: N basic-info problems → N-length array, for 0/1/several — never a hand-maintained number', () => {
+    const zero = createEmptyTemplateDraft()
+    zero.key = 'travel'
+    zero.name = '出差审批'
+    expect(validateTemplateBasicInfo(zero, null)).toHaveLength(0)
+
+    const one = createEmptyTemplateDraft()
+    one.key = 'travel'
+    one.name = '出差审批'
+    one.slaHoursText = 'abc'
+    expect(validateTemplateBasicInfo(one, null)).toHaveLength(1)
+
+    const several = createEmptyTemplateDraft()
+    several.slaHoursText = 'abc'
+    several.visibilityType = 'dept'
+    // key/name left blank + bad SLA + unresolved visibility scope = 4 issues.
+    expect(validateTemplateBasicInfo(several, null)).toHaveLength(4)
+  })
+
+  it('does NOT change the combined string-validator output: same messages, same order, for a multi-failure draft (regression pin for the extraction)', () => {
+    const draft = createEmptyTemplateDraft()
+    draft.visibilityType = 'dept'
+    draft.slaHoursText = 'abc'
+    // key/name left blank.
+    draft.fields = [] // avoid unrelated form-field errors interleaving with the basic-info block
+
+    const errors = validateTemplateFormFields(draft, '结构不受支持', null)
+
+    expect(errors).toEqual([
+      '结构不受支持',
+      '模板 Key 必填',
+      '模板名称必填',
+      '非全员可见范围至少需要一个 id',
+      'SLA 必须是正整数小时或留空',
+    ])
+  })
+})
+
 describe('approval template authoring helpers', () => {
   it('preserves visibilityRule metadata while rebuilding supported fields', () => {
     const template = buildTemplate()
@@ -527,6 +621,51 @@ describe('approval template authoring helpers', () => {
     expect((payload.approvalGraph.nodes[1]?.config as any).assigneeSources).toEqual([
       { kind: 'form_field_user', fieldId: 'reviewer' },
     ])
+  })
+
+  // P1-A0 publish-payload-shape pin — basic-info fields never travel through `publishTemplate`
+  // (which sends only `{ policy }`, see `approval-template-authoring-policy-carrier.test.ts`); they
+  // serialize through `buildCreateTemplatePayload`/`buildUpdateTemplatePayload` (identical function,
+  // `templateAuthoring.ts`) at save time. This slice touches no basic-info persistence code — this
+  // pin exists to prove that stays true. A mutation renaming/dropping/reshaping a basic-info payload
+  // key reds either assertion below.
+  it('P1-A0: pins the exact basic-info shape of the create/update payload (no key renamed, dropped, or reshaped)', () => {
+    const draft = createEmptyTemplateDraft()
+    draft.key = 'travel'
+    draft.name = '出差审批'
+    draft.category = '差旅'
+    draft.description = '跨部门出差需要审批'
+    draft.slaHoursText = '24'
+    draft.visibilityType = 'dept'
+    draft.visibilityIdsText = 'dept_a, dept_b'
+
+    const payload = buildCreateTemplatePayload(draft)
+
+    expect(Object.keys(payload).sort()).toEqual([
+      'approvalGraph',
+      'category',
+      'description',
+      'formSchema',
+      'key',
+      'name',
+      'slaHours',
+      'visibilityScope',
+    ])
+    expect({
+      key: payload.key,
+      name: payload.name,
+      category: payload.category,
+      description: payload.description,
+      slaHours: payload.slaHours,
+      visibilityScope: payload.visibilityScope,
+    }).toEqual({
+      key: 'travel',
+      name: '出差审批',
+      category: '差旅',
+      description: '跨部门出差需要审批',
+      slaHours: 24,
+      visibilityScope: { type: 'dept', ids: ['dept_a', 'dept_b'] },
+    })
   })
 
   it('round-trips a direct_manager assignee source (save emits {kind} + hydrate restores sourceKind)', () => {
@@ -852,6 +991,66 @@ describe('TemplateAuthoringView', () => {
     expect(payload.name).toBe('出差审批')
     expect(payload.approvalGraph.nodes.map((node: any) => node.key)).toEqual(['start', 'approval_1', 'end'])
     expect(replaceSpy).toHaveBeenCalledWith({ path: '/approval-templates/tpl_created/edit' })
+  })
+
+  // P1-A0 typed-control test — each basic-info control commits its typed value onto the draft and
+  // survives to the save payload. `key`/`name` are already covered by the test above; this covers
+  // the remaining controls (category/SLA/description/visibility type+ids), which previously had no
+  // stable `data-testid` to target. Positive control: every field's value round-trips unaltered.
+  it('P1-A0: every basic-info control commits its typed value through to the save payload (positive control)', async () => {
+    await mountView()
+
+    setInput('approval-template-key', 'travel')
+    setInput('approval-template-name', '出差审批')
+    setInput('approval-template-category', '差旅')
+    setInput('approval-template-sla-hours', '24')
+    setInput('approval-template-description', '跨部门出差需要审批')
+    const visibilityType = container!.querySelector('[data-testid="approval-template-visibility-type"]') as HTMLSelectElement
+    visibilityType.value = 'dept'
+    visibilityType.dispatchEvent(new Event('change'))
+    await flushUi()
+    setInput('approval-template-visibility-ids', 'dept_a, dept_b')
+
+    ;(container!.querySelector('[data-testid="approval-template-save-button"]') as HTMLButtonElement).click()
+    await flushUi()
+
+    expect(createTemplateSpy).toHaveBeenCalledTimes(1)
+    const payload = createTemplateSpy.mock.calls[0]?.[0] as any
+    expect(payload.key).toBe('travel')
+    expect(payload.name).toBe('出差审批')
+    expect(payload.category).toBe('差旅')
+    expect(payload.slaHours).toBe(24)
+    expect(payload.description).toBe('跨部门出差需要审批')
+    expect(payload.visibilityScope).toEqual({ type: 'dept', ids: ['dept_a', 'dept_b'] })
+  })
+
+  // P1-A0 validation-count derivation — the 基础信息 step-nav badge reads `.length` off
+  // `validateTemplateBasicInfo(draft, unsupportedReason)` (`TemplateAuthoringView.vue`
+  // `basicInfoIssueCount`). This exercises the LIVE component derivation (not the pure helper in
+  // isolation — a helper-only test would pass even if the view's binding were broken/hardcoded), at
+  // three states: 2 known issues, 0 issues, 1 different known issue. A mutation that hardcodes the
+  // badge number or drops `.length` fails at least one of these three assertions.
+  it('P1-A0: the 基础信息 step-nav issue count is DERIVED from typed issues, not hand-counted', async () => {
+    await mountView()
+
+    // State 1: brand-new draft — key + name both empty → exactly 2 typed issues.
+    let badge = container!.querySelector('[data-testid="approval-template-section-basic-issue-count"]')
+    expect(badge?.textContent?.trim()).toBe('2 项不完善')
+
+    // State 2: fill both required fields → count derives to 0, badge disappears entirely (not "0
+    // 项不完善" theater — matches the D0/M7 "no inert/empty control" grammar for a zero state).
+    setInput('approval-template-key', 'travel')
+    setInput('approval-template-name', '出差审批')
+    await flushUi()
+    badge = container!.querySelector('[data-testid="approval-template-section-basic-issue-count"]')
+    expect(badge).toBeNull()
+
+    // State 3: introduce exactly ONE different issue (bad SLA text) → count derives to 1, proving
+    // the badge tracks the CURRENT typed array rather than being stuck at its first-seen value.
+    setInput('approval-template-sla-hours', 'abc')
+    await flushUi()
+    badge = container!.querySelector('[data-testid="approval-template-section-basic-issue-count"]')
+    expect(badge?.textContent?.trim()).toBe('1 项不完善')
   })
 
   it('creates a common purchase template as a draft without publishing', async () => {

--- a/apps/web/tests/approvalTemplateAuthoring.spec.ts
+++ b/apps/web/tests/approvalTemplateAuthoring.spec.ts
@@ -352,7 +352,13 @@ describe('validateTemplateBasicInfo (P1-A0 typed issue model)', () => {
     ])
   })
 
-  it('every basic-info issue is severity "error" (no invented "warning" issue widens the validated set)', () => {
+  // Documentation pin, not a discriminating mutation guard: `severity` is a declared-but-currently-
+  // single-valued field (see the `AuthoringValidationSeverity` doc comment in templateAuthoring.ts)
+  // — every existing basic-info rule is a hard "must fix", so this can only ever observe 'error'
+  // today. It exists so a future PR that adds a real 'warning' rule updates this assertion
+  // deliberately instead of silently drifting past it; it does NOT prove a severity taxonomy is
+  // exercised yet, and a hardcoded `severity: 'error'` in the implementation would still pass it.
+  it('every basic-info issue is severity "error" today (declared-but-single-valued field; see comment)', () => {
     const draft = createEmptyTemplateDraft()
     draft.slaHoursText = 'abc'
 
@@ -411,6 +417,22 @@ describe('validateTemplateBasicInfo (P1-A0 typed issue model)', () => {
       '模板名称必填',
       '非全员可见范围至少需要一个 id',
       'SLA 必须是正整数小时或留空',
+    ])
+  })
+
+  it('does NOT change the combined string-validator output when a REAL field error interleaves with basic-info issues (the extraction boundary the fields=[] fixture above cannot exercise)', () => {
+    const draft = createEmptyTemplateDraft()
+    draft.name = '出差审批' // key still blank; name filled — asserts partial basic-info failure too
+    draft.fields[0].label = '' // triggers a genuine per-field error from the untouched downstream loop
+
+    const errors = validateTemplateFormFields(draft, null, null)
+
+    // Basic-info issues (from validateTemplateBasicInfo) must still precede the field-loop error,
+    // in the same relative order as before this extraction — this is the boundary a reordering bug
+    // in the split would live at, which the all-blank/fields=[] fixture above cannot see.
+    expect(errors).toEqual([
+      '模板 Key 必填',
+      '第 1 个字段的名称必填',
     ])
   })
 })
@@ -628,7 +650,10 @@ describe('approval template authoring helpers', () => {
   // serialize through `buildCreateTemplatePayload`/`buildUpdateTemplatePayload` (identical function,
   // `templateAuthoring.ts`) at save time. This slice touches no basic-info persistence code — this
   // pin exists to prove that stays true. A mutation renaming/dropping/reshaping a basic-info payload
-  // key reds either assertion below.
+  // key reds either assertion below. NOTE for future authors: the `Object.keys(...).sort()`
+  // assertion is a full shape pin, so it also reds on a legitimate ADDITIVE key from an unrelated
+  // later slice (e.g. a new top-level payload field) — that is expected; update the expected key
+  // list rather than assume this test caught a regression.
   it('P1-A0: pins the exact basic-info shape of the create/update payload (no key renamed, dropped, or reshaped)', () => {
     const draft = createEmptyTemplateDraft()
     draft.key = 'travel'
@@ -1036,6 +1061,10 @@ describe('TemplateAuthoringView', () => {
     // State 1: brand-new draft — key + name both empty → exactly 2 typed issues.
     let badge = container!.querySelector('[data-testid="approval-template-section-basic-issue-count"]')
     expect(badge?.textContent?.trim()).toBe('2 项不完善')
+    // The count also folds into the step button's aria-label (it OVERRIDES inner text for
+    // assistive tech, so a visual-only badge would be silently unannounced — see P1-A0 view diff).
+    const basicStepButton = container!.querySelector('[data-testid="approval-template-section-basic"]')
+    expect(basicStepButton?.getAttribute('aria-label')).toContain('2 项不完善')
 
     // State 2: fill both required fields → count derives to 0, badge disappears entirely (not "0
     // 项不完善" theater — matches the D0/M7 "no inert/empty control" grammar for a zero state).
@@ -1044,6 +1073,7 @@ describe('TemplateAuthoringView', () => {
     await flushUi()
     badge = container!.querySelector('[data-testid="approval-template-section-basic-issue-count"]')
     expect(badge).toBeNull()
+    expect(basicStepButton?.getAttribute('aria-label')).not.toContain('项不完善')
 
     // State 3: introduce exactly ONE different issue (bad SLA text) → count derives to 1, proving
     // the badge tracks the CURRENT typed array rather than being stuck at its first-seen value.


### PR DESCRIPTION
## Summary

P1-A0 slice per `docs/development/approval-parity-master-design-lock-20260817.md` §4 P1-A / §4 UI-0, and `docs/development/approval-lock0-d0-interaction-delta-20260817.md` L0-3 (typed-issue-record delta), scoped to the 基础信息 (basic-info) first wizard step + validation-count only.

**Scope note — basic-info controls were already typed.** `TemplateAuthoringDraft` (`templateAuthoring.ts`) is a fully-typed interface (`key: string`, `visibilityType: ApprovalTemplateVisibilityScope['type']`, `allowRevoke: boolean`, …) and every basic-info control in `TemplateAuthoringView.vue` binds directly via `v-model` onto it — no `any`, no ad-hoc/untyped change handlers. Per the task contract's own fallback ("if already typed, narrow scope"), this PR does **not** re-architect those bindings. It does add `data-testid`s to 6 of the 8 basic-info controls (category/SLA/description/visibility-type/visibility-ids/allow-revoke) that had none before — needed to write reliable typed-control tests, and a legitimate in-scope gap since untestable controls undermine the "typed control" claim in practice.

**Validation-count typed-issue refactor (the substantive change):**
- New `AuthoringValidationIssue { code, message, severity, target? }` in `templateAuthoring.ts`. `target: { kind: 'node'|'field'|'section', key }` reuses Lock-0 L0-3's exact record shape verbatim (so a later slice building the parent-lock's full header count can adopt this type instead of migrating twice); `severity` is a superset field L0-3 doesn't define, kept because every basic-info check is currently a hard "must fix" (no invented `warning` issue — the validated set is unchanged).
- `validateTemplateBasicInfo(draft, unsupportedReason)` extracts the SAME five checks `validateTemplateFormFields` has always run first (unsupportedReason / key / name / visibility scope / SLA hours), in the same order, same Chinese copy. `validateTemplateFormFields` now composes it (`.map(i => i.message)`) — combined string-validator output is byte-identical to before this extraction. `validationErrors` (save-blocking surface) and `publishChecklist` (publish pre-flight) now transitively call through `validateTemplateBasicInfo`, but their composition, values, and rendered strings are unchanged (pinned by an order-preservation regression test, including one fixture that interleaves a real per-field error with a basic-info failure).
- `TemplateAuthoringView.vue`: `basicInfoIssueCount` computed derives `.length` off `validateTemplateBasicInfo(...)` — never hand-counted. Renders as a nav badge on the 基础信息 step only, reusing the pre-existing `.template-authoring__step-count` pill CSS (defined but had zero template usage before this slice — apparently scaffolded for exactly this). Folded into that step's `aria-label` too, since the button's explicit `aria-label` otherwise overrides inner text for assistive tech.

**Deliberately NOT the parent-lock header count.** Lock-0 L0-3's header count is defined over `publishChecklist` (composing `publishFormFieldIssues`/`publishApprovalFlowIssues`/`publishPlaceholderRoleIssues`, which include flow/canvas/placeholder-role checks). This PR's badge is a narrower, basic-info-step-only count over a subset of `validateTemplateFormFields`. Presenting it as the L0-3 header count would fail L0-3's own A-5 gate ("a fixture failing only `validationErrors` and not the preflight must NOT change the count"). The parent-lock header count stays separately-tracked, undelivered debt — this PR does not claim to deliver it.

**`unsupportedReason` attribution** — included in the typed basic-info issues (and therefore in the badge) deliberately: `firstInvalidAuthoringSection` already routes a validate() failure carrying it to the `'basic'` step, so this mirrors an existing attribution rather than inventing a new one.

## Out of scope (per task contract)
Flow canvas, node config editor, assignee logic, form builder — untouched. No validation rules added/removed/reworded. Publish payload shape for basic-info fields is unchanged (pinned by test).

## Tests
All added to the existing (already-required-lane) `apps/web/tests/approvalTemplateAuthoring.spec.ts` — no new spec file, so no CI-token wiring was needed (`approvalTemplateAuthoring` is already in `run-required-web-tests.sh` and in `approval-web-guard.yml`'s path filters, which already cover `templateAuthoring.ts` + `TemplateAuthoringView.vue`).

- Typed-issue pin/derivation (pure functions): zero-issue positive control, exact `{code,message,severity,target}` shape, order-preserving regression pin against the pre-extraction string output, severity-is-always-error pin, unsupportedReason attribution pin.
- Mounted typed-control-commit test: every basic-info control (key/name/category/SLA/description/visibility type+ids) round-trips through to the save payload.
- Mounted validation-count derivation test: 3 states (2 issues → 0 → 1 different issue) proving the badge tracks the live typed array, not a snapshot or hardcoded number.
- Publish-payload-shape pin: `Object.keys(payload).sort()` + value equality on `buildCreateTemplatePayload`, guarding against a renamed/dropped/reshaped basic-info key.

**Mutation-probed** (cp-backup + sha256 restore each time, no `git checkout --`):
1. Hardcoded `validateTemplateBasicInfo` to return `[]` → reds 7 tests (the new derivation test + several pre-existing preflight-checklist tests, proving the compatibility shim is load-bearing).
2. Hardcoded the view's `basicInfoIssueCount` computed to a constant `2` → reds exactly the new DOM derivation test (proves the test targets the live binding, not just the pure helper).
3. Renamed `category` → `categoryX` in `buildCreateTemplatePayload` → reds exactly the payload-shape pin + the typed-control-commit test.

Each probe was reverted and verified sha256 byte-identical to the pre-mutation file before the next probe.

## Verification
- `pnpm exec vue-tsc -b` (apps/web): clean.
- `pnpm exec tsc --noEmit` (packages/core-backend): clean (unaffected — frontend-only diff).
- `apps/web/scripts/run-required-web-tests.sh` on Node 20.20.2: **368 test files / 4526 tests passed**, 0 failures (re-verified after the follow-up commit below: 86/86 in `approvalTemplateAuthoring.spec.ts`, vue-tsc clean).

**Follow-up commit** (`97830ef340`) closes three review gaps found by a second-pass review before requesting human review: (1) the order-preservation pin only used an all-basic-info-failure fixture, which can't exercise the boundary against a REAL interleaved per-field error — added that fixture; (2) the `severity` field's test/comment could read as if a warning tier were already exercised — reworded to state it is declared-but-single-valued today; (3) a doc comment said `publishChecklist`/`validationErrors` were "untouched", which is true for their output but not their call graph (both now transitively call `validateTemplateBasicInfo`) — reworded for precision. No production logic changed in that commit.

## Deferred (explicitly out of this slice)
- Lock-0 L0-3's parent-lock header count over the full `publishChecklist` (flow/canvas/placeholder-role issues) — separate, larger slice; would touch canvas-adjacent validators this task scoped out.
- Lock-0 L0-1/L0-2/L0-4/L0-5/L0-6 (already shipped in #4944, or tracked elsewhere) — not part of P1-A0.
- Master §2's other basic-info gaps (icon, curated group, typed requester scope, process-admin chips) — new fields, out of this contract's scope (typed-controls-mechanics + validation-count only).

Runtime authorization: none implied by this PR — no flag change, no UAT. Ordinary engineering slice under the RATIFIED master lock's P1-A design authorization.
