### PR TITLE
fix(approval): publish reads the in-progress policy before persistDraft rebuilds the draft

### DIFF
--- a/apps/web/src/views/approval/TemplateAuthoringView.vue
+++ b/apps/web/src/views/approval/TemplateAuthoringView.vue
@@ -3255,16 +3255,29 @@ async function confirmPublish() {
   publishChecklistVisible.value = false
   publishing.value = true
   try {
+    // Publish-sequencing fix (Lock-6 L6-P1 gate F3 finding, corroborated by an independent
+    // component-level probe during P3-B): `policy` is a PUBLISH-ONLY argument — it never travels
+    // through the create/update payload OR response (Lock-6 §0: "policy is a PUBLISH argument,
+    // never a template/version column"). `persistDraft()` below REPLACES `draft.value` wholesale
+    // via `draftFromTemplate(saved)`, re-deriving `allowRevoke` / the L6-A dedup tier from
+    // `saved.policy` — which can only ever echo the LAST-PUBLISHED policy (or nothing, for a
+    // template that has never published), never an in-progress, not-yet-published edit the admin
+    // just made in this same sitting. Reading `draft.value` for the publish payload AFTER
+    // `persistDraft()` therefore silently discarded any such edit — the allowRevoke checkbox (and,
+    // once added, the L6-A dedup-tier control) worked in the DOM but never reached the server.
+    // Fix: snapshot the in-progress policy BEFORE persistDraft() replaces the draft, and publish
+    // THAT snapshot. This does not change persistDraft/draftFromTemplate/hydrate behavior at all —
+    // an untouched draft's snapshot is byte-identical to what the old post-persistDraft read would
+    // have produced, so P-1/P-2 round-trip behavior is unaffected; only an in-session edit now
+    // survives to publish.
+    const policyToPublish = buildPublishPolicy(draft.value)
     const saved = await persistDraft()
     if (!saved) return
     // B3-09 — whitespace-only normalizes to null server-side; send undefined to keep the wire
     // payload identical to pre-B3-09 publishes when the admin typed nothing.
     const note = publishNote.value.trim()
     await publishTemplate(saved.id, {
-      // L6-P1 carrier fix — was `{ allowRevoke: draft.value.allowRevoke }`, a REPLACE that
-      // destroyed any sibling policy field (e.g. `autoApproval`) set only through the publish
-      // API. `buildPublishPolicy` merges onto the persisted `originalPolicy` instead.
-      policy: buildPublishPolicy(draft.value),
+      policy: policyToPublish,
       ...(note ? { note } : {}),
     })
     ElMessage.success('模板已发布')

--- a/apps/web/tests/approvalTemplateAuthoring.spec.ts
+++ b/apps/web/tests/approvalTemplateAuthoring.spec.ts
@@ -2208,6 +2208,87 @@ describe('TemplateAuthoringView', () => {
     expect(pushSpy).toHaveBeenCalledWith({ path: '/approval-templates/tpl_created' })
   })
 
+  // Publish-sequencing fix (Lock-6 L6-P1 gate F3 finding). `confirmPublish()` used to read
+  // `draft.value` for the publish payload AFTER `persistDraft()` had already REPLACED it via
+  // `draftFromTemplate(saved)` — and since `policy` is publish-only (never part of the create/
+  // update payload or response), that rebuild always re-derives `allowRevoke` from whatever was
+  // LAST published (or the default, for a template that never has), discarding any in-progress
+  // edit the admin just made. The checkbox was fully interactive and its DOM state was correct;
+  // the edit simply never reached the server. These two tests reproduce the discriminating case
+  // BOTH prior tests in this file miss: they interact with the checkbox and immediately publish in
+  // the SAME sitting (every prior test either never touches the control, or asserts against a pure
+  // `draftFromTemplate`/`buildPublishPolicy` call outside the component, never through the full
+  // click -> persistDraft -> publish sequence).
+  it('CREATE mode: unchecking allowRevoke and publishing in the SAME sitting reaches the server (was silently discarded)', async () => {
+    await mountView()
+    setInput('approval-template-key', 'purchase')
+    setInput('approval-template-name', '采购审批')
+
+    const checkbox = container!.querySelector('[data-testid="approval-template-allow-revoke"]') as HTMLInputElement
+    expect(checkbox.checked).toBe(true) // create-time default
+    checkbox.checked = false
+    checkbox.dispatchEvent(new Event('change'))
+    await flushUi()
+
+    ;(container!.querySelector('[data-testid="approval-template-publish-button"]') as HTMLButtonElement).click()
+    await flushUi()
+    const confirmButton = container!.querySelector('[data-testid="approval-publish-checklist-confirm"]') as HTMLButtonElement
+    confirmButton.click()
+    await flushUi()
+
+    expect(publishTemplateSpy).toHaveBeenCalledWith('tpl_created', { policy: { allowRevoke: false } })
+  })
+
+  it('UPDATE mode: unchecking allowRevoke on an EXISTING published template and publishing in the SAME sitting reaches the server (was silently discarded)', async () => {
+    routeParams = { id: 'tpl_seq' }
+    // The REAL backend's PATCH response carries the active published policy forward unchanged
+    // (Lock-6 L6-P1) — this override matches that contract; the shared beforeEach default omits
+    // `policy` entirely, which would mask this exact bug behind an unrealistic mock.
+    updateTemplateSpy.mockImplementation(async (id: string, payload: Record<string, unknown>) => ({
+      ...buildTemplate({ id, status: 'published', activeVersionId: 'ver_1', policy: { allowRevoke: true } }),
+      ...payload,
+    }))
+    getTemplateSpy.mockResolvedValue(buildTemplate({ id: 'tpl_seq', status: 'published', activeVersionId: 'ver_1', policy: { allowRevoke: true } }))
+    await mountView()
+    await flushUi()
+
+    const checkbox = container!.querySelector('[data-testid="approval-template-allow-revoke"]') as HTMLInputElement
+    expect(checkbox.checked).toBe(true)
+    checkbox.checked = false
+    checkbox.dispatchEvent(new Event('change'))
+    await flushUi()
+
+    ;(container!.querySelector('[data-testid="approval-template-publish-button"]') as HTMLButtonElement).click()
+    await flushUi()
+    const confirmButton = container!.querySelector('[data-testid="approval-publish-checklist-confirm"]') as HTMLButtonElement
+    confirmButton.click()
+    await flushUi()
+
+    expect(publishTemplateSpy).toHaveBeenCalledWith('tpl_seq', { policy: { allowRevoke: false } })
+  })
+
+  it('positive control: republishing WITHOUT touching allowRevoke still carries the persisted value unchanged (the fix does not disturb the untouched round trip, gate P-1)', async () => {
+    routeParams = { id: 'tpl_seq_untouched' }
+    updateTemplateSpy.mockImplementation(async (id: string, payload: Record<string, unknown>) => ({
+      ...buildTemplate({ id, status: 'published', activeVersionId: 'ver_1', policy: { allowRevoke: false } }),
+      ...payload,
+    }))
+    getTemplateSpy.mockResolvedValue(buildTemplate({ id: 'tpl_seq_untouched', status: 'published', activeVersionId: 'ver_1', policy: { allowRevoke: false } }))
+    await mountView()
+    await flushUi()
+
+    const checkbox = container!.querySelector('[data-testid="approval-template-allow-revoke"]') as HTMLInputElement
+    expect(checkbox.checked).toBe(false) // hydrated, untouched
+
+    ;(container!.querySelector('[data-testid="approval-template-publish-button"]') as HTMLButtonElement).click()
+    await flushUi()
+    const confirmButton = container!.querySelector('[data-testid="approval-publish-checklist-confirm"]') as HTMLButtonElement
+    confirmButton.click()
+    await flushUi()
+
+    expect(publishTemplateSpy).toHaveBeenCalledWith('tpl_seq_untouched', { policy: { allowRevoke: false } })
+  })
+
   // B3-09 (模板治理 — 发布说明): the checklist dialog carries an OPTIONAL note; typed → trimmed and
   // sent, untyped/whitespace-only → the payload has NO note key (byte-identical to pre-B3-09 wire).
   it('B3-09: publishes with a trimmed note when one is typed in the checklist dialog', async () => {


### PR DESCRIPTION
## Summary

- `confirmPublish()` called `persistDraft()` first, then read `draft.value` for the publish payload. `persistDraft()` REPLACES `draft.value` wholesale via `draftFromTemplate(saved)`, re-deriving `allowRevoke` (and, once P3-B/#lands-next lands, the L6-A dedup tier) from `saved.policy`. `policy` is a publish-only argument — it never travels through the create/update payload or response (Lock-6 §0: *"policy is a PUBLISH argument, never a template/version column"*) — so `saved.policy` can only ever echo the LAST-PUBLISHED policy (or nothing, for a template that has never published). Reading `draft.value` AFTER `persistDraft()` therefore silently discarded any in-progress, not-yet-published edit an admin made in the same sitting: the `allowRevoke` checkbox was fully interactive and its DOM state was correct, but toggling it and immediately publishing sent the OLD value to the server.
- **Provenance**: this is the L6-P1 adversarial gate's F3 finding — independently reproduced here via two component-level probes (create mode and update mode, since deleted, not committed as-is) during P3-B/L6-A work, discovered before any P3-B code was added. Confirmed pre-existing on unmodified `origin/main` and unrelated to the new dedup-tier control, which would have inherited the identical defect (pick a tier, publish in the same sitting → silently discarded).
- **Fix**: snapshot `buildPublishPolicy(draft.value)` BEFORE calling `persistDraft()`, and publish that snapshot instead of re-reading `draft.value` afterward. Does not change `persistDraft`, `draftFromTemplate`, or hydrate behavior at all — an untouched draft's snapshot is byte-identical to what the old post-`persistDraft` read would have produced, so the existing P-1/P-2 round-trip gates (docs/development/approval-lock6-requester-global-policy-20260817.md §3) are unaffected; only an in-session edit now survives to publish.

## Test plan

- New: `apps/web/tests/approvalTemplateAuthoring.spec.ts` — CREATE-mode and UPDATE-mode regressions (uncheck `allowRevoke`, publish in the same sitting, assert the payload reflects `false`) plus a positive control (republish WITHOUT touching the control still carries the persisted value unchanged — proves the fix doesn't disturb the untouched round trip).
- Mutation-verified via `cp`-backup + sha256 restore (never `git checkout --`): reverting the snapshot-before-`persistDraft` ordering turns both regressions red (`expected allowRevoke:false, received allowRevoke:true`) while the positive control stays green; restoring turns them green again.
- `npx vitest run approvalTemplateAuthoring.spec.ts` — 97/97 pass. `npx vitest run approval-template-authoring-policy-carrier` (the L6-P1 gates) — 9/9 pass, unaffected.
- `vue-tsc --noEmit` — clean.

## Scope

Frontend-only, one file (`TemplateAuthoringView.vue`) plus its spec. Does not change what `allowRevoke` means, does not touch the backend, does not touch the wizard step count or any More-settings surface. This is a prerequisite for the upcoming L6-A dedup-tier control (master §P3-B / Lock-6 §1) — without it, that control would be silently non-functional the first time an admin sets it and immediately publishes, which is the common case.

Not merging — merge order and RATIFY decisions stay with the requesting session.