### PR TITLE
fix(ops): restore literal -StagingRoot $stagingBase apply invocation (package-verify contract broken by #4998)

### DIFF
--- a/scripts/ops/multitable-onprem-deploy-launcher.ps1
+++ b/scripts/ops/multitable-onprem-deploy-launcher.ps1
@@ -192,24 +192,27 @@ try {
   # try/catch contract instead so a successful apply ("Package deploy
   # complete" + health 200) reliably yields launcher exit 0 and a Last
   # Result of 0 in the outer scheduled task (#1526 follow-up).
-  # Splatted so the S6-A switch is forwarded ONLY when the operator moved it off the
-  # default. A launcher can be newer than the archive it is pointed at; the default
-  # 'auto' is also the staged helper's own default, so omitting it keeps an older
-  # staged apply working, while an explicit 'off' against a helper too old to honour
-  # it fails loudly instead of silently ignoring the operator.
-  $applyParameters = @{
-    InstallDeps = $InstallDeps
-    PackageArchive = $resolvedArchive
-    RootDir = $resolvedRoot
-    RunMigrations = $RunMigrations
-    StagingRoot = $stagingBase
-  }
+  # The S6-A switch is forwarded ONLY when the operator moved it off the default.
+  # A launcher can be newer than the archive it is pointed at; the default 'auto'
+  # is also the staged helper's own default, so omitting it keeps an older staged
+  # apply working, while an explicit 'off' against a helper too old to honour it
+  # fails loudly instead of silently ignoring the operator. The fixed named
+  # arguments below (in particular `-StagingRoot $stagingBase`) are a package-verify
+  # contract (multitable-onprem-package-verify.sh) — keep them literal; only the
+  # optional switch is appended via array splatting.
+  $s6aArtifactRootAclArguments = @()
   if ($S6aArtifactRootAcl -ne 'auto') {
-    $applyParameters['S6aArtifactRootAcl'] = $S6aArtifactRootAcl
+    $s6aArtifactRootAclArguments = @('-S6aArtifactRootAcl', $S6aArtifactRootAcl)
   }
 
   try {
-    & $stagedApply @applyParameters
+    & $stagedApply `
+      -RootDir $resolvedRoot `
+      -PackageArchive $resolvedArchive `
+      -StagingRoot $stagingBase `
+      -InstallDeps $InstallDeps `
+      -RunMigrations $RunMigrations `
+      @s6aArtifactRootAclArguments
     $launcherExit = 0
   }
   catch {


### PR DESCRIPTION
## Summary

#4998 switched the staged apply-helper call in `multitable-onprem-deploy-launcher.ps1` to hashtable splatting so `-S6aArtifactRootAcl` could be forwarded conditionally. Behaviourally fine, but `multitable-onprem-package-verify.sh` greps the launcher for the **fixed string** `-StagingRoot $stagingBase` ("launcher must pass its resolved staging base to the staged apply helper"), so **every package built from main after #4998 fails verification** — observed on run 32202464007 (dispatched to validate #5000's freeze-block emitter; the failure is in the verify step, before that emitter runs).

Fix: keep the fixed named arguments literal (byte-identical to the pre-#4998 form) and append the optional switch via array splatting only when the operator moved it off `'auto'`. Semantics unchanged.

## Verification
- All 61 launcher/apply fixed-string contracts in `multitable-onprem-package-verify.sh` re-evaluated against the tree: the only remaining "miss" is a parser artefact of my checker (bash `"\$…"` needle), identical on pristine main.
- `multitable-onprem-s6a-artifact-root-acl.tests.ps1` 24/24 (PS 5.1, real icacls); `stock-preparation-onprem-acceptance.tests.ps1` all contract checks pass; launcher parses with 0 errors.
- `multitable-onprem-package-no-node-modules.test.mjs` 10/11 — the 1 failure is pre-existing on pristine main on this host (Release asset-list assertion), unrelated.
- A `multitable-onprem-package-build.yml` dispatch on this branch (`publish_release=false`) is the real proof; run linked below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)