### PR TITLE
ops(stock-prep): LAB-0 inventory — artifact-root filesystem probe (hardlink support token)

### DIFF
--- a/docs/development/onprem-deploy-path-acceleration-20260818.md
+++ b/docs/development/onprem-deploy-path-acceleration-20260818.md
@@ -94,10 +94,14 @@ plus three additions:
 fields plus the LAB-0 environment facts from read-only probes: node/pwsh
 majors, TCP reachability, one catalog `SELECT` for `server_version_num` +
 `rolcreatedb|rolsuper` + `rolcreaterole|rolsuper`, an unauthenticated health
-GET, disk/memory classes. No install, download, DB or principal creation,
-deploy, flag change, business-row read, or write beyond stdout — pinned by
-`stock-preparation-lab0-inventory.test.mjs` (22 cases, two of them
-discriminating negative controls). Next: one `preflight-and-report.ps1`
+GET, disk/memory classes, and (closing a Windows runtime-parity class-2 risk
+in `fs.link()`-based S6-A staging) `artifactRootFilesystem`/
+`artifactRootHardlinkSupported` — a read-only `Get-Volume` probe of the
+configured artifact root's volume format, path never printed. No install,
+download, DB or principal creation, deploy, flag change, business-row read,
+or write beyond stdout — pinned by `stock-preparation-lab0-inventory.test.mjs`
+(28 cases, two of them discriminating negative controls). Next: one
+`preflight-and-report.ps1`
 composing this + `stock-preparation-s6a-operator-preflight.mjs` + a reader for
 the runbook §2 privilege triple — one command, one paste, replacing step 9.
 

--- a/scripts/ops/stock-preparation-lab0-inventory.mjs
+++ b/scripts/ops/stock-preparation-lab0-inventory.mjs
@@ -35,7 +35,26 @@
 //     against pg_roles/current_setting, and it is the ONLY SQL string in the
 //     file;
 //   * no write of any kind beyond stdout: no file is created, appended to, or
-//     removed, and no environment variable is exported.
+//     removed, and no environment variable is exported;
+//   * no hardlink, directory creation, or any other filesystem mutation — the
+//     artifact-root filesystem probe below reads volume metadata only (the
+//     drive's format, via a read-only PowerShell `Get-Volume`), never the
+//     artifact root's contents, and it never calls fs.link().
+//
+// ARTIFACT-ROOT FILESYSTEM PROBE
+// -------------------------------
+// A Windows runtime-parity sweep found a class-2 risk: `fs.link()` in
+// lib/sealed-export/private-ingestion-blob-store.cjs runs inside the S6-A
+// artifact root, and on exFAT/FAT32 or an SMB-mounted artifact root that
+// returns EPERM/ENOTSUP this surfaces at runtime as
+// SEALED_EXPORT_STAGING_WRITE_FAILED. `artifactRootFilesystem` reports the
+// volume format of the configured artifact root (env var name read from
+// plugins/plugin-integration-core/lib/sealed-export/
+// stock-preparation-runtime-config.cjs's ENV.artifactRoot, so the two files
+// cannot drift) as a closed token, and `artifactRootHardlinkSupported` is
+// derived from it. The path itself is never printed — see
+// assertNoConfiguredInputLeaked, which treats it exactly like the PostgreSQL
+// connection string and health URL.
 //
 // VALUES-FREE DISCIPLINE
 // ----------------------
@@ -62,6 +81,22 @@ import { createRequire } from 'node:module'
 import { fileURLToPath } from 'node:url'
 
 const require = createRequire(import.meta.url)
+const REPO_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '..',
+  '..',
+)
+
+// The artifact-root env var name lives in the runtime config module, not
+// here, so the two files cannot drift. Only the ENV name mapping is read —
+// no loader function in that module is ever called, so nothing is executed
+// beyond resolving the object literal.
+const { ENV: SEALED_EXPORT_ENV } = require(
+  path.join(
+    REPO_ROOT,
+    'plugins/plugin-integration-core/lib/sealed-export/stock-preparation-runtime-config.cjs',
+  ),
+)
 
 // ---------------------------------------------------------------------------
 // The complete closed token vocabulary. Nothing outside this set (plus a
@@ -82,13 +117,17 @@ const TOKEN = Object.freeze({
   NODE20: 'NODE20',
   NODE22: 'NODE22',
   NODE_OTHER: 'NODE_OTHER',
+  NOT_CONFIGURED: 'NOT_CONFIGURED',
+  NTFS: 'NTFS',
   OTHER: 'OTHER',
   PASS: 'PASS',
   PG15: 'PG15',
   PG16: 'PG16',
   PG17: 'PG17',
   PG_OTHER: 'PG_OTHER',
+  REFS: 'REFS',
   UNKNOWN: 'UNKNOWN',
+  UNRESOLVED: 'UNRESOLVED',
   UNSET: 'UNSET',
   YES: 'YES',
   ZERO: '0',
@@ -160,6 +199,28 @@ function postgresMajorField(versionClass) {
   return TOKEN.UNKNOWN
 }
 
+// Maps the raw `FileSystem` token the probe reads off the artifact root's
+// volume to the closed set. null/empty (probe failed, timed out, or the path
+// was not drive-letter-rooted) is UNRESOLVED, never guessed as OTHER.
+function classifyArtifactRootFilesystem(raw) {
+  if (raw === null || raw === undefined) return TOKEN.UNRESOLVED
+  const normalized = String(raw).trim().toUpperCase()
+  if (normalized === '') return TOKEN.UNRESOLVED
+  if (normalized === 'NTFS') return TOKEN.NTFS
+  if (normalized === 'REFS') return TOKEN.REFS
+  return TOKEN.OTHER
+}
+
+// fs.link() (hardlink) is supported by NTFS and ReFS; every other Windows
+// filesystem this probe can observe (exFAT, FAT32, an SMB share reporting
+// something else) is a NO, and an inconclusive probe is UNKNOWN — never a
+// silent YES.
+function artifactRootHardlinkSupportedField(filesystemClass) {
+  if (filesystemClass === TOKEN.NTFS || filesystemClass === TOKEN.REFS) return TOKEN.YES
+  if (filesystemClass === TOKEN.OTHER) return TOKEN.NO
+  return TOKEN.UNKNOWN
+}
+
 function classifyDiskFree(freeBytes) {
   if (!Number.isFinite(freeBytes) || freeBytes < 0) return TOKEN.UNKNOWN
   if (freeBytes >= DISK_HIGH_WATER_BYTES) return TOKEN.DISK_GE_40GIB
@@ -218,6 +279,40 @@ function probePowerShellMajor(executable) {
     )
     if (result.error || result.status !== 0) return null
     return Number.parseInt(String(result.stdout).trim(), 10)
+  } catch {
+    return null
+  }
+}
+
+// Extracts a bare drive letter ("C") from a drive-letter-rooted Windows path
+// such as "C:\ArtifactRoot" or "C:/ArtifactRoot". UNC paths, relative paths,
+// and POSIX paths return null so the probe fails closed to UNRESOLVED
+// instead of guessing a volume.
+function windowsDriveLetter(targetPath) {
+  const match = String(targetPath ?? '').match(/^([A-Za-z]):[\\/]/)
+  return match ? match[1].toUpperCase() : null
+}
+
+// Read-only volume-format probe. `Get-Volume` reads volume metadata; it
+// creates nothing, attempts no hardlink, and never touches the artifact
+// root's contents. Only the drive letter is ever interpolated into the
+// command (regex-validated to a single A-Z above), and it is never printed.
+// Windows only, matching probePowerShellMajor's pattern: -NoProfile keeps a
+// profile script from running, a timeout bounds the call, and any error,
+// non-zero exit, or unparsable path returns null (-> UNRESOLVED).
+function probeArtifactRootFilesystem(targetPath) {
+  if (process.platform !== 'win32') return null
+  const drive = windowsDriveLetter(targetPath)
+  if (!drive) return null
+  try {
+    const result = spawnSync(
+      'powershell',
+      ['-NoProfile', '-NonInteractive', '-Command', `(Get-Volume -DriveLetter ${drive}).FileSystem`],
+      { encoding: 'utf8', timeout: DEFAULT_TIMEOUT_MS, windowsHide: true },
+    )
+    if (result.error || result.status !== 0) return null
+    const token = String(result.stdout).trim()
+    return token || null
   } catch {
     return null
   }
@@ -317,6 +412,7 @@ function probeMemory() {
 }
 
 const DEFAULT_PROBES = Object.freeze({
+  artifactRootFilesystem: probeArtifactRootFilesystem,
   diskFreeBytes: probeDiskFreeBytes,
   health: probeHealth,
   memory: probeMemory,
@@ -342,6 +438,11 @@ const ENV_VAR = Object.freeze({
 
 function readConfig(env) {
   return Object.freeze({
+    // Not an LAB0_-prefixed operator toggle: this is the real S6-A product
+    // env var (see SEALED_EXPORT_ENV above). Used only to derive a drive
+    // letter for the probe below and to self-scan the report for a leak —
+    // see assertNoConfiguredInputLeaked — never printed.
+    artifactRootPath: env[SEALED_EXPORT_ENV.artifactRoot] || '',
     diskPath: env[ENV_VAR.diskPath] || path.parse(process.cwd()).root || process.cwd(),
     factsProviderRaw: env[ENV_VAR.factsProvider] || '',
     healthProbeEnabled: env[ENV_VAR.probeHealth] !== '0',
@@ -405,6 +506,14 @@ async function runInventory({ env = process.env, probes = DEFAULT_PROBES } = {})
     ? postgres.canCreateRole
     : null
 
+  // NOT_CONFIGURED short-circuits before the probe runs at all — same shape
+  // as the postgresUrl gate above: an absent env var is a fact, not a probe
+  // failure, so it must not read as UNRESOLVED.
+  const artifactRootFilesystemClass = config.artifactRootPath
+    ? classifyArtifactRootFilesystem(p.artifactRootFilesystem(config.artifactRootPath))
+    : TOKEN.NOT_CONFIGURED
+  const artifactRootHardlinkSupported = artifactRootHardlinkSupportedField(artifactRootFilesystemClass)
+
   const runtimeHealthy = config.healthProbeEnabled ? await p.health(config.healthUrl) : null
 
   const diskFreeClass = classifyDiskFree(p.diskFreeBytes(config.diskPath))
@@ -413,6 +522,8 @@ async function runInventory({ env = process.env, probes = DEFAULT_PROBES } = {})
   const memoryFreeClass = classifyMemory(memory.freeBytes)
 
   const fields = Object.freeze({
+    artifactRootFilesystem: artifactRootFilesystemClass,
+    artifactRootHardlinkSupported,
     canCreateIsolatedTestDatabase: yesNo(isolatedDatabaseCapability),
     canCreateSelectOnlyTestPrincipal: yesNo(selectOnlyPrincipalCapability),
     diskFreeClass,
@@ -487,6 +598,8 @@ const HOST_FIELD_ORDER = Object.freeze([
   'metasheetRuntimeHealth',
   'diskFreeClass',
   'freeDiskAtLeast40GiB',
+  'artifactRootFilesystem',
+  'artifactRootHardlinkSupported',
   'memoryTotalClass',
   'freeMemoryAtLeast16GiB',
   'externalWrite',
@@ -504,7 +617,7 @@ function assertClosedSet(fields) {
 // Composed-output self-scan: nothing the operator configured may appear in the
 // report. Cheap, and it converts "we were careful" into "it cannot ship".
 function assertNoConfiguredInputLeaked(report, config) {
-  const sentinels = [config.postgresUrl, config.healthUrl, config.diskPath]
+  const sentinels = [config.postgresUrl, config.healthUrl, config.diskPath, config.artifactRootPath]
   for (const sentinel of sentinels) {
     if (typeof sentinel !== 'string' || sentinel.length < 4) continue
     if (report.includes(sentinel)) {
@@ -554,6 +667,11 @@ function buildOperatorGuidance() {
     `${pad(`${ENV_VAR.probeHealth}=0`)}skip the health probe (reports UNKNOWN).`,
     `${pad(`${ENV_VAR.probePowerShell}=0`)}skip the PowerShell probes (report UNKNOWN).`,
     '',
+    `artifactRootFilesystem/artifactRootHardlinkSupported read the S6-A`,
+    `sealed-export artifact-root env var (${SEALED_EXPORT_ENV.artifactRoot}) if it is`,
+    'already set in this environment — not an LAB0_ flag, and never printed.',
+    'Unset -> NOT_CONFIGURED. Windows only; every other platform -> UNRESOLVED.',
+    '',
     'The only SQL this tool executes is one read-only catalog SELECT against',
     'pg_roles for the connected session\'s own role. It creates no database, no',
     'role, and no grant; those remain a later, separately authorized step.',
@@ -589,9 +707,12 @@ export {
   CLOSED_TOKENS,
   ENV_VAR,
   HOST_FIELD_ORDER,
+  SEALED_EXPORT_ENV,
   SIX_FIELD_ORDER,
   TOKEN,
+  artifactRootHardlinkSupportedField,
   buildOperatorGuidance,
+  classifyArtifactRootFilesystem,
   classifyDiskFree,
   classifyFactsProvider,
   classifyMemory,

--- a/scripts/ops/stock-preparation-lab0-inventory.test.mjs
+++ b/scripts/ops/stock-preparation-lab0-inventory.test.mjs
@@ -27,8 +27,11 @@ import { fileURLToPath } from 'node:url'
 import {
   CATALOG_READ_SQL,
   ENV_VAR,
+  SEALED_EXPORT_ENV,
   SIX_FIELD_ORDER,
   TOKEN,
+  artifactRootHardlinkSupportedField,
+  classifyArtifactRootFilesystem,
   classifyDiskFree,
   classifyFactsProvider,
   classifyMemory,
@@ -46,10 +49,15 @@ const GIB = 1024 * 1024 * 1024
 // Credential-bearing inputs the tool is handed and must never echo.
 const SENTINEL_PG_URL = 'postgres://SENTINELUSER:SENTINELSECRET@SENTINELHOST.invalid:5432/SENTINELDB'
 const SENTINEL_HEALTH_URL = 'http://SENTINELRUNTIME.invalid:9901/api/health'
-const SENTINELS = ['SENTINELUSER', 'SENTINELSECRET', 'SENTINELHOST', 'SENTINELDB', 'SENTINELRUNTIME']
+const SENTINEL_ARTIFACT_ROOT = 'Z:\\SENTINELARTIFACTROOT\\blobs\\staging'
+const SENTINELS = [
+  'SENTINELUSER', 'SENTINELSECRET', 'SENTINELHOST', 'SENTINELDB', 'SENTINELRUNTIME',
+  'SENTINELARTIFACTROOT',
+]
 
 function goodProbes(overrides = {}) {
   return {
+    artifactRootFilesystem: () => 'NTFS',
     diskFreeBytes: () => 64 * GIB,
     health: async () => true,
     memory: () => ({ freeBytes: 24 * GIB, totalBytes: 64 * GIB }),
@@ -73,6 +81,7 @@ function goodEnv(overrides = {}) {
     [ENV_VAR.factsProvider]: '@lab0-operator',
     [ENV_VAR.healthUrl]: SENTINEL_HEALTH_URL,
     [ENV_VAR.postgresUrl]: SENTINEL_PG_URL,
+    [SEALED_EXPORT_ENV.artifactRoot]: SENTINEL_ARTIFACT_ROOT,
     ...overrides,
   }
 }
@@ -138,6 +147,27 @@ test('classifyFactsProvider: handle shapes accepted, anything else refused rathe
   assert.equal(classifyFactsProvider('a'.repeat(40)), TOKEN.INVALID_FORMAT)
 })
 
+test('classifyArtifactRootFilesystem: NTFS/ReFS are exact (case-insensitive), everything else is OTHER, absence is UNRESOLVED', () => {
+  assert.equal(classifyArtifactRootFilesystem('NTFS'), TOKEN.NTFS)
+  assert.equal(classifyArtifactRootFilesystem('ntfs'), TOKEN.NTFS)
+  assert.equal(classifyArtifactRootFilesystem('ReFS'), TOKEN.REFS)
+  assert.equal(classifyArtifactRootFilesystem('REFS'), TOKEN.REFS)
+  assert.equal(classifyArtifactRootFilesystem('FAT32'), TOKEN.OTHER)
+  assert.equal(classifyArtifactRootFilesystem('exFAT'), TOKEN.OTHER)
+  assert.equal(classifyArtifactRootFilesystem(null), TOKEN.UNRESOLVED)
+  assert.equal(classifyArtifactRootFilesystem(undefined), TOKEN.UNRESOLVED)
+  assert.equal(classifyArtifactRootFilesystem(''), TOKEN.UNRESOLVED)
+  assert.equal(classifyArtifactRootFilesystem('   '), TOKEN.UNRESOLVED)
+})
+
+test('artifactRootHardlinkSupportedField: only NTFS/ReFS answer YES, OTHER is NO, everything else is UNKNOWN', () => {
+  assert.equal(artifactRootHardlinkSupportedField(TOKEN.NTFS), TOKEN.YES)
+  assert.equal(artifactRootHardlinkSupportedField(TOKEN.REFS), TOKEN.YES)
+  assert.equal(artifactRootHardlinkSupportedField(TOKEN.OTHER), TOKEN.NO)
+  assert.equal(artifactRootHardlinkSupportedField(TOKEN.UNRESOLVED), TOKEN.UNKNOWN)
+  assert.equal(artifactRootHardlinkSupportedField(TOKEN.NOT_CONFIGURED), TOKEN.UNKNOWN)
+})
+
 // ---------------------------------------------------------------------------
 // 2. Orchestration outcomes.
 // ---------------------------------------------------------------------------
@@ -158,6 +188,8 @@ test('fully-known host: every six-field value is determinate, lab0Status=COMPLET
   assert.equal(result.fields.pwsh7Available, TOKEN.YES)
   assert.equal(result.fields.diskFreeClass, TOKEN.DISK_GE_40GIB)
   assert.equal(result.fields.freeDiskAtLeast40GiB, TOKEN.YES)
+  assert.equal(result.fields.artifactRootFilesystem, TOKEN.NTFS)
+  assert.equal(result.fields.artifactRootHardlinkSupported, TOKEN.YES)
   assert.equal(result.fields.externalWrite, 'false')
 })
 
@@ -240,6 +272,51 @@ test('no connection string configured: PostgreSQL fields are UNKNOWN and nothing
   assert.equal(result.sixField.postgresServiceAvailable, TOKEN.UNKNOWN)
   assert.equal(result.sixField.postgresMajorVersion, TOKEN.UNKNOWN)
   assert.equal(result.lab0Status, TOKEN.BLOCKED)
+})
+
+test('artifact-root env var unset: NOT_CONFIGURED, hardlink UNKNOWN, and the probe is never called', async () => {
+  let probeCalls = 0
+  const env = goodEnv()
+  delete env[SEALED_EXPORT_ENV.artifactRoot]
+  const result = await runInventory({
+    env,
+    probes: goodProbes({
+      artifactRootFilesystem: () => {
+        probeCalls += 1
+        return 'NTFS'
+      },
+    }),
+  })
+  assert.equal(probeCalls, 0)
+  assert.equal(result.fields.artifactRootFilesystem, TOKEN.NOT_CONFIGURED)
+  assert.equal(result.fields.artifactRootHardlinkSupported, TOKEN.UNKNOWN)
+})
+
+test('artifact-root probe returns null (non-Windows or unresolvable path): UNRESOLVED, hardlink UNKNOWN', async () => {
+  const result = await runInventory({
+    env: goodEnv(),
+    probes: goodProbes({ artifactRootFilesystem: () => null }),
+  })
+  assert.equal(result.fields.artifactRootFilesystem, TOKEN.UNRESOLVED)
+  assert.equal(result.fields.artifactRootHardlinkSupported, TOKEN.UNKNOWN)
+})
+
+test('artifact-root volume is a non-NTFS/ReFS filesystem: OTHER, hardlink NO — the class-2 risk case', async () => {
+  const result = await runInventory({
+    env: goodEnv(),
+    probes: goodProbes({ artifactRootFilesystem: () => 'FAT32' }),
+  })
+  assert.equal(result.fields.artifactRootFilesystem, TOKEN.OTHER)
+  assert.equal(result.fields.artifactRootHardlinkSupported, TOKEN.NO)
+})
+
+test('artifact-root volume is ReFS: hardlink YES, same as NTFS', async () => {
+  const result = await runInventory({
+    env: goodEnv(),
+    probes: goodProbes({ artifactRootFilesystem: () => 'ReFS' }),
+  })
+  assert.equal(result.fields.artifactRootFilesystem, TOKEN.REFS)
+  assert.equal(result.fields.artifactRootHardlinkSupported, TOKEN.YES)
 })
 
 test('a missing or malformed factsProvider blocks instead of emitting a bare template', async () => {
@@ -367,12 +444,24 @@ test('no filesystem write API and no package-installing command appear in the so
   }
 })
 
-test('the only child process is the read-only PowerShell version probe', () => {
+test('the only child processes are the two read-only PowerShell probes (version + artifact-root volume format)', () => {
   const spawnCalls = SOURCE.split('spawnSync(').length - 1
-  assert.equal(spawnCalls, 1)
+  assert.equal(spawnCalls, 2)
   assert.ok(SOURCE.includes("'-NoProfile', '-NonInteractive', '-Command', '$PSVersionTable.PSVersion.Major'"))
+  assert.ok(SOURCE.includes("'-NoProfile', '-NonInteractive', '-Command', "))
+  assert.ok(SOURCE.includes('Get-Volume'))
+  assert.ok(SOURCE.includes('.FileSystem'))
   for (const api of ['spawn(', 'exec(', 'execSync(', 'execFile(', 'fork(']) {
     assert.ok(!SOURCE.includes(api), `source must not use ${api}`)
+  }
+  // Both PowerShell call sites read state; neither may mutate a volume, a
+  // file, or anything else reachable through the shell.
+  for (const verb of [
+    'Set-Volume', 'Format-Volume', 'Initialize-Volume', 'Repair-Volume',
+    'New-Item', 'Remove-Item', 'Set-Content', 'Out-File', 'New-Volume',
+    'ConvertTo-', 'New-Hardlink', 'New-Item -ItemType HardLink',
+  ]) {
+    assert.ok(!SOURCE.includes(verb), `source must not use PowerShell verb ${verb}`)
   }
 })
 
@@ -402,6 +491,9 @@ test('CLI run with probes disabled emits a BLOCKED report and exit code 1', () =
   }
   delete env[ENV_VAR.postgresUrl]
   delete env[ENV_VAR.healthUrl]
+  // Guarantee NOT_CONFIGURED regardless of whether this host happens to have
+  // the real S6-A product env var set, so this subprocess run stays hermetic.
+  delete env[SEALED_EXPORT_ENV.artifactRoot]
 
   let stdout = ''
   let status = 0
@@ -420,5 +512,8 @@ test('CLI run with probes disabled emits a BLOCKED report and exit code 1', () =
   assert.ok(stdout.includes('businessRowsRead=0'))
   // A disabled probe must report UNKNOWN, never a fabricated NO.
   assert.ok(stdout.includes('powershell51Available=UNKNOWN'))
+  // An unset product env var is NOT_CONFIGURED, not UNKNOWN/UNRESOLVED.
+  assert.ok(stdout.includes('artifactRootFilesystem=NOT_CONFIGURED'))
+  assert.ok(stdout.includes('artifactRootHardlinkSupported=UNKNOWN'))
   assert.ok(!stdout.includes(os.tmpdir()))
 })


### PR DESCRIPTION
## Summary

Adds a read-only artifact-root filesystem probe to `scripts/ops/stock-preparation-lab0-inventory.mjs` (still non-mutating, values-free). Motivation: `private-ingestion-blob-store.cjs` hardlinks chunks inside the S6-A artifact root; on exFAT/FAT32 or an SMB-mounted root that fails at runtime as `SEALED_EXPORT_STAGING_WRITE_FAILED`. Now the LAB-0 reply says so before anyone deploys.

- New fields: `artifactRootFilesystem` = `NTFS | REFS | OTHER | UNRESOLVED | NOT_CONFIGURED`, `artifactRootHardlinkSupported` = `YES | NO | UNKNOWN` (derived).
- Env var name comes from `stock-preparation-runtime-config.cjs` `ENV.artifactRoot` (no duplicated string). win32 + drive-letter root → `(Get-Volume -DriveLetter X).FileSystem` via the existing `-NoProfile -NonInteractive` probe pattern; otherwise `UNRESOLVED`; unset → `NOT_CONFIGURED` without spawning. The raw path joins the leak-sentinel list and is never printed.
- Tests 22 → 28 (classifier boundaries; NOT_CONFIGURED / UNRESOLVED / OTHER / REFS branches; single-SQL and only-child-process contracts updated); all 28 pass on Windows incl. a live probe of the system drive → `NTFS`. Contract workflow already runs on ubuntu + windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
