### PR TITLE
feat(approval): K6 — form-field contact extensions form_field_user_manager / form_field_user_dept_head (Lock-2 §L2-C)

### DIFF
--- a/.github/workflows/approval-realdb-acceptance.yml
+++ b/.github/workflows/approval-realdb-acceptance.yml
@@ -18,6 +18,13 @@ name: Approval real-DB acceptance (Lock-1 assignee kinds)
 #     (tests/integration/approval-prior-node-approver.db.test.ts — G-1/G-2/G-10 dominance publish
 #      gate, actual-decider happy path + multi-seat all/any, OD-L1-3(a) latest-round via return,
 #      OD-L1-4(a) skipped/auto-approved fail-closed, G-12 no-dedup, freeze-of-rule)
+#   - approval-realdb-k6-contact: Lock-2 §L2-C form-field contact extensions
+#     (`form_field_user_manager` / `form_field_user_dept_head` — the FIRST Lock-2 lane in this
+#     file; the standalone-file/sibling-job rationale below applies unchanged)
+#     (tests/integration/approval-form-contact-extensions.db.test.ts — authoring choke, publish
+#      pins C-1/C-2, door-2 create-time 422, create-time freeze + dispatch over BOTH pointers,
+#      C-4 pointer distinctness, empty-vs-wedge split, D-4 freeze purity/temporal, D-2 wedge,
+#      handler admission)
 # Ephemeral first-party PostgreSQL container per job; no customer source, no deployment, no
 # flag change.
 #
@@ -51,6 +58,7 @@ on:
       - 'packages/core-backend/tests/integration/approval-dept-head-chain.db.test.ts'
       - 'packages/core-backend/tests/integration/approval-dept-head-at-level.db.test.ts'
       - 'packages/core-backend/tests/integration/approval-prior-node-approver.db.test.ts'
+      - 'packages/core-backend/tests/integration/approval-form-contact-extensions.db.test.ts'
       - 'packages/core-backend/tests/helpers/approval-schema-bootstrap.ts'
       - 'packages/core-backend/src/db/migrations/zzzz20260818120000_create_approval_usable_member_groups.ts'
       - 'packages/core-backend/src/services/ApprovalProductService.ts'
@@ -69,6 +77,7 @@ on:
       - 'packages/core-backend/tests/integration/approval-dept-head-chain.db.test.ts'
       - 'packages/core-backend/tests/integration/approval-dept-head-at-level.db.test.ts'
       - 'packages/core-backend/tests/integration/approval-prior-node-approver.db.test.ts'
+      - 'packages/core-backend/tests/integration/approval-form-contact-extensions.db.test.ts'
       - 'packages/core-backend/tests/helpers/approval-schema-bootstrap.ts'
       - 'packages/core-backend/src/db/migrations/zzzz20260818120000_create_approval_usable_member_groups.ts'
       - 'packages/core-backend/src/services/ApprovalProductService.ts'
@@ -468,6 +477,85 @@ jobs:
             echo "suite=approval-prior-node-approver.db.test.ts"
             echo "lock=approval-lock1-enterprise-assignees-20260817 §K3"
             echo "gates=G-1,G-2,G-10,G-11,G-12,G-18 (+OD-L1-3a latest-round, OD-L1-4a skipped/auto-approved fail-closed, freeze-of-rule)"
+            echo "sentinelArmed=EXPECT_DB=1"
+            echo "customerSourceAccess=NOT_INVOLVED"
+            echo "flagChanged=false"
+            echo "externalWrite=false"
+          } | tee -a "$GITHUB_STEP_SUMMARY"
+
+  approval-realdb-k6-contact:
+    name: approval-realdb-k6-contact
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: metasheet_approval_realdb
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d metasheet_approval_realdb"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 20
+    env:
+      DATABASE_URL: postgresql://postgres:postgres@127.0.0.1:5432/metasheet_approval_realdb
+      # Arms the suite's TOP-LEVEL anti-skip-green sentinel (the K2/K3 posture): a run in this
+      # lane with a missing/broken DATABASE_URL goes RED instead of silently reporting the whole
+      # suite as skipped.
+      EXPECT_DB: '1'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js 20.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.16.1
+          run_install: false
+
+      - name: Use empty npmrc for pnpm
+        run: |
+          echo "" > /tmp/empty-npmrc
+          echo "NPM_CONFIG_USERCONFIG=/tmp/empty-npmrc" >> "$GITHUB_ENV"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run DB migrations
+        env:
+          # Same per-PR-gate exclusion list as plugin-tests.yml's "Run DB migrations" step
+          # (see the T8 note there and packages/core-backend/MIGRATION_EXCLUDE_TRACKING.md
+          # for the per-item detail) — this lane provisions the identical schema the
+          # approval real-DB steps run against.
+          MIGRATION_EXCLUDE: 008_plugin_infrastructure.sql,048_create_event_bus_tables.sql,049_create_bpmn_workflow_tables.sql,042a_core_model_views.sql,20250924140000_create_gantt_tables.ts,20250925_create_view_tables.sql
+        run: pnpm --filter @metasheet/core-backend db:migrate
+
+      - name: Run Lock-2 §L2-C form-field contact extensions real-DB acceptance (whole file)
+        # WHOLE FILE, --reporter=verbose: a name filter matching zero tests would exit
+        # green and hide regressions; verbose prints every collected test so an empty
+        # collection shows in the log instead of reading as green.
+        run: >-
+          pnpm --filter @metasheet/core-backend exec vitest
+          --config vitest.integration.config.ts run
+          tests/integration/approval-form-contact-extensions.db.test.ts
+          --reporter=verbose
+
+      - name: Values-free evidence (this job)
+        run: |
+          {
+            echo "evidenceKind=CONTROLLED_SYNTHETIC_FUNCTIONAL"
+            echo "suite=approval-form-contact-extensions.db.test.ts"
+            echo "lock=approval-lock2-org-controls-field-routing-20260817 §L2-C"
+            echo "gates=choke,C-1,C-2,door-2(§2.2),core-both-pointers,C-4,C-5,empty-vs-wedge,D-4,D-2,D-5,handler-admission"
             echo "sentinelArmed=EXPECT_DB=1"
             echo "customerSourceAccess=NOT_INVOLVED"
             echo "flagChanged=false"

--- a/apps/web/src/approvals/approvalCapabilityRegistry.ts
+++ b/apps/web/src/approvals/approvalCapabilityRegistry.ts
@@ -65,6 +65,14 @@ export const APPROVAL_ASSIGNEE_SOURCE_LABELS: Record<ApprovalAssigneeSourceKind,
   // below). The cc-as-recipient row (OD-L1-7, §2.3 "a SEPARATE row — the approver row does not
   // admit it") is deferred to its own slice and is NOT added here.
   user_group: '用户组',
+  // Lock-2 §2.4 (RATIFIED 2026-08-17) — the two contact-derived rows (表单内联系人上级 /
+  // 表单内联系人部门负责人), admitted in the SAME slice that lands the publish pins + the
+  // fieldDerivedAssigneeIds snapshot end to end (Lock-2 §2.4 table: "Admitted when: publish pins
+  // + snapshot landed"). Node types `approval` AND `handler` — the handler admission rides
+  // HANDLER_ASSIGNEE_SOURCE_KINDS (grown 7→9 in this same slice), which Lock-2 rules is
+  // corpus-evidenced (C-6), not an M11 widening.
+  form_field_user_manager: '表单内联系人上级',
+  form_field_user_dept_head: '表单内联系人部门负责人',
 }
 
 /** Display order matches parent §10.3's listed order. Kept as an explicit array (rather than
@@ -89,6 +97,10 @@ const SHIPPED_ASSIGNEE_SOURCE_KIND_ORDER: readonly ApprovalAssigneeSourceKind[] 
   'prior_node_approver',
   // Lock-1 §K1: appended after K3 (ratified-kind append order).
   'user_group',
+  // Lock-2 §L2-C: the contact-derived pair appends after the Lock-1 kinds (ratified-kind append
+  // order; leader-pointer kind before parent-tree kind, matching the lock's own C-3 row order).
+  'form_field_user_manager',
+  'form_field_user_dept_head',
 ]
 
 export interface ApprovalAssigneeSourceCapability {

--- a/apps/web/src/approvals/approvalNodeEdit.ts
+++ b/apps/web/src/approvals/approvalNodeEdit.ts
@@ -278,6 +278,15 @@ function isAssigneeSourceValid(source: ApprovalAssigneeSource, topLevelUserField
     // normalizeApprovalAssigneeSources stays the arbiter on the ceiling).
     case 'dept_head_at_level':
       return Number.isInteger(source.level) && source.level >= 1
+    // Lock-2 §L2-C PREVIEW: a non-empty fieldId referencing a TOP-LEVEL `user` field (the shipped
+    // form_field_user posture) plus a level integer ≥ 1 (backend normalizeApprovalAssigneeSources
+    // stays the arbiter on the ceiling; the required/visibility/selection pins are the backend
+    // publish validator's job — the FE field picker only OFFERS eligible fields).
+    case 'form_field_user_manager':
+    case 'form_field_user_dept_head':
+      if (source.fieldId.trim().length === 0) return false
+      if (!Number.isInteger(source.level) || source.level < 1) return false
+      return topLevelUserFieldIds ? topLevelUserFieldIds.has(source.fieldId.trim()) : true
     // Lock-1 §K3 PREVIEW: a non-empty referenced node key. Whether the reference is legal
     // (an approval node strictly upstream on every runtime-reachable path) is the backend
     // PUBLISH gate's job (`assertPriorNodeApproverReferencesUpstream`); the FE picker only

--- a/apps/web/src/approvals/assigneeSource.ts
+++ b/apps/web/src/approvals/assigneeSource.ts
@@ -28,6 +28,11 @@ export function assigneeSourceSummary(source: ApprovalAssigneeSource): string {
     case 'manager_at_level': return `指定层级上级（第 ${source.level} 级）`
     case 'continuous_dept_heads': return `连续多级部门负责人（${source.levels} 级）`
     case 'dept_head_at_level': return `指定层级部门负责人（第 ${source.level} 级）`
+    // Lock-2 §L2-C: the concrete person derives from the contact chosen in the referenced form
+    // field at submit time — the summary names the template-authored field id + level (values-free;
+    // never a person id), mirroring the shipped form_field_user summary's field-id posture.
+    case 'form_field_user_manager': return `表单内联系人上级：${source.fieldId}（第 ${source.level} 级）`
+    case 'form_field_user_dept_head': return `表单内联系人部门负责人：${source.fieldId}（第 ${source.level} 级）`
     // Lock-1 §K2: pre-choice placeholder — the approver is unknowable until the requester
     // chooses at submit time, so the flow/route preview says exactly that.
     case 'requester_choice': return '提交人自选（提交时选择）'

--- a/apps/web/src/approvals/components/ApprovalGraphNodeConfigEditor.vue
+++ b/apps/web/src/approvals/components/ApprovalGraphNodeConfigEditor.vue
@@ -523,6 +523,48 @@
             />
           </el-select>
         </el-form-item>
+        <!-- Lock-2 §L2-C (表单内联系人上级 / 表单内联系人部门负责人) authoring sub-form: the SAME
+             typed field picker as form_field_user (top-level `user` fields only — never a raw field
+             id input) PLUS a single level input. The picker only OFFERS schema fields; the
+             required / no-visibility-rule / no-multi pins are enforced by the backend publish
+             validator, and the hint DISCLOSES them at authoring time (OD-L2-4's authoring-copy
+             disclosure posture). Both controls are live and emitted on save — no inert control. -->
+        <template v-else-if="approvalSourceKind(node.key, sourceIndex) === 'form_field_user_manager' || approvalSourceKind(node.key, sourceIndex) === 'form_field_user_dept_head'">
+          <el-form-item label="表单内联系人字段">
+            <el-select
+              :model-value="approvalSourceFieldId(node.key, sourceIndex)"
+              size="small"
+              :disabled="readOnly"
+              class="ms-w-240"
+              placeholder="选择表单联系人字段"
+              data-testid="approval-node-source-contact-field"
+              @update:model-value="(fieldId: string) => setApprovalSourceFieldId(node.key, sourceIndex, fieldId)"
+            >
+              <el-option
+                v-for="field in userFields"
+                :key="field.id"
+                :label="field.label || '未命名字段'"
+                :value="field.id"
+              />
+            </el-select>
+            <p
+              class="template-authoring__hint"
+              data-testid="approval-node-source-contact-field-hint"
+            >所选联系人字段须为必填且不带显示条件，发布时校验</p>
+          </el-form-item>
+          <el-form-item :label="approvalSourceKind(node.key, sourceIndex) === 'form_field_user_manager' ? '指定联系人上级层级' : '指定联系人部门负责人层级'">
+            <el-input-number
+              :model-value="approvalSourceLevel(node.key, sourceIndex)"
+              :min="1"
+              :max="10"
+              :step="1"
+              size="small"
+              :disabled="readOnly"
+              data-testid="approval-node-source-contact-level"
+              @update:model-value="(value: number) => setApprovalSourceLevel(node.key, sourceIndex, value ?? 1)"
+            />
+          </el-form-item>
+        </template>
         <el-form-item
           v-else-if="approvalSourceKind(node.key, sourceIndex) === 'manager_at_level' || approvalSourceKind(node.key, sourceIndex) === 'continuous_managers' || approvalSourceKind(node.key, sourceIndex) === 'continuous_dept_heads' || approvalSourceKind(node.key, sourceIndex) === 'dept_head_at_level'"
           :label="approvalSourceKind(node.key, sourceIndex) === 'manager_at_level' ? '指定上级层级' : approvalSourceKind(node.key, sourceIndex) === 'continuous_dept_heads' ? '部门负责人层级数' : approvalSourceKind(node.key, sourceIndex) === 'dept_head_at_level' ? '指定部门负责人层级' : '上级层级数'"
@@ -1128,7 +1170,24 @@ const showFieldPermissionsSection = computed(
 
 // ── Lock-0 L0-2 capability registry ──────────────────────────────────────────────────────────
 const registry = computed(() => props.registry ?? DEFAULT_APPROVAL_CAPABILITY_REGISTRY)
-const assigneeSourceRosterForNode = computed(() => assigneeSourceRoster(registry.value, props.node.type))
+const assigneeSourceRosterForNode = computed(() => {
+  const roster = assigneeSourceRoster(registry.value, props.node.type)
+  // Lock-2 §2.4 C-7 form-schema precondition (gate D-6): the two contact-derived kinds are
+  // OFFERED only when the form declares an eligible (top-level `user`) field — the affordance is
+  // schema-selected, and the backend publish validator remains the enforcement (an affordance is
+  // not a boundary). A kind ALREADY configured on this node stays offered regardless, so a
+  // persisted source never loses its checked radio when the form's last user field is removed
+  // (the unknown-value-safety posture: presentation must not orphan a stored value).
+  if (userFields.value.length > 0) return roster
+  const configuredKinds = new Set(
+    (approvalNodeEditFor(props.node.key)?.assigneeSources ?? []).map((source) => source.kind),
+  )
+  return roster.filter(
+    (capability) =>
+      (capability.kind !== 'form_field_user_manager' && capability.kind !== 'form_field_user_dept_head')
+      || configuredKinds.has(capability.kind),
+  )
+})
 const operationPoliciesForNode = computed(
   () => registry.value.operationPoliciesByNodeType[props.node.type] ?? [],
 )

--- a/apps/web/src/approvals/parallelEdit.ts
+++ b/apps/web/src/approvals/parallelEdit.ts
@@ -170,6 +170,13 @@ function dynamicAssigneeSourceFingerprint(source: ApprovalAssigneeSource): strin
       return `prior_node_approver:${source.nodeKey}`
     case 'form_field_user':
       return `form_field_user:${source.fieldId.trim()}`
+    // Lock-2 §2.5 locked entries — `<kind>:<fieldId>:<level>`, provably identical for the same
+    // field and level. Backend mirror: ApprovalAssigneeResolver.fieldDerivedAssigneeSourceKey
+    // (consumed by BOTH the backend fingerprint and the frozen-snapshot key) — keep in lockstep.
+    case 'form_field_user_manager':
+      return `form_field_user_manager:${source.fieldId.trim()}:${source.level}`
+    case 'form_field_user_dept_head':
+      return `form_field_user_dept_head:${source.fieldId.trim()}:${source.level}`
     case 'static_user':
     case 'static_role':
       return null

--- a/apps/web/src/approvals/templateAuthoring.ts
+++ b/apps/web/src/approvals/templateAuthoring.ts
@@ -682,6 +682,12 @@ function stepDraftFromApprovalNode(
     // Lock-1 §K1: dedicated array field — a group option list, never the shared idsText carrier.
     sourceKind = 'user_group'
     groupIds = [...source.groupIds]
+  } else if (source?.kind === 'form_field_user_manager' || source?.kind === 'form_field_user_dept_head') {
+    // Lock-2 §L2-C: field picker + single level — reuses the shared `fieldId` AND `level` fields
+    // (they coexist on the draft; each is meaningful only for the kinds that read it).
+    sourceKind = source.kind
+    fieldId = source.fieldId
+    level = source.level
   } else if (legacyType === 'user') {
     sourceKind = 'static_user'
     idsText = formatIds(legacyIds)
@@ -905,6 +911,9 @@ const BACKEND_ASSIGNEE_SOURCE_KEYS_BY_KIND: Record<string, string[]> = {
   // Lock-1 §K3: flat 2-level shape — the referenced prior node's key.
   prior_node_approver: ['kind', 'nodeKey'],
   form_field_user: ['kind', 'fieldId'],
+  // Lock-2 §L2-C: flat 3-key shape (field picker + single level).
+  form_field_user_manager: ['kind', 'fieldId', 'level'],
+  form_field_user_dept_head: ['kind', 'fieldId', 'level'],
   // Lock-1 §K2: `scope` is the ONE nested object in the source union (see
   // requesterChoiceSourceHasBackendDrop below for its per-type key check — the flat 2-level
   // allowlist alone cannot see inside it).
@@ -1232,7 +1241,7 @@ export function unsupportedTemplateAuthoringReason(template: ApprovalTemplateDet
     if (sources !== undefined) {
       if (!Array.isArray(sources) || sources.length !== 1) return true
       const source = sources[0] as ApprovalAssigneeSource
-      if (!['static_user', 'static_role', 'requester', 'form_field_user', 'direct_manager', 'dept_head', 'continuous_managers', 'manager_at_level', 'requester_choice', 'continuous_dept_heads', 'dept_head_at_level', 'prior_node_approver', 'user_group'].includes(source?.kind)) return true
+      if (!['static_user', 'static_role', 'requester', 'form_field_user', 'direct_manager', 'dept_head', 'continuous_managers', 'manager_at_level', 'requester_choice', 'continuous_dept_heads', 'dept_head_at_level', 'prior_node_approver', 'user_group', 'form_field_user_manager', 'form_field_user_dept_head'].includes(source?.kind)) return true
       // Lock-1 §K2: a malformed requester_choice shape must fail-closed to read-only here too —
       // hydrate would otherwise re-derive a default mode/scope and silently flatten it on save.
       if (source?.kind === 'requester_choice' && requesterChoiceSourceHasBackendDrop(source as unknown as Record<string, unknown>)) return true
@@ -1558,6 +1567,10 @@ export function sourceFromStep(step: ApprovalStepDraft, allSteps?: ApprovalStepD
   if (step.sourceKind === 'dept_head_at_level') {
     // Lock-1 §K5-b: reuses the shared `level` field (same shape as manager_at_level).
     return { kind: 'dept_head_at_level', level: step.level }
+  }
+  if (step.sourceKind === 'form_field_user_manager' || step.sourceKind === 'form_field_user_dept_head') {
+    // Lock-2 §L2-C: reuses the shared `fieldId` + `level` fields (field picker + single level).
+    return { kind: step.sourceKind, fieldId: step.fieldId, level: step.level }
   }
   if (step.sourceKind === 'requester_choice') {
     // Lock-1 §K2: re-shape the shared idsText carrier into the per-scope id list.

--- a/apps/web/src/types/approval.ts
+++ b/apps/web/src/types/approval.ts
@@ -18,7 +18,7 @@ export const APPROVAL_ROLE_CONFIGURE_SENTINEL = '__APPROVAL_ROLE_PLACEHOLDER__'
 // `APPROVAL_NODE_TYPES` admission set.
 export type ApprovalNodeType = 'start' | 'approval' | 'cc' | 'condition' | 'parallel' | 'end' | 'handler'
 export type ApprovalAssigneeType = 'user' | 'role'
-export type ApprovalAssigneeSourceKind = 'static_user' | 'static_role' | 'requester' | 'form_field_user' | 'direct_manager' | 'dept_head' | 'continuous_managers' | 'manager_at_level' | 'requester_choice' | 'continuous_dept_heads' | 'dept_head_at_level' | 'prior_node_approver' | 'user_group'
+export type ApprovalAssigneeSourceKind = 'static_user' | 'static_role' | 'requester' | 'form_field_user' | 'direct_manager' | 'dept_head' | 'continuous_managers' | 'manager_at_level' | 'requester_choice' | 'continuous_dept_heads' | 'dept_head_at_level' | 'prior_node_approver' | 'user_group' | 'form_field_user_manager' | 'form_field_user_dept_head'
 // P1-C (approval-parity-master-design-lock-20260817.md §P1-C / M6): 'threshold' is the shipped
 // ENGINE 4th mode (N-of-M / 门槛会签, ApprovalGraphExecutor.ts `normalizeApprovalMode`) — this type
 // was FE-unexposed until this slice. Byte-mirrors backend packages/core-backend/src/types/
@@ -75,6 +75,12 @@ export const HANDLER_ASSIGNEE_SOURCE_KINDS = [
   'direct_manager',
   'dept_head',
   'manager_at_level',
+  // Lock-2 §2.4 (RATIFIED 2026-08-17): the two contact-derived rows are ratified for node types
+  // `approval` AND `handler` (corpus C-6; Lock-2 resolves the between-locks gap Lock-3 §1.5 left —
+  // its forward-row sentence names only 表单内部门 while its roster lists 表单内联系人). Grows the
+  // exact set 7→9 in the SAME slice as the kinds, with the G-13 exact-set tests updated together.
+  'form_field_user_manager',
+  'form_field_user_dept_head',
 ] as const
 export type HandlerAssigneeSourceKind = typeof HANDLER_ASSIGNEE_SOURCE_KINDS[number]
 // Lock-3 §1.1 — handler aggregation mode. `'all'` 会签 / `'any'` 或签; absent ≡ 'all'.
@@ -302,6 +308,26 @@ export type ApprovalAssigneeSource =
    * (OD-L1-7) is a SEPARATE contract/registry row, not part of this shape.
    */
   | { kind: 'user_group'; groupIds: string[] }
+  /**
+   * Lock-2 §L2-C — 表单内联系人上级 (C-3 联系人上级). Byte-mirrors the backend union member: the
+   * person chosen in the referenced TOP-LEVEL `user` field is the ANCHOR, and the source resolves
+   * that person's manager at chain position `level` (level 1 = the anchor's own direct manager)
+   * via the `leader_in_dept` LEADER pointer, resolved AND FROZEN at create (submit IS create) into
+   * the instance snapshot — never re-read at dispatch. Publish pins: the field must exist
+   * top-level, be `type: 'user'`, `required: true`, carry NO `visibilityRule`, and not declare
+   * `selection: 'multi'`. Authoring shape = field picker + a single level input (upward only in
+   * v1; downward stays blocked on Lock-1 OD-L1-6).
+   */
+  | { kind: 'form_field_user_manager'; fieldId: string; level: number }
+  /**
+   * Lock-2 §L2-C — 表单内联系人部门负责人 (C-3 联系人部门负责人). Same anchor and freeze semantics
+   * as `form_field_user_manager` above, but a DIFFERENT pointer: the chosen contact's PRIMARY
+   * department, then the department PARENT tree reading `dept_manager_userid_list` per level
+   * (K4's walker re-anchored; the ratified continue-past-empty-level posture binds it — the chain
+   * is DENSE, so `level` addresses the level-th *resolved* head walking up). Same publish pins,
+   * same field-picker + level-input authoring shape.
+   */
+  | { kind: 'form_field_user_dept_head'; fieldId: string; level: number }
 
 export type RequesterChoiceAssigneeSource = Extract<ApprovalAssigneeSource, { kind: 'requester_choice' }>
 

--- a/apps/web/src/views/approval/TemplateAuthoringView.vue
+++ b/apps/web/src/views/approval/TemplateAuthoringView.vue
@@ -601,6 +601,21 @@
                 <el-option label="指定层级部门负责人" value="dept_head_at_level" />
                 <el-option label="节点审批人" value="prior_node_approver" />
                 <el-option label="用户组" value="user_group" />
+                <!-- Lock-2 §2.4 C-7 form-schema precondition (D-6): the contact-extension kinds
+                     are OFFERED only when the form declares a user field — the affordance is
+                     schema-selected; a persisted selection stays rendered via the v-if's
+                     already-selected escape so a stored value is never orphaned. The backend
+                     publish validator remains the enforcement. -->
+                <el-option
+                  v-if="userFields.length > 0 || step.sourceKind === 'form_field_user_manager'"
+                  label="表单内联系人上级"
+                  value="form_field_user_manager"
+                />
+                <el-option
+                  v-if="userFields.length > 0 || step.sourceKind === 'form_field_user_dept_head'"
+                  label="表单内联系人部门负责人"
+                  value="form_field_user_dept_head"
+                />
               </el-select>
             </el-form-item>
             <el-form-item v-if="step.sourceKind === 'continuous_managers'" label="上级层级数">
@@ -749,6 +764,33 @@
                 />
               </el-select>
             </el-form-item>
+            <!-- Lock-2 §L2-C (表单内联系人上级/部门负责人) linear authoring: typed field picker
+                 over the form's user fields (never a raw field-id input) + a single level input,
+                 reusing the shared `fieldId` and `level` draft fields. The hint discloses the
+                 publish pins (required + no visibility rule) at authoring time. -->
+            <template v-if="step.sourceKind === 'form_field_user_manager' || step.sourceKind === 'form_field_user_dept_head'">
+              <el-form-item label="表单内联系人字段">
+                <el-select v-model="step.fieldId" :disabled="readOnly" class="ms-w-100pct" data-testid="approval-step-contact-field">
+                  <el-option
+                    v-for="field in userFields"
+                    :key="field.id"
+                    :label="fieldDisplayLabel(field)"
+                    :value="field.id"
+                  />
+                </el-select>
+                <p class="template-authoring__hint" data-testid="approval-step-contact-field-hint">所选联系人字段须为必填且不带显示条件，发布时校验</p>
+              </el-form-item>
+              <el-form-item :label="step.sourceKind === 'form_field_user_manager' ? '指定联系人上级层级' : '指定联系人部门负责人层级'">
+                <el-input-number
+                  v-model="step.level"
+                  :min="1"
+                  :max="10"
+                  :step="1"
+                  :disabled="readOnly"
+                  data-testid="approval-step-contact-level"
+                />
+              </el-form-item>
+            </template>
             <!-- Lock-1 §K2 (提交人自选) linear authoring: mode + scope with typed pickers only
                  (the scope id list rides the shared idsText chip carrier via stepIds/setStepIds). -->
             <el-form-item v-if="step.sourceKind === 'requester_choice'" label="选择方式">
@@ -2432,6 +2474,10 @@ function defaultApprovalSourceForKind(kind: ApprovalAssigneeSourceKind): Approva
             : kind === 'requester_choice' ? { kind, mode: 'single', scope: { type: 'company' } }
               // Lock-1 §K4: same default shape as continuous_managers.
               : kind === 'continuous_dept_heads' ? { kind, levels: 1 }
+                // Lock-2 §L2-C: field picker + single level — fieldId starts unchosen ('' is
+                // invalid to save; the picker must be used) and level defaults to 1 (直属).
+                : kind === 'form_field_user_manager' ? { kind, fieldId: '', level: 1 }
+                  : kind === 'form_field_user_dept_head' ? { kind, fieldId: '', level: 1 }
                 // Lock-1 §K5-b: same default shape as manager_at_level.
                 : kind === 'dept_head_at_level' ? { kind, level: 1 }
                   // Lock-1 §K3: '' = not yet chosen — invalid to save until the typed picker
@@ -3089,9 +3135,18 @@ function setApprovalSourceIdsFromPicker(nodeKey: string, sourceIndex: number, id
 }
 function approvalSourceFieldId(nodeKey: string, sourceIndex: number): string {
   const source = approvalNodeSourceAt(nodeKey, sourceIndex)
-  return source?.kind === 'form_field_user' ? source.fieldId : ''
+  if (source?.kind === 'form_field_user') return source.fieldId
+  // Lock-2 §L2-C: the contact-extension kinds carry a fieldId too (field picker + level).
+  if (source?.kind === 'form_field_user_manager' || source?.kind === 'form_field_user_dept_head') return source.fieldId
+  return ''
 }
 function setApprovalSourceFieldId(nodeKey: string, sourceIndex: number, fieldId: string): void {
+  const current = approvalNodeSourceAt(nodeKey, sourceIndex)
+  // Lock-2 §L2-C: preserve the kind + configured level — only the referenced field changes.
+  if (current?.kind === 'form_field_user_manager' || current?.kind === 'form_field_user_dept_head') {
+    setApprovalNodeSourceAt(nodeKey, sourceIndex, { kind: current.kind, fieldId, level: current.level })
+    return
+  }
   setApprovalNodeSourceAt(nodeKey, sourceIndex, { kind: 'form_field_user', fieldId })
 }
 function approvalSourceLevel(nodeKey: string, sourceIndex: number): number {
@@ -3102,6 +3157,8 @@ function approvalSourceLevel(nodeKey: string, sourceIndex: number): number {
   if (source?.kind === 'continuous_dept_heads') return source.levels
   // Lock-1 §K5-b: same shared-field shape as manager_at_level.
   if (source?.kind === 'dept_head_at_level') return source.level
+  // Lock-2 §L2-C: the contact-extension kinds carry a single level beside their fieldId.
+  if (source?.kind === 'form_field_user_manager' || source?.kind === 'form_field_user_dept_head') return source.level
   return 1
 }
 function setApprovalSourceLevel(nodeKey: string, sourceIndex: number, value: number): void {
@@ -3110,6 +3167,12 @@ function setApprovalSourceLevel(nodeKey: string, sourceIndex: number, value: num
   else if (kind === 'continuous_managers') setApprovalNodeSourceAt(nodeKey, sourceIndex, { kind, levels: value })
   else if (kind === 'continuous_dept_heads') setApprovalNodeSourceAt(nodeKey, sourceIndex, { kind, levels: value })
   else if (kind === 'dept_head_at_level') setApprovalNodeSourceAt(nodeKey, sourceIndex, { kind, level: value })
+  else if (kind === 'form_field_user_manager' || kind === 'form_field_user_dept_head') {
+    // Lock-2 §L2-C: preserve the configured fieldId — only the level changes.
+    const current = approvalNodeSourceAt(nodeKey, sourceIndex)
+    const fieldId = current?.kind === kind ? current.fieldId : ''
+    setApprovalNodeSourceAt(nodeKey, sourceIndex, { kind, fieldId, level: value })
+  }
 }
 
 const userFields = computed(() => draft.value.fields.filter((field) => field.type === 'user' && field.id.trim()))
@@ -3131,12 +3194,14 @@ const fieldPermissionFields = computed(() => draft.value.fields.filter((field) =
 // condition because they read the identical Set, not two independently-derived ones.
 const routingDriverFieldIds = computed(() => {
   const ids = new Set<string>()
+  const driverKinds = new Set(['form_field_user', 'form_field_user_manager', 'form_field_user_dept_head'])
   for (const step of draft.value.steps) {
-    if (step.sourceKind === 'form_field_user' && step.fieldId.trim()) ids.add(step.fieldId.trim())
+    if (driverKinds.has(step.sourceKind) && step.fieldId.trim()) ids.add(step.fieldId.trim())
   }
   for (const edit of Object.values(draft.value.approvalNodeEdits ?? {})) {
     for (const source of edit.assigneeSources) {
-      if (source.kind === 'form_field_user' && source.fieldId.trim()) ids.add(source.fieldId.trim())
+      // Lock-2 §L2-C: the contact-extension kinds reference a driver field too — same hint.
+      if ((source.kind === 'form_field_user' || source.kind === 'form_field_user_manager' || source.kind === 'form_field_user_dept_head') && source.fieldId.trim()) ids.add(source.fieldId.trim())
     }
   }
   return ids

--- a/apps/web/tests/approval-assignee-source.test.ts
+++ b/apps/web/tests/approval-assignee-source.test.ts
@@ -46,6 +46,12 @@ describe('assigneeSourceSummary (single source)', () => {
     expect(assigneeSourceSummary({ kind: 'continuous_dept_heads', levels: 3 })).toBe('连续多级部门负责人（3 级）')
   })
 
+  it('form_field_user_manager: names the template-authored field id + level, never a person id (Lock-2 §L2-C)', () => {
+    expect(assigneeSourceSummary({ kind: 'form_field_user_manager', fieldId: 'contact', level: 2 })).toBe('表单内联系人上级：contact（第 2 级）')
+  })
+  it('form_field_user_dept_head: names the template-authored field id + level, never a person id (Lock-2 §L2-C)', () => {
+    expect(assigneeSourceSummary({ kind: 'form_field_user_dept_head', fieldId: 'contact', level: 1 })).toBe('表单内联系人部门负责人：contact（第 1 级）')
+  })
   it('dept_head_at_level: includes the specific level (Lock-1 §K5-b)', () => {
     expect(assigneeSourceSummary({ kind: 'dept_head_at_level', level: 2 })).toBe('指定层级部门负责人（第 2 级）')
   })

--- a/apps/web/tests/approval-template-authoring-approval-node-edit.test.ts
+++ b/apps/web/tests/approval-template-authoring-approval-node-edit.test.ts
@@ -256,6 +256,38 @@ describe('validateApprovalNodeEdits (preview mirrors the backend assignee rule)'
       a: { nodeKey: 'a', assigneeSources: [{ kind: 'dept_head_at_level', level: 1.5 }] },
     })[0]).toMatch(/dept_head_at_level/)
   })
+  it('Lock-2 §L2-C: form_field_user_manager / form_field_user_dept_head — a schema-present fieldId + positive integer level passes; blank/dangling fieldId and 0/non-integer level are flagged (isAssigneeSourceValid mirror site)', () => {
+    const fields = [{ id: 'contact', type: 'user' as const, label: '联系人' }]
+    for (const kind of ['form_field_user_manager', 'form_field_user_dept_head'] as const) {
+      expect(validateApprovalNodeEdits({
+        a: { nodeKey: 'a', assigneeSources: [{ kind, fieldId: 'contact', level: 2 }] },
+      }, fields)).toEqual([])
+      expect(validateApprovalNodeEdits({
+        a: { nodeKey: 'a', assigneeSources: [{ kind, fieldId: '', level: 2 }] },
+      }, fields)[0]).toMatch(new RegExp(kind))
+      expect(validateApprovalNodeEdits({
+        a: { nodeKey: 'a', assigneeSources: [{ kind, fieldId: 'dangling', level: 2 }] },
+      }, fields)[0]).toMatch(new RegExp(kind))
+      expect(validateApprovalNodeEdits({
+        a: { nodeKey: 'a', assigneeSources: [{ kind, fieldId: 'contact', level: 0 }] },
+      }, fields)[0]).toMatch(new RegExp(kind))
+      expect(validateApprovalNodeEdits({
+        a: { nodeKey: 'a', assigneeSources: [{ kind, fieldId: 'contact', level: 1.5 }] },
+      }, fields)[0]).toMatch(new RegExp(kind))
+    }
+  })
+  // Lock-2 §2.4: the contact-extension pair IS handler-admitted (unlike K5-b below) — a handler
+  // edit carrying either kind must PASS the roster check (positive control for the 7→9 growth).
+  it('Lock-2 §2.4: a HANDLER node carrying form_field_user_manager / form_field_user_dept_head passes the (now nine-member) handler roster', () => {
+    const fields = [{ id: 'contact', type: 'user' as const, label: '联系人' }]
+    expect(validateApprovalNodeEdits({
+      a: { nodeKey: 'a', nodeType: 'handler', assigneeSources: [{ kind: 'form_field_user_manager', fieldId: 'contact', level: 1 }] },
+    }, fields)).toEqual([])
+    expect(validateApprovalNodeEdits({
+      a: { nodeKey: 'a', nodeType: 'handler', assigneeSources: [{ kind: 'form_field_user_dept_head', fieldId: 'contact', level: 1 }] },
+    }, fields)).toEqual([])
+  })
+
   // Lock-3 §1.5 deferral invariant: dept_head_at_level (K5-b) is NOT in the handler roster in
   // this slice (Lock-3's forward ADMIT is a separate follow-up — see
   // approval-handler-node-authoring.spec.ts's exact-set test). A handler carrying it must fail
@@ -470,6 +502,26 @@ describe('G-5 fail-closed — complex approval-node config must stay within the 
   it('K5-b: a dept_head_at_level source with an unknown extra key forces read-only', () => {
     const graph = complexWith({ assigneeSources: [{ kind: 'dept_head_at_level', level: 2, futureFlag: true }] })
     expect(unsupportedTemplateAuthoringReason(buildTemplate(graph))).not.toBeNull()
+  })
+
+  // Lock-2 §L2-C — BACKEND_ASSIGNEE_SOURCE_KEYS_BY_KIND mirror site: the contact-extension pair
+  // must be ALLOWED (present in the allowlist) on the complex path, and an extra key must still
+  // be caught (the allowlist is per-kind exact, not a blanket pass-through).
+  it('K6: form_field_user_manager / form_field_user_dept_head are allowed on the complex path (registered in BACKEND_ASSIGNEE_SOURCE_KEYS_BY_KIND)', () => {
+    expect(unsupportedTemplateAuthoringReason(buildTemplate(
+      complexWith({ assigneeSources: [{ kind: 'form_field_user_manager', fieldId: 'contact', level: 2 }] }),
+    ))).toBeNull()
+    expect(unsupportedTemplateAuthoringReason(buildTemplate(
+      complexWith({ assigneeSources: [{ kind: 'form_field_user_dept_head', fieldId: 'contact', level: 1 }] }),
+    ))).toBeNull()
+  })
+  it('K6: a contact-extension source with an unknown extra key forces read-only', () => {
+    expect(unsupportedTemplateAuthoringReason(buildTemplate(
+      complexWith({ assigneeSources: [{ kind: 'form_field_user_manager', fieldId: 'contact', level: 2, futureFlag: true }] }),
+    ))).not.toBeNull()
+    expect(unsupportedTemplateAuthoringReason(buildTemplate(
+      complexWith({ assigneeSources: [{ kind: 'form_field_user_dept_head', fieldId: 'contact', level: 1, futureFlag: true }] }),
+    ))).not.toBeNull()
   })
 
   // Lock-1 §K3 — BACKEND_ASSIGNEE_SOURCE_KEYS_BY_KIND mirror site: prior_node_approver must be

--- a/apps/web/tests/approval-template-authoring-canvas-inspector.spec.ts
+++ b/apps/web/tests/approval-template-authoring-canvas-inspector.spec.ts
@@ -994,7 +994,7 @@ describe('Canvas V2 Slice A — canvas inspector', () => {
   // "iterate the exported table" mechanical assertion, not per-kind spot checks), so any single
   // label reverting to pre-D1 wording (or drifting to anything else) reds here regardless of
   // whether it happens to be one of the two kinds the D1/D2 test exercises.
-  it('D1 (P2-2): all thirteen assignee-source labels equal the ratified map by exact object equality', () => {
+  it('D1 (P2-2): all fifteen assignee-source labels equal the ratified map by exact object equality', () => {
     const RATIFIED_APPROVAL_ASSIGNEE_SOURCE_LABELS: Record<string, string> = {
       static_user: '指定成员',
       static_role: '指定角色',
@@ -1024,11 +1024,16 @@ describe('Canvas V2 Slice A — canvas inspector', () => {
       // "Admitted when: OD-L1-1 + OD-L1-2 decided; resolver, org binding, and picker landed").
       // The cc-as-recipient row (OD-L1-7) is a SEPARATE row NOT admitted by this slice.
       user_group: '用户组',
+      // Lock-2 §2.4 (RATIFIED 2026-08-17) — the two contact-derived rows (表单内联系人上级 /
+      // 表单内联系人部门负责人), admitted in the SAME slice that lands the publish pins + the
+      // fieldDerivedAssigneeIds snapshot end to end (Lock-2 §2.4 table).
+      form_field_user_manager: '表单内联系人上级',
+      form_field_user_dept_head: '表单内联系人部门负责人',
     }
     expect(APPROVAL_ASSIGNEE_SOURCE_LABELS).toEqual(RATIFIED_APPROVAL_ASSIGNEE_SOURCE_LABELS)
-    // Also pin the count so a stray 14th entry (which would still satisfy `toEqual` on the keys
+    // Also pin the count so a stray 16th entry (which would still satisfy `toEqual` on the keys
     // above via structural superset checks in some matcher semantics) cannot slip through unnoticed.
-    expect(Object.keys(APPROVAL_ASSIGNEE_SOURCE_LABELS)).toHaveLength(13)
+    expect(Object.keys(APPROVAL_ASSIGNEE_SOURCE_LABELS)).toHaveLength(15)
   })
 
   it('A-7: no scrim/overlay-mask element with the inspector mounted and visible', async () => {
@@ -1928,17 +1933,21 @@ describe('Lock-0 P1-A — registry-driven tab membership + roster (direct mount)
     unmount()
   })
 
-  it('A-3: roster equals the thirteen-member ApprovalAssigneeSourceKind union by exact set equality, not count or subset', () => {
+  it('A-3: roster equals the fifteen-member ApprovalAssigneeSourceKind union by exact set equality, not count or subset', () => {
     // Lock-1 §2.3: the exact-set gate grows from eight to eight-plus-ratified-K-kinds in the
     // SAME commit that lands each kind — K2 `requester_choice`, K4 `continuous_dept_heads`, K5-b
-    // `dept_head_at_level`, K3 `prior_node_approver`, K1 `user_group`.
-    const CANONICAL_THIRTEEN = [
+    // `dept_head_at_level`, K3 `prior_node_approver`, K1 `user_group`; Lock-2 §2.4 adds the
+    // contact-derived pair `form_field_user_manager` / `form_field_user_dept_head` in the SAME
+    // slice as the kinds.
+    const CANONICAL_FIFTEEN = [
       'continuous_dept_heads',
       'continuous_managers',
       'dept_head',
       'dept_head_at_level',
       'direct_manager',
       'form_field_user',
+      'form_field_user_dept_head',
+      'form_field_user_manager',
       'manager_at_level',
       'prior_node_approver',
       'requester',
@@ -1947,10 +1956,14 @@ describe('Lock-0 P1-A — registry-driven tab membership + roster (direct mount)
       'static_user',
       'user_group',
     ]
+    // Lock-2 §2.4 hazard closure: the roster ORDER array and the LABELS record must name the
+    // exact same kind set — a kind present in the labels record but absent from the order array
+    // used to render with a green build and a green suite; this set-equality makes that red.
+    expect([...Object.keys(APPROVAL_ASSIGNEE_SOURCE_LABELS)].sort()).toEqual(CANONICAL_FIFTEEN)
     const roster = [...assigneeSourceRoster(DEFAULT_APPROVAL_CAPABILITY_REGISTRY, 'approval')]
       .map((opt) => opt.kind)
       .sort()
-    expect(roster).toEqual(CANONICAL_THIRTEEN)
+    expect(roster).toEqual(CANONICAL_FIFTEEN)
 
     const node = makeApprovalNode('approval_x')
     const { container: c, unmount } = mountDirectInspector({
@@ -1963,7 +1976,7 @@ describe('Lock-0 P1-A — registry-driven tab membership + roster (direct mount)
     )
       .map((el) => el.getAttribute('data-testid')?.replace('approval-node-source-kind-', ''))
       .sort()
-    expect(rendered).toEqual(CANONICAL_THIRTEEN)
+    expect(rendered).toEqual(CANONICAL_FIFTEEN)
     unmount()
   })
 
@@ -2025,6 +2038,28 @@ describe('Lock-0 P1-A — registry-driven tab membership + roster (direct mount)
     unmount()
   })
 
+  // Lock-2 §L2-C — the contact-extension pair's authoring sub-form (canvas/graph inspector
+  // surface): registry-admitted, renders EDITABLE with the TYPED contact-field picker (a select
+  // over the form's user fields — never a raw field-id input) PLUS the single level input, the
+  // publish-pins disclosure hint, and no unknown-kind warning. Both kinds share one sub-form.
+  it('K6: form_field_user_manager renders EDITABLE with the contact-field picker + level input (registry-admitted)', () => {
+    const node = makeApprovalNode('approval_ffum')
+    const { container: c, unmount } = mountDirectInspector({
+      node,
+      registry: DEFAULT_APPROVAL_CAPABILITY_REGISTRY,
+      api: createStubConfigApi({ approval_ffum: { assigneeSources: [{ kind: 'form_field_user_manager', fieldId: 'reviewer', level: 2 }] } }),
+    })
+    const roster = c.querySelector('[data-testid="approval-node-source-kind-form_field_user_manager"]') as HTMLInputElement
+    expect(roster).not.toBeNull()
+    expect(roster.checked).toBe(true)
+    expect(c.querySelector('[data-testid="approval-node-source-contact-field"]')).not.toBeNull()
+    expect(c.querySelector('[data-testid="approval-node-source-contact-level"]')).not.toBeNull()
+    // OD-L2-4 authoring-copy disclosure: the pins hint renders with the picker.
+    expect(c.querySelector('[data-testid="approval-node-source-contact-field-hint"]')).not.toBeNull()
+    expect(c.querySelector('[data-testid="approval-node-source-kind-unknown"]')).toBeNull()
+    unmount()
+  })
+
   it('K1: user_group with zero bound options shows the honest empty-roster hint, not an inert control', () => {
     const node = makeApprovalNode('approval_ug_empty')
     const api = createStubConfigApi({ approval_ug_empty: { assigneeSources: [{ kind: 'user_group', groupIds: [] }] } })
@@ -2036,6 +2071,63 @@ describe('Lock-0 P1-A — registry-driven tab membership + roster (direct mount)
     })
     expect(c.querySelector('[data-testid="approval-node-source-group-empty"]')).not.toBeNull()
     unmount()
+  })
+
+  it('K6: form_field_user_dept_head renders EDITABLE with the same contact sub-form (pointer-distinct kind, same shape)', () => {
+    const node = makeApprovalNode('approval_ffudh')
+    const { container: c, unmount } = mountDirectInspector({
+      node,
+      registry: DEFAULT_APPROVAL_CAPABILITY_REGISTRY,
+      api: createStubConfigApi({ approval_ffudh: { assigneeSources: [{ kind: 'form_field_user_dept_head', fieldId: 'reviewer', level: 1 }] } }),
+    })
+    const roster = c.querySelector('[data-testid="approval-node-source-kind-form_field_user_dept_head"]') as HTMLInputElement
+    expect(roster).not.toBeNull()
+    expect(roster.checked).toBe(true)
+    expect(c.querySelector('[data-testid="approval-node-source-contact-field"]')).not.toBeNull()
+    expect(c.querySelector('[data-testid="approval-node-source-contact-level"]')).not.toBeNull()
+    expect(c.querySelector('[data-testid="approval-node-source-kind-unknown"]')).toBeNull()
+    unmount()
+  })
+
+  // Lock-2 §2.4 C-7 form-schema precondition (gate D-6): the two contact-derived kinds are
+  // OFFERED only when the form declares an eligible user field — the affordance is
+  // schema-selected. Negative arm: no user field → neither radio renders (while the rest of the
+  // roster still does — the filter is kind-selected, not blanket). Positive control: the SAME
+  // node with a user field present renders both. Already-configured escape: a node ALREADY
+  // carrying the kind keeps its radio even with zero user fields, so a persisted value is never
+  // orphaned by a later form edit.
+  it('D-6: contact-extension kinds are schema-selected — absent without a user field, present with one, and a configured source survives field removal', () => {
+    const node = makeApprovalNode('approval_d6')
+    const apiNoUserFields = createStubConfigApi({ approval_d6: { assigneeSources: [{ kind: 'direct_manager' }] } })
+    apiNoUserFields.userFields = []
+    const bare = mountDirectInspector({ node, registry: DEFAULT_APPROVAL_CAPABILITY_REGISTRY, api: apiNoUserFields })
+    expect(bare.container.querySelector('[data-testid="approval-node-source-kind-form_field_user_manager"]')).toBeNull()
+    expect(bare.container.querySelector('[data-testid="approval-node-source-kind-form_field_user_dept_head"]')).toBeNull()
+    // kind-selected, not blanket: the rest of the roster still renders.
+    expect(bare.container.querySelector('[data-testid="approval-node-source-kind-direct_manager"]')).not.toBeNull()
+    expect(bare.container.querySelector('[data-testid="approval-node-source-kind-form_field_user"]')).not.toBeNull()
+    bare.unmount()
+
+    // Positive control: with a user field declared, both radios render (schema-selected).
+    const withField = mountDirectInspector({
+      node: makeApprovalNode('approval_d6'),
+      registry: DEFAULT_APPROVAL_CAPABILITY_REGISTRY,
+      api: createStubConfigApi({ approval_d6: { assigneeSources: [{ kind: 'direct_manager' }] } }),
+    })
+    expect(withField.container.querySelector('[data-testid="approval-node-source-kind-form_field_user_manager"]')).not.toBeNull()
+    expect(withField.container.querySelector('[data-testid="approval-node-source-kind-form_field_user_dept_head"]')).not.toBeNull()
+    withField.unmount()
+
+    // Already-configured escape: zero user fields but the node ALREADY carries the kind — its
+    // radio stays (checked), while the OTHER unconfigured extension kind stays absent.
+    const apiConfigured = createStubConfigApi({ approval_d6: { assigneeSources: [{ kind: 'form_field_user_manager', fieldId: 'gone', level: 1 }] } })
+    apiConfigured.userFields = []
+    const configured = mountDirectInspector({ node: makeApprovalNode('approval_d6'), registry: DEFAULT_APPROVAL_CAPABILITY_REGISTRY, api: apiConfigured })
+    const kept = configured.container.querySelector('[data-testid="approval-node-source-kind-form_field_user_manager"]') as HTMLInputElement
+    expect(kept).not.toBeNull()
+    expect(kept.checked).toBe(true)
+    expect(configured.container.querySelector('[data-testid="approval-node-source-kind-form_field_user_dept_head"]')).toBeNull()
+    configured.unmount()
   })
 
   // Lock-1 §K3 — prior_node_approver authoring sub-form: registry-admitted, renders EDITABLE with

--- a/apps/web/tests/approval-template-authoring-parallel-edit.test.ts
+++ b/apps/web/tests/approval-template-authoring-parallel-edit.test.ts
@@ -408,6 +408,35 @@ describe('parallelDynamicAssigneeConflicts — publish preflight (F2)', () => {
     )).toEqual([])
   })
 
+  it('Lock-2 §L2-C: flags identical form_field_user_manager field+level pairs; differing field OR level does not collide — the fingerprint mirror is in lockstep with the backend', () => {
+    expect(parallelDynamicAssigneeConflicts(
+      withBranchSources([{ kind: 'form_field_user_manager', fieldId: 'contact', level: 2 }], [{ kind: 'form_field_user_manager', fieldId: 'contact', level: 2 }]),
+    )).toHaveLength(1)
+    expect(parallelDynamicAssigneeConflicts(
+      withBranchSources([{ kind: 'form_field_user_manager', fieldId: 'contact', level: 1 }], [{ kind: 'form_field_user_manager', fieldId: 'contact', level: 2 }]),
+    )).toHaveLength(0)
+    expect(parallelDynamicAssigneeConflicts(
+      withBranchSources([{ kind: 'form_field_user_manager', fieldId: 'contact_a', level: 2 }], [{ kind: 'form_field_user_manager', fieldId: 'contact_b', level: 2 }]),
+    )).toHaveLength(0)
+  })
+  it('Lock-2 §L2-C: the two contact-extension kinds never collide with each other, with form_field_user on the same field, or with the requester-anchored level kinds', () => {
+    // Different POINTERS on the same anchor field+level — publish must not block.
+    expect(parallelDynamicAssigneeConflicts(
+      withBranchSources([{ kind: 'form_field_user_manager', fieldId: 'contact', level: 1 }], [{ kind: 'form_field_user_dept_head', fieldId: 'contact', level: 1 }]),
+    )).toHaveLength(0)
+    // The shipped 联系人自己 (form_field_user) fingerprint has no level segment — no cross-kind collision.
+    expect(parallelDynamicAssigneeConflicts(
+      withBranchSources([{ kind: 'form_field_user', fieldId: 'contact' }], [{ kind: 'form_field_user_manager', fieldId: 'contact', level: 1 }]),
+    )).toHaveLength(0)
+    // Requester-anchored manager_at_level vs contact-anchored form_field_user_manager — different kinds.
+    expect(parallelDynamicAssigneeConflicts(
+      withBranchSources([{ kind: 'manager_at_level', level: 2 }], [{ kind: 'form_field_user_manager', fieldId: 'contact', level: 2 }]),
+    )).toHaveLength(0)
+    // And the dept-head pair vs dept_head_at_level (requester-anchored) — different kinds.
+    expect(parallelDynamicAssigneeConflicts(
+      withBranchSources([{ kind: 'dept_head_at_level', level: 2 }], [{ kind: 'form_field_user_dept_head', fieldId: 'contact', level: 2 }]),
+    )).toHaveLength(0)
+  })
   it('Lock-1 §K5-b: flags identical dept_head_at_level levels — the fingerprint mirror is in lockstep with the backend', () => {
     expect(parallelDynamicAssigneeConflicts(
       withBranchSources([{ kind: 'dept_head_at_level', level: 2 }], [{ kind: 'dept_head_at_level', level: 2 }]),

--- a/apps/web/tests/approvalTemplateAuthoring.spec.ts
+++ b/apps/web/tests/approvalTemplateAuthoring.spec.ts
@@ -862,6 +862,55 @@ describe('approval template authoring helpers', () => {
     )
   })
 
+  it('Lock-2 §L2-C: round-trips a form_field_user_manager source incl. fieldId + level (save emits {kind, fieldId, level}; both survive the real wire) — the linear editor accepted-kind list mirror site', () => {
+    const draft = createEmptyTemplateDraft()
+    draft.key = 'ffum'
+    draft.name = '表单内联系人上级审批'
+    draft.fields[0].id = 'contact'
+    draft.fields[0].type = 'user'
+    draft.fields[0].label = '联系人'
+    draft.fields[0].required = true
+    draft.steps[0].sourceKind = 'form_field_user_manager'
+    draft.steps[0].fieldId = 'contact'
+    draft.steps[0].level = 2
+
+    const payload = buildCreateTemplatePayload(draft)
+    expect((payload.approvalGraph.nodes[1]?.config as any).assigneeSources).toEqual([{ kind: 'form_field_user_manager', fieldId: 'contact', level: 2 }])
+
+    // wire-vs-fixture trap: assert fieldId AND level survive the real serialize→parse.
+    const rehydrated = draftFromTemplate(buildTemplate({ approvalGraph: payload.approvalGraph }))
+    expect(rehydrated.steps[0].sourceKind).toBe('form_field_user_manager')
+    expect(rehydrated.steps[0].fieldId).toBe('contact')
+    expect(rehydrated.steps[0].level).toBe(2)
+    // And the rebuilt graph is byte-identical to the first emit (no hydrate flatten).
+    expect(buildCreateTemplatePayload(rehydrated).approvalGraph.nodes[1]?.config).toEqual(
+      payload.approvalGraph.nodes[1]?.config,
+    )
+  })
+
+  it('Lock-2 §L2-C: round-trips a form_field_user_dept_head source incl. fieldId + level (pointer-distinct kind, same draft shape)', () => {
+    const draft = createEmptyTemplateDraft()
+    draft.key = 'ffudh'
+    draft.name = '表单内联系人部门负责人审批'
+    draft.fields[0].id = 'contact'
+    draft.fields[0].type = 'user'
+    draft.fields[0].label = '联系人'
+    draft.fields[0].required = true
+    draft.steps[0].sourceKind = 'form_field_user_dept_head'
+    draft.steps[0].fieldId = 'contact'
+    draft.steps[0].level = 1
+
+    const payload = buildCreateTemplatePayload(draft)
+    expect((payload.approvalGraph.nodes[1]?.config as any).assigneeSources).toEqual([{ kind: 'form_field_user_dept_head', fieldId: 'contact', level: 1 }])
+    const rehydrated = draftFromTemplate(buildTemplate({ approvalGraph: payload.approvalGraph }))
+    expect(rehydrated.steps[0].sourceKind).toBe('form_field_user_dept_head')
+    expect(rehydrated.steps[0].fieldId).toBe('contact')
+    expect(rehydrated.steps[0].level).toBe(1)
+    expect(buildCreateTemplatePayload(rehydrated).approvalGraph.nodes[1]?.config).toEqual(
+      payload.approvalGraph.nodes[1]?.config,
+    )
+  })
+
   it('Lock-1 §K3: round-trips a prior_node_approver source (localId reference → the referenced step CURRENT positional key on save; the stored key re-resolves to the SAME step) — the linear editor accepted-kind list mirror site', () => {
     const draft = createEmptyTemplateDraft()
     draft.key = 'k3'

--- a/packages/core-backend/src/services/ApprovalAssigneeResolver.ts
+++ b/packages/core-backend/src/services/ApprovalAssigneeResolver.ts
@@ -54,12 +54,34 @@ function metadataFor(
       kind: source.kind,
       sourceIndex,
       ...(source.kind === 'form_field_user' ? { fieldId: source.fieldId } : {}),
+      // Lock-2 §2.6 audit (form-field contact extensions): the referenced field id AND the
+      // configured chain level on the row — both template-authored (values-free) — so "why is
+      // this person an approver" is answerable from the row alone.
+      ...(source.kind === 'form_field_user_manager' || source.kind === 'form_field_user_dept_head'
+        ? { fieldId: source.fieldId, level: source.level }
+        : {}),
       // Lock-1 §K3 audit: the referenced prior node's key on the row (§2.6 — a template-authored
       // node key, values-free), so "why is this person an approver" is answerable from the row.
       ...(source.kind === 'prior_node_approver' ? { priorNodeKey: source.nodeKey } : {}),
       ...(source.kind === 'user_group' && resolvedGroupId ? { groupId: resolvedGroupId } : {}),
     },
   }
+}
+
+/**
+ * Lock-2 §2.5 — the ONE key under which a form-field contact-extension source is frozen into
+ * `ApprovalRequesterSnapshot.fieldDerivedAssigneeIds` AND fingerprinted by the parallel-conflict
+ * publish gate: `<kind>:<fieldId>:<level>`. A single exported producer (consumed by BOTH the
+ * create-time freeze in ApprovalProductService and the resolver arms below, and by the backend
+ * `dynamicAssigneeSourceFingerprint`) so the snapshot key and the fingerprint provably cannot
+ * drift. `fieldId` is trimmed defensively (the authoring choke already trims it at normalize).
+ * FE mirror: apps/web/src/approvals/parallelEdit.ts `dynamicAssigneeSourceFingerprint` — keep in
+ * lockstep.
+ */
+export function fieldDerivedAssigneeSourceKey(
+  source: Extract<ApprovalAssigneeSource, { kind: 'form_field_user_manager' | 'form_field_user_dept_head' }>,
+): string {
+  return `${source.kind}:${source.fieldId.trim()}:${source.level}`
 }
 
 /**
@@ -74,7 +96,14 @@ function isSystemSentinelActor(actorId: string): boolean {
   return actorId.startsWith('system:')
 }
 
-function resolveFormUserValue(value: unknown): string | null {
+/**
+ * Single-valued `user` form value → local user id (string id or `{ id }`; arrays yield `null` —
+ * the L2-B×L2-C latent drop Lock-2 documents, unreachable while `validateApprovalFormData`
+ * rejects arrays for `user` fields). EXPORTED (Lock-2 §L2-C) so the create-time field-derived
+ * freeze reads the chosen contact through the EXACT same reader the shipped `form_field_user`
+ * resolution uses — a second reader could drift.
+ */
+export function resolveFormUserValue(value: unknown): string | null {
   const stringId = normalizeId(value)
   if (stringId) return stringId
   if (isRecord(value)) {
@@ -385,6 +414,37 @@ export function resolveApprovalAssignees(
             const memberId = normalizeId(entry)
             if (memberId) pushResolved('user', memberId, source, sourceIndex, groupId)
           })
+        })
+        break
+      }
+      case 'form_field_user_manager':
+      case 'form_field_user_dept_head': {
+        // Lock-2 §L2-C (form-field contact extensions): resolve to the FROZEN create-time
+        // extension of the person chosen in the referenced `user` field — a pure map lookup over
+        // `fieldDerivedAssigneeIds` (source fingerprint → resolved local user ids), frozen by the
+        // create path from the frozen directory read (submit IS create, §0 Correction 2). NO live
+        // directory read happens here on ANY path — dispatch, return, admin-jump, timeout-jump
+        // all re-resolve the SAME frozen list (§2.1 resolver purity; the freeze is temporal, not
+        // a dead read — a directory change after create alters only NEWLY created approvals).
+        // An empty/absent entry (contact without a directory account, chain shorter than the
+        // configured level, or a snapshot that never baked the map because the graph carries no
+        // such source) is EMPTY resolution falling to the node's `emptyAssigneePolicy` (§2.6) —
+        // under the default 'error' that is a fail-closed APPROVAL_ASSIGNEE_EMPTY, and under an
+        // explicit 'auto-approve' an AUDITED auto-approval event, never a silent nobody. A FAILED
+        // create-time read never reaches this arm at all: the create wedge fails closed 422/503
+        // before any instance/assignment insert (§2.3), so "read failed" cannot masquerade as
+        // "resolved to nobody".
+        // NO requester self-exclusion (deliberate — Lock-2 §L2-C: shipped `dept_head`'s inline
+        // requester-exclusion is a requester-anchored artifact; a chosen contact's manager who
+        // happens to BE the requester still gets the seat, and same-person semantics compose
+        // through autoApprovalPolicy.mergeWithRequester). Anchor self-exclusion — the CONTACT is
+        // never their own manager/head — already happened inside the chain walk at create.
+        const rawMap = options.requesterSnapshot?.fieldDerivedAssigneeIds
+        const rawList = isRecord(rawMap) ? rawMap[fieldDerivedAssigneeSourceKey(source)] : undefined
+        const frozen = Array.isArray(rawList) ? rawList : []
+        frozen.forEach((entry) => {
+          const resolvedId = normalizeId(entry)
+          if (resolvedId) pushResolved('user', resolvedId, source, sourceIndex)
         })
         break
       }

--- a/packages/core-backend/src/services/ApprovalProductService.ts
+++ b/packages/core-backend/src/services/ApprovalProductService.ts
@@ -3,6 +3,7 @@ import { pool } from '../db/pg'
 import type {
   ApprovalActionRequest,
   ApprovalAssigneeSource,
+  ApprovalAssigneeSourceKind,
   ApprovalAutoApprovalReason,
   AutoApprovalActorMode,
   AutoApprovalMergeReason,
@@ -76,7 +77,7 @@ import {
   resolveVisibilityFieldReference,
 } from './ApprovalGraphExecutor'
 import { collectActiveNodeKeys, collectHiddenFieldIds, fieldAccessAtNodes, resolveFieldAccessAtNodes } from './approval-form-redaction'
-import { resolveApprovalAssignees } from './ApprovalAssigneeResolver'
+import { fieldDerivedAssigneeSourceKey, resolveApprovalAssignees, resolveFormUserValue } from './ApprovalAssigneeResolver'
 import { validateAmountTotalConsistency } from './amount-total-check'
 import { isApprovalAttachmentsEnabled } from '../routes/approval-attachments'
 import {
@@ -801,6 +802,32 @@ function normalizeApprovalAssigneeSources(
           kind: 'form_field_user',
           fieldId: source.fieldId.trim(),
         }
+      case 'form_field_user_manager':
+      case 'form_field_user_dept_head': {
+        // Lock-2 §L2-C + the Lock-1 G-1 posture for NEW kinds: exact-shape validation — unknown
+        // extra keys are REJECTED, never silently dropped; `fieldId` is a required non-empty
+        // string; `level` is validated `[1, MAX_MANAGER_CHAIN_LEVELS]` byte-identically to the
+        // shipped level-addressed kinds (out-of-range / non-integer / missing is rejected, never
+        // silently defaulted — enum-strictness). This normalize runs on save, publish, and
+        // restore, so pin (5) (level in range) holds on every stored graph. Whether the
+        // referenced field exists top-level, is a `user` field, is required, and carries no
+        // visibilityRule is the cross-schema validator's job
+        // (`validateApprovalAssigneeSourcesAgainstFormSchema` — pins (1)-(4)+(6)); normalize
+        // stays a shape check so stored drafts remain readable/re-saveable while being fixed.
+        const kind = source.kind as 'form_field_user_manager' | 'form_field_user_dept_head'
+        const sourceKeys = Object.keys(source)
+        if (sourceKeys.some((key) => !['kind', 'fieldId', 'level'].includes(key))) {
+          failValidation(context, `${sourcePath} carries unknown keys for ${kind}`)
+        }
+        if (!isNonEmptyString(source.fieldId)) {
+          failValidation(context, `${sourcePath}.fieldId is required`)
+        }
+        const level = source.level
+        if (typeof level !== 'number' || !Number.isInteger(level) || level < 1 || level > MAX_MANAGER_CHAIN_LEVELS) {
+          failValidation(context, `${sourcePath}.level must be an integer between 1 and ${MAX_MANAGER_CHAIN_LEVELS}`)
+        }
+        return { kind, fieldId: source.fieldId.trim(), level }
+      }
       case 'requester_choice': {
         // Lock-1 §K2 + G-1: exact-shape validation — mode enum, scope discriminated by type,
         // and (stricter than the shipped kinds, per the Lock-1 G-1 gate for NEW kinds) unknown
@@ -869,13 +896,64 @@ function validateApprovalAssigneeSourcesAgainstFormSchema(
     if (node.type !== 'approval' && node.type !== 'handler') return
     const config = node.config as { assigneeSources?: ApprovalAssigneeSource[] }
     for (const source of config.assigneeSources ?? []) {
-      if (source.kind !== 'form_field_user') continue
-      const field = fieldById.get(source.fieldId)
-      if (!field || field.type !== 'user') {
-        failValidation(
-          context,
-          `approvalGraph node ${node.key} assigneeSources form_field_user must reference a user field`,
-        )
+      if (source.kind === 'form_field_user') {
+        const field = fieldById.get(source.fieldId)
+        if (!field || field.type !== 'user') {
+          failValidation(
+            context,
+            `approvalGraph node ${node.key} assigneeSources form_field_user must reference a user field`,
+          )
+        }
+        continue
+      }
+      // Lock-2 §L2-C publish pins for the form-field contact extensions — closing the silent-skip
+      // this loop otherwise carries for every non-form_field_user kind (the kind-axis twin of
+      // Lock-3 R-10's node-type axis on this same function). Pins, in order:
+      //   (1) the referenced field exists and is TOP-LEVEL only (`fieldById` maps top-level fields
+      //       only — a detail sub-field has N row-values and is ambiguous as a single approver);
+      //   (2) the field's type is `user`;
+      //   (3) `required: true` — alone it closes nothing, because `validateApprovalFormData`
+      //       enforces `required` for VISIBLE fields only;
+      //   (4) NO `visibilityRule` — which makes the (3)+(4) pair provably sufficient: a field with
+      //       no rule is visible on both visibility passes regardless of data (OD-L2-5(a); the
+      //       independent create-time door 2 — APPROVAL_FORM_ROUTING_FIELD_EMPTY — backs this pair
+      //       so neither door covers for the other);
+      //   (5) `level` in range — enforced by `normalizeApprovalAssigneeSources`, which runs on
+      //       every save/publish/restore path ahead of this validator;
+      //   (6) the field must not declare `selection: 'multi'` until OD-L2-7's array support lands
+      //       in the SAME slice as the prop (props are unvalidated free text today, so the pin
+      //       reads the key defensively rather than trusting a typed carrier).
+      // NOTE (OD-L2-4, deliberately deferred): the ratified required-pin RETROFIT onto the shipped
+      // `form_field_user` arm above applies "to all four kinds at the next save/publish" and lands
+      // in its own slice with the authoring-copy disclosure — this slice pins only the kinds it
+      // ships, and the shipped arm keeps its shipped acceptance until that slice lands.
+      if (source.kind === 'form_field_user_manager' || source.kind === 'form_field_user_dept_head') {
+        const field = fieldById.get(source.fieldId)
+        if (!field || field.type !== 'user') {
+          failValidation(
+            context,
+            `approvalGraph node ${node.key} assigneeSources ${source.kind} must reference a top-level user field`,
+          )
+        }
+        if (field.required !== true) {
+          failValidation(
+            context,
+            `approvalGraph node ${node.key} assigneeSources ${source.kind} must reference a required user field`,
+          )
+        }
+        if (field.visibilityRule !== undefined) {
+          failValidation(
+            context,
+            `approvalGraph node ${node.key} assigneeSources ${source.kind} must not reference a field with a visibility rule`,
+          )
+        }
+        if (isRecord(field.props) && field.props.selection === 'multi') {
+          failValidation(
+            context,
+            `approvalGraph node ${node.key} assigneeSources ${source.kind} must not reference a multi-select user field`,
+          )
+        }
+        continue
       }
     }
   })
@@ -2096,6 +2174,14 @@ function dynamicAssigneeSourceFingerprint(source: ApprovalAssigneeSource): strin
       return `prior_node_approver:${source.nodeKey}`
     case 'form_field_user':
       return `form_field_user:${source.fieldId}`
+    case 'form_field_user_manager':
+    case 'form_field_user_dept_head':
+      // Lock-2 §2.5 locked entries: `<kind>:<fieldId>:<level>` — provably identical for the same
+      // field and level (the same chosen contact walks the same chain to the same position on
+      // every request), so identical sources on parallel branches are publish-blocked, unlike
+      // K2's deliberate `null`. Delegates to the SAME exported producer the create-time snapshot
+      // freeze and the resolver arms use, so fingerprint and snapshot key cannot drift.
+      return fieldDerivedAssigneeSourceKey(source)
     case 'static_user':
     case 'static_role':
       // Statics are owned by collectBranchAssignees' duplicate check, not this gate.
@@ -3881,6 +3967,86 @@ function resolveCalendarSlaOrgId(requesterSnapshot: Record<string, unknown> | nu
 }
 
 /**
+ * Lock-2 §2.3 (locked refactor, performed by the first slice to land after the lock): the per-kind
+ * capability traits that drive the create-time detectors below. The detectors used to be FOUR
+ * hand-maintained `||` chains over the same kinds ("hand-maintained disjunctions in four places do
+ * not converge") — each detector's kind set is now DERIVED from this ONE table, and the table is a
+ * `Record` over the full `ApprovalAssigneeSourceKind` union, so adding a kind without classifying
+ * it is a COMPILE error here (the same enforcement posture as the fingerprint `_exhaustive`
+ * guard). A mechanical exact-set test pins each derived set; editing a trait row — touching no
+ * detector — reds that test (Lock-2 gate D-3's "the set must first be proven DERIVED" arm).
+ *
+ * Traits:
+ *  - `requesterOrgRead`  — resolves from the REQUESTER's create-frozen org relations; arms the
+ *                          B5-b org-read fail-closed wedge (`runtimeGraphUsesOrgAssigneeSource`).
+ *  - `managerChain`      — consumes the requester `managerChainIds` snapshot (opt-in
+ *                          `includeManagerChain` bake).
+ *  - `deptHeadChain`     — consumes the requester `deptHeadChainIds` snapshot (opt-in
+ *                          `includeDeptHeadChain` bake).
+ *  - `fieldDerivedOrgRead` — Lock-2 §L2-C: resolves from a FORM-FIELD-CHOSEN principal's org
+ *                          relations at create (its OWN detector + wedge — deliberately NOT an
+ *                          extension of `runtimeGraphUsesOrgAssigneeSource`, which gates whether
+ *                          the REQUESTER's relations are read: folding these in would make every
+ *                          such template pay a requester org read it does not need, while omitting
+ *                          them would leave the new reads uncovered by any wedge).
+ */
+interface ApprovalAssigneeSourceKindTraits {
+  requesterOrgRead: boolean
+  managerChain: boolean
+  deptHeadChain: boolean
+  fieldDerivedOrgRead: boolean
+}
+
+const NO_ORG_TRAITS: ApprovalAssigneeSourceKindTraits = {
+  requesterOrgRead: false,
+  managerChain: false,
+  deptHeadChain: false,
+  fieldDerivedOrgRead: false,
+}
+
+export const APPROVAL_ASSIGNEE_SOURCE_KIND_TRAITS: Record<ApprovalAssigneeSourceKind, ApprovalAssigneeSourceKindTraits> = {
+  static_user: NO_ORG_TRAITS,
+  static_role: NO_ORG_TRAITS,
+  requester: NO_ORG_TRAITS,
+  // Shipped form_field_user resolves the chosen person THEMSELVES from the form snapshot — no
+  // directory read at all, so no org trait (C-3's 联系人自己 needs no extension machinery).
+  form_field_user: NO_ORG_TRAITS,
+  direct_manager: { ...NO_ORG_TRAITS, requesterOrgRead: true },
+  dept_head: { ...NO_ORG_TRAITS, requesterOrgRead: true },
+  continuous_managers: { ...NO_ORG_TRAITS, requesterOrgRead: true, managerChain: true },
+  manager_at_level: { ...NO_ORG_TRAITS, requesterOrgRead: true, managerChain: true },
+  // Lock-1 §K2: resolves from the create-frozen requester CHOICE, not the org directory.
+  requester_choice: NO_ORG_TRAITS,
+  continuous_dept_heads: { ...NO_ORG_TRAITS, requesterOrgRead: true, deptHeadChain: true },
+  dept_head_at_level: { ...NO_ORG_TRAITS, requesterOrgRead: true, deptHeadChain: true },
+  // Lock-1 §K3: resolves from INSTANCE-INTERNAL audit rows — deliberately NOT org-armed (§K3:
+  // arming the org wedge for it would fail creates that need no org read at all).
+  prior_node_approver: NO_ORG_TRAITS,
+  // Lock-1 §K1: user_group resolves purely from the create-frozen `groupMemberIds` snapshot — no
+  // live directory read at dispatch — so it arms NONE of the org detectors/wedges (mirrors
+  // requester_choice / prior_node_approver). Giving it any org trait would silently re-arm the
+  // REQUESTER org wedge, which its EAGER_EXPANSION freeze deliberately does not need.
+  user_group: NO_ORG_TRAITS,
+  // Lock-2 §L2-C: field-derived contact extensions — their org read is anchored on the CHOSEN
+  // contact, not the requester, so they arm ONLY the field-derived detector/wedge.
+  form_field_user_manager: { ...NO_ORG_TRAITS, fieldDerivedOrgRead: true },
+  form_field_user_dept_head: { ...NO_ORG_TRAITS, fieldDerivedOrgRead: true },
+}
+
+function assigneeSourceKindsWithTrait(trait: keyof ApprovalAssigneeSourceKindTraits): ReadonlySet<string> {
+  return new Set(
+    (Object.keys(APPROVAL_ASSIGNEE_SOURCE_KIND_TRAITS) as ApprovalAssigneeSourceKind[])
+      .filter((kind) => APPROVAL_ASSIGNEE_SOURCE_KIND_TRAITS[kind][trait]),
+  )
+}
+
+/** Derived, not enumerated (Lock-2 §2.3) — exported for the mechanical exact-set assertions. */
+export const ORG_ASSIGNEE_SOURCE_KINDS = assigneeSourceKindsWithTrait('requesterOrgRead')
+export const MANAGER_CHAIN_ASSIGNEE_SOURCE_KINDS = assigneeSourceKindsWithTrait('managerChain')
+export const DEPT_HEAD_CHAIN_ASSIGNEE_SOURCE_KINDS = assigneeSourceKindsWithTrait('deptHeadChain')
+export const FIELD_DERIVED_ORG_ASSIGNEE_SOURCE_KINDS = assigneeSourceKindsWithTrait('fieldDerivedOrgRead')
+
+/**
  * True when any approval node's assignee sources include a management-chain source
  * (`continuous_managers` or `manager_at_level`). Used at create time to decide
  * whether to walk the (more expensive) management chain into the requester snapshot
@@ -3898,7 +4064,7 @@ export function runtimeGraphUsesManagerChain(runtimeGraph: RuntimeGraph): boolea
     const sources = isRecord(config) ? config.assigneeSources : undefined
     if (!Array.isArray(sources)) return false
     return sources.some(
-      (source) => isRecord(source) && (source.kind === 'continuous_managers' || source.kind === 'manager_at_level'),
+      (source) => isRecord(source) && typeof source.kind === 'string' && MANAGER_CHAIN_ASSIGNEE_SOURCE_KINDS.has(source.kind),
     )
   })
 }
@@ -3930,7 +4096,7 @@ export function runtimeGraphUsesDeptHeadChain(runtimeGraph: RuntimeGraph): boole
     const sources = isRecord(config) ? config.assigneeSources : undefined
     if (!Array.isArray(sources)) return false
     return sources.some(
-      (source) => isRecord(source) && (source.kind === 'continuous_dept_heads' || source.kind === 'dept_head_at_level'),
+      (source) => isRecord(source) && typeof source.kind === 'string' && DEPT_HEAD_CHAIN_ASSIGNEE_SOURCE_KINDS.has(source.kind),
     )
   })
 }
@@ -3964,16 +4130,55 @@ export function runtimeGraphUsesOrgAssigneeSource(runtimeGraph: RuntimeGraph): b
     const sources = isRecord(config) ? config.assigneeSources : undefined
     if (!Array.isArray(sources)) return false
     return sources.some(
-      (source) =>
-        isRecord(source) &&
-        (source.kind === 'direct_manager' ||
-          source.kind === 'dept_head' ||
-          source.kind === 'continuous_managers' ||
-          source.kind === 'manager_at_level' ||
-          source.kind === 'continuous_dept_heads' ||
-          source.kind === 'dept_head_at_level'),
+      (source) => isRecord(source) && typeof source.kind === 'string' && ORG_ASSIGNEE_SOURCE_KINDS.has(source.kind),
     )
   })
+}
+
+/**
+ * Lock-2 §L2-C / §2.3 — every form-field contact-extension source in the published runtime graph,
+ * deduped by its fingerprint key (`fieldDerivedAssigneeSourceKey` — identical sources share ONE
+ * frozen entry) with the FIRST carrying node's key retained for values-free error reporting.
+ * Drives the create-time freeze (`resolveAndFreezeFieldDerivedAssignees`) and IS the new
+ * detector: a non-empty map means the create path performs field-derived org reads and the NEW
+ * fail-closed wedge arms; an empty map means no field-derived work at all (the
+ * `includeManagerChain` opt-in posture — unrelated approvals pay nothing). Node types `approval`
+ * AND `handler` — the Lock-2 §2.4 registry rows admit both, and leaving `handler` out would
+ * reproduce the exact R-13/R-14 "silent skip" class (a handler-carried source would never bake
+ * its snapshot entry and would resolve empty at dispatch). The kind membership is DERIVED from
+ * the trait table (`FIELD_DERIVED_ORG_ASSIGNEE_SOURCE_KINDS`), not a fourth hand-edited chain.
+ * `kind`/`fieldId`/`level` are read structurally (same posture as the other detectors above).
+ */
+export function collectRuntimeGraphFieldDerivedSources(
+  runtimeGraph: RuntimeGraph,
+): Map<string, { nodeKey: string; source: Extract<ApprovalAssigneeSource, { kind: 'form_field_user_manager' | 'form_field_user_dept_head' }> }> {
+  const byKey = new Map<string, { nodeKey: string; source: Extract<ApprovalAssigneeSource, { kind: 'form_field_user_manager' | 'form_field_user_dept_head' }> }>()
+  for (const node of runtimeGraph.nodes) {
+    if (node.type !== 'approval' && node.type !== 'handler') continue
+    const config: unknown = node.config
+    const sources = isRecord(config) ? config.assigneeSources : undefined
+    if (!Array.isArray(sources)) continue
+    for (const source of sources) {
+      if (
+        !isRecord(source)
+        || typeof source.kind !== 'string'
+        || !FIELD_DERIVED_ORG_ASSIGNEE_SOURCE_KINDS.has(source.kind)
+        || typeof source.fieldId !== 'string'
+        || source.fieldId.trim().length === 0
+        || typeof source.level !== 'number'
+        || !Number.isInteger(source.level)
+        || source.level < 1
+      ) continue
+      const typed = {
+        kind: source.kind as 'form_field_user_manager' | 'form_field_user_dept_head',
+        fieldId: source.fieldId.trim(),
+        level: source.level,
+      }
+      const key = fieldDerivedAssigneeSourceKey(typed)
+      if (!byKey.has(key)) byKey.set(key, { nodeKey: node.key, source: typed })
+    }
+  }
+  return byKey
 }
 
 /**
@@ -5903,6 +6108,114 @@ export class ApprovalProductService {
   }
 
   /**
+   * Lock-2 §L2-C — resolve every form-field contact-extension source AT CREATE from the person
+   * chosen in its referenced `user` field, and return the FROZEN map (source fingerprint →
+   * resolved local user ids) the requester snapshot carries. Order inside the method (§2.1
+   * validation-first): door 2 — the independent create-time 422 `APPROVAL_FORM_ROUTING_FIELD_EMPTY`
+   * for an EMPTY referenced field (§2.2; it survives any later widening of the publish pins, and
+   * fires BEFORE any field-derived org read so a payload failure never costs a directory read) —
+   * then ONE org-relations read per DISTINCT chosen contact.
+   *
+   * Anchoring (§L2-C corp-scoping): the contact's org relations resolve through the SAME
+   * machinery — and therefore the same routing-policy anchor — as the requester's own create-time
+   * read (`resolveApprovalRequesterOrgRelations`: policy-canonical integration when a policy
+   * governs, S7/legacy pick otherwise; every chain read is integration-scoped, never global). A
+   * contact linked in more than one policy-governed org raises the shipped
+   * `ApprovalRoutingPolicyError` and surfaces as the fail-closed 422
+   * `APPROVAL_ROUTING_POLICY_MISCONFIGURED`; any other read failure is a retryable 503
+   * `APPROVAL_FORM_ROUTING_ORG_UNRESOLVED` (the NEW wedge, §2.3) — both BEFORE any insert, zero
+   * rows. Genuine data absence (contact has no directory account / no primary department / a
+   * chain shorter than the configured level) is NOT a failure: the entry freezes as the resolved
+   * (possibly empty) list and empty resolution falls to the node's `emptyAssigneePolicy` (§2.6).
+   *
+   * The chains are the SHIPPED walks re-anchored on the contact (`form_field_user_manager` →
+   * `resolveManagerChain`'s leader-pointer walk via `includeManagerChain`;
+   * `form_field_user_dept_head` → K4's `resolveDeptHeadChain` parent-tree walk via
+   * `includeDeptHeadChain`, whose RATIFIED continue-past-empty-level posture binds this use), and
+   * `level` addresses the DENSE chain positionally (`chain[level - 1]`), byte-identical to
+   * `manager_at_level` / `dept_head_at_level` semantics. Anchor self-exclusion (the contact is
+   * never their own manager/head) is inherent to the walks; REQUESTER self-exclusion is
+   * deliberately NOT applied (§L2-C — the resolver arm documents the posture).
+   *
+   * Every error is values-free: node keys, field ids, and source fingerprint params are
+   * template-authored and permitted (§2.6); the chosen contact's id IS a form value and never
+   * appears in any message or details.
+   */
+  private async resolveAndFreezeFieldDerivedAssignees(
+    sources: ReturnType<typeof collectRuntimeGraphFieldDerivedSources>,
+    formData: Record<string, unknown>,
+  ): Promise<Record<string, string[]>> {
+    if (!pool) throw new Error('Database not available')
+
+    // Door 2 first (payload-level, no DB): every referenced field must carry a resolvable single
+    // value. The publish pins ((3) required + (4) no visibilityRule) make absence unreachable for
+    // templates published on this contract; this door is deliberately independent of them (§2.2).
+    const anchorNeeds = new Map<string, { includeManagerChain: boolean; includeDeptHeadChain: boolean }>()
+    const anchorBySourceKey = new Map<string, string>()
+    for (const [key, occurrence] of sources) {
+      const anchorId = resolveFormUserValue(formData[occurrence.source.fieldId])
+      if (!anchorId) {
+        throw new ServiceError(
+          `Approval node ${occurrence.nodeKey} routes on form field ${occurrence.source.fieldId}, which is empty`,
+          422,
+          'APPROVAL_FORM_ROUTING_FIELD_EMPTY',
+          { nodeKey: occurrence.nodeKey, fieldId: occurrence.source.fieldId },
+        )
+      }
+      anchorBySourceKey.set(key, anchorId)
+      const needs = anchorNeeds.get(anchorId) ?? { includeManagerChain: false, includeDeptHeadChain: false }
+      if (occurrence.source.kind === 'form_field_user_manager') needs.includeManagerChain = true
+      else needs.includeDeptHeadChain = true
+      anchorNeeds.set(anchorId, needs)
+    }
+
+    // ONE read per distinct anchor, walking only the chain(s) the referencing sources need.
+    const relationsByAnchor = new Map<string, ApprovalRequesterOrgRelations>()
+    for (const [anchorId, needs] of anchorNeeds) {
+      try {
+        relationsByAnchor.set(
+          anchorId,
+          await resolveApprovalRequesterOrgRelations(anchorId, pool.query.bind(pool), {
+            includeManagerChain: needs.includeManagerChain,
+            includeDeptHeadChain: needs.includeDeptHeadChain,
+          }),
+        )
+      } catch (error) {
+        // Values-free log: the anchor is a form value — never echo it.
+        metricsLogger.warn(
+          `Failed to resolve field-derived org relations for a form-chosen contact: ${
+            error instanceof Error ? error.message : 'unknown error'
+          }`,
+        )
+        if (error instanceof ApprovalRoutingPolicyError) {
+          throw new ServiceError(
+            'The directory routing policy governing a form-chosen contact is misconfigured, so approver resolution cannot run. Contact an administrator.',
+            422,
+            'APPROVAL_ROUTING_POLICY_MISCONFIGURED',
+          )
+        }
+        throw new ServiceError(
+          'Could not resolve the organization relations of a form-chosen contact required by this approval template. Please retry.',
+          503,
+          'APPROVAL_FORM_ROUTING_ORG_UNRESOLVED',
+        )
+      }
+    }
+
+    const frozen: Record<string, string[]> = {}
+    for (const [key, occurrence] of sources) {
+      const anchorId = anchorBySourceKey.get(key)
+      const relations = (anchorId ? relationsByAnchor.get(anchorId) : undefined) ?? {}
+      const chain = occurrence.source.kind === 'form_field_user_manager'
+        ? (relations.managerChainIds ?? [])
+        : (relations.deptHeadChainIds ?? [])
+      const resolved = chain[occurrence.source.level - 1]
+      frozen[key] = typeof resolved === 'string' && resolved.trim().length > 0 ? [resolved.trim()] : []
+    }
+    return frozen
+  }
+
+  /**
    * Lock-1 §K2 — validate the submit-time requester choices against every published
    * `requester_choice` node's configured scope, and return the FROZEN map (node key → chosen
    * local user ids) the requester snapshot carries. Every rejection is a values-free 422
@@ -6380,6 +6693,24 @@ export class ApprovalProductService {
       )
     }
 
+    // Lock-2 §L2-C (form-field contact extensions) — resolve the chosen contact's manager /
+    // department-head extension AT CREATE (submit IS create: the anchor travels in this very
+    // payload) and FREEZE the result; the resolver then reads only the frozen map, so no live
+    // directory read ever happens at dispatch/return/admin-jump/timeout. Placed HERE, in the
+    // pre-`BEGIN` band with the shipped wedge guards above and BEFORE any instance/assignment
+    // insert: every failure — door-2 empty field 422, routing-policy 422, transient read 503 —
+    // leaves zero rows. Its own detector + wedge, deliberately NOT `runtimeGraphUsesOrgAssigneeSource`
+    // (§2.3): the requester wedge above stays requester-scoped, and a field-derived-only template
+    // never pays a requester org read it does not need. OPT-IN — an empty collection does no work.
+    const fieldDerivedSources = collectRuntimeGraphFieldDerivedSources(runtimeGraph)
+    let frozenFieldDerivedAssigneeIds: Record<string, string[]> | undefined
+    if (fieldDerivedSources.size > 0) {
+      frozenFieldDerivedAssigneeIds = await this.resolveAndFreezeFieldDerivedAssignees(
+        fieldDerivedSources,
+        normalizedFormData,
+      )
+    }
+
     // Lock-1 §K2 (requester_choice) — validate the submitter's choices against each published
     // node's configured scope and freeze them. Placed HERE, with the org/role wedge guards
     // above and BEFORE any instance/assignment insert (mirroring the B5-b fail-closed
@@ -6459,6 +6790,13 @@ export class ApprovalProductService {
       ...(frozenGroupMemberIds && Object.keys(frozenGroupMemberIds).length > 0
         ? { groupMemberIds: frozenGroupMemberIds }
         : {}),
+      // Lock-2 §L2-C: freeze the field-derived contact-extension resolution (source fingerprint →
+      // resolved local user ids). Present whenever the graph carries such a source — INCLUDING
+      // entries frozen as `[]` (read ran, resolved nobody → emptyAssigneePolicy at the node), so
+      // "resolved to nobody" is distinguishable from "never baked". The resolver reads ONLY this
+      // map — immutable across return/admin-jump/timeout; a directory change after create never
+      // alters it (the sanctioned in-flight mutation is `transfer`).
+      ...(frozenFieldDerivedAssigneeIds ? { fieldDerivedAssigneeIds: frozenFieldDerivedAssigneeIds } : {}),
     }
     // Lock-1 §K3: `getPriorNodeApprovers` is deliberately OMITTED on the create/preview path — no
     // instance exists yet, so there are no audit rows to read. A `prior_node_approver` node can

--- a/packages/core-backend/src/types/approval-product.ts
+++ b/packages/core-backend/src/types/approval-product.ts
@@ -16,7 +16,7 @@ export type ApprovalProductPermission = typeof APPROVAL_PRODUCT_PERMISSIONS[numb
 // admission set in ApprovalProductService.ts) or the type is unpublishable.
 export type ApprovalNodeType = 'start' | 'approval' | 'cc' | 'condition' | 'parallel' | 'end' | 'handler'
 export type ApprovalAssigneeType = 'user' | 'role'
-export type ApprovalAssigneeSourceKind = 'static_user' | 'static_role' | 'requester' | 'form_field_user' | 'direct_manager' | 'dept_head' | 'continuous_managers' | 'manager_at_level' | 'requester_choice' | 'continuous_dept_heads' | 'dept_head_at_level' | 'prior_node_approver' | 'user_group'
+export type ApprovalAssigneeSourceKind = 'static_user' | 'static_role' | 'requester' | 'form_field_user' | 'direct_manager' | 'dept_head' | 'continuous_managers' | 'manager_at_level' | 'requester_choice' | 'continuous_dept_heads' | 'dept_head_at_level' | 'prior_node_approver' | 'user_group' | 'form_field_user_manager' | 'form_field_user_dept_head'
 export type ApprovalMode = 'single' | 'all' | 'any' | 'threshold'
 
 /**
@@ -36,6 +36,15 @@ export const HANDLER_ASSIGNEE_SOURCE_KINDS = [
   'direct_manager',
   'dept_head',
   'manager_at_level',
+  // Lock-2 §2.4 (RATIFIED 2026-08-17) — the two contact-derived rows are ratified for node types
+  // `approval` AND `handler` ("The handler rows are corpus-evidenced, not an M11 widening (C-6);
+  // Lock-3 §1.5's forward-row sentence names only 表单内部门 although its own roster lists
+  // 表单内联系人, so the two contact-derived rows supply what fell between the locks"). Each row
+  // lands in the SAME slice as its kind, so the exact-set roster grows 7→9 here — deliberately,
+  // with the G-13 exact-set tests updated in the same commit (they exist to make this growth a
+  // reviewed decision, not to forbid ratified rows).
+  'form_field_user_manager',
+  'form_field_user_dept_head',
 ] as const
 export type HandlerAssigneeSourceKind = typeof HANDLER_ASSIGNEE_SOURCE_KINDS[number]
 
@@ -431,6 +440,49 @@ export type ApprovalAssigneeSource =
    * this shape — deferred to its own slice (§K1 "cc is a second contract, not a rider").
    */
   | { kind: 'user_group'; groupIds: string[] }
+  /**
+   * Lock-2 §L2-C — 表单内联系人上级 (C-3 联系人上级): the person chosen in a `user` form field is
+   * the ANCHOR, and the source resolves that person's manager at chain position `level` (level 1 =
+   * the chosen anchor's own direct manager) via the `leader_in_dept` LEADER pointer — the SAME
+   * walk `resolveManagerChain` performs for the requester-anchored kinds, re-anchored on the
+   * chosen contact. FIELD-anchored, not requester-anchored: mutating the REQUESTER's own org
+   * relations never changes the resolution; mutating the CHOSEN contact's relations changes only
+   * NEWLY created approvals (freeze-at-create).
+   *
+   * Freeze semantics (Lock-2 §0 Correction 2 — submit IS create): the chosen contact travels in
+   * the create payload, so the create path resolves the extension AT CREATE from the directory and
+   * freezes the resolved ids into `ApprovalRequesterSnapshot.fieldDerivedAssigneeIds`, keyed by
+   * this source's fingerprint (`form_field_user_manager:<fieldId>:<level>`). The resolver reads
+   * ONLY that frozen map — no live directory read at dispatch/return/admin-jump/timeout (§2.1).
+   * `level` is validated `[1, MAX_MANAGER_CHAIN_LEVELS]` at normalize time; UPWARD only in v1
+   * (the downward variant stays blocked on Lock-1 OD-L1-6, inherited not re-owned).
+   * Publish pins (§L2-C): the referenced field must exist TOP-LEVEL, be `type: 'user'`,
+   * `required: true`, carry NO `visibilityRule`, and not declare `selection: 'multi'` (OD-L2-7).
+   * A value present but resolving to nobody (contact without a directory account, chain shorter
+   * than `level`) is EMPTY resolution → `emptyAssigneePolicy` (§2.6); an empty referenced field is
+   * the independent create-time 422 `APPROVAL_FORM_ROUTING_FIELD_EMPTY` (§2.2 door 2); a failed
+   * directory read/misconfigured routing policy is the fail-closed create wedge (§2.3) — three
+   * different things, never conflated. NO requester self-exclusion (deliberate, §L2-C: shipped
+   * `dept_head`'s requester-exclusion is a requester-anchored artifact; same-person composes
+   * through `autoApprovalPolicy.mergeWithRequester`).
+   */
+  | { kind: 'form_field_user_manager'; fieldId: string; level: number }
+  /**
+   * Lock-2 §L2-C — 表单内联系人部门负责人 (C-3 联系人部门负责人): the chosen contact's PRIMARY
+   * department, then the department PARENT tree (`external_parent_department_id`), reading
+   * `dept_manager_userid_list` per level — the SAME walk K4's `resolveDeptHeadChain` performs for
+   * the requester, re-anchored on the chosen contact; level 1 = the chosen anchor's own listed
+   * department head. Lock-1 §K4's RATIFIED continue-past-empty-level posture BINDS this walk (a
+   * level whose manager list is empty or resolves to no linked local user contributes nothing and
+   * the walk CONTINUES upward — the chain is DENSE, so `level` addresses the level-th *resolved*
+   * head walking up, exactly as `dept_head_at_level` does over the requester's chain). A DIFFERENT
+   * pointer from `form_field_user_manager` (leader pointer vs parent tree — the two coincide only
+   * where every department's leader is also its listed manager). Everything else — freeze into
+   * `fieldDerivedAssigneeIds` at create keyed by `form_field_user_dept_head:<fieldId>:<level>`,
+   * publish pins, door-2 empty-field 422, fail-closed wedge, no requester self-exclusion, upward
+   * only — is identical to the `form_field_user_manager` doc comment above.
+   */
+  | { kind: 'form_field_user_dept_head'; fieldId: string; level: number }
 
 export type RequesterChoiceAssigneeSource = Extract<ApprovalAssigneeSource, { kind: 'requester_choice' }>
 
@@ -445,6 +497,12 @@ export interface ApprovalAssigneeResolutionMetadata {
     kind: ApprovalAssigneeSourceKind
     sourceIndex: number
     fieldId?: string
+    /**
+     * Lock-2 §2.6 (`form_field_user_manager` / `form_field_user_dept_head`): the configured chain
+     * level this seat was resolved at, so "why is this person an approver" is answerable from the
+     * row alone. Template-authored (values-free); rides beside the existing optional `fieldId`.
+     */
+    level?: number
     /**
      * Lock-1 §K3 (`prior_node_approver` only): the referenced prior node's key, so "why is this
      * person an approver" is answerable from the row alone (§2.6 — a template-authored node key,
@@ -674,6 +732,21 @@ export interface ApprovalRequesterSnapshot {
    * snapshots omit it.
    */
   groupMemberIds?: Record<string, string[]>
+  /**
+   * Lock-2 §L2-C (form-field contact extensions) — the FROZEN field-derived resolution map:
+   * source fingerprint (`form_field_user_manager:<fieldId>:<level>` /
+   * `form_field_user_dept_head:<fieldId>:<level>`, see `fieldDerivedAssigneeSourceKey`) → resolved
+   * local user ids, resolved AT CREATE from the person chosen in the referenced `user` form field
+   * (submit IS create — Lock-2 §0 Correction 2) and never re-read afterwards. Keyed by fingerprint
+   * so identical sources share ONE entry and the resolver stays a pure map lookup (§2.1 — no
+   * resolver-internal database access; dispatch/return/admin-jump/timeout never touch the
+   * directory). OPT-IN: present only when the published runtime graph carries such a source
+   * (unrelated approvals pay nothing). An entry that is an EMPTY array means the create-time read
+   * ran and resolved nobody (contact without a directory account, chain shorter than the
+   * configured level) — EMPTY resolution falling to `emptyAssigneePolicy` (§2.6); a FAILED read
+   * never reaches this map (the create wedge fails closed 422/503 before any insert, §2.3).
+   */
+  fieldDerivedAssigneeIds?: Record<string, string[]>
   [key: string]: unknown
 }
 

--- a/packages/core-backend/tests/integration/approval-form-contact-extensions.db.test.ts
+++ b/packages/core-backend/tests/integration/approval-form-contact-extensions.db.test.ts
@@ -1,0 +1,656 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import net from 'net'
+import { MetaSheetServer } from '../../src/index'
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { query } from '../../src/db/pg'
+import { ensureApprovalSchemaReady, grantApprovalWriteForIntegrationActor } from '../helpers/approval-schema-bootstrap'
+
+/**
+ * Lock-2 §L2-C form-field contact extensions (`form_field_user_manager` 表单内联系人上级 /
+ * `form_field_user_dept_head` 表单内联系人部门负责人) — REAL-DB end-to-end acceptance
+ * (docs/development/approval-lock2-org-controls-field-routing-20260817.md §L2-C, §2.1-§2.6;
+ * gates C-1/C-2/C-4/C-5/D-2/D-4/D-5 + the door-2 create-time 422 of §2.2; harness mirrors
+ * approval-dept-head-chain.db.test.ts, org fixture extends it with a leader-pointer chain ABOVE
+ * the chosen contact).
+ *
+ * Org fixture (one integration `fc-<TS>`, org 'default'):
+ *   DEPT_TOP (root; dept_manager_userid_list = [HEAD2])
+ *     <- DEPT_MID (manager list EMPTY — the continue-past-empty-level level)
+ *          <- DEPT_BOT (CONTACT's primary dept; manager list = [HEAD1]; a DIFFERENT account
+ *                       LEADER1 is flagged leader_in_dept — the C-4 pointer-distinctness arm)
+ *   DEPT_L2 (LEADER1's primary dept; LEADER2 is flagged leader_in_dept — the contact's
+ *            manager chain is therefore [LEADER1, LEADER2] on the LEADER pointer)
+ *   DEPT_AGREE (separate; the SAME account AGREE is both leader_in_dept AND
+ *               dept_manager_userid_list[0] — the C-4 "pointers coincide" positive control)
+ *   DEPT_REQ (REQ's own primary dept; manager list = [REQ_HEAD], REQ_LEADER flagged leader —
+ *             the C-5 anchor-is-the-field negative material: neither ever resolves)
+ *
+ * Proves:
+ *  choke    both kinds save with a valid {fieldId, level}; out-of-range / non-integer / missing
+ *           level, missing fieldId, and an unknown extra key each 400 at the authoring choke with
+ *           the structural source path in the message and no person id (Lock-1 G-1 posture);
+ *  pins     (C-1/C-2) a dangling fieldId, a non-user field, a non-required user field, a
+ *           visibilityRule-carrying required field, and a props.selection='multi' field are each
+ *           rejected by validateApprovalAssigneeSourcesAgainstFormSchema (runs at save AND
+ *           publish AND restore); a fully compliant template publishes (shape-selected);
+ *  door 2   (§2.2) a whitespace-only contact value passes the required+type checks (door 1
+ *           cannot see it) yet resolves to NO anchor → create-time 422
+ *           APPROVAL_FORM_ROUTING_FIELD_EMPTY with ZERO instance rows — proving the create-time
+ *           door is live and independent of the publish pins;
+ *  core     dispatch resolves the extension of the SUBMITTED contact from the FROZEN create-time
+ *           read: manager kind level 1/2 → [LEADER1]/[LEADER2] (leader-pointer walk re-anchored
+ *           on the contact); dept-head kind level 1 → [HEAD1] and level 2 → [HEAD2] — DEPT_MID's
+ *           EMPTY manager list contributes nothing but the walk CONTINUES to DEPT_TOP (Lock-1
+ *           §K4's RATIFIED continue-past-empty-level posture binding this walker; the chain is
+ *           DENSE so level 2 addresses the second RESOLVED head); resolvedFrom carries
+ *           kind/sourceIndex/fieldId/level (D-5);
+ *  C-4      in DEPT_BOT the two pointers name DIFFERENT people (LEADER1 vs HEAD1) — the two kinds
+ *           resolve DIFFERENT approvers for the SAME submitted contact; in DEPT_AGREE they name
+ *           the SAME person (AGREE) — the test discriminates the pointer, not the label;
+ *  C-5      the resolution derives from the CHOSEN contact, never the requester (REQ's own
+ *           REQ_HEAD/REQ_LEADER never appear in any resolved set);
+ *  empty    a level past the contact's chain and a contact with NO directory account are EMPTY
+ *           resolution → the node's emptyAssigneePolicy (default 'error' → fail-closed 400
+ *           APPROVAL_ASSIGNEE_EMPTY at create, zero rows) — never a silent nobody and never the
+ *           wedge's 422/503 (three different things, §L2-C);
+ *  D-4      freeze purity is TEMPORAL: a directory mutation AFTER create does not move the
+ *           in-flight seat at dispatch (a live-read implementation would red here), while a NEW
+ *           create after the mutation DOES pick up the change;
+ *  D-2      a broken approval_routing policy governing the CONTACT's org fail-closes create 422
+ *           APPROVAL_ROUTING_POLICY_MISCONFIGURED (the shipped ApprovalRoutingPolicyError
+ *           surfaced through the NEW field-derived wedge) with zero rows, while a template with
+ *           NO field-derived source still creates under the SAME broken policy — the wedge is
+ *           source-selected;
+ *  handler  the kinds are handler-admitted (Lock-2 §2.4): a handler node carrying the manager
+ *           kind publishes, and dispatch reaches it with the SAME frozen resolution.
+ */
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const TS = Date.now()
+const REQ = `fc-req-${TS}`
+const APPROVER = `fc-appr-${TS}`
+const U_CONTACT = `fc-contact-${TS}`
+const U_CONTACT_AGREE = `fc-contactagree-${TS}`
+const U_CONTACT_NOACC = `fc-contactnoacc-${TS}` // local user with NO directory account (empty arm)
+const U_LEADER1 = `fc-leader1-${TS}`
+const U_LEADER2 = `fc-leader2-${TS}`
+const U_HEAD1 = `fc-head1-${TS}`
+const U_HEAD1B = `fc-head1b-${TS}` // post-mutation replacement head (D-4 temporal arm)
+const U_HEAD2 = `fc-head2-${TS}`
+const U_AGREE = `fc-agree-${TS}`
+const U_REQ_HEAD = `fc-reqhead-${TS}`
+
+const EXT_TOP = `ftop-${TS}`
+const EXT_MID = `fmid-${TS}`
+const EXT_BOT = `fbot-${TS}`
+const EXT_L2 = `fl2-${TS}`
+const EXT_AGREE_DEPT = `fagree-${TS}`
+const EXT_REQ_DEPT = `freqd-${TS}`
+const EXT_CONTACT = `econtact-${TS}`
+const EXT_CONTACT_AGREE = `econtactagree-${TS}`
+const EXT_LEADER1 = `eleader1-${TS}`
+const EXT_LEADER2 = `eleader2-${TS}`
+const EXT_HEAD1 = `ehead1-${TS}`
+const EXT_HEAD1B = `ehead1b-${TS}`
+const EXT_HEAD2 = `ehead2-${TS}`
+const EXT_AGREE_USER = `eagree-${TS}`
+const EXT_REQ = `ereq-${TS}`
+const EXT_REQ_HEAD = `ereqhead-${TS}`
+const EXT_REQ_LEADER = `ereqleader-${TS}`
+
+async function canListen(): Promise<boolean> {
+  return await new Promise((r) => {
+    const s = net.createServer()
+    s.once('error', () => r(false))
+    s.listen(0, '127.0.0.1', () => s.close(() => r(true)))
+  })
+}
+async function tok(base: string, userId: string): Promise<string> {
+  await grantApprovalWriteForIntegrationActor(userId)
+  const res = await fetch(`${base}/api/auth/dev-token?userId=${encodeURIComponent(userId)}&roles=admin&perms=${encodeURIComponent('*:*')}`)
+  return ((await res.json()) as { token: string }).token
+}
+async function req(base: string, path: string, token: string, opts: { method?: string; body?: unknown } = {}): Promise<Response> {
+  return fetch(`${base}${path}`, {
+    method: opts.method || 'GET',
+    headers: { Authorization: `Bearer ${token}`, ...(opts.body !== undefined ? { 'Content-Type': 'application/json' } : {}) },
+    ...(opts.body !== undefined ? { body: JSON.stringify(opts.body) } : {}),
+  })
+}
+
+// Publish pins (Lock-2 §L2-C): the referenced field is TOP-LEVEL, `user`, required, and carries
+// no visibilityRule — the compliant schema every positive-control template uses.
+const FORM_SCHEMA = {
+  fields: [
+    { id: 'reason', type: 'text', label: 'r', required: true },
+    { id: 'contact', type: 'user', label: '联系人', required: true },
+  ],
+}
+
+type ExtensionKind = 'form_field_user_manager' | 'form_field_user_dept_head'
+
+// gate (static APPROVER) -> ext (the contact extension under test) -> end.
+function extGraph(kind: ExtensionKind, level: number, emptyAssigneePolicy: 'error' | 'auto-approve' = 'error') {
+  return {
+    nodes: [
+      { key: 'start', type: 'start', name: 's', config: {} },
+      { key: 'gate', type: 'approval', name: 'gate', config: { assigneeSources: [{ kind: 'static_user', userIds: [APPROVER] }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+      { key: 'ext', type: 'approval', name: 'ext', config: { assigneeSources: [{ kind, fieldId: 'contact', level }], approvalMode: 'all', emptyAssigneePolicy } },
+      { key: 'end', type: 'end', name: 'e', config: {} },
+    ],
+    edges: [
+      { key: 's2g', source: 'start', target: 'gate' },
+      { key: 'g2x', source: 'gate', target: 'ext' },
+      { key: 'x2e', source: 'ext', target: 'end' },
+    ],
+  }
+}
+
+// single-node graph: the extension node is FIRST, so an empty resolution surfaces at create.
+function firstNodeGraph(kind: ExtensionKind, level: number) {
+  return {
+    nodes: [
+      { key: 'start', type: 'start', name: 's', config: {} },
+      { key: 'ext', type: 'approval', name: 'ext', config: { assigneeSources: [{ kind, fieldId: 'contact', level }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+      { key: 'end', type: 'end', name: 'e', config: {} },
+    ],
+    edges: [
+      { key: 's2x', source: 'start', target: 'ext' },
+      { key: 'x2e', source: 'ext', target: 'end' },
+    ],
+  }
+}
+
+// Lock-2 §2.4 handler admission: gate (static approval) -> handler carrying the extension -> end.
+function handlerGraph(kind: ExtensionKind, level: number) {
+  return {
+    nodes: [
+      { key: 'start', type: 'start', name: 's', config: {} },
+      { key: 'gate', type: 'approval', name: 'gate', config: { assigneeSources: [{ kind: 'static_user', userIds: [APPROVER] }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+      { key: 'do', type: 'handler', name: 'do', config: { assigneeSources: [{ kind, fieldId: 'contact', level }] } },
+      { key: 'end', type: 'end', name: 'e', config: {} },
+    ],
+    edges: [
+      { key: 's2g', source: 'start', target: 'gate' },
+      { key: 'g2d', source: 'gate', target: 'do' },
+      { key: 'd2e', source: 'do', target: 'end' },
+    ],
+  }
+}
+
+// Anti-skip-green sentinel (K2/K3 posture): the workflow lane sets EXPECT_DB=1 — there, a
+// missing/broken DATABASE_URL must go RED (this test runs and fails) instead of the whole suite
+// silently reporting skipped. Ordinary no-DB collection (EXPECT_DB unset) skips it cleanly.
+const itIfExpectDb = process.env.EXPECT_DB === '1' ? it : it.skip
+itIfExpectDb('sentinel: EXPECT_DB lane must have DATABASE_URL (a DB-expected run must never skip-green)', () => {
+  expect(process.env.DATABASE_URL).toBeTruthy()
+})
+
+describeIfDatabase('Lock-2 §L2-C form-field contact extensions — real-DB create-freeze/dispatch acceptance', () => {
+  let server: MetaSheetServer | undefined
+  let base = ''
+  let reqTok = ''
+  let apprTok = ''
+  let integrationId = ''
+  let brokenIntegrationId = ''
+  let deptBotId = ''
+
+  async function createTemplate(key: string, graph: unknown, formSchema: unknown = FORM_SCHEMA): Promise<string> {
+    const created = await req(base, '/api/approval-templates', reqTok, {
+      method: 'POST',
+      body: { key, name: key, formSchema, approvalGraph: graph },
+    })
+    expect(created.status, await created.clone().text()).toBe(201)
+    return ((await created.json()) as { id: string }).id
+  }
+  async function createPublished(key: string, graph: unknown, formSchema: unknown = FORM_SCHEMA): Promise<string> {
+    const tid = await createTemplate(key, graph, formSchema)
+    const published = await req(base, `/api/approval-templates/${tid}/publish`, reqTok, { method: 'POST', body: { policy: { allowRevoke: true } } })
+    expect(published.status, await published.clone().text()).toBe(200)
+    return tid
+  }
+  async function instanceCount(tid: string): Promise<number> {
+    const pool = poolManager.get()
+    const rows = await pool.query(`SELECT COUNT(*)::int AS n FROM approval_instances WHERE template_id = $1`, [tid])
+    return (rows.rows[0] as { n: number }).n
+  }
+  async function activeAssignees(iid: string, nodeKey: string): Promise<Array<{ assignee_id: string; metadata: Record<string, unknown> | null }>> {
+    const pool = poolManager.get()
+    const rows = await pool.query(
+      `SELECT assignee_id, metadata FROM approval_assignments WHERE instance_id = $1 AND node_key = $2 AND is_active = TRUE ORDER BY assignee_id`,
+      [iid, nodeKey],
+    )
+    return rows.rows as Array<{ assignee_id: string; metadata: Record<string, unknown> | null }>
+  }
+  async function createAsReq(tid: string, contactValue: unknown = U_CONTACT): Promise<{ status: number; iid?: string; text: string }> {
+    const started = await req(base, '/api/approvals', reqTok, { method: 'POST', body: { templateId: tid, formData: { reason: 'r', contact: contactValue } } })
+    const text = await started.clone().text()
+    if (started.status >= 300) return { status: started.status, text }
+    return { status: started.status, iid: ((await started.json()) as { id: string }).id, text }
+  }
+
+  beforeAll(async () => {
+    expect(await canListen()).toBe(true)
+    await ensureApprovalSchemaReady()
+
+    for (const u of [REQ, APPROVER, U_CONTACT, U_CONTACT_AGREE, U_CONTACT_NOACC, U_LEADER1, U_LEADER2, U_HEAD1, U_HEAD1B, U_HEAD2, U_AGREE, U_REQ_HEAD]) {
+      await query(`INSERT INTO users (id, email, password_hash) VALUES ($1, $2, 'x') ON CONFLICT (id) DO NOTHING`, [u, `${u}@example.test`])
+    }
+
+    const integ = await query<{ id: string }>(
+      `INSERT INTO directory_integrations (name, corp_id) VALUES ($1, $2) RETURNING id`,
+      [`fc-${TS}`, `fc-corp-${TS}`],
+    )
+    integrationId = integ.rows[0].id
+
+    // ── departments ──────────────────────────────────────────────────────────────────────────
+    await query(
+      `INSERT INTO directory_departments (integration_id, external_department_id, external_parent_department_id, name, is_active, raw)
+       VALUES ($1, $2, NULL, 'Top', true, $3::jsonb)`,
+      [integrationId, EXT_TOP, JSON.stringify({ dept_manager_userid_list: [EXT_HEAD2] })],
+    )
+    await query(
+      `INSERT INTO directory_departments (integration_id, external_department_id, external_parent_department_id, name, is_active, raw)
+       VALUES ($1, $2, $3, 'Mid', true, $4::jsonb)`,
+      [integrationId, EXT_MID, EXT_TOP, JSON.stringify({ dept_manager_userid_list: [] })],
+    )
+    const deptBot = await query<{ id: string }>(
+      `INSERT INTO directory_departments (integration_id, external_department_id, external_parent_department_id, name, is_active, raw)
+       VALUES ($1, $2, $3, 'Bot', true, $4::jsonb) RETURNING id`,
+      [integrationId, EXT_BOT, EXT_MID, JSON.stringify({ dept_manager_userid_list: [EXT_HEAD1] })],
+    )
+    deptBotId = deptBot.rows[0].id
+    const deptL2 = await query<{ id: string }>(
+      `INSERT INTO directory_departments (integration_id, external_department_id, external_parent_department_id, name, is_active, raw)
+       VALUES ($1, $2, NULL, 'L2', true, '{}'::jsonb) RETURNING id`,
+      [integrationId, EXT_L2],
+    )
+    const deptAgree = await query<{ id: string }>(
+      `INSERT INTO directory_departments (integration_id, external_department_id, external_parent_department_id, name, is_active, raw)
+       VALUES ($1, $2, NULL, 'Agree', true, $3::jsonb) RETURNING id`,
+      [integrationId, EXT_AGREE_DEPT, JSON.stringify({ dept_manager_userid_list: [EXT_AGREE_USER] })],
+    )
+    const deptReq = await query<{ id: string }>(
+      `INSERT INTO directory_departments (integration_id, external_department_id, external_parent_department_id, name, is_active, raw)
+       VALUES ($1, $2, NULL, 'ReqDept', true, $3::jsonb) RETURNING id`,
+      [integrationId, EXT_REQ_DEPT, JSON.stringify({ dept_manager_userid_list: [EXT_REQ_HEAD] })],
+    )
+
+    // ── accounts ─────────────────────────────────────────────────────────────────────────────
+    const insertAccount = async (external: string, name: string, raw: Record<string, unknown> = {}): Promise<string> => {
+      const row = await query<{ id: string }>(
+        `INSERT INTO directory_accounts (integration_id, external_user_id, external_key, name, raw)
+         VALUES ($1, $2, $3, $4, $5::jsonb) RETURNING id`,
+        [integrationId, external, `k-${external}`, name, JSON.stringify(raw)],
+      )
+      return row.rows[0].id
+    }
+    const accContact = await insertAccount(EXT_CONTACT, 'Contact')
+    const accContactAgree = await insertAccount(EXT_CONTACT_AGREE, 'ContactAgree')
+    // LEADER1: member of DEPT_BOT flagged leader_in_dept for it (the contact's level-1 manager on
+    // the LEADER pointer), with their OWN primary department DEPT_L2 — whose leader is LEADER2.
+    const accLeader1 = await insertAccount(EXT_LEADER1, 'Leader1', { leader_in_dept: [{ dept_id: EXT_BOT, leader: true }] })
+    const accLeader2 = await insertAccount(EXT_LEADER2, 'Leader2', { leader_in_dept: [{ dept_id: EXT_L2, leader: true }] })
+    const accHead1 = await insertAccount(EXT_HEAD1, 'Head1')
+    const accHead2 = await insertAccount(EXT_HEAD2, 'Head2')
+    const accAgree = await insertAccount(EXT_AGREE_USER, 'Agree', { leader_in_dept: [{ dept_id: EXT_AGREE_DEPT, leader: true }] })
+    // Requester material (C-5): REQ has their OWN dept/head/leader — none of which may resolve.
+    const accReq = await insertAccount(EXT_REQ, 'Req')
+    const accReqHead = await insertAccount(EXT_REQ_HEAD, 'ReqHead')
+    const accReqLeader = await insertAccount(EXT_REQ_LEADER, 'ReqLeader', { leader_in_dept: [{ dept_id: EXT_REQ_DEPT, leader: true }] })
+
+    await query(
+      `INSERT INTO directory_account_links (directory_account_id, local_user_id, link_status, match_strategy)
+       VALUES ($1, $2, 'linked', 'manual'), ($3, $4, 'linked', 'manual'), ($5, $6, 'linked', 'manual'),
+              ($7, $8, 'linked', 'manual'), ($9, $10, 'linked', 'manual'), ($11, $12, 'linked', 'manual'),
+              ($13, $14, 'linked', 'manual'), ($15, $16, 'linked', 'manual'), ($17, $18, 'linked', 'manual')`,
+      [
+        accContact, U_CONTACT,
+        accContactAgree, U_CONTACT_AGREE,
+        accLeader1, U_LEADER1,
+        accLeader2, U_LEADER2,
+        accHead1, U_HEAD1,
+        accHead2, U_HEAD2,
+        accAgree, U_AGREE,
+        accReq, REQ,
+        accReqHead, U_REQ_HEAD,
+      ],
+    )
+    // memberships: CONTACT primary in BOT (LEADER1 non-primary member there, so the leader hop
+    // finds them); LEADER1 primary in DEPT_L2 (LEADER2 non-primary member there); CONTACT_AGREE
+    // primary in DEPT_AGREE (AGREE non-primary member); REQ primary in DEPT_REQ (REQ_LEADER
+    // non-primary member).
+    await query(
+      `INSERT INTO directory_account_departments (directory_account_id, directory_department_id, is_primary)
+       VALUES ($1, $2, true), ($3, $2, false),
+              ($4, $5, true), ($6, $5, false),
+              ($7, $8, true), ($9, $8, false),
+              ($10, $11, true), ($12, $11, false)`,
+      [
+        accContact, deptBotId, accLeader1,
+        accLeader1, deptL2.rows[0].id, accLeader2,
+        accContactAgree, deptAgree.rows[0].id, accAgree,
+        accReq, deptReq.rows[0].id, accReqLeader,
+      ],
+    )
+
+    server = new MetaSheetServer({ port: 0, host: '127.0.0.1', pluginDirs: [] })
+    await server.start()
+    base = `http://127.0.0.1:${server.getAddress()!.port}`
+    reqTok = await tok(base, REQ)
+    apprTok = await tok(base, APPROVER)
+  })
+
+  afterAll(async () => {
+    try {
+      const pool = poolManager.get()
+      const tids = (await pool.query(`SELECT id FROM approval_templates WHERE key LIKE $1`, [`fc-${TS}-%`])).rows.map((r) => r.id as string)
+      if (tids.length > 0) {
+        const iids = (await pool.query(`SELECT id FROM approval_instances WHERE template_id = ANY($1::uuid[])`, [tids])).rows.map((r) => r.id as string)
+        if (iids.length > 0) {
+          await pool.query(`DELETE FROM approval_records WHERE instance_id = ANY($1)`, [iids])
+          await pool.query(`DELETE FROM approval_assignments WHERE instance_id = ANY($1)`, [iids])
+          await pool.query(`DELETE FROM approval_instances WHERE id = ANY($1)`, [iids])
+        }
+        await pool.query(`DELETE FROM approval_published_definitions WHERE template_id = ANY($1::uuid[])`, [tids])
+        await pool.query(`DELETE FROM approval_templates WHERE id = ANY($1::uuid[])`, [tids])
+      }
+      await query(`DELETE FROM org_directory_routing_policy WHERE org_id = 'default'`)
+      if (brokenIntegrationId) {
+        await query(`DELETE FROM directory_integrations WHERE id = $1`, [brokenIntegrationId])
+      }
+      if (integrationId) {
+        await query(`DELETE FROM directory_accounts WHERE integration_id = $1`, [integrationId])
+        await query(`DELETE FROM directory_departments WHERE integration_id = $1`, [integrationId])
+        await query(`DELETE FROM directory_integrations WHERE id = $1`, [integrationId])
+      }
+      await query(`DELETE FROM users WHERE id = ANY($1::varchar[])`, [[REQ, APPROVER, U_CONTACT, U_CONTACT_AGREE, U_CONTACT_NOACC, U_LEADER1, U_LEADER2, U_HEAD1, U_HEAD1B, U_HEAD2, U_AGREE, U_REQ_HEAD]])
+    } catch {
+      /* best effort */
+    }
+    if (server) await server.stop()
+  })
+
+  it('sentinel: DATABASE_URL is set (DB-backed lane must not silently skip)', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  // ── authoring choke (Lock-1 G-1 posture for NEW kinds) ──────────────────────────────────────
+  it('choke: both kinds save with a valid {fieldId, level}; bad level / missing fieldId / unknown extra key each 400 with the structural source path and no person id', async () => {
+    // Positive control FIRST: a valid shape of EACH kind saves.
+    expect(await createTemplate(`fc-${TS}-choke-ok-m`, extGraph('form_field_user_manager', 2))).toBeTruthy()
+    expect(await createTemplate(`fc-${TS}-choke-ok-d`, extGraph('form_field_user_dept_head', 1))).toBeTruthy()
+
+    const badLevels: unknown[] = [0, -1, 1.5, 11, 'two', null, undefined]
+    for (const kind of ['form_field_user_manager', 'form_field_user_dept_head'] as const) {
+      for (const level of badLevels) {
+        const graph = extGraph(kind, 1) as { nodes: Array<{ config: { assigneeSources?: unknown[] } }> }
+        const source: Record<string, unknown> = { kind, fieldId: 'contact' }
+        if (level !== undefined) source.level = level
+        graph.nodes[2].config.assigneeSources = [source]
+        const res = await req(base, '/api/approval-templates', reqTok, {
+          method: 'POST',
+          body: { key: `fc-${TS}-choke-bad`, name: 'bad', formSchema: FORM_SCHEMA, approvalGraph: graph },
+        })
+        expect(res.status, `${kind} level=${JSON.stringify(level)}`).toBe(400)
+        const raw = await res.clone().text()
+        // Values-free: the structural source-index path (template-authored, permitted by §2.6);
+        // never a person id (trivially — none was supplied for a shape rejection).
+        expect(raw).toContain('assigneeSources[0].level')
+      }
+
+      // missing fieldId
+      const noField = extGraph(kind, 1) as { nodes: Array<{ config: { assigneeSources?: unknown[] } }> }
+      noField.nodes[2].config.assigneeSources = [{ kind, level: 1 }]
+      const noFieldRes = await req(base, '/api/approval-templates', reqTok, {
+        method: 'POST',
+        body: { key: `fc-${TS}-choke-nf`, name: 'nf', formSchema: FORM_SCHEMA, approvalGraph: noField },
+      })
+      expect(noFieldRes.status).toBe(400)
+      expect(await noFieldRes.clone().text()).toContain('assigneeSources[0].fieldId')
+
+      // unknown extra key — REJECTED, never silently dropped (G-1 posture for new kinds).
+      const extraKey = extGraph(kind, 1) as { nodes: Array<{ config: { assigneeSources?: unknown[] } }> }
+      extraKey.nodes[2].config.assigneeSources = [{ kind, fieldId: 'contact', level: 1, futureFlag: true }]
+      const extraRes = await req(base, '/api/approval-templates', reqTok, {
+        method: 'POST',
+        body: { key: `fc-${TS}-choke-xk`, name: 'xk', formSchema: FORM_SCHEMA, approvalGraph: extraKey },
+      })
+      expect(extraRes.status).toBe(400)
+      expect(await extraRes.clone().text()).toContain('unknown keys')
+    }
+  })
+
+  // ── publish pins (C-1/C-2; the validator runs at save AND publish AND restore) ──────────────
+  it('pins: dangling field, non-user field, non-required field, visibilityRule field, and selection:multi each reject; the compliant shape publishes (shape-selected, not blanket)', async () => {
+    const negativeSchemas: Array<[string, unknown]> = [
+      // (1) dangling fieldId — the referenced field does not exist.
+      ['dangling', { fields: [{ id: 'reason', type: 'text', label: 'r', required: true }] }],
+      // (2) wrong type — `contact` exists but is not a user field.
+      ['nonuser', { fields: [{ id: 'reason', type: 'text', label: 'r', required: true }, { id: 'contact', type: 'text', label: 'c', required: true }] }],
+      // (3) not required.
+      ['optional', { fields: [{ id: 'reason', type: 'text', label: 'r', required: true }, { id: 'contact', type: 'user', label: 'c' }] }],
+      // (4) required but visibility-ruled — pin (3) alone closes nothing (§L2-C): the hidden-field
+      //     skip at validateApprovalFormData + pruneHiddenFormData would let the value vanish.
+      ['visrule', { fields: [{ id: 'reason', type: 'text', label: 'r', required: true }, { id: 'contact', type: 'user', label: 'c', required: true, visibilityRule: { fieldId: 'reason', operator: 'eq', value: 'show' } }] }],
+      // (6) selection: 'multi' — rejected until OD-L2-7's array support lands in the same slice.
+      ['multi', { fields: [{ id: 'reason', type: 'text', label: 'r', required: true }, { id: 'contact', type: 'user', label: 'c', required: true, props: { selection: 'multi' } }] }],
+    ]
+    for (const kind of ['form_field_user_manager', 'form_field_user_dept_head'] as const) {
+      for (const [name, schema] of negativeSchemas) {
+        const res = await req(base, '/api/approval-templates', reqTok, {
+          method: 'POST',
+          body: { key: `fc-${TS}-pin-${name}`, name, formSchema: schema, approvalGraph: extGraph(kind, 1) },
+        })
+        expect(res.status, `${kind} pin=${name}`).toBe(400)
+        const raw = await res.clone().text()
+        expect(raw).toContain(kind)
+        // Values-free: the node key is present; no person id can be (none supplied).
+        expect(raw).toContain('ext')
+      }
+      // Positive control: the SAME kind with the compliant schema publishes.
+      await createPublished(`fc-${TS}-pin-ok-${kind}`, extGraph(kind, 1))
+    }
+  })
+
+  // ── door 2 (§2.2) — the independent create-time 422, live through the REAL API ──────────────
+  it('door 2: a whitespace-only contact value passes the required+type checks (door 1 cannot see it) but yields NO anchor → 422 APPROVAL_FORM_ROUTING_FIELD_EMPTY, zero instance rows, values-free body', async () => {
+    const tid = await createPublished(`fc-${TS}-door2`, extGraph('form_field_user_manager', 1))
+    const res = await createAsReq(tid, '   ')
+    expect(res.status, res.text).toBe(422)
+    expect(res.text).toContain('APPROVAL_FORM_ROUTING_FIELD_EMPTY')
+    // Values-free: the template-authored node key + field id are permitted; no person/form value.
+    expect(res.text).toContain('contact')
+    expect(res.text).not.toContain(U_CONTACT)
+    expect(await instanceCount(tid)).toBe(0)
+    // Positive control: the SAME template with a real contact creates (the door is value-selected).
+    const ok = await createAsReq(tid)
+    expect(ok.status, ok.text).toBe(201)
+  })
+
+  // ── core: create-time freeze + dispatch, both pointers, both levels ─────────────────────────
+  it('core (manager kind): dispatch assigns the SUBMITTED contact\'s leader-pointer manager at the configured level — level 1 → LEADER1, level 2 → LEADER2 — with resolvedFrom kind/fieldId/level (D-5), never the requester\'s own manager (C-5)', async () => {
+    for (const [level, expected] of [[1, U_LEADER1], [2, U_LEADER2]] as const) {
+      const tid = await createPublished(`fc-${TS}-core-m${level}`, extGraph('form_field_user_manager', level))
+      const started = await createAsReq(tid)
+      expect(started.status, started.text).toBe(201)
+      const iid = started.iid!
+      const gateApprove = await req(base, `/api/approvals/${iid}/actions`, apprTok, { method: 'POST', body: { action: 'approve' } })
+      expect(gateApprove.status, await gateApprove.clone().text()).toBeLessThan(300)
+      const assignees = await activeAssignees(iid, 'ext')
+      expect(assignees.map((a) => a.assignee_id)).toEqual([expected])
+      const resolvedFrom = (assignees[0].metadata as { resolvedFrom?: Record<string, unknown> } | null)?.resolvedFrom
+      expect(resolvedFrom).toEqual({ kind: 'form_field_user_manager', sourceIndex: 0, fieldId: 'contact', level })
+      // C-5: the requester's own org material never resolves — the anchor is the FIELD.
+      expect(assignees.map((a) => a.assignee_id)).not.toContain(U_REQ_HEAD)
+    }
+  })
+
+  it('core (dept-head kind): level 1 → HEAD1; level 2 → HEAD2 THROUGH the empty-list DEPT_MID (the ratified continue-past-empty-level posture binds the re-anchored parent-tree walker; the chain is DENSE)', async () => {
+    for (const [level, expected] of [[1, U_HEAD1], [2, U_HEAD2]] as const) {
+      const tid = await createPublished(`fc-${TS}-core-d${level}`, extGraph('form_field_user_dept_head', level))
+      const started = await createAsReq(tid)
+      expect(started.status, started.text).toBe(201)
+      const iid = started.iid!
+      const gateApprove = await req(base, `/api/approvals/${iid}/actions`, apprTok, { method: 'POST', body: { action: 'approve' } })
+      expect(gateApprove.status, await gateApprove.clone().text()).toBeLessThan(300)
+      const assignees = await activeAssignees(iid, 'ext')
+      expect(assignees.map((a) => a.assignee_id)).toEqual([expected])
+      const resolvedFrom = (assignees[0].metadata as { resolvedFrom?: Record<string, unknown> } | null)?.resolvedFrom
+      expect(resolvedFrom).toEqual({ kind: 'form_field_user_dept_head', sourceIndex: 0, fieldId: 'contact', level })
+    }
+  })
+
+  // ── C-4 pointer distinctness ────────────────────────────────────────────────────────────────
+  it('C-4 arm 1 (DISAGREE): for the SAME submitted contact, the leader pointer (LEADER1) and the manager list (HEAD1) name DIFFERENT people — the two kinds resolve DIFFERENT approvers', async () => {
+    const mTid = await createPublished(`fc-${TS}-c4-m`, firstNodeGraph('form_field_user_manager', 1))
+    const mRes = await createAsReq(mTid)
+    expect(mRes.status, mRes.text).toBe(201)
+    const mAssignees = await activeAssignees(mRes.iid!, 'ext')
+
+    const dTid = await createPublished(`fc-${TS}-c4-d`, firstNodeGraph('form_field_user_dept_head', 1))
+    const dRes = await createAsReq(dTid)
+    expect(dRes.status, dRes.text).toBe(201)
+    const dAssignees = await activeAssignees(dRes.iid!, 'ext')
+
+    expect(mAssignees.map((a) => a.assignee_id)).toEqual([U_LEADER1])
+    expect(dAssignees.map((a) => a.assignee_id)).toEqual([U_HEAD1])
+    expect(mAssignees.map((a) => a.assignee_id)).not.toEqual(dAssignees.map((a) => a.assignee_id))
+  })
+
+  it('C-4 arm 2 (AGREE, positive control): where the two pointers COINCIDE, both kinds resolve the SAME person — the test discriminates the pointer, not the label', async () => {
+    const mTid = await createPublished(`fc-${TS}-c4a-m`, firstNodeGraph('form_field_user_manager', 1))
+    const mRes = await createAsReq(mTid, U_CONTACT_AGREE)
+    expect(mRes.status, mRes.text).toBe(201)
+    expect((await activeAssignees(mRes.iid!, 'ext')).map((a) => a.assignee_id)).toEqual([U_AGREE])
+
+    const dTid = await createPublished(`fc-${TS}-c4a-d`, firstNodeGraph('form_field_user_dept_head', 1))
+    const dRes = await createAsReq(dTid, U_CONTACT_AGREE)
+    expect(dRes.status, dRes.text).toBe(201)
+    expect((await activeAssignees(dRes.iid!, 'ext')).map((a) => a.assignee_id)).toEqual([U_AGREE])
+  })
+
+  // ── empty resolution: fail-closed per policy, never a silent nobody, never the wedge ────────
+  it('empty: a level past the contact\'s chain, and a contact with NO directory account, are EMPTY resolution → default policy \'error\' fail-closes create 400 APPROVAL_ASSIGNEE_EMPTY with zero rows (not the wedge\'s 422/503 — data absence is not a read failure)', async () => {
+    // Manager chain has 2 entries; level 5 is contract-valid but past the end.
+    const tid = await createPublished(`fc-${TS}-empty-lvl`, firstNodeGraph('form_field_user_manager', 5))
+    const res = await createAsReq(tid)
+    expect(res.status, res.text).toBe(400)
+    expect(res.text).toContain('APPROVAL_ASSIGNEE_EMPTY')
+    expect(await instanceCount(tid)).toBe(0)
+
+    // A real local user with NO directory account: the anchor read succeeds and finds nothing.
+    const tid2 = await createPublished(`fc-${TS}-empty-noacc`, firstNodeGraph('form_field_user_manager', 1))
+    const res2 = await createAsReq(tid2, U_CONTACT_NOACC)
+    expect(res2.status, res2.text).toBe(400)
+    expect(res2.text).toContain('APPROVAL_ASSIGNEE_EMPTY')
+    expect(await instanceCount(tid2)).toBe(0)
+    // Neither is the wedge shape: no routing-policy/org-unresolved code on a data-absence path.
+    expect(res.text).not.toContain('APPROVAL_ROUTING_POLICY_MISCONFIGURED')
+    expect(res2.text).not.toContain('APPROVAL_FORM_ROUTING_ORG_UNRESOLVED')
+  })
+
+  // ── D-4 freeze purity: temporal, not a dead read; no live read at dispatch ──────────────────
+  it('D-4 freeze purity: a directory mutation AFTER create does not move the in-flight seat at dispatch (a live-read implementation reds here), while a NEW create after the mutation DOES pick it up — the freeze is temporal', async () => {
+    const tid = await createPublished(`fc-${TS}-freeze`, extGraph('form_field_user_dept_head', 1))
+    const started = await createAsReq(tid)
+    expect(started.status, started.text).toBe(201)
+    const iid = started.iid!
+
+    // Mutate DEPT_BOT's manager list AFTER create: HEAD1 -> HEAD1B (a fresh linked account).
+    const accHead1b = await query<{ id: string }>(
+      `INSERT INTO directory_accounts (integration_id, external_user_id, external_key, name, raw)
+       VALUES ($1, $2, $3, 'Head1B', '{}'::jsonb) RETURNING id`,
+      [integrationId, EXT_HEAD1B, `k-head1b-${TS}`],
+    )
+    await query(
+      `INSERT INTO directory_account_links (directory_account_id, local_user_id, link_status, match_strategy)
+       VALUES ($1, $2, 'linked', 'manual')`,
+      [accHead1b.rows[0].id, U_HEAD1B],
+    )
+    try {
+      await query(
+        `UPDATE directory_departments SET raw = jsonb_set(COALESCE(raw, '{}'::jsonb), '{dept_manager_userid_list}', $2::jsonb) WHERE id = $1`,
+        [deptBotId, JSON.stringify([EXT_HEAD1B])],
+      )
+
+      // Dispatch the ALREADY-CREATED instance: the frozen snapshot must still resolve HEAD1 —
+      // no live directory read at dispatch (Lock-2 §2.1 resolver purity).
+      const gateApprove = await req(base, `/api/approvals/${iid}/actions`, apprTok, { method: 'POST', body: { action: 'approve' } })
+      expect(gateApprove.status, await gateApprove.clone().text()).toBeLessThan(300)
+      const inFlight = await activeAssignees(iid, 'ext')
+      expect(inFlight.map((a) => a.assignee_id)).toEqual([U_HEAD1])
+      expect(inFlight.map((a) => a.assignee_id)).not.toContain(U_HEAD1B)
+
+      // Temporal positive control: a NEW create AFTER the mutation resolves HEAD1B — the
+      // create-time read re-executes per create rather than being cached or dead.
+      const newTid = await createPublished(`fc-${TS}-freeze-new`, firstNodeGraph('form_field_user_dept_head', 1))
+      const newStarted = await createAsReq(newTid)
+      expect(newStarted.status, newStarted.text).toBe(201)
+      expect((await activeAssignees(newStarted.iid!, 'ext')).map((a) => a.assignee_id)).toEqual([U_HEAD1B])
+    } finally {
+      await query(
+        `UPDATE directory_departments SET raw = jsonb_set(COALESCE(raw, '{}'::jsonb), '{dept_manager_userid_list}', $2::jsonb) WHERE id = $1`,
+        [deptBotId, JSON.stringify([EXT_HEAD1])],
+      )
+    }
+  })
+
+  // ── D-2: the NEW field-derived wedge is fail-closed and source-selected ─────────────────────
+  it('D-2 wedge: a BROKEN approval_routing policy governing the contact\'s org fail-closes create 422 APPROVAL_ROUTING_POLICY_MISCONFIGURED with zero rows; a template with NO field-derived source still creates under the SAME broken policy (source-selected)', async () => {
+    const extTid = await createPublished(`fc-${TS}-wedge-ext`, extGraph('form_field_user_manager', 1))
+    const staticTid = await createPublished(`fc-${TS}-wedge-static`, {
+      nodes: [
+        { key: 'start', type: 'start', name: 's', config: {} },
+        { key: 'a1', type: 'approval', name: 'a1', config: { assigneeSources: [{ kind: 'static_user', userIds: [APPROVER] }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+        { key: 'end', type: 'end', name: 'e', config: {} },
+      ],
+      edges: [
+        { key: 's2a', source: 'start', target: 'a1' },
+        { key: 'a2e', source: 'a1', target: 'end' },
+      ],
+    })
+    // Broken policy: canonical_integration_id points at a real but NON-'active' integration in
+    // the same org (the FK requires a real row) → the shipped policy probe raises
+    // ApprovalRoutingPolicyError ("points at a 'disabled' integration") for every account linked
+    // in org 'default'.
+    const disabledInteg = await query<{ id: string }>(
+      `INSERT INTO directory_integrations (name, corp_id, status) VALUES ($1, $2, 'disabled') RETURNING id`,
+      [`fc-broken-${TS}`, `fc-broken-corp-${TS}`],
+    )
+    brokenIntegrationId = disabledInteg.rows[0].id
+    await query(
+      `INSERT INTO org_directory_routing_policy (org_id, purpose, canonical_integration_id)
+       VALUES ('default', 'approval_routing', $1)`,
+      [brokenIntegrationId],
+    )
+    try {
+      const res = await createAsReq(extTid)
+      expect(res.status, res.text).toBe(422)
+      expect(res.text).toContain('APPROVAL_ROUTING_POLICY_MISCONFIGURED')
+      expect(res.text).not.toContain(U_CONTACT)
+      expect(await instanceCount(extTid)).toBe(0)
+
+      // Source-selected: NO field-derived source ⇒ the new wedge never arms, create succeeds
+      // (the requester org read fails too, but runtimeGraphUsesOrgAssigneeSource is false for a
+      // static-only graph, so the shipped wedge stays quiet as well).
+      const staticRes = await req(base, '/api/approvals', reqTok, { method: 'POST', body: { templateId: staticTid, formData: { reason: 'r', contact: U_CONTACT } } })
+      expect(staticRes.status, await staticRes.clone().text()).toBe(201)
+    } finally {
+      await query(`DELETE FROM org_directory_routing_policy WHERE org_id = 'default'`)
+    }
+  })
+
+  // ── Lock-2 §2.4 handler admission ───────────────────────────────────────────────────────────
+  it('handler: a handler node carrying form_field_user_manager publishes (the 7→9 roster growth) and dispatch reaches it with the SAME frozen resolution', async () => {
+    const tid = await createPublished(`fc-${TS}-handler`, handlerGraph('form_field_user_manager', 1))
+    const started = await createAsReq(tid)
+    expect(started.status, started.text).toBe(201)
+    const iid = started.iid!
+    const gateApprove = await req(base, `/api/approvals/${iid}/actions`, apprTok, { method: 'POST', body: { action: 'approve' } })
+    expect(gateApprove.status, await gateApprove.clone().text()).toBeLessThan(300)
+    const assignees = await activeAssignees(iid, 'do')
+    expect(assignees.map((a) => a.assignee_id)).toEqual([U_LEADER1])
+    const resolvedFrom = (assignees[0].metadata as { resolvedFrom?: Record<string, unknown> } | null)?.resolvedFrom
+    expect(resolvedFrom).toEqual({ kind: 'form_field_user_manager', sourceIndex: 0, fieldId: 'contact', level: 1 })
+  })
+})

--- a/packages/core-backend/tests/unit/approval-assignee-resolver.test.ts
+++ b/packages/core-backend/tests/unit/approval-assignee-resolver.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { resolveApprovalAssignees } from '../../src/services/ApprovalAssigneeResolver'
+import { fieldDerivedAssigneeSourceKey, resolveApprovalAssignees } from '../../src/services/ApprovalAssigneeResolver'
 import type { ApprovalNodeConfig, FormSchema } from '../../src/types/approval-product'
 
 const userFieldSchema: FormSchema = {
@@ -218,6 +218,83 @@ describe('ApprovalAssigneeResolver', () => {
     expect(resolveDeptHeadAtLevel(2, { id: 'requester-1', deptHeadChainIds: ['h1', null as never, 'h3'] })).toEqual([])
     expect(resolveDeptHeadAtLevel(1, { id: 'requester-1', deptHeadChainIds: ['h1', null as never, 'h3'] })).toEqual([dhalEntry('h1')])
     expect(resolveDeptHeadAtLevel(3, { id: 'requester-1', deptHeadChainIds: ['h1', null as never, 'h3'] })).toEqual([dhalEntry('h3')])
+  })
+
+  // form_field_user_manager / form_field_user_dept_head (Lock-2 §L2-C) — pure map lookup over
+  // the create-frozen fieldDerivedAssigneeIds (source fingerprint → resolved local user ids).
+  function resolveFieldDerived(
+    kind: 'form_field_user_manager' | 'form_field_user_dept_head',
+    fieldId: string,
+    level: number,
+    requesterSnapshot: Record<string, unknown> | null,
+  ) {
+    return resolveApprovalAssignees({
+      nodeKey: 'review',
+      sourceStep: 2,
+      config: { assigneeSources: [{ kind, fieldId, level }] },
+      formSnapshot: { [fieldId]: 'contact-1' },
+      requesterSnapshot,
+    })
+  }
+
+  it('resolves the contact-extension kinds from the frozen fieldDerivedAssigneeIds entry keyed by <kind>:<fieldId>:<level> (positive control, both kinds; metadata carries fieldId + level)', () => {
+    expect(resolveFieldDerived('form_field_user_manager', 'contact', 2, {
+      id: 'requester-1',
+      fieldDerivedAssigneeIds: { 'form_field_user_manager:contact:2': ['mgr-2'] },
+    })).toEqual([{
+      assignmentType: 'user', assigneeId: 'mgr-2', nodeKey: 'review', sourceStep: 2,
+      metadata: { resolvedFrom: { kind: 'form_field_user_manager', sourceIndex: 0, fieldId: 'contact', level: 2 } },
+    }])
+    expect(resolveFieldDerived('form_field_user_dept_head', 'contact', 1, {
+      id: 'requester-1',
+      fieldDerivedAssigneeIds: { 'form_field_user_dept_head:contact:1': ['head-1'] },
+    })).toEqual([{
+      assignmentType: 'user', assigneeId: 'head-1', nodeKey: 'review', sourceStep: 2,
+      metadata: { resolvedFrom: { kind: 'form_field_user_dept_head', sourceIndex: 0, fieldId: 'contact', level: 1 } },
+    }])
+  })
+
+  it('the resolver lookup key IS fieldDerivedAssigneeSourceKey — a mismatched key (wrong level / wrong field) resolves EMPTY, proving snapshot key and fingerprint cannot drift silently', () => {
+    // Sanity-pin the exported producer itself (the create path, the fingerprint, and this arm all
+    // consume it — one producer, no drift).
+    expect(fieldDerivedAssigneeSourceKey({ kind: 'form_field_user_manager', fieldId: ' contact ', level: 2 }))
+      .toBe('form_field_user_manager:contact:2')
+    // A frozen entry at a DIFFERENT level/field is not read (empty resolution → emptyAssigneePolicy).
+    expect(resolveFieldDerived('form_field_user_manager', 'contact', 1, {
+      id: 'requester-1',
+      fieldDerivedAssigneeIds: { 'form_field_user_manager:contact:2': ['mgr-2'] },
+    })).toEqual([])
+    expect(resolveFieldDerived('form_field_user_manager', 'other', 2, {
+      id: 'requester-1',
+      fieldDerivedAssigneeIds: { 'form_field_user_manager:contact:2': ['mgr-2'] },
+    })).toEqual([])
+  })
+
+  it('contact-extension kinds apply NO requester self-exclusion (Lock-2 §L2-C deliberate posture — unlike manager_at_level/dept_head_at_level): a frozen id equal to the requester still gets the seat', () => {
+    expect(resolveFieldDerived('form_field_user_manager', 'contact', 1, {
+      id: 'requester-1',
+      fieldDerivedAssigneeIds: { 'form_field_user_manager:contact:1': ['requester-1'] },
+    })).toEqual([{
+      assignmentType: 'user', assigneeId: 'requester-1', nodeKey: 'review', sourceStep: 2,
+      metadata: { resolvedFrom: { kind: 'form_field_user_manager', sourceIndex: 0, fieldId: 'contact', level: 1 } },
+    }])
+    // Discriminating negative control: the SAME snapshot shape through dept_head_at_level (a
+    // requester-anchored kind) DOES self-exclude — the no-exclusion above is kind-selected.
+    expect(resolveApprovalAssignees({
+      nodeKey: 'review', sourceStep: 2,
+      config: { assigneeSources: [{ kind: 'dept_head_at_level', level: 1 }] },
+      formSnapshot: {},
+      requesterSnapshot: { id: 'requester-1', deptHeadChainIds: ['requester-1'] },
+    })).toEqual([])
+  })
+
+  it('contact-extension kinds resolve EMPTY (never throw) when the frozen entry is an empty array, the map is absent, or the snapshot is null — falls to emptyAssigneePolicy (Lock-2 §2.6)', () => {
+    expect(resolveFieldDerived('form_field_user_manager', 'contact', 1, {
+      id: 'requester-1',
+      fieldDerivedAssigneeIds: { 'form_field_user_manager:contact:1': [] },
+    })).toEqual([])
+    expect(resolveFieldDerived('form_field_user_dept_head', 'contact', 1, { id: 'requester-1' })).toEqual([])
+    expect(resolveFieldDerived('form_field_user_manager', 'contact', 1, null)).toEqual([])
   })
 
   // prior_node_approver (Lock-1 §K3) — resolves the referenced prior node's ACTUAL deciders from

--- a/packages/core-backend/tests/unit/approval-field-derived-sources.test.ts
+++ b/packages/core-backend/tests/unit/approval-field-derived-sources.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from 'vitest'
+import {
+  APPROVAL_ASSIGNEE_SOURCE_KIND_TRAITS,
+  DEPT_HEAD_CHAIN_ASSIGNEE_SOURCE_KINDS,
+  FIELD_DERIVED_ORG_ASSIGNEE_SOURCE_KINDS,
+  MANAGER_CHAIN_ASSIGNEE_SOURCE_KINDS,
+  ORG_ASSIGNEE_SOURCE_KINDS,
+  collectRuntimeGraphFieldDerivedSources,
+  runtimeGraphUsesDeptHeadChain,
+  runtimeGraphUsesManagerChain,
+  runtimeGraphUsesOrgAssigneeSource,
+} from '../../src/services/ApprovalProductService'
+import type { ApprovalAssigneeSourceKind, RuntimeGraph } from '../../src/types/approval-product'
+
+/**
+ * Lock-2 §2.3 (the locked derived-not-enumerated refactor) + gate D-3 (adapted): the create-time
+ * detectors' kind sets are DERIVED from the single APPROVAL_ASSIGNEE_SOURCE_KIND_TRAITS table —
+ * not four hand-maintained `||` chains — and each derived set is pinned by EXACT set equality.
+ *
+ * The "proven DERIVED" arm: the per-kind detector sweep below drives every detector from the trait
+ * table itself (expected = the trait row), so editing ONLY a trait row — touching no detector —
+ * moves the detector AND reds the exact-set pin here. Without that arm this file would pass on
+ * hand-maintained chains that happen to agree (the count-style assertion D-3's own text calls
+ * insufficient).
+ */
+
+// A minimal one-approval-node runtime graph carrying exactly one source of `kind`.
+function graphWithKind(kind: ApprovalAssigneeSourceKind, nodeType: 'approval' | 'handler' = 'approval'): RuntimeGraph {
+  // Shape params are irrelevant to the detectors (they read `kind` structurally); supply a
+  // superset of the per-kind params so the fixture is one function, not a per-kind switch.
+  const source = { kind, fieldId: 'contact', level: 1, levels: 1, nodeKey: 'gate', userIds: ['u'], roleIds: ['r'], mode: 'single', scope: { type: 'company' } }
+  return {
+    nodes: [
+      { key: 'start', type: 'start', config: {} },
+      { key: 'node_1', type: nodeType, config: { assigneeSources: [source] } as never },
+      { key: 'end', type: 'end', config: {} },
+    ],
+    edges: [
+      { key: 'e1', source: 'start', target: 'node_1' },
+      { key: 'e2', source: 'node_1', target: 'end' },
+    ],
+    policy: { allowRevoke: false },
+  }
+}
+
+const ALL_KINDS = Object.keys(APPROVAL_ASSIGNEE_SOURCE_KIND_TRAITS) as ApprovalAssigneeSourceKind[]
+
+describe('Lock-2 §2.3 — trait-derived detector kind sets (gate D-3 adapted)', () => {
+  it('the trait table covers the FULL fifteen-member ApprovalAssigneeSourceKind union (compile-forced Record; runtime exact-set pin)', () => {
+    expect([...ALL_KINDS].sort()).toEqual([
+      'continuous_dept_heads',
+      'continuous_managers',
+      'dept_head',
+      'dept_head_at_level',
+      'direct_manager',
+      'form_field_user',
+      'form_field_user_dept_head',
+      'form_field_user_manager',
+      'manager_at_level',
+      'prior_node_approver',
+      'requester',
+      'requester_choice',
+      'static_role',
+      'static_user',
+      'user_group',
+    ])
+  })
+
+  it('each derived set equals its canonical membership by EXACT set equality (not count or subset)', () => {
+    expect([...ORG_ASSIGNEE_SOURCE_KINDS].sort()).toEqual([
+      'continuous_dept_heads',
+      'continuous_managers',
+      'dept_head',
+      'dept_head_at_level',
+      'direct_manager',
+      'manager_at_level',
+    ])
+    expect([...MANAGER_CHAIN_ASSIGNEE_SOURCE_KINDS].sort()).toEqual([
+      'continuous_managers',
+      'manager_at_level',
+    ])
+    expect([...DEPT_HEAD_CHAIN_ASSIGNEE_SOURCE_KINDS].sort()).toEqual([
+      'continuous_dept_heads',
+      'dept_head_at_level',
+    ])
+    // Lock-2 §L2-C: the field-derived pair is its OWN detector set — deliberately NOT part of
+    // ORG_ASSIGNEE_SOURCE_KINDS (§2.3: the requester wedge stays requester-scoped).
+    expect([...FIELD_DERIVED_ORG_ASSIGNEE_SOURCE_KINDS].sort()).toEqual([
+      'form_field_user_dept_head',
+      'form_field_user_manager',
+    ])
+    const orgAndFieldDerived = [...ORG_ASSIGNEE_SOURCE_KINDS].filter((kind) => FIELD_DERIVED_ORG_ASSIGNEE_SOURCE_KINDS.has(kind))
+    expect(orgAndFieldDerived).toEqual([])
+  })
+
+  it('every detector is DRIVEN by the trait table: for EVERY kind, detector output equals the trait row (editing only a trait row moves the detector and reds the exact-set pin above)', () => {
+    for (const kind of ALL_KINDS) {
+      const traits = APPROVAL_ASSIGNEE_SOURCE_KIND_TRAITS[kind]
+      const graph = graphWithKind(kind)
+      expect(runtimeGraphUsesOrgAssigneeSource(graph), `${kind} requesterOrgRead`).toBe(traits.requesterOrgRead)
+      expect(runtimeGraphUsesManagerChain(graph), `${kind} managerChain`).toBe(traits.managerChain)
+      expect(runtimeGraphUsesDeptHeadChain(graph), `${kind} deptHeadChain`).toBe(traits.deptHeadChain)
+      expect(collectRuntimeGraphFieldDerivedSources(graph).size > 0, `${kind} fieldDerivedOrgRead`).toBe(traits.fieldDerivedOrgRead)
+    }
+  })
+})
+
+describe('Lock-2 §L2-C — collectRuntimeGraphFieldDerivedSources (detector + freeze driver)', () => {
+  it('collects one entry per DISTINCT fingerprint (identical sources share one; differing level/field/kind each get their own), keyed <kind>:<fieldId>:<level>', () => {
+    const graph: RuntimeGraph = {
+      nodes: [
+        { key: 'start', type: 'start', config: {} },
+        {
+          key: 'a1',
+          type: 'approval',
+          config: {
+            assigneeSources: [
+              { kind: 'form_field_user_manager', fieldId: 'contact', level: 1 },
+              { kind: 'form_field_user_manager', fieldId: 'contact', level: 2 },
+              { kind: 'form_field_user_dept_head', fieldId: 'contact', level: 1 },
+              // form_field_user (联系人自己) is NOT field-derived-org — no directory read at all.
+              { kind: 'form_field_user', fieldId: 'contact' },
+            ],
+          } as never,
+        },
+        {
+          key: 'a2',
+          type: 'approval',
+          // Identical to a1's first source — shares its fingerprint entry (first nodeKey kept).
+          config: { assigneeSources: [{ kind: 'form_field_user_manager', fieldId: 'contact', level: 1 }] } as never,
+        },
+        { key: 'end', type: 'end', config: {} },
+      ],
+      edges: [
+        { key: 'e1', source: 'start', target: 'a1' },
+        { key: 'e2', source: 'a1', target: 'a2' },
+        { key: 'e3', source: 'a2', target: 'end' },
+      ],
+      policy: { allowRevoke: false },
+    }
+    const collected = collectRuntimeGraphFieldDerivedSources(graph)
+    expect([...collected.keys()].sort()).toEqual([
+      'form_field_user_dept_head:contact:1',
+      'form_field_user_manager:contact:1',
+      'form_field_user_manager:contact:2',
+    ])
+    expect(collected.get('form_field_user_manager:contact:1')).toEqual({
+      nodeKey: 'a1',
+      source: { kind: 'form_field_user_manager', fieldId: 'contact', level: 1 },
+    })
+  })
+
+  it('collects from HANDLER nodes too (Lock-2 §2.4 admits both node types; leaving handler out would be the R-13 silent-skip class), and returns empty for a graph with no field-derived source', () => {
+    expect([...collectRuntimeGraphFieldDerivedSources(graphWithKind('form_field_user_manager', 'handler')).keys()])
+      .toEqual(['form_field_user_manager:contact:1'])
+    expect(collectRuntimeGraphFieldDerivedSources(graphWithKind('static_user')).size).toBe(0)
+    expect(collectRuntimeGraphFieldDerivedSources(graphWithKind('form_field_user')).size).toBe(0)
+  })
+})

--- a/packages/core-backend/tests/unit/approval-graph-executor.test.ts
+++ b/packages/core-backend/tests/unit/approval-graph-executor.test.ts
@@ -663,6 +663,65 @@ describe('ApprovalGraphExecutor', () => {
     ])
   })
 
+  it('Lock-2 §L2-C: a form-field contact extension whose FROZEN entry is empty resolves EMPTY through the REAL resolver, and the executor applies the node emptyAssigneePolicy (error throws APPROVAL_ASSIGNEE_EMPTY; auto-approve fires an AUDITED auto-approval) — never a crash, never a silent assignee', () => {
+    // Frozen map: level 1 resolved a manager; level 5 ran at create and resolved NOBODY (chain
+    // shorter than the level) — frozen as an EMPTY entry, the §2.6 empty-resolution shape.
+    const requesterSnapshot = {
+      id: 'requester-1',
+      fieldDerivedAssigneeIds: {
+        'form_field_user_manager:contact:1': ['contact-mgr-1'],
+        'form_field_user_manager:contact:5': [],
+      },
+    }
+    const realResolver = ({ nodeKey, sourceStep, config }: { nodeKey: string; sourceStep: number; config: any }) =>
+      resolveApprovalAssignees({ nodeKey, sourceStep, config, formSnapshot: { contact: 'contact-1' }, requesterSnapshot })
+
+    const contactGraph = (level: number, emptyAssigneePolicy: 'error' | 'auto-approve'): RuntimeGraph => ({
+      nodes: [
+        { key: 'start', type: 'start', config: {} },
+        {
+          key: 'ffum-node',
+          type: 'approval',
+          config: {
+            assigneeSources: [{ kind: 'form_field_user_manager', fieldId: 'contact', level }],
+            emptyAssigneePolicy,
+          },
+        },
+        { key: 'final-review', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['user-9'] } },
+        { key: 'end', type: 'end', config: {} },
+      ],
+      edges: [
+        { key: 'edge-start-ffum', source: 'start', target: 'ffum-node' },
+        { key: 'edge-ffum-final', source: 'ffum-node', target: 'final-review' },
+        { key: 'edge-final-end', source: 'final-review', target: 'end' },
+      ],
+      policy: { allowRevoke: true },
+    })
+
+    // Positive control FIRST: the frozen level-1 entry resolves a real assignee through the SAME
+    // real resolver + executor wiring, with the Lock-2 §2.6 audit metadata (fieldId + level).
+    const okExecutor = new ApprovalGraphExecutor(contactGraph(1, 'error'), { contact: 'contact-1' }, { assignmentResolver: realResolver })
+    expect(okExecutor.resolveInitialState().assignments).toEqual([
+      { assignmentType: 'user', assigneeId: 'contact-mgr-1', nodeKey: 'ffum-node', sourceStep: 1, metadata: { resolvedFrom: { kind: 'form_field_user_manager', sourceIndex: 0, fieldId: 'contact', level: 1 } } },
+    ])
+
+    // 'error' (the absent default): the frozen-empty entry -> empty resolution -> fail-closed 400.
+    const errorExecutor = new ApprovalGraphExecutor(contactGraph(5, 'error'), { contact: 'contact-1' }, { assignmentResolver: realResolver })
+    expect(() => errorExecutor.resolveInitialState()).toThrowError(expect.objectContaining({
+      code: 'APPROVAL_ASSIGNEE_EMPTY',
+      statusCode: 400,
+    }))
+
+    // 'auto-approve': the SAME empty resolution under the author-selected policy — an EXPLICIT,
+    // audited autoApprovalEvents entry (NEVER-NOBODY: no unassigned pending node, no silent skip).
+    const autoExecutor = new ApprovalGraphExecutor(contactGraph(5, 'auto-approve'), { contact: 'contact-1' }, { assignmentResolver: realResolver })
+    const autoInitial = autoExecutor.resolveInitialState()
+    expect(autoInitial.currentNodeKey).toBe('final-review')
+    expect(autoInitial.autoApprovalEvents).toEqual([
+      { nodeKey: 'ffum-node', sourceStep: 1, approvalMode: 'single', reason: 'empty-assignee' },
+    ])
+  })
+
   // ── Lock-1 §K6 precondition (landed by the K3 slice): normalizeApprovalMode fails CLOSED ──
   // The executor's mode normalizer previously mapped ANY unrecognized mode silently to 'single'
   // (fail-open). Contract-valid data never reached that arm (the authoring choke + the stored-graph

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -364,6 +364,16 @@ export default defineConfig({
       // plugin-tests.yml stays byte-identical (s6a pin). Two-point wiring — both points land in
       // the SAME commit.
       'tests/integration/approval-user-group.db.test.ts',
+      // Lock-2 §L2-C form-field contact extensions (form_field_user_manager /
+      // form_field_user_dept_head) real-DB acceptance (choke, publish pins C-1/C-2, door-2 422,
+      // create-time freeze + dispatch over both pointers, C-4 distinctness, empty-vs-wedge split,
+      // D-4 freeze purity, D-2 wedge, handler admission). DATABASE_URL-gated; excluded here so
+      // the no-DB default job cannot collect-and-skip-green it, and carried by the SAME dedicated
+      // .github/workflows/approval-realdb-acceptance.yml workflow (sibling job
+      // approval-realdb-k6-contact, EXPECT_DB=1 arming the top-level anti-skip sentinel) —
+      // plugin-tests.yml stays byte-identical (s6a pin). Two-point wiring — both points land in
+      // the SAME commit.
+      'tests/integration/approval-form-contact-extensions.db.test.ts',
       'tests/integration/approval-delegation-seam.db.test.ts',
       'tests/integration/approval-delegation-api.db.test.ts',
       'tests/integration/approval-detail-subform.db.test.ts',


### PR DESCRIPTION
Full-stack slice of the RATIFIED Lock-2 §L2-C form-field contact extensions (`docs/development/approval-lock2-org-controls-field-routing-20260817.md`, RATIFIED 2026-08-17, all eight ODs recorded) — the `form_field_user`-derived upward extension family of the Feishu 表单内联系人 parity row (corpus C-3): **`form_field_user_manager` 表单内联系人上级** and **`form_field_user_dept_head` 表单内联系人部门负责人**. C-3's third option 联系人自己 is the shipped `form_field_user` and mints no new kind (§L2-C). Follows the landed K2/K3/K4/K5-b slice pattern (#4952/#4973/#4958/#4962).

## Contract implemented (lock citations)

- **Shape** `{ kind; fieldId: string; level: number }`, `level` validated `[1, MAX_MANAGER_CHAIN_LEVELS]` byte-identically to the shipped level kinds, never coerced/defaulted; unknown extra keys rejected (Lock-1 G-1 posture for new kinds). **Upward only in v1** (§L2-C "Levels"; the downward variant stays blocked on Lock-1 OD-L1-6, inherited not re-owned).
- **Member set / walkers** (§L2-C table): `form_field_user_manager` = the chosen person's manager at position `level` on the **`leader_in_dept` leader pointer** — the shipped `resolveManagerChain` walk re-anchored on the contact; `form_field_user_dept_head` = the chosen person's **primary department, then the parent tree** reading `dept_manager_userid_list` per level — K4's `resolveDeptHeadChain` re-anchored. Lock-1 §K4's RATIFIED **continue-past-empty-level** posture binds the parent-tree walk (Lock-2: "is RATIFIED and binds that walker and this document's re-anchored use of it"); the chains are DENSE, so `level` addresses the level-th *resolved* position (`chain[level-1]`), mirroring `manager_at_level`/`dept_head_at_level`.
- **Resolve-time = CREATE (freeze semantics)**: per Lock-2 §0 Correction 2 ("submit IS create"), the chosen contact arrives in the create payload, so the create path resolves the extension **at create** and freezes it into the new opt-in snapshot field `ApprovalRequesterSnapshot.fieldDerivedAssigneeIds?: Record<string, string[]>` **keyed by the source fingerprint** (§L2-C "Snapshot"). The resolver arms are a pure map lookup — **no live directory read at dispatch/return/admin-jump/timeout** (§2.1), and the map is opt-in (built only when the published runtime graph carries such a source — the `includeManagerChain` posture).
- **Anchoring** (§L2-C corp scoping): the contact resolves through the same `resolveApprovalRequesterOrgRelations` machinery (policy-canonical integration when a policy governs; integration-scoped chain reads, never global); a contact in a policy-misconfigured / multi-policy-governed org raises the shipped `ApprovalRoutingPolicyError` → **422 `APPROVAL_ROUTING_POLICY_MISCONFIGURED`**, exactly as the lock words it.
- **Publish pins** (§L2-C "Publish pins, and the hole they close" + OD-L2-5(a)): `validateApprovalAssigneeSourcesAgainstFormSchema` (which previously `continue`d on every kind except `form_field_user`) now pins, for each new kind: (1) field exists TOP-LEVEL, (2) type `user`, (3) `required: true`, (4) **no `visibilityRule`** (the pair is what makes (3) sufficient — hidden-field skip + prune analysis quoted in-code), (5) level in range (enforced by the normalize choke on every save/publish/restore path), (6) no `selection: 'multi'` until OD-L2-7's array support lands.
- **Door 2** (§2.2): independent create-time **422 `APPROVAL_FORM_ROUTING_FIELD_EMPTY`** when a routed field is empty at create — fires before any field-derived org read, zero rows persisted.
- **Detector/wedge** (§2.3): new collector/detector `collectRuntimeGraphFieldDerivedSources` with its **own** fail-closed wedge (422 policy / 503 `APPROVAL_FORM_ROUTING_ORG_UNRESOLVED`), deliberately **not** an extension of `runtimeGraphUsesOrgAssigneeSource`. Plus the **locked §2.3 refactor** ("whichever slice lands first performs that refactor"): the four detector kind-disjunctions are now DERIVED from one compile-forced trait table `APPROVAL_ASSIGNEE_SOURCE_KIND_TRAITS` (Record over the full union), with mechanical exact-set tests and a "proven DERIVED" mutation arm (gate D-3 adapted).
- **Empty vs failed** (§L2-C / §2.6): value resolving to nobody (no account, chain shorter than level) freezes `[]` → `emptyAssigneePolicy` (default `error` → fail-closed `APPROVAL_ASSIGNEE_EMPTY`; `auto-approve` → an explicit **audited** auto-approval event — never a silent nobody); a FAILED read never reaches the map (wedge, zero rows). **No requester self-exclusion** (§L2-C: "Self-exclusion is deliberately NOT applied to field-derived resolution"); anchor self-exclusion is inherent to the walks. Same-person composes through `autoApprovalPolicy.mergeWithRequester` (Lock-4's surface).
- **Fingerprints** (§2.5): `<kind>:<fieldId>:<level>` on both compile-forced mirrors; one exported producer (`fieldDerivedAssigneeSourceKey`) is consumed by the backend fingerprint, the snapshot freeze, and the resolver arms, so key and fingerprint cannot drift.
- **Registry rows** (§2.4): 表单内联系人上级 / 表单内联系人部门负责人, node types **`approval` AND `handler`** — the handler admission is Lock-2's own ruling ("The handler rows are corpus-evidenced, not an M11 widening (C-6)… supply what fell between the locks"), so `HANDLER_ASSIGNEE_SOURCE_KINDS` grows 7→9 on both sides with the exact-set tests updated in the same commit. Lock-0 A-3 exact set grows 12→14. The §2.4 hazard (order array not covered by the label pin) is closed with a set-equality assertion. C-7's form-schema precondition (gate D-6) gates the affordance: the kinds are offered only when the form declares a top-level `user` field (already-configured sources stay rendered so persisted values are never orphaned); the publish validator remains the enforcement.
- **Audit** (§2.6 / D-5): `resolvedFrom` gains optional `level`; each seat carries `{ kind, sourceIndex, fieldId, level }`. Errors are values-free — node keys/field ids only; the chosen contact's id is a form value and appears in no message (asserted).

## Five FE mirror sites (Lock-1 §2.5, all in this PR)

1. BE `types/approval-product.ts` — kind union + source union members.
2. FE `apps/web/src/types/approval.ts` — both copies mirrored.
3. `templateAuthoring.ts` `BACKEND_ASSIGNEE_SOURCE_KEYS_BY_KIND` — `['kind','fieldId','level']` per kind (extra key ⇒ read-only, tested).
4. `templateAuthoring.ts` linear editor accepted-kind list (+ hydrate/emit arms; round-trip byte-identity tested over the real wire).
5. `assigneeSource.ts` `assigneeSourceSummary` — explicit typed cases (field id + level; no `JSON.stringify` fallback inherited).

Plus: `parallelEdit.ts` fingerprint mirror, `approvalNodeEdit.ts` `isAssigneeSourceValid` arms, capability-registry labels + order, and the authoring sub-forms — canvas inspector (typed contact-field picker over the form's user fields + level input + OD-L2-4 pins-disclosure hint; testids `approval-node-source-contact-field` / `-level` / `-field-hint`) and the linear step editor (`approval-step-contact-field` / `-level`). No inert control: every authored value is emitted and server-validated.

## Tests

**Real-DB acceptance** `packages/core-backend/tests/integration/approval-form-contact-extensions.db.test.ts` (13 tests, run green locally against a fresh migrated PG 3× including post-rebase):
- authoring choke (positive-first; bad level ×7, missing fieldId, unknown extra key; values-free paths);
- publish pins: 5 negative schemas per kind + compliant positive control (shape-selected);
- **door 2 live through the real API**: a whitespace-only contact value passes door 1's required+type checks yet yields no anchor → 422 `APPROVAL_FORM_ROUTING_FIELD_EMPTY`, zero rows, values-free; positive control creates;
- **happy path**: submitted person → frozen manager resolved → dispatch assigns — manager kind level 1→LEADER1 / level 2→LEADER2 (leader pointer), dept-head kind level 1→HEAD1 / level 2→HEAD2 **through an empty-manager-list middle department** (the continue-past-empty construction demanded by the walker semantics), with full `resolvedFrom` audit;
- **C-4 pointer distinctness** both arms (disagree + coincide positive control);
- C-5 field-anchored (the requester's own head/leader never resolve);
- empty vs wedge split: level-past-chain and no-account contact → 400 `APPROVAL_ASSIGNEE_EMPTY`, zero rows, and NOT the wedge codes;
- **freeze purity (D-4)**: directory mutated between create and dispatch → in-flight seat unchanged (a live-read implementation reds here); a NEW create picks up the mutation (temporal, not a dead read);
- **D-2 wedge**: broken `approval_routing` policy (canonical → real but `disabled` integration) → 422 `APPROVAL_ROUTING_POLICY_MISCONFIGURED`, zero rows; a no-field-derived template still creates under the same broken policy (source-selected);
- handler admission end-to-end (publish + dispatch reaches the handler with the same frozen resolution).

**Unit (BE)**: resolver arms (map lookup keyed by the exported producer; key-mismatch → empty; **no-requester-self-exclusion positive with a discriminating `dept_head_at_level` negative control**; empty/absent/null → empty, never throw); executor-level real-resolver oracle (frozen-empty entry → `error` throws `APPROVAL_ASSIGNEE_EMPTY` / `auto-approve` fires the audited event, in-range positive control first); new `approval-field-derived-sources.test.ts` — trait-table full-union pin, per-set exact-set equality, the per-kind detector sweep driven by the table itself, collector dedup/handler/negative cases.

**FE**: registry A-3 exact set 12→14 + labels D1 exact-object 14 + order-vs-labels set equality (the §2.4 hazard closure); K6 sub-form mount tests (both kinds); **D-6 affordance test** (absent without a user field — kind-selected, not blanket; present with one; configured source survives field removal); summary cases; parallel-edit fingerprint lockstep incl. non-collision across the two kinds / `form_field_user` on the same field / the requester-anchored level kinds; node-edit validity + allowlist + handler-roster 7→9 positive; linear round-trip byte-identity for both kinds.

**Mutation verification** (each applied alone; cp-backup + sha256 byte-identical restore verified; never `git checkout --`):

| # | Mutation (execution point) | Result |
|---|---|---|
| M1 | drop the snapshot freeze spread | reds exactly the 6 resolution-bearing DB tests; choke/pins/door-2/empty/D-2 stay green |
| M2 | freeze pick `chain[level-1]` → `chain[level]` | reds the 6 level-pinning DB tests (level-1-indexed semantics pinned) |
| M3 | drop publish pin (3) `required` | reds exactly the pins test |
| M4 | neuter door 2 (skip instead of throw) | reds exactly the door-2 test (422 → would-be 400, discriminating) |
| M5 | neuter the wedge (swallow → freeze `{}`, the fail-open this class exists to prevent) | reds exactly D-2 |
| M6a | drop `form_field_user_manager` from `SHIPPED_ASSIGNEE_SOURCE_KIND_ORDER` only | reds A-3 + K6 mount + D-6; D1 stays green |
| M6b | drop its label entry only | reds D1 + A-3 (the new order-vs-labels set equality) |
| M7 | drop the D-6 schema gate | reds exactly the D-6 test |
| M8 | edit ONLY the trait row (`fieldDerivedOrgRead: false`) | reds the derived-set exact-set pin + collector tests — the sets are proven DERIVED, not enumerated |

**Suites on the rebased head** (`origin/main@65a5bb4c9b`): backend `tsc` clean; `vue-tsc` clean; backend full no-DB suite green (exit 0, run on the rebased head); real-DB suite 13/13 green against a fresh migrated DB on the rebased head; FE approval-touched specs 300+ green. The apps/web full run carries 24 pre-existing failures (approvalStaticPicker et al.) — **byte-identical counts on a clean `origin/main` worktree** (A/B: 24 failed / 325 passed on both sides for the same 12-file set; approvalStaticPicker is one of the files the P7-R1 sweep classified genuinely-red-on-main), none in files this PR touches.

**CI wiring (two-point, same commit)**: new sibling job `approval-realdb-k6-contact` in `.github/workflows/approval-realdb-acceptance.yml` (EXPECT_DB=1 top-level anti-skip sentinel, whole-file verbose run, values-free evidence step, paths: entries in both triggers) + `vitest.config.ts` exclusion so the no-DB required job cannot collect-and-skip-green it. `plugin-tests.yml` is byte-identical (s6a pin untouched). No bootstrap-version bump anywhere in this diff, so no pinned copies to update.

## Deferred (deliberately, not oversights)

- **OD-L2-4(a) required-pin retrofit onto the shipped `form_field_user`** ("applies to all four kinds at the next save/publish", authoring-copy disclosure, published versions keep shipped behavior): a ratified narrowing of a *shipped* kind with its own fixture blast radius (its referenced fields are non-required in several existing suites) — it needs its own slice so its review isn't buried inside this one. This slice pins only the kinds it ships; the in-code comment at the validator marks the debt with the OD citation. Door 2 likewise fires only for the new kinds (applying it to the shipped kind would change published-version runtime behavior, which OD-L2-4(a) protects).
- **`form_field_dept_head`** (C-4 表单内部门负责人): requires L2-A's `department` form field type — a separate contract (OD-L2-1/3/5/8 surface), sequenced after this slice per the lock's own table.
- OD-L2-3 `maxSelections` publish cap + OD-L2-7 multi-select arrays: `user` fields are single-valued on main (arrays 400 at create — the baseline classification Lock-2 pins); pin (6) rejects `selection: 'multi'` references until the L2-B props slice lands the reader widening in the same slice as the prop.
- Cc rows stay DEFERRED (OD-L2-6(a)); Lock-4 dedup/fallback semantics untouched.

Design authority: Lock-2 RATIFIED §4 (design only — no flag, no UAT, no deployment; this PR is the kind-slice with its own required checks). Merge stays with the owner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
