### PR TITLE
feat(multitable): O-2 enablement hardening — registration atomicity, 40001 classifier+census, lease backoff, enablement ladder (Time Machine stage-7)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -1063,8 +1063,10 @@ jobs:
             tests/integration/multitable-exact-anchor-apply-realdb.test.ts \
             tests/integration/multitable-exact-anchor-route-wiring-realdb.test.ts \
             tests/integration/multitable-recovery-authority-stability-realdb.test.ts \
+            tests/integration/multitable-recovery-lease-backoff-realdb.test.ts \
             tests/integration/multitable-recovery-authority-unavailable-failclosed-realdb.test.ts \
             tests/integration/multitable-recovery-foreign-fence-availability-realdb.test.ts \
+            tests/integration/recovery-conflict-classifier-realdb.test.ts \
             tests/integration/multitable-automation-marker-anchor-realdb.test.ts \
             tests/integration/multitable-d1c-form-submit-revision-realdb.test.ts \
             tests/integration/multitable-d1c-plugin-revision-realdb.test.ts \
@@ -1264,6 +1266,7 @@ jobs:
             tests/integration/directory-deprovision-compensation.db.test.ts \
             tests/integration/directory-activation-source-lock.db.test.ts \
             tests/integration/login-alias-writers.db.test.ts \
+            tests/integration/auth-register-atomicity.db.test.ts \
             tests/integration/directory-deprovision-ledger-schema.db.test.ts \
             tests/integration/directory-deprovision-writer-ledger.db.test.ts \
             tests/integration/directory-deprovision-race-supersede.db.test.ts \

--- a/docs/development/multitable-timemachine-o2-enablement-ladder-20260819.md
+++ b/docs/development/multitable-timemachine-o2-enablement-ladder-20260819.md
@@ -26,6 +26,9 @@ fail-closed（安全但全部失败）；先开 trigger 而平台写路径没做
 - [ ] O2-S1（注册同事务原子性）、O2-S2（40001 单一分类器 + 11 写者 census）、
       O2-S3（recovery 租约有界退避）已合 main 且随镜像部署到目标主机。
 - [ ] 目标主机 `postdeploy-full` containment PASS（当前镜像、pending migrations = 0）。
+- [ ] **census 可达性升级已闭合**（对抗门 P3-1：40001 census 目前只数 token 不辨死代码——
+      `if (false && …)` 化 9 处仍全绿；trigger DISABLED 期为 P3，**L1 打开 trigger 前必须**
+      把 census 升级为可达性/行为级或逐面补判别腿）。
 - [ ] 回滚路径演练过一次：`ALTER TABLE … DISABLE TRIGGER` 全量脚本 + 单 flag 移除步骤
       （见 §5），并重跑 postdeploy-full 验证回到 inert 姿态。
 

--- a/docs/development/multitable-timemachine-o2-enablement-ladder-20260819.md
+++ b/docs/development/multitable-timemachine-o2-enablement-ladder-20260819.md
@@ -1,0 +1,81 @@
+# 多维表 Time Machine O-2 启用阶梯（enablement ladder）— PROPOSED
+
+> Status: **PROPOSED**（本文档不自我批准；RATIFY = owner 在承载 PR 留 exact-SHA 批注）。
+> 本文档只定义**顺序与判据**，不执行任何一步。每一级台阶都是**独立的 owner/ops 动作**，
+> 文档合入 ≠ 任何 flag/trigger 变更授权。
+> 基线：#4654 closeout（merged `12f1f8c466`，inert 落地）+ 双主机 postdeploy-full PASS
+> （prod run `31650980676`、both run `31651250987`）。当前姿态：4 flag 全 unset、
+> 9 authority triggers DISABLED、无 `meta_links.foreign_record_id` FK。
+
+## 0. 为什么需要阶梯
+
+closeout 落的是**默认关闭的基座**。把它变成活能力涉及两类互相独立的开关：
+
+- **DB 侧**：8 张平台授权表上的 9 个 triggers（出厂 DISABLED）。ENABLE 后平台权限写路径
+  开始参与 recovery-authority 串行化 ⇒ 平台写者第一次真的会遇到 40001。
+- **应用侧**：4 个 env flag（`MULTITABLE_HISTORY_CONTIGUITY_STRICT` /
+  `MULTITABLE_ENABLE_WRITER_FENCE` / `MULTITABLE_ENABLE_SHEET_REVERT` /
+  `MULTITABLE_ENABLE_PIT_RESET`）。
+
+顺序错误的代价不对称：先开 flag 后开 trigger ⇒ recovery 对 `authorityLease='unavailable'`
+fail-closed（安全但全部失败）；先开 trigger 而平台写路径没做 40001 分类 ⇒ 用户可见 500
+（这正是 O2-S2 存在的理由）。所以**trigger 先行、flag 逐个、staging 先于生产**。
+
+## 1. 前置（L0，全部满足才允许 L1）
+
+- [ ] O2-S1（注册同事务原子性）、O2-S2（40001 单一分类器 + 11 写者 census）、
+      O2-S3（recovery 租约有界退避）已合 main 且随镜像部署到目标主机。
+- [ ] 目标主机 `postdeploy-full` containment PASS（当前镜像、pending migrations = 0）。
+- [ ] 回滚路径演练过一次：`ALTER TABLE … DISABLE TRIGGER` 全量脚本 + 单 flag 移除步骤
+      （见 §5），并重跑 postdeploy-full 验证回到 inert 姿态。
+
+## 2. 阶梯（每级 = 独立 owner 授权 + 观察期）
+
+**L1 — staging ENABLE triggers（flags 保持全 OFF）**
+9/9 triggers ENABLE（仅 staging）。flags 全 OFF ⇒ recovery 端点仍不可达，本级只暴露
+「平台写 × authority 串行化」。观察 ≥2 日历日：40001 发生率、S2 分类器命中
+（409/具名 retryable，**零** unmapped 500）、平台写延迟无回归。
+
+**L2 — staging `MULTITABLE_HISTORY_CONTIGUITY_STRICT=1`**
+只读侧收严（历史链断裂拒绝重建）。观察：strict 拒绝率 = 预期（合成断链演练拒绝、
+正常表通过），无误伤。
+
+**L3 — staging `MULTITABLE_ENABLE_WRITER_FENCE=1`**
+写者围栏可达。观察：普通写路径无回归；S3 退避在写者间隙内拿到租约（演练）；
+写者不停时 recovery 仍具名 busy（fail-closed 不变）。
+
+**L4 — staging `MULTITABLE_ENABLE_SHEET_REVERT=1`（canary）**
+在**具名合成 org**（禁客户数据）上执行 revert 演练：precise-anchor 成功、
+preview-drift abort 正控、trash/link 状态核对。
+
+**L5 — staging `MULTITABLE_ENABLE_PIT_RESET=1`（canary）** — 同 L4 纪律做 reset 演练。
+
+**L6 — staging soak**：全开姿态 ≥7 日历日。判据（全部满足才可申请生产）：
+零 unmapped 40001（=零该类 500）、零 40P01、零 containment 意外、canary 演练全绿、
+recovery busy-exhaustion 率在口径内。
+
+**L7+ — 生产**：重复 L1→L5（同序、同判据、独立授权、canary org 另立）。任一观察不达
+⇒ 停在当前级或回滚一级，**不跳级、不补授权**。
+
+## 3. 每级通用规则
+
+授权 = owner 亲笔（exact 内容 + 目标环境 + 级别）；执行后立即跑 `postdeploy-full`
+（containment workflow 的 flag 腿此时**预期红**的项须与本级声明的开启集合精确一致——
+差一个即回滚）；观察窗内新增 P1/P2 ⇒ 冻结阶梯。
+
+## 4. 已登记残余（启用面不扩，此处只登记处置）
+
+- **foreign-fence 共享查找表形状**（FK KEY SHARE vs 行锁 FOR UPDATE，pre-existing）：
+  可用性问题非死锁；L4/L5 canary 演练须包含一次 link-in 表并发写场景确认无 40P01。
+  根治（围栏全部 link-in sheet 或弱化记录锁）留独立立项。
+- **retention 后恢复 / 整表 resurrect / 归档异步恢复（Phase D）**：与本阶梯无耦合，
+  另立设计锁。
+- **`#4446` resurrect 参考件**：reference-only（`multitable-4446-resurrect-reference-design-20260812.md`），
+  不随本阶梯启用。
+
+## 5. 回滚（每级可逆，单向依次撤）
+
+flag 级：从 compose/env 移除该 flag → 重启 → `predeploy-flags` 验证该 flag CONTAINED。
+trigger 级（大红开关）：9/9 `DISABLE TRIGGER` → `postdeploy-full` 验证回到出厂 inert
+指纹（`8c1be0b0…`/`14c180aa…` 仍应精确匹配——DISABLE 不改函数体）。
+回滚不需要迁移、不丢数据（authority locks 表保留，无消费者时惰性）。

--- a/packages/core-backend/src/auth/AuthService.ts
+++ b/packages/core-backend/src/auth/AuthService.ts
@@ -20,6 +20,7 @@ import {
   findUserIdByLoginAlias,
   isAuthLoginAliasCutoverEnabled,
 } from './login-alias-service'
+import type { AliasQueryClient } from './login-alias-service'
 import { evaluateUserAuthenticationGate } from './user-activation'
 import { isRecoveryAuthorityBusyError } from '../multitable/recovery-authorization-stability'
 
@@ -69,14 +70,17 @@ export interface AuthConfig {
 const ATTENDANCE_SELF_SERVICE_ROLE_ID = 'attendance_employee'
 const ATTENDANCE_SELF_SERVICE_PERMISSIONS = ['attendance:read', 'attendance:write'] as const
 
-// P23: user_roles is one of exact-anchor recovery's eight recovery-authority tables. A write
-// that lands while recovery holds the per-subject lease fails fast with Postgres SQLSTATE
-// 40001 (see recovery-authorization-stability.ts's isRecoveryAuthorityBusyError /
-// RECOVERY_AUTHORITY_BUSY_MARKER — reused here, not re-derived). That is transient and
-// retryable, so assignUserRoles below retries it a bounded number of times in-process before
-// giving up. USER_ROLE_ASSIGNMENT_RETRY_LIMIT is the total number of INSERT attempts (not
-// "retries after the first"); the backoff is small because assignUserRoles is also reached
-// from the read-path backfill in resolveRbacProfile, so a busy lease must not add much
+// P23: user_roles (and users) are among exact-anchor recovery's eight recovery-authority
+// tables. A write that lands while recovery holds the per-subject lease fails fast with
+// Postgres SQLSTATE 40001 (see recovery-authorization-stability.ts's
+// isRecoveryAuthorityBusyError / RECOVERY_AUTHORITY_BUSY_MARKER — reused here, not
+// re-derived). That is transient and retryable, so both retry sites below reuse these
+// constants: assignUserRoles retries its standalone INSERT a bounded number of times
+// in-process (read-path backfill in resolveRbacProfile), and register() retries its WHOLE
+// user-creation transaction the same bounded number of times (O2-S1 — a 40001 aborts the
+// open transaction, so per-statement retry inside it is impossible; the retry unit is the
+// transaction). USER_ROLE_ASSIGNMENT_RETRY_LIMIT is the total number of attempts (not
+// "retries after the first"); the backoff is small because a busy lease must not add much
 // latency to every authenticated request for a user missing attendance permissions.
 export const USER_ROLE_ASSIGNMENT_RETRY_LIMIT = 3
 const USER_ROLE_ASSIGNMENT_RETRY_BASE_DELAY_MS = 20
@@ -434,28 +438,65 @@ export class AuthService {
 
       // 创建用户
       const userId = crypto.randomUUID()
-      const newUser = await this.createUser({
-        id: userId,
-        email,
-        name,
-        password_hash: passwordHash,
-        role: 'user',
-        permissions: registrationPermissions
-      })
+      const selfServiceRoleIds = enableAttendanceSelfService
+        ? [ATTENDANCE_SELF_SERVICE_ROLE_ID]
+        : []
 
-      if (newUser && enableAttendanceSelfService) {
-        await this.assignUserRoles(userId, [ATTENDANCE_SELF_SERVICE_ROLE_ID])
+      // P23 / O2-S1: user creation and self-service role assignment are ONE transaction —
+      // the users, user_login_aliases, user_permissions and user_roles rows all commit or
+      // none do. user_roles (and users) are recovery-authority tables, so any of these
+      // writes can fail fast with 40001 while recovery holds the per-subject lease; a 40001
+      // aborts the whole open transaction (later statements would fail with 25P02), so the
+      // bounded retry re-runs the WHOLE transaction, reusing the same retry-limit/backoff
+      // constants assignUserRoles has always used. Exhaustion throws the same named
+      // UserRoleAssignmentRecoveryBusyError — but now with zero residue, unlike the
+      // pre-slice shape where the user row stayed committed while the role was missing.
+      const pool = poolManager.get()
+      for (let attempt = 1; ; attempt++) {
+        let newUser: User | null
+        try {
+          newUser = await pool.transaction(async (client) => {
+            const created = await this.createUserInTransaction(client, {
+              id: userId,
+              email,
+              name,
+              password_hash: passwordHash,
+              role: 'user',
+              permissions: registrationPermissions,
+            })
+            if (created && selfServiceRoleIds.length > 0) {
+              await this.insertUserRolesOnce(client, userId, selfServiceRoleIds)
+            }
+            return created
+          })
+        } catch (txnError) {
+          if (isRecoveryAuthorityBusyError(txnError)) {
+            if (attempt >= USER_ROLE_ASSIGNMENT_RETRY_LIMIT) {
+              throw new UserRoleAssignmentRecoveryBusyError(userId, selfServiceRoleIds, txnError)
+            }
+            await delay(USER_ROLE_ASSIGNMENT_RETRY_BASE_DELAY_MS * 2 ** (attempt - 1))
+            continue
+          }
+          // Non-retryable DB failure keeps the historical createUser swallow: warn + null
+          // (e.g. an alias conflict has rolled the whole transaction back, fail-closed).
+          this.logger.warn('Database insert failed', txnError instanceof Error ? txnError : undefined)
+          return null
+        }
+        if (newUser && selfServiceRoleIds.length > 0) {
+          // Only after the transaction actually committed — invalidating before commit
+          // could refill the cache from a state the commit then supersedes.
+          invalidateUserPerms(userId)
+        }
+        return newUser
       }
-
-      return newUser
     } catch (error) {
       this.logger.error('Registration error', error instanceof Error ? error : undefined)
-      // P23: the user row may already be committed (createUser succeeded) while role
-      // assignment could not persist after bounded retries. Re-throw so the caller (the
-      // registration route in routes/auth.ts, which wraps this call in its own try/catch)
-      // sees a failure instead of a fabricated success with a missing role — never swallow
-      // this one to `null` alongside the ordinary "email already exists" case. Every other
-      // error keeps the existing swallow-to-null behavior.
+      // P23: bounded whole-transaction retries exhausted against a busy recovery lease.
+      // Everything rolled back (no user/alias/permission/role residue — O2-S1), but
+      // re-throw so the caller (the registration route in routes/auth.ts, which wraps this
+      // call in its own try/catch) sees a retryable failure instead of a fabricated
+      // success — never swallow this one to `null` alongside the ordinary "email already
+      // exists" case. Every other error keeps the existing swallow-to-null behavior.
       if (error instanceof UserRoleAssignmentRecoveryBusyError) throw error
       return null
     }
@@ -683,79 +724,93 @@ export class AuthService {
   }
 
   /**
-   * 创建新用户
+   * 创建新用户 — runs inside the CALLER's open transaction (O2-S1).
+   *
+   * The only caller is register(), which owns the pool.transaction wrapper so that the
+   * self-service user_roles insert commits or rolls back atomically with the users row.
+   * Errors propagate to the transaction owner — retry/swallow semantics live there, because
+   * after a 40001 the transaction is aborted and nothing here could be retried in place.
    *
    * Load-bearing alias writer hook: activated self-registration must claim the email
    * login alias in the same transaction as the users row. Removing
    * claimNonEmptyLoginAliasesOrThrow here must fail tests/unit/login-alias-writers.test.ts
    * and tests/integration/login-alias-writers.db.test.ts (auth_register class).
+   * An alias conflict throws and rolls back the users insert (fail-closed).
    */
-  private async createUser(userData: {
-    id: string
-    email: string
-    name: string
-    password_hash: string
-    role: string
-    permissions: string[]
-  }): Promise<User | null> {
-    try {
-      try {
-        const pool = poolManager.get()
-        const permissionsJson = JSON.stringify(userData.permissions)
-        // Transaction required: alias conflict must roll back the users insert (fail-closed).
-        const created = await pool.transaction(async (client) => {
-          const result = await client.query(
-            `INSERT INTO users (
-               id, email, name, password_hash, role, permissions,
-               activation_status, local_password_set, is_active,
-               created_at, updated_at
-             )
-             VALUES ($1, $2, $3, $4, $5, $6::jsonb, 'activated', TRUE, TRUE, NOW(), NOW())
-             RETURNING id, email, name, role, permissions, must_change_password,
-                       activation_status, local_password_set, is_active, created_at, updated_at`,
-            [userData.id, userData.email, userData.name, userData.password_hash, userData.role, permissionsJson],
-          )
+  private async createUserInTransaction(
+    client: AliasQueryClient,
+    userData: {
+      id: string
+      email: string
+      name: string
+      password_hash: string
+      role: string
+      permissions: string[]
+    },
+  ): Promise<User | null> {
+    const permissionsJson = JSON.stringify(userData.permissions)
+    const result = await client.query(
+      `INSERT INTO users (
+         id, email, name, password_hash, role, permissions,
+         activation_status, local_password_set, is_active,
+         created_at, updated_at
+       )
+       VALUES ($1, $2, $3, $4, $5, $6::jsonb, 'activated', TRUE, TRUE, NOW(), NOW())
+       RETURNING id, email, name, role, permissions, must_change_password,
+                 activation_status, local_password_set, is_active, created_at, updated_at`,
+      [userData.id, userData.email, userData.name, userData.password_hash, userData.role, permissionsJson],
+    )
 
-          if (result.rows.length === 0) return null
+    if (result.rows.length === 0) return null
 
-          // Alias full-writer: claim non-empty identifiers (email for self-registration).
-          await claimNonEmptyLoginAliasesOrThrow({
-            userId: userData.id,
-            email: userData.email,
-            source: 'auth_register',
-            client,
-          })
+    // Alias full-writer: claim non-empty identifiers (email for self-registration).
+    await claimNonEmptyLoginAliasesOrThrow({
+      userId: userData.id,
+      email: userData.email,
+      source: 'auth_register',
+      client,
+    })
 
-          if (userData.permissions.length > 0) {
-            const values = userData.permissions.map((_, index) => `($1, $${index + 2})`).join(', ')
-            await client.query(
-              `INSERT INTO user_permissions (user_id, permission_code)
-               VALUES ${values}
-               ON CONFLICT DO NOTHING`,
-              [userData.id, ...userData.permissions],
-            )
-          }
+    if (userData.permissions.length > 0) {
+      const values = userData.permissions.map((_, index) => `($1, $${index + 2})`).join(', ')
+      await client.query(
+        `INSERT INTO user_permissions (user_id, permission_code)
+         VALUES ${values}
+         ON CONFLICT DO NOTHING`,
+        [userData.id, ...userData.permissions],
+      )
+    }
 
-          const row = result.rows[0] as User
-          return {
-            id: row.id,
-            email: row.email,
-            name: row.name,
-            role: row.role,
-            permissions: Array.isArray(row.permissions) ? row.permissions : [],
-            must_change_password: row.must_change_password,
-            created_at: row.created_at,
-            updated_at: row.updated_at,
-          }
-        })
-        return created
-      } catch (dbError) {
-        this.logger.warn('Database insert failed', dbError instanceof Error ? dbError : undefined)
-      }
-      return null
-    } catch (error) {
-      this.logger.error('Create user error', error instanceof Error ? error : undefined)
-      return null
+    const row = result.rows[0] as User
+    return {
+      id: row.id,
+      email: row.email,
+      name: row.name,
+      role: row.role,
+      permissions: Array.isArray(row.permissions) ? row.permissions : [],
+      must_change_password: row.must_change_password,
+      created_at: row.created_at,
+      updated_at: row.updated_at,
+    }
+  }
+
+  /**
+   * Single-shot user_roles insert against the given query surface (pool for the standalone
+   * retry loop in assignUserRoles, transaction client for register). Deliberately does NOT
+   * retry or invalidate caches — the caller owns both.
+   */
+  private async insertUserRolesOnce(
+    client: AliasQueryClient,
+    userId: string,
+    roleIds: readonly string[],
+  ): Promise<void> {
+    for (const roleId of roleIds) {
+      await client.query(
+        `INSERT INTO user_roles (user_id, role_id)
+         VALUES ($1, $2)
+         ON CONFLICT DO NOTHING`,
+        [userId, roleId]
+      )
     }
   }
 
@@ -764,14 +819,7 @@ export class AuthService {
     const pool = poolManager.get()
     for (let attempt = 1; ; attempt++) {
       try {
-        for (const roleId of roleIds) {
-          await pool.query(
-            `INSERT INTO user_roles (user_id, role_id)
-             VALUES ($1, $2)
-             ON CONFLICT DO NOTHING`,
-            [userId, roleId]
-          )
-        }
+        await this.insertUserRolesOnce(pool, userId, roleIds)
         invalidateUserPerms(userId)
         return
       } catch (error) {

--- a/packages/core-backend/src/auth/dingtalk-oauth.ts
+++ b/packages/core-backend/src/auth/dingtalk-oauth.ts
@@ -24,6 +24,7 @@ import {
   LoginAliasClaimError,
 } from './login-alias-service'
 import { recordDingTalkOAuthStateFallback, recordDingTalkOAuthStateOperation } from '../metrics/metrics'
+import { translateRecoveryConflict } from '../db/recovery-conflict'
 import {
   lockUsersForAccessGraphWrite,
   supersedeDeprovisionEvidenceForAccessGraphWrite,
@@ -821,7 +822,10 @@ async function createProvisionedUser(dtUser: DingTalkUserInfo): Promise<LocalUse
     // Load-bearing alias writer hook: claim real email/mobile inside the same transaction
     // as the JIT users insert. Removing claimNonEmptyLoginAliasesOrThrow must fail the
     // dingtalk_jit writer tests. Placeholder email is intentionally omitted from claims.
-    const row = await transaction(async (client) => {
+    // O2-S2: the JIT INSERT into users (a recovery-authority table) under a held recovery
+    // lease fails with the marker 40001 → named retryable RecoveryConflictError. Strictly
+    // additive: every other error falls through the fail-closed mappings below unchanged.
+    const row = await translateRecoveryConflict(() => transaction(async (client) => {
       // Persist real mobile on users.mobile in the same transaction as the alias claim.
       // Claiming a mobile login alias without storing users.mobile left profile/login
       // mirrors inconsistent under T2a OR-column reads.
@@ -857,7 +861,7 @@ async function createProvisionedUser(dtUser: DingTalkUserInfo): Promise<LocalUse
       }
 
       return created
-    })
+    }))
     return row
   } catch (error) {
     if (error instanceof LoginAliasClaimError && error.code === 'ALIAS_CONFLICT') {
@@ -1282,7 +1286,10 @@ export async function bindDingTalkIdentityToUser(input: {
   const openId = dtUser.openId || ''
   const unionId = dtUser.unionId || ''
 
-  await transaction(async (client) => {
+  // O2-S2: bind runs under the access-graph users mutex — a marker 40001 (recovery lease
+  // held) re-raises as the named retryable RecoveryConflictError; every policy error and
+  // fail-closed path below rethrows unchanged.
+  await translateRecoveryConflict(() => transaction(async (client) => {
     const lockedUsers = await lockUsersForAccessGraphWrite(client, [localUserId])
     if (!lockedUsers.has(localUserId)) {
       throw createPolicyError('Local user no longer exists', {
@@ -1393,7 +1400,7 @@ export async function bindDingTalkIdentityToUser(input: {
         reason: 'DingTalk identity bound by OAuth callback',
       })
     }
-  })
+  }))
 }
 
 export async function unbindSelfManagedDingTalkIdentity(input: {
@@ -1404,7 +1411,9 @@ export async function unbindSelfManagedDingTalkIdentity(input: {
   const actorId = String(input.actorId || '').trim() || localUserId
   if (!localUserId) throw new Error('localUserId is required')
 
-  return transaction(async (client) => {
+  // O2-S2: unbind runs under the access-graph users mutex — marker 40001 → named
+  // retryable RecoveryConflictError; every other error rethrows unchanged.
+  return translateRecoveryConflict(() => transaction(async (client) => {
     const lockedUsers = await lockUsersForAccessGraphWrite(client, [localUserId])
     if (!lockedUsers.has(localUserId)) {
       throw createPolicyError('Local user no longer exists', {
@@ -1447,7 +1456,7 @@ export async function unbindSelfManagedDingTalkIdentity(input: {
       reason: 'DingTalk identity unbound by the local user',
     })
     return true
-  })
+  }))
 }
 
 /**

--- a/packages/core-backend/src/auth/invite-accept-writes.ts
+++ b/packages/core-backend/src/auth/invite-accept-writes.ts
@@ -10,6 +10,7 @@
  */
 
 import { transaction } from '../db/pg'
+import { translateRecoveryConflict } from '../db/recovery-conflict'
 import {
   lockUsersForAccessGraphWrite,
   supersedeDeprovisionEvidenceForAccessGraphWrite,
@@ -37,7 +38,10 @@ export function inviteAcceptWriteErrorCode(error: unknown): string | undefined {
  * Throws with code INVITE_LEDGER_CONSUME_FAILED or INVITE_TARGET_UPDATE_MISMATCH.
  */
 export async function applyInviteAcceptanceWrites(input: InviteAcceptWriteInput): Promise<void> {
-  await transaction(async (client) => {
+  // O2-S2: `users` is a recovery-authority table — a write under a held recovery lease
+  // fails with the marker 40001. Surface it as the named retryable RecoveryConflictError;
+  // every other error rethrows unchanged (INVITE_* codes keep their exact semantics).
+  await translateRecoveryConflict(() => transaction(async (client) => {
     const locked = await lockUsersForAccessGraphWrite(client, [input.userId])
     const lockedUser = locked.get(input.userId)
     if (!lockedUser) {
@@ -82,5 +86,5 @@ export async function applyInviteAcceptanceWrites(input: InviteAcceptWriteInput)
         reason: 'superseded by invite acceptance activation',
       })
     }
-  })
+  }))
 }

--- a/packages/core-backend/src/auth/user-activate.ts
+++ b/packages/core-backend/src/auth/user-activate.ts
@@ -20,6 +20,7 @@
 
 import * as bcrypt from 'bcryptjs'
 import { transaction } from '../db/pg'
+import { translateRecoveryConflict } from '../db/recovery-conflict'
 import { getBcryptSaltRounds } from '../security/auth-runtime-config'
 import {
   lockUsersForAccessGraphWrite,
@@ -138,7 +139,11 @@ export async function activatePendingUser(input: ActivateUserInput): Promise<Act
     localPasswordSet = false
   }
 
-  await transaction(async (client) => {
+  // O2-S2: `users` is a recovery-authority table — a write under a held recovery lease
+  // fails with the marker 40001. Re-raise it as the named retryable RecoveryConflictError
+  // (mapActivateError in routes/admin-users.ts maps it to a retryable 409); every other
+  // error — every ACTIVATE_* reason included — rethrows unchanged.
+  await translateRecoveryConflict(() => transaction(async (client) => {
     const lockedUsers = await lockUsersForAccessGraphWrite(client, [userId])
     const user = lockedUsers.get(userId)
     if (!user) {
@@ -281,7 +286,7 @@ export async function activatePendingUser(input: ActivateUserInput): Promise<Act
       actorId: input.adminUserId ?? userId,
       reason: 'superseded by pending-user activation',
     })
-  })
+  }))
 
   return {
     userId,

--- a/packages/core-backend/src/db/recovery-conflict.ts
+++ b/packages/core-backend/src/db/recovery-conflict.ts
@@ -1,0 +1,132 @@
+/**
+ * O2-S2 — single 40001 recovery-conflict classifier + boundary adapters.
+ *
+ * Exact-anchor recovery (P23) holds a per-subject advisory lease across the eight
+ * recovery-authority tables (users, user_roles, user_permissions, role_permissions,
+ * field_permissions, record_permissions, spreadsheet_permissions,
+ * platform_member_group_members). A write against one of those tables under a held lease
+ * fails fast with Postgres SQLSTATE 40001 and message RECOVERY_AUTHORITY_BUSY_MARKER —
+ * a transient, retryable condition that must surface as a retryable 409 (or a named
+ * retryable service error), never as an unclassified 500.
+ *
+ * Lesson constraint (枚举陷阱不收敛): individual try/catch traps per write site do not
+ * converge — every audit finds a new unclassified writer. This module is the ONE
+ * classifier; a mechanical census test
+ * (tests/unit/recovery-conflict-census.test.ts) asserts every enumerated write surface
+ * routes through it.
+ *
+ * The discriminator is REUSED, not re-derived: `isRecoveryAuthorityBusyError`
+ * (multitable/recovery-authorization-stability.ts) is the same predicate admin-users and
+ * AuthService already use — code '40001' AND the exact marker message. A bare 40001
+ * without the marker (a genuine serialization_failure outside the recovery lease) is
+ * deliberately NOT classified here: those keep their original, byte-identical error
+ * paths. This module only ADDS a mapping for the lease-marker family; it loosens
+ * nothing.
+ */
+
+import type { Response } from 'express'
+import { isRecoveryAuthorityBusyError } from '../multitable/recovery-authorization-stability'
+import { jsonError } from '../util/response'
+
+/**
+ * Reuses the SAME error code (and message) the platform already publishes for this
+ * condition — univer-meta.ts sendRecoveryAuthorityBusy and admin-users.ts introduced
+ * `RECOVERY_AUTHORITY_BUSY` at 409; no new marker/constant/code is minted here.
+ */
+export const RECOVERY_CONFLICT_HTTP_STATUS = 409
+export const RECOVERY_CONFLICT_HTTP_CODE = 'RECOVERY_AUTHORITY_BUSY'
+export const RECOVERY_CONFLICT_HTTP_MESSAGE =
+  'Recovery is stabilizing permissions; retry this change.'
+
+/**
+ * `assignUserRoles` (auth/AuthService.ts) already converts an exhausted 40001 retry loop
+ * into its own named error carrying this code. The classifier recognises it BY CODE —
+ * importing the class from AuthService here would invert the auth→db layering and risk a
+ * module cycle. tests/unit/recovery-conflict-classifier.test.ts constructs the real class
+ * and pins this string against rename/code drift.
+ */
+const USER_ROLE_ASSIGNMENT_RECOVERY_BUSY_CODE = 'USER_ROLE_ASSIGNMENT_RECOVERY_BUSY'
+
+/**
+ * Named retryable error for SERVICE layers (modules that throw coded errors rather than
+ * writing HTTP responses). Carries the same published code, plus `retryable: true`, so
+ * any express boundary — including ones that only switch on `.code` — can map it without
+ * an instanceof (dual-copy/realm-safe: `classifyRecoveryConflict` discriminates by
+ * code+retryable, never by identity of this class).
+ */
+export class RecoveryConflictError extends Error {
+  readonly code = RECOVERY_CONFLICT_HTTP_CODE
+  readonly retryable = true
+
+  constructor(cause: unknown) {
+    // Values-free fixed message: never echo driver text.
+    super(RECOVERY_CONFLICT_HTTP_MESSAGE)
+    this.name = 'RecoveryConflictError'
+    if (cause !== undefined) {
+      Object.assign(this, { cause })
+    }
+  }
+}
+
+function readErrorShape(error: unknown): { code?: unknown; retryable?: unknown } | null {
+  if (typeof error !== 'object' || error === null) return null
+  return error as { code?: unknown; retryable?: unknown }
+}
+
+/**
+ * THE single classifier. Returns 'recovery_conflict' when (and only when) the error is a
+ * member of the recovery-authority-busy family:
+ *   1. the raw Postgres error — SQLSTATE 40001 with the exact lease marker message
+ *      (the EXISTING discriminator, reused verbatim);
+ *   2. a service-layer `RecoveryConflictError` re-raise (code + retryable, realm-safe);
+ *   3. AuthService's `UserRoleAssignmentRecoveryBusyError` (an already-retried,
+ *      exhausted member of the same family — recognised by ITS code + retryable).
+ * Everything else → null: callers must leave every other error path untouched.
+ */
+export function classifyRecoveryConflict(error: unknown): 'recovery_conflict' | null {
+  if (isRecoveryAuthorityBusyError(error)) return 'recovery_conflict'
+  const shape = readErrorShape(error)
+  if (!shape || shape.retryable !== true) return null
+  if (shape.code === RECOVERY_CONFLICT_HTTP_CODE) return 'recovery_conflict'
+  if (shape.code === USER_ROLE_ASSIGNMENT_RECOVERY_BUSY_CODE) return 'recovery_conflict'
+  return null
+}
+
+/**
+ * SERVICE-layer adapter: run a write operation; a recovery conflict is re-raised as the
+ * named retryable `RecoveryConflictError`, every other outcome (value or error) passes
+ * through unchanged — the original error OBJECT is rethrown, so non-40001 behaviour is
+ * byte-for-byte identical for callers.
+ */
+export async function translateRecoveryConflict<T>(op: () => Promise<T>): Promise<T> {
+  try {
+    return await op()
+  } catch (error) {
+    if (error instanceof RecoveryConflictError) throw error
+    if (classifyRecoveryConflict(error) === 'recovery_conflict') {
+      throw new RecoveryConflictError(error)
+    }
+    throw error
+  }
+}
+
+/**
+ * EXPRESS-boundary adapter: if the error is a recovery conflict, write the uniform
+ * retryable 409 (same status/code/message/details shape admin-users.ts already
+ * publishes) and return true; otherwise write NOTHING and return false so the caller's
+ * existing error path runs unchanged.
+ *
+ * Body is values-free: fixed code/message/retryable flag, no user- or request-derived
+ * data (审计面禁止编造值 applies — nothing from the thrown error is echoed).
+ */
+export function sendIfRecoveryConflict(res: Response, error: unknown): boolean {
+  if (classifyRecoveryConflict(error) !== 'recovery_conflict') return false
+  jsonError(
+    res,
+    RECOVERY_CONFLICT_HTTP_STATUS,
+    RECOVERY_CONFLICT_HTTP_CODE,
+    RECOVERY_CONFLICT_HTTP_MESSAGE,
+    { retryable: true },
+  )
+  return true
+}

--- a/packages/core-backend/src/directory/deprovision-evidence-api.ts
+++ b/packages/core-backend/src/directory/deprovision-evidence-api.ts
@@ -3,6 +3,7 @@
  */
 
 import { query, transaction } from '../db/pg'
+import { translateRecoveryConflict } from '../db/recovery-conflict'
 import { invalidateUserPerms } from '../rbac/service'
 import {
   resolveLeastDestructiveDirectoryDeprovisionPolicy,
@@ -282,7 +283,11 @@ export async function compensateSupersededDenyGrant(options: {
     )
   }
 
-  const compensated = await transaction(async (client) => {
+  // O2-S2: this transaction writes users / user_external_auth_grants under the access-graph
+  // mutex — a marker 40001 (recovery lease held) re-raises as the named retryable
+  // RecoveryConflictError; every other error (COMPENSATION_* / DRIFT_CONFLICT / 55P03 →
+  // COMPENSATION_SOURCE_BUSY included) rethrows unchanged.
+  const compensated = await translateRecoveryConflict(() => transaction(async (client) => {
     const ownerResult = await client.query(
       `SELECT local_user_id
          FROM directory_deprovision_events
@@ -543,7 +548,7 @@ export async function compensateSupersededDenyGrant(options: {
       accessGeneration: nextGeneration,
       alreadyCompensated: false,
     }
-  })
+  }))
 
   if (!compensated.alreadyCompensated) {
     invalidateUserPerms(compensated.event.local_user_id)
@@ -587,7 +592,9 @@ export async function restoreDeprovisionEvent(options: {
     }
   }
 
-  const restored = await transaction(async (client) => {
+  // O2-S2: writes users under the access-graph mutex — marker 40001 → named retryable
+  // RecoveryConflictError; every other error rethrows unchanged.
+  const restored = await translateRecoveryConflict(() => transaction(async (client) => {
     // Event identity is DB-immutable. Read only the owner first so the canonical
     // users-row mutex remains the first blocking lock shared with every other
     // access-graph writer.
@@ -966,7 +973,7 @@ export async function restoreDeprovisionEvent(options: {
       },
       restoredEffectCount: applied.length,
     }
-  })
+  }))
   invalidateUserPerms(restored.event.local_user_id)
 
   return {

--- a/packages/core-backend/src/directory/deprovision-ledger.ts
+++ b/packages/core-backend/src/directory/deprovision-ledger.ts
@@ -13,6 +13,7 @@ import type {
   PlannedEffect,
 } from './deprovision-planner'
 import { planDirectoryDeprovision } from './deprovision-planner'
+import { translateRecoveryConflict } from '../db/recovery-conflict'
 
 export type DirectoryTransactionClient = {
   query: (
@@ -297,6 +298,20 @@ async function writeEffects(
 }
 
 export async function applyDirectoryDeprovisionCandidate(
+  client: DirectoryTransactionClient,
+  input: ApplyDeprovisionCandidateInput,
+): Promise<ApplyDeprovisionCandidateResult> {
+  // O2-S2: this writer mutates users / user_orgs / user_external_auth_grants inside the
+  // caller's transaction — a marker 40001 (recovery lease held) re-raises as the named
+  // retryable RecoveryConflictError so the sync/route boundary can classify it; every
+  // other error (candidacy aborts included) rethrows unchanged. The caller's transaction
+  // still rolls back either way.
+  return translateRecoveryConflict(() =>
+    applyDirectoryDeprovisionCandidateWrites(client, input),
+  )
+}
+
+async function applyDirectoryDeprovisionCandidateWrites(
   client: DirectoryTransactionClient,
   input: ApplyDeprovisionCandidateInput,
 ): Promise<ApplyDeprovisionCandidateResult> {

--- a/packages/core-backend/src/directory/directory-sync.ts
+++ b/packages/core-backend/src/directory/directory-sync.ts
@@ -6,6 +6,7 @@ import { issueInviteToken } from '../auth/invite-tokens'
 import { validatePassword } from '../auth/password-policy'
 import { Logger } from '../core/logger'
 import { query, transaction } from '../db/pg'
+import { translateRecoveryConflict } from '../db/recovery-conflict'
 import { sweepStaleDepartmentBindings } from './department-binding-reconciliation'
 import {
   fetchDingTalkAppAccessToken,
@@ -3885,7 +3886,11 @@ export async function syncDirectoryIntegration(
     const autoAdmissionInvites: Array<{ userId: string; email: string; inviteToken: string }> = []
     const autoAdmissionOnboardingPackets: DirectoryAutoAdmissionOnboardingPacket[] = []
 
-    await transaction(async (client) => {
+    // O2-S2: the local-apply transaction writes users (admission / deprovision) — recovery-
+    // authority tables. A marker 40001 (recovery lease held) re-raises as the named retryable
+    // RecoveryConflictError; every other error, DirectorySyncLeaseLostError included,
+    // rethrows unchanged.
+    await translateRecoveryConflict(() => transaction(async (client) => {
       // T2 lock-correctness P2 (PB4-3 idiom — see local-directory-org.ts's reparent guard): the
       // pool wrapper issues a bare BEGIN, so on a deployment where default_transaction_isolation
       // is 'repeatable read' this transaction's snapshot would be taken by the
@@ -4617,7 +4622,7 @@ export async function syncDirectoryIntegration(
       if (completion.rows.length === 0) {
         throw new DirectorySyncLeaseLostError(runId)
       }
-    })
+    }))
 
     for (const invite of autoAdmissionInvites) {
       await recordInvite({
@@ -6738,7 +6743,9 @@ export async function bindDirectoryAccount(
   if (!localUser) throw new Error('Local user not found')
   const expectedPriorLocalUserId = previousLinkedUser?.local_user_id ?? null
 
-  await transaction(async (client) => {
+  // O2-S2: binds write users-adjacent recovery-authority state under the access-graph
+  // mutex — marker 40001 → named retryable RecoveryConflictError; other errors unchanged.
+  await translateRecoveryConflict(() => transaction(async (client) => {
     const lockedUsers = await lockUsersForAccessGraphWrite(client, [
       localUser.id,
       ...(expectedPriorLocalUserId ? [expectedPriorLocalUserId] : []),
@@ -6757,7 +6764,7 @@ export async function bindDirectoryAccount(
       localUser: lockedTargetUser,
       expectedPriorLocalUserId,
     })
-  })
+  }))
 
   const summary = await getDirectoryAccountSummary(normalizedAccountId)
   if (!summary) {
@@ -6830,7 +6837,9 @@ export async function admitDirectoryAccountUser(
 
   let userId = ''
 
-  await transaction(async (client) => {
+  // O2-S2: admission INSERTs a users row — a recovery-authority table. Marker 40001 →
+  // named retryable RecoveryConflictError; other errors unchanged.
+  await translateRecoveryConflict(() => transaction(async (client) => {
     const created = await createDirectoryAdmittedUserInTransaction(client, {
       account,
       adminUserId: normalizedAdminUserId,
@@ -6844,7 +6853,7 @@ export async function admitDirectoryAccountUser(
       expectedPriorLocalUserId: previousLinkedUser?.local_user_id ?? null,
     })
     userId = created.userId
-  })
+  }))
 
   // Pending: never issue invite or temporary password (T3 owns activation credentials).
   let resolvedInviteToken: string | null = null
@@ -6932,7 +6941,9 @@ export async function unbindDirectoryAccount(
 
   let previousLinkedUser: DirectoryAccountLinkedUserRow | null = null
 
-  await transaction(async (client) => {
+  // O2-S2: unbind writes users / deprovision evidence under the access-graph mutex —
+  // marker 40001 → named retryable RecoveryConflictError; other errors unchanged.
+  await translateRecoveryConflict(() => transaction(async (client) => {
     // This unlocked read is only an expected-holder snapshot. The first row lock is still the
     // canonical users row; after it is held, the account/link are locked and re-read. A mismatch
     // fails closed instead of modifying an unprotected replacement holder.
@@ -7073,7 +7084,7 @@ export async function unbindDirectoryAccount(
         reason: 'directory account unbound by an administrator',
       })
     }
-  })
+  }))
 
   const summary = await getDirectoryAccountSummary(normalizedAccountId)
   if (!summary) {

--- a/packages/core-backend/src/multitable/exact-anchor-recovery-execute.ts
+++ b/packages/core-backend/src/multitable/exact-anchor-recovery-execute.ts
@@ -20,6 +20,7 @@ import {
   hashExactAnchorSchema,
   hashRecoveryAuthorizationScope,
   verifyExactAnchorRecoveryIdentity,
+  type ExactAnchorRecoveryIdentityClaims,
   type ExactAnchorRecoveryMode,
 } from './restore-preview-identity'
 import { composeBaselineOverlay, ExactAnchorHistoryDataError, type EvaluateRecoveryFullReadAccess } from './exact-anchor-recovery'
@@ -440,13 +441,54 @@ export type ExactAnchorAppliedMutation =
  */
 export type ExactAnchorMutationTxnHook = (query: QueryFn, mutation: ExactAnchorAppliedMutation) => Promise<void>
 
-/** Typed control-flow error: thrown inside the txn to force a FULL rollback, mapped to a refusal outside. */
+/** Typed control-flow error: thrown inside the txn to force a FULL rollback, mapped to a refusal outside.
+ * `leaseBusy` marks the ONE retryable channel (O2-S3): the exclusive authority lease lost a NOWAIT race
+ * against ordinary shared-lease writers. Only that channel is eligible for the bounded backoff re-attempt;
+ * every other refusal (including a genuine preview drift, which shares the same PUBLIC reason) stays
+ * single-attempt so the retry loop can never mask a real drift/authorization refusal. */
 class ApplyRefusalError extends Error {
-  constructor(readonly reason: ExactAnchorApplyRefusal) {
+  constructor(
+    readonly reason: ExactAnchorApplyRefusal,
+    readonly leaseBusy: boolean = false,
+  ) {
     super(`exact-anchor apply refused: ${reason}`)
     this.name = 'ApplyRefusalError'
   }
 }
+
+/**
+ * O2-S3 — bounded backoff for exclusive-authority-lease starvation.
+ *
+ * The shared-writer/exclusive-recovery lease model is globally NOWAIT (no waiting ⇒ no deadlock cycles),
+ * so under a continuous stream of ordinary writers holding the SHARED lease, recovery's single NOWAIT
+ * try returned `busy` immediately — potentially forever. These constants bound a retry ladder: at most
+ * {@link RECOVERY_LEASE_BACKOFF_MAX_ATTEMPTS} whole-transaction attempts, separated by the increasing
+ * delays in {@link RECOVERY_LEASE_BACKOFF_DELAYS_MS} (last entry repeats if attempts exceed entries).
+ *
+ * Each attempt is a FRESH NOWAIT try: the busy attempt's transaction has fully ROLLED BACK (advisory
+ * xact locks are only releasable at transaction end, so a partially-taken lease can ONLY be released by
+ * rollback — the retry deliberately re-runs the whole apply transaction, never a mid-transaction
+ * re-poll) before the inter-attempt sleep runs. NOTHING is held during the sleep, so writers proceed
+ * freely and the no-deadlock model is preserved: no blocking lock acquisition is introduced and each
+ * round repeats the identical, unchanged lock order from zero. Exhaustion keeps the existing named busy
+ * outcome (`preview-drift` → 409 re-preview) — fail-closed unchanged.
+ */
+export const RECOVERY_LEASE_BACKOFF_MAX_ATTEMPTS = 4
+export const RECOVERY_LEASE_BACKOFF_DELAYS_MS: readonly number[] = [50, 100, 200]
+
+/** Delay (ms) to sleep after `attemptJustFailed` (1-based); clamps to the last configured rung. */
+export function recoveryLeaseBackoffDelayMs(
+  attemptJustFailed: number,
+  delays: readonly number[] = RECOVERY_LEASE_BACKOFF_DELAYS_MS,
+): number {
+  if (delays.length === 0) return 0
+  const index = Math.min(Math.max(1, Math.floor(attemptJustFailed)), delays.length) - 1
+  const value = delays[index]
+  return Number.isFinite(value) && value > 0 ? Math.floor(value) : 0
+}
+
+const defaultLeaseBackoffSleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms))
 
 /** Postgres unique-violation on the burn PK ⇒ the token was already used. */
 const isUniqueViolation = (e: unknown): boolean =>
@@ -756,6 +798,17 @@ export interface ExactAnchorApplyInput {
    * applied revert/delete AFTER that mutation's writes, BEFORE sealOperation. A throw ⇒ full rollback.
    */
   onMutationApplied?: ExactAnchorMutationTxnHook
+  /**
+   * OPTIONAL O2-S3 lease-backoff overrides — production callers omit this and get the exported defaults
+   * ({@link RECOVERY_LEASE_BACKOFF_MAX_ATTEMPTS} / {@link RECOVERY_LEASE_BACKOFF_DELAYS_MS}); tests use it
+   * to tighten budgets and observe attempts. `sleep(ms, attemptJustFailed)` runs BETWEEN attempts, strictly
+   * AFTER the failed attempt's transaction has fully rolled back — no lock of any kind is held while it runs.
+   */
+  leaseBackoff?: {
+    maxAttempts?: number
+    delaysMs?: readonly number[]
+    sleep?: (ms: number, attemptJustFailed: number) => Promise<void>
+  }
 }
 
 /**
@@ -769,10 +822,42 @@ export async function applyExactAnchorRecovery(
   // Identity verification is pure (no DB) — fail fast before opening a transaction.
   const verified = verifyExactAnchorRecoveryIdentity(input.token, { sheetId: input.sheetId, actorId: input.actorId })
   if (!verified.valid || !verified.claims) return { ok: false, reason: 'identity-invalid' }
-  const { anchorSeq, checkpointId, scopeHash, liveSetHash, schemaHash, mode, authorizedScopeHash } = verified.claims
+
+  // O2-S3 — bounded lease-starvation backoff. ONLY the authority-lease NOWAIT loss (`leaseBusy`) is
+  // retried; every other outcome returns immediately (single attempt, unchanged behaviour). By the time
+  // an attempt reports `leaseBusy`, its transaction has already fully ROLLED BACK (pool.transaction
+  // awaits ROLLBACK before rethrowing), so during the inter-attempt sleep NO fence/row/advisory lock is
+  // held and ordinary writers proceed freely. Each next round is a brand-new transaction repeating the
+  // identical existing lock order from zero — no new lock ordering, no blocking wait is introduced, and
+  // exhaustion returns the attempt's own named busy outcome (`preview-drift`) fail-closed unchanged.
+  const maxAttempts = Math.max(
+    1,
+    Math.floor(input.leaseBackoff?.maxAttempts ?? RECOVERY_LEASE_BACKOFF_MAX_ATTEMPTS),
+  )
+  const delays = input.leaseBackoff?.delaysMs ?? RECOVERY_LEASE_BACKOFF_DELAYS_MS
+  const sleep = input.leaseBackoff?.sleep ?? defaultLeaseBackoffSleep
+  for (let attempt = 1; ; attempt++) {
+    const { result, leaseBusy } = await applyExactAnchorRecoveryAttempt(transaction, input, verified.claims)
+    if (!leaseBusy || attempt >= maxAttempts) return result
+    await sleep(recoveryLeaseBackoffDelayMs(attempt, delays), attempt)
+  }
+}
+
+/**
+ * ONE whole-transaction NOWAIT attempt of the destructive apply. `leaseBusy` is true ONLY when the
+ * exclusive authority lease lost its NOWAIT race against shared-lease writers (the O2-S3 retryable
+ * channel); the attempt's transaction is fully rolled back in that case and `result` carries the named
+ * busy outcome that exhaustion returns unchanged.
+ */
+async function applyExactAnchorRecoveryAttempt(
+  transaction: <T>(fn: (query: QueryFn) => Promise<T>) => Promise<T>,
+  input: ExactAnchorApplyInput,
+  claims: ExactAnchorRecoveryIdentityClaims,
+): Promise<{ result: ExactAnchorApplyResult; leaseBusy: boolean }> {
+  const { anchorSeq, checkpointId, scopeHash, liveSetHash, schemaHash, mode, authorizedScopeHash } = claims
 
   try {
-    return await transaction(async (query) => {
+    const success = await transaction(async (query) => {
       // 0. PROVE a real ongoing transaction (pg_current_xact_id probe) before any fence/burn/write. A
       //    forged wrapper over a pool/autocommit client is caught by Postgres itself, not a marker; the
       //    refusal is the same values-free substrate refusal as every other trust failure (non-oracular).
@@ -1039,7 +1124,10 @@ export async function applyExactAnchorRecovery(
         }
       }
       const authorityLease = await input.stabilizeAuthorization(query, authorizationContext)
-      if (authorityLease === 'busy') throw new ApplyRefusalError('preview-drift')
+      // `leaseBusy: true` — the ONE bounded-backoff-retryable channel (O2-S3). The throw forces a FULL
+      // rollback (releasing every fence/row lock and any partially-taken exclusive authority key), after
+      // which the outer loop may re-attempt the whole transaction as a fresh NOWAIT try.
+      if (authorityLease === 'busy') throw new ApplyRefusalError('preview-drift', true)
       if (authorityLease === 'unavailable') {
         throw new ApplyRefusalError('recovery-trust-required')
       }
@@ -1406,10 +1494,13 @@ export async function applyExactAnchorRecovery(
           mode === 'revert' ? plan.createdAfterAnchor.length + plan.deletedAtAnchorLiveNow.length : 0,
       }
     })
+    return { result: success, leaseBusy: false }
   } catch (e) {
-    if (e instanceof ApplyRefusalError) return { ok: false, reason: e.reason }
+    if (e instanceof ApplyRefusalError) {
+      return { result: { ok: false, reason: e.reason }, leaseBusy: e.leaseBusy }
+    }
     const conflict = classifyExactAnchorDatabaseConflict(e)
-    if (conflict) return { ok: false, reason: conflict }
+    if (conflict) return { result: { ok: false, reason: conflict }, leaseBusy: false }
     throw e
   }
 }

--- a/packages/core-backend/src/routes/admin-directory.ts
+++ b/packages/core-backend/src/routes/admin-directory.ts
@@ -51,6 +51,7 @@ import {
   readDeprovisionRuntimeFlags,
   restoreDeprovisionEvent,
 } from '../directory/deprovision-evidence-api'
+import { sendIfRecoveryConflict } from '../db/recovery-conflict'
 import { isAdmin as isRbacAdmin } from '../rbac/service'
 // Roadmap §7.8 "Validate cron at save time" — see `isDirectoryScheduleCronValid` below for why this is
 // `SimpleCronExpression` (the SAME class `directory-sync-scheduler.ts` uses to actually run the job) rather
@@ -585,6 +586,8 @@ export function adminDirectoryRouter(): Router {
           jsonError(res, error.statusCode, error.code, error.message, { transferId: error.transferId })
           return
         }
+        // O2-S2: marker 40001 from the sync's local-apply transaction → retryable 409.
+        if (sendIfRecoveryConflict(res, error)) return
         const message = readErrorMessage(error, 'Failed to start directory sync')
         jsonError(res, /not found/i.test(message) ? 404 : 500, 'DIRECTORY_SYNC_FAILED', message)
         return
@@ -606,6 +609,8 @@ export function adminDirectoryRouter(): Router {
         jsonError(res, error.statusCode, error.code, error.message, { transferId: error.transferId })
         return
       }
+      // O2-S2: marker 40001 from the sync's local-apply transaction → retryable 409.
+      if (sendIfRecoveryConflict(res, error)) return
       const message = readErrorMessage(error, 'Failed to sync directory integration')
       jsonError(res, /not found/i.test(message) ? 404 : 500, 'DIRECTORY_SYNC_FAILED', message)
     }
@@ -897,6 +902,8 @@ export function adminDirectoryRouter(): Router {
       })
       jsonOk(res, { account: result.account })
     } catch (error) {
+      // O2-S2: named retryable RecoveryConflictError from the bind write → retryable 409.
+      if (sendIfRecoveryConflict(res, error)) return
       const message = readErrorMessage(error, 'Failed to bind directory account')
       const statusCode = /not found/i.test(message)
         ? 404
@@ -983,6 +990,8 @@ export function adminDirectoryRouter(): Router {
         enableDingTalkGrantApplied: result.enableDingTalkGrantApplied,
       })
     } catch (error) {
+      // O2-S2: named retryable RecoveryConflictError from the admission write → retryable 409.
+      if (sendIfRecoveryConflict(res, error)) return
       const message = readErrorMessage(error, 'Failed to create and bind local user for directory account')
       const statusCode = /not found/i.test(message)
         ? 404
@@ -1047,6 +1056,8 @@ export function adminDirectoryRouter(): Router {
         failed: outcome.failed,
       })
     } catch (error) {
+      // O2-S2: named retryable RecoveryConflictError from a bind write → retryable 409.
+      if (sendIfRecoveryConflict(res, error)) return
       const message = readErrorMessage(error, 'Failed to batch bind directory accounts')
       const statusCode = /not found/i.test(message)
         ? 404
@@ -1153,6 +1164,8 @@ export function adminDirectoryRouter(): Router {
         enableDingTalkGrantApplied,
       })
     } catch (error) {
+      // O2-S2: named retryable RecoveryConflictError from an admission write → retryable 409.
+      if (sendIfRecoveryConflict(res, error)) return
       const message = readErrorMessage(error, 'Failed to batch create and bind local users for directory accounts')
       const statusCode = /not found/i.test(message)
         ? 404
@@ -1194,6 +1207,8 @@ export function adminDirectoryRouter(): Router {
       })
       jsonOk(res, { account: result.account })
     } catch (error) {
+      // O2-S2: named retryable RecoveryConflictError from the unbind write → retryable 409.
+      if (sendIfRecoveryConflict(res, error)) return
       const message = readErrorMessage(error, 'Failed to unbind directory account')
       const statusCode = /not found/i.test(message)
         ? 404
@@ -1249,6 +1264,8 @@ export function adminDirectoryRouter(): Router {
         disableDingTalkGrant,
       })
     } catch (error) {
+      // O2-S2: named retryable RecoveryConflictError from an unbind write → retryable 409.
+      if (sendIfRecoveryConflict(res, error)) return
       const message = readErrorMessage(error, 'Failed to batch unbind directory accounts')
       const statusCode = /not found/i.test(message)
         ? 404
@@ -1481,6 +1498,11 @@ export function adminDirectoryRouter(): Router {
       })
       jsonOk(res, result)
     } catch (error) {
+      // O2-S2: restoreDeprovisionEvent re-raises a marker 40001 as the named retryable
+      // RecoveryConflictError → uniform retryable 409. Every coded mapping below is
+      // unchanged (RECOVERY_AUTHORITY_BUSY is not in its lists, so it previously fell
+      // to the unclassified 500).
+      if (sendIfRecoveryConflict(res, error)) return
       const errorCode = (error as { code?: unknown })?.code
       const code = typeof errorCode === 'string' ? errorCode : ''
       const knownStatus =
@@ -1561,6 +1583,9 @@ export function adminDirectoryRouter(): Router {
       })
       jsonOk(res, result)
     } catch (error) {
+      // O2-S2: compensateSupersededDenyGrant re-raises a marker 40001 as the named
+      // retryable RecoveryConflictError → uniform retryable 409; mappings below unchanged.
+      if (sendIfRecoveryConflict(res, error)) return
       const errorCode =
         (error as { code?: string })?.code
         || 'DEPROVISION_COMPENSATION_FAILED'

--- a/packages/core-backend/src/routes/admin-users.ts
+++ b/packages/core-backend/src/routes/admin-users.ts
@@ -50,7 +50,13 @@ import {
   type AccessGraphTransactionClient,
 } from '../directory/access-graph-mutex'
 import { isDatabaseSchemaError } from '../utils/database-errors'
-import { isRecoveryAuthorityBusyError } from '../multitable/recovery-authorization-stability'
+import {
+  classifyRecoveryConflict,
+  RECOVERY_CONFLICT_HTTP_CODE,
+  RECOVERY_CONFLICT_HTTP_MESSAGE,
+  RECOVERY_CONFLICT_HTTP_STATUS,
+  sendIfRecoveryConflict,
+} from '../db/recovery-conflict'
 import { jsonError, jsonOk, parsePagination } from '../util/response'
 import {
   acquireAttendanceCalculationRolloutLock,
@@ -393,16 +399,12 @@ const ADMIN_USER_PROFILE_SELECT = `
 // Reuses the SAME discriminator (isRecoveryAuthorityBusyError) and error code
 // (RECOVERY_AUTHORITY_BUSY) as univer-meta.ts — no new marker/constant is introduced.
 // Body is values-free: fixed code/message/retryable flag, no user- or request-derived data.
+// O2-S2: now delegates to the ONE shared classifier/adapter (db/recovery-conflict.ts).
+// Status/code/message/details are byte-identical to the previous inline body; the
+// discriminator is additive-only (it also recognises the named retryable service errors
+// of the same family — RecoveryConflictError / UserRoleAssignmentRecoveryBusyError).
 function sendIfRecoveryAuthorityBusy(res: Response, error: unknown): boolean {
-  if (!isRecoveryAuthorityBusyError(error)) return false
-  jsonError(
-    res,
-    409,
-    'RECOVERY_AUTHORITY_BUSY',
-    'Recovery is stabilizing permissions; retry this change.',
-    { retryable: true },
-  )
-  return true
+  return sendIfRecoveryConflict(res, error)
 }
 
 function getRequestUserId(req: Request): string {
@@ -1955,6 +1957,18 @@ export const ACTIVATE_ERROR_POLICY: Readonly<Record<ActivateErrorCode, ActivateP
  *   3. a TypeScript-AST scan of the `throwCoded` call sites, set-equal against this table's keys.
  */
 export function mapActivateError(error: unknown): { status: number; code: string; message: string } {
+  // O2-S2: activation writes users (a recovery-authority table). A recovery conflict —
+  // the marker 40001, re-raised by activatePendingUser as the named retryable
+  // RecoveryConflictError — is a retryable 409, not the ACTIVATE_FAILED 500 fallback.
+  // The classifier reads nothing that is published: status/code/message here are fixed
+  // constants, so the "never echo driver text" contract holds on this branch too.
+  if (classifyRecoveryConflict(error) === 'recovery_conflict') {
+    return {
+      status: RECOVERY_CONFLICT_HTTP_STATUS,
+      code: RECOVERY_CONFLICT_HTTP_CODE,
+      message: RECOVERY_CONFLICT_HTTP_MESSAGE,
+    }
+  }
   const rawCode = (error as { code?: unknown } | null)?.code
   // Exact membership, never a prefix. `.code` is the only property read off the thrown value.
   if (typeof rawCode === 'string') {

--- a/packages/core-backend/src/routes/attendance-admin.ts
+++ b/packages/core-backend/src/routes/attendance-admin.ts
@@ -3,6 +3,7 @@ import { Router } from 'express'
 import { rbacGuard } from '../rbac/rbac'
 import { isAdmin as isRbacAdmin, listUserPermissions } from '../rbac/service'
 import { query } from '../db/pg'
+import { sendIfRecoveryConflict } from '../db/recovery-conflict'
 import { MAX_MANAGER_CHAIN_LEVELS } from '../services/ApprovalDirectoryOrg'
 import { jsonError, jsonOk, parsePagination } from '../util/response'
 import { redeliverFailedAttendanceNotification } from '../services/AttendanceNotificationRedelivery'
@@ -958,6 +959,9 @@ export function attendanceAdminRouter(): Router {
         items: resolvedUsers.items,
       })
     } catch (error) {
+      // O2-S2: user_roles is a recovery-authority table — a marker 40001 under a held
+      // recovery lease is a retryable 409, not a 500. Every other error keeps its path.
+      if (sendIfRecoveryConflict(res, error)) return
       return jsonError(res, 500, 'BATCH_ROLE_ASSIGN_FAILED', (error as Error)?.message || 'Failed to batch assign role')
     }
   })
@@ -1024,6 +1028,8 @@ export function attendanceAdminRouter(): Router {
         items: resolvedUsers.items,
       })
     } catch (error) {
+      // O2-S2: marker 40001 → retryable 409 (see batch assign); all else unchanged.
+      if (sendIfRecoveryConflict(res, error)) return
       return jsonError(res, 500, 'BATCH_ROLE_UNASSIGN_FAILED', (error as Error)?.message || 'Failed to batch unassign role')
     }
   })
@@ -1089,6 +1095,8 @@ export function attendanceAdminRouter(): Router {
         isAdmin,
       })
     } catch (error) {
+      // O2-S2: marker 40001 → retryable 409 (see batch assign); all else unchanged.
+      if (sendIfRecoveryConflict(res, error)) return
       return jsonError(res, 500, 'ROLE_ASSIGN_FAILED', (error as Error)?.message || 'Failed to assign role')
     }
   })
@@ -1126,6 +1134,8 @@ export function attendanceAdminRouter(): Router {
         isAdmin,
       })
     } catch (error) {
+      // O2-S2: marker 40001 → retryable 409 (see batch assign); all else unchanged.
+      if (sendIfRecoveryConflict(res, error)) return
       return jsonError(res, 500, 'ROLE_UNASSIGN_FAILED', (error as Error)?.message || 'Failed to unassign role')
     }
   })

--- a/packages/core-backend/src/routes/auth.ts
+++ b/packages/core-backend/src/routes/auth.ts
@@ -31,6 +31,7 @@ import {
 } from '../auth/invite-accept-writes'
 import { verifyInviteToken } from '../auth/invite-tokens'
 import { validatePassword } from '../auth/password-policy'
+import { classifyRecoveryConflict, sendIfRecoveryConflict } from '../db/recovery-conflict'
 import { activatePendingUser } from '../auth/user-activate'
 import { createUserSession, getUserSession, listUserSessions, revokeUserSession, touchUserSession } from '../auth/session-registry'
 import { revokeUserSessions } from '../auth/session-revocation'
@@ -806,6 +807,12 @@ authRouter.post('/register', registerRateLimiter, async (req: Request, res: Resp
       }
     })
   } catch (error) {
+    // O2-S2: registration writes users/user_roles (recovery-authority tables). Both the
+    // raw marker 40001 and AuthService's already-retried, named
+    // UserRoleAssignmentRecoveryBusyError surface as the uniform retryable 409
+    // (RECOVERY_AUTHORITY_BUSY) instead of collapsing to a generic 500. Every other
+    // error keeps the exact 500 below.
+    if (sendIfRecoveryConflict(res, error)) return
     logger.error('Registration error', error instanceof Error ? error : undefined)
     res.status(500).json({
       success: false,
@@ -989,6 +996,9 @@ authRouter.post('/invite/accept', async (req: Request, res: Response) => {
       },
     })
   } catch (error) {
+    // O2-S2: applyInviteAcceptanceWrites re-raises a marker 40001 as the named retryable
+    // RecoveryConflictError → uniform retryable 409. INVITE_* semantics unchanged below.
+    if (sendIfRecoveryConflict(res, error)) return
     const code = inviteAcceptWriteErrorCode(error)
     if (code === INVITE_TARGET_UPDATE_MISMATCH) {
       return res.status(409).json({
@@ -1342,6 +1352,9 @@ authRouter.post('/dingtalk/unbind', async (req: Request, res: Response) => {
       data: nextSnapshot,
     })
   } catch (error) {
+    // O2-S2: unbind runs under the access-graph users mutex — marker 40001 → uniform
+    // retryable 409. Policy errors and the fail-closed 500 below are unchanged.
+    if (sendIfRecoveryConflict(res, error)) return
     if (error instanceof DingTalkLoginPolicyError) {
       return res.status(error.statusCode).json({
         success: false,
@@ -1586,6 +1599,11 @@ authRouter.post('/dingtalk/callback', async (req: Request, res: Response) => {
           },
         })
       } catch (error) {
+        // O2-S2: a recovery conflict (named retryable RecoveryConflictError from
+        // activatePendingUser) must NOT collapse into the 500 'activate_failed'
+        // fallback — rethrow it whole for the outer catch's uniform retryable 409.
+        // Every ACTIVATE_* mapping below is unchanged.
+        if (classifyRecoveryConflict(error) === 'recovery_conflict') throw error
         throw mapDingTalkActivationFailure(error)
       }
 
@@ -1653,6 +1671,11 @@ authRouter.post('/dingtalk/callback', async (req: Request, res: Response) => {
       },
     })
   } catch (error) {
+    // O2-S2: bind/JIT-provision/activate all write recovery-authority tables — marker
+    // 40001 (re-raised as the named retryable RecoveryConflictError by the service
+    // layer) → uniform retryable 409. Every DingTalk policy/request mapping below is
+    // unchanged; nothing fail-closed is loosened.
+    if (sendIfRecoveryConflict(res, error)) return
     logger.error('DingTalk callback error', error instanceof Error ? error : undefined)
     const statusCode = error instanceof DingTalkActivationIntentError
       ? error.statusCode
@@ -1760,6 +1783,9 @@ authRouter.post('/login/dingtalk/container', async (req: Request, res: Response)
       },
     })
   } catch (error) {
+    // O2-S2: container login can JIT-provision a users row — marker 40001 → uniform
+    // retryable 409; the mappings below are unchanged.
+    if (sendIfRecoveryConflict(res, error)) return
     logger.error('DingTalk container login error', error instanceof Error ? error : undefined)
     // DingTalkBusinessError here is DingTalk refusing the payload (typically an
     // invalid/expired authCode) — the caller's fault, not an upstream outage.

--- a/packages/core-backend/src/routes/permissions.ts
+++ b/packages/core-backend/src/routes/permissions.ts
@@ -8,6 +8,7 @@ import type { Request, Response } from 'express'
 import { authenticate } from '../middleware/auth'
 import { Logger } from '../core/logger'
 import { pool } from '../db/pg'
+import { sendIfRecoveryConflict } from '../db/recovery-conflict'
 import { auditLog } from '../audit/audit'
 import { getPermissionTemplate, listPermissionTemplates } from '../auth/permission-templates'
 import { userHasPermission, listUserPermissions, isAdmin, invalidateUserPerms } from '../rbac/service'
@@ -193,6 +194,10 @@ export function permissionsRouter(): Router {
         permission
       })
     } catch (error) {
+      // O2-S2: user_permissions is a recovery-authority table — a marker 40001 under a
+      // held recovery lease is a retryable 409, not an unclassified 500. Additive only:
+      // every other error keeps the exact path below.
+      if (sendIfRecoveryConflict(res, error)) return
       if (isDatabaseSchemaError(error) && allowDegradation) {
         if (!permsDegraded) {
           logger.warn('Permissions service degraded - tables not found')
@@ -262,6 +267,8 @@ export function permissionsRouter(): Router {
         permission
       })
     } catch (error) {
+      // O2-S2: see the grant handler — marker 40001 → retryable 409, all else unchanged.
+      if (sendIfRecoveryConflict(res, error)) return
       if (isDatabaseSchemaError(error) && allowDegradation) {
         if (!permsDegraded) {
           logger.warn('Permissions service degraded - tables not found')
@@ -402,6 +409,8 @@ export function permissionsRouter(): Router {
         isAdmin: admin,
       })
     } catch (error) {
+      // O2-S2: see the grant handler — marker 40001 → retryable 409, all else unchanged.
+      if (sendIfRecoveryConflict(res, error)) return
       if (isDatabaseSchemaError(error) && allowDegradation) {
         if (!permsDegraded) {
           logger.warn('Permissions template service degraded - tables not found')

--- a/packages/core-backend/src/routes/roles.ts
+++ b/packages/core-backend/src/routes/roles.ts
@@ -3,6 +3,7 @@ import { Router } from 'express'
 import { rbacGuard } from '../rbac/rbac'
 import { auditLog } from '../audit/audit'
 import { pool } from '../db/pg'
+import { sendIfRecoveryConflict } from '../db/recovery-conflict'
 import { parsePagination } from '../util/response'
 
 // 简易内存存储占位
@@ -30,9 +31,17 @@ export function rolesRouter(): Router {
     const name = req.body?.name || 'unnamed'
     const perms: string[] = Array.isArray(req.body?.permissions) ? req.body.permissions : []
     if (pool) {
-      await pool.query('INSERT INTO roles(id, name) VALUES ($1,$2) ON CONFLICT (id) DO NOTHING', [id, name])
-      for (const p of perms) {
-        await pool.query('INSERT INTO role_permissions(role_id, permission_code) VALUES ($1,$2) ON CONFLICT DO NOTHING', [id, p])
+      try {
+        await pool.query('INSERT INTO roles(id, name) VALUES ($1,$2) ON CONFLICT (id) DO NOTHING', [id, name])
+        for (const p of perms) {
+          await pool.query('INSERT INTO role_permissions(role_id, permission_code) VALUES ($1,$2) ON CONFLICT DO NOTHING', [id, p])
+        }
+      } catch (error) {
+        // O2-S2: role_permissions is a recovery-authority table — a marker 40001 under a
+        // held recovery lease is a retryable 409. Every other error rethrows unchanged
+        // (the handler had no catch before, so the rejection path is byte-identical).
+        if (sendIfRecoveryConflict(res, error)) return
+        throw error
       }
       await auditLog({ actorId: req.user?.id?.toString(), actorType: 'user', action: 'create', resourceType: 'role', resourceId: id, meta: { name, permissions: perms } })
       const { rows } = await pool.query('SELECT id, name, created_at, updated_at FROM roles WHERE id=$1', [id])
@@ -50,7 +59,13 @@ export function rolesRouter(): Router {
       if (!rows.length) return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: 'Role not found' } })
       const before = rows[0]
       const name = req.body?.name ?? before.name
-      await pool.query('UPDATE roles SET name=$1, updated_at=now() WHERE id=$2', [name, id])
+      try {
+        await pool.query('UPDATE roles SET name=$1, updated_at=now() WHERE id=$2', [name, id])
+      } catch (error) {
+        // O2-S2: marker 40001 → retryable 409; all else rethrows unchanged.
+        if (sendIfRecoveryConflict(res, error)) return
+        throw error
+      }
       await auditLog({ actorId: req.user?.id?.toString(), actorType: 'user', action: 'update', resourceType: 'role', resourceId: id, meta: { before, after: { id, name } } })
       return res.json({ ok: true, data: { id, name } })
     }
@@ -67,7 +82,15 @@ export function rolesRouter(): Router {
     if (pool) {
       const { rows } = await pool.query('SELECT id, name FROM roles WHERE id=$1', [id])
       const before = rows[0] || null
-      await pool.query('DELETE FROM roles WHERE id=$1', [id])
+      try {
+        // The FK cascade from roles → role_permissions deletes recovery-authority rows,
+        // so this DELETE can also surface the marker 40001.
+        await pool.query('DELETE FROM roles WHERE id=$1', [id])
+      } catch (error) {
+        // O2-S2: marker 40001 → retryable 409; all else rethrows unchanged.
+        if (sendIfRecoveryConflict(res, error)) return
+        throw error
+      }
       await auditLog({ actorId: req.user?.id?.toString(), actorType: 'user', action: 'delete', resourceType: 'role', resourceId: id, meta: { before } })
       return res.json({ ok: true, data: { id } })
     }

--- a/packages/core-backend/src/routes/spreadsheet-permissions.ts
+++ b/packages/core-backend/src/routes/spreadsheet-permissions.ts
@@ -3,6 +3,7 @@ import { Router } from 'express'
 import { rbacGuard } from '../rbac/rbac'
 import { auditLog } from '../audit/audit'
 import { pool, transaction } from '../db/pg'
+import { sendIfRecoveryConflict } from '../db/recovery-conflict'
 
 // Use the global Express.Request type which already includes user property
 type AuthenticatedRequest = Request
@@ -52,15 +53,23 @@ export function spreadsheetPermissionsRouter(): Router {
       // grant write serializes against a concurrent revert under ONE lock model. A grant INSERT already blocks on the
       // revert via the FK's implicit FOR KEY SHARE on meta_sheets vs the revert's FOR UPDATE; the explicit lock makes
       // the legacy route UNIFORM with #3402 rather than relying on that implicit FK lock (it does not close a new hole).
-      await transaction(async ({ query }) => {
-        await query('SELECT 1 FROM meta_sheets WHERE id = $1 FOR UPDATE', [req.params.id])
-        await query(
-          `INSERT INTO spreadsheet_permissions(sheet_id, user_id, subject_type, subject_id, perm_code)
-           VALUES ($1, $2, 'user', $2, $3)
-           ON CONFLICT DO NOTHING`,
-          [req.params.id, userId, perm],
-        )
-      })
+      try {
+        await transaction(async ({ query }) => {
+          await query('SELECT 1 FROM meta_sheets WHERE id = $1 FOR UPDATE', [req.params.id])
+          await query(
+            `INSERT INTO spreadsheet_permissions(sheet_id, user_id, subject_type, subject_id, perm_code)
+             VALUES ($1, $2, 'user', $2, $3)
+             ON CONFLICT DO NOTHING`,
+            [req.params.id, userId, perm],
+          )
+        })
+      } catch (error) {
+        // O2-S2: spreadsheet_permissions is a recovery-authority table — a marker 40001
+        // under a held recovery lease is a retryable 409. Every other error rethrows
+        // unchanged (the handler had no catch before, so that path is byte-identical).
+        if (sendIfRecoveryConflict(res, error)) return
+        throw error
+      }
     } else {
       const map = sheetPerms.get(req.params.id) || new Map<string, Set<string>>()
       const set = map.get(userId) || new Set<string>()
@@ -95,17 +104,23 @@ export function spreadsheetPermissionsRouter(): Router {
       // (unlike a grant INSERT) it is NOT FK-serialized against a concurrent permission-revert and could interleave
       // the revert's live-grant re-check and its apply. Take the SAME meta_sheets FOR UPDATE the revert holds so it
       // cannot. (#3402-style: lock the sheet row first, then write.)
-      await transaction(async ({ query }) => {
-        await query('SELECT 1 FROM meta_sheets WHERE id = $1 FOR UPDATE', [req.params.id])
-        await query(
-          `DELETE FROM spreadsheet_permissions
-           WHERE sheet_id = $1
-             AND subject_type = 'user'
-             AND user_id = $2
-             AND perm_code = $3`,
-          [req.params.id, userId, perm],
-        )
-      })
+      try {
+        await transaction(async ({ query }) => {
+          await query('SELECT 1 FROM meta_sheets WHERE id = $1 FOR UPDATE', [req.params.id])
+          await query(
+            `DELETE FROM spreadsheet_permissions
+             WHERE sheet_id = $1
+               AND subject_type = 'user'
+               AND user_id = $2
+               AND perm_code = $3`,
+            [req.params.id, userId, perm],
+          )
+        })
+      } catch (error) {
+        // O2-S2: marker 40001 → retryable 409 (see grant); all else rethrows unchanged.
+        if (sendIfRecoveryConflict(res, error)) return
+        throw error
+      }
     } else {
       const map = sheetPerms.get(req.params.id) || new Map<string, Set<string>>()
       const set = map.get(userId) || new Set<string>()

--- a/packages/core-backend/tests/integration/auth-register-atomicity.db.test.ts
+++ b/packages/core-backend/tests/integration/auth-register-atomicity.db.test.ts
@@ -1,0 +1,258 @@
+/**
+ * O2-S1 — registration atomicity (real Postgres).
+ *
+ * AuthService.register() creates the user AND assigns the attendance self-service role in
+ * ONE transaction, with bounded WHOLE-transaction retry on recovery-authority-busy (40001).
+ * Before this slice, createUser() committed first and assignUserRoles() ran in a separate
+ * transaction — a persistently busy lease then threw UserRoleAssignmentRecoveryBusyError
+ * while the users / user_login_aliases / user_permissions rows stayed committed (P23
+ * residue). This suite proves the residue is gone:
+ *
+ *  1. Failure injection (narrowly scoped per repo convention — the injected trigger fires
+ *     ONLY for this run's `${NS}-inject-` email namespace, so concurrent suites sharing the
+ *     DB never see it) makes the user_roles insert raise SQLSTATE 40001 with the real
+ *     RECOVERY_AUTHORITY_BUSY_MARKER. Retries exhaust → register rejects with the named
+ *     error AND all four tables (users, user_login_aliases, user_permissions, user_roles)
+ *     hold ZERO rows for that registration; a subsequent register with the SAME email then
+ *     succeeds.
+ *  2. Retry unit is the WHOLE transaction: a non-transactional sequence counts trigger
+ *     firings. After a 40001 the open transaction is aborted (any further statement fails
+ *     25P02 and cannot fire a BEFORE INSERT trigger), so N firings require N fresh
+ *     transactions in which the users insert succeeded again — the counter equaling
+ *     USER_ROLE_ASSIGNMENT_RETRY_LIMIT proves whole-transaction retry, not per-statement.
+ *  3. Positive control / scope proof: with the injection trigger ACTIVE, an email outside
+ *     the injection namespace registers successfully and its role row exists — the
+ *     zero-residue queries above are proven able to see rows by the same helpers here.
+ *  4. resolveRbacProfile call path (standalone assignUserRoles backfill) stays contained:
+ *     a busy lease during the read-path backfill must not fail login and must not fabricate
+ *     unpersisted attendance permissions — and the sequence delta proves the injection
+ *     genuinely fired on that path (not vacuous).
+ */
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import * as bcrypt from 'bcryptjs'
+import {
+  AuthService,
+  USER_ROLE_ASSIGNMENT_RETRY_LIMIT,
+  UserRoleAssignmentRecoveryBusyError,
+} from '../../src/auth/AuthService'
+import { normalizeLoginIdentifier } from '../../src/auth/login-identifier'
+import { RECOVERY_AUTHORITY_BUSY_MARKER } from '../../src/multitable/recovery-authorization-stability'
+import { query } from '../../src/db/pg'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
+const NS = `o2s1-${Date.now()}`
+const INJECT_EMAIL_PREFIX = `${NS}-inject-`
+const SEQ = `o2s1_busy_fire_seq_${Date.now()}`
+const FN = `o2s1_user_roles_busy_inject_${Date.now()}`
+const TRIGGER = `trg_${FN}`
+
+const createdUserIds: string[] = []
+const createdEmails: string[] = []
+
+async function cleanupRows() {
+  for (const uid of createdUserIds.splice(0, createdUserIds.length)) {
+    await query(`DELETE FROM user_sessions WHERE user_id = $1`, [uid])
+    await query(`DELETE FROM user_login_aliases WHERE user_id = $1`, [uid])
+    await query(`DELETE FROM user_permissions WHERE user_id = $1`, [uid])
+    await query(`DELETE FROM user_roles WHERE user_id = $1`, [uid])
+    await query(`DELETE FROM users WHERE id = $1`, [uid])
+  }
+  for (const email of createdEmails.splice(0, createdEmails.length)) {
+    // Residue sweep by email in case a failure path left rows without a captured id.
+    const rows = await query<{ id: string }>(`SELECT id FROM users WHERE lower(email) = lower($1)`, [email])
+    for (const row of rows.rows) {
+      await query(`DELETE FROM user_sessions WHERE user_id = $1`, [row.id])
+      await query(`DELETE FROM user_login_aliases WHERE user_id = $1`, [row.id])
+      await query(`DELETE FROM user_permissions WHERE user_id = $1`, [row.id])
+      await query(`DELETE FROM user_roles WHERE user_id = $1`, [row.id])
+      await query(`DELETE FROM users WHERE id = $1`, [row.id])
+    }
+    const normalized = normalizeLoginIdentifier(email)
+    if (normalized) {
+      await query(`DELETE FROM user_login_aliases WHERE normalized_value = $1`, [normalized])
+    }
+  }
+}
+
+/** Row counts across the four registration-owned tables, keyed by user id + email. */
+async function residueCounts(userId: string, email: string) {
+  const normalized = normalizeLoginIdentifier(email)
+  const [users, aliasesById, aliasesByValue, permissions, roles] = await Promise.all([
+    query(`SELECT 1 FROM users WHERE id = $1 OR lower(email) = lower($2)`, [userId, email]),
+    query(`SELECT 1 FROM user_login_aliases WHERE user_id = $1`, [userId]),
+    query(`SELECT 1 FROM user_login_aliases WHERE normalized_value = $1`, [normalized]),
+    query(`SELECT 1 FROM user_permissions WHERE user_id = $1`, [userId]),
+    query(`SELECT 1 FROM user_roles WHERE user_id = $1`, [userId]),
+  ])
+  return {
+    users: users.rows.length,
+    aliases: aliasesById.rows.length + aliasesByValue.rows.length,
+    permissions: permissions.rows.length,
+    roles: roles.rows.length,
+  }
+}
+
+async function triggerFireCount(): Promise<number> {
+  const result = await query<{ last_value: string; is_called: boolean }>(
+    `SELECT last_value, is_called FROM ${SEQ}`,
+  )
+  const row = result.rows[0]
+  if (!row) throw new Error(`sequence ${SEQ} missing`)
+  return row.is_called ? Number(row.last_value) : 0
+}
+
+async function createInjectionTrigger() {
+  // Narrow scope: fires only when the user being granted a role has an email in THIS run's
+  // inject namespace. Raises the exact production marker + SQLSTATE so
+  // isRecoveryAuthorityBusyError classifies it identically to a real busy lease.
+  await query(
+    `CREATE OR REPLACE FUNCTION ${FN}() RETURNS trigger AS $$
+     BEGIN
+       IF EXISTS (
+         SELECT 1 FROM users u
+         WHERE u.id = NEW.user_id
+           AND u.email LIKE '${INJECT_EMAIL_PREFIX}%'
+       ) THEN
+         PERFORM nextval('${SEQ}');
+         RAISE EXCEPTION '${RECOVERY_AUTHORITY_BUSY_MARKER}' USING ERRCODE = '40001';
+       END IF;
+       RETURN NEW;
+     END;
+     $$ LANGUAGE plpgsql`,
+  )
+  await query(
+    `CREATE TRIGGER ${TRIGGER}
+     BEFORE INSERT ON user_roles
+     FOR EACH ROW EXECUTE FUNCTION ${FN}()`,
+  )
+}
+
+async function dropInjectionTrigger() {
+  await query(`DROP TRIGGER IF EXISTS ${TRIGGER} ON user_roles`)
+}
+
+const originalProductMode = process.env.PRODUCT_MODE
+
+describeIfDatabase('O2-S1 registration atomicity (real Postgres)', () => {
+  beforeAll(async () => {
+    // attendance / platform both enable self-service role assignment; pin one explicitly.
+    process.env.PRODUCT_MODE = 'attendance'
+    await query(`CREATE SEQUENCE ${SEQ}`)
+    await createInjectionTrigger()
+  })
+
+  afterAll(async () => {
+    await dropInjectionTrigger()
+    await query(`DROP FUNCTION IF EXISTS ${FN}()`)
+    await query(`DROP SEQUENCE IF EXISTS ${SEQ}`)
+    await cleanupRows()
+    if (originalProductMode === undefined) {
+      delete process.env.PRODUCT_MODE
+    } else {
+      process.env.PRODUCT_MODE = originalProductMode
+    }
+  })
+
+  it('positive control + injection scope: an email OUTSIDE the inject namespace registers fully while the trigger is active', async () => {
+    const email = `${NS}-clean@atomicity.example`
+    createdEmails.push(email)
+
+    const firesBefore = await triggerFireCount()
+    const auth = new AuthService()
+    const user = await auth.register(email, 'AtomicPass9A!', 'Clean Register')
+    expect(user).toBeTruthy()
+    createdUserIds.push(user!.id)
+
+    // All four tables hold rows — this is the positive control proving the SAME queries used
+    // for the zero-residue assertion below are capable of seeing rows.
+    const counts = await residueCounts(user!.id, email)
+    expect(counts.users).toBeGreaterThan(0)
+    expect(counts.aliases).toBeGreaterThan(0)
+    expect(counts.permissions).toBeGreaterThan(0)
+    expect(counts.roles).toBeGreaterThan(0)
+
+    const role = await query(
+      `SELECT 1 FROM user_roles WHERE user_id = $1 AND role_id = 'attendance_employee'`,
+      [user!.id],
+    )
+    expect(role.rows.length).toBe(1)
+
+    // Scope proof: the active injection trigger did not fire for this out-of-namespace email.
+    expect(await triggerFireCount()).toBe(firesBefore)
+  })
+
+  it('resolveRbacProfile backfill path stays contained under a busy lease: read succeeds, no fabricated permissions, injection genuinely fired', async () => {
+    const email = `${INJECT_EMAIL_PREFIX}backfill@atomicity.example`
+    const userId = `${NS}-backfill-user`
+    createdUserIds.push(userId)
+    createdEmails.push(email)
+    const passwordHash = await bcrypt.hash('BackfillPass9A!', 4)
+    await query(
+      `INSERT INTO users (
+         id, email, name, password_hash, role, permissions,
+         is_active, activation_status, local_password_set, created_at, updated_at
+       ) VALUES ($1, $2, 'Backfill User', $3, 'user', '[]'::jsonb,
+                 TRUE, 'activated', TRUE, NOW(), NOW())`,
+      [userId, email, passwordHash],
+    )
+
+    const firesBefore = await triggerFireCount()
+    const auth = new AuthService()
+    const result = await auth.login(email, 'BackfillPass9A!')
+
+    // Contained: the busy backfill must not turn a valid login into a failure...
+    expect(result).toBeTruthy()
+    expect(result!.user.id).toBe(userId)
+    // ...and must not fabricate the unpersisted attendance permissions.
+    expect(result!.user.permissions).not.toContain('attendance:read')
+    expect(result!.user.permissions).not.toContain('attendance:write')
+    const roles = await query(`SELECT 1 FROM user_roles WHERE user_id = $1`, [userId])
+    expect(roles.rows.length).toBe(0)
+
+    // Not vacuous: the standalone assignUserRoles bounded retry really hit the injection —
+    // exactly the configured number of attempts.
+    expect(await triggerFireCount()).toBe(firesBefore + USER_ROLE_ASSIGNMENT_RETRY_LIMIT)
+  })
+
+  it('injection exhaustion leaves ZERO residue across users/login_aliases/user_permissions/user_roles, and the same email then registers successfully', async () => {
+    const email = `${INJECT_EMAIL_PREFIX}register@atomicity.example`
+    createdEmails.push(email)
+
+    const firesBefore = await triggerFireCount()
+    const auth = new AuthService()
+    let thrown: unknown
+    try {
+      await auth.register(email, 'AtomicPass9A!', 'Busy Register')
+      expect.unreachable('register must reject when whole-transaction retries exhaust')
+    } catch (error) {
+      thrown = error
+    }
+    expect(thrown).toBeInstanceOf(UserRoleAssignmentRecoveryBusyError)
+    const busy = thrown as UserRoleAssignmentRecoveryBusyError
+    expect(busy.retryable).toBe(true)
+    expect(busy.roleIds).toContain('attendance_employee')
+
+    // Whole-transaction retry, bounded: each firing requires a FRESH transaction in which
+    // the users insert succeeded again (after 40001 the prior transaction is aborted — a
+    // retry inside it would fail 25P02 without reaching this BEFORE INSERT trigger).
+    expect(await triggerFireCount()).toBe(firesBefore + USER_ROLE_ASSIGNMENT_RETRY_LIMIT)
+
+    // ZERO residue for the failed registration, in all four tables (the error carries the
+    // exact userId every rolled-back attempt used).
+    const counts = await residueCounts(busy.userId, email)
+    expect(counts).toEqual({ users: 0, aliases: 0, permissions: 0, roles: 0 })
+
+    // With the injection removed, the SAME email registers successfully — nothing latent
+    // (alias claim, unique index, permissions) was left behind to block it.
+    await dropInjectionTrigger()
+    const user = await auth.register(email, 'AtomicPass9A!', 'Recovered Register')
+    expect(user).toBeTruthy()
+    createdUserIds.push(user!.id)
+    const after = await residueCounts(user!.id, email)
+    expect(after.users).toBeGreaterThan(0)
+    expect(after.aliases).toBeGreaterThan(0)
+    expect(after.permissions).toBeGreaterThan(0)
+    expect(after.roles).toBeGreaterThan(0)
+  })
+})

--- a/packages/core-backend/tests/integration/invite-accept-concurrency-rollback.db.test.ts
+++ b/packages/core-backend/tests/integration/invite-accept-concurrency-rollback.db.test.ts
@@ -320,7 +320,9 @@ describeIfDatabase('invite accept concurrency + rollback (real DB)', () => {
     const writes = await fs.readFile(path.join(root, 'invite-accept-writes.ts'), 'utf8')
     const ledger = await fs.readFile(path.join(root, 'invite-ledger.ts'), 'utf8')
 
-    expect(writes).toContain('await transaction(async (client)')
+    // O2-S2: the one transaction is now wrapped by the 40001 recovery-conflict translator —
+    // pin the WHOLE shape (wrapper + single transaction) so neither can be dropped silently.
+    expect(writes).toContain('await translateRecoveryConflict(() => transaction(async (client)')
     expect(writes).toContain('markInviteAccepted')
     expect(writes).toContain('UPDATE users')
     expect(writes).toContain("activation_status = 'activated'")

--- a/packages/core-backend/tests/integration/multitable-recovery-lease-backoff-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-recovery-lease-backoff-realdb.test.ts
@@ -1,0 +1,481 @@
+/**
+ * O2-S3 — exclusive-authority-lease starvation backoff (real DB).
+ *
+ * Module under test: `exact-anchor-recovery-execute.ts` bounded lease backoff around
+ * `applyExactAnchorRecovery`, driven by the REAL `acquireRecoveryAuthorityLease` (the shared-writer /
+ * exclusive-recovery NOWAIT lease) with the nine authority triggers ENABLED — writers in these goldens
+ * hold the shared lease through the PRODUCTION trigger path (INSERT on user_permissions /
+ * role_permissions), never a synthetic lock call.
+ *
+ * Goldens:
+ *   CONTROL          no writer ⇒ the real lease acquires on the FIRST attempt and the apply lands
+ *                    (the busy goldens below are proven load-bearing, not vacuously green).
+ *   BASELINE (a)     writer holds the shared lease continuously; `maxAttempts: 1` (the old
+ *                    single-attempt semantics) ⇒ immediate named busy outcome (`preview-drift`),
+ *                    exactly one lease attempt, zero sleeps, zero writes.
+ *   GAP (b) + (e)    writer holds, then releases DURING the first backoff sleep ⇒ the next fresh
+ *                    NOWAIT attempt acquires the lease within the default budget. Two-connection
+ *                    evidence inside the sleep: an EXCLUSIVE probe on the actor key fails while the
+ *                    writer still holds (positive control: the probe detects held leases), succeeds
+ *                    after release (recovery holds NOTHING between attempts), and a brand-new writer
+ *                    transaction commits during the sleep (writers proceed during backoff).
+ *   PARTIAL (e')     writer holds only the ROLE key ⇒ recovery takes the USER key then loses the role
+ *                    NOWAIT try (a PARTIALLY-taken lease). The exclusive USER-key probe succeeds during
+ *                    the sleep ⇒ the partial acquisition was released by the attempt's rollback.
+ *   EXHAUSTION (c)   writer never pauses ⇒ default RECOVERY_LEASE_BACKOFF_MAX_ATTEMPTS fresh attempts
+ *                    separated by the exported increasing delays, then the SAME named busy outcome,
+ *                    fail-closed with zero writes (no burn, live row untouched).
+ *
+ * No-deadlock model preserved: every attempt is NOWAIT end-to-end and nothing is held between attempts
+ * (proven by the probes) — the backoff adds timer sleeps, never blocking lock waits.
+ *
+ * Two-point wiring: plugin-tests.yml multitable real-DB run list + vitest.config.ts no-DB exclusion;
+ * fail-not-skip sentinel below.
+ */
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { RECOVERY_AUTHORITY_TRIGGERS } from '../../src/db/migrations/zzzz20260721121000_add_recovery_authority_locks'
+import { acquireRecoveryAuthorityLease } from '../../src/multitable/recovery-authorization-stability'
+import { resolveExactAnchor } from '../../src/multitable/exact-anchor-recovery'
+import {
+  applyExactAnchorRecovery,
+  RECOVERY_LEASE_BACKOFF_DELAYS_MS,
+  RECOVERY_LEASE_BACKOFF_MAX_ATTEMPTS,
+  recoveryLeaseBackoffDelayMs,
+} from '../../src/multitable/exact-anchor-recovery-execute'
+import { activateCheckpoint, type QueryFn } from '../../src/multitable/history-trust-checkpoint'
+import { __resetRecoveryWriterStateColumnProbe } from '../../src/multitable/canonical-sheet-fence'
+import { __resetOperationLedgerColumnProbe } from '../../src/multitable/operation-ledger'
+
+import { randomUUID } from 'node:crypto'
+import type { PoolClient } from 'pg'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const FLAG = 'MULTITABLE_ENABLE_WRITER_FENCE'
+const STRICT = 'MULTITABLE_HISTORY_CONTIGUITY_STRICT'
+const TS = Date.now()
+const BASE = `base_o2s3_${TS}`
+const SHEET = `sheet_o2s3_${TS}`
+const F_STR = `fld_o2s3_note_${TS}`
+const ACTOR = `user_o2s3_${TS}`
+const ROLE = `role_o2s3_${TS}`
+
+const q = (sql: string, params: unknown[] = []) => poolManager.get().query(sql, params)
+const txn = <T>(fn: (query: QueryFn) => Promise<T>): Promise<T> =>
+  poolManager.get().transaction(async ({ query }) => fn(query as unknown as QueryFn)) as Promise<T>
+const internal = () => {
+  const pool = poolManager.get().getInternalPool()
+  if (!pool) throw new Error('internal pool unavailable')
+  return pool
+}
+
+// Kernel adjudication stubs (route injects real evaluators; this suite isolates the LEASE seam).
+const ALLOW = async () => true
+
+/** REAL lease acquisition over the actor key, with an attempt counter (the discriminator every golden pins). */
+const makeStabilizer = () => {
+  let calls = 0
+  const stabilize = async (query: QueryFn): Promise<'ready' | 'busy' | 'unavailable'> => {
+    calls += 1
+    return acquireRecoveryAuthorityLease(query, [ACTOR])
+  }
+  return { stabilize, attempts: () => calls }
+}
+
+const applyArgs = (
+  token: string,
+  stabilize: ReturnType<typeof makeStabilizer>['stabilize'],
+  leaseBackoff?: {
+    maxAttempts?: number
+    delaysMs?: readonly number[]
+    sleep?: (ms: number, attemptJustFailed: number) => Promise<void>
+  },
+) => ({
+  token,
+  sheetId: SHEET,
+  actorId: ACTOR,
+  preliminaryFullRead: ALLOW,
+  stabilizeAuthorization: stabilize,
+  finalLockedFullRead: ALLOW,
+  evaluatePlanAuthorization: ALLOW,
+  ...(leaseBackoff ? { leaseBackoff } : {}),
+})
+
+/** Open writer transaction holding the SHARED lease on the ACTOR user key via the PRODUCTION trigger path. */
+async function startSharedUserWriter(permissionCode: string): Promise<PoolClient> {
+  const client = await internal().connect()
+  await client.query('BEGIN')
+  await client.query(
+    'INSERT INTO user_permissions (user_id, permission_code) VALUES ($1,$2)',
+    [ACTOR, permissionCode],
+  )
+  return client
+}
+
+/** Open writer transaction holding the SHARED lease on the ROLE key only (role_permissions trigger). */
+async function startSharedRoleWriter(permissionCode: string): Promise<PoolClient> {
+  const client = await internal().connect()
+  await client.query('BEGIN')
+  await client.query(
+    'INSERT INTO role_permissions (role_id, permission_code) VALUES ($1,$2)',
+    [ROLE, permissionCode],
+  )
+  return client
+}
+
+/** Two-connection probe: can a FRESH connection take the EXCLUSIVE user-key lease right now? */
+async function probeExclusiveUserKey(): Promise<boolean> {
+  const client = await internal().connect()
+  try {
+    await client.query('BEGIN')
+    const res = await client.query(
+      'SELECT metasheet_try_recovery_authority_user($1, TRUE) AS acquired',
+      [ACTOR],
+    )
+    return (res.rows[0] as { acquired?: unknown } | undefined)?.acquired === true
+  } finally {
+    await client.query('ROLLBACK').catch(() => {})
+    client.release()
+  }
+}
+
+const releaseWriter = async (client: PoolClient | null, verb: 'COMMIT' | 'ROLLBACK' = 'ROLLBACK') => {
+  if (!client) return
+  await client.query(verb).catch(() => {})
+  client.release()
+}
+
+const revSeq = (recordId: string, version: number, action: 'create' | 'update' | 'delete', snap: Record<string, unknown>, seq: string, opId?: string | null) =>
+  q(
+    `INSERT INTO meta_record_revisions (id, sheet_id, record_id, version, action, source, changed_field_ids, patch, snapshot, seq, operation_id)
+     VALUES (gen_random_uuid(),$1,$2,$3,$4,'rest',ARRAY[]::text[],'{}'::jsonb,$5::jsonb,$6::bigint,$7::uuid)`,
+    [SHEET, recordId, version, action, JSON.stringify(snap), seq, opId ?? null],
+  )
+const live = (id: string, data: Record<string, unknown>, version = 1) =>
+  q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,$4)', [id, SHEET, JSON.stringify(data), version])
+const liveRow = async (id: string) =>
+  (await q('SELECT data, version FROM meta_records WHERE id = $1 AND sheet_id = $2', [id, SHEET])).rows[0] as { data: Record<string, unknown>; version: number } | undefined
+const burnCount = async () => Number(((await q('SELECT count(*)::int c FROM meta_recovery_token_burns WHERE sheet_id = $1', [SHEET])).rows[0] as { c: number }).c)
+
+async function sealAnchorOp(recordId: string, seq: string, snap: Record<string, unknown>): Promise<string> {
+  const opId = randomUUID()
+  await txn(async (query) => {
+    await query(
+      `INSERT INTO meta_record_revisions (id, sheet_id, record_id, version, action, source, changed_field_ids, patch, snapshot, seq, operation_id)
+       VALUES (gen_random_uuid(),$1,$2,1,'create','rest',ARRAY[]::text[],'{}'::jsonb,$3::jsonb,$4::bigint,$5::uuid)`,
+      [SHEET, recordId, JSON.stringify(snap), seq, opId],
+    )
+    await query(
+      `INSERT INTO meta_record_history_operations (sheet_id, operation_id, endpoint_seq, event_count) VALUES ($1,$2::uuid,$3::bigint,1)`,
+      [SHEET, opId, seq],
+    )
+  })
+  return opId
+}
+const activate = () => txn((query) => activateCheckpoint(query, { sheetId: SHEET }))
+
+async function wipe(): Promise<void> {
+  for (const t of ['meta_history_baselines', 'meta_history_trust_checkpoints', 'meta_recovery_token_burns', 'meta_record_version_markers', 'meta_records_trash', 'meta_record_revisions', 'meta_records'])
+    await q(`DELETE FROM ${t} WHERE sheet_id = $1`, [SHEET]).catch(() => {})
+  await q('DELETE FROM meta_record_history_operations WHERE sheet_id = $1', [SHEET]).catch(() => {})
+}
+
+/** Reserve `count` REAL chain-seq values strictly ABOVE the freshly-activated checkpoint (nextval only). */
+async function seqBand(count: number): Promise<string[]> {
+  await activate()
+  const floorRes = await q(
+    `SELECT trusted_since_seq::text AS s FROM meta_history_trust_checkpoints
+     WHERE sheet_id = $1 AND state = 'active' AND pruned_at IS NULL`,
+    [SHEET],
+  )
+  const floor = BigInt(String((floorRes.rows[0] as { s: string }).s))
+  const seqs: string[] = []
+  while (seqs.length < count) {
+    const r = await q(`SELECT nextval('meta_record_chain_seq')::text AS s`)
+    const s = BigInt(String((r.rows[0] as { s: string }).s))
+    if (s > floor) seqs.push(String(s))
+  }
+  return seqs
+}
+
+/** Minimal revert world: R live version 2 differs from the sealed at-anchor snapshot (version 1). */
+async function seedWorld() {
+  const R = `rec_o2s3_${TS}_${Math.random().toString(36).slice(2, 6)}`
+  const [sCreate, sUpdate] = await seqBand(2)
+  const anchorOp = await sealAnchorOp(R, sCreate, { [F_STR]: 'at-anchor' })
+  await revSeq(R, 2, 'update', { [F_STR]: 'live-now' }, sUpdate)
+  await live(R, { [F_STR]: 'live-now' }, 2)
+  return { R, anchorOp }
+}
+
+const preview = async (anchorOp: string) => {
+  const res = await resolveExactAnchor(q as unknown as QueryFn, {
+    sheetId: SHEET,
+    request: { kind: 'exact-anchor', anchorOperationId: anchorOp },
+    actorId: ACTOR,
+    mode: 'revert',
+    evaluateFullReadAccess: ALLOW,
+  })
+  expect(res.ok).toBe(true)
+  if (!res.ok) throw new Error('preview failed')
+  return res
+}
+
+test('sentinel: the real-DB allowlist step must have DATABASE_URL (fail-not-skip, scoped to that step)', () => {
+  if (process.env.METASHEET_REAL_DB_TEST_STEP === '1' && !process.env.DATABASE_URL) {
+    throw new Error('lease-backoff real-DB step is missing DATABASE_URL — the harness is broken, not legitimately skippable')
+  }
+  expect(true).toBe(true)
+})
+
+describe('O2-S3 — backoff constants (pure)', () => {
+  test('the ladder is bounded and strictly increasing; the delay helper clamps to the last rung', () => {
+    expect(RECOVERY_LEASE_BACKOFF_MAX_ATTEMPTS).toBeGreaterThan(1)
+    expect(RECOVERY_LEASE_BACKOFF_DELAYS_MS.length).toBe(RECOVERY_LEASE_BACKOFF_MAX_ATTEMPTS - 1)
+    for (let i = 1; i < RECOVERY_LEASE_BACKOFF_DELAYS_MS.length; i++) {
+      expect(RECOVERY_LEASE_BACKOFF_DELAYS_MS[i]).toBeGreaterThan(RECOVERY_LEASE_BACKOFF_DELAYS_MS[i - 1])
+    }
+    expect(recoveryLeaseBackoffDelayMs(1)).toBe(RECOVERY_LEASE_BACKOFF_DELAYS_MS[0])
+    expect(recoveryLeaseBackoffDelayMs(RECOVERY_LEASE_BACKOFF_DELAYS_MS.length)).toBe(
+      RECOVERY_LEASE_BACKOFF_DELAYS_MS[RECOVERY_LEASE_BACKOFF_DELAYS_MS.length - 1],
+    )
+    // Past-the-end attempts clamp to the LAST rung (never 0, never out-of-bounds undefined).
+    expect(recoveryLeaseBackoffDelayMs(99)).toBe(
+      RECOVERY_LEASE_BACKOFF_DELAYS_MS[RECOVERY_LEASE_BACKOFF_DELAYS_MS.length - 1],
+    )
+    expect(recoveryLeaseBackoffDelayMs(1, [])).toBe(0)
+  })
+})
+
+describeIfDatabase.sequential('O2-S3 — exclusive-authority-lease starvation backoff (real DB)', () => {
+  let initialTriggerStates: string[] = []
+
+  beforeAll(async () => {
+    await q("INSERT INTO users (id, password_hash) VALUES ($1,'x') ON CONFLICT (id) DO NOTHING", [ACTOR])
+    await q('INSERT INTO user_roles (user_id, role_id) VALUES ($1,$2) ON CONFLICT DO NOTHING', [ACTOR, ROLE])
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE, 'O2S3 Base'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET, BASE, 'O2S3'])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [F_STR, SHEET, 'Note', 'string', '{}', 1])
+    initialTriggerStates = (
+      await q(
+        `SELECT tgenabled FROM pg_trigger WHERE NOT tgisinternal AND tgname = ANY($1::text[]) ORDER BY tgname`,
+        [[...RECOVERY_AUTHORITY_TRIGGERS].map(([, trigger]) => trigger)],
+      )
+    ).rows.map((row) => String((row as { tgenabled: unknown }).tgenabled))
+    for (const [table, trigger] of RECOVERY_AUTHORITY_TRIGGERS) {
+      await q(`ALTER TABLE ${table} ENABLE TRIGGER ${trigger}`)
+    }
+  })
+
+  beforeEach(async () => {
+    await wipe()
+    process.env[FLAG] = 'true'
+    process.env[STRICT] = 'true'
+    __resetRecoveryWriterStateColumnProbe()
+    __resetOperationLedgerColumnProbe()
+  })
+
+  afterEach(async () => {
+    delete process.env[FLAG]
+    delete process.env[STRICT]
+    await q('DELETE FROM user_permissions WHERE user_id = $1', [ACTOR]).catch(() => {})
+    await q('DELETE FROM role_permissions WHERE role_id = $1', [ROLE]).catch(() => {})
+  })
+
+  afterAll(async () => {
+    for (const [table, trigger] of RECOVERY_AUTHORITY_TRIGGERS) {
+      await q(`ALTER TABLE ${table} DISABLE TRIGGER ${trigger}`).catch(() => {})
+    }
+    await wipe()
+    await q('DELETE FROM meta_fields WHERE sheet_id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE]).catch(() => {})
+    await q('DELETE FROM user_permissions WHERE user_id = $1', [ACTOR]).catch(() => {})
+    await q('DELETE FROM user_roles WHERE user_id = $1', [ACTOR]).catch(() => {})
+    await q('DELETE FROM users WHERE id = $1', [ACTOR]).catch(() => {})
+  })
+
+  test('sentinel: DATABASE_URL is set (this suite must RUN, never skip-green)', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  test('CONTROL: with no writer, the REAL lease acquires on the first attempt and the apply lands', async () => {
+    const { R, anchorOp } = await seedWorld()
+    const pv = await preview(anchorOp)
+    const stab = makeStabilizer()
+    const sleeps: Array<[number, number]> = []
+    const out = await applyExactAnchorRecovery(txn, applyArgs(pv.token, stab.stabilize, {
+      sleep: async (ms, attempt) => { sleeps.push([ms, attempt]) },
+    }))
+    expect(out).toMatchObject({ ok: true, mode: 'revert', applied: { reverts: 1, resurrects: 0, deletes: 0 } })
+    expect(stab.attempts()).toBe(1)
+    expect(sleeps).toEqual([])
+    expect((await liveRow(R))?.data).toEqual({ [F_STR]: 'at-anchor' })
+    expect(await burnCount()).toBe(1)
+  })
+
+  test('BASELINE (a): continuous shared writer + single attempt (old semantics) ⇒ immediate named busy outcome, zero writes', async () => {
+    const { R, anchorOp } = await seedWorld()
+    const pv = await preview(anchorOp)
+    const writer = await startSharedUserWriter('demo:read')
+    try {
+      const stab = makeStabilizer()
+      const sleeps: Array<[number, number]> = []
+      const out = await applyExactAnchorRecovery(txn, applyArgs(pv.token, stab.stabilize, {
+        maxAttempts: 1,
+        sleep: async (ms, attempt) => { sleeps.push([ms, attempt]) },
+      }))
+      expect(out).toEqual({ ok: false, reason: 'preview-drift' }) // the existing named busy outcome
+      expect(stab.attempts()).toBe(1) // exactly ONE NOWAIT try — busy immediately, no waiting
+      expect(sleeps).toEqual([]) // single-attempt semantics never sleeps
+      expect((await liveRow(R))?.data).toEqual({ [F_STR]: 'live-now' }) // zero writes
+      expect((await liveRow(R))?.version).toBe(2)
+      expect(await burnCount()).toBe(0) // burn rolled back with the refused attempt
+    } finally {
+      await releaseWriter(writer)
+    }
+  })
+
+  test('GAP (b) + two-connection (e): writer releases during the first backoff sleep ⇒ next fresh NOWAIT attempt acquires; nothing is held between attempts', async () => {
+    const { R, anchorOp } = await seedWorld()
+    const pv = await preview(anchorOp)
+    let writer: PoolClient | null = await startSharedUserWriter('demo:read')
+    const evidence: Array<[string, unknown]> = []
+    const sleeps: Array<[number, number]> = []
+    try {
+      const stab = makeStabilizer()
+      const out = await applyExactAnchorRecovery(txn, applyArgs(pv.token, stab.stabilize, {
+        // Default maxAttempts/delays — proves the exported constants flow through unmodified.
+        sleep: async (ms, attempt) => {
+          sleeps.push([ms, attempt])
+          if (attempt !== 1) return
+          // Positive control: while the writer still holds the shared lease, the exclusive probe FAILS —
+          // the probe genuinely detects held leases (its later `true` is not vacuous).
+          evidence.push(['exclusive-while-writer-holds', await probeExclusiveUserKey()])
+          // The writer stream pauses (gap): release the shared lease.
+          await releaseWriter(writer)
+          writer = null
+          // (e) Between attempts recovery holds NOTHING: a fresh connection can take the EXCLUSIVE key.
+          evidence.push(['exclusive-during-backoff', await probeExclusiveUserKey()])
+          // (e) A brand-new writer PROCEEDS during the backoff sleep (trigger shared lease + commit).
+          const during = await startSharedUserWriter('demo:write')
+          await releaseWriter(during, 'COMMIT')
+          evidence.push(['writer-committed-during-backoff', Number(
+            ((await q('SELECT count(*)::int c FROM user_permissions WHERE user_id = $1 AND permission_code = $2', [ACTOR, 'demo:write'])).rows[0] as { c: number }).c,
+          )])
+        },
+      }))
+      expect(out).toMatchObject({ ok: true, mode: 'revert', applied: { reverts: 1, resurrects: 0, deletes: 0 } })
+      expect(stab.attempts()).toBe(2) // busy once, acquired on the SECOND fresh NOWAIT try — within budget
+      expect(sleeps).toEqual([[RECOVERY_LEASE_BACKOFF_DELAYS_MS[0], 1]]) // default first rung, once
+      expect(evidence).toEqual([
+        ['exclusive-while-writer-holds', false],
+        ['exclusive-during-backoff', true],
+        ['writer-committed-during-backoff', 1],
+      ])
+      expect((await liveRow(R))?.data).toEqual({ [F_STR]: 'at-anchor' }) // settled post-commit truth
+      expect((await liveRow(R))?.version).toBe(3)
+      expect(await burnCount()).toBe(1)
+    } finally {
+      await releaseWriter(writer)
+    }
+  })
+
+  test("PARTIAL (e'): role-key writer makes the lease PARTIALLY taken (user key acquired, role key busy) — the partial is released between attempts", async () => {
+    const { R, anchorOp } = await seedWorld()
+    const pv = await preview(anchorOp)
+    let writer: PoolClient | null = await startSharedRoleWriter('demo:read')
+    const evidence: Array<[string, unknown]> = []
+    try {
+      let calls = 0
+      const stabilize = async (query: QueryFn): Promise<'ready' | 'busy' | 'unavailable'> => {
+        calls += 1
+        const r = await acquireRecoveryAuthorityLease(query, [ACTOR])
+        if (r === 'busy') {
+          // POSITIVE CONTROL, in-attempt: the busy attempt is still open here, so its PARTIAL
+          // acquisition (the exclusive USER key, taken before the ROLE key NOWAIT try lost) must make a
+          // fresh-connection exclusive probe FAIL. Without this, the during-backoff `true` below could
+          // be vacuous (a lease that was never taken is trivially "released").
+          evidence.push(['user-key-held-inside-busy-attempt', await probeExclusiveUserKey()])
+        }
+        return r
+      }
+      const out = await applyExactAnchorRecovery(txn, applyArgs(pv.token, stabilize, {
+        sleep: async (_ms, attempt) => {
+          if (attempt !== 1) return
+          // If the partial acquisition survived the attempt, this fresh-connection probe would fail.
+          evidence.push(['user-key-free-during-backoff', await probeExclusiveUserKey()])
+          await releaseWriter(writer)
+          writer = null
+        },
+      }))
+      expect(out).toMatchObject({ ok: true, applied: { reverts: 1 } })
+      expect(calls).toBe(2)
+      expect(evidence).toEqual([
+        ['user-key-held-inside-busy-attempt', false],
+        ['user-key-free-during-backoff', true],
+      ])
+      expect((await liveRow(R))?.data).toEqual({ [F_STR]: 'at-anchor' })
+    } finally {
+      await releaseWriter(writer)
+    }
+  })
+
+  test('EXHAUSTION (c): writer never pauses ⇒ default attempts with increasing spacing, then the SAME named busy outcome, zero writes', async () => {
+    const { R, anchorOp } = await seedWorld()
+    const pv = await preview(anchorOp)
+    const writer = await startSharedUserWriter('demo:read')
+    try {
+      const stab = makeStabilizer()
+      const sleeps: Array<[number, number]> = []
+      const out = await applyExactAnchorRecovery(txn, applyArgs(pv.token, stab.stabilize, {
+        sleep: async (ms, attempt) => { sleeps.push([ms, attempt]) }, // writer NEVER releases
+      }))
+      expect(out).toEqual({ ok: false, reason: 'preview-drift' }) // fail-closed named busy outcome unchanged
+      expect(stab.attempts()).toBe(RECOVERY_LEASE_BACKOFF_MAX_ATTEMPTS) // bounded — never spins forever
+      expect(sleeps).toEqual(
+        RECOVERY_LEASE_BACKOFF_DELAYS_MS.map((ms, i) => [ms, i + 1]), // increasing exported ladder
+      )
+      expect((await liveRow(R))?.data).toEqual({ [F_STR]: 'live-now' }) // zero writes after exhaustion
+      expect((await liveRow(R))?.version).toBe(2)
+      expect(await burnCount()).toBe(0)
+    } finally {
+      await releaseWriter(writer)
+    }
+  })
+
+  test('REAL-TIMER: default sleep (no injection) still acquires in a writer gap — the ladder is wall-clock real, not only hook-driven', async () => {
+    const { R, anchorOp } = await seedWorld()
+    const pv = await preview(anchorOp)
+    let writer: PoolClient | null = await startSharedUserWriter('demo:read')
+    let calls = 0
+    // No `sleep` injection: the DEFAULT timer ladder runs. The writer releases as soon as the FIRST
+    // NOWAIT try has verifiably lost (never earlier — releasing on a wall-clock timer could beat the
+    // first attempt and make this test pass without ever exercising the backoff).
+    const stabilize = async (query: QueryFn): Promise<'ready' | 'busy' | 'unavailable'> => {
+      calls += 1
+      const r = await acquireRecoveryAuthorityLease(query, [ACTOR])
+      if (r === 'busy' && writer) {
+        const held = writer
+        writer = null
+        void releaseWriter(held) // concurrent release; completes well inside the 50ms default sleep
+      }
+      return r
+    }
+    try {
+      const out = await applyExactAnchorRecovery(txn, applyArgs(pv.token, stabilize))
+      expect(out).toMatchObject({ ok: true, applied: { reverts: 1 } })
+      expect(calls).toBe(2) // busy once, then the REAL 50ms default backoff, then acquired
+      expect((await liveRow(R))?.data).toEqual({ [F_STR]: 'at-anchor' })
+      expect(await burnCount()).toBe(1)
+    } finally {
+      await releaseWriter(writer)
+    }
+  })
+
+  test('posture restore probe: the nine triggers were all disabled before this suite enabled them', () => {
+    expect(initialTriggerStates).toHaveLength(RECOVERY_AUTHORITY_TRIGGERS.length)
+    expect(new Set(initialTriggerStates)).toEqual(new Set(['D']))
+  })
+})

--- a/packages/core-backend/tests/integration/recovery-conflict-classifier-realdb.test.ts
+++ b/packages/core-backend/tests/integration/recovery-conflict-classifier-realdb.test.ts
@@ -1,0 +1,163 @@
+/**
+ * O2-S2 — real-Postgres proof that the single recovery-conflict classifier
+ * (src/db/recovery-conflict.ts) matches the PRODUCTION error shape, not just the unit
+ * fixtures: the marker 40001 asserted here is raised by the real recovery-authority
+ * trigger under a genuinely held exclusive lease.
+ *
+ * Mirrors the harness of multitable-recovery-authority-stability-realdb.test.ts
+ * (DATABASE_URL-gated; triggers enabled for the suite and restored after).
+ *
+ * Positive controls: the same write SUCCEEDS once the lease is released, and a real
+ * non-40001 failure (FK violation) passes through translateRecoveryConflict as the SAME
+ * pg error object — nothing outside the marker family is reclassified.
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { RECOVERY_AUTHORITY_TRIGGERS } from '../../src/db/migrations/zzzz20260721121000_add_recovery_authority_locks'
+import { acquireRecoveryAuthorityLease } from '../../src/multitable/recovery-authorization-stability'
+import {
+  classifyRecoveryConflict,
+  RECOVERY_CONFLICT_HTTP_CODE,
+  RecoveryConflictError,
+  translateRecoveryConflict,
+} from '../../src/db/recovery-conflict'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const TS = Date.now()
+
+// Fail-not-skip sentinel (skip-when-unreachable blind spot): inside the CI real-DB
+// allowlist step, a missing DATABASE_URL must be a FAILURE, never a silent skip-green.
+test('sentinel: the real-DB allowlist step must have DATABASE_URL', () => {
+  if (process.env.METASHEET_REAL_DB_TEST_STEP === '1' && !process.env.DATABASE_URL) {
+    throw new Error('recovery-conflict real-DB step is missing DATABASE_URL')
+  }
+  expect(true).toBe(true)
+})
+
+const USER_A = `user_o2s2_conflict_${TS}`
+const ROLE_A = `role_o2s2_conflict_${TS}`
+const q = (sql: string, params: unknown[] = []) => poolManager.get().query(sql, params)
+const asQuery = (client: { query: (sql: string, params?: unknown[]) => Promise<unknown> }) =>
+  (sql: string, params?: unknown[]) => client.query(sql, params) as never
+
+describeIfDatabase.sequential('O2-S2 classifier vs the real recovery-authority 40001', () => {
+  beforeAll(async () => {
+    await q(
+      `INSERT INTO users (id, password_hash) VALUES ($1,'x') ON CONFLICT (id) DO NOTHING`,
+      [USER_A],
+    )
+    await q(
+      `INSERT INTO roles (id, name) VALUES ($1,$1) ON CONFLICT (id) DO NOTHING`,
+      [ROLE_A],
+    )
+    for (const [table, trigger] of RECOVERY_AUTHORITY_TRIGGERS) {
+      await q(`ALTER TABLE ${table} ENABLE TRIGGER ${trigger}`)
+    }
+  })
+
+  afterAll(async () => {
+    for (const [table, trigger] of RECOVERY_AUTHORITY_TRIGGERS) {
+      await q(`ALTER TABLE ${table} DISABLE TRIGGER ${trigger}`).catch(() => {})
+    }
+    await q('DELETE FROM user_roles WHERE user_id = $1', [USER_A]).catch(() => {})
+    await q('DELETE FROM roles WHERE id = $1', [ROLE_A]).catch(() => {})
+    await q('DELETE FROM users WHERE id = $1', [USER_A]).catch(() => {})
+  })
+
+  test('the trigger-raised 40001 classifies as recovery_conflict; released lease → write succeeds', async () => {
+    const internal = poolManager.get().getInternalPool()
+    expect(internal).toBeTruthy()
+    const recovery = await internal!.connect()
+    const writer = await internal!.connect()
+    try {
+      await recovery.query('BEGIN')
+      expect(await acquireRecoveryAuthorityLease(asQuery(recovery), [USER_A])).toBe('ready')
+
+      await writer.query('BEGIN')
+      const raised = await writer
+        .query('INSERT INTO user_roles (user_id, role_id) VALUES ($1,$2)', [USER_A, ROLE_A])
+        .then(
+          () => null,
+          (error: unknown) => error,
+        )
+      await writer.query('ROLLBACK')
+      expect(raised).not.toBeNull()
+      // THE production shape, classified by THE single classifier.
+      expect(classifyRecoveryConflict(raised)).toBe('recovery_conflict')
+      expect((raised as { code?: string }).code).toBe('40001')
+
+      await recovery.query('COMMIT')
+
+      // Positive control: with the lease released the SAME write succeeds — the
+      // classification above came from the lease, not from ambient breakage.
+      await writer.query('BEGIN')
+      await writer.query('INSERT INTO user_roles (user_id, role_id) VALUES ($1,$2)', [USER_A, ROLE_A])
+      await writer.query('ROLLBACK')
+      expect(classifyRecoveryConflict(null)).toBeNull()
+    } finally {
+      await writer.query('ROLLBACK').catch(() => {})
+      await recovery.query('ROLLBACK').catch(() => {})
+      writer.release()
+      recovery.release()
+    }
+  })
+
+  test('translateRecoveryConflict re-raises the REAL trigger 40001 as the named retryable error', async () => {
+    const internal = poolManager.get().getInternalPool()
+    expect(internal).toBeTruthy()
+    const recovery = await internal!.connect()
+    const writer = await internal!.connect()
+    try {
+      await recovery.query('BEGIN')
+      expect(await acquireRecoveryAuthorityLease(asQuery(recovery), [USER_A])).toBe('ready')
+
+      await writer.query('BEGIN')
+      const caught = await translateRecoveryConflict(async () => {
+        await writer.query('INSERT INTO user_roles (user_id, role_id) VALUES ($1,$2)', [USER_A, ROLE_A])
+      }).then(
+        () => null,
+        (error: unknown) => error,
+      )
+      await writer.query('ROLLBACK')
+      await recovery.query('COMMIT')
+
+      expect(caught).toBeInstanceOf(RecoveryConflictError)
+      expect((caught as RecoveryConflictError).code).toBe(RECOVERY_CONFLICT_HTTP_CODE)
+      expect((caught as RecoveryConflictError).retryable).toBe(true)
+    } finally {
+      await writer.query('ROLLBACK').catch(() => {})
+      await recovery.query('ROLLBACK').catch(() => {})
+      writer.release()
+      recovery.release()
+    }
+  })
+
+  test('a REAL non-40001 failure (duplicate key) passes through as the SAME pg error', async () => {
+    const internal = poolManager.get().getInternalPool()
+    expect(internal).toBeTruthy()
+    const writer = await internal!.connect()
+    try {
+      await writer.query('BEGIN')
+      await writer.query('INSERT INTO user_roles (user_id, role_id) VALUES ($1,$2)', [USER_A, ROLE_A])
+      const caught = await translateRecoveryConflict(async () => {
+        // Second identical INSERT violates the (user_id, role_id) primary key: a REAL
+        // 23505, raised with no recovery lease held anywhere.
+        await writer.query('INSERT INTO user_roles (user_id, role_id) VALUES ($1,$2)', [USER_A, ROLE_A])
+      }).then(
+        () => null,
+        (error: unknown) => error,
+      )
+      await writer.query('ROLLBACK')
+
+      expect(caught).not.toBeNull()
+      expect(caught).not.toBeInstanceOf(RecoveryConflictError)
+      expect((caught as { code?: string }).code).toBe('23505')
+      expect(classifyRecoveryConflict(caught)).toBeNull()
+    } finally {
+      await writer.query('ROLLBACK').catch(() => {})
+      writer.release()
+    }
+  })
+})

--- a/packages/core-backend/tests/unit/AuthService.test.ts
+++ b/packages/core-backend/tests/unit/AuthService.test.ts
@@ -615,10 +615,13 @@ describe('AuthService.register', () => {
     ).rejects.toBeInstanceOf(UserRoleAssignmentRecoveryBusyError)
 
     // Bounded: exactly the configured retry limit worth of attempts, never unbounded and never
-    // a single silent try.
+    // a single silent try. O2-S1 made the retry unit the WHOLE transaction, so each attempt
+    // re-runs the users insert too — one user_roles attempt per transaction attempt.
     expect(userRolesAttempts).toBe(USER_ROLE_ASSIGNMENT_RETRY_LIMIT)
-    // The users row and permissions DID persist (createUser's own transaction is untouched by
-    // this slice) — it is specifically the "success with no role" outcome that must not happen.
+    expect(poolMocks.transaction).toHaveBeenCalledTimes(USER_ROLE_ASSIGNMENT_RETRY_LIMIT)
+    // The users insert ran inside every attempted transaction (each rolled back on the real
+    // pool — zero residue is proven by the real-DB suite,
+    // tests/integration/auth-register-atomicity.db.test.ts).
     expect(poolMocks.query.mock.calls.some(([sql]) => String(sql).includes('INSERT INTO users'))).toBe(true)
   })
 })

--- a/packages/core-backend/tests/unit/recovery-conflict-activate-mapping.test.ts
+++ b/packages/core-backend/tests/unit/recovery-conflict-activate-mapping.test.ts
@@ -1,0 +1,65 @@
+/**
+ * O2-S2 — mapActivateError (routes/admin-users.ts) recovery-conflict branch.
+ *
+ * The activate surface's HTTP mapping: a recovery conflict (the named retryable
+ * RecoveryConflictError re-raised by activatePendingUser, or a raw marker 40001) maps
+ * to the EXACT retryable 409 policy — and every pre-existing row of the closed
+ * ACTIVATE_* policy table plus the ACTIVATE_FAILED fallback stays byte-identical.
+ */
+
+import { describe, expect, it } from 'vitest'
+import {
+  ACTIVATE_ERROR_FALLBACK,
+  ACTIVATE_ERROR_POLICY,
+  mapActivateError,
+} from '../../src/routes/admin-users'
+import {
+  RECOVERY_CONFLICT_HTTP_CODE,
+  RECOVERY_CONFLICT_HTTP_MESSAGE,
+  RecoveryConflictError,
+} from '../../src/db/recovery-conflict'
+import { RECOVERY_AUTHORITY_BUSY_MARKER } from '../../src/multitable/recovery-authorization-stability'
+
+function markerError(): Error & { code: string } {
+  return Object.assign(new Error(RECOVERY_AUTHORITY_BUSY_MARKER), { code: '40001' })
+}
+
+describe('mapActivateError — O2-S2 recovery-conflict branch', () => {
+  it('the named RecoveryConflictError maps to the exact retryable 409', () => {
+    expect(mapActivateError(new RecoveryConflictError(markerError()))).toEqual({
+      status: 409,
+      code: RECOVERY_CONFLICT_HTTP_CODE,
+      message: RECOVERY_CONFLICT_HTTP_MESSAGE,
+    })
+  })
+
+  it('a raw marker 40001 leak maps to the same exact retryable 409', () => {
+    expect(mapActivateError(markerError())).toEqual({
+      status: 409,
+      code: RECOVERY_CONFLICT_HTTP_CODE,
+      message: RECOVERY_CONFLICT_HTTP_MESSAGE,
+    })
+  })
+
+  it('a bare 40001 WITHOUT the marker still falls to the ACTIVATE_FAILED fallback (nothing loosened)', () => {
+    expect(mapActivateError(
+      Object.assign(new Error('could not serialize access'), { code: '40001' }),
+    )).toEqual({ ...ACTIVATE_ERROR_FALLBACK })
+  })
+
+  it('authored ACTIVATE_* rows are byte-identical to the policy table', () => {
+    for (const [code, row] of Object.entries(ACTIVATE_ERROR_POLICY)) {
+      expect(mapActivateError(Object.assign(new Error('db text, never published'), { code }))).toEqual({
+        code,
+        status: row.status,
+        message: row.message,
+      })
+    }
+  })
+
+  it('unauthored errors keep the exact ACTIVATE_FAILED fallback', () => {
+    expect(mapActivateError(new Error('anything'))).toEqual({ ...ACTIVATE_ERROR_FALLBACK })
+    expect(mapActivateError(Object.assign(new Error('x'), { code: 'ACTIVATE_DB_FAILURE' })))
+      .toEqual({ ...ACTIVATE_ERROR_FALLBACK })
+  })
+})

--- a/packages/core-backend/tests/unit/recovery-conflict-census.test.ts
+++ b/packages/core-backend/tests/unit/recovery-conflict-census.test.ts
@@ -1,0 +1,178 @@
+/**
+ * O2-S2 — MECHANICAL census: every enumerated 40001 write surface routes through the ONE
+ * classifier module (src/db/recovery-conflict.ts).
+ *
+ * Lesson constraint (枚举陷阱不收敛): per-site try/catch traps do not converge, so the
+ * gate is not "did we remember each trap" but a source-level census over a HARDCODED
+ * table of the enumerated writers: each file must import the classifier module and carry
+ * at least the expected number of adapter calls. Removing a wiring — or a single call
+ * site from a multi-site file — turns this red (proven by the negative controls below,
+ * which run the SAME census function over mutated copies of the real sources).
+ *
+ * This is a static census, not a behaviour proof — the discriminating behaviour tests
+ * live in recovery-conflict-classifier.test.ts and recovery-conflict-surfaces-*.test.ts.
+ */
+
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const SRC_ROOT = path.resolve(__dirname, '../../src')
+
+type WiringRequirement = {
+  /** Repo-relative path under packages/core-backend/src. */
+  file: string
+  /** Adapter call tokens this surface must invoke, with the minimum call-site count. */
+  calls: Array<{ token: string; minCount: number }>
+}
+
+/**
+ * The census table. The first 11 rows are the O2-S2 taskbook's enumerated write
+ * surfaces; the last two are the HTTP boundaries that complete two service surfaces
+ * (mapActivateError lives in routes/admin-users.ts; the deprovision-evidence and
+ * directory-sync service errors surface via routes/admin-directory.ts).
+ */
+const WIRING_CENSUS: readonly WiringRequirement[] = [
+  { file: 'directory/deprovision-evidence-api.ts', calls: [{ token: 'translateRecoveryConflict', minCount: 2 }] },
+  { file: 'directory/deprovision-ledger.ts', calls: [{ token: 'translateRecoveryConflict', minCount: 1 }] },
+  { file: 'auth/invite-accept-writes.ts', calls: [{ token: 'translateRecoveryConflict', minCount: 1 }] },
+  { file: 'auth/user-activate.ts', calls: [{ token: 'translateRecoveryConflict', minCount: 1 }] },
+  { file: 'routes/attendance-admin.ts', calls: [{ token: 'sendIfRecoveryConflict', minCount: 4 }] },
+  { file: 'routes/spreadsheet-permissions.ts', calls: [{ token: 'sendIfRecoveryConflict', minCount: 2 }] },
+  { file: 'routes/permissions.ts', calls: [{ token: 'sendIfRecoveryConflict', minCount: 3 }] },
+  { file: 'routes/roles.ts', calls: [{ token: 'sendIfRecoveryConflict', minCount: 3 }] },
+  { file: 'directory/directory-sync.ts', calls: [{ token: 'translateRecoveryConflict', minCount: 4 }] },
+  { file: 'auth/dingtalk-oauth.ts', calls: [{ token: 'translateRecoveryConflict', minCount: 3 }] },
+  {
+    file: 'routes/auth.ts',
+    calls: [
+      // register / invite-accept / dingtalk unbind / dingtalk callback / container login.
+      { token: 'sendIfRecoveryConflict', minCount: 5 },
+      // activate-intent passthrough: a recovery conflict must not collapse into
+      // mapDingTalkActivationFailure's 500 fallback.
+      { token: 'classifyRecoveryConflict', minCount: 1 },
+    ],
+  },
+  {
+    file: 'routes/admin-users.ts',
+    calls: [
+      // sendIfRecoveryAuthorityBusy delegates here for all six platform-admin writers.
+      { token: 'sendIfRecoveryConflict', minCount: 1 },
+      // mapActivateError's retryable-409 branch.
+      { token: 'classifyRecoveryConflict', minCount: 1 },
+    ],
+  },
+  // restore / compensate / sync x2 / bind / admit / batch-bind / batch-admit /
+  // unbind / batch-unbind.
+  { file: 'routes/admin-directory.ts', calls: [{ token: 'sendIfRecoveryConflict', minCount: 10 }] },
+] as const
+
+const IMPORT_RE = /from\s+['"][^'"]*\/db\/recovery-conflict['"]/
+
+/** Comments must not satisfy the census — strip them before counting call tokens. */
+function stripComments(source: string): string {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/(^|[^:'"])\/\/[^\n]*/g, '$1')
+}
+
+function countCalls(strippedSource: string, token: string): number {
+  const matches = strippedSource.match(new RegExp(`\\b${token}\\s*\\(`, 'g'))
+  return matches ? matches.length : 0
+}
+
+/**
+ * The census core, over CONTENT (not paths) so the negative controls can run the exact
+ * same logic against mutated copies. Returns human-readable violations; [] means wired.
+ */
+function auditRecoveryConflictWiring(contents: ReadonlyMap<string, string>): string[] {
+  const violations: string[] = []
+  for (const requirement of WIRING_CENSUS) {
+    const source = contents.get(requirement.file)
+    if (source === undefined) {
+      violations.push(`${requirement.file}: MISSING from the provided content map`)
+      continue
+    }
+    // Guard the scan itself (扫描窗口教训): an empty read is indistinguishable from an
+    // unwired file, so fail loudly on it rather than counting zero occurrences.
+    if (source.trim().length === 0) {
+      violations.push(`${requirement.file}: EMPTY source — census scan itself is broken`)
+      continue
+    }
+    if (!IMPORT_RE.test(source)) {
+      violations.push(`${requirement.file}: no import from db/recovery-conflict`)
+    }
+    const stripped = stripComments(source)
+    for (const call of requirement.calls) {
+      const count = countCalls(stripped, call.token)
+      if (count < call.minCount) {
+        violations.push(
+          `${requirement.file}: expected >= ${call.minCount} call(s) of ${call.token}(), found ${count}`,
+        )
+      }
+    }
+  }
+  return violations
+}
+
+function loadRealContents(): Map<string, string> {
+  const contents = new Map<string, string>()
+  for (const requirement of WIRING_CENSUS) {
+    contents.set(requirement.file, readFileSync(path.join(SRC_ROOT, requirement.file), 'utf8'))
+  }
+  return contents
+}
+
+describe('O2-S2 recovery-conflict wiring census', () => {
+  it('every enumerated write surface routes through the single classifier module', () => {
+    expect(auditRecoveryConflictWiring(loadRealContents())).toEqual([])
+  })
+
+  it('NEGATIVE CONTROL: fully unwiring one surface turns the census red', () => {
+    const contents = loadRealContents()
+    const target = 'routes/roles.ts'
+    const original = contents.get(target) as string
+    // Mutation anchor: the wiring must actually be present before we strip it —
+    // otherwise this control proves nothing (无效mutation教训).
+    expect(original).toMatch(/\bsendIfRecoveryConflict\b/)
+
+    const mutated = original.replace(/\bsendIfRecoveryConflict\b/g, 'neverClassifiedHere')
+    expect(mutated).not.toBe(original)
+    contents.set(target, mutated)
+
+    const violations = auditRecoveryConflictWiring(contents)
+    expect(violations.some((entry) => entry.startsWith(`${target}:`))).toBe(true)
+    // And ONLY that surface regressed — the control must not pass by breaking the world.
+    expect(violations.filter((entry) => !entry.startsWith(`${target}:`))).toEqual([])
+  })
+
+  it('NEGATIVE CONTROL: dropping a single call site from a multi-site surface turns the census red', () => {
+    const contents = loadRealContents()
+    const target = 'routes/attendance-admin.ts'
+    const original = contents.get(target) as string
+    const callRe = /\bsendIfRecoveryConflict\s*\(/
+    expect(callRe.test(stripComments(original))).toBe(true)
+
+    // Neutralize exactly one call site (rename its identifier; the import stays).
+    const mutated = original.replace(callRe, 'sendIfRecoveryConflictDisabled(')
+    expect(mutated).not.toBe(original)
+    contents.set(target, mutated)
+
+    const violations = auditRecoveryConflictWiring(contents)
+    expect(
+      violations.some((entry) =>
+        entry.startsWith(`${target}:`) && entry.includes('sendIfRecoveryConflict'),
+      ),
+    ).toBe(true)
+  })
+
+  it('NEGATIVE CONTROL: a comment cannot satisfy the census (call counting ignores comments)', () => {
+    const stripped = stripComments(
+      '// sendIfRecoveryConflict(res, error)\n/* translateRecoveryConflict(() => op()) */\nconst x = 1\n',
+    )
+    expect(countCalls(stripped, 'sendIfRecoveryConflict')).toBe(0)
+    expect(countCalls(stripped, 'translateRecoveryConflict')).toBe(0)
+    // Positive control for the counter itself.
+    expect(countCalls('await sendIfRecoveryConflict(res, error)', 'sendIfRecoveryConflict')).toBe(1)
+  })
+})

--- a/packages/core-backend/tests/unit/recovery-conflict-classifier.test.ts
+++ b/packages/core-backend/tests/unit/recovery-conflict-classifier.test.ts
@@ -1,0 +1,168 @@
+/**
+ * O2-S2 — behaviour tests for the single 40001 recovery-conflict classifier
+ * (src/db/recovery-conflict.ts).
+ *
+ * Positive assertions are EXACT equalities ("不是错误X"教训 — never notEqual): a conflict
+ * classifies as 'recovery_conflict' and the express adapter writes precisely the uniform
+ * 409 body; a non-conflict returns null / false and the adapter writes NOTHING (proven
+ * with a positive control on the same spy, not by absence alone).
+ */
+
+import { describe, expect, it, vi } from 'vitest'
+import type { Response } from 'express'
+import {
+  classifyRecoveryConflict,
+  RECOVERY_CONFLICT_HTTP_CODE,
+  RECOVERY_CONFLICT_HTTP_MESSAGE,
+  RECOVERY_CONFLICT_HTTP_STATUS,
+  RecoveryConflictError,
+  sendIfRecoveryConflict,
+  translateRecoveryConflict,
+} from '../../src/db/recovery-conflict'
+import { RECOVERY_AUTHORITY_BUSY_MARKER } from '../../src/multitable/recovery-authorization-stability'
+import { UserRoleAssignmentRecoveryBusyError } from '../../src/auth/AuthService'
+
+function markerError(): Error & { code: string } {
+  // Exactly the shape node-postgres surfaces for the lease trigger's RAISE:
+  // SQLSTATE 40001 with the marker as the message.
+  return Object.assign(new Error(RECOVERY_AUTHORITY_BUSY_MARKER), { code: '40001' })
+}
+
+function mockResponse() {
+  const res = {
+    statusCode: 0,
+    body: undefined as unknown,
+    status(code: number) {
+      this.statusCode = code
+      return this
+    },
+    json(payload: unknown) {
+      this.body = payload
+      return this
+    },
+  }
+  return res as Response & { statusCode: number; body: unknown }
+}
+
+describe('classifyRecoveryConflict — the single discriminator', () => {
+  it('classifies the raw marker 40001 (reusing isRecoveryAuthorityBusyError)', () => {
+    expect(classifyRecoveryConflict(markerError())).toBe('recovery_conflict')
+  })
+
+  it('classifies the named service-layer RecoveryConflictError', () => {
+    expect(classifyRecoveryConflict(new RecoveryConflictError(markerError()))).toBe(
+      'recovery_conflict',
+    )
+  })
+
+  it('classifies the REAL UserRoleAssignmentRecoveryBusyError (pins the cross-module code contract)', () => {
+    // Constructed from the real class in auth/AuthService.ts — if its `code` or
+    // `retryable` ever drifts, this goes red before the register handler regresses to 500.
+    const real = new UserRoleAssignmentRecoveryBusyError('user-1', ['role-a'], markerError())
+    expect(classifyRecoveryConflict(real)).toBe('recovery_conflict')
+  })
+
+  it('does NOT classify a bare 40001 without the marker (serialization_failure keeps its original path)', () => {
+    expect(
+      classifyRecoveryConflict(
+        Object.assign(new Error('could not serialize access due to concurrent update'), {
+          code: '40001',
+        }),
+      ),
+    ).toBeNull()
+  })
+
+  it('does NOT classify the marker message under a different SQLSTATE', () => {
+    expect(
+      classifyRecoveryConflict(
+        Object.assign(new Error(RECOVERY_AUTHORITY_BUSY_MARKER), { code: '55P03' }),
+      ),
+    ).toBeNull()
+  })
+
+  it('does NOT classify a spoofed code without retryable=true, generic errors, or non-objects', () => {
+    expect(
+      classifyRecoveryConflict(
+        Object.assign(new Error('x'), { code: RECOVERY_CONFLICT_HTTP_CODE }),
+      ),
+    ).toBeNull()
+    expect(classifyRecoveryConflict(new Error('plain failure'))).toBeNull()
+    expect(classifyRecoveryConflict(null)).toBeNull()
+    expect(classifyRecoveryConflict(undefined)).toBeNull()
+    expect(classifyRecoveryConflict('40001')).toBeNull()
+  })
+})
+
+describe('translateRecoveryConflict — service-layer adapter', () => {
+  it('re-raises a marker 40001 as the named retryable RecoveryConflictError', async () => {
+    const raw = markerError()
+    const caught = await translateRecoveryConflict(async () => {
+      throw raw
+    }).then(
+      () => null,
+      (error: unknown) => error,
+    )
+    expect(caught).toBeInstanceOf(RecoveryConflictError)
+    expect((caught as RecoveryConflictError).code).toBe(RECOVERY_CONFLICT_HTTP_CODE)
+    expect((caught as RecoveryConflictError).retryable).toBe(true)
+    expect((caught as { cause?: unknown }).cause).toBe(raw)
+  })
+
+  it('rethrows every other error as the SAME object (non-40001 byte-identical)', async () => {
+    const original = Object.assign(new Error('column does not exist'), { code: '42703' })
+    const caught = await translateRecoveryConflict(async () => {
+      throw original
+    }).then(
+      () => null,
+      (error: unknown) => error,
+    )
+    expect(caught).toBe(original)
+  })
+
+  it('does not double-wrap an already-named RecoveryConflictError', async () => {
+    const named = new RecoveryConflictError(markerError())
+    const caught = await translateRecoveryConflict(async () => {
+      throw named
+    }).then(
+      () => null,
+      (error: unknown) => error,
+    )
+    expect(caught).toBe(named)
+  })
+
+  it('passes successful results through untouched', async () => {
+    await expect(translateRecoveryConflict(async () => 'ok')).resolves.toBe('ok')
+  })
+})
+
+describe('sendIfRecoveryConflict — express-boundary adapter', () => {
+  it('writes exactly the uniform retryable 409 for a conflict', () => {
+    const res = mockResponse()
+    expect(sendIfRecoveryConflict(res, markerError())).toBe(true)
+    expect(res.statusCode).toBe(RECOVERY_CONFLICT_HTTP_STATUS)
+    expect(res.body).toEqual({
+      ok: false,
+      error: {
+        code: RECOVERY_CONFLICT_HTTP_CODE,
+        message: RECOVERY_CONFLICT_HTTP_MESSAGE,
+        details: { retryable: true },
+      },
+    })
+  })
+
+  it('writes NOTHING for a non-conflict (with positive control on the same spies)', () => {
+    const res = mockResponse()
+    const statusSpy = vi.spyOn(res, 'status')
+    const jsonSpy = vi.spyOn(res, 'json')
+
+    expect(sendIfRecoveryConflict(res, new Error('boom'))).toBe(false)
+    expect(statusSpy).not.toHaveBeenCalled()
+    expect(jsonSpy).not.toHaveBeenCalled()
+
+    // Positive control: the same spies DO fire for a genuine conflict, so the
+    // not-called assertions above cannot pass vacuously.
+    expect(sendIfRecoveryConflict(res, markerError())).toBe(true)
+    expect(statusSpy).toHaveBeenCalledWith(RECOVERY_CONFLICT_HTTP_STATUS)
+    expect(jsonSpy).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/core-backend/tests/unit/recovery-conflict-surfaces-routes-admin-directory.test.ts
+++ b/packages/core-backend/tests/unit/recovery-conflict-surfaces-routes-admin-directory.test.ts
@@ -1,0 +1,170 @@
+/**
+ * O2-S2 — per-surface discriminating tests, HTTP layer (routes/admin-directory.ts,
+ * the boundary that surfaces directory/deprovision-evidence-api.ts conflicts).
+ *
+ * The service re-raises a marker 40001 as the named retryable RecoveryConflictError
+ * (proven in recovery-conflict-surfaces-services.test.ts); this suite proves the route
+ * catch maps that named error to the EXACT uniform retryable 409, while the
+ * pre-existing coded mappings (404 / 409 / 500) stay byte-identical.
+ */
+
+import type { Request, Response } from 'express'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const adminUsersMocks = vi.hoisted(() => ({
+  ensurePlatformAdmin: vi.fn(),
+}))
+
+const evidenceMocks = vi.hoisted(() => ({
+  compensateSupersededDenyGrant: vi.fn(),
+  listDeprovisionEffects: vi.fn(),
+  listDeprovisionEvents: vi.fn(),
+  previewDeprovisionForUser: vi.fn(),
+  readDeprovisionRuntimeFlags: vi.fn(() => ({})),
+  restoreDeprovisionEvent: vi.fn(),
+}))
+
+const auditMocks = vi.hoisted(() => ({
+  auditLog: vi.fn(),
+}))
+
+const pgMocks = vi.hoisted(() => ({
+  query: vi.fn(),
+  transaction: vi.fn(),
+}))
+
+vi.mock('../../src/routes/admin-users', () => ({
+  ensurePlatformAdmin: adminUsersMocks.ensurePlatformAdmin,
+}))
+
+vi.mock('../../src/directory/deprovision-evidence-api', () => evidenceMocks)
+
+vi.mock('../../src/audit/audit', () => ({
+  auditLog: auditMocks.auditLog,
+}))
+
+vi.mock('../../src/db/pg', () => ({
+  query: pgMocks.query,
+  transaction: pgMocks.transaction,
+  pool: { query: pgMocks.query },
+}))
+
+import { adminDirectoryRouter } from '../../src/routes/admin-directory'
+import {
+  RECOVERY_CONFLICT_HTTP_CODE,
+  RECOVERY_CONFLICT_HTTP_MESSAGE,
+  RecoveryConflictError,
+} from '../../src/db/recovery-conflict'
+import { RECOVERY_AUTHORITY_BUSY_MARKER } from '../../src/multitable/recovery-authorization-stability'
+
+const EVENT_ID = '44444444-4444-4444-8444-444444444444'
+
+const UNIFORM_409_BODY = {
+  ok: false,
+  error: {
+    code: RECOVERY_CONFLICT_HTTP_CODE,
+    message: RECOVERY_CONFLICT_HTTP_MESSAGE,
+    details: { retryable: true },
+  },
+}
+
+function markerError(): Error & { code: string } {
+  return Object.assign(new Error(RECOVERY_AUTHORITY_BUSY_MARKER), { code: '40001' })
+}
+
+function mockResponse() {
+  return {
+    statusCode: 200,
+    body: undefined as unknown,
+    status(code: number) {
+      this.statusCode = code
+      return this
+    },
+    json(payload: unknown) {
+      this.body = payload
+      return this
+    },
+  } as Response & { statusCode: number; body: unknown }
+}
+
+async function invokeRestore(body: Record<string, unknown>) {
+  const router = adminDirectoryRouter()
+  const layer = (router as unknown as {
+    stack: Array<{
+      route?: {
+        path: string
+        methods: Record<string, boolean>
+        stack: Array<{ handle: (req: Request, res: Response, next: (err?: unknown) => void) => unknown }>
+      }
+    }>
+  }).stack.find(
+    (entry) =>
+      entry.route?.path === '/deprovision/events/:eventId/restore'
+      && entry.route?.methods?.post,
+  )
+  if (!layer?.route) throw new Error('restore route not found')
+  const res = mockResponse()
+  const req = {
+    method: 'POST',
+    headers: {},
+    query: {},
+    params: { eventId: EVENT_ID },
+    body,
+    // admin-directory uses its OWN ensurePlatformAdmin (module-local, not the
+    // admin-users export) — the legacy role claim short-circuits its RBAC DB read.
+    user: { id: 'admin-1', role: 'admin' },
+  } as unknown as Request
+  await layer.route.stack[layer.route.stack.length - 1].handle(req, res, (err?: unknown) => {
+    if (err) throw err
+  })
+  return res
+}
+
+beforeEach(() => {
+  adminUsersMocks.ensurePlatformAdmin.mockReset()
+  adminUsersMocks.ensurePlatformAdmin.mockResolvedValue('admin-1')
+  evidenceMocks.restoreDeprovisionEvent.mockReset()
+  auditMocks.auditLog.mockReset()
+  auditMocks.auditLog.mockResolvedValue(undefined)
+})
+
+describe('POST /deprovision/events/:eventId/restore — recovery conflict boundary', () => {
+  it('the named RecoveryConflictError from the service → exact uniform retryable 409', async () => {
+    evidenceMocks.restoreDeprovisionEvent.mockRejectedValue(
+      new RecoveryConflictError(markerError()),
+    )
+    const res = await invokeRestore({ mode: 'rehire' })
+    expect(res.statusCode).toBe(409)
+    expect(res.body).toEqual(UNIFORM_409_BODY)
+  })
+
+  it('coded EVENT_NOT_FOUND keeps its ORIGINAL 404 mapping, exactly', async () => {
+    evidenceMocks.restoreDeprovisionEvent.mockRejectedValue(
+      Object.assign(new Error('Deprovision event not found'), { code: 'EVENT_NOT_FOUND' }),
+    )
+    const res = await invokeRestore({ mode: 'rehire' })
+    expect(res.statusCode).toBe(404)
+    expect(res.body).toEqual({
+      ok: false,
+      error: {
+        code: 'EVENT_NOT_FOUND',
+        message: 'Deprovision event not found',
+        details: undefined,
+      },
+    })
+  })
+
+  it('an uncoded failure keeps the ORIGINAL 500 DEPROVISION_RESTORE_FAILED, exactly', async () => {
+    evidenceMocks.restoreDeprovisionEvent.mockRejectedValue(new Error('raw driver text'))
+    const res = await invokeRestore({ mode: 'rehire' })
+    expect(res.statusCode).toBe(500)
+    expect(res.body).toEqual({
+      ok: false,
+      error: {
+        code: 'DEPROVISION_RESTORE_FAILED',
+        message: 'Restore failed',
+        details: undefined,
+      },
+    })
+  })
+})

--- a/packages/core-backend/tests/unit/recovery-conflict-surfaces-routes-auth.test.ts
+++ b/packages/core-backend/tests/unit/recovery-conflict-surfaces-routes-auth.test.ts
@@ -1,0 +1,246 @@
+/**
+ * O2-S2 — per-surface discriminating tests, HTTP layer (routes/auth.ts).
+ *
+ * Register: AuthService's REAL UserRoleAssignmentRecoveryBusyError (an exhausted-retry
+ * member of the recovery-conflict family) must surface as the EXACT uniform retryable
+ * 409 — not the generic 500. Invite accept: the named RecoveryConflictError produced by
+ * applyInviteAcceptanceWrites (real module, db/pg mocked to raise the marker 40001)
+ * surfaces the same way. Non-conflict errors keep their ORIGINAL bodies, asserted
+ * positively.
+ */
+
+import type { Request, Response } from 'express'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const authServiceMocks = vi.hoisted(() => ({
+  login: vi.fn(),
+  register: vi.fn(),
+  refreshToken: vi.fn(),
+  verifyToken: vi.fn(),
+  createToken: vi.fn(),
+  resolveSessionTenantId: vi.fn(),
+}))
+
+const inviteTokenMocks = vi.hoisted(() => ({
+  verifyInviteToken: vi.fn(),
+}))
+
+const pgMocks = vi.hoisted(() => ({
+  query: vi.fn(),
+  transaction: vi.fn(),
+}))
+
+const bcryptMocks = vi.hoisted(() => ({
+  hash: vi.fn(),
+  compare: vi.fn(),
+}))
+
+const sessionMocks = vi.hoisted(() => ({
+  revokeUserSessions: vi.fn(),
+}))
+
+vi.mock('../../src/auth/AuthService', () => ({
+  authService: authServiceMocks,
+}))
+
+vi.mock('../../src/auth/invite-tokens', () => ({
+  verifyInviteToken: inviteTokenMocks.verifyInviteToken,
+}))
+
+vi.mock('../../src/db/pg', () => ({
+  query: pgMocks.query,
+  transaction: pgMocks.transaction,
+  pool: { query: pgMocks.query },
+}))
+
+vi.mock('bcryptjs', () => bcryptMocks)
+
+vi.mock('../../src/auth/session-revocation', () => ({
+  revokeUserSessions: sessionMocks.revokeUserSessions,
+}))
+
+import { authRouter } from '../../src/routes/auth'
+import {
+  RECOVERY_CONFLICT_HTTP_CODE,
+  RECOVERY_CONFLICT_HTTP_MESSAGE,
+} from '../../src/db/recovery-conflict'
+import { RECOVERY_AUTHORITY_BUSY_MARKER } from '../../src/multitable/recovery-authorization-stability'
+
+// The REAL class from the REAL module — the mock above replaces the module for the
+// route under test, so pull the actual constructor for a faithful injected error.
+const { UserRoleAssignmentRecoveryBusyError } = await vi.importActual<
+  typeof import('../../src/auth/AuthService')
+>('../../src/auth/AuthService')
+
+const UNIFORM_409_BODY = {
+  ok: false,
+  error: {
+    code: RECOVERY_CONFLICT_HTTP_CODE,
+    message: RECOVERY_CONFLICT_HTTP_MESSAGE,
+    details: { retryable: true },
+  },
+}
+
+function markerError(): Error & { code: string } {
+  return Object.assign(new Error(RECOVERY_AUTHORITY_BUSY_MARKER), { code: '40001' })
+}
+
+function createMockResponse() {
+  return {
+    statusCode: 200,
+    body: undefined as unknown,
+    status(code: number) {
+      this.statusCode = code
+      return this
+    },
+    json(payload: unknown) {
+      this.body = payload
+      return this
+    },
+  } as Response & { statusCode: number; body: unknown }
+}
+
+async function invokeRoute(
+  method: 'get' | 'post',
+  path: string,
+  options: { body?: Record<string, unknown> } = {},
+) {
+  const layer = authRouter.stack.find(
+    (entry) => entry.route?.path === path && entry.route?.methods?.[method],
+  )
+  if (!layer?.route?.stack) throw new Error(`Route ${method.toUpperCase()} ${path} not found`)
+
+  const req = {
+    method: method.toUpperCase(),
+    url: path,
+    headers: {},
+    query: {},
+    params: {},
+    body: options.body ?? {},
+    user: undefined,
+    ip: '127.0.0.1',
+    socket: { remoteAddress: '127.0.0.1' },
+  } as unknown as Request
+  const res = createMockResponse()
+
+  for (const routeLayer of layer.route.stack) {
+    await new Promise<void>((resolve, reject) => {
+      try {
+        const maybePromise = routeLayer.handle(req, res, (error?: unknown) => {
+          if (error) reject(error)
+          else resolve()
+        })
+        if (maybePromise && typeof (maybePromise as Promise<unknown>).then === 'function') {
+          Promise.resolve(maybePromise).then(() => resolve()).catch(reject)
+        } else if (routeLayer.handle.length < 3) {
+          resolve()
+        }
+      } catch (error) {
+        reject(error)
+      }
+    })
+  }
+  return res
+}
+
+beforeEach(() => {
+  authServiceMocks.register.mockReset()
+  authServiceMocks.login.mockReset()
+  inviteTokenMocks.verifyInviteToken.mockReset()
+  pgMocks.query.mockReset()
+  pgMocks.transaction.mockReset()
+  bcryptMocks.hash.mockReset()
+  sessionMocks.revokeUserSessions.mockReset()
+})
+
+describe('POST /register — UserRoleAssignmentRecoveryBusyError surfaces as retryable 409', () => {
+  const body = { email: 'new@example.com', password: 'Str0ng!Passw0rd', name: 'New User' }
+
+  it('the REAL named retryable error from AuthService → exact uniform retryable 409', async () => {
+    authServiceMocks.register.mockRejectedValue(
+      new UserRoleAssignmentRecoveryBusyError('user-1', ['attendance_employee'], markerError()),
+    )
+    const res = await invokeRoute('post', '/register', { body })
+    expect(res.statusCode).toBe(409)
+    expect(res.body).toEqual(UNIFORM_409_BODY)
+  })
+
+  it('a raw marker 40001 leak also surfaces as the same retryable 409', async () => {
+    authServiceMocks.register.mockRejectedValue(markerError())
+    const res = await invokeRoute('post', '/register', { body })
+    expect(res.statusCode).toBe(409)
+    expect(res.body).toEqual(UNIFORM_409_BODY)
+  })
+
+  it('any other failure keeps the ORIGINAL generic 500 body, exactly', async () => {
+    authServiceMocks.register.mockRejectedValue(new Error('smtp exploded'))
+    const res = await invokeRoute('post', '/register', { body })
+    expect(res.statusCode).toBe(500)
+    expect(res.body).toEqual({ success: false, error: 'Internal server error' })
+  })
+})
+
+describe('POST /invite/accept — recovery conflict from the durable write surfaces as retryable 409', () => {
+  function scriptUpToWrites(): void {
+    inviteTokenMocks.verifyInviteToken.mockReturnValue({
+      type: 'invite',
+      userId: 'user-1',
+      email: 'alpha@example.com',
+      presetId: 'attendance-employee',
+      iat: Math.floor(Date.now() / 1000) - 60,
+    })
+    // getInviteTarget
+    pgMocks.query.mockResolvedValueOnce({
+      rows: [{
+        id: 'user-1',
+        email: 'alpha@example.com',
+        name: 'Alpha',
+        is_active: true,
+        activation_status: 'activated',
+        updated_at: '2026-03-13T00:00:00.000Z',
+      }],
+    })
+    bcryptMocks.hash.mockResolvedValue('password-hash')
+  }
+
+  it('marker 40001 in the invite-accept transaction → exact uniform retryable 409', async () => {
+    scriptUpToWrites()
+    // The REAL applyInviteAcceptanceWrites runs; its transaction raises the marker —
+    // exercising service translate → route sendIfRecoveryConflict end to end.
+    pgMocks.transaction.mockRejectedValue(markerError())
+    const res = await invokeRoute('post', '/invite/accept', {
+      body: { token: 'invite-token', password: 'Str0ng!Passw0rd' },
+    })
+    expect(res.statusCode).toBe(409)
+    expect(res.body).toEqual(UNIFORM_409_BODY)
+    expect(sessionMocks.revokeUserSessions).not.toHaveBeenCalled()
+  })
+
+  it('a non-conflict write failure keeps the ORIGINAL 500 body, exactly', async () => {
+    scriptUpToWrites()
+    pgMocks.transaction.mockRejectedValue(new Error('disk on fire'))
+    const res = await invokeRoute('post', '/invite/accept', {
+      body: { token: 'invite-token', password: 'Str0ng!Passw0rd' },
+    })
+    expect(res.statusCode).toBe(500)
+    expect(res.body).toEqual({ success: false, error: 'Internal server error' })
+  })
+
+  it('the coded INVITE_LEDGER_CONSUME_FAILED 409 mapping is untouched', async () => {
+    scriptUpToWrites()
+    pgMocks.transaction.mockRejectedValue(
+      Object.assign(new Error('Invite ledger could not be consumed'), {
+        code: 'INVITE_LEDGER_CONSUME_FAILED',
+      }),
+    )
+    const res = await invokeRoute('post', '/invite/accept', {
+      body: { token: 'invite-token', password: 'Str0ng!Passw0rd' },
+    })
+    expect(res.statusCode).toBe(409)
+    expect(res.body).toEqual({
+      success: false,
+      error: 'Invite token is missing, revoked, or already consumed',
+      code: 'INVITE_LEDGER_CONSUME_FAILED',
+    })
+  })
+})

--- a/packages/core-backend/tests/unit/recovery-conflict-surfaces-routes-rbac.test.ts
+++ b/packages/core-backend/tests/unit/recovery-conflict-surfaces-routes-rbac.test.ts
@@ -1,0 +1,331 @@
+/**
+ * O2-S2 — per-surface discriminating tests, HTTP layer (RBAC-family routers).
+ *
+ * For each route surface: inject the marker 40001 at the db seam → EXACT uniform
+ * retryable 409 body; inject a non-40001 error → the route's ORIGINAL error semantics,
+ * asserted positively (exact status/body, or the same error object rejecting for the
+ * routers that had no catch before this slice).
+ *
+ * Surfaces covered here:
+ *   - routes/roles.ts                  (POST /api/roles, DELETE /api/roles/:id)
+ *   - routes/spreadsheet-permissions.ts (grant / revoke)
+ *   - routes/permissions.ts            (POST /api/permissions/grant)
+ *   - routes/attendance-admin.ts       (POST .../users/:userId/roles/assign,
+ *                                       POST .../users/batch/roles/assign)
+ */
+
+import type { Request, Response, Router } from 'express'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const pgMocks = vi.hoisted(() => ({
+  query: vi.fn(),
+  transaction: vi.fn(),
+  poolQuery: vi.fn(),
+}))
+
+const rbacServiceMocks = vi.hoisted(() => ({
+  isAdmin: vi.fn(),
+  listUserPermissions: vi.fn(),
+  invalidateUserPerms: vi.fn(),
+  userHasPermission: vi.fn(),
+}))
+
+const auditMocks = vi.hoisted(() => ({
+  auditLog: vi.fn(),
+}))
+
+vi.mock('../../src/db/pg', () => ({
+  query: pgMocks.query,
+  transaction: pgMocks.transaction,
+  pool: { query: pgMocks.poolQuery },
+}))
+
+vi.mock('../../src/rbac/service', () => ({
+  isAdmin: rbacServiceMocks.isAdmin,
+  listUserPermissions: rbacServiceMocks.listUserPermissions,
+  invalidateUserPerms: rbacServiceMocks.invalidateUserPerms,
+  userHasPermission: rbacServiceMocks.userHasPermission,
+}))
+
+vi.mock('../../src/audit/audit', () => ({
+  auditLog: auditMocks.auditLog,
+}))
+
+// attendance-admin's module graph (not exercised here) — same seams as the
+// w4c4 route suite.
+vi.mock('../../src/routes/admin-users', () => ({
+  ensurePlatformAdmin: vi.fn(async () => 'admin-1'),
+}))
+vi.mock('../../src/services/AttendanceScheduler', () => ({
+  getSharedAttendanceScheduler: vi.fn(() => null),
+}))
+vi.mock('../../src/services/AttendanceNotificationRedelivery', () => ({
+  redeliverFailedAttendanceNotification: vi.fn(),
+}))
+
+import {
+  RECOVERY_CONFLICT_HTTP_CODE,
+  RECOVERY_CONFLICT_HTTP_MESSAGE,
+} from '../../src/db/recovery-conflict'
+import { RECOVERY_AUTHORITY_BUSY_MARKER } from '../../src/multitable/recovery-authorization-stability'
+import { rolesRouter } from '../../src/routes/roles'
+import { spreadsheetPermissionsRouter } from '../../src/routes/spreadsheet-permissions'
+import { permissionsRouter } from '../../src/routes/permissions'
+import { attendanceAdminRouter } from '../../src/routes/attendance-admin'
+
+const UNIFORM_409_BODY = {
+  ok: false,
+  error: {
+    code: RECOVERY_CONFLICT_HTTP_CODE,
+    message: RECOVERY_CONFLICT_HTTP_MESSAGE,
+    details: { retryable: true },
+  },
+}
+
+function markerError(): Error & { code: string } {
+  return Object.assign(new Error(RECOVERY_AUTHORITY_BUSY_MARKER), { code: '40001' })
+}
+
+function otherDbError(): Error & { code: string } {
+  return Object.assign(new Error('deadlock detected'), { code: '40P01' })
+}
+
+function mockResponse() {
+  const res = {
+    statusCode: 200,
+    body: undefined as unknown,
+    status(code: number) {
+      this.statusCode = code
+      return this
+    },
+    json(payload: unknown) {
+      this.body = payload
+      return this
+    },
+  }
+  return res as Response & { statusCode: number; body: unknown }
+}
+
+/** Invoke the route's FINAL handler directly (guards are not under test here). */
+function invokeHandler(
+  router: Router,
+  method: 'post' | 'put' | 'delete',
+  path: string,
+  req: Partial<Request>,
+  res: Response,
+): Promise<unknown> {
+  const layer = (router as unknown as {
+    stack: Array<{
+      route?: {
+        path: string
+        methods: Record<string, boolean>
+        stack: Array<{ handle: (req: Request, res: Response, next: (err?: unknown) => void) => unknown }>
+      }
+    }>
+  }).stack.find((entry) => entry.route?.path === path && entry.route?.methods?.[method])
+  if (!layer?.route) throw new Error(`Route ${method.toUpperCase()} ${path} not found`)
+  const handler = layer.route.stack[layer.route.stack.length - 1].handle
+  const fullReq = {
+    method: method.toUpperCase(),
+    headers: {},
+    query: {},
+    params: {},
+    body: {},
+    user: { id: 'admin-1' },
+    ...req,
+  } as unknown as Request
+  return Promise.resolve(handler(fullReq, res, (err?: unknown) => {
+    if (err) throw err
+  }))
+}
+
+beforeEach(() => {
+  pgMocks.query.mockReset()
+  pgMocks.transaction.mockReset()
+  pgMocks.poolQuery.mockReset()
+  rbacServiceMocks.isAdmin.mockReset()
+  rbacServiceMocks.listUserPermissions.mockReset()
+  rbacServiceMocks.invalidateUserPerms.mockReset()
+  auditMocks.auditLog.mockReset()
+  auditMocks.auditLog.mockResolvedValue(undefined)
+})
+
+describe('routes/roles.ts', () => {
+  it('POST /api/roles: marker 40001 on the write → exact uniform retryable 409', async () => {
+    pgMocks.poolQuery.mockRejectedValue(markerError())
+    const res = mockResponse()
+    await invokeHandler(rolesRouter(), 'post', '/api/roles', {
+      body: { id: 'role-1', name: 'Role', permissions: ['p:read'] },
+    }, res)
+    expect(res.statusCode).toBe(409)
+    expect(res.body).toEqual(UNIFORM_409_BODY)
+  })
+
+  it('POST /api/roles: non-40001 error → the SAME rejection as before (no catch existed)', async () => {
+    const original = otherDbError()
+    pgMocks.poolQuery.mockRejectedValue(original)
+    const res = mockResponse()
+    await expect(invokeHandler(rolesRouter(), 'post', '/api/roles', {
+      body: { id: 'role-1', name: 'Role' },
+    }, res)).rejects.toBe(original)
+    // And nothing was written to the response — the original semantics exactly.
+    expect(res.body).toBeUndefined()
+  })
+
+  it('DELETE /api/roles/:id: marker 40001 (FK cascade into role_permissions/user_roles) → 409', async () => {
+    pgMocks.poolQuery
+      .mockResolvedValueOnce({ rows: [{ id: 'role-1', name: 'Role' }] })
+      .mockRejectedValueOnce(markerError())
+    const res = mockResponse()
+    await invokeHandler(rolesRouter(), 'delete', '/api/roles/:id', {
+      params: { id: 'role-1' },
+    }, res)
+    expect(res.statusCode).toBe(409)
+    expect(res.body).toEqual(UNIFORM_409_BODY)
+  })
+})
+
+describe('routes/spreadsheet-permissions.ts', () => {
+  it('grant: marker 40001 inside the locked transaction → exact uniform retryable 409', async () => {
+    pgMocks.transaction.mockRejectedValue(markerError())
+    const res = mockResponse()
+    await invokeHandler(
+      spreadsheetPermissionsRouter(),
+      'post',
+      '/api/spreadsheets/:id/permissions/grant',
+      { params: { id: 'sheet-1' }, body: { userId: 'user-1', permission: 'read' } },
+      res,
+    )
+    expect(res.statusCode).toBe(409)
+    expect(res.body).toEqual(UNIFORM_409_BODY)
+  })
+
+  it('grant: non-40001 error → the SAME rejection as before (no catch existed)', async () => {
+    const original = otherDbError()
+    pgMocks.transaction.mockRejectedValue(original)
+    const res = mockResponse()
+    await expect(invokeHandler(
+      spreadsheetPermissionsRouter(),
+      'post',
+      '/api/spreadsheets/:id/permissions/grant',
+      { params: { id: 'sheet-1' }, body: { userId: 'user-1', permission: 'read' } },
+      res,
+    )).rejects.toBe(original)
+    expect(res.body).toBeUndefined()
+  })
+
+  it('revoke: marker 40001 inside the locked transaction → exact uniform retryable 409', async () => {
+    pgMocks.transaction.mockRejectedValue(markerError())
+    const res = mockResponse()
+    await invokeHandler(
+      spreadsheetPermissionsRouter(),
+      'post',
+      '/api/spreadsheets/:id/permissions/revoke',
+      { params: { id: 'sheet-1' }, body: { userId: 'user-1', permission: 'read' } },
+      res,
+    )
+    expect(res.statusCode).toBe(409)
+    expect(res.body).toEqual(UNIFORM_409_BODY)
+  })
+})
+
+describe('routes/permissions.ts', () => {
+  it('grant: marker 40001 on the user_permissions INSERT → exact uniform retryable 409', async () => {
+    rbacServiceMocks.isAdmin.mockResolvedValue(true)
+    pgMocks.poolQuery
+      .mockResolvedValueOnce({ rows: [{ code: 'perm:x' }] }) // permission exists
+      .mockRejectedValueOnce(markerError()) // INSERT INTO user_permissions
+    const res = mockResponse()
+    await invokeHandler(permissionsRouter(), 'post', '/api/permissions/grant', {
+      body: { userId: 'user-1', permission: 'perm:x' },
+    }, res)
+    expect(res.statusCode).toBe(409)
+    expect(res.body).toEqual(UNIFORM_409_BODY)
+  })
+
+  it('grant: non-40001 error → ORIGINAL 500 body, exactly as before', async () => {
+    rbacServiceMocks.isAdmin.mockResolvedValue(true)
+    pgMocks.poolQuery
+      .mockResolvedValueOnce({ rows: [{ code: 'perm:x' }] })
+      .mockRejectedValueOnce(otherDbError())
+    const res = mockResponse()
+    await invokeHandler(permissionsRouter(), 'post', '/api/permissions/grant', {
+      body: { userId: 'user-1', permission: 'perm:x' },
+    }, res)
+    expect(res.statusCode).toBe(500)
+    expect(res.body).toEqual({ error: 'Failed to grant permission' })
+  })
+})
+
+describe('routes/attendance-admin.ts', () => {
+  function installUserRolesRejection(error: unknown): void {
+    pgMocks.query.mockImplementation(async (sql: string) => {
+      if (/INSERT INTO user_roles/.test(sql)) throw error
+      if (/FROM users/.test(sql)) {
+        return {
+          rows: [{
+            id: 'user-1', email: 'u@example.com', name: 'U', employeeNo: null,
+            department: null, role: 'user', is_active: true, is_admin: false,
+            last_login_at: null, created_at: 'now',
+          }],
+        }
+      }
+      // ensureAttendanceRoleTemplates seeds permissions / role_permissions.
+      return { rows: [], rowCount: 0 }
+    })
+  }
+
+  it('single role assign: marker 40001 on the user_roles INSERT → exact uniform retryable 409', async () => {
+    installUserRolesRejection(markerError())
+    rbacServiceMocks.listUserPermissions.mockResolvedValue([])
+    rbacServiceMocks.isAdmin.mockResolvedValue(false)
+    const res = mockResponse()
+    await invokeHandler(
+      attendanceAdminRouter(),
+      'post',
+      '/api/attendance-admin/users/:userId/roles/assign',
+      { params: { userId: 'user-1' }, body: { roleId: 'role-x' } },
+      res,
+    )
+    expect(res.statusCode).toBe(409)
+    expect(res.body).toEqual(UNIFORM_409_BODY)
+  })
+
+  it('single role assign: non-40001 error → ORIGINAL 500 ROLE_ASSIGN_FAILED, exactly as before', async () => {
+    installUserRolesRejection(otherDbError())
+    const res = mockResponse()
+    await invokeHandler(
+      attendanceAdminRouter(),
+      'post',
+      '/api/attendance-admin/users/:userId/roles/assign',
+      { params: { userId: 'user-1' }, body: { roleId: 'role-x' } },
+      res,
+    )
+    expect(res.statusCode).toBe(500)
+    expect(res.body).toEqual({
+      ok: false,
+      error: { code: 'ROLE_ASSIGN_FAILED', message: 'deadlock detected', details: undefined },
+    })
+  })
+
+  it('batch role assign: marker 40001 on the user_roles INSERT → exact uniform retryable 409', async () => {
+    const batchUserId = '10000000-0000-4000-8000-000000000001'
+    pgMocks.query.mockImplementation(async (sql: string) => {
+      if (/INSERT INTO user_roles/.test(sql)) throw markerError()
+      if (/FROM users/.test(sql)) {
+        return { rows: [{ id: batchUserId, email: 'u@example.com', name: 'U', is_active: true }] }
+      }
+      return { rows: [], rowCount: 0 }
+    })
+    const res = mockResponse()
+    await invokeHandler(
+      attendanceAdminRouter(),
+      'post',
+      '/api/attendance-admin/users/batch/roles/assign',
+      { body: { userIds: [batchUserId], roleId: 'role-x' } },
+      res,
+    )
+    expect(res.statusCode).toBe(409)
+    expect(res.body).toEqual(UNIFORM_409_BODY)
+  })
+})

--- a/packages/core-backend/tests/unit/recovery-conflict-surfaces-services.test.ts
+++ b/packages/core-backend/tests/unit/recovery-conflict-surfaces-services.test.ts
@@ -1,0 +1,227 @@
+/**
+ * O2-S2 — per-surface discriminating tests, SERVICE layer.
+ *
+ * For each enumerated service write surface: inject the marker 40001 at the surface's
+ * database seam → the surface throws the NAMED retryable RecoveryConflictError (positive
+ * exact assertions — code + retryable, never notEqual); inject a non-40001 error → the
+ * SAME error object comes back out (`toBe`), proving the non-conflict path is
+ * byte-identical.
+ *
+ * Surfaces covered here:
+ *   - auth/invite-accept-writes.ts  (applyInviteAcceptanceWrites)
+ *   - auth/user-activate.ts         (activatePendingUser)
+ *   - directory/deprovision-ledger.ts (applyDirectoryDeprovisionCandidate)
+ *   - directory/deprovision-evidence-api.ts (restoreDeprovisionEvent,
+ *     compensateSupersededDenyGrant)
+ *   - directory/directory-sync.ts   (unbindDirectoryAccount)
+ *   - auth/dingtalk-oauth.ts        (createProvisionedUser via the test seam)
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const pgMocks = vi.hoisted(() => ({
+  query: vi.fn(),
+  transaction: vi.fn(),
+}))
+
+vi.mock('../../src/db/pg', () => ({
+  query: pgMocks.query,
+  transaction: pgMocks.transaction,
+  pool: { query: pgMocks.query },
+}))
+
+import {
+  RECOVERY_CONFLICT_HTTP_CODE,
+  RecoveryConflictError,
+} from '../../src/db/recovery-conflict'
+import { RECOVERY_AUTHORITY_BUSY_MARKER } from '../../src/multitable/recovery-authorization-stability'
+import { applyInviteAcceptanceWrites } from '../../src/auth/invite-accept-writes'
+import { activatePendingUser } from '../../src/auth/user-activate'
+import { applyDirectoryDeprovisionCandidate } from '../../src/directory/deprovision-ledger'
+import {
+  compensateSupersededDenyGrant,
+  restoreDeprovisionEvent,
+} from '../../src/directory/deprovision-evidence-api'
+import { unbindDirectoryAccount } from '../../src/directory/directory-sync'
+import { __dingtalkOAuthInternalsForTests } from '../../src/auth/dingtalk-oauth'
+
+function markerError(): Error & { code: string } {
+  return Object.assign(new Error(RECOVERY_AUTHORITY_BUSY_MARKER), { code: '40001' })
+}
+
+function otherDbError(): Error & { code: string } {
+  return Object.assign(new Error('column "ghost" does not exist'), { code: '42703' })
+}
+
+/** transaction() runs the handler against a client whose FIRST query rejects. */
+function installRejectingTransaction(error: unknown): void {
+  pgMocks.transaction.mockImplementation(async (
+    handler: (client: { query: (sql: string, params?: unknown[]) => Promise<unknown> }) => Promise<unknown>,
+  ) => handler({ query: vi.fn().mockRejectedValue(error) }))
+}
+
+async function caughtFrom(promise: Promise<unknown>): Promise<unknown> {
+  return promise.then(
+    () => {
+      throw new Error('expected the surface to reject, but it resolved')
+    },
+    (error: unknown) => error,
+  )
+}
+
+function expectNamedConflict(caught: unknown): void {
+  expect(caught).toBeInstanceOf(RecoveryConflictError)
+  expect((caught as RecoveryConflictError).code).toBe(RECOVERY_CONFLICT_HTTP_CODE)
+  expect((caught as RecoveryConflictError).retryable).toBe(true)
+}
+
+beforeEach(() => {
+  pgMocks.query.mockReset()
+  pgMocks.transaction.mockReset()
+})
+
+describe('applyInviteAcceptanceWrites (auth/invite-accept-writes.ts)', () => {
+  const input = {
+    inviteToken: 'tok',
+    userId: 'user-1',
+    email: 'user-1@example.com',
+    passwordHash: 'hash',
+    requestedName: '',
+  }
+
+  it('marker 40001 at the users write seam → named retryable RecoveryConflictError', async () => {
+    installRejectingTransaction(markerError())
+    expectNamedConflict(await caughtFrom(applyInviteAcceptanceWrites(input)))
+  })
+
+  it('non-40001 error → the SAME object rethrows (byte-identical path)', async () => {
+    const original = otherDbError()
+    installRejectingTransaction(original)
+    expect(await caughtFrom(applyInviteAcceptanceWrites(input))).toBe(original)
+  })
+})
+
+describe('activatePendingUser (auth/user-activate.ts)', () => {
+  const input = { userId: 'user-1', mode: 'admin_no_password' as const, adminUserId: 'admin-1' }
+
+  it('marker 40001 at the users write seam → named retryable RecoveryConflictError', async () => {
+    installRejectingTransaction(markerError())
+    expectNamedConflict(await caughtFrom(activatePendingUser(input)))
+  })
+
+  it('non-40001 error → the SAME object rethrows (ACTIVATE_* semantics untouched)', async () => {
+    const original = otherDbError()
+    installRejectingTransaction(original)
+    expect(await caughtFrom(activatePendingUser(input))).toBe(original)
+  })
+})
+
+describe('applyDirectoryDeprovisionCandidate (directory/deprovision-ledger.ts)', () => {
+  const input = {
+    localUserId: 'user-1',
+    orgId: 'org-1',
+    integrationId: '11111111-1111-4111-8111-111111111111',
+    directoryAccountId: '22222222-2222-4222-8222-222222222222',
+    runId: '33333333-3333-4333-8333-333333333333',
+    triggeredBy: 'admin-1',
+    policy: 'mark_inactive' as const,
+    write: true,
+  }
+
+  it('marker 40001 from the caller-supplied client → named retryable RecoveryConflictError', async () => {
+    const client = { query: vi.fn().mockRejectedValue(markerError()) }
+    expectNamedConflict(await caughtFrom(applyDirectoryDeprovisionCandidate(client, input)))
+  })
+
+  it('non-40001 error → the SAME object rethrows', async () => {
+    const original = otherDbError()
+    const client = { query: vi.fn().mockRejectedValue(original) }
+    expect(await caughtFrom(applyDirectoryDeprovisionCandidate(client, input))).toBe(original)
+  })
+})
+
+describe('deprovision evidence writers (directory/deprovision-evidence-api.ts)', () => {
+  it('restoreDeprovisionEvent: marker 40001 → named retryable RecoveryConflictError', async () => {
+    installRejectingTransaction(markerError())
+    expectNamedConflict(await caughtFrom(restoreDeprovisionEvent({
+      eventId: '44444444-4444-4444-8444-444444444444',
+      mode: 'rehire',
+      adminUserId: 'admin-1',
+    })))
+  })
+
+  it('restoreDeprovisionEvent: non-40001 error → the SAME object rethrows', async () => {
+    const original = otherDbError()
+    installRejectingTransaction(original)
+    expect(await caughtFrom(restoreDeprovisionEvent({
+      eventId: '44444444-4444-4444-8444-444444444444',
+      mode: 'rehire',
+      adminUserId: 'admin-1',
+    }))).toBe(original)
+  })
+
+  it('compensateSupersededDenyGrant: marker 40001 → named retryable RecoveryConflictError', async () => {
+    installRejectingTransaction(markerError())
+    expectNamedConflict(await caughtFrom(compensateSupersededDenyGrant({
+      eventId: '44444444-4444-4444-8444-444444444444',
+      adminUserId: 'admin-1',
+      confirm: true,
+      note: 'compensating orphan deny row',
+    })))
+  })
+
+  it('compensateSupersededDenyGrant: coded refusals still surface UNCHANGED (fail-closed intact)', async () => {
+    // The confirm gate throws BEFORE any transaction — the wiring must not touch it.
+    const caught = await caughtFrom(compensateSupersededDenyGrant({
+      eventId: '44444444-4444-4444-8444-444444444444',
+      adminUserId: 'admin-1',
+      confirm: false,
+    }))
+    expect((caught as { code?: string }).code).toBe('COMPENSATION_CONFIRM_REQUIRED')
+    expect(pgMocks.transaction).not.toHaveBeenCalled()
+  })
+})
+
+describe('unbindDirectoryAccount (directory/directory-sync.ts)', () => {
+  it('marker 40001 inside the unbind transaction → named retryable RecoveryConflictError', async () => {
+    installRejectingTransaction(markerError())
+    expectNamedConflict(await caughtFrom(unbindDirectoryAccount(
+      '22222222-2222-4222-8222-222222222222',
+      { adminUserId: 'admin-1' },
+    )))
+  })
+
+  it('non-40001 error → the SAME object rethrows', async () => {
+    const original = otherDbError()
+    installRejectingTransaction(original)
+    expect(await caughtFrom(unbindDirectoryAccount(
+      '22222222-2222-4222-8222-222222222222',
+      { adminUserId: 'admin-1' },
+    ))).toBe(original)
+  })
+})
+
+describe('createProvisionedUser (auth/dingtalk-oauth.ts JIT users INSERT)', () => {
+  const dtUser = {
+    openId: 'open-1',
+    unionId: 'union-1',
+    nick: 'JIT User',
+    email: null as string | null,
+    mobile: null as string | null,
+  }
+
+  it('marker 40001 at the users INSERT → named retryable RecoveryConflictError', async () => {
+    installRejectingTransaction(markerError())
+    expectNamedConflict(await caughtFrom(
+      __dingtalkOAuthInternalsForTests.createProvisionedUser(dtUser as never),
+    ))
+  })
+
+  it('non-40001 error → the SAME object rethrows (fail-closed mappings untouched)', async () => {
+    const original = otherDbError()
+    installRejectingTransaction(original)
+    expect(await caughtFrom(
+      __dingtalkOAuthInternalsForTests.createProvisionedUser(dtUser as never),
+    )).toBe(original)
+  })
+})

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -72,6 +72,9 @@ export default defineConfig({
       // INSERT when the bind throws after it. DATABASE_URL-gated; excluded here so the no-DB job
       // cannot skip-green it, and wired as a WHOLE FILE into the approval real-DB step.
       'tests/integration/directory-sync-admission-orphan-guard.db.test.ts',
+      // O2-S1 register() whole-transaction atomicity goldens: DATABASE_URL-gated; excluded here so
+      // the no-DB job cannot skip-green it; wired whole-file into the auth real-DB step in plugin-tests.yml.
+      'tests/integration/auth-register-atomicity.db.test.ts',
       // P2-1 (post-#3972 review): proves the create-time email existence check is
       // case-insensitive and that batchAdmitDirectoryAccountUsers enforces server-side
       // eligibility (no duplicate `users` row for a differently-cased email; no silent
@@ -1059,6 +1062,9 @@ export default defineConfig({
       // Time Machine closeout guard: per-subject authority leases. It is DATABASE_URL-gated and
       // pinned by the shared exact-anchor CI wiring contract.
       'tests/integration/multitable-recovery-authority-stability-realdb.test.ts',
+      // O2-S3 lease-starvation backoff goldens (DATABASE_URL-gated; two-point wired via the
+      // exact-anchor CI wiring contract).
+      'tests/integration/multitable-recovery-lease-backoff-realdb.test.ts',
       // TM-closeout slice goldens (DATABASE_URL-gated; two-point wired via the exact-anchor CI wiring contract).
       'tests/integration/multitable-recovery-authority-unavailable-failclosed-realdb.test.ts',
       'tests/integration/multitable-recovery-foreign-fence-availability-realdb.test.ts',

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -1065,6 +1065,10 @@ export default defineConfig({
       // O2-S3 lease-starvation backoff goldens (DATABASE_URL-gated; two-point wired via the
       // exact-anchor CI wiring contract).
       'tests/integration/multitable-recovery-lease-backoff-realdb.test.ts',
+      // O2-S2 recovery-conflict classifier vs the REAL authority-trigger 40001 (DATABASE_URL-gated;
+      // excluded here so the no-DB job cannot collect-skip-green it; two-point pinned via the
+      // exact-anchor CI wiring contract).
+      'tests/integration/recovery-conflict-classifier-realdb.test.ts',
       // TM-closeout slice goldens (DATABASE_URL-gated; two-point wired via the exact-anchor CI wiring contract).
       'tests/integration/multitable-recovery-authority-unavailable-failclosed-realdb.test.ts',
       'tests/integration/multitable-recovery-foreign-fence-availability-realdb.test.ts',

--- a/plugins/plugin-integration-core/lib/sealed-export/vectors/s6a-package-provenance-pins.json
+++ b/plugins/plugin-integration-core/lib/sealed-export/vectors/s6a-package-provenance-pins.json
@@ -86,6 +86,6 @@
     "s6aAcceptancePs51Test": "835c7c6ce943d82e0378a40a27c7fd1e8b79b526faa8ca4c8066e4231a4bfb0f",
     "s6aProductRuntimeTest": "de978adafa8b89772cefa921c2051f434bf346bf5c2978bef3424ee70f51ba3f",
     "multitableOnpremPackageBuild": "1b76a342e5b947faf271132a5ae246b225439fbace13a4ff90e1209f7fb6b6d6",
-    "pluginTestsWorkflow": "8cf594c67fad0c7441d7b473bf1ec961f5234306deddab3ccec09f0dd616f975"
+    "pluginTestsWorkflow": "219d353295279054ef7b391c94cdf7f516039e08ddcf47ca4d8474bdc8606bd9"
   }
 }

--- a/scripts/ops/multitable-exact-anchor-ci-wiring.test.mjs
+++ b/scripts/ops/multitable-exact-anchor-ci-wiring.test.mjs
@@ -19,6 +19,7 @@ const FILES = [
   'tests/integration/multitable-exact-anchor-route-wiring-realdb.test.ts',
   // Closeout database guard: authority reader/writer leases.
   'tests/integration/multitable-recovery-authority-stability-realdb.test.ts',
+  'tests/integration/multitable-recovery-lease-backoff-realdb.test.ts',
   // Closeout goldens added by the TM-closeout slices — must stay two-point wired (no manual-only goldens).
   'tests/integration/multitable-recovery-authority-unavailable-failclosed-realdb.test.ts',
   'tests/integration/multitable-recovery-foreign-fence-availability-realdb.test.ts',

--- a/scripts/ops/multitable-exact-anchor-ci-wiring.test.mjs
+++ b/scripts/ops/multitable-exact-anchor-ci-wiring.test.mjs
@@ -20,6 +20,7 @@ const FILES = [
   // Closeout database guard: authority reader/writer leases.
   'tests/integration/multitable-recovery-authority-stability-realdb.test.ts',
   'tests/integration/multitable-recovery-lease-backoff-realdb.test.ts',
+  'tests/integration/recovery-conflict-classifier-realdb.test.ts',
   // Closeout goldens added by the TM-closeout slices — must stay two-point wired (no manual-only goldens).
   'tests/integration/multitable-recovery-authority-unavailable-failclosed-realdb.test.ts',
   'tests/integration/multitable-recovery-foreign-fence-availability-realdb.test.ts',


### PR DESCRIPTION
Time Machine O-2 (owner closeout-plan stage 7): the hardening that must land BEFORE the recovery flags/triggers can ever be enabled. **Nothing here flips a flag, enables a trigger, or touches a host** — inert-by-default posture unchanged; enablement remains per-step owner-gated (see the PROPOSED ladder doc in this PR).

## Slices (each built in an isolated worktree, real-Postgres proven, mutation-proven)

### S1 — registration same-transaction atomicity (`47229e70a5`)
`AuthService.register()` now creates the user AND assigns roles in **one transaction**, with whole-transaction bounded retry on 40001 (`UserRoleAssignmentRecoveryBusyError` on exhaustion). Previously the user row committed first, so exhaustion left user/alias/permission residue (the P23 comments admitted it).
Real-DB proof: scoped 40001 injection (per-run email namespace trigger, real ERRCODE + marker) → exhaustion leaves **zero residue** across users/user_login_aliases/user_permissions/user_roles, then the SAME email registers successfully; trigger-fire delta == retry limit proves whole-transaction retry (per-statement retry would 25P02). Mutation: restoring the old commit-user-first shape → zero-residue assertion RED at the exact line.

### S2 — single 40001 classifier + mechanical census (`4be6928cbd`)
One shared `classifyRecoveryConflict`/`translateRecoveryConflict` (factored from the closeout's admin-users discriminator, not new) now backs **11 write surfaces**: deprovision-evidence-api, deprovision-ledger, invite-accept-writes, user-activate (mapActivateError), attendance-admin, spreadsheet-permissions, permissions, roles, directory-sync, dingtalk-oauth, and routes/auth.ts register (named retryable 409 — no more generic 500). Non-40001 paths byte-identical (positively asserted).
A **mechanical census test** (hardcoded surface list, AST/source-scan) asserts every surface routes through the classifier — with in-test negative controls (unwiring one surface reds the census). 4 lane mutations all RED at the discriminating tests. Real-DB: trigger-raised 40001 under a genuinely-held recovery lease classifies + re-raises correctly; real 23505 passes through unchanged; sentinel fail-not-skip proven.

### S3 — exclusive-recovery lease bounded backoff (`20b0ecbfad`)
Recovery lease acquisition retries a bounded, increasing ladder (constants exported), each attempt a **fresh NOWAIT try with all partial locks released between attempts** — starvation relief without touching the no-deadlock model. Exhaustion keeps the existing fail-closed refusal.
Real-DB proof (10/10): baseline immediate-busy control; writer-gap acquisition on attempt 2; exhaustion = exactly N fresh attempts + same named outcome + zero writes/burns; **two-connection evidence** that no lock is held during backoff sleeps (exclusive probe + a fresh writer commits mid-backoff); partial-lease release proven. 3 mutations (loop removed / busy marker dropped / ladder flattened) each RED discriminatingly.
**⚠️ Owner-flag (deliberate conservatism):** the public busy outcome remains the pre-existing `preview-drift` 409 — main has no distinct public RECOVERY_BUSY reason, and inventing one is a contract change needing its own ratification. Retry discrimination is internal. Say the word if you want a named public busy code as a follow-up.

### S4 — enablement ladder doc (`c14f9743f4`, **PROPOSED**)
Trigger-first → per-flag staging ladder (L1-L6) → production repeat (L7+), each step separately owner-authorized, soak criteria, single-step rollback, foreign-fence residual registered (not resolved). Ratification is the owner's.

### CI wiring (`5b7a0edc89`, one-shot)
3 realdb suites two-point wired (vitest exclude + plugin-tests whole-file lists); exact-anchor wiring guard FILES extended (21/21); **s6a pin mechanically recomputed** `8cf594c67f… → 219d353295…` (provenance test green locally).

## Integrated-state preflight (this exact head)
tsc clean · targeted units 76/76 · containment 19/19 · wiring guard 21/21 · s6a provenance 1/1 · realdb on a fresh migrated scratch DB: S1+S2+S3+login-alias-writers = **31/31**.

## Honest gaps (carried from lanes, verbatim-preserved)
- All realdb evidence is local Postgres; CI-runner execution lands with this PR's wiring (that is what the wiring is for).
- S1: transient-40001-then-succeed (retry N<limit) path is asserted via fire-count/call-count, not a dedicated flaky-injection scenario.
- S2: mapActivateError's 409 carries the named code but no `details.retryable` field (kept inside the AST-closed policy shape); two routes' new 409s use the canonical jsonError envelope which differs from those files' legacy local envelopes (pre-existing responses byte-identical).
- S3: only the authority-lease busy channel retries; row-level NOWAIT and other conflict classes deliberately unchanged.

Merge condition (owner pre-authorized 2026-08-19): 9 required checks green **AND** independent adversarial gate CLEAR (0 P1/0 P2) → merge; otherwise stop. Enablement ladder execution is NOT authorized by this merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)