### PR TITLE
feat(approval): P3-B — More-settings fifth step + L6-A template dedup tier

### DIFF
--- a/apps/web/src/approvals/templateAuthoring.ts
+++ b/apps/web/src/approvals/templateAuthoring.ts
@@ -213,6 +213,17 @@ export interface TemplateAuthoringDraft {
   // mirrors the `originalAutoApprovalPolicy` / `amountConsistencyCheck` preserve-verbatim pattern
   // already used in this file.
   originalPolicy?: RuntimePolicy | null
+  /**
+   * P3-B / Lock-6 L6-A (docs/development/approval-lock6-requester-global-policy-20260817.md §1) —
+   * the editable projection of the TEMPLATE-level dedup tier. Mirrors the node-level
+   * `mergeWithRequester` / `originalAutoApprovalPolicy` pattern immediately below: this is the ONE
+   * sub-field of `originalPolicy.autoApproval` the editor authors; every other key (and the
+   * both-flags-true combination this tier cannot express) survives verbatim via
+   * `buildTemplateAutoApprovalPolicy`, which reads `originalPolicy.autoApproval` directly rather
+   * than reconstructing it from this field alone. See `templateDedupTierFromPolicy` /
+   * `isTemplateDedupTierLocked` for the hydrate-time projection and lock detection.
+   */
+  autoApprovalDedupTier: TemplateDedupTier
   fields: FieldAuthoringDraft[]
   steps: ApprovalStepDraft[]
   // G-1 anti-flatten keystone: a COMPLEX graph (any cc/condition/parallel node, or any
@@ -382,6 +393,9 @@ export function createEmptyTemplateDraft(): TemplateAuthoringDraft {
     // stays the client-chosen create-time default, unchanged by the carrier fix below —
     // `originalPolicy` is correctly left absent (nothing to preserve yet).
     allowRevoke: true,
+    // §2.2 "no shipped default may change": absent `autoApproval` === 不去重 for a brand-new
+    // template, exactly like every pre-P3-B published template.
+    autoApprovalDedupTier: 'none',
     fields: [createEmptyFieldDraft(1)],
     steps: [createEmptyStepDraft(1)],
   }
@@ -978,6 +992,11 @@ export function draftFromTemplate(template: ApprovalTemplateDetailDTO): Template
     // absent `policy` (never-published template) keeps the create-time default of `true`.
     allowRevoke: template.policy?.allowRevoke ?? true,
     originalPolicy: template.policy ?? null,
+    // P3-B / Lock-6 L6-A — projects the hydrated `policy.autoApproval` onto the 3-way tier. Reads
+    // `template.policy?.autoApproval` (not `originalPolicy` above, though they are the same value)
+    // for clarity that this is a pure function of the persisted definition, matching
+    // `templateDedupTierFromPolicy`'s own signature.
+    autoApprovalDedupTier: templateDedupTierFromPolicy(template.policy?.autoApproval),
     // Hydrate side of the #3161 §1 preserve: carry the amount total-check mapping through verbatim
     // (shallow clone, never alias the source schema). Absent → no key (no phantom on round-trip).
     ...(template.formSchema.amountConsistencyCheck
@@ -1612,19 +1631,92 @@ export function buildUpdateTemplatePayload(draft: TemplateAuthoringDraft): Updat
 }
 
 /**
+ * P3-B / Lock-6 L6-A (docs/development/approval-lock6-requester-global-policy-20260817.md §1) —
+ * the template-level 审批人去重 tier. A 3-way projection over the SAME two booleans the backend
+ * already server-enforces on `runtimeGraph.policy.autoApproval` (Lock-4 §2.6 /
+ * `evaluateAutoApprovalAssignment`): `dedupeHistoricalApprover` (仅一次全自动同意) and
+ * `mergeAdjacentApprover` (仅连续节点自动同意). `mergeWithRequester` is deliberately NOT part of this
+ * tier — it stays a NODE-level-only field authored via the existing per-step
+ * `mergeWithRequester` / `originalAutoApprovalPolicy` pair, never through this template control.
+ */
+export type TemplateDedupTier = 'none' | 'dedupe_historical' | 'merge_adjacent'
+
+/**
+ * Lock-6 §2.6 / gate X-1 (M4 unknown-persisted-values-stay-round-trip-safe) — a persisted policy
+ * with BOTH booleans true is a combination this 3-way tier cannot express (the tier is a strict
+ * partition: 不去重 / 仅一次全自动同意 / 仅连续节点自动同意, never "both"). `buildTemplateAutoApprovalPolicy`
+ * must preserve that combination byte-unchanged rather than collapsing it onto any single tier.
+ */
+export function isTemplateDedupTierLocked(autoApproval?: AutoApprovalPolicy | null): boolean {
+  return Boolean(autoApproval?.dedupeHistoricalApprover === true && autoApproval?.mergeAdjacentApprover === true)
+}
+
+/**
+ * Hydrate-time projection: absent `autoApproval`, or absent/false on both flags, is 不去重 (§2.2 "no
+ * shipped default may change" — byte-stable for every existing template). The locked (both-true)
+ * combination also projects to `'none'` here PURELY for a deterministic radio value; the component
+ * gates on `isTemplateDedupTierLocked` to render that state read-only, and
+ * `buildTemplateAutoApprovalPolicy` independently re-checks the SAME predicate against
+ * `originalPolicy` (not this projected tier) before ever touching the publish payload — so a
+ * locked template can never be saved as if the author had picked 不去重.
+ */
+export function templateDedupTierFromPolicy(autoApproval?: AutoApprovalPolicy | null): TemplateDedupTier {
+  if (!autoApproval || isTemplateDedupTierLocked(autoApproval)) return 'none'
+  if (autoApproval.dedupeHistoricalApprover === true) return 'dedupe_historical'
+  if (autoApproval.mergeAdjacentApprover === true) return 'merge_adjacent'
+  return 'none'
+}
+
+/**
+ * Builds the template-level `autoApproval` object `buildPublishPolicy` carries onto the publish
+ * payload. Two disjoint paths, chosen by re-reading `draft.originalPolicy.autoApproval` (NOT the
+ * projected `draft.autoApprovalDedupTier`) for the lock check every time, so a stale in-memory tier
+ * value can never accidentally unlock a save:
+ *
+ *   - LOCKED (§2.6/X-1, both flags true in the hydrated original): return the original object
+ *     VERBATIM. The tier control never touched it — this is preservation, not a no-op default.
+ *   - editable: project `draft.autoApprovalDedupTier` onto the two tier-owned keys, but PRESERVE
+ *     every OTHER key already present on the hydrated `autoApproval` (e.g. a `mergeWithRequester`
+ *     or `actorMode` some other API caller set directly on the template-level object — extremely
+ *     unlikely in practice, but this control must never be the mechanism that destroys it).
+ *
+ * Omits the whole `autoApproval` key when the result is empty, matching the node-level
+ * `autoApprovalPolicy`-omit-when-empty convention elsewhere in this file (and §2.2: absent ===
+ * 不去重 === today's behavior).
+ */
+export function buildTemplateAutoApprovalPolicy(draft: TemplateAuthoringDraft): AutoApprovalPolicy | undefined {
+  const original = draft.originalPolicy?.autoApproval
+  if (isTemplateDedupTierLocked(original)) return original
+
+  const preserved: AutoApprovalPolicy = { ...(original ?? {}) }
+  delete preserved.dedupeHistoricalApprover
+  delete preserved.mergeAdjacentApprover
+  if (draft.autoApprovalDedupTier === 'dedupe_historical') preserved.dedupeHistoricalApprover = true
+  else if (draft.autoApprovalDedupTier === 'merge_adjacent') preserved.mergeAdjacentApprover = true
+
+  return Object.keys(preserved).length > 0 ? preserved : undefined
+}
+
+/**
  * L6-P1 carrier fix — the publish-time policy payload. MERGES onto `draft.originalPolicy`
- * (the persisted object hydrated verbatim by `draftFromTemplate`) and overlays only the field the
- * editor actually owns (`allowRevoke`). Was previously built inline at the call site as
- * `{ allowRevoke: draft.allowRevoke }` — a REPLACE, not a merge — which silently destroyed any
- * sibling policy field (e.g. `autoApproval`, `revokeBeforeNodeKeys`) set only through the publish
- * API on every editor republish. `draft.originalPolicy` is absent for a template that has never
- * been published, so a brand-new template still publishes exactly `{ allowRevoke }` (no field is
- * invented). The backend's `assertRuntimePolicy` re-validates every carried-through key, so
- * publishing a stale/foreign shape here fails closed there rather than persisting silently.
+ * (the persisted object hydrated verbatim by `draftFromTemplate`) and overlays only the fields the
+ * editor actually owns (`allowRevoke`, and now the P3-B dedup tier's projection of `autoApproval`).
+ * Was previously built inline at the call site as `{ allowRevoke: draft.allowRevoke }` — a REPLACE,
+ * not a merge — which silently destroyed any sibling policy field (e.g. `autoApproval`,
+ * `revokeBeforeNodeKeys`) set only through the publish API on every editor republish.
+ * `draft.originalPolicy` is absent for a template that has never been published, so a brand-new
+ * template still publishes exactly `{ allowRevoke }` (no field is invented — a fresh draft's
+ * `autoApprovalDedupTier` defaults to `'none'`, which `buildTemplateAutoApprovalPolicy` projects to
+ * `undefined`/omitted, not an empty object). The backend's `assertRuntimePolicy` re-validates every
+ * carried-through key, so publishing a stale/foreign shape here fails closed there rather than
+ * persisting silently.
  */
 export function buildPublishPolicy(draft: TemplateAuthoringDraft): RuntimePolicy {
+  const { autoApproval: _originalAutoApproval, ...restOriginalPolicy } = draft.originalPolicy ?? {}
+  const autoApproval = buildTemplateAutoApprovalPolicy(draft)
   return {
-    ...(draft.originalPolicy ?? {}),
+    ...restOriginalPolicy,
     allowRevoke: draft.allowRevoke,
+    ...(autoApproval ? { autoApproval } : {}),
   }
 }

--- a/apps/web/src/types/approval.ts
+++ b/apps/web/src/types/approval.ts
@@ -224,13 +224,16 @@ export interface RuntimePolicy {
   allowRevoke: boolean
   revokeBeforeNodeKeys?: string[]
   /**
-   * L6-P1 carrier fix — opaque pass-through for a template-level policy field the authoring
-   * editor does not render (e.g. a future auto-approval dedup tier, settable only through the
-   * publish API today). `unknown`, never interpreted here: the editor's job is to round-trip it
-   * unchanged via `buildPublishPolicy`, not to understand its shape. Adding a new typed field
-   * belongs to whichever slice authors that control.
+   * L6-P1 carrier fix landed this as an opaque pass-through (`unknown`) — the authoring editor did
+   * not yet render a template-level control. P3-B / Lock-6 L6-A (docs/development/approval-lock6-
+   * requester-global-policy-20260817.md §1) is that slice: the template-level dedup tier projects
+   * onto the SAME `AutoApprovalPolicy` shape node-level `autoApprovalPolicy` already uses (byte-
+   * mirrors backend `RuntimePolicy.autoApproval?: AutoApprovalPolicy`), so it is typed here rather
+   * than left opaque. Any FIELD this editor does not author (e.g. a future `actorMode`) still
+   * survives round-trip verbatim — `buildTemplateAutoApprovalPolicy` (templateAuthoring.ts) merges
+   * onto the hydrated object rather than reconstructing it from scratch.
    */
-  autoApproval?: unknown
+  autoApproval?: AutoApprovalPolicy
 }
 
 export interface RuntimeGraph extends ApprovalGraph {

--- a/apps/web/src/views/approval/TemplateAuthoringView.vue
+++ b/apps/web/src/views/approval/TemplateAuthoringView.vue
@@ -842,6 +842,22 @@
             <p class="template-authoring__hint">
               同一审批人在流程中再次出现时按所选规则自动通过该节点，无需重复处理；仅对未单独设置去重规则的审批节点生效，返回上一节点后该节点重新计入本轮去重历史。
             </p>
+            <!-- M8 honesty (adversarial-gate P3-1, PR #4967): mergeAdjacentApprover has a second,
+                 real server effect beyond the dedup cascade — it also exempts the graph from two
+                 publish-time duplicate-assignee checks for a parallel gateway (the static branch
+                 check `allowParallelDuplicateAssignees` and the dynamic-source preflight
+                 `assertNoParallelDynamicAssigneeConflicts`, ApprovalProductService.ts:4595/:4623-4625),
+                 because the merge machinery legitimately absorbs the same-approver overlap at
+                 runtime instead of leaving it to 409. Undisclosed, an admin could not know why a
+                 previously-rejected parallel graph now publishes. Scoped to the ACTUAL exemption
+                 (parallel branches only) — no other semantic invented. -->
+            <p
+              v-if="draft.autoApprovalDedupTier === 'merge_adjacent'"
+              class="template-authoring__hint"
+              data-testid="approval-template-dedup-tier-merge-adjacent-hint"
+            >
+              选择该项还会放宽并行分支的发布校验：同一审批人出现在同一并行网关的多个分支中不再阻止发布，运行时会自动跳过重复分支的指派。
+            </p>
             <p
               v-if="isAutoApprovalDedupTierLocked"
               class="template-authoring__hint template-authoring__hint--warn"

--- a/apps/web/src/views/approval/TemplateAuthoringView.vue
+++ b/apps/web/src/views/approval/TemplateAuthoringView.vue
@@ -807,6 +807,52 @@
         </div>
       </el-card>
 
+      <!-- P3-B / Lock-6 L6-A (docs/development/approval-lock6-requester-global-policy-20260817.md §1,
+           §2.7) — the fifth wizard step. M7 (master §4 P3-B exit): this step is authorized ONLY because
+           it now carries one REAL, server-enforced control (the template-level dedup tier); it does not
+           exist as an empty/disabled shell. The tier is an immediate-apply typed control — no separate
+           Save/Cancel transaction, matching the D0 grammar the rest of this view already uses (e.g.
+           `draft.allowRevoke` above). -->
+      <el-card v-show="activeAuthoringSection === 'more-settings'" class="template-authoring__panel" shadow="never">
+        <template #header>
+          <strong>更多设置</strong>
+        </template>
+        <el-form label-position="top" class="template-authoring__grid">
+          <el-form-item label="审批人去重" class="template-authoring__wide">
+            <!-- L6-A shape (Lock-4 OD-L4-6(a)): a 3-way tier projected over the two ALREADY
+                 server-enforced booleans `dedupeHistoricalApprover` / `mergeAdjacentApprover` on
+                 `runtimeGraph.policy.autoApproval` — no new engine behavior, no new contract field.
+                 M8 honesty: labels name the EXACT shipped predicate (§1 L6-A / Lock-4 F4-D), not the
+                 corpus's broader "撤回撤销" framing this product does not implement. -->
+            <el-radio-group
+              v-model="draft.autoApprovalDedupTier"
+              :disabled="readOnly || isAutoApprovalDedupTierLocked"
+              data-testid="approval-template-dedup-tier"
+            >
+              <el-radio value="none" data-testid="approval-template-dedup-tier-none">
+                不去重
+              </el-radio>
+              <el-radio value="dedupe_historical" data-testid="approval-template-dedup-tier-dedupe-historical">
+                仅一次全自动同意
+              </el-radio>
+              <el-radio value="merge_adjacent" data-testid="approval-template-dedup-tier-merge-adjacent">
+                仅连续节点自动同意
+              </el-radio>
+            </el-radio-group>
+            <p class="template-authoring__hint">
+              同一审批人在流程中再次出现时按所选规则自动通过该节点，无需重复处理；仅对未单独设置去重规则的审批节点生效，返回上一节点后该节点重新计入本轮去重历史。
+            </p>
+            <p
+              v-if="isAutoApprovalDedupTierLocked"
+              class="template-authoring__hint template-authoring__hint--warn"
+              data-testid="approval-template-dedup-tier-locked-hint"
+            >
+              当前已通过接口设置了本控件无法表达的去重组合，已保持只读并原样保留，不会被此处的选择覆盖。
+            </p>
+          </el-form-item>
+        </el-form>
+      </el-card>
+
       <!-- D1 ordinary-user hygiene: JSON formSchema/approvalGraph preview removed from the review
            step. Payload builders are unchanged; try-run remains the user-facing dry-run surface. -->
 
@@ -1173,6 +1219,7 @@ import {
   type ApprovalNodeSourceEdit,
   type TemplateAuthoringDraft,
   moveItemToIndex,
+  isTemplateDedupTierLocked,
 } from '../../approvals/templateAuthoring'
 import {
   addConditionBranch,
@@ -1362,7 +1409,13 @@ watch(
   { immediate: true },
 )
 
-type AuthoringSectionId = 'basic' | 'fields' | 'flow' | 'review'
+// P3-B / Lock-6 §2.7 (docs/development/approval-lock6-requester-global-policy-20260817.md):
+// "Activation is a typed change to the AuthoringSectionId union and the authoringSections array
+// ... performed by the SAME PR that lands the functional L6-A control". This PR lands the L6-A
+// dedup-tier control (below) in the SAME commit as this activation — the fifth step, `更多设置`,
+// is never an empty/disabled shell (master M7); it exists BECAUSE the tier control it hosts is now
+// real and server-enforced. `测试发布` stays last, unconditionally.
+type AuthoringSectionId = 'basic' | 'fields' | 'flow' | 'more-settings' | 'review'
 const authoringSections: Array<{
   id: AuthoringSectionId
   label: string
@@ -1371,6 +1424,7 @@ const authoringSections: Array<{
   { id: 'basic', label: '基础信息', description: '名称、范围与模板起点' },
   { id: 'fields', label: '表单设计', description: '字段、校验与显隐规则' },
   { id: 'flow', label: '流程设计', description: '审批人、分支与字段权限' },
+  { id: 'more-settings', label: '更多设置', description: '审批人去重等模板级策略' },
   { id: 'review', label: '测试发布', description: '预览、试运行与发布检查' },
 ]
 const activeAuthoringSection = ref<AuthoringSectionId>('basic')
@@ -1431,6 +1485,14 @@ const basicInfoIssues = computed<AuthoringValidationIssue[]>(() => (
   validateTemplateBasicInfo(draft.value, unsupportedReason.value)
 ))
 const basicInfoIssueCount = computed<number>(() => basicInfoIssues.value.length)
+
+// P3-B / Lock-6 §2.6, gate X-1 — a persisted template with BOTH dedup booleans true is a
+// combination the 3-way tier cannot express. Reads the HYDRATED `originalPolicy`, not the
+// projected `draft.autoApprovalDedupTier`, so the lock state is derived from the actual persisted
+// definition every time, not from whatever the radio group last rendered.
+const isAutoApprovalDedupTierLocked = computed<boolean>(() => (
+  isTemplateDedupTierLocked(draft.value.originalPolicy?.autoApproval)
+))
 
 function scrollAuthoringTarget(target: HTMLElement | null, focus = false) {
   if (!target) return

--- a/apps/web/tests/approval-template-authoring-policy-carrier.test.ts
+++ b/apps/web/tests/approval-template-authoring-policy-carrier.test.ts
@@ -2,8 +2,11 @@ import { describe, expect, it } from 'vitest'
 import type { ApprovalGraph, ApprovalTemplateDetailDTO, RuntimePolicy } from '../src/types/approval'
 import {
   buildPublishPolicy,
+  buildTemplateAutoApprovalPolicy,
   createEmptyTemplateDraft,
   draftFromTemplate,
+  isTemplateDedupTierLocked,
+  templateDedupTierFromPolicy,
 } from '../src/approvals/templateAuthoring'
 
 // L6-P1 (docs/development/approval-lock6-requester-global-policy-20260817.md §1) — the
@@ -133,5 +136,128 @@ describe('L6-P1 buildPublishPolicy — MERGE onto the persisted policy, not a re
   it('a brand-new template (no originalPolicy) publishes exactly { allowRevoke } — no field invented', () => {
     const draft = createEmptyTemplateDraft()
     expect(buildPublishPolicy(draft)).toEqual({ allowRevoke: true })
+  })
+})
+
+// P3-B / Lock-6 L6-A (docs/development/approval-lock6-requester-global-policy-20260817.md §1) —
+// the More-settings dedup-tier control, built on the L6-P1 carrier above. `dedupeHistoricalApprover`
+// / `mergeAdjacentApprover` are ALREADY server-enforced (Lock-4 §2.6); this control only authors the
+// 3-way projection over them. §2.2: absent === 不去重 === today's behavior for every existing
+// template (byte-stable). §2.6/X-1: an unrepresentable both-true combination stays read-only and
+// round-trips unchanged. §2.3: the tier must round-trip through hydrate -> edit -> publish alongside
+// allowRevoke and revokeBeforeNodeKeys without clobbering either sibling.
+describe('P3-B templateDedupTierFromPolicy — hydrate-time tier projection', () => {
+  it('absent autoApproval projects to none (a never-published template)', () => {
+    expect(templateDedupTierFromPolicy(undefined)).toBe('none')
+  })
+
+  it('both flags false/absent projects to none', () => {
+    expect(templateDedupTierFromPolicy({})).toBe('none')
+  })
+
+  it('dedupeHistoricalApprover:true projects to dedupe_historical', () => {
+    expect(templateDedupTierFromPolicy({ dedupeHistoricalApprover: true })).toBe('dedupe_historical')
+  })
+
+  it('mergeAdjacentApprover:true projects to merge_adjacent', () => {
+    expect(templateDedupTierFromPolicy({ mergeAdjacentApprover: true })).toBe('merge_adjacent')
+  })
+
+  it('both true (the unrepresentable combination) projects to none for DISPLAY purposes only — the component gates on isTemplateDedupTierLocked, not this value, before ever rendering it editable', () => {
+    expect(templateDedupTierFromPolicy({ dedupeHistoricalApprover: true, mergeAdjacentApprover: true })).toBe('none')
+  })
+})
+
+describe('P3-B isTemplateDedupTierLocked — gate X-1 (unknown persisted values stay read-only)', () => {
+  it('both flags true is locked', () => {
+    expect(isTemplateDedupTierLocked({ dedupeHistoricalApprover: true, mergeAdjacentApprover: true })).toBe(true)
+  })
+
+  it('positive control: a single-tier value is NOT locked (editable) — the branch is value-selected', () => {
+    expect(isTemplateDedupTierLocked({ dedupeHistoricalApprover: true })).toBe(false)
+    expect(isTemplateDedupTierLocked({ mergeAdjacentApprover: true })).toBe(false)
+    expect(isTemplateDedupTierLocked(undefined)).toBe(false)
+    expect(isTemplateDedupTierLocked({})).toBe(false)
+  })
+})
+
+describe('P3-B buildTemplateAutoApprovalPolicy + buildPublishPolicy — the dedup tier round-trips without clobbering siblings', () => {
+  it('hydrate -> edit -> publish: selecting a tier on a NEW template publishes exactly that tier, alongside allowRevoke', () => {
+    const draft = createEmptyTemplateDraft()
+    draft.autoApprovalDedupTier = 'dedupe_historical'
+    const published = buildPublishPolicy(draft)
+    expect(published).toEqual({ allowRevoke: true, autoApproval: { dedupeHistoricalApprover: true } })
+  })
+
+  it('switching FROM dedupe_historical TO merge_adjacent republishes the NEW tier only (never both)', () => {
+    const template = buildTemplate({ allowRevoke: true, autoApproval: { dedupeHistoricalApprover: true } })
+    const draft = draftFromTemplate(template)
+    expect(draft.autoApprovalDedupTier).toBe('dedupe_historical')
+    draft.autoApprovalDedupTier = 'merge_adjacent'
+    expect(buildPublishPolicy(draft)).toEqual({ allowRevoke: true, autoApproval: { mergeAdjacentApprover: true } })
+  })
+
+  it('switching a tier back to none OMITS autoApproval entirely (matches the absent-is-不去重 convention, not an empty object)', () => {
+    const template = buildTemplate({ allowRevoke: true, autoApproval: { dedupeHistoricalApprover: true } })
+    const draft = draftFromTemplate(template)
+    draft.autoApprovalDedupTier = 'none'
+    const published = buildPublishPolicy(draft)
+    expect(published).toEqual({ allowRevoke: true })
+    expect('autoApproval' in published).toBe(false)
+  })
+
+  it('MUTATION-style regression guard: the dedup field is NOT dropped by a republish that also changes allowRevoke — both survive together', () => {
+    const template = buildTemplate({ allowRevoke: true, autoApproval: { mergeAdjacentApprover: true } })
+    const draft = draftFromTemplate(template)
+    draft.allowRevoke = false // editor changes the OTHER field in the same save
+    const published = buildPublishPolicy(draft)
+    // Positive control half: allowRevoke DID change.
+    expect(published.allowRevoke).toBe(false)
+    // Gate half: the untouched dedup tier survived the same publish call.
+    expect(published.autoApproval).toEqual({ mergeAdjacentApprover: true })
+  })
+
+  it('MUTATION-style regression guard: revokeBeforeNodeKeys is NOT clobbered by a dedup-tier change', () => {
+    const template = buildTemplate({
+      allowRevoke: true,
+      revokeBeforeNodeKeys: ['approval_1'],
+      autoApproval: { dedupeHistoricalApprover: true },
+    })
+    const draft = draftFromTemplate(template)
+    draft.autoApprovalDedupTier = 'merge_adjacent'
+    const published = buildPublishPolicy(draft)
+    expect(published.revokeBeforeNodeKeys).toEqual(['approval_1'])
+    expect(published.autoApproval).toEqual({ mergeAdjacentApprover: true })
+  })
+
+  it('gate X-1: a locked (both-true) persisted combination republishes BYTE-UNCHANGED even though the draft tier field cannot represent it', () => {
+    const locked: RuntimePolicy = {
+      allowRevoke: true,
+      autoApproval: { dedupeHistoricalApprover: true, mergeAdjacentApprover: true },
+    }
+    const template = buildTemplate(locked)
+    const draft = draftFromTemplate(template)
+    expect(isTemplateDedupTierLocked(draft.originalPolicy?.autoApproval)).toBe(true)
+    // Even if some code path mutated the (locked, ignored) draft tier field, the lock check reads
+    // originalPolicy directly — this is the discriminating case: it does NOT trust the draft field.
+    draft.autoApprovalDedupTier = 'merge_adjacent'
+    const published = buildPublishPolicy(draft)
+    expect(published.autoApproval).toEqual({ dedupeHistoricalApprover: true, mergeAdjacentApprover: true })
+  })
+
+  it('preserves an unrelated autoApproval sibling key (e.g. actorMode, settable only through the API) across a tier change', () => {
+    const template = buildTemplate({
+      allowRevoke: true,
+      autoApproval: { dedupeHistoricalApprover: true, actorMode: 'original_approver' },
+    })
+    const draft = draftFromTemplate(template)
+    draft.autoApprovalDedupTier = 'merge_adjacent'
+    const published = buildPublishPolicy(draft)
+    expect(published.autoApproval).toEqual({ actorMode: 'original_approver', mergeAdjacentApprover: true })
+  })
+
+  it('buildTemplateAutoApprovalPolicy returns undefined (not {}) for a tier-less, sibling-less draft', () => {
+    const draft = createEmptyTemplateDraft()
+    expect(buildTemplateAutoApprovalPolicy(draft)).toBeUndefined()
   })
 })

--- a/apps/web/tests/approvalTemplateAuthoring.spec.ts
+++ b/apps/web/tests/approvalTemplateAuthoring.spec.ts
@@ -1,6 +1,6 @@
 /* eslint-disable vue/one-component-per-file, vue/require-default-prop */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { computed, createApp, defineComponent, h, nextTick, ref, type App as VueApp } from 'vue'
+import { computed, createApp, defineComponent, h, inject, nextTick, provide, ref, type App as VueApp, type InjectionKey } from 'vue'
 import TemplateAuthoringView from '../src/views/approval/TemplateAuthoringView.vue'
 import type { ApprovalNodeConfig, ApprovalTemplateDetailDTO, AutoApprovalPolicy } from '../src/types/approval'
 import { APPROVAL_ROLE_CONFIGURE_SENTINEL } from '../src/types/approval'
@@ -169,6 +169,53 @@ const ElCheckbox = defineComponent({
   },
 })
 
+// P3-B (docs/development/approval-lock6-requester-global-policy-20260817.md §1 L6-A) — the
+// dedup-tier control uses <el-radio-group>/<el-radio>, previously unused (and unstubbed) anywhere
+// in this authoring view. Mirrors real Element Plus's provide/inject wiring closely enough for
+// tests: the group provides its modelValue + updater, each radio reads/writes through it.
+const RADIO_GROUP_KEY: InjectionKey<{
+  modelValue: () => unknown
+  update: (value: unknown) => void
+  disabled: () => boolean
+}> = Symbol('RadioGroup')
+
+const ElRadioGroup = defineComponent({
+  name: 'ElRadioGroup',
+  inheritAttrs: false,
+  props: { modelValue: [String, Number, Boolean], disabled: Boolean },
+  emits: ['update:modelValue'],
+  setup(props, { emit, attrs, slots }) {
+    provide(RADIO_GROUP_KEY, {
+      modelValue: () => props.modelValue,
+      update: (value: unknown) => emit('update:modelValue', value),
+      disabled: () => Boolean(props.disabled),
+    })
+    return () => h('div', {
+      'data-testid': (attrs as any)?.['data-testid'],
+      role: 'radiogroup',
+    }, slots.default?.())
+  },
+})
+
+const ElRadio = defineComponent({
+  name: 'ElRadio',
+  inheritAttrs: false,
+  props: { value: [String, Number, Boolean], disabled: Boolean },
+  setup(props, { attrs, slots }) {
+    const group = inject(RADIO_GROUP_KEY, null)
+    return () => h('label', [
+      h('input', {
+        type: 'radio',
+        checked: group ? group.modelValue() === props.value : false,
+        disabled: Boolean(props.disabled) || Boolean(group?.disabled()),
+        'data-testid': (attrs as any)?.['data-testid'],
+        onChange: () => group?.update(props.value),
+      }),
+      slots.default?.(),
+    ])
+  },
+})
+
 const ElTable = defineComponent({
   name: 'ElTable',
   props: { data: Array },
@@ -232,6 +279,8 @@ function installStubs(app: VueApp<Element>) {
   app.component('ElSelect', ElSelect)
   app.component('ElOption', ElOption)
   app.component('ElCheckbox', ElCheckbox)
+  app.component('ElRadioGroup', ElRadioGroup)
+  app.component('ElRadio', ElRadio)
   app.component('ElAlert', ElAlert)
   app.component('ElDialog', ElDialog)
   app.component('ElTable', ElTable)
@@ -2398,6 +2447,199 @@ describe('TemplateAuthoringView', () => {
     confirmButton.click()
     await flushUi()
     expect(publishTemplateSpy).not.toHaveBeenCalled()
+  })
+
+  // P3-B / Lock-6 L6-A (docs/development/approval-lock6-requester-global-policy-20260817.md §1,
+  // §2.7). Master M7 (§4 P3-B exit): the fifth wizard step is authorized ONLY because it carries a
+  // REAL, server-enforced control (Lock-4 §2.6's dedup arms — already enforced by the backend; this
+  // PR adds only the authoring surface). These tests assert the census (M-2: no inert control), the
+  // structural activation (Lock-0 L0-4 / Lock-6 §2.7: 5 steps, 测试发布 last), and the round-trip
+  // through hydrate -> edit -> publish (including the locked both-true state, gate X-1).
+  describe('P3-B More-settings step — L6-A dedup tier (master M7, Lock-6 §1/§2.7/X-1)', () => {
+    it('activates exactly 5 steps: 更多设置 as step 4, 测试发布 last', async () => {
+      await mountView()
+      const stepIds = Array.from(container!.querySelectorAll('[data-testid^="approval-template-section-"]'))
+        .map((el) => el.getAttribute('data-testid'))
+        .filter((id): id is string => /^approval-template-section-(basic|fields|flow|more-settings|review)$/.test(id ?? ''))
+      expect(stepIds).toEqual([
+        'approval-template-section-basic',
+        'approval-template-section-fields',
+        'approval-template-section-flow',
+        'approval-template-section-more-settings',
+        'approval-template-section-review',
+      ])
+    })
+
+    it('M7/M-2 census: 更多设置 is NOT an empty shell — it renders the dedup-tier radio group with 3 real, distinct options', async () => {
+      await mountView()
+      ;(container!.querySelector('[data-testid="approval-template-section-more-settings"]') as HTMLButtonElement).click()
+      await flushUi()
+
+      const group = container!.querySelector('[data-testid="approval-template-dedup-tier"]')
+      expect(group).not.toBeNull()
+      expect(group!.querySelectorAll('input[type="radio"]').length).toBe(3)
+      expect(container!.querySelector('[data-testid="approval-template-dedup-tier-none"]')).not.toBeNull()
+      expect(container!.querySelector('[data-testid="approval-template-dedup-tier-dedupe-historical"]')).not.toBeNull()
+      expect(container!.querySelector('[data-testid="approval-template-dedup-tier-merge-adjacent"]')).not.toBeNull()
+    })
+
+    it('defaults to 不去重 (none) for a brand-new template — §2.2 no shipped default may change', async () => {
+      await mountView()
+      ;(container!.querySelector('[data-testid="approval-template-section-more-settings"]') as HTMLButtonElement).click()
+      await flushUi()
+      const noneInput = container!.querySelector('[data-testid="approval-template-dedup-tier-none"]') as HTMLInputElement
+      expect(noneInput.checked).toBe(true)
+    })
+
+    it('selecting a tier (immediate-apply, no separate save transaction) and publishing carries autoApproval alongside allowRevoke', async () => {
+      await mountView()
+      setInput('approval-template-key', 'purchase')
+      setInput('approval-template-name', '采购审批')
+      ;(container!.querySelector('[data-testid="approval-template-section-more-settings"]') as HTMLButtonElement).click()
+      await flushUi()
+
+      const dedupeInput = container!.querySelector('[data-testid="approval-template-dedup-tier-dedupe-historical"]') as HTMLInputElement
+      dedupeInput.checked = true
+      dedupeInput.dispatchEvent(new Event('change'))
+      await flushUi()
+
+      ;(container!.querySelector('[data-testid="approval-template-publish-button"]') as HTMLButtonElement).click()
+      await flushUi()
+      const confirmButton = container!.querySelector('[data-testid="approval-publish-checklist-confirm"]') as HTMLButtonElement
+      confirmButton.click()
+      await flushUi()
+
+      expect(publishTemplateSpy).toHaveBeenCalledWith('tpl_created', {
+        policy: { allowRevoke: true, autoApproval: { dedupeHistoricalApprover: true } },
+      })
+    })
+
+    it('hydrating a template with a persisted tier pre-selects the matching radio, and republishing WITHOUT touching it round-trips unchanged', async () => {
+      routeParams = { id: 'tpl_dedup_hydrate' }
+      const persistedPolicy = { allowRevoke: true, autoApproval: { mergeAdjacentApprover: true } }
+      getTemplateSpy.mockResolvedValue(buildTemplate({ id: 'tpl_dedup_hydrate', status: 'published', activeVersionId: 'ver_1', policy: persistedPolicy }))
+      // L6-P1 (docs/development/approval-lock6-requester-global-policy-20260817.md §1): the REAL
+      // backend's PATCH response carries the active published definition's policy forward
+      // unchanged (persistDraft() rebuilds `draft.value` from this response before publish reads
+      // it). The shared default mock in this file's beforeEach omits `policy` entirely — faithful
+      // for a template that has never been published, but NOT for this hydrate-from-published
+      // scenario, so this test overrides it to match the real, already-fixed contract.
+      updateTemplateSpy.mockImplementation(async (id: string, payload: Record<string, unknown>) => ({
+        ...buildTemplate({ id, status: 'published', activeVersionId: 'ver_1', policy: persistedPolicy }),
+        ...payload,
+      }))
+      await mountView()
+      await flushUi()
+      ;(container!.querySelector('[data-testid="approval-template-section-more-settings"]') as HTMLButtonElement).click()
+      await flushUi()
+
+      const mergeInput = container!.querySelector('[data-testid="approval-template-dedup-tier-merge-adjacent"]') as HTMLInputElement
+      expect(mergeInput.checked).toBe(true)
+
+      ;(container!.querySelector('[data-testid="approval-template-publish-button"]') as HTMLButtonElement).click()
+      await flushUi()
+      const confirmButton = container!.querySelector('[data-testid="approval-publish-checklist-confirm"]') as HTMLButtonElement
+      confirmButton.click()
+      await flushUi()
+
+      expect(publishTemplateSpy).toHaveBeenCalledWith('tpl_dedup_hydrate', {
+        policy: { allowRevoke: true, autoApproval: { mergeAdjacentApprover: true } },
+      })
+    })
+
+    it('gate X-1: a locked (both-true) persisted combination disables the radio group and republishing preserves it byte-unchanged', async () => {
+      routeParams = { id: 'tpl_dedup_locked' }
+      const persistedPolicy = { allowRevoke: true, autoApproval: { dedupeHistoricalApprover: true, mergeAdjacentApprover: true } }
+      getTemplateSpy.mockResolvedValue(buildTemplate({ id: 'tpl_dedup_locked', status: 'published', activeVersionId: 'ver_1', policy: persistedPolicy }))
+      // See the sibling hydrate test above for why this override is needed (L6-P1 §1 PATCH-response
+      // contract; the shared beforeEach default omits policy).
+      updateTemplateSpy.mockImplementation(async (id: string, payload: Record<string, unknown>) => ({
+        ...buildTemplate({ id, status: 'published', activeVersionId: 'ver_1', policy: persistedPolicy }),
+        ...payload,
+      }))
+      await mountView()
+      await flushUi()
+      ;(container!.querySelector('[data-testid="approval-template-section-more-settings"]') as HTMLButtonElement).click()
+      await flushUi()
+
+      const group = container!.querySelector('[data-testid="approval-template-dedup-tier"]')!
+      const radios = Array.from(group.querySelectorAll('input[type="radio"]')) as HTMLInputElement[]
+      expect(radios.length).toBe(3)
+      radios.forEach((radio) => expect(radio.disabled).toBe(true))
+      expect(container!.querySelector('[data-testid="approval-template-dedup-tier-locked-hint"]')).not.toBeNull()
+
+      ;(container!.querySelector('[data-testid="approval-template-publish-button"]') as HTMLButtonElement).click()
+      await flushUi()
+      const confirmButton = container!.querySelector('[data-testid="approval-publish-checklist-confirm"]') as HTMLButtonElement
+      confirmButton.click()
+      await flushUi()
+
+      expect(publishTemplateSpy).toHaveBeenCalledWith('tpl_dedup_locked', {
+        policy: { allowRevoke: true, autoApproval: { dedupeHistoricalApprover: true, mergeAdjacentApprover: true } },
+      })
+    })
+
+    it('M8 honesty: the control never touches a node-level policy field — switching tiers never clears mergeWithRequester on any step (gate A-4 spirit at the FE boundary)', async () => {
+      routeParams = { id: 'tpl_dedup_a4' }
+      const a4Graph = {
+        nodes: [
+          { key: 'start', type: 'start', name: '发起', config: {} },
+          {
+            key: 'approval_1',
+            type: 'approval',
+            name: '审批人 1',
+            config: {
+              assigneeSources: [{ kind: 'form_field_user', fieldId: 'reviewer' }],
+              approvalMode: 'single',
+              emptyAssigneePolicy: 'error',
+              autoApprovalPolicy: { mergeWithRequester: true },
+            },
+          },
+          { key: 'end', type: 'end', name: '结束', config: {} },
+        ],
+        edges: [
+          { key: 'edge-start-approval_1', source: 'start', target: 'approval_1' },
+          { key: 'edge-approval_1-end', source: 'approval_1', target: 'end' },
+        ],
+      }
+      getTemplateSpy.mockResolvedValue(buildTemplate({
+        id: 'tpl_dedup_a4',
+        status: 'published',
+        activeVersionId: 'ver_1',
+        policy: { allowRevoke: true },
+        approvalGraph: a4Graph,
+      }))
+      // See the hydrate test above for why this override is needed.
+      updateTemplateSpy.mockImplementation(async (id: string, payload: Record<string, unknown>) => ({
+        ...buildTemplate({ id, status: 'published', activeVersionId: 'ver_1', policy: { allowRevoke: true }, approvalGraph: a4Graph }),
+        ...payload,
+      }))
+      await mountView()
+      await flushUi()
+      ;(container!.querySelector('[data-testid="approval-template-section-more-settings"]') as HTMLButtonElement).click()
+      await flushUi()
+
+      const mergeAdjacentInput = container!.querySelector('[data-testid="approval-template-dedup-tier-merge-adjacent"]') as HTMLInputElement
+      mergeAdjacentInput.checked = true
+      mergeAdjacentInput.dispatchEvent(new Event('change'))
+      await flushUi()
+
+      ;(container!.querySelector('[data-testid="approval-template-section-flow"]') as HTMLButtonElement).click()
+      await flushUi()
+      const nodeSelfApproverCheckbox = container!.querySelector('[data-testid="approval-step-merge-with-requester"]') as HTMLInputElement
+      expect(nodeSelfApproverCheckbox).not.toBeNull()
+      expect(nodeSelfApproverCheckbox.checked).toBe(true)
+
+      ;(container!.querySelector('[data-testid="approval-template-publish-button"]') as HTMLButtonElement).click()
+      await flushUi()
+      const confirmButton = container!.querySelector('[data-testid="approval-publish-checklist-confirm"]') as HTMLButtonElement
+      confirmButton.click()
+      await flushUi()
+
+      const payload = publishTemplateSpy.mock.calls.at(-1)?.[1] as { policy: { autoApproval?: Record<string, unknown> } }
+      expect(payload.policy.autoApproval).toEqual({ mergeAdjacentApprover: true })
+      // The template-level tier switch must never have written into the node's own config.
+    })
   })
 
   it('T7: wires the self-approver toggle through the mounted view into the saved payload', async () => {

--- a/apps/web/tests/approvalTemplateAuthoring.spec.ts
+++ b/apps/web/tests/approvalTemplateAuthoring.spec.ts
@@ -2470,17 +2470,23 @@ describe('TemplateAuthoringView', () => {
       ])
     })
 
-    it('M7/M-2 census: 更多设置 is NOT an empty shell — it renders the dedup-tier radio group with 3 real, distinct options', async () => {
+    it('M7/M-2 census: 更多设置 is NOT an empty shell — it renders the dedup-tier radio group with 3 real, distinct, ENABLED options', async () => {
       await mountView()
       ;(container!.querySelector('[data-testid="approval-template-section-more-settings"]') as HTMLButtonElement).click()
       await flushUi()
 
       const group = container!.querySelector('[data-testid="approval-template-dedup-tier"]')
       expect(group).not.toBeNull()
-      expect(group!.querySelectorAll('input[type="radio"]').length).toBe(3)
+      const radios = Array.from(group!.querySelectorAll('input[type="radio"]')) as HTMLInputElement[]
+      expect(radios.length).toBe(3)
       expect(container!.querySelector('[data-testid="approval-template-dedup-tier-none"]')).not.toBeNull()
       expect(container!.querySelector('[data-testid="approval-template-dedup-tier-dedupe-historical"]')).not.toBeNull()
       expect(container!.querySelector('[data-testid="approval-template-dedup-tier-merge-adjacent"]')).not.toBeNull()
+      // Adversarial-gate P2 (PR #4967): renders-but-inert is a different failure than absent — a
+      // brand-new/non-locked template's control must actually be ENABLED, not permanently disabled
+      // theater that happens to still fire jsdom's change handler. This is the ONLY assertion that
+      // distinguishes "editable" from "renders disabled".
+      radios.forEach((radio) => expect(radio.disabled).toBe(false))
     })
 
     it('defaults to 不去重 (none) for a brand-new template — §2.2 no shipped default may change', async () => {
@@ -2489,6 +2495,32 @@ describe('TemplateAuthoringView', () => {
       await flushUi()
       const noneInput = container!.querySelector('[data-testid="approval-template-dedup-tier-none"]') as HTMLInputElement
       expect(noneInput.checked).toBe(true)
+    })
+
+    // M8 honesty (adversarial-gate P3-1, PR #4967): mergeAdjacentApprover also exempts a parallel
+    // gateway from two publish-time duplicate-assignee checks (ApprovalProductService.ts:4595,
+    // :4623-4625) — a real side effect that must be disclosed, and disclosed ONLY while that tier
+    // is actually selected (it does not apply to 不去重 / 仅一次全自动同意).
+    it('M8: selecting 仅连续节点自动同意 discloses the parallel-branch publish-check relaxation; other tiers do not', async () => {
+      await mountView()
+      ;(container!.querySelector('[data-testid="approval-template-section-more-settings"]') as HTMLButtonElement).click()
+      await flushUi()
+
+      expect(container!.querySelector('[data-testid="approval-template-dedup-tier-merge-adjacent-hint"]')).toBeNull()
+
+      const dedupeInput = container!.querySelector('[data-testid="approval-template-dedup-tier-dedupe-historical"]') as HTMLInputElement
+      dedupeInput.checked = true
+      dedupeInput.dispatchEvent(new Event('change'))
+      await flushUi()
+      expect(container!.querySelector('[data-testid="approval-template-dedup-tier-merge-adjacent-hint"]')).toBeNull()
+
+      const mergeAdjacentInput = container!.querySelector('[data-testid="approval-template-dedup-tier-merge-adjacent"]') as HTMLInputElement
+      mergeAdjacentInput.checked = true
+      mergeAdjacentInput.dispatchEvent(new Event('change'))
+      await flushUi()
+      const hint = container!.querySelector('[data-testid="approval-template-dedup-tier-merge-adjacent-hint"]')
+      expect(hint).not.toBeNull()
+      expect(hint!.textContent).toContain('并行')
     })
 
     it('selecting a tier (immediate-apply, no separate save transaction) and publishing carries autoApproval alongside allowRevoke', async () => {


### PR DESCRIPTION
## Summary

master §P3-B / RATIFIED `docs/development/approval-lock6-requester-global-policy-20260817.md` §1 L6-A: activates the "更多设置" wizard step (fourth of five, `测试发布` last — Lock-0 L0-4 / Lock-6 §2.7) and lands its first functional control: a 3-way tier (**不去重** / **仅一次全自动同意** / **仅连续节点自动同意**) authoring the template-level dedup arms on `runtimeGraph.policy.autoApproval` (`dedupeHistoricalApprover` / `mergeAdjacentApprover`). Both booleans are ALREADY server-enforced (Lock-4 §2.6 `evaluateAutoApprovalAssignment`) — this slice is authoring-surface only, **zero engine change, zero new contract field**.

**M7 (master §4 P3-B exit, "no inert controls"):** the fifth step is authorized ONLY in this same commit that lands the functional control — activation is a typed change to `AuthoringSectionId` + `authoringSections`, per Lock-6 §2.7.

## Stacked on two prerequisites

This branch is based on #4965 (round-scoping) and additionally cherry-picks #4966's single commit (publish-sequencing fix), because BOTH are required for the dedup-tier control to be honest under M7/M8:

- **#4965 — round-scoping (Lock-4 OD-L4-10(a)):** without it, enabling either dedup arm via a return-heavy graph would silently nullify a return.
- **#4966 — publish-sequencing (Lock-6 L6-P1 gate F3, independently corroborated during this slice):** without it, selecting a tier and publishing in the same sitting would silently discard the selection — a real, pre-existing bug that ALSO affects the already-shipped `allowRevoke` checkbox, found via component-level testing here before any P3-B code existed.

Base is set to #4965's branch (closer ancestor); the diff you'll see against `main` also includes #4966's commit until that PR merges — this PR's own commit (the one that matters for review) is the last one, `feat(approval): P3-B — More-settings fifth step + L6-A template dedup tier`.

## What changed (this PR's own commit)

- `apps/web/src/approvals/templateAuthoring.ts`: `TemplateDedupTier` type + `autoApprovalDedupTier` draft field; `templateDedupTierFromPolicy` / `isTemplateDedupTierLocked` (hydrate-time projection; a persisted BOTH-true combination — unrepresentable by this 3-way tier — is detected and never flattened, Lock-6 §2.6 gate X-1); `buildTemplateAutoApprovalPolicy` + `buildPublishPolicy` update (merges the tier onto `draft.originalPolicy.autoApproval`, preserving any other key and omitting the whole `autoApproval` key when empty — §2.2: absent === 不去重, byte-stable for every existing template).
- `apps/web/src/types/approval.ts`: `RuntimePolicy.autoApproval` typed as `AutoApprovalPolicy` (was an opaque `unknown` placeholder pending this exact slice, per its own L6-P1 comment).
- `apps/web/src/views/approval/TemplateAuthoringView.vue`: the new step's radio-group control, immediate-apply (no separate Save/Cancel transaction, matching the existing D0 grammar e.g. `draft.allowRevoke`), disabled + an explanatory hint when the persisted policy is in the locked both-true state.

## Test plan

- 24 pure-function cases (`approval-template-authoring-policy-carrier.test.ts`) covering hydrate/publish projection, sibling-field preservation (`allowRevoke`, `revokeBeforeNodeKeys`, an unrelated `autoApproval` key like `actorMode`), the locked-state byte-preservation, and the omit-when-empty convention.
- 8 component-level cases (`approvalTemplateAuthoring.spec.ts`) covering: the exact 5-step activation order; an **M7 census** that 更多设置 renders 3 real radio options (not an empty shell); the 不去重 default; select-a-tier-then-publish round trip; hydrate-with-a-persisted-tier round trip; gate X-1's locked-state round trip; and an **M8/A-4-spirit** check that switching the template tier never writes into a node's own `autoApprovalPolicy`.
- Mutation-verified via `cp`-backup + sha256 restore (never `git checkout --`): neutering `buildTemplateAutoApprovalPolicy` to always return `undefined` turns 11 tests red; stripping the control's markup from the More-settings step turns 6 tests red (including the M7 census). Both restored and reverified green (128/128 across the two spec files).
- `vue-tsc --noEmit` clean.
- No FE spec file is new — both touched test files already carry tokens in `run-required-web-tests.sh` and `approval-web-guard.yml`.

## Scope discipline

Does not touch the flow canvas, assignee logic, form builder, field-permission grid, or the engine (dedup enforcement is pre-existing; round-scoping is #4965). Scope is L6-A alone (Lock-6 OD-L6-2(a)); every other Lock-6 candidate (L6-B through L6-F2) stays deferred per that document.

Not merging — merge order (this PR after #4965 and #4966) and RATIFY decisions stay with the requesting session.