### PR TITLE
chore(sealed-export): pin the 63 provenance-digested paths to text eol=lf (byte-exact digests kept)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,75 @@
 scripts/ops/stock-preparation-prep-line-extended-smoke.mjs text eol=lf
 scripts/ops/stock-preparation-mvp-postdeploy-smoke.mjs text eol=lf
 scripts/ops/stock-preparation-rca-window-pm2-sample.mjs text eol=lf
+
+# ---------------------------------------------------------------------------
+# content-digest-pinned by sealed-export-package-provenance
+# ---------------------------------------------------------------------------
+# plugins/plugin-integration-core/lib/sealed-export/sealed-export-package-provenance.cjs
+# hashes each of the files below byte-for-byte (`sha256File`, and
+# `verifyPinnedMigrations` for the 06x/07x SQL) and compares the result against
+# the frozen manifest
+#   plugins/plugin-integration-core/lib/sealed-export/vectors/s6a-package-provenance-pins.json
+# Those pins were computed from LF bytes, so on a `core.autocrlf=true` checkout
+# (the default on Windows dev hosts) every single entry mismatches and
+# `sealed-export-package-provenance` / `sealed-export-s5-evidence` fail closed.
+#
+# `text eol=lf` — not `-text` — is deliberate. Both give an LF working tree, but
+# `text` also normalises on `git add`, so a CRLF-writing editor cannot push CRLF
+# bytes into the blob and break the pin for *every* platform. The index blobs
+# are already pure LF today, so these rules are a no-op for existing content.
+#
+# The digest must stay byte-exact: do NOT "fix" this by making `sha256File`
+# LF-normalise before hashing. A normalising digest would silently accept a
+# CRLF-tampered file, which is exactly what this gate exists to catch.
+#
+# Keep in sync with the PINNED_* rosters in
+# sealed-export-package-provenance.cjs.
+
+# PINNED_S1..S6_MODULES + the frozen pin manifest itself (its sha256 is emitted
+# as `frozenManifestDigest`). Directory-wide on purpose: PINNED_MODULE_RELATIVE_DIR
+# *is* this directory, all 31 tracked .cjs in it are pinned today, and every
+# module landed here becomes a pin candidate for the next stage — a per-file
+# list would silently miss the next one. Nothing binary lives here (.cjs/.json only).
+plugins/plugin-integration-core/lib/sealed-export/** text eol=lf
+
+# PINNED_MIGRATIONS — listed per file, not `migrations/*.sql`: only 6 of the 63
+# tracked migrations are pinned and the repo pins narrowly on purpose.
+packages/core-backend/migrations/068_create_integration_sealed_export_ingestion.sql text eol=lf
+packages/core-backend/migrations/069_create_integration_sealed_export_generation_kernel.sql text eol=lf
+packages/core-backend/migrations/070_create_integration_sealed_export_signer_authority.sql text eol=lf
+packages/core-backend/migrations/071_harden_integration_sealed_export_authority_lifecycle.sql text eol=lf
+packages/core-backend/migrations/072_harden_integration_sealed_export_terminal_signer_history.sql text eol=lf
+packages/core-backend/migrations/073_create_sealed_export_stock_prep_runtime_authority.sql text eol=lf
+
+# PINNED_EXTERNAL_MODULES — 7 of the 144 .cjs directly under
+# plugins/plugin-integration-core/lib/, so no directory rule here either.
+plugins/plugin-integration-core/lib/gip-profile-certification-contracts.cjs text eol=lf
+plugins/plugin-integration-core/lib/gip-canonical-json.cjs text eol=lf
+plugins/plugin-integration-core/lib/db.cjs text eol=lf
+plugins/plugin-integration-core/lib/stock-preparation-sealed-snapshot-decoder.cjs text eol=lf
+plugins/plugin-integration-core/lib/stock-preparation-readonly-intake.cjs text eol=lf
+plugins/plugin-integration-core/lib/stock-preparation-plm-source-persist-bridge.cjs text eol=lf
+plugins/plugin-integration-core/lib/stock-preparation-sync-run-persist.cjs text eol=lf
+
+# PINNED_RUNTIME_FILES
+plugins/plugin-integration-core/package.json text eol=lf
+pnpm-lock.yaml text eol=lf
+plugins/plugin-integration-core/index.cjs text eol=lf
+plugins/plugin-integration-core/lib/http-routes.cjs text eol=lf
+plugins/plugin-integration-core/scripts/provision-stock-preparation-sqlserver-sealed-snapshot.cjs text eol=lf
+scripts/ops/stock-preparation-s6a-onprem-acceptance.ps1 text eol=lf
+docs/operations/stock-preparation-s6a-sqlserver-onprem-runbook-20260731.md text eol=lf
+scripts/ops/multitable-onprem-package-verify.sh text eol=lf
+
+# PINNED_EVIDENCE_FILES
+.github/workflows/sealed-export-s5-sqlserver.yml text eol=lf
+scripts/ops/run-sealed-export-s5-sqlserver-evidence.cjs text eol=lf
+scripts/ops/verify-sealed-export-s5-sqlserver-evidence.cjs text eol=lf
+plugins/plugin-integration-core/__tests__/support/sealed-export-signer-authority-memory-db.cjs text eol=lf
+packages/core-backend/tests/integration/sealed-export-signer-authority-lifecycle-migration.db.test.ts text eol=lf
+packages/core-backend/tests/integration/sealed-export-s6a-runtime-authority.db.test.ts text eol=lf
+scripts/ops/__tests__/stock-preparation-s6a-onprem-acceptance.ps51.tests.ps1 text eol=lf
+plugins/plugin-integration-core/__tests__/sealed-export-s6a-product-runtime.test.cjs text eol=lf
+scripts/ops/multitable-onprem-package-build.sh text eol=lf
+.github/workflows/plugin-tests.yml text eol=lf

--- a/docs/development/stock-preparation-integration-line-status-ledger-20260818.md
+++ b/docs/development/stock-preparation-integration-line-status-ledger-20260818.md
@@ -52,7 +52,7 @@
 | win32 `chmod` 静默无效、仓库无 `icacls` | 声称的私密性在 Windows 运行时不存在 | #4989 attestation 门;后续 deploy launcher 加 `icacls` + 导出 attestation |
 | PG 矩阵未设 `PGOPTIONS`/`metasheet.sealed_export_*_role` → 073–075 走 latent 分支 | 非 superuser 路径首次在真机跑 | 待验证 + 角色绑定迁移臂(进行中) |
 | PG16+ `createrole_self_grant` 可能触发 `pg_auth_members` 零行谓词、无诊断 | DBA 建角色方式差异即失败 | 待验证 + 负控/诊断(进行中) |
-| provenance pins 按 LF 字节哈希;`core.autocrlf=true` 检出无法过 S5 evidence | 仅影响 Windows 开发机跑 CI 契约 | `.gitattributes -text` 或 LF 归一摘要 |
+| ~~provenance pins 按 LF 字节哈希;`core.autocrlf=true` 检出无法过 S5 evidence~~ | 仅影响 Windows 开发机跑 CI 契约 | 已闭环:`.gitattributes` 对 63 个受 pin 文件加 `text eol=lf`(非 `-text`,以便 `git add` 也归一,阻止 CRLF 字节进 blob);`sha256File` 保持逐字节,不做 LF 归一 |
 | `PROVENANCE_READ_NOT_IMPLEMENTED` 501 | 按行 provenance 读缺席 | 待排期 |
 
 ## 6. 与部署速度直接相关的 PR(2026-08-18)


### PR DESCRIPTION
## Summary

`sealed-export-package-provenance.cjs` hashes raw bytes and its 62 pins were computed from LF bytes; on a `core.autocrlf=true` checkout every pinned file is CRLF in the working tree, so `sealed-export-package-provenance` / `sealed-export-s5-evidence` fail with all digests mismatching (pre-existing, identical under `git stash`). This pins the **63 provenance-digested paths** to `text eol=lf` in `.gitattributes` so a fresh checkout on any platform produces the LF bytes the pins expect. `sha256File` stays byte-exact — LF-normalising digests would silently accept a CRLF-tampered file.

- One directory rule for `plugins/plugin-integration-core/lib/sealed-export/**` (that *is* `PINNED_MODULE_RELATIVE_DIR`; every module there is a pin candidate; only `.cjs`/`.json` live there) + 31 per-file rules for migrations 07x, external modules, runtime files and evidence files — narrow on purpose (a `migrations/*.sql` glob would hit 63 files for 6 pins).
- `text eol=lf` rather than `-text`: also normalises on `git add`, so a CRLF editor cannot push CRLF into a blob and break the pin on every platform.
- **No pin changes, no digest changes.** All 63 index blobs are pure LF; `git add --renormalize` over the roster stages an empty diff.

## Evidence (Windows 11, autocrlf=true)
- Before: 63/63 working-tree CRLF, 62/62 pin mismatches. After delete+checkout: 0 CRLF, 0 mismatches (e.g. `digests.cjs` 6382→6248 B, sha now = pin; migration 073 20086→19449 B, sha = pin).
- `sealed-export-package-provenance.test.cjs` OK, `sealed-export-s5-evidence.test.cjs` passed, PS 5.1 acceptance (`stock-preparation-s6a-onprem-acceptance.ps51.tests.ps1`, real powershell.exe) 10/10.
- CI: the gate runs on ubuntu only; no workflow change needed. Ledger §5 row updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)