### PR TITLE
docs(ops)+tool: on-prem deploy-path acceleration map + non-mutating LAB-0 inventory (DRAFT)

### DIFF
--- a/.github/workflows/stock-preparation-lab0-inventory.yml
+++ b/.github/workflows/stock-preparation-lab0-inventory.yml
@@ -1,0 +1,47 @@
+name: Stock Preparation LAB-0 Inventory
+
+# Hermetic contract test for the LAB-0 host-inventory tool (DRAFT, offline,
+# values-free). The tool replaces the six-field PostgreSQL readiness reply
+# (#4695) and the LAB-0 environment block (#4708) that an operator currently
+# hand-assembles; the contract test injects fake probes and asserts the tool
+# never installs, downloads, creates a database/principal, deploys, touches a
+# flag, reads a business row, or writes anything but stdout, and that every
+# emitted field stays inside its closed token set.
+#
+# Runs on ubuntu AND windows because the real host is Windows: the PowerShell
+# 5.1 / 7 probes and path handling must behave the same there. Same shape as
+# stock-preparation-s6a-operator-preflight.yml: checkout + setup-node only,
+# `node --test` directly. No DB, no network.
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/stock-preparation-lab0-inventory.yml'
+      - 'scripts/ops/stock-preparation-lab0-inventory.mjs'
+      - 'scripts/ops/stock-preparation-lab0-inventory.test.mjs'
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/stock-preparation-lab0-inventory.yml'
+      - 'scripts/ops/stock-preparation-lab0-inventory.mjs'
+      - 'scripts/ops/stock-preparation-lab0-inventory.test.mjs'
+
+permissions:
+  contents: read
+
+jobs:
+  contract:
+    name: LAB-0 inventory contract (${{ matrix.os }}, values-free, no DB, no network)
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Run hermetic inventory tests (fake probes only, no DB, no network)
+        run: node --test scripts/ops/stock-preparation-lab0-inventory.test.mjs

--- a/docs/development/onprem-deploy-path-acceleration-20260818.md
+++ b/docs/development/onprem-deploy-path-acceleration-20260818.md
@@ -1,0 +1,112 @@
+# On-Prem Deploy Path Acceleration — main → Windows test host (2026-08-18)
+
+Draft. Analysis + proposal only; authorizes nothing. Companion draft:
+`scripts/ops/stock-preparation-lab0-inventory.mjs`.
+
+## a. The path today
+
+| # | Step | Who | Produces | Wall time | Round-trips |
+|---|---|---|---|---|---|
+| 1 | Owner ratification comment on the governing issue (#4695 / #4708 / #4437) | owner | `owner…Decision=…_V1` | hours–days | 1 |
+| 2 | Build — `multitable-onprem-package-build.yml` (inputs `expected_sha`, `publish_release`, `release_tag`) | CI | .tgz/.zip + .sha256 + SHA256SUMS + metadata + bootstrap .ps1/.bat | ~3 min (run 30636435663) | 1 |
+| 3 | Verify — `multitable-onprem-package-verify.sh` on both archives inside the build job, + a `pnpm install --frozen-lockfile` dependency preflight | CI | verify .json/.md ×2 | in step 2 | 0 |
+| 3′ | Alternative: `stock-prep-main-package-verify.yml` = build + verify + one-byte negative control + migrate on PG 15/16/17, same run | CI | artifact only (`contents: read` — cannot publish) | ~4 min (run 31666982219) | 1 |
+| 4 | `multitable-onprem-package-no-node-modules.test.mjs` | CI | pass/fail | — | 0 — wired **only** into `plugin-tests.yml` |
+| 5 | Provenance — `BUILD_PROVENANCE.json` (gitCommit/gitRef/`sourceIsOnOriginMain`/fixMarkers); `packageProvenanceManifestDigest` = `verifySealedExportRuntimePackageProvenance().frozenManifestDigest` (65 pins) | CI / manual `node -e` | 2 digests | seconds | 0–1 |
+| 6 | Freeze + release — only step 2 with `publish_release=true` has `contents: write`; owner then transcribes 5 fields (`serviceRuntimeSha`, `releaseTag`, `packageFile`, `packageSha256`, `packageProvenanceManifestDigest`) into an issue comment | owner | frozen block | hours | 1–2 |
+| 7 | Transfer — `gh run download` / release download to a transfer workstation, then to the host. No automated Windows-host sync exists (docker-build.yml's `sync_rc`/`deploy_rc` lane, PR #4971, is the Linux K3-WISE host) | operator | package on host | minutes–hours | 1 |
+| 8 | Deploy — `deploy.bat` → `multitable-onprem-deploy-launcher.ps1` → staged `multitable-onprem-apply-package.ps1` (#4437's last PASS: `installDeps=0 runMigrations=0`) | operator | `apply exit=0` | minutes | 0 |
+| 9 | Preflight — **three** manual surfaces: LAB-0 inventory (#4708), the six-field reply (#4695), `stock-preparation-s6a-operator-preflight.mjs` (14 offline checks), plus hand-run Part-A SQL from the 2026-08-02 readiness checklist | operator → owner | values-free blocks | hours–days | **2–4** |
+| 10 | Smoke / acceptance — `stock-preparation-onprem-acceptance.ps1` (7 stages, one command) or `…-s6a-onprem-acceptance.ps1`; `stock-preparation-mvp-postdeploy-smoke.mjs` | operator | acceptance-summary .txt/.json | minutes | 0 |
+| 11 | Flag window — owner publishes one exact S6-B comment (fresh `acceptanceOperationId` + expected `operationBindingDigest`); 9 runtime env vars; one run + replay; single-use | owner + operator | run receipt | hours | 1 |
+| 12 | Restore — flag OFF, purge env, restart, capability disabled, token hygiene | operator | `flagOffRestored=PASS` | minutes | 0 |
+
+**CI is not the bottleneck.** Total machine time is ~5 minutes. The path is
+**8–12 human round-trips**, each one a values-free block a person writes and
+another person adjudicates.
+
+## b. The five sequential blockers (#4695 comment 5173506702, run 30861719019)
+
+`PROVISIONING_FAILED → RUNTIME_NOT_CONSTRUCTED → SEALED_EXPORT_BINDING_UNQUALIFIED → (drift-pin hardening) → activation 42501 → PASS`
+
+| # | Blocker | Class | Pre-deploy CI gate would have caught it? |
+|---|---|---|---|
+| 1 | missing migration **074** at provisioning | privilege (DB) | **Yes** — role-bound migration leg (§d) |
+| 2 | `RUNTIME_NOT_CONSTRUCTED` | env / config | Partly — a config-loader positive control; the operator preflight covers the artifact half |
+| 3 | `SEALED_EXPORT_BINDING_UNQUALIFIED` — frozen `:167 ownedCanonical(raw)` vs current `:233 ownedCanonical(projectExternalSystem(raw))`; DB-written `Date` timestamps refused as `EXOTIC_OBJECT` | **production defect** | **Yes** — any real-DB round-trip through the ordinary external-system API |
+| 4 | provenance drift-pin hardening (6 of 65 pins moved) | package / CI | **Yes** — pin-digest guards now exist |
+| 5 | activation `42501` — missing migration **075** row lock | privilege (DB) | **Yes** — same leg as #1 |
+
+Four of five were CI-catchable. The S6-A harness *did* find all five — but
+**after** the freeze, so the cost was a mandatory re-freeze, not a red check.
+
+## c. The PostgreSQL 17 question
+
+**Already validated on 15/16/17.** `stock-prep-s6a-postgres17-validation.yml`
+(frozen asset, SHA-gated) and `stock-prep-main-package-verify.yml`
+(built-from-main) both run the package's own `migrate.js` against ephemeral
+`postgres:15|16|17`, each leg re-confirming the live server major matches its
+matrix cell; `sealed-export-s6a-authority-row-lock.yml` and
+`…-grant-repair.yml` run the real-DB 073/074/075 tests on **16 and 17**. The
+matrix add is done — the readiness checklist's Part G item 2 ("no `postgres:17`
+exists anywhere in the repository", 2026-08-02) is **stale**.
+
+**What is still unvalidated on every version.** Neither PG-matrix workflow sets
+`PGOPTIONS` / `metasheet.sealed_export_runtime_role` /
+`…_provisioning_role` (grep: zero hits). So in the matrix, 073/074/075 take
+their documented latent-NOTICE branch: the role-safety predicate and the actual
+GRANTs are proven only by the vitest lane, which creates both roles **as the
+superuser `postgres`**.
+
+**The one version-sensitive surface in 068–073.** `GENERATED ALWAYS AS (…)
+STORED` is PG12+ and uniform across 15–17; `pg_has_role` /
+`has_table_privilege` / `has_column_privilege` are stable. But `073:508-514`,
+`074:123` and `075:166` require **zero `pg_auth_members` rows in either
+direction**, and PostgreSQL 16 changed role creation so a non-superuser
+`CREATEROLE` account is automatically granted membership in the roles it
+creates (`createrole_self_grant`). On 16/17 a DBA creating the two roles that
+way produces exactly the row 073 rejects as `sealed-export role has unsafe
+authority` — a message that does not say which branch failed.
+`createrole_self_grant` appears nowhere in the repo. Needs verification on a
+real PG17, but it is invisible to today's superuser-only coverage.
+
+## d. Proposal — one workflow, one script
+
+**`stock-prep-freeze-and-verify.yml` (dispatchable).** Composes, unchanged, the
+four jobs of `stock-prep-main-package-verify.yml` (`exclusion-list-drift-guard`,
+`build-main-package`, `verify-built-package`, `migrate-postgres [15,16,17]`),
+plus three additions:
+
+1. run `multitable-onprem-package-no-node-modules.test.mjs` inside
+   `verify-built-package` — *wiring only*;
+2. **new** role-bound migration leg: create the two roles in the ephemeral PG
+   (once as superuser, once as a non-superuser CREATEROLE account), export
+   `PGOPTIONS`, migrate, assert the runbook's three `has_*_privilege`
+   predicates — closes the latent-grant hole and §c's PG16+ hazard;
+3. **new** `freeze` job (`contents: write`, gated on a `publish_draft_release`
+   input): emits `frozenManifestDigest` from the **downloaded artifact** (the
+   comparison step already exists at
+   `stock-prep-s6a-postgres17-validation.yml:105-116` — here it *produces*),
+   creates a **draft** release with archives/checksums/verify reports, and
+   writes the paste-ready five-field freeze block to `$GITHUB_STEP_SUMMARY`.
+
+**`stock-preparation-lab0-inventory.mjs` (drafted here).** Emits #4695's six
+fields plus the LAB-0 environment facts from read-only probes: node/pwsh
+majors, TCP reachability, one catalog `SELECT` for `server_version_num` +
+`rolcreatedb|rolsuper` + `rolcreaterole|rolsuper`, an unauthenticated health
+GET, disk/memory classes. No install, download, DB or principal creation,
+deploy, flag change, business-row read, or write beyond stdout — pinned by
+`stock-preparation-lab0-inventory.test.mjs` (22 cases, two of them
+discriminating negative controls). Next: one `preflight-and-report.ps1`
+composing this + `stock-preparation-s6a-operator-preflight.mjs` + a reader for
+the runbook §2 privilege triple — one command, one paste, replacing step 9.
+
+## e. Top 5 accelerations
+
+| Rank | Change | Saves | Effort | Risk |
+|---|---|---|---|---|
+| 1 | One `freeze-and-verify` dispatch producing a draft release **and** the five-field block | 3 round-trips + hand-transcribing 5 digests | M | L — write scope is one draft release |
+| 2 | Host-side `preflight-and-report` (inventory + preflight + privilege triple) | 2–4 round-trips; kills the `UNKNOWN` class | S–M | L — read-only, contract-pinned |
+| 3 | Role-bound migration leg on the 15/16/17 matrix | pre-empts blockers 1 and 5 | M | M — goes red first; CREATEROLE leg may expose the PG16+ hazard |
+| 4 | Windows-host pull by `packageWorkflowRun`/`verifiedArtifactId` + SHA-256 gate, then the existing launcher | collapses steps 7–8 to one command | M | M — needs a host credential; keep pull-only |
+| 5 | Fold the no-node-modules test + provenance digest into the build run | removes a manual `node -e` and a cross-workflow dependency | S | L |

--- a/scripts/ops/stock-preparation-lab0-inventory.mjs
+++ b/scripts/ops/stock-preparation-lab0-inventory.mjs
@@ -1,0 +1,603 @@
+#!/usr/bin/env node
+'use strict'
+
+// Stock Preparation LAB-0 host inventory — DRAFT (non-mutating, values-free).
+//
+// STATUS: DRAFT. Not wired into any workflow, not referenced by any runbook,
+// and not authorized to be run against a customer machine. It exists so the
+// LAB-0 reply that #4708 and #4695 currently ask a human to hand-assemble can
+// be produced by a script instead.
+//
+// WHY THIS EXISTS
+// ---------------
+// #4708 "Phase LAB-0: inventory only" and #4695's PostgreSQL readiness lane
+// both stop the whole delivery path on a values-free block that an operator
+// types by hand:
+//
+//   #4695 six-field reply (issue comment 5161121847):
+//     metasheetTestRuntimeAvailable / postgresServiceAvailable /
+//     postgresMajorVersion / canCreateIsolatedTestDatabase /
+//     canCreateSelectOnlyTestPrincipal / factsProvider
+//
+// Every round-trip of that block costs a full owner<->operator cycle, and the
+// 2026-08-03 reply left two of the six as UNKNOWN — which cost another cycle
+// for facts a read-only catalog query answers in milliseconds. This tool emits
+// exactly that block, plus the LAB-0 environment facts around it, from
+// read-only probes.
+//
+// WHAT IT MUST NEVER DO (enforced by review + the sibling contract test)
+// ---------------------------------------------------------------------
+//   * no install, download, package fetch, or dependency command;
+//   * no database creation, role/principal creation, GRANT, or migration;
+//   * no deploy, service start/stop/restart, or PM2 call;
+//   * no feature-flag read-modify-write of any kind;
+//   * no business-row read — the only SQL executed is one catalog SELECT
+//     against pg_roles/current_setting, and it is the ONLY SQL string in the
+//     file;
+//   * no write of any kind beyond stdout: no file is created, appended to, or
+//     removed, and no environment variable is exported.
+//
+// VALUES-FREE DISCIPLINE
+// ----------------------
+// Every emitted field is a member of a closed token set declared in TOKEN
+// below (or the operator-supplied GitHub handle that #4695's template asks
+// for by name, shape-validated before it is echoed). Hostnames, ports,
+// database names, role names, connection strings, paths, versions as free
+// text, byte counts, and HTTP bodies are never emitted — a PostgreSQL server
+// version becomes PG15/PG16/PG17/PG_OTHER, free disk becomes a class, and a
+// health response becomes PASS/FAIL. formatReport() self-scans the composed
+// report against the configured inputs before returning it, so a future edit
+// that interpolates a URL into a field is caught rather than published.
+//
+// Style follows scripts/ops/stock-preparation-s6a-operator-preflight.mjs:
+// pure exported helpers, an injectable probe surface so the contract test
+// needs no host, and a fixed report shape.
+
+import fs from 'node:fs'
+import net from 'node:net'
+import os from 'node:os'
+import path from 'node:path'
+import { spawnSync } from 'node:child_process'
+import { createRequire } from 'node:module'
+import { fileURLToPath } from 'node:url'
+
+const require = createRequire(import.meta.url)
+
+// ---------------------------------------------------------------------------
+// The complete closed token vocabulary. Nothing outside this set (plus a
+// shape-validated GitHub handle for factsProvider) is ever written to stdout.
+// ---------------------------------------------------------------------------
+const TOKEN = Object.freeze({
+  BLOCKED: 'BLOCKED',
+  COMPLETE: 'COMPLETE',
+  DISK_10_TO_40GIB: 'DISK_10_TO_40GIB',
+  DISK_GE_40GIB: 'DISK_GE_40GIB',
+  DISK_LT_10GIB: 'DISK_LT_10GIB',
+  FAIL: 'FAIL',
+  FALSE: 'false',
+  INVALID_FORMAT: 'INVALID_FORMAT',
+  MEM_GE_16GIB: 'MEM_GE_16GIB',
+  MEM_LT_16GIB: 'MEM_LT_16GIB',
+  NO: 'NO',
+  NODE20: 'NODE20',
+  NODE22: 'NODE22',
+  NODE_OTHER: 'NODE_OTHER',
+  OTHER: 'OTHER',
+  PASS: 'PASS',
+  PG15: 'PG15',
+  PG16: 'PG16',
+  PG17: 'PG17',
+  PG_OTHER: 'PG_OTHER',
+  UNKNOWN: 'UNKNOWN',
+  UNSET: 'UNSET',
+  YES: 'YES',
+  ZERO: '0',
+})
+
+const CLOSED_TOKENS = Object.freeze(new Set(Object.values(TOKEN)))
+
+// The exact field names, in the exact order, of #4695's requested reply
+// (issue comment 5161121847). Pinned by the contract test so a rename here
+// cannot silently produce a block the issue will reject.
+const SIX_FIELD_ORDER = Object.freeze([
+  'metasheetTestRuntimeAvailable',
+  'postgresServiceAvailable',
+  'postgresMajorVersion',
+  'canCreateIsolatedTestDatabase',
+  'canCreateSelectOnlyTestPrincipal',
+  'factsProvider',
+])
+
+// The ONE SQL statement this tool may execute. Read-only catalog access:
+// current_setting() is a function call, pg_roles is a system view, and the
+// predicate is the current session's own role. It reads no business relation
+// and mutates nothing. Kept as a single exported constant so the contract
+// test can assert it is the only SQL in the file and that it starts SELECT.
+const CATALOG_READ_SQL =
+  'SELECT current_setting(\'server_version_num\') AS server_version_num, '
+  + '(rolcreatedb OR rolsuper) AS can_create_database, '
+  + '(rolcreaterole OR rolsuper) AS can_create_role '
+  + 'FROM pg_roles WHERE rolname = current_user'
+
+const GIB = 1024 * 1024 * 1024
+const DISK_HIGH_WATER_BYTES = 40 * GIB
+const DISK_LOW_WATER_BYTES = 10 * GIB
+const MEMORY_WATER_BYTES = 16 * GIB
+
+const DEFAULT_HEALTH_URL = 'http://127.0.0.1:8900/api/health'
+const DEFAULT_TIMEOUT_MS = 5000
+
+// ---------------------------------------------------------------------------
+// Pure classifiers. Each maps a raw observation to a closed token; none of
+// them can return an unregistered string.
+// ---------------------------------------------------------------------------
+function classifyNodeMajor(rawMajor) {
+  const major = Number.parseInt(String(rawMajor ?? ''), 10)
+  if (!Number.isInteger(major)) return TOKEN.UNKNOWN
+  if (major === 20) return TOKEN.NODE20
+  if (major === 22) return TOKEN.NODE22
+  return TOKEN.NODE_OTHER
+}
+
+// PostgreSQL server_version_num is major * 10000 + minor for major >= 10.
+function classifyPostgresMajor(rawServerVersionNum) {
+  const num = Number.parseInt(String(rawServerVersionNum ?? ''), 10)
+  if (!Number.isInteger(num) || num <= 0) return TOKEN.UNKNOWN
+  const major = Math.floor(num / 10000)
+  if (major === 15) return TOKEN.PG15
+  if (major === 16) return TOKEN.PG16
+  if (major === 17) return TOKEN.PG17
+  return TOKEN.PG_OTHER
+}
+
+// The six-field template asks for postgresMajorVersion as a bare number, so
+// the version class is projected back onto the closed set 15|16|17|OTHER.
+function postgresMajorField(versionClass) {
+  if (versionClass === TOKEN.PG15) return '15'
+  if (versionClass === TOKEN.PG16) return '16'
+  if (versionClass === TOKEN.PG17) return '17'
+  if (versionClass === TOKEN.PG_OTHER) return TOKEN.OTHER
+  return TOKEN.UNKNOWN
+}
+
+function classifyDiskFree(freeBytes) {
+  if (!Number.isFinite(freeBytes) || freeBytes < 0) return TOKEN.UNKNOWN
+  if (freeBytes >= DISK_HIGH_WATER_BYTES) return TOKEN.DISK_GE_40GIB
+  if (freeBytes >= DISK_LOW_WATER_BYTES) return TOKEN.DISK_10_TO_40GIB
+  return TOKEN.DISK_LT_10GIB
+}
+
+function classifyMemory(bytes) {
+  if (!Number.isFinite(bytes) || bytes < 0) return TOKEN.UNKNOWN
+  return bytes >= MEMORY_WATER_BYTES ? TOKEN.MEM_GE_16GIB : TOKEN.MEM_LT_16GIB
+}
+
+// #4695's template names factsProvider as a GitHub handle, so a handle is the
+// one non-token value this tool may echo. Anything that is not handle-shaped
+// is refused rather than printed — an operator who pastes a hostname or an
+// email address into the flag gets INVALID_FORMAT, not a leak.
+function classifyFactsProvider(raw) {
+  const trimmed = String(raw ?? '').trim()
+  if (trimmed === '') return TOKEN.UNSET
+  const bare = trimmed.startsWith('@') ? trimmed.slice(1) : trimmed
+  if (!/^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$/.test(bare)) {
+    return TOKEN.INVALID_FORMAT
+  }
+  return `@${bare}`
+}
+
+function yesNo(value) {
+  if (value === true) return TOKEN.YES
+  if (value === false) return TOKEN.NO
+  return TOKEN.UNKNOWN
+}
+
+function passFail(value) {
+  if (value === true) return TOKEN.PASS
+  if (value === false) return TOKEN.FAIL
+  return TOKEN.UNKNOWN
+}
+
+// ---------------------------------------------------------------------------
+// Default probes. Every one is read-only; each returns a plain observation and
+// classification happens above, so a probe can never invent a token.
+// ---------------------------------------------------------------------------
+function probeNodeMajor() {
+  return process.versions.node.split('.')[0]
+}
+
+// Windows PowerShell 5.1 and PowerShell 7 are separate executables and #4708
+// asks about both. `$PSVersionTable.PSVersion.Major` is a read of an
+// in-process variable; -NoProfile prevents any profile script from running.
+function probePowerShellMajor(executable) {
+  try {
+    const result = spawnSync(
+      executable,
+      ['-NoProfile', '-NonInteractive', '-Command', '$PSVersionTable.PSVersion.Major'],
+      { encoding: 'utf8', timeout: DEFAULT_TIMEOUT_MS, windowsHide: true },
+    )
+    if (result.error || result.status !== 0) return null
+    return Number.parseInt(String(result.stdout).trim(), 10)
+  } catch {
+    return null
+  }
+}
+
+// TCP connect + immediate destroy. No bytes are sent, so this cannot reach a
+// protocol handler, authenticate, or leave a session behind.
+function probeTcpReachable(host, port, timeoutMs = DEFAULT_TIMEOUT_MS) {
+  return new Promise((resolve) => {
+    let settled = false
+    const finish = (value) => {
+      if (settled) return
+      settled = true
+      try {
+        socket.destroy()
+      } catch {
+        // best effort
+      }
+      resolve(value)
+    }
+    const socket = net.connect({ host, port })
+    socket.setTimeout(timeoutMs)
+    socket.once('connect', () => finish(true))
+    socket.once('timeout', () => finish(false))
+    socket.once('error', () => finish(false))
+  })
+}
+
+// Loads `pg` if the host already has it (a deployed package does). Never
+// installs it — an absent driver is reported as a fact, not repaired.
+function loadPgClient() {
+  try {
+    const mod = require('pg')
+    return mod && mod.Client ? mod.Client : null
+  } catch {
+    return null
+  }
+}
+
+async function probePostgresCatalog(connectionString, timeoutMs = DEFAULT_TIMEOUT_MS) {
+  const Client = loadPgClient()
+  if (!Client) return { driverAvailable: false }
+  const client = new Client({
+    connectionString,
+    connectionTimeoutMillis: timeoutMs,
+    query_timeout: timeoutMs,
+  })
+  try {
+    await client.connect()
+    const result = await client.query(CATALOG_READ_SQL)
+    const row = result && result.rows && result.rows[0]
+    if (!row) return { connected: true, driverAvailable: true }
+    return {
+      canCreateDatabase: row.can_create_database === true,
+      canCreateRole: row.can_create_role === true,
+      connected: true,
+      driverAvailable: true,
+      serverVersionNum: row.server_version_num,
+    }
+  } catch {
+    return { connected: false, driverAvailable: true }
+  } finally {
+    try {
+      await client.end()
+    } catch {
+      // best effort
+    }
+  }
+}
+
+// Unauthenticated GET of the public health route. The body is never parsed,
+// stored, or echoed — only "did a 2xx come back".
+async function probeHealth(url, timeoutMs = DEFAULT_TIMEOUT_MS) {
+  try {
+    const response = await fetch(url, {
+      method: 'GET',
+      redirect: 'manual',
+      signal: AbortSignal.timeout(timeoutMs),
+    })
+    return response.status >= 200 && response.status < 300
+  } catch {
+    return null
+  }
+}
+
+function probeDiskFreeBytes(targetPath) {
+  try {
+    const stats = fs.statfsSync(targetPath)
+    return Number(stats.bavail) * Number(stats.bsize)
+  } catch {
+    return null
+  }
+}
+
+function probeMemory() {
+  return { freeBytes: os.freemem(), totalBytes: os.totalmem() }
+}
+
+const DEFAULT_PROBES = Object.freeze({
+  diskFreeBytes: probeDiskFreeBytes,
+  health: probeHealth,
+  memory: probeMemory,
+  nodeMajor: probeNodeMajor,
+  postgresCatalog: probePostgresCatalog,
+  powerShellMajor: probePowerShellMajor,
+  tcpReachable: probeTcpReachable,
+})
+
+// ---------------------------------------------------------------------------
+// Configuration. Inputs arrive as environment variables and are NEVER echoed;
+// only whether they were supplied ever reaches the report indirectly, through
+// the resulting UNKNOWN/determinate token.
+// ---------------------------------------------------------------------------
+const ENV_VAR = Object.freeze({
+  diskPath: 'LAB0_DISK_PATH',
+  factsProvider: 'LAB0_FACTS_PROVIDER',
+  healthUrl: 'LAB0_HEALTH_URL',
+  postgresUrl: 'LAB0_POSTGRES_URL',
+  probeHealth: 'LAB0_PROBE_HEALTH',
+  probePowerShell: 'LAB0_PROBE_POWERSHELL',
+})
+
+function readConfig(env) {
+  return Object.freeze({
+    diskPath: env[ENV_VAR.diskPath] || path.parse(process.cwd()).root || process.cwd(),
+    factsProviderRaw: env[ENV_VAR.factsProvider] || '',
+    healthProbeEnabled: env[ENV_VAR.probeHealth] !== '0',
+    healthUrl: env[ENV_VAR.healthUrl] || DEFAULT_HEALTH_URL,
+    postgresUrl: env[ENV_VAR.postgresUrl] || '',
+    powerShellProbeEnabled: env[ENV_VAR.probePowerShell] !== '0',
+  })
+}
+
+// A connection string is parsed only to obtain a host/port for the TCP probe.
+// Neither is returned to the caller and neither is ever emitted.
+function tcpTargetFromPostgresUrl(connectionString) {
+  try {
+    const parsed = new URL(connectionString)
+    const port = Number.parseInt(parsed.port || '5432', 10)
+    const host = parsed.hostname
+    if (!host || !Number.isInteger(port)) return null
+    return { host, port }
+  } catch {
+    return null
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Orchestration.
+// ---------------------------------------------------------------------------
+async function runInventory({ env = process.env, probes = DEFAULT_PROBES } = {}) {
+  const config = readConfig(env)
+  const p = { ...DEFAULT_PROBES, ...probes }
+
+  const nodeClass = classifyNodeMajor(p.nodeMajor())
+
+  let windowsPowerShellMajor = null
+  let pwshMajor = null
+  if (config.powerShellProbeEnabled) {
+    windowsPowerShellMajor = p.powerShellMajor('powershell')
+    pwshMajor = p.powerShellMajor('pwsh')
+  }
+
+  let postgresReachable = null
+  let postgres = { driverAvailable: false }
+  if (config.postgresUrl) {
+    const target = tcpTargetFromPostgresUrl(config.postgresUrl)
+    postgresReachable = target ? await p.tcpReachable(target.host, target.port) : null
+    postgres = await p.postgresCatalog(config.postgresUrl)
+    // A successful authenticated catalog read is stronger evidence of
+    // reachability than a bare TCP connect, so it can only upgrade the answer.
+    if (postgres.connected === true) postgresReachable = true
+  }
+
+  const postgresVersionClass = postgres.connected === true
+    ? classifyPostgresMajor(postgres.serverVersionNum)
+    : TOKEN.UNKNOWN
+
+  const isolatedDatabaseCapability = postgres.connected === true
+    && typeof postgres.canCreateDatabase === 'boolean'
+    ? postgres.canCreateDatabase
+    : null
+  const selectOnlyPrincipalCapability = postgres.connected === true
+    && typeof postgres.canCreateRole === 'boolean'
+    ? postgres.canCreateRole
+    : null
+
+  const runtimeHealthy = config.healthProbeEnabled ? await p.health(config.healthUrl) : null
+
+  const diskFreeClass = classifyDiskFree(p.diskFreeBytes(config.diskPath))
+  const memory = p.memory()
+  const memoryTotalClass = classifyMemory(memory.totalBytes)
+  const memoryFreeClass = classifyMemory(memory.freeBytes)
+
+  const fields = Object.freeze({
+    canCreateIsolatedTestDatabase: yesNo(isolatedDatabaseCapability),
+    canCreateSelectOnlyTestPrincipal: yesNo(selectOnlyPrincipalCapability),
+    diskFreeClass,
+    externalWrite: TOKEN.FALSE,
+    factsProvider: classifyFactsProvider(config.factsProviderRaw),
+    freeDiskAtLeast40GiB: diskFreeClass === TOKEN.UNKNOWN
+      ? TOKEN.UNKNOWN
+      : yesNo(diskFreeClass === TOKEN.DISK_GE_40GIB),
+    freeMemoryAtLeast16GiB: memoryFreeClass === TOKEN.UNKNOWN
+      ? TOKEN.UNKNOWN
+      : yesNo(memoryFreeClass === TOKEN.MEM_GE_16GIB),
+    memoryTotalClass,
+    metasheetRuntimeHealth: passFail(runtimeHealthy),
+    node20Available: yesNo(nodeClass === TOKEN.NODE20),
+    nodeMajorClass: nodeClass,
+    postgresDriverAvailable: yesNo(postgres.driverAvailable === true),
+    postgresServiceReachable: yesNo(postgresReachable),
+    postgresVersionClass,
+    powershell51Available: windowsPowerShellMajor === null
+      ? TOKEN.UNKNOWN
+      : yesNo(windowsPowerShellMajor === 5),
+    pwsh7Available: pwshMajor === null ? TOKEN.UNKNOWN : yesNo(pwshMajor >= 7),
+    selectOnlyPrincipalCapability: passFail(selectOnlyPrincipalCapability),
+    isolatedDatabaseCapability: passFail(isolatedDatabaseCapability),
+  })
+
+  const sixField = Object.freeze({
+    canCreateIsolatedTestDatabase: fields.canCreateIsolatedTestDatabase,
+    canCreateSelectOnlyTestPrincipal: fields.canCreateSelectOnlyTestPrincipal,
+    factsProvider: fields.factsProvider,
+    metasheetTestRuntimeAvailable: fields.metasheetRuntimeHealth === TOKEN.PASS
+      ? TOKEN.YES
+      : fields.metasheetRuntimeHealth === TOKEN.FAIL
+        ? TOKEN.NO
+        : TOKEN.UNKNOWN,
+    postgresMajorVersion: postgresMajorField(postgresVersionClass),
+    postgresServiceAvailable: fields.postgresServiceReachable,
+  })
+
+  // LAB-0 is COMPLETE only when every fact is determinate. An UNKNOWN is what
+  // burned the 2026-08-03 round-trip, so it is a blocking outcome here, not a
+  // footnote.
+  const blocking = SIX_FIELD_ORDER
+    .filter((name) => name !== 'factsProvider')
+    .some((name) => sixField[name] === TOKEN.UNKNOWN)
+  const providerMissing = sixField.factsProvider === TOKEN.UNSET
+    || sixField.factsProvider === TOKEN.INVALID_FORMAT
+  const lab0Status = blocking || providerMissing ? TOKEN.BLOCKED : TOKEN.COMPLETE
+
+  return Object.freeze({
+    config,
+    exitCode: lab0Status === TOKEN.COMPLETE ? 0 : 1,
+    fields,
+    lab0Status,
+    sixField,
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Report composition + self-scan.
+// ---------------------------------------------------------------------------
+const HOST_FIELD_ORDER = Object.freeze([
+  'nodeMajorClass',
+  'node20Available',
+  'powershell51Available',
+  'pwsh7Available',
+  'postgresDriverAvailable',
+  'postgresServiceReachable',
+  'postgresVersionClass',
+  'isolatedDatabaseCapability',
+  'selectOnlyPrincipalCapability',
+  'metasheetRuntimeHealth',
+  'diskFreeClass',
+  'freeDiskAtLeast40GiB',
+  'memoryTotalClass',
+  'freeMemoryAtLeast16GiB',
+  'externalWrite',
+])
+
+function assertClosedSet(fields) {
+  for (const [name, value] of Object.entries(fields)) {
+    if (name === 'factsProvider') continue
+    if (!CLOSED_TOKENS.has(value)) {
+      throw new Error(`LAB0_UNREGISTERED_TOKEN: ${name}`)
+    }
+  }
+}
+
+// Composed-output self-scan: nothing the operator configured may appear in the
+// report. Cheap, and it converts "we were careful" into "it cannot ship".
+function assertNoConfiguredInputLeaked(report, config) {
+  const sentinels = [config.postgresUrl, config.healthUrl, config.diskPath]
+  for (const sentinel of sentinels) {
+    if (typeof sentinel !== 'string' || sentinel.length < 4) continue
+    if (report.includes(sentinel)) {
+      throw new Error('LAB0_INPUT_LEAKED_INTO_REPORT')
+    }
+  }
+  return report
+}
+
+function formatReport(result) {
+  assertClosedSet(result.fields)
+  const lines = [
+    '=== LAB-0 host inventory (DRAFT — non-mutating, values-free) ===',
+    'inventoryTool=stock-preparation-lab0-inventory/v1-draft',
+    'mutationsPerformed=0',
+    'businessRowsRead=0',
+  ]
+  for (const name of HOST_FIELD_ORDER) {
+    lines.push(`${name}=${result.fields[name]}`)
+  }
+  lines.push('')
+  lines.push('=== #4695 six-field PostgreSQL readiness reply (paste verbatim) ===')
+  for (const name of SIX_FIELD_ORDER) {
+    lines.push(`${name}=${result.sixField[name]}`)
+  }
+  lines.push('')
+  lines.push(`lab0Status=${result.lab0Status}`)
+  return assertNoConfiguredInputLeaked(lines.join('\n'), result.config)
+}
+
+function buildOperatorGuidance() {
+  const pad = (text) => `  ${text.padEnd(26, ' ')}`
+  const cont = ' '.repeat(28)
+  return [
+    '=== How to run (values-free; nothing below installs, creates, or deploys) ===',
+    'All inputs are environment variables and none of them is ever printed.',
+    '',
+    `${pad(ENV_VAR.postgresUrl)}connection string for the candidate PostgreSQL`,
+    `${cont}service, authenticating as the account that would`,
+    `${cont}later create the isolated database and the`,
+    `${cont}SELECT-only principal. Unset -> the three`,
+    `${cont}PostgreSQL fields report UNKNOWN.`,
+    `${pad(ENV_VAR.healthUrl)}MetaSheet health route (default: the on-prem`,
+    `${cont}template port on loopback).`,
+    `${pad(ENV_VAR.diskPath)}filesystem to measure (default: the drive root).`,
+    `${pad(ENV_VAR.factsProvider)}the GitHub handle #4695 asks for in factsProvider.`,
+    `${pad(`${ENV_VAR.probeHealth}=0`)}skip the health probe (reports UNKNOWN).`,
+    `${pad(`${ENV_VAR.probePowerShell}=0`)}skip the PowerShell probes (report UNKNOWN).`,
+    '',
+    'The only SQL this tool executes is one read-only catalog SELECT against',
+    'pg_roles for the connected session\'s own role. It creates no database, no',
+    'role, and no grant; those remain a later, separately authorized step.',
+    '',
+    'lab0Status=BLOCKED means at least one fact is still UNKNOWN (or factsProvider',
+    'was not supplied) — report it as-is; do not fill a gap by hand.',
+  ].join('\n')
+}
+
+const isMain = (() => {
+  try {
+    return path.resolve(process.argv[1] || '') === fileURLToPath(import.meta.url)
+  } catch {
+    return false
+  }
+})()
+
+async function main() {
+  const result = await runInventory({ env: process.env })
+  process.stdout.write(formatReport(result))
+  process.stdout.write('\n\n')
+  process.stdout.write(buildOperatorGuidance())
+  process.stdout.write('\n')
+  process.exitCode = result.exitCode
+}
+
+if (isMain) {
+  await main()
+}
+
+export {
+  CATALOG_READ_SQL,
+  CLOSED_TOKENS,
+  ENV_VAR,
+  HOST_FIELD_ORDER,
+  SIX_FIELD_ORDER,
+  TOKEN,
+  buildOperatorGuidance,
+  classifyDiskFree,
+  classifyFactsProvider,
+  classifyMemory,
+  classifyNodeMajor,
+  classifyPostgresMajor,
+  formatReport,
+  postgresMajorField,
+  runInventory,
+}

--- a/scripts/ops/stock-preparation-lab0-inventory.test.mjs
+++ b/scripts/ops/stock-preparation-lab0-inventory.test.mjs
@@ -1,0 +1,424 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { execFileSync } from 'node:child_process'
+import fs from 'node:fs'
+import os from 'node:os'
+import { fileURLToPath } from 'node:url'
+
+// Contract test for the LAB-0 host inventory DRAFT.
+//
+// Hermetic by construction: every probe is injected, so no test below opens a
+// socket, spawns a shell, reaches a database, or touches a host. The one
+// subprocess case runs the script with both optional probes disabled and no
+// connection string, so it too performs no I/O beyond reading local memory and
+// a temp directory's filesystem stats.
+//
+// The assertions are grouped by the three claims this tool has to earn:
+//   1. classifiers are exact at their boundaries (a class that is wrong by one
+//      major version or one byte is worse than UNKNOWN, because it reads as a
+//      fact);
+//   2. the emitted block is values-free — the discriminating case feeds
+//      credential-bearing sentinels through the config and proves none reaches
+//      stdout;
+//   3. the tool is non-mutating — pinned against the source itself, since
+//      "we did not write anything this time" is not a property a behavioural
+//      test can establish.
+
+import {
+  CATALOG_READ_SQL,
+  ENV_VAR,
+  SIX_FIELD_ORDER,
+  TOKEN,
+  classifyDiskFree,
+  classifyFactsProvider,
+  classifyMemory,
+  classifyNodeMajor,
+  classifyPostgresMajor,
+  formatReport,
+  postgresMajorField,
+  runInventory,
+} from './stock-preparation-lab0-inventory.mjs'
+
+const SCRIPT_PATH = fileURLToPath(new URL('./stock-preparation-lab0-inventory.mjs', import.meta.url))
+const SOURCE = fs.readFileSync(SCRIPT_PATH, 'utf8')
+const GIB = 1024 * 1024 * 1024
+
+// Credential-bearing inputs the tool is handed and must never echo.
+const SENTINEL_PG_URL = 'postgres://SENTINELUSER:SENTINELSECRET@SENTINELHOST.invalid:5432/SENTINELDB'
+const SENTINEL_HEALTH_URL = 'http://SENTINELRUNTIME.invalid:9901/api/health'
+const SENTINELS = ['SENTINELUSER', 'SENTINELSECRET', 'SENTINELHOST', 'SENTINELDB', 'SENTINELRUNTIME']
+
+function goodProbes(overrides = {}) {
+  return {
+    diskFreeBytes: () => 64 * GIB,
+    health: async () => true,
+    memory: () => ({ freeBytes: 24 * GIB, totalBytes: 64 * GIB }),
+    nodeMajor: () => '20',
+    postgresCatalog: async () => ({
+      canCreateDatabase: true,
+      canCreateRole: true,
+      connected: true,
+      driverAvailable: true,
+      serverVersionNum: '170002',
+    }),
+    powerShellMajor: (executable) => (executable === 'powershell' ? 5 : 7),
+    tcpReachable: async () => true,
+    ...overrides,
+  }
+}
+
+function goodEnv(overrides = {}) {
+  return {
+    [ENV_VAR.diskPath]: os.tmpdir(),
+    [ENV_VAR.factsProvider]: '@lab0-operator',
+    [ENV_VAR.healthUrl]: SENTINEL_HEALTH_URL,
+    [ENV_VAR.postgresUrl]: SENTINEL_PG_URL,
+    ...overrides,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 1. Classifier boundaries.
+// ---------------------------------------------------------------------------
+test('classifyPostgresMajor: 15/16/17 boundaries are exact, everything else is PG_OTHER', () => {
+  assert.equal(classifyPostgresMajor('150000'), TOKEN.PG15)
+  assert.equal(classifyPostgresMajor('159999'), TOKEN.PG15)
+  assert.equal(classifyPostgresMajor('160000'), TOKEN.PG16)
+  assert.equal(classifyPostgresMajor('170002'), TOKEN.PG17)
+  assert.equal(classifyPostgresMajor('179999'), TOKEN.PG17)
+  assert.equal(classifyPostgresMajor('180000'), TOKEN.PG_OTHER)
+  assert.equal(classifyPostgresMajor('140012'), TOKEN.PG_OTHER)
+})
+
+test('classifyPostgresMajor: absent/garbage input is UNKNOWN, never a version', () => {
+  for (const bad of [null, undefined, '', 'seventeen', '0', '-1', {}]) {
+    assert.equal(classifyPostgresMajor(bad), TOKEN.UNKNOWN, `expected UNKNOWN for ${String(bad)}`)
+  }
+})
+
+test('postgresMajorField projects the class back onto the six-field template vocabulary', () => {
+  assert.equal(postgresMajorField(TOKEN.PG15), '15')
+  assert.equal(postgresMajorField(TOKEN.PG16), '16')
+  assert.equal(postgresMajorField(TOKEN.PG17), '17')
+  assert.equal(postgresMajorField(TOKEN.PG_OTHER), TOKEN.OTHER)
+  assert.equal(postgresMajorField(TOKEN.UNKNOWN), TOKEN.UNKNOWN)
+})
+
+test('classifyDiskFree: 40 GiB and 10 GiB water marks are inclusive lower bounds', () => {
+  assert.equal(classifyDiskFree(40 * GIB), TOKEN.DISK_GE_40GIB)
+  assert.equal(classifyDiskFree(40 * GIB - 1), TOKEN.DISK_10_TO_40GIB)
+  assert.equal(classifyDiskFree(10 * GIB), TOKEN.DISK_10_TO_40GIB)
+  assert.equal(classifyDiskFree(10 * GIB - 1), TOKEN.DISK_LT_10GIB)
+  assert.equal(classifyDiskFree(null), TOKEN.UNKNOWN)
+  assert.equal(classifyDiskFree(-1), TOKEN.UNKNOWN)
+})
+
+test('classifyMemory: 16 GiB is an inclusive lower bound', () => {
+  assert.equal(classifyMemory(16 * GIB), TOKEN.MEM_GE_16GIB)
+  assert.equal(classifyMemory(16 * GIB - 1), TOKEN.MEM_LT_16GIB)
+  assert.equal(classifyMemory(null), TOKEN.UNKNOWN)
+})
+
+test('classifyNodeMajor: only major 20 answers YES to node20Available', () => {
+  assert.equal(classifyNodeMajor('20'), TOKEN.NODE20)
+  assert.equal(classifyNodeMajor('22'), TOKEN.NODE22)
+  assert.equal(classifyNodeMajor('18'), TOKEN.NODE_OTHER)
+  assert.equal(classifyNodeMajor('x'), TOKEN.UNKNOWN)
+})
+
+test('classifyFactsProvider: handle shapes accepted, anything else refused rather than echoed', () => {
+  assert.equal(classifyFactsProvider('@lab0-operator'), '@lab0-operator')
+  assert.equal(classifyFactsProvider('lab0-operator'), '@lab0-operator')
+  assert.equal(classifyFactsProvider('  @lab0-operator  '), '@lab0-operator')
+  assert.equal(classifyFactsProvider(''), TOKEN.UNSET)
+  assert.equal(classifyFactsProvider(undefined), TOKEN.UNSET)
+  // A pasted hostname / email / connection string must not be printed back.
+  assert.equal(classifyFactsProvider('operator@example.com'), TOKEN.INVALID_FORMAT)
+  assert.equal(classifyFactsProvider('db.internal.example'), TOKEN.INVALID_FORMAT)
+  assert.equal(classifyFactsProvider('a'.repeat(40)), TOKEN.INVALID_FORMAT)
+})
+
+// ---------------------------------------------------------------------------
+// 2. Orchestration outcomes.
+// ---------------------------------------------------------------------------
+test('fully-known host: every six-field value is determinate, lab0Status=COMPLETE, exit 0', async () => {
+  const result = await runInventory({ env: goodEnv(), probes: goodProbes() })
+  assert.equal(result.lab0Status, TOKEN.COMPLETE)
+  assert.equal(result.exitCode, 0)
+  assert.deepEqual(result.sixField, {
+    canCreateIsolatedTestDatabase: TOKEN.YES,
+    canCreateSelectOnlyTestPrincipal: TOKEN.YES,
+    factsProvider: '@lab0-operator',
+    metasheetTestRuntimeAvailable: TOKEN.YES,
+    postgresMajorVersion: '17',
+    postgresServiceAvailable: TOKEN.YES,
+  })
+  assert.equal(result.fields.node20Available, TOKEN.YES)
+  assert.equal(result.fields.powershell51Available, TOKEN.YES)
+  assert.equal(result.fields.pwsh7Available, TOKEN.YES)
+  assert.equal(result.fields.diskFreeClass, TOKEN.DISK_GE_40GIB)
+  assert.equal(result.fields.freeDiskAtLeast40GiB, TOKEN.YES)
+  assert.equal(result.fields.externalWrite, 'false')
+})
+
+test('the exact 2026-08-03 host shape reproduces that reply and BLOCKS on it', async () => {
+  // Runtime down, PostgreSQL up and major 17, admin capabilities unknowable
+  // because the catalog read could not be performed. This is the shape that
+  // cost issue #4695 a full owner<->operator round-trip.
+  const result = await runInventory({
+    env: goodEnv(),
+    probes: goodProbes({
+      health: async () => null,
+      postgresCatalog: async () => ({ connected: false, driverAvailable: false }),
+      tcpReachable: async () => true,
+    }),
+  })
+  assert.equal(result.sixField.metasheetTestRuntimeAvailable, TOKEN.UNKNOWN)
+  assert.equal(result.sixField.postgresServiceAvailable, TOKEN.YES)
+  assert.equal(result.sixField.postgresMajorVersion, TOKEN.UNKNOWN)
+  assert.equal(result.sixField.canCreateIsolatedTestDatabase, TOKEN.UNKNOWN)
+  assert.equal(result.sixField.canCreateSelectOnlyTestPrincipal, TOKEN.UNKNOWN)
+  assert.equal(result.fields.postgresDriverAvailable, TOKEN.NO)
+  assert.equal(result.lab0Status, TOKEN.BLOCKED)
+  assert.equal(result.exitCode, 1)
+})
+
+test('health FAIL (reachable but non-2xx) is NO, not UNKNOWN — the two are different facts', async () => {
+  const result = await runInventory({
+    env: goodEnv(),
+    probes: goodProbes({ health: async () => false }),
+  })
+  assert.equal(result.fields.metasheetRuntimeHealth, TOKEN.FAIL)
+  assert.equal(result.sixField.metasheetTestRuntimeAvailable, TOKEN.NO)
+  // lab0Status describes whether the INVENTORY is complete, not whether the
+  // host is ready. A determinate NO is a complete inventory; #4695's readiness
+  // verdict is computed from the block, not by this tool.
+  assert.equal(result.lab0Status, TOKEN.COMPLETE)
+})
+
+test('a connected session without CREATEDB/CREATEROLE answers NO, not UNKNOWN', async () => {
+  const result = await runInventory({
+    env: goodEnv(),
+    probes: goodProbes({
+      postgresCatalog: async () => ({
+        canCreateDatabase: false,
+        canCreateRole: false,
+        connected: true,
+        driverAvailable: true,
+        serverVersionNum: '160004',
+      }),
+    }),
+  })
+  assert.equal(result.sixField.canCreateIsolatedTestDatabase, TOKEN.NO)
+  assert.equal(result.sixField.canCreateSelectOnlyTestPrincipal, TOKEN.NO)
+  assert.equal(result.sixField.postgresMajorVersion, '16')
+  // Determinate NOs are a COMPLETE inventory: the machine is answerable and
+  // simply says no. Only UNKNOWN blocks.
+  assert.equal(result.lab0Status, TOKEN.COMPLETE)
+})
+
+test('no connection string configured: PostgreSQL fields are UNKNOWN and nothing is probed', async () => {
+  let tcpCalls = 0
+  let catalogCalls = 0
+  const env = goodEnv()
+  delete env[ENV_VAR.postgresUrl]
+  const result = await runInventory({
+    env,
+    probes: goodProbes({
+      postgresCatalog: async () => {
+        catalogCalls += 1
+        return { connected: true, driverAvailable: true, serverVersionNum: '170002' }
+      },
+      tcpReachable: async () => {
+        tcpCalls += 1
+        return true
+      },
+    }),
+  })
+  assert.equal(tcpCalls, 0)
+  assert.equal(catalogCalls, 0)
+  assert.equal(result.sixField.postgresServiceAvailable, TOKEN.UNKNOWN)
+  assert.equal(result.sixField.postgresMajorVersion, TOKEN.UNKNOWN)
+  assert.equal(result.lab0Status, TOKEN.BLOCKED)
+})
+
+test('a missing or malformed factsProvider blocks instead of emitting a bare template', async () => {
+  const missing = await runInventory({
+    env: goodEnv({ [ENV_VAR.factsProvider]: '' }),
+    probes: goodProbes(),
+  })
+  assert.equal(missing.sixField.factsProvider, TOKEN.UNSET)
+  assert.equal(missing.lab0Status, TOKEN.BLOCKED)
+
+  const malformed = await runInventory({
+    env: goodEnv({ [ENV_VAR.factsProvider]: 'ops@corp.example' }),
+    probes: goodProbes(),
+  })
+  assert.equal(malformed.sixField.factsProvider, TOKEN.INVALID_FORMAT)
+  assert.equal(malformed.lab0Status, TOKEN.BLOCKED)
+})
+
+// ---------------------------------------------------------------------------
+// 3. Values-free output.
+// ---------------------------------------------------------------------------
+test('report contains none of the credential-bearing inputs it was handed', async () => {
+  const result = await runInventory({ env: goodEnv(), probes: goodProbes() })
+  const report = formatReport(result)
+  for (const sentinel of SENTINELS) {
+    assert.ok(!report.includes(sentinel), `report leaked sentinel ${sentinel}`)
+  }
+  assert.ok(!report.includes('5432'))
+  assert.ok(!report.includes('9901'))
+  assert.ok(!report.includes(os.tmpdir()))
+})
+
+test('every emitted value is a closed token (or the shape-validated handle)', async () => {
+  const result = await runInventory({ env: goodEnv(), probes: goodProbes() })
+  const allowed = new Set([
+    ...Object.values(TOKEN),
+    '15', '16', '17',
+    '@lab0-operator',
+  ])
+  for (const line of formatReport(result).split('\n')) {
+    if (!line.includes('=') || line.startsWith('===')) continue
+    const [name, value] = [line.slice(0, line.indexOf('=')), line.slice(line.indexOf('=') + 1)]
+    if (name === 'inventoryTool' || name === 'mutationsPerformed' || name === 'businessRowsRead') continue
+    assert.ok(allowed.has(value), `field ${name} emitted unregistered value ${value}`)
+  }
+})
+
+test('the six-field block matches #4695 comment 5161121847 field-for-field, in order', async () => {
+  assert.deepEqual(SIX_FIELD_ORDER, [
+    'metasheetTestRuntimeAvailable',
+    'postgresServiceAvailable',
+    'postgresMajorVersion',
+    'canCreateIsolatedTestDatabase',
+    'canCreateSelectOnlyTestPrincipal',
+    'factsProvider',
+  ])
+  const result = await runInventory({ env: goodEnv(), probes: goodProbes() })
+  const report = formatReport(result)
+  const block = report.slice(report.indexOf('=== #4695'))
+  const emitted = block
+    .split('\n')
+    .filter((line) => line.includes('=') && !line.startsWith('===') && !line.startsWith('lab0Status'))
+    .map((line) => line.slice(0, line.indexOf('=')))
+  assert.deepEqual(emitted, SIX_FIELD_ORDER)
+})
+
+test('formatReport fails closed on an unregistered token AND on a leaked input', () => {
+  // Two discriminating negative controls. Without them, the leak assertions
+  // above would still pass for a tool whose guards had been deleted.
+  const base = {
+    config: { diskPath: os.tmpdir(), healthUrl: SENTINEL_HEALTH_URL, postgresUrl: SENTINEL_PG_URL },
+    exitCode: 0,
+    lab0Status: TOKEN.COMPLETE,
+  }
+
+  // (a) a status field carrying free text is refused by the closed-set guard.
+  assert.throws(
+    () => formatReport({
+      ...base,
+      fields: { externalWrite: TOKEN.FALSE, nodeMajorClass: 'v20.11.1' },
+      sixField: {},
+    }),
+    /LAB0_UNREGISTERED_TOKEN/,
+  )
+
+  // (b) factsProvider is exempt from the closed set by design, so the composed
+  // self-scan is the only thing standing between it and a leaked URL.
+  assert.throws(
+    () => formatReport({
+      ...base,
+      fields: { externalWrite: TOKEN.FALSE, nodeMajorClass: TOKEN.NODE20 },
+      sixField: { factsProvider: SENTINEL_HEALTH_URL },
+    }),
+    /LAB0_INPUT_LEAKED_INTO_REPORT/,
+  )
+})
+
+// ---------------------------------------------------------------------------
+// 4. Non-mutation, pinned against the source.
+// ---------------------------------------------------------------------------
+test('exactly one SQL statement exists and it is a read-only catalog SELECT', () => {
+  assert.ok(CATALOG_READ_SQL.startsWith('SELECT '))
+  for (const verb of [
+    'INSERT', 'UPDATE', 'DELETE', 'CREATE', 'DROP', 'ALTER', 'GRANT',
+    'REVOKE', 'TRUNCATE', 'COPY', 'SET ', 'CALL ', 'DO ',
+  ]) {
+    assert.ok(!CATALOG_READ_SQL.includes(verb), `catalog SQL must not contain ${verb}`)
+  }
+  // No business relation: the only relation referenced is the system view.
+  assert.ok(CATALOG_READ_SQL.includes('FROM pg_roles'))
+  const queryCalls = SOURCE.split('client.query(').length - 1
+  assert.equal(queryCalls, 1, 'exactly one query call site is allowed')
+  assert.ok(SOURCE.includes('client.query(CATALOG_READ_SQL)'))
+})
+
+test('no filesystem write API and no package-installing command appear in the source', () => {
+  for (const api of [
+    'writeFileSync', 'appendFileSync', 'mkdirSync', 'rmSync', 'unlinkSync',
+    'mkdtempSync', 'createWriteStream', 'copyFileSync', 'chmodSync',
+  ]) {
+    assert.ok(!SOURCE.includes(api), `source must not use ${api}`)
+  }
+  for (const command of ['npm ', 'pnpm ', 'yarn ', 'Invoke-WebRequest', 'curl ', 'winget', 'choco']) {
+    assert.ok(!SOURCE.includes(command), `source must not shell out to ${command.trim()}`)
+  }
+})
+
+test('the only child process is the read-only PowerShell version probe', () => {
+  const spawnCalls = SOURCE.split('spawnSync(').length - 1
+  assert.equal(spawnCalls, 1)
+  assert.ok(SOURCE.includes("'-NoProfile', '-NonInteractive', '-Command', '$PSVersionTable.PSVersion.Major'"))
+  for (const api of ['spawn(', 'exec(', 'execSync(', 'execFile(', 'fork(']) {
+    assert.ok(!SOURCE.includes(api), `source must not use ${api}`)
+  }
+})
+
+test('the only HTTP request is an unauthenticated GET', () => {
+  const fetchCalls = SOURCE.split('fetch(').length - 1
+  assert.equal(fetchCalls, 1)
+  assert.ok(SOURCE.includes("method: 'GET'"))
+  for (const method of ["'POST'", "'PUT'", "'PATCH'", "'DELETE'"]) {
+    assert.ok(!SOURCE.includes(method), `source must not issue ${method}`)
+  }
+  // No credential is ever attached to the probe.
+  for (const header of ['Authorization', 'Bearer', 'METASHEET_ADMIN_TOKEN', 'Cookie']) {
+    assert.ok(!SOURCE.includes(header), `source must not attach ${header}`)
+  }
+})
+
+// ---------------------------------------------------------------------------
+// 5. End-to-end, still hermetic: both optional probes off, no connection string.
+// ---------------------------------------------------------------------------
+test('CLI run with probes disabled emits a BLOCKED report and exit code 1', () => {
+  const env = {
+    ...process.env,
+    [ENV_VAR.diskPath]: os.tmpdir(),
+    [ENV_VAR.factsProvider]: '@lab0-operator',
+    [ENV_VAR.probeHealth]: '0',
+    [ENV_VAR.probePowerShell]: '0',
+  }
+  delete env[ENV_VAR.postgresUrl]
+  delete env[ENV_VAR.healthUrl]
+
+  let stdout = ''
+  let status = 0
+  try {
+    stdout = execFileSync(process.execPath, [SCRIPT_PATH], { encoding: 'utf8', env })
+  } catch (error) {
+    stdout = String(error.stdout || '')
+    status = error.status
+  }
+  assert.equal(status, 1)
+  assert.ok(stdout.includes('lab0Status=BLOCKED'))
+  assert.ok(stdout.includes('metasheetTestRuntimeAvailable=UNKNOWN'))
+  assert.ok(stdout.includes('postgresServiceAvailable=UNKNOWN'))
+  assert.ok(stdout.includes('factsProvider=@lab0-operator'))
+  assert.ok(stdout.includes('mutationsPerformed=0'))
+  assert.ok(stdout.includes('businessRowsRead=0'))
+  // A disabled probe must report UNKNOWN, never a fabricated NO.
+  assert.ok(stdout.includes('powershell51Available=UNKNOWN'))
+  assert.ok(!stdout.includes(os.tmpdir()))
+})


### PR DESCRIPTION
## Summary

Draft acceleration for the `main → Windows on-prem test host` path, plus a **non-mutating** LAB-0 inventory tool.

**Doc** `docs/development/onprem-deploy-path-acceleration-20260818.md`
- Current path: 12 steps, ~5 min total CI wall time, but **8–12 owner/operator comment round-trips**; step 9 (preflight) is three separate manual surfaces (LAB-0 block #4708, six-field PG reply #4695, offline operator preflight), and the 2026-08-03 reply burned one cycle on two `UNKNOWN` fields that a read-only `pg_roles` query answers instantly.
- Failure history: the five sequential #4695 blockers classified; which a pre-deploy CI gate would have caught.
- PG17: what is validated today (both PG matrices already include 17 — the 2026-08-02 checklist Part G item 2 is stale), and two needs-verification findings: (a) neither PG matrix workflow sets `PGOPTIONS` / `metasheet.sealed_export_*_role`, so migrations 073/074/075 take their latent-NOTICE branch in CI; (b) PG16+ `createrole_self_grant` behaviour can trip the zero-`pg_auth_members` predicate with no diagnostic.
- Top-5 accelerations ranked with effort/risk.

**Tool** `scripts/ops/stock-preparation-lab0-inventory.mjs` (+22 hermetic tests, + path-filtered contract workflow on ubuntu **and windows**)
- Emits the exact six-field #4695 reply and the LAB-0 environment facts from read-only probes, values-free (closed token sets; PG version → `PG15/PG16/PG17/PG_OTHER`, disk → class, health → PASS/FAIL).
- Never installs, downloads, creates DB/principal, deploys, touches a flag, reads a business row, or writes anything but stdout. The only SQL is one catalog `SELECT` against `pg_roles` / `current_setting` — asserted by the contract test to be the only SQL string in the file.
- **DRAFT**: not wired into any runbook, not authorized to run against a customer machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
