### PR TITLE
fix(web): attendance rules/me honors the SR-1 self-service contract (omit subject-override headers)

### DIFF
--- a/apps/web/scripts/run-required-web-tests.sh
+++ b/apps/web/scripts/run-required-web-tests.sh
@@ -291,7 +291,12 @@
 set -euo pipefail
 cd "$(dirname "$0")/.."
 # Always-on Canvas V2 + residual PLAN 6fa2fbf6 / wave-3 canaries (files landed on main via #4815–#4826).
+# #5012 (2026-08-19, human-tail finding): tests/api.spec.ts carries the omitHeaders
+# MECHANIC leg (SR-1 rules/me self-service contract) — it ran in NO workflow before, so
+# reverting the apiFetch delete-loop was green across every required check. Full path
+# token: a bare `api.spec.ts` would substring-match other *-api specs.
 npx vitest run \
+  tests/api.spec.ts \
   approval-canvas-commands \
   approval-form-commands \
   approval-authoring-history \

--- a/apps/web/scripts/run-required-web-tests.sh
+++ b/apps/web/scripts/run-required-web-tests.sh
@@ -293,10 +293,16 @@ cd "$(dirname "$0")/.."
 # Always-on Canvas V2 + residual PLAN 6fa2fbf6 / wave-3 canaries (files landed on main via #4815–#4826).
 # #5012 (2026-08-19, human-tail finding): tests/api.spec.ts carries the omitHeaders
 # MECHANIC leg (SR-1 rules/me self-service contract) — it ran in NO workflow before, so
-# reverting the apiFetch delete-loop was green across every required check. Full path
-# token: a bare `api.spec.ts` would substring-match other *-api specs.
+# reverting the apiFetch delete-loop was green across every required check.
+# tests/attendance-rules-me-contract-sync.spec.ts pins the FE omit set against the
+# server's forbidden set BY READING THE PLUGIN SOURCE; it must live in THIS always-on
+# lane because attendance-web-guard skips vitest for plugins/**-only diffs.
+# These two are the first path-prefixed tokens in this bare-basename list — full paths
+# chosen for exactness (a future `*-api.spec.ts` would substring-collide with a bare
+# `api.spec.ts` token; today the bare token still selects exactly one file).
 npx vitest run \
   tests/api.spec.ts \
+  tests/attendance-rules-me-contract-sync.spec.ts \
   approval-canvas-commands \
   approval-form-commands \
   approval-authoring-history \

--- a/apps/web/src/utils/api.ts
+++ b/apps/web/src/utils/api.ts
@@ -25,6 +25,15 @@ let authRedirecting = false
 
 export interface ApiFetchOptions extends RequestInit {
   suppressUnauthorizedRedirect?: boolean
+  /**
+   * Header names to REMOVE after the global auth headers are applied. Needed for
+   * self-service routes whose contract REJECTS subject-override headers instead of
+   * ignoring them (e.g. attendance `rules/me`, SR-1): `authHeaders()` injects
+   * `x-tenant-id` globally, and a caller cannot un-send it by overriding the value —
+   * the guard fires on header PRESENCE. Deleting is the only spelling that honors
+   * the route contract.
+   */
+  omitHeaders?: readonly string[]
 }
 
 function resolveWindowOrigin(): string {
@@ -219,11 +228,12 @@ export async function apiFetch(
   options: ApiFetchOptions = {},
 ): Promise<Response> {
   const base = getApiBase()
-  const { suppressUnauthorizedRedirect = false, ...requestOptions } = options
+  const { suppressUnauthorizedRedirect = false, omitHeaders = [], ...requestOptions } = options
   const headers = new Headers({
     ...authHeaders(),
     ...(requestOptions.headers || {}),
   })
+  for (const name of omitHeaders) headers.delete(name)
   const body = requestOptions.body
   const isFormData = typeof FormData !== 'undefined' && body instanceof FormData
   if (!isFormData && body != null && !headers.has('Content-Type')) {

--- a/apps/web/src/views/AttendanceView.vue
+++ b/apps/web/src/views/AttendanceView.vue
@@ -24593,7 +24593,13 @@ async function loadSelfAttendanceRules(): Promise<void> {
   selfRulesLoading.value = true
   selfRulesError.value = null
   try {
-    const response = await apiFetch('/api/attendance/rules/me')
+    // SR-1 self-service contract: rules/me REJECTS subject-override headers (including
+    // the globally injected x-tenant-id) instead of ignoring them — subject and org come
+    // from the token alone. Human-tail finding 2026-08-19: real browsers with a tenant
+    // hint got a 400 banner here; synthetic traffic never sends the header.
+    const response = await apiFetch('/api/attendance/rules/me', {
+      omitHeaders: ['x-tenant-id', 'x-user-id', 'x-org-id', 'x-workspace-id', 'x-group-id'],
+    })
     const data = await response.json().catch(() => null)
     if (!response.ok || !data?.ok) {
       throw createApiError(response, data, tr('Failed to load your attendance rules', '加载您的考勤规则失败'))

--- a/apps/web/src/views/AttendanceView.vue
+++ b/apps/web/src/views/AttendanceView.vue
@@ -24598,7 +24598,18 @@ async function loadSelfAttendanceRules(): Promise<void> {
     // from the token alone. Human-tail finding 2026-08-19: real browsers with a tenant
     // hint got a 400 banner here; synthetic traffic never sends the header.
     const response = await apiFetch('/api/attendance/rules/me', {
-      omitHeaders: ['x-tenant-id', 'x-user-id', 'x-org-id', 'x-workspace-id', 'x-group-id'],
+      // The COMPLETE server-side forbidden set (index.cjs
+      // ATTENDANCE_RULES_ME_FORBIDDEN_HEADER_KEYS, 7 keys) — a partial copy would leave
+      // the 400 banner reachable for whichever hint type it missed (#5012 gate P3-1).
+      omitHeaders: [
+        'x-user-id',
+        'x-org-id',
+        'x-tenant-id',
+        'x-workspace-id',
+        'x-group-id',
+        'x-attendance-group-id',
+        'x-schedule-group-id',
+      ],
     })
     const data = await response.json().catch(() => null)
     if (!response.ok || !data?.ok) {

--- a/apps/web/src/views/AttendanceView.vue
+++ b/apps/web/src/views/AttendanceView.vue
@@ -10154,6 +10154,7 @@ import {
   type AttendanceLeaveQuickFillKind,
   type AttendanceLeaveQuickFillShiftWindow,
 } from './attendance/halfDayLeaveHelper'
+import { ATTENDANCE_RULES_ME_OMIT_HEADERS } from './attendance/rulesMeContract'
 import { usePlugins } from '../composables/usePlugins'
 import { apiFetch } from '../utils/api'
 import { readErrorMessage } from '../utils/error'
@@ -24598,18 +24599,9 @@ async function loadSelfAttendanceRules(): Promise<void> {
     // from the token alone. Human-tail finding 2026-08-19: real browsers with a tenant
     // hint got a 400 banner here; synthetic traffic never sends the header.
     const response = await apiFetch('/api/attendance/rules/me', {
-      // The COMPLETE server-side forbidden set (index.cjs
-      // ATTENDANCE_RULES_ME_FORBIDDEN_HEADER_KEYS, 7 keys) — a partial copy would leave
-      // the 400 banner reachable for whichever hint type it missed (#5012 gate P3-1).
-      omitHeaders: [
-        'x-user-id',
-        'x-org-id',
-        'x-tenant-id',
-        'x-workspace-id',
-        'x-group-id',
-        'x-attendance-group-id',
-        'x-schedule-group-id',
-      ],
+      // The COMPLETE server forbidden set, via the ONE shared contract mirror — the
+      // required-lane fixture-sync spec pins it against the server source (#5012).
+      omitHeaders: ATTENDANCE_RULES_ME_OMIT_HEADERS,
     })
     const data = await response.json().catch(() => null)
     if (!response.ok || !data?.ok) {

--- a/apps/web/src/views/attendance/rulesMeContract.ts
+++ b/apps/web/src/views/attendance/rulesMeContract.ts
@@ -9,6 +9,11 @@
  * required-lane fixture-sync spec (attendance-selfservice-dashboard.spec.ts) compares
  * this array against the server source itself, so an 8th server key reds CI here
  * instead of silently re-opening the 400 banner for that hint type.
+ *
+ * Scope note: this mirrors the HEADER half of the server contract only. The server
+ * additionally rejects subject-override keys in query/body
+ * (ATTENDANCE_RULES_ME_FORBIDDEN_QUERY_KEYS) — the single call site sends neither,
+ * so there is nothing to omit on that half.
  */
 export const ATTENDANCE_RULES_ME_OMIT_HEADERS: readonly string[] = Object.freeze([
   'x-user-id',

--- a/apps/web/src/views/attendance/rulesMeContract.ts
+++ b/apps/web/src/views/attendance/rulesMeContract.ts
@@ -6,7 +6,7 @@
  * deliberately, never silently ignoring them — while the web app's `authHeaders()`
  * injects `x-tenant-id` globally. Every rules/me call must therefore omit EXACTLY this
  * set. ONE exported constant so the call site and the specs share a single copy; the
- * required-lane fixture-sync spec (attendance-selfservice-dashboard.spec.ts) compares
+ * required-lane fixture-sync spec (attendance-rules-me-contract-sync.spec.ts) compares
  * this array against the server source itself, so an 8th server key reds CI here
  * instead of silently re-opening the 400 banner for that hint type.
  *

--- a/apps/web/src/views/attendance/rulesMeContract.ts
+++ b/apps/web/src/views/attendance/rulesMeContract.ts
@@ -1,0 +1,21 @@
+/**
+ * SR-1 self-service contract mirror for `GET /api/attendance/rules/me` (#5012).
+ *
+ * The server REJECTS subject-override headers on PRESENCE
+ * (`ATTENDANCE_RULES_ME_FORBIDDEN_HEADER_KEYS`, plugins/plugin-attendance/index.cjs) —
+ * deliberately, never silently ignoring them — while the web app's `authHeaders()`
+ * injects `x-tenant-id` globally. Every rules/me call must therefore omit EXACTLY this
+ * set. ONE exported constant so the call site and the specs share a single copy; the
+ * required-lane fixture-sync spec (attendance-selfservice-dashboard.spec.ts) compares
+ * this array against the server source itself, so an 8th server key reds CI here
+ * instead of silently re-opening the 400 banner for that hint type.
+ */
+export const ATTENDANCE_RULES_ME_OMIT_HEADERS: readonly string[] = Object.freeze([
+  'x-user-id',
+  'x-org-id',
+  'x-tenant-id',
+  'x-workspace-id',
+  'x-group-id',
+  'x-attendance-group-id',
+  'x-schedule-group-id',
+])

--- a/apps/web/tests/api.spec.ts
+++ b/apps/web/tests/api.spec.ts
@@ -27,6 +27,29 @@ describe('apiFetch', () => {
     }
   })
 
+  it('omitHeaders deletes globally injected headers AFTER auth headers apply (SR-1 self-service mechanic, #5012)', async () => {
+    store.tenantId = 'tenant_42'
+    store.auth_token = 'token-abc'
+
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200, statusText: 'OK' })
+    vi.stubGlobal('fetch', fetchMock)
+
+    // POSITIVE CONTROL: without omitHeaders the hint IS sent — proves the omit case
+    // below discriminates rather than passing against a hint that was never there.
+    await apiFetch('/api/attendance/rules/me', { suppressUnauthorizedRedirect: true })
+    const controlHeaders = fetchMock.mock.calls[0]?.[1]?.headers as Headers
+    expect(controlHeaders.get('x-tenant-id')).toBe('tenant_42')
+
+    await apiFetch('/api/attendance/rules/me', {
+      suppressUnauthorizedRedirect: true,
+      omitHeaders: ['x-tenant-id'],
+    })
+    const omittedHeaders = fetchMock.mock.calls[1]?.[1]?.headers as Headers
+    expect(omittedHeaders.has('x-tenant-id')).toBe(false)
+    // Non-subject headers survive the omit.
+    expect(omittedHeaders.get('authorization')).toBe('Bearer token-abc')
+  })
+
   it('forwards the stored tenant hint through auth headers', async () => {
     store.tenantId = 'tenant_42'
 

--- a/apps/web/tests/attendance-rules-me-contract-sync.spec.ts
+++ b/apps/web/tests/attendance-rules-me-contract-sync.spec.ts
@@ -28,6 +28,13 @@ describe('rules/me FE omit set ↔ server forbidden set sync', () => {
     const serverKeys = [...(anchor as RegExpMatchArray)[1].matchAll(/['"]([^'"]+)['"]/g)].map(
       (m) => m[1],
     )
+    // Structural, not enumerated (枚举陷阱不收敛): every comma-separated entry in the
+    // capture must have yielded a key — an entry in ANY unrecognized delimiter
+    // (backtick, template literal, bare identifier) reds this instead of vanishing.
+    const entryCount = (anchor as RegExpMatchArray)[1]
+      .split(',')
+      .filter((entry) => entry.trim().length > 0).length
+    expect(serverKeys.length).toBe(entryCount)
     expect(serverKeys.length).toBeGreaterThan(0)
     expect([...ATTENDANCE_RULES_ME_OMIT_HEADERS].sort()).toEqual([...serverKeys].sort())
   })

--- a/apps/web/tests/attendance-rules-me-contract-sync.spec.ts
+++ b/apps/web/tests/attendance-rules-me-contract-sync.spec.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { ATTENDANCE_RULES_ME_OMIT_HEADERS } from '../src/views/attendance/rulesMeContract'
+
+/**
+ * FE↔server key-set sync for the rules/me SR-1 header contract (#5012).
+ *
+ * Standalone spec ON PURPOSE (gate round-3 P2-1): it lives in the always-on
+ * `web-tests` required lane, so a PR that edits ONLY the plugin source still runs
+ * it — attendance-web-guard's classifier skips vitest entirely for plugins/**
+ * changes, which made the previous in-dashboard placement blind to exactly the
+ * server-only drift it exists to catch. readFileSync-only, no Vue mount, so it
+ * never touches the attendance component quarantine.
+ */
+describe('rules/me FE omit set ↔ server forbidden set sync', () => {
+  it('the shared FE constant equals ATTENDANCE_RULES_ME_FORBIDDEN_HEADER_KEYS in the plugin source', () => {
+    const pluginSource = readFileSync(
+      join(__dirname, '../../../plugins/plugin-attendance/index.cjs'),
+      'utf8',
+    )
+    const anchor = pluginSource.match(
+      /const ATTENDANCE_RULES_ME_FORBIDDEN_HEADER_KEYS = new Set\(\[([^\]]+)\]\)/,
+    )
+    expect(anchor, 'server forbidden-set literal must be found in the plugin source').toBeTruthy()
+    // Both quote styles: plugins/ has no eslint config and index.cjs already mixes
+    // quoting, so a double-quoted 8th key must red this leg too (round-3 P3-1).
+    const serverKeys = [...(anchor as RegExpMatchArray)[1].matchAll(/['"]([^'"]+)['"]/g)].map(
+      (m) => m[1],
+    )
+    expect(serverKeys.length).toBeGreaterThan(0)
+    expect([...ATTENDANCE_RULES_ME_OMIT_HEADERS].sort()).toEqual([...serverKeys].sort())
+  })
+})

--- a/apps/web/tests/attendance-selfservice-dashboard.spec.ts
+++ b/apps/web/tests/attendance-selfservice-dashboard.spec.ts
@@ -4,8 +4,6 @@ import AttendanceView from '../src/views/AttendanceView.vue'
 import { useLocale } from '../src/composables/useLocale'
 import { apiFetch } from '../src/utils/api'
 import { ATTENDANCE_RULES_ME_OMIT_HEADERS } from '../src/views/attendance/rulesMeContract'
-import { readFileSync } from 'node:fs'
-import { join } from 'node:path'
 import { resolveMakeupPunchRequestStatusCopy } from '../src/views/attendance/makeupPunchRequestStatus'
 
 const authMockState = vi.hoisted(() => ({
@@ -705,24 +703,6 @@ describe('Attendance self-service dashboard', () => {
     }
   })
 
-  it('FIXTURE-SYNC: the FE omit set equals the SERVER forbidden set, read from the plugin source (#5012)', () => {
-    // Kills the silent-drift channel (#5012 gate round-2 P3): an 8th key added to the
-    // server's ATTENDANCE_RULES_ME_FORBIDDEN_HEADER_KEYS must red THIS spec instead of
-    // silently re-opening the 400 banner for that hint type. Same fixture-sync idiom as
-    // attendance-import-header-recognition.spec.ts (readFileSync + anchored regex +
-    // non-empty anchor assertion + sorted equality).
-    const pluginSource = readFileSync(
-      join(__dirname, '../../../plugins/plugin-attendance/index.cjs'),
-      'utf8',
-    )
-    const anchor = pluginSource.match(
-      /const ATTENDANCE_RULES_ME_FORBIDDEN_HEADER_KEYS = new Set\(\[([^\]]+)\]\)/,
-    )
-    expect(anchor, 'server forbidden-set literal must be found in the plugin source').toBeTruthy()
-    const serverKeys = [...(anchor as RegExpMatchArray)[1].matchAll(/'([^']+)'/g)].map((m) => m[1])
-    expect(serverKeys.length).toBeGreaterThan(0)
-    expect([...ATTENDANCE_RULES_ME_OMIT_HEADERS].sort()).toEqual([...serverKeys].sort())
-  })
 
   it('renders self-service cards with status, request summaries, quick actions, and status guide', async () => {
     app = createApp(AttendanceView, { mode: 'overview' })

--- a/apps/web/tests/attendance-selfservice-dashboard.spec.ts
+++ b/apps/web/tests/attendance-selfservice-dashboard.spec.ts
@@ -680,6 +680,35 @@ describe('Attendance self-service dashboard', () => {
     container = null
   })
 
+  it('rules/me is called with the COMPLETE SR-1 forbidden-header omit set (human-tail finding 2026-08-19)', async () => {
+    // The server rejects subject-override headers on PRESENCE (index.cjs
+    // ATTENDANCE_RULES_ME_FORBIDDEN_HEADER_KEYS, 7 keys); authHeaders() injects
+    // x-tenant-id globally, so the call site MUST pass omitHeaders with the full set —
+    // a partial copy leaves the 400 banner reachable for the missed hint type, and
+    // reverting the fix left every required check green until this leg existed
+    // (#5012 gate P2-1).
+    app = createApp(AttendanceView, { mode: 'overview' })
+    app.mount(container!)
+    await flushUi()
+
+    const rulesCalls = vi.mocked(apiFetch).mock.calls.filter(([input]) => {
+      const url = typeof input === 'string' ? input : (input as Request).url
+      return url.includes('/api/attendance/rules/me')
+    })
+    expect(rulesCalls.length).toBeGreaterThan(0)
+    for (const [, init] of rulesCalls) {
+      expect((init as { omitHeaders?: readonly string[] } | undefined)?.omitHeaders ?? []).toEqual([
+        'x-user-id',
+        'x-org-id',
+        'x-tenant-id',
+        'x-workspace-id',
+        'x-group-id',
+        'x-attendance-group-id',
+        'x-schedule-group-id',
+      ])
+    }
+  })
+
   it('renders self-service cards with status, request summaries, quick actions, and status guide', async () => {
     app = createApp(AttendanceView, { mode: 'overview' })
     app.mount(container!)

--- a/apps/web/tests/attendance-selfservice-dashboard.spec.ts
+++ b/apps/web/tests/attendance-selfservice-dashboard.spec.ts
@@ -3,6 +3,9 @@ import { createApp, nextTick, ref, type App } from 'vue'
 import AttendanceView from '../src/views/AttendanceView.vue'
 import { useLocale } from '../src/composables/useLocale'
 import { apiFetch } from '../src/utils/api'
+import { ATTENDANCE_RULES_ME_OMIT_HEADERS } from '../src/views/attendance/rulesMeContract'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
 import { resolveMakeupPunchRequestStatusCopy } from '../src/views/attendance/makeupPunchRequestStatus'
 
 const authMockState = vi.hoisted(() => ({
@@ -697,16 +700,28 @@ describe('Attendance self-service dashboard', () => {
     })
     expect(rulesCalls.length).toBeGreaterThan(0)
     for (const [, init] of rulesCalls) {
-      expect((init as { omitHeaders?: readonly string[] } | undefined)?.omitHeaders ?? []).toEqual([
-        'x-user-id',
-        'x-org-id',
-        'x-tenant-id',
-        'x-workspace-id',
-        'x-group-id',
-        'x-attendance-group-id',
-        'x-schedule-group-id',
-      ])
+      const omitted = (init as { omitHeaders?: readonly string[] } | undefined)?.omitHeaders ?? []
+      expect([...omitted].sort()).toEqual([...ATTENDANCE_RULES_ME_OMIT_HEADERS].sort())
     }
+  })
+
+  it('FIXTURE-SYNC: the FE omit set equals the SERVER forbidden set, read from the plugin source (#5012)', () => {
+    // Kills the silent-drift channel (#5012 gate round-2 P3): an 8th key added to the
+    // server's ATTENDANCE_RULES_ME_FORBIDDEN_HEADER_KEYS must red THIS spec instead of
+    // silently re-opening the 400 banner for that hint type. Same fixture-sync idiom as
+    // attendance-import-header-recognition.spec.ts (readFileSync + anchored regex +
+    // non-empty anchor assertion + sorted equality).
+    const pluginSource = readFileSync(
+      join(__dirname, '../../../plugins/plugin-attendance/index.cjs'),
+      'utf8',
+    )
+    const anchor = pluginSource.match(
+      /const ATTENDANCE_RULES_ME_FORBIDDEN_HEADER_KEYS = new Set\(\[([^\]]+)\]\)/,
+    )
+    expect(anchor, 'server forbidden-set literal must be found in the plugin source').toBeTruthy()
+    const serverKeys = [...(anchor as RegExpMatchArray)[1].matchAll(/'([^']+)'/g)].map((m) => m[1])
+    expect(serverKeys.length).toBeGreaterThan(0)
+    expect([...ATTENDANCE_RULES_ME_OMIT_HEADERS].sort()).toEqual([...serverKeys].sort())
   })
 
   it('renders self-service cards with status, request summaries, quick actions, and status guide', async () => {


### PR DESCRIPTION
## Human-tail finding #1 (2026-08-19, org2 tester, real browser)

`authHeaders()` injects `x-tenant-id` into every request; `GET /api/attendance/rules/me` — per its SR-1 hardening — **rejects subject-override headers on PRESENCE** (deliberately, never silently ignores). Any real browser carrying a tenant hint got a 400 red banner on the attendance overview. Synthetic traffic never sends the header — exactly the class only the human tail could surface. Punching unaffected.

## Fix
- `apiFetch` gains `omitHeaders` (deleted AFTER global headers apply — the guard fires on presence, so value-override cannot un-send).
- The rules/me call site omits **the complete 7-key server set** (`ATTENDANCE_RULES_ME_FORBIDDEN_HEADER_KEYS`), via ONE shared export `apps/web/src/views/attendance/rulesMeContract.ts`. (Round-1 shipped a 5-of-7 copy — gate P3-1 — now complete.)

## Test coverage — each claim below was probe-verified at the noted heads (83f897f242 / 88c777ebe2) (mutation applied, spec red, mutation restored, spec green)
- **Call-site contract** — `attendance-selfservice-dashboard.spec.ts` (required `attendance-web-guard`): every rules/me call carries exactly the shared 7-key set. This spec `vi.mock`s `utils/api`, so it pins the *call-site intent only* — it cannot see the delete mechanic (round-2 gate P2: the mechanic alone was revert-green at 9b0c1c7fb7).
- **Mechanic** — new leg in `tests/api.spec.ts` (real fetch mock, now a full-path token in `run-required-web-tests.sh` → required `web-tests`; this spec previously ran in NO workflow). Positive control: without `omitHeaders` the stored tenant hint IS sent; with it, `x-tenant-id` absent while `authorization` survives. **Probe B**: deleting only `for (const name of omitHeaders) headers.delete(name)` in api.ts → 1 failed / 2 passed.
- **FE↔server key-set sync** — standalone `tests/attendance-rules-me-contract-sync.spec.ts` reads the plugin source (anchored regex on `ATTENDANCE_RULES_ME_FORBIDDEN_HEADER_KEYS`, non-empty anchor assertion, both quote styles, sorted equality). It is a full-path token in `run-required-web-tests.sh` → required **`web-tests`, which has no path filter** — so a PR touching ONLY `plugins/plugin-attendance/index.cjs` still runs it (round-3 gate P2-1: the earlier in-dashboard placement ran in NO lane for that diff shape, since `attendance-web-guard` skips vitest for `plugins/**`-only changes; and the earlier single-quote-only regex let a double-quoted key pass — gate Probe D′). **Probes at 88c777ebe2**: single-quoted AND double-quoted 8th server key each red exactly this leg (1 failed/1), restore → green.
- Org-resolution safety chain verified by the round-1 gate (single-org users keep the token claim; multi-org-no-claim users get the same DEFAULT_ORG_ID every other attendance route already gives them).

Known residual (out of scope, tracked): `useAuth.ts buildAuthHeaders()` is a second injector off the rules/me path; gate-orphaned remainder of api.ts specs beyond this leg.

**Deploy note: main only — staging stays untouched until the human-tail window closes.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

