### PR TITLE
feat(ops): S6-A win32 artifact-root ACL applied + verified before attestation (deploy path)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -154,6 +154,23 @@ jobs:
           & $powershell51 -NoProfile -ExecutionPolicy Bypass -File scripts/ops/__tests__/stock-preparation-rca-window.behavior.tests.ps1
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
+      # S6-A win32 artifact-root ACL + attestation (follow-up 1 of
+      # docs/development/stock-preparation-s6a-windows-runtime-parity-20260818.md). This is the
+      # only job with a real NTFS volume and a real icacls.exe, so the layer-3 checks (apply, verify,
+      # idempotent re-run, tampered-ACL retraction against a throwaway TEMP directory) can only run
+      # here. Both shells are exercised: the deploy path runs under whichever PowerShell the operator
+      # host provides, and 5.1's native-stderr semantics differ from pwsh 7's.
+      - name: Run S6-A artifact-root ACL attestation tests (Windows PowerShell 5.1 + pwsh 7)
+        shell: powershell
+        run: |
+          $powershell51 = "$env:SystemRoot\System32\WindowsPowerShell\v1.0\powershell.exe"
+          & $powershell51 -NoProfile -ExecutionPolicy Bypass -File `
+            scripts/ops/__tests__/multitable-onprem-s6a-artifact-root-acl.tests.ps1
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          & pwsh -NoProfile -ExecutionPolicy Bypass -File `
+            scripts/ops/__tests__/multitable-onprem-s6a-artifact-root-acl.tests.ps1
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
   test:
     runs-on: ubuntu-latest
 
@@ -529,6 +546,9 @@ jobs:
           ./scripts/ops/__tests__/stock-preparation-onprem-acceptance.behavior.tests.ps1
           ./scripts/ops/__tests__/stock-preparation-rca-window.tests.ps1
           ./scripts/ops/__tests__/stock-preparation-rca-window.behavior.tests.ps1
+          # Static wiring + the not-applicable branches only: there is no icacls / NTFS here, so the
+          # ACL layers self-report SKIP. The real-icacls coverage lives in stock-prep-powershell51.
+          ./scripts/ops/__tests__/multitable-onprem-s6a-artifact-root-acl.tests.ps1
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4

--- a/docs/development/stock-preparation-s6a-windows-runtime-parity-20260818.md
+++ b/docs/development/stock-preparation-s6a-windows-runtime-parity-20260818.md
@@ -45,12 +45,86 @@ safe-detail-token surface names the unmet control instead.
 `process.platform`, so both branches are testable on any host. The flag remains the outer
 gate: a disabled runtime is never asked to attest.
 
+## Follow-up 1 — DONE: the deploy path now enforces the ACL it attests
+
+`scripts/ops/multitable-onprem-s6a-artifact-root-acl.ps1` applies the ACL, re-reads it,
+and writes the attestation only when the re-read proves the control is in place. The
+attestation is therefore no longer an operator assertion.
+
+**Where it runs, and why not in the launcher.** The launcher is deliberately env-free —
+it extracts the archive and hands off before any `app.env` is read — so it cannot know
+the artifact root or the flag. `multitable-onprem-apply-package.ps1` already loads the
+same `app.env` PM2 sources (`Import-AppEnvFile`) and already invokes the PM2 start
+helper, so the step lives there, between the overlay and the restart. The launcher gains
+only the pass-through switch.
+
+**Flag-driven, not an opt-in switch.** Because the apply helper *does* have a notion of
+the flag, the step is gated on
+`MULTITABLE_STOCK_PREP_SQLSERVER_SEALED_SNAPSHOT_ENABLED` being `true` in that same
+`app.env` (trim + lower-case, matching `featureEnabled()`). A host that never enables
+S6-A is not touched at all: no directory is created, no ACL is applied, and its `app.env`
+is left byte-identical. An opt-in switch was rejected because the host that most needs
+the ACL is exactly the host that already declared the flag, and a switch an operator
+forgets is a silently unenforced control. `-S6aArtifactRootAcl off` (on both the launcher
+and the apply helper, default `auto`) is the escape hatch; it skips the step, which leaves
+the runtime refused rather than booting unenforced.
+
+**Contract.**
+
+- Artifact root comes from `MULTITABLE_STOCK_PREP_SQLSERVER_SEALED_SNAPSHOT_ARTIFACT_ROOT`
+  in that same file — the value the runtime itself resolves — and must be drive-qualified
+  or UNC, control-character free, and untrimmed-clean (`requiredText` / `path.isAbsolute`
+  parity). Created with `New-Item` when absent.
+- Service account is the identity running the apply helper, which is the identity that
+  starts PM2 and therefore owns the node process; there is no separate service-user
+  config to read. If it cannot be derived, the step fails closed with
+  `S6A_ARTIFACT_ROOT_ACL_SERVICE_ACCOUNT_UNKNOWN` **before** icacls runs and no
+  attestation is written.
+- `icacls <root> /inheritance:r /grant:r *S-1-5-18:(OI)(CI)F *<service-sid>:(OI)(CI)F`
+  plus `*S-1-5-32-544:(OI)(CI)F` when the run is elevated. Well-known SIDs, not display
+  names: the on-prem hosts are not guaranteed to be English and
+  `BUILTIN\Administrators` / `NT AUTHORITY\SYSTEM` are localized.
+- Verification is an independent re-read via `Get-Acl` with SID-typed access rules:
+  inheritance protected, no inherited ACE, no ACE for Everyone / Authenticated Users /
+  `BUILTIN\Users` / `BUILTIN\Guests`, and a full-control `(OI)(CI)` ACE for both the
+  service account and SYSTEM. Only then is
+  `MULTITABLE_STOCK_PREP_SQLSERVER_SEALED_SNAPSHOT_WIN32_ARTIFACT_ACL_ATTESTED=true`
+  written into `app.env` and into the process env.
+- On any failure the attestation is never written, **and a pre-existing one is retracted**
+  from `app.env`, so a host attested by an earlier deploy cannot stay attested after its
+  ACL drifts. The apply helper then throws `S6A_ARTIFACT_ROOT_ACL_ATTESTATION_FAILED`
+  before the restart.
+- Output is four values-free lines and nothing else — no path, no SID, no account name,
+  and icacls' own output is captured and discarded:
+  `s6aArtifactRootAclApplied=YES|NO`, `s6aArtifactRootAclVerified=PASS|FAIL|SKIP`,
+  `s6aWin32ArtifactAclAttested=YES|NO`, `s6aArtifactRootAclReason=<TOKEN>`. `SKIP` is the
+  documented third verified value for "the step did not run".
+- Idempotent: `/inheritance:r /grant:r` is a replace, and `app.env` is rewritten only when
+  the attestation line is not already exactly right, so a re-run leaves the ACL and the
+  file byte-identical.
+
+**Not edited: the S6-A on-prem runbook.**
+`docs/operations/stock-preparation-s6a-sqlserver-onprem-runbook-20260731.md` is
+digest-pinned as `runtimeFiles.s6aOnpremRunbook` in
+`plugins/plugin-integration-core/lib/sealed-export/vectors/s6a-package-provenance-pins.json`,
+so its §6 "set the runtime-only environment" list still omits the attestation variable.
+That is correct as written — the operator no longer sets it by hand; the apply helper
+does, and only after proving the ACL. Repinning the runbook needs the provenance-pin
+procedure, which is out of scope here.
+
+**Tests.** `scripts/ops/__tests__/multitable-onprem-s6a-artifact-root-acl.tests.ps1`, in
+three layers: static wiring (step precedes the restart, both entry points expose the
+switch, the package build requires the helper), injected icacls/ACL facts (argument
+vector, every fail-closed branch, retraction, values-free output), and real `icacls`
+against a throwaway directory under the process TEMP dir (apply, verify, idempotent
+re-run, and a tampered ACL that retracts the attestation). CI runs it under Windows
+PowerShell 5.1 *and* pwsh 7 in `plugin-tests.yml` job `stock-prep-powershell51` — the only
+job with a real NTFS volume — and under pwsh 7 on Linux in the `test` job for the static
+and not-applicable branches.
+
 ## Follow-ups (not in this change)
 
-1. `scripts/ops/multitable-onprem-deploy-launcher.ps1` must apply
-   `icacls <ARTIFACT_ROOT> /inheritance:r /grant:r "<svc>:(OI)(CI)F"` and export the
-   attestation env var. Until it does, an attested host is asserted, not enforced.
-2. Ask the owner whether a dedicated §10 token is wanted.
-3. Unrelated Windows-host observation: `core.autocrlf=true` checkouts fail
+1. Ask the owner whether a dedicated §10 token is wanted.
+2. Unrelated Windows-host observation: `core.autocrlf=true` checkouts fail
    `sealed-export-package-provenance` / `-s5-evidence`, because the pins hash LF bytes.
    Needs a `.gitattributes` `-text` rule or LF-normalising digests.

--- a/plugins/plugin-integration-core/lib/sealed-export/vectors/s6a-package-provenance-pins.json
+++ b/plugins/plugin-integration-core/lib/sealed-export/vectors/s6a-package-provenance-pins.json
@@ -85,7 +85,7 @@
     "s6aRuntimeAuthorityRealDbTest": "609da9054db15ced3567417b31ae743f2c3be1656f5e3d0874a77c3a4cbd0375",
     "s6aAcceptancePs51Test": "835c7c6ce943d82e0378a40a27c7fd1e8b79b526faa8ca4c8066e4231a4bfb0f",
     "s6aProductRuntimeTest": "de978adafa8b89772cefa921c2051f434bf346bf5c2978bef3424ee70f51ba3f",
-    "multitableOnpremPackageBuild": "ae477a24375a7269e5710a3481905c9b74255c03fd802841a16849aca48ee33a",
-    "pluginTestsWorkflow": "0daf855e090775118f104ce72426f50d8d8692dd4933a9eb20be077ad4462bff"
+    "multitableOnpremPackageBuild": "1b76a342e5b947faf271132a5ae246b225439fbace13a4ff90e1209f7fb6b6d6",
+    "pluginTestsWorkflow": "8cf594c67fad0c7441d7b473bf1ec961f5234306deddab3ccec09f0dd616f975"
   }
 }

--- a/scripts/ops/__tests__/multitable-onprem-s6a-artifact-root-acl.tests.ps1
+++ b/scripts/ops/__tests__/multitable-onprem-s6a-artifact-root-acl.tests.ps1
@@ -1,0 +1,461 @@
+#requires -Version 5.1
+# Tests for scripts/ops/multitable-onprem-s6a-artifact-root-acl.ps1 — follow-up 1 of
+# docs/development/stock-preparation-s6a-windows-runtime-parity-20260818.md.
+#
+# Three layers, because none of them substitutes for the others:
+#   1. STATIC wiring — the apply helper really invokes the step before the PM2
+#      restart, both entry points expose the escape hatch, the package ships the file.
+#   2. INJECTED icacls / ACL facts — proves the argument vector, the fail-closed
+#      branches, and that no attestation is ever written on a failure. A fake cannot
+#      prove the ACL is real, which is why layer 3 exists.
+#   3. REAL icacls against a throwaway directory under the process TEMP dir — proves
+#      the applied ACL actually verifies, that a re-run is idempotent, and that a
+#      tampered ACL retracts the attestation.
+#
+# Runs under Windows PowerShell 5.1 and pwsh 7. On a non-Windows host layers 2 and 3
+# are skipped and the not-applicable branch is asserted instead.
+$ErrorActionPreference = 'Stop'
+
+$opsDir = Join-Path $PSScriptRoot '..'
+$helperPath = Join-Path $opsDir 'multitable-onprem-s6a-artifact-root-acl.ps1'
+$applyPath = Join-Path $opsDir 'multitable-onprem-apply-package.ps1'
+$launcherPath = Join-Path $opsDir 'multitable-onprem-deploy-launcher.ps1'
+$packageBuildPath = Join-Path $opsDir 'multitable-onprem-package-build.sh'
+
+$pass = 0
+$fail = 0
+$skip = 0
+
+function Check {
+  param([string]$Name, [bool]$Ok)
+  if ($Ok) { $script:pass++; Write-Host "  PASS  $Name" }
+  else { $script:fail++; Write-Host "  FAIL  $Name" }
+}
+function Skip {
+  param([string]$Name)
+  $script:skip++
+  Write-Host "  SKIP  $Name"
+}
+
+$isWindowsHost = ([System.Environment]::OSVersion.Platform -eq [System.PlatformID]::Win32NT)
+
+# ── Layer 1: static wiring ───────────────────────────────────────────────────────
+$helperTokens = $null; $helperErrors = $null
+$helperAst = [System.Management.Automation.Language.Parser]::ParseFile(
+  $helperPath, [ref]$helperTokens, [ref]$helperErrors)
+$applyTokens = $null; $applyErrors = $null
+$applyAst = [System.Management.Automation.Language.Parser]::ParseFile(
+  $applyPath, [ref]$applyTokens, [ref]$applyErrors)
+$launcherTokens = $null; $launcherErrors = $null
+$launcherAst = [System.Management.Automation.Language.Parser]::ParseFile(
+  $launcherPath, [ref]$launcherTokens, [ref]$launcherErrors)
+
+Check 'helper, apply helper and launcher all parse without errors' (
+  $helperErrors.Count -eq 0 -and $applyErrors.Count -eq 0 -and $launcherErrors.Count -eq 0
+)
+
+function Get-ParameterDefault {
+  param($Ast, [string]$Name)
+  $parameter = @($Ast.ParamBlock.Parameters |
+    Where-Object { $_.Name.VariablePath.UserPath -eq $Name })
+  if ($parameter.Count -ne 1) { return $null }
+  if ($null -eq $parameter[0].DefaultValue) { return $null }
+  return $parameter[0].DefaultValue.Extent.Text
+}
+
+Check 'apply helper exposes -S6aArtifactRootAcl defaulting to auto' (
+  (Get-ParameterDefault -Ast $applyAst -Name 'S6aArtifactRootAcl') -eq "'auto'"
+)
+Check 'launcher exposes -S6aArtifactRootAcl defaulting to auto' (
+  (Get-ParameterDefault -Ast $launcherAst -Name 'S6aArtifactRootAcl') -eq "'auto'"
+)
+
+$applySrc = Get-Content -LiteralPath $applyPath -Raw
+$aclStepIndex = $applySrc.IndexOf('Invoke-S6aArtifactRootAclStep `')
+$pm2StartIndex = $applySrc.IndexOf("Write-Info 'Start or restart PM2 service'")
+Check 'apply helper runs the ACL/attestation step BEFORE the PM2 restart' (
+  $aclStepIndex -gt 0 -and $pm2StartIndex -gt 0 -and $aclStepIndex -lt $pm2StartIndex
+)
+Check 'apply helper gates the step on the sealed-snapshot flag, not on a bare switch' (
+  $applySrc -match 'Test-S6aSealedSnapshotFlagEnabled' -and
+  $applySrc -match 'MULTITABLE_STOCK_PREP_SQLSERVER_SEALED_SNAPSHOT_ENABLED'
+)
+Check 'apply helper fails closed when the ACL step reports a non-zero exit' (
+  $applySrc -match "throw 'S6A_ARTIFACT_ROOT_ACL_ATTESTATION_FAILED'"
+)
+Check 'on-prem package build requires the ACL helper as a package file' (
+  (Get-Content -LiteralPath $packageBuildPath -Raw) -match
+    '"scripts/ops/multitable-onprem-s6a-artifact-root-acl\.ps1"'
+)
+
+# The runtime gate and this helper must agree on the exact env names and on the
+# untrimmed / un-case-folded attestation literal.
+$runtimeConfigPath = Join-Path $opsDir '..\..\plugins\plugin-integration-core\lib\sealed-export\stock-preparation-runtime-config.cjs'
+$helperSrc = Get-Content -LiteralPath $helperPath -Raw
+if (Test-Path -LiteralPath $runtimeConfigPath -PathType Leaf) {
+  $runtimeSrc = Get-Content -LiteralPath $runtimeConfigPath -Raw
+  Check 'helper writes exactly the env name and literal the runtime gate reads' (
+    $runtimeSrc -match "MULTITABLE_STOCK_PREP_SQLSERVER_SEALED_SNAPSHOT_WIN32_ARTIFACT_ACL_ATTESTED" -and
+    $helperSrc -match "MULTITABLE_STOCK_PREP_SQLSERVER_SEALED_SNAPSHOT_WIN32_ARTIFACT_ACL_ATTESTED" -and
+    $helperSrc -match "\`$S6aAttestationValue = 'true'"
+  )
+} else {
+  Skip 'helper writes exactly the env name and literal the runtime gate reads'
+}
+
+# ── Load the helper without running it ───────────────────────────────────────────
+. $helperPath
+
+$realInvokeIcacls = (Get-Command Invoke-S6aIcacls).ScriptBlock
+$realGetFacts = (Get-Command Get-S6aArtifactRootAclFacts).ScriptBlock
+$realResolveAccount = (Get-Command Resolve-S6aServiceAccount).ScriptBlock
+
+$script:icaclsCalls = @()
+$script:icaclsMode = 'real'
+$script:fakeIcaclsExit = 0
+$script:factsMode = 'real'
+$script:fakeFactsOk = $true
+$script:accountMode = 'real'
+
+function Invoke-S6aIcacls {
+  param([string[]]$Arguments)
+  $script:icaclsCalls += , @($Arguments)
+  if ($script:icaclsMode -eq 'real') {
+    return (& $script:realInvokeIcacls -Arguments $Arguments)
+  }
+  return [pscustomobject]@{ ExitCode = $script:fakeIcaclsExit; LineCount = 0 }
+}
+
+function Get-S6aArtifactRootAclFacts {
+  param([string]$Path, [string]$ServiceAccountSid)
+  if ($script:factsMode -eq 'real') {
+    return (& $script:realGetFacts -Path $Path -ServiceAccountSid $ServiceAccountSid)
+  }
+  return [pscustomobject]@{
+    Ok = $script:fakeFactsOk
+    InheritanceDisabled = $script:fakeFactsOk
+    NoInheritedAce = $script:fakeFactsOk
+    NoForbiddenPrincipal = $script:fakeFactsOk
+    ServiceAceFullControl = $script:fakeFactsOk
+    SystemAceFullControl = $script:fakeFactsOk
+  }
+}
+
+function Resolve-S6aServiceAccount {
+  if ($script:accountMode -eq 'real') { return (& $script:realResolveAccount) }
+  return [pscustomobject]@{ Ok = $false; Sid = ''; Elevated = $false }
+}
+
+function Reset-Fakes {
+  $script:icaclsCalls = @()
+  $script:icaclsMode = 'real'
+  $script:fakeIcaclsExit = 0
+  $script:factsMode = 'real'
+  $script:fakeFactsOk = $true
+  $script:accountMode = 'real'
+}
+
+$ATTEST_KEY = 'MULTITABLE_STOCK_PREP_SQLSERVER_SEALED_SNAPSHOT_WIN32_ARTIFACT_ACL_ATTESTED'
+$FLAG_KEY = 'MULTITABLE_STOCK_PREP_SQLSERVER_SEALED_SNAPSHOT_ENABLED'
+$ROOT_KEY = 'MULTITABLE_STOCK_PREP_SQLSERVER_SEALED_SNAPSHOT_ARTIFACT_ROOT'
+
+$sandbox = Join-Path ([System.IO.Path]::GetTempPath()) ('s6a_acl_' + [guid]::NewGuid().ToString('N').Substring(0, 12))
+
+function New-Fixture {
+  param(
+    [string]$Enabled = 'true',
+    [string]$ArtifactRoot = $null,
+    [string]$PreExistingAttestation = $null,
+    [switch]$OmitArtifactRoot
+  )
+  $dir = Join-Path $sandbox ([guid]::NewGuid().ToString('N').Substring(0, 10))
+  New-Item -ItemType Directory -Path $dir -Force | Out-Null
+  $envFile = Join-Path $dir 'app.env'
+  $root = if ($ArtifactRoot) { $ArtifactRoot } else { Join-Path $dir 'artifacts' }
+  $lines = @(
+    '# fixture app.env',
+    'DATABASE_URL=postgres://fixture/db',
+    "$FLAG_KEY=$Enabled"
+  )
+  if (-not $OmitArtifactRoot) { $lines += "$ROOT_KEY=$root" }
+  if ($PreExistingAttestation) { $lines += "$ATTEST_KEY=$PreExistingAttestation" }
+  $lines += 'JWT_SECRET=fixture-secret'
+  [System.IO.File]::WriteAllText(
+    $envFile, (($lines -join "`r`n") + "`r`n"), (New-Object System.Text.UTF8Encoding($false)))
+  return [pscustomobject]@{ Dir = $dir; EnvFile = $envFile; ArtifactRoot = $root }
+}
+
+function Get-EnvValue {
+  param([string]$EnvFile, [string]$Name)
+  $map = Get-S6aAppEnvMap -EnvFile $EnvFile
+  return [string]$map[$Name]
+}
+
+function Test-LinesValuesFree {
+  param([string[]]$Lines, [string[]]$Secrets)
+  foreach ($line in $Lines) {
+    if ($line -notmatch '^s6a[A-Za-z0-9]+=[A-Za-z0-9_]+$') { return $false }
+    foreach ($secret in $Secrets) {
+      if ([string]::IsNullOrWhiteSpace($secret)) { continue }
+      if ($line.ToLowerInvariant().Contains($secret.ToLowerInvariant())) { return $false }
+    }
+  }
+  return $true
+}
+
+try {
+  New-Item -ItemType Directory -Path $sandbox -Force | Out-Null
+
+  # ── Contract of the emitted lines (host independent) ───────────────────────────
+  Reset-Fakes
+  $offFixture = New-Fixture
+  $offBefore = [System.IO.File]::ReadAllBytes($offFixture.EnvFile)
+  $offResult = Invoke-S6aArtifactRootAclAttestation `
+    -EnvFile $offFixture.EnvFile -AttestationMode 'off' -PlatformIsWindows $isWindowsHost
+  $offAfter = [System.IO.File]::ReadAllBytes($offFixture.EnvFile)
+  Check 'emitted contract is exactly the four documented keys, in order' (
+    $offResult.Lines.Count -eq 4 -and
+    $offResult.Lines[0] -match '^s6aArtifactRootAclApplied=(YES|NO)$' -and
+    $offResult.Lines[1] -match '^s6aArtifactRootAclVerified=(PASS|FAIL|SKIP)$' -and
+    $offResult.Lines[2] -match '^s6aWin32ArtifactAclAttested=(YES|NO)$' -and
+    $offResult.Lines[3] -match '^s6aArtifactRootAclReason=[A-Z0-9_]+|none$'
+  )
+  Check 'opt-out (-AttestationMode off) leaves the env file byte-identical' (
+    $offResult.Applied -eq 'NO' -and
+    $offResult.Verified -eq 'SKIP' -and
+    $offResult.Attested -eq 'NO' -and
+    $offResult.Reason -eq 'S6A_ARTIFACT_ROOT_ACL_DISABLED_BY_OPERATOR' -and
+    $offResult.Ok -and
+    (-not $offResult.Applicable) -and
+    (@(Compare-Object $offBefore $offAfter -SyncWindow 0)).Count -eq 0 -and
+    (-not (Test-Path -LiteralPath $offFixture.ArtifactRoot))
+  )
+
+  Reset-Fakes
+  $disabledFixture = New-Fixture -Enabled 'false' -PreExistingAttestation 'true'
+  $disabledBefore = [System.IO.File]::ReadAllBytes($disabledFixture.EnvFile)
+  $disabledResult = Invoke-S6aArtifactRootAclAttestation `
+    -EnvFile $disabledFixture.EnvFile -AttestationMode 'auto' -PlatformIsWindows $true
+  $disabledAfter = [System.IO.File]::ReadAllBytes($disabledFixture.EnvFile)
+  Check 'a host that never enables the sealed-snapshot flag is not touched at all' (
+    (-not $disabledResult.Applicable) -and
+    $disabledResult.Applied -eq 'NO' -and
+    $disabledResult.Verified -eq 'SKIP' -and
+    $disabledResult.Reason -eq 'S6A_ARTIFACT_ROOT_ACL_NOT_APPLICABLE' -and
+    $disabledResult.Ok -and
+    $script:icaclsCalls.Count -eq 0 -and
+    (@(Compare-Object $disabledBefore $disabledAfter -SyncWindow 0)).Count -eq 0 -and
+    (-not (Test-Path -LiteralPath $disabledFixture.ArtifactRoot))
+  )
+
+  Reset-Fakes
+  $posixFixture = New-Fixture
+  $posixBefore = [System.IO.File]::ReadAllBytes($posixFixture.EnvFile)
+  $posixResult = Invoke-S6aArtifactRootAclAttestation `
+    -EnvFile $posixFixture.EnvFile -AttestationMode 'auto' -PlatformIsWindows $false
+  $posixAfter = [System.IO.File]::ReadAllBytes($posixFixture.EnvFile)
+  Check 'a non-win32 host is never attested and never touched (POSIX modes still rule)' (
+    (-not $posixResult.Applicable) -and
+    $posixResult.Attested -eq 'NO' -and
+    $posixResult.Reason -eq 'S6A_ARTIFACT_ROOT_ACL_NOT_APPLICABLE' -and
+    $script:icaclsCalls.Count -eq 0 -and
+    (@(Compare-Object $posixBefore $posixAfter -SyncWindow 0)).Count -eq 0
+  )
+
+  if (-not $isWindowsHost) {
+    Skip 'injected-icacls happy path (Windows only)'
+    Skip 'injected-icacls argument vector (Windows only)'
+    Skip 'apply failure never attests (Windows only)'
+    Skip 'verify failure never attests and retracts a stale attestation (Windows only)'
+    Skip 'unknown service account fails closed before icacls (Windows only)'
+    Skip 'malformed artifact root fails closed (Windows only)'
+    Skip 'real icacls apply + verify + attest (Windows only)'
+    Skip 'real icacls run is idempotent (Windows only)'
+    Skip 'tampered real ACL retracts the attestation (Windows only)'
+  }
+  else {
+    $account = & $realResolveAccount
+    $accountSid = if ($account.Ok) { $account.Sid } else { '' }
+
+    # ── Layer 2: injected icacls / ACL facts ────────────────────────────────────
+    Reset-Fakes
+    $script:icaclsMode = 'fake'
+    $script:factsMode = 'fake'
+    $happy = New-Fixture
+    $happyResult = Invoke-S6aArtifactRootAclAttestation `
+      -EnvFile $happy.EnvFile -AttestationMode 'auto' -PlatformIsWindows $true
+    Check 'injected-icacls happy path applies, verifies and attests' (
+      $happyResult.Applicable -and
+      $happyResult.Applied -eq 'YES' -and
+      $happyResult.Verified -eq 'PASS' -and
+      $happyResult.Attested -eq 'YES' -and
+      $happyResult.Reason -eq 'none' -and
+      $happyResult.Ok -and
+      (Test-Path -LiteralPath $happy.ArtifactRoot -PathType Container) -and
+      (Get-EnvValue -EnvFile $happy.EnvFile -Name $ATTEST_KEY) -eq 'true' -and
+      (Get-EnvValue -EnvFile $happy.EnvFile -Name 'JWT_SECRET') -eq 'fixture-secret' -and
+      $env:MULTITABLE_STOCK_PREP_SQLSERVER_SEALED_SNAPSHOT_WIN32_ARTIFACT_ACL_ATTESTED -eq 'true'
+    )
+    $happyArgs = @($script:icaclsCalls[0])
+    Check 'injected-icacls argument vector is the specified hardening command' (
+      $script:icaclsCalls.Count -eq 1 -and
+      $happyArgs[0] -eq $happy.ArtifactRoot -and
+      $happyArgs[1] -eq '/inheritance:r' -and
+      $happyArgs[2] -eq '/grant:r' -and
+      ($happyArgs -contains '*S-1-5-18:(OI)(CI)F') -and
+      ($happyArgs -contains ('*' + $accountSid + ':(OI)(CI)F')) -and
+      (@($happyArgs | Where-Object { $_ -match '^\*S-1-5-32-545|^\*S-1-5-11|^\*S-1-1-0' }).Count -eq 0)
+    )
+    Check 'emitted lines carry no path, no SID and no account name' (
+      Test-LinesValuesFree -Lines $happyResult.Lines -Secrets @(
+        $happy.ArtifactRoot, $happy.EnvFile, $accountSid, $env:USERNAME
+      )
+    )
+
+    # Idempotent: the same run again must leave the env file byte-identical.
+    $happyBytes = [System.IO.File]::ReadAllBytes($happy.EnvFile)
+    $script:icaclsCalls = @()
+    $happyAgain = Invoke-S6aArtifactRootAclAttestation `
+      -EnvFile $happy.EnvFile -AttestationMode 'auto' -PlatformIsWindows $true
+    Check 'injected-icacls re-run is idempotent (env file unchanged, same verdict)' (
+      $happyAgain.Attested -eq 'YES' -and
+      $happyAgain.Reason -eq 'none' -and
+      (@(Compare-Object $happyBytes ([System.IO.File]::ReadAllBytes($happy.EnvFile)) -SyncWindow 0)).Count -eq 0
+    )
+
+    Reset-Fakes
+    $script:icaclsMode = 'fake'
+    $script:fakeIcaclsExit = 5
+    $script:factsMode = 'fake'
+    $applyFail = New-Fixture -PreExistingAttestation 'true'
+    $applyFailResult = Invoke-S6aArtifactRootAclAttestation `
+      -EnvFile $applyFail.EnvFile -AttestationMode 'auto' -PlatformIsWindows $true
+    Check 'a failed icacls apply never attests and retracts a stale attestation' (
+      $applyFailResult.Applicable -and
+      $applyFailResult.Applied -eq 'NO' -and
+      $applyFailResult.Verified -eq 'SKIP' -and
+      $applyFailResult.Attested -eq 'NO' -and
+      $applyFailResult.Reason -eq 'S6A_ARTIFACT_ROOT_ACL_APPLY_FAILED' -and
+      (-not $applyFailResult.Ok) -and
+      (Get-EnvValue -EnvFile $applyFail.EnvFile -Name $ATTEST_KEY) -eq '' -and
+      (Get-EnvValue -EnvFile $applyFail.EnvFile -Name 'JWT_SECRET') -eq 'fixture-secret' -and
+      (-not (Test-Path Env:MULTITABLE_STOCK_PREP_SQLSERVER_SEALED_SNAPSHOT_WIN32_ARTIFACT_ACL_ATTESTED))
+    )
+
+    Reset-Fakes
+    $script:icaclsMode = 'fake'
+    $script:factsMode = 'fake'
+    $script:fakeFactsOk = $false
+    $verifyFail = New-Fixture -PreExistingAttestation 'true'
+    $verifyFailResult = Invoke-S6aArtifactRootAclAttestation `
+      -EnvFile $verifyFail.EnvFile -AttestationMode 'auto' -PlatformIsWindows $true
+    Check 'a failed verify never attests and retracts a stale attestation' (
+      $verifyFailResult.Applied -eq 'YES' -and
+      $verifyFailResult.Verified -eq 'FAIL' -and
+      $verifyFailResult.Attested -eq 'NO' -and
+      $verifyFailResult.Reason -eq 'S6A_ARTIFACT_ROOT_ACL_VERIFY_FAILED' -and
+      (-not $verifyFailResult.Ok) -and
+      (Get-EnvValue -EnvFile $verifyFail.EnvFile -Name $ATTEST_KEY) -eq '' -and
+      (Get-EnvValue -EnvFile $verifyFail.EnvFile -Name 'DATABASE_URL') -eq 'postgres://fixture/db'
+    )
+
+    Reset-Fakes
+    $script:icaclsMode = 'fake'
+    $script:factsMode = 'fake'
+    $script:accountMode = 'fake'
+    $noAccount = New-Fixture
+    $noAccountResult = Invoke-S6aArtifactRootAclAttestation `
+      -EnvFile $noAccount.EnvFile -AttestationMode 'auto' -PlatformIsWindows $true
+    Check 'an underivable service account fails closed BEFORE icacls runs' (
+      $noAccountResult.Applied -eq 'NO' -and
+      $noAccountResult.Attested -eq 'NO' -and
+      $noAccountResult.Reason -eq 'S6A_ARTIFACT_ROOT_ACL_SERVICE_ACCOUNT_UNKNOWN' -and
+      (-not $noAccountResult.Ok) -and
+      $script:icaclsCalls.Count -eq 0 -and
+      (Get-EnvValue -EnvFile $noAccount.EnvFile -Name $ATTEST_KEY) -eq ''
+    )
+
+    Reset-Fakes
+    $script:icaclsMode = 'fake'
+    $script:factsMode = 'fake'
+    $relative = New-Fixture -ArtifactRoot 'artifacts\sealed'
+    $relativeResult = Invoke-S6aArtifactRootAclAttestation `
+      -EnvFile $relative.EnvFile -AttestationMode 'auto' -PlatformIsWindows $true
+    $unset = New-Fixture -OmitArtifactRoot
+    $unsetResult = Invoke-S6aArtifactRootAclAttestation `
+      -EnvFile $unset.EnvFile -AttestationMode 'auto' -PlatformIsWindows $true
+    Check 'a relative or missing artifact root fails closed with its own token' (
+      $relativeResult.Reason -eq 'S6A_ARTIFACT_ROOT_NOT_ABSOLUTE' -and
+      (-not $relativeResult.Ok) -and $relativeResult.Attested -eq 'NO' -and
+      $unsetResult.Reason -eq 'S6A_ARTIFACT_ROOT_UNSET' -and
+      (-not $unsetResult.Ok) -and $unsetResult.Attested -eq 'NO' -and
+      $script:icaclsCalls.Count -eq 0
+    )
+
+    # ── Layer 3: REAL icacls against a throwaway directory under TEMP ───────────
+    Reset-Fakes
+    $real = New-Fixture
+    $realResult = Invoke-S6aArtifactRootAclAttestation `
+      -EnvFile $real.EnvFile -AttestationMode 'auto' -PlatformIsWindows $true
+    $realAcl = if (Test-Path -LiteralPath $real.ArtifactRoot) { Get-Acl -LiteralPath $real.ArtifactRoot } else { $null }
+    $realSids = if ($null -ne $realAcl) {
+      @($realAcl.GetAccessRules($true, $true, [System.Security.Principal.SecurityIdentifier]) |
+        ForEach-Object { [string]$_.IdentityReference.Value })
+    } else { @() }
+    Check 'real icacls apply + Get-Acl verify + attestation write' (
+      $realResult.Applied -eq 'YES' -and
+      $realResult.Verified -eq 'PASS' -and
+      $realResult.Attested -eq 'YES' -and
+      $realResult.Reason -eq 'none' -and
+      $realResult.Ok -and
+      (Get-EnvValue -EnvFile $real.EnvFile -Name $ATTEST_KEY) -eq 'true'
+    )
+    Check 'the real ACL has inheritance disabled and no Users/Authenticated Users/Everyone ACE' (
+      $null -ne $realAcl -and
+      $realAcl.AreAccessRulesProtected -and
+      $realSids.Count -ge 2 -and
+      ($realSids -contains 'S-1-5-18') -and
+      ($realSids -contains $accountSid) -and
+      (@($realSids | Where-Object { @('S-1-1-0', 'S-1-5-11', 'S-1-5-32-545', 'S-1-5-32-546') -contains $_ }).Count -eq 0)
+    )
+
+    $realBytes = [System.IO.File]::ReadAllBytes($real.EnvFile)
+    $realAgain = Invoke-S6aArtifactRootAclAttestation `
+      -EnvFile $real.EnvFile -AttestationMode 'auto' -PlatformIsWindows $true
+    $realAclAgain = Get-Acl -LiteralPath $real.ArtifactRoot
+    Check 'real re-run is idempotent (same verdict, same ACL, byte-identical env file)' (
+      $realAgain.Verified -eq 'PASS' -and
+      $realAgain.Attested -eq 'YES' -and
+      (@(Compare-Object $realBytes ([System.IO.File]::ReadAllBytes($real.EnvFile)) -SyncWindow 0)).Count -eq 0 -and
+      $realAclAgain.Sddl -eq $realAcl.Sddl
+    )
+
+    # Tamper with the real ACL: an explicit Everyone grant survives /grant:r, so the
+    # verify must fail and the attestation written a moment ago must be retracted.
+    $tamper = & $realInvokeIcacls -Arguments @($real.ArtifactRoot, '/grant', '*S-1-1-0:(OI)(CI)F')
+    $tamperResult = Invoke-S6aArtifactRootAclAttestation `
+      -EnvFile $real.EnvFile -AttestationMode 'auto' -PlatformIsWindows $true
+    Check 'a tampered real ACL fails verify and retracts the attestation' (
+      $tamper.ExitCode -eq 0 -and
+      $tamperResult.Applied -eq 'YES' -and
+      $tamperResult.Verified -eq 'FAIL' -and
+      $tamperResult.Attested -eq 'NO' -and
+      $tamperResult.Reason -eq 'S6A_ARTIFACT_ROOT_ACL_VERIFY_FAILED' -and
+      (-not $tamperResult.Ok) -and
+      (Get-EnvValue -EnvFile $real.EnvFile -Name $ATTEST_KEY) -eq ''
+    )
+  }
+}
+finally {
+  Remove-Item Env:MULTITABLE_STOCK_PREP_SQLSERVER_SEALED_SNAPSHOT_WIN32_ARTIFACT_ACL_ATTESTED -ErrorAction SilentlyContinue
+  if (Test-Path -LiteralPath $sandbox) {
+    Remove-Item -LiteralPath $sandbox -Recurse -Force -ErrorAction SilentlyContinue
+  }
+}
+
+if ($fail -gt 0) {
+  Write-Host "FAILED: $fail check(s); $pass passed; $skip skipped"
+  exit 1
+}
+Write-Host "ALL S6-A ARTIFACT-ROOT ACL CHECKS PASS ($pass checks; $skip skipped)"
+exit 0

--- a/scripts/ops/multitable-onprem-apply-package.ps1
+++ b/scripts/ops/multitable-onprem-apply-package.ps1
@@ -18,7 +18,15 @@ param(
   [string]$DependencyRefreshTimeoutSec = '1800',
   [string]$DependencyRefreshHeartbeatSec = '60',
   [string]$HealthcheckAttempts = '12',
-  [string]$HealthcheckDelaySec = '5'
+  [string]$HealthcheckDelaySec = '5',
+  # 'auto' (default): when this host's app.env enables the S6-A sealed-snapshot
+  # flag, apply + verify the NTFS ACL on the artifact root and only then write the
+  # win32 artifact-ACL attestation into that same app.env. Hosts that never enable
+  # the flag are not touched. 'off' is the operator escape hatch: the step is
+  # skipped entirely, so the runtime keeps refusing to boot (fail-closed) rather
+  # than booting with an unenforced artifact root.
+  [ValidateSet('auto', 'off')]
+  [string]$S6aArtifactRootAcl = 'auto'
 )
 
 $ErrorActionPreference = 'Stop'
@@ -1002,6 +1010,55 @@ function Invoke-Healthcheck {
   return $false
 }
 
+function Test-S6aSealedSnapshotFlagEnabled {
+  # Same normalization as featureEnabled() in
+  # plugins/plugin-integration-core/lib/sealed-export/stock-preparation-runtime-config.cjs
+  # (trim + lower-case). Read from the process env, which Import-AppEnvFile has
+  # already populated from the very app.env PM2 sources.
+  $raw = [string][Environment]::GetEnvironmentVariable(
+    'MULTITABLE_STOCK_PREP_SQLSERVER_SEALED_SNAPSHOT_ENABLED', 'Process'
+  )
+  return ($raw.Trim().ToLowerInvariant() -eq 'true')
+}
+
+function Invoke-S6aArtifactRootAclStep {
+  param(
+    [string]$LiveRoot,
+    [string]$EnvFile,
+    [string]$Mode
+  )
+
+  # Follow-up 1 of docs/development/stock-preparation-s6a-windows-runtime-parity-20260818.md.
+  # chmod(0o700/0o600) no-ops on win32, so the S6-A runtime refuses to boot there
+  # unless MULTITABLE_STOCK_PREP_SQLSERVER_SEALED_SNAPSHOT_WIN32_ARTIFACT_ACL_ATTESTED
+  # is exactly 'true'. This step makes that attestation an ENFORCED fact rather than
+  # an operator assertion: it applies the NTFS ACL, re-reads it, and writes the
+  # attestation only when the re-read proves the control is in place.
+  #
+  # Flag-driven on purpose: hosts whose app.env does not enable the sealed-snapshot
+  # flag are never touched, and no operator has to remember a switch on the host
+  # that does enable it.
+  if ($Mode -eq 'off') {
+    Write-Info 'S6-A artifact-root ACL step skipped: -S6aArtifactRootAcl off'
+    return
+  }
+  if (-not (Test-S6aSealedSnapshotFlagEnabled)) {
+    return
+  }
+
+  $aclScript = Join-Path $LiveRoot 'scripts\ops\multitable-onprem-s6a-artifact-root-acl.ps1'
+  if (-not (Test-Path -LiteralPath $aclScript -PathType Leaf)) {
+    throw 'S6A_ARTIFACT_ROOT_ACL_HELPER_MISSING'
+  }
+
+  Write-Info 'Apply and verify the S6-A artifact-root NTFS ACL before the service restart'
+  & $aclScript -EnvFilePath $EnvFile -RootDir $LiveRoot -Mode $Mode
+  if ($LASTEXITCODE -ne 0) {
+    # The helper already emitted a values-free reason token; do not restate inputs.
+    throw 'S6A_ARTIFACT_ROOT_ACL_ATTESTATION_FAILED'
+  }
+}
+
 $resolvedRoot = Resolve-NormalizedPath -Candidate $RootDir -Label 'RootDir'
 $resolvedArchive = Resolve-NormalizedPath -Candidate $PackageArchive -Label 'PackageArchive'
 $resolvedEnvFile = if ([string]::IsNullOrWhiteSpace($EnvFile)) {
@@ -1225,6 +1282,14 @@ try {
         node $migratePath
       }
     }
+
+    # Must precede the restart: the attestation is written into the same app.env
+    # the PM2 startup helper re-imports, so the service can only ever start with an
+    # attestation that this run just proved.
+    Invoke-S6aArtifactRootAclStep `
+      -LiveRoot $resolvedRoot `
+      -EnvFile $resolvedEnvFile `
+      -Mode $S6aArtifactRootAcl
 
     if ($RestartService -ne '0') {
       $startScript = Join-Path $resolvedRoot 'scripts\ops\attendance-onprem-start-pm2.ps1'

--- a/scripts/ops/multitable-onprem-deploy-launcher.ps1
+++ b/scripts/ops/multitable-onprem-deploy-launcher.ps1
@@ -6,7 +6,13 @@ param(
   [ValidateSet('0', '1')]
   [string]$InstallDeps = '1',
   [ValidateSet('0', '1')]
-  [string]$RunMigrations = '1'
+  [string]$RunMigrations = '1',
+  # Passed straight through to the staged apply helper, which owns the service env.
+  # 'auto' (default) applies + verifies the S6-A artifact-root NTFS ACL and writes
+  # the win32 attestation ONLY on hosts whose app.env enables the sealed-snapshot
+  # flag; 'off' skips the step entirely (the runtime then stays refused).
+  [ValidateSet('auto', 'off')]
+  [string]$S6aArtifactRootAcl = 'auto'
 )
 
 $ErrorActionPreference = 'Stop'
@@ -186,13 +192,24 @@ try {
   # try/catch contract instead so a successful apply ("Package deploy
   # complete" + health 200) reliably yields launcher exit 0 and a Last
   # Result of 0 in the outer scheduled task (#1526 follow-up).
+  # Splatted so the S6-A switch is forwarded ONLY when the operator moved it off the
+  # default. A launcher can be newer than the archive it is pointed at; the default
+  # 'auto' is also the staged helper's own default, so omitting it keeps an older
+  # staged apply working, while an explicit 'off' against a helper too old to honour
+  # it fails loudly instead of silently ignoring the operator.
+  $applyParameters = @{
+    InstallDeps = $InstallDeps
+    PackageArchive = $resolvedArchive
+    RootDir = $resolvedRoot
+    RunMigrations = $RunMigrations
+    StagingRoot = $stagingBase
+  }
+  if ($S6aArtifactRootAcl -ne 'auto') {
+    $applyParameters['S6aArtifactRootAcl'] = $S6aArtifactRootAcl
+  }
+
   try {
-    & $stagedApply `
-      -RootDir $resolvedRoot `
-      -PackageArchive $resolvedArchive `
-      -StagingRoot $stagingBase `
-      -InstallDeps $InstallDeps `
-      -RunMigrations $RunMigrations
+    & $stagedApply @applyParameters
     $launcherExit = 0
   }
   catch {

--- a/scripts/ops/multitable-onprem-package-build.sh
+++ b/scripts/ops/multitable-onprem-package-build.sh
@@ -65,6 +65,10 @@ REQUIRED_PATHS=(
   "scripts/ops/multitable-onprem-apply-package.sh"
   "scripts/ops/multitable-onprem-apply-package.ps1"
   "scripts/ops/multitable-onprem-deploy-launcher.ps1"
+  # S6-A win32 artifact-root ACL + attestation step invoked by the apply helper
+  # before the PM2 restart. Absent from the package, an S6-A host cannot be
+  # attested and the runtime stays refused.
+  "scripts/ops/multitable-onprem-s6a-artifact-root-acl.ps1"
   "scripts/ops/multitable-onprem-package-install.sh"
   "scripts/ops/multitable-onprem-package-upgrade.sh"
   "scripts/ops/multitable-onprem-healthcheck.sh"

--- a/scripts/ops/multitable-onprem-s6a-artifact-root-acl.ps1
+++ b/scripts/ops/multitable-onprem-s6a-artifact-root-acl.ps1
@@ -1,0 +1,525 @@
+#requires -Version 5.1
+<#
+.SYNOPSIS
+  Applies the NTFS ACL the S6-A sealed-snapshot artifact root needs on Windows,
+  verifies it, and only then writes the win32 artifact-ACL attestation into the
+  service environment file.
+
+.DESCRIPTION
+  Follow-up 1 of docs/development/stock-preparation-s6a-windows-runtime-parity-20260818.md.
+
+  The sealed-export code asserts the confidentiality of the artifact tree with
+  POSIX modes (mkdir 0o700 / chmod 0o700 / chmod 0o600). On win32 those calls
+  succeed and then no-op, so the control is absent at runtime. The runtime gate
+  added by that change refuses to boot the S6-A runtime on win32 unless
+  MULTITABLE_STOCK_PREP_SQLSERVER_SEALED_SNAPSHOT_WIN32_ARTIFACT_ACL_ATTESTED is
+  exactly 'true'.
+
+  Without this helper that attestation is an operator ASSERTION. This helper makes
+  it an ENFORCED fact: it applies the ACL, re-reads it, and writes the attestation
+  only when the re-read proves the control is actually in place. It removes a stale
+  attestation when the re-read fails, so a host that was attested once cannot stay
+  attested after its ACL drifts.
+
+  Contract of the emitted lines (parseable, values-free — no path, no account name,
+  no SID ever reaches stdout):
+
+    s6aArtifactRootAclApplied=YES|NO
+    s6aArtifactRootAclVerified=PASS|FAIL|SKIP
+    s6aWin32ArtifactAclAttested=YES|NO
+    s6aArtifactRootAclReason=<TOKEN>
+
+  SKIP is the documented third verified value for "the step did not run" (opted
+  out, not win32, or the sealed-snapshot flag is off for this host).
+
+  Idempotent: `icacls /inheritance:r /grant:r` is a replace, and the env file is
+  rewritten only when the attestation line is not already exactly right, so a
+  re-run leaves both the ACL and the env file byte-identical.
+
+  Dot-sourceable: `. .\multitable-onprem-s6a-artifact-root-acl.ps1` defines the
+  helpers without running them, which is how the tests inject a fake icacls runner
+  and fake ACL facts.
+#>
+param(
+  [string]$EnvFilePath = '',
+  [string]$RootDir = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path,
+  [ValidateSet('auto', 'off')]
+  [string]$Mode = 'auto'
+)
+
+$ErrorActionPreference = 'Stop'
+
+# Same names the runtime reads (plugins/plugin-integration-core/lib/sealed-export/
+# stock-preparation-runtime-config.cjs FEATURE_FLAG / ENV.artifactRoot /
+# ENV.win32ArtifactAclAttested). Keep them in sync with that module.
+$S6aFeatureFlagEnvName = 'MULTITABLE_STOCK_PREP_SQLSERVER_SEALED_SNAPSHOT_ENABLED'
+$S6aArtifactRootEnvName = 'MULTITABLE_STOCK_PREP_SQLSERVER_SEALED_SNAPSHOT_ARTIFACT_ROOT'
+$S6aAttestationEnvName = 'MULTITABLE_STOCK_PREP_SQLSERVER_SEALED_SNAPSHOT_WIN32_ARTIFACT_ACL_ATTESTED'
+# The runtime compares this literal without trimming or case-folding.
+$S6aAttestationValue = 'true'
+
+# Well-known SIDs, not display names: the on-prem hosts are not guaranteed to be
+# English, and "BUILTIN\Administrators" / "NT AUTHORITY\SYSTEM" are localized.
+# icacls accepts the *S-<sid> form for both /grant and lookup.
+$S6aSystemSid = 'S-1-5-18'
+$S6aAdministratorsSid = 'S-1-5-32-544'
+$S6aForbiddenSids = @(
+  'S-1-1-0',       # Everyone
+  'S-1-5-11',      # Authenticated Users
+  'S-1-5-32-545',  # BUILTIN\Users
+  'S-1-5-32-546'   # BUILTIN\Guests
+)
+
+function Test-S6aWindowsPlatform {
+  return ([System.Environment]::OSVersion.Platform -eq [System.PlatformID]::Win32NT)
+}
+
+function Resolve-S6aAppEnvFile {
+  param([string]$Candidate, [string]$BaseDir)
+
+  if (-not [string]::IsNullOrWhiteSpace($Candidate)) {
+    return [System.IO.Path]::GetFullPath($Candidate.Trim().Trim('"'))
+  }
+
+  # Same order attendance-onprem-start-pm2.ps1 resolves it in, so the attestation
+  # lands in the file PM2 will actually source when the caller passes nothing.
+  foreach ($leaf in @('app.env', 'docker\app.env')) {
+    $candidate = Join-Path $BaseDir $leaf
+    if (Test-Path -LiteralPath $candidate -PathType Leaf) {
+      return [System.IO.Path]::GetFullPath($candidate)
+    }
+  }
+
+  return ''
+}
+
+function Get-S6aAppEnvMap {
+  param([string]$EnvFile)
+
+  # Mirror of the Import-AppEnvFile parser used by multitable-onprem-apply-package.ps1
+  # and attendance-onprem-start-pm2.ps1: last assignment wins, surrounding quotes
+  # stripped, '#' comments and non-assignment lines ignored.
+  $map = @{}
+  foreach ($rawLine in Get-Content -LiteralPath $EnvFile) {
+    $line = $rawLine.Trim()
+    if ([string]::IsNullOrWhiteSpace($line) -or $line.StartsWith('#')) { continue }
+
+    $parts = $line -split '=', 2
+    if ($parts.Length -ne 2) { continue }
+
+    $name = $parts[0].Trim()
+    if ([string]::IsNullOrWhiteSpace($name)) { continue }
+    $value = $parts[1].Trim()
+
+    if ($value.Length -ge 2) {
+      if (($value.StartsWith('"') -and $value.EndsWith('"')) -or
+          ($value.StartsWith("'") -and $value.EndsWith("'"))) {
+        $value = $value.Substring(1, $value.Length - 2)
+      }
+    }
+
+    $map[$name] = $value
+  }
+
+  return $map
+}
+
+function Test-S6aSealedSnapshotEnabled {
+  param([hashtable]$EnvMap)
+
+  # featureEnabled() in stock-preparation-runtime-config.cjs: trim + lower-case.
+  # The FLAG is a deployment toggle; only the ATTESTATION is compared literally.
+  if ($null -eq $EnvMap) { return $false }
+  $raw = [string]$EnvMap[$S6aFeatureFlagEnvName]
+  return ($raw.Trim().ToLowerInvariant() -eq 'true')
+}
+
+function Test-S6aArtifactRootShape {
+  param([string]$Candidate)
+
+  # requiredText() in the runtime rejects untrimmed text and control characters;
+  # path.isAbsolute() rejects relative roots. Require a drive-qualified or UNC path
+  # so a rooted-but-driveless value such as '\artifacts' cannot slip through.
+  if ([string]::IsNullOrEmpty($Candidate)) { return $false }
+  if ($Candidate.Length -gt 4096) { return $false }
+  if ($Candidate.Trim() -ne $Candidate) { return $false }
+  foreach ($char in $Candidate.ToCharArray()) {
+    if ([int]$char -lt 0x20 -or [int]$char -eq 0x7f) { return $false }
+  }
+  if ($Candidate.Contains('"')) { return $false }
+  return ($Candidate -match '^([A-Za-z]:\\|\\\\[^\\])')
+}
+
+function Resolve-S6aServiceAccount {
+  # The PM2 service is started by scripts/ops/attendance-onprem-start-pm2.ps1, which
+  # the apply helper invokes in-process. The identity that will own the node process
+  # is therefore the identity running this script — that is how the deploy path
+  # already "knows" the service account; there is no separate service-user config.
+  $result = [pscustomobject]@{
+    Ok = $false
+    Sid = ''
+    Elevated = $false
+  }
+
+  try {
+    $identity = [System.Security.Principal.WindowsIdentity]::GetCurrent()
+    if ($null -eq $identity -or $null -eq $identity.User) { return $result }
+    $sid = [string]$identity.User.Value
+    if ($sid -notmatch '^S-1-[0-9]+(-[0-9]+)+$') { return $result }
+    $principal = New-Object System.Security.Principal.WindowsPrincipal($identity)
+    $result.Elevated = $principal.IsInRole(
+      [System.Security.Principal.WindowsBuiltInRole]::Administrator
+    )
+    $result.Sid = $sid
+    $result.Ok = $true
+  }
+  catch {
+    # Fail closed; the caller emits S6A_ARTIFACT_ROOT_ACL_SERVICE_ACCOUNT_UNKNOWN.
+    return $result
+  }
+
+  return $result
+}
+
+function Resolve-S6aIcaclsPath {
+  $systemRoot = if ([string]::IsNullOrWhiteSpace($env:SystemRoot)) { 'C:\Windows' } else { $env:SystemRoot }
+  $candidate = Join-Path $systemRoot 'System32\icacls.exe'
+  if (Test-Path -LiteralPath $candidate -PathType Leaf) { return $candidate }
+  return 'icacls'
+}
+
+function Invoke-S6aIcacls {
+  param([string[]]$Arguments)
+
+  # Single injection point. Output is captured and DISCARDED: icacls echoes the
+  # target path and the granted principals, and neither may reach the deploy log.
+  #
+  # ErrorActionPreference is scoped to Continue for the native call: under 'Stop',
+  # Windows PowerShell 5.1 turns any native stderr line into a terminating
+  # NativeCommandError, which would hide the real exit code behind an exception.
+  $output = @()
+  $exitCode = 1
+  $previousErrorActionPreference = $ErrorActionPreference
+  try {
+    $ErrorActionPreference = 'Continue'
+    $output = @(& (Resolve-S6aIcaclsPath) @Arguments 2>&1)
+    $exitCode = $LASTEXITCODE
+  }
+  catch {
+    $exitCode = 1
+  }
+  finally {
+    $ErrorActionPreference = $previousErrorActionPreference
+  }
+
+  return [pscustomobject]@{
+    ExitCode = $exitCode
+    LineCount = @($output).Count
+  }
+}
+
+function Get-S6aArtifactRootAclFacts {
+  param(
+    [string]$Path,
+    [string]$ServiceAccountSid
+  )
+
+  # Verification is SID-based via Get-Acl rather than icacls text so it cannot be
+  # defeated by a localized display name, and so the check is independent of the
+  # command that applied the ACL.
+  $facts = [pscustomobject]@{
+    Ok = $false
+    InheritanceDisabled = $false
+    NoInheritedAce = $false
+    NoForbiddenPrincipal = $false
+    ServiceAceFullControl = $false
+    SystemAceFullControl = $false
+  }
+
+  try {
+    $acl = Get-Acl -LiteralPath $Path
+    $facts.InheritanceDisabled = [bool]$acl.AreAccessRulesProtected
+    $rules = @($acl.GetAccessRules(
+      $true, $true, [System.Security.Principal.SecurityIdentifier]
+    ))
+
+    $facts.NoInheritedAce = (@($rules | Where-Object { $_.IsInherited }).Count -eq 0)
+    $facts.NoForbiddenPrincipal = (@(
+      $rules | Where-Object { $S6aForbiddenSids -contains [string]$_.IdentityReference.Value }
+    ).Count -eq 0)
+    $facts.ServiceAceFullControl = (@(
+      $rules | Where-Object {
+        [string]$_.IdentityReference.Value -eq $ServiceAccountSid -and
+        $_.AccessControlType -eq [System.Security.AccessControl.AccessControlType]::Allow -and
+        ($_.FileSystemRights -band [System.Security.AccessControl.FileSystemRights]::FullControl) -eq
+          [System.Security.AccessControl.FileSystemRights]::FullControl -and
+        ($_.InheritanceFlags -band [System.Security.AccessControl.InheritanceFlags]::ContainerInherit) -ne 0 -and
+        ($_.InheritanceFlags -band [System.Security.AccessControl.InheritanceFlags]::ObjectInherit) -ne 0
+      }
+    ).Count -ge 1)
+    $facts.SystemAceFullControl = (@(
+      $rules | Where-Object {
+        [string]$_.IdentityReference.Value -eq $S6aSystemSid -and
+        $_.AccessControlType -eq [System.Security.AccessControl.AccessControlType]::Allow -and
+        ($_.FileSystemRights -band [System.Security.AccessControl.FileSystemRights]::FullControl) -eq
+          [System.Security.AccessControl.FileSystemRights]::FullControl
+      }
+    ).Count -ge 1)
+  }
+  catch {
+    return $facts
+  }
+
+  $facts.Ok = (
+    $facts.InheritanceDisabled -and
+    $facts.NoInheritedAce -and
+    $facts.NoForbiddenPrincipal -and
+    $facts.ServiceAceFullControl -and
+    $facts.SystemAceFullControl
+  )
+  return $facts
+}
+
+function Get-S6aEnvFileNewline {
+  param([string]$Raw)
+
+  if ($Raw -match "`r`n") { return "`r`n" }
+  if ($Raw -match "`n") { return "`n" }
+  return [System.Environment]::NewLine
+}
+
+function Set-S6aAppEnvKey {
+  param(
+    [string]$EnvFile,
+    [string]$Name,
+    [string]$Value
+  )
+
+  # Rewrites exactly one key and nothing else. Returns $true when the file changed;
+  # an already-correct file is left byte-identical so re-running is a no-op.
+  $raw = [System.IO.File]::ReadAllText($EnvFile)
+  $newline = Get-S6aEnvFileNewline -Raw $raw
+  $endsWithNewline = ($raw.Length -gt 0 -and ($raw.EndsWith("`n") -or $raw.EndsWith("`r")))
+  # No Max-substrings argument: in PowerShell a NEGATIVE max splits from the END of
+  # the string (so -1 would return the whole file as one element).
+  $lines = @($raw -split "`r`n|`n|`r")
+  if ($endsWithNewline -and $lines.Count -gt 0) {
+    $lines = @($lines[0..($lines.Count - 2)])
+  }
+  if ($raw.Length -eq 0) { $lines = @() }
+
+  $assignment = "$Name=$Value"
+  $pattern = '^\s*' + [regex]::Escape($Name) + '\s*='
+  $replaced = $false
+  $rebuilt = @()
+  foreach ($line in $lines) {
+    if ($line -match $pattern) {
+      if (-not $replaced) {
+        $rebuilt += $assignment
+        $replaced = $true
+      }
+      continue
+    }
+    $rebuilt += $line
+  }
+  if (-not $replaced) {
+    $rebuilt += $assignment
+  }
+
+  $next = ($rebuilt -join $newline)
+  if ($endsWithNewline -or $raw.Length -eq 0) {
+    $next += $newline
+  }
+  if ($next -eq $raw) { return $false }
+
+  $utf8NoBom = New-Object System.Text.UTF8Encoding($false)
+  [System.IO.File]::WriteAllText($EnvFile, $next, $utf8NoBom)
+  return $true
+}
+
+function Remove-S6aAppEnvKey {
+  param(
+    [string]$EnvFile,
+    [string]$Name
+  )
+
+  $raw = [System.IO.File]::ReadAllText($EnvFile)
+  $newline = Get-S6aEnvFileNewline -Raw $raw
+  $endsWithNewline = ($raw.Length -gt 0 -and ($raw.EndsWith("`n") -or $raw.EndsWith("`r")))
+  $lines = @($raw -split "`r`n|`n|`r")
+  if ($endsWithNewline -and $lines.Count -gt 0) {
+    $lines = @($lines[0..($lines.Count - 2)])
+  }
+  if ($raw.Length -eq 0) { $lines = @() }
+
+  $pattern = '^\s*' + [regex]::Escape($Name) + '\s*='
+  $rebuilt = @($lines | Where-Object { $_ -notmatch $pattern })
+  $next = ($rebuilt -join $newline)
+  if ($endsWithNewline -and $rebuilt.Count -gt 0) {
+    $next += $newline
+  }
+  if ($next -eq $raw) { return $false }
+
+  $utf8NoBom = New-Object System.Text.UTF8Encoding($false)
+  [System.IO.File]::WriteAllText($EnvFile, $next, $utf8NoBom)
+  return $true
+}
+
+function Invoke-S6aArtifactRootAclAttestation {
+  param(
+    [string]$EnvFile,
+    [ValidateSet('auto', 'off')]
+    [string]$AttestationMode = 'auto',
+    [bool]$PlatformIsWindows = (Test-S6aWindowsPlatform)
+  )
+
+  $applied = 'NO'
+  $verified = 'SKIP'
+  $attested = 'NO'
+  $reason = 'none'
+  $applicable = $false
+  $ok = $true
+
+  try {
+    if ($AttestationMode -eq 'off') {
+      $reason = 'S6A_ARTIFACT_ROOT_ACL_DISABLED_BY_OPERATOR'
+    }
+    elseif (-not $PlatformIsWindows) {
+      $reason = 'S6A_ARTIFACT_ROOT_ACL_NOT_APPLICABLE'
+    }
+    elseif ([string]::IsNullOrWhiteSpace($EnvFile) -or
+            -not (Test-Path -LiteralPath $EnvFile -PathType Leaf)) {
+      $reason = 'S6A_ENV_FILE_MISSING'
+      $ok = $false
+    }
+    else {
+      $envMap = Get-S6aAppEnvMap -EnvFile $EnvFile
+      if (-not (Test-S6aSealedSnapshotEnabled -EnvMap $envMap)) {
+        # Host never enables S6-A: touch neither the filesystem nor the env file.
+        $reason = 'S6A_ARTIFACT_ROOT_ACL_NOT_APPLICABLE'
+      }
+      else {
+        $applicable = $true
+        $artifactRoot = [string]$envMap[$S6aArtifactRootEnvName]
+
+        if ([string]::IsNullOrEmpty($artifactRoot)) {
+          $reason = 'S6A_ARTIFACT_ROOT_UNSET'
+          $ok = $false
+        }
+        elseif (-not (Test-S6aArtifactRootShape -Candidate $artifactRoot)) {
+          $reason = 'S6A_ARTIFACT_ROOT_NOT_ABSOLUTE'
+          $ok = $false
+        }
+        else {
+          $account = Resolve-S6aServiceAccount
+          if (-not $account.Ok) {
+            $reason = 'S6A_ARTIFACT_ROOT_ACL_SERVICE_ACCOUNT_UNKNOWN'
+            $ok = $false
+          }
+          else {
+            $created = $true
+            try {
+              if (-not (Test-Path -LiteralPath $artifactRoot -PathType Container)) {
+                New-Item -ItemType Directory -Path $artifactRoot -Force | Out-Null
+              }
+            }
+            catch {
+              # Never echo $_: the message carries the path.
+              $created = $false
+            }
+            if (-not $created -or -not (Test-Path -LiteralPath $artifactRoot -PathType Container)) {
+              $reason = 'S6A_ARTIFACT_ROOT_CREATE_FAILED'
+              $ok = $false
+            }
+            else {
+              $grants = @(
+                ('*' + $S6aSystemSid + ':(OI)(CI)F'),
+                ('*' + $account.Sid + ':(OI)(CI)F')
+              )
+              if ($account.Elevated) {
+                $grants += ('*' + $S6aAdministratorsSid + ':(OI)(CI)F')
+              }
+              $arguments = @($artifactRoot, '/inheritance:r', '/grant:r') + $grants
+              $icacls = Invoke-S6aIcacls -Arguments $arguments
+
+              if ($null -eq $icacls -or $icacls.ExitCode -ne 0) {
+                $reason = 'S6A_ARTIFACT_ROOT_ACL_APPLY_FAILED'
+                $ok = $false
+              }
+              else {
+                $applied = 'YES'
+                $facts = Get-S6aArtifactRootAclFacts `
+                  -Path $artifactRoot `
+                  -ServiceAccountSid $account.Sid
+                if ($null -eq $facts -or -not $facts.Ok) {
+                  $verified = 'FAIL'
+                  $reason = 'S6A_ARTIFACT_ROOT_ACL_VERIFY_FAILED'
+                  $ok = $false
+                }
+                else {
+                  $verified = 'PASS'
+                  try {
+                    Set-S6aAppEnvKey `
+                      -EnvFile $EnvFile `
+                      -Name $S6aAttestationEnvName `
+                      -Value $S6aAttestationValue | Out-Null
+                    Set-Item -Path ("Env:{0}" -f $S6aAttestationEnvName) -Value $S6aAttestationValue
+                    $attested = 'YES'
+                  }
+                  catch {
+                    $reason = 'S6A_ARTIFACT_ROOT_ACL_ENV_WRITE_FAILED'
+                    $ok = $false
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  catch {
+    $reason = 'S6A_ARTIFACT_ROOT_ACL_INTERNAL_ERROR'
+    $ok = $false
+  }
+
+  if ($applicable -and $attested -ne 'YES') {
+    # An attested host must be an ENFORCED host. If this run could not prove the
+    # ACL, a previously written attestation is retracted rather than left standing.
+    try {
+      Remove-S6aAppEnvKey -EnvFile $EnvFile -Name $S6aAttestationEnvName | Out-Null
+    }
+    catch {
+      $reason = 'S6A_ARTIFACT_ROOT_ACL_ENV_WRITE_FAILED'
+      $ok = $false
+    }
+    Remove-Item -Path ("Env:{0}" -f $S6aAttestationEnvName) -ErrorAction SilentlyContinue
+  }
+
+  $lines = @(
+    "s6aArtifactRootAclApplied=$applied",
+    "s6aArtifactRootAclVerified=$verified",
+    "s6aWin32ArtifactAclAttested=$attested",
+    "s6aArtifactRootAclReason=$reason"
+  )
+  foreach ($line in $lines) { Write-Host $line }
+
+  return [pscustomobject]@{
+    Applicable = $applicable
+    Applied = $applied
+    Attested = $attested
+    Lines = $lines
+    Ok = $ok
+    Reason = $reason
+    Verified = $verified
+  }
+}
+
+if ($MyInvocation.InvocationName -ne '.') {
+  $resolvedEnvFile = Resolve-S6aAppEnvFile -Candidate $EnvFilePath -BaseDir $RootDir
+  $result = Invoke-S6aArtifactRootAclAttestation `
+    -EnvFile $resolvedEnvFile `
+    -AttestationMode $Mode
+  if (-not $result.Ok) { exit 1 }
+  exit 0
+}


### PR DESCRIPTION
## Summary

Follow-up 1 of #4989: on a Windows host the S6-A runtime now refuses to boot unless `MULTITABLE_STOCK_PREP_SQLSERVER_SEALED_SNAPSHOT_WIN32_ARTIFACT_ACL_ATTESTED='true'`. This PR makes the on-prem deploy path **apply and verify** the NTFS ACL and only then set that attestation — so an attested host is enforced, not asserted.

### Design — flag-driven, in the apply helper
`multitable-onprem-deploy-launcher.ps1` is deliberately env-free (extract + hand-off before any `app.env` is read), so it cannot know the flag or the artifact root. `multitable-onprem-apply-package.ps1` already loads the same `app.env` PM2 sources and already invokes the PM2 start helper, so the step lives there — between the overlay and the restart — gated on `MULTITABLE_STOCK_PREP_SQLSERVER_SEALED_SNAPSHOT_ENABLED` (trim + lowercase, matching `featureEnabled()`). Hosts that never enable S6-A are untouched: no directory, no ACL, `app.env` byte-identical. `-S6aArtifactRootAcl auto|off` exists on launcher and apply helper as an escape hatch (launcher forwards it only when non-default so an older staged apply still works).

### New `scripts/ops/multitable-onprem-s6a-artifact-root-acl.ps1`
- Resolves the artifact root from the same env the runtime reads; creates it if absent.
- `icacls <root> /inheritance:r /grant:r <service SID>:(OI)(CI)F SYSTEM:(OI)(CI)F [Administrators…]` — well-known **SIDs**, not localized names.
- Verifies via `Get-Acl` (SID-typed re-read): inheritance protected, no inherited ACE, no `Everyone` / `Authenticated Users` / `Users` / `Guests`, full-control `(OI)(CI)` for service account + SYSTEM.
- Fail-closed named tokens (`S6A_ARTIFACT_ROOT_ACL_SERVICE_ACCOUNT_UNKNOWN`, `…_VERIFY_FAILED`, …); on any failure the attestation is **not** set and a stale attestation is **retracted**.
- Four values-free output lines (`s6aArtifactRootAclApplied`, `s6aArtifactRootAclVerified`, `s6aWin32ArtifactAclAttested`, `s6aArtifactRootAclReason`); icacls output discarded; idempotent.
- Added to `multitable-onprem-package-build.sh` REQUIRED_PATHS so a package cannot ship without it.

### Tests
`scripts/ops/__tests__/multitable-onprem-s6a-artifact-root-acl.tests.ps1` — 24 checks incl. real `icacls` against a throwaway `%TEMP%` directory (apply, verify, idempotent re-run, tampered-ACL retraction), attestation not set on verify failure, opt-out leaves env untouched. **This host: pwsh 7 24/24, Windows PowerShell 5.1 24/24 (0 skipped)**, re-run after rebase onto main. Wired into `plugin-tests.yml`'s `stock-prep-powershell51` job (the only job with real NTFS/icacls) under both shells; the Linux pwsh step covers static wiring + not-applicable branches.

Docs: `stock-preparation-s6a-windows-runtime-parity-20260818.md` follow-up 1 → done; the digest-pinned S6-A runbook is deliberately not edited (noted in the doc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
