### PR TITLE
fix(ops): [Q14] universe = config closed set (review P3) + Q3 anchor de-ambiguation

### DIFF
--- a/scripts/ops/attendance-staging-window-runner-remote.sh
+++ b/scripts/ops/attendance-staging-window-runner-remote.sh
@@ -2419,8 +2419,11 @@ action_soak_status() {
   # (uq_arc_w7_comparison_identity makes that marker operationId unique per (org,entrypoint)).
   soak_status_scalar "[Q4b]_w7_group_arm_clean_punches_cumulative" \
     "SELECT count(DISTINCT (c.input_provenance -> 'w7GroupShadowCompare' ->> 'operationId')) FROM attendance_record_calculations c JOIN attendance_records r ON r.id = c.attendance_record_id AND r.org_id = c.org_id WHERE c.created_at >= '${window_start}'::timestamptz AND c.created_at < now() AND c.mode = 'shadow' AND (c.input_provenance ? 'w7GroupShadowCompare') AND c.context_snapshot IS NOT NULL AND (c.context_snapshot ->> 'selector') = 'group_effective' AND c.outcome = 'completed' AND (c.shadow_diff_code IS NULL OR c.shadow_diff_code = 'equal');" >/dev/null
-  soak_status_rows "[Q14] posture-state distribution (org-count summary)" \
-    "SELECT COALESCE(w4.state,'legacy') AS w4_posture, COALESCE(w7.state,'off') AS w7_posture, count(*)::int AS org_count FROM (SELECT DISTINCT org_id FROM attendance_calculation_rollout_state UNION SELECT DISTINCT org_id FROM attendance_calculation_context_source_state) target LEFT JOIN attendance_calculation_rollout_state w4 ON w4.org_id = target.org_id LEFT JOIN attendance_calculation_context_source_state w7 ON w7.org_id = target.org_id GROUP BY w4_posture, w7_posture ORDER BY w4_posture, w7_posture;"
+  # [Q14] universe = config CLOSED SET (post-merge review P3: a posture-table-derived
+  # universe omits the legacy_only control org — no state rows — and the two-row summary
+  # misleads on-duty readers even though C1-C3 acceptance reads Q1-Q3, not Q14).
+  soak_status_rows "[Q14] posture-state distribution (org-count summary; config closed set)" \
+    "SELECT COALESCE(w4.state,'legacy') AS w4_posture, COALESCE(w7.state,'off') AS w7_posture, count(*)::int AS org_count FROM (VALUES ('${SOAK_ORG1}'),('${SOAK_ORG2}'),('${SOAK_ORG3}')) AS target(org_id) LEFT JOIN attendance_calculation_rollout_state w4 ON w4.org_id = target.org_id LEFT JOIN attendance_calculation_context_source_state w7 ON w7.org_id = target.org_id GROUP BY w4_posture, w7_posture ORDER BY w4_posture, w7_posture;"
   soak_status_rows "posture rows for the three soak orgs (W4 then W7)" \
     "SELECT 'w4' AS machine, org_id, state, version, prior_state FROM attendance_calculation_rollout_state WHERE org_id IN ('${SOAK_ORG1}','${SOAK_ORG2}','${SOAK_ORG3}') UNION ALL SELECT 'w7', org_id, state, version, prior_state FROM attendance_calculation_context_source_state WHERE org_id IN ('${SOAK_ORG1}','${SOAK_ORG2}','${SOAK_ORG3}') ORDER BY 1, 2;"
 

--- a/scripts/ops/attendance-window-runner-pipeline.test.mjs
+++ b/scripts/ops/attendance-window-runner-pipeline.test.mjs
@@ -1172,10 +1172,31 @@ function assertSoakContract({ remote, workflow }) {
     slices.status.includes('alerts+=("Q3b_posture_constancy_violations'),
     'a posture-constancy violation must raise a mechanical alert',
   )
+  // Post-merge review P3: [Q14]'s universe must also be the config closed set — the
+  // posture-derived universe rendered a two-row summary that hid the control org.
+  const q14Idx = slices.status.indexOf('[Q14] posture-state distribution')
+  const q14Sql = slices.status.slice(q14Idx, slices.status.indexOf('posture rows for the three soak orgs', q14Idx))
   assert.match(
-    slices.status,
-    /FROM \(VALUES \('\$\{SOAK_ORG1\}'\),\('\$\{SOAK_ORG2\}'\),\('\$\{SOAK_ORG3\}'\)\) AS target\(org_id\) LEFT JOIN attendance_calculation_rollout_state w4/,
+    q14Sql,
+    /FROM \(VALUES \('\$\{SOAK_ORG1\}'\),\('\$\{SOAK_ORG2\}'\),\('\$\{SOAK_ORG3\}'\)\) AS target\(org_id\)/,
+    '[Q14] must derive its universe from the config closed set (a posture-derived universe omits the legacy control org)',
+  )
+  assert.doesNotMatch(
+    q14Sql,
+    /SELECT DISTINCT org_id FROM attendance_calculation_rollout_state UNION/,
+    '[Q14] must not fall back to the posture-derived universe',
+  )
+  const q3Idx = slices.status.indexOf('[Q3] org/posture classification')
+  const q3Sql = slices.status.slice(q3Idx, slices.status.indexOf('[Q4a]', q3Idx))
+  assert.match(
+    q3Sql,
+    /FROM \(VALUES \('\$\{SOAK_ORG1\}'\),\('\$\{SOAK_ORG2\}'\),\('\$\{SOAK_ORG3\}'\)\) AS target\(org_id\)/,
     '[Q3] universe must be the config closed set — a posture-derived universe structurally omits the legacy control org',
+  )
+  assert.doesNotMatch(
+    q3Sql,
+    /SELECT DISTINCT org_id FROM attendance_calculation_rollout_state UNION/,
+    '[Q3] must not fall back to the posture-derived universe',
   )
   assert.ok(slices.status.includes("'group_effective'"), 'W7-2 counters must scope on the selector discriminator')
 
@@ -1323,17 +1344,38 @@ test('MUTATION (legacy control): dropping the legacy-regime addend from [Q1] tur
 
 test('MUTATION (legacy control): reverting [Q3] to the posture-derived universe turns the soak contract red', () => {
   const original = readFileSync(REMOTE_SH, 'utf8')
-  // Anchor includes Q3's own LEFT JOIN target so it cannot hit [Q2]'s closed-set join.
-  const anchor = "FROM (VALUES ('${SOAK_ORG1}'),('${SOAK_ORG2}'),('${SOAK_ORG3}')) AS target(org_id) LEFT JOIN attendance_calculation_rollout_state w4"
-  assert.ok(original.includes(anchor), 'mutation anchor must hit the Q3 closed-set universe')
-  const mutated = original.replace(
-    anchor,
-    'FROM (SELECT DISTINCT org_id FROM attendance_calculation_rollout_state UNION SELECT DISTINCT org_id FROM attendance_calculation_context_source_state) target LEFT JOIN attendance_calculation_rollout_state w4',
-  )
+  // Position-bounded: locate the VALUES clause INSIDE the [Q3] block (both [Q2] and [Q14]
+  // now carry closed-set joins of their own — third anchor-ambiguity of this family).
+  const q3Start = original.indexOf('[Q3] org/posture classification')
+  const q3End = original.indexOf('[Q4a]', q3Start)
+  const valuesClause = "FROM (VALUES ('${SOAK_ORG1}'),('${SOAK_ORG2}'),('${SOAK_ORG3}')) AS target(org_id)"
+  const at = original.indexOf(valuesClause, q3Start)
+  assert.ok(q3Start !== -1 && at !== -1 && at < q3End, 'mutation anchor must hit the Q3 closed-set universe inside the Q3 block')
+  const mutated = original.slice(0, at)
+    + 'FROM (SELECT DISTINCT org_id FROM attendance_calculation_rollout_state UNION SELECT DISTINCT org_id FROM attendance_calculation_context_source_state) target'
+    + original.slice(at + valuesClause.length)
   assert.notEqual(mutated, original, 'mutation must change the file')
   assert.throws(
     () => assertSoakContract({ remote: mutated, workflow: readFileSync(WORKFLOW, 'utf8') }),
     /structurally omits the legacy control org/,
+  )
+})
+
+test('MUTATION (legacy control): reverting [Q14] to the posture-derived universe turns the soak contract red', () => {
+  const original = readFileSync(REMOTE_SH, 'utf8')
+  const q14Anchor = "org-count summary; config closed set)\" \\"
+  assert.ok(original.includes(q14Anchor), 'mutation anchor must hit the Q14 header')
+  const closedSet = original.indexOf("FROM (VALUES ('${SOAK_ORG1}'),('${SOAK_ORG2}'),('${SOAK_ORG3}')) AS target(org_id) LEFT JOIN attendance_calculation_rollout_state w4 ON w4.org_id = target.org_id LEFT JOIN attendance_calculation_context_source_state w7", original.indexOf(q14Anchor))
+  assert.ok(closedSet !== -1, 'mutation anchor must hit Q14ʼs closed-set universe')
+  const mutated = original.slice(0, closedSet)
+    + original.slice(closedSet).replace(
+      "FROM (VALUES ('${SOAK_ORG1}'),('${SOAK_ORG2}'),('${SOAK_ORG3}')) AS target(org_id)",
+      'FROM (SELECT DISTINCT org_id FROM attendance_calculation_rollout_state UNION SELECT DISTINCT org_id FROM attendance_calculation_context_source_state) target',
+    )
+  assert.notEqual(mutated, original, 'mutation must change the file')
+  assert.throws(
+    () => assertSoakContract({ remote: mutated, workflow: readFileSync(WORKFLOW, 'utf8') }),
+    /omits the legacy control org/,
   )
 })
 

--- a/scripts/ops/attendance-window-runner-pipeline.test.mjs
+++ b/scripts/ops/attendance-window-runner-pipeline.test.mjs
@@ -1365,8 +1365,10 @@ test('MUTATION (legacy control): reverting [Q14] to the posture-derived universe
   const original = readFileSync(REMOTE_SH, 'utf8')
   const q14Anchor = "org-count summary; config closed set)\" \\"
   assert.ok(original.includes(q14Anchor), 'mutation anchor must hit the Q14 header')
-  const closedSet = original.indexOf("FROM (VALUES ('${SOAK_ORG1}'),('${SOAK_ORG2}'),('${SOAK_ORG3}')) AS target(org_id) LEFT JOIN attendance_calculation_rollout_state w4 ON w4.org_id = target.org_id LEFT JOIN attendance_calculation_context_source_state w7", original.indexOf(q14Anchor))
-  assert.ok(closedSet !== -1, 'mutation anchor must hit Q14ʼs closed-set universe')
+  const q14Start = original.indexOf(q14Anchor)
+  const q14End = original.indexOf('posture rows for the three soak orgs', q14Start)
+  const closedSet = original.indexOf("FROM (VALUES ('${SOAK_ORG1}'),('${SOAK_ORG2}'),('${SOAK_ORG3}')) AS target(org_id) LEFT JOIN attendance_calculation_rollout_state w4 ON w4.org_id = target.org_id LEFT JOIN attendance_calculation_context_source_state w7", q14Start)
+  assert.ok(q14Start !== -1 && q14End !== -1 && closedSet !== -1 && closedSet < q14End, 'mutation anchor must hit Q14ʼs closed-set universe inside the Q14 block')
   const mutated = original.slice(0, closedSet)
     + original.slice(closedSet).replace(
       "FROM (VALUES ('${SOAK_ORG1}'),('${SOAK_ORG2}'),('${SOAK_ORG3}')) AS target(org_id)",
@@ -1375,7 +1377,9 @@ test('MUTATION (legacy control): reverting [Q14] to the posture-derived universe
   assert.notEqual(mutated, original, 'mutation must change the file')
   assert.throws(
     () => assertSoakContract({ remote: mutated, workflow: readFileSync(WORKFLOW, 'utf8') }),
-    /omits the legacy control org/,
+    // Q14's OWN message only (#5008 gate P2: the loose /omits the legacy control org/ was
+    // a substring of Q3's message too, so the oracle could not tell which site it tested).
+    /\[Q14\] must derive its universe/,
   )
 })
 


### PR DESCRIPTION
## Post-merge review P3 — accepted

**[Q14]** derived its universe from the two posture state tables, so the org-count summary showed only two rows and omitted the `legacy_only` control org (which by design has no state rows) — misleading for on-duty readers. Acceptance (C1-C3) reads Q1-Q3 and was unaffected. Q14 now uses the same config `VALUES` closed set as Q2/Q3. **Display-only**: no alert condition reads Q14, so live-window verdict semantics are untouched.

En route: the new Q14 SQL collided with Q3's universe pin/mutation anchors (third anchor-ambiguity in this family) — Q3's pin and leg are now **label/position-bounded inside the [Q3] block**, closing the ambiguity class.

Also reaffirmed (per the same review, aligned with our ledger): the standing `W7_CRITICAL_SHADOW_DIFF=40` alert is the §5.2-signed window-cumulative explained family; **count-criteria-met ≠ soak complete** — human tail, W8, and the owner's closure ruling on #4556 remain ahead.

Pipeline **72/72** · census 58/58.

🤖 Generated with [Claude Code](https://claude.com/claude-code)