### PR TITLE
fix(ci): preserve deploy sync failures and bound smoke startup

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -81,6 +81,8 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Sync deploy host files
+        id: sync_deploy
+        continue-on-error: true
         env:
           DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
           DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
@@ -88,6 +90,9 @@ jobs:
           DEPLOY_PATH: ${{ secrets.DEPLOY_PATH }}
           DEPLOY_SYNC_MIN_FREE_KB: ${{ vars.DEPLOY_SYNC_MIN_FREE_KB || '1048576' }}
         run: |
+          set -uo pipefail
+          set +e
+          (
           set -euo pipefail
           mkdir -p ~/.ssh
           printf '%s' "$DEPLOY_SSH_KEY_B64" | base64 -d > ~/.ssh/deploy_key
@@ -142,9 +147,15 @@ jobs:
             scripts/ops/attendance-preflight.sh \
           | ssh $ssh_opts "$DEPLOY_USER@$DEPLOY_HOST" \
               "set -euo pipefail; mkdir -p '${remote_repo_path}/docker' '${remote_repo_path}/scripts/ops'; tar -xzf - -C '${remote_repo_path}'"
+          )
+          sync_rc=$?
+          set -e
+          echo "sync_rc=$sync_rc" >> "$GITHUB_OUTPUT"
+          exit "$sync_rc"
 
       - name: Remote deploy (with preflight logs)
         id: remote_deploy
+        if: ${{ steps.sync_deploy.outputs.sync_rc == '0' }}
         continue-on-error: true
         env:
           DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
@@ -574,6 +585,7 @@ jobs:
           METASHEET_FRONTEND_BASE_URL: ${{ vars.METASHEET_FRONTEND_BASE_URL || vars.PUBLIC_APP_URL || vars.METASHEET_BASE_URL || '' }}
           METASHEET_TENANT_ID: ${{ vars.METASHEET_TENANT_ID || '' }}
           K3_WISE_DEPLOY_SMOKE_REQUIRE_AUTH: ${{ vars.K3_WISE_DEPLOY_SMOKE_REQUIRE_AUTH || 'false' }}
+          K3_WISE_DEPLOY_SMOKE_TIMEOUT_MS: ${{ vars.K3_WISE_DEPLOY_SMOKE_TIMEOUT_MS || '30000' }}
         run: |
           set -euo pipefail
           smoke_out_dir="output/deploy/k3wise-postdeploy-smoke"
@@ -584,6 +596,7 @@ jobs:
           args=(
             --base-url "$METASHEET_BASE_URL"
             --out-dir "$smoke_out_dir"
+            --timeout-ms "$K3_WISE_DEPLOY_SMOKE_TIMEOUT_MS"
           )
           if [[ -n "${METASHEET_FRONTEND_BASE_URL:-}" ]]; then
             args+=(--frontend-base-url "$METASHEET_FRONTEND_BASE_URL")
@@ -611,6 +624,7 @@ jobs:
       - name: Write deploy summary (preflight + runbooks)
         if: always()
         env:
+          SYNC_RC: ${{ steps.sync_deploy.outputs.sync_rc }}
           DEPLOY_RC: ${{ steps.remote_deploy.outputs.deploy_rc }}
           DRILL_FAIL_STAGE: ${{ github.event.inputs.drill_fail_stage || 'none' }}
         run: |
@@ -621,11 +635,11 @@ jobs:
 
           preflight_status="UNKNOWN"
           overall="UNKNOWN"
-          if [[ -n "${DEPLOY_RC:-}" ]]; then
+          if [[ -n "${SYNC_RC:-}" && "${SYNC_RC}" != "0" ]]; then
+            overall="FAIL"
+          elif [[ "${SYNC_RC:-}" == "0" && -n "${DEPLOY_RC:-}" ]]; then
             overall="PASS"
-            if [[ "${DEPLOY_RC}" != "0" ]]; then
-              overall="FAIL"
-            fi
+            [[ "${DEPLOY_RC}" == "0" ]] || overall="FAIL"
           fi
 
           rc_meaning="unknown"
@@ -653,6 +667,7 @@ jobs:
           echo "## Deploy (Remote)" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "- Overall: **${overall}**" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Host sync exit code: \`${SYNC_RC:-missing}\`" >> "$GITHUB_STEP_SUMMARY"
           echo "- Remote exit code: \`${DEPLOY_RC:-missing}\` (meaning: ${rc_meaning})" >> "$GITHUB_STEP_SUMMARY"
           echo "- Drill fail stage: \`${DRILL_FAIL_STAGE:-none}\`" >> "$GITHUB_STEP_SUMMARY"
           if [[ "${DRILL_FAIL_STAGE:-none}" != "none" ]]; then
@@ -914,6 +929,15 @@ jobs:
       - name: Fail when remote deploy failed
         if: always()
         run: |
+          sync_rc="${{ steps.sync_deploy.outputs.sync_rc }}"
+          if [[ -z "$sync_rc" ]]; then
+            echo "sync_rc missing; failing deploy job." >&2
+            exit 1
+          fi
+          if [[ "$sync_rc" != "0" ]]; then
+            echo "Sync deploy host files failed: rc=$sync_rc" >&2
+            exit 1
+          fi
           rc="${{ steps.remote_deploy.outputs.deploy_rc }}"
           if [[ -z "$rc" ]]; then
             echo "deploy_rc missing; failing deploy job." >&2

--- a/scripts/ops/integration-k3wise-postdeploy-workflow-contract.test.mjs
+++ b/scripts/ops/integration-k3wise-postdeploy-workflow-contract.test.mjs
@@ -108,6 +108,10 @@ test('manual K3 WISE postdeploy smoke workflow keeps dispatch and auth contract 
 
 test('deploy workflow keeps K3 WISE smoke evidence wired into deploy summary and artifacts', () => {
   const raw = readFileSync(deployWorkflowPath, 'utf8')
+  const smokeStepStart = raw.indexOf('- name: K3 WISE postdeploy smoke\n')
+  const smokeStepEnd = raw.indexOf('\n      - name:', smokeStepStart + 1)
+  assert.ok(smokeStepStart >= 0 && smokeStepEnd > smokeStepStart, 'deploy smoke step must be extractable')
+  const smokeStep = raw.slice(smokeStepStart, smokeStepEnd)
 
   assertContains(raw, 'deploy:', 'docker-build deploy job')
   assertContains(raw, '- name: Resolve K3 WISE smoke token', 'deploy token resolver step')
@@ -138,11 +142,13 @@ test('deploy workflow keeps K3 WISE smoke evidence wired into deploy summary and
   assertContains(raw, "METASHEET_TENANT_ID: ${{ vars.METASHEET_TENANT_ID || '' }}", 'deploy smoke step')
   assertContains(raw, "METASHEET_FRONTEND_BASE_URL: ${{ vars.METASHEET_FRONTEND_BASE_URL || vars.PUBLIC_APP_URL || vars.METASHEET_BASE_URL || '' }}", 'deploy smoke step')
   assertContains(raw, "K3_WISE_DEPLOY_SMOKE_REQUIRE_AUTH: ${{ vars.K3_WISE_DEPLOY_SMOKE_REQUIRE_AUTH || 'false' }}", 'deploy smoke step')
+  assertContains(smokeStep, "K3_WISE_DEPLOY_SMOKE_TIMEOUT_MS: ${{ vars.K3_WISE_DEPLOY_SMOKE_TIMEOUT_MS || '30000' }}", 'deploy smoke step')
   assertContains(raw, 'smoke_out_dir="output/deploy/k3wise-postdeploy-smoke"', 'deploy smoke step')
   assertContains(raw, 'node scripts/ops/integration-k3wise-postdeploy-smoke.mjs', 'deploy smoke step')
   assertContains(raw, '--base-url "$METASHEET_BASE_URL"', 'deploy smoke step')
   assertContains(raw, 'args+=(--frontend-base-url "$METASHEET_FRONTEND_BASE_URL")', 'deploy smoke step')
   assertContains(raw, '--out-dir "$smoke_out_dir"', 'deploy smoke step')
+  assertContains(smokeStep, '--timeout-ms "$K3_WISE_DEPLOY_SMOKE_TIMEOUT_MS"', 'deploy smoke step')
   assertContains(raw, 'require_auth="${K3_WISE_DEPLOY_SMOKE_REQUIRE_AUTH:-false}"', 'deploy smoke step')
   assertContains(raw, 'case "${require_auth}" in', 'deploy smoke step')
   assertContains(raw, 'true|TRUE|True|1|yes|YES|Yes)', 'deploy smoke step')
@@ -183,6 +189,19 @@ test('deploy workflow checks deploy host disk before sync archive extraction', (
   const raw = readFileSync(deployWorkflowPath, 'utf8')
 
   assertContains(raw, '- name: Sync deploy host files', 'deploy host sync step')
+  assertContains(raw, 'id: sync_deploy', 'deploy host sync result step id')
+  assertContains(raw, 'set +e\n          (\n          set -euo pipefail', 'deploy host sync failure capture wrapper')
+  assertContains(raw, ')\n          sync_rc=$?', 'deploy host sync failure capture assignment')
+  assertContains(raw, 'echo "sync_rc=$sync_rc" >> "$GITHUB_OUTPUT"', 'deploy host sync result output')
+  assertContains(raw, 'exit "$sync_rc"', 'deploy host sync preserves failure outcome')
+  assertContains(raw, "if: ${{ steps.sync_deploy.outputs.sync_rc == '0' }}", 'remote deploy sync gate')
+  assertContains(raw, 'steps.sync_deploy.outputs.sync_rc', 'deploy final sync gate')
+  assertContains(raw, 'Sync deploy host files failed: rc=$sync_rc', 'deploy final sync failure message')
+  assertContains(raw, 'Host sync exit code: \\`${SYNC_RC:-missing}\\`', 'deploy summary sync result')
+  assert.ok(
+    raw.indexOf('Sync deploy host files failed: rc=$sync_rc') < raw.indexOf('deploy_rc missing; failing deploy job.'),
+    'deploy final gate must report a failed host sync before checking the skipped remote deploy output',
+  )
   assertContains(raw, "DEPLOY_SYNC_MIN_FREE_KB: ${{ vars.DEPLOY_SYNC_MIN_FREE_KB || '1048576' }}", 'deploy host sync disk gate env')
   assertContains(raw, 'DEPLOY_SYNC_MIN_FREE_KB="${DEPLOY_SYNC_MIN_FREE_KB:-1048576}"', 'deploy host sync disk gate default')
   assertContains(raw, 'DEPLOY_SYNC_MIN_FREE_KB=\'${DEPLOY_SYNC_MIN_FREE_KB}\' bash -s', 'deploy host sync remote env')


### PR DESCRIPTION
## Summary
- preserve the exact host-sync exit code while keeping the deploy job alive long enough to publish diagnostics
- skip remote deployment unless host sync returned `0`
- report host-sync failure before the misleading fallback `deploy_rc missing`
- give the automatic postdeploy K3 WISE smoke a bounded, configurable 30-second request timeout for cold-start conditions; no retries and no fail-open
- pin both behaviors in the existing workflow contract

## Verification
- exact head `89ce89be6c170ba0f453a88b2514d5c51e2ac663` on base `f9fc9807723263525110abf703c16ea72c66e4eb`
- `node --test scripts/ops/integration-k3wise-postdeploy-workflow-contract.test.mjs scripts/ops/deploy-immutable-traceability-contract.test.mjs scripts/ops/remote-summary-pipefail-contract.test.mjs` (9/9)
- workflow YAML parsed with PyYAML
- shell probe preserved a synthetic exit `78` as `sync_rc=78`
- observed-RED: the updated contract fails against the pre-patch workflow
- production evidence on `main@f2ed020d1`: immediate 10-second K3 smoke had 6 aborts; same exact SHA, auth, tenant, and 10-second gate passed 12/12 once the service was stable (run 32097231841)
- independent repeat on `main@680e93c01`: remote deploy and exact image verification passed, while the immediate 10-second K3 smoke had 10 pass / 2 fail; only `api-health` and `integration-plugin-health` aborted (run 32100034647)
- repository variable `K3_WISE_DEPLOY_SMOKE_TIMEOUT_MS` is unset, so the new 30000 ms default will apply
- two pre-rebase Grok 4.6 reviews plus one exact-head Grok 4.6 review on `89ce89be6`: 0 P1 / 0 P2 / 0 P3: 0 P1 / 0 P2 / 0 P3

## Boundary
This PR changes CI/deploy diagnostics and the automatic postdeploy smoke timeout only. It does not change application behavior, migrations, or production data. A post-merge automatic deploy is still required to prove the 30-second gate under actual cold-start timing.