### PR TITLE
ci(onprem): package-build lane emits the paste-ready freeze block (+ no-node-modules test, provenance manifest digest)

### DIFF
--- a/.github/workflows/multitable-onprem-package-build.yml
+++ b/.github/workflows/multitable-onprem-package-build.yml
@@ -1,5 +1,42 @@
 name: Multitable On-Prem Package Build
 
+# Dispatchable build -> verify -> (optional) GitHub Release for the multitable
+# on-prem package.
+#
+# FREEZE BLOCK (#4708 / #4693; ranked #1 in
+# docs/development/onprem-deploy-path-acceleration-20260818.md §e). After the
+# archives are built and verified this job additionally
+#   (a) runs the package archive contract test
+#       scripts/ops/multitable-onprem-package-no-node-modules.test.mjs, which
+#       until now shipped in ZERO build lanes (only .github/workflows/plugin-tests.yml
+#       ran it, on a different trigger), and
+#   (b) emits the paste-ready five-field freeze block the S6-B instruction
+#       requires, so the operator stops hand-assembling it from a separate
+#       `node -e` invocation and a second workflow run.
+#
+# THE CONTRACT TEST CAN FAIL THIS JOB, AND THAT IS INTENDED. It pins the
+# node_modules pruning helper, the shipped-verifier / repository-only-builder
+# split, and the release + artifact bootstrap-sidecar roster. A build whose own
+# archive contract has regressed must not reach "Publish GitHub Release". It is
+# hermetic (no network, no service containers) and runs against the repository
+# tree, so it costs seconds.
+#
+# Everything else added here is read-only reporting over bytes the build already
+# produced. With the default inputs (publish_release=false) the observable
+# behaviour is unchanged apart from one extra file in the uploaded artifact
+# (freeze-block.txt) and one extra $GITHUB_STEP_SUMMARY section.
+#
+# packageProvenanceManifestDigest is NOT recomputed here. It is read out of the
+# BUILT package by the product's own module: the packaged
+# plugins/plugin-integration-core/lib/sealed-export/sealed-export-package-provenance.cjs,
+# whose verifySealedExportRuntimePackageProvenance().frozenManifestDigest is the
+# sha256 of the packaged
+# plugins/plugin-integration-core/lib/sealed-export/vectors/s6a-package-provenance-pins.json.
+# That is the same value stock-prep-s6a-postgres17-validation.yml:105-119
+# compares against its frozen pin, and the same command the S6-A runbook
+# (docs/operations/stock-preparation-s6a-sqlserver-onprem-runbook-20260731.md §1.5)
+# tells the operator to run by hand.
+
 on:
   workflow_dispatch:
     inputs:
@@ -131,6 +168,151 @@ jobs:
           mv "$tmp" "$PACKAGE_META_FILE"
           echo "gitSha=$BUILD_SHA bound into $(basename "$PACKAGE_META_FILE") for human/tooling reference. NOTE: the one-click acceptance -ExpectedGitSha lock verifies BUILD_PROVENANCE.json.gitCommit INSIDE the archive (the checksummed bytes), NOT this external sidecar — an old archive cannot be laundered by a fresh sidecar."
 
+      # Wiring only — the test itself is unchanged. It asserts the build script
+      # prunes node_modules, that the builder stays repository-only while the
+      # verifier ships, and that BOTH first-hop bootstrap sidecars appear in the
+      # `assets=(` list and the artifact globs of THIS file. Deliberately placed
+      # before the release step: a regressed archive contract must not publish.
+      - name: Package archive contract test (no bundled node_modules)
+        run: node --test scripts/ops/multitable-onprem-package-no-node-modules.test.mjs
+
+      - name: Emit paste-ready freeze block
+        env:
+          PUBLISH_RELEASE: ${{ inputs.publish_release }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+        run: |
+          set -euo pipefail
+
+          out_dir="output/releases/multitable-onprem"
+          command -v unzip >/dev/null 2>&1 || {
+            echo "unzip is required to read the built package" >&2
+            exit 1
+          }
+          freeze_root="$(mktemp -d)"
+          unzip -q "$PACKAGE_FILE_ZIP" -d "$freeze_root"
+          pkg_root="${freeze_root}/$(basename "${PACKAGE_FILE_ZIP%.zip}")"
+          test -d "$pkg_root"
+
+          # serviceRuntimeSha is read from BUILD_PROVENANCE.json INSIDE the
+          # checksummed archive, not from the external sidecar the previous step
+          # stamped, and is then required to equal this job's build SHA. Same
+          # reasoning as stock-prep-main-package-verify.yml PIN-3: a freeze block
+          # must quote the commit the shipped bytes claim, not the one the run
+          # believes it built.
+          archive_git_commit="$(node - "$pkg_root" <<'NODE'
+          const fs = require('node:fs')
+          const path = require('node:path')
+          const root = process.argv[2]
+          const provenance = JSON.parse(
+            fs.readFileSync(path.join(root, 'BUILD_PROVENANCE.json'), 'utf8'),
+          )
+          console.log(provenance.gitCommit)
+          NODE
+          )"
+          if [[ "$archive_git_commit" != "$BUILD_SHA" ]]; then
+            echo "FATAL: in-archive BUILD_PROVENANCE.json gitCommit (${archive_git_commit}) != this job's build SHA (${BUILD_SHA})." >&2
+            exit 1
+          fi
+
+          # packageProvenanceManifestDigest — produced by the product's own
+          # verifier, loaded FROM the package and run AGAINST the package. No
+          # re-implementation of the digest here or anywhere in this file.
+          provenance_manifest_digest="$(node - "$pkg_root" <<'NODE'
+          const path = require('node:path')
+          const root = process.argv[2]
+          const verifier = require(
+            path.join(
+              root,
+              'plugins/plugin-integration-core/lib/sealed-export/' +
+                'sealed-export-package-provenance.cjs',
+            ),
+          )
+          const result = verifier.verifySealedExportRuntimePackageProvenance({
+            repoRoot: root,
+          })
+          if (
+            result?.verified !== true
+            || result?.runtimePackageVerified !== true
+            || result?.externalPackagePinRequired !== true
+          ) {
+            process.exit(1)
+          }
+          console.log(result.frozenManifestDigest)
+          NODE
+          )"
+          rm -rf "$freeze_root"
+
+          zip_sha256="$(sha256sum "$PACKAGE_FILE_ZIP" | awk '{print $1}')"
+          tgz_sha256="$(sha256sum "$PACKAGE_FILE" | awk '{print $1}')"
+          # The build already wrote .sha256 sidecars and SHA256SUMS; requiring
+          # the recomputation to agree keeps the block from quoting a digest that
+          # the published checksum files contradict.
+          sidecar_zip_sha256="$(awk '{print $1}' "${PACKAGE_FILE_ZIP}.sha256")"
+          sidecar_tgz_sha256="$(awk '{print $1}' "${PACKAGE_FILE}.sha256")"
+          if [[ "$zip_sha256" != "$sidecar_zip_sha256" || "$tgz_sha256" != "$sidecar_tgz_sha256" ]]; then
+            echo "FATAL: recomputed archive SHA-256 disagrees with the build's own .sha256 sidecar." >&2
+            exit 1
+          fi
+
+          # Closed token, never an invented tag: with publish_release=false (the
+          # default) nothing is published, so there is no releaseTag to quote.
+          if [[ "${PUBLISH_RELEASE}" == "true" && -n "${RELEASE_TAG}" ]]; then
+            resolved_release_tag="${RELEASE_TAG}"
+          else
+            resolved_release_tag="NOT_PUBLISHED"
+          fi
+
+          if [[ ! "$archive_git_commit" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "FATAL: serviceRuntimeSha is not 40-hex; refusing to emit a freeze block." >&2
+            exit 1
+          fi
+          for digest in "$zip_sha256" "$tgz_sha256" "$provenance_manifest_digest"; do
+            if [[ ! "$digest" =~ ^[0-9a-f]{64}$ ]]; then
+              echo "FATAL: a freeze-block digest is not 64-hex; refusing to emit a freeze block." >&2
+              exit 1
+            fi
+          done
+
+          # Exactly the eight lines #4708 / #4693 consume, in that order, and
+          # values-free: sha, tag, basename, digests and closed tokens only. Any
+          # supplementary field stays OUTSIDE this file so a whole-file paste is
+          # always the block and nothing but the block.
+          freeze_block_file="${out_dir}/freeze-block.txt"
+          {
+            echo "serviceRuntimeSha=${archive_git_commit}"
+            echo "releaseTag=${resolved_release_tag}"
+            echo "packageFile=$(basename "$PACKAGE_FILE_ZIP")"
+            echo "packageSha256=${zip_sha256}"
+            echo "packageProvenanceManifestDigest=${provenance_manifest_digest}"
+            echo "customerScope=SYNTHETIC_SINGLE_CUSTOMER"
+            echo "sourceMode=READ_ONLY"
+            echo "externalWrite=false"
+          } > "$freeze_block_file"
+
+          echo "FREEZE_BLOCK_FILE=$freeze_block_file" >> "$GITHUB_ENV"
+
+          echo "::group::Paste-ready freeze block"
+          cat "$freeze_block_file"
+          echo "::endgroup::"
+          echo "packageTgzSha256=${tgz_sha256}"
+          echo "buildProvenanceGitCommitMatchesBuildSha=PASS"
+          echo "archiveSha256MatchesSidecar=PASS"
+
+          {
+            echo "## Paste-ready freeze block"
+            echo ""
+            echo "Copy the block below verbatim into the #4708 / #4693 comment."
+            echo ""
+            echo '```text'
+            cat "$freeze_block_file"
+            echo '```'
+            echo ""
+            echo "Supplementary (NOT part of the block — the block pins the .zip):"
+            echo ""
+            echo "- \`packageTgzSha256=${tgz_sha256}\`"
+            echo "- \`packageFileTgz=$(basename "$PACKAGE_FILE")\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Publish GitHub Release
         if: ${{ inputs.publish_release == 'true' }}
         env:
@@ -184,6 +366,11 @@ jobs:
             output/releases/multitable-onprem/*.json
             output/releases/multitable-onprem/verify/*.json
             output/releases/multitable-onprem/verify/*.md
+            # Written by "Emit paste-ready freeze block". Listed explicitly:
+            # no glob above matches .txt, and it is deliberately NOT added to
+            # SHA256SUMS or to the release asset list — it is a report about the
+            # archives, not a shipped package byte.
+            output/releases/multitable-onprem/freeze-block.txt
           retention-days: 14
 
       - name: Step summary
@@ -197,6 +384,7 @@ jobs:
             echo "- First-hop bootstrap (.bat): \`${PACKAGE_BOOTSTRAP_BAT}\`"
             echo "- Verify (.tgz JSON): \`${PACKAGE_VERIFY_TGZ_JSON}\`"
             echo "- Verify (.zip JSON): \`${PACKAGE_VERIFY_ZIP_JSON}\`"
+            echo "- Freeze block: \`${FREEZE_BLOCK_FILE}\` (also rendered above, and in the artifact)"
             echo "- Artifact: \`multitable-onprem-package-${{ github.run_id }}-${{ github.run_attempt }}\`"
             if [[ "${{ inputs.publish_release }}" == "true" ]]; then
               echo "- Release tag: \`${{ inputs.release_tag }}\`"

--- a/scripts/ops/multitable-onprem-deploy-launcher.ps1
+++ b/scripts/ops/multitable-onprem-deploy-launcher.ps1
@@ -192,24 +192,27 @@ try {
   # try/catch contract instead so a successful apply ("Package deploy
   # complete" + health 200) reliably yields launcher exit 0 and a Last
   # Result of 0 in the outer scheduled task (#1526 follow-up).
-  # Splatted so the S6-A switch is forwarded ONLY when the operator moved it off the
-  # default. A launcher can be newer than the archive it is pointed at; the default
-  # 'auto' is also the staged helper's own default, so omitting it keeps an older
-  # staged apply working, while an explicit 'off' against a helper too old to honour
-  # it fails loudly instead of silently ignoring the operator.
-  $applyParameters = @{
-    InstallDeps = $InstallDeps
-    PackageArchive = $resolvedArchive
-    RootDir = $resolvedRoot
-    RunMigrations = $RunMigrations
-    StagingRoot = $stagingBase
-  }
+  # The S6-A switch is forwarded ONLY when the operator moved it off the default.
+  # A launcher can be newer than the archive it is pointed at; the default 'auto'
+  # is also the staged helper's own default, so omitting it keeps an older staged
+  # apply working, while an explicit 'off' against a helper too old to honour it
+  # fails loudly instead of silently ignoring the operator. The fixed named
+  # arguments below (in particular `-StagingRoot $stagingBase`) are a package-verify
+  # contract (multitable-onprem-package-verify.sh) — keep them literal; only the
+  # optional switch is appended via array splatting.
+  $s6aArtifactRootAclArguments = @()
   if ($S6aArtifactRootAcl -ne 'auto') {
-    $applyParameters['S6aArtifactRootAcl'] = $S6aArtifactRootAcl
+    $s6aArtifactRootAclArguments = @('-S6aArtifactRootAcl', $S6aArtifactRootAcl)
   }
 
   try {
-    & $stagedApply @applyParameters
+    & $stagedApply `
+      -RootDir $resolvedRoot `
+      -PackageArchive $resolvedArchive `
+      -StagingRoot $stagingBase `
+      -InstallDeps $InstallDeps `
+      -RunMigrations $RunMigrations `
+      @s6aArtifactRootAclArguments
     $launcherExit = 0
   }
   catch {

--- a/scripts/ops/multitable-onprem-package-no-node-modules.test.mjs
+++ b/scripts/ops/multitable-onprem-package-no-node-modules.test.mjs
@@ -534,3 +534,75 @@ test('on-prem verifier rejects packages missing the stock-preparation acceptance
     fs.rmSync(root, { recursive: true, force: true })
   }
 })
+
+test('package build workflow runs this contract test and emits the paste-ready freeze block', () => {
+  // Normalised locally: a core.autocrlf=true checkout hands this file CRLF, and
+  // the ordering/roster assertions below are newline-anchored.
+  const workflow = packageWorkflow.replace(/\r\n/g, '\n')
+
+  const contractTestStep = workflow.indexOf(
+    'node --test scripts/ops/multitable-onprem-package-no-node-modules.test.mjs',
+  )
+  assert.ok(
+    contractTestStep > -1,
+    'the build lane must run this archive contract test, not leave it to plugin-tests.yml alone',
+  )
+
+  const freezeStep = workflow.indexOf('- name: Emit paste-ready freeze block')
+  const releaseStep = workflow.indexOf('- name: Publish GitHub Release')
+  assert.ok(freezeStep > -1, 'the build lane must emit the freeze block')
+  assert.ok(releaseStep > -1, 'the release step should still exist')
+  assert.ok(
+    contractTestStep < releaseStep && freezeStep < releaseStep,
+    'a regressed archive contract or an unbuildable freeze block must be caught BEFORE the release publishes',
+  )
+
+  // The digest is read out of the built package by the product's own verifier.
+  // A re-implementation here (or a bare sha256sum of the pins vector) would
+  // silently drift from sealed-export-package-provenance.cjs.
+  assert.match(
+    workflow,
+    /verifier\.verifySealedExportRuntimePackageProvenance\(\{\n\s*repoRoot: root,\n\s*\}\)/,
+    'packageProvenanceManifestDigest must come from the packaged provenance module',
+  )
+  assert.match(
+    workflow,
+    /console\.log\(result\.frozenManifestDigest\)/,
+    'the emitted digest must be the module\'s frozenManifestDigest',
+  )
+
+  // Exactly the eight fields #4708 / #4693 consume, in order, values-free.
+  const freezeBlockFields = workflow.match(/echo "serviceRuntimeSha=[\s\S]*?echo "externalWrite=false"/)
+  assert.ok(freezeBlockFields, 'the freeze block must be written as one contiguous emission')
+  const emitted = freezeBlockFields[0]
+    .split('\n')
+    .map((line) => line.trim().match(/^echo "([A-Za-z][A-Za-z0-9]*)=/))
+    .filter(Boolean)
+    .map((match) => match[1])
+  assert.deepEqual(emitted, [
+    'serviceRuntimeSha',
+    'releaseTag',
+    'packageFile',
+    'packageSha256',
+    'packageProvenanceManifestDigest',
+    'customerScope',
+    'sourceMode',
+    'externalWrite',
+  ])
+
+  assert.match(
+    workflow,
+    /resolved_release_tag="NOT_PUBLISHED"/,
+    'an unpublished build must emit the closed token, never an invented release tag',
+  )
+  assert.match(
+    workflow,
+    /echo "packageTgzSha256=\$\{tgz_sha256\}"/,
+    'the .tgz digest must also be emitted alongside the block',
+  )
+  assert.match(
+    workflow,
+    /output\/releases\/multitable-onprem\/freeze-block\.txt/,
+    'the freeze block must ship inside the uploaded artifact',
+  )
+})


### PR DESCRIPTION
## Summary

Top-1 accelerator from `onprem-deploy-path-acceleration-20260818.md`: the package-build lane now emits the **paste-ready freeze block** that #4708 / #4693 ask an operator to hand-assemble, and runs the no-node-modules test on the built package.

Extends the existing `multitable-onprem-package-build.yml` (a brand-new dispatch workflow could not be validated from a branch). Two steps between metadata-bind and release publish:
1. `node --test scripts/ops/multitable-onprem-package-no-node-modules.test.mjs` — **can fail the job, intended** (stated in the header).
2. "Emit paste-ready freeze block" — to the grouped job log, `$GITHUB_STEP_SUMMARY`, and `freeze-block.txt` inside the uploaded artifact:
```
serviceRuntimeSha=<40-hex>   # read from BUILD_PROVENANCE.json INSIDE the checksummed archive, must equal BUILD_SHA
releaseTag=<tag|NOT_PUBLISHED>
packageFile=<basename .zip>
packageSha256=<64-hex>       # recomputed, must match the build's own .sha256 sidecar
packageProvenanceManifestDigest=<64-hex>   # packaged copy's verifySealedExportRuntimePackageProvenance().frozenManifestDigest — the same value stock-prep-s6a-postgres17-validation.yml pins and the runbook §1.5 has operators type by hand
customerScope=SYNTHETIC_SINGLE_CUSTOMER
sourceMode=READ_ONLY
externalWrite=false
```
`packageTgzSha256=` is emitted adjacent but outside the 8-line block so a whole-file paste is the block and nothing else. Default-input behaviour otherwise unchanged. `multitable-onprem-package-no-node-modules.test.mjs` gains a contract test pinning the new wiring (mutation-tested: invented tag / unwired test / re-implemented digest each fire).

Includes the #5000 hotfix commit (launcher `-StagingRoot $stagingBase` literal) because the emitter cannot be validated without a passing verify step; will squash cleanly once #5000 lands.

## Validation
- Branch dispatch [run 32202981686](https://github.com/zensgit/metasheet2/actions/runs/32202981686) (`publish_release=false`, `expected_sha` exact): **success**; emitted block: `serviceRuntimeSha=0a012820d…`, `releaseTag=NOT_PUBLISHED`, `packageFile=metasheet-multitable-onprem-v2.5.0-freezeblock-validate.zip`, `packageSha256=4303cd15…`, `packageProvenanceManifestDigest=327fb41f7b42c76b…3b4491` (= the current frozen manifest digest), `packageTgzSha256=bbbe85af…`.
- No pin refresh needed: neither edited file is in any `PINNED_*` roster; all 62 pinned paths verified against git-index bytes, 0 mismatches.
- YAML parses; `bash -n` on all run blocks; `node --check`; local negative controls for sidecar / gitCommit mismatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
