### PR TITLE
feat(approval): K3 — prior_node_approver assignee kind (Lock-1 §K3) + fail-closed normalizeApprovalMode

### DIFF
--- a/.github/workflows/approval-realdb-acceptance.yml
+++ b/.github/workflows/approval-realdb-acceptance.yml
@@ -10,6 +10,11 @@ name: Approval real-DB acceptance (Lock-1 assignee kinds)
 #     deptHeadChainIds snapshot field)
 #     (tests/integration/approval-dept-head-at-level.db.test.ts — G-1/G-2, positional-not-hop-count
 #      over real SQL, out-of-range→emptyAssigneePolicy, freeze-purity/temporal)
+#   - approval-realdb-k3: §K3 `prior_node_approver` (instance-internal audit-row resolution — no
+#     directory fixture at all, deliberately)
+#     (tests/integration/approval-prior-node-approver.db.test.ts — G-1/G-2/G-10 dominance publish
+#      gate, actual-decider happy path + multi-seat all/any, OD-L1-3(a) latest-round via return,
+#      OD-L1-4(a) skipped/auto-approved fail-closed, G-12 no-dedup, freeze-of-rule)
 # Ephemeral first-party PostgreSQL container per job; no customer source, no deployment, no
 # flag change.
 #
@@ -41,6 +46,7 @@ on:
       - 'packages/core-backend/tests/integration/approval-requester-choice.db.test.ts'
       - 'packages/core-backend/tests/integration/approval-dept-head-chain.db.test.ts'
       - 'packages/core-backend/tests/integration/approval-dept-head-at-level.db.test.ts'
+      - 'packages/core-backend/tests/integration/approval-prior-node-approver.db.test.ts'
       - 'packages/core-backend/tests/helpers/approval-schema-bootstrap.ts'
       - 'packages/core-backend/src/services/ApprovalProductService.ts'
       - 'packages/core-backend/src/services/ApprovalAssigneeResolver.ts'
@@ -56,6 +62,7 @@ on:
       - 'packages/core-backend/tests/integration/approval-requester-choice.db.test.ts'
       - 'packages/core-backend/tests/integration/approval-dept-head-chain.db.test.ts'
       - 'packages/core-backend/tests/integration/approval-dept-head-at-level.db.test.ts'
+      - 'packages/core-backend/tests/integration/approval-prior-node-approver.db.test.ts'
       - 'packages/core-backend/tests/helpers/approval-schema-bootstrap.ts'
       - 'packages/core-backend/src/services/ApprovalProductService.ts'
       - 'packages/core-backend/src/services/ApprovalAssigneeResolver.ts'
@@ -298,6 +305,85 @@ jobs:
             echo "suite=approval-dept-head-at-level.db.test.ts"
             echo "lock=approval-lock1-enterprise-assignees-20260817 §K5-b"
             echo "gates=G-1,G-2 (positional-not-hop-count over real SQL, out-of-range->emptyAssigneePolicy, freeze-purity/temporal)"
+            echo "customerSourceAccess=NOT_INVOLVED"
+            echo "flagChanged=false"
+            echo "externalWrite=false"
+          } | tee -a "$GITHUB_STEP_SUMMARY"
+
+  approval-realdb-k3:
+    name: approval-realdb-k3
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: metasheet_approval_realdb
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d metasheet_approval_realdb"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 20
+    env:
+      DATABASE_URL: postgresql://postgres:postgres@127.0.0.1:5432/metasheet_approval_realdb
+      # Arms the suite's TOP-LEVEL anti-skip-green sentinel (the K2 posture — deliberately not
+      # the inside-describeIfDatabase variant): a run in this lane with a missing/broken
+      # DATABASE_URL goes RED instead of silently reporting the whole suite as skipped.
+      EXPECT_DB: '1'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js 20.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.16.1
+          run_install: false
+
+      - name: Use empty npmrc for pnpm
+        run: |
+          echo "" > /tmp/empty-npmrc
+          echo "NPM_CONFIG_USERCONFIG=/tmp/empty-npmrc" >> "$GITHUB_ENV"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run DB migrations
+        env:
+          # Same per-PR-gate exclusion list as plugin-tests.yml's "Run DB migrations" step
+          # (see the T8 note there and packages/core-backend/MIGRATION_EXCLUDE_TRACKING.md
+          # for the per-item detail) — this lane provisions the identical schema the
+          # approval real-DB steps run against.
+          MIGRATION_EXCLUDE: 008_plugin_infrastructure.sql,048_create_event_bus_tables.sql,049_create_bpmn_workflow_tables.sql,042a_core_model_views.sql,20250924140000_create_gantt_tables.ts,20250925_create_view_tables.sql
+        run: pnpm --filter @metasheet/core-backend db:migrate
+
+      - name: Run Lock-1 §K3 prior_node_approver real-DB acceptance (whole file)
+        # WHOLE FILE, --reporter=verbose: a name filter matching zero tests would exit
+        # green and hide regressions; verbose prints every collected test so an empty
+        # collection shows in the log instead of reading as green.
+        run: >-
+          pnpm --filter @metasheet/core-backend exec vitest
+          --config vitest.integration.config.ts run
+          tests/integration/approval-prior-node-approver.db.test.ts
+          --reporter=verbose
+
+      - name: Values-free evidence (this job)
+        run: |
+          {
+            echo "evidenceKind=CONTROLLED_SYNTHETIC_FUNCTIONAL"
+            echo "suite=approval-prior-node-approver.db.test.ts"
+            echo "lock=approval-lock1-enterprise-assignees-20260817 §K3"
+            echo "gates=G-1,G-2,G-10,G-11,G-12,G-18 (+OD-L1-3a latest-round, OD-L1-4a skipped/auto-approved fail-closed, freeze-of-rule)"
+            echo "sentinelArmed=EXPECT_DB=1"
             echo "customerSourceAccess=NOT_INVOLVED"
             echo "flagChanged=false"
             echo "externalWrite=false"

--- a/apps/web/src/approvals/approvalCapabilityRegistry.ts
+++ b/apps/web/src/approvals/approvalCapabilityRegistry.ts
@@ -43,6 +43,12 @@ export const APPROVAL_ASSIGNEE_SOURCE_LABELS: Record<ApprovalAssigneeSourceKind,
   // NOT admitted on `handler` — Lock-3 §1.5's forward ADMIT row is a separate follow-up (see
   // HANDLER_ASSIGNEE_SOURCE_KINDS below, which deliberately does not include this kind).
   dept_head_at_level: '指定层级部门负责人',
+  // Lock-1 §K3 (RATIFIED 2026-08-17) — admitted in the SAME slice that lands the dominance
+  // validator + caller-supplied decider resolution end to end (registry table row: 节点审批人 /
+  // approval; "Admitted when: OD-L1-3 + OD-L1-4 decided; dominance validator landed" — both ODs
+  // are recorded (a) in the §4 ratification block). NOT admitted on `handler` (Lock-3 §1.5 lists
+  // no forward row for this kind at all).
+  prior_node_approver: '节点审批人',
 }
 
 /** Display order matches parent §10.3's listed order. Kept as an explicit array (rather than
@@ -63,6 +69,8 @@ const SHIPPED_ASSIGNEE_SOURCE_KIND_ORDER: readonly ApprovalAssigneeSourceKind[] 
   'continuous_dept_heads',
   // Lock-1 §K5-b: appended after K4 (strictly downstream of it).
   'dept_head_at_level',
+  // Lock-1 §K3: appended after K5-b (ratified-kind append order).
+  'prior_node_approver',
 ]
 
 export interface ApprovalAssigneeSourceCapability {

--- a/apps/web/src/approvals/approvalNodeEdit.ts
+++ b/apps/web/src/approvals/approvalNodeEdit.ts
@@ -11,6 +11,7 @@ import type {
   NodeFieldPermission,
 } from '../types/approval'
 import { APPROVAL_ROLE_CONFIGURE_SENTINEL, HANDLER_ASSIGNEE_SOURCE_KINDS } from '../types/approval'
+import { runtimeSuccessorTargets } from './parallelEdit'
 
 const HANDLER_ASSIGNEE_SOURCE_KIND_SET = new Set<string>(HANDLER_ASSIGNEE_SOURCE_KINDS)
 
@@ -217,6 +218,13 @@ function isAssigneeSourceValid(source: ApprovalAssigneeSource, topLevelUserField
     // normalizeApprovalAssigneeSources stays the arbiter on the ceiling).
     case 'dept_head_at_level':
       return Number.isInteger(source.level) && source.level >= 1
+    // Lock-1 §K3 PREVIEW: a non-empty referenced node key. Whether the reference is legal
+    // (an approval node strictly upstream on every runtime-reachable path) is the backend
+    // PUBLISH gate's job (`assertPriorNodeApproverReferencesUpstream`); the FE picker only
+    // OFFERS legal candidates (`legalPriorApproverNodeKeys` below), so this shape check plus
+    // the picker keep authoring honest without relaxing the backend arbiter.
+    case 'prior_node_approver':
+      return source.nodeKey.trim().length > 0
     case 'requester_choice':
       // Lock-1 §K2 PREVIEW (backend normalizeApprovalAssigneeSources stays the arbiter):
       // mode + scope discriminator, and a members/role scope needs ≥1 configured id.
@@ -295,6 +303,59 @@ export function validateApprovalNodeEdits(
     }
   }
   return errors
+}
+
+/**
+ * Lock-1 §K3 — the node keys a `prior_node_approver` source on `nodeKey`'s card may legally
+ * reference: `approval` nodes STRICTLY UPSTREAM on EVERY runtime-reachable path from the start
+ * node to the carrying node. FE mirror of the backend publish gate
+ * (`assertPriorNodeApproverReferencesUpstream`, ApprovalProductService.ts — the sole arbiter;
+ * this never relaxes it): T is offered ⟺ T is an approval node, T ≠ carrier, and removing T
+ * makes the carrier unreachable from start over `runtimeSuccessorTargets` (strict dominance by
+ * removal-reachability — the same conservative parallel posture: a node inside one parallel
+ * branch is never offered past the join or to a sibling branch, and a node reachable only
+ * through one condition branch is never offered after the merge). Drives the typed node PICKER
+ * (D0 §10.2 — never a free-text key input); order follows the graph's node-declaration order.
+ */
+export function legalPriorApproverNodeKeys(graph: ApprovalGraph, nodeKey: string): string[] {
+  const edgeByKey = new Map(graph.edges.map((edge) => [edge.key, edge]))
+  const outgoingBySource = new Map<string, ApprovalGraph['edges']>()
+  for (const edge of graph.edges) {
+    const existing = outgoingBySource.get(edge.source)
+    if (existing) existing.push(edge)
+    else outgoingBySource.set(edge.source, [edge])
+  }
+  const nodeByKey = new Map(graph.nodes.map((node) => [node.key, node]))
+  const startKey = graph.nodes.find((node) => node.type === 'start')?.key ?? null
+  if (startKey === null) return []
+
+  const reachableWithout = (skipKey: string | null): Set<string> => {
+    const visited = new Set<string>()
+    if (startKey === skipKey) return visited
+    const queue: string[] = [startKey]
+    for (let head = 0; head < queue.length; head += 1) {
+      const currentKey = queue[head]
+      if (currentKey === skipKey || visited.has(currentKey)) continue
+      visited.add(currentKey)
+      const current = nodeByKey.get(currentKey)
+      if (!current) continue
+      for (const target of runtimeSuccessorTargets(current, edgeByKey, outgoingBySource)) {
+        queue.push(target)
+      }
+    }
+    return visited
+  }
+
+  // An unreachable carrier has no runtime-reachable paths at all — offer nothing (the backend
+  // gate passes such references vacuously, but a picker offering candidates for a dead node
+  // would be authoring theater).
+  if (!reachableWithout(null).has(nodeKey)) return []
+  return graph.nodes
+    .filter((candidate) =>
+      candidate.type === 'approval'
+      && candidate.key !== nodeKey
+      && !reachableWithout(candidate.key).has(nodeKey))
+    .map((candidate) => candidate.key)
 }
 
 /**

--- a/apps/web/src/approvals/assigneeSource.ts
+++ b/apps/web/src/approvals/assigneeSource.ts
@@ -31,6 +31,10 @@ export function assigneeSourceSummary(source: ApprovalAssigneeSource): string {
     // Lock-1 §K2: pre-choice placeholder — the approver is unknowable until the requester
     // chooses at submit time, so the flow/route preview says exactly that.
     case 'requester_choice': return '提交人自选（提交时选择）'
+    // Lock-1 §K3: the concrete person is unknowable until the referenced node decides at
+    // runtime, so the summary names the referenced node key (a template-authored identifier,
+    // §2.6-permitted — never a person id).
+    case 'prior_node_approver': return `节点审批人（引用节点 ${source.nodeKey}）`
     // Lock-1 §2.5 item 5: values-free fallback. The previous `JSON.stringify(source)` default
     // leaked raw config (including raw IDs) into an ordinary-user surface for any kind this
     // switch does not know — a defect, not a precedent, per the ratified lock. An unknown kind

--- a/apps/web/src/approvals/components/ApprovalGraphNodeConfigEditor.vue
+++ b/apps/web/src/approvals/components/ApprovalGraphNodeConfigEditor.vue
@@ -633,6 +633,37 @@
             </el-select>
           </el-form-item>
         </template>
+        <!-- Lock-1 §K3 (节点审批人) authoring sub-form: a TYPED node picker restricted to the
+             publish-time-legal upstream approval nodes (D0 §10.2 — never a free-text node-key
+             input). Candidates come from the api's `priorApproverNodeOptions` (the shipped app
+             derives them via `legalPriorApproverNodeKeys` — the FE mirror of the backend publish
+             dominance gate, which stays the sole arbiter). -->
+        <el-form-item
+          v-else-if="approvalSourceKind(node.key, sourceIndex) === 'prior_node_approver'"
+          label="引用审批节点"
+        >
+          <el-select
+            :model-value="priorNodeApproverKey(node.key, sourceIndex)"
+            size="small"
+            :disabled="readOnly"
+            class="ms-w-240"
+            placeholder="选择上游审批节点"
+            data-testid="approval-node-source-prior-node"
+            @update:model-value="(key: string) => setPriorNodeApproverKey(node.key, sourceIndex, key)"
+          >
+            <el-option
+              v-for="option in priorApproverNodeOptionsFor(node.key)"
+              :key="option.key"
+              :label="option.label"
+              :value="option.key"
+            />
+          </el-select>
+          <p
+            v-if="priorApproverNodeOptionsFor(node.key).length === 0"
+            class="template-authoring__hint template-authoring__hint--warn"
+            data-testid="approval-node-source-prior-node-empty"
+          >当前节点上游没有可引用的审批节点（引用目标必须位于每条可达路径的上游）</p>
+        </el-form-item>
         <!-- G-5 sentinel hint: a starter preset's placeholder role surfaces HERE, in the editor,
              so the admin replaces it before publish (rather than hitting the publish-time 400).
              P1-B: scoped to THIS card's own source, not the node-wide aggregate — a node with N
@@ -815,6 +846,7 @@
 import { computed, inject, toRefs, unref, type ComputedRef, type Ref } from 'vue'
 import { Plus } from '@element-plus/icons-vue'
 import type {
+  ApprovalAssigneeSource,
   ApprovalAssigneeSourceKind,
   ApprovalMode,
   ApprovalNode,
@@ -1032,6 +1064,33 @@ function setRequesterChoiceScopeIds(nodeKey: string, sourceIndex: number, ids: s
   }
 }
 
+// ── Lock-1 §K3 prior_node_approver sub-form ─────────────────────────────────────────────────
+// Same pattern as the §K2 sub-form above: reads/writes the card AT sourceIndex of the SHARED
+// approvalNodeEditFor edit model directly. Candidates come from the api's OPTIONAL
+// `priorApproverNodeOptions` (always present on the shipped app's api object; component tests
+// that don't exercise K3 omit it — the picker then offers nothing, mutating nothing).
+function priorNodeApproverSourceFor(nodeKey: string, sourceIndex: number): Extract<ApprovalAssigneeSource, { kind: 'prior_node_approver' }> | null {
+  const source = approvalNodeEditFor(nodeKey)?.assigneeSources[sourceIndex]
+  return source?.kind === 'prior_node_approver' ? source : null
+}
+function priorNodeApproverKey(nodeKey: string, sourceIndex: number): string {
+  return priorNodeApproverSourceFor(nodeKey, sourceIndex)?.nodeKey ?? ''
+}
+function setPriorNodeApproverKey(nodeKey: string, sourceIndex: number, referencedNodeKey: string): void {
+  const source = priorNodeApproverSourceFor(nodeKey, sourceIndex)
+  if (!source || source.nodeKey === referencedNodeKey) return
+  const edit = approvalNodeEditFor(nodeKey)
+  if (!edit) return
+  if (sourceIndex < 0 || sourceIndex >= edit.assigneeSources.length) return
+  const nextSources = edit.assigneeSources.slice()
+  nextSources[sourceIndex] = { ...source, nodeKey: referencedNodeKey }
+  edit.assigneeSources = nextSources
+}
+const priorApproverNodeOptionsApi = api.priorApproverNodeOptions
+function priorApproverNodeOptionsFor(nodeKey: string): Array<{ key: string; label: string }> {
+  return priorApproverNodeOptionsApi?.(nodeKey) ?? []
+}
+
 /** D2: configured summary echo. Reads the LIVE edit model (not `node.config`, which is the stale
  *  pre-edit snapshot in list mode — `TemplateAuthoringView.vue`'s `graphPreviewNodes` is sourced
  *  from `draft.preservedGraph`, not the live effective graph) so it stays correct in both
@@ -1077,6 +1136,10 @@ function configuredSourceSummaryLine(nodeKey: string, sourceIndex: number): stri
         ? `指定角色${source.scope.roleIds.length ? `（${source.scope.roleIds.length} 个）` : '（未选择）'}`
         : '全公司'
     return `已配置：${label}（${mode} · ${scope}）`
+  }
+  if (source.kind === 'prior_node_approver') {
+    // §K3 echo — the referenced node's display label (a template-authored name/key, no person id).
+    return `已配置：${label}${source.nodeKey ? `（${graphNodeLabel(source.nodeKey)}）` : '（未选择）'}`
   }
   return `已配置：${label}`
 }

--- a/apps/web/src/approvals/linearStepSpine.ts
+++ b/apps/web/src/approvals/linearStepSpine.ts
@@ -51,6 +51,11 @@ export function isStepSourceResolvable(step: ApprovalStepDraft): boolean {
       return parseIdsText(step.idsText).length > 0
     case 'form_field_user':
       return step.fieldId.trim().length > 0
+    // Lock-1 §K3: a prior_node_approver step needs a chosen earlier-step reference
+    // (authoring-completeness only — strict-earlier ordering is validateTemplateApprovalFlow's
+    // and ultimately the backend publish dominance gate's job).
+    case 'prior_node_approver':
+      return step.priorStepLocalId.trim().length > 0
     default:
       return true
   }
@@ -60,9 +65,13 @@ export function isStepSourceResolvable(step: ApprovalStepDraft): boolean {
 // when their id array is empty. `form_field_user` is the one shape it does not already cover
 // (an unset fieldId renders as the bare `表单用户字段：`) — so that one case gets the same
 // honest-placeholder treatment here, in the SAME bracket convention, instead of a half-empty label.
-function stepSourceSummary(step: ApprovalStepDraft, resolvable: boolean): string {
+// Lock-1 §K3: `allSteps` threads through to `sourceFromStep` so a prior_node_approver chip can
+// derive its referenced step's positional key; an unchosen reference gets the same
+// honest-placeholder treatment.
+function stepSourceSummary(step: ApprovalStepDraft, resolvable: boolean, allSteps: ApprovalStepDraft[]): string {
   if (step.sourceKind === 'form_field_user' && !resolvable) return '表单用户字段：（未选择）'
-  return assigneeSourceSummary(sourceFromStep(step))
+  if (step.sourceKind === 'prior_node_approver' && !resolvable) return '节点审批人：（未选择）'
+  return assigneeSourceSummary(sourceFromStep(step, allSteps))
 }
 
 /**
@@ -86,7 +95,7 @@ export function buildLinearStepSpine(steps: ApprovalStepDraft[]): LinearStepSpin
       key: step.localId,
       role: 'step' as const,
       label: step.name.trim() || `审批人 ${position}`,
-      sourceSummary: stepSourceSummary(step, resolvable),
+      sourceSummary: stepSourceSummary(step, resolvable, steps),
       resolvable,
       stepIndex: position,
     }

--- a/apps/web/src/approvals/nodeConfigEditorContext.ts
+++ b/apps/web/src/approvals/nodeConfigEditorContext.ts
@@ -109,6 +109,17 @@ export interface ApprovalNodeConfigEditorApi {
    * always present on the shipped app's api object.
    */
   routingDriverFieldIds?: ComputedRef<Set<string>> | Ref<Set<string>> | Set<string>
+  /**
+   * Lock-1 §K3 — the LEGAL candidates for a `prior_node_approver` picker on `nodeKey`'s card:
+   * approval nodes strictly upstream on every runtime-reachable path (the shipped provider derives
+   * them from the live effective graph via `legalPriorApproverNodeKeys`, approvalNodeEdit.ts —
+   * the FE mirror of the backend publish dominance gate), each with its display label. The
+   * editor renders a TYPED node select over exactly this list (D0 §10.2 — never a free-text key
+   * input). OPTIONAL only so component-level tests that don't exercise K3 can omit it (the
+   * property is always present on the shipped app's api object); absent ⇒ the picker offers no
+   * candidates (fail-closed: nothing to select, nothing mutated).
+   */
+  priorApproverNodeOptions?: (nodeKey: string) => Array<{ key: string; label: string }>
   onUserSearch: (query: string) => void | Promise<void>
   directoryUsers: ComputedRef<Array<{ id: string }>> | Ref<Array<{ id: string }>> | Array<{ id: string }>
   directoryUsersLoading: ComputedRef<boolean> | Ref<boolean> | boolean

--- a/apps/web/src/approvals/parallelEdit.ts
+++ b/apps/web/src/approvals/parallelEdit.ts
@@ -163,6 +163,11 @@ function dynamicAssigneeSourceFingerprint(source: ApprovalAssigneeSource): strin
       return `continuous_dept_heads:${source.levels}`
     case 'dept_head_at_level':
       return `dept_head_at_level:${source.level}`
+    case 'prior_node_approver':
+      // Lock-1 §K3 / §2.4 locked entry (backend mirror — keep in lockstep): provably identical
+      // for the same referenced node — two branches asking "the deciders of node X" resolve the
+      // same people on every request.
+      return `prior_node_approver:${source.nodeKey}`
     case 'form_field_user':
       return `form_field_user:${source.fieldId.trim()}`
     case 'static_user':
@@ -182,7 +187,10 @@ function dynamicAssigneeSourceFingerprint(source: ApprovalAssigneeSource): strin
   }
 }
 
-function runtimeSuccessorTargets(
+// Exported for `approvalNodeEdit.ts`'s Lock-1 §K3 `legalPriorApproverNodeKeys` (the prior-node
+// picker's dominance walk) so both FE graph walks share ONE runtime-successor semantic — the
+// mirror of the backend's own `runtimeSuccessorTargets`.
+export function runtimeSuccessorTargets(
   node: ApprovalNode,
   edgeByKey: Map<string, ApprovalGraph['edges'][number]>,
   outgoingBySource: Map<string, ApprovalGraph['edges']>,

--- a/apps/web/src/approvals/templateAuthoring.ts
+++ b/apps/web/src/approvals/templateAuthoring.ts
@@ -68,7 +68,7 @@ export { PARALLEL_JOIN_MODES, parallelDynamicAssigneeConflicts } from './paralle
 export type { CcEdits, CcNodeEdit } from './ccEdit'
 export { CC_TARGET_TYPES } from './ccEdit'
 export type { ApprovalNodeEdits, ApprovalNodeSourceEdit } from './approvalNodeEdit'
-export { placeholderRoleNodeKeys, isPlaceholderRoleSource, addAssigneeSourceCard, removeAssigneeSourceCard } from './approvalNodeEdit'
+export { placeholderRoleNodeKeys, isPlaceholderRoleSource, addAssigneeSourceCard, removeAssigneeSourceCard, legalPriorApproverNodeKeys } from './approvalNodeEdit'
 
 export type AuthorableFieldType = Exclude<FormFieldType, 'attachment'>
 export type ApprovalStepSourceKind = ApprovalAssigneeSource['kind']
@@ -178,6 +178,13 @@ export interface ApprovalStepDraft {
   // chooser to a configured list, carried in the SAME `idsText` chip carrier the static
   // pickers use (userIds for members, roleIds for role) — sourceFromStep re-shapes it.
   requesterChoiceScopeType: 'company' | 'members' | 'role'
+  // Lock-1 §K3 (节点审批人) — meaningful only when `sourceKind === 'prior_node_approver'`: the
+  // `localId` of the EARLIER step whose actual decider(s) this step re-asks. Deliberately a
+  // step-localId reference, NOT a raw node key: the linear builder regenerates node keys
+  // positionally (`approval_${index+1}`), so a stored key would silently RETARGET when steps are
+  // inserted/reordered — the localId reference follows the intended step and `sourceFromStep`
+  // emits that step's CURRENT key at build time. `''` = not yet chosen (invalid to save).
+  priorStepLocalId: string
   approvalMode: ApprovalMode
   emptyAssigneePolicy: EmptyAssigneePolicy
   // Self-approver authoring: the editable toggle (merge the requester in as an
@@ -344,6 +351,7 @@ export function createEmptyStepDraft(index = 1): ApprovalStepDraft {
     level: 1,
     requesterChoiceMode: 'single',
     requesterChoiceScopeType: 'company',
+    priorStepLocalId: '',
     approvalMode: 'single',
     emptyAssigneePolicy: 'error',
     mergeWithRequester: false,
@@ -538,6 +546,9 @@ function stepDraftFromApprovalNode(
   let level = 1
   let requesterChoiceMode: 'single' | 'multi' = 'single'
   let requesterChoiceScopeType: 'company' | 'members' | 'role' = 'company'
+  // Lock-1 §K3: hydrated as '' here (this per-node projection has no cross-step context);
+  // `draftFromTemplate` resolves the stored nodeKey to the referenced EARLIER step's localId in a
+  // post-pass over the ordered chain.
   if (source?.kind === 'static_user') {
     sourceKind = 'static_user'
     idsText = formatIds(source.userIds)
@@ -575,6 +586,10 @@ function stepDraftFromApprovalNode(
     requesterChoiceScopeType = source.scope.type
     if (source.scope.type === 'members') idsText = formatIds(source.scope.userIds)
     else if (source.scope.type === 'role') idsText = formatIds(source.scope.roleIds)
+  } else if (source?.kind === 'prior_node_approver') {
+    // Lock-1 §K3: the stored nodeKey → step-localId resolution happens in draftFromTemplate's
+    // post-pass (see priorStepLocalId's field doc for why the draft carries a localId reference).
+    sourceKind = 'prior_node_approver'
   } else if (legacyType === 'user') {
     sourceKind = 'static_user'
     idsText = formatIds(legacyIds)
@@ -607,6 +622,7 @@ function stepDraftFromApprovalNode(
     level,
     requesterChoiceMode,
     requesterChoiceScopeType,
+    priorStepLocalId: '',
     approvalMode: config.approvalMode === 'all' || config.approvalMode === 'any' ? config.approvalMode : 'single',
     emptyAssigneePolicy: config.emptyAssigneePolicy === 'auto-approve' ? 'auto-approve' : 'error',
     mergeWithRequester,
@@ -728,6 +744,8 @@ const BACKEND_ASSIGNEE_SOURCE_KEYS_BY_KIND: Record<string, string[]> = {
   continuous_dept_heads: ['kind', 'levels'],
   // Lock-1 §K5-b: same flat 2-level shape as manager_at_level.
   dept_head_at_level: ['kind', 'level'],
+  // Lock-1 §K3: flat 2-level shape — the referenced prior node's key.
+  prior_node_approver: ['kind', 'nodeKey'],
   form_field_user: ['kind', 'fieldId'],
   // Lock-1 §K2: `scope` is the ONE nested object in the source union (see
   // requesterChoiceSourceHasBackendDrop below for its per-type key check — the flat 2-level
@@ -924,10 +942,23 @@ export function unsupportedTemplateAuthoringReason(template: ApprovalTemplateDet
     if (sources !== undefined) {
       if (!Array.isArray(sources) || sources.length !== 1) return true
       const source = sources[0] as ApprovalAssigneeSource
-      if (!['static_user', 'static_role', 'requester', 'form_field_user', 'direct_manager', 'dept_head', 'continuous_managers', 'manager_at_level', 'requester_choice', 'continuous_dept_heads', 'dept_head_at_level'].includes(source?.kind)) return true
+      if (!['static_user', 'static_role', 'requester', 'form_field_user', 'direct_manager', 'dept_head', 'continuous_managers', 'manager_at_level', 'requester_choice', 'continuous_dept_heads', 'dept_head_at_level', 'prior_node_approver'].includes(source?.kind)) return true
       // Lock-1 §K2: a malformed requester_choice shape must fail-closed to read-only here too —
       // hydrate would otherwise re-derive a default mode/scope and silently flatten it on save.
       if (source?.kind === 'requester_choice' && requesterChoiceSourceHasBackendDrop(source as unknown as Record<string, unknown>)) return true
+      // Lock-1 §K3: a prior_node_approver whose nodeKey is NOT an earlier approval node of this
+      // ordered linear chain (dangling / self / downstream) must fail-closed to read-only —
+      // hydrate's post-pass could not resolve it to a step-localId, so a re-save through the
+      // linear builder would silently emit an empty/retargeted reference. (The backend publish
+      // dominance gate is the arbiter; this only refuses to EDIT what the linear model cannot
+      // faithfully carry.)
+      if (source?.kind === 'prior_node_approver') {
+        const priorApprovalKeys = ordered
+          .slice(0, ordered.indexOf(node))
+          .filter((candidate) => candidate.type === 'approval')
+          .map((candidate) => candidate.key)
+        if (!priorApprovalKeys.includes(source.nodeKey)) return true
+      }
     }
     // T1-4: `buildStepConfig` re-emits only { fieldId, access } per entry (the backend allowlist),
     // so a linear node carrying an ARRAY-shaped fieldPermissions with an extra key or non-object
@@ -976,6 +1007,30 @@ export function draftFromTemplate(template: ApprovalTemplateDetailDTO): Template
     : ordered
         .map(stepDraftFromApprovalNode)
         .filter((step): step is ApprovalStepDraft => step !== null)
+
+  // Lock-1 §K3 post-pass: resolve each stored `prior_node_approver` nodeKey into the referenced
+  // EARLIER step's localId (steps[i] ↔ the i-th approval node of the ordered linear chain). The
+  // localId reference — not the raw key — is what the draft carries, so inserting/reordering
+  // steps can never silently retarget the reference (the builder re-emits the referenced step's
+  // CURRENT positional key). A reference that does not resolve to an earlier approval node stays
+  // '' — `unsupportedTemplateAuthoringReason` already forces such a template read-only (save
+  // disabled), so the '' default is unreachable on an editable draft.
+  if (!complex) {
+    const orderedApprovalNodes = ordered.filter((node) => node.type === 'approval')
+    orderedApprovalNodes.forEach((node, index) => {
+      const step = steps[index]
+      if (!step || step.sourceKind !== 'prior_node_approver') return
+      const config = node.config as Record<string, unknown>
+      const source = Array.isArray(config.assigneeSources)
+        ? config.assigneeSources[0] as ApprovalAssigneeSource | undefined
+        : undefined
+      if (source?.kind !== 'prior_node_approver') return
+      const referencedIndex = orderedApprovalNodes.findIndex((candidate) => candidate.key === source.nodeKey)
+      if (referencedIndex >= 0 && referencedIndex < index) {
+        step.priorStepLocalId = steps[referencedIndex].localId
+      }
+    })
+  }
 
   return {
     templateId: template.id,
@@ -1140,8 +1195,15 @@ export function buildFormSchema(draft: TemplateAuthoringDraft): FormSchema {
 
 /** Exported (G-B2-06) so `linearStepSpine.ts` can derive the same `ApprovalAssigneeSource` the
  * saved graph would carry and feed it to the shared `assigneeSourceSummary` humanizer, instead of
- * re-deriving a second sourceKind→text switch that could drift from this one. */
-export function sourceFromStep(step: ApprovalStepDraft): ApprovalAssigneeSource {
+ * re-deriving a second sourceKind→text switch that could drift from this one.
+ *
+ * Lock-1 §K3: `allSteps` (the draft's full ordered step list) is needed ONLY by
+ * `prior_node_approver` — the emitted `nodeKey` is the referenced step's CURRENT positional key
+ * (`approval_${index+1}`, the linear builder's own key scheme), derived from the step-localId
+ * reference at build time so insert/reorder can never silently retarget it. Callers without the
+ * list (none in-repo) would emit an empty `nodeKey`, which both the FE validation and the backend
+ * normalize choke reject — fail-closed, never a silently-wrong reference. */
+export function sourceFromStep(step: ApprovalStepDraft, allSteps?: ApprovalStepDraft[]): ApprovalAssigneeSource {
   if (step.sourceKind === 'static_user') {
     return { kind: 'static_user', userIds: parseIdsText(step.idsText) }
   }
@@ -1181,6 +1243,18 @@ export function sourceFromStep(step: ApprovalStepDraft): ApprovalAssigneeSource 
           : { type: 'company' as const }
     return { kind: 'requester_choice', mode: step.requesterChoiceMode, scope }
   }
+  if (step.sourceKind === 'prior_node_approver') {
+    // Lock-1 §K3: emit the referenced step's CURRENT positional key (see the docstring). An
+    // unresolved reference (missing localId / referenced step deleted or not EARLIER than this
+    // one) emits '' — rejected by validateTemplateApprovalFlow and by the backend normalize
+    // choke, never silently pointed elsewhere.
+    const stepIndex = allSteps?.findIndex((candidate) => candidate.localId === step.localId) ?? -1
+    const referencedIndex = allSteps?.findIndex((candidate) => candidate.localId === step.priorStepLocalId) ?? -1
+    const nodeKey = referencedIndex >= 0 && stepIndex >= 0 && referencedIndex < stepIndex
+      ? `approval_${referencedIndex + 1}`
+      : ''
+    return { kind: 'prior_node_approver', nodeKey }
+  }
   return { kind: 'requester' }
 }
 
@@ -1192,7 +1266,7 @@ export function sourceFromStep(step: ApprovalStepDraft): ApprovalAssigneeSource 
  * mirroring `buildFormSchema`'s `delete next.visibilityRule` omit-empty discipline so a
  * bare `{}` is never persisted.
  */
-function buildStepConfig(step: ApprovalStepDraft, fieldIds: Set<string>): ApprovalNodeConfig {
+function buildStepConfig(step: ApprovalStepDraft, fieldIds: Set<string>, allSteps: ApprovalStepDraft[]): ApprovalNodeConfig {
   const autoApprovalPolicy: AutoApprovalPolicy = {
     ...step.originalAutoApprovalPolicy,
     ...(step.mergeWithRequester ? { mergeWithRequester: true } : {}),
@@ -1211,7 +1285,7 @@ function buildStepConfig(step: ApprovalStepDraft, fieldIds: Set<string>): Approv
     .filter((permission) => permission.access !== 'editable' && fieldIds.has(permission.fieldId))
     .map((permission) => ({ fieldId: permission.fieldId, access: permission.access }))
   return {
-    assigneeSources: [sourceFromStep(step)],
+    assigneeSources: [sourceFromStep(step, allSteps)],
     approvalMode: step.approvalMode,
     emptyAssigneePolicy: step.emptyAssigneePolicy,
     ...(Object.keys(autoApprovalPolicy).length > 0 ? { autoApprovalPolicy } : {}),
@@ -1243,7 +1317,9 @@ export function buildApprovalGraph(draft: TemplateAuthoringDraft): ApprovalGraph
     key: `approval_${index + 1}`,
     type: 'approval' as const,
     name: step.name.trim() || `审批人 ${index + 1}`,
-    config: buildStepConfig(step, fieldIds),
+    // Lock-1 §K3: the full step list rides along so a prior_node_approver step can emit its
+    // referenced step's CURRENT positional key (localId reference → key at build time).
+    config: buildStepConfig(step, fieldIds, draft.steps),
   }))
   const nodes: ApprovalGraph['nodes'] = [
     { key: 'start', type: 'start', name: '发起', config: {} },
@@ -1597,6 +1673,16 @@ export function validateTemplateApprovalFlow(draft: TemplateAuthoringDraft): str
       && parseIdsText(step.idsText).length === 0
     ) {
       errors.push(`${label} 的提交人自选范围需要选择成员/角色`)
+    }
+    // Lock-1 §K3 PREVIEW (the backend publish dominance gate is the final arbiter): the
+    // referenced step must exist and be STRICTLY EARLIER than this one — a missing choice, a
+    // deleted referenced step, a self-reference, or a reference that ended up at/after this step
+    // via reorder all fail here (matching what `sourceFromStep` would emit as an empty nodeKey).
+    if (step.sourceKind === 'prior_node_approver') {
+      const referencedIndex = draft.steps.findIndex((candidate) => candidate.localId === step.priorStepLocalId)
+      if (referencedIndex < 0 || referencedIndex >= index) {
+        errors.push(`${label} 需要引用一个位于其之前的审批步骤作为节点审批人`)
+      }
     }
   })
   return errors

--- a/apps/web/src/types/approval.ts
+++ b/apps/web/src/types/approval.ts
@@ -18,7 +18,7 @@ export const APPROVAL_ROLE_CONFIGURE_SENTINEL = '__APPROVAL_ROLE_PLACEHOLDER__'
 // `APPROVAL_NODE_TYPES` admission set.
 export type ApprovalNodeType = 'start' | 'approval' | 'cc' | 'condition' | 'parallel' | 'end' | 'handler'
 export type ApprovalAssigneeType = 'user' | 'role'
-export type ApprovalAssigneeSourceKind = 'static_user' | 'static_role' | 'requester' | 'form_field_user' | 'direct_manager' | 'dept_head' | 'continuous_managers' | 'manager_at_level' | 'requester_choice' | 'continuous_dept_heads' | 'dept_head_at_level'
+export type ApprovalAssigneeSourceKind = 'static_user' | 'static_role' | 'requester' | 'form_field_user' | 'direct_manager' | 'dept_head' | 'continuous_managers' | 'manager_at_level' | 'requester_choice' | 'continuous_dept_heads' | 'dept_head_at_level' | 'prior_node_approver'
 export type ApprovalMode = 'single' | 'all' | 'any'
 export type ParallelJoinMode = 'all' | 'any'
 export type EmptyAssigneePolicy = 'error' | 'auto-approve'
@@ -173,6 +173,16 @@ export type ApprovalAssigneeSource =
    * level count).
    */
   | { kind: 'dept_head_at_level'; level: number }
+  /**
+   * Lock-1 §K3 — 节点审批人 (prior-node approver). Byte-mirrors the backend union member:
+   * `nodeKey` references an `approval` node strictly upstream on EVERY runtime-reachable path
+   * (a publish-time dominance check — dangling / downstream / self / branch-only references fail
+   * publish). Resolution happens at dispatch from the INSTANCE's own audit rows (the referenced
+   * node's actual deciders, latest round, system sentinels dropped) — never a directory read.
+   * The authoring picker is a TYPED node select restricted to the legal upstream set
+   * (`legalPriorApproverNodeKeys`), never a free-text key input.
+   */
+  | { kind: 'prior_node_approver'; nodeKey: string }
 
 export type RequesterChoiceAssigneeSource = Extract<ApprovalAssigneeSource, { kind: 'requester_choice' }>
 

--- a/apps/web/src/views/approval/TemplateAuthoringView.vue
+++ b/apps/web/src/views/approval/TemplateAuthoringView.vue
@@ -571,6 +571,7 @@
                 <el-option label="提交人自选" value="requester_choice" />
                 <el-option label="连续多级部门负责人" value="continuous_dept_heads" />
                 <el-option label="指定层级部门负责人" value="dept_head_at_level" />
+                <el-option label="节点审批人" value="prior_node_approver" />
               </el-select>
             </el-form-item>
             <el-form-item v-if="step.sourceKind === 'continuous_managers'" label="上级层级数">
@@ -619,6 +620,26 @@
                 :disabled="readOnly"
                 data-testid="approval-step-dept-head-level"
               />
+            </el-form-item>
+            <!-- Lock-1 §K3 (节点审批人) linear authoring: a TYPED picker over the STRICTLY-EARLIER
+                 steps only (never a free-text node key). The reference is stored as the earlier
+                 step's stable localId, so insert/reorder can never silently retarget it; the
+                 builder emits that step's current positional key at save. -->
+            <el-form-item v-if="step.sourceKind === 'prior_node_approver'" label="引用审批步骤">
+              <el-select
+                v-model="step.priorStepLocalId"
+                :disabled="readOnly"
+                class="ms-w-100pct"
+                placeholder="选择之前的审批步骤"
+                data-testid="approval-step-prior-node"
+              >
+                <el-option
+                  v-for="option in priorStepOptions(index)"
+                  :key="option.localId"
+                  :label="option.label"
+                  :value="option.localId"
+                />
+              </el-select>
             </el-form-item>
             <el-form-item v-if="step.sourceKind === 'static_user'" label="选择用户">
               <el-select
@@ -1219,6 +1240,7 @@ import {
   isPlaceholderRoleSource,
   addAssigneeSourceCard,
   removeAssigneeSourceCard,
+  legalPriorApproverNodeKeys,
   approvalFormulaInsertOptions,
   parallelDynamicAssigneeConflicts,
   CONDITION_RULE_OPERATORS,
@@ -1860,6 +1882,25 @@ function graphNodeLabel(nodeKey: string): string {
   return node.name?.trim() || nodeTypeLabel(node.type)
 }
 
+// Lock-1 §K3 — the LEGAL candidates for a prior_node_approver picker on `nodeKey`'s card:
+// approval nodes strictly upstream on every runtime-reachable path of the LIVE effective graph
+// (`legalPriorApproverNodeKeys`, the FE mirror of the backend publish dominance gate — which
+// stays the sole arbiter). Labels reuse `graphNodeLabel` (template-authored names, never ids).
+function priorApproverNodeOptions(nodeKey: string): Array<{ key: string; label: string }> {
+  return legalPriorApproverNodeKeys(canvasEffectiveGraph.value, nodeKey)
+    .map((key) => ({ key, label: graphNodeLabel(key) }))
+}
+
+// Lock-1 §K3 — the linear editor's picker candidates for step `index`: the STRICTLY-EARLIER
+// steps only (referenced by stable localId; the builder emits the referenced step's current
+// positional key at save — see ApprovalStepDraft.priorStepLocalId).
+function priorStepOptions(index: number): Array<{ localId: string; label: string }> {
+  return draft.value.steps.slice(0, index).map((candidate, candidateIndex) => ({
+    localId: candidate.localId,
+    label: candidate.name.trim() || `审批人 ${candidateIndex + 1}`,
+  }))
+}
+
 function graphEdgeTargetLabel(nodeKey: string, edgeKey: string): string {
   const edge = canvasEffectiveGraph.value.edges.find(
     (candidate) => candidate.source === nodeKey && candidate.key === edgeKey,
@@ -2025,7 +2066,10 @@ function defaultApprovalSourceForKind(kind: ApprovalAssigneeSourceKind): Approva
               : kind === 'continuous_dept_heads' ? { kind, levels: 1 }
                 // Lock-1 §K5-b: same default shape as manager_at_level.
                 : kind === 'dept_head_at_level' ? { kind, level: 1 }
-                  : { kind: kind as 'requester' | 'direct_manager' | 'dept_head' }
+                  // Lock-1 §K3: '' = not yet chosen — invalid to save until the typed picker
+                  // selects a legal upstream node (never silently defaulted to one).
+                  : kind === 'prior_node_approver' ? { kind, nodeKey: '' }
+                    : { kind: kind as 'requester' | 'direct_manager' | 'dept_head' }
 }
 function setApprovalSourceKind(nodeKey: string, sourceIndex: number, kind: ApprovalAssigneeSourceKind): void {
   const cacheKey = approvalSourceKindCacheKey(nodeKey, sourceIndex)
@@ -2854,6 +2898,8 @@ const nodeConfigEditorApi: ApprovalNodeConfigEditorApi = {
   conditionEdgeLabel,
   graphEdgeTargetLabel,
   graphNodeLabel,
+  // Lock-1 §K3: legal upstream candidates for the prior_node_approver typed node picker.
+  priorApproverNodeOptions,
   parallelJoinModeLabel,
   ccTargetTypeLabel,
   approvalSourceKind,

--- a/apps/web/tests/approval-assignee-source.test.ts
+++ b/apps/web/tests/approval-assignee-source.test.ts
@@ -65,6 +65,11 @@ describe('assigneeSourceSummary (single source)', () => {
     expect(membersScoped).not.toContain('secret_user_1')
   })
 
+  it('prior_node_approver: names the referenced node key (template-authored, §2.6-permitted) — never a person id (Lock-1 §K3)', () => {
+    expect(assigneeSourceSummary({ kind: 'prior_node_approver', nodeKey: 'approval_1' }))
+      .toBe('节点审批人（引用节点 approval_1）')
+  })
+
   // Lock-1 §2.5 item 5: the old `JSON.stringify(source)` default leaked raw config (raw IDs
   // included) into an ordinary-user surface — a defect, not a precedent. The default is now a
   // VALUES-FREE fixed label. G-16's "no JSON.stringify fallback reaches any surface" half.

--- a/apps/web/tests/approval-handler-node-authoring.spec.ts
+++ b/apps/web/tests/approval-handler-node-authoring.spec.ts
@@ -72,6 +72,9 @@ describe('Lock-3 G-13 — handler assignee-source registry exact set', () => {
     // doc comment), K5-b's own slice does not widen the SEVEN-member handler roster either. Not
     // admitting it here is the deliberate deferral, not an oversight.
     expect(roster).not.toContain('dept_head_at_level')
+    // Lock-1 §K3 `prior_node_approver`: unlike K5-b, Lock-3 §1.5 lists NO forward ADMIT row for
+    // this kind at all — its absence from the handler roster is the contract, not a deferral.
+    expect(roster).not.toContain('prior_node_approver')
   })
 
   it('mutation 1 — dropping an admitted kind fails the exact-set check', () => {
@@ -99,6 +102,17 @@ describe('Lock-3 G-13 — handler assignee-source registry exact set', () => {
   it('mutation 3 — adding dept_head_at_level (Lock-1 §K5-b, deliberately deferred) fails the exact-set check', () => {
     const added: ApprovalCapabilityRegistry = {
       assigneeSourcesByNodeType: { handler: [...assigneeSourceRoster(DEFAULT_APPROVAL_CAPABILITY_REGISTRY, 'handler'), { kind: 'dept_head_at_level', label: '指定层级部门负责人' }] },
+      operationPoliciesByNodeType: {},
+    }
+    const roster = assigneeSourceRoster(added, 'handler').map((c) => c.kind)
+    expect(new Set(roster)).not.toEqual(new Set(HANDLER_ASSIGNEE_SOURCE_KINDS))
+  })
+
+  // Lock-1 §K3: prior_node_approver has NO handler row in Lock-3 §1.5 (not even forward) —
+  // "adding" it must fail the exact-set check exactly like the probes above.
+  it('mutation 4 — adding prior_node_approver (Lock-1 §K3, no handler row exists) fails the exact-set check', () => {
+    const added: ApprovalCapabilityRegistry = {
+      assigneeSourcesByNodeType: { handler: [...assigneeSourceRoster(DEFAULT_APPROVAL_CAPABILITY_REGISTRY, 'handler'), { kind: 'prior_node_approver', label: '节点审批人' }] },
       operationPoliciesByNodeType: {},
     }
     const roster = assigneeSourceRoster(added, 'handler').map((c) => c.kind)

--- a/apps/web/tests/approval-template-authoring-approval-node-edit.test.ts
+++ b/apps/web/tests/approval-template-authoring-approval-node-edit.test.ts
@@ -11,6 +11,7 @@ import {
   addAssigneeSourceCard,
   applyApprovalNodeEditsToGraph,
   approvalNodeEditsFromGraph,
+  legalPriorApproverNodeKeys,
   placeholderRoleNodeKeys,
   removeAssigneeSourceCard,
   validateApprovalNodeEdits,
@@ -264,6 +265,81 @@ describe('validateApprovalNodeEdits (preview mirrors the backend assignee rule)'
       a: { nodeKey: 'a', nodeType: 'handler', assigneeSources: [{ kind: 'dept_head_at_level', level: 1 }] },
     })[0]).toMatch(/dept_head_at_level/)
   })
+
+  it('Lock-1 §K3: prior_node_approver — a non-empty nodeKey passes; an empty/blank one is flagged (isAssigneeSourceValid mirror site)', () => {
+    expect(validateApprovalNodeEdits({
+      a: { nodeKey: 'a', assigneeSources: [{ kind: 'prior_node_approver', nodeKey: 'gate' }] },
+    })).toEqual([])
+    expect(validateApprovalNodeEdits({
+      a: { nodeKey: 'a', assigneeSources: [{ kind: 'prior_node_approver', nodeKey: '' }] },
+    })[0]).toMatch(/prior_node_approver/)
+    expect(validateApprovalNodeEdits({
+      a: { nodeKey: 'a', assigneeSources: [{ kind: 'prior_node_approver', nodeKey: '   ' }] },
+    })[0]).toMatch(/prior_node_approver/)
+  })
+  // Lock-3 §1.5: prior_node_approver (K3) has NO handler row at all (not even a forward ADMIT) —
+  // a handler carrying it must fail closed.
+  it('Lock-1 §K3 / Lock-3 §1.5: a HANDLER node carrying prior_node_approver is rejected (not in the seven-member handler roster)', () => {
+    expect(validateApprovalNodeEdits({
+      a: { nodeKey: 'a', nodeType: 'handler', assigneeSources: [{ kind: 'prior_node_approver', nodeKey: 'gate' }] },
+    })[0]).toMatch(/prior_node_approver/)
+  })
+})
+
+// Lock-1 §K3 — legalPriorApproverNodeKeys: the FE mirror of the backend publish dominance gate
+// (`assertPriorNodeApproverReferencesUpstream`), driving the typed node picker. Candidate ⟺
+// approval node, ≠ carrier, strictly upstream on EVERY runtime-reachable path (removal test).
+// The full shape matrix (condition-branch / parallel-sibling / downstream / dangling) is owned by
+// the backend gate's own unit suite; this proves the MIRROR agrees on the discriminating shapes.
+describe('Lock-1 §K3: legalPriorApproverNodeKeys (typed picker candidates)', () => {
+  it('linear chain: offers exactly the strictly-earlier approval nodes (never self, never downstream, never start/end)', () => {
+    const graph: ApprovalGraph = {
+      nodes: [
+        { key: 'start', type: 'start', name: '发起', config: {} },
+        { key: 'a1', type: 'approval', name: '一审', config: { assigneeSources: [{ kind: 'requester' }] } },
+        { key: 'a2', type: 'approval', name: '二审', config: { assigneeSources: [{ kind: 'requester' }] } },
+        { key: 'a3', type: 'approval', name: '三审', config: { assigneeSources: [{ kind: 'requester' }] } },
+        { key: 'end', type: 'end', name: '结束', config: {} },
+      ],
+      edges: [
+        { key: 'e1', source: 'start', target: 'a1' },
+        { key: 'e2', source: 'a1', target: 'a2' },
+        { key: 'e3', source: 'a2', target: 'a3' },
+        { key: 'e4', source: 'a3', target: 'end' },
+      ],
+    }
+    expect(legalPriorApproverNodeKeys(graph, 'a3')).toEqual(['a1', 'a2'])
+    expect(legalPriorApproverNodeKeys(graph, 'a2')).toEqual(['a1'])
+    // The first approval node has nothing upstream — an empty candidate list (positive control
+    // that the non-empty lists above are carrier-selected, not a constant).
+    expect(legalPriorApproverNodeKeys(graph, 'a1')).toEqual([])
+  })
+
+  it('condition merge: a node reachable only through ONE branch is NOT offered after the merge; the pre-condition node is', () => {
+    const graph: ApprovalGraph = {
+      nodes: [
+        { key: 'start', type: 'start', name: '发起', config: {} },
+        { key: 'pre', type: 'approval', name: '预审', config: { assigneeSources: [{ kind: 'requester' }] } },
+        { key: 'route', type: 'condition', name: '判断', config: { branches: [{ edgeKey: 'edge-b1', rules: [{ fieldId: 'amount', operator: 'gt', value: 1 }] }], defaultEdgeKey: 'edge-b2' } },
+        { key: 'branch-a', type: 'approval', name: '高额', config: { assigneeSources: [{ kind: 'requester' }] } },
+        { key: 'branch-b', type: 'approval', name: '低额', config: { assigneeSources: [{ kind: 'requester' }] } },
+        { key: 'merge', type: 'approval', name: '终审', config: { assigneeSources: [{ kind: 'requester' }] } },
+        { key: 'end', type: 'end', name: '结束', config: {} },
+      ],
+      edges: [
+        { key: 'e1', source: 'start', target: 'pre' },
+        { key: 'e2', source: 'pre', target: 'route' },
+        { key: 'edge-b1', source: 'route', target: 'branch-a' },
+        { key: 'edge-b2', source: 'route', target: 'branch-b' },
+        { key: 'e3', source: 'branch-a', target: 'merge' },
+        { key: 'e4', source: 'branch-b', target: 'merge' },
+        { key: 'e5', source: 'merge', target: 'end' },
+      ],
+    }
+    expect(legalPriorApproverNodeKeys(graph, 'merge')).toEqual(['pre'])
+    // Within a branch, the pre-condition node is still on every path — offered.
+    expect(legalPriorApproverNodeKeys(graph, 'branch-a')).toEqual(['pre'])
+  })
 })
 
 describe('G-5 fail-closed — complex approval-node config must stay within the BACKEND allowlist', () => {
@@ -374,6 +450,18 @@ describe('G-5 fail-closed — complex approval-node config must stay within the 
   })
   it('K5-b: a dept_head_at_level source with an unknown extra key forces read-only', () => {
     const graph = complexWith({ assigneeSources: [{ kind: 'dept_head_at_level', level: 2, futureFlag: true }] })
+    expect(unsupportedTemplateAuthoringReason(buildTemplate(graph))).not.toBeNull()
+  })
+
+  // Lock-1 §K3 — BACKEND_ASSIGNEE_SOURCE_KEYS_BY_KIND mirror site: prior_node_approver must be
+  // ALLOWED (present in the allowlist) on the complex path, and an extra key on it must still be
+  // caught (the allowlist is per-kind exact, not a blanket pass-through).
+  it('K3: prior_node_approver is allowed on the complex path (registered in BACKEND_ASSIGNEE_SOURCE_KEYS_BY_KIND)', () => {
+    const graph = complexWith({ assigneeSources: [{ kind: 'prior_node_approver', nodeKey: 'approval_0' }] })
+    expect(unsupportedTemplateAuthoringReason(buildTemplate(graph))).toBeNull()
+  })
+  it('K3: a prior_node_approver source with an unknown extra key forces read-only', () => {
+    const graph = complexWith({ assigneeSources: [{ kind: 'prior_node_approver', nodeKey: 'approval_0', futureFlag: true }] })
     expect(unsupportedTemplateAuthoringReason(buildTemplate(graph))).not.toBeNull()
   })
 })

--- a/apps/web/tests/approval-template-authoring-canvas-inspector.spec.ts
+++ b/apps/web/tests/approval-template-authoring-canvas-inspector.spec.ts
@@ -983,7 +983,7 @@ describe('Canvas V2 Slice A — canvas inspector', () => {
   // "iterate the exported table" mechanical assertion, not per-kind spot checks), so any single
   // label reverting to pre-D1 wording (or drifting to anything else) reds here regardless of
   // whether it happens to be one of the two kinds the D1/D2 test exercises.
-  it('D1 (P2-2): all eleven assignee-source labels equal the ratified map by exact object equality', () => {
+  it('D1 (P2-2): all twelve assignee-source labels equal the ratified map by exact object equality', () => {
     const RATIFIED_APPROVAL_ASSIGNEE_SOURCE_LABELS: Record<string, string> = {
       static_user: '指定成员',
       static_role: '指定角色',
@@ -1003,11 +1003,16 @@ describe('Canvas V2 Slice A — canvas inspector', () => {
       // SAME slice that lands the resolver arm end to end (Lock-1 §2.3 table: "Admitted when: K4
       // landed").
       dept_head_at_level: '指定层级部门负责人',
+      // Lock-1 §K3 (RATIFIED 2026-08-17) — the 节点审批人 registry row, admitted in the SAME
+      // slice that lands the dominance validator + caller-supplied decider resolution end to end
+      // (Lock-1 §2.3 table: "Admitted when: OD-L1-3 + OD-L1-4 decided; dominance validator
+      // landed" — both recorded (a) in the §4 block).
+      prior_node_approver: '节点审批人',
     }
     expect(APPROVAL_ASSIGNEE_SOURCE_LABELS).toEqual(RATIFIED_APPROVAL_ASSIGNEE_SOURCE_LABELS)
-    // Also pin the count so a stray 12th entry (which would still satisfy `toEqual` on the keys
+    // Also pin the count so a stray 13th entry (which would still satisfy `toEqual` on the keys
     // above via structural superset checks in some matcher semantics) cannot slip through unnoticed.
-    expect(Object.keys(APPROVAL_ASSIGNEE_SOURCE_LABELS)).toHaveLength(11)
+    expect(Object.keys(APPROVAL_ASSIGNEE_SOURCE_LABELS)).toHaveLength(12)
   })
 
   it('A-7: no scrim/overlay-mask element with the inspector mounted and visible', async () => {
@@ -1765,11 +1770,11 @@ describe('Lock-0 P1-A — registry-driven tab membership + roster (direct mount)
     unmount()
   })
 
-  it('A-3: roster equals the eleven-member ApprovalAssigneeSourceKind union by exact set equality, not count or subset', () => {
+  it('A-3: roster equals the twelve-member ApprovalAssigneeSourceKind union by exact set equality, not count or subset', () => {
     // Lock-1 §2.3: the exact-set gate grows from eight to eight-plus-ratified-K-kinds in the
     // SAME commit that lands each kind — K2 `requester_choice`, K4 `continuous_dept_heads`, K5-b
-    // `dept_head_at_level`.
-    const CANONICAL_ELEVEN = [
+    // `dept_head_at_level`, K3 `prior_node_approver`.
+    const CANONICAL_TWELVE = [
       'continuous_dept_heads',
       'continuous_managers',
       'dept_head',
@@ -1777,6 +1782,7 @@ describe('Lock-0 P1-A — registry-driven tab membership + roster (direct mount)
       'direct_manager',
       'form_field_user',
       'manager_at_level',
+      'prior_node_approver',
       'requester',
       'requester_choice',
       'static_role',
@@ -1785,7 +1791,7 @@ describe('Lock-0 P1-A — registry-driven tab membership + roster (direct mount)
     const roster = [...assigneeSourceRoster(DEFAULT_APPROVAL_CAPABILITY_REGISTRY, 'approval')]
       .map((opt) => opt.kind)
       .sort()
-    expect(roster).toEqual(CANONICAL_ELEVEN)
+    expect(roster).toEqual(CANONICAL_TWELVE)
 
     const node = makeApprovalNode('approval_x')
     const { container: c, unmount } = mountDirectInspector({
@@ -1798,7 +1804,7 @@ describe('Lock-0 P1-A — registry-driven tab membership + roster (direct mount)
     )
       .map((el) => el.getAttribute('data-testid')?.replace('approval-node-source-kind-', ''))
       .sort()
-    expect(rendered).toEqual(CANONICAL_ELEVEN)
+    expect(rendered).toEqual(CANONICAL_TWELVE)
     unmount()
   })
 
@@ -1838,6 +1844,41 @@ describe('Lock-0 P1-A — registry-driven tab membership + roster (direct mount)
     expect(c.querySelector('[data-testid="approval-node-source-level"]')).not.toBeNull()
     expect(c.querySelector('[data-testid="approval-node-source-kind-unknown"]')).toBeNull()
     unmount()
+  })
+
+  // Lock-1 §K3 — prior_node_approver authoring sub-form: registry-admitted, renders EDITABLE with
+  // the TYPED node picker (a select over the api-supplied legal-upstream candidates — D0 §10.2:
+  // never a free-text node-key input), no unknown-kind hint. The api's `priorApproverNodeOptions`
+  // is the OPTIONAL member the shipped view provides via legalPriorApproverNodeKeys.
+  it('K3: prior_node_approver renders EDITABLE with the typed upstream-node picker; an empty candidate list shows the honest no-upstream hint', () => {
+    const node = makeApprovalNode('approval_k3')
+    const api = createStubConfigApi({ approval_k3: { assigneeSources: [{ kind: 'prior_node_approver', nodeKey: 'gate' }] } })
+    api.priorApproverNodeOptions = (nodeKey: string) => (nodeKey === 'approval_k3' ? [{ key: 'gate', label: '预审' }] : [])
+    const { container: c, unmount } = mountDirectInspector({
+      node,
+      registry: DEFAULT_APPROVAL_CAPABILITY_REGISTRY,
+      api,
+    })
+    const roster = c.querySelector('[data-testid="approval-node-source-kind-prior_node_approver"]') as HTMLInputElement
+    expect(roster).not.toBeNull()
+    expect(roster.checked).toBe(true)
+    expect(c.querySelector('[data-testid="approval-node-source-prior-node"]')).not.toBeNull()
+    // With ≥1 legal candidate the no-upstream hint must NOT render (hint is candidate-selected).
+    expect(c.querySelector('[data-testid="approval-node-source-prior-node-empty"]')).toBeNull()
+    expect(c.querySelector('[data-testid="approval-node-source-kind-unknown"]')).toBeNull()
+    unmount()
+
+    // Empty candidate list (e.g. the FIRST approval node, nothing upstream): the picker stays
+    // (typed, still no free-text path) and the honest hint renders.
+    const apiEmpty = createStubConfigApi({ approval_k3: { assigneeSources: [{ kind: 'prior_node_approver', nodeKey: '' }] } })
+    apiEmpty.priorApproverNodeOptions = () => []
+    const emptyMount = mountDirectInspector({
+      node: makeApprovalNode('approval_k3'),
+      registry: DEFAULT_APPROVAL_CAPABILITY_REGISTRY,
+      api: apiEmpty,
+    })
+    expect(emptyMount.container.querySelector('[data-testid="approval-node-source-prior-node-empty"]')).not.toBeNull()
+    emptyMount.unmount()
   })
 
   // A-4 SCOPE NOTE: this proves the ROSTER COMPONENT's own branching mechanism — given an

--- a/apps/web/tests/approval-template-authoring-parallel-edit.test.ts
+++ b/apps/web/tests/approval-template-authoring-parallel-edit.test.ts
@@ -418,6 +418,17 @@ describe('parallelDynamicAssigneeConflicts — publish preflight (F2)', () => {
     )).toEqual([])
   })
 
+  it('Lock-1 §K3: flags identical prior_node_approver references — the fingerprint mirror (`prior_node_approver:<nodeKey>`) is in lockstep with the backend', () => {
+    expect(parallelDynamicAssigneeConflicts(
+      withBranchSources([{ kind: 'prior_node_approver', nodeKey: 'gate' }], [{ kind: 'prior_node_approver', nodeKey: 'gate' }]),
+    )).toHaveLength(1)
+    // Positive control: DIFFERENT referenced nodes are NOT flagged (parameterized, not
+    // kind-blanket — different prior nodes may have different deciders).
+    expect(parallelDynamicAssigneeConflicts(
+      withBranchSources([{ kind: 'prior_node_approver', nodeKey: 'gate' }], [{ kind: 'prior_node_approver', nodeKey: 'gate2' }]),
+    )).toEqual([])
+  })
+
   it('Lock-1 §K2 / G-17: requester_choice × requester_choice is NOT flagged (null fingerprint DELIBERATE — same-person collision is the runtime 409 guard\'s job)', () => {
     // Two requester_choice sources on parallel branches are NOT provably identical — the
     // requester may pick different people per branch — so the publish preflight must not block

--- a/apps/web/tests/approvalTemplateAuthoring.spec.ts
+++ b/apps/web/tests/approvalTemplateAuthoring.spec.ts
@@ -8,10 +8,12 @@ import {
   buildApprovalGraph,
   buildCreateTemplatePayload,
   buildFormSchema,
+  createEmptyStepDraft,
   createEmptyTemplateDraft,
   draftFromTemplate,
   graphReadOnlyReason,
   unsupportedTemplateAuthoringReason,
+  validateTemplateApprovalFlow,
   validateTemplateDraft,
   validateTemplateFormFields,
   validateTemplateBasicInfo,
@@ -838,6 +840,104 @@ describe('approval template authoring helpers', () => {
     expect(buildCreateTemplatePayload(rehydrated).approvalGraph.nodes[1]?.config).toEqual(
       payload.approvalGraph.nodes[1]?.config,
     )
+  })
+
+  it('Lock-1 §K3: round-trips a prior_node_approver source (localId reference → the referenced step CURRENT positional key on save; the stored key re-resolves to the SAME step) — the linear editor accepted-kind list mirror site', () => {
+    const draft = createEmptyTemplateDraft()
+    draft.key = 'k3'
+    draft.name = '节点审批人审批'
+    draft.steps[0].name = '一审'
+    const second = createEmptyStepDraft(2)
+    second.sourceKind = 'prior_node_approver'
+    second.priorStepLocalId = draft.steps[0].localId
+    draft.steps.push(second)
+
+    const payload = buildCreateTemplatePayload(draft)
+    expect((payload.approvalGraph.nodes[2]?.config as any).assigneeSources).toEqual([{ kind: 'prior_node_approver', nodeKey: 'approval_1' }])
+
+    // wire-vs-fixture trap: the stored nodeKey survives the real serialize→parse and re-resolves
+    // to the FIRST step's fresh localId (a localId is session-scoped, so hydrate must re-derive
+    // the reference from the stored key + ordered chain, not carry the old localId).
+    const rehydrated = draftFromTemplate(buildTemplate({ approvalGraph: payload.approvalGraph }))
+    expect(rehydrated.steps[1].sourceKind).toBe('prior_node_approver')
+    expect(rehydrated.steps[1].priorStepLocalId).toBe(rehydrated.steps[0].localId)
+    // And the rebuilt graph is byte-identical to the first emit (no hydrate flatten).
+    expect(buildCreateTemplatePayload(rehydrated).approvalGraph.nodes[2]?.config).toEqual(
+      payload.approvalGraph.nodes[2]?.config,
+    )
+  })
+
+  it('Lock-1 §K3 retarget-safety: inserting a step ABOVE the referenced step re-emits the reference at the step NEW positional key — the reference follows the STEP, never the stale key', () => {
+    const draft = createEmptyTemplateDraft()
+    draft.key = 'k3-retarget'
+    draft.name = '节点审批人审批'
+    draft.steps[0].name = '一审'
+    const second = createEmptyStepDraft(2)
+    second.sourceKind = 'prior_node_approver'
+    second.priorStepLocalId = draft.steps[0].localId
+    draft.steps.push(second)
+    expect((buildCreateTemplatePayload(draft).approvalGraph.nodes[2]?.config as any).assigneeSources)
+      .toEqual([{ kind: 'prior_node_approver', nodeKey: 'approval_1' }])
+
+    // Insert a NEW first step: the referenced 一审 step shifts to position 2 (key approval_2).
+    // Under a raw-key carrier the reference would still say approval_1 — now the NEW step, a
+    // silent wrong-approver retarget. The localId carrier re-emits the moved step's current key.
+    draft.steps.unshift(createEmptyStepDraft(1))
+    const shifted = buildCreateTemplatePayload(draft)
+    expect((shifted.approvalGraph.nodes[3]?.config as any).assigneeSources)
+      .toEqual([{ kind: 'prior_node_approver', nodeKey: 'approval_2' }])
+  })
+
+  it('Lock-1 §K3 validation: a prior_node_approver step with no chosen reference — or referencing a NON-earlier step — is flagged; a valid earlier reference passes (positive control)', () => {
+    const draft = createEmptyTemplateDraft()
+    draft.key = 'k3-validate'
+    draft.name = '节点审批人审批'
+    const second = createEmptyStepDraft(2)
+    second.sourceKind = 'prior_node_approver'
+    draft.steps.push(second)
+    // No reference chosen.
+    expect(validateTemplateApprovalFlow(draft).some((e) => e.includes('节点审批人'))).toBe(true)
+    // Self/later reference (its own localId — index not strictly earlier).
+    second.priorStepLocalId = second.localId
+    expect(validateTemplateApprovalFlow(draft).some((e) => e.includes('节点审批人'))).toBe(true)
+    // Positive control: a strictly-earlier reference passes.
+    second.priorStepLocalId = draft.steps[0].localId
+    expect(validateTemplateApprovalFlow(draft).filter((e) => e.includes('节点审批人'))).toEqual([])
+  })
+
+  it('Lock-1 §K3 fail-closed hydrate: a LINEAR graph whose prior_node_approver references a NON-earlier node (self/dangling) opens read-only — never silently re-referenced on save', () => {
+    // Self-reference (illegal — publish would reject; a hand-crafted/stale row could carry it).
+    const selfRef = buildTemplate({
+      approvalGraph: {
+        nodes: [
+          { key: 'start', type: 'start', name: '发起', config: {} },
+          { key: 'approval_1', type: 'approval', name: '一审', config: { assigneeSources: [{ kind: 'prior_node_approver', nodeKey: 'approval_1' }] } },
+          { key: 'end', type: 'end', name: '结束', config: {} },
+        ],
+        edges: [
+          { key: 'e1', source: 'start', target: 'approval_1' },
+          { key: 'e2', source: 'approval_1', target: 'end' },
+        ],
+      } as any,
+    })
+    expect(unsupportedTemplateAuthoringReason(selfRef)).not.toBeNull()
+    // Positive control: the same shape referencing a genuinely EARLIER node is editable.
+    const legal = buildTemplate({
+      approvalGraph: {
+        nodes: [
+          { key: 'start', type: 'start', name: '发起', config: {} },
+          { key: 'approval_1', type: 'approval', name: '一审', config: { assigneeSources: [{ kind: 'requester' }] } },
+          { key: 'approval_2', type: 'approval', name: '二审', config: { assigneeSources: [{ kind: 'prior_node_approver', nodeKey: 'approval_1' }] } },
+          { key: 'end', type: 'end', name: '结束', config: {} },
+        ],
+        edges: [
+          { key: 'e1', source: 'start', target: 'approval_1' },
+          { key: 'e2', source: 'approval_1', target: 'approval_2' },
+          { key: 'e3', source: 'approval_2', target: 'end' },
+        ],
+      } as any,
+    })
+    expect(unsupportedTemplateAuthoringReason(legal)).toBeNull()
   })
 
   it('Lock-1 §K2: round-trips a requester_choice source incl. mode + role scope (idsText is the scope-id carrier)', () => {
@@ -2157,6 +2257,33 @@ describe('TemplateAuthoringView', () => {
     expect((container!.querySelector('[data-testid="approval-template-save-button"]') as HTMLButtonElement).disabled).toBe(false) // editable
     expect((container!.querySelector('[data-testid="approval-step-source-kind"]') as HTMLSelectElement).value).toBe('dept_head_at_level') // hydrated back
     expect((container!.querySelector('[data-testid="approval-step-dept-head-level"]') as HTMLInputElement)).not.toBeNull() // the level input renders for this kind
+  })
+
+  it('Lock-1 §K3: prior_node_approver reads back editable on a 2-step linear graph: sourceKind + the TYPED prior-step picker hydrated (registry-admitted, reference resolved to the earlier step)', async () => {
+    routeParams = { id: 'tpl_k3' }
+    getTemplateSpy.mockResolvedValue(buildTemplate({
+      approvalGraph: {
+        nodes: [
+          { key: 'start', type: 'start', name: '发起', config: {} },
+          { key: 'approval_1', type: 'approval', name: '一审', config: { assigneeSources: [{ kind: 'requester' }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+          { key: 'approval_2', type: 'approval', name: '二审', config: { assigneeSources: [{ kind: 'prior_node_approver', nodeKey: 'approval_1' }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+          { key: 'end', type: 'end', name: '结束', config: {} },
+        ],
+        edges: [
+          { key: 'e1', source: 'start', target: 'approval_1' },
+          { key: 'e2', source: 'approval_1', target: 'approval_2' },
+          { key: 'e3', source: 'approval_2', target: 'end' },
+        ],
+      } as any,
+    }))
+    await mountView()
+    await flushUi()
+
+    expect(container!.querySelector('[data-testid="approval-template-unsupported-alert"]')).toBeNull() // legal upstream reference → not fail-closed
+    expect((container!.querySelector('[data-testid="approval-template-save-button"]') as HTMLButtonElement).disabled).toBe(false) // editable
+    const kindSelects = container!.querySelectorAll('[data-testid="approval-step-source-kind"]')
+    expect((kindSelects[1] as HTMLSelectElement).value).toBe('prior_node_approver') // hydrated back on step 2
+    expect(container!.querySelector('[data-testid="approval-step-prior-node"]')).not.toBeNull() // the TYPED prior-step picker renders
   })
 
   it('updates an existing supported template without replacing it through create', async () => {

--- a/packages/core-backend/src/services/ApprovalAssigneeResolver.ts
+++ b/packages/core-backend/src/services/ApprovalAssigneeResolver.ts
@@ -21,6 +21,17 @@ export interface ResolveApprovalAssigneesOptions {
   formSchema?: FormSchema
   formSnapshot: Record<string, unknown>
   requesterSnapshot: Record<string, unknown> | null
+  /**
+   * Lock-1 §K3 (`prior_node_approver`) — referenced prior node key → that node's ACTUAL decider
+   * local user ids, read by the CALLER at node activation from instance-internal
+   * `approval_records` rows (LATEST `nodeEntryEpoch` round only, OD-L1-3(a); system sentinel
+   * actors already dropped) and passed in alongside the snapshots, exactly as `formSnapshot` and
+   * `requesterSnapshot` are. The resolver performs NO database access of its own (§2.1 purity —
+   * K3 is the one kind whose input is caller-supplied at activation rather than create-frozen).
+   * Absent/undefined (create-time cascade, read-only previews) ⇒ every `prior_node_approver`
+   * source resolves EMPTY and falls to the node's `emptyAssigneePolicy` (OD-L1-4(a)).
+   */
+  priorNodeApprovers?: Record<string, string[]>
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -37,8 +48,23 @@ function metadataFor(source: ApprovalAssigneeSource, sourceIndex: number): Appro
       kind: source.kind,
       sourceIndex,
       ...(source.kind === 'form_field_user' ? { fieldId: source.fieldId } : {}),
+      // Lock-1 §K3 audit: the referenced prior node's key on the row (§2.6 — a template-authored
+      // node key, values-free), so "why is this person an approver" is answerable from the row.
+      ...(source.kind === 'prior_node_approver' ? { priorNodeKey: source.nodeKey } : {}),
     },
   }
+}
+
+/**
+ * Lock-1 §K3 — `system:`-namespaced sentinel actors (`system:auto-approval`,
+ * `system:approval-timeout`) are not assignable users and are DROPPED, never assigned. The
+ * caller's audit-row read already drops them; this pure re-check keeps the guarantee even for a
+ * hand-assembled `priorNodeApprovers` map. The `system:` prefix is the repo-wide non-user actor
+ * namespace (directory-sync.ts applies the same predicate to reject `system:`-prefixed ids as
+ * user ids).
+ */
+function isSystemSentinelActor(actorId: string): boolean {
+  return actorId.startsWith('system:')
 }
 
 function resolveFormUserValue(value: unknown): string | null {
@@ -270,6 +296,33 @@ export function resolveApprovalAssignees(
           const headId = normalizeId(entry)
           if (headId && headId !== requesterId) {
             pushResolved('user', headId, source, sourceIndex)
+          }
+        })
+        break
+      }
+      case 'prior_node_approver': {
+        // Lock-1 §K3: resolve to the referenced prior node's ACTUAL decider(s), read from the
+        // caller-supplied `priorNodeApprovers` map (instance-internal approval_records actors,
+        // LATEST round only — OD-L1-3(a)); never from config, never from a directory read, and no
+        // resolver-internal database access (§2.1: K3's input is caller-supplied at activation).
+        // System sentinel actors are dropped here as a pure re-check (primary drop is in the
+        // caller's audit-row read); when nothing remains — the node was skipped, unreached,
+        // auto-approved under the system actor, or the map is absent (create-time cascade /
+        // choices-free preview) — resolution is EMPTY and falls to the node's emptyAssigneePolicy
+        // (OD-L1-4(a): fail-closed APPROVAL_ASSIGNEE_EMPTY under the default 'error'; an AUDITED
+        // auto-approval event under an explicit 'auto-approve' — never a silent nobody).
+        // NO self-exclusion (deliberate — the §K2 posture): a prior decider who is the requester
+        // still gets the seat; self-approval stays owned by autoApprovalPolicy.mergeWithRequester.
+        // Cross-node NO-DEDUP is structural: this node's `seen` set is per-resolution, so the same
+        // person approving at the prior node simply gets a fresh seat here; intra-node dedup
+        // (one seat per identity at THIS node) still applies via pushResolved.
+        const rawMap = options.priorNodeApprovers
+        const rawList = isRecord(rawMap) ? rawMap[source.nodeKey] : undefined
+        const deciders = Array.isArray(rawList) ? rawList : []
+        deciders.forEach((entry) => {
+          const deciderId = normalizeId(entry)
+          if (deciderId && !isSystemSentinelActor(deciderId)) {
+            pushResolved('user', deciderId, source, sourceIndex)
           }
         })
         break

--- a/packages/core-backend/src/services/ApprovalGraphExecutor.ts
+++ b/packages/core-backend/src/services/ApprovalGraphExecutor.ts
@@ -393,8 +393,33 @@ export function pruneHiddenFormData(
   )
 }
 
-function normalizeApprovalMode(value: unknown): ApprovalMode {
-  return value === 'all' || value === 'any' || value === 'single' || value === 'threshold' ? value : 'single'
+/**
+ * Lock-1 §K6 precondition (named by the K3 slice sequencing): the executor's approval-mode
+ * normalizer must fail CLOSED. The previous arm silently mapped ANY unrecognized mode to
+ * `'single'` — for contract-valid data the gap was unreachable (the authoring choke rejects
+ * unknown modes, and `asRuntimeGraph` re-normalizes every STORED graph through that same choke on
+ * each dispatch), but the moment a new mode (e.g. `sequential`) becomes authorable, deploy skew or
+ * rollback would degrade it silently to first-approver-wins with no error and no audit signal —
+ * the precise inverse of the S7 governing precedent.
+ *
+ * Enumerated legitimate inputs (widen-only: every value a re-normalized stored graph can carry):
+ *   - `undefined` — the absent default, ≡ `'single'` (the shipped contract; the service-side
+ *     normalizer emits the key only when set, and `single` is the documented absent default);
+ *   - the four shipped members `'single' | 'all' | 'any' | 'threshold'` — pass through unchanged.
+ * ANYTHING else (an unknown string, `null`, a non-string) throws a typed error instead of running
+ * as `'single'`. `null` is deliberately in the reject set: the authoring choke has always rejected
+ * it (`typeof null !== 'string'`), so no legitimately stored graph carries it. The raw value is
+ * deliberately NOT echoed into the message (values-free; the node key — template-authored — is).
+ */
+function normalizeApprovalMode(value: unknown, nodeKey: string): ApprovalMode {
+  if (value === undefined) return 'single'
+  if (value === 'all' || value === 'any' || value === 'single' || value === 'threshold') return value
+  throw new ServiceError(
+    `Approval node ${nodeKey} has an unsupported approval mode`,
+    400,
+    'APPROVAL_MODE_UNSUPPORTED',
+    { nodeKey },
+  )
 }
 
 function evaluateRule(rule: ConditionRule, formData: Record<string, unknown>): boolean {
@@ -991,7 +1016,7 @@ export class ApprovalGraphExecutor {
   }
 
   getApprovalMode(nodeKey: string): ApprovalMode {
-    return normalizeApprovalMode(this.getApprovalNodeConfig(nodeKey).approvalMode)
+    return normalizeApprovalMode(this.getApprovalNodeConfig(nodeKey).approvalMode, nodeKey)
   }
 
   // Lock-3 §2.2 — handler aggregation mode, fail-closed to `'all'` (see `normalizeHandlerMode`).
@@ -1208,7 +1233,7 @@ export class ApprovalGraphExecutor {
           throw new Error(`Approval node ${node.key} has invalid config`)
         }
         const sourceStep = this.stepIndexForNode(node.key)
-        const approvalMode = normalizeApprovalMode(approvalConfig.approvalMode)
+        const approvalMode = normalizeApprovalMode(approvalConfig.approvalMode, node.key)
         const assignments = this.resolveAssignmentsForApprovalNode(node.key, approvalConfig, sourceStep)
         if (assignments.length === 0) {
           if (approvalConfig.emptyAssigneePolicy === 'auto-approve') {
@@ -1535,7 +1560,7 @@ export class ApprovalGraphExecutor {
           throw new Error(`Approval node ${node.key} has invalid config`)
         }
         const sourceStep = this.stepIndexForNode(node.key)
-        const approvalMode = normalizeApprovalMode(approvalConfig.approvalMode)
+        const approvalMode = normalizeApprovalMode(approvalConfig.approvalMode, node.key)
         const assignments = this.resolveAssignmentsForApprovalNode(node.key, approvalConfig, sourceStep)
         if (assignments.length === 0) {
           if (approvalConfig.emptyAssigneePolicy === 'auto-approve') {
@@ -1718,7 +1743,7 @@ export class ApprovalGraphExecutor {
     approvalConfig: ApprovalNodeConfig,
     assignments: ApprovalGraphAssignment[],
   ): void {
-    if (normalizeApprovalMode(approvalConfig.approvalMode) !== 'threshold') return
+    if (normalizeApprovalMode(approvalConfig.approvalMode, nodeKey) !== 'threshold') return
     if (assignments.length === 0) return
     const threshold = this.getApprovalThreshold(nodeKey)
     const distinctSlots = new Set(

--- a/packages/core-backend/src/services/ApprovalProductService.ts
+++ b/packages/core-backend/src/services/ApprovalProductService.ts
@@ -718,6 +718,22 @@ function normalizeApprovalAssigneeSources(
         }
         return { kind: 'dept_head_at_level', level }
       }
+      case 'prior_node_approver': {
+        // Lock-1 §K3 + G-1: exact-shape validation — `nodeKey` is a required non-empty string,
+        // and (the Lock-1 G-1 posture for NEW kinds, stricter than the shipped kinds) unknown
+        // extra keys are REJECTED, never silently dropped. Whether the referenced node exists,
+        // is an approval node, and is strictly upstream on every runtime-reachable path is the
+        // PUBLISH gate's job (`assertPriorNodeApproverReferencesUpstream`) — normalize stays a
+        // shape check so stored drafts remain readable/re-saveable while being fixed.
+        const sourceKeys = Object.keys(source)
+        if (sourceKeys.some((key) => !['kind', 'nodeKey'].includes(key))) {
+          failValidation(context, `${sourcePath} carries unknown keys for prior_node_approver`)
+        }
+        if (!isNonEmptyString(source.nodeKey)) {
+          failValidation(context, `${sourcePath}.nodeKey is required`)
+        }
+        return { kind: 'prior_node_approver', nodeKey: source.nodeKey.trim() }
+      }
       case 'form_field_user':
         if (!isNonEmptyString(source.fieldId)) {
           failValidation(context, `${sourcePath}.fieldId is required`)
@@ -1880,6 +1896,10 @@ function dynamicAssigneeSourceFingerprint(source: ApprovalAssigneeSource): strin
       return `continuous_dept_heads:${source.levels}`
     case 'dept_head_at_level':
       return `dept_head_at_level:${source.level}`
+    case 'prior_node_approver':
+      // Lock-1 §K3 / §2.4 locked entry: provably identical for the same referenced node — two
+      // branches asking "the deciders of node X" resolve the same people on every request.
+      return `prior_node_approver:${source.nodeKey}`
     case 'form_field_user':
       return `form_field_user:${source.fieldId}`
     case 'static_user':
@@ -2051,6 +2071,96 @@ function runtimeSuccessorTargets(
 
   const firstEdge = outgoingBySource.get(node.key)?.[0]
   return firstEdge ? [firstEdge.target] : []
+}
+
+/**
+ * Lock-1 §K3 publish gate: every `prior_node_approver` reference must name an `approval` node
+ * STRICTLY UPSTREAM on EVERY runtime-reachable path from the start node to the carrying node —
+ * a DOMINANCE check ("every path" is load-bearing: a node reachable only through one condition
+ * branch resolves empty on the other, and a node inside a parallel region referenced from outside
+ * it may not have decided when the referencing node activates). No shipped gate performs this —
+ * `assertNoParallelDynamicAssigneeConflicts` walks FORWARD from a branch entry unioning
+ * fingerprints, a different predicate; what THIS gate reuses is its primitives
+ * (`runtimeSuccessorTargets`, the edge maps, the visited set), exactly as Lock-1 §K3 instructs.
+ *
+ * Mechanism: T strictly dominates C in the runtime-successor graph rooted at the start node ⟺
+ * removing T makes C unreachable from start (with T ≠ C). The removal-reachability test is run
+ * per reference; explicit dangling / non-approval / self checks come first so each failure names
+ * its reason. Deliberately CONSERVATIVE for parallel regions: a target inside one parallel branch
+ * never dominates a node past the join (a sibling-branch path avoids it), so such references are
+ * rejected even under joinMode 'all' — the lock's "may not have decided" posture; a reference to
+ * an upstream node WITHIN the same branch passes (no path through a sibling branch can re-enter
+ * this branch before the join).
+ *
+ * Deliberately publish-scoped (NOT create/update, NOT normalize) like
+ * `assertNoParallelDynamicAssigneeConflicts`: stored drafts stay readable and re-saveable while
+ * being fixed; instances only ever run PUBLISHED graphs, so publish is the single admission point
+ * (§2.2: an illegal reference is an authoring-time 400, never a dispatch-time surprise). Errors
+ * are values-free: node keys and source indexes only (§2.6 — template-authored identifiers).
+ */
+export function assertPriorNodeApproverReferencesUpstream(approvalGraph: ApprovalGraph): void {
+  const edgeByKey = new Map(approvalGraph.edges.map((edge) => [edge.key, edge]))
+  const outgoingBySource = new Map<string, ApprovalGraph['edges']>()
+  for (const edge of approvalGraph.edges) {
+    const existing = outgoingBySource.get(edge.source)
+    if (existing) existing.push(edge)
+    else outgoingBySource.set(edge.source, [edge])
+  }
+  const nodeByKey = new Map(approvalGraph.nodes.map((node) => [node.key, node]))
+  const startKey = approvalGraph.nodes.find((node) => node.type === 'start')?.key ?? null
+
+  // Keys reachable from start over runtime-possible successors, treating `skipKey` (the reference
+  // target under test) as removed. FIFO worklist + visited set (cycle-safe, each node once).
+  const reachableWithout = (skipKey: string): Set<string> => {
+    const visited = new Set<string>()
+    if (startKey === null || startKey === skipKey) return visited
+    const queue: string[] = [startKey]
+    for (let head = 0; head < queue.length; head += 1) {
+      const currentKey = queue[head]
+      if (currentKey === skipKey || visited.has(currentKey)) continue
+      visited.add(currentKey)
+      const current = nodeByKey.get(currentKey)
+      if (!current) continue
+      for (const target of runtimeSuccessorTargets(current, edgeByKey, outgoingBySource)) {
+        queue.push(target)
+      }
+    }
+    return visited
+  }
+
+  for (const node of approvalGraph.nodes) {
+    if (node.type !== 'approval') continue
+    const sources = (node.config as { assigneeSources?: ApprovalAssigneeSource[] }).assigneeSources ?? []
+    sources.forEach((source, sourceIndex) => {
+      if (source.kind !== 'prior_node_approver') return
+      const targetNodeKey = source.nodeKey
+      const fail = (reason: string, message: string): never => {
+        throw new ServiceError(message, 400, 'APPROVAL_ASSIGNEE_PRIOR_NODE_REFERENCE_INVALID', {
+          nodeKey: node.key,
+          sourceIndex,
+          targetNodeKey,
+          reason,
+        })
+      }
+      const target = nodeByKey.get(targetNodeKey)
+      if (!target) {
+        fail('dangling', `approvalGraph node ${node.key} assigneeSources[${sourceIndex}] prior_node_approver references a node (${targetNodeKey}) that does not exist`)
+      }
+      if (target.key === node.key) {
+        fail('self', `approvalGraph node ${node.key} assigneeSources[${sourceIndex}] prior_node_approver references its own node`)
+      }
+      if (target.type !== 'approval') {
+        fail('not-approval', `approvalGraph node ${node.key} assigneeSources[${sourceIndex}] prior_node_approver must reference an approval node (${targetNodeKey} is ${target.type})`)
+      }
+      // Strict dominance by removal-reachability: if the carrier is still reachable from start
+      // with the target removed, SOME runtime-reachable path avoids the target (downstream,
+      // sibling condition branch, or sibling parallel branch) — reject. An entirely-unreachable
+      // carrier passes vacuously (it can never activate; other gates own dead-node hygiene).
+      if (reachableWithout(targetNodeKey).has(node.key)) {
+        fail('not-upstream-on-every-path', `approvalGraph node ${node.key} assigneeSources[${sourceIndex}] prior_node_approver target ${targetNodeKey} is not strictly upstream on every runtime-reachable path`)
+      }
+    })
+  }
 }
 
 /**
@@ -3580,6 +3690,37 @@ export function runtimeGraphUsesOrgAssigneeSource(runtimeGraph: RuntimeGraph): b
 }
 
 /**
+ * Lock-1 §K3: the set of node keys referenced by any `prior_node_approver` source in the published
+ * runtime graph. OPT-IN gate in the `runtimeGraphUsesManagerChain` posture: an empty set means the
+ * runtime paths do no K3 work at all (no audit-row read), so unrelated approvals pay nothing.
+ * `kind`/`nodeKey` are read structurally (same posture as the other detectors above).
+ *
+ * Deliberately NOT added to `runtimeGraphUsesOrgAssigneeSource`: K3 resolves from INSTANCE-INTERNAL
+ * audit rows, not the org directory — §2.1 extends that org-read fail-closed detector to K4 and
+ * K5-b only, and arming it for K3 would fail creates that need no org read at all.
+ */
+export function collectRuntimeGraphPriorNodeApproverTargets(runtimeGraph: RuntimeGraph): Set<string> {
+  const targets = new Set<string>()
+  for (const node of runtimeGraph.nodes) {
+    if (node.type !== 'approval') continue
+    const config: unknown = node.config
+    const sources = isRecord(config) ? config.assigneeSources : undefined
+    if (!Array.isArray(sources)) continue
+    for (const source of sources) {
+      if (
+        isRecord(source)
+        && source.kind === 'prior_node_approver'
+        && typeof source.nodeKey === 'string'
+        && source.nodeKey.trim().length > 0
+      ) {
+        targets.add(source.nodeKey.trim())
+      }
+    }
+  }
+  return targets
+}
+
+/**
  * Lock-1 §K2: every `requester_choice` source in the published runtime graph, grouped by the
  * carrying approval node's key. Drives the create-time choice validation + snapshot freeze —
  * OPT-IN like `includeManagerChain`: an empty map means the create path does no K2 work at all.
@@ -3850,6 +3991,20 @@ function buildApprovalAssignmentResolver(options: {
   formSchema?: FormSchema
   formSnapshot: Record<string, unknown>
   requesterSnapshot: Record<string, unknown> | null
+  /**
+   * Lock-1 §K3 — LATE-BOUND provider of the prior-node decider map (referenced node key → actual
+   * decider user ids), read by the CALLER from instance-internal `approval_records` rows at node
+   * activation and threaded here so the resolver itself stays pure (§2.1: no resolver-internal
+   * database access; K3's input is caller-supplied alongside the snapshots). A PROVIDER rather
+   * than a plain map because dispatchAction constructs its executor before the actor's effective
+   * branch node — and therefore the in-flight approve merge — is known; the provider is invoked
+   * only when the executor actually resolves a node, which is always after the caller populated
+   * it. Omitted on the create/preview path (no instance rows exist yet): a `prior_node_approver`
+   * node reached by a create-time auto-approval cascade resolves EMPTY and falls to
+   * `emptyAssigneePolicy` (OD-L1-4(a)), and a route preview shows the honest EMPTY_ASSIGNEES
+   * marker (the §K2 pre-choice precedent).
+   */
+  getPriorNodeApprovers?: () => Record<string, string[]> | undefined
 }): ApprovalGraphAssignmentResolver {
   return ({ nodeKey, sourceStep, config }) => resolveApprovalAssignees({
     nodeKey,
@@ -3858,6 +4013,7 @@ function buildApprovalAssignmentResolver(options: {
     formSchema: options.formSchema,
     formSnapshot: options.formSnapshot,
     requesterSnapshot: options.requesterSnapshot,
+    priorNodeApprovers: options.getPriorNodeApprovers?.(),
   })
 }
 
@@ -4755,6 +4911,12 @@ export class ApprovalProductService {
       // otherwise the high path stalls at runtime on an unclaimable role assignment (nobody holds the
       // placeholder role). See APPROVAL_ROLE_CONFIGURE_SENTINEL.
       assertNoUnconfiguredPlaceholderRoles(approvalGraph)
+      // Lock-1 §K3: every prior_node_approver reference must be an approval node strictly
+      // upstream on EVERY runtime-reachable path (dominance) — dangling / downstream / self /
+      // condition-branch-only / parallel-sibling references fail publish here, values-free.
+      // UNCONDITIONAL (unlike the parallel-conflict gate below): no policy exemption makes an
+      // undominated reference resolvable.
+      assertPriorNodeApproverReferencesUpstream(approvalGraph)
       // F2 preflight: parallel branches with provably-identical DYNAMIC approver sources 409 every
       // request at fan-out — reject at publish with the runtime's own code. Exempt when the publish
       // policy's mergeAdjacentApprover absorbs same-approver overlap (mirrors the
@@ -5887,6 +6049,15 @@ export class ApprovalProductService {
         ? { requesterChoices: frozenRequesterChoices }
         : {}),
     }
+    // Lock-1 §K3: `getPriorNodeApprovers` is deliberately OMITTED on the create/preview path — no
+    // instance exists yet, so there are no audit rows to read. A `prior_node_approver` node can
+    // only activate here through a same-transaction auto-approval cascade (publish guarantees its
+    // target is strictly upstream, so it is never the first pending node); in that case it
+    // resolves EMPTY and falls to `emptyAssigneePolicy` (OD-L1-4(a) — the cascade's decider is
+    // the system sentinel, which is dropped by definition; under `actorMode:'original_approver'`
+    // the attributable decider is not re-materialized from an unpersisted round either — the
+    // fail-closed arm, never a silent wrong approver). Route previews show the honest
+    // EMPTY_ASSIGNEES marker for such nodes (the §K2 pre-choice precedent).
     const executor = new ApprovalGraphExecutor(runtimeGraph, normalizedFormData, {
       assignmentResolver: buildApprovalAssignmentResolver({
         formSchema,
@@ -6453,10 +6624,21 @@ export class ApprovalProductService {
       const oldAssignees = assignmentRowsForAudit(activeAssignments.rows)
       const formSnapshot = toNullableRecord(instance.form_snapshot) || {}
       const requesterSnapshot = toNullableRecord(instance.requester_snapshot)
+      // Lock-1 §K3: the jump (re)activates a node that may carry a `prior_node_approver` source —
+      // read the referenced nodes' persisted deciders (LATEST round, sentinels dropped) before
+      // resolution. No in-flight merge: the jumping admin is not a decider. A referenced node the
+      // jump SKIPPED OVER (never decided) yields an empty entry → emptyAssigneePolicy
+      // (OD-L1-4(a): the "node was skipped" arm). OPT-IN — undefined when the graph has no such
+      // source.
+      const jumpReferencedPriorNodeKeys = collectRuntimeGraphPriorNodeApproverTargets(runtimeGraph)
+      const jumpPriorNodeApprovers = jumpReferencedPriorNodeKeys.size > 0
+        ? await this.loadPriorNodeApproverDeciders(client, id, jumpReferencedPriorNodeKeys)
+        : undefined
       const executor = new ApprovalGraphExecutor(runtimeGraph, formSnapshot, {
         assignmentResolver: buildApprovalAssignmentResolver({
           formSnapshot,
           requesterSnapshot,
+          getPriorNodeApprovers: () => jumpPriorNodeApprovers,
         }),
         // Re-thread the frozen directory department + title + roles at dispatch (loaded requester_snapshot record).
         requesterContext: ((d, t, r) => ({
@@ -7002,10 +7184,23 @@ export class ApprovalProductService {
 
       const formSnapshot = toNullableRecord(instance.form_snapshot) || {}
       const requesterSnapshot = toNullableRecord(instance.requester_snapshot)
+      // Lock-1 §K3: a timeout JUMP (re)activates a node that may carry a `prior_node_approver`
+      // source — read the referenced nodes' persisted deciders (LATEST round, sentinels dropped)
+      // before resolution. No in-flight merge: the timeout scanner is a system actor, never a
+      // decider. A referenced node the jump skips over yields an empty entry →
+      // emptyAssigneePolicy (OD-L1-4(a)). OPT-IN — undefined when the graph has no such source
+      // (the transfer effect re-resolves nothing, so the read is skipped for it too).
+      const timeoutReferencedPriorNodeKeys = scannedEffect === 'jump'
+        ? collectRuntimeGraphPriorNodeApproverTargets(runtimeGraph)
+        : new Set<string>()
+      const timeoutPriorNodeApprovers = timeoutReferencedPriorNodeKeys.size > 0
+        ? await this.loadPriorNodeApproverDeciders(client, id, timeoutReferencedPriorNodeKeys)
+        : undefined
       const executor = new ApprovalGraphExecutor(runtimeGraph, formSnapshot, {
         assignmentResolver: buildApprovalAssignmentResolver({
           formSnapshot,
           requesterSnapshot,
+          getPriorNodeApprovers: () => timeoutPriorNodeApprovers,
         }),
         requesterContext: ((d, t, r) => ({
           department: typeof d === 'string' && d ? d : null,
@@ -7239,10 +7434,17 @@ export class ApprovalProductService {
       const runtimeGraph = asRuntimeGraph(runtime.runtime_graph)
       const formSnapshot = toNullableRecord(instance.form_snapshot) || {}
       const requesterSnapshot = toNullableRecord(instance.requester_snapshot)
+      // Lock-1 §K3 — late-bound decider map for any `prior_node_approver` source in this graph.
+      // Populated ONCE below (after the actor's effective branch node + action authorization are
+      // resolved) and BEFORE any resolution entry point runs; the provider indirection exists
+      // because the executor is constructed here, earlier than that point. Stays undefined when
+      // the graph carries no such source (OPT-IN — zero extra reads for unrelated approvals).
+      let priorNodeApprovers: Record<string, string[]> | undefined
       const executor = new ApprovalGraphExecutor(runtimeGraph, formSnapshot, {
         assignmentResolver: buildApprovalAssignmentResolver({
           formSnapshot,
           requesterSnapshot,
+          getPriorNodeApprovers: () => priorNodeApprovers,
         }),
         // Re-thread the frozen directory department + title + roles at dispatch (loaded requester_snapshot record).
         requesterContext: ((d, t, r) => ({
@@ -7290,6 +7492,29 @@ export class ApprovalProductService {
 
       if (request.action !== 'revoke' && !actorCanAct) {
         throw new ServiceError('Approval assignment not found for actor', 403, 'APPROVAL_ASSIGNMENT_REQUIRED')
+      }
+
+      // Lock-1 §K3 — populate the prior-node decider map (declared beside the executor above)
+      // when this graph references any prior node. Read ONCE per dispatch from instance-internal
+      // audit rows, BEFORE any of this transaction's own writes, and AFTER the authorization
+      // guard above (so a 403 stays a 403). For an `approve`, the acting user IS a decider of
+      // the CURRENT node's round — their own approve record is inserted only after resolution —
+      // so they are merged in scoped to the current round's epoch (resolved from the node's
+      // still-active assignments, exactly like the threshold tally's own capture). Partial-vote
+      // paths (all-mode with siblings remaining / threshold unmet) commit before any resolution,
+      // so the merge is only ever consumed when the node actually completes. A node auto-approved
+      // by THIS transaction's cascade has no persisted round yet and resolves EMPTY →
+      // emptyAssigneePolicy (OD-L1-4(a)).
+      const referencedPriorNodeKeys = collectRuntimeGraphPriorNodeApproverTargets(runtimeGraph)
+      if (referencedPriorNodeKeys.size > 0) {
+        const inFlightApprove = request.action === 'approve' && currentNodeKey && referencedPriorNodeKeys.has(currentNodeKey)
+          ? {
+              nodeKey: currentNodeKey,
+              actorId: actor.userId,
+              epoch: await this.currentNodeEntryEpoch(client, id, currentNodeKey),
+            }
+          : undefined
+        priorNodeApprovers = await this.loadPriorNodeApproverDeciders(client, id, referencedPriorNodeKeys, inFlightApprove)
       }
 
       // Lock-7 L7-C / OD-L7-3(a): `fieldWrites` is meaningful ONLY on a `handle` submission at a
@@ -9061,6 +9286,88 @@ export class ApprovalProductService {
     }
     const only = result.rows[0]?.entry_epoch
     return only === null || only === undefined ? null : Number(only)
+  }
+
+  // Lock-1 §K3 — the referenced prior nodes' ACTUAL deciders, read from instance-internal
+  // `approval_records` audit rows on the SAME transaction client (never a directory read;
+  // instance-internal reads are not directory reads — §2.1 keeps the resolver pure by having the
+  // CALLER read this at activation and pass it in alongside the snapshots).
+  //
+  // Round scoping (OD-L1-3(a), LATEST round only — matching the threshold tally's epoch-scoped
+  // posture): per referenced node, keep only the `action='approve'` rows whose
+  // `metadata.nodeEntryEpoch` equals the node's LATEST recorded epoch. Rows with NO epoch exist
+  // only on legacy pre-epoch instances — unreachable for K3 (the kind postdates epoch stamping,
+  // and an instance pins its published definition, which could not have carried the kind before
+  // this slice) — but are handled totally: they count only when NO epoched row exists.
+  //
+  // Sentinel actors (`system:auto-approval`, `system:approval-timeout` — the `system:` namespace,
+  // the repo-wide non-user actor convention) are DROPPED, never assigned (§K3); under
+  // `actorMode: 'original_approver'` the auto-approval row carries the ORIGINAL approver's real id
+  // and is therefore kept. Deciders keep audit-row order (occurred_at, id), deduped.
+  //
+  // `inFlight` (approve path only): the acting user IS a decider of the CURRENT node's round, but
+  // their own approve record is inserted only AFTER resolution — so the caller passes them here,
+  // scoped to the current round's epoch (persisted partial votes of THIS round are kept; any
+  // PRIOR round's rows are excluded even when the current round has no rows yet).
+  private async loadPriorNodeApproverDeciders(
+    client: { query: typeof pool.query },
+    instanceId: string,
+    referencedNodeKeys: ReadonlySet<string>,
+    inFlight?: { nodeKey: string; actorId: string; epoch: number | null },
+  ): Promise<Record<string, string[]>> {
+    const map: Record<string, string[]> = {}
+    if (referencedNodeKeys.size === 0) return map
+    const result = await client.query<{ actor_id: string; node_key: string; metadata: Record<string, unknown> | null }>(
+      `SELECT actor_id, metadata->>'nodeKey' AS node_key, metadata
+         FROM approval_records
+        WHERE instance_id = $1
+          AND action = 'approve'
+          AND metadata->>'nodeKey' = ANY($2::text[])
+        ORDER BY occurred_at ASC, id ASC`,
+      [instanceId, [...referencedNodeKeys]],
+    )
+    const rowsByNode = new Map<string, Array<{ actorId: string; epoch: number | null }>>()
+    for (const row of result.rows) {
+      const rawEpoch = toNullableRecord(row.metadata)?.nodeEntryEpoch
+      const epoch = typeof rawEpoch === 'number' && Number.isInteger(rawEpoch)
+        ? rawEpoch
+        : typeof rawEpoch === 'string' && /^\d+$/.test(rawEpoch)
+          ? Number.parseInt(rawEpoch, 10)
+          : null
+      const list = rowsByNode.get(row.node_key)
+      const entry = { actorId: row.actor_id, epoch }
+      if (list) list.push(entry)
+      else rowsByNode.set(row.node_key, [entry])
+    }
+    for (const nodeKey of referencedNodeKeys) {
+      const rows = rowsByNode.get(nodeKey) ?? []
+      let roundRows: Array<{ actorId: string; epoch: number | null }>
+      if (inFlight && inFlight.nodeKey === nodeKey) {
+        // The in-flight round is authoritative: keep only THIS round's persisted partial votes
+        // (epoch equality; a null in-flight epoch — legacy — keeps only epoch-less rows).
+        roundRows = rows.filter((row) => row.epoch === inFlight.epoch)
+      } else {
+        const epochs = rows.map((row) => row.epoch).filter((epoch): epoch is number => epoch !== null)
+        if (epochs.length > 0) {
+          const latest = Math.max(...epochs)
+          roundRows = rows.filter((row) => row.epoch === latest)
+        } else {
+          roundRows = rows
+        }
+      }
+      const deciders: string[] = []
+      const seen = new Set<string>()
+      const pushDecider = (actorId: string): void => {
+        const id = actorId.trim()
+        if (!id || id.startsWith('system:') || seen.has(id)) return
+        seen.add(id)
+        deciders.push(id)
+      }
+      for (const row of roundRows) pushDecider(row.actorId)
+      if (inFlight && inFlight.nodeKey === nodeKey) pushDecider(inFlight.actorId)
+      map[nodeKey] = deciders
+    }
+    return map
   }
 
   // Dynamic-source discriminator. `metadata.resolvedFrom` is written ONLY by

--- a/packages/core-backend/src/types/approval-product.ts
+++ b/packages/core-backend/src/types/approval-product.ts
@@ -16,7 +16,7 @@ export type ApprovalProductPermission = typeof APPROVAL_PRODUCT_PERMISSIONS[numb
 // admission set in ApprovalProductService.ts) or the type is unpublishable.
 export type ApprovalNodeType = 'start' | 'approval' | 'cc' | 'condition' | 'parallel' | 'end' | 'handler'
 export type ApprovalAssigneeType = 'user' | 'role'
-export type ApprovalAssigneeSourceKind = 'static_user' | 'static_role' | 'requester' | 'form_field_user' | 'direct_manager' | 'dept_head' | 'continuous_managers' | 'manager_at_level' | 'requester_choice' | 'continuous_dept_heads' | 'dept_head_at_level'
+export type ApprovalAssigneeSourceKind = 'static_user' | 'static_role' | 'requester' | 'form_field_user' | 'direct_manager' | 'dept_head' | 'continuous_managers' | 'manager_at_level' | 'requester_choice' | 'continuous_dept_heads' | 'dept_head_at_level' | 'prior_node_approver'
 export type ApprovalMode = 'single' | 'all' | 'any' | 'threshold'
 
 /**
@@ -281,6 +281,36 @@ export type ApprovalAssigneeSource =
    * dispatch-time failure).
    */
   | { kind: 'dept_head_at_level'; level: number }
+  /**
+   * Lock-1 §K3 — 节点审批人 (prior-node approver): resolves to the referenced prior node's ACTUAL
+   * decider(s) from INSTANCE state — the audited `action='approve'` actors at that node — never
+   * from that node's config and never from a directory read. `nodeKey` MUST reference an
+   * `approval` node strictly upstream on EVERY runtime-reachable path to the carrying node
+   * (a DOMINANCE check, enforced at publish by `assertPriorNodeApproverReferencesUpstream` —
+   * dangling / non-approval / self / not-on-every-path references are a publish-time 400,
+   * never a dispatch-time surprise).
+   *
+   * This is the ONE kind whose resolution is not a pure function of the create-time snapshot
+   * (§2.1 "K3 alone"): the deciders are unknowable at create, so the CALLER reads them at node
+   * activation from instance-internal `approval_records` rows (LATEST `nodeEntryEpoch` round only
+   * — OD-L1-3(a)) and passes them in alongside the snapshots
+   * (`ResolveApprovalAssigneesOptions.priorNodeApprovers`); the resolver itself stays pure and
+   * adds no database access. System sentinel actors (`system:auto-approval`,
+   * `system:approval-timeout` — the `system:` namespace) are DROPPED, never assigned; when
+   * dropping leaves nothing (or the referenced node was skipped / not reached), resolution is
+   * EMPTY and falls to the node's `emptyAssigneePolicy` (OD-L1-4(a) — under the default 'error'
+   * that is a fail-closed APPROVAL_ASSIGNEE_EMPTY, and under an explicit 'auto-approve' an
+   * AUDITED auto-approval event, never a silent nobody).
+   *
+   * Explicit NO-DEDUP across nodes (§K3): the same person approves AGAIN at the referencing node;
+   * intra-node identity dedup (the resolver's `seen` set) still collapses one identity to one
+   * seat WITHIN this node. NO self-exclusion (deliberate, the §K2 posture): a prior decider who
+   * happens to be the requester still gets the seat — self-approval semantics stay owned by
+   * `autoApprovalPolicy.mergeWithRequester`. The RULE (which node to reference) is frozen in the
+   * instance's pinned published runtime graph, so a re-publish never alters an in-flight
+   * instance's reference.
+   */
+  | { kind: 'prior_node_approver'; nodeKey: string }
 
 export type RequesterChoiceAssigneeSource = Extract<ApprovalAssigneeSource, { kind: 'requester_choice' }>
 
@@ -295,6 +325,12 @@ export interface ApprovalAssigneeResolutionMetadata {
     kind: ApprovalAssigneeSourceKind
     sourceIndex: number
     fieldId?: string
+    /**
+     * Lock-1 §K3 (`prior_node_approver` only): the referenced prior node's key, so "why is this
+     * person an approver" is answerable from the row alone (§2.6 — a template-authored node key,
+     * values-free).
+     */
+    priorNodeKey?: string
   }
   /**
    * Set when a delegation (委托) substituted this assignee: the original delegator's

--- a/packages/core-backend/tests/integration/approval-prior-node-approver.db.test.ts
+++ b/packages/core-backend/tests/integration/approval-prior-node-approver.db.test.ts
@@ -1,0 +1,474 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import net from 'net'
+import { MetaSheetServer } from '../../src/index'
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { query } from '../../src/db/pg'
+import { ensureApprovalSchemaReady, grantApprovalWriteForIntegrationActor } from '../helpers/approval-schema-bootstrap'
+
+/**
+ * Lock-1 §K3 `prior_node_approver` (节点审批人) — REAL-DB end-to-end acceptance
+ * (docs/development/approval-lock1-enterprise-assignees-20260817.md §K3; gates G-1/G-2/G-10/
+ * G-11/G-12/G-18 + OD-L1-3(a) LATEST-round scoping + OD-L1-4(a) skipped/empty fall-through +
+ * freeze-of-the-RULE). Harness mirrors approval-dept-head-at-level.db.test.ts (K5-b), but this
+ * kind needs NO directory fixture at all: resolution is INSTANCE-INTERNAL (audit-row actors),
+ * never a directory read — the absence of any directory_* setup here is itself the point.
+ *
+ * Proves:
+ *  G-1        authoring choke: missing/empty nodeKey and an unknown extra key each 400 naming the
+ *             structural source path; a valid shape saves (positive control). A DANGLING reference
+ *             is draft-SAVEABLE but publish-REJECTED — the dominance gate is publish-scoped.
+ *  G-10       upstream legality at publish: dangling / downstream / self references 400
+ *             (APPROVAL_ASSIGNEE_PRIOR_NODE_REFERENCE_INVALID, values-free: node keys + reason,
+ *             never a person id); the legal upstream reference publishes (positive control —
+ *             every other test in this file publishes one).
+ *  happy path prior node approved by X → the referencing node assigns EXACTLY X, with the §2.6
+ *             audit trail (resolvedFrom.kind/priorNodeKey) on the assignment row. This is ALSO
+ *             the in-flight-merge proof: X's own approve record is inserted after resolution, so
+ *             the caller-side merge is what carried X into the map.
+ *  multi-seat 会签 (all): BOTH actual deciders (partial-vote audit row + in-flight actor) are
+ *             assigned; 或签 (any): ONLY the acting decider is — "ACTUAL deciders", never the
+ *             configured seat list.
+ *  OD-L1-3(a) LATEST round only: after a return re-activates the referenced node and a DIFFERENT
+ *             seat decides round 2, the referencing node assigns the round-2 decider only.
+ *  OD-L1-4(a) skipped/empty fail-closed: an admin-jump PAST the referenced node (never decided)
+ *             fails 400 APPROVAL_ASSIGNEE_EMPTY under emptyAssigneePolicy 'error' — and a
+ *             create-time auto-approval cascade reaching the referencing node behaves the same
+ *             ('error' ⇒ create fails with ZERO rows; 'auto-approve' ⇒ the instance completes
+ *             with an EXPLICIT audited auto-approval record and no `system:*` assignee row —
+ *             never a silent nobody).
+ *  G-12       no cross-node dedup: the SAME person approves at the prior node and AGAIN at the
+ *             referencing node (intra-node dedup is unit-covered).
+ *  freeze     the RULE is frozen with the instance's pinned published definition: re-publishing
+ *             a v2 that changes the node's sources does NOT alter an in-flight instance's
+ *             resolution (v1 semantics discriminated against v2's).
+ */
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const TS = Date.now()
+const REQ = `pna-req-${TS}`
+const DECIDER_A = `pna-a-${TS}`
+const DECIDER_B = `pna-b-${TS}`
+const MID = `pna-mid-${TS}`
+
+async function canListen(): Promise<boolean> {
+  return await new Promise((r) => {
+    const s = net.createServer()
+    s.once('error', () => r(false))
+    s.listen(0, '127.0.0.1', () => s.close(() => r(true)))
+  })
+}
+async function tok(base: string, userId: string): Promise<string> {
+  await grantApprovalWriteForIntegrationActor(userId)
+  const res = await fetch(`${base}/api/auth/dev-token?userId=${encodeURIComponent(userId)}&roles=admin&perms=${encodeURIComponent('*:*')}`)
+  return ((await res.json()) as { token: string }).token
+}
+async function req(base: string, path: string, token: string, opts: { method?: string; body?: unknown } = {}): Promise<Response> {
+  return fetch(`${base}${path}`, {
+    method: opts.method || 'GET',
+    headers: { Authorization: `Bearer ${token}`, ...(opts.body !== undefined ? { 'Content-Type': 'application/json' } : {}) },
+    ...(opts.body !== undefined ? { body: JSON.stringify(opts.body) } : {}),
+  })
+}
+
+const FORM_SCHEMA = { fields: [{ id: 'reason', type: 'text', label: 'r', required: true }] }
+
+// start -> gate (configurable seats/mode) -> again (prior_node_approver ref 'gate') -> end.
+function pnaGraph(options: {
+  gateSources?: Array<Record<string, unknown>>
+  gateMode?: 'single' | 'all' | 'any'
+  againSources?: Array<Record<string, unknown>>
+  againPolicy?: 'error' | 'auto-approve'
+  gateAutoApproval?: Record<string, unknown>
+} = {}) {
+  return {
+    nodes: [
+      { key: 'start', type: 'start', name: 's', config: {} },
+      {
+        key: 'gate', type: 'approval', name: 'gate',
+        config: {
+          assigneeSources: options.gateSources ?? [{ kind: 'static_user', userIds: [DECIDER_A] }],
+          approvalMode: options.gateMode ?? 'single',
+          emptyAssigneePolicy: 'error',
+          ...(options.gateAutoApproval ? { autoApprovalPolicy: options.gateAutoApproval } : {}),
+        },
+      },
+      {
+        key: 'again', type: 'approval', name: 'again',
+        config: {
+          assigneeSources: options.againSources ?? [{ kind: 'prior_node_approver', nodeKey: 'gate' }],
+          approvalMode: 'single',
+          emptyAssigneePolicy: options.againPolicy ?? 'error',
+        },
+      },
+      { key: 'end', type: 'end', name: 'e', config: {} },
+    ],
+    edges: [
+      { key: 's2g', source: 'start', target: 'gate' },
+      { key: 'g2a', source: 'gate', target: 'again' },
+      { key: 'a2e', source: 'again', target: 'end' },
+    ],
+  }
+}
+
+// start -> gate(any A,B) -> mid(MID) -> again (prior 'gate') -> end — the return/round fixture,
+// and (with a jump) the skipped-node fixture referencing 'mid'.
+function fourNodeGraph(againRef: 'gate' | 'mid') {
+  return {
+    nodes: [
+      { key: 'start', type: 'start', name: 's', config: {} },
+      { key: 'gate', type: 'approval', name: 'gate', config: { assigneeSources: [{ kind: 'static_user', userIds: [DECIDER_A, DECIDER_B] }], approvalMode: 'any', emptyAssigneePolicy: 'error' } },
+      { key: 'mid', type: 'approval', name: 'mid', config: { assigneeSources: [{ kind: 'static_user', userIds: [MID] }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+      { key: 'again', type: 'approval', name: 'again', config: { assigneeSources: [{ kind: 'prior_node_approver', nodeKey: againRef }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+      { key: 'end', type: 'end', name: 'e', config: {} },
+    ],
+    edges: [
+      { key: 's2g', source: 'start', target: 'gate' },
+      { key: 'g2m', source: 'gate', target: 'mid' },
+      { key: 'm2a', source: 'mid', target: 'again' },
+      { key: 'a2e', source: 'again', target: 'end' },
+    ],
+  }
+}
+
+type ErrorBody = { code?: string; error?: { code?: string; message?: string; details?: Record<string, unknown> } }
+function errorCode(body: ErrorBody): string | undefined {
+  return body.code ?? body.error?.code
+}
+
+// K2-precedent anti-skip-green sentinel: TOP-LEVEL (not inside describeIfDatabase — there it
+// would be skipped exactly when it should fire). Armed by EXPECT_DB=1 in the
+// approval-realdb-acceptance.yml lane: a DB-expected run with a missing DATABASE_URL goes RED
+// instead of silently skip-greening the whole suite. Unarmed no-DB collection skips cleanly.
+const itIfExpectDb = process.env.EXPECT_DB === '1' ? it : it.skip
+itIfExpectDb('sentinel: EXPECT_DB lane must have DATABASE_URL (a DB-expected run must never skip-green)', () => {
+  expect(process.env.DATABASE_URL).toBeTruthy()
+})
+
+describeIfDatabase('Lock-1 §K3 prior_node_approver — real-DB publish/dispatch acceptance', () => {
+  let server: MetaSheetServer | undefined
+  let base = ''
+  let reqTok = ''
+  let aTok = ''
+  let bTok = ''
+  let midTok = ''
+
+  async function createTemplate(key: string, graph: unknown): Promise<string> {
+    const created = await req(base, '/api/approval-templates', reqTok, {
+      method: 'POST',
+      body: { key, name: key, formSchema: FORM_SCHEMA, approvalGraph: graph },
+    })
+    expect(created.status, await created.clone().text()).toBe(201)
+    return ((await created.json()) as { id: string }).id
+  }
+  async function publishTemplate(tid: string): Promise<Response> {
+    return req(base, `/api/approval-templates/${tid}/publish`, reqTok, { method: 'POST', body: { policy: { allowRevoke: true } } })
+  }
+  async function createPublished(key: string, graph: unknown): Promise<string> {
+    const tid = await createTemplate(key, graph)
+    const published = await publishTemplate(tid)
+    expect(published.status, await published.clone().text()).toBe(200)
+    return tid
+  }
+  async function activeAssignees(iid: string, nodeKey: string): Promise<Array<{ assignee_id: string; metadata: Record<string, unknown> | null }>> {
+    const pool = poolManager.get()
+    const rows = await pool.query(
+      `SELECT assignee_id, metadata FROM approval_assignments WHERE instance_id = $1 AND node_key = $2 AND is_active = TRUE ORDER BY assignee_id`,
+      [iid, nodeKey],
+    )
+    return rows.rows as Array<{ assignee_id: string; metadata: Record<string, unknown> | null }>
+  }
+  async function createAsReq(tid: string): Promise<{ status: number; iid?: string; text: string }> {
+    const started = await req(base, '/api/approvals', reqTok, { method: 'POST', body: { templateId: tid, formData: { reason: 'r' } } })
+    const text = await started.clone().text()
+    if (started.status >= 300) return { status: started.status, text }
+    return { status: started.status, iid: ((await started.json()) as { id: string }).id, text }
+  }
+  async function act(iid: string, token: string, body: Record<string, unknown>): Promise<Response> {
+    return req(base, `/api/approvals/${iid}/actions`, token, { method: 'POST', body })
+  }
+  async function instanceVersion(iid: string): Promise<number> {
+    const pool = poolManager.get()
+    const rows = await pool.query(`SELECT version FROM approval_instances WHERE id = $1`, [iid])
+    return Number(rows.rows[0].version)
+  }
+
+  beforeAll(async () => {
+    expect(await canListen()).toBe(true)
+    await ensureApprovalSchemaReady()
+    for (const u of [REQ, DECIDER_A, DECIDER_B, MID]) {
+      await query(`INSERT INTO users (id, email, password_hash) VALUES ($1, $2, 'x') ON CONFLICT (id) DO NOTHING`, [u, `${u}@example.test`])
+    }
+    server = new MetaSheetServer({ port: 0, host: '127.0.0.1', pluginDirs: [] })
+    await server.start()
+    base = `http://127.0.0.1:${server.getAddress()!.port}`
+    reqTok = await tok(base, REQ)
+    aTok = await tok(base, DECIDER_A)
+    bTok = await tok(base, DECIDER_B)
+    midTok = await tok(base, MID)
+  })
+
+  afterAll(async () => {
+    try {
+      const pool = poolManager.get()
+      const tids = (await pool.query(`SELECT id FROM approval_templates WHERE key LIKE $1`, [`pna-${TS}-%`])).rows.map((r) => r.id as string)
+      if (tids.length > 0) {
+        const iids = (await pool.query(`SELECT id FROM approval_instances WHERE template_id = ANY($1::uuid[])`, [tids])).rows.map((r) => r.id as string)
+        if (iids.length > 0) {
+          await pool.query(`DELETE FROM approval_records WHERE instance_id = ANY($1)`, [iids])
+          await pool.query(`DELETE FROM approval_assignments WHERE instance_id = ANY($1)`, [iids])
+          await pool.query(`DELETE FROM approval_instances WHERE id = ANY($1)`, [iids])
+        }
+        await pool.query(`DELETE FROM approval_published_definitions WHERE template_id = ANY($1::uuid[])`, [tids])
+        await pool.query(`DELETE FROM approval_templates WHERE id = ANY($1::uuid[])`, [tids])
+      }
+      await query(`DELETE FROM users WHERE id = ANY($1::varchar[])`, [[REQ, DECIDER_A, DECIDER_B, MID]])
+    } catch {
+      /* best effort */
+    }
+    if (server) await server.stop()
+  })
+
+  // ── G-1 — authoring choke: exact shape ───────────────────────────────────────────────────────
+  it('G-1: prior_node_approver saves with a valid shape; missing/empty nodeKey and an unknown extra key each 400 naming the structural source path (G-18: no person id)', async () => {
+    // Positive control FIRST: a valid shape saves as a draft.
+    const okTid = await createTemplate(`pna-${TS}-g1-ok`, pnaGraph())
+    expect(okTid).toBeTruthy()
+
+    const badSources: Array<Record<string, unknown>> = [
+      { kind: 'prior_node_approver' }, // nodeKey missing
+      { kind: 'prior_node_approver', nodeKey: '' }, // empty
+      { kind: 'prior_node_approver', nodeKey: '   ' }, // blank
+      { kind: 'prior_node_approver', nodeKey: 'gate', futureFlag: true }, // unknown extra key
+    ]
+    for (const source of badSources) {
+      const graph = pnaGraph({ againSources: [source] })
+      const res = await req(base, '/api/approval-templates', reqTok, {
+        method: 'POST',
+        body: { key: `pna-${TS}-g1-bad`, name: 'bad', formSchema: FORM_SCHEMA, approvalGraph: graph },
+      })
+      expect(res.status, JSON.stringify(source)).toBe(400)
+      const raw = await res.clone().text()
+      // G-18: values-free — the message carries the structural source path (template-authored,
+      // §2.6-permitted), never a person id (none was supplied for a shape rejection).
+      expect(raw).toContain('assigneeSources[0]')
+    }
+  })
+
+  // ── G-2 — not-yet-implemented is not inert (positive control: this slice's kind persists) ────
+  it('G-2: a contract-unimplemented kind (user_group / K1, not landed at this baseline) is rejected at authoring, never persisted', async () => {
+    const graph = pnaGraph({ againSources: [{ kind: 'user_group', groupIds: ['g1'] }] })
+    const key = `pna-${TS}-g2-unimplemented`
+    const res = await req(base, '/api/approval-templates', reqTok, {
+      method: 'POST',
+      body: { key, name: key, formSchema: FORM_SCHEMA, approvalGraph: graph },
+    })
+    expect(res.status).toBe(400)
+    const rows = await query(`SELECT id FROM approval_templates WHERE key = $1`, [key])
+    expect(rows.rows).toHaveLength(0)
+    // Positive control: prior_node_approver (this slice's implemented kind) persists — G-1 above.
+  })
+
+  // ── G-10 — upstream legality: the dominance gate is PUBLISH-scoped, values-free ─────────────
+  it('G-10: a DANGLING reference is draft-saveable but publish-rejected; DOWNSTREAM and SELF references publish-reject too; the reason + node keys are in the body, no person id (G-18)', async () => {
+    // Dangling: draft save OK (stored drafts stay fixable), publish 400.
+    const danglingTid = await createTemplate(`pna-${TS}-g10-dangling`, pnaGraph({ againSources: [{ kind: 'prior_node_approver', nodeKey: 'nope' }] }))
+    const danglingPub = await publishTemplate(danglingTid)
+    const danglingText = await danglingPub.clone().text()
+    expect(danglingPub.status, danglingText).toBe(400)
+    expect(errorCode(JSON.parse(danglingText) as ErrorBody)).toBe('APPROVAL_ASSIGNEE_PRIOR_NODE_REFERENCE_INVALID')
+    expect(danglingText).toContain('again')
+    expect(danglingText).toContain('nope')
+
+    // Downstream: gate references 'again' (which is after it).
+    const downstreamTid = await createTemplate(`pna-${TS}-g10-downstream`, pnaGraph({
+      gateSources: [{ kind: 'prior_node_approver', nodeKey: 'again' }],
+      againSources: [{ kind: 'static_user', userIds: [DECIDER_A] }],
+    }))
+    const downstreamPub = await publishTemplate(downstreamTid)
+    const downstreamText = await downstreamPub.clone().text()
+    expect(downstreamPub.status, downstreamText).toBe(400)
+    expect(errorCode(JSON.parse(downstreamText) as ErrorBody)).toBe('APPROVAL_ASSIGNEE_PRIOR_NODE_REFERENCE_INVALID')
+
+    // Self.
+    const selfTid = await createTemplate(`pna-${TS}-g10-self`, pnaGraph({ againSources: [{ kind: 'prior_node_approver', nodeKey: 'again' }] }))
+    const selfPub = await publishTemplate(selfTid)
+    expect(selfPub.status, await selfPub.clone().text()).toBe(400)
+
+    // Positive control: the legal upstream reference publishes (the same shape every dispatch
+    // test below relies on).
+    const legalTid = await createTemplate(`pna-${TS}-g10-legal`, pnaGraph())
+    const legalPub = await publishTemplate(legalTid)
+    expect(legalPub.status, await legalPub.clone().text()).toBe(200)
+  })
+
+  // ── Happy path + G-12 no-dedup + audit trail ─────────────────────────────────────────────────
+  it('happy path: gate approved by A → `again` assigns EXACTLY A with resolvedFrom.priorNodeKey audit; the SAME person then approves again at `again` (G-12 no cross-node dedup) and the instance completes', async () => {
+    const tid = await createPublished(`pna-${TS}-happy`, pnaGraph())
+    const started = await createAsReq(tid)
+    expect(started.status, started.text).toBe(201)
+    const iid = started.iid!
+
+    const gateApprove = await act(iid, aTok, { action: 'approve' })
+    expect(gateApprove.status, await gateApprove.clone().text()).toBeLessThan(300)
+
+    const assignees = await activeAssignees(iid, 'again')
+    expect(assignees.map((a) => a.assignee_id)).toEqual([DECIDER_A])
+    const resolvedFrom = (assignees[0].metadata as { resolvedFrom?: { kind?: string; priorNodeKey?: string } } | null)?.resolvedFrom
+    expect(resolvedFrom?.kind).toBe('prior_node_approver')
+    expect(resolvedFrom?.priorNodeKey).toBe('gate')
+
+    // G-12: the same person approves AGAIN at the referencing node — no cross-node dedup.
+    const againApprove = await act(iid, aTok, { action: 'approve' })
+    expect(againApprove.status, await againApprove.clone().text()).toBeLessThan(300)
+    const finalStatus = await query(`SELECT status FROM approval_instances WHERE id = $1`, [iid])
+    expect(finalStatus.rows[0].status).toBe('approved')
+  })
+
+  // ── Multi-seat semantics: ACTUAL deciders, not the configured seat list ──────────────────────
+  it('multi-seat 会签 (all): BOTH actual deciders assign at `again` (persisted partial vote + in-flight actor compose); 或签 (any): ONLY the acting decider does', async () => {
+    // all-mode: A approves (partial, committed as an audit row), then B approves (completes —
+    // B rides the in-flight merge). `again` = [A, B].
+    const allTid = await createPublished(`pna-${TS}-all`, pnaGraph({ gateSources: [{ kind: 'static_user', userIds: [DECIDER_A, DECIDER_B] }], gateMode: 'all' }))
+    const allStarted = await createAsReq(allTid)
+    expect(allStarted.status, allStarted.text).toBe(201)
+    const allIid = allStarted.iid!
+    const firstVote = await act(allIid, aTok, { action: 'approve' })
+    expect(firstVote.status, await firstVote.clone().text()).toBeLessThan(300)
+    expect(await activeAssignees(allIid, 'again')).toHaveLength(0) // partial: node not resolved yet
+    const secondVote = await act(allIid, bTok, { action: 'approve' })
+    expect(secondVote.status, await secondVote.clone().text()).toBeLessThan(300)
+    const allAssignees = await activeAssignees(allIid, 'again')
+    expect(allAssignees.map((a) => a.assignee_id).sort()).toEqual([DECIDER_A, DECIDER_B].sort())
+
+    // any-mode: A approves first — B never acted, so B is NOT an "actual decider".
+    const anyTid = await createPublished(`pna-${TS}-any`, pnaGraph({ gateSources: [{ kind: 'static_user', userIds: [DECIDER_A, DECIDER_B] }], gateMode: 'any' }))
+    const anyStarted = await createAsReq(anyTid)
+    expect(anyStarted.status, anyStarted.text).toBe(201)
+    const anyIid = anyStarted.iid!
+    const anyVote = await act(anyIid, aTok, { action: 'approve' })
+    expect(anyVote.status, await anyVote.clone().text()).toBeLessThan(300)
+    expect((await activeAssignees(anyIid, 'again')).map((a) => a.assignee_id)).toEqual([DECIDER_A])
+  })
+
+  // ── OD-L1-3(a) — LATEST round only ───────────────────────────────────────────────────────────
+  it('round scoping (OD-L1-3(a)): after a return re-activates the referenced node and a DIFFERENT seat decides round 2, `again` assigns the round-2 decider ONLY (round-1 votes never leak in)', async () => {
+    const tid = await createPublished(`pna-${TS}-rounds`, fourNodeGraph('gate'))
+    const started = await createAsReq(tid)
+    expect(started.status, started.text).toBe(201)
+    const iid = started.iid!
+
+    // Round 1: A decides gate (any-mode). mid activates.
+    const round1 = await act(iid, aTok, { action: 'approve' })
+    expect(round1.status, await round1.clone().text()).toBeLessThan(300)
+    // MID returns to gate → round 2 (fresh epoch; round-1 records now belong to a stale round).
+    const returned = await act(iid, midTok, { action: 'return', targetNodeKey: 'gate' })
+    expect(returned.status, await returned.clone().text()).toBeLessThan(300)
+    // Round 2: B decides gate this time.
+    const round2 = await act(iid, bTok, { action: 'approve' })
+    expect(round2.status, await round2.clone().text()).toBeLessThan(300)
+    // mid again, then advance to `again`.
+    const midApprove = await act(iid, midTok, { action: 'approve' })
+    expect(midApprove.status, await midApprove.clone().text()).toBeLessThan(300)
+
+    // LATEST round only: B — the round-2 decider — and NOT A (round 1).
+    expect((await activeAssignees(iid, 'again')).map((a) => a.assignee_id)).toEqual([DECIDER_B])
+  })
+
+  // ── OD-L1-4(a) — skipped referenced node fails closed (never silent) ─────────────────────────
+  it('skipped node (OD-L1-4(a)): an admin jump PAST the never-decided referenced node fails 400 APPROVAL_ASSIGNEE_EMPTY under `error` (values-free, names the node); the normal un-skipped flow through the SAME graph resolves (positive control)', async () => {
+    const tid = await createPublished(`pna-${TS}-skip`, fourNodeGraph('mid'))
+    const started = await createAsReq(tid)
+    expect(started.status, started.text).toBe(201)
+    const iid = started.iid!
+
+    // Instance sits at gate; jump straight to `again`, skipping mid (never decided).
+    const version = await instanceVersion(iid)
+    const jump = await req(base, `/api/approvals/${iid}/jump`, reqTok, {
+      method: 'POST',
+      body: { version, targetNodeKey: 'again', reason: 'skip-mid probe' },
+    })
+    const jumpText = await jump.clone().text()
+    expect(jump.status, jumpText).toBe(400)
+    expect(errorCode(JSON.parse(jumpText) as ErrorBody)).toBe('APPROVAL_ASSIGNEE_EMPTY')
+    expect(jumpText).toContain('again')
+    // Fail-closed: the failed jump left the instance pending at gate with zero `again` rows.
+    expect(await activeAssignees(iid, 'again')).toHaveLength(0)
+
+    // Positive control (the same graph, un-skipped): gate → mid → `again` assigns MID.
+    const gateApprove = await act(iid, aTok, { action: 'approve' })
+    expect(gateApprove.status, await gateApprove.clone().text()).toBeLessThan(300)
+    const midApprove = await act(iid, midTok, { action: 'approve' })
+    expect(midApprove.status, await midApprove.clone().text()).toBeLessThan(300)
+    expect((await activeAssignees(iid, 'again')).map((a) => a.assignee_id)).toEqual([MID])
+  })
+
+  // ── OD-L1-4(a) + G-11 — auto-approved referenced node: sentinel never assigned ───────────────
+  it('auto-approved referenced node: a create-time cascade reaching `again` fails the create 400 with ZERO rows under `error`; under an explicit `auto-approve` the instance completes with an AUDITED auto-approval record and NO system:* assignee row (never silent, G-11 arm)', async () => {
+    // gate resolves to the requester + mergeWithRequester → auto-approved at create (sentinel
+    // decider) → `again` activates during the create cascade with no persisted round.
+    const cascadeGraph = (againPolicy: 'error' | 'auto-approve') => pnaGraph({
+      gateSources: [{ kind: 'requester' }],
+      gateAutoApproval: { mergeWithRequester: true },
+      againPolicy,
+    })
+
+    // 'error': fail-closed create — 400 APPROVAL_ASSIGNEE_EMPTY, zero instance rows.
+    const errorTid = await createPublished(`pna-${TS}-cascade-err`, cascadeGraph('error'))
+    const preCount = await query(`SELECT COUNT(*)::int AS n FROM approval_instances WHERE template_id = $1`, [errorTid])
+    const failed = await createAsReq(errorTid)
+    expect(failed.status, failed.text).toBe(400)
+    expect(errorCode(JSON.parse(failed.text) as ErrorBody)).toBe('APPROVAL_ASSIGNEE_EMPTY')
+    const postCount = await query(`SELECT COUNT(*)::int AS n FROM approval_instances WHERE template_id = $1`, [errorTid])
+    expect(postCount.rows[0].n).toBe(preCount.rows[0].n)
+
+    // 'auto-approve': the instance completes; the empty resolution is an EXPLICIT audited
+    // auto-approval, and no `system:*` id ever becomes an assignee (G-11).
+    const autoTid = await createPublished(`pna-${TS}-cascade-auto`, cascadeGraph('auto-approve'))
+    const auto = await createAsReq(autoTid)
+    expect(auto.status, auto.text).toBe(201)
+    const autoIid = auto.iid!
+    const status = await query(`SELECT status FROM approval_instances WHERE id = $1`, [autoIid])
+    expect(status.rows[0].status).toBe('approved')
+    const sentinelAssignees = await query(
+      `SELECT assignee_id FROM approval_assignments WHERE instance_id = $1 AND assignee_id LIKE 'system:%'`,
+      [autoIid],
+    )
+    expect(sentinelAssignees.rows).toHaveLength(0)
+    const auditedAuto = await query(
+      `SELECT id FROM approval_records WHERE instance_id = $1 AND action = 'approve' AND actor_id = 'system:auto-approval' AND metadata->>'nodeKey' = 'again'`,
+      [autoIid],
+    )
+    expect(auditedAuto.rows.length).toBeGreaterThan(0)
+  })
+
+  // ── Freeze: the RULE rides the instance's pinned published definition ────────────────────────
+  it('freeze of the RULE: re-publishing a v2 that changes the referencing node sources does NOT alter an in-flight instance resolution (v1 semantics discriminated against v2)', async () => {
+    const tid = await createPublished(`pna-${TS}-freeze`, pnaGraph())
+    const started = await createAsReq(tid)
+    expect(started.status, started.text).toBe(201)
+    const iid = started.iid!
+
+    // Re-publish v2: `again` now names a STATIC approver (DECIDER_B). If the in-flight instance
+    // wrongly read the live template, `again` would assign B; the frozen v1 rule assigns the
+    // gate decider A. B ≠ A makes the arms discriminating, not vacuous.
+    const patched = await req(base, `/api/approval-templates/${tid}`, reqTok, {
+      method: 'PATCH',
+      body: { key: `pna-${TS}-freeze`, name: 'v2', formSchema: FORM_SCHEMA, approvalGraph: pnaGraph({ againSources: [{ kind: 'static_user', userIds: [DECIDER_B] }] }) },
+    })
+    expect(patched.status, await patched.clone().text()).toBe(200)
+    const republished = await publishTemplate(tid)
+    expect(republished.status, await republished.clone().text()).toBe(200)
+
+    // Dispatch the in-flight (v1-pinned) instance: gate approved by A → `again` = A per v1.
+    const gateApprove = await act(iid, aTok, { action: 'approve' })
+    expect(gateApprove.status, await gateApprove.clone().text()).toBeLessThan(300)
+    expect((await activeAssignees(iid, 'again')).map((a) => a.assignee_id)).toEqual([DECIDER_A])
+
+    // Positive control (temporal, not a dead read): a NEW instance under v2 picks up the v2
+    // static source — `again` assigns B without any gate decider involvement.
+    const v2Started = await createAsReq(tid)
+    expect(v2Started.status, v2Started.text).toBe(201)
+    const v2Approve = await act(v2Started.iid!, aTok, { action: 'approve' })
+    expect(v2Approve.status, await v2Approve.clone().text()).toBeLessThan(300)
+    expect((await activeAssignees(v2Started.iid!, 'again')).map((a) => a.assignee_id)).toEqual([DECIDER_B])
+  })
+})

--- a/packages/core-backend/tests/integration/approval-prior-node-approver.db.test.ts
+++ b/packages/core-backend/tests/integration/approval-prior-node-approver.db.test.ts
@@ -37,16 +37,21 @@ import { ensureApprovalSchemaReady, grantApprovalWriteForIntegrationActor } from
  *             with an EXPLICIT audited auto-approval record and no `system:*` assignee row —
  *             never a silent nobody). NOTE: this create-time arm resolves against an ABSENT
  *             `priorNodeApprovers` map (§K3: the map is never built on the create path), so it
- *             does not exercise the sentinel-drop filter itself — see G-11 below for the arm that
- *             does.
- *  G-11       sentinel-drop reachability: the referenced node auto-approves under
- *             `system:auto-approval` at CREATE (a COMMITTED, separate transaction — `gate`'s
- *             cascade halts at a REAL human node before ever reaching the referencing node, unlike
- *             the OD-L1-4(a) arm above). The referencing node activates LATER, on the acting
- *             decider's OWN approve transaction, which forces `loadPriorNodeApproverDeciders` to
- *             actually READ gate's persisted `system:auto-approval` row and DROP it — never a
- *             vacuous "map absent" pass. EMPTY resolution, no `system:*` assignee row, audited
- *             auto-approval instead.
+ *             does not exercise the sentinel-drop filter itself — see G-11 below for the arms that
+ *             do.
+ *  G-11       two arms, over a genuine dispatch-path transaction (not create-time):
+ *             (a) sentinel-drop: the referenced node auto-approves under `system:auto-approval` at
+ *             CREATE (a COMMITTED, separate transaction — the cascade halts at a REAL human node
+ *             before ever reaching the referencing node, unlike the OD-L1-4(a) arm above); the
+ *             referencing node activates LATER, on the acting decider's OWN approve — EMPTY
+ *             resolution, no `system:*` assignee row, audited auto-approval instead. Mutation
+ *             note: this arm alone cannot distinguish "the map was built and filtered" from "the
+ *             map was never built" — both look EMPTY (verified: gutting the dispatch call site
+ *             leaves it green). (b) human-survivor reachability: the SAME graph, but the
+ *             referencing node names BOTH the sentinel-only node AND a REAL decider in its
+ *             `assigneeSources` — the real decider MUST survive resolution, which requires
+ *             `loadPriorNodeApproverDeciders` to have genuinely run (a gutted call site drops the
+ *             survivor too, mutation-verified) — the arm that actually carries reachability.
  *  G-12       no cross-node dedup: the SAME person approves at the prior node and AGAIN at the
  *             referencing node (intra-node dedup is unit-covered).
  *  freeze     the RULE is frozen with the instance's pinned published definition: re-publishing
@@ -454,8 +459,17 @@ describeIfDatabase('Lock-1 §K3 prior_node_approver — real-DB publish/dispatch
     expect(auditedAuto.rows.length).toBeGreaterThan(0)
   })
 
-  // ── G-11 — service-door reachability: the sentinel filter reads a REAL committed row ──────────
-  it('service-door reachability (G-11): `gate` auto-approves under `system:auto-approval` at CREATE (a COMMITTED transaction, cascade halted at a REAL human `mid` node before ever touching `again`); MID\'s LATER approve activates `again`, forcing loadPriorNodeApproverDeciders to actually read + drop gate\'s persisted sentinel row — EMPTY resolution, no system:* assignee, audited auto-approval', async () => {
+  // ── G-11 — sentinel-drop over a genuine dispatch-path transaction ───────────────────────────
+  // NOTE on what this leg does and does NOT prove: it shows the sentinel never leaks into an
+  // assignee row even when `again` resolves on a REAL dispatch-path transaction (not the
+  // create-time cascade). It does NOT, by itself, prove `loadPriorNodeApproverDeciders` was
+  // actually CALLED — an empty resolution here looks IDENTICAL whether the map was built and
+  // correctly filtered, or never built at all (mutation-verified: gutting the dispatch call site
+  // so `priorNodeApprovers` stays undefined leaves this leg green, same failure mode the P2
+  // finding named for the OD-L1-4(a) arm above). That reachability claim is carried by the
+  // separate "human-survivor reachability (G-11)" leg below, which requires the map to be built
+  // and filtered correctly by MIXING a sentinel-only reference with a REAL decider reference.
+  it('sentinel-drop over a real dispatch-path transaction (G-11): `gate` auto-approves under `system:auto-approval` at CREATE (a COMMITTED transaction, cascade halted at a REAL human `mid` node before ever touching `again`); MID\'s LATER approve activates `again` on the dispatch path — EMPTY resolution, no system:* assignee, audited auto-approval', async () => {
     // start -> gate (requester + mergeWithRequester ⇒ auto-approves AT CREATE, COMMITTED) ->
     // mid (REAL human decider ⇒ the create-time cascade halts HERE, never reaching `again`) ->
     // again (prior_node_approver -> 'gate', emptyAssigneePolicy 'auto-approve') -> end.
@@ -464,9 +478,7 @@ describeIfDatabase('Lock-1 §K3 prior_node_approver — real-DB publish/dispatch
     // auto-approving node and resolves within the SAME create-time cascade — where
     // `getPriorNodeApprovers` is omitted entirely, §K3), this graph puts a REAL decider (`mid`)
     // between `gate` and `again`. `again` can only activate on MID's own approve — a SEPARATE,
-    // LATER transaction on the dispatch/act path, which DOES build the `priorNodeApprovers` map
-    // from `gate`'s already-committed row. That is the only path that exercises the service-side
-    // sentinel filter (`loadPriorNodeApproverDeciders`'s `pushDecider`) for real.
+    // LATER transaction on the dispatch/act path.
     const svcDoorGraph = {
       nodes: [
         { key: 'start', type: 'start', name: 's', config: {} },
@@ -534,6 +546,84 @@ describeIfDatabase('Lock-1 §K3 prior_node_approver — real-DB publish/dispatch
     expect(auditedAuto.rows.length).toBeGreaterThan(0)
     const finalStatus = await query(`SELECT status FROM approval_instances WHERE id = $1`, [iid])
     expect(finalStatus.rows[0].status).toBe('approved')
+  })
+
+  // ── G-11 — human-survivor reachability: the map-build itself is load-bearing ────────────────
+  // The leg above cannot distinguish "the map was built and correctly filtered" from "the map was
+  // never built at all" — both look like an EMPTY resolution. This leg closes that gap the way the
+  // resolver's OWN unit test does (approval-assignee-resolver.test.ts:260's mandatory
+  // human-survivor positive control): `again` references TWO prior nodes in the SAME
+  // `assigneeSources` array — the sentinel-only `gate` (must contribute nothing) AND the REAL
+  // human decider `mid` (must survive). `mid` is `again`'s own immediate predecessor, so MID's
+  // approve is simultaneously the ACT that activates `again` and the round `mid` itself is being
+  // decided in — `mid`'s entry is carried through the in-flight-merge branch of
+  // `loadPriorNodeApproverDeciders`, `gate`'s through the persisted-audit-row branch: one
+  // resolution, both branches of the SAME function. If the dispatch call site were gutted (the
+  // map stays undefined, mutation-verified to leave the leg above green), `again` would resolve
+  // to EMPTY here too — MID would silently NOT be an assignee — and the assertion below reds.
+  it('human-survivor reachability (G-11): `again` references BOTH the sentinel-only `gate` and the REAL decider `mid` — `mid` MUST survive resolution, which is only possible if loadPriorNodeApproverDeciders genuinely ran (a gutted call site, mutation-verified, silently drops MID too — NOT a vacuous "map absent" pass)', async () => {
+    const survivorGraph = {
+      nodes: [
+        { key: 'start', type: 'start', name: 's', config: {} },
+        {
+          key: 'gate', type: 'approval', name: 'gate',
+          config: {
+            assigneeSources: [{ kind: 'requester' }],
+            approvalMode: 'single',
+            emptyAssigneePolicy: 'error',
+            autoApprovalPolicy: { mergeWithRequester: true },
+          },
+        },
+        { key: 'mid', type: 'approval', name: 'mid', config: { assigneeSources: [{ kind: 'static_user', userIds: [MID] }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+        {
+          key: 'again', type: 'approval', name: 'again',
+          config: {
+            // Sentinel-only reference FIRST, real-decider reference SECOND — order-independence
+            // is incidental here; what matters is BOTH sources feed the SAME resolution.
+            assigneeSources: [
+              { kind: 'prior_node_approver', nodeKey: 'gate' },
+              { kind: 'prior_node_approver', nodeKey: 'mid' },
+            ],
+            approvalMode: 'single',
+            emptyAssigneePolicy: 'error',
+          },
+        },
+        { key: 'end', type: 'end', name: 'e', config: {} },
+      ],
+      edges: [
+        { key: 's2g', source: 'start', target: 'gate' },
+        { key: 'g2m', source: 'gate', target: 'mid' },
+        { key: 'm2a', source: 'mid', target: 'again' },
+        { key: 'a2e', source: 'again', target: 'end' },
+      ],
+    }
+    const tid = await createPublished(`pna-${TS}-g11-survivor`, survivorGraph)
+    const started = await createAsReq(tid)
+    expect(started.status, started.text).toBe(201)
+    const iid = started.iid!
+
+    // gate's sentinel row already committed at create; `again` untouched (cascade halted at mid).
+    const gateAuto = await query(
+      `SELECT id FROM approval_records WHERE instance_id = $1 AND action = 'approve' AND actor_id = 'system:auto-approval' AND metadata->>'nodeKey' = 'gate'`,
+      [iid],
+    )
+    expect(gateAuto.rows.length).toBeGreaterThan(0)
+    expect(await activeAssignees(iid, 'again')).toHaveLength(0)
+
+    // MID's approve is BOTH the decider of `mid` (in-flight branch) and the trigger that
+    // activates `again` (persisted-row branch, reading gate's committed sentinel).
+    const midApprove = await act(iid, midTok, { action: 'approve' })
+    expect(midApprove.status, await midApprove.clone().text()).toBeLessThan(300)
+
+    // The REAL survivor: `again` resolves to EXACTLY [MID] — gate's sentinel contributed
+    // nothing, but a genuinely-built, correctly-filtered map still carried mid's real decider
+    // through. A map that was never built (call-site gutted) would have dropped MID here too.
+    expect((await activeAssignees(iid, 'again')).map((a) => a.assignee_id)).toEqual([MID])
+    const sentinelAssignees = await query(
+      `SELECT assignee_id FROM approval_assignments WHERE instance_id = $1 AND assignee_id LIKE 'system:%'`,
+      [iid],
+    )
+    expect(sentinelAssignees.rows).toHaveLength(0)
   })
 
   // ── Freeze: the RULE rides the instance's pinned published definition ────────────────────────

--- a/packages/core-backend/tests/integration/approval-prior-node-approver.db.test.ts
+++ b/packages/core-backend/tests/integration/approval-prior-node-approver.db.test.ts
@@ -35,7 +35,18 @@ import { ensureApprovalSchemaReady, grantApprovalWriteForIntegrationActor } from
  *             create-time auto-approval cascade reaching the referencing node behaves the same
  *             ('error' ⇒ create fails with ZERO rows; 'auto-approve' ⇒ the instance completes
  *             with an EXPLICIT audited auto-approval record and no `system:*` assignee row —
- *             never a silent nobody).
+ *             never a silent nobody). NOTE: this create-time arm resolves against an ABSENT
+ *             `priorNodeApprovers` map (§K3: the map is never built on the create path), so it
+ *             does not exercise the sentinel-drop filter itself — see G-11 below for the arm that
+ *             does.
+ *  G-11       sentinel-drop reachability: the referenced node auto-approves under
+ *             `system:auto-approval` at CREATE (a COMMITTED, separate transaction — `gate`'s
+ *             cascade halts at a REAL human node before ever reaching the referencing node, unlike
+ *             the OD-L1-4(a) arm above). The referencing node activates LATER, on the acting
+ *             decider's OWN approve transaction, which forces `loadPriorNodeApproverDeciders` to
+ *             actually READ gate's persisted `system:auto-approval` row and DROP it — never a
+ *             vacuous "map absent" pass. EMPTY resolution, no `system:*` assignee row, audited
+ *             auto-approval instead.
  *  G-12       no cross-node dedup: the SAME person approves at the prior node and AGAIN at the
  *             referencing node (intra-node dedup is unit-covered).
  *  freeze     the RULE is frozen with the instance's pinned published definition: re-publishing
@@ -401,8 +412,11 @@ describeIfDatabase('Lock-1 §K3 prior_node_approver — real-DB publish/dispatch
     expect((await activeAssignees(iid, 'again')).map((a) => a.assignee_id)).toEqual([MID])
   })
 
-  // ── OD-L1-4(a) + G-11 — auto-approved referenced node: sentinel never assigned ───────────────
-  it('auto-approved referenced node: a create-time cascade reaching `again` fails the create 400 with ZERO rows under `error`; under an explicit `auto-approve` the instance completes with an AUDITED auto-approval record and NO system:* assignee row (never silent, G-11 arm)', async () => {
+  // ── OD-L1-4(a) — create-time cascade reaching the referencing node ───────────────────────────
+  // NOTE: this arm's `again` resolves against an ABSENT `priorNodeApprovers` map (the create path
+  // never builds one — §K3), so it does NOT exercise the sentinel-drop filter (G-11's actual
+  // reachability leg is below, "service-door reachability (G-11)"). Kept for OD-L1-4(a) coverage.
+  it('auto-approved referenced node: a create-time cascade reaching `again` fails the create 400 with ZERO rows under `error`; under an explicit `auto-approve` the instance completes with an AUDITED auto-approval record and NO system:* assignee row (never silent, OD-L1-4(a))', async () => {
     // gate resolves to the requester + mergeWithRequester → auto-approved at create (sentinel
     // decider) → `again` activates during the create cascade with no persisted round.
     const cascadeGraph = (againPolicy: 'error' | 'auto-approve') => pnaGraph({
@@ -438,6 +452,88 @@ describeIfDatabase('Lock-1 §K3 prior_node_approver — real-DB publish/dispatch
       [autoIid],
     )
     expect(auditedAuto.rows.length).toBeGreaterThan(0)
+  })
+
+  // ── G-11 — service-door reachability: the sentinel filter reads a REAL committed row ──────────
+  it('service-door reachability (G-11): `gate` auto-approves under `system:auto-approval` at CREATE (a COMMITTED transaction, cascade halted at a REAL human `mid` node before ever touching `again`); MID\'s LATER approve activates `again`, forcing loadPriorNodeApproverDeciders to actually read + drop gate\'s persisted sentinel row — EMPTY resolution, no system:* assignee, audited auto-approval', async () => {
+    // start -> gate (requester + mergeWithRequester ⇒ auto-approves AT CREATE, COMMITTED) ->
+    // mid (REAL human decider ⇒ the create-time cascade halts HERE, never reaching `again`) ->
+    // again (prior_node_approver -> 'gate', emptyAssigneePolicy 'auto-approve') -> end.
+    //
+    // Unlike the OD-L1-4(a) arm above (where `again` sits immediately downstream of the
+    // auto-approving node and resolves within the SAME create-time cascade — where
+    // `getPriorNodeApprovers` is omitted entirely, §K3), this graph puts a REAL decider (`mid`)
+    // between `gate` and `again`. `again` can only activate on MID's own approve — a SEPARATE,
+    // LATER transaction on the dispatch/act path, which DOES build the `priorNodeApprovers` map
+    // from `gate`'s already-committed row. That is the only path that exercises the service-side
+    // sentinel filter (`loadPriorNodeApproverDeciders`'s `pushDecider`) for real.
+    const svcDoorGraph = {
+      nodes: [
+        { key: 'start', type: 'start', name: 's', config: {} },
+        {
+          key: 'gate', type: 'approval', name: 'gate',
+          config: {
+            assigneeSources: [{ kind: 'requester' }],
+            approvalMode: 'single',
+            emptyAssigneePolicy: 'error',
+            autoApprovalPolicy: { mergeWithRequester: true },
+          },
+        },
+        { key: 'mid', type: 'approval', name: 'mid', config: { assigneeSources: [{ kind: 'static_user', userIds: [MID] }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+        {
+          key: 'again', type: 'approval', name: 'again',
+          config: {
+            assigneeSources: [{ kind: 'prior_node_approver', nodeKey: 'gate' }],
+            approvalMode: 'single',
+            emptyAssigneePolicy: 'auto-approve',
+          },
+        },
+        { key: 'end', type: 'end', name: 'e', config: {} },
+      ],
+      edges: [
+        { key: 's2g', source: 'start', target: 'gate' },
+        { key: 'g2m', source: 'gate', target: 'mid' },
+        { key: 'm2a', source: 'mid', target: 'again' },
+        { key: 'a2e', source: 'again', target: 'end' },
+      ],
+    }
+    const tid = await createPublished(`pna-${TS}-g11-svc-door`, svcDoorGraph)
+    const started = await createAsReq(tid)
+    expect(started.status, started.text).toBe(201)
+    const iid = started.iid!
+
+    // Reachability + COMMITTED: `gate`'s sentinel row already exists, from create()'s own
+    // transaction, BEFORE mid ever acts — not an in-flight merge on the SAME request.
+    const gateAuto = await query(
+      `SELECT id FROM approval_records WHERE instance_id = $1 AND action = 'approve' AND actor_id = 'system:auto-approval' AND metadata->>'nodeKey' = 'gate'`,
+      [iid],
+    )
+    expect(gateAuto.rows.length).toBeGreaterThan(0)
+    // The create-time cascade halted at `mid` (a real human) — `again` was never touched at create.
+    expect(await activeAssignees(iid, 'again')).toHaveLength(0)
+    expect((await activeAssignees(iid, 'mid')).map((a) => a.assignee_id)).toEqual([MID])
+
+    // MID's approve is a NEW, LATER transaction: `again` activates and its
+    // prior_node_approver('gate') resolution reads gate's committed sentinel row for real.
+    const midApprove = await act(iid, midTok, { action: 'approve' })
+    expect(midApprove.status, await midApprove.clone().text()).toBeLessThan(300)
+
+    // No phantom `system:*` seat — an EMPTY resolution, never a leaked sentinel assignee.
+    expect(await activeAssignees(iid, 'again')).toHaveLength(0)
+    const sentinelAssignees = await query(
+      `SELECT assignee_id FROM approval_assignments WHERE instance_id = $1 AND assignee_id LIKE 'system:%'`,
+      [iid],
+    )
+    expect(sentinelAssignees.rows).toHaveLength(0)
+    // The empty resolution is an EXPLICIT audited auto-approval on `again` itself
+    // (emptyAssigneePolicy 'auto-approve') — never a silent nobody.
+    const auditedAuto = await query(
+      `SELECT id FROM approval_records WHERE instance_id = $1 AND action = 'approve' AND actor_id = 'system:auto-approval' AND metadata->>'nodeKey' = 'again'`,
+      [iid],
+    )
+    expect(auditedAuto.rows.length).toBeGreaterThan(0)
+    const finalStatus = await query(`SELECT status FROM approval_instances WHERE id = $1`, [iid])
+    expect(finalStatus.rows[0].status).toBe('approved')
   })
 
   // ── Freeze: the RULE rides the instance's pinned published definition ────────────────────────

--- a/packages/core-backend/tests/unit/approval-assignee-resolver.test.ts
+++ b/packages/core-backend/tests/unit/approval-assignee-resolver.test.ts
@@ -220,6 +220,79 @@ describe('ApprovalAssigneeResolver', () => {
     expect(resolveDeptHeadAtLevel(3, { id: 'requester-1', deptHeadChainIds: ['h1', null as never, 'h3'] })).toEqual([dhalEntry('h3')])
   })
 
+  // prior_node_approver (Lock-1 §K3) — resolves the referenced prior node's ACTUAL deciders from
+  // the CALLER-supplied priorNodeApprovers map (instance-internal audit-row actors, latest round;
+  // read by the caller at activation — the resolver adds no DB access, §2.1).
+  function resolvePrior(
+    nodeKey: string,
+    priorNodeApprovers: Record<string, string[]> | undefined,
+    requesterSnapshot: Record<string, unknown> | null = { id: 'requester-1' },
+  ) {
+    return resolveApprovalAssignees({
+      nodeKey: 'review',
+      sourceStep: 2,
+      config: { assigneeSources: [{ kind: 'prior_node_approver', nodeKey }] },
+      formSnapshot: {},
+      requesterSnapshot,
+      ...(priorNodeApprovers !== undefined ? { priorNodeApprovers } : {}),
+    })
+  }
+
+  const priorEntry = (assigneeId: string, priorNodeKey = 'gate') => ({
+    assignmentType: 'user', assigneeId, nodeKey: 'review', sourceStep: 2,
+    metadata: { resolvedFrom: { kind: 'prior_node_approver', sourceIndex: 0, priorNodeKey } },
+  })
+
+  it('resolves prior_node_approver to the referenced node deciders from the caller-supplied map, stamping resolvedFrom.priorNodeKey (positive control)', () => {
+    expect(resolvePrior('gate', { gate: ['decider-1', 'decider-2'] }))
+      .toEqual([priorEntry('decider-1'), priorEntry('decider-2')])
+    // Keyed by the SOURCE's nodeKey, not the resolving node's — a map entry for a different node
+    // contributes nothing (reference-selected, not map-order-selected).
+    expect(resolvePrior('gate', { other: ['decider-9'] })).toEqual([])
+  })
+
+  it('resolves prior_node_approver to empty when the map is absent (create-time cascade / preview) or the entry is missing/empty — falls to emptyAssigneePolicy (OD-L1-4(a)), never a throw', () => {
+    expect(resolvePrior('gate', undefined)).toEqual([])
+    expect(resolvePrior('gate', {})).toEqual([])
+    expect(resolvePrior('gate', { gate: [] })).toEqual([])
+  })
+
+  it('drops system sentinel actors (system:auto-approval / system:approval-timeout) — never assigned, even from a hand-assembled map (G-11 pure re-check; the human decider in the SAME list survives)', () => {
+    expect(resolvePrior('gate', { gate: ['system:auto-approval', 'system:approval-timeout'] })).toEqual([])
+    // Actor-selected, not blanket: a human decider alongside the sentinels still resolves.
+    expect(resolvePrior('gate', { gate: ['system:auto-approval', 'decider-1'] })).toEqual([priorEntry('decider-1')])
+  })
+
+  it('does NOT self-exclude prior_node_approver (deliberate §K2-posture: a prior decider who is the requester keeps the seat; self-approval stays owned by autoApprovalPolicy)', () => {
+    expect(resolvePrior('gate', { gate: ['requester-1'] })).toEqual([priorEntry('requester-1')])
+  })
+
+  it('keeps intra-node identity dedup (G-12 positive control): the same decider listed twice — or resolved by two sources — collapses to ONE seat at this node', () => {
+    expect(resolvePrior('gate', { gate: ['decider-1', 'decider-1'] })).toEqual([priorEntry('decider-1')])
+    // Two prior_node_approver sources resolving the same person: one seat, first source wins.
+    expect(resolveApprovalAssignees({
+      nodeKey: 'review',
+      sourceStep: 2,
+      config: {
+        assigneeSources: [
+          { kind: 'prior_node_approver', nodeKey: 'gate' },
+          { kind: 'prior_node_approver', nodeKey: 'gate2' },
+        ],
+      },
+      formSnapshot: {},
+      requesterSnapshot: { id: 'requester-1' },
+      priorNodeApprovers: { gate: ['decider-1'], gate2: ['decider-1'] },
+    })).toEqual([priorEntry('decider-1')])
+  })
+
+  it('applies delegation substitution to a prior_node_approver decider (expansion happens BEFORE pushResolved, so the frozen delegation map covers this kind too)', () => {
+    expect(resolvePrior('gate', { gate: ['decider-1'] }, { id: 'requester-1', delegations: { 'decider-1': 'delegatee-7' } }))
+      .toEqual([{
+        assignmentType: 'user', assigneeId: 'delegatee-7', nodeKey: 'review', sourceStep: 2,
+        metadata: { resolvedFrom: { kind: 'prior_node_approver', sourceIndex: 0, priorNodeKey: 'gate' }, delegatedFrom: 'decider-1' },
+      }])
+  })
+
   it('resolves requester and static sources with source metadata', () => {
     expect(resolve({
       assigneeSources: [

--- a/packages/core-backend/tests/unit/approval-graph-executor.test.ts
+++ b/packages/core-backend/tests/unit/approval-graph-executor.test.ts
@@ -663,6 +663,150 @@ describe('ApprovalGraphExecutor', () => {
     ])
   })
 
+  // ── Lock-1 §K6 precondition (landed by the K3 slice): normalizeApprovalMode fails CLOSED ──
+  // The executor's mode normalizer previously mapped ANY unrecognized mode silently to 'single'
+  // (fail-open). Contract-valid data never reached that arm (the authoring choke + the stored-graph
+  // re-normalize both reject unknown modes), but deploy skew / rollback around a future mode (e.g.
+  // 'sequential') would degrade it silently to first-approver-wins. These tests pin the closure:
+  // the MUTATION "revert normalizeApprovalMode to fail-open" must red the first test below.
+  it('fails CLOSED: an unrecognized approvalMode reaching the executor throws APPROVAL_MODE_UNSUPPORTED instead of running as single (G-14 arm; mutation: revert to fail-open reds THIS test)', () => {
+    const unknownModeGraph = (approvalMode: unknown): RuntimeGraph => ({
+      nodes: [
+        { key: 'start', type: 'start', config: {} },
+        {
+          key: 'skewed',
+          type: 'approval',
+          // Hand-crafted config — the exact deploy-skew shape: a graph published by NEWER code
+          // carrying a mode THIS executor does not know. Bypasses the authoring choke on purpose.
+          config: { assigneeType: 'user', assigneeIds: ['approver-a', 'approver-b'], approvalMode: approvalMode as never },
+        },
+        { key: 'end', type: 'end', config: {} },
+      ],
+      edges: [
+        { key: 'edge-start-skewed', source: 'start', target: 'skewed' },
+        { key: 'edge-skewed-end', source: 'skewed', target: 'end' },
+      ],
+      policy: { allowRevoke: true },
+    })
+
+    for (const unknown of ['sequential', 'SINGLE', 'or_sign', null, 42]) {
+      const executor = new ApprovalGraphExecutor(unknownModeGraph(unknown), {})
+      // Accessor path (getApprovalMode) and resolution path (resolveInitialState) both fail
+      // closed — under the OLD fail-open arm both would have run the node as 'single'.
+      expect(() => executor.getApprovalMode('skewed'), JSON.stringify(unknown)).toThrowError(expect.objectContaining({
+        code: 'APPROVAL_MODE_UNSUPPORTED',
+        statusCode: 400,
+      }))
+      expect(() => executor.resolveInitialState(), JSON.stringify(unknown)).toThrowError(expect.objectContaining({
+        code: 'APPROVAL_MODE_UNSUPPORTED',
+      }))
+    }
+    // Values-free: the error names the node key (template-authored — permitted), never the raw
+    // unknown value (which could be arbitrary junk).
+    try {
+      new ApprovalGraphExecutor(unknownModeGraph('or_sign'), {}).getApprovalMode('skewed')
+      expect.unreachable('getApprovalMode must throw for an unknown mode')
+    } catch (error) {
+      expect((error as Error).message).toContain('skewed')
+      expect((error as Error).message).not.toContain('or_sign')
+    }
+  })
+
+  it('positive controls per mode: every LEGITIMATE shipped approvalMode — absent (≡ single), single, all, any, threshold — still executes (the rejection is unknown-selected, not blanket)', () => {
+    const modeGraph = (config: Record<string, unknown>): RuntimeGraph => ({
+      nodes: [
+        { key: 'start', type: 'start', config: {} },
+        { key: 'node-m', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['approver-a', 'approver-b'], ...config } as never },
+        { key: 'end', type: 'end', config: {} },
+      ],
+      edges: [
+        { key: 'edge-start-m', source: 'start', target: 'node-m' },
+        { key: 'edge-m-end', source: 'node-m', target: 'end' },
+      ],
+      policy: { allowRevoke: true },
+    })
+
+    // Absent → the documented 'single' default (the ONE legitimate non-member input).
+    const absentExecutor = new ApprovalGraphExecutor(modeGraph({}), {})
+    expect(absentExecutor.getApprovalMode('node-m')).toBe('single')
+    expect(absentExecutor.resolveInitialState().assignments).toHaveLength(2)
+
+    for (const mode of ['single', 'all', 'any'] as const) {
+      const executor = new ApprovalGraphExecutor(modeGraph({ approvalMode: mode }), {})
+      expect(executor.getApprovalMode('node-m')).toBe(mode)
+      expect(executor.resolveInitialState().assignments).toHaveLength(2)
+    }
+    // threshold needs its approvalThreshold to pass assertThresholdReachable.
+    const thresholdExecutor = new ApprovalGraphExecutor(modeGraph({ approvalMode: 'threshold', approvalThreshold: 2 }), {})
+    expect(thresholdExecutor.getApprovalMode('node-m')).toBe('threshold')
+    expect(thresholdExecutor.resolveInitialState().assignments).toHaveLength(2)
+  })
+
+  // ── Lock-1 §K3 prior_node_approver — REAL resolver + REAL executor oracle ──
+  // The same no-DB wiring precedent as the §K5-b test above: the REAL resolveApprovalAssignees
+  // (not a fake returning []) inside the REAL executor, the exact integration point the real-DB
+  // suite drives over SQL. The map is CALLER-supplied (the §2.1 contract): the test plays the
+  // caller's role exactly as dispatchAction does after reading audit rows.
+  it('Lock-1 §K3: a prior_node_approver node activated after the referenced node resolves that node ACTUAL deciders from the caller-supplied map; an absent/empty map falls to emptyAssigneePolicy (error throws APPROVAL_ASSIGNEE_EMPTY; auto-approve is an explicit audited event — never a silent nobody)', () => {
+    const k3Graph = (emptyAssigneePolicy: 'error' | 'auto-approve'): RuntimeGraph => ({
+      nodes: [
+        { key: 'start', type: 'start', config: {} },
+        { key: 'gate', type: 'approval', config: { assigneeSources: [{ kind: 'static_user', userIds: ['approver-1'] }] } },
+        { key: 'again', type: 'approval', config: { assigneeSources: [{ kind: 'prior_node_approver', nodeKey: 'gate' }], emptyAssigneePolicy } },
+        { key: 'end', type: 'end', config: {} },
+      ],
+      edges: [
+        { key: 'edge-start-gate', source: 'start', target: 'gate' },
+        { key: 'edge-gate-again', source: 'gate', target: 'again' },
+        { key: 'edge-again-end', source: 'again', target: 'end' },
+      ],
+      policy: { allowRevoke: true },
+    })
+    const resolverWith = (priorNodeApprovers?: Record<string, string[]>) =>
+      ({ nodeKey, sourceStep, config }: { nodeKey: string; sourceStep: number; config: never }) =>
+        resolveApprovalAssignees({
+          nodeKey,
+          sourceStep,
+          config,
+          formSnapshot: {},
+          requesterSnapshot: { id: 'requester-1' },
+          ...(priorNodeApprovers !== undefined ? { priorNodeApprovers } : {}),
+        })
+
+    // Happy path (positive control FIRST): gate approved by approver-1 → the caller (playing
+    // dispatchAction's role) supplies { gate: ['approver-1'] } → 'again' assigns approver-1 with
+    // the §2.6 audit trail (resolvedFrom.priorNodeKey).
+    const happyExecutor = new ApprovalGraphExecutor(k3Graph('error'), {}, { assignmentResolver: resolverWith({ gate: ['approver-1'] }) as never })
+    const advanced = happyExecutor.resolveAfterApprove('gate')
+    expect(advanced.currentNodeKey).toBe('again')
+    expect(advanced.assignments).toEqual([
+      {
+        assignmentType: 'user',
+        assigneeId: 'approver-1',
+        nodeKey: 'again',
+        sourceStep: 2,
+        metadata: { resolvedFrom: { kind: 'prior_node_approver', sourceIndex: 0, priorNodeKey: 'gate' } },
+      },
+    ])
+
+    // 'error' + no map (skipped/unreached/sentinel-only referenced round): fail-closed throw.
+    const errorExecutor = new ApprovalGraphExecutor(k3Graph('error'), {}, { assignmentResolver: resolverWith(undefined) as never })
+    expect(() => errorExecutor.resolveAfterApprove('gate')).toThrowError(expect.objectContaining({
+      code: 'APPROVAL_ASSIGNEE_EMPTY',
+      statusCode: 400,
+    }))
+
+    // 'auto-approve' + sentinel-only map: the drop leaves nothing and the node's OWN policy fires
+    // an EXPLICIT audited auto-approval event (OD-L1-4(a)) — never a silently-materialized
+    // assignee, never an unassigned pending node.
+    const autoExecutor = new ApprovalGraphExecutor(k3Graph('auto-approve'), {}, { assignmentResolver: resolverWith({ gate: ['system:auto-approval'] }) as never })
+    const autoAdvanced = autoExecutor.resolveAfterApprove('gate')
+    expect(autoAdvanced.status).toBe('approved')
+    expect(autoAdvanced.autoApprovalEvents).toEqual([
+      { nodeKey: 'again', sourceStep: 2, approvalMode: 'single', reason: 'empty-assignee' },
+    ])
+  })
+
   it('tags resolveAfterApprove resolutions with the resolved-away node aggregate mode', () => {
     const runtimeGraph: RuntimeGraph = {
       nodes: [

--- a/packages/core-backend/tests/unit/approval-prior-node-approver-gate.test.ts
+++ b/packages/core-backend/tests/unit/approval-prior-node-approver-gate.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, it } from 'vitest'
+import {
+  assertPriorNodeApproverReferencesUpstream,
+  collectRuntimeGraphPriorNodeApproverTargets,
+} from '../../src/services/ApprovalProductService'
+import type { ApprovalGraph, RuntimeGraph } from '../../src/types/approval-product'
+
+/**
+ * Lock-1 §K3 publish gate (`assertPriorNodeApproverReferencesUpstream`) — the DOMINANCE predicate:
+ * a `prior_node_approver` reference must name an `approval` node STRICTLY UPSTREAM on EVERY
+ * runtime-reachable path from start to the carrying node (G-10). Pure graph-shape oracle over the
+ * exported gate; the real-DB acceptance suite proves the publish-choke WIRING of the same gate
+ * over HTTP. Every rejection case is paired with a passing shape so the gate is shown to be
+ * shape-selected, not blanket.
+ */
+
+function approvalNode(key: string, sources: Array<Record<string, unknown>>): ApprovalGraph['nodes'][number] {
+  return { key, type: 'approval', config: { assigneeSources: sources } as never }
+}
+function staticSource(userId: string): Record<string, unknown> {
+  return { kind: 'static_user', userIds: [userId] }
+}
+function priorSource(nodeKey: string): Record<string, unknown> {
+  return { kind: 'prior_node_approver', nodeKey }
+}
+function linearGraph(nodes: ApprovalGraph['nodes']): ApprovalGraph {
+  const keys = ['start', ...nodes.map((node) => node.key), 'end']
+  return {
+    nodes: [
+      { key: 'start', type: 'start', config: {} },
+      ...nodes,
+      { key: 'end', type: 'end', config: {} },
+    ],
+    edges: keys.slice(0, -1).map((source, index) => ({
+      key: `edge-${source}-${keys[index + 1]}`,
+      source,
+      target: keys[index + 1],
+    })),
+  }
+}
+
+function gateError(graph: ApprovalGraph): { code?: string; details?: Record<string, unknown> } | null {
+  try {
+    assertPriorNodeApproverReferencesUpstream(graph)
+    return null
+  } catch (error) {
+    const serviceError = error as { code?: string; details?: Record<string, unknown>; message?: string }
+    return { code: serviceError.code, details: serviceError.details }
+  }
+}
+
+describe('Lock-1 §K3 assertPriorNodeApproverReferencesUpstream (G-10 dominance)', () => {
+  it('passes a legal strictly-upstream linear reference (positive control), and a graph with no prior_node_approver at all', () => {
+    expect(gateError(linearGraph([
+      approvalNode('gate', [staticSource('u1')]),
+      approvalNode('again', [priorSource('gate')]),
+    ]))).toBeNull()
+    expect(gateError(linearGraph([
+      approvalNode('gate', [staticSource('u1')]),
+      approvalNode('next', [staticSource('u2')]),
+    ]))).toBeNull()
+  })
+
+  it('rejects a dangling reference (no such node), values-free with node key + source index + reason', () => {
+    const error = gateError(linearGraph([
+      approvalNode('gate', [staticSource('u1')]),
+      approvalNode('again', [staticSource('u2'), priorSource('nope')]),
+    ]))
+    expect(error?.code).toBe('APPROVAL_ASSIGNEE_PRIOR_NODE_REFERENCE_INVALID')
+    expect(error?.details).toEqual({ nodeKey: 'again', sourceIndex: 1, targetNodeKey: 'nope', reason: 'dangling' })
+  })
+
+  it('rejects a self-reference', () => {
+    const error = gateError(linearGraph([
+      approvalNode('gate', [staticSource('u1')]),
+      approvalNode('again', [priorSource('again')]),
+    ]))
+    expect(error?.code).toBe('APPROVAL_ASSIGNEE_PRIOR_NODE_REFERENCE_INVALID')
+    expect(error?.details?.reason).toBe('self')
+  })
+
+  it('rejects a reference to a NON-approval node (start / cc), even when it is upstream on every path', () => {
+    const graph: ApprovalGraph = {
+      nodes: [
+        { key: 'start', type: 'start', config: {} },
+        { key: 'notify', type: 'cc', config: { targetType: 'user', targetIds: ['u9'] } as never },
+        approvalNode('again', [priorSource('notify')]),
+        { key: 'end', type: 'end', config: {} },
+      ],
+      edges: [
+        { key: 'e1', source: 'start', target: 'notify' },
+        { key: 'e2', source: 'notify', target: 'again' },
+        { key: 'e3', source: 'again', target: 'end' },
+      ],
+    }
+    expect(gateError(graph)?.details?.reason).toBe('not-approval')
+    const startRef = gateError(linearGraph([approvalNode('again', [priorSource('start')])]))
+    expect(startRef?.details?.reason).toBe('not-approval')
+  })
+
+  it('rejects a DOWNSTREAM reference (the target has not decided when the carrier activates)', () => {
+    const error = gateError(linearGraph([
+      approvalNode('first', [priorSource('later')]),
+      approvalNode('later', [staticSource('u2')]),
+    ]))
+    expect(error?.code).toBe('APPROVAL_ASSIGNEE_PRIOR_NODE_REFERENCE_INVALID')
+    expect(error?.details?.reason).toBe('not-upstream-on-every-path')
+  })
+
+  it('condition case (G-10): a target reachable only through ONE condition branch is rejected after the merge; a pre-condition target passes (the rejection is path-selected)', () => {
+    const conditionGraph = (targetKey: string): ApprovalGraph => ({
+      nodes: [
+        { key: 'start', type: 'start', config: {} },
+        approvalNode('pre', [staticSource('u0')]),
+        {
+          key: 'route',
+          type: 'condition',
+          config: {
+            branches: [{ edgeKey: 'edge-b1', rules: [{ fieldId: 'amount', operator: 'gt', value: 1 }] }],
+            defaultEdgeKey: 'edge-b2',
+          } as never,
+        },
+        approvalNode('branch-a', [staticSource('u1')]),
+        approvalNode('branch-b', [staticSource('u2')]),
+        approvalNode('merge', [priorSource(targetKey)]),
+        { key: 'end', type: 'end', config: {} },
+      ],
+      edges: [
+        { key: 'e-start-pre', source: 'start', target: 'pre' },
+        { key: 'e-pre-route', source: 'pre', target: 'route' },
+        { key: 'edge-b1', source: 'route', target: 'branch-a' },
+        { key: 'edge-b2', source: 'route', target: 'branch-b' },
+        { key: 'e-a-merge', source: 'branch-a', target: 'merge' },
+        { key: 'e-b-merge', source: 'branch-b', target: 'merge' },
+        { key: 'e-merge-end', source: 'merge', target: 'end' },
+      ],
+    })
+    // branch-a decides only on the edge-b1 path — the default path reaches `merge` without it.
+    expect(gateError(conditionGraph('branch-a'))?.details?.reason).toBe('not-upstream-on-every-path')
+    // The pre-condition node is on EVERY path — legal (positive control: same graph, different target).
+    expect(gateError(conditionGraph('pre'))).toBeNull()
+  })
+
+  it('parallel case (G-10): a target inside one parallel branch is rejected from a sibling branch AND from past the join (conservative even for joinMode all); a same-branch upstream target and a pre-fork target pass', () => {
+    const parallelGraph = (carrierKey: 'sibling' | 'after-join' | 'same-branch', targetKey: string): ApprovalGraph => {
+      const withPrior = (key: string, base: Array<Record<string, unknown>>): Array<Record<string, unknown>> =>
+        key === carrierKey ? [...base, priorSource(targetKey)] : base
+      return {
+        nodes: [
+          { key: 'start', type: 'start', config: {} },
+          approvalNode('pre', [staticSource('u0')]),
+          {
+            key: 'fork',
+            type: 'parallel',
+            config: { branches: ['edge-p1', 'edge-p2'], joinMode: 'all', joinNodeKey: 'join' } as never,
+          },
+          approvalNode('inside-a', [staticSource('u1')]),
+          approvalNode('same-branch', withPrior('same-branch', [staticSource('u3')])),
+          approvalNode('sibling', withPrior('sibling', [staticSource('u2')])),
+          approvalNode('join', [staticSource('u4')]),
+          approvalNode('after-join', withPrior('after-join', [staticSource('u5')])),
+          { key: 'end', type: 'end', config: {} },
+        ],
+        edges: [
+          { key: 'e-start-pre', source: 'start', target: 'pre' },
+          { key: 'e-pre-fork', source: 'pre', target: 'fork' },
+          { key: 'edge-p1', source: 'fork', target: 'inside-a' },
+          { key: 'e-a-same', source: 'inside-a', target: 'same-branch' },
+          { key: 'e-same-join', source: 'same-branch', target: 'join' },
+          { key: 'edge-p2', source: 'fork', target: 'sibling' },
+          { key: 'e-sib-join', source: 'sibling', target: 'join' },
+          { key: 'e-join-after', source: 'join', target: 'after-join' },
+          { key: 'e-after-end', source: 'after-join', target: 'end' },
+        ],
+      }
+    }
+    // Sibling branch: `sibling` references `inside-a` — active simultaneously, never dominant.
+    expect(gateError(parallelGraph('sibling', 'inside-a'))?.details?.reason).toBe('not-upstream-on-every-path')
+    // Past the join: still rejected (a sibling-branch path reaches the join without inside-a) —
+    // the lock's conservative "may not have decided" posture, even under joinMode 'all'.
+    expect(gateError(parallelGraph('after-join', 'inside-a'))?.details?.reason).toBe('not-upstream-on-every-path')
+    // SAME-branch upstream: `same-branch` references `inside-a` — every path to it passes
+    // inside-a (a sibling path cannot re-enter this branch before the join) — legal.
+    expect(gateError(parallelGraph('same-branch', 'inside-a'))).toBeNull()
+    // Pre-fork target from past the join — on every path — legal (positive control).
+    expect(gateError(parallelGraph('after-join', 'pre'))).toBeNull()
+  })
+})
+
+describe('Lock-1 §K3 collectRuntimeGraphPriorNodeApproverTargets (OPT-IN detector)', () => {
+  const asRuntime = (graph: ApprovalGraph): RuntimeGraph => ({ ...graph, policy: { allowRevoke: true } })
+
+  it('returns the referenced node-key set for approval nodes, and an EMPTY set for a graph with no prior_node_approver (unrelated approvals pay nothing)', () => {
+    expect([...collectRuntimeGraphPriorNodeApproverTargets(asRuntime(linearGraph([
+      approvalNode('gate', [staticSource('u1')]),
+      approvalNode('again', [priorSource('gate')]),
+      approvalNode('again2', [priorSource('gate'), priorSource('again')]),
+    ])))].sort()).toEqual(['again', 'gate'])
+    expect(collectRuntimeGraphPriorNodeApproverTargets(asRuntime(linearGraph([
+      approvalNode('gate', [staticSource('u1')]),
+    ]))).size).toBe(0)
+  })
+})

--- a/packages/core-backend/tests/unit/approval-prior-node-approver-gate.test.ts
+++ b/packages/core-backend/tests/unit/approval-prior-node-approver-gate.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import {
   assertPriorNodeApproverReferencesUpstream,
   collectRuntimeGraphPriorNodeApproverTargets,
+  runtimeGraphUsesOrgAssigneeSource,
 } from '../../src/services/ApprovalProductService'
 import type { ApprovalGraph, RuntimeGraph } from '../../src/types/approval-product'
 
@@ -199,5 +200,20 @@ describe('Lock-1 §K3 collectRuntimeGraphPriorNodeApproverTargets (OPT-IN detect
     expect(collectRuntimeGraphPriorNodeApproverTargets(asRuntime(linearGraph([
       approvalNode('gate', [staticSource('u1')]),
     ]))).size).toBe(0)
+  })
+
+  it('does NOT arm the org-read fail-closed detector: a graph using ONLY prior_node_approver is not an org-derived source (§2.1 extends that detector to K4/K5-b only — K3 reads instance-internal audit rows, no org read)', () => {
+    const k3Only = asRuntime(linearGraph([
+      approvalNode('gate', [staticSource('u1')]),
+      approvalNode('again', [priorSource('gate')]),
+    ]))
+    expect(runtimeGraphUsesOrgAssigneeSource(k3Only)).toBe(false)
+    // Positive control (the detector is source-selected, not dead): the SAME graph shape with an
+    // org-derived source DOES arm it.
+    const orgDerived = asRuntime(linearGraph([
+      approvalNode('gate', [{ kind: 'direct_manager' }]),
+      approvalNode('again', [priorSource('gate')]),
+    ]))
+    expect(runtimeGraphUsesOrgAssigneeSource(orgDerived)).toBe(true)
   })
 })

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -334,6 +334,14 @@ export default defineConfig({
       // approval-realdb-k5b) — plugin-tests.yml stays byte-identical (s6a pin). Two-point wiring —
       // both points land in the SAME commit.
       'tests/integration/approval-dept-head-at-level.db.test.ts',
+      // Lock-1 §K3 prior_node_approver real-DB acceptance (G-1/G-2/G-10/G-11/G-12/G-18 +
+      // OD-L1-3(a) latest-round + OD-L1-4(a) skipped/auto-approved fail-closed + freeze-of-rule).
+      // DATABASE_URL-gated; excluded here so the no-DB default job cannot collect-and-skip-green
+      // it, and carried by the SAME dedicated .github/workflows/approval-realdb-acceptance.yml
+      // workflow (sibling job approval-realdb-k3, EXPECT_DB=1 arming the top-level anti-skip
+      // sentinel) — plugin-tests.yml stays byte-identical (s6a pin). Two-point wiring — both
+      // points land in the SAME commit.
+      'tests/integration/approval-prior-node-approver.db.test.ts',
       'tests/integration/approval-delegation-seam.db.test.ts',
       'tests/integration/approval-delegation-api.db.test.ts',
       'tests/integration/approval-detail-subform.db.test.ts',


### PR DESCRIPTION
Full-stack slice of the RATIFIED Lock-1 §K3 `prior_node_approver` (节点审批人), following the exact K2 (#4952) / K4 (#4958) / K5-b (#4962) pattern, plus the §K6-sequencing precondition named for this slice: the executor's fail-open `normalizeApprovalMode` is closed here.

Lock: `docs/development/approval-lock1-enterprise-assignees-20260817.md` §K3, §2.1–2.6, G-1/G-2/G-10/G-11/G-12/G-18; owner decisions OD-L1-3(a) (LATEST round only) and OD-L1-4(a) (sentinel/skipped ⇒ `emptyAssigneePolicy`) per the §4 ratification block.

## What the kind does

`{ kind: 'prior_node_approver'; nodeKey }` resolves to the referenced prior node's **ACTUAL deciders from instance state** — the audited `action='approve'` actors — never that node's config and never a directory read (instance-internal reads are not directory reads; there is deliberately **no directory fixture at all** in the acceptance suite).

## Semantics implemented (lock citations)

- **Caller-supplied input, pure resolver (§2.1 "K3 alone")**: the deciders are unknowable at create, so the CALLER reads them at node activation from `approval_records` (`metadata->>'nodeKey'` idiom) and passes them in alongside the snapshots (`ResolveApprovalAssigneesOptions.priorNodeApprovers`). No resolver-internal DB access was added.
- **Round scoping (OD-L1-3(a))**: LATEST `nodeEntryEpoch` round only. The approve path additionally merges the **in-flight actor** scoped to the current round's epoch (their own approve record is inserted only after resolution) — so `或签` yields the acting decider, `会签` yields every seat that actually approved (persisted partial votes + the completing actor), and a returned-and-re-decided node yields the round-2 decider only.
- **Sentinels dropped (§K3 shipped precedent)**: `system:auto-approval` / `system:approval-timeout` (the repo-wide `system:` non-user namespace) are dropped at the audit-row read AND re-checked purely in the resolver; under `actorMode:'original_approver'` the row carries the real approver id and is kept.
- **Empty ⇒ `emptyAssigneePolicy` (OD-L1-4(a))**: a skipped / unreached / sentinel-only referenced node resolves EMPTY — fail-closed `APPROVAL_ASSIGNEE_EMPTY` under the default `error`, an **explicit audited** auto-approval event under `auto-approve`. Never a silent nobody. A create-time cascade reaching a referencing node behaves identically (`error` ⇒ create fails 400 with zero rows). Route previews show the honest `EMPTY_ASSIGNEES` marker (the §K2 pre-choice precedent).
- **NO cross-node dedup (§K3 explicit)**: the same person approves again at the referencing node; intra-node identity dedup (the resolver's `seen` set) is unchanged. NO self-exclusion (the §K2 posture) — self-approval stays owned by `autoApprovalPolicy`.
- **Freeze of the RULE**: the reference lives in the instance's pinned published runtime graph; re-publishing a v2 never alters an in-flight instance's resolution (real-DB test discriminates v1 vs v2 shapes).
- **Publish-time dominance gate (§K3, G-10)**: `assertPriorNodeApproverReferencesUpstream` — the target must be an `approval` node **strictly upstream on EVERY runtime-reachable path** (removal-reachability over `runtimeSuccessorTargets`, exactly the primitives the lock says to reuse; the parallel-conflict GATE itself was not reused — different predicate). Dangling / self / non-approval / downstream / condition-branch-only / parallel-sibling references are a values-free 400 `APPROVAL_ASSIGNEE_PRIOR_NODE_REFERENCE_INVALID`. Publish-scoped like the parallel-conflict gate (drafts stay saveable while being fixed; instances only run published graphs). Conservative for parallel regions per the lock's "may not have decided": a target inside one branch is rejected past the join even under joinMode `all`.
- **Fingerprint (§2.4 locked entry)**: `prior_node_approver:<nodeKey>` on BOTH mirrors, enforced by the existing `_exhaustive: never` guards.
- **OPT-IN (§2.1)**: `collectRuntimeGraphPriorNodeApproverTargets` gates every audit-row read — unrelated approvals pay nothing. `runtimeGraphUsesOrgAssigneeSource` is deliberately NOT extended (§2.1 names K4/K5-b only; K3 needs no org read, and arming the org-read fail-closed guard for it would fail creates that need no org read).

## normalizeApprovalMode closure (the named precondition)

`ApprovalGraphExecutor.normalizeApprovalMode` previously mapped ANY unrecognized mode silently to `'single'`. Now: `undefined` keeps the documented `'single'` absent-default; the four shipped members pass; **anything else** (unknown string, `null`, non-string) throws a typed 400 `APPROVAL_MODE_UNSUPPORTED` naming the node key — the raw value is deliberately not echoed. Widen-only verified: `asRuntimeGraph` re-normalizes every STORED graph through the service-side fail-closed choke on each dispatch (which rejects unknown modes and `null` and emits the key only when set), so `undefined` + the four members are the ONLY values that can legitimately reach the executor — no shipped mode hits the new rejection. Per-mode positive controls (absent / single / all / any / threshold) execute in the same unit suite; the mutation "revert to fail-open" reds exactly the named test (52/53 stay green — verified by actually running it).

## The five FE mirror sites (§2.5)

1. `packages/core-backend/src/types/approval-product.ts` — kind + union member (+ `resolvedFrom.priorNodeKey` audit field).
2. `apps/web/src/types/approval.ts` — FE copies of both.
3. `apps/web/src/approvals/templateAuthoring.ts` `BACKEND_ASSIGNEE_SOURCE_KEYS_BY_KIND` — `['kind','nodeKey']`.
4. `apps/web/src/approvals/templateAuthoring.ts` linear accepted-kind list — with REAL linear round-trip support (below), not a flatten hazard.
5. `apps/web/src/approvals/assigneeSource.ts` `assigneeSourceSummary` — explicit case naming the referenced node key (template-authored, §2.6-permitted); the values-free unknown-kind fallback stays.

Plus the M4 registry row 节点审批人 in the SAME commit (exact-set spec grows 11→12; NOT admitted on `handler` — Lock-3 §1.5 lists no row for this kind, pinned by a new mutation-4 exact-set probe) and the fingerprint mirror in `parallelEdit.ts`.

## Authoring

- **Canvas inspector**: a TYPED upstream-node picker (D0 §10.2 — never a free-text key) over `legalPriorApproverNodeKeys` (`approvalNodeEdit.ts`, the FE mirror of the backend dominance gate, sharing `parallelEdit`'s now-exported `runtimeSuccessorTargets`), provided through the context api's optional `priorApproverNodeOptions` off the live effective graph; honest "no upstream candidates" hint on e.g. the first approval node.
- **Linear editor**: the step stores a **stable step-localId reference**, deliberately NOT a raw node key — the linear builder renumbers keys positionally (`approval_${index+1}`), so a raw-key carrier would silently RETARGET the reference when a step is inserted above (the wrong-approver class this program exists to close). `sourceFromStep` emits the referenced step's CURRENT positional key at build; hydrate re-resolves the stored key in a post-pass; a linear graph whose reference is not an earlier approval node opens fail-closed read-only (never silently re-referenced on save). A retarget-safety test pins the insert-above case emitting the moved step's new key.

## Tests

- **Real-DB acceptance** `approval-prior-node-approver.db.test.ts` — new sibling job `approval-realdb-k3` in `approval-realdb-acceptance.yml` (EXPECT_DB=1 TOP-LEVEL anti-skip sentinel, the K2 posture; both `paths:` blocks extended). Two-point wiring in the same commit: excluded from the no-DB default `vitest.config.ts` (verified locally: naming the file under the default config collects nothing). `plugin-tests.yml` untouched (s6a pin). Covers: G-1 shape choke (+ dangling draft-saveable/publish-rejected split), G-2, G-10 (dangling/downstream/self + legal positive control), happy path with `resolvedFrom.priorNodeKey` audit (also the in-flight-merge proof), multi-seat all/any, OD-L1-3(a) latest-round via return+re-decide, OD-L1-4(a) skipped node via admin-jump + create-cascade both arms, G-12, freeze-of-the-RULE with a v2-discriminating positive control, and **two dedicated G-11 legs** — see "Fix round" below for exactly what each does and does not prove (the OD-L1-4(a) create-cascade arm above does NOT carry G-11's claim; only these two do).
- **Unit**: resolver arm (reference selection, sentinel drop with in-list survivor control, no-self-exclusion, intra-node dedup, delegation composition); executor mode-closure (named red-on-revert test + per-mode positive controls) and a REAL-resolver K3 executor oracle (happy / error / audited auto-approve); dominance-gate shape matrix + OPT-IN collector (new file `approval-prior-node-approver-gate.test.ts`, collected by the default no-DB job).
- **FE**: exact-set 11→12 (A-3 + D1), K3 canvas sub-form mount + empty-candidate hint, fingerprint lockstep + non-collision, per-kind allowlist arms, handler-roster refusal (roster assertion + mutation-4 probe), linear round-trip / retarget-safety / validation / fail-closed hydrate / mounted 2-step hydration. **No new FE spec files** — all extensions of already-wired specs, so no CI-token additions are needed in `run-required-web-tests.sh` / `approval-web-guard.yml`.

## Local verification (actually run, not inferred; re-run on the REBASED head after #4965/#4966 landed)

- backend `tsc --noEmit` clean (with a deliberate-type-error positive control proving the run bites) and `vue-tsc -b` clean — both re-run post-rebase.
- Full `apps/web/scripts/run-required-web-tests.sh` on Node 20.20.2: **4605/4617 passed; every spec this diff touches green** (incl. the extended approval specs, 285 tests re-run green post-rebase). The 12 failures are 5s TIMEOUTS in specs sharing zero imports with this diff (multitable automation/workbench, approval-center master-detail), and the same files fail **identically on the un-patched `origin/main` base on this machine** (base == head) — machine-environmental, not this diff; the always-on `web-tests.yml` ubuntu runner is the arbiter.
- **Real-DB suite rehearsed locally** against PG 16 (fresh DB per run, the workflow's exact MIGRATION_EXCLUDE list), on the REBASED head: K3 `approval-prior-node-approver.db.test.ts` **10/10**; sibling lanes whose `paths:` filters this diff trips: `approval-requester-choice.db.test.ts` **13/13**, `approval-dept-head-at-level.db.test.ts` **7/7**, `approval-handler-node.db.test.ts` **21/21**. (Stale count — this line is the author's original pre-fix-round local rehearsal. Two legs were added in the fix round below; current count is **12/12**, confirmed live on the `approval-realdb-k3` CI job, not just locally.)
- **Mutations** (cp-backup + sha256-identical restore, applied one at a time, each run for real):
  - executor fail-open revert → exactly the named G-14 test red (52/53 green);
  - resolver sentinel-drop removal → exactly the sentinel test red;
  - resolver map keyed by the resolving node instead of the source's reference → the 5 reference-selected tests red;
  - dominance-predicate inversion → both rejection AND positive-control arms red (4/8);
  - publish-choke call removal (wiring, not the function) → exactly the real-DB G-10 test red over real SQL, 9/10 others green;
  - FE roster-order drop → exactly A-3 + the K3 mount test red; label drop → exactly D1 red; fingerprint-case drop → exactly the lockstep test red.

## Deliberately out of scope

- The timeout-JUMP wiring shares the identical eager-read path as adminJump (same loader, same OD-L1-4(a) fall-through) but has no dedicated real-DB leg (the scanner harness is heavy); it is covered by the shared loader's real-DB legs + unit arms.
- Same-transaction cascade under `actorMode:'original_approver'`: the attributable decider of an unpersisted round is NOT re-materialized — resolution falls to `emptyAssigneePolicy` (fail-closed / audited), never a silently-wrong approver. Documented in the create-path comment; refinement would require threading in-memory cascade state into the resolver (an impurity §2.1 forbids).
- Lock-4's historical-dedup seam: §K3 names this kind the natural exemption and assigns the ruling to Lock-4 — nothing here prejudges it.
- No handler-roster widening (Lock-3 §1.5 lists no row for this kind), no flag changes, no migration, no deployment.

## Fix round (adversarial gate, 2026-08-18) — 0 P1 / 1 P2 closed, across two commits

**Retraction 1** (first commit): the original "OD-L1-4(a) skipped node via admin-jump + create-cascade both arms (incl. G-11 ...)" line above overclaimed. That arm's `again` resolves within the SAME create-time cascade that auto-approves `gate` — where `getPriorNodeApprovers` is deliberately omitted (§K3 create-path comment) — so its EMPTY result came from the map being **absent**, not from the sentinel-drop filter being exercised. Zero discriminating coverage of `loadPriorNodeApproverDeciders`'s service-side filter (`ApprovalProductService.ts` `pushDecider`) existed at the integration level; that filter was reachable only through the resolver's own unit test (`approval-assignee-resolver.test.ts`, hand-built map, bypasses the service layer). **Fix**: added a G-11 leg ("sentinel-drop over a real dispatch-path transaction") where `gate` auto-approves under `system:auto-approval` at CREATE (committed, separate transaction) behind a REAL human node (`mid`), so `again` can only activate on `mid`'s own LATER approve. Retitled the pre-existing create-cascade arm to drop the G-11 claim.

**Retraction 2** (second commit — caught by my own advisor review of the first commit, before it was reported done): the first commit's new leg *itself* could not distinguish "the `priorNodeApprovers` map was built and correctly filtered" from "the map was never built at all" — an empty resolution looks identical either way. I had claimed it forces `loadPriorNodeApproverDeciders` to "actually read + drop" the sentinel row and is "never a vacuous map-absent pass"; **mutation-tested, that claim was false**: gutting the dispatch-path call site (`ApprovalProductService.ts` ~7508–7517, so `priorNodeApprovers` stays undefined on dispatch too, not only at create) left the leg green — the exact same failure mode the P2 named for the original create-cascade arm. **Fix**: added a second leg, "human-survivor reachability (G-11)" — the referencing node's `assigneeSources` names BOTH the sentinel-only prior node AND a REAL decider (its own immediate predecessor, reached through the in-flight-merge branch of `loadPriorNodeApproverDeciders`, so one resolution exercises both the persisted-row and in-flight branches of the same function). The real decider can only survive resolution if the map was genuinely built. Retitled the first leg's docstring to state plainly what it does and does not prove, rather than leaving the overclaim standing.

**Mutation evidence** (cp-backup + sha256-verified restore, never `git checkout --`), current state:
- Gutting the dispatch call site (map stays undefined): the human-survivor leg REDS (along with 5 pre-existing tests — happy path, multi-seat, round-scoping, skipped-node, freeze-of-rule); the sentinel-drop-only leg stays green (documented, not a defect — it was never meant to carry this claim).
- Removing the service-side filter (`pushDecider`'s `startsWith('system:')` check) alone, or the resolver's check alone: BOTH G-11 legs stay green in either case — masked by the other filter (redundant by design, defense-in-depth; the resolver's own comment documents this).
- Removing **both** filters simultaneously: BOTH G-11 legs RED (`system:auto-approval` becomes a real, unclaimable assignee row) — all other tests in the file stay green.
- Net: the resolver's own unit test independently proves the resolver-side filter is load-bearing (hand-constructed map bypassing the service layer); the human-survivor leg independently proves (a) the service-side filter is load-bearing when both mechanisms are gone, and (b) `loadPriorNodeApproverDeciders` is genuinely invoked on the dispatch path, not just assumed to be. Neither filter alone is provably necessary at THIS call site — that is a correct description of a defense-in-depth design, not a residual gap.

**Re-verified after each commit**, current head: backend `tsc --noEmit` clean, `vue-tsc -b` clean, 3 relevant backend unit suites 99/99 (unchanged), full backend unit suite 9432 passed / 0 failed (run from a non-nested checkout — this worktree's own path independently triggers an unrelated `REPO_ROOT_AMBIGUOUS` resolver guard, environmental, not this diff), K3 real-DB suite **12/12 passing**, confirmed both locally and live on the `approval-realdb-k3` CI job for this PR, full `apps/web/scripts/run-required-web-tests.sh` on Node 20: 4620/4620 passed, `plugin-tests.yml` byte-identical, zero control bytes in changed files, no closing keywords bound to issue numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


