### PR TITLE
feat(approval): P1-B — multi-source assignee cards (＋添加审批人)

### DIFF
--- a/apps/web/src/approvals/approvalNodeEdit.ts
+++ b/apps/web/src/approvals/approvalNodeEdit.ts
@@ -110,6 +110,42 @@ export function approvalNodeEditsFromGraph(graph: ApprovalGraph | undefined): Ap
 }
 
 /**
+ * P1-B: append one new assignee-source card to a node's edit, in place. `defaultSource` is
+ * caller-supplied (the config editor derives it from the L0-2 capability registry roster for the
+ * node's TYPE, never a hand-picked kind — a `handler` node's roster differs from `approval`'s). No
+ * dedup, no reorder: the runtime resolver owns the union + identity dedup (master §P1-B item 4 /
+ * M5) — this only appends to the array. No-op when the node is not in `edits`.
+ */
+export function addAssigneeSourceCard(
+  edits: ApprovalNodeEdits,
+  nodeKey: string,
+  defaultSource: ApprovalAssigneeSource,
+): void {
+  const edit = edits[nodeKey]
+  if (!edit) return
+  edit.assigneeSources = [...edit.assigneeSources, cloneJson(defaultSource)]
+}
+
+/**
+ * P1-B fail-closed: a node must always keep ≥1 assignee source. Refuses (no-op) when the node has
+ * exactly one source, REGARDLESS of any caller-side disabled-button UX — a native `disabled`
+ * button element cannot even dispatch a click event, so the browser-level guard alone is
+ * untestable/unenforceable independent of this function; THIS is the actual invariant enforcement
+ * point (master §P1-B). Also a no-op for a missing node or an out-of-range index.
+ */
+export function removeAssigneeSourceCard(
+  edits: ApprovalNodeEdits,
+  nodeKey: string,
+  sourceIndex: number,
+): void {
+  const edit = edits[nodeKey]
+  if (!edit) return
+  if (edit.assigneeSources.length <= 1) return
+  if (sourceIndex < 0 || sourceIndex >= edit.assigneeSources.length) return
+  edit.assigneeSources = edit.assigneeSources.filter((_, index) => index !== sourceIndex)
+}
+
+/**
  * Apply the graph editor's owned fields while leaving every other node, edge, and config field
  * byte-identical. Optional fields only overwrite when present, preserving untouched absence.
  *
@@ -262,17 +298,19 @@ export function validateApprovalNodeEdits(
 }
 
 /**
- * B2-03 publish pre-flight: node keys whose FIRST assignee source is still the starter-preset
- * placeholder role (`APPROVAL_ROLE_CONFIGURE_SENTINEL`). The backend fail-fasts on this at PUBLISH
- * (`assertNoUnconfiguredPlaceholderRoles`, ApprovalProductService.ts) — this mirrors that check so
- * the publish-checklist can warn BEFORE the confirm instead of after a rejected request. Non-fatal
- * for save (mirrors the in-editor sentinel hint, which is also non-blocking).
+ * B2-03 publish pre-flight: node keys carrying a static_role placeholder role
+ * (`APPROVAL_ROLE_CONFIGURE_SENTINEL`) on ANY assignee source, not only the first. The backend
+ * fail-fasts on this at PUBLISH (`assertNoUnconfiguredPlaceholderRoles`, ApprovalProductService.ts)
+ * by looping every source on the node — this mirrors that check exactly so the publish-checklist
+ * can warn BEFORE the confirm instead of after a rejected request. P1-B widened this from
+ * `assigneeSources[0]`-only once the editor exposes N source cards (before that slice, index 0 was
+ * the only authorable source, so the two checks were equivalent). Non-fatal for save (mirrors the
+ * in-editor sentinel hint, which is also non-blocking).
  */
 export function placeholderRoleNodeKeys(edits: ApprovalNodeEdits): string[] {
   return Object.values(edits)
-    .filter((edit) => {
-      const source = edit.assigneeSources[0]
-      return source?.kind === 'static_role' && source.roleIds.includes(APPROVAL_ROLE_CONFIGURE_SENTINEL)
-    })
+    .filter((edit) => edit.assigneeSources.some(
+      (source) => source.kind === 'static_role' && source.roleIds.includes(APPROVAL_ROLE_CONFIGURE_SENTINEL),
+    ))
     .map((edit) => edit.nodeKey)
 }

--- a/apps/web/src/approvals/approvalNodeEdit.ts
+++ b/apps/web/src/approvals/approvalNodeEdit.ts
@@ -298,6 +298,17 @@ export function validateApprovalNodeEdits(
 }
 
 /**
+ * True when a single assignee source is the starter-preset placeholder role
+ * (`APPROVAL_ROLE_CONFIGURE_SENTINEL`). SINGLE shared predicate for both the aggregate publish
+ * checklist (`placeholderRoleNodeKeys`, below) and the per-card in-editor hint
+ * (`ApprovalGraphNodeConfigEditor.vue`'s `approvalSourceIsPlaceholder`) — the two surfaces must
+ * agree on exactly which source counts as a placeholder, so this is the one place that decides.
+ */
+export function isPlaceholderRoleSource(source: ApprovalAssigneeSource): boolean {
+  return source.kind === 'static_role' && source.roleIds.includes(APPROVAL_ROLE_CONFIGURE_SENTINEL)
+}
+
+/**
  * B2-03 publish pre-flight: node keys carrying a static_role placeholder role
  * (`APPROVAL_ROLE_CONFIGURE_SENTINEL`) on ANY assignee source, not only the first. The backend
  * fail-fasts on this at PUBLISH (`assertNoUnconfiguredPlaceholderRoles`, ApprovalProductService.ts)
@@ -309,8 +320,6 @@ export function validateApprovalNodeEdits(
  */
 export function placeholderRoleNodeKeys(edits: ApprovalNodeEdits): string[] {
   return Object.values(edits)
-    .filter((edit) => edit.assigneeSources.some(
-      (source) => source.kind === 'static_role' && source.roleIds.includes(APPROVAL_ROLE_CONFIGURE_SENTINEL),
-    ))
+    .filter((edit) => edit.assigneeSources.some(isPlaceholderRoleSource))
     .map((edit) => edit.nodeKey)
 }

--- a/apps/web/src/approvals/components/ApprovalGraphNodeConfigEditor.vue
+++ b/apps/web/src/approvals/components/ApprovalGraphNodeConfigEditor.vue
@@ -378,9 +378,12 @@
       </el-form-item>
     </div>
 
-    <!-- G-5: editable approval node — approver SOURCE only (assigneeSources[0]). The node's
+    <!-- G-5 / P1-B: editable approval node — ALL assignee-source cards (assigneeSources[]), one
+         card per array entry, each an independent roster + per-kind picker. The node's
          approvalMode / emptyAssigneePolicy / autoApprovalPolicy + edges are preserved. Legacy
-         nodes (no assigneeSources) aren't seeded → fall to the read-only summary below.
+         nodes (no assigneeSources) aren't seeded → fall to the read-only summary below. Master
+         §P1-B / M5: array order is display order; the runtime resolver owns the union + identity
+         dedup — this editor only appends/removes/edits cards, never reorders or merges them.
          Lock-3 §1.5: the SAME section renders a `handler` node (办理节点) — it reuses the exact roster
          radio-grid + per-kind typed pickers (registry-driven per node TYPE), swapping only the
          type-specific labels + the mode/opinion controls (handler has NO empty-policy / self-approval /
@@ -399,236 +402,281 @@
       class="template-authoring__approval-node-section"
       data-testid="approval-node-section-assignee"
     >
-      <!-- Lock-0 L0-2: registry-driven radio-grid roster (replaces the single el-select). §10.3
-           constrains the picker to be ONE component with plain labels + a configured summary
-           echo, not a specific control shape — a radio grid needs no further delta. -->
-      <el-form-item :label="node.type === 'handler' ? '办理人来源' : '审批人来源'">
-        <div
-          class="approval-node-source-roster"
-          role="radiogroup"
-          :aria-label="node.type === 'handler' ? '办理人来源' : '审批人来源'"
-          data-testid="approval-node-source-roster"
-        >
-          <label
-            v-for="opt in assigneeSourceRosterForNode"
-            :key="opt.kind"
-            class="approval-node-source-roster-option"
-          >
-            <input
-              type="radio"
-              :name="`approval-node-source-kind-${node.key}`"
-              :checked="approvalSourceKind(node.key) === opt.kind"
-              :disabled="readOnly"
-              :data-testid="`approval-node-source-kind-${opt.kind}`"
-              @change="() => { setApprovalSourceKind(node.key, opt.kind); syncApprovalNodeOptions(node.key) }"
-            />
-            <span>{{ opt.label }}</span>
-          </label>
-        </div>
-        <!-- L0-2 / A-4: a persisted source kind outside the registry stays read-only and
-             round-trips unchanged — never flattened to a registry default. -->
-        <p
-          v-if="!isKnownAssigneeSourceKind"
-          class="template-authoring__hint template-authoring__hint--warn"
-          data-testid="approval-node-source-kind-unknown"
-        >当前来源「{{ approvalSourceKind(node.key) }}」不在能力清单中，保留为只读，保存时不会被覆盖或清空</p>
-        <!-- D2: configured summary echo (parent §10.3), reusing the existing shared wording. -->
-        <p
-          v-if="configuredSourceSummaryLine"
-          class="template-authoring__hint"
-          data-testid="approval-node-source-configured-summary"
-        >{{ configuredSourceSummaryLine }}</p>
-      </el-form-item>
-      <!-- G-B2-18 + D1: typed directory pickers only; no ordinary raw-ID authoring path. -->
-      <template v-if="approvalSourceKind(node.key) === 'static_user' || approvalSourceKind(node.key) === 'static_role'">
-        <el-form-item v-if="approvalSourceKind(node.key) === 'static_user'" label="选择用户">
-          <el-select
-            :model-value="approvalSourceIds(node.key)"
-            multiple
-            filterable
-            remote
-            :remote-method="onUserSearch"
-            :loading="directoryUsersLoading"
-            size="small"
-            :disabled="readOnly"
-            class="ms-w-360"
-            placeholder="搜索用户名 / 邮箱"
-            data-testid="approval-node-source-user-picker"
-            @update:model-value="(ids: string[]) => setApprovalSourceIdsFromPicker(node.key, ids)"
-            @visible-change="(visible: boolean) => visible && onUserSearch('')"
-          >
-            <el-option
-              v-for="user in directoryUsers"
-              :key="user.id"
-              :label="formatUserLabel(user)"
-              :value="user.id"
-            />
-          </el-select>
-        </el-form-item>
-        <el-form-item v-else label="选择角色">
-          <el-select
-            :model-value="approvalSourceIds(node.key)"
-            multiple
-            filterable
-            size="small"
-            :disabled="readOnly"
-            class="ms-w-360"
-            placeholder="选择角色"
-            data-testid="approval-node-source-role-picker"
-            @update:model-value="(ids: string[]) => setApprovalSourceIdsFromPicker(node.key, ids)"
-          >
-            <el-option
-              v-for="role in directoryRoles"
-              :key="role.id"
-              :label="formatRoleLabel(role)"
-              :value="role.id"
-            />
-          </el-select>
-        </el-form-item>
-      </template>
-      <el-form-item
-        v-else-if="approvalSourceKind(node.key) === 'form_field_user'"
-        label="表单用户字段"
+      <!-- P1-B: one card per assigneeSources[] entry, keyed by its (stable, positional) index — the
+           array IS the identity model here (no separate id field), and add/remove/edit only ever
+           append/splice/replace by index, so index-as-key is safe. Each card is byte-identical to
+           the old single-source markup (every inner data-testid is UNCHANGED — only the radio
+           `name` gains a per-card suffix, which native radiogroups require) so a single-source node
+           renders the exact same DOM as before this slice (positive control). -->
+      <div
+        v-for="(source, sourceIndex) in (approvalNodeEditFor(node.key)?.assigneeSources ?? [])"
+        :key="sourceIndex"
+        class="approval-node-source-card"
+        data-testid="approval-node-source-card"
+        :data-source-index="sourceIndex"
       >
-        <el-select
-          :model-value="approvalSourceFieldId(node.key)"
-          size="small"
-          :disabled="readOnly"
-          class="ms-w-240"
-          placeholder="选择表单用户字段"
-          data-testid="approval-node-source-field"
-          @update:model-value="(fieldId: string) => setApprovalSourceFieldId(node.key, fieldId)"
-        >
-          <el-option
-            v-for="field in userFields"
-            :key="field.id"
-            :label="field.label || '未命名字段'"
-            :value="field.id"
-          />
-        </el-select>
-      </el-form-item>
-      <el-form-item
-        v-else-if="approvalSourceKind(node.key) === 'manager_at_level' || approvalSourceKind(node.key) === 'continuous_managers' || approvalSourceKind(node.key) === 'continuous_dept_heads' || approvalSourceKind(node.key) === 'dept_head_at_level'"
-        :label="approvalSourceKind(node.key) === 'manager_at_level' ? '指定上级层级' : approvalSourceKind(node.key) === 'continuous_dept_heads' ? '部门负责人层级数' : approvalSourceKind(node.key) === 'dept_head_at_level' ? '指定部门负责人层级' : '上级层级数'"
-      >
-        <el-input-number
-          :model-value="approvalSourceLevel(node.key)"
-          :min="1"
-          :max="10"
-          :step="1"
-          size="small"
-          :disabled="readOnly"
-          data-testid="approval-node-source-level"
-          @update:model-value="(value: number) => setApprovalSourceLevel(node.key, value ?? 1)"
-        />
-      </el-form-item>
-      <!-- Lock-1 §K2 (提交人自选) authoring sub-form: mode radio (单选/多选) + scope select
-           (全公司/指定成员/指定角色) with TYPED pickers only (D0 §10.2 — no raw-ID input).
-           The submit-time chooser itself lives in ApprovalNewView; this only authors the
-           mode + scope the server validates the requester's choice against. -->
-      <template v-else-if="approvalSourceKind(node.key) === 'requester_choice'">
-        <el-form-item label="选择方式">
+        <!-- Lock-0 L0-2: registry-driven radio-grid roster (replaces the single el-select). §10.3
+             constrains the picker to be ONE component with plain labels + a configured summary
+             echo, not a specific control shape — a radio grid needs no further delta. -->
+        <el-form-item :label="(node.type === 'handler' ? '办理人来源' : '审批人来源') + (approvalSourceCount(node.key) > 1 ? ` ${sourceIndex + 1}` : '')">
           <div
             class="approval-node-source-roster"
             role="radiogroup"
-            aria-label="选择方式"
-            data-testid="approval-node-requester-choice-mode"
+            :aria-label="node.type === 'handler' ? '办理人来源' : '审批人来源'"
+            data-testid="approval-node-source-roster"
           >
-            <label class="approval-node-source-roster-option">
+            <label
+              v-for="opt in assigneeSourceRosterForNode"
+              :key="opt.kind"
+              class="approval-node-source-roster-option"
+            >
               <input
                 type="radio"
-                :name="`approval-node-requester-choice-mode-${node.key}`"
-                :checked="requesterChoiceMode(node.key) === 'single'"
+                :name="`approval-node-source-kind-${node.key}-${sourceIndex}`"
+                :checked="approvalSourceKind(node.key, sourceIndex) === opt.kind"
                 :disabled="readOnly"
-                data-testid="approval-node-requester-choice-mode-single"
-                @change="() => setRequesterChoiceMode(node.key, 'single')"
+                :data-testid="`approval-node-source-kind-${opt.kind}`"
+                @change="() => { setApprovalSourceKind(node.key, sourceIndex, opt.kind); syncApprovalNodeOptions(node.key) }"
               />
-              <span>单选（提交时选一人）</span>
-            </label>
-            <label class="approval-node-source-roster-option">
-              <input
-                type="radio"
-                :name="`approval-node-requester-choice-mode-${node.key}`"
-                :checked="requesterChoiceMode(node.key) === 'multi'"
-                :disabled="readOnly"
-                data-testid="approval-node-requester-choice-mode-multi"
-                @change="() => setRequesterChoiceMode(node.key, 'multi')"
-              />
-              <span>多选（提交时可选多人）</span>
+              <span>{{ opt.label }}</span>
             </label>
           </div>
+          <!-- L0-2 / A-4: a persisted source kind outside the registry stays read-only and
+               round-trips unchanged — never flattened to a registry default. -->
+          <p
+            v-if="!isKnownAssigneeSourceKind(node.key, sourceIndex)"
+            class="template-authoring__hint template-authoring__hint--warn"
+            data-testid="approval-node-source-kind-unknown"
+          >当前来源「{{ approvalSourceKind(node.key, sourceIndex) }}」不在能力清单中，保留为只读，保存时不会被覆盖或清空</p>
+          <!-- D2: configured summary echo (parent §10.3), reusing the existing shared wording. -->
+          <p
+            v-if="configuredSourceSummaryLine(node.key, sourceIndex)"
+            class="template-authoring__hint"
+            data-testid="approval-node-source-configured-summary"
+          >{{ configuredSourceSummaryLine(node.key, sourceIndex) }}</p>
         </el-form-item>
-        <el-form-item label="可选范围">
+        <!-- G-B2-18 + D1: typed directory pickers only; no ordinary raw-ID authoring path. -->
+        <template v-if="approvalSourceKind(node.key, sourceIndex) === 'static_user' || approvalSourceKind(node.key, sourceIndex) === 'static_role'">
+          <el-form-item v-if="approvalSourceKind(node.key, sourceIndex) === 'static_user'" label="选择用户">
+            <el-select
+              :model-value="approvalSourceIds(node.key, sourceIndex)"
+              multiple
+              filterable
+              remote
+              :remote-method="onUserSearch"
+              :loading="directoryUsersLoading"
+              size="small"
+              :disabled="readOnly"
+              class="ms-w-360"
+              placeholder="搜索用户名 / 邮箱"
+              data-testid="approval-node-source-user-picker"
+              @update:model-value="(ids: string[]) => setApprovalSourceIdsFromPicker(node.key, sourceIndex, ids)"
+              @visible-change="(visible: boolean) => visible && onUserSearch('')"
+            >
+              <el-option
+                v-for="user in directoryUsers"
+                :key="user.id"
+                :label="formatUserLabel(user)"
+                :value="user.id"
+              />
+            </el-select>
+          </el-form-item>
+          <el-form-item v-else label="选择角色">
+            <el-select
+              :model-value="approvalSourceIds(node.key, sourceIndex)"
+              multiple
+              filterable
+              size="small"
+              :disabled="readOnly"
+              class="ms-w-360"
+              placeholder="选择角色"
+              data-testid="approval-node-source-role-picker"
+              @update:model-value="(ids: string[]) => setApprovalSourceIdsFromPicker(node.key, sourceIndex, ids)"
+            >
+              <el-option
+                v-for="role in directoryRoles"
+                :key="role.id"
+                :label="formatRoleLabel(role)"
+                :value="role.id"
+              />
+            </el-select>
+          </el-form-item>
+        </template>
+        <el-form-item
+          v-else-if="approvalSourceKind(node.key, sourceIndex) === 'form_field_user'"
+          label="表单用户字段"
+        >
           <el-select
-            :model-value="requesterChoiceScopeType(node.key)"
+            :model-value="approvalSourceFieldId(node.key, sourceIndex)"
             size="small"
             :disabled="readOnly"
             class="ms-w-240"
-            data-testid="approval-node-requester-choice-scope"
-            @update:model-value="(type: 'company' | 'members' | 'role') => setRequesterChoiceScopeType(node.key, type)"
-          >
-            <el-option label="全公司（任意成员）" value="company" />
-            <el-option label="指定成员" value="members" />
-            <el-option label="指定角色的成员" value="role" />
-          </el-select>
-        </el-form-item>
-        <el-form-item v-if="requesterChoiceScopeType(node.key) === 'members'" label="可选成员">
-          <el-select
-            :model-value="requesterChoiceScopeIds(node.key)"
-            multiple
-            filterable
-            remote
-            :remote-method="onUserSearch"
-            :loading="directoryUsersLoading"
-            size="small"
-            :disabled="readOnly"
-            class="ms-w-360"
-            placeholder="搜索用户名 / 邮箱"
-            data-testid="approval-node-requester-choice-user-picker"
-            @update:model-value="(ids: string[] | string) => setRequesterChoiceScopeIds(node.key, ids)"
-            @visible-change="(visible: boolean) => visible && onUserSearch('')"
+            placeholder="选择表单用户字段"
+            data-testid="approval-node-source-field"
+            @update:model-value="(fieldId: string) => setApprovalSourceFieldId(node.key, sourceIndex, fieldId)"
           >
             <el-option
-              v-for="user in directoryUsers"
-              :key="user.id"
-              :label="formatUserLabel(user)"
-              :value="user.id"
+              v-for="field in userFields"
+              :key="field.id"
+              :label="field.label || '未命名字段'"
+              :value="field.id"
             />
           </el-select>
         </el-form-item>
-        <el-form-item v-else-if="requesterChoiceScopeType(node.key) === 'role'" label="可选角色">
-          <el-select
-            :model-value="requesterChoiceScopeIds(node.key)"
-            multiple
-            filterable
+        <el-form-item
+          v-else-if="approvalSourceKind(node.key, sourceIndex) === 'manager_at_level' || approvalSourceKind(node.key, sourceIndex) === 'continuous_managers' || approvalSourceKind(node.key, sourceIndex) === 'continuous_dept_heads' || approvalSourceKind(node.key, sourceIndex) === 'dept_head_at_level'"
+          :label="approvalSourceKind(node.key, sourceIndex) === 'manager_at_level' ? '指定上级层级' : approvalSourceKind(node.key, sourceIndex) === 'continuous_dept_heads' ? '部门负责人层级数' : approvalSourceKind(node.key, sourceIndex) === 'dept_head_at_level' ? '指定部门负责人层级' : '上级层级数'"
+        >
+          <el-input-number
+            :model-value="approvalSourceLevel(node.key, sourceIndex)"
+            :min="1"
+            :max="10"
+            :step="1"
             size="small"
             :disabled="readOnly"
-            class="ms-w-360"
-            placeholder="选择角色"
-            data-testid="approval-node-requester-choice-role-picker"
-            @update:model-value="(ids: string[] | string) => setRequesterChoiceScopeIds(node.key, ids)"
-          >
-            <el-option
-              v-for="role in directoryRoles"
-              :key="role.id"
-              :label="formatRoleLabel(role)"
-              :value="role.id"
-            />
-          </el-select>
+            data-testid="approval-node-source-level"
+            @update:model-value="(value: number) => setApprovalSourceLevel(node.key, sourceIndex, value ?? 1)"
+          />
         </el-form-item>
-      </template>
-      <!-- G-5 sentinel hint: a starter preset's placeholder role surfaces HERE, in the editor,
-           so the admin replaces it before publish (rather than hitting the publish-time 400). -->
-      <el-alert
-        v-if="approvalSourceIsPlaceholder(node.key)"
-        type="warning"
-        :closable="false"
-        show-icon
-        class="template-authoring__placeholder-hint"
-        data-testid="approval-node-placeholder-hint"
-        title="此为占位审批角色，发布前请替换为真实角色 ID"
-        description="占位角色无人可认领，未替换将无法发布该模板。"
-      />
+        <!-- Lock-1 §K2 (提交人自选) authoring sub-form: mode radio (单选/多选) + scope select
+             (全公司/指定成员/指定角色) with TYPED pickers only (D0 §10.2 — no raw-ID input).
+             The submit-time chooser itself lives in ApprovalNewView; this only authors the
+             mode + scope the server validates the requester's choice against. -->
+        <template v-else-if="approvalSourceKind(node.key, sourceIndex) === 'requester_choice'">
+          <el-form-item label="选择方式">
+            <div
+              class="approval-node-source-roster"
+              role="radiogroup"
+              aria-label="选择方式"
+              data-testid="approval-node-requester-choice-mode"
+            >
+              <label class="approval-node-source-roster-option">
+                <input
+                  type="radio"
+                  :name="`approval-node-requester-choice-mode-${node.key}-${sourceIndex}`"
+                  :checked="requesterChoiceMode(node.key, sourceIndex) === 'single'"
+                  :disabled="readOnly"
+                  data-testid="approval-node-requester-choice-mode-single"
+                  @change="() => setRequesterChoiceMode(node.key, sourceIndex, 'single')"
+                />
+                <span>单选（提交时选一人）</span>
+              </label>
+              <label class="approval-node-source-roster-option">
+                <input
+                  type="radio"
+                  :name="`approval-node-requester-choice-mode-${node.key}-${sourceIndex}`"
+                  :checked="requesterChoiceMode(node.key, sourceIndex) === 'multi'"
+                  :disabled="readOnly"
+                  data-testid="approval-node-requester-choice-mode-multi"
+                  @change="() => setRequesterChoiceMode(node.key, sourceIndex, 'multi')"
+                />
+                <span>多选（提交时可选多人）</span>
+              </label>
+            </div>
+          </el-form-item>
+          <el-form-item label="可选范围">
+            <el-select
+              :model-value="requesterChoiceScopeType(node.key, sourceIndex)"
+              size="small"
+              :disabled="readOnly"
+              class="ms-w-240"
+              data-testid="approval-node-requester-choice-scope"
+              @update:model-value="(type: 'company' | 'members' | 'role') => setRequesterChoiceScopeType(node.key, sourceIndex, type)"
+            >
+              <el-option label="全公司（任意成员）" value="company" />
+              <el-option label="指定成员" value="members" />
+              <el-option label="指定角色的成员" value="role" />
+            </el-select>
+          </el-form-item>
+          <el-form-item v-if="requesterChoiceScopeType(node.key, sourceIndex) === 'members'" label="可选成员">
+            <el-select
+              :model-value="requesterChoiceScopeIds(node.key, sourceIndex)"
+              multiple
+              filterable
+              remote
+              :remote-method="onUserSearch"
+              :loading="directoryUsersLoading"
+              size="small"
+              :disabled="readOnly"
+              class="ms-w-360"
+              placeholder="搜索用户名 / 邮箱"
+              data-testid="approval-node-requester-choice-user-picker"
+              @update:model-value="(ids: string[] | string) => setRequesterChoiceScopeIds(node.key, sourceIndex, ids)"
+              @visible-change="(visible: boolean) => visible && onUserSearch('')"
+            >
+              <el-option
+                v-for="user in directoryUsers"
+                :key="user.id"
+                :label="formatUserLabel(user)"
+                :value="user.id"
+              />
+            </el-select>
+          </el-form-item>
+          <el-form-item v-else-if="requesterChoiceScopeType(node.key, sourceIndex) === 'role'" label="可选角色">
+            <el-select
+              :model-value="requesterChoiceScopeIds(node.key, sourceIndex)"
+              multiple
+              filterable
+              size="small"
+              :disabled="readOnly"
+              class="ms-w-360"
+              placeholder="选择角色"
+              data-testid="approval-node-requester-choice-role-picker"
+              @update:model-value="(ids: string[] | string) => setRequesterChoiceScopeIds(node.key, sourceIndex, ids)"
+            >
+              <el-option
+                v-for="role in directoryRoles"
+                :key="role.id"
+                :label="formatRoleLabel(role)"
+                :value="role.id"
+              />
+            </el-select>
+          </el-form-item>
+        </template>
+        <!-- G-5 sentinel hint: a starter preset's placeholder role surfaces HERE, in the editor,
+             so the admin replaces it before publish (rather than hitting the publish-time 400).
+             P1-B: scoped to THIS card's own source, not the node-wide aggregate — a node with N
+             cards points the hint at the exact offending card. -->
+        <el-alert
+          v-if="approvalSourceIsPlaceholder(node.key, sourceIndex)"
+          type="warning"
+          :closable="false"
+          show-icon
+          class="template-authoring__placeholder-hint"
+          data-testid="approval-node-placeholder-hint"
+          title="此为占位审批角色，发布前请替换为真实角色 ID"
+          description="占位角色无人可认领，未替换将无法发布该模板。"
+        />
+        <!-- P1-B remove affordance: fail-closed — a node must always keep ≥1 source. `disabled` here
+             is the UX signal; the actual guard lives in `removeApprovalSourceCard` itself (refuses
+             at length<=1 regardless of this attribute — M7: this is a real, working control, not
+             theater, and it stays correct even if a caller bypasses the disabled state). -->
+        <div class="approval-node-source-card-actions">
+          <el-button
+            size="small"
+            :disabled="readOnly || approvalSourceCount(node.key) <= 1"
+            data-testid="approval-node-source-remove"
+            @click="removeApprovalSourceCard(node.key, sourceIndex)"
+          >移除此{{ node.type === 'handler' ? '办理人' : '审批人' }}来源</el-button>
+        </div>
+      </div>
+      <!-- P1-B "＋添加审批人": appends one more source card, defaulted from the registry roster (never
+           a hand-picked kind — see defaultNewSourceKind). Sources form a UNION at runtime; the
+           resolver dedups overlapping people across cards (M8 — this editor never dedups, sorts, or
+           reorders; master §P1-B item 4 / M5). -->
+      <div class="approval-node-source-add">
+        <el-button
+          size="small"
+          :disabled="readOnly"
+          data-testid="approval-node-source-add"
+          @click="addApprovalSourceCard(node.key, defaultNewSourceKind())"
+        ><el-icon><Plus /></el-icon>{{ node.type === 'handler' ? '＋添加办理人' : '＋添加审批人' }}</el-button>
+        <p
+          v-if="approvalSourceCount(node.key) > 1"
+          class="template-authoring__hint"
+          data-testid="approval-node-source-union-hint"
+        >已配置 {{ approvalSourceCount(node.key) }} 个来源，取其并集；同一人出现在多个来源时，系统运行时自动去重（此编辑器本身不做去重或排序）</p>
+      </div>
       <!-- Approval-node policy grid: 审批模式 / 空审批人策略 / 自审策略. Handler nodes render NONE of
            these (M7 no inert controls) — a handler has NO empty-assignee/fallback key (§1.2) and no
            self-approval merge; its own controls are the 办理模式 + 办理意见 below. -->
@@ -767,6 +815,7 @@
 import { computed, inject, toRefs, unref, type ComputedRef, type Ref } from 'vue'
 import { Plus } from '@element-plus/icons-vue'
 import type {
+  ApprovalAssigneeSourceKind,
   ApprovalMode,
   ApprovalNode,
   EmptyAssigneePolicy,
@@ -870,6 +919,12 @@ const setApprovalSourceFieldId = api.setApprovalSourceFieldId
 const approvalSourceLevel = api.approvalSourceLevel
 const setApprovalSourceLevel = api.setApprovalSourceLevel
 const approvalSourceIsPlaceholder = api.approvalSourceIsPlaceholder
+// P1-B: multi-source card list — count drives the v-for, add/remove mutate the array. remove is
+// fail-closed in the mutator itself (api.removeApprovalSourceCard refuses at length<=1); the
+// `:disabled` binding below is UX only, never the sole guard.
+const approvalSourceCount = api.approvalSourceCount
+const addApprovalSourceCard = api.addApprovalSourceCard
+const removeApprovalSourceCard = api.removeApprovalSourceCard
 const approvalNodeMode = api.approvalNodeMode
 const setApprovalNodeMode = api.setApprovalNodeMode
 const approvalNodeEmptyPolicy = api.approvalNodeEmptyPolicy
@@ -899,37 +954,48 @@ const routingDriverFieldIds = computed(() => unwrap(api.routingDriverFieldIds ??
 // hand-written roster is kept here anymore — the registry is the only source.
 
 /** L0-2 / A-4: the currently configured source kind may be a persisted value the registry does
- *  not know about (legacy/unratified). Read-only in that case — never mutated, never flattened. */
-const isKnownAssigneeSourceKind = computed(() =>
-  isRegisteredAssigneeSourceKind(registry.value, props.node.type, approvalSourceKind(props.node.key)),
-)
+ *  not know about (legacy/unratified). Read-only in that case — never mutated, never flattened.
+ *  P1-B: per-CARD now — a node with N sources can have an unknown kind on any one of them, and only
+ *  THAT card must warn/read-only, not the whole node. */
+function isKnownAssigneeSourceKind(nodeKey: string, sourceIndex: number): boolean {
+  return isRegisteredAssigneeSourceKind(registry.value, props.node.type, approvalSourceKind(nodeKey, sourceIndex))
+}
+/** Registry-driven default kind for a brand-new card — the FIRST roster entry for this node type
+ *  (never hand-picked: a `handler` node's seven-member roster differs from `approval`'s). */
+function defaultNewSourceKind(): ApprovalAssigneeSourceKind {
+  return assigneeSourceRosterForNode.value[0]?.kind ?? 'requester'
+}
 
 // ── Lock-1 §K2 requester_choice sub-form ────────────────────────────────────────────────────
-// Reads/writes the PRIMARY source of the SHARED approvalNodeEditFor edit model directly (the
+// Reads/writes the CARD AT sourceIndex of the SHARED approvalNodeEditFor edit model directly (the
 // same live model the roster's kind switch mutates), so no new context-api surface is needed
-// and both presentations (canvas inspector tabs / flat structured list) stay one source.
-function requesterChoiceSourceFor(nodeKey: string): RequesterChoiceAssigneeSource | null {
-  const source = approvalNodeEditFor(nodeKey)?.assigneeSources[0]
+// and both presentations (canvas inspector tabs / flat structured list) stay one source. P1-B:
+// parameterized by sourceIndex — a node may carry more than one requester_choice card.
+function requesterChoiceSourceFor(nodeKey: string, sourceIndex: number): RequesterChoiceAssigneeSource | null {
+  const source = approvalNodeEditFor(nodeKey)?.assigneeSources[sourceIndex]
   return source?.kind === 'requester_choice' ? source : null
 }
-function replaceRequesterChoiceSource(nodeKey: string, next: RequesterChoiceAssigneeSource): void {
+function replaceRequesterChoiceSource(nodeKey: string, sourceIndex: number, next: RequesterChoiceAssigneeSource): void {
   const edit = approvalNodeEditFor(nodeKey)
   if (!edit) return
-  edit.assigneeSources = [next, ...edit.assigneeSources.slice(1)]
+  if (sourceIndex < 0 || sourceIndex >= edit.assigneeSources.length) return
+  const nextSources = edit.assigneeSources.slice()
+  nextSources[sourceIndex] = next
+  edit.assigneeSources = nextSources
 }
-function requesterChoiceMode(nodeKey: string): 'single' | 'multi' {
-  return requesterChoiceSourceFor(nodeKey)?.mode ?? 'single'
+function requesterChoiceMode(nodeKey: string, sourceIndex: number): 'single' | 'multi' {
+  return requesterChoiceSourceFor(nodeKey, sourceIndex)?.mode ?? 'single'
 }
-function setRequesterChoiceMode(nodeKey: string, mode: 'single' | 'multi'): void {
-  const source = requesterChoiceSourceFor(nodeKey)
+function setRequesterChoiceMode(nodeKey: string, sourceIndex: number, mode: 'single' | 'multi'): void {
+  const source = requesterChoiceSourceFor(nodeKey, sourceIndex)
   if (!source || source.mode === mode) return
-  replaceRequesterChoiceSource(nodeKey, { ...source, mode })
+  replaceRequesterChoiceSource(nodeKey, sourceIndex, { ...source, mode })
 }
-function requesterChoiceScopeType(nodeKey: string): 'company' | 'members' | 'role' {
-  return requesterChoiceSourceFor(nodeKey)?.scope.type ?? 'company'
+function requesterChoiceScopeType(nodeKey: string, sourceIndex: number): 'company' | 'members' | 'role' {
+  return requesterChoiceSourceFor(nodeKey, sourceIndex)?.scope.type ?? 'company'
 }
-function setRequesterChoiceScopeType(nodeKey: string, type: 'company' | 'members' | 'role'): void {
-  const source = requesterChoiceSourceFor(nodeKey)
+function setRequesterChoiceScopeType(nodeKey: string, sourceIndex: number, type: 'company' | 'members' | 'role'): void {
+  const source = requesterChoiceSourceFor(nodeKey, sourceIndex)
   if (!source || source.scope.type === type) return
   // A scope switch starts with an EMPTY id list deliberately: userIds and roleIds are different
   // id domains, so carrying one list into the other scope would author wrong config.
@@ -937,22 +1003,22 @@ function setRequesterChoiceScopeType(nodeKey: string, type: 'company' | 'members
     type === 'members' ? { type: 'members', userIds: [] }
       : type === 'role' ? { type: 'role', roleIds: [] }
         : { type: 'company' }
-  replaceRequesterChoiceSource(nodeKey, { ...source, scope })
+  replaceRequesterChoiceSource(nodeKey, sourceIndex, { ...source, scope })
 }
-function requesterChoiceScopeIds(nodeKey: string): string[] {
-  const source = requesterChoiceSourceFor(nodeKey)
+function requesterChoiceScopeIds(nodeKey: string, sourceIndex: number): string[] {
+  const source = requesterChoiceSourceFor(nodeKey, sourceIndex)
   if (source?.scope.type === 'members') return source.scope.userIds
   if (source?.scope.type === 'role') return source.scope.roleIds
   return []
 }
-function setRequesterChoiceScopeIds(nodeKey: string, ids: string[] | string): void {
-  const source = requesterChoiceSourceFor(nodeKey)
+function setRequesterChoiceScopeIds(nodeKey: string, sourceIndex: number, ids: string[] | string): void {
+  const source = requesterChoiceSourceFor(nodeKey, sourceIndex)
   if (!source) return
   const list = Array.isArray(ids) ? ids : ids ? [ids] : []
   if (source.scope.type === 'members') {
-    replaceRequesterChoiceSource(nodeKey, { ...source, scope: { type: 'members', userIds: list } })
+    replaceRequesterChoiceSource(nodeKey, sourceIndex, { ...source, scope: { type: 'members', userIds: list } })
   } else if (source.scope.type === 'role') {
-    replaceRequesterChoiceSource(nodeKey, { ...source, scope: { type: 'role', roleIds: list } })
+    replaceRequesterChoiceSource(nodeKey, sourceIndex, { ...source, scope: { type: 'role', roleIds: list } })
   }
 }
 
@@ -967,10 +1033,11 @@ function setRequesterChoiceScopeIds(nodeKey: string, ids: string[] | string): vo
  *  carries the incidental pre-D1 strings ("发起人", "部门主管") that this echo would otherwise
  *  contradict one line below the D1-labelled roster it belongs to. `static_user`/`static_role`/
  *  `form_field_user` also avoid raw ids/field-ids — the same no-raw-id rule the existing read-only
- *  `nodeConfigSummary` already applies to those three kinds (count/label only). */
-const configuredSourceSummaryLine = computed(() => {
-  if (!isKnownAssigneeSourceKind.value) return ''
-  const source = approvalNodeEditFor(props.node.key)?.assigneeSources[0]
+ *  `nodeConfigSummary` already applies to those three kinds (count/label only).
+ *  P1-B: per-card now — each source card echoes its OWN configured summary. */
+function configuredSourceSummaryLine(nodeKey: string, sourceIndex: number): string {
+  if (!isKnownAssigneeSourceKind(nodeKey, sourceIndex)) return ''
+  const source = approvalNodeEditFor(nodeKey)?.assigneeSources[sourceIndex]
   if (!source) return ''
   const label = APPROVAL_ASSIGNEE_SOURCE_LABELS[source.kind]
   if (source.kind === 'static_user') {
@@ -1002,7 +1069,7 @@ const configuredSourceSummaryLine = computed(() => {
     return `已配置：${label}（${mode} · ${scope}）`
   }
   return `已配置：${label}`
-})
+}
 
 const { node } = toRefs(props)
 </script>
@@ -1192,6 +1259,28 @@ const { node } = toRefs(props)
 
 .template-authoring__placeholder-hint {
   margin: 8px 0;
+}
+
+/* P1-B: cards stay flat (no nested box) — a thin top divider separates card N+1 from card N, same
+   "flat, no card-in-card" posture as the roster above. First card gets no divider. */
+.approval-node-source-card + .approval-node-source-card {
+  margin-top: 12px;
+  padding-top: 12px;
+  border-top: 1px dashed var(--el-border-color);
+}
+
+.approval-node-source-card-actions {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 4px;
+}
+
+.approval-node-source-add {
+  margin-top: 8px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
 }
 
 .template-authoring__field-perms {

--- a/apps/web/src/approvals/components/ApprovalGraphNodeConfigEditor.vue
+++ b/apps/web/src/approvals/components/ApprovalGraphNodeConfigEditor.vue
@@ -960,10 +960,20 @@ const routingDriverFieldIds = computed(() => unwrap(api.routingDriverFieldIds ??
 function isKnownAssigneeSourceKind(nodeKey: string, sourceIndex: number): boolean {
   return isRegisteredAssigneeSourceKind(registry.value, props.node.type, approvalSourceKind(nodeKey, sourceIndex))
 }
-/** Registry-driven default kind for a brand-new card — the FIRST roster entry for this node type
- *  (never hand-picked: a `handler` node's seven-member roster differs from `approval`'s). */
+/** Registry-driven default kind for a brand-new card. Prefers `requester` — the SAME default
+ *  `appendApprovalNode` seeds a brand-new node with (`graphTopologyEdit.ts`) — because it is valid
+ *  with ZERO further configuration (`isAssigneeSourceValid` returns true for `{ kind: 'requester' }`
+ *  unconditionally). The roster's raw first entry (`static_user`) is NOT a safe default: its shape
+ *  is `{ kind: 'static_user', userIds: [] }`, which `isAssigneeSourceValid` REJECTS (empty
+ *  `userIds`) — defaulting to it would make "＋添加审批人" immediately disable Save on every click
+ *  until the author manually picks users, on a template that validated fine before the click. Falls
+ *  back to the roster's first entry only if `requester` is somehow absent from this node type's
+ *  roster (never true at the shipped baseline: both `approval` and `handler` include it — defensive
+ *  only, never hand-picked outside the registry per master M4). */
 function defaultNewSourceKind(): ApprovalAssigneeSourceKind {
-  return assigneeSourceRosterForNode.value[0]?.kind ?? 'requester'
+  const roster = assigneeSourceRosterForNode.value
+  if (roster.some((opt) => opt.kind === 'requester')) return 'requester'
+  return roster[0]?.kind ?? 'requester'
 }
 
 // ── Lock-1 §K2 requester_choice sub-form ────────────────────────────────────────────────────

--- a/apps/web/src/approvals/nodeConfigEditorContext.ts
+++ b/apps/web/src/approvals/nodeConfigEditorContext.ts
@@ -56,16 +56,29 @@ export interface ApprovalNodeConfigEditorApi {
   ccTargetTypeLabel: (targetType: ApprovalAssigneeType) => string
   setCcTargetIds: (nodeKey: string, ids: string[]) => void
   syncCcOptions: (nodeKey: string) => void
-  approvalSourceKind: (nodeKey: string) => ApprovalAssigneeSourceKind
-  setApprovalSourceKind: (nodeKey: string, kind: ApprovalAssigneeSourceKind) => void
+  // P1-B: every per-source accessor takes an explicit `sourceIndex` — one card in the multi-source
+  // roster (`edit.assigneeSources[sourceIndex]`). Required (not defaulted to 0) so a missed callsite
+  // is a compile error under `src/**` typecheck, not a silent write to card 0. Master §P1-B / M5:
+  // array order is display order; the runtime resolver owns dedup — the FE never reorders or merges.
+  approvalSourceKind: (nodeKey: string, sourceIndex: number) => ApprovalAssigneeSourceKind
+  setApprovalSourceKind: (nodeKey: string, sourceIndex: number, kind: ApprovalAssigneeSourceKind) => void
   syncApprovalNodeOptions: (nodeKey: string) => void
-  approvalSourceIds: (nodeKey: string) => string[]
-  setApprovalSourceIdsFromPicker: (nodeKey: string, ids: string[]) => void
-  approvalSourceFieldId: (nodeKey: string) => string
-  setApprovalSourceFieldId: (nodeKey: string, fieldId: string) => void
-  approvalSourceLevel: (nodeKey: string) => number
-  setApprovalSourceLevel: (nodeKey: string, value: number) => void
-  approvalSourceIsPlaceholder: (nodeKey: string) => boolean
+  approvalSourceIds: (nodeKey: string, sourceIndex: number) => string[]
+  setApprovalSourceIdsFromPicker: (nodeKey: string, sourceIndex: number, ids: string[]) => void
+  approvalSourceFieldId: (nodeKey: string, sourceIndex: number) => string
+  setApprovalSourceFieldId: (nodeKey: string, sourceIndex: number, fieldId: string) => void
+  approvalSourceLevel: (nodeKey: string, sourceIndex: number) => number
+  setApprovalSourceLevel: (nodeKey: string, sourceIndex: number, value: number) => void
+  approvalSourceIsPlaceholder: (nodeKey: string, sourceIndex: number) => boolean
+  /** Card count for a node — drives the v-for and the "keep ≥1" remove-guard's disabled state. */
+  approvalSourceCount: (nodeKey: string) => number
+  /** Appends one new card, defaulted from the registry roster's first kind for this node type
+   *  (never a hand-picked kind — a `handler` node's roster differs from an `approval` node's). */
+  addApprovalSourceCard: (nodeKey: string, defaultKind: ApprovalAssigneeSourceKind) => void
+  /** Fail-closed: refuses (no-op) when the node has exactly one source — a node must always keep
+   *  ≥1 assignee source (master §P1-B). This guard lives in the mutator itself, not only in a
+   *  disabled button, so it holds even if a caller bypasses the disabled affordance. */
+  removeApprovalSourceCard: (nodeKey: string, sourceIndex: number) => void
   approvalNodeMode: (nodeKey: string) => ApprovalMode
   setApprovalNodeMode: (nodeKey: string, mode: ApprovalMode) => void
   approvalNodeEmptyPolicy: (nodeKey: string) => EmptyAssigneePolicy

--- a/apps/web/src/approvals/templateAuthoring.ts
+++ b/apps/web/src/approvals/templateAuthoring.ts
@@ -68,7 +68,7 @@ export { PARALLEL_JOIN_MODES, parallelDynamicAssigneeConflicts } from './paralle
 export type { CcEdits, CcNodeEdit } from './ccEdit'
 export { CC_TARGET_TYPES } from './ccEdit'
 export type { ApprovalNodeEdits, ApprovalNodeSourceEdit } from './approvalNodeEdit'
-export { placeholderRoleNodeKeys } from './approvalNodeEdit'
+export { placeholderRoleNodeKeys, addAssigneeSourceCard, removeAssigneeSourceCard } from './approvalNodeEdit'
 
 export type AuthorableFieldType = Exclude<FormFieldType, 'attachment'>
 export type ApprovalStepSourceKind = ApprovalAssigneeSource['kind']

--- a/apps/web/src/approvals/templateAuthoring.ts
+++ b/apps/web/src/approvals/templateAuthoring.ts
@@ -68,7 +68,7 @@ export { PARALLEL_JOIN_MODES, parallelDynamicAssigneeConflicts } from './paralle
 export type { CcEdits, CcNodeEdit } from './ccEdit'
 export { CC_TARGET_TYPES } from './ccEdit'
 export type { ApprovalNodeEdits, ApprovalNodeSourceEdit } from './approvalNodeEdit'
-export { placeholderRoleNodeKeys, addAssigneeSourceCard, removeAssigneeSourceCard } from './approvalNodeEdit'
+export { placeholderRoleNodeKeys, isPlaceholderRoleSource, addAssigneeSourceCard, removeAssigneeSourceCard } from './approvalNodeEdit'
 
 export type AuthorableFieldType = Exclude<FormFieldType, 'attachment'>
 export type ApprovalStepSourceKind = ApprovalAssigneeSource['kind']

--- a/apps/web/src/views/approval/TemplateAuthoringView.vue
+++ b/apps/web/src/views/approval/TemplateAuthoringView.vue
@@ -1154,6 +1154,7 @@ import {
   validateTemplateBasicInfo,
   type AuthoringValidationIssue,
   placeholderRoleNodeKeys,
+  isPlaceholderRoleSource,
   addAssigneeSourceCard,
   removeAssigneeSourceCard,
   approvalFormulaInsertOptions,
@@ -1242,9 +1243,6 @@ import type {
   ParallelJoinMode,
   ParallelNodeConfig,
 } from '../../types/approval'
-// P1-B: value import (not type-only) — approvalSourceIsPlaceholder now checks the card AT its own
-// sourceIndex directly instead of delegating to the aggregate publishPlaceholderRoleKeys list.
-import { APPROVAL_ROLE_CONFIGURE_SENTINEL } from '../../types/approval'
 import { useApprovalDirectory } from '../../approvals/useApprovalDirectory'
 import { assigneeSourceSummary } from '../../approvals/assigneeSource'
 import {
@@ -1974,9 +1972,11 @@ function approvalSourceIds(nodeKey: string, sourceIndex: number): string[] {
 // in the editor so the admin replaces it first. Non-blocking — the draft still saves. Computed
 // directly off the card at sourceIndex (not the aggregate `publishPlaceholderRoleKeys` list) so a
 // node with N cards points the hint at the EXACT offending card rather than lighting up all of them.
+// Delegates to the SAME `isPlaceholderRoleSource` predicate `placeholderRoleNodeKeys` uses, so the
+// per-card hint and the aggregate publish checklist item can never disagree on what counts.
 function approvalSourceIsPlaceholder(nodeKey: string, sourceIndex: number): boolean {
   const source = approvalNodeSourceAt(nodeKey, sourceIndex)
-  return source?.kind === 'static_role' && source.roleIds.includes(APPROVAL_ROLE_CONFIGURE_SENTINEL)
+  return Boolean(source && isPlaceholderRoleSource(source))
 }
 // P1-B: card count for the v-for + the "keep ≥1" remove-guard's disabled state.
 function approvalSourceCount(nodeKey: string): number {
@@ -1985,18 +1985,25 @@ function approvalSourceCount(nodeKey: string): number {
 // P1-B "＋添加审批人": appends one new card with the given default kind (the caller — the config
 // editor — reads it from the registry roster, never hand-picks one, so a `handler` node's add
 // button never seeds a kind outside its seven-member roster). Delegates to the pure, independently
-// unit-tested `addAssigneeSourceCard` (approvalNodeEdit.ts) — this wrapper only supplies the live
-// draft + clears the session kind-switch cache (a view-local UX convenience, never persisted).
+// unit-tested `addAssigneeSourceCard` (approvalNodeEdit.ts). Deliberately does NOT clear the P1-1
+// kind-switch cache: an append never shifts any EXISTING card's index (it only grows the array at
+// the end), so a card the author already configured-then-switched-away-from keeps its cached
+// payload intact across an unrelated add — clearing here would silently re-open the exact P1-1
+// config-loss bug in a new sequence (configure → switch away → add a card → switch back → cache
+// gone → empty payload, no undo).
 function addApprovalSourceCard(nodeKey: string, defaultKind: ApprovalAssigneeSourceKind): void {
   const edits = draft.value.approvalNodeEdits
   if (!edits) return
-  clearApprovalSourceKindCacheForNode(nodeKey)
   addAssigneeSourceCard(edits, nodeKey, defaultApprovalSourceForKind(defaultKind))
 }
 // P1-B fail-closed remove: a node must always keep ≥1 assignee source. Delegates to the pure,
 // independently unit-tested `removeAssigneeSourceCard` (approvalNodeEdit.ts), which refuses at
 // length<=1 REGARDLESS of the remove button's `disabled` attribute — see that function's doc
-// comment for why disabled-button DOM testing alone cannot prove this guard.
+// comment for why disabled-button DOM testing alone cannot prove this guard. Clears the P1-1
+// kind-switch cache for this node HERE (unlike add): removing a card SHIFTS every subsequent card's
+// index, so a stale per-index cache entry would otherwise attribute one card's cached payload to a
+// now-different card at the same index — clearing avoids that misattribution. It is a session-only
+// UX convenience (never persisted), so losing it on remove is a strictly safe/conservative choice.
 function removeApprovalSourceCard(nodeKey: string, sourceIndex: number): void {
   const edits = draft.value.approvalNodeEdits
   if (!edits) return

--- a/apps/web/src/views/approval/TemplateAuthoringView.vue
+++ b/apps/web/src/views/approval/TemplateAuthoringView.vue
@@ -1154,6 +1154,8 @@ import {
   validateTemplateBasicInfo,
   type AuthoringValidationIssue,
   placeholderRoleNodeKeys,
+  addAssigneeSourceCard,
+  removeAssigneeSourceCard,
   approvalFormulaInsertOptions,
   parallelDynamicAssigneeConflicts,
   CONDITION_RULE_OPERATORS,
@@ -1240,6 +1242,9 @@ import type {
   ParallelJoinMode,
   ParallelNodeConfig,
 } from '../../types/approval'
+// P1-B: value import (not type-only) — approvalSourceIsPlaceholder now checks the card AT its own
+// sourceIndex directly instead of delegating to the aggregate publishPlaceholderRoleKeys list.
+import { APPROVAL_ROLE_CONFIGURE_SENTINEL } from '../../types/approval'
 import { useApprovalDirectory } from '../../approvals/useApprovalDirectory'
 import { assigneeSourceSummary } from '../../approvals/assigneeSource'
 import {
@@ -1828,8 +1833,10 @@ function ccTargetTypeLabel(targetType: ApprovalAssigneeType): string {
 function approvalNodeEditFor(nodeKey: string): ApprovalNodeSourceEdit | undefined {
   return draft.value.approvalNodeEdits?.[nodeKey]
 }
-function approvalNodeFirstSource(nodeKey: string): ApprovalAssigneeSource | undefined {
-  return approvalNodeEditFor(nodeKey)?.assigneeSources[0]
+// P1-B: replaces the old assigneeSources[0]-only accessor — every card is addressed by its own
+// sourceIndex now (see nodeConfigEditorContext.ts's doc comment on the required-index posture).
+function approvalNodeSourceAt(nodeKey: string, sourceIndex: number): ApprovalAssigneeSource | undefined {
+  return approvalNodeEditFor(nodeKey)?.assigneeSources[sourceIndex]
 }
 function approvalNodeMode(nodeKey: string): ApprovalMode {
   return approvalNodeEditFor(nodeKey)?.approvalMode ?? 'single'
@@ -1885,29 +1892,47 @@ function setApprovalNodeFieldAccess(nodeKey: string, fieldId: string, access: No
   if (access !== 'editable') next.push({ fieldId, access })
   edit.fieldPermissions = next
 }
-// Replace ONLY the primary (first) source; preserve any extra sources verbatim (no flatten).
-function setApprovalNodeSource(nodeKey: string, source: ApprovalAssigneeSource): void {
+// P1-B: replace ONLY the card AT sourceIndex; every other card (and every other node field) is
+// preserved verbatim (no flatten). Out-of-range indexes are refused as a no-op.
+function setApprovalNodeSourceAt(nodeKey: string, sourceIndex: number, source: ApprovalAssigneeSource): void {
   const edit = approvalNodeEditFor(nodeKey)
   if (!edit) return
-  edit.assigneeSources = [source, ...edit.assigneeSources.slice(1)]
+  if (sourceIndex < 0 || sourceIndex >= edit.assigneeSources.length) return
+  const next = edit.assigneeSources.slice()
+  next[sourceIndex] = source
+  edit.assigneeSources = next
 }
-function approvalSourceKind(nodeKey: string): ApprovalAssigneeSourceKind {
-  return approvalNodeFirstSource(nodeKey)?.kind ?? 'requester'
+function approvalSourceKind(nodeKey: string, sourceIndex: number): ApprovalAssigneeSourceKind {
+  return approvalNodeSourceAt(nodeKey, sourceIndex)?.kind ?? 'requester'
 }
 // Gate P1-1 fix: the roster is a native `role="radiogroup"` (APG requires arrows to move AND
 // select, so commit-on-arrow stays — see the L0-2 radio grid), which means an accidental
-// ArrowUp/ArrowDown traversal calls this on every focus step. Naively replacing
-// `assigneeSources[0]` with a fresh, empty-payload object per kind (the pre-fix behaviour) is
-// therefore destructive: one arrow out and one arrow back silently discarded a configured
-// `userIds`/`roleIds`/`fieldId`/`levels`/`level` with no undo (canvas history never records a
-// per-keystroke config edit — A-8) and no save path (the stripped payload fails node validation).
-// Fix: cache the outgoing payload per (nodeKey, kind) for this editing session BEFORE switching,
-// and restore it verbatim if the author switches back to a previously-configured kind. Cleared by
-// `resetApprovalSourceKindCache()` whenever the draft is reseeded from a fresh template/graph (see
-// `reseedCanvasHistoryFromDraft`) — the cache is a session convenience, never persisted.
+// ArrowUp/ArrowDown traversal calls this on every focus step. Naively replacing a card with a
+// fresh, empty-payload object per kind (the pre-fix behaviour) is therefore destructive: one arrow
+// out and one arrow back silently discarded a configured `userIds`/`roleIds`/`fieldId`/`levels`/
+// `level` with no undo (canvas history never records a per-keystroke config edit — A-8) and no
+// save path (the stripped payload fails node validation).
+// Fix: cache the outgoing payload per (nodeKey, sourceIndex, kind) for this editing session BEFORE
+// switching, and restore it verbatim if the author switches back to a previously-configured kind on
+// THAT card. P1-B: keyed by card, not just node — two cards on one node cache independently, and
+// `resetApprovalSourceKindCache()` (draft reseed) still clears the whole session cache. Any
+// structural change to a node's source list (add/remove a card) also drops that node's cache slice
+// — see `addApprovalSourceCard`/`removeApprovalSourceCard` — because indexes shift and a stale
+// per-index cache entry would otherwise attribute one card's cached payload to a different card.
 const approvalSourceKindCache = ref<Record<string, Partial<Record<ApprovalAssigneeSourceKind, ApprovalAssigneeSource>>>>({})
 function resetApprovalSourceKindCache(): void {
   approvalSourceKindCache.value = {}
+}
+function approvalSourceKindCacheKey(nodeKey: string, sourceIndex: number): string {
+  return `${nodeKey}:${sourceIndex}`
+}
+function clearApprovalSourceKindCacheForNode(nodeKey: string): void {
+  const prefix = `${nodeKey}:`
+  const next: typeof approvalSourceKindCache.value = {}
+  for (const [key, value] of Object.entries(approvalSourceKindCache.value)) {
+    if (!key.startsWith(prefix)) next[key] = value
+  }
+  approvalSourceKindCache.value = next
 }
 function cloneAssigneeSource(source: ApprovalAssigneeSource): ApprovalAssigneeSource {
   return JSON.parse(JSON.stringify(source)) as ApprovalAssigneeSource
@@ -1926,30 +1951,57 @@ function defaultApprovalSourceForKind(kind: ApprovalAssigneeSourceKind): Approva
                 : kind === 'dept_head_at_level' ? { kind, level: 1 }
                   : { kind: kind as 'requester' | 'direct_manager' | 'dept_head' }
 }
-function setApprovalSourceKind(nodeKey: string, kind: ApprovalAssigneeSourceKind): void {
-  const current = approvalNodeFirstSource(nodeKey)
+function setApprovalSourceKind(nodeKey: string, sourceIndex: number, kind: ApprovalAssigneeSourceKind): void {
+  const cacheKey = approvalSourceKindCacheKey(nodeKey, sourceIndex)
+  const current = approvalNodeSourceAt(nodeKey, sourceIndex)
   if (current && current.kind !== kind) {
-    const cacheForNode = approvalSourceKindCache.value[nodeKey] ?? {}
-    cacheForNode[current.kind] = cloneAssigneeSource(current)
-    approvalSourceKindCache.value = { ...approvalSourceKindCache.value, [nodeKey]: cacheForNode }
+    const cacheForCard = approvalSourceKindCache.value[cacheKey] ?? {}
+    cacheForCard[current.kind] = cloneAssigneeSource(current)
+    approvalSourceKindCache.value = { ...approvalSourceKindCache.value, [cacheKey]: cacheForCard }
   }
-  const cached = approvalSourceKindCache.value[nodeKey]?.[kind]
+  const cached = approvalSourceKindCache.value[cacheKey]?.[kind]
   const next: ApprovalAssigneeSource = cached ? cloneAssigneeSource(cached) : defaultApprovalSourceForKind(kind)
-  setApprovalNodeSource(nodeKey, next)
+  setApprovalNodeSourceAt(nodeKey, sourceIndex, next)
 }
-function approvalSourceIds(nodeKey: string): string[] {
-  const source = approvalNodeFirstSource(nodeKey)
+function approvalSourceIds(nodeKey: string, sourceIndex: number): string[] {
+  const source = approvalNodeSourceAt(nodeKey, sourceIndex)
   if (source?.kind === 'static_user') return source.userIds
   if (source?.kind === 'static_role') return source.roleIds
   return []
 }
-// G-5 sentinel hint: true when the source is a static_role still carrying the starter-preset
+// G-5 sentinel hint: true when THIS card is a static_role still carrying the starter-preset
 // placeholder (APPROVAL_ROLE_CONFIGURE_SENTINEL). The backend blocks publish on it; this surfaces it
-// in the editor so the admin replaces it first. Non-blocking — the draft still saves. Delegates to
-// the shared `placeholderRoleNodeKeys` (B2-03) so the per-node hint and the aggregate publish
-// checklist item share one predicate.
-function approvalSourceIsPlaceholder(nodeKey: string): boolean {
-  return publishPlaceholderRoleKeys.value.includes(nodeKey)
+// in the editor so the admin replaces it first. Non-blocking — the draft still saves. Computed
+// directly off the card at sourceIndex (not the aggregate `publishPlaceholderRoleKeys` list) so a
+// node with N cards points the hint at the EXACT offending card rather than lighting up all of them.
+function approvalSourceIsPlaceholder(nodeKey: string, sourceIndex: number): boolean {
+  const source = approvalNodeSourceAt(nodeKey, sourceIndex)
+  return source?.kind === 'static_role' && source.roleIds.includes(APPROVAL_ROLE_CONFIGURE_SENTINEL)
+}
+// P1-B: card count for the v-for + the "keep ≥1" remove-guard's disabled state.
+function approvalSourceCount(nodeKey: string): number {
+  return approvalNodeEditFor(nodeKey)?.assigneeSources.length ?? 0
+}
+// P1-B "＋添加审批人": appends one new card with the given default kind (the caller — the config
+// editor — reads it from the registry roster, never hand-picks one, so a `handler` node's add
+// button never seeds a kind outside its seven-member roster). Delegates to the pure, independently
+// unit-tested `addAssigneeSourceCard` (approvalNodeEdit.ts) — this wrapper only supplies the live
+// draft + clears the session kind-switch cache (a view-local UX convenience, never persisted).
+function addApprovalSourceCard(nodeKey: string, defaultKind: ApprovalAssigneeSourceKind): void {
+  const edits = draft.value.approvalNodeEdits
+  if (!edits) return
+  clearApprovalSourceKindCacheForNode(nodeKey)
+  addAssigneeSourceCard(edits, nodeKey, defaultApprovalSourceForKind(defaultKind))
+}
+// P1-B fail-closed remove: a node must always keep ≥1 assignee source. Delegates to the pure,
+// independently unit-tested `removeAssigneeSourceCard` (approvalNodeEdit.ts), which refuses at
+// length<=1 REGARDLESS of the remove button's `disabled` attribute — see that function's doc
+// comment for why disabled-button DOM testing alone cannot prove this guard.
+function removeApprovalSourceCard(nodeKey: string, sourceIndex: number): void {
+  const edits = draft.value.approvalNodeEdits
+  if (!edits) return
+  clearApprovalSourceKindCacheForNode(nodeKey)
+  removeAssigneeSourceCard(edits, nodeKey, sourceIndex)
 }
 
 // ── Topology authoring (graphTopologyEdit + authoring session history) ──
@@ -2507,10 +2559,10 @@ function onCanvasNodeDrop(event: DragEvent, edgeKey: string): void {
   event.stopPropagation()
   applyCanvasNodeMove(edgeKey)
 }
-function setApprovalSourceIds(nodeKey: string, ids: string[]): void {
-  const kind = approvalSourceKind(nodeKey)
-  if (kind === 'static_user') setApprovalNodeSource(nodeKey, { kind, userIds: ids })
-  else if (kind === 'static_role') setApprovalNodeSource(nodeKey, { kind, roleIds: ids })
+function setApprovalSourceIds(nodeKey: string, sourceIndex: number, ids: string[]): void {
+  const kind = approvalSourceKind(nodeKey, sourceIndex)
+  if (kind === 'static_user') setApprovalNodeSourceAt(nodeKey, sourceIndex, { kind, userIds: ids })
+  else if (kind === 'static_role') setApprovalNodeSourceAt(nodeKey, sourceIndex, { kind, roleIds: ids })
 }
 // G-B2-18 manual-ID advanced fallback for the complex-node picker. Unlike the linear step (whose
 // idsText is a real persisted draft field — the SOLE carrier, only parsed into ids at save time),
@@ -2521,18 +2573,18 @@ function setApprovalSourceIds(nodeKey: string, ids: string[]): void {
 // buffer is the raw carrier instead (never part of node.config / the saved graph): read back
 // verbatim once the author has touched the field, falling back to the derived join before that
 // (hydrate / a node nobody has edited yet).
-function setApprovalSourceIdsFromPicker(nodeKey: string, ids: string[]): void {
-  setApprovalSourceIds(nodeKey, ids)
+function setApprovalSourceIdsFromPicker(nodeKey: string, sourceIndex: number, ids: string[]): void {
+  setApprovalSourceIds(nodeKey, sourceIndex, ids)
 }
-function approvalSourceFieldId(nodeKey: string): string {
-  const source = approvalNodeFirstSource(nodeKey)
+function approvalSourceFieldId(nodeKey: string, sourceIndex: number): string {
+  const source = approvalNodeSourceAt(nodeKey, sourceIndex)
   return source?.kind === 'form_field_user' ? source.fieldId : ''
 }
-function setApprovalSourceFieldId(nodeKey: string, fieldId: string): void {
-  setApprovalNodeSource(nodeKey, { kind: 'form_field_user', fieldId })
+function setApprovalSourceFieldId(nodeKey: string, sourceIndex: number, fieldId: string): void {
+  setApprovalNodeSourceAt(nodeKey, sourceIndex, { kind: 'form_field_user', fieldId })
 }
-function approvalSourceLevel(nodeKey: string): number {
-  const source = approvalNodeFirstSource(nodeKey)
+function approvalSourceLevel(nodeKey: string, sourceIndex: number): number {
+  const source = approvalNodeSourceAt(nodeKey, sourceIndex)
   if (source?.kind === 'manager_at_level') return source.level
   if (source?.kind === 'continuous_managers') return source.levels
   // Lock-1 §K4: same shared-field shape as continuous_managers.
@@ -2541,12 +2593,12 @@ function approvalSourceLevel(nodeKey: string): number {
   if (source?.kind === 'dept_head_at_level') return source.level
   return 1
 }
-function setApprovalSourceLevel(nodeKey: string, value: number): void {
-  const kind = approvalSourceKind(nodeKey)
-  if (kind === 'manager_at_level') setApprovalNodeSource(nodeKey, { kind, level: value })
-  else if (kind === 'continuous_managers') setApprovalNodeSource(nodeKey, { kind, levels: value })
-  else if (kind === 'continuous_dept_heads') setApprovalNodeSource(nodeKey, { kind, levels: value })
-  else if (kind === 'dept_head_at_level') setApprovalNodeSource(nodeKey, { kind, level: value })
+function setApprovalSourceLevel(nodeKey: string, sourceIndex: number, value: number): void {
+  const kind = approvalSourceKind(nodeKey, sourceIndex)
+  if (kind === 'manager_at_level') setApprovalNodeSourceAt(nodeKey, sourceIndex, { kind, level: value })
+  else if (kind === 'continuous_managers') setApprovalNodeSourceAt(nodeKey, sourceIndex, { kind, levels: value })
+  else if (kind === 'continuous_dept_heads') setApprovalNodeSourceAt(nodeKey, sourceIndex, { kind, levels: value })
+  else if (kind === 'dept_head_at_level') setApprovalNodeSourceAt(nodeKey, sourceIndex, { kind, level: value })
 }
 
 const userFields = computed(() => draft.value.fields.filter((field) => field.type === 'user' && field.id.trim()))
@@ -2611,10 +2663,8 @@ async function onUserSearch(query: string): Promise<void> {
     if (step.sourceKind !== 'static_user') continue
     for (const id of parseIdsText(step.idsText)) directory.ensureUserOptionVisible(id)
   }
-  for (const nodeKey of Object.keys(draft.value.approvalNodeEdits ?? {})) {
-    if (approvalSourceKind(nodeKey) !== 'static_user') continue
-    for (const id of approvalSourceIds(nodeKey)) directory.ensureUserOptionVisible(id)
-  }
+  // P1-B: a node may carry N cards now — sync EVERY card's chips, not just card 0.
+  for (const nodeKey of Object.keys(draft.value.approvalNodeEdits ?? {})) syncApprovalNodeOptions(nodeKey)
   for (const nodeKey of Object.keys(draft.value.ccEdits ?? {})) {
     const edit = ccEditFor(nodeKey)
     if (!edit || edit.targetType !== 'user') continue
@@ -2644,24 +2694,26 @@ function syncAllStepOptions(): void {
 }
 
 // G-B2-18: same hydrate-time visibility sync as syncStepOptions, applied to complex-graph
-// approval-node assignee sources (approvalNodeEdits is keyed by nodeKey).
+// approval-node assignee sources (approvalNodeEdits is keyed by nodeKey). P1-B: loops EVERY card on
+// the node — a node with N sources needs N cards' worth of chips kept visible, not just card 0.
 function syncApprovalNodeOptions(nodeKey: string): void {
-  const kind = approvalSourceKind(nodeKey)
-  if (kind === 'static_user') {
-    for (const id of approvalSourceIds(nodeKey)) directory.ensureUserOptionVisible(id)
-  } else if (kind === 'static_role') {
-    for (const id of approvalSourceIds(nodeKey)) directory.ensureRoleOptionVisible(id)
-  } else if (kind === 'requester_choice') {
-    // §K2: keep the configured scope list's chips visible in the sub-form pickers.
-    const source = approvalNodeEditFor(nodeKey)?.assigneeSources[0]
-    if (source?.kind === 'requester_choice') {
+  const edit = approvalNodeEditFor(nodeKey)
+  if (!edit) return
+  edit.assigneeSources.forEach((source, sourceIndex) => {
+    const kind = source.kind
+    if (kind === 'static_user') {
+      for (const id of approvalSourceIds(nodeKey, sourceIndex)) directory.ensureUserOptionVisible(id)
+    } else if (kind === 'static_role') {
+      for (const id of approvalSourceIds(nodeKey, sourceIndex)) directory.ensureRoleOptionVisible(id)
+    } else if (kind === 'requester_choice') {
+      // §K2: keep the configured scope list's chips visible in the sub-form pickers.
       if (source.scope.type === 'members') {
         for (const id of source.scope.userIds) directory.ensureUserOptionVisible(id)
       } else if (source.scope.type === 'role') {
         for (const id of source.scope.roleIds) directory.ensureRoleOptionVisible(id)
       }
     }
-  }
+  })
 }
 
 function syncAllApprovalNodeOptions(): void {
@@ -2731,6 +2783,9 @@ const nodeConfigEditorApi: ApprovalNodeConfigEditorApi = {
   approvalSourceLevel,
   setApprovalSourceLevel,
   approvalSourceIsPlaceholder,
+  approvalSourceCount,
+  addApprovalSourceCard,
+  removeApprovalSourceCard,
   approvalNodeMode,
   setApprovalNodeMode,
   approvalNodeEmptyPolicy,

--- a/apps/web/tests/approval-handler-node-config.spec.ts
+++ b/apps/web/tests/approval-handler-node-config.spec.ts
@@ -101,20 +101,31 @@ function createStubConfigApi(seed: Record<string, Partial<Edit>>): ApprovalNodeC
     ccTargetTypeLabel: () => '用户',
     setCcTargetIds: () => {},
     syncCcOptions: () => {},
-    approvalSourceKind: (k: string) => (edits[k]?.assigneeSources[0]?.kind as any) ?? 'requester',
-    setApprovalSourceKind: (k: string, kind: any) => {
-      const e = edits[k]; if (!e) return
+    // P1-B: every per-source accessor now takes an explicit sourceIndex (one card in the array).
+    approvalSourceKind: (k: string, i: number) => (edits[k]?.assigneeSources[i]?.kind as any) ?? 'requester',
+    setApprovalSourceKind: (k: string, i: number, kind: any) => {
+      const e = edits[k]; if (!e || i < 0 || i >= e.assigneeSources.length) return
       const next: Record<string, unknown> = kind === 'static_user' ? { kind, userIds: [] } : kind === 'static_role' ? { kind, roleIds: [] } : kind === 'form_field_user' ? { kind, fieldId: '' } : kind === 'manager_at_level' ? { kind, level: 1 } : { kind }
-      e.assigneeSources = [next, ...e.assigneeSources.slice(1)]
+      const nextSources = e.assigneeSources.slice(); nextSources[i] = next; e.assigneeSources = nextSources
     },
     syncApprovalNodeOptions: () => {},
-    approvalSourceIds: (k: string) => { const s = edits[k]?.assigneeSources[0]; return (s?.userIds as string[]) ?? (s?.roleIds as string[]) ?? [] },
+    approvalSourceIds: (k: string, i: number) => { const s = edits[k]?.assigneeSources[i]; return (s?.userIds as string[]) ?? (s?.roleIds as string[]) ?? [] },
     setApprovalSourceIdsFromPicker: () => {},
-    approvalSourceFieldId: (k: string) => (edits[k]?.assigneeSources[0]?.fieldId as string) ?? '',
+    approvalSourceFieldId: (k: string, i: number) => (edits[k]?.assigneeSources[i]?.fieldId as string) ?? '',
     setApprovalSourceFieldId: () => {},
-    approvalSourceLevel: (k: string) => (edits[k]?.assigneeSources[0]?.level as number) ?? 1,
+    approvalSourceLevel: (k: string, i: number) => (edits[k]?.assigneeSources[i]?.level as number) ?? 1,
     setApprovalSourceLevel: () => {},
     approvalSourceIsPlaceholder: () => false,
+    approvalSourceCount: (k: string) => edits[k]?.assigneeSources.length ?? 0,
+    addApprovalSourceCard: (k: string, defaultKind: any) => {
+      const e = edits[k]; if (!e) return
+      const next: Record<string, unknown> = defaultKind === 'static_user' ? { kind: defaultKind, userIds: [] } : defaultKind === 'static_role' ? { kind: defaultKind, roleIds: [] } : defaultKind === 'form_field_user' ? { kind: defaultKind, fieldId: '' } : defaultKind === 'manager_at_level' ? { kind: defaultKind, level: 1 } : { kind: defaultKind }
+      e.assigneeSources = [...e.assigneeSources, next]
+    },
+    removeApprovalSourceCard: (k: string, i: number) => {
+      const e = edits[k]; if (!e || e.assigneeSources.length <= 1) return
+      e.assigneeSources = e.assigneeSources.filter((_: unknown, idx: number) => idx !== i)
+    },
     approvalNodeMode: () => 'single',
     setApprovalNodeMode: () => {},
     approvalNodeEmptyPolicy: () => 'error',
@@ -232,5 +243,26 @@ describe('Lock-3 handler config surface + inspector tabs', () => {
     select.value = 'any'
     select.dispatchEvent(new Event('change'))
     expect(api.handlerNodeMode('handler_h')).toBe('any')
+  })
+
+  // P1-B — master §P1-B: multi-source assignee cards. A handler node's roster is the RATIFIED
+  // seven-member subset (Lock-3 §1.5, G-13) — "＋添加办理人" must default the new card from THAT
+  // roster, never a hand-picked kind or an approval-only kind (continuous_managers /
+  // requester_choice / continuous_dept_heads / dept_head_at_level are all absent from it).
+  it('P1-B: "＋添加办理人" defaults the new card from the SEVEN-member handler roster (never an approval-only kind)', () => {
+    const api = createStubConfigApi({ handler_h: { nodeType: 'handler', assigneeSources: [{ kind: 'requester' }] } })
+    const c = mountEditorFlat(handlerNode(), DEFAULT_APPROVAL_CAPABILITY_REGISTRY, api)
+
+    const addBtn = c.querySelector('[data-testid="approval-node-source-add"]') as HTMLButtonElement
+    expect(addBtn).not.toBeNull()
+    expect(addBtn.textContent).toContain('办理人') // handler-specific copy, not "审批人"
+    addBtn.click()
+
+    const sources = api.approvalNodeEditFor('handler_h')?.assigneeSources as Array<{ kind: string }>
+    expect(sources).toHaveLength(2)
+    expect(sources[0]).toEqual({ kind: 'requester' }) // untouched
+    const newKind = sources[1].kind
+    expect([...HANDLER_ASSIGNEE_SOURCE_KINDS]).toContain(newKind) // in-roster
+    expect(['continuous_managers', 'requester_choice', 'continuous_dept_heads', 'dept_head_at_level']).not.toContain(newKind)
   })
 })

--- a/apps/web/tests/approval-handler-node-config.spec.ts
+++ b/apps/web/tests/approval-handler-node-config.spec.ts
@@ -262,6 +262,9 @@ describe('Lock-3 handler config surface + inspector tabs', () => {
     expect(sources).toHaveLength(2)
     expect(sources[0]).toEqual({ kind: 'requester' }) // untouched
     const newKind = sources[1].kind
+    // `requester` specifically (valid with zero config) — NOT the roster's raw first entry
+    // (`static_user`, whose zero-config shape fails validation and would disable Save).
+    expect(newKind).toBe('requester')
     expect([...HANDLER_ASSIGNEE_SOURCE_KINDS]).toContain(newKind) // in-roster
     expect(['continuous_managers', 'requester_choice', 'continuous_dept_heads', 'dept_head_at_level']).not.toContain(newKind)
   })

--- a/apps/web/tests/approval-template-authoring-approval-node-edit.test.ts
+++ b/apps/web/tests/approval-template-authoring-approval-node-edit.test.ts
@@ -8,9 +8,13 @@ import {
   type TemplateAuthoringDraft,
 } from '../src/approvals/templateAuthoring'
 import {
+  addAssigneeSourceCard,
   applyApprovalNodeEditsToGraph,
   approvalNodeEditsFromGraph,
+  placeholderRoleNodeKeys,
+  removeAssigneeSourceCard,
   validateApprovalNodeEdits,
+  type ApprovalNodeEdits,
 } from '../src/approvals/approvalNodeEdit'
 
 // Approval-node editing inside the graph authoring model. PURE-LOGIC tests (no .vue)
@@ -371,5 +375,226 @@ describe('G-5 fail-closed — complex approval-node config must stay within the 
   it('K5-b: a dept_head_at_level source with an unknown extra key forces read-only', () => {
     const graph = complexWith({ assigneeSources: [{ kind: 'dept_head_at_level', level: 2, futureFlag: true }] })
     expect(unsupportedTemplateAuthoringReason(buildTemplate(graph))).not.toBeNull()
+  })
+})
+
+// P1-B — master §P1-B / approval-parity-master-design-lock-20260817.md: remove the linear/canvas
+// editor's single-source restriction and expose ALL existing assignee sources as editable cards.
+// This slice is FE-ONLY (the engine's `assigneeSources[]` union + identity dedup already ships —
+// ApprovalAssigneeResolver.ts:150 `sources.forEach`, dedup at :121-123). These are the PURE-LOGIC
+// halves: hydrate seeds the FULL array (not just [0]), addAssigneeSourceCard/removeAssigneeSourceCard
+// are the edit-model mutators the config editor's add/remove buttons delegate to, and
+// applyApprovalNodeEditsToGraph is the publish-payload-shape pin. The .vue wiring (multi-card render,
+// buttons, hydrate showing N cards) is covered in approval-template-authoring-canvas-inspector.spec.ts
+// (direct component mount) and approvalTemplateAuthoring.spec.ts (full SFC mount, real save payload).
+describe('P1-B: multi-source assignee cards — hydrate seeds the FULL array', () => {
+  // A cc node forces the COMPLEX/preserved-graph path (matches this suite's established
+  // LEGACY_GRAPH/FOUR_TYPE_GRAPH convention above) — this is the P1-B surface
+  // (`draft.approvalNodeEdits` → `ApprovalGraphNodeConfigEditor.vue`). A PURE linear topology
+  // (no condition/parallel/cc/handler node) instead projects through the SEPARATE `draft.steps`
+  // wizard model, whose `sourceFromStep` is single-source by design and stays that way — that
+  // model is an explicit P1-B non-goal (master lock source-anchor: "linear editor" = this SFC,
+  // not the step wizard), not a regression to chase here.
+  const TWO_SOURCE_GRAPH: ApprovalGraph = {
+    nodes: [
+      { key: 'start', type: 'start', name: '发起', config: {} },
+      {
+        key: 'approval_1', type: 'approval', name: '主管',
+        config: {
+          assigneeSources: [{ kind: 'direct_manager' }, { kind: 'dept_head' }],
+          approvalMode: 'any', emptyAssigneePolicy: 'error',
+        },
+      },
+      { key: 'cc_1', type: 'cc', name: '抄送', config: { targetType: 'role', targetIds: ['finance'] } },
+      { key: 'end', type: 'end', name: '结束', config: {} },
+    ],
+    edges: [
+      { key: 'e1', source: 'start', target: 'approval_1' },
+      { key: 'e2', source: 'approval_1', target: 'cc_1' },
+      { key: 'e3', source: 'cc_1', target: 'end' },
+    ],
+  }
+
+  it('seeds ALL sources, not only assigneeSources[0] (mutation: hydrate only [0] → this reds)', () => {
+    const edits = approvalNodeEditsFromGraph(TWO_SOURCE_GRAPH)
+    // A hydrate regressed to `assigneeSources: [node.config.assigneeSources[0]]` still passes a
+    // length-agnostic `toContainEqual`-style check, so pin the exact array — length AND contents.
+    expect(edits.approval_1.assigneeSources).toEqual([{ kind: 'direct_manager' }, { kind: 'dept_head' }])
+    expect(edits.approval_1.assigneeSources).toHaveLength(2)
+  })
+
+  it('round-trips 2 sources byte-identically through draftFromTemplate → buildApprovalGraph (no card dropped)', () => {
+    const original = JSON.parse(JSON.stringify(TWO_SOURCE_GRAPH)) as ApprovalGraph
+    const rebuilt = buildApprovalGraph(draftFromTemplate(buildTemplate(TWO_SOURCE_GRAPH)))
+    expect(rebuilt).toEqual(original)
+  })
+})
+
+describe('P1-B: addAssigneeSourceCard — appends without touching existing cards', () => {
+  function twoNodeEdits(sources: Array<Record<string, unknown>>): ApprovalNodeEdits {
+    return {
+      approval_1: { nodeKey: 'approval_1', assigneeSources: sources as never },
+      approval_2: { nodeKey: 'approval_2', assigneeSources: [{ kind: 'requester' }] },
+    }
+  }
+
+  it('appends the new card at the END; the existing card is untouched (positive control: single-source template still works)', () => {
+    const edits = twoNodeEdits([{ kind: 'direct_manager' }])
+    addAssigneeSourceCard(edits, 'approval_1', { kind: 'dept_head' })
+    expect(edits.approval_1.assigneeSources).toEqual([{ kind: 'direct_manager' }, { kind: 'dept_head' }])
+    // The OTHER node's edit is completely untouched — add is scoped to the named node only.
+    expect(edits.approval_2.assigneeSources).toEqual([{ kind: 'requester' }])
+  })
+
+  it('is a no-op for a node key absent from edits (no crash, no stray entry created)', () => {
+    const edits = twoNodeEdits([{ kind: 'direct_manager' }])
+    addAssigneeSourceCard(edits, 'no_such_node', { kind: 'requester' })
+    expect(Object.keys(edits)).toEqual(['approval_1', 'approval_2'])
+  })
+
+  it('deep-clones the default source — mutating the caller-supplied object afterward does not alter the stored card', () => {
+    const edits = twoNodeEdits([{ kind: 'direct_manager' }])
+    const mutableDefault: { kind: string; userIds: string[] } = { kind: 'static_user', userIds: ['u1'] }
+    addAssigneeSourceCard(edits, 'approval_1', mutableDefault as never)
+    mutableDefault.userIds.push('u2')
+    expect(edits.approval_1.assigneeSources[1]).toEqual({ kind: 'static_user', userIds: ['u1'] })
+  })
+})
+
+describe('P1-B: removeAssigneeSourceCard — removes the RIGHT card and is fail-closed at length<=1', () => {
+  function twoSourceEdits(): ApprovalNodeEdits {
+    return {
+      approval_1: {
+        nodeKey: 'approval_1',
+        // Deliberately distinguishable shapes (not two of the same kind) so a splice off-by-one
+        // is provable, not just a count check.
+        assigneeSources: [{ kind: 'direct_manager' }, { kind: 'dept_head' }, { kind: 'requester' }] as never,
+      },
+    }
+  }
+
+  it('removes the card AT sourceIndex; the SURVIVORS are the other two, in original order (not a count-only check)', () => {
+    const edits = twoSourceEdits()
+    removeAssigneeSourceCard(edits, 'approval_1', 1) // remove the MIDDLE card (dept_head)
+    expect(edits.approval_1.assigneeSources).toEqual([{ kind: 'direct_manager' }, { kind: 'requester' }])
+  })
+
+  it('removes index 0 correctly (not always "the last element" — discriminates a hardcoded pop/slice(1))', () => {
+    const edits = twoSourceEdits()
+    removeAssigneeSourceCard(edits, 'approval_1', 0)
+    expect(edits.approval_1.assigneeSources).toEqual([{ kind: 'dept_head' }, { kind: 'requester' }])
+  })
+
+  it('is a no-op for an out-of-range index (no crash, array untouched)', () => {
+    const edits = twoSourceEdits()
+    removeAssigneeSourceCard(edits, 'approval_1', 99)
+    expect(edits.approval_1.assigneeSources).toHaveLength(3)
+    removeAssigneeSourceCard(edits, 'approval_1', -1)
+    expect(edits.approval_1.assigneeSources).toHaveLength(3)
+  })
+
+  it('is a no-op for a missing node key', () => {
+    const edits = twoSourceEdits()
+    removeAssigneeSourceCard(edits, 'no_such_node', 0)
+    expect(Object.keys(edits)).toEqual(['approval_1'])
+  })
+
+  // THE fail-closed guard (master §P1-B: "a node must keep ≥1 source; removing the last is
+  // forbidden"). Positive control immediately above (2→2 survivors from a 3-source node) proves
+  // removal genuinely works; this proves it stops working at exactly 1. A mutation flipping the
+  // `length <= 1` guard to allow last-removal turns this red.
+  it('FAIL-CLOSED: refuses to remove the last remaining source — the node keeps its one card', () => {
+    const edits: ApprovalNodeEdits = {
+      approval_1: { nodeKey: 'approval_1', assigneeSources: [{ kind: 'direct_manager' }] },
+    }
+    removeAssigneeSourceCard(edits, 'approval_1', 0)
+    expect(edits.approval_1.assigneeSources).toEqual([{ kind: 'direct_manager' }]) // unchanged — refused
+    expect(edits.approval_1.assigneeSources).toHaveLength(1)
+  })
+
+  it('positive control for the guard above: at length 2, removal DOES proceed (the guard is length-selected, not a blanket refusal)', () => {
+    const edits: ApprovalNodeEdits = {
+      approval_1: { nodeKey: 'approval_1', assigneeSources: [{ kind: 'direct_manager' }, { kind: 'dept_head' }] },
+    }
+    removeAssigneeSourceCard(edits, 'approval_1', 0)
+    expect(edits.approval_1.assigneeSources).toEqual([{ kind: 'dept_head' }])
+  })
+})
+
+describe('P1-B: publish-payload-shape pin — applyApprovalNodeEditsToGraph serializes ALL sources', () => {
+  const THREE_SOURCE_GRAPH: ApprovalGraph = {
+    nodes: [
+      { key: 'start', type: 'start', name: '发起', config: {} },
+      {
+        key: 'approval_1', type: 'approval', name: '主管',
+        config: { assigneeSources: [{ kind: 'requester' }], approvalMode: 'any', emptyAssigneePolicy: 'error' },
+      },
+      { key: 'end', type: 'end', name: '结束', config: {} },
+    ],
+    edges: [
+      { key: 'e1', source: 'start', target: 'approval_1' },
+      { key: 'e2', source: 'approval_1', target: 'end' },
+    ],
+  }
+
+  it('a 3-source edit serializes as exactly 3 sources, in order, on the rebuilt graph (mutation dropping sources[1..] reds)', () => {
+    const edits = approvalNodeEditsFromGraph(THREE_SOURCE_GRAPH)
+    edits.approval_1.assigneeSources = [
+      { kind: 'direct_manager' },
+      { kind: 'dept_head' },
+      { kind: 'manager_at_level', level: 2 },
+    ]
+    const rebuilt = applyApprovalNodeEditsToGraph(THREE_SOURCE_GRAPH, edits)
+    const config = rebuilt.nodes.find((n) => n.key === 'approval_1')!.config as { assigneeSources: unknown }
+    expect(config.assigneeSources).toEqual([
+      { kind: 'direct_manager' },
+      { kind: 'dept_head' },
+      { kind: 'manager_at_level', level: 2 },
+    ])
+  })
+
+  it('validateApprovalNodeEdits passes all 3 sources through as independently-validated (a bad card at index 2 is still caught, not lost past index 0)', () => {
+    const errors = validateApprovalNodeEdits({
+      approval_1: {
+        nodeKey: 'approval_1',
+        assigneeSources: [
+          { kind: 'direct_manager' },
+          { kind: 'dept_head' },
+          { kind: 'static_role', roleIds: [] }, // invalid — empty roleIds
+        ],
+      },
+    })
+    expect(errors.some((e) => /static_role/.test(e))).toBe(true)
+  })
+})
+
+describe('P1-B: placeholderRoleNodeKeys widened to ALL sources (backend assertNoUnconfiguredPlaceholderRoles loops every source)', () => {
+  const SENTINEL = '__APPROVAL_ROLE_PLACEHOLDER__'
+
+  it('catches a placeholder at index 0 (unchanged prior behavior — positive control)', () => {
+    const edits: ApprovalNodeEdits = {
+      approval_1: { nodeKey: 'approval_1', assigneeSources: [{ kind: 'static_role', roleIds: [SENTINEL] }] },
+    }
+    expect(placeholderRoleNodeKeys(edits)).toEqual(['approval_1'])
+  })
+
+  it('P1-B: ALSO catches a placeholder at index 1 — before multi-card editing, index 1 was never authorable, so this is new coverage', () => {
+    const edits: ApprovalNodeEdits = {
+      approval_1: {
+        nodeKey: 'approval_1',
+        assigneeSources: [{ kind: 'direct_manager' }, { kind: 'static_role', roleIds: [SENTINEL] }],
+      },
+    }
+    expect(placeholderRoleNodeKeys(edits)).toEqual(['approval_1'])
+  })
+
+  it('a real (non-placeholder) role at any index does not false-positive', () => {
+    const edits: ApprovalNodeEdits = {
+      approval_1: {
+        nodeKey: 'approval_1',
+        assigneeSources: [{ kind: 'direct_manager' }, { kind: 'static_role', roleIds: ['real-role-id'] }],
+      },
+    }
+    expect(placeholderRoleNodeKeys(edits)).toEqual([])
   })
 })

--- a/apps/web/tests/approval-template-authoring-canvas-inspector.spec.ts
+++ b/apps/web/tests/approval-template-authoring-canvas-inspector.spec.ts
@@ -156,7 +156,16 @@ const ElSelect = defineComponent({
       disabled: this.disabled,
       'data-testid': (this.$attrs as any)?.['data-testid'],
       onChange: (event: Event) => {
-        const value = (event.target as HTMLSelectElement).value
+        const target = event.target as HTMLSelectElement
+        // P1-B/P2(b) stub fidelity fix (test-only): a real el-select `multiple` emits an ARRAY of
+        // selected values via `update:model-value`, not the native `<select>.value` single string.
+        // Every existing multi-select consumer in this file either already expects an array
+        // (requester_choice scope ids, via its own `Array.isArray(ids) ? ids : [ids]` coercion —
+        // unaffected either way) or is a non-multiple select (unaffected — this branch is gated on
+        // the `multiple` DOM attribute, which Vue's attr-fallthrough already sets from the real
+        // `multiple` template binding). Verified: no test in this file asserted a single-STRING
+        // written value for a genuinely multi-attributed select before this fix.
+        const value = target.multiple ? Array.from(target.selectedOptions).map((option) => option.value) : target.value
         this.$emit('update:modelValue', value)
         this.$emit('change', value)
       },
@@ -1182,6 +1191,71 @@ describe('Canvas V2 Slice A — canvas inspector', () => {
     expect(echo?.textContent).not.toBe('已配置：指定角色（未选择）')
   })
 
+  // P2(a) — adversarial gate (docs/development pinned MD, 2026-08-17): the OPPOSITE direction of
+  // the add-preserves-cache test above. `removeApprovalSourceCard` clears the WHOLE node's
+  // kind-switch cache before removing (`clearApprovalSourceKindCacheForNode`) precisely because
+  // removal SHIFTS every subsequent card's index — a survivor that slides into a REMOVED card's old
+  // index must NOT inherit that removed card's stale per-index cached payload. This was load-bearing
+  // but had zero coverage (mutation: deleting the clear-on-remove call left all 186 tests green).
+  it('P1-B / P2(a): removing card 0 does NOT leak its cached kind-switch payload into the survivor that slides into its old index', async () => {
+    routeParams = { id: 'tpl_p1b_remove_clears_cache' }
+    getTemplateSpy.mockResolvedValue(buildTemplate({ approvalGraph: buildMixedGraph() as any }))
+    await mountView()
+    await flushUi()
+    ;(container!.querySelector('[data-testid="approval-view-canvas"]') as HTMLButtonElement).click()
+    await flushUi()
+
+    // app_b: static_role, roleIds:['legal'] at card 0.
+    clickCanvasNode('app_b')
+    await flushUi()
+    let cards = container!.querySelectorAll('[data-testid="approval-node-source-card"]')
+    expect(cards).toHaveLength(1)
+
+    // Switch card 0 AWAY from static_role — this caches roleIds:['legal'] under the node's
+    // INDEX-0 cache slot (keyed `nodeKey:0`), exactly like the add-preserves-cache test above.
+    ;(cards[0].querySelector('[data-testid="approval-node-source-kind-requester"]') as HTMLInputElement).click()
+    await flushUi()
+
+    // Add a 2nd card — genuinely fresh, has NEVER held any roleIds. This becomes the survivor.
+    ;(container!.querySelector('[data-testid="approval-node-source-add"]') as HTMLButtonElement).click()
+    await flushUi()
+    cards = container!.querySelectorAll('[data-testid="approval-node-source-card"]')
+    expect(cards).toHaveLength(2)
+
+    // Remove card 0 — its CURRENT content is `requester` (switched above), but it still carries the
+    // STALE index-0 cache entry `{static_role: {roleIds:['legal']}}` from that switch. Card 1 (the
+    // fresh card) shifts DOWN into index 0.
+    ;(cards[0].querySelector('[data-testid="approval-node-source-remove"]') as HTMLButtonElement).click()
+    await flushUi()
+    cards = container!.querySelectorAll('[data-testid="approval-node-source-card"]')
+    expect(cards).toHaveLength(1)
+    expect((cards[0].querySelector('[data-testid="approval-node-source-kind-requester"]') as HTMLInputElement).checked).toBe(true)
+
+    // Switch the SURVIVOR (now at index 0, a card that NEVER held 'legal') to static_role. If the
+    // remove had not cleared the per-index cache, the survivor would wrongly inherit the REMOVED
+    // card's stale cached roleIds — a silent wrong-approver reaching Save.
+    ;(cards[0].querySelector('[data-testid="approval-node-source-kind-static_role"]') as HTMLInputElement).click()
+    await flushUi()
+    cards = container!.querySelectorAll('[data-testid="approval-node-source-card"]')
+    const rolePicker = cards[0].querySelector('[data-testid="approval-node-source-role-picker"]') as HTMLSelectElement
+    expect(rolePicker.value).not.toBe('legal') // must NOT inherit the removed card's cached role
+    expect(rolePicker.value).toBe('') // clean — a genuinely fresh static_role, no pre-selection
+    const echo2 = cards[0].querySelector('[data-testid="approval-node-source-configured-summary"]')
+    expect(echo2?.textContent).toBe('已配置：指定角色（未选择）')
+    expect(echo2?.textContent).not.toBe('已配置：指定角色（1 个）')
+    // NOTE: this test deliberately stops at the DOM/model assertions above rather than also
+    // round-tripping a Save. An empty `static_role` (the CORRECT, leak-free outcome this test
+    // proves) fails its own orthogonal `isAssigneeSourceValid` gate (`roleIds.some(...)`, a
+    // completely different concern from this cache leak) inside `persistDraft`'s `validate()` —
+    // `canSave`/the Save button's `disabled` state does NOT check per-source validity (only
+    // `unsupportedReason`), so the button stays clickable, but the click's `validate()` call
+    // correctly refuses to persist an unconfigured role and no `updateTemplate` call happens. That
+    // is expected, orthogonal behavior, not something this leak-freedom test should route around by
+    // picking a non-empty role (which would need a directory-backed picker option this full-mount
+    // section does not stub) — the picker value and configured-summary echo above are the complete,
+    // load-bearing, unambiguous proof that 'legal' did not leak into the survivor.
+  })
+
   it('Lock-7 G-13: the readonly honesty copy is retired atomically in BOTH authoring surfaces; selecting readonly renders no hint; the routing hint stays', async () => {
     // L0-6 one-change rule: the retired strings/markers must be absent from BOTH surface sources
     // (linear + canvas). Asserting on BOTH blobs is what reds if the copy is re-added to EITHER
@@ -2055,5 +2129,121 @@ describe('Lock-0 P1-A — registry-driven tab membership + roster (direct mount)
     // approval-handler-node-config.spec.ts's stub, which (unlike this file's createStubConfigApi)
     // already implements handlerNodeMode/handlerNodeOpinionRequired — required for a handler node
     // to render at all through THIS harness's `installStubs`.
+
+    // P2(b) — adversarial gate: the SIX non-kind write setters (`setApprovalSourceIdsFromPicker`,
+    // `setApprovalSourceFieldId`, `setApprovalSourceLevel`, `setRequesterChoiceMode`,
+    // `setRequesterChoiceScopeType`, `setRequesterChoiceScopeIds`) were never exercised at
+    // `sourceIndex >= 1` — every existing test either only READS card ≥1 (kind-checked, count,
+    // remove-disabled) or edits its KIND radio, never its typed sub-form. A regression hardcoding
+    // any of these six template callsites' `sourceIndex` argument to `0` left ALL 186 tests green.
+    // These two specs drive every one of the six at index >= 1 (one node with an index-0 CONTROL
+    // card that must stay byte-identical throughout) and assert the write lands on the card it was
+    // aimed at, not card 0.
+    it('P1-B / P2(b): setApprovalSourceIdsFromPicker / setApprovalSourceFieldId / setApprovalSourceLevel at sourceIndex >= 1 land on the RIGHT card — the index-0 control card stays byte-identical', () => {
+      const node = makeApprovalNode('approval_p2b_pickers')
+      const api = createStubConfigApi({
+        approval_p2b_pickers: {
+          assigneeSources: [
+            { kind: 'direct_manager' }, // 0: CONTROL — must be untouched by every write below
+            { kind: 'static_user', userIds: [] }, // 1: setApprovalSourceIdsFromPicker target (user branch)
+            { kind: 'static_role', roleIds: [] }, // 2: setApprovalSourceIdsFromPicker target (role branch)
+            { kind: 'form_field_user', fieldId: '' }, // 3: setApprovalSourceFieldId target
+            { kind: 'manager_at_level', level: 1 }, // 4: setApprovalSourceLevel target
+          ],
+        },
+      })
+      ;(api as { directoryUsers: Array<{ id: string }> }).directoryUsers = [{ id: 'u_only' }]
+      ;(api as { directoryRoles: Array<{ id: string }> }).directoryRoles = [{ id: 'r_only' }]
+      const { container: c, unmount } = mountDirectConfigEditorFlat({ node, registry: DEFAULT_APPROVAL_CAPABILITY_REGISTRY, api })
+
+      const cards = c.querySelectorAll('[data-testid="approval-node-source-card"]')
+      expect(cards).toHaveLength(5)
+
+      // setApprovalSourceIdsFromPicker at index 1 (static_user).
+      const userPicker = cards[1].querySelector('[data-testid="approval-node-source-user-picker"]') as HTMLSelectElement
+      userPicker.value = 'u_only'
+      userPicker.dispatchEvent(new Event('change'))
+
+      // setApprovalSourceIdsFromPicker at index 2 (static_role — the SAME setter, different kind).
+      const rolePicker = cards[2].querySelector('[data-testid="approval-node-source-role-picker"]') as HTMLSelectElement
+      rolePicker.value = 'r_only'
+      rolePicker.dispatchEvent(new Event('change'))
+
+      // setApprovalSourceFieldId at index 3. `userFields` defaults to [{id:'reviewer',...}] in the stub.
+      const fieldPicker = cards[3].querySelector('[data-testid="approval-node-source-field"]') as HTMLSelectElement
+      fieldPicker.value = 'reviewer'
+      fieldPicker.dispatchEvent(new Event('change'))
+
+      // setApprovalSourceLevel at index 4.
+      const levelInput = cards[4].querySelector('[data-testid="approval-node-source-level"]') as HTMLInputElement
+      levelInput.value = '4'
+      levelInput.dispatchEvent(new Event('input'))
+
+      const sources = api.approvalNodeEditFor('approval_p2b_pickers')?.assigneeSources as Array<Record<string, unknown>>
+      // CONTROL untouched by all FOUR writes above — proves none of them mis-targeted index 0.
+      expect(sources[0]).toEqual({ kind: 'direct_manager' })
+      expect(sources[1]).toEqual({ kind: 'static_user', userIds: ['u_only'] })
+      expect(sources[2]).toEqual({ kind: 'static_role', roleIds: ['r_only'] })
+      expect(sources[3]).toEqual({ kind: 'form_field_user', fieldId: 'reviewer' })
+      expect(sources[4]).toEqual({ kind: 'manager_at_level', level: 4 })
+      unmount()
+    })
+
+    it('P1-B / P2(b): the requester_choice sub-form — setRequesterChoiceMode / ScopeType / ScopeIds — at sourceIndex >= 1 lands on the RIGHT card — the index-0 control card stays byte-identical', async () => {
+      const node = makeApprovalNode('approval_p2b_rc')
+      const api = createStubConfigApi({
+        approval_p2b_rc: {
+          assigneeSources: [
+            { kind: 'direct_manager' }, // 0: CONTROL — must be untouched by every write below
+            { kind: 'requester_choice', mode: 'single', scope: { type: 'company' } }, // 1: target
+          ],
+        },
+      })
+      ;(api as { directoryUsers: Array<{ id: string; name?: string; email?: string }> }).directoryUsers = [
+        { id: 'u_alpha', name: 'Alpha', email: 'a@x.test' },
+      ]
+      const { container: c, unmount } = mountDirectConfigEditorFlat({ node, registry: DEFAULT_APPROVAL_CAPABILITY_REGISTRY, api })
+
+      let cards = c.querySelectorAll('[data-testid="approval-node-source-card"]')
+      expect(cards).toHaveLength(2)
+
+      // setRequesterChoiceMode at index 1 (single → multi).
+      const multiRadio = cards[1].querySelector('[data-testid="approval-node-requester-choice-mode-multi"]') as HTMLInputElement
+      multiRadio.checked = true
+      multiRadio.dispatchEvent(new Event('change'))
+      await flushUi()
+      expect(api.approvalNodeEditFor('approval_p2b_rc')?.assigneeSources[0]).toEqual({ kind: 'direct_manager' })
+      expect(api.approvalNodeEditFor('approval_p2b_rc')?.assigneeSources[1]).toEqual({
+        kind: 'requester_choice', mode: 'multi', scope: { type: 'company' },
+      })
+
+      // setRequesterChoiceScopeType at index 1 (company → members). Re-render is required before
+      // the members-only user-picker exists in the DOM (conditional on scope.type === 'members').
+      cards = c.querySelectorAll('[data-testid="approval-node-source-card"]')
+      const scopeSelect = cards[1].querySelector('[data-testid="approval-node-requester-choice-scope"]') as HTMLSelectElement
+      scopeSelect.value = 'members'
+      scopeSelect.dispatchEvent(new Event('change'))
+      await flushUi()
+      expect(api.approvalNodeEditFor('approval_p2b_rc')?.assigneeSources[0]).toEqual({ kind: 'direct_manager' })
+      expect(api.approvalNodeEditFor('approval_p2b_rc')?.assigneeSources[1]).toEqual({
+        kind: 'requester_choice', mode: 'multi', scope: { type: 'members', userIds: [] },
+      })
+
+      // setRequesterChoiceScopeIds at index 1.
+      cards = c.querySelectorAll('[data-testid="approval-node-source-card"]')
+      const userPicker = cards[1].querySelector('[data-testid="approval-node-requester-choice-user-picker"]') as HTMLSelectElement
+      expect(userPicker).not.toBeNull()
+      userPicker.value = 'u_alpha'
+      userPicker.dispatchEvent(new Event('change'))
+      await flushUi()
+
+      // Final assertion: card 0 is STILL byte-identical after all THREE writes at index 1, and
+      // card 1 accumulated every write correctly.
+      expect(api.approvalNodeEditFor('approval_p2b_rc')?.assigneeSources[0]).toEqual({ kind: 'direct_manager' })
+      expect(api.approvalNodeEditFor('approval_p2b_rc')?.assigneeSources[1]).toEqual({
+        kind: 'requester_choice', mode: 'multi', scope: { type: 'members', userIds: ['u_alpha'] },
+      })
+      unmount()
+    })
   })
 })

--- a/apps/web/tests/approval-template-authoring-canvas-inspector.spec.ts
+++ b/apps/web/tests/approval-template-authoring-canvas-inspector.spec.ts
@@ -1144,6 +1144,44 @@ describe('Canvas V2 Slice A — canvas inspector', () => {
     expect(appB.config.assigneeSources[0]).toEqual({ kind: 'static_role', roleIds: ['legal'] })
   })
 
+  // P1-B / P1-1 interaction: adding a NEW card must NOT clear the P1-1 kind-switch cache for
+  // EXISTING cards. Append never shifts card 0's index, so a naive "clear on any structural change"
+  // implementation would needlessly re-open the exact P1-1 config-loss bug in a new sequence.
+  it('P1-B: adding a 2nd card does NOT clear card 0\'s P1-1 kind-switch cache — switching card 0 away then back still restores its configured roleIds', async () => {
+    routeParams = { id: 'tpl_p1b_add_preserves_cache' }
+    getTemplateSpy.mockResolvedValue(buildTemplate({ approvalGraph: buildMixedGraph() as any }))
+    await mountView()
+    await flushUi()
+    ;(container!.querySelector('[data-testid="approval-view-canvas"]') as HTMLButtonElement).click()
+    await flushUi()
+
+    // app_b: static_role, roleIds:['legal'] at card 0 (the same P1-1 fixture as above).
+    clickCanvasNode('app_b')
+    await flushUi()
+    let cards = container!.querySelectorAll('[data-testid="approval-node-source-card"]')
+    expect(cards).toHaveLength(1)
+
+    // Switch card 0 away from static_role (caches roleIds:['legal'] under card index 0).
+    ;(cards[0].querySelector('[data-testid="approval-node-source-kind-requester"]') as HTMLInputElement).click()
+    await flushUi()
+
+    // NOW add a 2nd card — this must NOT clear card 0's just-cached payload.
+    ;(container!.querySelector('[data-testid="approval-node-source-add"]') as HTMLButtonElement).click()
+    await flushUi()
+    cards = container!.querySelectorAll('[data-testid="approval-node-source-card"]')
+    expect(cards).toHaveLength(2)
+
+    // Switch card 0 BACK to static_role — the cached roleIds must be restored, not emptied.
+    ;(cards[0].querySelector('[data-testid="approval-node-source-kind-static_role"]') as HTMLInputElement).click()
+    await flushUi()
+    cards = container!.querySelectorAll('[data-testid="approval-node-source-card"]')
+    const rolePickerAfter = cards[0].querySelector('[data-testid="approval-node-source-role-picker"]') as HTMLSelectElement
+    expect(rolePickerAfter.value).toBe('legal') // restored — the add did NOT wipe the cache
+    const echo = cards[0].querySelector('[data-testid="approval-node-source-configured-summary"]')
+    expect(echo?.textContent).toBe('已配置：指定角色（1 个）')
+    expect(echo?.textContent).not.toBe('已配置：指定角色（未选择）')
+  })
+
   it('Lock-7 G-13: the readonly honesty copy is retired atomically in BOTH authoring surfaces; selecting readonly renders no hint; the routing hint stays', async () => {
     // L0-6 one-change rule: the retired strings/markers must be absent from BOTH surface sources
     // (linear + canvas). Asserting on BOTH blobs is what reds if the copy is re-added to EITHER
@@ -1982,9 +2020,11 @@ describe('Lock-0 P1-A — registry-driven tab membership + roster (direct mount)
 
       expect(api.approvalNodeEditFor('approval_add')?.assigneeSources).toHaveLength(2)
       expect(api.approvalNodeEditFor('approval_add')?.assigneeSources[0]).toEqual({ kind: 'direct_manager' }) // untouched
-      // the new card is defaulted from the registry roster's FIRST kind (static_user for `approval`
-      // nodes) — never hand-picked, and never a kind outside the node-type roster.
-      expect(api.approvalNodeEditFor('approval_add')?.assigneeSources[1]).toMatchObject({ kind: 'static_user' })
+      // the new card defaults to `requester` — NOT the roster's raw first entry (`static_user`,
+      // whose zero-config shape `{ kind: 'static_user', userIds: [] }` fails validation and would
+      // disable Save on every single click of "＋添加审批人"). `requester` is valid with zero
+      // further configuration, same convention as a brand-new node (graphTopologyEdit.ts).
+      expect(api.approvalNodeEditFor('approval_add')?.assigneeSources[1]).toEqual({ kind: 'requester' })
       const cards = c.querySelectorAll('[data-testid="approval-node-source-card"]')
       expect(cards).toHaveLength(2)
       unmount()

--- a/apps/web/tests/approval-template-authoring-canvas-inspector.spec.ts
+++ b/apps/web/tests/approval-template-authoring-canvas-inspector.spec.ts
@@ -1394,10 +1394,11 @@ describe('Lock-0 P1-A — registry-driven tab membership + roster (direct mount)
       ccTargetTypeLabel: () => '用户',
       setCcTargetIds: () => {},
       syncCcOptions: () => {},
-      approvalSourceKind: (nodeKey: string) => (edits[nodeKey]?.assigneeSources[0]?.kind as any) ?? 'requester',
-      setApprovalSourceKind: (nodeKey: string, kind: any) => {
+      // P1-B: every per-source accessor now takes an explicit sourceIndex (one card in the array).
+      approvalSourceKind: (nodeKey: string, sourceIndex: number) => (edits[nodeKey]?.assigneeSources[sourceIndex]?.kind as any) ?? 'requester',
+      setApprovalSourceKind: (nodeKey: string, sourceIndex: number, kind: any) => {
         const edit = edits[nodeKey]
-        if (!edit) return
+        if (!edit || sourceIndex < 0 || sourceIndex >= edit.assigneeSources.length) return
         const next: Record<string, unknown> =
           kind === 'static_user' ? { kind, userIds: [] }
             : kind === 'static_role' ? { kind, roleIds: [] }
@@ -1409,30 +1410,32 @@ describe('Lock-0 P1-A — registry-driven tab membership + roster (direct mount)
                       // Lock-1 §K5-b: same default shape as manager_at_level.
                       : kind === 'dept_head_at_level' ? { kind, level: 1 }
                         : { kind }
-        edit.assigneeSources = [next, ...edit.assigneeSources.slice(1)]
+        const nextSources = edit.assigneeSources.slice()
+        nextSources[sourceIndex] = next
+        edit.assigneeSources = nextSources
       },
       syncApprovalNodeOptions: () => {},
-      approvalSourceIds: (nodeKey: string) => {
-        const source = edits[nodeKey]?.assigneeSources[0]
+      approvalSourceIds: (nodeKey: string, sourceIndex: number) => {
+        const source = edits[nodeKey]?.assigneeSources[sourceIndex]
         return (source?.userIds as string[]) ?? (source?.roleIds as string[]) ?? []
       },
-      setApprovalSourceIdsFromPicker: (nodeKey: string, ids: string[]) => {
-        const source = edits[nodeKey]?.assigneeSources[0]
+      setApprovalSourceIdsFromPicker: (nodeKey: string, sourceIndex: number, ids: string[]) => {
+        const source = edits[nodeKey]?.assigneeSources[sourceIndex]
         if (!source) return
         if (source.kind === 'static_user') source.userIds = ids
         else if (source.kind === 'static_role') source.roleIds = ids
       },
-      approvalSourceFieldId: (nodeKey: string) => (edits[nodeKey]?.assigneeSources[0]?.fieldId as string) ?? '',
-      setApprovalSourceFieldId: (nodeKey: string, fieldId: string) => {
-        const source = edits[nodeKey]?.assigneeSources[0]
+      approvalSourceFieldId: (nodeKey: string, sourceIndex: number) => (edits[nodeKey]?.assigneeSources[sourceIndex]?.fieldId as string) ?? '',
+      setApprovalSourceFieldId: (nodeKey: string, sourceIndex: number, fieldId: string) => {
+        const source = edits[nodeKey]?.assigneeSources[sourceIndex]
         if (source && source.kind === 'form_field_user') source.fieldId = fieldId
       },
-      approvalSourceLevel: (nodeKey: string) => {
-        const source = edits[nodeKey]?.assigneeSources[0]
+      approvalSourceLevel: (nodeKey: string, sourceIndex: number) => {
+        const source = edits[nodeKey]?.assigneeSources[sourceIndex]
         return (source?.level as number) ?? (source?.levels as number) ?? 1
       },
-      setApprovalSourceLevel: (nodeKey: string, value: number) => {
-        const source = edits[nodeKey]?.assigneeSources[0]
+      setApprovalSourceLevel: (nodeKey: string, sourceIndex: number, value: number) => {
+        const source = edits[nodeKey]?.assigneeSources[sourceIndex]
         if (!source) return
         if (source.kind === 'manager_at_level') source.level = value
         else if (source.kind === 'continuous_managers') source.levels = value
@@ -1440,6 +1443,26 @@ describe('Lock-0 P1-A — registry-driven tab membership + roster (direct mount)
         else if (source.kind === 'dept_head_at_level') source.level = value
       },
       approvalSourceIsPlaceholder: () => false,
+      approvalSourceCount: (nodeKey: string) => edits[nodeKey]?.assigneeSources.length ?? 0,
+      addApprovalSourceCard: (nodeKey: string, defaultKind: any) => {
+        const edit = edits[nodeKey]
+        if (!edit) return
+        const next: Record<string, unknown> =
+          defaultKind === 'static_user' ? { kind: defaultKind, userIds: [] }
+            : defaultKind === 'static_role' ? { kind: defaultKind, roleIds: [] }
+              : defaultKind === 'form_field_user' ? { kind: defaultKind, fieldId: '' }
+                : defaultKind === 'continuous_managers' ? { kind: defaultKind, levels: 1 }
+                  : defaultKind === 'manager_at_level' ? { kind: defaultKind, level: 1 }
+                    : defaultKind === 'continuous_dept_heads' ? { kind: defaultKind, levels: 1 }
+                      : defaultKind === 'dept_head_at_level' ? { kind: defaultKind, level: 1 }
+                        : { kind: defaultKind }
+        edit.assigneeSources = [...edit.assigneeSources, next]
+      },
+      removeApprovalSourceCard: (nodeKey: string, sourceIndex: number) => {
+        const edit = edits[nodeKey]
+        if (!edit || edit.assigneeSources.length <= 1) return
+        edit.assigneeSources = edit.assigneeSources.filter((_, index) => index !== sourceIndex)
+      },
       approvalNodeMode: () => 'single',
       setApprovalNodeMode: () => {},
       approvalNodeEmptyPolicy: () => 'error',
@@ -1900,5 +1923,97 @@ describe('Lock-0 P1-A — registry-driven tab membership + roster (direct mount)
       scope: { type: 'role', roleIds: ['role_fin'] },
     })
     unmount()
+  })
+
+  // P1-B — master §P1-B: multi-source assignee cards. The engine already unions + dedups
+  // `assigneeSources[]` (ApprovalAssigneeResolver.ts, verified unchanged by this slice); these
+  // tests cover the FE-ONLY surface — rendering N cards, add/remove wiring, and the M8 honesty
+  // copy. The fail-closed "keep ≥1 source" GUARD itself is unit-tested directly against the pure
+  // `removeAssigneeSourceCard` in approval-template-authoring-approval-node-edit.test.ts (a native
+  // `disabled` button cannot dispatch a click event at all, so DOM-level mutation testing of the
+  // guard is not meaningful here — this file proves the WIRING: the button reaches that function
+  // and the `disabled` attribute reflects the count correctly).
+  describe('P1-B: multi-source assignee cards', () => {
+    it('positive control: a SINGLE-source node renders exactly 1 card, remove disabled, no union hint (byte-identical to pre-P1-B shape)', () => {
+      const node = makeApprovalNode('approval_single')
+      const api = createStubConfigApi({ approval_single: { assigneeSources: [{ kind: 'direct_manager' }] } })
+      const { container: c, unmount } = mountDirectConfigEditorFlat({ node, registry: DEFAULT_APPROVAL_CAPABILITY_REGISTRY, api })
+
+      const cards = c.querySelectorAll('[data-testid="approval-node-source-card"]')
+      expect(cards).toHaveLength(1)
+      expect((c.querySelector('[data-testid="approval-node-source-remove"]') as HTMLButtonElement).disabled).toBe(true)
+      expect(c.querySelector('[data-testid="approval-node-source-union-hint"]')).toBeNull() // M8: no dedup-honesty copy for a trivial single-source node
+      expect(c.querySelector('[data-testid="approval-node-source-add"]')).not.toBeNull()
+      // every existing single-source testid still resolves exactly once — the old shape survives.
+      expect(c.querySelectorAll('[data-testid="approval-node-source-roster"]')).toHaveLength(1)
+      expect((c.querySelector('[data-testid="approval-node-source-kind-direct_manager"]') as HTMLInputElement).checked).toBe(true)
+      unmount()
+    })
+
+    it('hydrate: a node seeded with 2 sources renders exactly 2 cards, each showing its OWN kind (mutation: hydrate only [0] → this reds)', () => {
+      const node = makeApprovalNode('approval_two')
+      const api = createStubConfigApi({
+        approval_two: { assigneeSources: [{ kind: 'direct_manager' }, { kind: 'dept_head' }] },
+      })
+      const { container: c, unmount } = mountDirectConfigEditorFlat({ node, registry: DEFAULT_APPROVAL_CAPABILITY_REGISTRY, api })
+
+      const cards = c.querySelectorAll('[data-testid="approval-node-source-card"]')
+      expect(cards).toHaveLength(2)
+      expect((cards[0].querySelector('[data-testid="approval-node-source-kind-direct_manager"]') as HTMLInputElement).checked).toBe(true)
+      expect((cards[1].querySelector('[data-testid="approval-node-source-kind-dept_head"]') as HTMLInputElement).checked).toBe(true)
+      // remove is ENABLED once there is more than one card.
+      expect((cards[0].querySelector('[data-testid="approval-node-source-remove"]') as HTMLButtonElement).disabled).toBe(false)
+      expect((cards[1].querySelector('[data-testid="approval-node-source-remove"]') as HTMLButtonElement).disabled).toBe(false)
+      // M8 honesty: the union/dedup hint renders (count > 1) and does not claim the FE itself dedups.
+      const hint = c.querySelector('[data-testid="approval-node-source-union-hint"]')
+      expect(hint).not.toBeNull()
+      expect(hint!.textContent).toContain('并集')
+      expect(hint!.textContent).toMatch(/系统运行时自动去重|运行时/) // attributes dedup to the RUNTIME, not this editor
+      unmount()
+    })
+
+    it('"＋添加审批人" appends a registry-defaulted card; the existing card is untouched; the model has 2 sources', async () => {
+      const node = makeApprovalNode('approval_add')
+      const api = createStubConfigApi({ approval_add: { assigneeSources: [{ kind: 'direct_manager' }] } })
+      const { container: c, unmount } = mountDirectConfigEditorFlat({ node, registry: DEFAULT_APPROVAL_CAPABILITY_REGISTRY, api })
+
+      ;(c.querySelector('[data-testid="approval-node-source-add"]') as HTMLButtonElement).click()
+      await flushUi()
+
+      expect(api.approvalNodeEditFor('approval_add')?.assigneeSources).toHaveLength(2)
+      expect(api.approvalNodeEditFor('approval_add')?.assigneeSources[0]).toEqual({ kind: 'direct_manager' }) // untouched
+      // the new card is defaulted from the registry roster's FIRST kind (static_user for `approval`
+      // nodes) — never hand-picked, and never a kind outside the node-type roster.
+      expect(api.approvalNodeEditFor('approval_add')?.assigneeSources[1]).toMatchObject({ kind: 'static_user' })
+      const cards = c.querySelectorAll('[data-testid="approval-node-source-card"]')
+      expect(cards).toHaveLength(2)
+      unmount()
+    })
+
+    it('remove drops the RIGHT card — the SURVIVOR is the other one, not a stale re-render of the removed card (not a count-only assertion)', async () => {
+      const node = makeApprovalNode('approval_rm')
+      const api = createStubConfigApi({
+        approval_rm: { assigneeSources: [{ kind: 'direct_manager' }, { kind: 'dept_head' }] },
+      })
+      const { container: c, unmount } = mountDirectConfigEditorFlat({ node, registry: DEFAULT_APPROVAL_CAPABILITY_REGISTRY, api })
+
+      const removeCard0 = c.querySelectorAll('[data-testid="approval-node-source-card"]')[0]
+        .querySelector('[data-testid="approval-node-source-remove"]') as HTMLButtonElement
+      removeCard0.click()
+      await flushUi()
+
+      expect(api.approvalNodeEditFor('approval_rm')?.assigneeSources).toEqual([{ kind: 'dept_head' }])
+      const cards = c.querySelectorAll('[data-testid="approval-node-source-card"]')
+      expect(cards).toHaveLength(1)
+      expect((cards[0].querySelector('[data-testid="approval-node-source-kind-dept_head"]') as HTMLInputElement).checked).toBe(true)
+      // remove is disabled again now that exactly 1 remains — the UX signal tracks the guard.
+      expect((cards[0].querySelector('[data-testid="approval-node-source-remove"]') as HTMLButtonElement).disabled).toBe(true)
+      unmount()
+    })
+
+    // A `handler` node's own "add defaults from the seven-member handler roster" case is covered in
+    // approval-handler-node-config.spec.ts's stub, which (unlike this file's createStubConfigApi)
+    // already implements handlerNodeMode/handlerNodeOpinionRequired — required for a handler node
+    // to render at all through THIS harness's `installStubs`.
   })
 })

--- a/apps/web/tests/approvalTemplateAuthoring.spec.ts
+++ b/apps/web/tests/approvalTemplateAuthoring.spec.ts
@@ -1288,6 +1288,61 @@ describe('TemplateAuthoringView', () => {
     expect(payload.approvalGraph.edges).toEqual(graph.edges)
   })
 
+  // P1-B — master §P1-B / approval-parity-master-design-lock-20260817.md: multi-source assignee
+  // cards, full SFC mount (not the direct-component stub harness). Proves the REAL production
+  // TemplateAuthoringView wiring — the ＋添加审批人 button through to draft.approvalNodeEdits
+  // through to the save payload — for the exact scenario the task names: add a 2nd source card →
+  // model has 2 sources → publish payload has 2; remove one → back to 1. The FE-only claim (engine
+  // unchanged) is proven by ApprovalAssigneeResolver.ts's unmodified `sources.forEach` + dedup
+  // (verified by source read, not re-tested here — this file only covers the FE authoring surface).
+  it('P1-B: add a 2nd source card via the REAL "＋添加审批人" control → save payload carries 2 sources; remove one → save payload carries 1 (both survive the SAME node, edges/cc byte-identical)', async () => {
+    routeParams = { id: 'tpl_p1b_multicard' }
+    const graph = buildG5ComplexGraph({ assigneeSources: [{ kind: 'direct_manager' }], approvalMode: 'single', emptyAssigneePolicy: 'error' })
+    getTemplateSpy.mockResolvedValue(buildTemplate({ approvalGraph: graph }))
+    await mountView()
+    await flushUi()
+
+    // starts with exactly 1 card; add appends a 2nd.
+    expect(container!.querySelectorAll('[data-testid="approval-node-source-card"]')).toHaveLength(1)
+    ;(container!.querySelector('[data-testid="approval-node-source-add"]') as HTMLButtonElement).click()
+    await flushUi()
+    let cards = container!.querySelectorAll('[data-testid="approval-node-source-card"]')
+    expect(cards).toHaveLength(2)
+    // card 0 stays direct_manager (untouched by the add); configure card 1 to a distinguishable
+    // kind (dept_head) so a later removal can prove WHICH card survived, not just the count.
+    expect((cards[0].querySelector('[data-testid="approval-node-source-kind-direct_manager"]') as HTMLInputElement).checked).toBe(true)
+    ;(cards[1].querySelector('[data-testid="approval-node-source-kind-dept_head"]') as HTMLInputElement).click()
+    await flushUi()
+
+    ;(container!.querySelector('[data-testid="approval-template-save-button"]') as HTMLButtonElement).click()
+    await flushUi()
+    expect(updateTemplateSpy).toHaveBeenCalledTimes(1)
+    let approval1 = (updateTemplateSpy.mock.calls[0]?.[1] as any).approvalGraph.nodes.find((n: any) => n.key === 'approval_1')
+    expect(approval1.config.assigneeSources).toEqual([{ kind: 'direct_manager' }, { kind: 'dept_head' }]) // BOTH sources serialize
+    expect(approval1.config.approvalMode).toBe('single') // node-level fields untouched by the card add/edit
+    expect(approval1.config.emptyAssigneePolicy).toBe('error')
+
+    // remove card 0 (direct_manager) — the SURVIVOR is dept_head, not a stale re-render.
+    cards = container!.querySelectorAll('[data-testid="approval-node-source-card"]')
+    ;(cards[0].querySelector('[data-testid="approval-node-source-remove"]') as HTMLButtonElement).click()
+    await flushUi()
+    cards = container!.querySelectorAll('[data-testid="approval-node-source-card"]')
+    expect(cards).toHaveLength(1)
+    expect((cards[0].querySelector('[data-testid="approval-node-source-kind-dept_head"]') as HTMLInputElement).checked).toBe(true)
+    // remove is disabled again at exactly 1 card — the "keep ≥1" invariant's UX signal.
+    expect((cards[0].querySelector('[data-testid="approval-node-source-remove"]') as HTMLButtonElement).disabled).toBe(true)
+
+    ;(container!.querySelector('[data-testid="approval-template-save-button"]') as HTMLButtonElement).click()
+    await flushUi()
+    expect(updateTemplateSpy).toHaveBeenCalledTimes(2)
+    approval1 = (updateTemplateSpy.mock.calls[1]?.[1] as any).approvalGraph.nodes.find((n: any) => n.key === 'approval_1')
+    expect(approval1.config.assigneeSources).toEqual([{ kind: 'dept_head' }]) // exactly the survivor
+    // topology + the untouched cc node stay byte-identical across both saves.
+    expect((updateTemplateSpy.mock.calls[1]?.[1] as any).approvalGraph.edges).toEqual(graph.edges)
+    expect((updateTemplateSpy.mock.calls[1]?.[1] as any).approvalGraph.nodes.find((n: any) => n.key === 'cc_1').config)
+      .toEqual({ targetType: 'role', targetIds: ['finance'] })
+  })
+
   // G-B2-18 + D1: complex-graph static_user/static_role uses typed directory pickers only
   // (manual-ID ordinary path removed). cc forces the preserved-graph (complex) path.
   describe('G-B2-18: complex-node assignee picker', () => {

--- a/apps/web/tests/approvalTemplateAuthoring.spec.ts
+++ b/apps/web/tests/approvalTemplateAuthoring.spec.ts
@@ -1343,6 +1343,35 @@ describe('TemplateAuthoringView', () => {
       .toEqual({ targetType: 'role', targetIds: ['finance'] })
   })
 
+  // P1-B regression: the new-card default kind must be VALID with zero further configuration.
+  // The registry roster's raw first entry for `approval` is `static_user`, whose zero-config shape
+  // (`{ kind: 'static_user', userIds: [] }`) FAILS `isAssigneeSourceValid`/`validateApprovalNodeEdits`
+  // (empty `userIds`) — defaulting to it would mean clicking "＋添加审批人" on a perfectly valid
+  // template, without touching the new card at all, immediately creates an unconfigured/invalid
+  // source. This proves the default is `requester` (valid unconditionally) by driving the FULL save
+  // path with the new card COMPLETELY untouched — not just inspecting the model.
+  it('P1-B: clicking "＋添加审批人" alone (no further configuration) keeps the template save-able — the new card defaults to a VALID zero-config kind, not the roster\'s raw first entry', async () => {
+    routeParams = { id: 'tpl_p1b_add_default_valid' }
+    const graph = buildG5ComplexGraph({ assigneeSources: [{ kind: 'direct_manager' }], approvalMode: 'single', emptyAssigneePolicy: 'error' })
+    getTemplateSpy.mockResolvedValue(buildTemplate({ approvalGraph: graph }))
+    await mountView()
+    await flushUi()
+
+    ;(container!.querySelector('[data-testid="approval-node-source-add"]') as HTMLButtonElement).click()
+    await flushUi()
+    // save button itself is not gated on assignee validity (that gate is the publish checklist), but
+    // the SAVE must actually go through cleanly with the new card AS-IS — that's the real proof.
+    ;(container!.querySelector('[data-testid="approval-template-save-button"]') as HTMLButtonElement).click()
+    await flushUi()
+
+    expect(updateTemplateSpy).toHaveBeenCalledTimes(1)
+    const approval1 = (updateTemplateSpy.mock.calls[0]?.[1] as any).approvalGraph.nodes.find((n: any) => n.key === 'approval_1')
+    expect(approval1.config.assigneeSources).toEqual([{ kind: 'direct_manager' }, { kind: 'requester' }])
+    // and the PUBLISH checklist's flow item stays green too — a `requester` source is unconditionally
+    // valid, unlike the roster's raw first entry would have been.
+    expect(container!.querySelector('[data-testid="approval-node-source-kind-unknown"]')).toBeNull()
+  })
+
   // G-B2-18 + D1: complex-graph static_user/static_role uses typed directory pickers only
   // (manual-ID ordinary path removed). cc forces the preserved-graph (complex) path.
   describe('G-B2-18: complex-node assignee picker', () => {


### PR DESCRIPTION
## Summary

Implements slice **P1-B** from the RATIFIED `docs/development/approval-parity-master-design-lock-20260817.md` §P1 (P1-B item) and §4 UI map, consistent with the RATIFIED `docs/development/approval-lock1-enterprise-assignees-20260817.md` §2.3/§2.5.

- Removes `ApprovalGraphNodeConfigEditor.vue`'s single-source restriction (`assigneeSources[0]`-only) and exposes **all** of an approval/handler node's `assigneeSources[]` as editable cards, preserving array order.
- Each card reuses the exact single-source picker markup verbatim (kind roster, typed pickers, per-kind sub-forms) — no behavior change to any existing single-source template's DOM/testids (positive control: 172 pre-existing approval tests stay green unmodified).
- "＋添加审批人" (or "＋添加办理人" on a `handler` node) appends a new card, defaulted to `requester` — the same zero-config-valid default `appendApprovalNode` already uses for a brand-new node — never a hand-picked or out-of-roster kind (see "Fixup" below for why the registry roster's raw first entry is unsafe as the default).
- Each card's remove affordance is fail-closed: a node must always keep ≥1 source. The guard lives in `removeAssigneeSourceCard` (new pure function in `approvalNodeEdit.ts`) itself, not only in the button's `disabled` attribute — verified by mutation testing (see Test plan).
- M8 honesty: a hint line, shown only when a node has >1 source, attributes union/dedup to the **runtime resolver**, never claiming this editor dedups, sorts, or reorders (it doesn't — M5).

## Engine confirmation — FE-ONLY, engine unchanged

`packages/core-backend/src/services/ApprovalAssigneeResolver.ts` already:
- iterates `options.config.assigneeSources` with `sources.forEach(...)` (all sources, not just `[0]`), and
- dedups via a `seen` Set keyed on `assignmentType:finalId` inside `pushResolved`.

**Zero files under `packages/core-backend/` are touched by this PR** (`git diff --name-only | grep -v '^apps/web/'` → empty). The union + dedup shipped before this slice; this PR is exclusively the FE editor catching up to what the engine already supports.

Also confirmed unaffected by source-read (not modified, no behavior change needed):
- `apps/web/src/approvals/parallelEdit.ts`'s `dynamicAssigneeSourceFingerprint`/parallel-conflict walk — already loops every source in a node's `assigneeSources`.
- `apps/web/src/approvals/templateAuthoring.ts`'s `BACKEND_ASSIGNEE_SOURCE_KEYS_BY_KIND` complex-path allowlist check — already loops every source.
- `approvalNodeEditsFromGraph` (hydrate) / `applyApprovalNodeEditsToGraph` (publish) — already round-tripped the full array; this PR pins that shape with explicit tests + mutation coverage rather than changing behavior.

**Explicit non-goal**: the separate linear step wizard (`ApprovalStepDraft.sourceKind` / `draft.steps`, reachable only for graphs simple enough to classify as non-complex) stays single-source by design (`sourceFromStep`) — the master lock's "linear editor" in §P1-B refers to `ApprovalGraphNodeConfigEditor.vue` (its own source-anchor table names this file), not that separate wizard surface. Untouched here.

## Fixup commit (post-independent-review)

An independent review of the first push caught two real defects and one duplication, fixed in the second commit:

1. **New-card default was unsafe.** The registry roster's raw first entry for `approval` nodes is `static_user`, whose zero-config shape (`{ kind: 'static_user', userIds: [] }`) fails `isAssigneeSourceValid` — clicking "＋添加审批人" on a perfectly valid template, without touching the new card at all, created an invalid/unconfigured source. Verified empirically before fixing: saving right after "add" round-tripped the empty `static_user` shape to the backend. Now defaults to `requester` (valid unconditionally), falling back to the roster's first entry only if `requester` is absent from that node type's roster (defensive; never true at the shipped baseline).
2. **Cache-clear was mis-scoped.** `addApprovalSourceCard` was clearing the P1-1 kind-switch cache for the whole node on every add. Append never shifts an existing card's index, so the clear bought nothing and re-opened the P1-1 config-loss bug in a new sequence (configure a card → switch away → click add → switch back → cache gone). Only `removeApprovalSourceCard` clears now, since removal genuinely does shift subsequent indices.
3. **Consolidated a duplicated predicate.** `approvalSourceIsPlaceholder` (per-card hint) and `placeholderRoleNodeKeys` (aggregate publish checklist) each re-implemented the same `static_role` + sentinel-role check independently. Extracted one shared `isPlaceholderRoleSource` so the two surfaces can never independently drift; a mutation on that one function now reds tests for both consumers.

Also disclosing (non-blocking, doesn't change shipped behavior): `onUserSearch`'s directory-visibility sync now calls `syncApprovalNodeOptions` per node, which — beyond the `static_user` chip-visibility sync a plain user search needs — also runs `static_role`/`requester_choice`-scope visibility sync for that node as a side effect. This is idempotent and arguably more correct (a node with a `static_role`/`requester_choice` card alongside a `static_user` card now keeps ALL its chips visible after a search, not just the `static_user` ones), but it is a small widening beyond a literal one-for-one refactor of the pre-existing loop, named here so a reviewer doesn't have to discover it independently.

## Files changed (final, both commits combined — exact `git diff --numstat` against the branch point)

| File | +/- |
|---|---|
| `apps/web/src/approvals/components/ApprovalGraphNodeConfigEditor.vue` | +338/-239 |
| `apps/web/src/views/approval/TemplateAuthoringView.vue` | +126/-64 |
| `apps/web/tests/approval-template-authoring-approval-node-edit.test.ts` | +225/-0 |
| `apps/web/tests/approval-template-authoring-canvas-inspector.spec.ts` | +170/-15 |
| `apps/web/tests/approvalTemplateAuthoring.spec.ts` | +84/-0 |
| `apps/web/tests/approval-handler-node-config.spec.ts` | +42/-7 |
| `apps/web/src/approvals/approvalNodeEdit.ts` | +56/-9 |
| `apps/web/src/approvals/nodeConfigEditorContext.ts` | +22/-9 |
| `apps/web/src/approvals/templateAuthoring.ts` | +1/-1 |

9 files changed, 1064 insertions(+), 344 deletions(-) across both commits. `git diff --name-only <branch-point> HEAD | grep -v '^apps/web/'` → empty (FE-only confirmed against the actual branch point, not a possibly-advanced local `main` ref).

## Test plan

- [x] `vue-tsc -b` clean (Node 20.20.2, re-verified after the fixup commit).
- [x] Full `apps/web/scripts/run-required-web-tests.sh` green under Node 20.20.2, re-verified after the fixup commit: **368 test files / 4591 tests passed**.
- [x] Targeted approval token suite (196 tests across 5 files) green, including 24 new P1-B tests.
- [x] **Mutation-verified guards** (cp-backup + sha256-restore, never `git checkout --`):
  - Removed the `length <= 1` fail-closed guard in `removeAssigneeSourceCard` → the dedicated `FAIL-CLOSED` test reds. Restored, sha256-verified byte-identical.
  - Regressed hydrate to `assigneeSources[0]`-only → 3 independent tests (pure-model pin, round-trip, full-SFC hydrate) red. Restored, verified.
  - Regressed publish to drop `sources[1..]` → pure-model publish-shape pin AND full-SFC save-payload test red. Restored, verified.
  - Narrowed the widened `placeholderRoleNodeKeys` back to index-0-only → the new "catches index 1" test reds; the positive-control "index 0" and "no false positive" tests stay green (discriminating, not blanket). Restored, verified.
  - (Fixup) Neutered the consolidated `isPlaceholderRoleSource` → BOTH the aggregate-checklist test and the pre-existing per-card-hint test red, proving the consolidation is genuinely shared rather than two independently-drifting copies. Restored, sha256-verified.
- [x] Positive controls: single-source node renders byte-identical testids/DOM shape to pre-P1-B (explicit test + all 172 pre-existing tests unmodified-green); guard positive control proves removal genuinely works at length 2 (not a blanket refusal); the fixup's "add alone keeps the template save-able" test empirically drives the real save path with the new card completely untouched, not just an assertion on the model.
- [x] No raw NUL bytes in changed files; no closing-keyword prose in the diff; `git diff --stat` shows all files as text (no binary corruption).
- [x] No new spec file created — all new tests added to existing already-gated files, so no `run-required-web-tests.sh` / `approval-web-guard.yml` token changes were needed.

## Deferred / out of scope

- Net-new assignee kinds, org controls, department routing (Lock-2, already RATIFIED and separately landed) and any further Lock-1 kinds are untouched — this slice only exposes N cards of the **already-shipped** kind union.
- Linear step wizard (`ApprovalStepDraft`) stays single-source — explicit non-goal, see above.
- Not merging this PR per task instructions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
