### PR TITLE
ci(stock-prep): e2e lane lab_mode — package-mode walk + post-ON flag-OFF restoration arm (#4708 items 1 & 8)

### DIFF
--- a/.github/workflows/stock-preparation-e2e-functional-smoke.yml
+++ b/.github/workflows/stock-preparation-e2e-functional-smoke.yml
@@ -40,8 +40,27 @@ name: Stock Preparation E2E Functional Smoke
 # (MULTITABLE_STOCK_PREP_SQLSERVER_SEALED_SNAPSHOT_ENABLED) is set ONLY inside this job's own spawned
 # core-backend server-process environment for the duration of one arm — never in a committed file, never
 # as a repository/environment variable default, and the process is always restarted flag-OFF afterward.
+# Under `lab_mode` that last clause stops being a promise and becomes an assertion: see the post-window
+# arm described under LAB MODE below.
 #
-# Six jobs:
+# LAB MODE (S10, gated by the `lab_mode` input below; default 'false' = this lane is UNCHANGED, exactly
+# as with `s6a_row_count` above — same jobs, same arms, same claims, no extra server restart). Dispatching
+# with `lab_mode: true` adds three things, all aimed at producing #4708's functional evidence list in ONE
+# dispatch rather than across a machine session:
+#   1. it DEFAULTS `s6a_row_count` to the product's own declared bound (24999) — the dispatcher opting
+#      into the lab walk should not also have to remember a magic number. An explicitly supplied
+#      `s6a_row_count` still wins; lab mode only supplies the default.
+#   2. it runs the `functional-smoke-package` job below — the SAME primary 3-row walk, driven against an
+#      on-prem package BUILT AND EXTRACTED IN THE JOB rather than against the repo tree (#4708 item 1).
+#   3. it runs a post-ON flag-OFF RESTORATION arm inside the primary walk (#4708 item 8): after the
+#      flag-ON window closes, the server is restarted with the flag absent and the SAME three-part gate
+#      the pre-window arm asserts is re-asserted (health capability false + always-registered sibling
+#      route 200 + S6-A route 404), the checkout is scanned for any committed file that assigns the flag
+#      an enabling value, and the artifact-root capture directory is removed and proven gone.
+# What lab mode does NOT change: no schedule, no push trigger, no customer data, no external write, no
+# release, no flag default, and `permissions: contents: read` still makes "never publishes" structural.
+#
+# Seven jobs:
 #   contract            — pull_request only: syntax-checks the harness scripts (no server, no DB, no
 #                         secrets). Exists ONLY so GitHub registers this workflow_dispatch workflow while
 #                         it lives on a feature branch — GitHub will not let a brand-new workflow_dispatch
@@ -60,11 +79,29 @@ name: Stock Preparation E2E Functional Smoke
 #                         values-free result block — never as PASS — and the job goes red if any check
 #                         that DID run failed. Publishes its own row count/duration/roll-up outcome, plus
 #                         the product's own declared row-count bound, as job outputs for the scale-slope
-#                         job below.
+#                         job below. Under `lab_mode` it ALSO runs the post-ON flag-OFF restoration arm
+#                         (see LAB MODE above); at the default input it does not, and its workload is
+#                         byte-for-byte what it has always been.
+#   functional-smoke-package — the SAME primary arm, walkMode=package, gated to run ONLY under
+#                         `lab_mode` (default input: SKIPPED, never reported as a pass). Builds an on-prem
+#                         package from THIS commit in-job (the same INSTALL_DEPS=0/BUILD_WEB=0/
+#                         BUILD_BACKEND=0 invocation stock-prep-main-package-verify.yml and
+#                         stock-prep-staging-window-rehearsal.yml use), runs the existing five-check
+#                         verifier over it, extracts it, installs the package's OWN pinned dependencies
+#                         with --frozen-lockfile, applies migrations with the PACKAGE's own compiled
+#                         runner (packages/core-backend/dist/src/db/migrate.js), and then drives the
+#                         identical 3-row walk against `node packages/core-backend/dist/src/index.js`
+#                         with the package root as cwd. The harness is the same file, the assertions are
+#                         the same assertions; only the server under test moves. Emits walkMode=package
+#                         and packageTgzSha256 (a digest — values-free by this repo's convention) so the
+#                         evidence names which artifact it drove. This closes #4708 item 1's "the walk
+#                         runs from the repo tree" caveat on a LINUX runner; it establishes nothing about
+#                         a Windows-host installer, which remains machine-only.
 #   scale-midtier        — the mid-tier arm (E2E_S6A_ARM=midtier), its OWN Postgres + SQL Server, gated to
-#                         run ONLY when `s6a_row_count` requests scale (default input: this job is
-#                         SKIPPED, never reported as a pass). Publishes its own row count/duration/roll-up
-#                         outcome as job outputs.
+#                         run ONLY when scale is requested — i.e. `s6a_row_count` is set to something
+#                         other than the default, OR `lab_mode` is true (which defaults that row count to
+#                         24999). At the default input this job is SKIPPED, never reported as a pass.
+#                         Publishes its own row count/duration/roll-up outcome as job outputs.
 #   scale-rejection       — the rejection arm (E2E_S6A_ARM=rejection) at the product's declared bound + 1,
 #                         its OWN Postgres + SQL Server, gated identically to scale-midtier. Publishes its
 #                         own row count/duration/roll-up outcome as job outputs.
@@ -102,10 +139,23 @@ on:
         description: >-
           S6-A fixture row count. Default 3 = today's behaviour, no scale legs. Any other value (e.g.
           2500) ALSO runs a mid-tier calibration walk at that row count plus a fixed rejection arm at the
-          product's declared bound (24999) + 1 — see the SCALE paragraph above.
+          product's declared bound (24999) + 1 — see the SCALE paragraph above. Left at 3 while
+          lab_mode=true, it is DEFAULTED to 24999 (an explicit value here always wins).
         required: false
         default: '3'
         type: string
+      lab_mode:
+        description: >-
+          Lab lane. 'false' (default) = this workflow is unchanged in every respect. 'true' = default
+          s6a_row_count to 24999, add the package-mode walk job, and run the post-ON flag-OFF restoration
+          arm — see the LAB MODE paragraph above. Still dispatch-only, still synthetic data only, still
+          no external write, still no release.
+        required: false
+        default: 'false'
+        type: choice
+        options:
+          - 'false'
+          - 'true'
 
 permissions:
   contents: read
@@ -262,7 +312,17 @@ jobs:
           # runs the primary arm — E2E_S6A_ARM is set explicitly (not left to the script's own default)
           # so that is true by construction, not by coincidence of an unset env var.
           E2E_S6A_ARM: primary
-          E2E_S6A_ROW_COUNT: ${{ github.event.inputs.s6a_row_count || '3' }}
+          # S10 effective row count. Identical to `${{ github.event.inputs.s6a_row_count || '3' }}` in
+          # every case EXCEPT `lab_mode=true` with the row count left at its default, where it becomes the
+          # product's declared bound. This job's own walk is ALWAYS 3 rows regardless (the harness's
+          # primary arm hardcodes that); the value only feeds the harness's scale-requested reasoning, so
+          # passing the effective value keeps s6aMidTierReason/s6aRejectionReason honest about whether the
+          # dedicated scale jobs were expected to run.
+          E2E_S6A_ROW_COUNT: ${{ (github.event.inputs.lab_mode == 'true' && (github.event.inputs.s6a_row_count == '' || github.event.inputs.s6a_row_count == '3')) && '24999' || (github.event.inputs.s6a_row_count || '3') }}
+          # S10: enables the post-ON flag-OFF restoration arm INSIDE this job (an extra flag-OFF server
+          # restart after the flag-ON window, plus the committed-flag scan and the capture-directory
+          # cleanup assertion). 'false' — the default — leaves this job's phase list exactly as it was.
+          E2E_LAB_MODE: ${{ github.event.inputs.lab_mode || 'false' }}
         run: node scripts/ops/stock-preparation-e2e-functional-smoke.mjs
 
       - name: Write step summary
@@ -320,17 +380,249 @@ jobs:
           if-no-files-found: warn
           retention-days: 14
 
+  functional-smoke-package:
+    name: containerized functional smoke — PACKAGE mode (identical walk, built+extracted in-job)
+    # Gated to lab mode only. At the default input this job is SKIPPED, never reported as a pass — the
+    # same discipline the scale jobs follow, and the reason the default-input path is unchanged.
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.lab_mode == 'true'
+    needs: contract
+    runs-on: ubuntu-latest
+    # functional-smoke's 45m plus the measured package build/verify/extract/in-package-install cost
+    # (~4 min in stock-prep-main-package-verify.yml, plus a web+backend dist build this lane does not
+    # otherwise need). Comfortable headroom, not a claim it always needs this long.
+    timeout-minutes: 75
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: metasheet
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
+      mssql:
+        image: mcr.microsoft.com/mssql/server:2022-latest
+        env:
+          ACCEPT_EULA: 'Y'
+          # Ephemeral, throwaway container password (destroyed with the job) — not a real credential.
+          MSSQL_SA_PASSWORD: 'E2eFunc!Probe2026'
+        ports:
+          - 1433:1433
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js 20.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          # 9.15.9, NOT this lane's usual 10.16.1: the package stamps its own `packageManager` field to
+          # pnpm@9.15.9 (scripts/ops/multitable-onprem-package-build.sh), the packaged lockfile is
+          # verified against that version, and this job runs `pnpm install --frozen-lockfile` INSIDE the
+          # extracted package root. stock-prep-main-package-verify.yml and
+          # stock-prep-staging-window-rehearsal.yml both use 9.15.9 for the repo-root install as well,
+          # so a single version serves both installs here.
+          version: 9.15.9
+          run_install: false
+
+      - name: Use empty npmrc for pnpm
+        run: |
+          echo "" > /tmp/empty-npmrc
+          echo "NPM_CONFIG_USERCONFIG=/tmp/empty-npmrc" >> "$GITHUB_ENV"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build web/backend dist (the package ships compiled output, never sources)
+        run: |
+          pnpm --filter @metasheet/web build
+          pnpm --filter @metasheet/core-backend build
+
+      - name: Build the on-prem package from THIS commit and run the five-check verifier over it
+        id: pkg
+        env:
+          PACKAGE_TAG: e2elab${{ github.run_number }}
+        run: |
+          set -euo pipefail
+          # Same invocation stock-prep-main-package-verify.yml and stock-prep-staging-window-rehearsal.yml
+          # use (INSTALL_DEPS/BUILD_WEB/BUILD_BACKEND all 0 — the three steps above already did that work).
+          chmod +x scripts/ops/multitable-onprem-package-build.sh scripts/ops/multitable-onprem-package-verify.sh
+          INSTALL_DEPS=0 BUILD_WEB=0 BUILD_BACKEND=0 scripts/ops/multitable-onprem-package-build.sh
+          out_dir="output/releases/multitable-onprem"
+          pkg_tgz="$(ls -1 ${out_dir}/*.tgz | sort | tail -n 1)"
+          scripts/ops/multitable-onprem-package-verify.sh "$pkg_tgz"
+          tgz_sha="$(sha256sum "$pkg_tgz" | awk '{print $1}')"
+          {
+            echo "pkg_tgz=${pkg_tgz}"
+            echo "tgz_sha256=${tgz_sha}"
+          } >> "$GITHUB_OUTPUT"
+          # A DIGEST only — values-free by this repo's convention (stock-prep-main-package-verify.yml
+          # publishes packageTgzSha256 the same way). It names the artifact under test; it discloses none
+          # of its content.
+          echo "packageVerify=PASS"
+          echo "packageTgzSha256=${tgz_sha}"
+
+      - name: Extract the package (this is the runtime the walk will drive)
+        id: unpack
+        run: |
+          set -euo pipefail
+          mkdir -p "${RUNNER_TEMP}/pkgroot"
+          tar -xzf "${{ steps.pkg.outputs.pkg_tgz }}" -C "${RUNNER_TEMP}/pkgroot"
+          PKG_ROOT="$(find "${RUNNER_TEMP}/pkgroot" -mindepth 1 -maxdepth 1 -type d -print -quit)"
+          test -n "$PKG_ROOT"
+          # The claim this job makes is "the package's OWN compiled entry point served the walk", so the
+          # entry point must exist in the extracted tree BEFORE anything else. The harness re-checks this
+          # too (E2E_SERVER_ARGS is resolved against E2E_SERVER_ROOT at load time); asserting it here as
+          # well means a packaging regression fails at the packaging step, not as a health-check timeout.
+          test -f "${PKG_ROOT}/packages/core-backend/dist/src/index.js"
+          test -f "${PKG_ROOT}/packages/core-backend/dist/src/db/migrate.js"
+          chmod +x "${PKG_ROOT}/scripts/ops/"*.sh
+          echo "pkg_root=${PKG_ROOT}" >> "$GITHUB_OUTPUT"
+          echo "packageEntryPointPresent=PASS"
+          echo "packageMigrationRunnerPresent=PASS"
+
+      - name: Install the package's OWN pinned dependencies (frozen lockfile — never relaxed)
+        working-directory: ${{ steps.unpack.outputs.pkg_root }}
+        run: pnpm install --frozen-lockfile --reporter=append-only
+
+      - name: Wait for SQL Server
+        run: |
+          for i in $(seq 1 40); do
+            if pnpm --filter plugin-integration-core exec node -e "
+              const sql = require('mssql');
+              new sql.ConnectionPool({server:'127.0.0.1',port:1433,user:'sa',password:'E2eFunc!Probe2026',database:'master',options:{encrypt:true,trustServerCertificate:true},connectionTimeout:3000})
+                .connect().then(p => p.close()).then(() => process.exit(0)).catch(() => process.exit(1));
+            "; then
+              echo "SQL Server ready on attempt $i"
+              exit 0
+            fi
+            echo "attempt $i: SQL Server not ready yet; sleeping 5s"
+            sleep 5
+          done
+          echo "SQL Server never became ready within timeout"
+          exit 1
+
+      - name: Generate CI-local ephemeral secrets (masked, never logged, scoped to this run only)
+        run: |
+          set -euo pipefail
+          jwt_secret="$(openssl rand -hex 32)"
+          enc_key="$(openssl rand -hex 32)"
+          runtime_password="$(openssl rand -hex 16)"
+          provisioning_password="$(openssl rand -hex 16)"
+          echo "::add-mask::$jwt_secret"
+          echo "::add-mask::$enc_key"
+          echo "::add-mask::$runtime_password"
+          echo "::add-mask::$provisioning_password"
+          {
+            echo "E2E_JWT_SECRET=$jwt_secret"
+            echo "E2E_INTEGRATION_ENCRYPTION_KEY=$enc_key"
+            echo "E2E_S6A_RUNTIME_DB_ROLE=e2e_s6a_runtime"
+            echo "E2E_S6A_RUNTIME_DB_PASSWORD=$runtime_password"
+            echo "E2E_S6A_PROVISIONING_DB_ROLE=e2e_s6a_provision"
+            echo "E2E_S6A_PROVISIONING_DB_PASSWORD=$provisioning_password"
+          } >> "$GITHUB_ENV"
+
+      - name: Provision sealed-export Postgres roles, then migrate with the PACKAGE's own runner
+        env:
+          PG_SUPERUSER_URL: postgresql://postgres:postgres@127.0.0.1:5432/metasheet
+          RUNTIME_ROLE: ${{ env.E2E_S6A_RUNTIME_DB_ROLE }}
+          RUNTIME_PASSWORD: ${{ env.E2E_S6A_RUNTIME_DB_PASSWORD }}
+          PROVISIONING_ROLE: ${{ env.E2E_S6A_PROVISIONING_DB_ROLE }}
+          PROVISIONING_PASSWORD: ${{ env.E2E_S6A_PROVISIONING_DB_PASSWORD }}
+          # The whole point of package mode: the schema this walk runs against comes from the PACKAGE's
+          # compiled migration runner (the same `node packages/core-backend/dist/src/db/migrate.js`
+          # invocation stock-prep-main-package-verify.yml and stock-prep-s6a-postgres17-validation.yml
+          # use), not from the repo checkout's TypeScript sources. The provisioning script still creates
+          # the two separated non-superuser roles and still makes both role GUCs visible to the very
+          # first migration connection — that part is identical in both modes.
+          E2E_MIGRATE_ROOT: ${{ steps.unpack.outputs.pkg_root }}
+          E2E_MIGRATE_CMD: node
+          E2E_MIGRATE_ARGS: packages/core-backend/dist/src/db/migrate.js
+        run: node scripts/ops/stock-preparation-e2e-provision-postgres-roles-and-migrate.mjs
+
+      - name: Run containerized functional smoke against the EXTRACTED PACKAGE
+        id: smoke
+        env:
+          DATABASE_URL: postgresql://postgres:postgres@127.0.0.1:5432/metasheet
+          E2E_JWT_SECRET: ${{ env.E2E_JWT_SECRET }}
+          E2E_INTEGRATION_ENCRYPTION_KEY: ${{ env.E2E_INTEGRATION_ENCRYPTION_KEY }}
+          E2E_S6A_RUNTIME_DB_ROLE: ${{ env.E2E_S6A_RUNTIME_DB_ROLE }}
+          E2E_S6A_RUNTIME_DB_URL: postgresql://${{ env.E2E_S6A_RUNTIME_DB_ROLE }}:${{ env.E2E_S6A_RUNTIME_DB_PASSWORD }}@127.0.0.1:5432/metasheet
+          E2E_S6A_PROVISIONING_DB_ROLE: ${{ env.E2E_S6A_PROVISIONING_DB_ROLE }}
+          E2E_S6A_PROVISIONING_DB_URL: postgresql://${{ env.E2E_S6A_PROVISIONING_DB_ROLE }}:${{ env.E2E_S6A_PROVISIONING_DB_PASSWORD }}@127.0.0.1:5432/metasheet
+          MSSQL_HOST: 127.0.0.1
+          MSSQL_PORT: '1433'
+          MSSQL_USERNAME: sa
+          MSSQL_PASSWORD: 'E2eFunc!Probe2026'
+          # The IDENTICAL primary walk: same arm, same 3 rows, same assertions, same evidence keys. Only
+          # the server under test moves — from `pnpm run dev:core` in the repo tree to the package's own
+          # compiled entry point with the package root as cwd (plugin discovery is cwd-relative, which is
+          # why stock-prep-staging-window-rehearsal.yml starts the packaged backend the same way).
+          E2E_S6A_ARM: primary
+          E2E_S6A_ROW_COUNT: '3'
+          E2E_WALK_MODE: package
+          E2E_SERVER_ROOT: ${{ steps.unpack.outputs.pkg_root }}
+          E2E_SERVER_CMD: node
+          E2E_SERVER_ARGS: packages/core-backend/dist/src/index.js
+          # Names the artifact this walk drove. The harness shape-checks it (64-char lowercase hex) rather
+          # than trusting it, so an empty or truncated value cannot become a false identity claim.
+          E2E_PACKAGE_TGZ_SHA256: ${{ steps.pkg.outputs.tgz_sha256 }}
+          # This job exists only under lab mode, so the post-ON flag-OFF restoration arm runs here too —
+          # #4708 item 8 is asserted in BOTH walk modes, not only against the repo tree.
+          E2E_LAB_MODE: 'true'
+        run: node scripts/ops/stock-preparation-e2e-functional-smoke.mjs
+
+      - name: Write step summary
+        if: always()
+        run: |
+          echo "## Stock Preparation E2E Functional Smoke (PACKAGE mode, primary arm)" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Functional testing on synthetic data only. Does NOT substitute for the #4695 controlled" >> "$GITHUB_STEP_SUMMARY"
+          echo "acceptance and establishes no real-customer, external-write, or rollout claim. The walk" >> "$GITHUB_STEP_SUMMARY"
+          echo "here is the SAME walk the repo-mode job runs; only the server under test differs (the" >> "$GITHUB_STEP_SUMMARY"
+          echo "package's own compiled entry point, its own pinned dependency install, its own migration" >> "$GITHUB_STEP_SUMMARY"
+          echo "runner). This is a LINUX runner: it establishes nothing about a Windows-host installer." >> "$GITHUB_STEP_SUMMARY"
+          echo '```text' >> "$GITHUB_STEP_SUMMARY"
+          cat output/stock-preparation-e2e-functional-smoke/summary.txt 2>/dev/null >> "$GITHUB_STEP_SUMMARY" || echo "no summary produced" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload values-free evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: stock-preparation-e2e-functional-smoke-package
+          path: |
+            output/stock-preparation-e2e-functional-smoke/summary.txt
+            output/stock-preparation-e2e-functional-smoke/checks.json
+            output/stock-preparation-e2e-functional-smoke/existing-chain/summary.txt
+            output/stock-preparation-e2e-functional-smoke/existing-chain/checks.json
+          if-no-files-found: warn
+          retention-days: 14
+
   scale-midtier:
     name: R9 scale leg — mid-tier calibration walk (own Postgres + SQL Server)
-    # Gated so this job is SKIPPED (never reported as a pass) unless `s6a_row_count` requests scale — the
-    # SAME condition, computed the SAME way, as scale-rejection below and as
+    # Gated so this job is SKIPPED (never reported as a pass) unless scale is requested — the SAME
+    # condition, computed the SAME way, as scale-rejection below and as
     # scripts/ops/stock-preparation-e2e-compute-scale-slope.mjs's own independent re-derivation of
-    # "was scale requested" (see that script's SCALE_REQUESTED_INPUT — it does not infer this from
-    # whether this job ran, on purpose).
+    # "was scale requested" (see that script's SCALE_REQUESTED_INPUT/LAB_MODE_INPUT — it does not infer
+    # this from whether this job ran, on purpose).
+    #
+    # S10 added the `lab_mode` term: lab mode defaults `s6a_row_count` to 24999 for the row-count env
+    # below, and a gate that looked only at the raw input would skip this job on exactly the dispatches
+    # that asked for the lab walk.
     if: >-
       github.event_name == 'workflow_dispatch' &&
-      github.event.inputs.s6a_row_count != '' &&
-      github.event.inputs.s6a_row_count != '3'
+      (github.event.inputs.lab_mode == 'true' ||
+      (github.event.inputs.s6a_row_count != '' && github.event.inputs.s6a_row_count != '3'))
     needs: contract
     runs-on: ubuntu-latest
     # The mid-tier walk is a full capture -> private ingestion -> generation kernel -> apply -> activation
@@ -448,11 +740,12 @@ jobs:
           MSSQL_USERNAME: sa
           MSSQL_PASSWORD: 'E2eFunc!Probe2026'
           E2E_S6A_ARM: midtier
-          # This job only runs (see the job-level `if:` above) when this input requests scale, so the raw
-          # input is passed straight through — no `|| '3'` fallback (that fallback exists on
-          # functional-smoke's identically-named env var only to cover a default dispatch, which never
-          # reaches this job).
-          E2E_S6A_ROW_COUNT: ${{ github.event.inputs.s6a_row_count }}
+          # This job only runs (see the job-level `if:` above) when scale is requested. The expression is
+          # the S10 effective row count: the raw input when it names one, and the product's declared bound
+          # (24999) when `lab_mode` requested the lab walk without naming a row count. No `|| '3'`
+          # fallback — that fallback exists on functional-smoke's identically-named env var only to cover
+          # a default dispatch, which never reaches this job.
+          E2E_S6A_ROW_COUNT: ${{ (github.event.inputs.lab_mode == 'true' && (github.event.inputs.s6a_row_count == '' || github.event.inputs.s6a_row_count == '3')) && '24999' || (github.event.inputs.s6a_row_count || '3') }}
         run: node scripts/ops/stock-preparation-e2e-functional-smoke.mjs
 
       - name: Write step summary
@@ -506,8 +799,8 @@ jobs:
     # Gated identically to scale-midtier above — see that job's comment.
     if: >-
       github.event_name == 'workflow_dispatch' &&
-      github.event.inputs.s6a_row_count != '' &&
-      github.event.inputs.s6a_row_count != '3'
+      (github.event.inputs.lab_mode == 'true' ||
+      (github.event.inputs.s6a_row_count != '' && github.event.inputs.s6a_row_count != '3'))
     needs: contract
     runs-on: ubuntu-latest
     # The rejection arm seeds MAX_BUSINESS_LINES+1 (~25000) rows in batches of 500, then the product reads
@@ -625,11 +918,11 @@ jobs:
           MSSQL_USERNAME: sa
           MSSQL_PASSWORD: 'E2eFunc!Probe2026'
           E2E_S6A_ARM: rejection
-          # Same rationale as scale-midtier above: no `|| '3'` fallback, this job only runs when scale is
-          # requested. The rejection arm's OWN row count is always MAX_BUSINESS_LINES+1 regardless of the
-          # exact value here — this env var only feeds the script's S6A_SCALE_REQUESTED gate (see
-          # runS6ARejectionArm's caller in main()).
-          E2E_S6A_ROW_COUNT: ${{ github.event.inputs.s6a_row_count }}
+          # Same rationale as scale-midtier above: the S10 effective row count, no `|| '3'` fallback,
+          # this job only runs when scale is requested. The rejection arm's OWN row count is always
+          # MAX_BUSINESS_LINES+1 regardless of the exact value here — this env var only feeds the script's
+          # S6A_SCALE_REQUESTED gate (see runS6ARejectionArm's caller in main()).
+          E2E_S6A_ROW_COUNT: ${{ (github.event.inputs.lab_mode == 'true' && (github.event.inputs.s6a_row_count == '' || github.event.inputs.s6a_row_count == '3')) && '24999' || (github.event.inputs.s6a_row_count || '3') }}
         run: node scripts/ops/stock-preparation-e2e-functional-smoke.mjs
 
       - name: Write step summary
@@ -700,10 +993,13 @@ jobs:
       - name: Compute R9 two-point slope from job outputs (values-free; NOT_RUN if either data point is missing)
         id: slope
         env:
-          # The SAME raw input the scale jobs' own `if:` gates use — computed independently here rather
+          # The SAME raw inputs the scale jobs' own `if:` gates use — computed independently here rather
           # than inferred from whether those jobs ran, so a gate malfunction (job ran/skipped when it
-          # should not have) is DETECTABLE by comparing the two, not assumed away.
+          # should not have) is DETECTABLE by comparing the two, not assumed away. Both terms are passed
+          # RAW; the script re-derives "was scale requested" from them itself (S10 — a lab-mode dispatch
+          # requests scale without naming a row count, so the row count alone no longer decides).
           SCALE_REQUESTED_INPUT: ${{ github.event.inputs.s6a_row_count }}
+          LAB_MODE_INPUT: ${{ github.event.inputs.lab_mode }}
           # Bracket notation is required for hyphenated job ids in an expression context — dot notation on
           # `needs.scale-midtier` is not "scale" minus "midtier", it silently resolves to nothing.
           PRIMARY_JOB_RESULT: ${{ needs['functional-smoke'].result }}

--- a/scripts/ops/stock-preparation-e2e-compute-scale-slope.mjs
+++ b/scripts/ops/stock-preparation-e2e-compute-scale-slope.mjs
@@ -90,11 +90,23 @@ if (primaryJobResult !== 'success' && primaryJobResult !== 'failure') {
   plumbingFailures.push('PRIMARY_JOB_DID_NOT_EXECUTE')
 }
 
-// scaleRequested is computed independently from the SAME raw input the two scale jobs' own workflow-level
-// `if:` gates use (never inferred from job skip/run status, which would make this check circular).
+// scaleRequested is computed independently from the SAME raw inputs the two scale jobs' own
+// workflow-level `if:` gates use (never inferred from job skip/run status, which would make this check
+// circular).
+//
+// S10 added the second term. `lab_mode: true` requests the lab-scale walk WITHOUT the dispatcher having
+// to also type a row count (the workflow defaults `s6a_row_count` to the product's declared bound in
+// that case), so the scale jobs' gate is `lab_mode == 'true' || row_count not in {'', '3'}`. Deriving
+// scaleRequested from the row count ALONE would then report SCALE_NOT_REQUESTED on exactly the
+// dispatches where scale WAS requested, and this job would raise MIDTIER_JOB_RAN_BUT_SCALE_NOT_REQUESTED
+// against a gate that behaved correctly — a false plumbing finding. Both terms are re-derived here from
+// the inputs, not read back off the gate.
 const scaleRequestedInput = process.env.SCALE_REQUESTED_INPUT || ''
-const scaleRequested = scaleRequestedInput !== '' && scaleRequestedInput !== '3'
+const labModeInput = String(process.env.LAB_MODE_INPUT || '').trim().toLowerCase()
+const scaleRequested = labModeInput === 'true' ||
+  (scaleRequestedInput !== '' && scaleRequestedInput !== '3')
 S.scaleRequested = String(scaleRequested)
+S.labMode = String(labModeInput === 'true')
 
 let slopeNotRunReason = null
 

--- a/scripts/ops/stock-preparation-e2e-functional-smoke.mjs
+++ b/scripts/ops/stock-preparation-e2e-functional-smoke.mjs
@@ -33,6 +33,22 @@
 // S6A_ARM constant for the full rationale, and
 // scripts/ops/stock-preparation-e2e-compute-scale-slope.mjs for how the primary-vs-mid-tier timing slope
 // is reassembled downstream from separate job outputs now that the arms are separate processes.
+//
+// S10 additions — E2E_WALK_MODE ('repo' | 'package', default 'repo') and E2E_LAB_MODE ('true' | 'false',
+// default 'false'). Both default to EXACTLY the pre-S10 behaviour; neither changes what an unset-env
+// invocation does.
+//   * walk mode: E2E_SERVER_ROOT / E2E_SERVER_CMD / E2E_SERVER_ARGS let this SAME harness drive an
+//     EXTRACTED on-prem package root (`node packages/core-backend/dist/src/index.js`, cwd = package root)
+//     instead of the repo tree's `pnpm run dev:core`. Every assertion, arm, tenant and evidence key is
+//     unchanged — "the same walk, from the package" is only a claim if it really is the same walk. The
+//     declared mode and the actual spawn target are required to AGREE (crossed combinations throw at load
+//     time), and the walk emits `walkMode` plus `packageTgzSha256` so the evidence names which artifact
+//     it drove. Closes #4708 item 1's repo-tree caveat; see the S10 walk-mode config block below.
+//   * lab mode: adds a post-ON flag-OFF RESTORATION arm after the flag-ON window (re-asserting the same
+//     three-part gate the pre-window arm asserts, that no committed file outside documentation prose and
+//     this harness's own child env arms the flag, and that the artifact-root capture directory is gone),
+//     which is #4708 item 8. It is gated because it restarts the server one more time — a behaviour
+//     change, not merely an extra evidence key.
 
 import { spawn } from 'node:child_process'
 import { once } from 'node:events'
@@ -114,6 +130,98 @@ const REQUEST_TIMEOUT_MS = 20000
 const HEALTH_TIMEOUT_MS = 90000
 const ARTIFACT_ROOT = process.env.E2E_ARTIFACT_ROOT || path.join(os.tmpdir(), 'stock-prep-e2e-artifact-root')
 const OUT_DIR = process.env.E2E_OUT_DIR || path.join(REPO_ROOT, 'output/stock-preparation-e2e-functional-smoke')
+
+// ── S10 walk-mode config (#4708 item 1: "package install in isolated runtime") ───────────────────────
+//
+// Until this block, startServer() hardcoded `spawn('pnpm', ['--filter','@metasheet/core-backend','run',
+// 'dev:core'], { cwd: REPO_ROOT })` — i.e. the walk ALWAYS drove a tsx-from-source server in the repo
+// checkout. That is a real S6-A walk, but it is not evidence that the SHIPPED on-prem package can stand
+// the same walk up: the package's compiled `packages/core-backend/dist/src/index.js`, its own pinned
+// dependency install, and its cwd-relative plugin discovery are all untested by a repo-tree run.
+// (Recorded as gap 1 in docs/development/s6a-synthetic-e2e-in-ci-feasibility-20260818.md.)
+//
+// The override is three env vars and nothing else — the harness's assertions, arms, tenants, fixtures and
+// evidence keys are IDENTICAL in both modes, which is the whole point: "the same walk, from the package"
+// is only a claim if it really is the same walk. An UNSET E2E_SERVER_ROOT/E2E_SERVER_CMD/E2E_SERVER_ARGS
+// reproduces the previous spawn byte-for-byte.
+//
+// walkMode is NOT inferred from whether an override happens to be set — it is declared, and then the two
+// are required to AGREE. A run that declares `package` while actually spawning the repo tree (or the
+// reverse) would emit a walkMode line that is simply false, which is worse than no line at all; both
+// crossed combinations are a hard throw at load time rather than a check that could be waived later.
+const WALK_VALID_MODES = new Set(['repo', 'package'])
+const WALK_MODE = String(process.env.E2E_WALK_MODE || 'repo').trim()
+if (!WALK_VALID_MODES.has(WALK_MODE)) {
+  throw new Error(`invalid E2E_WALK_MODE: ${JSON.stringify(process.env.E2E_WALK_MODE)} (want one of: ${[...WALK_VALID_MODES].join(', ')})`)
+}
+const DEFAULT_SERVER_CMD = 'pnpm'
+const DEFAULT_SERVER_ARGS = Object.freeze(['--filter', '@metasheet/core-backend', 'run', 'dev:core'])
+// JSON array form is preferred (it survives arguments containing spaces); a bare whitespace-separated
+// string is accepted because that is what a workflow `env:` line most naturally carries for the single
+// -argument package case (`packages/core-backend/dist/src/index.js`).
+function parseServerArgs(raw, fallback) {
+  if (raw === undefined || raw === null || String(raw).trim() === '') return [...fallback]
+  const text = String(raw).trim()
+  if (text.startsWith('[')) {
+    let parsed
+    try {
+      parsed = JSON.parse(text)
+    } catch (error) {
+      throw new Error(`E2E_SERVER_ARGS looks like JSON but did not parse: ${String(error && error.message || error)}`)
+    }
+    if (!Array.isArray(parsed) || parsed.some((v) => typeof v !== 'string')) {
+      throw new Error('E2E_SERVER_ARGS JSON form must be an array of strings')
+    }
+    return parsed
+  }
+  return text.split(/\s+/).filter(Boolean)
+}
+const SERVER_ROOT = path.resolve(process.env.E2E_SERVER_ROOT || REPO_ROOT)
+const SERVER_CMD = String(process.env.E2E_SERVER_CMD || '').trim() || DEFAULT_SERVER_CMD
+const SERVER_ARGS = parseServerArgs(process.env.E2E_SERVER_ARGS, DEFAULT_SERVER_ARGS)
+const SERVER_ROOT_IS_REPO_ROOT = SERVER_ROOT === path.resolve(REPO_ROOT)
+if (WALK_MODE === 'package' && SERVER_ROOT_IS_REPO_ROOT) {
+  throw new Error('E2E_WALK_MODE=package requires E2E_SERVER_ROOT to point at an EXTRACTED package root, not the repo checkout')
+}
+if (WALK_MODE === 'package' && SERVER_CMD === DEFAULT_SERVER_CMD && String(process.env.E2E_SERVER_CMD || '').trim() === '') {
+  throw new Error('E2E_WALK_MODE=package requires an explicit E2E_SERVER_CMD (the repo-tree `pnpm run dev:core` default cannot start a package root)')
+}
+if (WALK_MODE === 'repo' && !SERVER_ROOT_IS_REPO_ROOT) {
+  throw new Error('E2E_SERVER_ROOT was overridden but E2E_WALK_MODE still says `repo` — declare package mode or drop the override')
+}
+// Structural proof that package mode really is driving the package's OWN compiled entry point: when the
+// first argument is a script path, that file must exist UNDER the declared server root. A typo'd path
+// would otherwise surface only as a health-check timeout, indistinguishable from a boot failure.
+const SERVER_ENTRY_CANDIDATE = SERVER_ARGS.length > 0 && /\.[cm]?js$/.test(SERVER_ARGS[0]) ? SERVER_ARGS[0] : ''
+const SERVER_ENTRY_RESOLVED = SERVER_ENTRY_CANDIDATE === ''
+  ? 'NOT_APPLICABLE'
+  : String(fs.existsSync(path.resolve(SERVER_ROOT, SERVER_ENTRY_CANDIDATE)))
+if (SERVER_ENTRY_RESOLVED === 'false') {
+  throw new Error(`E2E_SERVER_ARGS names a script that does not exist under E2E_SERVER_ROOT: ${SERVER_ENTRY_CANDIDATE}`)
+}
+// A DIGEST is values-free by this repo's own convention (stock-prep-main-package-verify.yml publishes
+// packageTgzSha256 exactly this way) — it identifies the artifact under test without disclosing any of
+// its content. Shape-checked rather than trusted: an empty or truncated value passed through here would
+// make the evidence line claim an identity it does not actually have.
+const PACKAGE_TGZ_SHA256 = String(process.env.E2E_PACKAGE_TGZ_SHA256 || '').trim()
+if (WALK_MODE === 'package' && !/^[0-9a-f]{64}$/.test(PACKAGE_TGZ_SHA256)) {
+  throw new Error('E2E_WALK_MODE=package requires E2E_PACKAGE_TGZ_SHA256 to be a 64-char lowercase hex SHA-256')
+}
+
+// ── S10 lab mode (#4708 item 8 + item 5's lab-scale default) ────────────────────────────────────────
+//
+// OFF by default, and the default path is byte-identical to before this constant existed: the post-ON
+// flag-OFF restoration arm below does an extra server restart, which IS a behaviour change, so it is
+// gated rather than made unconditional. The workflow's own header records that a default-input dispatch
+// must not change, and this is what keeps that true. When the workflow's `lab_mode` input is 'true' the
+// lane additionally (a) defaults `s6a_row_count` to the product's declared bound (24999), which is the
+// workflow's job, not this file's, and (b) runs the post-window arm, which is this file's.
+const LAB_MODE_VALID = new Set(['true', 'false'])
+const LAB_MODE_RAW = String(process.env.E2E_LAB_MODE || 'false').trim().toLowerCase()
+if (!LAB_MODE_VALID.has(LAB_MODE_RAW)) {
+  throw new Error(`invalid E2E_LAB_MODE: ${JSON.stringify(process.env.E2E_LAB_MODE)} (want one of: ${[...LAB_MODE_VALID].join(', ')})`)
+}
+const LAB_MODE = LAB_MODE_RAW === 'true'
 
 // Postgres sealed-export authority roles the workflow already created + migrated against.
 const RUNTIME_DB_ROLE = process.env.E2E_S6A_RUNTIME_DB_ROLE || ''
@@ -362,8 +470,13 @@ export async function startServer(extraEnv, label) {
   // calls startServer() directly without ever creating it first.
   fs.mkdirSync(OUT_DIR, { recursive: true })
   const logFd = fs.openSync(logPath, 'a')
-  const proc = spawn('pnpm', ['--filter', '@metasheet/core-backend', 'run', 'dev:core'], {
-    cwd: REPO_ROOT,
+  // SERVER_CMD/SERVER_ARGS/SERVER_ROOT default to EXACTLY the previous hardcoded
+  // `pnpm --filter @metasheet/core-backend run dev:core` in REPO_ROOT — see the S10 walk-mode config
+  // block. cwd is load-bearing in package mode: the on-prem package discovers its plugins relative to
+  // the process cwd (the same reason stock-prep-staging-window-rehearsal.yml starts the packaged
+  // backend with `working-directory: <pkg_root>`), so the server root is the cwd, never REPO_ROOT.
+  const proc = spawn(SERVER_CMD, SERVER_ARGS, {
+    cwd: SERVER_ROOT,
     env,
     stdio: ['ignore', logFd, logFd],
     // Its own process group leader, so stopServer() can signal the WHOLE tree pnpm spawns underneath it
@@ -376,7 +489,7 @@ export async function startServer(extraEnv, label) {
     await stopServer()
     throw new Error(`server (${label}) did not become healthy within ${HEALTH_TIMEOUT_MS}ms — see server-${label}.log`)
   }
-  note(`server (${label}) healthy`, `port=${PORT}`)
+  note(`server (${label}) healthy`, `port=${PORT} walkMode=${WALK_MODE}`)
   return true
 }
 
@@ -1416,6 +1529,10 @@ async function diagnoseS6APostCaptureRefusal() {
   }
 }
 
+// Set by attemptS6ARealRun() below; read ONLY by the S10 post-window cleanup arm. Module-private on
+// purpose — an operationId is a value, and this file's evidence block carries tokens and counts only.
+let lastPrimaryOperationId = ''
+
 async function attemptS6ARealRun() {
   const salt = `t${Math.floor(Date.now() / 1000)}`
   const systemId = `e2efunc-s6a-source-${salt}`
@@ -1712,6 +1829,11 @@ async function attemptS6ARealRun() {
     await requestJson('/api/integration/stock-preparation/mvp/ensure', { method: 'POST', token, body: {}, accept: [200, 201] })
 
     const operationId = `s6a-e2e-op-${salt}`
+    // Remembered (module-private, never emitted — it is a value, not a token) so the S10 post-window
+    // cleanup arm can snapshot THIS walk's run row after the flag-OFF restart. Assigned before the POST,
+    // not after, so a run that refuses still leaves the cleanup arm a real operationId to look up rather
+    // than silently degrading to the "matches nothing" scope.
+    lastPrimaryOperationId = operationId
     // Wall-clock (requirement 4), on the S6-A POST's own timeout — additive evidence only; this walk's
     // PASS/FAIL semantics are unchanged. Published as this job's own `primary_duration_ms` output (R9
     // restructure) and reassembled downstream, together with the mid-tier arm's own duration from its OWN
@@ -2457,6 +2579,191 @@ async function runS6ARejectionArm() {
 // downstream, from job outputs, by scripts/ops/stock-preparation-e2e-compute-scale-slope.mjs (invoked by
 // the workflow's `scale-slope` job) — never fabricated here from a single arm's partial view.
 
+// ── S10 post-ON flag-OFF restoration + cleanup arm (#4708 item 8) ───────────────────────────────────
+//
+// Every flag arm in this file runs BEFORE the flag-ON window (phases 1-2b), so nothing re-proved the
+// route was gated again AFTERWARD — "unconditional flag-OFF restoration" was, until this arm, an
+// assertion about a state this lane never actually observed. (Recorded as gap 2 in
+// docs/development/s6a-synthetic-e2e-in-ci-feasibility-20260818.md.) The window itself is already
+// process-scoped by construction — the flag only ever reaches ONE spawned child's env, and that child is
+// gone by the time this arm starts — but "by construction" is exactly the kind of claim that stops being
+// true silently, which is what this arm exists to catch.
+//
+// It re-uses runFlagArm() rather than re-implementing the three-part probe (health capability false +
+// an ALWAYS-registered sibling route answering 200 + the S6-A path 404), so post-window restoration is
+// asserted by the SAME code, to the SAME standard, as the pre-window flag-OFF arm — see the long block
+// comment above runFlagArm() for why a bare `http === 404` is not sufficient on its own.
+const S6A_FLAG_NAME = 'MULTITABLE_STOCK_PREP_SQLSERVER_SEALED_SNAPSHOT_ENABLED'
+// stock-preparation-runtime-config.cjs's featureEnabled() is
+// `String(env[FLAG] ?? '').trim().toLowerCase() === 'true'`, so the set of ENABLING literals is exactly
+// {true} modulo case and surrounding whitespace/quotes — '1', 'yes' and 'on' are NOT enabling, which is
+// precisely what phase 2's exact-match arms prove empirically rather than by reading the source. This
+// detector is therefore narrowed to `true` on purpose: widening it to '1'/'yes' would flag committed
+// lines that demonstrably cannot enable anything, i.e. manufacture false findings.
+const FLAG_ENABLING_ASSIGNMENT_RE = new RegExp(`${S6A_FLAG_NAME}\\s*[:=]\\s*["'\`]?\\s*true\\b`, 'i')
+// The only two committed places a flag-name-to-enabling-value coupling is legitimate, as a CLOSED set:
+//   docs   — prose/runbook text (`.md`). A document configures no runtime; the operator runbook has to
+//            be able to print the line an operator would type. Counted and surfaced, never waived away.
+//   harness — THIS file's own per-arm child-process env objects (the flag-ON walk and the mid-tier
+//            scale walk). Those are `spawn()` argument literals, scoped to one child that is killed at
+//            the end of the arm; they are never written to disk, an env file, or a job/workflow `env:`.
+// Anything else is unaccounted and fails the arm. That includes a new workflow `env:` key, a docker
+// app.env template line, an ecosystem.config.js entry, or a second harness acquiring one.
+const FLAG_HARNESS_PATH = 'scripts/ops/stock-preparation-e2e-functional-smoke.mjs'
+
+function gitGrepFlagMentions() {
+  return new Promise((resolve) => {
+    // `-I` skips binaries, `-n` numbers lines, `-F -e` takes the flag name as a literal (never a
+    // pattern). git grep searches the TRACKED working tree — i.e. exactly "the checkout", which is the
+    // scope this assertion claims, not an arbitrary directory walk that could wander into node_modules.
+    const proc = spawn('git', ['grep', '-I', '-n', '-F', '-e', S6A_FLAG_NAME], {
+      cwd: REPO_ROOT,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+    let out = ''
+    let err = ''
+    proc.stdout.on('data', (chunk) => { out += chunk.toString() })
+    proc.stderr.on('data', (chunk) => { err += chunk.toString() })
+    proc.on('close', (code) => resolve({ code, out, err }))
+    proc.on('error', (error) => resolve({ code: -1, out: '', err: String(error && error.message || error) }))
+  })
+}
+
+async function assertFlagAbsentFromCommittedConfiguration() {
+  // Detector self-test FIRST, on synthetic strings, so "we found nothing" can never be the silent
+  // output of a regex that matches nothing. Both directions are pinned: it must fire on the two shapes
+  // a real leak takes (dotenv/shell `=` and YAML/JS `:`), and must NOT fire on the values the product
+  // demonstrably treats as disabled.
+  const detectorFires = FLAG_ENABLING_ASSIGNMENT_RE.test(`${S6A_FLAG_NAME}=true`) &&
+    FLAG_ENABLING_ASSIGNMENT_RE.test(`  ${S6A_FLAG_NAME}: 'true'`) &&
+    FLAG_ENABLING_ASSIGNMENT_RE.test(`${S6A_FLAG_NAME}: "TRUE"`)
+  const detectorQuiet = !FLAG_ENABLING_ASSIGNMENT_RE.test(`${S6A_FLAG_NAME}=false`) &&
+    !FLAG_ENABLING_ASSIGNMENT_RE.test(`${S6A_FLAG_NAME}=1`) &&
+    !FLAG_ENABLING_ASSIGNMENT_RE.test(`${S6A_FLAG_NAME}=yes`)
+  const detectorLive = detectorFires && detectorQuiet
+  S.postWindowFlagScanDetectorLive = detectorLive ? 'PASS' : 'FAIL'
+  must('S10: the committed-flag detector fires on enabling assignments and stays quiet on disabled ones '
+    + '(so a zero finding below means "nothing there", not "nothing looked")', detectorLive,
+    `fires=${detectorFires} quiet=${detectorQuiet}`)
+
+  const grep = await gitGrepFlagMentions()
+  // git grep exits 1 when NOTHING matched. This file itself always mentions the flag, so a 1 here means
+  // the scan did not read the checkout at all (wrong cwd, no git, shallow/absent worktree) — a vacuous
+  // pass, which is the exact failure mode this whole arm exists to prevent.
+  if (grep.code !== 0) {
+    S.postWindowFlagMentionLineCount = 0
+    S.postWindowFlagEnablingLineCountDocs = 'NOT_RUN'
+    S.postWindowFlagEnablingLineCountHarness = 'NOT_RUN'
+    S.postWindowFlagEnablingLineCountOther = 'NOT_RUN'
+    must('S10: the committed-checkout flag scan actually read the checkout (this harness itself mentions '
+      + 'the flag, so a zero-match scan is a broken scan, not a clean repo)', false,
+      `gitGrepExit=${grep.code} stderr=${String(grep.err || '').split('\n')[0].slice(0, 120)}`)
+    return false
+  }
+
+  const mentions = grep.out.split('\n').map((line) => line.trim()).filter(Boolean).map((line) => {
+    // `path:lineno:text` — split on the first two colons only; the TEXT may contain any number more.
+    const firstColon = line.indexOf(':')
+    const secondColon = line.indexOf(':', firstColon + 1)
+    return {
+      filePath: firstColon < 0 ? line : line.slice(0, firstColon),
+      text: secondColon < 0 ? line : line.slice(secondColon + 1),
+    }
+  })
+  const enabling = mentions.filter((m) => FLAG_ENABLING_ASSIGNMENT_RE.test(m.text))
+  const docs = enabling.filter((m) => m.filePath.endsWith('.md'))
+  const harness = enabling.filter((m) => m.filePath === FLAG_HARNESS_PATH)
+  const other = enabling.filter((m) => !m.filePath.endsWith('.md') && m.filePath !== FLAG_HARNESS_PATH)
+  S.postWindowFlagMentionLineCount = mentions.length
+  S.postWindowFlagEnablingLineCountDocs = docs.length
+  S.postWindowFlagEnablingLineCountHarness = harness.length
+  S.postWindowFlagEnablingLineCountOther = other.length
+  for (const hit of other) note('S10 unaccounted committed flag assignment', hit.filePath)
+
+  // End-to-end positive control on the WHOLE pipeline (git grep -> line split -> detector), not just on
+  // the synthetic strings above: this file's own flag-ON walk sets the flag to 'true' in its spawn env,
+  // so the harness bucket MUST be non-empty. If it is empty, the scan and the detector disagree with a
+  // fact this very process demonstrates every dispatch, and no conclusion drawn from it is trustworthy.
+  const pipelineLive = mentions.length > 0 && harness.length > 0
+  must('S10: the flag scan pipeline observed this harness\'s OWN known enabling assignments (end-to-end '
+    + 'positive control on git grep + line parsing + detector together)', pipelineLive,
+    `mentionLines=${mentions.length} harnessEnabling=${harness.length}`)
+
+  const noneUnaccounted = other.length === 0
+  must('S10: no committed file outside documentation prose and this harness\'s own per-arm child env '
+    + 'assigns the S6-A flag an enabling value', noneUnaccounted,
+    `unaccounted=${other.length} docs=${docs.length} harness=${harness.length}`)
+
+  // A GitHub repository/environment VARIABLE only reaches a runtime by being mapped into a job's `env:`,
+  // at which point it is inherited by this process — so this process's OWN environment is exactly the
+  // surface through which such a variable could arm the flag. (The flag never appears in this lane's
+  // job env: the workflow puts it only in the harness's spawned child env, one arm at a time.)
+  const inProcessEnv = String(process.env[S6A_FLAG_NAME] ?? '').trim().toLowerCase() === 'true'
+  S.postWindowFlagInHarnessProcessEnv = String(inProcessEnv)
+  must('S10: the flag is not armed in this job\'s own environment (the only path a repository/environment '
+    + 'variable could take to reach the runtime)', !inProcessEnv, `armedInProcessEnv=${inProcessEnv}`)
+
+  return detectorLive && pipelineLive && noneUnaccounted && !inProcessEnv
+}
+
+// Cleanup evidence (#4708 item 8's second half). Values-free throughout: a YES/NO/NOT_RUN token for the
+// directory, and COUNTS for what the walk left in the database. Containers are destroyed with the job by
+// GitHub itself, which is a property of the runner and is therefore NOT claimed here as something this
+// script observed.
+async function assertPostWindowCleanup() {
+  const artifactRoot = path.resolve(ARTIFACT_ROOT)
+  const captureRoot = path.join(artifactRoot, 'capture')
+  const existedBefore = fs.existsSync(captureRoot)
+  S.captureDirectoryExistedBeforeCleanup = String(existedBefore)
+  if (!existedBefore) {
+    // Removing a directory that was never created proves nothing about retention, so this reports
+    // NOT_RUN rather than a vacuous YES — the same discipline every other phase in this file follows.
+    S.captureDirectoryRemoved = 'NOT_RUN'
+    S.captureDirectoryRemovedReason = 'NO_CAPTURE_DIRECTORY'
+  } else {
+    try {
+      fs.rmSync(artifactRoot, { recursive: true, force: true })
+    } catch {
+      // fall through — the existence check below is what decides, never the absence of a throw
+    }
+    const gone = !fs.existsSync(captureRoot) && !fs.existsSync(artifactRoot)
+    S.captureDirectoryRemoved = gone ? 'YES' : 'NO'
+    must('S10: the flag-ON window\'s artifact-root capture directory is removed afterward', gone,
+      `captureRootGone=${!fs.existsSync(captureRoot)}`)
+  }
+
+  try {
+    const snapshot = await withApplicationPool((pool) =>
+      snapshotS6AWriteState(pool, lastPrimaryOperationId || '<no-such-operation-id>'))
+    S.postWindowRunRowCount = snapshot.counts.runs
+    S.postWindowGenerationCount = snapshot.counts.generations
+    S.postWindowIngestionSessionCount = snapshot.counts.ingestionSessions
+    S.postWindowGenerationRowCount = snapshot.counts.generationRows
+    S.postWindowActivePointerCount = snapshot.counts.activePointers
+    S.postWindowRunStatus = snapshot.runStatus
+  } catch (error) {
+    S.postWindowRunRowCount = 'NOT_RUN'
+    S.postWindowGenerationCount = 'NOT_RUN'
+    S.postWindowIngestionSessionCount = 'NOT_RUN'
+    S.postWindowGenerationRowCount = 'NOT_RUN'
+    S.postWindowActivePointerCount = 'NOT_RUN'
+    S.postWindowRunStatus = 'NOT_RUN'
+    must('S10: post-window run/generation counts read back', false, String(error && error.message || error))
+  }
+}
+
+async function runPostWindowFlagOffRestorationArm() {
+  // Restart flag-OFF (the flag env var is simply not passed — `undefined` is what runFlagArm() already
+  // treats as "no flag at all", identical to phase 1's arm) and re-assert the full three-part gate.
+  await runFlagArm(undefined, false, 'postWindowFlagOff')
+  const routeGateRestored = S.postWindowFlagOffPass === 'PASS'
+  const configClean = await assertFlagAbsentFromCommittedConfiguration()
+  await assertPostWindowCleanup()
+  const restored = routeGateRestored && configClean
+  S.postWindowFlagOffRestored = restored ? 'YES' : 'NO'
+  S.postWindowFlagOffReason = restored ? 'RESTORED' : 'ASSERTION_FAILED'
+}
+
 // ── negative arm helper (exported for the workflow's separate negative-control job) ───────────────────
 export async function main() {
   fs.mkdirSync(OUT_DIR, { recursive: true })
@@ -2469,6 +2776,24 @@ export async function main() {
   S.s6aArm = S6A_ARM
   S.s6aBoundMaxBusinessLines = MAX_BUSINESS_LINES
   S.s6aPrimaryRowCount = DEFAULT_S6A_ROW_COUNT
+
+  // S10 walk-mode evidence (#4708 item 1). Emitted on EVERY dispatch, in both modes: a key that only
+  // appears in package mode would make its absence indistinguishable from "the field was dropped" — the
+  // same finding (review #4724) that made every exit path of attemptS6ARealRun() emit its roll-up key.
+  // packageTgzSha256 is a DIGEST, values-free by this repo's own convention, and reads NOT_RUN in repo
+  // mode because there is no package under test to identify — never an empty string, never a fake zero.
+  S.walkMode = WALK_MODE
+  S.packageTgzSha256 = WALK_MODE === 'package' ? PACKAGE_TGZ_SHA256 : 'NOT_RUN'
+  S.serverRootIsRepoRoot = String(SERVER_ROOT_IS_REPO_ROOT)
+  S.serverEntryResolvedUnderServerRoot = SERVER_ENTRY_RESOLVED
+  // S10 lab mode (#4708 items 5 + 8). Seeded NOT_RUN with the reason this dispatch cannot run the
+  // post-window arm; the arm itself overwrites both when it does run. ARM_DID_NOT_COMPLETE is the
+  // honest reading if this process dies between here and there.
+  S.labMode = String(LAB_MODE)
+  S.postWindowFlagOffRestored = 'NOT_RUN'
+  S.postWindowFlagOffReason = !LAB_MODE
+    ? 'LAB_MODE_NOT_REQUESTED'
+    : (S6A_ARM === 'primary' ? 'ARM_DID_NOT_COMPLETE' : 'NOT_PRIMARY_ARM')
 
   if (S6A_ARM === 'primary') {
     // Phases 1-3 run inside their own try/catch for the SAME reason Phase 4 already had one: an unexpected
@@ -2519,6 +2844,22 @@ export async function main() {
       // the evidence write below entirely, which is exactly the failure mode this whole block exists to
       // avoid.
       await stopServer().catch(() => {})
+    }
+
+    // Phase 6 (S10, lab mode only): the post-ON flag-OFF restoration + cleanup arm. It MUST come after
+    // phase 4 — that is the entire point; the pre-window arms (phases 1-2) cannot say anything about the
+    // state the lane leaves behind once the flag-ON window has closed. Gated on lab mode so a
+    // default-input dispatch performs exactly the phases it always has (this arm restarts the server one
+    // more time, which is a behaviour change, not just an extra evidence key).
+    if (LAB_MODE) {
+      try {
+        await runPostWindowFlagOffRestorationArm()
+      } catch (error) {
+        S.postWindowFlagOffRestored = 'NO'
+        S.postWindowFlagOffReason = 'UNEXPECTED_ERROR'
+        must('S10: post-ON flag-OFF restoration arm attempted', false, String(error && error.message || error))
+        await stopServer().catch(() => {})
+      }
     }
   }
 

--- a/scripts/ops/stock-preparation-e2e-provision-postgres-roles-and-migrate.mjs
+++ b/scripts/ops/stock-preparation-e2e-provision-postgres-roles-and-migrate.mjs
@@ -15,6 +15,8 @@
 //      migration — including 073 — sees them from the very first connection.
 //
 // Env in: PG_SUPERUSER_URL, RUNTIME_ROLE, RUNTIME_PASSWORD, PROVISIONING_ROLE, PROVISIONING_PASSWORD.
+// Optional (S10 package mode, all unset => byte-identical to before): E2E_MIGRATE_ROOT, E2E_MIGRATE_CMD,
+// E2E_MIGRATE_ARGS — see the comment above the spawn in main().
 // Never logs a password or a full connection string.
 
 import { spawn } from 'node:child_process'
@@ -79,9 +81,25 @@ async function main() {
   const migrateUrl = new URL(superuserUrl)
   migrateUrl.searchParams.set('options', options)
 
+  // S10 package-mode override. Unset env => byte-identical to before: the repo tree's own
+  // `pnpm --filter @metasheet/core-backend run migrate` (tsx over src/db/migrate.ts) in REPO_ROOT.
+  // When the e2e lane runs its package-mode leg, the migrations must come from the PACKAGE's own
+  // compiled runner (`node packages/core-backend/dist/src/db/migrate.js`, cwd = extracted package root
+  // — the same invocation stock-prep-main-package-verify.yml and stock-prep-s6a-postgres17-validation.yml
+  // already use), otherwise the "installed package in an isolated runtime" claim would quietly rest on
+  // the repo checkout's TypeScript sources for its schema.
+  const migrateRoot = process.env.E2E_MIGRATE_ROOT ? path.resolve(process.env.E2E_MIGRATE_ROOT) : REPO_ROOT
+  const migrateCmd = (process.env.E2E_MIGRATE_CMD || '').trim() || 'pnpm'
+  const migrateArgs = (process.env.E2E_MIGRATE_ARGS || '').trim()
+    ? (process.env.E2E_MIGRATE_ARGS || '').trim().split(/\s+/).filter(Boolean)
+    : ['--filter', '@metasheet/core-backend', 'run', 'migrate']
+  const migrateMode = migrateRoot === REPO_ROOT ? 'repo' : 'package'
+  // Values-free: a closed-set token, never the path (which is a runner temp location, not evidence).
+  process.stdout.write(`migrateMode=${migrateMode}\n`)
+
   const exitCode = await new Promise((resolve) => {
-    const proc = spawn('pnpm', ['--filter', '@metasheet/core-backend', 'run', 'migrate'], {
-      cwd: REPO_ROOT,
+    const proc = spawn(migrateCmd, migrateArgs, {
+      cwd: migrateRoot,
       env: { ...process.env, DATABASE_URL: migrateUrl.toString() },
       stdio: 'inherit',
     })


### PR DESCRIPTION
## Summary

Closes the two mechanical gaps that kept `stock-preparation-e2e-functional-smoke.yml` from producing **all 8** of #4708's functional evidence items in one dispatch (see #4987 for the map; 6/8 were already green — confirmed today on `main` at 24,999 rows, run 32118845106).

New dispatch input `lab_mode` (choice, default `'false'`). **With the default input the lane is byte-identical to today** — the header's "default-input path must not change" rule is respected; the new job and arm are gated on `lab_mode == 'true'`.

### Gap 1 — package-mode walk (item 1)
`startServer()` now spawns `SERVER_CMD/SERVER_ARGS` in `SERVER_ROOT`; unset env reproduces the old `pnpm --filter @metasheet/core-backend run dev:core` spawn exactly. New `functional-smoke-package` job builds + verifies + extracts the on-prem package **in-job** (same pattern as `stock-prep-main-package-verify.yml` / `stock-prep-staging-window-rehearsal.yml`, pnpm 9.15.9), migrates with `dist/src/db/migrate.js` (provisioning script gains `E2E_MIGRATE_ROOT/CMD/ARGS`), and runs the identical primary walk against `node packages/core-backend/dist/src/index.js` with the package root as cwd. `E2E_WALK_MODE` must agree with the actual target — crossed combos, a missing entry, or a malformed `E2E_PACKAGE_TGZ_SHA256` throw at load. Emits `walkMode=`, `packageTgzSha256=`, `serverRootIsRepoRoot=`, `serverEntryResolvedUnderServerRoot=`.

### Gap 2 — post-ON flag-OFF restoration arm (item 8)
Phase 6 reuses `runFlagArm()` for the three-part gate (health capability `false`, sibling route 200, S6-A route 404/absent) **after** the ON window, `git grep`s the checkout for enabling assignments bucketed into docs / this harness's own child env / unaccounted-must-be-zero (with a detector self-test and an end-to-end positive control), asserts the flag is absent from the job's own env, removes the artifact root, and emits post-window counts. Keys: `postWindowFlagOffRestored`, `captureDirectoryRemoved`, `postWindowFlagEnablingLineCount{Docs,Harness,Other}`, `postWindowRun/Generation/IngestionSession/GenerationRowCount`.

`scripts/ops/stock-preparation-e2e-compute-scale-slope.mjs` gains a `LAB_MODE_INPUT` term so a lab dispatch doesn't false-red the plumbing check.

Still: `permissions: contents: read`, `workflow_dispatch` only for the new job, no schedule/push trigger, synthetic data only, `externalWrite=false` throughout.

### Validation
- `node --check` on all four scripts (what the `contract` job runs); YAML parsed (7 jobs); folded-scalar `if:` gates contain no literal newline.
- Load-matrix probe: 12 env combinations, all expected load/throw outcomes.
- Flag-scan detector run against this checkout: 14 mention lines → 1 doc, 2 harness, **0 unaccounted**.
- Slope script run at default and lab inputs.

**Not verifiable locally (needs a real dispatch with `lab_mode=true`)**: package-mode boot env, in-package `pnpm install --frozen-lockfile` under 9.15.9 in this lane, `dist/src/db/migrate.js` against the role-GUC connection string, GitHub's parse of the effective-row-count expression. Suggested first dispatch after merge: `lab_mode=true`, `s6a_row_count=24999`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
