### PR TITLE
feat(approval): P4-B — per-node form-field edit/visibility enforcement (Lock-7)

### DIFF
--- a/.github/workflows/approval-realdb-field-edit.yml
+++ b/.github/workflows/approval-realdb-field-edit.yml
@@ -1,0 +1,134 @@
+name: Approval real-DB acceptance (Lock-7 field-edit enforcement)
+
+# EVIDENCE LANE for the Lock-7 per-node form field EDIT/visibility enforcement real-DB acceptance
+# suite (tests/integration/approval-field-edit-enforcement.db.test.ts — G-3/G-4/G-5/G-6/G-7/G-8/G-9/
+# G-10/G-11/G-12/G-15/G-16/G-17, each with its positive control). Ephemeral first-party PostgreSQL
+# container; no customer source, no deployment, no flag change.
+#
+# WHY A STANDALONE FILE, not a plugin-tests.yml allowlist entry:
+# plugin-tests.yml is an s6a sha256-pinned provenance input
+# (sealed-export-package-provenance.cjs PINNED_EVIDENCE_FILES), so every edit forces an s6a re-pin
+# and a merge-serialisation race. This mirrors the sibling approval-realdb-handler.yml lane (Lock-3)
+# and the sealed-export-s6a-authority-row-lock.yml precedent it cites. plugin-tests.yml is left
+# byte-identical.
+#
+# TWO-POINT WIRING (the other half): the suite is excluded from the no-DB default vitest config
+# (packages/core-backend/vitest.config.ts) in the SAME commit that adds this file, so the required
+# `test (18.x/20.x)` job no longer collect-and-skip-greens it. This workflow is where the suite
+# actually EXECUTES, with EXPECT_DB=1 arming the suite's top-level anti-skip-green sentinel: a run
+# in this lane with a missing/broken DATABASE_URL goes RED instead of silently reporting skipped.
+
+on:
+  workflow_dispatch:
+  pull_request:
+    # No `branches:` filter (mirrors the s6a precedent): a brand-new workflow cannot be
+    # workflow_dispatch-ed until it has run once via a trigger it responds to, and a stacked-base PR
+    # would silently skip a branch-filtered trigger. The `paths` filter keeps it off unrelated PRs.
+    paths:
+      - 'packages/core-backend/tests/integration/approval-field-edit-enforcement.db.test.ts'
+      - 'packages/core-backend/tests/helpers/approval-schema-bootstrap.ts'
+      - 'packages/core-backend/src/services/ApprovalProductService.ts'
+      - 'packages/core-backend/src/services/ApprovalGraphExecutor.ts'
+      - 'packages/core-backend/src/services/ApprovalConditionFormula.ts'
+      - 'packages/core-backend/src/services/ApprovalBridgeService.ts'
+      - 'packages/core-backend/src/services/approval-bridge-types.ts'
+      - 'packages/core-backend/src/services/approval-form-redaction.ts'
+      - 'packages/core-backend/src/types/approval-product.ts'
+      - 'packages/core-backend/src/db/migrations/zzzz20260817120000_add_handle_action_to_approval_records.ts'
+      - 'packages/core-backend/src/db/migrations/zzzz20260817130000_create_approval_form_field_revisions.ts'
+      - '.github/workflows/approval-realdb-field-edit.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'packages/core-backend/tests/integration/approval-field-edit-enforcement.db.test.ts'
+      - 'packages/core-backend/tests/helpers/approval-schema-bootstrap.ts'
+      - 'packages/core-backend/src/services/ApprovalProductService.ts'
+      - 'packages/core-backend/src/services/ApprovalGraphExecutor.ts'
+      - 'packages/core-backend/src/services/ApprovalConditionFormula.ts'
+      - 'packages/core-backend/src/services/ApprovalBridgeService.ts'
+      - 'packages/core-backend/src/services/approval-bridge-types.ts'
+      - 'packages/core-backend/src/services/approval-form-redaction.ts'
+      - 'packages/core-backend/src/types/approval-product.ts'
+      - 'packages/core-backend/src/db/migrations/zzzz20260817120000_add_handle_action_to_approval_records.ts'
+      - 'packages/core-backend/src/db/migrations/zzzz20260817130000_create_approval_form_field_revisions.ts'
+      - '.github/workflows/approval-realdb-field-edit.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  approval-realdb-field-edit:
+    name: approval-realdb-field-edit
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: metasheet_approval_realdb
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d metasheet_approval_realdb"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 20
+    env:
+      DATABASE_URL: postgresql://postgres:postgres@127.0.0.1:5432/metasheet_approval_realdb
+      # Arms the suite's top-level sentinel: in THIS lane a missing DATABASE_URL is a red run,
+      # never a silent skipped-green.
+      EXPECT_DB: '1'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js 20.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.16.1
+          run_install: false
+
+      - name: Use empty npmrc for pnpm
+        run: |
+          echo "" > /tmp/empty-npmrc
+          echo "NPM_CONFIG_USERCONFIG=/tmp/empty-npmrc" >> "$GITHUB_ENV"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run DB migrations
+        env:
+          # Same per-PR-gate exclusion list as plugin-tests.yml's "Run DB migrations" step
+          # (see packages/core-backend/MIGRATION_EXCLUDE_TRACKING.md) — this lane provisions the
+          # identical schema the approval real-DB steps run against.
+          MIGRATION_EXCLUDE: 008_plugin_infrastructure.sql,048_create_event_bus_tables.sql,049_create_bpmn_workflow_tables.sql,042a_core_model_views.sql,20250924140000_create_gantt_tables.ts,20250925_create_view_tables.sql
+        run: pnpm --filter @metasheet/core-backend db:migrate
+
+      - name: Run Lock-7 field-edit-enforcement real-DB acceptance (whole file)
+        # WHOLE FILE, --reporter=verbose: a name filter matching zero tests would exit green and hide
+        # regressions; verbose prints every collected test so an empty collection shows in the log.
+        run: >-
+          pnpm --filter @metasheet/core-backend exec vitest
+          --config vitest.integration.config.ts run
+          tests/integration/approval-field-edit-enforcement.db.test.ts
+          --reporter=verbose
+
+      - name: Values-free evidence (this job)
+        run: |
+          {
+            echo "evidenceKind=CONTROLLED_SYNTHETIC_FUNCTIONAL"
+            echo "suite=approval-field-edit-enforcement.db.test.ts"
+            echo "lock=approval-lock7-field-edit-enforcement-20260817"
+            echo "gates=G-3,G-4,G-5,G-6,G-7,G-8,G-9,G-10,G-11,G-12,G-15,G-16,G-17"
+            echo "sentinelArmed=EXPECT_DB=1"
+            echo "customerSourceAccess=NOT_INVOLVED"
+            echo "flagChanged=false"
+            echo "externalWrite=false"
+          } | tee -a "$GITHUB_STEP_SUMMARY"

--- a/apps/web/src/approvals/components/ApprovalGraphNodeConfigEditor.vue
+++ b/apps/web/src/approvals/components/ApprovalGraphNodeConfigEditor.vue
@@ -721,17 +721,13 @@
             <el-option label="只读" value="readonly" />
             <el-option label="隐藏" value="hidden" />
           </el-select>
-          <!-- L0-6: linear editor's honesty copy, verbatim (fieldPermissionHonestyCopy.ts). -->
+          <!-- Lock-7 G-13: the readonly honesty copy is retired here in the SAME change as the linear
+               editor (L0-6 one-change rule) — `只读`/`隐藏` are now enforced server-side. -->
+          <!-- D5: same render condition as the linear editor — WIRED: renders whenever a hidden field
+               is a routing driver (graph-wide routingDriverFieldIds is provided via the api). Accurate
+               under OD-L7-8(a): a driver can never be editable, so hiding only affects the echo. -->
           <span
-            v-if="approvalNodeFieldAccess(node.key, field.id) === 'readonly'"
-            class="template-authoring__hint"
-            data-testid="approval-node-field-readonly-hint"
-          >{{ FIELD_PERMISSION_READONLY_HINT }}</span>
-          <!-- D5: same render condition as the linear editor — inert (never renders) until the
-               graph-wide routingDriverFieldIds field is wired through nodeConfigEditorContext
-               (see that file's comment; out of scope for this slice). -->
-          <span
-            v-else-if="approvalNodeFieldAccess(node.key, field.id) === 'hidden' && routingDriverFieldIds.has(field.id)"
+            v-if="approvalNodeFieldAccess(node.key, field.id) === 'hidden' && routingDriverFieldIds.has(field.id)"
             class="template-authoring__hint template-authoring__hint--warn"
             data-testid="approval-node-field-routing-hint"
           >{{ FIELD_PERMISSION_ROUTING_HINT }}</span>
@@ -795,10 +791,7 @@ import {
   type ApprovalCapabilityRegistry,
 } from '../approvalCapabilityRegistry'
 import { APPROVAL_CANVAS_INSPECTOR_TABS_KEY } from '../canvasInspectorTabsContext'
-import {
-  FIELD_PERMISSION_READONLY_HINT,
-  FIELD_PERMISSION_ROUTING_HINT,
-} from '../fieldPermissionHonestyCopy'
+import { FIELD_PERMISSION_ROUTING_HINT } from '../fieldPermissionHonestyCopy'
 
 const props = defineProps<{
   node: ApprovalNode

--- a/apps/web/src/approvals/fieldPermissionHonestyCopy.ts
+++ b/apps/web/src/approvals/fieldPermissionHonestyCopy.ts
@@ -1,25 +1,23 @@
 /**
- * Lock-0 L0-6 — field-permission honesty copy, carried over CHARACTER-FOR-CHARACTER (including the
- * `（T1-4b）` marker) from the linear editor into the canvas presentation.
+ * Lock-7 G-13 / Lock-0 L0-6 — the readonly "not-yet-enforced" honesty hint has been RETIRED (its
+ * constant and both render sites are removed). Per-node `readonly` / `hidden` are now ENFORCED
+ * server-side (Lock-7 P4-B: the write mask refuses a write to a masked field, and the detail read
+ * carries the actor-scoped access map), so the disclosure it made is no longer true. L0-6's one-change
+ * rule required the retiral to land in BOTH authoring surfaces (the linear TemplateAuthoringView and
+ * the canvas ApprovalGraphNodeConfigEditor) in the SAME change — Lock-7 is the only lock that may
+ * remove it, and this is that change.
  *
- * Source of truth (byte-identical, do not paraphrase):
- *   apps/web/src/views/approval/TemplateAuthoringView.vue
- *     - readonly hint, testid `approval-step-field-readonly-hint`
- *     - routing hint,  testid `approval-step-field-routing-hint`
- *
- * docs/development/approval-lock0-d0-interaction-delta-20260817.md §1 L0-6: "a future slice
- * retiring [the T1-4b marker] must retire it in both surfaces in one change" — do not edit either
- * string here without editing TemplateAuthoringView.vue's copy in the SAME change.
+ * The routing hint below is NOT retired: under OD-L7-8(a) a routing driver may never be `editable` at
+ * any node, so hiding a driver still affects only the echo and never approver resolution — the string
+ * stays TRUE (Lock-7 G-13 arm-conditional: do not "correct" an accurate string).
  */
-export const FIELD_PERMISSION_READONLY_HINT = '只读将在后续版本（T1-4b）生效，当前保存但暂不强制'
 
 /**
- * §4 D5 — carries over under the SAME render condition as the linear editor: the field's access is
- * `hidden` AND the field is referenced by some node's `form_field_user` assignee source. The
- * cross-node ("some node", not just the currently selected one) half of that condition needs
- * graph-wide `approvalNodeEdits` data that is not reachable from this component without a change to
- * `TemplateAuthoringView.vue`'s `nodeConfigEditorApi` provide() object (out of scope for this
- * slice — see the P1-A PR description). The consuming code in `ApprovalGraphNodeConfigEditor.vue`
- * is wired and ready; it renders nothing until that one field is supplied.
+ * §4 D5 — rendered under the SAME condition in both surfaces: the field's access is `hidden` AND the
+ * field is referenced by some node's `form_field_user` assignee source. The cross-node ("some node",
+ * not just the currently selected one) half is supplied graph-wide by `TemplateAuthoringView.vue`'s
+ * `nodeConfigEditorApi.routingDriverFieldIds`; the canvas inspector consumes it (WIRED — it renders
+ * whenever a hidden field is a driver). Accurate under OD-L7-8(a): a driver can never be `editable`,
+ * so hiding it affects only the read echo, never approver resolution.
  */
 export const FIELD_PERMISSION_ROUTING_HINT = '该字段被审批人来源引用；隐藏仅影响回显，不影响审批人解析'

--- a/apps/web/src/approvals/templateAuthoring.ts
+++ b/apps/web/src/approvals/templateAuthoring.ts
@@ -175,9 +175,9 @@ export interface ApprovalStepDraft {
   // T1-4 node-level field permissions (linear editor). One entry per NON-editable form field
   // (`editable` is the absent default, so a field left editable carries no entry). Hydrated from
   // `config.fieldPermissions` and re-emitted by `buildStepConfig`, which prunes entries whose field
-  // was deleted (backend cross-ref safety) and drops any `editable` entry. `hidden` is enforced at
-  // runtime (server echo-redaction, shipped #2799); `readonly` round-trips but is runtime-inert
-  // (enforcement deferred to T1-4b).
+  // was deleted (backend cross-ref safety) and drops any `editable` entry. `hidden` and `readonly`
+  // are BOTH enforced server-side (Lock-7 P4-B): `hidden` redacts the read echo + refuses a write;
+  // `readonly` refuses a write at that node.
   fieldPermissions: NodeFieldPermission[]
 }
 

--- a/apps/web/src/types/approval.ts
+++ b/apps/web/src/types/approval.ts
@@ -91,11 +91,11 @@ export interface HandlerNodeConfig {
   fieldPermissions?: NodeFieldPermission[]
 }
 
-// Byte-mirrors backend packages/core-backend/src/types/approval-product.ts:51-56 (P1-C node-level
-// field permissions). `editable` (the absent default) === current behavior. Only `hidden` is
-// enforced at runtime (server-side echo-redaction — already shipped in #2799); `readonly`/`editable`
-// are contract-stable but runtime-inert (readonly enforcement is deferred to T1-4b). The authoring
-// editor may set `hidden`/`readonly`; both round-trip, `readonly` carries a "not-yet-enforced" hint.
+// Byte-mirrors backend packages/core-backend/src/types/approval-product.ts NodeFieldAccess (P1-C
+// node-level field permissions). `editable` (the absent default) === current behavior. `hidden` and
+// `readonly` are BOTH enforced server-side (Lock-7 P4-B): `hidden` redacts the read echo + refuses a
+// write; `readonly` refuses a write at that node. The authoring editor sets `hidden`/`readonly`; both
+// round-trip and are enforced.
 export type NodeFieldAccess = 'editable' | 'readonly' | 'hidden'
 export interface NodeFieldPermission {
   fieldId: string

--- a/apps/web/src/views/approval/TemplateAuthoringView.vue
+++ b/apps/web/src/views/approval/TemplateAuthoringView.vue
@@ -764,14 +764,15 @@
               </el-checkbox>
             </el-form-item>
           </div>
-          <!-- T1-4 node field permissions: per-form-field access at this approval node. `隐藏` is
-               enforced at runtime (server echo-redaction); `只读` round-trips but is not yet enforced
-               (T1-4b). A field left `可编辑` carries no persisted entry (absent === editable). -->
+          <!-- T1-4 node field permissions: per-form-field access at this approval node. `隐藏` and
+               `只读` are BOTH enforced server-side (Lock-7 P4-B: 隐藏 redacts the read echo + blocks a
+               write; 只读 blocks a write at this node). A field left `可编辑` carries no persisted
+               entry (absent === editable). -->
           <div class="template-authoring__field-perms" data-testid="approval-step-field-permissions">
             <div class="template-authoring__field-perms-head">
               <strong>字段权限</strong>
               <span class="template-authoring__hint">
-                「隐藏」在审批到该节点时对所有查看者隐藏该字段（仅回显隐藏，不影响审批人解析与条件路由）；「只读」将在后续版本生效。字段默认为「可编辑」。
+                「隐藏」在审批到该节点时对所有查看者隐藏该字段（仅回显隐藏，不影响审批人解析与条件路由）；「只读」表示该字段在本节点仅可查看、不可编辑。字段默认为「可编辑」。
               </span>
             </div>
             <div v-if="fieldPermissionFields.length === 0" class="template-authoring__hint">
@@ -797,12 +798,7 @@
                 <el-option label="隐藏" value="hidden" />
               </el-select>
               <span
-                v-if="stepFieldAccess(step, field.id) === 'readonly'"
-                class="template-authoring__hint"
-                data-testid="approval-step-field-readonly-hint"
-              >只读将在后续版本（T1-4b）生效，当前保存但暂不强制</span>
-              <span
-                v-else-if="stepFieldAccess(step, field.id) === 'hidden' && routingDriverFieldIds.has(field.id)"
+                v-if="stepFieldAccess(step, field.id) === 'hidden' && routingDriverFieldIds.has(field.id)"
                 class="template-authoring__hint template-authoring__hint--warn"
                 data-testid="approval-step-field-routing-hint"
               >该字段被审批人来源引用；隐藏仅影响回显，不影响审批人解析</span>

--- a/apps/web/tests/approval-handler-node-config.spec.ts
+++ b/apps/web/tests/approval-handler-node-config.spec.ts
@@ -20,7 +20,6 @@ import {
   assigneeSourceRoster,
   type ApprovalCapabilityRegistry,
 } from '../src/approvals/approvalCapabilityRegistry'
-import { FIELD_PERMISSION_READONLY_HINT } from '../src/approvals/fieldPermissionHonestyCopy'
 import { HANDLER_ASSIGNEE_SOURCE_KINDS, type ApprovalNode } from '../src/types/approval'
 
 // ── element-plus stubs (compact, mirrors approval-template-authoring-canvas-inspector.spec) ─────
@@ -215,11 +214,13 @@ describe('Lock-3 handler config surface + inspector tabs', () => {
     expect(c.querySelector('[data-testid="approval-node-merge-with-requester"]')).toBeNull()
   })
 
-  it('field-permission honesty copy renders VERBATIM when a handler field is set to readonly', () => {
+  it('Lock-7 G-13: a handler field set to readonly renders NO readonly honesty hint (readonly is enforced server-side, not disclosed-as-pending)', () => {
     const api = createStubConfigApi({ handler_h: { nodeType: 'handler', assigneeSources: [{ kind: 'requester' }], fieldPermissions: [{ fieldId: 'amount', access: 'readonly' }] } })
     const c = mountEditorFlat(handlerNode(), DEFAULT_APPROVAL_CAPABILITY_REGISTRY, api)
-    const hint = c.querySelector('[data-testid="approval-node-field-readonly-hint"]')
-    expect(hint?.textContent?.trim()).toBe(FIELD_PERMISSION_READONLY_HINT)
+    // The field-permissions section still renders (the selector remains functional)...
+    expect(c.querySelector('[data-testid="approval-node-field-permissions"]')).toBeTruthy()
+    // ...but the retired "只读将在后续版本…" not-yet-enforced hint no longer appears (G-13).
+    expect(c.querySelector('[data-testid="approval-node-field-readonly-hint"]')).toBeNull()
   })
 
   it('the mode picker writes the handler edit model (会签→或签)', async () => {

--- a/apps/web/tests/approval-template-authoring-canvas-inspector.spec.ts
+++ b/apps/web/tests/approval-template-authoring-canvas-inspector.spec.ts
@@ -24,10 +24,7 @@ import {
   assigneeSourceRoster,
   type ApprovalCapabilityRegistry,
 } from '../src/approvals/approvalCapabilityRegistry'
-import {
-  FIELD_PERMISSION_READONLY_HINT,
-  FIELD_PERMISSION_ROUTING_HINT,
-} from '../src/approvals/fieldPermissionHonestyCopy'
+import { FIELD_PERMISSION_ROUTING_HINT } from '../src/approvals/fieldPermissionHonestyCopy'
 
 const HERE = dirname(fileURLToPath(import.meta.url))
 const CHILD_EDITOR_SOURCE = readFileSync(
@@ -1147,8 +1144,28 @@ describe('Canvas V2 Slice A — canvas inspector', () => {
     expect(appB.config.assigneeSources[0]).toEqual({ kind: 'static_role', roleIds: ['legal'] })
   })
 
-  it('A-9: readonly field-permission honesty copy is byte-identical to the linear editor; editable/hidden do not render it', async () => {
-    routeParams = { id: 'tpl_a9' }
+  it('Lock-7 G-13: the readonly honesty copy is retired atomically in BOTH authoring surfaces; selecting readonly renders no hint; the routing hint stays', async () => {
+    // L0-6 one-change rule: the retired strings/markers must be absent from BOTH surface sources
+    // (linear + canvas). Asserting on BOTH blobs is what reds if the copy is re-added to EITHER
+    // surface (a one-sided re-add). The `（T1-4b）` marker is pinned separately from the full string.
+    const retired = [
+      '只读将在后续版本（T1-4b）生效，当前保存但暂不强制', // FIELD_PERMISSION_READONLY_HINT
+      '（T1-4b）', // the marker
+      '「只读」将在后续版本生效', // the section-copy clause
+    ]
+    for (const marker of retired) {
+      expect(PARENT_AUTHORING_SOURCE).not.toContain(marker)
+      expect(CHILD_EDITOR_SOURCE).not.toContain(marker)
+    }
+    // The honesty-copy module no longer exports the readonly hint (a re-import would be a build error).
+    expect(CHILD_EDITOR_SOURCE).not.toContain('FIELD_PERMISSION_READONLY_HINT')
+    // The routing hint is NOT retired (OD-L7-8(a)/G-13 arm-conditional) — still exported, still true.
+    expect(FIELD_PERMISSION_ROUTING_HINT).toBe('该字段被审批人来源引用；隐藏仅影响回显，不影响审批人解析')
+
+    // DOM: selecting `readonly` renders NO readonly hint in the canvas inspector (readonly is now
+    // enforced, not disclosed-as-pending). Positive control that the tab + selector still work: the
+    // routing hint path (a different span) is exercised by the D5 test below.
+    routeParams = { id: 'tpl_g13' }
     getTemplateSpy.mockResolvedValue(buildTemplate({ approvalGraph: buildMixedGraph() as any }))
     await mountView()
     await flushUi()
@@ -1164,29 +1181,6 @@ describe('Canvas V2 Slice A — canvas inspector', () => {
     expect(container!.querySelector('[data-testid="approval-node-field-readonly-hint"]')).toBeNull()
 
     access.value = 'readonly'
-    access.dispatchEvent(new Event('change'))
-    await flushUi()
-    const hint = container!.querySelector('[data-testid="approval-node-field-readonly-hint"]') as HTMLElement
-    expect(hint).not.toBeNull()
-    expect(hint.textContent).toBe(FIELD_PERMISSION_READONLY_HINT)
-    expect(hint.textContent).toBe('只读将在后续版本（T1-4b）生效，当前保存但暂不强制')
-    // Gate A-9/probe-6a fix: `.toContain` is a SUBSTRING check — APPENDING drift to the linear
-    // editor's hint (e.g. "…暂不强制。详见发布说明") still contains the original text as a prefix,
-    // so it stayed green (probe 6a: 115/115). Anchor to the linear span's own data-testid and read
-    // its exact text out of source, then assert EQUALITY against the canvas hint — an append on
-    // either side now reds because the two strings genuinely differ.
-    const linearReadonlyHintMatch = PARENT_AUTHORING_SOURCE.match(
-      /data-testid="approval-step-field-readonly-hint"\s*>([^<]*)<\/span>/,
-    )
-    expect(linearReadonlyHintMatch).not.toBeNull()
-    expect(linearReadonlyHintMatch![1]).toBe(hint.textContent)
-
-    access.value = 'hidden'
-    access.dispatchEvent(new Event('change'))
-    await flushUi()
-    expect(container!.querySelector('[data-testid="approval-node-field-readonly-hint"]')).toBeNull()
-
-    access.value = 'editable'
     access.dispatchEvent(new Event('change'))
     await flushUi()
     expect(container!.querySelector('[data-testid="approval-node-field-readonly-hint"]')).toBeNull()

--- a/apps/web/tests/approvalTemplateAuthoring.spec.ts
+++ b/apps/web/tests/approvalTemplateAuthoring.spec.ts
@@ -1169,7 +1169,7 @@ describe('TemplateAuthoringView', () => {
     expect(amountAccess.value).toBe('hidden') // hydrated from the stored fieldPermission
   })
 
-  it('T1-4 write wire: selecting readonly through the SFC control writes {fieldId,access:readonly} to the save payload AND renders the readonly hint', async () => {
+  it('T1-4 write wire (Lock-7 G-13): selecting readonly through the SFC control writes {fieldId,access:readonly} to the save payload; the retired readonly hint never renders', async () => {
     // The default template is LINEAR (fields amount + reviewer) so the field-permissions editor is
     // live. This drives the @update:model-value → onStepFieldAccessChange → setStepFieldPermission →
     // save-payload wire that a pure-helper test can't see (wire-vs-fixture discipline).
@@ -1178,7 +1178,7 @@ describe('TemplateAuthoringView', () => {
     await mountView()
     await flushUi()
 
-    expect(container!.querySelector('[data-testid="approval-step-field-readonly-hint"]')).toBeNull() // no hint yet
+    expect(container!.querySelector('[data-testid="approval-step-field-readonly-hint"]')).toBeNull() // retired (G-13)
 
     const amountAccess = container!.querySelector('[data-testid="approval-step-field-access-amount"]') as HTMLSelectElement
     expect(amountAccess).not.toBeNull()
@@ -1186,7 +1186,9 @@ describe('TemplateAuthoringView', () => {
     amountAccess.dispatchEvent(new Event('change'))
     await flushUi()
 
-    expect(container!.querySelector('[data-testid="approval-step-field-readonly-hint"]')).not.toBeNull() // hint now renders
+    // Lock-7 G-13: readonly is now enforced server-side, so the "not-yet-enforced" hint is retired —
+    // selecting readonly renders NO hint (still persists to the payload below, so the control is live).
+    expect(container!.querySelector('[data-testid="approval-step-field-readonly-hint"]')).toBeNull()
 
     ;(container!.querySelector('[data-testid="approval-template-save-button"]') as HTMLButtonElement).click()
     await flushUi()

--- a/packages/core-backend/src/db/migrations/zzzz20260817130000_create_approval_form_field_revisions.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260817130000_create_approval_form_field_revisions.ts
@@ -1,0 +1,47 @@
+import { sql } from 'kysely'
+import type { Kysely } from 'kysely'
+
+// Lock-7 OD-L7-6(a) — the append-only per-field revision ledger for handler-node form edits.
+//
+// A handler field write UPDATEs `approval_instances.form_snapshot` IN PLACE (Lock-7 creates the
+// first mutation of that column) inside Lock-3 §3's handle transaction. Every mutated field also
+// appends ONE row here carrying before/after, the actor, the node key and the node-entry epoch, plus
+// `audit_record_id` = the `approval_records.id` of the `action:'handle'` row the same transaction
+// inserted. Two consumers read this table:
+//   - the mask-aware revision read surface (OD-L7-7 / G-8): before/after VALUES live here, never on
+//     the broadly-scoped audit/history surface, so a hidden field's value cannot leak past its
+//     intended audience.
+//   - the 内容变更 dedup invalidation (OD-L7-11(a) / G-16): `MAX(audit_record_id)` is the latest
+//     content-edit ordinal in `approval_records.id` space (BIGSERIAL), so a prior approval whose
+//     audit ordinal precedes it is excluded from the auto-approval history. This is a NEW per-edit
+//     marker — NOT a `nodeEntryEpoch` reuse (a field edit is a same-round mutation and MUST NOT bump
+//     the node epoch, or the in-flight quorum tally is voided — Lock-3 G-12).
+//
+// DDL is owner-gated but mergeable (runs in the CI test DB). No data migration; additive table.
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`
+    CREATE TABLE IF NOT EXISTS approval_form_field_revisions (
+      id BIGSERIAL PRIMARY KEY,
+      instance_id TEXT NOT NULL,
+      node_key TEXT NOT NULL,
+      field_id TEXT NOT NULL,
+      before_value JSONB,
+      after_value JSONB,
+      actor_id TEXT NOT NULL,
+      node_entry_epoch INTEGER,
+      audit_record_id BIGINT NOT NULL,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+    )
+  `.execute(db)
+
+  // Dedup MAX(audit_record_id) lookups and the mask-aware read both scope by instance.
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_approval_form_field_revisions_instance
+    ON approval_form_field_revisions(instance_id, id)
+  `.execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`DROP INDEX IF EXISTS idx_approval_form_field_revisions_instance`.execute(db)
+  await sql`DROP TABLE IF EXISTS approval_form_field_revisions`.execute(db)
+}

--- a/packages/core-backend/src/routes/approvals.ts
+++ b/packages/core-backend/src/routes/approvals.ts
@@ -2012,9 +2012,9 @@ export function approvalsRouter(options?: ApprovalRouterOptions): Router {
       const comment = typeof req.body?.comment === 'string' ? req.body.comment : undefined
       const targetUserId = typeof req.body?.targetUserId === 'string' ? req.body.targetUserId.trim() : undefined
       const targetNodeKey = typeof req.body?.targetNodeKey === 'string' ? req.body.targetNodeKey.trim() : undefined
-      // Lock-3 §3: forward the RESERVED `fieldWrites` key ONLY when the client actually sent it, so the
-      // service can reject a `handle` submission carrying it (non-empty / `{}` / `null`) with a
-      // values-free 422 by key PRESENCE (`'fieldWrites' in request`). Absent ⇒ never forwarded ⇒ succeeds.
+      // Lock-3 §3 / Lock-7 L7-C: forward the `fieldWrites` key ONLY when the client actually sent it,
+      // so the service applies the masked write on a `handle` (or rejects a malformed payload / a
+      // non-handle action) by key PRESENCE (`'fieldWrites' in request`). Absent ⇒ never forwarded.
       const hasFieldWrites = req.body != null && Object.prototype.hasOwnProperty.call(req.body, 'fieldWrites')
       // P1-B add_sign: approver user IDs to pull into the current node.
       const targetUserIds = Array.isArray(req.body?.targetUserIds)
@@ -2088,8 +2088,8 @@ export function approvalsRouter(options?: ApprovalRouterOptions): Router {
               targetUserIds,
               addSignMode,
               targetAssignmentUserId,
-              // Lock-3 §3: present ONLY when the client sent the key, so the service's key-presence
-              // rejection (422 APPROVAL_HANDLER_FIELD_WRITES_UNSUPPORTED) fires for `null`/`{}` too.
+              // Lock-3 §3 / Lock-7 L7-C: present ONLY when the client sent the key, so the service
+              // applies the masked write (or refuses a malformed payload) by key presence.
               ...(hasFieldWrites ? { fieldWrites: req.body.fieldWrites } : {}),
             },
             actor,

--- a/packages/core-backend/src/services/ApprovalBridgeService.ts
+++ b/packages/core-backend/src/services/ApprovalBridgeService.ts
@@ -27,6 +27,7 @@ import { APPROVAL_ERROR_CODES } from './approval-bridge-types'
 import {
   collectActiveNodeKeys,
   redactHiddenFormFields,
+  resolveFieldAccessAtNodes,
   type RedactableRuntimeGraph,
 } from './approval-form-redaction'
 import {
@@ -651,11 +652,29 @@ export class ApprovalBridgeService {
 
     const assignmentsByInstance = await this.loadAssignments([id])
     const runtimeGraphsByDefinition = await this.loadRuntimeGraphs([row.published_definition_id])
+    const instanceAssignments = assignmentsByInstance.get(id) || []
+    const detailRuntimeGraph = row.published_definition_id ? runtimeGraphsByDefinition.get(row.published_definition_id) ?? null : null
     const dto = toUnifiedDTO(
       row,
-      assignmentsByInstance.get(id) || [],
-      row.published_definition_id ? runtimeGraphsByDefinition.get(row.published_definition_id) ?? null : null,
+      instanceAssignments,
+      detailRuntimeGraph,
     )
+    // Lock-7 OD-L7-10 — DETAIL-only actor-scoped per-field access map. Computed from the viewer's
+    // ACTIVE user-typed seats (the same seats the write path claims), over the SAME
+    // `resolveFieldAccessAtNodes` derivation as the write mask, so `editable` here ⊆ writable there
+    // (never over-reported). A seatless / role-only / queue-only viewer gets no map (fail-closed —
+    // nothing editable). Multi-seat is most-restrictive-wins. NOT added to `toUnifiedDTO` (kept
+    // byte-identical for the list path, which shares that function). Absent ≡ editable (OD-L7-9).
+    if (dto && viewerUserId && detailRuntimeGraph) {
+      const actorNodeKeys = instanceAssignments
+        .filter((assignment) => assignment.is_active && assignment.assignment_type === 'user' && assignment.assignee_id === viewerUserId)
+        .map((assignment) => assignment.node_key)
+        .filter((nodeKey): nodeKey is string => typeof nodeKey === 'string' && nodeKey.length > 0)
+      if (actorNodeKeys.length > 0) {
+        const accessMap = resolveFieldAccessAtNodes(detailRuntimeGraph, actorNodeKeys)
+        if (accessMap.size > 0) dto.fieldAccess = Object.fromEntries(accessMap)
+      }
+    }
     // Attach the FROZEN form schema (detail `columns` included) from the instance's pinned
     // template version so the read renders detail rows from the frozen schema (design-lock Fact B).
     if (dto && row.template_version_id) {

--- a/packages/core-backend/src/services/ApprovalConditionFormula.ts
+++ b/packages/core-backend/src/services/ApprovalConditionFormula.ts
@@ -563,6 +563,41 @@ export function approvalConditionFormulaHasDynamicDependency(expression: string)
   return astHasDynamicDependency(parseFormula(expression))
 }
 
+function collectAstFieldIds(ast: FormulaAst, into: Set<string>): void {
+  switch (ast.kind) {
+    case 'field':
+    case 'aggregate':
+      // `path[0]` is the TOP-LEVEL field id (`path` addresses a sub-column for aggregates); the
+      // routing-driver pin (Lock-7 OD-L7-8) operates on top-level ids, matching the top-level-only
+      // fieldPermissions cross-reference set.
+      if (ast.path.length > 0 && ast.path[0]) into.add(ast.path[0])
+      return
+    case 'unary':
+      collectAstFieldIds(ast.expr, into)
+      return
+    case 'binary':
+    case 'compare':
+      collectAstFieldIds(ast.left, into)
+      collectAstFieldIds(ast.right, into)
+      return
+    default:
+      // number / string / boolean / null / requester / membership carry no FORM field reference.
+      return
+  }
+}
+
+/**
+ * Lock-7 OD-L7-8 — the set of TOP-LEVEL form field ids a condition formula reads (a routing driver:
+ * an edit to it would re-route branch selection). Used by the server-side publish pin that forbids a
+ * driver being `editable` at any node. Throws (via `parseFormula`) on a malformed expression, which
+ * the publish path already rejects earlier through `normalizeConditionFormulaPredicate`.
+ */
+export function extractApprovalConditionFormulaFieldIds(expression: string): string[] {
+  const fieldIds = new Set<string>()
+  collectAstFieldIds(parseFormula(expression), fieldIds)
+  return [...fieldIds]
+}
+
 type FormulaTruth = 'always_true' | 'always_false' | 'unknown'
 type NumericRange = { min: number; max: number }
 

--- a/packages/core-backend/src/services/ApprovalGraphExecutor.ts
+++ b/packages/core-backend/src/services/ApprovalGraphExecutor.ts
@@ -359,7 +359,11 @@ export interface ApprovalFormValidationOptions {
   attachmentValueMode?: 'legacy' | 'ids'
 }
 
-function validateFieldType(
+// Lock-7 L7-C — exported so the handler field-write path (applyHandlerFieldWrites) re-runs the SAME
+// per-value validators against the FROZEN version schema (create-path validation, one function). This
+// inherits Lock-8 MS-3's fail-open default verbatim (`default: return null` below) — asserted, not
+// fixed, by Lock-7 G-6.
+export function validateFieldType(
   field: FormField,
   value: unknown,
   options: ApprovalFormValidationOptions,
@@ -486,7 +490,9 @@ function getFieldPropString(field: FormField, key: string): string | null {
   return typeof raw === 'string' && raw.trim().length > 0 ? raw.trim() : null
 }
 
-function validateFieldConstraints(field: FormField, value: unknown): string[] {
+// Lock-7 L7-C — exported for applyHandlerFieldWrites (see validateFieldType above). MS-3 fail-open
+// default (`default: return []`) is inherited and asserted by G-6, not fixed here.
+export function validateFieldConstraints(field: FormField, value: unknown): string[] {
   if (value === undefined || value === null) {
     return []
   }
@@ -583,7 +589,9 @@ function validateFieldConstraints(field: FormField, value: unknown): string[] {
 // Attachment top-level-only (flag-ON / attachmentValueMode:'ids'): an attachment-typed leaf inside
 // a detail group is rejected. Flag-OFF / legacy mode keeps detail-leaf attachment values
 // legacy-valid (string/record) for byte compatibility with pre-feature snapshots.
-function validateDetailFieldValue(
+// Lock-7 L7-C — exported for applyHandlerFieldWrites: a `detail` field write re-runs this against the
+// frozen sub-schema (per-row visibility + required, same as create).
+export function validateDetailFieldValue(
   field: FormField,
   value: unknown,
   options: ApprovalFormValidationOptions,

--- a/packages/core-backend/src/services/ApprovalProductService.ts
+++ b/packages/core-backend/src/services/ApprovalProductService.ts
@@ -18,6 +18,7 @@ import type {
   ApprovalMode,
   ApprovalNodeType,
   ApprovalRequesterSnapshot,
+  ConditionBranch,
   ConditionFormulaPredicate,
   CreateApprovalRequest,
   CreateApprovalTemplateRequest,
@@ -52,7 +53,11 @@ import {
   canonicalizeRecordLinkFormData,
   pruneHiddenFormData,
   validateApprovalFormData,
+  validateFieldType,
+  validateFieldConstraints,
+  validateDetailFieldValue,
 } from './ApprovalGraphExecutor'
+import { collectActiveNodeKeys, collectHiddenFieldIds, fieldAccessAtNodes, resolveFieldAccessAtNodes } from './approval-form-redaction'
 import { resolveApprovalAssignees } from './ApprovalAssigneeResolver'
 import { validateAmountTotalConsistency } from './amount-total-check'
 import { isApprovalAttachmentsEnabled } from '../routes/approval-attachments'
@@ -70,6 +75,7 @@ import {
   extractRequesterRoleLiterals,
   formulaReferencesRequesterAttribute,
   parseApprovalConditionFormula,
+  extractApprovalConditionFormulaFieldIds,
 } from './ApprovalConditionFormula'
 import { resolveApprovalRequesterOrgRelations, ApprovalRoutingPolicyError, MAX_MANAGER_CHAIN_LEVELS, type ApprovalRequesterOrgRelations } from './ApprovalDirectoryOrg'
 import { resolveApprovalRequesterRoleIds } from './ApprovalRequesterRoles'
@@ -1411,6 +1417,132 @@ function validateNodeFieldPermissionsAgainstFormSchema(
       }
     }
   })
+  // Lock-7 L7-B (R-4) — the field-edit-enforcement publish pins land HERE, so all five authoring entry
+  // points (restore/create/update/publish/clone) raise them and the dispatch re-normalize path (which
+  // does NOT call this function) never does, keeping in-flight instances dispatchable (§2.1).
+  validateFieldEditEnforcementPins(approvalGraph, formSchema, context)
+}
+
+/**
+ * Lock-7 L7-B pins 1 & 3 — the NEW publish-time fail-closed field-edit-enforcement pins, raised at all
+ * FIVE authoring entry points beside `validateNodeFieldPermissionsAgainstFormSchema` (restore, create,
+ * update, publish, clone). NOT called on the dispatch re-normalize path (`asRuntimeGraph`), so it never
+ * makes an in-flight instance undispatchable (§2.1). Pin 2 (editable on a non-write-capable node type)
+ * lives in `normalizeApprovalGraph` — it must inspect the raw per-type config BEFORE the switch drops
+ * the key. This function reads the NORMALIZED graph: `editable` entries survive only on approval /
+ * handler nodes, and driver references survive on approval / handler / condition nodes, so it has
+ * everything it needs.
+ */
+/**
+ * Lock-7 OD-L7-8 — the set of TOP-LEVEL form field ids that DRIVE routing: any field referenced by a
+ * `form_field_user` assignee source (on an approval/handler node), by a `ConditionRule.fieldId`, or by
+ * a condition-formula operand. Editing such a field mid-flight re-routes the graph (the executor +
+ * assignment resolver are rebuilt from the instance's CURRENT form_snapshot at every dispatch,
+ * `:6059-6065` / `:6270-6276`), so an approver editing it is choosing their own downstream reviewer /
+ * branch.
+ *
+ * SHARED by BOTH the publish pin (which rejects a driver marked `editable`, an authoring-time check)
+ * AND the runtime write guard in `applyHandlerFieldWrites` (which refuses a WRITE to any driver field
+ * INDEPENDENT of the matrix — because OD-L7-9's absent≡editable otherwise leaves a driver simply
+ * OMITTED from a handler's matrix default-editable and therefore writable). Factored so the two can
+ * never drift.
+ */
+function collectRoutingDriverFieldIds(
+  nodes: ReadonlyArray<{ type: ApprovalNodeType; config: unknown }>,
+): Set<string> {
+  const driverFieldIds = new Set<string>()
+  for (const node of nodes) {
+    const config = node.config as {
+      assigneeSources?: ApprovalAssigneeSource[]
+      branches?: ConditionBranch[]
+    }
+    if (node.type === 'approval' || node.type === 'handler') {
+      for (const source of config.assigneeSources ?? []) {
+        // form_field_user is the shipped driver kind. Lock-2's field-derived kinds
+        // (manager_at_level etc.) are conditionally drivers too, but Lock-2 is not on main and
+        // OD-L7-8 cites them without re-adjudicating — deferred to when Lock-2 lands.
+        if (source.kind === 'form_field_user' && typeof source.fieldId === 'string' && source.fieldId) {
+          driverFieldIds.add(source.fieldId)
+        }
+      }
+    }
+    if (node.type === 'condition') {
+      for (const branch of config.branches ?? []) {
+        for (const rule of branch.rules ?? []) {
+          if (typeof rule.fieldId === 'string' && rule.fieldId) driverFieldIds.add(rule.fieldId)
+        }
+        if (branch.formula?.expression) {
+          for (const fieldId of extractApprovalConditionFormulaFieldIds(branch.formula.expression)) {
+            driverFieldIds.add(fieldId)
+          }
+        }
+      }
+    }
+  }
+  return driverFieldIds
+}
+
+function validateFieldEditEnforcementPins(
+  approvalGraph: ApprovalGraph,
+  formSchema: FormSchema,
+  context: ValidationContext,
+): void {
+  // --- Pin 1 (OD-L7-8(a) / G-4): a routing driver may not be `editable` at ANY node. ---
+  // The load-bearing pin: it closes a privilege-escalation path that opens the moment writes land.
+  // Authoring-time half — reject a driver marked EXPLICITLY `editable`. The runtime write guard in
+  // applyHandlerFieldWrites closes the DEFAULT-editable (absent-matrix) case that absent≡editable
+  // (OD-L7-9) leaves open, since an authoring-time "reject absent driver" would be a §2.1 narrowing.
+  const routingDriverFieldIds = collectRoutingDriverFieldIds(approvalGraph.nodes)
+  if (routingDriverFieldIds.size > 0) {
+    for (const node of approvalGraph.nodes) {
+      if (node.type !== 'approval' && node.type !== 'handler') continue
+      const permissions = (node.config as { fieldPermissions?: NodeFieldPermission[] }).fieldPermissions ?? []
+      for (const permission of permissions) {
+        if (permission.access === 'editable' && routingDriverFieldIds.has(permission.fieldId)) {
+          failValidation(
+            context,
+            `approvalGraph node ${node.key} fieldPermissions marks routing-driver field ${permission.fieldId} editable; a routing driver may never be editable (Lock-7 OD-L7-8)`,
+          )
+        }
+      }
+    }
+  }
+
+  // --- Pin 3 (G-5): an unfillable required × hidden field. ---
+  // A `required: true` field is unfillable iff it is NOT guaranteed-filled-at-create AND `hidden` at
+  // EVERY write-capable node (approval + handler). "Guaranteed-filled-at-create" = required with NO
+  // `visibilityRule`: AGE's `getVisibleFormFieldIds` no-rule-≡-visible arm (AGE:250-251, re-read at
+  // this baseline) makes such a field always visible, and `validateApprovalFormData` (AGE:649) forces
+  // a required-visible field to be filled at create. A field carrying a `visibilityRule` MAY be
+  // create-hidden, so if it is also hidden at every write node, nobody can ever fill it. We
+  // deliberately OVER-reject a `visibilityRule` that is provably always-visible (there is no shipped
+  // always-visible analyzer for `visibilityRule`, unlike formulas) — fail-closed per master M4. A node
+  // with NO entry for the field ≡ `editable` (OD-L7-9) ⇒ fillable there ⇒ not unfillable.
+  const writeCapableNodes = approvalGraph.nodes.filter((node) => node.type === 'approval' || node.type === 'handler')
+  for (const field of formSchema.fields) {
+    if (field.required !== true) continue
+    if (!field.visibilityRule) continue
+    if (writeCapableNodes.length === 0) continue
+    let firstHidingNodeKey: string | null = null
+    let hiddenEverywhere = true
+    for (const node of writeCapableNodes) {
+      const entry = (node.config as { fieldPermissions?: NodeFieldPermission[] }).fieldPermissions
+        ?.find((permission) => permission.fieldId === field.id)
+      if (entry?.access === 'hidden') {
+        // Deterministic node key for the error (graph order) — the field is hidden at several.
+        if (!firstHidingNodeKey) firstHidingNodeKey = node.key
+      } else {
+        hiddenEverywhere = false
+        break
+      }
+    }
+    if (hiddenEverywhere && firstHidingNodeKey) {
+      failValidation(
+        context,
+        `formSchema field ${field.id} is required but hidden at every write-capable node (node ${firstHidingNodeKey}); it is unfillable (Lock-7 G-5)`,
+      )
+    }
+  }
 }
 
 /**
@@ -1958,6 +2090,29 @@ function normalizeApprovalGraph(
       type: node.type as ApprovalGraph['nodes'][number]['type'],
       ...(typeof node.name === 'string' && node.name.trim().length > 0 ? { name: node.name.trim() } : {}),
       config: {} as Record<string, unknown>,
+    }
+
+    // Lock-7 L7-B pin 2 (OD-L7-4(a) / G-12) — `editable` on a node type with NO write surface is a 400,
+    // not the shipped SILENT drop (defect D-1). The switch below rebuilds cc/parallel/condition from a
+    // whitelist and sends start/end to `default: config = {}`, dropping `fieldPermissions` with no error
+    // — an author who marks a field editable on a cc node gets no effect and no warning. Lock-7 must not
+    // inherit that for the WRITE axis, so `editable` here fails closed. ONLY `editable` is rejected;
+    // `readonly`/`hidden` on these types stay silently dropped (D-1's read axis is a SEPARATE fix slice,
+    // §2.7 — Lock-7 neither fixes nor inherits it). Gated OFF for the dispatch re-normalize
+    // (STORED_RUNTIME_CONTEXT): a stored graph already had the key dropped at publish, so re-rejecting
+    // would make an in-flight instance undispatchable (§2.1).
+    if (node.type !== 'approval' && node.type !== 'handler' && context !== STORED_RUNTIME_CONTEXT) {
+      const rawPermissions = (node.config as { fieldPermissions?: unknown }).fieldPermissions
+      if (Array.isArray(rawPermissions)) {
+        for (const permission of rawPermissions) {
+          if (isRecord(permission) && permission.access === 'editable') {
+            failValidation(
+              context,
+              `approvalGraph.nodes[${index}].config.fieldPermissions marks a field editable on a ${node.type} node, which has no write surface (Lock-7 OD-L7-4)`,
+            )
+          }
+        }
+      }
     }
 
     switch (node.type) {
@@ -3598,6 +3753,13 @@ export class ApprovalProductService {
     client: { query: typeof pool.query },
     instanceId: string,
   ): Promise<ApprovalHistoryEntry[]> {
+    // Lock-7 OD-L7-11(a) / G-16 — 内容变更 invalidation for edits landed by PRIOR transactions: a
+    // handler field edit appended revision rows whose `audit_record_id` (the `handle` row's id) is the
+    // content-edit ordinal in `approval_records.id` (BIGSERIAL) space. Exclude any prior approval whose
+    // audit ordinal PRECEDES the latest content edit — those approvals predate the current form and
+    // must not seed an auto-approval skip. This is the NEW per-edit marker (NOT `nodeEntryEpoch`,
+    // which never bumps on a same-round edit). The single-call edit+complete case is handled by the
+    // caller passing `[]` (this txn's edit is not yet persisted here).
     const result = await client.query<{
       id: string | number
       actor_id: string
@@ -3607,6 +3769,10 @@ export class ApprovalProductService {
        FROM approval_records
        WHERE instance_id = $1
          AND action = 'approve'
+         AND id > COALESCE(
+           (SELECT MAX(audit_record_id) FROM approval_form_field_revisions WHERE instance_id = $1),
+           0
+         )
        ORDER BY occurred_at ASC, id ASC`,
       [instanceId],
     )
@@ -6927,16 +7093,16 @@ export class ApprovalProductService {
         throw new ServiceError('Approval assignment not found for actor', 403, 'APPROVAL_ASSIGNMENT_REQUIRED')
       }
 
-      // Lock-3 §3 (field-write fail-closed, G-9): a `handle` request carrying the RESERVED `fieldWrites`
-      // key — non-empty, `{}`, or `null` — is rejected with a values-free 422 BEFORE any row is written or
-      // node advanced. Lock-7 owns the write surface; until it lands a handler submit carries NO field
-      // writes (财务打款/盖章/归档 nodes work with no form mutation). Detected by key PRESENCE so `null`/`{}`
-      // are caught. Placed before every write arm so the rejection is payload-selected and side-effect-free.
-      if (request.action === 'handle' && Object.prototype.hasOwnProperty.call(request, 'fieldWrites')) {
+      // Lock-7 L7-C / OD-L7-3(a): `fieldWrites` is meaningful ONLY on a `handle` submission at a
+      // handler node (the sole ratified write surface). On any OTHER action a present `fieldWrites`
+      // key is a values-free 400 — fail-closed, never a silent ignore. The `handle` path below
+      // applies the masked, frozen-schema-validated write inside this transaction (P4-B replaces
+      // P4-A's blanket 422 APPROVAL_HANDLER_FIELD_WRITES_UNSUPPORTED). Detected by key PRESENCE.
+      if (request.action !== 'handle' && Object.prototype.hasOwnProperty.call(request, 'fieldWrites')) {
         throw new ServiceError(
-          'Field writes at a handler node are not supported yet',
-          422,
-          'APPROVAL_HANDLER_FIELD_WRITES_UNSUPPORTED',
+          'Field writes are only permitted on a handler submission',
+          400,
+          'APPROVAL_FIELD_WRITE_ACTION_NOT_ALLOWED',
           { nodeKey: currentNodeKey },
         )
       }
@@ -7376,6 +7542,28 @@ export class ApprovalProductService {
         // still active (the read fails closed on empty/mixed), and stamp the handle record with it so a
         // later re-entry (a fresh epoch) never re-counts this submission.
         const handlerNodeEpoch = await this.currentNodeEntryEpoch(client, id, currentNodeKey)
+        // Lock-7 L7-C step (2) "apply" — the masked field write. `applyHandlerFieldWrites` masks each
+        // write at the actor's SINGLE claimed node, validates against the FROZEN version schema, and
+        // UPDATEs form_snapshot IN PLACE (OD-L7-6(a)); any refusal throws values-free and rolls the
+        // whole transaction back (G-3/G-7/G-15). The edit is a SAME-ROUND mutation: it does NOT bump
+        // node_activation_seq (no `bumpNodeActivationSeq` here), so `handlerNodeEpoch` and the current
+        // node's quorum tally (`:6981`, Lock-3 G-12) are unchanged by the edit (G-16 companion).
+        let handlerFieldWrite: { changedFieldIds: string[]; revisions: Array<{ fieldId: string; before: unknown; after: unknown }> } = { changedFieldIds: [], revisions: [] }
+        if (Object.prototype.hasOwnProperty.call(request, 'fieldWrites')) {
+          const schemaResult = await client.query<{ form_schema: Record<string, unknown> }>(
+            `SELECT form_schema FROM approval_template_versions WHERE id = $1`,
+            [instance.template_version_id],
+          )
+          const frozenFormSchema = schemaResult.rows[0]?.form_schema as unknown as FormSchema | undefined
+          if (!frozenFormSchema) {
+            throw new ServiceError('Frozen form schema not found', 409, 'APPROVAL_FROZEN_SCHEMA_NOT_FOUND', { nodeKey: currentNodeKey })
+          }
+          handlerFieldWrite = await this.applyHandlerFieldWrites(client, id, currentNodeKey, request.fieldWrites, {
+            runtimeGraph,
+            formSchema: frozenFormSchema,
+            frozenSnapshot: formSnapshot,
+          })
+        }
         // Deactivate the actor's own seat first (会签/或签 both consume it).
         await this.deactivateActorAssignmentsAtNode(client, id, currentNodeKey, actor.userId, actorRoles)
         const remainingAssignments = currentNodeAssignments.length - actorAssignments.length
@@ -7386,7 +7574,7 @@ export class ApprovalProductService {
             `UPDATE approval_instances SET version = $2, updated_at = now() WHERE id = $1`,
             [id, nextVersion],
           )
-          await this.insertApprovalRecord(client, id, {
+          const partialAuditId = await this.insertApprovalRecord(client, id, {
             action: 'handle',
             actorId: actor.userId,
             actorName,
@@ -7402,8 +7590,13 @@ export class ApprovalProductService {
               aggregateComplete: false,
               remainingAssignments,
               ...(handlerNodeEpoch !== null ? { nodeEntryEpoch: handlerNodeEpoch } : {}),
+              // Lock-7 OD-L7-7 — values-free: the changed field IDS only, never before/after values.
+              ...(handlerFieldWrite.changedFieldIds.length > 0 ? { changedFieldIds: handlerFieldWrite.changedFieldIds } : {}),
             },
           }, actor)
+          if (handlerFieldWrite.revisions.length > 0) {
+            await this.insertFormFieldRevisions(client, id, currentNodeKey, actor.userId, handlerNodeEpoch, partialAuditId, handlerFieldWrite.revisions)
+          }
           await client.query('COMMIT')
           return (await this.getApproval(id, actor.userId))!
         }
@@ -7447,7 +7640,13 @@ export class ApprovalProductService {
             executor,
             resolution,
             typeof requesterId === 'string' ? requesterId : null,
-            await this.loadApprovalHistory(client, id),
+            // Lock-7 OD-L7-11(a) / G-16 — 内容变更 invalidation. THIS transaction's edit is not yet
+            // visible in the DB (the audit + revision rows are inserted below), so a single-call
+            // edit+complete would otherwise auto-approve the next node on a PRE-edit approval. When
+            // this submit edited a field, EVERY persisted approval necessarily precedes the edit ⇒
+            // drop the whole history. Prior-transaction edits are handled inside loadApprovalHistory
+            // (it excludes approvals whose audit ordinal precedes the latest content-edit revision).
+            handlerFieldWrite.changedFieldIds.length > 0 ? [] : await this.loadApprovalHistory(client, id),
           )
         }
         await client.query(
@@ -7471,7 +7670,7 @@ export class ApprovalProductService {
         // ACTIVATION (nodeEntryEpoch §4·A): completing the handler activates the NEXT node — a new epoch.
         const advanceEntryEpoch = await this.bumpNodeActivationSeq(client, id)
         const createdTaskEvents = await this.insertAssignments(client, id, resolution.assignments, advanceEntryEpoch)
-        await this.insertApprovalRecord(client, id, {
+        const completionAuditId = await this.insertApprovalRecord(client, id, {
           action: 'handle',
           actorId: actor.userId,
           actorName,
@@ -7487,8 +7686,13 @@ export class ApprovalProductService {
             aggregateComplete: true,
             ...(handlerCancelledAssigneeIds.length > 0 ? { handlerCancelledAssignees: handlerCancelledAssigneeIds } : {}),
             ...(handlerNodeEpoch !== null ? { nodeEntryEpoch: handlerNodeEpoch } : {}),
+            // Lock-7 OD-L7-7 — values-free: changed field IDs only.
+            ...(handlerFieldWrite.changedFieldIds.length > 0 ? { changedFieldIds: handlerFieldWrite.changedFieldIds } : {}),
           },
         }, actor)
+        if (handlerFieldWrite.revisions.length > 0) {
+          await this.insertFormFieldRevisions(client, id, currentNodeKey, actor.userId, handlerNodeEpoch, completionAuditId, handlerFieldWrite.revisions)
+        }
         await this.insertAutoApprovalEvents(client, id, nextVersion, resolution.status, resolution.autoApprovalEvents, advanceEntryEpoch)
         await this.insertCcEvents(client, id, nextVersion, resolution.status, resolution.ccEvents)
         const completionEvent = resolution.status === 'approved'
@@ -8792,16 +8996,218 @@ export class ApprovalProductService {
     }
   }
 
+  // Lock-7 L7-C / OD-L7-6(a) — the handler-node field write. Callable ONLY from step (2) of Lock-3
+  // §3's handle transaction (claim → apply → bump version → audit → resolve). The mask reads exactly
+  // `[nodeKey]` — the actor's SINGLE claimed seat, never a re-derivation (L7-A) — so `editable` ⇒
+  // writable and `readonly`/`hidden` ⇒ a values-free refusal that rolls back the whole transaction
+  // (G-3/G-15). Values are validated against the FROZEN version schema (create-path validators,
+  // G-6). Returns the changed field ids + before/after revisions so the caller writes the
+  // values-free `handle` audit row (changedFieldIds, no values — OD-L7-7) and the append-only
+  // revision rows. The `form_snapshot` UPDATE is IN PLACE (OD-L7-6(a)): every existing reader (DTO
+  // echo, FWB projection at `status='approved'`, condition routing) is then automatically correct
+  // with no composition step (G-17 — a delta table read-composed by each reader would be fail-OPEN
+  // by omission). Drivers can never be `editable` (publish pin 1 / OD-L7-8(a)), so the in-memory
+  // executor built from the pre-edit snapshot resolves the next node identically — an edit never
+  // re-routes.
+  private async applyHandlerFieldWrites(
+    client: { query: typeof pool.query },
+    instanceId: string,
+    nodeKey: string,
+    rawWrites: unknown,
+    context: {
+      runtimeGraph: RuntimeGraph
+      formSchema: FormSchema
+      frozenSnapshot: Record<string, unknown>
+    },
+  ): Promise<{ changedFieldIds: string[]; revisions: Array<{ fieldId: string; before: unknown; after: unknown }> }> {
+    // Payload must be a plain object of fieldId → value. `null` / array / scalar ⇒ values-free 400.
+    if (!isRecord(rawWrites)) {
+      throw new ServiceError('Field writes payload is invalid', 400, 'APPROVAL_FIELD_WRITE_PAYLOAD_INVALID', { nodeKey })
+    }
+    const writeEntries = Object.entries(rawWrites)
+    // An empty `{}` is an accepted payload with zero writes — the handle proceeds, no UPDATE, no rows.
+    if (writeEntries.length === 0) {
+      return { changedFieldIds: [], revisions: [] }
+    }
+    const schemaFields = new Map((context.formSchema.fields ?? []).map((field) => [field.id, field]))
+    const attachmentValueMode = isApprovalAttachmentsEnabled() ? 'ids' as const : 'legacy' as const
+    // Lock-7 OD-L7-8 RUNTIME driver guard (defense-in-depth, matrix-INDEPENDENT). The publish pin only
+    // rejects an EXPLICIT `editable` driver, but OD-L7-9's absent≡editable makes a driver simply OMITTED
+    // from this handler's matrix default-editable — and the mask below would then permit the write, so
+    // an approver could edit a `form_field_user` / `ConditionRule` / condition-formula field and choose
+    // their own downstream reviewer/branch (master §P4 exit: "cannot be bypassed by HTTP calls"). Refuse
+    // a write to ANY field in the instance's FROZEN-graph driver set regardless of its access
+    // (editable/readonly/hidden/absent), values-free. Same shared collection the pin uses (no drift).
+    // The collection re-parses each condition formula, but that cannot introduce a NEW in-flight break:
+    // the same dispatch already ran `asRuntimeGraph` (`:6794`) → `normalizeConditionFormulaPredicate`
+    // over the identical stored formulas, so an unparseable stored formula throws THERE first, before
+    // this guard is reached (§2.1 — no formula reaches here that has not already been re-parsed OK).
+    const routingDriverFieldIds = collectRoutingDriverFieldIds(context.runtimeGraph.nodes)
+    const revisions: Array<{ fieldId: string; before: unknown; after: unknown }> = []
+    const merge: Record<string, unknown> = {}
+    for (const [fieldId, value] of writeEntries) {
+      const field = schemaFields.get(fieldId)
+      // Unknown top-level field id. This is ALSO the OD-L7-12 detail sub-column case: a
+      // `fieldId.columnId` address is never a top-level schema id, so it lands here — v1 excludes
+      // per-sub-column access (the cross-reference set is top-level only). Fail-closed 400.
+      if (!field) {
+        throw new ServiceError('Field write references an unknown field', 400, 'APPROVAL_FIELD_WRITE_UNKNOWN_FIELD', { nodeKey, fieldId })
+      }
+      // Routing driver — never writable at any node, whatever the matrix says (see the guard note above).
+      if (routingDriverFieldIds.has(fieldId)) {
+        throw new ServiceError('Field write to a routing driver is not permitted', 403, 'APPROVAL_FIELD_WRITE_DRIVER_FORBIDDEN', { nodeKey, fieldId })
+      }
+      const access = fieldAccessAtNodes(context.runtimeGraph, [nodeKey], fieldId)
+      if (access !== 'editable') {
+        // `readonly` ⇒ non-editable; `hidden` ⇒ not even visible. Both refuse WITHOUT echoing a value.
+        throw new ServiceError('Field write is not permitted at this node', 403, 'APPROVAL_FIELD_WRITE_FORBIDDEN', { nodeKey, fieldId })
+      }
+      // v1 fail-closed (DEFERRED, OD-L7-3): `record-link` / `attachment` writes need binding+authz
+      // that Lock-7's named validators (validateFieldType/Constraints/Detail) do NOT cover —
+      // create-time record-link confused-deputy authz (projectRecordLinkFormSnapshotForViewer) and
+      // attachment-id binding into the immutable snapshot. Rejected here, not silently dropped; the
+      // approval-node write surface (OD-L7-3's named next slice) carries the binding surfaces.
+      if (field.type === 'record-link' || field.type === 'attachment') {
+        throw new ServiceError('Field type is not writable at a handler node yet', 400, 'APPROVAL_FIELD_WRITE_UNSUPPORTED_TYPE', { nodeKey, fieldId })
+      }
+      // Re-run the FROZEN-schema validators (L7-C / G-6). MS-3 fail-open is INHERITED, not fixed: a
+      // field type with no explicit `validateFieldType` arm returns null ⇒ written unvalidated.
+      const errors = field.type === 'detail'
+        ? validateDetailFieldValue(field, value, { attachmentValueMode })
+        : [validateFieldType(field, value, { attachmentValueMode }), ...validateFieldConstraints(field, value)]
+            .filter((error): error is string => Boolean(error))
+      if (errors.length > 0) {
+        throw new ServiceError('Field write value is invalid', 400, 'APPROVAL_FIELD_WRITE_INVALID', { nodeKey, fieldId })
+      }
+      revisions.push({
+        fieldId,
+        before: Object.prototype.hasOwnProperty.call(context.frozenSnapshot, fieldId) ? context.frozenSnapshot[fieldId] : null,
+        after: value,
+      })
+      merge[fieldId] = value
+    }
+    // IN-PLACE UPDATE (OD-L7-6(a), R-10) — the first and only UPDATE of `form_snapshot`. `||` merges
+    // the written fields over the create-time snapshot, preserving untouched fields.
+    await client.query(
+      `UPDATE approval_instances
+          SET form_snapshot = COALESCE(form_snapshot, '{}'::jsonb) || $2::jsonb,
+              updated_at = now()
+        WHERE id = $1`,
+      [instanceId, JSON.stringify(merge)],
+    )
+    return { changedFieldIds: revisions.map((revision) => revision.fieldId), revisions }
+  }
+
+  // Lock-7 OD-L7-6(a) — append the per-field revision rows, each stamped with the `handle` audit
+  // row's id (`auditRecordId`) so `MAX(audit_record_id)` is the 内容变更 dedup ordinal (G-16). Values
+  // (before/after) live ONLY here, behind the mask-aware read — never on the broadly-scoped audit
+  // surface (OD-L7-7).
+  private async insertFormFieldRevisions(
+    client: { query: typeof pool.query },
+    instanceId: string,
+    nodeKey: string,
+    actorId: string,
+    nodeEntryEpoch: number | null,
+    auditRecordId: string,
+    revisions: Array<{ fieldId: string; before: unknown; after: unknown }>,
+  ): Promise<void> {
+    for (const revision of revisions) {
+      await client.query(
+        `INSERT INTO approval_form_field_revisions
+         (instance_id, node_key, field_id, before_value, after_value, actor_id, node_entry_epoch, audit_record_id)
+         VALUES ($1, $2, $3, $4::jsonb, $5::jsonb, $6, $7, $8)`,
+        [
+          instanceId,
+          nodeKey,
+          revision.fieldId,
+          revision.before === undefined ? null : JSON.stringify(revision.before),
+          revision.after === undefined ? null : JSON.stringify(revision.after),
+          actorId,
+          nodeEntryEpoch,
+          auditRecordId,
+        ],
+      )
+    }
+  }
+
+  /**
+   * Lock-7 OD-L7-7 / G-8 — the mask-aware revision read surface. Before/after VALUES live here (never
+   * on the broadly-scoped audit/history surface), and a field currently `hidden` at the instance's
+   * active node(s) has its before/after REDACTED (fail-closed), so a hidden field's value cannot leak
+   * through the revision surface either. WHO may call this at all (instance-detail read scope) is the
+   * OPEN owner question D-5 — Lock-7 deliberately does NOT settle it and adds no HTTP route here; the
+   * `actor` parameter is reserved for a later actor-scoped read once D-5 resolves.
+   */
+  async getFormFieldRevisions(
+    instanceId: string,
+    _actor?: { userId: string; roles?: string[] } | null,
+  ): Promise<Array<{ id: string; nodeKey: string; fieldId: string; before: unknown; after: unknown; actorId: string; nodeEntryEpoch: number | null; auditRecordId: string; redacted: boolean }>> {
+    if (!pool) throw new Error('Database not available')
+    const instanceResult = await pool.query<{ current_node_key: string | null; metadata: Record<string, unknown> | null; published_definition_id: string | null }>(
+      `SELECT current_node_key, metadata, published_definition_id FROM approval_instances WHERE id = $1`,
+      [instanceId],
+    )
+    const instance = instanceResult.rows[0]
+    let hiddenFieldIds = new Set<string>()
+    if (instance?.published_definition_id) {
+      const runtimeResult = await pool.query<{ runtime_graph: Record<string, unknown> }>(
+        `SELECT runtime_graph FROM approval_published_definitions WHERE id = $1`,
+        [instance.published_definition_id],
+      )
+      const runtimeGraph = runtimeResult.rows[0]?.runtime_graph
+      if (runtimeGraph) {
+        hiddenFieldIds = collectHiddenFieldIds(
+          runtimeGraph as unknown as { nodes?: Array<{ key?: unknown; type?: unknown; config?: unknown } | null> },
+          collectActiveNodeKeys(instance.current_node_key, instance.metadata),
+        )
+      }
+    }
+    const revisionsResult = await pool.query<{
+      id: string | number
+      node_key: string
+      field_id: string
+      before_value: unknown
+      after_value: unknown
+      actor_id: string
+      node_entry_epoch: number | null
+      audit_record_id: string | number
+    }>(
+      `SELECT id, node_key, field_id, before_value, after_value, actor_id, node_entry_epoch, audit_record_id
+         FROM approval_form_field_revisions
+        WHERE instance_id = $1
+        ORDER BY id ASC`,
+      [instanceId],
+    )
+    return revisionsResult.rows.map((row) => {
+      const redacted = hiddenFieldIds.has(row.field_id)
+      return {
+        id: String(row.id),
+        nodeKey: row.node_key,
+        fieldId: row.field_id,
+        before: redacted ? null : row.before_value,
+        after: redacted ? null : row.after_value,
+        actorId: row.actor_id,
+        nodeEntryEpoch: row.node_entry_epoch,
+        auditRecordId: String(row.audit_record_id),
+        redacted,
+      }
+    })
+  }
+
+  // Returns the inserted `approval_records.id` (decimal string). Lock-7 OD-L7-6(a) needs the `handle`
+  // row's id as the per-field revision rows' `audit_record_id` (the 内容变更 dedup ordinal, G-16) —
+  // callers that ignore the return value are unaffected (pure widening; RETURNING adds no round-trip).
   private async insertApprovalRecord(
     client: { query: typeof pool.query },
     instanceId: string,
     record: ApprovalRecordInsert,
     actor?: { ip?: string | null; userAgent?: string | null },
-  ): Promise<void> {
-    await client.query(
+  ): Promise<string> {
+    const result = await client.query<{ id: string | number }>(
       `INSERT INTO approval_records
        (instance_id, action, actor_id, actor_name, comment, from_status, to_status, from_version, to_version, metadata, target_user_id, ip_address, user_agent)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)`,
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
+       RETURNING id`,
       [
         instanceId,
         record.action,
@@ -8818,6 +9224,12 @@ export class ApprovalProductService {
         actor?.userAgent || null,
       ],
     )
+    // Production: `RETURNING id` on a successful single-row INSERT always yields exactly one row, so
+    // this is the `handle` row's id (the revision rows' audit_record_id, OD-L7-6(a)). The `?? ''`
+    // guard covers ONLY unit mocks whose fake query returns an empty `rows` for this INSERT — those
+    // paths never insert revision rows (no field writes), so the empty id is never consumed.
+    const insertedId = result?.rows?.[0]?.id
+    return insertedId != null ? String(insertedId) : ''
   }
 }
 

--- a/packages/core-backend/src/services/approval-bridge-types.ts
+++ b/packages/core-backend/src/services/approval-bridge-types.ts
@@ -7,7 +7,7 @@
 
 import type { QueryResult } from '../data-adapters/BaseAdapter'
 import type { ApprovalHistoryEntry, ApprovalRequest } from '../data-adapters/PLMAdapter'
-import type { ApprovalNodeType, FormSchema } from '../types/approval-product'
+import type { ApprovalNodeType, FormSchema, NodeFieldAccess } from '../types/approval-product'
 
 // ── Unified Approval DTO (API response shape) ──
 
@@ -38,6 +38,16 @@ export interface UnifiedApprovalDTO {
    * reads it to withhold approve/reject on a 办理 (handler) task. Absent ≡ not-a-handler.
    */
   currentNodeType?: ApprovalNodeType | null
+  /**
+   * Lock-7 OD-L7-10 — the ACTOR-SCOPED per-field access map for THIS viewer at their claimed
+   * seat(s): fieldId → one NodeFieldAccess value. Present ONLY on the DETAIL read
+   * (`getApproval`) — the list DTO stays byte-identical. Derived from the SAME
+   * `resolveFieldAccessAtNodes` the write mask uses, so a field reported `editable` here is exactly a
+   * field the write path accepts (never over-reports: a seatless / role-only viewer gets no map, and
+   * multi-seat is most-restrictive). Absent from the map ≡ `editable` (OD-L7-9). The FE grid uses it
+   * to render `readonly` fields read-only; it is presentation only — enforcement is server-side.
+   */
+  fieldAccess?: Record<string, NodeFieldAccess> | null
   /**
    * Parallel gateway (并行分支) — populated only when the instance is in a
    * parallel region (length ≥ 2). Absent on linear state; callers that don't

--- a/packages/core-backend/src/services/approval-form-redaction.ts
+++ b/packages/core-backend/src/services/approval-form-redaction.ts
@@ -1,4 +1,12 @@
-import type { NodeFieldPermission } from '../types/approval-product'
+import type { NodeFieldAccess, NodeFieldPermission } from '../types/approval-product'
+
+// Lock-7 L7-A — most-restrictive-wins ordering across nodes: hidden ≻ readonly ≻ editable.
+// Higher rank is more restrictive. Absent from the matrix ≡ `editable` (OD-L7-9, rank 0).
+const NODE_FIELD_ACCESS_RANK: Record<NodeFieldAccess, number> = {
+  editable: 0,
+  readonly: 1,
+  hidden: 2,
+}
 
 /**
  * Structurally-minimal view of a stored runtime graph for redaction purposes.
@@ -46,28 +54,78 @@ export interface RedactableRuntimeGraph {
  * snapshot and the byte path can never drift on what "hidden" means (no separate hidden decision).
  * Pure, allocation-cheap (empty Set on any degenerate input), never throws.
  */
+/**
+ * Lock-7 L7-A / OD-L7-5 — the SINGLE derivation of "this actor's / this instance's access to a
+ * field", over the given node set. Returns a `Map<fieldId, NodeFieldAccess>` holding, per field, the
+ * MOST-RESTRICTIVE access across every supplied node (`hidden` ≻ `readonly` ≻ `editable`). A field
+ * ABSENT from the returned map ≡ `editable` (OD-L7-9, legacy default). Pure, allocation-cheap on
+ * degenerate input, never throws.
+ *
+ * Three consumers, each supplying its own node set (L7-A table): the snapshot echo and attachment
+ * byte gate pass the INSTANCE-active node set (precedence preserved, read behaviour byte-identical);
+ * the NEW write mask passes exactly `[nodeKey]` — the actor's single claimed seat — where precedence
+ * is unobservable (one element) and only the absent-key default and the per-field access matter.
+ * Re-expressing `collectHiddenFieldIds` over THIS function is what keeps the three consumers from
+ * drifting on what "hidden" means (L7-A; G-1a asserts a single-node mutation reds all three).
+ */
+export function resolveFieldAccessAtNodes(
+  runtimeGraph: RedactableRuntimeGraph | null,
+  nodeKeys: ReadonlyArray<string | null | undefined>,
+): Map<string, NodeFieldAccess> {
+  const access = new Map<string, NodeFieldAccess>()
+  if (!runtimeGraph || !Array.isArray(runtimeGraph.nodes) || runtimeGraph.nodes.length === 0) {
+    return access
+  }
+  const targetKeys = new Set(
+    nodeKeys.filter((key): key is string => typeof key === 'string' && key.length > 0),
+  )
+  if (targetKeys.size === 0) return access
+
+  for (const node of runtimeGraph.nodes) {
+    if (!node || typeof node.key !== 'string' || !targetKeys.has(node.key)) continue
+    const permissions = (node.config as { fieldPermissions?: NodeFieldPermission[] } | undefined)?.fieldPermissions
+    if (!Array.isArray(permissions)) continue
+    for (const permission of permissions) {
+      if (!permission || typeof permission.fieldId !== 'string') continue
+      const candidate = permission.access
+      if (candidate !== 'editable' && candidate !== 'readonly' && candidate !== 'hidden') continue
+      const existing = access.get(permission.fieldId)
+      // Most-restrictive-wins: keep the higher rank. First-seen wins ties (identical rank).
+      if (existing === undefined || NODE_FIELD_ACCESS_RANK[candidate] > NODE_FIELD_ACCESS_RANK[existing]) {
+        access.set(permission.fieldId, candidate)
+      }
+    }
+  }
+  return access
+}
+
+/**
+ * Lock-7 L7-A — resolve one field's effective access at the given node set, defaulting ABSENT ≡
+ * `editable` (OD-L7-9). This is the write consumer's single read point (`[nodeKey]`) so the write
+ * mask and the read-DTO access map (OD-L7-10) never disagree — both go through this function.
+ */
+export function fieldAccessAtNodes(
+  runtimeGraph: RedactableRuntimeGraph | null,
+  nodeKeys: ReadonlyArray<string | null | undefined>,
+  fieldId: string,
+): NodeFieldAccess {
+  return resolveFieldAccessAtNodes(runtimeGraph, nodeKeys).get(fieldId) ?? 'editable'
+}
+
+/**
+ * The set of field ids the active node(s) mark `access: 'hidden'` — now DERIVED over
+ * `resolveFieldAccessAtNodes` (L7-A R-5) rather than a second traversal, so the hidden axis stays
+ * byte-identical to the shipped union while the snapshot echo, the attachment byte gate and the
+ * write mask all read one matrix. Byte-identical because most-restrictive-wins reduces to "hidden at
+ * ANY active node ⇒ hidden", which is exactly the prior union.
+ */
 export function collectHiddenFieldIds(
   runtimeGraph: RedactableRuntimeGraph | null,
   activeNodeKeys: ReadonlyArray<string | null | undefined>,
 ): Set<string> {
   const hiddenFieldIds = new Set<string>()
-  if (!runtimeGraph || !Array.isArray(runtimeGraph.nodes) || runtimeGraph.nodes.length === 0) {
-    return hiddenFieldIds
-  }
-  const activeKeys = new Set(
-    activeNodeKeys.filter((key): key is string => typeof key === 'string' && key.length > 0),
-  )
-  if (activeKeys.size === 0) return hiddenFieldIds
-
-  for (const node of runtimeGraph.nodes) {
-    if (!node || typeof node.key !== 'string' || !activeKeys.has(node.key)) continue
-    const permissions = (node.config as { fieldPermissions?: NodeFieldPermission[] } | undefined)?.fieldPermissions
-    if (!Array.isArray(permissions)) continue
-    for (const permission of permissions) {
-      if (permission && permission.access === 'hidden' && typeof permission.fieldId === 'string') {
-        hiddenFieldIds.add(permission.fieldId)
-      }
-    }
+  for (const [fieldId, access] of resolveFieldAccessAtNodes(runtimeGraph, activeNodeKeys)) {
+    if (access === 'hidden') hiddenFieldIds.add(fieldId)
   }
   return hiddenFieldIds
 }

--- a/packages/core-backend/src/types/approval-product.ts
+++ b/packages/core-backend/src/types/approval-product.ts
@@ -610,12 +610,13 @@ export interface ApprovalActionRequest {
    */
   targetAssignmentUserId?: string
   /**
-   * Lock-3 §3 — RESERVED field-write channel for a handler `handle` submission. The Lock-7
-   * field-edit-enforcement slice will own which fields are writable and the apply transaction; UNTIL
-   * then a `handle` request carrying this key (non-empty, `{}`, or `null`) is rejected with a
-   * values-free 422 `APPROVAL_HANDLER_FIELD_WRITES_UNSUPPORTED` before any row is written. Reserving it
-   * now makes the rejection testable (G-9) and makes Lock-7 a widening rather than a rename. Detected by
-   * key PRESENCE (`'fieldWrites' in request`), so an explicit `null`/`{}` is still caught.
+   * Lock-3 §3 / Lock-7 L7-C — the field-write channel for a handler `handle` submission. Lock-7 P4-B
+   * lands the write: a plain object `{ fieldId: value }` is applied under the actor's single-node mask
+   * (`editable` writes; `readonly`/`hidden`/unknown/detail-sub-column refuse values-free), validated
+   * against the FROZEN version schema, then UPDATEs `form_snapshot` in place inside the handle
+   * transaction plus append-only revision rows (OD-L7-6). `{}` is an accepted zero-write no-op;
+   * `null` / a non-object is a values-free 400 `APPROVAL_FIELD_WRITE_PAYLOAD_INVALID`. Meaningful only
+   * on `handle` — present on any other action it is a values-free 400. Detected by key PRESENCE.
    */
   fieldWrites?: unknown
 }

--- a/packages/core-backend/tests/helpers/approval-schema-bootstrap.ts
+++ b/packages/core-backend/tests/helpers/approval-schema-bootstrap.ts
@@ -5,7 +5,7 @@ const APPROVAL_SCHEMA_BOOTSTRAP_KEY = 'approval-schema-bootstrap'
 // idempotent DDL. The current bump adds Lock-3's `handle` action to the approval_records CHECK so the
 // handler-node real-DB suite's audit INSERT is accepted (matches the production migration
 // zzzz20260817120000_add_handle_action_to_approval_records).
-const APPROVAL_SCHEMA_BOOTSTRAP_VERSION = '20260817-handler-node-handle-action'
+const APPROVAL_SCHEMA_BOOTSTRAP_VERSION = '20260817-field-edit-enforcement-revisions'
 
 /**
  * Ensures the approval schema (tables, constraints, indexes, sequences) is
@@ -420,6 +420,25 @@ export async function ensureApprovalSchemaReady(): Promise<void> {
         END IF;
       END $$;
     `)
+
+    // Lock-7 OD-L7-6(a) — the append-only per-field revision ledger (matches production migration
+    // zzzz20260817130000_create_approval_form_field_revisions). Before/after VALUES live here (behind
+    // the mask-aware read), and MAX(audit_record_id) is the 内容变更 dedup ordinal (G-16).
+    await client.query(`
+      CREATE TABLE IF NOT EXISTS approval_form_field_revisions (
+        id BIGSERIAL PRIMARY KEY,
+        instance_id TEXT NOT NULL,
+        node_key TEXT NOT NULL,
+        field_id TEXT NOT NULL,
+        before_value JSONB,
+        after_value JSONB,
+        actor_id TEXT NOT NULL,
+        node_entry_epoch INTEGER,
+        audit_record_id BIGINT NOT NULL,
+        created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+      )
+    `)
+    await client.query(`CREATE INDEX IF NOT EXISTS idx_approval_form_field_revisions_instance ON approval_form_field_revisions(instance_id, id)`)
 
     await client.query(
       `INSERT INTO approval_test_schema_bootstrap_state (key, version, completed_at)

--- a/packages/core-backend/tests/integration/approval-field-edit-enforcement.db.test.ts
+++ b/packages/core-backend/tests/integration/approval-field-edit-enforcement.db.test.ts
@@ -1,0 +1,812 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import net from 'net'
+import { MetaSheetServer } from '../../src/index'
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { ApprovalProductService } from '../../src/services/ApprovalProductService'
+import { ensureApprovalSchemaReady, grantApprovalWriteForIntegrationActor } from '../helpers/approval-schema-bootstrap'
+
+/**
+ * Lock-7 (docs/development/approval-lock7-field-edit-enforcement-20260817.md) — per-node form field
+ * EDIT / visibility enforcement, REAL-DB end-to-end acceptance. Harness mirrors
+ * approval-handler-node.db.test.ts (Lock-3's suite). This is P4-B: the handler write surface that
+ * P4-A left returning a values-free 422 now performs the masked, frozen-schema-validated write.
+ *
+ * Gates covered here (behaviourally testable end-to-end): G-3 write mask actor-node-scoped, G-4
+ * routing-driver-never-editable (+ the hazard-real assertion), G-5 unfillable required×hidden, G-6
+ * frozen validators (+ MS-3 disclosure), G-7 transaction atomicity, G-8 audit values-free + mask-aware
+ * revision read, G-9 in-flight re-normalize, G-10 round-trip/restore, G-11 legacy default, G-12
+ * non-approval node types, G-15 direct-HTTP bypass matrix, G-16 内容变更 dedup invalidation (+ epoch
+ * unchanged), G-17 immutability-reader re-examination. Every absence assertion carries a positive
+ * control (§3).
+ *
+ * NOT here (covered elsewhere): G-1a/G-1b/G-2 derivation = approval-form-redaction.test.ts unit; G-13
+ * readonly-copy retirement = FE specs; G-14 enum mirror = approval-field-access-enum-mirror.test.ts.
+ */
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const TS = Date.now()
+const REQ = `fee-req-${TS}`
+const GATE = `fee-gate-${TS}` // approval node before the handler (approves as this actor)
+const HANDLER = `fee-h-${TS}` // handler seat (single)
+const HANDLER2 = `fee-h2-${TS}` // handler seat 2 (会签)
+const FINAL = `fee-final-${TS}` // approval node after the handler
+const KEYPFX = `fee-${TS}`
+
+async function canListen(): Promise<boolean> {
+  return await new Promise((r) => {
+    const s = net.createServer()
+    s.once('error', () => r(false))
+    s.listen(0, '127.0.0.1', () => s.close(() => r(true)))
+  })
+}
+async function tok(base: string, userId: string): Promise<string> {
+  await grantApprovalWriteForIntegrationActor(userId)
+  const res = await fetch(`${base}/api/auth/dev-token?userId=${encodeURIComponent(userId)}&roles=admin&perms=${encodeURIComponent('*:*')}`)
+  return ((await res.json()) as { token: string }).token
+}
+async function req(base: string, path: string, token: string, opts: { method?: string; body?: unknown } = {}): Promise<Response> {
+  return fetch(`${base}${path}`, {
+    method: opts.method || 'GET',
+    headers: { Authorization: `Bearer ${token}`, ...(opts.body !== undefined ? { 'Content-Type': 'application/json' } : {}) },
+    ...(opts.body !== undefined ? { body: JSON.stringify(opts.body) } : {}),
+  })
+}
+
+// Rich schema: `reason` required-always-visible (filled at create); `amount` number; `memo` text;
+// `secret` text (used as a hidden field); `pick` user (form_field_user driver); `route_num` number
+// (ConditionRule driver); `formula_num` number (condition-formula driver); `req_cond` required text
+// with a visibilityRule (create-hideable → the G-5 unfillable candidate).
+const FORM_SCHEMA = {
+  fields: [
+    { id: 'reason', type: 'text', label: 'reason', required: true },
+    { id: 'amount', type: 'number', label: 'amount' },
+    { id: 'memo', type: 'text', label: 'memo' },
+    { id: 'secret', type: 'text', label: 'secret' },
+    { id: 'pick', type: 'user', label: 'pick' },
+    { id: 'route_num', type: 'number', label: 'route_num' },
+    { id: 'formula_num', type: 'number', label: 'formula_num' },
+    { id: 'req_cond', type: 'text', label: 'req_cond', required: true, visibilityRule: { fieldId: 'amount', operator: 'eq', value: 100 } },
+  ],
+}
+
+function staticUser(userIds: string[]) {
+  return [{ kind: 'static_user', userIds }]
+}
+
+type NodeFieldPermission = { fieldId: string; access: 'editable' | 'readonly' | 'hidden' }
+
+// start → handler(HANDLER, fieldPermissions) → approval(FINAL) → end. The default handler roster is a
+// single seat so the handler completes on one submission.
+function handlerGraph(handlerFieldPermissions: NodeFieldPermission[], handlerConfig: Record<string, unknown> = {}) {
+  return {
+    nodes: [
+      { key: 'start', type: 'start', name: 's', config: {} },
+      { key: 'handler_h', type: 'handler', name: '办理', config: { assigneeSources: staticUser([HANDLER]), ...handlerConfig, ...(handlerFieldPermissions.length > 0 ? { fieldPermissions: handlerFieldPermissions } : {}) } },
+      { key: 'approval_final', type: 'approval', name: 'final', config: { assigneeSources: staticUser([FINAL]), approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+      { key: 'end', type: 'end', name: 'e', config: {} },
+    ],
+    edges: [
+      { key: 's2h', source: 'start', target: 'handler_h' },
+      { key: 'h2f', source: 'handler_h', target: 'approval_final' },
+      { key: 'f2e', source: 'approval_final', target: 'end' },
+    ],
+  }
+}
+
+type ErrorBody = { code?: string; error?: { code?: string; message?: string; details?: Record<string, unknown> } }
+function errorCode(body: ErrorBody): string | undefined {
+  return body.code ?? body.error?.code
+}
+
+// ── Anti-skip-green sentinel (mirrors approval-realdb-handler) ────────────────────────────────────
+const itIfExpectDb = process.env.EXPECT_DB === '1' ? it : it.skip
+itIfExpectDb('sentinel: EXPECT_DB lane must have DATABASE_URL (a DB-expected run must never skip-green)', () => {
+  expect(process.env.DATABASE_URL).toBeTruthy()
+})
+
+describeIfDatabase('Lock-7 field-edit enforcement — real-DB acceptance', () => {
+  let server: MetaSheetServer | undefined
+  let base = ''
+  let reqTok = ''
+  let handlerTok = ''
+  let handler2Tok = ''
+  let finalTok = ''
+  let gateTok = ''
+  const service = new ApprovalProductService()
+
+  async function createTemplate(key: string, graph: unknown, schema: unknown = FORM_SCHEMA): Promise<Response> {
+    return req(base, '/api/approval-templates', reqTok, {
+      method: 'POST',
+      body: { key, name: key, formSchema: schema, approvalGraph: graph },
+    })
+  }
+  async function createTemplateId(key: string, graph: unknown, schema: unknown = FORM_SCHEMA): Promise<string> {
+    const created = await createTemplate(key, graph, schema)
+    expect(created.status, await created.clone().text()).toBe(201)
+    return ((await created.json()) as { id: string }).id
+  }
+  async function publishTemplate(tid: string, policy: Record<string, unknown> = { allowRevoke: true }): Promise<Response> {
+    return req(base, `/api/approval-templates/${tid}/publish`, reqTok, { method: 'POST', body: { policy } })
+  }
+  async function createPublished(key: string, graph: unknown, policy?: Record<string, unknown>): Promise<string> {
+    const tid = await createTemplateId(key, graph)
+    const published = await publishTemplate(tid, policy)
+    expect(published.status, await published.clone().text()).toBe(200)
+    return tid
+  }
+  async function createInstance(tid: string, formData: Record<string, unknown> = { reason: 'r' }): Promise<string> {
+    const ok = await req(base, '/api/approvals', reqTok, { method: 'POST', body: { templateId: tid, formData } })
+    expect(ok.status, await ok.clone().text()).toBe(201)
+    return ((await ok.json()) as { id: string }).id
+  }
+  async function act(iid: string, token: string, body: Record<string, unknown>): Promise<Response> {
+    return req(base, `/api/approvals/${iid}/actions`, token, { method: 'POST', body })
+  }
+  async function instanceRow(iid: string): Promise<{ status: string; current_node_key: string | null; version: number; form_snapshot: Record<string, unknown> | null }> {
+    const pool = poolManager.get()
+    const rows = await pool.query(`SELECT status, current_node_key, version, form_snapshot FROM approval_instances WHERE id = $1`, [iid])
+    return rows.rows[0] as { status: string; current_node_key: string | null; version: number; form_snapshot: Record<string, unknown> | null }
+  }
+  async function records(iid: string, action?: string): Promise<Array<{ action: string; actor_id: string | null; metadata: Record<string, unknown> | null }>> {
+    const pool = poolManager.get()
+    const rows = action
+      ? await pool.query(`SELECT action, actor_id, metadata FROM approval_records WHERE instance_id = $1 AND action = $2 ORDER BY id ASC`, [iid, action])
+      : await pool.query(`SELECT action, actor_id, metadata FROM approval_records WHERE instance_id = $1 ORDER BY id ASC`, [iid])
+    return rows.rows as Array<{ action: string; actor_id: string | null; metadata: Record<string, unknown> | null }>
+  }
+  async function revisionRows(iid: string): Promise<Array<{ field_id: string; before_value: unknown; after_value: unknown; node_key: string; actor_id: string; audit_record_id: string; node_entry_epoch: number | null }>> {
+    const pool = poolManager.get()
+    const rows = await pool.query(
+      `SELECT field_id, before_value, after_value, node_key, actor_id, audit_record_id::text AS audit_record_id, node_entry_epoch FROM approval_form_field_revisions WHERE instance_id = $1 ORDER BY id ASC`,
+      [iid],
+    )
+    return rows.rows as Array<{ field_id: string; before_value: unknown; after_value: unknown; node_key: string; actor_id: string; audit_record_id: string; node_entry_epoch: number | null }>
+  }
+  async function activeSeats(iid: string): Promise<Array<{ assignee_id: string; node_key: string | null; entry_epoch: number | string | null }>> {
+    const pool = poolManager.get()
+    const rows = await pool.query(`SELECT assignee_id, node_key, entry_epoch FROM approval_assignments WHERE instance_id = $1 AND is_active = TRUE ORDER BY assignee_id`, [iid])
+    return rows.rows as Array<{ assignee_id: string; node_key: string | null; entry_epoch: number | string | null }>
+  }
+
+  beforeAll(async () => {
+    expect(await canListen()).toBe(true)
+    await ensureApprovalSchemaReady()
+    const pool = poolManager.get()
+    await pool.query(`ALTER TABLE users ADD COLUMN IF NOT EXISTS is_active boolean NOT NULL DEFAULT true`)
+    for (const userId of [REQ, GATE, HANDLER, HANDLER2, FINAL]) {
+      await pool.query(`INSERT INTO users (id, email, password_hash, is_active) VALUES ($1, $2, 'x', TRUE) ON CONFLICT (id) DO NOTHING`, [userId, `${userId}@x.test`])
+    }
+    server = new MetaSheetServer({ port: 0, host: '127.0.0.1', pluginDirs: [] })
+    await server.start()
+    base = `http://127.0.0.1:${server.getAddress()!.port}`
+    reqTok = await tok(base, REQ)
+    handlerTok = await tok(base, HANDLER)
+    handler2Tok = await tok(base, HANDLER2)
+    finalTok = await tok(base, FINAL)
+    gateTok = await tok(base, GATE)
+  })
+
+  afterAll(async () => {
+    try {
+      const pool = poolManager.get()
+      const tids = (await pool.query(`SELECT id FROM approval_templates WHERE key LIKE $1`, [`${KEYPFX}-%`])).rows.map((r) => r.id as string)
+      if (tids.length > 0) {
+        const iids = (await pool.query(`SELECT id FROM approval_instances WHERE template_id = ANY($1::uuid[])`, [tids])).rows.map((r) => r.id as string)
+        if (iids.length > 0) {
+          await pool.query(`DELETE FROM approval_form_field_revisions WHERE instance_id = ANY($1)`, [iids])
+          await pool.query(`DELETE FROM approval_records WHERE instance_id = ANY($1)`, [iids])
+          await pool.query(`DELETE FROM approval_assignments WHERE instance_id = ANY($1)`, [iids])
+          await pool.query(`DELETE FROM approval_instances WHERE id = ANY($1)`, [iids])
+        }
+        await pool.query(`DELETE FROM approval_published_definitions WHERE template_id = ANY($1::uuid[])`, [tids])
+        await pool.query(`DELETE FROM approval_templates WHERE id = ANY($1::uuid[])`, [tids])
+      }
+      await pool.query(`DELETE FROM users WHERE id = ANY($1::varchar[])`, [[REQ, GATE, HANDLER, HANDLER2, FINAL]])
+    } catch {
+      /* best effort */
+    }
+    if (server) await server.stop()
+  })
+
+  // ── G-11 — legacy default: no fieldPermissions behaves byte-identically ───────────────────────
+  it('G-11: a handler with NO fieldPermissions accepts a field write to a NON-driver field (absent ≡ editable); a hidden matrix DIVERGES in the same fixture', async () => {
+    // Positive default: no matrix → memo (a NON-driver field) is editable → written. A DRIVER field is
+    // refused by the runtime driver guard even with no matrix (covered by "G-4 (runtime driver guard)").
+    // Positive default: no matrix → memo is editable → written.
+    const tidDefault = await createPublished(`${KEYPFX}-g11-default`, handlerGraph([]))
+    const iidDefault = await createInstance(tidDefault)
+    const okWrite = await act(iidDefault, handlerTok, { action: 'handle', fieldWrites: { memo: 'edited-by-default' } })
+    expect(okWrite.status, await okWrite.clone().text()).toBe(200)
+    expect((await instanceRow(iidDefault)).form_snapshot?.memo).toBe('edited-by-default')
+
+    // Divergence: same field, hidden matrix → write refused (absent-≡-editable is default-selected).
+    const tidHidden = await createPublished(`${KEYPFX}-g11-hidden`, handlerGraph([{ fieldId: 'memo', access: 'hidden' }]))
+    const iidHidden = await createInstance(tidHidden)
+    const refused = await act(iidHidden, handlerTok, { action: 'handle', fieldWrites: { memo: 'x' } })
+    expect(refused.status).toBe(403)
+    expect(errorCode((await refused.json()) as ErrorBody)).toBe('APPROVAL_FIELD_WRITE_FORBIDDEN')
+  })
+
+  // ── G-3 — write mask is ACTOR-NODE-scoped ─────────────────────────────────────────────────────
+  it('G-3: a field readonly at the actor node is refused even though editable at another node; editable at the actor node is written even though hidden elsewhere; the mirror inverts both', async () => {
+    // Two sequential handlers. handler_A: memo readonly, amount editable. handler_B: memo editable, amount hidden.
+    const twoHandlers = {
+      nodes: [
+        { key: 'start', type: 'start', name: 's', config: {} },
+        { key: 'handler_A', type: 'handler', name: 'A', config: { assigneeSources: staticUser([HANDLER]), fieldPermissions: [{ fieldId: 'memo', access: 'readonly' }, { fieldId: 'amount', access: 'editable' }] } },
+        { key: 'handler_B', type: 'handler', name: 'B', config: { assigneeSources: staticUser([HANDLER2]), fieldPermissions: [{ fieldId: 'memo', access: 'editable' }, { fieldId: 'amount', access: 'hidden' }] } },
+        { key: 'approval_final', type: 'approval', name: 'f', config: { assigneeSources: staticUser([FINAL]), approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+        { key: 'end', type: 'end', name: 'e', config: {} },
+      ],
+      edges: [
+        { key: 's2a', source: 'start', target: 'handler_A' },
+        { key: 'a2b', source: 'handler_A', target: 'handler_B' },
+        { key: 'b2f', source: 'handler_B', target: 'approval_final' },
+        { key: 'f2e', source: 'approval_final', target: 'end' },
+      ],
+    }
+    const tid = await createPublished(`${KEYPFX}-g3`, twoHandlers)
+    const iid = await createInstance(tid)
+    // At handler_A: memo is readonly HERE (editable at B) → refused; amount is editable HERE → written.
+    const refuseMemo = await act(iid, handlerTok, { action: 'handle', fieldWrites: { memo: 'nope' } })
+    expect(refuseMemo.status).toBe(403)
+    expect(errorCode((await refuseMemo.json()) as ErrorBody)).toBe('APPROVAL_FIELD_WRITE_FORBIDDEN')
+    const writeAmount = await act(iid, handlerTok, { action: 'handle', fieldWrites: { amount: 42 } })
+    expect(writeAmount.status, await writeAmount.clone().text()).toBe(200)
+    expect((await instanceRow(iid)).form_snapshot?.amount).toBe(42)
+    // Mirror at handler_B: amount hidden HERE (editable at A) → refused; memo editable HERE → written.
+    const refuseAmount = await act(iid, handler2Tok, { action: 'handle', fieldWrites: { amount: 99 } })
+    expect(refuseAmount.status).toBe(403)
+    const writeMemo = await act(iid, handler2Tok, { action: 'handle', fieldWrites: { memo: 'ok-at-B' } })
+    expect(writeMemo.status, await writeMemo.clone().text()).toBe(200)
+    expect((await instanceRow(iid)).form_snapshot?.memo).toBe('ok-at-B')
+  })
+
+  // ── G-15 — direct-HTTP bypass matrix (each refusal reason 4xx, values-free, zero rows) ────────
+  it('G-15: each write-refusal reason is a values-free 4xx with zero rows; one compliant call succeeds in the same fixture; legacy approve carries no field payload', async () => {
+    const tid = await createPublished(`${KEYPFX}-g15`, handlerGraph([
+      { fieldId: 'memo', access: 'editable' },
+      { fieldId: 'secret', access: 'hidden' },
+      { fieldId: 'amount', access: 'readonly' },
+    ]))
+    // no-active-seat: FINAL is not seated at the handler → 403 (assignment required)
+    const iidSeat = await createInstance(tid)
+    const noSeat = await act(iidSeat, finalTok, { action: 'handle', fieldWrites: { memo: 'x' } })
+    expect(noSeat.status).toBe(403)
+
+    const reasons: Array<{ label: string; body: Record<string, unknown>; code: string; httpStatus: number }> = [
+      { label: 'readonly', body: { action: 'handle', fieldWrites: { amount: 1 } }, code: 'APPROVAL_FIELD_WRITE_FORBIDDEN', httpStatus: 403 },
+      { label: 'hidden', body: { action: 'handle', fieldWrites: { secret: 's' } }, code: 'APPROVAL_FIELD_WRITE_FORBIDDEN', httpStatus: 403 },
+      { label: 'unknown-field', body: { action: 'handle', fieldWrites: { nope_field: 'x' } }, code: 'APPROVAL_FIELD_WRITE_UNKNOWN_FIELD', httpStatus: 400 },
+      { label: 'detail-subcolumn-address', body: { action: 'handle', fieldWrites: { 'memo.sub': 'x' } }, code: 'APPROVAL_FIELD_WRITE_UNKNOWN_FIELD', httpStatus: 400 },
+      { label: 'payload-not-object', body: { action: 'handle', fieldWrites: [1, 2] }, code: 'APPROVAL_FIELD_WRITE_PAYLOAD_INVALID', httpStatus: 400 },
+      { label: 'payload-null', body: { action: 'handle', fieldWrites: null }, code: 'APPROVAL_FIELD_WRITE_PAYLOAD_INVALID', httpStatus: 400 },
+    ]
+    for (const { label, body, code, httpStatus } of reasons) {
+      const iid = await createInstance(tid)
+      const res = await act(iid, handlerTok, body)
+      expect(res.status, `${label}: ${await res.clone().text()}`).toBe(httpStatus)
+      const errBody = (await res.json()) as ErrorBody
+      expect(errorCode(errBody), label).toBe(code)
+      // values-free: the error details never carry a submitted VALUE.
+      const detailsStr = JSON.stringify(errBody.error?.details ?? {})
+      expect(detailsStr.includes('nope_field') || label !== 'unknown-field').toBe(true) // fieldId is a schema id, allowed
+      expect(detailsStr).not.toContain('"x"')
+      expect(detailsStr).not.toContain('"s"')
+      // zero rows: no revision row, still at the handler, no handle audit row.
+      expect(await revisionRows(iid)).toHaveLength(0)
+      expect((await instanceRow(iid)).current_node_key).toBe('handler_h')
+      expect(await records(iid, 'handle')).toHaveLength(0)
+    }
+
+    // Positive control: a fully-compliant call succeeds in the same fixture (refusal is reason-selected).
+    const iidOk = await createInstance(tid)
+    const ok = await act(iidOk, handlerTok, { action: 'handle', fieldWrites: { memo: 'compliant' } })
+    expect(ok.status, await ok.clone().text()).toBe(200)
+    expect((await instanceRow(iidOk)).form_snapshot?.memo).toBe('compliant')
+
+    // Legacy approve carries NO field payload: fieldWrites on a non-handle action is a values-free 400.
+    const tidApprove = await createPublished(`${KEYPFX}-g15-approve`, {
+      nodes: [
+        { key: 'start', type: 'start', name: 's', config: {} },
+        { key: 'approval_x', type: 'approval', name: 'x', config: { assigneeSources: staticUser([GATE]), approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+        { key: 'end', type: 'end', name: 'e', config: {} },
+      ],
+      edges: [{ key: 's2x', source: 'start', target: 'approval_x' }, { key: 'x2e', source: 'approval_x', target: 'end' }],
+    })
+    const iidApprove = await createInstance(tidApprove)
+    const approveWithWrites = await act(iidApprove, gateTok, { action: 'approve', fieldWrites: { memo: 'x' } })
+    expect(approveWithWrites.status).toBe(400)
+    expect(errorCode((await approveWithWrites.json()) as ErrorBody)).toBe('APPROVAL_FIELD_WRITE_ACTION_NOT_ALLOWED')
+  })
+
+  // ── G-6 — writes re-run the FROZEN validators; MS-3 fail-open is disclosed ─────────────────────
+  it('G-6: a type-violating write is refused with zero rows; validation is against the PINNED version schema, not the live template', async () => {
+    const tid = await createPublished(`${KEYPFX}-g6`, handlerGraph([{ fieldId: 'amount', access: 'editable' }]))
+    const iid = await createInstance(tid)
+    // amount is a number field → a string value violates validateFieldType → refused, zero rows, no advance.
+    const bad = await act(iid, handlerTok, { action: 'handle', fieldWrites: { amount: 'not-a-number' } })
+    expect(bad.status).toBe(400)
+    expect(errorCode((await bad.json()) as ErrorBody)).toBe('APPROVAL_FIELD_WRITE_INVALID')
+    expect(await revisionRows(iid)).toHaveLength(0)
+    expect((await instanceRow(iid)).current_node_key).toBe('handler_h')
+    // Positive control: a valid number is written.
+    const good = await act(iid, handlerTok, { action: 'handle', fieldWrites: { amount: 7 } })
+    expect(good.status, await good.clone().text()).toBe(200)
+    expect((await instanceRow(iid)).form_snapshot?.amount).toBe(7)
+  })
+
+  it('G-6 (frozen schema): after the live template schema changes, the write still validates against the instance\'s PINNED version', async () => {
+    const tid = await createPublished(`${KEYPFX}-g6-frozen`, handlerGraph([{ fieldId: 'amount', access: 'editable' }]))
+    const iid = await createInstance(tid)
+    // Mutate the LIVE template: retype `amount` from number to text via a new draft (does NOT re-publish
+    // → the in-flight instance keeps its pinned version). The pinned schema still says `amount` is a
+    // number, so a string write is STILL refused (proves the pinned, not live, schema governs).
+    const patched = { ...FORM_SCHEMA, fields: FORM_SCHEMA.fields.map((f) => (f.id === 'amount' ? { ...f, type: 'text' } : f)) }
+    const upd = await req(base, `/api/approval-templates/${tid}`, reqTok, { method: 'PATCH', body: { formSchema: patched } })
+    expect(upd.status, await upd.clone().text()).toBe(200)
+    const stillRefused = await act(iid, handlerTok, { action: 'handle', fieldWrites: { amount: 'now-text' } })
+    expect(stillRefused.status).toBe(400)
+    expect(errorCode((await stillRefused.json()) as ErrorBody)).toBe('APPROVAL_FIELD_WRITE_INVALID')
+  })
+
+  // ── G-7 — transaction atomicity: a mid-write refusal rolls the WHOLE transaction back ─────────
+  it('G-7: a batch write with one valid + one readonly field refuses and leaves ZERO snapshot/revision/audit/assignment change and an unchanged version; the all-valid batch changes all', async () => {
+    const tid = await createPublished(`${KEYPFX}-g7`, handlerGraph([
+      { fieldId: 'memo', access: 'editable' },
+      { fieldId: 'amount', access: 'readonly' },
+    ]))
+    const iid = await createInstance(tid)
+    const before = await instanceRow(iid)
+    const beforeSeats = await activeSeats(iid)
+    // memo (valid/editable) + amount (readonly) → the readonly refusal aborts the WHOLE thing.
+    const refused = await act(iid, handlerTok, { action: 'handle', fieldWrites: { memo: 'should-not-persist', amount: 1 } })
+    expect(refused.status).toBe(403)
+    const after = await instanceRow(iid)
+    expect(after.form_snapshot?.memo).toBeUndefined() // the valid field was NOT written (rollback)
+    expect(after.version).toBe(before.version) // version unchanged
+    expect(after.current_node_key).toBe('handler_h') // no advance
+    expect(await revisionRows(iid)).toHaveLength(0) // zero revision rows
+    expect(await records(iid, 'handle')).toHaveLength(0) // zero audit rows
+    expect(await activeSeats(iid)).toEqual(beforeSeats) // zero assignment change
+    // Positive control: the all-valid single-field batch changes snapshot + writes a revision + advances.
+    const ok = await act(iid, handlerTok, { action: 'handle', fieldWrites: { memo: 'persisted' } })
+    expect(ok.status, await ok.clone().text()).toBe(200)
+    expect((await instanceRow(iid)).form_snapshot?.memo).toBe('persisted')
+    expect(await revisionRows(iid)).toHaveLength(1)
+    expect((await records(iid, 'handle'))).toHaveLength(1)
+  })
+
+  // ── G-8 — audit is values-free but answerable; the revision surface is mask-aware ─────────────
+  it('G-8: the handle audit row carries changedFieldIds and NO value; the revision table carries before/after; the mask-aware read redacts a hidden field but returns a visible one', async () => {
+    // memo editable; secret editable at THIS handler but hidden at a later approval node → after advance
+    // the instance is no longer AT a hiding node, so the read is visible. To exercise redaction we hide
+    // `secret` at the handler where the instance PAUSES — use a two-handler graph so the second handler
+    // hides `secret` while the instance sits there after the first handler's edit.
+    const graph = {
+      nodes: [
+        { key: 'start', type: 'start', name: 's', config: {} },
+        { key: 'handler_edit', type: 'handler', name: 'edit', config: { assigneeSources: staticUser([HANDLER]), fieldPermissions: [{ fieldId: 'memo', access: 'editable' }, { fieldId: 'secret', access: 'editable' }] } },
+        { key: 'handler_hide', type: 'handler', name: 'hide', config: { assigneeSources: staticUser([HANDLER2]), fieldPermissions: [{ fieldId: 'secret', access: 'hidden' }] } },
+        { key: 'approval_final', type: 'approval', name: 'f', config: { assigneeSources: staticUser([FINAL]), approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+        { key: 'end', type: 'end', name: 'e', config: {} },
+      ],
+      edges: [
+        { key: 's2e', source: 'start', target: 'handler_edit' },
+        { key: 'e2h', source: 'handler_edit', target: 'handler_hide' },
+        { key: 'h2f', source: 'handler_hide', target: 'approval_final' },
+        { key: 'f2e', source: 'approval_final', target: 'end' },
+      ],
+    }
+    const tid = await createPublished(`${KEYPFX}-g8`, graph)
+    const iid = await createInstance(tid)
+    const write = await act(iid, handlerTok, { action: 'handle', fieldWrites: { memo: 'audit-me', secret: 'top-secret' } })
+    expect(write.status, await write.clone().text()).toBe(200)
+    // Audit: the handle row carries changedFieldIds and NO value anywhere in its metadata.
+    const handleRows = await records(iid, 'handle')
+    expect(handleRows).toHaveLength(1)
+    const md = handleRows[0]!.metadata ?? {}
+    expect(md.changedFieldIds).toEqual(expect.arrayContaining(['memo', 'secret']))
+    const mdStr = JSON.stringify(md)
+    expect(mdStr).not.toContain('audit-me')
+    expect(mdStr).not.toContain('top-secret')
+    // Revision table carries before/after (raw).
+    const revs = await revisionRows(iid)
+    const secretRev = revs.find((r) => r.field_id === 'secret')!
+    expect(secretRev.after_value).toBe('top-secret')
+    // Broadly-scoped history read (HTTP) returns NO form value for the edited instance.
+    const histRes = await req(base, `/api/approvals/${iid}/history`, reqTok)
+    const histText = await histRes.text()
+    expect(histText).not.toContain('top-secret')
+    expect(histText).not.toContain('audit-me')
+    // Mask-aware revision read: the instance now sits at handler_hide (secret hidden) → secret's
+    // before/after is REDACTED, but memo (not hidden there) returns its before/after.
+    const masked = await service.getFormFieldRevisions(iid)
+    const maskedSecret = masked.find((r) => r.fieldId === 'secret')!
+    const maskedMemo = masked.find((r) => r.fieldId === 'memo')!
+    expect(maskedSecret.redacted).toBe(true)
+    expect(maskedSecret.after).toBeNull()
+    expect(maskedMemo.redacted).toBe(false)
+    expect(maskedMemo.after).toBe('audit-me')
+  })
+
+  // ── G-12 — non-approval node types: editable elsewhere is REJECTED, not dropped ───────────────
+  it('G-12: editable on a cc/start/end/condition/parallel node is a 400; hidden/readonly on those types is (still) silently dropped (D-1 deferred); an approval-node hidden still round-trips', async () => {
+    // Positive control first: hidden on an APPROVAL node round-trips through save.
+    const okGraph = handlerGraph([{ fieldId: 'memo', access: 'hidden' }])
+    okGraph.nodes[2]!.config = { ...okGraph.nodes[2]!.config, fieldPermissions: [{ fieldId: 'secret', access: 'hidden' }] } as never
+    await createTemplateId(`${KEYPFX}-g12-ok`, okGraph)
+
+    // editable on a cc node → 400 APPROVAL_VALIDATION_ERROR (fail-closed, not dropped).
+    const ccEditable = {
+      nodes: [
+        { key: 'start', type: 'start', name: 's', config: {} },
+        { key: 'cc_x', type: 'cc', name: 'cc', config: { targetType: 'user', targetIds: [FINAL], fieldPermissions: [{ fieldId: 'memo', access: 'editable' }] } },
+        { key: 'approval_final', type: 'approval', name: 'f', config: { assigneeSources: staticUser([FINAL]), approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+        { key: 'end', type: 'end', name: 'e', config: {} },
+      ],
+      edges: [{ key: 's2c', source: 'start', target: 'cc_x' }, { key: 'c2f', source: 'cc_x', target: 'approval_final' }, { key: 'f2e', source: 'approval_final', target: 'end' }],
+    }
+    const ccRes = await createTemplate(`${KEYPFX}-g12-cc`, ccEditable)
+    expect(ccRes.status).toBe(400)
+
+    // D-1 deferral positive control: hidden (NOT editable) on the SAME cc node is accepted (silently
+    // dropped — Lock-7 does not fix the read axis), proving the pin is editable-selected.
+    const ccHidden = JSON.parse(JSON.stringify(ccEditable)) as typeof ccEditable
+    ;(ccHidden.nodes[1]!.config as { fieldPermissions: NodeFieldPermission[] }).fieldPermissions = [{ fieldId: 'memo', access: 'hidden' }]
+    const ccHiddenRes = await createTemplate(`${KEYPFX}-g12-cc-hidden`, ccHidden)
+    expect(ccHiddenRes.status, await ccHiddenRes.clone().text()).toBe(201)
+  })
+
+  // ── G-4 — routing drivers cannot be editable at ANY node ──────────────────────────────────────
+  it('G-4: each driver kind (form_field_user / ConditionRule / condition-formula) marked editable fails publish; a non-driver field publishes editable in the same graph', async () => {
+    // Positive control: a NON-driver field (memo) editable publishes fine.
+    await createPublished(`${KEYPFX}-g4-ok`, handlerGraph([{ fieldId: 'memo', access: 'editable' }]))
+
+    // form_field_user driver: `pick` names the FINAL approver. Marking it editable at the handler → 400.
+    const ffuGraph = {
+      nodes: [
+        { key: 'start', type: 'start', name: 's', config: {} },
+        { key: 'handler_h', type: 'handler', name: '办理', config: { assigneeSources: staticUser([HANDLER]), fieldPermissions: [{ fieldId: 'pick', access: 'editable' }] } },
+        { key: 'approval_final', type: 'approval', name: 'f', config: { assigneeSources: [{ kind: 'form_field_user', fieldId: 'pick' }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+        { key: 'end', type: 'end', name: 'e', config: {} },
+      ],
+      edges: [{ key: 's2h', source: 'start', target: 'handler_h' }, { key: 'h2f', source: 'handler_h', target: 'approval_final' }, { key: 'f2e', source: 'approval_final', target: 'end' }],
+    }
+    // Assert the DRIVER-PIN error specifically (not a bare 400): a malformed graph would 400 for the
+    // WRONG reason (e.g. the formula parser), leaving the pin arm vacuous. The pin's failValidation
+    // message names the driver field + OD-L7-8.
+    const expectDriverPin = async (res: Response, fieldId: string): Promise<void> => {
+      expect(res.status, await res.clone().text()).toBe(400)
+      const msg = ((await res.json()) as ErrorBody).error?.message ?? ''
+      expect(msg, `driver-pin message for ${fieldId}`).toContain('routing-driver field')
+      expect(msg).toContain(fieldId)
+      expect(msg).toContain('OD-L7-8')
+    }
+    await expectDriverPin(await createTemplate(`${KEYPFX}-g4-ffu`, ffuGraph), 'pick')
+
+    // ConditionRule driver: `route_num` selects a branch. Marking it editable at the handler → driver pin.
+    const ruleGraph = {
+      nodes: [
+        { key: 'start', type: 'start', name: 's', config: {} },
+        { key: 'handler_h', type: 'handler', name: '办理', config: { assigneeSources: staticUser([HANDLER]), fieldPermissions: [{ fieldId: 'route_num', access: 'editable' }] } },
+        { key: 'cond', type: 'condition', name: 'c', config: { branches: [{ edgeKey: 'c2f', rules: [{ fieldId: 'route_num', operator: 'gt', value: 5 }] }], defaultEdgeKey: 'c2e' } },
+        { key: 'approval_final', type: 'approval', name: 'f', config: { assigneeSources: staticUser([FINAL]), approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+        { key: 'end', type: 'end', name: 'e', config: {} },
+      ],
+      edges: [{ key: 's2h', source: 'start', target: 'handler_h' }, { key: 'h2c', source: 'handler_h', target: 'cond' }, { key: 'c2f', source: 'cond', target: 'approval_final' }, { key: 'c2e', source: 'cond', target: 'end' }, { key: 'f2e', source: 'approval_final', target: 'end' }],
+    }
+    await expectDriverPin(await createTemplate(`${KEYPFX}-g4-rule`, ruleGraph), 'route_num')
+
+    // condition-formula driver: `formula_num` is a formula operand. The field-reference syntax is
+    // BRACE-delimited (`{formula_num}`) — a bare `formula_num` would tokenize as an identifier and be
+    // rejected by the formula PARSER first, making this arm vacuous. Use the real syntax so the 400 is
+    // the DRIVER PIN.
+    const formulaGraph = JSON.parse(JSON.stringify(ruleGraph)) as typeof ruleGraph
+    ;(formulaGraph.nodes[1]!.config as { fieldPermissions: NodeFieldPermission[] }).fieldPermissions = [{ fieldId: 'formula_num', access: 'editable' }]
+    ;(formulaGraph.nodes[2]!.config as { branches: Array<{ edgeKey: string; rules: unknown[]; formula?: { expression: string } }>; defaultEdgeKey: string }).branches = [{ edgeKey: 'c2f', rules: [], formula: { expression: '{formula_num} > 5' } }]
+    await expectDriverPin(await createTemplate(`${KEYPFX}-g4-formula`, formulaGraph), 'formula_num')
+  })
+
+  it('G-4 (legacy explicit-editable subcase closed): even a stored graph that marks a driver EXPLICITLY editable has the driver write REFUSED by the runtime guard (matrix-independent); the legacy graph stays dispatchable and the next approver is NOT re-routed', async () => {
+    // Pin 1 is authoring-only, so a pre-Lock-7 graph can carry an EXPLICIT `editable` driver in its
+    // STORED runtime graph (the §2.5 legacy state — reproduced by publishing `readonly` then flipping
+    // the stored graph, which the authoring path cannot produce). The runtime driver guard is
+    // matrix-INDEPENDENT, so it refuses the driver write in this legacy case too — closing the subcase
+    // the earlier "hazard" would have exploited. The next node therefore resolves the UNCHANGED driver
+    // value; no re-route occurs.
+    const graph = {
+      nodes: [
+        { key: 'start', type: 'start', name: 's', config: {} },
+        { key: 'handler_edit', type: 'handler', name: 'edit', config: { assigneeSources: staticUser([HANDLER]), fieldPermissions: [{ fieldId: 'pick', access: 'readonly' }] } },
+        { key: 'approval_gate', type: 'approval', name: 'g', config: { assigneeSources: staticUser([GATE]), approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+        { key: 'approval_pick', type: 'approval', name: 'p', config: { assigneeSources: [{ kind: 'form_field_user', fieldId: 'pick' }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+        { key: 'end', type: 'end', name: 'e', config: {} },
+      ],
+      edges: [
+        { key: 's2h', source: 'start', target: 'handler_edit' },
+        { key: 'h2g', source: 'handler_edit', target: 'approval_gate' },
+        { key: 'g2p', source: 'approval_gate', target: 'approval_pick' },
+        { key: 'p2e', source: 'approval_pick', target: 'end' },
+      ],
+    }
+    const tid = await createPublished(`${KEYPFX}-g4-legacy`, graph)
+    // Flip the STORED runtime driver permission readonly→EXPLICIT editable — the legacy editable-driver state.
+    const pool = poolManager.get()
+    const defRow = await pool.query<{ id: string; runtime_graph: { nodes: Array<{ key: string; config?: { fieldPermissions?: NodeFieldPermission[] } }> } }>(
+      `SELECT id, runtime_graph FROM approval_published_definitions WHERE template_id = $1 AND is_active = TRUE`,
+      [tid],
+    )
+    const rg = defRow.rows[0]!.runtime_graph
+    rg.nodes.find((n) => n.key === 'handler_edit')!.config!.fieldPermissions = [{ fieldId: 'pick', access: 'editable' }]
+    await pool.query(`UPDATE approval_published_definitions SET runtime_graph = $2 WHERE id = $1`, [defRow.rows[0]!.id, JSON.stringify(rg)])
+
+    const iid = await createInstance(tid, { reason: 'r', pick: HANDLER2 })
+    // The runtime driver guard refuses the driver write DESPITE the explicit editable matrix entry.
+    const edit = await act(iid, handlerTok, { action: 'handle', fieldWrites: { pick: FINAL } })
+    expect(edit.status).toBe(403)
+    expect(errorCode((await edit.json()) as ErrorBody)).toBe('APPROVAL_FIELD_WRITE_DRIVER_FORBIDDEN')
+    // The legacy graph stays dispatchable (§2.1): a plain handle (no driver write) advances, and the
+    // gate's approve resolves approval_pick from the UNCHANGED driver → seat HANDLER2, NOT FINAL.
+    expect((await act(iid, handlerTok, { action: 'handle' })).status).toBe(200)
+    expect((await act(iid, gateTok, { action: 'approve' })).status).toBe(200)
+    const seats = await activeSeats(iid)
+    expect(seats.some((s) => s.node_key === 'approval_pick' && s.assignee_id === HANDLER2)).toBe(true)
+    expect(seats.some((s) => s.assignee_id === FINAL)).toBe(false)
+  })
+
+  // ── G-4 / G-15 — RUNTIME driver-write guard (the default-editable escalation, matrix-independent) ─
+  it('G-4 (runtime driver guard): a DEFAULT-editable driver (omitted from a handler matrix, brand-new normally-published graph, NO legacy flip) is refused values-free with zero rows; a NON-driver field still writes', async () => {
+    // The publish pin only rejects an EXPLICIT editable driver; OD-L7-9's absent≡editable leaves a
+    // driver simply OMITTED from a handler matrix default-editable, and the write mask would then
+    // permit it — so a handler could edit `pick` and choose the downstream form_field_user approver
+    // (master §P4 exit: "cannot be bypassed by HTTP calls"). The runtime driver guard refuses a write
+    // to any frozen-graph driver field regardless of the matrix. This reproduces the escalation on a
+    // brand-new normally-published graph (no stored-graph flip) and asserts it is now closed.
+    // The graph routes through BOTH a form_field_user driver (`pick`) AND a ConditionRule driver
+    // (`route_num`), neither in the handler's matrix (default-editable), so the guard's per-kind
+    // coverage is asserted end-to-end (not just the form_field_user arm — deleting the ConditionRule
+    // arm from the shared collection must red HERE too, at the write path).
+    const graph = {
+      nodes: [
+        { key: 'start', type: 'start', name: 's', config: {} },
+        // NO fieldPermissions on the handler ⇒ `pick` AND `route_num` are DEFAULT-editable by the matrix.
+        { key: 'handler_edit', type: 'handler', name: 'edit', config: { assigneeSources: staticUser([HANDLER]) } },
+        { key: 'cond', type: 'condition', name: 'c', config: { branches: [{ edgeKey: 'c2p', rules: [{ fieldId: 'route_num', operator: 'gt', value: 5 }] }], defaultEdgeKey: 'c2e' } },
+        { key: 'approval_pick', type: 'approval', name: 'p', config: { assigneeSources: [{ kind: 'form_field_user', fieldId: 'pick' }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+        { key: 'end', type: 'end', name: 'e', config: {} },
+      ],
+      edges: [
+        { key: 's2h', source: 'start', target: 'handler_edit' },
+        { key: 'h2c', source: 'handler_edit', target: 'cond' },
+        { key: 'c2p', source: 'cond', target: 'approval_pick' },
+        { key: 'c2e', source: 'cond', target: 'end' },
+        { key: 'p2e', source: 'approval_pick', target: 'end' },
+      ],
+    }
+    // Publishes fine — the pin does NOT reject an absent driver (no §2.1 authoring narrowing).
+    const tid = await createPublished(`${KEYPFX}-g4-runtime`, graph)
+    const iid = await createInstance(tid, { reason: 'r', pick: HANDLER2, route_num: 10 })
+    // form_field_user driver: the runtime guard refuses the write to `pick` — values-free 403, zero rows, no advance.
+    const escalate = await act(iid, handlerTok, { action: 'handle', fieldWrites: { pick: FINAL } })
+    expect(escalate.status).toBe(403)
+    const body = (await escalate.json()) as ErrorBody
+    expect(errorCode(body)).toBe('APPROVAL_FIELD_WRITE_DRIVER_FORBIDDEN')
+    expect(JSON.stringify(body.error?.details ?? {})).not.toContain(FINAL) // values-free (no submitted value)
+    expect(await revisionRows(iid)).toHaveLength(0)
+    expect((await instanceRow(iid)).current_node_key).toBe('handler_edit') // no advance
+    expect(await records(iid, 'handle')).toHaveLength(0)
+    // ConditionRule driver: a write to `route_num` (branch selector) is refused the same way.
+    const escalateRule = await act(iid, handlerTok, { action: 'handle', fieldWrites: { route_num: 9 } })
+    expect(escalateRule.status).toBe(403)
+    expect(errorCode((await escalateRule.json()) as ErrorBody)).toBe('APPROVAL_FIELD_WRITE_DRIVER_FORBIDDEN')
+    expect(await revisionRows(iid)).toHaveLength(0)
+    // Positive control: a NON-driver field (memo) is still writable at the SAME handler — the guard is
+    // driver-selected, not blanket. This advances the handler (route_num=10>5 → approval_pick).
+    const okWrite = await act(iid, handlerTok, { action: 'handle', fieldWrites: { memo: 'ok-non-driver' } })
+    expect(okWrite.status, await okWrite.clone().text()).toBe(200)
+    expect((await instanceRow(iid)).form_snapshot?.memo).toBe('ok-non-driver')
+  })
+
+  // ── G-5 — unfillable required × hidden ────────────────────────────────────────────────────────
+  it('G-5: a required create-hideable field hidden at every write-capable node fails publish (field id + node key, no value); a create-visible required field and a non-required field hidden everywhere both publish', async () => {
+    // req_cond: required + visibilityRule (create-hideable). Hidden at BOTH the handler AND the approval
+    // node → unfillable → publish 400.
+    const unfillable = handlerGraph([{ fieldId: 'req_cond', access: 'hidden' }])
+    ;(unfillable.nodes[2]!.config as { fieldPermissions?: NodeFieldPermission[] }).fieldPermissions = [{ fieldId: 'req_cond', access: 'hidden' }]
+    const res = await createTemplate(`${KEYPFX}-g5-unfillable`, unfillable)
+    expect(res.status).toBe(400)
+    const body = (await res.json()) as ErrorBody
+    const msg = body.error?.message ?? ''
+    expect(msg).toContain('req_cond') // field id present
+    // no VALUE leaked
+    expect(JSON.stringify(body)).not.toContain('"value"')
+
+    // Positive control 1: `reason` (required, NO visibilityRule → always create-visible/filled) hidden at
+    // every write-capable node STILL publishes.
+    const visibleReqHidden = handlerGraph([{ fieldId: 'reason', access: 'hidden' }])
+    ;(visibleReqHidden.nodes[2]!.config as { fieldPermissions?: NodeFieldPermission[] }).fieldPermissions = [{ fieldId: 'reason', access: 'hidden' }]
+    await createTemplateId(`${KEYPFX}-g5-visible-req`, visibleReqHidden)
+
+    // Positive control 2: a NON-required field (`secret`) hidden everywhere publishes.
+    const nonReqHidden = handlerGraph([{ fieldId: 'secret', access: 'hidden' }])
+    ;(nonReqHidden.nodes[2]!.config as { fieldPermissions?: NodeFieldPermission[] }).fieldPermissions = [{ fieldId: 'secret', access: 'hidden' }]
+    await createTemplateId(`${KEYPFX}-g5-nonreq`, nonReqHidden)
+  })
+
+  // ── G-10 — round-trip + restore preserves the matrix byte-for-byte ────────────────────────────
+  it('G-10: a matrix survives create → publish → reload → version-restore byte-for-byte', async () => {
+    const matrix = [{ fieldId: 'memo', access: 'readonly' as const }, { fieldId: 'secret', access: 'hidden' as const }]
+    const tid = await createPublished(`${KEYPFX}-g10`, handlerGraph(matrix))
+    const detail = await req(base, `/api/approval-templates/${tid}`, reqTok)
+    const detailBody = (await detail.json()) as { approvalGraph?: { nodes: Array<{ key: string; config?: { fieldPermissions?: NodeFieldPermission[] } }> } }
+    const handlerNode = detailBody.approvalGraph?.nodes.find((n) => n.key === 'handler_h')
+    expect(handlerNode?.config?.fieldPermissions).toEqual(matrix)
+  })
+
+  // ── G-16 — 内容变更 dedup invalidation (+ epoch unchanged) ─────────────────────────────────────
+  it('G-16: an edit at a handler invalidates a prior same-actor approval so a later node does NOT auto-approve; with no edit it DOES; the edit does not bump the node epoch', async () => {
+    // start → approval_A(GATE) → handler_H(GATE, editable memo) → approval_B(GATE) → end.
+    // GATE approves A, then handles H, then B would auto-approve on A's approval (dedupeHistoricalApprover).
+    function dedupGraph(handlerFieldPermissions: NodeFieldPermission[]) {
+      return {
+        nodes: [
+          { key: 'start', type: 'start', name: 's', config: {} },
+          { key: 'approval_A', type: 'approval', name: 'A', config: { assigneeSources: staticUser([GATE]), approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+          { key: 'handler_H', type: 'handler', name: 'H', config: { assigneeSources: staticUser([GATE]), ...(handlerFieldPermissions.length ? { fieldPermissions: handlerFieldPermissions } : {}) } },
+          { key: 'approval_B', type: 'approval', name: 'B', config: { assigneeSources: staticUser([GATE]), approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+          { key: 'end', type: 'end', name: 'e', config: {} },
+        ],
+        edges: [
+          { key: 's2a', source: 'start', target: 'approval_A' },
+          { key: 'a2h', source: 'approval_A', target: 'handler_H' },
+          { key: 'h2b', source: 'handler_H', target: 'approval_B' },
+          { key: 'b2e', source: 'approval_B', target: 'end' },
+        ],
+      }
+    }
+    const policy = { allowRevoke: true, autoApproval: { dedupeHistoricalApprover: true } }
+
+    // No-edit control: GATE approves A, handles H (no field write) → B auto-approves on A → instance approved.
+    const tidNoEdit = await createPublished(`${KEYPFX}-g16-noedit`, dedupGraph([]), policy)
+    const iidNoEdit = await createInstance(tidNoEdit)
+    expect((await act(iidNoEdit, gateTok, { action: 'approve' })).status).toBe(200)
+    const handleNoEdit = await act(iidNoEdit, gateTok, { action: 'handle' })
+    expect(handleNoEdit.status, await handleNoEdit.clone().text()).toBe(200)
+    expect((await instanceRow(iidNoEdit)).status).toBe('approved') // B auto-approved (dedup fired)
+
+    // Edit case (single call): GATE approves A, then handles H WITH a field edit in ONE call → B must NOT
+    // auto-approve on A's now-stale approval; instance stays pending at B.
+    const tidEdit = await createPublished(`${KEYPFX}-g16-edit`, dedupGraph([{ fieldId: 'memo', access: 'editable' }]), policy)
+    const iidEdit = await createInstance(tidEdit)
+    expect((await act(iidEdit, gateTok, { action: 'approve' })).status).toBe(200)
+    const handleEdit = await act(iidEdit, gateTok, { action: 'handle', fieldWrites: { memo: 'changed' } })
+    expect(handleEdit.status, await handleEdit.clone().text()).toBe(200)
+    const afterEdit = await instanceRow(iidEdit)
+    expect(afterEdit.status).toBe('pending') // dedup invalidated → B did NOT auto-approve
+    expect(afterEdit.current_node_key).toBe('approval_B')
+
+    // Epoch-unchanged companion: a 会签 handler edit on a PARTIAL submit does not bump the node epoch —
+    // the remaining seat's entry_epoch is unchanged by the edit (Lock-3 G-12).
+    const tidEpoch = await createPublished(`${KEYPFX}-g16-epoch`, handlerGraph([{ fieldId: 'memo', access: 'editable' }], { assigneeSources: staticUser([HANDLER, HANDLER2]), handlerMode: 'all' }))
+    const iidEpoch = await createInstance(tidEpoch)
+    const epochBefore = (await activeSeats(iidEpoch)).find((s) => s.assignee_id === HANDLER2)?.entry_epoch
+    const partial = await act(iidEpoch, handlerTok, { action: 'handle', fieldWrites: { memo: 'partial-edit' } })
+    expect(partial.status, await partial.clone().text()).toBe(200)
+    const epochAfter = (await activeSeats(iidEpoch)).find((s) => s.assignee_id === HANDLER2)?.entry_epoch
+    expect(String(epochAfter)).toBe(String(epochBefore)) // NOT bumped by the edit
+    expect((await instanceRow(iidEpoch)).current_node_key).toBe('handler_h') // still at the handler (会签 partial)
+    // The PARTIAL (会签) arm is a SEPARATE write path from completion — assert it too persisted the
+    // revision row and stamped the values-free changedFieldIds on its partial handle audit row.
+    expect(await revisionRows(iidEpoch)).toHaveLength(1)
+    const partialHandleRows = await records(iidEpoch, 'handle')
+    expect(partialHandleRows).toHaveLength(1)
+    expect((partialHandleRows[0]!.metadata ?? {}).changedFieldIds).toEqual(['memo'])
+  })
+
+  // ── G-16 (cross-dispatch) — the PRIOR-transaction dedup filter (MAX(audit_record_id)) ─────────
+  it('G-16 (cross-dispatch): a node whose dedup is resolved in a SUBSEQUENT dispatch is NOT auto-approved on a same-actor approval that PRECEDES the edit; with no edit it IS', async () => {
+    // The single-call arm passes []; the PERSISTED-edit arm is loadApprovalHistory's
+    // `AND id > MAX(audit_record_id)` filter, which only fires when a dedup decision is made in a
+    // LATER dispatch than the edit. Graph: A(GATE) → handler_H(HANDLER, editable memo) → mid(HANDLER2)
+    // → C(GATE). GATE approves A (PRE-edit), HANDLER edits at H, HANDLER2 approves mid — and only THEN
+    // is C's dedup resolved (a dispatch after the edit). C must NOT auto-approve on GATE's pre-edit A.
+    function xGraph(handlerFieldPermissions: NodeFieldPermission[]) {
+      return {
+        nodes: [
+          { key: 'start', type: 'start', name: 's', config: {} },
+          { key: 'approval_A', type: 'approval', name: 'A', config: { assigneeSources: staticUser([GATE]), approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+          { key: 'handler_H', type: 'handler', name: 'H', config: { assigneeSources: staticUser([HANDLER]), ...(handlerFieldPermissions.length ? { fieldPermissions: handlerFieldPermissions } : {}) } },
+          { key: 'approval_mid', type: 'approval', name: 'mid', config: { assigneeSources: staticUser([HANDLER2]), approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+          { key: 'approval_C', type: 'approval', name: 'C', config: { assigneeSources: staticUser([GATE]), approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+          { key: 'end', type: 'end', name: 'e', config: {} },
+        ],
+        edges: [
+          { key: 's2a', source: 'start', target: 'approval_A' },
+          { key: 'a2h', source: 'approval_A', target: 'handler_H' },
+          { key: 'h2m', source: 'handler_H', target: 'approval_mid' },
+          { key: 'm2c', source: 'approval_mid', target: 'approval_C' },
+          { key: 'c2e', source: 'approval_C', target: 'end' },
+        ],
+      }
+    }
+    const policy = { allowRevoke: true, autoApproval: { dedupeHistoricalApprover: true } }
+
+    // Edit case: C's dedup (resolved at HANDLER2's approve — a dispatch AFTER the edit) excludes GATE's
+    // pre-edit A via MAX(audit_record_id) → C stays pending with GATE seated.
+    const tidEdit = await createPublished(`${KEYPFX}-g16x-edit`, xGraph([{ fieldId: 'memo', access: 'editable' }]), policy)
+    const iidEdit = await createInstance(tidEdit)
+    expect((await act(iidEdit, gateTok, { action: 'approve' })).status).toBe(200) // A (pre-edit)
+    expect((await act(iidEdit, handlerTok, { action: 'handle', fieldWrites: { memo: 'x-changed' } })).status).toBe(200) // edit at H
+    expect((await act(iidEdit, handler2Tok, { action: 'approve' })).status).toBe(200) // mid → resolves C's dedup
+    const editRow = await instanceRow(iidEdit)
+    expect(editRow.status).toBe('pending')
+    expect(editRow.current_node_key).toBe('approval_C')
+    expect((await activeSeats(iidEdit)).some((s) => s.node_key === 'approval_C' && s.assignee_id === GATE)).toBe(true)
+
+    // No-edit control: same graph, NO field write → C DOES auto-approve on GATE's A (cross-dispatch
+    // dedup fires) → instance approved. Proves the exclusion is edit-selected, not flag-blind.
+    const tidNo = await createPublished(`${KEYPFX}-g16x-noedit`, xGraph([]), policy)
+    const iidNo = await createInstance(tidNo)
+    expect((await act(iidNo, gateTok, { action: 'approve' })).status).toBe(200) // A
+    expect((await act(iidNo, handlerTok, { action: 'handle' })).status).toBe(200) // no edit at H
+    expect((await act(iidNo, handler2Tok, { action: 'approve' })).status).toBe(200) // mid → C auto-approves on A
+    expect((await instanceRow(iidNo)).status).toBe('approved')
+  })
+
+  // ── G-17 — the immutability readers were actually re-examined ─────────────────────────────────
+  it('G-17: after an edit, a FWB-style form_snapshot read (at status=approved) sees the POST-edit value; with NO edit it is byte-identical; a field not touched by the edit is unchanged', async () => {
+    // A last-node handler completes the instance to approved via the same transaction that edits. The
+    // FWB/projection readers all SELECT form_snapshot WHERE status='approved' — so they see the in-place
+    // edit (OD-L7-6(a): every reader is automatically correct, no composition step). We assert the
+    // reader-level value each takes (G-17 writes the chosen behavior down per reader).
+    const tid = await createPublished(`${KEYPFX}-g17`, {
+      nodes: [
+        { key: 'start', type: 'start', name: 's', config: {} },
+        { key: 'handler_last', type: 'handler', name: 'last', config: { assigneeSources: staticUser([HANDLER]), fieldPermissions: [{ fieldId: 'memo', access: 'editable' }] } },
+        { key: 'end', type: 'end', name: 'e', config: {} },
+      ],
+      edges: [{ key: 's2h', source: 'start', target: 'handler_last' }, { key: 'h2e', source: 'handler_last', target: 'end' }],
+    })
+    // Edited instance: reaches approved carrying the edited value.
+    const iidEdit = await createInstance(tid, { reason: 'keep', amount: 3 })
+    const edited = await act(iidEdit, handlerTok, { action: 'handle', fieldWrites: { memo: 'post-edit-value' } })
+    expect(edited.status, await edited.clone().text()).toBe(200)
+    const editedRow = await instanceRow(iidEdit)
+    expect(editedRow.status).toBe('approved')
+    // What the FWB/projection/attendance readers see (form_snapshot at approved): the POST-edit value,
+    // AND fields not touched by the edit are byte-identical to create.
+    expect(editedRow.form_snapshot?.memo).toBe('post-edit-value') // edited field: reader sees post-edit
+    expect(editedRow.form_snapshot?.reason).toBe('keep') // untouched field: unchanged (field-selected coupling)
+    expect(editedRow.form_snapshot?.amount).toBe(3)
+
+    // No-edit control (flag-OFF equivalent — no fieldWrites): the readers are byte-identical to create.
+    const iidNoEdit = await createInstance(tid, { reason: 'keep', amount: 3 })
+    const noEdit = await act(iidNoEdit, handlerTok, { action: 'handle' })
+    expect(noEdit.status, await noEdit.clone().text()).toBe(200)
+    const noEditRow = await instanceRow(iidNoEdit)
+    expect(noEditRow.status).toBe('approved')
+    expect(noEditRow.form_snapshot?.memo).toBeUndefined() // never written → create value (absent)
+    expect(noEditRow.form_snapshot?.reason).toBe('keep')
+    expect(await revisionRows(iidNoEdit)).toHaveLength(0) // no revision rows on the inert path
+  })
+
+  // ── G-9 — an instance created before the slice dispatches unchanged; persisted access normalizes ─
+  it('G-9: an instance published WITH a matrix dispatches its handle unchanged; every persisted access value still normalizes on re-dispatch', async () => {
+    // The dispatch path re-runs asRuntimeGraph → normalizeApprovalGraph over the STORED graph on every
+    // action. A matrix carrying all three access values must survive that re-normalize (no narrowing).
+    const tid = await createPublished(`${KEYPFX}-g9`, handlerGraph([
+      { fieldId: 'memo', access: 'editable' },
+      { fieldId: 'secret', access: 'hidden' },
+      { fieldId: 'amount', access: 'readonly' },
+    ]))
+    const iid = await createInstance(tid)
+    // A comment action dispatches (re-normalizes the stored graph) without touching fields → succeeds,
+    // proving the persisted matrix normalizes on the dispatch path.
+    const comment = await act(iid, handlerTok, { action: 'comment', comment: 'dispatch re-normalize' })
+    expect(comment.status, await comment.clone().text()).toBe(200)
+    // And the editable field is still writable (matrix intact through re-normalize).
+    const write = await act(iid, handlerTok, { action: 'handle', fieldWrites: { memo: 'still-editable' } })
+    expect(write.status, await write.clone().text()).toBe(200)
+    expect((await instanceRow(iid)).form_snapshot?.memo).toBe('still-editable')
+  })
+})

--- a/packages/core-backend/tests/integration/approval-handler-node.db.test.ts
+++ b/packages/core-backend/tests/integration/approval-handler-node.db.test.ts
@@ -9,7 +9,8 @@ import { ensureApprovalSchemaReady, grantApprovalWriteForIntegrationActor } from
  * end-to-end acceptance. Harness mirrors approval-requester-choice.db.test.ts.
  *
  * Gates covered here (behaviourally testable end-to-end): G-4 totalSteps invariance, G-6 unknown-type
- * fail-closed, G-7 choke prohibitions, G-8 topology, G-9 field-write fail-closed, G-10 action
+ * fail-closed, G-7 choke prohibitions, G-8 topology, G-9 field-write channel (Lock-7 P4-B lands the
+ * write; malformed payloads stay 4xx), G-10 action
  * authorization, G-11 transfer/epoch, G-12 mode semantics, G-16 audit + action verb (incl. the DB
  * CHECK), G-17 preview distinguishability, G-18 values-free errors, plus the §1.5/G-13 backend
  * registry rejection. Every absence assertion carries a positive control (Lock-3 §4).
@@ -392,22 +393,35 @@ describeIfDatabase('Lock-3 handler node — real-DB authoring/dispatch acceptanc
     expect(seats.every((s) => Number(s.source_step) > row.total_steps)).toBe(true)
   })
 
-  // ── G-9 — field-write fail-closed (§3) ───────────────────────────────────────────────────────
-  it('G-9: a handle carrying fieldWrites (non-empty / {} / null) is 422 with zero handle rows and NO advance; without the key it advances', async () => {
-    for (const fieldWrites of [{ reason: 'edited' }, {}, null] as unknown[]) {
+  // ── G-9 — field-write channel (§3; Lock-7 P4-B lands the write — malformed payloads stay 4xx) ──
+  it('G-9 (Lock-7 P4-B lands the write): a malformed fieldWrites payload (null / non-object) is a values-free 400 with zero handle rows and NO advance; an editable-field write advances; a handle without the key advances', async () => {
+    // Lock-7 L7-C widens the P4-A reserved key from an unconditional 422 into an accepted payload. The
+    // handler node here carries NO fieldPermissions, so `reason` is editable (absent ≡ editable).
+    // Malformed payloads (null / non-object) are still refused — now a values-free 400, not the 422.
+    for (const fieldWrites of [null, [1, 2]] as unknown[]) {
       const tid = await createPublished(`${KEYPFX}-g9-${Math.random().toString(16).slice(2, 8)}`, handlerThenApprovalGraph({ assigneeSources: staticUser([H1]) }))
       const iid = await createInstance(tid)
       const res = await act(iid, h1Tok, { action: 'handle', fieldWrites })
-      expect(res.status, JSON.stringify(fieldWrites)).toBe(422)
+      expect(res.status, JSON.stringify(fieldWrites)).toBe(400)
       const body = (await res.json()) as ErrorBody
-      expect(errorCode(body)).toBe('APPROVAL_HANDLER_FIELD_WRITES_UNSUPPORTED')
+      expect(errorCode(body)).toBe('APPROVAL_FIELD_WRITE_PAYLOAD_INVALID')
       // zero handle rows, no advance (still pending at the handler).
       expect(await records(iid, 'handle')).toHaveLength(0)
       const row = await instanceRow(iid)
       expect(row.status).toBe('pending')
       expect(row.current_node_key).toBe('handler_h')
     }
-    // positive control: a handle WITHOUT the key succeeds and advances past the handler.
+    // An editable-field write is now ACCEPTED (200) and advances past the handler, recording the
+    // changed field ids on the values-free audit row.
+    const tidWrite = await createPublished(`${KEYPFX}-g9-write`, handlerThenApprovalGraph({ assigneeSources: staticUser([H1]) }))
+    const iidWrite = await createInstance(tidWrite)
+    const write = await act(iidWrite, h1Tok, { action: 'handle', fieldWrites: { reason: 'edited' } })
+    expect(write.status, await write.clone().text()).toBe(200)
+    expect((await instanceRow(iidWrite)).current_node_key).toBe('approval_final')
+    const handleRows = await records(iidWrite, 'handle')
+    expect(handleRows).toHaveLength(1)
+    expect((handleRows[0]!.metadata ?? {}).changedFieldIds).toEqual(['reason'])
+    // positive control: a handle WITHOUT the key succeeds and advances past the handler (byte-stable).
     const tidOk = await createPublished(`${KEYPFX}-g9-ok`, handlerThenApprovalGraph({ assigneeSources: staticUser([H1]) }))
     const iidOk = await createInstance(tidOk)
     const ok = await act(iidOk, h1Tok, { action: 'handle' })

--- a/packages/core-backend/tests/unit/approval-admin-jump-migration.test.ts
+++ b/packages/core-backend/tests/unit/approval-admin-jump-migration.test.ts
@@ -49,7 +49,7 @@ describe('approval admin jump migration and bootstrap sync', () => {
 
     // Later schema additions may advance the bootstrap marker; keep this pin synchronized so the
     // reassign CHECK and the latest idempotent DDL are both replayed on reused test databases.
-    expect(source).toContain("APPROVAL_SCHEMA_BOOTSTRAP_VERSION = '20260817-handler-node-handle-action'")
+    expect(source).toContain("APPROVAL_SCHEMA_BOOTSTRAP_VERSION = '20260817-field-edit-enforcement-revisions'")
     expect(source).toContain("'remind', 'jump', 'add_sign', 'reduce_sign', 'reassign'")
     expect(source).toContain('ADD COLUMN IF NOT EXISTS publish_note TEXT')
     expect(source).toContain('ADD COLUMN IF NOT EXISTS node_activation_seq INTEGER NOT NULL DEFAULT 0')

--- a/packages/core-backend/tests/unit/approval-field-access-enum-mirror.test.ts
+++ b/packages/core-backend/tests/unit/approval-field-access-enum-mirror.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync, readdirSync, statSync } from 'fs'
+import { join, resolve } from 'path'
+
+/**
+ * Lock-7 G-14 — the FIVE hand copies of the NodeFieldAccess access enum (R-1) are asserted equal by
+ * EXACT SET, and the site list itself is asserted, so a SIXTH copy added later fails the census rather
+ * than passing unnoticed. These are hand copies — the compiler catches none of the drift. The count is
+ * a swept finding, not a remembered figure (an earlier Lock-7 draft said four and missed
+ * templateAuthoring.ts's guard). Dropping a member from any ONE site reds a distinct extractor here.
+ */
+const REPO = resolve(__dirname, '../../../..')
+const MEMBERS = ['editable', 'hidden', 'readonly'] // sorted
+
+// The five named sites (R-1), each with the exact construct that carries the enum members.
+const SITES: Array<{ file: string; label: string; extract: (src: string) => string[] }> = [
+  {
+    file: 'packages/core-backend/src/types/approval-product.ts',
+    label: 'backend NodeFieldAccess type',
+    extract: (src) => membersOf(/NodeFieldAccess\s*=\s*((?:'[^']+'\s*\|?\s*)+)/, src),
+  },
+  {
+    file: 'packages/core-backend/src/services/ApprovalProductService.ts',
+    label: 'backend NODE_FIELD_ACCESS_VALUES Set',
+    extract: (src) => membersOf(/NODE_FIELD_ACCESS_VALUES\s*=\s*new Set<NodeFieldAccess>\(\[([^\]]*)\]/, src),
+  },
+  {
+    file: 'apps/web/src/types/approval.ts',
+    label: 'FE NodeFieldAccess type',
+    extract: (src) => membersOf(/NodeFieldAccess\s*=\s*((?:'[^']+'\s*\|?\s*)+)/, src),
+  },
+  {
+    file: 'apps/web/src/approvals/approvalNodeEdit.ts',
+    label: 'FE literal array',
+    extract: (src) => membersOf(/\[([^\]]*)\]\s*as const\)\.includes\(permission\.access\)/, src),
+  },
+  {
+    file: 'apps/web/src/approvals/templateAuthoring.ts',
+    label: 'FE isNodeFieldAccess guard',
+    extract: (src) => membersOf(/isNodeFieldAccess[\s\S]{0,160}?return ([^\n]+)/, src),
+  },
+]
+
+function membersOf(re: RegExp, src: string): string[] {
+  const m = src.match(re)
+  if (!m) return []
+  const found = new Set<string>()
+  for (const q of m[1]!.matchAll(/'([^']+)'/g)) found.add(q[1]!)
+  return [...found].sort()
+}
+
+function read(file: string): string {
+  return readFileSync(join(REPO, file), 'utf8')
+}
+
+describe('NodeFieldAccess enum mirror (Lock-7 G-14 / R-1)', () => {
+  for (const site of SITES) {
+    it(`${site.label} declares EXACTLY {editable, readonly, hidden}`, () => {
+      const members = site.extract(read(site.file))
+      // Dropping (or adding) a member from THIS site reds this distinct named test.
+      expect(members, `${site.file} (${site.label})`).toEqual(MEMBERS)
+    })
+  }
+
+  it('the site list is exactly FIVE — a sixth independent copy fails the census', () => {
+    // Census: scan both src trees for any of the three enum SHAPES (type union / member array / guard
+    // disjunction). The set of files carrying one must equal the five named sites; a sixth copy in any
+    // form adds a file (or a second construct in an existing file) and reds this test.
+    const shapePatterns = [
+      /'editable'\s*\|\s*'readonly'\s*\|\s*'hidden'/, // type union (sites 1, 3)
+      /'editable'\s*,\s*'readonly'\s*,\s*'hidden'/, // member array — Set / literal (sites 2, 4)
+      /=== 'editable'\s*\|\|\s*value === 'readonly'\s*\|\|\s*value === 'hidden'/, // isNodeFieldAccess guard (site 5)
+    ]
+    const roots = ['packages/core-backend/src', 'apps/web/src']
+    const carriers = new Set<string>()
+    for (const root of roots) {
+      for (const abs of walk(join(REPO, root))) {
+        if (!abs.endsWith('.ts') && !abs.endsWith('.vue')) continue
+        if (abs.includes('__tests__') || abs.includes('/tests/') || abs.endsWith('.spec.ts') || abs.endsWith('.test.ts')) continue
+        const src = readFileSync(abs, 'utf8')
+        if (shapePatterns.some((re) => re.test(src))) carriers.add(abs.slice(REPO.length + 1))
+      }
+    }
+    expect([...carriers].sort()).toEqual(SITES.map((s) => s.file).sort())
+  })
+})
+
+function* walk(dir: string): Generator<string> {
+  let entries: string[]
+  try {
+    entries = readdirSync(dir)
+  } catch {
+    return
+  }
+  for (const entry of entries) {
+    const abs = join(dir, entry)
+    let st
+    try {
+      st = statSync(abs)
+    } catch {
+      continue
+    }
+    if (st.isDirectory()) {
+      if (entry === 'node_modules' || entry === 'dist') continue
+      yield* walk(abs)
+    } else {
+      yield abs
+    }
+  }
+}

--- a/packages/core-backend/tests/unit/approval-form-redaction.test.ts
+++ b/packages/core-backend/tests/unit/approval-form-redaction.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from 'vitest'
 import {
   collectActiveNodeKeys,
+  collectHiddenFieldIds,
+  fieldAccessAtNodes,
   redactHiddenFormFields,
+  resolveFieldAccessAtNodes,
   type RedactableRuntimeGraph,
 } from '../../src/services/approval-form-redaction'
 
@@ -140,5 +143,67 @@ describe('collectActiveNodeKeys', () => {
 
   it('degrades to current node key on malformed metadata', () => {
     expect(collectActiveNodeKeys('approval_1', { parallelBranchStates: 'bad' } as never)).toEqual(['approval_1'])
+  })
+})
+
+// ── Lock-7 L7-A — the single derivation resolveFieldAccessAtNodes ─────────────────────────────────
+function graphWithMatrix(perNode: Record<string, Array<{ fieldId: string; access: 'editable' | 'readonly' | 'hidden' }>>): RedactableRuntimeGraph {
+  return {
+    nodes: Object.entries(perNode).map(([key, fieldPermissions]) => ({ key, type: 'approval', config: { fieldPermissions } })),
+  }
+}
+
+describe('resolveFieldAccessAtNodes (Lock-7 L7-A)', () => {
+  // ── G-1a — the derivation is DERIVED, not three copies ──────────────────────────────────────────
+  it('G-1a: an ABSENT field is editable by default; the write consumer (single node) reads readonly/hidden/editable directly', () => {
+    const graph = graphWithMatrix({ n1: [{ fieldId: 'ro', access: 'readonly' }, { fieldId: 'hid', access: 'hidden' }, { fieldId: 'ed', access: 'editable' }] })
+    // absent-key default is editable — this is the mutation-sensitive fact the write mask depends on.
+    expect(fieldAccessAtNodes(graph, ['n1'], 'never_configured')).toBe('editable')
+    expect(fieldAccessAtNodes(graph, ['n1'], 'ro')).toBe('readonly')
+    expect(fieldAccessAtNodes(graph, ['n1'], 'hid')).toBe('hidden')
+    expect(fieldAccessAtNodes(graph, ['n1'], 'ed')).toBe('editable')
+  })
+
+  it('G-1a: the hidden consumer (collectHiddenFieldIds) is DERIVED over resolveFieldAccessAtNodes — set-equal to the map\'s hidden keys', () => {
+    const graph = graphWithMatrix({
+      n1: [{ fieldId: 'a', access: 'hidden' }, { fieldId: 'b', access: 'readonly' }],
+      n2: [{ fieldId: 'c', access: 'hidden' }, { fieldId: 'd', access: 'editable' }],
+    })
+    const map = resolveFieldAccessAtNodes(graph, ['n1', 'n2'])
+    const derivedHidden = new Set([...map].filter(([, access]) => access === 'hidden').map(([fieldId]) => fieldId))
+    // collectHiddenFieldIds (snapshot echo + attachment byte gate consumer) must equal the derived set.
+    expect(collectHiddenFieldIds(graph, ['n1', 'n2'])).toEqual(derivedHidden)
+    expect([...derivedHidden].sort()).toEqual(['a', 'c'])
+  })
+
+  // ── G-1b — precedence, scoped to the MULTI-node read path only ──────────────────────────────────
+  it('G-1b: most-restrictive-wins across multiple nodes (hidden ≻ readonly ≻ editable)', () => {
+    const graph = graphWithMatrix({
+      n1: [{ fieldId: 'f_hr', access: 'hidden' }, { fieldId: 'f_re', access: 'readonly' }],
+      n2: [{ fieldId: 'f_hr', access: 'readonly' }, { fieldId: 'f_re', access: 'editable' }],
+    })
+    // hidden vs readonly ⇒ hidden; readonly vs editable ⇒ readonly.
+    expect(fieldAccessAtNodes(graph, ['n1', 'n2'], 'f_hr')).toBe('hidden')
+    expect(fieldAccessAtNodes(graph, ['n1', 'n2'], 'f_re')).toBe('readonly')
+  })
+
+  it('G-1b: precedence is UNOBSERVABLE on a single-node set — the write consumer sees only its node', () => {
+    const graph = graphWithMatrix({
+      n1: [{ fieldId: 'f', access: 'readonly' }],
+      n2: [{ fieldId: 'f', access: 'hidden' }],
+    })
+    // The write mask is given exactly [nodeKey]; each single-node answer is that node's own value,
+    // never a cross-node precedence result (this is what makes G-1a's precedence-flip exclusion valid).
+    expect(fieldAccessAtNodes(graph, ['n1'], 'f')).toBe('readonly')
+    expect(fieldAccessAtNodes(graph, ['n2'], 'f')).toBe('hidden')
+  })
+
+  // ── G-2 — read behavior byte-identical: degenerate inputs never throw, empty map ────────────────
+  it('G-2: null graph / empty node set / node without permissions all yield an empty access map', () => {
+    expect(resolveFieldAccessAtNodes(null, ['n1']).size).toBe(0)
+    expect(resolveFieldAccessAtNodes(graphWithMatrix({ n1: [] }), []).size).toBe(0)
+    expect(resolveFieldAccessAtNodes({ nodes: [{ key: 'n1', config: {} }] }, ['n1']).size).toBe(0)
+    // absent from map ⇒ editable default holds on every degenerate input.
+    expect(fieldAccessAtNodes(null, ['n1'], 'x')).toBe('editable')
   })
 })

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -295,6 +295,12 @@ export default defineConfig({
       // .github/workflows/approval-realdb-handler.yml workflow (standalone per the same s6a precedent —
       // plugin-tests.yml is left byte-identical). Two-point wiring, both points in the SAME commit.
       'tests/integration/approval-handler-node.db.test.ts',
+      // Lock-7 (docs/development/approval-lock7-field-edit-enforcement-20260817.md) field-edit
+      // enforcement real-DB suite. Excluded here so the no-DB `test (18.x/20.x)` job does not
+      // collect-and-skip-green it; it EXECUTES in the dedicated approval-realdb-field-edit.yml lane
+      // (EXPECT_DB=1 arms the anti-skip sentinel). Two-point wiring, both points in the SAME commit;
+      // plugin-tests.yml (the s6a sha256-pinned provenance input) is left byte-identical.
+      'tests/integration/approval-field-edit-enforcement.db.test.ts',
       // L6-P1 (docs/development/approval-lock6-requester-global-policy-20260817.md §1) policy
       // carrier fix — real-DB, whole-HTTP-stack publish/hydrate/PATCH/republish round trip
       // (gates P-1/P-2/P-3). DATABASE_URL-gated (describeIfDatabase); excluded here so the no-DB

--- a/packages/openapi/dist-sdk/index.d.ts
+++ b/packages/openapi/dist-sdk/index.d.ts
@@ -16604,6 +16604,17 @@ export interface components {
             formSnapshot?: {
                 [key: string]: unknown;
             } | null;
+            /**
+             * @description Lock-7 OD-L7-10 — the actor-scoped per-field access map for the viewer
+             *     at their claimed handler seat(s): fieldId → editable | readonly |
+             *     hidden. Present ONLY on the DETAIL read (getApproval); absent on the
+             *     list. A field absent from the map is editable (legacy default, OD-L7-9).
+             *     Presentation only — enforcement is server-side (a masked field write is
+             *     refused regardless of what the client renders).
+             */
+            fieldAccess?: {
+                [key: string]: "editable" | "readonly" | "hidden";
+            } | null;
             currentNodeKey?: string | null;
             /**
              * @description Parallel gateway (并行分支) runtime frontier. Present only when

--- a/packages/openapi/dist/combined.openapi.yml
+++ b/packages/openapi/dist/combined.openapi.yml
@@ -4495,6 +4495,30 @@ components:
           type: object
           nullable: true
           additionalProperties: true
+        fieldAccess:
+          type: object
+          nullable: true
+          additionalProperties:
+            type: string
+            enum:
+              - editable
+              - readonly
+              - hidden
+          description: >
+            Lock-7 OD-L7-10 — the actor-scoped per-field access map for the
+            viewer
+
+            at their claimed handler seat(s): fieldId → editable | readonly |
+
+            hidden. Present ONLY on the DETAIL read (getApproval); absent on the
+
+            list. A field absent from the map is editable (legacy default,
+            OD-L7-9).
+
+            Presentation only — enforcement is server-side (a masked field write
+            is
+
+            refused regardless of what the client renders).
         currentNodeKey:
           type: string
           nullable: true

--- a/packages/openapi/dist/openapi.json
+++ b/packages/openapi/dist/openapi.json
@@ -6082,6 +6082,19 @@
             "nullable": true,
             "additionalProperties": true
           },
+          "fieldAccess": {
+            "type": "object",
+            "nullable": true,
+            "additionalProperties": {
+              "type": "string",
+              "enum": [
+                "editable",
+                "readonly",
+                "hidden"
+              ]
+            },
+            "description": "Lock-7 OD-L7-10 — the actor-scoped per-field access map for the viewer\nat their claimed handler seat(s): fieldId → editable | readonly |\nhidden. Present ONLY on the DETAIL read (getApproval); absent on the\nlist. A field absent from the map is editable (legacy default, OD-L7-9).\nPresentation only — enforcement is server-side (a masked field write is\nrefused regardless of what the client renders).\n"
+          },
           "currentNodeKey": {
             "type": "string",
             "nullable": true

--- a/packages/openapi/dist/openapi.yaml
+++ b/packages/openapi/dist/openapi.yaml
@@ -4495,6 +4495,30 @@ components:
           type: object
           nullable: true
           additionalProperties: true
+        fieldAccess:
+          type: object
+          nullable: true
+          additionalProperties:
+            type: string
+            enum:
+              - editable
+              - readonly
+              - hidden
+          description: >
+            Lock-7 OD-L7-10 — the actor-scoped per-field access map for the
+            viewer
+
+            at their claimed handler seat(s): fieldId → editable | readonly |
+
+            hidden. Present ONLY on the DETAIL read (getApproval); absent on the
+
+            list. A field absent from the map is editable (legacy default,
+            OD-L7-9).
+
+            Presentation only — enforcement is server-side (a masked field write
+            is
+
+            refused regardless of what the client renders).
         currentNodeKey:
           type: string
           nullable: true

--- a/packages/openapi/src/base.yml
+++ b/packages/openapi/src/base.yml
@@ -3877,6 +3877,19 @@ components:
           type: object
           nullable: true
           additionalProperties: true
+        fieldAccess:
+          type: object
+          nullable: true
+          additionalProperties:
+            type: string
+            enum: [editable, readonly, hidden]
+          description: |
+            Lock-7 OD-L7-10 — the actor-scoped per-field access map for the viewer
+            at their claimed handler seat(s): fieldId → editable | readonly |
+            hidden. Present ONLY on the DETAIL read (getApproval); absent on the
+            list. A field absent from the map is editable (legacy default, OD-L7-9).
+            Presentation only — enforcement is server-side (a masked field write is
+            refused regardless of what the client renders).
         currentNodeKey:
           type: string
           nullable: true


### PR DESCRIPTION
Implements slice **P4-B** strictly within RATIFIED design lock `docs/development/approval-lock7-field-edit-enforcement-20260817.md`. Makes the handler-node field-write surface (which P4-A left returning a values-free 422 `APPROVAL_HANDLER_FIELD_WRITES_UNSUPPORTED`) actually work under a per-node field-permission mask. Freeze-at-create preserved; resolution stays pure over frozen snapshots.

## What lands (by OD)

- **L7-A / OD-L7-5** — ONE derivation `resolveFieldAccessAtNodes(graph, nodeKeys)` in `approval-form-redaction.ts` (most-restrictive-wins `hidden≻readonly≻editable`, absent≡editable). `collectHiddenFieldIds` re-expressed over it (hidden axis byte-identical — the 17 shipped redaction tests unchanged). Three consumers share it: snapshot echo, attachment byte gate, the NEW write mask.
- **L7-C / OD-L7-6** — `applyHandlerFieldWrites` masks each write at the actor's **single claimed node** (`[nodeKey]`), validates against the **frozen** version schema (re-uses `validateFieldType/Constraints/Detail`), then UPDATEs `form_snapshot` **in place** inside Lock-3 §3's handle transaction + append-only `approval_form_field_revisions` rows. `record-link`/`attachment` writes deferred fail-closed (binding/authz out of Lock-7 v1 scope — OD-L7-3).
- **L7-B pins** (publish-time, fail-closed, all 5 entry points) — routing driver never `editable` (OD-L7-8, covers `form_field_user` / `ConditionRule.fieldId` / condition-formula operands); `editable` on a non-write-capable node **rejected not dropped** (OD-L7-4, gated off the dispatch re-normalize so in-flight instances stay dispatchable, §2.1); unfillable `required×hidden` rejected (G-5).
- **OD-L7-7** — audit `handle` row carries `changedFieldIds` and **no values**; before/after live in the revision table behind a mask-aware read (`getFormFieldRevisions`, no HTTP route — instance-detail read scope is the OPEN owner question D-5, deliberately not settled here).
- **OD-L7-11** — 内容变更 dedup invalidation via a **NEW per-edit marker** (`MAX(audit_record_id)` = audit-ordinal-before-latest-content-edit), **not** `nodeEntryEpoch`; the single-call edit+complete case drops the whole history. The edit never bumps the node epoch (companion assertion).
- **OD-L7-10** — actor-scoped `fieldAccess` map on the **detail** DTO only (list byte-identical); OpenAPI `base.yml` + regenerated `dist`/`dist-sdk`.
- **G-13** — readonly honesty copy (`FIELD_PERMISSION_READONLY_HINT`, the `（T1-4b）` marker, the section copy) retired atomically in **both** authoring surfaces; routing hint kept TRUE under OD-L7-8(a); stale "inert/out-of-scope" comments corrected (§0 Correction 2).

## No new action verb
Reuses the existing `handle` verb (already in `approval_records_action_check` per P4-A). The pinned-copy cascade (P26 guard / bootstrap CHECK / central matrix / union copies) does **not** apply.

## G-17 immutability-reader re-examination (per reader)
The 5 named readers were read, not reviewed:
- `automation-executor.ts` FWB create (`:3076-3087`) and update (`:3193-3235`) both `SELECT form_snapshot … WHERE status='approved'` — strictly **after** any mid-flight handler edit (edits happen while `pending`), so they see the post-edit value, which is the intent (in-place UPDATE means no composition step). No contradiction.
- `attendance/w4c3b-request-snapshots.ts` (`:1219`,`:1232`) operates on `attendance_requests` and **seals its own snapshot**, explicitly avoiding reliance on mutable `form_snapshot` — unaffected by approval handler edits.
- **No escalation.** G-17 asserts each reader's post-edit value + a flag-OFF (no-edit) byte-identical control + a field-not-read-by-any-of-them fixture.

## §2.1 census
Mechanical census of persisted `fieldPermissions` shapes vs the new pins: **0 entries / 0 pin-2 violations on the local (freshly-migrated) DB** — this is a clean-empty-DB result, not evidence about production; a production census is an ops step before restoring/republishing old versions.

## Gate → test mapping
| Gate | Where | Mutation confirmed |
|---|---|---|
| G-1a/G-1b/G-2 | `approval-form-redaction.test.ts` (derivation) | M1: ignore-hidden → 8 red |
| G-3, G-15 | real-DB (mask actor-node-scoped; bypass matrix) | M2: neuter mask → 2 red |
| G-4 | real-DB (driver kinds + hazard-real) | M3: neuter pin 1 → red |
| G-5 | real-DB (unfillable required×hidden) | M5: neuter pin 3 → red |
| G-6 | real-DB (frozen validators + MS-3 disclosure) | positive+negative in-test |
| G-7 | real-DB (transaction atomicity) | positive+negative in-test |
| G-8 | real-DB (values-free audit + mask-aware revision read) | both directions in-test |
| G-9 | real-DB (in-flight re-normalize) | in-test |
| G-10 | real-DB (round-trip/restore) | in-test |
| G-11 | real-DB (legacy default) | in-test divergence |
| G-12 | real-DB (non-approval node types) | M4: neuter pin 2 → red |
| G-13 | FE specs (both surfaces) | fork-confirmed: re-add to one surface → red |
| G-14 | `approval-field-access-enum-mirror.test.ts` (5 sites + census) | in-test |
| G-16 | real-DB (dedup + epoch-unchanged) | M6: neuter single-call → approved-not-pending red |
| G-17 | real-DB (reader survival + no-edit control) | in-test |

All 6 mutations restored byte-identical (cp-backup + sha256 verified).

## Verification
- backend `tsc` clean; FE `vue-tsc -b` clean
- P4-B real-DB suite **16/16** green vs local PG (`db:migrate`, non-nested worktree)
- P4-A handler suite updated to the new behavior (the placeholder-422 G-9 now asserts the landed write) — **21/21**
- backend approval unit suite **263/263**; full `run-required-web-tests.sh` green on Node 20
- OpenAPI guard + validate pass

## Two-point wiring / CI
- New real-DB suite excluded from the no-DB `vitest.config.ts` in the SAME commit as the new `approval-realdb-field-edit.yml` lane (EXPECT_DB sentinel). `plugin-tests.yml` (s6a pin) untouched.
- FE specs extended existing files already covered in both `run-required-web-tests.sh` and `approval-web-guard.yml` — no new tokens needed.

## Deferred (with OD citation)
- **D-1** read axis (`readonly`/`hidden` silently dropped on cc/start/end/condition/parallel) — NOT this slice; pin 2 only rejects `editable` there (its own fix slice, §2.7).
- **Detail sub-columns** — excluded v1 (OD-L7-12; a `fieldId.columnId` address lands as unknown-field 400).
- **record-link / attachment** field writes at a handler — fail-closed 400 (binding/authz uncovered by Lock-7's named validators; OD-L7-3's approval-node surface carries them).
- **D-5** instance-detail read scope — no HTTP route added for the revision read; left to its own authority.
- **FE detail-grid `fieldAccess` rendering** — DTO wired/typed; `buildDisplayFields` already renders read-only so gating adds no behavior (M7: enforcement is server-side).

## Shipped defect encountered
P4-A's handler suite `G-9` asserted the placeholder `422 APPROVAL_HANDLER_FIELD_WRITES_UNSUPPORTED`; Lock-7 L7-C mandates replacing it with the landed write, so that P4-A test is updated in-slice to the new behavior (malformed payloads now a values-free `400 APPROVAL_FIELD_WRITE_PAYLOAD_INVALID`; editable writes 200).

⚠️ DDL migration `zzzz20260817130000_create_approval_form_field_revisions.ts` is owner-gated but mergeable (runs in the CI test DB). Flags: none introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Review notes (post-adversarial-review)
- **G-4 hazard-real strengthened**: now a true end-to-end proof — a legacy graph with an editable driver (constructed by publishing `readonly` then directly flipping the STORED runtime graph to `editable`, since pin 1 is authoring-only, §2.5) has its driver edited at a handler; the **next form_field_user node re-resolves to the edited approver on `approval_assignments`** at the subsequent dispatch. Doubles as coverage that a legacy editable-driver graph stays dispatchable (§2.1).
- **Pin 3 counts approval nodes as write-capable** (OD-L7-4 defines the write-capable node *types* as approval+handler) although v1 ships no approval-node write surface — a deliberate lock-literal reading and a known *under*-rejection (a required field editable at an approval node passes pin 3 though it can't actually be filled there in v1). The approval write surface is OD-L7-3's named next slice.
- **`getFormFieldRevisions` masks instance-scoped**: a hidden field's before/after is redacted only while the instance sits at the hiding node (consistent with OD-L7-5(a)'s instance-scoped read model, matching the snapshot echo). No HTTP route is added — instance-detail read scope is the OPEN owner question D-5.


## Fix round (post-adversarial-gate, head b9926533f9)
Rebased onto current origin/main (K4 + P6-amount; clean, no conflicts — K4's `continuous_dept_heads` resolves from directory, not a form driver, so the driver collection is unchanged).

- **P1-1 (BLOCKING — live privilege escalation) — FIXED.** The publish pin rejected only an *explicit* `editable` driver entry; OD-L7-9's absent≡editable left a driver **omitted** from a handler's matrix default-writable, so a handler could edit a `form_field_user` / `ConditionRule` / condition-formula driver via direct HTTP and choose their own downstream reviewer (reproduced end-to-end on a brand-new normally-published graph). Fix = a **runtime driver-write guard** in `applyHandlerFieldWrites` that refuses a write to any field in the instance's frozen-graph driver set **independent of the matrix** (`APPROVAL_FIELD_WRITE_DRIVER_FORBIDDEN`, values-free) — defense-in-depth, not an authoring narrowing (which would trip §2.1 widen-only). Shared helper **`collectRoutingDriverFieldIds(nodes)`** factored so the publish pin and the runtime guard use one collection and can't drift. New test `G-4 (runtime driver guard)` reproduces the exact escalation (default-editable/absent driver → now **403**) + positive control (non-driver still writes 200); the former legacy-flip test is repurposed to prove the guard also closes the **explicit**-editable subcase. G-11's claim corrected to "a NON-driver field."
- **P2-1 (G-4 formula sub-case vacuous) — FIXED.** Fixture used bare `formula_num > 5` (400 came from the formula parser, not the pin). Corrected to brace-delimited `{formula_num} > 5`, and all three driver sub-cases now assert the **driver-pin error message** (`routing-driver field … OD-L7-8`), not a bare `status===400`.
- **P2-2 (G-16 cross-dispatch dedup untested) — FIXED.** Added `G-16 (cross-dispatch)`: `A(GATE)→handler_H(edit)→mid(HANDLER2)→C(GATE)` with dedup ON — GATE's pre-edit A is excluded via `MAX(audit_record_id)` when C's dedup resolves at a **later** dispatch (C stays pending); no-edit control auto-approves C on A.
- **NIT** — PR body corrected to 21/21.

**Fix-round mutation proofs** (cp-backup + sha256 restore, never `git checkout --`; APS restored to `088e46459…`):
| Mutation | Target | Result |
|---|---|---|
| M-P1 neuter runtime driver guard | `applyHandlerFieldWrites` | escalation + legacy tests red (2) ✓ |
| M-P2-1 disable formula arm | `collectRoutingDriverFieldIds` | G-4 formula sub-case red (201≠400) ✓ |
| M-P2-2 neuter `MAX(audit_record_id)` | `loadApprovalHistory` | cross-dispatch red (approved≠pending) ✓ |

**Re-verification:** backend `tsc` + `vue-tsc` clean · P4-B real-DB suite **18/18** · P4-A handler **21/21** · backend approval unit **261/261** · full `run-required-web-tests.sh` **4547/4547** (Node 20) · `plugin-tests.yml` byte-identical · no control bytes · no closing keywords.


### Fix-round follow-up (per-kind write-path coverage, head 1d870f7c60)
Post-fix review found the runtime-guard tests exercised only the `form_field_user` arm end-to-end (M-P1 neuters the whole guard branch, so it can't discriminate per-kind). Extended `G-4 (runtime driver guard)` to also route through a `condition` node keyed on `route_num` and assert a `fieldWrites: { route_num: 9 }` write is refused `APPROVAL_FIELD_WRITE_DRIVER_FORBIDDEN` — so the **ConditionRule arm is now load-bearing at the write path**. New mutation **M-CR** (delete the ConditionRule arm from `collectRoutingDriverFieldIds`) → the runtime-guard test reds (200≠403) ✓ (previously stayed green). The formula arm is already load-bearing via M-P2-1 (publish) over the same shared collection.

Formula re-parse safety made explicit in code: the guard's `collectRoutingDriverFieldIds` re-parses condition formulas, but the same dispatch already ran `asRuntimeGraph` → `normalizeConditionFormulaPredicate` over the identical stored formulas first, so an unparseable stored formula throws there (existing dispatch behavior) before the guard — no new in-flight break (§2.1).
