### PR TITLE
fix(ops): C1/C2/C3 evidence reaches the legacy control org — dual-regime Q1/Q2, closed-set Q3, Q2b alert

### DIFF
--- a/scripts/ops/attendance-staging-window-runner-remote.sh
+++ b/scripts/ops/attendance-staging-window-runner-remote.sh
@@ -2405,7 +2405,7 @@ action_soak_status() {
   soak_status_scalar "[Q1]_clean_punch_total_cumulative" \
     "SELECT (SELECT count(DISTINCT op.operation_id) FROM attendance_result_operations op JOIN attendance_record_calculations c ON c.org_id = op.org_id AND c.operation_id = op.operation_id WHERE op.org_id IN ('${SOAK_ORG1}','${SOAK_ORG2}','${SOAK_ORG3}') AND op.entrypoint = 'live_punch' AND op.state = 'completed' AND op.created_at >= '${window_start}'::timestamptz AND op.created_at < now() AND c.calculation_kind = 'calculation' AND c.outcome = 'completed' AND (c.shadow_diff_code IS NULL OR c.shadow_diff_code = 'equal')) + (SELECT count(*) FROM attendance_records r WHERE r.org_id IN ('${SOAK_ORG1}','${SOAK_ORG2}','${SOAK_ORG3}') AND NOT EXISTS (SELECT 1 FROM attendance_calculation_rollout_state s WHERE s.org_id = r.org_id AND s.state <> 'legacy') AND EXISTS (SELECT 1 FROM users u WHERE u.id = r.user_id AND u.username LIKE '${SOAK_USER_PREFIX}%') AND r.first_in_at IS NOT NULL AND r.last_out_at IS NOT NULL AND r.created_at >= '${window_start}'::timestamptz AND r.created_at < now());" >/dev/null
   soak_status_rows "[Q2] per-org clean punches (cumulative; BOTH regimes; weakest org first)" \
-    "SELECT org_id, sum(cnt)::int AS clean_punch_count FROM ( SELECT c.org_id, count(DISTINCT op.operation_id) AS cnt FROM attendance_result_operations op JOIN attendance_record_calculations c ON c.org_id = op.org_id AND c.operation_id = op.operation_id WHERE op.org_id IN ('${SOAK_ORG1}','${SOAK_ORG2}','${SOAK_ORG3}') AND op.entrypoint = 'live_punch' AND op.state = 'completed' AND op.created_at >= '${window_start}'::timestamptz AND op.created_at < now() AND c.calculation_kind = 'calculation' AND c.outcome = 'completed' AND (c.shadow_diff_code IS NULL OR c.shadow_diff_code = 'equal') GROUP BY c.org_id UNION ALL SELECT r.org_id, count(*) FROM attendance_records r WHERE r.org_id IN ('${SOAK_ORG1}','${SOAK_ORG2}','${SOAK_ORG3}') AND NOT EXISTS (SELECT 1 FROM attendance_calculation_rollout_state s WHERE s.org_id = r.org_id AND s.state <> 'legacy') AND EXISTS (SELECT 1 FROM users u WHERE u.id = r.user_id AND u.username LIKE '${SOAK_USER_PREFIX}%') AND r.first_in_at IS NOT NULL AND r.last_out_at IS NOT NULL AND r.created_at >= '${window_start}'::timestamptz AND r.created_at < now() GROUP BY r.org_id ) both_regimes GROUP BY org_id ORDER BY clean_punch_count ASC;"
+    "SELECT target.org_id, COALESCE(sum(cnt), 0)::int AS clean_punch_count FROM (VALUES ('${SOAK_ORG1}'),('${SOAK_ORG2}'),('${SOAK_ORG3}')) AS target(org_id) LEFT JOIN ( SELECT c.org_id, count(DISTINCT op.operation_id) AS cnt FROM attendance_result_operations op JOIN attendance_record_calculations c ON c.org_id = op.org_id AND c.operation_id = op.operation_id WHERE op.org_id IN ('${SOAK_ORG1}','${SOAK_ORG2}','${SOAK_ORG3}') AND op.entrypoint = 'live_punch' AND op.state = 'completed' AND op.created_at >= '${window_start}'::timestamptz AND op.created_at < now() AND c.calculation_kind = 'calculation' AND c.outcome = 'completed' AND (c.shadow_diff_code IS NULL OR c.shadow_diff_code = 'equal') GROUP BY c.org_id UNION ALL SELECT r.org_id, count(*) FROM attendance_records r WHERE r.org_id IN ('${SOAK_ORG1}','${SOAK_ORG2}','${SOAK_ORG3}') AND NOT EXISTS (SELECT 1 FROM attendance_calculation_rollout_state s WHERE s.org_id = r.org_id AND s.state <> 'legacy') AND EXISTS (SELECT 1 FROM users u WHERE u.id = r.user_id AND u.username LIKE '${SOAK_USER_PREFIX}%') AND r.first_in_at IS NOT NULL AND r.last_out_at IS NOT NULL AND r.created_at >= '${window_start}'::timestamptz AND r.created_at < now() GROUP BY r.org_id ) both_regimes ON both_regimes.org_id = target.org_id GROUP BY target.org_id ORDER BY clean_punch_count ASC;"
   soak_status_rows "[Q3] org/posture classification (three-posture buckets; investigate any 'unclassified')" \
     "SELECT target.org_id, COALESCE(w4.state, 'legacy') AS w4_posture, COALESCE(w7.state, 'off') AS w7_posture, CASE WHEN COALESCE(w4.state,'legacy') = 'legacy' AND COALESCE(w7.state,'off') = 'off' THEN 'legacy_only' WHEN COALESCE(w4.state,'legacy') <> 'legacy' AND COALESCE(w7.state,'off') = 'off' THEN 'w4_only_legacy_arm' WHEN COALESCE(w7.state,'off') IN ('group_shadow','group_eligible','group_authoritative') THEN 'both_machines_group_arm' WHEN COALESCE(w7.state,'off') = 'suspended' THEN 'w7_suspended' ELSE 'unclassified' END AS soak_posture_bucket FROM (VALUES ('${SOAK_ORG1}'),('${SOAK_ORG2}'),('${SOAK_ORG3}')) AS target(org_id) LEFT JOIN attendance_calculation_rollout_state w4 ON w4.org_id = target.org_id LEFT JOIN attendance_calculation_context_source_state w7 ON w7.org_id = target.org_id ORDER BY soak_posture_bucket, target.org_id;"
   soak_status_scalar "[Q4a]_w4_legacy_arm_clean_punches_cumulative" \
@@ -2436,11 +2436,28 @@ action_soak_status() {
   for org in "$SOAK_ORG1" "$SOAK_ORG2" "$SOAK_ORG3"; do
     ctrl_state="$(soak_psql_ta "SELECT COALESCE((SELECT state FROM attendance_calculation_rollout_state WHERE org_id = '${org}'), 'legacy');")"
     if [[ "$ctrl_state" == "legacy" ]]; then
+      # Byte-neutrality = the W4 CALCULATION machinery never touched the org. An operation
+      # row with accepted_write_posture='legacy_projection_only' is the RULED ledger of a
+      # legacy write (boundary seals one per punch, resolved_calculation_id NULL, zero calc
+      # rows — pinned by attendance-w4c2-live-scheduled-boundary.db.test.ts) and is NOT
+      # contamination; #4975 gate P1 reproduced 60 such rows on the control org. Count calc
+      # rows plus only NON-legacy-posture ops (NULL posture is anomalous => counted).
       ctrl_rows="$(soak_status_scalar "[Q2b]_legacy_control_w4_rows_${org:0:8}" \
-        "SELECT (SELECT count(*) FROM attendance_record_calculations WHERE org_id = '${org}') + (SELECT count(*) FROM attendance_result_operations WHERE org_id = '${org}');")"
+        "SELECT (SELECT count(*) FROM attendance_record_calculations WHERE org_id = '${org}') + (SELECT count(*) FROM attendance_result_operations WHERE org_id = '${org}' AND COALESCE(accepted_write_posture, '') <> 'legacy_projection_only');")"
       [[ "$ctrl_rows" == "0" ]] || alerts+=("Q2b_legacy_control_w4_rows_${org:0:8}=${ctrl_rows}")
     fi
   done
+
+  # --- [Q3b] posture-constancy guard (#4975 gate P2-2): the dual-regime counters assume
+  # each config org's posture is CONSTANT in-window (walks are seed-time acts). A W4 row in
+  # state 'legacy' with a non-NULL prior_state is a ROLLBACK (shadow->legacy is a legal
+  # transition) — its history double-counts and Q2b false-alarms; any state outside this
+  # soak's plan (legacy|shadow) — e.g. 'suspended' — makes the org invisible to BOTH
+  # regimes. Either voids the counting assumptions => mechanical alert.
+  local pc_bad
+  pc_bad="$(soak_psql_ta "SELECT count(*) FROM attendance_calculation_rollout_state WHERE org_id IN ('${SOAK_ORG1}','${SOAK_ORG2}','${SOAK_ORG3}') AND (state NOT IN ('legacy','shadow') OR (state = 'legacy' AND prior_state IS NOT NULL));")"
+  echo "[Q3b]_posture_constancy_violations=${pc_bad}" >> "$SOAK_STATUS_FILE"
+  [[ "$pc_bad" == "0" ]] || alerts+=("Q3b_posture_constancy_violations=${pc_bad}")
 
   # --- per-org read set ------------------------------------------------------------------
   local org8

--- a/scripts/ops/attendance-staging-window-runner-remote.sh
+++ b/scripts/ops/attendance-staging-window-runner-remote.sh
@@ -2393,12 +2393,21 @@ action_soak_status() {
   } >> "$SOAK_STATUS_FILE"
 
   # --- cumulative count criteria (C1-C4) -------------------------------------------------
+  # [Q1]/[Q2] count BOTH regimes (post-merge review P1: the W4-side join is structurally
+  # empty for a legacy_only org, so C1/C2 evidence was unreachable for the control arm):
+  #  - W4-postured orgs: DISTINCT clean operations (calc completed, diff NULL|equal) — the
+  #    converged unit (a transient in-only mismatch row keeps its op out until it converges);
+  #  - legacy-postured orgs (rollout row absent or state='legacy'): COMPLETED PAIR DAYS —
+  #    attendance_records with BOTH boundaries set, created in-window, synthetic-family
+  #    users only — the same one-per-user-per-day converged unit in the regime that org
+  #    actually runs. Orgs are the config CLOSED SET; posture is read at query time (this
+  #    soak's postures are constant in-window by design — org walks are seed-time acts).
   soak_status_scalar "[Q1]_clean_punch_total_cumulative" \
-    "SELECT count(DISTINCT op.operation_id) FROM attendance_result_operations op JOIN attendance_record_calculations c ON c.org_id = op.org_id AND c.operation_id = op.operation_id WHERE op.entrypoint = 'live_punch' AND op.state = 'completed' AND op.created_at >= '${window_start}'::timestamptz AND op.created_at < now() AND c.calculation_kind = 'calculation' AND c.outcome = 'completed' AND (c.shadow_diff_code IS NULL OR c.shadow_diff_code = 'equal');" >/dev/null
-  soak_status_rows "[Q2] per-org clean punches (cumulative; weakest org first)" \
-    "SELECT c.org_id, count(DISTINCT op.operation_id) AS clean_punch_count FROM attendance_result_operations op JOIN attendance_record_calculations c ON c.org_id = op.org_id AND c.operation_id = op.operation_id WHERE op.entrypoint = 'live_punch' AND op.state = 'completed' AND op.created_at >= '${window_start}'::timestamptz AND op.created_at < now() AND c.calculation_kind = 'calculation' AND c.outcome = 'completed' AND (c.shadow_diff_code IS NULL OR c.shadow_diff_code = 'equal') GROUP BY c.org_id ORDER BY clean_punch_count ASC;"
+    "SELECT (SELECT count(DISTINCT op.operation_id) FROM attendance_result_operations op JOIN attendance_record_calculations c ON c.org_id = op.org_id AND c.operation_id = op.operation_id WHERE op.org_id IN ('${SOAK_ORG1}','${SOAK_ORG2}','${SOAK_ORG3}') AND op.entrypoint = 'live_punch' AND op.state = 'completed' AND op.created_at >= '${window_start}'::timestamptz AND op.created_at < now() AND c.calculation_kind = 'calculation' AND c.outcome = 'completed' AND (c.shadow_diff_code IS NULL OR c.shadow_diff_code = 'equal')) + (SELECT count(*) FROM attendance_records r WHERE r.org_id IN ('${SOAK_ORG1}','${SOAK_ORG2}','${SOAK_ORG3}') AND NOT EXISTS (SELECT 1 FROM attendance_calculation_rollout_state s WHERE s.org_id = r.org_id AND s.state <> 'legacy') AND EXISTS (SELECT 1 FROM users u WHERE u.id = r.user_id AND u.username LIKE '${SOAK_USER_PREFIX}%') AND r.first_in_at IS NOT NULL AND r.last_out_at IS NOT NULL AND r.created_at >= '${window_start}'::timestamptz AND r.created_at < now());" >/dev/null
+  soak_status_rows "[Q2] per-org clean punches (cumulative; BOTH regimes; weakest org first)" \
+    "SELECT org_id, sum(cnt)::int AS clean_punch_count FROM ( SELECT c.org_id, count(DISTINCT op.operation_id) AS cnt FROM attendance_result_operations op JOIN attendance_record_calculations c ON c.org_id = op.org_id AND c.operation_id = op.operation_id WHERE op.org_id IN ('${SOAK_ORG1}','${SOAK_ORG2}','${SOAK_ORG3}') AND op.entrypoint = 'live_punch' AND op.state = 'completed' AND op.created_at >= '${window_start}'::timestamptz AND op.created_at < now() AND c.calculation_kind = 'calculation' AND c.outcome = 'completed' AND (c.shadow_diff_code IS NULL OR c.shadow_diff_code = 'equal') GROUP BY c.org_id UNION ALL SELECT r.org_id, count(*) FROM attendance_records r WHERE r.org_id IN ('${SOAK_ORG1}','${SOAK_ORG2}','${SOAK_ORG3}') AND NOT EXISTS (SELECT 1 FROM attendance_calculation_rollout_state s WHERE s.org_id = r.org_id AND s.state <> 'legacy') AND EXISTS (SELECT 1 FROM users u WHERE u.id = r.user_id AND u.username LIKE '${SOAK_USER_PREFIX}%') AND r.first_in_at IS NOT NULL AND r.last_out_at IS NOT NULL AND r.created_at >= '${window_start}'::timestamptz AND r.created_at < now() GROUP BY r.org_id ) both_regimes GROUP BY org_id ORDER BY clean_punch_count ASC;"
   soak_status_rows "[Q3] org/posture classification (three-posture buckets; investigate any 'unclassified')" \
-    "SELECT target.org_id, COALESCE(w4.state, 'legacy') AS w4_posture, COALESCE(w7.state, 'off') AS w7_posture, CASE WHEN COALESCE(w4.state,'legacy') = 'legacy' AND COALESCE(w7.state,'off') = 'off' THEN 'legacy_only' WHEN COALESCE(w4.state,'legacy') <> 'legacy' AND COALESCE(w7.state,'off') = 'off' THEN 'w4_only_legacy_arm' WHEN COALESCE(w7.state,'off') IN ('group_shadow','group_eligible','group_authoritative') THEN 'both_machines_group_arm' WHEN COALESCE(w7.state,'off') = 'suspended' THEN 'w7_suspended' ELSE 'unclassified' END AS soak_posture_bucket FROM (SELECT DISTINCT org_id FROM attendance_calculation_rollout_state UNION SELECT DISTINCT org_id FROM attendance_calculation_context_source_state) target LEFT JOIN attendance_calculation_rollout_state w4 ON w4.org_id = target.org_id LEFT JOIN attendance_calculation_context_source_state w7 ON w7.org_id = target.org_id ORDER BY soak_posture_bucket, target.org_id;"
+    "SELECT target.org_id, COALESCE(w4.state, 'legacy') AS w4_posture, COALESCE(w7.state, 'off') AS w7_posture, CASE WHEN COALESCE(w4.state,'legacy') = 'legacy' AND COALESCE(w7.state,'off') = 'off' THEN 'legacy_only' WHEN COALESCE(w4.state,'legacy') <> 'legacy' AND COALESCE(w7.state,'off') = 'off' THEN 'w4_only_legacy_arm' WHEN COALESCE(w7.state,'off') IN ('group_shadow','group_eligible','group_authoritative') THEN 'both_machines_group_arm' WHEN COALESCE(w7.state,'off') = 'suspended' THEN 'w7_suspended' ELSE 'unclassified' END AS soak_posture_bucket FROM (VALUES ('${SOAK_ORG1}'),('${SOAK_ORG2}'),('${SOAK_ORG3}')) AS target(org_id) LEFT JOIN attendance_calculation_rollout_state w4 ON w4.org_id = target.org_id LEFT JOIN attendance_calculation_context_source_state w7 ON w7.org_id = target.org_id ORDER BY soak_posture_bucket, target.org_id;"
   soak_status_scalar "[Q4a]_w4_legacy_arm_clean_punches_cumulative" \
     "SELECT count(DISTINCT op.operation_id) FROM attendance_result_operations op JOIN attendance_record_calculations c ON c.org_id = op.org_id AND c.operation_id = op.operation_id LEFT JOIN attendance_calculation_context_source_state w7 ON w7.org_id = op.org_id WHERE op.entrypoint = 'live_punch' AND op.state = 'completed' AND op.created_at >= '${window_start}'::timestamptz AND op.created_at < now() AND c.calculation_kind = 'calculation' AND c.outcome = 'completed' AND (c.shadow_diff_code IS NULL OR c.shadow_diff_code = 'equal') AND COALESCE(w7.state, 'off') = 'off';" >/dev/null
   # [Q4b] MUST NOT join attendance_result_operations: a W7 group-shadow comparison row
@@ -2420,8 +2429,21 @@ action_soak_status() {
     "SELECT count(*) FROM pg_constraint WHERE conname IN ('fk_arc_record', 'fk_ar_current_calculation') AND contype = 'f';")"
   [[ "$v" == "2" ]] || alerts+=("Q15a_fk_constraints_missing=${v}")
 
+  # --- [Q2b] legacy-control byte-neutrality (post-merge review P1 follow-through): for
+  # every CONFIG org still legacy-postured, ANY W4 calculation or operation row is an
+  # alert — the control arm's evidence is that the W4 machinery never touched it.
+  local ctrl_state ctrl_rows org
+  for org in "$SOAK_ORG1" "$SOAK_ORG2" "$SOAK_ORG3"; do
+    ctrl_state="$(soak_psql_ta "SELECT COALESCE((SELECT state FROM attendance_calculation_rollout_state WHERE org_id = '${org}'), 'legacy');")"
+    if [[ "$ctrl_state" == "legacy" ]]; then
+      ctrl_rows="$(soak_status_scalar "[Q2b]_legacy_control_w4_rows_${org:0:8}" \
+        "SELECT (SELECT count(*) FROM attendance_record_calculations WHERE org_id = '${org}') + (SELECT count(*) FROM attendance_result_operations WHERE org_id = '${org}');")"
+      [[ "$ctrl_rows" == "0" ]] || alerts+=("Q2b_legacy_control_w4_rows_${org:0:8}=${ctrl_rows}")
+    fi
+  done
+
   # --- per-org read set ------------------------------------------------------------------
-  local org org8
+  local org8
   for org in "$SOAK_ORG1" "$SOAK_ORG2" "$SOAK_ORG3"; do
     org8="${org:0:8}"
     echo "" >> "$SOAK_STATUS_FILE"

--- a/scripts/ops/attendance-staging-window-runner-remote.sh
+++ b/scripts/ops/attendance-staging-window-runner-remote.sh
@@ -2455,7 +2455,10 @@ action_soak_status() {
   # soak's plan (legacy|shadow) — e.g. 'suspended' — makes the org invisible to BOTH
   # regimes. Either voids the counting assumptions => mechanical alert.
   local pc_bad
-  pc_bad="$(soak_psql_ta "SELECT count(*) FROM attendance_calculation_rollout_state WHERE org_id IN ('${SOAK_ORG1}','${SOAK_ORG2}','${SOAK_ORG3}') AND (state NOT IN ('legacy','shadow') OR (state = 'legacy' AND prior_state IS NOT NULL));")"
+  # changed_at >= window_start catches the FORWARD walk too (legacy->shadow mid-window, or
+  # a round trip landing on a nominal-looking shape) — every seed-time walk precedes the
+  # window start, so this adds no false alarms (#4975 gate round-2 P3).
+  pc_bad="$(soak_psql_ta "SELECT count(*) FROM attendance_calculation_rollout_state WHERE org_id IN ('${SOAK_ORG1}','${SOAK_ORG2}','${SOAK_ORG3}') AND (state NOT IN ('legacy','shadow') OR (state = 'legacy' AND prior_state IS NOT NULL) OR changed_at >= '${window_start}'::timestamptz);")"
   echo "[Q3b]_posture_constancy_violations=${pc_bad}" >> "$SOAK_STATUS_FILE"
   [[ "$pc_bad" == "0" ]] || alerts+=("Q3b_posture_constancy_violations=${pc_bad}")
 

--- a/scripts/ops/attendance-window-runner-pipeline.test.mjs
+++ b/scripts/ops/attendance-window-runner-pipeline.test.mjs
@@ -1104,7 +1104,10 @@ function assertSoakContract({ remote, workflow }) {
     'a legacy-postured config org with ANY W4 calc/operation row must raise a mechanical alert',
   )
   const q1Idx = slices.status.indexOf('[Q1]_clean_punch_total_cumulative')
-  const q1Sql = slices.status.slice(q1Idx, slices.status.indexOf('>/dev/null', q1Idx))
+  // #4975 gate P2-3: the slice ends at the NEXT Q-label, never at a redirection token — a
+  // dropped `>/dev/null` widened the old slice across [Q2] and satisfied Q1's regexes
+  // vacuously while the suite stayed green.
+  const q1Sql = slices.status.slice(q1Idx, slices.status.indexOf('[Q2]', q1Idx))
   assert.match(
     q1Sql,
     /\+ \(SELECT count\(\*\) FROM attendance_records r WHERE r\.org_id IN/,
@@ -1121,11 +1124,51 @@ function assertSoakContract({ remote, workflow }) {
     'the legacy clean unit is the COMPLETED PAIR DAY — mirroring the W4 sideʼs converged unit',
   )
   const q2Idx = slices.status.indexOf('[Q2] per-org clean punches')
-  const q2Sql = slices.status.slice(q2Idx, slices.status.indexOf('ORDER BY clean_punch_count ASC', q2Idx))
+  const q2Sql = slices.status.slice(q2Idx, slices.status.indexOf('[Q3]', q2Idx))
   assert.match(q2Sql, /UNION ALL/, '[Q2] must union both regimes so every config org can appear')
+  // #4975 gate P2-1: [Q2] must be closed-set LEFT JOINed so a zero-count config org still
+  // appears as a row (omit-on-zero hid exactly the org the criteria need to see).
+  assert.match(
+    q2Sql,
+    /FROM \(VALUES \('\$\{SOAK_ORG1\}'\),\('\$\{SOAK_ORG2\}'\),\('\$\{SOAK_ORG3\}'\)\) AS target\(org_id\) LEFT JOIN/,
+    '[Q2] must LEFT JOIN the config closed set — every config org appears even at zero',
+  )
+  assert.match(
+    q2Sql,
+    /UNION ALL SELECT r\.org_id, count\(\*\) FROM attendance_records r/,
+    '[Q2]ʼs legacy branch must COUNT real rows, never a constant',
+  )
+  // #4975 gate P2-4: the legacy addendʼs WINDOW scope is load-bearing (an unscoped count
+  // would import pre-window history into C1/C2).
+  assert.match(
+    q1Sql,
+    /r\.created_at >= '\$\{window_start\}'::timestamptz AND r\.created_at < now\(\)/,
+    'the legacy addend must be window-scoped',
+  )
+  // #4975 gate P1: Q2b must count calc rows plus only NON-legacy-posture operations — a
+  // legacy_projection_only op row is the RULED ledger of a legacy write, not contamination
+  // (the gate reproduced 60 such rows on the control org; the naive form would hard-fail
+  // every future soak-status on correct behavior).
+  assert.ok(
+    slices.status.includes("COALESCE(accepted_write_posture, '') <> 'legacy_projection_only'"),
+    'Q2b must exclude the ruled legacy_projection_only operation ledger from the contamination count',
+  )
+  assert.ok(
+    slices.status.includes('[Q3b]_posture_constancy_violations'),
+    'the posture-constancy guard must exist (a rollback or out-of-plan posture voids the dual-regime counters)',
+  )
   assert.match(
     slices.status,
-    /FROM \(VALUES \('\$\{SOAK_ORG1\}'\),\('\$\{SOAK_ORG2\}'\),\('\$\{SOAK_ORG3\}'\)\) AS target\(org_id\)/,
+    /state NOT IN \('legacy','shadow'\) OR \(state = 'legacy' AND prior_state IS NOT NULL\)/,
+    'Q3b must catch BOTH the rolled-back shape and out-of-plan states',
+  )
+  assert.ok(
+    slices.status.includes('alerts+=("Q3b_posture_constancy_violations'),
+    'a posture-constancy violation must raise a mechanical alert',
+  )
+  assert.match(
+    slices.status,
+    /FROM \(VALUES \('\$\{SOAK_ORG1\}'\),\('\$\{SOAK_ORG2\}'\),\('\$\{SOAK_ORG3\}'\)\) AS target\(org_id\) LEFT JOIN attendance_calculation_rollout_state w4/,
     '[Q3] universe must be the config closed set — a posture-derived universe structurally omits the legacy control org',
   )
   assert.ok(slices.status.includes("'group_effective'"), 'W7-2 counters must scope on the selector discriminator')
@@ -1274,11 +1317,12 @@ test('MUTATION (legacy control): dropping the legacy-regime addend from [Q1] tur
 
 test('MUTATION (legacy control): reverting [Q3] to the posture-derived universe turns the soak contract red', () => {
   const original = readFileSync(REMOTE_SH, 'utf8')
-  const anchor = "FROM (VALUES ('${SOAK_ORG1}'),('${SOAK_ORG2}'),('${SOAK_ORG3}')) AS target(org_id)"
-  assert.ok(original.includes(anchor), 'mutation anchor must hit the closed-set universe')
+  // Anchor includes Q3's own LEFT JOIN target so it cannot hit [Q2]'s closed-set join.
+  const anchor = "FROM (VALUES ('${SOAK_ORG1}'),('${SOAK_ORG2}'),('${SOAK_ORG3}')) AS target(org_id) LEFT JOIN attendance_calculation_rollout_state w4"
+  assert.ok(original.includes(anchor), 'mutation anchor must hit the Q3 closed-set universe')
   const mutated = original.replace(
     anchor,
-    'FROM (SELECT DISTINCT org_id FROM attendance_calculation_rollout_state UNION SELECT DISTINCT org_id FROM attendance_calculation_context_source_state) target',
+    'FROM (SELECT DISTINCT org_id FROM attendance_calculation_rollout_state UNION SELECT DISTINCT org_id FROM attendance_calculation_context_source_state) target LEFT JOIN attendance_calculation_rollout_state w4',
   )
   assert.notEqual(mutated, original, 'mutation must change the file')
   assert.throws(

--- a/scripts/ops/attendance-window-runner-pipeline.test.mjs
+++ b/scripts/ops/attendance-window-runner-pipeline.test.mjs
@@ -1159,8 +1159,14 @@ function assertSoakContract({ remote, workflow }) {
   )
   assert.match(
     slices.status,
-    /state NOT IN \('legacy','shadow'\) OR \(state = 'legacy' AND prior_state IS NOT NULL\)/,
-    'Q3b must catch BOTH the rolled-back shape and out-of-plan states',
+    /state NOT IN \('legacy','shadow'\) OR \(state = 'legacy' AND prior_state IS NOT NULL\) OR changed_at >= '\$\{window_start\}'::timestamptz/,
+    'Q3b must catch the rolled-back shape, out-of-plan states, AND any in-window posture change (forward walks land on nominal-looking shapes)',
+  )
+  // #4975 gate round-2 P3: the window scope is load-bearing on BOTH legacy branches.
+  assert.match(
+    q2Sql,
+    /r\.created_at >= '\$\{window_start\}'::timestamptz AND r\.created_at < now\(\)/,
+    '[Q2]ʼs legacy branch must be window-scoped too',
   )
   assert.ok(
     slices.status.includes('alerts+=("Q3b_posture_constancy_violations'),

--- a/scripts/ops/attendance-window-runner-pipeline.test.mjs
+++ b/scripts/ops/attendance-window-runner-pipeline.test.mjs
@@ -1094,6 +1094,40 @@ function assertSoakContract({ remote, workflow }) {
     assert.ok(slices.status.includes(label), `soak-status must run the monitoring-pack ${label} read`)
   }
   assert.ok(slices.status.includes('w7GroupShadowCompare'), 'W7-2 counters must scope on the writer-controlled marker')
+  // Post-merge review P1: the W4-side operations join is STRUCTURALLY EMPTY for a
+  // legacy_only org, so C1/C2/C3 evidence must reach the control arm through its own
+  // regime — completed pair days from the legacy tables — and Q3's universe must be the
+  // config CLOSED SET (a posture-table-derived universe can never show a pure-legacy org).
+  assert.ok(slices.status.includes('[Q2b]'), 'the legacy-control byte-neutrality read must exist')
+  assert.ok(
+    slices.status.includes('Q2b_legacy_control_w4_rows'),
+    'a legacy-postured config org with ANY W4 calc/operation row must raise a mechanical alert',
+  )
+  const q1Idx = slices.status.indexOf('[Q1]_clean_punch_total_cumulative')
+  const q1Sql = slices.status.slice(q1Idx, slices.status.indexOf('>/dev/null', q1Idx))
+  assert.match(
+    q1Sql,
+    /\+ \(SELECT count\(\*\) FROM attendance_records r WHERE r\.org_id IN/,
+    '[Q1] must ADD the legacy-regime completed-pair count — the operations join alone cannot see the control org',
+  )
+  assert.match(
+    q1Sql,
+    /NOT EXISTS \(SELECT 1 FROM attendance_calculation_rollout_state s WHERE s\.org_id = r\.org_id AND s\.state <> 'legacy'\)/,
+    'the legacy-side count must scope to legacy-postured orgs only (a W4-shadow orgʼs legacy rows would double count)',
+  )
+  assert.match(
+    q1Sql,
+    /r\.first_in_at IS NOT NULL AND r\.last_out_at IS NOT NULL/,
+    'the legacy clean unit is the COMPLETED PAIR DAY — mirroring the W4 sideʼs converged unit',
+  )
+  const q2Idx = slices.status.indexOf('[Q2] per-org clean punches')
+  const q2Sql = slices.status.slice(q2Idx, slices.status.indexOf('ORDER BY clean_punch_count ASC', q2Idx))
+  assert.match(q2Sql, /UNION ALL/, '[Q2] must union both regimes so every config org can appear')
+  assert.match(
+    slices.status,
+    /FROM \(VALUES \('\$\{SOAK_ORG1\}'\),\('\$\{SOAK_ORG2\}'\),\('\$\{SOAK_ORG3\}'\)\) AS target\(org_id\)/,
+    '[Q3] universe must be the config closed set — a posture-derived universe structurally omits the legacy control org',
+  )
   assert.ok(slices.status.includes("'group_effective'"), 'W7-2 counters must scope on the selector discriminator')
 
   // P1-1 signature guard: a W7 group-shadow comparison row carries operation_id IS NULL BY
@@ -1223,6 +1257,45 @@ test('MUTATION: unrouting soak-seed from the dispatcher turns the soak contract 
   assert.throws(
     () => assertSoakContract({ remote: mutated, workflow: readFileSync(WORKFLOW, 'utf8') }),
     /dispatcher must route soak-seed/,
+  )
+})
+
+test('MUTATION (legacy control): dropping the legacy-regime addend from [Q1] turns the soak contract red', () => {
+  const original = readFileSync(REMOTE_SH, 'utf8')
+  const anchor = "+ (SELECT count(*) FROM attendance_records r WHERE r.org_id IN"
+  assert.ok(original.includes(anchor), 'mutation anchor must hit the legacy addend')
+  const mutated = original.replace(anchor, "+ (SELECT 0 WHERE 'x' IN")
+  assert.notEqual(mutated, original, 'mutation must change the file')
+  assert.throws(
+    () => assertSoakContract({ remote: mutated, workflow: readFileSync(WORKFLOW, 'utf8') }),
+    /operations join alone cannot see the control org/,
+  )
+})
+
+test('MUTATION (legacy control): reverting [Q3] to the posture-derived universe turns the soak contract red', () => {
+  const original = readFileSync(REMOTE_SH, 'utf8')
+  const anchor = "FROM (VALUES ('${SOAK_ORG1}'),('${SOAK_ORG2}'),('${SOAK_ORG3}')) AS target(org_id)"
+  assert.ok(original.includes(anchor), 'mutation anchor must hit the closed-set universe')
+  const mutated = original.replace(
+    anchor,
+    'FROM (SELECT DISTINCT org_id FROM attendance_calculation_rollout_state UNION SELECT DISTINCT org_id FROM attendance_calculation_context_source_state) target',
+  )
+  assert.notEqual(mutated, original, 'mutation must change the file')
+  assert.throws(
+    () => assertSoakContract({ remote: mutated, workflow: readFileSync(WORKFLOW, 'utf8') }),
+    /structurally omits the legacy control org/,
+  )
+})
+
+test('MUTATION (legacy control): deleting the Q2b byte-neutrality alert turns the soak contract red', () => {
+  const original = readFileSync(REMOTE_SH, 'utf8')
+  const anchor = 'alerts+=("Q2b_legacy_control_w4_rows_'
+  assert.ok(original.includes(anchor), 'mutation anchor must hit the Q2b alert push')
+  const mutated = original.replace(anchor, 'true # ("Q2b_note_')
+  assert.notEqual(mutated, original, 'mutation must change the file')
+  assert.throws(
+    () => assertSoakContract({ remote: mutated, workflow: readFileSync(WORKFLOW, 'utf8') }),
+    /must raise a mechanical alert/,
   )
 })
 


### PR DESCRIPTION
## Post-merge review P1 — accepted, fixed as option (a): execute the ruled contract, don't amend it

**The defect**: Q1/Q2 inner-join `attendance_result_operations × attendance_record_calculations` — rows a `legacy_only` org never produces **by design** (it is the control arm); Q3's universe derived only from the two posture tables. So C2 (≥20/org for THREE orgs) and C3 (M≥3 postures) were structurally unprovable from the declared authoritative source, forever. Measured: first pair-cadence batch = 180/180 HTTP across 3 orgs; DB Q1 +60; Q2/Q3 omitted org1.

**The fix**:
- **[Q1]/[Q2] dual-regime**: W4-postured orgs keep the converged clean-operations unit; legacy-postured orgs count **completed pair days** (both boundaries set, in-window, synthetic-family username join) — the same one-per-user-per-day converged unit in the regime that org actually runs. Legacy side excludes W4-postured orgs (double-count guard) and both sides scope to the config **closed set**.
- **[Q3]** universe = `VALUES` of the three config orgs (absent posture rows COALESCE → `legacy_only` reachable; M≥3 provable).
- **NEW [Q2b]** mechanical alert: any W4 calc/operation row for a legacy-postured config org alerts — the control arm's byte-neutrality is now an enforced invariant.

Pins + 3 mutation legs (drop the legacy addend / revert the universe / delete the alert — each reds its own pin). Pipeline **71/71** · census 58/58. W8 pack documents the mirrors (runner = executing authority).

Unit-semantics disclosure: the two regimes' units are both 'one converged day per user' but measured in their own tables; recorded in the query comments and the acceptance ledger. Owner may veto per §2A.9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)