### PR TITLE
feat(approval): K5-b — dept_head_at_level assignee kind (Lock-1 §K5-b)

### DIFF
--- a/.github/workflows/approval-realdb-acceptance.yml
+++ b/.github/workflows/approval-realdb-acceptance.yml
@@ -6,6 +6,10 @@ name: Approval real-DB acceptance (Lock-1 assignee kinds)
 #   - approval-realdb-k4: §K4 `continuous_dept_heads`
 #     (tests/integration/approval-dept-head-chain.db.test.ts — G-1/G-2/G-13,
 #      continue-past-empty-level over real SQL, freeze-purity/temporal)
+#   - approval-realdb-k5b: §K5-b `dept_head_at_level` (strictly downstream of K4 — reads the SAME
+#     deptHeadChainIds snapshot field)
+#     (tests/integration/approval-dept-head-at-level.db.test.ts — G-1/G-2, positional-not-hop-count
+#      over real SQL, out-of-range→emptyAssigneePolicy, freeze-purity/temporal)
 # Ephemeral first-party PostgreSQL container per job; no customer source, no deployment, no
 # flag change.
 #
@@ -36,6 +40,7 @@ on:
     paths:
       - 'packages/core-backend/tests/integration/approval-requester-choice.db.test.ts'
       - 'packages/core-backend/tests/integration/approval-dept-head-chain.db.test.ts'
+      - 'packages/core-backend/tests/integration/approval-dept-head-at-level.db.test.ts'
       - 'packages/core-backend/tests/helpers/approval-schema-bootstrap.ts'
       - 'packages/core-backend/src/services/ApprovalProductService.ts'
       - 'packages/core-backend/src/services/ApprovalAssigneeResolver.ts'
@@ -50,6 +55,7 @@ on:
     paths:
       - 'packages/core-backend/tests/integration/approval-requester-choice.db.test.ts'
       - 'packages/core-backend/tests/integration/approval-dept-head-chain.db.test.ts'
+      - 'packages/core-backend/tests/integration/approval-dept-head-at-level.db.test.ts'
       - 'packages/core-backend/tests/helpers/approval-schema-bootstrap.ts'
       - 'packages/core-backend/src/services/ApprovalProductService.ts'
       - 'packages/core-backend/src/services/ApprovalAssigneeResolver.ts'
@@ -215,6 +221,83 @@ jobs:
             echo "suite=approval-dept-head-chain.db.test.ts"
             echo "lock=approval-lock1-enterprise-assignees-20260817 §K4"
             echo "gates=G-1,G-2,G-13 (continue-past-empty-level over real SQL, freeze-purity/temporal)"
+            echo "customerSourceAccess=NOT_INVOLVED"
+            echo "flagChanged=false"
+            echo "externalWrite=false"
+          } | tee -a "$GITHUB_STEP_SUMMARY"
+
+  approval-realdb-k5b:
+    name: approval-realdb-k5b
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: metasheet_approval_realdb
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d metasheet_approval_realdb"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 20
+    env:
+      DATABASE_URL: postgresql://postgres:postgres@127.0.0.1:5432/metasheet_approval_realdb
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js 20.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.16.1
+          run_install: false
+
+      - name: Use empty npmrc for pnpm
+        run: |
+          echo "" > /tmp/empty-npmrc
+          echo "NPM_CONFIG_USERCONFIG=/tmp/empty-npmrc" >> "$GITHUB_ENV"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run DB migrations
+        env:
+          # Same per-PR-gate exclusion list as plugin-tests.yml's "Run DB migrations" step
+          # (see the T8 note there and packages/core-backend/MIGRATION_EXCLUDE_TRACKING.md
+          # for the per-item detail) — this lane provisions the identical schema the
+          # approval real-DB steps run against.
+          MIGRATION_EXCLUDE: 008_plugin_infrastructure.sql,048_create_event_bus_tables.sql,049_create_bpmn_workflow_tables.sql,042a_core_model_views.sql,20250924140000_create_gantt_tables.ts,20250925_create_view_tables.sql
+        run: pnpm --filter @metasheet/core-backend db:migrate
+
+      - name: Run Lock-1 §K5-b dept_head_at_level real-DB acceptance (whole file)
+        # WHOLE FILE, --reporter=verbose: a name filter matching zero tests would exit
+        # green and hide regressions; verbose prints every collected test so an empty
+        # collection shows in the log instead of reading as green. The sentinel here is
+        # the file's own top-level `sentinel: DATABASE_URL is set` test — it is INSIDE
+        # describeIfDatabase (same posture as K4's job), which is sufficient in THIS lane
+        # because DATABASE_URL is unconditionally set above.
+        run: >-
+          pnpm --filter @metasheet/core-backend exec vitest
+          --config vitest.integration.config.ts run
+          tests/integration/approval-dept-head-at-level.db.test.ts
+          --reporter=verbose
+
+      - name: Values-free evidence (this job)
+        run: |
+          {
+            echo "evidenceKind=CONTROLLED_SYNTHETIC_FUNCTIONAL"
+            echo "suite=approval-dept-head-at-level.db.test.ts"
+            echo "lock=approval-lock1-enterprise-assignees-20260817 §K5-b"
+            echo "gates=G-1,G-2 (positional-not-hop-count over real SQL, out-of-range->emptyAssigneePolicy, freeze-purity/temporal)"
             echo "customerSourceAccess=NOT_INVOLVED"
             echo "flagChanged=false"
             echo "externalWrite=false"

--- a/apps/web/src/approvals/approvalCapabilityRegistry.ts
+++ b/apps/web/src/approvals/approvalCapabilityRegistry.ts
@@ -38,6 +38,11 @@ export const APPROVAL_ASSIGNEE_SOURCE_LABELS: Record<ApprovalAssigneeSourceKind,
   // deptHeadChainIds snapshot + resolver arm end to end (registry table row:
   // 连续多级部门负责人 / approval).
   continuous_dept_heads: '连续多级部门负责人',
+  // Lock-1 §K5-b (RATIFIED 2026-08-17) — admitted in the SAME slice that lands the resolver arm
+  // end to end (registry table row: 指定层级部门负责人 / approval; "Admitted when: K4 landed").
+  // NOT admitted on `handler` — Lock-3 §1.5's forward ADMIT row is a separate follow-up (see
+  // HANDLER_ASSIGNEE_SOURCE_KINDS below, which deliberately does not include this kind).
+  dept_head_at_level: '指定层级部门负责人',
 }
 
 /** Display order matches parent §10.3's listed order. Kept as an explicit array (rather than
@@ -56,6 +61,8 @@ const SHIPPED_ASSIGNEE_SOURCE_KIND_ORDER: readonly ApprovalAssigneeSourceKind[] 
   'requester_choice',
   // Lock-1 §K4: appended after K2.
   'continuous_dept_heads',
+  // Lock-1 §K5-b: appended after K4 (strictly downstream of it).
+  'dept_head_at_level',
 ]
 
 export interface ApprovalAssigneeSourceCapability {

--- a/apps/web/src/approvals/approvalNodeEdit.ts
+++ b/apps/web/src/approvals/approvalNodeEdit.ts
@@ -177,6 +177,10 @@ function isAssigneeSourceValid(source: ApprovalAssigneeSource, topLevelUserField
     // normalizeApprovalAssigneeSources stays the arbiter on the ceiling).
     case 'continuous_dept_heads':
       return Number.isInteger(source.levels) && source.levels >= 1
+    // Lock-1 §K5-b PREVIEW: same shape/cap posture as manager_at_level (backend
+    // normalizeApprovalAssigneeSources stays the arbiter on the ceiling).
+    case 'dept_head_at_level':
+      return Number.isInteger(source.level) && source.level >= 1
     case 'requester_choice':
       // Lock-1 §K2 PREVIEW (backend normalizeApprovalAssigneeSources stays the arbiter):
       // mode + scope discriminator, and a members/role scope needs ≥1 configured id.

--- a/apps/web/src/approvals/assigneeSource.ts
+++ b/apps/web/src/approvals/assigneeSource.ts
@@ -27,6 +27,7 @@ export function assigneeSourceSummary(source: ApprovalAssigneeSource): string {
     case 'continuous_managers': return `连续多级上级（${source.levels} 级）`
     case 'manager_at_level': return `指定层级上级（第 ${source.level} 级）`
     case 'continuous_dept_heads': return `连续多级部门负责人（${source.levels} 级）`
+    case 'dept_head_at_level': return `指定层级部门负责人（第 ${source.level} 级）`
     // Lock-1 §K2: pre-choice placeholder — the approver is unknowable until the requester
     // chooses at submit time, so the flow/route preview says exactly that.
     case 'requester_choice': return '提交人自选（提交时选择）'

--- a/apps/web/src/approvals/components/ApprovalGraphNodeConfigEditor.vue
+++ b/apps/web/src/approvals/components/ApprovalGraphNodeConfigEditor.vue
@@ -508,8 +508,8 @@
         </el-select>
       </el-form-item>
       <el-form-item
-        v-else-if="approvalSourceKind(node.key) === 'manager_at_level' || approvalSourceKind(node.key) === 'continuous_managers' || approvalSourceKind(node.key) === 'continuous_dept_heads'"
-        :label="approvalSourceKind(node.key) === 'manager_at_level' ? '指定上级层级' : approvalSourceKind(node.key) === 'continuous_dept_heads' ? '部门负责人层级数' : '上级层级数'"
+        v-else-if="approvalSourceKind(node.key) === 'manager_at_level' || approvalSourceKind(node.key) === 'continuous_managers' || approvalSourceKind(node.key) === 'continuous_dept_heads' || approvalSourceKind(node.key) === 'dept_head_at_level'"
+        :label="approvalSourceKind(node.key) === 'manager_at_level' ? '指定上级层级' : approvalSourceKind(node.key) === 'continuous_dept_heads' ? '部门负责人层级数' : approvalSourceKind(node.key) === 'dept_head_at_level' ? '指定部门负责人层级' : '上级层级数'"
       >
         <el-input-number
           :model-value="approvalSourceLevel(node.key)"

--- a/apps/web/src/approvals/parallelEdit.ts
+++ b/apps/web/src/approvals/parallelEdit.ts
@@ -161,6 +161,8 @@ function dynamicAssigneeSourceFingerprint(source: ApprovalAssigneeSource): strin
       return `manager_at_level:${source.level}`
     case 'continuous_dept_heads':
       return `continuous_dept_heads:${source.levels}`
+    case 'dept_head_at_level':
+      return `dept_head_at_level:${source.level}`
     case 'form_field_user':
       return `form_field_user:${source.fieldId.trim()}`
     case 'static_user':

--- a/apps/web/src/approvals/templateAuthoring.ts
+++ b/apps/web/src/approvals/templateAuthoring.ts
@@ -518,6 +518,10 @@ function stepDraftFromApprovalNode(
     // Lock-1 §K4: same shape as continuous_managers — reuses the shared `levels` field.
     sourceKind = 'continuous_dept_heads'
     levels = source.levels
+  } else if (source?.kind === 'dept_head_at_level') {
+    // Lock-1 §K5-b: same shape as manager_at_level — reuses the shared `level` field.
+    sourceKind = 'dept_head_at_level'
+    level = source.level
   } else if (source?.kind === 'requester_choice') {
     // Lock-1 §K2: hydrate mode + scope; a members/role scope's id list rides the shared
     // idsText chip carrier (sourceFromStep re-shapes it back per scope type).
@@ -677,6 +681,8 @@ const BACKEND_ASSIGNEE_SOURCE_KEYS_BY_KIND: Record<string, string[]> = {
   manager_at_level: ['kind', 'level'],
   // Lock-1 §K4: same flat 2-level shape as continuous_managers.
   continuous_dept_heads: ['kind', 'levels'],
+  // Lock-1 §K5-b: same flat 2-level shape as manager_at_level.
+  dept_head_at_level: ['kind', 'level'],
   form_field_user: ['kind', 'fieldId'],
   // Lock-1 §K2: `scope` is the ONE nested object in the source union (see
   // requesterChoiceSourceHasBackendDrop below for its per-type key check — the flat 2-level
@@ -873,7 +879,7 @@ export function unsupportedTemplateAuthoringReason(template: ApprovalTemplateDet
     if (sources !== undefined) {
       if (!Array.isArray(sources) || sources.length !== 1) return true
       const source = sources[0] as ApprovalAssigneeSource
-      if (!['static_user', 'static_role', 'requester', 'form_field_user', 'direct_manager', 'dept_head', 'continuous_managers', 'manager_at_level', 'requester_choice', 'continuous_dept_heads'].includes(source?.kind)) return true
+      if (!['static_user', 'static_role', 'requester', 'form_field_user', 'direct_manager', 'dept_head', 'continuous_managers', 'manager_at_level', 'requester_choice', 'continuous_dept_heads', 'dept_head_at_level'].includes(source?.kind)) return true
       // Lock-1 §K2: a malformed requester_choice shape must fail-closed to read-only here too —
       // hydrate would otherwise re-derive a default mode/scope and silently flatten it on save.
       if (source?.kind === 'requester_choice' && requesterChoiceSourceHasBackendDrop(source as unknown as Record<string, unknown>)) return true
@@ -1090,6 +1096,10 @@ export function sourceFromStep(step: ApprovalStepDraft): ApprovalAssigneeSource 
   if (step.sourceKind === 'continuous_dept_heads') {
     // Lock-1 §K4: reuses the shared `levels` field (same shape as continuous_managers).
     return { kind: 'continuous_dept_heads', levels: step.levels }
+  }
+  if (step.sourceKind === 'dept_head_at_level') {
+    // Lock-1 §K5-b: reuses the shared `level` field (same shape as manager_at_level).
+    return { kind: 'dept_head_at_level', level: step.level }
   }
   if (step.sourceKind === 'requester_choice') {
     // Lock-1 §K2: re-shape the shared idsText carrier into the per-scope id list.

--- a/apps/web/src/types/approval.ts
+++ b/apps/web/src/types/approval.ts
@@ -18,7 +18,7 @@ export const APPROVAL_ROLE_CONFIGURE_SENTINEL = '__APPROVAL_ROLE_PLACEHOLDER__'
 // `APPROVAL_NODE_TYPES` admission set.
 export type ApprovalNodeType = 'start' | 'approval' | 'cc' | 'condition' | 'parallel' | 'end' | 'handler'
 export type ApprovalAssigneeType = 'user' | 'role'
-export type ApprovalAssigneeSourceKind = 'static_user' | 'static_role' | 'requester' | 'form_field_user' | 'direct_manager' | 'dept_head' | 'continuous_managers' | 'manager_at_level' | 'requester_choice' | 'continuous_dept_heads'
+export type ApprovalAssigneeSourceKind = 'static_user' | 'static_role' | 'requester' | 'form_field_user' | 'direct_manager' | 'dept_head' | 'continuous_managers' | 'manager_at_level' | 'requester_choice' | 'continuous_dept_heads' | 'dept_head_at_level'
 export type ApprovalMode = 'single' | 'all' | 'any'
 export type ParallelJoinMode = 'all' | 'any'
 export type EmptyAssigneePolicy = 'error' | 'auto-approve'
@@ -156,6 +156,14 @@ export type ApprovalAssigneeSource =
    * same as `continuous_managers`.
    */
   | { kind: 'continuous_dept_heads'; levels: number }
+  /**
+   * Lock-1 §K5-b — 指定层级部门负责人. Byte-mirrors the backend union member: `deptHeadChainIds[level-1]`,
+   * positionally identical to `manager_at_level` but over the K4 department-head chain instead of
+   * `managerChainIds`. Level 1 = the requester's own department head. No authoring shape beyond
+   * `level`; the picker is the SAME plain level input as `manager_at_level` (single level, not a
+   * level count).
+   */
+  | { kind: 'dept_head_at_level'; level: number }
 
 export type RequesterChoiceAssigneeSource = Extract<ApprovalAssigneeSource, { kind: 'requester_choice' }>
 

--- a/apps/web/src/views/approval/TemplateAuthoringView.vue
+++ b/apps/web/src/views/approval/TemplateAuthoringView.vue
@@ -570,6 +570,7 @@
                 <el-option label="表单用户字段" value="form_field_user" />
                 <el-option label="提交人自选" value="requester_choice" />
                 <el-option label="连续多级部门负责人" value="continuous_dept_heads" />
+                <el-option label="指定层级部门负责人" value="dept_head_at_level" />
               </el-select>
             </el-form-item>
             <el-form-item v-if="step.sourceKind === 'continuous_managers'" label="上级层级数">
@@ -605,6 +606,18 @@
                 :step="1"
                 :disabled="readOnly"
                 data-testid="approval-step-level"
+              />
+            </el-form-item>
+            <!-- Lock-1 §K5-b (指定层级部门负责人) linear authoring: reuses the shared `level`
+                 field, same shape/cap posture as manager_at_level (a single level, not a count). -->
+            <el-form-item v-if="step.sourceKind === 'dept_head_at_level'" label="指定部门负责人层级">
+              <el-input-number
+                v-model="step.level"
+                :min="1"
+                :max="10"
+                :step="1"
+                :disabled="readOnly"
+                data-testid="approval-step-dept-head-level"
               />
             </el-form-item>
             <el-form-item v-if="step.sourceKind === 'static_user'" label="选择用户">
@@ -1905,7 +1918,9 @@ function defaultApprovalSourceForKind(kind: ApprovalAssigneeSourceKind): Approva
             : kind === 'requester_choice' ? { kind, mode: 'single', scope: { type: 'company' } }
               // Lock-1 §K4: same default shape as continuous_managers.
               : kind === 'continuous_dept_heads' ? { kind, levels: 1 }
-                : { kind: kind as 'requester' | 'direct_manager' | 'dept_head' }
+                // Lock-1 §K5-b: same default shape as manager_at_level.
+                : kind === 'dept_head_at_level' ? { kind, level: 1 }
+                  : { kind: kind as 'requester' | 'direct_manager' | 'dept_head' }
 }
 function setApprovalSourceKind(nodeKey: string, kind: ApprovalAssigneeSourceKind): void {
   const current = approvalNodeFirstSource(nodeKey)
@@ -2518,6 +2533,8 @@ function approvalSourceLevel(nodeKey: string): number {
   if (source?.kind === 'continuous_managers') return source.levels
   // Lock-1 §K4: same shared-field shape as continuous_managers.
   if (source?.kind === 'continuous_dept_heads') return source.levels
+  // Lock-1 §K5-b: same shared-field shape as manager_at_level.
+  if (source?.kind === 'dept_head_at_level') return source.level
   return 1
 }
 function setApprovalSourceLevel(nodeKey: string, value: number): void {
@@ -2525,6 +2542,7 @@ function setApprovalSourceLevel(nodeKey: string, value: number): void {
   if (kind === 'manager_at_level') setApprovalNodeSource(nodeKey, { kind, level: value })
   else if (kind === 'continuous_managers') setApprovalNodeSource(nodeKey, { kind, levels: value })
   else if (kind === 'continuous_dept_heads') setApprovalNodeSource(nodeKey, { kind, levels: value })
+  else if (kind === 'dept_head_at_level') setApprovalNodeSource(nodeKey, { kind, level: value })
 }
 
 const userFields = computed(() => draft.value.fields.filter((field) => field.type === 'user' && field.id.trim()))

--- a/apps/web/tests/approval-assignee-source.test.ts
+++ b/apps/web/tests/approval-assignee-source.test.ts
@@ -46,6 +46,10 @@ describe('assigneeSourceSummary (single source)', () => {
     expect(assigneeSourceSummary({ kind: 'continuous_dept_heads', levels: 3 })).toBe('连续多级部门负责人（3 级）')
   })
 
+  it('dept_head_at_level: includes the specific level (Lock-1 §K5-b)', () => {
+    expect(assigneeSourceSummary({ kind: 'dept_head_at_level', level: 2 })).toBe('指定层级部门负责人（第 2 级）')
+  })
+
   it('requester_choice: fixed pre-choice placeholder (提交时选择), no config values leaked (Lock-1 §K2)', () => {
     expect(
       assigneeSourceSummary({ kind: 'requester_choice', mode: 'single', scope: { type: 'company' } }),

--- a/apps/web/tests/approval-handler-node-authoring.spec.ts
+++ b/apps/web/tests/approval-handler-node-authoring.spec.ts
@@ -65,6 +65,13 @@ describe('Lock-3 G-13 — handler assignee-source registry exact set', () => {
     expect(roster.length).toBeLessThan(approvalRoster.length)
     expect(roster).not.toContain('continuous_managers')
     expect(roster).not.toContain('requester_choice')
+    // Lock-1 §K5-b `dept_head_at_level`: Lock-3 §1.5 names it a FORWARD ADMIT row for `handler`,
+    // but per the SAME precedent this file already documents for `requester_choice` (shipped
+    // before P4-A, and P4-A deliberately did NOT retroactively widen the roster for it — "a
+    // separate follow-up decision, not P4-A", approval-product.ts's HANDLER_ASSIGNEE_SOURCE_KINDS
+    // doc comment), K5-b's own slice does not widen the SEVEN-member handler roster either. Not
+    // admitting it here is the deliberate deferral, not an oversight.
+    expect(roster).not.toContain('dept_head_at_level')
   })
 
   it('mutation 1 — dropping an admitted kind fails the exact-set check', () => {
@@ -79,6 +86,19 @@ describe('Lock-3 G-13 — handler assignee-source registry exact set', () => {
   it('mutation 2 — adding continuous_managers fails the exact-set check', () => {
     const added: ApprovalCapabilityRegistry = {
       assigneeSourcesByNodeType: { handler: [...assigneeSourceRoster(DEFAULT_APPROVAL_CAPABILITY_REGISTRY, 'handler'), { kind: 'continuous_managers', label: '连续多级上级' }] },
+      operationPoliciesByNodeType: {},
+    }
+    const roster = assigneeSourceRoster(added, 'handler').map((c) => c.kind)
+    expect(new Set(roster)).not.toEqual(new Set(HANDLER_ASSIGNEE_SOURCE_KINDS))
+  })
+
+  // Lock-1 §K5-b deferral invariant: even though Lock-3 §1.5 names dept_head_at_level a FORWARD
+  // ADMIT row for `handler`, this slice does NOT land it (see the `roster).not.toContain(...)`
+  // assertion above) — so "adding" it here must fail the exact-set check exactly like mutation 2's
+  // continuous_managers, not be silently accepted as a legitimate widening.
+  it('mutation 3 — adding dept_head_at_level (Lock-1 §K5-b, deliberately deferred) fails the exact-set check', () => {
+    const added: ApprovalCapabilityRegistry = {
+      assigneeSourcesByNodeType: { handler: [...assigneeSourceRoster(DEFAULT_APPROVAL_CAPABILITY_REGISTRY, 'handler'), { kind: 'dept_head_at_level', label: '指定层级部门负责人' }] },
       operationPoliciesByNodeType: {},
     }
     const roster = assigneeSourceRoster(added, 'handler').map((c) => c.kind)

--- a/apps/web/tests/approval-template-authoring-approval-node-edit.test.ts
+++ b/apps/web/tests/approval-template-authoring-approval-node-edit.test.ts
@@ -240,6 +240,26 @@ describe('validateApprovalNodeEdits (preview mirrors the backend assignee rule)'
       a: { nodeKey: 'a', assigneeSources: [{ kind: 'continuous_dept_heads', levels: 1.5 }] },
     })[0]).toMatch(/continuous_dept_heads/)
   })
+  it('Lock-1 §K5-b: dept_head_at_level — a positive integer level passes; 0/non-integer is flagged (isAssigneeSourceValid mirror site)', () => {
+    expect(validateApprovalNodeEdits({
+      a: { nodeKey: 'a', assigneeSources: [{ kind: 'dept_head_at_level', level: 2 }] },
+    })).toEqual([])
+    expect(validateApprovalNodeEdits({
+      a: { nodeKey: 'a', assigneeSources: [{ kind: 'dept_head_at_level', level: 0 }] },
+    })[0]).toMatch(/dept_head_at_level/)
+    expect(validateApprovalNodeEdits({
+      a: { nodeKey: 'a', assigneeSources: [{ kind: 'dept_head_at_level', level: 1.5 }] },
+    })[0]).toMatch(/dept_head_at_level/)
+  })
+  // Lock-3 §1.5 deferral invariant: dept_head_at_level (K5-b) is NOT in the handler roster in
+  // this slice (Lock-3's forward ADMIT is a separate follow-up — see
+  // approval-handler-node-authoring.spec.ts's exact-set test). A handler carrying it must fail
+  // closed here too.
+  it('Lock-3 §1.5 deferral: a HANDLER node carrying dept_head_at_level is rejected (not in the seven-member handler roster)', () => {
+    expect(validateApprovalNodeEdits({
+      a: { nodeKey: 'a', nodeType: 'handler', assigneeSources: [{ kind: 'dept_head_at_level', level: 1 }] },
+    })[0]).toMatch(/dept_head_at_level/)
+  })
 })
 
 describe('G-5 fail-closed — complex approval-node config must stay within the BACKEND allowlist', () => {
@@ -338,6 +358,18 @@ describe('G-5 fail-closed — complex approval-node config must stay within the 
   })
   it('K4: a continuous_dept_heads source with an unknown extra key forces read-only', () => {
     const graph = complexWith({ assigneeSources: [{ kind: 'continuous_dept_heads', levels: 3, futureFlag: true }] })
+    expect(unsupportedTemplateAuthoringReason(buildTemplate(graph))).not.toBeNull()
+  })
+
+  // Lock-1 §K5-b — BACKEND_ASSIGNEE_SOURCE_KEYS_BY_KIND mirror site: dept_head_at_level must be
+  // ALLOWED (present in the allowlist) on the complex path, and an extra key on it must still be
+  // caught (the allowlist is per-kind exact, not a blanket pass-through).
+  it('K5-b: dept_head_at_level is allowed on the complex path (registered in BACKEND_ASSIGNEE_SOURCE_KEYS_BY_KIND)', () => {
+    const graph = complexWith({ assigneeSources: [{ kind: 'dept_head_at_level', level: 2 }] })
+    expect(unsupportedTemplateAuthoringReason(buildTemplate(graph))).toBeNull()
+  })
+  it('K5-b: a dept_head_at_level source with an unknown extra key forces read-only', () => {
+    const graph = complexWith({ assigneeSources: [{ kind: 'dept_head_at_level', level: 2, futureFlag: true }] })
     expect(unsupportedTemplateAuthoringReason(buildTemplate(graph))).not.toBeNull()
   })
 })

--- a/apps/web/tests/approval-template-authoring-canvas-inspector.spec.ts
+++ b/apps/web/tests/approval-template-authoring-canvas-inspector.spec.ts
@@ -977,7 +977,7 @@ describe('Canvas V2 Slice A — canvas inspector', () => {
   // "iterate the exported table" mechanical assertion, not per-kind spot checks), so any single
   // label reverting to pre-D1 wording (or drifting to anything else) reds here regardless of
   // whether it happens to be one of the two kinds the D1/D2 test exercises.
-  it('D1 (P2-2): all ten assignee-source labels equal the ratified map by exact object equality', () => {
+  it('D1 (P2-2): all eleven assignee-source labels equal the ratified map by exact object equality', () => {
     const RATIFIED_APPROVAL_ASSIGNEE_SOURCE_LABELS: Record<string, string> = {
       static_user: '指定成员',
       static_role: '指定角色',
@@ -993,11 +993,15 @@ describe('Canvas V2 Slice A — canvas inspector', () => {
       // Lock-1 §K4 (RATIFIED 2026-08-17) — the 连续多级部门负责人 registry row, admitted in the
       // SAME slice that lands the deptHeadChainIds snapshot + resolver arm (Lock-1 §2.3 table).
       continuous_dept_heads: '连续多级部门负责人',
+      // Lock-1 §K5-b (RATIFIED 2026-08-17) — the 指定层级部门负责人 registry row, admitted in the
+      // SAME slice that lands the resolver arm end to end (Lock-1 §2.3 table: "Admitted when: K4
+      // landed").
+      dept_head_at_level: '指定层级部门负责人',
     }
     expect(APPROVAL_ASSIGNEE_SOURCE_LABELS).toEqual(RATIFIED_APPROVAL_ASSIGNEE_SOURCE_LABELS)
-    // Also pin the count so a stray 11th entry (which would still satisfy `toEqual` on the keys
+    // Also pin the count so a stray 12th entry (which would still satisfy `toEqual` on the keys
     // above via structural superset checks in some matcher semantics) cannot slip through unnoticed.
-    expect(Object.keys(APPROVAL_ASSIGNEE_SOURCE_LABELS)).toHaveLength(10)
+    expect(Object.keys(APPROVAL_ASSIGNEE_SOURCE_LABELS)).toHaveLength(11)
   })
 
   it('A-7: no scrim/overlay-mask element with the inspector mounted and visible', async () => {
@@ -1408,7 +1412,9 @@ describe('Lock-0 P1-A — registry-driven tab membership + roster (direct mount)
                   : kind === 'manager_at_level' ? { kind, level: 1 }
                     // Lock-1 §K4: same default shape as continuous_managers.
                     : kind === 'continuous_dept_heads' ? { kind, levels: 1 }
-                      : { kind }
+                      // Lock-1 §K5-b: same default shape as manager_at_level.
+                      : kind === 'dept_head_at_level' ? { kind, level: 1 }
+                        : { kind }
         edit.assigneeSources = [next, ...edit.assigneeSources.slice(1)]
       },
       syncApprovalNodeOptions: () => {},
@@ -1437,6 +1443,7 @@ describe('Lock-0 P1-A — registry-driven tab membership + roster (direct mount)
         if (source.kind === 'manager_at_level') source.level = value
         else if (source.kind === 'continuous_managers') source.levels = value
         else if (source.kind === 'continuous_dept_heads') source.levels = value
+        else if (source.kind === 'dept_head_at_level') source.level = value
       },
       approvalSourceIsPlaceholder: () => false,
       approvalNodeMode: () => 'single',
@@ -1629,13 +1636,15 @@ describe('Lock-0 P1-A — registry-driven tab membership + roster (direct mount)
     unmount()
   })
 
-  it('A-3: roster equals the ten-member ApprovalAssigneeSourceKind union by exact set equality, not count or subset', () => {
+  it('A-3: roster equals the eleven-member ApprovalAssigneeSourceKind union by exact set equality, not count or subset', () => {
     // Lock-1 §2.3: the exact-set gate grows from eight to eight-plus-ratified-K-kinds in the
-    // SAME commit that lands each kind — K2 `requester_choice`, K4 `continuous_dept_heads`.
-    const CANONICAL_TEN = [
+    // SAME commit that lands each kind — K2 `requester_choice`, K4 `continuous_dept_heads`, K5-b
+    // `dept_head_at_level`.
+    const CANONICAL_ELEVEN = [
       'continuous_dept_heads',
       'continuous_managers',
       'dept_head',
+      'dept_head_at_level',
       'direct_manager',
       'form_field_user',
       'manager_at_level',
@@ -1647,7 +1656,7 @@ describe('Lock-0 P1-A — registry-driven tab membership + roster (direct mount)
     const roster = [...assigneeSourceRoster(DEFAULT_APPROVAL_CAPABILITY_REGISTRY, 'approval')]
       .map((opt) => opt.kind)
       .sort()
-    expect(roster).toEqual(CANONICAL_TEN)
+    expect(roster).toEqual(CANONICAL_ELEVEN)
 
     const node = makeApprovalNode('approval_x')
     const { container: c, unmount } = mountDirectInspector({
@@ -1660,7 +1669,7 @@ describe('Lock-0 P1-A — registry-driven tab membership + roster (direct mount)
     )
       .map((el) => el.getAttribute('data-testid')?.replace('approval-node-source-kind-', ''))
       .sort()
-    expect(rendered).toEqual(CANONICAL_TEN)
+    expect(rendered).toEqual(CANONICAL_ELEVEN)
     unmount()
   })
 
@@ -1676,6 +1685,25 @@ describe('Lock-0 P1-A — registry-driven tab membership + roster (direct mount)
       api: createStubConfigApi({ approval_dh: { assigneeSources: [{ kind: 'continuous_dept_heads', levels: 2 }] } }),
     })
     const roster = c.querySelector('[data-testid="approval-node-source-kind-continuous_dept_heads"]') as HTMLInputElement
+    expect(roster).not.toBeNull()
+    expect(roster.checked).toBe(true)
+    expect(c.querySelector('[data-testid="approval-node-source-level"]')).not.toBeNull()
+    expect(c.querySelector('[data-testid="approval-node-source-kind-unknown"]')).toBeNull()
+    unmount()
+  })
+
+  // Lock-1 §K5-b — dept_head_at_level authoring sub-form: registry-admitted, renders EDITABLE
+  // with the SAME shared level input as manager_at_level (a single level, not a count — the
+  // el-input-number is shared by kind-family via approvalSourceLevel/setApprovalSourceLevel, so
+  // this reuses testid `approval-node-source-level`, not K4's `-dept-head-levels`).
+  it('K5-b: dept_head_at_level renders EDITABLE with the level input (registry-admitted)', () => {
+    const node = makeApprovalNode('approval_dhal')
+    const { container: c, unmount } = mountDirectInspector({
+      node,
+      registry: DEFAULT_APPROVAL_CAPABILITY_REGISTRY,
+      api: createStubConfigApi({ approval_dhal: { assigneeSources: [{ kind: 'dept_head_at_level', level: 2 }] } }),
+    })
+    const roster = c.querySelector('[data-testid="approval-node-source-kind-dept_head_at_level"]') as HTMLInputElement
     expect(roster).not.toBeNull()
     expect(roster.checked).toBe(true)
     expect(c.querySelector('[data-testid="approval-node-source-level"]')).not.toBeNull()

--- a/apps/web/tests/approval-template-authoring-parallel-edit.test.ts
+++ b/apps/web/tests/approval-template-authoring-parallel-edit.test.ts
@@ -408,6 +408,16 @@ describe('parallelDynamicAssigneeConflicts — publish preflight (F2)', () => {
     )).toEqual([])
   })
 
+  it('Lock-1 §K5-b: flags identical dept_head_at_level levels — the fingerprint mirror is in lockstep with the backend', () => {
+    expect(parallelDynamicAssigneeConflicts(
+      withBranchSources([{ kind: 'dept_head_at_level', level: 2 }], [{ kind: 'dept_head_at_level', level: 2 }]),
+    )).toHaveLength(1)
+    // Positive control: DIFFERENT levels are NOT flagged (parameterized, not kind-blanket).
+    expect(parallelDynamicAssigneeConflicts(
+      withBranchSources([{ kind: 'dept_head_at_level', level: 1 }], [{ kind: 'dept_head_at_level', level: 3 }]),
+    )).toEqual([])
+  })
+
   it('Lock-1 §K2 / G-17: requester_choice × requester_choice is NOT flagged (null fingerprint DELIBERATE — same-person collision is the runtime 409 guard\'s job)', () => {
     // Two requester_choice sources on parallel branches are NOT provably identical — the
     // requester may pick different people per branch — so the publish preflight must not block
@@ -436,6 +446,16 @@ describe('parallelDynamicAssigneeConflicts — publish preflight (F2)', () => {
     // pointer, per §K4) — same `levels` value must not collide even though the shapes are alike.
     expect(parallelDynamicAssigneeConflicts(
       withBranchSources([{ kind: 'continuous_managers', levels: 2 }], [{ kind: 'continuous_dept_heads', levels: 2 }]),
+    )).toEqual([])
+    // Lock-1 §K5-b: manager_at_level and dept_head_at_level are DIFFERENT kinds (different chain
+    // pointer, positionally alike shape — `level`) — same `level` value must not collide.
+    expect(parallelDynamicAssigneeConflicts(
+      withBranchSources([{ kind: 'manager_at_level', level: 2 }], [{ kind: 'dept_head_at_level', level: 2 }]),
+    )).toEqual([])
+    // ...and dept_head_at_level vs continuous_dept_heads (both read deptHeadChainIds) must not
+    // collide on the same numeric value either — the fingerprint is kind-prefixed, not bare-number.
+    expect(parallelDynamicAssigneeConflicts(
+      withBranchSources([{ kind: 'continuous_dept_heads', levels: 2 }], [{ kind: 'dept_head_at_level', level: 2 }]),
     )).toEqual([])
   })
 

--- a/apps/web/tests/approvalTemplateAuthoring.spec.ts
+++ b/apps/web/tests/approvalTemplateAuthoring.spec.ts
@@ -771,6 +771,26 @@ describe('approval template authoring helpers', () => {
     expect(rehydrated.steps[0].level).toBe(2)
   })
 
+  it('Lock-1 §K5-b: round-trips a dept_head_at_level source incl. level (save emits {kind, level}; level survives the real wire) — the linear editor accepted-kind list mirror site', () => {
+    const draft = createEmptyTemplateDraft()
+    draft.key = 'dhal'
+    draft.name = '指定层级部门负责人审批'
+    draft.steps[0].sourceKind = 'dept_head_at_level'
+    draft.steps[0].level = 2
+
+    const payload = buildCreateTemplatePayload(draft)
+    expect((payload.approvalGraph.nodes[1]?.config as any).assigneeSources).toEqual([{ kind: 'dept_head_at_level', level: 2 }])
+
+    // wire-vs-fixture trap: assert `level` survives the real serialize→parse, not a hand-built chip.
+    const rehydrated = draftFromTemplate(buildTemplate({ approvalGraph: payload.approvalGraph }))
+    expect(rehydrated.steps[0].sourceKind).toBe('dept_head_at_level')
+    expect(rehydrated.steps[0].level).toBe(2)
+    // And the rebuilt graph is byte-identical to the first emit (no hydrate flatten).
+    expect(buildCreateTemplatePayload(rehydrated).approvalGraph.nodes[1]?.config).toEqual(
+      payload.approvalGraph.nodes[1]?.config,
+    )
+  })
+
   it('Lock-1 §K2: round-trips a requester_choice source incl. mode + role scope (idsText is the scope-id carrier)', () => {
     const draft = createEmptyTemplateDraft()
     draft.key = 'rc'
@@ -1988,6 +2008,20 @@ describe('TemplateAuthoringView', () => {
     expect((container!.querySelector('[data-testid="approval-template-save-button"]') as HTMLButtonElement).disabled).toBe(false) // editable
     expect((container!.querySelector('[data-testid="approval-step-source-kind"]') as HTMLSelectElement).value).toBe('continuous_dept_heads') // hydrated back
     expect((container!.querySelector('[data-testid="approval-step-dept-head-levels"]') as HTMLInputElement)).not.toBeNull() // the levels input renders for this kind
+  })
+
+  it('Lock-1 §K5-b: dept_head_at_level reads back editable: a saved dept_head_at_level template is NOT fail-closed (sourceKind + level input hydrated, registry-admitted)', async () => {
+    routeParams = { id: 'tpl_dhal' }
+    getTemplateSpy.mockResolvedValue(buildTemplate({
+      approvalGraph: buildComboGraph({ assigneeSources: [{ kind: 'dept_head_at_level', level: 2 }], approvalMode: 'single', emptyAssigneePolicy: 'error' }),
+    }))
+    await mountView()
+    await flushUi()
+
+    expect(container!.querySelector('[data-testid="approval-template-unsupported-alert"]')).toBeNull() // in the allowlist → not fail-closed
+    expect((container!.querySelector('[data-testid="approval-template-save-button"]') as HTMLButtonElement).disabled).toBe(false) // editable
+    expect((container!.querySelector('[data-testid="approval-step-source-kind"]') as HTMLSelectElement).value).toBe('dept_head_at_level') // hydrated back
+    expect((container!.querySelector('[data-testid="approval-step-dept-head-level"]') as HTMLInputElement)).not.toBeNull() // the level input renders for this kind
   })
 
   it('updates an existing supported template without replacing it through create', async () => {

--- a/packages/core-backend/src/services/ApprovalAssigneeResolver.ts
+++ b/packages/core-backend/src/services/ApprovalAssigneeResolver.ts
@@ -274,6 +274,33 @@ export function resolveApprovalAssignees(
         })
         break
       }
+      case 'dept_head_at_level': {
+        // Lock-1 §K5-b: resolve to a SINGLE level of the requester's DEPARTMENT-HEAD chain (the
+        // `source.level`-th entry, level 1 = the requester's own department head), frozen in the
+        // same `deptHeadChainIds` snapshot K4's `continuous_dept_heads` reads — positionally
+        // IDENTICAL to `manager_at_level` (:205-225 above), just over a different chain. Strictly
+        // downstream of K4: no new snapshot field, no new directory read of its own.
+        // Self-exclusion drops a hop resolving to the requester; an empty result (chain shorter
+        // than `level`, or `deptHeadChainIds` absent because no node in the published graph
+        // triggered the bake) falls through to `emptyAssigneePolicy` — Lock-1 §K5's explicit
+        // ruling that an in-contract level absent from THIS requester's chain is never a
+        // dispatch-time failure. deptHeadChainIds is DENSE under the RATIFIED
+        // continue-past-empty-level posture (resolveDeptHeadChain continues past an empty/
+        // unresolved level to that department's own parent — see the union member's doc
+        // comment), so chain[level-1] is the level-th *resolved* head walking up, NOT "the head
+        // N parent-hops up": an intermediate department with no resolvable head shifts every
+        // deeper level's position, exactly as `manager_at_level`'s own dense-chain contract does
+        // for managerChainIds. A null rung (defensive, never produced by the builder) resolves
+        // that level to empty via normalizeId — positional, no compaction.
+        const requesterId = normalizeId(options.requesterSnapshot?.id)
+        const rawChain = options.requesterSnapshot?.deptHeadChainIds
+        const chain = Array.isArray(rawChain) ? rawChain : []
+        const headId = normalizeId(chain[source.level - 1])
+        if (headId && headId !== requesterId) {
+          pushResolved('user', headId, source, sourceIndex)
+        }
+        break
+      }
       default:
         throw new ServiceError(
           `Approval node ${options.nodeKey} has an unsupported assignee source`,

--- a/packages/core-backend/src/services/ApprovalProductService.ts
+++ b/packages/core-backend/src/services/ApprovalProductService.ts
@@ -669,6 +669,16 @@ function normalizeApprovalAssigneeSources(
         }
         return { kind: 'continuous_dept_heads', levels }
       }
+      case 'dept_head_at_level': {
+        // Lock-1 §K5-b: `level` validated byte-identically to `manager_at_level` — an
+        // out-of-range / non-integer / missing `level` is rejected, never silently
+        // defaulted (enum-strictness).
+        const level = source.level
+        if (typeof level !== 'number' || !Number.isInteger(level) || level < 1 || level > MAX_MANAGER_CHAIN_LEVELS) {
+          failValidation(context, `${sourcePath}.level must be an integer between 1 and ${MAX_MANAGER_CHAIN_LEVELS}`)
+        }
+        return { kind: 'dept_head_at_level', level }
+      }
       case 'form_field_user':
         if (!isNonEmptyString(source.fieldId)) {
           failValidation(context, `${sourcePath}.fieldId is required`)
@@ -1614,6 +1624,8 @@ function dynamicAssigneeSourceFingerprint(source: ApprovalAssigneeSource): strin
       return `manager_at_level:${source.level}`
     case 'continuous_dept_heads':
       return `continuous_dept_heads:${source.levels}`
+    case 'dept_head_at_level':
+      return `dept_head_at_level:${source.level}`
     case 'form_field_user':
       return `form_field_user:${source.fieldId}`
     case 'static_user':
@@ -3203,14 +3215,24 @@ export function runtimeGraphUsesManagerChain(runtimeGraph: RuntimeGraph): boolea
 }
 
 /**
- * Lock-1 §K4: true when any approval node's assignee sources include `continuous_dept_heads`.
- * Used at create time to decide whether to walk the (more expensive) department-head chain into
- * the requester snapshot — a SEPARATE opt-in gate from `runtimeGraphUsesManagerChain` above,
- * because `continuous_dept_heads` bakes a DIFFERENT snapshot field (`deptHeadChainIds`, a
- * different walk over a different pointer — see the union member's doc comment) via a DIFFERENT
- * option (`includeDeptHeadChain`), so an unrelated template never pays for either walk. `kind` is
- * read structurally so this works before the kind is added to the typed union (same posture as
- * `runtimeGraphUsesManagerChain`).
+ * Lock-1 §K4 / §K5-b: true when any approval node's assignee sources include `continuous_dept_heads`
+ * OR `dept_head_at_level`. Used at create time to decide whether to walk the (more expensive)
+ * department-head chain into the requester snapshot — a SEPARATE opt-in gate from
+ * `runtimeGraphUsesManagerChain` above, because both kinds bake the SAME `deptHeadChainIds`
+ * snapshot field (a different walk over a different pointer — see the union members' doc
+ * comments) via a DIFFERENT option (`includeDeptHeadChain`), so an unrelated template never pays
+ * for either walk. K5-b is strictly downstream of K4: it reads the identical snapshot field K4
+ * builds, so it shares this ONE gate rather than minting its own — mirroring how
+ * `runtimeGraphUsesManagerChain` above carries both `continuous_managers` AND `manager_at_level`
+ * for the manager-chain snapshot. Missing this extension would reproduce the exact "silent skip"
+ * class R-13 names: a graph using ONLY `dept_head_at_level` would never bake `deptHeadChainIds`,
+ * so the resolver's positional read would see `undefined` and resolve empty — indistinguishable
+ * from "no head at that level" and liable to silently auto-approve under
+ * `emptyAssigneePolicy:'auto-approve'`. Node-type is `approval`-only (§2.3 registry row: neither
+ * kind is admitted on a `handler` node in this slice — Lock-3 §1.5's forward ADMIT for K5-b on
+ * handler is deliberately NOT landed here; see the `dept_head_at_level` resolver arm comment).
+ * `kind` is read structurally so this works before the kind is added to the typed union (same
+ * posture as `runtimeGraphUsesManagerChain`).
  */
 export function runtimeGraphUsesDeptHeadChain(runtimeGraph: RuntimeGraph): boolean {
   return runtimeGraph.nodes.some((node) => {
@@ -3218,7 +3240,9 @@ export function runtimeGraphUsesDeptHeadChain(runtimeGraph: RuntimeGraph): boole
     const config: unknown = node.config
     const sources = isRecord(config) ? config.assigneeSources : undefined
     if (!Array.isArray(sources)) return false
-    return sources.some((source) => isRecord(source) && source.kind === 'continuous_dept_heads')
+    return sources.some(
+      (source) => isRecord(source) && (source.kind === 'continuous_dept_heads' || source.kind === 'dept_head_at_level'),
+    )
   })
 }
 
@@ -3232,12 +3256,12 @@ export function runtimeGraphUsesDeptHeadChain(runtimeGraph: RuntimeGraph): boole
  * transient read failure — with NO instance and NO assignment created. Genuine data absence (the
  * read SUCCEEDED, the requester simply has no manager) still follows `emptyAssigneePolicy`.
  *
- * Lock-1 §2.1 EXTENSION (K4): `continuous_dept_heads` is EXTENDED into this detector alongside the
- * four shipped org-derived kinds. Leaving it unextended would reproduce exactly the B5-b fail-open
- * this guard closed: an org read failure plus `emptyAssigneePolicy: 'auto-approve'` would silently
- * auto-approve instead of fail-closing at create. (K5-b `dept_head_at_level` is NOT added here —
- * it is not implemented in this slice; §2.3 admits its registry row only once K4 has landed, and
- * this detector must not claim a kind that does not exist yet.)
+ * Lock-1 §2.1 EXTENSION (K4 + K5-b): `continuous_dept_heads` and `dept_head_at_level` are EXTENDED
+ * into this detector alongside the four shipped org-derived kinds — §2.1 names both explicitly
+ * ("That detector MUST be extended to K4 and K5-b"). Leaving either unextended would reproduce
+ * exactly the B5-b fail-open this guard closed: an org read failure plus
+ * `emptyAssigneePolicy: 'auto-approve'` would silently auto-approve instead of fail-closing at
+ * create.
  */
 export function runtimeGraphUsesOrgAssigneeSource(runtimeGraph: RuntimeGraph): boolean {
   return runtimeGraph.nodes.some((node) => {
@@ -3257,7 +3281,8 @@ export function runtimeGraphUsesOrgAssigneeSource(runtimeGraph: RuntimeGraph): b
           source.kind === 'dept_head' ||
           source.kind === 'continuous_managers' ||
           source.kind === 'manager_at_level' ||
-          source.kind === 'continuous_dept_heads'),
+          source.kind === 'continuous_dept_heads' ||
+          source.kind === 'dept_head_at_level'),
     )
   })
 }

--- a/packages/core-backend/src/types/approval-product.ts
+++ b/packages/core-backend/src/types/approval-product.ts
@@ -16,7 +16,7 @@ export type ApprovalProductPermission = typeof APPROVAL_PRODUCT_PERMISSIONS[numb
 // admission set in ApprovalProductService.ts) or the type is unpublishable.
 export type ApprovalNodeType = 'start' | 'approval' | 'cc' | 'condition' | 'parallel' | 'end' | 'handler'
 export type ApprovalAssigneeType = 'user' | 'role'
-export type ApprovalAssigneeSourceKind = 'static_user' | 'static_role' | 'requester' | 'form_field_user' | 'direct_manager' | 'dept_head' | 'continuous_managers' | 'manager_at_level' | 'requester_choice' | 'continuous_dept_heads'
+export type ApprovalAssigneeSourceKind = 'static_user' | 'static_role' | 'requester' | 'form_field_user' | 'direct_manager' | 'dept_head' | 'continuous_managers' | 'manager_at_level' | 'requester_choice' | 'continuous_dept_heads' | 'dept_head_at_level'
 export type ApprovalMode = 'single' | 'all' | 'any' | 'threshold'
 
 /**
@@ -259,6 +259,19 @@ export type ApprovalAssigneeSource =
    * `[1, MAX_MANAGER_CHAIN_LEVELS]` at normalize time, byte-identically to `continuous_managers`.
    */
   | { kind: 'continuous_dept_heads'; levels: number }
+  /**
+   * Lock-1 §K5-b — 指定层级部门负责人 (dept head at a specific level): `deptHeadChainIds[level-1]`,
+   * positionally IDENTICAL to `manager_at_level` but reading the K4 department-head chain instead
+   * of `managerChainIds` (a different pointer — see the `continuous_dept_heads` doc comment above).
+   * Level 1 = the requester's own department head (byte-identical to the single-level `dept_head`).
+   * Strictly downstream of K4: this reads the SAME `deptHeadChainIds` snapshot field K4 builds — it
+   * does not add a snapshot field of its own. `level` is validated `[1, MAX_MANAGER_CHAIN_LEVELS]`
+   * at normalize time, byte-identically to `manager_at_level`. A `level` valid in contract but past
+   * the end of THIS requester's (possibly shorter) chain resolves EMPTY and falls to
+   * `emptyAssigneePolicy` — the shipped `manager_at_level` behavior, unchanged (Lock-1 §K5: never a
+   * dispatch-time failure).
+   */
+  | { kind: 'dept_head_at_level'; level: number }
 
 export type RequesterChoiceAssigneeSource = Extract<ApprovalAssigneeSource, { kind: 'requester_choice' }>
 
@@ -448,13 +461,15 @@ export interface ApprovalRequesterSnapshot {
    * Lock-1 §K4 — ordered local user ids of the requester's DEPARTMENT-HEAD chain, level 1 first
    * (the requester's own department head). A DIFFERENT pointer from `managerChainIds` — see the
    * `continuous_dept_heads` union member doc comment for the leader-pointer vs parent-tree
-   * distinction. Frozen at create time only when the published graph uses `continuous_dept_heads`
-   * (gated by `runtimeGraphUsesDeptHeadChain`, so it is not baked for every approval).
+   * distinction. Frozen at create time when the published graph uses `continuous_dept_heads` OR
+   * Lock-1 §K5-b `dept_head_at_level` (gated by `runtimeGraphUsesDeptHeadChain`, EXTENDED to both
+   * kinds, so it is not baked for every approval).
    * Cycle-guarded (visited set of external DEPARTMENT ids) + capped at MAX_MANAGER_CHAIN_LEVELS;
    * self-excluded on the requester's LOCAL id; absent when unresolvable or unused. A level whose
    * head is unresolved contributes nothing but does NOT truncate the walk (ratified
    * continue-past-empty-level posture). Read by `continuous_dept_heads` (slices it to its own
-   * `levels`). Purely additive; existing snapshots omit it.
+   * `levels`) and by `dept_head_at_level` (positional single-level pick, `[level-1]`). Purely
+   * additive; existing snapshots omit it.
    */
   deptHeadChainIds?: string[]
   /**

--- a/packages/core-backend/tests/integration/approval-dept-head-at-level.db.test.ts
+++ b/packages/core-backend/tests/integration/approval-dept-head-at-level.db.test.ts
@@ -1,0 +1,398 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import net from 'net'
+import { MetaSheetServer } from '../../src/index'
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { query } from '../../src/db/pg'
+import { ensureApprovalSchemaReady, grantApprovalWriteForIntegrationActor } from '../helpers/approval-schema-bootstrap'
+
+/**
+ * Lock-1 §K5-b `dept_head_at_level` (指定层级部门负责人) — REAL-DB end-to-end acceptance
+ * (docs/development/approval-lock1-enterprise-assignees-20260817.md §K5-b; gates G-1/G-2/G-3/
+ * G-18/G-19/G-20; harness mirrors approval-dept-head-chain.db.test.ts (K4) — this kind is
+ * strictly downstream of K4, reading the SAME `deptHeadChainIds` snapshot field, so the org
+ * fixture below is deliberately shaped IDENTICALLY to K4's, to prove the SAME chain positioned by
+ * a SINGLE `level` resolves the SAME entry `continuous_dept_heads` would slice to).
+ *
+ * Org fixture (one integration, `dhal-<TS>`):
+ *   DEPT_TOP (root; manager list = [HEAD3])
+ *     <- DEPT_MID (manager list EMPTY — the continue-past-empty-level level; load-bearing for the
+ *                  positional-not-hop-count proof below)
+ *          <- DEPT_BOT (REQ's primary dept; manager list = [HEAD1])
+ *
+ * deptHeadChainIds for REQ = [HEAD1, HEAD3] (DEPT_MID's empty list contributes nothing but does
+ * NOT terminate the walk or shift a "hole" into the array — the array is DENSE).
+ *
+ * Proves:
+ *  G-1      level validated byte-identically to manager_at_level: out-of-range / non-integer /
+ *           missing 400s; a valid shape saves in the same fixture (positive control);
+ *  G-2      a contract-unimplemented kind (user_group) is rejected at authoring, never persisted;
+ *  core     dept_head_at_level level=2 resolves EXACTLY HEAD3 — the SAME entry
+ *           continuous_dept_heads levels=2 slices to at position [1] — proving the read is
+ *           POSITIONAL over the dense chain (level 2 = the second RESOLVED head, walking through
+ *           DEPT_MID's empty level), never "the head 2 parent-hops up" (which would be DEPT_MID's
+ *           own — nonexistent — head);
+ *  level=1  resolves EXACTLY HEAD1 (the requester's own department head, byte-identical to the
+ *           shipped single-level `dept_head`);
+ *  out-of-  level=5 (valid in contract, [1, MAX_MANAGER_CHAIN_LEVELS]) against a chain of length 2
+ *  range    resolves EMPTY and falls to the node's `emptyAssigneePolicy` — a NORMAL
+ *           APPROVAL_ASSIGNEE_EMPTY 400 under 'error' (Lock-1 §K5: never a dispatch CRASH, never
+ *           silently coerced to a shallower level);
+ *  freeze   a directory mutation (DEPT_BOT's manager list swapped) AFTER create does not change an
+ *  purity   in-flight assignment (frozen snapshot) but DOES change a NEWLY created approval — the
+ *           freeze is temporal, not a dead/cached read;
+ *  G-18     the level-validation 400 body carries the node key/source index, never a person id.
+ *
+ * G-20 (org-read fail-closed extension to dept_head_at_level) lives in the existing parametrized
+ * fixture `approval-routing-policy-failclose.api.test.ts` (KINDS now includes
+ * 'dept_head_at_level') — not duplicated here, same posture as K4.
+ */
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const TS = Date.now()
+const REQ = `dhal-req-${TS}`
+const APPROVER = `dhal-appr-${TS}`
+const U_HEAD1 = `dhal-head1-${TS}`
+const U_HEAD1B = `dhal-head1b-${TS}` // post-mutation replacement head (freeze-purity temporal arm)
+const U_HEAD3 = `dhal-head3-${TS}`
+
+const EXT_TOP = `dhaltop-${TS}`
+const EXT_MID = `dhalmid-${TS}`
+const EXT_BOT = `dhalbot-${TS}`
+const EXT_HEAD1 = `dhalehead1-${TS}`
+const EXT_HEAD1B = `dhalehead1b-${TS}`
+const EXT_HEAD3 = `dhalehead3-${TS}`
+const EXT_REQ = `dhalereq-${TS}`
+
+async function canListen(): Promise<boolean> {
+  return await new Promise((r) => {
+    const s = net.createServer()
+    s.once('error', () => r(false))
+    s.listen(0, '127.0.0.1', () => s.close(() => r(true)))
+  })
+}
+async function tok(base: string, userId: string): Promise<string> {
+  await grantApprovalWriteForIntegrationActor(userId)
+  const res = await fetch(`${base}/api/auth/dev-token?userId=${encodeURIComponent(userId)}&roles=admin&perms=${encodeURIComponent('*:*')}`)
+  return ((await res.json()) as { token: string }).token
+}
+async function req(base: string, path: string, token: string, opts: { method?: string; body?: unknown } = {}): Promise<Response> {
+  return fetch(`${base}${path}`, {
+    method: opts.method || 'GET',
+    headers: { Authorization: `Bearer ${token}`, ...(opts.body !== undefined ? { 'Content-Type': 'application/json' } : {}) },
+    ...(opts.body !== undefined ? { body: JSON.stringify(opts.body) } : {}),
+  })
+}
+
+const FORM_SCHEMA = { fields: [{ id: 'reason', type: 'text', label: 'r', required: true }] }
+
+// gate (static APPROVER) -> head (dept_head_at_level) -> end.
+function headGraph(level: number, emptyAssigneePolicy: 'error' | 'auto-approve' = 'error') {
+  return {
+    nodes: [
+      { key: 'start', type: 'start', name: 's', config: {} },
+      { key: 'gate', type: 'approval', name: 'gate', config: { assigneeSources: [{ kind: 'static_user', userIds: [APPROVER] }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+      { key: 'head', type: 'approval', name: 'head', config: { assigneeSources: [{ kind: 'dept_head_at_level', level }], approvalMode: 'single', emptyAssigneePolicy } },
+      { key: 'end', type: 'end', name: 'e', config: {} },
+    ],
+    edges: [
+      { key: 's2g', source: 'start', target: 'gate' },
+      { key: 'g2h', source: 'gate', target: 'head' },
+      { key: 'h2e', source: 'head', target: 'end' },
+    ],
+  }
+}
+
+type ErrorBody = { code?: string; error?: { code?: string; message?: string; details?: Record<string, unknown> } }
+function errorCode(body: ErrorBody): string | undefined {
+  return body.code ?? body.error?.code
+}
+
+describeIfDatabase('Lock-1 §K5-b dept_head_at_level — real-DB create/freeze/dispatch acceptance', () => {
+  let server: MetaSheetServer | undefined
+  let base = ''
+  let reqTok = ''
+  let apprTok = ''
+  let head1Tok = ''
+  let head1bTok = ''
+  let head3Tok = ''
+  let integrationId = ''
+  let deptBotId = ''
+
+  async function createTemplate(key: string, graph: unknown): Promise<string> {
+    const created = await req(base, '/api/approval-templates', reqTok, {
+      method: 'POST',
+      body: { key, name: key, formSchema: FORM_SCHEMA, approvalGraph: graph },
+    })
+    expect(created.status, await created.clone().text()).toBe(201)
+    return ((await created.json()) as { id: string }).id
+  }
+  async function publishTemplate(tid: string): Promise<Response> {
+    return req(base, `/api/approval-templates/${tid}/publish`, reqTok, { method: 'POST', body: { policy: { allowRevoke: true } } })
+  }
+  async function createPublished(key: string, graph: unknown): Promise<string> {
+    const tid = await createTemplate(key, graph)
+    const published = await publishTemplate(tid)
+    expect(published.status, await published.clone().text()).toBe(200)
+    return tid
+  }
+  async function activeAssignees(iid: string, nodeKey: string): Promise<Array<{ assignee_id: string; metadata: Record<string, unknown> | null }>> {
+    const pool = poolManager.get()
+    const rows = await pool.query(
+      `SELECT assignee_id, metadata FROM approval_assignments WHERE instance_id = $1 AND node_key = $2 AND is_active = TRUE ORDER BY assignee_id`,
+      [iid, nodeKey],
+    )
+    return rows.rows as Array<{ assignee_id: string; metadata: Record<string, unknown> | null }>
+  }
+  async function createAsReq(tid: string): Promise<{ status: number; iid?: string; text: string }> {
+    const started = await req(base, '/api/approvals', reqTok, { method: 'POST', body: { templateId: tid, formData: { reason: 'r' } } })
+    const text = await started.clone().text()
+    if (started.status >= 300) return { status: started.status, text }
+    return { status: started.status, iid: ((await started.json()) as { id: string }).id, text }
+  }
+
+  beforeAll(async () => {
+    expect(await canListen()).toBe(true)
+    await ensureApprovalSchemaReady()
+
+    for (const u of [REQ, APPROVER, U_HEAD1, U_HEAD1B, U_HEAD3]) {
+      await query(`INSERT INTO users (id, email, password_hash) VALUES ($1, $2, 'x') ON CONFLICT (id) DO NOTHING`, [u, `${u}@example.test`])
+    }
+
+    const integ = await query<{ id: string }>(
+      `INSERT INTO directory_integrations (name, corp_id) VALUES ($1, $2) RETURNING id`,
+      [`dhal-${TS}`, `dhal-corp-${TS}`],
+    )
+    integrationId = integ.rows[0].id
+
+    // DEPT_TOP <- DEPT_MID(empty) <- DEPT_BOT (REQ's primary) — same shape as K4's fixture.
+    await query(
+      `INSERT INTO directory_departments (integration_id, external_department_id, external_parent_department_id, name, is_active, raw)
+       VALUES ($1, $2, NULL, 'Top', true, $3::jsonb)`,
+      [integrationId, EXT_TOP, JSON.stringify({ dept_manager_userid_list: [EXT_HEAD3] })],
+    )
+    // DEPT_MID: EMPTY manager list — the continue-past-empty-level / positional proof point.
+    await query(
+      `INSERT INTO directory_departments (integration_id, external_department_id, external_parent_department_id, name, is_active, raw)
+       VALUES ($1, $2, $3, 'Mid', true, $4::jsonb)`,
+      [integrationId, EXT_MID, EXT_TOP, JSON.stringify({ dept_manager_userid_list: [] })],
+    )
+    const deptBot = await query<{ id: string }>(
+      `INSERT INTO directory_departments (integration_id, external_department_id, external_parent_department_id, name, is_active, raw)
+       VALUES ($1, $2, $3, 'Bot', true, $4::jsonb) RETURNING id`,
+      [integrationId, EXT_BOT, EXT_MID, JSON.stringify({ dept_manager_userid_list: [EXT_HEAD1] })],
+    )
+    deptBotId = deptBot.rows[0].id
+
+    const accReq = await query<{ id: string }>(
+      `INSERT INTO directory_accounts (integration_id, external_user_id, external_key, name, raw)
+       VALUES ($1, $2, $3, 'Req', '{}'::jsonb) RETURNING id`,
+      [integrationId, EXT_REQ, `k-req-${TS}`],
+    )
+    const accHead1 = await query<{ id: string }>(
+      `INSERT INTO directory_accounts (integration_id, external_user_id, external_key, name, raw)
+       VALUES ($1, $2, $3, 'Head1', '{}'::jsonb) RETURNING id`,
+      [integrationId, EXT_HEAD1, `k-head1-${TS}`],
+    )
+    const accHead3 = await query<{ id: string }>(
+      `INSERT INTO directory_accounts (integration_id, external_user_id, external_key, name, raw)
+       VALUES ($1, $2, $3, 'Head3', '{}'::jsonb) RETURNING id`,
+      [integrationId, EXT_HEAD3, `k-head3-${TS}`],
+    )
+
+    await query(
+      `INSERT INTO directory_account_links (directory_account_id, local_user_id, link_status, match_strategy)
+       VALUES ($1, $2, 'linked', 'manual'), ($3, $4, 'linked', 'manual'), ($5, $6, 'linked', 'manual')`,
+      [accReq.rows[0].id, REQ, accHead1.rows[0].id, U_HEAD1, accHead3.rows[0].id, U_HEAD3],
+    )
+    await query(
+      `INSERT INTO directory_account_departments (directory_account_id, directory_department_id, is_primary)
+       VALUES ($1, $2, true)`,
+      [accReq.rows[0].id, deptBotId],
+    )
+
+    server = new MetaSheetServer({ port: 0, host: '127.0.0.1', pluginDirs: [] })
+    await server.start()
+    base = `http://127.0.0.1:${server.getAddress()!.port}`
+    reqTok = await tok(base, REQ)
+    apprTok = await tok(base, APPROVER)
+    head1Tok = await tok(base, U_HEAD1)
+    head1bTok = await tok(base, U_HEAD1B)
+    head3Tok = await tok(base, U_HEAD3)
+  })
+
+  afterAll(async () => {
+    try {
+      const pool = poolManager.get()
+      const tids = (await pool.query(`SELECT id FROM approval_templates WHERE key LIKE $1`, [`dhal-${TS}-%`])).rows.map((r) => r.id as string)
+      if (tids.length > 0) {
+        const iids = (await pool.query(`SELECT id FROM approval_instances WHERE template_id = ANY($1::uuid[])`, [tids])).rows.map((r) => r.id as string)
+        if (iids.length > 0) {
+          await pool.query(`DELETE FROM approval_records WHERE instance_id = ANY($1)`, [iids])
+          await pool.query(`DELETE FROM approval_assignments WHERE instance_id = ANY($1)`, [iids])
+          await pool.query(`DELETE FROM approval_instances WHERE id = ANY($1)`, [iids])
+        }
+        await pool.query(`DELETE FROM approval_published_definitions WHERE template_id = ANY($1::uuid[])`, [tids])
+        await pool.query(`DELETE FROM approval_templates WHERE id = ANY($1::uuid[])`, [tids])
+      }
+      if (integrationId) {
+        await query(`DELETE FROM directory_accounts WHERE integration_id = $1`, [integrationId])
+        await query(`DELETE FROM directory_departments WHERE integration_id = $1`, [integrationId])
+        await query(`DELETE FROM directory_integrations WHERE id = $1`, [integrationId])
+      }
+      await query(`DELETE FROM users WHERE id = ANY($1::varchar[])`, [[REQ, APPROVER, U_HEAD1, U_HEAD1B, U_HEAD3]])
+    } catch {
+      /* best effort */
+    }
+    if (server) await server.stop()
+  })
+
+  it('sentinel: DATABASE_URL is set (DB-backed lane must not silently skip)', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  // ── G-1 — authoring choke: level validated byte-identically to manager_at_level ─────────────
+  it('G-1: dept_head_at_level saves with a valid level; out-of-range / non-integer / missing each 400 (G-18: node key present, no person id)', async () => {
+    // Positive control FIRST: a valid shape saves.
+    const okTid = await createTemplate(`dhal-${TS}-g1-ok`, headGraph(2))
+    expect(okTid).toBeTruthy()
+
+    const badLevels: unknown[] = [0, -1, 1.5, 11, 'two', null, undefined]
+    for (const level of badLevels) {
+      const graph = headGraph(2) as { nodes: Array<{ config: { assigneeSources?: unknown[] } }> }
+      const source: Record<string, unknown> = { kind: 'dept_head_at_level' }
+      if (level !== undefined) source.level = level
+      graph.nodes[2].config.assigneeSources = [source]
+      const res = await req(base, '/api/approval-templates', reqTok, {
+        method: 'POST',
+        body: { key: `dhal-${TS}-g1-bad`, name: 'bad', formSchema: FORM_SCHEMA, approvalGraph: graph },
+      })
+      expect(res.status, JSON.stringify(level)).toBe(400)
+      const raw = await res.clone().text()
+      // G-18: values-free — the message carries the structural source-index location
+      // (`assigneeSources[0].level`, a template-authored path — permitted by §2.6) and never a
+      // person id (trivially true here since none was ever supplied for a shape-rejection).
+      expect(raw).toContain('assigneeSources[0].level')
+    }
+  })
+
+  // ── G-2 — not-yet-implemented is not inert ───────────────────────────────────────────────────
+  it('G-2: a contract-unimplemented kind (user_group / K1, not landed at this baseline) is rejected at authoring, never persisted', async () => {
+    const graph = headGraph(1) as { nodes: Array<{ config: { assigneeSources?: unknown[] } }> }
+    graph.nodes[2].config.assigneeSources = [{ kind: 'user_group', groupIds: ['g1'] }]
+    const key = `dhal-${TS}-g2-unimplemented`
+    const res = await req(base, '/api/approval-templates', reqTok, {
+      method: 'POST',
+      body: { key, name: key, formSchema: FORM_SCHEMA, approvalGraph: graph },
+    })
+    expect(res.status).toBe(400)
+    const rows = await query(`SELECT id FROM approval_templates WHERE key = $1`, [key])
+    expect(rows.rows).toHaveLength(0)
+    // Positive control: dept_head_at_level (this slice's implemented kind) persists — G-1 above.
+  })
+
+  // ── Core: positional read over the real 3-level department-parent tree ──────────────────────
+  it('core: level=1 resolves EXACTLY HEAD1 (own department head, byte-identical to the shipped single-level dept_head)', async () => {
+    const tid = await createPublished(`dhal-${TS}-core-l1`, headGraph(1))
+    const started = await createAsReq(tid)
+    expect(started.status, started.text).toBe(201)
+    const iid = started.iid!
+
+    const gateApprove = await req(base, `/api/approvals/${iid}/actions`, apprTok, { method: 'POST', body: { action: 'approve' } })
+    expect(gateApprove.status, await gateApprove.clone().text()).toBeLessThan(300)
+
+    const assignees = await activeAssignees(iid, 'head')
+    expect(assignees.map((a) => a.assignee_id)).toEqual([U_HEAD1])
+    const resolvedFrom = (assignees[0].metadata as { resolvedFrom?: { kind?: string } } | null)?.resolvedFrom
+    expect(resolvedFrom?.kind).toBe('dept_head_at_level')
+
+    await req(base, `/api/approvals/${iid}/actions`, head1Tok, { method: 'POST', body: { action: 'approve' } })
+  })
+
+  it('core: level=2 resolves EXACTLY HEAD3 — DEPT_MID (empty list) contributes nothing but the positional read walks THROUGH it (ratified continue-past-empty-level posture, proven positional not hop-count)', async () => {
+    const tid = await createPublished(`dhal-${TS}-core-l2`, headGraph(2))
+    const started = await createAsReq(tid)
+    expect(started.status, started.text).toBe(201)
+    const iid = started.iid!
+
+    const gateApprove = await req(base, `/api/approvals/${iid}/actions`, apprTok, { method: 'POST', body: { action: 'approve' } })
+    expect(gateApprove.status, await gateApprove.clone().text()).toBeLessThan(300)
+
+    const assignees = await activeAssignees(iid, 'head')
+    expect(assignees.map((a) => a.assignee_id)).toEqual([U_HEAD3])
+    const resolvedFrom = (assignees[0].metadata as { resolvedFrom?: { kind?: string } } | null)?.resolvedFrom
+    expect(resolvedFrom?.kind).toBe('dept_head_at_level')
+
+    await req(base, `/api/approvals/${iid}/actions`, head3Tok, { method: 'POST', body: { action: 'approve' } })
+  })
+
+  // ── Out-of-range: a level valid in CONTRACT but beyond THIS requester's (shorter) chain ──────
+  it('out-of-range: level=5 (valid in [1, MAX_MANAGER_CHAIN_LEVELS]) against a 2-entry chain resolves EMPTY and falls to emptyAssigneePolicy — a normal APPROVAL_ASSIGNEE_EMPTY 400, NEVER a crash or silent coercion (Lock-1 §K5)', async () => {
+    const tid = await createPublished(`dhal-${TS}-oor`, headGraph(5, 'error'))
+    const started = await createAsReq(tid)
+    expect(started.status, started.text).toBe(201)
+    const iid = started.iid!
+
+    const gateApprove = await req(base, `/api/approvals/${iid}/actions`, apprTok, { method: 'POST', body: { action: 'approve' } })
+    const text = await gateApprove.clone().text()
+    expect(gateApprove.status, text).toBe(400)
+    expect(errorCode(JSON.parse(text) as ErrorBody)).toBe('APPROVAL_ASSIGNEE_EMPTY')
+    // G-18: values-free — the node key is present, no person id (there is none to leak — the
+    // resolution genuinely found nobody).
+    expect(text).toContain('head')
+
+    const assignees = await activeAssignees(iid, 'head')
+    expect(assignees).toHaveLength(0)
+  })
+
+  // ── Freeze purity: dispatch does not re-read the directory; the read IS per-create (temporal) ─
+  it('freeze purity: a directory mutation AFTER create does not change the in-flight (frozen) assignee, but DOES change a NEWLY created approval — temporal, not a dead read', async () => {
+    const tid = await createPublished(`dhal-${TS}-freeze`, headGraph(1))
+    const started = await createAsReq(tid)
+    expect(started.status, started.text).toBe(201)
+    const iid = started.iid!
+
+    // Mutate DEPT_BOT's manager list AFTER create: HEAD1 -> HEAD1B.
+    const accHead1b = await query<{ id: string }>(
+      `INSERT INTO directory_accounts (integration_id, external_user_id, external_key, name, raw)
+       VALUES ($1, $2, $3, 'Head1B', '{}'::jsonb) RETURNING id`,
+      [integrationId, EXT_HEAD1B, `k-head1b-${TS}`],
+    )
+    await query(
+      `INSERT INTO directory_account_links (directory_account_id, local_user_id, link_status, match_strategy)
+       VALUES ($1, $2, 'linked', 'manual')`,
+      [accHead1b.rows[0].id, U_HEAD1B],
+    )
+    try {
+      await query(
+        `UPDATE directory_departments SET raw = jsonb_set(COALESCE(raw, '{}'::jsonb), '{dept_manager_userid_list}', $2::jsonb) WHERE id = $1`,
+        [deptBotId, JSON.stringify([EXT_HEAD1B])],
+      )
+
+      // Dispatch the ALREADY-CREATED instance: the frozen snapshot must still resolve HEAD1, not
+      // HEAD1B — no live directory re-read at dispatch.
+      const gateApprove = await req(base, `/api/approvals/${iid}/actions`, apprTok, { method: 'POST', body: { action: 'approve' } })
+      expect(gateApprove.status, await gateApprove.clone().text()).toBeLessThan(300)
+      const inFlight = await activeAssignees(iid, 'head')
+      expect(inFlight.map((a) => a.assignee_id)).toEqual([U_HEAD1])
+
+      // Positive control (temporal, not dead-cache): a NEW create AFTER the mutation DOES pick up
+      // HEAD1B — the scope read re-executes per create rather than being cached at module load.
+      const newTid = await createPublished(`dhal-${TS}-freeze-new`, headGraph(1))
+      const newStarted = await createAsReq(newTid)
+      expect(newStarted.status, newStarted.text).toBe(201)
+      const newGateApprove = await req(base, `/api/approvals/${newStarted.iid}/actions`, apprTok, { method: 'POST', body: { action: 'approve' } })
+      expect(newGateApprove.status, await newGateApprove.clone().text()).toBeLessThan(300)
+      const newAssignees = await activeAssignees(newStarted.iid!, 'head')
+      expect(newAssignees.map((a) => a.assignee_id)).toEqual([U_HEAD1B])
+
+      // Clean up both in-flight instances so they do not linger PENDING.
+      await req(base, `/api/approvals/${iid}/actions`, head1Tok, { method: 'POST', body: { action: 'approve' } })
+      await req(base, `/api/approvals/${newStarted.iid}/actions`, head1bTok, { method: 'POST', body: { action: 'approve' } })
+    } finally {
+      // Restore DEPT_BOT's manager list for any later test in this file relying on HEAD1.
+      await query(
+        `UPDATE directory_departments SET raw = jsonb_set(COALESCE(raw, '{}'::jsonb), '{dept_manager_userid_list}', $2::jsonb) WHERE id = $1`,
+        [deptBotId, JSON.stringify([EXT_HEAD1])],
+      )
+    }
+  })
+})

--- a/packages/core-backend/tests/integration/approval-dept-head-chain.db.test.ts
+++ b/packages/core-backend/tests/integration/approval-dept-head-chain.db.test.ts
@@ -347,9 +347,15 @@ describeIfDatabase('Lock-1 §K4 continuous_dept_heads — real-DB create/freeze/
   })
 
   // ── G-2 — not-yet-implemented is not inert ───────────────────────────────────────────────────
-  it('G-2: a contract-unimplemented kind (dept_head_at_level / K5-b, not landed in this slice) is rejected at authoring, never persisted', async () => {
+  // NOTE: `dept_head_at_level` (K5-b) is no longer this test's "unimplemented" example — Lock-1
+  // §K5-b landed in a LATER slice (docs/development/approval-lock1-enterprise-assignees-20260817.md
+  // §K5-b; real-DB acceptance for it lives in its own approval-dept-head-at-level.db.test.ts,
+  // sibling job approval-realdb-k5b). `user_group` (Lock-1 §K1) is still genuinely unimplemented at
+  // this baseline — it is not even a member of ApprovalAssigneeSourceKind yet — so it is the
+  // fixture now.
+  it('G-2: a contract-unimplemented kind (user_group / K1, not landed at this baseline) is rejected at authoring, never persisted', async () => {
     const graph = headsGraph(3) as { nodes: Array<{ config: { assigneeSources?: unknown[] } }> }
-    graph.nodes[2].config.assigneeSources = [{ kind: 'dept_head_at_level', level: 1 }]
+    graph.nodes[2].config.assigneeSources = [{ kind: 'user_group', groupIds: ['g1'] }]
     const key = `dh-${TS}-g2-unimplemented`
     const res = await req(base, '/api/approval-templates', reqTok, {
       method: 'POST',

--- a/packages/core-backend/tests/integration/approval-routing-policy-failclose.api.test.ts
+++ b/packages/core-backend/tests/integration/approval-routing-policy-failclose.api.test.ts
@@ -24,8 +24,8 @@ import { grantApprovalWriteForIntegrationActor } from '../helpers/approval-schem
  * a broken policy became a FAIL-OPEN that silently approves approvals.
  *
  * Proof, for EACH of the org assignee sources (direct_manager / dept_head / continuous_managers /
- * manager_at_level, plus Lock-1 §K4's continuous_dept_heads — all with the dangerous auto-approve
- * policy):
+ * manager_at_level, plus Lock-1 §K4's continuous_dept_heads and Lock-1 §K5-b's dept_head_at_level
+ * — all with the dangerous auto-approve policy):
  *   A. BROKEN POLICY (canonical target disabled) → create rejected **422
  *      APPROVAL_ROUTING_POLICY_MISCONFIGURED**, and — the load-bearing half — **ZERO
  *      approval_instances and ZERO approval_assignments** exist for the template.
@@ -78,7 +78,7 @@ async function req(base: string, path: string, token: string, opts: { method?: s
   })
 }
 
-type OrgSourceKind = 'direct_manager' | 'dept_head' | 'continuous_managers' | 'manager_at_level' | 'continuous_dept_heads'
+type OrgSourceKind = 'direct_manager' | 'dept_head' | 'continuous_managers' | 'manager_at_level' | 'continuous_dept_heads' | 'dept_head_at_level'
 function graph(kind: OrgSourceKind) {
   const source =
     kind === 'continuous_managers' ? { kind, levels: 2 }
@@ -87,7 +87,9 @@ function graph(kind: OrgSourceKind) {
         // (runtimeGraphUsesOrgAssigneeSource, ApprovalProductService.ts) — this fixture proves the
         // extension is load-bearing, not merely declared.
         : kind === 'continuous_dept_heads' ? { kind, levels: 2 }
-          : { kind }
+          // Lock-1 §K5-b: extends the SAME detector (§2.1 names K4 AND K5-b explicitly).
+          : kind === 'dept_head_at_level' ? { kind, level: 1 }
+            : { kind }
   return {
     nodes: [
       { key: 'start', type: 'start', name: 's', config: {} },
@@ -286,9 +288,9 @@ describeIfDatabase('B5-b owner P1 — routing-policy fail-close at approval crea
     expect(asg.rows[0].n).toBe(0)
   }
 
-  const KINDS: OrgSourceKind[] = ['direct_manager', 'dept_head', 'continuous_managers', 'manager_at_level', 'continuous_dept_heads']
+  const KINDS: OrgSourceKind[] = ['direct_manager', 'dept_head', 'continuous_managers', 'manager_at_level', 'continuous_dept_heads', 'dept_head_at_level']
 
-  it('A. BROKEN policy → 422 APPROVAL_ROUTING_POLICY_MISCONFIGURED for ALL FIVE org sources (Lock-1 §K4 extends the set), zero instances, zero assignments', async () => {
+  it('A. BROKEN policy → 422 APPROVAL_ROUTING_POLICY_MISCONFIGURED for ALL SIX org sources (Lock-1 §K4 + §K5-b extend the set), zero instances, zero assignments', async () => {
     await setPolicy('default', dtIntId)
     await query(`UPDATE directory_integrations SET status = 'disabled' WHERE id = $1`, [dtIntId])
     try {
@@ -306,7 +308,7 @@ describeIfDatabase('B5-b owner P1 — routing-policy fail-close at approval crea
     }
   })
 
-  it('B. TRANSIENT org-read failure → 503 APPROVAL_REQUESTER_ORG_UNRESOLVED for all five sources (Lock-1 §K4 extends the set), zero instances, zero assignments', async () => {
+  it('B. TRANSIENT org-read failure → 503 APPROVAL_REQUESTER_ORG_UNRESOLVED for all six sources (Lock-1 §K4 + §K5-b extend the set), zero instances, zero assignments', async () => {
     // healthy policy in place; arm the scoped Pool.query spy only for the create calls
     // (non-policy Error shape — not a config error). Publish stays on the healthy path.
     await setPolicy('default', localIntId)

--- a/packages/core-backend/tests/unit/approval-assignee-resolver.test.ts
+++ b/packages/core-backend/tests/unit/approval-assignee-resolver.test.ts
@@ -166,6 +166,60 @@ describe('ApprovalAssigneeResolver', () => {
     expect(resolveManagerAtLevel(3, { id: 'requester-1', managerChainIds: ['m1', null as never, 'm3'] })).toEqual([malEntry('m3')])
   })
 
+  // dept_head_at_level (Lock-1 §K5-b) — resolves a SINGLE level of the snapshot
+  // deptHeadChainIds (chain[level-1]), positionally IDENTICAL to manager_at_level above but over
+  // the K4 department-head chain instead of managerChainIds.
+  function resolveDeptHeadAtLevel(level: number, requesterSnapshot: Record<string, unknown> | null) {
+    return resolveApprovalAssignees({
+      nodeKey: 'review',
+      sourceStep: 2,
+      config: { assigneeSources: [{ kind: 'dept_head_at_level', level }] },
+      formSnapshot: {},
+      requesterSnapshot,
+    })
+  }
+
+  const dhalEntry = (assigneeId: string) => ({
+    assignmentType: 'user', assigneeId, nodeKey: 'review', sourceStep: 2,
+    metadata: { resolvedFrom: { kind: 'dept_head_at_level', sourceIndex: 0 } },
+  })
+
+  it('resolves dept_head_at_level to the single dept-head-chain entry at that 1-based level (positive control: a valid in-range level resolves the right head)', () => {
+    expect(resolveDeptHeadAtLevel(1, { id: 'requester-1', deptHeadChainIds: ['h1', 'h2', 'h3'] }))
+      .toEqual([dhalEntry('h1')])
+    expect(resolveDeptHeadAtLevel(3, { id: 'requester-1', deptHeadChainIds: ['h1', 'h2', 'h3'] }))
+      .toEqual([dhalEntry('h3')])
+  })
+
+  it('resolves dept_head_at_level to empty when the chain is shorter than the level, and when deptHeadChainIds is absent — falls to emptyAssigneePolicy, NEVER a dispatch-time failure (Lock-1 §K5)', () => {
+    // Out-of-range: level valid in contract ([1, MAX_MANAGER_CHAIN_LEVELS]) but deeper than THIS
+    // requester's (possibly shorter) chain — empty, not an error.
+    expect(resolveDeptHeadAtLevel(4, { id: 'requester-1', deptHeadChainIds: ['h1', 'h2'] })).toEqual([])
+    // deptHeadChainIds absent entirely (e.g. requester has no primary department, or the snapshot
+    // simply was not baked) — still empty, never a throw.
+    expect(resolveDeptHeadAtLevel(2, { id: 'requester-1' })).toEqual([])
+    expect(resolveDeptHeadAtLevel(2, null)).toEqual([])
+  })
+
+  it('self-excludes dept_head_at_level when the picked level resolves to the requester', () => {
+    expect(resolveDeptHeadAtLevel(1, { id: 'requester-1', deptHeadChainIds: ['requester-1', 'h2'] })).toEqual([])
+    expect(resolveDeptHeadAtLevel(2, { id: 'requester-1', deptHeadChainIds: ['requester-1', 'h2'] })).toEqual([dhalEntry('h2')])
+  })
+
+  // Density-contract pin (mirrors manager_at_level's above): resolveDeptHeadChain
+  // (ApprovalDirectoryOrg) is DENSE under the RATIFIED continue-past-empty-level posture — a level
+  // whose head is unresolved contributes NOTHING but does not truncate the walk, so the walk
+  // itself already compacted before the snapshot was frozen. chain[level-1] is therefore the
+  // level-th *resolved* head, not "the head N parent-hops up" — positional over the DENSE array,
+  // never a live re-walk. This pins the defensive behavior if a null/'' rung ever reached the
+  // resolver: that level resolves empty (positional, no compaction), and a later dense level is
+  // unaffected.
+  it('dept_head_at_level treats a null/empty rung positionally (dense-snapshot contract)', () => {
+    expect(resolveDeptHeadAtLevel(2, { id: 'requester-1', deptHeadChainIds: ['h1', null as never, 'h3'] })).toEqual([])
+    expect(resolveDeptHeadAtLevel(1, { id: 'requester-1', deptHeadChainIds: ['h1', null as never, 'h3'] })).toEqual([dhalEntry('h1')])
+    expect(resolveDeptHeadAtLevel(3, { id: 'requester-1', deptHeadChainIds: ['h1', null as never, 'h3'] })).toEqual([dhalEntry('h3')])
+  })
+
   it('resolves requester and static sources with source metadata', () => {
     expect(resolve({
       assigneeSources: [

--- a/packages/core-backend/tests/unit/approval-dept-head-chain.test.ts
+++ b/packages/core-backend/tests/unit/approval-dept-head-chain.test.ts
@@ -281,6 +281,20 @@ describe('runtimeGraphUsesDeptHeadChain (K4 conditional-bake scanner)', () => {
     expect(runtimeGraphUsesDeptHeadChain(graph([{ kind: 'requester' }, { kind: 'continuous_dept_heads', levels: 1 }]))).toBe(true)
   })
 
+  // Lock-1 §K5-b: dept_head_at_level is STRICTLY DOWNSTREAM of K4 — it reads the SAME
+  // deptHeadChainIds snapshot field, so it shares this ONE gate rather than minting its own
+  // (mirrors runtimeGraphUsesManagerChain carrying both continuous_managers AND
+  // manager_at_level). Missing this is the R-13 "silent skip" class: a graph using ONLY
+  // dept_head_at_level would never bake deptHeadChainIds, and the resolver's positional read
+  // would see `undefined` — indistinguishable from "no head at that level".
+  it('detects a dept_head_at_level source on an approval node (K5-b shares K4\'s gate — strictly downstream)', () => {
+    expect(runtimeGraphUsesDeptHeadChain(graph([{ kind: 'dept_head_at_level', level: 2 }]))).toBe(true)
+  })
+
+  it('detects dept_head_at_level mixed with non-chain sources', () => {
+    expect(runtimeGraphUsesDeptHeadChain(graph([{ kind: 'requester' }, { kind: 'dept_head_at_level', level: 1 }]))).toBe(true)
+  })
+
   it('returns false for continuous_managers / manager_at_level — a SEPARATE gate from runtimeGraphUsesManagerChain, not a relabeling', () => {
     expect(runtimeGraphUsesDeptHeadChain(graph([{ kind: 'continuous_managers', levels: 2 }]))).toBe(false)
     expect(runtimeGraphUsesDeptHeadChain(graph([{ kind: 'manager_at_level', level: 1 }]))).toBe(false)
@@ -302,6 +316,11 @@ describe('runtimeGraphUsesOrgAssigneeSource — K4 extension (Lock-1 §2.1, G-20
 
   it('treats continuous_dept_heads as an org-derived source (extends the B5-b fail-closed guard)', () => {
     expect(runtimeGraphUsesOrgAssigneeSource(graph([{ kind: 'continuous_dept_heads', levels: 2 }]))).toBe(true)
+  })
+
+  // Lock-1 §2.1 names K4 AND K5-b explicitly ("That detector MUST be extended to K4 and K5-b").
+  it('treats dept_head_at_level as an org-derived source (Lock-1 §2.1 K5-b extension, extends the B5-b fail-closed guard)', () => {
+    expect(runtimeGraphUsesOrgAssigneeSource(graph([{ kind: 'dept_head_at_level', level: 2 }]))).toBe(true)
   })
 
   it('still detects the four shipped org-derived kinds (no narrowing regression)', () => {

--- a/packages/core-backend/tests/unit/approval-graph-executor.test.ts
+++ b/packages/core-backend/tests/unit/approval-graph-executor.test.ts
@@ -5,6 +5,7 @@ import {
   pruneHiddenFormData,
   validateApprovalFormData,
 } from '../../src/services/ApprovalGraphExecutor'
+import { resolveApprovalAssignees } from '../../src/services/ApprovalAssigneeResolver'
 import type { FormSchema, RuntimeGraph } from '../../src/types/approval-product'
 
 describe('ApprovalGraphExecutor', () => {
@@ -593,6 +594,73 @@ describe('ApprovalGraphExecutor', () => {
       code: 'APPROVAL_ASSIGNEE_EMPTY',
       statusCode: 400,
     }))
+  })
+
+  // Lock-1 §K5-b: this is the REAL resolveApprovalAssignees wired into the REAL executor (not a
+  // fake resolver returning `[]`) — the exact integration point the real-DB acceptance suite
+  // exercises over real SQL (approval-dept-head-at-level.db.test.ts's out-of-range leg), run here
+  // as a local, no-DB oracle for the SAME assertion: a `level` valid in contract but past the end
+  // of the frozen deptHeadChainIds resolves EMPTY via the resolver's own positional slice, and the
+  // executor's existing (unmodified) empty-assignee branching decides what happens next — never a
+  // crash, never a silently-materialized assignee. Positive control pair, per §K5's own text
+  // ("resolves EMPTY and falls to emptyAssigneePolicy, which is the shipped manager_at_level
+  // behavior, unchanged"): 'error' throws APPROVAL_ASSIGNEE_EMPTY; 'auto-approve' auto-approves —
+  // both are the SAME shipped emptyAssigneePolicy branch every other kind already goes through.
+  it('Lock-1 §K5-b: dept_head_at_level level past the end of the frozen deptHeadChainIds resolves EMPTY through the REAL resolver, and the executor applies the node emptyAssigneePolicy (error throws APPROVAL_ASSIGNEE_EMPTY; auto-approve auto-approves) — never a crash, never a silent assignee', () => {
+    const requesterSnapshot = { id: 'requester-1', deptHeadChainIds: ['head-1', 'head-2'] }
+    const realResolver = ({ nodeKey, sourceStep, config }: { nodeKey: string; sourceStep: number; config: any }) =>
+      resolveApprovalAssignees({ nodeKey, sourceStep, config, formSnapshot: {}, requesterSnapshot })
+
+    const outOfRangeGraph = (emptyAssigneePolicy: 'error' | 'auto-approve'): RuntimeGraph => ({
+      nodes: [
+        { key: 'start', type: 'start', config: {} },
+        {
+          key: 'dhal-oor',
+          type: 'approval',
+          config: {
+            assigneeSources: [{ kind: 'dept_head_at_level', level: 5 }],
+            emptyAssigneePolicy,
+          },
+        },
+        { key: 'final-review', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['user-9'] } },
+        { key: 'end', type: 'end', config: {} },
+      ],
+      edges: [
+        { key: 'edge-start-oor', source: 'start', target: 'dhal-oor' },
+        { key: 'edge-oor-final', source: 'dhal-oor', target: 'final-review' },
+        { key: 'edge-final-end', source: 'final-review', target: 'end' },
+      ],
+      policy: { allowRevoke: true },
+    })
+
+    // Positive control FIRST: an IN-RANGE level resolves a real assignee through the SAME real
+    // resolver + executor wiring (proves the fixture itself is capable of a non-empty result —
+    // the out-of-range legs below are not vacuously empty because of a broken fixture).
+    const inRangeExecutor = new ApprovalGraphExecutor(
+      { ...outOfRangeGraph('error'), nodes: outOfRangeGraph('error').nodes.map((n) => n.key === 'dhal-oor' ? { ...n, config: { assigneeSources: [{ kind: 'dept_head_at_level', level: 1 }], emptyAssigneePolicy: 'error' } } : n) },
+      {},
+      { assignmentResolver: realResolver },
+    )
+    expect(inRangeExecutor.resolveInitialState().assignments).toEqual([
+      { assignmentType: 'user', assigneeId: 'head-1', nodeKey: 'dhal-oor', sourceStep: 1, metadata: { resolvedFrom: { kind: 'dept_head_at_level', sourceIndex: 0 } } },
+    ])
+
+    // 'error': out-of-range level (5) against a 2-entry chain -> empty resolution -> throws.
+    const errorExecutor = new ApprovalGraphExecutor(outOfRangeGraph('error'), {}, { assignmentResolver: realResolver })
+    expect(() => errorExecutor.resolveInitialState()).toThrowError(expect.objectContaining({
+      code: 'APPROVAL_ASSIGNEE_EMPTY',
+      statusCode: 400,
+    }))
+
+    // 'auto-approve': the SAME empty resolution, but the node's own policy governs — the shipped,
+    // unmodified `emptyAssigneePolicy: 'auto-approve'` branch fires (never a silent NOBODY: it is
+    // an EXPLICIT, audited autoApprovalEvents entry, not an unassigned pending node).
+    const autoExecutor = new ApprovalGraphExecutor(outOfRangeGraph('auto-approve'), {}, { assignmentResolver: realResolver })
+    const autoInitial = autoExecutor.resolveInitialState()
+    expect(autoInitial.currentNodeKey).toBe('final-review')
+    expect(autoInitial.autoApprovalEvents).toEqual([
+      { nodeKey: 'dhal-oor', sourceStep: 1, approvalMode: 'single', reason: 'empty-assignee' },
+    ])
   })
 
   it('tags resolveAfterApprove resolutions with the resolved-away node aggregate mode', () => {

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -310,6 +310,14 @@ export default defineConfig({
       // approval-realdb-k4) — plugin-tests.yml stays byte-identical (s6a pin). Two-point wiring —
       // both points land in the SAME commit.
       'tests/integration/approval-dept-head-chain.db.test.ts',
+      // Lock-1 §K5-b dept_head_at_level real-DB acceptance (G-1/G-2/core positional-not-hop-count,
+      // out-of-range, freeze purity) — strictly downstream of K4, reads the SAME deptHeadChainIds
+      // snapshot field. DATABASE_URL-gated; excluded here so the no-DB default job cannot
+      // collect-and-skip-green it, and carried by the SAME dedicated
+      // .github/workflows/approval-realdb-acceptance.yml workflow (sibling job
+      // approval-realdb-k5b) — plugin-tests.yml stays byte-identical (s6a pin). Two-point wiring —
+      // both points land in the SAME commit.
+      'tests/integration/approval-dept-head-at-level.db.test.ts',
       'tests/integration/approval-delegation-seam.db.test.ts',
       'tests/integration/approval-delegation-api.db.test.ts',
       'tests/integration/approval-detail-subform.db.test.ts',


### PR DESCRIPTION
## Summary

Full-stack slice of the RATIFIED Lock-1 §K5-b `dept_head_at_level` (指定层级部门负责人), implemented strictly within `docs/development/approval-lock1-enterprise-assignees-20260817.md` following K4's (`continuous_dept_heads`, #4958) exact pattern. Strictly downstream of K4: reads the SAME `deptHeadChainIds` snapshot field K4 builds — no new snapshot field, no new directory read.

**Level semantics (OD citation: Lock-1 §K5, lines 231-234 + 247-251):** `{ kind: 'dept_head_at_level'; level: number }`, `level` validated `[1, MAX_MANAGER_CHAIN_LEVELS]` at the authoring choke (never coerced/defaulted). Resolution is `deptHeadChainIds[level-1]` — **absolute, 1-based, positional** over the frozen chain (level 1 = the requester's own department head, byte-identical to the shipped single-level `dept_head`), mirroring `manager_at_level` exactly but over the K4 department-head chain instead of `managerChainIds`. Because `deptHeadChainIds` is DENSE under K4's ratified continue-past-empty-level posture, `chain[level-1]` is the level-th *resolved* head walking up, not "the head N parent-hops up" — proven in the new real-DB suite against a 3-level tree with an intermediate empty-manager-list department. **Out-of-range behavior:** a `level` valid in contract but deeper than THIS requester's chain resolves EMPTY and falls to the node's `emptyAssigneePolicy` — this is the shipped `manager_at_level` behavior, unchanged, and is NEVER a dispatch-time crash or silent coercion (verified by both a real-DB leg and a new local executor oracle using the real resolver).

## Backend

- types: `ApprovalAssigneeSourceKind` + source union member `{kind:'dept_head_at_level'; level:number}`
- `normalizeApprovalAssigneeSources`: level validated byte-identically to `manager_at_level`
- resolver: pure `dept_head_at_level` arm — positional pick, self-exclusion, `emptyAssigneePolicy` fallthrough
- `runtimeGraphUsesDeptHeadChain` EXTENDED to `dept_head_at_level` (shares K4's ONE gate — closes the R-13 "silent skip" class: a graph using ONLY `dept_head_at_level` would otherwise never bake `deptHeadChainIds`)
- `runtimeGraphUsesOrgAssigneeSource` EXTENDED per Lock-1 §2.1's explicit "MUST be extended to K4 and K5-b" instruction (closes the B5-b fail-open class for this kind too — an org-read failure now fails create 422/503 before any insert, even under `emptyAssigneePolicy:'auto-approve'`)
- fingerprint: `dept_head_at_level:<level>` on both mirrors, lockstep-enforced by the existing `_exhaustive:never` guard

## The five §2.5 mirror sites (+ registry row + config editor)

1. `packages/core-backend/src/types/approval-product.ts` — union member
2. `apps/web/src/types/approval.ts` — FE union mirror
3. `apps/web/src/approvals/templateAuthoring.ts` — `BACKEND_ASSIGNEE_SOURCE_KEYS_BY_KIND` + `unsupportedTemplateAuthoringReason` allowlist
4. `apps/web/src/approvals/templateAuthoring.ts` — linear editor's accepted-kind list (same file, item 4 of §2.5)
5. `apps/web/src/approvals/assigneeSource.ts` — `assigneeSourceSummary` explicit case (values-free)

Plus: `approvalCapabilityRegistry.ts` registry row (指定层级部门负责人, exact-set 10→11), `approvalNodeEdit.ts` FE preview validation, `parallelEdit.ts` fingerprint mirror, `ApprovalGraphNodeConfigEditor.vue` (reuses the shared level input, testid `approval-node-source-level`), `TemplateAuthoringView.vue` (own dedicated level field, testid `approval-step-dept-head-level` — singular, distinct from K4's `approval-step-dept-head-levels` count field).

## Deferred (deliberately, not an oversight)

Lock-3 §1.5 names `dept_head_at_level` a FORWARD ADMIT row for the `handler` node's seven-member assignee roster ("Forward rows, conditional on Lock-1 landing... Each row lands in the same slice as its kind"). **This slice does NOT widen `HANDLER_ASSIGNEE_SOURCE_KINDS`.** It follows the identical precedent Lock-3's own P4-A slice already set for `requester_choice` — shipped before P4-A, yet P4-A explicitly declined to retroactively widen the handler roster for it ("a separate follow-up decision, not P4-A", per the doc comment on `HANDLER_ASSIGNEE_SOURCE_KINDS`). Widening the handler roster for K5-b while `requester_choice` — same forward-ADMIT sentence, same disposition — stays out would be an unruled asymmetry no owner has decided. Two new tests assert the deferral holds: a mutation-3 exact-set probe in `approval-handler-node-authoring.spec.ts` (adding `dept_head_at_level` to the handler roster must fail the exact-set check) and a positive `validateApprovalNodeEdits` rejection for a handler node carrying it.

Also untouched, out of this slice's scope per the OD: Lock-1 §K5-c (downward `最高-n` addressing, OD-L1-6, BLOCKED on snapshot data) and §K5-a (`manager_at_level` picker/label polish — already expressible, no backend contract change needed).

## Tests

- **Real-DB**: new `approval-dept-head-at-level.db.test.ts` (G-1 level validation, G-2 not-yet-implemented, positional-not-hop-count over a real 3-level department-parent tree with an intermediate empty-manager-list department, out-of-range → `APPROVAL_ASSIGNEE_EMPTY` 400, freeze-purity/temporal). G-20 satisfied by extending the existing parametrized `approval-routing-policy-failclose.api.test.ts` fixture (KINDS array, four→six) rather than duplicating it. `approval-dept-head-chain.db.test.ts`'s own G-2 fixture is repointed from `dept_head_at_level` (now implemented) to `user_group` (still genuinely unimplemented) — same precedent K2's own file already used.
- **Unit — resolver**: `approval-assignee-resolver.test.ts` gains a `dept_head_at_level` block mirroring `manager_at_level`'s exactly (in-range positive control, out-of-range/absent-snapshot empty, self-exclusion, dense-snapshot positional null-rung contract).
- **Unit — detectors**: `approval-dept-head-chain.test.ts` gains `dept_head_at_level` cases for both `runtimeGraphUsesDeptHeadChain` and `runtimeGraphUsesOrgAssigneeSource`.
- **Unit — executor oracle (new, added after independent review)**: `approval-graph-executor.test.ts` wires the REAL `resolveApprovalAssignees` into the REAL `ApprovalGraphExecutor` (not a fake resolver) and proves the out-of-range → `emptyAssigneePolicy` behavior locally, with a positive control — this is the runnable, no-DB analogue of the real-DB suite's out-of-range leg, which could not be executed in this sandbox (see Verification below).
- **FE**: extended (not new) specs across all five mirror sites + registry exact-set + sub-form mount + parallel-edit fingerprint (incl. non-collision vs `manager_at_level` and vs `continuous_dept_heads` on the same numeric value) + linear round-trip + mounted hydration + the handler-deferral invariant tests. No new spec files, so no CI-token wiring is needed.
- **Two-point wiring**: `vitest.config.ts` excludes the new `.db.test.ts` from the no-DB default job; `.github/workflows/approval-realdb-acceptance.yml` gains a sibling `approval-realdb-k5b` job and both `paths:` blocks gain the new test file. `plugin-tests.yml` is untouched (s6a pin).

## Verification

- Backend `tsc --noEmit`: clean. `apps/web` `vue-tsc -b`: clean.
- `apps/web/scripts/run-required-web-tests.sh` on Node 20.20.2: **368 files / 4527 tests, all green.**
- Backend `tests/unit/` (no DB): 496/513 files green — the 17 red files fail identically on an UNMODIFIED file (`approval-requester-choice.db.test.ts`) with a `REPO_ROOT_AMBIGUOUS` error caused by this worktree being nested inside the canonical repo directory (two ancestors both contain `packages/core-backend/package.json`); confirmed pre-existing/environmental, not caused by this change, and will not reproduce in CI's fresh checkout.
- **Mutation-verified, for real** (cp-backup + sha256 byte-identical restore after each, never `git checkout --`; each applied alone and restored before the next — full per-mutation red/green table in the second commit's message): drop `dept_head_at_level` from `SHIPPED_ASSIGNEE_SOURCE_KIND_ORDER`; drop it from `APPROVAL_ASSIGNEE_SOURCE_LABELS`; drop it from `runtimeGraphUsesDeptHeadChain`; drop it from `runtimeGraphUsesOrgAssigneeSource`; drop the resolver arm's self-exclusion guard; off-by-one the resolver arm's chain index. Every mutation reds exactly its predicted test set and nothing else.
- **Repo-wide sweep** (`git grep -n "dept_head_at_level" <pre-K5-b SHA>`): the only pre-existing test-code reference was `approval-dept-head-chain.db.test.ts`'s own G-2 "not-yet-implemented" fixture, already repointed to `user_group` — confirmed no other test used this kind as an unknown/unregistered-kind fixture that would now silently go vacuous.
- **Not executed locally** (honest scoping, not a claim of verification): `approval-dept-head-at-level.db.test.ts` itself — this sandbox has no `DATABASE_URL` and the nested-worktree `REPO_ROOT_AMBIGUOUS` issue above blocks even collection of any `.db.test.ts` file here (reproduced identically on an untouched K4/K2 file as a negative control). The `approval-realdb-k5b` CI job is this suite's first real run. The out-of-range leg's exact HTTP-level behavior is corroborated by the new local executor oracle (item above) using the real resolver, but the full end-to-end HTTP/SQL path is CI-first.

Master invariants M1-M11 honored: M4 fail-closed registry (Record-typed LABELS forces a compile error on a missing entry), M7 no inert controls (level input is a real, wired `el-input-number`), M8 honesty (deferred items + CI-first legs stated above), M10 not applicable (no formatted-number claim), M11 (absence-from-corpus framing not invoked here — this is a ratified-lock implementation, not a benchmark claim).

🤖 Generated with [Claude Code](https://claude.com/claude-code)