### PR TITLE
fix(dingtalk): harden Stream UAT terminal evidence

### DIFF
--- a/.github/workflows/dingtalk-interactive-card-stream-staging-uat.yml
+++ b/.github/workflows/dingtalk-interactive-card-stream-staging-uat.yml
@@ -6,10 +6,11 @@ run-name: "DingTalk Stream Staging UAT: ${{ inputs.action }}"
 # One dispatch = ONE action. Stream stays OFF except explicit action=on.
 # Lifecycle flags are NEVER written by this lane.
 #
-# EXECUTABLE: status | observe | prepare | on | off | https-on | https-off
+# EXECUTABLE: status | observe-baseline | observe | prepare | on | off | https-on | https-off
 #   status  = read-only values-free snapshot (booleans / counts / reason classes)
-#   observe = read-only callback/corp-anchor/card-update result classes from the
-#             current Stream-ON backend container; never emits raw logs or ids
+#   observe-baseline = capture values-free per-delivery log counts before one human click
+#   observe = require callback/corp-anchor evidence to increase beyond the persisted
+#             same-delivery baseline; never emits raw logs or ids
 #   prepare = transport Stream credentials (chmod-600 files), derive exactly one
 #             active integration for live DINGTALK_CORP_ID with >=2 linked local users,
 #             atomically write the four credential/id env keys into
@@ -38,18 +39,18 @@ on:
   workflow_dispatch:
     inputs:
       action:
-        description: 'status | observe | prepare | on | off | https-on | https-off'
+        description: 'status | observe-baseline | observe | prepare | on | off | https-on | https-off'
         required: true
         type: choice
         # Quote 'on'/'off' — YAML 1.1 bare on/off become booleans.
-        options: [status, observe, prepare, 'on', 'off', https-on, https-off]
+        options: [status, observe-baseline, observe, prepare, 'on', 'off', https-on, https-off]
         default: status
       deploy_sha:
         description: 'FULL 40-char lowercase commit SHA currently deployed on staging. Required for every non-status action; optional for status exact-match reporting.'
         required: false
         default: ''
       expected_delivery_id:
-        description: 'Lowercase delivery UUID required only for observe; used for matching and never emitted.'
+        description: 'Lowercase delivery UUID required for observe-baseline/observe; used for matching and never emitted.'
         required: false
         default: ''
 
@@ -80,7 +81,7 @@ jobs:
           # (bash -n and other children must not inherit raw secret env).
         run: |
           set -euo pipefail
-          case "$ACTION" in status|observe|prepare|on|off|https-on|https-off) ;; *)
+          case "$ACTION" in status|observe-baseline|observe|prepare|on|off|https-on|https-off) ;; *)
             echo "invalid action: $ACTION" >&2; exit 2
           ;; esac
 
@@ -97,13 +98,13 @@ jobs:
             exit 2
           fi
 
-          if [[ "$ACTION" == "observe" ]]; then
+          if [[ "$ACTION" == "observe" || "$ACTION" == "observe-baseline" ]]; then
             if [[ ! "$EXPECTED_DELIVERY_ID" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$ ]]; then
-              echo "observe requires expected_delivery_id as a lowercase UUID" >&2
+              echo "${ACTION} requires expected_delivery_id as a lowercase UUID" >&2
               exit 2
             fi
           elif [[ -n "$EXPECTED_DELIVERY_ID" ]]; then
-            echo "expected_delivery_id is accepted only for action=observe" >&2
+            echo "expected_delivery_id is accepted only for action=observe-baseline/observe" >&2
             exit 2
           fi
 
@@ -158,7 +159,7 @@ jobs:
           RUNNER_DIR: ${{ steps.sync.outputs.runner_dir }}
           # prepare secrets are materialized INSIDE this step under EXIT trap —
           # never via a prior step secrets_dir output (cross-step leak / cancel).
-          # status/observe/on/off do not receive credential secrets.
+          # status/observe-baseline/observe/on/off do not receive credential secrets.
           STAGING_DINGTALK_INTERACTIVE_CARD_CLIENT_ID: ${{ inputs.action == 'prepare' && secrets.STAGING_DINGTALK_INTERACTIVE_CARD_CLIENT_ID || '' }}
           STAGING_DINGTALK_INTERACTIVE_CARD_CLIENT_SECRET: ${{ inputs.action == 'prepare' && secrets.STAGING_DINGTALK_INTERACTIVE_CARD_CLIENT_SECRET || '' }}
           STAGING_DINGTALK_INTERACTIVE_CARD_TEMPLATE_ID: ${{ inputs.action == 'prepare' && secrets.STAGING_DINGTALK_INTERACTIVE_CARD_TEMPLATE_ID || '' }}
@@ -177,7 +178,7 @@ jobs:
 
           ssh_opts="-o BatchMode=yes -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes -o UserKnownHostsFile=$HOME/.ssh/known_hosts -o GlobalKnownHostsFile=/dev/null -i $HOME/.ssh/deploy_key"
           DEPLOY_PATH="${DEPLOY_PATH:-metasheet2}"
-          case "$ACTION" in status|observe|prepare|on|off|https-on|https-off) ;; *)
+          case "$ACTION" in status|observe-baseline|observe|prepare|on|off|https-on|https-off) ;; *)
             echo "refusing invalid action in remote execution step" >&2
             exit 2
           ;; esac
@@ -190,13 +191,13 @@ jobs:
             echo "refusing invalid optional deploy_sha in remote execution step" >&2
             exit 2
           fi
-          if [[ "$ACTION" == "observe" ]]; then
+          if [[ "$ACTION" == "observe" || "$ACTION" == "observe-baseline" ]]; then
             if [[ ! "$EXPECTED_DELIVERY_ID" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$ ]]; then
               echo "refusing invalid expected_delivery_id in remote execution step" >&2
               exit 2
             fi
           elif [[ -n "$EXPECTED_DELIVERY_ID" ]]; then
-            echo "refusing expected_delivery_id outside action=observe" >&2
+            echo "refusing expected_delivery_id outside action=observe-baseline/observe" >&2
             exit 2
           fi
           for pair in "DEPLOY_PATH=$DEPLOY_PATH" "STAGING_DEPLOY_PATH=$STAGING_DEPLOY_PATH"; do
@@ -361,7 +362,8 @@ jobs:
             echo "- Remote rc: \`${REMOTE_RC:-missing}\`"
             echo "- Artifact: \`${ARTIFACT_NAME:-missing}\`"
             echo ""
-            echo "**Executable:** status / observe / prepare / on / off / https-on / https-off."
+            echo "**Executable:** status / observe-baseline / observe / prepare / on / off / https-on / https-off."
+            echo "For every human callback: run observe-baseline first, click once, then run observe; successful observe advances the checkpoint."
             echo "prepare forces Stream OFF after writing credentials + derived integration id."
             echo "on flips ONLY Stream flag true after prerequisite + LOG_LEVEL checks; proves worker_started only."
             echo "stream_connected is always unknown here (SDK connect resolves + retries forever; not log-proven)."

--- a/.github/workflows/dingtalk-interactive-card-stream-staging-uat.yml
+++ b/.github/workflows/dingtalk-interactive-card-stream-staging-uat.yml
@@ -6,11 +6,10 @@ run-name: "DingTalk Stream Staging UAT: ${{ inputs.action }}"
 # One dispatch = ONE action. Stream stays OFF except explicit action=on.
 # Lifecycle flags are NEVER written by this lane.
 #
-# EXECUTABLE: status | observe-baseline | observe | prepare | on | off | https-on | https-off
+# EXECUTABLE: status | observe | prepare | on | off | https-on | https-off
 #   status  = read-only values-free snapshot (booleans / counts / reason classes)
-#   observe-baseline = capture values-free per-delivery log counts before one human click
-#   observe = require callback/corp-anchor evidence to increase beyond the persisted
-#             same-delivery baseline; never emits raw logs or ids
+#   observe = hold open a fresh five-minute log window and require exactly one
+#             atomic callback evidence record after observer_armed=true
 #   prepare = transport Stream credentials (chmod-600 files), derive exactly one
 #             active integration for live DINGTALK_CORP_ID with >=2 linked local users,
 #             atomically write the four credential/id env keys into
@@ -39,18 +38,18 @@ on:
   workflow_dispatch:
     inputs:
       action:
-        description: 'status | observe-baseline | observe | prepare | on | off | https-on | https-off'
+        description: 'status | observe | prepare | on | off | https-on | https-off'
         required: true
         type: choice
         # Quote 'on'/'off' — YAML 1.1 bare on/off become booleans.
-        options: [status, observe-baseline, observe, prepare, 'on', 'off', https-on, https-off]
+        options: [status, observe, prepare, 'on', 'off', https-on, https-off]
         default: status
       deploy_sha:
         description: 'FULL 40-char lowercase commit SHA currently deployed on staging. Required for every non-status action; optional for status exact-match reporting.'
         required: false
         default: ''
       expected_delivery_id:
-        description: 'Lowercase delivery UUID required for observe-baseline/observe; used for matching and never emitted.'
+        description: 'Lowercase delivery UUID required only for observe; used for matching and never emitted.'
         required: false
         default: ''
 
@@ -81,7 +80,7 @@ jobs:
           # (bash -n and other children must not inherit raw secret env).
         run: |
           set -euo pipefail
-          case "$ACTION" in status|observe-baseline|observe|prepare|on|off|https-on|https-off) ;; *)
+          case "$ACTION" in status|observe|prepare|on|off|https-on|https-off) ;; *)
             echo "invalid action: $ACTION" >&2; exit 2
           ;; esac
 
@@ -98,13 +97,13 @@ jobs:
             exit 2
           fi
 
-          if [[ "$ACTION" == "observe" || "$ACTION" == "observe-baseline" ]]; then
+          if [[ "$ACTION" == "observe" ]]; then
             if [[ ! "$EXPECTED_DELIVERY_ID" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$ ]]; then
-              echo "${ACTION} requires expected_delivery_id as a lowercase UUID" >&2
+            echo "observe requires expected_delivery_id as a lowercase UUID" >&2
               exit 2
             fi
           elif [[ -n "$EXPECTED_DELIVERY_ID" ]]; then
-            echo "expected_delivery_id is accepted only for action=observe-baseline/observe" >&2
+            echo "expected_delivery_id is accepted only for action=observe" >&2
             exit 2
           fi
 
@@ -159,7 +158,7 @@ jobs:
           RUNNER_DIR: ${{ steps.sync.outputs.runner_dir }}
           # prepare secrets are materialized INSIDE this step under EXIT trap —
           # never via a prior step secrets_dir output (cross-step leak / cancel).
-          # status/observe-baseline/observe/on/off do not receive credential secrets.
+          # status/observe/on/off do not receive credential secrets.
           STAGING_DINGTALK_INTERACTIVE_CARD_CLIENT_ID: ${{ inputs.action == 'prepare' && secrets.STAGING_DINGTALK_INTERACTIVE_CARD_CLIENT_ID || '' }}
           STAGING_DINGTALK_INTERACTIVE_CARD_CLIENT_SECRET: ${{ inputs.action == 'prepare' && secrets.STAGING_DINGTALK_INTERACTIVE_CARD_CLIENT_SECRET || '' }}
           STAGING_DINGTALK_INTERACTIVE_CARD_TEMPLATE_ID: ${{ inputs.action == 'prepare' && secrets.STAGING_DINGTALK_INTERACTIVE_CARD_TEMPLATE_ID || '' }}
@@ -178,7 +177,7 @@ jobs:
 
           ssh_opts="-o BatchMode=yes -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes -o UserKnownHostsFile=$HOME/.ssh/known_hosts -o GlobalKnownHostsFile=/dev/null -i $HOME/.ssh/deploy_key"
           DEPLOY_PATH="${DEPLOY_PATH:-metasheet2}"
-          case "$ACTION" in status|observe-baseline|observe|prepare|on|off|https-on|https-off) ;; *)
+          case "$ACTION" in status|observe|prepare|on|off|https-on|https-off) ;; *)
             echo "refusing invalid action in remote execution step" >&2
             exit 2
           ;; esac
@@ -191,13 +190,13 @@ jobs:
             echo "refusing invalid optional deploy_sha in remote execution step" >&2
             exit 2
           fi
-          if [[ "$ACTION" == "observe" || "$ACTION" == "observe-baseline" ]]; then
+          if [[ "$ACTION" == "observe" ]]; then
             if [[ ! "$EXPECTED_DELIVERY_ID" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$ ]]; then
               echo "refusing invalid expected_delivery_id in remote execution step" >&2
               exit 2
             fi
           elif [[ -n "$EXPECTED_DELIVERY_ID" ]]; then
-            echo "refusing expected_delivery_id outside action=observe-baseline/observe" >&2
+            echo "refusing expected_delivery_id outside action=observe" >&2
             exit 2
           fi
           for pair in "DEPLOY_PATH=$DEPLOY_PATH" "STAGING_DEPLOY_PATH=$STAGING_DEPLOY_PATH"; do
@@ -362,8 +361,8 @@ jobs:
             echo "- Remote rc: \`${REMOTE_RC:-missing}\`"
             echo "- Artifact: \`${ARTIFACT_NAME:-missing}\`"
             echo ""
-            echo "**Executable:** status / observe-baseline / observe / prepare / on / off / https-on / https-off."
-            echo "For every human callback: run observe-baseline first, click once, then run observe; successful observe advances the checkpoint."
+            echo "**Executable:** status / observe / prepare / on / off / https-on / https-off."
+            echo "For every callback: start observe, wait for observer_armed=true, click once immediately, then let the full five-minute observation window finish."
             echo "prepare forces Stream OFF after writing credentials + derived integration id."
             echo "on flips ONLY Stream flag true after prerequisite + LOG_LEVEL checks; proves worker_started only."
             echo "stream_connected is always unknown here (SDK connect resolves + retries forever; not log-proven)."

--- a/docs/development/approval-dingtalk-slice-b-uat-checklist-20260710.md
+++ b/docs/development/approval-dingtalk-slice-b-uat-checklist-20260710.md
@@ -83,11 +83,12 @@ DingTalk interactive-card callback corp anchor
 | U7 | 未绑定钉钉的操作者点卡 | 无引擎调用；卡面「请先在网页端绑定钉钉后再处理」 | ⬜ |
 | U8 | 点「驳回」 | 跳 Slice-A 决策页（深链），页面强制意见后驳回成功 | ⬜ |
 
-**U4–U8 每次点击的证据纪律**：先对该 delivery 运行 `observe-baseline`，确认
-`reason=baseline_captured`；再执行**恰一次**点击/技术注入；最后运行 `observe`。`observe`
-必须证明同一 delivery 的 anchor/handled 计数均相对 checkpoint 严格增加，成功后自动推进
-checkpoint。不得拿 U4 留下的历史日志作为 U5 的证据；未先捕获 checkpoint、日志计数回退
-（容器重建）或本轮无增量都必须判失败并重新从 `observe-baseline` 开始。
+**U4–U7 每次回调的证据纪律**：对该 delivery 启动 `observe`，看到
+`observer_armed=true` 后立即执行**恰一次**点击/受控技术注入，并等待完整五分钟观察窗结束。
+`observe` 只读取该固定窗口内的日志，并要求恰好一条原子 completion-evidence 记录；该记录把 delivery、corp 锚点判定与
+callback outcome 绑定在同一次完成调用中。不得拿 U4 的历史日志证明 U5；容器在窗口内重建、
+零条或多条 completion evidence 都必须失败。U8 是网页深链，不产生 Stream callback；以网页
+响应、审批审计与原卡终态更新三者证明，不套用 `observe`。
 
 ## 3. 卡片终态（B-4 面）
 

--- a/docs/development/approval-dingtalk-slice-b-uat-checklist-20260710.md
+++ b/docs/development/approval-dingtalk-slice-b-uat-checklist-20260710.md
@@ -83,6 +83,12 @@ DingTalk interactive-card callback corp anchor
 | U7 | 未绑定钉钉的操作者点卡 | 无引擎调用；卡面「请先在网页端绑定钉钉后再处理」 | ⬜ |
 | U8 | 点「驳回」 | 跳 Slice-A 决策页（深链），页面强制意见后驳回成功 | ⬜ |
 
+**U4–U8 每次点击的证据纪律**：先对该 delivery 运行 `observe-baseline`，确认
+`reason=baseline_captured`；再执行**恰一次**点击/技术注入；最后运行 `observe`。`observe`
+必须证明同一 delivery 的 anchor/handled 计数均相对 checkpoint 严格增加，成功后自动推进
+checkpoint。不得拿 U4 留下的历史日志作为 U5 的证据；未先捕获 checkpoint、日志计数回退
+（容器重建）或本轮无增量都必须判失败并重新从 `observe-baseline` 开始。
+
 ## 3. 卡片终态（B-4 面）
 
 | # | 步骤 | 期望 | 结果 |

--- a/docs/development/approval-dingtalk-slice-b-uat-checklist-20260710.md
+++ b/docs/development/approval-dingtalk-slice-b-uat-checklist-20260710.md
@@ -14,7 +14,7 @@
 ### 0-a. 🚧 硬前置：真实回调帧的 corpId 字段形状（**flag ON 之前必须做完**）
 
 P1-2 跨企业门（#4116）用「点击方企业」与「台账 `integration_id` 所属企业」比对，fail-closed。它按优先级读：
-**(1) frame header `eventCorpId`**（SDK 类型化、网关填充，adapter 盖到 payload 上）→ **(2) body `corpId`**；两者都缺 ⇒ 判 `corp_mismatch` 拒绝。
+**(1) frame header `eventCorpId`**（SDK 类型化、网关填充，adapter 盖到 payload 上）→ **(2) body `corpId`**；两者都缺 ⇒ 判 `corp_anchor_absent` 拒绝；锚点存在但与台账企业不一致 ⇒ 判真正的 `corp_mismatch`；header/body 同时存在但互相冲突 ⇒ 判 `corp_anchor_conflict`。
 
 **风险（#4116 对抗审阅 P3-2，未经真实帧验证）**：`dingtalk-stream@2.1.5` 的类型声明里 `eventCorpId` 只出现在 **EVENT 主题**的 header 组；**互动卡 callback 帧很可能根本不带这个 header**。若为真：
 - 门会静默退化为只认 body `corpId`（不是「网关保证的权威锚点」，与设计意图不符）；
@@ -79,7 +79,7 @@ DingTalk interactive-card callback corp anchor
 |---|---|---|---|
 | U4 | 受理人 A 点「同意」 | 引擎记录 approve（web 端可见）；audit actor=A 的本地账号；台账回调结果 executed | ⬜ |
 | U5 | A 重复点击（重复回调） | 幂等收敛：无第二次引擎写；卡面显示真实终态 | ⬜ |
-| U6 | 非受理人 B 点「同意」（转发的卡） | 引擎 403 `APPROVAL_ASSIGNMENT_REQUIRED`；**无审批写入**；卡面「当前账号无权处理该审批」 | ⬜ |
+| U6 | 非受理人 B 的受控技术注入同意回调（不依赖卡片转发） | 保持 `supportForward=false`、不开转发；引擎 403 `APPROVAL_ASSIGNMENT_REQUIRED`；**无审批写入**；卡面「当前账号无权处理该审批」 | ⬜ |
 | U7 | 未绑定钉钉的操作者点卡 | 无引擎调用；卡面「请先在网页端绑定钉钉后再处理」 | ⬜ |
 | U8 | 点「驳回」 | 跳 Slice-A 决策页（深链），页面强制意见后驳回成功 | ⬜ |
 
@@ -90,7 +90,7 @@ DingTalk interactive-card callback corp anchor
 | U9 | U4 成功后卡面 | `已由 <A 的服务端本地显示名> 同意 · <时间>`（显示名非钉钉 payload 回显），且「同意」「驳回」操作区消失；模板须定义默认值为 `true` 的公共布尔变量 `actionsVisible`，两个按钮均以其为显示条件 | ⬜ |
 | U10 | 卡片更新 API 人为置失败（如临时错模板）后 A 同意 | **审批已提交不回滚**；日志 values-free 错误；再次点击经 stale summary 收敛出真实终态 | ⬜ |
 | U11 | 伪造/过期 outTrackId 的回调（技术注入） | 卡面中性文案，与 operator-未解析场景**字节等同**（无存在性 oracle） | ⬜ |
-| **U11-a** | **真实点击的企业来源（#4116 跨企业门实证）** | 一次**真实**的同意点击必须**通过**跨企业门（而不是被 `corp_mismatch` 拒掉）。这是 §0-a 的验收面：worker values-free 日志应显示门读到了企业锚点（header `eventCorpId` 或 body `corpId`）**且与台账 `integration_id` 所属企业一致**。**若真实点击被判 `corp_mismatch` ⇒ 说明真实帧根本不带任何 corp 字段 ⇒ 立刻停止 UAT、关 flag**（这正是 §0-a 预警的 dead-on-arrival）。 | ⬜ |
+| **U11-a** | **真实点击的企业来源（#4116 跨企业门实证）** | 一次**真实**的同意点击必须**通过**跨企业门（而不是被拒）。这是 §0-a 的验收面：worker values-free 日志应显示门读到了企业锚点（header `eventCorpId` 或 body `corpId`）**且与台账 `integration_id` 所属企业一致**。**若真实点击判 `corp_anchor_absent` ⇒ 真实帧缺企业锚点，立刻停止 UAT、关 flag**；**若判真正的 `corp_mismatch` ⇒ 锚点存在但企业确实不一致，按跨企业点击处置，保持拒绝并检查测试账号/绑定企业/台账配置，不得把它误报为缺锚点 dead-on-arrival**。 | ⬜ |
 | **U11-b** | **过期卡（若已启用保留期清扫 #4142）** | 已被清扫成 `expired` 的卡再点击 ⇒ 不可操作、**零审批写入**，卡面走 stale 终态文案。（清扫默认 OFF；只有设了 `DINGTALK_DELIVERY_RETENTION_DAYS` 才需验这条，且**窗口须大于审批 SLA**，否则活卡会被过期。） | ⬜ |
 
 ## 4. 生命周期与运维（W2b 面）

--- a/packages/core-backend/src/integrations/dingtalk/interactive-card-callback.ts
+++ b/packages/core-backend/src/integrations/dingtalk/interactive-card-callback.ts
@@ -182,6 +182,26 @@ interface CallbackCorpAnchor {
   value: string
 }
 
+type CallbackCorpGateResult =
+  | 'matched'
+  | 'corp_anchor_conflict'
+  | 'corp_anchor_absent'
+  | 'delivery_corp_unresolved'
+  | 'corp_mismatch'
+
+type CallbackCompletionEvidence = {
+  deliveryId: string
+  headerEventCorpIdPresent: boolean
+  bodyCorpIdPresent: boolean
+  corpGateResult: CallbackCorpGateResult
+}
+
+type ResolvedCallbackOutcome = {
+  result: DingTalkApprovalCardCallbackResult
+  operatorDisplayName: string | null
+  completionEvidence: CallbackCompletionEvidence | null
+}
+
 function readCallbackCorpAnchor(payload: unknown): CallbackCorpAnchor {
   const record = asRecord(payload)
   if (!record) return { headerPresent: false, bodyPresent: false, conflict: false, value: '' }
@@ -420,7 +440,8 @@ async function resolveOperatorLocalUser(
 /**
  * Full B-3 execution: parse → ledger-only delivery resolve → fail-closed operator mapping →
  * same-source token threading → A-4 wrapper — then the B-4 terminal card update at outcome
- * production. Returns the typed outcome; never logs (callers own values-free logging).
+ * production. Returns the typed outcome and emits one values-free completion-evidence record only
+ * after the terminal-update attempt has completed; transport callers retain their existing outcome log.
  *
  * The B-4 follow-up is failure-isolated by construction: `applyDingTalkApprovalCardTerminalUpdate`
  * never throws and holds no query/engine access, so the committed action and the returned outcome
@@ -430,8 +451,17 @@ export async function executeDingTalkApprovalCardCallback(
   deps: DingTalkApprovalCardCallbackDeps,
   payload: unknown,
 ): Promise<DingTalkApprovalCardCallbackResult> {
-  const { result, operatorDisplayName } = await resolveDingTalkApprovalCardCallbackOutcome(deps, payload)
+  const { result, operatorDisplayName, completionEvidence } = await resolveDingTalkApprovalCardCallbackOutcome(deps, payload)
   await applyDingTalkApprovalCardTerminalUpdate(result, { operatorDisplayName }, deps.cardUpdateSender)
+  if (completionEvidence) {
+    // One atomic, values-free record binds the corp-anchor result and terminal callback outcome to
+    // the same completed invocation. UAT must consume this record instead of joining independent
+    // anchor/handled log lines that could belong to different callbacks.
+    logger.info('DingTalk interactive-card callback completed evidence', {
+      ...completionEvidence,
+      callbackOutcome: result.outcome,
+    })
+  }
   return result
 }
 
@@ -443,7 +473,7 @@ export async function executeDingTalkApprovalCardCallback(
 async function resolveDingTalkApprovalCardCallbackOutcome(
   deps: DingTalkApprovalCardCallbackDeps,
   payload: unknown,
-): Promise<{ result: DingTalkApprovalCardCallbackResult; operatorDisplayName: string | null }> {
+): Promise<ResolvedCallbackOutcome> {
   const parsed = parseDingTalkApprovalCardCallback(payload)
   if (parsed.ok === false) {
     return {
@@ -451,13 +481,16 @@ async function resolveDingTalkApprovalCardCallbackOutcome(
         ? { outcome: 'rejected', reason: parsed.reason }
         : { outcome: 'ignored_unsupported_action', outTrackId: parsed.outTrackId },
       operatorDisplayName: null,
+      completionEvidence: null,
     }
   }
   const { outTrackId, operatorDingTalkUserId } = parsed.callback
 
   // LEDGER-ONLY resolution (§2): the delivery row is the sole delivery → instance anchor.
   const delivery = await findDingTalkApprovalCardDeliveryById(deps.query, outTrackId)
-  if (!delivery) return { result: { outcome: 'delivery_not_found', outTrackId }, operatorDisplayName: null }
+  if (!delivery) {
+    return { result: { outcome: 'delivery_not_found', outTrackId }, operatorDisplayName: null, completionEvidence: null }
+  }
 
   // Owner hard gate (2026-07-10): operator identity may only resolve inside the delivery's own
   // DingTalk corp. An unpinned delivery (integration_id NULL) refuses OUTRIGHT — never a global
@@ -466,6 +499,7 @@ async function resolveDingTalkApprovalCardCallbackOutcome(
     return {
       result: { outcome: 'operator_unresolved', deliveryId: delivery.id, reason: 'integration_unpinned' },
       operatorDisplayName: null,
+      completionEvidence: null,
     }
   }
 
@@ -514,10 +548,18 @@ async function resolveDingTalkApprovalCardCallbackOutcome(
           : anchor.value !== deliveryCorpId ? 'corp_mismatch'
             : null
 
+  const completionEvidence: CallbackCompletionEvidence = {
+    deliveryId: delivery.id,
+    headerEventCorpIdPresent: anchor.headerPresent,
+    bodyCorpIdPresent: anchor.bodyPresent,
+    corpGateResult: corpRefusal ?? 'matched',
+  }
+
   if (corpRefusal) {
     return {
       result: { outcome: 'operator_unresolved', deliveryId: delivery.id, reason: corpRefusal },
       operatorDisplayName: null,
+      completionEvidence,
     }
   }
 
@@ -526,6 +568,7 @@ async function resolveDingTalkApprovalCardCallbackOutcome(
     return {
       result: { outcome: 'operator_unresolved', deliveryId: delivery.id, reason: operator.reason },
       operatorDisplayName: null,
+      completionEvidence,
     }
   }
 
@@ -534,7 +577,11 @@ async function resolveDingTalkApprovalCardCallbackOutcome(
   // unreachable here by the owner gate above (P2 landing discipline: do NOT re-add it).
   const linkSecret = await resolveApprovalCardLinkSecretForIntegration(delivery.integration_id, deps.query)
   if (!linkSecret) {
-    return { result: { outcome: 'link_secret_unavailable', deliveryId: delivery.id }, operatorDisplayName: operator.userName }
+    return {
+      result: { outcome: 'link_secret_unavailable', deliveryId: delivery.id },
+      operatorDisplayName: operator.userName,
+      completionEvidence,
+    }
   }
   const token = createHmac('sha256', linkSecret).update(delivery.id).digest('hex').slice(0, 32)
 
@@ -559,9 +606,17 @@ async function resolveDingTalkApprovalCardCallbackOutcome(
   const operatorDisplayName = operator.userName
   switch (outcome.status) {
     case 'ok':
-      return { result: { outcome: 'executed', deliveryId: delivery.id, summary: outcome.summary }, operatorDisplayName }
+      return {
+        result: { outcome: 'executed', deliveryId: delivery.id, summary: outcome.summary },
+        operatorDisplayName,
+        completionEvidence,
+      }
     case 'stale':
-      return { result: { outcome: 'stale', deliveryId: delivery.id, summary: outcome.summary }, operatorDisplayName }
+      return {
+        result: { outcome: 'stale', deliveryId: delivery.id, summary: outcome.summary },
+        operatorDisplayName,
+        completionEvidence,
+      }
     case 'engine_rejected':
       // Values-free: the engine's human-readable message may carry titles/names — only the stable
       // code and HTTP class cross this boundary. B-4 maps codes to reason-coded card copy.
@@ -574,9 +629,14 @@ async function resolveDingTalkApprovalCardCallbackOutcome(
           summary: outcome.summary,
         },
         operatorDisplayName,
+        completionEvidence,
       }
     case 'not_found':
     default:
-      return { result: { outcome: 'wrapper_not_found', deliveryId: delivery.id }, operatorDisplayName }
+      return {
+        result: { outcome: 'wrapper_not_found', deliveryId: delivery.id },
+        operatorDisplayName,
+        completionEvidence,
+      }
   }
 }

--- a/packages/core-backend/src/integrations/dingtalk/interactive-card-update.ts
+++ b/packages/core-backend/src/integrations/dingtalk/interactive-card-update.ts
@@ -26,7 +26,10 @@ import {
 } from './client'
 import { resolveDingTalkInteractiveCardStreamConfig } from './interactive-card-stream'
 import type { DingTalkApprovalCardCallbackResult } from './interactive-card-callback'
-import type { ApprovalCardDeliverySummary } from '../../services/ApprovalCardDeliveryAction'
+import type {
+  ApprovalCardActionOutcome,
+  ApprovalCardDeliverySummary,
+} from '../../services/ApprovalCardDeliveryAction'
 
 const logger = new Logger('DingTalkInteractiveCardUpdate')
 
@@ -165,6 +168,37 @@ export function buildDingTalkApprovalCardTerminalUpdate(
 }
 
 /**
+ * Web deep-link convergence is deliberately narrower than the Stream callback mapping. It updates
+ * only the interactive card named by the authoritative delivery summary, and only after the
+ * approval engine reports a true reject/revoke terminal state. Replaying the same outcome produces
+ * the same update-by-key payload, so retries and stale deep-link submissions are idempotent.
+ */
+export function buildDingTalkApprovalCardWebTerminalUpdate(
+  outcome: ApprovalCardActionOutcome,
+): DingTalkApprovalCardTerminalUpdate | null {
+  if (outcome.status !== 'ok' && outcome.status !== 'stale') return null
+
+  const { summary } = outcome
+  if (summary.deliveryKind !== 'interactive_card') return null
+
+  if (summary.approval.status === 'revoked') {
+    return {
+      outTrackId: summary.deliveryId,
+      statusText: '审批已撤销',
+      actionsVisible: false,
+    }
+  }
+  if (summary.approval.status !== 'rejected') return null
+
+  const actedAt = summary.actedAction === 'reject' ? formatCardTime(summary.actedAt) : null
+  return {
+    outTrackId: summary.deliveryId,
+    statusText: actedAt ? `已驳回 · ${actedAt}` : '审批已拒绝',
+    actionsVisible: false,
+  }
+}
+
+/**
  * Production sender: same env-gated Stream credentials the B-2 send used (`resolve…StreamConfig`),
  * app-token via the shared cache, official update endpoint. Returns `null` when the stream gate is
  * off — with the flag off no card was ever sent by this channel, so there is nothing to update.
@@ -183,6 +217,49 @@ export function createDingTalkApprovalCardStreamUpdateSender(
   }
 }
 
+async function applyBuiltDingTalkApprovalCardTerminalUpdate(
+  build: () => DingTalkApprovalCardTerminalUpdate | null,
+  fallbackOutTrackId: string,
+  sender?: DingTalkApprovalCardUpdateSender,
+): Promise<DingTalkApprovalCardTerminalUpdateOutcome> {
+  try {
+    const update = build()
+    if (!update) return { status: 'skipped', reason: 'no_update_for_outcome' }
+
+    const send = sender ?? createDingTalkApprovalCardStreamUpdateSender()
+    if (!send) return { status: 'skipped', reason: 'stream_config_disabled' }
+
+    await send(update)
+    return { status: 'updated', outTrackId: update.outTrackId }
+  } catch (error) {
+    const reason = error instanceof Error ? error.name : 'UnknownError'
+    // Values-free: stable error class + ledger id only. Never log error messages, API bodies,
+    // comments, approval titles, or card parameter values.
+    logger.warn(`DingTalk approval-card terminal update failed (card_update_failed:${reason}) delivery=${fallbackOutTrackId}`)
+    return { status: 'failed', outTrackId: fallbackOutTrackId, reason }
+  }
+}
+
+/**
+ * Post-commit presentation hook for the `/m/approval-decision` web path. This function is total:
+ * DingTalk/config failures resolve to a typed failure and can never alter the committed approval or
+ * delivery ledger. The route intentionally ignores that typed result after recording the warning.
+ */
+export async function applyDingTalkApprovalCardWebTerminalUpdate(
+  outcome: ApprovalCardActionOutcome,
+  sender?: DingTalkApprovalCardUpdateSender,
+): Promise<DingTalkApprovalCardTerminalUpdateOutcome> {
+  const outTrackId =
+    outcome.status === 'ok' || outcome.status === 'stale' || outcome.status === 'engine_rejected'
+      ? outcome.summary.deliveryId
+      : 'unknown'
+  return applyBuiltDingTalkApprovalCardTerminalUpdate(
+    () => buildDingTalkApprovalCardWebTerminalUpdate(outcome),
+    outTrackId,
+    sender,
+  )
+}
+
 /**
  * The B-4 follow-up hook: build the terminal update for an outcome and send it. NEVER throws and
  * touches no database — the committed approval action is out of reach from here (no-rollback
@@ -194,24 +271,10 @@ export async function applyDingTalkApprovalCardTerminalUpdate(
   context: DingTalkApprovalCardTerminalUpdateContext = {},
   sender?: DingTalkApprovalCardUpdateSender,
 ): Promise<DingTalkApprovalCardTerminalUpdateOutcome> {
-  // Review P3-1: the copy builder and sender resolution sit INSIDE the try so "never throws" is
-  // structural, not incidental — both are total functions today, but a future edit to either must
-  // not be able to break the no-rollback invariant.
-  try {
-    const update = buildDingTalkApprovalCardTerminalUpdate(result, context)
-    if (!update) return { status: 'skipped', reason: 'no_update_for_outcome' }
-
-    const send = sender ?? createDingTalkApprovalCardStreamUpdateSender()
-    if (!send) return { status: 'skipped', reason: 'stream_config_disabled' }
-
-    await send(update)
-    return { status: 'updated', outTrackId: update.outTrackId }
-  } catch (error) {
-    const reason = error instanceof Error ? error.name : 'UnknownError'
-    // Values-free (lock §5.3): reason class + ledger id only — API error bodies and card payloads
-    // never enter logs. The action itself is already committed and stays committed.
-    const outTrackId = 'deliveryId' in result ? result.deliveryId : ('outTrackId' in result ? result.outTrackId : 'unknown')
-    logger.warn(`DingTalk approval-card terminal update failed (card_update_failed:${reason}) delivery=${outTrackId}`)
-    return { status: 'failed', outTrackId, reason }
-  }
+  const outTrackId = 'deliveryId' in result ? result.deliveryId : ('outTrackId' in result ? result.outTrackId : 'unknown')
+  return applyBuiltDingTalkApprovalCardTerminalUpdate(
+    () => buildDingTalkApprovalCardTerminalUpdate(result, context),
+    outTrackId,
+    sender,
+  )
 }

--- a/packages/core-backend/src/routes/approvals.ts
+++ b/packages/core-backend/src/routes/approvals.ts
@@ -23,6 +23,7 @@ import {
   executeApprovalActionFromCardDelivery,
   getApprovalCardDeliverySummary,
 } from '../services/ApprovalCardDeliveryAction'
+import { applyDingTalkApprovalCardWebTerminalUpdate } from '../integrations/dingtalk/interactive-card-update'
 import {
   ApprovalProductService,
   resolveApprovalListPaging,
@@ -1965,6 +1966,10 @@ export function approvalsRouter(options?: ApprovalRouterOptions): Router {
           },
         },
       )
+      // The approval action and delivery-ledger claim have already committed inside the wrapper.
+      // This presentation follow-up is failure-isolated and idempotent; DingTalk failure must not
+      // change the HTTP decision result or roll back the approval.
+      await applyDingTalkApprovalCardWebTerminalUpdate(outcome)
       if (outcome.status === 'not_found') {
         return res.status(404).json(approvalErrorResponse('APPROVAL_CARD_DELIVERY_NOT_FOUND', 'Card delivery not found'))
       }

--- a/packages/core-backend/src/services/ApprovalCardDeliveryAction.ts
+++ b/packages/core-backend/src/services/ApprovalCardDeliveryAction.ts
@@ -50,6 +50,7 @@ export type ApprovalCardDecision = 'approve' | 'reject'
 
 export interface ApprovalCardDeliverySummary {
   deliveryId: string
+  deliveryKind: DingTalkApprovalCardDeliveryRow['delivery_kind']
   cardState: DingTalkApprovalCardDeliveryRow['card_state']
   sendStatus: DingTalkApprovalCardDeliveryRow['send_status']
   nodeKey: string
@@ -174,6 +175,7 @@ async function buildSummary(
   if (!instance) return null
   return {
     deliveryId: delivery.id,
+    deliveryKind: delivery.delivery_kind,
     cardState: delivery.card_state,
     sendStatus: delivery.send_status,
     nodeKey: delivery.node_key,

--- a/packages/core-backend/tests/integration/approval-card-delivery-wrapper.db.test.ts
+++ b/packages/core-backend/tests/integration/approval-card-delivery-wrapper.db.test.ts
@@ -19,6 +19,7 @@ import {
   getApprovalCardDeliverySummary,
   verifyApprovalCardLinkToken,
 } from '../../src/services/ApprovalCardDeliveryAction'
+import { applyDingTalkApprovalCardWebTerminalUpdate } from '../../src/integrations/dingtalk/interactive-card-update'
 import {
   insertDingTalkApprovalCardDelivery,
   markDingTalkApprovalCardDeliverySendFailed,
@@ -116,7 +117,11 @@ async function newInstance(tid: string = templateId): Promise<string> {
 
 async function newSentDelivery(
   instanceId: string,
-  opts: { nodeKey?: string; entryEpoch?: number | null } = {},
+  opts: {
+    nodeKey?: string
+    entryEpoch?: number | null
+    deliveryKind?: 'work_notice_action_card' | 'interactive_card'
+  } = {},
 ): Promise<string> {
   const nodeKey = opts.nodeKey ?? 'approval_1'
   // P1-1 STRICT epoch: an actionable card MUST carry the round's non-null epoch (the real send path
@@ -128,7 +133,7 @@ async function newSentDelivery(
     nodeKey,
     recipientUserId: APPROVER,
     recipientDingTalkUserId: `dd_${APPROVER}`,
-    deliveryKind: 'work_notice_action_card',
+    deliveryKind: opts.deliveryKind ?? 'work_notice_action_card',
     entryEpoch,
   })
   await markDingTalkApprovalCardDeliverySent(q, row.id, 'task_cdw')
@@ -527,6 +532,45 @@ describeIfDatabase('A-4 card-delivery wrapper (real DB)', () => {
       expect(retry.summary.actedAction).toBe('reject')
       expect(retry.summary.approval.status).toBe('rejected')
     }
+  })
+
+  test('WEB REJECT no-rollback: DingTalk update failure cannot undo the committed approval or acted ledger claim', async () => {
+    const instanceId = await newInstance()
+    const deliveryId = await newSentDelivery(instanceId, { deliveryKind: 'interactive_card' })
+    const action = await executeApprovalActionFromCardDelivery(
+      { query: q, approvals },
+      {
+        deliveryId,
+        token: tokenFor(deliveryId),
+        decision: 'reject',
+        comment: '材料不完整',
+        actor: approverActor,
+      },
+    )
+    expect(action.status).toBe('ok')
+
+    const update = await applyDingTalkApprovalCardWebTerminalUpdate(
+      action,
+      async () => { throw new Error('DingTalk response body must stay values-free') },
+    )
+    expect(update).toEqual({ status: 'failed', outTrackId: deliveryId, reason: 'Error' })
+
+    const approval = await q('SELECT status FROM approval_instances WHERE id = $1', [instanceId])
+    expect(approval.rows[0]).toMatchObject({ status: 'rejected' })
+    const card = await q(
+      `SELECT card_state, acted_action, acted_by FROM dingtalk_approval_card_deliveries WHERE id = $1`,
+      [deliveryId],
+    )
+    expect(card.rows[0]).toMatchObject({
+      card_state: 'acted',
+      acted_action: 'reject',
+      acted_by: APPROVER,
+    })
+    const records = await q(
+      `SELECT COUNT(*)::int AS count FROM approval_records WHERE instance_id = $1 AND action = 'reject'`,
+      [instanceId],
+    )
+    expect((records.rows[0] as { count: number }).count).toBe(1)
   })
 
   test('CONCURRENCY tripwire: two simultaneous approves — exactly one engine action, one claim, loser gets the real terminal state', async () => {

--- a/packages/core-backend/tests/integration/approval-card-delivery-wrapper.db.test.ts
+++ b/packages/core-backend/tests/integration/approval-card-delivery-wrapper.db.test.ts
@@ -75,6 +75,51 @@ async function waitUntilBlockedOnInstanceLock(blockerPid: number, timeoutMs = 50
 }
 
 /**
+ * Wait until TWO distinct dispatch transactions are in the same instance-lock queue rooted at the
+ * holder. The second transaction may wait behind the first waiter rather than directly on the
+ * holder, so walk `pg_blocking_pids` transitively instead of requiring two direct blockers.
+ */
+async function waitUntilDistinctInstanceLockWaiters(
+  blockerPid: number,
+  expectedWaiters = 2,
+  timeoutMs = 5000,
+): Promise<number[]> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    const r = await q(
+      `WITH RECURSIVE
+         waiters AS (
+           SELECT pid
+             FROM pg_stat_activity
+            WHERE datname = current_database()
+              AND wait_event_type = 'Lock'
+              AND query ILIKE '%approval_instances%'
+              AND query ILIKE '%for update%'
+         ),
+         lock_chain(waiter_pid, blocker_pid) AS (
+           SELECT waiters.pid, direct_blocker.pid
+             FROM waiters
+             CROSS JOIN LATERAL unnest(pg_blocking_pids(waiters.pid)) AS direct_blocker(pid)
+           UNION
+           SELECT lock_chain.waiter_pid, upstream_blocker.pid
+             FROM lock_chain
+             CROSS JOIN LATERAL unnest(pg_blocking_pids(lock_chain.blocker_pid)) AS upstream_blocker(pid)
+         )
+       SELECT DISTINCT waiter_pid::int AS pid
+         FROM lock_chain
+        WHERE blocker_pid = $1`,
+      [blockerPid],
+    )
+    const pids = (r.rows as Array<{ pid: number | string }>).map((row) => Number(row.pid))
+    if (pids.length >= expectedWaiters) return pids
+    await sleep(25)
+  }
+  throw new Error(
+    `timed out waiting for ${expectedWaiters} distinct dispatchAction lock waiters rooted at holder ${blockerPid}; the double-tap test became sequential or dispatchAction stopped locking approval_instances`,
+  )
+}
+
+/**
  * Same deterministic lock-wait proof, for the DELIVERY row (owner P1 2026-07-12). Correlated to OUR
  * holder via pg_blocking_pids so a foreign waiter can never satisfy it.
  */
@@ -576,20 +621,53 @@ describeIfDatabase('A-4 card-delivery wrapper (real DB)', () => {
   test('CONCURRENCY tripwire: two simultaneous approves — exactly one engine action, one claim, loser gets the real terminal state', async () => {
     // The wrapper is dispatch-THEN-claim, so in a true concurrent window BOTH requests can enter
     // the engine — the engine's own gates (FOR UPDATE + status/version) must reduce them to one.
-    // A sequential duplicate-tap test cannot prove this; Promise.all does.
+    // A bare Promise.all cannot prove this: one call can complete before the other starts its
+    // transaction. Hold the engine's instance lock, park BOTH distinct dispatch transactions on it
+    // (verified through the full pg_blocking_pids chain), then release the shared barrier.
+    //
+    // Mutation proof: removing the engine's instance FOR UPDATE means neither request parks here;
+    // moving the second request below COMMIT leaves only one waiter. Both mutations time out at the
+    // barrier instead of quietly reducing this golden to a sequential duplicate-tap assertion.
     const instanceId = await newInstance()
     const deliveryId = await newSentDelivery(instanceId)
+    const holder = await poolManager.get().getInternalPool().connect()
+    let firstPromise: ReturnType<typeof executeApprovalActionFromCardDelivery> | undefined
+    let secondPromise: ReturnType<typeof executeApprovalActionFromCardDelivery> | undefined
+    try {
+      await holder.query('BEGIN')
+      await holder.query(
+        `SELECT id FROM approval_instances
+          WHERE id = $1 AND COALESCE(source_system, 'platform') = 'platform'
+          FOR UPDATE`,
+        [instanceId],
+      )
+      const holderPid = Number((await holder.query('SELECT pg_backend_pid() AS pid')).rows[0].pid)
 
-    const [first, second] = await Promise.all([
-      executeApprovalActionFromCardDelivery(
+      firstPromise = executeApprovalActionFromCardDelivery(
         { query: q, approvals },
         { deliveryId, token: tokenFor(deliveryId), decision: 'approve', comment: '并发A', actor: approverActor },
-      ),
-      executeApprovalActionFromCardDelivery(
+      )
+      await waitUntilBlockedOnInstanceLock(holderPid, 2500)
+
+      secondPromise = executeApprovalActionFromCardDelivery(
         { query: q, approvals },
         { deliveryId, token: tokenFor(deliveryId), decision: 'approve', comment: '并发B', actor: approverActor },
-      ),
-    ])
+      )
+      const waiterPids = await waitUntilDistinctInstanceLockWaiters(holderPid, 2, 2500)
+      expect(new Set(waiterPids).size).toBeGreaterThanOrEqual(2)
+
+      // Both requests are inside the same load-bearing engine lock window. Only now may either
+      // acquire the row and decide/claim.
+      await holder.query('COMMIT')
+    } catch (error) {
+      await holder.query('ROLLBACK').catch(() => {})
+      await Promise.allSettled([firstPromise, secondPromise].filter((promise): promise is Promise<unknown> => promise !== undefined))
+      throw error
+    } finally {
+      holder.release()
+    }
+
+    const [first, second] = await Promise.all([firstPromise!, secondPromise!])
     const outcomes = [first, second]
     const winners = outcomes.filter((o) => o.status === 'ok')
     expect(winners).toHaveLength(1)
@@ -611,10 +689,11 @@ describeIfDatabase('A-4 card-delivery wrapper (real DB)', () => {
       .filter((r) => r.metadata?.channel === 'dingtalk_card')
     expect(channelRecords).toHaveLength(1)
 
-    // exactly ONE acted claim on the card
+    // Exactly ONE durable claim on the card, paired with the one engine action above.
     const card = await q(`SELECT card_state, acted_by, acted_action FROM dingtalk_approval_card_deliveries WHERE id = $1`, [deliveryId])
     expect((card.rows[0] as { card_state: string }).card_state).toBe('acted')
     expect((card.rows[0] as { acted_action: string }).acted_action).toBe('approve')
+    expect((card.rows[0] as { acted_by: string }).acted_by).toBe(APPROVER)
   })
 
     test('non-assignee actor is rejected by the ENGINE (zero bypass), card stays claimable', async () => {

--- a/packages/core-backend/tests/integration/dingtalk-approval-card-callback.db.test.ts
+++ b/packages/core-backend/tests/integration/dingtalk-approval-card-callback.db.test.ts
@@ -440,6 +440,17 @@ describeIfDatabase('B-3 DingTalk card callback adapter (real DB)', () => {
       return null
     }
 
+    /** Atomic completion evidence: anchor provenance + corp gate + outcome from one invocation. */
+    const completionLogFor = (deliveryId: string): Record<string, unknown> | null => {
+      for (const call of infoSpy.mock.calls) {
+        const [msg, meta] = call as [string, Record<string, unknown> | undefined]
+        if (msg === 'DingTalk interactive-card callback completed evidence' && meta?.deliveryId === deliveryId) {
+          return meta
+        }
+      }
+      return null
+    }
+
     /** Every string that ever reached ANY logger call this test — used to prove no corp value leaked. */
     const allLoggedText = (): string =>
       infoSpy.mock.calls.map((c) => JSON.stringify(c)).join(' | ')
@@ -463,6 +474,12 @@ describeIfDatabase('B-3 DingTalk card callback adapter (real DB)', () => {
       )
       expect(res.outcome).toBe('executed')
       expect(anchorLogFor(deliveryId)).toMatchObject({ headerEventCorpIdPresent: true, bodyCorpIdPresent: false })
+      expect(completionLogFor(deliveryId)).toMatchObject({
+        headerEventCorpIdPresent: true,
+        bodyCorpIdPresent: false,
+        corpGateResult: 'matched',
+        callbackOutcome: 'executed',
+      })
     })
 
     test('BODY-ONLY (no header) → executes; presence logged as header=false body=true — THIS is the §0-a answer that says the header does not exist on real frames', async () => {
@@ -480,6 +497,12 @@ describeIfDatabase('B-3 DingTalk card callback adapter (real DB)', () => {
       expect(res).toEqual({ outcome: 'operator_unresolved', deliveryId, reason: 'corp_anchor_absent' })
       expect(await approveRecordCount(instanceId)).toBe(0)
       expect(anchorLogFor(deliveryId)).toMatchObject({ headerEventCorpIdPresent: false, bodyCorpIdPresent: false })
+      expect(completionLogFor(deliveryId)).toMatchObject({
+        headerEventCorpIdPresent: false,
+        bodyCorpIdPresent: false,
+        corpGateResult: 'corp_anchor_absent',
+        callbackOutcome: 'operator_unresolved',
+      })
     })
 
     test('CONFLICT (header ≠ body) → corp_anchor_conflict, NOT absent — a disagreement must never be misreported as "no anchor exists"', async () => {
@@ -546,6 +569,12 @@ describeIfDatabase('B-3 DingTalk card callback adapter (real DB)', () => {
       const res = await executeDingTalkApprovalCardCallback(deps, payloadFor(deliveryId, DD_OP_B, {}, 'approve', CORP_A))
       expect(res).toEqual({ outcome: 'operator_unresolved', deliveryId, reason: 'corp_mismatch' })
       expect(await approveRecordCount(instanceId)).toBe(0)
+      expect(completionLogFor(deliveryId)).toMatchObject({
+        headerEventCorpIdPresent: false,
+        bodyCorpIdPresent: true,
+        corpGateResult: 'corp_mismatch',
+        callbackOutcome: 'operator_unresolved',
+      })
     })
 
     test('VALUES-FREE: no corp id, user id, form value or raw payload EVER reaches a log line', async () => {
@@ -565,6 +594,7 @@ describeIfDatabase('B-3 DingTalk card callback adapter (real DB)', () => {
 
       // ...while the presence booleans ARE there. Absent this, the test would pass by logging nothing.
       expect(anchorLogFor(deliveryId)).toMatchObject({ headerEventCorpIdPresent: true, bodyCorpIdPresent: true })
+      expect(completionLogFor(deliveryId)).toMatchObject({ corpGateResult: 'matched', callbackOutcome: 'executed' })
     })
   })
 

--- a/packages/core-backend/tests/unit/approval-card-web-terminal-route.test.ts
+++ b/packages/core-backend/tests/unit/approval-card-web-terminal-route.test.ts
@@ -1,0 +1,106 @@
+import express, { type Express } from 'express'
+import request from 'supertest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { usePinnedServer } from '../utils/pinned-server'
+
+const state = vi.hoisted(() => ({
+  actionOutcome: {
+    status: 'ok',
+    summary: {
+      deliveryId: 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee',
+      deliveryKind: 'interactive_card',
+      cardState: 'acted',
+      sendStatus: 'sent',
+      nodeKey: 'approval_1',
+      recipientUserId: 'user-1',
+      viewerIsRecipient: true,
+      actionable: false,
+      approval: {
+        instanceId: 'approval-1',
+        title: null,
+        requestNo: null,
+        status: 'rejected',
+        currentNodeKey: null,
+        rejectCommentRequired: true,
+      },
+      actedAction: 'reject',
+      actedAt: '2026-08-18T04:00:00.000Z',
+    },
+  },
+  execute: vi.fn(),
+  update: vi.fn(),
+}))
+
+vi.mock('../../src/db/pg', () => ({
+  pool: {
+    query: vi.fn(async () => ({ rows: [], rowCount: 0 })),
+    connect: vi.fn(),
+  },
+}))
+
+vi.mock('../../src/middleware/auth', () => ({
+  authenticate: (req: express.Request, _res: express.Response, next: express.NextFunction) => {
+    req.user = {
+      id: 'user-1',
+      name: 'Route Approver',
+      roles: [],
+      permissions: ['*:*'],
+    } as never
+    next()
+  },
+}))
+
+vi.mock('../../src/rbac/rbac', () => ({
+  rbacGuard: () => (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),
+  rbacGuardAny: () => (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),
+}))
+
+vi.mock('../../src/services/ApprovalCardDeliveryAction', () => ({
+  executeApprovalActionFromCardDelivery: state.execute,
+  getApprovalCardDeliverySummary: vi.fn(),
+}))
+
+vi.mock('../../src/integrations/dingtalk/interactive-card-update', () => ({
+  applyDingTalkApprovalCardWebTerminalUpdate: state.update,
+}))
+
+const pinned = usePinnedServer()
+
+describe('approval-card web terminal route seam', () => {
+  let app: Express
+
+  beforeEach(async () => {
+    vi.resetModules()
+    state.execute.mockReset().mockResolvedValue(state.actionOutcome)
+    state.update.mockReset().mockResolvedValue({
+      status: 'failed',
+      outTrackId: state.actionOutcome.summary.deliveryId,
+      reason: 'Error',
+    })
+    const { approvalsRouter } = await import('../../src/routes/approvals')
+    app = express()
+    app.use(express.json())
+    app.use(approvalsRouter())
+  })
+
+  it('runs the failure-isolated card update after reject and preserves the successful HTTP result', async () => {
+    pinned.setApp(app)
+    const response = await request(pinned.url())
+      .post(`/api/approval-card-deliveries/${state.actionOutcome.summary.deliveryId}/actions`)
+      .send({ decision: 'reject', comment: '材料不完整', t: 'a'.repeat(32) })
+
+    expect(response.status).toBe(200)
+    expect(response.body).toMatchObject({
+      ok: true,
+      data: {
+        approval: { status: 'rejected' },
+        actedAction: 'reject',
+      },
+    })
+    expect(state.execute).toHaveBeenCalledTimes(1)
+    expect(state.update).toHaveBeenCalledTimes(1)
+    expect(state.update).toHaveBeenCalledWith(state.actionOutcome)
+    expect(state.execute.mock.invocationCallOrder[0]).toBeLessThan(state.update.mock.invocationCallOrder[0])
+  })
+})

--- a/packages/core-backend/tests/unit/dingtalk-corp-anchor-log-emission.test.ts
+++ b/packages/core-backend/tests/unit/dingtalk-corp-anchor-log-emission.test.ts
@@ -24,6 +24,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import winston from 'winston'
 
 const ANCHOR_MSG = 'DingTalk interactive-card callback corp anchor'
+const COMPLETION_MSG = 'DingTalk interactive-card callback completed evidence'
 
 describe('UAT §0-a: the corp-anchor record survives the winston level gate', () => {
   const originalLevel = process.env.LOG_LEVEL
@@ -43,7 +44,7 @@ describe('UAT §0-a: the corp-anchor record survives the winston level gate', ()
     vi.resetModules()
   })
 
-  const emitAnchor = async (level: string): Promise<Array<Record<string, unknown>>> => {
+  const emitEvidence = async (level: string): Promise<Array<Record<string, unknown>>> => {
     process.env.LOG_LEVEL = level
     vi.resetModules()
     const { Logger } = await import('../../src/core/logger')
@@ -53,22 +54,37 @@ describe('UAT §0-a: the corp-anchor record survives the winston level gate', ()
       headerEventCorpIdPresent: true,
       bodyCorpIdPresent: false,
     })
+    logger.info(COMPLETION_MSG, {
+      deliveryId: 'd-0a',
+      headerEventCorpIdPresent: true,
+      bodyCorpIdPresent: false,
+      corpGateResult: 'matched',
+      callbackOutcome: 'executed',
+    })
     return transportLog.mock.calls.map((c) => c[0] as Record<string, unknown>)
   }
 
-  it('POSITIVE CONTROL — at LOG_LEVEL=info the record REACHES the transport, with the presence booleans and no corp value', async () => {
-    const emitted = await emitAnchor('info')
+  it('POSITIVE CONTROL — at LOG_LEVEL=info both evidence records REACH the transport with no corp value', async () => {
+    const emitted = await emitEvidence('info')
     const anchor = emitted.find((i) => i.message === ANCHOR_MSG)
+    const completion = emitted.find((i) => i.message === COMPLETION_MSG)
 
     expect(anchor).toBeDefined()
     expect(anchor).toMatchObject({ headerEventCorpIdPresent: true, bodyCorpIdPresent: false })
+    expect(completion).toMatchObject({
+      headerEventCorpIdPresent: true,
+      bodyCorpIdPresent: false,
+      corpGateResult: 'matched',
+      callbackOutcome: 'executed',
+    })
     // The instrument must never become an exfiltration channel for the identifier it exists to count.
-    expect(JSON.stringify(anchor)).not.toMatch(/corp_[A-Za-z0-9]/)
+    expect(JSON.stringify([anchor, completion])).not.toMatch(/corp_[A-Za-z0-9]/)
   })
 
-  it('THE TRAP — at LOG_LEVEL=warn the SAME record never reaches the transport: silence does NOT mean "no anchor"', async () => {
-    const emitted = await emitAnchor('warn')
+  it('THE TRAP — at LOG_LEVEL=warn neither evidence record reaches the transport', async () => {
+    const emitted = await emitEvidence('warn')
     expect(emitted.find((i) => i.message === ANCHOR_MSG)).toBeUndefined()
+    expect(emitted.find((i) => i.message === COMPLETION_MSG)).toBeUndefined()
     // ⇒ §0-a MUST self-check that the probe is live (see the UAT checklist) before reading silence as
     // "the real frame carries no corp field". Otherwise the flag gets closed for the wrong reason.
   })

--- a/packages/core-backend/tests/unit/dingtalk-interactive-card-update.test.ts
+++ b/packages/core-backend/tests/unit/dingtalk-interactive-card-update.test.ts
@@ -26,11 +26,13 @@ import {
   DINGTALK_APPROVAL_CARD_NO_PERMISSION_TEXT,
   DINGTALK_APPROVAL_CARD_SYSTEM_UNAVAILABLE_TEXT,
   applyDingTalkApprovalCardTerminalUpdate,
+  applyDingTalkApprovalCardWebTerminalUpdate,
   buildDingTalkApprovalCardTerminalUpdate,
   createDingTalkApprovalCardStreamUpdateSender,
 } from '../../src/integrations/dingtalk/interactive-card-update'
 import type { DingTalkApprovalCardCallbackResult } from '../../src/integrations/dingtalk/interactive-card-callback'
 import { __resetDingTalkAppAccessTokenCacheForTests } from '../../src/integrations/dingtalk/client'
+import { Logger } from '../../src/core/logger'
 import type { ApprovalCardDeliverySummary } from '../../src/services/ApprovalCardDeliveryAction'
 
 const DELIVERY_ID = 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee'
@@ -42,6 +44,7 @@ const ACTED_AT_TEXT = '2026/07/10 14:30'
 function canarySummary(overrides: Partial<ApprovalCardDeliverySummary> = {}, approvalOverrides: Partial<ApprovalCardDeliverySummary['approval']> = {}): ApprovalCardDeliverySummary {
   return {
     deliveryId: DELIVERY_ID,
+    deliveryKind: 'interactive_card',
     cardState: 'acted',
     sendStatus: 'sent',
     nodeKey: 'NODE_KEY_CANARY',
@@ -62,6 +65,128 @@ function canarySummary(overrides: Partial<ApprovalCardDeliverySummary> = {}, app
     ...overrides,
   }
 }
+
+describe('applyDingTalkApprovalCardWebTerminalUpdate (deep-link terminal convergence)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('retires the original interactive card after a committed web reject', async () => {
+    const sends: unknown[] = []
+    const outcome = await applyDingTalkApprovalCardWebTerminalUpdate(
+      {
+        status: 'ok',
+        summary: canarySummary(
+          { actedAction: 'reject' },
+          { status: 'rejected' },
+        ),
+      },
+      async (update) => { sends.push(update) },
+    )
+
+    expect(outcome).toEqual({ status: 'updated', outTrackId: DELIVERY_ID })
+    expect(sends).toEqual([{
+      outTrackId: DELIVERY_ID,
+      statusText: `已驳回 · ${ACTED_AT_TEXT}`,
+      actionsVisible: false,
+    }])
+  })
+
+  it('retires a revoked card from the authoritative approval status', async () => {
+    const sends: unknown[] = []
+    const outcome = await applyDingTalkApprovalCardWebTerminalUpdate(
+      {
+        status: 'stale',
+        summary: canarySummary(
+          { cardState: 'superseded', actedAction: null, actedAt: null },
+          { status: 'revoked' },
+        ),
+      },
+      async (update) => { sends.push(update) },
+    )
+
+    expect(outcome).toEqual({ status: 'updated', outTrackId: DELIVERY_ID })
+    expect(sends).toEqual([{
+      outTrackId: DELIVERY_ID,
+      statusText: '审批已撤销',
+      actionsVisible: false,
+    }])
+  })
+
+  it('skips legacy work-notice deliveries and non-terminal outcomes', async () => {
+    const sender = vi.fn()
+    const workNotice = await applyDingTalkApprovalCardWebTerminalUpdate(
+      {
+        status: 'ok',
+        summary: canarySummary(
+          { deliveryKind: 'work_notice_action_card', actedAction: 'reject' },
+          { status: 'rejected' },
+        ),
+      },
+      sender,
+    )
+    const pending = await applyDingTalkApprovalCardWebTerminalUpdate(
+      {
+        status: 'engine_rejected',
+        code: 'VALIDATION_ERROR',
+        message: 'COMMENT_CANARY',
+        httpStatus: 400,
+        summary: canarySummary(
+          { cardState: 'sent', actedAction: null, actedAt: null },
+          { status: 'pending' },
+        ),
+      },
+      sender,
+    )
+
+    expect(workNotice).toEqual({ status: 'skipped', reason: 'no_update_for_outcome' })
+    expect(pending).toEqual({ status: 'skipped', reason: 'no_update_for_outcome' })
+    expect(sender).not.toHaveBeenCalled()
+  })
+
+  it('is idempotent: replaying the same terminal outcome emits byte-equal update-by-key payloads', async () => {
+    const sends: unknown[] = []
+    const outcome = {
+      status: 'ok' as const,
+      summary: canarySummary(
+        { actedAction: 'reject' },
+        { status: 'rejected' },
+      ),
+    }
+    const sender = async (update: unknown) => { sends.push(update) }
+
+    await Promise.all([
+      applyDingTalkApprovalCardWebTerminalUpdate(outcome, sender),
+      applyDingTalkApprovalCardWebTerminalUpdate(outcome, sender),
+    ])
+
+    expect(sends).toHaveLength(2)
+    expect(sends[0]).toEqual(sends[1])
+  })
+
+  it('isolates sender failure and logs only the error class plus delivery id', async () => {
+    const warning = vi.spyOn(Logger.prototype, 'warn').mockImplementation(() => {})
+    const outcome = await applyDingTalkApprovalCardWebTerminalUpdate(
+      {
+        status: 'ok',
+        summary: canarySummary(
+          { actedAction: 'reject' },
+          { status: 'rejected' },
+        ),
+      },
+      async () => { throw new Error('SECRET_API_BODY TITLE_CANARY COMMENT_CANARY') },
+    )
+
+    expect(outcome).toEqual({ status: 'failed', outTrackId: DELIVERY_ID, reason: 'Error' })
+    expect(warning).toHaveBeenCalledTimes(1)
+    const serialized = JSON.stringify(warning.mock.calls[0])
+    expect(serialized).toContain(`card_update_failed:Error`)
+    expect(serialized).toContain(DELIVERY_ID)
+    expect(serialized).not.toContain('SECRET_API_BODY')
+    expect(serialized).not.toContain('TITLE_CANARY')
+    expect(serialized).not.toContain('COMMENT_CANARY')
+  })
+})
 
 const CANARIES = [
   'NODE_KEY_CANARY',

--- a/scripts/ops/dingtalk-interactive-card-stream-staging-uat-contract.test.mjs
+++ b/scripts/ops/dingtalk-interactive-card-stream-staging-uat-contract.test.mjs
@@ -2,7 +2,7 @@
 // dingtalk-interactive-card-stream-staging-uat-contract.test.mjs
 //
 // Durable synthetic contract for the MINIMAL controlled Stream staging UAT lane:
-//   EXECUTABLE: status | observe | prepare | on | off | https-on | https-off
+//   EXECUTABLE: status | observe-baseline | observe | prepare | on | off | https-on | https-off
 //
 // Load-bearing rails:
 //   * workflow wiring (dispatch choices, SSH, concurrency, no schedule)
@@ -20,7 +20,8 @@
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
 import { spawnSync } from 'node:child_process'
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { createHash } from 'node:crypto'
+import { existsSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { createRequire } from 'node:module'
@@ -111,11 +112,40 @@ function actionBody(source, name, nextNames = []) {
   return source.slice(start, end)
 }
 
-function runObserveFixture(observe, { dir, expected, lines }) {
+function observerSupport(source) {
+  return actionBody(source, 'observer_delivery_hash', ['action_observe_baseline'])
+}
+
+function writeObserverBaseline(dir, expected, anchorCount, handledCount) {
+  const deliveryHash = createHash('sha256').update(expected).digest('hex')
+  writeFileSync(
+    join(dir, 'callback-observer-baseline'),
+    [
+      'schema=dingtalk-interactive-card-stream-callback-baseline-v1',
+      `delivery_id_sha256=${deliveryHash}`,
+      `callback_anchor_log_count=${anchorCount}`,
+      `callback_handled_count=${handledCount}`,
+      '',
+    ].join('\n'),
+    { mode: 0o600 },
+  )
+}
+
+function runObserveFixture(observe, support, {
+  dir,
+  expected,
+  lines,
+  baselineAnchor = 0,
+  baselineHandled = 0,
+  preserveBaseline = false,
+}) {
   const output = join(dir, 'output')
   const logs = join(dir, 'backend.log')
   const harness = join(dir, 'harness.sh')
   writeFileSync(logs, `${lines.join('\n')}\n`)
+  if (!preserveBaseline) {
+    writeObserverBaseline(dir, expected, baselineAnchor, baselineHandled)
+  }
   writeFileSync(
     harness,
     [
@@ -132,7 +162,9 @@ function runObserveFixture(observe, { dir, expected, lines }) {
       'docker() { [[ "$1" == "logs" ]] || return 1; cat "$LOG_FIXTURE"; }',
       'BACKEND_CONTAINER=metasheet-staging-backend',
       'FLAG_STREAM=DINGTALK_INTERACTIVE_CARD_STREAM_ENABLED',
+      'OBSERVE_BASELINE_FILE="$STREAM_UAT_PERSIST_DIR/callback-observer-baseline"',
       'mkdir -p "$STREAM_UAT_PERSIST_DIR" "$OUTPUT_DIR"',
+      support,
       observe,
       'action_observe',
     ].join('\n'),
@@ -151,7 +183,7 @@ function runObserveFixture(observe, { dir, expected, lines }) {
 }
 
 function removeObserveGuard(observe, condition) {
-  const start = observe.indexOf(`  [[ "${condition}" -gt 0 ]] ` + '\\')
+  const start = observe.indexOf(`  [[ ${condition} ]] ` + '\\')
   assert.notEqual(start, -1, `${condition} guard must exist for mutation test`)
   const firstEnd = observe.indexOf('\n', start)
   const secondEnd = observe.indexOf('\n', firstEnd + 1)
@@ -183,11 +215,11 @@ test('workflow YAML parses with repository-available parser', () => {
 test('workflow action choices include observer and reversible HTTPS gateway actions', () => {
   const doc = loadYaml(read(WORKFLOW))
   const inputs = workflowOn(doc).workflow_dispatch.inputs
-  assert.deepEqual(inputs.action.options, ['status', 'observe', 'prepare', 'on', 'off', 'https-on', 'https-off'])
+  assert.deepEqual(inputs.action.options, ['status', 'observe-baseline', 'observe', 'prepare', 'on', 'off', 'https-on', 'https-off'])
   assert.equal(inputs.action.default, 'status')
   // Quote on/off so YAML 1.1 keeps strings (loadYaml may coerce bare on/off).
   const yaml = read(WORKFLOW)
-  assert.match(yaml, /options:\s*\[status,\s*observe,\s*prepare,\s*'on',\s*'off',\s*https-on,\s*https-off\]/)
+  assert.match(yaml, /options:\s*\[status,\s*observe-baseline,\s*observe,\s*prepare,\s*'on',\s*'off',\s*https-on,\s*https-off\]/)
   assert.ok(
     inputs.action.options.every((o) => typeof o === 'string'),
     'on/off must remain strings after parse',
@@ -277,6 +309,13 @@ test('U11-a distinguishes an absent corp anchor from a real corp mismatch', () =
   assert.doesNotMatch(u11a, /corp_mismatch.*根本不带/)
 })
 
+test('U4-U8 require a same-delivery baseline before each human callback', () => {
+  const checklist = read(UAT_CHECKLIST)
+  assert.match(checklist, /先对该 delivery 运行 `observe-baseline`/)
+  assert.match(checklist, /不得拿 U4 留下的历史日志作为 U5 的证据/)
+  assert.match(checklist, /本轮无增量都必须判失败/)
+})
+
 // --- exact-SHA gate -------------------------------------------------------------------
 
 test('workflow exact-SHA gate requires full 40-char deploy_sha for every non-status action', () => {
@@ -297,25 +336,27 @@ test('workflow exact-SHA gate requires full 40-char deploy_sha for every non-sta
   )
 })
 
-test('observe exclusively requires a lowercase expected delivery UUID and never emits it', () => {
+test('observe-baseline and observe exclusively require a lowercase delivery UUID and never emit it', () => {
   const yaml = read(WORKFLOW)
   const doc = loadYaml(yaml)
   const validate = doc.jobs.run.steps.find((s) => s.name === 'Validate inputs and embedded scripts')
   assert.equal(validate.env.EXPECTED_DELIVERY_ID, '${{ inputs.expected_delivery_id }}')
-  assert.match(validate.run, /observe requires expected_delivery_id as a lowercase UUID/)
-  assert.match(validate.run, /expected_delivery_id is accepted only for action=observe/)
+  assert.match(validate.run, /\$ACTION" == "observe" \|\| "\$ACTION" == "observe-baseline"/)
+  assert.match(validate.run, /expected_delivery_id is accepted only for action=observe-baseline\/observe/)
   assert.match(validate.run, /\[1-5\]\[0-9a-f\]\{3\}/)
   const remoteStep = doc.jobs.run.steps.find((s) => s.name === 'Run remote action')
   assert.equal(remoteStep.env.EXPECTED_DELIVERY_ID, '${{ inputs.expected_delivery_id }}')
   assert.match(remoteStep.run, /refusing invalid expected_delivery_id in remote execution step/)
-  assert.match(remoteStep.run, /refusing expected_delivery_id outside action=observe/)
-  assert.match(remoteStep.run, /case "\$ACTION" in status\|observe\|prepare\|on\|off\|https-on\|https-off/)
+  assert.match(remoteStep.run, /refusing expected_delivery_id outside action=observe-baseline\/observe/)
+  assert.match(remoteStep.run, /case "\$ACTION" in status\|observe-baseline\|observe\|prepare\|on\|off\|https-on\|https-off/)
   assert.match(remoteStep.run, /refusing invalid deploy_sha in remote execution step/)
   assert.match(remoteStep.run, /refusing invalid optional deploy_sha in remote execution step/)
   const source = read(REMOTE_SH)
+  const support = observerSupport(source)
+  const baseline = actionBody(source, 'action_observe_baseline', ['action_observe'])
   const observe = actionBody(source, 'action_observe', ['action_prepare'])
-  assert.match(observe, /grep -F -c "\$EXPECTED_DELIVERY_ID"/)
-  assert.doesNotMatch(observe, /echo .*EXPECTED_DELIVERY_ID/)
+  assert.match(support, /grep -F -c "\$EXPECTED_DELIVERY_ID"/)
+  assert.doesNotMatch(`${support}\n${baseline}\n${observe}`, /echo .*EXPECTED_DELIVERY_ID/)
 })
 
 test('workflow and remote preflights reject cross-action delivery-id injection before SSH construction', () => {
@@ -361,9 +402,9 @@ test('workflow and remote preflights reject cross-action delivery-id injection b
     },
   )
 
-  for (const action of ['status', 'observe', 'prepare', 'on', 'off', 'https-on', 'https-off']) {
+  for (const action of ['status', 'observe-baseline', 'observe', 'prepare', 'on', 'off', 'https-on', 'https-off']) {
     const deploySha = action === 'status' ? '' : sha
-    const expectedDeliveryId = action === 'observe' ? deliveryId : ''
+    const expectedDeliveryId = action === 'observe' || action === 'observe-baseline' ? deliveryId : ''
     assert.equal(runValidate(action, deploySha, expectedDeliveryId).status, 0, `validate ${action}`)
     assert.equal(runRemotePreflight(action, deploySha, expectedDeliveryId).status, 0, `remote ${action}`)
   }
@@ -374,6 +415,8 @@ test('workflow and remote preflights reject cross-action delivery-id injection b
   }
   assert.equal(runValidate('observe', sha, '').status, 2)
   assert.equal(runRemotePreflight('observe', sha, '').status, 2)
+  assert.equal(runValidate('observe-baseline', sha, '').status, 2)
+  assert.equal(runRemotePreflight('observe-baseline', sha, '').status, 2)
   assert.equal(runValidate('observe', sha, "'; touch /tmp/stream-uat-injection; #").status, 2)
   assert.equal(runRemotePreflight('observe', sha, "'; touch /tmp/stream-uat-injection; #").status, 2)
   assert.equal(runValidate('status', "'; touch /tmp/stream-uat-injection; #", '').status, 2)
@@ -385,13 +428,15 @@ test('remote script require_exact_deployed_sha used by every non-status action a
   const source = read(REMOTE_SH)
   assert.match(source, /require_exact_deployed_sha/)
   assert.match(source, /resolve_deployed_sha/)
+  const baseline = actionBody(source, 'action_observe_baseline', ['action_observe'])
   const observe = actionBody(source, 'action_observe', ['action_prepare'])
   const prepare = actionBody(source, 'action_prepare', ['action_on'])
   const on = actionBody(source, 'action_on', ['action_off'])
   const off = actionBody(source, 'action_off', ['action_https_on'])
   const httpsOn = actionBody(source, 'action_https_on', ['action_https_off'])
   const httpsOff = actionBody(source, 'action_https_off')
-  const status = actionBody(source, 'action_status', ['action_observe'])
+  const status = actionBody(source, 'action_status', ['observer_delivery_hash'])
+  assert.match(baseline, /require_exact_deployed_sha "observe-baseline"/)
   assert.match(observe, /require_exact_deployed_sha "observe"/)
   assert.match(prepare, /require_exact_deployed_sha/)
   assert.match(on, /require_exact_deployed_sha/)
@@ -401,9 +446,13 @@ test('remote script require_exact_deployed_sha used by every non-status action a
   assert.doesNotMatch(status, /require_exact_deployed_sha/)
 })
 
-test('observe is read-only and emits values-free callback classes without raw logs or ids', () => {
+test('observer mutates only its local checkpoint and emits values-free callback classes', () => {
   const source = read(REMOTE_SH)
+  const support = observerSupport(source)
+  const baseline = actionBody(source, 'action_observe_baseline', ['action_observe'])
   const observe = actionBody(source, 'action_observe', ['action_prepare'])
+  assert.match(baseline, /reason=baseline_captured/)
+  assert.match(baseline, /write_observer_baseline_state/)
   assert.match(observe, /action=observe/)
   assert.match(observe, /require_lifecycle_flags_off "observe"/)
   assert.match(observe, /require_log_level_info_or_debug "observe"/)
@@ -413,7 +462,13 @@ test('observe is read-only and emits values-free callback classes without raw lo
   assert.match(observe, /window_callback_handler_error_count=/)
   assert.match(observe, /card_update_failed_count=/)
   assert.match(observe, /callback_anchor_log_count=\$\{anchor_count\}/)
+  assert.match(observe, /callback_anchor_log_count_before=\$\{baseline_anchor_count\}/)
+  assert.match(observe, /callback_anchor_log_count_delta=\$\{anchor_delta\}/)
   assert.match(observe, /callback_handled_count=\$\{handled_count\}/)
+  assert.match(observe, /callback_handled_count_before=\$\{baseline_handled_count\}/)
+  assert.match(observe, /callback_handled_count_delta=\$\{handled_delta\}/)
+  assert.match(observe, /run observe-baseline immediately before the human click/)
+  assert.match(support, /delivery_id_sha256=/)
   assert.match(observe, /outside closed set/)
   assert.doesNotMatch(observe, /handled_outcome="(?:other|unknown)"/)
   for (const outcome of [
@@ -434,11 +489,12 @@ test('observe is read-only and emits values-free callback classes without raw lo
   assert.doesNotMatch(observe, /handled_outcome="(?:accepted|duplicate)"/)
   assert.doesNotMatch(observe, /echo "callback_handler_error_count=/)
   assert.doesNotMatch(observe, /cat "\$tmp"|echo "\$anchor_line"|deliveryId=/)
-  assert.doesNotMatch(observe, /atomic_(?:set|upsert)|recreate_backend_only|compose_staging_cmd up/)
+  assert.doesNotMatch(`${baseline}\n${observe}`, /atomic_(?:set|upsert)_env|recreate_backend_only|compose_staging_cmd up/)
 })
 
 test('observe dynamically scopes Winston log evidence to the expected delivery', () => {
   const source = read(REMOTE_SH)
+  const support = observerSupport(source)
   const observe = actionBody(source, 'action_observe', ['action_prepare'])
   const dir = mkdtempSync(join(tmpdir(), 'stream-observer-'))
   const output = join(dir, 'output')
@@ -475,11 +531,14 @@ test('observe dynamically scopes Winston log evidence to the expected delivery',
         'docker() { [[ "$1" == "logs" ]] || return 1; cat "$LOG_FIXTURE"; }',
         'BACKEND_CONTAINER=metasheet-staging-backend',
         'FLAG_STREAM=DINGTALK_INTERACTIVE_CARD_STREAM_ENABLED',
+        'OBSERVE_BASELINE_FILE="$STREAM_UAT_PERSIST_DIR/callback-observer-baseline"',
         'mkdir -p "$STREAM_UAT_PERSIST_DIR" "$OUTPUT_DIR"',
+        support,
         observe,
         'action_observe',
       ].join('\n'),
     )
+    writeObserverBaseline(dir, expected, 0, 0)
     const result = spawnSync('bash', [harness], {
       encoding: 'utf8',
       env: {
@@ -507,6 +566,7 @@ test('observe dynamically scopes Winston log evidence to the expected delivery',
 
 test('observe precisely classifies scoped out_track_id terminal outcomes', () => {
   const source = read(REMOTE_SH)
+  const support = observerSupport(source)
   const observe = actionBody(source, 'action_observe', ['action_prepare'])
   const dir = mkdtempSync(join(tmpdir(), 'stream-observer-out-track-'))
   const output = join(dir, 'output')
@@ -530,7 +590,9 @@ test('observe precisely classifies scoped out_track_id terminal outcomes', () =>
         'docker() { [[ "$1" == "logs" ]] || return 1; cat "$LOG_FIXTURE"; }',
         'BACKEND_CONTAINER=metasheet-staging-backend',
         'FLAG_STREAM=DINGTALK_INTERACTIVE_CARD_STREAM_ENABLED',
+        'OBSERVE_BASELINE_FILE="$STREAM_UAT_PERSIST_DIR/callback-observer-baseline"',
         'mkdir -p "$STREAM_UAT_PERSIST_DIR" "$OUTPUT_DIR"',
+        support,
         observe,
         'action_observe',
       ].join('\n'),
@@ -552,6 +614,7 @@ test('observe precisely classifies scoped out_track_id terminal outcomes', () =>
           line,
         ].join('\n') + '\n',
       )
+      writeObserverBaseline(dir, expected, 0, 0)
       const result = spawnSync('bash', [harness], {
         encoding: 'utf8',
         env: {
@@ -572,8 +635,151 @@ test('observe precisely classifies scoped out_track_id terminal outcomes', () =>
   }
 })
 
+test('observer checkpoint rejects historical evidence and advances only after new callback pairs', () => {
+  const source = read(REMOTE_SH)
+  const support = observerSupport(source)
+  const baseline = actionBody(source, 'action_observe_baseline', ['action_observe'])
+  const observe = actionBody(source, 'action_observe', ['action_prepare'])
+  const dir = mkdtempSync(join(tmpdir(), 'stream-observer-baseline-'))
+  const output = join(dir, 'output')
+  const logs = join(dir, 'backend.log')
+  const harness = join(dir, 'baseline-harness.sh')
+  const expected = '12345678-1234-4123-8123-123456789abc'
+  const anchor = `info: DingTalk interactive-card callback corp anchor {"deliveryId":"${expected}","headerEventCorpIdPresent":true,"bodyCorpIdPresent":false}`
+  const handled = `info: DingTalk interactive-card callback handled (executed delivery=${expected})`
+  const firstPair = [anchor, handled]
+  try {
+    writeFileSync(logs, `${firstPair.join('\n')}\n`)
+    writeFileSync(
+      harness,
+      [
+        '#!/usr/bin/env bash',
+        'set -euo pipefail',
+        'log() { :; }',
+        'fail() { echo "$*" >&2; exit 1; }',
+        'assert_staging_only() { :; }',
+        'require_exact_deployed_sha() { :; }',
+        'require_lifecycle_flags_off() { :; }',
+        'require_log_level_info_or_debug() { :; }',
+        'register_ephemeral() { :; }',
+        'read_flag_from_container() { printf true; }',
+        'docker() { [[ "$1" == "logs" ]] || return 1; cat "$LOG_FIXTURE"; }',
+        'BACKEND_CONTAINER=metasheet-staging-backend',
+        'FLAG_STREAM=DINGTALK_INTERACTIVE_CARD_STREAM_ENABLED',
+        'OBSERVE_BASELINE_FILE="$STREAM_UAT_PERSIST_DIR/callback-observer-baseline"',
+        'mkdir -p "$STREAM_UAT_PERSIST_DIR" "$OUTPUT_DIR"',
+        support,
+        baseline,
+        'action_observe_baseline',
+      ].join('\n'),
+    )
+    const baselineResult = spawnSync('bash', [harness], {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        EXPECTED_DELIVERY_ID: expected,
+        LOG_FIXTURE: logs,
+        OUTPUT_DIR: output,
+        STREAM_UAT_PERSIST_DIR: dir,
+      },
+    })
+    assert.equal(baselineResult.status, 0, baselineResult.stderr)
+    const baselineArtifact = readFileSync(join(output, 'callback-observer.txt'), 'utf8')
+    assert.match(baselineArtifact, /reason=baseline_captured/)
+    assert.match(baselineArtifact, /callback_anchor_log_count=1/)
+    assert.match(baselineArtifact, /callback_handled_count=1/)
+    const baselinePath = join(dir, 'callback-observer-baseline')
+    assert.equal(statSync(baselinePath).mode & 0o777, 0o600)
+    assert.doesNotMatch(readFileSync(baselinePath, 'utf8'), new RegExp(expected))
+
+    rmSync(output, { recursive: true, force: true })
+    const historical = runObserveFixture(observe, support, {
+      dir,
+      expected,
+      lines: firstPair,
+      preserveBaseline: true,
+    })
+    assert.notEqual(historical.result.status, 0)
+    assert.match(historical.result.stderr, /new scoped callback anchor evidence \(before=1;after=1\)/)
+
+    const twoPairs = [...firstPair, anchor, handled]
+    const incremented = runObserveFixture(observe, support, {
+      dir,
+      expected,
+      lines: twoPairs,
+      preserveBaseline: true,
+    })
+    assert.equal(incremented.result.status, 0, incremented.result.stderr)
+    const incrementedArtifact = readFileSync(join(output, 'callback-observer.txt'), 'utf8')
+    assert.match(incrementedArtifact, /callback_anchor_log_count_before=1/)
+    assert.match(incrementedArtifact, /callback_anchor_log_count_delta=1/)
+    assert.match(incrementedArtifact, /callback_handled_count_before=1/)
+    assert.match(incrementedArtifact, /callback_handled_count_delta=1/)
+
+    rmSync(output, { recursive: true, force: true })
+    const repeatedWithoutCallback = runObserveFixture(observe, support, {
+      dir,
+      expected,
+      lines: twoPairs,
+      preserveBaseline: true,
+    })
+    assert.notEqual(repeatedWithoutCallback.result.status, 0)
+    assert.match(repeatedWithoutCallback.result.stderr, /new scoped callback anchor evidence \(before=2;after=2\)/)
+
+    const thirdPair = runObserveFixture(observe, support, {
+      dir,
+      expected,
+      lines: [...twoPairs, anchor, handled],
+      preserveBaseline: true,
+    })
+    assert.equal(thirdPair.result.status, 0, thirdPair.result.stderr)
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('observer checkpoint is bound to the expected delivery hash (load-bearing)', () => {
+  const source = read(REMOTE_SH)
+  const support = observerSupport(source)
+  const observe = actionBody(source, 'action_observe', ['action_prepare'])
+  const dir = mkdtempSync(join(tmpdir(), 'stream-observer-delivery-binding-'))
+  const expected = '12345678-1234-4123-8123-123456789abc'
+  const other = '87654321-4321-4123-8123-cba987654321'
+  const lines = [
+    `info: DingTalk interactive-card callback corp anchor {"deliveryId":"${expected}","headerEventCorpIdPresent":true,"bodyCorpIdPresent":false}`,
+    `info: DingTalk interactive-card callback handled (executed delivery=${expected})`,
+  ]
+  try {
+    writeObserverBaseline(dir, other, 0, 0)
+    const original = runObserveFixture(observe, support, {
+      dir,
+      expected,
+      lines,
+      preserveBaseline: true,
+    })
+    assert.notEqual(original.result.status, 0)
+    assert.match(original.result.stderr, /valid same-delivery checkpoint/)
+
+    const mutatedSupport = support.replace(
+      '  [[ "$delivery_hash" == "$expected_hash" ]] || return 1',
+      '  : # mutation: accept a checkpoint belonging to another delivery',
+    )
+    assert.notEqual(mutatedSupport, support)
+    const mutated = runObserveFixture(observe, mutatedSupport, {
+      dir,
+      expected,
+      lines,
+      preserveBaseline: true,
+    })
+    assert.equal(mutated.result.status, 0, mutated.result.stderr)
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
 test('observe fails closed for missing scoped evidence and an unknown outcome', () => {
   const source = read(REMOTE_SH)
+  const support = observerSupport(source)
   const observe = actionBody(source, 'action_observe', ['action_prepare'])
   const dir = mkdtempSync(join(tmpdir(), 'stream-observer-negative-'))
   const expected = '12345678-1234-4123-8123-123456789abc'
@@ -583,12 +789,12 @@ test('observe fails closed for missing scoped evidence and an unknown outcome', 
       {
         name: 'anchor_count=0',
         lines: [`info: DingTalk interactive-card callback handled (executed delivery=${expected})`],
-        reason: /callback_anchor_log_count=0/,
+        reason: /new scoped callback anchor evidence \(before=0;after=0\)/,
       },
       {
         name: 'handled_count=0',
         lines: [anchor],
-        reason: /callback_handled_count=0/,
+        reason: /new scoped callback handled evidence \(before=0;after=0\)/,
       },
       {
         name: 'outcome outside closed set',
@@ -596,7 +802,7 @@ test('observe fails closed for missing scoped evidence and an unknown outcome', 
         reason: /outside closed set/,
       },
     ]) {
-      const { output, result } = runObserveFixture(observe, { dir, expected, lines })
+      const { output, result } = runObserveFixture(observe, support, { dir, expected, lines })
       assert.notEqual(result.status, 0, `${name} must fail`)
       assert.match(result.stderr, reason)
       assert.doesNotMatch(result.stderr, new RegExp(expected))
@@ -609,6 +815,7 @@ test('observe fails closed for missing scoped evidence and an unknown outcome', 
 
 test('observe evidence and outcome guards are mutation-killed', () => {
   const source = read(REMOTE_SH)
+  const support = observerSupport(source)
   const observe = actionBody(source, 'action_observe', ['action_prepare'])
   const expected = '12345678-1234-4123-8123-123456789abc'
   const anchor = `info: DingTalk interactive-card callback corp anchor {"deliveryId":"${expected}","headerEventCorpIdPresent":true,"bodyCorpIdPresent":false}`
@@ -616,12 +823,12 @@ test('observe evidence and outcome guards are mutation-killed', () => {
     {
       name: 'remove anchor_count guard',
       lines: [`info: DingTalk interactive-card callback handled (executed delivery=${expected})`],
-      mutate: (body) => removeObserveGuard(body, '$anchor_count'),
+      mutate: (body) => removeObserveGuard(body, '"$anchor_count" -gt "$baseline_anchor_count"'),
     },
     {
       name: 'remove handled_count guard',
       lines: [anchor],
-      mutate: (body) => removeObserveGuard(body, '$handled_count'),
+      mutate: (body) => removeObserveGuard(body, '"$handled_count" -gt "$baseline_handled_count"'),
     },
     {
       name: 'restore open outcome fallback',
@@ -631,16 +838,38 @@ test('observe evidence and outcome guards are mutation-killed', () => {
         '      *) handled_outcome="executed" ;;',
       ),
     },
+    {
+      name: 'remove both per-click increment guards',
+      lines: [anchor, `info: DingTalk interactive-card callback handled (executed delivery=${expected})`],
+      baselineAnchor: 1,
+      baselineHandled: 1,
+      mutate: (body) => removeObserveGuard(
+        removeObserveGuard(body, '"$anchor_count" -gt "$baseline_anchor_count"'),
+        '"$handled_count" -gt "$baseline_handled_count"',
+      ),
+    },
   ]
 
-  for (const { name, lines, mutate } of mutations) {
+  for (const { name, lines, baselineAnchor = 0, baselineHandled = 0, mutate } of mutations) {
     const dir = mkdtempSync(join(tmpdir(), 'stream-observer-mutation-'))
     try {
-      const original = runObserveFixture(observe, { dir, expected, lines })
+      const original = runObserveFixture(observe, support, {
+        dir,
+        expected,
+        lines,
+        baselineAnchor,
+        baselineHandled,
+      })
       assert.notEqual(original.result.status, 0, `${name}: original must fail`)
       const mutatedObserve = mutate(observe)
       assert.notEqual(mutatedObserve, observe, `${name}: mutation must change the body`)
-      const mutated = runObserveFixture(mutatedObserve, { dir, expected, lines })
+      const mutated = runObserveFixture(mutatedObserve, support, {
+        dir,
+        expected,
+        lines,
+        baselineAnchor,
+        baselineHandled,
+      })
       assert.equal(mutated.result.status, 0, `${name}: mutation must be caught by the test fixture`)
     } finally {
       rmSync(dir, { recursive: true, force: true })
@@ -1268,7 +1497,7 @@ test('status artifacts emit only booleans/counts/reason classes/sha schema keys'
 
 test('status action is read-only: no env writes, no flag flips, no compose up', () => {
   const source = read(REMOTE_SH)
-  const status = actionBody(source, 'action_status', ['action_observe'])
+  const status = actionBody(source, 'action_status', ['observer_delivery_hash'])
   assert.match(status, /write_status_artifact/)
   assert.doesNotMatch(status, /atomic_upsert_env_keys_from_files/)
   assert.doesNotMatch(status, /atomic_set_stream_flag/)

--- a/scripts/ops/dingtalk-interactive-card-stream-staging-uat-contract.test.mjs
+++ b/scripts/ops/dingtalk-interactive-card-stream-staging-uat-contract.test.mjs
@@ -2,7 +2,7 @@
 // dingtalk-interactive-card-stream-staging-uat-contract.test.mjs
 //
 // Durable synthetic contract for the MINIMAL controlled Stream staging UAT lane:
-//   EXECUTABLE: status | observe-baseline | observe | prepare | on | off | https-on | https-off
+//   EXECUTABLE: status | observe | prepare | on | off | https-on | https-off
 //
 // Load-bearing rails:
 //   * workflow wiring (dispatch choices, SSH, concurrency, no schedule)
@@ -20,8 +20,7 @@
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
 import { spawnSync } from 'node:child_process'
-import { createHash } from 'node:crypto'
-import { existsSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { createRequire } from 'node:module'
@@ -112,46 +111,38 @@ function actionBody(source, name, nextNames = []) {
   return source.slice(start, end)
 }
 
-function observerSupport(source) {
-  return actionBody(source, 'observer_delivery_hash', ['action_observe_baseline'])
-}
-
-function writeObserverBaseline(dir, expected, anchorCount, handledCount) {
-  const deliveryHash = createHash('sha256').update(expected).digest('hex')
-  writeFileSync(
-    join(dir, 'callback-observer-baseline'),
-    [
-      'schema=dingtalk-interactive-card-stream-callback-baseline-v1',
-      `delivery_id_sha256=${deliveryHash}`,
-      `callback_anchor_log_count=${anchorCount}`,
-      `callback_handled_count=${handledCount}`,
-      '',
-    ].join('\n'),
-    { mode: 0o600 },
-  )
-}
-
-function runObserveFixture(observe, support, {
+function runObserveFixture(observe, {
   dir,
   expected,
-  lines,
-  baselineAnchor = 0,
-  baselineHandled = 0,
-  preserveBaseline = false,
+  windowLines = [],
+  historicalLines = [],
+  injectAfterArm = true,
+  containerChanges = false,
+  delayedLines = [],
 }) {
   const output = join(dir, 'output')
-  const logs = join(dir, 'backend.log')
+  const historicalLogs = join(dir, 'historical.log')
+  const windowLogs = join(dir, 'window.log')
+  const inspectCount = join(dir, 'inspect-count')
+  const logsCount = join(dir, 'logs-count')
   const harness = join(dir, 'harness.sh')
-  writeFileSync(logs, `${lines.join('\n')}\n`)
-  if (!preserveBaseline) {
-    writeObserverBaseline(dir, expected, baselineAnchor, baselineHandled)
-  }
+  writeFileSync(historicalLogs, historicalLines.length > 0 ? `${historicalLines.join('\n')}\n` : '')
+  writeFileSync(windowLogs, '')
+  writeFileSync(inspectCount, '0')
+  writeFileSync(logsCount, '0')
+  const testObserve = observe
+    .replace('for attempt in $(seq 1 300); do', 'for attempt in $(seq 1 2); do')
+    .replace('    sleep 1', '    sleep 0.05')
   writeFileSync(
     harness,
     [
       '#!/usr/bin/env bash',
       'set -euo pipefail',
-      'log() { :; }',
+      'log() {',
+      '  if [[ "$*" == observer_armed=true* && "$INJECT_AFTER_ARM" == "true" ]]; then',
+      '    printf "%s\\n" "$INJECT_LINES" >> "$WINDOW_LOG_FIXTURE"',
+      '  fi',
+      '}',
       'fail() { echo "$*" >&2; exit 1; }',
       'assert_staging_only() { :; }',
       'require_exact_deployed_sha() { :; }',
@@ -159,13 +150,33 @@ function runObserveFixture(observe, support, {
       'require_log_level_info_or_debug() { :; }',
       'register_ephemeral() { :; }',
       'read_flag_from_container() { printf true; }',
-      'docker() { [[ "$1" == "logs" ]] || return 1; cat "$LOG_FIXTURE"; }',
+      'docker() {',
+      '  if [[ "$1" == "inspect" ]]; then',
+      '    local count',
+      '    count="$(cat "$INSPECT_COUNT_FILE")"',
+      '    count=$((count + 1))',
+      '    printf "%s" "$count" > "$INSPECT_COUNT_FILE"',
+      '    if [[ "$MOCK_CONTAINER_CHANGES" == "true" && "$count" -gt 1 ]]; then printf "%064d" 0 | tr 0 b; else printf "%064d" 0 | tr 0 a; fi',
+      '    return 0',
+      '  fi',
+      '  [[ "$1" == "logs" ]] || return 1',
+      '  local logs_count',
+      '  logs_count="$(cat "$LOGS_COUNT_FILE")"',
+      '  logs_count=$((logs_count + 1))',
+      '  printf "%s" "$logs_count" > "$LOGS_COUNT_FILE"',
+      '  if [[ "$logs_count" == "2" && -n "$DELAYED_LINES" ]]; then',
+      '    printf "%s\\n" "$DELAYED_LINES" >> "$WINDOW_LOG_FIXTURE"',
+      '  fi',
+      '  if [[ " $* " == *" --since "* ]]; then',
+      '    cat "$WINDOW_LOG_FIXTURE"',
+      '  else',
+      '    cat "$HISTORICAL_LOG_FIXTURE" "$WINDOW_LOG_FIXTURE"',
+      '  fi',
+      '}',
       'BACKEND_CONTAINER=metasheet-staging-backend',
       'FLAG_STREAM=DINGTALK_INTERACTIVE_CARD_STREAM_ENABLED',
-      'OBSERVE_BASELINE_FILE="$STREAM_UAT_PERSIST_DIR/callback-observer-baseline"',
       'mkdir -p "$STREAM_UAT_PERSIST_DIR" "$OUTPUT_DIR"',
-      support,
-      observe,
+      testObserve,
       'action_observe',
     ].join('\n'),
   )
@@ -174,21 +185,19 @@ function runObserveFixture(observe, support, {
     env: {
       ...process.env,
       EXPECTED_DELIVERY_ID: expected,
-      LOG_FIXTURE: logs,
+      HISTORICAL_LOG_FIXTURE: historicalLogs,
+      WINDOW_LOG_FIXTURE: windowLogs,
+      INSPECT_COUNT_FILE: inspectCount,
+      LOGS_COUNT_FILE: logsCount,
+      INJECT_AFTER_ARM: String(injectAfterArm),
+      INJECT_LINES: windowLines.join('\n'),
+      MOCK_CONTAINER_CHANGES: String(containerChanges),
+      DELAYED_LINES: delayedLines.join('\n'),
       OUTPUT_DIR: output,
       STREAM_UAT_PERSIST_DIR: dir,
     },
   })
   return { output, result }
-}
-
-function removeObserveGuard(observe, condition) {
-  const start = observe.indexOf(`  [[ ${condition} ]] ` + '\\')
-  assert.notEqual(start, -1, `${condition} guard must exist for mutation test`)
-  const firstEnd = observe.indexOf('\n', start)
-  const secondEnd = observe.indexOf('\n', firstEnd + 1)
-  assert.notEqual(secondEnd, -1, `${condition} guard must have a failure line`)
-  return observe.slice(0, start) + observe.slice(secondEnd + 1)
 }
 
 // --- parse / presence -----------------------------------------------------------------
@@ -215,11 +224,11 @@ test('workflow YAML parses with repository-available parser', () => {
 test('workflow action choices include observer and reversible HTTPS gateway actions', () => {
   const doc = loadYaml(read(WORKFLOW))
   const inputs = workflowOn(doc).workflow_dispatch.inputs
-  assert.deepEqual(inputs.action.options, ['status', 'observe-baseline', 'observe', 'prepare', 'on', 'off', 'https-on', 'https-off'])
+  assert.deepEqual(inputs.action.options, ['status', 'observe', 'prepare', 'on', 'off', 'https-on', 'https-off'])
   assert.equal(inputs.action.default, 'status')
   // Quote on/off so YAML 1.1 keeps strings (loadYaml may coerce bare on/off).
   const yaml = read(WORKFLOW)
-  assert.match(yaml, /options:\s*\[status,\s*observe-baseline,\s*observe,\s*prepare,\s*'on',\s*'off',\s*https-on,\s*https-off\]/)
+  assert.match(yaml, /options:\s*\[status,\s*observe,\s*prepare,\s*'on',\s*'off',\s*https-on,\s*https-off\]/)
   assert.ok(
     inputs.action.options.every((o) => typeof o === 'string'),
     'on/off must remain strings after parse',
@@ -309,11 +318,12 @@ test('U11-a distinguishes an absent corp anchor from a real corp mismatch', () =
   assert.doesNotMatch(u11a, /corp_mismatch.*根本不带/)
 })
 
-test('U4-U8 require a same-delivery baseline before each human callback', () => {
+test('U4-U7 require a fresh armed observer window; U8 uses web evidence', () => {
   const checklist = read(UAT_CHECKLIST)
-  assert.match(checklist, /先对该 delivery 运行 `observe-baseline`/)
-  assert.match(checklist, /不得拿 U4 留下的历史日志作为 U5 的证据/)
-  assert.match(checklist, /本轮无增量都必须判失败/)
+  assert.match(checklist, /看到\s*`observer_armed=true` 后立即执行/)
+  assert.match(checklist, /等待完整五分钟观察窗结束/)
+  assert.match(checklist, /不得拿 U4 的历史日志证明 U5/)
+  assert.match(checklist, /U8 是网页深链，不产生 Stream callback/)
 })
 
 // --- exact-SHA gate -------------------------------------------------------------------
@@ -336,27 +346,25 @@ test('workflow exact-SHA gate requires full 40-char deploy_sha for every non-sta
   )
 })
 
-test('observe-baseline and observe exclusively require a lowercase delivery UUID and never emit it', () => {
+test('observe exclusively requires a lowercase expected delivery UUID and never emits it', () => {
   const yaml = read(WORKFLOW)
   const doc = loadYaml(yaml)
   const validate = doc.jobs.run.steps.find((s) => s.name === 'Validate inputs and embedded scripts')
   assert.equal(validate.env.EXPECTED_DELIVERY_ID, '${{ inputs.expected_delivery_id }}')
-  assert.match(validate.run, /\$ACTION" == "observe" \|\| "\$ACTION" == "observe-baseline"/)
-  assert.match(validate.run, /expected_delivery_id is accepted only for action=observe-baseline\/observe/)
+  assert.match(validate.run, /observe requires expected_delivery_id as a lowercase UUID/)
+  assert.match(validate.run, /expected_delivery_id is accepted only for action=observe/)
   assert.match(validate.run, /\[1-5\]\[0-9a-f\]\{3\}/)
   const remoteStep = doc.jobs.run.steps.find((s) => s.name === 'Run remote action')
   assert.equal(remoteStep.env.EXPECTED_DELIVERY_ID, '${{ inputs.expected_delivery_id }}')
   assert.match(remoteStep.run, /refusing invalid expected_delivery_id in remote execution step/)
-  assert.match(remoteStep.run, /refusing expected_delivery_id outside action=observe-baseline\/observe/)
-  assert.match(remoteStep.run, /case "\$ACTION" in status\|observe-baseline\|observe\|prepare\|on\|off\|https-on\|https-off/)
+  assert.match(remoteStep.run, /refusing expected_delivery_id outside action=observe/)
+  assert.match(remoteStep.run, /case "\$ACTION" in status\|observe\|prepare\|on\|off\|https-on\|https-off/)
   assert.match(remoteStep.run, /refusing invalid deploy_sha in remote execution step/)
   assert.match(remoteStep.run, /refusing invalid optional deploy_sha in remote execution step/)
   const source = read(REMOTE_SH)
-  const support = observerSupport(source)
-  const baseline = actionBody(source, 'action_observe_baseline', ['action_observe'])
   const observe = actionBody(source, 'action_observe', ['action_prepare'])
-  assert.match(support, /grep -F -c "\$EXPECTED_DELIVERY_ID"/)
-  assert.doesNotMatch(`${support}\n${baseline}\n${observe}`, /echo .*EXPECTED_DELIVERY_ID/)
+  assert.match(observe, /grep -F -c "\$EXPECTED_DELIVERY_ID"/)
+  assert.doesNotMatch(observe, /echo .*EXPECTED_DELIVERY_ID/)
 })
 
 test('workflow and remote preflights reject cross-action delivery-id injection before SSH construction', () => {
@@ -402,9 +410,9 @@ test('workflow and remote preflights reject cross-action delivery-id injection b
     },
   )
 
-  for (const action of ['status', 'observe-baseline', 'observe', 'prepare', 'on', 'off', 'https-on', 'https-off']) {
+  for (const action of ['status', 'observe', 'prepare', 'on', 'off', 'https-on', 'https-off']) {
     const deploySha = action === 'status' ? '' : sha
-    const expectedDeliveryId = action === 'observe' || action === 'observe-baseline' ? deliveryId : ''
+    const expectedDeliveryId = action === 'observe' ? deliveryId : ''
     assert.equal(runValidate(action, deploySha, expectedDeliveryId).status, 0, `validate ${action}`)
     assert.equal(runRemotePreflight(action, deploySha, expectedDeliveryId).status, 0, `remote ${action}`)
   }
@@ -415,8 +423,6 @@ test('workflow and remote preflights reject cross-action delivery-id injection b
   }
   assert.equal(runValidate('observe', sha, '').status, 2)
   assert.equal(runRemotePreflight('observe', sha, '').status, 2)
-  assert.equal(runValidate('observe-baseline', sha, '').status, 2)
-  assert.equal(runRemotePreflight('observe-baseline', sha, '').status, 2)
   assert.equal(runValidate('observe', sha, "'; touch /tmp/stream-uat-injection; #").status, 2)
   assert.equal(runRemotePreflight('observe', sha, "'; touch /tmp/stream-uat-injection; #").status, 2)
   assert.equal(runValidate('status', "'; touch /tmp/stream-uat-injection; #", '').status, 2)
@@ -428,15 +434,13 @@ test('remote script require_exact_deployed_sha used by every non-status action a
   const source = read(REMOTE_SH)
   assert.match(source, /require_exact_deployed_sha/)
   assert.match(source, /resolve_deployed_sha/)
-  const baseline = actionBody(source, 'action_observe_baseline', ['action_observe'])
   const observe = actionBody(source, 'action_observe', ['action_prepare'])
   const prepare = actionBody(source, 'action_prepare', ['action_on'])
   const on = actionBody(source, 'action_on', ['action_off'])
   const off = actionBody(source, 'action_off', ['action_https_on'])
   const httpsOn = actionBody(source, 'action_https_on', ['action_https_off'])
   const httpsOff = actionBody(source, 'action_https_off')
-  const status = actionBody(source, 'action_status', ['observer_delivery_hash'])
-  assert.match(baseline, /require_exact_deployed_sha "observe-baseline"/)
+  const status = actionBody(source, 'action_status', ['action_observe'])
   assert.match(observe, /require_exact_deployed_sha "observe"/)
   assert.match(prepare, /require_exact_deployed_sha/)
   assert.match(on, /require_exact_deployed_sha/)
@@ -446,115 +450,54 @@ test('remote script require_exact_deployed_sha used by every non-status action a
   assert.doesNotMatch(status, /require_exact_deployed_sha/)
 })
 
-test('observer mutates only its local checkpoint and emits values-free callback classes', () => {
+test('observe opens one fresh log window and emits only values-free callback classes', () => {
   const source = read(REMOTE_SH)
-  const support = observerSupport(source)
-  const baseline = actionBody(source, 'action_observe_baseline', ['action_observe'])
   const observe = actionBody(source, 'action_observe', ['action_prepare'])
-  assert.match(baseline, /reason=baseline_captured/)
-  assert.match(baseline, /write_observer_baseline_state/)
   assert.match(observe, /action=observe/)
   assert.match(observe, /require_lifecycle_flags_off "observe"/)
   assert.match(observe, /require_log_level_info_or_debug "observe"/)
+  assert.match(observe, /observer_armed=true/)
+  assert.doesNotMatch(observe, /evidence_count.*&& break/)
+  assert.match(observe, /docker logs --since "\$window_started"/)
+  assert.match(observe, /docker inspect --format '\{\{\.Id\}\}'/)
+  assert.match(observe, /callback_evidence_count=1/)
   assert.match(observe, /header_event_corp_id_present=/)
   assert.match(observe, /body_corp_id_present=/)
+  assert.match(observe, /corp_gate_result=/)
   assert.match(observe, /latest_callback_outcome=/)
   assert.match(observe, /window_callback_handler_error_count=/)
   assert.match(observe, /card_update_failed_count=/)
-  assert.match(observe, /callback_anchor_log_count=\$\{anchor_count\}/)
-  assert.match(observe, /callback_anchor_log_count_before=\$\{baseline_anchor_count\}/)
-  assert.match(observe, /callback_anchor_log_count_delta=\$\{anchor_delta\}/)
-  assert.match(observe, /callback_handled_count=\$\{handled_count\}/)
-  assert.match(observe, /callback_handled_count_before=\$\{baseline_handled_count\}/)
-  assert.match(observe, /callback_handled_count_delta=\$\{handled_delta\}/)
-  assert.match(observe, /run observe-baseline immediately before the human click/)
-  assert.match(support, /delivery_id_sha256=/)
-  assert.match(observe, /outside closed set/)
-  assert.doesNotMatch(observe, /handled_outcome="(?:other|unknown)"/)
-  for (const outcome of [
-    'ignored_unsupported_action',
-    'delivery_not_found',
-    'executed',
-    'stale',
-    'operator_unresolved',
-    'link_secret_unavailable',
-    'engine_rejected',
-    'wrapper_not_found',
-  ]) {
-    assert.match(observe, new RegExp(`handled_outcome="${outcome}"`))
-  }
-  // A parse-time rejection has no delivery id and cannot be claimed as scoped
-  // evidence for EXPECTED_DELIVERY_ID. The two out_track_id outcomes above do.
-  assert.doesNotMatch(observe, /handled_outcome="rejected"/)
-  assert.doesNotMatch(observe, /handled_outcome="(?:accepted|duplicate)"/)
+  assert.match(observe, /outside the closed set/)
+  assert.doesNotMatch(observe, /callback_outcome="(?:other|unknown|rejected|ignored_unsupported_action|delivery_not_found)"/)
   assert.doesNotMatch(observe, /echo "callback_handler_error_count=/)
-  assert.doesNotMatch(observe, /cat "\$tmp"|echo "\$anchor_line"|deliveryId=/)
-  assert.doesNotMatch(`${baseline}\n${observe}`, /atomic_(?:set|upsert)_env|recreate_backend_only|compose_staging_cmd up/)
+  assert.doesNotMatch(observe, /cat "\$tmp"|echo "\$evidence_line"|deliveryId=/)
+  assert.doesNotMatch(observe, /atomic_(?:set|upsert)|recreate_backend_only|compose_staging_cmd up/)
+  assert.doesNotMatch(source, /callback-observer-baseline|observe-baseline/)
 })
 
-test('observe dynamically scopes Winston log evidence to the expected delivery', () => {
+test('observe accepts one atomic same-delivery completion emitted after the window is armed', () => {
   const source = read(REMOTE_SH)
-  const support = observerSupport(source)
   const observe = actionBody(source, 'action_observe', ['action_prepare'])
   const dir = mkdtempSync(join(tmpdir(), 'stream-observer-'))
-  const output = join(dir, 'output')
-  const logs = join(dir, 'backend.log')
-  const harness = join(dir, 'harness.sh')
   const expected = '12345678-1234-4123-8123-123456789abc'
   const other = '87654321-4321-4123-8123-cba987654321'
   try {
-    writeFileSync(
-      logs,
-      [
-        `info: DingTalk interactive-card callback corp anchor {"deliveryId":"${other}","headerEventCorpIdPresent":false,"bodyCorpIdPresent":true}`,
-        `info: DingTalk interactive-card callback handled (stale delivery=${other})`,
-        `info: DingTalk interactive-card callback corp anchor {"deliveryId":"${expected}","headerEventCorpIdPresent":true,"bodyCorpIdPresent":false}`,
-        `info: DingTalk interactive-card callback handled (operator_unresolved:missing_link delivery=${expected})`,
-        `info: DingTalk interactive-card callback handled (executed delivery=${expected})`,
+    const { output, result } = runObserveFixture(observe, {
+      dir,
+      expected,
+      windowLines: [
+        `info: DingTalk interactive-card callback completed evidence {"deliveryId":"${other}","headerEventCorpIdPresent":false,"bodyCorpIdPresent":true,"corpGateResult":"matched","callbackOutcome":"stale"}`,
         'warn: DingTalk interactive-card callback failed (callback_handler_error)',
         `warn: DingTalk approval-card terminal update failed (card_update_failed:Error) delivery=${expected}`,
-      ].join('\n') + '\n',
-    )
-    writeFileSync(
-      harness,
-      [
-        '#!/usr/bin/env bash',
-        'set -euo pipefail',
-        'log() { :; }',
-        'fail() { echo "$*" >&2; exit 1; }',
-        'assert_staging_only() { :; }',
-        'require_exact_deployed_sha() { :; }',
-        'require_lifecycle_flags_off() { :; }',
-        'require_log_level_info_or_debug() { :; }',
-        'register_ephemeral() { :; }',
-        'read_flag_from_container() { printf true; }',
-        'docker() { [[ "$1" == "logs" ]] || return 1; cat "$LOG_FIXTURE"; }',
-        'BACKEND_CONTAINER=metasheet-staging-backend',
-        'FLAG_STREAM=DINGTALK_INTERACTIVE_CARD_STREAM_ENABLED',
-        'OBSERVE_BASELINE_FILE="$STREAM_UAT_PERSIST_DIR/callback-observer-baseline"',
-        'mkdir -p "$STREAM_UAT_PERSIST_DIR" "$OUTPUT_DIR"',
-        support,
-        observe,
-        'action_observe',
-      ].join('\n'),
-    )
-    writeObserverBaseline(dir, expected, 0, 0)
-    const result = spawnSync('bash', [harness], {
-      encoding: 'utf8',
-      env: {
-        ...process.env,
-        EXPECTED_DELIVERY_ID: expected,
-        LOG_FIXTURE: logs,
-        OUTPUT_DIR: output,
-        STREAM_UAT_PERSIST_DIR: dir,
-      },
+        `info: DingTalk interactive-card callback completed evidence {"deliveryId":"${expected}","headerEventCorpIdPresent":true,"bodyCorpIdPresent":false,"corpGateResult":"matched","callbackOutcome":"executed"}`,
+      ],
     })
     assert.equal(result.status, 0, result.stderr)
     const artifact = readFileSync(join(output, 'callback-observer.txt'), 'utf8')
-    assert.match(artifact, /callback_anchor_log_count=1/)
+    assert.match(artifact, /callback_evidence_count=1/)
     assert.match(artifact, /header_event_corp_id_present=true/)
     assert.match(artifact, /body_corp_id_present=false/)
-    assert.match(artifact, /callback_handled_count=2/)
+    assert.match(artifact, /corp_gate_result=matched/)
     assert.match(artifact, /latest_callback_outcome=executed/)
     assert.match(artifact, /window_callback_handler_error_count=1/)
     assert.match(artifact, /card_update_failed_count=1/)
@@ -564,315 +507,168 @@ test('observe dynamically scopes Winston log evidence to the expected delivery',
   }
 })
 
-test('observe precisely classifies scoped out_track_id terminal outcomes', () => {
+test('observe classifies the closed corp-gate and callback-outcome matrices', () => {
   const source = read(REMOTE_SH)
-  const support = observerSupport(source)
   const observe = actionBody(source, 'action_observe', ['action_prepare'])
-  const dir = mkdtempSync(join(tmpdir(), 'stream-observer-out-track-'))
-  const output = join(dir, 'output')
-  const logs = join(dir, 'backend.log')
-  const harness = join(dir, 'harness.sh')
   const expected = '12345678-1234-4123-8123-123456789abc'
-  try {
-    writeFileSync(
-      harness,
-      [
-        '#!/usr/bin/env bash',
-        'set -euo pipefail',
-        'log() { :; }',
-        'fail() { echo "$*" >&2; exit 1; }',
-        'assert_staging_only() { :; }',
-        'require_exact_deployed_sha() { :; }',
-        'require_lifecycle_flags_off() { :; }',
-        'require_log_level_info_or_debug() { :; }',
-        'register_ephemeral() { :; }',
-        'read_flag_from_container() { printf true; }',
-        'docker() { [[ "$1" == "logs" ]] || return 1; cat "$LOG_FIXTURE"; }',
-        'BACKEND_CONTAINER=metasheet-staging-backend',
-        'FLAG_STREAM=DINGTALK_INTERACTIVE_CARD_STREAM_ENABLED',
-        'OBSERVE_BASELINE_FILE="$STREAM_UAT_PERSIST_DIR/callback-observer-baseline"',
-        'mkdir -p "$STREAM_UAT_PERSIST_DIR" "$OUTPUT_DIR"',
-        support,
-        observe,
-        'action_observe',
-      ].join('\n'),
-    )
-    for (const [line, expectedOutcome] of [
-      [
-        `info: DingTalk interactive-card callback handled (ignored_unsupported_action out_track_id=${expected})`,
-        'ignored_unsupported_action',
-      ],
-      [
-        `info: DingTalk interactive-card callback handled (delivery_not_found out_track_id=${expected})`,
-        'delivery_not_found',
-      ],
-    ]) {
-      writeFileSync(
-        logs,
-        [
-          `info: DingTalk interactive-card callback corp anchor {"deliveryId":"${expected}","headerEventCorpIdPresent":true,"bodyCorpIdPresent":false}`,
-          line,
-        ].join('\n') + '\n',
-      )
-      writeObserverBaseline(dir, expected, 0, 0)
-      const result = spawnSync('bash', [harness], {
-        encoding: 'utf8',
-        env: {
-          ...process.env,
-          EXPECTED_DELIVERY_ID: expected,
-          LOG_FIXTURE: logs,
-          OUTPUT_DIR: output,
-          STREAM_UAT_PERSIST_DIR: dir,
-        },
-      })
+  for (const [corpGate, outcome] of [
+    ['matched', 'stale'],
+    ['corp_anchor_absent', 'operator_unresolved'],
+    ['corp_anchor_conflict', 'operator_unresolved'],
+    ['delivery_corp_unresolved', 'operator_unresolved'],
+    ['corp_mismatch', 'operator_unresolved'],
+    ['matched', 'link_secret_unavailable'],
+    ['matched', 'engine_rejected'],
+    ['matched', 'wrapper_not_found'],
+  ]) {
+    const dir = mkdtempSync(join(tmpdir(), 'stream-observer-matrix-'))
+    try {
+      const line = `info: DingTalk interactive-card callback completed evidence {"deliveryId":"${expected}","headerEventCorpIdPresent":false,"bodyCorpIdPresent":true,"corpGateResult":"${corpGate}","callbackOutcome":"${outcome}"}`
+      const { output, result } = runObserveFixture(observe, { dir, expected, windowLines: [line] })
       assert.equal(result.status, 0, result.stderr)
       const artifact = readFileSync(join(output, 'callback-observer.txt'), 'utf8')
-      assert.match(artifact, new RegExp(`latest_callback_outcome=${expectedOutcome}`))
+      assert.match(artifact, new RegExp(`corp_gate_result=${corpGate}`))
+      assert.match(artifact, new RegExp(`latest_callback_outcome=${outcome}`))
       assert.doesNotMatch(artifact, new RegExp(expected))
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
     }
-  } finally {
-    rmSync(dir, { recursive: true, force: true })
   }
 })
 
-test('observer checkpoint rejects historical evidence and advances only after new callback pairs', () => {
+test('observe ignores historical evidence; removing --since makes the fixture false-green', () => {
   const source = read(REMOTE_SH)
-  const support = observerSupport(source)
-  const baseline = actionBody(source, 'action_observe_baseline', ['action_observe'])
   const observe = actionBody(source, 'action_observe', ['action_prepare'])
-  const dir = mkdtempSync(join(tmpdir(), 'stream-observer-baseline-'))
-  const output = join(dir, 'output')
-  const logs = join(dir, 'backend.log')
-  const harness = join(dir, 'baseline-harness.sh')
   const expected = '12345678-1234-4123-8123-123456789abc'
-  const anchor = `info: DingTalk interactive-card callback corp anchor {"deliveryId":"${expected}","headerEventCorpIdPresent":true,"bodyCorpIdPresent":false}`
-  const handled = `info: DingTalk interactive-card callback handled (executed delivery=${expected})`
-  const firstPair = [anchor, handled]
+  const historical = `info: DingTalk interactive-card callback completed evidence {"deliveryId":"${expected}","headerEventCorpIdPresent":true,"bodyCorpIdPresent":false,"corpGateResult":"matched","callbackOutcome":"executed"}`
+  const originalDir = mkdtempSync(join(tmpdir(), 'stream-observer-history-original-'))
+  const mutatedDir = mkdtempSync(join(tmpdir(), 'stream-observer-history-mutated-'))
   try {
-    writeFileSync(logs, `${firstPair.join('\n')}\n`)
-    writeFileSync(
-      harness,
-      [
-        '#!/usr/bin/env bash',
-        'set -euo pipefail',
-        'log() { :; }',
-        'fail() { echo "$*" >&2; exit 1; }',
-        'assert_staging_only() { :; }',
-        'require_exact_deployed_sha() { :; }',
-        'require_lifecycle_flags_off() { :; }',
-        'require_log_level_info_or_debug() { :; }',
-        'register_ephemeral() { :; }',
-        'read_flag_from_container() { printf true; }',
-        'docker() { [[ "$1" == "logs" ]] || return 1; cat "$LOG_FIXTURE"; }',
-        'BACKEND_CONTAINER=metasheet-staging-backend',
-        'FLAG_STREAM=DINGTALK_INTERACTIVE_CARD_STREAM_ENABLED',
-        'OBSERVE_BASELINE_FILE="$STREAM_UAT_PERSIST_DIR/callback-observer-baseline"',
-        'mkdir -p "$STREAM_UAT_PERSIST_DIR" "$OUTPUT_DIR"',
-        support,
-        baseline,
-        'action_observe_baseline',
-      ].join('\n'),
-    )
-    const baselineResult = spawnSync('bash', [harness], {
-      encoding: 'utf8',
-      env: {
-        ...process.env,
-        EXPECTED_DELIVERY_ID: expected,
-        LOG_FIXTURE: logs,
-        OUTPUT_DIR: output,
-        STREAM_UAT_PERSIST_DIR: dir,
-      },
-    })
-    assert.equal(baselineResult.status, 0, baselineResult.stderr)
-    const baselineArtifact = readFileSync(join(output, 'callback-observer.txt'), 'utf8')
-    assert.match(baselineArtifact, /reason=baseline_captured/)
-    assert.match(baselineArtifact, /callback_anchor_log_count=1/)
-    assert.match(baselineArtifact, /callback_handled_count=1/)
-    const baselinePath = join(dir, 'callback-observer-baseline')
-    assert.equal(statSync(baselinePath).mode & 0o777, 0o600)
-    assert.doesNotMatch(readFileSync(baselinePath, 'utf8'), new RegExp(expected))
-
-    rmSync(output, { recursive: true, force: true })
-    const historical = runObserveFixture(observe, support, {
-      dir,
+    const original = runObserveFixture(observe, {
+      dir: originalDir,
       expected,
-      lines: firstPair,
-      preserveBaseline: true,
-    })
-    assert.notEqual(historical.result.status, 0)
-    assert.match(historical.result.stderr, /new scoped callback anchor evidence \(before=1;after=1\)/)
-
-    const twoPairs = [...firstPair, anchor, handled]
-    const incremented = runObserveFixture(observe, support, {
-      dir,
-      expected,
-      lines: twoPairs,
-      preserveBaseline: true,
-    })
-    assert.equal(incremented.result.status, 0, incremented.result.stderr)
-    const incrementedArtifact = readFileSync(join(output, 'callback-observer.txt'), 'utf8')
-    assert.match(incrementedArtifact, /callback_anchor_log_count_before=1/)
-    assert.match(incrementedArtifact, /callback_anchor_log_count_delta=1/)
-    assert.match(incrementedArtifact, /callback_handled_count_before=1/)
-    assert.match(incrementedArtifact, /callback_handled_count_delta=1/)
-
-    rmSync(output, { recursive: true, force: true })
-    const repeatedWithoutCallback = runObserveFixture(observe, support, {
-      dir,
-      expected,
-      lines: twoPairs,
-      preserveBaseline: true,
-    })
-    assert.notEqual(repeatedWithoutCallback.result.status, 0)
-    assert.match(repeatedWithoutCallback.result.stderr, /new scoped callback anchor evidence \(before=2;after=2\)/)
-
-    const thirdPair = runObserveFixture(observe, support, {
-      dir,
-      expected,
-      lines: [...twoPairs, anchor, handled],
-      preserveBaseline: true,
-    })
-    assert.equal(thirdPair.result.status, 0, thirdPair.result.stderr)
-  } finally {
-    rmSync(dir, { recursive: true, force: true })
-  }
-})
-
-test('observer checkpoint is bound to the expected delivery hash (load-bearing)', () => {
-  const source = read(REMOTE_SH)
-  const support = observerSupport(source)
-  const observe = actionBody(source, 'action_observe', ['action_prepare'])
-  const dir = mkdtempSync(join(tmpdir(), 'stream-observer-delivery-binding-'))
-  const expected = '12345678-1234-4123-8123-123456789abc'
-  const other = '87654321-4321-4123-8123-cba987654321'
-  const lines = [
-    `info: DingTalk interactive-card callback corp anchor {"deliveryId":"${expected}","headerEventCorpIdPresent":true,"bodyCorpIdPresent":false}`,
-    `info: DingTalk interactive-card callback handled (executed delivery=${expected})`,
-  ]
-  try {
-    writeObserverBaseline(dir, other, 0, 0)
-    const original = runObserveFixture(observe, support, {
-      dir,
-      expected,
-      lines,
-      preserveBaseline: true,
+      historicalLines: [historical],
+      injectAfterArm: false,
     })
     assert.notEqual(original.result.status, 0)
-    assert.match(original.result.stderr, /valid same-delivery checkpoint/)
+    assert.match(original.result.stderr, /timed out without one completed callback/)
 
-    const mutatedSupport = support.replace(
-      '  [[ "$delivery_hash" == "$expected_hash" ]] || return 1',
-      '  : # mutation: accept a checkpoint belonging to another delivery',
+    const mutatedObserve = observe.replace(
+      'docker logs --since "$window_started" "$BACKEND_CONTAINER"',
+      'docker logs "$BACKEND_CONTAINER"',
     )
-    assert.notEqual(mutatedSupport, support)
-    const mutated = runObserveFixture(observe, mutatedSupport, {
-      dir,
+    assert.notEqual(mutatedObserve, observe)
+    const mutated = runObserveFixture(mutatedObserve, {
+      dir: mutatedDir,
       expected,
-      lines,
-      preserveBaseline: true,
+      historicalLines: [historical],
+      injectAfterArm: false,
     })
     assert.equal(mutated.result.status, 0, mutated.result.stderr)
   } finally {
-    rmSync(dir, { recursive: true, force: true })
+    rmSync(originalDir, { recursive: true, force: true })
+    rmSync(mutatedDir, { recursive: true, force: true })
   }
 })
 
-test('observe fails closed for missing scoped evidence and an unknown outcome', () => {
+test('observe rejects split, duplicate, unknown, and container-replaced evidence', () => {
   const source = read(REMOTE_SH)
-  const support = observerSupport(source)
   const observe = actionBody(source, 'action_observe', ['action_prepare'])
-  const dir = mkdtempSync(join(tmpdir(), 'stream-observer-negative-'))
   const expected = '12345678-1234-4123-8123-123456789abc'
-  const anchor = `info: DingTalk interactive-card callback corp anchor {"deliveryId":"${expected}","headerEventCorpIdPresent":true,"bodyCorpIdPresent":false}`
-  try {
-    for (const { name, lines, reason } of [
-      {
-        name: 'anchor_count=0',
-        lines: [`info: DingTalk interactive-card callback handled (executed delivery=${expected})`],
-        reason: /new scoped callback anchor evidence \(before=0;after=0\)/,
-      },
-      {
-        name: 'handled_count=0',
-        lines: [anchor],
-        reason: /new scoped callback handled evidence \(before=0;after=0\)/,
-      },
-      {
-        name: 'outcome outside closed set',
-        lines: [anchor, `info: DingTalk interactive-card callback handled (unexpected delivery=${expected})`],
-        reason: /outside closed set/,
-      },
-    ]) {
-      const { output, result } = runObserveFixture(observe, support, { dir, expected, lines })
-      assert.notEqual(result.status, 0, `${name} must fail`)
-      assert.match(result.stderr, reason)
+  const valid = `info: DingTalk interactive-card callback completed evidence {"deliveryId":"${expected}","headerEventCorpIdPresent":true,"bodyCorpIdPresent":false,"corpGateResult":"matched","callbackOutcome":"executed"}`
+  const cases = [
+    {
+      name: 'split legacy lines',
+      lines: [
+        `info: DingTalk interactive-card callback corp anchor {"deliveryId":"${expected}","headerEventCorpIdPresent":true,"bodyCorpIdPresent":false}`,
+        `info: DingTalk interactive-card callback handled (executed delivery=${expected})`,
+      ],
+      reason: /timed out without one completed callback/,
+    },
+    { name: 'duplicate completion', lines: [valid, valid], reason: /requires exactly one completed callback/ },
+    {
+      name: 'delayed duplicate completion',
+      lines: [valid],
+      delayedLines: [valid],
+      reason: /requires exactly one completed callback/,
+    },
+    {
+      name: 'unknown outcome',
+      lines: [valid.replace('"executed"', '"unexpected"')],
+      reason: /callback outcome outside the closed set/,
+    },
+    { name: 'container replacement', lines: [valid], containerChanges: true, reason: /container changed/ },
+  ]
+  for (const entry of cases) {
+    const dir = mkdtempSync(join(tmpdir(), 'stream-observer-negative-'))
+    try {
+      const { output, result } = runObserveFixture(observe, {
+        dir,
+        expected,
+        windowLines: entry.lines,
+        delayedLines: entry.delayedLines ?? [],
+        containerChanges: entry.containerChanges ?? false,
+      })
+      assert.notEqual(result.status, 0, `${entry.name} must fail`)
+      assert.match(result.stderr, entry.reason)
       assert.doesNotMatch(result.stderr, new RegExp(expected))
       assert.equal(existsSync(join(output, 'callback-observer.txt')), false)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
     }
-  } finally {
-    rmSync(dir, { recursive: true, force: true })
   }
 })
 
-test('observe evidence and outcome guards are mutation-killed', () => {
+test('observe duplicate and outcome guards are mutation-killed', () => {
   const source = read(REMOTE_SH)
-  const support = observerSupport(source)
   const observe = actionBody(source, 'action_observe', ['action_prepare'])
   const expected = '12345678-1234-4123-8123-123456789abc'
-  const anchor = `info: DingTalk interactive-card callback corp anchor {"deliveryId":"${expected}","headerEventCorpIdPresent":true,"bodyCorpIdPresent":false}`
+  const valid = `info: DingTalk interactive-card callback completed evidence {"deliveryId":"${expected}","headerEventCorpIdPresent":true,"bodyCorpIdPresent":false,"corpGateResult":"matched","callbackOutcome":"executed"}`
   const mutations = [
     {
-      name: 'remove anchor_count guard',
-      lines: [`info: DingTalk interactive-card callback handled (executed delivery=${expected})`],
-      mutate: (body) => removeObserveGuard(body, '"$anchor_count" -gt "$baseline_anchor_count"'),
-    },
-    {
-      name: 'remove handled_count guard',
-      lines: [anchor],
-      mutate: (body) => removeObserveGuard(body, '"$handled_count" -gt "$baseline_handled_count"'),
-    },
-    {
-      name: 'restore open outcome fallback',
-      lines: [anchor, `info: DingTalk interactive-card callback handled (unexpected delivery=${expected})`],
+      name: 'restore early exit after first completion',
+      lines: [valid],
+      delayedLines: [valid],
       mutate: (body) => body.replace(
-        '      *) fail "action=observe observed callback outcome outside closed set (callback_handled_count=${handled_count})" ;;',
-        '      *) handled_outcome="executed" ;;',
+        '    sleep 1',
+        '    [[ "$evidence_count" == "1" ]] && break # mutation: miss delayed duplicate evidence\n    sleep 1',
       ),
     },
     {
-      name: 'remove both per-click increment guards',
-      lines: [anchor, `info: DingTalk interactive-card callback handled (executed delivery=${expected})`],
-      baselineAnchor: 1,
-      baselineHandled: 1,
-      mutate: (body) => removeObserveGuard(
-        removeObserveGuard(body, '"$anchor_count" -gt "$baseline_anchor_count"'),
-        '"$handled_count" -gt "$baseline_handled_count"',
+      name: 'remove duplicate guard',
+      lines: [valid, valid],
+      mutate: (body) => body.replace(
+        '    [[ "$evidence_count" -le 1 ]] \\\n      || fail "action=observe requires exactly one completed callback in the fresh window (callback_evidence_count=${evidence_count})"',
+        '    : # mutation: accept duplicate callback evidence',
+      ),
+    },
+    {
+      name: 'restore open outcome fallback',
+      lines: [valid.replace('"executed"', '"unexpected"')],
+      mutate: (body) => body.replace(
+        '  [[ -n "$callback_outcome" ]] || fail "action=observe completed evidence carried a callback outcome outside the closed set"',
+        '  callback_outcome="executed" # mutation: accept unknown outcome',
       ),
     },
   ]
 
-  for (const { name, lines, baselineAnchor = 0, baselineHandled = 0, mutate } of mutations) {
-    const dir = mkdtempSync(join(tmpdir(), 'stream-observer-mutation-'))
+  for (const { name, lines, delayedLines = [], mutate } of mutations) {
+    const originalDir = mkdtempSync(join(tmpdir(), 'stream-observer-mutation-original-'))
+    const mutatedDir = mkdtempSync(join(tmpdir(), 'stream-observer-mutation-mutated-'))
     try {
-      const original = runObserveFixture(observe, support, {
-        dir,
-        expected,
-        lines,
-        baselineAnchor,
-        baselineHandled,
-      })
+      const original = runObserveFixture(observe, { dir: originalDir, expected, windowLines: lines, delayedLines })
       assert.notEqual(original.result.status, 0, `${name}: original must fail`)
       const mutatedObserve = mutate(observe)
       assert.notEqual(mutatedObserve, observe, `${name}: mutation must change the body`)
-      const mutated = runObserveFixture(mutatedObserve, support, {
-        dir,
-        expected,
-        lines,
-        baselineAnchor,
-        baselineHandled,
-      })
-      assert.equal(mutated.result.status, 0, `${name}: mutation must be caught by the test fixture`)
+      const mutated = runObserveFixture(mutatedObserve, { dir: mutatedDir, expected, windowLines: lines, delayedLines })
+      assert.equal(
+        mutated.result.status,
+        0,
+        `${name}: mutation must be caught by the test fixture\nstdout=${mutated.result.stdout}\nstderr=${mutated.result.stderr}`,
+      )
     } finally {
-      rmSync(dir, { recursive: true, force: true })
+      rmSync(originalDir, { recursive: true, force: true })
+      rmSync(mutatedDir, { recursive: true, force: true })
     }
   }
 })
@@ -1497,7 +1293,7 @@ test('status artifacts emit only booleans/counts/reason classes/sha schema keys'
 
 test('status action is read-only: no env writes, no flag flips, no compose up', () => {
   const source = read(REMOTE_SH)
-  const status = actionBody(source, 'action_status', ['observer_delivery_hash'])
+  const status = actionBody(source, 'action_status', ['action_observe'])
   assert.match(status, /write_status_artifact/)
   assert.doesNotMatch(status, /atomic_upsert_env_keys_from_files/)
   assert.doesNotMatch(status, /atomic_set_stream_flag/)

--- a/scripts/ops/dingtalk-interactive-card-stream-staging-uat-contract.test.mjs
+++ b/scripts/ops/dingtalk-interactive-card-stream-staging-uat-contract.test.mjs
@@ -35,6 +35,21 @@ const WORKFLOW = join(
   'workflows',
   'dingtalk-interactive-card-stream-staging-uat.yml',
 )
+const UAT_CHECKLIST = join(
+  REPO_ROOT,
+  'docs',
+  'development',
+  'approval-dingtalk-slice-b-uat-checklist-20260710.md',
+)
+const DINGTALK_CLIENT = join(
+  REPO_ROOT,
+  'packages',
+  'core-backend',
+  'src',
+  'integrations',
+  'dingtalk',
+  'client.ts',
+)
 const ATTENDANCE_WORKFLOW = join(
   REPO_ROOT,
   '.github',
@@ -94,6 +109,54 @@ function actionBody(source, name, nextNames = []) {
   const mainIdx = source.indexOf('\n# --- main', start + 1)
   if (mainIdx !== -1 && mainIdx < end) end = mainIdx
   return source.slice(start, end)
+}
+
+function runObserveFixture(observe, { dir, expected, lines }) {
+  const output = join(dir, 'output')
+  const logs = join(dir, 'backend.log')
+  const harness = join(dir, 'harness.sh')
+  writeFileSync(logs, `${lines.join('\n')}\n`)
+  writeFileSync(
+    harness,
+    [
+      '#!/usr/bin/env bash',
+      'set -euo pipefail',
+      'log() { :; }',
+      'fail() { echo "$*" >&2; exit 1; }',
+      'assert_staging_only() { :; }',
+      'require_exact_deployed_sha() { :; }',
+      'require_lifecycle_flags_off() { :; }',
+      'require_log_level_info_or_debug() { :; }',
+      'register_ephemeral() { :; }',
+      'read_flag_from_container() { printf true; }',
+      'docker() { [[ "$1" == "logs" ]] || return 1; cat "$LOG_FIXTURE"; }',
+      'BACKEND_CONTAINER=metasheet-staging-backend',
+      'FLAG_STREAM=DINGTALK_INTERACTIVE_CARD_STREAM_ENABLED',
+      'mkdir -p "$STREAM_UAT_PERSIST_DIR" "$OUTPUT_DIR"',
+      observe,
+      'action_observe',
+    ].join('\n'),
+  )
+  const result = spawnSync('bash', [harness], {
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      EXPECTED_DELIVERY_ID: expected,
+      LOG_FIXTURE: logs,
+      OUTPUT_DIR: output,
+      STREAM_UAT_PERSIST_DIR: dir,
+    },
+  })
+  return { output, result }
+}
+
+function removeObserveGuard(observe, condition) {
+  const start = observe.indexOf(`  [[ "${condition}" -gt 0 ]] ` + '\\')
+  assert.notEqual(start, -1, `${condition} guard must exist for mutation test`)
+  const firstEnd = observe.indexOf('\n', start)
+  const secondEnd = observe.indexOf('\n', firstEnd + 1)
+  assert.notEqual(secondEnd, -1, `${condition} guard must have a failure line`)
+  return observe.slice(0, start) + observe.slice(secondEnd + 1)
 }
 
 // --- parse / presence -----------------------------------------------------------------
@@ -192,6 +255,26 @@ test('contract suite is wired into the required Node 20 plugin-tests lane', () =
     step.run,
     /node --test scripts\/ops\/dingtalk-interactive-card-stream-staging-uat-contract\.test\.mjs/,
   )
+})
+
+test('U6 keeps card forwarding disabled and uses controlled callback injection for B', () => {
+  const checklist = read(UAT_CHECKLIST)
+  assert.match(
+    checklist,
+    /\| U6 \| 非受理人 B 的受控技术注入同意回调（不依赖卡片转发） \|[^\n]*supportForward=false/,
+  )
+  assert.doesNotMatch(checklist, /\| U6 \|[^\n]*转发的卡/)
+  assert.match(read(DINGTALK_CLIENT), /supportForward:\s*false/)
+})
+
+test('U11-a distinguishes an absent corp anchor from a real corp mismatch', () => {
+  const checklist = read(UAT_CHECKLIST)
+  const u11a = checklist.split('\n').find((line) => line.startsWith('| **U11-a**'))
+  assert.ok(u11a, 'U11-a checklist row must exist')
+  assert.match(checklist, /两者都缺 ⇒ 判 `corp_anchor_absent`/)
+  assert.match(u11a, /`corp_anchor_absent` ⇒ 真实帧缺企业锚点/)
+  assert.match(u11a, /`corp_mismatch` ⇒ 锚点存在但企业确实不一致/)
+  assert.doesNotMatch(u11a, /corp_mismatch.*根本不带/)
 })
 
 // --- exact-SHA gate -------------------------------------------------------------------
@@ -329,6 +412,10 @@ test('observe is read-only and emits values-free callback classes without raw lo
   assert.match(observe, /latest_callback_outcome=/)
   assert.match(observe, /window_callback_handler_error_count=/)
   assert.match(observe, /card_update_failed_count=/)
+  assert.match(observe, /callback_anchor_log_count=\$\{anchor_count\}/)
+  assert.match(observe, /callback_handled_count=\$\{handled_count\}/)
+  assert.match(observe, /outside closed set/)
+  assert.doesNotMatch(observe, /handled_outcome="(?:other|unknown)"/)
   for (const outcome of [
     'ignored_unsupported_action',
     'delivery_not_found',
@@ -458,7 +545,13 @@ test('observe precisely classifies scoped out_track_id terminal outcomes', () =>
         'delivery_not_found',
       ],
     ]) {
-      writeFileSync(logs, `${line}\n`)
+      writeFileSync(
+        logs,
+        [
+          `info: DingTalk interactive-card callback corp anchor {"deliveryId":"${expected}","headerEventCorpIdPresent":true,"bodyCorpIdPresent":false}`,
+          line,
+        ].join('\n') + '\n',
+      )
       const result = spawnSync('bash', [harness], {
         encoding: 'utf8',
         env: {
@@ -476,6 +569,82 @@ test('observe precisely classifies scoped out_track_id terminal outcomes', () =>
     }
   } finally {
     rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('observe fails closed for missing scoped evidence and an unknown outcome', () => {
+  const source = read(REMOTE_SH)
+  const observe = actionBody(source, 'action_observe', ['action_prepare'])
+  const dir = mkdtempSync(join(tmpdir(), 'stream-observer-negative-'))
+  const expected = '12345678-1234-4123-8123-123456789abc'
+  const anchor = `info: DingTalk interactive-card callback corp anchor {"deliveryId":"${expected}","headerEventCorpIdPresent":true,"bodyCorpIdPresent":false}`
+  try {
+    for (const { name, lines, reason } of [
+      {
+        name: 'anchor_count=0',
+        lines: [`info: DingTalk interactive-card callback handled (executed delivery=${expected})`],
+        reason: /callback_anchor_log_count=0/,
+      },
+      {
+        name: 'handled_count=0',
+        lines: [anchor],
+        reason: /callback_handled_count=0/,
+      },
+      {
+        name: 'outcome outside closed set',
+        lines: [anchor, `info: DingTalk interactive-card callback handled (unexpected delivery=${expected})`],
+        reason: /outside closed set/,
+      },
+    ]) {
+      const { output, result } = runObserveFixture(observe, { dir, expected, lines })
+      assert.notEqual(result.status, 0, `${name} must fail`)
+      assert.match(result.stderr, reason)
+      assert.doesNotMatch(result.stderr, new RegExp(expected))
+      assert.equal(existsSync(join(output, 'callback-observer.txt')), false)
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('observe evidence and outcome guards are mutation-killed', () => {
+  const source = read(REMOTE_SH)
+  const observe = actionBody(source, 'action_observe', ['action_prepare'])
+  const expected = '12345678-1234-4123-8123-123456789abc'
+  const anchor = `info: DingTalk interactive-card callback corp anchor {"deliveryId":"${expected}","headerEventCorpIdPresent":true,"bodyCorpIdPresent":false}`
+  const mutations = [
+    {
+      name: 'remove anchor_count guard',
+      lines: [`info: DingTalk interactive-card callback handled (executed delivery=${expected})`],
+      mutate: (body) => removeObserveGuard(body, '$anchor_count'),
+    },
+    {
+      name: 'remove handled_count guard',
+      lines: [anchor],
+      mutate: (body) => removeObserveGuard(body, '$handled_count'),
+    },
+    {
+      name: 'restore open outcome fallback',
+      lines: [anchor, `info: DingTalk interactive-card callback handled (unexpected delivery=${expected})`],
+      mutate: (body) => body.replace(
+        '      *) fail "action=observe observed callback outcome outside closed set (callback_handled_count=${handled_count})" ;;',
+        '      *) handled_outcome="executed" ;;',
+      ),
+    },
+  ]
+
+  for (const { name, lines, mutate } of mutations) {
+    const dir = mkdtempSync(join(tmpdir(), 'stream-observer-mutation-'))
+    try {
+      const original = runObserveFixture(observe, { dir, expected, lines })
+      assert.notEqual(original.result.status, 0, `${name}: original must fail`)
+      const mutatedObserve = mutate(observe)
+      assert.notEqual(mutatedObserve, observe, `${name}: mutation must change the body`)
+      const mutated = runObserveFixture(mutatedObserve, { dir, expected, lines })
+      assert.equal(mutated.result.status, 0, `${name}: mutation must be caught by the test fixture`)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
   }
 })
 

--- a/scripts/ops/dingtalk-interactive-card-stream-staging-uat-remote.sh
+++ b/scripts/ops/dingtalk-interactive-card-stream-staging-uat-remote.sh
@@ -1743,7 +1743,7 @@ action_observe() {
     || fail "action=observe requires live Stream ON (got stream_enabled=${live_flag})"
 
   local tmp anchor_count handled_count window_handler_error_count update_failed_count
-  local header_present="unknown" body_present="unknown" handled_outcome="unknown"
+  local header_present="" body_present="" handled_outcome=""
   tmp="$(mktemp "${STREAM_UAT_PERSIST_DIR}/.callback-observer.XXXXXX")"
   register_ephemeral "$tmp"
   chmod 600 "$tmp"
@@ -1757,6 +1757,11 @@ action_observe() {
   # EXPECTED_DELIVERY_ID.
   window_handler_error_count="$(grep -F -c 'DingTalk interactive-card callback failed (callback_handler_error)' "$tmp" || true)"
   update_failed_count="$(grep -F 'DingTalk approval-card terminal update failed (card_update_failed:' "$tmp" | grep -F -c "$EXPECTED_DELIVERY_ID" || true)"
+
+  [[ "$anchor_count" -gt 0 ]] \
+    || fail "action=observe requires scoped callback anchor evidence (callback_anchor_log_count=${anchor_count})"
+  [[ "$handled_count" -gt 0 ]] \
+    || fail "action=observe requires scoped callback handled evidence (callback_handled_count=${handled_count})"
 
   if [[ "$anchor_count" -gt 0 ]]; then
     local anchor_line
@@ -1783,7 +1788,7 @@ action_observe() {
       *'(link_secret_unavailable delivery='*) handled_outcome="link_secret_unavailable" ;;
       *'(engine_rejected:'*) handled_outcome="engine_rejected" ;;
       *'(wrapper_not_found delivery='*) handled_outcome="wrapper_not_found" ;;
-      *) handled_outcome="other" ;;
+      *) fail "action=observe observed callback outcome outside closed set (callback_handled_count=${handled_count})" ;;
     esac
   fi
 

--- a/scripts/ops/dingtalk-interactive-card-stream-staging-uat-remote.sh
+++ b/scripts/ops/dingtalk-interactive-card-stream-staging-uat-remote.sh
@@ -7,8 +7,10 @@
 #
 # EXECUTABLE:
 #   status  — read-only snapshot (booleans / counts / reason classes / SHA only)
-#   observe — read-only callback/corp-anchor/card-update result classes for one
-#             validated expected delivery UUID; never emits raw logs or ids
+#   observe-baseline — capture values-free per-delivery callback log counts before
+#             the human click; writes only a sealed local observer checkpoint
+#   observe — require callback/corp-anchor evidence to increase beyond that
+#             checkpoint for one validated delivery UUID; never emits raw logs or ids
 #   prepare — transport Stream credentials via chmod-600 files, derive exactly
 #             one active integration for live DINGTALK_CORP_ID with >=2 active
 #             linked local users, atomically write the four credential/id env
@@ -46,7 +48,7 @@ set -euo pipefail
 log() { echo "[stream-uat] $*"; }
 fail() { echo "[stream-uat][error] $*" >&2; exit 1; }
 
-ACTION="${ACTION:?ACTION is required (status|observe|prepare|on|off|https-on|https-off)}"
+ACTION="${ACTION:?ACTION is required (status|observe-baseline|observe|prepare|on|off|https-on|https-off)}"
 DEPLOY_SHA="${DEPLOY_SHA:-}"
 EXPECTED_DELIVERY_ID="${EXPECTED_DELIVERY_ID:-}"
 STAGING_DEPLOY_PATH="${STAGING_DEPLOY_PATH:-metasheet2-dingtalk-staging}"
@@ -508,6 +510,7 @@ STAGING_ENV_FILE="${STAGING_DIR}/docker/app.staging.env"
 STREAM_UAT_PERSIST_DIR="${HOME}/.metasheet2/stream-uat"
 mkdir -p "$STREAM_UAT_PERSIST_DIR"
 chmod 700 "$STREAM_UAT_PERSIST_DIR" 2>/dev/null || true
+OBSERVE_BASELINE_FILE="${STREAM_UAT_PERSIST_DIR}/callback-observer-baseline"
 HTTPS_GATEWAY_PERSIST_DIR="${HOME}/.metasheet2/staging-https-gateway"
 HTTPS_ENV_BACKUP="${HTTPS_GATEWAY_PERSIST_DIR}/app.staging.env.before-https"
 HTTPS_ENV_BACKUP_SHA256="${HTTPS_ENV_BACKUP}.sha256"
@@ -1729,6 +1732,90 @@ action_status() {
   log "action=status complete (read-only)"
 }
 
+observer_delivery_hash() {
+  printf '%s' "$EXPECTED_DELIVERY_ID" | sha256sum | awk '{print $1}'
+}
+
+read_scoped_callback_counts() {
+  local log_file="$1"
+  local anchor_count handled_count
+  anchor_count="$(grep -F 'DingTalk interactive-card callback corp anchor' "$log_file" | grep -F -c "$EXPECTED_DELIVERY_ID" || true)"
+  handled_count="$(grep -F 'DingTalk interactive-card callback handled (' "$log_file" | grep -F -c "$EXPECTED_DELIVERY_ID" || true)"
+  printf '%s %s\n' "$anchor_count" "$handled_count"
+}
+
+write_observer_baseline_state() {
+  local delivery_hash="$1" anchor_count="$2" handled_count="$3"
+  local candidate
+  [[ "$delivery_hash" =~ ^[0-9a-f]{64}$ ]] || return 1
+  [[ "$anchor_count" =~ ^[0-9]+$ && "$handled_count" =~ ^[0-9]+$ ]] || return 1
+  candidate="$(mktemp "${STREAM_UAT_PERSIST_DIR}/.callback-observer-baseline.XXXXXX")"
+  register_ephemeral "$candidate"
+  umask 077
+  {
+    echo "schema=dingtalk-interactive-card-stream-callback-baseline-v1"
+    echo "delivery_id_sha256=${delivery_hash}"
+    echo "callback_anchor_log_count=${anchor_count}"
+    echo "callback_handled_count=${handled_count}"
+  } >"$candidate"
+  chmod 600 "$candidate"
+  mv -f "$candidate" "$OBSERVE_BASELINE_FILE"
+  chmod 600 "$OBSERVE_BASELINE_FILE"
+}
+
+read_observer_baseline_state() {
+  local expected_hash="$1"
+  local schema delivery_hash anchor_count handled_count
+  [[ -f "$OBSERVE_BASELINE_FILE" ]] || return 1
+  [[ "$(wc -l <"$OBSERVE_BASELINE_FILE" | tr -d '[:space:]')" == "4" ]] || return 1
+  [[ "$(grep -F -c 'schema=' "$OBSERVE_BASELINE_FILE" || true)" == "1" ]] || return 1
+  [[ "$(grep -F -c 'delivery_id_sha256=' "$OBSERVE_BASELINE_FILE" || true)" == "1" ]] || return 1
+  [[ "$(grep -F -c 'callback_anchor_log_count=' "$OBSERVE_BASELINE_FILE" || true)" == "1" ]] || return 1
+  [[ "$(grep -F -c 'callback_handled_count=' "$OBSERVE_BASELINE_FILE" || true)" == "1" ]] || return 1
+  schema="$(awk -F= '$1 == "schema" { print $2 }' "$OBSERVE_BASELINE_FILE")"
+  delivery_hash="$(awk -F= '$1 == "delivery_id_sha256" { print $2 }' "$OBSERVE_BASELINE_FILE")"
+  anchor_count="$(awk -F= '$1 == "callback_anchor_log_count" { print $2 }' "$OBSERVE_BASELINE_FILE")"
+  handled_count="$(awk -F= '$1 == "callback_handled_count" { print $2 }' "$OBSERVE_BASELINE_FILE")"
+  [[ "$schema" == "dingtalk-interactive-card-stream-callback-baseline-v1" ]] || return 1
+  [[ "$delivery_hash" == "$expected_hash" ]] || return 1
+  [[ "$anchor_count" =~ ^[0-9]+$ && "$handled_count" =~ ^[0-9]+$ ]] || return 1
+  printf '%s %s\n' "$anchor_count" "$handled_count"
+}
+
+action_observe_baseline() {
+  assert_staging_only
+  require_exact_deployed_sha "observe-baseline"
+  require_lifecycle_flags_off "observe-baseline"
+  require_log_level_info_or_debug "observe-baseline"
+  [[ "$EXPECTED_DELIVERY_ID" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$ ]] \
+    || fail "action=observe-baseline requires expected_delivery_id as a lowercase UUID"
+
+  local live_flag tmp delivery_hash anchor_count handled_count
+  live_flag="$(read_flag_from_container "$FLAG_STREAM" || echo unknown)"
+  [[ "$live_flag" == "true" ]] \
+    || fail "action=observe-baseline requires live Stream ON (got stream_enabled=${live_flag})"
+  tmp="$(mktemp "${STREAM_UAT_PERSIST_DIR}/.callback-observer.XXXXXX")"
+  register_ephemeral "$tmp"
+  chmod 600 "$tmp"
+  docker logs "$BACKEND_CONTAINER" >"$tmp" 2>&1 \
+    || fail "action=observe-baseline could not read current backend container logs"
+  read -r anchor_count handled_count < <(read_scoped_callback_counts "$tmp")
+  delivery_hash="$(observer_delivery_hash)"
+  write_observer_baseline_state "$delivery_hash" "$anchor_count" "$handled_count" \
+    || fail "action=observe-baseline could not persist a valid observer checkpoint"
+  rm -f "$tmp"
+  {
+    echo "schema=dingtalk-interactive-card-stream-callback-observer-v2"
+    echo "action=observe-baseline"
+    echo "reason=baseline_captured"
+    echo "stream_enabled=true"
+    echo "callback_anchor_log_count=${anchor_count}"
+    echo "callback_handled_count=${handled_count}"
+  } > "${OUTPUT_DIR}/callback-observer.txt"
+  cp "${OUTPUT_DIR}/callback-observer.txt" "${OUTPUT_DIR}/summary.txt"
+  log "action=observe-baseline complete; perform exactly one human callback before action=observe"
+}
+
 action_observe() {
   assert_staging_only
   require_exact_deployed_sha "observe"
@@ -1742,7 +1829,8 @@ action_observe() {
   [[ "$live_flag" == "true" ]] \
     || fail "action=observe requires live Stream ON (got stream_enabled=${live_flag})"
 
-  local tmp anchor_count handled_count window_handler_error_count update_failed_count
+  local tmp delivery_hash baseline_anchor_count baseline_handled_count
+  local anchor_count handled_count anchor_delta handled_delta window_handler_error_count update_failed_count
   local header_present="" body_present="" handled_outcome=""
   tmp="$(mktemp "${STREAM_UAT_PERSIST_DIR}/.callback-observer.XXXXXX")"
   register_ephemeral "$tmp"
@@ -1750,18 +1838,22 @@ action_observe() {
   docker logs "$BACKEND_CONTAINER" >"$tmp" 2>&1 \
     || fail "action=observe could not read current backend container logs"
 
-  anchor_count="$(grep -F 'DingTalk interactive-card callback corp anchor' "$tmp" | grep -F -c "$EXPECTED_DELIVERY_ID" || true)"
-  handled_count="$(grep -F 'DingTalk interactive-card callback handled (' "$tmp" | grep -F -c "$EXPECTED_DELIVERY_ID" || true)"
+  read -r anchor_count handled_count < <(read_scoped_callback_counts "$tmp")
   # The worker's catch log intentionally carries no delivery id. Keep it as a
   # window-level diagnostic; it must never be presented as scoped evidence for
   # EXPECTED_DELIVERY_ID.
   window_handler_error_count="$(grep -F -c 'DingTalk interactive-card callback failed (callback_handler_error)' "$tmp" || true)"
   update_failed_count="$(grep -F 'DingTalk approval-card terminal update failed (card_update_failed:' "$tmp" | grep -F -c "$EXPECTED_DELIVERY_ID" || true)"
 
-  [[ "$anchor_count" -gt 0 ]] \
-    || fail "action=observe requires scoped callback anchor evidence (callback_anchor_log_count=${anchor_count})"
-  [[ "$handled_count" -gt 0 ]] \
-    || fail "action=observe requires scoped callback handled evidence (callback_handled_count=${handled_count})"
+  delivery_hash="$(observer_delivery_hash)"
+  read -r baseline_anchor_count baseline_handled_count < <(read_observer_baseline_state "$delivery_hash") \
+    || fail "action=observe requires a valid same-delivery checkpoint; run observe-baseline immediately before the human click"
+  [[ "$anchor_count" -gt "$baseline_anchor_count" ]] \
+    || fail "action=observe requires new scoped callback anchor evidence (before=${baseline_anchor_count};after=${anchor_count})"
+  [[ "$handled_count" -gt "$baseline_handled_count" ]] \
+    || fail "action=observe requires new scoped callback handled evidence (before=${baseline_handled_count};after=${handled_count})"
+  anchor_delta=$((anchor_count - baseline_anchor_count))
+  handled_delta=$((handled_count - baseline_handled_count))
 
   if [[ "$anchor_count" -gt 0 ]]; then
     local anchor_line
@@ -1794,18 +1886,24 @@ action_observe() {
 
   rm -f "$tmp"
   {
-    echo "schema=dingtalk-interactive-card-stream-callback-observer-v1"
+    echo "schema=dingtalk-interactive-card-stream-callback-observer-v2"
     echo "action=observe"
     echo "reason=ok"
     echo "stream_enabled=true"
     echo "callback_anchor_log_count=${anchor_count}"
+    echo "callback_anchor_log_count_before=${baseline_anchor_count}"
+    echo "callback_anchor_log_count_delta=${anchor_delta}"
     echo "header_event_corp_id_present=${header_present}"
     echo "body_corp_id_present=${body_present}"
     echo "callback_handled_count=${handled_count}"
+    echo "callback_handled_count_before=${baseline_handled_count}"
+    echo "callback_handled_count_delta=${handled_delta}"
     echo "latest_callback_outcome=${handled_outcome}"
     echo "window_callback_handler_error_count=${window_handler_error_count}"
     echo "card_update_failed_count=${update_failed_count}"
   } > "${OUTPUT_DIR}/callback-observer.txt"
+  write_observer_baseline_state "$delivery_hash" "$anchor_count" "$handled_count" \
+    || fail "action=observe could not advance the observer checkpoint"
   cp "${OUTPUT_DIR}/callback-observer.txt" "${OUTPUT_DIR}/summary.txt"
   log "action=observe complete (values-free callback classes only)"
 }
@@ -2087,13 +2185,14 @@ chmod 700 "$OUTPUT_DIR" 2>/dev/null || true
 
 case "$ACTION" in
   status) action_status ;;
+  observe-baseline) action_observe_baseline ;;
   observe) action_observe ;;
   prepare) action_prepare ;;
   on) action_on ;;
   off) action_off ;;
   https-on) action_https_on ;;
   https-off) action_https_off ;;
-  *) fail "invalid ACTION='${ACTION}' (expected status|observe|prepare|on|off|https-on|https-off)" ;;
+  *) fail "invalid ACTION='${ACTION}' (expected status|observe-baseline|observe|prepare|on|off|https-on|https-off)" ;;
 esac
 
 log "done action=${ACTION}"

--- a/scripts/ops/dingtalk-interactive-card-stream-staging-uat-remote.sh
+++ b/scripts/ops/dingtalk-interactive-card-stream-staging-uat-remote.sh
@@ -7,10 +7,9 @@
 #
 # EXECUTABLE:
 #   status  — read-only snapshot (booleans / counts / reason classes / SHA only)
-#   observe-baseline — capture values-free per-delivery callback log counts before
-#             the human click; writes only a sealed local observer checkpoint
-#   observe — require callback/corp-anchor evidence to increase beyond that
-#             checkpoint for one validated delivery UUID; never emits raw logs or ids
+#   observe — open a fresh five-minute log window, then require exactly one atomic
+#             callback-completion evidence record for a validated delivery UUID;
+#             never emits raw logs or ids
 #   prepare — transport Stream credentials via chmod-600 files, derive exactly
 #             one active integration for live DINGTALK_CORP_ID with >=2 active
 #             linked local users, atomically write the four credential/id env
@@ -48,7 +47,7 @@ set -euo pipefail
 log() { echo "[stream-uat] $*"; }
 fail() { echo "[stream-uat][error] $*" >&2; exit 1; }
 
-ACTION="${ACTION:?ACTION is required (status|observe-baseline|observe|prepare|on|off|https-on|https-off)}"
+ACTION="${ACTION:?ACTION is required (status|observe|prepare|on|off|https-on|https-off)}"
 DEPLOY_SHA="${DEPLOY_SHA:-}"
 EXPECTED_DELIVERY_ID="${EXPECTED_DELIVERY_ID:-}"
 STAGING_DEPLOY_PATH="${STAGING_DEPLOY_PATH:-metasheet2-dingtalk-staging}"
@@ -510,7 +509,6 @@ STAGING_ENV_FILE="${STAGING_DIR}/docker/app.staging.env"
 STREAM_UAT_PERSIST_DIR="${HOME}/.metasheet2/stream-uat"
 mkdir -p "$STREAM_UAT_PERSIST_DIR"
 chmod 700 "$STREAM_UAT_PERSIST_DIR" 2>/dev/null || true
-OBSERVE_BASELINE_FILE="${STREAM_UAT_PERSIST_DIR}/callback-observer-baseline"
 HTTPS_GATEWAY_PERSIST_DIR="${HOME}/.metasheet2/staging-https-gateway"
 HTTPS_ENV_BACKUP="${HTTPS_GATEWAY_PERSIST_DIR}/app.staging.env.before-https"
 HTTPS_ENV_BACKUP_SHA256="${HTTPS_ENV_BACKUP}.sha256"
@@ -1732,90 +1730,6 @@ action_status() {
   log "action=status complete (read-only)"
 }
 
-observer_delivery_hash() {
-  printf '%s' "$EXPECTED_DELIVERY_ID" | sha256sum | awk '{print $1}'
-}
-
-read_scoped_callback_counts() {
-  local log_file="$1"
-  local anchor_count handled_count
-  anchor_count="$(grep -F 'DingTalk interactive-card callback corp anchor' "$log_file" | grep -F -c "$EXPECTED_DELIVERY_ID" || true)"
-  handled_count="$(grep -F 'DingTalk interactive-card callback handled (' "$log_file" | grep -F -c "$EXPECTED_DELIVERY_ID" || true)"
-  printf '%s %s\n' "$anchor_count" "$handled_count"
-}
-
-write_observer_baseline_state() {
-  local delivery_hash="$1" anchor_count="$2" handled_count="$3"
-  local candidate
-  [[ "$delivery_hash" =~ ^[0-9a-f]{64}$ ]] || return 1
-  [[ "$anchor_count" =~ ^[0-9]+$ && "$handled_count" =~ ^[0-9]+$ ]] || return 1
-  candidate="$(mktemp "${STREAM_UAT_PERSIST_DIR}/.callback-observer-baseline.XXXXXX")"
-  register_ephemeral "$candidate"
-  umask 077
-  {
-    echo "schema=dingtalk-interactive-card-stream-callback-baseline-v1"
-    echo "delivery_id_sha256=${delivery_hash}"
-    echo "callback_anchor_log_count=${anchor_count}"
-    echo "callback_handled_count=${handled_count}"
-  } >"$candidate"
-  chmod 600 "$candidate"
-  mv -f "$candidate" "$OBSERVE_BASELINE_FILE"
-  chmod 600 "$OBSERVE_BASELINE_FILE"
-}
-
-read_observer_baseline_state() {
-  local expected_hash="$1"
-  local schema delivery_hash anchor_count handled_count
-  [[ -f "$OBSERVE_BASELINE_FILE" ]] || return 1
-  [[ "$(wc -l <"$OBSERVE_BASELINE_FILE" | tr -d '[:space:]')" == "4" ]] || return 1
-  [[ "$(grep -F -c 'schema=' "$OBSERVE_BASELINE_FILE" || true)" == "1" ]] || return 1
-  [[ "$(grep -F -c 'delivery_id_sha256=' "$OBSERVE_BASELINE_FILE" || true)" == "1" ]] || return 1
-  [[ "$(grep -F -c 'callback_anchor_log_count=' "$OBSERVE_BASELINE_FILE" || true)" == "1" ]] || return 1
-  [[ "$(grep -F -c 'callback_handled_count=' "$OBSERVE_BASELINE_FILE" || true)" == "1" ]] || return 1
-  schema="$(awk -F= '$1 == "schema" { print $2 }' "$OBSERVE_BASELINE_FILE")"
-  delivery_hash="$(awk -F= '$1 == "delivery_id_sha256" { print $2 }' "$OBSERVE_BASELINE_FILE")"
-  anchor_count="$(awk -F= '$1 == "callback_anchor_log_count" { print $2 }' "$OBSERVE_BASELINE_FILE")"
-  handled_count="$(awk -F= '$1 == "callback_handled_count" { print $2 }' "$OBSERVE_BASELINE_FILE")"
-  [[ "$schema" == "dingtalk-interactive-card-stream-callback-baseline-v1" ]] || return 1
-  [[ "$delivery_hash" == "$expected_hash" ]] || return 1
-  [[ "$anchor_count" =~ ^[0-9]+$ && "$handled_count" =~ ^[0-9]+$ ]] || return 1
-  printf '%s %s\n' "$anchor_count" "$handled_count"
-}
-
-action_observe_baseline() {
-  assert_staging_only
-  require_exact_deployed_sha "observe-baseline"
-  require_lifecycle_flags_off "observe-baseline"
-  require_log_level_info_or_debug "observe-baseline"
-  [[ "$EXPECTED_DELIVERY_ID" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$ ]] \
-    || fail "action=observe-baseline requires expected_delivery_id as a lowercase UUID"
-
-  local live_flag tmp delivery_hash anchor_count handled_count
-  live_flag="$(read_flag_from_container "$FLAG_STREAM" || echo unknown)"
-  [[ "$live_flag" == "true" ]] \
-    || fail "action=observe-baseline requires live Stream ON (got stream_enabled=${live_flag})"
-  tmp="$(mktemp "${STREAM_UAT_PERSIST_DIR}/.callback-observer.XXXXXX")"
-  register_ephemeral "$tmp"
-  chmod 600 "$tmp"
-  docker logs "$BACKEND_CONTAINER" >"$tmp" 2>&1 \
-    || fail "action=observe-baseline could not read current backend container logs"
-  read -r anchor_count handled_count < <(read_scoped_callback_counts "$tmp")
-  delivery_hash="$(observer_delivery_hash)"
-  write_observer_baseline_state "$delivery_hash" "$anchor_count" "$handled_count" \
-    || fail "action=observe-baseline could not persist a valid observer checkpoint"
-  rm -f "$tmp"
-  {
-    echo "schema=dingtalk-interactive-card-stream-callback-observer-v2"
-    echo "action=observe-baseline"
-    echo "reason=baseline_captured"
-    echo "stream_enabled=true"
-    echo "callback_anchor_log_count=${anchor_count}"
-    echo "callback_handled_count=${handled_count}"
-  } > "${OUTPUT_DIR}/callback-observer.txt"
-  cp "${OUTPUT_DIR}/callback-observer.txt" "${OUTPUT_DIR}/summary.txt"
-  log "action=observe-baseline complete; perform exactly one human callback before action=observe"
-}
-
 action_observe() {
   assert_staging_only
   require_exact_deployed_sha "observe"
@@ -1829,81 +1743,82 @@ action_observe() {
   [[ "$live_flag" == "true" ]] \
     || fail "action=observe requires live Stream ON (got stream_enabled=${live_flag})"
 
-  local tmp delivery_hash baseline_anchor_count baseline_handled_count
-  local anchor_count handled_count anchor_delta handled_delta window_handler_error_count update_failed_count
-  local header_present="" body_present="" handled_outcome=""
+  local tmp window_started container_id current_container_id attempt evidence_count="0"
+  local evidence_line header_present="" body_present="" corp_gate_result="" callback_outcome=""
+  local window_handler_error_count update_failed_count
   tmp="$(mktemp "${STREAM_UAT_PERSIST_DIR}/.callback-observer.XXXXXX")"
   register_ephemeral "$tmp"
   chmod 600 "$tmp"
-  docker logs "$BACKEND_CONTAINER" >"$tmp" 2>&1 \
-    || fail "action=observe could not read current backend container logs"
+  container_id="$(docker inspect --format '{{.Id}}' "$BACKEND_CONTAINER" 2>/dev/null || true)"
+  [[ "$container_id" =~ ^[0-9a-f]{12,64}$ ]] \
+    || fail "action=observe could not resolve the backend container identity"
+  window_started="$(date -u +'%Y-%m-%dT%H:%M:%S.%NZ')"
+  [[ "$window_started" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T ]] \
+    || fail "action=observe could not establish a fresh log-window timestamp"
 
-  read -r anchor_count handled_count < <(read_scoped_callback_counts "$tmp")
+  log "observer_armed=true; perform exactly one callback now; observation remains open for the full five-minute window"
+  for attempt in $(seq 1 300); do
+    current_container_id="$(docker inspect --format '{{.Id}}' "$BACKEND_CONTAINER" 2>/dev/null || true)"
+    [[ "$current_container_id" == "$container_id" ]] \
+      || fail "action=observe backend container changed during the observation window"
+    docker logs --since "$window_started" "$BACKEND_CONTAINER" >"$tmp" 2>&1 \
+      || fail "action=observe could not read the fresh backend log window"
+    evidence_count="$(grep -F 'DingTalk interactive-card callback completed evidence' "$tmp" | grep -F -c "$EXPECTED_DELIVERY_ID" || true)"
+    [[ "$evidence_count" -le 1 ]] \
+      || fail "action=observe requires exactly one completed callback in the fresh window (callback_evidence_count=${evidence_count})"
+    sleep 1
+  done
+  [[ "$evidence_count" -ge 1 ]] \
+    || fail "action=observe timed out without one completed callback in the fresh window (callback_evidence_count=${evidence_count})"
+
+  current_container_id="$(docker inspect --format '{{.Id}}' "$BACKEND_CONTAINER" 2>/dev/null || true)"
+  [[ "$current_container_id" == "$container_id" ]] \
+    || fail "action=observe backend container changed before evidence classification"
+  evidence_line="$(grep -F 'DingTalk interactive-card callback completed evidence' "$tmp" | grep -F "$EXPECTED_DELIVERY_ID")"
+  case "$evidence_line" in
+    *'"headerEventCorpIdPresent":true'*|*'headerEventCorpIdPresent=true'*) header_present="true" ;;
+    *'"headerEventCorpIdPresent":false'*|*'headerEventCorpIdPresent=false'*) header_present="false" ;;
+    *) fail "action=observe completed evidence omitted header anchor presence" ;;
+  esac
+  case "$evidence_line" in
+    *'"bodyCorpIdPresent":true'*|*'bodyCorpIdPresent=true'*) body_present="true" ;;
+    *'"bodyCorpIdPresent":false'*|*'bodyCorpIdPresent=false'*) body_present="false" ;;
+    *) fail "action=observe completed evidence omitted body anchor presence" ;;
+  esac
+  for candidate in matched corp_anchor_conflict corp_anchor_absent delivery_corp_unresolved corp_mismatch; do
+    if [[ "$evidence_line" == *"\"corpGateResult\":\"${candidate}\""* || "$evidence_line" == *"corpGateResult=${candidate}"* ]]; then
+      [[ -z "$corp_gate_result" ]] || fail "action=observe completed evidence carried ambiguous corp gate results"
+      corp_gate_result="$candidate"
+    fi
+  done
+  [[ -n "$corp_gate_result" ]] || fail "action=observe completed evidence carried a corp gate result outside the closed set"
+  for candidate in operator_unresolved link_secret_unavailable executed stale engine_rejected wrapper_not_found; do
+    if [[ "$evidence_line" == *"\"callbackOutcome\":\"${candidate}\""* || "$evidence_line" == *"callbackOutcome=${candidate}"* ]]; then
+      [[ -z "$callback_outcome" ]] || fail "action=observe completed evidence carried ambiguous callback outcomes"
+      callback_outcome="$candidate"
+    fi
+  done
+  [[ -n "$callback_outcome" ]] || fail "action=observe completed evidence carried a callback outcome outside the closed set"
+
   # The worker's catch log intentionally carries no delivery id. Keep it as a
-  # window-level diagnostic; it must never be presented as scoped evidence for
-  # EXPECTED_DELIVERY_ID.
+  # fresh-window diagnostic; it must never be presented as scoped evidence.
   window_handler_error_count="$(grep -F -c 'DingTalk interactive-card callback failed (callback_handler_error)' "$tmp" || true)"
   update_failed_count="$(grep -F 'DingTalk approval-card terminal update failed (card_update_failed:' "$tmp" | grep -F -c "$EXPECTED_DELIVERY_ID" || true)"
 
-  delivery_hash="$(observer_delivery_hash)"
-  read -r baseline_anchor_count baseline_handled_count < <(read_observer_baseline_state "$delivery_hash") \
-    || fail "action=observe requires a valid same-delivery checkpoint; run observe-baseline immediately before the human click"
-  [[ "$anchor_count" -gt "$baseline_anchor_count" ]] \
-    || fail "action=observe requires new scoped callback anchor evidence (before=${baseline_anchor_count};after=${anchor_count})"
-  [[ "$handled_count" -gt "$baseline_handled_count" ]] \
-    || fail "action=observe requires new scoped callback handled evidence (before=${baseline_handled_count};after=${handled_count})"
-  anchor_delta=$((anchor_count - baseline_anchor_count))
-  handled_delta=$((handled_count - baseline_handled_count))
-
-  if [[ "$anchor_count" -gt 0 ]]; then
-    local anchor_line
-    anchor_line="$(grep -F 'DingTalk interactive-card callback corp anchor' "$tmp" | grep -F "$EXPECTED_DELIVERY_ID" | tail -n 1)"
-    [[ "$anchor_line" == *'headerEventCorpIdPresent=true'* || "$anchor_line" == *'"headerEventCorpIdPresent":true'* ]] \
-      && header_present="true"
-    [[ "$anchor_line" == *'headerEventCorpIdPresent=false'* || "$anchor_line" == *'"headerEventCorpIdPresent":false'* ]] \
-      && header_present="false"
-    [[ "$anchor_line" == *'bodyCorpIdPresent=true'* || "$anchor_line" == *'"bodyCorpIdPresent":true'* ]] \
-      && body_present="true"
-    [[ "$anchor_line" == *'bodyCorpIdPresent=false'* || "$anchor_line" == *'"bodyCorpIdPresent":false'* ]] \
-      && body_present="false"
-  fi
-
-  if [[ "$handled_count" -gt 0 ]]; then
-    local handled_line
-    handled_line="$(grep -F 'DingTalk interactive-card callback handled (' "$tmp" | grep -F "$EXPECTED_DELIVERY_ID" | tail -n 1)"
-    case "$handled_line" in
-      *'(ignored_unsupported_action out_track_id='*) handled_outcome="ignored_unsupported_action" ;;
-      *'(delivery_not_found out_track_id='*) handled_outcome="delivery_not_found" ;;
-      *'(executed delivery='*) handled_outcome="executed" ;;
-      *'(stale delivery='*) handled_outcome="stale" ;;
-      *'(operator_unresolved:'*) handled_outcome="operator_unresolved" ;;
-      *'(link_secret_unavailable delivery='*) handled_outcome="link_secret_unavailable" ;;
-      *'(engine_rejected:'*) handled_outcome="engine_rejected" ;;
-      *'(wrapper_not_found delivery='*) handled_outcome="wrapper_not_found" ;;
-      *) fail "action=observe observed callback outcome outside closed set (callback_handled_count=${handled_count})" ;;
-    esac
-  fi
-
   rm -f "$tmp"
   {
-    echo "schema=dingtalk-interactive-card-stream-callback-observer-v2"
+    echo "schema=dingtalk-interactive-card-stream-callback-observer-v3"
     echo "action=observe"
     echo "reason=ok"
     echo "stream_enabled=true"
-    echo "callback_anchor_log_count=${anchor_count}"
-    echo "callback_anchor_log_count_before=${baseline_anchor_count}"
-    echo "callback_anchor_log_count_delta=${anchor_delta}"
+    echo "callback_evidence_count=1"
     echo "header_event_corp_id_present=${header_present}"
     echo "body_corp_id_present=${body_present}"
-    echo "callback_handled_count=${handled_count}"
-    echo "callback_handled_count_before=${baseline_handled_count}"
-    echo "callback_handled_count_delta=${handled_delta}"
-    echo "latest_callback_outcome=${handled_outcome}"
+    echo "corp_gate_result=${corp_gate_result}"
+    echo "latest_callback_outcome=${callback_outcome}"
     echo "window_callback_handler_error_count=${window_handler_error_count}"
     echo "card_update_failed_count=${update_failed_count}"
   } > "${OUTPUT_DIR}/callback-observer.txt"
-  write_observer_baseline_state "$delivery_hash" "$anchor_count" "$handled_count" \
-    || fail "action=observe could not advance the observer checkpoint"
   cp "${OUTPUT_DIR}/callback-observer.txt" "${OUTPUT_DIR}/summary.txt"
   log "action=observe complete (values-free callback classes only)"
 }
@@ -2185,14 +2100,13 @@ chmod 700 "$OUTPUT_DIR" 2>/dev/null || true
 
 case "$ACTION" in
   status) action_status ;;
-  observe-baseline) action_observe_baseline ;;
   observe) action_observe ;;
   prepare) action_prepare ;;
   on) action_on ;;
   off) action_off ;;
   https-on) action_https_on ;;
   https-off) action_https_off ;;
-  *) fail "invalid ACTION='${ACTION}' (expected status|observe-baseline|observe|prepare|on|off|https-on|https-off)" ;;
+  *) fail "invalid ACTION='${ACTION}' (expected status|observe|prepare|on|off|https-on|https-off)" ;;
 esac
 
 log "done action=${ACTION}"


### PR DESCRIPTION
## What

Closes the remaining code-review gaps in the DingTalk interactive-card UAT surface:

1. Stream callback observation is per-callback and fail-closed. `observe` arms a fresh fixed five-minute Docker log window, requires exactly one same-delivery atomic completion record, rejects delayed duplicates, and fails if the backend container changes. The record binds corp-anchor provenance, the closed corp-gate result, and the closed callback outcome from one completed invocation; historical logs and split anchor/outcome lines cannot satisfy it.
2. U6 uses controlled non-assignee callback injection while production keeps `supportForward=false`; U11-a distinguishes `corp_anchor_absent` from a genuine `corp_mismatch`. U8 is explicitly a Web deep-link flow and uses Web response + audit + terminal-card evidence rather than a nonexistent Stream callback.
3. A successful Web deep-link reject updates the original interactive card to a terminal presentation with `actionsVisible=false`; update failures remain post-commit, values-free, and cannot roll back the approval.
4. The double-tap golden proves two distinct PostgreSQL sessions are queued behind the same instance-row holder before release.

## Local verification

- `node --test scripts/ops/dingtalk-interactive-card-stream-staging-uat-contract.test.mjs` - 56/56
- targeted callback/Stream unit tests - 64/64
- `pnpm --filter @metasheet/core-backend exec tsc --noEmit`
- `dingtalk-approval-card-callback.db.test.ts` - 20/20 against an isolated fully-migrated scratch DB
- production completion-log mutation - 4 named real-DB assertions red; restored suite 20/20
- observer mutations - removing `--since`, duplicate enforcement, closed outcome enforcement, or restoring early exit after first evidence makes its dedicated fixture fail
- `bash -n scripts/ops/dingtalk-interactive-card-stream-staging-uat-remote.sh`
- `git diff --check`

The earlier deterministic double-tap battery remains 28/28 across three isolated scratch-DB runs.

## Review record

- The first independent review found one P2: container-lifetime logs from U4 could satisfy U5.
- The second independent review at `7cd61c95b1` found two P2s in the attempted checkpoint fix: a stale/tampered checkpoint could replay history, and anchor/outcome counts could come from different callbacks.
- `da25be94cf` removes the checkpoint design, adds one atomic producer record, and keeps the observation open for the full fixed window. Codex then found and fixed an early-exit race that could miss a delayed duplicate.
- A fresh independent exact-head review and exact-head CI are required before this Draft can be considered review-ready.

## Safety boundary

Draft/HELD. No staging operation, flag change, template publication, UAT action, auto-merge, or merge is authorized by this PR. Stream and all lifecycle switches remain OFF. Real DingTalk template behavior and callback corp-anchor shape still require a separately authorized staging UAT window.

## Residual scope

This change converges the originating card after the card deep-link reject path. It does not add a general revoke fan-out over every historical delivery.
