### PR TITLE
feat(approval): P6-explanation — explanation (说明) display-only field type (Lock-8 L8-A)

### DIFF
--- a/.github/workflows/approval-web-guard.yml
+++ b/.github/workflows/approval-web-guard.yml
@@ -272,6 +272,12 @@ on:
       - 'apps/web/tests/approval-date-range-field.test.ts'
       - 'apps/web/tests/approval-date-range-visibility.test.ts'
       - 'apps/web/tests/approval-date-range-inline-editor.spec.ts'
+      # L8-A (2026-08-17, approval-lock8-field-vocabulary-20260817.md §1.1): explanation (说明).
+      # No new src file (every touched src file already has a path entry above); three new spec
+      # files.
+      - 'apps/web/tests/approval-explanation-field.test.ts'
+      - 'apps/web/tests/approval-explanation-inline-editor.spec.ts'
+      - 'apps/web/tests/approval-lock8-field-type-census.test.ts'
       - '.github/workflows/approval-web-guard.yml'
   push:
     branches: [main]
@@ -512,6 +518,11 @@ on:
       - 'apps/web/tests/approval-date-range-field.test.ts'
       - 'apps/web/tests/approval-date-range-visibility.test.ts'
       - 'apps/web/tests/approval-date-range-inline-editor.spec.ts'
+      # L8-A (2026-08-17, approval-lock8-field-vocabulary-20260817.md §1.1): explanation (same set
+      # as the pull_request block above).
+      - 'apps/web/tests/approval-explanation-field.test.ts'
+      - 'apps/web/tests/approval-explanation-inline-editor.spec.ts'
+      - 'apps/web/tests/approval-lock8-field-type-census.test.ts'
       - '.github/workflows/approval-web-guard.yml'
 
 jobs:
@@ -579,6 +590,9 @@ jobs:
             approval-date-range-field \
             approval-date-range-visibility \
             approval-date-range-inline-editor \
+            approval-explanation-field \
+            approval-explanation-inline-editor \
+            approval-lock8-field-type-census \
             --reporter=dot
 
       - name: Run FWB mapping authoring contract

--- a/apps/web/scripts/run-required-web-tests.sh
+++ b/apps/web/scripts/run-required-web-tests.sh
@@ -208,6 +208,21 @@
 # three bare basename tokens; verified no existing token (checked the full `approval-date*` /
 # `*date-range*` namespace) is a substring of any of them or vice versa — the namespace was
 # entirely empty before this slice.
+#
+# L8-A (2026-08-17, docs/development/approval-lock8-field-vocabulary-20260817.md §1.1): explanation
+# (说明) — three new tokens. `approval-explanation-field` (draft carrier/buildFormSchema A-1
+# valuelessness stripping/hydration/registration-completeness/MS-9 predicate+retype-clearing/FE
+# resolveVisibilityFieldReference/prefill exclusion/buildDisplayFields visibility-gated render/
+# summaryFields exclusion/condition-branch exclusion pure-fn specs), `approval-explanation-inline-
+# editor` (ApprovalFormInlineEditor.vue mounted spec: retype option, props.text property block, M7
+# wired-not-inert control, 必填/占位文本 HIDDEN-for-explanation, type-selected non-rendering
+# negative), `approval-lock8-field-type-census` (§2.1 N-1: the MS-5/MS-9 mechanical census —
+# exhaustive per-type loops over `AUTHORABLE_FIELD_TYPES` with a completeness meta-check; the
+# backend half lives in packages/core-backend/tests/unit/approval-lock8-field-type-census.test.ts).
+# All three bare basename tokens; verified no existing token (checked the full `approval-explan*` /
+# `*explanation*` / `*lock8*` / `*census*` namespace) is a substring of any of them or vice versa —
+# the namespace was entirely empty before this slice (one pre-existing `lock8` hit is a doc-comment
+# citation, not a test token).
 set -euo pipefail
 cd "$(dirname "$0")/.."
 # Always-on Canvas V2 + residual PLAN 6fa2fbf6 / wave-3 canaries (files landed on main via #4815–#4826).
@@ -233,6 +248,9 @@ npx vitest run \
   approval-date-range-field \
   approval-date-range-visibility \
   approval-date-range-inline-editor \
+  approval-explanation-field \
+  approval-explanation-inline-editor \
+  approval-lock8-field-type-census \
   --reporter=dot
 npx vitest run featureFlagsApprovalAttachments --reporter=dot
 npx vitest run approval-fwb-mapping-config approval-fwb-mapping-editor --reporter=dot

--- a/apps/web/src/approvals/approvalFormCommands.ts
+++ b/apps/web/src/approvals/approvalFormCommands.ts
@@ -151,6 +151,7 @@ const FIELD_LABELS: Record<AuthorableFieldType, string> = {
   detail: '明细',
   'record-link': '关联记录',
   date_range: '日期区间',
+  explanation: '说明',
 }
 
 const AUTHORABLE_FIELD_TYPES = new Set<AuthorableFieldType>(
@@ -328,6 +329,11 @@ export function addFormField(
     dateRangeStartLabel: '',
     dateRangeEndLabel: '',
     dateRangeDurationLabel: '',
+    // L8-A: same neutral-defaults discipline as the L8-B/L8-C keys above — no authoring affordance
+    // for `explanationText` exists here; a freshly-added explanation field simply carries an empty
+    // body (matching §1.1's no-absent-default: it stays publish-rejected until the OTHER, live
+    // authoring surface — ApprovalFormInlineEditor — writes one).
+    explanationText: '',
   }
 
   const fields = [...draft.fields]

--- a/apps/web/src/approvals/components/ApprovalFormBuilder.vue
+++ b/apps/web/src/approvals/components/ApprovalFormBuilder.vue
@@ -309,6 +309,13 @@ const selectedFieldReferences = computed(() =>
  * Visibility depends-on candidates: other fields with an id, excluding
  * `record-link`/`detail` (server fail-closed as visibility dependencies).
  * Option TEXT is the business label only — ids ride the non-visible value.
+ *
+ * Lock-8 L8-A (approval-lock8-field-vocabulary-20260817.md §1.1, MS-9): `explanation` joins the
+ * exclusion — it carries no value at all, so offering it here would be an M7 inert control
+ * (always selectable, never publishable; the server rejects it unconditionally regardless of
+ * which authoring surface produced the reference). NOTE: `date_range` is NOT excluded here — this
+ * F2 track's own predicate predates it and stayed unaddressed by L8-B, out of this slice's scope;
+ * not re-fixed here to avoid an unrelated-scope edit riding along.
  */
 const visibilityOptions = computed(() => {
   const current = selectedField.value
@@ -319,7 +326,8 @@ const visibilityOptions = computed(() => {
         field.localId !== current.localId &&
         field.id.trim().length > 0 &&
         field.type !== 'record-link' &&
-        field.type !== 'detail',
+        field.type !== 'detail' &&
+        field.type !== 'explanation',
     )
     .map((field) => ({
       id: field.id.trim(),

--- a/apps/web/src/approvals/components/ApprovalFormInlineEditor.vue
+++ b/apps/web/src/approvals/components/ApprovalFormInlineEditor.vue
@@ -128,12 +128,16 @@
               <el-option label="明细（子表单）" value="detail" />
               <el-option label="关联记录" value="record-link" />
               <el-option label="日期区间" value="date_range" />
+              <el-option label="说明" value="explanation" />
             </el-select>
           </el-form-item>
-          <el-form-item label="占位文本">
+          <!-- Lock-8 L8-A (approval-lock8-field-vocabulary-20260817.md §1.1, A-1): explanation is
+               DISPLAY-ONLY — no submitted value, so 占位文本/是否必填 are hidden rather than left as
+               inert controls that would always fail publish (M7). -->
+          <el-form-item v-if="field.type !== 'explanation'" label="占位文本">
             <el-input v-model="field.placeholder" :disabled="readOnly" />
           </el-form-item>
-          <el-form-item label="是否必填">
+          <el-form-item v-if="field.type !== 'explanation'" label="是否必填">
             <el-checkbox v-model="field.required" :disabled="readOnly">必填</el-checkbox>
           </el-form-item>
           <el-form-item
@@ -324,6 +328,29 @@
             </div>
             <div class="template-authoring__hint">
               时长由起始、结束自动计算并展示，不可编辑；提交时以系统计算结果为准。
+            </div>
+          </el-form-item>
+          <!-- Lock-8 L8-A (approval-lock8-field-vocabulary-20260817.md §1.1, OD-L8-2/OD-L8-3):
+               explanation (说明) — display-only, renders `props.text` to the requester/approver.
+               No 必填/占位文本/选项 (A-1: a valueless field has nothing to require, prompt, or
+               choose among). This control writes to a real FieldAuthoringDraft key
+               `buildFormSchema` emits (M7: no inert/disabled-theater controls). -->
+          <el-form-item
+            v-if="field.type === 'explanation'"
+            label="说明内容"
+            class="template-authoring__wide"
+            data-testid="approval-explanation-config"
+          >
+            <el-input
+              v-model="field.explanationText"
+              :disabled="readOnly"
+              type="textarea"
+              :rows="3"
+              placeholder="向提交人 / 审批人展示的说明文本"
+              data-testid="approval-explanation-text"
+            />
+            <div class="template-authoring__hint">
+              说明为纯展示控件，不收集任何提交值，不可设置必填、占位文本或选项。
             </div>
           </el-form-item>
           <!-- detail / sub-form (明细) config: sub-field list editor + minRows/maxRows. Each

--- a/apps/web/src/approvals/components/ApprovalFormPalette.vue
+++ b/apps/web/src/approvals/components/ApprovalFormPalette.vue
@@ -81,6 +81,8 @@ export const APPROVAL_FORM_FIELD_TYPE_LABELS: Record<
   'record-link': '关联记录',
   // Lock-8 L8-B (approval-lock8-field-vocabulary-20260817.md §1.2).
   date_range: '日期区间',
+  // Lock-8 L8-A (approval-lock8-field-vocabulary-20260817.md §1.1).
+  explanation: '说明',
 }
 
 export const APPROVAL_FORM_FIELD_TYPE_MARKS: Record<AuthorableFieldType, string> = {
@@ -95,14 +97,18 @@ export const APPROVAL_FORM_FIELD_TYPE_MARKS: Record<AuthorableFieldType, string>
   detail: '表',
   'record-link': '链',
   date_range: '区',
+  explanation: '明',
 }
 
+// Lock-8 L8-A (§2.6): the group needs an owner decision — placed in 其他 as a REVERSIBLE
+// presentation choice (goal-set provenance; see this repo's execution ledger §3 for the one-line
+// note), not a ratified OD-L8-3 group. Moving it later is a data-only change to this array.
 export const APPROVAL_FORM_PALETTE_GROUPS: ApprovalFormPaletteGroup[] = [
   { id: 'text', label: '文本', types: ['text', 'textarea'] },
   { id: 'number', label: '数值', types: ['number'] },
   { id: 'choice', label: '选项', types: ['select', 'multi-select'] },
   { id: 'date', label: '日期', types: ['date', 'datetime', 'date_range'] },
-  { id: 'other', label: '其他', types: ['user', 'detail', 'record-link'] },
+  { id: 'other', label: '其他', types: ['user', 'detail', 'record-link', 'explanation'] },
 ].map(({ id, label, types }) => ({
   id,
   label,

--- a/apps/web/src/approvals/conditionEdit.ts
+++ b/apps/web/src/approvals/conditionEdit.ts
@@ -131,6 +131,10 @@ export function approvalFormulaInsertOptions(formSchema: FormSchema): FormulaIns
     // would silently never match. OD-L8-5 admits date_range endpoints ONLY into field-level
     // visibility (a separate mechanism); it stays excluded from condition branches entirely.
     if (field.type === 'date_range') continue
+    // Lock-8 L8-A (§1.1): explanation carries no value at all — a stricter case than date_range's
+    // non-scalar exclusion (there is nothing to compare, ever). Excluded from condition rules AND
+    // formulas the same way.
+    if (field.type === 'explanation') continue
     if (field.type === 'detail') {
       // Detail only contributes aggregate column tokens, not a bare top-level `{detailId}`.
       for (const column of field.columns ?? []) {
@@ -288,6 +292,12 @@ export function validateConditionEdits(
   const dateRangeFieldIds = new Set(
     formSchema.fields.filter((field) => field.type === 'date_range').map((field) => field.id),
   )
+  // Lock-8 L8-A (§1.1): explanation carries no value at all — excluded from condition
+  // branches/formulas entirely, same mechanism as record-link/date_range above. FE PREVIEW mirror
+  // of the backend `validateNonScalarFieldsNotUsedInConditions` guard.
+  const explanationFieldIds = new Set(
+    formSchema.fields.filter((field) => field.type === 'explanation').map((field) => field.id),
+  )
   // Outgoing edge keys per node key (edges whose `source` is that node) — the legal targets for a
   // branch/default edge of that condition node.
   const outgoingByNode = new Map<string, Set<string>>()
@@ -317,6 +327,12 @@ export function validateConditionEdits(
             errors.push(`${formulaLabel} 不能引用日期区间字段 ${fieldId}（v1）`)
           }
         }
+        for (const fieldId of explanationFieldIds) {
+          const re = new RegExp(`\\{\\s*${fieldId.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\s*\\}`)
+          if (re.test(branch.formulaExpression)) {
+            errors.push(`${formulaLabel} 不能引用说明字段 ${fieldId}（无值）`)
+          }
+        }
         return
       }
       // A rules-mode branch with ZERO rules is never legitimate: the runtime evaluates
@@ -338,6 +354,8 @@ export function validateConditionEdits(
           errors.push(`${ruleLabel} 不能引用关联记录字段（v1）`)
         } else if (dateRangeFieldIds.has(fieldId)) {
           errors.push(`${ruleLabel} 不能引用日期区间字段（v1）`)
+        } else if (explanationFieldIds.has(fieldId)) {
+          errors.push(`${ruleLabel} 不能引用说明字段（无值）`)
         }
         if (!isConditionRuleOperator(rule.operator)) {
           errors.push(`${ruleLabel} 的运算符无效`)

--- a/apps/web/src/approvals/detailField.ts
+++ b/apps/web/src/approvals/detailField.ts
@@ -548,6 +548,15 @@ export function buildDisplayFields(
   const knownFieldIds = new Set(fields.map((field) => field.id))
   const result: DisplayField[] = []
   const pipelineOn = options.attachmentPipelineEnabled === true
+  // Lock-8 L8-A (§1.1, OD-L8-2/OD-L8-3): explanation carries no formSnapshot value at all (A-1),
+  // so "is this field's id a snapshot key" — the test every OTHER arm below uses — is never true
+  // for it and can't gate its render. Its visibility must instead be evaluated directly against
+  // the FROZEN schema + snapshot, mirroring the fill view's own live evaluation: a hidden
+  // explanation must render nothing here either, exactly like a hidden field whose value the
+  // requester never got to see is never in the snapshot for any OTHER type.
+  const visibleFieldIds = formSchema
+    ? new Set(getVisibleFormFields(formSchema, snapshot).map((field) => field.id))
+    : null
 
   for (const field of fields) {
     if (field.type === 'detail') continue
@@ -556,6 +565,12 @@ export function buildDisplayFields(
     // were the reader's data. They resolve through `attachmentRefs.ts` in their own block.
     // Flag OFF (default): keep rendering legacy string/object values inline — no new endpoint.
     if (field.type === 'attachment' && pipelineOn) continue
+    if (field.type === 'explanation') {
+      if (!visibleFieldIds?.has(field.id)) continue
+      const text = typeof field.props?.text === 'string' ? field.props.text : ''
+      result.push({ key: field.id, label: field.label || field.id, value: text })
+      continue
+    }
     if (!Object.prototype.hasOwnProperty.call(snapshot, field.id)) continue
     result.push({
       key: field.id,
@@ -592,9 +607,11 @@ export function summaryFields(
   const fields = formSchema?.fields
   if (!Array.isArray(fields) || fields.length === 0) return []
 
+  // Lock-8 L8-A: explanation is authoring copy, not "data the requester filled in" — excluded from
+  // the compact glance line the same way attachment/detail are (each for its own reason).
   const eligibleFieldIds = new Set(
     fields
-      .filter((field) => field.type !== 'attachment' && field.type !== 'detail')
+      .filter((field) => field.type !== 'attachment' && field.type !== 'detail' && field.type !== 'explanation')
       .map((field) => field.id),
   )
   if (eligibleFieldIds.size === 0) return []

--- a/apps/web/src/approvals/fieldVisibility.ts
+++ b/apps/web/src/approvals/fieldVisibility.ts
@@ -31,7 +31,9 @@ export function resolveVisibilityFieldReference(
   const fieldMap = new Map(fields.map((field) => [field.id, field]))
   const direct = fieldMap.get(rawFieldId)
   if (direct) {
-    return direct.type === 'date_range' ? null : { field: direct }
+    // Lock-8 L8-A (§1.1, MS-8/MS-9): `explanation` carries no value at all — refused as a bare
+    // reference the same way date_range's WHOLE value is, with no endpoint fallback (it has none).
+    return direct.type === 'date_range' || direct.type === 'explanation' ? null : { field: direct }
   }
   const dot = rawFieldId.lastIndexOf('.')
   if (dot <= 0 || dot === rawFieldId.length - 1) return null

--- a/apps/web/src/approvals/prefillFromSnapshot.ts
+++ b/apps/web/src/approvals/prefillFromSnapshot.ts
@@ -68,6 +68,11 @@ function isCompatibleValue(type: FormFieldType, value: unknown): boolean {
       // picker of the wrong kind). Safe by construction: the field just keeps its normal blank/
       // default-seeded value, same as any other never-prefilled type.
       return false
+    case 'explanation':
+      // Lock-8 L8-A: explanation carries no submitted value (A-1) — it is never a snapshot key on
+      // a legitimately-published field, so this arm is defensive (an out-of-band/legacy snapshot
+      // carrying a stray key here must not resurrect it as if it were a real answer).
+      return false
     default:
       return false
   }

--- a/apps/web/src/approvals/recordLinkField.ts
+++ b/apps/web/src/approvals/recordLinkField.ts
@@ -85,9 +85,13 @@ export function isRecordLinkType(type: FormFieldType): boolean {
  * non-scalar and "never as one comparable value"; its two endpoints are separately selectable via
  * `dateRangeVisibilityEndpointOptions` below, a per-type ADDITIVE affordance, not a widening of
  * this boolean.
+ *
+ * Lock-8 L8-A (approval-lock8-field-vocabulary-20260817.md §1.1, MS-9) extends the SAME exclusion
+ * to `explanation` — it carries no value at all (a stricter case than "non-scalar": there is
+ * nothing to compare, ever), and unlike date_range it gets no endpoint fallback (it has none).
  */
 export function isSelectableConditionOrVisibilityDependencyType(type: FormFieldType | string): boolean {
-  return type !== 'record-link' && type !== 'detail' && type !== 'date_range'
+  return type !== 'record-link' && type !== 'detail' && type !== 'date_range' && type !== 'explanation'
 }
 
 /**
@@ -130,7 +134,10 @@ export function visibilityReferenceBaseFieldId(rawFieldId: string): string {
  * Pure helper for authoring + unit tests. Lock-8 L8-B: `date_range` joins record-link/detail as a
  * type whose retype-away must clear stale dependents — including a dotted endpoint address
  * (`${id}.start`/`${id}.end`), which `visibilityReferenceBaseFieldId` resolves to the same base id
- * a bare reference would use, so neither form survives orphaned.
+ * a bare reference would use, so neither form survives orphaned. Lock-8 L8-A: `explanation` joins
+ * too, matching record-link/detail's ONE-direction shape (nothing could ever validly have
+ * depended on it, so only "became explanation" needs clearing — there is no endpoint fallback to
+ * distinguish, unlike date_range).
  */
 export function clearStaleRecordLinkDependencies<T extends {
   id: string
@@ -142,7 +149,12 @@ export function clearStaleRecordLinkDependencies<T extends {
   changedFieldId: string,
   changedType: string,
 ): { fields: T[]; conditionRules: Array<{ fieldId: string }> } {
-  if (changedType !== 'record-link' && changedType !== 'detail' && changedType !== 'date_range') {
+  if (
+    changedType !== 'record-link' &&
+    changedType !== 'detail' &&
+    changedType !== 'date_range' &&
+    changedType !== 'explanation'
+  ) {
     return { fields, conditionRules }
   }
   const id = changedFieldId.trim()

--- a/apps/web/src/approvals/templateAuthoring.ts
+++ b/apps/web/src/approvals/templateAuthoring.ts
@@ -92,6 +92,10 @@ export const AUTHORABLE_FIELD_TYPES: AuthorableFieldType[] = [
   'record-link',
   // Lock-8 L8-B (approval-lock8-field-vocabulary-20260817.md §1.2): start+end date pair.
   'date_range',
+  // Lock-8 L8-A (approval-lock8-field-vocabulary-20260817.md §1.1): display-only 说明. Top-level
+  // only — excluded from `DETAIL_LEAF_FIELD_TYPES` (detailField.ts), never a whole-value
+  // visibility/condition dependency (MS-8/MS-9/MS-10).
+  'explanation',
 ]
 
 /**
@@ -151,6 +155,13 @@ export interface FieldAuthoringDraft {
   dateRangeStartLabel: string
   dateRangeEndLabel: string
   dateRangeDurationLabel: string
+  /**
+   * Lock-8 L8-A (approval-lock8-field-vocabulary-20260817.md §1.1, OD-L8-3(a)): the authored body
+   * (`props.text`) shown to the requester/approver. Meaningful only when `type === 'explanation'`.
+   * `''` is the "not yet written" draft state — publish rejects a blank/missing `props.text`, never
+   * silently defaults it.
+   */
+  explanationText: string
   original?: FormField
 }
 
@@ -306,6 +317,7 @@ export function createEmptyFieldDraft(index = 1): FieldAuthoringDraft {
     dateRangeStartLabel: '',
     dateRangeEndLabel: '',
     dateRangeDurationLabel: '',
+    explanationText: '',
   }
 }
 
@@ -521,6 +533,11 @@ function fieldDraftFromField(field: FormField): FieldAuthoringDraft | null {
     dateRangeStartLabel: field.type === 'date_range' && typeof props.startLabel === 'string' ? props.startLabel : '',
     dateRangeEndLabel: field.type === 'date_range' && typeof props.endLabel === 'string' ? props.endLabel : '',
     dateRangeDurationLabel: field.type === 'date_range' && typeof props.durationLabel === 'string' ? props.durationLabel : '',
+    // L8-A: typeof-guarded, same discipline as the L8-B/L8-C keys above — a malformed stored value
+    // hydrates to the "unset" draft state rather than throwing or coercing. The backend requires a
+    // non-blank `props.text` at publish, so a freshly-saved template can never reach this hydration
+    // path with a malformed value; this stays defensive for out-of-band data.
+    explanationText: field.type === 'explanation' && typeof props.text === 'string' ? props.text : '',
     original: field,
   }
 }
@@ -1092,6 +1109,18 @@ export function buildFormSchema(draft: TemplateAuthoringDraft): FormSchema {
       if (!field.placeholder.trim()) {
         delete next.placeholder
       }
+      // Lock-8 L8-A (§1.1, OD-L8-2, A-1): explanation is DISPLAY-ONLY — force `required: false` and
+      // strip `placeholder`/`defaultValue` regardless of what the draft or `original` spread carries.
+      // `required`/`placeholder` are set UNCONDITIONALLY above from the draft (an author who toggled
+      // 必填 before retyping AWAY... into explanation would otherwise still emit `required: true`);
+      // `defaultValue` is never deleted anywhere else in this function — it only ever survives via
+      // the `original` spread (a field retyped FROM a type that had one). None of the three may leak
+      // through a retype. `options` is already handled by the non-select/multi-select delete below.
+      if (field.type === 'explanation') {
+        next.required = false
+        delete next.placeholder
+        delete next.defaultValue
+      }
       if (field.type === 'select' || field.type === 'multi-select') {
         next.options = parseOptionsText(field.optionsText)
       } else {
@@ -1160,10 +1189,17 @@ export function buildFormSchema(draft: TemplateAuthoringDraft): FormSchema {
         const durationLabel = field.dateRangeDurationLabel.trim()
         if (durationLabel) props.durationLabel = durationLabel
         next.props = props
+      } else if (field.type === 'explanation') {
+        // L8-A (§1.1, OD-L8-3(a)): a BRAND NEW type — same discipline as date_range, props built
+        // fresh (never spreading `next.props`/`original`). `text` has no absent-default: an
+        // unwritten draft emits an empty string, and publish's non-blank check rejects it rather
+        // than the client silently picking a placeholder body.
+        next.props = { text: field.explanationText.trim() }
       } else if (next.props && typeof next.props === 'object') {
-        // Drop record-link pins + L8-C display keys + L8-B date_range keys when type changes away;
-        // keep other type-specific props only if still meaningful (do not leave baseId/sheetId, a
-        // formatted-number display flag, or a date_range prop on a text field).
+        // Drop record-link pins + L8-C display keys + L8-B date_range keys + L8-A explanation
+        // text when type changes away; keep other type-specific props only if still meaningful (do
+        // not leave baseId/sheetId, a formatted-number display flag, a date_range prop, or a stale
+        // explanation body on a field retyped to something else).
         const props = { ...next.props } as Record<string, unknown>
         delete props.baseId
         delete props.sheetId
@@ -1174,6 +1210,7 @@ export function buildFormSchema(draft: TemplateAuthoringDraft): FormSchema {
         delete props.startLabel
         delete props.endLabel
         delete props.durationLabel
+        delete props.text
         if (Object.keys(props).length === 0) delete next.props
         else next.props = props
       }

--- a/apps/web/src/multitable/fwbRuleAuthoring.ts
+++ b/apps/web/src/multitable/fwbRuleAuthoring.ts
@@ -238,11 +238,17 @@ export function sheetFieldsToFwbTargets(
 }
 
 export function templateSchemaToFwbFields(
-  formSchema: { fields?: ReadonlyArray<{ id?: unknown; label?: unknown }> } | null | undefined,
+  formSchema: { fields?: ReadonlyArray<{ id?: unknown; label?: unknown; type?: unknown }> } | null | undefined,
 ): TemplateFieldInfo[] {
   const fields = Array.isArray(formSchema?.fields) ? formSchema!.fields! : []
   return fields
     .map((field) => {
+      // Lock-8 L8-A (approval-lock8-field-vocabulary-20260817.md §1.1): explanation carries no
+      // submitted value (A-1) — it can never be a legitimate FWB mapping source. This is the ONE
+      // FE site that lists candidate source fields for the mapping picker (fwbMappingConfig.ts's
+      // `validateFwbMappingConfig` only checks source-id EXISTENCE, not type — see Lock-8 §0's
+      // "Unverified at this baseline" note), so the exclusion belongs here.
+      if (field?.type === 'explanation') return null
       const id = typeof field?.id === 'string' ? field.id : ''
       const label = typeof field?.label === 'string' && field.label.trim() ? field.label : id
       return id ? { id, label } : null

--- a/apps/web/src/types/approval.ts
+++ b/apps/web/src/types/approval.ts
@@ -77,6 +77,16 @@ export type FormFieldType =
    * endpoints are.
    */
   | 'date_range'
+  /**
+   * Lock-8 L8-A (approval-lock8-field-vocabulary-20260817.md §1.1, OD-L8-2/OD-L8-3): a
+   * DISPLAY-ONLY field (说明) — renders authored `props.text` to the requester/approver. No
+   * submitted value: `required`/`defaultValue`/`options`/`placeholder` are all refused at
+   * publish (A-1), the field never enters `formSnapshot` or FWB source candidates, is excluded
+   * from detail columns (MS-4/MS-5), and is never a whole-value visibility/condition dependency
+   * (MS-8/MS-9/MS-10) — it has no value to compare. `label` stays authoring-list-only (BE
+   * requires a non-blank label for every field, `:786`); the rendered body is `props.text`.
+   */
+  | 'explanation'
 
 export interface ApprovalNode {
   key: string

--- a/apps/web/src/views/approval/ApprovalNewView.vue
+++ b/apps/web/src/views/approval/ApprovalNewView.vue
@@ -531,6 +531,21 @@
               附件上传功能即将支持，请先在其他字段中注明附件信息。
             </div>
 
+            <!-- Lock-8 L8-A (approval-lock8-field-vocabulary-20260817.md §1.1, OD-L8-2/OD-L8-3)
+                 explanation: display-only. Renders the authored `props.text` body to the
+                 requester. No v-model: an explanation collects nothing (A-1), so there is no
+                 formData key to bind — WITHOUT this arm, an explanation field would fall through
+                 to the plain-text-input fallback below and silently collect a value it must never
+                 carry. white-space:pre-wrap preserves authored line breaks without interpreting
+                 markup (plain text, never raw HTML). -->
+            <div
+              v-else-if="field.type === 'explanation'"
+              class="approval-new__explanation"
+              data-testid="approval-explanation-field"
+            >
+              {{ (field.props?.text as string) || '' }}
+            </div>
+
             <!-- fallback -->
             <el-input
               v-else
@@ -1620,6 +1635,19 @@ watch([visibleFieldIds, template], () => {
 
 .approval-new__date-range-duration-label::after {
   content: '：';
+}
+
+.approval-new__explanation {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 10px 12px;
+  border-radius: 6px;
+  background: var(--ms-bg-subtle, var(--el-fill-color-light));
+  color: var(--ms-text-2, var(--el-text-color-regular));
+  font-size: 13px;
+  line-height: 1.6;
+  white-space: pre-wrap;
+  word-break: break-word;
 }
 
 .approval-new__form {

--- a/apps/web/src/views/approval/TemplateAuthoringView.vue
+++ b/apps/web/src/views/approval/TemplateAuthoringView.vue
@@ -2974,8 +2974,13 @@ function swap<T>(items: T[], index: number, delta: -1 | 1) {
 // source-scans every file under src/views for that literal component name and fails the build if
 // it appears, even as an import of its exported constants. This stays a SECOND, non-derived
 // registration site the F2 forcing-function test (approval-form-palette-chips.spec.ts:107) does
-// not cover; approval-date-range-field.test.ts census-checks this file's set is consistent with
-// AUTHORABLE_FIELD_TYPES instead.
+// NOT cover — and neither did approval-date-range-field.test.ts's own "census" (correction, gate
+// P2-1: an earlier version of this comment claimed that file checked THIS array; it only ever
+// re-read the F2 component's own APPROVAL_FORM_PALETTE_GROUPS, never `fieldPaletteGroups` below —
+// deleting `explanation` from this array alone left every then-reachable spec green). This array's
+// completeness against AUTHORABLE_FIELD_TYPES is covered by a REAL mount of this view (not a
+// duplicated literal): apps/web/tests/approval-form-inline-editor-extract.spec.ts's "(o) MS-13
+// completeness" test queries the rendered `approval-field-palette-*` chip DOM directly.
 const FIELD_PALETTE_LABELS: Record<AuthorableFieldType, string> = {
   text: '文本',
   textarea: '多行文本',

--- a/apps/web/src/views/approval/TemplateAuthoringView.vue
+++ b/apps/web/src/views/approval/TemplateAuthoringView.vue
@@ -1747,6 +1747,9 @@ function conditionEditFor(nodeKey: string): ConditionNodeEdit | undefined {
 // visibilityFieldOptions below) — its `{start,end}` value has no per-type predicate for MS-9 in
 // this slice, and `validateConditionEdits` (conditionEdit.ts) rejects any rule that references one.
 // Offering it here would be an M7 inert control: always selectable, never publishable.
+// Lock-8 L8-A (§1.1): explanation carries no value at all — excluded the same way, an M7 inert
+// control would otherwise always fail publish (`validateConditionEdits` rejects any rule
+// referencing one).
 const conditionFieldOptions = computed(() =>
   draft.value.fields
     .filter((field) => (
@@ -1754,6 +1757,7 @@ const conditionFieldOptions = computed(() =>
       && field.type !== 'record-link'
       && field.type !== 'detail'
       && field.type !== 'date_range'
+      && field.type !== 'explanation'
     ))
     .map((field) => ({ id: field.id.trim(), label: fieldDisplayLabel(field) })),
 )
@@ -2984,6 +2988,7 @@ const FIELD_PALETTE_LABELS: Record<AuthorableFieldType, string> = {
   detail: '明细',
   'record-link': '关联记录',
   date_range: '日期区间',
+  explanation: '说明',
 }
 const FIELD_PALETTE_MARKS: Record<AuthorableFieldType, string> = {
   text: 'A',
@@ -2997,13 +3002,19 @@ const FIELD_PALETTE_MARKS: Record<AuthorableFieldType, string> = {
   detail: '表',
   'record-link': '链',
   date_range: '区',
+  explanation: '明',
 }
+// Lock-8 L8-A (§2.6): the group needs an owner decision — placed in 其他 as a REVERSIBLE
+// presentation choice (goal-set provenance; see this repo's execution ledger §3), not a ratified
+// OD-L8-3 group. Same choice as the F2 Designer 2.0 palette component's independent copy
+// (apps/web/src/approvals/components/ApprovalForm + Palette.vue, split across this comment on
+// purpose — see that file's own doc comment for why the literal name can't appear here whole).
 const fieldPaletteGroups = [
   { id: 'text', label: '文本', types: ['text', 'textarea'] },
   { id: 'number', label: '数值', types: ['number'] },
   { id: 'choice', label: '选项', types: ['select', 'multi-select'] },
   { id: 'date', label: '日期', types: ['date', 'datetime', 'date_range'] },
-  { id: 'other', label: '其他', types: ['user', 'detail', 'record-link'] },
+  { id: 'other', label: '其他', types: ['user', 'detail', 'record-link', 'explanation'] },
 ].map((group) => ({
   ...group,
   entries: group.types.map((type) => ({
@@ -3136,6 +3147,9 @@ function visibilityFieldOptions(current: FieldAuthoringDraft) {
     if (field.localId === current.localId) continue
     if (!field.id.trim()) continue
     if (field.type === 'record-link' || field.type === 'detail') continue
+    // Lock-8 L8-A (§1.1): explanation carries no value at all — never offered, bare or dotted (it
+    // has no endpoints, unlike date_range).
+    if (field.type === 'explanation') continue
     if (field.type === 'date_range') {
       const fieldId = field.id.trim()
       const label = fieldDisplayLabel(field)
@@ -3170,7 +3184,12 @@ function invalidateStaleRecordLinkDependencies(changedField: FieldAuthoringDraft
   const changedId = changedField.id.trim()
   if (!changedId) return
   const bareBanned =
-    changedField.type === 'record-link' || changedField.type === 'detail' || changedField.type === 'date_range'
+    changedField.type === 'record-link'
+    || changedField.type === 'detail'
+    || changedField.type === 'date_range'
+    // Lock-8 L8-A (§1.1): explanation matches record-link/detail's ONE-direction shape — nothing
+    // could ever validly have depended on it, so only "became explanation" needs clearing.
+    || changedField.type === 'explanation'
   const stillDateRange = changedField.type === 'date_range'
   for (const field of draft.value.fields) {
     const dependsOn = field.visibility.dependsOnFieldId.trim()

--- a/apps/web/src/views/approval/TemplateDetailView.vue
+++ b/apps/web/src/views/approval/TemplateDetailView.vue
@@ -970,6 +970,7 @@ function fieldTypeLabel(type: FormFieldType) {
     detail: '明细',
     'record-link': '关联记录',
     date_range: '日期区间',
+    explanation: '说明',
   }
   return map[type] ?? type
 }

--- a/apps/web/tests/approval-explanation-field.test.ts
+++ b/apps/web/tests/approval-explanation-field.test.ts
@@ -1,0 +1,373 @@
+import { describe, expect, it } from 'vitest'
+import {
+  AUTHORABLE_FIELD_TYPES,
+  DETAIL_LEAF_FIELD_TYPES,
+  buildFormSchema,
+  createEmptyFieldDraft,
+  createEmptyTemplateDraft,
+  draftFromTemplate,
+  type TemplateAuthoringDraft,
+} from '../src/approvals/templateAuthoring'
+import { addFormField, updateFormFieldProperties } from '../src/approvals/approvalFormCommands'
+import {
+  buildDisplayFields,
+  summaryFields,
+} from '../src/approvals/detailField'
+import { prefillFromSnapshot } from '../src/approvals/prefillFromSnapshot'
+import {
+  isSelectableConditionOrVisibilityDependencyType,
+  clearStaleRecordLinkDependencies,
+} from '../src/approvals/recordLinkField'
+import { resolveVisibilityFieldReference } from '../src/approvals/fieldVisibility'
+import {
+  approvalFormulaInsertOptions,
+  validateConditionEdits,
+  type ConditionEdits,
+} from '../src/approvals/conditionEdit'
+import type { ApprovalTemplateDetailDTO, FormField, FormSchema } from '../src/types/approval'
+import {
+  APPROVAL_FORM_FIELD_TYPE_LABELS,
+  APPROVAL_FORM_PALETTE_GROUPS,
+} from '../src/approvals/components/ApprovalFormPalette.vue'
+
+// Lock-8 L8-A (docs/development/approval-lock8-field-vocabulary-20260817.md §1.1) — explanation
+// (说明) FE registration completeness + A-1 valuelessness + display/prefill/condition/visibility
+// exclusions.
+//
+// Registration completeness (N-1 style, family-scoped — the FULL MS-1..MS-13 mechanical census is
+// L8-A's OWN deliverable per §2.1, covered by approval-lock8-field-type-census.test.ts on the
+// backend and this file's own MS-5/MS-9 loops below on the frontend): AUTHORABLE_FIELD_TYPES, the
+// palette groups (cross-checking the existing forcing-function test at
+// approval-form-palette-chips.spec.ts:107), FIELD_LABELS-derived authorable set (via addFormField),
+// buildFormSchema's props arm, and draftFromTemplate hydration all agree explanation is admitted;
+// DETAIL_LEAF_FIELD_TYPES agrees it is EXCLUDED (MS-4/MS-5).
+
+function buildTemplate(overrides: Partial<ApprovalTemplateDetailDTO> = {}): ApprovalTemplateDetailDTO {
+  return {
+    id: 'tpl_1',
+    key: 'expense',
+    name: '费用审批',
+    description: null,
+    category: null,
+    visibilityScope: { type: 'all', ids: [] },
+    slaHours: null,
+    status: 'draft',
+    activeVersionId: null,
+    latestVersionId: 'ver_1',
+    createdAt: '2026-08-17T00:00:00Z',
+    updatedAt: '2026-08-17T00:00:00Z',
+    formSchema: { fields: [] },
+    approvalGraph: {
+      nodes: [
+        { key: 'start', type: 'start', name: '发起', config: {} },
+        { key: 'approval_1', type: 'approval', name: '审批人 1', config: { assigneeSources: [{ kind: 'requester' }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+        { key: 'end', type: 'end', name: '结束', config: {} },
+      ],
+      edges: [
+        { key: 'edge-start-approval_1', source: 'start', target: 'approval_1' },
+        { key: 'edge-approval_1-end', source: 'approval_1', target: 'end' },
+      ],
+    },
+    ...overrides,
+  }
+}
+
+describe('Lock-8 L8-A registration completeness (FE)', () => {
+  it('explanation IS in AUTHORABLE_FIELD_TYPES', () => {
+    expect(AUTHORABLE_FIELD_TYPES).toContain('explanation')
+  })
+
+  it('explanation IS in the 其他 palette group, and the census is exact (mirrors :107 forcing function)', () => {
+    const groupedTypes = APPROVAL_FORM_PALETTE_GROUPS.flatMap((group) => group.entries.map((entry) => entry.type))
+    expect([...groupedTypes].sort()).toEqual([...AUTHORABLE_FIELD_TYPES].sort())
+    const otherGroup = APPROVAL_FORM_PALETTE_GROUPS.find((group) => group.id === 'other')
+    expect(otherGroup?.entries.map((entry) => entry.type)).toContain('explanation')
+    expect(APPROVAL_FORM_FIELD_TYPE_LABELS.explanation).toBe('说明')
+  })
+
+  it('explanation IS admitted by the approvalFormCommands authorable-type gate (addFormField)', () => {
+    const draft = createEmptyTemplateDraft()
+    const result = addFormField(draft, 'explanation', { persistentId: 'note', localId: 'local_note' })
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      const field = result.draft.fields.find((f) => f.localId === 'local_note')
+      expect(field?.type).toBe('explanation')
+    }
+  })
+
+  it('explanation stays admitted for a property update (not rejected as unsupported_field_type)', () => {
+    const draft = createEmptyTemplateDraft()
+    const added = addFormField(draft, 'explanation', { persistentId: 'note', localId: 'local_note' })
+    if (!added.ok) throw new Error('setup failed')
+    const result = updateFormFieldProperties(added.draft, 'local_note', { label: '提示说明' })
+    expect(result.ok).toBe(true)
+  })
+
+  it('explanation is NOT in DETAIL_LEAF_FIELD_TYPES — MS-4/MS-5 exclusion (correct BY OMISSION)', () => {
+    expect(DETAIL_LEAF_FIELD_TYPES).not.toContain('explanation')
+  })
+})
+
+describe('Lock-8 L8-A draft carrier + buildFormSchema', () => {
+  it('createEmptyFieldDraft seeds a neutral/unset explanationText default', () => {
+    const draft = createEmptyFieldDraft(1)
+    expect(draft.explanationText).toBe('')
+  })
+
+  it('buildFormSchema emits { text } props for an explanation field', () => {
+    const templateDraft: TemplateAuthoringDraft = {
+      ...createEmptyTemplateDraft(),
+      fields: [{
+        ...createEmptyFieldDraft(1),
+        id: 'note', type: 'explanation', label: '说明',
+        explanationText: '  仅供参考，请如实填写  ',
+      }],
+    }
+    const schema = buildFormSchema(templateDraft)
+    expect(schema.fields[0].props).toEqual({ text: '仅供参考，请如实填写' })
+  })
+
+  it('A-1: buildFormSchema FORCES required:false and strips placeholder/defaultValue even when the draft/original carries them', () => {
+    const original: FormField = {
+      id: 'note', type: 'text', label: '说明', required: true, placeholder: '请输入', defaultValue: '默认文字',
+    }
+    const templateDraft: TemplateAuthoringDraft = {
+      ...createEmptyTemplateDraft(),
+      fields: [{
+        ...createEmptyFieldDraft(1),
+        id: 'note', type: 'explanation', label: '说明',
+        // Simulates an author who toggled 必填/占位文本 BEFORE retyping to explanation, or a
+        // retype-away-and-back where `original` still carries a stale defaultValue.
+        required: true, placeholder: '请输入', explanationText: '仅供参考', original,
+      }],
+    }
+    const schema = buildFormSchema(templateDraft)
+    expect(schema.fields[0].required).toBe(false)
+    expect(schema.fields[0].placeholder).toBeUndefined()
+    expect(schema.fields[0].defaultValue).toBeUndefined()
+    expect(schema.fields[0].options).toBeUndefined()
+  })
+
+  it('buildFormSchema strips explanation props.text when the field is retyped away (no stale prop on the new type)', () => {
+    const original: FormField = { id: 'note', type: 'explanation', label: '说明', props: { text: '仅供参考' } }
+    const templateDraft: TemplateAuthoringDraft = {
+      ...createEmptyTemplateDraft(),
+      fields: [{
+        ...createEmptyFieldDraft(1),
+        id: 'note', type: 'text', label: '说明', original,
+      }],
+    }
+    const schema = buildFormSchema(templateDraft)
+    expect(schema.fields[0].props).toBeUndefined()
+  })
+
+  it('draftFromTemplate hydrates explanationText typeof-guarded (a malformed stored value hydrates to "unset", not a throw/coercion)', () => {
+    const template = buildTemplate({
+      formSchema: {
+        fields: [{ id: 'note', type: 'explanation', label: '说明', props: { text: '仅供参考' } }],
+      },
+    })
+    const draft = draftFromTemplate(template)
+    const field = draft.fields.find((f) => f.id === 'note')
+    expect(field?.explanationText).toBe('仅供参考')
+
+    const malformed = buildTemplate({
+      formSchema: {
+        fields: [{ id: 'note', type: 'explanation', label: '说明', props: { text: 42 } }],
+      },
+    })
+    const malformedDraft = draftFromTemplate(malformed)
+    const malformedField = malformedDraft.fields.find((f) => f.id === 'note')
+    expect(malformedField?.explanationText).toBe('')
+  })
+})
+
+describe('Lock-8 L8-A MS-9: FE selectable-dependency predicate + retype dependency clearing', () => {
+  it('isSelectableConditionOrVisibilityDependencyType(explanation) is false', () => {
+    expect(isSelectableConditionOrVisibilityDependencyType('explanation')).toBe(false)
+  })
+
+  it('positive control: every OTHER authorable type stays selectable (the exclusion is type-selected)', () => {
+    for (const type of AUTHORABLE_FIELD_TYPES) {
+      if (type === 'explanation' || type === 'record-link' || type === 'detail' || type === 'date_range') continue
+      expect(isSelectableConditionOrVisibilityDependencyType(type)).toBe(true)
+    }
+  })
+
+  it('retyping a field TO explanation clears a stale visibility dependency pointing at it', () => {
+    const fields = [
+      { id: 'note', type: 'explanation', visibility: { dependsOnFieldId: '', operator: 'eq', valueText: '' } },
+      { id: 'reason', type: 'text', visibility: { dependsOnFieldId: 'note', operator: 'notEmpty', valueText: '' } },
+    ]
+    const result = clearStaleRecordLinkDependencies(fields, [{ fieldId: 'note' }], 'note', 'explanation')
+    expect(result.fields[1].visibility).toEqual({ dependsOnFieldId: '', operator: 'eq', valueText: '' })
+    expect(result.conditionRules[0].fieldId).toBe('')
+  })
+})
+
+describe('Lock-8 L8-A FE resolveVisibilityFieldReference (mirrors the backend gate)', () => {
+  const fields = [
+    { id: 'note', type: 'explanation', label: '说明', props: { text: '仅供参考' } },
+    { id: 'kind', type: 'text', label: '类型' },
+  ] as FormSchema['fields']
+
+  it('refuses a bare reference to an explanation field (null, no endpoint fallback)', () => {
+    expect(resolveVisibilityFieldReference('note', fields)).toBeNull()
+  })
+
+  it('positive control: resolves a bare reference to an ordinary text field', () => {
+    expect(resolveVisibilityFieldReference('kind', fields)).toEqual({ field: fields[1] })
+  })
+})
+
+describe('Lock-8 L8-A prefill exclusion (再次提交)', () => {
+  it('explanation is never prefilled, even if an out-of-band snapshot carries a stray key', () => {
+    const schema: FormSchema = {
+      fields: [
+        { id: 'note', type: 'explanation', label: '说明', props: { text: '仅供参考' } },
+        { id: 'reason', type: 'textarea', label: '事由' },
+      ],
+    }
+    const result = prefillFromSnapshot(schema, { note: 'someone typed here anyway', reason: '出差申请' })
+    expect(result).toEqual({ reason: '出差申请' })
+    expect(Object.prototype.hasOwnProperty.call(result, 'note')).toBe(false)
+  })
+})
+
+describe('Lock-8 L8-A display: buildDisplayFields renders props.text to BOTH the requester (再次提交 review) and the approver (detail view) — the SAME shared function', () => {
+  it('renders the authored text when the explanation field is VISIBLE, sourced from props.text NOT the (empty) snapshot', () => {
+    const schema: FormSchema = {
+      fields: [{ id: 'note', type: 'explanation', label: '说明', props: { text: '仅供参考，请如实填写' } }],
+    }
+    // formSnapshot carries NOTHING for `note` (A-1: it is never a submitted value) — proves the
+    // render is sourced from the FROZEN SCHEMA, not the snapshot.
+    const fields = buildDisplayFields(schema, {})
+    expect(fields).toEqual([{ key: 'note', label: '说明', value: '仅供参考，请如实填写' }])
+  })
+
+  it('renders NOTHING when the explanation field is HIDDEN by its own visibilityRule (visibility is not bypassed)', () => {
+    const schema: FormSchema = {
+      fields: [
+        { id: 'kind', type: 'text', label: '类型' },
+        {
+          id: 'note', type: 'explanation', label: '说明', props: { text: '仅供参考' },
+          visibilityRule: { fieldId: 'kind', operator: 'eq', value: 'special' },
+        },
+      ],
+    }
+    // kind !== 'special' -> note's own visibilityRule evaluates false -> hidden.
+    const hidden = buildDisplayFields(schema, { kind: 'normal' })
+    expect(hidden.find((f) => f.key === 'note')).toBeUndefined()
+    // Positive control: kind === 'special' -> note's rule evaluates true -> visible, still
+    // sourced from props.text (the snapshot never carries a `note` key either way).
+    const visible = buildDisplayFields(schema, { kind: 'special' })
+    expect(visible.find((f) => f.key === 'note')).toEqual({ key: 'note', label: '说明', value: '仅供参考' })
+  })
+
+  it('an explanation field carrying its OWN visibilityRule stays legal — only rules pointing AT it are refused', () => {
+    // This is the same case as above, restated to make the distinction explicit: explanation MAY
+    // be the DEPENDENT side of a visibilityRule (its OWN rule, evaluated against another field's
+    // value); it may never be the fieldId TARGET another field's rule points AT (MS-8/MS-9).
+    const schema: FormSchema = {
+      fields: [
+        { id: 'kind', type: 'text', label: '类型' },
+        {
+          id: 'note', type: 'explanation', label: '说明', props: { text: '仅供参考' },
+          visibilityRule: { fieldId: 'kind', operator: 'notEmpty' },
+        },
+      ],
+    }
+    expect(buildDisplayFields(schema, { kind: 'x' }).find((f) => f.key === 'note')).toBeDefined()
+    expect(buildDisplayFields(schema, {}).find((f) => f.key === 'note')).toBeUndefined()
+  })
+
+  it('never reaches formatDisplayValue\'s String() default even when a snapshot DOES carry a stray key for it', () => {
+    const schema: FormSchema = {
+      fields: [{ id: 'note', type: 'explanation', label: '说明', props: { text: '仅供参考' } }],
+    }
+    // If this arm fell through to the generic String()-based formatter, an object snapshot value
+    // would render as "[object Object]" (M8 dishonesty). It must instead render props.text.
+    const fields = buildDisplayFields(schema, { note: { anything: true } })
+    expect(fields).toEqual([{ key: 'note', label: '说明', value: '仅供参考' }])
+  })
+
+  it('summaryFields (list-row glance line) EXCLUDES explanation — it is authoring copy, not requester-filled data', () => {
+    const schema: FormSchema = {
+      fields: [
+        { id: 'note', type: 'explanation', label: '说明', props: { text: '仅供参考' } },
+        { id: 'reason', type: 'text', label: '事由' },
+      ],
+    }
+    const summary = summaryFields(schema, { reason: '出差申请' })
+    expect(summary.map((f) => f.key)).toEqual(['reason'])
+  })
+})
+
+describe('Lock-8 L8-A condition-branch exclusion (FE preview mirror)', () => {
+  it('approvalFormulaInsertOptions never offers an explanation field as an insertable token', () => {
+    const schema: FormSchema = {
+      fields: [
+        { id: 'note', type: 'explanation', label: '说明', props: { text: '仅供参考' } },
+        { id: 'kind', type: 'text', label: '类型' },
+      ],
+    }
+    const options = approvalFormulaInsertOptions(schema)
+    expect(options.map((o) => o.token)).not.toContain('{note}')
+    expect(options.map((o) => o.token)).toContain('{kind}')
+  })
+
+  it('validateConditionEdits rejects a rule referencing an explanation field, both rule-mode and formula-mode', () => {
+    const schema: FormSchema = {
+      fields: [
+        { id: 'note', type: 'explanation', label: '说明', props: { text: '仅供参考' } },
+        { id: 'kind', type: 'text', label: '类型' },
+      ],
+    }
+    const ruleModeEdits: ConditionEdits = {
+      cond_1: {
+        nodeKey: 'cond_1',
+        branches: [{
+          edgeKey: 'edge-yes', predicateMode: 'rules', conjunction: 'and',
+          rules: [{ fieldId: 'note', operator: 'eq', value: 'x' }],
+          formulaExpression: '',
+        }],
+        defaultEdgeKey: '',
+      },
+    }
+    expect(validateConditionEdits(ruleModeEdits, schema)).toEqual(
+      expect.arrayContaining([expect.stringMatching(/说明字段/)]),
+    )
+
+    const formulaModeEdits: ConditionEdits = {
+      cond_1: {
+        nodeKey: 'cond_1',
+        branches: [{
+          edgeKey: 'edge-yes', predicateMode: 'formula', conjunction: 'and',
+          rules: [], formulaExpression: '{note} == "x"',
+        }],
+        defaultEdgeKey: '',
+      },
+    }
+    expect(validateConditionEdits(formulaModeEdits, schema)).toEqual(
+      expect.arrayContaining([expect.stringMatching(/说明字段/)]),
+    )
+  })
+
+  it('positive control: a rule referencing a text field is NOT flagged by either predicate', () => {
+    const schema: FormSchema = {
+      fields: [{ id: 'kind', type: 'text', label: '类型' }],
+    }
+    const edits: ConditionEdits = {
+      cond_1: {
+        nodeKey: 'cond_1',
+        branches: [{
+          edgeKey: 'edge-yes', predicateMode: 'rules', conjunction: 'and',
+          rules: [{ fieldId: 'kind', operator: 'eq', value: 'x' }],
+          formulaExpression: '',
+        }],
+        defaultEdgeKey: '',
+      },
+    }
+    expect(validateConditionEdits(edits, schema)).toEqual([])
+  })
+})

--- a/apps/web/tests/approval-explanation-inline-editor.spec.ts
+++ b/apps/web/tests/approval-explanation-inline-editor.spec.ts
@@ -1,0 +1,233 @@
+/* eslint-disable vue/one-component-per-file, vue/require-default-prop */
+/**
+ * Lock-8 L8-A (docs/development/approval-lock8-field-vocabulary-20260817.md §1.1, §2.6) —
+ * ApprovalFormInlineEditor.vue is the ONLY property-editor surface (no per-type inspector
+ * component exists, §2.6); a new type silently renders only type-invariant rows unless an arm is
+ * added. This proves the explanation arm DOES render — the type option exists in the retype
+ * `<select>`, a explanation field's property block renders a REAL, WIRED props.text control (M7:
+ * no inert/disabled-theater control), AND the 必填/占位文本 controls every OTHER type gets are
+ * HIDDEN for explanation (A-1: nothing to require or prompt for) — standalone mount, mirroring
+ * `approval-date-range-inline-editor.spec.ts`'s own harness.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createApp, defineComponent, h, nextTick, type App as VueApp } from 'vue'
+import ApprovalFormInlineEditor from '../src/approvals/components/ApprovalFormInlineEditor.vue'
+import { createEmptyFieldDraft, type FieldAuthoringDraft } from '../src/approvals/templateAuthoring'
+
+const ElButton = defineComponent({
+  name: 'ElButton',
+  props: { disabled: Boolean, loading: Boolean, type: String, text: Boolean, link: Boolean, size: String },
+  emits: ['click'],
+  render() {
+    return h('button', {
+      type: 'button',
+      disabled: this.disabled || this.loading,
+      'data-testid': (this.$attrs as any)?.['data-testid'],
+      onClick: (event: Event) => this.$emit('click', event),
+    }, this.$slots.default?.())
+  },
+})
+
+const ElInput = defineComponent({
+  name: 'ElInput',
+  props: { modelValue: [String, Number], disabled: Boolean, type: String, rows: Number, placeholder: String, size: String },
+  emits: ['update:modelValue'],
+  render() {
+    const tag = this.type === 'textarea' ? 'textarea' : 'input'
+    return h(tag, {
+      value: this.modelValue ?? '',
+      disabled: this.disabled,
+      placeholder: this.placeholder,
+      'data-testid': (this.$attrs as any)?.['data-testid'],
+      onInput: (event: Event) => this.$emit('update:modelValue', (event.target as HTMLInputElement).value),
+    })
+  },
+})
+
+const ElSelect = defineComponent({
+  name: 'ElSelect',
+  props: { modelValue: [String, Array], disabled: Boolean },
+  emits: ['update:modelValue', 'change', 'visible-change'],
+  render() {
+    return h('select', {
+      value: this.modelValue ?? '',
+      disabled: this.disabled,
+      'data-testid': (this.$attrs as any)?.['data-testid'],
+      onChange: (event: Event) => {
+        const value = (event.target as HTMLSelectElement).value
+        this.$emit('update:modelValue', value)
+        this.$emit('change', value)
+      },
+    }, this.$slots.default?.())
+  },
+})
+
+const ElOption = defineComponent({
+  name: 'ElOption',
+  props: { label: String, value: String },
+  render() {
+    return h('option', { value: this.value }, this.label)
+  },
+})
+
+const ElCheckbox = defineComponent({
+  name: 'ElCheckbox',
+  inheritAttrs: false,
+  props: { modelValue: Boolean, disabled: Boolean },
+  emits: ['update:modelValue'],
+  render() {
+    return h('label', [
+      h('input', {
+        type: 'checkbox',
+        checked: this.modelValue,
+        disabled: this.disabled,
+        'data-testid': (this.$attrs as any)?.['data-testid'],
+        onChange: (event: Event) => this.$emit('update:modelValue', (event.target as HTMLInputElement).checked),
+      }),
+      this.$slots.default?.(),
+    ])
+  },
+})
+
+const passthrough = (name: string, tag = 'div') => defineComponent({
+  name,
+  render() {
+    return h(tag, { 'data-testid': (this.$attrs as any)?.['data-testid'] }, this.$slots.default?.())
+  },
+})
+
+function installStubs(app: VueApp<Element>) {
+  app.directive('loading', {})
+  app.component('ElButton', ElButton)
+  app.component('ElInput', ElInput)
+  app.component('ElInputNumber', passthrough('ElInputNumber', 'input'))
+  app.component('ElSelect', ElSelect)
+  app.component('ElOption', ElOption)
+  app.component('ElCheckbox', ElCheckbox)
+  app.component('ElAlert', passthrough('ElAlert'))
+  app.component('ElDialog', passthrough('ElDialog'))
+  app.component('ElTable', passthrough('ElTable'))
+  app.component('ElTableColumn', passthrough('ElTableColumn'))
+  app.component('ElCard', passthrough('ElCard'))
+  app.component('ElForm', passthrough('ElForm', 'form'))
+  app.component('ElFormItem', passthrough('ElFormItem', 'section'))
+  app.component('ElIcon', passthrough('ElIcon', 'span'))
+  app.component('ElCollapse', passthrough('ElCollapse'))
+  app.component('ElCollapseItem', passthrough('ElCollapseItem'))
+}
+
+let app: VueApp<Element> | null = null
+let container: HTMLDivElement | null = null
+
+function mount(fields: FieldAuthoringDraft[]) {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  app = createApp({
+    render() {
+      return h(ApprovalFormInlineEditor, {
+        fields,
+        readOnly: false,
+        templateName: 'explanation 独立挂载测试',
+        formFieldFocusLocalId: fields[0]?.localId ?? null,
+        fieldPaletteGroups: [{
+          id: 'other',
+          label: '其他',
+          entries: [{ type: 'explanation', label: '说明', mark: '明' }],
+        }],
+        fieldPaletteLabels: {
+          text: '文本', textarea: '多行文本', number: '数字', date: '日期', datetime: '日期时间',
+          select: '单选', 'multi-select': '多选', user: '人员', detail: '明细', 'record-link': '关联记录',
+          date_range: '日期区间', explanation: '说明',
+        },
+        detailLeafTypeOptions: [],
+        recordLinkCatalogError: '',
+        recordLinkCatalogLoading: false,
+        recordLinkCatalogLoaded: true,
+        recordLinkBaseOptionsFor: () => [],
+        recordLinkSheetOptionsFor: () => [],
+        visibilityFieldOptions: () => [],
+        onAddFieldOfType: vi.fn(),
+        onSelectFieldFocus: vi.fn(),
+        onMoveField: vi.fn(),
+        onRemoveField: vi.fn(),
+        onRetryRecordLinkCatalog: vi.fn(),
+      })
+    },
+  })
+  installStubs(app)
+  app.mount(container)
+  return container
+}
+
+afterEach(() => {
+  app?.unmount()
+  container?.remove()
+  app = null
+  container = null
+})
+
+describe('ApprovalFormInlineEditor explanation arm (Lock-8 L8-A)', () => {
+  it('the retype <select> offers 说明/explanation (M7: reachable from every field, not just fresh adds)', async () => {
+    const field: FieldAuthoringDraft = { ...createEmptyFieldDraft(1), localId: 'f1', id: 'field_1' }
+    const el = mount([field])
+    await nextTick()
+    const typeSelect = el.querySelector('[data-testid="approval-field-type"]') as HTMLSelectElement
+    const options = Array.from(typeSelect.querySelectorAll('option')).map((o) => o.getAttribute('value'))
+    expect(options).toContain('explanation')
+  })
+
+  it('an explanation field renders the props.text config block with a WIRED textarea control', async () => {
+    const field: FieldAuthoringDraft = {
+      ...createEmptyFieldDraft(1),
+      localId: 'f1', id: 'note', type: 'explanation', explanationText: '',
+    }
+    const el = mount([field])
+    await nextTick()
+    expect(el.querySelector('[data-testid="approval-explanation-config"]')).not.toBeNull()
+    const textInput = el.querySelector('[data-testid="approval-explanation-text"]') as HTMLTextAreaElement
+    expect(textInput).not.toBeNull()
+    // M7: WIRED, not inert — typing mutates the SAME reactive draft object the parent owns
+    // (direct-property-edit path, FB-D7 legacy, same discipline as date_range/record-link).
+    textInput.value = '仅供参考，请如实填写'
+    textInput.dispatchEvent(new Event('input'))
+    await nextTick()
+    expect(field.explanationText).toBe('仅供参考，请如实填写')
+  })
+
+  it('A-1: 必填/占位文本 controls are HIDDEN for explanation (nothing to require or prompt for)', async () => {
+    const field: FieldAuthoringDraft = {
+      ...createEmptyFieldDraft(1),
+      localId: 'f1', id: 'note', type: 'explanation', explanationText: '仅供参考',
+    }
+    const el = mount([field])
+    await nextTick()
+    expect(el.querySelector('[data-testid="approval-explanation-config"]')).not.toBeNull()
+    // The ONLY checkbox this editor ever renders (with a single non-detail field selected, as
+    // here) is 是否必填 — zero checkboxes proves it is hidden for explanation, not merely
+    // unlabeled. Detail sub-field rows render their OWN per-column checkbox, irrelevant here
+    // since the mounted field is `explanation`, not `detail`.
+    expect(el.querySelectorAll('input[type="checkbox"]').length).toBe(0)
+    // 占位文本 binds a plain (non-checkbox) <el-input v-model="field.placeholder">; with the
+    // required checkbox proven absent and the explanation config block confirmed present, the
+    // total <input>/<textarea> count on the page is the closed set: 字段名称 (label) + 类型
+    // (select, not input) + explanation's own props.text textarea — i.e. exactly 2 text-entry
+    // elements, not 3 (which 占位文本 present would make it).
+    const textEntryElements = el.querySelectorAll('input[type="text"], input:not([type]), textarea')
+    expect(textEntryElements.length).toBe(2)
+  })
+
+  it('positive control: 必填/占位文本 controls ARE present for a NON-explanation type (hiding is type-selected)', async () => {
+    const field: FieldAuthoringDraft = { ...createEmptyFieldDraft(1), localId: 'f1', id: 'field_1', type: 'text' }
+    const el = mount([field])
+    await nextTick()
+    expect(el.querySelectorAll('input[type="checkbox"]').length).toBeGreaterThan(0)
+    expect(el.querySelector('[data-testid="approval-explanation-config"]')).toBeNull()
+  })
+
+  it('a NON-explanation field renders NO explanation property block (the arm is type-selected, not always-on)', async () => {
+    const field: FieldAuthoringDraft = { ...createEmptyFieldDraft(1), localId: 'f1', id: 'field_1', type: 'text' }
+    const el = mount([field])
+    await nextTick()
+    expect(el.querySelector('[data-testid="approval-explanation-config"]')).toBeNull()
+  })
+})

--- a/apps/web/tests/approval-form-authoring-adapter.test.ts
+++ b/apps/web/tests/approval-form-authoring-adapter.test.ts
@@ -519,6 +519,9 @@ describe('legacy length-derived helpers - frozen fallback baseline (delta §5 F1
       dateRangeStartLabel: '',
       dateRangeEndLabel: '',
       dateRangeDurationLabel: '',
+      // L8-A (approval-lock8-field-vocabulary-20260817.md §1.1): same deliberate-widening,
+      // neutral-defaults discipline — meaningless until retyped to `explanation`.
+      explanationText: '',
     })
     expect(localId).toMatch(/^field_\d+_[0-9a-f]{1,6}$/)
     // Default-arg pin: the historical `index = 1` default stays intact.

--- a/apps/web/tests/approval-form-field-inspector.spec.ts
+++ b/apps/web/tests/approval-form-field-inspector.spec.ts
@@ -339,6 +339,8 @@ describe('ApprovalFormFieldInspector — surface (§3.4)', () => {
         'record-link',
         // Lock-8 L8-B (approval-lock8-field-vocabulary-20260817.md §1.2).
         'date_range',
+        // Lock-8 L8-A (approval-lock8-field-vocabulary-20260817.md §1.1).
+        'explanation',
       ]),
     )
     expect(values).not.toContain('attachment')

--- a/apps/web/tests/approval-form-inline-editor-extract.spec.ts
+++ b/apps/web/tests/approval-form-inline-editor-extract.spec.ts
@@ -12,7 +12,11 @@ import { computed, createApp, defineComponent, h, inject, nextTick, provide, ref
 import TemplateAuthoringView from '../src/views/approval/TemplateAuthoringView.vue'
 import ApprovalFormInlineEditor from '../src/approvals/components/ApprovalFormInlineEditor.vue'
 import type { ApprovalTemplateDetailDTO } from '../src/types/approval'
-import { createEmptyFieldDraft, type FieldAuthoringDraft } from '../src/approvals/templateAuthoring'
+import {
+  AUTHORABLE_FIELD_TYPES,
+  createEmptyFieldDraft,
+  type FieldAuthoringDraft,
+} from '../src/approvals/templateAuthoring'
 
 const pushSpy = vi.fn().mockResolvedValue(undefined)
 const replaceSpy = vi.fn().mockResolvedValue(undefined)
@@ -797,5 +801,62 @@ describe('ApprovalFormInlineEditor extraction (F0, Gate F0)', () => {
     // Positive control: the sweep DOES find the mandated replacement copy — not passing over an
     // empty string set (Lock-8 gate M-2).
     expect(text).toContain('格式化数字')
+  })
+
+  // Lock-8 L8-A gate P2-1 hardening: the (j) test above proves invalidateStaleRecordLinkDependencies
+  // fires on the "became record-link" direction; `bareBanned` also lists `explanation` (this PR's
+  // OWN addition — TemplateAuthoringView.vue's `invalidateStaleRecordLinkDependencies`), and until
+  // now nothing distinguished that arm from a no-op: deleting `|| changedField.type === 'explanation'`
+  // left every reachable spec green. This is the same scenario as (j), target type swapped.
+  it('(n) invalidate-record-link-deps ALSO clears a stale visibility dependency when the depended-on field is retyped to explanation (Lock-8 L8-A)', async () => {
+    await mountView()
+    ;(container!.querySelector('[data-testid="approval-field-palette-text"]') as HTMLButtonElement).click()
+    await flushUi()
+
+    // Same setup as (j): the newly-added field is focused; give it a visibility rule depending on
+    // the ORIGINAL (create-mode default, index-1) field — still type='text' here, an eligible
+    // dependency.
+    const dependentRow = focusedFieldRow()
+    const dependsSelect = dependentRow.querySelector('[data-testid="approval-field-visibility-depends"]') as HTMLSelectElement
+    const dependencyOption = dependsSelect.querySelector('option:not([value=""])') as HTMLOptionElement
+    expect(dependencyOption).not.toBeNull()
+    const dependencyValue = dependencyOption.value
+    dependsSelect.value = dependencyValue
+    dependsSelect.dispatchEvent(new Event('change'))
+    await flushUi()
+    expect(dependsSelect.value).toBe(dependencyValue)
+    // Ground-truth signal (same trap (j) documents): read the operator select's v-if, not the
+    // depends <select>'s own `.value` getter after its matching option disappears.
+    const operatorSelect = () => dependentRow.querySelector('[data-testid="approval-field-visibility-operator"]')
+    expect(operatorSelect()).not.toBeNull()
+
+    // Retype the ORIGINAL field (the dependency target) to explanation — the other field row.
+    const allRows = Array.from(container!.querySelectorAll('[data-testid="approval-template-field-row"]'))
+    const targetRow = allRows.find((row) => row !== dependentRow) as HTMLElement
+    const typeSelect = targetRow.querySelector('[data-testid="approval-field-type"]') as HTMLSelectElement
+    typeSelect.value = 'explanation'
+    typeSelect.dispatchEvent(new Event('change'))
+    await flushUi()
+
+    // The dependent field's stale visibility rule was cleared (server would fail-close on an
+    // illegal dependency, since explanation is never offered by visibilityFieldOptions):
+    expect(operatorSelect()).toBeNull()
+  })
+
+  // Lock-8 L8-A gate P2-1 hardening: `fieldPaletteGroups` (TemplateAuthoringView.vue) is a SECOND,
+  // independent copy of the F2 `APPROVAL_FORM_PALETTE_GROUPS` membership (approval-form-palette-
+  // chips.spec.ts:107 already forces THAT array's completeness against `AUTHORABLE_FIELD_TYPES`,
+  // but never covered this one — deleting `explanation` from this file's `fieldPaletteGroups` array
+  // alone left every reachable spec green). This mounts the REAL view (not a duplicated literal) and
+  // generalizes the same forcing-function shape to the actually-shipped chip DOM, so a future type
+  // added to AUTHORABLE_FIELD_TYPES but dropped from this file's `fieldPaletteGroups` reds here.
+  it('(o) MS-13 completeness: the VIEW-owned fieldPaletteGroups renders exactly one palette chip per AUTHORABLE_FIELD_TYPES member, no more, no fewer', async () => {
+    await mountView()
+    const chipTypes = Array.from(
+      container!.querySelectorAll('[data-testid^="approval-field-palette-"]'),
+    ).map((el) => (el.getAttribute('data-testid') ?? '').replace('approval-field-palette-', ''))
+    expect([...chipTypes].sort()).toEqual([...AUTHORABLE_FIELD_TYPES].sort())
+    // No duplicate registration of the same type across groups.
+    expect(chipTypes).toHaveLength(new Set(chipTypes).size)
   })
 })

--- a/apps/web/tests/approval-lock8-field-type-census.test.ts
+++ b/apps/web/tests/approval-lock8-field-type-census.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest'
+import { AUTHORABLE_FIELD_TYPES } from '../src/approvals/templateAuthoring'
+import { isDetailLeafFieldType } from '../src/approvals/detailField'
+import { isSelectableConditionOrVisibilityDependencyType } from '../src/approvals/recordLinkField'
+
+// Lock-8 L8-A §2.1 N-1 — mechanical census, FRONTEND half. See the backend sibling
+// (packages/core-backend/tests/unit/approval-lock8-field-type-census.test.ts) for the full scope
+// note on what MS-1..MS-13 this repo can and cannot anchor mechanically; this file covers:
+//
+//   COVERED here, anchored on the REAL exported set/predicate:
+//     - MS-5  FE detail-leaf explicit list (`isDetailLeafFieldType`) — one call per canonical
+//             AUTHORABLE type, hand-authored expectation table, completeness meta-check
+//     - MS-9  FE selectable condition/visibility dependency predicate
+//             (`isSelectableConditionOrVisibilityDependencyType`) — same shape
+//
+//   NOT a runtime row here (see the backend file's note for the full reasoning):
+//     - MS-1  FE/BE union sync — no runtime footprint; compiler-forced via Record<FormFieldType,…>
+//             maps (MS-11) plus this file's own `AUTHORABLE_FIELD_TYPES` import, which would fail
+//             to TYPECHECK before ever running if a member were absent from its declaring array.
+//     - MS-6  AUTHORABLE_FIELD_TYPES / approvalFormCommands.ts FIELD_LABELS — FIELD_LABELS is a
+//             `Record<AuthorableFieldType,string>` LITERAL and AUTHORABLE_FIELD_TYPES here derives
+//             from `Object.keys(FIELD_LABELS)` — compile-forced, verified by `vue-tsc -b`, not a
+//             vitest row. approval-explanation-field.test.ts pins the BEHAVIOURAL side (addFormField
+//             admits it).
+//     - MS-11 four label/mark maps — all `Record<AuthorableFieldType|FormFieldType,…>` literals,
+//             compile-forced the same way.
+//     - MS-13 palette GROUPING (the one non-compile-forced part of MS-13 — plain string arrays, not
+//             a Record) — covered by the PRE-EXISTING forcing function
+//             `approval-form-palette-chips.spec.ts:107` (`[...groupedTypes].sort() ===
+//             [...AUTHORABLE_FIELD_TYPES].sort()`), generalized rather than reinvented, and
+//             cross-checked again in approval-explanation-field.test.ts's own registration-
+//             completeness describe block. The inline-editor's per-type property block (the other
+//             half of MS-13) is a MOUNTED-component concern — see
+//             approval-explanation-inline-editor.spec.ts.
+//     - MS-3/MS-12 are pinned by approval-explanation-field.test.ts's dedicated describe blocks
+//             (prefill / buildDisplayFields / summaryFields), not a type-indexed table — their
+//             shape ("does X have an arm", "is X's render source correct") does not fit the
+//             exact-equality census style as cleanly as a dedicated positive/negative pair does.
+
+// MS-5 expectation table — mirrors the backend MS-4 table's boundary (detail/record-link/
+// date_range/explanation excluded; attachment is EXCLUDED here too, unlike the backend's
+// DETAIL_LEAF_FIELD_TYPES — the FE list is the 8-member explicit array documented at
+// detailField.ts:20-24, deliberately narrower than the backend's flag-gated 9-member set).
+const MS5_DETAIL_LEAF_ADMITTED: Readonly<Record<string, boolean>> = {
+  text: true,
+  textarea: true,
+  number: true,
+  date: true,
+  datetime: true,
+  select: true,
+  'multi-select': true,
+  user: true,
+  detail: false,
+  'record-link': false,
+  date_range: false,
+  explanation: false,
+}
+
+// MS-9 expectation table — the FE selectable condition/visibility dependency predicate.
+const MS9_SELECTABLE_DEPENDENCY: Readonly<Record<string, boolean>> = {
+  text: true,
+  textarea: true,
+  number: true,
+  date: true,
+  datetime: true,
+  select: true,
+  'multi-select': true,
+  user: true,
+  detail: false,
+  'record-link': false,
+  date_range: false,
+  explanation: false,
+}
+
+describe('Lock-8 L8-A field-type census (N-1) — frontend sites', () => {
+  it('MS-5: completeness — the expectation table covers EXACTLY AUTHORABLE_FIELD_TYPES', () => {
+    // Adding a 13th authorable type with no row here reds THIS assertion first.
+    expect(Object.keys(MS5_DETAIL_LEAF_ADMITTED).sort()).toEqual([...AUTHORABLE_FIELD_TYPES].sort())
+  })
+
+  for (const type of [...AUTHORABLE_FIELD_TYPES].sort()) {
+    const admitted = MS5_DETAIL_LEAF_ADMITTED[type]
+    it(`MS-5: ${type} is ${admitted ? 'a valid' : 'NOT a valid'} detail-leaf sub-field type`, () => {
+      expect(isDetailLeafFieldType(type)).toBe(admitted)
+    })
+  }
+
+  it('MS-9: completeness — the expectation table covers EXACTLY AUTHORABLE_FIELD_TYPES', () => {
+    expect(Object.keys(MS9_SELECTABLE_DEPENDENCY).sort()).toEqual([...AUTHORABLE_FIELD_TYPES].sort())
+  })
+
+  for (const type of [...AUTHORABLE_FIELD_TYPES].sort()) {
+    const admitted = MS9_SELECTABLE_DEPENDENCY[type]
+    it(`MS-9: ${type} is ${admitted ? 'ADMITTED' : 'REFUSED'} as a condition/visibility dependency`, () => {
+      expect(isSelectableConditionOrVisibilityDependencyType(type)).toBe(admitted)
+    })
+  }
+})

--- a/apps/web/tests/approval-lock8-field-type-census.test.ts
+++ b/apps/web/tests/approval-lock8-field-type-census.test.ts
@@ -25,12 +25,21 @@ import { isSelectableConditionOrVisibilityDependencyType } from '../src/approval
 //     - MS-11 four label/mark maps — all `Record<AuthorableFieldType|FormFieldType,…>` literals,
 //             compile-forced the same way.
 //     - MS-13 palette GROUPING (the one non-compile-forced part of MS-13 — plain string arrays, not
-//             a Record) — covered by the PRE-EXISTING forcing function
+//             a Record) has TWO independent registration sites, NOT one: the F2
+//             `ApprovalFormPalette.vue` component's exported `APPROVAL_FORM_PALETTE_GROUPS`, and
+//             `TemplateAuthoringView.vue`'s own separate `fieldPaletteGroups` local (the array
+//             actually shipped into the live inline editor). The PRE-EXISTING forcing function
 //             `approval-form-palette-chips.spec.ts:107` (`[...groupedTypes].sort() ===
-//             [...AUTHORABLE_FIELD_TYPES].sort()`), generalized rather than reinvented, and
-//             cross-checked again in approval-explanation-field.test.ts's own registration-
-//             completeness describe block. The inline-editor's per-type property block (the other
-//             half of MS-13) is a MOUNTED-component concern — see
+//             [...AUTHORABLE_FIELD_TYPES].sort()`) and approval-explanation-field.test.ts's own
+//             registration-completeness describe block BOTH read only `APPROVAL_FORM_PALETTE_GROUPS`
+//             — neither one is reachable from `TemplateAuthoringView.vue`'s copy (correction, gate
+//             P2-1: an earlier draft of this comment claimed :107 was "generalized" to cover it;
+//             that was false — deleting `explanation` from the view's own array alone left every
+//             then-reachable spec green). The view's own copy is covered separately, by a REAL
+//             mount (not a duplicated literal): `approval-form-inline-editor-extract.spec.ts`'s "(o)
+//             MS-13 completeness" test queries the rendered `approval-field-palette-*` chip DOM and
+//             asserts it against `AUTHORABLE_FIELD_TYPES` directly. The inline-editor's per-type
+//             property block (the other half of MS-13) is a MOUNTED-component concern — see
 //             approval-explanation-inline-editor.spec.ts.
 //     - MS-3/MS-12 are pinned by approval-explanation-field.test.ts's dedicated describe blocks
 //             (prefill / buildDisplayFields / summaryFields), not a type-indexed table — their

--- a/apps/web/tests/approvalTemplateAuthoring.spec.ts
+++ b/apps/web/tests/approvalTemplateAuthoring.spec.ts
@@ -3334,6 +3334,74 @@ describe('TemplateAuthoringView', () => {
     // the matching <option> disappears regardless of whether the reactive string was actually cleared.
     expect(operatorSelect()).toBeNull()
   })
+
+  // Lock-8 L8-A (§1.1) gate P2-1 hardening: explanation carries no value at all, so
+  // `visibilityFieldOptions` excludes it TOTALLY (no bare option, and — unlike date_range — no
+  // dotted endpoint options either, since it has none). Until now nothing distinguished the
+  // `if (field.type === 'explanation') continue` guard from a no-op: deleting it alone left every
+  // reachable spec green. The number-field leg is a mandatory positive control.
+  it('Lock-8 L8-A: the visibility depends-on picker excludes an explanation field entirely (no bare option, no endpoint options), while a sibling number field remains selectable', async () => {
+    routeParams = { id: 'tpl_1' }
+    getTemplateSpy.mockResolvedValue(buildTemplate({
+      formSchema: {
+        fields: [
+          { id: 'amount', type: 'number', label: '金额' },
+          { id: 'note', type: 'explanation', label: '说明', props: { text: '请仔细阅读' } },
+          { id: 'reason', type: 'text', label: '事由' },
+        ],
+      } as any,
+    }))
+    await mountView()
+    await flushUi()
+
+    const reasonRow = () => container!.querySelectorAll('[data-testid="approval-template-field-row"]')[2] as HTMLElement
+    const dependsSelect = reasonRow().querySelector('[data-testid="approval-field-visibility-depends"]') as HTMLSelectElement
+    const optionValues = Array.from(dependsSelect.options).map((o) => o.value)
+    // Positive control FIRST — proves the options list is non-trivial, not accidentally emptied.
+    expect(optionValues).toContain('amount')
+    expect(optionValues).not.toContain('note')
+    expect(optionValues.some((v) => v.startsWith('note.'))).toBe(false)
+  })
+
+  // Lock-8 L8-A (§1.1) gate P2-1 hardening: `conditionFieldOptions` (graph condition rule field
+  // picker) also excludes explanation entirely — `validateConditionEdits` rejects any rule
+  // referencing a valueless field, so offering it here would be an M7 inert control. Until now
+  // nothing distinguished this PR's `&& field.type !== 'explanation'` guard from a no-op: deleting
+  // it alone left every reachable spec green.
+  it('Lock-8 L8-A: the condition rule field picker excludes an explanation field entirely while a sibling number field remains selectable', async () => {
+    routeParams = { id: 'tpl_1' }
+    getTemplateSpy.mockResolvedValue(buildTemplate({
+      formSchema: {
+        fields: [
+          { id: 'amount', type: 'number', label: '金额' },
+          { id: 'note', type: 'explanation', label: '说明', props: { text: '请仔细阅读' } },
+        ],
+      } as any,
+      approvalGraph: {
+        nodes: [
+          { key: 'start', type: 'start', name: '发起', config: {} },
+          { key: 'cond_1', type: 'condition', name: '判断', config: { branches: [{ edgeKey: 'e-a', rules: [{ fieldId: 'amount', operator: 'gte', value: 100 }] }], defaultEdgeKey: 'e-b' } },
+          { key: 'app_a', type: 'approval', name: 'A', config: { assigneeSources: [{ kind: 'dept_head' }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+          { key: 'end', type: 'end', name: '结束', config: {} },
+        ],
+        edges: [
+          { key: 'e-start-c', source: 'start', target: 'cond_1' },
+          { key: 'e-a', source: 'cond_1', target: 'app_a' },
+          { key: 'e-b', source: 'cond_1', target: 'end' },
+          { key: 'e-a-end', source: 'app_a', target: 'end' },
+        ],
+      },
+    }))
+    await mountView()
+    await flushUi()
+
+    const fieldSelect = container!.querySelector('[data-testid="approval-condition-rule-field"]') as HTMLSelectElement
+    expect(fieldSelect).not.toBeNull()
+    const optionValues = Array.from(fieldSelect.options).map((o) => o.value)
+    // Positive control FIRST — proves the options list is non-trivial, not accidentally emptied.
+    expect(optionValues).toContain('amount')
+    expect(optionValues).not.toContain('note')
+  })
   })
 
 describe('L8-C: formatted-number authoring (docs/development/approval-lock8-field-vocabulary-20260817.md §1.3, OD-L8-6)', () => {

--- a/apps/web/tests/fwb-rule-authoring-helpers.test.ts
+++ b/apps/web/tests/fwb-rule-authoring-helpers.test.ts
@@ -156,6 +156,15 @@ describe('fwbRuleAuthoring helpers', () => {
         { id: 2, label: 'bad' },
       ],
     })).toEqual([{ id: 'f1', label: 'Reason' }])
+    // Lock-8 L8-A (approval-lock8-field-vocabulary-20260817.md §1.1): explanation carries no
+    // submitted value (A-1) — excluded from the FWB mapping source candidate list; a text field
+    // in the SAME schema IS still included (positive control — exclusion is type-selected).
+    expect(templateSchemaToFwbFields({
+      fields: [
+        { id: 'note', label: '说明', type: 'explanation' },
+        { id: 'reason', label: 'Reason', type: 'text' },
+      ],
+    })).toEqual([{ id: 'reason', label: 'Reason' }])
     expect(templateSchemaToFwbRecordLinks({
       fields: [
         { id: 'linked', label: 'Order', type: 'record-link', props: { baseId: 'base_1', sheetId: 'sheet_1' } },

--- a/docs/development/approval-parity-execution-ledger-20260817.md
+++ b/docs/development/approval-parity-execution-ledger-20260817.md
@@ -83,6 +83,7 @@ reviewable behavior.
 | Number FWB | fail-closed | existing FWB contract | independent exact-number decision |
 | Flag order | Canvas, durable prerequisite plus FWB, attachments | owner handoff plus production FWB dependency | explicit owner change |
 | Private release prerequisites | tracked outside public repository artifacts | disclosure discipline | owner records closure out of band |
+| explanation (说明) palette group (Lock-8 L8-A §2.6) | 其他 group, in both `ApprovalFormPalette.vue` (F2) and `TemplateAuthoringView.vue`'s own copy | reversible presentation choice, goal-set instruction (2026-08-17) executing this slice — Lock-8 §2.6 records the group as needing an owner decision, not yet ratified as an OD-L8-3 group | owner picks a different group; a data-only change to both palette arrays |
 
 ## 4. Evidence ledger template
 

--- a/packages/core-backend/src/services/ApprovalGraphExecutor.ts
+++ b/packages/core-backend/src/services/ApprovalGraphExecutor.ts
@@ -260,7 +260,11 @@ export function resolveVisibilityFieldReference(
   const fieldMap = new Map(fields.map((field) => [field.id, field]))
   const direct = fieldMap.get(rawFieldId)
   if (direct) {
-    return direct.type === 'date_range' ? null : { field: direct }
+    // Lock-8 L8-A (§1.1, MS-8): `explanation` carries no value at all — refused as a bare
+    // reference the same way date_range's WHOLE value is, and with no endpoint fallback (it has
+    // none). A saved graph can never legitimately reach this branch (publish already denies it,
+    // ApprovalProductService.ts), but this runtime resolver stays defensive independent of that.
+    return direct.type === 'date_range' || direct.type === 'explanation' ? null : { field: direct }
   }
   const dot = rawFieldId.lastIndexOf('.')
   if (dot <= 0 || dot === rawFieldId.length - 1) return null
@@ -559,6 +563,13 @@ export function validateFieldType(
       }
       return null
     }
+    // Lock-8 L8-A (§1.1, MS-3): explanation accepts NO submitted value — an explicit arm, not the
+    // fall-through `default: return null` above (which would make the type fail-OPEN: any value
+    // silently accepted). This function only reaches here when `value !== undefined && value !==
+    // null` (the early return above already lets an absent/unset value through) — so this arm ONLY
+    // fires when a client actually submitted something for a field that must carry nothing.
+    case 'explanation':
+      return `${field.id} does not accept a submitted value`
     default:
       return null
   }

--- a/packages/core-backend/src/services/ApprovalProductService.ts
+++ b/packages/core-backend/src/services/ApprovalProductService.ts
@@ -9659,7 +9659,20 @@ export class ApprovalProductService {
       // create-time record-link confused-deputy authz (projectRecordLinkFormSnapshotForViewer) and
       // attachment-id binding into the immutable snapshot. Rejected here, not silently dropped; the
       // approval-node write surface (OD-L7-3's named next slice) carries the binding surfaces.
-      if (field.type === 'record-link' || field.type === 'attachment') {
+      //
+      // Lock-8 L8-A (§1.1) gate P2-2 hardening: `explanation` joins this refusal for a DIFFERENT
+      // reason — it carries no value at ANY time (display-only, A-1). A handler node with NO matrix
+      // entry for it defaults to OD-L7-9 absent≡editable (`fieldAccessAtNodes` above), so the ONLY
+      // remaining backstop was `validateFieldType`'s explicit `case 'explanation'` arm
+      // (ApprovalGraphExecutor.ts) — which DOES refuse a non-null submitted value, but that function's
+      // own universal `value === undefined || value === null` early return (shared by every field
+      // type, not explanation-specific) lets a `null` write skip validation entirely. Without this
+      // arm, `fieldWrites: {<explanationId>: null}` would reach the `merge[fieldId] = value` in-place
+      // UPDATE below and add an `explanation` key to `form_snapshot` (plus a field-revision row) for a
+      // field type A-1 declares is contractually absent from formSnapshot. The payload this closes is
+      // necessarily `null`-only — any non-null value is independently refused by `validateFieldType`'s
+      // arm above, unaffected by this change.
+      if (field.type === 'record-link' || field.type === 'attachment' || field.type === 'explanation') {
         throw new ServiceError('Field type is not writable at a handler node yet', 400, 'APPROVAL_FIELD_WRITE_UNSUPPORTED_TYPE', { nodeKey, fieldId })
       }
       // Re-run the FROZEN-schema validators (L7-C / G-6). MS-3 fail-open is INHERITED, not fixed: a

--- a/packages/core-backend/src/services/ApprovalProductService.ts
+++ b/packages/core-backend/src/services/ApprovalProductService.ts
@@ -440,7 +440,9 @@ const STORED_RUNTIME_CONTEXT: ValidationContext = {
   code: 'APPROVAL_RUNTIME_GRAPH_INVALID',
 }
 
-const FORM_FIELD_TYPES = new Set([
+// EXPORTED (Lock-8 L8-A §2.1 N-1: the census import-anchor, not a re-declared list) so a census
+// test can assert exact-set equality against the canonical type set and mutation-prove membership.
+export const FORM_FIELD_TYPES = new Set([
   'text',
   'textarea',
   'number',
@@ -457,6 +459,9 @@ const FORM_FIELD_TYPES = new Set([
   // Top-level only — explicitly excluded from DETAIL_LEAF below (OD-L8-4: two-to-three sub-values
   // in a single-leaf column structure ripples into lineDerivation/FWB-per-column/diff-granularity).
   'date_range',
+  // Lock-8 L8-A (§1.1, OD-L8-2): display-only 说明. Top-level only — excluded from DETAIL_LEAF
+  // below (a valueless control inside a repeating row has no per-row meaning).
+  'explanation',
 ])
 
 // L8-C (docs/development/approval-lock8-field-vocabulary-20260817.md §1.3, OD-L8-6/OD-L8-7): the
@@ -492,6 +497,11 @@ export const DATE_RANGE_FIELD_ALLOWED_PROP_KEYS = new Set([
   'durationLabel',
 ])
 
+// Lock-8 L8-A (§1.1, OD-L8-3(a)): the allowlist of props keys permitted on `explanation`. `text`
+// is the ONLY key — the rendered body shown to the requester/approver. Mirrors record-link's
+// fail-closed shape (§0.4): unknown keys fail publish, canonicalized props never spread residually.
+export const EXPLANATION_FIELD_ALLOWED_PROP_KEYS = new Set(['text'])
+
 // Leaf sub-field types allowed inside a `detail` group's columns. The attachment pipeline narrows
 // this set only while its feature flag is enabled; flag OFF preserves the pre-feature authoring
 // contract for existing templates. `record-link` is v1-excluded from detail (FWB-0 Layer 2:
@@ -509,9 +519,18 @@ export const DATE_RANGE_FIELD_ALLOWED_PROP_KEYS = new Set([
 // .test.ts's OD-L8-4 describe block for the full mutation log. Earlier PR-body language claiming
 // this filter alone is "what B-4's mutation removes to prove load-bearing" was imprecise and has
 // been corrected.
-const DETAIL_LEAF_FIELD_TYPES = new Set(
+//
+// Lock-8 L8-A (§1.1, MS-4): `explanation` is excluded too — UNLIKE record-link/date_range it has
+// NO separate explicit `nested` guard in `normalizeFormField` (its props block below runs
+// regardless of nesting; the shared column-shape checks harmlessly canonicalize `props.text`
+// either way), so THIS filter is the sole, independently mutation-provable rejection site for a
+// nested explanation column — no pre-emption ambiguity to correct later.
+//
+// EXPORTED (mirrors FORM_FIELD_TYPES) so a census test can assert this DERIVED set is exactly
+// FORM_FIELD_TYPES minus {detail, record-link, date_range, explanation} rather than re-declaring it.
+export const DETAIL_LEAF_FIELD_TYPES = new Set(
   [...FORM_FIELD_TYPES].filter(
-    (type) => type !== 'detail' && type !== 'record-link' && type !== 'date_range',
+    (type) => type !== 'detail' && type !== 'record-link' && type !== 'date_range' && type !== 'explanation',
   ),
 )
 
@@ -1092,6 +1111,46 @@ function normalizeFormField(
     dateRangeProps = canonical
   }
 
+  // Lock-8 L8-A (§1.1, OD-L8-2/OD-L8-3, A-1): explanation is DISPLAY-ONLY — no submitted value, so
+  // `required`/`defaultValue`/`options`/`placeholder` are each refused OUTRIGHT at publish (nothing
+  // to require, default, choose among, or prompt for). The generic shape checks above only reject a
+  // WRONGLY-TYPED value (e.g. `required: 'yes'`); a well-typed-but-meaningless one (`required: true`,
+  // a real placeholder string) must be rejected HERE, per-type. `props.text` is the ONLY allowed
+  // key — the rendered body (OD-L8-3(a)); the strict allowlist mirrors record-link's fail-closed
+  // shape (§0.4): unknown keys fail publish, canonicalized props never spread residually. No
+  // separate `nested` guard (unlike record-link/date_range): `DETAIL_LEAF_FIELD_TYPES` above is the
+  // sole, independently mutation-provable rejection for a nested explanation column (MS-4).
+  let explanationProps: Record<string, unknown> | undefined
+  if (value.type === 'explanation') {
+    if (value.required === true) {
+      failValidation(context, `formSchema.fields[${index}] explanation cannot be required (no submitted value)`)
+    }
+    if (value.defaultValue !== undefined) {
+      failValidation(context, `formSchema.fields[${index}] explanation cannot carry a defaultValue (no submitted value)`)
+    }
+    if (value.placeholder !== undefined) {
+      failValidation(context, `formSchema.fields[${index}] explanation cannot carry a placeholder (no submitted value)`)
+    }
+    if (value.options !== undefined) {
+      failValidation(context, `formSchema.fields[${index}] explanation cannot carry options (no submitted value)`)
+    }
+    const props = isRecord(value.props) ? value.props : null
+    const extraKeys = props
+      ? Object.keys(props).filter((key) => !EXPLANATION_FIELD_ALLOWED_PROP_KEYS.has(key))
+      : []
+    if (extraKeys.length > 0) {
+      failValidation(
+        context,
+        `formSchema.fields[${index}] explanation props may only contain ${[...EXPLANATION_FIELD_ALLOWED_PROP_KEYS].join(', ')} (unknown: ${extraKeys.join(', ')})`,
+      )
+    }
+    const text = props?.text
+    if (typeof text !== 'string' || !text.trim()) {
+      failValidation(context, `formSchema.fields[${index}] explanation props.text is required`)
+    }
+    explanationProps = { text: (text as string).trim() }
+  }
+
   const visibilityRule = normalizeFormFieldVisibilityRule(value.visibilityRule, index, context)
   const detail = normalizeDetailFieldParts(value, index, context, nested)
 
@@ -1116,9 +1175,11 @@ function normalizeFormField(
         ? { props: numberProps }
         : dateRangeProps
           ? { props: dateRangeProps }
-          : isRecord(value.props)
-            ? { props: { ...value.props } }
-            : {}),
+          : explanationProps
+            ? { props: explanationProps }
+            : isRecord(value.props)
+              ? { props: { ...value.props } }
+              : {}),
     ...(visibilityRule ? { visibilityRule } : {}),
     ...detail,
   } as FormSchema['fields'][number]
@@ -1327,6 +1388,15 @@ function validateFormFieldVisibilityRules(
         failValidation(
           context,
           `formSchema.fields[${index}].visibilityRule.fieldId cannot reference a date_range field as a single value — reference its .start or .end endpoint (Lock-8 OD-L8-5)`,
+        )
+      }
+      // Lock-8 L8-A (§1.1, MS-8): explanation carries NO value at all (not merely non-scalar) —
+      // there is nothing to compare, so a dependent field can never legitimately key visibility off
+      // one. Unlike date_range there is no endpoint address to fall back to; the exclusion is total.
+      if (target.type === 'explanation') {
+        failValidation(
+          context,
+          `formSchema.fields[${index}].visibilityRule.fieldId cannot reference an explanation field (it carries no value)`,
         )
       }
       return
@@ -2252,6 +2322,11 @@ function validateConditionBranchRules(approvalGraph: ApprovalGraph, formSchema: 
  * address); this lock does not extend endpoint addressing to condition branches — `date_range` is
  * simply excluded from them, exactly like record-link, rather than left auto-admitted and
  * fail-open (§0.3's governing fact: a new member auto-admits into every hand-maintained gate).
+ *
+ * Lock-8 L8-A (§1.1, MS-10) reuses the SAME mechanism for `explanation`: it carries no value at
+ * all (a stricter case than "non-scalar" — there is nothing to compare, ever), so a condition rule
+ * or formula referencing one can never legitimately match. Name kept generic (this function
+ * already covers non-scalar AND valueless types under one gate) rather than adding a parallel one.
  */
 function validateNonScalarFieldsNotUsedInConditions(
   approvalGraph: ApprovalGraph,
@@ -2261,6 +2336,7 @@ function validateNonScalarFieldsNotUsedInConditions(
   const nonScalarFieldTypes: ReadonlyArray<{ type: FormField['type']; label: string }> = [
     { type: 'record-link', label: 'record-link' },
     { type: 'date_range', label: 'date_range' },
+    { type: 'explanation', label: 'explanation' },
   ]
   const fieldTypeById = new Map((formSchema.fields ?? []).map((field) => [field.id, field.type]))
   const nonScalarFieldIds = new Set(

--- a/packages/core-backend/src/types/approval-product.ts
+++ b/packages/core-backend/src/types/approval-product.ts
@@ -114,6 +114,16 @@ export type FormFieldType =
    * endpoints are.
    */
   | 'date_range'
+  /**
+   * Lock-8 L8-A (approval-lock8-field-vocabulary-20260817.md §1.1, OD-L8-2/OD-L8-3): a
+   * DISPLAY-ONLY field (说明) — renders authored `props.text` to the requester/approver. No
+   * submitted value: `required`/`defaultValue`/`options`/`placeholder` are all refused at
+   * publish (A-1), the field never enters `formSnapshot` or FWB source candidates, is excluded
+   * from detail columns (MS-4/MS-5), and is never a whole-value visibility/condition dependency
+   * (MS-8/MS-9/MS-10) — it has no value to compare. `label` stays authoring-list-only (BE
+   * requires a non-blank label for every field, `:786`); the rendered body is `props.text`.
+   */
+  | 'explanation'
 
 export interface ApprovalNode {
   key: string

--- a/packages/core-backend/tests/unit/approval-lock8-explanation-field.test.ts
+++ b/packages/core-backend/tests/unit/approval-lock8-explanation-field.test.ts
@@ -1,0 +1,365 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  resolveVisibilityFieldReference,
+  validateApprovalFormData,
+} from '../../src/services/ApprovalGraphExecutor'
+import type { FormSchema } from '../../src/types/approval-product'
+
+// Lock-8 L8-A (docs/development/approval-lock8-field-vocabulary-20260817.md §1.1) — explanation
+// (说明): a DISPLAY-ONLY field. Renders authored `props.text` to the requester/approver; collects
+// NO value. This file covers:
+//   - N-1 style census: the props allowlist is EXACTLY { text }
+//   - A-1 valuelessness: required/defaultValue/options/placeholder each fail publish, with a
+//     textarea positive control proving the rejection is TYPE-selected, not a generic bug
+//   - props.text round-trip + strict allowlist (unknown key fails publish)
+//   - MS-3 submit-time value validation: an explicit "no value permitted" arm (not the fail-open
+//     `default: return null`), with a textarea positive control proving a REAL value DOES reach
+//     validation and succeed on this same schema
+//   - MS-4: detail-column exclusion (positive edit), with a number positive control
+//   - MS-8: visibility whole-value denylist, with a text positive control
+//   - MS-10: condition-branch exclusion, with a text positive control
+//   - the BE `resolveVisibilityFieldReference` runtime mirror
+
+const pgState = vi.hoisted(() => ({
+  client: { query: vi.fn(), release: vi.fn() },
+  pool: { query: vi.fn(), connect: vi.fn() },
+}))
+
+vi.mock('../../src/db/pg', () => ({
+  pool: pgState.pool,
+}))
+
+function normalize(sql: string): string {
+  return sql.replace(/\s+/g, ' ').trim()
+}
+
+function buildRuntimeGraph(policyOverrides?: Record<string, unknown>) {
+  return {
+    nodes: [
+      { key: 'start', type: 'start', config: {} },
+      { key: 'approval_1', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['manager-1'] } },
+      { key: 'end', type: 'end', config: {} },
+    ],
+    edges: [
+      { key: 'edge-start-approval', source: 'start', target: 'approval_1' },
+      { key: 'edge-approval-end', source: 'approval_1', target: 'end' },
+    ],
+    policy: { allowRevoke: true, ...policyOverrides },
+  }
+}
+
+/** Wires the minimal INSERT-only DB mock a successful `createTemplate` call needs. */
+function mockSuccessfulCreate(tplId: string, verId: string) {
+  pgState.client.query.mockImplementation(async (sql: string, params?: unknown[]) => {
+    const s = normalize(sql)
+    if (s === 'BEGIN' || s === 'COMMIT' || s === 'ROLLBACK') return { rows: [], rowCount: 0 }
+    if (s.startsWith('INSERT INTO approval_templates')) {
+      return {
+        rows: [{
+          id: tplId, key: String(params?.[0]), name: String(params?.[1]), description: null, category: null,
+          visibility_scope: JSON.parse(String(params?.[4])), sla_hours: null, status: 'draft',
+          active_version_id: null, latest_version_id: null,
+          created_at: new Date('2026-08-17T00:00:00.000Z'), updated_at: new Date('2026-08-17T00:00:00.000Z'),
+        }],
+        rowCount: 1,
+      }
+    }
+    if (s.startsWith('INSERT INTO approval_template_versions')) {
+      return {
+        rows: [{
+          id: verId, template_id: tplId, version: 1, status: 'draft',
+          form_schema: JSON.parse(String(params?.[1])),
+          approval_graph: JSON.parse(String(params?.[2])),
+          created_at: new Date('2026-08-17T00:00:00.000Z'), updated_at: new Date('2026-08-17T00:00:00.000Z'),
+        }],
+        rowCount: 1,
+      }
+    }
+    if (s.startsWith('UPDATE approval_templates')) {
+      return {
+        rows: [{
+          id: tplId, key: `key-${tplId}`, name: 'Explanation Tpl', description: null, category: null,
+          visibility_scope: { type: 'all', ids: [] }, sla_hours: null, status: 'draft',
+          active_version_id: null, latest_version_id: verId,
+          created_at: new Date('2026-08-17T00:00:00.000Z'), updated_at: new Date('2026-08-17T00:00:00.000Z'),
+        }],
+        rowCount: 1,
+      }
+    }
+    throw new Error(`Unhandled query: ${s}`)
+  })
+}
+
+describe('Lock-8 L8-A explanation field contract (approval-lock8-field-vocabulary-20260817.md §1.1)', () => {
+  beforeEach(() => {
+    pgState.pool.connect.mockReset()
+    pgState.pool.query.mockReset()
+    pgState.client.query.mockReset()
+    pgState.client.release.mockReset()
+    pgState.pool.connect.mockResolvedValue(pgState.client)
+  })
+
+  const wrap = (field: Record<string, unknown>, extra: Record<string, unknown>[] = []) => ({
+    key: `exp-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+    name: 'Explanation Tpl',
+    formSchema: { fields: [field, ...extra] },
+    approvalGraph: buildRuntimeGraph(),
+  })
+  const create = async (request: unknown) => {
+    const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+    return new ApprovalProductService().createTemplate(request as never)
+  }
+
+  it('N-1 style census: the props allowlist is EXACTLY { text }', async () => {
+    const { EXPLANATION_FIELD_ALLOWED_PROP_KEYS } = await import('../../src/services/ApprovalProductService')
+    // Mutation-provable: adding/removing a member here reds this exact-equality assertion
+    // directly — the census IS the test, not a claim about it (mirrors L8-B/L8-C's own pattern).
+    expect([...EXPLANATION_FIELD_ALLOWED_PROP_KEYS].sort()).toEqual(['text'])
+  })
+
+  describe('A-1: valuelessness — required/defaultValue/options/placeholder each fail publish', () => {
+    it('required: true fails publish', async () => {
+      await expect(create(wrap({
+        id: 'note', type: 'explanation', label: '说明', required: true, props: { text: '仅供参考' },
+      }))).rejects.toThrow(/explanation cannot be required/)
+    })
+
+    it('positive control: required: true on a textarea publishes normally (rejection is type-selected)', async () => {
+      mockSuccessfulCreate('tpl-req-ctrl', 'ver-req-ctrl')
+      const result = await create(wrap({ id: 'note', type: 'textarea', label: '备注', required: true }))
+      expect(result.formSchema.fields[0].required).toBe(true)
+    })
+
+    it('a defaultValue fails publish', async () => {
+      await expect(create(wrap({
+        id: 'note', type: 'explanation', label: '说明', defaultValue: '仅供参考', props: { text: '仅供参考' },
+      }))).rejects.toThrow(/explanation cannot carry a defaultValue/)
+    })
+
+    it('positive control: a defaultValue on a textarea publishes normally', async () => {
+      mockSuccessfulCreate('tpl-dv-ctrl', 'ver-dv-ctrl')
+      const result = await create(wrap({ id: 'note', type: 'textarea', label: '备注', defaultValue: '默认值' }))
+      expect(result.formSchema.fields[0].defaultValue).toBe('默认值')
+    })
+
+    it('a placeholder fails publish', async () => {
+      await expect(create(wrap({
+        id: 'note', type: 'explanation', label: '说明', placeholder: '请输入', props: { text: '仅供参考' },
+      }))).rejects.toThrow(/explanation cannot carry a placeholder/)
+    })
+
+    it('positive control: a placeholder on a textarea publishes normally', async () => {
+      mockSuccessfulCreate('tpl-ph-ctrl', 'ver-ph-ctrl')
+      const result = await create(wrap({ id: 'note', type: 'textarea', label: '备注', placeholder: '请输入' }))
+      expect(result.formSchema.fields[0].placeholder).toBe('请输入')
+    })
+
+    it('options fails publish', async () => {
+      await expect(create(wrap({
+        id: 'note', type: 'explanation', label: '说明',
+        options: [{ label: 'A', value: 'a' }], props: { text: '仅供参考' },
+      }))).rejects.toThrow(/explanation cannot carry options/)
+    })
+
+    it('positive control: options on a select publishes normally', async () => {
+      mockSuccessfulCreate('tpl-opt-ctrl', 'ver-opt-ctrl')
+      const result = await create(wrap({
+        id: 'pick', type: 'select', label: '选择', options: [{ label: 'A', value: 'a' }],
+      }))
+      expect(result.formSchema.fields[0].options).toEqual([{ label: 'A', value: 'a' }])
+    })
+  })
+
+  describe('props.text: required + strict allowlist', () => {
+    it('a missing props.text fails publish', async () => {
+      await expect(create(wrap({ id: 'note', type: 'explanation', label: '说明' })))
+        .rejects.toThrow(/explanation props\.text is required/)
+    })
+
+    it('a blank props.text fails publish (whitespace-only is not "written")', async () => {
+      await expect(create(wrap({ id: 'note', type: 'explanation', label: '说明', props: { text: '   ' } })))
+        .rejects.toThrow(/explanation props\.text is required/)
+    })
+
+    it('rejects an unknown props key (fail-closed, mirrors record-link/date_range shape)', async () => {
+      await expect(create(wrap({
+        id: 'note', type: 'explanation', label: '说明', props: { text: '仅供参考', printable: true },
+      }))).rejects.toThrow(/explanation props may only contain/)
+    })
+
+    it('accepts and canonicalizes { text } — trimmed, no residual spread of an unknown key', async () => {
+      mockSuccessfulCreate('tpl-exp', 'ver-exp')
+      const result = await create(wrap({
+        id: 'note', type: 'explanation', label: '说明', props: { text: '  仅供参考，请如实填写  ' },
+      }))
+      const field = result.formSchema.fields[0]
+      expect(field.type).toBe('explanation')
+      expect(field.props).toEqual({ text: '仅供参考，请如实填写' })
+    })
+
+    it('a non-blank label is still required for explanation (BE requires it for EVERY field)', async () => {
+      await expect(create(wrap({ id: 'note', type: 'explanation', label: '', props: { text: '仅供参考' } })))
+        .rejects.toThrow(/label is required/)
+    })
+  })
+
+  describe('MS-4: detail-column eligibility — explanation EXCLUDED', () => {
+    it('explanation as a detail column FAILS publish', async () => {
+      await expect(create(wrap({
+        id: 'items', type: 'detail', label: '明细',
+        columns: [{ id: 'note', type: 'explanation', label: '说明', props: { text: '仅供参考' } }],
+      }))).rejects.toThrow(/type is not a valid leaf sub-field/)
+    })
+
+    it('positive control: number STAYS admitted as a detail column throughout', async () => {
+      mockSuccessfulCreate('tpl-dc-exp', 'ver-dc-exp')
+      const result = await create(wrap({
+        id: 'items', type: 'detail', label: '明细',
+        columns: [{ id: 'qty', type: 'number', label: '数量' }],
+      }))
+      expect(result.formSchema.fields[0].columns?.[0].type).toBe('number')
+    })
+  })
+
+  describe('MS-8: visibility whole-value denylist — explanation EXCLUDED', () => {
+    it('a visibilityRule referencing an explanation field is refused', async () => {
+      await expect(create(wrap(
+        { id: 'note', type: 'explanation', label: '说明', props: { text: '仅供参考' } },
+        [{ id: 'reason', type: 'text', label: '事由', visibilityRule: { fieldId: 'note', operator: 'notEmpty' } }],
+      ))).rejects.toThrow(/cannot reference an explanation field/)
+    })
+
+    it('positive control: a visibilityRule referencing a text field is admitted and round-trips', async () => {
+      mockSuccessfulCreate('tpl-vis-exp', 'ver-vis-exp')
+      const result = await create(wrap(
+        { id: 'kind', type: 'text', label: '类型' },
+        [{ id: 'reason', type: 'text', label: '事由', visibilityRule: { fieldId: 'kind', operator: 'notEmpty' } }],
+      ))
+      expect(result.formSchema.fields[1].visibilityRule).toEqual({ fieldId: 'kind', operator: 'notEmpty' })
+    })
+  })
+
+  describe('MS-10: condition-branch exclusion — explanation EXCLUDED', () => {
+    it('rejects a simple condition rule comparing an explanation field', async () => {
+      const request = {
+        key: `exp-cond-${Date.now()}`,
+        name: 'Explanation Cond',
+        formSchema: {
+          fields: [{ id: 'note', type: 'explanation', label: '说明', props: { text: '仅供参考' } }],
+        },
+        approvalGraph: {
+          nodes: [
+            { key: 'start', type: 'start', config: {} },
+            {
+              key: 'route',
+              type: 'condition',
+              config: {
+                branches: [{ edgeKey: 'edge-yes', rules: [{ fieldId: 'note', operator: 'eq', value: 'anything' }] }],
+                defaultEdgeKey: 'edge-no',
+              },
+            },
+            { key: 'yes', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['u1'] } },
+            { key: 'no', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['u1'] } },
+            { key: 'end', type: 'end', config: {} },
+          ],
+          edges: [
+            { key: 'edge-start-route', source: 'start', target: 'route' },
+            { key: 'edge-yes', source: 'route', target: 'yes' },
+            { key: 'edge-no', source: 'route', target: 'no' },
+            { key: 'edge-yes-end', source: 'yes', target: 'end' },
+            { key: 'edge-no-end', source: 'no', target: 'end' },
+          ],
+          policy: { allowRevoke: true },
+        },
+      }
+      await expect(create(request)).rejects.toThrow(/cannot reference explanation field/)
+    })
+
+    it('positive control: a simple condition rule comparing a text field is admitted', async () => {
+      mockSuccessfulCreate('tpl-cond-exp', 'ver-cond-exp')
+      const request = {
+        key: `exp-cond-ctrl-${Date.now()}`,
+        name: 'Explanation Cond Control',
+        formSchema: {
+          fields: [{ id: 'kind', type: 'text', label: '类型' }],
+        },
+        approvalGraph: {
+          nodes: [
+            { key: 'start', type: 'start', config: {} },
+            {
+              key: 'route',
+              type: 'condition',
+              config: {
+                branches: [{ edgeKey: 'edge-yes', rules: [{ fieldId: 'kind', operator: 'eq', value: 'urgent' }] }],
+                defaultEdgeKey: 'edge-no',
+              },
+            },
+            { key: 'yes', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['u1'] } },
+            { key: 'no', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['u1'] } },
+            { key: 'end', type: 'end', config: {} },
+          ],
+          edges: [
+            { key: 'edge-start-route', source: 'start', target: 'route' },
+            { key: 'edge-yes', source: 'route', target: 'yes' },
+            { key: 'edge-no', source: 'route', target: 'no' },
+            { key: 'edge-yes-end', source: 'yes', target: 'end' },
+            { key: 'edge-no-end', source: 'no', target: 'end' },
+          ],
+          policy: { allowRevoke: true },
+        },
+      }
+      const result = await create(request)
+      expect(result.formSchema.fields[0].type).toBe('text')
+    })
+  })
+})
+
+describe('Lock-8 L8-A submit-time value validation (MS-3, ApprovalGraphExecutor)', () => {
+  it('no submitted value (absent key) is accepted — the field collects nothing', () => {
+    const schema: FormSchema = {
+      fields: [{ id: 'note', type: 'explanation', label: '说明', props: { text: '仅供参考' } }],
+    }
+    expect(validateApprovalFormData(schema, {})).toEqual([])
+  })
+
+  it('ANY submitted value is rejected — an explicit "no value permitted" arm, not fail-open', () => {
+    const schema: FormSchema = {
+      fields: [{ id: 'note', type: 'explanation', label: '说明', props: { text: '仅供参考' } }],
+    }
+    expect(validateApprovalFormData(schema, { note: '我自己填的' }))
+      .toEqual(['note does not accept a submitted value'])
+    // Non-string values are rejected too — this is not a string-shape check, it is total.
+    expect(validateApprovalFormData(schema, { note: 42 }))
+      .toEqual(['note does not accept a submitted value'])
+    expect(validateApprovalFormData(schema, { note: { anything: true } }))
+      .toEqual(['note does not accept a submitted value'])
+  })
+
+  it('positive control: a textarea field in the SAME schema DOES accept and validate its value', () => {
+    const schema: FormSchema = {
+      fields: [
+        { id: 'note', type: 'explanation', label: '说明', props: { text: '仅供参考' } },
+        { id: 'reason', type: 'textarea', label: '事由' },
+      ],
+    }
+    expect(validateApprovalFormData(schema, { reason: '出差申请' })).toEqual([])
+    // A wrong-typed textarea value DOES fail — proving the positive control is a real validator,
+    // not a vacuous "always passes" path.
+    expect(validateApprovalFormData(schema, { reason: 42 as unknown as string })).toEqual(['reason must be a string'])
+  })
+})
+
+describe('Lock-8 L8-A resolveVisibilityFieldReference (BE runtime mirror)', () => {
+  const fields = [
+    { id: 'note', type: 'explanation', label: '说明', props: { text: '仅供参考' } },
+    { id: 'kind', type: 'text', label: '类型' },
+  ] as FormSchema['fields']
+
+  it('refuses a bare reference to an explanation field (null, no endpoint fallback)', () => {
+    expect(resolveVisibilityFieldReference('note', fields)).toBeNull()
+  })
+
+  it('positive control: resolves a bare reference to an ordinary text field', () => {
+    expect(resolveVisibilityFieldReference('kind', fields)).toEqual({ field: fields[1] })
+  })
+})

--- a/packages/core-backend/tests/unit/approval-lock8-explanation-field.test.ts
+++ b/packages/core-backend/tests/unit/approval-lock8-explanation-field.test.ts
@@ -363,3 +363,64 @@ describe('Lock-8 L8-A resolveVisibilityFieldReference (BE runtime mirror)', () =
     expect(resolveVisibilityFieldReference('kind', fields)).toEqual({ field: fields[1] })
   })
 })
+
+// Lock-8 L8-A gate P2-2 (fix-round hardening): `applyHandlerFieldWrites` (the ONE other form_snapshot
+// write door besides create — the create door is closed by pruneHiddenFormData + the publish gates
+// above) gives record-link/attachment an explicit APPROVAL_FIELD_WRITE_UNSUPPORTED_TYPE refusal;
+// explanation — the one type carrying no value at any time — must join that refusal or a handler
+// node with no fieldPermissions matrix entry for it (OD-L7-9 absent≡editable) would let
+// `fieldWrites: {<id>: null}` reach the in-place `form_snapshot` UPDATE, falsifying A-1's "absent
+// from formSnapshot" contract. Calls the REAL private method (TS privacy is compile-time only) with
+// a fake `client.query` mock — no live DB needed since the method's only DB access is the single
+// UPDATE this test proves never runs.
+describe('Lock-8 L8-A gate P2-2: applyHandlerFieldWrites refuses an explanation write (form_snapshot absence, A-1)', () => {
+  const formSchema: FormSchema = {
+    fields: [
+      { id: 'note', type: 'explanation', label: '说明', props: { text: '仅供参考' } },
+      { id: 'reason', type: 'text', label: '事由' },
+    ],
+  }
+  // Minimal handler-node runtime graph: NO fieldPermissions entry for either field (OD-L7-9
+  // absent≡editable), NO routing driver — the exact "reachable in default config" shape the gate
+  // finding names (APPROVAL_NODE_TYPES handler nodes are not flag-gated).
+  const runtimeGraph = {
+    nodes: [{ key: 'h1', type: 'handler', config: {} }],
+  } as never
+
+  async function callApplyHandlerFieldWrites(fieldWrites: Record<string, unknown>) {
+    const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+    const service = new ApprovalProductService()
+    const client = { query: vi.fn().mockResolvedValue({ rows: [], rowCount: 0 }) }
+    const result = (service as unknown as {
+      applyHandlerFieldWrites(
+        client: { query: typeof client.query },
+        instanceId: string,
+        nodeKey: string,
+        rawWrites: unknown,
+        context: { runtimeGraph: unknown; formSchema: FormSchema; frozenSnapshot: Record<string, unknown> },
+      ): Promise<{ changedFieldIds: string[]; revisions: unknown[] }>
+    }).applyHandlerFieldWrites(client, 'inst_1', 'h1', fieldWrites, { runtimeGraph, formSchema, frozenSnapshot: {} })
+    return { result, client }
+  }
+
+  it('a null explanation write is refused 400 APPROVAL_FIELD_WRITE_UNSUPPORTED_TYPE, with ZERO rows (the UPDATE never runs)', async () => {
+    const { result, client } = await callApplyHandlerFieldWrites({ note: null })
+    await expect(result).rejects.toMatchObject({ statusCode: 400, code: 'APPROVAL_FIELD_WRITE_UNSUPPORTED_TYPE' })
+    expect(client.query).not.toHaveBeenCalled()
+  })
+
+  it('a non-null (smuggled) explanation write is ALSO refused with the same code, not merely the null gap', async () => {
+    const { result, client } = await callApplyHandlerFieldWrites({ note: 'smuggled value' })
+    await expect(result).rejects.toMatchObject({ statusCode: 400, code: 'APPROVAL_FIELD_WRITE_UNSUPPORTED_TYPE' })
+    expect(client.query).not.toHaveBeenCalled()
+  })
+
+  it('positive control: an ORDINARY field write in the SAME fixture/node is accepted and reaches the UPDATE — proves the harness is not vacuously fail-closed for every write', async () => {
+    const { result, client } = await callApplyHandlerFieldWrites({ reason: '出差申请' })
+    await expect(result).resolves.toMatchObject({ changedFieldIds: ['reason'] })
+    expect(client.query).toHaveBeenCalledTimes(1)
+    const [sql, params] = client.query.mock.calls[0] as [string, unknown[]]
+    expect(sql).toMatch(/UPDATE approval_instances/)
+    expect(JSON.parse(String(params[1]))).toEqual({ reason: '出差申请' })
+  })
+})

--- a/packages/core-backend/tests/unit/approval-lock8-field-type-census.test.ts
+++ b/packages/core-backend/tests/unit/approval-lock8-field-type-census.test.ts
@@ -36,8 +36,16 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 //             (MS-5/MS-9 as full runtime-predicate loops; MS-6/MS-11/MS-13's label/mark maps are
 //             TypeScript-`Record<AuthorableFieldType,…>`-literal COMPILE-forced — verified by
 //             `vue-tsc -b`, not a vitest row — MS-13's palette GROUPING is the one non-compile-
-//             forced part, covered by the pre-existing forcing function
-//             `approval-form-palette-chips.spec.ts:107`, generalized rather than reinvented).
+//             forced part. It has TWO independent registration sites: the F2
+//             `ApprovalFormPalette.vue` component's exported `APPROVAL_FORM_PALETTE_GROUPS`, covered
+//             by the pre-existing forcing function `approval-form-palette-chips.spec.ts:107`; and
+//             `TemplateAuthoringView.vue`'s own separate `fieldPaletteGroups` local (the array
+//             actually shipped into the live inline editor), NOT reachable from :107 (correction,
+//             gate P2-1: an earlier version of this comment claimed :107 was "generalized" to cover
+//             both — false; deleting `explanation` from the view's own array alone left every
+//             then-reachable spec green) — covered separately by
+//             apps/web/tests/approval-form-inline-editor-extract.spec.ts's "(o) MS-13 completeness"
+//             test, which mounts the real view and queries the rendered chip DOM).
 //   COVERED here, but against the COMMITTED artifact, not a live rebuild:
 //     - MS-7  OpenAPI (dist/openapi.json)  — reads the COMMITTED `packages/openapi/dist/
 //             openapi.json` this PR regenerated (`pnpm --filter @metasheet/openapi run

--- a/packages/core-backend/tests/unit/approval-lock8-field-type-census.test.ts
+++ b/packages/core-backend/tests/unit/approval-lock8-field-type-census.test.ts
@@ -1,0 +1,364 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Lock-8 L8-A §2.1 N-1 — the mechanical census this lock names as L8-A's OWN deliverable: "one
+// exported table of field types × the sites that must carry them, with every gate iterating it...
+// adding a [new] field type with no row reds the equality test."
+//
+// HONEST SCOPE (M8 — no overclaim). MS-1 through MS-13 name thirteen site FAMILIES
+// (docs/development/approval-lock8-field-vocabulary-20260817.md §0.3). This file mechanically
+// covers the BACKEND sites that are genuinely anchorable to a real runtime artifact (not a
+// re-declared parallel list) WITHOUT mounting a browser component:
+//
+//   COVERED here, anchored on the REAL exported set/behavior:
+//     - MS-2  FORM_FIELD_TYPES            — exact-set equality against the canonical type list
+//     - MS-4  DETAIL_LEAF_FIELD_TYPES     — equals FORM_FIELD_TYPES minus the derived exclusions
+//     - MS-8  visibility whole-value gate — BEHAVIORAL, one publish attempt per canonical type
+//     - MS-10 condition-branch gate       — BEHAVIORAL, one publish attempt per canonical type
+//   Each of MS-8/MS-10 carries a completeness meta-assertion: the hand-authored expectation
+//   table's key set must equal FORM_FIELD_TYPES exactly — adding a 14th type without adding its
+//   row reds that assertion FIRST, before any behavioral row is even reached.
+//
+//   NOT mechanically covered by a runtime census row here, and why:
+//     - MS-1  FE/BE union sync            — a TypeScript union has NO runtime footprint; the
+//             real forcing function is the compiler (`Record<FormFieldType,…>` maps — see MS-11)
+//             plus this file's own MS-2/MS-4 imports, which would fail to COMPILE if a member
+//             were missing from the exported Set literal's inferred type. A regex/AST parse of
+//             the two `.ts` union declarations was deliberately NOT built — that is the
+//             source-text-assertion antipattern (feedback_source_text_assertions_are_not_behaviour
+//             .md): it would assert the TEXT says the right thing, not that anything BEHAVES
+//             differently, and buys nothing the compiler doesn't already give for free.
+//     - MS-3  submit-time value validation — pinned directly by
+//             approval-lock8-explanation-field.test.ts's own describe block (an explicit
+//             per-family arm, not a type-indexed table — MS-3's shape is "does X have an arm",
+//             which the census's exact-equality style does not fit as cleanly as a dedicated test).
+//     - MS-5/MS-6/MS-9/MS-11/MS-12/MS-13  are FRONTEND sites — see
+//             apps/web/tests/approval-lock8-field-type-census.test.ts for their FE-side coverage
+//             (MS-5/MS-9 as full runtime-predicate loops; MS-6/MS-11/MS-13's label/mark maps are
+//             TypeScript-`Record<AuthorableFieldType,…>`-literal COMPILE-forced — verified by
+//             `vue-tsc -b`, not a vitest row — MS-13's palette GROUPING is the one non-compile-
+//             forced part, covered by the pre-existing forcing function
+//             `approval-form-palette-chips.spec.ts:107`, generalized rather than reinvented).
+//   COVERED here, but against the COMMITTED artifact, not a live rebuild:
+//     - MS-7  OpenAPI (dist/openapi.json)  — reads the COMMITTED `packages/openapi/dist/
+//             openapi.json` this PR regenerated (`pnpm --filter @metasheet/openapi run
+//             generate:sdk`, verified with `guard:codegen`) and asserts `explanation` is in both
+//             `FormFieldGeneric.type`'s enum and `FormField`'s `discriminator.mapping`. This is a
+//             STALE-ARTIFACT detector, not a live-rebuild proof: no CI workflow in this repo
+//             currently runs `pnpm --filter @metasheet/openapi run build` (or `guard:codegen`)
+//             before the backend/frontend vitest suites — a PRE-EXISTING gap this file does not
+//             newly introduce or claim to close. If `base.yml` is edited again without
+//             regenerating `dist/`, THIS test reds (the committed JSON stops matching), but only
+//             because the stale committed file is what it reads — it cannot catch a base.yml edit
+//             that regenerates dist/openapi.json for something else and forgets this member.
+
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import {
+  DETAIL_LEAF_FIELD_TYPES,
+  FORM_FIELD_TYPES,
+} from '../../src/services/ApprovalProductService'
+
+const pgState = vi.hoisted(() => ({
+  client: { query: vi.fn(), release: vi.fn() },
+  pool: { query: vi.fn(), connect: vi.fn() },
+}))
+
+vi.mock('../../src/db/pg', () => ({
+  pool: pgState.pool,
+}))
+
+function normalize(sql: string): string {
+  return sql.replace(/\s+/g, ' ').trim()
+}
+
+function buildRuntimeGraph(policyOverrides?: Record<string, unknown>) {
+  return {
+    nodes: [
+      { key: 'start', type: 'start', config: {} },
+      { key: 'approval_1', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['manager-1'] } },
+      { key: 'end', type: 'end', config: {} },
+    ],
+    edges: [
+      { key: 'edge-start-approval', source: 'start', target: 'approval_1' },
+      { key: 'edge-approval-end', source: 'approval_1', target: 'end' },
+    ],
+    policy: { allowRevoke: true, ...policyOverrides },
+  }
+}
+
+function mockSuccessfulCreate(tplId: string, verId: string) {
+  pgState.client.query.mockImplementation(async (sql: string, params?: unknown[]) => {
+    const s = normalize(sql)
+    if (s === 'BEGIN' || s === 'COMMIT' || s === 'ROLLBACK') return { rows: [], rowCount: 0 }
+    if (s.startsWith('INSERT INTO approval_templates')) {
+      return {
+        rows: [{
+          id: tplId, key: String(params?.[0]), name: String(params?.[1]), description: null, category: null,
+          visibility_scope: JSON.parse(String(params?.[4])), sla_hours: null, status: 'draft',
+          active_version_id: null, latest_version_id: null,
+          created_at: new Date('2026-08-17T00:00:00.000Z'), updated_at: new Date('2026-08-17T00:00:00.000Z'),
+        }],
+        rowCount: 1,
+      }
+    }
+    if (s.startsWith('INSERT INTO approval_template_versions')) {
+      return {
+        rows: [{
+          id: verId, template_id: tplId, version: 1, status: 'draft',
+          form_schema: JSON.parse(String(params?.[1])),
+          approval_graph: JSON.parse(String(params?.[2])),
+          created_at: new Date('2026-08-17T00:00:00.000Z'), updated_at: new Date('2026-08-17T00:00:00.000Z'),
+        }],
+        rowCount: 1,
+      }
+    }
+    if (s.startsWith('UPDATE approval_templates')) {
+      return {
+        rows: [{
+          id: tplId, key: `key-${tplId}`, name: 'Census Tpl', description: null, category: null,
+          visibility_scope: { type: 'all', ids: [] }, sla_hours: null, status: 'draft',
+          active_version_id: null, latest_version_id: verId,
+          created_at: new Date('2026-08-17T00:00:00.000Z'), updated_at: new Date('2026-08-17T00:00:00.000Z'),
+        }],
+        rowCount: 1,
+      }
+    }
+    throw new Error(`Unhandled query: ${s}`)
+  })
+}
+
+const create = async (request: unknown) => {
+  const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+  return new ApprovalProductService().createTemplate(request as never)
+}
+
+/** One minimal-but-VALID top-level field of each canonical type — just enough to pass every
+ * OTHER publish check, so a create() failure in the tests below is attributable ONLY to the
+ * gate under test (visibility / condition), never an unrelated shape error. */
+function minimalField(type: string): Record<string, unknown> {
+  switch (type) {
+    case 'select':
+    case 'multi-select':
+      return { id: 'src', type, label: 'Src', options: [{ label: 'A', value: 'a' }] }
+    case 'detail':
+      return { id: 'src', type, label: 'Src', columns: [{ id: 'c1', type: 'text', label: 'C' }] }
+    case 'record-link':
+      return { id: 'src', type, label: 'Src', props: { baseId: 'base_1', sheetId: 'sheet_1' } }
+    case 'date_range':
+      return { id: 'src', type, label: 'Src', props: { dateType: 'date', startLabel: 'S', endLabel: 'E' } }
+    case 'explanation':
+      return { id: 'src', type, label: 'Src', props: { text: 'x' } }
+    default:
+      return { id: 'src', type, label: 'Src' }
+  }
+}
+
+// MS-8 expectation table (whole-value visibility dependency admission). Hand-authored ONCE, per
+// the same "N-1 style census" doctrine as the props-allowlist exact-set tests — the mutation
+// probe is deleting a row's exclusion at the real site (ApprovalProductService.ts), not editing
+// this table. Completeness (key-set === FORM_FIELD_TYPES) is asserted below.
+const MS8_VISIBILITY_ADMITTED: Readonly<Record<string, boolean>> = {
+  text: true,
+  textarea: true,
+  number: true,
+  date: true,
+  datetime: true,
+  select: true,
+  'multi-select': true,
+  user: true,
+  attachment: true,
+  detail: false,
+  'record-link': false,
+  date_range: false,
+  explanation: false,
+}
+
+// Named refusal pattern per REFUSED MS-8 type. Required so a REFUSED row's assertion can never be
+// satisfied by an unrelated crash (e.g. an unmocked DB call reached because validation silently
+// let the reference through) — `.rejects.toThrow(pattern)` fails outright if create() actually
+// RESOLVES, since every row below (admitted or not) gets a fully-wired successful-create mock.
+const MS8_REFUSAL_MESSAGE: Readonly<Record<string, RegExp>> = {
+  detail: /cannot reference a detail field/,
+  'record-link': /cannot reference a record-link field/,
+  date_range: /cannot reference a date_range field/,
+  explanation: /cannot reference an explanation field/,
+}
+
+// MS-10 expectation table (condition-branch rule admission). `detail` is TRUE here — a PRE-
+// EXISTING gap (validateNonScalarFieldsNotUsedInConditions never listed it, and no other check
+// validates a condition rule's fieldId against the schema at all), NOT something L8-A introduces
+// or is scoped to close; recorded so the table reflects reality rather than intent.
+const MS10_CONDITION_ADMITTED: Readonly<Record<string, boolean>> = {
+  text: true,
+  textarea: true,
+  number: true,
+  date: true,
+  datetime: true,
+  select: true,
+  'multi-select': true,
+  user: true,
+  attachment: true,
+  detail: true,
+  'record-link': false,
+  date_range: false,
+  explanation: false,
+}
+
+// Named refusal pattern per REFUSED MS-10 type — same rejects-must-be-attributable discipline as
+// MS8_REFUSAL_MESSAGE above.
+const MS10_REFUSAL_MESSAGE: Readonly<Record<string, RegExp>> = {
+  'record-link': /cannot reference record-link field/,
+  date_range: /cannot reference date_range field/,
+  explanation: /cannot reference explanation field/,
+}
+
+describe('Lock-8 L8-A field-type census (N-1) — backend sites', () => {
+  beforeEach(() => {
+    pgState.pool.connect.mockReset()
+    pgState.pool.query.mockReset()
+    pgState.client.query.mockReset()
+    pgState.client.release.mockReset()
+    pgState.pool.connect.mockResolvedValue(pgState.client)
+  })
+
+  it('MS-2: FORM_FIELD_TYPES is exactly the 13 canonical types (mutation: drop one → reds directly)', () => {
+    expect([...FORM_FIELD_TYPES].sort()).toEqual([
+      'attachment', 'date', 'date_range', 'datetime', 'detail', 'explanation',
+      'multi-select', 'number', 'record-link', 'select', 'text', 'textarea', 'user',
+    ].sort())
+  })
+
+  it('MS-4: DETAIL_LEAF_FIELD_TYPES is DERIVED — exactly FORM_FIELD_TYPES minus the excluded set', () => {
+    const expected = new Set(
+      [...FORM_FIELD_TYPES].filter(
+        (type) => type !== 'detail' && type !== 'record-link' && type !== 'date_range' && type !== 'explanation',
+      ),
+    )
+    expect([...DETAIL_LEAF_FIELD_TYPES].sort()).toEqual([...expected].sort())
+    // Anchored, not re-declared: the exclusion set itself, named explicitly (so a mutation
+    // removing ONLY 'explanation' from the real filter is caught even though the derivation
+    // above would otherwise recompute the SAME (wrong) answer from a stale local copy).
+    expect(DETAIL_LEAF_FIELD_TYPES.has('detail')).toBe(false)
+    expect(DETAIL_LEAF_FIELD_TYPES.has('record-link')).toBe(false)
+    expect(DETAIL_LEAF_FIELD_TYPES.has('date_range')).toBe(false)
+    expect(DETAIL_LEAF_FIELD_TYPES.has('explanation')).toBe(false)
+    expect(DETAIL_LEAF_FIELD_TYPES.has('text')).toBe(true)
+  })
+
+  describe('MS-8: visibility whole-value dependency admission, one publish attempt per type', () => {
+    it('completeness: the expectation table covers EXACTLY the canonical type set', () => {
+      // Adding a 14th type to FORM_FIELD_TYPES with no row here reds THIS assertion first.
+      expect(Object.keys(MS8_VISIBILITY_ADMITTED).sort()).toEqual([...FORM_FIELD_TYPES].sort())
+    })
+
+    for (const type of [...FORM_FIELD_TYPES].sort()) {
+      const admitted = MS8_VISIBILITY_ADMITTED[type]
+      it(`${type}: ${admitted ? 'ADMITTED' : 'REFUSED'} as a bare visibility dependency`, async () => {
+        const request = {
+          key: `census-vis-${type}-${Date.now()}`,
+          name: 'Census Visibility',
+          formSchema: {
+            fields: [
+              minimalField(type),
+              { id: 'dep', type: 'text', label: 'Dep', visibilityRule: { fieldId: 'src', operator: 'notEmpty' } },
+            ],
+          },
+          approvalGraph: buildRuntimeGraph(),
+        }
+        // ALWAYS wire a successful-create mock, for BOTH admitted and refused rows: a REFUSED
+        // row must fail because the VALIDATOR rejected it, never because an unmocked DB call
+        // crashed after validation silently let a mutated reference through — that crash would
+        // ALSO satisfy a bare `.rejects.toThrow()` and hide the very half-registration this
+        // census exists to catch (mutation-verified below).
+        mockSuccessfulCreate(`tpl-vis-${type}`, `ver-vis-${type}`)
+        if (admitted) {
+          const result = await create(request)
+          expect(result.formSchema.fields[1].visibilityRule).toEqual({ fieldId: 'src', operator: 'notEmpty' })
+        } else {
+          const pattern = MS8_REFUSAL_MESSAGE[type]
+          expect(pattern, `missing MS8_REFUSAL_MESSAGE row for ${type}`).toBeDefined()
+          await expect(create(request)).rejects.toThrow(pattern)
+        }
+      })
+    }
+  })
+
+  describe('MS-10: condition-branch rule admission, one publish attempt per type', () => {
+    it('completeness: the expectation table covers EXACTLY the canonical type set', () => {
+      expect(Object.keys(MS10_CONDITION_ADMITTED).sort()).toEqual([...FORM_FIELD_TYPES].sort())
+    })
+
+    for (const type of [...FORM_FIELD_TYPES].sort()) {
+      const admitted = MS10_CONDITION_ADMITTED[type]
+      it(`${type}: ${admitted ? 'ADMITTED' : 'REFUSED'} as a condition-branch rule field`, async () => {
+        const request = {
+          key: `census-cond-${type}-${Date.now()}`,
+          name: 'Census Condition',
+          formSchema: { fields: [minimalField(type)] },
+          approvalGraph: {
+            nodes: [
+              { key: 'start', type: 'start', config: {} },
+              {
+                key: 'route',
+                type: 'condition',
+                config: {
+                  branches: [{ edgeKey: 'edge-yes', rules: [{ fieldId: 'src', operator: 'eq', value: 'x' }] }],
+                  defaultEdgeKey: 'edge-no',
+                },
+              },
+              { key: 'yes', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['u1'] } },
+              { key: 'no', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['u1'] } },
+              { key: 'end', type: 'end', config: {} },
+            ],
+            edges: [
+              { key: 'edge-start-route', source: 'start', target: 'route' },
+              { key: 'edge-yes', source: 'route', target: 'yes' },
+              { key: 'edge-no', source: 'route', target: 'no' },
+              { key: 'edge-yes-end', source: 'yes', target: 'end' },
+              { key: 'edge-no-end', source: 'no', target: 'end' },
+            ],
+            policy: { allowRevoke: true },
+          },
+        }
+        // Same discipline as MS-8 above: always wire a successful-create mock so a REFUSED row's
+        // rejection is attributable to the VALIDATOR, never an unmocked-DB crash.
+        mockSuccessfulCreate(`tpl-cond-${type}`, `ver-cond-${type}`)
+        if (admitted) {
+          const result = await create(request)
+          expect(result.formSchema.fields[0].type).toBe(type)
+        } else {
+          const pattern = MS10_REFUSAL_MESSAGE[type]
+          expect(pattern, `missing MS10_REFUSAL_MESSAGE row for ${type}`).toBeDefined()
+          await expect(create(request)).rejects.toThrow(pattern)
+        }
+      })
+    }
+  })
+})
+
+describe('Lock-8 L8-A MS-7: OpenAPI dist/openapi.json (stale-artifact detector, see file-header note)', () => {
+  const openapiJsonPath = join(__dirname, '../../../openapi/dist/openapi.json')
+  const openapi = JSON.parse(readFileSync(openapiJsonPath, 'utf-8')) as {
+    components: {
+      schemas: {
+        FormFieldGeneric: { properties: { type: { enum: string[] } } }
+        FormField: { discriminator: { mapping: Record<string, string> } }
+      }
+    }
+  }
+
+  it('FormFieldGeneric.type enum contains explanation', () => {
+    expect(openapi.components.schemas.FormFieldGeneric.properties.type.enum).toContain('explanation')
+  })
+
+  it('FormField discriminator.mapping routes explanation to FormFieldGeneric', () => {
+    expect(openapi.components.schemas.FormField.discriminator.mapping.explanation)
+      .toBe('#/components/schemas/FormFieldGeneric')
+  })
+
+  it('positive control: date_range (the prior family) is ALSO present — proves this reads a real, non-empty artifact', () => {
+    expect(openapi.components.schemas.FormFieldGeneric.properties.type.enum).toContain('date_range')
+    expect(openapi.components.schemas.FormField.discriminator.mapping.date_range)
+      .toBe('#/components/schemas/FormFieldGeneric')
+  })
+})

--- a/packages/openapi/dist-sdk/index.d.ts
+++ b/packages/openapi/dist-sdk/index.d.ts
@@ -16514,7 +16514,7 @@ export interface components {
              * @description discriminator enum property added by openapi-typescript
              * @enum {string}
              */
-            type: "text" | "textarea" | "number" | "date" | "datetime" | "select" | "multi-select" | "user" | "attachment" | "detail" | "date_range";
+            type: "text" | "textarea" | "number" | "date" | "datetime" | "select" | "multi-select" | "user" | "attachment" | "detail" | "date_range" | "explanation";
             label: string;
             required?: boolean;
             placeholder?: string;

--- a/packages/openapi/dist/combined.openapi.yml
+++ b/packages/openapi/dist/combined.openapi.yml
@@ -4292,6 +4292,7 @@ components:
             - attachment
             - detail
             - date_range
+            - explanation
         label:
           type: string
         required:
@@ -4376,6 +4377,7 @@ components:
           attachment: '#/components/schemas/FormFieldGeneric'
           detail: '#/components/schemas/FormFieldGeneric'
           date_range: '#/components/schemas/FormFieldGeneric'
+          explanation: '#/components/schemas/FormFieldGeneric'
     FormSchema:
       type: object
       properties:

--- a/packages/openapi/dist/openapi.json
+++ b/packages/openapi/dist/openapi.json
@@ -5803,7 +5803,8 @@
               "user",
               "attachment",
               "detail",
-              "date_range"
+              "date_range",
+              "explanation"
             ]
           },
           "label": {
@@ -5914,7 +5915,8 @@
             "user": "#/components/schemas/FormFieldGeneric",
             "attachment": "#/components/schemas/FormFieldGeneric",
             "detail": "#/components/schemas/FormFieldGeneric",
-            "date_range": "#/components/schemas/FormFieldGeneric"
+            "date_range": "#/components/schemas/FormFieldGeneric",
+            "explanation": "#/components/schemas/FormFieldGeneric"
           }
         }
       },

--- a/packages/openapi/dist/openapi.yaml
+++ b/packages/openapi/dist/openapi.yaml
@@ -4292,6 +4292,7 @@ components:
             - attachment
             - detail
             - date_range
+            - explanation
         label:
           type: string
         required:
@@ -4376,6 +4377,7 @@ components:
           attachment: '#/components/schemas/FormFieldGeneric'
           detail: '#/components/schemas/FormFieldGeneric'
           date_range: '#/components/schemas/FormFieldGeneric'
+          explanation: '#/components/schemas/FormFieldGeneric'
     FormSchema:
       type: object
       properties:

--- a/packages/openapi/src/base.yml
+++ b/packages/openapi/src/base.yml
@@ -3688,7 +3688,7 @@ components:
           type: string
         type:
           type: string
-          enum: [text, textarea, number, date, datetime, select, multi-select, user, attachment, detail, date_range]
+          enum: [text, textarea, number, date, datetime, select, multi-select, user, attachment, detail, date_range, explanation]
         label:
           type: string
         required:
@@ -3765,6 +3765,7 @@ components:
           attachment: '#/components/schemas/FormFieldGeneric'
           detail: '#/components/schemas/FormFieldGeneric'
           date_range: '#/components/schemas/FormFieldGeneric'
+          explanation: '#/components/schemas/FormFieldGeneric'
     FormSchema:
       type: object
       properties:


### PR DESCRIPTION
## Summary

Implements **Lock-8 L8-A — `explanation` (说明)**, a DISPLAY-ONLY approval form field type, per the RATIFIED `docs/development/approval-lock8-field-vocabulary-20260817.md` §1.1 (OD-L8-2 display-only, OD-L8-3(a) `props.text` carrier). Follows the `date_range` (#4964) registration pattern site-for-site: MS-1..MS-13 (Lock-8 §0.3's thirteen hand-maintained site families), plus delivers the MS-1..13 mechanical census the lock names as L8-A's own deliverable (§2.1).

**Contract:** `explanation` collects NO value. `required`/`defaultValue`/`options`/`placeholder` are all refused at publish (A-1); it never enters `formSnapshot` or FWB source candidates; excluded from detail columns (MS-4/MS-5); never a whole-value visibility/condition dependency (MS-8/MS-9/MS-10) — it has no value to compare.

## Registration sites (mirrors #4964's site list)

- **MS-1** unions — `apps/web/src/types/approval.ts`, `packages/core-backend/src/types/approval-product.ts`
- **MS-2** BE `FORM_FIELD_TYPES` (now exported) + new `EXPLANATION_FIELD_ALLOWED_PROP_KEYS` strict allowlist (`{ text }` only, mirrors record-link's fail-closed shape)
- **MS-3** explicit `validateFieldType` arm — "does not accept a submitted value" (not the fail-open `default: return null`)
- **MS-4/MS-5** detail-leaf exclusion — BE `DETAIL_LEAF_FIELD_TYPES` (now exported) filter extended; FE explicit list left untouched (correct by omission). No separate `nested` guard added (unlike record-link/date_range) — documented why in-line, so there's no F3-style pre-emption ambiguity to correct later.
- **MS-6** FE authorable-type registries (`templateAuthoring.ts` `AUTHORABLE_FIELD_TYPES`, `approvalFormCommands.ts` `FIELD_LABELS`)
- **MS-7** OpenAPI (`FormFieldGeneric` enum + `discriminator.mapping`; `dist`/`dist-sdk` regenerated; `guard:codegen` passes)
- **MS-8/MS-9** whole-value visibility/condition denylist on BOTH sides — BE `normalizeFormFieldVisibilityRule` + `validateNonScalarFieldsNotUsedInConditions`; FE `isSelectableConditionOrVisibilityDependencyType` + `conditionEdit.ts` (rule-mode AND formula-mode) + the shared `resolveVisibilityFieldReference` mirror (BE + FE). No endpoint fallback (unlike `date_range`) — the exclusion is total.
- **MS-10** condition-branch exclusion, same mechanism as MS-8/9
- **MS-11** label maps — `TemplateDetailView.vue` (compile-forced `Record<FormFieldType,…>`), `TemplateAuthoringView.vue`'s own copy, `ApprovalFormPalette.vue`, `approvalFormCommands.ts`
- **MS-12** display/prefill — `ApprovalNewView.vue` fill-view arm (renders `props.text`, no `v-model`); `detailField.ts` `buildDisplayFields` renders `props.text` from the **frozen schema** (never `formSnapshot`), gated on the field's own `visibilityRule` evaluated against the snapshot — a hidden explanation renders nothing, same as every other type's snapshot-membership gate; `summaryFields` excludes it; `prefillFromSnapshot.ts` never prefills it
- **MS-13** palette chip (其他 group) + `ApprovalFormInlineEditor.vue` inline `props.text` textarea control (必填/占位文本 controls hidden for explanation, A-1)
- **FWB source exclusion** — `templateSchemaToFwbFields` (the ONE FE site listing mapping-picker candidates; the BE has no source-field-type check at all per Lock-8 §0's own "Unverified" note, so this FE-side fix is the actual closure)
- **`ApprovalFormBuilder.vue`** (F2, now landed on main) — excluded from its own `visibilityOptions` predicate too. `date_range` is *not* excluded there — a pre-existing gap this slice does not fix (documented in-place, not silently left unexplained).

## Palette group (Lock-8 §2.6)

Placed in the **其他** group in both `ApprovalFormPalette.vue` and `TemplateAuthoringView.vue`'s independent copy. Lock-8 §2.6 records this as needing an **owner decision**, not yet a ratified OD-L8-3 group — this is a **reversible presentation choice** (goal-set provenance, 2026-08-17), recorded as a one-line row in `docs/development/approval-parity-execution-ledger-20260817.md` §3 Decision ledger.

## N-1 mechanical census (honest scope, no overclaim)

Two new test files, each anchored on a **real exported set/predicate/behavior** — never a re-declared parallel list:

- **Covered as a genuine runtime census row:** MS-2/MS-4 (BE, Set equality), MS-8/MS-10 (BE, full 13-canonical-type behavioral publish loop, completeness meta-check, **named refusal-message assertions** so an unmocked-DB crash can never masquerade as a validator rejection — this exact failure mode was caught and fixed during development, see mutation log below), MS-5/MS-9 (FE, full predicate loop + completeness meta-check), MS-7 (reads the committed `dist/openapi.json` — a stale-artifact detector, not a live-rebuild proof; no CI workflow in this repo currently runs the openapi build before vitest, a pre-existing gap not newly introduced here).
- **Not a runtime census row, and why (documented in both files' headers):** MS-1 (TS unions have no runtime footprint — compile-forced via MS-11's `Record<FormFieldType,…>` maps, verified by `tsc`/`vue-tsc`, not vitest); MS-3 (pinned by a dedicated describe block, not a type-indexed table — its shape doesn't fit exact-equality cleanly); MS-6/MS-11/MS-13's label maps (compile-forced literals); MS-13's palette *grouping* (the one non-compile-forced part) — ~~reuses the pre-existing forcing function `approval-form-palette-chips.spec.ts:107` rather than reinventing it~~ **RETRACTED, see Fix-round section below: `:107` only ever covered `ApprovalFormPalette.vue`'s array; `TemplateAuthoringView.vue`'s independent copy was unguarded until the fix-round.**

**Mutation-verified** (cp-backup + sha256-verified restore, never `git checkout --`):
- BE census reds exactly on the `explanation` row when the visibility-denylist block is removed (first attempt used a bare `.rejects.toThrow()` with no message match, which was **false-green** — an unmocked DB call crashed with an unrelated error and still "passed"; fixed by always wiring a successful-create mock plus named refusal-message regexes, then re-verified the mutation reds correctly).
- FE census + the dedicated `approval-explanation-field.test.ts` predicate test both red when `isSelectableConditionOrVisibilityDependencyType`'s exclusion is removed.
- `buildDisplayFields`'s visibility gate reds (both directions) when the gate is removed — the advisor flagged this exact risk (an explanation hidden by its own `visibilityRule` must not render anyway) before it shipped.

## Tests

- Registration completeness (drop-from-one-site style, sampled across BE + FE sites)
- Display-only fail-closed set: cannot be required / detail column / condition driver / FWB source / value carrier — each with a positive control (textarea/text/number staying admitted)
- `props.text` round-trip + strict allowlist (unknown key fails publish)
- Renders to requester (fill view) AND approver (detail view, shared `buildDisplayFields`)
- MS-1..13 census with mutation proof of catching a half-registration

## House rules followed

Isolated worktree from a fresh `origin/main` fetch (confirmed HEAD == `origin/main` before branching). Every mutation probe: `cp` backup + `sha256sum` byte-identical restore, never `git checkout --`. Positive controls on every "asserts X does not happen." No raw control bytes (`source-files-no-raw-control-bytes.test.ts` passes). No new date-parsing site (`source-files-hourcycle-parsing-guard.test.ts` passes unchanged, h24 `KNOWN_SITES` untouched). No closing keywords. Values-free client errors (publish refusals stay in the existing `formSchema.fields[${index}] …` index-only form; `props.text` is never interpolated into an error/diff/read-only-reason string). Conventional commit. No action verb added, no `APPROVAL_SCHEMA_BOOTSTRAP_VERSION` bump — P26/collector/admin-jump pinned copies unaffected.

**Deferred/out of scope:** F2 `ApprovalFormFieldInspector.vue` has no per-type props editor for ANY type (record-link/date_range/number all skip it too — matches precedent, not newly deferred here). `date_range`'s own pre-existing gap in `ApprovalFormBuilder.vue`'s `visibilityOptions` predicate (not excluding it) is documented but not fixed — out of this slice's charter. OpenAPI `guard:codegen` isn't wired into any CI workflow today (pre-existing gap, verified manually here, not newly introduced).

## Verification

- Backend `tsc --noEmit`: clean
- Frontend `vue-tsc -b --force`: clean
- `packages/openapi`: `generate:sdk` + `guard:codegen` both pass
- New/touched test files: all green (see commit message for full breakdown)
- Full `apps/web/scripts/run-required-web-tests.sh`: green, aside from a handful of unrelated `multitable-workbench-permission-wiring` / `public-multitable-form` / `fwb-rule-authoring` (DingTalk-flow) specs that time out only under full-suite resource pressure in this sandbox — each confirmed to pass cleanly in isolation, and none is touched by this diff (`fwbRuleAuthoring.ts`'s own `.spec.ts` file, `fwb-rule-authoring.spec.ts`, passes 18/19 in isolation with the 19th passing alone via `-t` filter at 3.1s vs the 5s budget — a timing flake, not a logic failure).
- Full backend `tests/unit`: green aside from a pre-existing `REPO_ROOT_AMBIGUOUS` artifact from this sandbox's nested-worktree path structure (`.claude/worktrees/…` living inside the parent checkout, both containing `packages/core-backend/package.json`) — reproduces identically in isolation, unrelated to this diff, affects only `attendance-w6-*`/`plm-disable-routes` files this PR never touches.

Rebased onto current `origin/main` (`d002b1883a`, includes #4965/#4966) immediately before push; #4967 was still open at push time and this branch does not depend on it.

## Fix-round (adversarial gate: 0 P1 / 2 P2)

Both P2s closed, each with a positive mutation-proven test (cp-backup + sha256-verified restore; every mutation re-verified with the WHOLE containing spec file unfiltered, not `-t`, to confirm it reds ONLY the intended test):

- **P2-1** — `TemplateAuthoringView.vue`'s independent `fieldPaletteGroups`/`conditionFieldOptions`/`visibilityFieldOptions`/`invalidateStaleRecordLinkDependencies` were entirely unguarded (deleting this PR's own `explanation` guard from any of the four sites left every reachable spec green). **This retracts the "reuses `:107`" / "census-checks this file's set" claims above and in both `templateAuthoring`/`approval-lock8-field-type-census` test-file headers — those claims were false; `:107` and the BE/FE census files only ever read `ApprovalFormPalette.vue`'s `APPROVAL_FORM_PALETTE_GROUPS`, never this view's own copy.** Fixed by adding four tests against the REAL mounted view (not duplicated literals): a DOM-chip completeness census for `fieldPaletteGroups` (generalizes `:107`'s pattern to this second array), an `invalidateStaleRecordLinkDependencies` retype-to-explanation case (mirrors the pre-existing record-link test), and `visibilityFieldOptions`/`conditionFieldOptions` exclusion tests (mirror the existing `date_range` OD-L8-5(a)/(c) pattern). Source-comment claims in `TemplateAuthoringView.vue` and both census test files corrected in place.
- **P2-2** — `applyHandlerFieldWrites` (`ApprovalProductService.ts`) refused `record-link`/`attachment` handler-node field writes but not `explanation`, so `fieldWrites: {<explanationId>: null}` at a handler node with no matrix entry (OD-L7-9 absent≡editable) reached the in-place `form_snapshot` UPDATE, falsifying A-1's "absent from formSnapshot" contract. Fixed by adding `explanation` to the same refusal arm. New unit-level tests call the real private method directly (TS privacy is compile-time only) with a fake `client.query` mock — no DB needed, since the method's only DB access is the one UPDATE the tests prove never runs for `explanation` (null AND non-null payloads both refused; positive control proves an ordinary field write still reaches the UPDATE in the same fixture). This is unit-level at the write door, not an end-to-end `POST .../handle` exercise — the gate had already proven handler-node reachability independently.

Re-verified after the fix-round: backend `tsc --noEmit` clean; frontend `vue-tsc -b --force` clean; full `run-required-web-tests.sh` green (368 files / 4630 tests, Node 20.20.2); no closing keywords; no raw control bytes; `plugin-tests.yml` byte-identical to `main`; `h24` `KNOWN_SITES` untouched; no `package.json` change. Rebased twice onto `origin/main` as it advanced during this round (last rebase base: `680e93c018`, an unrelated concurrent attendance commit — verified zero file overlap with this diff before and after rebasing).

No P3/NIT items from the gate were in scope for this round (0 P1 + 2 P2 only) — they remain as the gate documented them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

