### PR TITLE
ci(stock-prep): Node 24 leg on the package migrate lane (host parity) + ASCII-only LAB-0 output

### DIFF
--- a/.github/workflows/stock-prep-main-package-verify.yml
+++ b/.github/workflows/stock-prep-main-package-verify.yml
@@ -575,16 +575,42 @@ jobs:
   # `needs` includes verify-built-package on purpose: there is no reason to
   # migrate an artifact that has not passed the five-check verifier, PIN-1 and
   # the tamper control first.
+  #
+  # NODE 24 LEG. The on-prem test host this package actually gets installed
+  # and migrated on runs Node 24.x, but every leg here previously ran the
+  # package's install/verify/migrate steps under Node 20 only (the build job
+  # above stays pinned to Node 20 deliberately — see its own comment — because
+  # it must match multitable-onprem-package-build.yml's build-time toolchain
+  # byte for byte). This job is where the built package's OWN dependency
+  # install (`pnpm install --frozen-lockfile` against the packaged lockfile)
+  # and its OWN migration runner (`packages/core-backend/dist/src/db/migrate.js`)
+  # actually execute, which is exactly the host-parity question. The matrix
+  # below is expressed as explicit `include:` combinations, not a `pg`x`node`
+  # cross product, so the three existing pg15/16/17-on-Node20 legs are
+  # untouched and exactly one new pg17-on-Node24 leg is added (pg17 chosen as
+  # the newest/most-representative PostgreSQL major already in this matrix;
+  # migrate-postgres-role-bound is left alone — it is a specialized PG16/17
+  # CREATEROLE negative-control arm, not a general Node-runtime check, and
+  # doubling its already-heavy positive+negative-control steps would not add
+  # Node-compatibility signal).
   # ---------------------------------------------------------------------
   migrate-postgres:
-    name: Migrate on PostgreSQL ${{ matrix.pg }}
+    name: Migrate on PostgreSQL ${{ matrix.pg }} (Node ${{ matrix.node }})
     needs: [build-main-package, verify-built-package]
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
-        pg: ['15', '16', '17']
+        include:
+          - pg: '15'
+            node: '20'
+          - pg: '16'
+            node: '20'
+          - pg: '17'
+            node: '20'
+          - pg: '17'
+            node: '24'
     services:
       postgres:
         image: postgres:${{ matrix.pg }}
@@ -715,7 +741,10 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          # matrix.node: '20' for the three original legs, '24' for the new
+          # host-parity leg (see this job's header comment). The root
+          # package.json engines field (">=18.0.0") does not reject Node 24.
+          node-version: ${{ matrix.node }}
 
       - name: Install the package's own pinned dependencies (frozen lockfile — never relaxed)
         working-directory: ${{ env.PKG_ROOT }}
@@ -805,7 +834,11 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: main-package-migrate-postgres-${{ matrix.pg }}-evidence-${{ github.run_id }}-${{ github.run_attempt }}
+          # matrix.node is included because pg='17' now appears in TWO legs
+          # (node 20 and node 24, see this job's header comment); without it
+          # both legs would upload under the same artifact name in the same
+          # run and collide.
+          name: main-package-migrate-postgres-${{ matrix.pg }}-node${{ matrix.node }}-evidence-${{ github.run_id }}-${{ github.run_attempt }}
           retention-days: 14
           if-no-files-found: warn
           path: |
@@ -818,6 +851,7 @@ jobs:
         run: |
           {
             echo "postgresMajorVersion=${{ matrix.pg }}"
+            echo "nodeMajorVersion=${{ matrix.node }}"
             echo "postgresServerVersionPinMatch=PASS"
             echo "sameArtifactAsBuildJob=PASS"
             echo "packagedMigration074Present=PASS"
@@ -1511,6 +1545,7 @@ jobs:
             echo "migration075ExecutedAllVersions=PASS"
             echo "oneByteNegativeCheck=PASS"
             echo "postgresMajorVersionsExercised=15,16,17"
+            echo "nodeMajorVersionsExercised=20,24"
             echo "migrationApplyAllVersions=PASS"
             echo "migrationReplayIdempotentAllVersions=PASS"
             echo "migrationClaimScope=PACKAGE_MIGRATIONS_MINUS_EXCLUSION_SET"

--- a/scripts/ops/stock-preparation-lab0-inventory.mjs
+++ b/scripts/ops/stock-preparation-lab0-inventory.mjs
@@ -630,7 +630,7 @@ function assertNoConfiguredInputLeaked(report, config) {
 function formatReport(result) {
   assertClosedSet(result.fields)
   const lines = [
-    '=== LAB-0 host inventory (DRAFT — non-mutating, values-free) ===',
+    '=== LAB-0 host inventory (DRAFT -- non-mutating, values-free) ===',
     'inventoryTool=stock-preparation-lab0-inventory/v1-draft',
     'mutationsPerformed=0',
     'businessRowsRead=0',
@@ -669,7 +669,7 @@ function buildOperatorGuidance() {
     '',
     `artifactRootFilesystem/artifactRootHardlinkSupported read the S6-A`,
     `sealed-export artifact-root env var (${SEALED_EXPORT_ENV.artifactRoot}) if it is`,
-    'already set in this environment — not an LAB0_ flag, and never printed.',
+    'already set in this environment -- not an LAB0_ flag, and never printed.',
     'Unset -> NOT_CONFIGURED. Windows only; every other platform -> UNRESOLVED.',
     '',
     'The only SQL this tool executes is one read-only catalog SELECT against',
@@ -677,7 +677,7 @@ function buildOperatorGuidance() {
     'role, and no grant; those remain a later, separately authorized step.',
     '',
     'lab0Status=BLOCKED means at least one fact is still UNKNOWN (or factsProvider',
-    'was not supplied) — report it as-is; do not fill a gap by hand.',
+    'was not supplied) -- report it as-is; do not fill a gap by hand.',
   ].join('\n')
 }
 

--- a/scripts/ops/stock-preparation-lab0-inventory.test.mjs
+++ b/scripts/ops/stock-preparation-lab0-inventory.test.mjs
@@ -31,6 +31,7 @@ import {
   SIX_FIELD_ORDER,
   TOKEN,
   artifactRootHardlinkSupportedField,
+  buildOperatorGuidance,
   classifyArtifactRootFilesystem,
   classifyDiskFree,
   classifyFactsProvider,
@@ -516,4 +517,48 @@ test('CLI run with probes disabled emits a BLOCKED report and exit code 1', () =
   assert.ok(stdout.includes('artifactRootFilesystem=NOT_CONFIGURED'))
   assert.ok(stdout.includes('artifactRootHardlinkSupported=UNKNOWN'))
   assert.ok(!stdout.includes(os.tmpdir()))
+})
+
+// ---------------------------------------------------------------------------
+// 6. ASCII-only printed output (Windows console code page 936 mojibake guard).
+//
+// A non-ASCII glyph (the tool used an em dash) renders as mojibake ("锟?" /
+// "�?") on a Windows console running the code page 936 (Simplified Chinese)
+// codepage that this tool's on-prem host uses. This is a byte-level property
+// of the rendered output, not something the closed-token assertions above
+// exercise: every classified FIELD value is already an ASCII token, but the
+// surrounding banner and help text are free text that could carry a stray
+// non-ASCII character.  Encode to the same UTF-8 bytes process.stdout.write
+// emits and assert every one is < 0x80.
+// ---------------------------------------------------------------------------
+test('a COMPLETE report + operator guidance render as pure ASCII bytes', async () => {
+  const result = await runInventory({ env: goodEnv(), probes: goodProbes() })
+  const rendered = `${formatReport(result)}\n\n${buildOperatorGuidance()}\n`
+  const bytes = Buffer.from(rendered, 'utf8')
+  assert.ok(bytes.length > 0, 'rendered output must not be empty')
+  for (let i = 0; i < bytes.length; i += 1) {
+    assert.ok(
+      bytes[i] < 0x80,
+      `non-ASCII byte 0x${bytes[i].toString(16)} at offset ${i} in rendered LAB-0 output`,
+    )
+  }
+})
+
+test('a BLOCKED report (unset inputs, every optional probe off) also renders as pure ASCII bytes', async () => {
+  const env = goodEnv({ [ENV_VAR.factsProvider]: '' })
+  delete env[ENV_VAR.postgresUrl]
+  delete env[SEALED_EXPORT_ENV.artifactRoot]
+  const result = await runInventory({
+    env,
+    probes: goodProbes({ health: async () => null, powerShellMajor: () => null }),
+  })
+  assert.equal(result.lab0Status, TOKEN.BLOCKED)
+  const rendered = `${formatReport(result)}\n\n${buildOperatorGuidance()}\n`
+  const bytes = Buffer.from(rendered, 'utf8')
+  for (let i = 0; i < bytes.length; i += 1) {
+    assert.ok(
+      bytes[i] < 0x80,
+      `non-ASCII byte 0x${bytes[i].toString(16)} at offset ${i} in rendered LAB-0 output`,
+    )
+  }
 })


### PR DESCRIPTION
## Summary

Two small follow-ups from the 2026-08-19 LAB-0 inventory of the controlled Windows host.

**A. Node 24 leg.** The host runs Node 24.x while the package lanes validated on 18/20. `stock-prep-main-package-verify.yml` `migrate-postgres` (the job that runs the built package's own `pnpm install --frozen-lockfile` + migration runner) gains an explicit `matrix.include` combo pg17/Node 24 alongside the unchanged pg15/16/17 on Node 20; `fail-fast: false`; artifact names now include the node major to avoid the pg17 collision. `build-main-package` stays pinned to Node 20 (byte-for-byte parity with the build lane). Neither workflow is in the provenance evidence-file pins (checked); root `engines.node >=18` admits 24.

**B. ASCII-only LAB-0 output.** On the host console (cp936) the em-dashes in the tool's banners rendered as mojibake. Printed strings are now ASCII (`--`); no `key=value` token changed. Two hermetic tests assert every output byte < 0x80. `stock-preparation-lab0-inventory.test.mjs` 28 → 30, all pass on Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)