### PR TITLE
fix(ops): preflight staging deploy migrations

### DIFF
--- a/scripts/ops/attendance-staging-window-runner-remote.sh
+++ b/scripts/ops/attendance-staging-window-runner-remote.sh
@@ -3,7 +3,7 @@
 #
 # Remote (deploy-host) half of .github/workflows/attendance-staging-window-runner.yml.
 # Executes ONE action per invocation against the STAGING stack only:
-#   deploy         — pin staging backend+web to a full-SHA image tag, migrate, verify build+auth
+#   deploy         — resolve a full-SHA tag to immutable backend+web digests, migrate, verify build+auth
 #   smoke          — run one of the five window smokes in-container (bundle doc:
 #                    docs/development/attendance-staging-window-bundle-20260702.md)
 #   status         — read-only snapshot (containers, health, settings, pending migrations)
@@ -128,6 +128,28 @@ STAGING_WEB_HEALTH_URL="http://127.0.0.1:8082/api/health"
 STAGING_BACKEND_HEALTH_URL="http://127.0.0.1:18900/health"
 IN_CONTAINER_BASE_URL="http://127.0.0.1:8900"
 MIGRATE_JS="packages/core-backend/dist/src/db/migrate.js"
+CANDIDATE_DB_ENV_KEYS=(
+  DATABASE_URL
+  NODE_ENV
+  SECRET_PROVIDER
+  ALLOW_SECRET_FALLBACK
+  DB_SSL
+  DB_SSL_REJECT_UNAUTHORIZED
+  DB_SSL_CA
+  DB_SSL_CERT
+  DB_SSL_KEY
+  DB_POOL_MAX
+  DB_POOL_MIN
+  DB_IDLE_TIMEOUT
+  DB_CONNECT_TIMEOUT
+  DB_QUERY_TIMEOUT
+  DB_STATEMENT_TIMEOUT
+  DB_SLOW_MS
+  APP_NAME
+  NODE_EXTRA_CA_CERTS
+  MIGRATION_INCLUDE_SUPERSEDED_LEGACY_SQL
+  MIGRATION_EXCLUDE
+)
 # Fixed, clearly-synthetic rehearsal DB name for action=migrate. Lives inside the SAME
 # postgres container/server as staging, never on a different host, and is always dropped
 # (created fresh each run — never assumed to persist).
@@ -150,6 +172,9 @@ resolve_home_path() {
 STAGING_DIR="$(resolve_home_path "$STAGING_DEPLOY_PATH")"
 PROD_REPO_DIR="$(resolve_home_path "$DEPLOY_PATH")"
 LEGACY_STAGING_COMPOSE_FILE="${STAGING_DIR}/docker-compose.app.staging.yml"
+STAGING_ENV_FILE="${STAGING_DIR}/docker/app.staging.env"
+COMPOSE_ENV_FILE="$STAGING_ENV_FILE"
+DEPLOY_ENV_SNAPSHOT=""
 # The override MUST persist across runs. `docker compose up -d` stamps each container's
 # com.docker.compose.project.config_files label with the -f paths it was given, so any later
 # `docker compose config` (e.g. the recovery-flag containment check) re-reads THIS file BY PATH.
@@ -163,6 +188,7 @@ LEGACY_STAGING_COMPOSE_FILE="${STAGING_DIR}/docker-compose.app.staging.yml"
 RUNNER_PERSIST_DIR="${HOME}/.metasheet2/window-runner"
 OVERRIDE_FILE="${RUNNER_PERSIST_DIR}/docker-compose.window-runner.override.yml"
 PERSISTENT_STAGING_COMPOSE_FILE="${RUNNER_PERSIST_DIR}/docker-compose.app.staging.yml"
+DEPLOY_IDENTITY_FILE="${RUNNER_PERSIST_DIR}/deploy-identity.env"
 STAGING_COMPOSE_FILE="$LEGACY_STAGING_COMPOSE_FILE"
 if [[ -f "$PERSISTENT_STAGING_COMPOSE_FILE" ]]; then
   STAGING_COMPOSE_FILE="$PERSISTENT_STAGING_COMPOSE_FILE"
@@ -220,10 +246,122 @@ require_compose_v2() {
   fail "docker compose v2 plugin is required (legacy docker-compose v1 breaks up -d against existing containers; see docs/development/staging-deploy-d88ad587b-20260426.md)"
 }
 
+cleanup_deploy_env_snapshot() {
+  if [[ -n "$DEPLOY_ENV_SNAPSHOT" ]]; then
+    rm -f "$DEPLOY_ENV_SNAPSHOT"
+    DEPLOY_ENV_SNAPSHOT=""
+  fi
+  COMPOSE_ENV_FILE="$STAGING_ENV_FILE"
+}
+
+prepare_deploy_env_snapshot() {
+  [[ -f "$STAGING_ENV_FILE" ]] || fail "canonical staging env file missing: ${STAGING_ENV_FILE}"
+  mkdir -p "$RUNNER_PERSIST_DIR"
+  find "$RUNNER_PERSIST_DIR" -maxdepth 1 -type f -name '.deploy-env.*' -mmin +60 -delete
+  local attempt before after snapshot_hash candidate
+  for attempt in 1 2 3; do
+    before="$(hash_value "$STAGING_ENV_FILE")"
+    candidate="$(mktemp "${RUNNER_PERSIST_DIR}/.deploy-env.XXXXXX")"
+    DEPLOY_ENV_SNAPSHOT="$candidate"
+    chmod 600 "$candidate"
+    cp "$STAGING_ENV_FILE" "$candidate"
+    chmod 600 "$candidate"
+    after="$(hash_value "$STAGING_ENV_FILE")"
+    snapshot_hash="$(hash_value "$candidate")"
+    if [[ "$before" == "$after" && "$after" == "$snapshot_hash" ]]; then
+      COMPOSE_ENV_FILE="$DEPLOY_ENV_SNAPSHOT"
+      log "captured stable per-run staging env snapshot (values suppressed)"
+      return 0
+    fi
+    rm -f "$candidate"
+    DEPLOY_ENV_SNAPSHOT=""
+  done
+  fail "canonical staging env changed during three snapshot attempts; refusing deployment"
+}
+
+resolve_immutable_repo_digest() {
+  local tagged_image="$1"
+  local repository="${tagged_image%:*}"
+  local digest
+  digest="$(docker image inspect -f '{{range .RepoDigests}}{{println .}}{{end}}' "$tagged_image" \
+    | awk -v prefix="${repository}@" 'index($0, prefix) == 1 { print; exit }')"
+  [[ "$digest" == "${repository}@sha256:"* && "${digest#"${repository}@sha256:"}" =~ ^[0-9a-f]{64}$ ]] \
+    || fail "pulled image has no immutable digest for ${repository}"
+  printf '%s' "$digest"
+}
+
+read_deploy_identity_field() {
+  local key="$1"
+  local -a values=()
+  [[ -f "$DEPLOY_IDENTITY_FILE" ]] || fail "deploy identity record missing: ${DEPLOY_IDENTITY_FILE}"
+  mapfile -t values < <(sed -n "s/^${key}=//p" "$DEPLOY_IDENTITY_FILE")
+  [[ "${#values[@]}" -eq 1 && -n "${values[0]}" ]] \
+    || fail "deploy identity record must contain exactly one non-empty ${key}"
+  printf '%s' "${values[0]}"
+}
+
+write_deploy_identity_record() {
+  local deploy_sha="$1" backend_digest="$2" web_digest="$3" env_sha256="$4" candidate
+  candidate="$(mktemp "${RUNNER_PERSIST_DIR}/.deploy-identity.XXXXXX")"
+  chmod 600 "$candidate"
+  {
+    echo "deploy_sha=${deploy_sha}"
+    echo "backend_digest=${backend_digest}"
+    echo "web_digest=${web_digest}"
+    echo "env_sha256=${env_sha256}"
+  } > "$candidate"
+  mv -f "$candidate" "$DEPLOY_IDENTITY_FILE"
+  log "persisted values-free deploy identity record"
+}
+
+assert_deploy_env_snapshot_matches_record() {
+  local recorded actual
+  recorded="$(read_deploy_identity_field env_sha256)"
+  [[ "$recorded" =~ ^[0-9a-f]{64}$ ]] \
+    || fail "deploy identity record has an invalid env fingerprint"
+  actual="$(hash_value "$COMPOSE_ENV_FILE")"
+  [[ "$actual" == "$recorded" ]] \
+    || fail "staging env differs from the env snapshot used by the recorded deploy; use action=deploy before changing soak flags"
+}
+
+assert_running_image_digests() {
+  local backend_digest="$1" web_digest="$2" live_backend live_web
+  [[ "$backend_digest" == "ghcr.io/${IMAGE_OWNER}/metasheet2-backend@sha256:"* \
+     && "${backend_digest#"ghcr.io/${IMAGE_OWNER}/metasheet2-backend@sha256:"}" =~ ^[0-9a-f]{64}$ ]] \
+    || fail "expected backend image has an invalid immutable digest"
+  [[ "$web_digest" == "ghcr.io/${IMAGE_OWNER}/metasheet2-web@sha256:"* \
+     && "${web_digest#"ghcr.io/${IMAGE_OWNER}/metasheet2-web@sha256:"}" =~ ^[0-9a-f]{64}$ ]] \
+    || fail "expected web image has an invalid immutable digest"
+  live_backend="$(docker inspect -f '{{.Config.Image}}' "$BACKEND_CONTAINER" 2>/dev/null || true)"
+  live_web="$(docker inspect -f '{{.Config.Image}}' "$WEB_CONTAINER" 2>/dev/null || true)"
+  [[ "$live_backend" == "$backend_digest" ]] \
+    || fail "running backend image differs from the recorded immutable digest"
+  [[ "$live_web" == "$web_digest" ]] \
+    || fail "running web image differs from the recorded immutable digest"
+}
+
+assert_running_deploy_identity() {
+  local expected_sha="$1" recorded_sha backend_digest web_digest
+  recorded_sha="$(read_deploy_identity_field deploy_sha)"
+  backend_digest="$(read_deploy_identity_field backend_digest)"
+  web_digest="$(read_deploy_identity_field web_digest)"
+  [[ "$recorded_sha" == "$expected_sha" ]] \
+    || fail "deploy identity record is for ${recorded_sha}, expected ${expected_sha}"
+  assert_running_image_digests "$backend_digest" "$web_digest"
+}
+
+assert_current_recorded_deploy_identity() {
+  local recorded_sha
+  recorded_sha="$(read_deploy_identity_field deploy_sha)"
+  [[ "$recorded_sha" =~ ^[0-9a-f]{40}$ ]] \
+    || fail "deploy identity record has an invalid deploy SHA"
+  assert_running_deploy_identity "$recorded_sha"
+}
+
 compose_staging() {
   # The ONLY compose entry point in this script: staging compose file + runner override.
-  (cd "$STAGING_DIR" && IMAGE_OWNER="$IMAGE_OWNER" IMAGE_TAG="$DEPLOY_SHA" \
-    docker compose --project-directory "$STAGING_DIR" -f "$STAGING_COMPOSE_FILE" -f "$OVERRIDE_FILE" "$@")
+  (cd "$STAGING_DIR" && IMAGE_OWNER="$IMAGE_OWNER" IMAGE_TAG="$DEPLOY_SHA" APP_ENV_FILE="$COMPOSE_ENV_FILE" \
+    docker compose --project-directory "$STAGING_DIR" --env-file "$COMPOSE_ENV_FILE" -f "$STAGING_COMPOSE_FILE" -f "$OVERRIDE_FILE" "$@")
 }
 
 prepare_staging_compose_for_deploy() {
@@ -240,8 +378,8 @@ prepare_staging_compose_for_deploy() {
   mkdir -p "$RUNNER_PERSIST_DIR"
   STAGING_COMPOSE_CANDIDATE_TMP="$(mktemp "${RUNNER_PERSIST_DIR}/.staging-compose.XXXXXX")"
   cp "$candidate" "$STAGING_COMPOSE_CANDIDATE_TMP"
-  if ! (cd "$STAGING_DIR" && IMAGE_OWNER="$IMAGE_OWNER" IMAGE_TAG="$DEPLOY_SHA" \
-    docker compose --project-directory "$STAGING_DIR" -f "$STAGING_COMPOSE_CANDIDATE_TMP" config) >/dev/null 2>&1; then
+  if ! (cd "$STAGING_DIR" && IMAGE_OWNER="$IMAGE_OWNER" IMAGE_TAG="$DEPLOY_SHA" APP_ENV_FILE="$COMPOSE_ENV_FILE" \
+    docker compose --project-directory "$STAGING_DIR" --env-file "$COMPOSE_ENV_FILE" -f "$STAGING_COMPOSE_CANDIDATE_TMP" config) >/dev/null 2>&1; then
     rm -f "$STAGING_COMPOSE_CANDIDATE_TMP"
     STAGING_COMPOSE_CANDIDATE_TMP=""
     fail "checked-out staging compose candidate failed validation; kept ${STAGING_COMPOSE_FILE}"
@@ -304,10 +442,11 @@ except Exception:
 }
 
 wait_for_health_commit() {
-  local expected="$1" attempts="${2:-30}" delay="${3:-4}" i commit
+  local expected="$1" expected_digest="$2" expected_web_digest="$3" attempts="${4:-30}" delay="${5:-4}" i commit
   for ((i = 1; i <= attempts; i += 1)); do
     commit="$(fetch_health_commit)"
     if [[ "$commit" == "$expected" ]]; then
+      assert_running_image_digests "$expected_digest" "$expected_web_digest"
       log "health build.commit matches deploy sha (attempt ${i}/${attempts})"
       return 0
     fi
@@ -318,20 +457,21 @@ wait_for_health_commit() {
   # L6 precedent (tracker 2026-06-21 annual-leave staging closeout, re-proven by run
   # 29314093729): the staging stack's env file can pin a stale METASHEET_BUILD_COMMIT,
   # so /api/health build metadata is NOT a reliable deploy identity on staging. The
-  # accepted deploy evidence is the CONTAINER IMAGE TAG. Health must still be
+  # accepted deploy evidence is the immutable CONTAINER IMAGE DIGEST. Health must still be
   # RESPONDING (fetch_health_commit returned a body above); identity falls back to
   # docker inspect. Fail closed if neither channel matches.
   local live_image
   live_image="$(docker inspect -f '{{.Config.Image}}' "$BACKEND_CONTAINER" 2>/dev/null || true)"
-  if [[ "$live_image" == *":${expected}" ]]; then
+  if [[ "$live_image" == "$expected_digest" ]]; then
+    assert_running_image_digests "$expected_digest" "$expected_web_digest"
     if ! curl -sS --max-time 10 "$STAGING_WEB_HEALTH_URL" | grep -q '"ok":true'; then
-      fail "backend image tag matches ${expected} but /api/health is not ok — not accepting image-tag identity for an unhealthy backend"
+      fail "backend image digest matches ${expected} but /api/health is not ok — not accepting digest identity for an unhealthy backend"
     fi
-    log "health build.commit is stale (env-pinned; L6 precedent) but backend container image tag matches deploy sha: ${live_image}"
-    echo "identity_channel=image-tag health_commit_stale=1 live_image=${live_image}" > "${OUTPUT_DIR}/deploy-identity.txt"
+    log "health build.commit is stale (env-pinned; L6 precedent) but backend container image matches the preflighted digest: ${live_image}"
+    echo "identity_channel=image-digest health_commit_stale=1 live_image=${live_image}" > "${OUTPUT_DIR}/deploy-identity.txt"
     return 0
   fi
-  fail "staging deploy identity failed BOTH channels: /api/health build.commit never matched ${expected} AND backend image is '${live_image:-<none>}'"
+  fail "staging deploy identity failed BOTH channels: /api/health build.commit never matched ${expected} AND backend image is not the preflighted digest"
 }
 
 prepare_container_runner() {
@@ -430,16 +570,142 @@ auth_round_trip() {
   log "auth round-trip OK (me=200, settings=200)"
 }
 
+live_database_env_fingerprint() {
+  python3 -c 'import hashlib,json,sys
+items=json.load(open(sys.argv[1], encoding="utf-8"))
+env=dict(item.split("=", 1) for item in items if "=" in item)
+keys=sys.argv[2:]
+payload=[[key, key in env, env.get(key, "")] for key in keys]
+print(hashlib.sha256(json.dumps(payload, separators=(",", ":")).encode()).hexdigest())' \
+    <(docker inspect -f '{{json .Config.Env}}' "$BACKEND_CONTAINER") \
+    "${CANDIDATE_DB_ENV_KEYS[@]}"
+}
+
+candidate_database_env_fingerprint() {
+  local backend_image="$1"
+  local base_candidate="$2"
+  local override_candidate="$3"
+  python3 -c 'import hashlib,json,sys
+def env_list(path):
+    items=json.load(open(path, encoding="utf-8"))
+    return dict(item.split("=", 1) for item in items if "=" in item)
+env=env_list(sys.argv[1])
+config=json.load(open(sys.argv[2], encoding="utf-8"))
+for key,value in config["services"]["backend"].get("environment", {}).items():
+    if value is None:
+        env.pop(key, None)
+    else:
+        env[key]=str(value)
+keys=sys.argv[3:]
+payload=[[key, key in env, env.get(key, "")] for key in keys]
+print(hashlib.sha256(json.dumps(payload, separators=(",", ":")).encode()).hexdigest())' \
+    <(docker image inspect -f '{{json .Config.Env}}' "$backend_image") \
+    <((cd "$STAGING_DIR" && IMAGE_OWNER="$IMAGE_OWNER" IMAGE_TAG="$DEPLOY_SHA" APP_ENV_FILE="$COMPOSE_ENV_FILE" \
+      docker compose --project-directory "$STAGING_DIR" --env-file "$COMPOSE_ENV_FILE" -f "$base_candidate" -f "$override_candidate" config --format json)) \
+    "${CANDIDATE_DB_ENV_KEYS[@]}"
+}
+
+run_candidate_migration_preflight() {
+  local backend_image="$1"
+  local base_candidate="$2"
+  local override_candidate="$3"
+  local list_file="${OUTPUT_DIR}/candidate-migrate-list-before.txt"
+  local stdout_file="${OUTPUT_DIR}/candidate-migration-alignment-stdout.txt"
+  local report_dir="${OUTPUT_DIR}/candidate-migration-report"
+  local live_fingerprint candidate_fingerprint secret_provider
+  local -a decisions=()
+
+  [[ -f "$COMPOSE_ENV_FILE" ]] || {
+    echo "[window-runner][error] per-run staging env snapshot missing" >&2
+    return 1
+  }
+  docker inspect "$BACKEND_CONTAINER" >/dev/null 2>&1 || {
+    echo "[window-runner][error] staging backend container not found: ${BACKEND_CONTAINER}" >&2
+    return 1
+  }
+  rm -rf "$report_dir"
+
+  live_fingerprint="$(live_database_env_fingerprint)" || {
+    echo "[window-runner][error] could not fingerprint the live backend DB/migration environment" >&2
+    return 1
+  }
+  candidate_fingerprint="$(candidate_database_env_fingerprint "$backend_image" "$base_candidate" "$override_candidate")" || {
+    echo "[window-runner][error] could not fingerprint the candidate backend DB/migration environment" >&2
+    return 1
+  }
+  if [[ "$live_fingerprint" != "$candidate_fingerprint" ]]; then
+    echo "[window-runner][error] candidate DB/migration environment differs from the live backend (values suppressed); refusing cross-target preflight" >&2
+    return 1
+  fi
+
+  secret_provider="$(docker exec "$BACKEND_CONTAINER" printenv SECRET_PROVIDER 2>/dev/null || true)"
+  case "$secret_provider" in
+    ''|env) ;;
+    *)
+      echo "[window-runner][error] candidate migration preflight requires SECRET_PROVIDER=env or unset; got a non-env provider (value suppressed)" >&2
+      return 1
+      ;;
+  esac
+
+  if ! (
+    local key value
+    local -a env_args=()
+    for key in "${CANDIDATE_DB_ENV_KEYS[@]}"; do
+      if value="$(docker exec "$BACKEND_CONTAINER" printenv "$key" 2>/dev/null)"; then
+        printf -v "$key" '%s' "$value"
+        export "$key"
+        env_args+=(--env "$key")
+      fi
+    done
+    [[ -n "${DATABASE_URL:-}" ]] || exit 1
+    docker run --rm \
+      --user "$(id -u):$(id -g)" \
+      --network "container:${BACKEND_CONTAINER}" \
+      "${env_args[@]}" \
+      "$backend_image" node "$MIGRATE_JS" --list < /dev/null
+  ) 2>&1 | tee "$list_file"; then
+    echo "[window-runner][error] candidate image could not list migrations against the live staging DB" >&2
+    return 1
+  fi
+
+  if ! docker run --rm \
+    --user "$(id -u):$(id -g)" \
+    --network none \
+    -v "${OUTPUT_DIR}:${CONTAINER_RUNNER_DIR}" \
+    "$backend_image" node /app/scripts/ops/staging-migration-alignment-report.mjs \
+    --migrate-list-file "${CONTAINER_RUNNER_DIR}/candidate-migrate-list-before.txt" \
+    --out-dir "${CONTAINER_RUNNER_DIR}/candidate-migration-report" < /dev/null 2>&1 \
+    | tee "$stdout_file"; then
+    echo "[window-runner][error] candidate image migration alignment report failed" >&2
+    return 1
+  fi
+
+  mapfile -t decisions < <(sed -n 's/^\[staging-migration-alignment-report\] decision=//p' "$stdout_file")
+  if [[ "${#decisions[@]}" -ne 1 || "${decisions[0]}" != "aligned" ]]; then
+    echo "[window-runner][error] candidate migration alignment must emit exactly one decision=aligned; got: ${decisions[*]:-(missing)}" >&2
+    return 1
+  fi
+  log "candidate migration preflight OK before persistent config or live-container changes"
+}
+
 # --- actions ---------------------------------------------------------------------------
 
 action_deploy() {
   require_sha
   require_compose_v2
+  trap cleanup_deploy_env_snapshot EXIT
+  prepare_deploy_env_snapshot
   local STAGING_COMPOSE_CANDIDATE_TMP=""
   prepare_staging_compose_for_deploy
 
   local backend_image="ghcr.io/${IMAGE_OWNER}/metasheet2-backend:${DEPLOY_SHA}"
   local web_image="ghcr.io/${IMAGE_OWNER}/metasheet2-web:${DEPLOY_SHA}"
+  docker pull "$backend_image" 2>&1 | tee "${OUTPUT_DIR}/candidate-backend-pull.log"
+  docker pull "$web_image" 2>&1 | tee "${OUTPUT_DIR}/candidate-web-pull.log"
+  local backend_immutable web_immutable
+  backend_immutable="$(resolve_immutable_repo_digest "$backend_image")"
+  web_immutable="$(resolve_immutable_repo_digest "$web_image")"
+  log "resolved candidate images to immutable repository digests"
 
   local pg_id_before redis_id_before
   pg_id_before="$(docker inspect -f '{{.Id}}' "$POSTGRES_CONTAINER")" \
@@ -460,18 +726,18 @@ action_deploy() {
   override_tmp="$(mktemp "${RUNNER_PERSIST_DIR}/.override.XXXXXX")"
   {
     echo "# Written by attendance-staging-window-runner (run ${RUN_STAMP}). Pins the staging"
-    echo "# backend/web images to one full-SHA tag; env flips happen ONLY here, together with"
+    echo "# backend/web images to immutable digests resolved from one full-SHA tag; env flips happen ONLY here, together with"
     echo "# the deploy (bundle §3.4). Redeploying with set_window_env=none removes the flags."
     echo "services:"
     echo "  backend:"
-    echo "    image: ${backend_image}"
+    echo "    image: ${backend_immutable}"
     if [[ "$SET_WINDOW_ENV" == "rd-window" ]]; then
       echo "    environment:"
       echo "      ATTENDANCE_SCHEDULER_ENABLED: \"true\""
       echo "      ATTENDANCE_NOTIFICATION_DELIVERY_WORKER_ENABLED: \"true\""
     fi
     echo "  web:"
-    echo "    image: ${web_image}"
+    echo "    image: ${web_immutable}"
   } > "$override_tmp"
   # Validate the candidate renders against the staging compose file BEFORE it goes live — a broken
   # override would otherwise dangle EVERY container's config_files label. On failure, keep the
@@ -479,11 +745,23 @@ action_deploy() {
   # Validate in the SAME cwd as compose_staging() above: staging compose uses relative
   # env_file + .env interpolation, so `cd "$STAGING_DIR"` first — otherwise we'd validate a
   # different resolved config than the one `up -d` actually executes.
-  if ! (cd "$STAGING_DIR" && IMAGE_OWNER="$IMAGE_OWNER" IMAGE_TAG="$DEPLOY_SHA" \
-    docker compose --project-directory "$STAGING_DIR" -f "$STAGING_COMPOSE_CANDIDATE_TMP" -f "$override_tmp" config) >/dev/null 2>&1; then
+  if ! (cd "$STAGING_DIR" && IMAGE_OWNER="$IMAGE_OWNER" IMAGE_TAG="$DEPLOY_SHA" APP_ENV_FILE="$COMPOSE_ENV_FILE" \
+    docker compose --project-directory "$STAGING_DIR" --env-file "$COMPOSE_ENV_FILE" -f "$STAGING_COMPOSE_CANDIDATE_TMP" -f "$override_tmp" config) >/dev/null 2>&1; then
     rm -f "$override_tmp" "$STAGING_COMPOSE_CANDIDATE_TMP"
     fail "candidate base/override pair failed 'docker compose config' validation; kept previous persistent files"
   fi
+  local preflight_rc=0
+  run_candidate_migration_preflight "$backend_immutable" "$STAGING_COMPOSE_CANDIDATE_TMP" "$override_tmp" || preflight_rc=$?
+  if [[ "$preflight_rc" -ne 0 ]]; then
+    rm -f "$override_tmp" "$STAGING_COMPOSE_CANDIDATE_TMP"
+    STAGING_COMPOSE_CANDIDATE_TMP=""
+    fail "candidate migration preflight failed before deployment; live staging containers and persistent compose files were not changed"
+  fi
+  # From this point onward the persistent compose pair and live containers may change. An
+  # earlier success record must not survive a partial redeploy (including a same-SHA retry),
+  # or smoke/soak could mistake a failed transition for a completed deployment.
+  rm -f "$DEPLOY_IDENTITY_FILE"
+  log "invalidated prior deploy identity before persistent or live state changes"
   # Both candidates are validated as one pair before either persistent file changes. Each
   # same-directory rename is atomic; workflow concurrency serializes staging transitions.
   mv -f "$STAGING_COMPOSE_CANDIDATE_TMP" "$PERSISTENT_STAGING_COMPOSE_FILE"
@@ -493,7 +771,6 @@ action_deploy() {
   log "staging compose installed atomically at persistent path: ${STAGING_COMPOSE_FILE}"
   log "override written (persistent, atomic): ${OVERRIDE_FILE} (env mode: ${SET_WINDOW_ENV})"
 
-  compose_staging pull backend web 2>&1 | tee "${OUTPUT_DIR}/compose-pull.log"
   # NEVER recreate postgres/redis: only backend+web, --no-deps.
   local -a up_args=(up -d --no-deps)
   if [[ "$FORCE_RECREATE" == "true" ]]; then
@@ -509,12 +786,14 @@ action_deploy() {
   [[ "$redis_id_before" == "$redis_id_after" ]] || fail "staging redis container was recreated — hard constraint violated"
   log "postgres/redis untouched (container ids unchanged)"
 
-  local running_backend_image
+  local running_backend_image running_web_image
   running_backend_image="$(docker inspect -f '{{.Config.Image}}' "$BACKEND_CONTAINER")"
-  [[ "$running_backend_image" == "$backend_image" ]] \
-    || fail "backend container image is ${running_backend_image}, expected ${backend_image}"
-
-  wait_for_health_commit "$DEPLOY_SHA"
+  running_web_image="$(docker inspect -f '{{.Config.Image}}' "$WEB_CONTAINER")"
+  [[ "$running_backend_image" == "$backend_immutable" ]] \
+    || fail "backend container image is ${running_backend_image}, expected immutable digest ${backend_immutable}"
+  [[ "$running_web_image" == "$web_immutable" ]] \
+    || fail "web container image is ${running_web_image}, expected immutable digest ${web_immutable}"
+  wait_for_health_commit "$DEPLOY_SHA" "$backend_immutable" "$web_immutable"
   curl -fsS --max-time 10 "$STAGING_WEB_HEALTH_URL" > "${OUTPUT_DIR}/health-web.json"
   curl -fsS --max-time 10 "$STAGING_BACKEND_HEALTH_URL" > "${OUTPUT_DIR}/health-backend.json" || true
 
@@ -531,8 +810,10 @@ action_deploy() {
     --out-dir "${CONTAINER_RUNNER_DIR}/migration-report" < /dev/null 2>&1 \
     | tee "${OUTPUT_DIR}/migration-alignment-stdout.txt"
   docker cp "${BACKEND_CONTAINER}:${CONTAINER_RUNNER_DIR}/migration-report" "${OUTPUT_DIR}/migration-report" || true
-  if grep -q 'decision=do_not_run_full_migrate' "${OUTPUT_DIR}/migration-alignment-stdout.txt"; then
-    fail "migration alignment report says do_not_run_full_migrate — STOP per bundle §3.2; follow docs/development/staging-migration-alignment-runbook-verification-20260519.md"
+  local -a live_decisions=()
+  mapfile -t live_decisions < <(sed -n 's/^\[staging-migration-alignment-report\] decision=//p' "${OUTPUT_DIR}/migration-alignment-stdout.txt")
+  if [[ "${#live_decisions[@]}" -ne 1 || "${live_decisions[0]}" != "aligned" ]]; then
+    fail "live migration alignment must emit exactly one decision=aligned before migrate; got: ${live_decisions[*]:-(missing)}"
   fi
 
   staging_exec node "$MIGRATE_JS" < /dev/null 2>&1 | tee "${OUTPUT_DIR}/migrate-run.log"
@@ -550,8 +831,17 @@ action_deploy() {
     echo "force_recreate=${FORCE_RECREATE}"
     echo "backend_image=${backend_image}"
     echo "web_image=${web_image}"
+    echo "backend_immutable=${backend_immutable}"
+    echo "web_immutable=${web_immutable}"
     echo "result=ok"
   } > "${OUTPUT_DIR}/summary.txt"
+  local deploy_env_sha256
+  deploy_env_sha256="$(hash_value "$COMPOSE_ENV_FILE")"
+  cleanup_deploy_env_snapshot
+  trap - EXIT
+  # This record is the completed-deploy capability consumed by smoke/soak. Persist it only
+  # after health, migration, auth, and snapshot gates have all passed.
+  write_deploy_identity_record "$DEPLOY_SHA" "$backend_immutable" "$web_immutable" "$deploy_env_sha256"
   log "deploy OK: ${DEPLOY_SHA}"
 }
 
@@ -604,20 +894,16 @@ action_smoke() {
   local smoke_src="${PROD_REPO_DIR}/scripts/ops/${smoke_script}"
   [[ -f "$smoke_src" ]] || fail "smoke script missing in host-synced repo: ${smoke_src}"
 
-  # The deployed build must BE the SHA the stamps will name (bundle §2). Same dual-channel
-  # identity as the deploy verifier: staging /api/health build.commit is env-pinned stale
-  # (L6 precedent; proven again by run 29378042837), so fall back to the backend container
-  # image tag — but only for a HEALTHY backend (health must answer ok:true).
-  local live_commit live_image
+  # The deployed build must BE the SHA the stamps will name (bundle §2). The persistent
+  # values-free deploy identity maps that SHA to the immutable backend/web digests; health
+  # metadata remains an informational second channel because staging can pin it stale.
+  local live_commit
   live_commit="$(fetch_health_commit)"
+  assert_running_deploy_identity "$DEPLOY_SHA"
+  curl -sS --max-time 10 "$STAGING_WEB_HEALTH_URL" | grep -q '"ok":true' \
+    || fail "staging backend is not healthy; refusing smoke"
   if [[ "$live_commit" != "$DEPLOY_SHA" ]]; then
-    live_image="$(docker inspect -f '{{.Config.Image}}' "$BACKEND_CONTAINER" 2>/dev/null || true)"
-    if [[ "$live_image" == "ghcr.io/${IMAGE_OWNER}/metasheet2-backend:${DEPLOY_SHA}" ]] \
-       && curl -sS --max-time 10 "$STAGING_WEB_HEALTH_URL" | grep -q '"ok":true'; then
-      log "smoke identity: health build.commit stale ('${live_commit:-<unreachable>}', env-pinned) but backend image tag matches deploy sha: ${live_image}"
-    else
-      fail "staging identity failed BOTH channels for smoke: /api/health build.commit='${live_commit:-<unreachable>}' and backend image='${live_image:-<none>}' vs deploy_sha=${DEPLOY_SHA}; refusing to smoke a mismatched build"
-    fi
+    log "smoke identity: health build.commit stale ('${live_commit:-<unreachable>}', env-pinned) but recorded immutable digests match deploy sha ${DEPLOY_SHA}"
   fi
 
   prepare_container_runner
@@ -1284,12 +1570,13 @@ soak_require_backend_clis() {
 }
 
 soak_backend_image_sha() {
-  # stdout: the RUNNING backend image's full-SHA tag; fails when the pin is not full-SHA.
-  local live_image
-  live_image="$(docker inspect -f '{{.Config.Image}}' "$BACKEND_CONTAINER")"
-  [[ "$live_image" =~ :([0-9a-f]{40})$ ]] \
-    || fail "backend image tag is not a full-SHA pin: '${live_image}'"
-  printf '%s' "${BASH_REMATCH[1]}"
+  # stdout: the full deploy SHA whose recorded immutable digests match both RUNNING images.
+  local recorded_sha
+  recorded_sha="$(read_deploy_identity_field deploy_sha)"
+  [[ "$recorded_sha" =~ ^[0-9a-f]{40}$ ]] \
+    || fail "deploy identity record has an invalid full SHA"
+  assert_running_deploy_identity "$recorded_sha"
+  printf '%s' "$recorded_sha"
 }
 
 action_soak_baseline() {
@@ -1305,12 +1592,11 @@ action_soak_baseline() {
     fail "refusing to capture the p95 baseline: ${SOAK_W4_ENV_NAME}='${w4_env:-<unset>}' ${SOAK_W7_ENV_NAME}='${w7_env:-<unset>}' already set on the serving backend — the baseline must precede the flags (P95-BASELINE-CAPTURE-PACK-20260816; an unanchored +5% claim is not evidence)"
   fi
   soak_resolve_pg
-  # Build identity = the CONTAINER IMAGE TAG SHA. This is the accepted staging deploy
+  # Build identity = the deploy SHA whose persisted record pins both CONTAINER IMAGE DIGESTS.
+  # This is the accepted staging deploy
   # identity (L6 precedent: /api/health build.commit can be env-pinned stale, so it is NOT a
   # reliable identity — recorded below only as an informational cross-check). Recording the
-  # image-tag SHA is load-bearing for the soak-flags SHA-scope gate (P2-2): soak-flags
-  # requires DEPLOY_SHA == the running image tag, so the marker's staging_build_commit must
-  # be that same channel or the comparison would false-mismatch on a stale health commit.
+  # recorded SHA is load-bearing for the soak-flags SHA-scope gate (P2-2).
   local live_commit commit sha8 ts
   live_commit="$(fetch_health_commit)"
   commit="$(soak_backend_image_sha)"
@@ -1889,6 +2175,8 @@ action_soak_flags() {
   soak_require_orgs
   require_sha
   require_compose_v2
+  trap cleanup_deploy_env_snapshot EXIT
+  prepare_deploy_env_snapshot
   # ORDER ENFORCEMENT (second half of the baseline<->flags gate): the marker only exists
   # once action=soak-baseline captured a PRE-enablement p95 baseline.
   [[ -f "$SOAK_BASELINE_MARKER" ]] \
@@ -1907,14 +2195,12 @@ action_soak_flags() {
   if [[ -f "$OVERRIDE_FILE" ]] && grep -qE 'ATTENDANCE_SCHEDULER_ENABLED|ATTENDANCE_NOTIFICATION_DELIVERY_WORKER_ENABLED' "$OVERRIDE_FILE"; then
     fail "existing runner override carries rd-window env flags; refusing to rewrite them from a soak action — redeploy with set_window_env=none first"
   fi
-  # This action changes ENV only, never images: deploy_sha must equal BOTH running images.
+  # This action changes ENV only, never images: deploy_sha must map to BOTH running digests.
+  assert_running_deploy_identity "$DEPLOY_SHA"
+  assert_deploy_env_snapshot_matches_record
   local backend_image web_image
   backend_image="$(docker inspect -f '{{.Config.Image}}' "$BACKEND_CONTAINER")"
   web_image="$(docker inspect -f '{{.Config.Image}}' "$WEB_CONTAINER")"
-  [[ "$backend_image" == "ghcr.io/${IMAGE_OWNER}/metasheet2-backend:${DEPLOY_SHA}" ]] \
-    || fail "deploy_sha must equal the RUNNING backend image tag (running: ${backend_image}) — soak-flags flips env only, never images; use action=deploy to change images"
-  [[ "$web_image" == "ghcr.io/${IMAGE_OWNER}/metasheet2-web:${DEPLOY_SHA}" ]] \
-    || fail "deploy_sha must equal the RUNNING web image tag (running: ${web_image})"
 
   local pg_id_before redis_id_before web_id_before
   pg_id_before="$(docker inspect -f '{{.Id}}' "$POSTGRES_CONTAINER")"
@@ -1941,8 +2227,8 @@ action_soak_flags() {
     echo "  web:"
     echo "    image: ${web_image}"
   } > "$soak_override_tmp"
-  if ! (cd "$STAGING_DIR" && IMAGE_OWNER="$IMAGE_OWNER" IMAGE_TAG="$DEPLOY_SHA" \
-    docker compose --project-directory "$STAGING_DIR" -f "$STAGING_COMPOSE_FILE" -f "$soak_override_tmp" config) >/dev/null 2>&1; then
+  if ! (cd "$STAGING_DIR" && IMAGE_OWNER="$IMAGE_OWNER" IMAGE_TAG="$DEPLOY_SHA" APP_ENV_FILE="$COMPOSE_ENV_FILE" \
+    docker compose --project-directory "$STAGING_DIR" --env-file "$COMPOSE_ENV_FILE" -f "$STAGING_COMPOSE_FILE" -f "$soak_override_tmp" config) >/dev/null 2>&1; then
     rm -f "$soak_override_tmp"
     fail "candidate soak override failed 'docker compose config' validation; kept previous override at ${OVERRIDE_FILE}"
   fi
@@ -1999,6 +2285,8 @@ action_soak_flags() {
     echo "window_start=$(cat "$SOAK_WINDOW_START_FILE")"
     echo "result=ok"
   } > "${OUTPUT_DIR}/summary.txt"
+  cleanup_deploy_env_snapshot
+  trap - EXIT
   log "soak-flags OK: W4=${SOAK_ORG1_SHORT},${SOAK_ORG2_SHORT},${SOAK_ORG3_SHORT} W7=${SOAK_ORG3_SHORT} live on the backend"
 }
 
@@ -2139,6 +2427,7 @@ soak_run_classify() {
 
 action_soak_run() {
   soak_validate_opts
+  assert_current_recorded_deploy_identity
   local punch_target config_path
   # Default `auto` = this run's ONE-DAY BATCH: with the 2/user/day cap (one in/out pair per
   # user per wall-clock day — same-day session packing floods §4.2-critical review_required
@@ -2359,6 +2648,7 @@ soak_status_rows() {
 
 action_soak_status() {
   soak_validate_opts
+  assert_current_recorded_deploy_identity
   soak_resolve_pg
   local window_start
   window_start="$(soak_opt window_start '')"

--- a/scripts/ops/attendance-window-runner-pipeline.test.mjs
+++ b/scripts/ops/attendance-window-runner-pipeline.test.mjs
@@ -41,6 +41,89 @@ function runPlainBash(script) {
   return spawnSync('bash', ['-c', script], { encoding: 'utf8' })
 }
 
+function extractShellFunction(source, name) {
+  const start = source.indexOf(`${name}() {`)
+  assert.notEqual(start, -1, `shell function missing: ${name}`)
+  const end = source.indexOf('\n}\n', start)
+  assert.notEqual(end, -1, `shell function end missing: ${name}`)
+  return source.slice(start, end + 3)
+}
+
+function runImmutableResolver(source, taggedImage, inspectOutput) {
+  const resolver = extractShellFunction(source, 'resolve_immutable_repo_digest')
+  return spawnSync('bash', ['-o', 'pipefail', '-c', `set -euo pipefail
+fail() { printf '%s\\n' "$*" >&2; exit 1; }
+docker() { printf '%s\\n' "$MOCK_INSPECT"; }
+${resolver}
+resolve_immutable_repo_digest "$TAGGED_IMAGE"`], {
+    encoding: 'utf8',
+    env: { ...process.env, TAGGED_IMAGE: taggedImage, MOCK_INSPECT: inspectOutput },
+  })
+}
+
+function runDeployEnvSnapshot(source, { failCopy = false } = {}) {
+  const dir = mkdtempSync(join(tmpdir(), 'window-runner-env-snapshot-'))
+  const envFile = join(dir, 'staging.env')
+  writeFileSync(envFile, 'DATABASE_URL=postgresql://staging.example/db\nSECRET_VALUE=not-logged\n')
+
+  const hashValue = extractShellFunction(source, 'hash_value')
+  const cleanup = extractShellFunction(source, 'cleanup_deploy_env_snapshot')
+  const prepare = extractShellFunction(source, 'prepare_deploy_env_snapshot')
+  const copyOverride = failCopy ? 'cp() { return 7; }' : ''
+  const script = `set -euo pipefail
+log() { :; }
+fail() { printf '%s\\n' "$*" >&2; exit 1; }
+${hashValue}
+${cleanup}
+${prepare}
+${copyOverride}
+STAGING_ENV_FILE="$TEST_ENV_FILE"
+RUNNER_PERSIST_DIR="$TEST_PERSIST_DIR"
+COMPOSE_ENV_FILE="$STAGING_ENV_FILE"
+DEPLOY_ENV_SNAPSHOT=""
+trap cleanup_deploy_env_snapshot EXIT
+prepare_deploy_env_snapshot
+snapshot="$DEPLOY_ENV_SNAPSHOT"
+cmp -s "$STAGING_ENV_FILE" "$snapshot"
+mode="$(stat -f '%Lp' "$snapshot" 2>/dev/null || stat -c '%a' "$snapshot")"
+printf 'mode=%s\\n' "$mode"
+printf 'selected_snapshot=%s\\n' "$([[ "$COMPOSE_ENV_FILE" == "$snapshot" ]] && echo 1 || echo 0)"
+cleanup_deploy_env_snapshot
+trap - EXIT
+printf 'cleanup=%s\\n' "$([[ ! -e "$snapshot" && "$COMPOSE_ENV_FILE" == "$STAGING_ENV_FILE" ]] && echo 1 || echo 0)"`
+
+  const result = spawnSync('bash', ['-o', 'pipefail', '-c', script], {
+    encoding: 'utf8',
+    env: { ...process.env, TEST_ENV_FILE: envFile, TEST_PERSIST_DIR: dir },
+  })
+  const residue = readdirSync(dir).filter((name) => name.startsWith('.deploy-env.'))
+  rmSync(dir, { recursive: true, force: true })
+  return { ...result, residue }
+}
+
+function assertImmutableResolverContract(remote) {
+  const repository = 'ghcr.io/zensgit/metasheet2-backend'
+  const tag = `${repository}:${'a'.repeat(40)}`
+  const expected = `${repository}@sha256:${'b'.repeat(64)}`
+  const good = runImmutableResolver(
+    remote,
+    tag,
+    [`other.example/backend@sha256:${'c'.repeat(64)}`, expected, `${repository}@sha256:${'d'.repeat(64)}`].join('\n'),
+  )
+  assert.equal(good.status, 0, good.stderr)
+  assert.equal(good.stdout, expected, 'resolver must return the first exact-repository digest, never the mutable tag')
+
+  for (const inspectOutput of [
+    '',
+    `other.example/backend@sha256:${'c'.repeat(64)}`,
+    `${repository}@sha256:${'b'.repeat(63)}`,
+    `${repository}@sha256:${'g'.repeat(64)}`,
+  ]) {
+    const rejected = runImmutableResolver(remote, tag, inspectOutput)
+    assert.notEqual(rejected.status, 0, `resolver must reject invalid inspect output: ${inspectOutput}`)
+  }
+}
+
 test('leg (a): zero grep matches in the pipeline still exits 0 (normal outcome)', () => {
   const dir = mkdtempSync(join(tmpdir(), 'window-runner-pipe-'))
   const out = join(dir, 'filtered.log')
@@ -153,18 +236,18 @@ function assertPersistentComposeContract({ workflow, remote, lifecycleRemote, st
   assert.match(stagingCompose, /METASHEET_BUILD_IMAGE_TAG: \$\{IMAGE_TAG:-unknown\}/)
   assert.match(
     remote,
-    /IMAGE_OWNER="\$IMAGE_OWNER" IMAGE_TAG="\$DEPLOY_SHA" \\\n\s+docker compose --project-directory "\$STAGING_DIR" -f "\$STAGING_COMPOSE_FILE" -f "\$OVERRIDE_FILE"/,
+    /IMAGE_OWNER="\$IMAGE_OWNER" IMAGE_TAG="\$DEPLOY_SHA" APP_ENV_FILE="\$COMPOSE_ENV_FILE" \\\n\s+docker compose --project-directory "\$STAGING_DIR" --env-file "\$COMPOSE_ENV_FILE" -f "\$STAGING_COMPOSE_FILE" -f "\$OVERRIDE_FILE"/,
     'live pull/up must render health identity from the exact deploy SHA',
   )
   assert.match(
     deploy,
-    /IMAGE_OWNER="\$IMAGE_OWNER" IMAGE_TAG="\$DEPLOY_SHA" \\\n\s+docker compose --project-directory "\$STAGING_DIR" -f "\$STAGING_COMPOSE_CANDIDATE_TMP" -f "\$override_tmp" config/,
+    /IMAGE_OWNER="\$IMAGE_OWNER" IMAGE_TAG="\$DEPLOY_SHA" APP_ENV_FILE="\$COMPOSE_ENV_FILE" \\\n\s+docker compose --project-directory "\$STAGING_DIR" --env-file "\$COMPOSE_ENV_FILE" -f "\$STAGING_COMPOSE_CANDIDATE_TMP" -f "\$override_tmp" config/,
     'base/override validation must use the same exact-SHA interpolation as live pull/up',
   )
   assert.equal(
     (remote.match(/docker compose --project-directory "\$STAGING_DIR"/g) || []).length,
-    4,
-    'every non-version-check attendance compose invocation must pin the staging project directory (compose_staging, deploy compose-candidate validation, deploy pair validation, soak-flags pair validation)',
+    5,
+    'every non-version-check attendance compose invocation must pin the staging project directory (compose_staging, deploy compose-candidate validation, deploy pair validation, candidate-env fingerprint, soak-flags pair validation)',
   )
   assert.equal(
     (lifecycleRemote.match(/docker compose --project-directory "\$STAGING_DIR"/g) || []).length,
@@ -176,6 +259,215 @@ function assertPersistentComposeContract({ workflow, remote, lifecycleRemote, st
   }
 }
 
+function composeServiceBlock(source, serviceName) {
+  const marker = `  ${serviceName}:\n`
+  const start = source.indexOf(marker)
+  assert.notEqual(start, -1, `compose service missing: ${serviceName}`)
+  const tail = source.slice(start + marker.length)
+  const next = tail.search(/\n  [A-Za-z0-9_-]+:\n|\nvolumes:\n/)
+  return source.slice(start, next === -1 ? source.length : start + marker.length + next)
+}
+
+function assertCandidateMigrationPreflightContract({ remote, stagingCompose }) {
+  assert.match(
+    remote,
+    /STAGING_ENV_FILE="\$\{STAGING_DIR\}\/docker\/app\.staging\.env"/,
+    'attendance deploy must name the canonical staging env file explicitly',
+  )
+  assert.match(remote, /COMPOSE_ENV_FILE="\$STAGING_ENV_FILE"/)
+  assert.match(remote, /DEPLOY_ENV_SNAPSHOT="\$candidate"/)
+  assert.match(remote, /COMPOSE_ENV_FILE="\$DEPLOY_ENV_SNAPSHOT"/)
+  assert.match(remote, /DEPLOY_IDENTITY_FILE="\$\{RUNNER_PERSIST_DIR\}\/deploy-identity\.env"/)
+  assert.match(
+    remote,
+    /before="\$\(hash_value "\$STAGING_ENV_FILE"\)"[\s\S]*?cp "\$STAGING_ENV_FILE" "\$candidate"[\s\S]*?after="\$\(hash_value "\$STAGING_ENV_FILE"\)"[\s\S]*?snapshot_hash="\$\(hash_value "\$candidate"\)"[\s\S]*?"\$before" == "\$after" && "\$after" == "\$snapshot_hash"/,
+    'deploy env snapshot must prove a stable copy before use',
+  )
+  assert.match(remote, /chmod 600 "\$candidate"/)
+  assert.match(
+    remote,
+    /find "\$RUNNER_PERSIST_DIR" -maxdepth 1 -type f -name '\.deploy-env\.\*' -mmin \+60 -delete/,
+    'a new deploy must remove abandoned secret snapshots left by untrappable process death',
+  )
+
+  const composeInvocations = remote.match(/docker compose --project-directory "\$STAGING_DIR"/g) || []
+  const envFileBindings = remote.match(
+    /docker compose --project-directory "\$STAGING_DIR" --env-file "\$COMPOSE_ENV_FILE"/g,
+  ) || []
+  assert.equal(
+    envFileBindings.length,
+    composeInvocations.length,
+    'every attendance compose invocation must bind the selected canonical-or-snapshot env file',
+  )
+  assert.equal(
+    (remote.match(/APP_ENV_FILE="\$COMPOSE_ENV_FILE"/g) || []).length,
+    composeInvocations.length,
+    'every attendance compose invocation must use the same selected env_file interpolation',
+  )
+  for (const serviceName of ['postgres', 'backend']) {
+    assert.match(
+      composeServiceBlock(stagingCompose, serviceName),
+      /env_file:\n\s+- \$\{APP_ENV_FILE:-\.\/docker\/app\.staging\.env\}/,
+      `${serviceName} must consume the APP_ENV_FILE interpolation pinned by the runner`,
+    )
+  }
+
+  const envKeysMatch = remote.match(/CANDIDATE_DB_ENV_KEYS=\(\n([\s\S]*?)\n\)/)
+  assert.ok(envKeysMatch, 'candidate DB env allowlist must exist')
+  const envKeys = envKeysMatch[1].trim().split(/\s+/)
+  assert.deepEqual(envKeys, [
+    'DATABASE_URL',
+    'NODE_ENV',
+    'SECRET_PROVIDER',
+    'ALLOW_SECRET_FALLBACK',
+    'DB_SSL',
+    'DB_SSL_REJECT_UNAUTHORIZED',
+    'DB_SSL_CA',
+    'DB_SSL_CERT',
+    'DB_SSL_KEY',
+    'DB_POOL_MAX',
+    'DB_POOL_MIN',
+    'DB_IDLE_TIMEOUT',
+    'DB_CONNECT_TIMEOUT',
+    'DB_QUERY_TIMEOUT',
+    'DB_STATEMENT_TIMEOUT',
+    'DB_SLOW_MS',
+    'APP_NAME',
+    'NODE_EXTRA_CA_CERTS',
+    'MIGRATION_INCLUDE_SUPERSEDED_LEGACY_SQL',
+    'MIGRATION_EXCLUDE',
+  ])
+
+  const preflightStart = remote.indexOf('run_candidate_migration_preflight() {')
+  const preflightEnd = remote.indexOf('\naction_deploy() {', preflightStart)
+  assert.ok(preflightStart >= 0 && preflightEnd > preflightStart, 'candidate migration preflight function must exist')
+  const preflight = remote.slice(preflightStart, preflightEnd)
+  assert.match(preflight, /docker run --rm/)
+  assert.match(preflight, /--network "container:\$\{BACKEND_CONTAINER\}"/)
+  assert.match(preflight, /for key in "\$\{CANDIDATE_DB_ENV_KEYS\[@\]\}"/)
+  assert.match(preflight, /env_args\+=\(--env "\$key"\)/)
+  assert.match(preflight, /"\$\{env_args\[@\]\}"/)
+  assert.doesNotMatch(preflight, /docker run[\s\S]*?--env-file\b/)
+  assert.match(preflight, /"\$backend_image" node "\$MIGRATE_JS" --list/)
+
+  const offlineStart = preflight.indexOf('  if ! docker run --rm', preflight.indexOf('tee "$list_file"'))
+  const offlineEnd = preflight.indexOf('  mapfile -t decisions', offlineStart)
+  assert.ok(offlineStart >= 0 && offlineEnd > offlineStart, 'offline alignment-report leg must exist')
+  const offlineLeg = preflight.slice(offlineStart, offlineEnd)
+  assert.match(
+    offlineLeg,
+    /docker run --rm \\\n\s+--user "\$\(id -u\):\$\(id -g\)" \\\n\s+--network none \\\n[\s\S]*?staging-migration-alignment-report\.mjs/,
+    'the offline report must run without network, secrets, or root-owned host artifacts',
+  )
+  assert.doesNotMatch(offlineLeg, /--env(?:-file)?\b|env_args/, 'offline report must receive no environment input')
+  assert.match(preflight, /live_fingerprint="\$\(live_database_env_fingerprint\)"/)
+  assert.match(preflight, /candidate_fingerprint="\$\(candidate_database_env_fingerprint "\$backend_image" "\$base_candidate" "\$override_candidate"\)"/)
+  assert.match(
+    preflight,
+    /if \[\[ "\$live_fingerprint" != "\$candidate_fingerprint" \]\]; then[\s\S]*?return 1[\s\S]*?fi/,
+    'candidate and live DB/migration environments must match before the networked probe',
+  )
+  assert.match(remote, /config\["services"\]\["backend"\]\.get\("environment", \{\}\)/)
+  assert.match(
+    preflight,
+    /mapfile -t decisions < <\(sed -n '[^']*decision=[^']*' "\$stdout_file"\)[\s\S]*?if \[\[ "\$\{#decisions\[@\]\}" -ne 1 \|\| "\$\{decisions\[0\]\}" != "aligned" \]\]; then[\s\S]*?return 1[\s\S]*?fi/,
+    'only one exact aligned decision may pass the preflight',
+  )
+
+  const deployStart = remote.indexOf('action_deploy() {')
+  const deployEnd = remote.indexOf('\naction_smoke() {', deployStart)
+  const deploy = remote.slice(deployStart, deployEnd)
+  const imagePullIndex = deploy.indexOf('docker pull "$backend_image"')
+  const preflightCallIndex = deploy.indexOf('run_candidate_migration_preflight "$backend_immutable"')
+  const baseMoveIndex = deploy.indexOf('mv -f "$STAGING_COMPOSE_CANDIDATE_TMP" "$PERSISTENT_STAGING_COMPOSE_FILE"')
+  const liveUpIndex = deploy.indexOf('compose_staging "${up_args[@]}"')
+  const snapshotIndex = deploy.indexOf('prepare_deploy_env_snapshot')
+  const snapshotTrapIndex = deploy.indexOf('trap cleanup_deploy_env_snapshot EXIT')
+  const identityInvalidateIndex = deploy.indexOf('rm -f "$DEPLOY_IDENTITY_FILE"')
+  const identityWriteIndex = deploy.indexOf('write_deploy_identity_record "$DEPLOY_SHA" "$backend_immutable" "$web_immutable" "$deploy_env_sha256"')
+  const healthIndex = deploy.indexOf('wait_for_health_commit "$DEPLOY_SHA" "$backend_immutable" "$web_immutable"')
+  const authIndex = deploy.indexOf('auth_round_trip')
+  const summaryIndex = deploy.indexOf('> "${OUTPUT_DIR}/summary.txt"')
+  assert.match(
+    deploy,
+    /mapfile -t live_decisions < <\(sed -n '[^']*decision=[^']*' "\$\{OUTPUT_DIR\}\/migration-alignment-stdout\.txt"\)[\s\S]*?if \[\[ "\$\{#live_decisions\[@\]\}" -ne 1 \|\| "\$\{live_decisions\[0\]\}" != "aligned" \]\]; then[\s\S]*?fail "live migration alignment must emit exactly one decision=aligned/,
+    'the post-up report must repeat the exact-aligned gate before migrate',
+  )
+  assert.ok(imagePullIndex >= 0, 'candidate backend image must be pulled before its preflight runs')
+  assert.match(
+    deploy,
+    /run_candidate_migration_preflight "\$backend_immutable" "\$STAGING_COMPOSE_CANDIDATE_TMP" "\$override_tmp" \|\| preflight_rc=\$\?[\s\S]*?if \[\[ "\$preflight_rc" -ne 0 \]\]; then[\s\S]*?fail "candidate migration preflight failed before deployment;/,
+    'deploy must stop on every candidate preflight failure before changing live state',
+  )
+  assert.ok(snapshotIndex >= 0 && snapshotIndex < preflightCallIndex, 'deploy must snapshot env before preflight')
+  assert.ok(snapshotTrapIndex >= 0 && snapshotTrapIndex < snapshotIndex, 'snapshot cleanup trap must be armed before snapshot creation')
+  assert.match(deploy, /trap cleanup_deploy_env_snapshot EXIT/)
+  assert.match(deploy, /cleanup_deploy_env_snapshot\n\s+trap - EXIT/)
+  assert.match(deploy, /backend_immutable="\$\(resolve_immutable_repo_digest "\$backend_image"\)"/)
+  assert.match(deploy, /web_immutable="\$\(resolve_immutable_repo_digest "\$web_image"\)"/)
+  assert.match(deploy, /echo "    image: \$\{backend_immutable\}"/)
+  assert.match(deploy, /echo "    image: \$\{web_immutable\}"/)
+  assert.equal((deploy.match(/docker pull "\$backend_image"/g) || []).length, 1)
+  assert.equal((deploy.match(/docker pull "\$web_image"/g) || []).length, 1)
+  assert.doesNotMatch(
+    deploy.slice(preflightCallIndex),
+    /(?:docker|compose_staging) pull\b/,
+    'no image may be pulled again after immutable digests have been preflighted',
+  )
+  assert.doesNotMatch(
+    deploy,
+    /STAGING_ENV_FILE/,
+    'deploy must use only its immutable per-run env snapshot after capture',
+  )
+  assert.match(deploy, /running_backend_image.*?== "\$backend_immutable"/s)
+  assert.match(deploy, /running_web_image.*?== "\$web_immutable"/s)
+  assert.ok(
+    preflightCallIndex < identityInvalidateIndex && identityInvalidateIndex < baseMoveIndex,
+    'deploy must invalidate any prior completion record after preflight but before persistent or live state changes',
+  )
+  assert.ok(
+    liveUpIndex < healthIndex && healthIndex < authIndex && authIndex < summaryIndex && summaryIndex < identityWriteIndex,
+    'deploy must persist its completion identity only after health, migration/auth, and summary gates pass',
+  )
+  assert.match(
+    remote,
+    /write_deploy_identity_record\(\)[\s\S]*?mktemp "\$\{RUNNER_PERSIST_DIR\}\/\.deploy-identity\.XXXXXX"[\s\S]*?chmod 600 "\$candidate"[\s\S]*?echo "env_sha256=\$\{env_sha256\}"[\s\S]*?mv -f "\$candidate" "\$DEPLOY_IDENTITY_FILE"/,
+    'the values-free deploy identity record must be written atomically',
+  )
+  assert.match(
+    remote,
+    /wait_for_health_commit\(\)[\s\S]*?local expected="\$1" expected_digest="\$2" expected_web_digest="\$3"[\s\S]*?if \[\[ "\$live_image" == "\$expected_digest" \]\]; then/,
+    'health fallback must compare the running image to the preflighted immutable digest',
+  )
+  assert.equal(
+    (extractShellFunction(remote, 'wait_for_health_commit').match(/assert_running_image_digests "\$expected_digest" "\$expected_web_digest"/g) || []).length,
+    2,
+    'both health-commit and digest-fallback success paths must recheck the running backend and web digests',
+  )
+  assert.match(
+    remote,
+    /action_smoke\(\)[\s\S]*?assert_running_deploy_identity "\$DEPLOY_SHA"[\s\S]*?"ok":true/,
+    'smoke must verify the persisted SHA-to-digest mapping and live health',
+  )
+  assert.match(
+    remote,
+    /soak_backend_image_sha\(\)[\s\S]*?assert_running_deploy_identity "\$recorded_sha"[\s\S]*?printf '%s' "\$recorded_sha"/,
+    'soak baseline identity must resolve through the same immutable deploy record',
+  )
+  assert.ok(
+    imagePullIndex < preflightCallIndex,
+    'candidate backend image must be pulled before the candidate migration preflight',
+  )
+  assert.ok(
+    preflightCallIndex < baseMoveIndex,
+    'candidate migration preflight must pass before persistent compose files change',
+  )
+  assert.ok(
+    preflightCallIndex < liveUpIndex,
+    'candidate migration preflight must pass before backend/web containers are recreated',
+  )
+}
+
 test('deploy ships and atomically installs the checked-out staging compose at a persistent path', () => {
   assertPersistentComposeContract({
     workflow: readFileSync(WORKFLOW, 'utf8'),
@@ -183,6 +475,289 @@ test('deploy ships and atomically installs the checked-out staging compose at a 
     lifecycleRemote: readFileSync(LIFECYCLE_REMOTE_SH, 'utf8'),
     stagingCompose: readFileSync(STAGING_COMPOSE, 'utf8'),
   })
+})
+
+test('deploy preflights candidate-image migrations before persistent config or live containers change', () => {
+  assertCandidateMigrationPreflightContract({
+    remote: readFileSync(REMOTE_SH, 'utf8'),
+    stagingCompose: readFileSync(STAGING_COMPOSE, 'utf8'),
+  })
+})
+
+test('immutable image resolver accepts only a valid digest for the exact repository', () => {
+  assertImmutableResolverContract(readFileSync(REMOTE_SH, 'utf8'))
+})
+
+test('deploy env snapshot is exact, mode 0600, selected for the run, and removed', () => {
+  const result = runDeployEnvSnapshot(readFileSync(REMOTE_SH, 'utf8'))
+  assert.equal(result.status, 0, result.stderr)
+  assert.match(result.stdout, /^mode=600$/m)
+  assert.match(result.stdout, /^selected_snapshot=1$/m)
+  assert.match(result.stdout, /^cleanup=1$/m)
+  assert.deepEqual(result.residue, [], 'successful cleanup must leave no per-run env snapshot')
+})
+
+test('deploy env snapshot is removed when copying the canonical env fails', () => {
+  const result = runDeployEnvSnapshot(readFileSync(REMOTE_SH, 'utf8'), { failCopy: true })
+  assert.notEqual(result.status, 0, 'copy failure must fail closed')
+  assert.deepEqual(result.residue, [], 'the EXIT trap must remove a partially-created env snapshot')
+})
+
+test('MUTATION: returning the original tag from the immutable resolver turns the executable contract red', () => {
+  const original = readFileSync(REMOTE_SH, 'utf8')
+  const resolver = extractShellFunction(original, 'resolve_immutable_repo_digest')
+  const mutatedResolver = resolver.replace(`printf '%s' "$digest"`, `printf '%s' "$tagged_image"`)
+  assert.notEqual(mutatedResolver, resolver, 'mutation anchor must replace the resolver output')
+  const mutated = original.replace(resolver, mutatedResolver)
+  assert.throws(() => assertImmutableResolverContract(mutated), /first exact-repository digest/)
+})
+
+test('MUTATION: moving the candidate migration preflight after persistent-file replacement turns the contract red', () => {
+  const original = readFileSync(REMOTE_SH, 'utf8')
+  const call = '  run_candidate_migration_preflight "$backend_immutable" "$STAGING_COMPOSE_CANDIDATE_TMP" "$override_tmp" || preflight_rc=$?\n'
+  const move = '  mv -f "$STAGING_COMPOSE_CANDIDATE_TMP" "$PERSISTENT_STAGING_COMPOSE_FILE"\n'
+  const mutated = original.replace(call, '').replace(move, `${move}${call}`)
+  assert.throws(
+    () => assertCandidateMigrationPreflightContract({
+      remote: mutated,
+      stagingCompose: readFileSync(STAGING_COMPOSE, 'utf8'),
+    }),
+    /stop on every candidate preflight failure|before persistent compose files change/,
+  )
+})
+
+test('MUTATION: dropping the selected env-file binding from attendance compose turns the contract red', () => {
+  const original = readFileSync(REMOTE_SH, 'utf8')
+  const mutated = original.replaceAll(' --env-file "$COMPOSE_ENV_FILE"', '')
+  assert.throws(
+    () => assertCandidateMigrationPreflightContract({
+      remote: mutated,
+      stagingCompose: readFileSync(STAGING_COMPOSE, 'utf8'),
+    }),
+    /bind the selected canonical-or-snapshot env file/,
+  )
+})
+
+test('MUTATION: rereading the canonical env after snapshot capture turns the contract red', () => {
+  const original = readFileSync(REMOTE_SH, 'utf8')
+  const deployStart = original.indexOf('action_deploy() {')
+  const deployEnd = original.indexOf('\naction_smoke() {', deployStart)
+  const deploy = original.slice(deployStart, deployEnd)
+  const mutatedDeploy = deploy.replace(
+    '--env-file "$COMPOSE_ENV_FILE" -f "$STAGING_COMPOSE_CANDIDATE_TMP" -f "$override_tmp" config',
+    '--env-file "$STAGING_ENV_FILE" -f "$STAGING_COMPOSE_CANDIDATE_TMP" -f "$override_tmp" config',
+  )
+  assert.notEqual(mutatedDeploy, deploy, 'mutation fixture must replace one deploy env snapshot binding')
+  const mutated = original.slice(0, deployStart) + mutatedDeploy + original.slice(deployEnd)
+  assert.throws(
+    () => assertCandidateMigrationPreflightContract({
+      remote: mutated,
+      stagingCompose: readFileSync(STAGING_COMPOSE, 'utf8'),
+    }),
+    /immutable per-run env snapshot|bind the selected canonical-or-snapshot env file/,
+  )
+})
+
+test('MUTATION: pulling the backend again after preflight turns the contract red', () => {
+  const original = readFileSync(REMOTE_SH, 'utf8')
+  const move = '  mv -f "$STAGING_COMPOSE_CANDIDATE_TMP" "$PERSISTENT_STAGING_COMPOSE_FILE"\n'
+  const mutated = original.replace(move, `  docker pull "$backend_image"\n${move}`)
+  assert.notEqual(mutated, original, 'mutation fixture must add a post-preflight pull')
+  assert.throws(
+    () => assertCandidateMigrationPreflightContract({
+      remote: mutated,
+      stagingCompose: readFileSync(STAGING_COMPOSE, 'utf8'),
+    }),
+    /no image may be pulled again|Expected values to be strictly equal/,
+  )
+})
+
+test('MUTATION: restoring mutable tags in the persisted override turns the contract red', () => {
+  const original = readFileSync(REMOTE_SH, 'utf8')
+  const mutated = original
+    .replace('echo "    image: ${backend_immutable}"', 'echo "    image: ${backend_image}"')
+    .replace('echo "    image: ${web_immutable}"', 'echo "    image: ${web_image}"')
+  assert.notEqual(mutated, original, 'mutation fixture must restore mutable image tags')
+  assert.throws(
+    () => assertCandidateMigrationPreflightContract({
+      remote: mutated,
+      stagingCompose: readFileSync(STAGING_COMPOSE, 'utf8'),
+    }),
+    /backend_immutable|web_immutable/,
+  )
+})
+
+test('MUTATION: restoring tag-only health fallback turns the identity contract red', () => {
+  const original = readFileSync(REMOTE_SH, 'utf8')
+  const mutated = original.replace(
+    '  if [[ "$live_image" == "$expected_digest" ]]; then\n',
+    '  if [[ "$live_image" == *":${expected}" ]]; then\n',
+  )
+  assert.notEqual(mutated, original, 'mutation anchor must restore the tag-only fallback')
+  assert.throws(
+    () => assertCandidateMigrationPreflightContract({
+      remote: mutated,
+      stagingCompose: readFileSync(STAGING_COMPOSE, 'utf8'),
+    }),
+    /health fallback must compare.*immutable digest/,
+  )
+})
+
+test('MUTATION: removing the persisted deploy identity write turns the contract red', () => {
+  const original = readFileSync(REMOTE_SH, 'utf8')
+  const mutated = original.replace(
+    '  write_deploy_identity_record "$DEPLOY_SHA" "$backend_immutable" "$web_immutable" "$deploy_env_sha256"\n',
+    '',
+  )
+  assert.notEqual(mutated, original, 'mutation anchor must remove the deploy identity write')
+  assert.throws(
+    () => assertCandidateMigrationPreflightContract({
+      remote: mutated,
+      stagingCompose: readFileSync(STAGING_COMPOSE, 'utf8'),
+    }),
+    /persist (?:the verified SHA-to-digest|its completion) identity/,
+  )
+})
+
+test('MUTATION: retaining an old deploy identity across the first live change turns the contract red', () => {
+  const original = readFileSync(REMOTE_SH, 'utf8')
+  const mutated = original.replace('  rm -f "$DEPLOY_IDENTITY_FILE"\n', '')
+  assert.notEqual(mutated, original, 'mutation anchor must remove the prior-identity invalidation')
+  assert.throws(
+    () => assertCandidateMigrationPreflightContract({
+      remote: mutated,
+      stagingCompose: readFileSync(STAGING_COMPOSE, 'utf8'),
+    }),
+    /invalidate any prior completion record/,
+  )
+})
+
+test('MUTATION: persisting deploy identity before health and auth gates turns the contract red', () => {
+  const original = readFileSync(REMOTE_SH, 'utf8')
+  const write = '  write_deploy_identity_record "$DEPLOY_SHA" "$backend_immutable" "$web_immutable" "$deploy_env_sha256"\n'
+  const health = '  wait_for_health_commit "$DEPLOY_SHA" "$backend_immutable" "$web_immutable"\n'
+  const mutated = original.replace(write, '').replace(health, `${write}${health}`)
+  assert.notEqual(mutated, original, 'mutation anchor must move the completion record before health')
+  assert.throws(
+    () => assertCandidateMigrationPreflightContract({
+      remote: mutated,
+      stagingCompose: readFileSync(STAGING_COMPOSE, 'utf8'),
+    }),
+    /only after health, migration\/auth, and summary gates pass/,
+  )
+})
+
+test('MUTATION: arming snapshot cleanup after snapshot creation turns the contract red', () => {
+  const original = readFileSync(REMOTE_SH, 'utf8')
+  const deployStart = original.indexOf('action_deploy() {')
+  const deployEnd = original.indexOf('\naction_smoke() {', deployStart)
+  const deploy = original.slice(deployStart, deployEnd)
+  const mutatedDeploy = deploy
+    .replace('  trap cleanup_deploy_env_snapshot EXIT\n', '')
+    .replace('  prepare_deploy_env_snapshot\n', '  prepare_deploy_env_snapshot\n  trap cleanup_deploy_env_snapshot EXIT\n')
+  assert.notEqual(mutatedDeploy, deploy, 'mutation fixture must move the cleanup trap')
+  const mutated = original.slice(0, deployStart) + mutatedDeploy + original.slice(deployEnd)
+  assert.throws(
+    () => assertCandidateMigrationPreflightContract({
+      remote: mutated,
+      stagingCompose: readFileSync(STAGING_COMPOSE, 'utf8'),
+    }),
+    /cleanup trap must be armed before snapshot creation/,
+  )
+})
+
+test('MUTATION: accepting every non-do-not decision turns the exact-aligned contract red', () => {
+  const original = readFileSync(REMOTE_SH, 'utf8')
+  const mutated = original.replace(
+    '  if [[ "${#decisions[@]}" -ne 1 || "${decisions[0]}" != "aligned" ]]; then\n',
+    '  if [[ "${decisions[0]:-}" == "do_not_run_full_migrate" ]]; then\n',
+  )
+  assert.throws(
+    () => assertCandidateMigrationPreflightContract({
+      remote: mutated,
+      stagingCompose: readFileSync(STAGING_COMPOSE, 'utf8'),
+    }),
+    /only one exact aligned decision may pass/,
+  )
+})
+
+test('MUTATION: weakening the post-up migration decision gate turns the contract red', () => {
+  const original = readFileSync(REMOTE_SH, 'utf8')
+  const mutated = original.replace(
+    '  if [[ "${#live_decisions[@]}" -ne 1 || "${live_decisions[0]}" != "aligned" ]]; then\n',
+    '  if [[ "${live_decisions[0]:-}" == "do_not_run_full_migrate" ]]; then\n',
+  )
+  assert.notEqual(mutated, original, 'mutation anchor must weaken the post-up decision gate')
+  assert.throws(
+    () => assertCandidateMigrationPreflightContract({
+      remote: mutated,
+      stagingCompose: readFileSync(STAGING_COMPOSE, 'utf8'),
+    }),
+    /post-up report must repeat the exact-aligned gate/,
+  )
+})
+
+for (const serviceName of ['postgres', 'backend']) {
+  test(`MUTATION: removing APP_ENV_FILE consumption from ${serviceName} turns the contract red`, () => {
+    const original = readFileSync(STAGING_COMPOSE, 'utf8')
+    const block = composeServiceBlock(original, serviceName)
+    const mutated = original.replace(
+      block,
+      block.replace('${APP_ENV_FILE:-./docker/app.staging.env}', './docker/other.env'),
+    )
+    assert.throws(
+      () => assertCandidateMigrationPreflightContract({
+        remote: readFileSync(REMOTE_SH, 'utf8'),
+        stagingCompose: mutated,
+      }),
+      new RegExp(`${serviceName} must consume`),
+    )
+  })
+}
+
+test('MUTATION: expanding the candidate DB env allowlist to a DingTalk secret turns the contract red', () => {
+  const original = readFileSync(REMOTE_SH, 'utf8')
+  const mutated = original.replace(
+    '  DATABASE_URL\n',
+    '  DATABASE_URL\n  DINGTALK_INTERACTIVE_CARD_CLIENT_SECRET\n',
+  )
+  assert.throws(
+    () => assertCandidateMigrationPreflightContract({
+      remote: mutated,
+      stagingCompose: readFileSync(STAGING_COMPOSE, 'utf8'),
+    }),
+    /deep-equal/,
+  )
+})
+
+test('MUTATION: passing DB environment into the offline report turns the contract red', () => {
+  const original = readFileSync(REMOTE_SH, 'utf8')
+  const mutated = original.replace(
+    '    --network none \\\n',
+    '    --network none \\\n    --env DATABASE_URL \\\n',
+  )
+  assert.throws(
+    () => assertCandidateMigrationPreflightContract({
+      remote: mutated,
+      stagingCompose: readFileSync(STAGING_COMPOSE, 'utf8'),
+    }),
+    /offline report must receive no environment input/,
+  )
+})
+
+test('MUTATION: dropping the live-vs-candidate DB environment comparison turns the contract red', () => {
+  const original = readFileSync(REMOTE_SH, 'utf8')
+  const mutated = original.replace(
+    '  if [[ "$live_fingerprint" != "$candidate_fingerprint" ]]; then\n',
+    '  if false; then\n',
+  )
+  assert.throws(
+    () => assertCandidateMigrationPreflightContract({
+      remote: mutated,
+      stagingCompose: readFileSync(STAGING_COMPOSE, 'utf8'),
+    }),
+    /candidate and live DB\/migration environments must match/,
+  )
 })
 
 test('MUTATION: removing the deploy compose preparation call turns the full contract red', () => {
@@ -207,8 +782,8 @@ test('MUTATION: removing the deploy compose preparation call turns the full cont
 test('MUTATION: dropping exact-SHA interpolation from live compose turns the health contract red', () => {
   const original = readFileSync(REMOTE_SH, 'utf8')
   const mutated = original.replace(
-    'IMAGE_OWNER="$IMAGE_OWNER" IMAGE_TAG="$DEPLOY_SHA" \\\n    docker compose --project-directory "$STAGING_DIR" -f "$STAGING_COMPOSE_FILE" -f "$OVERRIDE_FILE"',
-    'docker compose --project-directory "$STAGING_DIR" -f "$STAGING_COMPOSE_FILE" -f "$OVERRIDE_FILE"',
+    'IMAGE_OWNER="$IMAGE_OWNER" IMAGE_TAG="$DEPLOY_SHA" APP_ENV_FILE="$COMPOSE_ENV_FILE" \\\n    docker compose --project-directory "$STAGING_DIR" --env-file "$COMPOSE_ENV_FILE" -f "$STAGING_COMPOSE_FILE" -f "$OVERRIDE_FILE"',
+    'APP_ENV_FILE="$COMPOSE_ENV_FILE" \\\n    docker compose --project-directory "$STAGING_DIR" --env-file "$COMPOSE_ENV_FILE" -f "$STAGING_COMPOSE_FILE" -f "$OVERRIDE_FILE"',
   )
   assert.throws(
     () => assertPersistentComposeContract({
@@ -419,14 +994,14 @@ test('persistent override: lives under $HOME/.metasheet2/window-runner, NOT the 
 test('persistent override: written atomically — mktemp candidate + docker compose config validation + rename, never a truncating write straight onto the live file', () => {
   const remote = readFileSync(REMOTE_SH, 'utf8')
   assert.match(remote, /override_tmp="\$\(mktemp "\$\{RUNNER_PERSIST_DIR\}\/\.override\.XXXXXX"\)"/, 'expected a mktemp candidate override in the persist dir (X placeholder at the END — no trailing suffix)')
-  const validateIdx = remote.indexOf('docker compose --project-directory "$STAGING_DIR" -f "$STAGING_COMPOSE_CANDIDATE_TMP" -f "$override_tmp" config')
+  const validateIdx = remote.indexOf('docker compose --project-directory "$STAGING_DIR" --env-file "$COMPOSE_ENV_FILE" -f "$STAGING_COMPOSE_CANDIDATE_TMP" -f "$override_tmp" config')
   const mvIdx = remote.indexOf('mv -f "$override_tmp" "$OVERRIDE_FILE"')
   assert.notEqual(validateIdx, -1, 'candidate override must be validated with docker compose config before replacing the live file')
   // the validation MUST run in the same cwd as compose_staging() (cd "$STAGING_DIR"), or it
   // resolves relative env_file/.env differently than the config `up -d` actually executes
   assert.match(
     remote.slice(Math.max(0, validateIdx - 120), validateIdx),
-    /\(cd "\$STAGING_DIR" && IMAGE_OWNER="\$IMAGE_OWNER" IMAGE_TAG="\$DEPLOY_SHA" \\\n\s*$/,
+    /\(cd "\$STAGING_DIR" && IMAGE_OWNER="\$IMAGE_OWNER" IMAGE_TAG="\$DEPLOY_SHA" APP_ENV_FILE="\$COMPOSE_ENV_FILE" \\\n\s*$/,
     'candidate pair validation must use the staging cwd and exact-SHA interpolation, matching compose_staging()',
   )
   assert.notEqual(mvIdx, -1, 'candidate override must be atomically renamed into place')
@@ -558,7 +1133,15 @@ function assertSoakContract({ remote, workflow }) {
   assert.match(
     workflow,
     /"\$ACTION" == "deploy" \|\| "\$ACTION" == "smoke" \|\| "\$ACTION" == "soak-flags"/,
-    'deploy_sha must be required for soak-flags (env-only action still pins the RUNNING image tags)',
+    'deploy_sha must be required for soak-flags (env-only action still pins the RUNNING image digests)',
+  )
+  assert.ok(
+    slices.run.includes('assert_current_recorded_deploy_identity'),
+    'soak-run must verify both running image digests against the recorded completed deploy',
+  )
+  assert.ok(
+    slices.status.includes('assert_current_recorded_deploy_identity'),
+    'soak-status must verify both running image digests against the recorded completed deploy',
   )
   assert.match(workflow, /export SOAK_ORGS='\$\{SOAK_ORGS\}'/, 'validated soak_orgs must reach the remote script')
   assert.match(workflow, /export SOAK_OPTS='\$\{SOAK_OPTS\}'/, 'validated soak_opts must reach the remote script')
@@ -853,10 +1436,16 @@ function assertSoakContract({ remote, workflow }) {
   // candidate->validate->rename via the SAME persistent override; backend-only recreate
   // with postgres/redis/web container-id assertions; exact env verification + health.
   const markerGateIdx = slices.flags.indexOf('[[ -f "$SOAK_BASELINE_MARKER" ]]')
+  const snapshotTrapIdx = slices.flags.indexOf('trap cleanup_deploy_env_snapshot EXIT')
+  const snapshotIdx = slices.flags.indexOf('prepare_deploy_env_snapshot')
   const overrideTmpIdx = slices.flags.indexOf('mktemp "${RUNNER_PERSIST_DIR}/.soak-override.XXXXXX"')
   const flagsValidateIdx = slices.flags.indexOf('-f "$soak_override_tmp" config')
   const flagsRenameIdx = slices.flags.indexOf('mv -f "$soak_override_tmp" "$OVERRIDE_FILE"')
   assert.notEqual(markerGateIdx, -1, 'soak-flags must gate on the soak-baseline marker (baseline BEFORE flags)')
+  assert.ok(
+    snapshotTrapIdx >= 0 && snapshotTrapIdx < snapshotIdx && snapshotIdx < markerGateIdx,
+    'soak-flags must arm cleanup and freeze the env before every validation or live change',
+  )
   // P2-2: the marker gate must be SHA-scoped — a stale-build marker (mid-soak redeploy) must
   // not satisfy it, or every later O4-2 "+5% vs baseline" anchors to the wrong image.
   assert.match(
@@ -877,6 +1466,18 @@ function assertSoakContract({ remote, workflow }) {
     slices.flags.includes('carries rd-window env flags'),
     'soak-flags must refuse to silently rewrite an rd-window override',
   )
+  assert.match(
+    slices.flags,
+    /assert_running_deploy_identity "\$DEPLOY_SHA"/,
+    'soak-flags must bind DEPLOY_SHA to both running immutable image digests before rewriting env',
+  )
+  assert.match(
+    slices.flags,
+    /assert_deploy_env_snapshot_matches_record/,
+    'soak-flags must refuse canonical env drift since the recorded deploy',
+  )
+  assert.match(slices.flags, /echo "    image: \$\{backend_image\}"/)
+  assert.match(slices.flags, /echo "    image: \$\{web_image\}"/)
   assert.match(
     slices.flags,
     /compose_staging up -d --no-deps backend 2>&1/,
@@ -909,6 +1510,7 @@ function assertSoakContract({ remote, workflow }) {
   )
   assert.ok(slices.flags.includes('"ok":true'), 'soak-flags must health-check after the recreate')
   assert.match(slices.flags, /> "\$SOAK_WINDOW_START_FILE"/, 'soak-flags must record the soak window start')
+  assert.match(slices.flags, /cleanup_deploy_env_snapshot\n\s+trap - EXIT/)
 
   // soak-run: real login route only (never minted tokens), ruled rate ceiling + daily
   // quota, generator + exact execute confirmation, flags-live order gate, tokens never
@@ -1148,6 +1750,44 @@ test('MUTATION: deleting the soak-flags baseline-marker gate turns the soak cont
   assert.throws(
     () => assertSoakContract({ remote: mutated, workflow: readFileSync(WORKFLOW, 'utf8') }),
     /baseline marker|baseline-marker/,
+  )
+})
+
+test('MUTATION: deleting the soak-flags immutable identity gate turns the soak contract red', () => {
+  const original = readFileSync(REMOTE_SH, 'utf8')
+  const slices = extractSoakSlices(original)
+  const mutatedFlags = slices.flags.replace('  assert_running_deploy_identity "$DEPLOY_SHA"\n', '')
+  const mutated = original.replace(slices.flags, mutatedFlags)
+  assert.notEqual(mutated, original, 'mutation anchor must hit the soak-flags identity gate')
+  assert.throws(
+    () => assertSoakContract({ remote: mutated, workflow: readFileSync(WORKFLOW, 'utf8') }),
+    /both running immutable image digests/,
+  )
+})
+
+for (const action of ['run', 'status']) {
+  test(`MUTATION: deleting the soak-${action} recorded deploy identity gate turns the soak contract red`, () => {
+    const original = readFileSync(REMOTE_SH, 'utf8')
+    const slices = extractSoakSlices(original)
+    const mutatedSlice = slices[action].replace('  assert_current_recorded_deploy_identity\n', '')
+    const mutated = original.replace(slices[action], mutatedSlice)
+    assert.notEqual(mutated, original, `mutation anchor must hit the soak-${action} identity gate`)
+    assert.throws(
+      () => assertSoakContract({ remote: mutated, workflow: readFileSync(WORKFLOW, 'utf8') }),
+      new RegExp(`soak-${action} must verify both running image digests`),
+    )
+  })
+}
+
+test('MUTATION: deleting the soak-flags env snapshot binding turns the soak contract red', () => {
+  const original = readFileSync(REMOTE_SH, 'utf8')
+  const slices = extractSoakSlices(original)
+  const mutatedFlags = slices.flags.replace('  assert_deploy_env_snapshot_matches_record\n', '')
+  const mutated = original.replace(slices.flags, mutatedFlags)
+  assert.notEqual(mutated, original, 'mutation anchor must hit the soak-flags env identity gate')
+  assert.throws(
+    () => assertSoakContract({ remote: mutated, workflow: readFileSync(WORKFLOW, 'utf8') }),
+    /canonical env drift/,
   )
 })
 

--- a/scripts/ops/attendance-window-runner-pipeline.test.mjs
+++ b/scripts/ops/attendance-window-runner-pipeline.test.mjs
@@ -85,7 +85,7 @@ trap cleanup_deploy_env_snapshot EXIT
 prepare_deploy_env_snapshot
 snapshot="$DEPLOY_ENV_SNAPSHOT"
 cmp -s "$STAGING_ENV_FILE" "$snapshot"
-mode="$(stat -f '%Lp' "$snapshot" 2>/dev/null || stat -c '%a' "$snapshot")"
+mode="$(stat -c '%a' "$snapshot" 2>/dev/null || stat -f '%Lp' "$snapshot")"
 printf 'mode=%s\\n' "$mode"
 printf 'selected_snapshot=%s\\n' "$([[ "$COMPOSE_ENV_FILE" == "$snapshot" ]] && echo 1 || echo 0)"
 cleanup_deploy_env_snapshot

--- a/scripts/ops/dingtalk-interactive-card-stream-staging-uat-contract.test.mjs
+++ b/scripts/ops/dingtalk-interactive-card-stream-staging-uat-contract.test.mjs
@@ -96,6 +96,14 @@ function actionBody(source, name, nextNames = []) {
   return source.slice(start, end)
 }
 
+function extractShellFunction(source, name) {
+  const start = source.indexOf(`${name}() {`)
+  assert.notEqual(start, -1, `shell function missing: ${name}`)
+  const end = source.indexOf('\n}\n', start)
+  assert.notEqual(end, -1, `shell function end missing: ${name}`)
+  return source.slice(start, end + 3)
+}
+
 // --- parse / presence -----------------------------------------------------------------
 
 test('remote script and workflow files exist', () => {
@@ -316,6 +324,66 @@ test('remote script require_exact_deployed_sha used by every non-status action a
   assert.match(httpsOn, /require_exact_deployed_sha/)
   assert.match(httpsOff, /require_exact_deployed_sha/)
   assert.doesNotMatch(status, /require_exact_deployed_sha/)
+})
+
+test('digest-pinned staging resolves only through the matching completed deploy record and persisted override', () => {
+  const source = read(REMOTE_SH)
+  assert.match(source, /ATTENDANCE_DEPLOY_IDENTITY_FILE=/)
+  assert.match(source, /metasheet2-backend@sha256:\[0-9a-f\]\{64\}/)
+  assert.match(source, /grep -Fqx "    image: \$\{recorded_digest\}" "\$ATTENDANCE_OVERRIDE_FILE"/)
+
+  const dir = mkdtempSync(join(tmpdir(), 'stream-uat-digest-pin-'))
+  const identity = join(dir, 'deploy-identity.env')
+  const override = join(dir, 'attendance.override.yml')
+  const sha = 'c'.repeat(40)
+  const digest = `ghcr.io/zensgit/metasheet2-backend@sha256:${'d'.repeat(64)}`
+  const functions = [
+    extractShellFunction(source, 'read_attendance_deploy_identity_field'),
+    extractShellFunction(source, 'resolve_live_backend_image_pin'),
+    extractShellFunction(source, 'resolve_deployed_sha'),
+  ].join('\n')
+
+  const run = () => spawnSync(
+    'bash',
+    ['-o', 'pipefail', '-c', `set -euo pipefail
+${functions}
+ATTENDANCE_DEPLOY_IDENTITY_FILE="$IDENTITY_FILE"
+ATTENDANCE_OVERRIDE_FILE="$OVERRIDE_FILE"
+BACKEND_CONTAINER=metasheet-staging-backend
+docker() { printf '%s' "$LIVE_DIGEST"; }
+fetch_health_commit() { printf stale-health-metadata; }
+resolve_live_backend_image_pin
+printf '\n'
+resolve_deployed_sha`],
+    {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        IDENTITY_FILE: identity,
+        OVERRIDE_FILE: override,
+        LIVE_DIGEST: digest,
+      },
+    },
+  )
+
+  try {
+    writeFileSync(identity, `deploy_sha=${sha}\nbackend_digest=${digest}\n`)
+    writeFileSync(override, `services:\n  backend:\n    image: ${digest}\n`)
+    const accepted = run()
+    assert.equal(accepted.status, 0, accepted.stderr)
+    assert.equal(accepted.stdout, `zensgit ${sha}\n${sha}`)
+
+    writeFileSync(identity, `deploy_sha=${sha}\nbackend_digest=ghcr.io/zensgit/metasheet2-backend@sha256:${'e'.repeat(64)}\n`)
+    const rejectedRecord = run()
+    assert.notEqual(rejectedRecord.status, 0, 'a mismatched completion record must fail closed')
+
+    writeFileSync(identity, `deploy_sha=${sha}\nbackend_digest=${digest}\n`)
+    writeFileSync(override, 'services:\n  backend:\n    image: ghcr.io/zensgit/metasheet2-backend:mutable\n')
+    const rejectedOverride = run()
+    assert.notEqual(rejectedOverride.status, 0, 'a persisted override that does not retain the digest must fail closed')
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
 })
 
 test('observe is read-only and emits values-free callback classes without raw logs or ids', () => {

--- a/scripts/ops/dingtalk-interactive-card-stream-staging-uat-remote.sh
+++ b/scripts/ops/dingtalk-interactive-card-stream-staging-uat-remote.sh
@@ -496,6 +496,7 @@ LEGACY_STAGING_COMPOSE_FILE="${STAGING_DIR}/docker-compose.app.staging.yml"
 ATTENDANCE_PERSIST_DIR="${HOME}/.metasheet2/window-runner"
 ATTENDANCE_OVERRIDE_FILE="${ATTENDANCE_PERSIST_DIR}/docker-compose.window-runner.override.yml"
 PERSISTENT_STAGING_COMPOSE_FILE="${ATTENDANCE_PERSIST_DIR}/docker-compose.app.staging.yml"
+ATTENDANCE_DEPLOY_IDENTITY_FILE="${ATTENDANCE_PERSIST_DIR}/deploy-identity.env"
 STAGING_COMPOSE_FILE="$LEGACY_STAGING_COMPOSE_FILE"
 if [[ -f "$PERSISTENT_STAGING_COMPOSE_FILE" ]]; then
   STAGING_COMPOSE_FILE="$PERSISTENT_STAGING_COMPOSE_FILE"
@@ -552,11 +553,30 @@ require_compose_v2() {
   fail "docker compose v2 plugin is required"
 }
 
+read_attendance_deploy_identity_field() {
+  local key="$1" value count
+  [[ -f "$ATTENDANCE_DEPLOY_IDENTITY_FILE" ]] || return 1
+  value="$(sed -n "s/^${key}=//p" "$ATTENDANCE_DEPLOY_IDENTITY_FILE" | head -n 1)"
+  count="$(sed -n "s/^${key}=//p" "$ATTENDANCE_DEPLOY_IDENTITY_FILE" | wc -l | tr -d '[:space:]')"
+  [[ "$count" == "1" && -n "$value" ]] || return 1
+  printf '%s' "$value"
+}
+
 resolve_live_backend_image_pin() {
-  local live_image
+  local live_image image_owner recorded_sha recorded_digest
   live_image="$(docker inspect -f '{{.Config.Image}}' "$BACKEND_CONTAINER" 2>/dev/null || true)"
   if [[ "$live_image" =~ ^ghcr\.io/([A-Za-z0-9._-]+)/metasheet2-backend:([0-9a-f]{40})$ ]]; then
     printf '%s %s' "${BASH_REMATCH[1]}" "${BASH_REMATCH[2]}"
+    return 0
+  fi
+  if [[ "$live_image" =~ ^ghcr\.io/([A-Za-z0-9._-]+)/metasheet2-backend@sha256:[0-9a-f]{64}$ ]]; then
+    image_owner="${BASH_REMATCH[1]}"
+    recorded_sha="$(read_attendance_deploy_identity_field deploy_sha)" || return 1
+    recorded_digest="$(read_attendance_deploy_identity_field backend_digest)" || return 1
+    [[ "$recorded_sha" =~ ^[0-9a-f]{40}$ && "$recorded_digest" == "$live_image" ]] || return 1
+    [[ -f "$ATTENDANCE_OVERRIDE_FILE" ]] || return 1
+    grep -Fqx "    image: ${recorded_digest}" "$ATTENDANCE_OVERRIDE_FILE" || return 1
+    printf '%s %s' "$image_owner" "$recorded_sha"
     return 0
   fi
   return 1
@@ -576,7 +596,7 @@ compose_staging_cmd() {
     image_tag="$PINNED_IMAGE_TAG"
   else
     if ! image_pin="$(resolve_live_backend_image_pin)"; then
-      echo "[stream-uat][error] running backend image is not an exact ghcr.io owner/metasheet2-backend:<40-sha> pin; refusing compose" >&2
+      echo "[stream-uat][error] running backend image lacks an exact full-SHA tag or matching immutable deploy identity; refusing compose" >&2
       return 1
     fi
     read -r image_owner image_tag <<< "$image_pin"
@@ -588,7 +608,7 @@ compose_staging_cmd() {
 pin_live_backend_image_for_transition() {
   local image_pin
   if ! image_pin="$(resolve_live_backend_image_pin)"; then
-    fail "running backend image is not an exact ghcr.io owner/metasheet2-backend:<40-sha> pin; refusing transition"
+    fail "running backend image lacks an exact full-SHA tag or matching immutable deploy identity; refusing transition"
   fi
   read -r PINNED_IMAGE_OWNER PINNED_IMAGE_TAG <<< "$image_pin"
   [[ "$PINNED_IMAGE_TAG" == "$DEPLOY_SHA" ]] \
@@ -628,10 +648,18 @@ except Exception:
 }
 
 resolve_deployed_sha() {
-  local live_image image_commit="" health_commit=""
+  local live_image image_commit="" health_commit="" image_pin=""
   live_image="$(docker inspect -f '{{.Config.Image}}' "$BACKEND_CONTAINER" 2>/dev/null || true)"
   if [[ "$live_image" =~ :([0-9a-f]{40})$ ]]; then
     image_commit="${BASH_REMATCH[1]}"
+  elif [[ "$live_image" == *@sha256:* ]]; then
+    if image_pin="$(resolve_live_backend_image_pin)"; then
+      read -r _ image_commit <<< "$image_pin"
+      printf '%s' "$image_commit"
+    else
+      printf 'unknown'
+    fi
+    return 0
   fi
   health_commit="$(fetch_health_commit)"
 

--- a/scripts/ops/dingtalk-lifecycle-staging-canary-contract.test.mjs
+++ b/scripts/ops/dingtalk-lifecycle-staging-canary-contract.test.mjs
@@ -643,10 +643,11 @@ test('staging compose derives health build identity from the exact image tag, no
   assert.ok(envFileIndex >= 0 && environmentIndex > envFileIndex)
 })
 
-test('P1 backend recreate reuses the exact running image pin instead of latest or unknown', () => {
+test('P1 backend recreate reuses the exact running tag pin instead of latest or unknown', () => {
   const source = read(REMOTE_SH)
   assert.match(source, /resolve_live_backend_image_pin\(\)/)
   assert.match(source, /metasheet2-backend:\(\[0-9a-f\]\{40\}\)/)
+  assert.match(source, /metasheet2-backend@sha256:\[0-9a-f\]\{64\}/)
   assert.match(
     source,
     /IMAGE_OWNER="\$image_owner" IMAGE_TAG="\$image_tag" \\\n\s+docker compose --project-directory "\$STAGING_DIR"/,
@@ -689,6 +690,71 @@ test('P1 backend recreate reuses the exact running image pin instead of latest o
   )
   assert.equal(result.status, 0, result.stderr)
   assert.match(result.stdout, new RegExp(`^zensgit\\|${sha}\\|compose `))
+})
+
+test('P1 backend recreate accepts a digest only when the completion record and persisted override match it', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'lifecycle-digest-pin-'))
+  const identity = join(dir, 'deploy-identity.env')
+  const override = join(dir, 'attendance.override.yml')
+  const sha = 'c'.repeat(40)
+  const digest = `ghcr.io/zensgit/metasheet2-backend@sha256:${'d'.repeat(64)}`
+  writeFileSync(identity, `deploy_sha=${sha}\nbackend_digest=${digest}\n`)
+  writeFileSync(override, `services:\n  backend:\n    image: ${digest}\n`)
+
+  const run = () => spawnSync(
+    'bash',
+    [
+      '-o',
+      'pipefail',
+      '-c',
+      `source "$1"
+       STAGING_DIR=/tmp
+       STAGING_COMPOSE_FILE=/tmp/docker-compose.app.staging.yml
+       ATTENDANCE_DEPLOY_IDENTITY_FILE="$2"
+       ATTENDANCE_OVERRIDE_FILE="$3"
+       LIFECYCLE_OVERRIDE_FILE=/tmp/not-present-lifecycle
+       docker() {
+         if [[ "$1" == "inspect" ]]; then
+           printf '%s' "$LIVE_DIGEST"
+         else
+           printf '%s|%s|%s' "$IMAGE_OWNER" "$IMAGE_TAG" "$*"
+         fi
+       }
+       compose_staging_cmd "" config`,
+      'bash',
+      REMOTE_SH,
+      identity,
+      override,
+    ],
+    {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        ACTION: 'status',
+        OUTPUT_DIR: '/tmp/lifecycle-canary-contract-source-only',
+        RUN_STAMP: 'contract',
+        LIFECYCLE_CANARY_SOURCE_ONLY: 'true',
+        LIVE_DIGEST: digest,
+      },
+    },
+  )
+
+  try {
+    const accepted = run()
+    assert.equal(accepted.status, 0, accepted.stderr)
+    assert.match(accepted.stdout, new RegExp(`^zensgit\\|${sha}\\|compose `))
+
+    writeFileSync(identity, `deploy_sha=${sha}\nbackend_digest=ghcr.io/zensgit/metasheet2-backend@sha256:${'e'.repeat(64)}\n`)
+    const rejectedRecord = run()
+    assert.notEqual(rejectedRecord.status, 0, 'a mismatched completion record must fail closed')
+
+    writeFileSync(identity, `deploy_sha=${sha}\nbackend_digest=${digest}\n`)
+    writeFileSync(override, 'services:\n  backend:\n    image: ghcr.io/zensgit/metasheet2-backend:mutable\n')
+    const rejectedOverride = run()
+    assert.notEqual(rejectedOverride.status, 0, 'a persisted override that does not retain the digest must fail closed')
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
 })
 
 test('P1 rollback recreate retains the proven image pin after the backend container disappears', () => {

--- a/scripts/ops/dingtalk-lifecycle-staging-canary-remote.sh
+++ b/scripts/ops/dingtalk-lifecycle-staging-canary-remote.sh
@@ -207,6 +207,7 @@ LEGACY_STAGING_COMPOSE_FILE="${STAGING_DIR}/docker-compose.app.staging.yml"
 ATTENDANCE_PERSIST_DIR="${HOME}/.metasheet2/window-runner"
 ATTENDANCE_OVERRIDE_FILE="${ATTENDANCE_PERSIST_DIR}/docker-compose.window-runner.override.yml"
 PERSISTENT_STAGING_COMPOSE_FILE="${ATTENDANCE_PERSIST_DIR}/docker-compose.app.staging.yml"
+ATTENDANCE_DEPLOY_IDENTITY_FILE="${ATTENDANCE_PERSIST_DIR}/deploy-identity.env"
 STAGING_COMPOSE_FILE="$LEGACY_STAGING_COMPOSE_FILE"
 if [[ -f "$PERSISTENT_STAGING_COMPOSE_FILE" ]]; then
   STAGING_COMPOSE_FILE="$PERSISTENT_STAGING_COMPOSE_FILE"
@@ -280,11 +281,30 @@ require_compose_v2() {
   fail "docker compose v2 plugin is required"
 }
 
+read_attendance_deploy_identity_field() {
+  local key="$1" value count
+  [[ -f "$ATTENDANCE_DEPLOY_IDENTITY_FILE" ]] || return 1
+  value="$(sed -n "s/^${key}=//p" "$ATTENDANCE_DEPLOY_IDENTITY_FILE" | head -n 1)"
+  count="$(sed -n "s/^${key}=//p" "$ATTENDANCE_DEPLOY_IDENTITY_FILE" | wc -l | tr -d '[:space:]')"
+  [[ "$count" == "1" && -n "$value" ]] || return 1
+  printf '%s' "$value"
+}
+
 resolve_live_backend_image_pin() {
-  local live_image
+  local live_image image_owner recorded_sha recorded_digest
   live_image="$(docker inspect -f '{{.Config.Image}}' "$BACKEND_CONTAINER" 2>/dev/null || true)"
   if [[ "$live_image" =~ ^ghcr\.io/([A-Za-z0-9._-]+)/metasheet2-backend:([0-9a-f]{40})$ ]]; then
     printf '%s %s' "${BASH_REMATCH[1]}" "${BASH_REMATCH[2]}"
+    return 0
+  fi
+  if [[ "$live_image" =~ ^ghcr\.io/([A-Za-z0-9._-]+)/metasheet2-backend@sha256:[0-9a-f]{64}$ ]]; then
+    image_owner="${BASH_REMATCH[1]}"
+    recorded_sha="$(read_attendance_deploy_identity_field deploy_sha)" || return 1
+    recorded_digest="$(read_attendance_deploy_identity_field backend_digest)" || return 1
+    [[ "$recorded_sha" =~ ^[0-9a-f]{40}$ && "$recorded_digest" == "$live_image" ]] || return 1
+    [[ -f "$ATTENDANCE_OVERRIDE_FILE" ]] || return 1
+    grep -Fqx "    image: ${recorded_digest}" "$ATTENDANCE_OVERRIDE_FILE" || return 1
+    printf '%s %s' "$image_owner" "$recorded_sha"
     return 0
   fi
   return 1
@@ -309,7 +329,7 @@ compose_staging_cmd() {
     image_tag="$PINNED_IMAGE_TAG"
   else
     if ! image_pin="$(resolve_live_backend_image_pin)"; then
-      echo "[lifecycle-canary][error] running backend image is not an exact ghcr.io owner/metasheet2-backend:<40-sha> pin; refusing compose" >&2
+      echo "[lifecycle-canary][error] running backend image lacks an exact full-SHA tag or matching immutable deploy identity; refusing compose" >&2
       return 1
     fi
     read -r image_owner image_tag <<< "$image_pin"
@@ -321,7 +341,7 @@ compose_staging_cmd() {
 pin_live_backend_image_for_transition() {
   local image_pin
   if ! image_pin="$(resolve_live_backend_image_pin)"; then
-    fail "running backend image is not an exact ghcr.io owner/metasheet2-backend:<40-sha> pin; refusing transition"
+    fail "running backend image lacks an exact full-SHA tag or matching immutable deploy identity; refusing transition"
   fi
   read -r PINNED_IMAGE_OWNER PINNED_IMAGE_TAG <<< "$image_pin"
   [[ "$PINNED_IMAGE_TAG" == "$DEPLOY_SHA" ]] \
@@ -361,10 +381,18 @@ except Exception:
 }
 
 resolve_deployed_sha() {
-  local live_image image_commit="" health_commit=""
+  local live_image image_commit="" health_commit="" image_pin=""
   live_image="$(docker inspect -f '{{.Config.Image}}' "$BACKEND_CONTAINER" 2>/dev/null || true)"
   if [[ "$live_image" =~ :([0-9a-f]{40})$ ]]; then
     image_commit="${BASH_REMATCH[1]}"
+  elif [[ "$live_image" == *@sha256:* ]]; then
+    if image_pin="$(resolve_live_backend_image_pin)"; then
+      read -r _ image_commit <<< "$image_pin"
+      printf '%s' "$image_commit"
+    else
+      printf 'unknown'
+    fi
+    return 0
   fi
   health_commit="$(fetch_health_commit)"
 

--- a/scripts/ops/dingtalk-oauth-staging-config-contract.test.mjs
+++ b/scripts/ops/dingtalk-oauth-staging-config-contract.test.mjs
@@ -1,10 +1,47 @@
 import assert from 'node:assert/strict'
-import { readFileSync } from 'node:fs'
+import { spawnSync } from 'node:child_process'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { test } from 'node:test'
 
 const workflow = readFileSync(new URL('../../.github/workflows/dingtalk-oauth-staging-config.yml', import.meta.url), 'utf8')
 const remote = readFileSync(new URL('./dingtalk-oauth-staging-config-remote.sh', import.meta.url), 'utf8')
 const contractWorkflow = readFileSync(new URL('../../.github/workflows/dingtalk-oauth-staging-config-contract.yml', import.meta.url), 'utf8')
+
+function extractShellFunction(source, name) {
+  const start = source.indexOf(`${name}() {`)
+  assert.notEqual(start, -1, `shell function missing: ${name}`)
+  const end = source.indexOf('\n}\n', start)
+  assert.notEqual(end, -1, `shell function end missing: ${name}`)
+  return source.slice(start, end + 3)
+}
+
+function runDigestIdentity({ identity, override, digest, functionName = 'resolve_image_pin' }) {
+  const functions = [
+    extractShellFunction(remote, 'read_attendance_deploy_identity_field'),
+    extractShellFunction(remote, 'resolve_live_backend_image_pin'),
+    extractShellFunction(remote, 'resolve_image_pin'),
+    extractShellFunction(remote, 'deployed_sha'),
+  ].join('\n')
+  return spawnSync('bash', ['-o', 'pipefail', '-c', `set -euo pipefail
+fail() { printf '%s\\n' "$*" >&2; exit 1; }
+health_commit() { printf stale-health-metadata; }
+${functions}
+ATTENDANCE_DEPLOY_IDENTITY_FILE="$IDENTITY_FILE"
+ATTENDANCE_OVERRIDE_FILE="$OVERRIDE_FILE"
+BACKEND_CONTAINER=metasheet-staging-backend
+docker() { printf '%s' "$LIVE_DIGEST"; }
+${functionName}`], {
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      IDENTITY_FILE: identity,
+      OVERRIDE_FILE: override,
+      LIVE_DIGEST: digest,
+    },
+  })
+}
 
 test('workflow is manual, staging-serialized, pinned-SSH, and fail-honest', () => {
   assert.match(workflow, /workflow_dispatch:/)
@@ -72,6 +109,32 @@ test('write is compose-validated, atomic, backend-only, and rollback-capable', (
   assert.match(remote, /redis_before.*redis_after/s)
   assert.match(remote, /web_before.*web_after/s)
   assert.doesNotMatch(remote, /\[\[ -w "\$target_dir" \]\]/)
+})
+
+test('digest-pinned staging resolves only through the matching completion record and override', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'oauth-digest-pin-'))
+  const identity = join(dir, 'deploy-identity.env')
+  const override = join(dir, 'attendance.override.yml')
+  const sha = 'a'.repeat(40)
+  const digest = `ghcr.io/zensgit/metasheet2-backend@sha256:${'b'.repeat(64)}`
+  writeFileSync(identity, `deploy_sha=${sha}\nbackend_digest=${digest}\n`)
+  writeFileSync(override, `services:\n  backend:\n    image: ${digest}\n`)
+
+  try {
+    const pin = runDigestIdentity({ identity, override, digest })
+    assert.equal(pin.status, 0, pin.stderr)
+    assert.equal(pin.stdout, `zensgit ${sha}`)
+
+    const deployed = runDigestIdentity({ identity, override, digest, functionName: 'deployed_sha' })
+    assert.equal(deployed.status, 0, deployed.stderr)
+    assert.equal(deployed.stdout, sha, 'digest identity must not depend on stale health build metadata')
+
+    writeFileSync(identity, `deploy_sha=${sha}\nbackend_digest=ghcr.io/zensgit/metasheet2-backend@sha256:${'c'.repeat(64)}\n`)
+    const rejected = runDigestIdentity({ identity, override, digest })
+    assert.notEqual(rejected.status, 0, 'a digest absent from the completion record must fail closed')
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
 })
 
 test('transport input closed sets reject shell metacharacters', () => {

--- a/scripts/ops/dingtalk-oauth-staging-config-remote.sh
+++ b/scripts/ops/dingtalk-oauth-staging-config-remote.sh
@@ -46,6 +46,7 @@ LEGACY_COMPOSE_FILE="${STAGING_DIR}/docker-compose.app.staging.yml"
 ATTENDANCE_DIR="${HOME}/.metasheet2/window-runner"
 PERSISTENT_COMPOSE_FILE="${ATTENDANCE_DIR}/docker-compose.app.staging.yml"
 ATTENDANCE_OVERRIDE_FILE="${ATTENDANCE_DIR}/docker-compose.window-runner.override.yml"
+ATTENDANCE_DEPLOY_IDENTITY_FILE="${ATTENDANCE_DIR}/deploy-identity.env"
 LIFECYCLE_OVERRIDE_FILE="${HOME}/.metasheet2/lifecycle-canary/docker-compose.lifecycle-canary.override.yml"
 PERSIST_DIR="${HOME}/.metasheet2/dingtalk-oauth-config"
 STAGING_COMPOSE_FILE="$LEGACY_COMPOSE_FILE"
@@ -130,9 +131,18 @@ except Exception: print("")' || true
 }
 
 deployed_sha() {
-  local image image_sha="" http_sha
+  local image image_sha="" http_sha image_pin=""
   image="$(docker inspect -f '{{.Config.Image}}' "$BACKEND_CONTAINER" 2>/dev/null || true)"
   [[ "$image" =~ :([0-9a-f]{40})$ ]] && image_sha="${BASH_REMATCH[1]}"
+  if [[ "$image" == *@sha256:* ]]; then
+    if image_pin="$(resolve_live_backend_image_pin)"; then
+      read -r _ image_sha <<< "$image_pin"
+      printf '%s' "$image_sha"
+    else
+      printf unknown
+    fi
+    return 0
+  fi
   http_sha="$(health_commit)"
   if [[ "$image_sha" =~ ^[0-9a-f]{40}$ && "$http_sha" == "$image_sha" ]]; then
     printf '%s' "$image_sha"
@@ -165,12 +175,38 @@ write_status() {
   cp "${OUTPUT_DIR}/status.txt" "${OUTPUT_DIR}/summary.txt"
 }
 
-resolve_image_pin() {
-  local image
+read_attendance_deploy_identity_field() {
+  local key="$1" value count
+  [[ -f "$ATTENDANCE_DEPLOY_IDENTITY_FILE" ]] || return 1
+  value="$(sed -n "s/^${key}=//p" "$ATTENDANCE_DEPLOY_IDENTITY_FILE" | head -n 1)"
+  count="$(sed -n "s/^${key}=//p" "$ATTENDANCE_DEPLOY_IDENTITY_FILE" | wc -l | tr -d '[:space:]')"
+  [[ "$count" == "1" && -n "$value" ]] || return 1
+  printf '%s' "$value"
+}
+
+resolve_live_backend_image_pin() {
+  local image image_owner recorded_sha recorded_digest
   image="$(docker inspect -f '{{.Config.Image}}' "$BACKEND_CONTAINER" 2>/dev/null || true)"
-  [[ "$image" =~ ^ghcr\.io/([A-Za-z0-9._-]+)/metasheet2-backend:([0-9a-f]{40})$ ]] \
-    || fail "backend image is not pinned to a full SHA"
-  printf '%s %s' "${BASH_REMATCH[1]}" "${BASH_REMATCH[2]}"
+  if [[ "$image" =~ ^ghcr\.io/([A-Za-z0-9._-]+)/metasheet2-backend:([0-9a-f]{40})$ ]]; then
+    printf '%s %s' "${BASH_REMATCH[1]}" "${BASH_REMATCH[2]}"
+    return 0
+  fi
+  if [[ "$image" =~ ^ghcr\.io/([A-Za-z0-9._-]+)/metasheet2-backend@sha256:[0-9a-f]{64}$ ]]; then
+    image_owner="${BASH_REMATCH[1]}"
+    recorded_sha="$(read_attendance_deploy_identity_field deploy_sha)" || return 1
+    recorded_digest="$(read_attendance_deploy_identity_field backend_digest)" || return 1
+    [[ "$recorded_sha" =~ ^[0-9a-f]{40}$ && "$recorded_digest" == "$image" ]] || return 1
+    [[ -f "$ATTENDANCE_OVERRIDE_FILE" ]] || return 1
+    grep -Fqx "    image: ${recorded_digest}" "$ATTENDANCE_OVERRIDE_FILE" || return 1
+    printf '%s %s' "$image_owner" "$recorded_sha"
+    return 0
+  fi
+  return 1
+}
+
+resolve_image_pin() {
+  resolve_live_backend_image_pin \
+    || fail "backend image lacks an exact full-SHA tag or matching immutable deploy identity"
 }
 
 compose_with_env() {


### PR DESCRIPTION
## What changed

- snapshot `docker/app.staging.env` once per deploy, bind every compose invocation to that 0600 snapshot, and fail if the canonical file changes during capture;
- resolve full-SHA image tags once to immutable backend/web repository digests, then reuse those exact digests without any post-preflight pull;
- run the candidate image's migration list against the live staging DB before persistent compose files or live containers change, with a closed DB/migration env allowlist and an offline values-free alignment report;
- require exactly one `decision=aligned` both before deployment and again after the new containers are up;
- invalidate stale completion identity before the first persistent/live change and write the new values-free SHA/digest/env-fingerprint record only after health, migrations, auth, and summary gates pass;
- make attendance smoke/soak, lifecycle canary, OAuth config, and Stream UAT understand digest-pinned deployments only when the live digest, completion record, and persisted override agree.

## Why

Staging deploy run `31944319144` recreated backend/web before discovering two pending migrations and stopping at `do_not_run_full_migrate`. The old path therefore allowed a migration incompatibility to become a partial live deployment. This PR moves the compatibility decision before any persistent or live mutation and makes later operator lanes consume the same immutable deploy identity.

## Verification

- `bash scripts/ops/attendance-run-gate-contract-case.sh strict /private/tmp/codex-attendance-strict-exact-20260818` (pass; attendance runner 94/94)
- `pnpm verify:attendance-window-runner:pipeline:test` (94/94)
- lifecycle + OAuth + Stream contracts together (274/274)
- Stream UAT contract separately (51/51)
- `bash -n` on all four changed remote scripts
- `git diff --check`
- independent read-only adversarial review: 0 P1 / 0 P2 on exact patch
- rebase patch-id unchanged: `c4b75fddc36b17f55974ef6b883f9ba39f64c1d9`

## Hold / operations boundary

- Draft and unarmed. Do not auto-merge.
- No staging action, secret read/write, flag change, migration, deployment, prepare, or UAT was performed by this PR work.
- Stream and all lifecycle flags remain OFF.
- The two currently pending W7 migrations require a separate owner-authorized `action=migrate` before any deploy.
- After merge, the intended separately authorized sequence is `migrate -> deploy exact merge SHA with flags OFF -> read-only status -> prepare`; real UAT remains a later explicit authorization.

## Known separate UAT findings

This deploy-safety PR does not claim full Stream UAT completion. The current UAT evidence still needs follow-up for terminal card-button retirement, the documented forwarding step versus `supportForward:false`, observer unknown-evidence fail-closed behavior, corp-field-absence classification, and a deterministic concurrent double-click barrier.
